### PR TITLE
Fix 2 typos in code that has zero test coverage

### DIFF
--- a/lib/rubocop/cop/team.rb
+++ b/lib/rubocop/cop/team.rb
@@ -97,8 +97,8 @@ module RuboCop
         file_errors.each do |cop, errors|
           errors.each do |e|
             handle_error(e,
-                         Rainbow("An error occurred while #{cop.name}" /
-                         " cop was inspecting #{file}.".red))
+                         Rainbow("An error occurred while #{cop.name}" \
+                         " cop was inspecting #{file}.").red)
           end
         end
       end


### PR DESCRIPTION
 - Use `\`, not `/` to continue one line onto the next.
 - Can't call `#red` on the string, only on the `Rainbow` instance.

Introduced by accident in #2205.

cc @daviddavis 