### PR TITLE
Allow `%Q` for dynamic strings with double quotes inside

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 ### Bug Fixes
 
 * [#2411](https://github.com/bbatsov/rubocop/issues/2411): Make local inherited configuration override configuration loaded from gems. ([@jonas054][])
+* [#2413](https://github.com/bbatsov/rubocop/issues/2413): Allow `%Q` for dynamic strings with double quotes inside them. ([@jonas054][])
 
 ## 0.35.1 (10/11/2015)
 

--- a/lib/rubocop/cop/style/unneeded_percent_q.rb
+++ b/lib/rubocop/cop/style/unneeded_percent_q.rb
@@ -37,13 +37,22 @@ module RuboCop
           if src.start_with?(PERCENT_Q) && src =~ STRING_INTERPOLATION_REGEXP
             return
           end
+          if src.start_with?(PERCENT_CAPITAL_Q) &&
+             src.include?(QUOTE) && src =~ STRING_INTERPOLATION_REGEXP
+            return
+          end
 
+          add_offense(node, :expression)
+        end
+
+        def message(node)
+          src = node.loc.expression.source
           extra = if src.start_with?(PERCENT_CAPITAL_Q)
                     DYNAMIC_MSG
                   else
                     EMPTY
                   end
-          add_offense(node, :expression, format(MSG, src[0, 2], extra))
+          format(MSG, src[0, 2], extra)
         end
 
         def autocorrect(node)

--- a/spec/rubocop/cop/style/unneeded_percent_q_spec.rb
+++ b/spec/rubocop/cop/style/unneeded_percent_q_spec.rb
@@ -107,7 +107,7 @@ describe RuboCop::Cop::Style::UnneededPercentQ do
     end
 
     it 'accepts a dynamic %Q string with double quotes' do
-      inspect_source(cop, '%Q("hi\#{4}")')
+      inspect_source(cop, '%Q("hi#{4}")')
 
       expect(cop.messages).to be_empty
     end


### PR DESCRIPTION
If the string is dynamic and has double quote characters inside it, then `%Q` is warranted. We had a spec example for this already, but it contained a backslash that shouldn't be there.