### PR TITLE
[Fix #1868] Only register an offense in Count for select with block or &:something format

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 
 * Don't count required keyword args when specifying `CountKeywordArgs: false` for `ParameterLists`. ([@sumeet][])
 * [#1879](https://github.com/bbatsov/rubocop/issues/1879): Avoid auto-correcting hash with trailing comma into invalid code in `BracesAroundHashParameters`. ([@jonas054][])
+* [#1868](https://github.com/bbatsov/rubocop/issues/1868): Do not register an offense in `Performance/Count` when `select` is called with symbols or strings as the parameters. ([@rrosenblum][])
 
 ## 0.31.0 (05/05/2015)
 

--- a/lib/rubocop/cop/performance/count.rb
+++ b/lib/rubocop/cop/performance/count.rb
@@ -14,12 +14,15 @@ module RuboCop
       #   [1, 2, 3].reject { |e| e > 2 }.length
       #   [1, 2, 3].select { |e| e > 2 }.count { |e| e.odd? }
       #   [1, 2, 3].reject { |e| e > 2 }.count { |e| e.even? }
+      #   array.select(&:value).count
       #
       #   # good
       #   [1, 2, 3].count { |e| e > 2 }
       #   [1, 2, 3].count { |e| e < 2 }
       #   [1, 2, 3].count { |e| e > 2 && e.odd? }
       #   [1, 2, 3].count { |e| e < 2 && e.even? }
+      #   Model.select('field AS field_one').count
+      #   Model.select(:value).count
       class Count < Cop
         MSG = 'Use `count` instead of `%s...%s`.'
 
@@ -27,56 +30,56 @@ module RuboCop
         COUNTERS = [:count, :length, :size]
 
         def on_send(node)
-          expression, first_method, second_method, third_method = parse(node)
-
-          return unless COUNTERS.include?(third_method)
-
-          begin_pos = if SELECTORS.include?(first_method)
-                        return if second_method.is_a?(Symbol)
-                        expression.loc.selector.begin_pos
-                      else
-                        return unless SELECTORS.include?(second_method)
-                        expression.parent.loc.selector.begin_pos
-                      end
-
+          selector, selector_loc, params, counter = parse(node)
+          return unless COUNTERS.include?(counter)
+          return unless SELECTORS.include?(selector)
+          return if params && !params.block_pass_type?
           return if node.parent && node.parent.block_type?
 
           range = Parser::Source::Range.new(node.loc.expression.source_buffer,
-                                            begin_pos,
+                                            selector_loc.begin_pos,
                                             node.loc.expression.end_pos)
 
-          add_offense(node, range,
-                      format(MSG, first_method || second_method, third_method))
+          add_offense(node, range, format(MSG, selector, counter))
         end
 
         def autocorrect(node)
-          expression, first_method, second_method, = parse(node)
+          selector, selector_loc = parse(node)
 
-          return if first_method == :reject || second_method == :reject
+          return if selector == :reject
 
-          selector = if SELECTORS.include?(first_method)
-                       expression.loc.selector
-                     else
-                       expression.parent.loc.selector
-                     end
+          range = Parser::Source::Range.new(node.loc.expression.source_buffer,
+                                            node.loc.dot.begin_pos,
+                                            node.loc.expression.end_pos)
 
           lambda do |corrector|
-            range = Parser::Source::Range.new(node.loc.expression.source_buffer,
-                                              node.loc.dot.begin_pos,
-                                              node.loc.expression.end_pos)
             corrector.remove(range)
-            corrector.replace(selector, 'count')
+            corrector.replace(selector_loc, 'count')
           end
         end
 
         private
 
         def parse(node)
-          left, third_method = *node
-          expression, second_method = *left
-          _enumerable, first_method = *expression
+          left, counter = *node
+          expression, selector, params = *left
 
-          [expression, first_method, second_method, third_method]
+          selector_loc =
+            if selector.is_a?(Symbol)
+              if expression && expression.parent.loc.respond_to?(:selector)
+                expression.parent.loc.selector
+              end
+            else
+              _enumerable, selector, params = *expression
+
+              expression.loc.selector if contains_selector?(expression)
+            end
+
+          [selector, selector_loc, params, counter]
+        end
+
+        def contains_selector?(node)
+          node.respond_to?(:loc) && node.loc.respond_to?(:selector)
         end
       end
     end

--- a/spec/rubocop/cop/performance/count_spec.rb
+++ b/spec/rubocop/cop/performance/count_spec.rb
@@ -11,6 +11,7 @@ describe RuboCop::Cop::Performance::Count do
 
       expect(cop.messages)
         .to eq(["Use `count` instead of `#{selector}...size`."])
+      expect(cop.highlights).to eq(["#{selector} { |e| e.even? }.size"])
     end
 
     it "registers an offense for using hash.#{selector}...size" do
@@ -18,6 +19,7 @@ describe RuboCop::Cop::Performance::Count do
 
       expect(cop.messages)
         .to eq(["Use `count` instead of `#{selector}...size`."])
+      expect(cop.highlights).to eq(["#{selector} { |e| e == :a }.size"])
     end
 
     it "registers an offense for using array.#{selector}...length" do
@@ -25,6 +27,7 @@ describe RuboCop::Cop::Performance::Count do
 
       expect(cop.messages)
         .to eq(["Use `count` instead of `#{selector}...length`."])
+      expect(cop.highlights).to eq(["#{selector} { |e| e.even? }.length"])
     end
 
     it "registers an offense for using hash.#{selector}...length" do
@@ -32,6 +35,7 @@ describe RuboCop::Cop::Performance::Count do
 
       expect(cop.messages)
         .to eq(["Use `count` instead of `#{selector}...length`."])
+      expect(cop.highlights).to eq(["#{selector} { |e| e == :a }.length"])
     end
 
     it "registers an offense for using array.#{selector}...count" do
@@ -39,6 +43,7 @@ describe RuboCop::Cop::Performance::Count do
 
       expect(cop.messages)
         .to eq(["Use `count` instead of `#{selector}...count`."])
+      expect(cop.highlights).to eq(["#{selector} { |e| e.even? }.count"])
     end
 
     it "registers an offense for using hash.#{selector}...count" do
@@ -46,16 +51,17 @@ describe RuboCop::Cop::Performance::Count do
 
       expect(cop.messages)
         .to eq(["Use `count` instead of `#{selector}...count`."])
+      expect(cop.highlights).to eq(["#{selector} { |e| e == :a }.count"])
     end
 
-    it "allows usage of #{selector}...count with a block" do
+    it "allows usage of #{selector}...count with a block on an array" do
       inspect_source(cop,
                      "[1, 2, 3].#{selector} { |e| e.odd? }.count { |e| e > 2 }")
 
       expect(cop.messages).to be_empty
     end
 
-    it "allows usage of #{selector}...count with a block" do
+    it "allows usage of #{selector}...count with a block on a hash" do
       source = "{a: 1, b: 2}.#{selector} { |e| e == :a }.count { |e| e > 2 }"
       inspect_source(cop, source)
 
@@ -69,27 +75,15 @@ describe RuboCop::Cop::Performance::Count do
 
       expect(cop.messages)
         .to eq(["Use `count` instead of `#{selector}...count`."])
+      expect(cop.highlights).to eq(["#{selector}(&:value).count"])
     end
 
-    it "allows usage of #{selector}!...size" do
-      inspect_source(cop,
-                     "[1, 2, 3].#{selector}! { |e| e.odd? }.size")
+    it "registers an offense for #{selector}(&:something).count" do
+      inspect_source(cop, "foo.#{selector}(&:something).count")
 
-      expect(cop.messages).to be_empty
-    end
-
-    it "allows usage of #{selector}!...count" do
-      inspect_source(cop,
-                     "[1, 2, 3].#{selector}! { |e| e.odd? }.count")
-
-      expect(cop.messages).to be_empty
-    end
-
-    it "allows usage of #{selector}!...length" do
-      inspect_source(cop,
-                     "[1, 2, 3].#{selector}! { |e| e.odd? }.length")
-
-      expect(cop.messages).to be_empty
+      expect(cop.messages)
+        .to eq(["Use `count` instead of `#{selector}...count`."])
+      expect(cop.highlights).to eq(["#{selector}(&:something).count"])
     end
 
     it "allows usage of #{selector} without getting the size" do
@@ -97,10 +91,60 @@ describe RuboCop::Cop::Performance::Count do
 
       expect(cop.messages).to be_empty
     end
+
+    context 'bang methods' do
+      it "allows usage of #{selector}!...size" do
+        inspect_source(cop,
+                       "[1, 2, 3].#{selector}! { |e| e.odd? }.size")
+
+        expect(cop.messages).to be_empty
+      end
+
+      it "allows usage of #{selector}!...count" do
+        inspect_source(cop,
+                       "[1, 2, 3].#{selector}! { |e| e.odd? }.count")
+
+        expect(cop.messages).to be_empty
+      end
+
+      it "allows usage of #{selector}!...length" do
+        inspect_source(cop,
+                       "[1, 2, 3].#{selector}! { |e| e.odd? }.length")
+
+        expect(cop.messages).to be_empty
+      end
+    end
   end
 
   it_behaves_like('selectors', 'select')
   it_behaves_like('selectors', 'reject')
+
+  context 'ActiveRecord select' do
+    it 'allows usage of select with a string' do
+      inspect_source(cop, "Model.select('field AS field_one').count")
+
+      expect(cop.messages).to be_empty
+    end
+
+    it 'allows usage of select with multiple strings' do
+      source = "Model.select('field AS field_one', 'other AS field_two').count"
+      inspect_source(cop, source)
+
+      expect(cop.messages).to be_empty
+    end
+
+    it 'allows usage of select with a symbol' do
+      inspect_source(cop, 'Model.select(:field).count')
+
+      expect(cop.messages).to be_empty
+    end
+
+    it 'allows usage of select with multiple symbols' do
+      inspect_source(cop, 'Model.select(:field, :other_field).count')
+
+      expect(cop.messages).to be_empty
+    end
+  end
 
   it 'allows usage of another method with size' do
     inspect_source(cop, '[1, 2, 3].map { |e| e + 1 }.size')
@@ -128,71 +172,113 @@ describe RuboCop::Cop::Performance::Count do
     expect(cop.messages).to be_empty
   end
 
+  it 'allows usage of count on an interstitial method with blocks ' \
+     'called on select' do
+    inspect_source(cop, ['Data = Struct.new(:value)',
+                         'array = [Data.new(2), Data.new(3), Data.new(2)]',
+                         'array.select(&:value).uniq { |v| v > 2 }.count'])
+
+    expect(cop.messages).to be_empty
+  end
+
+  it 'allows usage of size called on an assigned variable' do
+    inspect_source(cop, ['nodes = [1]',
+                         'nodes.size'].join("\n"))
+
+    expect(cop.messages).to be_empty
+  end
+
+  it 'allows usage of methods called on size' do
+    inspect_source(cop, 'shorter.size.to_f')
+
+    expect(cop.messages).to be_empty
+  end
+
+  context 'properly parses non related code' do
+    it 'will not raise an error for Bundler.setup' do
+      expect { inspect_source(cop, 'Bundler.setup(:default, :development)') }
+        .to_not raise_error
+    end
+
+    it 'will not raise an error for RakeTask.new' do
+      expect { inspect_source(cop, 'RakeTask.new(:spec)') }
+        .to_not raise_error
+    end
+  end
+
   context 'autocorrect' do
-    it 'corrects select..size to count' do
-      new_source = autocorrect_source(cop, '[1, 2].select { |e| e > 2 }.size')
+    context 'will correct' do
+      it 'select..size to count' do
+        new_source = autocorrect_source(cop, '[1, 2].select { |e| e > 2 }.size')
 
-      expect(new_source).to eq('[1, 2].count { |e| e > 2 }')
+        expect(new_source).to eq('[1, 2].count { |e| e > 2 }')
+      end
+
+      it 'select..count without a block to count' do
+        new_source = autocorrect_source(cop,
+                                        '[1, 2].select { |e| e > 2 }.count')
+
+        expect(new_source).to eq('[1, 2].count { |e| e > 2 }')
+      end
+
+      it 'select..length to count' do
+        new_source = autocorrect_source(cop,
+                                        '[1, 2].select { |e| e > 2 }.length')
+
+        expect(new_source).to eq('[1, 2].count { |e| e > 2 }')
+      end
+
+      it 'select...size when select has parameters' do
+        source = ['Data = Struct.new(:value)',
+                  'array = [Data.new(2), Data.new(3), Data.new(2)]',
+                  'puts array.select(&:value).size'].join("\n")
+
+        new_source = autocorrect_source(cop, source)
+
+        expect(new_source)
+          .to eq(['Data = Struct.new(:value)',
+                  'array = [Data.new(2), Data.new(3), Data.new(2)]',
+                  'puts array.count(&:value)'].join("\n"))
+      end
     end
 
-    it 'corrects select..count without a block to count' do
-      new_source = autocorrect_source(cop, '[1, 2].select { |e| e > 2 }.count')
+    describe 'will not correct' do
+      it 'reject...size' do
+        new_source = autocorrect_source(cop, '[1, 2].reject { |e| e > 2 }.size')
 
-      expect(new_source).to eq('[1, 2].count { |e| e > 2 }')
-    end
+        expect(new_source).to eq('[1, 2].reject { |e| e > 2 }.size')
+      end
 
-    it 'corrects select..length to count' do
-      new_source = autocorrect_source(cop, '[1, 2].select { |e| e > 2 }.length')
+      it 'reject...count' do
+        new_source = autocorrect_source(cop,
+                                        '[1, 2].reject { |e| e > 2 }.count')
 
-      expect(new_source).to eq('[1, 2].count { |e| e > 2 }')
-    end
+        expect(new_source).to eq('[1, 2].reject { |e| e > 2 }.count')
+      end
 
-    it 'corrects select...size when select has parameters' do
-      source = ['Data = Struct.new(:value)',
-                'array = [Data.new(2), Data.new(3), Data.new(2)]',
-                'puts array.select(&:value).size'].join("\n")
+      it 'reject...length' do
+        new_source = autocorrect_source(cop,
+                                        '[1, 2].reject { |e| e > 2 }.length')
 
-      new_source = autocorrect_source(cop, source)
+        expect(new_source).to eq('[1, 2].reject { |e| e > 2 }.length')
+      end
 
-      expect(new_source)
-        .to eq(['Data = Struct.new(:value)',
-                'array = [Data.new(2), Data.new(3), Data.new(2)]',
-                'puts array.count(&:value)'].join("\n"))
-    end
+      it 'select...count when count has a block' do
+        source = '[1, 2].select { |e| e > 2 }.count { |e| e.even? }'
+        new_source = autocorrect_source(cop, source)
 
-    it 'will not correct reject...size' do
-      new_source = autocorrect_source(cop, '[1, 2].reject { |e| e > 2 }.size')
+        expect(new_source).to eq(source)
+      end
 
-      expect(new_source).to eq('[1, 2].reject { |e| e > 2 }.size')
-    end
+      it 'reject...size when select has parameters' do
+        source = ['Data = Struct.new(:value)',
+                  'array = [Data.new(2), Data.new(3), Data.new(2)]',
+                  'puts array.reject(&:value).size'].join("\n")
 
-    it 'will not correct reject...count' do
-      new_source = autocorrect_source(cop, '[1, 2].reject { |e| e > 2 }.count')
+        new_source = autocorrect_source(cop, source)
 
-      expect(new_source).to eq('[1, 2].reject { |e| e > 2 }.count')
-    end
-
-    it 'will not correct reject...length' do
-      new_source = autocorrect_source(cop, '[1, 2].reject { |e| e > 2 }.length')
-
-      expect(new_source).to eq('[1, 2].reject { |e| e > 2 }.length')
-    end
-
-    it 'will not correct select...count when count has a block' do
-      source = '[1, 2].select { |e| e > 2 }.count { |e| e.even? }'
-      new_source = autocorrect_source(cop, source)
-
-      expect(new_source).to eq(source)
-    end
-
-    it 'will not correct reject...size when select has parameters' do
-      source = ['Data = Struct.new(:value)',
-                'array = [Data.new(2), Data.new(3), Data.new(2)]',
-                'puts array.reject(&:value).size'].join("\n")
-
-      new_source = autocorrect_source(cop, source)
-
-      expect(new_source).to eq(source)
+        expect(new_source).to eq(source)
+      end
     end
   end
 end


### PR DESCRIPTION
This fixes #1868.

This was a bit more difficult to fix than I thought it would be. I might be missing something, but in general, it has proven challenging to properly parse method chains that can take parameters or blocks. This was similar to the challenges in `Performance/Sample`. 

The only parameters to `select`, that will cause an offense, are the `&:something` format.

The other notable functionality to this cop, is that if a block is passed to both `select` and `count`, it will not register an offense. This functionality is present in version `0.31.0`. This will miss some offenses on `Enumerable`, but should be safe implementation with Rails.