### PR TITLE
[Fix #1708] Improve message for FirstParameterIndentation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,10 @@
 * [#1964](https://github.com/bbatsov/rubocop/issues/1964): Fix `RedundantBegin` auto-correct issue with comments by doing a smaller correction. ([@jonas054][])
 * [#1978](https://github.com/bbatsov/rubocop/pull/1978): Don't count disabled offences if fail-level is autocorrect. ([@sch1zo][])
 
+### Changes
+
+* [#1708](https://github.com/bbatsov/rubocop/issues/1708): Improve message for `FirstParameterIndentation`. ([@tejasbubane][])
+
 ## 0.32.0 (06/06/2015)
 
 ### New features
@@ -1458,3 +1462,4 @@
 [@panthomakos]: https://github.com/panthomakos
 [@matugm]: https://github.com/matugm
 [@m1foley]: https://github.com/m1foley
+[@tejasbubane]: https://github.com/tejasbubane

--- a/lib/rubocop/cop/style/first_parameter_indentation.rb
+++ b/lib/rubocop/cop/style/first_parameter_indentation.rb
@@ -44,9 +44,9 @@ module RuboCop
           base = if text !~ /\n/ && special_inner_call_indentation?(send_node)
                    "`#{text}`"
                  elsif text.lines.reverse_each.first =~ /^\s*#/
-                   'the previous line (not counting the comment)'
+                   'the start of the previous line (not counting the comment)'
                  else
-                   'the previous line'
+                   'the start of the previous line'
                  end
           format('Indent the first parameter one step more than %s.', base)
         end

--- a/spec/rubocop/cop/style/first_parameter_indentation_spec.rb
+++ b/spec/rubocop/cop/style/first_parameter_indentation_spec.rb
@@ -25,7 +25,8 @@ describe RuboCop::Cop::Style::FirstParameterIndentation, :config do
                              '    bar: 3',
                              ')'])
         expect(cop.messages).to eq(['Indent the first parameter one step ' \
-                                    'more than the previous line.'])
+                                    'more than the start of the ' \
+                                    'previous line.'])
         expect(cop.highlights).to eq([':foo'])
       end
 
@@ -85,7 +86,8 @@ describe RuboCop::Cop::Style::FirstParameterIndentation, :config do
                                '      b: 2',
                                '  )'])
           expect(cop.messages).to eq(['Indent the first parameter one step ' \
-                                      'more than the previous line.'])
+                                      'more than the start of the ' \
+                                      'previous line.'])
           expect(cop.highlights).to eq(['b: 2'])
         end
 
@@ -115,9 +117,9 @@ describe RuboCop::Cop::Style::FirstParameterIndentation, :config do
                                  '  # comment',
                                  '  b: 2',
                                  '  )'])
-            expect(cop.messages).to eq(['Indent the first parameter one ' \
-                                        'step more than the previous line ' \
-                                        '(not counting the comment).'])
+            expect(cop.messages).to eq(['Indent the first parameter one step ' \
+                                        'more than the start of the previous ' \
+                                        'line (not counting the comment).'])
             expect(cop.highlights).to eq(['b: 2'])
           end
         end
@@ -236,7 +238,8 @@ describe RuboCop::Cop::Style::FirstParameterIndentation, :config do
                                '          merge(',
                                '  bar: 3))'])
           expect(cop.messages).to eq(['Indent the first parameter one step ' \
-                                      'more than the previous line.'])
+                                      'more than the start of the ' \
+                                      'previous line.'])
           expect(cop.highlights).to eq(['bar: 3'])
         end
 
@@ -281,7 +284,8 @@ describe RuboCop::Cop::Style::FirstParameterIndentation, :config do
         inspect_source(cop, ['run(:foo, defaults.merge(',
                              '            bar: 3))'])
         expect(cop.messages).to eq(['Indent the first parameter one step ' \
-                                    'more than the previous line.'])
+                                    'more than the start of the ' \
+                                    'previous line.'])
         expect(cop.highlights).to eq(['bar: 3'])
       end
 


### PR DESCRIPTION
Fix the commit message from #1951 as mentioned in https://github.com/bbatsov/rubocop/pull/1951#issuecomment-109801630

Tejas Bubane is described as the author, while I'm described as the committer.