### PR TITLE
String replacement

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 * [#1980](https://github.com/bbatsov/rubocop/pull/1980): `--auto-gen-config` now outputs an excluded files list for failed cops (up to a maxiumum of 15 files). ([@bmorrall][])
 * [#1918](https://github.com/bbatsov/rubocop/issues/1918): New configuration parameter `AllCops:DisabledByDefault` when set to `true` makes only cops found in user configuration enabled, which makes cop selection *opt-in*. ([@jonas054][])
+* New cop `Performance/StringReplacement` checks for usages of `gsub` that can be replaced with `tr` or `delete`. ([@rrosenblum][])
 
 ### Bugs fixed
 

--- a/config/enabled.yml
+++ b/config/enabled.yml
@@ -1065,6 +1065,14 @@ Performance/Size:
   Reference: 'https://github.com/JuanitoFatas/fast-ruby#arraycount-vs-arraysize-code'
   Enabled: true
 
+Performance/StringReplacement:
+  Description: >-
+                  Use `tr` instead of `gsub` when you are replacing the same
+                  number of characters. Use `delete` instead of `gsub` when
+                  you are deleting characters.
+  Reference: 'https://github.com/JuanitoFatas/fast-ruby#stringgsub-vs-stringtr-code'
+  Enabled: true
+
 ##################### Rails ##################################
 
 Rails/ActionFilter:

--- a/lib/rubocop.rb
+++ b/lib/rubocop.rb
@@ -127,6 +127,7 @@ require 'rubocop/cop/performance/flat_map'
 require 'rubocop/cop/performance/reverse_each'
 require 'rubocop/cop/performance/sample'
 require 'rubocop/cop/performance/size'
+require 'rubocop/cop/performance/string_replacement'
 
 require 'rubocop/cop/style/access_modifier_indentation'
 require 'rubocop/cop/style/accessor_method_name'

--- a/lib/rubocop/cop/performance/string_replacement.rb
+++ b/lib/rubocop/cop/performance/string_replacement.rb
@@ -1,0 +1,162 @@
+# encoding: utf-8
+
+module RuboCop
+  module Cop
+    module Performance
+      # This cop identifies places where `gsub` can be replaced by
+      # `tr` or `delete`.
+      #
+      # @example
+      #   @bad
+      #   'abc'.gsub('b', 'd')
+      #   'abc'.gsub('a', '')
+      #   'abc'.gsub(/a/, 'd')
+      #   'abc'.gsub!('a', 'd')
+      #
+      #   @good
+      #   'abc'.gsub(/.*/, 'a')
+      #   'abc'.gsub(/a+/, 'd')
+      #   'abc'.tr('b', 'd')
+      #   'a b c'.delete(' ')
+      class StringReplacement < Cop
+        MSG = 'Use `%s` instead of `%s`.'
+        DETERMINISTIC_REGEX = /^[\w\s\-,."']+$/
+        REGEXP_CONSTRUCTOR_METHODS = [:new, :compile]
+        GSUB_METHODS = [:gsub, :gsub!]
+        DETERMINISTIC_TYPES = [:regexp, :str, :send]
+
+        def on_send(node)
+          _string, method, first_param, second_param = *node
+          return unless GSUB_METHODS.include?(method)
+          return unless second_param && second_param.str_type?
+          return unless DETERMINISTIC_TYPES.include?(first_param.type)
+
+          first_source = first_source(first_param)
+          second_source, = *second_param
+
+          return if first_source.nil?
+
+          if regex?(first_param)
+            return unless first_source =~ DETERMINISTIC_REGEX
+          end
+
+          if first_source.length != second_source.length
+            return unless second_source.empty?
+          end
+
+          message = message(method, first_source, second_source)
+          add_offense(node, range(node), message)
+        end
+
+        def autocorrect(node)
+          _string, method, first_param, second_param = *node
+          first_source = first_source(first_param)
+          second_source, = *second_param
+          replacement_method = replacement_method(first_source, second_source)
+
+          lambda do |corrector|
+            replacement =
+              if second_source.empty? && first_source.length == 1
+                "#{replacement_method}#{'!' if bang_method?(method)}" \
+                "(#{escape(first_source)})"
+              else
+                "#{replacement_method}#{'!' if bang_method?(method)}" \
+                "(#{escape(first_source)}, #{escape(second_source)})"
+              end
+
+            corrector.replace(range(node), replacement)
+          end
+        end
+
+        private
+
+        def first_source(first_param)
+          case first_param.type
+          when :regexp, :send
+            return nil unless regex?(first_param)
+
+            source, = extract_source(first_param)
+          when :str
+            source, = *first_param
+          end
+
+          source
+        end
+
+        def extract_source(node)
+          case node.type
+          when :regexp
+            source_from_regex_literal(node)
+          when :send
+            source_from_regex_constructor(node)
+          end
+        end
+
+        def source_from_regex_literal(node)
+          regex, = *node
+          source, = *regex
+          source
+        end
+
+        def source_from_regex_constructor(node)
+          _const, _init, regex = *node
+          case regex.type
+          when :regexp
+            source_from_regex_literal(regex)
+          when :str
+            source, = *regex
+            source
+          end
+        end
+
+        def regex?(node)
+          return true if node.regexp_type?
+
+          const, init, = *node
+          _, klass = *const
+
+          klass == :Regexp && REGEXP_CONSTRUCTOR_METHODS.include?(init)
+        end
+
+        def range(node)
+          Parser::Source::Range.new(node.loc.expression.source_buffer,
+                                    node.loc.selector.begin_pos,
+                                    node.loc.expression.end_pos)
+        end
+
+        def replacement_method(first_source, second_source)
+          if second_source.empty? && first_source.length == 1
+            'delete'
+          else
+            'tr'
+          end
+        end
+
+        def message(method, first_source, second_source)
+          replacement_method = replacement_method(first_source, second_source)
+
+          format(MSG,
+                 "#{replacement_method}#{'!' if bang_method?(method)}",
+                 method)
+        end
+
+        def bang_method?(method)
+          method.to_s.end_with?('!')
+        end
+
+        def escape(string)
+          if require_double_quotes?(string)
+            string.inspect
+          else
+            "'#{string}'"
+          end
+        end
+
+        def require_double_quotes?(string)
+          /'/ =~ string.inspect ||
+            StringHelp::ESCAPED_CHAR_REGEXP =~ string.inspect
+        end
+      end
+    end
+  end
+end

--- a/lib/rubocop/cop/style/symbol_literal.rb
+++ b/lib/rubocop/cop/style/symbol_literal.rb
@@ -27,7 +27,7 @@ module RuboCop
           lambda do |corrector|
             current_name = node.loc.expression.source
             corrector.replace(node.loc.expression,
-                              current_name.gsub(/["']/, ''))
+                              current_name.delete(%q('")))
           end
         end
       end

--- a/lib/rubocop/options.rb
+++ b/lib/rubocop/options.rb
@@ -197,7 +197,7 @@ module RuboCop
     # e.g. [..., '--auto-correct', ...] to :auto_correct.
     def long_opt_symbol(args)
       long_opt = args.find { |arg| arg.start_with?('--') }
-      long_opt[2..-1].sub(/ .*/, '').gsub(/-/, '_').to_sym
+      long_opt[2..-1].sub(/ .*/, '').tr('-', '_').to_sym
     end
 
     def validate_auto_gen_config_option(args)

--- a/spec/rubocop/cop/performance/string_replacement_spec.rb
+++ b/spec/rubocop/cop/performance/string_replacement_spec.rb
@@ -1,0 +1,456 @@
+# encoding: utf-8
+
+require 'spec_helper'
+
+describe RuboCop::Cop::Performance::StringReplacement do
+  subject(:cop) { described_class.new }
+
+  it 'accepts methods other than gsub' do
+    inspect_source(cop, "'abc'.insert(2, 'a')")
+
+    expect(cop.messages).to be_empty
+  end
+
+  shared_examples 'accepts' do |method|
+    context 'non deterministic parameters' do
+      it 'accepts the first param being a variable' do
+        inspect_source(cop, ['regex = /abc/',
+                             "'abc'.#{method}(regex, '1')"])
+
+        expect(cop.messages).to be_empty
+      end
+
+      it 'accepts the second param being a variable' do
+        inspect_source(cop, ["replacement = 'efg'",
+                             "'abc'.#{method}('abc', replacement)"])
+
+        expect(cop.messages).to be_empty
+      end
+
+      it 'accepts the both params being a variables' do
+        inspect_source(cop, ['regex = /abc/',
+                             "replacement = 'efg'",
+                             "'abc'.#{method}(regex, replacement)"])
+
+        expect(cop.messages).to be_empty
+      end
+
+      it 'accepts gsub with only one param' do
+        inspect_source(cop, "'abc'.#{method}('ab')")
+
+        expect(cop.messages).to be_empty
+      end
+
+      it 'accepts gsub with a block' do
+        inspect_source(cop, "'abc'.#{method}('ab') { |s| s.upcase } ")
+
+        expect(cop.messages).to be_empty
+      end
+
+      it 'accepts a pattern with string interpolation' do
+        inspect_source(cop, ["foo = 'a'",
+                             "'abc'.#{method}(\"\#{foo}\", '1')"])
+
+        expect(cop.messages).to be_empty
+      end
+
+      it 'accepts a replacement with string interpolation' do
+        inspect_source(cop, ["foo = '1'",
+                             "'abc'.#{method}('a', \"\#{foo}\")"])
+
+        expect(cop.messages).to be_empty
+      end
+
+      it 'allows empty regex literal pattern' do
+        inspect_source(cop, "'abc'.gsub(//, '1')")
+
+        expect(cop.messages).to be_empty
+      end
+
+      it 'allows empty regex pattern from string' do
+        inspect_source(cop, "'abc'.gsub(Regexp.new(''), '1')")
+
+        expect(cop.messages).to be_empty
+      end
+
+      it 'allows empty regex pattern from regex' do
+        inspect_source(cop, "'abc'.gsub(Regexp.new(//), '1')")
+
+        expect(cop.messages).to be_empty
+      end
+
+      it 'allows empty string pattern' do
+        inspect_source(cop, "'abc'.gsub('', '1')")
+
+        expect(cop.messages).to be_empty
+      end
+    end
+
+    it 'accepts calls to gsub when the length of the pattern is shorter than ' \
+       'the length of the replacement' do
+      inspect_source(cop, "'abc'.#{method}('a', 'ab')")
+
+      expect(cop.messages).to be_empty
+    end
+
+    it 'accepts calls to gsub when the length of the pattern is longer than ' \
+       'the length of the replacement' do
+      inspect_source(cop, "'abc'.#{method}('ab', 'd')")
+
+      expect(cop.messages).to be_empty
+    end
+  end
+
+  it_behaves_like('accepts', 'gsub')
+  it_behaves_like('accepts', 'gsub!')
+
+  describe 'deterministic regex' do
+    describe 'regex literal' do
+      it 'registers an offense when only using word characters' do
+        inspect_source(cop, "'abc'.gsub(/abc/, '123')")
+
+        expect(cop.messages).to eq(['Use `tr` instead of `gsub`.'])
+      end
+
+      it 'registers an offense when using single quote' do
+        inspect_source(cop, "'abc'.gsub(/'/, '')")
+
+        expect(cop.messages).to eq(['Use `delete` instead of `gsub`.'])
+      end
+
+      it 'registers an offense when using double quote' do
+        inspect_source(cop, %('abc'.gsub(/"/, '')))
+
+        expect(cop.messages).to eq(['Use `delete` instead of `gsub`.'])
+      end
+
+      it 'registers an offense when using space' do
+        inspect_source(cop, %('abc'.gsub(/ /, '')))
+
+        expect(cop.messages).to eq(['Use `delete` instead of `gsub`.'])
+      end
+
+      it 'registers an offense when using comma' do
+        inspect_source(cop, %('abc'.gsub(/,/, '')))
+
+        expect(cop.messages).to eq(['Use `delete` instead of `gsub`.'])
+      end
+
+      it 'registers an offense when using underscore' do
+        inspect_source(cop, %('abc'.gsub(/_/, '')))
+
+        expect(cop.messages).to eq(['Use `delete` instead of `gsub`.'])
+      end
+
+      it 'registers an offense when using dash' do
+        inspect_source(cop, %('abc'.gsub(/-/, '')))
+
+        expect(cop.messages).to eq(['Use `delete` instead of `gsub`.'])
+      end
+
+      it 'registers an offense when using numbers' do
+        inspect_source(cop, %('123'.gsub(/123/, 'abc')))
+
+        expect(cop.messages).to eq(['Use `tr` instead of `gsub`.'])
+      end
+
+      it 'allows deterministic regex when the length of the pattern ' \
+         'and the length of the replacement do not match' do
+        inspect_source(cop, %('abc'.gsub(/ab/, 'def')))
+
+        expect(cop.messages).to be_empty
+      end
+
+      it 'regeisters an offense when escape characters in regex' do
+        inspect_source(cop, %('abc'.gsub(/\n/, ',')))
+
+        expect(cop.messages).to eq(['Use `tr` instead of `gsub`.'])
+      end
+
+      it 'registers an offense when using %r notation' do
+        inspect_source(cop, %('/abc'.gsub(%r{abc}, 'def')))
+
+        expect(cop.messages).to eq(['Use `tr` instead of `gsub`.'])
+      end
+    end
+
+    describe 'regex constructor' do
+      it 'registers an offense when only using word characters' do
+        inspect_source(cop, "'abc'.gsub(Regexp.new('abc'), '123')")
+
+        expect(cop.messages).to eq(['Use `tr` instead of `gsub`.'])
+      end
+
+      it 'registers an offense when regex is built from regex' do
+        inspect_source(cop, "'abc'.gsub(Regexp.new(/abc/), '123')")
+
+        expect(cop.messages).to eq(['Use `tr` instead of `gsub`.'])
+      end
+
+      it 'registers an offense when using compile' do
+        inspect_source(cop, "'123'.gsub(Regexp.compile('12'), 'ab')")
+
+        expect(cop.messages).to eq(['Use `tr` instead of `gsub`.'])
+      end
+    end
+  end
+
+  describe 'non deterministic regex' do
+    it 'allows regex containing a +' do
+      inspect_source(cop, %('abc'.gsub(/a+/, 'def')))
+
+      expect(cop.messages).to be_empty
+    end
+
+    it 'allows regex containing a *' do
+      inspect_source(cop, %('abc'.gsub(/a*/, 'def')))
+
+      expect(cop.messages).to be_empty
+    end
+
+    it 'allows regex containing a ^' do
+      inspect_source(cop, %('abc'.gsub(/^/, '')))
+
+      expect(cop.messages).to be_empty
+    end
+
+    it 'allows regex containing a $' do
+      inspect_source(cop, %('abc'.gsub(/$/, '')))
+
+      expect(cop.messages).to be_empty
+    end
+
+    it 'allows regex containing a ?' do
+      inspect_source(cop, %('abc'.gsub(/a?/, 'def')))
+
+      expect(cop.messages).to be_empty
+    end
+
+    it 'allows regex containing a |' do
+      inspect_source(cop, %('abc'.gsub(/a|b/, 'd')))
+
+      expect(cop.messages).to be_empty
+    end
+
+    it 'allows regex containing ()' do
+      inspect_source(cop, %('abc'.gsub(/(ab)/, 'd')))
+
+      expect(cop.messages).to be_empty
+    end
+
+    it 'allows regex containing escaped ()' do
+      inspect_source(cop, %('(abc)'.gsub(/\(ab\)/, 'd')))
+
+      expect(cop.messages).to be_empty
+    end
+
+    it 'allows regex containing {}' do
+      inspect_source(cop, %('abc'.gsub(/a{3,}/, 'd')))
+
+      expect(cop.messages).to be_empty
+    end
+
+    it 'allows regex containing []' do
+      inspect_source(cop, %('abc'.gsub(/[a-z]/, 'd')))
+
+      expect(cop.messages).to be_empty
+    end
+
+    it 'allows regex containing a backslash' do
+      inspect_source(cop, '"abc".gsub(/\s/, "d")')
+
+      expect(cop.messages).to be_empty
+    end
+
+    it 'allows regex literal containing interpolations' do
+      inspect_source(cop, ["foo = 'a'",
+                           '"abc".gsub(/#{foo}/, "d")'])
+
+      expect(cop.messages).to be_empty
+    end
+
+    it 'allows regex constructor containing a string with interpolations' do
+      inspect_source(cop, ["foo = 'a'",
+                           '"abc".gsub(Regexp.new("#{foo}"), "d")'])
+
+      expect(cop.messages).to be_empty
+    end
+
+    it 'allows regex constructor containing regex with interpolations' do
+      inspect_source(cop, ["foo = 'a'",
+                           '"abc".gsub(Regexp.new(/#{foo}/), "d")'])
+
+      expect(cop.messages).to be_empty
+    end
+  end
+
+  it 'registers an offense when the pattern has non deterministic regex ' \
+     'as a string' do
+    inspect_source(cop, %('a + c'.gsub('+', '-')))
+
+    expect(cop.messages).to eq(['Use `tr` instead of `gsub`.'])
+  end
+
+  it 'registers an offense when using gsub to find and replace ' \
+     'a single character ' do
+    inspect_source(cop, "'abc'.gsub('a', '1')")
+
+    expect(cop.messages).to eq(['Use `tr` instead of `gsub`.'])
+    expect(cop.highlights).to eq(["gsub('a', '1')"])
+  end
+
+  it 'registers an offense when using gsub! to find and replace ' \
+     'a single character ' do
+    inspect_source(cop, "'abc'.gsub!('a', '1')")
+
+    expect(cop.messages).to eq(['Use `tr!` instead of `gsub!`.'])
+    expect(cop.highlights).to eq(["gsub!('a', '1')"])
+  end
+
+  it 'registers an offense for gsub when the length of the pattern matches ' \
+     'the length of the replacement' do
+    inspect_source(cop, "'abc'.gsub('ab', 'de')")
+
+    expect(cop.messages).to eq(['Use `tr` instead of `gsub`.'])
+    expect(cop.highlights).to eq(["gsub('ab', 'de')"])
+  end
+
+  it 'registers an offense for gsub! when the length of the pattern matches ' \
+     'the length of the replacement' do
+    inspect_source(cop, "'abc'.gsub!('ab', 'de')")
+
+    expect(cop.messages).to eq(['Use `tr!` instead of `gsub!`.'])
+    expect(cop.highlights).to eq(["gsub!('ab', 'de')"])
+  end
+
+  it 'registers an offense for gsub! when deleting one characters' do
+    inspect_source(cop, "'abc'.gsub!('a', '')")
+
+    expect(cop.messages).to eq(['Use `delete!` instead of `gsub!`.'])
+    expect(cop.highlights).to eq(["gsub!('a', '')"])
+  end
+
+  it 'registers an offense for gsub! when deleting multiple characters' do
+    inspect_source(cop, "'abc'.gsub!('ab', '')")
+
+    expect(cop.messages).to eq(['Use `tr!` instead of `gsub!`.'])
+    expect(cop.highlights).to eq(["gsub!('ab', '')"])
+  end
+
+  it 'registers an offense when using escape characters in the replacement' do
+    inspect_source(cop, "'abc'.gsub('a', '\n')")
+
+    expect(cop.messages).to eq(['Use `tr` instead of `gsub`.'])
+  end
+
+  it 'regeisters an offense when using escape characters in the pattern' do
+    inspect_source(cop, "'abc'.gsub('\n', ',')")
+
+    expect(cop.messages).to eq(['Use `tr` instead of `gsub`.'])
+  end
+
+  context 'auto-correct' do
+    describe 'corrects to tr' do
+      it 'when the length of the pattern and replacement are the same' do
+        new_source = autocorrect_source(cop, "'abc'.gsub('ab', 'de')")
+
+        expect(new_source).to eq("'abc'.tr('ab', 'de')")
+      end
+
+      it 'when the length of the pattern and replacement are the same' do
+        new_source = autocorrect_source(cop, "'abc'.gsub!('ab', 'de')")
+
+        expect(new_source).to eq("'abc'.tr!('ab', 'de')")
+      end
+
+      it 'when the pattern is a regex literal' do
+        new_source = autocorrect_source(cop, "'abc'.gsub(/ab/, '12')")
+
+        expect(new_source).to eq("'abc'.tr('ab', '12')")
+      end
+
+      it 'when the pattern is a regex literal using %r' do
+        new_source = autocorrect_source(cop, "'abc'.gsub(%r{ab}, '12')")
+
+        expect(new_source).to eq("'abc'.tr('ab', '12')")
+      end
+
+      it 'when the pattern uses Regexp.new' do
+        new_source = autocorrect_source(cop,
+                                        "'abc'.gsub(Regexp.new('ab'), '12')")
+
+        expect(new_source).to eq("'abc'.tr('ab', '12')")
+      end
+
+      it 'when the pattern uses Regexp.compile' do
+        new_source = autocorrect_source(cop,
+                                        "'abc'.gsub(Regexp.compile('a'), '1')")
+
+        expect(new_source).to eq("'abc'.tr('a', '1')")
+      end
+
+      it 'when the replacement contains an escape character' do
+        new_source = autocorrect_source(cop, "'abc'.gsub('a', '\n')")
+
+        expect(new_source).to eq("'abc'.tr('a', \"\\n\")")
+      end
+
+      it 'when the pattern contains an escape character' do
+        new_source = autocorrect_source(cop, "'abc'.gsub('\n', ',')")
+
+        expect(new_source).to eq("'abc'.tr(\"\\n\", ',')")
+      end
+
+      it 'when replacing to a single quote' do
+        new_source = autocorrect_source(cop, '"a`b".gsub("`", "\'")')
+
+        expect(new_source).to eq('"a`b".tr(\'`\', "\'")')
+      end
+
+      it 'when replacing to a double quote' do
+        new_source = autocorrect_source(cop, '"a`b".gsub("`", "\"")')
+
+        expect(new_source).to eq('"a`b".tr(\'`\', "\"")')
+      end
+
+      it 'when deleteing multiple characters' do
+        new_source = autocorrect_source(cop, "'abc'.gsub('ab', '')")
+
+        expect(new_source).to eq("'abc'.tr('ab', '')")
+      end
+    end
+
+    describe 'corrects to delete' do
+      it 'when deleteing a single character' do
+        new_source = autocorrect_source(cop, "'abc'.gsub!('a', '')")
+
+        expect(new_source).to eq("'abc'.delete!('a')")
+      end
+
+      it 'when the pattern is a regex literal' do
+        new_source = autocorrect_source(cop, "'abc'.gsub(/a/, '')")
+
+        expect(new_source).to eq("'abc'.delete('a')")
+      end
+
+      it 'when deleteing an escape character' do
+        new_source = autocorrect_source(cop, "'abc'.gsub('\n', '')")
+
+        expect(new_source).to eq("'abc'.delete(\"\\n\")")
+      end
+
+      it 'when the pattern uses Regexp.new' do
+        new_source = autocorrect_source(cop, "'abc'.gsub(Regexp.new('a'), '')")
+
+        expect(new_source).to eq("'abc'.delete('a')")
+      end
+
+      it 'when the pattern uses Regexp.compile' do
+        new_source = autocorrect_source(cop,
+                                        "'ab'.gsub(Regexp.compile('a'), '')")
+
+        expect(new_source).to eq("'ab'.delete('a')")
+      end
+    end
+  end
+end


### PR DESCRIPTION
This will identify usages of `gsub` that can be changed to `tr` or `delete`. I think I covered all of the edge cases. I left the check for regex params fairly conservative to avoid potential false positives.