### PR TITLE
[Fix #1843] Fix TrailingBlankLines crash on block comment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@
 * [#1829](https://github.com/bbatsov/rubocop/pull/1829): Fix bug in `Sample` and `FlatMap` that would cause them to report having been auto-corrected when they were not. ([@rrosenblum][])
 * [#1832](https://github.com/bbatsov/rubocop/pull/1832): Fix bug in `UnusedMethodArgument` that would cause them to report having been auto-corrected when they were not. ([@jonas054][])
 * [#1834](https://github.com/bbatsov/rubocop/issues/1834): Support only boolean values for `AutoCorrect` configuration parameter, and remove warning for unknown parameter. ([@jonas054][])
+* [#1843](https://github.com/bbatsov/rubocop/issues/1843): Fix crash in `TrailingBlankLines` when a file ends with a block comment without final newline. ([@jonas054][])
 
 ## 0.30.1 (21/04/2015)
 

--- a/lib/rubocop/cop/style/trailing_blank_lines.rb
+++ b/lib/rubocop/cop/style/trailing_blank_lines.rb
@@ -43,7 +43,7 @@ module RuboCop
           return false if processed_source.tokens.empty?
 
           extra = sb.source[processed_source.tokens.last.pos.end_pos..-1]
-          extra.strip.start_with?('__END__')
+          extra && extra.strip.start_with?('__END__')
         end
 
         def message(wanted_blank_lines, blank_lines)

--- a/spec/rubocop/cop/style/trailing_blank_lines_spec.rb
+++ b/spec/rubocop/cop/style/trailing_blank_lines_spec.rb
@@ -40,8 +40,17 @@ describe RuboCop::Cop::Style::TrailingBlankLines, :config do
       expect(cop.messages).to eq(['3 trailing blank lines detected.'])
     end
 
-    it 'registers an offense for no final newline' do
+    it 'registers an offense for no final newline after assignment' do
       inspect_source(cop, 'x = 0')
+      expect(cop.messages).to eq(['Final newline missing.'])
+    end
+
+    it 'registers an offense for no final newline after block comment' do
+      inspect_source(cop,
+                     "puts 'testing rubocop when final new line is missing " \
+                     "after block comments'\n\n=begin\nfirst line\nsecond " \
+                     "line\nthird line\n=end")
+
       expect(cop.messages).to eq(['Final newline missing.'])
     end
 


### PR DESCRIPTION
It's a special case when there is a block comment at the end of a file but no final newline.