### PR TITLE
Make relative Excludes work in .rubocop_todo.yml

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 * [#2244](https://github.com/bbatsov/rubocop/issues/2244): Disregard annotation keywords in `Style/CommentAnnotation` if they don't start a comment. ([@jonas054][])
 * [#2257](https://github.com/bbatsov/rubocop/pull/2257): Fix bug where `Style/RescueEnsureAlignment` will register an offense for `rescue` and `ensure` on the same line. ([@rrosenblum][])
 * [#2255](https://github.com/bbatsov/rubocop/issues/2255): Refine the offense highlighting for `Style/SymbolProc`. ([@bbatsov][])
+* [#2260](https://github.com/bbatsov/rubocop/pull/2260): Make `Exclude` in `.rubocop_todo.yml` work when running from a subdirectory. ([@jonas054][])
 
 ### Changes
 

--- a/lib/rubocop/config.rb
+++ b/lib/rubocop/config.rb
@@ -162,13 +162,15 @@ module RuboCop
       relative_path(path, base_dir_for_path_parameters)
     end
 
-    # Paths specified in .rubocop.yml files are relative to the directory where
-    # that file is. Paths in other config files are relative to the current
-    # directory. This is so that paths in config/default.yml, for example, are
-    # not relative to RuboCop's config directory since that wouldn't work.
+    # Paths specified in .rubocop.yml and .rubocop_todo.yml files are relative
+    # to the directory where that file is. Paths in other config files are
+    # relative to the current directory. This is so that paths in
+    # config/default.yml, for example, are not relative to RuboCop's config
+    # directory since that wouldn't work.
     def base_dir_for_path_parameters
+      config_files = [ConfigLoader::DOTFILE, ConfigLoader::AUTO_GENERATED_FILE]
       @base_dir_for_path_parameters ||=
-        if File.basename(loaded_path) == ConfigLoader::DOTFILE
+        if config_files.include?(File.basename(loaded_path))
           File.expand_path(File.dirname(loaded_path))
         else
           Dir.pwd

--- a/spec/rubocop/cli_spec.rb
+++ b/spec/rubocop/cli_spec.rb
@@ -2620,6 +2620,17 @@ describe RuboCop::CLI, :isolated_environment do
     end
 
     describe 'including/excluding' do
+      it 'honors Exclude settings in .rubocop_todo.yml one level up' do
+        create_file('lib/example.rb', ['# encoding: utf-8',
+                                       'puts %x(ls)'])
+        create_file('.rubocop.yml', 'inherit_from: .rubocop_todo.yml')
+        create_file('.rubocop_todo.yml', ['Style/CommandLiteral:',
+                                          '  Exclude:',
+                                          '    - lib/example.rb'])
+        Dir.chdir('lib') { expect(cli.run([])).to eq(0) }
+        expect($stdout.string).to include('no offenses detected')
+      end
+
       it 'includes some directories by default' do
         source = ['# encoding: utf-8',
                   'read_attribute(:test)',


### PR DESCRIPTION
When `Exclude` properties are read, we make the paths absolute so that matching against them will be easy regardless of current directory. The interpretation of relative paths is different when they are specified in `.rubocop.yml` compared to, for example, `default.yml`. What we forgot is that the same goes for `.rubocop_todo.yml` too.