### PR TITLE
[Fix #1865] Identify unnecessary rubocop:disable comments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## master (unreleased)
 
+### New features
+
+* [#1865](https://github.com/bbatsov/rubocop/issues/1865): The option `--format d` now prints `(unnecessary)` after a cop name to indicate that a `rubocop:disable` comment can be removed. ([@jonas054][])
+
 ### Bugs fixed
 
 * Don't count required keyword args when specifying `CountKeywordArgs: false` for `ParameterLists`. ([@sumeet][])

--- a/lib/rubocop/cop/cop.rb
+++ b/lib/rubocop/cop/cop.rb
@@ -154,8 +154,6 @@ module RuboCop
       def add_offense(node, loc, message = nil, severity = nil)
         location = loc.is_a?(Symbol) ? node.loc.send(loc) : loc
 
-        return unless enabled_line?(location.line)
-
         # Don't include the same location twice for one cop.
         return if @offenses.find { |o| o.location == location }
 
@@ -164,20 +162,20 @@ module RuboCop
         message ||= message(node)
         message = annotate_message(message)
 
-        corrected = correct(node)
+        status = enabled_line?(location.line) ? correct(node) : :disabled
 
-        @offenses << Offense.new(severity, location, message, name, corrected)
+        @offenses << Offense.new(severity, location, message, name, status)
         yield if block_given?
       end
 
       def correct(node)
-        return nil unless support_autocorrect?
-        return false unless autocorrect?
+        return :unsupported unless support_autocorrect?
+        return :uncorrected unless autocorrect?
 
         correction = autocorrect(node)
-        return false unless correction
+        return :uncorrected unless correction
         @corrections << correction
-        true
+        :corrected
       end
 
       def config_to_allow_offenses

--- a/lib/rubocop/cop/offense.rb
+++ b/lib/rubocop/cop/offense.rb
@@ -56,16 +56,29 @@ module RuboCop
       #
       # @return [Boolean]
       #   whether this offense is automatically corrected.
-      attr_reader :corrected
+      def corrected
+        @status == :unsupported ? nil : @status == :corrected
+      end
       alias_method :corrected?, :corrected
 
+      # @api public
+      #
+      # @!attribute [r] disabled?
+      #
+      # @return [Boolean]
+      #   whether this offense was locally disabled where it occurred
+      def disabled?
+        @status == :disabled
+      end
+
       # @api private
-      def initialize(severity, location, message, cop_name, corrected = false)
+      def initialize(severity, location, message, cop_name,
+                     status = :uncorrected)
         @severity = RuboCop::Cop::Severity.new(severity)
         @location = location
         @message = message.freeze
         @cop_name = cop_name.freeze
-        @corrected = corrected
+        @status = status
         freeze
       end
 

--- a/lib/rubocop/formatter/base_formatter.rb
+++ b/lib/rubocop/formatter/base_formatter.rb
@@ -102,6 +102,10 @@ module RuboCop
       def file_finished(file, offenses)
       end
 
+      def wanted_offenses(offenses)
+        offenses.reject(&:disabled?)
+      end
+
       # @api public
       #
       # Invoked after all files are inspected, or interrupted by user.

--- a/lib/rubocop/formatter/formatter_set.rb
+++ b/lib/rubocop/formatter/formatter_set.rb
@@ -21,12 +21,16 @@ module RuboCop
         'disabled' => DisabledLinesFormatter
       }
 
-      FORMATTER_APIS = [:started, :file_started, :file_finished, :finished]
+      FORMATTER_APIS = [:started, :file_started, :finished]
 
       FORMATTER_APIS.each do |method_name|
         define_method(method_name) do |*args|
           each { |f| f.send(method_name, *args) }
         end
+      end
+
+      def file_finished(file, offenses)
+        each { |f| f.file_finished(file, f.wanted_offenses(offenses)) }
       end
 
       def add_formatter(formatter_type, output_path = nil)

--- a/lib/rubocop/runner.rb
+++ b/lib/rubocop/runner.rb
@@ -190,8 +190,11 @@ module RuboCop
 
     def considered_failure?(offense)
       # For :autocorrect level, any offense - corrected or not - is a failure.
-      @options[:fail_level] == :autocorrect ||
-        !offense.corrected? && offense.severity >= minimum_severity_to_fail
+      return true if @options[:fail_level] == :autocorrect
+
+      return false if offense.disabled?
+
+      !offense.corrected? && offense.severity >= minimum_severity_to_fail
     end
 
     def minimum_severity_to_fail

--- a/spec/rubocop/cop/offense_spec.rb
+++ b/spec/rubocop/cop/offense_spec.rb
@@ -9,7 +9,7 @@ describe RuboCop::Cop::Offense do
     Parser::Source::Range.new(source_buffer, 0, 1)
   end
   subject(:offense) do
-    described_class.new(:convention, location, 'message', 'CopName', true)
+    described_class.new(:convention, location, 'message', 'CopName', :corrected)
   end
 
   it 'has a few required attributes' do

--- a/spec/rubocop/formatter/base_formatter_spec.rb
+++ b/spec/rubocop/formatter/base_formatter_spec.rb
@@ -57,10 +57,13 @@ module RuboCop
             expect(output).to eq([
               'started',
               'file_started',
+              'wanted_offenses',
               'file_finished',
               'file_started',
+              'wanted_offenses',
               'file_finished',
               'file_started',
+              'wanted_offenses',
               'file_finished',
               'finished',
               ''
@@ -167,6 +170,14 @@ module RuboCop
           include_examples 'receives a file path', :file_finished
 
           it 'receives an array of detected offenses for the file' do
+            class << formatter
+              # Override null object behavior, since the return value will be
+              # the input to file_finished.
+              def wanted_offenses(offenses)
+                offenses
+              end
+            end
+
             expect(formatter).to receive(:file_finished)
               .exactly(3).times do |file, offenses|
               case File.basename(file)

--- a/spec/rubocop/formatter/clang_style_formatter_spec.rb
+++ b/spec/rubocop/formatter/clang_style_formatter_spec.rb
@@ -80,7 +80,7 @@ module RuboCop
 
         let(:offense) do
           Cop::Offense.new(:convention, location,
-                           'This is a message.', 'CopName', corrected)
+                           'This is a message.', 'CopName', status)
         end
 
         let(:location) do
@@ -90,7 +90,7 @@ module RuboCop
         end
 
         context 'when the offense is not corrected' do
-          let(:corrected) { false }
+          let(:status) { :uncorrected }
 
           it 'prints message as-is' do
             formatter.report_file(file, [offense])
@@ -100,7 +100,7 @@ module RuboCop
         end
 
         context 'when the offense is automatically corrected' do
-          let(:corrected) { true }
+          let(:status) { :corrected }
 
           it 'prints [Corrected] along with message' do
             formatter.report_file(file, [offense])

--- a/spec/rubocop/formatter/disabled_lines_formatter_spec.rb
+++ b/spec/rubocop/formatter/disabled_lines_formatter_spec.rb
@@ -44,21 +44,39 @@ module RuboCop
       describe '#finished' do
         context 'when there disabled cops detected' do
           let(:cop_disabled_line_ranges) do
-            { cop_disabled_line_ranges: { 'LineLength' => [1..1] } }
+            {
+              cop_disabled_line_ranges: {
+                'LineLength' => [1..1],
+                'ClassLength' => [1..Float::INFINITY]
+              }
+            }
           end
+          let(:offenses) do
+            [
+              Cop::Offense.new(:convention, location, 'Class too long.',
+                               'ClassLength', :disabled),
+              # This one is outside of the disabled line range:
+              Cop::Offense.new(:convention, location, 'Line too long.',
+                               'LineLength', :uncorrected)
+            ]
+          end
+          let(:location) { OpenStruct.new(line: 3) }
 
           before do
             formatter.started(files)
             formatter.file_started('lib/rubocop.rb', cop_disabled_line_ranges)
+            formatter.file_finished('lib/rubocop.rb', offenses)
           end
 
           it 'lists disabled cops by file' do
             formatter.finished(files)
-            expect(output.string).to eq(['',
-                                         'Cops disabled line ranges:',
-                                         '',
-                                         'lib/rubocop.rb:1..1: LineLength',
-                                         ''].join("\n"))
+            expect(output.string)
+              .to eq(['',
+                      'Cops disabled line ranges:',
+                      '',
+                      'lib/rubocop.rb:1..1: LineLength (unnecessary)',
+                      'lib/rubocop.rb:1..Infinity: ClassLength',
+                      ''].join("\n"))
           end
         end
       end

--- a/spec/rubocop/formatter/emacs_style_formatter_spec.rb
+++ b/spec/rubocop/formatter/emacs_style_formatter_spec.rb
@@ -33,7 +33,7 @@ module RuboCop
 
           let(:offense) do
             Cop::Offense.new(:convention, location,
-                             'This is a message.', 'CopName', corrected)
+                             'This is a message.', 'CopName', status)
           end
 
           let(:location) do
@@ -42,7 +42,7 @@ module RuboCop
             Parser::Source::Range.new(source_buffer, 0, 1)
           end
 
-          let(:corrected) { true }
+          let(:status) { :corrected }
 
           it 'prints [Corrected] along with message' do
             formatter.file_finished(file, [offense])

--- a/spec/rubocop/formatter/fuubar_style_formatter_spec.rb
+++ b/spec/rubocop/formatter/fuubar_style_formatter_spec.rb
@@ -53,9 +53,9 @@ module RuboCop
         formatter.started(files)
       end
 
-      def offense(severity, corrected = false)
+      def offense(severity, status = :uncorrected)
         source_range = double('source_range').as_null_object
-        Cop::Offense.new(severity, source_range, 'message', 'Cop', corrected)
+        Cop::Offense.new(severity, source_range, 'message', 'Cop', status)
       end
 
       context 'initially' do
@@ -117,7 +117,7 @@ module RuboCop
 
       context 'when a offense is detected in a file and auto-corrected' do
         before do
-          formatter.file_finished(files[0], [offense(:convention, true)])
+          formatter.file_finished(files[0], [offense(:convention, :corrected)])
         end
 
         it 'is green' do

--- a/spec/rubocop/formatter/json_formatter_spec.rb
+++ b/spec/rubocop/formatter/json_formatter_spec.rb
@@ -15,7 +15,7 @@ module RuboCop
     end
     let(:offense) do
       Cop::Offense.new(:convention, location,
-                       'This is message', 'CopName', true)
+                       'This is message', 'CopName', :corrected)
     end
 
     describe '#started' do

