### PR TITLE
Add SuspiciousParamNames option to Style/OptionHash

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 * [#2143](https://github.com/bbatsov/rubocop/pull/2143): New cop `Performance/CaseWhenSplat` will identify and rearange `case` `when` statements that contain a `when` condition with a splat. ([@rrosenblum][])
 * New cop `Lint/DuplicatedKey` checks for duplicated keys in hashes, which Ruby 2.2 warns against. ([@sliuu][])
+* [#2106](https://github.com/bbatsov/rubocop/issues/2106): Add `SuspiciousParamNames` option to `Style/OptionHash`. ([@wli][])
 
 ### Changes
 

--- a/config/default.yml
+++ b/config/default.yml
@@ -523,6 +523,15 @@ Style/MultilineOperationIndentation:
 Style/NumericLiterals:
   MinDigits: 5
 
+Style/OptionHash:
+  # A list of parameter names that will be flagged by this cop.
+  SuspiciousParamNames:
+    - options
+    - opts
+    - args
+    - params
+    - parameters
+
 # Allow safe assignment in conditions.
 Style/ParenthesesAroundCondition:
   AllowSafeAssignment: true

--- a/lib/rubocop/cop/style/option_hash.rb
+++ b/lib/rubocop/cop/style/option_hash.rb
@@ -33,7 +33,7 @@ module RuboCop
           # asserting last argument is an optional argument
           return unless last_arg.optarg_type?
 
-          _, default_value = *last_arg
+          arg, default_value = *last_arg
 
           # asserting default value is a hash
           return unless default_value.hash_type?
@@ -42,6 +42,9 @@ module RuboCop
           *key_value_pairs = *default_value
           return unless key_value_pairs.empty?
 
+          # Check for suspicious argument names
+          return unless name_in_suspicious_param_names?(arg)
+
           add_offense(last_arg, :expression, MSG)
         end
 
@@ -49,6 +52,11 @@ module RuboCop
 
         def supports_keyword_arguments?
           RUBY_VERSION >= '2.0.0'
+        end
+
+        def name_in_suspicious_param_names?(arg_name)
+          cop_config.key?('SuspiciousParamNames') &&
+            cop_config['SuspiciousParamNames'].include?(arg_name.to_s)
         end
       end
     end

--- a/spec/rubocop/cop/style/option_hash_spec.rb
+++ b/spec/rubocop/cop/style/option_hash_spec.rb
@@ -2,11 +2,9 @@
 
 require 'spec_helper'
 
-describe RuboCop::Cop::Style::OptionHash do
-  subject(:cop) { described_class.new }
-  before(:each) do
-    inspect_source(cop, source)
-  end
+describe RuboCop::Cop::Style::OptionHash, :config do
+  subject(:cop) { described_class.new(config) }
+  let(:cop_config) { { 'SuspiciousParamNames' => ['options'] } }
 
   let(:source) do
     [
@@ -18,12 +16,14 @@ describe RuboCop::Cop::Style::OptionHash do
 
   context 'ruby < 2.0, which has no keyword arguments', ruby_less_than: 2.0 do
     it 'does not register an offense' do
+      inspect_source(cop, source)
       expect(cop.offenses).to be_empty
     end
   end
 
   context 'ruby >= 2.0', ruby_greater_than_or_equal: 2.0 do
     it 'registers an offense' do
+      inspect_source(cop, source)
       expect(cop.offenses.size).to eq(1)
       expect(cop.messages.first)
         .to eq('Prefer keyword arguments to options hashes.')
@@ -40,7 +40,16 @@ describe RuboCop::Cop::Style::OptionHash do
         ]
       end
 
-      it 'registers an offense' do
+      it 'does not register an offense' do
+        inspect_source(cop, source)
+        expect(cop.offenses).to be_empty
+      end
+
+      it 'registers an offense when in SuspiciousParamNames list' do
+        cop_config['SuspiciousParamNames'] = ['config']
+
+        inspect_source(cop, source)
+
         expect(cop.offenses.size).to eq(1)
         expect(cop.messages.first)
           .to eq('Prefer keyword arguments to options hashes.')
@@ -49,6 +58,10 @@ describe RuboCop::Cop::Style::OptionHash do
     end
 
     context 'when there are no arguments' do
+      before(:each) do
+        inspect_source(cop, source)
+      end
+
       let(:source) do
         [
           'def meditate',
@@ -64,6 +77,10 @@ describe RuboCop::Cop::Style::OptionHash do
     end
 
     context 'when the last argument is a non-options-hash optional hash' do
+      before(:each) do
+        inspect_source(cop, source)
+      end
+
       let(:source) do
         [
           'def cook(instructions, ingredients = { hot: [], cold: [] })',


### PR DESCRIPTION
This adds the `SuspiciousParamNames` option to `Style/OptionHash`. To override, just specify the array of names.

Style/OptionHash:
  Enabled: true
  SuspiciousParamNames:
    - options
    - opts
    - args
    - params
    - parameters