### PR TITLE
[Fix #2111] Handle BOM in InitialIndentation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 
 * [#2105](https://github.com/bbatsov/rubocop/pull/2105): Fix a warning that was thrown when enabling `Style/OptionHash`. ([@wli][])
 * [#2107](https://github.com/bbatsov/rubocop/pull/2107): Fix auto-correct of `Style/ParallelAssignment` for nested expressions. ([@rrosenblum][])
+* [#2111](https://github.com/bbatsov/rubocop/issues/2111): Deal with byte order mark in `Style/InitialIndentation`. ([@jonas054][])
 
 ## 0.33.0 (05/08/2015)
 

--- a/lib/rubocop/cop/style/initial_indentation.rb
+++ b/lib/rubocop/cop/style/initial_indentation.rb
@@ -17,6 +17,11 @@ module RuboCop
 
           with_space = range_with_surrounding_space(first_token.pos, :left,
                                                     nil, !:with_newline)
+          # If the file starts with a byte order mark (BOM), the column can be
+          # non-zero, but then we find out here if there's no space to the left
+          # of the first token.
+          return if with_space == first_token.pos
+
           space = Parser::Source::Range.new(processed_source.buffer,
                                             with_space.begin_pos,
                                             first_token.pos.begin_pos)

--- a/spec/rubocop/cop/style/initial_indentation_spec.rb
+++ b/spec/rubocop/cop/style/initial_indentation_spec.rb
@@ -17,6 +17,26 @@ describe RuboCop::Cop::Style::InitialIndentation do
     expect(cop.offenses).to be_empty
   end
 
+  context 'for a file with byte order mark' do
+    let(:bom) { "\xef\xbb\xbf" }
+
+    it 'accepts unindented method call' do
+      inspect_source(cop, bom + 'puts 1')
+      expect(cop.offenses).to be_empty
+    end
+
+    it 'registers an offense for indented method call' do
+      inspect_source(cop, bom + '  puts 1')
+      expect(cop.offenses.size).to eq(1)
+    end
+
+    it 'registers an offense for indented method call after comment' do
+      inspect_source(cop, [bom + '# comment',
+                           '  puts 1'])
+      expect(cop.offenses.size).to eq(1)
+    end
+  end
+
   it 'accepts empty file' do
     inspect_source(cop, '')
     expect(cop.offenses).to be_empty


### PR DESCRIPTION
Files that contain a byte order mark are a special case that makes it possible for the first token to have a non-zero column without being indented. Add handling of that case.