### PR TITLE
Add rubocop-cask to the list of known custom cops

### DIFF
--- a/README.md
+++ b/README.md
@@ -999,6 +999,8 @@ other cop.
 
 * [rubocop-rspec](https://github.com/nevir/rubocop-rspec) -
   RSpec-specific analysis
+* [rubocop-cask](https://github.com/caskroom/rubocop-cask) - Analysis
+  for Homebrew-Cask files.
 
 ### Custom Formatters
 


### PR DESCRIPTION
[rubocop-cask](https://github.com/caskroom/rubocop-cask) is a RuboCop plugin for linting Homebrew-Cask cask definition files, and is now [live on Homebrew-Cask](https://github.com/caskroom/homebrew-cask/pull/16317).

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/bbatsov/rubocop/2577)
<!-- Reviewable:end -->
