### PR TITLE
Fix autocorrection of PercentLiteralDelimiters with no content

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 * [#1773](https://github.com/bbatsov/rubocop/pull/1773): Fix typo ('strptime' -> 'strftime') in `Rails/TimeZone`. ([@palkan][])
 * [#1777](https://github.com/bbatsov/rubocop/pull/1777): Fix offense message from Rails/TimeZone. ([@mzp][])
 * Fix handling of `while` and `until` with assignment in `IndentationWidth`. ([@lumeet][])
+* [#1791](https://github.com/bbatsov/rubocop/pull/1791): Fix autocorrection of `PercentLiteralDelimiters` with no content. ([@cshaffer][])
 
 ## 0.30.0 (06/04/2015)
 

--- a/lib/rubocop/cop/style/percent_literal_delimiters.rb
+++ b/lib/rubocop/cop/style/percent_literal_delimiters.rb
@@ -76,6 +76,8 @@ module RuboCop
           case object
           when String
             ''
+          when NilClass
+            ''
           when Parser::AST::Node
             part_range = object.loc.send(part)
             left_of_part = part_range.source_line[0...part_range.column]

--- a/spec/rubocop/cop/style/percent_literal_delimiters_spec.rb
+++ b/spec/rubocop/cop/style/percent_literal_delimiters_spec.rb
@@ -225,6 +225,11 @@ describe RuboCop::Cop::Style::PercentLiteralDelimiters, :config do
       expect(new_source).to eq('%[string]')
     end
 
+    it 'fixes a string with no content' do
+      new_source = autocorrect_source(cop, '%()')
+      expect(new_source).to eq('%[]')
+    end
+
     it 'fixes a string array' do
       new_source = autocorrect_source(cop, '%w(some words)')
       expect(new_source).to eq('%w[some words]')


### PR DESCRIPTION
This fixes a bug where autocorrecting this line:

`puts %||`

would raise, rather than autocorrecting with this:

`puts %()`