### PR TITLE
Update FlatMap to account for flatten!

### DIFF
--- a/lib/rubocop/cop/performance/flat_map.rb
+++ b/lib/rubocop/cop/performance/flat_map.rb
@@ -15,14 +15,15 @@ module RuboCop
       #   [1, 2, 3, 4].map { |e| [e, e] }.flatten
       #   [1, 2, 3, 4].collect { |e| [e, e] }.flatten
       class FlatMap < Cop
-        MSG = 'Use `flat_map` instead of `%s...flatten`.'
+        MSG = 'Use `flat_map` instead of `%s...%s`.'
         FLATTEN_MULTIPLE_LEVELS = ' Beware, `flat_map` only flattens 1 level ' \
                                   'and `flatten` can be used to flatten ' \
                                   'multiple levels'
+        FLATTEN = [:flatten, :flatten!]
 
         def on_send(node)
           left, second_method, flatten_param  = *node
-          return unless second_method == :flatten
+          return unless FLATTEN.include?(second_method)
           flatten_level, = *flatten_param
           expression, = *left
           _array, first_method = *expression

--- a/spec/rubocop/cop/performance/flat_map_spec.rb
+++ b/spec/rubocop/cop/performance/flat_map_spec.rb
@@ -5,29 +5,29 @@ require 'spec_helper'
 describe RuboCop::Cop::Performance::FlatMap, :config do
   subject(:cop) { described_class.new(config) }
 
-  shared_examples 'map_and_collect' do |method|
-    it "registers an offense when calling #{method}...flatten(1)" do
-      inspect_source(cop, "[1, 2, 3, 4].#{method} { |e| [e, e] }.flatten(1)")
+  shared_examples 'map_and_collect' do |method, flatten|
+    it "registers an offense when calling #{method}...#{flatten}(1)" do
+      inspect_source(cop, "[1, 2, 3, 4].#{method} { |e| [e, e] }.#{flatten}(1)")
 
       expect(cop.messages)
-        .to eq(["Use `flat_map` instead of `#{method}...flatten`."])
+        .to eq(["Use `flat_map` instead of `#{method}...#{flatten}`."])
     end
 
-    it "does not register an offense when calling #{method}...flatten " \
+    it "does not register an offense when calling #{method}...#{flatten} " \
       'with a number greater than 1' do
-      inspect_source(cop, "[1, 2, 3, 4].#{method} { |e| [e, e] }.flatten(3)")
+      inspect_source(cop, "[1, 2, 3, 4].#{method} { |e| [e, e] }.#{flatten}(3)")
 
       expect(cop.messages).to be_empty
     end
 
-    it "does not register an offense when calling #{method}!...flatten!" do
-      inspect_source(cop, "[1, 2, 3, 4].#{method}! { |e| [e, e] }.flatten!")
+    it "does not register an offense when calling #{method}!...#{flatten}" do
+      inspect_source(cop, "[1, 2, 3, 4].#{method}! { |e| [e, e] }.#{flatten}")
 
       expect(cop.messages).to be_empty
     end
 
-    it "corrects #{method}..flatten(1) to flat_map" do
-      source = "[1, 2].#{method} { |e| [e, e] }.flatten(1)"
+    it "corrects #{method}..#{flatten}(1) to flat_map" do
+      source = "[1, 2].#{method} { |e| [e, e] }.#{flatten}(1)"
       new_source = autocorrect_source(cop, source)
 
       expect(new_source).to eq('[1, 2].flat_map { |e| [e, e] }')
@@ -42,20 +42,23 @@ describe RuboCop::Cop::Performance::FlatMap, :config do
                           })
     end
 
-    it_behaves_like('map_and_collect', 'map')
-    it_behaves_like('map_and_collect', 'collect')
+    shared_examples 'flatten_with_params_disabled' do |method, flatten|
+      it "does not registers an offense when calling #{method}...#{flatten}" do
+        inspect_source(cop, "[1, 2, 3, 4].map { |e| [e, e] }.#{flatten}")
 
-    it 'does not registers an offense when calling map...flatten' do
-      inspect_source(cop, '[1, 2, 3, 4].map { |e| [e, e] }.flatten')
-
-      expect(cop.messages).to be_empty
+        expect(cop.messages).to be_empty
+      end
     end
 
-    it 'does not registers an offense when calling collect...flatten' do
-      inspect_source(cop, '[1, 2, 3, 4].collect { |e| [e, e] }.flatten')
+    it_behaves_like('map_and_collect', 'map', 'flatten')
+    it_behaves_like('map_and_collect', 'map', 'flatten!')
+    it_behaves_like('map_and_collect', 'collect', 'flatten')
+    it_behaves_like('map_and_collect', 'collect', 'flatten!')
 
