### PR TITLE
Performance tweaks phase 3

### DIFF
--- a/lib/rubocop/config.rb
+++ b/lib/rubocop/config.rb
@@ -151,11 +151,11 @@ module RuboCop
     end
 
     def patterns_to_include
-      self['AllCops']['Include']
+      @patterns_to_include ||= self['AllCops']['Include']
     end
 
     def patterns_to_exclude
-      self['AllCops']['Exclude']
+      @patterns_to_exclude ||= self['AllCops']['Exclude']
     end
 
     def path_relative_to_config(path)

--- a/lib/rubocop/formatter/progress_formatter.rb
+++ b/lib/rubocop/formatter/progress_formatter.rb
@@ -8,6 +8,14 @@ module RuboCop
     class ProgressFormatter < ClangStyleFormatter
       include TextUtil
 
+      DOT = '.'.freeze
+      GREEN_DOT = Rainbow(DOT).green.freeze
+
+      def initialize(output)
+        super
+        @dot = @output.tty? ? GREEN_DOT : DOT
+      end
+
       def started(target_files)
         super
         @offenses_for_files = {}
@@ -36,14 +44,14 @@ module RuboCop
           end
         end
 
-        report_summary(inspected_files.count,
+        report_summary(inspected_files.size,
                        @total_offense_count,
                        @total_correction_count)
       end
 
       def report_file_as_mark(offenses)
         mark = if offenses.empty?
-                 green('.')
+                 @dot
                else
                  highest_offense = offenses.max_by(&:severity)
                  colored_severity_code(highest_offense)

--- a/lib/rubocop/processed_source.rb
+++ b/lib/rubocop/processed_source.rb
@@ -44,7 +44,7 @@ module RuboCop
     def lines
       @lines ||= begin
         all_lines = raw_source.lines.map(&:chomp)
-        last_token_line = tokens.any? ? tokens.last.pos.line : all_lines.count
+        last_token_line = tokens.any? ? tokens.last.pos.line : all_lines.size
         result = []
         all_lines.each_with_index do |line, ix|
           break if ix >= last_token_line && line == '__END__'


### PR DESCRIPTION
Now that RuboCop caches results, I decided to profile the memory against a cached run.

The change to progress formatter drops the memory usage of progress formatter and colorizable by 99% for a clean run against all of RuboCop. 

before
99360  rubocop/lib/rubocop/formatter/colorizable.rb
50240  rubocop/lib/rubocop/formatter/progress_formatter.rb

after
880  rubocop/lib/rubocop/formatter/progress_formatter.rb
640  rubocop/lib/rubocop/formatter/colorizable.rb