### PR TITLE
Hash key ending in = needs a hashrocket

### DIFF
--- a/lib/rubocop/cop/style/hash_syntax.rb
+++ b/lib/rubocop/cop/style/hash_syntax.rb
@@ -93,13 +93,10 @@ module RuboCop
         def word_symbol_pair?(pair)
           key, _value = *pair
 
-          if key.sym_type?
-            sym_name = key.loc.expression.source
+          return false unless key.sym_type?
 
-            sym_name !~ /\A:["']/
-          else
-            false
-          end
+          sym_name = key.loc.expression.source
+          sym_name !~ /\A:["']|=\z/
         end
 
         def check(pairs, delim, msg)

--- a/spec/rubocop/cop/style/hash_syntax_spec.rb
+++ b/spec/rubocop/cop/style/hash_syntax_spec.rb
@@ -46,6 +46,11 @@ describe RuboCop::Cop::Style::HashSyntax, :config do
         expect(cop.messages).to be_empty
       end
 
+      it 'accepts hash rockets when symbol keys end with =' do
+        inspect_source(cop, 'x = { :a= => 0 }')
+        expect(cop.messages).to be_empty
+      end
+
       it 'registers offense when keys start with an uppercase letter' do
         inspect_source(cop, 'x = { :A => 0 }')
         expect(cop.messages).to eq(['Use the new Ruby 1.9 hash syntax.'])


### PR DESCRIPTION
Fix for bug introduced by 89e5eb317eb97ea6ff2a06bc797e8a7f6e52b234.

For example when creating stubs or mocks, sometimes we have a hash key that ends with the equals sign:

    let(:foo) { double("Foo", set?: true, :changes= => true) }

Changing the `:changes=` to use 1.9 hash syntax raises a

    "SyntaxError: unexpected ':'"