### PR TITLE
[Fix #2272] `Lint/NonLocalExitFromIterator` doesn't warn about block passed to `Module#define_method`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,7 @@
 * [#2356](https://github.com/bbatsov/rubocop/pull/2356): `Style/Encoding` will now place the encoding comment on the second line if the first line is a shebang. ([@rrosenblum][])
 * `Style/InitialIndentation` cop doesn't error out when a line begins with an integer literal. ([@alexdowad][])
 * [#2296](https://github.com/bbatsov/rubocop/issues/2296): In `Style/DotPosition`, don't "correct" (and break) a method call which has a line comment (or blank line) between the dot and the selector. ([@alexdowad][])
+* [#2272](https://github.com/bbatsov/rubocop/issues/2272): `Lint/NonLocalExitFromIterator` does not warn about `return` in a block which is passed to `Module#define_method`. ([@alexdowad][])
 
 ## 0.34.2 (21/09/2015)
 

--- a/spec/rubocop/cop/lint/non_local_exit_from_iterator_spec.rb
+++ b/spec/rubocop/cop/lint/non_local_exit_from_iterator_spec.rb
@@ -150,5 +150,17 @@ describe RuboCop::Cop::Lint::NonLocalExitFromIterator do
 
       it { expect(cop.offenses).to be_empty }
     end
+
+    context 'when the message is define_method' do
+      let(:source) { <<-END }
+        [:method_one, :method_two].each do |method_name|
+          define_method(method_name) do
+            return if predicate?
+          end
+        end
+      END
+
+      it { expect(cop.offenses).to be_empty }
+    end
   end
 end


### PR DESCRIPTION
`return`s don't cause problems in blocks passed to `define_method`.