### PR TITLE
[Fix #1309] Add argument handling to MultilineBlockLayout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,8 @@
 * [#1492](https://github.com/bbatsov/rubocop/pull/1492): Abort when auto-correct causes an infinite loop. ([@dblock][])
 * Options `-e`/`--emacs` and `-s`/`--silent` are no longer recognized. Using them will now raise an error. ([@bquorning][])
 * [#1565](https://github.com/bbatsov/rubocop/issues/1565): Let `--fail-level A` cause exit with error if all offenses are auto-corrected. ([@jonas054][])
+* [#1309](https://github.com/bbatsov/rubocop/issues/1309): Add argument handling to `MultilineBlockLayout`. ([@lumeet][])
+
 
 ### Bugs fixed
 

--- a/lib/rubocop/cop/style/multiline_block_layout.rb
+++ b/lib/rubocop/cop/style/multiline_block_layout.rb
@@ -4,11 +4,18 @@ module RuboCop
   module Cop
     module Style
       # This cop checks whether the multiline do end blocks have a newline
-      # after the start of the block.
+      # after the start of the block. Additionally, it checks whether the block
+      # arguments, if any, are on the same line as the start of the block.
       #
       # @example
       #   # bad
       #   blah do |i| foo(i)
+      #     bar(i)
+      #   end
+      #
+      #   # bad
+      #   blah do
+      #     |i| foo(i)
       #     bar(i)
       #   end
       #
@@ -30,6 +37,8 @@ module RuboCop
       #   }
       class MultilineBlockLayout < Cop
         MSG = 'Block body expression is on the same line as the block start.'
+        ARG_MSG = 'Block argument expression is not on the same line as the ' \
+                  'block start.'
 
         def on_block(node)
           end_loc = node.loc.end
@@ -38,34 +47,73 @@ module RuboCop
 
           # A block node has three children: the block start,
           # the arguments, and the expression. We care if the block start
-          # and the expression start on the same line.
-          last_expression = node.children.last
-          return unless last_expression
-          expression_loc = last_expression.loc
-          return unless do_loc.line == expression_loc.line
+          # with arguments and the expression start on the same line.
+          _block_start, args, last_expression = node.children
 
-          expression = last_expression.loc.expression
+          if !args.children.empty? && do_loc.line != args.loc.end.line
+            add_offense_for_expression(node, args, ARG_MSG)
+          else
+            return unless last_expression
+            expression_loc = last_expression.loc
+            return unless do_loc.line == expression_loc.line
+            add_offense_for_expression(node, last_expression, MSG)
+          end
+        end
+
+        def add_offense_for_expression(node, expr, msg)
+          expression = expr.loc.expression
           range = Parser::Source::Range.new(expression.source_buffer,
                                             expression.begin_pos,
                                             expression.end_pos)
 
-          add_offense(node, range)
+          add_offense(node, range, msg)
         end
 
         def autocorrect(node)
           @corrections << lambda do |corrector|
-            _method, _args, block_body = *node
-            first_node = if block_body.type == :begin
-                           block_body.children.first
-                         else
-                           block_body
-                         end
+            _method, args, block_body = *node
+            unless args.children.empty? ||
+                   args.loc.end.line == node.loc.begin.line
+              autocorrect_arguments(corrector, node, args, block_body)
+              expr_before_body = args.loc.expression.end
+            end
 
-            block_start_col = node.loc.expression.column
+            return unless block_body
 
-            corrector.insert_before(first_node.loc.expression,
-                                    "\n  #{' ' * block_start_col}")
+            expr_before_body ||= node.loc.begin
+            if expr_before_body.line == block_body.loc.line
+              autocorrect_body(corrector, node, block_body)
+            end
           end
+        end
+
+        def autocorrect_arguments(corrector, node, args, block_body)
+          end_pos = if block_body
+                      block_body.loc.expression.begin_pos
+                    else
+                      node.loc.end.begin.begin_pos - 1
+                    end
+          range = Parser::Source::Range.new(args.loc.expression.source_buffer,
+                                            node.loc.begin.end.begin_pos,
+                                            end_pos)
+          corrector.replace(range, " |#{block_arg_string(args)}|")
+        end
+
+        def autocorrect_body(corrector, node, block_body)
+          first_node = if block_body.type == :begin
+                         block_body.children.first
+                       else
+                         block_body
+                       end
+
+          block_start_col = node.loc.expression.column
+
+          corrector.insert_before(first_node.loc.expression,
+                                  "\n  #{' ' * block_start_col}")
+        end
+
+        def block_arg_string(args)
+          args.children.map { |a| a.loc.expression.source }.join(', ')
         end
       end
     end

--- a/spec/rubocop/cop/style/multiline_block_layout_spec.rb
+++ b/spec/rubocop/cop/style/multiline_block_layout_spec.rb
@@ -87,6 +87,36 @@ describe RuboCop::Cop::Style::MultilineBlockLayout do
       .to eq(['Block body expression is on the same line as the block start.'])
   end
 
+  it 'registers an offense for line-break before arguments' do
+    inspect_source(cop,
+                   ['test do',
+                    '  |x| play_with(x)',
+                    'end'])
+    expect(cop.messages)
+      .to eq(['Block argument expression is not on the same line as the ' \
+              'block start.'])
+  end
+
+  it 'registers an offense for line-break before arguments with empty block' do
+    inspect_source(cop,
+                   ['test do',
+                    '  |x|',
+                    'end'])
+    expect(cop.messages)
+      .to eq(['Block argument expression is not on the same line as the ' \
+              'block start.'])
+  end
+
+  it 'registers an offense for line-break within arguments' do
+    inspect_source(cop,
+                   ['test do |x,',
+                    '  y|',
+                    'end'])
+    expect(cop.messages)
+      .to eq(['Block argument expression is not on the same line as the ' \
+              'block start.'])
+  end
+
   it 'auto-corrects a do/end block with params that is missing newlines' do
     src = ['test do |foo| bar',
            'end']
@@ -134,5 +164,36 @@ describe RuboCop::Cop::Style::MultilineBlockLayout do
                               '      foo',
                               '  bar',
                               '}'].join("\n"))
+  end
+
+  it 'auto-corrects a line-break before arguments' do
+    new_source = autocorrect_source(cop,
+                                    ['test do',
+                                     '  |x| play_with(x)',
+                                     'end'])
+
+    expect(new_source).to eq(['test do |x|',
+                              '  play_with(x)',
+                              'end'].join("\n"))
+  end
+
+  it 'auto-corrects a line-break before arguments with empty block' do
+    new_source = autocorrect_source(cop,
+                                    ['test do',
+                                     '  |x|',
+                                     'end'])
+
+    expect(new_source).to eq(['test do |x|',
+                              'end'].join("\n"))
+  end
+
+  it 'auto-corrects a line-break within arguments' do
+    new_source = autocorrect_source(cop,
+                                    ['test do |x,',
+                                     '  y| play_with(x, y)',
+                                     'end'])
+    expect(new_source).to eq(['test do |x, y|',
+                              '  play_with(x, y)',
+                              'end'].join("\n"))
   end
 end


### PR DESCRIPTION
The cop now registers an offense for arguments on a wrong line.
Auto-correction is also applied to these expressions.

Fixes #1309.