### PR TITLE
Do not store results affected by crashes in the cache

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 * `Style/IfUnlessModifier` accepts blocks followed by a chained call. ([@lumeet][])
 * [#2261](https://github.com/bbatsov/rubocop/issues/2261): Make relative `Exclude` paths in `$HOME/.rubocop_todo.yml` be relative to current directory. ([@jonas054][])
 * [#2246](https://github.com/bbatsov/rubocop/pull/2246): Do not register an offense for `Style/TrailingUnderscoreVariable` when the underscore variable is preceeded by a splat variable. ([@rrosenblum][])
+* [#2292](https://github.com/bbatsov/rubocop/pull/2292): Results should not be stored in the cache if affected by errors (crashes). ([@jonas054][])
 
 ## 0.34.2 (21/09/2015)
 

--- a/spec/rubocop/runner_spec.rb
+++ b/spec/rubocop/runner_spec.rb
@@ -61,6 +61,26 @@ describe RuboCop::Runner, :isolated_environment do
       end
     end
 
+    context 'if a cop crashes' do
+      before(:each) do
+        # The cache responds that it's not valid, which means that new results
+        # should normally be collected and saved...
+        cache = double('cache', 'valid?' => false)
+        # ... but there's a crash in one cop.
+        runner.errors = ['An error occurred in ...']
+
+        allow(RuboCop::ResultCache).to receive(:new) { cache }
+      end
+
+      let(:source) { '' }
+
+      it 'does not call ResultCache#save' do
+        # The double doesn't define #save, so we'd get an error if it were
+        # called.
+        runner.run([])
+      end
+    end
+
     context 'if -s/--stdin is used with an offense' do
       let(:options) do
         {


### PR DESCRIPTION
When there's an error in a cop for a certain inspected file, we don't want to cache the result, because that means the error will be hidden in the next run.