### PR TITLE
Style/VariableName cop checks naming style of method parameters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@
 * [#2277](https://github.com/bbatsov/rubocop/pull/2277): New cop `Style/FirstMethodParameterLineBreak` checks for a line break before the first parameter in a multi-line method parameter definition. ([@panthomakos][])
 * Add `Rails/PluralizationGrammar` cop, checks for incorrect grammar when using methods like `3.day.ago`, when you should write `3.days.ago`. ([@maxjacobson][])
 * [#2347](https://github.com/bbatsov/rubocop/pull/2347): `Lint/Eval` cop does not warn about "security risk" when eval argument is a string literal without interpolations. ([@alexdowad][])
+* [#2335](https://github.com/bbatsov/rubocop/issues/2335): `Style/VariableName` cop checks naming style of method parameters. ([@alexdowad][])
 
 ### Bug Fixes
 

--- a/lib/rubocop/cop/style/variable_name.rb
+++ b/lib/rubocop/cop/style/variable_name.rb
@@ -23,6 +23,11 @@ module RuboCop
           check_name(node, name, node.loc.name)
         end
 
+        def on_arg(node)
+          name, = *node
+          check_name(node, name, node.loc.name)
+        end
+
         private
 
         def message(style)

--- a/spec/rubocop/cop/style/variable_name_spec.rb
+++ b/spec/rubocop/cop/style/variable_name_spec.rb
@@ -57,6 +57,12 @@ describe RuboCop::Cop::Style::VariableName, :config do
       expect(cop.highlights).to eq(['@@myAttr'])
     end
 
+    it 'registers an offense for camel case in method parameter' do
+      inspect_source(cop, 'def method(funnyArg); end')
+      expect(cop.offenses.size).to eq(1)
+      expect(cop.highlights).to eq(['funnyArg'])
+    end
+
     include_examples 'always accepted'
   end
 
@@ -91,6 +97,12 @@ describe RuboCop::Cop::Style::VariableName, :config do
     it 'accepts camel case in class variable name' do
       inspect_source(cop, '@@myAttr = 2')
       expect(cop.offenses).to be_empty
+    end
+
+    it 'registers an offense for snake case in method parameter' do
+      inspect_source(cop, 'def method(funny_arg); end')
+      expect(cop.offenses.size).to eq(1)
+      expect(cop.highlights).to eq(['funny_arg'])
     end
 
     include_examples 'always accepted'


### PR DESCRIPTION
Fixes #2335.