### PR TITLE
Make CLI-test JRuby-compatible

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,6 @@ rvm:
 matrix:
   allow_failures:
     - rvm: ruby-head
-    - rvm: jruby-19mode
     - rvm: rbx-2
   fast_finish: true
 before_install: gem update --remote bundler

--- a/spec/rubocop/cli_spec.rb
+++ b/spec/rubocop/cli_spec.rb
@@ -3284,9 +3284,10 @@ describe RuboCop::CLI, :isolated_environment do
                                            '    - **/*_old.rb'])
 
       cli.run(['example'])
+      # MRI and JRuby return slightly different error messages.
       expect($stderr.string)
-        .to start_with('(<unknown>): did not find expected alphabetic or ' \
-          'numeric character while scanning an alias at line 3 column 7')
+        .to match(/^\(<unknown>\):\ (did\ not\ find\ )?expected\ alphabetic\ or
+                  \ numeric\ character/x)
     end
 
     context 'when a file inherits from the old auto generated file' do


### PR DESCRIPTION
All specs should now pass on JRuby 1.7.

The differences derive from subtle differences in LibYAML and SnakeYAML.