### PR TITLE
Add Exclude items to the DisabledConfigFormatter output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## master (unreleased)
 
+### New features
+
+* [#1980](https://github.com/bbatsov/rubocop/pull/1980): `--auto-gen-config` now outputs an excluded files list for failed cops (up to a maxiumum of 15 files). ([@bmorrall][])
+
 ### Bugs fixed
 
 * [#1988](https://github.com/bbatsov/rubocop/issues/1988): Fix bug in `Style/ParallelAssignment` when assigning from `Module::CONSTANT`. ([@rrosenblum][])
@@ -1471,3 +1475,4 @@
 [@matugm]: https://github.com/matugm
 [@m1foley]: https://github.com/m1foley
 [@tejasbubane]: https://github.com/tejasbubane
+[@bmorrall]: https://github.com/bmorrall

--- a/spec/rubocop/cli_spec.rb
+++ b/spec/rubocop/cli_spec.rb
@@ -813,12 +813,14 @@ describe RuboCop::CLI, :isolated_environment do
                   '# Cop supports --auto-correct.',
                   '# Configuration parameters: MultiSpaceAllowedForOperators.',
                   'Style/SpaceAroundOperators:',
-                  '  Enabled: false',
+                  '  Exclude:',
+                  "    - 'example1.rb'",
                   '',
                   '# Offense count: 2',
                   '# Cop supports --auto-correct.',
                   'Style/TrailingWhitespace:',
-                  '  Enabled: false'])
+                  '  Exclude:',
+                  "    - 'example1.rb'"])
 
         # Create new CLI instance to avoid using cached configuration.
         new_cli = described_class.new
@@ -849,7 +851,8 @@ describe RuboCop::CLI, :isolated_environment do
                   '# Offense count: 1',
                   '# Cop supports --auto-correct.',
                   'Style/TrailingWhitespace:',
-                  '  Enabled: false',
+                  '  Exclude:',
+                  "    - 'example1.rb'",
                   ''].join("\n"))
       end
 
@@ -903,34 +906,40 @@ describe RuboCop::CLI, :isolated_environment do
            '# Offense count: 1',
            '# Cop supports --auto-correct.',
            'Style/CommentIndentation:',
-           '  Enabled: false',
+           '  Exclude:',
+           "    - 'example2.rb'",
            '',
            '# Offense count: 1',
            '# Configuration parameters: AllowedVariables.',
            'Style/GlobalVars:',
-           '  Enabled: false',
+           '  Exclude:',
+           "    - 'example1.rb'",
            '',
            '# Offense count: 1',
            '# Cop supports --auto-correct.',
            '# Configuration parameters: EnforcedStyle, SupportedStyles.',
            'Style/IndentationConsistency:',
-           '  Enabled: false',
+           '  Exclude:',
+           "    - 'example2.rb'",
            '',
            '# Offense count: 1',
            '# Cop supports --auto-correct.',
            '# Configuration parameters: MultiSpaceAllowedForOperators.',
            'Style/SpaceAroundOperators:',
-           '  Enabled: false',
+           '  Exclude:',
+           "    - 'example1.rb'",
            '',
            '# Offense count: 1',
            '# Cop supports --auto-correct.',
            'Style/Tab:',
-           '  Enabled: false',
+           '  Exclude:',
+           "    - 'example2.rb'",
            '',
            '# Offense count: 2',
            '# Cop supports --auto-correct.',
            'Style/TrailingWhitespace:',
-           '  Enabled: false']
+           '  Exclude:',
+           "    - 'example1.rb'"]
         actual = IO.read('.rubocop_todo.yml').split($RS)
         expected.each_with_index do |line, ix|
           if line.is_a?(String)
@@ -962,18 +971,21 @@ describe RuboCop::CLI, :isolated_environment do
            '# Offense count: 1',
            '# Cop supports --auto-correct.',
            'Style/CommentIndentation:',
-           '  Enabled: false',
+           '  Exclude:',
+           "    - 'example2.rb'",
            '',
            '# Offense count: 1',
            '# Cop supports --auto-correct.',
            '# Configuration parameters: EnforcedStyle, SupportedStyles.',
            'Style/IndentationConsistency:',
-           '  Enabled: false',
+           '  Exclude:',
+           "    - 'example2.rb'",
            '',
            '# Offense count: 1',
            '# Cop supports --auto-correct.',
            'Style/Tab:',
-           '  Enabled: false']
+           '  Exclude:',
+           "    - 'example2.rb'"]
         actual = IO.read('.rubocop_todo.yml').split($RS)
         expect(actual.length).to eq(expected.length)
         expected.each_with_index do |line, ix|
@@ -1006,7 +1018,8 @@ describe RuboCop::CLI, :isolated_environment do
            '# Configuration parameters: EnforcedStyle, SupportedStyles, ' \
            'AllowInnerSlashes.',
            'Style/RegexpLiteral:',
-           '  Enabled: false']
+           '  Exclude:',
+           "    - 'example.rb'"]
         actual = IO.read('.rubocop_todo.yml').split($RS)
         expected.each_with_index do |line, ix|
           if line.is_a?(String)


### PR DESCRIPTION
I was testing some legacy code by using `--auto-gen-config`, and found it frustrating that trivial Cops had been disabled due to trival issues in one or two files.

I didn't want to disable Whitespace Formatting, or other Style rules in any new code; so I thought I'd play around with the generator to Exclude relative file paths.

An example of what I managed to make it output, is as follows:

```
# Offense count: 1
# Cop supports --auto-correct.
Style/Tab:
  Exclude:
    - 'example2.rb'
```

This way, its easier to globally disable Cops in my `.rubocop.yml`, and have a checklist of files to fix in my `.rubocop_todos.yml`, instead of globally disabling rules the rest of my code abides by.

What do you think?