### PR TITLE
[Fix #2244] Annotations can only begin a comment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 * [#2121](https://github.com/bbatsov/rubocop/issues/2121): Allow space before values in hash literals in `Style/ExtraSpacing` to avoid correction conflict. ([@jonas054][])
 * [#2241](https://github.com/bbatsov/rubocop/issues/2241): Read cache in binary format. ([@jonas054][])
 * [#2247](https://github.com/bbatsov/rubocop/issues/2247): Fix auto-correct of `Performance/CaseWhenSplat` for percent arrays (`%w`, `%W`, `%i`, and `%I`). ([@rrosenblum][])
+* [#2244](https://github.com/bbatsov/rubocop/issues/2244): Disregard annotation keywords in `Style/CommentAnnotation` if they don't start a comment. ([@jonas054][])
 
 ### Changes
 

--- a/lib/rubocop/cop/style/comment_annotation.rb
+++ b/lib/rubocop/cop/style/comment_annotation.rb
@@ -15,7 +15,9 @@ module RuboCop
                        'is missing a note.'
 
         def investigate(processed_source)
-          processed_source.comments.each do |comment|
+          processed_source.comments.each_with_index do |comment, ix|
+            next unless first_comment_line?(processed_source.comments, ix)
+
             margin, first_word, colon, space, note = split_comment(comment)
             next unless annotation?(comment) &&
                         !correct_annotation?(first_word, colon, space, note)
@@ -35,6 +37,10 @@ module RuboCop
         end
 
         private
+
+        def first_comment_line?(comments, ix)
+          ix == 0 || comments[ix - 1].loc.line < comments[ix].loc.line - 1
+        end
 
         def autocorrect(comment)
           margin, first_word, colon, space, note = split_comment(comment)

--- a/spec/rubocop/cop/style/comment_annotation_spec.rb
+++ b/spec/rubocop/cop/style/comment_annotation_spec.rb
@@ -112,6 +112,14 @@ describe RuboCop::Cop::Style::CommentAnnotation, :config do
     expect(cop.offenses).to be_empty
   end
 
+  it 'accepts a keyword that is somewhere in a sentence' do
+    src = ['# Example: There are three reviews, with ranks 1, 2, and 3. A new',
+           '# review is saved with rank 2. The two reviews that originally had',
+           '# ranks 2 and 3 will have their ranks increased to 3 and 4.']
+    inspect_source(cop, src)
+    expect(cop.offenses).to be_empty
+  end
+
   context 'when a keyword is not in the configuration' do
     let(:cop_config) do
       { 'Keywords' => %w(FIXME OPTIMIZE HACK REVIEW) }


### PR DESCRIPTION
If annotation keywords appear further down in a comment block, we don't regard is as an annotation.