### PR TITLE
Remove trailing named variables

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 * [#2036](https://github.com/bbatsov/rubocop/issues/2036): New cop `Style/StabbyLambdaParentheses` will find and correct cases where a stabby lambda's paramaters are not wrapped in parentheses. ([@hmadison][])
 * [#2246](https://github.com/bbatsov/rubocop/pull/2246): `Style/TrailingUnderscoreVariable` will now register an offense for `*_`. ([@rrosenblum][])
+* [#2246](https://github.com/bbatsov/rubocop/pull/2246): `Style/TrailingUnderscoreVariable` now has a configuration to remove named underscore variables (Defaulted to false). ([@rrosenblum][])
 
 ### Bug Fixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 * [#2275](https://github.com/bbatsov/rubocop/pull/2275): Copy default `Exclude` into `Exclude` lists in `.rubocop_todo.yml`. ([@jonas054][])
 * `Style/IfUnlessModifier` accepts blocks followed by a chained call. ([@lumeet][])
 * [#2261](https://github.com/bbatsov/rubocop/issues/2261): Make relative `Exclude` paths in `$HOME/.rubocop_todo.yml` be relative to current directory. ([@jonas054][])
+* [#2246](https://github.com/bbatsov/rubocop/pull/2246): Do not register an offense for `Style/TrailingUnderscoreVariable` when the underscore variable is preceeded by a splat variable. ([@rrosenblum][])
 
 ## 0.34.2 (21/09/2015)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### New features
 
 * [#2036](https://github.com/bbatsov/rubocop/issues/2036): New cop `Style/StabbyLambdaParentheses` will find and correct cases where a stabby lambda's paramaters are not wrapped in parentheses. ([@hmadison][])
+* [#2246](https://github.com/bbatsov/rubocop/pull/2246): `Style/TrailingUnderscoreVariable` will now register an offense for `*_`. ([@rrosenblum][])
 
 ### Bug Fixes
 

--- a/config/enabled.yml
+++ b/config/enabled.yml
@@ -764,6 +764,7 @@ Style/TrailingUnderscoreVariable:
   Description: >-
                  Checks for the usage of unneeded trailing underscores at the
                  end of parallel variable assignment.
+  AllowNamedUnderscoreVariables: true
   Enabled: true
 
 Style/VariableInterpolation:

--- a/lib/rubocop/cop/mixin/access_modifier_node.rb
+++ b/lib/rubocop/cop/mixin/access_modifier_node.rb
@@ -40,7 +40,7 @@ module RuboCop
       # Returns true when the block node looks like Class or Module.new do ... .
       def class_constructor?(block_node)
         send_node = block_node.children.first
-        receiver_node, method_name, *_ = *send_node
+        receiver_node, method_name, = *send_node
         return false unless method_name == :new
         %w(Class Module).include?(Util.const_name(receiver_node))
       end

--- a/lib/rubocop/cop/style/indentation_width.rb
+++ b/lib/rubocop/cop/style/indentation_width.rb
@@ -257,7 +257,7 @@ module RuboCop
           return false unless body_node.loc.column == first_char_pos_on_line
 
           if [:rescue, :ensure].include?(body_node.type)
-            block_body, *_ = *body_node
+            block_body, = *body_node
             return unless block_body
           end
 

--- a/lib/rubocop/cop/style/trailing_underscore_variable.rb
+++ b/lib/rubocop/cop/style/trailing_underscore_variable.rb
@@ -15,6 +15,8 @@ module RuboCop
       #   #good
       #   a, b, = foo()
       #   a, = foo()
+      #   *a, b, _ = foo()  => We need to know to not include 2 variables in a
+      #   a, *b, _ = foo()  => The correction `a, *b, = foo()` is a syntax error
       class TrailingUnderscoreVariable < Cop
         include SurroundingSpace
 
@@ -69,6 +71,13 @@ module RuboCop
               break unless var.to_s.start_with?(UNDERSCORE)
             end
             first_offense = variable
+          end
+
+          return nil if first_offense.nil?
+
+          first_offense_index = variables.index(first_offense)
+          0.upto(first_offense_index - 1).each do |index|
+            return nil if variables[index].splat_type?
           end
 
           first_offense

--- a/lib/rubocop/cop/style/trailing_underscore_variable.rb
+++ b/lib/rubocop/cop/style/trailing_underscore_variable.rb
@@ -60,7 +60,9 @@ module RuboCop
           first_offense = nil
 
           variables.reverse_each do |variable|
-            break unless variable.children.first == :_
+            var, = *variable
+            var, = *var
+            break unless var == :_
             first_offense = variable
           end
 

--- a/lib/rubocop/cop/style/trailing_underscore_variable.rb
+++ b/lib/rubocop/cop/style/trailing_underscore_variable.rb
@@ -18,7 +18,8 @@ module RuboCop
       class TrailingUnderscoreVariable < Cop
         include SurroundingSpace
 
-        MSG = 'Do not use trailing `_`s in parallel assignment.'
+        MSG = 'Do not use trailing `_`s in parallel assignment.'.freeze
+        UNDERSCORE = '_'.freeze
 
         def on_masgn(node)
           left, = *node
@@ -62,11 +63,20 @@ module RuboCop
           variables.reverse_each do |variable|
             var, = *variable
             var, = *var
-            break unless var == :_
+            if allow_named_underscore_variables
+              break unless var == :_
+            else
+              break unless var.to_s.start_with?(UNDERSCORE)
+            end
             first_offense = variable
           end
 
           first_offense
+        end
+
+        def allow_named_underscore_variables
+          @allow_named_underscore_variables ||=
+            cop_config['AllowNamedUnderscoreVariables']
         end
       end
     end

--- a/spec/rubocop/cop/style/trailing_underscore_variable_spec.rb
+++ b/spec/rubocop/cop/style/trailing_underscore_variable_spec.rb
@@ -21,6 +21,13 @@ describe RuboCop::Cop::Style::TrailingUnderscoreVariable do
       .to eq(['Do not use trailing `_`s in parallel assignment.'])
   end
 
+  it 'registers an offense for splat underscore as the last variable' do
+    inspect_source(cop, 'a, *_ = foo()')
+
+    expect(cop.messages)
+      .to eq(['Do not use trailing `_`s in parallel assignment.'])
+  end
+
   it 'registers an offense when underscore is the second to last variable ' \
      'and blank is the last variable' do
     inspect_source(cop, 'a, _, = foo()')
@@ -63,6 +70,13 @@ describe RuboCop::Cop::Style::TrailingUnderscoreVariable do
     expect(cop.messages).to be_empty
   end
 
+  it 'does not register an offense for a named splat underscore ' \
+     'as the last variable' do
+    inspect_source(cop, 'a, *_b = foo()')
+
+    expect(cop.messages).to be_empty
+  end
+
   describe 'autocorrect' do
     it 'removes trailing underscores automatically' do
       new_source = autocorrect_source(cop, 'a, b, _ = foo()')
@@ -98,6 +112,12 @@ describe RuboCop::Cop::Style::TrailingUnderscoreVariable do
       new_source = autocorrect_source(cop, '_, _, _, = foo()')
 
       expect(new_source).to eq('foo()')
+    end
+
+    it 'remove splat underscore' do
+      new_source = autocorrect_source(cop, 'a, *_ = foo()')
+
+      expect(new_source).to eq('a, = foo()')
     end
   end
 end

--- a/spec/rubocop/cop/style/trailing_underscore_variable_spec.rb
+++ b/spec/rubocop/cop/style/trailing_underscore_variable_spec.rb
@@ -3,121 +3,176 @@
 require 'spec_helper'
 
 describe RuboCop::Cop::Style::TrailingUnderscoreVariable do
-  subject(:cop) { described_class.new }
+  subject(:cop) { described_class.new(config) }
 
-  it 'registers an offense when the last variable of parallel assignment is ' \
-     'an underscore' do
-    inspect_source(cop, 'a, b, _ = foo()')
+  shared_examples 'common functionality' do
+    it 'registers an offense when the last variable of parallel assignment ' \
+       'is an underscore' do
+      inspect_source(cop, 'a, b, _ = foo()')
 
-    expect(cop.messages)
-      .to eq(['Do not use trailing `_`s in parallel assignment.'])
-  end
-
-  it 'registers an offense when multiple underscores are used '\
-     'as the last variables of parallel assignment ' do
-    inspect_source(cop, 'a, _, _ = foo()')
-
-    expect(cop.messages)
-      .to eq(['Do not use trailing `_`s in parallel assignment.'])
-  end
-
-  it 'registers an offense for splat underscore as the last variable' do
-    inspect_source(cop, 'a, *_ = foo()')
-
-    expect(cop.messages)
-      .to eq(['Do not use trailing `_`s in parallel assignment.'])
-  end
-
-  it 'registers an offense when underscore is the second to last variable ' \
-     'and blank is the last variable' do
-    inspect_source(cop, 'a, _, = foo()')
-
-    expect(cop.messages)
-      .to eq(['Do not use trailing `_`s in parallel assignment.'])
-  end
-
-  it 'registers an offense when underscore is the only variable ' \
-     'in parallel assignment' do
-    inspect_source(cop, '_, = foo()')
-
-    expect(cop.messages)
-      .to eq(['Do not use trailing `_`s in parallel assignment.'])
-  end
-
-  it 'registers an offense for an underscore as the last param ' \
-     'when there is also an underscore as the first param' do
-    inspect_source(cop, '_, b, _ = foo()')
-
-    expect(cop.messages)
-      .to eq(['Do not use trailing `_`s in parallel assignment.'])
-  end
-
-  it 'does not register an offense when there are no underscores' do
-    inspect_source(cop, 'a, b, c = foo()')
-
-    expect(cop.messages).to be_empty
-  end
-
-  it 'does not register an offense for underscores at the beginning' do
-    inspect_source(cop, '_, a, b = foo()')
-
-    expect(cop.messages).to be_empty
-  end
-
-  it 'does not register an offense for variables starting with an underscore' do
-    inspect_source(cop, 'a, b, _c = foo()')
-
-    expect(cop.messages).to be_empty
-  end
-
-  it 'does not register an offense for a named splat underscore ' \
-     'as the last variable' do
-    inspect_source(cop, 'a, *_b = foo()')
-
-    expect(cop.messages).to be_empty
-  end
-
-  describe 'autocorrect' do
-    it 'removes trailing underscores automatically' do
-      new_source = autocorrect_source(cop, 'a, b, _ = foo()')
-
-      expect(new_source).to eq('a, b, = foo()')
+      expect(cop.messages)
+        .to eq(['Do not use trailing `_`s in parallel assignment.'])
     end
 
-    it 'removes trailing underscores and commas' do
-      new_source = autocorrect_source(cop, 'a, b, _, = foo()')
+    it 'registers an offense when multiple underscores are used '\
+       'as the last variables of parallel assignment ' do
+      inspect_source(cop, 'a, _, _ = foo()')
 
-      expect(new_source).to eq('a, b, = foo()')
+      expect(cop.messages)
+        .to eq(['Do not use trailing `_`s in parallel assignment.'])
     end
 
-    it 'removes multiple trailing underscores' do
-      new_source = autocorrect_source(cop, 'a, _, _ = foo()')
+    it 'registers an offense for splat underscore as the last variable' do
+      inspect_source(cop, 'a, *_ = foo()')
 
-      expect(new_source).to eq('a, = foo()')
+      expect(cop.messages)
+        .to eq(['Do not use trailing `_`s in parallel assignment.'])
     end
 
-    it 'removes multiple trailing underscores and commas' do
-      new_source = autocorrect_source(cop, 'a, _, _, = foo()')
+    it 'registers an offense when underscore is the second to last variable ' \
+       'and blank is the last variable' do
+      inspect_source(cop, 'a, _, = foo()')
 
-      expect(new_source).to eq('a, = foo()')
+      expect(cop.messages)
+        .to eq(['Do not use trailing `_`s in parallel assignment.'])
     end
 
-    it 'removes trailing comma when it is the only variable' do
-      new_source = autocorrect_source(cop, '_, = foo()')
+    it 'registers an offense when underscore is the only variable ' \
+       'in parallel assignment' do
+      inspect_source(cop, '_, = foo()')
 
-      expect(new_source).to eq('foo()')
+      expect(cop.messages)
+        .to eq(['Do not use trailing `_`s in parallel assignment.'])
     end
 
-    it 'removes multiple trailing underscores and commas' do
-      new_source = autocorrect_source(cop, '_, _, _, = foo()')
+    it 'registers an offense for an underscore as the last param ' \
+       'when there is also an underscore as the first param' do
+      inspect_source(cop, '_, b, _ = foo()')
 
-      expect(new_source).to eq('foo()')
+      expect(cop.messages)
+        .to eq(['Do not use trailing `_`s in parallel assignment.'])
     end
 
-    it 'remove splat underscore' do
-      new_source = autocorrect_source(cop, 'a, *_ = foo()')
+    it 'does not register an offense when there are no underscores' do
+      inspect_source(cop, 'a, b, c = foo()')
 
-      expect(new_source).to eq('a, = foo()')
+      expect(cop.messages).to be_empty
+    end
+
+    it 'does not register an offense for underscores at the beginning' do
+      inspect_source(cop, '_, a, b = foo()')
+
+      expect(cop.messages).to be_empty
+    end
+
+    describe 'autocorrect' do
+      it 'removes trailing underscores automatically' do
+        new_source = autocorrect_source(cop, 'a, b, _ = foo()')
+
+        expect(new_source).to eq('a, b, = foo()')
+      end
+
+      it 'removes trailing underscores and commas' do
+        new_source = autocorrect_source(cop, 'a, b, _, = foo()')
+
+        expect(new_source).to eq('a, b, = foo()')
+      end
+
+      it 'removes multiple trailing underscores' do
+        new_source = autocorrect_source(cop, 'a, _, _ = foo()')
+
+        expect(new_source).to eq('a, = foo()')
+      end
+
+      it 'removes multiple trailing underscores and commas' do
+        new_source = autocorrect_source(cop, 'a, _, _, = foo()')
+
+        expect(new_source).to eq('a, = foo()')
+      end
+
+      it 'removes trailing comma when it is the only variable' do
+        new_source = autocorrect_source(cop, '_, = foo()')
+
+        expect(new_source).to eq('foo()')
+      end
+
+      it 'removes multiple trailing underscores and commas' do
+        new_source = autocorrect_source(cop, '_, _, _, = foo()')
+
+        expect(new_source).to eq('foo()')
+      end
+
+      it 'remove splat underscore' do
+        new_source = autocorrect_source(cop, 'a, *_ = foo()')
+
+        expect(new_source).to eq('a, = foo()')
+      end
+    end
+  end
+
+  context 'configured to allow named underscore variables' do
+    include_examples 'common functionality'
+
+    let(:config) do
+      RuboCop::Config.new('Style/TrailingUnderscoreVariable' => {
+                            'Enabled' => true,
+                            'AllowNamedUnderscoreVariables' => true
+                          })
+    end
+
+    it 'does not register an offense for named variables ' \
+       'that start with an underscore' do
+      inspect_source(cop, 'a, b, _c = foo()')
+
+      expect(cop.messages).to be_empty
+    end
+
+    it 'does not register an offense for a named splat underscore ' \
+       'as the last variable' do
+      inspect_source(cop, 'a, *_b = foo()')
+
+      expect(cop.messages).to be_empty
+    end
+  end
+
+  context 'configured to not allow named underscore variables' do
+    include_examples 'common functionality'
+
+    let(:config) do
+      RuboCop::Config.new('Style/TrailingUnderscoreVariable' => {
+                            'Enabled' => true,
+                            'AllowNamedUnderscoreVariables' => false
+                          })
+    end
+
+    it 'registers an offense for named variables ' \
+       'that start with an underscore' do
+      inspect_source(cop, 'a, b, _c = foo()')
+
+      expect(cop.messages)
+        .to eq(['Do not use trailing `_`s in parallel assignment.'])
+    end
+
+    it 'registers an offense for a named splat underscore ' \
+       'as the last variable' do
+      inspect_source(cop, 'a, *_b = foo()')
+
+      expect(cop.messages)
+        .to eq(['Do not use trailing `_`s in parallel assignment.'])
+    end
+
+    context 'autocorrect' do
+      it 'removes named underscore variables' do
+        new_source = autocorrect_source(cop, 'a, _b = foo()')
+
+        expect(new_source).to eq('a, = foo()')
+      end
+
+      it 'removes named splat underscore variables' do
+        new_source = autocorrect_source(cop, 'a, *_b = foo()')
+
+        expect(new_source).to eq('a, = foo()')
+      end
     end
   end
 end

--- a/spec/rubocop/cop/style/trailing_underscore_variable_spec.rb
+++ b/spec/rubocop/cop/style/trailing_underscore_variable_spec.rb
@@ -65,6 +65,56 @@ describe RuboCop::Cop::Style::TrailingUnderscoreVariable do
       expect(cop.messages).to be_empty
     end
 
+    it 'does not register an offense for an underscore preceeded by a ' \
+       'splat variable anywhere in the argument chain' do
+      inspect_source(cop, '*a, b, _ = foo()')
+
+      expect(cop.messages).to be_empty
+    end
+
+    it 'does not register an offense for an underscore preceeded by a ' \
+       'splat variable' do
+      inspect_source(cop, 'a, *b, _ = foo()')
+
+      expect(cop.messages).to be_empty
+    end
+
+    it 'does not register an offense for multiple underscores preceeded by a ' \
+       'splat variable' do
+      inspect_source(cop, 'a, *b, _, _ = foo()')
+
+      expect(cop.messages).to be_empty
+    end
+
+    it 'does not register an offense for multiple named underscores ' \
+       'preceeded by a splat variable' do
+      inspect_source(cop, 'a, *b, _c, _d = foo()')
+
+      expect(cop.messages).to be_empty
+    end
+
+    it 'registers an offense for multiple underscore variables preceeded by ' \
+       'a splat underscore variable' do
+      inspect_source(cop, 'a, *_, _, _ = foo()')
+
+      expect(cop.messages)
+        .to eq(['Do not use trailing `_`s in parallel assignment.'])
+    end
+
+    it 'does not register an offense for a named underscore variable ' \
+       'preceeded by a splat variable' do
+      inspect_source(cop, 'a, *b, _c = foo()')
+
+      expect(cop.messages).to be_empty
+    end
+
+    it 'does not register an offense for a named variable preceeded by a ' \
+       'names splat underscore variable' do
+      inspect_source(cop, 'a, *b, _c = foo()')
+
+      expect(cop.messages).to be_empty
+    end
+
     describe 'autocorrect' do
       it 'removes trailing underscores automatically' do
         new_source = autocorrect_source(cop, 'a, b, _ = foo()')
@@ -120,6 +170,13 @@ describe RuboCop::Cop::Style::TrailingUnderscoreVariable do
                           })
     end
 
+    it 'does not register an offense for an underscore variable preceeded ' \
+       'by a named splat underscore variable' do
+      inspect_source(cop, 'a, *_b, _ = foo()')
+
+      expect(cop.messages).to be_empty
+    end
+
     it 'does not register an offense for named variables ' \
        'that start with an underscore' do
       inspect_source(cop, 'a, b, _c = foo()')
@@ -130,6 +187,20 @@ describe RuboCop::Cop::Style::TrailingUnderscoreVariable do
     it 'does not register an offense for a named splat underscore ' \
        'as the last variable' do
       inspect_source(cop, 'a, *_b = foo()')
+
+      expect(cop.messages).to be_empty
+    end
+
+    it 'does not register an offense for an underscore preceeded by ' \
+       'a named splat underscore' do
+      inspect_source(cop, 'a, *_b, _ = foo()')
+
+      expect(cop.messages).to be_empty
+    end
+
+    it 'does not register an offense for multiple underscore variables ' \
+       'preceeded by a named splat underscore variable' do
+      inspect_source(cop, 'a, *_b, _, _ = foo()')
 
       expect(cop.messages).to be_empty
     end
@@ -161,6 +232,37 @@ describe RuboCop::Cop::Style::TrailingUnderscoreVariable do
         .to eq(['Do not use trailing `_`s in parallel assignment.'])
     end
 
+    it 'does not register an offense for a named underscore preceeded by a ' \
+       'splat variable' do
+      inspect_source(cop, 'a, *b, _c = foo()')
+
+      expect(cop.messages).to be_empty
+    end
+
+    it 'registers an offense for an underscore variable preceeded ' \
+       'by a named splat underscore variable' do
+      inspect_source(cop, 'a, *_b, _ = foo()')
+
+      expect(cop.messages)
+        .to eq(['Do not use trailing `_`s in parallel assignment.'])
+    end
+
+    it 'registers an offense for an underscore preceeded by ' \
+       'a named splat underscore' do
+      inspect_source(cop, 'a, b, *_c, _ = foo()')
+
+      expect(cop.messages)
+        .to eq(['Do not use trailing `_`s in parallel assignment.'])
+    end
+
+    it 'registers an offense for multiple underscore variables ' \
+       'preceeded by a named splat underscore variable' do
+      inspect_source(cop, 'a, *_b, _, _ = foo()')
+
+      expect(cop.messages)
+        .to eq(['Do not use trailing `_`s in parallel assignment.'])
+    end
+
     context 'autocorrect' do
       it 'removes named underscore variables' do
         new_source = autocorrect_source(cop, 'a, _b = foo()')
@@ -170,6 +272,12 @@ describe RuboCop::Cop::Style::TrailingUnderscoreVariable do
 
       it 'removes named splat underscore variables' do
         new_source = autocorrect_source(cop, 'a, *_b = foo()')
+
+        expect(new_source).to eq('a, = foo()')
+      end
+
+      it 'removes named splat underscore and named underscore variables' do
+        new_source = autocorrect_source(cop, 'a, *_b, _c = foo()')
 
         expect(new_source).to eq('a, = foo()')
       end


### PR DESCRIPTION
This turned into a larger commit than I originally thought it would be. 

There are 3 modification to `Style/TrailingUnderscorevariable`.
* Register an offense for trailing `*_`
 * this was never covered by the cop initially
* Add a configuration to remove named trailing underscore variables.
 * I set this to be defaulted to true. Looking through RuboCop as an example, the vast majority of trailing named variables do not provide any useful information.
* Do not register an offense for a trailing underscore variables that are preceeded by a splat variable
 * This has been a bug in the cop since it was first created.
 * `a, *b, = foo()` is a syntax error