### PR TITLE
New cop Lint/UselessOptionalArgument

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 * [#1918](https://github.com/bbatsov/rubocop/issues/1918): New configuration parameter `AllCops:DisabledByDefault` when set to `true` makes only cops found in user configuration enabled, which makes cop selection *opt-in*. ([@jonas054][])
 * New cop `Performance/StringReplacement` checks for usages of `gsub` that can be replaced with `tr` or `delete`. ([@rrosenblum][])
 * [#2001](https://github.com/bbatsov/rubocop/issues/2001): New cop `Style/InitialIndentation` checks for indentation of the first non-blank non-comment line in a file. ([@jonas054][])
+* New cop `Lint/UselessOptionalArgument` checks for optional arguments that do not appear at the end of an argument list. ([@rrosenblum][])
 
 ### Bugs fixed
 

--- a/config/enabled.yml
+++ b/config/enabled.yml
@@ -1017,6 +1017,12 @@ Lint/UselessElseWithoutRescue:
   Description: 'Checks for useless `else` in `begin..end` without `rescue`.'
   Enabled: true
 
+Lint/UselessOptionalArgument:
+  Description: >-
+                 Checks for optional arguments that do not appear at the end
+                 of the argument list
+  Enabled: true
+
 Lint/UselessSetterCall:
   Description: 'Checks for useless setter call to a local variable.'
   Enabled: true

--- a/lib/rubocop.rb
+++ b/lib/rubocop.rb
@@ -108,6 +108,7 @@ require 'rubocop/cop/lint/useless_access_modifier'
 require 'rubocop/cop/lint/useless_assignment'
 require 'rubocop/cop/lint/useless_comparison'
 require 'rubocop/cop/lint/useless_else_without_rescue'
+require 'rubocop/cop/lint/useless_optional_argument'
 require 'rubocop/cop/lint/useless_setter_call'
 require 'rubocop/cop/lint/void'
 

--- a/lib/rubocop/cop/lint/useless_optional_argument.rb
+++ b/lib/rubocop/cop/lint/useless_optional_argument.rb
@@ -1,0 +1,56 @@
+# encoding: utf-8
+
+module RuboCop
+  module Cop
+    module Lint
+      # This cop checks for optional arguments to methods
+      # that do not come at the end of the argument list
+      #
+      # @example
+      #   # bad
+      #   def foo(a = 1, b, c)
+      #   end
+      #
+      #   # good
+      #   def baz(a, b, c = 1)
+      #   end
+      #
+      #   def foobar(a = 1, b = 2, c = 3)
+      #   end
+      class UselessOptionalArgument < Cop
+        MSG = 'Useless optional argument for variable `%s`.'
+
+        def on_def(node)
+          _method, arguments, = *node
+          arguments = *arguments
+          optarg_positions = []
+          arg_positions = []
+
+          arguments.each_with_index do |argument, index|
+            optarg_positions << index if argument.optarg_type?
+            arg_positions << index if argument.arg_type?
+          end
+
+          return if optarg_positions.empty? || arg_positions.empty?
+
+          optarg_positions.each do |optarg_position|
+            # there can only be one group of optional arguments
+            break if  optarg_position > arg_positions.max
+            argument = arguments[optarg_position]
+            arg, = *argument
+
+            add_offense(argument, :expression, format(MSG, arg))
+          end
+        end
+
+        def autocorrect(node)
+          arg, = *node
+
+          lambda do |corrector|
+            corrector.replace(node.loc.expression, arg.to_s)
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/rubocop/cop/lint/useless_optional_argument_spec.rb
+++ b/spec/rubocop/cop/lint/useless_optional_argument_spec.rb
@@ -1,0 +1,135 @@
+# encoding: utf-8
+
+require 'spec_helper'
+
+describe RuboCop::Cop::Lint::UselessOptionalArgument do
+  subject(:cop) { described_class.new }
+
+  it 'registers an offense when an optional argument is followed by a ' \
+     'required argument' do
+    inspect_source(cop, ['def foo(a = 1, b)',
+                         'end'])
+
+    expect(cop.messages).to eq(['Useless optional argument for variable `a`.'])
+    expect(cop.highlights).to eq(['a = 1'])
+  end
+
+  it 'registers an offense for each optional argument when multiple ' \
+     'optional arguments are followed by a required argument' do
+    inspect_source(cop, ['def foo(a = 1, b = 2, c)',
+                         'end'])
+
+    expect(cop.messages).to eq(['Useless optional argument for variable `a`.',
+                                'Useless optional argument for variable `b`.'])
+    expect(cop.highlights).to eq(['a = 1', 'b = 2'])
+  end
+
+  it 'allows methods without arguments' do
+    inspect_source(cop, ['def foo',
+                         'end'])
+
+    expect(cop.messages).to be_empty
+  end
+
+  it 'allows methods with only one required argument' do
+    inspect_source(cop, ['def foo(a)',
+                         'end'])
+
+    expect(cop.messages).to be_empty
+  end
+
+  it 'allows methods with only required arguments' do
+    inspect_source(cop, ['def foo(a, b, c)',
+                         'end'])
+
+    expect(cop.messages).to be_empty
+  end
+
+  it 'allows methods with only one optional argument' do
+    inspect_source(cop, ['def foo(a = 1)',
+                         'end'])
+
+    expect(cop.messages).to be_empty
+  end
+
+  it 'allows methods with only optional arguments' do
+    inspect_source(cop, ['def foo(a = 1, b = 2, c = 3)',
+                         'end'])
+
+    expect(cop.messages).to be_empty
+  end
+
+  it 'allows methods with multiple optional arguments at the end' do
+    inspect_source(cop, ['def foo(a, b = 2, c = 3)',
+                         'end'])
+
+    expect(cop.messages).to be_empty
+  end
+
+  describe 'autocorrect' do
+    it 'corrects a single useless optional arguments' do
+      new_source = autocorrect_source(cop, ['def foo(a = 1, b)',
+                                            'end'])
+
+      expect(new_source).to eq(['def foo(a, b)',
+                                'end'].join("\n"))
+    end
+
+    it 'corrects multiple useless optional arguments' do
+      new_source = autocorrect_source(cop, ['def foo(a = 1, b = 2, c)',
+                                            'end'])
+
+      expect(new_source).to eq(['def foo(a, b, c)',
+                                'end'].join("\n"))
+    end
+  end
+
+  context 'named params' do
+    context 'with default values', ruby_greater_than_or_equal: 2.0 do
+      it 'allows optional arguments before an optional named argument' do
+        inspect_source(cop, ['def foo(a = 1, b: 2)',
+                             'end'])
+
+        expect(cop.messages).to be_empty
+      end
+    end
+
+    context 'required params', ruby_greater_than_or_equal: 2.1 do
+      it 'registers an offense for optional arguments that come before ' \
+         'required arguments where there are name arguments' do
+        inspect_source(cop, ['def foo(a = 1, b, c:, d: 4)',
+                             'end'])
+
+        expect(cop.messages)
+          .to eq(['Useless optional argument for variable `a`.'])
+        expect(cop.highlights).to eq(['a = 1'])
+      end
+
+      it 'allows optional arguments before required named arguments' do
+        inspect_source(cop, ['def foo(a = 1, b:)',
+                             'end'])
+
+        expect(cop.messages).to be_empty
+      end
+
+      it 'allows optional arguments to come before a mix of required and ' \
+         'optional named argument' do
+        inspect_source(cop, ['def foo(a = 1, b:, c: 3)',
+                             'end'])
+
+        expect(cop.messages).to be_empty
+      end
+
+      context 'autocorrect' do
+        it 'removes the default values of optional arguments when they ' \
+           'appear before required arguments and named arguments' do
+          new_source = autocorrect_source(cop, ['def foo(a = 1, b, c:, d: 4)',
+                                                'end'])
+
+          expect(new_source).to eq(['def foo(a, b, c:, d: 4)',
+                                    'end'].join("\n"))
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
This is a fairly straight forward cop. It will find optional arguments that do not appear at the end of an argument list. Since `nil` and not provided are different concepts, any optional arguments that are followed by required arguments become required arguments. The default value will never be able to be used.

Something that I did not know, is that you cannot have multiple groups of optional arguments. It seems that ruby will complain about trying to create multiple groups, but it will not complain about optional arguments at the beginning. 

```ruby
# allowed but the optional argument is actually required
def foo(a = 1, b)
end

# produces a SyntaxError
def foo(a = 1, b, c = 2)
end
```