### PR TITLE
[Fix #2003] Let --auto-correct disable Lint/UnneededDisable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -58,6 +58,7 @@
 * [#2321](https://github.com/bbatsov/rubocop/issues/2321): In `Style/EachWithObject`, don't replace reduce with each_with_object if the accumulator parameter is assigned to in the block. ([@alexdowad][])
 * [#1981](https://github.com/bbatsov/rubocop/issues/1981): `Lint/UselessAssignment` doesn't erroneously identify assignments in identical if branches as useless. ([@alexdowad][])
 * [#2323](https://github.com/bbatsov/rubocop/issues/2323): `Style/IfUnlessModifier` cop parenthesizes autocorrected code when necessary due to operator precedence, to avoid changing its meaning. ([@alexdowad][])
+* [#2003](https://github.com/bbatsov/rubocop/issues/2003): Let `--auto-correct` disable `Lint/UnneededDisable`. ([@jonas054][])
 
 ## 0.34.2 (21/09/2015)
 

--- a/lib/rubocop/formatter/formatter_set.rb
+++ b/lib/rubocop/formatter/formatter_set.rb
@@ -41,7 +41,11 @@ module RuboCop
         if @cop_disabled_line_ranges.any? &&
            # Don't check unneeded disable if --only or --except option is
            # given, because these options override configuration.
-           (@options[:except] || []).empty? && (@options[:only] || []).empty?
+           (@options[:except] || []).empty? &&
+           (@options[:only] || []).empty? &&
+           # And not if --auto-correct is given, because line numbers might
+           # have changed and @cop_disabled_line_ranges can't be trusted.
+           !@options[:auto_correct]
           config = @config_store.for(file)
           if config['Lint/UnneededDisable']['Enabled']
             cop = Cop::Lint::UnneededDisable.new(config, @options)

--- a/spec/rubocop/cli_spec.rb
+++ b/spec/rubocop/cli_spec.rb
@@ -2374,6 +2374,26 @@ describe RuboCop::CLI, :isolated_environment do
                 ''].join("\n"))
     end
 
+    context 'when --auto-correct is given' do
+      it 'does not trigger UnneededDisable due to lines moving around' do
+        src = ['a = 1 # rubocop:disable Lint/UselessAssignment']
+        create_file('example.rb', src)
+        create_file('.rubocop.yml', ['Style/Encoding:',
+                                     '  Enabled: true'])
+        expect(cli.run(['--format', 'offenses', '-a', 'example.rb'])).to eq(0)
+        expect($stdout.string).to eq(['',
+                                      '1  Style/Encoding',
+                                      '--',
+                                      '1  Total',
+                                      '',
+                                      ''].join("\n"))
+        expect(IO.read('example.rb'))
+          .to eq(['# encoding: utf-8',
+                  'a = 1 # rubocop:disable Lint/UselessAssignment',
+                  ''].join("\n"))
+      end
+    end
+
     it 'can disable selected cops in a code section' do
       create_file('example.rb',
                   ['# encoding: utf-8',


### PR DESCRIPTION
The problem is this. When `Runner` calls `FormatterSet#file_started`, it gives the `cop_disabled_line_ranges` and it's stored in `FormatterSet`. Then `Runner` starts its inspection loop for the file and each time the file is updated (by `autocorrect`), a new `processed_source` object is created with new `cop_disabled_line_ranges`. But the reference in `FormatterSet` is still to the original line ranges.

One possible solution could be to try to update the `processed_source` object instead. That seems hard. This solution takes the easy way out, just disabling the `UnneededDisable` cop in this tricky situation.