### PR TITLE
[Fix #1735] Handle trailing space in LineEndConcatenation autocorrect

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,7 @@
 * [#1676](https://github.com/bbatsov/rubocop/pull/1676): Fix auto-correct in `Lambda` when a new multi-line lambda is used as an argument. ([@lumeet][])
 * [#1656](https://github.com/bbatsov/rubocop/issues/1656): Fix bug that would include hidden directories implicitly. ([@jonas054][])
 * [#1728](https://github.com/bbatsov/rubocop/pull/1728): Fix bug in `LiteralInInterpolation` and `AssignmentInCondition`. ([@ypresto][])
+* [#1735](https://github.com/bbatsov/rubocop/issues/1735): Handle trailing space in `LineEndConcatenation` autocorrect. ([@jonas054][])
 
 ### Changes
 

--- a/lib/rubocop/cop/style/line_end_concatenation.rb
+++ b/lib/rubocop/cop/style/line_end_concatenation.rb
@@ -36,6 +36,10 @@ module RuboCop
 
         def autocorrect(operator_range)
           @corrections << lambda do |corrector|
+            # Include any trailing whitespace so we don't create a syntax error.
+            operator_range = range_with_surrounding_space(operator_range,
+                                                          :right, nil,
+                                                          !:with_newline)
             corrector.replace(operator_range, '\\')
           end
         end

--- a/spec/rubocop/cop/style/line_end_concatenation_spec.rb
+++ b/spec/rubocop/cop/style/line_end_concatenation_spec.rb
@@ -152,6 +152,16 @@ describe RuboCop::Cop::Style::LineEndConcatenation do
     expect(corrected).to eq ['top = "test" \\', '"top"'].join("\n")
   end
 
+  # The "central auto-correction engine" can't handle intermediate states where
+  # the code has syntax errors, so it's important to fix the trailing
+  # whitespace in this cop.
+  it 'autocorrects a + with trailing whitespace to \\' do
+    corrected = autocorrect_source(cop,
+                                   ['top = "test" + ',
+                                    '"top"'])
+    expect(corrected).to eq ['top = "test" \\', '"top"'].join("\n")
+  end
+
   it 'autocorrects for chained concatenations and << calls' do
     corrected = autocorrect_source(cop,
                                    ['top = "test#{x}" <<',


### PR DESCRIPTION
A trailing space after a backslash is a syntax error, so it must be avoided.

Complexity went over the threshold, so a little refactoring was needed in `util.rb`.