### PR TITLE
Speed up `Lint/Debugger` by 45%.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Changes
 
 * [#1351](https://github.com/bbatsov/rubocop/issues/1351): Allow class emitter methods in `Style/MethodName`. ([@jonas054][])
+* Speed up `Lint/Debugger` by 45%. ([@wli][])
 
 ### Bug Fixes
 

--- a/lib/rubocop/cop/lint/debugger.rb
+++ b/lib/rubocop/cop/lint/debugger.rb
@@ -50,7 +50,7 @@ module RuboCop
         # (send nil :save_screenshot)
         CAPYBARA_SAVE_SCREENSHOT = s(:send, nil, :save_screenshot)
 
-        DEBUGGER_NODES = [
+        DEBUGGER_NODES = Set.new([
           DEBUGGER_NODE,
           BYEBUG_NODE,
           PRY_NODE,
@@ -59,12 +59,12 @@ module RuboCop
           CAPYBARA_SAVE_PAGE,
           CAPYBARA_SAVE_OPEN_SCREENSHOT,
           CAPYBARA_SAVE_SCREENSHOT
-        ]
+        ].map(&:to_sexp))
 
         def on_send(node)
           receiver, method_name, *_args = *node
           node_without_args = self.class.s(:send, receiver, method_name)
-          return unless DEBUGGER_NODES.include? node_without_args
+          return unless DEBUGGER_NODES.include?(node_without_args.to_sexp)
           add_offense(node,
                       :expression,
                       format(MSG, node.loc.expression.source))


### PR DESCRIPTION
Using a set is a lot more efficient than a list.

Rubocop takes up a decent chunk of time in our CI build, so I wanted to see if there's anything I could do to speed it up. I recorded the timings and ran this over rubocop's own codebase. This is a small win, though anyone is welcome to take a crack at the other cops.

Before
````
Slowest Cops
2.501s: Style/ClosingParenthesisIndentation
2.315s: Style/MultilineOperationIndentation
1.197s: Style/IndentationWidth
1.103s: Lint/BlockAlignment
1.010s: Style/FirstParameterIndentation
0.797s: Lint/DeprecatedClassMethods
0.710s: Metrics/LineLength
0.683s: Lint/Debugger
0.618s: Style/SignalException
0.513s: Style/EmptyLines
0.505s: Style/StringLiterals
0.411s: Style/ExtraSpacing
0.380s: Style/ColonMethodCall
0.378s: Style/SpaceAroundOperators
0.375s: Style/SpaceInsideHashLiteralBraces
0.350s: Style/Semicolon
0.315s: Style/FormatString
0.306s: Style/IndentationConsistency
0.285s: Style/TrailingComma
0.232s: Style/StringLiteralsInInterpolation
````

After
````
Slowest Cops
2.437s: Style/ClosingParenthesisIndentation
2.260s: Style/MultilineOperationIndentation
1.184s: Style/IndentationWidth
1.079s: Lint/BlockAlignment
0.963s: Style/FirstParameterIndentation
0.776s: Lint/DeprecatedClassMethods
0.672s: Metrics/LineLength
0.601s: Style/SignalException
0.513s: Style/EmptyLines
0.471s: Style/StringLiterals
0.420s: Style/ExtraSpacing
0.388s: Style/SpaceAroundOperators
0.378s: Lint/Debugger
0.367s: Style/ColonMethodCall
0.365s: Style/SpaceInsideHashLiteralBraces
0.338s: Style/Semicolon
0.316s: Style/FormatString
0.297s: Style/IndentationConsistency
0.290s: Style/TrailingComma
0.215s: Style/StringLiteralsInInterpolation
````

@bbatsov I have the beginnings of this output in a branch, but I'm not sure whether this is something that you'd want in master: https://github.com/bbatsov/rubocop/compare/master...wli:performance