### PR TITLE
Support DefEndAlignment in IndentationWidth

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 * New cop `Style/TrailingUnderscoreVariable` to remove trailing underscore variables from mass assignment. ([@rrosenblum][])
 * [#1136](https://github.com/bbatsov/rubocop/issues/1136): New cop `Performance/ParallelAssignment` to avoid usages of unnessary parallel assignment. ([@rrosenblum][])
 * [#1278](https://github.com/bbatsov/rubocop/issues/1278): `DefEndAlignment` and `EndAlignment` cops do auto-correction. ([@lumeet][])
+* `IndentationWidth` cop follows the `AlignWith` option of the `DefEndAlignment` cop. ([@lumeet][])
 
 ### Bugs fixed
 

--- a/lib/rubocop/cop/style/indentation_width.rb
+++ b/lib/rubocop/cop/style/indentation_width.rb
@@ -86,7 +86,15 @@ module RuboCop
                                                          args)
 
           _method_name, _args, body = *args.first
-          check_indentation(node.loc.expression, body)
+          def_end_config = config.for_cop('Lint/DefEndAlignment')
+          style = if def_end_config['Enabled']
+                    def_end_config['AlignWith']
+                  else
+                    'start_of_line'
+                  end
+          base = style == 'def' ? args.first : node
+
+          check_indentation(base.loc.expression, body)
           ignore_node(args.first)
         end
 


### PR DESCRIPTION
`AlignWith` of `DefEndAlignment` is used to align method body when
`def` is preceded by a modifier. Similar behavior already exists for
`EndAlignment`.