### PR TITLE
Count cop

### DIFF
--- a/lib/rubocop/cop/performance/count.rb
+++ b/lib/rubocop/cop/performance/count.rb
@@ -27,33 +27,57 @@ module RuboCop
         COUNTERS = [:count, :length, :size]
 
         def on_send(node)
-          left, second_method = *node
-          expression, = *left
-          _enumerable, first_method = *expression
+          expression, first_method, second_method, third_method = parse(node)
 
-          return unless COUNTERS.include?(second_method)
-          return unless SELECTORS.include?(first_method)
+          return unless COUNTERS.include?(third_method)
+
+          begin_pos = if SELECTORS.include?(first_method)
+                        return if second_method.is_a?(Symbol)
+                        expression.loc.selector.begin_pos
+                      else
+                        return unless SELECTORS.include?(second_method)
+                        expression.parent.loc.selector.begin_pos
+                      end
+
           return if node.parent && node.parent.block_type?
 
-          add_offense(node,
-                      node.loc.selector,
-                      format(MSG, first_method, second_method))
+          range = Parser::Source::Range.new(node.loc.expression.source_buffer,
+                                            begin_pos,
+                                            node.loc.expression.end_pos)
+
+          add_offense(node, range,
+                      format(MSG, first_method || second_method, third_method))
         end
 
         def autocorrect(node)
-          left, = *node
-          expression, = *left
-          _enumerable, first_method = *expression
+          expression, first_method, second_method, = parse(node)
 
-          return if first_method == :reject
+          fail CorrectionNotPossible if first_method == :reject ||
+                                        second_method == :reject
+
+          selector = if SELECTORS.include?(first_method)
+                       expression.loc.selector
+                     else
+                       expression.parent.loc.selector
+                     end
 
           @corrections << lambda do |corrector|
             range = Parser::Source::Range.new(node.loc.expression.source_buffer,
                                               node.loc.dot.begin_pos,
                                               node.loc.expression.end_pos)
             corrector.remove(range)
-            corrector.replace(expression.loc.selector, 'count')
+            corrector.replace(selector, 'count')
           end
+        end
+
+        private
+
+        def parse(node)
+          left, third_method = *node
+          expression, second_method = *left
+          _enumerable, first_method = *expression
+
+          [expression, first_method, second_method, third_method]
         end
       end
     end

--- a/lib/rubocop/formatter/simple_text_formatter.rb
+++ b/lib/rubocop/formatter/simple_text_formatter.rb
@@ -70,7 +70,7 @@ module RuboCop
 
       def count_stats(offenses)
         @total_offense_count += offenses.count
-        @total_correction_count += offenses.select(&:corrected?).count
+        @total_correction_count += offenses.count(&:corrected?)
       end
 
       def smart_path(path)


### PR DESCRIPTION
This fixes  #1824. 

* The cop will no longer report an offense for `array.select(&:value).uniq.count`
* It will report an offense for `puts array.select(&:value).count`
* I have also fixed a bug with the range for the highlight of the offense
