### PR TITLE
Do not show NonNilCheck offenses as corrected when they have not been

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@
 * `Debugger` cop now checks for the Capybara debug method `save_screenshot`. ([@crazydog115][])
 * [#1282](https://github.com/bbatsov/rubocop/issues/1282): `CaseIndentation` cop does auto-correction. ([@lumeet][])
 * [#1928](https://github.com/bbatsov/rubocop/issues/1928): Do auto-correction one offense at a time (rather than one cop at a time) if there are tabs in the code. ([@jonas054][])
+* Do not show `Style/NonNilCheck` offenses as corrected when the source code is not modified. ([@rrosenblum][])
 
 ### Changes
 

--- a/lib/rubocop/cop/style/non_nil_check.rb
+++ b/lib/rubocop/cop/style/non_nil_check.rb
@@ -84,15 +84,19 @@ module RuboCop
         end
 
         def autocorrect_comparison(node)
+          expr = node.loc.expression.source
+
+          new_code =
+            if include_semantic_changes?
+              expr.sub(/\s*!=\s*nil/, '')
+            else
+              expr.sub(/^(\S*)\s*!=\s*nil/, '!\1.nil?')
+            end
+
+          return if expr == new_code
+
           lambda do |corrector|
-            expr = node.loc.expression
-            new_code =
-              if include_semantic_changes?
-                expr.source.sub(/\s*!=\s*nil/, '')
-              else
-                expr.source.sub(/^(\S*)\s*!=\s*nil/, '!\1.nil?')
-              end
-            corrector.replace(expr, new_code)
+            corrector.replace(node.loc.expression, new_code)
           end
         end
 

--- a/spec/rubocop/cop/style/non_nil_check_spec.rb
+++ b/spec/rubocop/cop/style/non_nil_check_spec.rb
@@ -79,6 +79,14 @@ describe RuboCop::Cop::Style::NonNilCheck, :config do
       corrected = autocorrect_source(cop, '!nil?')
       expect(corrected).to eq '!nil?'
     end
+
+    it 'does not report corrected when the code was not modified' do
+      source = 'return nil unless (line =~ //) != nil'
+      corrected = autocorrect_source(cop, source)
+
+      expect(corrected).to eq(source)
+      expect(cop.corrections).to be_empty
+    end
   end
 
   context 'when allowing semantic changes' do
@@ -127,6 +135,14 @@ describe RuboCop::Cop::Style::NonNilCheck, :config do
     it 'does not blow up when autocorrecting implicit receiver' do
       corrected = autocorrect_source(cop, '!nil?')
       expect(corrected).to eq 'self'
+    end
+
+    it 'corrects code that would not be modified if ' \
+       'IncludeSemanticChanges were false' do
+      corrected = autocorrect_source(cop,
+                                     'return nil unless (line =~ //) != nil')
+
+      expect(corrected).to eq('return nil unless (line =~ //)')
     end
   end
 end


### PR DESCRIPTION
When running `rubocop -a`, I had some offense from `NonNilCheck` show up as corrected when the source had not been changed. I have modified this cop to run corrections when the source has not been changed. 