### PR TITLE
Change occurrences of find to any?

### DIFF
--- a/lib/rubocop/cop/cop.rb
+++ b/lib/rubocop/cop/cop.rb
@@ -155,7 +155,7 @@ module RuboCop
         location = loc.is_a?(Symbol) ? node.loc.send(loc) : loc
 
         # Don't include the same location twice for one cop.
-        return if @offenses.find { |o| o.location == location }
+        return if @offenses.any? { |o| o.location == location }
 
         severity = custom_severity || severity || default_severity
 

--- a/lib/rubocop/cop/mixin/autocorrect_alignment.rb
+++ b/lib/rubocop/cop/mixin/autocorrect_alignment.rb
@@ -75,7 +75,7 @@ module RuboCop
       end
 
       def block_comment_within?(expr)
-        processed_source.comments.select(&:document?).find do |c|
+        processed_source.comments.select(&:document?).any? do |c|
           within?(c.loc.expression, expr)
         end
       end

--- a/lib/rubocop/cop/mixin/string_help.rb
+++ b/lib/rubocop/cop/mixin/string_help.rb
@@ -31,7 +31,7 @@ module RuboCop
       def inside_interpolation?(node)
         # A :begin node inside a :dstr node is an interpolation.
         begin_found = false
-        node.each_ancestor.find do |a|
+        node.each_ancestor.any? do |a|
           begin_found = true if a.type == :begin
           begin_found && a.type == :dstr
         end

--- a/lib/rubocop/cop/style/braces_around_hash_parameters.rb
+++ b/lib/rubocop/cop/style/braces_around_hash_parameters.rb
@@ -70,7 +70,7 @@ module RuboCop
           comments = processed_source.comments
           right_brace_and_space = range_with_surrounding_space(node.loc.end,
                                                                :left)
-          if comments.find { |c| c.loc.line == right_brace_and_space.line }
+          if comments.any? { |c| c.loc.line == right_brace_and_space.line }
             # Removing a line break between a comment and the closing
             # parenthesis would cause a syntax error, so we only remove the
             # braces in that case.

--- a/lib/rubocop/cop/style/multiline_operation_indentation.rb
+++ b/lib/rubocop/cop/style/multiline_operation_indentation.rb
@@ -175,7 +175,7 @@ module RuboCop
         end
 
         def not_for_this_cop?(node)
-          node.each_ancestor.find do |ancestor|
+          node.each_ancestor.any? do |ancestor|
             grouped_expression?(ancestor) ||
               inside_arg_list_parentheses?(node, ancestor)
           end


### PR DESCRIPTION
I came across some places where `find` could be replaced by `any?`. There seems to be some minor performance gains by using the appropriate method.

```ruby
ARRAY = (1..100).to_a

def slow
  ARRAY.find { |e| e > 50 }
end

def fast
  ARRAY.any? { |e| e > 50 }
end

Benchmark.ips do |x|
  x.report('find') { slow }
  x.report('any?') { fast }
  x.compare!
end
```
```
Calculating -------------------------------------
                find    23.028k i/100ms
                any?    31.036k i/100ms
-------------------------------------------------
                find    273.206k (± 2.6%) i/s -      1.382M
                any?    386.981k (± 2.6%) i/s -      1.955M

Comparison:
                any?:   386980.7 i/s
                find:   273206.5 i/s - 1.42x slower
```