### PR TITLE
Support ruby3

### DIFF
--- a/lib/rubocop/cop/lint/unused_block_argument.rb
+++ b/lib/rubocop/cop/lint/unused_block_argument.rb
@@ -1,4 +1,5 @@
 # encoding: utf-8
+# frozen_string_literal: true
 
 module RuboCop
   module Cop

--- a/lib/rubocop/cop/lint/unused_block_argument.rb
+++ b/lib/rubocop/cop/lint/unused_block_argument.rb
@@ -26,7 +26,8 @@ module RuboCop
         end
 
         def message(variable)
-          message = "Unused #{variable_type(variable)} - `#{variable.name}`."
+          message =
+            "Unused #{variable_type(variable)} - `#{variable.name}`.".dup
 
           return message if variable.explicit_block_local_variable?
 
@@ -65,7 +66,7 @@ module RuboCop
         end
 
         def message_for_lambda(variable, all_arguments)
-          message = message_for_underscore_prefix(variable)
+          message = message_for_underscore_prefix(variable).dup
 
           if all_arguments.none?(&:referenced?)
             message << ' Also consider using a proc without arguments ' \

--- a/lib/rubocop/cop/lint/useless_assignment.rb
+++ b/lib/rubocop/cop/lint/useless_assignment.rb
@@ -1,4 +1,5 @@
 # encoding: utf-8
+# frozen_string_literal: true
 
 module RuboCop
   module Cop

--- a/lib/rubocop/cop/lint/useless_assignment.rb
+++ b/lib/rubocop/cop/lint/useless_assignment.rb
@@ -47,7 +47,7 @@ module RuboCop
         def message_for_useless_assignment(assignment)
           variable = assignment.variable
 
-          message = format(MSG, variable.name)
+          message = format(MSG, variable.name).dup
 
           if assignment.multiple_assignment?
             message << " Use `_` or `_#{variable.name}` as a variable name " \

--- a/lib/rubocop/cop/style/if_unless_modifier.rb
+++ b/lib/rubocop/cop/style/if_unless_modifier.rb
@@ -1,4 +1,5 @@
 # encoding: utf-8
+# frozen_string_literal: true
 
 module RuboCop
   module Cop

--- a/lib/rubocop/cop/style/if_unless_modifier.rb
+++ b/lib/rubocop/cop/style/if_unless_modifier.rb
@@ -63,7 +63,7 @@ module RuboCop
             c.loc.line == node.loc.line
           end
           if first_line_comment
-            oneline << ' ' << first_line_comment.loc.expression.source
+            oneline << ' ' + first_line_comment.loc.expression.source
           end
           oneline = "(#{oneline})" if parenthesize?(node)
 

--- a/lib/rubocop/cop/style/parallel_assignment.rb
+++ b/lib/rubocop/cop/style/parallel_assignment.rb
@@ -1,4 +1,5 @@
 # encoding: utf-8
+# frozen_string_literal: true
 
 require 'tsort'
 

--- a/lib/rubocop/cop/style/parallel_assignment.rb
+++ b/lib/rubocop/cop/style/parallel_assignment.rb
@@ -197,10 +197,10 @@ module RuboCop
             _node, rescue_clause = *node.parent
             _, _, rescue_result = *rescue_clause
 
-            "begin\n" <<
-              indentation(node) << assignment.join("\n#{indentation(node)}") <<
-              "\n#{offset(node)}rescue\n" <<
-              indentation(node) << rescue_result.source <<
+            "begin\n" + indentation(node) +
+              assignment.join("\n#{indentation(node)}") +
+              "\n#{offset(node)}rescue\n" +
+              indentation(node) + rescue_result.source +
               "\n#{offset(node)}end"
           end
 
@@ -220,8 +220,9 @@ module RuboCop
                                         parent.loc.keyword.begin_pos,
                                         parent.loc.expression.end_pos)
 
-            "#{modifier_range.source}\n" <<
-              indentation(node) << assignment.join("\n#{indentation(node)}") <<
+            "#{modifier_range.source}\n" +
+              indentation(node) +
+              assignment.join("\n#{indentation(node)}") +
               "\n#{offset(node)}end"
           end
 

--- a/lib/rubocop/cop/style/predicate_name.rb
+++ b/lib/rubocop/cop/style/predicate_name.rb
@@ -1,4 +1,5 @@
 # encoding: utf-8
+# frozen_string_literal: true
 
 module RuboCop
   module Cop

--- a/lib/rubocop/cop/style/predicate_name.rb
+++ b/lib/rubocop/cop/style/predicate_name.rb
@@ -40,8 +40,8 @@ module RuboCop
           new_name = if prefix_blacklist.include?(prefix)
                        method_name.sub(prefix, '')
                      else
-                       method_name.dup
-                     end
+                       method_name
+                     end.dup
           new_name << '?' unless method_name.end_with?('?')
           new_name
         end

--- a/lib/rubocop/cop/style/rescue_modifier.rb
+++ b/lib/rubocop/cop/style/rescue_modifier.rb
@@ -1,4 +1,5 @@
 # encoding: utf-8
