### PR TITLE
[Fix #2393] `Style/MethodCallParentheses` doesn't fail on `obj.method ||= func()`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -64,6 +64,7 @@
 * [#2323](https://github.com/bbatsov/rubocop/issues/2323): `Style/IfUnlessModifier` cop parenthesizes autocorrected code when necessary due to operator precedence, to avoid changing its meaning. ([@alexdowad][])
 * [#2003](https://github.com/bbatsov/rubocop/issues/2003): Make `Lint/UnneededDisable` work with `--auto-correct`. ([@jonas054][])
 * Default RuboCop cache dir moved to per-user folders. ([@br3nda][])
+* [#2393](https://github.com/bbatsov/rubocop/pull/2393): `Style/MethodCallParentheses` doesn't fail on `obj.method ||= func()`. ([@alexdowad][])
 
 ## 0.34.2 (21/09/2015)
 

--- a/lib/rubocop/cop/style/method_call_parentheses.rb
+++ b/lib/rubocop/cop/style/method_call_parentheses.rb
@@ -37,6 +37,14 @@ module RuboCop
               mlhs_node, _mrhs_node = *asgn_node
               asgn_node = mlhs_node.children[node.sibling_index]
             end
+            # `obj.method = value` parses as (send ... :method= ...), and will
+            # not be returned as an `asgn_node` here
+            # however, `obj.method ||= value` parses as (or-asgn (send ...) ...)
+            # which IS an `asgn_node`
+            if asgn_node.or_asgn_type? || asgn_node.and_asgn_type?
+              asgn_node, _value = *asgn_node
+              return false if asgn_node.send_type?
+            end
 
             asgn_node.loc.name.source == method_name.to_s
           end

--- a/spec/rubocop/cop/style/method_call_parentheses_spec.rb
+++ b/spec/rubocop/cop/style/method_call_parentheses_spec.rb
@@ -52,6 +52,16 @@ describe RuboCop::Cop::Style::MethodCallParentheses do
     end
   end
 
+  it 'registers an offense for `obj.method ||= func()`' do
+    inspect_source(cop, 'obj.method ||= func()')
+    expect(cop.offenses.size).to eq 1
+  end
+
+  it 'registers an offense for `obj.method &&= func()`' do
+    inspect_source(cop, 'obj.method &&= func()')
+    expect(cop.offenses.size).to eq 1
+  end
+
   it 'auto-corrects by removing unneeded braces' do
     new_source = autocorrect_source(cop, 'test()')
     expect(new_source).to eq('test')


### PR DESCRIPTION
Fixes #2393.