### PR TITLE
Use English spelling offense instead of offence

### DIFF
--- a/spec/rubocop/cop/style/documentation_spec.rb
+++ b/spec/rubocop/cop/style/documentation_spec.rb
@@ -155,7 +155,7 @@ describe RuboCop::Cop::Style::Documentation do
         expect(cop.offenses).to be_empty
       end
 
-      it "registers an offence for nested #{keyword} without documentation" do
+      it "registers an offense for nested #{keyword} without documentation" do
         inspect_source(cop,
                        ['module TestModule #:nodoc:',
                         '  TEST = 20',

--- a/spec/rubocop/cop/style/empty_else_spec.rb
+++ b/spec/rubocop/cop/style/empty_else_spec.rb
@@ -29,14 +29,14 @@ describe RuboCop::Cop::Style::EmptyElse do
       end
 
       context 'with an else-clause with side-effects' do
-        it "doesn't register an offence" do
+        it "doesn't register an offense" do
           inspect_source(cop, 'if cond; foo else bar; nil end')
           expect(cop.messages).to be_empty
         end
       end
 
       context 'with no else-clause' do
-        it "doesn't register an offence" do
+        it "doesn't register an offense" do
           inspect_source(cop, 'if cond; foo end')
           expect(cop.messages).to be_empty
         end
@@ -59,14 +59,14 @@ describe RuboCop::Cop::Style::EmptyElse do
       end
 
       context 'with an else-clause with side-effects' do
-        it "doesn't register an offence" do
+        it "doesn't register an offense" do
           inspect_source(cop, 'unless cond; foo else bar; nil end')
           expect(cop.messages).to be_empty
         end
       end
 
       context 'with no else-clause' do
-        it "doesn't register an offence" do
+        it "doesn't register an offense" do
           inspect_source(cop, 'unless cond; foo end')
           expect(cop.messages).to be_empty
         end
@@ -89,14 +89,14 @@ describe RuboCop::Cop::Style::EmptyElse do
       end
 
       context 'with an else-clause with side-effects' do
-        it "doesn't register an offence" do
+        it "doesn't register an offense" do
           inspect_source(cop, 'case v; when a; foo; else b; nil end')
           expect(cop.messages).to be_empty
         end
       end
 
       context 'with no else-clause' do
-        it "doesn't register an offence" do
+        it "doesn't register an offense" do
           inspect_source(cop, 'case v; when a; foo; when b; bar; end')
           expect(cop.messages).to be_empty
         end
@@ -128,14 +128,14 @@ describe RuboCop::Cop::Style::EmptyElse do
       end
 
       context 'with an else-clause with side-effects' do
-        it "doesn't register an offence" do
+        it "doesn't register an offense" do
           inspect_source(cop, 'if cond; foo else bar; nil end')
           expect(cop.messages).to be_empty
         end
       end
 
       context 'with no else-clause' do
-        it "doesn't register an offence" do
+        it "doesn't register an offense" do
           inspect_source(cop, 'if cond; foo end')
           expect(cop.messages).to be_empty
         end
@@ -144,7 +144,7 @@ describe RuboCop::Cop::Style::EmptyElse do
 
     context 'given an unless-statement' do
       context 'with a completely empty else-clause' do
-        it "doesn't register an offence" do
+        it "doesn't register an offense" do
           inspect_source(cop, 'unless cond; foo else end')
           expect(cop.messages).to be_empty
         end
@@ -158,14 +158,14 @@ describe RuboCop::Cop::Style::EmptyElse do
       end
 
       context 'with an else-clause with side-effects' do
-        it "doesn't register an offence" do
+        it "doesn't register an offense" do
           inspect_source(cop, 'unless cond; foo else bar; nil end')
           expect(cop.messages).to be_empty
         end
       end
 
       context 'with no else-clause' do
-        it "doesn't register an offence" do
+        it "doesn't register an offense" do
           inspect_source(cop, 'unless cond; foo end')
           expect(cop.messages).to be_empty
         end
@@ -174,28 +174,28 @@ describe RuboCop::Cop::Style::EmptyElse do
 
     context 'given a case statement' do
       context 'with a completely empty else-clause' do
-        it "doesn't register an offence" do
+        it "doesn't register an offense" do
           inspect_source(cop, 'case v; when a; foo else end')
           expect(cop.messages).to be_empty
         end
       end
 
       context 'with an else-clause containing only the literal nil' do
-        it 'registers an offence' do
+        it 'registers an offense' do
           inspect_source(cop, 'case v; when a; foo; when b; bar; else nil end')
           expect(cop.messages).to eq(['Redundant `else`-clause.'])
         end
       end
 
       context 'with an else-clause with side-effects' do
-        it "doesn't register an offence" do
+        it "doesn't register an offense" do
           inspect_source(cop, 'case v; when a; foo; else b; nil end')
           expect(cop.messages).to be_empty
         end
       end
 
       context 'with no else-clause' do
-        it "doesn't register an offence" do
+        it "doesn't register an offense" do
           inspect_source(cop, 'case v; when a; foo; when b; bar; end')
           expect(cop.messages).to be_empty
         end
@@ -227,14 +227,14 @@ describe RuboCop::Cop::Style::EmptyElse do
       end
 
       context 'with an else-clause with side-effects' do
-        it "doesn't register an offence" do
+        it "doesn't register an offense" do
           inspect_source(cop, 'if cond; foo else bar; nil end')
           expect(cop.messages).to be_empty
         end
       end
 
       context 'with no else-clause' do
-        it "doesn't register an offence" do
+        it "doesn't register an offense" do
           inspect_source(cop, 'if cond; foo end')
           expect(cop.messages).to be_empty
         end
@@ -257,14 +257,14 @@ describe RuboCop::Cop::Style::EmptyElse do
       end
 
       context 'with an else-clause with side-effects' do
-        it "doesn't register an offence" do
+        it "doesn't register an offense" do
           inspect_source(cop, 'unless cond; foo else bar; nil end')
           expect(cop.messages).to be_empty
         end
       end
 
       context 'with no else-clause' do
-        it "doesn't register an offence" do
+        it "doesn't register an offense" do
           inspect_source(cop, 'unless cond; foo end')
           expect(cop.messages).to be_empty
         end
@@ -273,28 +273,28 @@ describe RuboCop::Cop::Style::EmptyElse do
 
     context 'given a case statement' do
       context 'with a completely empty else-clause' do
-        it 'registers an offence' do
+        it 'registers an offense' do
           inspect_source(cop, 'case v; when a; foo else end')
           expect(cop.messages).to eq(['Redundant `else`-clause.'])
         end
       end
 
       context 'with an else-clause containing only the literal nil' do
-        it 'registers an offence' do
+        it 'registers an offense' do
           inspect_source(cop, 'case v; when a; foo; when b; bar; else nil end')
           expect(cop.messages).to eq(['Redundant `else`-clause.'])
         end
       end
 
       context 'with an else-clause with side-effects' do
-        it "doesn't register an offence" do
+        it "doesn't register an offense" do
           inspect_source(cop, 'case v; when a; foo; else b; nil end')
           expect(cop.messages).to be_empty
         end
       end
 
       context 'with no else-clause' do
-        it "doesn't register an offence" do
+        it "doesn't register an offense" do
           inspect_source(cop, 'case v; when a; foo; when b; bar; end')
           expect(cop.messages).to be_empty
         end

--- a/spec/rubocop/cop/style/hash_syntax_spec.rb
+++ b/spec/rubocop/cop/style/hash_syntax_spec.rb
@@ -139,7 +139,7 @@ describe RuboCop::Cop::Style::HashSyntax, :config do
         expect(cop.messages).to eq(['Use hash rockets syntax.'])
       end
 
-      it 'regeisters an offence when using hash rockets ' \
+      it 'regeisters an offense when using hash rockets ' \
         'and no elements have a symbol value' do
         inspect_source(cop, 'x = { :a => 1, :b => 2 }')
         expect(cop.messages)
@@ -147,7 +147,7 @@ describe RuboCop::Cop::Style::HashSyntax, :config do
                   'Use the new Ruby 1.9 hash syntax.'])
       end
 
