### PR TITLE
Allow methods to be excluded from MethodLength by name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Changes
 
 * [#801](https://github.com/bbatsov/rubocop/issues/801): New style `context_dependent` for `Style/BracesAroundHashParameters` looks at preceding parameter to determine if braces should be used for final parameter. ([@jonas054][])
+* Methods can now be excluded from Metrics/MethodLength by qualified name (e.g. MyModule::MyClass#my_method). ([@mwean][])
 
 ## 0.27.1 (08/11/2014)
 
@@ -1154,3 +1155,4 @@
 [@mvz]: https://github.com/mvz
 [@jfelchner]: https://github.com/jfelchner
 [@janraasch]: https://github.com/janraasch
+[@mwean]: https://github.com/mwean

--- a/config/default.yml
+++ b/config/default.yml
@@ -553,6 +553,11 @@ Metrics/LineLength:
 Metrics/MethodLength:
   CountComments: false  # count full line comments?
   Max: 10
+  # IgnoredMethods:
+  #   - MyModule::MyClass#my_method
+  #   - AnotherClass.my_method
+  # Modules/classes are separated by "::" and methods are prepended
+  # by "." if it is a class method and "#" if it is an instance method.
 
 Metrics/ParameterLists:
   Max: 5

--- a/lib/rubocop/cop/metrics/method_length.rb
+++ b/lib/rubocop/cop/metrics/method_length.rb
@@ -6,14 +6,38 @@ module RuboCop
       # This cop checks if the length a method exceeds some maximum value.
       # Comment lines can optionally be ignored.
       # The maximum allowed length is configurable.
+      # Methods can be ignored by name (e.g. MyModule::MyClass#my_method).
       class MethodLength < Cop
         include OnMethodDef
         include CodeLength
 
         private
 
-        def on_method_def(node, _method_name, _args, _body)
-          check_code_length(node)
+        def on_method_def(node, method_name, _args, _body)
+          separator = method_separator(node)
+          full_name = [namespace(node), method_name].join(separator)
+
+          check_code_length(node) unless ignored_methods.include?(full_name)
+        end
+
+        def namespace(node)
+          modules = node.ancestors.select do |ancestor|
+            [:class, :module].include?(ancestor.type)
+          end
+
+          modules.map { |mod| mod.loc.name.source }.reverse.join('::')
+        end
+
+        def method_separator(node)
+          class_method?(node) ? '.' : '#'
+        end
+
+        def class_method?(node)
+          node.type == :defs || (node.parent && node.parent.sclass_type?)
+        end
+
+        def ignored_methods
+          cop_config['IgnoredMethods'] || []
         end
 
         def message(length, max_length)

--- a/spec/rubocop/cop/metrics/method_length_spec.rb
+++ b/spec/rubocop/cop/metrics/method_length_spec.rb
@@ -144,4 +144,120 @@ describe RuboCop::Cop::Metrics::MethodLength, :config do
       expect(cop.offenses.map(&:line).sort).to eq([1])
     end
   end
+
+  describe 'ignoring methods' do
+    context 'an instance method is ignored' do
+      before { cop_config['IgnoredMethods'] = ['K#some_method'] }
+
+      it 'does not reject the method' do
+        inspect_source(cop, ['class K',
+                             '  def some_method()',
+                             '    a = 1',
+                             '    a = 2',
+                             '    a = 3',
+                             '    a = 4',
+                             '    a = 5',
+                             '    a = 6',
+                             '  end',
+                             'end'])
+        expect(cop.offenses).to be_empty
+      end
+    end
+
+    context 'a class method is ignored' do
+      before { cop_config['IgnoredMethods'] = ['K.some_method'] }
+
+      it 'does not reject the method' do
+        inspect_source(cop, ['class K',
+                             '  def self.some_method()',
+                             '    a = 1',
+                             '    a = 2',
+                             '    a = 3',
+                             '    a = 4',
+                             '    a = 5',
+                             '    a = 6',
+                             '  end',
+                             'end'])
+        expect(cop.offenses).to be_empty
+      end
+
+      it 'handles class methods, syntax #2' do
+        inspect_source(cop, ['class K',
+                             '  class << self',
+                             '    def some_method()',
+                             '      a = 1',
+                             '      a = 2',
+                             '      a = 3',
+                             '      a = 4',
+                             '      a = 5',
+                             '      a = 6',
+                             '    end',
+                             '  end',
+                             'end'])
+        expect(cop.offenses).to be_empty
+      end
+    end
+
+    context 'classes inside a module' do
+      before { cop_config['IgnoredMethods'] = ['J::K#some_method'] }
+
+      it 'does not reject the ignored method' do
+        inspect_source(cop, ['module J',
+                             '  class K',
+                             '    def some_method()',
+                             '      a = 1',
+                             '      a = 2',
+                             '      a = 3',
+                             '      a = 4',
+                             '      a = 5',
+                             '      a = 6',
+                             '    end',
+                             '  end',
+                             'end'])
+        expect(cop.offenses).to be_empty
+      end
+    end
+
+    context 'multiple ignored methods' do
+      before do
+        cop_config['IgnoredMethods'] = %w(
+          K.some_method
+          K.another_method
+          K#last_method
+        )
+      end
+
+      it 'does not reject any ignored methods' do
+        inspect_source(cop, ['class K',
+                             '  class << self',
+                             '    def some_method()',
+                             '      a = 1',
+                             '      a = 2',
+                             '      a = 3',
+                             '      a = 4',
+                             '      a = 5',
+                             '      a = 6',
+                             '    end',
+                             '  end',
+                             '  def self.another_method()',
+                             '    a = 1',
+                             '    a = 2',
+                             '    a = 3',
+                             '    a = 4',
+                             '    a = 5',
+                             '    a = 6',
+                             '  end',
+                             '  def last_method()',
+                             '    a = 1',
+                             '    a = 2',
+                             '    a = 3',
+                             '    a = 4',
+                             '    a = 5',
+                             '    a = 6',
+                             '  end',
+                             'end'])
+        expect(cop.offenses).to be_empty
+      end
+    end
+  end
 end


### PR DESCRIPTION
This feature allows you to exclude certain methods from `Metrics/MethodLength` using the `IgnoredMethods` configuration:

```yaml
IgnoredMethods:
  - "MyModule::MyClass#my_method"
  - AnotherClass.my_method
```

Class methods are denoted by `.method_name` and instance methods by `#method_name`. This could probably be generalized and extended to take the place of using comments for disabling cops inside source code.

This feature was inspired by how Cane handles [ignoring methods](https://github.com/square/cane/blob/master/lib/cane/abc_check.rb#L26).