### PR TITLE
Fix RedundantReturn without arguments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 * Make it possible to disable `Lint/UnneededDisable`. ([@jonas054][])
 * [#1958](https://github.com/bbatsov/rubocop/issues/1958): Show name of `Lint/UnneededDisable` when `-D/--display-cop-names` is given. ([@jonas054][])
 * Do not show `Style/NonNilCheck` offenses as corrected when the source code is not modified. ([@rrosenblum][])
+* Fix auto-correct in `Style/RedundantReturn` when `return` has no arguments. ([@lumeet][])
 
 ## 0.32.0 (06/06/2015)
 

--- a/lib/rubocop/cop/style/redundant_return.rb
+++ b/lib/rubocop/cop/style/redundant_return.rb
@@ -29,6 +29,11 @@ module RuboCop
 
         def autocorrect(node)
           lambda do |corrector|
+            unless arguments?(node.children)
+              corrector.replace(node.loc.expression, 'nil')
+              next
+            end
+
             if node.children.size > 1
               kids = node.children.map { |child| child.loc.expression }
               corrector.insert_before(kids.first, '[')
@@ -37,6 +42,13 @@ module RuboCop
             return_kw = range_with_surrounding_space(node.loc.keyword, :right)
             corrector.remove(return_kw)
           end
+        end
+
+        def arguments?(args)
+          return false if args.empty?
+          return true if args.size > 1
+
+          !args.first.begin_type? || !args.first.children.empty?
         end
 
         def on_method_def(_node, _method_name, _args, body)

--- a/spec/rubocop/cop/style/redundant_return_spec.rb
+++ b/spec/rubocop/cop/style/redundant_return_spec.rb
@@ -72,6 +72,37 @@ describe RuboCop::Cop::Style::RedundantReturn, :config do
     expect(new_source).to eq(result_src)
   end
 
+  context 'when return has no arguments' do
+    shared_examples 'common behavior' do |ret|
+      let(:src) do
+        ['def func',
+         '  one',
+         '  two',
+         "  #{ret}",
+         '  # comment',
+         'end']
+      end
+
+      it "registers an offense for #{ret}" do
+        inspect_source(cop, src)
+        expect(cop.offenses.size).to eq(1)
+      end
+
+      it "auto-corrects by replacing #{ret} with nil" do
+        new_source = autocorrect_source(cop, src)
+        expect(new_source).to eq(['def func',
+                                  '  one',
+                                  '  two',
+                                  '  nil',
+                                  '  # comment',
+                                  'end'].join("\n"))
+      end
+    end
+
+    it_behaves_like 'common behavior', 'return'
+    it_behaves_like 'common behavior', 'return()'
+  end
+
   context 'when multi-value returns are not allowed' do
     it 'reports an offense for def with only a return' do
       src = ['def func',


### PR DESCRIPTION
Correcting a redundant `return` without arguments by removing it,
causes the return value of the method to change. Instead, `return` is
now replaced with `nil`.

As a bonus, comments after the `return` won't get misaligned.

Alternatively, of course, we could just keep the `return` as it is.