### PR TITLE
[Fix #2021] Allow semantic block in array or range

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@
 * Allow string interpolation segments inside single quoted string literals when double quotes are preferred. ([@segiddins][])
 * [#2026](https://github.com/bbatsov/rubocop/issues/2026): Allow `Time.current` when style is "acceptable".([@palkan][])
 * [#2029](https://github.com/bbatsov/rubocop/issues/2029): Fix bug where `Style/RedundantReturn` auto-corrects returning implicit hashes to invalid syntax. ([@rrosenblum][])
+* [#2021](https://github.com/bbatsov/rubocop/issues/2021): Fix bug in `Style/BlockDelimiters` when a `semantic` expression is used in an array or a range. ([@lumeet][])
 
 ## 0.32.1 (24/06/2015)
 

--- a/lib/rubocop/cop/style/block_delimiters.rb
+++ b/lib/rubocop/cop/style/block_delimiters.rb
@@ -155,7 +155,8 @@ module RuboCop
         def return_value_of_scope?(node)
           return unless node.parent
 
-          conditional?(node.parent) || node.parent.children.last == node
+          conditional?(node.parent) || array_or_range?(node.parent) ||
+            node.parent.children.last == node
         end
 
         def procedural_methods
@@ -172,6 +173,10 @@ module RuboCop
 
         def conditional?(node)
           node.if_type? || node.or_type? || node.and_type?
+        end
+
+        def array_or_range?(node)
+          node.array_type? || node.irange_type? || node.erange_type?
         end
       end
     end

--- a/spec/rubocop/cop/style/block_delimiters_spec.rb
+++ b/spec/rubocop/cop/style/block_delimiters_spec.rb
@@ -107,6 +107,21 @@ describe RuboCop::Cop::Style::BlockDelimiters, :config do
       expect(cop.messages).to be_empty
     end
 
+    it 'accepts a single line block with {} if used in an array' do
+      inspect_source(cop, '[detect { true }, other]')
+      expect(cop.messages).to be_empty
+    end
+
+    it 'accepts a single line block with {} if used in an irange' do
+      inspect_source(cop, 'detect { true }..other')
+      expect(cop.messages).to be_empty
+    end
+
+    it 'accepts a single line block with {} if used in an erange' do
+      inspect_source(cop, 'detect { true }...other')
+      expect(cop.messages).to be_empty
+    end
+
     it 'accepts a multi-line functional block with do-end if it is ' \
        'a known procedural method' do
       inspect_source(cop, ['foo = bar.tap do |x|',


### PR DESCRIPTION
The `BlockDelimiters` cop now allows using `semantic` blocks in arrays
and ranges.