### PR TITLE
[Fix #2265] Handle unary + in ExtraSpacing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 
 ### Bug Fixes
 
+* [#2065](https://github.com/bbatsov/rubocop/issues/2065): Handle unary `+` in `ExtraSpacing` cop. ([@jonas054][])
 * [#2275](https://github.com/bbatsov/rubocop/pull/2275): Copy default `Exclude` into `Exclude` lists in `.rubocop_todo.yml`. ([@jonas054][])
 * `Style/IfUnlessModifier` accepts blocks followed by a chained call. ([@lumeet][])
 * [#2261](https://github.com/bbatsov/rubocop/issues/2261): Make relative `Exclude` paths in `$HOME/.rubocop_todo.yml` be relative to current directory. ([@jonas054][])

--- a/lib/rubocop/cop/style/extra_spacing.rb
+++ b/lib/rubocop/cop/style/extra_spacing.rb
@@ -34,6 +34,9 @@ module RuboCop
             end_pos = t2.pos.begin_pos - 1
             range = Parser::Source::Range.new(processed_source.buffer,
                                               start_pos, end_pos)
+            # Unary + doesn't appear as a token and needs special handling.
+            next if unary_plus_non_offense?(range)
+
             add_offense(range, range, MSG)
           end
         end
@@ -43,6 +46,10 @@ module RuboCop
         end
 
         private
+
+        def unary_plus_non_offense?(range)
+          range.resize(range.size + 1).source =~ /^ ?\+$/
+        end
 
         # Returns an array of ranges that should not be reported. It's the
         # extra spaces between the keys and values in a hash, since those are

--- a/spec/rubocop/cop/style/extra_spacing_spec.rb
+++ b/spec/rubocop/cop/style/extra_spacing_spec.rb
@@ -55,6 +55,14 @@ describe RuboCop::Cop::Style::ExtraSpacing, :config do
       expect(cop.offenses.size).to eq(1)
     end
 
+    it 'can handle unary plus in an argument list' do
+      source = ['assert_difference(MyModel.count, +2,',
+                '                  3,  +3,', # Extra spacing only here.
+                '                  4,+4)']
+      inspect_source(cop, source)
+      expect(cop.offenses.map { |o| o.location.line }).to eq([2])
+    end
+
     it 'gives the correct line' do
       inspect_source(cop, ['class A   < String',
                            'end'])


### PR DESCRIPTION
Unary plus is tricky. There's no token for it, so we must take steps.