-      expect(cop.messages).to be_empty
-    end
+    it_behaves_like('flatten_with_params_disabled', 'map', 'flatten')
+    it_behaves_like('flatten_with_params_disabled', 'collect', 'flatten')
+    it_behaves_like('flatten_with_params_disabled', 'map', 'flatten!')
+    it_behaves_like('flatten_with_params_disabled', 'collect', 'flatten!')
   end
 
   describe 'configured to warn when flatten is not called with parameters' do
@@ -66,39 +69,32 @@ describe RuboCop::Cop::Performance::FlatMap, :config do
                           })
     end
 
-    it_behaves_like('map_and_collect', 'map')
-    it_behaves_like('map_and_collect', 'collect')
+    shared_examples 'flatten_with_params_enabled' do |method, flatten|
+      it "registers an offense when calling #{method}...#{flatten}" do
+        inspect_source(cop, "[1, 2, 3, 4].map { |e| [e, e] }.#{flatten}")
 
-    it 'does not registers an offense when calling map...flatten' do
-      inspect_source(cop, '[1, 2, 3, 4].map { |e| [e, e] }.flatten')
+        expect(cop.messages)
+          .to eq(["Use `flat_map` instead of `map...#{flatten}`. " \
+               'Beware, `flat_map` only flattens 1 level and `flatten` ' \
+               'can be used to flatten multiple levels'])
+      end
 
-      expect(cop.messages)
-        .to eq(['Use `flat_map` instead of `map...flatten`. ' \
-             'Beware, `flat_map` only flattens 1 level and `flatten` ' \
-             'can be used to flatten multiple levels'])
+      it "will not correct #{method}..#{flatten} to flat_map" do
+        source = "[1, 2].map { |e| [e, e] }.#{flatten}"
+        new_source = autocorrect_source(cop, source)
+
+        expect(new_source).to eq("[1, 2].map { |e| [e, e] }.#{flatten}")
+      end
     end
 
-    it 'does not registers an offense when calling collect...flatten' do
-      inspect_source(cop, '[1, 2, 3, 4].collect { |e| [e, e] }.flatten')
+    it_behaves_like('map_and_collect', 'map', 'flatten')
+    it_behaves_like('map_and_collect', 'map', 'flatten!')
+    it_behaves_like('map_and_collect', 'collect', 'flatten')
+    it_behaves_like('map_and_collect', 'collect', 'flatten!')
 
-      expect(cop.messages)
-        .to eq(['Use `flat_map` instead of `collect...flatten`. ' \
-             'Beware, `flat_map` only flattens 1 level and `flatten` ' \
-             'can be used to flatten multiple levels'])
-    end
-
-    it 'will not correct map..flatten to flat_map' do
-      source = '[1, 2].map { |e| [e, e] }.flatten'
-      new_source = autocorrect_source(cop, source)
-
-      expect(new_source).to eq('[1, 2].map { |e| [e, e] }.flatten')
-    end
-
-    it 'will not correct collect..flatten to flat_map' do
-      source = '[1, 2].collect { |e| [e, e] }.flatten'
-      new_source = autocorrect_source(cop, source)
-
-      expect(new_source).to eq('[1, 2].collect { |e| [e, e] }.flatten')
-    end
+    it_behaves_like('flatten_with_params_enabled', 'map', 'flatten')
+    it_behaves_like('flatten_with_params_enabled', 'collect', 'flatten')
+    it_behaves_like('flatten_with_params_enabled', 'map', 'flatten!')
+    it_behaves_like('flatten_with_params_enabled', 'collect', 'flatten!')
   end
 end


### PR DESCRIPTION
To my surprise, `map...flatten!` performs even worse than calling `map...flatten`

```ruby
ARRAY = (1..100).to_a

def slow
  ARRAY.map { |e| [e, e] }.flatten
end

def fast
  ARRAY.flat_map { |e| [e, e] }
end

def flatten_bang
  ARRAY.map { |e| [e, e] }.flatten!
end

Benchmark.ips do |x|
  x.report('map..flatten') { slow }
  x.report('map..flatten!') { flatten_bang }
  x.report('flat_map') { fast }
  x.compare!
end

Calculating -------------------------------------
        map..flatten     2.678k i/100ms
       map..flatten!     2.349k i/100ms
            flat_map     3.368k i/100ms
-------------------------------------------------
        map..flatten     27.831k (± 6.2%) i/s -    139.256k
       map..flatten!     24.652k (±10.0%) i/s -    122.148k
            flat_map     34.229k (± 7.0%) i/s -    171.768k

Comparison:
            flat_map:    34228.7 i/s
        map..flatten:    27831.1 i/s - 1.23x slower
       map..flatten!:    24651.5 i/s - 1.39x slower
```