### PR TITLE
[Fix #2248] Allow AutoResourceCleanup block-pass

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@
 * [#2121](https://github.com/bbatsov/rubocop/issues/2121): Allow space before values in hash literals in `Style/ExtraSpacing` to avoid correction conflict. ([@jonas054][])
 * [#2241](https://github.com/bbatsov/rubocop/issues/2241): Read cache in binary format. ([@jonas054][])
 
+### Changes
+
+* [#2248](https://github.com/bbatsov/rubocop/issues/2248): Allow block-pass in `Style/AutoResourceCleanup`. ([@lumeet][])
+
 ## 0.34.1 (09/09/2015)
 
 ### Bug Fixes

--- a/lib/rubocop/cop/style/auto_resource_cleanup.rb
+++ b/lib/rubocop/cop/style/auto_resource_cleanup.rb
@@ -25,7 +25,7 @@ module RuboCop
         ]
 
         def on_send(node)
-          receiver_node, method_name, *_arg_nodes = *node
+          receiver_node, method_name, *arg_nodes = *node
 
           TARGET_METHODS.each do |(target_class, target_method)|
             target_receiver = s(:const, nil, target_class)
@@ -33,6 +33,7 @@ module RuboCop
             next if receiver_node != target_receiver
             next if method_name != target_method
             next if node.parent && node.parent.block_type?
+            next if !arg_nodes.empty? && arg_nodes.last.block_pass_type?
 
             add_offense(node,
                         :expression,

--- a/spec/rubocop/cop/style/auto_resource_cleanup_spec.rb
+++ b/spec/rubocop/cop/style/auto_resource_cleanup_spec.rb
@@ -16,4 +16,10 @@ describe RuboCop::Cop::Style::AutoResourceCleanup do
 
     expect(cop.offenses).to be_empty
   end
+
+  it 'does not register an offense for File.open with block-pass' do
+    inspect_source(cop, 'File.open("file", &:read)')
+
+    expect(cop.offenses).to be_empty
+  end
 end


### PR DESCRIPTION
Accept `File.open('file', &:read)` in `Style/AutoResourceCleanup`.