### PR TITLE
Unify node type checks across several cops

### DIFF
--- a/lib/rubocop/ast_node.rb
+++ b/lib/rubocop/ast_node.rb
@@ -11,6 +11,16 @@ module Astrolabe
   class Node
     COMPARISON_OPERATORS = [:==, :===, :!=, :<=, :>=, :>, :<, :<=>].freeze
 
+    TRUTHY_LITERALS = [:str, :dstr, :xstr, :int, :float, :sym, :dsym, :array,
+                       :hash, :regexp, :true, :irange, :erange].freeze
+    FALSEY_LITERALS = [:false, :nil].freeze
+    LITERALS = (TRUTHY_LITERALS + FALSEY_LITERALS).freeze
+    BASIC_LITERALS = LITERALS - [:dstr, :xstr, :dsym, :array, :hash, :irange,
+                                 :erange].freeze
+
+    VARIABLES = [:ivar, :gvar, :cvar, :lvar].freeze
+    REFERENCES = [:nth_ref, :back_ref].freeze
+
     # def_matcher can be used to define a pattern-matching method on Node:
     class << self
       extend RuboCop::NodePattern::Macros
@@ -53,6 +63,30 @@ module Astrolabe
     def_matcher :equals_asgn?, '{lvasgn ivasgn cvasgn gvasgn casgn masgn}'
     def_matcher :shorthand_asgn?, '{op_asgn or_asgn and_asgn}'
     def_matcher :assignment?, '{equals_asgn? shorthand_asgn? asgn_method_call?}'
+
+    def literal?
+      LITERALS.include?(type)
+    end
+
+    def basic_literal?
+      BASIC_LITERALS.include?(type)
+    end
+
+    def truthy_literal?
+      TRUTHY_LITERALS.include?(type)
+    end
+
+    def falsey_literal?
+      FALSEY_LITERALS.include?(type)
+    end
+
+    def variable?
+      VARIABLES.include?(type)
+    end
+
+    def reference?
+      REFERENCES.include?(type)
+    end
 
     # Some expressions are evaluated for their value, some for their side
     # effects, and some for both

--- a/lib/rubocop/cop/lint/literal_in_condition.rb
+++ b/lib/rubocop/cop/lint/literal_in_condition.rb
@@ -62,7 +62,7 @@ module RuboCop
           cond, = *node
 
           # if the cond node is literal we obviously have a problem
-          if literal?(cond)
+          if cond.literal?
             add_offense(cond, :expression)
           else
             # alternatively we have to consider a logical node with a
@@ -79,15 +79,11 @@ module RuboCop
           method_name == :!
         end
 
-        def literal?(node)
-          LITERALS.include?(node.type)
-        end
-
         def basic_literal?(node)
           if node && node.type == :array
             primitive_array?(node)
           else
-            BASIC_LITERALS.include?(node.type)
+            node.basic_literal?
           end
         end
 
@@ -114,7 +110,7 @@ module RuboCop
         end
 
         def handle_node(node)
-          if literal?(node)
+          if node.literal?
             add_offense(node, :expression)
           elsif [:send, :and, :or, :begin].include?(node.type)
             check_node(node)

--- a/lib/rubocop/cop/lint/literal_in_interpolation.rb
+++ b/lib/rubocop/cop/lint/literal_in_interpolation.rb
@@ -9,9 +9,6 @@ module RuboCop
       #
       #   "result is #{10}"
       class LiteralInInterpolation < Cop
-        LITERALS = [:str, :dstr, :int, :float, :array,
-                    :hash, :regexp, :nil, :true, :false]
-
         MSG = 'Literal interpolation detected.'
 
         def on_dstr(node)
@@ -19,7 +16,7 @@ module RuboCop
             final_node = begin_node.children.last
             next unless final_node
             next if special_keyword?(final_node)
-            next unless LITERALS.include?(final_node.type)
+            next unless final_node.literal?
 
             add_offense(final_node, :expression)
           end

