### PR TITLE
[Fix #1926] Do not crash when correcting a hash with a splat in it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,7 @@
 * [#1905](https://github.com/bbatsov/rubocop/issues/1905): Ignore sparse and trailing comments in `Style/Documentation`. ([@RGBD][])
 * [#1923](https://github.com/bbatsov/rubocop/issues/1923): Handle properly `for` without body in `Style/Next`. ([@bbatsov][])
 * [#1901](https://github.com/bbatsov/rubocop/issues/1901): Do not auto correct comments that are missing a note. ([@rrosenblum][])
+* [#1926](https://github.com/bbatsov/rubocop/issues/1926): Fix crash in `Style/AlignHash` when correcting a hash with a splat in it. ([@rrosenblum][])
 
 ## 0.31.0 (05/05/2015)
 

--- a/lib/rubocop/cop/style/align_hash.rb
+++ b/lib/rubocop/cop/style/align_hash.rb
@@ -231,9 +231,13 @@ module RuboCop
           key, value = *node
 
           lambda do |corrector|
-            adjust(corrector, key_delta, key.loc.expression)
-            adjust(corrector, separator_delta, node.loc.operator)
-            adjust(corrector, value_delta, value.loc.expression)
+            if value.nil?
+              adjust(corrector, key_delta, node.loc.expression)
+            else
+              adjust(corrector, key_delta, key.loc.expression)
+              adjust(corrector, separator_delta, node.loc.operator)
+              adjust(corrector, value_delta, value.loc.expression)
+            end
           end
         end
 


### PR DESCRIPTION
This fixes #1926.