### PR TITLE
[Fix #2113] Handle non-string tokens in ExtraSpacing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 * [#2105](https://github.com/bbatsov/rubocop/pull/2105): Fix a warning that was thrown when enabling `Style/OptionHash`. ([@wli][])
 * [#2107](https://github.com/bbatsov/rubocop/pull/2107): Fix auto-correct of `Style/ParallelAssignment` for nested expressions. ([@rrosenblum][])
 * [#2111](https://github.com/bbatsov/rubocop/issues/2111): Deal with byte order mark in `Style/InitialIndentation`. ([@jonas054][])
+* [#2113](https://github.com/bbatsov/rubocop/issues/2113): Handle non-string tokens in `Style/ExtraSpacing`. ([@jonas054][])
 
 ## 0.33.0 (05/08/2015)
 

--- a/lib/rubocop/cop/style/extra_spacing.rb
+++ b/lib/rubocop/cop/style/extra_spacing.rb
@@ -104,7 +104,7 @@ module RuboCop
         end
 
         def aligned_same_character?(token, line)
-          line[token.pos.column] == token.text[0]
+          line[token.pos.column] == token.text.to_s[0]
         end
       end
     end

--- a/spec/rubocop/cop/style/extra_spacing_spec.rb
+++ b/spec/rubocop/cop/style/extra_spacing_spec.rb
@@ -14,6 +14,13 @@ describe RuboCop::Cop::Style::ExtraSpacing, :config do
       expect(cop.offenses.size).to eq(1)
     end
 
+    it 'can handle extra space before a float' do
+      source = ['{:a => "a",',
+                ' :b => [nil,  2.5]}']
+      inspect_source(cop, source)
+      expect(cop.offenses.size).to eq(1)
+    end
+
     it 'gives the correct line' do
       inspect_source(cop, ['class A   < String',
                            'end'])


### PR DESCRIPTION
The type of the text attribute in a `Token` is usually a `String`, but not always. For example, for `:tFLOAT` tokens it's a `Float`. Convert the text to `String` type before retrieving the first character.