### PR TITLE
Bug: HashSyntax doesn't register offense with mixed keys.

### DIFF
--- a/spec/rubocop/cop/style/hash_syntax_spec.rb
+++ b/spec/rubocop/cop/style/hash_syntax_spec.rb
@@ -91,6 +91,16 @@ describe RuboCop::Cop::Style::HashSyntax, :config do
         new_source = autocorrect_source(cop, '{ :a=>1, :b=>2 }')
         expect(new_source).to eq('{ a: 1, b: 2 }')
       end
+
+      it 'registers offense when mixed keys including Integer' do
+        inspect_source(cop, "{ :a => 'hey', 123 => 'bob' }")
+        expect(cop.messages).to eq(['Use the new Ruby 1.9 hash syntax.'])
+      end
+
+      it 'autocorrects with mixed keys including Integer' do
+        new_source = autocorrect_source(cop, "{ :a => 'hey', 123 => 'bob' }")
+        expect(new_source).to eq("{ a: 'hey', 123 => 'bob' }")
+      end
     end
 
     context 'with SpaceAroundOperators disabled' do


### PR DESCRIPTION
We ran into this autocorrecting in Hashie, see https://github.com/intridea/hashie/commit/9298241eb2d500fa573b1c2aa22ecd91c877d812.

I think I am missing some cases from that commit/auto-correct that have to do with Integer and symbol keys. After this example is fixed I would run autocorrect on Hashie's HEAD and see if that produces working code. 