### PR TITLE
[Fix #2286] Auto-correct empty method in SingleLineMethods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 * [#2275](https://github.com/bbatsov/rubocop/pull/2275): Copy default `Exclude` into `Exclude` lists in `.rubocop_todo.yml`. ([@jonas054][])
 * `Style/IfUnlessModifier` accepts blocks followed by a chained call. ([@lumeet][])
 * [#2261](https://github.com/bbatsov/rubocop/issues/2261): Make relative `Exclude` paths in `$HOME/.rubocop_todo.yml` be relative to current directory. ([@jonas054][])
+* [#2286](https://github.com/bbatsov/rubocop/issues/2286): Handle auto-correction of empty method when `AllowIfMethodIsEmpty` is `false` in `Style/SingleLineMethods`. ([@jonas054][])
 * [#2246](https://github.com/bbatsov/rubocop/pull/2246): Do not register an offense for `Style/TrailingUnderscoreVariable` when the underscore variable is preceeded by a splat variable. ([@rrosenblum][])
 * [#2292](https://github.com/bbatsov/rubocop/pull/2292): Results should not be stored in the cache if affected by errors (crashes). ([@jonas054][])
 * [#2280](https://github.com/bbatsov/rubocop/issues/2280): Avoid reporting space between hash literal keys and values in `Style/ExtraSpacing`. ([@jonas054][])

--- a/lib/rubocop/cop/style/single_line_methods.rb
+++ b/lib/rubocop/cop/style/single_line_methods.rb
@@ -34,12 +34,14 @@ module RuboCop
             c.loc.line == node.loc.expression.line
           end
           lambda do |corrector|
-            if body.type == :begin
-              body.children.each do |part|
-                break_line_before(part.loc.expression, node, corrector, 1)
+            if body
+              if body.type == :begin
+                body.children.each do |part|
+                  break_line_before(part.loc.expression, node, corrector, 1)
+                end
+              else
+                break_line_before(body.loc.expression, node, corrector, 1)
               end
-            else
-              break_line_before(body.loc.expression, node, corrector, 1)
             end
 
             break_line_before(node.loc.end, node, corrector, 0)

--- a/spec/rubocop/cop/style/single_line_methods_spec.rb
+++ b/spec/rubocop/cop/style/single_line_methods_spec.rb
@@ -28,6 +28,12 @@ describe RuboCop::Cop::Style::SingleLineMethods do
                            'def @table.columns; end'])
       expect(cop.offenses.size).to eq(3)
     end
+
+    it 'auto-corrects an empty method' do
+      corrected = autocorrect_source(cop, 'def x; end')
+      expect(corrected).to eq(['def x; ',
+                               'end'].join("\n"))
+    end
   end
 
   context 'when AllowIfMethodIsEmpty is enabled' do


### PR DESCRIPTION
Handle the case when there is no body in `SingleLineMethods#autocorrect`.