### PR TITLE
Set fuubar throttle and disable color based on CI flag 

### DIFF
--- a/lib/rubocop/formatter/fuubar_style_formatter.rb
+++ b/lib/rubocop/formatter/fuubar_style_formatter.rb
@@ -26,7 +26,8 @@ module RuboCop
           output: output,
           total: target_files.count,
           format: bar_format,
-          autostart: false
+          autostart: false,
+          throttle_rate: continuous_integration? ? 1.0 : nil
         )
         with_color { @progressbar.start }
       end
@@ -53,7 +54,7 @@ module RuboCop
       end
 
       def with_color
-        if rainbow.enabled
+        if rainbow.enabled && !continuous_integration?
           output.write colorize('', progressbar_color).chomp(RESET_SEQUENCE)
           yield
           output.write RESET_SEQUENCE
@@ -68,6 +69,14 @@ module RuboCop
         else
           :green
         end
+      end
+
+      private
+
+      def continuous_integration?
+        @continuous_integration ||= !(ENV['CI'].nil? ||
+                                      ENV['CI'] == '' ||
+                                      ENV['CI'] == 'false')
       end
     end
   end

--- a/spec/rubocop/formatter/fuubar_style_formatter_spec.rb
+++ b/spec/rubocop/formatter/fuubar_style_formatter_spec.rb
@@ -16,16 +16,19 @@ module RuboCop
     describe '#with_color' do
       around do |example|
         original_state = formatter.rainbow.enabled
+        original_flag = ENV['CI']
 
         begin
           example.run
         ensure
           formatter.rainbow.enabled = original_state
+          ENV['CI'] = original_flag
         end
       end
 
       context 'when color is enabled' do
         before do
+          ENV['CI'] = 'false'
           formatter.rainbow.enabled = true
         end
 
@@ -37,7 +40,20 @@ module RuboCop
 
       context 'when color is enabled' do
         before do
+          ENV['CI'] = 'false'
           formatter.rainbow.enabled = false
+        end
+
+        it 'outputs nothing' do
+          formatter.with_color { formatter.output.write 'foo' }
+          expect(output.string).to eq('foo')
+        end
+      end
+
+      context 'when CI flag is enabled' do
+        before do
+          ENV['CI'] = 'true'
+          formatter.rainbow.enabled = true
         end
 
         it 'outputs nothing' do


### PR DESCRIPTION
Fuubar uses this flag to enable proper output for CI providers like CircleCI: http://git.io/v0JZh

Without these changes I just get a blank output on Circle until Rubocop has finished running.