### PR TITLE
[Fix #1734] optimize hidden dirs search

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,7 @@
 
 * [#1397](https://github.com/bbatsov/rubocop/issues/1397): `UnneededPercentX` renamed to `CommandLiteral`. The cop can be configured to enforce using either `%x` or backticks around command literals, or using `%x` around multi-line commands and backticks around single-line commands. The cop ignores heredoc commands. ([@bquorning][])
 * [#1020](https://github.com/bbatsov/rubocop/issues/1020): Removed the `MaxSlashes` configuration option for `RegexpLiteral`. Instead, the cop can be configured to enforce using either `%r` or slashes around regular expressions, or using `%r` around multi-line regexes and slashes around single-line regexes. ([@bquorning][])
+* [#1734](https://github.com/bbatsov/rubocop/issues/1734): The default exclusion of hidden directories has been optimized for speed. ([@jonas054][])
 
 ## 0.29.1 (13/02/2015)
 

--- a/lib/rubocop/path_util.rb
+++ b/lib/rubocop/path_util.rb
@@ -6,6 +6,10 @@ module RuboCop
     module_function
 
     def relative_path(path, base_dir = Dir.pwd)
+      # Optimization for the common case where path begins with the base
+      # dir. Just cut off the first part.
+      return path[(base_dir.length + 1)..-1] if path.start_with?(base_dir)
+
       path_name = Pathname.new(File.expand_path(path))
       path_name.relative_path_from(Pathname.new(base_dir)).to_s
     end


### PR DESCRIPTION
A couple of optimizations to combat long start-up times when there are many files in a hidden directory.