### PR TITLE
Fix comment detection in Documentation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,7 @@
 * [#1735](https://github.com/bbatsov/rubocop/issues/1735): Handle trailing space in `LineEndConcatenation` autocorrect. ([@jonas054][])
 * [#1750](https://github.com/bbatsov/rubocop/issues/1750): Escape offending code lines output by the HTML formatter in case they contain markup. ([@jonas054][])
 * [#1541](https://github.com/bbatsov/rubocop/issues/1541): No inspection of text that follows `__END__`. ([@jonas054][])
+* Fix comment detection in `Style/Documentation`. ([@lumeet][])
 
 ### Changes
 

--- a/lib/rubocop/cop/style/documentation.rb
+++ b/lib/rubocop/cop/style/documentation.rb
@@ -70,10 +70,17 @@ module RuboCop
           preceding_comment = ast_with_comments[node].last
           distance = node.loc.keyword.line - preceding_comment.loc.line
           return false if distance > 1
+          return false unless comment_line_only?(preceding_comment)
 
           # As long as there's at least one comment line that isn't an
           # annotation, it's OK.
           ast_with_comments[node].any? { |comment| !annotation?(comment) }
+        end
+
+        def comment_line_only?(comment)
+          source_buffer = comment.loc.expression.source_buffer
+          comment_line = source_buffer.source_line(comment.loc.line)
+          comment_line =~ /^\s*#/
         end
 
         # The :nodoc: comment is not actually associated with the class/module

--- a/spec/rubocop/cop/style/documentation_spec.rb
+++ b/spec/rubocop/cop/style/documentation_spec.rb
@@ -144,6 +144,17 @@ describe RuboCop::Cop::Style::Documentation do
     end.to_not raise_error
   end
 
+  it 'registers an offense if the comment line contains code' do
+    inspect_source(cop,
+                   ['module A # The A Module',
+                    '  class B',
+                    '    C = 1',
+                    '  end',
+                    'end'
+                   ])
+    expect(cop.offenses.size).to eq 1
+  end
+
   context 'with # :nodoc:' do
     %w(class module).each do |keyword|
       it "accepts non-namespace #{keyword} without documentation" do


### PR DESCRIPTION
`Style/Documentation` only accepts comments on lines that include
nothing else but the comment itself.

For example, a class definition after a `# :nodoc:`-line doesn't get reported.

On a side note, related to this, I'm wondering if `Style/InlineComment` is actually doing what is was meant to do.