### PR TITLE
Add missing periods to offense messages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,7 @@
 * [#2045](https://github.com/bbatsov/rubocop/issues/2045): Fix crash in `Style/IndentationWidth` when using `private_class_method def self.foo` syntax. ([@unmanbearpig][])
 * [#2006](https://github.com/bbatsov/rubocop/issues/2006): Fix crash in `Style/FirstParameterIndentation` in case of nested offenses. ([@unmanbearpig][])
 * [#2059](https://github.com/bbatsov/rubocop/issues/2059): Don't check for trivial accessors in modules. ([@bbatsov][])
+* Add proper punctuation to the end of offense messages, where it is missing. ([@lumeet][])
 
 ## 0.32.1 (24/06/2015)
 

--- a/lib/rubocop/cop/lint/block_alignment.rb
+++ b/lib/rubocop/cop/lint/block_alignment.rb
@@ -14,7 +14,7 @@ module RuboCop
       class BlockAlignment < Cop
         include CheckAssignment
 
-        MSG = '`end` at %d, %d is not aligned with `%s` at %d, %d%s'
+        MSG = '`end` at %d, %d is not aligned with `%s` at %d, %d%s.'
 
         def on_block(node)
           return if ignored_node?(node)

--- a/lib/rubocop/cop/lint/def_end_alignment.rb
+++ b/lib/rubocop/cop/lint/def_end_alignment.rb
@@ -20,7 +20,7 @@ module RuboCop
         include OnMethodDef
         include EndKeywordAlignment
 
-        MSG = '`end` at %d, %d is not aligned with `%s` at %d, %d'
+        MSG = '`end` at %d, %d is not aligned with `%s` at %d, %d.'
 
         def on_method_def(node, _method_name, _args, _body)
           check_offset_of_node(node)

--- a/lib/rubocop/cop/mixin/end_keyword_alignment.rb
+++ b/lib/rubocop/cop/mixin/end_keyword_alignment.rb
@@ -6,7 +6,7 @@ module RuboCop
     module EndKeywordAlignment
       include ConfigurableEnforcedStyle
 
-      MSG = '`end` at %d, %d is not aligned with `%s` at %d, %d'
+      MSG = '`end` at %d, %d is not aligned with `%s` at %d, %d.'
 
       private
 

--- a/lib/rubocop/cop/performance/flat_map.rb
+++ b/lib/rubocop/cop/performance/flat_map.rb
@@ -18,7 +18,7 @@ module RuboCop
         MSG = 'Use `flat_map` instead of `%s...%s`.'
         FLATTEN_MULTIPLE_LEVELS = ' Beware, `flat_map` only flattens 1 level ' \
                                   'and `flatten` can be used to flatten ' \
-                                  'multiple levels'
+                                  'multiple levels.'
         FLATTEN = [:flatten, :flatten!]
 
         def on_send(node)

--- a/lib/rubocop/cop/style/percent_literal_delimiters.rb
+++ b/lib/rubocop/cop/style/percent_literal_delimiters.rb
@@ -33,7 +33,7 @@ module RuboCop
           delimiters = preferred_delimiters(type)
 
           "`#{type}`-literals should be delimited by " \
-          "`#{delimiters[0]}` and `#{delimiters[1]}`"
+          "`#{delimiters[0]}` and `#{delimiters[1]}`."
         end
 
         private

--- a/spec/rubocop/cli_spec.rb
+++ b/spec/rubocop/cli_spec.rb
@@ -1779,7 +1779,7 @@ describe RuboCop::CLI, :isolated_environment do
                       '  if something',
                       '  ^^',
                       'example3.rb:5:5: W: end at 5, 4 is not aligned ' \
-                      'with if at 3, 2',
+                      'with if at 3, 2.',
                       '    end',
                       '    ^^^',
                       '',
@@ -2928,8 +2928,8 @@ describe RuboCop::CLI, :isolated_environment do
       cli.run(['--format', 'simple', '-c', 'rubocop.yml', 'example1.rb'])
       expect($stdout.string)
         .to eq(['== example1.rb ==',
-                'C:  2:  6: %w-literals should be delimited by [ and ]',
-                'C:  3:  6: %q-literals should be delimited by ( and )',
+                'C:  2:  6: %w-literals should be delimited by [ and ].',
+                'C:  3:  6: %q-literals should be delimited by ( and ).',
                 'C:  3:  6: Use %q only for strings that contain both single ' \
                 'quotes and double quotes.',
                 '',

--- a/spec/rubocop/cop/lint/block_alignment_spec.rb
+++ b/spec/rubocop/cop/lint/block_alignment_spec.rb
@@ -12,7 +12,7 @@ describe RuboCop::Cop::Lint::BlockAlignment do
                       '  end'
                      ])
       expect(cop.messages)
-        .to eq(['`end` at 2, 2 is not aligned with `test do` at 1, 0'])
+        .to eq(['`end` at 2, 2 is not aligned with `test do` at 1, 0.'])
     end
 
     it 'auto-corrects alignment' do
@@ -32,7 +32,7 @@ describe RuboCop::Cop::Lint::BlockAlignment do
                       '  end'
                      ])
       expect(cop.messages)
-        .to eq(['`end` at 2, 2 is not aligned with `test do |ala|` at 1, 0'])
+        .to eq(['`end` at 2, 2 is not aligned with `test do |ala|` at 1, 0.'])
     end
 
     it 'auto-corrects alignment' do
@@ -82,7 +82,7 @@ describe RuboCop::Cop::Lint::BlockAlignment do
                      ])
       expect(cop.messages)
         .to eq(['`end` at 2, 4 is not aligned with' \
-                ' `a = b = c = test do |ala|` at 1, 0'])
+                ' `a = b = c = test do |ala|` at 1, 0.'])
     end
 
     it 'accepts end aligned with the first variable' do
