### PR TITLE
Add jruby-head and jruby-9.0.0.0 to Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,7 @@ rvm:
   - 2.2
   - ruby-head
   - jruby-19mode
+  - jruby-9.0.1.0
   - rbx-2
 matrix:
   allow_failures:


### PR DESCRIPTION
I submit this to demonstrate what JRuby 9k thinks of the test suite. I'm expecting `jruby-head` to pass and `jruby-9.0.0.0` to produce one failure. If so, are we happy with `jruby-head` or should we wait for the next official release, perhaps?