### PR TITLE
Fix empty parens auto-correction in SymbolProc

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,6 +54,7 @@
 * Fix bug in `Style/IndentationWidth` when `rescue` or `ensure` is preceded by an empty body. ([@lumeet][])
 * [#2183](https://github.com/bbatsov/rubocop/issues/2183): Fix bug in `Style/BlockDelimiters` when auto-correcting adjacent braces. ([@lumeet][])
 * [#2199](https://github.com/bbatsov/rubocop/issues/2199): Make `rubocop` exit with error when there are only `Lint/UnneededDisable` offenses. ([@jonas054][])
+* Fix handling of empty parentheses when auto-correcting in `Style/SymbolProc`. ([@lumeet][])
 
 ## 0.33.0 (05/08/2015)
 

--- a/lib/rubocop/cop/style/symbol_proc.rb
+++ b/lib/rubocop/cop/style/symbol_proc.rb
@@ -76,9 +76,20 @@ module RuboCop
         def block_range_with_space(node)
           block_range =
             Parser::Source::Range.new(node.loc.expression.source_buffer,
-                                      node.loc.begin.begin_pos,
+                                      begin_pos_for_replacement(node),
                                       node.loc.end.end_pos)
           range_with_surrounding_space(block_range, :left)
+        end
+
+        def begin_pos_for_replacement(node)
+          block_send_or_super, _block_args, _block_body = *node
+          expr = block_send_or_super.loc.expression
+
+          if (paren_pos = (expr.source =~ /\(\s*\)$/))
+            expr.begin_pos + paren_pos
+          else
+            node.loc.begin.begin_pos
+          end
         end
 
         def ignored_methods

--- a/spec/rubocop/cop/style/symbol_proc_spec.rb
+++ b/spec/rubocop/cop/style/symbol_proc_spec.rb
@@ -102,6 +102,11 @@ describe RuboCop::Cop::Style::SymbolProc, :config do
     expect(corrected).to eq 'coll.map(&:upcase).map(&:downcase)'
   end
 
+  it 'auto-corrects correctly when there are no arguments in parentheses' do
+    corrected = autocorrect_source(cop, ['coll.map(   ) { |s| s.upcase }'])
+    expect(corrected).to eq 'coll.map(&:upcase)'
+  end
+
   it 'does not crash with a bare method call' do
     run = -> { inspect_source(cop, 'coll.map { |s| bare_method }') }
     expect(&run).not_to raise_error


### PR DESCRIPTION
```test() { |x| x.inspect }``` no longer gets corrected to ```test()(&:inspect)```.