### PR TITLE
[Fix #1981] `Lint/UselessAssignment` doesn't warn when variable is assigned from identical if branches

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,6 +54,7 @@
 * [#2262](https://github.com/bbatsov/rubocop/issues/2262): Replace `Rainbow` reference with `Colorizable#yellow`. ([@minustehbare][])
 * [#2068](https://github.com/bbatsov/rubocop/issues/2068): Display warning if `Style/Copyright` is misconfigured. ([@alexdowad][])
 * [#2321](https://github.com/bbatsov/rubocop/issues/2321): In `Style/EachWithObject`, don't replace reduce with each_with_object if the accumulator parameter is assigned to in the block. ([@alexdowad][])
+* [#1981](https://github.com/bbatsov/rubocop/issues/1981): `Lint/UselessAssignment` doesn't erroneously identify assignments in identical if branches as useless. ([@alexdowad][])
 
 ## 0.34.2 (21/09/2015)
 

--- a/lib/rubocop/cop/variable_force/locatable.rb
+++ b/lib/rubocop/cop/variable_force/locatable.rb
@@ -133,7 +133,7 @@ module RuboCop
         end
 
         def body_index
-          branch_point_node.children.index(branch_body_node)
+          branch_point_node.children.index { |n| n.equal?(branch_body_node) }
         end
 
         def set_branch_point_and_body_nodes!

--- a/spec/rubocop/cop/lint/useless_assignment_spec.rb
+++ b/spec/rubocop/cop/lint/useless_assignment_spec.rb
@@ -1774,5 +1774,24 @@ describe RuboCop::Cop::Lint::UselessAssignment do
           .to eq('Useless assignment to variable - `enviromnent`.')
       end
     end
+
+    # regression test, from problem in Locatable
+    context 'when a variable is assigned in 2 identical if branches' do
+      let(:source) do
+        ['def foo',
+         '  if bar',
+         '    foo = 1',
+         '  else',
+         '    foo = 1',
+         '  end',
+         '  foo.bar.baz',
+         'end']
+      end
+
+      it "doesn't think 1 of the 2 assignments is useless" do
+        inspect_source(cop, source)
+        expect(cop.offenses).to be_empty
+      end
+    end
   end
 end


### PR DESCRIPTION
Make up your mind, value object or reference object -- you can't have both!