### PR TITLE
Don't count required keyword args when specifying CountKeywordArgs: fals...

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## master (unreleased)
 
+### Bugs fixed
+
+* Don't count required keyword args when specifying `CountKeywordArgs: false` for `ParameterLists`. ([@sumeet][])
+
 ## 0.31.0 (05/05/2015)
 
 ### New features
@@ -1393,3 +1397,4 @@
 [@tmr08c]: https://github.com/tmr08c
 [@hbd225]: https://github.com/hbd225
 [@l8nite]: https://github.com/l8nite
+[@sumeet]: https://github.com/sumeet

--- a/lib/rubocop/cop/metrics/parameter_lists.rb
+++ b/lib/rubocop/cop/metrics/parameter_lists.rb
@@ -27,7 +27,7 @@ module RuboCop
           if count_keyword_args?
             node.children.size
           else
-            node.children.count { |a| a.type != :kwoptarg }
+            node.children.count { |a| ![:kwoptarg, :kwarg].include?(a.type) }
           end
         end
 

--- a/spec/rubocop/cop/metrics/parameter_lists_spec.rb
+++ b/spec/rubocop/cop/metrics/parameter_lists_spec.rb
@@ -35,8 +35,14 @@ describe RuboCop::Cop::Metrics::ParameterLists, :config do
   context 'When CountKeywordArgs is false' do
     before { cop_config['CountKeywordArgs'] = false }
 
-    it 'it does not count keyword arguments', ruby: 2 do
+    it 'does not count keyword arguments', ruby: 2 do
       inspect_source(cop, ['def meth(a, b, c, d: 1, e: 2)',
+                           'end'])
+      expect(cop.offenses).to be_empty
+    end
+
+    it 'does not count keyword arguments without default values', ruby: 2.1 do
+      inspect_source(cop, ['def meth(a, b, c, d:, e:)',
                            'end'])
       expect(cop.offenses).to be_empty
     end


### PR DESCRIPTION
...e for ParameterLists.

Hey! First time contributing here. I thought it was awesome that the parameter list cop had an option for ignoring keyword params. I modified it to also ignore keyword params that don't have default values. My guess is the intention behind this cop was to warn coders of huge lists of positional params (hence the `CountKeywordArgs` option). So this feels like more of a bug fix instead of a change in intent.

What do you guys think?