### PR TITLE
Memoize Config#to_s

### DIFF
--- a/lib/rubocop/config.rb
+++ b/lib/rubocop/config.rb
@@ -23,6 +23,10 @@ module RuboCop
       super(hash)
     end
 
+    def to_s
+      @to_s ||= __getobj__.to_s
+    end
+
     def make_excludes_absolute
       keys.each do |key|
         validate_section_presence(key)


### PR DESCRIPTION
`ResultCache#file_checksum` is calling this method *a lot*. Profiling is fun :muscle: 

Tested with `time rubocop` on my usual ~2500 files:

    Before (warm cache):
    rubocop  6.24s user 0.45s system 99% cpu 6.710 total

    After (warm cache):
    rubocop  1.37s user 0.37s system 99% cpu 1.750 total

No changelog entry, since it just an improvement on an unreleased feature.