### PR TITLE
Fix PerlBackrefs Cop Autocorrections to Not Raise

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@
 
 ### Bugs fixed
 
+* [#1634](https://github.com/bbatsov/rubocop/pull/1634): Fix `PerlBackrefs` Cop Autocorrections to Not Raise. ([@cshaffer][])
 * [#1553](https://github.com/bbatsov/rubocop/pull/1553): Fix bug where `Style/EmptyLinesAroundAccessModifier` interfered with `Style/EmptyLinesAroundBlockBody` when there is and access modifier at the beginning of a block. ([@volkert][])
 * Handle element assignment in `Lint/AssignmentInCondition`. ([@jonas054][])
 * [#1484](https://github.com/bbatsov/rubocop/issues/1484): Fix `EmptyLinesAroundAccessModifier` incorrectly finding a violation inside method calls with names identical to an access modifier. ([@dblock][])
@@ -1244,3 +1245,4 @@
 [@lumeet]: https://github.com/lumeet
 [@mmozuras]: https://github.com/mmozuras
 [@d4rk5eed]: https://github.com/d4rk5eed
+[@cshaffer]: https://github.com/cshaffer

--- a/lib/rubocop/cop/style/perl_backrefs.rb
+++ b/lib/rubocop/cop/style/perl_backrefs.rb
@@ -18,10 +18,10 @@ module RuboCop
             parent_type = node.parent ? node.parent.type : nil
             if [:dstr, :xstr, :regexp].include?(parent_type)
               corrector.replace(node.loc.expression,
-                                "{Regexp.last_match[#{backref}]}")
+                                "{Regexp.last_match(#{backref})}")
             else
               corrector.replace(node.loc.expression,
-                                "Regexp.last_match[#{backref}]")
+                                "Regexp.last_match(#{backref})")
             end
           end
         end

--- a/spec/rubocop/cop/style/perl_backrefs_spec.rb
+++ b/spec/rubocop/cop/style/perl_backrefs_spec.rb
@@ -12,11 +12,11 @@ describe RuboCop::Cop::Style::PerlBackrefs do
 
   it 'auto-corrects $1 to Regexp.last_match[1]' do
     new_source = autocorrect_source(cop, '$1')
-    expect(new_source).to eq('Regexp.last_match[1]')
+    expect(new_source).to eq('Regexp.last_match(1)')
   end
 
   it 'auto-corrects #$1 to #{Regexp.last_match[1]}' do
     new_source = autocorrect_source(cop, '"#$1"')
-    expect(new_source).to eq('"#{Regexp.last_match[1]}"')
+    expect(new_source).to eq('"#{Regexp.last_match(1)}"')
   end
 end


### PR DESCRIPTION
When `MatchData` is `nil` an exception is raised trying to call `[]` on `nil`. For example:

As it stands today, this code:
```ruby
def match_this(input)
  input.match(/(.)(.)(\d+)(\d)/.match('THX1138.'))
  $1
end
```
which behaves like this:
```
match_this('HX1138')
=> "H"
match_this('nope')
=> nil
```

will get autocorrected into this:
```ruby
def match_this(input)
  input.match(/(.)(.)(\d+)(\d)/.match('THX1138.'))
  Regexp.last_match[1]
end
```
However this autocorrected code behaves like this:
```
match_this('HX1138')
=> "H"
match_this('nope')
NoMethodError: undefined method `[]' for nil:NilClass
```

This commit makes it so instead the code is autocorrected to this:
```ruby
def match_this(input)
  input.match(/(.)(.)(\d+)(\d)/.match('THX1138.'))
  Regexp.last_match(1)
end
```

Which behaves the same as the initial method.