@@ -123,7 +123,7 @@ describe RuboCop::Cop::Lint::BlockAlignment do
                    ])
     expect(cop.messages)
       .to eq(['`end` at 2, 2 is not aligned with `variable = test do |ala|`' \
-              ' at 1, 0'])
+              ' at 1, 0.'])
   end
 
   context 'when the block is defined on the next line' do
@@ -146,7 +146,7 @@ describe RuboCop::Cop::Lint::BlockAlignment do
                      ])
       expect(cop.messages)
         .to eq(['`end` at 4, 0 is not aligned with' \
-                ' `a_long_method_that_dont_fit_on_the_line do |v|` at 2, 2'])
+                ' `a_long_method_that_dont_fit_on_the_line do |v|` at 2, 2.'])
     end
 
     it 'auto-corrects alignment' do
@@ -202,11 +202,11 @@ describe RuboCop::Cop::Lint::BlockAlignment do
       inspect_source(cop, src)
       expect(cop.messages)
         .to eq(['`end` at 5, 8 is not aligned with `bar.get_stuffs` at 2, 2' \
-                ' or `.reject do |stuff|` at 3, 6',
+                ' or `.reject do |stuff|` at 3, 6.',
                 '`end` at 7, 4 is not aligned with `bar.get_stuffs` at 2, 2' \
-                ' or `end.select do |stuff|` at 5, 8',
+                ' or `end.select do |stuff|` at 5, 8.',
                 '`end` at 10, 8 is not aligned with `bar.get_stuffs` at 2, 2' \
-                ' or `.select do |stuff|` at 8, 6'])
+                ' or `.select do |stuff|` at 8, 6.'])
     end
 
     # Example from issue 393 of bbatsov/rubocop on github:
