### PR TITLE
Ignore irrelevant cops when investigating a file

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -12,7 +12,7 @@ Metrics/AbcSize:
 # Offense count: 13
 # Configuration parameters: CountComments.
 Metrics/ClassLength:
-  Max: 141
+  Max: 144
 
 # Offense count: 42
 Metrics/CyclomaticComplexity:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 * [#2109](https://github.com/bbatsov/rubocop/issues/2109): Allow alignment with a token on the nearest line with same indentation in `Style/ExtraSpacing`. ([@jonas054][])
 * `Lint/EndAlignment` handles the `case` keyword. ([@lumeet][])
 * [#2146](https://github.com/bbatsov/rubocop/pull/2146): Add STDIN support. ([@caseywebdev][])
+* [#2175](https://github.com/bbatsov/rubocop/pull/2175): Files that are excluded from a cop (e.g. using the `Exclude:` config option) are no longer being processed by that cop. ([@bquorning][])
 
 ### Bug Fixes
 

--- a/lib/rubocop/cop/cop.rb
+++ b/lib/rubocop/cop/cop.rb
@@ -198,6 +198,10 @@ module RuboCop
           !file_name_matches_any?(file, 'Exclude', false)
       end
 
+      def excluded_file?(file)
+        !relevant_file?(file)
+      end
+
       def style_guide_url
         url = cop_config && cop_config['StyleGuide']
         (url.nil? || url.empty?) ? nil : url

--- a/spec/rubocop/cop/commissioner_spec.rb
+++ b/spec/rubocop/cop/commissioner_spec.rb
@@ -4,7 +4,9 @@ require 'spec_helper'
 
 describe RuboCop::Cop::Commissioner do
   describe '#investigate' do
-    let(:cop) { double(RuboCop::Cop, offenses: []).as_null_object }
+    let(:cop) do
+      double(RuboCop::Cop, offenses: [], excluded_file?: false).as_null_object
+    end
     let(:force) { double(RuboCop::Cop::Force).as_null_object }
 
     it 'returns all offenses found by the cops' do
@@ -20,9 +22,9 @@ describe RuboCop::Cop::Commissioner do
     context 'when a cop has no interest in the file' do
       it 'returns all offenses except the ones of the cop' do
         cops = []
-        cops << double('cop A', offenses: %w(foo), relevant_file?: true)
-        cops << double('cop B', offenses: %w(bar), relevant_file?: false)
-        cops << double('cop C', offenses: %w(baz), relevant_file?: true)
+        cops << double('cop A', offenses: %w(foo), excluded_file?: false)
+        cops << double('cop B', offenses: %w(bar), excluded_file?: true)
+        cops << double('cop C', offenses: %w(baz), excluded_file?: false)
         cops.each(&:as_null_object)
 
         commissioner = described_class.new(cops, [])

--- a/spec/rubocop/cop/rails/action_filter_spec.rb
+++ b/spec/rubocop/cop/rails/action_filter_spec.rb
@@ -4,9 +4,12 @@ require 'spec_helper'
 
 describe RuboCop::Cop::Rails::ActionFilter, :config do
   subject(:cop) { described_class.new(config) }
+  let(:cop_config) { { 'Include' => nil } }
 
   context 'when style is action' do
-    let(:cop_config) { { 'EnforcedStyle' => 'action' } }
+    before do
+      cop_config.update('EnforcedStyle' => 'action')
+    end
 
     described_class::FILTER_METHODS.each do |method|
       it "registers an offense for #{method}" do
@@ -34,7 +37,9 @@ describe RuboCop::Cop::Rails::ActionFilter, :config do
   end
 
   context 'when style is filter' do
-    let(:cop_config) { { 'EnforcedStyle' => 'filter' } }
+    before do
+      cop_config.update('EnforcedStyle' => 'filter')
+    end
 
     described_class::ACTION_METHODS.each do |method|
       it "registers an offense for #{method}" do


### PR DESCRIPTION
Fixes #2142.

Instead of checking a cop's relevance for the current file multiple times in the investigation process, we can filter the cops one time, at the very beginning of the investigation.

The specs ~~are~~ were failing because of `Rails/ActionFilter`s default configuration:
```yml
Rails/ActionFilter:
  Include:
    - app/controllers/**/*.rb
```

The temporary file being tested of course doesn’t match the configured `Include` pattern, and is therefore ignored. ~~But I believe this is a problem with the spec, not with the implementation. Please help me: how can the specs be fixed?~~