### PR TITLE
Add #assignment? and #asgn_method_call? to Node, use to make code more concise

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -67,6 +67,7 @@
 * Default RuboCop cache dir moved to per-user folders. ([@br3nda][])
 * [#2393](https://github.com/bbatsov/rubocop/pull/2393): `Style/MethodCallParentheses` doesn't fail on `obj.method ||= func()`. ([@alexdowad][])
 * [#2344](https://github.com/bbatsov/rubocop/pull/2344): When autocorrecting, `Style/ParallelAssignment` reorders assignment statements, if necessary, to avoid breaking code. ([@alexdowad][])
+* `Style/MultilineOperationAlignment` does not try to align the receiver and selector of a method call if both are on the LHS of an assignment. ([@alexdowad][])
 
 ## 0.34.2 (21/09/2015)
 

--- a/lib/rubocop.rb
+++ b/lib/rubocop.rb
@@ -15,8 +15,8 @@ require 'rubocop/version'
 
 require 'rubocop/path_util'
 require 'rubocop/string_util'
-require 'rubocop/ast_node'
 require 'rubocop/node_pattern'
+require 'rubocop/ast_node'
 
 require 'rubocop/cop/util'
 require 'rubocop/cop/offense'

--- a/lib/rubocop/ast_node.rb
+++ b/lib/rubocop/ast_node.rb
@@ -9,6 +9,24 @@ module Astrolabe
   # If any of it is accepted, it can be deleted from here
   #
   class Node
+    # def_matcher can be used to define a pattern-matching method on Node:
+    class << self
+      extend RuboCop::NodePattern::Macros
+      NODE_EIGENCLASS = self
+
+      # define both Node.method_name(node), and also node.method_name
+      def def_matcher(method_name, pattern_str)
+        NODE_EIGENCLASS.def_node_matcher method_name, pattern_str
+        class_eval("def #{method_name}; Node.#{method_name}(self); end")
+      end
+    end
+
+    ## Destructuring
+
+    def_matcher :method_name, '{(send _ $_ ...) (block (send _ $_ ...) ...)}'
+
+    ## Predicates
+
     def multiline?
       expr = loc.expression
       expr && (expr.first_line != expr.last_line)
@@ -17,5 +35,13 @@ module Astrolabe
     def single_line?
       !multiline?
     end
+
+    def asgn_method_call?
+      method_name != :== && method_name.to_s.end_with?('=')
+    end
+
+    def_matcher :equals_asgn?, '{lvasgn ivasgn cvasgn gvasgn casgn masgn}'
+    def_matcher :shorthand_asgn?, '{op_asgn or_asgn and_asgn}'
+    def_matcher :assignment?, '{equals_asgn? shorthand_asgn? asgn_method_call?}'
   end
 end

--- a/lib/rubocop/ast_node.rb
+++ b/lib/rubocop/ast_node.rb
@@ -12,11 +12,10 @@ module Astrolabe
     # def_matcher can be used to define a pattern-matching method on Node:
     class << self
       extend RuboCop::NodePattern::Macros
-      NODE_EIGENCLASS = self
 
       # define both Node.method_name(node), and also node.method_name
       def def_matcher(method_name, pattern_str)
-        NODE_EIGENCLASS.def_node_matcher method_name, pattern_str
+        singleton_class.def_node_matcher method_name, pattern_str
         class_eval("def #{method_name}; Node.#{method_name}(self); end")
       end
     end
@@ -24,6 +23,8 @@ module Astrolabe
     ## Destructuring
 
     def_matcher :method_name, '{(send _ $_ ...) (block (send _ $_ ...) ...)}'
+    # Note: for masgn, #asgn_rhs will be an array node
+    def_matcher :asgn_rhs, '[assignment? (... $_)]'
 
     ## Predicates
 

--- a/lib/rubocop/cop/lint/parentheses_as_grouped_expression.rb
+++ b/lib/rubocop/cop/lint/parentheses_as_grouped_expression.rb
@@ -14,7 +14,7 @@ module RuboCop
 
         def on_send(node)
           _receiver, method_name, args = *node
-          return if operator?(method_name) || method_name.to_s.end_with?('=')
+          return if operator?(method_name) || node.asgn_method_call?
           return unless args && args.loc.expression.source.start_with?('(')
 
           space_length = spaces_before_left_parenthesis(node)

--- a/lib/rubocop/cop/lint/space_before_first_arg.rb
+++ b/lib/rubocop/cop/lint/space_before_first_arg.rb
@@ -20,7 +20,7 @@ module RuboCop
           _receiver, method_name, *args = *node
           return if args.empty?
           return if operator?(method_name)
-          return if method_name.to_s.end_with?('=')
+          return if node.asgn_method_call?
 
           # Setter calls with parentheses are parsed this way. The parentheses
           # belong to the argument, not the send node.

--- a/lib/rubocop/cop/metrics/abc_size.rb
+++ b/lib/rubocop/cop/metrics/abc_size.rb
@@ -21,7 +21,7 @@ module RuboCop
           condition = 0
 
           node.each_node do |child|
-            if ASGN_NODES.include?(child.type)
+            if child.assignment?
               assignment += 1
             elsif BRANCH_NODES.include?(child.type)
               branch += 1

--- a/lib/rubocop/cop/mixin/check_assignment.rb
+++ b/lib/rubocop/cop/mixin/check_assignment.rb
@@ -23,13 +23,12 @@ module RuboCop
       end
 
       def on_send(node)
-        _receiver, method_name, *_, rhs = *node
-
         # we only want to indent relative to the receiver
         # when the method called looks like a setter
-        return unless method_name.to_s.end_with?('=')
+        return unless node.asgn_method_call?
 
         # This will match if, case, begin, blocks, etc.
+        rhs = node.children.last
         check_assignment(node, rhs) if rhs.is_a?(AST::Node)
       end
     end

--- a/lib/rubocop/cop/mixin/safe_assignment.rb
+++ b/lib/rubocop/cop/mixin/safe_assignment.rb
@@ -6,21 +6,10 @@ module RuboCop
     # putting parentheses around an assignment to indicate "I know I'm using an
     # assignment as a condition. It's not a mistake."
     module SafeAssignment
-      def safe_assignment?(node)
-        return false unless node.type == :begin
-        return false unless node.children.size == 1
+      extend NodePattern::Macros
 
-        child = node.children.first
-        case child.type
-        when :send
-          _receiver, method_name, _args = *child
-          method_name.to_s.end_with?('=')
-        when *Util::EQUALS_ASGN_NODES
-          true
-        else
-          false
-        end
-      end
+      def_node_matcher :safe_assignment?,
+                       '(begin {equals_asgn? asgn_method_call?})'
 
       def safe_assignment_allowed?
         cop_config['AllowSafeAssignment']

--- a/lib/rubocop/cop/style/and_or.rb
+++ b/lib/rubocop/cop/style/and_or.rb
@@ -67,7 +67,7 @@ module RuboCop
                 correct_send(expr, corrector)
               elsif expr.return_type?
                 correct_other(expr, corrector)
-              elsif ASGN_NODES.include?(expr.type)
+              elsif expr.assignment?
                 correct_other(expr, corrector)
               end
             end

--- a/lib/rubocop/cop/style/block_delimiters.rb
+++ b/lib/rubocop/cop/style/block_delimiters.rb
@@ -188,8 +188,7 @@ module RuboCop
           if node.parent.begin_type?
             return_value_used?(node.parent)
           else
-            Util::ASGN_NODES.include?(node.parent.type) ||
-              node.parent.send_type?
+            node.parent.assignment? || node.parent.send_type?
           end
         end
 

--- a/lib/rubocop/cop/style/braces_around_hash_parameters.rb
+++ b/lib/rubocop/cop/style/braces_around_hash_parameters.rb
@@ -15,7 +15,7 @@ module RuboCop
           _receiver, method_name, *args = *node
 
           # Discard attr writer methods.
-          return if method_name.to_s.end_with?('=')
+          return if node.asgn_method_call?
           # Discard operator methods.
           return if operator?(method_name)
 

--- a/lib/rubocop/cop/style/each_with_object.rb
+++ b/lib/rubocop/cop/style/each_with_object.rb
@@ -41,7 +41,7 @@ module RuboCop
           first_arg, = *args
           accumulator_var, = *first_arg
           return if body.each_descendant.any? do |n|
-            next unless ASGN_NODES.include?(n.type)
+            next unless n.assignment?
             lhs, _rhs = *n
             lhs.equal?(accumulator_var)
           end

--- a/lib/rubocop/cop/style/multiline_operation_indentation.rb
+++ b/lib/rubocop/cop/style/multiline_operation_indentation.rb
@@ -161,17 +161,7 @@ module RuboCop
         end
 
         def assignment?(node)
-          node.each_ancestor.find do |a|
-            case a.type
-            when :send
-              _receiver, method_name, *_args = *a
-              # The []= operator is the only assignment operator that is parsed
-              # as a :send node.
-              method_name == :[]=
-            when *ASGN_NODES
-              true
-            end
-          end
+          node.each_ancestor.find(&:assignment?)
         end
 
         def not_for_this_cop?(node)

--- a/lib/rubocop/cop/style/single_space_before_first_arg.rb
+++ b/lib/rubocop/cop/style/single_space_before_first_arg.rb
@@ -20,7 +20,7 @@ module RuboCop
           _receiver, method_name, *args = *node
           return if args.empty?
           return if operator?(method_name)
-          return if method_name.to_s.end_with?('=')
+          return if node.asgn_method_call?
 
           arg1 = args.first.loc.expression
           return if arg1.line > node.loc.line

--- a/spec/rubocop/cop/metrics/abc_size_spec.rb
+++ b/spec/rubocop/cop/metrics/abc_size_spec.rb
@@ -41,7 +41,7 @@ describe RuboCop::Cop::Metrics::AbcSize, :config do
                            'end'])
       expect(cop.messages)
         .to eq(['Assignment Branch Condition size for method_name is too ' \
-                'high. [2/0]'])
+                'high. [1.41/0]'])
       expect(cop.config_to_allow_offenses).to eq('Max' => 2)
     end
 

