### PR TITLE
[Fix #1579] Block equality check in BlockAlignment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@
 * Handle symbols in `Lint/Void`. ([@bbatsov][])
 * [#1695](https://github.com/bbatsov/rubocop/pull/1695): Fix bug with `--auto-gen-config` and `SpaceInsideBlockBraces`. ([@meganemura][])
 * Correct issues with whitespace around multi-line lambda arguments. ([@zvkemp][])
+* [#1579](https://github.com/bbatsov/rubocop/issues/1579): Fix handling of similar-looking blocks in `BlockAlignment`. ([@lumeet][])
 
 ### Changes
 

--- a/lib/rubocop/cop/lint/block_alignment.rb
+++ b/lib/rubocop/cop/lint/block_alignment.rb
@@ -16,24 +16,19 @@ module RuboCop
 
         MSG = '`end` at %d, %d is not aligned with `%s` at %d, %d%s'
 
-        def initialize(config = nil, options = nil)
-          super
-          @inspected_blocks = []
-        end
-
         def on_block(node)
-          return if already_processed_node?(node)
+          return if ignored_node?(node)
           check_block_alignment(node, node)
         end
 
         def on_and(node)
-          return if already_processed_node?(node)
+          return if ignored_node?(node)
 
           _left, right = *node
           return unless right.type == :block
 
           check_block_alignment(node, right)
-          @inspected_blocks << right
+          ignore_node(right)
         end
 
         alias_method :on_or, :on_and
@@ -74,9 +69,9 @@ module RuboCop
                                                                 block_node)
             return
           end
-          return if already_processed_node?(block_node)
+          return if ignored_node?(block_node)
 
-          @inspected_blocks << block_node
+          ignore_node(block_node)
           check_block_alignment(begin_node, block_node)
         end
 
@@ -138,10 +133,6 @@ module RuboCop
         end
 
         def message
-        end
-
-        def already_processed_node?(node)
-          @inspected_blocks.include?(node)
         end
 
         def block_is_on_next_line?(begin_node, block_node)

--- a/spec/rubocop/cop/lint/block_alignment_spec.rb
+++ b/spec/rubocop/cop/lint/block_alignment_spec.rb
@@ -530,4 +530,16 @@ describe RuboCop::Cop::Lint::BlockAlignment do
     expect(cop.messages)
       .to eq(['`end` at 3, 2 is not aligned with `var1, var2` at 1, 0'])
   end
+
+  context 'when multiple similar-looking blocks have misaligned ends' do
+    it 'registers an offense for each of them' do
+      inspect_source(cop,
+                     ['a = test do',
+                      ' end',
+                      'b = test do',
+                      ' end'
+                     ])
+      expect(cop.offenses.size).to eq 2
+    end
+  end
 end


### PR DESCRIPTION
The class-specific `already_processed_node?` is replaced with the
generic `ignored_node?` to fix a bug when checking block equality.
Offenses for each similar-looking block will now be reported.

So, the real issue isn't the one reported in #1579. Here's an example that should generate an offense for each of the blocks but the second one is currently ignored:

```ruby
a = test
    .some do
      thing
   end

b = test
    .some do
      thing
   end
```

I'm not totally sure if `ignore_node` and related methods are the right tools here. Let me know if I've misunderstood something. Also, I didn't add an entry to `CHANGELOG.md`. Should I?