### PR TITLE
[Fix #2129] Fix empty interpolation bug

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 * [#2107](https://github.com/bbatsov/rubocop/pull/2107): Fix auto-correct of `Style/ParallelAssignment` for nested expressions. ([@rrosenblum][])
 * [#2111](https://github.com/bbatsov/rubocop/issues/2111): Deal with byte order mark in `Style/InitialIndentation`. ([@jonas054][])
 * [#2113](https://github.com/bbatsov/rubocop/issues/2113): Handle non-string tokens in `Style/ExtraSpacing`. ([@jonas054][])
+* [#2129](https://github.com/bbatsov/rubocop/issues/2129): Handle empty interpolations in `Style/SpaceInsideStringInterpolation`. ([@lumeet][])
 
 ## 0.33.0 (05/08/2015)
 

--- a/lib/rubocop/cop/style/space_inside_string_interpolation.rb
+++ b/lib/rubocop/cop/style/space_inside_string_interpolation.rb
@@ -20,6 +20,7 @@ module RuboCop
         def on_dstr(node)
           node.children.select { |n| n.type == :begin }.each do |begin_node|
             final_node = begin_node.children.last
+            next unless final_node
 
             interp = final_node.loc.expression
             interp_with_surrounding_space = range_with_surrounding_space(interp)

--- a/spec/rubocop/cop/style/space_inside_string_interpolation_spec.rb
+++ b/spec/rubocop/cop/style/space_inside_string_interpolation_spec.rb
@@ -66,6 +66,11 @@ describe RuboCop::Cop::Style::SpaceInsideStringInterpolation, :config do
         expect(new_source).to eq(source.join("\n"))
       end
     end
+
+    it 'accepts empty interpolation' do
+      inspect_source(cop, '"#{}"')
+      expect(cop.messages).to be_empty
+    end
   end
 
   context 'when EnforcedStyle is space' do
@@ -103,6 +108,11 @@ describe RuboCop::Cop::Style::SpaceInsideStringInterpolation, :config do
         new_source = autocorrect_source(cop, source)
         expect(new_source).to eq(source.join("\n"))
       end
+    end
+
+    it 'accepts empty interpolation' do
+      inspect_source(cop, '"#{}"')
+      expect(cop.messages).to be_empty
     end
   end
 end


### PR DESCRIPTION
`Style/SpaceInsideStringInterpolation` does not fail on empty
interpolation.