### PR TITLE
Allow chaining in IfUnlessModifier

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 ### Bug Fixes
 
 * [#2275](https://github.com/bbatsov/rubocop/pull/2275): Copy default `Exclude` into `Exclude` lists in `.rubocop_todo.yml`. ([@jonas054][])
+* `Style/IfUnlessModifier` accepts blocks followed by a chained call. ([@lumeet][])
 
 ## 0.34.2 (21/09/2015)
 

--- a/lib/rubocop/cop/style/if_unless_modifier.rb
+++ b/lib/rubocop/cop/style/if_unless_modifier.rb
@@ -20,8 +20,15 @@ module RuboCop
           return if modifier_if?(node)
           return if elsif?(node)
           return if if_else?(node)
+          # Accept cases that require parentheses around modifier if statement.
+          return if chained?(node)
           return unless fit_within_line_as_modifier_form?(node)
           add_offense(node, :keyword, message(node.loc.keyword.source))
+        end
+
+        def chained?(node)
+          ancestor = node.ancestors.first
+          ancestor && ancestor.send_type?
         end
 
         def autocorrect(node)

--- a/spec/rubocop/cop/style/if_unless_modifier_spec.rb
+++ b/spec/rubocop/cop/style/if_unless_modifier_spec.rb
@@ -242,4 +242,11 @@ describe RuboCop::Cop::Style::IfUnlessModifier do
       end
     end
   end
+
+  it 'accepts if-end followed by a chained call' do
+    inspect_source(cop, ['if test',
+                         '  something',
+                         'end.inspect'])
+    expect(cop.messages).to be_empty
+  end
 end


### PR DESCRIPTION
Don't register an offense for an if-end block if it's immediately
followed by a chained call.

Currently, auto-correction produces changes in AST. That's why I call this a bug.

Before:
```ruby
if test
  something
end.inspect
```

After:
```ruby
something if test.inspect
```