### PR TITLE
Make inherit_from override inherit_gem

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 ### Bug Fixes
 
 * [#2407](https://github.com/bbatsov/rubocop/issues/2407): Use `Process.uid` rather than `Etc.getlogin` for simplicity and compatibility. ([@jujugrrr][])
+* [#2411](https://github.com/bbatsov/rubocop/issues/2411): Make local inherited configuration override configuration loaded from gems. ([@jonas054][])
 
 ## 0.35.0 (07/11/2015)
 

--- a/README.md
+++ b/README.md
@@ -329,7 +329,6 @@ key and the relative path within the gem as the value:
 
 ```yaml
 inherit_gem:
-  rubocop: config/default.yml
   my-shared-gem: .rubocop.yml
   cucumber: conf/rubocop.yml
 ```

--- a/lib/rubocop/config_loader.rb
+++ b/lib/rubocop/config_loader.rb
@@ -175,7 +175,8 @@ module RuboCop
       def resolve_inheritance_from_gems(hash, gems)
         (gems || {}).each_pair do |gem_name, config_path|
           hash['inherit_from'] = Array(hash['inherit_from'])
-          hash['inherit_from'] << gem_config_path(gem_name, config_path)
+          # Put gem configuration first so local configuration overrides it.
+          hash['inherit_from'].unshift gem_config_path(gem_name, config_path)
         end
       end
 

--- a/spec/rubocop/config_loader_spec.rb
+++ b/spec/rubocop/config_loader_spec.rb
@@ -282,23 +282,31 @@ describe RuboCop::ConfigLoader do
         create_file('somegemname/config/rubocop.yml',
                     ['Metrics/MethodLength:',
                      '  Enabled: false',
-                     '  Max: 200'
+                     '  Max: 200',
+                     '  CountComments: false'
+                    ])
+        create_file('local.yml',
+                    ['Metrics/MethodLength:',
+                     '  CountComments: true'
                     ])
         create_file(file_path,
                     ['inherit_gem:',
                      '  somegemname: config/rubocop.yml',
+                     '',
+                     'inherit_from: local.yml',
                      '',
                      'Metrics/MethodLength:',
                      '  Enabled: true'
                     ])
       end
 
-      it 'returns values from the gem config' do
+      it 'returns values from the gem config with local overrides' do
         mock_spec = Struct.new(:gem_dir).new('somegemname')
         expect(Gem::Specification).to receive(:find_by_name)
           .at_least(:once).with('somegemname').and_return(mock_spec)
 
         expected = { 'Enabled' => true,        # overridden in .rubocop.yml
+                     'CountComments' => true,  # overridden in local.yml
                      'Max' => 200 }            # inherited from somegem
         expect(configuration_from_file['Metrics/MethodLength'].to_set)
           .to be_superset(expected.to_set)


### PR DESCRIPTION
The problem was discovered in #2411, but this change does not fix the problem reported there.

Make configuration loading work as described in the README regarding precedence of `.rubocop.yml`, `inherit_from`, and `inherit_gem`.

Remove `rubocop: config/default.yml` from the example in the README as it makes no sense. All configurations are based on the `default.yml` of the `rubocop` being run.

Cc: @jhansche