### PR TITLE
Fix File name too long error when STDIN is provided

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## master (unreleased)
 
+### Bug Fixes
+
+* [#2214](https://github.com/bbatsov/rubocop/pull/2214): Fix `File name too long error` when `STDIN` option is provided. ([@mrfoto][])
+
 ## 0.34.0 (05/09/2015)
 
 ### New features
@@ -1586,3 +1590,4 @@
 [@caseywebdev]: https://github.com/caseywebdev
 [@MGerrior]: https://github.com/MGerrior
 [@imtayadeway]: https://github.com/imtayadeway
+[@mrfoto]: https://github.com/mrfoto

--- a/lib/rubocop/result_cache.rb
+++ b/lib/rubocop/result_cache.rb
@@ -108,7 +108,7 @@ module RuboCop
     end
 
     NON_CHANGING = [:color, :format, :formatters, :out, :debug, :fail_level,
-                    :cache, :fail_fast]
+                    :cache, :fail_fast, :stdin]
 
     # Return the options given at invocation, minus the ones that have no
     # effect on which offenses and disabled line ranges are found, and thus


### PR DESCRIPTION
Because the whole file is passed as an option `@path` can get enormous and `mkdir` raises `File name too long`.

This PR simply removes `stdin` as a relevant option.