### PR TITLE
Return nil from autocorrect? if cop does not support autocorrection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### New features
 
+* [#1712](https://github.com/bbatsov/rubocop/pull/1712): Set `Offense#corrected?` to `true`, `false`, or `nil` when it was, wasn't, or can't be auto-corrected, respectively. ([@vassilevsky][])
 * [#1669](https://github.com/bbatsov/rubocop/pull/1669): Add command-line switch `--display-style-guide`. ([@marxarelli][])
 * [#1405](https://github.com/bbatsov/rubocop/issues/1405): Add Rails TimeZone and Date cops. ([@palkan][])
 * [#1641](https://github.com/bbatsov/rubocop/pull/1641): Add ruby19_no_mixed_keys style to `HashStyle` cop. ([@iainbeeston][])
@@ -1302,3 +1303,4 @@
 [@jdoconnor]: https://github.com/jdoconnor
 [@meganemura]: https://github.com/meganemura
 [@zvkemp]: https://github.com/zvkemp
+[@vassilevsky]: https://github.com/vassilevsky

--- a/lib/rubocop/cop/autocorrect_logic.rb
+++ b/lib/rubocop/cop/autocorrect_logic.rb
@@ -5,7 +5,7 @@ module RuboCop
     # This module encapsulates the logic for autocorrect behaviour for a cop
     module AutocorrectLogic
       def autocorrect?
-        @options[:auto_correct] && support_autocorrect? && autocorrect_enabled?
+        @options.fetch(:auto_correct, false) && support_autocorrect? && autocorrect_enabled?
       end
 
       def support_autocorrect?

--- a/lib/rubocop/cop/autocorrect_logic.rb
+++ b/lib/rubocop/cop/autocorrect_logic.rb
@@ -5,7 +5,11 @@ module RuboCop
     # This module encapsulates the logic for autocorrect behaviour for a cop
     module AutocorrectLogic
       def autocorrect?
-        @options.fetch(:auto_correct, false) && support_autocorrect? && autocorrect_enabled?
+        autocorrect_requested? && support_autocorrect? && autocorrect_enabled?
+      end
+
+      def autocorrect_requested?
+        @options.fetch(:auto_correct, false)
       end
 
       def support_autocorrect?

--- a/lib/rubocop/cop/cop.rb
+++ b/lib/rubocop/cop/cop.rb
@@ -152,14 +152,20 @@ module RuboCop
         message ||= message(node)
         message = annotate_message(message)
 
-        corrected = begin
-                      autocorrect(node) if autocorrect?
-                      autocorrect?
-                    rescue CorrectionNotPossible
-                      false
-                    end
+        corrected = correct(node)
+
         @offenses << Offense.new(severity, location, message, name, corrected)
         yield if block_given?
+      end
+
+      def correct(node)
+        return nil unless support_autocorrect?
+        return false unless autocorrect?
+
+        autocorrect(node)
+        true
+      rescue CorrectionNotPossible
+        false
       end
 
       def config_to_allow_offenses

--- a/lib/rubocop/cop/cop.rb
+++ b/lib/rubocop/cop/cop.rb
@@ -106,7 +106,7 @@ module RuboCop
 
       def initialize(config = nil, options = nil)
         @config = config || Config.new
-        @options = options || { auto_correct: false, debug: false }
+        @options = options || { debug: false }
 
         @offenses = []
         @corrections = []

--- a/spec/rubocop/cop/cop_spec.rb
+++ b/spec/rubocop/cop/cop_spec.rb
@@ -145,14 +145,19 @@ describe RuboCop::Cop::Cop do
       allow(cop).to receive(:support_autocorrect?) { support_autocorrect }
     end
 
-    context 'when the option is false' do
-      let(:options) { { auto_correct: false } }
+    context 'when the option is not given' do
+      let(:options) { {} }
       it { should be false }
     end
 
-    context 'when the option is true' do
+    context 'when the option is given' do
       let(:options) { { auto_correct: true } }
       it { should be true }
+
+      context 'when cop does not support autocorrection' do
+        let(:support_autocorrect) { false }
+        it { should be false }
+      end
 
       context 'when the cop is set to not autocorrect' do
         let(:config) do


### PR DESCRIPTION
More meaningful values of offenses' `corrected` attribute:

* `nil` — the cop does not support autocorrection at all;
* `false` — the cop could autocorrect this offense, but didn't do it for one reason or another;
* `true` — the cop has autocorrected this offense.