### PR TITLE
Fix `Style/MethodCallParentheses` failed on or assign to instance vaiable's accessor

### DIFF
--- a/lib/rubocop/cop/style/method_call_parentheses.rb
+++ b/lib/rubocop/cop/style/method_call_parentheses.rb
@@ -38,7 +38,8 @@ module RuboCop
               asgn_node = mlhs_node.children[node.sibling_index]
             end
 
-            asgn_node.loc.name.source == method_name.to_s
+            asgn_node.loc.respond_to?(:name) &&
+              (asgn_node.loc.name.source == method_name.to_s)
           end
         end
       end


### PR DESCRIPTION
`Style/MethodCallParentheses` failed on following code.

```
@foo.bar ||= puts()
```

This is a backtrace log that reported with running `rubocop -d --only Style/MethodCallParentheses`.

```
$ rubocop --only Style/MethodCallParentheses sample.rb -d
Inspecting 1 file
Scanning /home/ozaki/dev/rubocop_sample/sample.rb
For /home/ozaki/dev/rubocop_sample: configuration from /home/ozaki/dev/rubocop_sample/.rubocop.yml
Default configuration from /home/ozaki/dev/rubocop_sample/vendor/bundle/ruby/2.1.0/gems/rubocop-0.34.2/config/default.yml
Inheriting configuration from /home/ozaki/dev/rubocop_sample/vendor/bundle/ruby/2.1.0/gems/rubocop-0.34.2/config/enabled.yml
Inheriting configuration from /home/ozaki/dev/rubocop_sample/vendor/bundle/ruby/2.1.0/gems/rubocop-0.34.2/config/disabled.yml
.

1 file inspected, no offenses detected
Finished in 0.04518964 seconds
```

I corrected `lib/rubocop/cop/style/method_call_parentheses.rb` to check the `asgn_node.loc` respond to `name`. 
(I wonder this is right way to fix this bug...)
