### PR TITLE
[Fix #2261] Exclude paths in ~/.rubocop_todo.yml relative to current dir

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## master (unreleased)
 
+### Bug Fixes
+
+* [#2261](https://github.com/bbatsov/rubocop/issues/2261): Make relative `Exclude` paths in `$HOME/.rubocop_todo.yml` be relative to current directory. ([@jonas054][])
+
 ### New features
 
 * [#2036](https://github.com/bbatsov/rubocop/issues/2036): New cop `Style/StabbyLambdaParentheses` will find and correct cases where a stabby lambda's paramaters are not wrapped in parentheses. ([@hmadison][])

--- a/lib/rubocop/config.rb
+++ b/lib/rubocop/config.rb
@@ -170,7 +170,8 @@ module RuboCop
     def base_dir_for_path_parameters
       config_files = [ConfigLoader::DOTFILE, ConfigLoader::AUTO_GENERATED_FILE]
       @base_dir_for_path_parameters ||=
-        if config_files.include?(File.basename(loaded_path))
+        if config_files.include?(File.basename(loaded_path)) &&
+           loaded_path != File.join(Dir.home, ConfigLoader::DOTFILE)
           File.expand_path(File.dirname(loaded_path))
         else
           Dir.pwd

--- a/spec/rubocop/cli_spec.rb
+++ b/spec/rubocop/cli_spec.rb
@@ -3418,6 +3418,19 @@ describe RuboCop::CLI, :isolated_environment do
       end
     end
 
+    context 'when configuration is taken from $HOME/.rubocop.yml' do
+      before do
+        create_file("#{Dir.home}/.rubocop.yml", ['Metrics/LineLength:',
+                                                 '  Exclude:',
+                                                 '    - dir/example.rb'])
+        create_file('dir/example.rb', '#' * 90)
+      end
+
+      it 'handles relative excludes correctly when run from project root' do
+        expect(cli.run([])).to eq(0)
+      end
+    end
+
     it 'shows an error if the input file cannot be found' do
       begin
         cli.run(%w(/tmp/not_a_file))


### PR DESCRIPTION
You wouldn't expect paths to refer to code in the home directory. This makes more sense.