### PR TITLE
Allow interpolated Strings in %W() arrays

### DIFF
--- a/lib/rubocop/cop/style/unneeded_interpolation.rb
+++ b/lib/rubocop/cop/style/unneeded_interpolation.rb
@@ -16,6 +16,8 @@ module RuboCop
       #   # good if @var is already a String
       #   @var
       class UnneededInterpolation < Cop
+        include PercentLiteral
+
         MSG = 'Prefer `to_s` over string interpolation.'
 
         VARIABLE_INTERPOLATION_TYPES = [
@@ -32,7 +34,8 @@ module RuboCop
         def single_interpolation?(node)
           single_child?(node) &&
             interpolation?(node.children.first) &&
-            !implicit_concatenation?(node)
+            !implicit_concatenation?(node) &&
+            !embedded_in_percent_array?(node)
         end
 
         def single_variable_interpolation?(node)
@@ -53,6 +56,12 @@ module RuboCop
 
         def implicit_concatenation?(node)
           node.parent && node.parent.type == :dstr
+        end
+
+        def embedded_in_percent_array?(node)
+          node.parent &&
+            node.parent.type == :array &&
+            percent_literal?(node.parent)
         end
 
         def autocorrect(node)

--- a/spec/rubocop/cop/style/unneeded_interpolation_spec.rb
+++ b/spec/rubocop/cop/style/unneeded_interpolation_spec.rb
@@ -95,6 +95,12 @@ describe RuboCop::Cop::Style::UnneededInterpolation do
     expect(cop.highlights).to eq(['"#{var}"'])
   end
 
+  it 'registers an offense for ["#{@var}"]' do
+    inspect_source(cop, '["#{@var}", \'foo\']')
+    expect(cop.offenses.size).to eq(1)
+    expect(cop.highlights).to eq(['"#{@var}"'])
+  end
+
   it 'accepts strings with characters before the interpolation' do
     inspect_source(cop, '"this is #{@sparta}"')
     expect(cop.offenses).to be_empty
@@ -112,6 +118,11 @@ describe RuboCop::Cop::Style::UnneededInterpolation do
 
   it 'accepts strings implicitly concatenated with an earlier string' do
     inspect_source(cop, %q('this is ' "#{sparta}"))
+    expect(cop.offenses).to be_empty
+  end
+
+  it 'accepts strings that are part of a %W()' do
+    inspect_source(cop, '%W(#{@var} foo)')
     expect(cop.offenses).to be_empty
   end
 


### PR DESCRIPTION
Style/UnneededInterpolation would register an offense for `%W(#{@var} foo)`