### PR TITLE
Update RedundantBegin cop to respect heredocs

### DIFF
--- a/lib/rubocop/cop/style/redundant_begin.rb
+++ b/lib/rubocop/cop/style/redundant_begin.rb
@@ -36,21 +36,42 @@ module RuboCop
         end
 
         def autocorrect(node)
+          child = node.children.first
+          node_range = range_with_surrounding_space(node.loc.expression)
+          child_range = range_with_surrounding_space(corrected_range(child))
+          columns = child.loc.column - node.loc.column
+          child_source = unindent(child_range, columns)
+
           lambda do |corrector|
-            child = node.children.first
-
-            begin_indent = node.loc.column
-            child_indent = child.loc.column
-
-            indent_diff = child_indent - begin_indent
-
-            corrector.replace(
-              range_with_surrounding_space(node.loc.expression),
-              range_with_surrounding_space(
-                child.loc.expression
-              ).source.gsub(/^[ \t]{#{indent_diff}}/, '')
-            )
+            corrector.replace(node_range, child_source)
           end
+        end
+
+        def corrected_range(node)
+          Parser::Source::Range.new(
+            node.loc.expression.source_buffer,
+            node.loc.expression.begin_pos,
+            corrected_range_end(node)
+          )
+        end
+
+        def corrected_range_end(node)
+          [
+            last_heredoc_position(node),
+            node.loc.expression.end_pos
+          ].compact.max
+        end
+
+        def last_heredoc_position(root)
+          root
+            .each_node
+            .select { |node| node.loc.respond_to?(:heredoc_end) }
+            .map { |node| node.loc.heredoc_end.end_pos }
+            .max
+        end
+
+        def unindent(range, columns)
+          range.source.gsub(/^[ \t]{#{columns}}/, '')
         end
       end
     end

--- a/spec/rubocop/cop/style/redundant_begin_spec.rb
+++ b/spec/rubocop/cop/style/redundant_begin_spec.rb
@@ -118,4 +118,58 @@ describe RuboCop::Cop::Style::RedundantBegin do
     new_source = autocorrect_source(cop, src)
     expect(new_source).to eq(result_src)
   end
+
+  it 'respects indented heredocs' do
+    source = <<-CODE.split("\n")
+def method
+  begin
+    fail
+  rescue
+    puts <<-EOS
+      This is a string
+    EOS
+  end
+end
+    CODE
+
+    expected = <<-CODE.split("\n")
+def method
+  fail
+rescue
+  puts <<-EOS
+    This is a string
+  EOS
+end
+    CODE
+
+    corrected = autocorrect_source(cop, source).split("\n")
+    expect(corrected).to eq(expected)
+  end
+
+  it 'respects unindented heredocs' do
+    source = <<-CODE.split("\n")
+def method
+  begin
+    fail
+  rescue
+    puts <<-EOS
+This is a string
+    EOS
+  end
+end
+    CODE
+
+    expected = <<-CODE.split("\n")
+def method
+  fail
+rescue
+  puts <<-EOS
+This is a string
+  EOS
+end
+    CODE
+
+    corrected = autocorrect_source(cop, source).split("\n")
+    expect(corrected).to eq(expected)
+  end
 end


### PR DESCRIPTION
The RedundantBegin cop does not respect heredocs, stripping all but the first line of the heredoc when updating the source. This PR adds failing tests to demonstrate. 

This PR also updates the strategy for removing the extra begin/end. In the previous version, when a heredoc was used in the last command of the block, the end of the range to be replaced was returned as the first line of the heredoc, not the last line of the heredoc. I believe this may be an issue in the parsing library not correctly returning ranges for heredoc. The new strategy is a work around until the root issue can be resolved.