### PR TITLE
Improve ExtraSpacing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@
 * [#2052](https://github.com/bbatsov/rubocop/pull/2052): `Style/RescueModifier` uses token stream to identify offenses. ([@urbanautomaton][])
 * [#2008](https://github.com/bbatsov/rubocop/issues/2008): `Style/SpaceBeforeModifierKeyword` now also checks for *too many* spaces before a modifier keyword. ([@jonas054][])
 * Rename `Rails/Date` and `Rails/TimeZone` style names to "strict" and "flexible" and make "flexible" to be default. ([@palkan][])
+* [#2035](https://github.com/bbatsov/rubocop/issues/2035): `Style/ExtraSpacing` is now enabled by default and has a configuration parameter `AllowForAlignment` that is `true` by default, making it allow extra spacing if it's used for alignment purposes. ([@jonas054][])
 
 ### Bugs fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,6 @@
 ### Changes
 
 * [#2052](https://github.com/bbatsov/rubocop/pull/2052): `Style/RescueModifier` uses token stream to identify offenses. ([@urbanautomaton][])
-* [#2008](https://github.com/bbatsov/rubocop/issues/2008): `Style/SpaceBeforeModifierKeyword` now also checks for *too many* spaces before a modifier keyword. ([@jonas054][])
 * Rename `Rails/Date` and `Rails/TimeZone` style names to "strict" and "flexible" and make "flexible" to be default. ([@palkan][])
 * [#2035](https://github.com/bbatsov/rubocop/issues/2035): `Style/ExtraSpacing` is now enabled by default and has a configuration parameter `AllowForAlignment` that is `true` by default, making it allow extra spacing if it's used for alignment purposes. ([@jonas054][])
 

--- a/config/default.yml
+++ b/config/default.yml
@@ -383,6 +383,12 @@ Style/Encoding:
     - always
   AutoCorrectEncodingComment: '# encoding: utf-8'
 
+Style/ExtraSpacing:
+  # When true, allows most uses of extra spacing if the intent is to align
+  # things with the previous or next line, not counting empty lines or comment
+  # lines.
+  AllowForAlignment: true
+
 Style/FileName:
   # File names listed in AllCops:Include are excluded by default. Add extra
   # excludes here.

--- a/config/disabled.yml
+++ b/config/disabled.yml
@@ -49,10 +49,6 @@ Style/SymbolArray:
   StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#percent-i'
   Enabled: false
 
-Style/ExtraSpacing:
-  Description: 'Do not use unnecessary spacing.'
-  Enabled: false
-
 Lint/LiteralInInterpolation:
   Description: 'Avoid interpolating literals in strings'
   AutoCorrect: false

--- a/config/enabled.yml
+++ b/config/enabled.yml
@@ -651,7 +651,7 @@ Style/SpaceAroundOperators:
   Enabled: true
 
 Style/SpaceBeforeModifierKeyword:
-  Description: 'Put one space before the modifier keyword.'
+  Description: 'Put a space before the modifier keyword.'
   Enabled: true
 
 Style/SpaceInsideBrackets:

--- a/config/enabled.yml
+++ b/config/enabled.yml
@@ -243,6 +243,10 @@ Style/EvenOdd:
   StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#predicate-methods'
   Enabled: true
 
+Style/ExtraSpacing:
+  Description: 'Do not use unnecessary spacing.'
+  Enabled: true
+
 Style/FileName:
   Description: 'Use snake_case for source file names.'
   StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#snake-case-files'

--- a/lib/rubocop/cop/lint/duplicate_methods.rb
+++ b/lib/rubocop/cop/lint/duplicate_methods.rb
@@ -65,7 +65,7 @@ module RuboCop
 
         def method_names(body)
           body.child_nodes.map do |node|
-            _receiver, node, body  = *node if node.send_type?
+            _receiver, node, body = *node if node.send_type?
 
             if node.is_a? Symbol
               next if body.nil?

--- a/lib/rubocop/cop/performance/flat_map.rb
+++ b/lib/rubocop/cop/performance/flat_map.rb
@@ -22,7 +22,7 @@ module RuboCop
         FLATTEN = [:flatten, :flatten!]
 
         def on_send(node)
-          left, second_method, flatten_param  = *node
+          left, second_method, flatten_param = *node
           return unless FLATTEN.include?(second_method)
           flatten_level, = *flatten_param
           expression, = *left
@@ -44,7 +44,7 @@ module RuboCop
         end
 
         def autocorrect(node)
-          receiver, _flatten, flatten_param  = *node
+          receiver, _flatten, flatten_param = *node
           flatten_level, = *flatten_param
           return if flatten_level.nil?
 

--- a/lib/rubocop/cop/style/extra_spacing.rb
+++ b/lib/rubocop/cop/style/extra_spacing.rb
@@ -7,25 +7,98 @@ module RuboCop
       #
       # @example
       #
-      #   name     = "RuboCop"
+      #   # good if AllowForAlignment is true
+      #   name      = "RuboCop"
+      #   # Some comment and an empty line
+      #
+      #   website  += "/bbatsov/rubocop" unless cond
+      #   puts        "rubocop"          if     debug
+      #
+      #   # bad for any configuration
+      #   set_app("RuboCop")
       #   website  = "https://github.com/bbatsov/rubocop"
       class ExtraSpacing < Cop
         MSG = 'Unnecessary spacing detected.'
 
         def investigate(processed_source)
           processed_source.tokens.each_cons(2) do |t1, t2|
-            next unless t1.pos.line == t2.pos.line
-            next unless t2.pos.begin_pos - 1 > t1.pos.end_pos
-            buffer = processed_source.buffer
+            next if t2.type == :tNL
+            next if t1.pos.line != t2.pos.line
+            next if t2.pos.begin_pos - 1 <= t1.pos.end_pos
+            next if allow_for_alignment? && aligned_with_something?(t2)
             start_pos = t1.pos.end_pos
             end_pos = t2.pos.begin_pos - 1
-            range = Parser::Source::Range.new(buffer, start_pos, end_pos)
+            range = Parser::Source::Range.new(processed_source.buffer,
+                                              start_pos, end_pos)
             add_offense(range, range, MSG)
           end
         end
 
         def autocorrect(range)
           ->(corrector) { corrector.remove(range) }
+        end
+
+        private
+
+        def allow_for_alignment?
+          cop_config['AllowForAlignment']
+        end
+
+        def aligned_with_something?(token)
+          return aligned_comments?(token) if token.type == :tCOMMENT
+
+          pre = (token.pos.line - 2).downto(0)
+          post = token.pos.line.upto(processed_source.lines.size - 1)
+          aligned_with?(pre, token) || aligned_with?(post, token)
+        end
+
+        def aligned_comments?(token)
+          ix = processed_source.comments.index do |c|
+            c.loc.expression.begin_pos == token.pos.begin_pos
+          end
+          aligned_with_previous_comment?(ix) || aligned_with_next_comment?(ix)
+        end
+
+        def aligned_with_previous_comment?(ix)
+          ix > 0 && comment_column(ix - 1) == comment_column(ix)
+        end
+
+        def aligned_with_next_comment?(ix)
+          ix < processed_source.comments.length - 1 &&
+            comment_column(ix + 1) == comment_column(ix)
+        end
+
+        def comment_column(ix)
+          processed_source.comments[ix].loc.column
+        end
+
+        def aligned_with?(indices_to_check, token)
+          indices_to_check.each do |ix|
+            next if comment_lines.include?(ix + 1)
+            line = processed_source.lines[ix]
+            next if line.strip.empty?
+            return (aligned_words?(token, line) ||
+                    aligned_assignments?(token, line) ||
+                    aligned_same_character?(token, line))
+          end
+          false # No line to check was found.
+        end
+
+        def comment_lines
+          @comment_lines ||= processed_source.comments.map(&:loc).map(&:line)
+        end
+
+        def aligned_words?(token, line)
+          line[token.pos.column - 1, 2] =~ /\s\S/
+        end
+
+        def aligned_assignments?(token, line)
+          token.type == :tOP_ASGN &&
+            line[token.pos.column + token.text.length] == '='
+        end
+
+        def aligned_same_character?(token, line)
+          line[token.pos.column] == token.text[0]
         end
       end
     end

--- a/lib/rubocop/cop/style/optional_arguments.rb
+++ b/lib/rubocop/cop/style/optional_arguments.rb
@@ -36,7 +36,7 @@ module RuboCop
 
           optarg_positions.each do |optarg_position|
             # there can only be one group of optional arguments
-            break if  optarg_position > arg_positions.max
+            break if optarg_position > arg_positions.max
             argument = arguments[optarg_position]
             arg, = *argument
 

--- a/lib/rubocop/cop/style/while_until_do.rb
+++ b/lib/rubocop/cop/style/while_until_do.rb
@@ -16,7 +16,7 @@ module RuboCop
         def handle(node)
           length = node.loc.expression.source.lines.to_a.size
           return unless length > 1
-          return unless  node.loc.begin && node.loc.begin.is?('do')
+          return unless node.loc.begin && node.loc.begin.is?('do')
 
           add_offense(node, :begin, error_message(node.type))
         end

--- a/lib/rubocop/options.rb
+++ b/lib/rubocop/options.rb
@@ -180,6 +180,7 @@ module RuboCop
   # This module contains help texts for command line options.
   module OptionsHelp
     MAX_EXCL = RuboCop::Options::DEFAULT_MAXIMUM_EXCLUSION_ITEMS.to_s
+    # rubocop:disable Style/ExtraSpacing
     TEXT = {
       only:                 'Run only the given cop(s).',
       only_guide_cops:     ['Run only cops for rules that link to a',

--- a/spec/rubocop/cop/lint/debugger_spec.rb
+++ b/spec/rubocop/cop/lint/debugger_spec.rb
@@ -3,7 +3,7 @@
 require 'spec_helper'
 
 describe RuboCop::Cop::Lint::Debugger do
-  subject(:cop) { described_class.new  }
+  subject(:cop) { described_class.new }
 
   include_examples 'debugger', 'debugger', 'debugger'
   include_examples 'debugger', 'byebug', 'byebug'

--- a/spec/rubocop/cop/lint/useless_assignment_spec.rb
+++ b/spec/rubocop/cop/lint/useless_assignment_spec.rb
@@ -1640,7 +1640,7 @@ describe RuboCop::Cop::Lint::UselessAssignment do
   end
 
   context 'when a variable is assigned ' \
-          'and passed to a method followed by method taking block'  do
+          'and passed to a method followed by method taking block' do
     let(:source) do
       [
         "pattern = '*.rb'",

--- a/spec/rubocop/cop/offense_spec.rb
+++ b/spec/rubocop/cop/offense_spec.rb
@@ -108,7 +108,7 @@ describe RuboCop::Cop::Offense do
     end
 
     # We want a nice table layout, so we allow space inside empty hashes.
-    # rubocop:disable Style/SpaceInsideHashLiteralBraces
+    # rubocop:disable Style/SpaceInsideHashLiteralBraces, Style/ExtraSpacing
     [
       [{                           }, {                           }, 0],
 

--- a/spec/rubocop/cop/style/block_end_newline_spec.rb
+++ b/spec/rubocop/cop/style/block_end_newline_spec.rb
@@ -38,8 +38,8 @@ describe RuboCop::Cop::Style::BlockEndNewline do
   end
 
   it 'autocorrects a do/end block where the end is not on its own line' do
-    src =  ['test do',
-            '  foo end']
+    src = ['test do',
+           '  foo end']
 
     new_source = autocorrect_source(cop, src)
 
@@ -49,8 +49,8 @@ describe RuboCop::Cop::Style::BlockEndNewline do
   end
 
   it 'autocorrects a {} block where the } is not on its own line' do
-    src =  ['test {',
-            '  foo }']
+    src = ['test {',
+           '  foo }']
 
     new_source = autocorrect_source(cop, src)
 

--- a/spec/rubocop/cop/style/extra_spacing_spec.rb
+++ b/spec/rubocop/cop/style/extra_spacing_spec.rb
@@ -2,67 +2,144 @@
 
 require 'spec_helper'
 
-describe RuboCop::Cop::Style::ExtraSpacing do
-  subject(:cop) { described_class.new }
+describe RuboCop::Cop::Style::ExtraSpacing, :config do
+  subject(:cop) { described_class.new(config) }
 
-  it 'registers an offense for double extra spacing on variable assignment' do
-    inspect_source(cop, 'm    = "hello"')
-    expect(cop.offenses.size).to eq(1)
+  shared_examples 'common behavior' do
+    it 'registers an offense for alignment with token not preceded by space' do
+      # The = and the ( are on the same column, but this is not for alignment,
+      # it's just a mistake.
+      inspect_source(cop, ['website("example.org")',
+                           'name   = "Jill"'])
+      expect(cop.offenses.size).to eq(1)
+    end
+
+    it 'gives the correct line' do
+      inspect_source(cop, ['class A   < String',
+                           'end'])
+      expect(cop.offenses.first.location.line).to eq(1)
+    end
+
+    it 'registers an offense for double extra spacing on variable assignment' do
+      inspect_source(cop, 'm    = "hello"')
+      expect(cop.offenses.size).to eq(1)
+    end
+
+    it 'ignores whitespace at the beginning of the line' do
+      inspect_source(cop, '  m = "hello"')
+      expect(cop.offenses.size).to eq(0)
+    end
+
+    it 'ignores whitespace inside a string' do
+      inspect_source(cop, 'm = "hello   this"')
+      expect(cop.offenses.size).to eq(0)
+    end
+
+    it 'ignores trailing whitespace' do
+      inspect_source(cop, ['      class Benchmarker < Performer     ',
+                           '      end'])
+      expect(cop.offenses.size).to eq(0)
+    end
+
+    it 'registers an offense on class inheritance' do
+      inspect_source(cop, ['class A   < String',
+                           'end'])
+      expect(cop.offenses.size).to eq(1)
+    end
+
+    it 'auto-corrects a line indented with mixed whitespace' do
+      new_source = autocorrect_source(cop, ['website("example.org")',
+                                            'name    = "Jill"'])
+      expect(new_source).to eq(['website("example.org")',
+                                'name = "Jill"'].join("\n"))
+    end
+
+    it 'auto-corrects the class inheritance' do
+      new_source = autocorrect_source(cop, ['class A   < String',
+                                            'end'])
+      expect(new_source).to eq(['class A < String',
+                                'end'].join("\n"))
+    end
   end
 
-  it 'ignores whitespace at the beginning of the line' do
-    inspect_source(cop, '  m = "hello"')
-    expect(cop.offenses.size).to eq(0)
-  end
-
-  it 'ignores whitespace inside a string' do
-    inspect_source(cop, 'm = "hello   this"')
-    expect(cop.offenses.size).to eq(0)
-  end
-
-  it 'does not permit you to line up assignments' do
-    inspect_source(cop, [
+  SOURCES = {
+    'lining up assignments' => [
       'website = "example.org"',
       'name    = "Jill"'
-    ])
-    expect(cop.offenses.size).to eq(1)
+    ],
+
+    'lining up assignments with empty lines and comments in between' => [
+      'a   += 1',
+      '',
+      '# Comment',
+      'aa   = 2',
+      'bb   = 3',
+      '',
+      'a  ||= 1'
+    ],
+
+    'aligning with the same character' => [
+      '      y, m = (year * 12 + (mon - 1) + n).divmod(12)',
+      '      m,   = (m + 1)                    .divmod(1)'
+    ],
+
+    'lining up different kinds of assignments' => [
+      'type_name ||= value.class.name if value',
+      'type_name   = type_name.to_s   if type_name',
+      '',
+      'type_name  = value.class.name if     value',
+      'type_name += type_name.to_s   unless type_name',
+      '',
+      'a  += 1',
+      'aa -= 2'
+    ],
+
+    'aligning comments on non-adjacent lines' => [
+      %(include_examples 'aligned',   'var = until',  'test'),
+      '',
+      %(include_examples 'unaligned', "var = if",     'test')
+    ],
+
+    'aligning tokens with empty line between' => [
+      'unless nochdir',
+      '  Dir.chdir "/"    # Release old working directory.',
+      'end',
+      '',
+      'File.umask 0000    # Ensure sensible umask.'
+    ]
+  }
+
+  context 'when AllowForAlignment is true' do
+    let(:cop_config) { { 'AllowForAlignment' => true } }
+
+    include_examples 'common behavior'
+
+    context 'with extra spacing for alignment purposes' do
+      SOURCES.each do |reason, src|
+        context "such as #{reason}" do
+          it 'allows it' do
+            inspect_source(cop, src)
+            expect(cop.offenses).to be_empty
+          end
+        end
+      end
+    end
   end
 
-  it 'gives the correct line' do
-    inspect_source(cop, [
-      'website = "example.org"',
-      'name    = "Jill"'
-    ])
-    expect(cop.offenses.first.location.line).to eq(2)
-  end
+  context 'when AllowForAlignment is false' do
+    let(:cop_config) { { 'AllowForAlignment' => false } }
 
-  it 'registers an offense on class inheritance' do
-    inspect_source(cop, [
-      'class A   < String',
-      'end'
-    ])
-    expect(cop.offenses.size).to eq(1)
-  end
+    include_examples 'common behavior'
 
-  it 'auto-corrects a line indented with mixed whitespace' do
-    new_source = autocorrect_source(cop, [
-      'website = "example.org"',
-      'name    = "Jill"'
-    ])
-    expect(new_source).to eq([
-      'website = "example.org"',
-      'name = "Jill"'
-    ].join("\n"))
-  end
-
-  it 'auto-corrects the class inheritance' do
-    new_source = autocorrect_source(cop, [
-      'class A   < String',
-      'end'
-    ])
-    expect(new_source).to eq([
-      'class A < String',
-      'end'
-    ].join("\n"))
+    context 'with extra spacing for alignment purposes' do
+      SOURCES.each do |reason, src|
+        context "such as #{reason}" do
+          it 'registers offense(s)' do
+            inspect_source(cop, src)
+            expect(cop.offenses).not_to be_empty
+          end
+        end
+      end
+    end
   end
 end

--- a/spec/rubocop/cop/style/if_unless_modifier_spec.rb
+++ b/spec/rubocop/cop/style/if_unless_modifier_spec.rb
@@ -22,7 +22,7 @@ describe RuboCop::Cop::Style::IfUnlessModifier do
     let(:condition) { 'a' * 38 }
     let(:body) { 'b' * 38 }
 
-    it 'registers an offense'  do
+    it 'registers an offense' do
       # This if statement fits exactly on one line if written as a
       # modifier.
       expect("#{body} if #{condition}".length).to eq(80)
@@ -108,7 +108,7 @@ describe RuboCop::Cop::Style::IfUnlessModifier do
        'end']
     end
 
-    it 'registers an offense'  do
+    it 'registers an offense' do
       inspect_source(cop, source)
       expect(cop.offenses.size).to eq(1)
     end

--- a/spec/rubocop/cop/style/space_before_modifier_keyword_spec.rb
+++ b/spec/rubocop/cop/style/space_before_modifier_keyword_spec.rb
@@ -11,19 +11,7 @@ describe RuboCop::Cop::Style::SpaceBeforeModifierKeyword do
                          'a = 42unless a == 2',
                          'a = [1,2,3]unless a == 2',
                          'a = {:a => "b"}if a == 2'])
-    expect(cop.highlights).to eq(%w(if if unless unless if))
-    expect(cop.messages).to eq(['Put a space before the modifier keyword.'] * 5)
-  end
-
-  it 'registers an offense for extra space before if/unless' do
-    inspect_source(cop, ['(a = 3)  if a == 2',
-                         'a = "test"   if a == 2',
-                         'a = 42  unless a == 2',
-                         'a = [1,2,3]   unless a == 2',
-                         'a = {:a => "b"}  if a == 2'])
-    expect(cop.highlights).to eq(['  ', '   ', '  ', '   ', '  '])
-    expect(cop.messages)
-      .to eq(['Put only one space before the modifier keyword.'] * 5)
+    expect(cop.highlights).to eq([')', '"', '2', ']', '}'])
   end
 
   it 'registers an offense for missing space before while/until' do
@@ -32,16 +20,7 @@ describe RuboCop::Cop::Style::SpaceBeforeModifierKeyword do
                          'a = 42while b',
                          'a = [1,2,3]until b',
                          'a = {:a => "b"}while b'])
-    expect(cop.highlights).to eq(%w(while until while until while))
-  end
-
-  it 'registers an offense for extra space before while/until' do
-    inspect_source(cop, ['(a = 3)  while b',
-                         'a = "test"  until b',
-                         'a = 42  while b',
-                         'a = [1,2,3]  until b',
-                         'a = {:a => "b"}  while b'])
-    expect(cop.highlights).to eq(['  '] * 5)
+    expect(cop.highlights).to eq([')', '"', '2', ']', '}'])
   end
 
   it 'accepts modifiers with preceding space' do
@@ -49,16 +28,6 @@ describe RuboCop::Cop::Style::SpaceBeforeModifierKeyword do
                          'a = "test" unless b',
                          'a = 42 while b',
                          'a = [1,2,3] until b'])
-    expect(cop.offenses).to be_empty
-  end
-
-  it 'accepts non-modifier if' do
-    inspect_source(cop, ['    if space_length == 0',
-                         '      add_offense(kw, kw, MSG_MISSING)',
-                         '    elsif space_length > 1',
-                         '      space = kw_with_space.resize(space_length)',
-                         '      add_offense(space, space, MSG_EXTRA)',
-                         '    end'])
     expect(cop.offenses).to be_empty
   end
 
@@ -87,29 +56,6 @@ describe RuboCop::Cop::Style::SpaceBeforeModifierKeyword do
                                           'a = 42while b',
                                           'a = [1,2,3]until b',
                                           'a = {:a => "b"}while b'])
-    expect(new_source).to eq(['(a = 3) if a == 2',
-                              'a = "test" if a == 2',
-                              'a = 42 unless a == 2',
-                              'a = [1,2,3] unless a == 2',
-                              'a = {:a => "b"} if a == 2',
-                              '(a = 3) while b',
-                              'a = "test" until b',
-                              'a = 42 while b',
-                              'a = [1,2,3] until b',
-                              'a = {:a => "b"} while b'].join("\n"))
-  end
-
-  it 'auto-corrects extra space' do
-    new_source = autocorrect_source(cop, ['(a = 3)  if a == 2',
-                                          'a = "test"   if a == 2',
-                                          'a = 42  unless a == 2',
-                                          'a = [1,2,3]   unless a == 2',
-                                          'a = {:a => "b"}  if a == 2',
-                                          '(a = 3)   while b',
-                                          'a = "test"  until b',
-                                          'a = 42   while b',
-                                          'a = [1,2,3]  until b',
-                                          'a = {:a => "b"}   while b'])
     expect(new_source).to eq(['(a = 3) if a == 2',
                               'a = "test" if a == 2',
                               'a = 42 unless a == 2',

--- a/spec/rubocop/cop/style/while_until_modifier_spec.rb
+++ b/spec/rubocop/cop/style/while_until_modifier_spec.rb
@@ -52,7 +52,7 @@ describe RuboCop::Cop::Style::WhileUntilModifier do
        'end']
     end
 
-    it 'registers an offense'  do
+    it 'registers an offense' do
       inspect_source(cop, source)
       expect(cop.offenses.size).to eq(1)
     end

--- a/spec/rubocop/formatter/json_formatter_spec.rb
+++ b/spec/rubocop/formatter/json_formatter_spec.rb
@@ -122,7 +122,7 @@ module RuboCop
       end
 
       it 'sets value of #hash_for_location for :location key' do
-        location_hash =  { line: 3, column: 6, length: 1 }
+        location_hash = { line: 3, column: 6, length: 1 }
         expect(hash[:location]).to eq(location_hash)
       end
     end

--- a/spec/rubocop/rake_task_spec.rb
+++ b/spec/rubocop/rake_task_spec.rb
@@ -63,7 +63,7 @@ describe RuboCop::RakeTask do
 
       cli = double('cli', run: 0)
       allow(RuboCop::CLI).to receive(:new) { cli }
-      options = ['--format', 'files',  '--display-cop-names', 'lib/**/*.rb']
+      options = ['--format', 'files', '--display-cop-names', 'lib/**/*.rb']
       expect(cli).to receive(:run).with(options)
 
       Rake::Task['rubocop'].execute
@@ -112,7 +112,7 @@ describe RuboCop::RakeTask do
 
         cli = double('cli', run: 0)
         allow(RuboCop::CLI).to receive(:new) { cli }
-        options = ['--auto-correct', '--format', 'files',  '-D', 'lib/**/*.rb']
+        options = ['--auto-correct', '--format', 'files', '-D', 'lib/**/*.rb']
         expect(cli).to receive(:run).with(options)
 
         Rake::Task['rubocop:auto_correct'].execute


### PR DESCRIPTION
For #2035. Make `ExtraSpacing` enabled by default, but add a configuration parameter that can be used to retain the old strict checking of extra spacing.

The changes made to `SpaceBeforeModifierKeyword` in #2027 are not needed if we make this change, so the corresponding commit is reverted.