### PR TITLE
Remove duplicate RSpec configurations

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -25,12 +25,6 @@ RSpec.configure do |config|
   config.filter_run_excluding ruby_less_than: (lambda do |v|
     ruby_version >= Gem::Version.new(v)
   end)
-  config.filter_run_excluding ruby_less_than: (lambda do |v|
-    ruby_version >= Gem::Version.new(v)
-  end)
-  config.filter_run_excluding ruby_greater_than_or_equal: (lambda do |v|
-    ruby_version < Gem::Version.new(v)
-  end)
   config.filter_run_excluding ruby_greater_than_or_equal: (lambda do |v|
     ruby_version < Gem::Version.new(v)
   end)


### PR DESCRIPTION
I came across some duplicate RSpec configurations for `ruby_less_than` and `ruby_greater_than_or_equal`.