### PR TITLE
Resolve #290 to inherit rubocop config from a gem.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 * [#2246](https://github.com/bbatsov/rubocop/pull/2246): `Style/TrailingUnderscoreVariable` now has a configuration to remove named underscore variables (Defaulted to false). ([@rrosenblum][])
 * [#2276](https://github.com/bbatsov/rubocop/pull/2276): New cop `Performance/FixedSize` will register an offense when calling `length`, `size`, or `count` on statically sized objected (strings, symbols, arrays, and hashes). ([@rrosenblum][])
 * New cop `Style/NestedModifier` checks for nested `if`, `unless`, `while` and `until` modifier statements. ([@lumeet][])
+* [#2270](https://github.com/bbatsov/rubocop/pull/2270): Add a new `inherit_gem` configuration to inherit a config file from an installed gem [(originally requested in #290)](https://github.com/bbatsov/rubocop/issues/290). ([@jhansche][])
 
 ### Bug Fixes
 
@@ -1644,3 +1645,4 @@
 [@dreyks]: https://github.com/dreyks
 [@hmadison]: https://github.com/hmadison
 [@miquella]: https://github.com/miquella
+[@jhansche]: https://github.com/jhansche

--- a/README.md
+++ b/README.md
@@ -269,6 +269,11 @@ Metrics/LineLength:
 
 ### Inheritance
 
+RuboCop supports inheriting configuration from one or more supplemental
+configuration files at runtime.
+
+#### Inheriting from another configuration file in the project
+
 The optional `inherit_from` directive is used to include configuration
 from one or more files. This makes it possible to have the common
 project settings in the `.rubocop.yml` file at the project root, and
@@ -284,6 +289,40 @@ inheritance is:
 inherit_from:
   - ../.rubocop.yml
   - ../conf/.rubocop.yml
+```
+
+#### Inheriting configuration from a dependency gem
+
+The optional `inherit_gem` directive is used to include configuration from
+one or more gems external to the current project. This makes it possible to
+inherit a shared dependency's RuboCop configuration that can be used from
+multiple disparate projects.
+
+Configurations inherited in this way will be essentially *prepended* to the
+`inherit_from` directive, such that the `inherit_gem` configurations will be
+loaded first, then the `inherit_from` relative file paths will be loaded
+(overriding the configurations from the gems), and finally the remaining
+directives in the configuration file will supersede any of the inherited
+configurations. This means the configurations inherited from one or more gems
+have the lowest precedence of inheritance.
+
+The directive should be formatted as a YAML Hash using the gem name as the
+key and the relative path within the gem as the value:
+
+```yaml
+inherit_gem:
+  rubocop: config/default.yml
+  my-shared-gem: .rubocop.yml
+  cucumber: conf/rubocop.yml
+```
+
+**Note**: If the shared dependency is declared using a [Bundler](http://bundler.io/)
+Gemfile and the gem was installed using `bundle install`, it would be
+necessary to also invoke RuboCop using Bundler in order to find the
+dependency's installation path at runtime:
+
+```
+$ bundle exec rubocop <options...>
 ```
 
 ### Defaults


### PR DESCRIPTION
The config directive should be in Hash format, with the `gem_name`
as the key, and the `relative_path_to_config` as the value. Ex:

    inherit_from: .rubocop_todo.yml

    inherit_gem:
        cucumber: config/rubocop.yml
        mygem: path/to/my/shared/rubocop.yml

If the gem is not installed, a warning is emitted, but execution
continues without the gem's config.