### PR TITLE
Allow using multi-line lambdas for Rails' Scopes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@
 
 ### Bug Fixes
 
+* Allow using multi-line lambdas for Rails' Scopes. ([@wk8][])
 * [#2123](https://github.com/bbatsov/rubocop/pull/2123): Fix handing of dynamic widths `Lint/FormatParameterMismatch`. ([@edmz][])
 * [#2116](https://github.com/bbatsov/rubocop/pull/2116): Fix named params (using hash) `Lint/FormatParameterMismatch`. ([@edmz][])
 * [#2135](https://github.com/bbatsov/rubocop/issues/2135): Ignore `super` and `zsuper` nodes in `Style/SymbolProc`. ([@bbatsov][])
@@ -1568,3 +1569,4 @@
 [@wli]: https://github.com/wli
 [@caseywebdev]: https://github.com/caseywebdev
 [@MGerrior]: https://github.com/MGerrior
+[@wk8]: https://github.com/wk8

--- a/lib/rubocop/cop/rails/scope_args.rb
+++ b/lib/rubocop/cop/rails/scope_args.rb
@@ -24,8 +24,16 @@ module RuboCop
           return unless args.size == 2
 
           second_arg = args[1]
+          return unless second_arg.type == :send && !lambda?(second_arg)
 
-          add_offense(second_arg, :expression) if second_arg.type == :send
+          add_offense(second_arg, :expression)
+        end
+
+        private
+
+        def lambda?(send_node)
+          receiver_node, selector_node = *send_node
+          receiver_node.nil? && selector_node == :lambda
         end
       end
     end

--- a/spec/rubocop/cop/rails/scope_args_spec.rb
+++ b/spec/rubocop/cop/rails/scope_args_spec.rb
@@ -22,4 +22,13 @@ describe RuboCop::Cop::Rails::ScopeArgs do
                    'scope :active, proc { where(active: true) }')
     expect(cop.offenses).to be_empty
   end
+
+  it 'accepts a multi-line lamba arg' do
+    inspect_source(cop,
+                   'scope :active_by_status, lambda do |status|' \
+                   '  where(active: true)' \
+                   '    .where(status: status)' \
+                   'end')
+    expect(cop.offenses).to be_empty
+  end
 end


### PR DESCRIPTION
Rails' scopes can, and should, be multi-line lambdas when they spawn
more than one line.

This patch makes the `Rubocop::Cop::Rails::ScopeArgs` allow this.

Added a unit test.