### PR TITLE
Refactor NodePattern::Compiler (using recursion rather than state machine and explicit stack)

### DIFF
--- a/spec/rubocop/node_pattern_spec.rb
+++ b/spec/rubocop/node_pattern_spec.rb
@@ -267,11 +267,6 @@ describe RuboCop::NodePattern do
         it_behaves_like :matching
       end
 
-      context 'containing a wildcard' do
-        let(:pattern) { '{1 _}' }
-        it_behaves_like :invalid
-      end
-
       context 'containing multiple []' do
         let(:pattern) { '{[(int odd?) int] [!nil float]}' }
 
@@ -302,11 +297,6 @@ describe RuboCop::NodePattern do
       let(:pattern) { '{(send int ...) (send const ...)}' }
       let(:ruby) { 'Const.method' }
       it_behaves_like :matching
-    end
-
-    context 'with a nested set' do
-      let(:pattern) { '{{1 2}}' }
-      it_behaves_like :invalid
     end
   end
 
@@ -439,6 +429,13 @@ describe RuboCop::NodePattern do
       let(:ruby) { '5 + 4' }
       let(:captured_vals) { [[s(:int, 5), :+], s(:int, 4)] }
       it_behaves_like :multiple_capture
+    end
+
+    context 'at the very beginning of a sequence' do
+      let(:pattern) { '($... (int 1))' }
+      let(:ruby) { '10 * 1' }
+      let(:captured_val) { [s(:int, 10), :*] }
+      it_behaves_like :single_capture
     end
   end
 
@@ -597,6 +594,12 @@ describe RuboCop::NodePattern do
       let(:ruby) { '[1,2].zip([3,4])' }
       it_behaves_like :nonmatching
     end
+
+    context 'at the very beginning of a sequence' do
+      let(:pattern) { '(... (int 1))' }
+      let(:ruby) { '10 * 1' }
+      it_behaves_like :matching
+    end
   end
 
   describe 'predicates' do
@@ -607,7 +610,8 @@ describe RuboCop::NodePattern do
     end
 
     context 'at head position of a sequence' do
-      let(:pattern) { '(send_type? int ...)' }
+      # called on the type symbol
+      let(:pattern) { '(!nil? int ...)' }
       let(:ruby) { '1.inc' }
       it_behaves_like :matching
     end
@@ -762,11 +766,6 @@ describe RuboCop::NodePattern do
       it_behaves_like :invalid
     end
 
-    context 'with double negation' do
-      let(:pattern) { '(send !!const)' }
-      it_behaves_like :invalid
-    end
-
     context 'with negated ellipsis' do
       let(:pattern) { '(send !...)' }
       it_behaves_like :invalid
@@ -774,16 +773,6 @@ describe RuboCop::NodePattern do
 
     context 'with doubled ellipsis' do
       let(:pattern) { '(send ... ...)' }
-      it_behaves_like :invalid
-    end
-
-    context 'with a wildcard inside []' do
-      let(:pattern) { '[_x _y]' }
-      it_behaves_like :invalid
-    end
-
-    context 'with a capture directly inside []' do
-      let(:pattern) { '[!nil $send]' }
       it_behaves_like :invalid
     end
   end


### PR DESCRIPTION
This makes the compiler code smaller, easier to understand, and faster (due to using the Ruby evaluation stack rather than an explicit software stack). It will be easier to modify and extend as well.

At the same time, I'd like to open some discussion about where we want this `NodePattern` code to go.

@bbatsov said earlier today:

> Now that we've used node patterns a bit I know that I like them a lot, but I hate dealing with multiline strings. Ideally we'd be able to represent them is some more structured manner.

I've been thinking about this. We could use Ruby arrays as S-expressions and represent them that way. That would mean losing out on the extra syntax like `{}` and `[]` and so on, which makes them signficantly more terse.

After looking at "pattern" code for a while, this kind of thing doesn't look bad to me:

```ruby
def_node_matcher, :predicate?, <<-END
  {(type1 (nested ...))
   (type2 [!x !y] ...)
   (type3 _ :symbol _)}
END
```

If the node pattern is very brief, and doesn't nest more than about 2 levels, just a single-line string looks good to my eyes. Otherwise, the << notation for multiline strings seems to help.

I was prompted to invent `NodePattern` after seeing how much repetitive AST destructure-and-check code is in RuboCop. The idea is to compress all this code down into something very terse, with all the "filler" compressed out and only the "meat" left. If you used to program primarily in C/C++/Java before learning Ruby, you know how empowering it can be to code in a language which compresses every 10 lines of code down to 2. Since there is so much less code on the page, you can understand it far more quickly. Just visually, as you scan down the page, the meaning of the code stands out so much more when not loaded with repetitive "filler". You can iterate faster and try more things. That is what I hope this will do for RuboCop.

At the same time:

- The pattern language should be simple enough that a new dev can learn it in a few minutes
- The compiler should be simple and fast
- The compiled code should also be fast
- It should be visually pleasing
- It should integrate well with the host language (Ruby)

A note on the last one. The `NodePattern` language is not Turing-complete, nor should it be. In many places, when processing ASTs, the full power of a general programming language is needed to implement some check. Rather than adding more and more features to `NodePattern` to increase its power, I would prefer to make the power of Ruby available where it is needed, without throwing out `NodePattern` and going back to tedious manual destructuring.

The only step I have taken in this direction is adding "predicates" to `NodePattern` -- you can use something like `assignment?` as a pattern, and it will call `assignment?` on the target node. As we extend `Node` with more custom predicates, this will make node patterns more and more powerful.

I feel something more is still needed, though. Question: should `NodePattern` have some syntax for inserting an arbitrary Ruby expression into a pattern? What would that look like? Or could the way that `NodePattern` is invoked be adjusted, to make it more flexible and better able to integrate with Ruby?

I'm also thinking of the following addition: `^` to move "up" a level and match against the target node's parent, `^^` to match against the grandparent, and so on. What do you think about this? Is the pattern language getting too complicated?