### PR TITLE
Include all *_filter and *_action methods from Rails 4.2 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
 * `Lint/EndAlignment` handles the `case` keyword. ([@lumeet][])
 * [#2146](https://github.com/bbatsov/rubocop/pull/2146): Add STDIN support. ([@caseywebdev][])
 * [#2175](https://github.com/bbatsov/rubocop/pull/2175): Files that are excluded from a cop (e.g. using the `Exclude:` config option) are no longer being processed by that cop. ([@bquorning][])
+* `Rails/ActionFilter` now handles complete list of methods found in the Rails 4.2 [release notes](https://github.com/rails/rails/blob/4115a12da1409c753c747fd4bab6e612c0c6e51a/guides/source/4_2_release_notes.md#notable-changes-1). ([@MGerrior][])
 
 ### Bug Fixes
 
@@ -1564,3 +1565,4 @@
 [@syndbg]: https://github.com/syndbg
 [@wli]: https://github.com/wli
 [@caseywebdev]: https://github.com/caseywebdev
+[@MGerrior]: https://github.com/MGerrior

--- a/lib/rubocop/cop/rails/action_filter.rb
+++ b/lib/rubocop/cop/rails/action_filter.rb
@@ -12,11 +12,37 @@ module RuboCop
 
         MSG = 'Prefer `%s` over `%s`.'
 
-        FILTER_METHODS = [:before_filter, :skip_before_filter,
-                          :after_filter, :around_filter]
+        FILTER_METHODS = [
+          :after_filter,
+          :append_after_filter,
+          :append_around_filter,
+          :append_before_filter,
+          :around_filter,
+          :before_filter,
+          :prepend_after_filter,
+          :prepend_around_filter,
+          :prepend_before_filter,
+          :skip_after_filter,
+          :skip_around_filter,
+          :skip_before_filter,
+          :skip_filter
+        ]
 
-        ACTION_METHODS = [:before_action, :skip_before_action,
-                          :after_action, :around_action]
+        ACTION_METHODS = [
+          :after_action,
+          :append_after_action,
+          :append_around_action,
+          :append_before_action,
+          :around_action,
+          :before_action,
+          :prepend_after_action,
+          :prepend_around_action,
+          :prepend_before_action,
+          :skip_after_action,
+          :skip_around_action,
+          :skip_before_action,
+          :skip_action_callback
+        ]
 
         def on_block(node)
           method, _args, _body = *node

--- a/spec/rubocop/cop/rails/action_filter_spec.rb
+++ b/spec/rubocop/cop/rails/action_filter_spec.rb
@@ -6,6 +6,46 @@ describe RuboCop::Cop::Rails::ActionFilter, :config do
   subject(:cop) { described_class.new(config) }
   let(:cop_config) { { 'Include' => nil } }
 
+  describe '::FILTER_METHODS' do
+    it 'contains all of the filter methods' do
+      expect(described_class::FILTER_METHODS).to eq([
+        :after_filter,
+        :append_after_filter,
+        :append_around_filter,
+        :append_before_filter,
+        :around_filter,
+        :before_filter,
+        :prepend_after_filter,
+        :prepend_around_filter,
+        :prepend_before_filter,
+        :skip_after_filter,
+        :skip_around_filter,
+        :skip_before_filter,
+        :skip_filter
+      ])
+    end
+  end
+
+  describe '::ACTION_METHODS' do
+    it 'contains all of the action methods' do
+      expect(described_class::ACTION_METHODS).to eq([
+        :after_action,
+        :append_after_action,
+        :append_around_action,
+        :append_before_action,
+        :around_action,
+        :before_action,
+        :prepend_after_action,
+        :prepend_around_action,
+        :prepend_before_action,
+        :skip_after_action,
+        :skip_around_action,
+        :skip_before_action,
+        :skip_action_callback
+      ])
+    end
+  end
+
   context 'when style is action' do
     before do
       cop_config.update('EnforcedStyle' => 'action')


### PR DESCRIPTION
This commit attempts to round out the list of `*_filter` and `*_action`
methods that are detected and replaced by the `Rails/ActionFilter` cop. It
is currently only acting on 4 out of the 13 methods listed in the Rails
4.2 [release notes] (https://github.com/rails/rails/blob/4115a12da1409c753c747fd4bab6e612c0c6e51a/guides/source/4_2_release_notes.md#notable-changes-1).