### PR TITLE
[Fix #2212] Handle methods without parentheses in auto-correct

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Bug Fixes
 
+* [#2212](https://github.com/bbatsov/rubocop/issues/2212): Handle methods without parentheses in auto-correct. ([@karreiro][])
 * [#2214](https://github.com/bbatsov/rubocop/pull/2214): Fix `File name too long error` when `STDIN` option is provided. ([@mrfoto][])
 * [#2217](https://github.com/bbatsov/rubocop/issues/2217): Allow block arguments in `Style/SymbolProc`. ([@lumeet][])
 
@@ -1592,3 +1593,4 @@
 [@MGerrior]: https://github.com/MGerrior
 [@imtayadeway]: https://github.com/imtayadeway
 [@mrfoto]: https://github.com/mrfoto
+[@karreiro]: https://github.com/karreiro

--- a/lib/rubocop/cop/performance/string_replacement.rb
+++ b/lib/rubocop/cop/performance/string_replacement.rb
@@ -28,7 +28,6 @@ module RuboCop
         TR = 'tr'.freeze
         BANG = '!'.freeze
         SINGLE_QUOTE = "'".freeze
-        CLOSING_PAREN = ')'.freeze
 
         def on_send(node)
           _string, method, first_param, second_param = *node
@@ -164,13 +163,17 @@ module RuboCop
             StringHelp::ESCAPED_CHAR_REGEXP =~ string
         end
 
+        def method_suffix(node)
+          node.loc.end ? node.loc.end.source : ''
+        end
+
         def remove_second_param(corrector, node, first_param)
           end_range =
             Parser::Source::Range.new(node.loc.expression.source_buffer,
                                       first_param.loc.expression.end_pos,
                                       node.loc.expression.end_pos)
 
-          corrector.replace(end_range, CLOSING_PAREN)
+          corrector.replace(end_range, method_suffix(node))
         end
       end
     end

--- a/spec/rubocop/cop/performance/string_replacement_spec.rb
+++ b/spec/rubocop/cop/performance/string_replacement_spec.rb
@@ -434,6 +434,12 @@ describe RuboCop::Cop::Performance::StringReplacement do
 
         expect(new_source).to eq("'ab'.delete('a')")
       end
+
+      it 'corrects when there are no brackets' do
+        new_source = autocorrect_source(cop, "'abc'.gsub! 'a', ''")
+
+        expect(new_source).to eq("'abc'.delete! 'a'")
+      end
     end
   end
 end


### PR DESCRIPTION
Add to `StringReplacement` a condition for checking if the method has an opening parentheses, before adding the ')' in the end of the new call.