### PR TITLE
Exclude RSpec files from PredicateName cop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,6 +56,7 @@
 * [#3064](https://github.com/bbatsov/rubocop/pull/3064): `Style/SpaceAfterNot` highlights the entire expression instead of just the exlamation mark. ([@rrosenblum][])
 * [#3085](https://github.com/bbatsov/rubocop/pull/3085): Enable `Style/MultilineArrayBraceLayout` and `Style/MultilineHashBraceLayout` with the `symmetrical` style by default. ([@panthomakos][])
 * [#3091](https://github.com/bbatsov/rubocop/pull/3091): Enable `Style/MultilineMethodCallBraceLayout` and `Style/MultilineMethodDefinitionBraceLayout` with the `symmetrical` style by default. ([@panthomakos][])
+* [#1830](https://github.com/bbatsov/rubocop/pull/1830): `Style/PredicateName` now ignores the `spec/` directory, since there is a strong convention for using `have_*` and `be_*` helper methods in RSpec. ([@gylaz][])
 
 ## 0.39.0 (2016-03-27)
 
@@ -2145,3 +2146,4 @@
 [@akihiro17]: https://github.com/akihiro17
 [@magni-]: https://github.com/magni-
 [@NobodysNightmare]: https://github.com/NobodysNightmare
+[@gylaz]: https://github.com/gylaz

--- a/config/default.yml
+++ b/config/default.yml
@@ -763,6 +763,10 @@ Style/PredicateName:
   # should still be accepted
   NameWhitelist:
     - is_a?
+  # Exclude Rspec specs because there is a strong convetion to write spec
+  # helpers in the form of `have_something` or `be_something`.
+  Exclude:
+    - 'spec/**/*'
 
 Style/RaiseArgs:
   EnforcedStyle: exploded


### PR DESCRIPTION
Using [Predicate matchers][predicates] is a common convention
within the RSpec community.

[Related blog post][blog-post].

[predicates]: https://www.relishapp.com/rspec/rspec-expectations/v/3-2/docs/built-in-matchers/predicate-matchers
[blog-post]: http://www.elabs.se/blog/51-simple-tricks-to-clean-up-your-capybara-tests