### PR TITLE
Change message for ClassLength and ModuleLength

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@
 * Prefer `SpaceInsideBlockBraces` to `SpaceBeforeSemicolon` and `SpaceAfterSemicolon` to avoid an infinite loop when auto-correcting. ([@lumeet][])
 * [#1873](https://github.com/bbatsov/rubocop/issues/1873): Move `ParallelAssignment` cop from Performance to Style. ([@rrosenblum][])
 * Add `getlocal` to acceptable methods of `Rails/TimeZone`. ([@ojab][])
+* [#1851](https://github.com/bbatsov/rubocop/issues/1851), [#1948](https://github.com/bbatsov/rubocop/issues/1948): Change offense message for `ClassLength` and `ModuleLength` to match that of `MethodLength`. ([@bquorning][])
 
 ### Bugs fixed
 

--- a/lib/rubocop/cop/metrics/class_length.rb
+++ b/lib/rubocop/cop/metrics/class_length.rb
@@ -16,7 +16,7 @@ module RuboCop
         private
 
         def message(length, max_length)
-          format('Class definition is too long. [%d/%d]', length, max_length)
+          format('Class has too many lines. [%d/%d]', length, max_length)
         end
       end
     end

--- a/lib/rubocop/cop/metrics/module_length.rb
+++ b/lib/rubocop/cop/metrics/module_length.rb
@@ -16,7 +16,7 @@ module RuboCop
         private
 
         def message(length, max_length)
-          format('Module definition is too long. [%d/%d]', length, max_length)
+          format('Module has too many lines. [%d/%d]', length, max_length)
         end
       end
     end

--- a/spec/rubocop/cop/metrics/class_length_spec.rb
+++ b/spec/rubocop/cop/metrics/class_length_spec.rb
@@ -16,7 +16,7 @@ describe RuboCop::Cop::Metrics::ClassLength, :config do
                          '  a = 6',
                          'end'])
     expect(cop.offenses.size).to eq(1)
-    expect(cop.messages).to eq(['Class definition is too long. [6/5]'])
+    expect(cop.messages).to eq(['Class has too many lines. [6/5]'])
     expect(cop.config_to_allow_offenses).to eq('Max' => 6)
   end
 

--- a/spec/rubocop/cop/metrics/module_length_spec.rb
+++ b/spec/rubocop/cop/metrics/module_length_spec.rb
@@ -16,7 +16,7 @@ describe RuboCop::Cop::Metrics::ModuleLength, :config do
                          '  a = 6',
                          'end'])
     expect(cop.offenses.size).to eq(1)
-    expect(cop.messages).to eq(['Module definition is too long. [6/5]'])
+    expect(cop.messages).to eq(['Module has too many lines. [6/5]'])
     expect(cop.config_to_allow_offenses).to eq('Max' => 6)
   end
 


### PR DESCRIPTION
There was some confusion (#1851, #1948) whether the "Class/Module definition is too long" message was referring to the number of lines in the class/module, or to the number of characters in the class/module name. Using the same [explicit offense message as in `MethodLength`](https://github.com/bbatsov/rubocop/blob/master/lib/rubocop/cop/metrics/method_length.rb#L20) should clear this up.

cc @jonas054 