### PR TITLE
Add formatter 'quiet'

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 * Add autocorrect to `RedundantException`. ([@mattjmcnaughton][])
 * [#1571](https://github.com/bbatsov/rubocop/pull/1571): New cop `StructInheritance` checks for inheritance from Struct.new. ([@mmozuras][])
 * [#1575](https://github.com/bbatsov/rubocop/issues/1575): New cop `DuplicateMethods` points out duplicate method name in class and module. ([@d4rk5eed][])
+* [#1583](https://github.com/bbatsov/rubocop/issues/1583): Add `quiet` formatter that is silent when no offenses are found. ([@dhempy][])
 
 ### Changes
 
@@ -1240,3 +1241,4 @@
 [@lumeet]: https://github.com/lumeet
 [@mmozuras]: https://github.com/mmozuras
 [@d4rk5eed]: https://github.com/d4rk5eed
+[@dhempy]: https://github.com/dhempy

--- a/README.md
+++ b/README.md
@@ -57,6 +57,7 @@ release.**
     - [JSON Formatter](#json-formatter)
     - [Offense Count Formatter](#offense-count-formatter)
     - [HTML Formatter](#html-formatter)
+    - [Quiet Formatter](#quiet-formatter)
 - [Compatibility](#compatibility)
 - [Editor integration](#editor-integration)
     - [Emacs](#emacs)
@@ -547,6 +548,23 @@ C:  2:  3: Favor modifier if usage when having a single-line body. Another good 
 W:  4:  5: end at 4, 4 is not aligned with if at 2, 2
 
 1 file inspected, 4 offenses detected
+```
+
+### Quiet Formatter
+
+Produces no output if there are no offenses.
+Otherwise, identical to the Simple formatter.
+
+```
+$ rubocop --format quiet naughty.rb
+== naughty.rb ==
+C:  1:  5: Use snake_case for method names.
+C:  2:  3: Use a guard clause instead of wrapping the code inside a conditional expression.
+
+1 file inspected, 2 offenses detected
+
+$ rubocop --format quiet nice.rb
+$
 ```
 
 ### File List Formatter

--- a/lib/rubocop.rb
+++ b/lib/rubocop.rb
@@ -283,6 +283,7 @@ require 'rubocop/formatter/json_formatter'
 require 'rubocop/formatter/html_formatter'
 require 'rubocop/formatter/file_list_formatter'
 require 'rubocop/formatter/offense_count_formatter'
+require 'rubocop/formatter/quiet_formatter'
 require 'rubocop/formatter/formatter_set'
 
 require 'rubocop/config'

--- a/lib/rubocop/formatter/formatter_set.rb
+++ b/lib/rubocop/formatter/formatter_set.rb
@@ -18,7 +18,8 @@ module RuboCop
         'html'     => HTMLFormatter,
         'files'    => FileListFormatter,
         'offenses' => OffenseCountFormatter,
-        'disabled' => DisabledLinesFormatter
+        'disabled' => DisabledLinesFormatter,
+        'quiet'    => QuietFormatter
       }
 
       FORMATTER_APIS = [:started, :file_started, :file_finished, :finished]

--- a/lib/rubocop/formatter/quiet_formatter.rb
+++ b/lib/rubocop/formatter/quiet_formatter.rb
@@ -1,0 +1,13 @@
+# encoding: utf-8
+
+module RuboCop
+  module Formatter
+    # If no offences are found, no output is displayed.
+    # Otherwise, SimpleTextFormatter's output is displayed.
+    class QuietFormatter < SimpleTextFormatter
+      def report_summary(file_count, offense_count, correction_count)
+        super unless offense_count.zero?
+      end
+    end
+  end
+end

--- a/lib/rubocop/options.rb
+++ b/lib/rubocop/options.rb
@@ -29,6 +29,7 @@ module RuboCop
                          '  [j]son',
                          '  [h]tml',
                          '  [fi]les',
+                         '  [q]uiet',
                          '  [o]ffenses',
                          '  custom formatter class name'],
       out:              ['Write output to a file instead of STDOUT.',

--- a/spec/rubocop/cli_spec.rb
+++ b/spec/rubocop/cli_spec.rb
@@ -1447,6 +1447,25 @@ describe RuboCop::CLI, :isolated_environment do
           end
         end
 
+        context 'when quiet format is specified' do
+          context 'with an offensive file' do
+            it 'outputs with simple format' do
+              cli.run(['--format', 'quiet', 'example.rb'])
+              expect($stdout.string)
+                .to include(["== #{target_file} ==",
+                             'C:  2: 81: Line is too long. [90/80]'].join("\n"))
+            end
+          end
+
+          context 'with a clean file' do
+            it 'outputs nothing' do
+              create_file('clean.rb', ['puts \'Hello, world!\''])
+              cli.run(['--format', 'quiet', 'clean.rb'])
+              expect($stdout.string).to eq('')
+            end
+          end
+        end
+
         context 'when unknown format name is specified' do
           it 'aborts with error message' do
             expect { cli.run(['--format', 'unknown', 'example.rb']) }

--- a/spec/rubocop/options_spec.rb
+++ b/spec/rubocop/options_spec.rb
@@ -58,6 +58,7 @@ Usage: rubocop [options] [file1, file2, ...]
                                        [j]son
                                        [h]tml
                                        [fi]les
+                                       [q]uiet
                                        [o]ffenses
                                        custom formatter class name
     -o, --out FILE                   Write output to a file instead of STDOUT.


### PR DESCRIPTION
New formatter `quiet` produces no output if no offenses are found.  Otherwise, it outputs in `simple` format.