### PR TITLE
[Fix #2262] Replace Rainbow reference with Colorizable#yellow

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,6 +49,7 @@
 * `Style/InitialIndentation` cop doesn't error out when a line begins with an integer literal. ([@alexdowad][])
 * [#2296](https://github.com/bbatsov/rubocop/issues/2296): In `Style/DotPosition`, don't "correct" (and break) a method call which has a line comment (or blank line) between the dot and the selector. ([@alexdowad][])
 * [#2272](https://github.com/bbatsov/rubocop/issues/2272): `Lint/NonLocalExitFromIterator` does not warn about `return` in a block which is passed to `Module#define_method`. ([@alexdowad][])
+* [#2262](https://github.com/bbatsov/rubocop/issues/2262): Replace `Rainbow` reference with `Colorizable#yellow`. ([@minustehbare][])
 
 ## 0.34.2 (21/09/2015)
 
@@ -1677,3 +1678,4 @@
 [@eagletmt]: https://github.com/eagletmt
 [@apiology]: https://github.com/apiology
 [@alexdowad]: https://github.com/alexdowad
+[@minustehbare]: https://github.com/minustehbare

--- a/lib/rubocop/formatter/simple_text_formatter.rb
+++ b/lib/rubocop/formatter/simple_text_formatter.rb
@@ -90,7 +90,7 @@ module RuboCop
       end
 
       def annotate_message(msg)
-        msg.gsub(/`(.*?)`/, Rainbow('\1').yellow)
+        msg.gsub(/`(.*?)`/, yellow('\1'))
       end
 
       def message(offense)

--- a/spec/rubocop/formatter/simple_text_formatter_spec.rb
+++ b/spec/rubocop/formatter/simple_text_formatter_spec.rb
@@ -5,6 +5,10 @@ require 'spec_helper'
 module RuboCop
   module Formatter
     describe SimpleTextFormatter do
+      before do
+        Rainbow.enabled = true
+      end
+
       subject(:formatter) { described_class.new(output) }
       let(:output) { StringIO.new }
 
@@ -17,7 +21,8 @@ module RuboCop
 
         let(:offense) do
           Cop::Offense.new(:convention, location,
-                           'This is a message.', 'CopName', status)
+                           'This is a message with `colored text`.',
+                           'CopName', status)
         end
 
         let(:location) do
@@ -53,7 +58,7 @@ module RuboCop
 
           it 'prints message as-is' do
             expect(output.string)
-              .to include(': This is a message.')
+              .to include(': This is a message with colored text.')
           end
         end
 
@@ -62,7 +67,7 @@ module RuboCop
 
           it 'prints [Corrected] along with message' do
             expect(output.string)
-              .to include(': [Corrected] This is a message.')
+              .to include(': [Corrected] This is a message with colored text.')
           end
         end
       end
@@ -127,6 +132,10 @@ module RuboCop
                ''].join("\n"))
           end
         end
+      end
+
+      after do
+        Rainbow.enabled = false
       end
     end
   end


### PR DESCRIPTION
As described in #2262, using the `--format simple --out some_file.txt` options caused colors to be output into the text file even though they are not supported.  The cause of this problem was a reference to `Rainbow('\1').yellow` which is enabled by default.

Using the methods mixed in through the `Colorizable` module, I replaced this call with `Colorizable#yellow` which respects the output's support (or lack thereof) for coloring.