### PR TITLE
[Fix #1547] Use fail in in Semicolon#autocorrect instead of if

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@
 * Fix bug where `auto_correct` Rake tasks does not take in the options specified in its parent task. ([@rrosenblum][])
 * [#1054](https://github.com/bbatsov/rubocop/issues/1054): Handle comments within concatenated strings in `LineEndConcatenation`. ([@yujinakayama][], [@jonas054][])
 * [#1527](https://github.com/bbatsov/rubocop/issues/1527): Make autocorrect `BracesAroundHashParameter` leave the correct number of spaces. ([@mattjmcnaughton][])
+* [#1547](https://github.com/bbatsov/rubocop/issues/1547): Don't print `[Corrected]` when auto-correction was avoided in `Style/Semicolon`. ([@jonas054][])
 
 ## 0.28.0 (10/12/2014)
 

--- a/lib/rubocop/cop/style/semicolon.rb
+++ b/lib/rubocop/cop/style/semicolon.rb
@@ -55,7 +55,8 @@ module RuboCop
         end
 
         def autocorrect(range)
-          @corrections << ->(corrector) { corrector.remove(range) } if range
+          fail CorrectionNotPossible unless range
+          @corrections << ->(corrector) { corrector.remove(range) }
         end
       end
     end

--- a/spec/rubocop/cli_spec.rb
+++ b/spec/rubocop/cli_spec.rb
@@ -369,12 +369,12 @@ describe RuboCop::CLI, :isolated_environment do
                                              ''].join("\n"))
         expect($stdout.string).to eq(['',
                                       '10  Style/TrailingWhitespace',
-                                      '5   Style/Semicolon',
+                                      '3   Style/Semicolon',
                                       '3   Style/SingleLineMethods',
                                       '1   Style/DefWithParentheses',
                                       '1   Style/EmptyLineBetweenDefs',
                                       '--',
-                                      '20  Total',
+                                      '18  Total',
                                       '',
                                       ''].join("\n"))
       end
@@ -619,22 +619,26 @@ describe RuboCop::CLI, :isolated_environment do
         create_file('example.rb', ['# encoding: utf-8',
                                    'a = c and b',
                                    'not a && b',
-                                   'func a do b end'])
+                                   'func a do b end',
+                                   "Signal.trap('TERM') { system(cmd); exit }"])
         expect(cli.run(%w(-a -f simple))).to eq(1)
         expect($stderr.string).to eq('')
-        expect(IO.read('example.rb')).to eq(['# encoding: utf-8',
-                                             'a = c and b',
-                                             'not a && b',
-                                             'func a do b end',
-                                             ''].join("\n"))
+        expect(IO.read('example.rb'))
+          .to eq(['# encoding: utf-8',
+                  'a = c and b',
+                  'not a && b',
+                  'func a do b end',
+                  "Signal.trap('TERM') { system(cmd); exit }",
+                  ''].join("\n"))
         expect($stdout.string)
           .to eq(['== example.rb ==',
                   'C:  2:  7: Use && instead of and.',
                   'C:  3:  1: Use ! instead of not.',
                   'C:  4:  8: Prefer {...} over do...end for single-line ' \
                   'blocks.',
+                  'C:  5: 34: Do not use semicolons to terminate expressions.',
                   '',
-                  '1 file inspected, 3 offenses detected',
+                  '1 file inspected, 4 offenses detected',
                   ''].join("\n"))
       end
 


### PR DESCRIPTION
The correct way to avoid an auto-correction is `fail CorrectionNotPossible`. That will have the desired effect, i.e. that `[Corrected]` is not added to the report.