### PR TITLE
Case when splat

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## master (unreleased)
 
+### New features
+
+* [#2143](https://github.com/bbatsov/rubocop/pull/2143): New cop `Performance/CaseWhenSplat` will identify and rearange `case` `when` statements that contain a `when` condition with a splat. ([@rrosenblum][])
+
 ### Changes
 
 * [#1351](https://github.com/bbatsov/rubocop/issues/1351): Allow class emitter methods in `Style/MethodName`. ([@jonas054][])

--- a/config/enabled.yml
+++ b/config/enabled.yml
@@ -926,7 +926,7 @@ Lint/Eval:
 
 Lint/FormatParameterMismatch:
   Description: 'The number of parameters to format/sprint must match the fields.'
-  Enabled: true  
+  Enabled: true
 
 Lint/HandleExceptions:
   Description: "Don't suppress exception."
@@ -1049,6 +1049,12 @@ Lint/Void:
   Enabled: true
 
 ##################### Performance #############################
+
+Performance/CaseWhenSplat:
+  Description: >-
+                  Place `when` conditions that use splat at the end
+                  of the list of `when` branches.
+  Enabled: true
 
 Performance/Count:
   Description: >-

--- a/lib/rubocop.rb
+++ b/lib/rubocop.rb
@@ -123,6 +123,7 @@ require 'rubocop/cop/metrics/method_length'
 require 'rubocop/cop/metrics/parameter_lists'
 require 'rubocop/cop/metrics/perceived_complexity'
 
+require 'rubocop/cop/performance/case_when_splat'
 require 'rubocop/cop/performance/count'
 require 'rubocop/cop/performance/detect'
 require 'rubocop/cop/performance/flat_map'

--- a/lib/rubocop/cop/mixin/safe_assignment.rb
+++ b/lib/rubocop/cop/mixin/safe_assignment.rb
@@ -12,11 +12,11 @@ module RuboCop
 
         child = node.children.first
         case child.type
-        when *Util::EQUALS_ASGN_NODES
-          true
         when :send
           _receiver, method_name, _args = *child
           method_name.to_s.end_with?('=')
+        when *Util::EQUALS_ASGN_NODES
+          true
         else
           false
         end

--- a/lib/rubocop/cop/performance/case_when_splat.rb
+++ b/lib/rubocop/cop/performance/case_when_splat.rb
@@ -1,0 +1,132 @@
+# encoding: utf-8
+
+module RuboCop
+  module Cop
+    module Performance
+      # Place `when` conditions that use splat at the end
+      # of the list of `when` branches.
+      #
+      # Ruby has to allocate memory for the splat expansion every time
+      # that the `case` `when` statement is run. Since Ruby does not support
+      # fall through inside of `case` `when`, like some other languages do,
+      # the order of the `when` branches does not matter. By placing any
+      # splat expansions at the end of the list of `when` branches we will
+      # reduce the number of times that memory has to be allocated for
+      # the expansion.
+      #
+      # This is not a guaranteed performance improvement. If the data being
+      # processed by the `case` condition is normalized in a manner that favors
+      # hitting a condition in the splat expansion, it is possible that
+      # moving the splat condition to the end will use more memory,
+      # and run slightly slower.
+      #
+      # @example
+      #   # bad
+      #   case foo
+      #   when *condition
+      #     bar
+      #   when baz
+      #     foobar
+      #   end
+      #
+      #   case foo
+      #   when *[1, 2, 3, 4]
+      #     bar
+      #   when 5
+      #     baz
+      #   end
+      #
+      #   # good
+      #   case foo
+      #   when baz
+      #     foobar
+      #   when *condition
+      #     bar
+      #   end
+      #
+      #   case foo
+      #   when 1, 2, 3, 4
+      #     bar
+      #   when 5
+      #     baz
+      #   end
+      class CaseWhenSplat < Cop
+        include AutocorrectAlignment
+
+        MSG = 'Place `when` conditions with a splat ' \
+              'at the end of the `when` branches.'.freeze
+        ARRAY_MSG = 'Do not expand array literals in `when` conditions.'.freeze
+
+        def on_case(node)
+          _case_branch, *when_branches, _else_branch = *node
+          when_conditions =
+            when_branches.each_with_object([]) do |branch, conditions|
+              condition, = *branch
+              conditions << condition
+            end
+
+          splat_offenses(when_conditions).reverse_each do |condition|
+            range = condition.parent.loc.keyword.join(condition.loc.expression)
+            variable, = *condition
+            message = variable.array_type? ? ARRAY_MSG : MSG
+            add_offense(condition.parent, range, message)
+          end
+        end
+
+        def autocorrect(node)
+          condition, = *node
+          variable, = *condition
+          if variable.array_type?
+            correct_array_literal(condition, variable)
+          else
+            reorder_splat_condition(node)
+          end
+        end
+
+        private
+
+        def splat_offenses(when_conditions)
+          found_non_splat = false
+          when_conditions.reverse.each_with_object([]) do |condition, result|
+            found_non_splat ||= true if error_condition?(condition)
+
+            next unless condition.splat_type?
+            result << condition if found_non_splat
+          end
+        end
+
+        def error_condition?(condition)
+          variable, = *condition
+
+          (condition.splat_type? && variable.array_type?) ||
+            !condition.splat_type?
+        end
+
+        def correct_array_literal(condition, variable)
+          lambda do |corrector|
+            corrector.remove(condition.loc.operator)
+            corrector.remove(variable.loc.begin)
+            corrector.remove(variable.loc.end)
+          end
+        end
+
+        def reorder_splat_condition(node)
+          _case_branch, *when_branches, _else_branch = *node.parent
+          current_index = when_branches.index { |branch| branch == node }
+          next_branch = when_branches[current_index + 1]
+          correction = "\n#{offset(node)}#{node.loc.expression.source}"
+          range =
+            Parser::Source::Range.new(node.parent,
+                                      node.loc.expression.begin_pos,
+                                      next_branch.loc.expression.begin_pos)
+
+          lambda do |corrector|
+            corrector.remove(range)
+            corrector.insert_after(when_branches.last.loc.expression,
+                                   correction)
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/rubocop/cop/variable_force.rb
+++ b/lib/rubocop/cop/variable_force.rb
@@ -106,28 +106,28 @@ module RuboCop
       # rubocop:disable Metrics/MethodLength, Metrics/CyclomaticComplexity
       def dispatch_node(node)
         case node.type
-        when *ARGUMENT_DECLARATION_TYPES
-          process_variable_declaration(node)
         when VARIABLE_ASSIGNMENT_TYPE
           process_variable_assignment(node)
         when REGEXP_NAMED_CAPTURE_TYPE
           process_regexp_named_captures(node)
-        when *OPERATOR_ASSIGNMENT_TYPES
-          process_variable_operator_assignment(node)
         when MULTIPLE_ASSIGNMENT_TYPE
           process_variable_multiple_assignment(node)
         when VARIABLE_REFERENCE_TYPE
           process_variable_referencing(node)
-        when *LOOP_TYPES
-          process_loop(node)
         when RESCUE_TYPE
           process_rescue(node)
         when ZERO_ARITY_SUPER_TYPE
           process_zero_arity_super(node)
-        when *SCOPE_TYPES
-          process_scope(node)
         when SEND_TYPE
           process_send(node)
+        when *ARGUMENT_DECLARATION_TYPES
+          process_variable_declaration(node)
+        when *OPERATOR_ASSIGNMENT_TYPES
+          process_variable_operator_assignment(node)
+        when *LOOP_TYPES
+          process_loop(node)
+        when *SCOPE_TYPES
+          process_scope(node)
         end
       end
       # rubocop:enable Metrics/MethodLength, Metrics/CyclomaticComplexity
@@ -326,13 +326,13 @@ module RuboCop
           case node.type
           when :lvar
             referenced_variable_names_in_loop << node.children.first
+          when :lvasgn
+            assignment_nodes_in_loop << node
           when *OPERATOR_ASSIGNMENT_TYPES
             asgn_node = node.children.first
             if asgn_node.type == :lvasgn
               referenced_variable_names_in_loop << asgn_node.children.first
             end
-          when :lvasgn
-            assignment_nodes_in_loop << node
           end
         end
 

--- a/lib/rubocop/cop/variable_force/locatable.rb
+++ b/lib/rubocop/cop/variable_force/locatable.rb
@@ -80,9 +80,9 @@ module RuboCop
           case branch_point_node.type
           when :if                     then if_body_name
           when :case                   then case_body_name
-          when *LOGICAL_OPERATOR_TYPES then logical_operator_body_name
           when RESCUE_TYPE             then rescue_body_name
           when ENSURE_TYPE             then ensure_body_name
+          when *LOGICAL_OPERATOR_TYPES then logical_operator_body_name
           else fail InvalidBranchBodyError
           end
         rescue InvalidBranchBodyError
@@ -157,14 +157,14 @@ module RuboCop
           child_index = parent_node.children.index(child_node)
 
           case parent_node.type
-          when *BRANCH_TYPES
-            child_index != CONDITION_INDEX_OF_BRANCH_NODE
-          when *LOGICAL_OPERATOR_TYPES
-            child_index != LEFT_SIDE_INDEX_OF_LOGICAL_OPERATOR_NODE
           when RESCUE_TYPE
             true
           when ENSURE_TYPE
             child_index != ENSURE_INDEX_OF_ENSURE_NODE
+          when *BRANCH_TYPES
+            child_index != CONDITION_INDEX_OF_BRANCH_NODE
+          when *LOGICAL_OPERATOR_TYPES
+            child_index != LEFT_SIDE_INDEX_OF_LOGICAL_OPERATOR_NODE
           else
             false
           end

--- a/spec/rubocop/cop/performance/case_when_splat_spec.rb
+++ b/spec/rubocop/cop/performance/case_when_splat_spec.rb
@@ -1,0 +1,302 @@
+# encoding: utf-8
+
+require 'spec_helper'
+
+describe RuboCop::Cop::Performance::CaseWhenSplat do
+  subject(:cop) { described_class.new }
+
+  it 'allows case when without splat' do
+    inspect_source(cop, ['case foo',
+                         'when 1',
+                         '  bar',
+                         'else',
+                         '  baz',
+                         'end'])
+
+    expect(cop.messages).to be_empty
+  end
+
+  it 'allows splat on a variable in the last when condition' do
+    inspect_source(cop, ['case foo',
+                         'when 4',
+                         '  foobar',
+                         'when *cond',
+                         '  bar',
+                         'else',
+                         '  baz',
+                         'end'])
+
+    expect(cop.messages).to be_empty
+  end
+
+  it 'allows multiple splat conditions on variables at the end' do
+    inspect_source(cop, ['case foo',
+                         'when 4',
+                         '  foobar',
+                         'when *cond1',
+                         '  bar',
+                         'when *cond2',
+                         '  doo',
+                         'else',
+                         '  baz',
+                         'end'])
+
+    expect(cop.messages).to be_empty
+  end
+
+  it 'registers an offense for case when with a splat in the first condition' do
+    inspect_source(cop, ['case foo',
+                         'when *cond',
+                         '  bar',
+                         'when 4',
+                         '  foobar',
+                         'else',
+                         '  baz',
+                         'end'])
+
+    expect(cop.messages).to eq([described_class::MSG])
+    expect(cop.highlights).to eq(['when *cond'])
+  end
+
+  it 'registers an offense for case when with a splat without an else' do
+    inspect_source(cop, ['case foo',
+                         'when *baz',
+                         '  bar',
+                         'when 4',
+                         '  foobar',
+                         'end'])
+
+    expect(cop.messages).to eq([described_class::MSG])
+    expect(cop.highlights).to eq(['when *baz'])
+  end
+
+  it 'registers an offense for splat conditions in when then' do
+    inspect_source(cop, ['case foo',
+                         'when *cond then bar',
+                         'when 4 then baz',
+                         'end'])
+
+    expect(cop.messages).to eq([described_class::MSG])
+    expect(cop.highlights).to eq(['when *cond'])
+  end
+
+  it 'registers an offense for multiple splat conditions at the beginning' do
+    inspect_source(cop, ['case foo',
+                         'when *cond1',
+                         '  bar',
+                         'when *cond2',
+                         '  doo',
+                         'when 4',
+                         '  foobar',
+                         'else',
+                         '  baz',
+                         'end'])
+
+    expect(cop.messages).to eq([described_class::MSG, described_class::MSG])
+    expect(cop.highlights).to eq(['when *cond1', 'when *cond2'])
+  end
+
+  it 'registers an offense for multiple out of order splat conditions' do
+    inspect_source(cop, ['case foo',
+                         'when *cond1',
+                         '  bar',
+                         'when 8',
+                         '  barfoo',
+                         'when *SOME_CONSTANT',
+                         '  doo',
+                         'when 4',
+                         '  foobar',
+                         'else',
+                         '  baz',
+                         'end'])
+
+    expect(cop.messages).to eq([described_class::MSG, described_class::MSG])
+    expect(cop.highlights).to eq(['when *cond1', 'when *SOME_CONSTANT'])
+  end
+
+  it 'registers an offense for splat condition that do not appear at the end' do
+    inspect_source(cop, ['case foo',
+                         'when *cond1',
+                         '  bar',
+                         'when 8',
+                         '  barfoo',
+                         'when *cond2',
+                         '  doo',
+                         'when 4',
+                         '  foobar',
+                         'when *cond3',
+                         '  doofoo',
+                         'else',
+                         '  baz',
+                         'end'])
+
+    expect(cop.messages).to eq([described_class::MSG, described_class::MSG])
+    expect(cop.highlights).to eq(['when *cond1', 'when *cond2'])
+  end
+
+  it 'registers an offense for splat on an array literal' do
+    inspect_source(cop, ['case foo',
+                         'when *[1, 2]',
+                         '  bar',
+                         'when *[3, 4]',
+                         '  bar',
+                         'when 5',
+                         '  baz',
+                         'end'])
+
+    expect(cop.messages)
+      .to eq([described_class::ARRAY_MSG, described_class::ARRAY_MSG])
+    expect(cop.highlights).to eq(['when *[1, 2]', 'when *[3, 4]'])
+  end
+
+  it 'registers an offense for splat on array literal as the last condition' do
+    inspect_source(cop, ['case foo',
+                         'when *[1, 2]',
+                         '  bar',
+                         'end'])
+
+    expect(cop.messages).to eq([described_class::ARRAY_MSG])
+    expect(cop.highlights).to eq(['when *[1, 2]'])
+  end
+
+  it 'registers an offense for a splat on a variable that proceeds a splat ' \
+     'on an array literal as the last condition' do
+    inspect_source(cop, ['case foo',
+                         'when *cond',
+                         '  bar',
+                         'when *[1, 2]',
+                         '  baz',
+                         'end'])
+
+    expect(cop.messages)
+      .to eq([described_class::MSG, described_class::ARRAY_MSG])
+    expect(cop.highlights).to eq(['when *cond', 'when *[1, 2]'])
+  end
+
+  context 'autocorrect' do
+    it 'corrects *array to a list of the elements in the array' do
+      new_source = autocorrect_source(cop, ['case foo',
+                                            'when *[1, 2]',
+                                            '  bar',
+                                            'when 3',
+                                            '  baz',
+                                            'end'])
+
+      expect(new_source).to eq(['case foo',
+                                'when 1, 2',
+                                '  bar',
+                                'when 3',
+                                '  baz',
+                                'end'].join("\n"))
+    end
+
+    it 'moves a single splat condition to the end of the when conditions' do
+      new_source = autocorrect_source(cop, ['case foo',
+                                            'when *cond',
+                                            '  bar',
+                                            'when 3',
+                                            '  baz',
+                                            'end'])
+
+      expect(new_source).to eq(['case foo',
+                                'when 3',
+                                '  baz',
+                                'when *cond',
+                                '  bar',
+                                'end'].join("\n"))
+    end
+
+    it 'moves multiple splat condition to the end of the when conditions' do
+      new_source = autocorrect_source(cop, ['case foo',
+                                            'when *cond1',
+                                            '  bar',
+                                            'when *cond2',
+                                            '  foobar',
+                                            'when 5',
+                                            '  baz',
+                                            'end'])
+
+      expect(new_source).to eq(['case foo',
+                                'when 5',
+                                '  baz',
+                                'when *cond1',
+                                '  bar',
+                                'when *cond2',
+                                '  foobar',
+                                'end'].join("\n"))
+    end
+
+    it 'moves multiple out of order splat condition to the end ' \
+       'of the when conditions' do
+      new_source = autocorrect_source(cop, ['case foo',
+                                            'when *cond1',
+                                            '  bar',
+                                            'when 3',
+                                            '  doo',
+                                            'when *cond2',
+                                            '  foobar',
+                                            'when 6',
+                                            '  baz',
+                                            'end'])
+
+      expect(new_source).to eq(['case foo',
+                                'when 3',
+                                '  doo',
+                                'when 6',
+                                '  baz',
+                                'when *cond1',
+                                '  bar',
+                                'when *cond2',
+                                '  foobar',
+                                'end'].join("\n"))
+    end
+
+    it 'corrects splat condition when using when then' do
+      new_source = autocorrect_source(cop, ['case foo',
+                                            'when *cond then bar',
+                                            'when 4 then baz',
+                                            'end'])
+
+      expect(new_source).to eq(['case foo',
+                                'when 4 then baz',
+                                'when *cond then bar',
+                                'end'].join("\n"))
+    end
+
+    it 'corrects nested case when statements' do
+      new_source = autocorrect_source(cop, ['def check',
+                                            '  case foo',
+                                            '  when *cond',
+                                            '    bar',
+                                            '  when 3',
+                                            '    baz',
+                                            '  end',
+                                            'end'])
+
+      expect(new_source).to eq(['def check',
+                                '  case foo',
+                                '  when 3',
+                                '    baz',
+                                '  when *cond',
+                                '    bar',
+                                '  end',
+                                'end'].join("\n"))
+    end
+
+    it 'corrects splat on variable and on array literal at the same time' do
+      new_source = autocorrect_source(cop, ['case foo',
+                                            'when *cond',
+                                            '  bar',
+                                            'when *[1, 2]',
+                                            '  baz',
+                                            'end'])
+
+      expect(new_source).to eq(['case foo',
+                                'when 1, 2',
+                                '  baz',
+                                'when *cond',
+                                '  bar',
+                                'end'].join("\n"))
+    end
+  end
+end


### PR DESCRIPTION
This is part 1 of memory performance improvements.

There is a slight risk in the auto-correct. If more than one `when` condition could apply to the same input, and the earlier condition is used as a short circuiting, then auto-correct could change the code to do the wrong thing. I do not think this is a large concern. If somebody thinks otherwise, I will gladly disable auto-correct by default. I also wasn't sure if I should document this risk inside of the description, class, or not at all.

Example
```ruby
case foo
when 2
  puts 'special'
when *[2, 4, 6]
  puts 'even'
end

# auto-corrected
case foo
when *[2, 4, 6]
  puts 'even'
when 2
  puts 'special'
end
```

While running [memory_profiler](https://github.com/SamSaffron/memory_profiler) on RuboCop. The sample for the data came from running RuboCop against `lib/rubocop/cop/performance`, `lib/rubocop/cop/rails`, and `lib/rubocop/cop/lint`. I could not sample running against the entire project because of the time and resources needed to analyze that much memory.

Total memory consumption dropped by about 2%
The memory allocation for `variable_force.rb` dropped by 30%.
There was little impact on `locatable.rb`, and `safe_assignment.rb` didn't fall into the top 50 most memory consuming files.