### PR TITLE
Fix an unnecessary offense for Rails/TimeZone

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@
 * [#2129](https://github.com/bbatsov/rubocop/issues/2129): Handle empty interpolations in `Style/SpaceInsideStringInterpolation`. ([@lumeet][])
 * [#2119](https://github.com/bbatsov/rubocop/issues/2119): Do not raise an error in `Style/RescueEnsureAlignment` and `Style/RescueModifier` when processing an excluded file. ([@rrosenblum][])
 * [#2149](https://github.com/bbatsov/rubocop/issues/2149): Do not register an offense in `Rails/Date` when `Date#to_time` is called with a time zone argument. ([@maxjacobson][])
+* Do not register a `Rails/TimeZone` offense when using Time.new safely. ([@maxjacobson][])
 
 ## 0.33.0 (05/08/2015)
 

--- a/lib/rubocop/cop/rails/time_zone.rb
+++ b/lib/rubocop/cop/rails/time_zone.rb
@@ -66,6 +66,8 @@ module RuboCop
 
           method_name = (chain & DANGEROUS_METHODS).join('.')
 
+          return if offset_provided?(node)
+
           message = build_message(klass, method_name, node)
 
           add_offense(node, :selector, message)
@@ -162,6 +164,15 @@ module RuboCop
           end
 
           acceptable
+        end
+
+        # Time.new can be called with a time zone offset
+        # When it is, that should be considered safe
+        # Example:
+        # Time.new(1988, 3, 15, 3, 0, 0, "-05:00")
+        def offset_provided?(node)
+          _, _, *args = *node
+          args.length >= 7
         end
       end
     end

--- a/spec/rubocop/cop/rails/time_zone_spec.rb
+++ b/spec/rubocop/cop/rails/time_zone_spec.rb
@@ -33,6 +33,11 @@ describe RuboCop::Cop::Rails::TimeZone, :config do
         expect(cop.offenses.first.message).to include('`Time.zone.local`')
       end
 
+      it "does not register an offense for #{klass}.new with zone argument" do
+        inspect_source(cop, "#{klass}.new(1988, 3, 15, 3, 0, 0, '-05:00')")
+        expect(cop.offenses).to be_empty
+      end
+
       it "registers an offense for ::#{klass}.now" do
         inspect_source(cop, "::#{klass}.now")
         expect(cop.offenses.size).to eq(1)


### PR DESCRIPTION
When 7 or more arguments are provided to Time.new or DateTime.new, the developer specified a UTC offset, and it will be used. That's great, right? That should be enough information not to raise an offense.