### PR TITLE
[Fix #1351] Allow class emitter methods in Style/MethodName

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,12 @@
 
 ## master (unreleased)
 
+### Changes
+
+* [#1351](https://github.com/bbatsov/rubocop/issues/1351): Allow class emitter methods in `Style/MethodName`. ([@jonas054][])
+
 ### Bug Fixes
+
 * [#2105](https://github.com/bbatsov/rubocop/pull/2105): Fix a warning that was thrown when enabling `Style/OptionHash`. ([@wli][])
 
 ## 0.33.0 (05/08/2015)

--- a/spec/rubocop/cop/style/method_name_spec.rb
+++ b/spec/rubocop/cop/style/method_name_spec.rb
@@ -14,10 +14,21 @@ describe RuboCop::Cop::Style::MethodName, :config do
     end
 
     it 'registers an offense for capitalized camel case' do
-      inspect_source(cop, ['def MyMethod',
+      inspect_source(cop, ['class MyClass',
+                           '  def MyMethod',
+                           '  end',
                            'end'])
       expect(cop.offenses.size).to eq(1)
       expect(cop.highlights).to eq(['MyMethod'])
+    end
+
+    it 'registers an offense for singleton upper case method without ' \
+       'corresponding class' do
+      inspect_source(cop, ['module Sequel',
+                           '  def self.Model(source)',
+                           '  end',
+                           'end'])
+      expect(cop.highlights).to eq(['Model'])
     end
   end
 
@@ -32,6 +43,19 @@ describe RuboCop::Cop::Style::MethodName, :config do
                            '  # ...',
                            'end'])
       expect(cop.offenses).to be_empty
+    end
+
+    %w(class module).each do |kind|
+      it "accepts class emitter method in a #{kind}" do
+        inspect_source(cop, ["#{kind} Sequel",
+                             '  def self.Model(source)',
+                             '  end',
+                             '',
+                             '  class Model',
+                             '  end',
+                             'end'])
+        expect(cop.offenses).to be_empty
+      end
     end
   end
 


### PR DESCRIPTION
Trying to close an old issue...

Singleton methods that have the same name as a class defined in the same scope shall be allowed.