### PR TITLE
Ensure ResultCache.cache_root doesn't return symlinks

### DIFF
--- a/lib/rubocop/result_cache.rb
+++ b/lib/rubocop/result_cache.rb
@@ -93,7 +93,10 @@ module RuboCop
 
     def self.cache_root(config_store)
       root = config_store.for('.')['AllCops']['CacheRootDirectory']
-      root = File.join(Dir.tmpdir, Process.uid.to_s) if root == '/tmp'
+      if root == '/tmp'
+        tmpdir = File.realpath(Dir.tmpdir)
+        root = File.join(tmpdir, Process.uid.to_s)
+      end
       File.join(root, 'rubocop_cache')
     end
 

--- a/spec/rubocop/result_cache_spec.rb
+++ b/spec/rubocop/result_cache_spec.rb
@@ -177,7 +177,7 @@ end
 
 describe RuboCop::ResultCache, :isolated_environment do
   let(:config_store) { double('config_store') }
-  let(:tmpdir) { Dir.tmpdir }
+  let(:tmpdir) { File.realpath(Dir.tmpdir) }
   let(:puid) { Process.uid.to_s }
 
   describe 'the cache path when using a temp directory' do


### PR DESCRIPTION
On OS X the temp directory is under `/var/folder/...` but `/var` is a symlink to `/private/var` and that causes the symlink check in `Cache#save` to fail.

This is the same issue than #683 and caused the spec to fail on OS X.

I’m not sure what to write in the Changelog for this.