### PR TITLE
[Fix #2287] Fix alignment of whitespace lines

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,7 @@
 * Fix `Style/UnneededPercentQ` condition for single-quoted literal containing interpolation-like string. ([@eagletmt][])
 * [#2324](https://github.com/bbatsov/rubocop/issues/2324): Handle `--only Lint/Syntax` and `--except Lint/Syntax` correctly. ([@jonas054][])
 * [#2317](https://github.com/bbatsov/rubocop/issues/2317): Handle `case` as an argument correctly in `Lint/EndAlignment`. ([@lumeet][])
+* [#2287](https://github.com/bbatsov/rubocop/issues/2287): Fix auto-correct of lines with only whitespace in `Style/IndentationWidth`. ([@lumeet][])
 
 ## 0.34.2 (21/09/2015)
 

--- a/lib/rubocop/cop/mixin/autocorrect_alignment.rb
+++ b/lib/rubocop/cop/mixin/autocorrect_alignment.rb
@@ -82,7 +82,7 @@ module RuboCop
             corrector.insert_before(range, ' ' * column_delta)
           end
         else
-          remove(range, corrector) if range.source =~ /^[ \t]+$/
+          remove(range, corrector) if range.source =~ /\A[ \t]+\z/
         end
       end
 

--- a/spec/rubocop/cop/style/indentation_width_spec.rb
+++ b/spec/rubocop/cop/style/indentation_width_spec.rb
@@ -263,6 +263,20 @@ describe RuboCop::Cop::Style::IndentationWidth do
           corrected = autocorrect_source(cop, src)
           expect(corrected).to eq src.join("\n")
         end
+
+        it 'handles lines with only whitespace' do
+          corrected = autocorrect_source(cop, ['def x',
+                                               '    y',
+                                               ' ',
+                                               'rescue',
+                                               'end'])
+
+          expect(corrected).to eq ['def x',
+                                   '  y',
+                                   ' ',
+                                   'rescue',
+                                   'end'].join("\n")
+        end
       end
 
       it 'accepts a one line if statement' do


### PR DESCRIPTION
The `AutocorrectAlignment` mixin no longer tries to remove whitespace
containing a newline.