### PR TITLE
Emit acceptable methods in `Rails/TimeZone`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### New features
 
+* `Rails/TimeZone` emits acceptable methods on a violation when `EnforcedStyle` is `:acceptable`. ([@l8nite][])
 * Recognize rackup file (config.ru) out of the box. ([@carhartl][])
 * [#1788](https://github.com/bbatsov/rubocop/pull/1788): New cop `ModuleLength` checks for overly long module definitions. ([@sdeframond][])
 * New cop `Performance/Count` to convert `Enumerable#select...size`, `Enumerable#reject...size`, `Enumerable#select...count`, `Enumerable#reject...count` `Enumerable#select...length`, and `Enumerable#reject...length` to `Enumerable#count`. ([@rrosenblum][])
@@ -1388,3 +1389,4 @@
 [@dylandavidson]: https://github.com/dylandavidson
 [@tmr08c]: https://github.com/tmr08c
 [@hbd225]: https://github.com/hbd225
+[@l8nite]: https://github.com/l8nite

--- a/spec/rubocop/cop/rails/time_zone_spec.rb
+++ b/spec/rubocop/cop/rails/time_zone_spec.rb
@@ -141,6 +141,17 @@ describe RuboCop::Cop::Rails::TimeZone, :config do
     let(:cop_config) { { 'EnforcedStyle' => 'acceptable' } }
 
     described_class::TIMECLASS.each do |klass|
+      it "registers an offense for #{klass}.now" do
+        inspect_source(cop, "#{klass}.now")
+        expect(cop.offenses.size).to eq(1)
+        expect(cop.offenses.first.message).to include('Use one of')
+
+        described_class::ACCEPTED_METHODS.each do |a_method|
+          expect(cop.offenses.first.message)
+            .to include("#{klass}.now.#{a_method}")
+        end
+      end
+
       described_class::ACCEPTED_METHODS.each do |a_method|
         it "accepts #{klass}.now.#{a_method}" do
           inspect_source(cop, "#{klass}.now.#{a_method}")


### PR DESCRIPTION
When `Rails/TimeZone` detects a violation and the enforced style is `:acceptable`, the suggested fix is misleading.

The previous message was:
`Do not use Time.now without zone. Use Time.zone.now instead.`

The new message with this fix is:
`Do not use Time.now without zone. Use one of Time.now.in_time_zone, Time.now.utc, etc...`