### PR TITLE
ProcessedSource: use exception when .from_file raises

### DIFF
--- a/lib/rubocop/processed_source.rb
+++ b/lib/rubocop/processed_source.rb
@@ -15,8 +15,10 @@ module RuboCop
     def self.from_file(path)
       file = File.read(path)
       new(file, path)
-    rescue
+    rescue Errno::ENOENT
       abort("#{Rainbow('rubocop: No such file or directory').red} -- #{path}")
+    rescue => ex
+      abort("#{Rainbow("rubocop: #{ex.message}").red} -- #{path}")
     end
 
     def initialize(source, path = nil)


### PR DESCRIPTION
We ran into an issue recently where a file  was emitting an error from RuboCop about `No such file or directory` while the file actually did exist. While debugging, we eventually tracked down the actual cause of the error to the fact that the file had a very unusual encoding (UTF-32LE, which apparently couldn't be force-encoded to UTF-8), which caused an exception during parsing due to encoding incompatibilities.

The `rescue` clause here assumed that the only reason an exception would be raised was a missing file: in our case, that led to a very confusing & inaccurate error message that made debugging a bit harder than it had to be.

New behavior from this patch:

* Rescue `Errno::ENOENT` specifically for the missing file case to  maintain the existing error text.
* Rescue all other `StandardError` exceptions and abort, like before, but using the caught exception's `#message` so that the user-visible message reflects the originating message.

I've specced this behavior as well, but it's a little mock heavy & dependent on `ProcessedSource`'s implementation details in order to not change the actual code much. Not sure how useful you'll find that.

This is just trying to make the error handling more likely to produce useful output in unexpected error cases: it's not really a bugfix in any concrete sense.