### PR TITLE
[Fix #1682] Add STDIN support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 * [#2126](https://github.com/bbatsov/rubocop/pull/2126): `Style/RescueModifier` can now auto-correct. ([@rrosenblum][])
 * [#2109](https://github.com/bbatsov/rubocop/issues/2109): Allow alignment with a token on the nearest line with same indentation in `Style/ExtraSpacing`. ([@jonas054][])
 * `Lint/EndAlignment` handles the `case` keyword. ([@lumeet][])
+* [#2146](https://github.com/bbatsov/rubocop/pull/2146): Add STDIN support. ([@caseywebdev][])
 
 ### Bug Fixes
 
@@ -1547,3 +1548,4 @@
 [@edmz]: https://github.com/edmz
 [@syndbg]: https://github.com/syndbg
 [@wli]: https://github.com/wli
+[@caseywebdev]: https://github.com/caseywebdev

--- a/README.md
+++ b/README.md
@@ -176,6 +176,7 @@ Command flag              | Description
 `--exclude-limit`         | Limit how many individual files `--auto-gen-config` can list in `Exclude` parameters, default is 15.
 `--show-cops`             | Shows available cops and their configuration.
 `--fail-level`            | Minimum [severity](#severity) for exit with error code. Full severity name or upper case initial can be given. Normally, auto-corrected offenses are ignored. Use `A` or `autocorrect` if you'd like them to trigger failure.
+`-s/--stdin`              | Pipe source from STDIN. This is useful for editor integration.
 
 ### Cops
 

--- a/lib/rubocop/options.rb
+++ b/lib/rubocop/options.rb
@@ -18,6 +18,10 @@ module RuboCop
 
       validate_compatibility
 
+      if @options[:stdin] && !args.one?
+        fail ArgumentError, '-s/--stdin requires exactly one path.'
+      end
+
       [@options, args]
     end
 
@@ -133,6 +137,7 @@ module RuboCop
 
       option(opts, '-v', '--version')
       option(opts, '-V', '--verbose-version')
+      option(opts, '-s', '--stdin') { @options[:stdin] = $stdin.read }
     end
 
     # Sets a value in the @options hash, based on the given long option and its
@@ -230,7 +235,9 @@ module RuboCop
       auto_correct:         'Auto-correct offenses.',
       no_color:             'Disable color output.',
       version:              'Display version.',
-      verbose_version:      'Display verbose version.'
+      verbose_version:      'Display verbose version.',
+      stdin:                ['Pipe source from STDIN.',
+                             'This is useful for editor integration.']
     }
   end
 end

--- a/lib/rubocop/runner.rb
+++ b/lib/rubocop/runner.rb
@@ -65,7 +65,7 @@ module RuboCop
     def process_file(file)
       puts "Scanning #{file}" if @options[:debug]
 
-      processed_source = ProcessedSource.from_file(file)
+      processed_source = get_processed_source(file)
       file_info = {
         cop_disabled_line_ranges: processed_source.disabled_line_ranges,
         comments: processed_source.comments,
@@ -111,7 +111,7 @@ module RuboCop
         # loop if we find any.
         break unless updated_source_file
 
-        processed_source = ProcessedSource.from_file(file)
+        processed_source = get_processed_source(file)
       end
 
       offenses
@@ -208,6 +208,11 @@ module RuboCop
         name = @options[:fail_level] || :refactor
         RuboCop::Cop::Severity.new(name)
       end
+    end
+
+    def get_processed_source(file)
+      return ProcessedSource.new(@options[:stdin], file) if @options[:stdin]
+      ProcessedSource.from_file(file)
     end
   end
 end

--- a/spec/rubocop/options_spec.rb
+++ b/spec/rubocop/options_spec.rb
@@ -86,6 +86,8 @@ Usage: rubocop [options] [file1, file2, ...]
     -n, --no-color                   Disable color output.
     -v, --version                    Display version.
     -V, --verbose-version            Display verbose version.
+    -s, --stdin                      Pipe source from STDIN.
+                                     This is useful for editor integration.
         END
         # rubocop:enable Metrics/LineLength
 
@@ -202,6 +204,27 @@ Usage: rubocop [options] [file1, file2, ...]
 
       it 'fails if given without --auto-gen-config' do
         expect { options.parse %w(--exclude-limit 10) }
+          .to raise_error(ArgumentError)
+      end
+    end
+
+    describe '-s/--stdin' do
+      before do
+        $stdin = StringIO.new
+        $stdin.puts("{ foo: 'bar' }")
+        $stdin.rewind
+      end
+
+      it 'fails if no paths are given' do
+        expect { options.parse %w(-s) }.to raise_error(ArgumentError)
+      end
+
+      it 'succeeds with exactly one path' do
+        expect { options.parse %w(--stdin foo) }.not_to raise_error
+      end
+
+      it 'fails if more than one path is given' do
+        expect { options.parse %w(--stdin foo bar) }
           .to raise_error(ArgumentError)
       end
     end

--- a/spec/rubocop/runner_spec.rb
+++ b/spec/rubocop/runner_spec.rb
@@ -60,6 +60,40 @@ describe RuboCop::Runner, :isolated_environment do
         END
       end
     end
+
+    context 'if -s/--stdin is used with an offense' do
+      let(:options) do
+        {
+          formatters: [['progress', formatter_output_path]],
+          stdin: <<-END.strip_indent
+            # coding: utf-8
+            def INVALID_CODE
+            end
+          END
+        }
+      end
+      let(:source) { '' }
+
+      it 'returns false' do
+        expect(runner.run([])).to be false
+      end
+
+      it 'sends the offense to a formatter' do
+        runner.run([])
+        expect(formatter_output).to eq <<-END.strip_indent
+          Inspecting 1 file
+          C
+
+          Offenses:
+
+          example.rb:2:5: C: Use snake_case for method names.
+          def INVALID_CODE
+              ^^^^^^^^^^^^
+
+          1 file inspected, 1 offense detected
+        END
+      end
+    end
   end
 
   describe '#run with cops autocorrecting each-other' do


### PR DESCRIPTION
Without STDIN support, text editor plugins have to create tmp files to implement lint-as-you-type because the actual file is not saved yet. This is far from ideal, and this PR aims to fix that.  Here's example usage:

```bash
$ echo '{:foo => :bar}' | bin/rubocop -s the-file-path.rb
Inspecting 1 file
C

Offenses:

the-file-path.rb:1:1: C: Missing utf-8 encoding comment.
{:foo => :bar}
^
the-file-path.rb:1:1: C: Use snake_case for source file names.
{:foo => :bar}
^
the-file-path.rb:1:1: C: Space inside { missing.
{:foo => :bar}
^
the-file-path.rb:1:2: C: Use the new Ruby 1.9 hash syntax.
{:foo => :bar}
 ^^^^^^^
the-file-path.rb:1:14: C: Space inside } missing.
{:foo => :bar}
             ^

1 file inspected, 5 offenses detected
```

The file path is still used for things like source file name linting, but the raw source comes from STDIN.