### PR TITLE
[Fix #1691] Handle var = <line break> in EndAlignment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## master (unreleased)
 
+### Bugs fixed
+
+* [#1691](https://github.com/bbatsov/rubocop/issues/1691): For assignments with line break after `=`, use `keyword` alignment in `EndAlignment` regardless of configured style. ([@jonas054][])
+
 ## 0.30.0 (06/04/2015)
 
 ### New features

--- a/lib/rubocop/cop/lint/end_alignment.rb
+++ b/lib/rubocop/cop/lint/end_alignment.rb
@@ -20,8 +20,6 @@ module RuboCop
         include EndKeywordAlignment
         include IfNode
 
-        MSG = '`end` at %d, %d is not aligned with `%s` at %d, %d'
-
         def on_class(node)
           check_offset_of_node(node)
         end
@@ -55,8 +53,8 @@ module RuboCop
           return unless [:if, :while, :until].include?(rhs.type)
           return if ternary_op?(rhs)
 
-          if style == :variable
-            expr = node.loc.expression
+          expr = node.loc.expression
+          if style == :variable && !line_break_before_keyword?(expr, rhs)
             range = Parser::Source::Range.new(expr.source_buffer,
                                               expr.begin_pos,
                                               rhs.loc.keyword.end_pos)
@@ -68,6 +66,10 @@ module RuboCop
 
           check_offset(rhs, range.source, offset)
           ignore_node(rhs) # Don't check again.
+        end
+
+        def line_break_before_keyword?(whole_expression, rhs)
+          rhs.loc.keyword.line > whole_expression.line
         end
       end
     end

--- a/spec/rubocop/cop/lint/end_alignment_spec.rb
+++ b/spec/rubocop/cop/lint/end_alignment_spec.rb
@@ -70,6 +70,8 @@ describe RuboCop::Cop::Lint::EndAlignment, :config do
       include_examples 'aligned', 'var = until',  'test', 'end.abc.join("")'
       include_examples 'aligned', 'var = until',  'test', 'end.abc.tap {}'
 
+      include_examples 'aligned', "var =\n  if",  'test', '  end'
+
       include_examples 'misaligned', '', 'var = if',     'test', '      end'
       include_examples 'misaligned', '', 'var = unless', 'test', '      end'
       include_examples 'misaligned', '', 'var = while',  'test', '      end'

--- a/spec/support/shared_examples.rb
+++ b/spec/support/shared_examples.rb
@@ -47,6 +47,7 @@ end
 
 shared_examples_for 'aligned' do |alignment_base, arg, end_kw, name|
   name ||= alignment_base
+  name = name.gsub(/\n/, ' <newline>')
   it "accepts matching #{name} ... end" do
     inspect_source(cop, ["#{alignment_base} #{arg}",
                          end_kw])


### PR DESCRIPTION
In this case, the cop should enforce `keyword` alignment even if `variable` alignment is selected in configuration.