### PR TITLE
[Fix #2317] Fix case-end alignment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,7 @@
 * [#2294](https://github.com/bbatsov/rubocop/issues/2294): Do not register an offense in `Performance/StringReplacement` for regex with options. ([@rrosenblum][])
 * Fix `Style/UnneededPercentQ` condition for single-quoted literal containing interpolation-like string. ([@eagletmt][])
 * [#2324](https://github.com/bbatsov/rubocop/issues/2324): Handle `--only Lint/Syntax` and `--except Lint/Syntax` correctly. ([@jonas054][])
+* [#2317](https://github.com/bbatsov/rubocop/issues/2317): Handle `case` as an argument correctly in `Lint/EndAlignment`. ([@lumeet][])
 
 ## 0.34.2 (21/09/2015)
 

--- a/spec/rubocop/cop/lint/end_alignment_spec.rb
+++ b/spec/rubocop/cop/lint/end_alignment_spec.rb
@@ -88,6 +88,26 @@ describe RuboCop::Cop::Lint::EndAlignment, :config do
     end
   end
 
+  context 'case as argument' do
+    context 'when AlignWith is keyword' do
+      let(:cop_config) do
+        { 'AlignWith' => 'keyword', 'AutoCorrect' => true }
+      end
+
+      include_examples 'aligned', 'test case', 'a when b', '     end'
+      include_examples 'misaligned', 'test ', 'case', 'a when b', 'end'
+    end
+
+    context 'when AlignWith is variable' do
+      let(:cop_config) do
+        { 'AlignWith' => 'variable', 'AutoCorrect' => true }
+      end
+
+      include_examples 'aligned', 'test case', 'a when b', 'end'
+      include_examples 'misaligned', '', 'test case', 'a when b', '     end'
+    end
+  end
+
   context 'regarding assignment' do
     context 'when AlignWith is keyword' do
       include_examples 'misaligned', 'var = ', 'if',     'test',     'end'


### PR DESCRIPTION
Handle cases in `Lint/EndAlignment` when `case` is used as an
argument.