### PR TITLE
`TrailingComma` got `strict_comma`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 * [#1604](https://github.com/bbatsov/rubocop/issues/1604): Add `IgnoreClassMethods` option to `TrivialAccessors` cop. ([@bbatsov][])
 * [#1651](https://github.com/bbatsov/rubocop/issues/1651): The `Style/SpaceAroundOperators` cop now also detects extra spaces around operators. A list of operators that *may* be surrounded by multiple spaces is configurable. ([@bquorning][])
 * Add auto-correct to `Encoding` cop. ([@rrosenblum][])
+* [#1621](https://github.com/bbatsov/rubocop/issues/1621): `TrailingComma` has a new style `consistent_comma`. ([@tamird][])
 
 ## 0.29.1 (13/02/2015)
 

--- a/config/default.yml
+++ b/config/default.yml
@@ -515,11 +515,14 @@ Style/TrailingBlankLines:
     - final_blank_line
 
 Style/TrailingComma:
-  # If EnforcedStyleForMultiline is comma, the cop allows a comma after the
+  # If EnforcedStyleForMultiline is comma, the cop requires a comma after the
   # last item of a list, but only for lists where each item is on its own line.
+  # If EnforcedStyleForMultiline is consistent_comma, the cop requires a comma
+  # after the last item of a list, for all lists.
   EnforcedStyleForMultiline: no_comma
   SupportedStyles:
     - comma
+    - consistent_comma
     - no_comma
 
 # TrivialAccessors doesn't require exact name matches and doesn't allow


### PR DESCRIPTION
Any element with a line break in its declaration is now considered to
be multiline, which results in more consistent behaviour for this cop.