### PR TITLE
[Fix #1793] Check in TrailingComma if found comma is in a comment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 * [#1777](https://github.com/bbatsov/rubocop/pull/1777): Fix offense message from Rails/TimeZone. ([@mzp][])
 * Fix handling of `while` and `until` with assignment in `IndentationWidth`. ([@lumeet][])
 * [#1791](https://github.com/bbatsov/rubocop/pull/1791): Fix autocorrection of `PercentLiteralDelimiters` with no content. ([@cshaffer][])
+* [#1793](https://github.com/bbatsov/rubocop/pull/1793): Fix bug in `TrailingComma` that caused `,` in comment to count as a trailing comma. ([@jonas054][])
 
 ## 0.30.0 (06/04/2015)
 

--- a/lib/rubocop/cop/style/trailing_comma.rb
+++ b/lib/rubocop/cop/style/trailing_comma.rb
@@ -78,7 +78,7 @@ module RuboCop
           comma_offset = after_last_item.source =~ /,/
           should_have_comma =
             [:comma, :consistent_comma].include?(style) && multiline?(node)
-          if comma_offset
+          if comma_offset && !inside_comment?(after_last_item, comma_offset)
             unless should_have_comma
               extra_info = case style
                            when :comma
@@ -96,6 +96,13 @@ module RuboCop
           end
         end
         # rubocop:enable Metrics/MethodLength
+
+        def inside_comment?(range, comma_offset)
+          processed_source.comments.any? do |comment|
+            comment_offset = comment.loc.expression.begin_pos - range.begin_pos
+            comment_offset >= 0 && comment_offset < comma_offset
+          end
+        end
 
         def heredoc?(source_after_last_item)
           source_after_last_item =~ /\w/

--- a/spec/rubocop/cop/style/trailing_comma_spec.rb
+++ b/spec/rubocop/cop/style/trailing_comma_spec.rb
@@ -178,6 +178,14 @@ describe RuboCop::Cop::Style::TrailingComma, :config do
         expect(cop.offenses).to be_empty
       end
 
+      it 'accepts comma in comment after last value item' do
+        inspect_source(cop, ['{ ',
+                             "  foo: 'foo',",
+                             "  bar: 'bar'.delete(',')#,",
+                             '}'])
+        expect(cop.offenses).to be_empty
+      end
+
       it 'auto-corrects unwanted comma in an Array literal' do
         new_source = autocorrect_source(cop, ['VALUES = [',
                                               '           1001,',
@@ -260,6 +268,16 @@ describe RuboCop::Cop::Style::TrailingComma, :config do
         inspect_source(cop, ['MAP = { a: 1001,',
                              '        b: 2020,',
                              '        c: 3333',
+                             '}'])
+        expect(cop.messages)
+          .to eq(['Put a comma after the last item of a multiline hash.'])
+        expect(cop.highlights).to eq(['c: 3333'])
+      end
+
+      it 'registers an offense for trailing comma in a comment in Hash' do
+        inspect_source(cop, ['MAP = { a: 1001,',
+                             '        b: 2020,',
+                             '        c: 3333 # ,',
                              '}'])
         expect(cop.messages)
           .to eq(['Put a comma after the last item of a multiline hash.'])


### PR DESCRIPTION
Amend the error-prone regexp matching (which is kept - no fundamentally different solution found) with checking the ranges of comments.