### PR TITLE
Convert tests from using should to use is_expected

### DIFF
--- a/spec/rubocop/cop/cop_spec.rb
+++ b/spec/rubocop/cop/cop_spec.rb
@@ -156,11 +156,9 @@ describe RuboCop::Cop::Cop do
     context '#types' do
       subject { described_class.all.types }
       it('has types') { expect(subject.length).not_to eq(0) }
-      it { should include :lint }
-      it do
-        should include :rails
-      end
-      it { should include :style }
+      it { is_expected.to include(:lint) }
+      it { is_expected.to include(:rails) }
+      it { is_expected.to include(:style) }
       it 'contains every value only once' do
         expect(subject.length).to eq(subject.uniq.length)
       end
@@ -201,23 +199,23 @@ describe RuboCop::Cop::Cop do
 
     context 'when the option is not given' do
       let(:options) { {} }
-      it { should be false }
+      it { is_expected.to be(false) }
     end
 
     context 'when the option is given' do
       let(:options) { { auto_correct: true } }
-      it { should be true }
+      it { is_expected.to be(true) }
 
       context 'when cop does not support autocorrection' do
         let(:support_autocorrect) { false }
-        it { should be false }
+        it { is_expected.to be(false) }
       end
 
       context 'when the cop is set to not autocorrect' do
         let(:config) do
           RuboCop::Config.new('Cop/Cop' => { 'AutoCorrect' => 'False' })
         end
-        it { should be false }
+        it { is_expected.to be(false) }
       end
     end
   end

--- a/spec/rubocop/cop/team_spec.rb
+++ b/spec/rubocop/cop/team_spec.rb
@@ -13,12 +13,12 @@ describe RuboCop::Cop::Team do
 
     context 'when the option argument of .new is omitted' do
       subject { described_class.new(cop_classes, config).autocorrect? }
-      it { should be_falsey }
+      it { is_expected.to be_falsey }
     end
 
     context 'when { auto_correct: true } is passed to .new' do
       let(:options) { { auto_correct: true } }
-      it { should be_truthy }
+      it { is_expected.to be_truthy }
     end
   end
 
@@ -27,12 +27,12 @@ describe RuboCop::Cop::Team do
 
     context 'when the option argument of .new is omitted' do
       subject { described_class.new(cop_classes, config).debug? }
-      it { should be_falsey }
+      it { is_expected.to be_falsey }
     end
 
     context 'when { debug: true } is passed to .new' do
       let(:options) { { debug: true } }
-      it { should be_truthy }
+      it { is_expected.to be_truthy }
     end
   end
 

--- a/spec/rubocop/cop/util_spec.rb
+++ b/spec/rubocop/cop/util_spec.rb
@@ -51,17 +51,17 @@ describe RuboCop::Cop::Util do
 
     context 'when side is :both' do
       let(:side) { :both }
-      it { should eq(',Error,') }
+      it { is_expected.to eq(',Error,') }
     end
 
     context 'when side is :left' do
       let(:side) { :left }
-      it { should eq(',Error') }
+      it { is_expected.to eq(',Error') }
     end
 
     context 'when side is :right' do
       let(:side) { :right }
-      it { should eq('Error,') }
+      it { is_expected.to eq('Error,') }
     end
   end
 
@@ -76,17 +76,17 @@ describe RuboCop::Cop::Util do
 
     context 'when side is :both' do
       let(:side) { :both }
-      it { should eq('  a(2) ') }
+      it { is_expected.to eq('  a(2) ') }
     end
 
     context 'when side is :left' do
       let(:side) { :left }
-      it { should eq('  a(2)') }
+      it { is_expected.to eq('  a(2)') }
     end
 
     context 'when side is :right' do
       let(:side) { :right }
-      it { should eq('a(2) ') }
+      it { is_expected.to eq('a(2) ') }
     end
   end
 
@@ -95,7 +95,7 @@ describe RuboCop::Cop::Util do
     [1..1, 1...1, 1..2, 1...2, 1..3, 1...3, 1..-1, 1...-1].each do |range|
       context "with range #{range}" do
         subject { described_class.numeric_range_size(range) }
-        it { should eq(range.size) }
+        it { is_expected.to eq(range.size) }
       end
     end
   end

--- a/spec/rubocop/cop/variable_force/variable_spec.rb
+++ b/spec/rubocop/cop/variable_force/variable_spec.rb
@@ -27,14 +27,14 @@ describe RuboCop::Cop::VariableForce::Variable do
     subject { variable.referenced? }
 
     context 'when the variable is not assigned' do
-      it { should be_falsey }
+      it { is_expected.to be_falsey }
 
       context 'and the variable is referenced' do
         before do
           variable.reference!(s(:lvar, name))
         end
 
-        it { should be_truthy }
+        it { is_expected.to be_truthy }
       end
     end
 
@@ -44,7 +44,7 @@ describe RuboCop::Cop::VariableForce::Variable do
       end
 
       context 'and the variable is not yet referenced' do
-        it { should be_falsey }
+        it { is_expected.to be_falsey }
       end
 
       context 'and the variable is referenced' do
@@ -52,7 +52,7 @@ describe RuboCop::Cop::VariableForce::Variable do
           variable.reference!(s(:lvar, name))
         end
 
-        it { should be_truthy }
+        it { is_expected.to be_truthy }
       end
     end
   end

--- a/spec/rubocop/formatter/colorizable_spec.rb
+++ b/spec/rubocop/formatter/colorizable_spec.rb
@@ -34,7 +34,7 @@ module RuboCop
 
         shared_examples 'does nothing' do
           it 'does nothing' do
-            should eq('foo')
+            is_expected.to eq('foo')
           end
         end
 
@@ -49,7 +49,7 @@ module RuboCop
             end
 
             it 'colorize the passed string' do
-              should eq("\e[31mfoo\e[0m")
+              is_expected.to eq("\e[31mfoo\e[0m")
             end
           end
 


### PR DESCRIPTION
Updating the language in tests from the old `should` to the newer `is_expected.to`.