### PR TITLE
[Fix #2324] Handle --only Lint/Syntax and --except Lint/Syntax

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@
 * [#2295](https://github.com/bbatsov/rubocop/issues/2295): Fix Performance/Detect autocorrect to handle rogue newlines. ([@palkan][])
 * [#2294](https://github.com/bbatsov/rubocop/issues/2294): Do not register an offense in `Performance/StringReplacement` for regex with options. ([@rrosenblum][])
 * Fix `Style/UnneededPercentQ` condition for single-quoted literal containing interpolation-like string. ([@eagletmt][])
+* [#2324](https://github.com/bbatsov/rubocop/issues/2324): Handle `--only Lint/Syntax` and `--except Lint/Syntax` correctly. ([@jonas054][])
 
 ## 0.34.2 (21/09/2015)
 

--- a/lib/rubocop/runner.rb
+++ b/lib/rubocop/runner.rb
@@ -185,7 +185,9 @@ module RuboCop
       @mobilized_cop_classes[config.object_id] ||= begin
         cop_classes = Cop::Cop.all
 
-        [:only, :except].each { |opt| Options.validate_cop_list(@options[opt]) }
+        [:only, :except].each do |opt|
+          OptionsValidator.validate_cop_list(@options[opt])
+        end
 
         if @options[:only]
           cop_classes.select! { |c| c.match?(@options[:only]) }

--- a/spec/rubocop/cli_spec.rb
+++ b/spec/rubocop/cli_spec.rb
@@ -1304,6 +1304,20 @@ describe RuboCop::CLI, :isolated_environment do
             .to include('Unrecognized cop or namespace: Style/123.')
         end
 
+        it 'exits with error if an empty string is given' do
+          create_file('example.rb', 'x')
+          expect(cli.run(['--only', ''])).to eq(1)
+          expect($stderr.string).to include('Unrecognized cop or namespace: .')
+        end
+
+        %w(Syntax Lint/Syntax).each do |name|
+          it "only checks syntax if #{name} is given" do
+            create_file('example.rb', 'x ')
+            expect(cli.run(['--only', name])).to eq(0)
+            expect($stdout.string).to include('no offenses detected')
+          end
+        end
+
         %w(Lint/UnneededDisable UnneededDisable).each do |name|
           it "exits with error if cop name #{name} is passed" do
             create_file('example.rb', ['if x== 0 ',
@@ -1490,6 +1504,21 @@ describe RuboCop::CLI, :isolated_environment do
           expect(cli.run(['--except', 'Style/123'])).to eq(1)
           expect($stderr.string)
             .to include('Unrecognized cop or namespace: Style/123.')
+        end
+
+        it 'exits with error if an empty string is given' do
+          create_file('example.rb', 'x')
+          expect(cli.run(['--except', ''])).to eq(1)
+          expect($stderr.string).to include('Unrecognized cop or namespace: .')
+        end
+
+        %w(Syntax Lint/Syntax).each do |name|
+          it "exits with error if #{name} is given" do
+            create_file('example.rb', 'x ')
+            expect(cli.run(['--except', name])).to eq(1)
+            expect($stderr.string)
+              .to include('Syntax checking can not be turned off.')
+          end
         end
       end
 


### PR DESCRIPTION
The `Syntax` cop is a special cop that's run before all others and it isn't included in `Cop::Cop.all`. Add special handling for command line options that can have `Lint/Syntax` or `Syntax` as an argument. Running `--only Lint/Syntax` is a valid use case, but `--except Lint/Syntax` is not allowed.