### PR TITLE
Fix handling of trailing comma in SpaceAfterComma and SpaceAroundBlockParameters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@
 * Fix bug in `MultilineTernaryOperator` where it will not register an offense when only the false branch is on a separate line. ([@rrosenblum][])
 * Fix crash in `MultilineBlockLayout` when using new lambda literal syntax without parentheses. ([@hbd225][])
 * [#1859](https://github.com/bbatsov/rubocop/pull/1859): Fix bugs in `IfUnlessModifier` concerning comments and empty lines. ([@jonas054][])
+* Fix handling of trailing comma in `SpaceAroundBlockParameters` and `SpaceAfterComma`. ([@lumeet][])
 
 ## 0.30.1 (21/04/2015)
 

--- a/lib/rubocop/cop/mixin/space_after_punctuation.rb
+++ b/lib/rubocop/cop/mixin/space_after_punctuation.rb
@@ -11,7 +11,7 @@ module RuboCop
         processed_source.tokens.each_cons(2) do |t1, t2|
           next unless kind(t1) && t1.pos.line == t2.pos.line &&
                       t2.pos.column == t1.pos.column + offset &&
-                      ![:tRPAREN, :tRBRACK].include?(t2.type)
+                      ![:tRPAREN, :tRBRACK, :tPIPE].include?(t2.type)
 
           add_offense(t1, t1.pos, format(MSG, kind(t1)))
         end

--- a/lib/rubocop/cop/style/space_around_block_parameters.rb
+++ b/lib/rubocop/cop/style/space_around_block_parameters.rb
@@ -38,24 +38,40 @@ module RuboCop
         end
 
         def check_inside_pipes(args, opening_pipe, closing_pipe)
+          if style == :no_space
+            check_no_space_style_inside_pipes(args, opening_pipe, closing_pipe)
+          elsif style == :space
+            check_space_style_inside_pipes(args, opening_pipe, closing_pipe)
+          end
+        end
+
+        def check_no_space_style_inside_pipes(args, opening_pipe, closing_pipe)
           first = args.first.loc.expression
           last = args.last.loc.expression
 
-          if style == :no_space
-            check_no_space(opening_pipe.end_pos, first.begin_pos,
-                           'Space before first')
-            check_no_space(last.end_pos, closing_pipe.begin_pos,
-                           'Space after last')
-          elsif style == :space
-            check_space(opening_pipe.end_pos, first.begin_pos, first,
-                        'before first block parameter')
-            check_space(last.end_pos, closing_pipe.begin_pos, last,
-                        'after last block parameter')
-            check_no_space(opening_pipe.end_pos, first.begin_pos - 1,
-                           'Extra space before first')
-            check_no_space(last.end_pos + 1, closing_pipe.begin_pos,
-                           'Extra space after last')
-          end
+          check_no_space(opening_pipe.end_pos, first.begin_pos,
+                         'Space before first')
+          check_no_space(last_end_pos_inside_pipes(last.end_pos),
+                         closing_pipe.begin_pos, 'Space after last')
+        end
+
+        def check_space_style_inside_pipes(args, opening_pipe, closing_pipe)
+          first = args.first.loc.expression
+          last = args.last.loc.expression
+          last_end_pos = last_end_pos_inside_pipes(last.end_pos)
+
+          check_space(opening_pipe.end_pos, first.begin_pos, first,
+                      'before first block parameter')
+          check_space(last_end_pos, closing_pipe.begin_pos, last,
+                      'after last block parameter')
+          check_no_space(opening_pipe.end_pos, first.begin_pos - 1,
+                         'Extra space before first')
+          check_no_space(last_end_pos + 1, closing_pipe.begin_pos,
+                         'Extra space after last')
+        end
+
+        def last_end_pos_inside_pipes(pos)
+          processed_source.buffer.source[pos] == ',' ? pos + 1 : pos
         end
 
         def check_each_arg(args)

--- a/spec/rubocop/cop/style/space_around_block_parameters_spec.rb
+++ b/spec/rubocop/cop/style/space_around_block_parameters_spec.rb
@@ -71,6 +71,20 @@ describe RuboCop::Cop::Style::SpaceAroundBlockParameters, :config do
       expect(cop.highlights).to eq(['  '])
     end
 
+    context 'trailing comma' do
+      it 'registers an offense for space after the last comma' do
+        inspect_source(cop, '{}.each { |x, | puts x }')
+        expect(cop.messages)
+          .to eq(['Space after last block parameter detected.'])
+        expect(cop.highlights).to eq([' '])
+      end
+
+      it 'accepts no space after the last comma' do
+        inspect_source(cop, '{}.each { |x,| puts x }')
+        expect(cop.offenses).to be_empty
+      end
+    end
+
     it 'auto-corrects offenses' do
       new_source = autocorrect_source(cop,
                                       '{}.each { |  x=5,  (y,*z) |puts x }')
@@ -144,6 +158,20 @@ describe RuboCop::Cop::Style::SpaceAroundBlockParameters, :config do
       expect(cop.messages)
         .to eq(['Extra space before block parameter detected.'])
       expect(cop.highlights).to eq(['  '])
+    end
+
+    context 'trailing comma' do
+      it 'accepts space after the last comma' do
+        inspect_source(cop, '{}.each { | x, | puts x }')
+        expect(cop.offenses).to be_empty
+      end
+
+      it 'registers an offense for no space after the last comma' do
+        inspect_source(cop, '{}.each { | x,| puts x }')
+        expect(cop.messages)
+          .to eq(['Space after last block parameter missing.'])
+        expect(cop.highlights).to eq(['x'])
+      end
     end
 
     it 'auto-corrects offenses' do


### PR DESCRIPTION
Both `Style/SpaceAfterComma` and `Style/SpaceAroundBlockParameters`
failed to properly handle a comma after the last item.

Together the bugs caused an infinite loop when auto-correcting.

Perhaps there should be a new cop for the trailing comma.