### PR TITLE
Stop converting to 19 hash syntax when invalid

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,10 +12,12 @@
 * [#1791](https://github.com/bbatsov/rubocop/pull/1791): Fix autocorrection of `PercentLiteralDelimiters` with no content. ([@cshaffer][])
 * Fix handling of `while` and `until` with assignment in `IndentationWidth`. ([@lumeet][])
 * [#1793](https://github.com/bbatsov/rubocop/pull/1793): Fix bug in `TrailingComma` that caused `,` in comment to count as a trailing comma. ([@jonas054][])
+* [#1765](https://github.com/bbatsov/rubocop/pull/1765): Update 1.9 hash to stop triggering when the symbol is not valid in the 1.9 hash syntax. ([@crimsonknave][])
 
 ## 0.30.0 (06/04/2015)
 
 ### New features
+
 * [#1767](https://github.com/bbatsov/rubocop/pull/1767): Do not register offenses on non-enumerable select/find_all by `Performance/Detect`. ([@palkan][])
 * [#1600](https://github.com/bbatsov/rubocop/issues/1600): Add `line_count_based` and `semantic` styles to the `BlockDelimiters` (formerly `Blocks`) cop. ([@clowder][], [@mudge][])
 * [#1712](https://github.com/bbatsov/rubocop/pull/1712): Set `Offense#corrected?` to `true`, `false`, or `nil` when it was, wasn't, or can't be auto-corrected, respectively. ([@vassilevsky][])
@@ -1345,3 +1347,4 @@
 [@mudge]: https://github.com/mudge
 [@mzp]: https://github.com/mzp
 [@bankair]: https://github.com/bankair
+[@crimsonknave]: https://github.com/crimsonknave

--- a/lib/rubocop/cop/style/hash_syntax.rb
+++ b/lib/rubocop/cop/style/hash_syntax.rb
@@ -96,7 +96,13 @@ module RuboCop
           return false unless key.sym_type?
 
           sym_name = key.loc.expression.source
-          sym_name !~ /\A:["']|=\z/
+          valid_19_syntax_symbol?(sym_name)
+        end
+
+        def valid_19_syntax_symbol?(sym_name)
+          return false if sym_name =~ /\A:["']/
+          sym_name.sub!(/\A:/, '')
+          RuboCop::ProcessedSource.new("{ #{sym_name}: :foo }").valid_syntax?
         end
 
         def check(pairs, delim, msg)

--- a/lib/rubocop/cop/style/hash_syntax.rb
+++ b/lib/rubocop/cop/style/hash_syntax.rb
@@ -100,7 +100,6 @@ module RuboCop
         end
 
         def valid_19_syntax_symbol?(sym_name)
-          return false if sym_name =~ /\A:["']/
           sym_name.sub!(/\A:/, '')
           RuboCop::ProcessedSource.new("{ #{sym_name}: :foo }").valid_syntax?
         end

--- a/spec/rubocop/cop/style/hash_syntax_spec.rb
+++ b/spec/rubocop/cop/style/hash_syntax_spec.rb
@@ -51,6 +51,11 @@ describe RuboCop::Cop::Style::HashSyntax, :config do
         expect(cop.messages).to be_empty
       end
 
+      it 'accepts hash rockets when symbol characters are not supported' do
+        inspect_source(cop, 'x = { :[] => 0 }')
+        expect(cop.messages).to be_empty
+      end
+
       it 'registers offense when keys start with an uppercase letter' do
         inspect_source(cop, 'x = { :A => 0 }')
         expect(cop.messages).to eq(['Use the new Ruby 1.9 hash syntax.'])

--- a/spec/rubocop/cop/style/hash_syntax_spec.rb
+++ b/spec/rubocop/cop/style/hash_syntax_spec.rb
@@ -41,9 +41,18 @@ describe RuboCop::Cop::Style::HashSyntax, :config do
         expect(cop.messages).to be_empty
       end
 
-      it 'accepts hash rockets when symbol keys have string in them' do
-        inspect_source(cop, 'x = { :"string" => 0 }')
-        expect(cop.messages).to be_empty
+      context 'ruby < 2.2', ruby_less_than: 2.2 do
+        it 'accepts hash rockets when symbol keys have string in them' do
+          inspect_source(cop, 'x = { :"string" => 0 }')
+          expect(cop.messages).to be_empty
+        end
+      end
+
+      context 'ruby >= 2.2', ruby_greater_than_or_equal: 2.2 do
+        it 'registers an offense when symbol keys have strings in them' do
+          inspect_source(cop, 'x = { :"string" => 0 }')
+          expect(cop.messages).to eq(['Use the new Ruby 1.9 hash syntax.'])
+        end
       end
 
       it 'accepts hash rockets when symbol keys end with =' do
@@ -283,37 +292,57 @@ describe RuboCop::Cop::Style::HashSyntax, :config do
         expect(cop.config_to_allow_offenses).to eq('Enabled' => false)
       end
 
-      it 'accepts hash rockets when keys have whitespaces in them' do
-        inspect_source(cop, 'x = { :"t o" => 0, :b => 1 }')
-        expect(cop.messages).to be_empty
+      context 'ruby < 2.2', ruby_less_than: 2.2 do
+        it 'accepts hash rockets when keys have whitespaces in them' do
+          inspect_source(cop, 'x = { :"t o" => 0, :b => 1 }')
+          expect(cop.messages).to be_empty
+        end
+
+        it 'registers an offense when keys have whitespaces and mix styles' do
+          inspect_source(cop, 'x = { :"t o" => 0, b: 1 }')
+          expect(cop.messages).to eq(["Don't mix styles in the same hash."])
+          expect(cop.config_to_allow_offenses).to eq('Enabled' => false)
+        end
+
+        it 'accepts hash rockets when keys have special symbols in them' do
+          inspect_source(cop, 'x = { :"\tab" => 1, :b => 1 }')
+          expect(cop.messages).to be_empty
+        end
+
+        it 'registers an offense when keys have special symbols and '\
+          'mix styles' do
+          inspect_source(cop, 'x = { :"\tab" => 1, b: 1 }')
+          expect(cop.messages).to eq(["Don't mix styles in the same hash."])
+          expect(cop.config_to_allow_offenses).to eq('Enabled' => false)
+        end
+
+        it 'accepts hash rockets when keys start with a digit' do
+          inspect_source(cop, 'x = { :"1" => 1, :b => 1 }')
+          expect(cop.messages).to be_empty
+        end
+
+        it 'registers an offense when keys start with a digit and mix styles' do
+          inspect_source(cop, 'x = { :"1" => 1, b: 1 }')
+          expect(cop.messages).to eq(["Don't mix styles in the same hash."])
+          expect(cop.config_to_allow_offenses).to eq('Enabled' => false)
+        end
       end
 
-      it 'registers an offense when keys have whitespaces and mix styles' do
-        inspect_source(cop, 'x = { :"t o" => 0, b: 1 }')
-        expect(cop.messages).to eq(["Don't mix styles in the same hash."])
-        expect(cop.config_to_allow_offenses).to eq('Enabled' => false)
-      end
+      context 'ruby >= 2.2', ruby_greater_than_or_equal: 2.2 do
+        it 'registers an offense when keys have whitespaces in them' do
+          inspect_source(cop, 'x = { :"t o" => 0 }')
+          expect(cop.messages).to eq(['Use the new Ruby 1.9 hash syntax.'])
+        end
 
-      it 'accepts hash rockets when keys have special symbols in them' do
-        inspect_source(cop, 'x = { :"\tab" => 1, :b => 1 }')
-        expect(cop.messages).to be_empty
-      end
+        it 'registers an offense when keys have special symbols in them' do
+          inspect_source(cop, 'x = { :"\tab" => 1 }')
+          expect(cop.messages).to eq(['Use the new Ruby 1.9 hash syntax.'])
+        end
 
-      it 'registers an offense when keys have special symbols and mix styles' do
-        inspect_source(cop, 'x = { :"\tab" => 1, b: 1 }')
-        expect(cop.messages).to eq(["Don't mix styles in the same hash."])
-        expect(cop.config_to_allow_offenses).to eq('Enabled' => false)
-      end
-
-      it 'accepts hash rockets when keys start with a digit' do
-        inspect_source(cop, 'x = { :"1" => 1, :b => 1 }')
-        expect(cop.messages).to be_empty
-      end
-
-      it 'registers an offense when keys start with a digit and mix styles' do
-        inspect_source(cop, 'x = { :"1" => 1, b: 1 }')
-        expect(cop.messages).to eq(["Don't mix styles in the same hash."])
-        expect(cop.config_to_allow_offenses).to eq('Enabled' => false)
+        it 'accepts hash rockets when keys start with a digit' do
+          inspect_source(cop, 'x = { :"1" => 1 }')
+          expect(cop.messages).to eq(['Use the new Ruby 1.9 hash syntax.'])
+        end
       end
 
       it 'auto-corrects old to new style' do
@@ -399,37 +428,57 @@ describe RuboCop::Cop::Style::HashSyntax, :config do
         expect(cop.config_to_allow_offenses).to eq('Enabled' => false)
       end
 
-      it 'accepts hash rockets when keys have whitespaces in them' do
-        inspect_source(cop, 'x = { :"t o" => 0, :b => 1 }')
-        expect(cop.messages).to be_empty
+      context 'ruby < 2.2', ruby_less_than: 2.2 do
+        it 'accepts hash rockets when keys have whitespaces in them' do
+          inspect_source(cop, 'x = { :"t o" => 0, :b => 1 }')
+          expect(cop.messages).to be_empty
+        end
+
+        it 'registers an offense when keys have whitespaces and mix styles' do
+          inspect_source(cop, 'x = { :"t o" => 0, b: 1 }')
+          expect(cop.messages).to eq(["Don't mix styles in the same hash."])
+          expect(cop.config_to_allow_offenses).to eq('Enabled' => false)
+        end
+
+        it 'accepts hash rockets when keys have special symbols in them' do
+          inspect_source(cop, 'x = { :"\tab" => 1, :b => 1 }')
+          expect(cop.messages).to be_empty
+        end
+
+        it 'registers an offense when keys have special symbols and ' \
+          'mix styles' do
+          inspect_source(cop, 'x = { :"\tab" => 1, b: 1 }')
+          expect(cop.messages).to eq(["Don't mix styles in the same hash."])
+          expect(cop.config_to_allow_offenses).to eq('Enabled' => false)
+        end
+
+        it 'accepts hash rockets when keys start with a digit' do
+          inspect_source(cop, 'x = { :"1" => 1, :b => 1 }')
+          expect(cop.messages).to be_empty
+        end
+
+        it 'registers an offense when keys start with a digit and mix styles' do
+          inspect_source(cop, 'x = { :"1" => 1, b: 1 }')
+          expect(cop.messages).to eq(["Don't mix styles in the same hash."])
+          expect(cop.config_to_allow_offenses).to eq('Enabled' => false)
+        end
       end
 
-      it 'registers an offense when keys have whitespaces and mix styles' do
-        inspect_source(cop, 'x = { :"t o" => 0, b: 1 }')
-        expect(cop.messages).to eq(["Don't mix styles in the same hash."])
-        expect(cop.config_to_allow_offenses).to eq('Enabled' => false)
-      end
+      context 'ruby >= 2.2', ruby_greater_than_or_equal: 2.2 do
+        it 'registers an offense when keys have whitespaces in them' do
+          inspect_source(cop, 'x = { :"t o" => 0 }')
+          expect(cop.messages).to eq(['Use the new Ruby 1.9 hash syntax.'])
+        end
 
-      it 'accepts hash rockets when keys have special symbols in them' do
-        inspect_source(cop, 'x = { :"\tab" => 1, :b => 1 }')
-        expect(cop.messages).to be_empty
-      end
+        it 'registers an offense when keys have special symbols in them' do
+          inspect_source(cop, 'x = { :"\tab" => 1 }')
+          expect(cop.messages).to eq(['Use the new Ruby 1.9 hash syntax.'])
+        end
 
-      it 'registers an offense when keys have special symbols and mix styles' do
-        inspect_source(cop, 'x = { :"\tab" => 1, b: 1 }')
-        expect(cop.messages).to eq(["Don't mix styles in the same hash."])
-        expect(cop.config_to_allow_offenses).to eq('Enabled' => false)
-      end
-
-      it 'accepts hash rockets when keys start with a digit' do
-        inspect_source(cop, 'x = { :"1" => 1, :b => 1 }')
-        expect(cop.messages).to be_empty
-      end
-
-      it 'registers an offense when keys start with a digit and mix styles' do
-        inspect_source(cop, 'x = { :"1" => 1, b: 1 }')
-        expect(cop.messages).to eq(["Don't mix styles in the same hash."])
-        expect(cop.config_to_allow_offenses).to eq('Enabled' => false)
+        it 'accepts hash rockets when keys start with a digit' do
+          inspect_source(cop, 'x = { :"1" => 1 }')
+          expect(cop.messages).to eq(['Use the new Ruby 1.9 hash syntax.'])
+        end
       end
 
       it 'auto-corrects old to new style' do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -21,6 +21,20 @@ RSpec.configure do |config|
 
   config.filter_run_excluding ruby: ->(v) { !RUBY_VERSION.start_with?(v.to_s) }
 
+  ruby_version = Gem::Version.new(RUBY_VERSION)
+  config.filter_run_excluding ruby_less_than: (lambda do |v|
+    ruby_version >= Gem::Version.new(v)
+  end)
+  config.filter_run_excluding ruby_less_than: (lambda do |v|
+    ruby_version >= Gem::Version.new(v)
+  end)
+  config.filter_run_excluding ruby_greater_than_or_equal: (lambda do |v|
+    ruby_version < Gem::Version.new(v)
+  end)
+  config.filter_run_excluding ruby_greater_than_or_equal: (lambda do |v|
+    ruby_version < Gem::Version.new(v)
+  end)
+
   broken_filter = lambda do |v|
     v.is_a?(Symbol) ? RUBY_ENGINE == v.to_s : v
   end


### PR DESCRIPTION
Version 0.30.0 is now telling me to convert to 19 hash syntax in cases when it should not. There are a few cases where you can have a valid symbol that does not convert to valid 19 hash syntax. According to [this comment](http://stackoverflow.com/questions/2134702/ruby-1-9-hash-with-a-dash-in-a-key#comment2074558_2134851) the regex is pretty straight forward. 

Most of the time this would not come up, but I've seen it while setting the `[]` method in a test double.

```
failure.rb:2:3: C: Use the new Ruby 1.9 hash syntax.
  :[] => 'asdf'
  ^^^^^^
```

As requested in the contributing guidelines:
```
rubocop -V
0.30.0 (using Parser 2.2.0.3, running on ruby 2.0.0 x86_64-linux)
```