### PR TITLE
[Fix #1676] Disable argument lambda auto-correction in Lambda

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,7 @@
 * [#1695](https://github.com/bbatsov/rubocop/pull/1695): Fix bug with `--auto-gen-config` and `SpaceInsideBlockBraces`. ([@meganemura][])
 * Correct issues with whitespace around multi-line lambda arguments. ([@zvkemp][])
 * [#1579](https://github.com/bbatsov/rubocop/issues/1579): Fix handling of similar-looking blocks in `BlockAlignment`. ([@lumeet][])
+* [#1676](https://github.com/bbatsov/rubocop/pull/1676): Fix auto-correct in `Lambda` when a new multi-line lambda is used as an argument. ([@lumeet][])
 
 ### Changes
 

--- a/spec/rubocop/cop/style/lambda_spec.rb
+++ b/spec/rubocop/cop/style/lambda_spec.rb
@@ -134,4 +134,22 @@ describe RuboCop::Cop::Style::Lambda do
                                 'end'].join("\n"))
     end
   end
+
+  context 'new multi-line lambda as an argument' do
+    let(:source) do
+      ['has_many :kittens, -> do',
+       '  where(cats: Cat.young.where_values_hash)',
+       'end, source: cats']
+    end
+
+    it 'registers an offense' do
+      inspect_source(cop, source)
+      expect(cop.offenses.size).to eq 1
+    end
+
+    it 'does not auto-correct' do
+      expect(autocorrect_source(cop, source)).to eq(source.join("\n"))
+      expect(cop.offenses.map(&:corrected?)).to eq [false]
+    end
+  end
 end


### PR DESCRIPTION
Don't let `Style/Lambda` perform auto-corrections that would change
the abstract syntax tree.

This was the cleanest solution I could come up with. I'm not quite sure, though, if it violates some rules unknown to me. Please, review carefully. :)