### PR TITLE
[Fix #1642] Raise right exception on bad config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Bugs fixed
 
 * [#1638](https://github.com/bbatsov/rubocop/issues/1638): Use Parser functionality rather than regular expressions for matching comments in `FirstParameterIndentation`. ([@jonas054][])
+* [#1642](https://github.com/bbatsov/rubocop/issues/1642): Raise the correct exception if the configuration file is malformed. ([@bquorning][])
 
 ## 0.29.0 (05/02/2015)
 

--- a/lib/rubocop/cli.rb
+++ b/lib/rubocop/cli.rb
@@ -29,7 +29,7 @@ module RuboCop
       $stderr.puts "Ambiguous cop name #{e.message} needs namespace " \
                    'qualifier.'
       return 1
-    rescue => e
+    rescue StandardError, SyntaxError => e
       $stderr.puts e.message
       $stderr.puts e.backtrace
       return 1

--- a/lib/rubocop/runner.rb
+++ b/lib/rubocop/runner.rb
@@ -27,24 +27,7 @@ module RuboCop
 
     def run(paths)
       target_files = find_target_files(paths)
-
-      inspected_files = []
-      all_passed = true
-
-      formatter_set.started(target_files)
-
-      target_files.each do |file|
-        break if aborting?
-        offenses = process_file(file)
-        all_passed = false if offenses.any? { |o| considered_failure?(o) }
-        inspected_files << file
-        break if @options[:fail_fast] && !all_passed
-      end
-
-      all_passed
-    ensure
-      formatter_set.finished(inspected_files.freeze)
-      formatter_set.close_output_files
+      inspect_files(target_files)
     end
 
     def abort
@@ -57,6 +40,26 @@ module RuboCop
       target_finder = TargetFinder.new(@config_store, @options)
       target_files = target_finder.find(paths)
       target_files.each(&:freeze).freeze
+    end
+
+    def inspect_files(files)
+      inspected_files = []
+      all_passed = true
+
+      formatter_set.started(files)
+
+      files.each do |file|
+        break if aborting?
+        offenses = process_file(file)
+        all_passed = false if offenses.any? { |o| considered_failure?(o) }
+        inspected_files << file
+        break if @options[:fail_fast] && !all_passed
+      end
+
+      all_passed
+    ensure
+      formatter_set.finished(inspected_files.freeze)
+      formatter_set.close_output_files
     end
 
     def process_file(file)

--- a/spec/rubocop/cli_spec.rb
+++ b/spec/rubocop/cli_spec.rb
@@ -2692,6 +2692,17 @@ describe RuboCop::CLI, :isolated_environment do
                 ''].join("\n"))
     end
 
+    it 'fails when a configuration file has invalid YAML syntax' do
+      create_file('example/.rubocop.yml', ['AllCops:',
+                                           '  Exclude:',
+                                           '    - **/*_old.rb'])
+
+      cli.run(['example'])
+      expect($stderr.string)
+        .to start_with('(<unknown>): did not find expected alphabetic or ' \
+          'numeric character while scanning an alias at line 3 column 7')
+    end
+
     context 'when a file inherits from the old auto generated file' do
       before do
         create_file('rubocop-todo.yml', '')


### PR DESCRIPTION
~~In case of syntax errors in the config file, `#find_target_files` will raise an exception. That exception needs to be able to travel up the call chain, and not be caught by that #ensure block. Solution: extract the code with an `#ensure` block to a new method.~~

[Updated] In case of syntax errors in the config file, #find_target_files will raise an exception. Before that exception whould be cought in `CLI#run`, the `#ensure` block in `Runner#run` would cause *another* exception to be raised, and only this irrelevant exception would be caught by `CLI#run` and reported to the user.

Solution: Extract the code with an `#ensure` block to a new method.