### PR TITLE
Add AllowUnusedKeywordArguments option for UnusedMethodArgument

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 * New cop `Style/NestedModifier` checks for nested `if`, `unless`, `while` and `until` modifier statements. ([@lumeet][])
 * [#2270](https://github.com/bbatsov/rubocop/pull/2270): Add a new `inherit_gem` configuration to inherit a config file from an installed gem [(originally requested in #290)](https://github.com/bbatsov/rubocop/issues/290). ([@jhansche][])
 * Allow `StyleGuide` parameters in local configuration for all cops, so users can add references to custom style guide documents. ([@cornelius][])
+* `UnusedMethodArgument` cop allows configuration to skip keyword arguments. ([@apiology][])
 
 ### Bug Fixes
 
@@ -1653,3 +1654,4 @@
 [@jhansche]: https://github.com/jhansche
 [@cornelius]: https://github.com/cornelius
 [@eagletmt]: https://github.com/eagletmt
+[@apiology]: https://github.com/apiology

--- a/config/default.yml
+++ b/config/default.yml
@@ -849,6 +849,10 @@ Lint/DefEndAlignment:
     - def
   AutoCorrect: false
 
+# Checks for unused method arguments.  
+Lint/UnusedMethodArgument:
+  AllowUnusedKeywordArguments: false
+
 ##################### Rails ##################################
 
 Rails/ActionFilter:

--- a/lib/rubocop/cop/lint/unused_method_argument.rb
+++ b/lib/rubocop/cop/lint/unused_method_argument.rb
@@ -15,6 +15,8 @@ module RuboCop
 
         def check_argument(variable)
           return unless variable.method_argument?
+          return if variable.keyword_argument? &&
+                    cop_config && cop_config['AllowUnusedKeywordArguments']
           super
         end
 

--- a/spec/rubocop/cop/lint/unused_method_argument_spec.rb
+++ b/spec/rubocop/cop/lint/unused_method_argument_spec.rb
@@ -2,8 +2,9 @@
 
 require 'spec_helper'
 
-describe RuboCop::Cop::Lint::UnusedMethodArgument do
-  subject(:cop) { described_class.new }
+describe RuboCop::Cop::Lint::UnusedMethodArgument, :config do
+  subject(:cop) { described_class.new(config) }
+  let(:cop_config) { { 'AllowUnusedKeywordArguments' => false } }
 
   describe 'inspection' do
     before do
@@ -76,6 +77,14 @@ describe RuboCop::Cop::Lint::UnusedMethodArgument do
         expect(cop.highlights).to eq(['bar'])
         expect(cop.offenses.first.message)
           .to eq('Unused method argument - `bar`.')
+      end
+
+      context 'and AllowUnusedKeywordArguments set' do
+        let(:cop_config) { { 'AllowUnusedKeywordArguments' => true } }
+
+        it 'does not care' do
+          expect(cop.offenses).to be_empty
+        end
       end
     end
 


### PR DESCRIPTION
Hi!

The UnusedMethodArgument cop is great for finding unused method arguments.  One reason why people might have unused method arguments is when they are subclassing or adhering to a duck type.  In those cases, RuboCop suggests adding an underscore to the method argument.  

This is normally great advice for positional arguments, but in Ruby, underscores in front of keyword arguments result in run-time errors when you try to pass in those keyword arguments--the underscore doesn't have the same semantics as positional arguments.

The net result is that if you have a project with a lot of subclassing and/or duck-types and keyword arguments, UnusedMethodArgument gives you a lot of false positives.

This change provides an option called "AllowUnusedKeywordArguments" to address this by disabling the cop for unused keyword arguments.