### PR TITLE
[Fix #1834] Improve the AutoCorrect config parameter handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@
 * [#1820](https://github.com/bbatsov/rubocop/issues/1820): Correct the logic in `AlignHash` for when to ignore a key because it's not on its own line. ([@jonas054][])
 * [#1829](https://github.com/bbatsov/rubocop/pull/1829): Fix bug in `Sample` and `FlatMap` that would cause them to report having been auto-corrected when they were not. ([@rrosenblum][])
 * [#1832](https://github.com/bbatsov/rubocop/pull/1832): Fix bug in `UnusedMethodArgument` that would cause them to report having been auto-corrected when they were not. ([@jonas054][])
+* [#1834](https://github.com/bbatsov/rubocop/issues/1834): Support only boolean values for `AutoCorrect` configuration parameter, and remove warning for unknown parameter. ([@jonas054][])
 
 ## 0.30.1 (21/04/2015)
 

--- a/README.md
+++ b/README.md
@@ -384,6 +384,16 @@ Metrics/CyclomaticComplexity:
   Severity: warning
 ```
 
+#### AutoCorrect
+
+Cops that support the `--auto-correct` option can have that support
+disabled. For example:
+
+```yaml
+Style/PerlBackrefs:
+  AutoCorrect: false
+```
+
 ### Automatically Generated Configuration
 
 If you have a code base with an overwhelming amount of offenses, it can

--- a/lib/rubocop/config.rb
+++ b/lib/rubocop/config.rb
@@ -14,7 +14,7 @@ module RuboCop
 
     class ValidationError < StandardError; end
 
-    COMMON_PARAMS = %w(Exclude Include Severity)
+    COMMON_PARAMS = %w(Exclude Include Severity AutoCorrect)
 
     attr_reader :loaded_path
 

--- a/lib/rubocop/cop/autocorrect_logic.rb
+++ b/lib/rubocop/cop/autocorrect_logic.rb
@@ -19,7 +19,7 @@ module RuboCop
       def autocorrect_enabled?
         # allow turning off autocorrect on a cop by cop basis
         return true unless cop_config
-        cop_config['AutoCorrect'] != 'False'
+        cop_config['AutoCorrect'] != false
       end
     end
   end

--- a/spec/rubocop/cli_spec.rb
+++ b/spec/rubocop/cli_spec.rb
@@ -676,6 +676,18 @@ describe RuboCop::CLI, :isolated_environment do
                                              'puts [1]',
                                              ''].join("\n"))
       end
+
+      it 'can be disabled for any cop in configuration' do
+        create_file('example.rb', ['# encoding: utf-8',
+                                   'puts "Hello", 123456'])
+        create_file('.rubocop.yml', ['Style/StringLiterals:',
+                                     '  AutoCorrect: false'])
+        expect(cli.run(%w(--auto-correct))).to eq(1)
+        expect($stderr.string).to eq('')
+        expect(IO.read('example.rb')).to eq(['# encoding: utf-8',
+                                             'puts "Hello", 123_456',
+                                             ''].join("\n"))
+      end
     end
 
     describe '--auto-gen-config' do

--- a/spec/rubocop/cop/cop_spec.rb
+++ b/spec/rubocop/cop/cop_spec.rb
@@ -213,7 +213,7 @@ describe RuboCop::Cop::Cop do
 
       context 'when the cop is set to not autocorrect' do
         let(:config) do
-          RuboCop::Config.new('Cop/Cop' => { 'AutoCorrect' => 'False' })
+          RuboCop::Config.new('Cop/Cop' => { 'AutoCorrect' => false })
         end
         it { is_expected.to be(false) }
       end


### PR DESCRIPTION
Allow boolean `false` as value, besides string `"False"`. Ensure no warning is printed when the `AutoCorrect` parameter is used.