### PR TITLE
Exclude test directories from Documentation cop by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
 ### Changes
 
 * [#2248](https://github.com/bbatsov/rubocop/issues/2248): Allow block-pass in `Style/AutoResourceCleanup`. ([@lumeet][])
+* [#2258](https://github.com/bbatsov/rubocop/pull/2258): `Style/Documentation` will exclude test directories by default. ([@rrosenblum][])
 
 ## 0.34.1 (09/09/2015)
 

--- a/config/enabled.yml
+++ b/config/enabled.yml
@@ -171,6 +171,9 @@ Style/DeprecatedHashMethods:
 Style/Documentation:
   Description: 'Document classes and non-namespace modules.'
   Enabled: true
+  Exclude:
+    - 'spec/**/*'
+    - 'test/**/*'
 
 Style/DotPosition:
   Description: 'Checks the position of the dot in multi-line method calls.'

--- a/spec/.rubocop.yml
+++ b/spec/.rubocop.yml
@@ -1,5 +1,0 @@
-inherit_from: ../.rubocop.yml
-
-# The documentation check doesn't make sense for test code
-Style/Documentation:
-  Enabled: false


### PR DESCRIPTION
The comment from the `spec/.rubocop.yml` file says it all
> `# The documentation check doesn't make sense for test code`

I think this applies to nearly all projects.