### PR TITLE
Sample: support shuffle randomness source and first/last params

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 * Don't count required keyword args when specifying `CountKeywordArgs: false` for `ParameterLists`. ([@sumeet][])
 * [#1879](https://github.com/bbatsov/rubocop/issues/1879): Avoid auto-correcting hash with trailing comma into invalid code in `BracesAroundHashParameters`. ([@jonas054][])
 * [#1868](https://github.com/bbatsov/rubocop/issues/1868): Do not register an offense in `Performance/Count` when `select` is called with symbols or strings as the parameters. ([@rrosenblum][])
+* `Sample` rewritten to properly handle shuffle randomness source, first/last params and non-literal ranges. ([@chastell][])
 
 ### New features
 
@@ -1413,3 +1414,4 @@
 [@l8nite]: https://github.com/l8nite
 [@sumeet]: https://github.com/sumeet
 [@ojab]: https://github.com/ojab
+[@chastell]: https://github.com/chastell

--- a/lib/rubocop/cop/performance/sample.rb
+++ b/lib/rubocop/cop/performance/sample.rb
@@ -1,89 +1,123 @@
-# encoding: utf-8
+# encoding: UTF-8
 
 module RuboCop
   module Cop
     module Performance
-      # This cop is used to identify usages of `shuffle.first` and
-      # change them to use `sample` instead.
+      # This cop is used to identify usages of `shuffle.first`, `shuffle.last`
+      # and `shuffle[]` and change them to use `sample` instead.
       #
       # @example
       #   # bad
       #   [1, 2, 3].shuffle.first
+      #   [1, 2, 3].shuffle.first(2)
       #   [1, 2, 3].shuffle.last
-      #   [1, 2, 3].shuffle[0]
-      #   [1, 2, 3].shuffle[0, 3]
-      #   [1, 2, 3].shuffle(random: Random.new(1))
+      #   [1, 2, 3].shuffle[2]
+      #   [1, 2, 3].shuffle[1, 3]
+      #   [1, 2, 3].shuffle(random: Random.new).first
       #
       #   # good
       #   [1, 2, 3].shuffle
       #   [1, 2, 3].sample
       #   [1, 2, 3].sample(3)
-      #   [1, 2, 3].sample(random: Random.new(1))
+      #   [1, 2, 3].shuffle[foo, bar]
+      #   [1, 2, 3].shuffle(random: Random.new)
       class Sample < Cop
-        MSG = 'Use `sample` instead of `shuffle%s`.'
-        RANGE_TYPES = [:irange, :erange]
-        VALID_ARRAY_SELECTORS = [:first, :last, :[], nil]
+        MSG = 'Use `%<correct>s` instead of `%<incorrect>s`.'
 
         def on_send(node)
-          _receiver, first_method, params, = *node
-          return unless first_method == :shuffle
-          _receiver, second_method, params, = *node.parent if params.nil?
-          return unless VALID_ARRAY_SELECTORS.include?(second_method)
-          return if second_method.nil? && params.nil?
-
-          add_offense(node, range_of_shuffle(node), message(node, params))
+          analyzer = ShuffleAnalyzer.new(node)
+          return unless analyzer.offensive?
+          add_offense(node, analyzer.source_range, analyzer.message)
         end
 
         def autocorrect(node)
-          _receiver, _method, params, selector = *node
-          _receiver, _method, params, selector = *node.parent if params.nil?
-
-          return if params && RANGE_TYPES.include?(params.type)
-
-          range = if params && (params.hash_type? || params.lvar_type?)
-                    range_of_shuffle(node)
-                  else
-                    Parser::Source::Range.new(node.loc.expression.source_buffer,
-                                              node.loc.selector.begin_pos,
-                                              node.parent.loc.selector.end_pos)
-                  end
-
-          lambda do |corrector|
-            corrector.replace(range, 'sample')
-            return if selector.nil?
-            corrector.insert_after(range, "(#{selector.loc.expression.source})")
-          end
+          ShuffleAnalyzer.new(node).autocorrect
         end
 
-        private
+        # An internal class for representing a shuffle + method node analyzer.
+        class ShuffleAnalyzer
+          def initialize(shuffle_node)
+            @shuffle_node = shuffle_node
+            @method_node  = shuffle_node.parent
+          end
 
-        def message(node, params)
-          if params && params.lvar_type?
-            format(MSG, shuffle_params(node))
-          elsif node.parent
-            _params, selector = *node.parent
-            if selector == :[]
-              format(MSG, node.parent.loc.selector.source)
-            else
-              format(MSG, ".#{node.parent.loc.selector.source}")
+          def autocorrect
+            ->(corrector) { corrector.replace(source_range, correct) }
+          end
+
+          def message
+            format(MSG, correct: correct, incorrect: source_range.source)
+          end
+
+          def offensive?
+            shuffle_node.to_a[1] == :shuffle && corrigible?
+          end
+
+          def source_range
+            Parser::Source::Range.new(shuffle_node.loc.expression.source_buffer,
+                                      shuffle_node.loc.selector.begin_pos,
+                                      method_node.loc.expression.end_pos)
+          end
+
+          private
+
+          attr_reader :method_node, :shuffle_node
+
+          def correct
+            args = [sample_arg, shuffle_arg].compact.join(', ')
+            args.empty? ? 'sample' : "sample(#{args})"
+          end
+
+          def corrigible?
+            case method
+            when :first, :last then true
+            when :[]           then sample_size != 0
+            else false
             end
-          else
-            format(MSG, shuffle_params(node))
           end
-        end
 
-        def range_of_shuffle(node)
-          Parser::Source::Range.new(node.loc.expression.source_buffer,
-                                    node.loc.selector.begin_pos,
-                                    node.loc.selector.end_pos)
-        end
+          def method
+            method_node.to_a[1]
+          end
 
-        def shuffle_params(node)
-          params = Parser::Source::Range.new(node.loc.expression.source_buffer,
-                                             node.loc.selector.end_pos,
-                                             node.loc.expression.end_pos)
+          def method_arg
+            _, _, arg = *method_node
+            arg.loc.expression.source if arg
+          end
 
-          params.source
+          def range_size(range_node)
+            vals = *range_node
+            return 0 unless vals.all?(&:int_type?)
+            low, high = *vals.map(&:to_a).map(&:first)
+            case range_node.type
+            when :erange then (low...high).size
+            when :irange then (low..high).size
+            end
+          end
+
+          def sample_arg
+            case method
+            when :first, :last then method_arg
+            when :[]           then sample_size
+            end
+          end
+
+          def sample_size
+            _, _, *args = *method_node
+            case args.size
+            when 1
+              arg = args.first
+              range_size(arg) if [:erange, :irange].include?(arg.type)
+            when 2
+              arg = args.last
+              arg.int_type? ? arg.to_a.first : 0
+            end
+          end
+
+          def shuffle_arg
+            _, _, arg = *shuffle_node
+            arg.loc.expression.source if arg
+          end
         end
       end
     end

--- a/lib/rubocop/cop/performance/sample.rb
+++ b/lib/rubocop/cop/performance/sample.rb
@@ -85,13 +85,16 @@ module RuboCop
             arg.loc.expression.source if arg
           end
 
+          # FIXME: use Range#size once Ruby 1.9 support is dropped
           def range_size(range_node)
             vals = *range_node
             return 0 unless vals.all?(&:int_type?)
             low, high = *vals.map(&:to_a).map(&:first)
+            size = high - low
+            return 0 if size < 0
             case range_node.type
-            when :erange then (low...high).size
-            when :irange then (low..high).size
+            when :erange then size
+            when :irange then size + 1
             end
           end
 

--- a/spec/rubocop/cop/performance/sample_spec.rb
+++ b/spec/rubocop/cop/performance/sample_spec.rb
@@ -6,25 +6,15 @@ describe RuboCop::Cop::Performance::Sample do
   subject(:cop) { described_class.new }
 
   shared_examples 'registers offense' do |wrong, right|
-    it "when using #{wrong} on a literal Array" do
+    it "when using #{wrong}" do
       inspect_source(cop, "[1, 2, 3].#{wrong}")
-      expect(cop.messages).to eq(["Use `#{right}` instead of `#{wrong}`."])
-    end
-
-    it "when using #{wrong} on a collection variable" do
-      inspect_source(cop, ['coll = [1, 2, 3]', "coll.#{wrong}"].join("\n"))
       expect(cop.messages).to eq(["Use `#{right}` instead of `#{wrong}`."])
     end
   end
 
-  shared_examples 'does not register offense' do |acceptable|
-    it "when using #{acceptable} on a literal Array" do
+  shared_examples 'accepts' do |acceptable|
+    it acceptable do
       inspect_source(cop, "[1, 2, 3].#{acceptable}")
-      expect(cop.messages).to be_empty
-    end
-
-    it "when using #{acceptable} on a collection variable" do
-      inspect_source(cop, ['coll = [1, 2, 3]', "coll.#{acceptable}"].join("\n"))
       expect(cop.messages).to be_empty
     end
   end
@@ -36,23 +26,16 @@ describe RuboCop::Cop::Performance::Sample do
     end
   end
 
-  shared_examples 'does not correct' do |acceptable|
-    it acceptable do
-      new_source = autocorrect_source(cop, "[1, 2, 3].#{acceptable}")
-      expect(new_source).to eq("[1, 2, 3].#{acceptable}")
-    end
-  end
-
   fixes = {
-    'shuffle.first'   => 'sample',
-    'shuffle.last'    => 'sample',
-    'shuffle[0]'      => 'sample',
-    'shuffle[2]'      => 'sample',
-    'shuffle[0, 3]'   => 'sample(3)',
-    'shuffle[2, 3]'   => 'sample(3)',
-    'shuffle[0..3]'   => 'sample(4)',
-    'shuffle[0...3]'  => 'sample(3)',
-    'shuffle[-4..-3]' => 'sample(2)',
+    'shuffle.first'      => 'sample',
+    'shuffle.last'       => 'sample',
+    'shuffle[0]'         => 'sample',
+    'shuffle[2]'         => 'sample',
+    'shuffle[0, 3]'      => 'sample(3)',
+    'shuffle[2, 3]'      => 'sample(3)',
+    'shuffle[0..3]'      => 'sample(4)',
+    'shuffle[0...3]'     => 'sample(3)',
+    'shuffle[-4..-3]'    => 'sample(2)',
     'shuffle.first(2)'   => 'sample(2)',
     'shuffle.last(3)'    => 'sample(3)',
     'shuffle.first(foo)' => 'sample(foo)',
@@ -70,20 +53,13 @@ describe RuboCop::Cop::Performance::Sample do
     it_behaves_like('corrects',          wrong, right)
   end
 
-  acceptables = [
-    'sample',
-    'shuffle',
-    'shuffle[2..-3]',
-    'shuffle[foo..bar]',
-    'shuffle[foo, bar]',
-    'shuffle(random: Random.new)',
-    'shuffle.join([5, 6, 7])',
-    'shuffle.map { |e| e }',
-    'shuffle(random: Random.new).find(&:odd?)'
-  ]
-
-  acceptables.each do |acceptable|
-    it_behaves_like('does not register offense', acceptable)
-    it_behaves_like('does not correct',          acceptable)
-  end
+  it_behaves_like('accepts', 'sample')
+  it_behaves_like('accepts', 'shuffle')
+  it_behaves_like('accepts', 'shuffle[2..-3]')
+  it_behaves_like('accepts', 'shuffle[foo..bar]')
+  it_behaves_like('accepts', 'shuffle[foo, bar]')
+  it_behaves_like('accepts', 'shuffle(random: Random.new)')
+  it_behaves_like('accepts', 'shuffle.join([5, 6, 7])')
+  it_behaves_like('accepts', 'shuffle.map { |e| e }')
+  it_behaves_like('accepts', 'shuffle(random: Random.new).find(&:odd?)')
 end


### PR DESCRIPTION
`Performance/Sample` registers the below as an offense:

```Ruby
[1, 2, 3].shuffle(random: foo).find(&:bar)
```

I believe [I have a valid use-case](https://github.com/chastell/signore/commit/1b6c1f0fbc963753e217c6764546cada9769a621) for ‘first shuffle, then find the first valid one’ over ‘select the valid ones, then find a random one’ – in my case the ‘shuffle + find’ approach is ~75 times faster than ‘select + sample’.