### PR TITLE
Fix auto-correct alignment of Style/ParallelAssignment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Bug Fixes
 * [#2105](https://github.com/bbatsov/rubocop/pull/2105): Fix a warning that was thrown when enabling `Style/OptionHash`. ([@wli][])
+* [#2107](https://github.com/bbatsov/rubocop/pull/2107): Fix auto-correct of `Style/ParallelAssignment` for nested expressions. ([@rrosenblum][])
 
 ## 0.33.0 (05/08/2015)
 

--- a/lib/rubocop/cop/style/parallel_assignment.rb
+++ b/lib/rubocop/cop/style/parallel_assignment.rb
@@ -106,7 +106,7 @@ module RuboCop
           end
 
           def correction
-            "#{assignment.join("\n#{indent}")}"
+            "#{assignment.join("\n#{base_indentation}")}"
           end
 
           def correction_range
@@ -115,12 +115,12 @@ module RuboCop
 
           protected
 
-          def space_offset
-            @node.loc.expression.column
+          def base_indentation
+            ' ' * @node.loc.column
           end
 
-          def indent
-            ' ' * space_offset
+          def extra_indentation
+            base_indentation + (' ' * indentation_width)
           end
 
           attr_reader :indentation_width
@@ -148,21 +148,14 @@ module RuboCop
             _, _, rescue_result = *rescue_clause
 
             "begin\n" <<
-              indent << assignment.join("\n#{indent}") <<
-              "\nrescue\n" <<
-              indent << rescue_result.loc.expression.source <<
-              "\nend"
+              extra_indentation << assignment.join("\n#{extra_indentation}") <<
+              "\n#{base_indentation}rescue\n" <<
+              extra_indentation << rescue_result.loc.expression.source <<
+              "\n#{base_indentation}end"
           end
 
           def correction_range
             @node.parent.loc.expression
-          end
-
-          protected
-
-          def space_offset
-            offset = super
-            offset + indentation_width
           end
         end
 
@@ -178,19 +171,12 @@ module RuboCop
                                         parent.loc.expression.end_pos)
 
             "#{modifier_range.source}\n" <<
-              indent << assignment.join("\n#{indent}") <<
-              "\nend"
+              extra_indentation << assignment.join("\n#{extra_indentation}") <<
+              "\n#{base_indentation}end"
           end
 
           def correction_range
             @node.parent.loc.expression
-          end
-
-          protected
-
-          def space_offset
-            offset = super
-            offset + indentation_width
           end
         end
       end

--- a/spec/rubocop/cop/style/parallel_assignment_spec.rb
+++ b/spec/rubocop/cop/style/parallel_assignment_spec.rb
@@ -183,6 +183,20 @@ describe RuboCop::Cop::Style::ParallelAssignment, :config do
                                   'end'].join("\n"))
       end
 
+      it 'when the expression uses a modifier if statement ' \
+         'inside a method' do
+        new_source = autocorrect_source(cop, ['def foo',
+                                              '  a, b = 1, 2 if foo',
+                                              'end'])
+
+        expect(new_source).to eq(['def foo',
+                                  '  if foo',
+                                  '    a = 1',
+                                  '    b = 2',
+                                  '  end',
+                                  'end'].join("\n"))
+      end
+
       it 'parallel assignment in if statements' do
         new_source = autocorrect_source(cop, ['if foo',
                                               '  a, b = 1, 2',
@@ -265,7 +279,7 @@ describe RuboCop::Cop::Style::ParallelAssignment, :config do
                                   'end'].join("\n"))
       end
 
-      it 'parallel assignment in rescuce statements' do
+      it 'parallel assignment in rescue statements' do
         new_source = autocorrect_source(cop, ['begin',
                                               '  a, b = 1, 2',
                                               'rescue',
@@ -277,6 +291,22 @@ describe RuboCop::Cop::Style::ParallelAssignment, :config do
                                   '  b = 2',
                                   'rescue',
                                   "  'foo'",
+                                  'end'].join("\n"))
+      end
+
+      it 'when the expression uses a modifier rescue statement ' \
+         'inside a method' do
+        new_source = autocorrect_source(cop, ['def foo',
+                                              '  a, b = 1, 2 rescue foo',
+                                              'end'])
+
+        expect(new_source).to eq(['def foo',
+                                  '  begin',
+                                  '    a = 1',
+                                  '    b = 2',
+                                  '  rescue',
+                                  '    foo',
+                                  '  end',
                                   'end'].join("\n"))
       end
     end


### PR DESCRIPTION
The auto correct was not properly accounting for the space offset of nested assignment.

I found this while writing auto correct functionality for `Style/RescueModifier` (pull request coming shortly). I am going to try to find a more generic way to come up with space offset and indentation for corrections that span multiple lines.