### PR TITLE
[Fix #2079] Circular argument reference cop issue

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@
 * [#2001](https://github.com/bbatsov/rubocop/issues/2001): New cop `Style/InitialIndentation` checks for indentation of the first non-blank non-comment line in a file. ([@jonas054][])
 * [#2060](https://github.com/bbatsov/rubocop/issues/2060): New cop `Style/RescueEnsureAlignment` checks for bad alignment of `rescue` and `ensure` keywords. ([@lumeet][])
 * New cop `Style/OptionalArguments` checks for optional arguments that do not appear at the end of an argument list. ([@rrosenblum][])
-* New cop `Lint/CircularArgumentReference` checks for "circular argument references" in keyword arguments, which Ruby 2.2 warns against. ([@maxjacobson][])
+* New cop `Lint/CircularArgumentReference` checks for "circular argument references" in keyword arguments, which Ruby 2.2 warns against. ([@maxjacobson][], [@sliuu][])
 
 ### Changes
 
@@ -1514,3 +1514,4 @@
 [@urbanautomaton]: https://github.com/urbanautomaton.com
 [@unmanbearpig]: https://github.com/unmanbearpig
 [@maxjacobson]: https://github.com/maxjacobson
+[@sliuu]: https://github.com/sliuu

--- a/lib/rubocop/cop/lint/circular_argument_reference.rb
+++ b/lib/rubocop/cop/lint/circular_argument_reference.rb
@@ -18,11 +18,13 @@ module RuboCop
           arg_name, arg_value = *node
           case arg_value.type
           when :send
-            # ruby 2.0
-            _, name = *arg_value
-            return unless name == arg_name
+            # Ruby 2.0 will have type send every time, and "send nil" if it is
+            # calling itself with a specified "self" receiver
+            receiver, name = *arg_value
+            return unless name == arg_name && receiver.nil?
           when :lvar
-            # ruby 2.2
+            # Ruby 2.2.2 will have type lvar if it is calling its own method
+            # without a specified "self"
             return unless arg_value.to_a == [arg_name]
           else
             return

--- a/spec/rubocop/cop/lint/circular_argument_reference_spec.rb
+++ b/spec/rubocop/cop/lint/circular_argument_reference_spec.rb
@@ -16,7 +16,7 @@ describe RuboCop::Cop::Lint::CircularArgumentReference do
     it 'fails with a syntax error before the cop even comes into play' do
       expect { inspect_source(cop, source) }.to raise_error(
         RuntimeError, /Error parsing/)
-      expect(cop.offenses.size).to eq(0)
+      expect(cop.offenses).to be_empty
     end
   end
 
@@ -35,7 +35,7 @@ describe RuboCop::Cop::Lint::CircularArgumentReference do
       end
 
       it 'does not register an offense' do
-        expect(cop.offenses.size).to eq(0)
+        expect(cop.offenses).to be_empty
       end
     end
 
@@ -48,7 +48,7 @@ describe RuboCop::Cop::Lint::CircularArgumentReference do
         ]
       end
       it 'does not register an offense' do
-        expect(cop.offenses.size).to eq(0)
+        expect(cop.offenses).to be_empty
       end
     end
 
@@ -68,7 +68,37 @@ describe RuboCop::Cop::Lint::CircularArgumentReference do
       end
     end
 
-    context 'when there are multiple offense keyword arguments' do
+    context 'when the keyword argument is not circular, but calls a method ' \
+            'of its own class with a self specification' do
+      let(:source) do
+        [
+          'def puts_value(value: self.class.value, smile: self.smile)',
+          '  puts value',
+          'end'
+        ]
+      end
+
+      it 'does not register an offense' do
+        expect(cop.offenses).to be_empty
+      end
+    end
+
+    context 'when the keyword argument is not circular, but calls a method ' \
+            'of some other object with the same name' do
+      let(:source) do
+        [
+          'def puts_length(length: mystring.length)',
+          '  puts length',
+          'end'
+        ]
+      end
+
+      it 'does not register an offense' do
+        expect(cop.offenses).to be_empty
+      end
+    end
+
+    context 'when there are multiple offensive keyword arguments' do
       let(:source) do
         [
           'def some_method(some_arg: some_arg, other_arg: other_arg)',


### PR DESCRIPTION
When calling method names that are the same as keyword arguments, but are called to a specific class, that should not be considered a circular argument reference 