### PR TITLE
[Fix #2045] Fix error on class method definition with modifier

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@
 * [#2029](https://github.com/bbatsov/rubocop/issues/2029): Fix bug where `Style/RedundantReturn` auto-corrects returning implicit hashes to invalid syntax. ([@rrosenblum][])
 * [#2021](https://github.com/bbatsov/rubocop/issues/2021): Fix bug in `Style/BlockDelimiters` when a `semantic` expression is used in an array or a range. ([@lumeet][])
 * [#1992](https://github.com/bbatsov/rubocop/issues/1992): Allow parentheses in assignment to a variable with the same name as the method's in `Style/MethodCallParentheses`. ([@lumeet][])
+* [#2045](https://github.com/bbatsov/rubocop/issues/2045): Fix crash in `Style/IndentationWidth` when using `private_class_method def self.foo` syntax. ([@unmanbearpig][])
 
 ## 0.32.1 (24/06/2015)
 
@@ -1504,3 +1505,4 @@
 [@awwaiid]: https://github.com/awwaiid
 [@segiddins]: https://github.com/segiddins
 [@urbanautomaton]: https://github.com/urbanautomaton.com
+[@unmanbearpig]: https://github.com/unmanbearpig

--- a/lib/rubocop/cop/style/indentation_width.rb
+++ b/lib/rubocop/cop/style/indentation_width.rb
@@ -85,7 +85,8 @@ module RuboCop
           return unless modifier_and_def_on_same_line?(receiver, method_name,
                                                        args)
 
-          _method_name, _args, body = *args.first
+          *_, body = *args.first
+
           def_end_config = config.for_cop('Lint/DefEndAlignment')
           style = if def_end_config['Enabled']
                     def_end_config['AlignWith']

--- a/spec/rubocop/cop/style/indentation_width_spec.rb
+++ b/spec/rubocop/cop/style/indentation_width_spec.rb
@@ -755,6 +755,13 @@ describe RuboCop::Cop::Style::IndentationWidth do
                           'end'])
           expect(cop.offenses).to be_empty
         end
+
+        it 'with an assignment' do
+          inspect_source(cop, [
+                           'something = def self.foo',
+                           'end'])
+          expect(cop.offenses).to be_empty
+        end
       end
 
       context 'when end is aligned with start of line' do
@@ -777,6 +784,15 @@ describe RuboCop::Cop::Style::IndentationWidth do
             it 'registers an offense for bad indentation of a def body' do
               inspect_source(cop,
                              ['foo def test',
+                              '      something',
+                              '    end'])
+              expect(cop.messages)
+                .to eq(['Use 2 (not 6) spaces for indentation.'])
+            end
+
+            it 'registers an offense for bad indentation of a defs body' do
+              inspect_source(cop,
+                             ['foo def self.test',
                               '      something',
                               '    end'])
               expect(cop.messages)
@@ -806,6 +822,15 @@ describe RuboCop::Cop::Style::IndentationWidth do
             it 'registers an offense for bad indentation of a def body' do
               inspect_source(cop,
                              ['foo def test',
+                              '  something',
+                              '    end'])
+              expect(cop.messages)
+                .to eq(['Use 2 (not -2) spaces for indentation.'])
+            end
+
+            it 'registers an offense for bad indentation of a defs body' do
+              inspect_source(cop,
+                             ['foo def self.test',
                               '  something',
                               '    end'])
               expect(cop.messages)
@@ -961,6 +986,19 @@ describe RuboCop::Cop::Style::IndentationWidth do
       it 'registers an offense for bad indentation of bodies' do
         inspect_source(cop,
                        ['def my_func',
+                        "  puts 'do something error prone'",
+                        'rescue SomeException',
+                        " puts 'wrongly intended error handling'",
+                        'rescue',
+                        " puts 'wrongly intended error handling'",
+                        'end'])
+        expect(cop.messages).to eq(['Use 2 (not 1) spaces for indentation.',
+                                    'Use 2 (not 1) spaces for indentation.'])
+      end
+
+      it 'registers an offense for bad indentation of defs bodies with a modifier' do
+        inspect_source(cop,
+                       ['foo def self.my_func',
                         "  puts 'do something error prone'",
                         'rescue SomeException',
                         " puts 'wrongly intended error handling'",


### PR DESCRIPTION
We were assuming that method body is always the third element of a
method definition node

```
_method_name, _args, body = *args.first
```

and here is an example how args.first looks in case of regular methods:
```
(def :test
  (args)
  (send nil :body))
```

but in case of class methods, for example in this code
```
private_class_method def self.bar
```

there is an extra `(self)` element:
```
(defs
  (self) :bar
  (args)
  (send nil :body))
```

So the body becomes the fourth element instead.

Always taking the last element takes care
of the issue.