### PR TITLE
Make use of TextUtil#pluralize

### DIFF
--- a/lib/rubocop/cli.rb
+++ b/lib/rubocop/cli.rb
@@ -4,6 +4,8 @@ module RuboCop
   # The CLI is a class responsible of handling all the command line interface
   # logic.
   class CLI
+    include Formatter::TextUtil
+
     attr_reader :options, :config_store
 
     def initialize
@@ -100,8 +102,7 @@ module RuboCop
     def display_error_summary(errors)
       return if errors.empty?
 
-      plural = errors.count > 1 ? 's' : ''
-      warn "\n#{errors.count} error#{plural} occurred:".color(:red)
+      warn "\n#{pluralize(errors.size, 'error')} occurred:".color(:red)
 
       errors.each { |error| warn error }
 

--- a/lib/rubocop/formatter/progress_formatter.rb
+++ b/lib/rubocop/formatter/progress_formatter.rb
@@ -6,11 +6,12 @@ module RuboCop
     # letters for files with problems in the them. In the end it
     # appends the regular report data in the clang style format.
     class ProgressFormatter < ClangStyleFormatter
+      include TextUtil
+
       def started(target_files)
         super
         @offenses_for_files = {}
-        file_phrase = target_files.count == 1 ? 'file' : 'files'
-        output.puts "Inspecting #{target_files.count} #{file_phrase}"
+        output.puts "Inspecting #{pluralize(target_files.size, 'file')}"
       end
 
       def file_finished(file, offenses)


### PR DESCRIPTION
This is fairly negligible, but I came across some code that should be making use of the `pluralize` method. 