### PR TITLE
Adds FavorJoin auto-correct to ArrayJoin cop.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 * [#1278](https://github.com/bbatsov/rubocop/issues/1278): `DefEndAlignment` and `EndAlignment` cops do auto-correction. ([@lumeet][])
 * `IndentationWidth` cop follows the `AlignWith` option of the `DefEndAlignment` cop. ([@lumeet][])
 * [#1837](https://github.com/bbatsov/rubocop/issues/1837): New cop `EachWithObjectArgument` checks that `each_with_object` isn't called with an immutable object as argument. ([@jonas054][])
+* `ArrayJoin` cop does auto-correction. ([@tmr08c][])
 
 ### Bugs fixed
 
@@ -1383,3 +1384,4 @@
 [@til]: https://github.com/til
 [@carhartl]: https://github.com/carhartl
 [@dylandavidson]: https://github.com/dylandavidson
+[@tmr08c]: https://github.com/tmr08c

--- a/lib/rubocop/cop/style/array_join.rb
+++ b/lib/rubocop/cop/style/array_join.rb
@@ -18,6 +18,17 @@ module RuboCop
 
           add_offense(node, :selector)
         end
+
+        def autocorrect(node)
+          receiver_node, _method_name, *arg_nodes = *node
+          expr = node.loc.expression
+          array = receiver_node.loc.expression.source
+          join_arg  = arg_nodes[0].loc.expression.source
+
+          lambda do |corrector|
+            corrector.replace(expr, "#{array}.join(#{join_arg})")
+          end
+        end
       end
     end
   end

--- a/spec/rubocop/cop/style/array_join_spec.rb
+++ b/spec/rubocop/cop/style/array_join_spec.rb
@@ -11,6 +11,27 @@ describe RuboCop::Cop::Style::ArrayJoin do
     expect(cop.offenses.size).to eq(1)
   end
 
+  it "autocorrects '*' to 'join' when there are spaces" do
+    corrected =
+      autocorrect_source(cop,
+                         '%w(one two three) * ", "')
+    expect(corrected).to eq '%w(one two three).join(", ")'
+  end
+
+  it "autocorrects '*' to 'join' when there are no spaces" do
+    corrected =
+      autocorrect_source(cop,
+                         '%w(one two three)*", "')
+    expect(corrected).to eq '%w(one two three).join(", ")'
+  end
+
+  it "autocorrects '*' to 'join' when setting to a variable" do
+    corrected =
+      autocorrect_source(cop,
+                         'foo = %w(one two three)*", "')
+    expect(corrected).to eq 'foo = %w(one two three).join(", ")'
+  end
+
   it 'does not register an offense for numbers' do
     inspect_source(cop,
                    '%w(one two three) * 4')


### PR DESCRIPTION
This updates the `ArrayJoin` cop to add auto-correct functionality.

# Examples

## Before

```ruby
[1,2,3] * "-"
[1,2,3]*"-"

%w(a b c) * ', '
%w(a b c)*', '
```

## After

```ruby
[1, 2, 3].join('-')
[1, 2, 3].join('-')

%w(a b c).join(', ')
%w(a b c).join(', ')
```

# Additional tests

I wrote some additional tests to confirm my Regexp but I did not include them.

I can add them if they do not look like overkill.

```ruby
it "autocorrects '*' to 'join' when there are no spaces" do
  corrected = 
    autocorrect_source(cop,
                       '%w(one two three)*", "')
 expect(corrected).to eq '%w(one two three).join(", ")'
end

it "autocorrects '*' to 'join' when setting to a variable" do
  corrected =
    autocorrect_source(cop,
                       'foo = %w(one two three)*", "')
  expect(corrected).to eq 'foo = %w(one two three).join(", ")'
end
```