--- a/lib/rubocop/cop/lint/useless_setter_call.rb
+++ b/lib/rubocop/cop/lint/useless_setter_call.rb
@@ -17,13 +17,6 @@ module RuboCop
 
         MSG = 'Useless setter call to local variable `%s`.'
         ASSIGNMENT_TYPES = [:lvasgn, :ivasgn, :cvasgn, :gvasgn].freeze
-        LITERAL_TYPES = [
-          :true, :false, :nil,
-          :int, :float,
-          :str, :dstr, :sym, :dsym, :xstr, :regexp,
-          :array, :hash,
-          :irange, :erange
-        ].freeze
 
         private
 
@@ -136,16 +129,16 @@ module RuboCop
           def process_assignment(asgn_node, rhs_node)
             lhs_variable_name, = *asgn_node
 
-            if [:lvar, :ivar, :cvar, :gvar].include?(rhs_node.type)
-              rhs_variable_name, = *rhs_node
-              @local[lhs_variable_name] = @local[rhs_variable_name]
-            else
-              @local[lhs_variable_name] = constructor?(rhs_node)
-            end
+            @local[lhs_variable_name] = if rhs_node.variable?
+                                          rhs_variable_name, = *rhs_node
+                                          @local[rhs_variable_name]
+                                        else
+                                          constructor?(rhs_node)
+                                        end
           end
 
           def constructor?(node)
-            return true if LITERAL_TYPES.include?(node.type)
+            return true if node.literal?
             return false unless node.type == :send
             _receiver, method = *node
             method == :new

--- a/lib/rubocop/cop/lint/void.rb
+++ b/lib/rubocop/cop/lint/void.rb
@@ -11,9 +11,6 @@ module RuboCop
         LIT_MSG = 'Literal `%s` used in void context.'
 
         OPS = %w(* / % + - == === != < > <= >= <=>)
-        VARS = [:ivar, :lvar, :cvar, :const]
-        LITERALS = [:str, :dstr, :int, :float, :array,
-                    :hash, :regexp, :nil, :true, :false, :sym]
 
         def on_begin(node)
           check_begin(node)
@@ -45,12 +42,12 @@ module RuboCop
         end
 
         def check_for_var(node)
-          return unless VARS.include?(node.type)
+          return unless node.variable? || node.const_type?
           add_offense(node, :name, format(VAR_MSG, node.loc.name.source))
         end
 
         def check_for_literal(node)
-          return unless LITERALS.include?(node.type)
+          return unless node.literal?
           add_offense(node, :expression, format(LIT_MSG, node.source))
         end
       end

--- a/lib/rubocop/cop/style/each_with_object.rb
+++ b/lib/rubocop/cop/style/each_with_object.rb
@@ -29,7 +29,7 @@ module RuboCop
           _, method_name, method_arg = *method
 
           return unless METHODS.include? method_name
-          return if method_arg && BASIC_LITERALS.include?(method_arg.type)
+          return if method_arg && method_arg.basic_literal?
 
           return_value = return_value(body)
           return unless return_value

--- a/lib/rubocop/cop/style/infinite_loop.rb
+++ b/lib/rubocop/cop/style/infinite_loop.rb
@@ -18,15 +18,10 @@ module RuboCop
       class InfiniteLoop < Cop
         MSG = 'Use `Kernel#loop` for infinite loops.'
 
-        TRUTHY_LITERALS = [:str, :dstr, :int, :float, :array,
-                           :hash, :regexp, :true]
-
-        FALSEY_LITERALS = [:nil, :false]
-
         def on_while(node)
           condition, = *node
 
-          return unless TRUTHY_LITERALS.include?(condition.type)
+          return unless condition.truthy_literal?
 
           add_offense(node, :keyword)
         end
@@ -34,7 +29,7 @@ module RuboCop
         def on_until(node)
           condition, = *node
 
-          return unless FALSEY_LITERALS.include?(condition.type)
+          return unless condition.falsey_literal?
 
           add_offense(node, :keyword)
         end

--- a/lib/rubocop/cop/style/unneeded_interpolation.rb
+++ b/lib/rubocop/cop/style/unneeded_interpolation.rb
@@ -20,11 +20,6 @@ module RuboCop
 
         MSG = 'Prefer `to_s` over string interpolation.'
 
