### PR TITLE
Add Pattern helper to make pattern-matching on ASTs more concise

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -44,3 +44,48 @@ task :console do
   ARGV.clear
   IRB.start
 end
+
+desc 'Benchmark a cop on given source file/dir'
+task :bench_cop, [:cop, :srcpath, :times] do |_task, args|
+  require 'benchmark'
+  require 'rubocop'
+  include RuboCop
+  include RuboCop::Formatter::TextUtil
+
+  cop_name = args[:cop]
+  src_path = args[:srcpath]
+  iterations = args[:times] ? args[:times].to_i : 1
+
+  cop_class = if cop_name.include?('/')
+                Cop::Cop.all.find { |klass| klass.cop_name == cop_name }
+              else
+                Cop::Cop.all.find do |klass|
+                  klass.cop_name[/[a-zA-Z]+$/] == cop_name
+                end
+              end
+  fail "No such cop: #{cop_name}" if cop_class.nil?
+
+  config = ConfigLoader.load_file(ConfigLoader::DEFAULT_FILE)
+  cop = cop_class.new(config)
+
+  puts "Benchmarking #{cop.cop_name} on #{src_path} (using default config)"
+
+  files = if File.directory?(src_path)
+            Dir[File.join(src_path, '**', '*.rb')]
+          else
+            [src_path]
+          end
+
+  puts "(#{pluralize(iterations, 'iteration')}, " \
+    "#{pluralize(files.size, 'file')})"
+
+  srcs = files.map { |file| ProcessedSource.from_file(file) }
+
+  puts 'Finished parsing source, testing inspection...'
+  puts(Benchmark.measure do
+    iterations.times do
+      commissioner = Cop::Commissioner.new([cop], [])
+      srcs.each { |src| commissioner.investigate(src) }
+    end
+  end)
+end

--- a/lib/rubocop.rb
+++ b/lib/rubocop.rb
@@ -16,6 +16,7 @@ require 'rubocop/version'
 require 'rubocop/path_util'
 require 'rubocop/string_util'
 require 'rubocop/ast_node'
+require 'rubocop/node_pattern'
 
 require 'rubocop/cop/util'
 require 'rubocop/cop/offense'

--- a/lib/rubocop/cop/cop.rb
+++ b/lib/rubocop/cop/cop.rb
@@ -66,6 +66,7 @@ module RuboCop
     #   end
     class Cop
       extend AST::Sexp
+      extend NodePattern::Macros
       include Util
       include IgnoredNode
       include AutocorrectLogic

--- a/lib/rubocop/cop/style/double_negation.rb
+++ b/lib/rubocop/cop/style/double_negation.rb
@@ -22,22 +22,11 @@ module RuboCop
       class DoubleNegation < Cop
         MSG = 'Avoid the use of double negation (`!!`).'
 
+        def_node_matcher :double_negative?, '(send (send _ :!) :!)'
+
         def on_send(node)
-          return unless not_node?(node)
-
-          receiver, _method_name, *_args = *node
-
-          add_offense(node, :selector) if not_node?(receiver)
-        end
-
-        private
-
-        def not_node?(node)
-          _receiver, method_name, *args = *node
-
-          # ! does not take any arguments
-          args.empty? && method_name == :! &&
-            node.loc.selector.is?('!')
+          return unless double_negative?(node) && node.loc.selector.is?('!')
+          add_offense(node, :selector)
         end
       end
     end

