### PR TITLE
Fix crash on short lambda syntax without parentheses

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@
 * [#1843](https://github.com/bbatsov/rubocop/issues/1843): Fix crash in `TrailingBlankLines` when a file ends with a block comment without final newline. ([@jonas054][])
 * [#1849](https://github.com/bbatsov/rubocop/issues/1849): Fix bug where you can not have nested arrays in the Rake task configuration. ([@rrosenblum][])
 * Fix bug in `MultilineTernaryOperator` where it will not register an offense when only the false branch is on a separate line. ([@rrosenblum][])
+* Fix crash in `MultilineBlockLayout` when using new lambda literal syntax without parentheses. ([@hbd225][])
 
 ## 0.30.1 (21/04/2015)
 
@@ -1385,3 +1386,4 @@
 [@carhartl]: https://github.com/carhartl
 [@dylandavidson]: https://github.com/dylandavidson
 [@tmr08c]: https://github.com/tmr08c
+[@hbd225]: https://github.com/hbd225

--- a/lib/rubocop/cop/style/multiline_block_layout.rb
+++ b/lib/rubocop/cop/style/multiline_block_layout.rb
@@ -50,14 +50,17 @@ module RuboCop
           # with arguments and the expression start on the same line.
           _block_start, args, last_expression = node.children
 
-          if !args.children.empty? && do_loc.line != args.loc.end.line
-            add_offense_for_expression(node, args, ARG_MSG)
-          else
-            return unless last_expression
-            expression_loc = last_expression.loc
-            return unless do_loc.line == expression_loc.line
-            add_offense_for_expression(node, last_expression, MSG)
+          unless args.children.empty?
+            line = args.loc.end.nil? ? args.loc.line : args.loc.end.line
+            if do_loc.line != line
+              add_offense_for_expression(node, args, ARG_MSG)
+            end
           end
+
+          return unless last_expression
+          expression_loc = last_expression.loc
+          return unless do_loc.line == expression_loc.line
+          add_offense_for_expression(node, last_expression, MSG)
         end
 
         def add_offense_for_expression(node, expr, msg)

--- a/spec/rubocop/cop/style/multiline_block_layout_spec.rb
+++ b/spec/rubocop/cop/style/multiline_block_layout_spec.rb
@@ -87,6 +87,16 @@ describe RuboCop::Cop::Style::MultilineBlockLayout do
       .to eq(['Block body expression is on the same line as the block start.'])
   end
 
+  it 'registers offenses for new lambda literal syntax as expected' do
+    inspect_source(cop,
+                   ['-> x do foo',
+                    '  bar',
+                    'end'
+                   ])
+    expect(cop.messages)
+      .to eq(['Block body expression is on the same line as the block start.'])
+  end
+
   it 'registers an offense for line-break before arguments' do
     inspect_source(cop,
                    ['test do',


### PR DESCRIPTION
When using short lambda syntax without parentheses,
args.loc.end return nil so that it causes crash.