### PR TITLE
[Fix #1988] Do not error in Style/ParallelAssignment when assigning from a constant with colon notation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## master (unreleased)
 
+### Bugs fixed
+
+* [#1988](https://github.com/bbatsov/rubocop/issues/1988): Fix bug in `Style/ParallelAssignment` when assigning from `Module::CONSTANT`. ([@rrosenblum][])
+
 ## 0.32.1 (24/06/2015)
 
 ### New features

--- a/lib/rubocop/cop/style/parallel_assignment.rb
+++ b/lib/rubocop/cop/style/parallel_assignment.rb
@@ -37,6 +37,9 @@ module RuboCop
           # account for edge cases using one variable with a comma
           return if left_elements.size == 1
 
+          # account for edge case of Constant::CONSTANT
+          return unless right.array_type?
+
           # allow mass assignment as the return of a method call
           return if right.block_type? || right.send_type?
 

--- a/spec/rubocop/cop/style/parallel_assignment_spec.rb
+++ b/spec/rubocop/cop/style/parallel_assignment_spec.rb
@@ -44,6 +44,10 @@ describe RuboCop::Cop::Style::ParallelAssignment, :config do
   it_behaves_like('offenses', ['if true',
                                '  a, b = 1, 2',
                                'end'].join("\n"))
+  it_behaves_like('offenses',
+                  'a, b = Float::INFINITY, Float::INFINITY')
+  it_behaves_like('offenses',
+                  'Float::INFINITY, Float::INFINITY = 1, 2')
 
   shared_examples('allowed') do |source|
     it "allows assignment of: #{source}" do
@@ -77,6 +81,8 @@ describe RuboCop::Cop::Style::ParallelAssignment, :config do
                               'a, b, c = foo'].join("\n"))
   it_behaves_like('allowed', ['array = [1, 2, 3]',
                               'a, = array'].join("\n"))
+  it_behaves_like('allowed',
+                  'a, b = Float::INFINITY')
 
   it 'hightlights the entire expression' do
     inspect_source(cop, 'a, b = 1, 2')


### PR DESCRIPTION
This fixes #1988. It turns out that the colon notation used when referencing `Float::INFINITY` parses to look like multiple variables. There was an easy fix to this.