### PR TITLE
[Fix #1918] Add config param AllCops:DisabledByDefault

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### New features
 
 * [#1980](https://github.com/bbatsov/rubocop/pull/1980): `--auto-gen-config` now outputs an excluded files list for failed cops (up to a maxiumum of 15 files). ([@bmorrall][])
+* [#1918](https://github.com/bbatsov/rubocop/issues/1918): New configuration parameter `AllCops:DisabledByDefault` when set to `true` makes only cops found in user configuration enabled, which makes cop selection *opt-in*. ([@jonas054][])
 
 ### Bugs fixed
 

--- a/README.md
+++ b/README.md
@@ -368,6 +368,15 @@ Metrics/LineLength:
   Enabled: false
 ```
 
+Most cops are enabled by default. Some cops, configured in [config/disabled.yml](https://github.com/bbatsov/rubocop/blob/master/config/disabled.yml), are disabled by default. The cop enabling process can be altered by setting `DisabledByDefault` to `true`.
+
+```yaml
+AllCops:
+  DisabledByDefault: true
+```
+
+All cops are then disabled by default, and only cops appearing in user configuration files are enabled. `Enabled: true` does not have to be set for cops in user configuration. They will be enabled anyway.
+
 #### Severity
 
 Each cop has a default severity level based on which department it belongs

--- a/config/default.yml
+++ b/config/default.yml
@@ -42,6 +42,13 @@ AllCops:
   # default. Change behavior by overriding StyleGuideCopsOnly, or by giving
   # the --only-guide-cops option.
   StyleGuideCopsOnly: false
+  # All cops except the ones in disabled.yml are enabled by default. Change
+  # this behavior by overriding DisabledByDefault. When DisabledByDefault is
+  # true, all cops in the default configuration are disabled, and and only cops
+  # in user configuration are enabled. This makes cops opt-in instead of
+  # opt-out. Note that when DisabledByDefault is true, cops in user
+  # configuration will be enabled even if they don't set the Enabled parameter.
+  DisabledByDefault: false
 
 # Indent private/protected/public as deep as method definitions
 Style/AccessModifierIndentation:


### PR DESCRIPTION
By disabling cops in default configuration we make the selection process "opt-in". In order for this feature to work well together with `--auto-gen-config` (and any pre-existing config file), we allow the mere existence of configuration for a cop in a user configuration file to make the cop enabled (the `Enabled` parameter does not have to be set).

The value this feature brings is for people who want to run on the latest RuboCop without having a steady inflow of new cops, and thus new offenses to fix. I hope those users are the exception, and that most want the added value of new cops (which is why `DisabledByDefault` is false by default).