### PR TITLE
Fix Style/UnneededPercentQ condition

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@
 * [#2285](https://github.com/bbatsov/rubocop/issues/2285): Fix `ConfigurableNaming#class_emitter_method?` error when handling singleton class methods. ([@palkan][])
 * [#2295](https://github.com/bbatsov/rubocop/issues/2295): Fix Performance/Detect autocorrect to handle rogue newlines. ([@palkan][])
 * [#2294](https://github.com/bbatsov/rubocop/issues/2294): Do not register an offense in `Performance/StringReplacement` for regex with options. ([@rrosenblum][])
+* Fix `Style/UnneededPercentQ` condition for single-quoted literal containing interpolation-like string. ([@eagletmt][])
 
 ## 0.34.2 (21/09/2015)
 
@@ -1651,3 +1652,4 @@
 [@miquella]: https://github.com/miquella
 [@jhansche]: https://github.com/jhansche
 [@cornelius]: https://github.com/cornelius
+[@eagletmt]: https://github.com/eagletmt

--- a/lib/rubocop/cop/style/unneeded_percent_q.rb
+++ b/lib/rubocop/cop/style/unneeded_percent_q.rb
@@ -13,6 +13,7 @@ module RuboCop
         EMPTY = ''.freeze
         PERCENT_Q = '%q'.freeze
         PERCENT_CAPITAL_Q = '%Q'.freeze
+        STRING_INTERPOLATION_REGEXP = /#\{.+}/
 
         def on_dstr(node)
           check(node)
@@ -33,6 +34,9 @@ module RuboCop
           return unless start_with_percent_q_variant?(src)
           return if src.include?(SINGLE_QUOTE) && src.include?(QUOTE)
           return if src =~ StringHelp::ESCAPED_CHAR_REGEXP
+          if src.start_with?(PERCENT_Q) && src =~ STRING_INTERPOLATION_REGEXP
+            return
+          end
 
           extra = if src.start_with?(PERCENT_CAPITAL_Q)
                     DYNAMIC_MSG

--- a/spec/rubocop/cop/style/unneeded_percent_q_spec.rb
+++ b/spec/rubocop/cop/style/unneeded_percent_q_spec.rb
@@ -174,4 +174,10 @@ describe RuboCop::Cop::Style::UnneededPercentQ do
 
     expect(cop.messages).to be_empty
   end
+
+  it 'accepts %q containing string interpolation' do
+    inspect_source(cop, %(%q(foo \#{'bar'} baz)))
+
+    expect(cop.messages).to be_empty
+  end
 end


### PR DESCRIPTION
`%q(foo #{'bar'} baz)` should not be warned because auto-correcting it
to `"foo #{'bar'} baz"` is wrong.