### PR TITLE
Do not register an offense for UnneededPercentQ when %q or %Q occurs in an interpolated string

### DIFF
--- a/lib/rubocop/cop/style/unneeded_percent_q.rb
+++ b/lib/rubocop/cop/style/unneeded_percent_q.rb
@@ -14,7 +14,7 @@ module RuboCop
         end
 
         def on_str(node)
-          check(node)
+          check(node) if string_literal?(node)
         end
 
         # We process regexp nodes because the inner str nodes can cause
@@ -51,6 +51,11 @@ module RuboCop
             corrector.replace(node.loc.begin, delimiter)
             corrector.replace(node.loc.end, delimiter)
           end
+        end
+
+        def string_literal?(node)
+          node.loc.respond_to?(:begin) && node.loc.respond_to?(:end) &&
+            node.loc.begin && node.loc.end
         end
       end
     end

--- a/spec/rubocop/cop/style/unneeded_percent_q_spec.rb
+++ b/spec/rubocop/cop/style/unneeded_percent_q_spec.rb
@@ -134,7 +134,7 @@ describe RuboCop::Cop::Style::UnneededPercentQ do
       it 'corrects a dynamic string without quotes' do
         new_source = autocorrect_source(cop, "%Q(hi\#{4})")
 
-        expect(new_source).to eq(%Q("hi\#{4}"))
+        expect(new_source).to eq(%("hi\#{4}"))
       end
     end
   end
@@ -145,5 +145,33 @@ describe RuboCop::Cop::Style::UnneededPercentQ do
                          '%q("hi")',
                          'END'])
     expect(cop.offenses).to be_empty
+  end
+
+  it 'accepts %q at the beginning of a double quoted string ' \
+     'with interpolation' do
+    inspect_source(cop, "\"%q(a)\#{b}\"")
+
+    expect(cop.messages).to be_empty
+  end
+
+  it 'accepts %Q at the beginning of a double quoted string ' \
+     'with interpolation' do
+    inspect_source(cop, "\"%Q(a)\#{b}\"")
+
+    expect(cop.messages).to be_empty
+  end
+
+  it 'accepts %q at the beginning of a section of a double quoted string ' \
+     'with interpolation' do
+    inspect_source(cop, %("%\#{b}%q(a)"))
+
+    expect(cop.messages).to be_empty
+  end
+
+  it 'accepts %Q at the beginning of a section of a double quoted string ' \
+     'with interpolation' do
+    inspect_source(cop, %("%\#{b}%Q(a)"))
+
+    expect(cop.messages).to be_empty
   end
 end

--- a/spec/rubocop/cop/style/unneeded_percent_q_spec.rb
+++ b/spec/rubocop/cop/style/unneeded_percent_q_spec.rb
@@ -6,114 +6,136 @@ describe RuboCop::Cop::Style::UnneededPercentQ do
   subject(:cop) { described_class.new }
 
   context 'with %q strings' do
-    let(:source) do
-      <<-END.strip_indent
-        %q('hi') # line 1
-        %q("hi")
-        %q(hi)
-        %q('"hi"')
-        %q('hi\\t') # line 5
-      END
-    end
-    let(:corrected) do
-      <<-END.strip_indent
-        "'hi'" # line 1
-        '"hi"'
-        'hi'
-        %q('"hi"')
-        %q('hi\\t') # line 5
-      END
-    end
-    before { inspect_source(cop, source) }
-
     it 'registers an offense for only single quotes' do
-      expect(cop.offenses.map(&:line)).to include(1)
+      inspect_source(cop, "%q('hi')")
+
       expect(cop.messages).to eq(['Use `%q` only for strings that contain ' \
-                                  'both single quotes and double quotes.'] * 3)
+                                  'both single quotes and double quotes.'])
     end
 
     it 'registers an offense for only double quotes' do
-      expect(cop.offenses.map(&:line)).to include(2)
+      inspect_source(cop, '%q("hi")')
+
+      expect(cop.messages).to eq(['Use `%q` only for strings that contain ' \
+                                  'both single quotes and double quotes.'])
     end
 
     it 'registers an offense for no quotes' do
-      expect(cop.offenses.map(&:line)).to include(3)
+      inspect_source(cop, '%q(hi)')
+
+      expect(cop.messages).to eq(['Use `%q` only for strings that contain ' \
+                                  'both single quotes and double quotes.'])
     end
 
     it 'accepts a string with single quotes and double quotes' do
-      expect(cop.offenses.map(&:line)).not_to include(4)
+      inspect_source(cop, %q(%q('"hi"')))
+
+      expect(cop.messages).to be_empty
     end
 
     it 'accepts a string with a tab character' do
-      expect(cop.offenses.map(&:line)).not_to include(5)
+      inspect_source(cop, "%q('hi\\t')")
+
+      expect(cop.messages).to be_empty
     end
 
