### PR TITLE
Fix spacing in yaml files

### DIFF
--- a/config/default.yml
+++ b/config/default.yml
@@ -667,10 +667,10 @@ Rails/ActionFilter:
     - app/controllers/**/*.rb
 
 Rails/Date:
-  # The value `always` disallows usage of `Date.today`, `Date.current`, 
+  # The value `always` disallows usage of `Date.today`, `Date.current`,
   # `Date#to_time` etc.
-  # The value `acceptable` allows usage of `Date.current`, `Date.yesterday`, etc 
-  # (but not `Date.today`) which are overriden by ActiveSupport to handle current 
+  # The value `acceptable` allows usage of `Date.current`, `Date.yesterday`, etc
+  # (but not `Date.today`) which are overriden by ActiveSupport to handle current
   # time zone.
   EnforcedStyle: always
   SupportedStyles:

--- a/config/disabled.yml
+++ b/config/disabled.yml
@@ -44,4 +44,3 @@ Style/SymbolArray:
 Style/ExtraSpacing:
   Description: 'Do not use unnecessary spacing.'
   Enabled: false
-

--- a/config/enabled.yml
+++ b/config/enabled.yml
@@ -976,7 +976,7 @@ Rails/ActionFilter:
   Enabled: true
 
 Rails/Date:
-  Description: >- 
+  Description: >-
                   Checks the correct usage of date aware methods,
                   such as Date.today, Date.current etc.
   Enabled: true


### PR DESCRIPTION
I imagined that RuboCop contributors would have their editors configured to strip trailing spaces :trollface: 