### PR TITLE
Encoding with shebang

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,7 @@
 * Handle a backslash at the end of a line in `Style/SpaceAroundOperators`. ([@lumeet][])
 * Don't warn about lack of "leading space" in a =begin/=end comment. ([@alexdowad][])
 * [#2307](https://github.com/bbatsov/rubocop/issues/2307): In `Lint/FormatParameterMismatch`, don't register an offense if either argument to % is not a literal. ([@alexdowad][])
+* [#2356](https://github.com/bbatsov/rubocop/pull/2356): `Style/Encoding` will now place the encoding comment on the second line if the first line is a shebang. ([@rrosenblum][])
 
 ## 0.34.2 (21/09/2015)
 

--- a/lib/rubocop/cop/style/encoding.rb
+++ b/lib/rubocop/cop/style/encoding.rb
@@ -34,7 +34,11 @@ module RuboCop
           encoding = cop_config['AutoCorrectEncodingComment']
           if encoding && encoding =~ ENCODING_PATTERN
             lambda do |corrector|
-              corrector.replace(node.pos, "#{encoding}\n#{node.pos.source}")
+              if encoding_line_number(processed_source) == 0
+                corrector.insert_before(node.pos, "#{encoding}\n")
+              else
+                corrector.insert_after(node.pos, "\n#{encoding}")
+              end
             end
           else
             fail "#{encoding} does not match #{ENCODING_PATTERN}"

--- a/lib/rubocop/cop/style/encoding.rb
+++ b/lib/rubocop/cop/style/encoding.rb
@@ -16,7 +16,9 @@ module RuboCop
 
         MSG_MISSING = 'Missing utf-8 encoding comment.'
         MSG_UNNECESSARY = 'Unnecessary utf-8 encoding comment.'
-        ENCODING_PATTERN = /#.*coding\s?[:=]\s?(?:UTF|utf)-8/
+        ENCODING_PATTERN = /#.*coding\s?[:=]\s?(?:UTF|utf)-8/.freeze
+        AUTO_CORRECT_ENCODING_COMMENT = 'AutoCorrectEncodingComment'.freeze
+        SHEBANG = '#!'.freeze
 
         def investigate(processed_source)
           return if processed_source.buffer.source.empty?
@@ -31,7 +33,7 @@ module RuboCop
         end
 
         def autocorrect(node)
-          encoding = cop_config['AutoCorrectEncodingComment']
+          encoding = cop_config[AUTO_CORRECT_ENCODING_COMMENT]
           if encoding && encoding =~ ENCODING_PATTERN
             lambda do |corrector|
               if encoding_line_number(processed_source) == 0
@@ -62,7 +64,7 @@ module RuboCop
 
         def encoding_line_number(processed_source)
           line_number = 0
-          line_number += 1 if processed_source[line_number].start_with?('#!')
+          line_number += 1 if processed_source[line_number].start_with?(SHEBANG)
           line_number
         end
       end

--- a/spec/rubocop/cop/style/encoding_spec.rb
+++ b/spec/rubocop/cop/style/encoding_spec.rb
@@ -148,14 +148,15 @@ describe RuboCop::Cop::Style::Encoding, :config do
 
     context 'auto-correct' do
       context 'valid auto correct encoding comment' do
-        it 'inserts an encoding comment as the first line' do
+        it 'inserts an encoding comment on the first line of files without ' \
+           'a shebang' do
           cop_config['AutoCorrectEncodingComment'] = '# encoding: utf-8'
           new_source = autocorrect_source(cop, 'def foo() end')
 
           expect(new_source).to eq("# encoding: utf-8\ndef foo() end")
         end
 
-        it 'inserts an encoding comment as the first line and leaves ' \
+        it 'inserts an encoding comment on the first line and leaves ' \
            'the wrong encoding line when encoding is in the wrong place' do
           cop_config['AutoCorrectEncodingComment'] = '# encoding: utf-8'
           new_source = autocorrect_source(cop, ['def foo() end',
@@ -164,6 +165,18 @@ describe RuboCop::Cop::Style::Encoding, :config do
           expect(new_source).to eq(['# encoding: utf-8',
                                     'def foo() end',
                                     '# encoding: utf-8'].join("\n"))
+        end
+
+        it 'inserts an encoding comment on the second line when the first ' \
+           'line is a shebang' do
+          new_source = autocorrect_source(cop, ['#!/usr/bin/env ruby',
+                                                'def foo',
+                                                'end'])
+
+          expect(new_source).to eq(['#!/usr/bin/env ruby',
+                                    '# encoding: utf-8',
+                                    'def foo',
+                                    'end'].join("\n"))
         end
       end
 


### PR DESCRIPTION
I noticed that auto-correct would place the encoding comment on the line before the shebang instead of after it.