### PR TITLE
[Fix #1602] Add :nodoc:-support to Documentation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 * [#1621](https://github.com/bbatsov/rubocop/issues/1621): `TrailingComma` has a new style `consistent_comma`. ([@tamird][])
 * [#1611](https://github.com/bbatsov/rubocop/issues/1611): Add `empty`, `nil`, and `both` `SupportedStyles` to `EmptyElse` cop. Default is `both`. ([@rrosenblum][])
 * [#1611](https://github.com/bbatsov/rubocop/issues/1611): Add new `MissingElse` cop. Default is to have this cop be disabled. ([@rrosenblum][])
+* [#1602](https://github.com/bbatsov/rubocop/issues/1602): Add support for `# :nodoc` in `Documentation`. ([@lumeet][])
 
 ### Bugs fixed
 

--- a/spec/rubocop/cop/style/documentation_spec.rb
+++ b/spec/rubocop/cop/style/documentation_spec.rb
@@ -143,4 +143,45 @@ describe RuboCop::Cop::Style::Documentation do
                      ])
     end.to_not raise_error
   end
+
+  context 'with # :nodoc:' do
+    %w(class module).each do |keyword|
+      it "accepts non-namespace #{keyword} without documentation" do
+        inspect_source(cop,
+                       ["#{keyword} Test #:nodoc:",
+                        '  TEST = 20',
+                        'end'
+                       ])
+        expect(cop.offenses).to be_empty
+      end
+
+      it "registers an offence for nested #{keyword} without documentation" do
+        inspect_source(cop,
+                       ['module TestModule #:nodoc:',
+                        '  TEST = 20',
+                        "  #{keyword} Test",
+                        '    TEST = 20',
+                        '  end',
+                        'end'
+                       ])
+        expect(cop.offenses.size).to eq(1)
+      end
+
+      context 'with `all` modifier' do
+        it "accepts nested #{keyword} without documentation" do
+          inspect_source(cop,
+                         ['module A #:nodoc: all',
+                          '  module B',
+                          '    TEST = 20',
+                          "    #{keyword} Test",
+                          '      TEST = 20',
+                          '    end',
+                          '  end',
+                          'end'
+                         ])
+          expect(cop.offenses).to be_empty
+        end
+      end
+    end
+  end
 end


### PR DESCRIPTION
Make Style/Documenation skip the documentation requirement when RDoc's
`# :nodoc: [all]` modifier is applied.