### PR TITLE
[Fix #1565] Add fail level A/autocorrect

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@
 
 * [#1492](https://github.com/bbatsov/rubocop/pull/1492): Abort when auto-correct causes an infinite loop. ([@dblock][])
 * Options `-e`/`--emacs` and `-s`/`--silent` are no longer recognized. Using them will now raise an error. ([@bquorning][])
+* [#1565](https://github.com/bbatsov/rubocop/issues/1565): Let `--fail-level A` cause exit with error if all offenses are auto-corrected. ([@jonas054][])
 
 ### Bugs fixed
 

--- a/README.md
+++ b/README.md
@@ -44,6 +44,7 @@ release.**
     - [Inheritance](#inheritance)
     - [Defaults](#defaults)
     - [Including/Excluding files](#includingexcluding-files)
+    - [Generic configuration parameters](#generic-configuration-parameters)
     - [Automatically Generated Configuration](#automatically-generated-configuration)
 - [Disabling Cops within Source Code](#disabling-cops-within-source-code)
 - [Formatters](#formatters)
@@ -170,7 +171,7 @@ Command flag              | Description
 `--except`                | Run all cops enabled by configuration except the specified cop(s) and/or departments.
 `--auto-gen-config`       | Generate a configuration file acting as a TODO list.
 `--show-cops`             | Shows available cops and their configuration.
-`--fail-level`            | Minimum severity for exit with error code.
+`--fail-level`            | Minimum [severity](#severity) for exit with error code. Full severity name or upper case initial can be given. Normally, auto-corrected offenses are ignored. Use `A` or `autocorrect` if you'd like them to trigger failure.
 
 ### Cops
 
@@ -350,6 +351,13 @@ Rails/DefaultScope:
     - app/models/problematic.rb
 ```
 
+### Generic configuration parameters
+
+In addition to `Include` and `Exclude`, the following parameters are available
+for every cop.
+
+#### Enabled
+
 Specific cops can be disabled by setting `Enabled` to `false` for that specific cop.
 
 ```yaml
@@ -357,8 +365,10 @@ Metrics/LineLength:
   Enabled: false
 ```
 
-Cops can customize their severity level. All cops support the `Severity` param.
-Allowed params are `refactor`, `convention`, `warning`, `error` and `fatal`.
+#### Severity
+
+Cops can customize their severity level. Allowed params are `refactor`,
+`convention`, `warning`, `error` and `fatal`.
 
 ```yaml
 Metrics/CyclomaticComplexity:

--- a/lib/rubocop/options.rb
+++ b/lib/rubocop/options.rb
@@ -35,7 +35,8 @@ module RuboCop
                          'This option applies to the previously',
                          'specified --format, or the default format',
                          'if no format is specified.'],
-      fail_level:        'Minimum severity for exit with error code.',
+      fail_level:       ['Minimum severity (A/R/C/W/E/F) for exit',
+                         'with error code.'],
       show_cops:        ['Shows the given cops, or all cops by',
                          'default, and their configurations for the',
                          'current directory.'],
@@ -146,9 +147,10 @@ module RuboCop
     end
 
     def add_severity_option(opts)
+      table = RuboCop::Cop::Severity::CODE_TABLE.merge(A: :autocorrect)
       option(opts, '--fail-level SEVERITY',
-             RuboCop::Cop::Severity::NAMES,
-             RuboCop::Cop::Severity::CODE_TABLE) do |severity|
+             RuboCop::Cop::Severity::NAMES + [:autocorrect],
+             table) do |severity|
         @options[:fail_level] = severity
       end
     end

--- a/lib/rubocop/runner.rb
+++ b/lib/rubocop/runner.rb
@@ -195,7 +195,9 @@ module RuboCop
     end
 
     def considered_failure?(offense)
-      !offense.corrected? && offense.severity >= minimum_severity_to_fail
+      # For :autocorrect level, any offense - corrected or not - is a failure.
+      @options[:fail_level] == :autocorrect ||
+        !offense.corrected? && offense.severity >= minimum_severity_to_fail
     end
 
     def minimum_severity_to_fail

--- a/spec/rubocop/options_spec.rb
+++ b/spec/rubocop/options_spec.rb
@@ -65,7 +65,8 @@ Usage: rubocop [options] [file1, file2, ...]
                                      specified --format, or the default format
                                      if no format is specified.
     -r, --require FILE               Require Ruby file.
-        --fail-level SEVERITY        Minimum severity for exit with error code.
+        --fail-level SEVERITY        Minimum severity (A/R/C/W/E/F) for exit
+                                     with error code.
         --show-cops [COP1,COP2,...]  Shows the given cops, or all cops by
                                      default, and their configurations for the
                                      current directory.
@@ -135,6 +136,29 @@ Usage: rubocop [options] [file1, file2, ...]
                ' :show_cops]'].join
         expect { options.parse %w(-vV --show-cops) }
           .to raise_error(ArgumentError, msg)
+      end
+    end
+
+    describe '--fail-level' do
+      it 'accepts full severity names' do
+        %w(refactor convention warning error fatal).each do |severity|
+          expect { options.parse(['--fail-level', severity]) }
+            .not_to raise_error
+        end
+      end
+
+      it 'accepts severity initial letters' do
+        %w(R C W E F).each do |severity|
+          expect { options.parse(['--fail-level', severity]) }
+            .not_to raise_error
+        end
+      end
+
+      it 'accepts the "fake" severities A/autocorrect' do
+        %w(autocorrect A).each do |severity|
+          expect { options.parse(['--fail-level', severity]) }
+            .not_to raise_error
+        end
       end
     end
 


### PR DESCRIPTION
It seems to me that it's possible to add another fail level without messing things up. What do you think?

Add a new parameter for `--fail-level` which is not a real severity. It's just a fail level that means "fail if there were any offenses, even if they were all auto-corrected".