### PR TITLE
Substitute slow regex for something faster

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@
 * [#1839](https://github.com/bbatsov/rubocop/issues/1839): Remove Rainbow monkey patching of String which conflicts with other gems like colorize. ([@daviddavis][])
 * `Style/HashSyntax` is now a bit faster when checking Ruby 1.9 syntax hash keys. ([@bquorning][])
 * `Lint/DeprecatedClassMethods` is now a whole lot faster. ([@bquorning][])
+* `Lint/BlockAlignment`, `Style/IndentationWidth`, and `Style/MultilineOperationIndentation` are now quite a bit faster. ([@bquorning][])
 
 ### Bug Fixes
 

--- a/lib/rubocop/cop/util.rb
+++ b/lib/rubocop/cop/util.rb
@@ -187,7 +187,7 @@ module RuboCop
 
       def begins_its_line?(range)
         source_before_end = range.source_buffer.source[0...range.begin_pos]
-        source_before_end =~ /\n\s*\Z/
+        source_before_end.rpartition("\n").last.strip.empty?
       end
 
       def within_node?(inner, outer)

--- a/lib/rubocop/cop/util.rb
+++ b/lib/rubocop/cop/util.rb
@@ -186,8 +186,8 @@ module RuboCop
       end
 
       def begins_its_line?(range)
-        source_before_end = range.source_buffer.source[0...range.begin_pos]
-        source_before_end.rpartition("\n").last.strip.empty?
+        source_before_range = range.source_buffer.source[0...range.begin_pos]
+        source_before_range.rpartition("\n").last.strip.empty?
       end
 
       def within_node?(inner, outer)


### PR DESCRIPTION
Somehow, the `\s*` part of the regex makes it really slow, I guess it's looking through the entire "source_before_end" string and not just looking backwards from the end of the string.

This approach will reverse the string, then remove all (now leading) spaces *that are not a newline*. According to Ruby's Regexp documentation (1.9.2 till 2.2.3, couldn't this documentation for older versions), the `\s` metacharacter is defined as:

    /\s/ - A whitespace character: /[ \t\r\n\f]/

So we remove those leading non-newline whitespace characters (`/[ \t\r\f]/`) and check if there's a newline at the beginning of the remaining string.

Informal benchmarking shows around 30% speed increase on `Lint/BlockAlignment` and `Style/IndentationWidth`, while `Style/MultilineOperationIndentation` seems to be between 45% and 55% faster.