### PR TITLE
Fix bad merge for Style/OptionHash

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## master (unreleased)
 
+### Bug Fixes
+* [#2105](https://github.com/bbatsov/rubocop/pull/2105): Fix a warning that was thrown when enabling `Style/OptionHash`. ([@wli][])
+
 ## 0.33.0 (05/08/2015)
 
 ### New features
@@ -1525,3 +1528,4 @@
 [@sliuu]: https://github.com/sliuu
 [@edmz]: https://github.com/edmz
 [@syndbg]: https://github.com/syndbg
+[@wli]: https://github.com/wli

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,7 +21,7 @@
 * [#2060](https://github.com/bbatsov/rubocop/issues/2060): New cop `Style/RescueEnsureAlignment` checks for bad alignment of `rescue` and `ensure` keywords. ([@lumeet][])
 * New cop `Style/OptionalArguments` checks for optional arguments that do not appear at the end of an argument list. ([@rrosenblum][])
 * New cop `Lint/CircularArgumentReference` checks for "circular argument references" in keyword arguments, which Ruby 2.2 warns against. ([@maxjacobson][], [@sliuu][])
-* [#2030](https://github.com/bbatsov/rubocop/issues/2030): New cop `Lint/OptionHash` checks for option hashes and encourages changing them to keyword arguments (disabled by default). ([@maxjacobson][])
+* [#2030](https://github.com/bbatsov/rubocop/issues/2030): New cop `Style/OptionHash` checks for option hashes and encourages changing them to keyword arguments (disabled by default). ([@maxjacobson][])
 
 ### Changes
 

--- a/config/disabled.yml
+++ b/config/disabled.yml
@@ -46,6 +46,7 @@ Style/MissingElse:
 
 Style/OptionHash:
   Description: "Don't use option hashes when you can use keyword arguments."
+  Enabled: false
 
 Style/Send:
   Description: 'Prefer `Object#__send__` or `Object#public_send` to `send`, as `send` may overlap with existing methods.'


### PR DESCRIPTION
This line was introduced in a5be58e249eb766e1e9cfbcd537232a202f1136a, but accidentally deleted when merging 35ef5ed43c36bc5bb0bae839a8fb9bd3cee1ff7c.

I put this in my .rubocop.yml file.
````
Style/OptionHash:
  Enabled: true
````

And got the following error:

````
Warning: unrecognized parameter Style/OptionHash:Enabled found in .rubocop.yml
````

It looks like we need to specify `Enabled: false` by default for it not to complain.