### PR TITLE
[Fix #1608] Add 'align_braces' style for Style/IndentHash

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@
 * [#2173](https://github.com/bbatsov/rubocop/issues/2173): `Style/AlignParameters` also checks parameter alignment for method definitions. ([@alexdowad][])
 * [#1825](https://github.com/bbatsov/rubocop/issues/1825): New `NameWhitelist` configuration parameter for `Style/PredicateName` can be used to suppress errors on known-good predicate names. ([@alexdowad][])
 * `Style/Documentation` recognizes 'Constant = Class.new' as a class definition. ([@alexdowad][])
+* [#1608](https://github.com/bbatsov/rubocop/issues/1608): Add new 'align_braces' style for `Style/IndentHash`. ([@alexdowad][])
 
 ### Bug Fixes
 

--- a/config/default.yml
+++ b/config/default.yml
@@ -494,6 +494,7 @@ Style/IndentHash:
   SupportedStyles:
     - special_inside_parentheses
     - consistent
+    - align_braces
 
 Style/LambdaCall:
   EnforcedStyle: call

--- a/lib/rubocop/cop/cop.rb
+++ b/lib/rubocop/cop/cop.rb
@@ -185,7 +185,8 @@ module RuboCop
       end
 
       def config_to_allow_offenses
-        Formatter::DisabledConfigFormatter.config_to_allow_offenses[cop_name]
+        Formatter::DisabledConfigFormatter
+          .config_to_allow_offenses[cop_name] ||= {}
       end
 
       def config_to_allow_offenses=(hash)

--- a/lib/rubocop/cop/mixin/configurable_enforced_style.rb
+++ b/lib/rubocop/cop/mixin/configurable_enforced_style.rb
@@ -12,14 +12,36 @@ module RuboCop
         style_detected(style)
       end
 
-      def style_detected(detected)
-        return if no_acceptable_style?
-        self.detected_style ||= detected.to_s
-        return unless detected_style != detected.to_s
-        conflicting_styles_detected
+      def unexpected_style_detected(unexpected)
+        style_detected(unexpected)
       end
 
-      alias unexpected_style_detected style_detected
+      def ambiguous_style_detected(*possibilities)
+        style_detected(possibilities)
+      end
+
+      def style_detected(detected)
+        # `detected` can be a single style, or an Array of possible styles
+        # (if there is more than one which matches the observed code)
+
+        return if no_acceptable_style?
+
+        if detected.is_a?(Array)
+          detected.map!(&:to_s)
+        else
+          detected = detected.to_s
+        end
+
+        if !detected_style # we haven't observed any specific style yet
+          self.detected_style = detected
+        elsif detected_style.is_a?(Array)
+          self.detected_style &= [*detected]
+        elsif detected.is_a?(Array)
+          no_acceptable_style! unless detected.include?(detected_style)
+        else
+          no_acceptable_style! unless detected_style == detected
+        end
+      end
 
       def no_acceptable_style?
         config_to_allow_offenses['Enabled'] == false
@@ -34,7 +56,19 @@ module RuboCop
       end
 
       def detected_style=(style)
-        config_to_allow_offenses[parameter_name] = style
+        if style.nil?
+          no_acceptable_style!
+        elsif style.is_a?(Array)
+          if style.empty?
+            no_acceptable_style!
+          elsif style.one?
+            config_to_allow_offenses[parameter_name] = style[0]
+          else
+            config_to_allow_offenses[parameter_name] = style
+          end
+        else
+          config_to_allow_offenses[parameter_name] = style
+        end
       end
 
       alias_method :conflicting_styles_detected, :no_acceptable_style!

--- a/lib/rubocop/cop/mixin/configurable_enforced_style.rb
+++ b/lib/rubocop/cop/mixin/configurable_enforced_style.rb
@@ -5,7 +5,8 @@ module RuboCop
     # Handles `EnforcedStyle` configuration parameters.
     module ConfigurableEnforcedStyle
       def unexpected_style_detected(style)
-        self.config_to_allow_offenses ||= { parameter_name => style.to_s }
+        return if config_to_allow_offenses['Enabled'] == false
+        config_to_allow_offenses[parameter_name] ||= style.to_s
         return unless config_to_allow_offenses['Enabled'] ||
                       config_to_allow_offenses[parameter_name] != style.to_s
         conflicting_styles_detected
@@ -18,7 +19,7 @@ module RuboCop
       def correct_style_detected
         # Enabled:true indicates, later when the opposite style is detected,
         # that the correct style is used somewhere.
-        self.config_to_allow_offenses ||= { 'Enabled' => true }
+        config_to_allow_offenses['Enabled'] ||= true
         conflicting_styles_detected if config_to_allow_offenses[parameter_name]
       end
 

--- a/lib/rubocop/cop/mixin/configurable_max.rb
+++ b/lib/rubocop/cop/mixin/configurable_max.rb
@@ -6,7 +6,7 @@ module RuboCop
     # appropriate value with --auto-gen-config.
     module ConfigurableMax
       def max=(value)
-        cfg = self.config_to_allow_offenses ||= {}
+        cfg = config_to_allow_offenses
         value = [cfg[parameter_name], value].max if cfg[parameter_name]
         cfg[parameter_name] = value
       end

--- a/lib/rubocop/formatter/disabled_config_formatter.rb
+++ b/lib/rubocop/formatter/disabled_config_formatter.rb
@@ -33,11 +33,11 @@ module RuboCop
 
       def file_finished(file, offenses)
         @cops_with_offenses ||= Hash.new(0)
-        @files_with_offences ||= {}
+        @files_with_offenses ||= {}
         offenses.each do |o|
           @cops_with_offenses[o.cop_name] += 1
-          @files_with_offences[o.cop_name] ||= []
-          @files_with_offences[o.cop_name] << file
+          @files_with_offenses[o.cop_name] ||= []
+          @files_with_offenses[o.cop_name] << file
         end
       end
 
@@ -92,7 +92,7 @@ module RuboCop
       def output_offending_files(output, cfg, cop_name)
         return unless cfg.empty?
 
-        offending_files = @files_with_offences[cop_name].uniq.sort
+        offending_files = @files_with_offenses[cop_name].uniq.sort
         if offending_files.count > @exclude_limit
           output.puts '  Enabled: false'
         else

--- a/lib/rubocop/formatter/disabled_config_formatter.rb
+++ b/lib/rubocop/formatter/disabled_config_formatter.rb
@@ -56,9 +56,7 @@ module RuboCop
           cfg = self.class.config_to_allow_offenses[cop_name]
           cfg ||= {}
           output_cop_comments(output, cfg, cop_name, offense_count)
-          output.puts "#{cop_name}:"
-          cfg.each { |key, value| output.puts "  #{key}: #{value}" }
-          output_offending_files(output, cfg, cop_name)
+          output_cop_config(output, cfg, cop_name)
         end
         puts "Created #{output.path}."
         puts "Run `rubocop --config #{output.path}`, or"
@@ -80,6 +78,15 @@ module RuboCop
         return if params.empty?
 
         output.puts "# Configuration parameters: #{params.join(', ')}."
+      end
+
+      def output_cop_config(output, cfg, cop_name)
+        output.puts "#{cop_name}:"
+        cfg.each do |key, value|
+          value = value[0] if value.is_a?(Array)
+          output.puts "  #{key}: #{value}"
+        end
+        output_offending_files(output, cfg, cop_name)
       end
 
       def output_offending_files(output, cfg, cop_name)

--- a/spec/rubocop/cli_spec.rb
+++ b/spec/rubocop/cli_spec.rb
@@ -2149,7 +2149,7 @@ describe RuboCop::CLI, :isolated_environment do
           .to eq('1 file inspected, no offenses detected' \
                  "\n")
       end
-      it 'succeeds when there is only a disabled offence' do
+      it 'succeeds when there is only a disabled offense' do
         create_file(target_file, ['# encoding: utf-8',
                                   'def f',
                                   ' x # rubocop:disable Style/IndentationWidth',

--- a/spec/rubocop/cop/lint/nested_method_definition_spec.rb
+++ b/spec/rubocop/cop/lint/nested_method_definition_spec.rb
@@ -21,14 +21,14 @@ describe RuboCop::Cop::Lint::NestedMethodDefinition do
     expect(cop.offenses.size).to eq(1)
   end
 
-  it 'registers an offence for a nested method definition inside lambda' do
+  it 'registers an offense for a nested method definition inside lambda' do
     inspect_source(cop, ['def foo',
                          '  bar = -> { def baz; puts; end }',
                          'end'])
     expect(cop.offenses.size).to eq(1)
   end
 
-  it 'does not register an offence for a lambda definition inside method' do
+  it 'does not register an offense for a lambda definition inside method' do
     inspect_source(cop, ['def foo',
                          '  bar = -> { puts  }',
                          '  bar.call',

--- a/spec/rubocop/cop/style/indent_hash_spec.rb
+++ b/spec/rubocop/cop/style/indent_hash_spec.rb
@@ -31,7 +31,7 @@ describe RuboCop::Cop::Style::IndentHash do
       expect(cop.messages)
         .to eq(['Indent the right brace the same as the start of the line ' \
                 'where the left brace is.'])
-      expect(cop.config_to_allow_offenses).to eq(nil)
+      expect(cop.config_to_allow_offenses).to be_empty
     end
   end
 

--- a/spec/rubocop/cop/style/indent_hash_spec.rb
+++ b/spec/rubocop/cop/style/indent_hash_spec.rb
@@ -6,7 +6,8 @@ describe RuboCop::Cop::Style::IndentHash do
   subject(:cop) { described_class.new(config) }
   let(:config) do
     supported_styles = {
-      'SupportedStyles' => %w(special_inside_parentheses consistent)
+      'SupportedStyles' => %w(special_inside_parentheses consistent
+                              align_braces)
     }
     RuboCop::Config.new('Style/AlignHash' => align_hash_config,
                         'Style/IndentHash' =>
@@ -239,7 +240,7 @@ describe RuboCop::Cop::Style::IndentHash do
           expect(cop.offenses).to be_empty
         end
 
-        it 'registers an offense for incorrect indentation' do
+        it "registers an offense for 'consistent' indentation" do
           inspect_source(cop,
                          ['func({',
                           '  a: 1',
@@ -247,11 +248,25 @@ describe RuboCop::Cop::Style::IndentHash do
           expect(cop.messages)
             .to eq(['Use 2 spaces for indentation in a hash, relative to the' \
                     ' first position after the preceding left parenthesis.',
-
                     'Indent the right brace the same as the first position ' \
                     'after the preceding left parenthesis.'])
           expect(cop.config_to_allow_offenses)
             .to eq('EnforcedStyle' => 'consistent')
+        end
+
+        it "registers an offense for 'align_braces' indentation" do
+          inspect_source(cop,
+                         ['var = {',
+                          '        a: 1',
+                          '      }'])
+          # since there are no parens, warning message is for 'consistent' style
+          expect(cop.messages)
+            .to eq(['Use 2 spaces for indentation in a hash, relative to the' \
+                    ' start of the line where the left curly brace is.',
+                    'Indent the right brace the same as the start of the ' \
+                    'line where the left brace is.'])
+          expect(cop.config_to_allow_offenses)
+            .to eq('EnforcedStyle' => 'align_braces')
         end
 
         it 'auto-corrects incorrectly indented first pair' do
@@ -319,7 +334,8 @@ describe RuboCop::Cop::Style::IndentHash do
                     'Indent the right brace the same as the start of the ' \
                     'line where the left brace is.'])
           expect(cop.config_to_allow_offenses)
-            .to eq('EnforcedStyle' => 'special_inside_parentheses')
+            .to eq('EnforcedStyle' => %w(special_inside_parentheses
+                                         align_braces))
         end
 
         it 'accepts normal indentation for second argument' do
@@ -362,6 +378,97 @@ describe RuboCop::Cop::Style::IndentHash do
         expect(cop.highlights).to eq(['a: 1'])
         expect(cop.config_to_allow_offenses).to eq('Enabled' => false)
       end
+    end
+  end
+
+  context 'when EnforcedStyle is align_braces' do
+    let(:cop_config) { { 'EnforcedStyle' => 'align_braces' } }
+
+    it 'accepts correctly indented first pair' do
+      inspect_source(cop,
+                     ['a = {',
+                      '      a: 1',
+                      '    }'])
+      expect(cop.offenses).to be_empty
+    end
+
+    it 'accepts several pairs per line' do
+      inspect_source(cop,
+                     ['a = {',
+                      '      a: 1, b: 2',
+                      '    }'])
+      expect(cop.offenses).to be_empty
+    end
+
+    it 'accepts a first pair on the same line as the left brace' do
+      inspect_source(cop,
+                     ['a = { "a" => 1,',
+                      '      "b" => 2 }'])
+      expect(cop.offenses).to be_empty
+    end
+
+    it 'accepts single line hash' do
+      inspect_source(cop,
+                     'a = { a: 1, b: 2 }')
+      expect(cop.offenses).to be_empty
+    end
+
+    it 'accepts an empty hash' do
+      inspect_source(cop,
+                     'a = {}')
+      expect(cop.offenses).to be_empty
+    end
+
+    context "when 'consistent' style is used" do
+      it 'registers an offense for incorrect indentation' do
+        inspect_source(cop,
+                       ['func({',
+                        '  a: 1',
+                        '})'])
+        expect(cop.messages)
+          .to eq(['Use 2 spaces for indentation in a hash, relative to the' \
+                  ' position of the opening brace.',
+                  'Indent the right brace the same as the left brace.'])
+        expect(cop.config_to_allow_offenses)
+          .to eq('EnforcedStyle' => 'consistent')
+      end
+
+      it 'auto-corrects incorrectly indented first pair' do
+        corrected = autocorrect_source(cop, ['var = {',
+                                             '  a: 1',
+                                             '}'])
+        expect(corrected).to eq ['var = {',
+                                 '        a: 1',
+                                 '      }'].join("\n")
+      end
+    end
+
+    context "when 'special_inside_parentheses' style is used" do
+      it 'registers an offense for incorrect indentation' do
+        inspect_source(cop,
+                       ['var = {',
+                        '  a: 1',
+                        '}',
+                        'func({',
+                        '       a: 1',
+                        '     })'])
+        expect(cop.messages)
+          .to eq(['Use 2 spaces for indentation in a hash, relative to the' \
+                  ' position of the opening brace.',
+                  'Indent the right brace the same as the left brace.'])
+        expect(cop.config_to_allow_offenses)
+          .to eq('EnforcedStyle' => 'special_inside_parentheses')
+      end
+    end
+
+    it 'registers an offense for incorrectly indented }' do
+      inspect_source(cop,
+                     ['a << {',
+                      '  }'])
+      expect(cop.highlights).to eq(['}'])
+      expect(cop.messages)
+        .to eq(['Indent the right brace the same as the left brace.'])
+      expect(cop.config_to_allow_offenses).to be_empty
     end
   end
 end

--- a/spec/rubocop/cop/style/symbol_literal_spec.rb
+++ b/spec/rubocop/cop/style/symbol_literal_spec.rb
@@ -5,7 +5,7 @@ require 'spec_helper'
 describe RuboCop::Cop::Style::SymbolLiteral do
   subject(:cop) { described_class.new }
 
-  it 'registers an offence for word-line symbols using string syntax' do
+  it 'registers an offense for word-line symbols using string syntax' do
     inspect_source(cop, 'x = { :"test" => 0 }')
     expect(cop.offenses.size).to eq(1)
   end

--- a/spec/rubocop/formatter/disabled_config_formatter_spec.rb
+++ b/spec/rubocop/formatter/disabled_config_formatter_spec.rb
@@ -50,7 +50,7 @@ module RuboCop
                     ''].join("\n"))
         end
 
-        it 'displays a file exclusion list up to a maximum of 15 offences' do
+        it 'displays a file exclusion list up to a maximum of 15 offenses' do
           exclusion_list = []
           file_list = []
 


### PR DESCRIPTION
'align_braces' style is like:

```ruby
  hash = {
           'key' => 'value',
           'another' => 'value'
         }
```

I personally don't like this style much, but I can see why some people would (as demonstrated by #1608), and think it is a reasonable choice and one which is good to support.

The (slightly) tricky part was getting `--auto-gen-config` to keep working robustly, now that `Style/IndentHash` has 3 styles rather than 2. This meant taking the previous work I did on `ConfigurableEnforcedStyle` a step further and fully generalizing it to deal with multiple, partially-overlapping styles.

Fixes #1608.