### PR TITLE
[Fix #1750] Escape offending code lines output by HTMLFormatter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,7 @@
 * [#1656](https://github.com/bbatsov/rubocop/issues/1656): Fix bug that would include hidden directories implicitly. ([@jonas054][])
 * [#1728](https://github.com/bbatsov/rubocop/pull/1728): Fix bug in `LiteralInInterpolation` and `AssignmentInCondition`. ([@ypresto][])
 * [#1735](https://github.com/bbatsov/rubocop/issues/1735): Handle trailing space in `LineEndConcatenation` autocorrect. ([@jonas054][])
+* [#1750](https://github.com/bbatsov/rubocop/issues/1750): Escape offending code lines output by the HTML formatter in case they contain markup. ([@jonas054][])
 
 ### Changes
 

--- a/lib/rubocop/formatter/html_formatter.rb
+++ b/lib/rubocop/formatter/html_formatter.rb
@@ -1,5 +1,6 @@
 # encoding: utf-8
 
+require 'cgi'
 require 'erb'
 require 'ostruct'
 require 'base64'
@@ -101,11 +102,16 @@ module RuboCop
 
           source_line = location.source_line
 
-          source_line[0...column_range.begin] +
+          escape(source_line[0...column_range.begin]) +
             "<span class=\"highlight #{offense.severity}\">" +
-            source_line[column_range] +
+            escape(source_line[column_range]) +
             '</span>' +
-            source_line[column_range.end..-1]
+            escape(source_line[column_range.end..-1])
+        end
+
+        def escape(s)
+          # Single quotes not escaped in Ruby 1.9, so add extra substitution.
+          CGI.escapeHTML(s).gsub(/'/, '&#39;')
         end
 
         def base64_encoded_logo_image

--- a/spec/fixtures/html_formatter/expected.html
+++ b/spec/fixtures/html_formatter/expected.html
@@ -311,7 +311,7 @@ TvFXMeuCkZPcaEBLqvgPBhCuiZo8+sAAAAAASUVORK5CYII=
     <div class="information">
       <div class="infobox">
         3 files inspected,
-        13 offenses detected
+        15 offenses detected
       </div>
     </div>
     <div id="offenses">
@@ -328,7 +328,7 @@ TvFXMeuCkZPcaEBLqvgPBhCuiZo8+sAAAAAASUVORK5CYII=
               <span class="message">Missing top-level class documentation comment.</span>
             </div>
             
-            <pre><code><span class="highlight convention">class</span> ApplicationController < ActionController::Base</code></pre>
+            <pre><code><span class="highlight convention">class</span> ApplicationController &lt; ActionController::Base</code></pre>
             
           </div>
           
@@ -348,7 +348,7 @@ TvFXMeuCkZPcaEBLqvgPBhCuiZo8+sAAAAAASUVORK5CYII=
               <span class="message">Missing top-level class documentation comment.</span>
             </div>
             
-            <pre><code><span class="highlight convention">class</span> BooksController < ApplicationController</code></pre>
+            <pre><code><span class="highlight convention">class</span> BooksController &lt; ApplicationController</code></pre>
             
           </div>
           
@@ -359,7 +359,7 @@ TvFXMeuCkZPcaEBLqvgPBhCuiZo8+sAAAAAASUVORK5CYII=
               <span class="message">Line is too long. [83/80]</span>
             </div>
             
-            <pre><code>        format.html { redirect_to @book, notice: 'Book was successfully created.<span class="highlight convention">' }</span></code></pre>
+            <pre><code>        format.html { redirect_to @book, notice: &#39;Book was successfully created.<span class="highlight convention">&#39; }</span></code></pre>
             
           </div>
           
@@ -370,7 +370,7 @@ TvFXMeuCkZPcaEBLqvgPBhCuiZo8+sAAAAAASUVORK5CYII=
               <span class="message">Line is too long. [83/80]</span>
             </div>
             
-            <pre><code>        format.html { redirect_to @book, notice: 'Book was successfully updated.<span class="highlight convention">' }</span></code></pre>
+            <pre><code>        format.html { redirect_to @book, notice: &#39;Book was successfully updated.<span class="highlight convention">&#39; }</span></code></pre>
             
           </div>
           
@@ -381,7 +381,7 @@ TvFXMeuCkZPcaEBLqvgPBhCuiZo8+sAAAAAASUVORK5CYII=
               <span class="message">Line is too long. [87/80]</span>
             </div>
             
-            <pre><code>      format.html { redirect_to books_url, notice: 'Book was successfully destro<span class="highlight convention">yed.' }</span></code></pre>
+            <pre><code>      format.html { redirect_to books_url, notice: &#39;Book was successfully destro<span class="highlight convention">yed.&#39; }</span></code></pre>
             
           </div>
           
@@ -435,7 +435,7 @@ TvFXMeuCkZPcaEBLqvgPBhCuiZo8+sAAAAAASUVORK5CYII=
       
       
       <div class="offense-box">
-        <div class="box-title"><h3>app/models/book.rb - 4 offenses</h3></div>
+        <div class="box-title"><h3>app/models/book.rb - 6 offenses</h3></div>
         <div class="offense-reports">
           
           <div class="report">
@@ -445,7 +445,7 @@ TvFXMeuCkZPcaEBLqvgPBhCuiZo8+sAAAAAASUVORK5CYII=
               <span class="message">Missing top-level class documentation comment.</span>
             </div>
             
-            <pre><code><span class="highlight convention">class</span> Book < ActiveRecord::Base</code></pre>
+            <pre><code><span class="highlight convention">class</span> Book &lt; ActiveRecord::Base</code></pre>
             
           </div>
           
@@ -482,6 +482,28 @@ TvFXMeuCkZPcaEBLqvgPBhCuiZo8+sAAAAAASUVORK5CYII=
             
           </div>
           
+          <div class="report">
+            <div class="meta">
+              <span class="location">Line #4</span> –
+              <span class="severity convention">convention:</span>
+              <span class="message">Avoid using <code>rescue</code> in its modifier form.</span>
+            </div>
+            
+            <pre><code>    <span class="highlight convention">Regexp.new(/\A&lt;p&gt;(.*)&lt;\/p&gt;\Z/m).match(full_document)[1] rescue full_document</span></code></pre>
+            
+          </div>
+          
+          <div class="report">
+            <div class="meta">
+              <span class="location">Line #4</span> –
+              <span class="severity convention">convention:</span>
+              <span class="message">Use <code>%r</code> around regular expression.</span>
+            </div>
+            
+            <pre><code>    Regexp.new(<span class="highlight convention">/\A&lt;p&gt;(.*)&lt;\/p&gt;\Z/m</span>).match(full_document)[1] rescue full_document</code></pre>
+            
+          </div>
+          
         </div>
       </div>
       
@@ -489,7 +511,7 @@ TvFXMeuCkZPcaEBLqvgPBhCuiZo8+sAAAAAASUVORK5CYII=
     </div>
     <footer>
       Generated by <a href="https://github.com/bbatsov/rubocop">RuboCop</a>
-      <span class="version">0.26.1</span>
+      <span class="version">0.29.1</span>
     </footer>
   </body>
 </html>

--- a/spec/fixtures/html_formatter/project/app/models/book.rb
+++ b/spec/fixtures/html_formatter/project/app/models/book.rb
@@ -1,5 +1,6 @@
 class Book < ActiveRecord::Base
   def someMethod
     foo = bar = baz
+    Regexp.new(/\A<p>(.*)<\/p>\Z/m).match(full_document)[1] rescue full_document
   end
 end


### PR DESCRIPTION
In case they contain markup.