### PR TITLE
[Fix #1928] Avoid two changes overwriting in AutocorrectAlignment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 * Do not show `Style/NonNilCheck` offenses as corrected when the source code is not modified. ([@rrosenblum][])
 * Fix auto-correct in `Style/RedundantReturn` when `return` has no arguments. ([@lumeet][])
 * [#1955](https://github.com/bbatsov/rubocop/issues/1955): Fix false positive for `Style/TrailingComma` cop. ([@mattjmcnaughton][])
+* [#1928](https://github.com/bbatsov/rubocop/issues/1928): Avoid auto-correcting two alignment offenses in the same area at the same time. ([@jonas054][])
 
 ## 0.32.0 (06/06/2015)
 

--- a/spec/rubocop/cli_spec.rb
+++ b/spec/rubocop/cli_spec.rb
@@ -61,6 +61,37 @@ describe RuboCop::CLI, :isolated_environment do
         expect(IO.read('example.rb')).to eq(corrected.join("\n"))
       end
 
+      it 'corrects IndentationWidth and IndentationConsistency offenses' do
+        source = ["require 'spec_helper'",
+                  'describe ArticlesController do',
+                  '  render_views',
+                  '    describe "GET \'index\'" do',
+                  '            it "returns http success" do',
+                  '            end',
+                  '        describe "admin user" do',
+                  '             before(:each) do',
+                  '            end',
+                  '        end',
+                  '    end',
+                  'end']
+        create_file('example.rb', source)
+        expect(cli.run(['--auto-correct'])).to eq(0)
+        corrected = ["require 'spec_helper'",
+                     'describe ArticlesController do',
+                     '  render_views',
+                     "  describe \"GET 'index'\" do",
+                     "    it 'returns http success' do",
+                     '    end',
+                     "    describe 'admin user' do",
+                     '      before(:each) do',
+                     '      end',
+                     '    end',
+                     '  end',
+                     'end',
+                     '']
+        expect(IO.read('example.rb')).to eq(corrected.join("\n"))
+      end
+
       it 'corrects SymbolProc and SpaceBeforeBlockBraces offenses' do
         source = ['foo.map{ |a| a.nil? }']
         create_file('example.rb', source)

--- a/spec/rubocop/cop/style/align_array_spec.rb
+++ b/spec/rubocop/cop/style/align_array_spec.rb
@@ -54,7 +54,7 @@ describe RuboCop::Cop::Style::AlignArray do
                               ']'].join("\n"))
   end
 
-  it 'auto-corrects array within array with too much indentation' do
+  it 'does not auto-correct array within array with too much indentation' do
     original_source = ['[:l1,',
                        '  [:l2,',
                        '',
@@ -62,13 +62,13 @@ describe RuboCop::Cop::Style::AlignArray do
                        '     [:l4]]]]']
     new_source = autocorrect_source(cop, original_source)
     expect(new_source).to eq(['[:l1,',
-                              ' [:l2,',
+                              ' [:l2,', # Corrected
                               '',
-                              '  [:l3,',
-                              '   [:l4]]]]'].join("\n"))
+                              '   [:l3,', # Not corrected
+                              '    [:l4]]]]'].join("\n"))
   end
 
-  it 'auto-corrects array within array with too little indentation' do
+  it 'does not auto-correct array within array with too little indentation' do
     original_source = ['[:l1,',
                        '[:l2,',
                        '',
@@ -76,10 +76,10 @@ describe RuboCop::Cop::Style::AlignArray do
                        '   [:l4]]]]']
     new_source = autocorrect_source(cop, original_source)
     expect(new_source).to eq(['[:l1,',
-                              ' [:l2,',
+                              ' [:l2,', # Corrected
                               '',
-                              '  [:l3,',
-                              '   [:l4]]]]'].join("\n"))
+                              '   [:l3,', # Not corrected
+                              '    [:l4]]]]'].join("\n"))
   end
 
   it 'auto-corrects only elements that begin a line' do

--- a/spec/rubocop/cop/style/indentation_consistency_spec.rb
+++ b/spec/rubocop/cop/style/indentation_consistency_spec.rb
@@ -548,5 +548,36 @@ describe RuboCop::Cop::Style::IndentationConsistency, :config do
                       'end'])
       expect(cop.offenses).to be_empty
     end
+
+    it 'does not auto-correct an offense within another offense' do
+      corrected = autocorrect_source(cop,
+                                     ["require 'spec_helper'",
+                                      'describe ArticlesController do',
+                                      '  render_views',
+                                      '    describe "GET \'index\'" do',
+                                      '            it "returns success" do',
+                                      '            end',
+                                      '        describe "admin user" do',
+                                      '             before(:each) do',
+                                      '            end',
+                                      '        end',
+                                      '    end',
+                                      'end'])
+      expect(cop.offenses.map(&:line)).to eq [4, 7] # Two offenses are found.
+
+      # The offense on line 4 is corrected, affecting lines 4 to 11.
+      expect(corrected).to eq ["require 'spec_helper'",
+                               'describe ArticlesController do',
+                               '  render_views',
+                               "  describe \"GET 'index'\" do",
+                               '          it "returns success" do',
+                               '          end',
+                               '      describe "admin user" do',
+                               '           before(:each) do',
+                               '          end',
+                               '      end',
+                               '  end',
+                               'end'].join("\n")
+    end
   end
 end


### PR DESCRIPTION
Just report the inner offense and correct the outer. The next auto-correct iteration will fix the inner offense.