### PR TITLE
Fix while and until in Style/IndentationWidth

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 * [#1769](https://github.com/bbatsov/rubocop/issues/1769): Fix bug where `LiteralInInterpolation` registers an offense for interpolation of `__LINE__`. ([@rrosenblum][])
 * [#1773](https://github.com/bbatsov/rubocop/pull/1773): Fix typo ('strptime' -> 'strftime') in `Rails/TimeZone`. ([@palkan][])
 * [#1777](https://github.com/bbatsov/rubocop/pull/1777): Fix offense message from Rails/TimeZone. ([@mzp][])
+* Fix handling of `while` and `until` with assignment in `IndentationWidth`. ([@lumeet][])
 
 ## 0.30.0 (06/04/2015)
 

--- a/lib/rubocop/cop/style/indentation_width.rb
+++ b/lib/rubocop/cop/style/indentation_width.rb
@@ -100,6 +100,8 @@ module RuboCop
         end
 
         def on_while(node, base = node)
+          return if ignored_node?(node)
+
           _condition, body = *node
           return unless node.loc.keyword.begin_pos ==
                         node.loc.expression.begin_pos

--- a/spec/rubocop/cop/style/indentation_width_spec.rb
+++ b/spec/rubocop/cop/style/indentation_width_spec.rb
@@ -416,6 +416,35 @@ describe RuboCop::Cop::Style::IndentationWidth do
                 .to eq(['Use 2 (not 8) spaces for indentation.'])
             end
           end
+
+          context 'and end is aligned randomly' do
+            it 'registers an offense for an if' do
+              inspect_source(cop,
+                             ['var = if a',
+                              '          0',
+                              '      end'])
+              expect(cop.messages)
+                .to eq(['Use 2 (not 10) spaces for indentation.'])
+            end
+
+            it 'registers an offense for a while' do
+              inspect_source(cop,
+                             ['var = while a',
+                              '          b',
+                              '      end'])
+              expect(cop.messages)
+                .to eq(['Use 2 (not 10) spaces for indentation.'])
+            end
+
+            it 'registers an offense for an until' do
+              inspect_source(cop,
+                             ['var = until a',
+                              '          b',
+                              '      end'])
+              expect(cop.messages)
+                .to eq(['Use 2 (not 10) spaces for indentation.'])
+            end
+          end
         end
 
         shared_examples 'assignment and if with keyword alignment' do


### PR DESCRIPTION
When

* `while` or `until` is used in assignment and
* `AlignWith` configuration for `Lint/EndAlignment` is set as
  `variable`,

the cop

* reports only one offense and
* doesn't cause an infinite loop when auto-correcting.

`if`, `unless` already do the same correctly.