### PR TITLE
Sort auto-generated config by offense count (in descending order)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### New features
 
+* [#1663](https://github.com/bbatsov/rubocop/pull/1663): Sort auto-generated config by offense count (in descending order). ([@vassilevsky][])
 * [#1669](https://github.com/bbatsov/rubocop/pull/1669): Add command-line switch `--display-style-guide`. ([@marxarelli][])
 * [#1405](https://github.com/bbatsov/rubocop/issues/1405): Add Rails TimeZone and Date cops. ([@palkan][])
 * [#1641](https://github.com/bbatsov/rubocop/pull/1641): Add ruby19_no_mixed_keys style to `HashStyle` cop. ([@iainbeeston][])
@@ -1298,3 +1299,4 @@
 [@palkan]: https://github.com/palkan
 [@jdoconnor]: https://github.com/jdoconnor
 [@meganemura]: https://github.com/meganemura
+[@vassilevsky]: https://github.com/vassilevsky

--- a/lib/rubocop/formatter/disabled_config_formatter.rb
+++ b/lib/rubocop/formatter/disabled_config_formatter.rb
@@ -33,7 +33,9 @@ module RuboCop
         # Syntax isn't a real cop and it can't be disabled.
         @cops_with_offenses.delete('Syntax')
 
-        @cops_with_offenses.sort.each do |cop_name, offense_count|
+        @cops_with_offenses
+          .sort_by { |cop_name, offense_count| [-offense_count, cop_name] }
+          .each do |cop_name, offense_count|
           output.puts
           cfg = self.class.config_to_allow_offenses[cop_name]
           cfg ||= { 'Enabled' => false }
@@ -41,6 +43,7 @@ module RuboCop
           output.puts "#{cop_name}:"
           cfg.each { |key, value| output.puts "  #{key}: #{value}" }
         end
+
         puts "Created #{output.path}."
         puts "Run `rubocop --config #{output.path}`, or"
         puts "add inherit_from: #{output.path} in a .rubocop.yml file."

--- a/spec/rubocop/cli_spec.rb
+++ b/spec/rubocop/cli_spec.rb
@@ -686,7 +686,12 @@ describe RuboCop::CLI, :isolated_environment do
         create_file('.rubocop.yml', ['inherit_from: .rubocop_todo.yml'])
         expect(cli.run(['--auto-gen-config'])).to eq(1)
         expect(IO.readlines('.rubocop_todo.yml')[7..-1].map(&:chomp))
-          .to eq(['# Offense count: 1',
+          .to eq(['# Offense count: 2',
+                  '# Cop supports --auto-correct.',
+                  'Style/TrailingWhitespace:',
+                  '  Enabled: false',
+                  '',
+                  '# Offense count: 1',
                   '# Configuration parameters: AllowURI, URISchemes.',
                   'Metrics/LineLength:',
                   '  Max: 85',
@@ -695,11 +700,6 @@ describe RuboCop::CLI, :isolated_environment do
                   '# Cop supports --auto-correct.',
                   '# Configuration parameters: MultiSpaceAllowedForOperators.',
                   'Style/SpaceAroundOperators:',
-                  '  Enabled: false',
-                  '',
-                  '# Offense count: 2',
-                  '# Cop supports --auto-correct.',
-                  'Style/TrailingWhitespace:',
                   '  Enabled: false'])
 
         # Create new CLI instance to avoid using cached configuration.
@@ -755,6 +755,11 @@ describe RuboCop::CLI, :isolated_environment do
            'Metrics/LineLength:',
            '  Max: 90',
            '',
+           '# Offense count: 2',
+           '# Cop supports --auto-correct.',
+           'Style/TrailingWhitespace:',
+           '  Enabled: false',
+           '',
            '# Offense count: 1',
            '# Cop supports --auto-correct.',
            'Style/CommentIndentation:',
@@ -779,11 +784,6 @@ describe RuboCop::CLI, :isolated_environment do
            '# Offense count: 1',
            '# Cop supports --auto-correct.',
            'Style/Tab:',
-           '  Enabled: false',
-           '',
-           '# Offense count: 2',
-           '# Cop supports --auto-correct.',
-           'Style/TrailingWhitespace:',
            '  Enabled: false']
         actual = IO.read('.rubocop_todo.yml').split($RS)
         expected.each_with_index do |line, ix|


### PR DESCRIPTION
This puts the most important offenses at the top of the file so that developers can address them first.

On the other hand, if a developer has little time, they can address rare offenses at the end of the file quickly.