### PR TITLE
Update wording for stdlib English module

### DIFF
--- a/lib/rubocop/cop/style/special_global_vars.rb
+++ b/lib/rubocop/cop/style/special_global_vars.rb
@@ -5,8 +5,10 @@ module RuboCop
     module Style
       # This cop looks for uses of Perl-style global variables.
       class SpecialGlobalVars < Cop
-        MSG_BOTH = 'Prefer `%s` from the English library, or `%s` over `%s`.'
-        MSG_ENGLISH = 'Prefer `%s` from the English library over `%s`.'
+        MSG_BOTH = 'Prefer `%s` from the stdlib \'English\' module, ' \
+        'or `%s` over `%s`.'
+        MSG_ENGLISH = 'Prefer `%s` from the stdlib \'English\' module ' \
+        'over `%s`.'
         MSG_REGULAR = 'Prefer `%s` over `%s`.'
 
         PREFERRED_VARS = {

--- a/spec/rubocop/cop/style/special_global_vars_spec.rb
+++ b/spec/rubocop/cop/style/special_global_vars_spec.rb
@@ -30,14 +30,15 @@ describe RuboCop::Cop::Style::SpecialGlobalVars do
     inspect_source(cop, 'puts $$')
     expect(cop.offenses.size).to eq(1)
     expect(cop.messages)
-      .to eq(['Prefer `$PROCESS_ID` or `$PID` from the English ' \
-              'library over `$$`.'])
+      .to eq(['Prefer `$PROCESS_ID` or `$PID` from the stdlib \'English\' ' \
+              'module over `$$`.'])
   end
 
   it 'is clear about variables from the English library vs those not' do
     inspect_source(cop, 'puts $*')
     expect(cop.messages)
-      .to eq(['Prefer `$ARGV` from the English library, or `ARGV` over `$*`.'])
+      .to eq(['Prefer `$ARGV` from the stdlib \'English\' module, ' \
+              'or `ARGV` over `$*`.'])
   end
 
   it 'does not register an offense for backrefs like $1' do


### PR DESCRIPTION
Make references to the [English module in stdlib](http://ruby-doc.org/stdlib-2.0.0/libdoc/English/rdoc/English.html) a bit more clear
In response to issue #2310 