### PR TITLE
Lock RSpec version since some specs are failing on 3.2.0

### DIFF
--- a/rubocop.gemspec
+++ b/rubocop.gemspec
@@ -32,7 +32,7 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency('astrolabe', '~> 1.3')
   s.add_runtime_dependency('ruby-progressbar', '~> 1.4')
   s.add_development_dependency('rake', '~> 10.1')
-  s.add_development_dependency('rspec', '~> 3.0')
+  s.add_development_dependency('rspec', '~> 3.1.0')
   s.add_development_dependency('yard', '~> 0.8')
   s.add_development_dependency('bundler', '~> 1.3')
   s.add_development_dependency('simplecov', '~> 0.7')


### PR DESCRIPTION
Couldn't spend enough time to figure out why the `JSONFormatter` specs were failing, but I was able to isolate it to RSpec 3.2.  This commit freezes RSpec to 3.1 in the meantime so the builds will pass.