### PR TITLE
[Fix #2241] Read cache in binary format

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 * [#2234](https://github.com/bbatsov/rubocop/issues/2234): Do not register an offense for `Lint/FormatParameterMismatch` when the format string is a variable. ([@rrosenblum][])
 * [#2240](https://github.com/bbatsov/rubocop/pull/2240): `Lint/UnneededDisable` should not report non-`Lint` `rubocop:disable` comments when running `rubocop --lint`. ([@jonas054][])
 * [#2121](https://github.com/bbatsov/rubocop/issues/2121): Allow space before values in hash literals in `Style/ExtraSpacing` to avoid correction conflict. ([@jonas054][])
+* [#2241](https://github.com/bbatsov/rubocop/issues/2241): Read cache in binary format. ([@jonas054][])
 
 ## 0.34.1 (09/09/2015)
 

--- a/lib/rubocop/result_cache.rb
+++ b/lib/rubocop/result_cache.rb
@@ -20,7 +20,7 @@ module RuboCop
     end
 
     def load
-      Marshal.load(IO.read(@path))
+      Marshal.load(IO.binread(@path))
     end
 
     def save(offenses, disabled_line_ranges, comments)


### PR DESCRIPTION
It's written as binary, so it should be read as binary. Makes a difference only on Windows systems as far as we know.