### PR TITLE
Autocorrect refactorings

### DIFF
--- a/lib/rubocop/cop/cop.rb
+++ b/lib/rubocop/cop/cop.rb
@@ -2,7 +2,6 @@
 
 module RuboCop
   module Cop
-    class CorrectionNotPossible < Exception; end
     class AmbiguousCopName < Exception; end
 
     # Store for all cops with helper functions
@@ -162,10 +161,7 @@ module RuboCop
         return nil unless support_autocorrect?
         return false unless autocorrect?
 
-        autocorrect(node)
-        true
-      rescue CorrectionNotPossible
-        false
+        autocorrect(node) ? true : false
       end
 
       def config_to_allow_offenses

--- a/lib/rubocop/cop/cop.rb
+++ b/lib/rubocop/cop/cop.rb
@@ -161,7 +161,10 @@ module RuboCop
         return nil unless support_autocorrect?
         return false unless autocorrect?
 
-        autocorrect(node) ? true : false
+        correction = autocorrect(node)
+        return false unless correction
+        @corrections << correction
+        true
       end
 
       def config_to_allow_offenses

--- a/lib/rubocop/cop/lint/block_alignment.rb
+++ b/lib/rubocop/cop/lint/block_alignment.rb
@@ -143,7 +143,7 @@ module RuboCop
           ancestor_node = ancestor_on_same_line(node)
           source = node.loc.expression.source_buffer
 
-          @corrections << lambda do |corrector|
+          lambda do |corrector|
             start_col = (ancestor_node || node).loc.expression.column
             starting_position_of_block_end = node.loc.end.begin_pos
             end_col = node.loc.end.column

--- a/lib/rubocop/cop/lint/deprecated_class_methods.rb
+++ b/lib/rubocop/cop/lint/deprecated_class_methods.rb
@@ -29,7 +29,7 @@ module RuboCop
         end
 
         def autocorrect(node)
-          @corrections << lambda do |corrector|
+          lambda do |corrector|
             receiver, method_name, *_args = *node
 
             DEPRECATED_METHODS.each do |data|

--- a/lib/rubocop/cop/lint/space_before_first_arg.rb
+++ b/lib/rubocop/cop/lint/space_before_first_arg.rb
@@ -36,7 +36,7 @@ module RuboCop
         end
 
         def autocorrect(range)
-          @corrections << ->(corrector) { corrector.insert_before(range, ' ') }
+          ->(corrector) { corrector.insert_before(range, ' ') }
         end
       end
     end

--- a/lib/rubocop/cop/lint/string_conversion_in_interpolation.rb
+++ b/lib/rubocop/cop/lint/string_conversion_in_interpolation.rb
@@ -32,7 +32,7 @@ module RuboCop
         private
 
         def autocorrect(node)
-          @corrections << lambda do |corrector|
+          lambda do |corrector|
             receiver, _method_name, *_args = *node
             corrector.replace(
               node.loc.expression,

--- a/lib/rubocop/cop/mixin/autocorrect_alignment.rb
+++ b/lib/rubocop/cop/mixin/autocorrect_alignment.rb
@@ -35,7 +35,7 @@ module RuboCop
         # value of @column_delta. A local variable fixes the problem.
         column_delta = @column_delta
 
-        fail CorrectionNotPossible if block_comment_within?(expr)
+        return if block_comment_within?(expr)
 
         @corrections << lambda do |corrector|
           each_line(expr) do |line_begin_pos|

--- a/lib/rubocop/cop/mixin/autocorrect_alignment.rb
+++ b/lib/rubocop/cop/mixin/autocorrect_alignment.rb
@@ -37,7 +37,7 @@ module RuboCop
 
         return if block_comment_within?(expr)
 
-        @corrections << lambda do |corrector|
+        lambda do |corrector|
           each_line(expr) do |line_begin_pos|
             autocorrect_line(corrector, line_begin_pos, expr, column_delta,
                              heredoc_ranges)

--- a/lib/rubocop/cop/mixin/autocorrect_unless_changing_ast.rb
+++ b/lib/rubocop/cop/mixin/autocorrect_unless_changing_ast.rb
@@ -18,7 +18,7 @@ module RuboCop
           return
         end
 
-        @corrections << correction(node)
+        correction(node)
       end
 
       private

--- a/lib/rubocop/cop/mixin/autocorrect_unless_changing_ast.rb
+++ b/lib/rubocop/cop/mixin/autocorrect_unless_changing_ast.rb
@@ -15,7 +15,7 @@ module RuboCop
 
         # Make the correction only if it doesn't change the AST for the buffer.
         if processed_source.ast != ProcessedSource.new(new_buffer_src).ast
-          fail CorrectionNotPossible
+          return
         end
 
         @corrections << correction(node)

--- a/lib/rubocop/cop/mixin/empty_lines_around_body.rb
+++ b/lib/rubocop/cop/mixin/empty_lines_around_body.rb
@@ -12,7 +12,7 @@ module RuboCop
         MSG_MISSING = 'Empty line missing at %s body %s.'
 
         def autocorrect(range)
-          @corrections << lambda do |corrector|
+          lambda do |corrector|
             case style
             when :no_empty_lines then corrector.remove(range)
             when :empty_lines    then corrector.insert_before(range, "\n")

--- a/lib/rubocop/cop/mixin/space_after_punctuation.rb
+++ b/lib/rubocop/cop/mixin/space_after_punctuation.rb
@@ -24,9 +24,7 @@ module RuboCop
       end
 
       def autocorrect(token)
-        @corrections << lambda do |corrector|
-          corrector.replace(token.pos, token.pos.source + ' ')
-        end
+        ->(corrector) { corrector.replace(token.pos, token.pos.source + ' ') }
       end
     end
   end

--- a/lib/rubocop/cop/mixin/space_before_punctuation.rb
+++ b/lib/rubocop/cop/mixin/space_before_punctuation.rb
@@ -23,9 +23,7 @@ module RuboCop
       end
 
       def autocorrect(pos_before_punctuation)
-        @corrections << lambda do |corrector|
-          corrector.remove(pos_before_punctuation)
-        end
+        ->(corrector) { corrector.remove(pos_before_punctuation) }
       end
     end
   end

--- a/lib/rubocop/cop/mixin/space_inside.rb
+++ b/lib/rubocop/cop/mixin/space_inside.rb
@@ -27,7 +27,7 @@ module RuboCop
       end
 
       def autocorrect(range)
-        @corrections << ->(corrector) { corrector.remove(range) }
+        ->(corrector) { corrector.remove(range) }
       end
 
       # Wraps info about the brackets. Makes it easy to check whether a token

--- a/lib/rubocop/cop/mixin/string_literals_help.rb
+++ b/lib/rubocop/cop/mixin/string_literals_help.rb
@@ -17,7 +17,7 @@ module RuboCop
       end
 
       def autocorrect(node)
-        @corrections << lambda do |corrector|
+        lambda do |corrector|
           replacement = node.loc.begin.is?('"') ? "'" : '"'
           corrector.replace(node.loc.begin, replacement)
           corrector.replace(node.loc.end, replacement)

--- a/lib/rubocop/cop/mixin/unused_argument.rb
+++ b/lib/rubocop/cop/mixin/unused_argument.rb
@@ -26,9 +26,7 @@ module RuboCop
         def autocorrect(node)
           return if [:kwarg, :kwoptarg].include?(node.type)
 
-          @corrections << lambda do |corrector|
-            corrector.insert_before(node.loc.name, '_')
-          end
+          ->(corrector) { corrector.insert_before(node.loc.name, '_') }
         end
       end
     end

--- a/lib/rubocop/cop/mixin/unused_argument.rb
+++ b/lib/rubocop/cop/mixin/unused_argument.rb
@@ -24,7 +24,7 @@ module RuboCop
         end
 
         def autocorrect(node)
-          fail CorrectionNotPossible if [:kwarg, :kwoptarg].include?(node.type)
+          return if [:kwarg, :kwoptarg].include?(node.type)
 
           @corrections << lambda do |corrector|
             corrector.insert_before(node.loc.name, '_')

--- a/lib/rubocop/cop/performance/count.rb
+++ b/lib/rubocop/cop/performance/count.rb
@@ -60,7 +60,7 @@ module RuboCop
                        expression.parent.loc.selector
                      end
 
-          @corrections << lambda do |corrector|
+          lambda do |corrector|
             range = Parser::Source::Range.new(node.loc.expression.source_buffer,
                                               node.loc.dot.begin_pos,
                                               node.loc.expression.end_pos)

--- a/lib/rubocop/cop/performance/count.rb
+++ b/lib/rubocop/cop/performance/count.rb
@@ -52,8 +52,7 @@ module RuboCop
         def autocorrect(node)
           expression, first_method, second_method, = parse(node)
 
-          fail CorrectionNotPossible if first_method == :reject ||
-                                        second_method == :reject
+          return if first_method == :reject || second_method == :reject
 
           selector = if SELECTORS.include?(first_method)
                        expression.loc.selector

--- a/lib/rubocop/cop/performance/detect.rb
+++ b/lib/rubocop/cop/performance/detect.rb
@@ -58,7 +58,7 @@ module RuboCop
 
           receiver, _args, _body = *receiver if receiver.block_type?
 
-          @corrections << lambda do |corrector|
+          lambda do |corrector|
             corrector.remove(first_range)
             corrector.replace(receiver.loc.selector, replacement)
           end

--- a/lib/rubocop/cop/performance/flat_map.rb
+++ b/lib/rubocop/cop/performance/flat_map.rb
@@ -46,7 +46,8 @@ module RuboCop
         def autocorrect(node)
           receiver, _flatten, flatten_param  = *node
           flatten_level, = *flatten_param
-          fail CorrectionNotPossible if flatten_level.nil?
+          return if flatten_level.nil?
+
           array, = *receiver
 
           @corrections << lambda do |corrector|

--- a/lib/rubocop/cop/performance/flat_map.rb
+++ b/lib/rubocop/cop/performance/flat_map.rb
@@ -50,7 +50,7 @@ module RuboCop
 
           array, = *receiver
 
-          @corrections << lambda do |corrector|
+          lambda do |corrector|
             range = Parser::Source::Range.new(node.loc.expression.source_buffer,
                                               node.loc.dot.begin_pos,
                                               node.loc.expression.end_pos)

--- a/lib/rubocop/cop/performance/reverse_each.rb
+++ b/lib/rubocop/cop/performance/reverse_each.rb
@@ -33,9 +33,7 @@ module RuboCop
         end
 
         def autocorrect(node)
-          @corrections << lambda do |corrector|
-            corrector.replace(node.loc.dot, '_')
-          end
+          ->(corrector) { corrector.replace(node.loc.dot, '_') }
         end
       end
     end

--- a/lib/rubocop/cop/performance/sample.rb
+++ b/lib/rubocop/cop/performance/sample.rb
@@ -36,7 +36,7 @@ module RuboCop
           _receiver, _method, params, selector = *node
           _receiver, _method, params, selector = *node.parent if params.nil?
 
-          fail CorrectionNotPossible unless correction_possible?(params)
+          return if params && RANGE_TYPES.include?(params.type)
 
           range = if params && (params.hash_type? || params.lvar_type?)
                     range_of_shuffle(node)
@@ -54,10 +54,6 @@ module RuboCop
         end
 
         private
-
-        def correction_possible?(params)
-          params.nil? || !RANGE_TYPES.include?(params.type)
-        end
 
         def message(node, params)
           if params && params.lvar_type?

--- a/lib/rubocop/cop/performance/sample.rb
+++ b/lib/rubocop/cop/performance/sample.rb
@@ -46,7 +46,7 @@ module RuboCop
                                               node.parent.loc.selector.end_pos)
                   end
 
