### PR TITLE
Fix typo in rails cop

### DIFF
--- a/lib/rubocop/cop/rails/read_write_attribute.rb
+++ b/lib/rubocop/cop/rails/read_write_attribute.rb
@@ -33,7 +33,7 @@ module RuboCop
           if method_name == :read_attribute
             format(MSG, 'self[:attr]', 'read_attribute(:attr)')
           else
-            format(MSG, 'self[:attr] = val', 'write_attribute(:attr, var)')
+            format(MSG, 'self[:attr] = val', 'write_attribute(:attr, val)')
           end
         end
 


### PR DESCRIPTION
A typographical error in `read_write_attribute.rb` fixed