### PR TITLE
[Fix #1611] Add SupportedStyles to EmptyElse cop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 * [#1651](https://github.com/bbatsov/rubocop/issues/1651): The `Style/SpaceAroundOperators` cop now also detects extra spaces around operators. A list of operators that *may* be surrounded by multiple spaces is configurable. ([@bquorning][])
 * Add auto-correct to `Encoding` cop. ([@rrosenblum][])
 * [#1621](https://github.com/bbatsov/rubocop/issues/1621): `TrailingComma` has a new style `consistent_comma`. ([@tamird][])
+* [#1611](https://github.com/bbatsov/rubocop/issues/1611): Add `empty`, `nil`, and `both` `SupportedStyles` to `EmptyElse` cop. Default is `both`. ([@rrosenblum][])
 
 ### Bugs fixed
 

--- a/config/default.yml
+++ b/config/default.yml
@@ -224,6 +224,17 @@ Style/DotPosition:
     - leading
     - trailing
 
+# Warn on empty else statements
+# empty - warn only on empty else
+# nil - warn on else with nil in it
+# both - warn on empty else and else with nil in it
+Style/EmptyElse:
+  EnforcedStyle: both
+  SupportedStyles:
+    - empty
+    - nil
+    - both
+
 # Use empty lines between defs.
 Style/EmptyLineBetweenDefs:
   # If true, this parameter means that single line method definitions don't

--- a/lib/rubocop/cop/mixin/on_normal_if_unless.rb
+++ b/lib/rubocop/cop/mixin/on_normal_if_unless.rb
@@ -15,6 +15,23 @@ module RuboCop
         return if modifier_if?(node) || ternary_op?(node)
         on_normal_if_unless(node)
       end
+
+      def if_else_clause(node)
+        return unless node.if_type?
+
+        keyword = node.loc.keyword
+        if keyword.is?('if')
+          node.children.last
+        elsif keyword.is?('elsif')
+          node.children.last
+        elsif keyword.is?('unless')
+          node.children[1]
+        end
+      end
+
+      def case_else_clause(node)
+        node.children.last if node.case_type?
+      end
     end
   end
 end

--- a/spec/rubocop/cop/style/empty_else_spec.rb
+++ b/spec/rubocop/cop/style/empty_else_spec.rb
@@ -4,96 +4,300 @@ require 'spec_helper'
 
 describe RuboCop::Cop::Style::EmptyElse do
   subject(:cop) { described_class.new(config) }
-  let(:config) do
-    RuboCop::Config.new
+
+  context 'configured to warn on empty else' do
+    let(:config) do
+      RuboCop::Config.new('Style/EmptyElse' => {
+                            'EnforcedStyle' => 'empty',
+                            'SupportedStyles' => %w(empty nil both)
+                          })
+    end
+
+    context 'given an if-statement' do
+      context 'with a completely empty else-clause' do
+        it 'registers an offense' do
+          inspect_source(cop, 'if a; foo else end')
+          expect(cop.messages).to eq(['Redundant `else`-clause.'])
+        end
+      end
+
+      context 'with an else-clause containing only the literal nil' do
+        it "doesn't register an offense" do
+          inspect_source(cop, 'if a; foo elsif b; bar else nil end')
+          expect(cop.messages).to be_empty
+        end
+      end
+
+      context 'with an else-clause with side-effects' do
+        it "doesn't register an offence" do
+          inspect_source(cop, 'if cond; foo else bar; nil end')
+          expect(cop.messages).to be_empty
+        end
+      end
+
+      context 'with no else-clause' do
+        it "doesn't register an offence" do
+          inspect_source(cop, 'if cond; foo end')
+          expect(cop.messages).to be_empty
+        end
+      end
+    end
+
+    context 'given an unless-statement' do
+      context 'with a completely empty else-clause' do
+        it 'registers an offense' do
+          inspect_source(cop, 'unless cond; foo else end')
+          expect(cop.messages).to eq(['Redundant `else`-clause.'])
+        end
+      end
+
+      context 'with an else-clause containing only the literal nil' do
+        it 'registers an offense' do
+          inspect_source(cop, 'unless cond; foo else nil end')
+          expect(cop.messages).to be_empty
+        end
+      end
+
+      context 'with an else-clause with side-effects' do
+        it "doesn't register an offence" do
+          inspect_source(cop, 'unless cond; foo else bar; nil end')
+          expect(cop.messages).to be_empty
+        end
+      end
+
+      context 'with no else-clause' do
+        it "doesn't register an offence" do
+          inspect_source(cop, 'unless cond; foo end')
+          expect(cop.messages).to be_empty
+        end
+      end
+    end
+
+    context 'given a case statement' do
+      context 'with a completely empty else-clause' do
+        it 'registers an offense' do
+          inspect_source(cop, 'case v; when a; foo else end')
+          expect(cop.messages).to eq(['Redundant `else`-clause.'])
+        end
+      end
+
+      context 'with an else-clause containing only the literal nil' do
+        it 'registers an offense' do
+          inspect_source(cop, 'case v; when a; foo; when b; bar; else nil end')
+          expect(cop.messages).to be_empty
+        end
+      end
+
+      context 'with an else-clause with side-effects' do
+        it "doesn't register an offence" do
+          inspect_source(cop, 'case v; when a; foo; else b; nil end')
+          expect(cop.messages).to be_empty
+        end
+      end
+
+      context 'with no else-clause' do
+        it "doesn't register an offence" do
+          inspect_source(cop, 'case v; when a; foo; when b; bar; end')
+          expect(cop.messages).to be_empty
+        end
+      end
+    end
   end
 
-  context 'given an if-statement' do
-    context 'with a completely empty else-clause' do
-      it 'registers an offense' do
-        inspect_source(cop, 'if a; foo else end')
-        expect(cop.messages).to eq(['Redundant empty `else`-clause.'])
+  context 'configured to warn on nil in else' do
+    let(:config) do
+      RuboCop::Config.new('Style/EmptyElse' => {
+                            'EnforcedStyle' => 'nil',
+                            'SupportedStyles' => %w(empty nil both)
+                          })
+    end
+
+    context 'given an if-statement' do
+      context 'with a completely empty else-clause' do
+        it "doesn't register an offense" do
+          inspect_source(cop, 'if a; foo else end')
+          expect(cop.messages).to be_empty
+        end
+      end
+
+      context 'with an else-clause containing only the literal nil' do
+        it 'registers an offense' do
+          inspect_source(cop, 'if a; foo elsif b; bar else nil end')
+          expect(cop.messages).to eq(['Redundant `else`-clause.'])
+        end
+      end
+
+      context 'with an else-clause with side-effects' do
+        it "doesn't register an offence" do
+          inspect_source(cop, 'if cond; foo else bar; nil end')
+          expect(cop.messages).to be_empty
+        end
+      end
+
+      context 'with no else-clause' do
+        it "doesn't register an offence" do
+          inspect_source(cop, 'if cond; foo end')
+          expect(cop.messages).to be_empty
+        end
       end
     end
 
-    context 'with an else-clause containing only the literal nil' do
-      it 'registers an offense' do
-        inspect_source(cop, 'if a; foo elsif b; bar else nil end')
-        expect(cop.messages).to eq(['Redundant empty `else`-clause.'])
+    context 'given an unless-statement' do
+      context 'with a completely empty else-clause' do
+        it "doesn't register an offence" do
+          inspect_source(cop, 'unless cond; foo else end')
+          expect(cop.messages).to be_empty
+        end
+      end
+
+      context 'with an else-clause containing only the literal nil' do
+        it 'registers an offense' do
+          inspect_source(cop, 'unless cond; foo else nil end')
+          expect(cop.messages).to eq(['Redundant `else`-clause.'])
+        end
+      end
+
+      context 'with an else-clause with side-effects' do
+        it "doesn't register an offence" do
+          inspect_source(cop, 'unless cond; foo else bar; nil end')
+          expect(cop.messages).to be_empty
+        end
+      end
+
+      context 'with no else-clause' do
+        it "doesn't register an offence" do
+          inspect_source(cop, 'unless cond; foo end')
+          expect(cop.messages).to be_empty
+        end
       end
     end
 
-    context 'with an else-clause with side-effects' do
-      it "doesn't register an offence" do
-        inspect_source(cop, 'if cond; foo else bar; nil end')
-        expect(cop.messages).to be_empty
+    context 'given a case statement' do
+      context 'with a completely empty else-clause' do
+        it "doesn't register an offence" do
+          inspect_source(cop, 'case v; when a; foo else end')
+          expect(cop.messages).to be_empty
+        end
       end
-    end
 
-    context 'with no else-clause' do
-      it "doesn't register an offence" do
-        inspect_source(cop, 'if cond; foo end')
-        expect(cop.messages).to be_empty
+      context 'with an else-clause containing only the literal nil' do
+        it 'registers an offence' do
+          inspect_source(cop, 'case v; when a; foo; when b; bar; else nil end')
+          expect(cop.messages).to eq(['Redundant `else`-clause.'])
+        end
+      end
+
+      context 'with an else-clause with side-effects' do
+        it "doesn't register an offence" do
+          inspect_source(cop, 'case v; when a; foo; else b; nil end')
+          expect(cop.messages).to be_empty
+        end
+      end
+
+      context 'with no else-clause' do
+        it "doesn't register an offence" do
+          inspect_source(cop, 'case v; when a; foo; when b; bar; end')
+          expect(cop.messages).to be_empty
+        end
       end
     end
   end
 
-  context 'given an unless-statement' do
-    context 'with a completely empty else-clause' do
-      it 'registers an offense' do
-        inspect_source(cop, 'unless cond; foo else end')
-        expect(cop.messages).to eq(['Redundant empty `else`-clause.'])
+  context 'configured to warn on empty else and nil in else' do
+    let(:config) do
+      RuboCop::Config.new('Style/EmptyElse' => {
+                            'EnforcedStyle' => 'both',
+                            'SupportedStyles' => %w(empty nil both)
+                          })
+    end
+
+    context 'given an if-statement' do
+      context 'with a completely empty else-clause' do
+        it 'registers an offense' do
+          inspect_source(cop, 'if a; foo else end')
+          expect(cop.messages).to eq(['Redundant `else`-clause.'])
+        end
+      end
+
+      context 'with an else-clause containing only the literal nil' do
+        it 'registers an offense' do
+          inspect_source(cop, 'if a; foo elsif b; bar else nil end')
+          expect(cop.messages).to eq(['Redundant `else`-clause.'])
+        end
+      end
+
+      context 'with an else-clause with side-effects' do
+        it "doesn't register an offence" do
+          inspect_source(cop, 'if cond; foo else bar; nil end')
+          expect(cop.messages).to be_empty
+        end
+      end
+
+      context 'with no else-clause' do
+        it "doesn't register an offence" do
+          inspect_source(cop, 'if cond; foo end')
+          expect(cop.messages).to be_empty
+        end
       end
     end
 
-    context 'with an else-clause containing only the literal nil' do
-      it 'registers an offense' do
-        inspect_source(cop, 'unless cond; foo else nil end')
-        expect(cop.messages).to eq(['Redundant empty `else`-clause.'])
+    context 'given an unless-statement' do
+      context 'with a completely empty else-clause' do
+        it 'registers an offense' do
+          inspect_source(cop, 'unless cond; foo else end')
+          expect(cop.messages).to eq(['Redundant `else`-clause.'])
+        end
+      end
+
+      context 'with an else-clause containing only the literal nil' do
+        it 'registers an offense' do
+          inspect_source(cop, 'unless cond; foo else nil end')
+          expect(cop.messages).to eq(['Redundant `else`-clause.'])
+        end
+      end
+
+      context 'with an else-clause with side-effects' do
+        it "doesn't register an offence" do
+          inspect_source(cop, 'unless cond; foo else bar; nil end')
+          expect(cop.messages).to be_empty
+        end
+      end
+
+      context 'with no else-clause' do
+        it "doesn't register an offence" do
+          inspect_source(cop, 'unless cond; foo end')
+          expect(cop.messages).to be_empty
+        end
       end
     end
 
-    context 'with an else-clause with side-effects' do
-      it "doesn't register an offence" do
-        inspect_source(cop, 'unless cond; foo else bar; nil end')
-        expect(cop.messages).to be_empty
+    context 'given a case statement' do
+      context 'with a completely empty else-clause' do
+        it 'registers an offence' do
+          inspect_source(cop, 'case v; when a; foo else end')
+          expect(cop.messages).to eq(['Redundant `else`-clause.'])
+        end
       end
-    end
 
-    context 'with no else-clause' do
-      it "doesn't register an offence" do
-        inspect_source(cop, 'unless cond; foo end')
-        expect(cop.messages).to be_empty
+      context 'with an else-clause containing only the literal nil' do
+        it 'registers an offence' do
+          inspect_source(cop, 'case v; when a; foo; when b; bar; else nil end')
+          expect(cop.messages).to eq(['Redundant `else`-clause.'])
+        end
       end
-    end
-  end
 
-  context 'given a case statement' do
-    context 'with a completely empty else-clause' do
-      it 'registers an offense' do
-        inspect_source(cop, 'case v; when a; foo else end')
-        expect(cop.messages).to eq(['Redundant empty `else`-clause.'])
+      context 'with an else-clause with side-effects' do
+        it "doesn't register an offence" do
+          inspect_source(cop, 'case v; when a; foo; else b; nil end')
+          expect(cop.messages).to be_empty
+        end
       end
-    end
 
-    context 'with an else-clause containing only the literal nil' do
-      it 'registers an offense' do
-        inspect_source(cop, 'case v; when a; foo; when b; bar; else nil end')
-        expect(cop.messages).to eq(['Redundant empty `else`-clause.'])
-      end
-    end
-
-    context 'with an else-clause with side-effects' do
-      it "doesn't register an offence" do
-        inspect_source(cop, 'case v; when a; foo; else b; nil end')
-        expect(cop.messages).to be_empty
-      end
-    end
-
-    context 'with no else-clause' do
-      it "doesn't register an offence" do
-        inspect_source(cop, 'case v; when a; foo; when b; bar; end')
-        expect(cop.messages).to be_empty
+      context 'with no else-clause' do
+        it "doesn't register an offence" do
+          inspect_source(cop, 'case v; when a; foo; when b; bar; end')
+          expect(cop.messages).to be_empty
+        end
       end
     end
   end


### PR DESCRIPTION
This resolves #1611. It adds SupportedStyles to the EmptyElse cop. The styles are implicit, explicit, and empty. The default is to empty.