### PR TITLE
Fix bug in MultilineTernary for not registering an offense when the false value is on a seperate line

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@
 * [#1834](https://github.com/bbatsov/rubocop/issues/1834): Support only boolean values for `AutoCorrect` configuration parameter, and remove warning for unknown parameter. ([@jonas054][])
 * [#1843](https://github.com/bbatsov/rubocop/issues/1843): Fix crash in `TrailingBlankLines` when a file ends with a block comment without final newline. ([@jonas054][])
 * [#1849](https://github.com/bbatsov/rubocop/issues/1849): Fix bug where you can not have nested arrays in the Rake task configuration. ([@rrosenblum][])
+* Fix bug in `MultilineTernaryOperator` where it will not register an offense when only the false branch is on a separate line. ([@rrosenblum][])
 
 ## 0.30.1 (21/04/2015)
 

--- a/lib/rubocop/cop/style/multiline_ternary_operator.rb
+++ b/lib/rubocop/cop/style/multiline_ternary_operator.rb
@@ -9,12 +9,13 @@ module RuboCop
               ' use `if`/`unless` instead.'
 
         def on_if(node)
+          _condition, _if_branch, else_branch = *node
           loc = node.loc
 
           # discard non-ternary ops
           return unless loc.respond_to?(:question)
 
-          add_offense(node, :expression) if loc.line != loc.colon.line
+          add_offense(node, :expression) if loc.line != else_branch.loc.line
         end
       end
     end

--- a/spec/rubocop/cop/style/multiline_ternary_operator_spec.rb
+++ b/spec/rubocop/cop/style/multiline_ternary_operator_spec.rb
@@ -5,9 +5,25 @@ require 'spec_helper'
 describe RuboCop::Cop::Style::MultilineTernaryOperator do
   subject(:cop) { described_class.new }
 
-  it 'registers offense for a multiline ternary operator expression' do
+  it 'registers offense when the if branch and the else branch are ' \
+     'on a separate line from the condition' do
     inspect_source(cop, ['a = cond ?',
                          '  b : c'])
+    expect(cop.offenses.size).to eq(1)
+  end
+
+  it 'registers an offense when the false branch is on a separate line' do
+    inspect_source(cop, ['a = cond ? b :',
+                         '    c'].join("\n"))
+
+    expect(cop.offenses.size).to eq(1)
+  end
+
+  it 'registers an offense when everything is on a separate line' do
+    inspect_source(cop, ['a = cond ?',
+                         '    b :',
+                         '    c'])
+
     expect(cop.offenses.size).to eq(1)
   end
 


### PR DESCRIPTION
I came across a condition that should register an offense. It happens when the false value is the only thing that appears on a separate line.
```ruby
a.nil? ? true :
         false
```

The cop was comparing the location of the node to the location of the colon.