### PR TITLE
[Fix #1820] Check only keys starting their lines in AlignHash

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 
 * [#1816](https://github.com/bbatsov/rubocop/issues/1816): Fix bug in `Sample` when calling `#shuffle` with something other than an element selector. ([@rrosenblum][])
 * [#1768](https://github.com/bbatsov/rubocop/pull/1768): `DefEndAlignment` recognizes preceding `private_class_method` or `public_class_method` before `def`. ([@til][])
+* [#1820](https://github.com/bbatsov/rubocop/issues/1820): Correct the logic in `AlignHash` for when to ignore a key because it's not on its own line. ([@jonas054][])
 
 ## 0.30.1 (21/04/2015)
 

--- a/spec/rubocop/cop/style/align_hash_spec.rb
+++ b/spec/rubocop/cop/style/align_hash_spec.rb
@@ -19,7 +19,14 @@ describe RuboCop::Cop::Style::AlignHash, :config do
 
     it "does not auto-correct pairs that don't start a line" do
       source = ['render :json => {:a => messages,',
-                '                 :b => :json}, :status => 404']
+                '                 :b => :json}, :status => 404',
+                'def example',
+                '  a(',
+                '    b: :c,',
+                '    d: e(',
+                '      f: g',
+                '    ), h: :i)',
+                'end']
       new_source = autocorrect_source(cop, source)
       expect(new_source).to eq(source.join("\n"))
     end


### PR DESCRIPTION
The problem was that we checked if a key was on the same line as the start of the previous key. That's no good, because it could be on the same line as the end of the previous key, and that's just as bad.