### PR TITLE
Add Performance/Size cop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@
 * [#1281](https://github.com/bbatsov/rubocop/issues/1281): `IfUnlessModifier` cop does auto-correction. ([@lumeet][])
 * New cop `Performance/Detect` to detect usage of `select.first`, `select.last`, `find_all.first`, and `find_all.last` and convert them to use `detect` instead. ([@palkan][], [@rrosenblum][])
 * [#1728](https://github.com/bbatsov/rubocop/pull/1728): New cop `NonLocalExitFromIterator` checks for misused `return` in block. ([@ypresto][])
+* New cop `Performance/Size` to convert calls to `count` on `Array` and `Hash` to `size`. ([@rrosenblum][])
 
 ### Bugs fixed
 

--- a/config/enabled.yml
+++ b/config/enabled.yml
@@ -975,6 +975,12 @@ Lint/Void:
 
 ##################### Performance #############################
 
+Performance/Size:
+  Description: >-
+                  Use `size` instead of `count` for counting
+                  the number of elements in `Array` and `Hash`.
+  Enabled: true
+
 Performance/Detect:
   Description: >-
                   Use `detect` instead of `select.first`, `find_all.first`,

--- a/lib/rubocop.rb
+++ b/lib/rubocop.rb
@@ -116,6 +116,7 @@ require 'rubocop/cop/metrics/parameter_lists'
 require 'rubocop/cop/metrics/perceived_complexity'
 
 require 'rubocop/cop/performance/detect'
+require 'rubocop/cop/performance/size'
 require 'rubocop/cop/performance/reverse_each'
 
 require 'rubocop/cop/style/access_modifier_indentation'

--- a/lib/rubocop/cop/performance/size.rb
+++ b/lib/rubocop/cop/performance/size.rb
@@ -1,0 +1,64 @@
+# encoding: utf-8
+
+module RuboCop
+  module Cop
+    module Performance
+      # This cop is used to identify usages of `count` on an
+      # `Array` and `Hash` and change them to `size`.
+      #
+      # @example
+      #   # bad
+      #   [1, 2, 3].count
+      #
+      #   # bad
+      #   {a: 1, b: 2, c: 3}.count
+      #
+      #   # good
+      #   [1, 2, 3].size
+      #
+      #   # good
+      #   {a: 1, b: 2, c: 3}.size
+      #
+      #   # good
+      #   [1, 2, 3].count { |e| e > 2 }
+      # TODO: Add advanced detection of variables that could
+      # have been assigned to an array or a hash.
+      class Size < Cop
+        MSG = 'Use `size` instead of `count`.'
+
+        def on_send(node)
+          receiver, method = *node
+
+          return if receiver.nil?
+          return unless method == :count
+          return unless array?(receiver) || hash?(receiver)
+          return if node.parent && node.parent.block_type?
+
+          add_offense(node, node.loc.selector)
+        end
+
+        def autocorrect(node)
+          @corrections << lambda do |corrector|
+            corrector.replace(node.loc.selector, 'size')
+          end
+        end
+
+        private
+
+        def array?(node)
+          receiver, method = *node
+          _, constant = *receiver
+
+          node.array_type? || constant == :Array || method == :to_a
+        end
+
+        def hash?(node)
+          receiver, method = *node
+          _, constant = *receiver
+
+          node.hash_type? || constant == :Hash || method == :to_h
+        end
+      end
+    end
+  end
+end

--- a/spec/rubocop/cop/performance/size_spec.rb
+++ b/spec/rubocop/cop/performance/size_spec.rb
@@ -1,0 +1,133 @@
+# encoding: utf-8
+
+require 'spec_helper'
+
+describe RuboCop::Cop::Performance::Size do
+  subject(:cop) { described_class.new }
+
+  it 'does not register an offense when calling count ' \
+     'as a stand alone method' do
+    inspect_source(cop, 'count(items)')
+
+    expect(cop.messages).to be_empty
+  end
+
+  it 'does not register an offense when calling count on an object ' \
+     'other than an array or a hash' do
+    inspect_source(cop, 'object.count(items)')
+
+    expect(cop.messages).to be_empty
+  end
+
+  describe 'on array' do
+    it 'registers an offense when calling count' do
+      inspect_source(cop, '[1, 2, 3].count')
+
+      expect(cop.messages).to eq(['Use `size` instead of `count`.'])
+    end
+
+    it 'registers an offense when calling count on to_a' do
+      inspect_source(cop, '(1..3).to_a.count')
+
+      expect(cop.messages).to eq(['Use `size` instead of `count`.'])
+    end
+
+    it 'registers an offense when calling count on Array[]' do
+      inspect_source(cop, 'Array[*1..5].count')
+
+      expect(cop.messages).to eq(['Use `size` instead of `count`.'])
+    end
+
+    it 'does not register an offense when calling size' do
+      inspect_source(cop, '[1, 2, 3].size')
+
+      expect(cop.messages).to be_empty
+    end
+
+    it 'does not register an offense when calling another method' do
+      inspect_source(cop, '[1, 2, 3].each')
+
+      expect(cop.messages).to be_empty
+    end
+
+    it 'does not register an offense when calling count with a block' do
+      inspect_source(cop, '[1, 2, 3].count { |e| e > 3 }')
+
+      expect(cop.messages).to be_empty
+    end
+
+    it 'corrects count to size' do
+      new_source = autocorrect_source(cop, '[1, 2, 3].count')
+
+      expect(new_source).to eq('[1, 2, 3].size')
+    end
+
+    it 'corrects count to size on to_a' do
+      new_source = autocorrect_source(cop, '(1..3).to_a.count')
+
+      expect(new_source).to eq('(1..3).to_a.size')
+    end
+
+    it 'corrects count to size on Array[]' do
+      new_source = autocorrect_source(cop, 'Array[*1..5].count')
+
+      expect(new_source).to eq('Array[*1..5].size')
+    end
+  end
+
+  describe 'on hash' do
+    it 'registers an offense when calling count' do
+      inspect_source(cop, '{a: 1, b: 2, c: 3}.count')
+
+      expect(cop.messages).to eq(['Use `size` instead of `count`.'])
+    end
+
+    it 'registers an offense when calling count on to_h' do
+      inspect_source(cop, '[[:foo, :bar], [1, 2]].to_h.count')
+
+      expect(cop.messages).to eq(['Use `size` instead of `count`.'])
+    end
+
+    it 'registers an offense when calling count on Hash[]' do
+      inspect_source(cop, "Hash[*('a'..'z')].count")
+
+      expect(cop.messages).to eq(['Use `size` instead of `count`.'])
+    end
+
+    it 'does not register an offense when calling size' do
+      inspect_source(cop, '{a: 1, b: 2, c: 3}.size')
+
+      expect(cop.messages).to be_empty
+    end
+
+    it 'does not register an offense when calling another method' do
+      inspect_source(cop, '{a: 1, b: 2, c: 3}.each')
+
+      expect(cop.messages).to be_empty
+    end
+
+    it 'does not register an offense when calling count with a block' do
+      inspect_source(cop, '{a: 1, b: 2, c: 3}.count { |e| e > 3 }')
+
+      expect(cop.messages).to be_empty
+    end
+
+    it 'corrects count to size' do
+      new_source = autocorrect_source(cop, '{a: 1, b: 2, c: 3}.count')
+
+      expect(new_source).to eq('{a: 1, b: 2, c: 3}.size')
+    end
+
+    it 'corrects count to size on to_h' do
+      new_source = autocorrect_source(cop, '[[:foo, :bar], [1, 2]].to_h.count')
+
+      expect(new_source).to eq('[[:foo, :bar], [1, 2]].to_h.size')
+    end
+
+    it 'corrects count to size on Hash[]' do
+      new_source = autocorrect_source(cop, "Hash[*('a'..'z')].count")
+
+      expect(new_source).to eq("Hash[*('a'..'z')].size")
+    end
+  end
+end


### PR DESCRIPTION
This started as a cop specifically for `Array`, but I discovered that `Hash` has a `count` method even though it is not mentioned in the documentation.
```
HASH = Hash[*1..100]

def slow
  HASH.count
end

def fast
  HASH.size
end

Benchmark.ips do |x| 
  x.report('count') { slow }
  x.report('size') { fast }
  x.compare!
end

Calculating -------------------------------------
                count    21.099k i/100ms
                size   141.896k i/100ms
-------------------------------------------------
                count    247.280k (± 5.1%) i/s -      1.245M
                size      7.631M (± 8.5%) i/s -     37.886M

Comparison:
                size:  7630884.6 i/s
                count:   247280.4 i/s - 30.86x slower
```