### PR TITLE
don't count disabled offences if fail-level is autocorrect

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 * [#1955](https://github.com/bbatsov/rubocop/issues/1955): Fix false positive for `Style/TrailingComma` cop. ([@mattjmcnaughton][])
 * [#1928](https://github.com/bbatsov/rubocop/issues/1928): Avoid auto-correcting two alignment offenses in the same area at the same time. ([@jonas054][])
 * [#1964](https://github.com/bbatsov/rubocop/issues/1964): Fix `RedundantBegin` auto-correct issue with comments by doing a smaller correction. ([@jonas054][])
+* [#1978](https://github.com/bbatsov/rubocop/pull/1978): Don't count disabled offences if fail-level is autocorrect. ([@sch1zo][])
 
 ## 0.32.0 (06/06/2015)
 

--- a/lib/rubocop/runner.rb
+++ b/lib/rubocop/runner.rb
@@ -196,9 +196,9 @@ module RuboCop
 
     def considered_failure?(offense)
       # For :autocorrect level, any offense - corrected or not - is a failure.
-      return true if @options[:fail_level] == :autocorrect
-
       return false if offense.disabled?
+
+      return true if @options[:fail_level] == :autocorrect
 
       !offense.corrected? && offense.severity >= minimum_severity_to_fail
     end

--- a/spec/rubocop/cli_spec.rb
+++ b/spec/rubocop/cli_spec.rb
@@ -1836,6 +1836,25 @@ describe RuboCop::CLI, :isolated_environment do
       end
     end
 
+    describe 'with --auto-correct and disabled offense' do
+      let(:target_file) { 'example.rb' }
+      after do
+        expect($stdout.string.lines.to_a.last)
+          .to eq('1 file inspected, no offenses detected' \
+                 "\n")
+      end
+      it 'succeeds when there is only a disabled offence' do
+        create_file(target_file, ['# encoding: utf-8',
+                                  'def f',
+                                  ' x # rubocop:disable Style/IndentationWidth',
+                                  'end'])
+
+        expect(cli.run(['--auto-correct', '--format', 'simple',
+                        '--fail-level', 'autocorrect',
+                        target_file])).to eq(0)
+      end
+    end
+
     describe '--force-exclusion' do
       let(:target_file) { 'example.rb' }
 


### PR DESCRIPTION
Stumbled across this case because we always use fail-level autocorrect and noticed that the wrong error-code is returned for files with disabled offences. This minor change should fix that.

there is probably a better place to put that spec but I have no idea how that >3000 lines spec file is structured (maybe it would be a good idea to somehow split that file for easier navigation)