### PR TITLE
Fix bug with --auto-gen-config and SpaceInsideBlockBraces

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@
 * [#1684](https://github.com/bbatsov/rubocop/issues/1684): Ignore symbol keys like `:"string"` in `HashSyntax`. ([@bbatsov][])
 * Handle explicit `begin` blocks in `Lint/Void`. ([@bbatsov][])
 * Handle symbols in `Lint/Void`. ([@bbatsov][])
+* [#1695](https://github.com/bbatsov/rubocop/pull/1695): Fix bug with `--auto-gen-config` and `SpaceInsideBlockBraces`. ([@meganemura][])
 
 ## 0.29.1 (13/02/2015)
 
@@ -1292,3 +1293,4 @@
 [@pimterry]: https://github.com/pimterry
 [@palkan]: https://github.com/palkan
 [@jdoconnor]: https://github.com/jdoconnor
+[@meganemura]: https://github.com/meganemura

--- a/lib/rubocop/cop/style/space_inside_block_braces.rb
+++ b/lib/rubocop/cop/style/space_inside_block_braces.rb
@@ -80,7 +80,9 @@ module RuboCop
             if left_brace.end_pos == args_delimiter.begin_pos &&
                cop_config['SpaceBeforeBlockParameters']
               offense(sb, left_brace.begin_pos, args_delimiter.end_pos,
-                      'Space between { and | missing.')
+                      'Space between { and | missing.') do
+                opposite_style_detected
+              end
             end
           else
             # We indicate the position after the left brace. Otherwise it's
@@ -95,7 +97,9 @@ module RuboCop
           if pipe?(args_delimiter)
             unless cop_config['SpaceBeforeBlockParameters']
               offense(sb, left_brace.end_pos, args_delimiter.begin_pos,
-                      'Space between { and | detected.')
+                      'Space between { and | detected.') do
+                opposite_style_detected
+              end
             end
           else
             brace_with_space = range_with_surrounding_space(left_brace, :right)

--- a/spec/rubocop/cop/style/space_inside_block_braces_spec.rb
+++ b/spec/rubocop/cop/style/space_inside_block_braces_spec.rb
@@ -107,6 +107,7 @@ describe RuboCop::Cop::Style::SpaceInsideBlockBraces do
     inspect_source(cop, 'each {puts }')
     expect(cop.messages).to eq(['Space missing inside {.'])
     expect(cop.highlights).to eq(['p'])
+    expect(cop.config_to_allow_offenses).to eq('Enabled' => false)
   end
 
   it 'registers an offense for right brace without inner space' do
@@ -148,6 +149,7 @@ describe RuboCop::Cop::Style::SpaceInsideBlockBraces do
       inspect_source(cop, 'each {|x| puts }')
       expect(cop.messages).to eq(['Space between { and | missing.'])
       expect(cop.highlights).to eq(['{|'])
+      expect(cop.config_to_allow_offenses).to eq('Enabled' => false)
     end
 
     it 'accepts new lambda syntax' do
@@ -195,6 +197,7 @@ describe RuboCop::Cop::Style::SpaceInsideBlockBraces do
         inspect_source(cop, 'each { |x| puts }')
         expect(cop.messages).to eq(['Space between { and | detected.'])
         expect(cop.highlights).to eq([' '])
+        expect(cop.config_to_allow_offenses).to eq('Enabled' => false)
       end
 
       it 'accepts new lambda syntax' do
@@ -241,6 +244,7 @@ describe RuboCop::Cop::Style::SpaceInsideBlockBraces do
       inspect_source(cop, 'each {puts  }')
       expect(cop.messages).to eq(['Space inside } detected.'])
       expect(cop.highlights).to eq(['  '])
+      expect(cop.config_to_allow_offenses).to eq('Enabled' => false)
     end
 
     it 'registers offenses for both braces with inner space' do
@@ -274,6 +278,7 @@ describe RuboCop::Cop::Style::SpaceInsideBlockBraces do
           inspect_source(cop, 'each {|x| puts}')
           expect(cop.messages).to eq(['Space between { and | missing.'])
           expect(cop.highlights).to eq(['{|'])
+          expect(cop.config_to_allow_offenses).to eq('Enabled' => false)
         end
 
         it 'accepts new lambda syntax' do
@@ -300,6 +305,7 @@ describe RuboCop::Cop::Style::SpaceInsideBlockBraces do
           inspect_source(cop, 'each { |x| puts}')
           expect(cop.messages).to eq(['Space between { and | detected.'])
           expect(cop.highlights).to eq([' '])
+          expect(cop.config_to_allow_offenses).to eq('Enabled' => false)
         end
 
         it 'accepts new lambda syntax' do


### PR DESCRIPTION
Auto generated config does not disable `SpaceInsideBlockBraces` cop for the following situation.

```ruby
$ bundle exec rubocop --auto-gen-config foo.rb
foo.rb:1:6: C: Space between { and | missing.
each {|x| x }
     ^^
```

Offence detected, but we got the following auto-generated config.

```
Style/SpaceInsideBlockBraces:
  Enabled: true
```

So, the config does not disable it.

And, the similar issue is occured in the situation below.

 * `.rubocop.yml`
```yaml
Style/SpaceInsideBlockBraces:
    SpaceBeforeBlockParameters: false
    EnforcedStyle: no_space
```

 * detection
```ruby
$ bundle exec rubocop --auto-gen-config foo.rb
foo.rb:1:7: C: Space between { and | detected.
each { |x| x}
      ^
```

 * auto-generated config
```
Style/SpaceInsideBlockBraces:
  Enabled: true
```

This commit fixes these issues.


RuboCop: 0.29.1 (using Parser 2.2.0.3, running on ruby 2.1.4 x86_64-darwin13.0), master (ccedef2)