### PR TITLE
Include minimum version number in readme install instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,7 +104,7 @@ $ gem install rubocop
 If you'd rather install RuboCop using `bundler`, don't require it in your `Gemfile`:
 
 ```
-gem 'rubocop', require: false
+gem 'rubocop', '~> 0.34', require: false
 ```
 
 ## Basic Usage


### PR DESCRIPTION
Using bundler to install Rubocop without specifying a version number resulted in installing 0.26.1, despite the most recent version having no conflicts with any other gems.