### PR TITLE
Change AbcSize to only iterate through child nodes once

### DIFF
--- a/lib/rubocop/cop/metrics/abc_size.rb
+++ b/lib/rubocop/cop/metrics/abc_size.rb
@@ -10,16 +10,27 @@ module RuboCop
         include MethodComplexity
 
         MSG = 'Assignment Branch Condition size for %s is too high. [%.4g/%.4g]'
-        BRANCH_NODES = [:send]
-        CONDITION_NODES = CyclomaticComplexity::COUNTED_NODES
+        BRANCH_NODES = [:send].freeze
+        CONDITION_NODES = CyclomaticComplexity::COUNTED_NODES.freeze
 
         private
 
         def complexity(node)
-          a = node.each_node(ASGN_NODES).count
-          b = node.each_node(BRANCH_NODES).count
-          c = node.each_node(CONDITION_NODES).count
-          Math.sqrt(a**2 + b**2 + c**2).round(2)
+          assignment = 0
+          branch = 0
+          condition = 0
+
+          node.each_node do |child|
+            if ASGN_NODES.include?(child.type)
+              assignment += 1
+            elsif BRANCH_NODES.include?(child.type)
+              branch += 1
+            elsif CONDITION_NODES.include?(child.type)
+              condition += 1
+            end
+          end
+
+          Math.sqrt(assignment**2 + branch**2 + condition**2).round(2)
         end
       end
     end


### PR DESCRIPTION
This causes the memory usage of `Metrics/AbcSize` to drop from 332808 bytes to 83768 bytes (75%). There is a small speed improvement here as well.


I attempted to write this with a case statement, but that caused the memory consumption to increase by 486% and had a noticeable negative impact on speed

```ruby
case child.type
when *ASGN_NODES
  assignment += 1
when *BRANCH_NODES
  branch += 1
when *CONDITION_NODES
  condition += 1
end
```

This looks better as a case statement, but it is not worth it. The issue is that ruby has to expand the `_NODES` array in every when branch.