### PR TITLE
Lint for ordinal circular argument references

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@
 * [#2329](https://github.com/bbatsov/rubocop/pull/2329): New style `braces_for_chaining` for `Style/BlockDelimiters` cop enforces braces on a multi-line block if its return value is being chained with another method. ([@panthomakos][])
 * `Lint/LiteralInCondition` warns if a symbol or dynamic symbol is used as a condition. ([@alexdowad][])
 * [#2369](https://github.com/bbatsov/rubocop/issues/2369): `Style/TrailingComma` doesn't add a trailing comma to a multiline method chain which is the only arg to a method call. ([@alexdowad][])
+* `CircularArgumentReference` cop updated to lint for ordinal circular argument references on top of optional keyword arguments. ([@maxjacobson][])
 
 ### Bug Fixes
 

--- a/config/enabled.yml
+++ b/config/enabled.yml
@@ -880,7 +880,7 @@ Lint/BlockAlignment:
   Enabled: true
 
 Lint/CircularArgumentReference:
-  Description: "Don't refer to the keyword argument in the default value."
+  Description: "Default values in optional keyword arguments and optional ordinal arguments should not refer back to the name of the argument."
   Enabled: true
 
 Lint/ConditionPosition:

--- a/lib/rubocop/cop/lint/circular_argument_reference.rb
+++ b/lib/rubocop/cop/lint/circular_argument_reference.rb
@@ -3,19 +3,50 @@
 module RuboCop
   module Cop
     module Lint
-      # This cop checks for circular argument references in keyword arguments.
+      # This cop checks for circular argument references in optional keyword
+      # arguments and optional ordinal arguments.
       #
       # This cop mirrors a warning produced by MRI since 2.2.
       #
       # @example
+      #   # bad
       #   def bake(pie: pie)
       #     pie.heat_up
+      #   end
+      #
+      #   # good
+      #   def bake(pie:)
+      #     pie.refrigerate
+      #   end
+      #
+      #   # good
+      #   def bake(pie: self.pie)
+      #     pie.feed_to(user)
+      #   end
+      #
+      #   # bad
+      #   def cook(dry_ingredients = dry_ingredients)
+      #     dry_ingredients.reduce(&:+)
+      #   end
+      #
+      #   # good
+      #   def cook(dry_ingredients = self.dry_ingredients)
+      #     dry_ingredients.combine
       #   end
       class CircularArgumentReference < Cop
         MSG = 'Circular argument reference - `%s`.'
 
         def on_kwoptarg(node)
-          arg_name, arg_value = *node
+          check_for_circular_argument_references(*node)
+        end
+
+        def on_optarg(node)
+          check_for_circular_argument_references(*node)
+        end
+
+        private
+
+        def check_for_circular_argument_references(arg_name, arg_value)
           case arg_value.type
           when :send
             # Ruby 2.0 will have type send every time, and "send nil" if it is

--- a/spec/rubocop/cop/lint/circular_argument_reference_spec.rb
+++ b/spec/rubocop/cop/lint/circular_argument_reference_spec.rb
@@ -4,32 +4,34 @@ require 'spec_helper'
 
 describe RuboCop::Cop::Lint::CircularArgumentReference do
   subject(:cop) { described_class.new }
-  context 'ruby < 2.0, which has no keyword arguments', ruby_less_than: 2.0 do
-    let(:source) do
-      [
-        'def some_method(some_arg: some_method)',
-        '  puts some_arg',
-        'end'
-      ]
-    end
 
-    it 'fails with a syntax error before the cop even comes into play' do
-      expect { inspect_source(cop, source) }.to raise_error(
-        RuntimeError, /Error parsing/)
-      expect(cop.offenses).to be_empty
-    end
-  end
-
-  context 'ruby >= 2.0', ruby_greater_than_or_equal: 2.0 do
+  describe 'circular argument references in ordinal arguments' do
     before(:each) do
       inspect_source(cop, source)
     end
 
-    context 'when the keyword argument is not circular' do
+    context 'when the method contains a circular argument reference' do
       let(:source) do
         [
-          'def some_method(some_arg: nil)',
-          '  puts some_arg',
+          'def omg_wow(msg = msg)',
+          '  puts msg',
+          'end'
+        ]
+      end
+
+      it 'registers an offense' do
+        expect(cop.offenses.size).to eq(1)
+        expect(cop.offenses.first.message)
+          .to eq('Circular argument reference - `msg`.')
+        expect(cop.highlights).to eq ['msg']
+      end
+    end
+
+    context 'when the method does not contain a circular argument reference' do
+      let(:source) do
+        [
+          'def omg_wow(msg)',
+          '  puts msg',
           'end'
         ]
       end
@@ -39,7 +41,23 @@ describe RuboCop::Cop::Lint::CircularArgumentReference do
       end
     end
 
-    context 'when the keyword argument is not circular, and calls a method' do
+    context 'when the seemingly-circular default value is a method call' do
+      let(:source) do
+        [
+          'def omg_wow(msg = self.msg)',
+          '  puts msg',
+          'end'
+        ]
+      end
+
+      it 'does not register an offense' do
+        expect(cop.offenses).to be_empty
+      end
+    end
+  end
+
+  describe 'circular argument references in keyword arguments' do
+    context 'ruby < 2.0, which has no keyword arguments', ruby_less_than: 2.0 do
       let(:source) do
         [
           'def some_method(some_arg: some_method)',
@@ -47,73 +65,109 @@ describe RuboCop::Cop::Lint::CircularArgumentReference do
           'end'
         ]
       end
-      it 'does not register an offense' do
+
+      it 'fails with a syntax error before the cop even comes into play' do
+        expect { inspect_source(cop, source) }.to raise_error(
+          RuntimeError, /Error parsing/)
         expect(cop.offenses).to be_empty
       end
     end
 
-    context 'when there is one circular argument reference' do
-      let(:source) do
-        [
-          'def some_method(some_arg: some_arg)',
-          '  puts some_arg',
-          'end'
-        ]
-      end
-      it 'registers an offense' do
-        expect(cop.offenses.size).to eq(1)
-        expect(cop.offenses.first.message)
-          .to eq('Circular argument reference - `some_arg`.')
-        expect(cop.highlights).to eq ['some_arg']
-      end
-    end
-
-    context 'when the keyword argument is not circular, but calls a method ' \
-            'of its own class with a self specification' do
-      let(:source) do
-        [
-          'def puts_value(value: self.class.value, smile: self.smile)',
-          '  puts value',
-          'end'
-        ]
+    context 'ruby >= 2.0', ruby_greater_than_or_equal: 2.0 do
+      before(:each) do
+        inspect_source(cop, source)
       end
 
-      it 'does not register an offense' do
-        expect(cop.offenses).to be_empty
-      end
-    end
+      context 'when the keyword argument is not circular' do
+        let(:source) do
+          [
+            'def some_method(some_arg: nil)',
+            '  puts some_arg',
+            'end'
+          ]
+        end
 
-    context 'when the keyword argument is not circular, but calls a method ' \
-            'of some other object with the same name' do
-      let(:source) do
-        [
-          'def puts_length(length: mystring.length)',
-          '  puts length',
-          'end'
-        ]
-      end
-
-      it 'does not register an offense' do
-        expect(cop.offenses).to be_empty
-      end
-    end
-
-    context 'when there are multiple offensive keyword arguments' do
-      let(:source) do
-        [
-          'def some_method(some_arg: some_arg, other_arg: other_arg)',
-          '  puts [some_arg, other_arg]',
-          'end'
-        ]
+        it 'does not register an offense' do
+          expect(cop.offenses).to be_empty
+        end
       end
 
-      it 'registers two offenses' do
-        expect(cop.offenses.size).to eq(2)
-        expect(cop.offenses.first.message)
-          .to eq('Circular argument reference - `some_arg`.')
-        expect(cop.offenses.last.message)
-          .to eq('Circular argument reference - `other_arg`.')
-        expect(cop.highlights).to eq %w(some_arg other_arg)
+      context 'when the keyword argument is not circular, and calls a method' do
+        let(:source) do
+          [
+            'def some_method(some_arg: some_method)',
+            '  puts some_arg',
+            'end'
+          ]
+        end
+        it 'does not register an offense' do
+          expect(cop.offenses).to be_empty
+        end
+      end
+
+      context 'when there is one circular argument reference' do
+        let(:source) do
+          [
+            'def some_method(some_arg: some_arg)',
+            '  puts some_arg',
+            'end'
+          ]
+        end
+        it 'registers an offense' do
+          expect(cop.offenses.size).to eq(1)
+          expect(cop.offenses.first.message)
+            .to eq('Circular argument reference - `some_arg`.')
+          expect(cop.highlights).to eq ['some_arg']
+        end
+      end
+
+      context 'when the keyword argument is not circular, but calls a method ' \
+              'of its own class with a self specification' do
+        let(:source) do
+          [
+            'def puts_value(value: self.class.value, smile: self.smile)',
+            '  puts value',
+            'end'
+          ]
+        end
+
+        it 'does not register an offense' do
+          expect(cop.offenses).to be_empty
+        end
+      end
+
+      context 'when the keyword argument is not circular, but calls a method ' \
+              'of some other object with the same name' do
+        let(:source) do
+          [
+            'def puts_length(length: mystring.length)',
+            '  puts length',
+            'end'
+          ]
+        end
+
+        it 'does not register an offense' do
+          expect(cop.offenses).to be_empty
+        end
+      end
+
+      context 'when there are multiple offensive keyword arguments' do
+        let(:source) do
+          [
+            'def some_method(some_arg: some_arg, other_arg: other_arg)',
+            '  puts [some_arg, other_arg]',
+            'end'
+          ]
+        end
+
+        it 'registers two offenses' do
+          expect(cop.offenses.size).to eq(2)
+          expect(cop.offenses.first.message)
+            .to eq('Circular argument reference - `some_arg`.')
+          expect(cop.offenses.last.message)
+            .to eq('Circular argument reference - `other_arg`.')
+          expect(cop.highlights).to eq %w(some_arg other_arg)
+        end
       end
     end
   end


### PR DESCRIPTION
I noticed that Ruby emits a warning for ordinal circular argument references, not just optional keyword argument references. Should be helpful for RuboCop to lint for these as well.