### PR TITLE
Fix false positive for Style/TrailingComma cop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 * [#1958](https://github.com/bbatsov/rubocop/issues/1958): Show name of `Lint/UnneededDisable` when `-D/--display-cop-names` is given. ([@jonas054][])
 * Do not show `Style/NonNilCheck` offenses as corrected when the source code is not modified. ([@rrosenblum][])
 * Fix auto-correct in `Style/RedundantReturn` when `return` has no arguments. ([@lumeet][])
+* [#1955](https://github.com/bbatsov/rubocop/issues/1955): Fix false positive for `Style/TrailingComma` cop. ([@mattjmcnaughton][])
 
 ## 0.32.0 (06/06/2015)
 

--- a/lib/rubocop/cop/style/trailing_comma.rb
+++ b/lib/rubocop/cop/style/trailing_comma.rb
@@ -71,6 +71,7 @@ module RuboCop
         # rubocop:disable Metrics/MethodLength
         def check(node, items, kind, begin_pos, end_pos)
           sb = items.first.loc.expression.source_buffer
+
           after_last_item = Parser::Source::Range.new(sb, begin_pos, end_pos)
 
           return if heredoc?(after_last_item.source)
@@ -123,6 +124,12 @@ module RuboCop
                      else
                        node.children
                      end
+
+          # Without this check, Foo.new({}) is considered multiline, which
+          # it should not be. Essentially, if there are no elements, the
+          # expression can not be multiline.
+          return if elements.empty?
+
           items = elements.map { |e| e.loc.expression }
           if style == :consistent_comma
             items.each_cons(2).any? { |a, b| !on_same_line?(a, b) }

--- a/spec/rubocop/cop/style/trailing_comma_spec.rb
+++ b/spec/rubocop/cop/style/trailing_comma_spec.rb
@@ -360,6 +360,15 @@ describe RuboCop::Cop::Style::TrailingComma, :config do
         expect(cop.offenses).to be_empty
       end
 
+      it 'accepts an empty hash being passed as a method argument' do
+        inspect_source(cop, 'Foo.new({})')
+        inspect_source(cop, ['Foo.new({',
+                             '         })'])
+        inspect_source(cop, ['Foo.new([',
+                             '         ])'])
+        expect(cop.offenses).to be_empty
+      end
+
       it 'auto-corrects an Array literal with two of the values on the same' \
          ' line and a trailing comma' do
         new_source = autocorrect_source(cop, ['VALUES = [',


### PR DESCRIPTION
Fixes #1955. 

Adds an extra check to the `multiline?` method of the `trailing_comma.rb` method to ensure expressions like `Foo.new({})` are not considered multiline.