### PR TITLE
[Fix #1638] Better comment matching in FirstParameterIndentation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## master (unreleased)
 
+### Bugs fixed
+
+* [#1638](https://github.com/bbatsov/rubocop/issues/1638): Use Parser functionality rather than regular expressions for matching comments in `FirstParameterIndentation`. ([@jonas054][])
+
 ## 0.29.0 (05/02/2015)
 
 ### New features

--- a/lib/rubocop/cop/style/first_parameter_indentation.rb
+++ b/lib/rubocop/cop/style/first_parameter_indentation.rb
@@ -22,8 +22,6 @@ module RuboCop
         include AutocorrectAlignment
         include ConfigurableEnforcedStyle
 
-        COMMENT_OR_BLANK_LINE = /^\s*(#.*)?$/
-
         def on_send(node)
           _receiver, method_name, *args = *node
           return if args.empty?
@@ -93,8 +91,13 @@ module RuboCop
         # containing the previous line that's not a comment line or a blank
         # line.
         def previous_code_line(line_number)
+          @comment_lines ||=
+            processed_source.comments
+            .select { |c| begins_its_line?(c.loc.expression) }
+            .map { |c| c.loc.line }
+
           line = ''
-          while line =~ COMMENT_OR_BLANK_LINE
+          while line =~ /^\s*$/ || @comment_lines.include?(line_number)
             line_number -= 1
             line = processed_source.lines[line_number - 1]
           end

--- a/spec/rubocop/cop/style/first_parameter_indentation_spec.rb
+++ b/spec/rubocop/cop/style/first_parameter_indentation_spec.rb
@@ -102,7 +102,7 @@ describe RuboCop::Cop::Style::FirstParameterIndentation, :config do
         context 'when preceded by a comment line' do
           it 'accepts a correctly indented first parameter' do
             inspect_source(cop, ['puts x.',
-                                 '  merge(',
+                                 '  merge( # EOL comment',
                                  '    # comment',
                                  '    b: 2',
                                  '  )'])
@@ -238,6 +238,17 @@ describe RuboCop::Cop::Style::FirstParameterIndentation, :config do
           expect(cop.messages).to eq(['Indent the first parameter one step ' \
                                       'more than the previous line.'])
           expect(cop.highlights).to eq(['bar: 3'])
+        end
+
+        it 'accepts a correctly indented first parameter in interpolation' do
+          inspect_source(cop, ['puts %(',
+                               '  <p>',
+                               '    #{Array(',
+                               '      42',
+                               '    )}',
+                               '  </p>',
+                               ')'])
+          expect(cop.offenses).to be_empty
         end
       end
 


### PR DESCRIPTION
The attribute `processed_source.comments` is much less error-prone and should be preferred over regexps.