### PR TITLE
[Fix #1284] Support namespace args to --only/--except

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 * [#1539](https://github.com/bbatsov/rubocop/pull/1539): Implement autocorrection for Rails/ReadWriteAttribute cop. ([@huerlisi][])
 * [#1324](https://github.com/bbatsov/rubocop/issues/1324): Add `AllCops/DisplayCopNames` configuration option for showing cop names in reports, like `--display-cop-names`. ([@jonas054][])
 * [#1271](https://github.com/bbatsov/rubocop/issues/1271): `Lambda` cop does auto-correction. ([@lumeet][])
+* [#1284](https://github.com/bbatsov/rubocop/issues/1284): Support namespaces, e.g. `Lint`, in the arguments to `--only` and `--except`. ([@jonas054][])
 
 ### Changes
 

--- a/README.md
+++ b/README.md
@@ -160,8 +160,8 @@ Command flag              | Description
 `-R/--rails`              | Run extra Rails cops.
 `-l/--lint`               | Run only lint cops.
 `-a/--auto-correct`       | Auto-correct certain offenses. *Note:* Experimental - use with caution.
-`--only`                  | Run only the specified cop(s).
-`--except`                | Run all cops enabled by configuration except the specified one(s).
+`--only`                  | Run only the specified cop(s) and/or cops in the specified departments.
+`--except`                | Run all cops enabled by configuration except the specified cop(s) and/or departments.
 `--auto-gen-config`       | Generate a configuration file acting as a TODO list.
 `--show-cops`             | Shows available cops and their configuration.
 `--fail-level`            | Minimum severity for exit with error code.

--- a/lib/rubocop/options.rb
+++ b/lib/rubocop/options.rb
@@ -70,6 +70,19 @@ module RuboCop
       [@options, args]
     end
 
+    # Cop name validation must be done later than option parsing, so it's not
+    # called from within this class.
+    def self.validate_cop_list(names)
+      return unless names
+
+      namespaces = Cop::Cop.all.types.map { |t| t.to_s.capitalize }
+      names.each do |name|
+        next if Cop::Cop.all.any? { |c| c.cop_name == name } ||
+                namespaces.include?(name)
+        fail ArgumentError, "Unrecognized cop or namespace: #{name}."
+      end
+    end
+
     private
 
     def define_options(args)


### PR DESCRIPTION
Make it possible to give whole namespaces, e.g. `Lint`, in the comma separated lists given to `--only` and `--except`.