### PR TITLE
[Fix #2194] allow any options with --auto-gen-config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,10 @@
 * [#2295](https://github.com/bbatsov/rubocop/issues/2295): Fix Performance/Detect autocorrect to handle rogue newlines. ([@palkan][])
 * [#2294](https://github.com/bbatsov/rubocop/issues/2294): Do not register an offense in `Performance/StringReplacement` for regex with options. ([@rrosenblum][])
 
+### Changes
+
+* [#2194](https://github.com/bbatsov/rubocop/issues/2194): Allow any options with `--auto-gen-config`. ([@agrimm][])
+
 ## 0.34.2 (21/09/2015)
 
 ### Bug Fixes

--- a/lib/rubocop/options.rb
+++ b/lib/rubocop/options.rb
@@ -90,7 +90,6 @@ module RuboCop
       option(opts, '-c', '--config FILE')
 
       option(opts, '--auto-gen-config') do
-        validate_auto_gen_config_option(args)
         @options[:formatters] = [[DEFAULT_FORMATTER],
                                  [Formatter::DisabledConfigFormatter,
                                   ConfigLoader::AUTO_GENERATED_FILE]]
@@ -171,14 +170,6 @@ module RuboCop
     def long_opt_symbol(args)
       long_opt = args.find { |arg| arg.start_with?('--') }
       long_opt[2..-1].sub(/ .*/, '').tr('-', '_').to_sym
-    end
-
-    def validate_auto_gen_config_option(args)
-      return if args.empty?
-      return if args.size <= 2 && args.first == '--exclude-limit'
-
-      warn '--auto-gen-config can only be combined with --exclude-limit.'
-      exit(1)
     end
 
     def validate_exclude_limit_option(args)

--- a/spec/rubocop/cli_spec.rb
+++ b/spec/rubocop/cli_spec.rb
@@ -980,21 +980,6 @@ describe RuboCop::CLI, :isolated_environment do
                   ''].join("\n"))
       end
 
-      it 'exits with error if file arguments are given' do
-        create_file('example1.rb', ['# encoding: utf-8',
-                                    'x= 0 ',
-                                    '#' * 85,
-                                    'y ',
-                                    'puts x'])
-        expect { cli.run(['--auto-gen-config', 'example1.rb']) }
-          .to exit_with_code(1)
-        expect($stderr.string)
-          .to eq(['--auto-gen-config can only be combined with ' \
-                  '--exclude-limit.',
-                  ''].join("\n"))
-        expect($stdout.string).to eq('')
-      end
-
       it 'can generate a todo list' do
         create_file('example1.rb', ['# encoding: utf-8',
                                     '$x= 0 ',

--- a/spec/rubocop/options_spec.rb
+++ b/spec/rubocop/options_spec.rb
@@ -231,6 +231,13 @@ Usage: rubocop [options] [file1, file2, ...]
       end
     end
 
+    describe '--auto-gen-config' do
+      it 'accepts other options' do
+        expect { options.parse %w(--auto-gen-config --rails) }
+          .not_to raise_error
+      end
+    end
+
     describe '-s/--stdin' do
       before do
         $stdin = StringIO.new


### PR DESCRIPTION
Fixes #2194 , allowing you to add options after `--auto-gen-config`, for example `rubocop --auto-gen-config --rails`. Users were already able to do `rubocop --rails --auto-gen-config`.

The output in `.rubocop_todo.yml` does not accurately reflect the parameters passed in, but that was already the case - that can be seen by doing `rubocop --rails --auto-gen-config` with the current version of RuboCop. As allowing any option with `--auto-gen-config`, and accurately displaying what parameters are passed in, can be fixed independently of each other, I made the latter a separate PR:
 #2267 .