### PR TITLE
fix multi-line lambda autocorrect whitespace issue

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@
 * Handle explicit `begin` blocks in `Lint/Void`. ([@bbatsov][])
 * Handle symbols in `Lint/Void`. ([@bbatsov][])
 * [#1695](https://github.com/bbatsov/rubocop/pull/1695): Fix bug with `--auto-gen-config` and `SpaceInsideBlockBraces`. ([@meganemura][])
+* Correct issues with whitespace around multi-line lambda arguments. ([@zvkemp][])
 
 ## 0.29.1 (13/02/2015)
 
@@ -1294,3 +1295,4 @@
 [@palkan]: https://github.com/palkan
 [@jdoconnor]: https://github.com/jdoconnor
 [@meganemura]: https://github.com/meganemura
+[@zvkemp]: https://github.com/zvkemp

--- a/lib/rubocop/cop/style/blocks.rb
+++ b/lib/rubocop/cop/style/blocks.rb
@@ -43,9 +43,9 @@ module RuboCop
           lambda do |corrector|
             b, e = node.loc.begin, node.loc.end
             if b.is?('{')
-              # If the left brace is immediately preceded by a word character,
+              # If the left brace is not preceded by a whitespace character,
               # then we need a space before `do` to get valid Ruby code.
-              if b.source_buffer.source[b.begin_pos - 1, 1] =~ /\w/
+              if b.source_buffer.source[b.begin_pos - 1, 1] =~ /\S/
                 corrector.insert_before(b, ' ')
               end
               corrector.replace(b, 'do')

--- a/spec/rubocop/cop/style/lambda_spec.rb
+++ b/spec/rubocop/cop/style/lambda_spec.rb
@@ -73,4 +73,65 @@ describe RuboCop::Cop::Style::Lambda do
                               '  x',
                               'end'].join("\n"))
   end
+
+  context 'unusual lack of spacing' do
+    # The lack of spacing shown here is valid ruby syntax,
+    # and can be the result of previous autocorrects re-writing
+    # a multi-line `->(x){ ... }` to `->(x)do ... end`.
+    # See rubocop/cop/style/blocks.rb.
+    # Tests correction of an issue resulting in `lambdado` syntax errors.
+    it 'auto-corrects a multi-line lambda' do
+      new_source = autocorrect_source(cop, ['->(x)do',
+                                            '  x',
+                                            'end'])
+      expect(new_source).to eq(['lambda do |x|',
+                                '  x',
+                                'end'].join("\n"))
+    end
+
+    it 'auto-corrects a multi-line lambda with no spacing after args' do
+      new_source = autocorrect_source(cop, ['-> (x)do',
+                                            '  x',
+                                            'end'])
+      expect(new_source).to eq(['lambda do |x|',
+                                '  x',
+                                'end'].join("\n"))
+    end
+
+    it 'auto-corrects a multi-line lambda with no spacing before args' do
+      new_source = autocorrect_source(cop, ['->(x) do',
+                                            '  x',
+                                            'end'])
+      expect(new_source).to eq(['lambda do |x|',
+                                '  x',
+                                'end'].join("\n"))
+    end
+
+    it 'auto-corrects a multi-line lambda with empty args' do
+      new_source = autocorrect_source(cop, ['->()do',
+                                            '  x',
+                                            'end'])
+      expect(new_source).to eq(['lambda do',
+                                '  x',
+                                'end'].join("\n"))
+    end
+
+    it 'auto-corrects a multi-line lambda with empty args and bad spacing' do
+      new_source = autocorrect_source(cop, ['-> ()do',
+                                            '  x',
+                                            'end'])
+      expect(new_source).to eq(['lambda do',
+                                '  x',
+                                'end'].join("\n"))
+    end
+
+    it 'auto-corrects a new multi-line lambda with no args' do
+      new_source = autocorrect_source(cop, ['->do',
+                                            '  x',
+                                            'end'])
+      expect(new_source).to eq(['lambda do',
+                                '  x',
+                                'end'].join("\n"))
+    end
+  end
 end


### PR DESCRIPTION
Fixes an issue in which multi-line lambdas of the form

```ruby
->(x){
  x
}
```

...would be auto-corrected to:

```ruby
lambdado |x|
  x
end
```

This was the result of a multi-step autocorrect wherein the curly brackets were replaced by Cop::Style::Blocks, and then the Cop::Style::Lambda would convert the arguments to block-style without correcting for whitespace.

These changes ensures a space is added before `do ... end` blocks in general (if necessary), and fixes the whitespace issues with multi-line lambda arguments.

```
rubocop -V
0.29.1 (using Parser 2.2.0.3, running on ruby 2.1.5 x86_64-darwin14.0)
```