### PR TITLE
[Fix #2110]: `FormatParameterMismatch` not recognizing single paramet…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,8 @@
 
 ### Bug Fixes
 
+* [#2123](https://github.com/bbatsov/rubocop/pull/2123): Fix handing of dynamic widths `Lint/FormatParameterMismatch`. ([@edmz][])
+* [#2116](https://github.com/bbatsov/rubocop/pull/2116): Fix named params (using hash) `Lint/FormatParameterMismatch`. ([@edmz][])
 * [#2135](https://github.com/bbatsov/rubocop/issues/2135): Ignore `super` and `zsuper` nodes in `Style/SymbolProc`. ([@bbatsov][])
 * [#2165](https://github.com/bbatsov/rubocop/issues/2165): Fix a NPE in `Style/Alias`. ([@bbatsov][])
 * [#2168](https://github.com/bbatsov/rubocop/issues/2168): Fix a NPE in `Rails/TimeZone`. ([@bbatsov][])

--- a/spec/rubocop/cop/lint/format_parameter_mismatch_spec.rb
+++ b/spec/rubocop/cop/lint/format_parameter_mismatch_spec.rb
@@ -58,9 +58,65 @@ describe RuboCop::Cop::Lint::FormatParameterMismatch do
     expect(cop.messages).to eq(msg)
   end
 
-  it 'does not register an offense for % when arguments and fields match' do
+  it 'does not register offense for `String#%` when arguments, fields match' do
     inspect_source(cop, '"%s %s" % [1, 2]')
     expect(cop.offenses).to be_empty
+  end
+
+  it 'does not register an offense when single argument is a hash' do
+    inspect_source(cop, 'puts "%s" % {"a" => 1}')
+    expect(cop.offenses).to be_empty
+  end
+
+  it 'does not register an offense when single argument is not an array' do
+    inspect_source(cop, 'puts "%s" % 42')
+    expect(cop.offenses).to be_empty
+
+    inspect_source(cop, 'puts "%s" % "1"')
+    expect(cop.offenses).to be_empty
+
+    inspect_source(cop, 'puts "%s" % 1.2')
+    expect(cop.offenses).to be_empty
+
+    inspect_source(cop, 'puts "%s" % :a')
+    expect(cop.offenses).to be_empty
+
+    inspect_source(cop, 'puts "%s" % CONST')
+    expect(cop.offenses).to be_empty
+  end
+
+  it 'ignores percent right next to format string' do
+    inspect_source(cop, 'format("%0.1f%% percent", 22.5)')
+    expect(cop.offenses).to be_empty
+  end
+
+  it 'ignores dynamic widths' do
+    inspect_source(cop, 'format("%*d", max_width, id)')
+    expect(cop.offenses).to be_empty
+  end
+
+  it 'does not register an offense argument is the result of a message send' do
+    inspect_source(cop, '"%s" % "a b c".gsub(" ", "_")')
+    expect(cop.offenses).to be_empty
+
+    inspect_source(cop, 'format("%s", "a b c".gsub(" ", "_"))')
+    expect(cop.offenses).to be_empty
+  end
+
+  it 'does not register an offense when using named parameters' do
+    inspect_source(cop, '"foo %{bar} baz" % { bar: 42 }')
+    expect(cop.offenses).to be_empty
+  end
+
+  it 'identifies correctly digits for spacing in format' do
+    inspect_source(cop, '"duration: %10.fms" % 42')
+    expect(cop.offenses).to be_empty
+  end
+
+  it 'finds faults even when the string looks like a HEREDOC' do
+    # heredocs are ignored at the moment
+    inspect_source(cop, 'format("<< %s bleh", 1, 2)')
+    expect(cop.offenses.size).to eq(1)
   end
 
   it 'finds the correct number of fields' do
@@ -71,9 +127,9 @@ describe RuboCop::Cop::Lint::FormatParameterMismatch do
     expect('%s %s'.scan(cop.fields_regex).size)
       .to eq(2)
     expect('%s %s %%'.scan(cop.fields_regex).size)
-      .to eq(2)
+      .to eq(3)
     expect('%s %s %%'.scan(cop.fields_regex).size)
-      .to eq(2)
+      .to eq(3)
     expect('% d'.scan(cop.fields_regex).size)
       .to eq(1)
     expect('%+d'.scan(cop.fields_regex).size)


### PR DESCRIPTION
…ers that were not an array.

The cop was not checking the case where the parameter for format
was a single value, for example, an integer or another string.