### PR TITLE
Call :expression on node instead of :keyword loc

### DIFF
--- a/lib/rubocop/cop/mixin/code_length.rb
+++ b/lib/rubocop/cop/mixin/code_length.rb
@@ -18,7 +18,7 @@ module RuboCop
         length = code_length(node)
         return unless length > max_length
 
-        add_offense(node, :keyword, message(length, max_length)) do
+        add_offense(node, :expression, message(length, max_length)) do
           self.max = length
         end
       end

--- a/spec/rubocop/cop/metrics/class_length_spec.rb
+++ b/spec/rubocop/cop/metrics/class_length_spec.rb
@@ -20,6 +20,20 @@ describe RuboCop::Cop::Metrics::ClassLength, :config do
     expect(cop.config_to_allow_offenses).to eq('Max' => 6)
   end
 
+  it 'reports the correct beginning and end lines' do
+    inspect_source(cop, ['class Test',
+                         '  a = 1',
+                         '  a = 2',
+                         '  a = 3',
+                         '  a = 4',
+                         '  a = 5',
+                         '  a = 6',
+                         'end'])
+    offense = cop.offenses.first
+    expect(offense.location.first_line).to eq(1)
+    expect(offense.location.last_line).to eq(8)
+  end
+
   it 'accepts a class with 5 lines' do
     inspect_source(cop, ['class Test',
                          '  a = 1',

--- a/spec/rubocop/cop/metrics/method_length_spec.rb
+++ b/spec/rubocop/cop/metrics/method_length_spec.rb
@@ -20,6 +20,20 @@ describe RuboCop::Cop::Metrics::MethodLength, :config do
     expect(cop.config_to_allow_offenses).to eq('Max' => 6)
   end
 
+  it 'reports the correct beginning and end lines' do
+    inspect_source(cop, ['def m()',
+                         '  a = 1',
+                         '  a = 2',
+                         '  a = 3',
+                         '  a = 4',
+                         '  a = 5',
+                         '  a = 6',
+                         'end'])
+    offense = cop.offenses.first
+    expect(offense.location.first_line).to eq(1)
+    expect(offense.location.last_line).to eq(8)
+  end
+
   it 'accepts a method with less than 5 lines' do
     inspect_source(cop, ['def m()',
                          '  a = 1',

--- a/spec/rubocop/cop/metrics/module_length_spec.rb
+++ b/spec/rubocop/cop/metrics/module_length_spec.rb
@@ -20,6 +20,20 @@ describe RuboCop::Cop::Metrics::ModuleLength, :config do
     expect(cop.config_to_allow_offenses).to eq('Max' => 6)
   end
 
+  it 'reports the correct beginning and end lines' do
+    inspect_source(cop, ['module Test',
+                         '  a = 1',
+                         '  a = 2',
+                         '  a = 3',
+                         '  a = 4',
+                         '  a = 5',
+                         '  a = 6',
+                         'end'])
+    offense = cop.offenses.first
+    expect(offense.location.first_line).to eq(1)
+    expect(offense.location.last_line).to eq(8)
+  end
+
   it 'accepts a module with 5 lines' do
     inspect_source(cop, ['module Test',
                          '  a = 1',


### PR DESCRIPTION
This changes `RuboCop::Cop::CodeLength`s `check_code_length` method to
return `node.loc` instead of `:keyword`.

When `:keyword` is passed in it calls `node.loc.keyword` which returns
the keyword, eg: `class`, `def`, or `module` and only reports the line
with that keyword as the beginning and end lines.

This passes `:expression` instead which will return the entire block
instead of the defining line.