### PR TITLE
Always allow a StyleGuide parameter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 * [#2276](https://github.com/bbatsov/rubocop/pull/2276): New cop `Performance/FixedSize` will register an offense when calling `length`, `size`, or `count` on statically sized objected (strings, symbols, arrays, and hashes). ([@rrosenblum][])
 * New cop `Style/NestedModifier` checks for nested `if`, `unless`, `while` and `until` modifier statements. ([@lumeet][])
 * [#2270](https://github.com/bbatsov/rubocop/pull/2270): Add a new `inherit_gem` configuration to inherit a config file from an installed gem [(originally requested in #290)](https://github.com/bbatsov/rubocop/issues/290). ([@jhansche][])
+* Allow `StyleGuide` parameters in local configuration for all cops, so users can add references to custom style guide documents. ([@cornelius][])
 
 ### Bug Fixes
 
@@ -1648,3 +1649,4 @@
 [@hmadison]: https://github.com/hmadison
 [@miquella]: https://github.com/miquella
 [@jhansche]: https://github.com/jhansche
+[@cornelius]: https://github.com/cornelius

--- a/lib/rubocop/config.rb
+++ b/lib/rubocop/config.rb
@@ -14,7 +14,7 @@ module RuboCop
 
     class ValidationError < StandardError; end
 
-    COMMON_PARAMS = %w(Exclude Include Severity AutoCorrect)
+    COMMON_PARAMS = %w(Exclude Include Severity AutoCorrect StyleGuide)
 
     attr_reader :loaded_path
 

--- a/spec/rubocop/config_spec.rb
+++ b/spec/rubocop/config_spec.rb
@@ -88,12 +88,13 @@ describe RuboCop::Config do
       # configuration, but are nonetheless allowed for any cop.
       before do
         create_file(configuration_path, [
-          'Metrics/LineLength:',
+          'Metrics/ModuleLength:',
           '  Exclude:',
           '    - lib/file.rb',
           '  Include:',
           '    - lib/file.xyz',
-          '  Severity: warning'
+          '  Severity: warning',
+          '  StyleGuide: https://example.com/some-style.html'
         ])
       end
 


### PR DESCRIPTION
StyleGuide parameters are currently only allowed for cops which already
have one in the default configuration. There is a validation warning when
a StyleGuide parameter is found in the local configuration.

It can be useful to add a link to a specific style guide providing some
rationale for the configuration, so this patch allows to always add a
StyleGuide parameter.

This pull request supersedes #2305 