### PR TITLE
[Fix #2154] Fix auto-correct of StringReplacement with a backslash again

### DIFF
--- a/lib/rubocop/cop/performance/string_replacement.rb
+++ b/lib/rubocop/cop/performance/string_replacement.rb
@@ -60,13 +60,12 @@ module RuboCop
                                                   first_source,
                                                   second_source)
 
-          range = Parser::Source::Range.new(node.loc.expression.source_buffer,
-                                            node.loc.selector.begin_pos,
-                                            first_param.loc.expression.end_pos)
-
           lambda do |corrector|
-            corrector.replace(range,
-                              "#{replacement_method}(#{escape(first_source)}")
+            corrector.replace(node.loc.selector, replacement_method)
+            unless first_param.str_type?
+              corrector.replace(first_param.loc.expression,
+                                escape(first_source))
+            end
 
             if second_source.empty? && first_source.length == 1
               remove_second_param(corrector, node, first_param)
@@ -162,7 +161,7 @@ module RuboCop
 
         def require_double_quotes?(string)
           string.inspect.include?(SINGLE_QUOTE) ||
-            StringHelp::ESCAPED_CHAR_REGEXP =~ string.inspect
+            StringHelp::ESCAPED_CHAR_REGEXP =~ string
         end
 
         def remove_second_param(corrector, node, first_param)

--- a/spec/rubocop/cop/performance/string_replacement_spec.rb
+++ b/spec/rubocop/cop/performance/string_replacement_spec.rb
@@ -381,24 +381,30 @@ describe RuboCop::Cop::Performance::StringReplacement do
       it 'when the pattern contains an escape character' do
         new_source = autocorrect_source(cop, "'abc'.gsub('\n', ',')")
 
-        expect(new_source).to eq("'abc'.tr(\"\\n\", ',')")
+        expect(new_source).to eq("'abc'.tr('\n', ',')")
+      end
+
+      it 'when the pattern contains double backslash' do
+        new_source = autocorrect_source(cop, "''.gsub('\\\\', '')")
+
+        expect(new_source).to eq("''.delete('\\\\')")
       end
 
       it 'when replacing to a single quote' do
         new_source = autocorrect_source(cop, '"a`b".gsub("`", "\'")')
 
-        expect(new_source).to eq('"a`b".tr(\'`\', "\'")')
+        expect(new_source).to eq('"a`b".tr("`", "\'")')
       end
 
       it 'when replacing to a double quote' do
         new_source = autocorrect_source(cop, '"a`b".gsub("`", "\"")')
 
-        expect(new_source).to eq('"a`b".tr(\'`\', "\"")')
+        expect(new_source).to eq('"a`b".tr("`", "\"")')
       end
     end
 
     describe 'corrects to delete' do
-      it 'when deleteing a single character' do
+      it 'when deleting a single character' do
         new_source = autocorrect_source(cop, "'abc'.gsub!('a', '')")
 
         expect(new_source).to eq("'abc'.delete!('a')")
@@ -410,10 +416,10 @@ describe RuboCop::Cop::Performance::StringReplacement do
         expect(new_source).to eq("'abc'.delete('a')")
       end
 
-      it 'when deleteing an escape character' do
+      it 'when deleting an escape character' do
         new_source = autocorrect_source(cop, "'abc'.gsub('\n', '')")
 
-        expect(new_source).to eq("'abc'.delete(\"\\n\")")
+        expect(new_source).to eq("'abc'.delete('\n')")
       end
 
       it 'when the pattern uses Regexp.new' do

--- a/spec/rubocop/cop/performance/string_replacement_spec.rb
+++ b/spec/rubocop/cop/performance/string_replacement_spec.rb
@@ -334,69 +334,69 @@ describe RuboCop::Cop::Performance::StringReplacement do
 
   context 'auto-correct' do
     describe 'corrects to tr' do
-      it 'when the length of the pattern and replacement are the same' do
+      it 'corrects when the length of the pattern and replacement are one' do
         new_source = autocorrect_source(cop, "'abc'.gsub('a', 'd')")
 
         expect(new_source).to eq("'abc'.tr('a', 'd')")
       end
 
-      it 'when the pattern is a regex literal' do
+      it 'corrects when the pattern is a regex literal' do
         new_source = autocorrect_source(cop, "'abc'.gsub(/a/, '1')")
 
         expect(new_source).to eq("'abc'.tr('a', '1')")
       end
 
