### PR TITLE
Style/Documentation recognizes 'Const = Class.new' as a 'class definition'

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@
 * [#1729](https://github.com/bbatsov/rubocop/issues/1729): `Style/MethodDefParentheses` supports new 'require_no_parentheses_except_multiline' style. ([@alexdowad][])
 * [#2173](https://github.com/bbatsov/rubocop/issues/2173): `Style/AlignParameters` also checks parameter alignment for method definitions. ([@alexdowad][])
 * [#1825](https://github.com/bbatsov/rubocop/issues/1825): New `NameWhitelist` configuration parameter for `Style/PredicateName` can be used to suppress errors on known-good predicate names. ([@alexdowad][])
+* `Style/Documentation` recognizes 'Constant = Class.new' as a class definition. ([@alexdowad][])
 
 ### Bug Fixes
 

--- a/lib/rubocop/cop/style/documentation.rb
+++ b/lib/rubocop/cop/style/documentation.rb
@@ -47,18 +47,21 @@ module RuboCop
           end
         end
 
+        # 'Const = Class.new' or 'Const = Module.new' are module definitions
+        mod_new = '(send (const nil {:Class :Module}) :new ...)'
+        def_node_matcher :module_definition?,
+                         "{class
+                           module
+                           (casgn _ _ {#{mod_new} (block #{mod_new} ...)})}"
+
         def namespace?(body_node)
           return false unless body_node
 
           case body_node.type
           when :begin
-            body_node.children.all? do |node|
-              [:class, :module].include?(node.type)
-            end
-          when :class, :module
-            true
+            body_node.children.all? { |node| module_definition?(node) }
           else
-            false
+            module_definition?(body_node)
           end
         end
 

--- a/spec/rubocop/cop/style/documentation_spec.rb
+++ b/spec/rubocop/cop/style/documentation_spec.rb
@@ -133,6 +133,36 @@ describe RuboCop::Cop::Style::Documentation do
     expect(cop.offenses).to be_empty
   end
 
+  it 'accepts namespace class which uses Constant = Class.new' do
+    inspect_source(cop,
+                   ['class Test',
+                    '  A = Class.new',
+                    '  B = Class.new(A)',
+                    '  C = Class.new { call_method }',
+                    'end'])
+    expect(cop.offenses).to be_empty
+  end
+
+  it 'accepts namespace module which uses Constant = Class.new' do
+    inspect_source(cop,
+                   ['module Test',
+                    '  A = Class.new',
+                    '  B = Class.new(A)',
+                    '  C = Class.new { call_method }',
+                    'end'])
+    expect(cop.offenses).to be_empty
+  end
+
+  it 'accepts namespace module which uses Constant = Module.new' do
+    inspect_source(cop,
+                   ['module Test',
+                    '  A = Module.new',
+                    '  B = Module.new { call_method }',
+                    'end'
+                   ])
+    expect(cop.offenses).to be_empty
+  end
+
   it 'does not raise an error for an implicit match conditional' do
     expect do
       inspect_source(cop,


### PR DESCRIPTION
...and likewise for modules.