### PR TITLE
New hash syntax cop that reports mixed syntax in the same hash

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### New features
 
+* [#1641](https://github.com/bbatsov/rubocop/pull/1641): Add ruby19_no_mixed_keys style to `HashStyle` cop. ([@iainbeeston][])
 * [#1604](https://github.com/bbatsov/rubocop/issues/1604): Add `IgnoreClassMethods` option to `TrivialAccessors` cop. ([@bbatsov][])
 * [#1651](https://github.com/bbatsov/rubocop/issues/1651): The `Style/SpaceAroundOperators` cop now also detects extra spaces around operators. A list of operators that *may* be surrounded by multiple spaces is configurable. ([@bquorning][])
 
@@ -1265,3 +1266,4 @@
 [@d4rk5eed]: https://github.com/d4rk5eed
 [@cshaffer]: https://github.com/cshaffer
 [@eitoball]: https://github.com/eitoball
+[@iainbeeston]: https://github.com/iainbeeston

--- a/config/default.yml
+++ b/config/default.yml
@@ -303,6 +303,7 @@ Style/HashSyntax:
   EnforcedStyle: ruby19
   SupportedStyles:
     - ruby19
+    - ruby19_no_mixed_keys
     - hash_rockets
 
 Style/IfUnlessModifier:

--- a/spec/rubocop/cop/style/hash_syntax_spec.rb
+++ b/spec/rubocop/cop/style/hash_syntax_spec.rb
@@ -134,4 +134,90 @@ describe RuboCop::Cop::Style::HashSyntax, :config do
       expect(new_source).to eq('{ :a => 1, :b => 2}')
     end
   end
+
+  context 'configured to enforce ruby 1.9 style with no mixed keys' do
+    let(:cop_config) { { 'EnforcedStyle' => 'ruby19_no_mixed_keys' } }
+
+    it 'accepts new syntax in a hash literal' do
+      inspect_source(cop, 'x = { a: 0, b: 1 }')
+      expect(cop.messages).to be_empty
+    end
+
+    it 'registers offense for hash rocket syntax when new is possible' do
+      inspect_source(cop, 'x = { :a => 0 }')
+      expect(cop.messages).to eq(['Use the new Ruby 1.9 hash syntax.'])
+      expect(cop.config_to_allow_offenses)
+        .to eq('EnforcedStyle' => 'hash_rockets')
+    end
+
+    it 'registers an offense for mixed syntax when new is possible' do
+      inspect_source(cop, 'x = { :a => 0, b: 1 }')
+      expect(cop.messages).to eq(['Use the new Ruby 1.9 hash syntax.'])
+      expect(cop.config_to_allow_offenses).to eq('Enabled' => false)
+    end
+
+    it 'accepts new syntax in method calls' do
+      inspect_source(cop, 'func(3, a: 0)')
+      expect(cop.messages).to be_empty
+    end
+
+    it 'registers an offense for hash rockets in method calls' do
+      inspect_source(cop, 'func(3, :a => 0)')
+      expect(cop.messages).to eq(['Use the new Ruby 1.9 hash syntax.'])
+    end
+
+    it 'accepts hash rockets when keys have different types' do
+      inspect_source(cop, 'x = { :a => 0, "b" => 1 }')
+      expect(cop.messages).to be_empty
+    end
+
+    it 'registers an offense when keys have different types and styles' do
+      inspect_source(cop, 'x = { a: 0, "b" => 1 }')
+      expect(cop.messages).to eq(["Don't mix styles in the same hash."])
+      expect(cop.config_to_allow_offenses).to eq('Enabled' => false)
+    end
+
+    it 'accepts hash rockets when keys have whitespaces in them' do
+      inspect_source(cop, 'x = { :"t o" => 0, :b => 1 }')
+      expect(cop.messages).to be_empty
+    end
+
+    it 'registers an offense when keys have whitespaces and mix styles' do
+      inspect_source(cop, 'x = { :"t o" => 0, b: 1 }')
+      expect(cop.messages).to eq(["Don't mix styles in the same hash."])
+      expect(cop.config_to_allow_offenses).to eq('Enabled' => false)
+    end
+
+    it 'accepts hash rockets when keys have special symbols in them' do
+      inspect_source(cop, 'x = { :"\tab" => 1, :b => 1 }')
+      expect(cop.messages).to be_empty
+    end
+
+    it 'registers an offense when keys have special symbols and mix styles' do
+      inspect_source(cop, 'x = { :"\tab" => 1, b: 1 }')
+      expect(cop.messages).to eq(["Don't mix styles in the same hash."])
+      expect(cop.config_to_allow_offenses).to eq('Enabled' => false)
+    end
+
+    it 'accepts hash rockets when keys start with a digit' do
+      inspect_source(cop, 'x = { :"1" => 1, :b => 1 }')
+      expect(cop.messages).to be_empty
+    end
+
+    it 'registers an offense when keys start with a digit and mix styles' do
+      inspect_source(cop, 'x = { :"1" => 1, b: 1 }')
+      expect(cop.messages).to eq(["Don't mix styles in the same hash."])
+      expect(cop.config_to_allow_offenses).to eq('Enabled' => false)
+    end
+
+    it 'auto-corrects old to new style' do
+      new_source = autocorrect_source(cop, '{ :a => 1, :b => 2 }')
+      expect(new_source).to eq('{ a: 1, b: 2 }')
+    end
+
+    it 'auto-corrects to hash rockets when new style cannot be used for all' do
+      new_source = autocorrect_source(cop, '{ a: 1, "b" => 2 }')
+      expect(new_source).to eq('{ :a => 1, "b" => 2 }')
+    end
+  end
 end


### PR DESCRIPTION
When I'm working on legacy code I don't care if hashes use hash rocket syntax or 1.9 syntax, but I do dislike hashes that mix the two. For example, I often see hashes that look like this `{a: 1, :b => 2}` (note that it mixes both styles of hash key). I usually end up converting these to use the same style, so that the previous example would become `{a: 1, b: 2}`. But I don't especially care which style I use (hash rockets or 1.9 style) and I don't want to change all of the hashes throughout a project to use a uniform style. My preference would be to change as few entries as possible (in a given hash) until they all use the same style, so for example `{:a => 1, :b => 2, c: 3}` I would change to `{:a => 1, :b => 2, :c => 3}`.

This PR adds a new cop that reports only hashes that mix the two forms, and autocorrects them to use a unified style (based on whichever style is most common in a given hash)