### PR TITLE
Do not register a Rails/Date offense unnecessarily

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
 * [#2113](https://github.com/bbatsov/rubocop/issues/2113): Handle non-string tokens in `Style/ExtraSpacing`. ([@jonas054][])
 * [#2129](https://github.com/bbatsov/rubocop/issues/2129): Handle empty interpolations in `Style/SpaceInsideStringInterpolation`. ([@lumeet][])
 * [#2119](https://github.com/bbatsov/rubocop/issues/2119): Do not raise an error in `Style/RescueEnsureAlignment` and `Style/RescueModifier` when processing an excluded file. ([@rrosenblum][])
+* [#2149](https://github.com/bbatsov/rubocop/issues/2149): Do not register an offense in `Rails/Date` when `Date#to_time` is called with a time zone argument. ([@maxjacobson][])
 
 ## 0.33.0 (05/08/2015)
 

--- a/lib/rubocop/cop/rails/date.rb
+++ b/lib/rubocop/cop/rails/date.rb
@@ -54,8 +54,9 @@ module RuboCop
         end
 
         def on_send(node)
-          receiver, method_name, *_args = *node
+          receiver, method_name, *args = *node
           return unless receiver && bad_methods.include?(method_name)
+          return if method_name == :to_time && args.length == 1
 
           add_offense(node, :selector,
                       format(MSG_SEND,

--- a/spec/rubocop/cop/rails/date_spec.rb
+++ b/spec/rubocop/cop/rails/date_spec.rb
@@ -41,6 +41,13 @@ describe RuboCop::Cop::Rails::Date, :config do
         expect(cop.offenses).to be_empty
       end
     end
+
+    context 'when a zone is provided' do
+      it 'does not register an offense' do
+        inspect_source(cop, 'date.to_time(:utc)')
+        expect(cop.offenses).to be_empty
+      end
+    end
   end
 
   context 'when EnforcedStyle is "flexible"' do


### PR DESCRIPTION
`Time.zone.today.to_time(:utc)` should not complain that: "it knows nothing about time zone in use" because it's specified right there.

FIx #2149