### PR TITLE
[Fix #1794] Check if there are tokens before accessing them

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
 * [#1806](https://github.com/bbatsov/rubocop/issues/1806): Require a newer version of `parser` and use its corrected solution for comment association in `Style/Documentation`. ([@jonas054][])
 * [#1792](https://github.com/bbatsov/rubocop/issues/1792): Fix bugs in `Sample` that did not account for array selectors with a range and passing random to shuffle. ([@rrosenblum][])
 * [#1770](https://github.com/bbatsov/rubocop/pull/1770): Add more acceptable methods to `Rails/TimeZone` (`utc`, `localtime`, `to_i`, `iso8601` etc). ([@palkan][])
+* [#1795](https://github.com/bbatsov/rubocop/pull/1795): Fix bug in `TrailingBlankLines` that caused a crash for files containing only newlines. ([@renuo][])
 
 ## 0.30.0 (06/04/2015)
 
@@ -1351,3 +1352,4 @@
 [@mzp]: https://github.com/mzp
 [@bankair]: https://github.com/bankair
 [@crimsonknave]: https://github.com/crimsonknave
+[@renuo]: https://github.com/renuo

--- a/lib/rubocop/cop/style/trailing_blank_lines.rb
+++ b/lib/rubocop/cop/style/trailing_blank_lines.rb
@@ -16,8 +16,7 @@ module RuboCop
           # followed by some data to read. If so, we don't check it because
           # there could be good reasons why it needs to end with a certain
           # number of newlines.
-          extra = sb.source[processed_source.tokens.last.pos.end_pos..-1]
-          return if extra.strip.start_with?('__END__')
+          return if ends_in_end?(processed_source)
 
           whitespace_at_end = sb.source[/\s*\Z/]
           blank_lines = whitespace_at_end.count("\n") - 1
@@ -36,6 +35,16 @@ module RuboCop
         end
 
         private
+
+        def ends_in_end?(processed_source)
+          sb = processed_source.buffer
+
+          return true if sb.source.strip.start_with?('__END__')
+          return false if processed_source.tokens.empty?
+
+          extra = sb.source[processed_source.tokens.last.pos.end_pos..-1]
+          extra.strip.start_with?('__END__')
+        end
 
         def message(wanted_blank_lines, blank_lines)
           case blank_lines

--- a/spec/rubocop/cop/style/trailing_blank_lines_spec.rb
+++ b/spec/rubocop/cop/style/trailing_blank_lines_spec.rb
@@ -19,16 +19,23 @@ describe RuboCop::Cop::Style::TrailingBlankLines, :config do
     end
 
     it 'accepts final blank lines if they come after __END__' do
-      inspect_source(cop, ['x = 0',
-                           '',
-                           '__END__',
-                           '',
-                           ''])
+      inspect_source(cop, ['x = 0', '', '__END__', '', ''])
+      expect(cop.offenses).to be_empty
+    end
+
+    it 'accepts final blank lines if they come after __END__ in empty file' do
+      inspect_source(cop, ['__END__', '', '', ''])
       expect(cop.offenses).to be_empty
     end
 
     it 'registers an offense for multiple trailing blank lines' do
       inspect_source(cop, ['x = 0', '', '', '', ''])
+      expect(cop.offenses.size).to eq(1)
+      expect(cop.messages).to eq(['3 trailing blank lines detected.'])
+    end
+
+    it 'registers an offense for multiple blank lines in an empty file' do
+      inspect_source(cop, ['', '', '', '', ''])
       expect(cop.offenses.size).to eq(1)
       expect(cop.messages).to eq(['3 trailing blank lines detected.'])
     end
@@ -41,6 +48,11 @@ describe RuboCop::Cop::Style::TrailingBlankLines, :config do
     it 'auto-corrects unwanted blank lines' do
       new_source = autocorrect_source(cop, ['x = 0', '', '', '', ''])
       expect(new_source).to eq(['x = 0', ''].join("\n"))
+    end
+
+    it 'auto-corrects unwanted blank lines in an empty file' do
+      new_source = autocorrect_source(cop, ['', '', '', '', ''])
+      expect(new_source).to eq(['', ''].join("\n"))
     end
 
     it 'auto-corrects even if some lines have space' do
@@ -64,6 +76,13 @@ describe RuboCop::Cop::Style::TrailingBlankLines, :config do
         .to eq(['3 trailing blank lines instead of 1 detected.'])
     end
 
+    it 'registers an offense for multiple blank lines in an empty file' do
+      inspect_source(cop, ['', '', '', '', ''])
+      expect(cop.offenses.size).to eq(1)
+      expect(cop.messages)
+        .to eq(['3 trailing blank lines instead of 1 detected.'])
+    end
+
     it 'registers an offense for no final newline' do
       inspect_source(cop, 'x = 0')
       expect(cop.messages).to eq(['Final newline missing.'])
@@ -77,6 +96,11 @@ describe RuboCop::Cop::Style::TrailingBlankLines, :config do
     it 'auto-corrects unwanted blank lines' do
       new_source = autocorrect_source(cop, ['x = 0', '', '', '', ''])
       expect(new_source).to eq(['x = 0', '', ''].join("\n"))
+    end
+
+    it 'auto-corrects unwanted blank lines in an empty file' do
+      new_source = autocorrect_source(cop, ['', '', '', '', ''])
+      expect(new_source).to eq(['', '', ''].join("\n"))
     end
 
     it 'auto-corrects missing blank line' do


### PR DESCRIPTION
This PR fixes a problem occurring if rubocop scans empty files containing only new lines (#1794). I extracted the function determining the `__END__` token into an own method which respects empty token lists.

I'm not sure what to expect from autocorrection though.