-    it 'auto-corrects' do
-      new_source = autocorrect_source(cop, source)
-      expect(new_source).to eq(corrected)
+    it 'accepts regular expressions starting with %q' do
+      inspect_source(cop, '/%q?/')
+
+      expect(cop.messages).to be_empty
+    end
+
+    context 'auto-correct' do
+      it 'registers an offense for only single quotes' do
+        new_source = autocorrect_source(cop, "%q('hi')")
+
+        expect(new_source).to eq(%q("'hi'"))
+      end
+
+      it 'registers an offense for only double quotes' do
+        new_source = autocorrect_source(cop, '%q("hi")')
+
+        expect(new_source).to eq(%q('"hi"'))
+      end
+
+      it 'registers an offense for no quotes' do
+        new_source = autocorrect_source(cop, '%q(hi)')
+
+        expect(new_source).to eq("'hi'")
+      end
     end
   end
 
   context 'with %Q strings' do
-    let(:source) do
-      <<-END.strip_indent
-        %Q(hi) # line 1
-        %Q("hi")
-        %Q(hi\#{4})
-        %Q('"hi"')
-        %Q("\\thi")
-        %Q("hi\#{4}")
-        /%Q?/ # line 7
-      END
-    end
-    let(:corrected) do
-      <<-END.strip_indent
-        "hi" # line 1
-        '"hi"'
-        "hi\#{4}"
-        %Q('"hi"')
-        %Q("\\thi")
-        %Q("hi\#{4}")
-        /%Q?/ # line 7
-      END
-    end
-    before { inspect_source(cop, source) }
-
     it 'registers an offense for static string without quotes' do
-      expect(cop.offenses.map(&:line)).to include(1)
+      inspect_source(cop, '%Q(hi)')
+
       expect(cop.messages).to eq(['Use `%Q` only for strings that contain ' \
                                   'both single quotes and double quotes, or ' \
                                   'for dynamic strings that contain double ' \
-                                  'quotes.'] * 3)
+                                  'quotes.'])
     end
 
     it 'registers an offense for static string with only double quotes' do
-      expect(cop.offenses.map(&:line)).to include(2)
+      inspect_source(cop, '%Q("hi")')
+
+      expect(cop.messages).to eq(['Use `%Q` only for strings that contain ' \
+                                  'both single quotes and double quotes, or ' \
+                                  'for dynamic strings that contain double ' \
+                                  'quotes.'])
     end
 
     it 'registers an offense for dynamic string without quotes' do
-      expect(cop.offenses.map(&:line)).to include(3)
+      inspect_source(cop, "%Q(hi\#{4})")
+
+      expect(cop.messages).to eq(['Use `%Q` only for strings that contain ' \
+                                  'both single quotes and double quotes, or ' \
+                                  'for dynamic strings that contain double ' \
+                                  'quotes.'])
     end
 
     it 'accepts a string with single quotes and double quotes' do
-      expect(cop.offenses.map(&:line)).not_to include(4)
+      inspect_source(cop, %q(%Q('"hi"')))
+
+      expect(cop.messages).to be_empty
     end
 
     it 'accepts a string with double quotes and tab character' do
-      expect(cop.offenses.map(&:line)).not_to include(5)
+      inspect_source(cop, '%Q("\\thi")')
+
+      expect(cop.messages).to be_empty
     end
 
     it 'accepts a dynamic %Q string with double quotes' do
-      expect(cop.offenses.map(&:line)).not_to include(6)
+      inspect_source(cop, '%Q("hi\#{4}")')
+
+      expect(cop.messages).to be_empty
     end
 
     it 'accepts regular expressions starting with %Q' do
-      expect(cop.offenses.map(&:line)).not_to include(7)
+      inspect_source(cop, '/%Q?/')
+
+      expect(cop.messages).to be_empty
     end
 
-    it 'auto-corrects' do
-      new_source = autocorrect_source(cop, source)
-      expect(new_source).to eq(corrected)
+    context 'auto-correct' do
+      it 'corrects a static string without quotes' do
+        new_source = autocorrect_source(cop, '%Q(hi)')
+
+        expect(new_source).to eq('"hi"')
+      end
+
+      it 'corrects a static string with only double quotes' do
+        new_source = autocorrect_source(cop, '%Q("hi")')
+
+        expect(new_source).to eq(%q('"hi"'))
+      end
+
+      it 'corrects a dynamic string without quotes' do
+        new_source = autocorrect_source(cop, "%Q(hi\#{4})")
+
+        expect(new_source).to eq(%Q("hi\#{4}"))
+      end
     end
   end
 


### PR DESCRIPTION
I came across a strange issue with `UnneededPercentQ` earlier. It would register an offense for a double quoted string that uses interpolation and has a section that begins with `%q` or `%Q`.

example offenses
```ruby
"%q#{foo}"
"%Q#{foo}"
"#{foo}%q"
"#{foo}%Q"
```