-        VARIABLE_INTERPOLATION_TYPES = [
-          :ivar, :cvar, :gvar,
-          :back_ref, :nth_ref
-        ].freeze
-
         def on_dstr(node)
           add_offense(node, :expression, MSG) if single_interpolation?(node)
         end
@@ -51,7 +46,7 @@ module RuboCop
         end
 
         def variable_interpolation?(node)
-          VARIABLE_INTERPOLATION_TYPES.include?(node.type)
+          node.variable? || node.reference?
         end
 
         def implicit_concatenation?(node)

--- a/lib/rubocop/cop/style/variable_interpolation.rb
+++ b/lib/rubocop/cop/style/variable_interpolation.rb
@@ -5,7 +5,6 @@ module RuboCop
     module Style
       # This cop checks for variable interpolation (like "#@ivar").
       class VariableInterpolation < Cop
-        VAR_TYPES = [:ivar, :cvar, :gvar, :nth_ref, :back_ref]
         MSG = 'Replace interpolated variable `%s` with expression `#{%s}`.'
 
         def on_dstr(node)
@@ -35,7 +34,7 @@ module RuboCop
         end
 
         def var_nodes(nodes)
-          nodes.select { |n| VAR_TYPES.include?(n.type) }
+          nodes.select { |n| n.variable? || n.reference? }
         end
       end
     end

--- a/lib/rubocop/cop/util.rb
+++ b/lib/rubocop/cop/util.rb
@@ -13,12 +13,6 @@ module RuboCop
       SHORTHAND_ASGN_NODES = [:op_asgn, :or_asgn, :and_asgn]
       ASGN_NODES = EQUALS_ASGN_NODES + SHORTHAND_ASGN_NODES
 
-      LITERALS = [:str, :dstr, :int, :float, :sym, :dsym, :array,
-                  :hash, :regexp, :nil, :true, :false]
-      BASIC_LITERALS = LITERALS - [:dstr, :dsym, :array, :hash]
-
-      VARIABLES = [:ivar, :gvar, :cvar, :lvar]
-
       # http://phrogz.net/programmingruby/language.html#table_18.4
       # Backtick is added last just to help editors parse this code.
       OPERATOR_METHODS = %w(
@@ -30,18 +24,6 @@ module RuboCop
 
       def operator?(symbol)
         OPERATOR_METHODS.include?(symbol)
-      end
-
-      def literal?(node)
-        LITERALS.include?(node.type)
-      end
-
-      def variable?(node)
-        VARIABLES.include?(node.type)
-      end
-
-      def constant?(node)
-        node.const_type?
       end
 
       def strip_quotes(str)

--- a/spec/rubocop/cop/style/redundant_parentheses_spec.rb
+++ b/spec/rubocop/cop/style/redundant_parentheses_spec.rb
@@ -58,4 +58,14 @@ describe RuboCop::Cop::Style::RedundantParentheses do
     inspect_source(cop, '(a)...(b)')
     expect(cop.offenses).to be_empty
   end
+
+  it 'accepts parentheses around an irange' do
+    inspect_source(cop, '(a..b)')
+    expect(cop.offenses).to be_empty
+  end
+
+  it 'accepts parentheses around an erange' do
+    inspect_source(cop, '(a...b)')
+    expect(cop.offenses).to be_empty
+  end
 end

--- a/spec/rubocop/cop/style/unneeded_interpolation_spec.rb
+++ b/spec/rubocop/cop/style/unneeded_interpolation_spec.rb
@@ -136,6 +136,11 @@ describe RuboCop::Cop::Style::UnneededInterpolation do
     expect(corrected).to eq '@var.to_s'
   end
 
+  it 'autocorrects "#{var}"' do
+    corrected = autocorrect_source(cop, ['var = 1; "#{var}"'])
+    expect(corrected).to eq 'var = 1; var.to_s'
+  end
+
   it 'autocorrects "#{@var}"' do
     corrected = autocorrect_source(cop, ['"#{@var}"'])
     expect(corrected).to eq '@var.to_s'


### PR DESCRIPTION
Apply `literal?`, `basic_literal?`, `truthy_literal?`, `falsey_literal?`, `variable?` and `reference?` to generic checks.