### PR TITLE
[Fix #1769] LiteralInInterpolation registers an offense for __LINE__

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Bugs fixed
 
 * [#1691](https://github.com/bbatsov/rubocop/issues/1691): For assignments with line break after `=`, use `keyword` alignment in `EndAlignment` regardless of configured style. ([@jonas054][])
+* [#1769](https://github.com/bbatsov/rubocop/issues/1769): Fix bug where `LiteralInInterpolation` registers an offense for interpolation of `__LINE__`. ([@rrosenblum][])
 
 ## 0.30.0 (06/04/2015)
 

--- a/lib/rubocop/cop/lint/literal_in_interpolation.rb
+++ b/lib/rubocop/cop/lint/literal_in_interpolation.rb
@@ -18,8 +18,7 @@ module RuboCop
           node.children.select { |n| n.type == :begin }.each do |begin_node|
             final_node = begin_node.children.last
             next unless final_node
-            # handle strings like __FILE__
-            next if special_string?(final_node)
+            next if special_keyword?(final_node)
             next unless LITERALS.include?(final_node.type)
 
             add_offense(final_node, :expression)
@@ -28,8 +27,10 @@ module RuboCop
 
         private
 
-        def special_string?(node)
-          node.type == :str && !node.loc.respond_to?(:begin)
+        def special_keyword?(node)
+          # handle strings like __FILE__
+          (node.type == :str && !node.loc.respond_to?(:begin)) ||
+            node.loc.expression.is?('__LINE__')
         end
       end
     end

--- a/spec/rubocop/cop/lint/literal_in_interpolation_spec.rb
+++ b/spec/rubocop/cop/lint/literal_in_interpolation_spec.rb
@@ -5,33 +5,51 @@ require 'spec_helper'
 describe RuboCop::Cop::Lint::LiteralInInterpolation do
   subject(:cop) { described_class.new }
 
-  %w(1 2.0 [1] {}).each do |lit|
-    it "registers an offense for #{lit} in interpolation" do
-      inspect_source(cop,
-                     "\"this is the \#{#{lit}}\"")
-      expect(cop.offenses.size).to eq(1)
-    end
-
-    it "registers an offense only for final #{lit} in interpolation" do
-      inspect_source(cop,
-                     "\"this is the \#{#{lit};#{lit}}\"")
-      expect(cop.offenses.size).to eq(1)
-    end
-  end
-
   it 'accepts empty interpolation' do
-    inspect_source(cop, '"this is #{} silly"')
+    inspect_source(cop, '"this is #{a} silly"')
     expect(cop.offenses).to be_empty
   end
 
-  it 'accepts strings like __FILE__' do
-    inspect_source(cop, '"this is #{__FILE__} silly"')
-    expect(cop.offenses).to be_empty
+  shared_examples 'literal interpolation' do |literal|
+    it "registers an offense for #{literal} in interpolation" do
+      inspect_source(cop, %("this is the \#{#{literal}}"))
+      expect(cop.offenses.size).to eq(1)
+    end
+
+    it "registers an offense only for final #{literal} in interpolation" do
+      inspect_source(cop, %("this is the \#{#{literal};#{literal}}"))
+      expect(cop.offenses.size).to eq(1)
+    end
   end
 
-  it 'registers an offense for interpolation after __FILE__' do
-    inspect_source(cop,
-                   '"this is the #{__FILE__} #{1}"')
-    expect(cop.offenses.size).to eq(1)
+  it_behaves_like('literal interpolation', 1)
+  it_behaves_like('literal interpolation', -1)
+  it_behaves_like('literal interpolation', 1_123)
+  it_behaves_like('literal interpolation', 123_456_789_123_456_789)
+  it_behaves_like('literal interpolation', 1.2e-3)
+  it_behaves_like('literal interpolation', 0xaabb)
+  it_behaves_like('literal interpolation', 0377)
+  it_behaves_like('literal interpolation', 2.0)
+  it_behaves_like('literal interpolation', [])
+  it_behaves_like('literal interpolation', [1])
+  it_behaves_like('literal interpolation', true)
+  it_behaves_like('literal interpolation', false)
+  it_behaves_like('literal interpolation', 'nil')
+
+  shared_examples 'special keywords' do |keyword|
+    it "accepts strings like #{keyword}" do
+      inspect_source(cop, %("this is \#{#{keyword}} silly"))
+      expect(cop.offenses).to be_empty
+    end
+
+    it "registers an offense for interpolation after #{keyword}" do
+      inspect_source(cop, %("this is the \#{#{keyword}} \#{1}"))
+      expect(cop.offenses.size).to eq(1)
+    end
   end
+
+  it_behaves_like('special keywords', '__FILE__')
+  it_behaves_like('special keywords', '__LINE__')
+  it_behaves_like('special keywords', '__END__')
+  it_behaves_like('special keywords', '__ENCODING__')
 end


### PR DESCRIPTION
This fixes #1769. I added in a bunch of other test cases as well.