+# frozen_string_literal: true
 
 module RuboCop
   module Cop

--- a/lib/rubocop/cop/style/rescue_modifier.rb
+++ b/lib/rubocop/cop/style/rescue_modifier.rb
@@ -25,10 +25,10 @@ module RuboCop
           *_, rescue_args = *rescue_modifier
 
           correction =
-            "begin\n" <<
-            indentation(node) << operation.source <<
-            "\n#{offset(node)}rescue\n" <<
-            indentation(node) << rescue_args.source <<
+            "begin\n" +
+            indentation(node) + operation.source +
+            "\n#{offset(node)}rescue\n" +
+            indentation(node) + rescue_args.source +
             "\n#{offset(node)}end"
           range = Parser::Source::Range.new(node.loc.expression.source_buffer,
                                             node.loc.expression.begin_pos,

--- a/lib/rubocop/formatter/disabled_lines_formatter.rb
+++ b/lib/rubocop/formatter/disabled_lines_formatter.rb
@@ -27,7 +27,7 @@ module RuboCop
       private
 
       def cops_disabled_in_comments_summary
-        summary = "\nCops disabled line ranges:\n\n"
+        summary = "\nCops disabled line ranges:\n\n".dup
 
         @cop_disabled_line_ranges.each do |file, disabled_cops|
           disabled_cops.each do |cop, line_ranges|

--- a/lib/rubocop/formatter/disabled_lines_formatter.rb
+++ b/lib/rubocop/formatter/disabled_lines_formatter.rb
@@ -1,4 +1,6 @@
 # encoding: utf-8
+# frozen_string_literal: true
+
 module RuboCop
   module Formatter
     # A basic formatter that displays the lines disabled

--- a/lib/rubocop/formatter/emacs_style_formatter.rb
+++ b/lib/rubocop/formatter/emacs_style_formatter.rb
@@ -1,4 +1,5 @@
 # encoding: utf-8
+# frozen_string_literal: true
 
 module RuboCop
   module Formatter

--- a/lib/rubocop/formatter/emacs_style_formatter.rb
+++ b/lib/rubocop/formatter/emacs_style_formatter.rb
@@ -8,7 +8,7 @@ module RuboCop
     class EmacsStyleFormatter < BaseFormatter
       def file_finished(file, offenses)
         offenses.each do |o|
-          message = o.corrected? ? '[Corrected] ' : ''
+          message = (o.corrected? ? '[Corrected] ' : '').dup
           message << o.message
 
           output.printf("%s:%d:%d: %s: %s\n",

--- a/lib/rubocop/formatter/simple_text_formatter.rb
+++ b/lib/rubocop/formatter/simple_text_formatter.rb
@@ -1,4 +1,5 @@
 # encoding: utf-8
+# frozen_string_literal: true
 
 require 'rubocop/formatter/colorizable'
 require 'rubocop/formatter/text_util'

--- a/lib/rubocop/formatter/simple_text_formatter.rb
+++ b/lib/rubocop/formatter/simple_text_formatter.rb
@@ -47,16 +47,17 @@ module RuboCop
       end
 
       def report_summary(file_count, offense_count, correction_count)
-        summary = pluralize(file_count, 'file')
+        summary = pluralize(file_count, 'file').dup
         summary << ' inspected, '
 
-        offenses_text = pluralize(offense_count, 'offense', no_for_zero: true)
+        offenses_text =
+          pluralize(offense_count, 'offense', no_for_zero: true).dup
         offenses_text << ' detected'
         summary << colorize(offenses_text, offense_count.zero? ? :green : :red)
 
         if correction_count > 0
           summary << ', '
-          correction_text = pluralize(correction_count, 'offense')
+          correction_text = pluralize(correction_count, 'offense').dup
           correction_text << ' corrected'
           color = correction_count == offense_count ? :green : :cyan
           summary << colorize(correction_text, color)
@@ -94,7 +95,8 @@ module RuboCop
       end
 
       def message(offense)
-        message = offense.corrected? ? green('[Corrected] ') : ''
+        message =
+          (offense.corrected? ? green('[Corrected] ') : '').dup
         message << annotate_message(offense.message)
       end
     end

--- a/lib/rubocop/formatter/text_util.rb
+++ b/lib/rubocop/formatter/text_util.rb
@@ -1,4 +1,5 @@
 # encoding: utf-8
+# frozen_string_literal: true
 
 module RuboCop
   module Formatter

--- a/lib/rubocop/formatter/text_util.rb
+++ b/lib/rubocop/formatter/text_util.rb
@@ -11,7 +11,7 @@ module RuboCop
                  'no'
                else
                  number.to_s
-               end
+               end.dup
 
         text << " #{thing}"
         text << 's' unless number == 1


### PR DESCRIPTION
# WHAT
Supported ruby3.
Ruby3 String will not be able to use the `<<` without `.dup`.

# REF
- https://bugs.ruby-lang.org/issues/11473 (English)
- http://d.hatena.ne.jp/ku-ma-me/20151004/p1 (Japanese)