### PR TITLE
[Fix #1637] Fix UnusedArgument with binding

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,6 +52,7 @@
 * [#1750](https://github.com/bbatsov/rubocop/issues/1750): Escape offending code lines output by the HTML formatter in case they contain markup. ([@jonas054][])
 * [#1541](https://github.com/bbatsov/rubocop/issues/1541): No inspection of text that follows `__END__`. ([@jonas054][])
 * Fix comment detection in `Style/Documentation`. ([@lumeet][])
+* [#1637](https://github.com/bbatsov/rubocop/issues/1637): Fix handling of `binding` calls in `UnusedBlockArgument` and `UnusedMethodArgument`. ([@lumeet][])
 
 ### Changes
 

--- a/lib/rubocop/cop/variable_force/reference.rb
+++ b/lib/rubocop/cop/variable_force/reference.rb
@@ -10,7 +10,7 @@ module RuboCop
         VARIABLE_REFERENCE_TYPES = (
           [VARIABLE_REFERENCE_TYPE] +
           OPERATOR_ASSIGNMENT_TYPES +
-          [ZERO_ARITY_SUPER_TYPE]
+          [ZERO_ARITY_SUPER_TYPE, SEND_TYPE]
         ).freeze
 
         attr_reader :node, :scope
@@ -32,10 +32,16 @@ module RuboCop
         #       super
         #     end
         #
-        # In this case, the variable `foo` is not explicitly referenced,
-        # but it can be considered used implicitly by the `super`.
+        # Another case is `binding`:
+        #
+        #     def some_method(foo)
+        #       do_something(binding)
+        #     end
+        #
+        # In these cases, the variable `foo` is not explicitly referenced,
+        # but it can be considered used implicitly by the `super` or `binding`.
         def explicit?
-          @node.type != ZERO_ARITY_SUPER_TYPE
+          ![ZERO_ARITY_SUPER_TYPE, SEND_TYPE].include?(@node.type)
         end
       end
     end

--- a/spec/rubocop/cop/lint/underscore_prefixed_variable_name_spec.rb
+++ b/spec/rubocop/cop/lint/underscore_prefixed_variable_name_spec.rb
@@ -120,59 +120,61 @@ describe RuboCop::Cop::Lint::UnderscorePrefixedVariableName do
     end
   end
 
-  context 'in a method calling `super` without arguments' do
-    context 'when an underscore-prefixed argument is not used explicitly' do
-      let(:source) { <<-END }
-        def some_method(*_)
-          super
-        end
-      END
+  %w(super binding).each do |keyword|
+    context "in a method calling `#{keyword}` without arguments" do
+      context 'when an underscore-prefixed argument is not used explicitly' do
+        let(:source) { <<-END }
+          def some_method(*_)
+            #{keyword}
+          end
+        END
 
-      it 'accepts' do
-        expect(cop.offenses).to be_empty
+        it 'accepts' do
+          expect(cop.offenses).to be_empty
+        end
+      end
+
+      context 'when an underscore-prefixed argument is used explicitly' do
+        let(:source) { <<-END }
+          def some_method(*_)
+            #{keyword}
+            puts _
+          end
+        END
+
+        it 'registers an offense' do
+          expect(cop.offenses.size).to eq(1)
+          expect(cop.offenses.first.line).to eq(1)
+          expect(cop.highlights).to eq(['_'])
+        end
       end
     end
 
-    context 'when an underscore-prefixed argument is used explicitly' do
-      let(:source) { <<-END }
-        def some_method(*_)
-          super
-          puts _
-        end
-      END
+    context "in a method calling `#{keyword}` with arguments" do
+      context 'when an underscore-prefixed argument is not used' do
+        let(:source) { <<-END }
+          def some_method(*_)
+            #{keyword}(:something)
+          end
+        END
 
-      it 'registers an offense' do
-        expect(cop.offenses.size).to eq(1)
-        expect(cop.offenses.first.line).to eq(1)
-        expect(cop.highlights).to eq(['_'])
+        it 'accepts' do
+          expect(cop.offenses).to be_empty
+        end
       end
-    end
-  end
 
-  context 'in a method calling `super` with arguments' do
-    context 'when an underscore-prefixed argument is not used' do
-      let(:source) { <<-END }
-        def some_method(*_)
-          super(:something)
+      context 'when an underscore-prefixed argument is used explicitly' do
+        let(:source) { <<-END }
+          def some_method(*_)
+            #{keyword}(*_)
+          end
+        END
+
+        it 'registers an offense' do
+          expect(cop.offenses.size).to eq(1)
+          expect(cop.offenses.first.line).to eq(1)
+          expect(cop.highlights).to eq(['_'])
         end
-      END
-
-      it 'accepts' do
-        expect(cop.offenses).to be_empty
-      end
-    end
-
-    context 'when an underscore-prefixed argument is used explicitly' do
-      let(:source) { <<-END }
-        def some_method(*_)
-          super(*_)
-        end
-      END
-
-      it 'registers an offense' do
-        expect(cop.offenses.size).to eq(1)
-        expect(cop.offenses.first.line).to eq(1)
-        expect(cop.highlights).to eq(['_'])
       end
     end
   end


### PR DESCRIPTION
This patch ignores any offenses by `Style/UnusedBlockArgument` and
`Style/UnusedMethodArgument` when `binding` is called in their scopes
without arguments. Additionally, `UnderscorePrefixedVariableName` now
interprets a `binding` call as an implicit reference to all variables.

At the implementation level, I think this one resembles the case of `super`. When it comes to the specs, I've tried to follow the style of each file. I'm not sure if there's something that should be avoided or preferred, though.

This seems to fix #1713, too, but I thought it would be better to confirm that with some specs in another PR as soon as this one is alright.