### PR TITLE
Properly correct percent literal delimiters with escape characters in them

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,7 @@
 * [#2059](https://github.com/bbatsov/rubocop/issues/2059): Don't check for trivial accessors in modules. ([@bbatsov][])
 * Add proper punctuation to the end of offense messages, where it is missing. ([@lumeet][])
 * [#2071](https://github.com/bbatsov/rubocop/pull/2071): Keep line breaks in place on WordArray autocorrect.([@unmanbearpig][])
+* [#2075](https://github.com/bbatsov/rubocop/pull/2075): Properly correct `Style/PercentLiteralDelimiters` with escape characters in them. ([@rrosenblum][])
 
 ## 0.32.1 (24/06/2015)
 

--- a/lib/rubocop/cop/style/percent_literal_delimiters.rb
+++ b/lib/rubocop/cop/style/percent_literal_delimiters.rb
@@ -43,20 +43,9 @@ module RuboCop
 
           opening_delimiter, closing_delimiter = preferred_delimiters(type)
 
-          first_child, *_middle, last_child = *node
-          opening_newline = new_line(node.loc.begin, first_child)
-          expression_indentation = leading_whitespace(first_child, :expression)
-          closing_newline = new_line(node.loc.end, last_child)
-          closing_indentation = leading_whitespace(node, :end)
-          expression, reg_opt = *contents(node)
-
-          corrected_source =
-            type + opening_delimiter + opening_newline +
-            expression_indentation + expression + closing_newline +
-            closing_indentation + closing_delimiter + reg_opt
-
           lambda do |corrector|
-            corrector.replace(node.loc.expression, corrected_source)
+            corrector.replace(node.loc.begin, "#{type}#{opening_delimiter}")
+            corrector.replace(node.loc.end, closing_delimiter)
           end
         end
 
@@ -70,49 +59,6 @@ module RuboCop
 
         def preferred_delimiters(type)
           cop_config['PreferredDelimiters'][type].split(//)
-        end
-
-        def leading_whitespace(object, part)
-          case object
-          when String
-            ''
-          when NilClass
-            ''
-          when Parser::AST::Node
-            part_range = object.loc.send(part)
-            left_of_part = part_range.source_line[0...part_range.column]
-            /^(\s*)$/.match(left_of_part) ? left_of_part : ''
-          else
-            fail "Unsupported object #{object}"
-          end
-        end
-
-        def contents(node)
-          first_child, *middle, last_child = *node
-          last_child ||= first_child
-          if node.type == :regexp
-            *_, next_to_last_child = *middle
-            next_to_last_child ||= first_child
-            expression = source(node, first_child, next_to_last_child)
-            reg_opt = last_child.loc.expression.source
-          else
-            expression = if first_child.is_a?(Parser::AST::Node)
-                           source(node, first_child, last_child)
-                         else
-                           first_child.to_s
-                         end
-            reg_opt = ''
-          end
-
-          [expression, reg_opt]
-        end
-
-        def source(node, begin_node, end_node)
-          Parser::Source::Range.new(
-            node.loc.expression.source_buffer,
-            begin_node.loc.expression.begin_pos,
-            end_node.loc.expression.end_pos
-          ).source
         end
 
         def uses_preferred_delimiter?(node, type)
@@ -132,15 +78,6 @@ module RuboCop
           elsif node.respond_to?(:type) && node.type == :str
             node.loc.expression.source
           end
-        end
-
-        def new_line(range, child_node)
-          same_line?(range, child_node) ? '' : "\n"
-        end
-
-        def same_line?(range, child_node)
-          !child_node.is_a?(Parser::AST::Node) ||
-            range.begin.line == child_node.loc.line
         end
       end
     end

--- a/spec/rubocop/cop/style/percent_literal_delimiters_spec.rb
+++ b/spec/rubocop/cop/style/percent_literal_delimiters_spec.rb
@@ -317,5 +317,32 @@ describe RuboCop::Cop::Style::PercentLiteralDelimiters, :config do
       new_source = autocorrect_source(cop, original_source)
       expect(new_source).to eq(corrected_source)
     end
+
+    shared_examples :escape_characters do |percent_literal|
+      it "corrects #{percent_literal} with \\n in it" do
+        new_source = autocorrect_source(cop, "#{percent_literal}{\n}")
+
+        expect(new_source).to eq("#{percent_literal}[\n]")
+      end
+
+      it "corrects #{percent_literal} with \\t in it" do
+        new_source = autocorrect_source(cop, "#{percent_literal}{\t}")
+
+        expect(new_source).to eq("#{percent_literal}[\t]")
+      end
+    end
+
+    it_behaves_like(:escape_characters, '%')
+    it_behaves_like(:escape_characters, '%q')
+    it_behaves_like(:escape_characters, '%Q')
+    it_behaves_like(:escape_characters, '%s')
+    it_behaves_like(:escape_characters, '%w')
+    it_behaves_like(:escape_characters, '%W')
+    it_behaves_like(:escape_characters, '%x')
+    it_behaves_like(:escape_characters, '%r')
+
+    context 'symbol array', ruby_greater_than_or_equal: 2.0 do
+      it_behaves_like(:escape_characters, '%i')
+    end
   end
 end


### PR DESCRIPTION
I had an issue where something like `%{\n}` would be corrected to
```ruby
%(
)
```
While trying to fix this, it became easier to replace the delimiter than to figure proper escaping. I am pretty happy with the simplicity of this fix.