### PR TITLE
[Fix #2369] Don't add trailing comma to multiline method chain which is sole arg

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@
 * [#2335](https://github.com/bbatsov/rubocop/issues/2335): `Style/VariableName` cop checks naming style of method parameters. ([@alexdowad][])
 * [#2329](https://github.com/bbatsov/rubocop/pull/2329): New style `braces_for_chaining` for `Style/BlockDelimiters` cop enforces braces on a multi-line block if its return value is being chained with another method. ([@panthomakos][])
 * `Lint/LiteralInCondition` warns if a symbol or dynamic symbol is used as a condition. ([@alexdowad][])
+* [#2369](https://github.com/bbatsov/rubocop/issues/2369): `Style/TrailingComma` doesn't add a trailing comma to a multiline method chain which is the only arg to a method call. ([@alexdowad][])
 
 ### Bug Fixes
 

--- a/spec/rubocop/cop/style/trailing_comma_spec.rb
+++ b/spec/rubocop/cop/style/trailing_comma_spec.rb
@@ -413,6 +413,18 @@ describe RuboCop::Cop::Style::TrailingComma, :config do
                                   '              d: 1,',
                                   '           )'].join("\n"))
       end
+
+      it 'accepts a method with a single multiline method call arg' \
+         ' and no trailing comma' do
+        inspect_source(cop, <<-CODE)
+          some_method(
+            SomeObject
+              .method
+              .method
+          )
+        CODE
+        expect(cop.offenses).to be_empty
+      end
     end
 
     context 'when EnforcedStyleForMultiline is consistent_comma' do
@@ -611,6 +623,18 @@ describe RuboCop::Cop::Style::TrailingComma, :config do
                                   '              c: 0,',
                                   '              d: 1,',
                                   '           )'].join("\n"))
+      end
+
+      it 'accepts a method with a single multiline method call arg ' \
+         'and no trailing comma' do
+        inspect_source(cop, <<-CODE)
+          some_method(
+            SomeObject
+              .method
+              .method
+          )
+        CODE
+        expect(cop.offenses).to be_empty
       end
     end
   end


### PR DESCRIPTION
RuboCops, do you agree with #2369? Personally, I think adding a trailing comma in that case does look strange.