### PR TITLE
Use CorrectionNotPossible in UnusedArgument#autocorrect

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,8 @@
 * [#1816](https://github.com/bbatsov/rubocop/issues/1816): Fix bug in `Sample` when calling `#shuffle` with something other than an element selector. ([@rrosenblum][])
 * [#1768](https://github.com/bbatsov/rubocop/pull/1768): `DefEndAlignment` recognizes preceding `private_class_method` or `public_class_method` before `def`. ([@til][])
 * [#1820](https://github.com/bbatsov/rubocop/issues/1820): Correct the logic in `AlignHash` for when to ignore a key because it's not on its own line. ([@jonas054][])
-* Fix bug in `Sample` and `FlatMap` that would cause them to report having been auto-corrected when they were not. ([@rrosenblum][])
+* [#1829](https://github.com/bbatsov/rubocop/pull/1829): Fix bug in `Sample` and `FlatMap` that would cause them to report having been auto-corrected when they were not. ([@rrosenblum][])
+* [#1832](https://github.com/bbatsov/rubocop/pull/1832): Fix bug in `UnusedMethodArgument` that would cause them to report having been auto-corrected when they were not. ([@jonas054][])
 
 ## 0.30.1 (21/04/2015)
 

--- a/lib/rubocop/cop/mixin/unused_argument.rb
+++ b/lib/rubocop/cop/mixin/unused_argument.rb
@@ -24,7 +24,7 @@ module RuboCop
         end
 
         def autocorrect(node)
-          return if [:kwarg, :kwoptarg].include?(node.type)
+          fail CorrectionNotPossible if [:kwarg, :kwoptarg].include?(node.type)
 
           @corrections << lambda do |corrector|
             corrector.insert_before(node.loc.name, '_')

--- a/lib/rubocop/cop/rails/delegate.rb
+++ b/lib/rubocop/cop/rails/delegate.rb
@@ -41,10 +41,7 @@ module RuboCop
         private
 
         def autocorrect(node)
-          method_name, args, body = *node
-          return unless trivial_delegate?(method_name, args, body)
-          return if private_or_protected_delegation(node)
-
+          method_name, _args, body = *node
           delegation = ["delegate :#{body.children[1]}",
                         "to: :#{body.children[0].children[1]}"]
           if method_name == prefixed_method_name(body)

--- a/lib/rubocop/cop/style/method_call_parentheses.rb
+++ b/lib/rubocop/cop/style/method_call_parentheses.rb
@@ -17,13 +17,6 @@ module RuboCop
         end
 
         def autocorrect(node)
-          # Bail out if the call is going to be auto-corrected by EmptyLiteral.
-          if config.for_cop('Style/EmptyLiteral')['Enabled'] &&
-             [EmptyLiteral::HASH_NODE,
-              EmptyLiteral::ARRAY_NODE,
-              EmptyLiteral::STR_NODE].include?(node)
-            return
-          end
           @corrections << lambda do |corrector|
             corrector.remove(node.loc.begin)
             corrector.remove(node.loc.end)

--- a/spec/rubocop/cop/style/method_call_parentheses_spec.rb
+++ b/spec/rubocop/cop/style/method_call_parentheses_spec.rb
@@ -2,11 +2,8 @@
 
 require 'spec_helper'
 
-describe RuboCop::Cop::Style::MethodCallParentheses, :config do
-  subject(:cop) { described_class.new(config) }
-  let(:config) do
-    RuboCop::Config.new('Style/EmptyLiteral' => { 'Enabled' => true })
-  end
+describe RuboCop::Cop::Style::MethodCallParentheses do
+  subject(:cop) { described_class.new }
 
   it 'registers an offense for parens in method call without args' do
     inspect_source(cop, 'top.test()')
@@ -33,27 +30,15 @@ describe RuboCop::Cop::Style::MethodCallParentheses, :config do
     expect(new_source).to eq('test')
   end
 
-  it 'does not auto-correct calls that will be changed to empty literals' do
+  # These will be offenses for the EmptyLiteral cop. The autocorrect loop will
+  # handle that.
+  it 'auto-corrects calls that could be empty literals' do
     original = ['Hash.new()',
                 'Array.new()',
                 'String.new()']
     new_source = autocorrect_source(cop, original)
-    expect(new_source).to eq(original.join("\n"))
-  end
-
-  context 'when EmptyLiteral is disabled' do
-    let(:config) do
-      RuboCop::Config.new('Style/EmptyLiteral' => { 'Enabled' => false })
-    end
-
-    it 'auto-corrects calls that could be empty literals' do
-      original = ['Hash.new()',
-                  'Array.new()',
-                  'String.new()']
-      new_source = autocorrect_source(cop, original)
-      expect(new_source).to eq(['Hash.new',
-                                'Array.new',
-                                'String.new'].join("\n"))
-    end
+    expect(new_source).to eq(['Hash.new',
+                              'Array.new',
+                              'String.new'].join("\n"))
   end
 end


### PR DESCRIPTION
One remaining case where `[Corrected]` would be reported when nothing was changed.

Also remove unneeded returns in `Delegate` ("dead code") and `MethodCallParentheses` (unnecessary since the autocorrect loop handles conflicts).