### PR TITLE
Handle class methods in EmptyLineBetweenDefs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@
 * [#2175](https://github.com/bbatsov/rubocop/pull/2175): Files that are excluded from a cop (e.g. using the `Exclude:` config option) are no longer being processed by that cop. ([@bquorning][])
 * `Rails/ActionFilter` now handles complete list of methods found in the Rails 4.2 [release notes](https://github.com/rails/rails/blob/4115a12da1409c753c747fd4bab6e612c0c6e51a/guides/source/4_2_release_notes.md#notable-changes-1). ([@MGerrior][])
 * [*2138](https://github.com/bbatsov/rubocop/issues/2138): Change the offense in `Style/Next` to highlight the condition instead of the iteration. ([@rrosenblum][])
+* `Style/EmptyLineBetweenDefs` now handles class methods as well. ([@unmanbearpig][])
 
 ### Bug Fixes
 

--- a/lib/rubocop/cop/style/empty_line_between_defs.rb
+++ b/lib/rubocop/cop/style/empty_line_between_defs.rb
@@ -6,9 +6,10 @@ module RuboCop
       # This cop checks whether method definitions are
       # separated by empty lines.
       class EmptyLineBetweenDefs < Cop
+        include OnMethodDef
         MSG = 'Use empty lines between method definitions.'
 
-        def on_def(node)
+        def on_method_def(node, _method_name, _args, _body)
           return unless node.parent && node.parent.begin_type?
 
           nodes = [prev_node(node), node]
@@ -24,7 +25,8 @@ module RuboCop
         private
 
         def def_node?(node)
-          node && node.def_type?
+          return unless node
+          node.def_type? || node.defs_type?
         end
 
         def blank_lines_between?(first_def_node, second_def_node)

--- a/spec/rubocop/cop/style/empty_line_between_defs_spec.rb
+++ b/spec/rubocop/cop/style/empty_line_between_defs_spec.rb
@@ -89,6 +89,72 @@ describe RuboCop::Cop::Style::EmptyLineBetweenDefs, :config do
     end
   end
 
+  context 'class methods' do
+    context 'adjacent class methods' do
+      let(:offending_source) do
+        ['class Test',
+         '  def self.foo',
+         '    true',
+         '  end',
+         '  def self.bar',
+         '    true',
+         '  end',
+         'end']
+      end
+
+      it 'registers an offense for missing blank line between methods' do
+        inspect_source(cop, offending_source)
+        expect(cop.offenses.size).to eq(1)
+      end
+
+      it 'autocorrects it' do
+        corrected = autocorrect_source(cop, offending_source)
+        expect(corrected).to eq(['class Test',
+                                 '  def self.foo',
+                                 '    true',
+                                 '  end',
+                                 '',
+                                 '  def self.bar',
+                                 '    true',
+                                 '  end',
+                                 'end']
+                                 .join("\n"))
+      end
+    end
+
+    context 'mixed instance and class methods' do
+      let(:offending_source) do
+        ['class Test',
+         '  def foo',
+         '    true',
+         '  end',
+         '  def self.bar',
+         '    true',
+         '  end',
+         'end']
+      end
+
+      it 'registers an offense for missing blank line between methods' do
+        inspect_source(cop, offending_source)
+        expect(cop.offenses.size).to eq(1)
+      end
+
+      it 'autocorrects it' do
+        corrected = autocorrect_source(cop, offending_source)
+        expect(corrected).to eq(['class Test',
+                                 '  def foo',
+                                 '    true',
+                                 '  end',
+                                 '',
+                                 '  def self.bar',
+                                 '    true',
+                                 '  end',
+                                 'end']
+                                 .join("\n"))
+      end
+    end
+  end
+
   # Only one def, so rule about empty line *between* defs does not
   # apply.
   it 'accepts a def that follows a line with code' do


### PR DESCRIPTION
I've made it check `defs` node type as well as `def`, that's the
only change that was needed to make it work with class methods.