### PR TITLE
Tweak rspec config

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -36,11 +36,13 @@ RSpec.configure do |config|
   config.filter_run_excluding broken: broken_filter
 
   config.expect_with :rspec do |expectations|
+    expectations.include_chain_clauses_in_custom_matcher_descriptions = true
     expectations.syntax = :expect # Disable `should`
   end
 
   config.mock_with :rspec do |mocks|
     mocks.syntax = :expect # Disable `should_receive` and `stub`
+    mocks.verify_partial_doubles = true
   end
 end
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -18,6 +18,7 @@ RSpec.configure do |config|
   config.run_all_when_everything_filtered = true
 
   config.order = :random
+  Kernel.srand config.seed
 
   config.filter_run_excluding ruby: ->(v) { !RUBY_VERSION.start_with?(v.to_s) }
 


### PR DESCRIPTION
I set up a new project recently and running `rspec init` produced a config file with some interesting settings. 

* `Kernel.srand config.seed` - Pass RSpec's random seed to the Kernel for more reproducible tests.
* `expectations.include_chain_clauses_in_custom_matcher_descriptions = true` - Sets if custom matcher descriptions and failure messages should include clauses from methods defined using chain
* `mocks.verify_partial_doubles = true` - the same argument and
method existence checks that are performed for object_double are also performed on partial doubles

Both `include_chain_clauses_in_custom_matcher_descriptions` and `verify_partial_doubles` are going to be defaulted to true in RSpec 4.