### PR TITLE
Allow hash rockets in hashes with symbol values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 * [#1611](https://github.com/bbatsov/rubocop/issues/1611): Add `empty`, `nil`, and `both` `SupportedStyles` to `EmptyElse` cop. Default is `both`. ([@rrosenblum][])
 * [#1611](https://github.com/bbatsov/rubocop/issues/1611): Add new `MissingElse` cop. Default is to have this cop be disabled. ([@rrosenblum][])
 * [#1602](https://github.com/bbatsov/rubocop/issues/1602): Add support for `# :nodoc` in `Documentation`. ([@lumeet][])
+* [#1437](https://github.com/bbatsov/rubocop/issues/1437): Modify `HashSyntax` cop to allow the use of hash rockets for hashes that have symbol values when using ruby19 syntax. ([@rrosenblum][])
 
 ### Bugs fixed
 

--- a/config/default.yml
+++ b/config/default.yml
@@ -323,6 +323,8 @@ Style/HashSyntax:
     - ruby19
     - ruby19_no_mixed_keys
     - hash_rockets
+# Force hashes that have a symbol value to use hash rockets
+  UseHashRocketsWithSymbolValues: false
 
 Style/IfUnlessModifier:
   MaxLineLength: 80

--- a/spec/rubocop/cop/style/hash_syntax_spec.rb
+++ b/spec/rubocop/cop/style/hash_syntax_spec.rb
@@ -6,86 +6,90 @@ describe RuboCop::Cop::Style::HashSyntax, :config do
   subject(:cop) { described_class.new(config) }
 
   context 'configured to enforce ruby19 style' do
-    let(:config) do
-      RuboCop::Config.new('Style/HashSyntax' => {
-                            'EnforcedStyle'   => 'ruby19',
-                            'SupportedStyles' => %w(ruby19 hash_rockets)
-                          },
-                          'Style/SpaceAroundOperators' => {
-                            'Enabled' => true
-                          })
-    end
+    context 'with SpaceAroundOperators enabled' do
+      let(:config) do
+        RuboCop::Config.new('Style/HashSyntax' => {
+                              'EnforcedStyle'   => 'ruby19',
+                              'SupportedStyles' => %w(ruby19 hash_rockets),
+                              'UseHashRocketsWithSymbolValues' => false
+                            },
+                            'Style/SpaceAroundOperators' => {
+                              'Enabled' => true
+                            })
+      end
 
-    it 'registers offense for hash rocket syntax when new is possible' do
-      inspect_source(cop, 'x = { :a => 0 }')
-      expect(cop.messages).to eq(['Use the new Ruby 1.9 hash syntax.'])
-      expect(cop.config_to_allow_offenses)
-        .to eq('EnforcedStyle' => 'hash_rockets')
-    end
+      it 'registers offense for hash rocket syntax when new is possible' do
+        inspect_source(cop, 'x = { :a => 0 }')
+        expect(cop.messages).to eq(['Use the new Ruby 1.9 hash syntax.'])
+        expect(cop.config_to_allow_offenses)
+          .to eq('EnforcedStyle' => 'hash_rockets')
+      end
 
-    it 'registers an offense for mixed syntax when new is possible' do
-      inspect_source(cop, 'x = { :a => 0, b: 1 }')
-      expect(cop.messages).to eq(['Use the new Ruby 1.9 hash syntax.'])
-      expect(cop.config_to_allow_offenses).to eq('Enabled' => false)
-    end
+      it 'registers an offense for mixed syntax when new is possible' do
+        inspect_source(cop, 'x = { :a => 0, b: 1 }')
+        expect(cop.messages).to eq(['Use the new Ruby 1.9 hash syntax.'])
+        expect(cop.config_to_allow_offenses).to eq('Enabled' => false)
+      end
 
-    it 'registers an offense for hash rockets in method calls' do
-      inspect_source(cop, 'func(3, :a => 0)')
-      expect(cop.messages).to eq(['Use the new Ruby 1.9 hash syntax.'])
-    end
+      it 'registers an offense for hash rockets in method calls' do
+        inspect_source(cop, 'func(3, :a => 0)')
+        expect(cop.messages).to eq(['Use the new Ruby 1.9 hash syntax.'])
+      end
 
-    it 'accepts hash rockets when keys have different types' do
-      inspect_source(cop, 'x = { :a => 0, "b" => 1 }')
-      expect(cop.messages).to be_empty
-    end
+      it 'accepts hash rockets when keys have different types' do
+        inspect_source(cop, 'x = { :a => 0, "b" => 1 }')
+        expect(cop.messages).to be_empty
+      end
 
-    it 'accepts hash rockets when keys have whitespaces in them' do
-      inspect_source(cop, 'x = { :"t o" => 0 }')
-      expect(cop.messages).to be_empty
-    end
+      it 'accepts hash rockets when keys have whitespaces in them' do
+        inspect_source(cop, 'x = { :"t o" => 0 }')
+        expect(cop.messages).to be_empty
+      end
 
-    it 'accepts hash rockets when keys have special symbols in them' do
-      inspect_source(cop, 'x = { :"\tab" => 1 }')
-      expect(cop.messages).to be_empty
-    end
+      it 'accepts hash rockets when keys have special symbols in them' do
+        inspect_source(cop, 'x = { :"\tab" => 1 }')
+        expect(cop.messages).to be_empty
+      end
 
-    it 'accepts hash rockets when keys start with a digit' do
-      inspect_source(cop, 'x = { :"1" => 1 }')
-      expect(cop.messages).to be_empty
-    end
+      it 'accepts hash rockets when keys start with a digit' do
+        inspect_source(cop, 'x = { :"1" => 1 }')
+        expect(cop.messages).to be_empty
+      end
 
-    it 'registers offense when keys start with an uppercase letter' do
-      inspect_source(cop, 'x = { :A => 0 }')
-      expect(cop.messages).to eq(['Use the new Ruby 1.9 hash syntax.'])
-    end
+      it 'registers offense when keys start with an uppercase letter' do
+        inspect_source(cop, 'x = { :A => 0 }')
+        expect(cop.messages).to eq(['Use the new Ruby 1.9 hash syntax.'])
+      end
 
-    it 'accepts new syntax in a hash literal' do
-      inspect_source(cop, 'x = { a: 0, b: 1 }')
-      expect(cop.messages).to be_empty
-    end
+      it 'accepts new syntax in a hash literal' do
+        inspect_source(cop, 'x = { a: 0, b: 1 }')
+        expect(cop.messages).to be_empty
+      end
 
-    it 'accepts new syntax in method calls' do
-      inspect_source(cop, 'func(3, a: 0)')
-      expect(cop.messages).to be_empty
-    end
+      it 'accepts new syntax in method calls' do
+        inspect_source(cop, 'func(3, a: 0)')
+        expect(cop.messages).to be_empty
+      end
 
-    it 'auto-corrects old to new style' do
-      new_source = autocorrect_source(cop, '{ :a => 1, :b   =>  2}')
-      expect(new_source).to eq('{ a: 1, b: 2}')
-    end
+      it 'auto-corrects old to new style' do
+        new_source = autocorrect_source(cop, '{ :a => 1, :b   =>  2}')
+        expect(new_source).to eq('{ a: 1, b: 2}')
+      end
 
-    it 'auto-corrects even if it interferes with SpaceAroundOperators' do
-      # Clobbering caused by two cops changing in the same range is dealt with
-      # by the auto-correct loop, so there's no reason to avoid a change.
-      new_source = autocorrect_source(cop, '{ :a=>1, :b=>2 }')
-      expect(new_source).to eq('{ a: 1, b: 2 }')
+      it 'auto-corrects even if it interferes with SpaceAroundOperators' do
+        # Clobbering caused by two cops changing in the same range is dealt with
+        # by the auto-correct loop, so there's no reason to avoid a change.
+        new_source = autocorrect_source(cop, '{ :a=>1, :b=>2 }')
+        expect(new_source).to eq('{ a: 1, b: 2 }')
+      end
     end
 
     context 'with SpaceAroundOperators disabled' do
       let(:config) do
         RuboCop::Config.new('Style/HashSyntax' => {
                               'EnforcedStyle'   => 'ruby19',
-                              'SupportedStyles' => %w(ruby19 hash_rockets)
+                              'SupportedStyles' => %w(ruby19 hash_rockets),
+                              'UseHashRocketsWithSymbolValues' => false
                             },
                             'Style/SpaceAroundOperators' => {
                               'Enabled' => false
@@ -97,26 +101,107 @@ describe RuboCop::Cop::Style::HashSyntax, :config do
         expect(new_source).to eq('{ a: 1, b: 2 }')
       end
     end
+
+    context 'configured to use hash rockets when symbol values are found' do
+      let(:config) do
+        RuboCop::Config.new('Style/HashSyntax' => {
+                              'EnforcedStyle' => 'ruby19',
+                              'SupportedStyles' => %w(ruby19 hash_rockets),
+                              'UseHashRocketsWithSymbolValues' => true
+                            })
+      end
+
+      it 'accepts ruby19 syntax when no elements have symbol values' do
+        inspect_source(cop, 'x = { a: 1, b: 2 }')
+        expect(cop.messages).to be_empty
+      end
+
+      it 'accepts ruby19 syntax when no elements have symbol values ' \
+        'in method calls' do
+        inspect_source(cop, 'func(3, a: 0)')
+        expect(cop.messages).to be_empty
+      end
+
+      it 'accepts new syntax in method calls' do
+        inspect_source(cop, 'func(3, a: 0)')
+        expect(cop.messages).to be_empty
+      end
+
+      it 'registers an offense when any element uses a symbol for the value' do
+        inspect_source(cop, 'x = { a: 1, b: :c }')
+        expect(cop.messages)
+          .to eq(['Use hash rockets syntax.', 'Use hash rockets syntax.'])
+      end
+
+      it 'registers an offense when any element has a symbol value ' \
+        'in method calls' do
+        inspect_source(cop, 'func(3, b: :c)')
+        expect(cop.messages).to eq(['Use hash rockets syntax.'])
+      end
+
+      it 'regeisters an offence when using hash rockets ' \
+        'and no elements have a symbol value' do
+        inspect_source(cop, 'x = { :a => 1, :b => 2 }')
+        expect(cop.messages)
+          .to eq(['Use the new Ruby 1.9 hash syntax.',
+                  'Use the new Ruby 1.9 hash syntax.'])
+      end
+
+      it 'regeisters an offence for hashes with elements on multiple lines' do
+        inspect_source(cop, "x = { a: :b,\n c: :d }")
+        expect(cop.messages)
+          .to eq(['Use hash rockets syntax.', 'Use hash rockets syntax.'])
+      end
+
+      it 'auto-corrects to ruby19 style when there are no symbol values' do
+        new_source = autocorrect_source(cop, '{ :a => 1, :b => 2 }')
+        expect(new_source).to eq('{ a: 1, b: 2 }')
+      end
+
+      it 'auto-corrects to hash rockets ' \
+        'when there is an element with a symbol value' do
+        new_source = autocorrect_source(cop, '{ a: 1, :b => :c }')
+        expect(new_source).to eq('{ :a => 1, :b => :c }')
+      end
+
+      it 'auto-corrects to hash rockets ' \
+        'when all elements have symbol value' do
+        new_source = autocorrect_source(cop, '{ a: :b, c: :d }')
+        expect(new_source).to eq('{ :a => :b, :c => :d }')
+      end
+
+      it 'auto-correct does not change anything when the hash ' \
+        'is already ruby19 style and there are no symbol values' do
+        new_source = autocorrect_source(cop, '{ a: 1, b: 2 }')
+        expect(new_source).to eq('{ a: 1, b: 2 }')
+      end
+    end
   end
 
   context 'configured to enforce hash rockets style' do
-    let(:cop_config) { { 'EnforcedStyle' => 'hash_rockets' } }
+    let(:config) do
+      RuboCop::Config.new('Style/HashSyntax' => {
+                            'EnforcedStyle' => 'hash_rockets',
+                            'SupportedStyles' => %w(ruby19 hash_rockets),
+                            'UseHashRocketsWithSymbolValues' => false
+                          })
+    end
 
     it 'registers offense for Ruby 1.9 style' do
       inspect_source(cop, 'x = { a: 0 }')
-      expect(cop.messages).to eq(['Always use hash rockets in hashes.'])
+      expect(cop.messages).to eq(['Use hash rockets syntax.'])
       expect(cop.config_to_allow_offenses).to eq('EnforcedStyle' => 'ruby19')
     end
 
     it 'registers an offense for mixed syntax' do
       inspect_source(cop, 'x = { :a => 0, b: 1 }')
-      expect(cop.messages).to eq(['Always use hash rockets in hashes.'])
+      expect(cop.messages).to eq(['Use hash rockets syntax.'])
       expect(cop.config_to_allow_offenses).to eq('Enabled' => false)
     end
 
     it 'registers an offense for 1.9 style in method calls' do
       inspect_source(cop, 'func(3, a: 0)')
-      expect(cop.messages).to eq(['Always use hash rockets in hashes.'])
+      expect(cop.messages).to eq(['Use hash rockets syntax.'])
     end
 
     it 'accepts hash rockets in a hash literal' do
@@ -133,91 +218,230 @@ describe RuboCop::Cop::Style::HashSyntax, :config do
       new_source = autocorrect_source(cop, '{ a: 1, b: 2}')
       expect(new_source).to eq('{ :a => 1, :b => 2}')
     end
+
+    context 'UseHashRocketsWithSymbolValues has no impact' do
+      let(:config) do
+        RuboCop::Config.new('Style/HashSyntax' => {
+                              'EnforcedStyle' => 'hash_rockets',
+                              'SupportedStyles' => %w(ruby19 hash_rockets),
+                              'UseHashRocketsWithSymbolValues' => true
+                            })
+      end
+
+      it 'does not register an offense when there is a symbol value' do
+        inspect_source(cop, '{ :a => :b, :c => :d }')
+        expect(cop.messages).to be_empty
+      end
+    end
   end
 
   context 'configured to enforce ruby 1.9 style with no mixed keys' do
-    let(:cop_config) { { 'EnforcedStyle' => 'ruby19_no_mixed_keys' } }
+    context 'UseHashRocketsWithSymbolValues disabled' do
+      let(:cop_config) do
+        {
+          'EnforcedStyle' => 'ruby19_no_mixed_keys',
+          'UseHashRocketsWithSymbolValues' => false
+        }
+      end
 
-    it 'accepts new syntax in a hash literal' do
-      inspect_source(cop, 'x = { a: 0, b: 1 }')
-      expect(cop.messages).to be_empty
+      it 'accepts new syntax in a hash literal' do
+        inspect_source(cop, 'x = { a: 0, b: 1 }')
+        expect(cop.messages).to be_empty
+      end
+
+      it 'registers offense for hash rocket syntax when new is possible' do
+        inspect_source(cop, 'x = { :a => 0 }')
+        expect(cop.messages).to eq(['Use the new Ruby 1.9 hash syntax.'])
+        expect(cop.config_to_allow_offenses)
+          .to eq('EnforcedStyle' => 'hash_rockets')
+      end
+
+      it 'registers an offense for mixed syntax when new is possible' do
+        inspect_source(cop, 'x = { :a => 0, b: 1 }')
+        expect(cop.messages).to eq(['Use the new Ruby 1.9 hash syntax.'])
+        expect(cop.config_to_allow_offenses).to eq('Enabled' => false)
+      end
+
+      it 'accepts new syntax in method calls' do
+        inspect_source(cop, 'func(3, a: 0)')
+        expect(cop.messages).to be_empty
+      end
+
+      it 'registers an offense for hash rockets in method calls' do
+        inspect_source(cop, 'func(3, :a => 0)')
+        expect(cop.messages).to eq(['Use the new Ruby 1.9 hash syntax.'])
+      end
+
+      it 'accepts hash rockets when keys have different types' do
+        inspect_source(cop, 'x = { :a => 0, "b" => 1 }')
+        expect(cop.messages).to be_empty
+      end
+
+      it 'registers an offense when keys have different types and styles' do
+        inspect_source(cop, 'x = { a: 0, "b" => 1 }')
+        expect(cop.messages).to eq(["Don't mix styles in the same hash."])
+        expect(cop.config_to_allow_offenses).to eq('Enabled' => false)
+      end
+
+      it 'accepts hash rockets when keys have whitespaces in them' do
+        inspect_source(cop, 'x = { :"t o" => 0, :b => 1 }')
+        expect(cop.messages).to be_empty
+      end
+
+      it 'registers an offense when keys have whitespaces and mix styles' do
+        inspect_source(cop, 'x = { :"t o" => 0, b: 1 }')
+        expect(cop.messages).to eq(["Don't mix styles in the same hash."])
+        expect(cop.config_to_allow_offenses).to eq('Enabled' => false)
+      end
+
+      it 'accepts hash rockets when keys have special symbols in them' do
+        inspect_source(cop, 'x = { :"\tab" => 1, :b => 1 }')
+        expect(cop.messages).to be_empty
+      end
+
+      it 'registers an offense when keys have special symbols and mix styles' do
+        inspect_source(cop, 'x = { :"\tab" => 1, b: 1 }')
+        expect(cop.messages).to eq(["Don't mix styles in the same hash."])
+        expect(cop.config_to_allow_offenses).to eq('Enabled' => false)
+      end
+
+      it 'accepts hash rockets when keys start with a digit' do
+        inspect_source(cop, 'x = { :"1" => 1, :b => 1 }')
+        expect(cop.messages).to be_empty
+      end
+
+      it 'registers an offense when keys start with a digit and mix styles' do
+        inspect_source(cop, 'x = { :"1" => 1, b: 1 }')
+        expect(cop.messages).to eq(["Don't mix styles in the same hash."])
+        expect(cop.config_to_allow_offenses).to eq('Enabled' => false)
+      end
+
+      it 'auto-corrects old to new style' do
+        new_source = autocorrect_source(cop, '{ :a => 1, :b => 2 }')
+        expect(new_source).to eq('{ a: 1, b: 2 }')
+      end
+
+      it 'auto-corrects to hash rockets when new style cannot be used ' \
+        'for all' do
+        new_source = autocorrect_source(cop, '{ a: 1, "b" => 2 }')
+        expect(new_source).to eq('{ :a => 1, "b" => 2 }')
+      end
     end
 
-    it 'registers offense for hash rocket syntax when new is possible' do
-      inspect_source(cop, 'x = { :a => 0 }')
-      expect(cop.messages).to eq(['Use the new Ruby 1.9 hash syntax.'])
-      expect(cop.config_to_allow_offenses)
-        .to eq('EnforcedStyle' => 'hash_rockets')
-    end
+    context 'UseHashRocketsWithSymbolValues enabled' do
+      let(:cop_config) do
+        {
+          'EnforcedStyle' => 'ruby19_no_mixed_keys',
+          'UseHashRocketsWithSymbolValues' => true
+        }
+      end
 
-    it 'registers an offense for mixed syntax when new is possible' do
-      inspect_source(cop, 'x = { :a => 0, b: 1 }')
-      expect(cop.messages).to eq(['Use the new Ruby 1.9 hash syntax.'])
-      expect(cop.config_to_allow_offenses).to eq('Enabled' => false)
-    end
+      it 'registers an offense when any element uses a symbol for the value' do
+        inspect_source(cop, 'x = { a: 1, b: :c }')
+        expect(cop.messages)
+          .to eq(['Use hash rockets syntax.', 'Use hash rockets syntax.'])
+      end
 
-    it 'accepts new syntax in method calls' do
-      inspect_source(cop, 'func(3, a: 0)')
-      expect(cop.messages).to be_empty
-    end
+      it 'registers an offense when any element has a symbol value ' \
+        'in method calls' do
+        inspect_source(cop, 'func(3, b: :c)')
+        expect(cop.messages).to eq(['Use hash rockets syntax.'])
+      end
 
-    it 'registers an offense for hash rockets in method calls' do
-      inspect_source(cop, 'func(3, :a => 0)')
-      expect(cop.messages).to eq(['Use the new Ruby 1.9 hash syntax.'])
-    end
+      it 'auto-corrects to hash rockets ' \
+        'when there is an element with a symbol value' do
+        new_source = autocorrect_source(cop, '{ a: 1, :b => :c }')
+        expect(new_source).to eq('{ :a => 1, :b => :c }')
+      end
 
-    it 'accepts hash rockets when keys have different types' do
-      inspect_source(cop, 'x = { :a => 0, "b" => 1 }')
-      expect(cop.messages).to be_empty
-    end
+      it 'auto-corrects to hash rockets ' \
+        'when all elements have symbol value' do
+        new_source = autocorrect_source(cop, '{ a: :b, c: :d }')
+        expect(new_source).to eq('{ :a => :b, :c => :d }')
+      end
 
-    it 'registers an offense when keys have different types and styles' do
-      inspect_source(cop, 'x = { a: 0, "b" => 1 }')
-      expect(cop.messages).to eq(["Don't mix styles in the same hash."])
-      expect(cop.config_to_allow_offenses).to eq('Enabled' => false)
-    end
+      it 'accepts new syntax in a hash literal' do
+        inspect_source(cop, 'x = { a: 0, b: 1 }')
+        expect(cop.messages).to be_empty
+      end
 
-    it 'accepts hash rockets when keys have whitespaces in them' do
-      inspect_source(cop, 'x = { :"t o" => 0, :b => 1 }')
-      expect(cop.messages).to be_empty
-    end
+      it 'registers offense for hash rocket syntax when new is possible' do
+        inspect_source(cop, 'x = { :a => 0 }')
+        expect(cop.messages).to eq(['Use the new Ruby 1.9 hash syntax.'])
+        expect(cop.config_to_allow_offenses)
+          .to eq('EnforcedStyle' => 'hash_rockets')
+      end
 
-    it 'registers an offense when keys have whitespaces and mix styles' do
-      inspect_source(cop, 'x = { :"t o" => 0, b: 1 }')
-      expect(cop.messages).to eq(["Don't mix styles in the same hash."])
-      expect(cop.config_to_allow_offenses).to eq('Enabled' => false)
-    end
+      it 'registers an offense for mixed syntax when new is possible' do
+        inspect_source(cop, 'x = { :a => 0, b: 1 }')
+        expect(cop.messages).to eq(['Use the new Ruby 1.9 hash syntax.'])
+        expect(cop.config_to_allow_offenses).to eq('Enabled' => false)
+      end
 
-    it 'accepts hash rockets when keys have special symbols in them' do
-      inspect_source(cop, 'x = { :"\tab" => 1, :b => 1 }')
-      expect(cop.messages).to be_empty
-    end
+      it 'accepts new syntax in method calls' do
+        inspect_source(cop, 'func(3, a: 0)')
+        expect(cop.messages).to be_empty
+      end
 
-    it 'registers an offense when keys have special symbols and mix styles' do
-      inspect_source(cop, 'x = { :"\tab" => 1, b: 1 }')
-      expect(cop.messages).to eq(["Don't mix styles in the same hash."])
-      expect(cop.config_to_allow_offenses).to eq('Enabled' => false)
-    end
+      it 'registers an offense for hash rockets in method calls' do
+        inspect_source(cop, 'func(3, :a => 0)')
+        expect(cop.messages).to eq(['Use the new Ruby 1.9 hash syntax.'])
+      end
 
-    it 'accepts hash rockets when keys start with a digit' do
-      inspect_source(cop, 'x = { :"1" => 1, :b => 1 }')
-      expect(cop.messages).to be_empty
-    end
+      it 'accepts hash rockets when keys have different types' do
+        inspect_source(cop, 'x = { :a => 0, "b" => 1 }')
+        expect(cop.messages).to be_empty
+      end
 
-    it 'registers an offense when keys start with a digit and mix styles' do
-      inspect_source(cop, 'x = { :"1" => 1, b: 1 }')
-      expect(cop.messages).to eq(["Don't mix styles in the same hash."])
-      expect(cop.config_to_allow_offenses).to eq('Enabled' => false)
-    end
+      it 'registers an offense when keys have different types and styles' do
+        inspect_source(cop, 'x = { a: 0, "b" => 1 }')
+        expect(cop.messages).to eq(["Don't mix styles in the same hash."])
+        expect(cop.config_to_allow_offenses).to eq('Enabled' => false)
+      end
 
-    it 'auto-corrects old to new style' do
-      new_source = autocorrect_source(cop, '{ :a => 1, :b => 2 }')
-      expect(new_source).to eq('{ a: 1, b: 2 }')
-    end
+      it 'accepts hash rockets when keys have whitespaces in them' do
+        inspect_source(cop, 'x = { :"t o" => 0, :b => 1 }')
+        expect(cop.messages).to be_empty
+      end
 
-    it 'auto-corrects to hash rockets when new style cannot be used for all' do
-      new_source = autocorrect_source(cop, '{ a: 1, "b" => 2 }')
-      expect(new_source).to eq('{ :a => 1, "b" => 2 }')
+      it 'registers an offense when keys have whitespaces and mix styles' do
+        inspect_source(cop, 'x = { :"t o" => 0, b: 1 }')
+        expect(cop.messages).to eq(["Don't mix styles in the same hash."])
+        expect(cop.config_to_allow_offenses).to eq('Enabled' => false)
+      end
+
+      it 'accepts hash rockets when keys have special symbols in them' do
+        inspect_source(cop, 'x = { :"\tab" => 1, :b => 1 }')
+        expect(cop.messages).to be_empty
+      end
+
+      it 'registers an offense when keys have special symbols and mix styles' do
+        inspect_source(cop, 'x = { :"\tab" => 1, b: 1 }')
+        expect(cop.messages).to eq(["Don't mix styles in the same hash."])
+        expect(cop.config_to_allow_offenses).to eq('Enabled' => false)
+      end
+
+      it 'accepts hash rockets when keys start with a digit' do
+        inspect_source(cop, 'x = { :"1" => 1, :b => 1 }')
+        expect(cop.messages).to be_empty
+      end
+
+      it 'registers an offense when keys start with a digit and mix styles' do
+        inspect_source(cop, 'x = { :"1" => 1, b: 1 }')
+        expect(cop.messages).to eq(["Don't mix styles in the same hash."])
+        expect(cop.config_to_allow_offenses).to eq('Enabled' => false)
+      end
+
+      it 'auto-corrects old to new style' do
+        new_source = autocorrect_source(cop, '{ :a => 1, :b => 2 }')
+        expect(new_source).to eq('{ a: 1, b: 2 }')
+      end
+
+      it 'auto-corrects to hash rockets when new style cannot be used ' \
+        'for all' do
+        new_source = autocorrect_source(cop, '{ a: 1, "b" => 2 }')
+        expect(new_source).to eq('{ :a => 1, "b" => 2 }')
+      end
     end
   end
 end


### PR DESCRIPTION
This resolves #1437. This will ignore the syntax used for a hash element when the value of that element is a symbol. When the value is not a symbol, it will enforce the ruby19 syntax.