### PR TITLE
Fix bad test in StructInheritance

### DIFF
--- a/lib/rubocop/cop/style/struct_inheritance.rb
+++ b/lib/rubocop/cop/style/struct_inheritance.rb
@@ -25,16 +25,17 @@ module RuboCop
         private
 
         def struct_constructor?(node)
-          if node && node.send_type?
-            receiver, method_name = *node
+          return false unless node
 
-            receiver &&
-              receiver.const_type? &&
-              receiver.children.last == :Struct &&
-              method_name == :new
-          else
-            false
-          end
+          send_node = node.block_type? ? node.children.first : node
+          return false unless send_node.send_type?
+
+          receiver, method_name = *send_node
+
+          receiver &&
+            receiver.const_type? &&
+            receiver.children.last == :Struct &&
+            method_name == :new
         end
       end
     end

--- a/spec/rubocop/cop/style/struct_inheritance_spec.rb
+++ b/spec/rubocop/cop/style/struct_inheritance_spec.rb
@@ -18,7 +18,7 @@ describe RuboCop::Cop::Style::StructInheritance do
                    ['class Person < Struct.new(:first_name, :last_name) do end',
                     'end'
                    ])
-    expect(cop.offenses).to be_empty
+    expect(cop.offenses.size).to eq(1)
   end
 
   it 'accepts plain class' do


### PR DESCRIPTION
The following cases are now handled similarly.

```ruby
class Person < Struct.new(:first_name, :last_name) do end
end

class Person < Struct.new(:first_name, :last_name)
end
```

I think this is what the cop is supposed to do. In other words, the spec description was right but the test itself was incorrect.