### PR TITLE
Copy Exclude from default config into .rubocop_todo.yml

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 * [#2036](https://github.com/bbatsov/rubocop/issues/2036): New cop `Style/StabbyLambdaParentheses` will find and correct cases where a stabby lambda's paramaters are not wrapped in parentheses. ([@hmadison][])
 
+### Bug Fixes
+
+* [#2275](https://github.com/bbatsov/rubocop/pull/2275): Copy default `Exclude` into `Exclude` lists in `.rubocop_todo.yml`. ([@jonas054][])
+
 ## 0.34.2 (21/09/2015)
 
 ### Bug Fixes

--- a/lib/rubocop/config_loader.rb
+++ b/lib/rubocop/config_loader.rb
@@ -18,6 +18,7 @@ module RuboCop
     class << self
       attr_accessor :debug, :auto_gen_config, :exclude_limit
       attr_writer :root_level # The upwards search is stopped at this level.
+      attr_writer :default_configuration
 
       alias_method :debug?, :debug
       alias_method :auto_gen_config?, :auto_gen_config

--- a/lib/rubocop/formatter/disabled_config_formatter.rb
+++ b/lib/rubocop/formatter/disabled_config_formatter.rb
@@ -89,16 +89,21 @@ module RuboCop
         if offending_files.count > @exclude_limit
           output.puts '  Enabled: false'
         else
-          output_exclude_list(output, offending_files)
+          output_exclude_list(output, offending_files, cop_name)
         end
       end
 
-      def output_exclude_list(output, offending_files)
+      def output_exclude_list(output, offending_files, cop_name)
         require 'pathname'
         parent = Pathname.new(Dir.pwd)
 
+        # Exclude properties in .rubocop_todo.yml override default ones, so in
+        # order to retain the default excludes we must copy them.
+        default_cfg = RuboCop::ConfigLoader.default_configuration[cop_name]
+        default_excludes = default_cfg ? default_cfg['Exclude'] || [] : []
+
         output.puts '  Exclude:'
-        offending_files.each do |file|
+        (default_excludes + offending_files).each do |file|
           file_path = Pathname.new(file)
           begin
             relative = file_path.relative_path_from(parent)

--- a/spec/rubocop/cli_spec.rb
+++ b/spec/rubocop/cli_spec.rb
@@ -1004,7 +1004,16 @@ describe RuboCop::CLI, :isolated_environment do
                                     'puts x'])
         create_file('example2.rb', ['# encoding: utf-8',
                                     "\tx = 0",
-                                    'puts x'])
+                                    'puts x',
+                                    '',
+                                    'class A',
+                                    '  def a',
+                                    '  end',
+                                    'end'])
+        # Make ConfigLoader reload the default configuration so that its
+        # absolute Exclude paths will point into this example's work directory.
+        RuboCop::ConfigLoader.default_configuration = nil
+
         expect(cli.run(['--auto-gen-config'])).to eq(1)
         expect($stderr.string).to eq('')
         expect($stdout.string)
@@ -1035,12 +1044,20 @@ describe RuboCop::CLI, :isolated_environment do
            "    - 'example2.rb'",
            '',
            '# Offense count: 1',
+           '# Configuration parameters: Exclude.',
+           'Style/Documentation:',
+           '  Exclude:',
+           "    - 'spec/**/*'", # Copied from default configuration
+           "    - 'test/**/*'", # Copied from default configuration
+           "    - 'example2.rb'",
+           '',
+           '# Offense count: 1',
            '# Configuration parameters: AllowedVariables.',
            'Style/GlobalVars:',
            '  Exclude:',
            "    - 'example1.rb'",
            '',
-           '# Offense count: 1',
+           '# Offense count: 2',
            '# Cop supports --auto-correct.',
            '# Configuration parameters: EnforcedStyle, SupportedStyles.',
            'Style/IndentationConsistency:',


### PR DESCRIPTION
Otherwise the defaults are overridden by the list in `.rubocop_todo.yml`, which means that offenses can remain after `rubocop --auto-gen-config`.