### PR TITLE
[Fix #1935] Allow Symbol#to_proc blocks in Performance/Size

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,7 @@
 * [#1905](https://github.com/bbatsov/rubocop/issues/1905): Ignore sparse and trailing comments in `Style/Documentation`. ([@RGBD][])
 * [#1923](https://github.com/bbatsov/rubocop/issues/1923): Handle properly `for` without body in `Style/Next`. ([@bbatsov][])
 * [#1901](https://github.com/bbatsov/rubocop/issues/1901): Do not auto correct comments that are missing a note. ([@rrosenblum][])
+* [#1935](https://github.com/bbatsov/rubocop/issues/1935): Allow `Symbol#to_proc` blocks in Performance/Size. ([@m1foley][])
 
 ## 0.31.0 (05/05/2015)
 
@@ -1433,3 +1434,4 @@
 [@crazydog115]: https://github.com/crazydog115
 [@RGBD]: https://github.com/RGBD
 [@panthomakos]: https://github.com/panthomakos
+[@m1foley]: https://github.com/m1foley

--- a/lib/rubocop/cop/performance/size.rb
+++ b/lib/rubocop/cop/performance/size.rb
@@ -27,12 +27,13 @@ module RuboCop
         MSG = 'Use `size` instead of `count`.'
 
         def on_send(node)
-          receiver, method = *node
+          receiver, method, args = *node
 
           return if receiver.nil?
           return unless method == :count
           return unless array?(receiver) || hash?(receiver)
           return if node.parent && node.parent.block_type?
+          return if args && args.block_pass_type?
 
           add_offense(node, node.loc.selector)
         end

--- a/spec/rubocop/cop/performance/size_spec.rb
+++ b/spec/rubocop/cop/performance/size_spec.rb
@@ -56,6 +56,12 @@ describe RuboCop::Cop::Performance::Size do
       expect(cop.messages).to be_empty
     end
 
+    it 'does not register an offense when calling count with a to_proc block' do
+      inspect_source(cop, '[1, 2, 3].count(&:nil?)')
+
+      expect(cop.offenses).to be_empty
+    end
+
     it 'corrects count to size' do
       new_source = autocorrect_source(cop, '[1, 2, 3].count')
 
@@ -110,6 +116,12 @@ describe RuboCop::Cop::Performance::Size do
       inspect_source(cop, '{a: 1, b: 2, c: 3}.count { |e| e > 3 }')
 
       expect(cop.messages).to be_empty
+    end
+
+    it 'does not register an offense when calling count with a to_proc block' do
+      inspect_source(cop, '{a: 1, b: 2, c: 3}.count(&:nil?)')
+
+      expect(cop.offenses).to be_empty
     end
 
     it 'corrects count to size' do


### PR DESCRIPTION
This check should pass when passing a block to `count`, but `Symbol#to_proc` blocks were not being allowed like they should.

Fixes #1935
