### PR TITLE
Make --lint work with Lint/UnneededDisable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 * [#2232](https://github.com/bbatsov/rubocop/issues/2232): Fix false positive in `Lint/FormatParameterMismatch` for argument with splat operator. ([@dreyks][])
 * [#2237](https://github.com/bbatsov/rubocop/pull/2237): Allow `Lint/FormatParameterMismatch` to be called using `Kernel.format` and `Kernel.sprintf`. ([@rrosenblum][])
 * [#2234](https://github.com/bbatsov/rubocop/issues/2234): Do not register an offense for `Lint/FormatParameterMismatch` when the format string is a variable. ([@rrosenblum][])
+* [#2240](https://github.com/bbatsov/rubocop/pull/2240): `Lint/UnneededDisable` should not report non-`Lint` `rubocop:disable` comments when running `rubocop --lint`. ([@jonas054][])
 
 ## 0.34.1 (09/09/2015)
 

--- a/lib/rubocop/options.rb
+++ b/lib/rubocop/options.rb
@@ -137,7 +137,10 @@ module RuboCop
       option(opts, '-D', '--display-cop-names')
       option(opts, '-S', '--display-style-guide')
       option(opts, '-R', '--rails')
-      option(opts, '-l', '--lint')
+      option(opts, '-l', '--lint') do
+        @options[:only] ||= []
+        @options[:only] << 'Lint'
+      end
       option(opts, '-a', '--auto-correct')
 
       @options[:color] = true

--- a/lib/rubocop/runner.rb
+++ b/lib/rubocop/runner.rb
@@ -180,9 +180,7 @@ module RuboCop
         [:only, :except].each { |opt| Options.validate_cop_list(@options[opt]) }
 
         if @options[:only]
-          cop_classes.select! do |c|
-            c.match?(@options[:only]) || @options[:lint] && c.lint?
-          end
+          cop_classes.select! { |c| c.match?(@options[:only]) }
         else
           filter_cop_classes(cop_classes, config)
         end
@@ -201,9 +199,6 @@ module RuboCop
 
       # filter out Rails cops unless requested
       cop_classes.reject!(&:rails?) unless run_rails_cops?(config)
-
-      # select only lint cops when --lint is passed
-      cop_classes.select!(&:lint?) if @options[:lint]
     end
 
     def run_rails_cops?(config)

--- a/spec/rubocop/cli_spec.rb
+++ b/spec/rubocop/cli_spec.rb
@@ -1533,6 +1533,7 @@ describe RuboCop::CLI, :isolated_environment do
       it 'runs only lint cops' do
         create_file('example.rb', ['if 0 ',
                                    "\ty",
+                                   "\tz # rubocop:disable Style/Tab",
                                    'end'])
         # IfUnlessModifier depends on the configuration of LineLength.
 


### PR DESCRIPTION
Currently, running `rubocop --lint` on the RuboCop source code gives a number or reports from `Lint/UnneededDisable`. That's not good.

By letting `--lint` be an alias for `--only Lint`, we take advantage of the logic that's already in place for handling of `--only` in `Lint/UnneededDisable`.