### PR TITLE
[Fix #1899] Mind comments when correcting braced hash

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@
 * `Sample` rewritten to properly handle shuffle randomness source, first/last params and non-literal ranges. ([@chastell][])
 * [#1873](https://github.com/bbatsov/rubocop/issues/1873): Modify `ParallelAssignment` to properly autocorrect when the assignment is protected by a modifier statement. ([@rrosenblum][])
 * Configure `ParallelAssignment` to work with non-standard `IndentationWidths`. ([@rrosenblum][])
+* [#1899](https://github.com/bbatsov/rubocop/issues/1899): Be careful about comments when auto-correcting in `BracesAroundHashParameters`. ([@jonas054][])
 
 ## 0.31.0 (05/05/2015)
 

--- a/spec/rubocop/cop/style/braces_around_hash_parameters_spec.rb
+++ b/spec/rubocop/cop/style/braces_around_hash_parameters_spec.rb
@@ -144,6 +144,20 @@ describe RuboCop::Cop::Style::BracesAroundHashParameters, :config do
       expect(corrected).to eq('get :i, q: { x: 1 }')
     end
 
+    context 'with a comment following the last key-value pair' do
+      it 'corrects and leaves line breaks' do
+        src = ['r = opts.merge({',
+               '  p1: opts[:a],',
+               '  p2: (opts[:b] || opts[:c]) # a comment',
+               '})']
+        corrected = autocorrect_source(cop, src)
+        expect(corrected).to eq(['r = opts.merge(',
+                                 '  p1: opts[:a],',
+                                 '  p2: (opts[:b] || opts[:c]) # a comment',
+                                 ')'].join("\n"))
+      end
+    end
+
     context 'in a method call without parentheses' do
       it 'does not correct a hash parameter with trailing comma' do
         # Because `get :i, x: 1,` is invalid syntax.


### PR DESCRIPTION
Make sure we don't move a closing parenthesis up to a comment line where it would become part of the comment.