### PR TITLE
[Fix #1591] Don't check #[] parameters in MultilineOperationIndentation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,7 @@
 * [#1573](https://github.com/bbatsov/rubocop/issues/1573): Fix assignment-related auto-correction for `BlockAlignment`. ([@lumeet][])
 * [#1587](https://github.com/bbatsov/rubocop/pull/1587): Exit with exit code 1 if there were errors ("crashing" cops). ([@jonas054][])
 * [#1574](https://github.com/bbatsov/rubocop/issues/1574): Avoid auto-correcting `Hash.new` to `{}` when braces would be interpreted as a block. ([@jonas054][])
+* [#1591](https://github.com/bbatsov/rubocop/issues/1591): Don't check parameters inside `[]` in `MultilineOperationIndentation`. ([@jonas054][])
 
 ## 0.28.0 (10/12/2014)
 

--- a/lib/rubocop/cop/style/multiline_operation_indentation.rb
+++ b/lib/rubocop/cop/style/multiline_operation_indentation.rb
@@ -25,8 +25,9 @@ module RuboCop
         end
 
         def on_send(node)
-          receiver, _method_name, *_args = *node
+          receiver, method_name, *_args = *node
           return unless receiver
+          return if method_name == :[] # Don't check parameters inside [].
 
           lhs, rhs = left_hand_side(receiver), right_hand_side(node)
           range = offending_range(node, lhs, rhs, style)

--- a/spec/rubocop/cop/style/multiline_operation_indentation_spec.rb
+++ b/spec/rubocop/cop/style/multiline_operation_indentation_spec.rb
@@ -151,6 +151,14 @@ describe RuboCop::Cop::Style::MultilineOperationIndentation do
       expect(cop.messages).to be_empty
     end
 
+    it 'accepts any indentation of parameters to #[]' do
+      inspect_source(cop,
+                     ['payment = Models::IncomingPayments[',
+                      "        id:      input['incoming-payment-id'],",
+                      '           user_id: @user[:id]]'])
+      expect(cop.messages).to be_empty
+    end
+
     it 'registers an offense for extra indentation of 3rd line in typical ' \
        'RSpec code' do
       inspect_source(cop,


### PR DESCRIPTION
Those parameters aren't the operators that this cop should check.