### PR TITLE
Don't hardcode "today" into Rails Date cop

### DIFF
--- a/lib/rubocop/cop/rails/date.rb
+++ b/lib/rubocop/cop/rails/date.rb
@@ -75,7 +75,7 @@ module RuboCop
           add_offense(node, :selector,
                       format(MSG,
                              "Date.#{method_name}",
-                             'Time.zone.today')
+                             "Time.zone.#{method_name}")
                      )
         end
 


### PR DESCRIPTION
Currently, the `RuboCop::Cop::Rails::Date` cop generates messages like:

> Do not use `Date.yesterday` without zone. Use `Time.zone.today` instead.

Clearly, this is the wrong message. This pull request fixes this issue.