### PR TITLE
Include `Time.zone.now` in acceptable alternatives

### DIFF
--- a/lib/rubocop/cop/rails/time_zone.rb
+++ b/lib/rubocop/cop/rails/time_zone.rb
@@ -68,13 +68,9 @@ module RuboCop
 
         def build_message(klass, method_name, node)
           if acceptable?
-            accepted_methods = ACCEPTED_METHODS.map do |am|
-              "`#{klass}.#{method_name}.#{am}`"
-            end
-
             format(MSG_ACCEPTABLE,
                    "#{klass}.#{method_name}",
-                   accepted_methods.join(', ')
+                   acceptable_methods(klass, method_name, node).join(', ')
                   )
           else
             safe_method_name = safe_method(method_name, node)
@@ -145,6 +141,18 @@ module RuboCop
 
         def good_methods
           style == :always ? [:zone] : [:zone] + ACCEPTED_METHODS
+        end
+
+        def acceptable_methods(klass, method_name, node)
+          acceptable = [
+            "`#{klass}.zone.#{safe_method(method_name, node)}`"
+          ]
+
+          ACCEPTED_METHODS.each do |am|
+            acceptable << "`#{klass}.#{method_name}.#{am}`"
+          end
+
+          acceptable
         end
       end
     end

--- a/spec/rubocop/cop/rails/time_zone_spec.rb
+++ b/spec/rubocop/cop/rails/time_zone_spec.rb
@@ -146,6 +146,8 @@ describe RuboCop::Cop::Rails::TimeZone, :config do
         expect(cop.offenses.size).to eq(1)
         expect(cop.offenses.first.message).to include('Use one of')
 
+        expect(cop.offenses.first.message).to include("#{klass}.zone.now")
+
         described_class::ACCEPTED_METHODS.each do |a_method|
           expect(cop.offenses.first.message)
             .to include("#{klass}.now.#{a_method}")
@@ -157,6 +159,11 @@ describe RuboCop::Cop::Rails::TimeZone, :config do
           inspect_source(cop, "#{klass}.now.#{a_method}")
           expect(cop.offenses).to be_empty
         end
+      end
+
+      it 'accepts #{klass}.zone.now' do
+        inspect_source(cop, "#{klass}.zone.now")
+        expect(cop.offenses).to be_empty
       end
     end
 


### PR DESCRIPTION
In reference to #1863, this includes the `Time.zone.now` method as the first suggested alternative when the enforced style is `:acceptable`