### PR TITLE
[Fix #2344] When correcting parallel assignment, reorder lines to avoid breaking code

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -65,6 +65,7 @@
 * [#2003](https://github.com/bbatsov/rubocop/issues/2003): Make `Lint/UnneededDisable` work with `--auto-correct`. ([@jonas054][])
 * Default RuboCop cache dir moved to per-user folders. ([@br3nda][])
 * [#2393](https://github.com/bbatsov/rubocop/pull/2393): `Style/MethodCallParentheses` doesn't fail on `obj.method ||= func()`. ([@alexdowad][])
+* [#2344](https://github.com/bbatsov/rubocop/pull/2344): When autocorrecting, `Style/ParallelAssignment` reorders assignment statements, if necessary, to avoid breaking code. ([@alexdowad][])
 
 ## 0.34.2 (21/09/2015)
 


### PR DESCRIPTION
This is a first draft of a fix for #2344.

The part which I'm not happy with yet is:

```ruby
            find_symbol = lambda do |node, symbol|
              node.children.any? { |obj| obj.equal?(symbol) } ||
              node.each_child_node.any? { |child| find_symbol[child, symbol] }
            end
```

To determine whether an expression has a dependency on a certain variable, I'm just searching the AST to see if a symbol with the variable's name occurs anywhere. I would like this to be more robust.

In the `variable_force` code, I can see you already have logic for searching ASTs and building a table of where each variable is used. This is exactly what I need. But it seems hard to reuse that code -- there's no entry point where I can just call something like `node.references_variable?(var)`.

Do I have to make `Style/ParallelAssignment` part of the "variable force" to use that existing code?