### PR TITLE
Add option AllowHeredoc to Metrics/LineLength

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### New features
 
+* [#2479](https://github.com/bbatsov/rubocop/pull/2479): Add option `AllowHeredoc` to `Metrics/LineLength`. ([@fphilipe][])
 * [#2416](https://github.com/bbatsov/rubocop/pull/2416): New cop `Style/ConditionalAssignment` checks for assignment of the same variable in all branches of conditionals and replaces them with a single assignment to the return of the conditional. ([@rrosenblum][])
 * [#2410](https://github.com/bbatsov/rubocop/pull/2410): New cop `Style/IndentAssignment` checks the indentation of the first line of the right-hand-side of a multi-line assignment. ([@panthomakos][])
 * [#2431](https://github.com/bbatsov/rubocop/issues/2431): Add `IgnoreExecutableScripts` option to `Style/FileName`. ([@sometimesfood][])

--- a/config/default.yml
+++ b/config/default.yml
@@ -847,6 +847,7 @@ Metrics/LineLength:
   Max: 80
   # To make it possible to copy or click on URIs in the code, we allow lines
   # contaning a URI to be longer than Max.
+  AllowHeredoc: true
   AllowURI: true
   URISchemes:
     - http

--- a/spec/rubocop/cli_spec.rb
+++ b/spec/rubocop/cli_spec.rb
@@ -927,7 +927,8 @@ describe RuboCop::CLI, :isolated_environment do
         expect(cli.run(['--auto-gen-config'])).to eq(1)
         expect(IO.readlines('.rubocop_todo.yml')[8..-1].map(&:chomp))
           .to eq(['# Offense count: 1',
-                  '# Configuration parameters: AllowURI, URISchemes.',
+                  '# Configuration parameters: AllowHeredoc, AllowURI, ' \
+                  'URISchemes.',
                   '# URISchemes: http, https',
                   'Metrics/LineLength:',
                   '  Max: 85',
@@ -963,7 +964,8 @@ describe RuboCop::CLI, :isolated_environment do
         expect(cli.run(['--auto-gen-config'])).to eq(1)
         expect(IO.readlines('.rubocop_todo.yml')[8..-1].join)
           .to eq(['# Offense count: 1',
-                  '# Configuration parameters: AllowURI, URISchemes.',
+                  '# Configuration parameters: AllowHeredoc, AllowURI, ' \
+                  'URISchemes.',
                   '# URISchemes: http, https',
                   'Metrics/LineLength:',
                   '  Max: 81',
@@ -1019,7 +1021,7 @@ describe RuboCop::CLI, :isolated_environment do
            'again.',
            '',
            '# Offense count: 2',
-           '# Configuration parameters: AllowURI, URISchemes.',
+           '# Configuration parameters: AllowHeredoc, AllowURI, URISchemes.',
            '# URISchemes: http, https',
            'Metrics/LineLength:',
            '  Max: 90',
@@ -1109,7 +1111,7 @@ describe RuboCop::CLI, :isolated_environment do
            'again.',
            '',
            '# Offense count: 3',
-           '# Configuration parameters: AllowURI, URISchemes.',
+           '# Configuration parameters: AllowHeredoc, AllowURI, URISchemes.',
            '# URISchemes: http, https',
            'Metrics/LineLength:',
            '  Max: 90', # Offense occurs in 2 files, limit is 1, so no Exclude.

--- a/spec/rubocop/config_loader_spec.rb
+++ b/spec/rubocop/config_loader_spec.rb
@@ -195,6 +195,7 @@ describe RuboCop::ConfigLoader do
               'https://github.com/bbatsov/ruby-style-guide#80-character-limits',
               'Enabled' => true,
               'Max' => 77,
+              'AllowHeredoc' => true,
               'AllowURI' => true,
               'URISchemes' => %w(http https)
             },

--- a/spec/rubocop/options_spec.rb
+++ b/spec/rubocop/options_spec.rb
@@ -34,7 +34,6 @@ describe RuboCop::Options, :isolated_environment do
         rescue SystemExit # rubocop:disable Lint/HandleExceptions
         end
 
-        # rubocop:disable Metrics/LineLength
         expected_help = <<-END
 Usage: rubocop [options] [file1, file2, ...]
     -L, --list-target-files          List all files RuboCop will inspect.
@@ -94,7 +93,6 @@ Usage: rubocop [options] [file1, file2, ...]
     -s, --stdin                      Pipe source from STDIN.
                                      This is useful for editor integration.
         END
-        # rubocop:enable Metrics/LineLength
 
         expect($stdout.string).to eq(expected_help)
       end


### PR DESCRIPTION
This option can either be `true` or a list of heredoc delimiters. When set to `true`, long lines in all heredocs are allowed. When set to a list, long lines are only allowed in heredocs delimited by the specified delimiters.

Closes #1407

/cc @jfelchner