### PR TITLE
Remove unnecessary comment for style checking

### DIFF
--- a/lib/rubocop/cop/style/multiline_operation_indentation.rb
+++ b/lib/rubocop/cop/style/multiline_operation_indentation.rb
@@ -12,7 +12,7 @@ module RuboCop
       #   b
       #     something
       #   end
-      class MultilineOperationIndentation < Cop # rubocop:disable ClassLength
+      class MultilineOperationIndentation < Cop
         include ConfigurableEnforcedStyle
         include AutocorrectAlignment
 


### PR DESCRIPTION
# WHAT
Remove unnecessary comment for style checking

# WHY
Because it was failed style checking

before
<img width="1025" alt="screenshot 2015-08-30 23 16 21" src="https://cloud.githubusercontent.com/assets/3052342/9567689/4f0106e0-4f6f-11e5-85fc-af914c6efb5a.png">

after
<img width="950" alt="screenshot 2015-08-30 23 22 28" src="https://cloud.githubusercontent.com/assets/3052342/9567690/5e293c3c-4f6f-11e5-8091-28f3cecb644c.png">