### PR TITLE
Disable cops for offensive files only (Issue #1696)

### DIFF
--- a/lib/rubocop/formatter/disabled_config_formatter.rb
+++ b/lib/rubocop/formatter/disabled_config_formatter.rb
@@ -77,8 +77,7 @@ module RuboCop
 
       def relative_path(filename)
         @base_dir ||= Pathname.new(
-          File.dirname(Pathname.new(output.path).realpath.to_s)
-        )
+          File.dirname(Pathname.new(output.path).realpath.to_s))
         Pathname.new(filename).relative_path_from(@base_dir)
       end
     end

--- a/lib/rubocop/formatter/disabled_config_formatter.rb
+++ b/lib/rubocop/formatter/disabled_config_formatter.rb
@@ -76,9 +76,8 @@ module RuboCop
       private
 
       def relative_path(filename)
-        @base_dir ||= Pathname.new(
-          File.dirname(Pathname.new(output.path).realpath.to_s))
-        Pathname.new(filename).relative_path_from(@base_dir)
+        @base_dir ||= Pathname.new(File.dirname(File.expand_path(output.path)))
+        Pathname.new(File.expand_path(filename)).relative_path_from(@base_dir)
       end
     end
   end

--- a/spec/rubocop/cli_spec.rb
+++ b/spec/rubocop/cli_spec.rb
@@ -690,17 +690,21 @@ describe RuboCop::CLI, :isolated_environment do
                   '# Configuration parameters: AllowURI, URISchemes.',
                   'Metrics/LineLength:',
                   '  Max: 85',
+                  '  Exclude:',
+                  '    - example1.rb',
                   '',
                   '# Offense count: 1',
                   '# Cop supports --auto-correct.',
                   '# Configuration parameters: MultiSpaceAllowedForOperators.',
                   'Style/SpaceAroundOperators:',
-                  '  Enabled: false',
+                  '  Exclude:',
+                  '    - example1.rb',
                   '',
                   '# Offense count: 2',
                   '# Cop supports --auto-correct.',
                   'Style/TrailingWhitespace:',
-                  '  Enabled: false'])
+                  '  Exclude:',
+                  '    - example1.rb'])
 
         # Create new CLI instance to avoid using cached configuration.
         new_cli = described_class.new
@@ -754,37 +758,45 @@ describe RuboCop::CLI, :isolated_environment do
            '# Configuration parameters: AllowURI, URISchemes.',
            'Metrics/LineLength:',
            '  Max: 90',
+           '  Exclude:',
+           '    - example1.rb',
            '',
            '# Offense count: 1',
            '# Cop supports --auto-correct.',
            'Style/CommentIndentation:',
-           '  Enabled: false',
+           '  Exclude:',
+           '    - example2.rb',
            '',
            '# Offense count: 1',
            '# Configuration parameters: AllowedVariables.',
            'Style/GlobalVars:',
-           '  Enabled: false',
+           '  Exclude:',
+           '    - example1.rb',
            '',
            '# Offense count: 1',
            '# Cop supports --auto-correct.',
            'Style/IndentationConsistency:',
-           '  Enabled: false',
+           '  Exclude:',
+           '    - example2.rb',
            '',
            '# Offense count: 1',
            '# Cop supports --auto-correct.',
            '# Configuration parameters: MultiSpaceAllowedForOperators.',
            'Style/SpaceAroundOperators:',
-           '  Enabled: false',
+           '  Exclude:',
+           '    - example1.rb',
            '',
            '# Offense count: 1',
            '# Cop supports --auto-correct.',
            'Style/Tab:',
-           '  Enabled: false',
+           '  Exclude:',
+           '    - example2.rb',
            '',
            '# Offense count: 2',
            '# Cop supports --auto-correct.',
            'Style/TrailingWhitespace:',
-           '  Enabled: false']
+           '  Exclude:',
+           '    - example1.rb']
         actual = IO.read('.rubocop_todo.yml').split($RS)
         expected.each_with_index do |line, ix|
           if line.is_a?(String)
@@ -816,17 +828,20 @@ describe RuboCop::CLI, :isolated_environment do
            '# Offense count: 1',
            '# Cop supports --auto-correct.',
            'Style/CommentIndentation:',
-           '  Enabled: false',
+           '  Exclude:',
+           '    - example2.rb',
            '',
            '# Offense count: 1',
            '# Cop supports --auto-correct.',
            'Style/IndentationConsistency:',
-           '  Enabled: false',
+           '  Exclude:',
+           '    - example2.rb',
            '',
            '# Offense count: 1',
            '# Cop supports --auto-correct.',
            'Style/Tab:',
-           '  Enabled: false']
+           '  Exclude:',
+           '    - example2.rb']
         actual = IO.read('.rubocop_todo.yml').split($RS)
         expect(actual.length).to eq(expected.length)
         expected.each_with_index do |line, ix|
@@ -860,7 +875,8 @@ describe RuboCop::CLI, :isolated_environment do
            '# Offense count: 1',
            '# Configuration parameters: MaxSlashes.',
            'Style/RegexpLiteral:',
-           '  Enabled: false']
+           '  Exclude:',
+           '    - example.rb']
         actual = IO.read('.rubocop_todo.yml').split($RS)
         expected.each_with_index do |line, ix|
           if line.is_a?(String)

--- a/spec/rubocop/formatter/disabled_config_formatter_spec.rb
+++ b/spec/rubocop/formatter/disabled_config_formatter_spec.rb
@@ -7,6 +7,7 @@ require 'ostruct'
 module RuboCop
   module Formatter
     describe DisabledConfigFormatter do
+
       subject(:formatter) { described_class.new(output) }
       let(:output) do
         o = StringIO.new
@@ -31,11 +32,13 @@ module RuboCop
                                        '',
                                        '# Offense count: 1',
                                        'Cop1:',
-                                       '  Enabled: false',
+                                       '  Exclude:',
+                                       '    - test.rb',
                                        '',
                                        '# Offense count: 1',
                                        'Cop2:',
-                                       '  Enabled: false',
+                                       '  Exclude:',
+                                       '    - test.rb',
                                        ''].join("\n"))
           expect($stdout.string)
             .to eq(['Created .rubocop_todo.yml.',


### PR DESCRIPTION
This patch provides solution for issue #1696. When run with option *--auto-gen-config*, instead of setting *Enable: false* for the cop, it sets *Exclude:* for the list of files where offense happened.

bin/rubocop -V
0.29.1 (using Parser 2.2.0.3, running on ruby 2.1.5 x86_64-darwin14.0)