### PR TITLE
Check case-end alignment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 * [#1351](https://github.com/bbatsov/rubocop/issues/1351): Allow class emitter methods in `Style/MethodName`. ([@jonas054][])
 * [#2126](https://github.com/bbatsov/rubocop/pull/2126): `Style/RescueModifier` can now auto-correct. ([@rrosenblum][])
 * [#2109](https://github.com/bbatsov/rubocop/issues/2109): Allow alignment with a token on the nearest line with same indentation in `Style/ExtraSpacing`. ([@jonas054][])
+* `Lint/EndAlignment` handles the `case` keyword. ([@lumeet][])
 
 ### Bug Fixes
 

--- a/lib/rubocop/cop/lint/end_alignment.rb
+++ b/lib/rubocop/cop/lint/end_alignment.rb
@@ -40,6 +40,10 @@ module RuboCop
           check_offset_of_node(node)
         end
 
+        def on_case(node)
+          check_offset_of_node(node)
+        end
+
         private
 
         def check_assignment(node, rhs)
@@ -50,7 +54,7 @@ module RuboCop
 
           return unless rhs
 
-          return unless [:if, :while, :until].include?(rhs.type)
+          return unless [:if, :while, :until, :case].include?(rhs.type)
           return if ternary_op?(rhs)
 
           expr = node.loc.expression

--- a/spec/rubocop/cop/lint/end_alignment_spec.rb
+++ b/spec/rubocop/cop/lint/end_alignment_spec.rb
@@ -17,6 +17,7 @@ describe RuboCop::Cop::Lint::EndAlignment, :config do
   include_examples 'misaligned', '', 'unless', 'test',      '  end'
   include_examples 'misaligned', '', 'while',  'test',      '  end'
   include_examples 'misaligned', '', 'until',  'test',      '  end'
+  include_examples 'misaligned', '', 'case',   'a when b',  '  end'
 
   include_examples 'aligned', 'class',  'Test',      'end'
   include_examples 'aligned', 'module', 'Test',      'end'
@@ -24,6 +25,7 @@ describe RuboCop::Cop::Lint::EndAlignment, :config do
   include_examples 'aligned', 'unless', 'test',      'end'
   include_examples 'aligned', 'while',  'test',      'end'
   include_examples 'aligned', 'until',  'test',      'end'
+  include_examples 'aligned', 'case',   'a when b',  'end'
 
   it 'can handle ternary if' do
     inspect_source(cop, 'a = cond ? x : y')
@@ -88,15 +90,17 @@ describe RuboCop::Cop::Lint::EndAlignment, :config do
 
   context 'regarding assignment' do
     context 'when AlignWith is keyword' do
-      include_examples 'misaligned', 'var = ', 'if',     'test', 'end'
-      include_examples 'misaligned', 'var = ', 'unless', 'test', 'end'
-      include_examples 'misaligned', 'var = ', 'while',  'test', 'end'
-      include_examples 'misaligned', 'var = ', 'until',  'test', 'end'
+      include_examples 'misaligned', 'var = ', 'if',     'test',     'end'
+      include_examples 'misaligned', 'var = ', 'unless', 'test',     'end'
+      include_examples 'misaligned', 'var = ', 'while',  'test',     'end'
+      include_examples 'misaligned', 'var = ', 'until',  'test',     'end'
+      include_examples 'misaligned', 'var = ', 'case',   'a when b', 'end'
 
-      include_examples 'aligned', 'var = if',     'test', '      end'
-      include_examples 'aligned', 'var = unless', 'test', '      end'
-      include_examples 'aligned', 'var = while',  'test', '      end'
-      include_examples 'aligned', 'var = until',  'test', '      end'
+      include_examples 'aligned', 'var = if',     'test',     '      end'
+      include_examples 'aligned', 'var = unless', 'test',     '      end'
+      include_examples 'aligned', 'var = while',  'test',     '      end'
+      include_examples 'aligned', 'var = until',  'test',     '      end'
+      include_examples 'aligned', 'var = case',   'a when b', '      end'
     end
 
     context 'when AlignWith is variable' do
@@ -104,20 +108,22 @@ describe RuboCop::Cop::Lint::EndAlignment, :config do
         { 'AlignWith' => 'variable', 'AutoCorrect' => true }
       end
 
-      include_examples 'aligned', 'var = if',     'test', 'end'
-      include_examples 'aligned', 'var = unless', 'test', 'end'
-      include_examples 'aligned', 'var = while',  'test', 'end'
-      include_examples 'aligned', 'var = until',  'test', 'end'
-      include_examples 'aligned', 'var = until',  'test', 'end.abc.join("")'
-      include_examples 'aligned', 'var = until',  'test', 'end.abc.tap {}'
+      include_examples 'aligned', 'var = if',     'test',     'end'
+      include_examples 'aligned', 'var = unless', 'test',     'end'
+      include_examples 'aligned', 'var = while',  'test',     'end'
+      include_examples 'aligned', 'var = until',  'test',     'end'
+      include_examples 'aligned', 'var = until',  'test',     'end.ab.join("")'
+      include_examples 'aligned', 'var = until',  'test',     'end.ab.tap {}'
+      include_examples 'aligned', 'var = case',   'a when b', 'end'
 
       include_examples 'aligned', "var =\n  if",  'test', '  end'
 
-      include_examples 'misaligned', '', 'var = if',     'test', '      end'
-      include_examples 'misaligned', '', 'var = unless', 'test', '      end'
-      include_examples 'misaligned', '', 'var = while',  'test', '      end'
-      include_examples 'misaligned', '', 'var = until',  'test', '      end'
-      include_examples 'misaligned', '', 'var = until',  'test', '      end.j'
+      include_examples 'misaligned', '', 'var = if',     'test',     '      end'
+      include_examples 'misaligned', '', 'var = unless', 'test',     '      end'
+      include_examples 'misaligned', '', 'var = while',  'test',     '      end'
+      include_examples 'misaligned', '', 'var = until',  'test',     '      end'
+      include_examples 'misaligned', '', 'var = until',  'test',   '      end.j'
+      include_examples 'misaligned', '', 'var = case',   'a when b', '      end'
 
       include_examples 'aligned', '@var = if',  'test', 'end'
       include_examples 'aligned', '@@var = if', 'test', 'end'


### PR DESCRIPTION
`Lint/EndAlignment` handles the `case` keyword.