@@ -294,7 +294,7 @@ describe RuboCop::Cop::Lint::BlockAlignment do
       inspect_source(cop, src)
       expect(cop.messages)
         .to eq(['`end` at 4, 4 is not aligned with `e,` at 1, 0 or' \
-                ' `f = [5, 6].map do |i|` at 2, 0'])
+                ' `f = [5, 6].map do |i|` at 2, 0.'])
     end
 
     it 'can not auto-correct' do
@@ -324,7 +324,7 @@ describe RuboCop::Cop::Lint::BlockAlignment do
                    ])
     expect(cop.messages)
       .to eq(['`end` at 2, 2 is not aligned with `@variable = test do |ala|`' \
-              ' at 1, 0'])
+              ' at 1, 0.'])
   end
 
   it 'accepts end aligned with a class variable' do
@@ -342,7 +342,7 @@ describe RuboCop::Cop::Lint::BlockAlignment do
                    ])
     expect(cop.messages)
       .to eq(['`end` at 2, 2 is not aligned with `@@variable = test do |ala|`' \
-              ' at 1, 0'])
+              ' at 1, 0.'])
   end
 
   it 'accepts end aligned with a global variable' do
@@ -360,7 +360,7 @@ describe RuboCop::Cop::Lint::BlockAlignment do
                    ])
     expect(cop.messages)
       .to eq(['`end` at 2, 2 is not aligned with `$variable = test do |ala|`' \
-              ' at 1, 0'])
+              ' at 1, 0.'])
   end
 
   it 'accepts end aligned with a constant' do
@@ -378,7 +378,7 @@ describe RuboCop::Cop::Lint::BlockAlignment do
                    ])
     expect(cop.messages)
       .to eq(['`end` at 2, 2 is not aligned with' \
-              ' `Module::CONSTANT = test do |ala|` at 1, 0'])
+              ' `Module::CONSTANT = test do |ala|` at 1, 0.'])
   end
 
   it 'accepts end aligned with a method call' do
@@ -398,7 +398,7 @@ describe RuboCop::Cop::Lint::BlockAlignment do
                    ])
     expect(cop.messages)
       .to eq(['`end` at 3, 2 is not aligned with' \
-              ' `parser.children << lambda do |token|` at 1, 0'])
+              ' `parser.children << lambda do |token|` at 1, 0.'])
   end
 
   it 'accepts end aligned with a method call with arguments' do
@@ -419,7 +419,7 @@ describe RuboCop::Cop::Lint::BlockAlignment do
                    ])
     expect(cop.messages)
       .to eq(['`end` at 3, 2 is not aligned with' \
-              ' `@h[:f] = f.each_pair.map do |f, v|` at 1, 0'])
+              ' `@h[:f] = f.each_pair.map do |f, v|` at 1, 0.'])
   end
 
   it 'does not raise an error for nested block in a method call' do
@@ -446,7 +446,7 @@ describe RuboCop::Cop::Lint::BlockAlignment do
                    ])
     expect(cop.messages)
       .to eq(['`end` at 3, 2 is not aligned with `arr.all? do |o|` at 1, 7 or' \
-              ' `expect(arr.all? do |o|` at 1, 0'])
+              ' `expect(arr.all? do |o|` at 1, 0.'])
   end
 
   it 'accepts end aligned with an op-asgn (+=, -=)' do
@@ -465,7 +465,7 @@ describe RuboCop::Cop::Lint::BlockAlignment do
                     '  end'
                    ])
     expect(cop.messages)
-      .to eq(['`end` at 3, 2 is not aligned with `rb` at 1, 0'])
+      .to eq(['`end` at 3, 2 is not aligned with `rb` at 1, 0.'])
   end
 
   it 'accepts end aligned with an and-asgn (&&=)' do
@@ -483,7 +483,7 @@ describe RuboCop::Cop::Lint::BlockAlignment do
                    ])
     expect(cop.messages)
       .to eq(['`end` at 2, 2 is not aligned with `variable &&= test do |ala|`' \
-              ' at 1, 0'])
+              ' at 1, 0.'])
   end
 
   it 'accepts end aligned with an or-asgn (||=)' do
