### PR TITLE
[Fix #2124] Find only comments between defs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@
 * [#2119](https://github.com/bbatsov/rubocop/issues/2119): Do not raise an error in `Style/RescueEnsureAlignment` and `Style/RescueModifier` when processing an excluded file. ([@rrosenblum][])
 * [#2149](https://github.com/bbatsov/rubocop/issues/2149): Do not register an offense in `Rails/Date` when `Date#to_time` is called with a time zone argument. ([@maxjacobson][])
 * Do not register a `Rails/TimeZone` offense when using Time.new safely. ([@maxjacobson][])
+* [#2124](https://github.com/bbatsov/rubocop/issues/2124): Fix bug in `Style/EmptyLineBetweenDefs` when there are only comments between method definitions. ([@lumeet][])
 
 ## 0.33.0 (05/08/2015)
 

--- a/spec/rubocop/cop/style/empty_line_between_defs_spec.rb
+++ b/spec/rubocop/cop/style/empty_line_between_defs_spec.rb
@@ -25,6 +25,37 @@ describe RuboCop::Cop::Style::EmptyLineBetweenDefs, :config do
     expect(cop.offenses.map(&:line).sort).to eq([7])
   end
 
+  context 'when there are only comments between defs' do
+    let(:source) do
+      ['class J',
+       '  def n',
+       '  end # n-related',
+       '  # checks something o-related',
+       '  # and more',
+       '  def o',
+       '  end',
+       'end']
+    end
+
+    it 'registers an offense' do
+      inspect_source(cop, source)
+      expect(cop.offenses.size).to eq(1)
+    end
+
+    it 'auto-corrects' do
+      corrected = autocorrect_source(cop, source)
+      expect(corrected).to eq(['class J',
+                               '  def n',
+                               '  end # n-related',
+                               '',
+                               '  # checks something o-related',
+                               '  # and more',
+                               '  def o',
+                               '  end',
+                               'end'].join("\n"))
+    end
+  end
+
   # Only one def, so rule about empty line *between* defs does not
   # apply.
   it 'accepts a def that follows a line with code' do


### PR DESCRIPTION
The `Style/EmptyLineBetweenDefs` cop registers an offense when there
are only comments between method definitions.