### PR TITLE
[Fix #2006] Fix crash in case of nested offenses

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@
 * [#2021](https://github.com/bbatsov/rubocop/issues/2021): Fix bug in `Style/BlockDelimiters` when a `semantic` expression is used in an array or a range. ([@lumeet][])
 * [#1992](https://github.com/bbatsov/rubocop/issues/1992): Allow parentheses in assignment to a variable with the same name as the method's in `Style/MethodCallParentheses`. ([@lumeet][])
 * [#2045](https://github.com/bbatsov/rubocop/issues/2045): Fix crash in `Style/IndentationWidth` when using `private_class_method def self.foo` syntax. ([@unmanbearpig][])
+* [#2006](https://github.com/bbatsov/rubocop/issues/2006): Fix crash in `Style/FirstParameterIndentation` in case of nested offenses. ([@unmanbearpig][])
 
 ## 0.32.1 (24/06/2015)
 

--- a/lib/rubocop/cop/style/first_parameter_indentation.rb
+++ b/lib/rubocop/cop/style/first_parameter_indentation.rb
@@ -39,6 +39,8 @@ module RuboCop
         private
 
         def message(arg_node)
+          return 'Bad indentation of the first parameter.' if arg_node.nil?
+
           send_node = arg_node.parent
           text = base_range(send_node, arg_node).source.strip
           base = if text !~ /\n/ && special_inner_call_indentation?(send_node)

--- a/spec/rubocop/cop/style/first_parameter_indentation_spec.rb
+++ b/spec/rubocop/cop/style/first_parameter_indentation_spec.rb
@@ -38,6 +38,39 @@ describe RuboCop::Cop::Style::FirstParameterIndentation, :config do
         expect(cop.highlights).to eq([':foo'])
       end
 
+      it 'registers an offense on lines affected by another offense' do
+        inspect_source(cop, ['foo(',
+                             ' bar(',
+                             '  7',
+                             ')',
+                             ')'])
+
+        expect(cop.highlights).to eq([['bar(',
+                                       '  7',
+                                       ')'].join("\n"),
+                                      '7'])
+
+        expect(cop.messages)
+          .to eq(['Indent the first parameter one step more than ' \
+                  'the start of the previous line.',
+                  'Bad indentation of the first parameter.'])
+      end
+
+      it 'auto-corrects nested offenses' do
+        new_source = autocorrect_source(cop, ['foo(',
+                                              ' bar(',
+                                              '  7',
+                                              ')',
+                                              ')'])
+
+        expect(new_source)
+          .to eq(['foo(',
+                  '  bar(',
+                  '   7',
+                  ' )', # Will be corrected by IndentationConsistency.
+                  ')'].join("\n"))
+      end
+
       context 'for assignment' do
         it 'accepts a correctly indented first parameter and does not care ' \
            'about the second parameter' do


### PR DESCRIPTION
The error happened when `check_alignment` in AutocorrectAlignment adds
an offense with nil node.

```ruby
if offenses.any? { |o| within?(expr, o.location) }
  # If this offense is within a line range that is already being
  # realigned by autocorrect, we report the offense without
  # autocorrecting it. Two rewrites in the same area by the same
  # cop can not be handled. The next iteration will find the
  # offense again and correct it.
  add_offense(nil, expr)
```

In this case `add_offense` passes that nil into `message` method of the
cop that uses AutocorrectAlignment. `FirstParameterIndentation#message`
didn't handle the case when node is nil, so I've added a guard with
a generic message for this case. It looks like the message should be clear enough
since there probably would be a more detailed message reported just before this one.

I'm not sure if this is the best solution. Maybe `check_alignment` shouldn't pass nil into `add_offense` and handle this case somehow differently instead, but I'm not sure about that.