### PR TITLE
Fixed correction for && for return without value

### DIFF
--- a/lib/rubocop/cop/style/and_or.rb
+++ b/lib/rubocop/cop/style/and_or.rb
@@ -73,7 +73,7 @@ module RuboCop
               corrector.replace(range, '(')
               corrector.insert_after(args.last.loc.expression, ')')
             end
-            corrector.replace(node.loc.operator, replacement)
+            corrector.replace(node.loc.operator, replacement) unless expr2.type == :return
           end
         end
 

--- a/spec/rubocop/cop/style/and_or_spec.rb
+++ b/spec/rubocop/cop/style/and_or_spec.rb
@@ -124,6 +124,12 @@ describe RuboCop::Cop::Style::AndOr, :config do
       expect(new_source).to eq(src)
     end
 
+    it 'leaves *and* as is if auto-correction changes the meaning return without value' do
+      src = 'method(a) and return'
+      new_source = autocorrect_source(cop, src)
+      expect(new_source).to eq(src)
+    end
+
     it 'warns on short-circuit (and)' do
       inspect_source(cop, 'x = a + b and return x')
       expect(cop.offenses.size).to eq(1)


### PR DESCRIPTION
Thanks for the awesome work on this gem!

This fixes a correction when a statement ends with `return` (and no return value).  See the test case for an example.