### PR TITLE
[ExtraSpacing] failing specs for unexpected behavior

### DIFF
--- a/spec/rubocop/cop/style/extra_spacing_spec.rb
+++ b/spec/rubocop/cop/style/extra_spacing_spec.rb
@@ -6,6 +6,20 @@ describe RuboCop::Cop::Style::ExtraSpacing, :config do
   subject(:cop) { described_class.new(config) }
 
   shared_examples 'common behavior' do
+    it 'registers an offense, even when the = aligns with the superclass' do
+      inspect_source(cop, ['class FooClass < SuperClass',
+                           '  CONSTANT       = :foo',
+                           'end'])
+      expect(cop.offenses.size).to eq(1)
+    end
+
+    it 'registers an offense, even when the = aligns subclassing <' do
+      inspect_source(cop, ['class FooClass < SuperClass',
+                           '  CONSTANT     = :foo',
+                           'end'])
+      expect(cop.offenses.size).to eq(1)
+    end
+
     it 'registers an offense for alignment with token not preceded by space' do
       # The = and the ( are on the same column, but this is not for alignment,
       # it's just a mistake.


### PR DESCRIPTION
I ran into this behavior today and was surprised. I expect offenses for the whitespace between the constant and the equal sign, even though these align with stuff on the line above.

These specs pass (register offenses) when misaligned with the line above.