-      it 'regeisters an offence for hashes with elements on multiple lines' do
+      it 'regeisters an offense for hashes with elements on multiple lines' do
         inspect_source(cop, "x = { a: :b,\n c: :d }")
         expect(cop.messages)
           .to eq(['Use hash rockets syntax.', 'Use hash rockets syntax.'])

--- a/spec/rubocop/cop/style/missing_else_spec.rb
+++ b/spec/rubocop/cop/style/missing_else_spec.rb
@@ -31,7 +31,7 @@ describe RuboCop::Cop::Style::MissingElse do
       end
 
       context 'with an else-clause with side-effects' do
-        it "doesn't register an offence" do
+        it "doesn't register an offense" do
           inspect_source(cop, 'if cond; foo else bar; nil end')
           expect(cop.messages).to be_empty
         end
@@ -62,7 +62,7 @@ describe RuboCop::Cop::Style::MissingElse do
       end
 
       context 'with an else-clause with side-effects' do
-        it "doesn't register an offence" do
+        it "doesn't register an offense" do
           inspect_source(cop, 'unless cond; foo else bar; nil end')
           expect(cop.messages).to be_empty
         end
@@ -78,7 +78,7 @@ describe RuboCop::Cop::Style::MissingElse do
 
     context 'given a case statement' do
       context 'with a completely empty else-clause' do
