### PR TITLE
[Fix #1868] Do not register an offense in Performance/Count for select called as a static method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@
 * [#1879](https://github.com/bbatsov/rubocop/issues/1879): Avoid auto-correcting hash with trailing comma into invalid code in `BracesAroundHashParameters`. ([@jonas054][])
 * [#1868](https://github.com/bbatsov/rubocop/issues/1868): Do not register an offense in `Performance/Count` when `select` is called with symbols or strings as the parameters. ([@rrosenblum][])
 * `Sample` rewritten to properly handle shuffle randomness source, first/last params and non-literal ranges. ([@chastell][])
+* [#1868](https://github.com/bbatsov/rubocop/issues/1868): Do not register an offense in `Performance/Count` when `select` is called as a static method. This should fix the false positives for use with `ActiveRecord`. ([@rrosenblum][])
 
 ## 0.31.0 (05/05/2015)
 

--- a/spec/rubocop/cop/performance/count_spec.rb
+++ b/spec/rubocop/cop/performance/count_spec.rb
@@ -121,26 +121,40 @@ describe RuboCop::Cop::Performance::Count do
 
   context 'ActiveRecord select' do
     it 'allows usage of select with a string' do
-      inspect_source(cop, "Model.select('field AS field_one').count")
+      source = ['klass = Model',
+                "klass.select('field AS field_one').count"].join("\n")
+      inspect_source(cop, source)
 
       expect(cop.messages).to be_empty
     end
 
     it 'allows usage of select with multiple strings' do
-      source = "Model.select('field AS field_one', 'other AS field_two').count"
+      source = ['klass = Model',
+                "klass.select('field AS one', 'other AS two').count"]
+               .join("\n")
       inspect_source(cop, source)
 
       expect(cop.messages).to be_empty
     end
 
     it 'allows usage of select with a symbol' do
-      inspect_source(cop, 'Model.select(:field).count')
+      source = ['klass = Model',
+                'klass.select(:field).count'].join("\n")
+      inspect_source(cop, source)
 
       expect(cop.messages).to be_empty
     end
 
     it 'allows usage of select with multiple symbols' do
-      inspect_source(cop, 'Model.select(:field, :other_field).count')
+      source = ['klass = Model',
+                'klass.select(:field, :other_field).count'].join("\n")
+      inspect_source(cop, source)
+
+      expect(cop.messages).to be_empty
+    end
+
+    it 'allows usage of select called as a static method' do
+      inspect_source(cop, 'Model.select { |model| model.works? }.count')
 
       expect(cop.messages).to be_empty
     end


### PR DESCRIPTION
This should unscope most calls to ActiveRecord's `select` methods making this cop safer to use.