### PR TITLE
Take operator precedence into account when autocorrecting in Style/IfUnlessModifier cop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,6 +55,7 @@
 * [#2068](https://github.com/bbatsov/rubocop/issues/2068): Display warning if `Style/Copyright` is misconfigured. ([@alexdowad][])
 * [#2321](https://github.com/bbatsov/rubocop/issues/2321): In `Style/EachWithObject`, don't replace reduce with each_with_object if the accumulator parameter is assigned to in the block. ([@alexdowad][])
 * [#1981](https://github.com/bbatsov/rubocop/issues/1981): `Lint/UselessAssignment` doesn't erroneously identify assignments in identical if branches as useless. ([@alexdowad][])
+* [#2323](https://github.com/bbatsov/rubocop/issues/2323): `Style/IfUnlessModifier` cop parenthesizes autocorrected code when necessary due to operator precedence, to avoid changing its meaning. ([@alexdowad][])
 
 ## 0.34.2 (21/09/2015)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,6 +54,7 @@
 * [#2262](https://github.com/bbatsov/rubocop/issues/2262): Replace `Rainbow` reference with `Colorizable#yellow`. ([@minustehbare][])
 * [#2068](https://github.com/bbatsov/rubocop/issues/2068): Display warning if `Style/Copyright` is misconfigured. ([@alexdowad][])
 * [#2321](https://github.com/bbatsov/rubocop/issues/2321): In `Style/EachWithObject`, don't replace reduce with each_with_object if the accumulator parameter is assigned to in the block. ([@alexdowad][])
+* [#1981](https://github.com/bbatsov/rubocop/issues/1981): `Lint/UselessAssignment` doesn't erroneously identify assignments in identical if branches as useless. ([@alexdowad][])
 
 ## 0.34.2 (21/09/2015)
 

--- a/lib/rubocop/cop/variable_force/locatable.rb
+++ b/lib/rubocop/cop/variable_force/locatable.rb
@@ -133,7 +133,7 @@ module RuboCop
         end
 
         def body_index
-          branch_point_node.children.index(branch_body_node)
+          branch_point_node.children.index { |n| n.equal?(branch_body_node) }
         end
 
         def set_branch_point_and_body_nodes!

--- a/spec/rubocop/cop/lint/useless_assignment_spec.rb
+++ b/spec/rubocop/cop/lint/useless_assignment_spec.rb
@@ -1774,5 +1774,24 @@ describe RuboCop::Cop::Lint::UselessAssignment do
           .to eq('Useless assignment to variable - `enviromnent`.')
       end
     end
+
+    # regression test, from problem in Locatable
+    context 'when a variable is assigned in 2 identical if branches' do
+      let(:source) do
+        ['def foo',
+         '  if bar',
+         '    foo = 1',
+         '  else',
+         '    foo = 1',
+         '  end',
+         '  foo.bar.baz',
+         'end']
+      end
+
+      it "doesn't think 1 of the 2 assignments is useless" do
+        inspect_source(cop, source)
+        expect(cop.offenses).to be_empty
+      end
+    end
   end
 end

--- a/spec/rubocop/cop/style/if_unless_modifier_spec.rb
+++ b/spec/rubocop/cop/style/if_unless_modifier_spec.rb
@@ -249,4 +249,64 @@ describe RuboCop::Cop::Style::IfUnlessModifier do
                          'end.inspect'])
     expect(cop.messages).to be_empty
   end
+
+  it "doesn't break if-end when used as RHS of local var assignment" do
+    corrected = autocorrect_source(cop, ['a = if b',
+                                         '  1',
+                                         'end'])
+    expect(corrected).to eq 'a = (1 if b)'
+  end
+
+  it "doesn't break if-end when used as RHS of instance var assignment" do
+    corrected = autocorrect_source(cop, ['@a = if b',
+                                         '  1',
+                                         'end'])
+    expect(corrected).to eq '@a = (1 if b)'
+  end
+
+  it "doesn't break if-end when used as RHS of class var assignment" do
+    corrected = autocorrect_source(cop, ['@@a = if b',
+                                         '  1',
+                                         'end'])
+    expect(corrected).to eq '@@a = (1 if b)'
+  end
+
+  it "doesn't break if-end when used as RHS of constant assignment" do
+    corrected = autocorrect_source(cop, ['A = if b',
+                                         '  1',
+                                         'end'])
+    expect(corrected).to eq 'A = (1 if b)'
+  end
+
+  it "doesn't break if-end when used as RHS of binary arithmetic" do
+    corrected = autocorrect_source(cop, ['a + if b',
+                                         '  1',
+                                         'end'])
+    expect(corrected).to eq 'a + (1 if b)'
+  end
+
+  it 'accepts if-end when used as LHS of binary arithmetic' do
+    inspect_source(cop, ['if test',
+                         '  1',
+                         'end + 2'])
+    expect(cop.messages).to be_empty
+  end
+
+  context 'if-end is argument to a parenthesized method call' do
+    it "doesn't add redundant parentheses" do
+      corrected = autocorrect_source(cop, ['puts("string", if a',
+                                           '  1',
+                                           'end)'])
+      expect(corrected).to eq 'puts("string", 1 if a)'
+    end
+  end
+
+  context 'if-end is argument to a non-parenthesized method call' do
+    it 'adds parentheses so as not to change meaning' do
+      corrected = autocorrect_source(cop, ['puts "string", if a',
+                                           '  1',
+                                           'end'])
+      expect(corrected).to eq 'puts "string", (1 if a)'
+    end
+  end
 end


### PR DESCRIPTION
...Otherwise, we could change the meaning of the "corrected" code.

Fixes #2323.