### PR TITLE
fix bug when Etc.login is nil

### DIFF
--- a/lib/rubocop/result_cache.rb
+++ b/lib/rubocop/result_cache.rb
@@ -79,7 +79,7 @@ module RuboCop
 
     def self.cache_root(config_store)
       root = config_store.for('.')['AllCops']['CacheRootDirectory']
-      root = File.join(Dir.tmpdir, Etc.getlogin) if root == '/tmp'
+      root = File.join(Dir.tmpdir, Etc.getlogin || '') if root == '/tmp'
       File.join(root, 'rubocop_cache')
     end
 

--- a/spec/rubocop/result_cache_spec.rb
+++ b/spec/rubocop/result_cache_spec.rb
@@ -124,4 +124,22 @@ describe RuboCop::ResultCache, :isolated_environment do
         .to eq("Removing the 2 oldest files from #{cache_root}\n")
     end
   end
+
+  describe '.cache_root' do
+    subject { described_class.cache_root(config_store) }
+    before do
+      allow(config_store).to receive(:for).with('.') {
+        { 'AllCops' => { 'CacheRootDirectory' => '/tmp' } }
+      }
+    end
+    context 'Etc.getlogin is non-nil' do
+      before { expect(Etc).to receive(:getlogin) { 'foo' } }
+      it { is_expected.to eq '/tmp/foo/rubocop_cache' }
+    end
+
+    context 'Etc.getlogin is nil' do
+      before { expect(Etc).to receive(:getlogin) { nil } }
+      it { is_expected.to eq '/tmp/rubocop_cache' }
+    end
+  end
 end


### PR DESCRIPTION
`Etc.login` reads `$USER` env, but some container base CI run as root user,
so `Etc.login` returns `nil`, and `File.join('/tmp', nil)` will fail.