### PR TITLE
[Fix #2183] Fix auto-correcting adjacent braces

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,7 @@
 * [#2009](https://github.com/bbatsov/rubocop/issues/2009): Fix bug in `RuboCop::ConfigLoader.load_file` when `safe_yaml` is required. ([@eitoball][])
 * [#2155](https://github.com/bbatsov/rubocop/issues/2155): Configuration `EndAlignment: AlignWith: variable` only applies when the operands of `=` are on the same line. ([@jonas054][])
 * Fix bug in `Style/IndentationWidth` when `rescue` or `ensure` is preceded by an empty body. ([@lumeet][])
+* [#2183](https://github.com/bbatsov/rubocop/issues/2183): Fix bug in `Style/BlockDelimiters` when auto-correcting adjacent braces. ([@lumeet][])
 
 ## 0.33.0 (05/08/2015)
 

--- a/lib/rubocop/cop/style/block_delimiters.rb
+++ b/lib/rubocop/cop/style/block_delimiters.rb
@@ -59,11 +59,8 @@ module RuboCop
             b = node.loc.begin
             e = node.loc.end
             if b.is?('{')
-              # If the left brace is not preceded by a whitespace character,
-              # then we need a space before `do` to get valid Ruby code.
-              if b.source_buffer.source[b.begin_pos - 1, 1] =~ /\S/
-                corrector.insert_before(b, ' ')
-              end
+              corrector.insert_before(b, ' ') unless whitespace_before?(b)
+              corrector.insert_before(e, ' ') unless whitespace_before?(e)
               corrector.replace(b, 'do')
               corrector.replace(e, 'end')
             else
@@ -71,6 +68,10 @@ module RuboCop
               corrector.replace(e, '}')
             end
           end
+        end
+
+        def whitespace_before?(node)
+          node.source_buffer.source[node.begin_pos - 1, 1] =~ /\s/
         end
 
         def get_block(node)

--- a/spec/rubocop/cop/style/block_delimiters_spec.rb
+++ b/spec/rubocop/cop/style/block_delimiters_spec.rb
@@ -334,6 +334,17 @@ describe RuboCop::Cop::Style::BlockDelimiters, :config do
         expect(new_source).to eq(expected_source)
       end
 
+      it 'auto-corrects adjacent curly braces correctly' do
+        source = ['(0..3).each { |a| a.times {',
+                  '  puts a',
+                  '}}']
+
+        new_source = autocorrect_source(cop, source)
+        expect(new_source).to eq(['(0..3).each do |a| a.times do',
+                                  '  puts a',
+                                  'end end'].join("\n"))
+      end
+
       it 'does not auto-correct {} if do-end would introduce a syntax error' do
         src = ['my_method :arg1, arg2: proc {',
                '  something',


### PR DESCRIPTION
`Style/BlockDelimiters` doesn't produce `endend` when auto-correcting
nested blocks.