### PR TITLE
Fix offense message from Rails/TimeZone.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 * [#1691](https://github.com/bbatsov/rubocop/issues/1691): For assignments with line break after `=`, use `keyword` alignment in `EndAlignment` regardless of configured style. ([@jonas054][])
 * [#1769](https://github.com/bbatsov/rubocop/issues/1769): Fix bug where `LiteralInInterpolation` registers an offense for interpolation of `__LINE__`. ([@rrosenblum][])
 * [#1773](https://github.com/bbatsov/rubocop/pull/1773): Fix typo ('strptime' -> 'strftime') in `Rails/TimeZone`. ([@palkan][])
+* [#1777](https://github.com/bbatsov/rubocop/pull/1777): Fix offense message from Rails/TimeZone. ([@mzp][])
 
 ## 0.30.0 (06/04/2015)
 
@@ -1338,3 +1339,4 @@
 [@ypresto]: https://github.com/ypresto
 [@clowder]: https://github.com/clowder
 [@mudge]: https://github.com/mudge
+[@mzp]: https://github.com/mzp

--- a/lib/rubocop/cop/rails/time_zone.rb
+++ b/lib/rubocop/cop/rails/time_zone.rb
@@ -56,7 +56,7 @@ module RuboCop
           add_offense(node, :selector,
                       format(MSG,
                              "#{klass}.#{method_name}",
-                             "#Time.zone.#{safe_method_name}")
+                             "Time.zone.#{safe_method_name}")
                      )
         end
 

--- a/lib/rubocop/cop/rails/time_zone.rb
+++ b/lib/rubocop/cop/rails/time_zone.rb
@@ -35,6 +35,8 @@ module RuboCop
 
         DANGER_METHODS = [:now, :local, :new, :strftime, :parse, :at]
 
+        SAFE_METHODS = { 'new' => 'local' }
+
         def on_const(node)
           _module, klass = *node
 
@@ -52,10 +54,12 @@ module RuboCop
 
           method_name = (chain & DANGER_METHODS).join('.')
 
+          safe_method_name = SAFE_METHODS.fetch(method_name, method_name)
+
           add_offense(node, :selector,
                       format(MSG,
                              "#{klass}.#{method_name}",
-                             "#Time.zone.#{method_name}")
+                             "#Time.zone.#{safe_method_name}")
                      )
         end
 

--- a/lib/rubocop/cop/rails/time_zone.rb
+++ b/lib/rubocop/cop/rails/time_zone.rb
@@ -35,8 +35,6 @@ module RuboCop
 
         DANGER_METHODS = [:now, :local, :new, :strftime, :parse, :at]
 
-        SAFE_METHODS = { 'new' => 'local' }
-
         def on_const(node)
           _module, klass = *node
 
@@ -53,8 +51,7 @@ module RuboCop
                     !(chain & good_methods).empty?
 
           method_name = (chain & DANGER_METHODS).join('.')
-
-          safe_method_name = SAFE_METHODS.fetch(method_name, method_name)
+          safe_method_name = safe_method(method_name, node)
 
           add_offense(node, :selector,
                       format(MSG,
@@ -86,6 +83,17 @@ module RuboCop
           receiver, _method_name, *_args = *node.parent
 
           receiver == node
+        end
+
+        def safe_method(method_name, node)
+          _receiver, _method_name, *args = *node
+          return method_name unless method_name == 'new'
+
+          if args.empty?
+            'now'
+          else
+            'local'
+          end
         end
 
         def good_methods

--- a/spec/rubocop/cop/rails/time_zone_spec.rb
+++ b/spec/rubocop/cop/rails/time_zone_spec.rb
@@ -22,13 +22,13 @@ describe RuboCop::Cop::Rails::TimeZone, :config do
       it "registers an offense for #{klass}.new without argument" do
         inspect_source(cop, "#{klass}.new")
         expect(cop.offenses.size).to eq(1)
-        expect(cop.offenses.first.message).to include('#Time.zone.now')
+        expect(cop.offenses.first.message).to include('Time.zone.now')
       end
 
       it "registers an offense for #{klass}.new with argument" do
         inspect_source(cop, "#{klass}.new(2012, 6, 10, 12, 00)")
         expect(cop.offenses.size).to eq(1)
-        expect(cop.offenses.first.message).to include('#Time.zone.local')
+        expect(cop.offenses.first.message).to include('Time.zone.local')
       end
     end
 

--- a/spec/rubocop/cop/rails/time_zone_spec.rb
+++ b/spec/rubocop/cop/rails/time_zone_spec.rb
@@ -22,6 +22,7 @@ describe RuboCop::Cop::Rails::TimeZone, :config do
       it "registers an offense for #{klass}.new" do
         inspect_source(cop, "#{klass}.new(2012, 6, 10, 12, 00)")
         expect(cop.offenses.size).to eq(1)
+        expect(cop.offenses.first.message).to include('#Time.zone.local')
       end
     end
 

--- a/spec/rubocop/cop/rails/time_zone_spec.rb
+++ b/spec/rubocop/cop/rails/time_zone_spec.rb
@@ -19,7 +19,13 @@ describe RuboCop::Cop::Rails::TimeZone, :config do
         expect(cop.offenses.size).to eq(1)
       end
 
-      it "registers an offense for #{klass}.new" do
+      it "registers an offense for #{klass}.new without argument" do
+        inspect_source(cop, "#{klass}.new")
+        expect(cop.offenses.size).to eq(1)
+        expect(cop.offenses.first.message).to include('#Time.zone.now')
+      end
+
+      it "registers an offense for #{klass}.new with argument" do
         inspect_source(cop, "#{klass}.new(2012, 6, 10, 12, 00)")
         expect(cop.offenses.size).to eq(1)
         expect(cop.offenses.first.message).to include('#Time.zone.local')


### PR DESCRIPTION
Now, Rubocop generate "Use #Time.zone.[:new] instead." for following code.

```ruby
Time.new(2014, 1, 1)
```

But `Time.zone.new` does not exist. We should use `Time.zone.local`.

As requested in the contributing guidelines:

```
$bundle exec rubocop -V
0.30.0 (using Parser 2.2.0.3, running on ruby 2.2.0 x86_64-linux)
```