### PR TITLE
Make the FirstParameterIndentation message more informative.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 * Make it possible to disable `Lint/UnneededDisable`. ([@jonas054][])
 
+### Changes
+
+* [#1708](https://github.com/bbatsov/rubocop/issues/1708): Improve message for `FirstParameterIndentation`. ([@tejasbubane][])
+
 ## 0.32.0 (06/06/2015)
 
 ### New features
@@ -1447,3 +1451,4 @@
 [@panthomakos]: https://github.com/panthomakos
 [@matugm]: https://github.com/matugm
 [@m1foley]: https://github.com/m1foley
+[@tejasbubane]: https://github.com/tejasbubane

--- a/lib/rubocop/cop/style/first_parameter_indentation.rb
+++ b/lib/rubocop/cop/style/first_parameter_indentation.rb
@@ -44,9 +44,9 @@ module RuboCop
           base = if text !~ /\n/ && special_inner_call_indentation?(send_node)
                    "`#{text}`"
                  elsif text.lines.reverse_each.first =~ /^\s*#/
-                   'the previous line (not counting the comment)'
+                   'the start of the previous line (not counting the comment)'
                  else
-                   'the previous line'
+                   'the start of the previous line'
                  end
           format('Indent the first parameter one step more than %s.', base)
         end

--- a/spec/rubocop/cop/style/first_parameter_indentation_spec.rb
+++ b/spec/rubocop/cop/style/first_parameter_indentation_spec.rb
@@ -25,7 +25,8 @@ describe RuboCop::Cop::Style::FirstParameterIndentation, :config do
                              '    bar: 3',
                              ')'])
         expect(cop.messages).to eq(['Indent the first parameter one step ' \
-                                    'more than the previous line.'])
+                                    'more than the start of the ' \
+                                    'previous line.'])
         expect(cop.highlights).to eq([':foo'])
       end
 
@@ -85,7 +86,8 @@ describe RuboCop::Cop::Style::FirstParameterIndentation, :config do
                                '      b: 2',
                                '  )'])
           expect(cop.messages).to eq(['Indent the first parameter one step ' \
-                                      'more than the previous line.'])
+                                      'more than the start of the ' \
+                                      'previous line.'])
           expect(cop.highlights).to eq(['b: 2'])
         end
 
@@ -115,9 +117,9 @@ describe RuboCop::Cop::Style::FirstParameterIndentation, :config do
                                  '  # comment',
                                  '  b: 2',
                                  '  )'])
-            expect(cop.messages).to eq(['Indent the first parameter one ' \
-                                        'step more than the previous line ' \
-                                        '(not counting the comment).'])
+            expect(cop.messages).to eq(['Indent the first parameter one step ' \
+                                        'more than the start of the previous ' \
+                                        'line (not counting the comment).'])
             expect(cop.highlights).to eq(['b: 2'])
           end
         end
@@ -236,7 +238,8 @@ describe RuboCop::Cop::Style::FirstParameterIndentation, :config do
                                '          merge(',
                                '  bar: 3))'])
           expect(cop.messages).to eq(['Indent the first parameter one step ' \
-                                      'more than the previous line.'])
+                                      'more than the start of the ' \
+                                      'previous line.'])
           expect(cop.highlights).to eq(['bar: 3'])
         end
 
@@ -281,7 +284,8 @@ describe RuboCop::Cop::Style::FirstParameterIndentation, :config do
         inspect_source(cop, ['run(:foo, defaults.merge(',
                              '            bar: 3))'])
         expect(cop.messages).to eq(['Indent the first parameter one step ' \
-                                    'more than the previous line.'])
+                                    'more than the start of the ' \
+                                    'previous line.'])
         expect(cop.highlights).to eq(['bar: 3'])
       end
 


### PR DESCRIPTION
Fixes #1708

Mention in the message that the first argument should be aligned one step ahead of the start of the previous line.