### PR TITLE
[Fix #2093] if/then/end generates OLC offense

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,7 @@
 * [#2075](https://github.com/bbatsov/rubocop/pull/2075): Properly correct `Style/PercentLiteralDelimiters` with escape characters in them. ([@rrosenblum][])
 * [#2023](https://github.com/bbatsov/rubocop/issues/2023): Avoid auto-correction corruption in `IndentationWidth`. ([@jonas054][])
 * [#2080](https://github.com/bbatsov/rubocop/issues/2080): Properly parse code in `Performance/Count` when calling `select..count` in a class that extends an enumerable. ([@rrosenblum][])
+* [#2093](https://github.com/bbatsov/rubocop/issues/2093): Fix bug in `Style/OneLineConditional` which should not raise an offense with an 'if/then/end' statement. ([@sliuu][])
 
 ## 0.32.1 (24/06/2015)
 

--- a/lib/rubocop/cop/style/one_line_conditional.rb
+++ b/lib/rubocop/cop/style/one_line_conditional.rb
@@ -9,11 +9,15 @@ module RuboCop
         include OnNormalIfUnless
 
         MSG = 'Favor the ternary operator (?:) ' \
-              'over if/then/else/end constructs.'
+              'over %s/then/else/end constructs.'
 
         def on_normal_if_unless(node)
-          return if node.loc.expression.source.include?("\n")
-          add_offense(node, :expression, MSG)
+          exp = node.loc.expression.source
+          return if exp.include?("\n")
+          return unless node.loc.respond_to?(:else) && node.loc.else
+          condition = exp.include?('if') ? 'if' : 'unless'
+
+          add_offense(node, :expression, format(MSG, condition))
         end
       end
     end

--- a/spec/rubocop/cop/style/one_line_conditional_spec.rb
+++ b/spec/rubocop/cop/style/one_line_conditional_spec.rb
@@ -5,9 +5,25 @@ require 'spec_helper'
 describe RuboCop::Cop::Style::OneLineConditional do
   subject(:cop) { described_class.new }
 
-  it 'registers an offense for one line if/then/end' do
+  it 'registers an offense for one line if/then/else/end' do
     inspect_source(cop, 'if cond then run else dont end')
     expect(cop.messages).to eq(['Favor the ternary operator (?:)' \
                                 ' over if/then/else/end constructs.'])
+  end
+
+  it 'does not register an offense for if/then/end' do
+    inspect_source(cop, 'if cond then run end')
+    expect(cop.messages).to be_empty
+  end
+
+  it 'does register an offense for one line unless/then/else/end' do
+    inspect_source(cop, 'unless cond then run else dont end')
+    expect(cop.messages).to eq(['Favor the ternary operator (?:)' \
+                                ' over unless/then/else/end constructs.'])
+  end
+
+  it 'does not register an offense for one line unless/then/end' do
+    inspect_source(cop, 'unless cond then run end')
+    expect(cop.messages).to be_empty
   end
 end


### PR DESCRIPTION
A single-line if/then/end statement should not generate a one line conditional offense