### PR TITLE
[Fix #2154] Fix auto-correct of StringReplacement with a backslash

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@
 * [#2149](https://github.com/bbatsov/rubocop/issues/2149): Do not register an offense in `Rails/Date` when `Date#to_time` is called with a time zone argument. ([@maxjacobson][])
 * Do not register a `Rails/TimeZone` offense when using Time.new safely. ([@maxjacobson][])
 * [#2124](https://github.com/bbatsov/rubocop/issues/2124): Fix bug in `Style/EmptyLineBetweenDefs` when there are only comments between method definitions. ([@lumeet][])
+* [#2154](https://github.com/bbatsov/rubocop/issues/2154): `Performance/StringReplacement` can auto-correct replacements with backslash in them. ([@rrosenblum][])
 
 ## 0.33.0 (05/08/2015)
 

--- a/spec/rubocop/cop/performance/string_replacement_spec.rb
+++ b/spec/rubocop/cop/performance/string_replacement_spec.rb
@@ -366,10 +366,16 @@ describe RuboCop::Cop::Performance::StringReplacement do
         expect(new_source).to eq("'abc'.tr('a', '1')")
       end
 
-      it 'when the replacement contains an escape character' do
+      it 'when the replacement contains an escape new line character' do
         new_source = autocorrect_source(cop, "'abc'.gsub('a', '\n')")
 
-        expect(new_source).to eq("'abc'.tr('a', \"\\n\")")
+        expect(new_source).to eq("'abc'.tr('a', '\n')")
+      end
+
+      it 'when the replacement contains an escape backslash character' do
+        new_source = autocorrect_source(cop, "\"\".gsub('/', '\\\\')")
+
+        expect(new_source).to eq("\"\".tr('/', '\\\\')")
       end
 
       it 'when the pattern contains an escape character' do


### PR DESCRIPTION
This fixes #2154. It was easier to not touch the second parameter rather than trying to properly escape it. In my mind, this is a slightly more simplistic solution. The only down fall is that when replacing with `delete`, 2 calls to corrector are needed.

Some general clean up made it in as well, let me know if I should break this out into a different commit/PR.