### PR TITLE
Make Style/HashSyntax a bit faster

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@
 * Improve handling of `super` in `Style/SymbolProc`. ([@lumeet][])
 * `Style/SymbolProc` is applied to methods receiving arguments. ([@lumeet][])
 * [#1839](https://github.com/bbatsov/rubocop/issues/1839): Remove Rainbow monkey patching of String which conflicts with other gems like colorize. ([@daviddavis][])
+* `Style/HashSyntax` is now a bit faster when checking Ruby 1.9 syntax hash keys. ([@bquorning][])
 
 ### Bug Fixes
 

--- a/lib/rubocop/cop/style/hash_syntax.rb
+++ b/lib/rubocop/cop/style/hash_syntax.rb
@@ -101,6 +101,11 @@ module RuboCop
 
         def valid_19_syntax_symbol?(sym_name)
           sym_name.sub!(/\A:/, '')
+
+          # Most hash keys can be matched against a simple regex.
+          return true if sym_name =~ /\A[_a-z]\w*[?!]?\z/i
+
+          # For more complicated hash keys, let the Parser validate the syntax.
           RuboCop::ProcessedSource.new("{ #{sym_name}: :foo }").valid_syntax?
         end
 


### PR DESCRIPTION
The `RuboCop::ProcessedSource#valid_syntax?` check is rather slow, so let's first do a fast check against a simple regex. The regex will probably not match *all* correct inputs, in which case we fall back to calling `RuboCop::ProcessedSource#valid_syntax?`.

The regex was built by running RuboCop against the Rails 4.2.4 source code with a `puts sym_name` after the regex.

I have not written a performance test as such, but instead run it against a repository of ~2500 files:

    $ time rubocop -f o --only HashSyntax

    Before:
    rubocop -f o --only HashSyntax  22.83s user 0.30s system 99% cpu 23.147 total

    After:
    rubocop -f o --only HashSyntax  19.94s user 0.23s system 99% cpu 20.198 total