### PR TITLE
Always allow a StyleGuide parameter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 * [#2246](https://github.com/bbatsov/rubocop/pull/2246): `Style/TrailingUnderscoreVariable` will now register an offense for `*_`. ([@rrosenblum][])
 * [#2246](https://github.com/bbatsov/rubocop/pull/2246): `Style/TrailingUnderscoreVariable` now has a configuration to remove named underscore variables (Defaulted to false). ([@rrosenblum][])
 * [#2276](https://github.com/bbatsov/rubocop/pull/2276): New cop `Performance/FixedSize` will register an offense when calling `length`, `size`, or `count` on statically sized objected (strings, symbols, arrays, and hashes). ([@rrosenblum][])
+* Allow `StyleGuide` parameters in local configuration for all cops, so users can add references to custom style guide documents. ([@cornelius][])
 
 ### Bug Fixes
 
@@ -1643,3 +1644,4 @@
 [@dreyks]: https://github.com/dreyks
 [@hmadison]: https://github.com/hmadison
 [@miquella]: https://github.com/miquella
+[@cornelius]: https://github.com/cornelius

--- a/lib/rubocop/config.rb
+++ b/lib/rubocop/config.rb
@@ -14,7 +14,7 @@ module RuboCop
 
     class ValidationError < StandardError; end
 
-    COMMON_PARAMS = %w(Exclude Include Severity AutoCorrect)
+    COMMON_PARAMS = %w(Exclude Include Severity AutoCorrect StyleGuide)
 
     attr_reader :loaded_path
 

--- a/spec/rubocop/config_spec.rb
+++ b/spec/rubocop/config_spec.rb
@@ -88,12 +88,13 @@ describe RuboCop::Config do
       # configuration, but are nonetheless allowed for any cop.
       before do
         create_file(configuration_path, [
-          'Metrics/LineLength:',
+          'Metrics/ModuleLength:',
           '  Exclude:',
           '    - lib/file.rb',
           '  Include:',
           '    - lib/file.xyz',
-          '  Severity: warning'
+          '  Severity: warning',
+          '  StyleGuide: https://example.com/some-style.html'
         ])
       end
 


### PR DESCRIPTION
StyleGuide parameters are currently only allowed for cops which already
have one in the default configuration. There is a validation warning when
a StyleGuide parameter is found in the local configuration.

It can be useful to add a link to a specific style guide providing some
rationale for the configuration, so this patch allows to always add a
StyleGuide parameter.