### PR TITLE
Exit with exit code 1 if there were errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,7 @@
 * [#1527](https://github.com/bbatsov/rubocop/issues/1527): Make autocorrect `BracesAroundHashParameter` leave the correct number of spaces. ([@mattjmcnaughton][])
 * [#1547](https://github.com/bbatsov/rubocop/issues/1547): Don't print `[Corrected]` when auto-correction was avoided in `Style/Semicolon`. ([@jonas054][])
 * [#1573](https://github.com/bbatsov/rubocop/issues/1573): Fix assignment-related auto-correction for `BlockAlignment`. ([@lumeet][])
+* [#1587](https://github.com/bbatsov/rubocop/pull/1587): Exit with exit code 1 if there were errors ("crashing" cops). ([@jonas054][])
 
 ## 0.28.0 (10/12/2014)
 

--- a/lib/rubocop/cli.rb
+++ b/lib/rubocop/cli.rb
@@ -24,7 +24,7 @@ module RuboCop
       all_passed = runner.run(paths)
       display_error_summary(runner.errors)
 
-      all_passed && !runner.aborting? ? 0 : 1
+      all_passed && !runner.aborting? && runner.errors.empty? ? 0 : 1
     rescue Cop::AmbiguousCopName => e
       $stderr.puts "Ambiguous cop name #{e.message} needs namespace " \
                    'qualifier.'


### PR DESCRIPTION
This is necessary in order to make errors visible in Travis for example.

There's currently a crash in `Style/StructInheritance` (just created #1586) but we've missed it because `rubocop` still exits with `0`.