### PR TITLE
Change handling of semicolon in block braces

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## master (unreleased)
 
+### Changes
+
+* Prefer `SpaceInsideBlockBraces` to `SpaceBeforeSemicolon` and `SpaceAfterSemicolon` to avoid an infinite loop when auto-correcting. ([@lumeet][])
+
 ### Bugs fixed
 
 * Don't count required keyword args when specifying `CountKeywordArgs: false` for `ParameterLists`. ([@sumeet][])

--- a/lib/rubocop/cop/mixin/space_after_punctuation.rb
+++ b/lib/rubocop/cop/mixin/space_after_punctuation.rb
@@ -11,10 +11,17 @@ module RuboCop
         processed_source.tokens.each_cons(2) do |t1, t2|
           next unless kind(t1) && t1.pos.line == t2.pos.line &&
                       t2.pos.column == t1.pos.column + offset &&
-                      ![:tRPAREN, :tRBRACK, :tPIPE].include?(t2.type)
+                      ![:tRPAREN, :tRBRACK, :tPIPE].include?(t2.type) &&
+                      !(t2.type == :tRCURLY && space_forbidden_before_rcurly?)
 
           add_offense(t1, t1.pos, format(MSG, kind(t1)))
         end
+      end
+
+      def space_forbidden_before_rcurly?
+        cfg = config.for_cop('Style/SpaceInsideBlockBraces')
+        style = cfg['Enabled'] ? cfg['EnforcedStyle'] : 'space'
+        style == 'no_space'
       end
 
       # The normal offset, i.e., the distance from the punctuation

--- a/lib/rubocop/cop/mixin/space_before_punctuation.rb
+++ b/lib/rubocop/cop/mixin/space_before_punctuation.rb
@@ -10,7 +10,8 @@ module RuboCop
       def investigate(processed_source)
         processed_source.tokens.each_cons(2) do |t1, t2|
           next unless kind(t2) && t1.pos.line == t2.pos.line &&
-                      t2.pos.begin_pos > t1.pos.end_pos
+                      t2.pos.begin_pos > t1.pos.end_pos &&
+                      !(t1.type == :tLCURLY && space_required_after_lcurly?)
           buffer = processed_source.buffer
           pos_before_punctuation = Parser::Source::Range.new(buffer,
                                                              t1.pos.end_pos,
@@ -20,6 +21,12 @@ module RuboCop
                       pos_before_punctuation,
                       format(MSG, kind(t2)))
         end
+      end
+
+      def space_required_after_lcurly?
+        cfg = config.for_cop('Style/SpaceInsideBlockBraces')
+        style = cfg['Enabled'] ? cfg['EnforcedStyle'] : 'space'
+        style == 'space'
       end
 
       def autocorrect(pos_before_punctuation)

--- a/spec/rubocop/cli_spec.rb
+++ b/spec/rubocop/cli_spec.rb
@@ -68,36 +68,6 @@ describe RuboCop::CLI, :isolated_environment do
         expect(IO.read('example.rb')).to eq(corrected)
       end
 
-      it 'crashes on infinite loop but prints offenses' do
-        create_file('example.rb', '3.times{ something;other_thing;}')
-        # This configuration makes --auto-correct impossible to finish since a
-        # space will be added after each ; but then removed again for the one
-        # that's inside }.
-        create_file('.rubocop.yml', ['SpaceInsideBlockBraces:',
-                                     '  EnforcedStyle: no_space',
-                                     '  SpaceBeforeBlockParameters: false'])
-        cmd = %w(--only SpaceAfterSemicolon,SpaceInsideBlockBraces
-                 --auto-correct --format simple)
-        expect { cli.run(cmd) }.to raise_error(RuboCop::Runner::
-                                               InfiniteCorrectionLoop)
-        expect(IO.read('example.rb'))
-          .to eq("3.times{something; other_thing;}\n")
-
-        expected_output = [
-          '== example.rb ==',
-          'C:  1:  9: [Corrected] Space inside { detected.',
-          'C:  1: 19: [Corrected] Space missing after semicolon.',
-          'C:  1: 31: [Corrected] Space missing after semicolon.',
-          'C:  1: 32: [Corrected] Space inside } detected.',
-          'C:  1: 33: [Corrected] Space inside } detected.',
-          '',
-          # We're interrupted during inspection, hence 0 files inspected.
-          '0 files inspected, 5 offenses detected, 5 offenses corrected',
-          ''
-        ]
-        expect($stdout.string).to eq(expected_output.join("\n"))
-      end
-
       it 'corrects complicated cases conservatively' do
         # Two cops make corrections here; Style/BracesAroundHashParameters, and
         # Style/AlignHash. Because they make minimal corrections relating only

