### PR TITLE
Upgrade ruby-progressbar to 1.7

### DIFF
--- a/rubocop.gemspec
+++ b/rubocop.gemspec
@@ -42,7 +42,7 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency('parser', '>= 2.2.2.5', '< 3.0')
   s.add_runtime_dependency('powerpack', '~> 0.1')
   s.add_runtime_dependency('astrolabe', '~> 1.3')
-  s.add_runtime_dependency('ruby-progressbar', '~> 1.4')
+  s.add_runtime_dependency('ruby-progressbar', '~> 1.7')
   s.add_development_dependency('rake', '~> 10.1')
   s.add_development_dependency('rspec', '~> 3.3.0')
   s.add_development_dependency('yard', '~> 0.8')


### PR DESCRIPTION
I am not sure if there is a reason to be on the older version or not. The upgrade appears to work fine.