### PR TITLE
Do not error when procesing an excluded file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 * [#2111](https://github.com/bbatsov/rubocop/issues/2111): Deal with byte order mark in `Style/InitialIndentation`. ([@jonas054][])
 * [#2113](https://github.com/bbatsov/rubocop/issues/2113): Handle non-string tokens in `Style/ExtraSpacing`. ([@jonas054][])
 * [#2129](https://github.com/bbatsov/rubocop/issues/2129): Handle empty interpolations in `Style/SpaceInsideStringInterpolation`. ([@lumeet][])
+* [#2119](https://github.com/bbatsov/rubocop/issues/2119): Do not raise an error in `Style/RescueEnsureAlignment` and `Style/RescueModifier` when processing an excluded file. ([@rrosenblum][])
 
 ## 0.33.0 (05/08/2015)
 

--- a/lib/rubocop/cop/style/rescue_ensure_alignment.rb
+++ b/lib/rubocop/cop/style/rescue_ensure_alignment.rb
@@ -65,7 +65,8 @@ module RuboCop
         end
 
         def modifier?(node)
-          @modifier_locations.include? node.loc.keyword
+          return false unless @modifier_locations.respond_to?(:include?)
+          @modifier_locations.include?(node.loc.keyword)
         end
 
         def ancestor_node(node)

--- a/lib/rubocop/cop/style/rescue_modifier.rb
+++ b/lib/rubocop/cop/style/rescue_modifier.rb
@@ -42,6 +42,7 @@ module RuboCop
         private
 
         def modifier?(node)
+          return false unless @modifier_locations.respond_to?(:include?)
           @modifier_locations.include?(node.loc.keyword)
         end
       end

--- a/spec/rubocop/cop/style/rescue_ensure_alignment_spec.rb
+++ b/spec/rubocop/cop/style/rescue_ensure_alignment_spec.rb
@@ -73,4 +73,24 @@ describe RuboCop::Cop::Style::RescueEnsureAlignment do
   context 'ensure' do
     it_behaves_like 'common behavior', 'ensure'
   end
+
+  describe 'excluded file' do
+    let(:config) do
+      RuboCop::Config.new('Style/RescueEnsureAlignment' =>
+                          { 'Enabled' => true,
+                            'Exclude' => ['**/**'] })
+    end
+
+    subject(:cop) { described_class.new(config) }
+
+    it 'processes excluded files with issue' do
+      inspect_source_file(cop, ['begin',
+                                '  foo',
+                                'rescue',
+                                '  bar',
+                                'end'])
+
+      expect(cop.messages).to be_empty
+    end
+  end
 end

--- a/spec/rubocop/cop/style/rescue_modifier_spec.rb
+++ b/spec/rubocop/cop/style/rescue_modifier_spec.rb
@@ -188,4 +188,20 @@ describe RuboCop::Cop::Style::RescueModifier do
                                 'end'].join("\n"))
     end
   end
+
+  describe 'excluded file' do
+    let(:config) do
+      RuboCop::Config.new('Style/RescueModifier' =>
+                          { 'Enabled' => true,
+                            'Exclude' => ['**/**'] })
+    end
+
+    subject(:cop) { described_class.new(config) }
+
+    it 'processes excluded files with issue' do
+      inspect_source_file(cop, 'foo rescue bar')
+
+      expect(cop.messages).to be_empty
+    end
+  end
 end


### PR DESCRIPTION
This fixes #2119.

Take a look at the conversation in the issue. RuboCop preferable should not be processing a cop for an excluded file. I am unsure how to accomplish this. Should I create a separate issue to discuss this?