### PR TITLE
Add autocorrect for Style/Lambda cop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 * [#1507](https://github.com/bbatsov/rubocop/issues/1507): `Debugger` cop now checks for the Capybara debug methods `save_and_open_page` and `save_and_open_screenshot`. ([@rrosenblum][])
 * [#1539](https://github.com/bbatsov/rubocop/pull/1539): Implement autocorrection for Rails/ReadWriteAttribute cop. ([@huerlisi][])
 * [#1324](https://github.com/bbatsov/rubocop/issues/1324): Add `AllCops/DisplayCopNames` configuration option for showing cop names in reports, like `--display-cop-names`. ([@jonas054][])
+* [#1271](https://github.com/bbatsov/rubocop/issues/1271): `Lambda` cop does auto-correction. ([@lumeet][])
 
 ### Changes
 
@@ -1221,3 +1222,4 @@
 [@mattjmcnaughton]: https://github.com/mattjmcnaughton
 [@huerlisi]: https://github.com/huerlisi
 [@volkert]: https://github.com/volkert
+[@lumeet]: https://github.com/lumeet

--- a/lib/rubocop/cop/style/lambda.rb
+++ b/lib/rubocop/cop/style/lambda.rb
@@ -8,6 +8,7 @@ module RuboCop
       # anonymous functions.
       class Lambda < Cop
         SINGLE_MSG = 'Use the new lambda literal syntax `->(params) {...}`.'
+        SINGLE_NO_ARG_MSG = 'Use the new lambda literal syntax `-> {...}`.'
         MULTI_MSG = 'Use the `lambda` method for multi-line lambdas.'
 
         TARGET = s(:send, nil, :lambda)
@@ -17,14 +18,14 @@ module RuboCop
           # (block
           #   (send nil :lambda)
           #   ...)
-          block_method, = *node
+          block_method, args, = *node
 
           return unless block_method == TARGET
           selector = block_method.loc.selector.source
           lambda_length = lambda_length(node)
 
           if selector != '->' && lambda_length == 0
-            add_offense(block_method, :expression, SINGLE_MSG)
+            add_offense_for_single_line(block_method, args)
           elsif selector == '->' && lambda_length > 0
             add_offense(block_method, :expression, MULTI_MSG)
           end
@@ -32,11 +33,56 @@ module RuboCop
 
         private
 
+        def add_offense_for_single_line(block_method, args)
+          if args.children.empty?
+            add_offense(block_method, :expression, SINGLE_NO_ARG_MSG)
+          else
+            add_offense(block_method, :expression, SINGLE_MSG)
+          end
+        end
+
         def lambda_length(block_node)
           start_line = block_node.loc.begin.line
           end_line = block_node.loc.end.line
 
           end_line - start_line
+        end
+
+        def autocorrect(node)
+          ancestor = node.ancestors.first
+
+          @corrections << lambda do |corrector|
+            if node.loc.expression.source == 'lambda'
+              autocorrect_old_to_new(corrector, ancestor)
+            else
+              autocorrect_new_to_old(corrector, ancestor)
+            end
+          end
+        end
+
+        def autocorrect_new_to_old(corrector, node)
+          block_method, args = *node
+          corrector.replace(block_method.loc.expression, 'lambda')
+          return if args.children.empty?
+
+          arg_str = " |#{lambda_arg_string(args)}|"
+          corrector.remove(args.loc.expression)
+          corrector.insert_after(node.loc.begin, arg_str)
+        end
+
+        def autocorrect_old_to_new(corrector, node)
+          block_method, args = *node
+          corrector.replace(block_method.loc.expression, '->')
+          return if args.children.empty?
+
+          arg_str = "(#{lambda_arg_string(args)})"
+          whitespace_and_old_args = node.loc.begin.end.join(args.loc.end)
+          corrector.insert_after(block_method.loc.expression, arg_str)
+          corrector.remove(whitespace_and_old_args)
+        end
+
+        def lambda_arg_string(args)
+          args.children.map { |a| a.loc.expression.source }.join(', ')
         end
       end
     end

--- a/spec/rubocop/cop/style/lambda_spec.rb
+++ b/spec/rubocop/cop/style/lambda_spec.rb
@@ -12,6 +12,13 @@ describe RuboCop::Cop::Style::Lambda do
       .to eq(['Use the new lambda literal syntax `->(params) {...}`.'])
   end
 
+  it 'registers an offense for an old single-line no-argument lambda call' do
+    inspect_source(cop, 'f = lambda { x }')
+    expect(cop.offenses.size).to eq(1)
+    expect(cop.messages)
+      .to eq(['Use the new lambda literal syntax `-> {...}`.'])
+  end
+
   it 'accepts the new lambda literal with single-line body' do
     inspect_source(cop, ['lambda = ->(x) { x }',
                          'lambda.(1)'])
@@ -37,5 +44,33 @@ describe RuboCop::Cop::Style::Lambda do
   it 'accepts the lambda call outside of block' do
     inspect_source(cop, 'l = lambda.test')
     expect(cop.offenses).to be_empty
+  end
+
+  it 'auto-corrects an old single-line lambda call' do
+    new_source = autocorrect_source(cop, 'f = lambda { |x| x }')
+    expect(new_source).to eq('f = ->(x) { x }')
+  end
+
+  it 'auto-corrects an old single-line no-argument lambda call' do
+    new_source = autocorrect_source(cop, 'f = lambda { x }')
+    expect(new_source).to eq('f = -> { x }')
+  end
+
+  it 'auto-corrects a new multi-line lambda call' do
+    new_source = autocorrect_source(cop, ['f = ->(x) do',
+                                          '  x',
+                                          'end'])
+    expect(new_source).to eq(['f = lambda do |x|',
+                              '  x',
+                              'end'].join("\n"))
+  end
+
+  it 'auto-corrects a new multi-line no-argument lambda call' do
+    new_source = autocorrect_source(cop, ['f = -> do',
+                                          '  x',
+                                          'end'])
+    expect(new_source).to eq(['f = lambda do',
+                              '  x',
+                              'end'].join("\n"))
   end
 end


### PR DESCRIPTION
Fixes #1272. I ended up using sub instead of `Parser::Source::Rewriter` just because I feel it's still more readable that way. I'm not quite sure if there's a strong preference for the other option, though. For sure, there's also the possibility that I'm missing something in the pattern. :)