### PR TITLE
Fix the error happening with empty config sections

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 * [#1769](https://github.com/bbatsov/rubocop/issues/1769): Fix bug where `LiteralInInterpolation` registers an offense for interpolation of `__LINE__`. ([@rrosenblum][])
 * [#1773](https://github.com/bbatsov/rubocop/pull/1773): Fix typo ('strptime' -> 'strftime') in `Rails/TimeZone`. ([@palkan][])
 * [#1777](https://github.com/bbatsov/rubocop/pull/1777): Fix offense message from Rails/TimeZone. ([@mzp][])
+* [#1781](https://github.com/bbatsov/rubocop/pull/1781): Fix the error happening with empty config sections. ([@bankair][])
 
 ## 0.30.0 (06/04/2015)
 
@@ -1340,3 +1341,4 @@
 [@clowder]: https://github.com/clowder
 [@mudge]: https://github.com/mudge
 [@mzp]: https://github.com/mzp
+[@bankair]: https://github.com/bankair

--- a/lib/rubocop/config_loader.rb
+++ b/lib/rubocop/config_loader.rb
@@ -31,6 +31,9 @@ module RuboCop
         Array(hash.delete('require')).each { |r| require(r) }
 
         hash.delete('inherit_from')
+        # Prevent rubocop from failing when there is an empty section in the
+        # configuration
+        hash.delete_if { |_section, content| content.nil? }
         config = Config.new(hash, path)
 
         config.deprecation_check do |deprecation_message|

--- a/spec/rubocop/config_spec.rb
+++ b/spec/rubocop/config_spec.rb
@@ -71,6 +71,20 @@ describe RuboCop::Config do
       end
     end
 
+    context 'when the configuration file includes an empty section' do
+      before do
+        create_file(configuration_path, [
+          'AllCops:',
+          '  RunRailsCops: true',
+          'Rails/HasAndBelongsToMany:'
+        ])
+      end
+
+      it 'does not raise validation error' do
+        expect { configuration.validate }.to_not raise_error
+      end
+    end
+
     context 'when the configuration includes any common parameter' do
       # Common parameters are parameters that are not in the default
       # configuration, but are nonetheless allowed for any cop.


### PR DESCRIPTION
When a configuration section is empty like follow:

```
AllCops:
  RunRailsCops: true
Rails/HasAndBelongsToMany:
```

The config object contains a key/value association
with an empty (nil) value, which leads to an ugly exception:

```
  1) RuboCop::Config#validate when the configuration file includes an empty section does not raise validation error
     Failure/Error: expect { configuration.validate }.to_not raise_error
       expected no Exception, got #<NoMethodError: undefined method `each_key' for nil:NilClass> with backtrace:
         # /Users/alexandreignjatovic/Documents/perso/dev/rubocop/lib/rubocop/config.rb:177:in `block in validate_parameter_names'
         # /Users/alexandreignjatovic/Documents/perso/dev/rubocop/lib/rubocop/config.rb:176:in `each'
         # /Users/alexandreignjatovic/Documents/perso/dev/rubocop/lib/rubocop/config.rb:176:in `validate_parameter_names'
         # /Users/alexandreignjatovic/Documents/perso/dev/rubocop/lib/rubocop/config.rb:111:in `validate'
         # /Users/alexandreignjatovic/Documents/perso/dev/rubocop/lib/rubocop/config.rb:80:in `warn_unless_valid'
         # /Users/alexandreignjatovic/Documents/perso/dev/rubocop/lib/rubocop/config_loader.rb:41:in `load_file'
         # /Users/alexandreignjatovic/Documents/perso/dev/rubocop/spec/rubocop/config_spec.rb:20:in `block (3 levels) in <top (required)>'
         # /Users/alexandreignjatovic/Documents/perso/dev/rubocop/spec/rubocop/config_spec.rb:84:in `block (5 levels) in <top (required)>'
         # /Users/alexandreignjatovic/Documents/perso/dev/rubocop/spec/rubocop/config_spec.rb:84:in `block (4 levels) in <top (required)>'
         # /Users/alexandreignjatovic/Documents/perso/dev/rubocop/spec/support/shared_contexts.rb:27:in `block (4 levels) in <top (required)>'
         # /Users/alexandreignjatovic/Documents/perso/dev/rubocop/spec/support/shared_contexts.rb:26:in `chdir'
         # /Users/alexandreignjatovic/Documents/perso/dev/rubocop/spec/support/shared_contexts.rb:26:in `block (3 levels) in <top (required)>'
         # /Users/alexandreignjatovic/Documents/perso/dev/rubocop/spec/support/shared_contexts.rb:8:in `block (2 levels) in <top (required)>'
     # ./spec/rubocop/config_spec.rb:84:in `block (4 levels) in <top (required)>'
     # ./spec/support/shared_contexts.rb:27:in `block (4 levels) in <top (required)>'
     # ./spec/support/shared_contexts.rb:26:in `chdir'
     # ./spec/support/shared_contexts.rb:26:in `block (3 levels) in <top (required)>'
     # ./spec/support/shared_contexts.rb:8:in `block (2 levels) in <top (required)>'
```

Instead of checking everywhere that the config sections are not
containing nil, I removed all empty section in the config loader.

I also added a spec test