### PR TITLE
Fix alignment of rescue/ensure after empty body

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,7 @@
 * [#2154](https://github.com/bbatsov/rubocop/issues/2154): `Performance/StringReplacement` can auto-correct replacements with backslash in them. ([@rrosenblum][])
 * [#2009](https://github.com/bbatsov/rubocop/issues/2009): Fix bug in `RuboCop::ConfigLoader.load_file` when `safe_yaml` is required. ([@eitoball][])
 * [#2155](https://github.com/bbatsov/rubocop/issues/2155): Configuration `EndAlignment: AlignWith: variable` only applies when the operands of `=` are on the same line. ([@jonas054][])
+* Fix bug in `Style/IndentationWidth` when `rescue` or `ensure` is preceded by an empty body. ([@lumeet][])
 
 ## 0.33.0 (05/08/2015)
 

--- a/lib/rubocop/cop/style/indentation_width.rb
+++ b/lib/rubocop/cop/style/indentation_width.rb
@@ -256,6 +256,11 @@ module RuboCop
           first_char_pos_on_line = body_node.loc.expression.source_line =~ /\S/
           return false unless body_node.loc.column == first_char_pos_on_line
 
+          if [:rescue, :ensure].include?(body_node.type)
+            block_body, *_ = *body_node
+            return unless block_body
+          end
+
           true
         end
 

--- a/spec/rubocop/cop/style/indentation_width_spec.rb
+++ b/spec/rubocop/cop/style/indentation_width_spec.rb
@@ -124,6 +124,22 @@ describe RuboCop::Cop::Style::IndentationWidth do
         expect(cop.offenses).to be_empty
       end
 
+      it 'accepts `rescue` after an empty body' do
+        inspect_source(cop, ['begin',
+                             'rescue',
+                             '  handle_error',
+                             'end'])
+        expect(cop.offenses).to be_empty
+      end
+
+      it 'accepts `ensure` after an empty body' do
+        inspect_source(cop, ['begin',
+                             'ensure',
+                             '  something',
+                             'end'])
+        expect(cop.offenses).to be_empty
+      end
+
       describe '#autocorrect' do
         it 'corrects bad indentation' do
           corrected = autocorrect_source(cop,


### PR DESCRIPTION
`Style/IndentationWidth` never aligns `rescue` or `ensure`.

Related to #2121.