--- a/spec/rubocop/cop/style/multiline_operation_indentation_spec.rb
+++ b/spec/rubocop/cop/style/multiline_operation_indentation_spec.rb
@@ -168,6 +168,23 @@ describe RuboCop::Cop::Style::MultilineOperationIndentation do
       expect(cop.messages).to eq(['Use 2 (not 6) spaces for indenting an ' \
                                   'expression spanning multiple lines.'])
     end
+
+    it 'registers an offense for aligned code on LHS of assignment' do
+      inspect_source(cop, ['def config_to_allow_offenses',
+                           '  Formatter::DisabledConfigFormatter',
+                           '  .config_to_allow_offenses[cop_name] ||= {}',
+                           'end'])
+      expect(cop.messages).to eq(['Use 2 (not 0) spaces for indenting an ' \
+        'expression spanning multiple lines.'])
+    end
+
+    it 'registers an offense for a method call where the receiver and ' \
+       'selector are on different lines, without indentation' do
+      inspect_source(cop, ['Formatter::DisabledConfigFormatter',
+                           '.config_to_allow_offenses[cop_name] ||= {}'])
+      expect(cop.messages).to eq(['Use 2 (not 0) spaces for indenting an ' \
+        'expression spanning multiple lines.'])
+    end
   end
 
   context 'when EnforcedStyle is aligned' do


### PR DESCRIPTION
Leveraging `NodePattern` to do some refactoring here.

A test case for the ABC cop has been adjusted, because this code:

   x[0] = 1

...is now counted as an assignment and a method call, rather than 2 method calls.