-          @corrections << lambda do |corrector|
+          lambda do |corrector|
             corrector.replace(range, 'sample')
             return if selector.nil?
             corrector.insert_after(range, "(#{selector.loc.expression.source})")

--- a/lib/rubocop/cop/performance/size.rb
+++ b/lib/rubocop/cop/performance/size.rb
@@ -38,9 +38,7 @@ module RuboCop
         end
 
         def autocorrect(node)
-          @corrections << lambda do |corrector|
-            corrector.replace(node.loc.selector, 'size')
-          end
+          ->(corrector) { corrector.replace(node.loc.selector, 'size') }
         end
 
         private

--- a/lib/rubocop/cop/rails/action_filter.rb
+++ b/lib/rubocop/cop/rails/action_filter.rb
@@ -31,7 +31,7 @@ module RuboCop
         end
 
         def autocorrect(node)
-          @corrections << lambda do |corrector|
+          lambda do |corrector|
             corrector.replace(node.loc.selector,
                               preferred_method(node.loc.selector.source).to_s)
           end

--- a/lib/rubocop/cop/rails/delegate.rb
+++ b/lib/rubocop/cop/rails/delegate.rb
@@ -48,7 +48,7 @@ module RuboCop
             delegation << ['prefix: true']
           end
 
-          @corrections << lambda do |corrector|
+          lambda do |corrector|
             corrector.replace(node.loc.expression, delegation.join(', '))
           end
         end

--- a/lib/rubocop/cop/rails/find_by.rb
+++ b/lib/rubocop/cop/rails/find_by.rb
@@ -41,7 +41,7 @@ module RuboCop
             node.loc.selector.end_pos
           )
 
-          @corrections << lambda do |corrector|
+          lambda do |corrector|
             corrector.replace(where_loc, 'find_by')
             corrector.replace(first_loc, '')
           end

--- a/lib/rubocop/cop/rails/find_each.rb
+++ b/lib/rubocop/cop/rails/find_each.rb
@@ -31,9 +31,7 @@ module RuboCop
         def autocorrect(node)
           each_loc = node.loc.selector
 
-          @corrections << lambda do |corrector|
-            corrector.replace(each_loc, 'find_each')
-          end
+          ->(corrector) { corrector.replace(each_loc, 'find_each') }
         end
       end
     end

--- a/lib/rubocop/cop/rails/read_write_attribute.rb
+++ b/lib/rubocop/cop/rails/read_write_attribute.rb
@@ -47,9 +47,7 @@ module RuboCop
             replacement = write_attribute_replacement(node)
           end
 
-          @corrections << lambda do |corrector|
-            corrector.replace(node.loc.expression, replacement)
-          end
+          ->(corrector) { corrector.replace(node.loc.expression, replacement) }
         end
 
         private

--- a/lib/rubocop/cop/style/alias.rb
+++ b/lib/rubocop/cop/style/alias.rb
@@ -31,7 +31,7 @@ module RuboCop
         end
 
         def autocorrect(node)
-          @corrections << lambda do |corrector|
+          lambda do |corrector|
             # replace alias with alias_method
             corrector.replace(node.loc.keyword, 'alias_method')
             # insert a comma