@@ -501,7 +501,7 @@ describe RuboCop::Cop::Lint::BlockAlignment do
                    ])
     expect(cop.messages)
       .to eq(['`end` at 2, 2 is not aligned with `variable ||= test do |ala|`' \
-              ' at 1, 0'])
+              ' at 1, 0.'])
   end
 
   it 'accepts end aligned with a mass assignment' do
@@ -528,7 +528,7 @@ describe RuboCop::Cop::Lint::BlockAlignment do
                     '  end'
                    ])
     expect(cop.messages)
-      .to eq(['`end` at 3, 2 is not aligned with `var1, var2` at 1, 0'])
+      .to eq(['`end` at 3, 2 is not aligned with `var1, var2` at 1, 0.'])
   end
 
   context 'when multiple similar-looking blocks have misaligned ends' do

--- a/spec/rubocop/cop/lint/def_end_alignment_spec.rb
+++ b/spec/rubocop/cop/lint/def_end_alignment_spec.rb
@@ -42,7 +42,7 @@ describe RuboCop::Cop::Lint::DefEndAlignment, :config do
         inspect_source(cop, source)
         expect(cop.offenses.size).to eq(1)
         expect(cop.messages.first)
-          .to eq('`end` at 7, 4 is not aligned with `foo def` at 5, 4')
+          .to eq('`end` at 7, 4 is not aligned with `foo def` at 5, 4.')
         expect(cop.highlights.first).to eq('end')
         expect(cop.config_to_allow_offenses).to eq('Enabled' => false)
       end
@@ -85,7 +85,7 @@ describe RuboCop::Cop::Lint::DefEndAlignment, :config do
           inspect_source(cop, source)
           expect(cop.offenses.size).to eq(1)
           expect(cop.messages.first)
-            .to eq('`end` at 3, 0 is not aligned with `def` at 1, 4')
+            .to eq('`end` at 3, 0 is not aligned with `def` at 1, 4.')
           expect(cop.highlights.first).to eq('end')
           expect(cop.config_to_allow_offenses).to eq('Enabled' => false)
         end

--- a/spec/rubocop/cop/lint/end_alignment_spec.rb
+++ b/spec/rubocop/cop/lint/end_alignment_spec.rb
@@ -49,7 +49,7 @@ describe RuboCop::Cop::Lint::EndAlignment, :config do
       inspect_source(cop, source)
       expect(cop.offenses.size).to eq(1)
       expect(cop.messages.first)
-        .to eq('`end` at 6, 0 is not aligned with `if` at 4, 4')
+        .to eq('`end` at 6, 0 is not aligned with `if` at 4, 4.')
       expect(cop.highlights.first).to eq('end')
       expect(cop.config_to_allow_offenses).to eq('Enabled' => false)
     end
@@ -75,7 +75,7 @@ describe RuboCop::Cop::Lint::EndAlignment, :config do
       inspect_source(cop, source)
       expect(cop.offenses.size).to eq(1)
       expect(cop.messages.first)
-        .to eq('`end` at 2, 7 is not aligned with `module` at 1, 0')
+        .to eq('`end` at 2, 7 is not aligned with `module` at 1, 0.')
       expect(cop.highlights.first).to eq('end')
     end
 

--- a/spec/rubocop/cop/performance/flat_map_spec.rb
+++ b/spec/rubocop/cop/performance/flat_map_spec.rb
@@ -76,7 +76,7 @@ describe RuboCop::Cop::Performance::FlatMap, :config do
         expect(cop.messages)
           .to eq(["Use `flat_map` instead of `map...#{flatten}`. " \
                'Beware, `flat_map` only flattens 1 level and `flatten` ' \
-               'can be used to flatten multiple levels'])
+               'can be used to flatten multiple levels.'])
       end
 
       it "will not correct #{method}..#{flatten} to flat_map" do

