### PR TITLE
[Fix #1959] Allow Lint/UnneededDisable to be inline disabled

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@
 ### Changes
 
 * [#1708](https://github.com/bbatsov/rubocop/issues/1708): Improve message for `FirstParameterIndentation`. ([@tejasbubane][])
+* [#1959](https://github.com/bbatsov/rubocop/issues/1959): Allow `Lint/UnneededDisable` to be inline disabled. ([@rrosenblum][])
 
 ## 0.32.0 (06/06/2015)
 

--- a/lib/rubocop/comment_config.rb
+++ b/lib/rubocop/comment_config.rb
@@ -4,6 +4,7 @@ module RuboCop
   # This class parses the special `rubocop:disable` comments in a source
   # and provides a way to check if each cop is enabled at arbitrary line.
   class CommentConfig
+    UNNEEDED_DISABLE = 'Lint/UnneededDisable'
     COMMENT_DIRECTIVE_REGEXP = Regexp.new(
       '\A# rubocop : ((?:dis|en)able)\b ((?:[\w/]+,? )+)'.gsub(' ', '\s*')
     )
@@ -73,7 +74,9 @@ module RuboCop
     end
 
     def all_cop_names
-      @all_cop_names ||= Cop::Cop.all.map(&:cop_name)
+      @all_cop_names ||= Cop::Cop.all.map(&:cop_name).reject do |cop_name|
+        cop_name == UNNEEDED_DISABLE
+      end
     end
 
     def comment_only_line?(line_number)

--- a/lib/rubocop/cop/lint/unneeded_disable.rb
+++ b/lib/rubocop/cop/lint/unneeded_disable.rb
@@ -26,7 +26,9 @@ module RuboCop
               unneeded_cop = find_unneeded(comment, offenses, cop, cop_offenses,
                                            line_range)
 
-              next if ignore_offense?(disabled_ranges, line_range)
+              unless all_disabled?(comment)
+                next if ignore_offense?(disabled_ranges, line_range)
+              end
 
               if unneeded_cop
                 unneeded_cops[comment.loc.expression] ||= Set.new
@@ -41,11 +43,15 @@ module RuboCop
         private
 
         def find_unneeded(comment, offenses, cop, cop_offenses, line_range)
-          if comment.loc.expression.source =~ /rubocop:disable\s+all\b/
+          if all_disabled?(comment)
             'all cops' if offenses.none? { |o| line_range.include?(o.line) }
           elsif cop_offenses.none? { |o| line_range.include?(o.line) }
             cop
           end
+        end
+
+        def all_disabled?(comment)
+          comment.loc.expression.source =~ /rubocop:disable\s+all\b/
         end
 
         def ignore_offense?(disabled_ranges, line_range)

--- a/lib/rubocop/cop/lint/unneeded_disable.rb
+++ b/lib/rubocop/cop/lint/unneeded_disable.rb
@@ -17,6 +17,7 @@ module RuboCop
 
         def check(offenses, cop_disabled_line_ranges, comments)
           unneeded_cops = {}
+          disabled_ranges = cop_disabled_line_ranges[COP_NAME] || [0..0]
 
           cop_disabled_line_ranges.each do |cop, line_ranges|
             cop_offenses = offenses.select { |o| o.cop_name == cop }
@@ -24,6 +25,9 @@ module RuboCop
               comment = comments.find { |c| c.loc.line == line_range.begin }
               unneeded_cop = find_unneeded(comment, offenses, cop, cop_offenses,
                                            line_range)
+
+              next if ignore_offense?(disabled_ranges, line_range)
+
               if unneeded_cop
                 unneeded_cops[comment.loc.expression] ||= Set.new
                 unneeded_cops[comment.loc.expression].add(unneeded_cop)
@@ -31,10 +35,7 @@ module RuboCop
             end
           end
 
-          unneeded_cops.each do |range, cops|
-            add_offense(range, range,
-                        "Unnecessary disabling of #{cops.sort.join(', ')}.")
-          end
+          add_offenses(unneeded_cops)
         end
 
         private
@@ -44,6 +45,19 @@ module RuboCop
             'all cops' if offenses.none? { |o| line_range.include?(o.line) }
           elsif cop_offenses.none? { |o| line_range.include?(o.line) }
             cop
+          end
+        end
+
+        def ignore_offense?(disabled_ranges, line_range)
+          disabled_ranges.any? do |range|
+            range.include?(line_range.min) && range.include?(line_range.max)
+          end
+        end
+
+        def add_offenses(unneeded_cops)
+          unneeded_cops.each do |range, cops|
+            add_offense(range, range,
+                        "Unnecessary disabling of #{cops.sort.join(', ')}.")
           end
         end
       end

--- a/spec/rubocop/comment_config_spec.rb
+++ b/spec/rubocop/comment_config_spec.rb
@@ -88,10 +88,15 @@ describe RuboCop::CommentConfig do
       expect(loop_disabled_lines).not_to include(22)
     end
 
-    it 'supports disabling all cops with keyword all' do
+    it 'supports disabling all cops except Lint/UnneededDisable with ' \
+       'keyword all' do
       expected_part = (9..10).to_a
 
-      RuboCop::Cop::Cop.all.each do |cop|
+      cops = RuboCop::Cop::Cop.all.reject do |klass|
+        klass == RuboCop::Cop::Lint::UnneededDisable
+      end
+
+      cops.each do |cop|
         disabled_lines = disabled_lines_of_cop(cop)
         expect(disabled_lines & expected_part).to eq(expected_part)
       end

--- a/spec/rubocop/cop/lint/unneeded_disable_spec.rb
+++ b/spec/rubocop/cop/lint/unneeded_disable_spec.rb
@@ -61,6 +61,50 @@ describe RuboCop::Cop::Lint::UnneededDisable do
             end
           end
 
+          context 'itself' do
+            let(:source) { '# rubocop:disable Lint/UnneededDisable' }
+            let(:cop_disabled_line_ranges) do
+              { 'Lint/UnneededDisable' => [1..Float::INFINITY] }
+            end
+
+            it 'does not return an offense' do
+              expect(cop.offenses).to be_empty
+            end
+          end
+
+          context 'itself and another cop' do
+            context 'disabled on the same range' do
+              let(:source) do
+                '# rubocop:disable Lint/UnneededDisable, Metrics/ClassLength'
+              end
+
+              let(:cop_disabled_line_ranges) do
+                { 'Lint/UnneededDisable' => [1..Float::INFINITY],
+                  'Metrics/ClassLength' => [1..Float::INFINITY] }
+              end
+
+              it 'does not return an offense' do
+                expect(cop.offenses).to be_empty
+              end
+            end
+          end
+
+          context 'multiple cops' do
+            let(:source) do
+              '# rubocop:disable Metrics/MethodLength, Metrics/ClassLength'
+            end
+            let(:cop_disabled_line_ranges) do
+              { 'Metrics/ClassLength' => [1..Float::INFINITY],
+                'Metrics/MethodLength' => [1..Float::INFINITY] }
+            end
+
+            it 'returns an offenses' do
+              expect(cop.messages)
+                .to eq(['Unnecessary disabling of Metrics/ClassLength, ' \
+                        'Metrics/MethodLength.'])
+            end
+          end
+
           context 'all cops' do
             let(:source) { '# rubocop:disable all' }
             let(:cop_disabled_line_ranges) do

--- a/spec/rubocop/cop/lint/unneeded_disable_spec.rb
+++ b/spec/rubocop/cop/lint/unneeded_disable_spec.rb
@@ -110,7 +110,8 @@ describe RuboCop::Cop::Lint::UnneededDisable do
             let(:cop_disabled_line_ranges) do
               {
                 'Metrics/MethodLength' => [1..Float::INFINITY],
-                'Metrics/ClassLength' => [1..Float::INFINITY]
+                'Metrics/ClassLength' => [1..Float::INFINITY],
+                'Lint/UnneededDisable' => [1..Float::INFINITY]
                 # etc... (no need to include all cops here)
               }
             end


### PR DESCRIPTION
This fixes #1959. I am not sure how I feel about being able to inline disable this cop. Regardless of that, this will make it work.