### PR TITLE
[Fix #2407] Use Etc.getpwuid.name to retrieve user login

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## master (unreleased)
 
+### Bug Fixes
+
+* [#2407](https://github.com/bbatsov/rubocop/issues/2407): Use `Process.uid` rather than `Etc.getlogin` for simplicity and compatibility. ([@jujugrrr][])
+
 ## 0.35.0 (07/11/2015)
 
 ### New features
@@ -1708,3 +1712,4 @@
 [@tansaku]: https://github.com/tansaku
 [@ptrippett]: https://github.com/ptrippett
 [@br3nda]: https://github.com/br3nda
+[@jujugrrr]: https://github.com/jujugrrr

--- a/lib/rubocop/result_cache.rb
+++ b/lib/rubocop/result_cache.rb
@@ -79,7 +79,7 @@ module RuboCop
 
     def self.cache_root(config_store)
       root = config_store.for('.')['AllCops']['CacheRootDirectory']
-      root = File.join(Dir.tmpdir, Etc.getlogin) if root == '/tmp'
+      root = File.join(Dir.tmpdir, Process.uid.to_s) if root == '/tmp'
       File.join(root, 'rubocop_cache')
     end
 

--- a/rubocop.gemspec
+++ b/rubocop.gemspec
@@ -43,6 +43,9 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency('powerpack', '~> 0.1')
   s.add_runtime_dependency('astrolabe', '~> 1.3')
   s.add_runtime_dependency('ruby-progressbar', '~> 1.7')
+  # Pinning tins due to 1.7.0 incompatibility with Ruby < 2.0
+  # https://github.com/flori/tins/blob/v1.7.0/tins.gemspec#L19
+  s.add_runtime_dependency('tins', '<= 1.6.0')
   s.add_development_dependency('rake', '~> 10.1')
   s.add_development_dependency('rspec', '~> 3.3.0')
   s.add_development_dependency('yard', '~> 0.8')

--- a/spec/rubocop/result_cache_spec.rb
+++ b/spec/rubocop/result_cache_spec.rb
@@ -125,3 +125,21 @@ describe RuboCop::ResultCache, :isolated_environment do
     end
   end
 end
+
+describe RuboCop::ResultCache, :isolated_environment do
+  let(:config_store) { double('config_store') }
+  let(:tmpdir) { Dir.tmpdir }
+  let(:puid) { Process.uid.to_s }
+
+  describe 'the cache path when using a temp directory' do
+    before do
+      allow(config_store).to receive(:for).with('.').and_return(
+        'AllCops' => { 'CacheRootDirectory' => '/tmp' }
+      )
+    end
+    it 'contains the process uid' do
+      cacheroot = RuboCop::ResultCache.cache_root(config_store)
+      expect(cacheroot).to eq(File.join(tmpdir, puid, 'rubocop_cache'))
+    end
+  end
+end


### PR DESCRIPTION
#2407.

Might be a better approach than #2406 as it keeps the "per login" cache feature.
I'll close when any of the 2 PR got merged.