--- a/spec/rubocop/cop/style/space_after_semicolon_spec.rb
+++ b/spec/rubocop/cop/style/space_after_semicolon_spec.rb
@@ -3,7 +3,11 @@
 require 'spec_helper'
 
 describe RuboCop::Cop::Style::SpaceAfterSemicolon do
-  subject(:cop) { described_class.new }
+  subject(:cop) { described_class.new(config) }
+  let(:config) do
+    RuboCop::Config.new('Style/SpaceInsideBlockBraces' => brace_config)
+  end
+  let(:brace_config) { {} }
 
   it 'registers an offense for semicolon without space after it' do
     inspect_source(cop, 'x = 1;y = 2')
@@ -19,5 +23,41 @@ describe RuboCop::Cop::Style::SpaceAfterSemicolon do
   it 'auto-corrects missing space' do
     new_source = autocorrect_source(cop, 'x = 1;y = 2')
     expect(new_source).to eq('x = 1; y = 2')
+  end
+
+  context 'inside block braces' do
+    shared_examples 'common behavior' do
+      it 'accepts a space between a semicolon and a closing brace' do
+        inspect_source(cop, 'test { ; }')
+        expect(cop.messages).to be_empty
+      end
+    end
+
+    context 'when EnforcedStyle for SpaceInsideBlockBraces is space' do
+      let(:brace_config) do
+        { 'Enabled' => true, 'EnforcedStyle' => 'space' }
+      end
+
+      it_behaves_like 'common behavior'
+
+      it 'registers an offense for no space between a semicolon and a ' \
+         'closing brace' do
+        inspect_source(cop, 'test { ;}')
+        expect(cop.messages).to eq(['Space missing after semicolon.'])
+      end
+    end
+
+    context 'when EnforcedStyle for SpaceInsideBlockBraces is no_space' do
+      let(:brace_config) do
+        { 'Enabled' => true, 'EnforcedStyle' => 'no_space' }
+      end
+
+      it_behaves_like 'common behavior'
+
+      it 'accepts no space between a semicolon and a closing brace' do
+        inspect_source(cop, 'test { ;}')
+        expect(cop.messages).to be_empty
+      end
+    end
   end
 end

--- a/spec/rubocop/cop/style/space_before_semicolon_spec.rb
+++ b/spec/rubocop/cop/style/space_before_semicolon_spec.rb
@@ -3,7 +3,11 @@
 require 'spec_helper'
 
 describe RuboCop::Cop::Style::SpaceBeforeSemicolon do
-  subject(:cop) { described_class.new }
+  subject(:cop) { described_class.new(config) }
+  let(:config) do
+    RuboCop::Config.new('Style/SpaceInsideBlockBraces' => brace_config)
+  end
+  let(:brace_config) { {} }
 
   it 'registers an offense for space before semicolon' do
     inspect_source(cop, 'x = 1 ; y = 2')
@@ -24,5 +28,41 @@ describe RuboCop::Cop::Style::SpaceBeforeSemicolon do
   it 'handles more than one space before a semicolon' do
     new_source = autocorrect_source(cop, 'x = 1  ; y = 2')
     expect(new_source).to eq('x = 1; y = 2')
+  end
+
+  context 'inside block braces' do
+    shared_examples 'common behavior' do
+      it 'accepts no space between an opening brace and a semicolon' do
+        inspect_source(cop, 'test {; }')
+        expect(cop.messages).to be_empty
+      end
+    end
+
+    context 'when EnforcedStyle for SpaceInsideBlockBraces is space' do
+      let(:brace_config) do
+        { 'Enabled' => true, 'EnforcedStyle' => 'space' }
+      end
+
+      it_behaves_like 'common behavior'
+
+      it 'accepts a space between an opening brace and a semicolon' do
+        inspect_source(cop, 'test { ; }')
+        expect(cop.messages).to be_empty
+      end
+    end
+
+    context 'when EnforcedStyle for SpaceInsideBlockBraces is no_space' do
+      let(:brace_config) do
+        { 'Enabled' => true, 'EnforcedStyle' => 'no_space' }
+      end
+
+      it_behaves_like 'common behavior'
+
+      it 'registers an offense for a space between an opening brace and a ' \
+         'semicolon' do
+        inspect_source(cop, 'test { ; }')
+        expect(cop.messages).to eq(['Space found before semicolon.'])
+      end
+    end
   end
 end


### PR DESCRIPTION
The fix prevents `Style/SpaceBeforeSemicolon`, `Style/SpaceAfterSemicolon` and `Style/SpaceInsideBlockBraces` from auto-correcting in an infinite loop.