### PR TITLE
[Fix #1574] Don't auto-correct Hash.new into block braces

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,7 @@
 * [#1547](https://github.com/bbatsov/rubocop/issues/1547): Don't print `[Corrected]` when auto-correction was avoided in `Style/Semicolon`. ([@jonas054][])
 * [#1573](https://github.com/bbatsov/rubocop/issues/1573): Fix assignment-related auto-correction for `BlockAlignment`. ([@lumeet][])
 * [#1587](https://github.com/bbatsov/rubocop/pull/1587): Exit with exit code 1 if there were errors ("crashing" cops). ([@jonas054][])
+* [#1574](https://github.com/bbatsov/rubocop/issues/1574): Avoid auto-correcting `Hash.new` to `{}` when braces would be interpreted as a block. ([@jonas054][])
 
 ## 0.28.0 (10/12/2014)
 

--- a/spec/rubocop/cop/style/empty_literal_spec.rb
+++ b/spec/rubocop/cop/style/empty_literal_spec.rb
@@ -64,8 +64,25 @@ describe RuboCop::Cop::Style::EmptyLiteral do
     end
 
     it 'auto-corrects Hash.new to {}' do
-      new_source = autocorrect_source(cop, 'test = Hash.new')
-      expect(new_source).to eq('test = {}')
+      new_source = autocorrect_source(cop, 'Hash.new')
+      expect(new_source).to eq('{}')
+    end
+
+    it 'auto-corrects Hash.new to {} in various contexts' do
+      new_source =
+        autocorrect_source(cop, ['test = Hash.new',
+                                 'Hash.new.merge("a" => 3)',
+                                 'yadayada.map { a }.reduce(Hash.new, :merge)'])
+      expect(new_source)
+        .to eq(['test = {}',
+                '{}.merge("a" => 3)',
+                'yadayada.map { a }.reduce({}, :merge)'].join("\n"))
+    end
+
+    it 'does not auto-correct Hash.new to {} if changing code meaning' do
+      source = 'yadayada.map { a }.reduce Hash.new, :merge'
+      new_source = autocorrect_source(cop, source)
+      expect(new_source).to eq(source)
     end
   end
 


### PR DESCRIPTION
When `{}` would be interpreted as block braces we issue the offense report, but don't auto-correct.

Staying away from adding parentheses in `autocorrect`, since I'm not sure about the implications.