### PR TITLE
Correct nested if/unless modifiers using &&

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@
 * `Style/IfUnlessModifier` accepts blocks followed by a chained call. ([@lumeet][])
 * [#2261](https://github.com/bbatsov/rubocop/issues/2261): Make relative `Exclude` paths in `$HOME/.rubocop_todo.yml` be relative to current directory. ([@jonas054][])
 
+### Changes
+
+* [#2289](https://github.com/bbatsov/rubocop/pull/2289): `Style/IfUnlessModifier` will now auto-correct nested `if` and `unless` modifiers using `&&` instead of a second `if` or `unless`. ([@rrosenblum][])
+
 ## 0.34.2 (21/09/2015)
 
 ### Bug Fixes

--- a/spec/rubocop/cop/style/if_unless_modifier_spec.rb
+++ b/spec/rubocop/cop/style/if_unless_modifier_spec.rb
@@ -91,6 +91,55 @@ describe RuboCop::Cop::Style::IfUnlessModifier do
     end
   end
 
+  context 'multiline if that fits on one line with an if in the body' do
+    let(:source) do
+      ["if #{condition}",
+       "  #{body} if c",
+       'end']
+    end
+
+    let(:condition) { 'a' * 3 }
+    let(:body) { 'b' * 3 }
+
+    it 'registers an offense' do
+      inspect_source(cop, source)
+      expect(cop.messages).to eq(
+        ['Favor modifier `if` usage when having a single-line' \
+         ' body. Another good alternative is the usage of control flow' \
+         ' `&&`/`||`.'])
+    end
+
+    it 'does auto-correction' do
+      corrected = autocorrect_source(cop, source)
+      expect(corrected).to eq "#{body} if #{condition} && c"
+    end
+  end
+
+  context 'multiline if that fits on one line with an if containing an || ' \
+          'in the body' do
+    let(:source) do
+      ["if #{condition}",
+       "  #{body} if c || d",
+       'end']
+    end
+
+    let(:condition) { 'a' * 3 }
+    let(:body) { 'b' * 3 }
+
+    it 'registers an offense' do
+      inspect_source(cop, source)
+      expect(cop.messages).to eq(
+        ['Favor modifier `if` usage when having a single-line' \
+         ' body. Another good alternative is the usage of control flow' \
+         ' `&&`/`||`.'])
+    end
+
+    it 'does auto-correction' do
+      corrected = autocorrect_source(cop, source)
+      expect(corrected).to eq "#{body} if #{condition} && (c || d)"
+    end
+  end
+
   context 'short multiline if near an else etc' do
     let(:source) do
       ['if x',
@@ -155,6 +204,55 @@ describe RuboCop::Cop::Style::IfUnlessModifier do
     it 'does auto-correction' do
       corrected = autocorrect_source(cop, source)
       expect(corrected).to eq 'b unless a'
+    end
+  end
+
+  context 'multiline unless that fits on one line with an unless in the body' do
+    let(:source) do
+      ["unless #{condition}",
+       "  #{body} unless c",
+       'end']
+    end
+
+    let(:condition) { 'a' * 3 }
+    let(:body) { 'b' * 3 }
+
+    it 'registers an offense' do
+      inspect_source(cop, source)
+      expect(cop.messages).to eq(
+        ['Favor modifier `unless` usage when having a single-line' \
+         ' body. Another good alternative is the usage of control flow' \
+         ' `&&`/`||`.'])
+    end
+
+    it 'does auto-correction' do
+      corrected = autocorrect_source(cop, source)
+      expect(corrected).to eq "#{body} unless #{condition} && c"
+    end
+  end
+
+  context 'multiline unless that fits on one line with an unless ' \
+          'containing an || in the body' do
+    let(:source) do
+      ["unless #{condition}",
+       "  #{body} unless c || d",
+       'end']
+    end
+
+    let(:condition) { 'a' * 3 }
+    let(:body) { 'b' * 3 }
+
+    it 'registers an offense' do
+      inspect_source(cop, source)
+      expect(cop.messages).to eq(
+        ['Favor modifier `unless` usage when having a single-line' \
+         ' body. Another good alternative is the usage of control flow' \
+         ' `&&`/`||`.'])
+    end
+
+    it 'does auto-correction' do
+      corrected = autocorrect_source(cop, source)
+      expect(corrected).to eq "#{body} unless #{condition} && (c || d)"
     end
   end
 


### PR DESCRIPTION
I noticed the auto-correct of `IfUnlessModifier` had some awkward results when the body had an `if` or `unless` modifier.

```ruby
if foo
  a if bar
end

# auto-correct
a if bar if foo
```
 I didn't realize that a double `if` or `unless` modifier was valid syntax. Instead of using a double modifier, I think that `&&` looks better.

The code would now be auto-corrected to
```ruby
a if foo && bar
```


Maybe we should have a cop about double inline modifiers.
```ruby
a if foo if bar
a while foo if bar
```