### PR TITLE
Handle backslash in SpaceAroundOperators

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,7 @@
 * [#2317](https://github.com/bbatsov/rubocop/issues/2317): Handle `case` as an argument correctly in `Lint/EndAlignment`. ([@lumeet][])
 * [#2287](https://github.com/bbatsov/rubocop/issues/2287): Fix auto-correct of lines with only whitespace in `Style/IndentationWidth`. ([@lumeet][])
 * [#2331](https://github.com/bbatsov/rubocop/issues/2331): Do not register an offense in `Performance/Size` for `count` with an argument. ([@rrosenblum][])
+* Handle a backslash at the end of a line in `Style/SpaceAroundOperators`. ([@lumeet][])
 
 ## 0.34.2 (21/09/2015)
 

--- a/lib/rubocop/cop/style/space_around_operators.rb
+++ b/lib/rubocop/cop/style/space_around_operators.rb
@@ -57,6 +57,8 @@ module RuboCop
 
         def check_operator(op)
           with_space = range_with_surrounding_space(op)
+          return if with_space.source.start_with?("\n")
+
           if op.is?('**')
             unless with_space.is?('**')
               add_offense(with_space, op,

--- a/spec/rubocop/cop/style/space_around_operators_spec.rb
+++ b/spec/rubocop/cop/style/space_around_operators_spec.rb
@@ -115,6 +115,12 @@ describe RuboCop::Cop::Style::SpaceAroundOperators, :config do
     expect(cop.offenses).to be_empty
   end
 
+  it 'accepts an operator at the beginning of a line' do
+    inspect_source(cop, ['a = b \\',
+                         '    && c'])
+    expect(cop.offenses).to be_empty
+  end
+
   it 'registers an offenses for exponent operator with spaces' do
     inspect_source(cop, 'x = a * b ** 2')
     expect(cop.messages).to eq(


### PR DESCRIPTION
Do not register an offense if a line ends with a `\` and the following
line begins with an operator.