### PR TITLE
Lint/FormatParameterMismatch ignores % if LHS or RHS is not a literal

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,7 @@
 * [#2331](https://github.com/bbatsov/rubocop/issues/2331): Do not register an offense in `Performance/Size` for `count` with an argument. ([@rrosenblum][])
 * Handle a backslash at the end of a line in `Style/SpaceAroundOperators`. ([@lumeet][])
 * Don't warn about lack of "leading space" in a =begin/=end comment. ([@alexdowad][])
+* [#2307](https://github.com/bbatsov/rubocop/issues/2307): In `Lint/FormatParameterMismatch`, don't register an offense if either argument to % is not a literal. ([@alexdowad][])
 
 ## 0.34.2 (21/09/2015)
 

--- a/spec/rubocop/cop/lint/format_parameter_mismatch_spec.rb
+++ b/spec/rubocop/cop/lint/format_parameter_mismatch_spec.rb
@@ -133,6 +133,30 @@ describe RuboCop::Cop::Lint::FormatParameterMismatch do
     expect(cop.offenses).to be_empty
   end
 
+  context 'when multiple arguments are called for' do
+    context 'and a single variable argument is passed' do
+      it 'does not register an offense' do
+        # the variable could evaluate to an array
+        inspect_source(cop, 'puts "%s %s" % var')
+        expect(cop.offenses).to be_empty
+      end
+    end
+
+    context 'and a single send node is passed' do
+      it 'does not register an offense' do
+        inspect_source(cop, 'puts "%s %s" % ("ab".chars)')
+        expect(cop.offenses).to be_empty
+      end
+    end
+  end
+
+  context 'when format is not a string literal' do
+    it 'does not register an offense' do
+      inspect_source(cop, 'puts str % [1, 2]')
+      expect(cop.offenses).to be_empty
+    end
+  end
+
   it 'ignores percent right next to format string' do
     inspect_source(cop, 'format("%0.1f%% percent", 22.5)')
     expect(cop.offenses).to be_empty


### PR DESCRIPTION
If the LHS is not a literal, it could evaluate to a format string with any
number of arguments, so we can't count an offense for that. On the other hand,
if the RHS is not a literal, it could evaluate to an array with any number
of arguments, so we can't count an offense for that either.

Fixes #2307.