### PR TITLE
Don't warn about lack of leading space in =begin/=end comments

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,10 @@ rvm:
   - jruby-19mode
   - jruby-9.0.1.0
   - rbx-2
+env:
+  # this doesn't do anything for MRI or RBX, but it doesn't hurt them either
+  # for JRuby, it enables us to get more accurate coverage data
+  - JRUBY_OPTS="--debug"
 matrix:
   allow_failures:
     - rvm: ruby-head

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,7 @@
 * [#2287](https://github.com/bbatsov/rubocop/issues/2287): Fix auto-correct of lines with only whitespace in `Style/IndentationWidth`. ([@lumeet][])
 * [#2331](https://github.com/bbatsov/rubocop/issues/2331): Do not register an offense in `Performance/Size` for `count` with an argument. ([@rrosenblum][])
 * Handle a backslash at the end of a line in `Style/SpaceAroundOperators`. ([@lumeet][])
+* Don't warn about lack of "leading space" in a =begin/=end comment. ([@alexdowad][])
 
 ## 0.34.2 (21/09/2015)
 

--- a/lib/rubocop/cop/style/leading_comment_space.rb
+++ b/lib/rubocop/cop/style/leading_comment_space.rb
@@ -6,13 +6,14 @@ module RuboCop
       # This cop checks whether comments have a leading space
       # after the # denoting the start of the comment. The
       # leading space is not required for some RDoc special syntax,
-      # like #++, #--, #:nodoc, etc.
+      # like #++, #--, #:nodoc, etc. Neither is it required for
+      # =begin/=end comments.
       class LeadingCommentSpace < Cop
         MSG = 'Missing space after #.'
 
         def investigate(processed_source)
           processed_source.comments.each do |comment|
-            next unless comment.text =~ /^#+[^#\s=:+-]/
+            next unless comment.text =~ /\A#+[^#\s=:+-]/
             next if comment.text.start_with?('#!') && comment.loc.line == 1
 
             add_offense(comment, :expression)

--- a/spec/rubocop/cop/style/leading_comment_space_spec.rb
+++ b/spec/rubocop/cop/style/leading_comment_space_spec.rb
@@ -61,4 +61,11 @@ describe RuboCop::Cop::Style::LeadingCommentSpace do
     new_source = autocorrect_source(cop, '#comment')
     expect(new_source).to eq('# comment')
   end
+
+  it 'accepts =begin/=end comments' do
+    inspect_source(cop, ['=begin',
+                         '#blahblah',
+                         '=end'])
+    expect(cop.offenses).to be_empty
+  end
 end


### PR DESCRIPTION
...Even if one of the lines inside the comment starts with a # without a following
space. Here is an example, from rspec-mocks:

    =begin
    This benchmark script is for troubleshooting the performance of
    #264. To use it, you have to edit the code in #264 a bit: