### PR TITLE
Fix stack overflow when loading default config - JRuby on Windows 8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@
 * [#1604](https://github.com/bbatsov/rubocop/issues/1604): Add `IgnoreClassMethods` option to `TrivialAccessors` cop. ([@bbatsov][])
 * [#1651](https://github.com/bbatsov/rubocop/issues/1651): The `Style/SpaceAroundOperators` cop now also detects extra spaces around operators. A list of operators that *may* be surrounded by multiple spaces is configurable. ([@bquorning][])
 
+### Bugs fixed
+
+* [#1659](https://github.com/bbatsov/rubocop/pull/1659): Fix stack overflow with JRuby and Windows 8, during initial config validation. ([@pimterry][])
+
 ## 0.29.1 (13/02/2015)
 
 ### Bugs fixed
@@ -1267,3 +1271,4 @@
 [@cshaffer]: https://github.com/cshaffer
 [@eitoball]: https://github.com/eitoball
 [@iainbeeston]: https://github.com/iainbeeston
+[@pimterry]: https://github.com/pimterry

--- a/lib/rubocop/config.rb
+++ b/lib/rubocop/config.rb
@@ -95,8 +95,9 @@ module RuboCop
     # TODO: This should be a private method
     def validate
       # Don't validate RuboCop's own files. Avoids infinite recursion.
-      return if loaded_path.start_with?(File.join(ConfigLoader::RUBOCOP_HOME,
-                                                  'config'))
+      base_config_path = File.expand_path(File.join(ConfigLoader::RUBOCOP_HOME,
+                                                    'config'))
+      return if File.expand_path(loaded_path).start_with?(base_config_path)
 
       valid_cop_names, invalid_cop_names = @hash.keys.partition do |key|
         ConfigLoader.default_configuration.key?(key)

--- a/spec/rubocop/config_spec.rb
+++ b/spec/rubocop/config_spec.rb
@@ -38,6 +38,23 @@ describe RuboCop::Config do
       end
     end
 
+    context 'when the configuration is in the base RuboCop config folder' do
+      before do
+        create_file(configuration_path, [
+          'InvalidProperty:',
+          '  Enabled: true'
+        ])
+        stub_const('RuboCop::ConfigLoader::RUBOCOP_HOME', rubocop_home_path)
+      end
+
+      let(:rubocop_home_path) { File.realpath('.') }
+      let(:configuration_path) { 'config/.rubocop.yml' }
+
+      it 'is not validated' do
+        expect { configuration.validate }.to_not raise_error
+      end
+    end
+
     context 'when the configuration includes any unrecognized parameter' do
       before do
         create_file(configuration_path, [


### PR DESCRIPTION
It's impossible to start Rubocop on my machine, with JRuby and Windows 8 (not sure which is the issue). Rubocop version 0.29.1.

If you try to so, you get a stack overflow, with:

```
SystemStackError: stack level too deep                                                                              
                   each at org/jruby/RubyArray.java:1613                                                            
              partition at org/jruby/RubyEnumerable.java:914                                                        
               validate at C:/jruby-1.7.18/lib/ruby/gems/shared/gems/rubocop-0.29.1/lib/rubocop/config.rb:102       
      warn_unless_valid at C:/jruby-1.7.18/lib/ruby/gems/shared/gems/rubocop-0.29.1/lib/rubocop/config.rb:80        
              load_file at C:/jruby-1.7.18/lib/ruby/gems/shared/gems/rubocop-0.29.1/lib/rubocop/config_loader.rb:41 
           base_configs at C:/jruby-1.7.18/lib/ruby/gems/shared/gems/rubocop-0.29.1/lib/rubocop/config_loader.rb:69 
                    map at org/jruby/RubyArray.java:2412                                                            
           base_configs at C:/jruby-1.7.18/lib/ruby/gems/shared/gems/rubocop-0.29.1/lib/rubocop/config_loader.rb:60 
    resolve_inheritance at C:/jruby-1.7.18/lib/ruby/gems/shared/gems/rubocop-0.29.1/lib/rubocop/config_loader.rb:128
              load_file at C:/jruby-1.7.18/lib/ruby/gems/shared/gems/rubocop-0.29.1/lib/rubocop/config_loader.rb:29 
  default_configuration at C:/jruby-1.7.18/lib/ruby/gems/shared/gems/rubocop-0.29.1/lib/rubocop/config_loader.rb:99 
               validate at C:/jruby-1.7.18/lib/ruby/gems/shared/gems/rubocop-0.29.1/lib/rubocop/config.rb:103       
                   each at org/jruby/RubyArray.java:1613                                                            
              partition at org/jruby/RubyEnumerable.java:914                                                        
               validate at C:/jruby-1.7.18/lib/ruby/gems/shared/gems/rubocop-0.29.1/lib/rubocop/config.rb:102       
      warn_unless_valid at C:/jruby-1.7.18/lib/ruby/gems/shared/gems/rubocop-0.29.1/lib/rubocop/config.rb:80        
              load_file at C:/jruby-1.7.18/lib/ruby/gems/shared/gems/rubocop-0.29.1/lib/rubocop/config_loader.rb:41 
           base_configs at C:/jruby-1.7.18/lib/ruby/gems/shared/gems/rubocop-0.29.1/lib/rubocop/config_loader.rb:69 
                    map at org/jruby/RubyArray.java:2412         
                    ....                                                   
```

This happens because the check that ensures Rubocop does not validate its own config (and fall into an infinite loop) simply checks that RUBOCOP_HOME is not a prefix (via start_with?) of the config path. That's not sufficient.

For this check to be sufficient each path must be in a canonical format first, as otherwise two different (by string comparison) paths might actually refer to the same underlying path, giving false negatives.

In my case the paths being compared are:

```
C:\jruby-1.7.18\lib\ruby\gems\shared\gems\rubocop-0.29.1/config
C:/jruby-1.7.18/lib/ruby/gems/shared/gems/rubocop-0.29.1/config/enabled.yml
```

Note the different slashes. Path 1 is in reality a parent directory of path 2, but it is not a string prefix of path 2 (which is what the current test checks for). This seems to happen because File.realpath produces different slashes to File.join, but I don't think the source of this matters.

This patch fixes this generally, by ensuring the paths are always run through File.expand_path first, which ensures you get a canonical format for the path, not just what you were given from elsewhere. I've also put in an actual test for this feature (not validating your built-in config), since there wasn't one.