### PR TITLE
Next can auto-correct nested offenses

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 * [#2411](https://github.com/bbatsov/rubocop/issues/2411): Make local inherited configuration override configuration loaded from gems. ([@jonas054][])
 * [#2413](https://github.com/bbatsov/rubocop/issues/2413): Allow `%Q` for dynamic strings with double quotes inside them. ([@jonas054][])
 * [#2404](https://github.com/bbatsov/rubocop/issues/2404): `Style/Next` does not remove comments when auto-correcting. ([@lumeet][])
+* `Style/Next` handles auto-correction of nested offenses. ([@lumeet][])
 
 ### Changes
 

--- a/lib/rubocop/cop/style/next.rb
+++ b/lib/rubocop/cop/style/next.rb
@@ -106,19 +106,25 @@ module RuboCop
             next_code = 'next ' << opposite_kw << ' ' <<
                         cond.loc.expression.source
             corrector.insert_before(node.loc.expression, next_code)
-            corrector.replace(node.loc.expression,
-                              body_range(node, cond).source)
+            corrector.remove(cond_range(node, cond))
+            corrector.remove(end_range(node))
           end
         end
 
-        def body_range(node, cond)
+        def cond_range(node, cond)
+          Parser::Source::Range.new(node.loc.expression.source_buffer,
+                                    node.loc.expression.begin_pos,
+                                    cond.loc.expression.end_pos)
+        end
+
+        def end_range(node)
           source_buffer = node.loc.expression.source_buffer
-          end_pos = node.loc.end.begin_pos - node.loc.end.column
-          end_pos -= 1 if end_followed_by_whitespace_only?(source_buffer,
-                                                           node.loc.end.end_pos)
-          Parser::Source::Range.new(source_buffer,
-                                    cond.loc.expression.end_pos,
-                                    end_pos)
+          end_pos = node.loc.end.end_pos
+          begin_pos = node.loc.end.begin_pos - node.loc.expression.column
+          begin_pos -= 1 if end_followed_by_whitespace_only?(source_buffer,
+                                                             end_pos)
+
+          Parser::Source::Range.new(source_buffer, begin_pos, end_pos)
         end
 
         def end_followed_by_whitespace_only?(source_buffer, end_pos)

--- a/spec/rubocop/cop/style/next_spec.rb
+++ b/spec/rubocop/cop/style/next_spec.rb
@@ -325,6 +325,26 @@ describe RuboCop::Cop::Style::Next, :config do
                               'end'].join("\n"))
   end
 
+  it 'handles nested autocorrections' do
+    new_source = autocorrect_source(cop, ['loop do',
+                                          '  if test',
+                                          '    loop do',
+                                          '      if test',
+                                          '        something',
+                                          '      end',
+                                          '    end',
+                                          '  end',
+                                          'end'])
+    expect(new_source).to eq(['loop do',
+                              '  next unless test',
+                              '    loop do', # another cop can fix indentation
+                              '      next unless test',
+                              # another cop can fix indentation
+                              '        something',
+                              '    end',
+                              'end'].join("\n"))
+  end
+
   it_behaves_like 'iterators', 'if'
   it_behaves_like 'iterators', 'unless'
 


### PR DESCRIPTION
Previous auto-correction strategies could not handle nested offenses
but caused a `spans more than one line`-error. The bug was present
even before #2429, so a new changelog entry has been added.