### PR TITLE
[Fix #2008] Check for too many spaces in SpaceBeforeModifierKeyword

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@
 * [#2001](https://github.com/bbatsov/rubocop/issues/2001): New cop `Style/InitialIndentation` checks for indentation of the first non-blank non-comment line in a file. ([@jonas054][])
 * New cop `Lint/UselessOptionalArgument` checks for optional arguments that do not appear at the end of an argument list. ([@rrosenblum][])
 
+### Changes
+
+* [#2008](https://github.com/bbatsov/rubocop/issues/2008): `Style/SpaceBeforeModifierKeyword` now also checks for *too many* spaces before a modifier keyword. ([@jonas054][])
+
 ### Bugs fixed
 
 * [#2014](https://github.com/bbatsov/rubocop/pull/2014): Fix `Style/TrivialAccessors` to support AllowPredicates: false. ([@gotrevor][])

--- a/config/enabled.yml
+++ b/config/enabled.yml
@@ -637,7 +637,7 @@ Style/SpaceAroundOperators:
   Enabled: true
 
 Style/SpaceBeforeModifierKeyword:
-  Description: 'Put a space before the modifier keyword.'
+  Description: 'Put one space before the modifier keyword.'
   Enabled: true
 
 Style/SpaceInsideBrackets:

--- a/lib/rubocop/cop/style/space_before_modifier_keyword.rb
+++ b/lib/rubocop/cop/style/space_before_modifier_keyword.rb
@@ -3,17 +3,24 @@
 module RuboCop
   module Cop
     module Style
-      # Here we check if modifier keywords are preceded by a space.
+      # Here we check if modifier keywords are preceded by one space.
       class SpaceBeforeModifierKeyword < Cop
-        MSG = 'Put a space before the modifier keyword.'
+        MSG_MISSING = 'Put a space before the modifier keyword.'
+        MSG_EXTRA = 'Put only one space before the modifier keyword.'
 
         def on_if(node)
           return unless modifier?(node)
 
           kw = node.loc.keyword
-          b = kw.begin_pos
-          left_of_kw = Parser::Source::Range.new(kw.source_buffer, b - 1, b)
-          add_offense(node, left_of_kw) unless left_of_kw.is?(' ')
+          kw_with_space = range_with_surrounding_space(kw, :left)
+          space_length = kw_with_space.length - kw.length
+
+          if space_length == 0
+            add_offense(kw, kw, MSG_MISSING)
+          elsif space_length > 1
+            space = kw_with_space.resize(space_length)
+            add_offense(space, space, MSG_EXTRA)
+          end
         end
         alias_method :on_while, :on_if
         alias_method :on_until, :on_if
@@ -28,8 +35,14 @@ module RuboCop
           node.loc.keyword.is?('elsif')
         end
 
-        def autocorrect(node)
-          ->(corrector) { corrector.insert_before(node.loc.keyword, ' ') }
+        def autocorrect(range)
+          lambda do |corrector|
+            if range.source.start_with?(' ')
+              corrector.replace(range, ' ')
+            else
+              corrector.insert_before(range, ' ')
+            end
+          end
         end
       end
     end

--- a/spec/rubocop/cop/style/space_before_modifier_keyword_spec.rb
+++ b/spec/rubocop/cop/style/space_before_modifier_keyword_spec.rb
@@ -11,7 +11,19 @@ describe RuboCop::Cop::Style::SpaceBeforeModifierKeyword do
                          'a = 42unless a == 2',
                          'a = [1,2,3]unless a == 2',
                          'a = {:a => "b"}if a == 2'])
-    expect(cop.highlights).to eq([')', '"', '2', ']', '}'])
+    expect(cop.highlights).to eq(%w(if if unless unless if))
+    expect(cop.messages).to eq(['Put a space before the modifier keyword.'] * 5)
+  end
+
+  it 'registers an offense for extra space before if/unless' do
+    inspect_source(cop, ['(a = 3)  if a == 2',
+                         'a = "test"   if a == 2',
+                         'a = 42  unless a == 2',
+                         'a = [1,2,3]   unless a == 2',
+                         'a = {:a => "b"}  if a == 2'])
+    expect(cop.highlights).to eq(['  ', '   ', '  ', '   ', '  '])
+    expect(cop.messages)
+      .to eq(['Put only one space before the modifier keyword.'] * 5)
   end
 
   it 'registers an offense for missing space before while/until' do
@@ -20,7 +32,16 @@ describe RuboCop::Cop::Style::SpaceBeforeModifierKeyword do
                          'a = 42while b',
                          'a = [1,2,3]until b',
                          'a = {:a => "b"}while b'])
-    expect(cop.highlights).to eq([')', '"', '2', ']', '}'])
+    expect(cop.highlights).to eq(%w(while until while until while))
+  end
+
+  it 'registers an offense for extra space before while/until' do
+    inspect_source(cop, ['(a = 3)  while b',
+                         'a = "test"  until b',
+                         'a = 42  while b',
+                         'a = [1,2,3]  until b',
+                         'a = {:a => "b"}  while b'])
+    expect(cop.highlights).to eq(['  '] * 5)
   end
 
   it 'accepts modifiers with preceding space' do
@@ -28,6 +49,16 @@ describe RuboCop::Cop::Style::SpaceBeforeModifierKeyword do
                          'a = "test" unless b',
                          'a = 42 while b',
                          'a = [1,2,3] until b'])
+    expect(cop.offenses).to be_empty
+  end
+
+  it 'accepts non-modifier if' do
+    inspect_source(cop, ['    if space_length == 0',
+                         '      add_offense(kw, kw, MSG_MISSING)',
+                         '    elsif space_length > 1',
+                         '      space = kw_with_space.resize(space_length)',
+                         '      add_offense(space, space, MSG_EXTRA)',
+                         '    end'])
     expect(cop.offenses).to be_empty
   end
 
@@ -56,6 +87,29 @@ describe RuboCop::Cop::Style::SpaceBeforeModifierKeyword do
                                           'a = 42while b',
                                           'a = [1,2,3]until b',
                                           'a = {:a => "b"}while b'])
+    expect(new_source).to eq(['(a = 3) if a == 2',
+                              'a = "test" if a == 2',
+                              'a = 42 unless a == 2',
+                              'a = [1,2,3] unless a == 2',
+                              'a = {:a => "b"} if a == 2',
+                              '(a = 3) while b',
+                              'a = "test" until b',
+                              'a = 42 while b',
+                              'a = [1,2,3] until b',
+                              'a = {:a => "b"} while b'].join("\n"))
+  end
+
+  it 'auto-corrects extra space' do
+    new_source = autocorrect_source(cop, ['(a = 3)  if a == 2',
+                                          'a = "test"   if a == 2',
+                                          'a = 42  unless a == 2',
+                                          'a = [1,2,3]   unless a == 2',
+                                          'a = {:a => "b"}  if a == 2',
+                                          '(a = 3)   while b',
+                                          'a = "test"  until b',
+                                          'a = 42   while b',
+                                          'a = [1,2,3]  until b',
+                                          'a = {:a => "b"}   while b'])
     expect(new_source).to eq(['(a = 3) if a == 2',
                               'a = "test" if a == 2',
                               'a = 42 unless a == 2',


### PR DESCRIPTION
Previously we only checked for missing space.