--- a/lib/rubocop/cop/style/align_hash.rb
+++ b/lib/rubocop/cop/style/align_hash.rb
@@ -230,7 +230,7 @@ module RuboCop
 
           key, value = *node
 
-          @corrections << lambda do |corrector|
+          lambda do |corrector|
             adjust(corrector, key_delta, key.loc.expression)
             adjust(corrector, separator_delta, node.loc.operator)
             adjust(corrector, value_delta, value.loc.expression)

--- a/lib/rubocop/cop/style/attr.rb
+++ b/lib/rubocop/cop/style/attr.rb
@@ -14,9 +14,7 @@ module RuboCop
         end
 
         def autocorrect(node)
-          @corrections << lambda do |corrector|
-            corrector.replace(node.loc.selector, 'attr_reader')
-          end
+          ->(corrector) { corrector.replace(node.loc.selector, 'attr_reader') }
         end
       end
     end

--- a/lib/rubocop/cop/style/bare_percent_literals.rb
+++ b/lib/rubocop/cop/style/bare_percent_literals.rb
@@ -36,7 +36,7 @@ module RuboCop
         def autocorrect(node)
           src = node.loc.begin.source
           replacement = src.start_with?('%Q') ? '%' : '%Q'
-          @corrections << lambda do |corrector|
+          lambda do |corrector|
             corrector.replace(node.loc.begin, src.sub(/%Q?/, replacement))
           end
         end

--- a/lib/rubocop/cop/style/block_comments.rb
+++ b/lib/rubocop/cop/style/block_comments.rb
@@ -18,7 +18,7 @@ module RuboCop
         def autocorrect(comment)
           eq_begin, eq_end, contents = parts(comment)
 
