### PR TITLE
[Fix #1656] Avoid unwanted matching of hidden directories

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,7 @@
 * Correct issues with whitespace around multi-line lambda arguments. ([@zvkemp][])
 * [#1579](https://github.com/bbatsov/rubocop/issues/1579): Fix handling of similar-looking blocks in `BlockAlignment`. ([@lumeet][])
 * [#1676](https://github.com/bbatsov/rubocop/pull/1676): Fix auto-correct in `Lambda` when a new multi-line lambda is used as an argument. ([@lumeet][])
+* [#1656](https://github.com/bbatsov/rubocop/issues/1656): Fix bug that would include hidden directories implicitly. ([@jonas054][])
 
 ### Changes
 

--- a/lib/rubocop/path_util.rb
+++ b/lib/rubocop/path_util.rb
@@ -25,15 +25,11 @@ module RuboCop
           # beginning with dot, but not a new match. That's a special case,
           # though. Not what we want to handle here. And this is a match that
           # we overrule. Only patterns like dir/**/.* can be used to match dot
-          # files.
-          return false if basename.start_with?('.')
+          # files. Hidden directories (starting with a dot) will also produce
+          # an old match, just like hidden files.
+          return false if path.split(File::SEPARATOR).any? { |s| hidden?(s) }
 
-          # Hidden directories (starting with a dot) will also produce an old
-          # match, just like hidden files. A deprecation warning would be wrong
-          # for these.
-          if path.split(File::SEPARATOR).none? { |s| s.start_with?('.') }
-            issue_deprecation_warning(basename, pattern, config_path)
-          end
+          issue_deprecation_warning(basename, pattern, config_path)
         end
         old_match || new_match
       when Regexp
@@ -49,6 +45,10 @@ module RuboCop
                     end
       warn("Warning: Deprecated pattern style '#{pattern}' in " \
            "#{config_path}#{instruction}")
+    end
+
+    def hidden?(path_component)
+      path_component =~ /^\.[^.]/
     end
   end
 end

--- a/spec/rubocop/cli_spec.rb
+++ b/spec/rubocop/cli_spec.rb
@@ -2209,9 +2209,11 @@ describe RuboCop::CLI, :isolated_environment do
       create_file('regexp', 'x=0')
       create_file('.dot1/file.rb', 'x=0') # Hidden but explicitly included
       create_file('.dot2/file.rb', 'x=0') # Hidden, excluded by default
+      create_file('.dot3/file.rake', 'x=0') # Hidden, not included by wildcard
       create_file('.rubocop.yml', ['AllCops:',
                                    '  Include:',
                                    '    - example',
+                                   '    - "**/*.rake"',
                                    '    - !ruby/regexp /regexp$/',
                                    '    - .dot1/**/*'
                                   ])

--- a/spec/rubocop/path_util_spec.rb
+++ b/spec/rubocop/path_util_spec.rb
@@ -23,6 +23,8 @@ describe RuboCop::PathUtil do
       create_file('dir/files', '')
       create_file('dir/dir/file', '')
       create_file('dir/sub/file', '')
+      create_file('dir/.hidden/file', '')
+      create_file('dir/.hidden_file', '')
       $stderr = StringIO.new
     end
 
@@ -36,6 +38,20 @@ describe RuboCop::PathUtil do
           .to eq(["Warning: Deprecated pattern style 'dir/**' in " \
                   ".rubocop.yml. Change to 'dir/**/*'.",
                   ''].join("\n"))
+      end
+
+      it 'does not match dir/** for file in hidden dir' do
+        expect(subject.match_path?('dir/**', 'dir/.hidden/file',
+                                   '.rubocop.yml'))
+          .to be_falsey
+        expect($stderr.string).to eq('')
+      end
+
+      it 'does not match dir/** for hidden file' do
+        expect(subject.match_path?('dir/**', 'dir/.hidden_file',
+                                   '.rubocop.yml'))
+          .to be_falsey
+        expect($stderr.string).to eq('')
       end
 
       it 'matches strings to the basename and prints warning' do
@@ -67,6 +83,12 @@ describe RuboCop::PathUtil do
       expect(subject.match_path?('**/file',  'file', '')).to be_truthy
 
       expect(subject.match_path?('sub/*',    'dir/sub/file', '')).to be_falsey
+
+      expect(subject.match_path?('**/*', 'dir/.hidden/file', '')).to be_falsey
+      expect(subject.match_path?('**/*', 'dir/.hidden_file', '')).to be_falsey
+      expect(subject.match_path?('**/.*/*', 'dir/.hidden/file', ''))
+        .to be_truthy
+      expect(subject.match_path?('**/.*', 'dir/.hidden_file', '')).to be_truthy
     end
 
     it 'matches regexps' do


### PR DESCRIPTION
The logic for avoid the matching of hidden directories was almost there already. We used it for not printing deprecation warnings, so the change is to use it for not returning true in `PathUtil#match_path?`.