### PR TITLE
Unused args cops can be configured to ignore empty methods/blocks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@
 * [#2369](https://github.com/bbatsov/rubocop/issues/2369): `Style/TrailingComma` doesn't add a trailing comma to a multiline method chain which is the only arg to a method call. ([@alexdowad][])
 * `CircularArgumentReference` cop updated to lint for ordinal circular argument references on top of optional keyword arguments. ([@maxjacobson][])
 * Added ability to download shared rubocop config files from remote urls. ([@ptrippett][])
+* [#1601](https://github.com/bbatsov/rubocop/issues/1601): Add `IgnoreEmptyMethods` config parameter for `Lint/UnusedMethodArgument` and `IgnoreEmptyBlocks` config parameter for `Lint/UnusedBlockArgument` cops. ([@alexdowad][])
 
 ### Bug Fixes
 

--- a/config/default.yml
+++ b/config/default.yml
@@ -858,9 +858,14 @@ Lint/DefEndAlignment:
     - def
   AutoCorrect: false
 
+# Checks for unused block arguments
+Lint/UnusedBlockArgument:
+  IgnoreEmptyBlocks: true
+
 # Checks for unused method arguments.  
 Lint/UnusedMethodArgument:
   AllowUnusedKeywordArguments: false
+  IgnoreEmptyMethods: true
 
 ##################### Rails ##################################
 

--- a/config/enabled.yml
+++ b/config/enabled.yml
@@ -867,7 +867,7 @@ Lint/AmbiguousOperator:
 Lint/AmbiguousRegexpLiteral:
   Description: >-
                  Checks for ambiguous regexp literals in the first argument of
-                 a method invocation without parenthesis.
+                 a method invocation without parentheses.
   Enabled: true
 
 Lint/AssignmentInCondition:

--- a/lib/rubocop/config.rb
+++ b/lib/rubocop/config.rb
@@ -20,6 +20,9 @@ module RuboCop
 
     def initialize(hash = {}, loaded_path = nil)
       @loaded_path = loaded_path
+      @for_cop = Hash.new do |h, cop|
+        h[cop] = self[Cop::Cop.qualified_cop_name(cop, loaded_path)] || {}
+      end
       super(hash)
     end
 
@@ -72,13 +75,11 @@ module RuboCop
     end
 
     def for_cop(cop)
-      cop = cop.cop_name if cop.respond_to?(:cop_name)
-      @for_cop ||= {}
-      @for_cop[cop] ||= self[Cop::Cop.qualified_cop_name(cop, loaded_path)]
+      @for_cop[cop.respond_to?(:cop_name) ? cop.cop_name : cop]
     end
 
     def cop_enabled?(cop)
-      for_cop(cop).nil? || for_cop(cop)['Enabled']
+      for_cop(cop).empty? || for_cop(cop)['Enabled']
     end
 
     def warn_unless_valid

--- a/lib/rubocop/cop/cop.rb
+++ b/lib/rubocop/cop/cop.rb
@@ -208,12 +208,12 @@ module RuboCop
       end
 
       def style_guide_url
-        url = cop_config && cop_config['StyleGuide']
+        url = cop_config['StyleGuide']
         (url.nil? || url.empty?) ? nil : url
       end
 
       def reference_url
-        url = cop_config && cop_config['Reference']
+        url = cop_config['Reference']
         (url.nil? || url.empty?) ? nil : url
       end
 
@@ -235,7 +235,7 @@ module RuboCop
       end
 
       def file_name_matches_any?(file, parameter, default_result)
-        patterns = cop_config && cop_config[parameter]
+        patterns = cop_config[parameter]
         return default_result unless patterns
         path = nil
         patterns.any? do |pattern|
@@ -258,7 +258,7 @@ module RuboCop
       end
 
       def custom_severity
-        severity = cop_config && cop_config['Severity']
+        severity = cop_config['Severity']
         return unless severity
 
         if Severity::NAMES.include?(severity.to_sym)

--- a/lib/rubocop/cop/lint/unused_block_argument.rb
+++ b/lib/rubocop/cop/lint/unused_block_argument.rb
@@ -16,6 +16,12 @@ module RuboCop
 
         def check_argument(variable)
           return unless variable.block_argument?
+
+          if cop_config['IgnoreEmptyBlocks']
+            _send, _args, body = *variable.scope.node
+            return if body.nil?
+          end
+
           super
         end
 

--- a/lib/rubocop/cop/lint/unused_method_argument.rb
+++ b/lib/rubocop/cop/lint/unused_method_argument.rb
@@ -16,7 +16,7 @@ module RuboCop
         def check_argument(variable)
           return unless variable.method_argument?
           return if variable.keyword_argument? &&
-                    cop_config && cop_config['AllowUnusedKeywordArguments']
+                    cop_config['AllowUnusedKeywordArguments']
           super
         end
 

--- a/lib/rubocop/cop/lint/unused_method_argument.rb
+++ b/lib/rubocop/cop/lint/unused_method_argument.rb
@@ -17,6 +17,12 @@ module RuboCop
           return unless variable.method_argument?
           return if variable.keyword_argument? &&
                     cop_config['AllowUnusedKeywordArguments']
+
+          if cop_config['IgnoreEmptyMethods']
+            _name, _args, body = *variable.scope.node
+            return if body.nil?
+          end
+
           super
         end
 

--- a/lib/rubocop/cop/mixin/negative_conditional.rb
+++ b/lib/rubocop/cop/mixin/negative_conditional.rb
@@ -8,7 +8,7 @@ module RuboCop
       def check_negative_conditional(node)
         condition, _body, _rest = *node
 
-        # Look at last expression of contents if there's a parenthesis
+        # Look at last expression of contents if there are parentheses
         # around condition.
         condition = condition.children.last while condition.type == :begin
         return unless condition.type == :send

--- a/lib/rubocop/cop/mixin/statement_modifier.rb
+++ b/lib/rubocop/cop/mixin/statement_modifier.rb
@@ -30,7 +30,7 @@ module RuboCop
       end
 
       def max_line_length
-        cop_config && cop_config['MaxLineLength'] ||
+        cop_config['MaxLineLength'] ||
           config.for_cop('Metrics/LineLength')['Max']
       end
 

--- a/lib/rubocop/formatter/base_formatter.rb
+++ b/lib/rubocop/formatter/base_formatter.rb
@@ -1,6 +1,6 @@
 # encoding: utf-8
 
-# rubocop:disable Metrics/LineLength, Lint/UnusedMethodArgument
+# rubocop:disable Metrics/LineLength
 
 module RuboCop
   module Formatter

--- a/spec/rubocop/cop/lint/unused_block_argument_spec.rb
+++ b/spec/rubocop/cop/lint/unused_block_argument_spec.rb
@@ -113,7 +113,7 @@ describe RuboCop::Cop::Lint::UnusedBlockArgument, :config do
         end
       end
 
-      context 'and an arguments is unused' do
+      context 'and an argument is unused' do
         let(:source) { <<-END }
           -> (foo, bar) { puts bar }
         END

--- a/spec/rubocop/cop/lint/unused_block_argument_spec.rb
+++ b/spec/rubocop/cop/lint/unused_block_argument_spec.rb
@@ -2,7 +2,7 @@
 
 require 'spec_helper'
 
-describe RuboCop::Cop::Lint::UnusedBlockArgument do
+describe RuboCop::Cop::Lint::UnusedBlockArgument, :config do
   subject(:cop) { described_class.new }
 
   context 'inspection' do
@@ -270,6 +270,31 @@ describe RuboCop::Cop::Lint::UnusedBlockArgument do
       SOURCE
 
       expect(autocorrect_source(cop, original_source)).to eq(original_source)
+    end
+  end
+
+  context 'when IgnoreEmptyBlocks config parameter is set' do
+    subject(:cop) { described_class.new(config) }
+    let(:cop_config) { { 'IgnoreEmptyBlocks' => true } }
+
+    it 'accepts an empty block with a single unused parameter' do
+      inspect_source(cop, '->(arg) { }')
+      expect(cop.offenses).to be_empty
+    end
+
+    it 'registers an offense for a non-empty block with an unused parameter' do
+      inspect_source(cop, '->(arg) { 1 }')
+      expect(cop.offenses.size).to eq 1
+    end
+
+    it 'accepts an empty block with multiple unused parameters' do
+      inspect_source(cop, '->(arg1, arg2, *others) { }')
+      expect(cop.offenses).to be_empty
+    end
+
+    it 'registers an offense for a non-empty block with multiple unused args' do
+      inspect_source(cop, '->(arg1, arg2, *others) { 1 }')
+      expect(cop.offenses.size).to eq 3
     end
   end
 end

--- a/spec/rubocop/cop/lint/unused_method_argument_spec.rb
+++ b/spec/rubocop/cop/lint/unused_method_argument_spec.rb
@@ -4,7 +4,9 @@ require 'spec_helper'
 
 describe RuboCop::Cop::Lint::UnusedMethodArgument, :config do
   subject(:cop) { described_class.new(config) }
-  let(:cop_config) { { 'AllowUnusedKeywordArguments' => false } }
+  let(:cop_config) do
+    { 'AllowUnusedKeywordArguments' => false, 'IgnoreEmptyMethods' => false }
+  end
 
   describe 'inspection' do
     before do
@@ -326,6 +328,38 @@ describe RuboCop::Cop::Lint::UnusedMethodArgument, :config do
       it 'ignores that since modifying the name changes the method interface' do
         expect(corrected_source).to eq(source)
       end
+    end
+  end
+
+  context 'when IgnoreEmptyMethods config parameter is set' do
+    let(:cop_config) { { 'IgnoreEmptyMethods' => true } }
+
+    it 'accepts an empty method with a single unused parameter' do
+      inspect_source(cop, ['def method(arg)',
+                           'end'])
+      expect(cop.offenses).to be_empty
+    end
+
+    it 'registers an offense for a non-empty method with a single unused ' \
+        'parameter' do
+      inspect_source(cop, ['def method(arg)',
+                           '  1',
+                           'end'])
+      expect(cop.offenses.size).to eq 1
+    end
+
+    it 'accepts an empty method with multiple unused parameters' do
+      inspect_source(cop, ['def method(a, b, *others)',
+                           'end'])
+      expect(cop.offenses).to be_empty
+    end
+
+    it 'registers an offense for a non-empty method with multiple unused ' \
+       'parameters' do
+      inspect_source(cop, ['def method(a, b, *others)',
+                           '  1',
+                           'end'])
+      expect(cop.offenses.size).to eq 3
     end
   end
 end

--- a/spec/rubocop/cop/style/and_or_spec.rb
+++ b/spec/rubocop/cop/style/and_or_spec.rb
@@ -192,12 +192,12 @@ describe RuboCop::Cop::Style::AndOr, :config do
       expect(new_source).to eq('obj.method(a,b) || b')
     end
 
-    it 'auto-corrects "or" with || and doesn\'t add extra parenthesis' do
+    it 'auto-corrects "or" with || and doesn\'t add extra parentheses' do
       new_source = autocorrect_source(cop, 'method(a, b) or b')
       expect(new_source).to eq('method(a, b) || b')
     end
 
-    it 'auto-corrects "or" with || and add parenthesis on left expr' do
+    it 'auto-corrects "or" with || and adds parentheses to expr' do
       new_source = autocorrect_source(cop, 'b or method a,b')
       expect(new_source).to eq('b || method(a,b)')
     end
@@ -222,12 +222,12 @@ describe RuboCop::Cop::Style::AndOr, :config do
       expect(new_source).to eq('obj.method(a,b) && b')
     end
 
-    it 'auto-corrects "and" with && and doesn\'t add extra parenthesis' do
+    it 'auto-corrects "and" with && and doesn\'t add extra parentheses' do
       new_source = autocorrect_source(cop, 'method(a, b) and b')
       expect(new_source).to eq('method(a, b) && b')
     end
 
-    it 'auto-corrects "and" with && and add parenthesis on left expr' do
+    it 'auto-corrects "and" with && and adds parentheses to expr' do
       new_source = autocorrect_source(cop, 'b and method a,b')
       expect(new_source).to eq('b && method(a,b)')
     end

--- a/spec/rubocop/cop/style/parentheses_around_condition_spec.rb
+++ b/spec/rubocop/cop/style/parentheses_around_condition_spec.rb
@@ -87,7 +87,7 @@ describe RuboCop::Cop::Style::ParenthesesAroundCondition, :config do
     expect(cop.offenses).to be_empty
   end
 
-  it 'is not confused by leading parenthesis in subexpression' do
+  it 'is not confused by leading parentheses in subexpression' do
     inspect_source(cop, '(a > b) && other ? one : two')
     expect(cop.offenses).to be_empty
   end


### PR DESCRIPTION
I also took the opportunity to do some cleanup at the same time:

- `cop_config` returns an empty `Hash` if there are no configuration parameters for a cop. This makes extra guard clauses unnecessary.
- Cop class and module have been merged into one. (Rationale is in the commit message.)
- Corrected pervasive misspelling of "parentheses".