### PR TITLE
[Fix #2213] Write to cache in binary mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 * [#2212](https://github.com/bbatsov/rubocop/issues/2212): Handle methods without parentheses in auto-correct. ([@karreiro][])
 * [#2214](https://github.com/bbatsov/rubocop/pull/2214): Fix `File name too long error` when `STDIN` option is provided. ([@mrfoto][])
 * [#2217](https://github.com/bbatsov/rubocop/issues/2217): Allow block arguments in `Style/SymbolProc`. ([@lumeet][])
+* [#2213](https://github.com/bbatsov/rubocop/issues/2213): Write to cache with binary encoding to avoid transcoding exceptions in some locales. ([@jonas054][])
 
 ## 0.34.0 (05/09/2015)
 

--- a/lib/rubocop/result_cache.rb
+++ b/lib/rubocop/result_cache.rb
@@ -26,7 +26,7 @@ module RuboCop
     def save(offenses, disabled_line_ranges, comments)
       FileUtils.mkdir_p(File.dirname(@path))
       preliminary_path = "#{@path}_#{rand(1_000_000_000)}"
-      File.open(preliminary_path, 'w') do |f|
+      File.open(preliminary_path, 'wb') do |f|
         # The Hash[x.sort] call is a trick that converts a Hash with a default
         # block to a Hash without a default block. Thus making it possible to
         # dump.

--- a/spec/rubocop/result_cache_spec.rb
+++ b/spec/rubocop/result_cache_spec.rb
@@ -82,6 +82,18 @@ describe RuboCop::ResultCache, :isolated_environment do
     end
   end
 
+  describe '#save' do
+    context 'when the default internal encoding is UTF-8' do
+      let(:comments) { ["# Hello \xF0"] }
+      before(:each) { Encoding.default_internal = Encoding::UTF_8 }
+      after(:each) { Encoding.default_internal = nil }
+
+      it 'writes non UTF-8 encodable data to file with no exception' do
+        cache.save(offenses, disabled_lines, comments)
+      end
+    end
+  end
+
   describe '.cleanup' do
     before do
       cfg = { 'AllCops' => { 'MaxFilesInCache' => 1 } }


### PR DESCRIPTION
If the cache file is opened for writing with `UTF-8` encoding (for example) there can be an exception when the marshalled data with `ASCII-8BIT` encoding is written to file.