### PR TITLE
[Fix #1958] Show Lint/UnneededDisable for --display-cop-names

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Bugs fixed
 
 * Make it possible to disable `Lint/UnneededDisable`. ([@jonas054][])
+* [#1958](https://github.com/bbatsov/rubocop/issues/1958): Show name of `Lint/UnneededDisable` when `-D/--display-cop-names` is given. ([@jonas054][])
 
 ## 0.32.0 (06/06/2015)
 

--- a/lib/rubocop/runner.rb
+++ b/lib/rubocop/runner.rb
@@ -69,8 +69,7 @@ module RuboCop
       file_info = {
         cop_disabled_line_ranges: processed_source.disabled_line_ranges,
         comments: processed_source.comments,
-        only_cops: @options[:only],
-        excepted_cops: @options[:except],
+        cli_options: @options,
         config_store: @config_store
       }
 

--- a/spec/rubocop/cli_spec.rb
+++ b/spec/rubocop/cli_spec.rb
@@ -1261,15 +1261,15 @@ describe RuboCop::CLI, :isolated_environment do
 
     describe '-D/--display-cop-names' do
       it 'shows cop names' do
-        create_file('example1.rb', "\tputs 0")
+        create_file('example1.rb', "\tputs 0 # rubocop:disable NumericLiterals")
         file = abs('example1.rb')
 
-        expect(cli.run(['--format',
-                        'emacs',
-                        '--display-cop-names',
+        expect(cli.run(['--format', 'emacs', '--display-cop-names',
                         'example1.rb'])).to eq(1)
-        expect($stdout.string.lines.to_a[-1])
+        expect($stdout.string)
           .to eq(["#{file}:1:1: C: Style/Tab: Tab detected.",
+                  "#{file}:1:9: W: Lint/UnneededDisable: Unnecessary " \
+                  'disabling of Style/NumericLiterals.',
                   ''].join("\n"))
       end
     end


### PR DESCRIPTION
Make it behave like other cops by calling the constructor in a more normal way (without arguments should only be used for testing).