### PR TITLE
Allow comments before an access modifier [fix #2463]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@
 * `ProgressFormatter` fully respects the `--no-color` switch. ([@savef][])
 * Replace `Time.zone.current` with `Time.current` on `Rails::TimeZone` cop message. ([@volmer][])
 * [#2451](https://github.com/bbatsov/rubocop/issues/2451): `Style/StabbyLambdaParentheses` does not treat method calls named `lambda` as lambdas. ([@domcleal][])
+* [#2463](https://github.com/bbatsov/rubocop/issues/2463): Allow comments before an access modifier. ([@codebeige][])
 
 ### Changes
 
@@ -1743,3 +1744,4 @@
 [@savef]: https://github.com/savef
 [@volmer]: https://github.com/volmer
 [@domcleal]: https://github.com/domcleal
+[@codebeige]: https://github.com/codebeige

--- a/lib/rubocop/cop/style/empty_lines_around_access_modifier.rb
+++ b/lib/rubocop/cop/style/empty_lines_around_access_modifier.rb
@@ -41,6 +41,12 @@ module RuboCop
 
         private
 
+        def previous_line_ignoring_comments(processed_source, send_line)
+          processed_source[0..send_line - 2].reverse.find do |line|
+            !comment_line?(line)
+          end
+        end
+
         def previous_line_empty?(previous_line)
           block_start?(previous_line.lstrip) ||
             class_def?(previous_line.lstrip) ||
@@ -53,7 +59,8 @@ module RuboCop
 
         def empty_lines_around?(node)
           send_line = node.loc.line
-          previous_line = processed_source[send_line - 2]
+          previous_line = previous_line_ignoring_comments(processed_source,
+                                                          send_line)
           next_line = processed_source[send_line]
 
           previous_line_empty?(previous_line) && next_line_empty?(next_line)

--- a/spec/rubocop/cop/style/empty_lines_around_access_modifier_spec.rb
+++ b/spec/rubocop/cop/style/empty_lines_around_access_modifier_spec.rb
@@ -32,6 +32,19 @@ describe RuboCop::Cop::Style::EmptyLinesAroundAccessModifier do
         .to eq(["Keep a blank line before and after `#{access_modifier}`."])
     end
 
+    it "ignores comment line before #{access_modifier}" do
+      inspect_source(cop,
+                     ['class Test',
+                      '  something',
+                      '',
+                      '  # This comment is fine',
+                      "  #{access_modifier}",
+                      '',
+                      '  def test; end',
+                      'end'])
+      expect(cop.offenses.size).to eq(0)
+    end
+
     it "ignores #{access_modifier} inside a method call" do
       inspect_source(cop,
                      ['class Test',


### PR DESCRIPTION
This should resolve issue #2463. Tested on `mri` and `jruby`. Did not succeed in installing a usable `rbx` with `rbenv` on OS X.