### PR TITLE
[Fix #1324] Add AllCops/DisplayCopNames config option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 * [#1506](https://github.com/bbatsov/rubocop/pull/1506): Add auto-correct from `EvenOdd` cop. ([@blainesch][])
 * [#1507](https://github.com/bbatsov/rubocop/issues/1507): `Debugger` cop now checks for the Capybara debug methods `save_and_open_page` and `save_and_open_screenshot`. ([@rrosenblum][])
 * [#1539](https://github.com/bbatsov/rubocop/pull/1539): Implement autocorrection for Rails/ReadWriteAttribute cop. ([@huerlisi][])
+* [#1324](https://github.com/bbatsov/rubocop/issues/1324): Add `AllCops/DisplayCopNames` configuration option for showing cop names in reports, like `--display-cop-names`. ([@jonas054][])
 
 ### Changes
 

--- a/config/default.yml
+++ b/config/default.yml
@@ -29,6 +29,10 @@ AllCops:
   # By default, the rails cops are not run. Override in project or home
   # directory .rubocop.yml files, or by giving the -R/--rails option.
   RunRailsCops: false
+  # Cop names are not displayed in offense messages by default. Change behavior
+  # by overriding DisplayCopNames, or by giving the -D/--display-cop-names
+  # option.
+  DisplayCopNames: false
 
 # Indent private/protected/public as deep as method definitions
 Style/AccessModifierIndentation:

--- a/lib/rubocop/cop/cop.rb
+++ b/lib/rubocop/cop/cop.rb
@@ -128,7 +128,8 @@ module RuboCop
       end
 
       def display_cop_names?
-        debug? || @options[:display_cop_names]
+        debug? || @options[:display_cop_names] ||
+          config['AllCops'] && config['AllCops']['DisplayCopNames']
       end
 
       def message(_node = nil)

--- a/spec/rubocop/cli_spec.rb
+++ b/spec/rubocop/cli_spec.rb
@@ -1999,6 +1999,31 @@ describe RuboCop::CLI, :isolated_environment do
                 ''].join("\n"))
     end
 
+    it 'displays cop names if DisplayCopNames is true' do
+      source = ['# encoding: utf-8',
+                'x = 0 ',
+                'puts x']
+      create_file('example1.rb', source)
+
+      # DisplayCopNames: false inherited from config/default.yml
+      create_file('.rubocop.yml', [])
+
+      create_file('dir/example2.rb', source)
+      create_file('dir/.rubocop.yml', ['AllCops:',
+                                       '  DisplayCopNames: true'])
+
+      expect(cli.run(%w(--format simple))).to eq(1)
+      expect($stdout.string)
+        .to eq(['== example1.rb ==',
+                'C:  2:  6: Trailing whitespace detected.',
+                '== dir/example2.rb ==',
+                'C:  2:  6: Style/TrailingWhitespace: Trailing whitespace' \
+                ' detected.',
+                '',
+                '2 files inspected, 2 offenses detected',
+                ''].join("\n"))
+    end
+
     it 'finds included files' do
       create_file('file.rb', 'x=0') # Included by default
       create_file('example', 'x=0')


### PR DESCRIPTION
Is set to `false` by default. Can be overridden by local setting (of course) and by `--display-cop-names` command line option.