### PR TITLE
[Fix #1612] Allowed expand_path on inherit_from in .rubocop.yml

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,7 @@
 * [#1594](https://github.com/bbatsov/rubocop/issues/1594): Fix `@example` warnings in Yard Doc documentation generation. ([@mattjmcnaughton][])
 * [#1598](https://github.com/bbatsov/rubocop/issues/1598): Fix bug in file inclusion when running from another directory. ([@jonas054][])
 * [#1580](https://github.com/bbatsov/rubocop/issues/1580): Don't print `[Corrected]` when auto-correction was avoided in `TrivialAccessors`. ([@lumeet][])
+* [#1612](https://github.com/bbatsov/rubocop/issues/1612): Allow `expand_path` on `inherit_from` in `.rubocop.yml`. ([@mattjmcnaughton][])
 
 ## 0.28.0 (10/12/2014)
 

--- a/lib/rubocop/config_loader.rb
+++ b/lib/rubocop/config_loader.rb
@@ -58,7 +58,7 @@ module RuboCop
 
       def base_configs(path, inherit_from)
         configs = Array(inherit_from).map do |f|
-          f = File.join(File.dirname(path), f) unless f.start_with?('/')
+          f = File.expand_path(f, File.dirname(path))
 
           if auto_gen_config?
             next if f.include?(AUTO_GENERATED_FILE)

--- a/spec/rubocop/config_loader_spec.rb
+++ b/spec/rubocop/config_loader_spec.rb
@@ -246,6 +246,19 @@ describe RuboCop::ConfigLoader do
           .to be_superset(expected.to_set)
       end
     end
+
+    context 'when a file inherits from an expanded path' do
+      let(:file_path) { '.rubocop.yml' }
+
+      before do
+        create_file('~/.rubocop.yml', [''])
+        create_file(file_path, ['inherit_from: ~/.rubocop.yml'])
+      end
+
+      it 'does not fail to load expanded path' do
+        expect { configuration_from_file }.not_to raise_error
+      end
+    end
   end
 
   describe '.load_file', :isolated_environment do


### PR DESCRIPTION
I think this [Fix #1612], but let me know if I'm missing anything!