-        it "doesn't register an offence" do
+        it "doesn't register an offense" do
           inspect_source(cop, 'case v; when a; foo else end')
           expect(cop.messages).to be_empty
         end
@@ -92,7 +92,7 @@ describe RuboCop::Cop::Style::MissingElse do
       end
 
       context 'with an else-clause with side-effects' do
-        it "doesn't register an offence" do
+        it "doesn't register an offense" do
           inspect_source(cop, 'case v; when a; foo; else b; nil end')
           expect(cop.messages).to be_empty
         end
@@ -134,7 +134,7 @@ describe RuboCop::Cop::Style::MissingElse do
       end
 
       context 'with an else-clause with side-effects' do
-        it "doesn't register an offence" do
+        it "doesn't register an offense" do
           inspect_source(cop, 'if cond; foo else bar; nil end')
           expect(cop.messages).to be_empty
         end
@@ -165,7 +165,7 @@ describe RuboCop::Cop::Style::MissingElse do
       end
 
       context 'with an else-clause with side-effects' do
-        it "doesn't register an offence" do
+        it "doesn't register an offense" do
           inspect_source(cop, 'unless cond; foo else bar; nil end')
           expect(cop.messages).to be_empty
         end
@@ -182,7 +182,7 @@ describe RuboCop::Cop::Style::MissingElse do
 
     context 'given a case statement' do
       context 'with a completely empty else-clause' do
-        it "doesn't register an offence" do
+        it "doesn't register an offense" do
           inspect_source(cop, 'case v; when a; foo else end')
           expect(cop.messages).to be_empty
         end
@@ -196,7 +196,7 @@ describe RuboCop::Cop::Style::MissingElse do
       end
 
       context 'with an else-clause with side-effects' do
-        it "doesn't register an offence" do
+        it "doesn't register an offense" do
           inspect_source(cop, 'case v; when a; foo; else b; nil end')
           expect(cop.messages).to be_empty
         end
@@ -243,7 +243,7 @@ describe RuboCop::Cop::Style::MissingElse do
       end
 
       context 'with an else-clause with side-effects' do
-        it "doesn't register an offence" do
+        it "doesn't register an offense" do
           inspect_source(cop, 'if cond; foo else bar; nil end')
           expect(cop.messages).to be_empty
         end
@@ -275,7 +275,7 @@ describe RuboCop::Cop::Style::MissingElse do
       end
 
       context 'with an else-clause with side-effects' do
-        it "doesn't register an offence" do
+        it "doesn't register an offense" do
           inspect_source(cop, 'unless cond; foo else bar; nil end')
           expect(cop.messages).to be_empty
         end
@@ -293,7 +293,7 @@ describe RuboCop::Cop::Style::MissingElse do
 
     context 'given a case statement' do
       context 'with a completely empty else-clause' do
-        it "doesn't register an offence" do
+        it "doesn't register an offense" do
           inspect_source(cop, 'case v; when a; foo else end')
           expect(cop.messages).to be_empty
         end
@@ -307,7 +307,7 @@ describe RuboCop::Cop::Style::MissingElse do
       end
 
       context 'with an else-clause with side-effects' do
-        it "doesn't register an offence" do
+        it "doesn't register an offense" do
           inspect_source(cop, 'case v; when a; foo; else b; nil end')
           expect(cop.messages).to be_empty
         end
