### PR TITLE
Rescue ensure same line

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 * [#2241](https://github.com/bbatsov/rubocop/issues/2241): Read cache in binary format. ([@jonas054][])
 * [#2247](https://github.com/bbatsov/rubocop/issues/2247): Fix auto-correct of `Performance/CaseWhenSplat` for percent arrays (`%w`, `%W`, `%i`, and `%I`). ([@rrosenblum][])
 * [#2244](https://github.com/bbatsov/rubocop/issues/2244): Disregard annotation keywords in `Style/CommentAnnotation` if they don't start a comment. ([@jonas054][])
+* [#2257](https://github.com/bbatsov/rubocop/pull/2257): Fix bug where `Style/RescueEnsureAlignment` will register an offense for `rescue` and `ensure` on the same line. ([@rrosenblum][])
 
 ### Changes
 

--- a/lib/rubocop/cop/style/rescue_ensure_alignment.rb
+++ b/lib/rubocop/cop/style/rescue_ensure_alignment.rb
@@ -33,9 +33,11 @@ module RuboCop
         end
 
         def investigate(processed_source)
-          @modifier_locations = processed_source.tokens
-                                .select { |t| t.type == :kRESCUE_MOD }
-                                .map(&:pos)
+          @modifier_locations =
+            processed_source.tokens.each_with_object([]) do |token, locations|
+              next unless token.type == :kRESCUE_MOD
+              locations << token.pos
+            end
         end
 
         def autocorrect(node)

--- a/lib/rubocop/cop/style/rescue_ensure_alignment.rb
+++ b/lib/rubocop/cop/style/rescue_ensure_alignment.rb
@@ -56,6 +56,7 @@ module RuboCop
         def check(node)
           end_loc = ancestor_node(node).loc.end
           return if end_loc.column == node.loc.keyword.column
+          return if end_loc.line == node.loc.keyword.line
 
           kw_loc = node.loc.keyword
 

--- a/spec/rubocop/cop/style/rescue_ensure_alignment_spec.rb
+++ b/spec/rubocop/cop/style/rescue_ensure_alignment_spec.rb
@@ -37,6 +37,12 @@ describe RuboCop::Cop::Style::RescueEnsureAlignment do
                                     ' `end` at 5, 0.'])
       end
 
+      it 'accepts rescue and ensure on the same line' do
+        inspect_source(cop, 'begin; puts 1; rescue; ensure; puts 2; end')
+
+        expect(cop.messages).to be_empty
+      end
+
       it 'auto-corrects' do
         corrected = autocorrect_source(cop, ['begin',
                                              '  something',


### PR DESCRIPTION
`RescueEnsureAlignment` complained about the alignment of `rescue` and `ensure` on the same line. The other alignment cops account for this edge case already.