### PR TITLE
[Fix #2280] Avoid everything between key, value in ExtraSpacing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 * [#2261](https://github.com/bbatsov/rubocop/issues/2261): Make relative `Exclude` paths in `$HOME/.rubocop_todo.yml` be relative to current directory. ([@jonas054][])
 * [#2246](https://github.com/bbatsov/rubocop/pull/2246): Do not register an offense for `Style/TrailingUnderscoreVariable` when the underscore variable is preceeded by a splat variable. ([@rrosenblum][])
 * [#2292](https://github.com/bbatsov/rubocop/pull/2292): Results should not be stored in the cache if affected by errors (crashes). ([@jonas054][])
+* [#2280](https://github.com/bbatsov/rubocop/issues/2280): Avoid reporting space between hash literal keys and values in `Style/ExtraSpacing`. ([@jonas054][])
 
 ## 0.34.2 (21/09/2015)
 

--- a/spec/rubocop/cop/style/extra_spacing_spec.rb
+++ b/spec/rubocop/cop/style/extra_spacing_spec.rb
@@ -24,6 +24,30 @@ describe RuboCop::Cop::Style::ExtraSpacing, :config do
       expect(cop.offenses).to be_empty
     end
 
+    it 'accepts space between key and value in a hash with hash rockets' do
+      source = [
+        'ospf_h = {',
+        "  'ospfTest'    => {",
+        "    'foo'      => {",
+        "      area: '0.0.0.0', cost: 10, hello: 30, pass: true },",
+        "    'longname' => {",
+        "      area: '1.1.1.38', pass: false },",
+        "    'vlan101'  => {",
+        "      area: '2.2.2.101', cost: 5, hello: 20, pass: true }",
+        '  },',
+        "  'TestOspfInt' => {",
+        "    'x'               => {",
+        "      area: '0.0.0.19' },",
+        "    'vlan290'         => {",
+        "      area: '2.2.2.29', cost: 200, hello: 30, pass: true },",
+        "    'port-channel100' => {",
+        "      area: '3.2.2.29', cost: 25, hello: 50, pass: false }",
+        '  }',
+        '}']
+      inspect_source(cop, source)
+      expect(cop.offenses).to be_empty
+    end
+
     it 'can handle extra space before a float' do
       source = ['{:a => "a",',
                 ' :b => [nil,  2.5]}']


### PR DESCRIPTION
Update of what inside hash literals we leave to `AlignHash`. I've chosen to exempt the whole range from the end of the key to the beginning of the value.

For `table` and `separator` alignment in `AlignHash` this is an easy decision. The space will be handled.

For `key` alignment, it could be argued that extra space before and after the separator should be handled by `ExtraSpacing`, but I felt it would add complexity, and would be a change in policy that would require some updates in the RuboCop code where we have aligned the values even though it's not mandated by `AlignHash`.