### PR TITLE
Handle back_refs in VariableInterpolation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 * [#2413](https://github.com/bbatsov/rubocop/issues/2413): Allow `%Q` for dynamic strings with double quotes inside them. ([@jonas054][])
 * [#2404](https://github.com/bbatsov/rubocop/issues/2404): `Style/Next` does not remove comments when auto-correcting. ([@lumeet][])
 * `Style/Next` handles auto-correction of nested offenses. ([@lumeet][])
+* `Style/VariableInterpolation` now detects non-numeric regex back references. ([@cgriego][])
 
 ### Changes
 
@@ -1734,3 +1735,4 @@
 [@br3nda]: https://github.com/br3nda
 [@jujugrrr]: https://github.com/jujugrrr
 [@sometimesfood]: https://github.com/sometimesfood
+[@cgriego]: https://github.com/cgriego

--- a/lib/rubocop/cop/style/variable_interpolation.rb
+++ b/lib/rubocop/cop/style/variable_interpolation.rb
@@ -5,6 +5,7 @@ module RuboCop
     module Style
       # This cop checks for variable interpolation (like "#@ivar").
       class VariableInterpolation < Cop
+        VAR_TYPES = [:ivar, :cvar, :gvar, :nth_ref, :back_ref]
         MSG = 'Replace interpolated variable `%s` with expression `#{%s}`.'
 
         def on_dstr(node)
@@ -35,7 +36,7 @@ module RuboCop
         end
 
         def var_nodes(nodes)
-          nodes.select { |n| [:ivar, :cvar, :gvar, :nth_ref].include?(n.type) }
+          nodes.select { |n| VAR_TYPES.include?(n.type) }
         end
       end
     end

--- a/spec/rubocop/cop/style/variable_interpolation_spec.rb
+++ b/spec/rubocop/cop/style/variable_interpolation_spec.rb
@@ -25,7 +25,7 @@ describe RuboCop::Cop::Style::VariableInterpolation do
               ' with expression `#{$test}`.'])
   end
 
-  it 'registers an offense for interpolated global variables in regexp' do
+  it 'registers an offense for interpolated global variables in backticks' do
     inspect_source(cop,
                    'puts `this is a #$test`')
     expect(cop.offenses.size).to eq(1)
@@ -35,13 +35,22 @@ describe RuboCop::Cop::Style::VariableInterpolation do
               ' with expression `#{$test}`.'])
   end
 
-  it 'registers an offense for interpolated regexp back references' do
+  it 'registers an offense for interpolated regexp nth back references' do
     inspect_source(cop,
                    'puts "this is a #$1"')
     expect(cop.offenses.size).to eq(1)
     expect(cop.highlights).to eq(['$1'])
     expect(cop.messages)
       .to eq(['Replace interpolated variable `$1` with expression `#{$1}`.'])
+  end
+
+  it 'registers an offense for interpolated regexp back references' do
+    inspect_source(cop,
+                   'puts "this is a #$+"')
+    expect(cop.offenses.size).to eq(1)
+    expect(cop.highlights).to eq(['$+'])
+    expect(cop.messages)
+      .to eq(['Replace interpolated variable `$+` with expression `#{$+}`.'])
   end
 
   it 'registers an offense for interpolated instance variables' do
@@ -65,7 +74,7 @@ describe RuboCop::Cop::Style::VariableInterpolation do
 
   it 'does not register an offense for variables in expressions' do
     inspect_source(cop,
-                   'puts "this is a #{@test} #{@@t} #{$t} #{$1}"')
+                   'puts "this is a #{@test} #{@@t} #{$t} #{$1} #{$+}"')
     expect(cop.offenses).to be_empty
   end
 


### PR DESCRIPTION
The Style/VariableInterpolation cop detected numeric back references
(nth_ref), but not others (back_ref) such as $~ $& $+ $` or $'.