### PR TITLE
Travis: notify GitHub all is well before allowed failures finish

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,6 +14,7 @@ matrix:
     - rvm: ruby-head
     - rvm: jruby-19mode
     - rvm: rbx-2
+  fast_finish: true
 before_install: gem update --remote bundler
 install:
   - bundle install --retry=3


### PR DESCRIPTION
This makes Travis notify GitHub all is well / not well before waiting for the allowed failures.