### PR TITLE
[Fix #2121] Allow space before values in hash literals in ExtraSpacing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,12 +2,13 @@
 
 ## master (unreleased)
 
-### Bug fixes
+### Bug Fixes
 
 * [#2232](https://github.com/bbatsov/rubocop/issues/2232): Fix false positive in `Lint/FormatParameterMismatch` for argument with splat operator. ([@dreyks][])
 * [#2237](https://github.com/bbatsov/rubocop/pull/2237): Allow `Lint/FormatParameterMismatch` to be called using `Kernel.format` and `Kernel.sprintf`. ([@rrosenblum][])
 * [#2234](https://github.com/bbatsov/rubocop/issues/2234): Do not register an offense for `Lint/FormatParameterMismatch` when the format string is a variable. ([@rrosenblum][])
 * [#2240](https://github.com/bbatsov/rubocop/pull/2240): `Lint/UnneededDisable` should not report non-`Lint` `rubocop:disable` comments when running `rubocop --lint`. ([@jonas054][])
+* [#2121](https://github.com/bbatsov/rubocop/issues/2121): Allow space before values in hash literals in `Style/ExtraSpacing` to avoid correction conflict. ([@jonas054][])
 
 ## 0.34.1 (09/09/2015)
 

--- a/lib/rubocop/options.rb
+++ b/lib/rubocop/options.rb
@@ -200,7 +200,6 @@ module RuboCop
   # This module contains help texts for command line options.
   module OptionsHelp
     MAX_EXCL = RuboCop::Options::DEFAULT_MAXIMUM_EXCLUSION_ITEMS.to_s
-    # rubocop:disable Style/ExtraSpacing
     TEXT = {
       only:                 'Run only the given cop(s).',
       only_guide_cops:     ['Run only cops for rules that link to a',

--- a/spec/rubocop/cli_spec.rb
+++ b/spec/rubocop/cli_spec.rb
@@ -90,6 +90,24 @@ describe RuboCop::CLI, :isolated_environment do
     end
 
     describe '--auto-correct' do
+      it 'does not correct ExtraSpacing in a hash that would be changed back' do
+        create_file('.rubocop.yml', ['Style/AlignHash:',
+                                     '  EnforcedColonStyle: table'])
+        source = ['hash = {',
+                  '  alice: {',
+                  '    age:  23,',
+                  "    role: 'Director'",
+                  '  },',
+                  '  bob:   {',
+                  '    age:  25,',
+                  "    role: 'Consultant'",
+                  '  }',
+                  '}']
+        create_file('example.rb', source)
+        expect(cli.run(['--auto-correct'])).to eq(1)
+        expect(IO.read('example.rb')).to eq(source.join("\n") + "\n")
+      end
+
       it 'corrects IndentationWidth, RedundantBegin, and ' \
          'RescueEnsureAlignment offenses' do
         source = ['def verify_section',

--- a/spec/rubocop/cop/style/extra_spacing_spec.rb
+++ b/spec/rubocop/cop/style/extra_spacing_spec.rb
@@ -14,6 +14,16 @@ describe RuboCop::Cop::Style::ExtraSpacing, :config do
       expect(cop.offenses.size).to eq(1)
     end
 
+    it 'accepts aligned values of an implicit hash literal' do
+      source = ["register(street1:    '1 Market',",
+                "         street2:    '#200',",
+                "         :city =>    'Some Town',",
+                "         state:      'CA',",
+                "         postal_code:'99999-1111')"]
+      inspect_source(cop, source)
+      expect(cop.offenses).to be_empty
+    end
+
     it 'can handle extra space before a float' do
       source = ['{:a => "a",',
                 ' :b => [nil,  2.5]}']
@@ -137,14 +147,6 @@ describe RuboCop::Cop::Style::ExtraSpacing, :config do
       'carrier_attribute_name = FactoryGirl.create(:attribute,',
       "                                            name:   'Carrier',",
       '                                            values: %w{verizon})'
-    ],
-
-    'aligning values of an implicit hash literal' => [
-      "register(street1:     '1 Market',",
-      "         street2:     '#200',",
-      "         city:        'Some Town',",
-      "         state:       'CA',",
-      "         postal_code: '99999-1111')"
     ]
   }
 


### PR DESCRIPTION
Leave the spacing before values to the `AlignHash` cop. Avoid infinite correction loops between `AlignHash` and `ExtraSpacing`.