### PR TITLE
[Fix #2015] Fix --auto-correct for DefEndAlignment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@
 * [#1995](https://github.com/bbatsov/rubocop/pull/1995): Improve message for `Rails/TimeZone`. ([@palkan][])
 * [#1977](https://github.com/bbatsov/rubocop/issues/1977): Fix bugs in `Rails/Date` and `Rails/TimeZone` when using namespaced Time/Date. ([@palkan][])
 * [#1973](https://github.com/bbatsov/rubocop/issues/1973): Do not register an offense in `Performance/Detect` when `select` is called on `Enumerable::Lazy`. ([@palkan][])
+* [#2015](https://github.com/bbatsov/rubocop/issues/2015): Fix bug occurring for auto-correction of a misaligned `end` in a file with only one method. ([@jonas054][])
 
 ## 0.32.1 (24/06/2015)
 

--- a/lib/rubocop/cop/lint/def_end_alignment.rb
+++ b/lib/rubocop/cop/lint/def_end_alignment.rb
@@ -49,7 +49,11 @@ module RuboCop
         private
 
         def autocorrect(node)
-          align(node, style == :start_of_line ? node.ancestors.first : node)
+          if style == :start_of_line && node.parent && node.parent.send_type?
+            align(node, node.parent)
+          else
+            align(node, node)
+          end
         end
       end
     end

--- a/spec/rubocop/cli_spec.rb
+++ b/spec/rubocop/cli_spec.rb
@@ -51,7 +51,7 @@ describe RuboCop::CLI, :isolated_environment do
         create_file('example.rb', source)
         create_file('.rubocop.yml', ['Lint/DefEndAlignment:',
                                      '  AutoCorrect: true'])
-        expect(cli.run(['--auto-correct'])).to eq(1)
+        expect(cli.run(['--auto-correct'])).to eq(0)
         corrected = ['# comment 1',
                      '',
                      '# comment 2',
@@ -60,8 +60,9 @@ describe RuboCop::CLI, :isolated_environment do
                      '  bar',
                      'rescue',
                      '  baz',
-                     '  end', # TODO: The `end` should have been corrected.
+                     'end',
                      '']
+        expect($stderr.string).to eq('')
         expect(IO.read('example.rb')).to eq(corrected.join("\n"))
       end
 


### PR DESCRIPTION
The `end` should be aligned with the parent of `def` only if that parent is a `send` node (such as
`private`).