### PR TITLE
Fix bug in Performance/Sample that causes an offense for shuffle by itself

### DIFF
--- a/lib/rubocop/cop/performance/sample.rb
+++ b/lib/rubocop/cop/performance/sample.rb
@@ -15,6 +15,7 @@ module RuboCop
       #   [1, 2, 3].shuffle(random: Random.new(1))
       #
       #   # good
+      #   [1, 2, 3].shuffle
       #   [1, 2, 3].sample
       #   [1, 2, 3].sample(3)
       #   [1, 2, 3].sample(random: Random.new(1))
@@ -28,6 +29,7 @@ module RuboCop
           return unless first_method == :shuffle
           _receiver, second_method, params, = *node.parent if params.nil?
           return unless VALID_ARRAY_SELECTORS.include?(second_method)
+          return if second_method.nil? && params.nil?
 
           add_offense(node, range_of_shuffle(node), message(node, params))
         end

--- a/spec/rubocop/cop/performance/sample_spec.rb
+++ b/spec/rubocop/cop/performance/sample_spec.rb
@@ -65,6 +65,12 @@ describe RuboCop::Cop::Performance::Sample do
     expect(cop.messages).to be_empty
   end
 
+  it 'does not register an offense when calling shuffle by itself' do
+    inspect_source(cop, '[1, 2, 3, 4].shuffle')
+
+    expect(cop.messages).to be_empty
+  end
+
   context 'autocorrect' do
     shared_examples 'corrects' do |selector|
       it "shuffle#{selector} to sample" do


### PR DESCRIPTION
I don't know how I missed this one earlier. I was looking at #1838, and noticed that I missed the condition for `shuffle` by itself. The new issue seems unrelated to this fix, and I think #1838 has most likely already been fixed in master. 

This cop has caused so much more trouble than it should have.