### PR TITLE
[Fix 1879] Avoid auto-correcting hash braces and trailing comma

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 ### Bugs fixed
 
 * Don't count required keyword args when specifying `CountKeywordArgs: false` for `ParameterLists`. ([@sumeet][])
+* [#1879](https://github.com/bbatsov/rubocop/issues/1879): Avoid auto-correcting hash with trailing comma into invalid code in `BracesAroundHashParameters`. ([@jonas054][])
 
 ## 0.31.0 (05/05/2015)
 

--- a/spec/rubocop/cop/style/braces_around_hash_parameters_spec.rb
+++ b/spec/rubocop/cop/style/braces_around_hash_parameters_spec.rb
@@ -143,6 +143,15 @@ describe RuboCop::Cop::Style::BracesAroundHashParameters, :config do
       corrected = autocorrect_source(cop, 'get :i, { q: { x: 1 } }')
       expect(corrected).to eq('get :i, q: { x: 1 }')
     end
+
+    context 'in a method call without parentheses' do
+      it 'does not correct a hash parameter with trailing comma' do
+        # Because `get :i, x: 1,` is invalid syntax.
+        src = 'get :i, { x: 1, }'
+        corrected = autocorrect_source(cop, src)
+        expect(corrected).to eq(src)
+      end
+    end
   end
 
   context 'when EnforcedStyle is no_braces' do


### PR DESCRIPTION
If the last argument in a method call without parentheses is a hash with braces and a trailing comma, avoid auto-correcting it since the trailing comma makes it a syntax error when the braces are gone.