### PR TITLE
Fix ProgressFormatter not respecting `--no-color`.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 * [#2404](https://github.com/bbatsov/rubocop/issues/2404): `Style/Next` does not remove comments when auto-correcting. ([@lumeet][])
 * `Style/Next` handles auto-correction of nested offenses. ([@lumeet][])
 * `Style/VariableInterpolation` now detects non-numeric regex back references. ([@cgriego][])
+* `ProgressFormatter` fully respects the `--no-color` switch. ([@savef][])
 
 ### Changes
 
@@ -1736,3 +1737,4 @@
 [@jujugrrr]: https://github.com/jujugrrr
 [@sometimesfood]: https://github.com/sometimesfood
 [@cgriego]: https://github.com/cgriego
+[@savef]: https://github.com/savef

--- a/lib/rubocop/formatter/progress_formatter.rb
+++ b/lib/rubocop/formatter/progress_formatter.rb
@@ -13,7 +13,7 @@ module RuboCop
 
       def initialize(output)
         super
-        @dot = @output.tty? ? GREEN_DOT : DOT
+        @dot = (@output.tty? && Rainbow.enabled) ? GREEN_DOT : DOT
       end
 
       def started(target_files)


### PR DESCRIPTION
The coloured dots appear in the output even when the CLI switch to not use colour has been passed. At the point when the formatter is initialised `Rainbow.enabled` has been disabled globally if we want no colour so we can check this too before opting for the `GREEN_DOT`.