### PR TITLE
Remove custom RSpec matcher find_offenses_in

### DIFF
--- a/spec/rubocop/cop/style/inline_comment_spec.rb
+++ b/spec/rubocop/cop/style/inline_comment_spec.rb
@@ -3,11 +3,12 @@
 require 'spec_helper'
 
 describe RuboCop::Cop::Style::InlineComment do
-  it 'registers an offense for a inline comment' do
-    code = 'two = 1 + 1 # An inline comment'
+  subject(:cop) { described_class.new }
 
-    expect(subject).to find_offenses_in(code)
-      .with_message('Avoid inline comments.')
-      .with_highlight('# An inline comment')
+  it 'registers an offense for a inline comment' do
+    inspect_source(cop, 'two = 1 + 1 # An inline comment')
+
+    expect(cop.messages).to eq(['Avoid inline comments.'])
+    expect(cop.highlights).to eq(['# An inline comment'])
   end
 end

--- a/spec/support/custom_matchers.rb
+++ b/spec/support/custom_matchers.rb
@@ -27,32 +27,3 @@ RSpec::Matchers.define :exit_with_code do |code|
     "expect block to call exit(#{code})"
   end
 end
-
-RSpec::Matchers.define :find_offenses_in do |code|
-  match do |cop|
-    inspect_source(cop, code)
-    includes_highlight(cop) &&
-      includes_message(cop) &&
-      cop.offenses.any?
-  end
-
-  chain :with_highlight do |highlight|
-    @highlight = highlight
-  end
-
-  chain :with_message do |message|
-    @message = message
-  end
-
-  def includes_highlight(cop)
-    return true unless @highlight
-
-    cop.highlights.include?(@highlight)
-  end
-
-  def includes_message(cop)
-    return true unless @message
-
-    cop.offenses.map(&:message).include?(@message)
-  end
-end


### PR DESCRIPTION
I was going through some of the disabled cops and came across a test using `find_offenses_in` which I had never seen before. Upon further inspection, the tests for `Style/InlineComment` were the only tests that used the method. It seems like a better idea to follow what all other tests than to have a custom matcher that is used in one place.