### PR TITLE
Cleanup

### DIFF
--- a/lib/rubocop/cop/style/encoding.rb
+++ b/lib/rubocop/cop/style/encoding.rb
@@ -33,7 +33,7 @@ module RuboCop
 
         def offense(processed_source, line_number)
           line = processed_source[line_number]
-          encoding_present = line =~ /#.*coding\s?[:=]\s?(UTF|utf)-8/
+          encoding_present = line =~ /#.*coding\s?[:=]\s?(?:UTF|utf)-8/
           ascii_only = processed_source.buffer.source.ascii_only?
           always_encode = style == :always
 

--- a/spec/rubocop/cop/style/space_around_operators_spec.rb
+++ b/spec/rubocop/cop/style/space_around_operators_spec.rb
@@ -197,11 +197,11 @@ describe RuboCop::Cop::Style::SpaceAroundOperators, :config do
     end
 
     it 'registers an offense in presence of modifier while statement' do
-      check_modifier('unless')
+      check_modifier('while')
     end
 
     it 'registers an offense in presence of modifier until statement' do
-      check_modifier('unless')
+      check_modifier('until')
     end
 
     def check_modifier(keyword)


### PR DESCRIPTION
I noticed that the regex for encoding is using matching groups when it doesn't need to.

I also noticed that it looks like some of the tests in `space_around_operators_spec.rb` were copied and pasted without updating the content of the test.
