### PR TITLE
Use `String#blank?` instead of regexes

### DIFF
--- a/lib/rubocop/cop/mixin/autocorrect_alignment.rb
+++ b/lib/rubocop/cop/mixin/autocorrect_alignment.rb
@@ -45,7 +45,7 @@ module RuboCop
       end
 
       def start_of_line?(loc)
-        loc.expression.source_line[0...loc.column] =~ /^\s*$/
+        loc.expression.source_line[0...loc.column].blank?
       end
 
       def autocorrect(arg)

--- a/lib/rubocop/cop/style/first_parameter_indentation.rb
+++ b/lib/rubocop/cop/style/first_parameter_indentation.rb
@@ -99,7 +99,7 @@ module RuboCop
             .map { |c| c.loc.line }
 
           line = ''
-          while line =~ /^\s*$/ || @comment_lines.include?(line_number)
+          while line.blank? || @comment_lines.include?(line_number)
             line_number -= 1
             line = processed_source.lines[line_number - 1]
           end


### PR DESCRIPTION
Since we have `String#blank?` from Powerpack, it would be better to use
that instead of regexes that do the same thing.