### PR TITLE
Update Lint/UnneededDisable description

### DIFF
--- a/config/enabled.yml
+++ b/config/enabled.yml
@@ -975,7 +975,10 @@ Lint/UnderscorePrefixedVariableName:
   Enabled: true
 
 Lint/UnneededDisable:
-  Description: 'Checks for rubocop:disable comments that can be removed.'
+  Description: >-
+                 Checks for rubocop:disable comments that can be removed.
+                 Note: this cop is not disabled when disabling all cops.
+                 It must be explicitly disabled.
   Enabled: true
 
 Lint/UnusedBlockArgument:


### PR DESCRIPTION
I thought it might be nice to document that `Lint/UnneededDisable` is not disabled when disabling all.