### PR TITLE
fix attr cop implementation bbatsov/rubocop#2483

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@
 * [#2452](https://github.com/bbatsov/rubocop/issues/2452): `Style/TrailingComma` incorrectly categorizes single-line hashes in methods calls. ([@panthomakos][])
 * [#2441](https://github.com/bbatsov/rubocop/issues/2441): `Style/AlignParameters` doesn't crash if it finds nested offenses. ([@alexdowad][])
 * [#2436](https://github.com/bbatsov/rubocop/issues/2436): `Style/SpaceInsideHashLiteralBraces` doesn't mangle a hash literal which is not surrounded by curly braces, but has another hash literal which does as its first key. ([@alexdowad][])
+* [#2483](https://github.com/bbatsov/rubocop/issues/2483): `Style/Attr` differentiate between attr_accessor and attr_reader. ([@weh][])
 
 ### Changes
 
@@ -1756,3 +1757,4 @@
 [@volmer]: https://github.com/volmer
 [@domcleal]: https://github.com/domcleal
 [@codebeige]: https://github.com/codebeige
+[@weh]: https://github.com/weh

--- a/lib/rubocop/cop/style/attr.rb
+++ b/lib/rubocop/cop/style/attr.rb
@@ -5,16 +5,40 @@ module RuboCop
     module Style
       # This cop checks for uses of Module#attr.
       class Attr < Cop
-        MSG = 'Do not use `attr`. Use `attr_reader` instead.'
-
         def on_send(node)
           return unless command?(:attr, node)
           _receiver, _method_name, *args = *node
-          add_offense(node, :selector) if args.any?
+          msg = "Do not use `attr`. Use `#{replacement_method(node)}` instead."
+
+          add_offense(node, :selector, msg) if args.any?
         end
 
         def autocorrect(node)
-          ->(corrector) { corrector.replace(node.loc.selector, 'attr_reader') }
+          _receiver, _method_name, attr_name, setter = *node
+          node_expr = node.loc.expression
+          attr_expr = attr_name.loc.expression
+
+          if setter && (setter.true_type? || setter.false_type?)
+            remove = Parser::Source::Range.new(node_expr.source_buffer,
+                                               attr_expr.end_pos,
+                                               node_expr.end_pos)
+          end
+
+          lambda do |corrector|
+            corrector.replace(node.loc.selector, replacement_method(node))
+            corrector.replace(remove, '') if remove
+          end
+        end
+
+        private
+
+        def replacement_method(node)
+          _receiver, _method_name, _attr_name, setter = *node
+          if setter && (setter.true_type? || setter.false_type?)
+            setter.true_type? ? 'attr_accessor' : 'attr_reader'
+          else
+            'attr_reader'
+          end
         end
       end
     end

--- a/spec/rubocop/cop/style/attr_spec.rb
+++ b/spec/rubocop/cop/style/attr_spec.rb
@@ -22,8 +22,50 @@ describe RuboCop::Cop::Style::Attr do
     expect(cop.offenses).to be_empty
   end
 
-  it 'auto-corrects attr to attr_reader' do
-    new_source = autocorrect_source(cop, 'attr :name')
-    expect(new_source).to eq('attr_reader :name')
+  context 'auto-corrects' do
+    it 'attr to attr_reader' do
+      new_source = autocorrect_source(cop, 'attr :name')
+      expect(new_source).to eq('attr_reader :name')
+    end
+
+    it 'attr, false to attr_reader' do
+      new_source = autocorrect_source(cop, 'attr :name, false')
+      expect(new_source).to eq('attr_reader :name')
+    end
+
+    it 'attr :name, true to attr_accessor :name' do
+      new_source = autocorrect_source(cop, 'attr :name, true')
+      expect(new_source).to eq('attr_accessor :name')
+    end
+
+    it 'attr with multiple names to attr_reader' do
+      new_source = autocorrect_source(cop, 'attr :foo, :bar')
+      expect(new_source).to eq('attr_reader :foo, :bar')
+    end
+  end
+
+  context 'offense message' do
+    let(:msg_reader) { 'Do not use `attr`. Use `attr_reader` instead.' }
+    let(:msg_accessor) { 'Do not use `attr`. Use `attr_accessor` instead.' }
+
+    it 'for attr :name suggests to use attr_reader' do
+      inspect_source(cop, 'attr :name')
+      expect(cop.offenses.first.message).to eq(msg_reader)
+    end
+
+    it 'for attr :name, false suggests to use attr_reader' do
+      inspect_source(cop, 'attr :name, false')
+      expect(cop.offenses.first.message).to eq(msg_reader)
+    end
+
+    it 'for attr :name, true suggests to use attr_accessor' do
+      inspect_source(cop, 'attr :name, true')
+      expect(cop.offenses.first.message).to eq(msg_accessor)
+    end
+
+    it 'for attr with multiple names suggests to use attr_reader' do
+      inspect_source(cop, 'attr :foo, :bar')
+      expect(cop.offenses.first.message).to eq(msg_reader)
+    end
   end
 end


### PR DESCRIPTION
extend the attr cop implementation to respect the additional boolean param.
Fixes #2483 