--- a/spec/rubocop/cop/style/percent_literal_delimiters_spec.rb
+++ b/spec/rubocop/cop/style/percent_literal_delimiters_spec.rb
@@ -30,7 +30,7 @@ describe RuboCop::Cop::Style::PercentLiteralDelimiters, :config do
     it 'registers an offense for other delimiters' do
       inspect_source(cop, '%(string)')
       expect(cop.messages).to eq([
-        '`%`-literals should be delimited by `[` and `]`'
+        '`%`-literals should be delimited by `[` and `]`.'
       ])
     end
 
@@ -56,7 +56,7 @@ describe RuboCop::Cop::Style::PercentLiteralDelimiters, :config do
     it 'registers an offense for other delimiters' do
       inspect_source(cop, '%q(string)')
       expect(cop.messages).to eq([
-        '`%q`-literals should be delimited by `[` and `]`'
+        '`%q`-literals should be delimited by `[` and `]`.'
       ])
     end
 
@@ -76,7 +76,7 @@ describe RuboCop::Cop::Style::PercentLiteralDelimiters, :config do
     it 'registers an offense for other delimiters' do
       inspect_source(cop, '%Q(string)')
       expect(cop.messages).to eq([
-        '`%Q`-literals should be delimited by `[` and `]`'
+        '`%Q`-literals should be delimited by `[` and `]`.'
       ])
     end
 
@@ -102,7 +102,7 @@ describe RuboCop::Cop::Style::PercentLiteralDelimiters, :config do
     it 'registers an offense for other delimiters' do
       inspect_source(cop, '%w(some words)')
       expect(cop.messages).to eq([
-        '`%w`-literals should be delimited by `[` and `]`'
+        '`%w`-literals should be delimited by `[` and `]`.'
       ])
     end
 
@@ -122,7 +122,7 @@ describe RuboCop::Cop::Style::PercentLiteralDelimiters, :config do
     it 'registers an offense for other delimiters' do
       inspect_source(cop, '%W(some words)')
       expect(cop.messages).to eq([
-        '`%W`-literals should be delimited by `[` and `]`'
+        '`%W`-literals should be delimited by `[` and `]`.'
       ])
     end
 
@@ -148,7 +148,7 @@ describe RuboCop::Cop::Style::PercentLiteralDelimiters, :config do
     it 'registers an offense for other delimiters' do
       inspect_source(cop, '%r(regexp)')
       expect(cop.messages).to eq([
-        '`%r`-literals should be delimited by `[` and `]`'
+        '`%r`-literals should be delimited by `[` and `]`.'
       ])
     end
 
@@ -174,7 +174,7 @@ describe RuboCop::Cop::Style::PercentLiteralDelimiters, :config do
     it 'registers an offense for other delimiters' do
       inspect_source(cop, '%i(some symbols)')
       expect(cop.messages).to eq([
-        '`%i`-literals should be delimited by `[` and `]`'
+        '`%i`-literals should be delimited by `[` and `]`.'
       ])
     end
   end
@@ -188,7 +188,7 @@ describe RuboCop::Cop::Style::PercentLiteralDelimiters, :config do
     it 'registers an offense for other delimiters' do
       inspect_source(cop, '%s(symbol)')
       expect(cop.messages).to eq([
-        '`%s`-literals should be delimited by `[` and `]`'
+        '`%s`-literals should be delimited by `[` and `]`.'
       ])
     end
   end
@@ -202,7 +202,7 @@ describe RuboCop::Cop::Style::PercentLiteralDelimiters, :config do
     it 'registers an offense for other delimiters' do
       inspect_source(cop, '%x(command)')
       expect(cop.messages).to eq([
-        '`%x`-literals should be delimited by `[` and `]`'
+        '`%x`-literals should be delimited by `[` and `]`.'
       ])
     end
 


### PR DESCRIPTION
Just added a couple of missing periods. I guess this is how it's supposed to be.