### PR TITLE
Allow individual non ASCII characters in comments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 * [#1351](https://github.com/bbatsov/rubocop/issues/1351): Allow class emitter methods in `Style/MethodName`. ([@jonas054][])
 * [#2126](https://github.com/bbatsov/rubocop/pull/2126): `Style/RescueModifier` can now auto-correct. ([@rrosenblum][])
 * [#2109](https://github.com/bbatsov/rubocop/issues/2109): Allow alignment with a token on the nearest line with same indentation in `Style/ExtraSpacing`. ([@jonas054][])
+* Allow individual non ASCII characters in `Style/AsciiComments`. ([@agrimm][])
 
 ### Bug Fixes
 

--- a/lib/rubocop/cop/style/ascii_comments.rb
+++ b/lib/rubocop/cop/style/ascii_comments.rb
@@ -10,7 +10,9 @@ module RuboCop
 
         def investigate(processed_source)
           processed_source.comments.each do |comment|
-            add_offense(comment, :expression) unless comment.text.ascii_only?
+            next if comment.text.ascii_only? ||
+                    comment.text !~ /[^\x00-\x7F]{2,}/
+            add_offense(comment, :expression)
           end
         end
       end

--- a/spec/rubocop/cop/style/ascii_comments_spec.rb
+++ b/spec/rubocop/cop/style/ascii_comments_spec.rb
@@ -18,4 +18,11 @@ describe RuboCop::Cop::Style::AsciiComments do
     inspect_source(cop, '# AZaz1@$%~,;*_`|')
     expect(cop.offenses).to be_empty
   end
+
+  it 'accepts comments with one non-ascii character' do
+    inspect_source(cop,
+                   ['# encoding: utf-8',
+                    '# REVIEW: Does this font handle "Ө" and "Ү"?'])
+    expect(cop.offenses).to be_empty
+  end
 end


### PR DESCRIPTION
I agree with https://github.com/bbatsov/ruby-style-guide#english-comments , but I sometimes have code falling foul of the cop for individual characters, such as a Euro symbol or a smart apostrophe. This allows one non-ASCII character at a time.

This doesn't have the number of non-ASCII characters configurable, but I don't see a good rationale for allowing more than one character at a time without turning the cop off.