### PR TITLE
[Fix #1644] Avoid globbing entire file system

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 * [#1642](https://github.com/bbatsov/rubocop/issues/1642): Raise the correct exception if the configuration file is malformed. ([@bquorning][])
 * [#1647](https://github.com/bbatsov/rubocop/issues/1647): Skip `SpaceAroundBlockParameters` when lambda has no argument. ([@eitoball][])
 * [#1649](https://github.com/bbatsov/rubocop/issues/1649): Handle exception assignments in `UselessSetterCall`. ([@bbatsov][])
+* [#1644](https://github.com/bbatsov/rubocop/issues/1644): Don't search the entire file system when a folder is named `,`. ([@bquorning][])
 
 ## 0.29.0 (05/02/2015)
 

--- a/lib/rubocop/target_finder.rb
+++ b/lib/rubocop/target_finder.rb
@@ -88,6 +88,7 @@ module RuboCop
     def find_files(base_dir, flags)
       wanted_toplevel_dirs = toplevel_dirs(base_dir, flags) -
                              excluded_dirs(base_dir)
+      wanted_toplevel_dirs.map! { |dir| dir.gsub(',', '\,') }
 
       pattern = if wanted_toplevel_dirs.empty?
                   # We need this special case to avoid creating the pattern

--- a/spec/rubocop/target_finder_spec.rb
+++ b/spec/rubocop/target_finder_spec.rb
@@ -140,6 +140,19 @@ describe RuboCop::TargetFinder, :isolated_environment do
       expect(found_basenames).not_to include('ruby1.rb')
       expect(found_basenames).to include('ruby3.rb')
     end
+
+    it 'works also if a folder is named ","' do
+      create_file(',/ruby4.rb', '# encoding: utf-8')
+
+      config = double('config')
+      exclude_property = { 'Exclude' => [File.expand_path('dir1/**/*')] }
+      allow(config).to receive(:[]).with('AllCops').and_return(exclude_property)
+      allow(config_store).to receive(:for).and_return(config)
+
+      expect(found_basenames).not_to include('ruby1.rb')
+      expect(found_basenames).to include('ruby3.rb')
+      expect(found_basenames).to include('ruby4.rb')
+    end
   end
 
   describe '#target_files_in_dir' do


### PR DESCRIPTION
If a toplevel folder is named `,` the resulting pattern for `Dir.glob` would contain something like `{foo/,}/**/*`, which would search the entire file system.

Fixes #1644.