### PR TITLE
[Fix #2009] Use SafeYAML.whitelist! to allow deserialize Regexp when SafeYAML is required

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,4 +19,5 @@ install:
   - bundle install --retry=3
 script:
   - bundle exec rspec
+  - bundle exec rake coveralls:push
   - bundle exec rubocop

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@
 * Do not register a `Rails/TimeZone` offense when using Time.new safely. ([@maxjacobson][])
 * [#2124](https://github.com/bbatsov/rubocop/issues/2124): Fix bug in `Style/EmptyLineBetweenDefs` when there are only comments between method definitions. ([@lumeet][])
 * [#2154](https://github.com/bbatsov/rubocop/issues/2154): `Performance/StringReplacement` can auto-correct replacements with backslash in them. ([@rrosenblum][])
+* [#2009](https://github.com/bbatsov/rubocop/issues/2009): Fix bug in `RuboCop::ConfigLoader.load_file` when `safe_yaml` is required. ([@eitoball][])
 
 ## 0.33.0 (05/08/2015)
 

--- a/Gemfile
+++ b/Gemfile
@@ -6,6 +6,7 @@ gemspec
 
 group :test do
   gem 'coveralls', require: false
+  gem 'safe_yaml', require: false
 end
 
 local_gemfile = 'Gemfile.local'

--- a/Rakefile
+++ b/Rakefile
@@ -30,6 +30,13 @@ task default: [:spec, :internal_investigation]
 require 'yard'
 YARD::Rake::YardocTask.new
 
+begin
+  require 'coveralls/rake/task'
+  Coveralls::RakeTask.new
+rescue LoadError
+  warn 'Coveralls rake task is not loaded. Only for test'
+end
+
 RuboCop::RakeTask.new
 
 task :console do

--- a/lib/rubocop/config_loader.rb
+++ b/lib/rubocop/config_loader.rb
@@ -147,7 +147,11 @@ module RuboCop
 
       def yaml_safe_load(yaml_code)
         if YAML.respond_to?(:safe_load) # Ruby 2.1+
-          YAML.safe_load(yaml_code, [Regexp])
+          if defined?(SafeYAML)
+            YAML.safe_load(yaml_code, nil, whitelisted_tags: %w(!ruby/regexp))
+          else
+            YAML.safe_load(yaml_code, [Regexp])
+          end
         else
           YAML.load(yaml_code)
         end

--- a/rubocop.gemspec
+++ b/rubocop.gemspec
@@ -47,5 +47,5 @@ Gem::Specification.new do |s|
   s.add_development_dependency('rspec', '~> 3.2.0')
   s.add_development_dependency('yard', '~> 0.8')
   s.add_development_dependency('bundler', '~> 1.3')
-  s.add_development_dependency('simplecov', '~> 0.7')
+  s.add_development_dependency('simplecov', '~> 0.10')
 end

--- a/spec/rubocop/config_loader_spec.rb
+++ b/spec/rubocop/config_loader_spec.rb
@@ -304,6 +304,12 @@ describe RuboCop::ConfigLoader do
         if ::Process.respond_to?(:fork)
           # To load SafeYAML in different memory space
           pid = ::Process.fork do
+            # Need to write coverage result under different name
+            if defined?(SimpleCov)
+              SimpleCov.command_name "rspec_#{Process.pid}"
+              SimpleCov.pid = Process.pid
+            end
+
             require 'safe_yaml'
             configuration = described_class.load_file('.rubocop.yml')
 

--- a/spec/support/coverage.rb
+++ b/spec/support/coverage.rb
@@ -2,12 +2,9 @@
 
 if ENV['TRAVIS'] || ENV['COVERAGE']
   require 'simplecov'
+  require 'coveralls' if ENV['TRAVIS']
 
-  if ENV['TRAVIS']
-    require 'coveralls'
-    SimpleCov.formatter = Coveralls::SimpleCov::Formatter
-  end
-
+  SimpleCov.command_name "rspec_#{Process.pid}"
   SimpleCov.start do
     add_filter '/spec/'
     add_filter '/vendor/bundle/'


### PR DESCRIPTION
`SafeYAML` overrides `YAML.safe_yaml` with `SafeYAML.load`. This method has different method signature.