### PR TITLE
Don't recreate class_nodes over and over

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@
 * `Style/SymbolProc` is applied to methods receiving arguments. ([@lumeet][])
 * [#1839](https://github.com/bbatsov/rubocop/issues/1839): Remove Rainbow monkey patching of String which conflicts with other gems like colorize. ([@daviddavis][])
 * `Style/HashSyntax` is now a bit faster when checking Ruby 1.9 syntax hash keys. ([@bquorning][])
+* `Lint/DeprecatedClassMethods` is now a whole lot faster. ([@bquorning][])
 
 ### Bug Fixes
 


### PR DESCRIPTION
By moving the `#class_nodes` method from `DeprecatedClassMethods` into `DeprecatedClassMethods::DeprecatedClassMethod`, it now gets created only once per deprecated class method (that’s 2 in total) instead of once per deprecated class method per file being tested (that would be 2 * n).

Informal benchmarking suggests that `Lint/DeprecatedClassMethods` will run around 75% faster than before.