### PR TITLE
[Fix #2109] Consider indentation in ExtraSpacing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 * [#1351](https://github.com/bbatsov/rubocop/issues/1351): Allow class emitter methods in `Style/MethodName`. ([@jonas054][])
 * [#2126](https://github.com/bbatsov/rubocop/pull/2126): `Style/RescueModifier` can now auto-correct. ([@rrosenblum][])
+* [#2109](https://github.com/bbatsov/rubocop/issues/2109): Allow alignment with a token on the nearest line with same indentation in `Style/ExtraSpacing`. ([@jonas054][])
 
 ### Bug Fixes
 

--- a/spec/rubocop/cop/style/extra_spacing_spec.rb
+++ b/spec/rubocop/cop/style/extra_spacing_spec.rb
@@ -128,6 +128,23 @@ describe RuboCop::Cop::Style::ExtraSpacing, :config do
       'end',
       '',
       'File.umask 0000    # Ensure sensible umask.'
+    ],
+
+    'aligning long assignment expressions that include line breaks' => [
+      'size_attribute_name    = FactoryGirl.create(:attribute,',
+      "                                            name:   'Size',",
+      '                                            values: %w{small large})',
+      'carrier_attribute_name = FactoryGirl.create(:attribute,',
+      "                                            name:   'Carrier',",
+      '                                            values: %w{verizon})'
+    ],
+
+    'aligning values of an implicit hash literal' => [
+      "register(street1:     '1 Market',",
+      "         street2:     '#200',",
+      "         city:        'Some Town',",
+      "         state:       'CA',",
+      "         postal_code: '99999-1111')"
     ]
   }
 


### PR DESCRIPTION
When searching for possibly aligned tokens, if none is found using the normal search algorithm that looks on the nearest lines, skipping empty and comment lines, do another search where only lines with the same indentation are considered.

This must be an addition to the existing algorithm. The old stuff is still needed.