### PR TITLE
Account for multi-line hashes in method calls.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### New features
 
+* Adjust behavior of `TrailingComma` cop to account for multi-line hashes nested within method calls. ([@panthomakos][])
 * New cop `SpaceInsideStringInterpolation` checks for spaces within string interpolations. ([@glasnt][])
 * New cop `NestedMethodDefinition` checks for method definitions inside other methods. ([@ojab][])
 * `LiteralInInterpolation` cop does auto-correction. ([@tmr08c][])
@@ -1431,3 +1432,4 @@
 [@glasnt]: https://github.com/glasnt
 [@crazydog115]: https://github.com/crazydog115
 [@RGBD]: https://github.com/RGBD
+[@panthomakos]: https://github.com/panthomakos

--- a/lib/rubocop/cop/style/trailing_comma.rb
+++ b/lib/rubocop/cop/style/trailing_comma.rb
@@ -119,7 +119,7 @@ module RuboCop
         def multiline?(node)
           elements = if node.type == :send
                        _receiver, _method_name, *args = *node
-                       args
+                       args.flat_map { |a| a.type == :hash ? a.children : a }
                      else
                        node.children
                      end

--- a/spec/rubocop/cop/style/trailing_comma_spec.rb
+++ b/spec/rubocop/cop/style/trailing_comma_spec.rb
@@ -237,6 +237,14 @@ describe RuboCop::Cop::Style::TrailingComma, :config do
           expect(cop.offenses).to be_empty
         end
 
+        it 'accepts a Hash literal with no trailing comma' do
+          inspect_source(cop, ['VALUES = {',
+                               '           a: "b",',
+                               '           c: "d",',
+                               '           e: "f"}'])
+          expect(cop.offenses).to be_empty
+        end
+
         it 'accepts a method call with Hash as last parameter split on ' \
            'multiple lines' do
           inspect_source(cop, ['some_method(a: "b",',
@@ -405,11 +413,31 @@ describe RuboCop::Cop::Style::TrailingComma, :config do
             .to eq(['Put a comma after the last item of a multiline array.'])
         end
 
-        it 'accepts a method call with Hash as last parameter split on ' \
-           'multiple lines' do
+        it 'registers an offense for a Hash literal with no trailing comma' do
+          inspect_source(cop, ['VALUES = {',
+                               '           a: "b",',
+                               '           b: "c",',
+                               '           d: "e"}'])
+          expect(cop.messages)
+            .to eq(['Put a comma after the last item of a multiline hash.'])
+        end
+
+        it 'registers an offense for a method call, with a Hash as the ' \
+           'last parameter, split on multiple lines' do
           inspect_source(cop, ['some_method(a: "b",',
                                '            c: "d")'])
-          expect(cop.offenses).to be_empty
+          expect(cop.messages)
+            .to eq(['Put a comma after the last parameter of a ' \
+                    'multiline method call.'])
+        end
+
+        it 'auto-corrects a missing comma in a Hash literal' do
+          new_source = autocorrect_source(cop, ['MAP = { a: 1001,',
+                                                '        b: 2020,',
+                                                '        c: 3333}'])
+          expect(new_source).to eq(['MAP = { a: 1001,',
+                                    '        b: 2020,',
+                                    '        c: 3333,}'].join("\n"))
         end
       end
 
@@ -485,6 +513,15 @@ describe RuboCop::Cop::Style::TrailingComma, :config do
                              '              b,',
                              '              c: 0,',
                              '              d: 1,',
+                             '           )'])
+        expect(cop.offenses).to be_empty
+      end
+
+      it 'accepts a trailing comma in a method call with ' \
+         'a single hash parameter' do
+        inspect_source(cop, ['some_method(',
+                             '              a: 0,',
+                             '              b: 1,',
                              '           )'])
         expect(cop.offenses).to be_empty
       end


### PR DESCRIPTION
The `TrailingComma` cop treats each method parameter as an individual item when looking for multi-line method calls. If there is only a single item and that item is a hash the cop does not check if that hash spans multiple lines.

This fix ensures that method calls with a single hash parameter can still qualify as spanning multiple lines if the hash itself spans multiple lines.

Here is an example of a method call that would not count as spanning multiple lines before:

```
method(
  a: 'a',
  b: 'b',
)
```

The code change I've included here fixes this by accounting for parameters that are hashes instead of just counting the total number of parameters.