### PR TITLE
Add explicit error when a section is empty

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,8 +8,9 @@
 * [#1769](https://github.com/bbatsov/rubocop/issues/1769): Fix bug where `LiteralInInterpolation` registers an offense for interpolation of `__LINE__`. ([@rrosenblum][])
 * [#1773](https://github.com/bbatsov/rubocop/pull/1773): Fix typo ('strptime' -> 'strftime') in `Rails/TimeZone`. ([@palkan][])
 * [#1777](https://github.com/bbatsov/rubocop/pull/1777): Fix offense message from Rails/TimeZone. ([@mzp][])
-* Fix handling of `while` and `until` with assignment in `IndentationWidth`. ([@lumeet][])
+* [#1784](https://github.com/bbatsov/rubocop/pull/1784): Add an explicit error message when config contains an empty section. ([@bankair][])
 * [#1791](https://github.com/bbatsov/rubocop/pull/1791): Fix autocorrection of `PercentLiteralDelimiters` with no content. ([@cshaffer][])
+* Fix handling of `while` and `until` with assignment in `IndentationWidth`. ([@lumeet][])
 * [#1793](https://github.com/bbatsov/rubocop/pull/1793): Fix bug in `TrailingComma` that caused `,` in comment to count as a trailing comma. ([@jonas054][])
 
 ## 0.30.0 (06/04/2015)
@@ -1343,3 +1344,4 @@
 [@clowder]: https://github.com/clowder
 [@mudge]: https://github.com/mudge
 [@mzp]: https://github.com/mzp
+[@bankair]: https://github.com/bankair

--- a/lib/rubocop/config.rb
+++ b/lib/rubocop/config.rb
@@ -26,6 +26,7 @@ module RuboCop
 
     def make_excludes_absolute
       keys.each do |key|
+        validate_section_presence(key)
         next unless self[key]['Exclude']
 
         self[key]['Exclude'].map! do |exclude_elem|
@@ -172,8 +173,16 @@ module RuboCop
 
     private
 
+    def validate_section_presence(name)
+      return unless @hash.key?(name) && @hash[name].nil?
+      fail ValidationError,
+           "empty section #{name} found " \
+           "in #{loaded_path || self}"
+    end
+
     def validate_parameter_names(valid_cop_names)
       valid_cop_names.each do |name|
+        validate_section_presence(name)
         @hash[name].each_key do |param|
           next if COMMON_PARAMS.include?(param) ||
                   ConfigLoader.default_configuration[name].key?(param)

--- a/spec/rubocop/config_spec.rb
+++ b/spec/rubocop/config_spec.rb
@@ -38,6 +38,18 @@ describe RuboCop::Config do
       end
     end
 
+    context 'when the configuration includes an empty section' do
+      before do
+        create_file(configuration_path, ['Metrics/LineLength:'])
+      end
+
+      it 'raises validation error' do
+        expect { configuration.validate }
+          .to raise_error(described_class::ValidationError,
+                          %r{^empty section Metrics/LineLength})
+      end
+    end
+
     context 'when the configuration is in the base RuboCop config folder' do
       before do
         create_file(configuration_path, [


### PR DESCRIPTION
Raises a ValidationError "empty section #{name} found in #{loaded_path || self}" instead of 'undefined method `each_key' for nil:NilClass' when the configuration file contains an empty section.

closes issue #1782
