### PR TITLE
Fix bug that would report offenses being auto-corrected when they were not

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 * [#1816](https://github.com/bbatsov/rubocop/issues/1816): Fix bug in `Sample` when calling `#shuffle` with something other than an element selector. ([@rrosenblum][])
 * [#1768](https://github.com/bbatsov/rubocop/pull/1768): `DefEndAlignment` recognizes preceding `private_class_method` or `public_class_method` before `def`. ([@til][])
 * [#1820](https://github.com/bbatsov/rubocop/issues/1820): Correct the logic in `AlignHash` for when to ignore a key because it's not on its own line. ([@jonas054][])
+* Fix bug in `Sample` and `FlatMap` that would cause them to report having been auto-corrected when they were not. ([@rrosenblum][])
 
 ## 0.30.1 (21/04/2015)
 

--- a/lib/rubocop/cop/performance/flat_map.rb
+++ b/lib/rubocop/cop/performance/flat_map.rb
@@ -46,7 +46,7 @@ module RuboCop
         def autocorrect(node)
           receiver, _flatten, flatten_param  = *node
           flatten_level, = *flatten_param
-          return if flatten_level.nil?
+          fail CorrectionNotPossible if flatten_level.nil?
           array, = *receiver
 
           @corrections << lambda do |corrector|

--- a/lib/rubocop/cop/performance/sample.rb
+++ b/lib/rubocop/cop/performance/sample.rb
@@ -36,7 +36,7 @@ module RuboCop
           _receiver, _method, params, selector = *node
           _receiver, _method, params, selector = *node.parent if params.nil?
 
-          return if params && RANGE_TYPES.include?(params.type)
+          fail CorrectionNotPossible unless correction_possible?(params)
 
           range = if params && (params.hash_type? || params.lvar_type?)
                     range_of_shuffle(node)
@@ -54,6 +54,10 @@ module RuboCop
         end
 
         private
+
+        def correction_possible?(params)
+          params.nil? || !RANGE_TYPES.include?(params.type)
+        end
 
         def message(node, params)
           if params && params.lvar_type?


### PR DESCRIPTION
In fixing the some bugs in the `Sample` cop, I noticed that some offenses were reporting that they had been corrected when they were not. I found out that I should be using `fail CorrectionNotPossible` instead of `return` in `autocorrect` when the error cannot be corrected.