### PR TITLE
Nested hash keys are faster than creaing a new array

### DIFF
--- a/lib/rubocop/cop/mixin/surrounding_space.rb
+++ b/lib/rubocop/cop/mixin/surrounding_space.rb
@@ -17,13 +17,13 @@ module RuboCop
 
       def index_of_first_token(node)
         b = node.loc.expression.begin
-        token_table[[b.line, b.column]]
+        token_table[b.line][b.column]
       end
 
       def index_of_last_token(node)
         e = node.loc.expression.end
         (0...e.column).to_a.reverse.find do |c|
-          ix = token_table[[e.line, c]]
+          ix = token_table[e.line][c]
           return ix if ix
         end
       end
@@ -32,7 +32,8 @@ module RuboCop
         @token_table ||= begin
           table = {}
           @processed_source.tokens.each_with_index do |t, ix|
-            table[[t.pos.line, t.pos.column]] = ix
+            table[t.pos.line] ||= {}
+            table[t.pos.line][t.pos.column] = ix
           end
           table
         end

--- a/lib/rubocop/cop/mixin/surrounding_space.rb
+++ b/lib/rubocop/cop/mixin/surrounding_space.rb
@@ -22,7 +22,7 @@ module RuboCop
 
       def index_of_last_token(node)
         e = node.loc.expression.end
-        (0...e.column).to_a.reverse.find do |c|
+        (0...e.column).to_a.reverse_each do |c|
           ix = token_table[e.line][c]
           return ix if ix
         end


### PR DESCRIPTION
I had this micro-optimization lying around, and thought I might as well make a PR out of it. In practice, the performance gains are probably negligible…

Benchmark says nested hash reading is over 600% faster and writing is over 150% faster than creating a new array and using that as a hash key:

    Calculating -------------------------------------
          read array key    57.851k i/100ms
        read nested keys   129.057k i/100ms
         write array key     9.000  i/100ms
       write nested keys    26.000  i/100ms
    -------------------------------------------------
          read array key    937.092k (± 3.9%) i/s -      4.686M
        read nested keys      6.728M (± 3.7%) i/s -     33.684M
         write array key     82.370  (±19.4%) i/s -    396.000
       write nested keys    218.754  (±41.1%) i/s -    884.000

Benchmark script:

```rb
require 'benchmark/ips'

Benchmark.ips do |x|
  a = {}
  100.times do |x|
    100.times do |y|
      a[[x, y]] = 42
    end
  end

  x.report("read array key") do
    a[[42, 42]]
  end

  b = {}
  100.times do |x|
    100.times do |y|
      b[x] ||= {}
      b[x][y] = 42
    end
  end

  x.report("read nested keys") do
    b[42][42]
  end

  x.report("write array key") do
    a = {}
    100.times do |x|
      100.times do |y|
        a[[x, y]] = 42
      end
    end
  end

  x.report("write nested keys") do
    b = {}
    100.times do |x|
      100.times do |y|
        b[x] ||= {}
        b[x][y] = 42
      end
    end
  end
end
```