### PR TITLE
[Fix #2449] Fix StabbyLambdaParentheses with lambda

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@
 * [#2451](https://github.com/bbatsov/rubocop/issues/2451): `Style/StabbyLambdaParentheses` does not treat method calls named `lambda` as lambdas. ([@domcleal][])
 * [#2463](https://github.com/bbatsov/rubocop/issues/2463): Allow comments before an access modifier. ([@codebeige][])
 * [#2471](https://github.com/bbatsov/rubocop/issues/2471): `Style/MethodName` doesn't choke on methods which are defined inside methods. ([@alexdowad][])
+* [#2449](https://github.com/bbatsov/rubocop/issues/2449): `Style/StabbyLambdaParentheses` only checks lambdas in the arrow form. ([@lumeet][])
 
 ### Changes
 

--- a/lib/rubocop/cop/style/stabby_lambda_parentheses.rb
+++ b/lib/rubocop/cop/style/stabby_lambda_parentheses.rb
@@ -20,11 +20,12 @@ module RuboCop
       class StabbyLambdaParentheses < Cop
         MSG_REQUIRE = 'Wrap stabby lambda arguments with parentheses.'
         MSG_NO_REQUIRE = 'Do not wrap stabby lambda arguments with parentheses.'
+        ARROW = '->'.freeze
 
         include ConfigurableEnforcedStyle
 
         def on_send(node)
-          return unless lambda_with_args?(node)
+          return unless arrow_lambda_with_args?(node)
 
           if style == :require_parentheses
             if parentheses?(node)
@@ -79,13 +80,17 @@ module RuboCop
           end
         end
 
-        def lambda_with_args?(node)
-          lambda_node?(node) && args?(node)
+        def arrow_lambda_with_args?(node)
+          lambda_node?(node) && arrow_form?(node) && args?(node)
         end
 
         def lambda_node?(node)
           receiver, call = *node
           receiver.nil? && call == :lambda
+        end
+
+        def arrow_form?(node)
+          node.loc.selector.source == ARROW
         end
 
         def node_args(node)

--- a/spec/rubocop/cop/style/stabby_lambda_parentheses_spec.rb
+++ b/spec/rubocop/cop/style/stabby_lambda_parentheses_spec.rb
@@ -4,8 +4,27 @@ require 'spec_helper'
 describe RuboCop::Cop::Style::StabbyLambdaParentheses, :config do
   subject(:cop) { described_class.new(config) }
 
+  shared_examples 'common' do
+    it 'does not check the old lambda syntax' do
+      inspect_source(cop, 'lambda(&:nil?)')
+      expect(cop.offenses).to be_empty
+    end
+
+    it 'does not check a stabby lambda without arguments' do
+      inspect_source(cop, '-> { true }')
+      expect(cop.offenses).to be_empty
+    end
+
+    it 'does not check a method call named lambda' do
+      inspect_source(cop, 'o.lambda')
+      expect(cop.offenses).to be_empty
+    end
+  end
+
   context 'require_parentheses' do
     let(:cop_config) { { 'EnforcedStyle' => 'require_parentheses' } }
+
+    it_behaves_like 'common'
 
     it 'registers an offense for a stabby lambda without parentheses' do
       inspect_source(cop, '->a,b,c { a + b + c }')
@@ -23,20 +42,12 @@ describe RuboCop::Cop::Style::StabbyLambdaParentheses, :config do
       corrected = autocorrect_source(cop, ['->a,b,c { a + b + c }'])
       expect(corrected).to eq '->(a,b,c) { a + b + c }'
     end
-
-    it 'does not check a stabby lambda without arguments' do
-      inspect_source(cop, '-> { true }')
-      expect(cop.offenses).to be_empty
-    end
-
-    it 'does not check a method call named lambda' do
-      inspect_source(cop, 'o.lambda')
-      expect(cop.offenses).to be_empty
-    end
   end
 
   context 'require_no_parentheses' do
     let(:cop_config) { { 'EnforcedStyle' => 'require_no_parentheses' } }
+
+    it_behaves_like 'common'
 
     it 'registers an offense for a stabby lambda with parentheses' do
       inspect_source(cop, '->(a,b,c) { a + b + c }')
@@ -48,11 +59,6 @@ describe RuboCop::Cop::Style::StabbyLambdaParentheses, :config do
     it 'autocorrects when a stabby lambda does not parentheses' do
       corrected = autocorrect_source(cop, ['->(a,b,c) { a + b + c }'])
       expect(corrected).to eq '->a,b,c { a + b + c }'
-    end
-
-    it 'does not check a stabby lambda without arguments' do
-      inspect_source(cop, '-> { true }')
-      expect(cop.offenses).to be_empty
     end
   end
 end


### PR DESCRIPTION
`Style/StabbyLambdaParentheses` does not check lambdas that use the
old `lambda` method.