### PR TITLE
[Fix #2390] `Performance/StringReplacement` doesn't convert `gsub(/./, ...)` to `tr`

### DIFF
--- a/lib/rubocop/cop/performance/string_replacement.rb
+++ b/lib/rubocop/cop/performance/string_replacement.rb
@@ -20,7 +20,7 @@ module RuboCop
       #   'a b c'.delete(' ')
       class StringReplacement < Cop
         MSG = 'Use `%s` instead of `%s`.'
-        DETERMINISTIC_REGEX = /^[\w\s\-,."']+$/.freeze
+        DETERMINISTIC_REGEX = /^[\w\s\-,"']+$/.freeze
         REGEXP_CONSTRUCTOR_METHODS = [:new, :compile].freeze
         GSUB_METHODS = [:gsub, :gsub!].freeze
         DETERMINISTIC_TYPES = [:regexp, :str, :send].freeze

--- a/spec/rubocop/cop/performance/string_replacement_spec.rb
+++ b/spec/rubocop/cop/performance/string_replacement_spec.rb
@@ -244,6 +244,12 @@ describe RuboCop::Cop::Performance::StringReplacement do
       expect(cop.messages).to be_empty
     end
 
+    it 'allows regex containing a .' do
+      inspect_source(cop, %('abc'.gsub(/./, 'a')))
+
+      expect(cop.messages).to be_empty
+    end
+
     it 'allows regex containing a |' do
       inspect_source(cop, %('abc'.gsub(/a|b/, 'd')))
 


### PR DESCRIPTION
Fixes #2390.