### PR TITLE
Add $username to default /tmp folder path.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -61,6 +61,7 @@
 * [#1981](https://github.com/bbatsov/rubocop/issues/1981): `Lint/UselessAssignment` doesn't erroneously identify assignments in identical if branches as useless. ([@alexdowad][])
 * [#2323](https://github.com/bbatsov/rubocop/issues/2323): `Style/IfUnlessModifier` cop parenthesizes autocorrected code when necessary due to operator precedence, to avoid changing its meaning. ([@alexdowad][])
 * [#2003](https://github.com/bbatsov/rubocop/issues/2003): Make `Lint/UnneededDisable` work with `--auto-correct`. ([@jonas054][])
+* Default RuboCop cache dir moved to per-user folders. ([@br3nda][])
 
 ## 0.34.2 (21/09/2015)
 
@@ -1692,3 +1693,4 @@
 [@minustehbare]: https://github.com/minustehbare
 [@tansaku]: https://github.com/tansaku
 [@ptrippett]: https://github.com/ptrippett
+[@br3nda]: https://github.com/br3nda

--- a/lib/rubocop/result_cache.rb
+++ b/lib/rubocop/result_cache.rb
@@ -3,6 +3,7 @@
 require 'digest/md5'
 require 'find'
 require 'tmpdir'
+require 'etc'
 
 module RuboCop
   # Provides functionality for caching rubocop runs.
@@ -78,7 +79,7 @@ module RuboCop
 
     def self.cache_root(config_store)
       root = config_store.for('.')['AllCops']['CacheRootDirectory']
-      root = Dir.tmpdir if root == '/tmp'
+      root = File.join(Dir.tmpdir, Etc.getlogin) if root == '/tmp'
       File.join(root, 'rubocop_cache')
     end
 


### PR DESCRIPTION
Re-submit of https://github.com/bbatsov/rubocop/pull/2368

On multi user machines, whoever runs rubocop first owns /tmp/rubocop_cache
Other users often cannot write to that folder.

This adds the user's username into the default calculated cache directory.