### PR TITLE
Fix 1555 remove gem spec files

### DIFF
--- a/rubocop.gemspec
+++ b/rubocop.gemspec
@@ -16,8 +16,10 @@ Gem::Specification.new do |s|
   EOF
 
   s.email = 'rubocop@googlegroups.com'
-  s.files = `git ls-files`.split($RS)
-  s.test_files = s.files.grep(/^spec\//)
+  s.files = `git ls-files`.split($RS).reject do |file|
+    file =~ /^spec\//
+  end
+  s.test_files = []
   s.executables = s.files.grep(/^bin\//) { |f| File.basename(f) }
   s.extra_rdoc_files = ['LICENSE.txt', 'README.md']
   s.homepage = 'http://github.com/bbatsov/rubocop'

--- a/rubocop.gemspec
+++ b/rubocop.gemspec
@@ -17,7 +17,17 @@ Gem::Specification.new do |s|
 
   s.email = 'rubocop@googlegroups.com'
   s.files = `git ls-files`.split($RS).reject do |file|
-    file =~ /^spec\//
+    file =~ /^(?:
+    spec\/.*
+    |Gemfile
+    |Rakefile
+    |\.rspec
+    |\.gitignore
+    |\.rubocop.yml
+    |\.rubocop_todo.yml
+    |\.travis.yml
+    |.*\.eps
+    )$/x
   end
   s.test_files = []
   s.executables = s.files.grep(/^bin\//) { |f| File.basename(f) }


### PR DESCRIPTION
Remove development files which aren't needed in released gems

- also removes huge *.eps file
- also clears practically unused "test_files" gemspec entry