### PR TITLE
[Fix #2098] Distinguish between kinds of comments in ExtraSpacing

### DIFF
--- a/lib/rubocop/cop/style/extra_spacing.rb
+++ b/lib/rubocop/cop/style/extra_spacing.rb
@@ -85,7 +85,13 @@ module RuboCop
         end
 
         def comment_lines
-          @comment_lines ||= processed_source.comments.map(&:loc).map(&:line)
+          @comment_lines ||=
+            begin
+              whole_line_comments = processed_source.comments.select do |c|
+                begins_its_line?(c.loc.expression)
+              end
+              whole_line_comments.map(&:loc).map(&:line)
+            end
         end
 
         def aligned_words?(token, line)

--- a/spec/rubocop/cop/style/extra_spacing_spec.rb
+++ b/spec/rubocop/cop/style/extra_spacing_spec.rb
@@ -100,6 +100,21 @@ describe RuboCop::Cop::Style::ExtraSpacing, :config do
       %(include_examples 'unaligned', "var = if",     'test')
     ],
 
+    'aligning = on lines where there are trailing comments' => [
+      'a_long_var_name = 100 # this is 100',
+      'short_name1     = 2',
+      '',
+      'clear',
+      '',
+      'short_name2     = 2',
+      'a_long_var_name = 100 # this is 100',
+      '',
+      'clear',
+      '',
+      'short_name3     = 2   # this is 2',
+      'a_long_var_name = 100 # this is 100'
+    ],
+
     'aligning tokens with empty line between' => [
       'unless nochdir',
       '  Dir.chdir "/"    # Release old working directory.',


### PR DESCRIPTION
A whole line comment shall be skipped when looking for possible alignment, but an EOL comment shall not affect the search for alignment of other tokens.

This fixes an unreleased change, so no changelog update.