### PR TITLE
[Fix #1460] Allow `alias` in lexical class/module scope

### DIFF
--- a/spec/rubocop/cop/style/alias_spec.rb
+++ b/spec/rubocop/cop/style/alias_spec.rb
@@ -56,4 +56,30 @@ describe RuboCop::Cop::Style::Alias do
                     'end'])
     expect(cop.offenses).to be_empty
   end
+
+  it 'accepts alias in lexical class scope' do
+    inspect_source(cop,
+                   ['class Westerner',
+                    '  alias given_name first_name',
+                    'end'])
+    expect(cop.offenses).to be_empty
+  end
+
+  it 'accepts alias in lexical module scope' do
+    inspect_source(cop,
+                   ['module Mononymous',
+                    '  alias full_name first_name',
+                    'end'])
+    expect(cop.offenses).to be_empty
+  end
+
+  it 'does not choke on empty class definitions' do
+    expect { inspect_source(cop, ['class Something; end']) }
+      .not_to raise_error
+  end
+
+  it 'does not choke on empty module definitions' do
+    expect { inspect_source(cop, ['module Something; end']) }
+      .not_to raise_error
+  end
 end


### PR DESCRIPTION
Fixed `Style/Alias` cop to allow the use of `alias` in lexical class and
module scope, as the style guide does not forbid it.