### PR TITLE
[Fix #2284] Ruby versions should not share result cache

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
 * [#2246](https://github.com/bbatsov/rubocop/pull/2246): Do not register an offense for `Style/TrailingUnderscoreVariable` when the underscore variable is preceeded by a splat variable. ([@rrosenblum][])
 * [#2292](https://github.com/bbatsov/rubocop/pull/2292): Results should not be stored in the cache if affected by errors (crashes). ([@jonas054][])
 * [#2280](https://github.com/bbatsov/rubocop/issues/2280): Avoid reporting space between hash literal keys and values in `Style/ExtraSpacing`. ([@jonas054][])
+* [#2284](https://github.com/bbatsov/rubocop/issues/2284): Fix result cache being shared between ruby versions. ([@miquella][])
 
 ## 0.34.2 (21/09/2015)
 
@@ -1638,3 +1639,4 @@
 [@karreiro]: https://github.com/karreiro
 [@dreyks]: https://github.com/dreyks
 [@hmadison]: https://github.com/hmadison
+[@miquella]: https://github.com/miquella

--- a/README.md
+++ b/README.md
@@ -836,6 +836,7 @@ are no changes in:
 * RuboCop configuration for the file
 * the options given to `rubocop`, with some exceptions that have no
   bearing on which offenses are reported
+* the Ruby version used to invoke `rubocop`
 * version of the `rubocop` program (or to be precise, anything in the
   source code of the invoked `rubocop` program)
 

--- a/lib/rubocop/result_cache.rb
+++ b/lib/rubocop/result_cache.rb
@@ -11,7 +11,8 @@ module RuboCop
     # collisions.
     def initialize(file, options, config_store, cache_root = nil)
       cache_root ||= ResultCache.cache_root(config_store)
-      @path = File.join(cache_root, rubocop_checksum, relevant_options(options),
+      @path = File.join(cache_root, rubocop_checksum, RUBY_VERSION,
+                        relevant_options(options),
                         file_checksum(file, config_store))
     end
 

--- a/spec/rubocop/result_cache_spec.rb
+++ b/spec/rubocop/result_cache_spec.rb
@@ -111,12 +111,12 @@ describe RuboCop::ResultCache, :isolated_environment do
       cache.save(offenses, disabled_lines, comments)
       cache2 = described_class.new('other.rb', options, config_store,
                                    cache_root)
-      expect(Dir["#{cache_root}/*/_/*"].size).to eq(1)
+      expect(Dir["#{cache_root}/*/*/_/*"].size).to eq(1)
       cache.class.cleanup(config_store, :verbose, cache_root)
       expect($stdout.string).to eq('')
 
       cache2.save(offenses, disabled_lines, comments)
-      underscore_dir = Dir["#{cache_root}/*/_"].first
+      underscore_dir = Dir["#{cache_root}/*/*/_"].first
       expect(Dir["#{underscore_dir}/*"].size).to eq(2)
       cache.class.cleanup(config_store, :verbose, cache_root)
       expect(File.exist?(underscore_dir)).to be_falsey


### PR DESCRIPTION
The parser as well as some linters change behavior depending on what
version of Ruby is running. Because of this, the result cache cannot be
shared between different versions of Ruby.