### PR TITLE
Don't invoke UnneededDisable if --only or --except is given

### DIFF
--- a/lib/rubocop/formatter/formatter_set.rb
+++ b/lib/rubocop/formatter/formatter_set.rb
@@ -35,12 +35,15 @@ module RuboCop
         @comments ||= {}
         @comments[file] = options[:comments]
         @excepted_cops = options[:excepted_cops] || []
+        @only_cops = options[:only_cops] || []
         each { |f| f.file_started(file, options) }
       end
 
       def file_finished(file, offenses)
         if @cop_disabled_line_ranges[file].any? &&
-           (@excepted_cops & %w(Lint Lint/UnneededDisable)).empty?
+           # Don't check unneeded disable if --only or --except option is
+           # given, because these options override configuration.
+           @excepted_cops.empty? && @only_cops.empty?
           cop = Cop::Lint::UnneededDisable.new
           cop.check(file, offenses, @cop_disabled_line_ranges, @comments)
           offenses += cop.offenses

--- a/lib/rubocop/runner.rb
+++ b/lib/rubocop/runner.rb
@@ -69,6 +69,7 @@ module RuboCop
       file_info = {
         cop_disabled_line_ranges: processed_source.disabled_line_ranges,
         comments: processed_source.comments,
+        only_cops: @options[:only],
         excepted_cops: @options[:except]
       }
 

--- a/spec/rubocop/cli_spec.rb
+++ b/spec/rubocop/cli_spec.rb
@@ -898,7 +898,10 @@ describe RuboCop::CLI, :isolated_environment do
     describe '--only' do
       context 'when one cop is given' do
         it 'runs just one cop' do
-          create_file('example.rb', ['if x== 0 ',
+          # The disable comment should not be reported as unnecessary (even if
+          # it is) since --only overrides configuration.
+          create_file('example.rb', ['# rubocop:disable LineLength',
+                                     'if x== 0 ',
                                      "\ty",
                                      'end'])
           # IfUnlessModifier depends on the configuration of LineLength.
@@ -908,7 +911,7 @@ describe RuboCop::CLI, :isolated_environment do
                           'example.rb'])).to eq(1)
           expect($stdout.string)
             .to eq(['== example.rb ==',
-                    'C:  1:  1: Favor modifier if usage when ' \
+                    'C:  2:  1: Favor modifier if usage when ' \
                     'having a single-line body. Another good alternative is ' \
                     'the usage of control flow &&/||.',
                     '',
@@ -1116,7 +1119,10 @@ describe RuboCop::CLI, :isolated_environment do
 
       context 'when one cop plus one namespace are given' do
         it 'runs all cops except the given' do
-          create_file('example.rb', ['if x== 0 ',
+          # The disable comment should not be reported as unnecessary (even if
+          # it is) since --except overrides configuration.
+          create_file('example.rb', ['# rubocop:disable LineLength',
+                                     'if x== 0 ',
                                      "\ty = 3",
                                      'end'])
           expect(cli.run(['--format', 'offenses',


### PR DESCRIPTION
The point of `UnneededDisable` is to check whether a `rubocop:disable` comment is unnecessary because the cop is already disabled in configuration. If that configuration is overridden it's too complicated to do the check accurately, so better to just skip it.

Fixes an unreleased feature, so no changelog.