### PR TITLE
[Fix #2003] Handle --auto-correct in Lint/UnneededDisable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -59,6 +59,7 @@
 * [#2321](https://github.com/bbatsov/rubocop/issues/2321): In `Style/EachWithObject`, don't replace reduce with each_with_object if the accumulator parameter is assigned to in the block. ([@alexdowad][])
 * [#1981](https://github.com/bbatsov/rubocop/issues/1981): `Lint/UselessAssignment` doesn't erroneously identify assignments in identical if branches as useless. ([@alexdowad][])
 * [#2323](https://github.com/bbatsov/rubocop/issues/2323): `Style/IfUnlessModifier` cop parenthesizes autocorrected code when necessary due to operator precedence, to avoid changing its meaning. ([@alexdowad][])
+* [#2003](https://github.com/bbatsov/rubocop/issues/2003): Make `Lint/UnneededDisable` work with `--auto-correct`. ([@jonas054][])
 
 ## 0.34.2 (21/09/2015)
 

--- a/spec/rubocop/cli_spec.rb
+++ b/spec/rubocop/cli_spec.rb
@@ -2374,6 +2374,26 @@ describe RuboCop::CLI, :isolated_environment do
                 ''].join("\n"))
     end
 
+    context 'when --auto-correct is given' do
+      it 'does not trigger UnneededDisable due to lines moving around' do
+        src = ['a = 1 # rubocop:disable Lint/UselessAssignment']
+        create_file('example.rb', src)
+        create_file('.rubocop.yml', ['Style/Encoding:',
+                                     '  Enabled: true'])
+        expect(cli.run(['--format', 'offenses', '-a', 'example.rb'])).to eq(0)
+        expect($stdout.string).to eq(['',
+                                      '1  Style/Encoding',
+                                      '--',
+                                      '1  Total',
+                                      '',
+                                      ''].join("\n"))
+        expect(IO.read('example.rb'))
+          .to eq(['# encoding: utf-8',
+                  'a = 1 # rubocop:disable Lint/UselessAssignment',
+                  ''].join("\n"))
+      end
+    end
+
     it 'can disable selected cops in a code section' do
       create_file('example.rb',
                   ['# encoding: utf-8',


### PR DESCRIPTION
The problem is this. When `Runner` calls `FormatterSet#file_started`, it gives the `cop_disabled_line_ranges` and `comments` and they are stored in `FormatterSet`. Then `Runner` starts its inspection loop for the file and each time the file is updated (by `autocorrect`), a new `processed_source` object is created with new `cop_disabled_line_ranges` and `comments`. But the references in `FormatterSet` are still to the original ranges and comments.

The solution is to send delegator objects to `file_started`. These delegators are updated each time the code is parsed again after correction, so that the disabled lines and comments that `Lint/UnneededDisable` uses are the latest, rather than the ones given before inspection started.

Supersedes and closes #2380.