--- a/lib/rubocop/node_pattern.rb
+++ b/lib/rubocop/node_pattern.rb
@@ -1,0 +1,465 @@
+# encoding: utf-8
+
+# rubocop:disable Metrics/ClassLength
+
+module RuboCop
+  # This class performs a pattern-matching operation on an AST node.
+  #
+  # Initialize a new `NodePattern` with `NodePattern.new(pattern_string)`, then
+  # pass an AST node to `NodePattern#match`. Alternatively, use one of the class
+  # macros in `NodePattern::Macros` to define your own pattern-matching method.
+  #
+  # If the match fails, `nil` will be returned. If the match succeeds, the
+  # return value depends on whether a block was provided to `#match`, and
+  # whether the pattern contained any "captures" (values which are extracted
+  # from a matching AST.)
+  #
+  # - With block: #match yields the captures (if any) and passes the return
+  #               value of the block through.
+  # - With no block, but one capture: the capture is returned.
+  # - With no block, but multiple captures: captures are returned as an array.
+  # - With no captures: #match returns `true`.
+  #
+  # ## Pattern string format examples
+  #
+  #    ':sym'              # matches a literal symbol
+  #    '1'                 # matches a literal integer
+  #    'nil'               # matches a literal nil
+  #    'send'              # matches (send ...)
+  #    '(send)'            # matches (send)
+  #    '(send ...)'        # matches (send ...)
+  #    '{send class}'      # matches (send ...) or (class ...)
+  #    '({send class})'    # matches (send) or (class)
+  #    '(send const)'      # matches (send (const ...))
+  #    '(send _ :new)'     # matches (send <anything> :new)
+  #    '(send $_ :new)'    # as above, but whatever matches the $_ is captured
+  #    '(send $_ $_)'      # you can use as many captures as you want
+  #    '(send !const ...)' # ! negates the next part of the pattern
+  #    '$(send const ...)' # arbitrary matching can be performed on a capture
+  #    '(send _recv _msg)' # wildcards can be named (for readability)
+  #    '(send ... :new)'   # you can specifically match against the last child
+  #                        # (this only works for the very last)
+  #    '(send $...)'       # capture all the children as an array
+  #    '(send $... int)'   # capture all children but the last as an array
+  #    '(send _x :+ _x)'   # unification is performed on named wildcards
+  #                        # (like Prolog variables...)
+  #    '(int odd?)'        # words which end with a ? are predicate methods,
+  #                        # are are called on the target to see if it matches
+  #                        # any Ruby method which the matched object supports
+  #                        # can be used
+  #    '(int [!1 !2])'     # [] contains multiple patterns, ALL of which must
+  #                        # match in that position
+  #                        # ({} is pattern union, [] is intersection)
+  #    '(send %1 _)'       # % stands for a parameter which must be supplied to
+  #                        # #match at matching time
+  #                        # it will be compared to the corresponding value in
+  #                        # the AST using #==
+  #                        # a bare '%' is the same as '%1'
+  #
+  # You can nest arbitrarily deep:
+  #
+  #     # matches node parsed from 'Const = Class.new' or 'Const = Module.new':
+  #     '(casgn nil const (send (const nil {:Class :Module}) :new)))'
+  #     # matches a node parsed from an 'if', with a '==' comparison,
+  #     # and no 'else' branch:
+  #     '(if (send _ :== _) _ nil)'
+  #
+  # Note that patterns like 'send' are implemented by calling `#send_type?` on
+  # the node being matched, 'const' by `#const_type?`, 'int' by `#int_type?`,
+  # and so on. Therefore, if you add methods which are named like
+  # `#prefix_type?` to the AST node class, then 'prefix' will become usable as
+  # a pattern.
+  #
+  # Also node that if you need a "guard clause" to protect against possible nils
+  # in a certain place in the AST, you can do it like this: `[!nil <pattern>]`
+  #
+  class NodePattern
+    # @private
+    Invalid = Class.new(StandardError)
+
+    # @private
+    # Builds Ruby code which implements a pattern
+    class Compiler
+      RSYM      = %r{:(?:[\w+-@_*/?!<>~|%^]+|==|\[\]=?)}
+      ID_CHAR   = /[a-zA-Z_]/
+      META_CHAR = /\(|\)|\{|\}|\[|\]|\$|\!|\.\.\./
+      TOKEN     = /\G(?:\s+|#{META_CHAR}|#{ID_CHAR}+\??|%\d*|\d+|#{RSYM}|.)/
+
+      META      = /\A#{META_CHAR}\Z/
+      NODE      = /\A#{ID_CHAR}+\Z/
+      PREDICATE = /\A#{ID_CHAR}+\?\Z/
+      LITERAL   = /\A(?:#{RSYM}|\d+|nil)\Z/
+      WILDCARD  = /\A_#{ID_CHAR}*\Z/
+      PARAM     = /\A%\d*\Z/
+
+      # Rather than using (explicit) recursion for nested patterns, we
+      # use a state machine with a stack, and run over the tokens in the
+      # pattern from left to right, updating state variables as we go.
+
+      def initialize(str, node_var = 'node0')
+        @string   = str
+        @stack    = []    # when entering (), [], or {}, push state on the stack
+
+        @temps    = 0     # avoid name clashes between temp variables
+        @index    = nil   # which position the match is at in ()
+        @context  = :root
+        @node     = node_var
+        @negated  = false # just saw a !
+
+        @captures = 0     # number of captures seen
+        @capture  = false # just saw a $
+        @cstack   = []    # used only when processing {}
+
+        @terms    = []    # used when building up a && or || expression
+        @unify    = {}    # named wildcard -> temp variable number
+        @params   = 0     # highest % (param) number seen
+
+        run
+      end
+
+      def run
+        @string.scan(TOKEN) do |token|
+          case token
+          when /^\s+/ # do nothing
+          when META then meta_token(token)
+          when WILDCARD then wildcard(token[1..-1])
+          when LITERAL then atom("(#{current_value} == #{token})")
+          when PREDICATE then atom("(#{current_node}.#{token})")
+          when NODE then atom("((temp=#{current_node}) && temp.#{token}_type?)")
+          when PARAM then param(token[1..-1])
+          else fail_due_to("invalid token #{token.inspect}")
+          end
+        end
+
+        fail_due_to('unbalanced pattern') unless @stack.empty?
+      end
+
+      def meta_token(token)
+        case token
+        when '(' then opening_paren
+        when ')' then closing_paren
+        when '{' then opening_curly
+        when '}' then closing_curly
+        when '[' then opening_square
+        when ']' then closing_square
+        when '$' then capture
+        when '!' then negate
+        when '...' then goto_last_child
+        end
+      end
+
+      def emit_match_code
+        @terms.empty? ? 'true' : @terms.join(' && ')
+      end
+
+      def emit_capture_list
+        (1..@captures).map { |n| "capture#{n}" }.join(',')
+      end
+
+      def emit_retval
+        if @captures.zero?
+          'true'
+        elsif @captures == 1
+          'capture1'
+        else
+          "[#{emit_capture_list}]"
+        end
+      end
+
+      def emit_param_list
+        (1..@params).map { |n| "param#{n}" }.join(',')
+      end
+
+      def emit_trailing_param_list
+        params = emit_param_list
+        params.empty? ? '' : ',' << params
+      end
+
+      def emit_method_code
+        <<-CODE
+          return nil unless #{emit_match_code}
+          block_given? ? yield(#{emit_capture_list}) : (return #{emit_retval})
+        CODE
+      end
+
+      def opening_paren
+        if @context != :root && @index == 0
+          # ((...) ...) is invalid, since you cannot destructure a node TYPE,
+          # you can only destructure child nodes
+          # ({(...) ...} ...) is equally invalid, since that would also mean
+          # trying to destructure a node type
+          fail_due_to('parentheses in invalid position')
+        end
+        enter_new_context(:sequence)
+      end
+
+      def closing_paren
+        # when entering (), @terms is initialized with a single entry, so if
+        # the parens are empty, there will be only 1 item in @terms
+        fail_due_to('empty parentheses') if @terms.one?
+        fail_due_to('! before )') if @negated
+
+        if @context != :last_child
+          # when inside ( ), context will be either :sequence or :last_child
+          # :last_child indicates that we have seen a ... token, which makes
+          # us jump to the last child of the destructured node
+          # if the ( ) is nested properly, context should be :sequence here
+          fail_due_to('unbalanced parentheses') if @context != :sequence
+          fail_due_to('$ before )') if @capture
+          # since we haven't seen a ..., add a check that there are no
+          # remaining children
+          add_term "(#{@node}.children.size == #{@index - 1})"
+        else
+          @terms << "(#{@node}.children.size >= #{@index - 1})" if @index > 1
+
+          if @capture
+            # we have a $... pattern, so capture all the remaining children
+            @terms << "(capture#{@captures} = " \
+              "#{@node}.children[#{@index - 1}..-1])"
+            @capture = false
+          end
+        end
+
+        leave_context("(#{@terms.join(' && ')})")
+      end
+
+      def opening_curly
+        fail_due_to('nested curly braces') if @context == :union
+        enter_new_context(:union)
+      end
+
+      def closing_curly
+        fail_due_to('unbalanced curly braces') if @context != :union
+        # when entering a { }, @terms is initialized with a single
+        # expression which stores the current node in a temp variable
+        # so if the { } is empty, @terms.size will be 1 right here
+        fail_due_to('empty set') if @terms.one?
+        fail_due_to('! before }') if @negated
+        leave_context("(#{@terms.shift}; #{@terms.join(' || ')})")
+      end
+
+      def opening_square
+        fail_due_to('nested square brackets') if @context == :intersection
+        enter_new_context(:intersection)
+      end
+
+      def closing_square
+        fail_due_to('unbalanced square brackets') if @context != :intersection
+        fail_due_to('empty square brackets') if @terms.one?
+        fail_due_to('! before ]') if @negated
+        leave_context("(#{@terms.join(' && ')})")
+      end
+
+      def capture
+        fail_due_to('$ after !') if @negated # $! is OK, but not !$
+        fail_due_to('use $[], not [$]') if @context == :intersection
+        # check if we are in ( ) and have seen a $... earlier
+        # if so, it will capture all the children but the last, and the
+        # following part will capture the last child
+        maybe_capture_intervening_children
+        fail_due_to('repeated $') if @capture
+        @captures += 1
+        @capture = true
+      end
+
+      def negate
+        fail_due_to('repeated !') if @negated
+        @negated = true
+      end
+
+      def wildcard(name)
+        fail_due_to('_ inside { ... }') if @context == :union
+        fail_due_to('_ inside [ ... ]') if @context == :intersection
+        if name.empty?
+          atom('true')
+        elsif @unify.key?(name)
+          # we have already seen a wildcard with this name before
+          # so the value it matched the first time will already be stored
+          # in a temp. check if this value matches the one stored in the temp
+          atom("(#{current_value} == temp#{@unify[name]})")
+        else
+          n = @unify[name] = (@temps += 1)
+          atom("(temp#{n} = #{current_value}; true)")
+        end
+      end
+
+      def atom(term)
+        maybe_capture_intervening_children
+        if @context == :last_child
+          # this is AFTER a ...
+          # so make sure that there are enough children for it to match,
+          # without rematching one of the children which already matched
+          @terms << "(#{@node}.children.size > #{@index - 1})" if @index > 1
+        end
+        add_term term
+        @index += 1 if @context == :sequence
+      end
+
+      def param(number)
+        number = number.empty? ? 1 : Integer(number)
+        @params = number if number > @params
+        atom("(#{current_value} == param#{number})")
+      end
+
+      def goto_last_child
+        fail_due_to('... repeated') if @context == :last_child
+        fail_due_to('... used outside of parens') unless @context == :sequence
+        fail_due_to('! before ...') if @negated
+        # set @capture to a special value to indicate that we have seen $...
+        @capture = :children if @capture
+        @context = :last_child
+      end
+
+      def enter_new_context(context)
+        # just entering (), [], or {}
+        # does this pattern appear after ...? if so capture intervening children
+        maybe_capture_intervening_children
+
+        if @context == :last_child && @index > 1
+          @terms << "(#{@node}.children.size > #{@index - 1})"
+        end
+        term = "(node#{@temps += 1} = #{current_node})"
+
+        # store state machine vars on the stack
+        @stack.push([@node, @index, @terms, @negated, @capture, @captures,
+                     @context])
+
+        # "stack frame" -- second slot, which is initialized to 'nil',
+        # is a "local variable" used for processing captures within each
+        # branch of a {}
+        # it stores the value of @captures after processing the first branch
+        @cstack.push([@captures, nil]) if context == :union
+
+        # re-initialize state machine vars for new context
+        @context = context
+        @terms = [term]
+        @node = "node#{@temps}"
+        @negated = @capture = false
+        @index = 0 if context == :sequence
+      end
+
+      def leave_context(term)
+        fail_due_to('unbalanced pattern') if @stack.empty?
+
+        _, @captures = @cstack.pop if @context == :union
+
+        # why do we pop 'captures' off the stack, but don't store it in
+        # @captures? we want to know what @captures was before entering this
+        # context, IN CASE it was captured
+        # for example, if compiling $(send $...), @captures will be different
+        # after processing the children, due to the $...
+        # but we need to know the capture # for the OUTER capture
+        @node, @index, @terms, @negated, @capture, captures, @context =
+          @stack.pop
+        add_term(term, captures)
+        @index += 1 if @context == :sequence
+      end
+
+      def maybe_capture_intervening_children
+        # if $... is followed by a final pattern, gather up all the intervening
+        # children into a capture before generating code for that pattern
+        return unless @context == :last_child && @capture == :children
+        @terms << "(capture#{@captures} = #{@node}.children[#{@index - 1}..-2])"
+        @capture = false
+      end
+
+      def add_term(term, capture_n = @captures)
+        ((term = "(!#{term})") && (@negated = false)) if @negated
+        if @capture
+          term = "((#{term}) && (capture#{capture_n} = #{current_value}; true))"
+          @capture = false
+        end
+        @terms << term
+
+        return unless @context == :union
+        # we push a "frame" on cstack for each nested {}
+        # this enables us to check after each branch to ensure that they all
+        # have the same number of captures
+        previous_captures, union_captures = @cstack.last
+        if !union_captures
+          @cstack.last[1] = @captures
+        elsif union_captures != @captures
+          fail_due_to('each branch of {} must have same # of captures')
+        end
+        @captures = previous_captures
+      end
+
+      def current_node
+        if @context == :last_child
+          "#{@node}.children.last"
+        elsif @context == :sequence && @index > 0
+          "#{@node}.children[#{@index - 1}]"
+        else
+          @node
+        end
+      end
+
+      def current_value
+        if @context == :sequence && @index == 0
+          "#{@node}.type"
+        else
+          current_node
+        end
+      end
+
+      def fail_due_to(message)
+        fail Invalid, "Couldn't compile due to #{message}. Pattern: #{@string}"
+      end
+    end
+
+    # Helpers for defining methods based on a pattern string
+    module Macros
+      # Define a method which applies a pattern to an AST node
+      #
+      # The new method will return nil if the node does not match
+      # If the node matches, and a block is provided, the new method will
+      # yield to the block (passing any captures as block arguments).
+      # If the node matches, and no block is provided, the new method will
+      # return the captures, or `true` if there were none.
+      def def_node_matcher(method_name, pattern_str)
+        compiler = RuboCop::NodePattern::Compiler.new(pattern_str, 'node')
+        src = "def #{method_name}(node" << compiler.emit_trailing_param_list <<
+              ');' << compiler.emit_method_code << ';end'
+        class_eval(src)
+      end
+
+      # Define a method which recurses over the descendants of an AST node,
+      # checking whether any of them match the provided pattern
+      #
+      # If the method name ends with '?', the new method will return `true`
+      # as soon as it finds a descendant which matches. Otherwise, it will
+      # yield all descendants which match.
+      def def_node_search(method_name, pattern_str)
+        compiler = RuboCop::NodePattern::Compiler.new(pattern_str, 'node')
+        if method_name.to_s.end_with?('?')
+          on_match = 'return true'
+          prelude = ''
+        else
+          yieldval = compiler.emit_capture_list
+          yieldval = 'node' if yieldval.empty?
+          on_match = "yield(#{yieldval})"
+          prelude = "return enum_for(:#{method_name},node0) unless block_given?"
+        end
+        src = <<-END
+          def #{method_name}(node0#{compiler.emit_trailing_param_list})
+            #{prelude}
+            node0.each_node do |node|
+              if #{compiler.emit_match_code}
+                #{on_match}
+              end
+            end
+            nil
+          end
+        END
+        class_eval(src)
+      end
+    end
+
+    def initialize(str)
+      compiler = Compiler.new(str)
+      src = 'def match(node0' << compiler.emit_trailing_param_list << ');' <<
+            compiler.emit_method_code << 'end'
+      instance_eval(src)
+    end
+  end
+end

--- a/spec/rubocop/node_pattern_spec.rb
+++ b/spec/rubocop/node_pattern_spec.rb
@@ -1,0 +1,790 @@
+# encoding: utf-8
+
+require 'spec_helper'
+
+describe RuboCop::NodePattern do
+  let(:node) do
+    buffer = Parser::Source::Buffer.new('(string)', 1)
+    buffer.source = ruby
+    builder = Astrolabe::Builder.new
+    Parser::CurrentRuby.new(builder).parse(buffer)
+  end
+
+  let(:params) { [] }
+
+  shared_examples :matching do
+    include AST::Sexp
+    it 'matches' do
+      expect(RuboCop::NodePattern.new(pattern).match(node, *params)).to be true
+    end
+  end
+
+  shared_examples :nonmatching do
+    it "doesn't match" do
+      expect(RuboCop::NodePattern.new(pattern).match(node, *params)).to be_nil
+    end
+  end
+
+  shared_examples :invalid do
+    it 'is invalid' do
+      expect { RuboCop::NodePattern.new(pattern) }
+        .to raise_error(RuboCop::NodePattern::Invalid)
+    end
+  end
+
+  shared_examples :single_capture do
+    include AST::Sexp
+    it 'yields captured value(s) and returns true if there is a block' do
+      expect do |probe|
+        compiled = RuboCop::NodePattern.new(pattern)
+        retval = compiled.match(node, *params) do |capture|
+          probe.to_proc.call(capture)
+          :retval_from_block
+        end
+        expect(retval).to be :retval_from_block
+      end.to yield_with_args(captured_val)
+    end
+
+    it 'returns captured values if there is no block' do
+      retval = RuboCop::NodePattern.new(pattern).match(node, *params)
+      expect(retval).to eq captured_val
+    end
+  end
+
+  shared_examples :multiple_capture do
+    include AST::Sexp
+    it 'yields captured value(s) and returns true if there is a block' do
+      expect do |probe|
+        compiled = RuboCop::NodePattern.new(pattern)
+        retval = compiled.match(node, *params) do |*captures|
+          probe.to_proc.call(captures)
+          :retval_from_block
+        end
+        expect(retval).to be :retval_from_block
+      end.to yield_with_args(captured_vals)
+    end
+
+    it 'returns captured values if there is no block' do
+      retval = RuboCop::NodePattern.new(pattern).match(node, *params)
+      expect(retval).to eq captured_vals
+    end
+  end
+
+  describe 'bare node type' do
+    let(:pattern) { 'send' }
+
+    context 'on a node with the same type' do
+      let(:ruby) { 'obj.method' }
+      it_behaves_like :matching
+    end
+
+    context 'on a node with a different type' do
+      let(:ruby) { '@ivar' }
+      it_behaves_like :nonmatching
+    end
+  end
+
+  describe 'simple sequence' do
+    let(:pattern) { '(send int :+ int)' }
+
+    context 'on a node with the same type and matching children' do
+      let(:ruby) { '1 + 1' }
+      it_behaves_like :matching
+    end
+
+    context 'on a node with a different type' do
+      let(:ruby) { 'a = 1' }
+      it_behaves_like :nonmatching
+    end
+
+    context 'on a node with the same type and non-matching children' do
+      context 'with non-matching selector' do
+        let(:ruby) { '1 - 1' }
+        it_behaves_like :nonmatching
+      end
+
+      context 'with non-matching receiver type' do
+        let(:ruby) { '1.0 + 1' }
+        it_behaves_like :nonmatching
+      end
+    end
+
+    context 'on a node with too many children' do
+      let(:pattern) { '(send int :blah int)' }
+      let(:ruby) { '1.blah(1, 2)' }
+      it_behaves_like :nonmatching
+    end
+
+    context 'with a nested sequence in head position' do
+      let(:pattern) { '((send) int :blah)' }
+      it_behaves_like :invalid
+    end
+
+    context 'with a nested sequence in non-head position' do
+      let(:pattern) { '(send (send _ :a) :b)' }
+      let(:ruby) { 'obj.a.b' }
+      it_behaves_like :matching
+    end
+  end
+
+  describe 'sequence with trailing ...' do
+    let(:pattern) { '(send int :blah ...)' }
+
+    context 'on a node with the same type and exact number of children' do
+      let(:ruby) { '1.blah' }
+      it_behaves_like :matching
+    end
+
+    context 'on a node with the same type and more children' do
+      context 'with 1 child more' do
+        let(:ruby) { '1.blah(1)' }
+        it_behaves_like :matching
+      end
+
+      context 'with 2 children more' do
+        let(:ruby) { '1.blah(1, :something)' }
+        it_behaves_like :matching
+      end
+    end
+
+    context 'on a node with the same type and fewer children' do
+      let(:pattern) { '(send int :blah int int ...)' }
+      let(:ruby) { '1.blah(2)' }
+      it_behaves_like :nonmatching
+    end
+
+    context 'on a node with fewer children, with a wildcard preceding' do
+      let(:pattern) { '(hash _ ...)' }
+      let(:ruby) { '{}' }
+      it_behaves_like :nonmatching
+    end
+
+    context 'on a node with a different type' do
+      let(:ruby) { 'A = 1' }
+      it_behaves_like :nonmatching
+    end
+
+    context 'on a node with non-matching children' do
+      let(:ruby) { '1.foo' }
+      it_behaves_like :nonmatching
+    end
+  end
+
+  describe 'wildcards' do
+    describe 'unnamed wildcards' do
+      context 'at the root level' do
+        let(:pattern) { '_' }
+        let(:ruby) { 'class << self; def something; 1; end end.freeze' }
+        it_behaves_like :matching
+      end
+
+      context 'within a sequence' do
+        let(:pattern) { '(const _ _)' }
+        let(:ruby) { 'Const' }
+        it_behaves_like :matching
+      end
+
+      context 'within a sequence with other patterns intervening' do
+        let(:pattern) { '(ivasgn _ (int _))' }
+        let(:ruby) { '@abc = 22' }
+        it_behaves_like :matching
+      end
+
+      context 'in head position of a sequence' do
+        let(:pattern) { '(_ int ...)' }
+        let(:ruby) { '1 + a' }
+        it_behaves_like :matching
+      end
+
+      context 'negated' do
+        let(:pattern) { '!_' }
+        let(:ruby) { '123' }
+        it_behaves_like :nonmatching
+      end
+    end
+
+    describe 'named wildcards' do
+      # unification is done on named wildcards!
+      context 'at the root level' do
+        let(:pattern) { '_node' }
+        let(:ruby) { 'class << self; def something; 1; end end.freeze' }
+        it_behaves_like :matching
+      end
+
+      context 'within a sequence' do
+        context 'with values which can be unified' do
+          let(:pattern) { '(send _num :+ _num)' }
+          let(:ruby) { '5 + 5' }
+          it_behaves_like :matching
+        end
+
+        context 'with values which cannot be unified' do
+          let(:pattern) { '(send _num :+ _num)' }
+          let(:ruby) { '5 + 4' }
+          it_behaves_like :nonmatching
+        end
+
+        context 'unifying the node type with an argument' do
+          let(:pattern) { '(_type _ _type)' }
+          let(:ruby) { 'obj.send' }
+          it_behaves_like :matching
+        end
+      end
+
+      context 'within a sequence with other patterns intervening' do
+        let(:pattern) { '(ivasgn _ivar (int _val))' }
+        let(:ruby) { '@abc = 22' }
+        it_behaves_like :matching
+      end
+
+      context 'in head position of a sequence' do
+        let(:pattern) { '(_type int ...)' }
+        let(:ruby) { '1 + a' }
+        it_behaves_like :matching
+      end
+    end
+  end
+
+  describe 'sets' do
+    context 'at the top level' do
+      context 'containing symbol literals' do
+        context 'when the AST has a matching symbol' do
+          let(:pattern) { '(send _ {:a :b})' }
+          let(:ruby) { 'obj.b' }
+          it_behaves_like :matching
+        end
+
+        context 'when the AST does not have a matching symbol' do
+          let(:pattern) { '(send _ {:a :b})' }
+          let(:ruby) { 'obj.c' }
+          it_behaves_like :nonmatching
+        end
+      end
+
+      context 'containing integer literals' do
+        let(:pattern) { '(send (int {1 10}) :abs)' }
+        let(:ruby) { '10.abs' }
+        it_behaves_like :matching
+      end
+
+      context 'containing a wildcard' do
+        let(:pattern) { '{1 _}' }
+        it_behaves_like :invalid
+      end
+
+      context 'containing multiple []' do
+        let(:pattern) { '{[(int odd?) int] [!nil float]}' }
+
+        context 'on a node which meets all requirements of the first []' do
+          let(:ruby) { '3' }
+          it_behaves_like :matching
+        end
+
+        context 'on a node which meets all requirements of the second []' do
+          let(:ruby) { '2.2' }
+          it_behaves_like :matching
+        end
+
+        context 'on a node which meets some requirements but not all' do
+          let(:ruby) { '2' }
+          it_behaves_like :nonmatching
+        end
+      end
+    end
+
+    context 'nested inside a sequence' do
+      let(:pattern) { '(send {const int} ...)' }
+      let(:ruby) { 'Const.method' }
+      it_behaves_like :matching
+    end
+
+    context 'with a nested sequence' do
+      let(:pattern) { '{(send int ...) (send const ...)}' }
+      let(:ruby) { 'Const.method' }
+      it_behaves_like :matching
+    end
+
+    context 'with a nested set' do
+      let(:pattern) { '{{1 2}}' }
+      it_behaves_like :invalid
+    end
+  end
+
+  describe 'captures on a wildcard' do
+    context 'at the root level' do
+      let(:pattern) { '$_' }
+      let(:ruby) { 'begin; raise StandardError; rescue Exception => e; end' }
+      let(:captured_val) { node }
+      it_behaves_like :single_capture
+    end
+
+    context 'in head position in a sequence' do
+      let(:pattern) { '($_ ...)' }
+      let(:ruby) { 'A.method' }
+      let(:captured_val) { :send }
+      it_behaves_like :single_capture
+    end
+
+    context 'in non-head position in a sequence' do
+      let(:pattern) { '(send $_ ...)' }
+      let(:ruby) { 'A.method' }
+      let(:captured_val) { s(:const, nil, :A) }
+      it_behaves_like :single_capture
+    end
+
+    context 'in a nested sequence' do
+      let(:pattern) { '(send (const nil $_) ...)' }
+      let(:ruby) { 'A.method' }
+      let(:captured_val) { :A }
+      it_behaves_like :single_capture
+    end
+  end
+
+  describe 'captures which also perform a match' do
+    context 'on a sequence' do
+      let(:pattern) { '(send $(send _ :keys) :each)' }
+      let(:ruby) { '{}.keys.each' }
+      let(:captured_val) { s(:send, s(:hash), :keys) }
+      it_behaves_like :single_capture
+    end
+
+    context 'on a set' do
+      let(:pattern) { '(send _ ${:inc :dec})' }
+      let(:ruby) { '1.dec' }
+      let(:captured_val) { :dec }
+      it_behaves_like :single_capture
+    end
+
+    context 'on []' do
+      let(:pattern) { '(send (int $[!odd? !zero?]) :inc)' }
+      let(:ruby) { '2.inc' }
+      let(:captured_val) { 2 }
+      it_behaves_like :single_capture
+    end
+
+    context 'on a node type' do
+      let(:pattern) { '(send $int :inc)' }
+      let(:ruby) { '5.inc' }
+      let(:captured_val) { s(:int, 5) }
+      it_behaves_like :single_capture
+    end
+
+    context 'on a literal' do
+      let(:pattern) { '(send int $:inc)' }
+      let(:ruby) { '5.inc' }
+      let(:captured_val) { :inc }
+      it_behaves_like :single_capture
+    end
+
+    context 'when nested' do
+      let(:pattern) { '(send $(int $_) :inc)' }
+      let(:ruby) { '5.inc' }
+      let(:captured_vals) { [s(:int, 5), 5] }
+      it_behaves_like :multiple_capture
+    end
+  end
+
+  describe 'captures on ...' do
+    context 'with no remaining pattern at the end' do
+      let(:pattern) { '(send $...)' }
+      let(:ruby) { '5.inc' }
+      let(:captured_val) { [s(:int, 5), :inc] }
+      it_behaves_like :single_capture
+    end
+
+    context 'with a remaining node type at the end' do
+      let(:pattern) { '(send $... int)' }
+      let(:ruby) { '5 + 4' }
+      let(:captured_val) { [s(:int, 5), :+] }
+      it_behaves_like :single_capture
+    end
+
+    context 'with a remaining sequence at the end' do
+      let(:pattern) { '(send $... (int 4))' }
+      let(:ruby) { '5 + 4' }
+      let(:captured_val) { [s(:int, 5), :+] }
+      it_behaves_like :single_capture
+    end
+
+    context 'with a remaining set at the end' do
+      let(:pattern) { '(send $... {int float})' }
+      let(:ruby) { '5 + 4' }
+      let(:captured_val) { [s(:int, 5), :+] }
+      it_behaves_like :single_capture
+    end
+
+    context 'with a remaining [] at the end' do
+      let(:pattern) { '(send $... [(int even?) (int zero?)])' }
+      let(:ruby) { '5 + 0' }
+      let(:captured_val) { [s(:int, 5), :+] }
+      it_behaves_like :single_capture
+    end
+
+    context 'with a remaining literal at the end' do
+      let(:pattern) { '(send $... :inc)' }
+      let(:ruby) { '5.inc' }
+      let(:captured_val) { [s(:int, 5)] }
+      it_behaves_like :single_capture
+    end
+
+    context 'with a remaining wildcard at the end' do
+      let(:pattern) { '(send $... _)' }
+      let(:ruby) { '5.inc' }
+      let(:captured_val) { [s(:int, 5)] }
+      it_behaves_like :single_capture
+    end
+
+    context 'with a remaining capture at the end' do
+      let(:pattern) { '(send $... $_)' }
+      let(:ruby) { '5 + 4' }
+      let(:captured_vals) { [[s(:int, 5), :+], s(:int, 4)] }
+      it_behaves_like :multiple_capture
+    end
+  end
+
+  describe 'captures within sets' do
+    context 'on simple subpatterns' do
+      let(:pattern) { '{$send $int $float}' }
+      let(:ruby) { '2.0' }
+      let(:captured_val) { s(:float, 2.0) }
+      it_behaves_like :single_capture
+    end
+
+    context 'within nested sequences' do
+      let(:pattern) { '{(send $_ $_) (const $_ $_)}' }
+      let(:ruby) { 'Namespace::CONST' }
+      let(:captured_vals) { [s(:const, nil, :Namespace), :CONST] }
+      it_behaves_like :multiple_capture
+    end
+
+    context 'with complex nesting' do
+      let(:pattern) do
+        '{(send {$int $float} {$:inc $:dec}) ' \
+        '[!nil {($_ sym $_) (send ($_ $_) :object_id)}]}'
+      end
+      let(:ruby) { '10.object_id' }
+      let(:captured_vals) { [:int, 10] }
+      it_behaves_like :multiple_capture
+    end
+
+    context 'with a different number of captures in each branch' do
+      let(:pattern) { '{(send $...) (int $...) (send $_ $_)}' }
+      it_behaves_like :invalid
+    end
+  end
+
+  describe 'negation' do
+    context 'on a symbol' do
+      let(:pattern) { '(send _ !:abc)' }
+
+      context 'with a matching symbol' do
+        let(:ruby) { 'obj.abc' }
+        it_behaves_like :nonmatching
+      end
+
+      context 'with a non-matching symbol' do
+        let(:ruby) { 'obj.xyz' }
+        it_behaves_like :matching
+      end
+
+      context 'with a non-matching symbol, but too many children' do
+        let(:ruby) { 'obj.xyz(1)' }
+        it_behaves_like :nonmatching
+      end
+    end
+
+    context 'on a set' do
+      let(:pattern) { '(ivasgn _ !(int {1 2}))' }
+
+      context 'with a matching value' do
+        let(:ruby) { '@a = 1' }
+        it_behaves_like :nonmatching
+      end
+
+      context 'with a non-matching value' do
+        let(:ruby) { '@a = 3' }
+        it_behaves_like :matching
+      end
+    end
+
+    context 'on a sequence' do
+      let(:pattern) { '!(ivasgn :@a ...)' }
+
+      context 'with a matching node' do
+        let(:ruby) { '@a = 1' }
+        it_behaves_like :nonmatching
+      end
+
+      context 'with a node of different type' do
+        let(:ruby) { '@@a = 1' }
+        it_behaves_like :matching
+      end
+
+      context 'with a node with non-matching children' do
+        let(:ruby) { '@b = 1' }
+        it_behaves_like :matching
+      end
+    end
+
+    context 'on square brackets' do
+      let(:pattern) { '![!int !float]' }
+
+      context 'with a node which meets all requirements of []' do
+        let(:ruby) { '"abc"' }
+        it_behaves_like :nonmatching
+      end
+
+      context 'with a node which meets only 1 requirement of []' do
+        let(:ruby) { '1' }
+        it_behaves_like :matching
+      end
+    end
+
+    context 'when nested in complex ways' do
+      let(:pattern) { '!(send !{int float} !:+ !(send _ :to_i))' }
+
+      context 'with (send str :+ (send str :to_i))' do
+        let(:ruby) { '"abc" + "1".to_i' }
+        it_behaves_like :matching
+      end
+
+      context 'with (send int :- int)' do
+        let(:ruby) { '1 - 1' }
+        it_behaves_like :matching
+      end
+
+      context 'with (send str :<< str)' do
+        let(:ruby) { '"abc" << "xyz"' }
+        it_behaves_like :nonmatching
+      end
+    end
+  end
+
+  describe 'ellipsis' do
+    context 'preceding a capture' do
+      let(:pattern) { '(send array :push ... $_)' }
+      let(:ruby) { '[1].push(2, 3, 4)' }
+      let(:captured_val) { s(:int, 4) }
+      it_behaves_like :single_capture
+    end
+
+    context 'with a wildcard at the end, but no remaining child to match it' do
+      let(:pattern) { '(send array :zip array ... _)' }
+      let(:ruby) { '[1,2].zip([3,4])' }
+      it_behaves_like :nonmatching
+    end
+
+    context 'with a nodetype at the end, but no remaining child to match it' do
+      let(:pattern) { '(send array :zip array ... array)' }
+      let(:ruby) { '[1,2].zip([3,4])' }
+      it_behaves_like :nonmatching
+    end
+
+    context 'with a nested sequence at the end, but no remaining child' do
+      let(:pattern) { '(send array :zip array ... (array ...))' }
+      let(:ruby) { '[1,2].zip([3,4])' }
+      it_behaves_like :nonmatching
+    end
+
+    context 'with a set at the end, but no remaining child to match it' do
+      let(:pattern) { '(send array :zip array ... {array})' }
+      let(:ruby) { '[1,2].zip([3,4])' }
+      it_behaves_like :nonmatching
+    end
+
+    context 'with [] at the end, but no remaining child to match it' do
+      let(:pattern) { '(send array :zip array ... [array !nil])' }
+      let(:ruby) { '[1,2].zip([3,4])' }
+      it_behaves_like :nonmatching
+    end
+  end
+
+  describe 'predicates' do
+    context 'in root position' do
+      let(:pattern) { 'send_type?' }
+      let(:ruby) { '1.inc' }
+      it_behaves_like :matching
+    end
+
+    context 'at head position of a sequence' do
+      let(:pattern) { '(send_type? int ...)' }
+      let(:ruby) { '1.inc' }
+      it_behaves_like :matching
+    end
+
+    context 'applied to an integer for which the predicate is true' do
+      let(:pattern) { '(send (int odd?) :inc)' }
+      let(:ruby) { '1.inc' }
+      it_behaves_like :matching
+    end
+
+    context 'applied to an integer for which the predicate is false' do
+      let(:pattern) { '(send (int odd?) :inc)' }
+      let(:ruby) { '2.inc' }
+      it_behaves_like :nonmatching
+    end
+
+    context 'when captured' do
+      let(:pattern) { '(send (int $odd?) :inc)' }
+      let(:ruby) { '1.inc' }
+      let(:captured_val) { 1 }
+      it_behaves_like :single_capture
+    end
+
+    context 'when negated' do
+      let(:pattern) { '(send int !nil?)' }
+      let(:ruby) { '1.inc' }
+      it_behaves_like :matching
+    end
+
+    context 'when in last-child position, but all children have already ' \
+            'been matched' do
+      let(:pattern) { '(send int :inc ... !nil?)' }
+      let(:ruby) { '1.inc' }
+      it_behaves_like :nonmatching
+    end
+  end
+
+  describe 'params' do
+    context 'in root position' do
+      let(:pattern) { '%1' }
+      let(:params) { [s(:int, 10)] }
+      let(:ruby) { '10' }
+      it_behaves_like :matching
+    end
+
+    context 'in a nested sequence' do
+      let(:pattern) { '(send (send _ %2) %1)' }
+      let(:params) { [:inc, :dec] }
+      let(:ruby) { '5.dec.inc' }
+      it_behaves_like :matching
+    end
+
+    context 'when preceded by ...' do
+      let(:pattern) { '(send ... %1)' }
+      let(:params) { [s(:int, 10)] }
+      let(:ruby) { '1 + 10' }
+      it_behaves_like :matching
+    end
+
+    context 'when preceded by $...' do
+      let(:pattern) { '(send $... %1)' }
+      let(:params) { [s(:int, 10)] }
+      let(:ruby) { '1 + 10' }
+      let(:captured_val) { [s(:int, 1), :+] }
+      it_behaves_like :single_capture
+    end
+
+    context 'when captured' do
+      let(:pattern) { '(const _ $%1)' }
+      let(:params) { [:A] }
+      let(:ruby) { 'Namespace::A' }
+      let(:captured_val) { :A }
+      it_behaves_like :single_capture
+    end
+
+    context 'when negated, with a matching value' do
+      let(:pattern) { '(const _ !%1)' }
+      let(:params) { [:A] }
+      let(:ruby) { 'Namespace::A' }
+      it_behaves_like :nonmatching
+    end
+
+    context 'when negated, with a nonmatching value' do
+      let(:pattern) { '(const _ !%1)' }
+      let(:params) { [:A] }
+      let(:ruby) { 'Namespace::B' }
+      it_behaves_like :matching
+    end
+
+    context 'without explicit number' do
+      let(:pattern) { '(const %2 %)' }
+      let(:params) { [:A, s(:const, nil, :Namespace)] }
+      let(:ruby) { 'Namespace::A' }
+      it_behaves_like :matching
+    end
+
+    context 'when inside a union, with a matching value' do
+      let(:pattern) { '{str (int %)}' }
+      let(:params) { [10] }
+      let(:ruby) { '10' }
+      it_behaves_like :matching
+    end
+
+    context 'when inside a union, with a nonmatching value' do
+      let(:pattern) { '{str (int %)}' }
+      let(:params) { [10] }
+      let(:ruby) { '1.0' }
+      it_behaves_like :nonmatching
+    end
+
+    context 'when inside an intersection' do
+      let(:pattern) { '(int [!%1 %2 !zero?])' }
+      let(:params) { [10, 20] }
+      let(:ruby) { '20' }
+      it_behaves_like :matching
+    end
+  end
+
+  describe 'bad syntax' do
+    context 'with empty parentheses' do
+      let(:pattern) { '()' }
+      it_behaves_like :invalid
+    end
+
+    context 'with unmatched opening paren' do
+      let(:pattern) { '(send (const)' }
+      it_behaves_like :invalid
+    end
+
+    context 'with unmatched closing paren' do
+      let(:pattern) { '(send (const)))' }
+      it_behaves_like :invalid
+    end
+
+    context 'with unmatched opening curly' do
+      let(:pattern) { '{send const' }
+      it_behaves_like :invalid
+    end
+
+    context 'with unmatched closing curly' do
+      let(:pattern) { '{send const}}' }
+      it_behaves_like :invalid
+    end
+
+    context 'with negated closing paren' do
+      let(:pattern) { '(send (const) !)' }
+      it_behaves_like :invalid
+    end
+
+    context 'with negated closing curly' do
+      let(:pattern) { '{send const !}' }
+      it_behaves_like :invalid
+    end
+
+    context 'with double negation' do
+      let(:pattern) { '(send !!const)' }
+      it_behaves_like :invalid
+    end
+
+    context 'with negated ellipsis' do
+      let(:pattern) { '(send !...)' }
+      it_behaves_like :invalid
+    end
+
+    context 'with doubled ellipsis' do
+      let(:pattern) { '(send ... ...)' }
+      it_behaves_like :invalid
+    end
+
+    context 'with a wildcard inside []' do
+      let(:pattern) { '[_x _y]' }
+      it_behaves_like :invalid
+    end
+
+    context 'with a capture directly inside []' do
+      let(:pattern) { '[!nil $send]' }
+      it_behaves_like :invalid
+    end
+  end
+end


### PR DESCRIPTION
While working on #2359, I used a very complex conditional with lots of calls like `node.children[1].children[0].type == ...` and so on. @bbatsov commented on this:

> I don't like the usage of array references and children in general, as it really obscures what you're trying to do. Even I'm not sure about it, so people not familiar with parser will be extra confused. 

This PR is an attempt to make that kind of code very concise. It introduces a pattern-matching language for AST nodes. Pass a pattern string to `RuboCop::Pattern.new`, it compiles it into a method which runs just as fast as if it was written in straight Ruby.

Here are some examples of what the pattern format looks like:

```ruby
# Let's say we want to match this
Const = Class.new
# Or:
Const = Module.new

pattern = Pattern.new '(casgn _ const (send (const _ {:Class :Module}) :new ...))'
pattern.match(parser.parse(src)) # => true
```

Alphabetic identifiers match node types, `()` destructures a node, `{}` provides alternative patterns, any of which can match. `_` is a wildcard, symbol and integer literals match themselves, `...` matches any remaining children up to the end of a node.

Other features: `!` negates the next part of the pattern, `$` captures whatever it matches (returning it from `#match` if the overall match succeeds), and you can match against the last child of a node by preceding it with a `...`.

If you extend `Astrolabe::Node` with methods which have a `_type?` suffix, the prefix will become usable in `Pattern`. For example:

```ruby
class Astrolabe::Node
  BASIC_LITERALS = [:str, :int, :float, :sym, :regexp, :nil, :true, :false]
  def basic_literal_type?
    BASIC_LITERALS.include?(type)
  end
end

Pattern.new '(send basic_literal ...)' # this will now work
```

Thoughts?