### PR TITLE
Refactor empty_line_between_defs cop

### DIFF
--- a/spec/rubocop/cop/style/empty_line_between_defs_spec.rb
+++ b/spec/rubocop/cop/style/empty_line_between_defs_spec.rb
@@ -141,6 +141,18 @@ describe RuboCop::Cop::Style::EmptyLineBetweenDefs, :config do
                              '  def b; end'].join("\n"))
   end
 
+  it 'treats lines with whitespaces as blank' do
+    source = ['  class J',
+              '    def n',
+              '    end',
+              '    ',
+              '    def o',
+              '    end',
+              '  end']
+    inspect_source(cop, source)
+    expect(cop.offenses).to be_empty
+  end
+
   context 'when AllowAdjacentOneLineDefs is enabled' do
     let(:cop_config) { { 'AllowAdjacentOneLineDefs' => true } }
 


### PR DESCRIPTION
Simplified conditionals in empty_line_between_defs cop and extracted a
few methods

That's a follow-up to https://github.com/bbatsov/rubocop/pull/2136