### PR TITLE
Use YAML.safe_load

### DIFF
--- a/lib/rubocop/config_loader.rb
+++ b/lib/rubocop/config_loader.rb
@@ -114,7 +114,7 @@ module RuboCop
         # is not possible to reproduce now, but we want to avoid it in case
         # it's still there. So we only load the YAML code if we find some real
         # code in there.
-        hash = yaml_code =~ /^[A-Z]/i ? YAML.load(yaml_code) : {}
+        hash = yaml_code =~ /^[A-Z]/i ? yaml_safe_load(yaml_code) : {}
         puts "configuration from #{absolute_path}" if debug?
 
         unless hash.is_a?(Hash)
@@ -122,6 +122,14 @@ module RuboCop
         end
 
         hash
+      end
+
+      def yaml_safe_load(yaml_code)
+        if YAML.respond_to?(:safe_load) # Ruby 2.1+
+          YAML.safe_load(yaml_code, [Regexp])
+        else
+          YAML.load(yaml_code)
+        end
       end
 
       def resolve_inheritance(path, hash)


### PR DESCRIPTION
There's a vulnerability in `YAML.load`
which can enable arbitrary code to be run.
`YAML.safe_load` does not deserialize unsafe classes.

Related reading:

* http://blog.codeclimate.com/blog/2013/01/10/rails-remote-code-execution-vulnerability-explained/
* https://github.com/tenderlove/psych/issues/119
* http://docs.ruby-lang.org/en/2.1.0/Psych.html#method-c-safe_load

While Rubocop is generally run locally,
it could be used in server-side, hosted environments.

I can't think of a downside to using the `safe_load` version.

This change is intended to maintain backwards compatibility
with Ruby versions that appear to be supported by Rubocop
(judging by the `.travis.yml` file).