### PR TITLE
[Fix #1647] Skip Style/SpaceAroundBlockParameters when lambda has no argument

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 * [#1638](https://github.com/bbatsov/rubocop/issues/1638): Use Parser functionality rather than regular expressions for matching comments in `FirstParameterIndentation`. ([@jonas054][])
 * [#1642](https://github.com/bbatsov/rubocop/issues/1642): Raise the correct exception if the configuration file is malformed. ([@bquorning][])
+* [#1647](https://github.com/bbatsov/rubocop/issues/1647): Skip `SpaceAroundBlockParameters` when lambda has no argument. ([@eitoball][])
 
 ## 0.29.0 (05/02/2015)
 
@@ -1254,3 +1255,4 @@
 [@mmozuras]: https://github.com/mmozuras
 [@d4rk5eed]: https://github.com/d4rk5eed
 [@cshaffer]: https://github.com/cshaffer
+[@eitoball]: https://github.com/eitoball

--- a/lib/rubocop/cop/style/space_around_block_parameters.rb
+++ b/lib/rubocop/cop/style/space_around_block_parameters.rb
@@ -18,7 +18,7 @@ module RuboCop
         def on_block(node)
           _method, args, body = *node
           opening_pipe, closing_pipe = args.loc.begin, args.loc.end
-          return unless opening_pipe
+          return unless !args.children.empty? && opening_pipe
 
           check_inside_pipes(args.children, opening_pipe, closing_pipe)
 

--- a/spec/rubocop/cop/style/space_around_block_parameters_spec.rb
+++ b/spec/rubocop/cop/style/space_around_block_parameters_spec.rb
@@ -10,6 +10,11 @@ describe RuboCop::Cop::Style::SpaceAroundBlockParameters, :config do
       inspect_source(cop, '{}.each {}')
       expect(cop.offenses).to be_empty
     end
+
+    it 'skips lambda without args' do
+      inspect_source(cop, '->() { puts "a" }')
+      expect(cop.offenses).to be_empty
+    end
   end
 
   context 'when EnforcedStyleInsidePipes is no_space' do


### PR DESCRIPTION
Style/SpaceAroundBlockParameters cop raises exception when lambda has no argument like:

```ruby
->() { puts "a" }
```

This PR should fix this problem.

---
Rubocop Version: 0.29.0 (using Parser 2.2.0.2, running on ruby 2.1.5 x86_64-darwin14.0)