### PR TITLE
[Fix #1278] Add auto-correct for EndKeywordAlignment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 * `CommentAnnotation` cop does auto-correction. ([@dylandavidson][])
 * New cop `Style/TrailingUnderscoreVariable` to remove trailing underscore variables from mass assignment. ([@rrosenblum][])
 * [#1136](https://github.com/bbatsov/rubocop/issues/1136): New cop `Performance/ParallelAssignment` to avoid usages of unnessary parallel assignment. ([@rrosenblum][])
+* [#1278](https://github.com/bbatsov/rubocop/issues/1278): `DefEndAlignment` and `EndAlignment` cops do auto-correction. ([@lumeet][])
 
 ### Bugs fixed
 

--- a/config/default.yml
+++ b/config/default.yml
@@ -781,6 +781,7 @@ Lint/EndAlignment:
   SupportedStyles:
     - keyword
     - variable
+  AutoCorrect: false
 
 Lint/DefEndAlignment:
   # The value `def` means that `end` should be aligned with the def keyword.
@@ -791,6 +792,7 @@ Lint/DefEndAlignment:
   SupportedStyles:
     - start_of_line
     - def
+  AutoCorrect: false
 
 ##################### Rails ##################################
 

--- a/lib/rubocop/cop/lint/def_end_alignment.rb
+++ b/lib/rubocop/cop/lint/def_end_alignment.rb
@@ -45,6 +45,12 @@ module RuboCop
 
           ignore_node(method_def) # Don't check the same `end` again.
         end
+
+        private
+
+        def autocorrect(node)
+          align(node, style == :start_of_line ? node.ancestors.first : node)
+        end
       end
     end
   end

--- a/lib/rubocop/cop/lint/end_alignment.rb
+++ b/lib/rubocop/cop/lint/end_alignment.rb
@@ -71,6 +71,11 @@ module RuboCop
         def line_break_before_keyword?(whole_expression, rhs)
           rhs.loc.keyword.line > whole_expression.line
         end
+
+        def autocorrect(node)
+          align(node,
+                style == :variable ? node.each_ancestor(:lvasgn).first : node)
+        end
       end
     end
   end

--- a/lib/rubocop/cop/mixin/end_keyword_alignment.rb
+++ b/lib/rubocop/cop/mixin/end_keyword_alignment.rb
@@ -24,7 +24,7 @@ module RuboCop
 
         if kw_loc.line != end_loc.line &&
            kw_loc.column != end_loc.column + offset
-          add_offense(nil, end_loc,
+          add_offense(node, end_loc,
                       format(MSG, end_loc.line, end_loc.column,
                              alignment_base, kw_loc.line, kw_loc.column)) do
             opposite_style_detected
@@ -36,6 +36,19 @@ module RuboCop
 
       def parameter_name
         'AlignWith'
+      end
+
+      def align(node, alignment_node)
+        source_buffer = node.loc.expression.source_buffer
+        begin_pos = node.loc.end.begin_pos
+        whitespace = Parser::Source::Range.new(source_buffer,
+                                               begin_pos - node.loc.end.column,
+                                               begin_pos)
+        fail CorrectionNotPossible unless whitespace.source.strip.empty?
+
+        column = alignment_node ? alignment_node.loc.expression.column : 0
+
+        ->(corrector) { corrector.replace(whitespace, ' ' * column) }
       end
     end
   end

--- a/spec/rubocop/cop/lint/def_end_alignment_spec.rb
+++ b/spec/rubocop/cop/lint/def_end_alignment_spec.rb
@@ -8,8 +8,20 @@ describe RuboCop::Cop::Lint::DefEndAlignment, :config do
     cop_config['AlignWith'] == 'def' ? 'start_of_line' : 'def'
   end
 
+  let(:source) do
+    ['private def a',
+     '  a1',
+     'end',
+     '',
+     'private def b',
+     '          b1',
+     '        end']
+  end
+
   context 'when AlignWith is start_of_line' do
-    let(:cop_config) { { 'AlignWith' => 'start_of_line' } }
+    let(:cop_config) do
+      { 'AlignWith' => 'start_of_line', 'AutoCorrect' => true }
+    end
 
     include_examples 'misaligned', '', 'def', 'test',      '  end'
     include_examples 'misaligned', '', 'def', 'Test.test', '  end', 'defs'
@@ -45,24 +57,33 @@ describe RuboCop::Cop::Lint::DefEndAlignment, :config do
                        '                    end')
     end
 
-    it 'registers an offense for correct + opposite' do
-      inspect_source(cop, ['private def a',
-                           '  a1',
-                           'end',
-                           '',
-                           'private def b',
-                           '          b1',
-                           '        end'])
-      expect(cop.offenses.size).to eq(1)
-      expect(cop.messages.first)
-        .to eq('`end` at 7, 8 is not aligned with `private def` at 5, 8')
-      expect(cop.highlights.first).to eq('end')
-      expect(cop.config_to_allow_offenses).to eq('Enabled' => false)
+    context 'correct + opposite' do
+      it 'registers an offense' do
+        inspect_source(cop, source)
+        expect(cop.offenses.size).to eq(1)
+        expect(cop.messages.first)
+          .to eq('`end` at 7, 8 is not aligned with `private def` at 5, 8')
+        expect(cop.highlights.first).to eq('end')
+        expect(cop.config_to_allow_offenses).to eq('Enabled' => false)
+      end
+
+      it 'does auto-correction' do
+        corrected = autocorrect_source(cop, source)
+        expect(corrected).to eq(['private def a',
+                                 '  a1',
+                                 'end',
+                                 '',
+                                 'private def b',
+                                 '          b1',
+                                 'end'].join("\n"))
+      end
     end
   end
 
   context 'when AlignWith is def' do
-    let(:cop_config) { { 'AlignWith' => 'def' } }
+    let(:cop_config) do
+      { 'AlignWith' => 'def', 'AutoCorrect' => true }
+    end
 
     include_examples 'misaligned', '', 'def', 'test',      '  end'
     include_examples 'misaligned', '', 'def', 'Test.test', '  end', 'defs'
@@ -97,19 +118,26 @@ describe RuboCop::Cop::Lint::DefEndAlignment, :config do
                        'module_function ', 'def', 'test',
                        'end')
 
-      it 'registers an offense for correct + opposite' do
-        inspect_source(cop, ['private def a',
-                             '  a1',
-                             'end',
-                             '',
-                             'private def b',
-                             '          b1',
-                             '        end'])
-        expect(cop.offenses.size).to eq(1)
-        expect(cop.messages.first)
-          .to eq('`end` at 3, 0 is not aligned with `def` at 1, 8')
-        expect(cop.highlights.first).to eq('end')
-        expect(cop.config_to_allow_offenses).to eq('Enabled' => false)
+      context 'correct + opposite' do
+        it 'registers an offense' do
+          inspect_source(cop, source)
+          expect(cop.offenses.size).to eq(1)
+          expect(cop.messages.first)
+            .to eq('`end` at 3, 0 is not aligned with `def` at 1, 8')
+          expect(cop.highlights.first).to eq('end')
+          expect(cop.config_to_allow_offenses).to eq('Enabled' => false)
+        end
+
+        it 'does auto-correction' do
+          corrected = autocorrect_source(cop, source)
+          expect(corrected).to eq(['private def a',
+                                   '  a1',
+                                   '        end',
+                                   '',
+                                   'private def b',
+                                   '          b1',
+                                   '        end'].join("\n"))
+        end
       end
     end
   end

--- a/spec/support/shared_examples.rb
+++ b/spec/support/shared_examples.rb
@@ -34,14 +34,23 @@ end
 
 shared_examples_for 'misaligned' do |prefix, alignment_base, arg, end_kw, name|
   name ||= alignment_base
+  source = ["#{prefix}#{alignment_base} #{arg}",
+            end_kw]
+
   it "registers an offense for mismatched #{name} ... end" do
-    inspect_source(cop, ["#{prefix}#{alignment_base} #{arg}",
-                         end_kw])
+    inspect_source(cop, source)
     expect(cop.offenses.size).to eq(1)
     regexp = /`end` at 2, \d+ is not aligned with `#{alignment_base}` at 1,/
     expect(cop.messages.first).to match(regexp)
     expect(cop.highlights.first).to eq('end')
     expect(cop.config_to_allow_offenses).to eq('AlignWith' => opposite)
+  end
+
+  it "auto-corrects mismatched #{name} ... end" do
+    aligned_source = ["#{prefix}#{alignment_base} #{arg}",
+                      "#{' ' * prefix.length}#{end_kw.strip}"].join("\n")
+    corrected = autocorrect_source(cop, source)
+    expect(corrected).to eq(aligned_source)
   end
 end
 


### PR DESCRIPTION
`Lint/EndAlignment` and `Lint/DefEndAlignment` do auto-correction.