### PR TITLE
Allow shebanged files with non-snake-case names

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@
 * [#2411](https://github.com/bbatsov/rubocop/issues/2411): Make local inherited configuration override configuration loaded from gems. ([@jonas054][])
 * [#2413](https://github.com/bbatsov/rubocop/issues/2413): Allow `%Q` for dynamic strings with double quotes inside them. ([@jonas054][])
 
+### Changes
+
+* [#2427](https://github.com/bbatsov/rubocop/pull/2427): Allow non-snake-case file names (e.g. `some-random-script`) for Ruby scripts that have a shebang. ([@sometimesfood][])
+
 ## 0.35.1 (10/11/2015)
 
 ### Bug Fixes
@@ -1724,3 +1728,4 @@
 [@ptrippett]: https://github.com/ptrippett
 [@br3nda]: https://github.com/br3nda
 [@jujugrrr]: https://github.com/jujugrrr
+[@sometimesfood]: https://github.com/sometimesfood

--- a/lib/rubocop/cop/style/file_name.rb
+++ b/lib/rubocop/cop/style/file_name.rb
@@ -3,7 +3,9 @@
 module RuboCop
   module Cop
     module Style
-      # This cop makes sure that Ruby source files have snake_case names.
+      # This cop makes sure that Ruby source files have snake_case
+      # names. Ruby scripts (i.e. source files with a shebang in the
+      # first line) are ignored.
       class FileName < Cop
         MSG = 'Use snake_case for source file names.'
 
@@ -16,6 +18,9 @@ module RuboCop
           basename = File.basename(file_path).sub(/\.[^\.]+$/, '')
           return if snake_case?(basename)
 
+          first_line = processed_source.lines.first
+          return if shebang?(first_line)
+
           range = source_range(processed_source.buffer, 1, 0)
           add_offense(nil, range)
         end
@@ -24,6 +29,10 @@ module RuboCop
 
         def snake_case?(basename)
           basename.split('.').all? { |fragment| fragment =~ SNAKE_CASE }
+        end
+
+        def shebang?(line)
+          line.start_with?('#!')
         end
       end
     end

--- a/spec/rubocop/cop/style/file_name_spec.rb
+++ b/spec/rubocop/cop/style/file_name_spec.rb
@@ -70,6 +70,15 @@ describe RuboCop::Cop::Style::FileName do
     end
   end
 
+  context 'with non-snake-case file names with a shebang' do
+    let(:filename) { '/some/dir/test-case' }
+    let(:source) { ['#!/usr/bin/env ruby', 'print 1'] }
+
+    it 'does not report an offense' do
+      expect(cop.offenses).to be_empty
+    end
+  end
+
   context 'when the file is specified in AllCops/Include' do
     let(:includes) { ['**/Gemfile'] }
 


### PR DESCRIPTION
While rubocop's snake case filename policy is great for Ruby source files in general, snake case filenames should not be mandatory for Ruby scripts (i.e. source files that have a shebang).

This pull request changes the Style/FileName cop to allow non-snake-case file names (e.g. `some-random-script`) for Ruby scripts that have a shebang.