### PR TITLE
[Fix #2471] Style/MethodName can check methods defined in `def self.method`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@
 * Replace `Time.zone.current` with `Time.current` on `Rails::TimeZone` cop message. ([@volmer][])
 * [#2451](https://github.com/bbatsov/rubocop/issues/2451): `Style/StabbyLambdaParentheses` does not treat method calls named `lambda` as lambdas. ([@domcleal][])
 * [#2463](https://github.com/bbatsov/rubocop/issues/2463): Allow comments before an access modifier. ([@codebeige][])
+* [#2471](https://github.com/bbatsov/rubocop/issues/2471): `Style/MethodName` doesn't choke on methods which are defined inside methods. ([@alexdowad][])
 
 ### Changes
 

--- a/lib/rubocop/cop/mixin/configurable_naming.rb
+++ b/lib/rubocop/cop/mixin/configurable_naming.rb
@@ -31,6 +31,9 @@ module RuboCop
       # the method has the same name as a class defined in the class/module.
       def class_emitter_method?(node, name)
         return false unless node.defs_type?
+        # a class emitter method may be defined inside `def self.included`,
+        # `def self.extended`, etc.
+        node = node.parent while node.parent && node.parent.defs_type?
         return false unless node.parent
 
         node.parent.children.compact.any? do |c|

--- a/spec/rubocop/cop/style/method_name_spec.rb
+++ b/spec/rubocop/cop/style/method_name_spec.rb
@@ -56,6 +56,23 @@ describe RuboCop::Cop::Style::MethodName, :config do
                              'end'])
         expect(cop.offenses).to be_empty
       end
+
+      it "accepts class emitter method in a #{kind}, even when it is " \
+         'defined inside another method' do
+        inspect_source(cop, ['module DPN',
+                             '  module Flow',
+                             '    module BaseFlow',
+                             '      class Start',
+                             '      end',
+                             '      def self.included(base)',
+                             '        def base.Start(aws_env, *args)',
+                             '        end',
+                             '      end',
+                             '    end',
+                             '  end',
+                             'end'])
+        expect(cop.offenses.size).to eq(0)
+      end
     end
   end
 


### PR DESCRIPTION
Previously, it would fail with an exception.

It now accepts the following as a "class emitter method":

```ruby
    class A
    end
    def self.method(klass)
      def klass.A
      end
    end
```

This form is most likely to occur with `method` as an interpreter hook, such
as `included`, `extended`, and so on.