### PR TITLE
Bug: parallel assignment with a side effect.

### DIFF
--- a/spec/rubocop/cop/style/parallel_assignment_spec.rb
+++ b/spec/rubocop/cop/style/parallel_assignment_spec.rb
@@ -309,6 +309,16 @@ describe RuboCop::Cop::Style::ParallelAssignment, :config do
                                   '  end',
                                   'end'].join("\n"))
       end
+
+      it 'when the expression order matters' do
+        new_source = autocorrect_source(cop, [
+          'type, value_type = type.class, type.first'])
+
+        expect(new_source).to eq([
+          'value_type = type.first',
+          'type = type.class'
+        ].join("\n"))
+      end
     end
 
     describe 'does not correct' do


### PR DESCRIPTION
Let me demonstrate:

```ruby
type = [Hash]
type, value_type = type.class, type.first
=> [Array, Hash] 
```

after auto-correct

```ruby
type = [Hash]
type = type.class
value_type = type.first
=> Undefined method `first` for Array:Class
```

I think a generic fix just changes the order of assignment to do right-to-left, but that will seem odd most of the time.