### PR TITLE
Fix capitalization in Overcommit instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -747,7 +747,7 @@ following to your `.overcommit.yml` file:
 
 ```yaml
 PreCommit:
-  Rubocop:
+  RuboCop:
     enabled: true
 ```
 


### PR DESCRIPTION
This section was added by b2176b91, which reflected the correct way to
configure Overcommit to work with RuboCop at the time. However, since
then, Overcommit changed the capitalization of the hook name and
configuration to match the capitalization preferred by the RuboCop
project[0], so we need to update these instructions to match.

[0]: https://github.com/brigade/overcommit/commit/68a000f1