### PR TITLE
Remove redundant 'rubocop' Rake task

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -37,8 +37,6 @@ rescue LoadError
   warn 'Coveralls rake task is not loaded. Only for test'
 end
 
-RuboCop::RakeTask.new
-
 task :console do
   require 'irb'
   require 'irb/completion'


### PR DESCRIPTION
We have 'rake internal_investigation' for that.