### PR TITLE
Username in default tmp folder path.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,7 +48,7 @@
 * [#2356](https://github.com/bbatsov/rubocop/pull/2356): `Style/Encoding` will now place the encoding comment on the second line if the first line is a shebang. ([@rrosenblum][])
 * `Style/InitialIndentation` cop doesn't error out when a line begins with an integer literal. ([@alexdowad][])
 * [#2296](https://github.com/bbatsov/rubocop/issues/2296): In `Style/DotPosition`, don't "correct" (and break) a method call which has a line comment (or blank line) between the dot and the selector. ([@alexdowad][])
-* Default rubocop cache dir moved to per-user folders. (```/tmp/rubocop_cache``` -> ```/tmp/$username/rubocop_cache```) ([@br3nda][])
+* Default rubocop cache dir moved to per-user folders. (`/tmp/rubocop_cache` -> `/tmp/$username/rubocop_cache`) ([@br3nda][])
 
 ## 0.34.2 (21/09/2015)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,7 +48,7 @@
 * [#2356](https://github.com/bbatsov/rubocop/pull/2356): `Style/Encoding` will now place the encoding comment on the second line if the first line is a shebang. ([@rrosenblum][])
 * `Style/InitialIndentation` cop doesn't error out when a line begins with an integer literal. ([@alexdowad][])
 * [#2296](https://github.com/bbatsov/rubocop/issues/2296): In `Style/DotPosition`, don't "correct" (and break) a method call which has a line comment (or blank line) between the dot and the selector. ([@alexdowad][])
-* Default rubocop cache dir moved to per-user folders. (`/tmp/rubocop_cache` -> `/tmp/$username/rubocop_cache`) ([@br3nda][])
+* Default rubocop cache dir moved to per-user folders. (`/tmp/rubocop_cache` -> `/tmp/$username/rubocop_cache`). ([@br3nda][])
 
 ## 0.34.2 (21/09/2015)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,7 @@
 * [#2356](https://github.com/bbatsov/rubocop/pull/2356): `Style/Encoding` will now place the encoding comment on the second line if the first line is a shebang. ([@rrosenblum][])
 * `Style/InitialIndentation` cop doesn't error out when a line begins with an integer literal. ([@alexdowad][])
 * [#2296](https://github.com/bbatsov/rubocop/issues/2296): In `Style/DotPosition`, don't "correct" (and break) a method call which has a line comment (or blank line) between the dot and the selector. ([@alexdowad][])
+* Default rubocop cache dir moved to per-user folders. (```/tmp/rubocop_cache``` -> ```/tmp/$username/rubocop_cache```) ([@br3nda][])
 
 ## 0.34.2 (21/09/2015)
 
@@ -1676,3 +1677,4 @@
 [@eagletmt]: https://github.com/eagletmt
 [@apiology]: https://github.com/apiology
 [@alexdowad]: https://github.com/alexdowad
+[@br3nda]: https://github.com/br3nda

--- a/lib/rubocop/result_cache.rb
+++ b/lib/rubocop/result_cache.rb
@@ -3,6 +3,7 @@
 require 'digest/md5'
 require 'find'
 require 'tmpdir'
+require 'etc'
 
 module RuboCop
   # Provides functionality for caching rubocop runs.
@@ -78,7 +79,7 @@ module RuboCop
 
     def self.cache_root(config_store)
       root = config_store.for('.')['AllCops']['CacheRootDirectory']
-      root = Dir.tmpdir if root == '/tmp'
+      root = File.join(Dir.tmpdir, Etc.getlogin) if root == '/tmp'
       File.join(root, 'rubocop_cache')
     end
 


### PR DESCRIPTION
On multi user machines, whoever runs rubocop first owns /tmp/rubocop_cache
Other users often cannot write to that folder.

This adds the user's username into the default calculated cache directory


