### PR TITLE
Added missing default for AllCops/StyleGuideCopsOnly

### DIFF
--- a/config/default.yml
+++ b/config/default.yml
@@ -33,6 +33,10 @@ AllCops:
   # by overriding DisplayCopNames, or by giving the -D/--display-cop-names
   # option.
   DisplayCopNames: false
+  # Additional cops that do not reference a style guide rule may be enabled by
+  # default. Change behavior by overriding StyleGuideCopsOnly, or by giving
+  # the --only-guide-cops option.
+  StyleGuideCopsOnly: false
 
 # Indent private/protected/public as deep as method definitions
 Style/AccessModifierIndentation:


### PR DESCRIPTION
Looks like I forgot to implement a default setting for `AllCops/StyleGuideCopsOnly` in #1454. I'm still not sure why my tests didn't catch it, but this should fix any "unrecognized parameter" warnings when using that feature. 

Ah, and I just realized that my tests don't check stderr, and that's why they pass. :)