### PR TITLE
[Fix #1992] Relax rule for method call with parens

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@
 * [#2026](https://github.com/bbatsov/rubocop/issues/2026): Allow `Time.current` when style is "acceptable".([@palkan][])
 * [#2029](https://github.com/bbatsov/rubocop/issues/2029): Fix bug where `Style/RedundantReturn` auto-corrects returning implicit hashes to invalid syntax. ([@rrosenblum][])
 * [#2021](https://github.com/bbatsov/rubocop/issues/2021): Fix bug in `Style/BlockDelimiters` when a `semantic` expression is used in an array or a range. ([@lumeet][])
+* [#1992](https://github.com/bbatsov/rubocop/issues/1992): Allow parentheses in assignment to a variable with the same name as the method's in `Style/MethodCallParentheses`. ([@lumeet][])
 
 ## 0.32.1 (24/06/2015)
 

--- a/lib/rubocop/cop/style/method_call_parentheses.rb
+++ b/lib/rubocop/cop/style/method_call_parentheses.rb
@@ -7,19 +7,38 @@ module RuboCop
       class MethodCallParentheses < Cop
         MSG = 'Do not use parentheses for method calls with no arguments.'
 
+        ASGN_NODES = [:lvasgn, :masgn] + Util::SHORTHAND_ASGN_NODES
+
         def on_send(node)
           _receiver, method_name, *args = *node
 
           # methods starting with a capital letter should be skipped
           return if method_name =~ /\A[A-Z]/
+          return unless args.empty? && node.loc.begin
+          return if same_name_assignment?(node)
 
-          add_offense(node, :begin) if args.empty? && node.loc.begin
+          add_offense(node, :begin)
         end
 
         def autocorrect(node)
           lambda do |corrector|
             corrector.remove(node.loc.begin)
             corrector.remove(node.loc.end)
+          end
+        end
+
+        private
+
+        def same_name_assignment?(node)
+          _receiver, method_name, *_args = *node
+
+          node.each_ancestor(ASGN_NODES).any? do |asgn_node|
+            if asgn_node.masgn_type?
+              mlhs_node, _mrhs_node = *asgn_node
+              asgn_node = mlhs_node.children[node.sibling_index]
+            end
+
+            asgn_node.loc.name.source == method_name.to_s
           end
         end
       end

--- a/spec/rubocop/cop/style/method_call_parentheses_spec.rb
+++ b/spec/rubocop/cop/style/method_call_parentheses_spec.rb
@@ -25,6 +25,33 @@ describe RuboCop::Cop::Style::MethodCallParentheses do
     expect(cop.offenses).to be_empty
   end
 
+  context 'assignment to a variable with the same name' do
+    it 'accepts parens in local variable assignment ' do
+      inspect_source(cop, 'test = test()')
+      expect(cop.offenses).to be_empty
+    end
+
+    it 'accepts parens in shorthand assignment' do
+      inspect_source(cop, 'test ||= test()')
+      expect(cop.offenses).to be_empty
+    end
+
+    it 'accepts parens in parallel assignment' do
+      inspect_source(cop, 'one, test = 1, test()')
+      expect(cop.offenses).to be_empty
+    end
+
+    it 'accepts parens in complex assignment' do
+      inspect_source(cop, ['test = begin',
+                           '  case a',
+                           '  when b',
+                           '    c = test() if d',
+                           '  end',
+                           'end'])
+      expect(cop.offenses).to be_empty
+    end
+  end
+
   it 'auto-corrects by removing unneeded braces' do
     new_source = autocorrect_source(cop, 'test()')
     expect(new_source).to eq('test')


### PR DESCRIPTION
`Style/MethodCallParentheses` doesn't register an offense when the
result of method call is assigned to a variable with the same name as the
method's.