### PR TITLE
[Fix #2285] Fix ConfigurableNaming error with singleton methods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@
 * [#2292](https://github.com/bbatsov/rubocop/pull/2292): Results should not be stored in the cache if affected by errors (crashes). ([@jonas054][])
 * [#2280](https://github.com/bbatsov/rubocop/issues/2280): Avoid reporting space between hash literal keys and values in `Style/ExtraSpacing`. ([@jonas054][])
 * [#2284](https://github.com/bbatsov/rubocop/issues/2284): Fix result cache being shared between ruby versions. ([@miquella][])
+* [#2285](https://github.com/bbatsov/rubocop/issues/2285): Fix `ConfigurableNaming#class_emitter_method?` error when handling singleton class methods. ([@palkan][])
 
 ## 0.34.2 (21/09/2015)
 

--- a/lib/rubocop/cop/mixin/configurable_naming.rb
+++ b/lib/rubocop/cop/mixin/configurable_naming.rb
@@ -33,7 +33,7 @@ module RuboCop
         return false unless node.defs_type?
         return false unless node.parent
 
-        node.parent.children.any? do |c|
+        node.parent.children.compact.any? do |c|
           c.class_type? && c.loc.name.is?(name.to_s)
         end
       end

--- a/spec/rubocop/cop/style/method_name_spec.rb
+++ b/spec/rubocop/cop/style/method_name_spec.rb
@@ -95,6 +95,14 @@ describe RuboCop::Cop::Style::MethodName, :config do
       expect(cop.offenses).to be_empty
     end
 
+    it 'registers an offense for singleton camelCase method within class' do
+      inspect_source(cop, ['class Sequel',
+                           '  def self.fooBar',
+                           '  end',
+                           'end'])
+      expect(cop.highlights).to eq(['fooBar'])
+    end
+
     include_examples 'never accepted'
     include_examples 'always accepted'
   end
@@ -132,6 +140,14 @@ describe RuboCop::Cop::Style::MethodName, :config do
                            'end'])
       expect(cop.highlights).to eq(['my_method'])
       expect(cop.config_to_allow_offenses).to eq('Enabled' => false)
+    end
+
+    it 'registers an offense for singleton snake_case method within class' do
+      inspect_source(cop, ['class Sequel',
+                           '  def self.foo_bar',
+                           '  end',
+                           'end'])
+      expect(cop.highlights).to eq(['foo_bar'])
     end
 
     include_examples 'always accepted'


### PR DESCRIPTION
According to [ast format](https://github.com/whitequark/parser/blob/master/doc/AST_FORMAT.md#class) there can be a `nil` among class node children. This hasn't been taken into consideration.