### PR TITLE
Debugger cop checks for Pry.rescue

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 * [#2270](https://github.com/bbatsov/rubocop/pull/2270): Add a new `inherit_gem` configuration to inherit a config file from an installed gem [(originally requested in #290)](https://github.com/bbatsov/rubocop/issues/290). ([@jhansche][])
 * Allow `StyleGuide` parameters in local configuration for all cops, so users can add references to custom style guide documents. ([@cornelius][])
 * `UnusedMethodArgument` cop allows configuration to skip keyword arguments. ([@apiology][])
+* [#2318](https://github.com/bbatsov/rubocop/pull/2318): `Lint/Debugger` cop now checks for `Pry.rescue`. ([@rrosenblum][])
 
 ### Bug Fixes
 

--- a/lib/rubocop/cop/lint/debugger.rb
+++ b/lib/rubocop/cop/lint/debugger.rb
@@ -35,6 +35,12 @@ module RuboCop
         #   (send nil :binding) :pry_remote)
         PRY_REMOTE_NODE = s(:send, s(:send, nil, :binding), :pry_remote)
 
+        # Pry.rescue
+        #
+        # (send
+        #   (const nil :Pry) :rescue)
+        PRY_RESCUE = s(:send, s('const', nil, :Pry), :rescue)
+
         # save_and_open_page
         #
         # (send nil :save_and_open_page)
@@ -56,6 +62,7 @@ module RuboCop
           PRY_NODE,
           REMOTE_PRY_NODE,
           PRY_REMOTE_NODE,
+          PRY_RESCUE,
           CAPYBARA_SAVE_PAGE,
           CAPYBARA_SAVE_OPEN_SCREENSHOT,
           CAPYBARA_SAVE_SCREENSHOT

--- a/spec/rubocop/cop/lint/debugger_spec.rb
+++ b/spec/rubocop/cop/lint/debugger_spec.rb
@@ -8,7 +8,7 @@ describe RuboCop::Cop::Lint::Debugger do
   include_examples 'debugger', 'debugger', 'debugger'
   include_examples 'debugger', 'byebug', 'byebug'
   include_examples 'debugger', 'pry binding', %w(binding.pry binding.remote_pry
-                                                 binding.pry_remote)
+                                                 binding.pry_remote Pry.rescue)
   include_examples 'debugger',
                    'capybara debug method', %w(save_and_open_page
                                                save_and_open_screenshot


### PR DESCRIPTION
I have been using `pry-rescue` and realized that we do not check for it in `Lint/Debugger` https://github.com/ConradIrwin/pry-rescue.