### PR TITLE
[Fix #2177] Fix invalid offense for def inside `if`

### DIFF
--- a/lib/rubocop/cop/style/empty_line_between_defs.rb
+++ b/lib/rubocop/cop/style/empty_line_between_defs.rb
@@ -9,6 +9,8 @@ module RuboCop
         MSG = 'Use empty lines between defs.'
 
         def on_def(node)
+          return unless node.parent && node.parent.begin_type?
+
           nodes = [prev_node(node), node]
 
           return unless nodes.all?(&method(:def_node?))
@@ -30,7 +32,7 @@ module RuboCop
         end
 
         def prev_node(node)
-          return nil unless node.parent && node.sibling_index > 0
+          return nil unless node.sibling_index > 0
 
           node.parent.children[node.sibling_index - 1]
         end

--- a/spec/rubocop/cop/style/empty_line_between_defs_spec.rb
+++ b/spec/rubocop/cop/style/empty_line_between_defs_spec.rb
@@ -56,6 +56,39 @@ describe RuboCop::Cop::Style::EmptyLineBetweenDefs, :config do
     end
   end
 
+  context 'conditional method definitions' do
+    it 'accepts defs inside a conditional without blank lines in between' do
+      source = ['if condition',
+                '  def foo',
+                '    true',
+                '  end',
+                'else',
+                '  def foo',
+                '    false',
+                '  end',
+                'end']
+      inspect_source(cop, source)
+      expect(cop.offenses).to be_empty
+    end
+
+    it 'registers an offense for consecutive defs inside a conditional' do
+      source = ['if condition',
+                '  def foo',
+                '    true',
+                '  end',
+                '  def bar',
+                '    true',
+                '  end',
+                'else',
+                '  def foo',
+                '    false',
+                '  end',
+                'end']
+      inspect_source(cop, source)
+      expect(cop.offenses.size).to eq(1)
+    end
+  end
+
   # Only one def, so rule about empty line *between* defs does not
   # apply.
   it 'accepts a def that follows a line with code' do


### PR DESCRIPTION
Invalid offense was reported by `Style/EmptyLineBetweenDefs` for def
nodes inside both branches of an `if` statement. I've added a check and
specs for this case.

It looks like it's the only case of that nature that we need to check,
so a simple check for `if` parent node would suffice.