### PR TITLE
Support class method visibility modifiers in DefEndAlignment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 ### Bugs fixed
 
 * [#1816](https://github.com/bbatsov/rubocop/issues/1816): Fix bug in `Sample` when calling `#shuffle` with something other than an element selector. ([@rrosenblum][])
+* [#1768](https://github.com/bbatsov/rubocop/pull/1768): `DefEndAlignment` recognizes preceding `private_class_method` or `public_class_method` before `def`. ([@til][])
 
 ## 0.30.1 (21/04/2015)
 
@@ -1364,3 +1365,4 @@
 [@crimsonknave]: https://github.com/crimsonknave
 [@renuo]: https://github.com/renuo
 [@sdeframond]: https://github.com/sdeframond
+[@til]: https://github.com/til

--- a/lib/rubocop/cop/mixin/on_method_def.rb
+++ b/lib/rubocop/cop/mixin/on_method_def.rb
@@ -22,6 +22,7 @@ module RuboCop
       def visibility_and_def_on_same_line?(receiver, method_name, args)
         !receiver &&
           [:public, :protected, :private,
+           :private_class_method, :public_class_method,
            :module_function].include?(method_name) &&
           args.size == 1 && [:def, :defs].include?(args.first.type)
       end

--- a/spec/rubocop/cop/lint/def_end_alignment_spec.rb
+++ b/spec/rubocop/cop/lint/def_end_alignment_spec.rb
@@ -18,10 +18,12 @@ describe RuboCop::Cop::Lint::DefEndAlignment, :config do
     include_examples 'aligned', 'def', 'Test.test', 'end', 'defs'
 
     context 'in ruby 2.1 or later' do
-      include_examples 'aligned', 'public def',          'test', 'end'
-      include_examples 'aligned', 'protected def',       'test', 'end'
-      include_examples 'aligned', 'private def',         'test', 'end'
-      include_examples 'aligned', 'module_function def', 'test', 'end'
+      include_examples 'aligned', 'public def',               'test', 'end'
+      include_examples 'aligned', 'protected def',            'test', 'end'
+      include_examples 'aligned', 'private def',              'test', 'end'
+      include_examples 'aligned', 'module_function def',      'test', 'end'
+      include_examples 'aligned', 'private_class_method def', 'test', 'end'
+      include_examples 'aligned', 'public_class_method def',  'test', 'end'
 
       include_examples('misaligned', '',
                        'public def', 'test',
@@ -35,6 +37,12 @@ describe RuboCop::Cop::Lint::DefEndAlignment, :config do
       include_examples('misaligned', '',
                        'module_function def', 'test',
                        '                end')
+      include_examples('misaligned', '',
+                       'private_class_method def', 'test',
+                       '                     end')
+      include_examples('misaligned', '',
+                       'public_class_method def', 'test',
+                       '                    end')
     end
 
     it 'registers an offense for correct + opposite' do


### PR DESCRIPTION
Make sure `DefEndAlignment` recognizes def lines preceded with
`private_class_method` or `public_class_method`, and does not complain about
misaligned `end`, like this:

```ruby
private_class_method def self.foo
  ...
end
```