@@ -355,7 +355,7 @@ describe RuboCop::Cop::Style::MissingElse do
       end
 
       context 'with an else-clause with side-effects' do
-        it "doesn't register an offence" do
+        it "doesn't register an offense" do
           inspect_source(cop, 'if cond; foo else bar; nil end')
           expect(cop.messages).to be_empty
         end
@@ -386,7 +386,7 @@ describe RuboCop::Cop::Style::MissingElse do
       end
 
       context 'with an else-clause with side-effects' do
-        it "doesn't register an offence" do
+        it "doesn't register an offense" do
           inspect_source(cop, 'unless cond; foo else bar; nil end')
           expect(cop.messages).to be_empty
         end
@@ -403,7 +403,7 @@ describe RuboCop::Cop::Style::MissingElse do
 
     context 'given a case statement' do
       context 'with a completely empty else-clause' do
-        it "doesn't register an offence" do
+        it "doesn't register an offense" do
           inspect_source(cop, 'case v; when a; foo else end')
           expect(cop.messages).to be_empty
         end
@@ -417,7 +417,7 @@ describe RuboCop::Cop::Style::MissingElse do
       end
 
       context 'with an else-clause with side-effects' do
-        it "doesn't register an offence" do
+        it "doesn't register an offense" do
           inspect_source(cop, 'case v; when a; foo; else b; nil end')
           expect(cop.messages).to be_empty
         end
@@ -464,7 +464,7 @@ describe RuboCop::Cop::Style::MissingElse do
       end
 
       context 'with an else-clause with side-effects' do
-        it "doesn't register an offence" do
+        it "doesn't register an offense" do
           inspect_source(cop, 'if cond; foo else bar; nil end')
           expect(cop.messages).to be_empty
         end
@@ -495,7 +495,7 @@ describe RuboCop::Cop::Style::MissingElse do
       end
 
       context 'with an else-clause with side-effects' do
-        it "doesn't register an offence" do
+        it "doesn't register an offense" do
           inspect_source(cop, 'unless cond; foo else bar; nil end')
           expect(cop.messages).to be_empty
         end
@@ -512,7 +512,7 @@ describe RuboCop::Cop::Style::MissingElse do
 
     context 'given a case statement' do
       context 'with a completely empty else-clause' do
-        it "doesn't register an offence" do
+        it "doesn't register an offense" do
           inspect_source(cop, 'case v; when a; foo else end')
           expect(cop.messages).to be_empty
         end
@@ -526,7 +526,7 @@ describe RuboCop::Cop::Style::MissingElse do
       end
 
       context 'with an else-clause with side-effects' do
-        it "doesn't register an offence" do
+        it "doesn't register an offense" do
           inspect_source(cop, 'case v; when a; foo; else b; nil end')
           expect(cop.messages).to be_empty
         end
@@ -572,7 +572,7 @@ describe RuboCop::Cop::Style::MissingElse do
       end
 
       context 'with an else-clause with side-effects' do
-        it "doesn't register an offence" do
+        it "doesn't register an offense" do
           inspect_source(cop, 'if cond; foo else bar; nil end')
           expect(cop.messages).to be_empty
         end
@@ -602,7 +602,7 @@ describe RuboCop::Cop::Style::MissingElse do
       end
 
       context 'with an else-clause with side-effects' do
-        it "doesn't register an offence" do
+        it "doesn't register an offense" do
           inspect_source(cop, 'unless cond; foo else bar; nil end')
           expect(cop.messages).to be_empty
         end
@@ -618,7 +618,7 @@ describe RuboCop::Cop::Style::MissingElse do
 
     context 'given a case statement' do
       context 'with a completely empty else-clause' do
-        it "doesn't register an offence" do
+        it "doesn't register an offense" do
           inspect_source(cop, 'case v; when a; foo else end')
           expect(cop.messages).to be_empty
         end
@@ -632,7 +632,7 @@ describe RuboCop::Cop::Style::MissingElse do
       end
 
       context 'with an else-clause with side-effects' do
-        it "doesn't register an offence" do
+        it "doesn't register an offense" do
           inspect_source(cop, 'case v; when a; foo; else b; nil end')
           expect(cop.messages).to be_empty
         end


### PR DESCRIPTION
Some specs were using the wrong spelling (following the naming decided in #700).

No changelog entry necessary, right?