### PR TITLE
Implement autocorrection for Rails/ReadWriteAttribute cop.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 * [#1430](https://github.com/bbatsov/rubocop/issues/1430): Add `--except` option for disabling cops on the command line. ([@jonas054][])
 * [#1506](https://github.com/bbatsov/rubocop/pull/1506): Add auto-correct from `EvenOdd` cop. ([@blainesch][])
 * [#1507](https://github.com/bbatsov/rubocop/issues/1507): `Debugger` cop now checks for the Capybara debug methods `save_and_open_page` and `save_and_open_screenshot`. ([@rrosenblum][])
+* [#1539](https://github.com/bbatsov/rubocop/pull/1539): Implement autocorrection for Rails/ReadWriteAttribute cop. ([@huerlisi][])
 
 ### Changes
 
@@ -1216,3 +1217,4 @@
 [@kakutani]: https://github.com/kakutani
 [@rrosenblum]: https://github.com/rrosenblum
 [@mattjmcnaughton]: https://github.com/mattjmcnaughton
+[@huerlisi]: https://github.com/huerlisi

--- a/spec/rubocop/cop/rails/read_write_attribute_spec.rb
+++ b/spec/rubocop/cop/rails/read_write_attribute_spec.rb
@@ -11,9 +11,116 @@ describe RuboCop::Cop::Rails::ReadWriteAttribute do
     expect(cop.highlights).to eq(['read_attribute'])
   end
 
+  it 'registers no offense for read_attribute with explicit receiver' do
+    inspect_source(cop, 'res = object.read_attribute(:test)')
+    expect(cop.offenses.size).to eq(0)
+  end
+
   it 'registers an offense for write_attribute' do
     inspect_source(cop, 'write_attribute(:test, val)')
     expect(cop.offenses.size).to eq(1)
     expect(cop.highlights).to eq(['write_attribute'])
+  end
+
+  it 'registers no offense for write_attribute with explicit receiver' do
+    inspect_source(cop, 'object.write_attribute(:test, val)')
+    expect(cop.offenses.size).to eq(0)
+  end
+
+  describe '#autocorrect' do
+    context 'write_attribute' do
+      it 'autocorrects symbol' do
+        source = 'write_attribute(:attr, var)'
+        corrected_source = 'self[:attr] = var'
+
+        expect(autocorrect_source(cop, source)).to eq(corrected_source)
+      end
+
+      it 'autocorrects string' do
+        source = "write_attribute('attr', 'test')"
+        corrected_source = "self['attr'] = 'test'"
+
+        expect(autocorrect_source(cop, source)).to eq(corrected_source)
+      end
+
+      it 'autocorrects without parentheses' do
+        source = "write_attribute 'attr', 'test'"
+        corrected_source = "self['attr'] = 'test'"
+
+        expect(autocorrect_source(cop, source)).to eq(corrected_source)
+      end
+
+      it 'autocorrects expression' do
+        source = "write_attribute(:attr, 'test_' + postfix)"
+        corrected_source = "self[:attr] = 'test_' + postfix"
+
+        expect(autocorrect_source(cop, source)).to eq(corrected_source)
+      end
+
+      it 'autocorrects multiline' do
+        source = [
+          'write_attribute(',
+          ':attr, ',
+          '(',
+          "'test_' + postfix",
+          ').to_sym',
+          ')'
+        ]
+        corrected_source = [
+          'self[:attr] = (',
+          "'test_' + postfix",
+          ').to_sym'
+        ].join("\n")
+
+        expect(autocorrect_source(cop, source)).to eq(corrected_source)
+      end
+    end
+
+    context 'read_attribute' do
+      it 'autocorrects symbol' do
+        source = 'res = read_attribute(:test)'
+        corrected_source = 'res = self[:test]'
+
+        expect(autocorrect_source(cop, source)).to eq(corrected_source)
+      end
+
+      it 'autocorrects string' do
+        source = "res = read_attribute('test')"
+        corrected_source = "res = self['test']"
+
+        expect(autocorrect_source(cop, source)).to eq(corrected_source)
+      end
+
+      it 'autocorrects without parentheses' do
+        source = "res = read_attribute 'test'"
+        corrected_source = "res = self['test']"
+
+        expect(autocorrect_source(cop, source)).to eq(corrected_source)
+      end
+
+      it 'autocorrects expression' do
+        source = "res = read_attribute('test_' + postfix)"
+        corrected_source = "res = self['test_' + postfix]"
+
+        expect(autocorrect_source(cop, source)).to eq(corrected_source)
+      end
+
+      it 'autocorrects multiline' do
+        source = [
+          'res = read_attribute(',
+          '(',
+          "'test_' + postfix",
+          ').to_sym',
+          ')'
+        ]
+        corrected_source = [
+          'res = self[(',
+          "'test_' + postfix",
+          ').to_sym]'
+        ].join("\n")
+
+        expect(autocorrect_source(cop, source)).to eq(corrected_source)
+      end
+    end
   end
 end

--- a/spec/rubocop/cop/rails/read_write_attribute_spec.rb
+++ b/spec/rubocop/cop/rails/read_write_attribute_spec.rb
@@ -5,26 +5,30 @@ require 'spec_helper'
 describe RuboCop::Cop::Rails::ReadWriteAttribute do
   subject(:cop) { described_class.new }
 
-  it 'registers an offense for read_attribute' do
-    inspect_source(cop, 'res = read_attribute(:test)')
-    expect(cop.offenses.size).to eq(1)
-    expect(cop.highlights).to eq(['read_attribute'])
+  context 'read_attribute' do
+    it 'registers an offense' do
+      inspect_source(cop, 'res = read_attribute(:test)')
+      expect(cop.offenses.size).to eq(1)
+      expect(cop.highlights).to eq(['read_attribute'])
+    end
+
+    it 'registers no offense with explicit receiver' do
+      inspect_source(cop, 'res = object.read_attribute(:test)')
+      expect(cop.offenses.size).to eq(0)
+    end
   end
 
-  it 'registers no offense for read_attribute with explicit receiver' do
-    inspect_source(cop, 'res = object.read_attribute(:test)')
-    expect(cop.offenses.size).to eq(0)
-  end
+  context 'write_attribute' do
+    it 'registers an offense' do
+      inspect_source(cop, 'write_attribute(:test, val)')
+      expect(cop.offenses.size).to eq(1)
+      expect(cop.highlights).to eq(['write_attribute'])
+    end
 
-  it 'registers an offense for write_attribute' do
-    inspect_source(cop, 'write_attribute(:test, val)')
-    expect(cop.offenses.size).to eq(1)
-    expect(cop.highlights).to eq(['write_attribute'])
-  end
-
-  it 'registers no offense for write_attribute with explicit receiver' do
-    inspect_source(cop, 'object.write_attribute(:test, val)')
-    expect(cop.offenses.size).to eq(0)
+    it 'registers no offense with explicit receiver' do
+      inspect_source(cop, 'object.write_attribute(:test, val)')
+      expect(cop.offenses.size).to eq(0)
+    end
   end
 
   describe '#autocorrect' do


### PR DESCRIPTION
This implements autocorrection for the Rails/ReadWriteAttribute cop.

It is my first contribution to rubocop, therefore I'm not sure it fits your coding conventions;-)