### PR TITLE
Replace multiple {start,end}_with? calls into one

### DIFF
--- a/lib/rubocop/cop/mixin/string_literals_help.rb
+++ b/lib/rubocop/cop/mixin/string_literals_help.rb
@@ -8,7 +8,7 @@ module RuboCop
 
       def wrong_quotes?(node, style)
         src = node.source
-        return false if src.start_with?('%') || src.start_with?('?')
+        return false if src.start_with?('%', '?')
         if style == :single_quotes
           src !~ /'/ && src !~ StringHelp::ESCAPED_CHAR_REGEXP
         else

--- a/lib/rubocop/cop/style/empty_lines_around_access_modifier.rb
+++ b/lib/rubocop/cop/style/empty_lines_around_access_modifier.rb
@@ -67,7 +67,7 @@ module RuboCop
         end
 
         def class_def?(line)
-          %w(class module).any? { |keyword| line.start_with?(keyword) }
+          line.start_with?('class', 'module')
         end
 
         def block_start?(line)

--- a/lib/rubocop/cop/style/unneeded_percent_q.rb
+++ b/lib/rubocop/cop/style/unneeded_percent_q.rb
@@ -70,7 +70,7 @@ module RuboCop
         end
 
         def start_with_percent_q_variant?(string)
-          string.start_with?(PERCENT_Q) || string.start_with?(PERCENT_CAPITAL_Q)
+          string.start_with?(PERCENT_Q, PERCENT_CAPITAL_Q)
         end
       end
     end

--- a/lib/rubocop/target_finder.rb
+++ b/lib/rubocop/target_finder.rb
@@ -104,7 +104,7 @@ module RuboCop
 
     def toplevel_dirs(base_dir, flags)
       Dir.glob(File.join(base_dir, '*'), flags).select do |dir|
-        File.directory?(dir) && !(dir.end_with?('/.') || dir.end_with?('/..'))
+        File.directory?(dir) && !dir.end_with?('/.', '/..')
       end
     end
 


### PR DESCRIPTION
Both [String#start_with?](http://ruby-doc.org/core-2.2.4/String.html#method-i-start_with-3F) and [String#end_with?](http://ruby-doc.org/core-2.2.4/String.html#method-i-end_with-3F) can accept variable number of arguments. It allows to eliminate some duplication and also often makes the code a bit faster.

Please let me know if I should squash the commits together.