### PR TITLE
Add reference links to cops

### DIFF
--- a/config/enabled.yml
+++ b/config/enabled.yml
@@ -270,6 +270,7 @@ Style/FormatString:
 Style/GlobalVars:
   Description: 'Do not introduce global variables.'
   StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#instance-vars'
+  Reference: 'http://www.zenspider.com/Languages/Ruby/QuickRef.html'
   Enabled: true
 
 Style/GuardClause:
@@ -453,6 +454,7 @@ Style/ParallelAssignment:
                   matches on both sides of the assignment.
                   This also provides performance benefits
   StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#parallel-assignment'
+  Reference: 'https://github.com/JuanitoFatas/fast-ruby#parallel-assignment-vs-sequential-assignment-code'
   Enabled: true
 
 Style/ParenthesesAroundCondition:
@@ -774,6 +776,7 @@ Metrics/AbcSize:
   Description: >-
                  A calculated magnitude based on number of assignments,
                  branches, and conditions.
+  Reference: 'http://c2.com/cgi/wiki?AbcMetric'
   Enabled: true
 
 Metrics/BlockNesting:
@@ -1027,6 +1030,7 @@ Performance/Detect:
   Description: >-
                   Use `detect` instead of `select.first`, `find_all.first`,
                   `select.last`, and `find_all.last`.
+  Reference: 'https://github.com/JuanitoFatas/fast-ruby#enumerabledetect-vs-enumerableselectfirst-code'
   Enabled: true
 
 Performance/FlatMap:
@@ -1034,6 +1038,7 @@ Performance/FlatMap:
                   Use `Enumerable#flat_map`
                   instead of `Enumerable#map...Array#flatten(1)`
                   or `Enumberable#collect..Array#flatten(1)`
+  Reference: 'https://github.com/JuanitoFatas/fast-ruby#enumerablemaparrayflatten-vs-enumerableflat_map-code'
   Enabled: true
   EnabledForFlattenWithoutParams: false
   # If enabled, this cop will warn about usages of
@@ -1043,18 +1048,21 @@ Performance/FlatMap:
 
 Performance/ReverseEach:
   Description: 'Use `reverse_each` instead of `reverse.each`.'
+  Reference: 'https://github.com/JuanitoFatas/fast-ruby#enumerablereverseeach-vs-enumerablereverse_each-code'
   Enabled: true
 
 Performance/Sample:
   Description: >-
                   Use `sample` instead of `shuffle.first`,
                   `shuffle.last`, and `shuffle[Fixnum]`.
+  Reference: 'https://github.com/JuanitoFatas/fast-ruby#arrayshufflefirst-vs-arraysample-code'
   Enabled: true
 
 Performance/Size:
   Description: >-
                   Use `size` instead of `count` for counting
                   the number of elements in `Array` and `Hash`.
+  Reference: 'https://github.com/JuanitoFatas/fast-ruby#arraycount-vs-arraysize-code'
   Enabled: true
 
 ##################### Rails ##################################
@@ -1105,6 +1113,8 @@ Rails/ScopeArgs:
 
 Rails/TimeZone:
   Description: 'Checks the correct usage of time zone aware methods.'
+  StyleGuide: 'https://github.com/bbatsov/rails-style-guide#time'
+  Reference: 'http://danilenko.org/2012/7/6/rails_timezones'
   Enabled: true
 
 Rails/Validation:


### PR DESCRIPTION
It seemed useful to provide links to the fast-ruby project since it helped inspire the performance cops. It also provides nice information for anyone that is unaware of the performance gains. If people like this, we can consider treating the links similar to the `StyleGuide` links. 