### PR TITLE
[Fix #2199] Exit with error for only UnneededDisable offenses

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,7 @@
 * [#2155](https://github.com/bbatsov/rubocop/issues/2155): Configuration `EndAlignment: AlignWith: variable` only applies when the operands of `=` are on the same line. ([@jonas054][])
 * Fix bug in `Style/IndentationWidth` when `rescue` or `ensure` is preceded by an empty body. ([@lumeet][])
 * [#2183](https://github.com/bbatsov/rubocop/issues/2183): Fix bug in `Style/BlockDelimiters` when auto-correcting adjacent braces. ([@lumeet][])
+* [#2199](https://github.com/bbatsov/rubocop/issues/2199): Make `rubocop` exit with error when there are only `Lint/UnneededDisable` offenses. ([@jonas054][])
 
 ## 0.33.0 (05/08/2015)
 

--- a/lib/rubocop/formatter/formatter_set.rb
+++ b/lib/rubocop/formatter/formatter_set.rb
@@ -52,6 +52,7 @@ module RuboCop
 
         offenses = offenses.sort.reject(&:disabled?)
         each { |f| f.file_finished(file, offenses) }
+        offenses
       end
 
       def add_formatter(formatter_type, output_path = nil)

--- a/lib/rubocop/runner.rb
+++ b/lib/rubocop/runner.rb
@@ -87,7 +87,7 @@ module RuboCop
 
       offenses = do_inspection_loop(file, processed_source)
 
-      formatter_set.file_finished(file, offenses.compact.sort.freeze)
+      offenses = formatter_set.file_finished(file, offenses.compact.sort.freeze)
 
       offenses
     rescue InfiniteCorrectionLoop => e

--- a/spec/rubocop/cli_spec.rb
+++ b/spec/rubocop/cli_spec.rb
@@ -2373,6 +2373,15 @@ describe RuboCop::CLI, :isolated_environment do
                   ''].join("\n"))
       end
 
+      context 'and there are no other offenses' do
+        it 'exits with error code' do
+          create_file('example.rb',
+                      ['# encoding: utf-8',
+                       'a' * 10 + ' # rubocop:disable LineLength'])
+          expect(cli.run(['example.rb'])).to eq(1)
+        end
+      end
+
       context 'and UnneededDisable is disabled' do
         it 'does not cause UnneededDisable offenses to be reported' do
           create_file('example.rb',


### PR DESCRIPTION
The `UnneededDisable` cop is special. It finds its offenses after all the other cops, so we must take extra steps to include its offenses in the total that determines the exit code.