-          @corrections << lambda do |corrector|
+          lambda do |corrector|
             corrector.remove(eq_begin)
             unless contents.length == 0
               corrector.replace(contents,

--- a/lib/rubocop/cop/style/block_end_newline.rb
+++ b/lib/rubocop/cop/style/block_end_newline.rb
@@ -40,7 +40,7 @@ module RuboCop
         end
 
         def autocorrect(node)
-          @corrections << lambda do |corrector|
+          lambda do |corrector|
             indentation = indentation_of_block_start_line(node)
             corrector.insert_before(node.loc.end, "\n" + (' ' * indentation))
           end

--- a/lib/rubocop/cop/style/braces_around_hash_parameters.rb
+++ b/lib/rubocop/cop/style/braces_around_hash_parameters.rb
@@ -48,7 +48,7 @@ module RuboCop
         end
 
         def autocorrect(node)
-          @corrections << lambda do |corrector|
+          lambda do |corrector|
             if braces?(node)
               right_range = range_with_surrounding_space(node.loc.begin, :right)
               corrector.remove(right_range)

--- a/lib/rubocop/cop/style/character_literal.rb
+++ b/lib/rubocop/cop/style/character_literal.rb
@@ -16,7 +16,7 @@ module RuboCop
         end
 
         def autocorrect(node)
-          @corrections << lambda do |corrector|
+          lambda do |corrector|
             string = node.loc.expression.source[1..-1]
 
             if string.length == 1 # normal character

--- a/lib/rubocop/cop/style/class_check.rb
+++ b/lib/rubocop/cop/style/class_check.rb
@@ -31,7 +31,7 @@ module RuboCop
         def autocorrect(node)
           _receiver, method_name, *_args = *node
 
-          @corrections << lambda do |corrector|
+          lambda do |corrector|
             corrector.replace(node.loc.selector,
                               method_name == :is_a? ? 'kind_of?' : 'is_a?')
           end

--- a/lib/rubocop/cop/style/class_methods.rb
+++ b/lib/rubocop/cop/style/class_methods.rb
@@ -60,9 +60,7 @@ module RuboCop
         end
 
         def autocorrect(node)
-          @corrections << lambda do |corrector|
-            corrector.replace(node.loc.name, 'self')
-          end
+          ->(corrector) { corrector.replace(node.loc.name, 'self') }
         end
       end
     end

--- a/lib/rubocop/cop/style/collection_methods.rb
+++ b/lib/rubocop/cop/style/collection_methods.rb
@@ -26,7 +26,7 @@ module RuboCop
         end
 
         def autocorrect(node)
-          @corrections << lambda do |corrector|
+          lambda do |corrector|
             corrector.replace(node.loc.selector,
                               preferred_method(node.loc.selector.source))
           end

--- a/lib/rubocop/cop/style/colon_method_call.rb
+++ b/lib/rubocop/cop/style/colon_method_call.rb
@@ -32,9 +32,7 @@ module RuboCop
         end
 
         def autocorrect(node)
-          @corrections << lambda do |corrector|
-            corrector.replace(node.loc.dot, '.')
-          end
+          ->(corrector) { corrector.replace(node.loc.dot, '.') }
         end
       end
     end

--- a/lib/rubocop/cop/style/command_literal.rb
+++ b/lib/rubocop/cop/style/command_literal.rb
@@ -101,7 +101,7 @@ module RuboCop
         end
 
         def autocorrect(node)
-          fail CorrectionNotPossible if contains_backtick?(node)
+          return if contains_backtick?(node)
 
           if backtick_literal?(node)
             replacement = ['%x', ''].zip(preferred_delimiters).map(&:join)

--- a/lib/rubocop/cop/style/command_literal.rb
+++ b/lib/rubocop/cop/style/command_literal.rb
@@ -109,7 +109,7 @@ module RuboCop
             replacement = %w(` `)
           end
 
-          @corrections << lambda do |corrector|
+          lambda do |corrector|
             corrector.replace(node.loc.begin, replacement.first)
             corrector.replace(node.loc.end, replacement.last)
           end

--- a/lib/rubocop/cop/style/comment_annotation.rb
+++ b/lib/rubocop/cop/style/comment_annotation.rb
@@ -29,7 +29,7 @@ module RuboCop
         private
 
         def autocorrect(range)
-          @corrections << lambda do |corrector|
+          lambda do |corrector|
             annotation_keyword = range.source.split(/:?\s+/).first
             corrector.replace(range, annotation_keyword.upcase << ': ')
           end

--- a/lib/rubocop/cop/style/copyright.rb
+++ b/lib/rubocop/cop/style/copyright.rb
@@ -72,7 +72,7 @@ module RuboCop
             'your RuboCop config' if autocorrect_notice.empty?
           fail "AutocorrectNotice '#{autocorrect_notice}' must match " \
             "Notice /#{notice}/" unless autocorrect_notice =~ Regexp.new(notice)
-          @corrections << lambda do |corrector|
+          lambda do |corrector|
             if token.nil?
               range = Parser::Source::Range.new('', 0, 0)
             else

--- a/lib/rubocop/cop/style/def_with_parentheses.rb
+++ b/lib/rubocop/cop/style/def_with_parentheses.rb
@@ -22,7 +22,7 @@ module RuboCop
         end
 
         def autocorrect(node)
-          @corrections << lambda do |corrector|
+          lambda do |corrector|
             corrector.remove(node.loc.begin)
             corrector.remove(node.loc.end)
           end

--- a/lib/rubocop/cop/style/deprecated_hash_methods.rb
+++ b/lib/rubocop/cop/style/deprecated_hash_methods.rb
@@ -22,7 +22,7 @@ module RuboCop
         end
 
         def autocorrect(node)
-          @corrections << lambda do |corrector|
+          lambda do |corrector|
             corrector.replace(node.loc.selector,
                               proper_method_name(node.loc.selector.source))
           end

--- a/lib/rubocop/cop/style/dot_position.rb
+++ b/lib/rubocop/cop/style/dot_position.rb
@@ -61,7 +61,7 @@ module RuboCop
             selector = node.loc.begin
           end
 
-          @corrections << lambda do |corrector|
+          lambda do |corrector|
             corrector.remove(node.loc.dot)
             case style
             when :leading

--- a/lib/rubocop/cop/style/empty_line_between_defs.rb
+++ b/lib/rubocop/cop/style/empty_line_between_defs.rb
@@ -36,9 +36,7 @@ module RuboCop
 
         def autocorrect(node)
           range = range_with_surrounding_space(node.loc.expression, :left)
-          @corrections << lambda do |corrector|
-            corrector.insert_before(range, "\n")
-          end
+          ->(corrector) { corrector.insert_before(range, "\n") }
         end
       end
     end

--- a/lib/rubocop/cop/style/empty_lines.rb
+++ b/lib/rubocop/cop/style/empty_lines.rb
@@ -36,7 +36,7 @@ module RuboCop
         end
 
         def autocorrect(range)
-          @corrections << ->(corrector) { corrector.remove(range) }
+          ->(corrector) { corrector.remove(range) }
         end
       end
     end

--- a/lib/rubocop/cop/style/empty_lines_around_access_modifier.rb
+++ b/lib/rubocop/cop/style/empty_lines_around_access_modifier.rb
@@ -18,7 +18,7 @@ module RuboCop
         end
 
         def autocorrect(node)
-          @corrections << lambda do |corrector|
+          lambda do |corrector|
             send_line = node.loc.line
             previous_line = processed_source[send_line - 2]
             next_line = processed_source[send_line]

--- a/lib/rubocop/cop/style/empty_literal.rb
+++ b/lib/rubocop/cop/style/empty_literal.rb
@@ -56,9 +56,7 @@ module RuboCop
                  when STR_NODE
                    "''"
                  end
-          @corrections << lambda do |corrector|
-            corrector.replace(node.loc.expression, name)
-          end
+          ->(corrector) { corrector.replace(node.loc.expression, name) }
         end
 
         def first_arg_in_method_call_without_parentheses?(node)

--- a/lib/rubocop/cop/style/empty_literal.rb
+++ b/lib/rubocop/cop/style/empty_literal.rb
@@ -51,9 +51,7 @@ module RuboCop
                    # because the braces are interpreted as a block, so we avoid
                    # the correction. Parentheses around the arguments would
                    # solve the problem, but we let the user add those manually.
-                   if first_arg_in_method_call_without_parentheses?(node)
-                     fail CorrectionNotPossible
-                   end
+                   return if first_arg_in_method_call_without_parentheses?(node)
                    '{}'
                  when STR_NODE
                    "''"

--- a/lib/rubocop/cop/style/encoding.rb
+++ b/lib/rubocop/cop/style/encoding.rb
@@ -33,7 +33,7 @@ module RuboCop
         def autocorrect(node)
           encoding = cop_config['AutoCorrectEncodingComment']
           if encoding && encoding =~ ENCODING_PATTERN
-            @corrections << lambda do |corrector|
+            lambda do |corrector|
               corrector.replace(node.pos, "#{encoding}\n#{node.pos.source}")
             end
           else

--- a/lib/rubocop/cop/style/even_odd.rb
+++ b/lib/rubocop/cop/style/even_odd.rb
@@ -26,10 +26,8 @@ module RuboCop
         end
 
         def autocorrect(node)
-          @corrections << lambda do |corrector|
-            correction = "#{base_number(node)}.#{offense_type(node)}?"
-            corrector.replace(node.loc.expression, correction)
-          end
+          correction = "#{base_number(node)}.#{offense_type(node)}?"
+          ->(corrector) { corrector.replace(node.loc.expression, correction) }
         end
 
         private

--- a/lib/rubocop/cop/style/extra_spacing.rb
+++ b/lib/rubocop/cop/style/extra_spacing.rb
@@ -25,9 +25,7 @@ module RuboCop
         end
 
         def autocorrect(range)
-          @corrections << lambda do |corrector|
-            corrector.remove(range)
-          end
+          ->(corrector) { corrector.remove(range) }
         end
       end
     end

--- a/lib/rubocop/cop/style/hash_syntax.rb
+++ b/lib/rubocop/cop/style/hash_syntax.rb
@@ -58,7 +58,7 @@ module RuboCop
         end
 
         def autocorrect(node)
-          @corrections << lambda do |corrector|
+          lambda do |corrector|
             if style == :hash_rockets || @force_hash_rockets
               autocorrect_hash_rockets(corrector, node)
             elsif style == :ruby19_no_mixed_keys

--- a/lib/rubocop/cop/style/if_unless_modifier.rb
+++ b/lib/rubocop/cop/style/if_unless_modifier.rb
@@ -31,7 +31,7 @@ module RuboCop
             cond, _else, body = *node
           end
 
-          @corrections << lambda do |corrector|
+          lambda do |corrector|
             oneline = "#{body.loc.expression.source} " \
                       "#{node.loc.keyword.source} " +
                       cond.loc.expression.source

--- a/lib/rubocop/cop/style/infinite_loop.rb
+++ b/lib/rubocop/cop/style/infinite_loop.rb
@@ -40,14 +40,14 @@ module RuboCop
         end
 
         def autocorrect(node)
-          @corrections << lambda do |corrector|
-            condition_node, = *node
-            start_range = node.loc.keyword.begin
-            end_range = if node.loc.begin
-                          node.loc.begin.end
-                        else
-                          condition_node.loc.expression.end
-                        end
+          condition_node, = *node
+          start_range = node.loc.keyword.begin
+          end_range = if node.loc.begin
+                        node.loc.begin.end
+                      else
+                        condition_node.loc.expression.end
+                      end
+          lambda do |corrector|
             corrector.replace(start_range.join(end_range), 'loop do')
           end
         end

--- a/lib/rubocop/cop/style/lambda_call.rb
+++ b/lib/rubocop/cop/style/lambda_call.rb
@@ -37,7 +37,7 @@ module RuboCop
         end
 
         def autocorrect(node)
-          @corrections << lambda do |corrector|
+          lambda do |corrector|
             if style == :call
               receiver_node, = *node
               expr = node.loc.expression

--- a/lib/rubocop/cop/style/leading_comment_space.rb
+++ b/lib/rubocop/cop/style/leading_comment_space.rb
@@ -23,9 +23,7 @@ module RuboCop
           expr = comment.loc.expression
           b = expr.begin_pos
           hash_mark = Parser::Source::Range.new(expr.source_buffer, b, b + 1)
-          @corrections << lambda do |corrector|
-            corrector.insert_after(hash_mark, ' ')
-          end
+          ->(corrector) { corrector.insert_after(hash_mark, ' ') }
         end
       end
     end

--- a/lib/rubocop/cop/style/line_end_concatenation.rb
+++ b/lib/rubocop/cop/style/line_end_concatenation.rb
@@ -35,13 +35,11 @@ module RuboCop
         end
 
         def autocorrect(operator_range)
-          @corrections << lambda do |corrector|
-            # Include any trailing whitespace so we don't create a syntax error.
-            operator_range = range_with_surrounding_space(operator_range,
-                                                          :right, nil,
-                                                          !:with_newline)
-            corrector.replace(operator_range, '\\')
-          end
+          # Include any trailing whitespace so we don't create a syntax error.
+          operator_range = range_with_surrounding_space(operator_range,
+                                                        :right, nil,
+                                                        !:with_newline)
+          ->(corrector) { corrector.replace(operator_range, '\\') }
         end
 
         private

--- a/lib/rubocop/cop/style/method_call_parentheses.rb
+++ b/lib/rubocop/cop/style/method_call_parentheses.rb
@@ -17,7 +17,7 @@ module RuboCop
         end
 
         def autocorrect(node)
-          @corrections << lambda do |corrector|
+          lambda do |corrector|
             corrector.remove(node.loc.begin)
             corrector.remove(node.loc.end)
           end

--- a/lib/rubocop/cop/style/method_def_parentheses.rb
+++ b/lib/rubocop/cop/style/method_def_parentheses.rb
@@ -24,7 +24,7 @@ module RuboCop
         end
 
         def autocorrect(node)
-          @corrections << lambda do |corrector|
+          lambda do |corrector|
             if style == :require_parentheses
               args_expr = args_node(node).loc.expression
               args_with_space = range_with_surrounding_space(args_expr, :left)

--- a/lib/rubocop/cop/style/multiline_block_layout.rb
+++ b/lib/rubocop/cop/style/multiline_block_layout.rb
@@ -70,7 +70,7 @@ module RuboCop
         end
 
         def autocorrect(node)
-          @corrections << lambda do |corrector|
+          lambda do |corrector|
             _method, args, block_body = *node
             unless args.children.empty? ||
                    args.loc.end.line == node.loc.begin.line

--- a/lib/rubocop/cop/style/multiline_if_then.rb
+++ b/lib/rubocop/cop/style/multiline_if_then.rb
@@ -30,7 +30,7 @@ module RuboCop
         end
 
         def autocorrect(node)
-          @corrections << lambda do |corrector|
+          lambda do |corrector|
             corrector.remove(range_with_surrounding_space(node.loc.begin,
                                                           :left))
           end

--- a/lib/rubocop/cop/style/negated_if.rb
+++ b/lib/rubocop/cop/style/negated_if.rb
@@ -28,7 +28,7 @@ module RuboCop
         private
 
         def autocorrect(node)
-          @corrections << lambda do |corrector|
+          lambda do |corrector|
             condition, _body, _rest = *node
             # look inside parentheses around the condition
             condition = condition.children.first while condition.type == :begin

--- a/lib/rubocop/cop/style/negated_while.rb
+++ b/lib/rubocop/cop/style/negated_while.rb
@@ -28,7 +28,7 @@ module RuboCop
         private
 
         def autocorrect(node)
-          @corrections << lambda do |corrector|
+          lambda do |corrector|
             condition, _body, _rest = *node
             # Look inside parentheses around the condition, if any.
             condition, = *condition while condition.type == :begin

--- a/lib/rubocop/cop/style/nil_comparison.rb
+++ b/lib/rubocop/cop/style/nil_comparison.rb
@@ -29,11 +29,9 @@ module RuboCop
         private
 
         def autocorrect(node)
-          @corrections << lambda do |corrector|
-            expr = node.loc.expression
-            new_code = expr.source.sub(/\s*={2,3}\s*nil/, '.nil?')
-            corrector.replace(expr, new_code)
-          end
+          expr = node.loc.expression
+          new_code = expr.source.sub(/\s*={2,3}\s*nil/, '.nil?')
+          ->(corrector) { corrector.replace(expr, new_code) }
         end
       end
     end

--- a/lib/rubocop/cop/style/non_nil_check.rb
+++ b/lib/rubocop/cop/style/non_nil_check.rb
@@ -84,7 +84,7 @@ module RuboCop
         end
 
         def autocorrect_comparison(node)
-          @corrections << lambda do |corrector|
+          lambda do |corrector|
             expr = node.loc.expression
             new_code =
               if include_semantic_changes?
@@ -97,7 +97,7 @@ module RuboCop
         end
 
         def autocorrect_non_nil(node, inner_node)
-          @corrections << lambda do |corrector|
+          lambda do |corrector|
             receiver, _method, _args = *inner_node
             if receiver
               corrector.replace(node.loc.expression,

--- a/lib/rubocop/cop/style/not.rb
+++ b/lib/rubocop/cop/style/not.rb
@@ -22,11 +22,9 @@ module RuboCop
         private
 
         def correction(node)
-          lambda do |corrector|
-            old_source = node.loc.expression.source
-            new_source = old_source.sub(/not\s+/, '!')
-            corrector.replace(node.loc.expression, new_source)
-          end
+          old_source = node.loc.expression.source
+          new_source = old_source.sub(/not\s+/, '!')
+          ->(corrector) { corrector.replace(node.loc.expression, new_source) }
         end
       end
     end

--- a/lib/rubocop/cop/style/numeric_literals.rb
+++ b/lib/rubocop/cop/style/numeric_literals.rb
@@ -46,11 +46,8 @@ module RuboCop
         end
 
         def autocorrect(node)
-          @corrections << lambda do |corrector|
-            corrector.replace(
-              node.loc.expression,
-              format_number(node)
-            )
+          lambda do |corrector|
+            corrector.replace(node.loc.expression, format_number(node))
           end
         end
 

--- a/lib/rubocop/cop/style/parentheses_around_condition.rb
+++ b/lib/rubocop/cop/style/parentheses_around_condition.rb
@@ -61,7 +61,7 @@ module RuboCop
         end
 
         def autocorrect(node)
-          @corrections << lambda do |corrector|
+          lambda do |corrector|
             corrector.remove(node.loc.begin)
             corrector.remove(node.loc.end)
           end

--- a/lib/rubocop/cop/style/percent_literal_delimiters.rb
+++ b/lib/rubocop/cop/style/percent_literal_delimiters.rb
@@ -55,7 +55,7 @@ module RuboCop
             expression_indentation + expression + closing_newline +
             closing_indentation + closing_delimiter + reg_opt
 
-          @corrections << lambda do |corrector|
+          lambda do |corrector|
             corrector.replace(node.loc.expression, corrected_source)
           end
         end

--- a/lib/rubocop/cop/style/percent_q_literals.rb
+++ b/lib/rubocop/cop/style/percent_q_literals.rb
@@ -39,7 +39,7 @@ module RuboCop
         def autocorrect(node)
           src = node.loc.expression.source
 
-          @corrections << lambda do |corrector|
+          lambda do |corrector|
             corrector.replace(node.loc.expression, corrected(src))
           end
         end

--- a/lib/rubocop/cop/style/perl_backrefs.rb
+++ b/lib/rubocop/cop/style/perl_backrefs.rb
@@ -13,7 +13,7 @@ module RuboCop
         end
 
         def autocorrect(node)
-          @corrections << lambda do |corrector|
+          lambda do |corrector|
             backref, = *node
             parent_type = node.parent ? node.parent.type : nil
             if [:dstr, :xstr, :regexp].include?(parent_type)

--- a/lib/rubocop/cop/style/proc.rb
+++ b/lib/rubocop/cop/style/proc.rb
@@ -22,9 +22,7 @@ module RuboCop
         end
 
         def autocorrect(node)
-          @corrections << lambda do |corrector|
-            corrector.replace(node.loc.expression, 'proc')
-          end
+          ->(corrector) { corrector.replace(node.loc.expression, 'proc') }
         end
       end
     end

--- a/lib/rubocop/cop/style/redundant_begin.rb
+++ b/lib/rubocop/cop/style/redundant_begin.rb
@@ -36,7 +36,7 @@ module RuboCop
         end
 
         def autocorrect(node)
-          @corrections << lambda do |corrector|
+          lambda do |corrector|
             child = node.children.first
 
             begin_indent = node.loc.column

--- a/lib/rubocop/cop/style/redundant_exception.rb
+++ b/lib/rubocop/cop/style/redundant_exception.rb
@@ -29,14 +29,12 @@ module RuboCop
 
         # switch `raise RuntimeError, 'message'` to `raise 'message'`
         def autocorrect(node)
-          @corrections << lambda do |corrector|
-            start_range = node.loc.expression.begin
-            no_comma = range_with_surrounding_comma(node.loc.expression.end,
-                                                    :right)
-            comma_range = start_range.join(no_comma)
-            final_range = range_with_surrounding_space(comma_range, :right)
-            corrector.replace(final_range, '')
-          end
+          start_range = node.loc.expression.begin
+          no_comma = range_with_surrounding_comma(node.loc.expression.end,
+                                                  :right)
+          comma_range = start_range.join(no_comma)
+          final_range = range_with_surrounding_space(comma_range, :right)
+          ->(corrector) { corrector.replace(final_range, '') }
         end
       end
     end

--- a/lib/rubocop/cop/style/redundant_return.rb
+++ b/lib/rubocop/cop/style/redundant_return.rb
@@ -28,7 +28,7 @@ module RuboCop
         private
 
         def autocorrect(node)
-          @corrections << lambda do |corrector|
+          lambda do |corrector|
             if node.children.size > 1
               kids = node.children.map { |child| child.loc.expression }
               corrector.insert_before(kids.first, '[')

--- a/lib/rubocop/cop/style/redundant_self.rb
+++ b/lib/rubocop/cop/style/redundant_self.rb
@@ -103,7 +103,7 @@ module RuboCop
 
         def autocorrect(node)
           receiver, _method_name, *_args = *node
-          @corrections << lambda do |corrector|
+          lambda do |corrector|
             corrector.remove(receiver.loc.expression)
             corrector.remove(node.loc.dot)
           end

--- a/lib/rubocop/cop/style/regexp_literal.rb
+++ b/lib/rubocop/cop/style/regexp_literal.rb
@@ -97,7 +97,7 @@ module RuboCop
         end
 
         def autocorrect(node)
-          fail CorrectionNotPossible if contains_slash?(node)
+          return if contains_slash?(node)
 
           if slash_literal?(node)
             replacement = ['%r', ''].zip(preferred_delimiters).map(&:join)

--- a/lib/rubocop/cop/style/regexp_literal.rb
+++ b/lib/rubocop/cop/style/regexp_literal.rb
@@ -105,7 +105,7 @@ module RuboCop
             replacement = %w(/ /)
           end
 
-          @corrections << lambda do |corrector|
+          lambda do |corrector|
             corrector.replace(node.loc.begin, replacement.first)
             corrector.replace(node.loc.end, replacement.last)
           end

--- a/lib/rubocop/cop/style/self_assignment.rb
+++ b/lib/rubocop/cop/style/self_assignment.rb
@@ -84,7 +84,7 @@ module RuboCop
         end
 
         def apply_autocorrect(node, rhs, operator, new_rhs)
-          @corrections << lambda do |corrector|
+          lambda do |corrector|
             corrector.insert_before(node.loc.operator, operator)
             corrector.replace(rhs.loc.expression, new_rhs.loc.expression.source)
           end

--- a/lib/rubocop/cop/style/semicolon.rb
+++ b/lib/rubocop/cop/style/semicolon.rb
@@ -55,7 +55,7 @@ module RuboCop
         end
 
         def autocorrect(range)
-          fail CorrectionNotPossible unless range
+          return unless range
           @corrections << ->(corrector) { corrector.remove(range) }
         end
       end

--- a/lib/rubocop/cop/style/semicolon.rb
+++ b/lib/rubocop/cop/style/semicolon.rb
@@ -56,7 +56,7 @@ module RuboCop
 
         def autocorrect(range)
           return unless range
-          @corrections << ->(corrector) { corrector.remove(range) }
+          ->(corrector) { corrector.remove(range) }
         end
       end
     end

--- a/lib/rubocop/cop/style/signal_exception.rb
+++ b/lib/rubocop/cop/style/signal_exception.rb
@@ -34,7 +34,7 @@ module RuboCop
         end
 
         def autocorrect(node)
-          @corrections << lambda do |corrector|
+          lambda do |corrector|
             name =
               case style
               when :semantic then command?(:raise, node) ? 'fail' : 'raise'

--- a/lib/rubocop/cop/style/single_line_methods.rb
+++ b/lib/rubocop/cop/style/single_line_methods.rb
@@ -32,7 +32,7 @@ module RuboCop
           eol_comment = processed_source.comments.find do |c|
             c.loc.line == node.loc.expression.line
           end
-          @corrections << lambda do |corrector|
+          lambda do |corrector|
             if body.type == :begin
               body.children.each do |part|
                 break_line_before(part.loc.expression, node, corrector, 1)

--- a/lib/rubocop/cop/style/single_space_before_first_arg.rb
+++ b/lib/rubocop/cop/style/single_space_before_first_arg.rb
@@ -33,7 +33,7 @@ module RuboCop
         end
 
         def autocorrect(range)
-          @corrections << ->(corrector) { corrector.replace(range, ' ') }
+          ->(corrector) { corrector.replace(range, ' ') }
         end
       end
     end

--- a/lib/rubocop/cop/style/space_after_colon.rb
+++ b/lib/rubocop/cop/style/space_after_colon.rb
@@ -30,9 +30,7 @@ module RuboCop
         end
 
         def autocorrect(range)
-          @corrections << lambda do |corrector|
-            corrector.insert_after(range, ' ')
-          end
+          ->(corrector) { corrector.insert_after(range, ' ') }
         end
       end
     end

--- a/lib/rubocop/cop/style/space_after_control_keyword.rb
+++ b/lib/rubocop/cop/style/space_after_control_keyword.rb
@@ -27,9 +27,7 @@ module RuboCop
         end
 
         def autocorrect(node)
-          @corrections << lambda do |corrector|
-            corrector.insert_after(node.loc.keyword, ' ')
-          end
+          ->(corrector) { corrector.insert_after(node.loc.keyword, ' ') }
         end
       end
     end

--- a/lib/rubocop/cop/style/space_after_method_name.rb
+++ b/lib/rubocop/cop/style/space_after_method_name.rb
@@ -30,9 +30,7 @@ module RuboCop
         end
 
         def autocorrect(pos_before_left_paren)
-          @corrections << lambda do |corrector|
-            corrector.remove(pos_before_left_paren)
-          end
+          ->(corrector) { corrector.remove(pos_before_left_paren) }
         end
       end
     end

--- a/lib/rubocop/cop/style/space_after_not.rb
+++ b/lib/rubocop/cop/style/space_after_not.rb
@@ -25,7 +25,7 @@ module RuboCop
         end
 
         def autocorrect(node)
-          @corrections << lambda do |corrector|
+          lambda do |corrector|
             receiver, _method_name, *_args = *node
             space_range =
               Parser::Source::Range.new(node.loc.selector.source_buffer,

--- a/lib/rubocop/cop/style/space_around_block_parameters.rb
+++ b/lib/rubocop/cop/style/space_around_block_parameters.rb
@@ -79,7 +79,7 @@ module RuboCop
         end
 
         def autocorrect(range)
-          @corrections << lambda do |corrector|
+          lambda do |corrector|
             case range.source
             when /^\s+$/ then corrector.remove(range)
             else              corrector.insert_after(range, ' ')

--- a/lib/rubocop/cop/style/space_around_equals_in_parameter_default.rb
+++ b/lib/rubocop/cop/style/space_around_equals_in_parameter_default.rb
@@ -62,9 +62,7 @@ module RuboCop
           m = range.source.match(/=\s*(\S+)/)
           rest = m ? m.captures[0] : ''
           replacement = style == :space ? ' = ' : '='
-          @corrections << lambda do |corrector|
-            corrector.replace(range, replacement + rest)
-          end
+          ->(corrector) { corrector.replace(range, replacement + rest) }
         end
       end
     end

--- a/lib/rubocop/cop/style/space_around_operators.rb
+++ b/lib/rubocop/cop/style/space_around_operators.rb
@@ -79,7 +79,7 @@ module RuboCop
         end
 
         def autocorrect(range)
-          @corrections << lambda do |corrector|
+          lambda do |corrector|
             case range.source
             when /\*\*/
               corrector.replace(range, '**')

--- a/lib/rubocop/cop/style/space_before_block_braces.rb
+++ b/lib/rubocop/cop/style/space_before_block_braces.rb
@@ -51,7 +51,7 @@ module RuboCop
         end
 
         def autocorrect(range)
-          @corrections << lambda do |corrector|
+          lambda do |corrector|
             case range.source
             when /\s/ then corrector.remove(range)
             else           corrector.insert_before(range, ' ')

--- a/lib/rubocop/cop/style/space_before_comment.rb
+++ b/lib/rubocop/cop/style/space_before_comment.rb
@@ -19,9 +19,7 @@ module RuboCop
         private
 
         def autocorrect(range)
-          @corrections << lambda do |corrector|
-            corrector.insert_before(range, ' ')
-          end
+          ->(corrector) { corrector.insert_before(range, ' ') }
         end
       end
     end

--- a/lib/rubocop/cop/style/space_before_modifier_keyword.rb
+++ b/lib/rubocop/cop/style/space_before_modifier_keyword.rb
@@ -29,9 +29,7 @@ module RuboCop
         end
 
         def autocorrect(node)
-          @corrections << lambda do |corrector|
-            corrector.insert_before(node.loc.keyword, ' ')
-          end
+          ->(corrector) { corrector.insert_before(node.loc.keyword, ' ') }
         end
       end
     end

--- a/lib/rubocop/cop/style/space_inside_block_braces.rb
+++ b/lib/rubocop/cop/style/space_inside_block_braces.rb
@@ -148,7 +148,7 @@ module RuboCop
         end
 
         def autocorrect(range)
-          @corrections << lambda do |corrector|
+          lambda do |corrector|
             case range.source
             when /\s/ then corrector.remove(range)
             when '{}' then corrector.replace(range, '{ }')

--- a/lib/rubocop/cop/style/space_inside_hash_literal_braces.rb
+++ b/lib/rubocop/cop/style/space_inside_hash_literal_braces.rb
@@ -68,7 +68,7 @@ module RuboCop
         end
 
         def autocorrect(range)
-          @corrections << lambda do |corrector|
+          lambda do |corrector|
             # It is possible that BracesAroundHashParameters will remove the
             # braces while this cop inserts spaces. This can lead to unwanted
             # changes to the inspected code. If we replace the brace with a

--- a/lib/rubocop/cop/style/space_inside_range_literal.rb
+++ b/lib/rubocop/cop/style/space_inside_range_literal.rb
@@ -48,7 +48,7 @@ module RuboCop
           operator = node.loc.operator.source
           operator_escaped = operator.gsub(/\./, '\.')
 
-          @corrections << lambda do |corrector|
+          lambda do |corrector|
             corrector.replace(
               node.loc.expression,
               expression

--- a/lib/rubocop/cop/style/special_global_vars.rb
+++ b/lib/rubocop/cop/style/special_global_vars.rb
@@ -71,7 +71,7 @@ module RuboCop
         end
 
         def autocorrect(node)
-          @corrections << lambda do |corrector|
+          lambda do |corrector|
             global_var, = *node
             parent_type = node.parent ? node.parent.type : nil
             if [:dstr, :xstr, :regexp].include?(parent_type)

--- a/lib/rubocop/cop/style/symbol_literal.rb
+++ b/lib/rubocop/cop/style/symbol_literal.rb
@@ -24,7 +24,7 @@ module RuboCop
         end
 
         def autocorrect(node)
-          @corrections << lambda do |corrector|
+          lambda do |corrector|
             current_name = node.loc.expression.source
             corrector.replace(node.loc.expression,
                               current_name.gsub(/["']/, ''))

--- a/lib/rubocop/cop/style/symbol_proc.rb
+++ b/lib/rubocop/cop/style/symbol_proc.rb
@@ -40,7 +40,7 @@ module RuboCop
         end
 
         def autocorrect(node)
-          @corrections << lambda do |corrector|
+          lambda do |corrector|
             _block_method, _block_args, block_body = *node
             _receiver, method_name, _args = *block_body
 

--- a/lib/rubocop/cop/style/tab.rb
+++ b/lib/rubocop/cop/style/tab.rb
@@ -25,7 +25,7 @@ module RuboCop
         private
 
         def autocorrect(range)
-          @corrections << lambda do |corrector|
+          lambda do |corrector|
             corrector.replace(range, range.source.gsub(/\t/, '  '))
           end
         end

--- a/lib/rubocop/cop/style/trailing_blank_lines.rb
+++ b/lib/rubocop/cop/style/trailing_blank_lines.rb
@@ -64,7 +64,7 @@ module RuboCop
         end
 
         def autocorrect(range)
-          @corrections << lambda do |corrector|
+          lambda do |corrector|
             corrector.replace(range, style == :final_newline ? "\n" : "\n\n")
           end
         end

--- a/lib/rubocop/cop/style/trailing_comma.rb
+++ b/lib/rubocop/cop/style/trailing_comma.rb
@@ -159,7 +159,7 @@ module RuboCop
         end
 
         def autocorrect(range)
-          @corrections << lambda do |corrector|
+          lambda do |corrector|
             case range.source
             when ',' then corrector.remove(range)
             else          corrector.insert_after(range, ',')

--- a/lib/rubocop/cop/style/trailing_underscore_variable.rb
+++ b/lib/rubocop/cop/style/trailing_underscore_variable.rb
@@ -51,9 +51,7 @@ module RuboCop
                                       first_offense.loc.expression.begin_pos,
                                       end_position)
 
-          @corrections << lambda do |corrector|
-            corrector.remove(range) unless range.nil?
-          end
+          ->(corrector) { corrector.remove(range) unless range.nil? }
         end
 
         private

--- a/lib/rubocop/cop/style/trailing_whitespace.rb
+++ b/lib/rubocop/cop/style/trailing_whitespace.rb
@@ -20,7 +20,7 @@ module RuboCop
         end
 
         def autocorrect(range)
-          @corrections << ->(corrector) { corrector.remove(range) }
+          ->(corrector) { corrector.remove(range) }
         end
       end
     end

--- a/lib/rubocop/cop/style/trivial_accessors.rb
+++ b/lib/rubocop/cop/style/trivial_accessors.rb
@@ -121,8 +121,6 @@ module RuboCop
             autocorrect_instance(node)
           elsif node.type == :defs && node.children.first.type == :self
             autocorrect_class(node)
-          else
-            fail CorrectionNotPossible
           end
         end
 
@@ -130,7 +128,7 @@ module RuboCop
           method_name, args, body = *node
           unless names_match?(method_name, body) &&
                  (kind = trivial_accessor_kind(method_name, args, body))
-            fail CorrectionNotPossible
+            return
           end
 
           @corrections << lambda do |corrector|
@@ -145,7 +143,7 @@ module RuboCop
           _, method_name, args, body = *node
           unless names_match?(method_name, body) &&
                  (kind = trivial_accessor_kind(method_name, args, body))
-            fail CorrectionNotPossible
+            return
           end
 
           @corrections << lambda do |corrector|

--- a/lib/rubocop/cop/style/trivial_accessors.rb
+++ b/lib/rubocop/cop/style/trivial_accessors.rb
@@ -131,11 +131,8 @@ module RuboCop
             return
           end
 
-          @corrections << lambda do |corrector|
-            corrector.replace(
-              node.loc.expression,
-              accessor(kind, method_name)
-            )
+          lambda do |corrector|
+            corrector.replace(node.loc.expression, accessor(kind, method_name))
           end
         end
 
@@ -146,7 +143,7 @@ module RuboCop
             return
           end
 
-          @corrections << lambda do |corrector|
+          lambda do |corrector|
             indent = ' ' * node.loc.column
             corrector.replace(
               node.loc.expression,

--- a/lib/rubocop/cop/style/unneeded_capital_w.rb
+++ b/lib/rubocop/cop/style/unneeded_capital_w.rb
@@ -25,7 +25,7 @@ module RuboCop
         end
 
         def autocorrect(node)
-          @corrections << lambda do |corrector|
+          lambda do |corrector|
             src = node.loc.begin.source
             corrector.replace(node.loc.begin, src.tr('W', 'w'))
           end

--- a/lib/rubocop/cop/style/unneeded_percent_q.rb
+++ b/lib/rubocop/cop/style/unneeded_percent_q.rb
@@ -47,7 +47,7 @@ module RuboCop
 
         def autocorrect(node)
           delimiter = node.loc.expression.source =~ /^%Q[^"]+$|'/ ? '"' : "'"
-          @corrections << lambda do |corrector|
+          lambda do |corrector|
             corrector.replace(node.loc.begin, delimiter)
             corrector.replace(node.loc.end, delimiter)
           end

--- a/lib/rubocop/cop/style/variable_interpolation.rb
+++ b/lib/rubocop/cop/style/variable_interpolation.rb
@@ -30,10 +30,8 @@ module RuboCop
         end
 
         def autocorrect(node)
-          @corrections << lambda do |corrector|
-            expr = node.loc.expression
-            corrector.replace(expr, "{#{expr.source}}")
-          end
+          expr = node.loc.expression
+          ->(corrector) { corrector.replace(expr, "{#{expr.source}}") }
         end
 
         def var_nodes(nodes)

--- a/lib/rubocop/cop/style/when_then.rb
+++ b/lib/rubocop/cop/style/when_then.rb
@@ -14,9 +14,7 @@ module RuboCop
         end
 
         def autocorrect(node)
-          @corrections << lambda do |corrector|
-            corrector.replace(node.loc.begin, ' then')
-          end
+          ->(corrector) { corrector.replace(node.loc.begin, ' then') }
         end
       end
     end

--- a/lib/rubocop/cop/style/while_until_do.rb
+++ b/lib/rubocop/cop/style/while_until_do.rb
@@ -28,13 +28,11 @@ module RuboCop
         end
 
         def autocorrect(node)
-          @corrections << lambda do |corrector|
-            condition_node, = *node
-            end_of_condition_range = condition_node.loc.expression.end
-            do_range = node.loc.begin
-            whitespaces_and_do_range = end_of_condition_range.join(do_range)
-            corrector.remove(whitespaces_and_do_range)
-          end
+          condition_node, = *node
+          end_of_condition_range = condition_node.loc.expression.end
+          do_range = node.loc.begin
+          whitespaces_and_do_range = end_of_condition_range.join(do_range)
+          ->(corrector) { corrector.remove(whitespaces_and_do_range) }
         end
       end
     end

--- a/lib/rubocop/cop/style/while_until_modifier.rb
+++ b/lib/rubocop/cop/style/while_until_modifier.rb
@@ -19,12 +19,10 @@ module RuboCop
 
         def autocorrect(node)
           cond, body = *node
-          @corrections << lambda do |corrector|
-            oneline = "#{body.loc.expression.source} " \
-                      "#{node.loc.keyword.source} " +
-                      cond.loc.expression.source
-            corrector.replace(node.loc.expression, oneline)
-          end
+          oneline = "#{body.loc.expression.source} " \
+                    "#{node.loc.keyword.source} " +
+                    cond.loc.expression.source
+          ->(corrector) { corrector.replace(node.loc.expression, oneline) }
         end
 
         private

--- a/lib/rubocop/cop/style/word_array.rb
+++ b/lib/rubocop/cop/style/word_array.rb
@@ -64,7 +64,7 @@ module RuboCop
           contents = node.children.map { |n| source_for(n) }.join(' ')
           char = @interpolated ? 'W' : 'w'
 
-          @corrections << lambda do |corrector|
+          lambda do |corrector|
             corrector.replace(node.loc.expression, "%#{char}(#{contents})")
           end
         end

--- a/spec/rubocop/cop/cop_spec.rb
+++ b/spec/rubocop/cop/cop_spec.rb
@@ -116,8 +116,7 @@ describe RuboCop::Cop::Cop do
       context 'when offense was not corrected because of an error' do
         before do
           allow(@cop).to receive(:autocorrect?).and_return(true)
-          allow(@cop).to receive(:autocorrect)
-            .and_raise(RuboCop::Cop::CorrectionNotPossible)
+          allow(@cop).to receive(:autocorrect).and_return(false)
         end
 
         it 'is set to false' do

--- a/spec/support/cops/class_must_be_a_module_cop.rb
+++ b/spec/support/cops/class_must_be_a_module_cop.rb
@@ -9,9 +9,7 @@ module RuboCop
         end
 
         def autocorrect(node)
-          @corrections << lambda do |corrector|
-            corrector.replace(node.loc.keyword, 'module')
-          end
+          ->(corrector) { corrector.replace(node.loc.keyword, 'module') }
         end
       end
     end

--- a/spec/support/cops/module_must_be_a_class_cop.rb
+++ b/spec/support/cops/module_must_be_a_class_cop.rb
@@ -9,9 +9,7 @@ module RuboCop
         end
 
         def autocorrect(node)
-          @corrections << lambda do |corrector|
-            corrector.replace(node.loc.keyword, 'class')
-          end
+          ->(corrector) { corrector.replace(node.loc.keyword, 'class') }
         end
       end
     end


### PR DESCRIPTION
A couple of improvements (IMO) for `autocorrect`.

The first one is to make future mistakes less likely when it comes to abandoning an auto-correction. People's natural instinct is to just return in these situations, so let's work *with* that instinct, not *against* it.

The second one is mostly about reducing duplication, and also that a pure function is generally nicer than one with side-effects.