### PR TITLE
[Fix #1586] StructInheritance cop failing with `< DelegateClass(Something)`

### DIFF
--- a/lib/rubocop/cop/style/struct_inheritance.rb
+++ b/lib/rubocop/cop/style/struct_inheritance.rb
@@ -27,7 +27,9 @@ module RuboCop
         def struct_constructor?(node)
           if node && node.send_type?
             receiver, method_name = *node
-            receiver.const_type? &&
+
+            receiver &&
+              receiver.const_type? &&
               receiver.children.last == :Struct &&
               method_name == :new
           else

--- a/spec/rubocop/cop/style/struct_inheritance_spec.rb
+++ b/spec/rubocop/cop/style/struct_inheritance_spec.rb
@@ -29,6 +29,14 @@ describe RuboCop::Cop::Style::StructInheritance do
     expect(cop.offenses).to be_empty
   end
 
+  it 'accepts extending DelegateClass' do
+    inspect_source(cop,
+                   ['class Person < DelegateClass(Animal)',
+                    'end'
+                   ])
+    expect(cop.offenses).to be_empty
+  end
+
   it 'accepts assignment to Struct.new' do
     inspect_source(cop, 'Person = Struct.new(:first_name, :last_name)')
     expect(cop.offenses).to be_empty


### PR DESCRIPTION
https://github.com/bbatsov/rubocop/issues/1586