### PR TITLE
[Fix #1928] Auto-correct one offense at a time if there are tabs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 * Show reference links when displaying style guide links. ([@rrosenblum][])
 * `Debugger` cop now checks for the Capybara debug method `save_screenshot`. ([@crazydog115][])
 * [#1282](https://github.com/bbatsov/rubocop/issues/1282): `CaseIndentation` cop does auto-correction. ([@lumeet][])
+* [#1928](https://github.com/bbatsov/rubocop/issues/1928): Do auto-correction one offense at a time (rather than one cop at a time) if there are tabs in the code. ([@jonas054][])
 
 ### Changes
 

--- a/lib/rubocop/cop/team.rb
+++ b/lib/rubocop/cop/team.rb
@@ -79,7 +79,14 @@ module RuboCop
           cop.relevant_file?(buffer.name) && cop.corrections.any?
         end
         if cop_with_corrections
-          corrector = Corrector.new(buffer, cop_with_corrections.corrections)
+          corrections = cop_with_corrections.corrections
+          # Be extra careful if there are tabs in the source and just correct
+          # one offense, because inserting or removing space next to a tab has
+          # special implications, and existing ranges can't be used after such
+          # a change.
+          corrections = [corrections.first] if buffer.source =~ /\t/
+
+          corrector = Corrector.new(buffer, corrections)
           corrector.rewrite
         else
           buffer.source

--- a/spec/rubocop/cli_spec.rb
+++ b/spec/rubocop/cli_spec.rb
@@ -35,6 +35,32 @@ describe RuboCop::CLI, :isolated_environment do
     end
 
     describe '--auto-correct' do
+      it 'corrects Tab and IndentationConsistency offenses' do
+        source = ['  render_views',
+                  "    describe 'GET index' do",
+                  "\t    it 'returns http success' do",
+                  "\t    end",
+                  "\tdescribe 'admin user' do",
+                  '     before(:each) do',
+                  "\t    end",
+                  "\tend",
+                  '    end',
+                  '']
+        create_file('example.rb', source)
+        expect(cli.run(['--auto-correct'])).to eq(0)
+        corrected = ['  render_views',
+                     "  describe 'GET index' do",
+                     "    it 'returns http success' do",
+                     '    end',
+                     "    describe 'admin user' do",
+                     '      before(:each) do',
+                     '      end',
+                     '    end',
+                     '  end',
+                     '']
+        expect(IO.read('example.rb')).to eq(corrected.join("\n"))
+      end
+
       it 'corrects SymbolProc and SpaceBeforeBlockBraces offenses' do
         source = ['foo.map{ |a| a.nil? }']
         create_file('example.rb', source)


### PR DESCRIPTION
Some indentation/alignment cops don't handle tabs well. It would be quite complicated to make them tab-aware, so a better solution is to be more cautious in `autocorrect`.

We recently discussed how we don't want to make generic solutions that hide bugs in cops. I don't think this change falls into that category, though.