### PR TITLE
Fixes an issue with empty lines around modifier keyword and beginning of a block

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@
 
 ### Bugs fixed
 
+* [#1553](https://github.com/bbatsov/rubocop/pull/1553): Fix bug where `Style/EmptyLinesAroundAccessModifier` interfered with `Style/EmptyLinesAroundBlockBody` when there is and access modifier at the beginning of a block. ([@volkert][])
 * Handle element assignment in `Lint/AssignmentInCondition`. ([@jonas054][])
 * [#1484](https://github.com/bbatsov/rubocop/issues/1484): Fix `EmptyLinesAroundAccessModifier` incorrectly finding a violation inside method calls with names identical to an access modifier. ([@dblock][])
 * Fix bug concerning `Exclude` properties inherited from a higher directory level. ([@jonas054][])
@@ -1219,3 +1220,4 @@
 [@rrosenblum]: https://github.com/rrosenblum
 [@mattjmcnaughton]: https://github.com/mattjmcnaughton
 [@huerlisi]: https://github.com/huerlisi
+[@volkert]: https://github.com/volkert

--- a/lib/rubocop/cop/style/empty_lines_around_access_modifier.rb
+++ b/lib/rubocop/cop/style/empty_lines_around_access_modifier.rb
@@ -42,7 +42,9 @@ module RuboCop
         private
 
         def previous_line_empty?(previous_line)
-          class_def?(previous_line.lstrip) || previous_line.blank?
+          block_start?(previous_line.lstrip) ||
+            class_def?(previous_line.lstrip) ||
+            previous_line.blank?
         end
 
         def next_line_empty?(next_line)
@@ -59,6 +61,10 @@ module RuboCop
 
         def class_def?(line)
           %w(class module).any? { |keyword| line.start_with?(keyword) }
+        end
+
+        def block_start?(line)
+          line.match(/ (do|{)( \|.*?\|)?\s?$/)
         end
 
         def body_end?(line)

--- a/spec/rubocop/cop/style/empty_lines_around_access_modifier_spec.rb
+++ b/spec/rubocop/cop/style/empty_lines_around_access_modifier_spec.rb
@@ -108,6 +108,52 @@ describe RuboCop::Cop::Style::EmptyLinesAroundAccessModifier do
       expect(cop.offenses).to be_empty
     end
 
+    context 'at the beginning of block' do
+      context 'for blocks defined with do' do
+        it 'accepts missing blank line' do
+          inspect_source(cop,
+                         ['included do',
+                          "  #{access_modifier}",
+                          '',
+                          '  def test; end',
+                          'end'])
+          expect(cop.offenses).to be_empty
+        end
+
+        it 'accepts missing blank line with arguments' do
+          inspect_source(cop,
+                         ['included do |foo|',
+                          "  #{access_modifier}",
+                          '',
+                          '  def test; end',
+                          'end'])
+          expect(cop.offenses).to be_empty
+        end
+      end
+
+      context 'for blocks defined with {}' do
+        it 'accepts missing blank line' do
+          inspect_source(cop,
+                         ['included {',
+                          "  #{access_modifier}",
+                          '',
+                          '  def test; end',
+                          '}'])
+          expect(cop.offenses).to be_empty
+        end
+
+        it 'accepts missing blank line with arguments' do
+          inspect_source(cop,
+                         ['included { |foo|',
+                          "  #{access_modifier}",
+                          '',
+                          '  def test; end',
+                          '}'])
+          expect(cop.offenses).to be_empty
+        end
+      end
+    end
+
     it 'accepts missing blank line when at the end of block' do
       inspect_source(cop,
                      ['class Test',


### PR DESCRIPTION
There is no way that the following code is valid for rubocop. It will either complain about the missing empty line above the access modifier (`Style/EmptyLinesAroundAccessModifier`) or the empty line at the beginning of a block (`Style/EmptyLinesAroundBlockBody`).

```ruby
included do
  private
   
  def bar
  end
end
```

This example occured when using rails concerns.
This PR fixes this issue. Please let me know if I can improve my PR, I'm looking forward to contribute!