### PR TITLE
Move next offense

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@
 * [#2146](https://github.com/bbatsov/rubocop/pull/2146): Add STDIN support. ([@caseywebdev][])
 * [#2175](https://github.com/bbatsov/rubocop/pull/2175): Files that are excluded from a cop (e.g. using the `Exclude:` config option) are no longer being processed by that cop. ([@bquorning][])
 * `Rails/ActionFilter` now handles complete list of methods found in the Rails 4.2 [release notes](https://github.com/rails/rails/blob/4115a12da1409c753c747fd4bab6e612c0c6e51a/guides/source/4_2_release_notes.md#notable-changes-1). ([@MGerrior][])
+* [*2138](https://github.com/bbatsov/rubocop/issues/2138): Change the offense in `Style/Next` to highlight the condition instead of the iteration. ([@rrosenblum][])
 
 ### Bug Fixes
 

--- a/lib/rubocop/cop/style/next.rb
+++ b/lib/rubocop/cop/style/next.rb
@@ -23,60 +23,59 @@ module RuboCop
         include ConfigurableEnforcedStyle
         include MinBodyLength
 
-        MSG = 'Use `next` to skip iteration.'
+        MSG = 'Use `next` to skip iteration.'.freeze
+        EXIT_TYPES = [:break, :return].freeze
+        EACH_ = 'each_'.freeze
         ENUMERATORS = [:collect, :detect, :downto, :each, :find, :find_all,
                        :inject, :loop, :map!, :map, :reduce, :reverse_each,
-                       :select, :times, :upto]
+                       :select, :times, :upto].freeze
 
         def on_block(node)
           block_owner, _, body = *node
-          return unless block_owner.type == :send
-          return if body.nil?
+          return unless block_owner.send_type?
+          return unless body && ends_with_condition?(body)
 
           _, method_name = *block_owner
           return unless enumerator?(method_name)
-          return unless ends_with_condition?(body)
-          *_, condition = *body
 
-          offense_node = (condition && condition.if_type?) ? condition : body
-          add_offense(offense_node, :keyword, MSG)
+          offense_node = offense_node(body)
+          add_offense(offense_node, offense_location(offense_node), MSG)
         end
 
         def on_while(node)
           _, body = *node
           return unless body && ends_with_condition?(body)
-          *_, condition = *body
 
-          offense_node = (condition && condition.if_type?) ? condition : body
-          add_offense(offense_node, :keyword, MSG)
+          offense_node = offense_node(body)
+          add_offense(offense_node, offense_location(offense_node), MSG)
         end
         alias_method :on_until, :on_while
 
         def on_for(node)
           _, _, body = *node
           return unless body && ends_with_condition?(body)
-          *_, condition = *body
 
-          offense_node = (condition && condition.if_type?) ? condition : body
-          add_offense(offense_node, :keyword, MSG)
+          offense_node = offense_node(body)
+          add_offense(offense_node, offense_location(offense_node), MSG)
         end
 
         private
 
         def enumerator?(method_name)
-          ENUMERATORS.include?(method_name) || /\Aeach_/.match(method_name)
+          ENUMERATORS.include?(method_name) ||
+            method_name.to_s.start_with?(EACH_)
         end
 
         def ends_with_condition?(body)
           return true if simple_if_without_break?(body)
 
-          body.type == :begin && simple_if_without_break?(body.children.last)
+          body.begin_type? && simple_if_without_break?(body.children.last)
         end
 
         def simple_if_without_break?(node)
+          return false unless node.if_type?
           return false if ternary_op?(node)
           return false if if_else?(node)
-          return false unless node.type == :if
           return false if style == :skip_modifier_ifs && modifier_if?(node)
           return false if !modifier_if?(node) && !min_body_length?(node)
 
@@ -85,7 +84,18 @@ module RuboCop
           _conditional, if_body, _else_body = *node
           return true unless if_body
 
-          ![:break, :return].include?(if_body.type)
+          !EXIT_TYPES.include?(if_body.type)
+        end
+
+        def offense_node(body)
+          *_, condition = *body
+          (condition && condition.if_type?) ? condition : body
+        end
+
+        def offense_location(offense_node)
+          condition_expression, = *offense_node
+          offense_begin_pos = offense_node.loc.expression.begin
+          offense_begin_pos.join(condition_expression.loc.expression)
         end
       end
     end

--- a/lib/rubocop/cop/style/next.rb
+++ b/lib/rubocop/cop/style/next.rb
@@ -36,23 +36,29 @@ module RuboCop
           _, method_name = *block_owner
           return unless enumerator?(method_name)
           return unless ends_with_condition?(body)
+          *_, condition = *body
 
-          add_offense(block_owner, :selector, MSG)
+          offense_node = (condition && condition.if_type?) ? condition : body
+          add_offense(offense_node, :keyword, MSG)
         end
 
         def on_while(node)
           _, body = *node
           return unless body && ends_with_condition?(body)
+          *_, condition = *body
 
-          add_offense(node, :keyword, MSG)
+          offense_node = (condition && condition.if_type?) ? condition : body
+          add_offense(offense_node, :keyword, MSG)
         end
         alias_method :on_until, :on_while
 
         def on_for(node)
           _, _, body = *node
           return unless body && ends_with_condition?(body)
+          *_, condition = *body
 
-          add_offense(node, :keyword, MSG)
+          offense_node = (condition && condition.if_type?) ? condition : body
+          add_offense(offense_node, :keyword, MSG)
         end
 
         private

--- a/spec/rubocop/cop/style/next_spec.rb
+++ b/spec/rubocop/cop/style/next_spec.rb
@@ -6,279 +6,264 @@ describe RuboCop::Cop::Style::Next, :config do
   subject(:cop) { described_class.new(config) }
   let(:cop_config) { { 'MinBodyLength' => 1 } }
 
-  it 'finds all kind of loops with condition at the end of the iteration' do
-    # TODO: Split this long example into multiple examples.
-    inspect_source(cop,
-                   ['3.downto(1) do',
-                    '  if o == 1',
-                    '    puts o',
-                    '  end',
-                    'end',
-                    '',
-                    '[].each do |o|',
-                    '  if o == 1',
-                    '    puts o',
-                    '  end',
-                    'end',
-                    '',
-                    '[].each_with_object({}) do |o, a|',
-                    '  if o == 1',
-                    '    a[o] = {}',
-                    '  end',
-                    'end',
-                    '',
-                    'for o in 1..3 do',
-                    '  if o == 1',
-                    '    puts o',
-                    '  end',
-                    'end',
-                    '',
-                    'loop do',
-                    '  if o == 1',
-                    '    puts o',
-                    '  end',
-                    'end',
-                    '',
-                    '{}.map do |k, v|',
-                    '  if v == 1',
-                    '    puts k',
-                    '  end',
-                    'end',
-                    '',
-                    '3.times do |o|',
-                    '  if o == 1',
-                    '    puts o',
-                    '  end',
-                    'end',
-                    '',
-                    'until false',
-                    '  if o == 1',
-                    '    puts o',
-                    '  end',
-                    'end',
-                    '',
-                    'while true',
-                    '  if o == 1',
-                    '    puts o',
-                    '  end',
-                    'end'])
-    expect(cop.offenses.size).to eq(9)
-    expect(cop.offenses.map(&:line).sort).to eq([2, 8, 14, 20, 26, 32, 38, 44,
-                                                 50])
-    expect(cop.messages) .to eq(['Use `next` to skip iteration.'] * 9)
-    expect(cop.highlights).to eq(%w(if if if if if if if if if))
+  shared_examples 'iterators' do |condition|
+    it "registers an offense for #{condition} inside of downto" do
+      inspect_source(cop, ['3.downto(1) do',
+                           "  #{condition} o == 1",
+                           '    puts o',
+                           '  end',
+                           'end'])
+
+      expect(cop.messages).to eq(['Use `next` to skip iteration.'])
+      expect(cop.highlights).to eq(["#{condition} o == 1"])
+    end
+
+    it "registers an offense for #{condition} inside of each" do
+      inspect_source(cop, ['[].each do |o|',
+                           "  #{condition} o == 1",
+                           '    puts o',
+                           '  end',
+                           'end'])
+
+      expect(cop.messages).to eq(['Use `next` to skip iteration.'])
+      expect(cop.highlights).to eq(["#{condition} o == 1"])
+    end
+
+    it "registers an offense for #{condition} inside of each_with_object" do
+      inspect_source(cop, ['[].each_with_object({}) do |o, a|',
+                           "  #{condition} o == 1",
+                           '    a[o] = {}',
+                           '  end',
+                           'end'])
+
+      expect(cop.messages).to eq(['Use `next` to skip iteration.'])
+      expect(cop.highlights).to eq(["#{condition} o == 1"])
+    end
+
+    it "registers an offense for #{condition}  inside of for" do
+      inspect_source(cop, ['for o in 1..3 do',
+                           "  #{condition} o == 1",
+                           '    puts o',
+                           '  end',
+                           'end'])
+
+      expect(cop.messages).to eq(['Use `next` to skip iteration.'])
+      expect(cop.highlights).to eq(["#{condition} o == 1"])
+    end
+
+    it "registers an offense for #{condition} inside of loop" do
+      inspect_source(cop, ['loop do',
+                           "  #{condition} o == 1",
+                           '    puts o',
+                           '  end',
+                           'end'])
+
+      expect(cop.messages).to eq(['Use `next` to skip iteration.'])
+      expect(cop.highlights).to eq(["#{condition} o == 1"])
+    end
+
+    it "registers an offense for #{condition} inside of map" do
+      inspect_source(cop, ['loop do',
+                           '  {}.map do |k, v|',
+                           "    #{condition} v == 1",
+                           '      puts k',
+                           '    end',
+                           '  end',
+                           'end'])
+
+      expect(cop.messages).to eq(['Use `next` to skip iteration.'])
+      expect(cop.highlights).to eq(["#{condition} v == 1"])
+    end
+
+    it "registers an offense for #{condition} inside of times" do
+      inspect_source(cop, ['loop do',
+                           '  3.times do |o|',
+                           "    #{condition} o == 1",
+                           '      puts o',
+                           '    end',
+                           '  end',
+                           'end'])
+
+      expect(cop.messages).to eq(['Use `next` to skip iteration.'])
+      expect(cop.highlights).to eq(["#{condition} o == 1"])
+    end
+
+    it "registers an offense for #{condition} inside of nested iterators" do
+      inspect_source(cop, ['loop do',
+                           '  until false',
+                           "    #{condition} o == 1",
+                           '      puts o',
+                           '    end',
+                           '  end',
+                           'end'])
+
+      expect(cop.messages).to eq(['Use `next` to skip iteration.'])
+      expect(cop.highlights).to eq(["#{condition} o == 1"])
+    end
+
+    it "registers an offense for #{condition} inside of nested iterators" do
+      inspect_source(cop, ['loop do',
+                           '  while true',
+                           "    #{condition} o == 1",
+                           '      puts o',
+                           '    end',
+                           '  end',
+                           'end'])
+
+      expect(cop.messages).to eq(['Use `next` to skip iteration.'])
+      expect(cop.highlights).to eq(["#{condition} o == 1"])
+    end
+
+    it 'registers an offense for a condition at the end of an iterator ' \
+       'when there is more in the iterator than the condition' do
+      inspect_source(cop, ['[].each do |o|',
+                           '  puts o',
+                           "  #{condition} o == 1",
+                           '    puts o',
+                           '  end',
+                           'end'])
+
+      expect(cop.messages).to eq(['Use `next` to skip iteration.'])
+      expect(cop.highlights).to eq(["#{condition} o == 1"])
+    end
+
+    it 'allows loops with conditional break' do
+      inspect_source(cop, ['loop do',
+                           "  puts ''",
+                           "  break #{condition} o == 1",
+                           'end'])
+
+      expect(cop.offenses).to be_empty
+    end
+
+    it 'allows loops with conditional return' do
+      inspect_source(cop, ['loop do',
+                           "  puts ''",
+                           "  return #{condition} o == 1",
+                           'end'])
+
+      expect(cop.offenses).to be_empty
+    end
+
+    it "allows loops with #{condition} being the entire body with else" do
+      inspect_source(cop, ['[].each do |o|',
+                           "  #{condition} o == 1",
+                           '    puts o',
+                           '  else',
+                           "    puts 'no'",
+                           '  end',
+                           'end'])
+
+      expect(cop.offenses).to be_empty
+    end
+
+    it "allows loops with #{condition} with else at the end" do
+      inspect_source(cop, ['[].each do |o|',
+                           '  puts o',
+                           "  #{condition} o == 1",
+                           '    puts o',
+                           '  else',
+                           "    puts 'no'",
+                           '  end',
+                           'end'])
+
+      expect(cop.offenses).to be_empty
+    end
+
+    it "reports an offense for #{condition} whose body has 3 lines" do
+      inspect_source(cop, ['arr.each do |e|',
+                           "  #{condition} something",
+                           '    work',
+                           '    work',
+                           '    work',
+                           '  end',
+                           'end'])
+
+      expect(cop.offenses.size).to eq(1)
+      expect(cop.highlights).to eq(["#{condition} something"])
+    end
+
+    context 'EnforcedStyle: skip_modifier_ifs' do
+      let(:cop_config) do
+        { 'EnforcedStyle' => 'skip_modifier_ifs' }
+      end
+
+      it "allows modifier #{condition}" do
+        inspect_source(cop, ['[].each do |o|',
+                             "  puts o #{condition} o == 1",
+                             'end'])
+
+        expect(cop.offenses).to be_empty
+      end
+    end
+
+    context 'EnforcedStyle: always' do
+      let(:cop_config) do
+        { 'EnforcedStyle' => 'always' }
+      end
+
+      it "registers an offense for modifier #{condition}" do
+        inspect_source(cop, ['[].each do |o|',
+                             "  puts o #{condition} o == 1",
+                             'end'])
+
+        expect(cop.messages).to eq(['Use `next` to skip iteration.'])
+        expect(cop.highlights).to eq(["puts o #{condition} o == 1"])
+      end
+    end
   end
 
-  it 'registers an offense for unless inside until' do
-    inspect_source(cop, ['until false',
-                         '  unless o == 1',
-                         '    puts o',
-                         '  end',
+  it_behaves_like 'iterators', 'if'
+  it_behaves_like 'iterators', 'unless'
+
+  it 'allows empty blocks' do
+    inspect_source(cop, ['[].each do',
+                         'end',
+                         '[].each { }'])
+
+    expect(cop.offenses).to be_empty
+  end
+
+  it 'allows loops with conditions at the end with ternary op' do
+    inspect_source(cop, ['[].each do |o|',
+                         '  o == x ? y : z',
                          'end'])
 
-    expect(cop.highlights).to eq(['unless'])
+    expect(cop.offenses).to be_empty
   end
 
-  it 'registers an offense for unless inside for' do
-    inspect_source(cop, ['for o in 1..3 do',
-                         '  unless o == 1',
-                         '    puts o',
-                         '  end',
+  it 'allows super nodes' do
+    # https://github.com/bbatsov/rubocop/issues/1115
+    inspect_source(cop, ['def foo',
+                         '  super(a, a) { a }',
                          'end'])
 
-    expect(cop.highlights).to eq(['unless'])
-  end
-
-  it 'finds loop with condition at the end in different styles' do
-    inspect_source(cop,
-                   ['[].each do |o|',
-                    '  if o == 1',
-                    '    puts o',
-                    '  end',
-                    'end',
-                    '',
-                    '[].each do |o|',
-                    '  puts o',
-                    '  if o == 1',
-                    '    puts o',
-                    '  end',
-                    'end',
-                    '',
-                    '[].each do |o|',
-                    '  unless o == 1',
-                    '    puts o',
-                    '  end',
-                    'end'])
-
-    expect(cop.offenses.size).to eq(3)
-    expect(cop.offenses.map(&:line).sort).to eq([2, 9, 15])
-    expect(cop.messages)
-      .to eq(['Use `next` to skip iteration.'] * 3)
-    expect(cop.highlights).to eq(%w(if if unless))
-  end
-
-  it 'ignores empty blocks' do
-    inspect_source(cop,
-                   ['[].each do', 'end',
-                    '[].each { }'])
-    expect(cop.offenses.size).to eq(0)
-  end
-
-  it 'ignores loops with conditional break' do
-    inspect_source(cop,
-                   ['loop do',
-                    "  puts ''",
-                    '  break if o == 1',
-                    'end',
-                    '',
-                    'loop do',
-                    '  break if o == 1',
-                    'end',
-                    '',
-                    'loop do',
-                    "  puts ''",
-                    '  break unless o == 1',
-                    'end',
-                    '',
-                    'loop do',
-                    '  break unless o == 1',
-                    'end',
-                    '',
-                    'loop do',
-                    '  if o == 1',
-                    '    break',
-                    '  end',
-                    'end'])
-    expect(cop.offenses.size).to eq(0)
-  end
-
-  it 'ignores loops with conditional return' do
-    inspect_source(cop,
-                   ['loop do',
-                    "  puts ''",
-                    '  return if o == 1',
-                    'end',
-                    '',
-                    'loop do',
-                    "  puts ''",
-                    '  if o == 1',
-                    '    return',
-                    '  end',
-                    'end'])
-    expect(cop.offenses.size).to eq(0)
-  end
-
-  context 'EnforcedStyle: skip_modifier_ifs' do
-    let(:cop_config) do
-      { 'EnforcedStyle' => 'skip_modifier_ifs' }
-    end
-
-    it 'ignores modifier ifs' do
-      inspect_source(cop,
-                     ['[].each do |o|',
-                      '  puts o if o == 1',
-                      'end',
-                      '',
-                      '[].each do |o|',
-                      '  puts o unless o == 1',
-                      'end'])
-
-      expect(cop.offenses.size).to eq(0)
-    end
-  end
-
-  context 'EnforcedStyle: always' do
-    let(:cop_config) do
-      { 'EnforcedStyle' => 'always' }
-    end
-
-    it 'does not ignore modifier ifs' do
-      inspect_source(cop,
-                     ['[].each do |o|',
-                      '  puts o if o == 1',
-                      'end',
-                      '',
-                      '[].each do |o|',
-                      '  puts o unless o == 1',
-                      'end'])
-
-      expect(cop.offenses.size).to eq(2)
-      expect(cop.offenses.map(&:line).sort).to eq([2, 6])
-      expect(cop.messages).to eq(['Use `next` to skip iteration.'] * 2)
-      expect(cop.highlights).to eq(%w(if unless))
-    end
-  end
-
-  it 'ignores loops with conditions at the end with else' do
-    inspect_source(cop,
-                   ['[].each do |o|',
-                    '  if o == 1',
-                    '    puts o',
-                    '  else',
-                    "    puts 'no'",
-                    '  end',
-                    'end',
-                    '',
-                    '[].each do |o|',
-                    '  puts o',
-                    '  if o == 1',
-                    '    puts o',
-                    '  else',
-                    "    puts 'no'",
-                    '  end',
-                    'end',
-                    '',
-                    '[].each do |o|',
-                    '  unless o == 1',
-                    '    puts o',
-                    '  else',
-                    "    puts 'no'",
-                    '  end',
-                    'end'])
-
-    expect(cop.offenses.size).to eq(0)
-  end
-
-  it 'ignores loops with conditions at the end with ternary op' do
-    inspect_source(cop,
-                   ['[].each do |o|',
-                    '  o == x ? y : z',
-                    'end'
-                   ])
-
-    expect(cop.offenses.size).to eq(0)
-  end
-
-  # https://github.com/bbatsov/rubocop/issues/1115
-  it 'ignores super nodes' do
-    inspect_source(cop,
-                   ['def foo',
-                    '  super(a, a) { a }',
-                    'end'])
-    expect(cop.offenses.size).to eq(0)
+    expect(cop.offenses).to be_empty
   end
 
   it 'does not blow up on empty body until block' do
     inspect_source(cop, 'until sup; end')
-    expect(cop.offenses.size).to eq(0)
+
+    expect(cop.offenses).to be_empty
   end
 
   it 'does not blow up on empty body while block' do
     inspect_source(cop, 'while sup; end')
-    expect(cop.offenses.size).to eq(0)
+
+    expect(cop.offenses).to be_empty
   end
 
   it 'does not blow up on empty body for block' do
     inspect_source(cop, 'for x in y; end')
-    expect(cop.offenses.size).to eq(0)
+
+    expect(cop.offenses).to be_empty
   end
 
   it 'does not crash with an empty body branch' do
-    inspect_source(cop,
-                   ['loop do',
-                    '  if true',
-                    '  end',
-                    'end'])
+    inspect_source(cop, ['loop do',
+                         '  if true',
+                         '  end',
+                         'end'])
     expect(cop.offenses).to be_empty
   end
 
@@ -288,26 +273,13 @@ describe RuboCop::Cop::Style::Next, :config do
     end
 
     it 'accepts if whose body has 1 line' do
-      inspect_source(cop,
-                     ['arr.each do |e|',
-                      '  if something',
-                      '    work',
-                      '  end',
-                      'end'])
-      expect(cop.offenses).to be_empty
-    end
+      inspect_source(cop, ['arr.each do |e|',
+                           '  if something',
+                           '    work',
+                           '  end',
+                           'end'])
 
-    it 'reports an offense for if whose body has 3 lines' do
-      inspect_source(cop,
-                     ['arr.each do |e|',
-                      '  if something',
-                      '    work',
-                      '    work',
-                      '    work',
-                      '  end',
-                      'end'])
-      expect(cop.offenses.size).to eq(1)
-      expect(cop.highlights).to eq(['if'])
+      expect(cop.offenses).to be_empty
     end
   end
 
@@ -322,6 +294,7 @@ describe RuboCop::Cop::Style::Next, :config do
                 '    puts o',
                 '  end',
                 'end']
+
       expect { inspect_source(cop, source) }
         .to raise_error('MinBodyLength needs to be a positive integer!')
     end

--- a/spec/rubocop/cop/style/next_spec.rb
+++ b/spec/rubocop/cop/style/next_spec.rb
@@ -63,11 +63,30 @@ describe RuboCop::Cop::Style::Next, :config do
                     '  end',
                     'end'])
     expect(cop.offenses.size).to eq(9)
-    expect(cop.offenses.map(&:line).sort).to eq([1, 7, 13, 19, 25, 31, 37, 43,
-                                                 49])
+    expect(cop.offenses.map(&:line).sort).to eq([2, 8, 14, 20, 26, 32, 38, 44,
+                                                 50])
     expect(cop.messages) .to eq(['Use `next` to skip iteration.'] * 9)
-    expect(cop.highlights).to eq(%w(downto each each_with_object for loop map
-                                    times until while))
+    expect(cop.highlights).to eq(%w(if if if if if if if if if))
+  end
+
+  it 'registers an offense for unless inside until' do
+    inspect_source(cop, ['until false',
+                         '  unless o == 1',
+                         '    puts o',
+                         '  end',
+                         'end'])
+
+    expect(cop.highlights).to eq(['unless'])
+  end
+
+  it 'registers an offense for unless inside for' do
+    inspect_source(cop, ['for o in 1..3 do',
+                         '  unless o == 1',
+                         '    puts o',
+                         '  end',
+                         'end'])
+
+    expect(cop.highlights).to eq(['unless'])
   end
 
   it 'finds loop with condition at the end in different styles' do
@@ -92,10 +111,10 @@ describe RuboCop::Cop::Style::Next, :config do
                     'end'])
 
     expect(cop.offenses.size).to eq(3)
-    expect(cop.offenses.map(&:line).sort).to eq([1, 7, 14])
+    expect(cop.offenses.map(&:line).sort).to eq([2, 9, 15])
     expect(cop.messages)
       .to eq(['Use `next` to skip iteration.'] * 3)
-    expect(cop.highlights).to eq(['each'] * 3)
+    expect(cop.highlights).to eq(%w(if if unless))
   end
 
   it 'ignores empty blocks' do
@@ -184,10 +203,9 @@ describe RuboCop::Cop::Style::Next, :config do
                       'end'])
 
       expect(cop.offenses.size).to eq(2)
-      expect(cop.offenses.map(&:line).sort).to eq([1, 5])
-      expect(cop.messages)
-        .to eq(['Use `next` to skip iteration.'] * 2)
-      expect(cop.highlights).to eq(['each'] * 2)
+      expect(cop.offenses.map(&:line).sort).to eq([2, 6])
+      expect(cop.messages).to eq(['Use `next` to skip iteration.'] * 2)
+      expect(cop.highlights).to eq(%w(if unless))
     end
   end
 
@@ -289,7 +307,7 @@ describe RuboCop::Cop::Style::Next, :config do
                       '  end',
                       'end'])
       expect(cop.offenses.size).to eq(1)
-      expect(cop.highlights).to eq(['each'])
+      expect(cop.highlights).to eq(['if'])
     end
   end
 


### PR DESCRIPTION
This fixes #2138. It moves the offense location from pointing to the iterator to point to the condition. 

While working on this, I noticed that it isn't configured to work on some methods. Some of the methods that I noticed were missing are `select!`, `reject`, and `reject!`. Is there a reason that these methods are not checked? If not, I will submit a PR to add them.