### PR TITLE
[Fix #1644] Avoid globbing entire file system (fix for jruby and rbx)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@
 * Configure `ParallelAssignment` to work with non-standard `IndentationWidths`. ([@rrosenblum][])
 * [#1899](https://github.com/bbatsov/rubocop/issues/1899): Be careful about comments when auto-correcting in `BracesAroundHashParameters`. ([@jonas054][])
 * [#1897](https://github.com/bbatsov/rubocop/issues/1897): Don't report that semicolon separated statements can be converted to modifier form in `IfUnlessModifier` (and don't auto-correct them). ([@jonas054][])
+* [#1644](https://github.com/bbatsov/rubocop/issues/1644): Don't search the entire file system when a folder is named `,` (fix for jruby and rbx). ([@rrosenblum][])
 
 ## 0.31.0 (05/05/2015)
 

--- a/lib/rubocop/target_finder.rb
+++ b/lib/rubocop/target_finder.rb
@@ -88,16 +88,16 @@ module RuboCop
     def find_files(base_dir, flags)
       wanted_toplevel_dirs = toplevel_dirs(base_dir, flags) -
                              excluded_dirs(base_dir)
-      wanted_toplevel_dirs.map! { |dir| dir.gsub(',', '\,') }
+      wanted_toplevel_dirs.map! { |dir| dir << '/**/*' }
 
       pattern = if wanted_toplevel_dirs.empty?
                   # We need this special case to avoid creating the pattern
                   # /**/* which searches the entire file system.
-                  "#{base_dir}/**/*"
+                  ["#{base_dir}/**/*"]
                 else
                   # Search the non-excluded top directories, but also add files
                   # on the top level, which would otherwise not be found.
-                  "{#{base_dir}/*,{#{wanted_toplevel_dirs.join(',')}}/**/*}"
+                  wanted_toplevel_dirs.unshift("#{base_dir}/*")
                 end
       Dir.glob(pattern, flags).select { |path| FileTest.file?(path) }
     end


### PR DESCRIPTION
This fixes #1644 for jruby and rbx. @bquorning put in a fix in #1645, but the issue still existed for jruby and rbx. I guess the implementation of `Dir.glob` is slightly different for them.