### PR TITLE
[Fix #1503] Add comment in LineLength config for URI handling

### DIFF
--- a/config/default.yml
+++ b/config/default.yml
@@ -555,6 +555,8 @@ Metrics/CyclomaticComplexity:
 
 Metrics/LineLength:
   Max: 80
+  # To make it possible to copy or click on URIs in the code, we allow lines
+  # contaning a URI to be longer than Max.
   AllowURI: true
   URISchemes:
     - http


### PR DESCRIPTION
Explanation for the parameter `Metrics/LineLength:AllowURI`.