### PR TITLE
Add auto-correct to CommentAnnotation cop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 * Recognize rackup file (config.ru) out of the box. ([@carhartl][])
 * [#1788](https://github.com/bbatsov/rubocop/pull/1788): New cop `ModuleLength` checks for overly long module definitions. ([@sdeframond][])
 * New cop `Performance/Count` to convert `Enumerable#select...size`, `Enumerable#reject...size`, `Enumerable#select...count`, `Enumerable#reject...count` `Enumerable#select...length`, and `Enumerable#reject...length` to `Enumerable#count`. ([@rrosenblum][])
+* `CommentAnnotation` cop does auto-correction. ([@dylandavidson][])
 
 ### Bugs fixed
 
@@ -1369,3 +1370,4 @@
 [@sdeframond]: https://github.com/sdeframond
 [@til]: https://github.com/til
 [@carhartl]: https://github.com/carhartl
+[@dylandavidson]: https://github.com/dylandavidson

--- a/lib/rubocop/cop/style/comment_annotation.rb
+++ b/lib/rubocop/cop/style/comment_annotation.rb
@@ -18,15 +18,22 @@ module RuboCop
                         !correct_annotation?(first_word, colon, space, note)
 
             start = comment.loc.expression.begin_pos + margin.length
-            length = first_word.length + (colon || '').length
+            length = first_word.length + colon.to_s.length + space.to_s.length
             range = Parser::Source::Range.new(processed_source.buffer,
                                               start,
                                               start + length)
-            add_offense(nil, range)
+            add_offense(range, range)
           end
         end
 
         private
+
+        def autocorrect(range)
+          @corrections << lambda do |corrector|
+            annotation_keyword = range.source.split(/:?\s+/).first
+            corrector.replace(range, annotation_keyword.upcase << ': ')
+          end
+        end
 
         def correct_annotation?(first_word, colon, space, note)
           keyword?(first_word) && (colon && space && note || !colon && !note)

--- a/spec/rubocop/cop/style/comment_annotation_spec.rb
+++ b/spec/rubocop/cop/style/comment_annotation_spec.rb
@@ -13,12 +13,22 @@ describe RuboCop::Cop::Style::CommentAnnotation, :config do
     expect(cop.offenses.size).to eq(1)
   end
 
+  it 'autocorrects a missing colon' do
+    corrected = autocorrect_source(cop, '# TODO make better')
+    expect(corrected).to eq('# TODO: make better')
+  end
+
   context 'with configured keyword' do
     let(:cop_config) { { 'Keywords' => %w(ISSUE) } }
 
     it 'registers an offense for a missing colon after the word' do
       inspect_source(cop, '# ISSUE wrong order')
       expect(cop.offenses.size).to eq(1)
+    end
+
+    it 'autocorrects a missing colon after keyword' do
+      corrected = autocorrect_source(cop, '# ISSUE wrong order')
+      expect(corrected).to eq('# ISSUE: wrong order')
     end
   end
 
@@ -41,9 +51,19 @@ describe RuboCop::Cop::Style::CommentAnnotation, :config do
     expect(cop.offenses.size).to eq(1)
   end
 
+  it 'autocorrects lower case' do
+    corrected = autocorrect_source(cop, '# fixme: does not work')
+    expect(corrected).to eq('# FIXME: does not work')
+  end
+
   it 'registers an offense for capitalized annotation keyword' do
     inspect_source(cop, '# Optimize: does not work')
     expect(cop.offenses.size).to eq(1)
+  end
+
+  it 'autocorrects a capitalized annotation keyword' do
+    corrected = autocorrect_source(cop, '# Optimize: does not work')
+    expect(corrected).to eq('# OPTIMIZE: does not work')
   end
 
   it 'registers an offense for upper case with colon but no note' do


### PR DESCRIPTION
As it says, this adds auto-correct for `CommentAnnotation`.

Some examples:
```
WAS:
# TODO make better
BECOMES:
# TODO: make better

WAS:
# fixme: does not work
BECOMES:
# FIXME: does not work

WAS:
# Optimize: does not work
BECOMES:
# OPTIMIZE: does not work
```

Includes specs to reflect these cases. Also, this cop should be taken off [this wiki](https://github.com/bbatsov/rubocop/wiki/Automatic-Corrections) since this adds auto-correct for it.