### PR TITLE
Adds auto-correct to LiteralInInterpolation cop.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,10 @@
 * Don't count required keyword args when specifying `CountKeywordArgs: false` for `ParameterLists`. ([@sumeet][])
 * [#1879](https://github.com/bbatsov/rubocop/issues/1879): Avoid auto-correcting hash with trailing comma into invalid code in `BracesAroundHashParameters`. ([@jonas054][])
 
+### New features
+
+* `LiteralInInterpolation` cop does auto-correction. ([@tmr08c][])
+
 ## 0.31.0 (05/05/2015)
 
 ### New features

--- a/config/disabled.yml
+++ b/config/disabled.yml
@@ -52,3 +52,7 @@ Style/SymbolArray:
 Style/ExtraSpacing:
   Description: 'Do not use unnecessary spacing.'
   Enabled: false
+
+Lint/LiteralInInterpolation:
+  Description: 'Avoid interpolating literals in strings'
+  AutoCorrect: false

--- a/lib/rubocop/cop/lint/literal_in_interpolation.rb
+++ b/lib/rubocop/cop/lint/literal_in_interpolation.rb
@@ -25,12 +25,22 @@ module RuboCop
           end
         end
 
+        def autocorrect(node)
+          expr = node.parent.loc.expression
+          value = autocorrected_value(node)
+          ->(corrector) { corrector.replace(expr, value) }
+        end
+
         private
 
         def special_keyword?(node)
           # handle strings like __FILE__
           (node.type == :str && !node.loc.respond_to?(:begin)) ||
             node.loc.expression.is?('__LINE__')
+        end
+
+        def autocorrected_value(node)
+          node.str_type? ? node.children.last : node.loc.expression.source
         end
       end
     end

--- a/spec/rubocop/cop/lint/literal_in_interpolation_spec.rb
+++ b/spec/rubocop/cop/lint/literal_in_interpolation_spec.rb
@@ -16,6 +16,47 @@ describe RuboCop::Cop::Lint::LiteralInInterpolation do
       expect(cop.offenses.size).to eq(1)
     end
 
+    it "should have #{literal} as the message highlight" do
+      inspect_source(cop, %("this is the \#{#{literal}}"))
+      expect(cop.highlights).to eq(["#{literal}"])
+    end
+
+    it "removes interpolation around #{literal}" do
+      corrected = autocorrect_source(cop, %("this is the \#{#{literal}}"))
+      expect(corrected).to eq(%("this is the #{literal}"))
+    end
+
+    it "removes interpolation around #{literal} when there is more text" do
+      corrected =
+        autocorrect_source(cop, %("this is the \#{#{literal}} literally"))
+      expect(corrected).to eq(%("this is the #{literal} literally"))
+    end
+
+    it "removes interpolation around multiple #{literal}" do
+      corrected =
+        autocorrect_source(cop,
+                           %("some \#{#{literal}} with \#{#{literal}} too"))
+      expect(corrected).to eq(%("some #{literal} with #{literal} too"))
+    end
+
+    context 'when there is non-literal and literal interpolation' do
+      context 'when literal interpolation is before non-literal' do
+        it 'only remove interpolation around literal' do
+          corrected =
+            autocorrect_source(cop, %("this is \#{#{literal}} with \#{a} now"))
+          expect(corrected).to eq(%("this is #{literal} with \#{a} now"))
+        end
+      end
+
+      context 'when literal interpolation is after non-literal' do
+        it 'only remove interpolation around literal' do
+          corrected =
+            autocorrect_source(cop, %("this is \#{a} with \#{#{literal}} now"))
+          expect(corrected).to eq(%("this is \#{a} with #{literal} now"))
+        end
+      end
+    end
+
     it "registers an offense only for final #{literal} in interpolation" do
       inspect_source(cop, %("this is the \#{#{literal};#{literal}}"))
       expect(cop.offenses.size).to eq(1)
@@ -42,9 +83,20 @@ describe RuboCop::Cop::Lint::LiteralInInterpolation do
       expect(cop.offenses).to be_empty
     end
 
+    it "does not try to autocrrect strings like #{keyword}" do
+      corrected = autocorrect_source(cop, %("this is the \#{#{keyword}} silly"))
+
+      expect(corrected).to eq(%("this is the \#{#{keyword}} silly"))
+    end
+
     it "registers an offense for interpolation after #{keyword}" do
       inspect_source(cop, %("this is the \#{#{keyword}} \#{1}"))
       expect(cop.offenses.size).to eq(1)
+    end
+
+    it "auto-corrects literal interpolation after #{keyword}" do
+      corrected = autocorrect_source(cop, %("this is the \#{#{keyword}} \#{1}"))
+      expect(corrected).to eq(%("this is the \#{#{keyword}} 1"))
     end
   end
 
@@ -52,4 +104,24 @@ describe RuboCop::Cop::Lint::LiteralInInterpolation do
   it_behaves_like('special keywords', '__LINE__')
   it_behaves_like('special keywords', '__END__')
   it_behaves_like('special keywords', '__ENCODING__')
+
+  shared_examples 'non-special string literal interpolation' do |string|
+    it "registers an offense for #{string}" do
+      inspect_source(cop, %("this is the \#{#{string}}"))
+      expect(cop.offenses.size).to eq(1)
+    end
+
+    it "should have #{string} in the message highlight" do
+      inspect_source(cop, %("this is the \#{#{string}}"))
+      expect(cop.highlights).to eq(["#{string}"])
+    end
+
+    it "should remove the interpolation and quotes around #{string}" do
+      corrected = autocorrect_source(cop, %("this is the \#{#{string}}"))
+      expect(corrected).to eq(%("this is the #{string.gsub(/'|"/, '')}"))
+    end
+  end
+
+  it_behaves_like('non-special string literal interpolation', %('foo'))
+  it_behaves_like('non-special string literal interpolation', %("foo"))
 end


### PR DESCRIPTION
This updates the `LiteralInInterpolation` cop to add auto-correction functionality.

## Example

### Before

```ruby
"This is string #{1}"
"another #{'string'}"
"let us #{a} with #{1}"
"does it work? #{true}"
```

### After

```ruby
'This is string 1'
'another string'
"let us #{a} with 1"
'does it work? true'
```

## Additional Specs

I added additional specs to test the auto-correct functionality with the existing examples as well as with multiple literals interpolated and literal interpolation mixed with non-literal interpolation.
