### PR TITLE
[Fix #1901] Do not correct comments that are missing a note

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@
 * [#1803](https://github.com/bbatsov/rubocop/issues/1803): Don't warn for `return` from `lambda` block in `NonLocalExitFromIterator`. ([@ypresto][])
 * [#1905](https://github.com/bbatsov/rubocop/issues/1905): Ignore sparse and trailing comments in `Style/Documentation`. ([@RGBD][])
 * [#1923](https://github.com/bbatsov/rubocop/issues/1923): Handle properly `for` without body in `Style/Next`. ([@bbatsov][])
+* [#1901](https://github.com/bbatsov/rubocop/issues/1901): Do not auto correct comments that are missing a note. ([@rrosenblum][])
 
 ## 0.31.0 (05/05/2015)
 


### PR DESCRIPTION
This fixes #1901. I am not sure exactly why this caused an infinite loop, but I was able to find a solution. I decided that the proper fix for `# TODO:` was to remove the colon because to add a space would cause an offense for trailing white space.

I had to make a few changes the way this cop works in order to fix the bug. The cop will now highlight the entire comment that is in error instead of the keyword. It might be possible to fix this issue without this, but this seemed like a more solid solution.