### PR TITLE
[Fix #2023] Avoid double auto-correct in IndentationWidth

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,7 @@
 * Add proper punctuation to the end of offense messages, where it is missing. ([@lumeet][])
 * [#2071](https://github.com/bbatsov/rubocop/pull/2071): Keep line breaks in place on WordArray autocorrect.([@unmanbearpig][])
 * [#2075](https://github.com/bbatsov/rubocop/pull/2075): Properly correct `Style/PercentLiteralDelimiters` with escape characters in them. ([@rrosenblum][])
+* [#2023](https://github.com/bbatsov/rubocop/issues/2023): Avoid auto-correction corruption in `IndentationWidth`. ([@jonas054][])
 
 ## 0.32.1 (24/06/2015)
 

--- a/spec/rubocop/cli_spec.rb
+++ b/spec/rubocop/cli_spec.rb
@@ -35,6 +35,26 @@ describe RuboCop::CLI, :isolated_environment do
     end
 
     describe '--auto-correct' do
+      it 'corrects IndentationWidth, RedundantBegin, and ' \
+         'RescueEnsureAlignment offenses' do
+        source = ['def verify_section',
+                  '      begin',
+                  '      scroll_down_until_element_exists',
+                  '      rescue',
+                  '        scroll_down_until_element_exists',
+                  '        end',
+                  'end']
+        create_file('example.rb', source)
+        expect(cli.run(['--auto-correct'])).to eq(0)
+        corrected = ['def verify_section',
+                     '  scroll_down_until_element_exists',
+                     'rescue',
+                     '  scroll_down_until_element_exists',
+                     'end',
+                     '']
+        expect(IO.read('example.rb')).to eq(corrected.join("\n"))
+      end
+
       it 'corrects InitialIndentation offenses' do
         source = ['  # comment 1',
                   '',

--- a/spec/rubocop/cop/style/indentation_width_spec.rb
+++ b/spec/rubocop/cop/style/indentation_width_spec.rb
@@ -160,12 +160,12 @@ describe RuboCop::Cop::Style::IndentationWidth do
                                    'comment',
                                    'which spans a few lines',
                                    '=end',
-                                   # The method has no block comment inside, so
-                                   # it's corrected.
-                                   '  def baz',
-                                   # Method contents are also corrected.
-                                   '    do_something',
-                                   '  end',
+                                   # The method has no block comment inside,
+                                   # but it's within a class that has a block
+                                   # comment, so it's not corrected either.
+                                   'def baz',
+                                   'do_something',
+                                   'end',
                                    'end',
                                    'end'].join("\n")
         end


### PR DESCRIPTION
`IndentationWidth` can auto-correct a node spanning multiple lines. This is a useful feature, because
it takes care of `end` keywords, changing their indentation together with the chunk that they surround. The `end` keywords are not auto-corrected by default in the cops that specifically deal with them.

The problem with this feature in `IndentationWidth` is that incorrect indentation can be found within a node that is being corrected. This results in corrupted code and must be avoided. The next round in the iterative auto-correction process will pick up the skipped correction.