### PR TITLE
Fix alignment for assignments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@
 * [#2124](https://github.com/bbatsov/rubocop/issues/2124): Fix bug in `Style/EmptyLineBetweenDefs` when there are only comments between method definitions. ([@lumeet][])
 * [#2154](https://github.com/bbatsov/rubocop/issues/2154): `Performance/StringReplacement` can auto-correct replacements with backslash in them. ([@rrosenblum][])
 * [#2009](https://github.com/bbatsov/rubocop/issues/2009): Fix bug in `RuboCop::ConfigLoader.load_file` when `safe_yaml` is required. ([@eitoball][])
+* [#2155](https://github.com/bbatsov/rubocop/issues/2155): Configuration `EndAlignment: AlignWith: variable` only applies when the operands of `=` are on the same line. ([@jonas054][])
 
 ## 0.33.0 (05/08/2015)
 

--- a/lib/rubocop/cop/lint/end_alignment.rb
+++ b/lib/rubocop/cop/lint/end_alignment.rb
@@ -58,7 +58,7 @@ module RuboCop
           return if ternary_op?(rhs)
 
           expr = node.loc.expression
-          if style == :variable && !line_break_before_keyword?(expr, rhs)
+          if variable_alignment?(expr, rhs, style)
             range = Parser::Source::Range.new(expr.source_buffer,
                                               expr.begin_pos,
                                               rhs.loc.keyword.end_pos)
@@ -70,10 +70,6 @@ module RuboCop
 
           check_offset(rhs, range.source, offset)
           ignore_node(rhs) # Don't check again.
-        end
-
-        def line_break_before_keyword?(whole_expression, rhs)
-          rhs.loc.keyword.line > whole_expression.line
         end
 
         def autocorrect(node)

--- a/lib/rubocop/cop/mixin/end_keyword_alignment.rb
+++ b/lib/rubocop/cop/mixin/end_keyword_alignment.rb
@@ -38,6 +38,15 @@ module RuboCop
         'AlignWith'
       end
 
+      def variable_alignment?(whole_expression, rhs, end_alignment_style)
+        end_alignment_style == :variable &&
+          !line_break_before_keyword?(whole_expression, rhs)
+      end
+
+      def line_break_before_keyword?(whole_expression, rhs)
+        rhs.loc.line > whole_expression.line
+      end
+
       def align(node, alignment_node)
         source_buffer = node.loc.expression.source_buffer
         begin_pos = node.loc.end.begin_pos

--- a/lib/rubocop/cop/style/else_alignment.rb
+++ b/lib/rubocop/cop/style/else_alignment.rb
@@ -86,7 +86,11 @@ module RuboCop
 
           end_config = config.for_cop('Lint/EndAlignment')
           style = end_config['Enabled'] ? end_config['AlignWith'] : 'keyword'
-          base = style == 'variable' ? node : rhs
+          base = if style == 'variable' && node.loc.line == rhs.loc.line
+                   node
+                 else
+                   rhs
+                 end
 
           return if rhs.type != :if
 

--- a/lib/rubocop/cop/style/else_alignment.rb
+++ b/lib/rubocop/cop/style/else_alignment.rb
@@ -8,6 +8,7 @@ module RuboCop
       # are special cases when they should follow the same rules as the
       # alignment of end.
       class ElseAlignment < Cop
+        include EndKeywordAlignment
         include AutocorrectAlignment
         include CheckAssignment
 
@@ -86,11 +87,7 @@ module RuboCop
 
           end_config = config.for_cop('Lint/EndAlignment')
           style = end_config['Enabled'] ? end_config['AlignWith'] : 'keyword'
-          base = if style == 'variable' && node.loc.line == rhs.loc.line
-                   node
-                 else
-                   rhs
-                 end
+          base = variable_alignment?(node.loc, rhs, style.to_sym) ? node : rhs
 
           return if rhs.type != :if
 

--- a/lib/rubocop/cop/style/indentation_width.rb
+++ b/lib/rubocop/cop/style/indentation_width.rb
@@ -13,6 +13,7 @@ module RuboCop
       #    end
       #   end
       class IndentationWidth < Cop # rubocop:disable Metrics/ClassLength
+        include EndKeywordAlignment
         include AutocorrectAlignment
         include OnMethodDef
         include CheckAssignment
@@ -174,11 +175,7 @@ module RuboCop
 
           end_config = config.for_cop('Lint/EndAlignment')
           style = end_config['Enabled'] ? end_config['AlignWith'] : 'keyword'
-          base = if style == 'variable' && node.loc.line == rhs.loc.line
-                   node
-                 else
-                   rhs
-                 end
+          base = variable_alignment?(node.loc, rhs, style.to_sym) ? node : rhs
 
           case rhs.type
           when :if            then on_if(rhs, base)

--- a/lib/rubocop/cop/style/indentation_width.rb
+++ b/lib/rubocop/cop/style/indentation_width.rb
@@ -174,7 +174,11 @@ module RuboCop
 
           end_config = config.for_cop('Lint/EndAlignment')
           style = end_config['Enabled'] ? end_config['AlignWith'] : 'keyword'
-          base = style == 'variable' ? node : rhs
+          base = if style == 'variable' && node.loc.line == rhs.loc.line
+                   node
+                 else
+                   rhs
+                 end
 
           case rhs.type
           when :if            then on_if(rhs, base)

--- a/spec/rubocop/cop/style/else_alignment_spec.rb
+++ b/spec/rubocop/cop/style/else_alignment_spec.rb
@@ -39,6 +39,18 @@ describe RuboCop::Cop::Style::ElseAlignment do
       expect(cop.highlights).to eq(['elsif'])
     end
 
+    it 'accepts indentation after else when if is on new line after ' \
+       'assignment' do
+      inspect_source(cop,
+                     ['Rails.application.config.ideal_postcodes_key =',
+                      '  if Rails.env.production? || Rails.env.staging?',
+                      '    "AAAA-AAAA-AAAA-AAAA"',
+                      '  else',
+                      '    "BBBB-BBBB-BBBB-BBBB"',
+                      '  end'])
+      expect(cop.offenses).to be_empty
+    end
+
     describe '#autocorrect' do
       it 'corrects bad alignment' do
         corrected = autocorrect_source(cop,

--- a/spec/rubocop/cop/style/indentation_width_spec.rb
+++ b/spec/rubocop/cop/style/indentation_width_spec.rb
@@ -115,6 +115,15 @@ describe RuboCop::Cop::Style::IndentationWidth do
           .to eq(['Use 2 (not 3) spaces for indentation.'])
       end
 
+      it 'accepts indentation after if on new line after assignment' do
+        inspect_source(cop,
+                       ['Rails.application.config.ideal_postcodes_key =',
+                        '  if Rails.env.production? || Rails.env.staging?',
+                        '    "AAAA-AAAA-AAAA-AAAA"',
+                        '  end'])
+        expect(cop.offenses).to be_empty
+      end
+
       describe '#autocorrect' do
         it 'corrects bad indentation' do
           corrected = autocorrect_source(cop,


### PR DESCRIPTION
When there is a line break after `=` then indentation after `if`/`else` shall be relative to the keyword and not to the variable.