### PR TITLE
Only check for modifier before def

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### New features
 
+* [#2007](https://github.com/bbatsov/rubocop/pull/2007): Allow any modifier before `def`, not only visibility modifiers. ([@fphilipe][])
 * [#1980](https://github.com/bbatsov/rubocop/pull/1980): `--auto-gen-config` now outputs an excluded files list for failed cops (up to a maxiumum of 15 files). ([@bmorrall][])
 * [#1918](https://github.com/bbatsov/rubocop/issues/1918): New configuration parameter `AllCops:DisabledByDefault` when set to `true` makes only cops found in user configuration enabled, which makes cop selection *opt-in*. ([@jonas054][])
 * New cop `Performance/StringReplacement` checks for usages of `gsub` that can be replaced with `tr` or `delete`. ([@rrosenblum][])
@@ -1481,3 +1482,4 @@
 [@m1foley]: https://github.com/m1foley
 [@tejasbubane]: https://github.com/tejasbubane
 [@bmorrall]: https://github.com/bmorrall
+[@fphilipe]: https://github.com/fphilipe

--- a/lib/rubocop/cop/lint/def_end_alignment.rb
+++ b/lib/rubocop/cop/lint/def_end_alignment.rb
@@ -28,8 +28,8 @@ module RuboCop
 
         def on_send(node)
           receiver, method_name, *args = *node
-          return unless visibility_and_def_on_same_line?(receiver, method_name,
-                                                         args)
+          return unless modifier_and_def_on_same_line?(receiver, method_name,
+                                                       args)
 
           method_def = args.first
           if style == :start_of_line

--- a/lib/rubocop/cop/mixin/on_method_def.rb
+++ b/lib/rubocop/cop/mixin/on_method_def.rb
@@ -19,12 +19,11 @@ module RuboCop
       # Returns true for constructs such as
       # private def my_method
       # which are allowed in Ruby 2.1 and later.
-      def visibility_and_def_on_same_line?(receiver, method_name, args)
+      def modifier_and_def_on_same_line?(receiver, method_name, args)
         !receiver &&
-          [:public, :protected, :private,
-           :private_class_method, :public_class_method,
-           :module_function].include?(method_name) &&
-          args.size == 1 && [:def, :defs].include?(args.first.type)
+          method_name != :def &&
+          args.size == 1 &&
+          [:def, :defs].include?(args.first.type)
       end
     end
   end

--- a/lib/rubocop/cop/style/indentation_width.rb
+++ b/lib/rubocop/cop/style/indentation_width.rb
@@ -82,8 +82,8 @@ module RuboCop
         def on_send(node)
           super
           receiver, method_name, *args = *node
-          return unless visibility_and_def_on_same_line?(receiver, method_name,
-                                                         args)
+          return unless modifier_and_def_on_same_line?(receiver, method_name,
+                                                       args)
 
           _method_name, _args, body = *args.first
           def_end_config = config.for_cop('Lint/DefEndAlignment')

--- a/spec/rubocop/cop/lint/def_end_alignment_spec.rb
+++ b/spec/rubocop/cop/lint/def_end_alignment_spec.rb
@@ -9,13 +9,13 @@ describe RuboCop::Cop::Lint::DefEndAlignment, :config do
   end
 
   let(:source) do
-    ['private def a',
+    ['foo def a',
      '  a1',
      'end',
      '',
-     'private def b',
-     '          b1',
-     '        end']
+     'foo def b',
+     '      b1',
+     '    end']
   end
 
   context 'when AlignWith is start_of_line' do
@@ -30,31 +30,11 @@ describe RuboCop::Cop::Lint::DefEndAlignment, :config do
     include_examples 'aligned', 'def', 'Test.test', 'end', 'defs'
 
     context 'in ruby 2.1 or later' do
-      include_examples 'aligned', 'public def',               'test', 'end'
-      include_examples 'aligned', 'protected def',            'test', 'end'
-      include_examples 'aligned', 'private def',              'test', 'end'
-      include_examples 'aligned', 'module_function def',      'test', 'end'
-      include_examples 'aligned', 'private_class_method def', 'test', 'end'
-      include_examples 'aligned', 'public_class_method def',  'test', 'end'
+      include_examples 'aligned', 'foo def', 'test', 'end'
 
       include_examples('misaligned', '',
-                       'public def', 'test',
-                       '       end')
-      include_examples('misaligned', '',
-                       'protected def', 'test',
-                       '          end')
-      include_examples('misaligned', '',
-                       'private def', 'test',
-                       '        end')
-      include_examples('misaligned', '',
-                       'module_function def', 'test',
-                       '                end')
-      include_examples('misaligned', '',
-                       'private_class_method def', 'test',
-                       '                     end')
-      include_examples('misaligned', '',
-                       'public_class_method def', 'test',
-                       '                    end')
+                       'foo def', 'test',
+                       '    end')
     end
 
     context 'correct + opposite' do
@@ -62,19 +42,19 @@ describe RuboCop::Cop::Lint::DefEndAlignment, :config do
         inspect_source(cop, source)
         expect(cop.offenses.size).to eq(1)
         expect(cop.messages.first)
-          .to eq('`end` at 7, 8 is not aligned with `private def` at 5, 8')
+          .to eq('`end` at 7, 4 is not aligned with `foo def` at 5, 4')
         expect(cop.highlights.first).to eq('end')
         expect(cop.config_to_allow_offenses).to eq('Enabled' => false)
       end
 
       it 'does auto-correction' do
         corrected = autocorrect_source(cop, source)
-        expect(corrected).to eq(['private def a',
+        expect(corrected).to eq(['foo def a',
                                  '  a1',
                                  'end',
                                  '',
-                                 'private def b',
-                                 '          b1',
+                                 'foo def b',
+                                 '      b1',
                                  'end'].join("\n"))
       end
     end
@@ -93,29 +73,11 @@ describe RuboCop::Cop::Lint::DefEndAlignment, :config do
 
     context 'in ruby 2.1 or later' do
       include_examples('aligned',
-                       'public def',          'test',
-                       '       end')
-      include_examples('aligned',
-                       'protected def',       'test',
-                       '          end')
-      include_examples('aligned',
-                       'private def', 'test',
-                       '        end')
-      include_examples('aligned',
-                       'module_function def', 'test',
-                       '                end')
+                       'foo def', 'test',
+                       '    end')
 
       include_examples('misaligned',
-                       'public ', 'def', 'test',
-                       'end')
-      include_examples('misaligned',
-                       'protected ', 'def', 'test',
-                       'end')
-      include_examples('misaligned',
-                       'private ', 'def', 'test',
-                       'end')
-      include_examples('misaligned',
-                       'module_function ', 'def', 'test',
+                       'foo ', 'def', 'test',
                        'end')
 
       context 'correct + opposite' do
@@ -123,20 +85,20 @@ describe RuboCop::Cop::Lint::DefEndAlignment, :config do
           inspect_source(cop, source)
           expect(cop.offenses.size).to eq(1)
           expect(cop.messages.first)
-            .to eq('`end` at 3, 0 is not aligned with `def` at 1, 8')
+            .to eq('`end` at 3, 0 is not aligned with `def` at 1, 4')
           expect(cop.highlights.first).to eq('end')
           expect(cop.config_to_allow_offenses).to eq('Enabled' => false)
         end
 
         it 'does auto-correction' do
           corrected = autocorrect_source(cop, source)
-          expect(corrected).to eq(['private def a',
+          expect(corrected).to eq(['foo def a',
                                    '  a1',
-                                   '        end',
+                                   '    end',
                                    '',
-                                   'private def b',
-                                   '          b1',
-                                   '        end'].join("\n"))
+                                   'foo def b',
+                                   '      b1',
+                                   '    end'].join("\n"))
         end
       end
     end

--- a/spec/rubocop/cop/style/indentation_width_spec.rb
+++ b/spec/rubocop/cop/style/indentation_width_spec.rb
@@ -768,7 +768,7 @@ describe RuboCop::Cop::Style::IndentationWidth do
           context 'when modifier and def are on the same line' do
             it 'accepts a correctly aligned body' do
               inspect_source(cop,
-                             ['private def test',
+                             ['foo def test',
                               '  something',
                               'end'])
               expect(cop.offenses).to be_empty
@@ -776,11 +776,11 @@ describe RuboCop::Cop::Style::IndentationWidth do
 
             it 'registers an offense for bad indentation of a def body' do
               inspect_source(cop,
-                             ['private def test',
-                              '          something',
-                              '        end'])
+                             ['foo def test',
+                              '      something',
+                              '    end'])
               expect(cop.messages)
-                .to eq(['Use 2 (not 10) spaces for indentation.'])
+                .to eq(['Use 2 (not 6) spaces for indentation.'])
             end
           end
         end
@@ -797,19 +797,19 @@ describe RuboCop::Cop::Style::IndentationWidth do
           context 'when modifier and def are on the same line' do
             it 'accepts a correctly aligned body' do
               inspect_source(cop,
-                             ['private def test',
-                              '          something',
+                             ['foo def test',
+                              '      something',
                               'end'])
               expect(cop.offenses).to be_empty
             end
 
             it 'registers an offense for bad indentation of a def body' do
               inspect_source(cop,
-                             ['private def test',
+                             ['foo def test',
                               '  something',
-                              '        end'])
+                              '    end'])
               expect(cop.messages)
-                .to eq(['Use 2 (not -6) spaces for indentation.'])
+                .to eq(['Use 2 (not -2) spaces for indentation.'])
             end
           end
         end


### PR DESCRIPTION
Previously, only certain methods primarily related to method visibility were allowed before a `def`. This changes the behavior such that anything before `def` is allowed.

Closes #1467