### PR TITLE
[Fix #1594] Fix Warnings in yard doc generation regarding @example

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,7 @@
 * [#1574](https://github.com/bbatsov/rubocop/issues/1574): Avoid auto-correcting `Hash.new` to `{}` when braces would be interpreted as a block. ([@jonas054][])
 * [#1591](https://github.com/bbatsov/rubocop/issues/1591): Don't check parameters inside `[]` in `MultilineOperationIndentation`. ([@jonas054][])
 * [#1509](https://github.com/bbatsov/rubocop/issues/1509): Ignore class methods in `Rails/Delegate`. ([@bbatsov][])
+* [#1594](https://github.com/bbatsov/rubocop/issues/1594): Fix `@example` warnings in Yard Doc documentation generation. ([@mattjmcnaughton][])
 
 ## 0.28.0 (10/12/2014)
 

--- a/lib/rubocop/cop/corrector.rb
+++ b/lib/rubocop/cop/corrector.rb
@@ -17,19 +17,19 @@ module RuboCop
       #
       # @example
       #
-      # class AndOrCorrector
-      #   def initialize(node)
-      #     @node = node
+      #   class AndOrCorrector
+      #     def initialize(node)
+      #       @node = node
+      #     end
+      #
+      #     def call(corrector)
+      #       replacement = (@node.type == :and ? '&&' : '||')
+      #       corrector.replace(@node.loc.operator, replacement)
+      #     end
       #   end
       #
-      #   def call(corrector)
-      #     replacement = (@node.type == :and ? '&&' : '||')
-      #     corrector.replace(@node.loc.operator, replacement)
-      #   end
-      # end
-      #
-      # corrections = [AndOrCorrector.new(node)]
-      # corrector = Corrector.new(source_buffer, corrections)
+      #   corrections = [AndOrCorrector.new(node)]
+      #   corrector = Corrector.new(source_buffer, corrections)
       def initialize(source_buffer, corrections)
         @source_buffer = source_buffer
         @corrections = corrections

--- a/lib/rubocop/cop/lint/parentheses_as_grouped_expression.rb
+++ b/lib/rubocop/cop/lint/parentheses_as_grouped_expression.rb
@@ -8,7 +8,7 @@ module RuboCop
       #
       # @example
       #
-      # puts (x + y)
+      #   puts (x + y)
       class ParenthesesAsGroupedExpression < Cop
         MSG = '`(...)` interpreted as grouped expression.'
 

--- a/lib/rubocop/cop/lint/require_parentheses.rb
+++ b/lib/rubocop/cop/lint/require_parentheses.rb
@@ -14,9 +14,9 @@ module RuboCop
       #
       # @example
       #
-      # if day.is? :tuesday && month == :jan
-      #   ...
-      # end
+      #   if day.is? :tuesday && month == :jan
+      #     ...
+      #   end
       class RequireParentheses < Cop
         include IfNode
 

--- a/lib/rubocop/cop/style/indentation_consistency.rb
+++ b/lib/rubocop/cop/style/indentation_consistency.rb
@@ -7,12 +7,12 @@ module RuboCop
       #
       # @example
       #
-      # class A
-      #   def test
-      #     puts 'hello'
-      #      puts 'world'
+      #   class A
+      #     def test
+      #       puts 'hello'
+      #        puts 'world'
+      #     end
       #   end
-      # end
       class IndentationConsistency < Cop
         include AutocorrectAlignment
         include AccessModifierNode

--- a/lib/rubocop/cop/style/indentation_width.rb
+++ b/lib/rubocop/cop/style/indentation_width.rb
@@ -7,11 +7,11 @@ module RuboCop
       #
       # @example
       #
-      # class A
-      #  def test
-      #   puts 'hello'
-      #  end
-      # end
+      #   class A
+      #    def test
+      #     puts 'hello'
+      #    end
+      #   end
       class IndentationWidth < Cop # rubocop:disable Metrics/ClassLength
         include AutocorrectAlignment
         include OnMethodDef

--- a/lib/rubocop/cop/style/method_called_on_do_end_block.rb
+++ b/lib/rubocop/cop/style/method_called_on_do_end_block.rb
@@ -9,9 +9,9 @@ module RuboCop
       #
       # @example
       #
-      # a do
-      #   b
-      # end.c
+      #   a do
+      #     b
+      #   end.c
       class MethodCalledOnDoEndBlock < Cop
         MSG = 'Avoid chaining a method call on a do...end block.'
 

--- a/lib/rubocop/cop/style/module_function.rb
+++ b/lib/rubocop/cop/style/module_function.rb
@@ -7,10 +7,10 @@ module RuboCop
       #
       # @example
       #
-      # module Test
-      #   extend self
+      #   module Test
+      #     extend self
       #
-      #   ...
+      #     ...
       # end
       class ModuleFunction < Cop
         MSG = 'Use `module_function` instead of `extend self`.'


### PR DESCRIPTION
Really simple fix. Just changing the indentation on the `@example` so that fit within the Yard Doc guidelines. Fixes #1594 