### PR TITLE
Remove unneded `require`s

### DIFF
--- a/spec/rubocop/cop/rails/action_filter_spec.rb
+++ b/spec/rubocop/cop/rails/action_filter_spec.rb
@@ -1,7 +1,6 @@
 # encoding: utf-8
 
 require 'spec_helper'
-require 'tempfile'
 
 describe RuboCop::Cop::Rails::ActionFilter, :config do
   subject(:cop) { described_class.new(config) }

--- a/spec/rubocop/cop/style/end_of_line_spec.rb
+++ b/spec/rubocop/cop/style/end_of_line_spec.rb
@@ -1,7 +1,6 @@
 # encoding: utf-8
 
 require 'spec_helper'
-require 'tempfile'
 
 describe RuboCop::Cop::Style::EndOfLine do
   subject(:cop) { described_class.new }

--- a/spec/rubocop/formatter/formatter_set_spec.rb
+++ b/spec/rubocop/formatter/formatter_set_spec.rb
@@ -1,7 +1,6 @@
 # encoding: utf-8
 
 require 'spec_helper'
-require 'tempfile'
 
 module RuboCop
   module Formatter

--- a/spec/rubocop/formatter/simple_text_formatter_spec.rb
+++ b/spec/rubocop/formatter/simple_text_formatter_spec.rb
@@ -2,7 +2,6 @@
 
 require 'spec_helper'
 require 'stringio'
-require 'tempfile'
 
 module RuboCop
   module Formatter


### PR DESCRIPTION
Since the spec helper rewrite done in #1403, the tempfile library is being required in the proper place: [where it is used](https://github.com/bbatsov/rubocop/blob/master/spec/support/cop_helper.rb). Thus, these requires can be removed now.