--- a/spec/rubocop/formatter/simple_text_formatter_spec.rb
+++ b/spec/rubocop/formatter/simple_text_formatter_spec.rb
@@ -19,7 +19,7 @@ module RuboCop
 
         let(:offense) do
           Cop::Offense.new(:convention, location,
-                           'This is a message.', 'CopName', corrected)
+                           'This is a message.', 'CopName', status)
         end
 
         let(:location) do
@@ -28,7 +28,7 @@ module RuboCop
           Parser::Source::Range.new(source_buffer, 0, 1)
         end
 
-        let(:corrected) { false }
+        let(:status) { :uncorrected }
 
         context 'the file is under the current working directory' do
           let(:file) { File.expand_path('spec/spec_helper.rb') }
@@ -51,7 +51,7 @@ module RuboCop
         end
 
         context 'when the offense is not corrected' do
-          let(:corrected) { false }
+          let(:status) { :uncorrected }
 
           it 'prints message as-is' do
             expect(output.string)
@@ -60,7 +60,7 @@ module RuboCop
         end
 
         context 'when the offense is automatically corrected' do
-          let(:corrected) { true }
+          let(:status) { :corrected }
 
           it 'prints [Corrected] along with message' do
             expect(output.string)


### PR DESCRIPTION
*I think I found a way to add this functionality, not mess up the code badly, and keep public APIs backwards compatible.*

Keep all offenses around, including locally disabled ones, until reporting time.

Let the formatters do the filtering by adding a new method `wanted_offenses` in the public API of `BaseFormatter`. The default behavior is to not keep the comment-disabled offenses, which makes the change backwards compatible.

Likewise, the public API of `Offense` is amended with a `disabled?` method, but the `corrected`/`corrected?` methods stay compatible.

`DisabledLinesFormatter` outputs a red `(unnecessary)` after lines with a disabled cop and a line range that didn't have any offenses for that cop.