### PR TITLE
Improve readability of to_time warning

### DIFF
--- a/lib/rubocop/cop/rails/date.rb
+++ b/lib/rubocop/cop/rails/date.rb
@@ -40,8 +40,8 @@ module RuboCop
 
         MSG = 'Do not use `%s` without zone. Use `%s` instead.'
 
-        MSG_SEND =  'Do not use `%s` on Date objects,' \
-                    'because it knows nothing about time zone in use.'
+        MSG_SEND =  'Do not use `%s` on Date objects, ' \
+                    'because they know nothing about the time zone in use.'
 
         BAD_DAYS = [:today, :current, :yesterday, :tomorrow]
 


### PR DESCRIPTION
Changing from:

Rails/Date: Do not use to_time on Date objects,because it knows nothing about time zone in use.

To:

Rails/Date: Do not use to_time on Date objects, because they know nothing about the time zone in use.

I think "in use" is a bit ambiguous but I'm not sure what to replace it with.