### PR TITLE
Fix CharacterLiteral's auto-correct of single quotes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,6 +57,7 @@
 * [#2484](https://github.com/bbatsov/rubocop/issues/2484): Remove two vulnerabilities in cache handling. ([@jonas054][])
 * [#2517](https://github.com/bbatsov/rubocop/issues/2517): `Lint/UselessAccessModifier` doesn't think that an access modifier applied to `attr_writer` is useless. ([@alexdowad][])
 * [#2518](https://github.com/bbatsov/rubocop/issues/2518): `Style/ConditionalAssignment` doesn't think that branches using `<<` and `[]=` should be combined. ([@alexdowad][])
+* `CharacterLiteral` auto-corrector now properly corrects `?'`. ([@bfontaine][])
 
 ### Changes
 
@@ -1785,3 +1786,4 @@
 [@domcleal]: https://github.com/domcleal
 [@codebeige]: https://github.com/codebeige
 [@weh]: https://github.com/weh
+[@bfontaine]: https://github.com/bfontaine

--- a/lib/rubocop/cop/style/character_literal.rb
+++ b/lib/rubocop/cop/style/character_literal.rb
@@ -19,10 +19,12 @@ module RuboCop
           lambda do |corrector|
             string = node.source[1..-1]
 
-            if string.length == 1 # normal character
-              corrector.replace(node.loc.expression, "'#{string}'")
-            elsif string.length == 2 # special character like \n
+            # special character like \n
+            # or ' which needs to use "" or be escaped.
+            if string.length == 2 || string == "'"
               corrector.replace(node.loc.expression, %("#{string}"))
+            elsif string.length == 1 # normal character
+              corrector.replace(node.loc.expression, "'#{string}'")
             end
           end
         end

--- a/spec/rubocop/cop/style/character_literal_spec.rb
+++ b/spec/rubocop/cop/style/character_literal_spec.rb
@@ -34,4 +34,9 @@ describe RuboCop::Cop::Style::CharacterLiteral do
     new_source = autocorrect_source(cop, 'x = ?\n')
     expect(new_source).to eq('x = "\\n"')
   end
+
+  it 'auto-corrects ?\' to "\'"' do
+    new_source = autocorrect_source(cop, 'x = ?\'')
+    expect(new_source).to eq('x = "\'"')
+  end
 end


### PR DESCRIPTION
As shown in the test this fixes a case where `CharacterLiteral`’s auto-correct would break Ruby code when encountering `?'`, e.g.:

```rb
puts ?'
```

Without the fix in this PR this would be auto-corrected to:

```rb
puts '''
```

This leads to an “unterminated string” failure from Rubocop because it catches its own mistake:

```
Offenses:

example.rb:1:6: C: [Corrected] Do not use the character literal - use string literal instead.
puts ?'
     ^^
example.rb:1:8: F: unterminated string meets end of file
puts '''
       ^
```

Note: I wasn’t able to run the test suite due to an error similar to the one #683 fixed (I’m on OS X). I’m currently investigating to understand where’s the issue.