### PR TITLE
[Fix #2452] Style/TrailingComma and single-line hashes in method calls

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@
 * [#2464](https://github.com/bbatsov/rubocop/issues/2464): `Style/ParallelAssignment` understands aref and attribute assignments, and doesn't warn if they can't be correctly rearranged into a series of single assignments. ([@alexdowad][])
 * [#2482](https://github.com/bbatsov/rubocop/issues/2482): `Style/AndOr` doesn't raise an exception when trying to autocorrect `!variable or ...`. ([@alexdowad][])
 * [#2446](https://github.com/bbatsov/rubocop/issues/2446): `Style/Tab` doesn't register errors for leading tabs which occur inside a string literal (including heredoc). ([@alexdowad][])
+* [#2452](https://github.com/bbatsov/rubocop/issues/2452): `Style/TrailingComma` incorrectly categorizes single-line hashes in methods calls. ([@panthomakos][])
 
 ### Changes
 

--- a/lib/rubocop/cop/style/trailing_comma.rb
+++ b/lib/rubocop/cop/style/trailing_comma.rb
@@ -123,7 +123,16 @@ module RuboCop
         def multiline?(node)
           elements = if node.type == :send
                        _receiver, _method_name, *args = *node
-                       args.flat_map { |a| a.type == :hash ? a.children : a }
+                       args.flat_map do |a|
+                         # For each argument, if it is a multi-line hash,
+                         # then promote the hash elements to method arguments
+                         # for the purpose of determining multi-line-ness.
+                         if a.hash_type? && a.loc.first_line != a.loc.last_line
+                           a.children
+                         else
+                           a
+                         end
+                       end
                      else
                        node.children
                      end

--- a/spec/rubocop/cop/style/trailing_comma_spec.rb
+++ b/spec/rubocop/cop/style/trailing_comma_spec.rb
@@ -346,6 +346,16 @@ describe RuboCop::Cop::Style::TrailingComma, :config do
         expect(cop.offenses).to be_empty
       end
 
+      it 'accepts a trailing comma in a method call with single ' \
+         'line hashes' do
+        inspect_source(cop, ['some_method(',
+                             ' { a: 0, b: 1 },',
+                             ' { a: 1, b: 0 },',
+                             ')'])
+
+        expect(cop.offenses).to be_empty
+      end
+
       it 'accepts a multiline word array' do
         inspect_source(cop, ['ingredients = %w(',
                              '  sausage',
@@ -550,6 +560,16 @@ describe RuboCop::Cop::Style::TrailingComma, :config do
                              '              a: 0,',
                              '              b: 1,',
                              '           )'])
+        expect(cop.offenses).to be_empty
+      end
+
+      it 'accepts a trailing comma in a method call with single ' \
+         'line hashes' do
+        inspect_source(cop, ['some_method(',
+                             ' { a: 0, b: 1 },',
+                             ' { a: 1, b: 0 },',
+                             ')'])
+
         expect(cop.offenses).to be_empty
       end
 


### PR DESCRIPTION
@jonas054 

`Style/TrailingComma` always assumes that all the elements of a hash
count towards the arguments of a method call for the purposes of
determining if the method-call is multi-line.

This is a problem because each pair of consecutive arguments is checked
to determine if any arguments fall on the same line. Since all the
elements of a single-line hash always fall on the same line, this check
will always fail.

Visually it makes sense to consider a single-line hash as a single
argument in a method call.

Example:

```
method(
  { a: 1, b: 2 },
  { a: 2, b: 3 },
)
```

I have corrected this behavior by only counting the elements of a hash
if the hash itself is a multi-line hash.