### PR TITLE
Replace `Time.zone.current` with `Time.current` on Rails::TimeZone message

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
 * `Style/Next` handles auto-correction of nested offenses. ([@lumeet][])
 * `Style/VariableInterpolation` now detects non-numeric regex back references. ([@cgriego][])
 * `ProgressFormatter` fully respects the `--no-color` switch. ([@savef][])
+* Replace `Time.zone.current` with `Time.current` on `Rails::TimeZone` cop message. ([@volmer][])
 
 ### Changes
 
@@ -1738,3 +1739,4 @@
 [@sometimesfood]: https://github.com/sometimesfood
 [@cgriego]: https://github.com/cgriego
 [@savef]: https://github.com/savef
+[@volmer]: https://github.com/volmer

--- a/lib/rubocop/cop/rails/time_zone.rb
+++ b/lib/rubocop/cop/rails/time_zone.rb
@@ -43,7 +43,7 @@ module RuboCop
         DANGEROUS_METHODS = [:now, :local, :new, :strftime,
                              :parse, :at, :current]
 
-        ACCEPTED_METHODS = [:current, :in_time_zone, :utc, :getlocal,
+        ACCEPTED_METHODS = [:in_time_zone, :utc, :getlocal,
                             :iso8601, :jisx0301, :rfc3339,
                             :to_i, :to_f]
 
@@ -151,12 +151,13 @@ module RuboCop
         end
 
         def good_methods
-          style == :strict ? [:zone] : [:zone] + ACCEPTED_METHODS
+          style == :strict ? [:zone] : [:zone, :current] + ACCEPTED_METHODS
         end
 
         def acceptable_methods(klass, method_name, node)
           acceptable = [
-            "`Time.zone.#{safe_method(method_name, node)}`"
+            "`Time.zone.#{safe_method(method_name, node)}`",
+            "`#{klass}.current`"
           ]
 
           ACCEPTED_METHODS.each do |am|

--- a/spec/rubocop/cop/rails/time_zone_spec.rb
+++ b/spec/rubocop/cop/rails/time_zone_spec.rb
@@ -176,6 +176,7 @@ describe RuboCop::Cop::Rails::TimeZone, :config do
 
         expect(cop.offenses.first.message).to include('Use one of')
         expect(cop.offenses.first.message).to include('`Time.zone.now`')
+        expect(cop.offenses.first.message).to include("`#{klass}.current`")
 
         described_class::ACCEPTED_METHODS.each do |a_method|
           expect(cop.offenses.first.message)


### PR DESCRIPTION
The default message for the `flexible` style mentions `Time.zone.current` (e.g. "Do not use `Time.now` without zone. Use one of `Time.zone.now`, `Time.zone.current`, `Time.now.in_time_zone`,  `Time.now.utc`, `Time.now.getlocal`, `Time.now.iso8601`, `Time.now.jisx0301`, `Time.now.rfc3339`,  `Time.now.to_i`, `Time.now.to_f` instead.").

Calling `Time.zone.current` causes a `NoMethodError` since there's no `current` method on  `ActiveSupport::TimeZone`. Instead, the message should mention `Time.current`, which is probably the intended call that takes the time zone in account.

With this change the message would change to "Do not use `Time.now` without zone. Use one of `Time.zone.now`, `Time.current`, `Time.now.in_time_zone`, `Time.now.utc`, `Time.now.getlocal`, `Time.now.iso8601`, `Time.now.jisx0301`, `Time.now.rfc3339`, `Time.now.to_i`, `Time.now.to_f` instead."

```
[12] pry(main)> Time.now
=> 2015-11-26 16:51:59 -0500
[13] pry(main)> Time.zone.now
=> Thu, 26 Nov 2015 21:52:02 UTC +00:00
[14] pry(main)> Time.current
=> Thu, 26 Nov 2015 21:52:08 UTC +00:00
[15] pry(main)> Time.zone.current
NoMethodError: undefined method `current' for #<ActiveSupport::TimeZone:0x007f81a08e1380>
from (pry):15:in `<main>'
```