### PR TITLE
Ignore UnusedBlockArgument for keyword arguments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Bug fixes
 
 * [#2983](https://github.com/bbatsov/rubocop/pull/2983): `Style/AlignParameters` message was clarified for `with_fixed_indentation` style. ([@dylanahsmith][])
+* [#2314](https://github.com/bbatsov/rubocop/pull/2314): Ignore `UnusedBlockArgument` for keyword arguments. ([@volkert][])
 
 ## 0.39.0 (27/03/2016)
 

--- a/config/default.yml
+++ b/config/default.yml
@@ -1051,6 +1051,10 @@ Lint/UnusedMethodArgument:
   AllowUnusedKeywordArguments: false
   IgnoreEmptyMethods: true
 
+# Checks for unused block arguments.
+Lint/UnusedBlockArgument:
+  AllowUnusedKeywordArguments: false
+
 ##################### Performance ############################
 
 Performance/RedundantMerge:

--- a/lib/rubocop/cop/lint/unused_block_argument.rb
+++ b/lib/rubocop/cop/lint/unused_block_argument.rb
@@ -16,6 +16,8 @@ module RuboCop
 
         def check_argument(variable)
           return unless variable.block_argument?
+          return if variable.keyword_argument? &&
+                    cop_config && cop_config['AllowUnusedKeywordArguments']
 
           if cop_config['IgnoreEmptyBlocks']
             _send, _args, body = *variable.scope.node

--- a/spec/rubocop/cli_spec.rb
+++ b/spec/rubocop/cli_spec.rb
@@ -147,6 +147,8 @@ describe RuboCop::CLI, :isolated_environment do
                                    '    super(arg1, arg2) { |response| }',
                                    '  end',
                                    'end'])
+        create_file('.rubocop.yml', ['Lint/UnusedBlockArgument:',
+                                     '  IgnoreEmptyBlocks: true'])
         expect(cli.run(['--format', 'simple', 'example.rb'])).to eq(0)
         expect($stdout.string)
           .to eq(['',

--- a/spec/rubocop/cop/cop_spec.rb
+++ b/spec/rubocop/cop/cop_spec.rb
@@ -95,7 +95,7 @@ describe RuboCop::Cop::Cop do
       context 'when offense was corrected' do
         before do
           allow(@cop).to receive(:autocorrect?).and_return(true)
-          allow(@cop).to receive(:autocorrect).and_return(->(corrector) {})
+          allow(@cop).to receive(:autocorrect).and_return(->(_corrector) {})
         end
 
         it 'is set to true' do


### PR DESCRIPTION
This PR is related to #2304 with a fix for unused block arguments.

Rubocop currently suggests to prepend an underscore to unused keyword arguments for blocks. This would break the keyword argument and theres no other way around it but ignoring the fact that there are unused keyword arguments.