-      it 'when the pattern is a regex literal using %r' do
+      it 'corrects when the pattern is a regex literal using %r' do
         new_source = autocorrect_source(cop, "'abc'.gsub(%r{a}, '1')")
 
         expect(new_source).to eq("'abc'.tr('a', '1')")
       end
 
-      it 'when the pattern uses Regexp.new' do
+      it 'corrects when the pattern uses Regexp.new' do
         new_source = autocorrect_source(cop,
                                         "'abc'.gsub(Regexp.new('a'), '1')")
 
         expect(new_source).to eq("'abc'.tr('a', '1')")
       end
 
-      it 'when the pattern uses Regexp.compile' do
+      it 'corrects when the pattern uses Regexp.compile' do
         new_source = autocorrect_source(cop,
                                         "'abc'.gsub(Regexp.compile('a'), '1')")
 
         expect(new_source).to eq("'abc'.tr('a', '1')")
       end
 
-      it 'when the replacement contains an escape new line character' do
+      it 'corrects when the replacement contains a new line character' do
         new_source = autocorrect_source(cop, "'abc'.gsub('a', '\n')")
 
         expect(new_source).to eq("'abc'.tr('a', '\n')")
       end
 
-      it 'when the replacement contains an escape backslash character' do
+      it 'corrects when the replacement contains escape backslash' do
         new_source = autocorrect_source(cop, "\"\".gsub('/', '\\\\')")
 
         expect(new_source).to eq("\"\".tr('/', '\\\\')")
       end
 
-      it 'when the pattern contains an escape character' do
+      it 'corrects when the pattern contains a new line character' do
         new_source = autocorrect_source(cop, "'abc'.gsub('\n', ',')")
 
         expect(new_source).to eq("'abc'.tr('\n', ',')")
       end
 
-      it 'when the pattern contains double backslash' do
+      it 'corrects when the pattern contains double backslash' do
         new_source = autocorrect_source(cop, "''.gsub('\\\\', '')")
 
         expect(new_source).to eq("''.delete('\\\\')")
       end
 
-      it 'when replacing to a single quote' do
+      it 'corrects when replacing to a single quote' do
         new_source = autocorrect_source(cop, '"a`b".gsub("`", "\'")')
 
         expect(new_source).to eq('"a`b".tr("`", "\'")')
       end
 
-      it 'when replacing to a double quote' do
+      it 'corrects when replacing to a double quote' do
         new_source = autocorrect_source(cop, '"a`b".gsub("`", "\"")')
 
         expect(new_source).to eq('"a`b".tr("`", "\"")')
@@ -404,31 +404,31 @@ describe RuboCop::Cop::Performance::StringReplacement do
     end
 
     describe 'corrects to delete' do
-      it 'when deleting a single character' do
+      it 'corrects when deleting a single character' do
         new_source = autocorrect_source(cop, "'abc'.gsub!('a', '')")
 
         expect(new_source).to eq("'abc'.delete!('a')")
       end
 
-      it 'when the pattern is a regex literal' do
+      it 'corrects when the pattern is a regex literal' do
         new_source = autocorrect_source(cop, "'abc'.gsub(/a/, '')")
 
         expect(new_source).to eq("'abc'.delete('a')")
       end
 
-      it 'when deleting an escape character' do
+      it 'corrects when deleting an escape character' do
         new_source = autocorrect_source(cop, "'abc'.gsub('\n', '')")
 
         expect(new_source).to eq("'abc'.delete('\n')")
       end
 
-      it 'when the pattern uses Regexp.new' do
+      it 'corrects when the pattern uses Regexp.new' do
         new_source = autocorrect_source(cop, "'abc'.gsub(Regexp.new('a'), '')")
 
         expect(new_source).to eq("'abc'.delete('a')")
       end
 
-      it 'when the pattern uses Regexp.compile' do
+      it 'corrects when the pattern uses Regexp.compile' do
         new_source = autocorrect_source(cop,
                                         "'ab'.gsub(Regexp.compile('a'), '')")
 


### PR DESCRIPTION
It turns out I didn't fix all scenarios that include a backslash. @aevernon added a comment to #2154 that `''.gsub('\\', '')` was not auto-correcting properly.

The new solution does not touch the first parameter unless it is a regular expression. 