### PR TITLE
Replace CorrectionNotPossible in EndAlignment

### DIFF
--- a/lib/rubocop/cop/mixin/end_keyword_alignment.rb
+++ b/lib/rubocop/cop/mixin/end_keyword_alignment.rb
@@ -44,7 +44,7 @@ module RuboCop
         whitespace = Parser::Source::Range.new(source_buffer,
                                                begin_pos - node.loc.end.column,
                                                begin_pos)
-        fail CorrectionNotPossible unless whitespace.source.strip.empty?
+        return false unless whitespace.source.strip.empty?
 
         column = alignment_node ? alignment_node.loc.expression.column : 0
 

--- a/spec/rubocop/cop/lint/end_alignment_spec.rb
+++ b/spec/rubocop/cop/lint/end_alignment_spec.rb
@@ -65,6 +65,27 @@ describe RuboCop::Cop::Lint::EndAlignment, :config do
     end
   end
 
+  context 'when end is preceded by something else than whitespace' do
+    let(:source) do
+      ['module A',
+       'puts a end']
+    end
+
+    it 'registers an offense' do
+      inspect_source(cop, source)
+      expect(cop.offenses.size).to eq(1)
+      expect(cop.messages.first)
+        .to eq('`end` at 2, 7 is not aligned with `module` at 1, 0')
+      expect(cop.highlights.first).to eq('end')
+    end
+
+    it "doesn't auto-correct" do
+      expect(autocorrect_source(cop, source))
+        .to eq(source.join("\n"))
+      expect(cop.offenses.map(&:corrected?)).to eq [false]
+    end
+  end
+
   context 'regarding assignment' do
     context 'when AlignWith is keyword' do
       include_examples 'misaligned', 'var = ', 'if',     'test', 'end'


### PR DESCRIPTION
494fc90a makes use of `CorrectionNotPossible`, which was eliminated
just before. Here's a fix along with the missing test.