### PR TITLE
Keep line breaks in place on WordArray autocorrect

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,7 @@
 * [#2006](https://github.com/bbatsov/rubocop/issues/2006): Fix crash in `Style/FirstParameterIndentation` in case of nested offenses. ([@unmanbearpig][])
 * [#2059](https://github.com/bbatsov/rubocop/issues/2059): Don't check for trivial accessors in modules. ([@bbatsov][])
 * Add proper punctuation to the end of offense messages, where it is missing. ([@lumeet][])
+* [#2071](https://github.com/bbatsov/rubocop/pull/2071): Keep line breaks in place on WordArray autocorrect.([@unmanbearpig][])
 
 ## 0.32.1 (24/06/2015)
 

--- a/lib/rubocop/cop/style/word_array.rb
+++ b/lib/rubocop/cop/style/word_array.rb
@@ -61,12 +61,24 @@ module RuboCop
 
         def autocorrect(node)
           @interpolated = false
-          contents = node.children.map { |n| source_for(n) }.join(' ')
+          contents = autocorrect_words(node.children, node.loc.line)
+
           char = @interpolated ? 'W' : 'w'
 
           lambda do |corrector|
             corrector.replace(node.loc.expression, "%#{char}(#{contents})")
           end
+        end
+
+        def autocorrect_words(word_nodes, base_line_number)
+          previous_node_line_number = base_line_number
+          word_nodes.map do |node|
+            number_of_line_breaks = node.loc.line - previous_node_line_number
+            line_breaks = "\n" * number_of_line_breaks
+            previous_node_line_number = node.loc.line
+
+            line_breaks + source_for(node)
+          end.join(' ')
         end
 
         def source_for(str_node)

--- a/spec/rubocop/cop/style/word_array_spec.rb
+++ b/spec/rubocop/cop/style/word_array_spec.rb
@@ -101,6 +101,14 @@ describe RuboCop::Cop::Style::WordArray, :config do
     expect(new_source).to eq('%W(one two \n \t)')
   end
 
+  it 'keeps the line breaks in place after auto-correct' do
+    new_source = autocorrect_source(cop,
+                                    ["['one',",
+                                     "'two', 'three']"])
+    expect(new_source).to eq(['%w(one ',
+                              'two three)'].join("\n"))
+  end
+
   context 'with a custom WordRegex configuration' do
     let(:cop_config) { { 'MinSize' => 0, 'WordRegex' => /\A[\w@.]+\z/ } }
 


### PR DESCRIPTION
I've found a problem that when I have an array of words that spans
multiple lines

```ruby
array = ['first_word', 'second_word', 'third_word', 'fourth_word',
         'fifth_word', 'sixth_word', 'seveth_word']
```

Auto-correct replaces it with %w() syntax, which is fine, but it also
removes all of the line breaks, which makes the line too long and forces
me to fix it manually.

I've made Syntax/WordArray take into account existing line breaks when
it auto-corrects it.