### PR TITLE
[Fix #1816] Do not register an offense for shuffle when using all of the elements of the shuffled array

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 * [#1788](https://github.com/bbatsov/rubocop/pull/1788): New cop `ModuleLength` checks for overly long module definitions. ([@sdeframond][])
 
+### Bugs fixed
+
+* [#1816](https://github.com/bbatsov/rubocop/issues/1816): Fix bug in `Sample` when calling `#shuffle` with something other than an element selector. ([@rrosenblum][])
+
 ## 0.30.1 (21/04/2015)
 
 ### Bugs fixed

--- a/spec/rubocop/cop/performance/sample_spec.rb
+++ b/spec/rubocop/cop/performance/sample_spec.rb
@@ -40,15 +40,27 @@ describe RuboCop::Cop::Performance::Sample do
       .to eq(['Use `sample` instead of `shuffle(random)`.'])
   end
 
-  it 'when using shuffle with a defined random' do
+  it 'registers an offense when using shuffle with a defined random' do
     inspect_source(cop, '[1, 2, 3, 4].shuffle(random: Random.new(1))')
 
     expect(cop.messages)
       .to eq(['Use `sample` instead of `shuffle(random: Random.new(1))`.'])
   end
 
-  it 'does not registers an offense when using sample' do
+  it 'does not register an offense when using sample' do
     inspect_source(cop, '[1, 2, 3, 4].sample')
+
+    expect(cop.messages).to be_empty
+  end
+
+  it 'does not register an offense when calling a method on shuffle' do
+    inspect_source(cop, '[1, 2, 3, 4].shuffle.join([5, 6, 7])')
+
+    expect(cop.messages).to be_empty
+  end
+
+  it 'does not register an offense when calling map on shuffle' do
+    inspect_source(cop, '[1, 2, 3, 4].shuffle.map { |e| e }')
 
     expect(cop.messages).to be_empty
   end


### PR DESCRIPTION
This fixes #1816. I was missing some important negative test cases when I implemented the fix for `shuffle[0, 3]`. This lead to the code moving away from only checking for usages of `shuffle.first`, `shuffle.last`, and `shuffle[]`. I have added in some negative tests and added back in the checks for calls to `.first`, `.last`, and `[]`.