### PR TITLE
[Fix #1541] Do not inspect after __END__

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,7 @@
 * [#1728](https://github.com/bbatsov/rubocop/pull/1728): Fix bug in `LiteralInInterpolation` and `AssignmentInCondition`. ([@ypresto][])
 * [#1735](https://github.com/bbatsov/rubocop/issues/1735): Handle trailing space in `LineEndConcatenation` autocorrect. ([@jonas054][])
 * [#1750](https://github.com/bbatsov/rubocop/issues/1750): Escape offending code lines output by the HTML formatter in case they contain markup. ([@jonas054][])
+* [#1541](https://github.com/bbatsov/rubocop/issues/1541): No inspection of text that follows `__END__`. ([@jonas054][])
 
 ### Changes
 

--- a/lib/rubocop/cop/style/end_of_line.rb
+++ b/lib/rubocop/cop/style/end_of_line.rb
@@ -8,7 +8,12 @@ module RuboCop
         MSG = 'Carriage return character detected.'
 
         def investigate(processed_source)
+          last_token = processed_source.tokens.last
+          last_line =
+            last_token ? last_token.pos.line : processed_source.lines.length
+
           processed_source.raw_source.each_line.with_index do |line, index|
+            break if index >= last_line
             next unless line =~ /\r$/
 
             range =

--- a/lib/rubocop/cop/style/trailing_blank_lines.rb
+++ b/lib/rubocop/cop/style/trailing_blank_lines.rb
@@ -12,6 +12,13 @@ module RuboCop
           sb = processed_source.buffer
           return if sb.source.empty?
 
+          # The extra text that comes after the last token could be __END__
+          # followed by some data to read. If so, we don't check it because
+          # there could be good reasons why it needs to end with a certain
+          # number of newlines.
+          extra = sb.source[processed_source.tokens.last.pos.end_pos..-1]
+          return if extra.strip.start_with?('__END__')
+
           whitespace_at_end = sb.source[/\s*\Z/]
           blank_lines = whitespace_at_end.count("\n") - 1
           wanted_blank_lines = style == :final_newline ? 0 : 1

--- a/lib/rubocop/processed_source.rb
+++ b/lib/rubocop/processed_source.rb
@@ -36,8 +36,19 @@ module RuboCop
       comment_config.cop_disabled_line_ranges
     end
 
+    # Returns the source lines, line break characters removed, excluding a
+    # possible __END__ and everything that comes after.
     def lines
-      @lines ||= raw_source.lines.map(&:chomp)
+      @lines ||= begin
+        all_lines = raw_source.lines.map(&:chomp)
+        last_token_line = tokens.any? ? tokens.last.pos.line : all_lines.count
+        result = []
+        all_lines.each_with_index do |line, ix|
+          break if ix >= last_token_line && line == '__END__'
+          result << line
+        end
+        result
+      end
     end
 
     def [](*args)

--- a/spec/rubocop/cop/metrics/line_length_spec.rb
+++ b/spec/rubocop/cop/metrics/line_length_spec.rb
@@ -23,6 +23,13 @@ describe RuboCop::Cop::Metrics::LineLength, :config do
     expect(cop.offenses).to be_empty
   end
 
+  it 'registers an offense for long line before __END__ but not after' do
+    inspect_source(cop, ['#' * 150,
+                         '__END__',
+                         '#' * 200])
+    expect(cop.messages).to eq(['Line is too long. [150/80]'])
+  end
+
   context 'when AllowURI option is enabled' do
     let(:cop_config) { { 'Max' => 80, 'AllowURI' => true } }
 

--- a/spec/rubocop/cop/style/comment_indentation_spec.rb
+++ b/spec/rubocop/cop/style/comment_indentation_spec.rb
@@ -57,6 +57,14 @@ describe RuboCop::Cop::Style::CommentIndentation do
     end
   end
 
+  it 'registers offenses before __END__ but not after' do
+    inspect_source(cop, [' #',
+                         '__END__',
+                         '  #'])
+    expect(cop.messages)
+      .to eq(['Incorrect indentation detected (column 1 instead of 0).'])
+  end
+
   context 'around program structure keywords' do
     it 'accepts correctly indented comments' do
       inspect_source(cop, ['#',

--- a/spec/rubocop/cop/style/end_of_line_spec.rb
+++ b/spec/rubocop/cop/style/end_of_line_spec.rb
@@ -6,6 +6,11 @@ require 'tempfile'
 describe RuboCop::Cop::Style::EndOfLine do
   subject(:cop) { described_class.new }
 
+  it 'accepts an empty file' do
+    inspect_source_file(cop, '')
+    expect(cop.offenses).to be_empty
+  end
+
   it 'registers an offense for CR+LF' do
     inspect_source_file(cop, ['x=0', '', "y=1\r"])
     expect(cop.messages).to eq(['Carriage return character detected.'])
@@ -19,6 +24,13 @@ describe RuboCop::Cop::Style::EndOfLine do
   it 'registers an offense for CR at end of file' do
     inspect_source_file(cop, "x=0\r")
     expect(cop.messages).to eq(['Carriage return character detected.'])
+  end
+
+  it 'does not register offenses after __END__' do
+    inspect_source(cop, ['x=0',
+                         '__END__',
+                         "x=0\r"])
+    expect(cop.offenses).to be_empty
   end
 
   shared_examples 'iso-8859-15' do

--- a/spec/rubocop/cop/style/tab_spec.rb
+++ b/spec/rubocop/cop/style/tab_spec.rb
@@ -20,6 +20,13 @@ describe RuboCop::Cop::Style::Tab do
     expect(cop.offenses.size).to eq(1)
   end
 
+  it 'registers offenses before __END__ but not after' do
+    inspect_source(cop, ["\tx = 0",
+                         '__END__',
+                         "\tx = 0"])
+    expect(cop.messages).to eq(['Tab detected.'])
+  end
+
   it 'accepts a line with tab in a string' do
     inspect_source(cop, "(x = \"\t\")")
     expect(cop.offenses).to be_empty

--- a/spec/rubocop/cop/style/trailing_blank_lines_spec.rb
+++ b/spec/rubocop/cop/style/trailing_blank_lines_spec.rb
@@ -18,6 +18,15 @@ describe RuboCop::Cop::Style::TrailingBlankLines, :config do
       expect(cop.offenses).to be_empty
     end
 
+    it 'accepts final blank lines if they come after __END__' do
+      inspect_source(cop, ['x = 0',
+                           '',
+                           '__END__',
+                           '',
+                           ''])
+      expect(cop.offenses).to be_empty
+    end
+
     it 'registers an offense for multiple trailing blank lines' do
       inspect_source(cop, ['x = 0', '', '', '', ''])
       expect(cop.offenses.size).to eq(1)

--- a/spec/rubocop/cop/style/trailing_whitespace_spec.rb
+++ b/spec/rubocop/cop/style/trailing_whitespace_spec.rb
@@ -6,14 +6,62 @@ describe RuboCop::Cop::Style::TrailingWhitespace do
   subject(:cop) { described_class.new }
 
   it 'registers an offense for a line ending with space' do
-    source = 'x = 0 '
-    inspect_source(cop, source)
+    inspect_source(cop, 'x = 0 ')
+    expect(cop.offenses.size).to eq(1)
+  end
+
+  it 'registers an offense for a blank line with space' do
+    inspect_source(cop, '  ')
     expect(cop.offenses.size).to eq(1)
   end
 
   it 'registers an offense for a line ending with tab' do
     inspect_source(cop, "x = 0\t")
     expect(cop.offenses.size).to eq(1)
+  end
+
+  it 'registers an offense for trailing whitespace in a heredoc string' do
+    inspect_source(cop, ['x = <<END',
+                         '  Hi   ',
+                         'END'])
+    expect(cop.offenses.size).to eq(1)
+  end
+
+  it 'registers offenses before __END__ but not after' do
+    inspect_source(cop, ["x = 0\t",
+                         ' ',
+                         '__END__',
+                         "x = 0\t"])
+    expect(cop.offenses.map(&:line)).to eq([1, 2])
+  end
+
+  it 'is not fooled by __END__ within a documentation comment' do
+    inspect_source(cop, ["x = 0\t",
+                         '=begin',
+                         '__END__',
+                         '=end',
+                         "x = 0\t"])
+    expect(cop.offenses.map(&:line)).to eq([1, 5])
+  end
+
+  it 'is not fooled by heredoc containing __END__' do
+    inspect_source(cop, ['x1 = <<END ',
+                         '__END__',
+                         "x2 = 0\t",
+                         'END',
+                         "x3 = 0\t"])
+    expect(cop.offenses.map(&:line)).to eq([1, 3, 5])
+  end
+
+  it 'is not fooled by heredoc containing __END__ within a doc comment' do
+    inspect_source(cop, ['x1 = <<END ',
+                         '=begin  ',
+                         '__END__',
+                         '=end',
+                         "x2 = 0\t",
+                         'END',
+                         "x3 = 0\t"])
+    expect(cop.offenses.map(&:line)).to eq([1, 2, 5, 7])
   end
 
   it 'accepts a line without trailing whitespace' do


### PR DESCRIPTION
Fixed the cops that suffer from this problem. Checked performance afterwards and didn't see any significant degradation.