### PR TITLE
Bump parser dependency to 2.2.2.1 and fix Style/Documentation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 * Fix handling of `while` and `until` with assignment in `IndentationWidth`. ([@lumeet][])
 * [#1793](https://github.com/bbatsov/rubocop/pull/1793): Fix bug in `TrailingComma` that caused `,` in comment to count as a trailing comma. ([@jonas054][])
 * [#1765](https://github.com/bbatsov/rubocop/pull/1765): Update 1.9 hash to stop triggering when the symbol is not valid in the 1.9 hash syntax. ([@crimsonknave][])
+* [#1806](https://github.com/bbatsov/rubocop/issues/1806): Require a newer version of `parser` and use its corrected solution for comment association in `Style/Documentation`. ([@jonas054][])
 
 ## 0.30.0 (06/04/2015)
 

--- a/lib/rubocop/cop/style/documentation.rb
+++ b/lib/rubocop/cop/style/documentation.rb
@@ -83,16 +83,15 @@ module RuboCop
           comment_line =~ /^\s*#/
         end
 
-        # The :nodoc: comment is not actually associated with the class/module
-        # ifself but its first commentable child node. Unless the element is
-        # tagged with :nodoc:, the search proceeds to check its ancestors for
-        # :nodoc: all.
+        # First checks if the :nodoc: comment is associated with the
+        # class/module. Unless the element is tagged with :nodoc:, the search
+        # proceeds to check its ancestors for :nodoc: all.
+        # Note: How end-of-line comments are associated with code changed in
+        # parser-2.2.0.4.
         def nodoc?(node, ast_with_comments, require_all = false)
           return false unless node
-          nodoc_node = node.children.last
+          nodoc_node = node.children.first
           return false unless nodoc_node
-
-          nodoc_node = nodoc_node.children.first while nodoc_node.type == :begin
           comment = ast_with_comments[nodoc_node].first
 
           if comment && comment.loc.line == node.loc.line

--- a/rubocop.gemspec
+++ b/rubocop.gemspec
@@ -39,7 +39,7 @@ Gem::Specification.new do |s|
   s.summary = 'Automatic Ruby code style checking tool.'
 
   s.add_runtime_dependency('rainbow', '>= 1.99.1', '< 3.0')
-  s.add_runtime_dependency('parser', '>= 2.2.0.1', '< 3.0')
+  s.add_runtime_dependency('parser', '>= 2.2.2.1', '< 3.0')
   s.add_runtime_dependency('powerpack', '~> 0.1')
   s.add_runtime_dependency('astrolabe', '~> 1.3')
   s.add_runtime_dependency('ruby-progressbar', '~> 1.4')


### PR DESCRIPTION
How EOL comments are associated changed in 2.2.0.4. Update dependency to ensure we get the new behavior, and adapt `Documentation` cop to the new behavior.

This should fix the failing build on `master`.