### PR TITLE
Add option to enforce filename checks, fixes #2431

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 * [#2416](https://github.com/bbatsov/rubocop/pull/2416): New cop `Style/ConditionalAssignment` checks for assignment of the same variable in all branches of conditionals and replaces them with a single assignment to the return of the conditional. ([@rrosenblum][])
 * [#2410](https://github.com/bbatsov/rubocop/pull/2410): New cop `Style/IndentAssignment` checks the indentation of the first line of the right-hand-side of a multi-line assignment. ([@panthomakos][])
+* [#2431](https://github.com/bbatsov/rubocop/issues/2431): Add `IgnoreExecutableScripts` option to `Style/FileName`. ([@sometimesfood][])
 
 ### Bug Fixes
 

--- a/config/default.yml
+++ b/config/default.yml
@@ -414,6 +414,11 @@ Style/FileName:
   # excludes here.
   Exclude: []
 
+  # With `IgnoreExecutableScripts` set to `true`, this cop does not
+  # report offending filenames for executable scripts (i.e. source
+  # files with a shebang in the first line).
+  IgnoreExecutableScripts: true
+
 Style/FirstParameterIndentation:
   EnforcedStyle: special_for_inner_method_call_in_parentheses
   SupportedStyles:

--- a/lib/rubocop/cop/style/file_name.rb
+++ b/lib/rubocop/cop/style/file_name.rb
@@ -19,7 +19,8 @@ module RuboCop
           return if snake_case?(basename)
 
           first_line = processed_source.lines.first
-          return if shebang?(first_line)
+          return if cop_config['IgnoreExecutableScripts'] &&
+                    shebang?(first_line)
 
           range = source_range(processed_source.buffer, 1, 0)
           add_offense(nil, range)

--- a/spec/rubocop/cop/style/file_name_spec.rb
+++ b/spec/rubocop/cop/style/file_name_spec.rb
@@ -7,10 +7,12 @@ describe RuboCop::Cop::Style::FileName do
 
   let(:config) do
     RuboCop::Config.new(
-      { 'AllCops' => { 'Include' => includes } },
+      { 'AllCops' => { 'Include' => includes },
+        'Style/FileName' => cop_config },
       '/some/.rubocop.yml'
     )
   end
+  let(:cop_config) { { 'IgnoreExecutableScripts' => true } }
 
   let(:includes) { [] }
   let(:source) { ['print 1'] }
@@ -76,6 +78,14 @@ describe RuboCop::Cop::Style::FileName do
 
     it 'does not report an offense' do
       expect(cop.offenses).to be_empty
+    end
+
+    context 'when IgnoreExecutableScripts is disabled' do
+      let(:cop_config) { { 'IgnoreExecutableScripts' => false } }
+
+      it 'reports an offense' do
+        expect(cop.offenses.size).to eq(1)
+      end
     end
   end
 


### PR DESCRIPTION
This commit adds an option named `ForceScriptChecks` to the `Style/FileName` cop. When set to `true`, filename checks are forced for all Ruby source files. The default behaviour is not to enforce filename conventions for Ruby scripts that have a shebang.

@bbatsov: I'm not happy with the current name of the config option; any ideas for a better name?