### PR TITLE
[Fix #1598] Match absolute path too in Config#file_to_include?

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,7 @@
 * [#1591](https://github.com/bbatsov/rubocop/issues/1591): Don't check parameters inside `[]` in `MultilineOperationIndentation`. ([@jonas054][])
 * [#1509](https://github.com/bbatsov/rubocop/issues/1509): Ignore class methods in `Rails/Delegate`. ([@bbatsov][])
 * [#1594](https://github.com/bbatsov/rubocop/issues/1594): Fix `@example` warnings in Yard Doc documentation generation. ([@mattjmcnaughton][])
+* [#1598](https://github.com/bbatsov/rubocop/issues/1598): Fix bug in file inclusion when running from another directory. ([@jonas054][])
 
 ## 0.28.0 (10/12/2014)
 

--- a/lib/rubocop/config.rb
+++ b/lib/rubocop/config.rb
@@ -111,9 +111,11 @@ module RuboCop
     end
 
     def file_to_include?(file)
+      absolute_file_path = File.expand_path(file)
       relative_file_path = path_relative_to_config(file)
       patterns_to_include.any? do |pattern|
-        match_path?(pattern, relative_file_path, loaded_path)
+        match_path?(pattern, relative_file_path, loaded_path) ||
+          match_path?(pattern, absolute_file_path, loaded_path)
       end
     end
 

--- a/spec/rubocop/cli_spec.rb
+++ b/spec/rubocop/cli_spec.rb
@@ -1687,6 +1687,44 @@ describe RuboCop::CLI, :isolated_environment do
     end
   end
 
+  context 'when given a file/directory that is not under the current dir' do
+    shared_examples 'checks Rakefile' do
+      it 'checks a Rakefile but Style/FileName does not report' do
+        create_file('Rakefile', 'x = 1')
+        create_file('other/empty', '')
+        Dir.chdir('other') do
+          expect(cli.run(['--format', 'simple', checked_path])).to eq(1)
+        end
+        expect($stdout.string)
+          .to eq(["== #{abs('Rakefile')} ==",
+                  'W:  1:  1: Useless assignment to variable - x.',
+                  '',
+                  '1 file inspected, 1 offense detected',
+                  ''].join("\n"))
+      end
+    end
+
+    context 'and the directory is absolute' do
+      let(:checked_path) { abs('..') }
+      include_examples 'checks Rakefile'
+    end
+
+    context 'and the directory is relative' do
+      let(:checked_path) { '..' }
+      include_examples 'checks Rakefile'
+    end
+
+    context 'and the Rakefile path is absolute' do
+      let(:checked_path) { abs('../Rakefile') }
+      include_examples 'checks Rakefile'
+    end
+
+    context 'and the Rakefile path is relative' do
+      let(:checked_path) { '../Rakefile' }
+      include_examples 'checks Rakefile'
+    end
+  end
+
   it 'checks a given correct file and returns 0' do
     create_file('example.rb', ['# encoding: utf-8',
                                'x = 0',


### PR DESCRIPTION
Running from another directory (not the inspected one) would cause incorrect matching against include patterns.