### PR TITLE
[Fix #2029] Style/RedundantReturn auto-corrects implicit hashes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@
 * [#2015](https://github.com/bbatsov/rubocop/issues/2015): Fix bug occurring for auto-correction of a misaligned `end` in a file with only one method. ([@jonas054][])
 * Allow string interpolation segments inside single quoted string literals when double quotes are preferred. ([@segiddins][])
 * [#2026](https://github.com/bbatsov/rubocop/issues/2026): Allow `Time.current` when style is "acceptable".([@palkan][])
+* [#2029](https://github.com/bbatsov/rubocop/issues/2029): Fix bug where `Style/RedundantReturn` auto-corrects returning implicit hashes to invalid syntax. ([@rrosenblum][])
 
 ## 0.32.1 (24/06/2015)
 

--- a/lib/rubocop/cop/style/redundant_return.rb
+++ b/lib/rubocop/cop/style/redundant_return.rb
@@ -34,14 +34,31 @@ module RuboCop
               next
             end
 
+            return_value, = *node
             if node.children.size > 1
-              kids = node.children.map { |child| child.loc.expression }
-              corrector.insert_before(kids.first, '[')
-              corrector.insert_after(kids.last, ']')
+              add_brackets(corrector, node)
+            elsif return_value.hash_type?
+              add_braces(corrector, return_value) unless braces?(return_value)
             end
             return_kw = range_with_surrounding_space(node.loc.keyword, :right)
             corrector.remove(return_kw)
           end
+        end
+
+        def braces?(arg)
+          arg.loc.begin
+        end
+
+        def add_brackets(corrector, node)
+          kids = node.children.map { |child| child.loc.expression }
+          corrector.insert_before(kids.first, '[')
+          corrector.insert_after(kids.last, ']')
+        end
+
+        def add_braces(corrector, node)
+          kids = node.children.map { |child| child.loc.expression }
+          corrector.insert_before(kids.first, '{')
+          corrector.insert_after(kids.last, '}')
         end
 
         def arguments?(args)

--- a/spec/rubocop/cop/style/redundant_return_spec.rb
+++ b/spec/rubocop/cop/style/redundant_return_spec.rb
@@ -150,6 +150,28 @@ describe RuboCop::Cop::Style::RedundantReturn, :config do
       new_source = autocorrect_source(cop, src)
       expect(new_source).to eq(result_src)
     end
+
+    it 'auto-corrects removes return when using an explicit hash' do
+      src = ['def func',
+             '  return {:a => 1, :b => 2}',
+             'end'].join("\n")
+      result_src = ['def func',
+                    '  {:a => 1, :b => 2}', # :a => 1, :b => 2 is not valid Ruby
+                    'end'].join("\n")
+      new_source = autocorrect_source(cop, src)
+      expect(new_source).to eq(result_src)
+    end
+
+    it 'auto-corrects by making an implicit hash explicit' do
+      src = ['def func',
+             '  return :a => 1, :b => 2',
+             'end'].join("\n")
+      result_src = ['def func',
+                    '  {:a => 1, :b => 2}', # :a => 1, :b => 2 is not valid Ruby
+                    'end'].join("\n")
+      new_source = autocorrect_source(cop, src)
+      expect(new_source).to eq(result_src)
+    end
   end
 
   context 'when multi-value returns are allowed' do


### PR DESCRIPTION
This fixes #2029 