### PR TITLE
Silence the beast

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,5 +24,5 @@ install:
   - bundle install --retry=3
 script:
   - bundle exec rspec
-  - bundle exec rake coveralls:push
+  - "[[ `ruby -v` =~ ^jruby ]] || bundle exec rake coveralls:push"
   - bundle exec rubocop


### PR DESCRIPTION
Coveralls is incredibly noisy about "decreasing code coverage" on PRs.
From examining the results of some Coveralls runs, it seems that the coverage
stats for JRuby are quite inconsistent (even slighly random). Therefore,
do not send coverage data to Coveralls for JRuby.

Sure, they may whine and cry a bit. Too bad.

Another thing which might help:

![screenshot from 2015-11-10 23 13 54](https://cloud.githubusercontent.com/assets/1067359/11076079/7729b926-8801-11e5-8cb5-f6000b8dfe71.png)

@bbatsov: tweak your threshold up a bit!!