### PR TITLE
Accept yield in UnusedMethodArgument

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -59,6 +59,7 @@
 * [#2481](https://github.com/bbatsov/rubocop/issues/2481): New `WorstOffendersFormatter` prints a list of files with offenses (and offense counts), showing the files with the most offenses first. ([@alexdowad][])
 * New `IfInsideElse` cop catches `if..end` nodes which can be converted into an `elsif` instead, reducing the nesting level. ([@alexdowad][])
 * [#1725](https://github.com/bbatsov/rubocop/issues/1725): --color CLI option forces color output, even when not printing to a TTY. ([@alexdowad][])
+* [#2584](https://github.com/bbatsov/rubocop/pull/2584): `Lint/UnusedMethodArgument` will not register an offense for a method that takes in `&block` as an argument and calls `yield` in the method. ([@rrosenblum][])
 
 ### Bug Fixes
 

--- a/lib/rubocop/cop/lint/unused_method_argument.rb
+++ b/lib/rubocop/cop/lint/unused_method_argument.rb
@@ -18,10 +18,9 @@ module RuboCop
           return if variable.keyword_argument? &&
                     cop_config['AllowUnusedKeywordArguments']
 
-          if cop_config['IgnoreEmptyMethods']
-            _name, _args, body = *variable.scope.node
-            return if body.nil?
-          end
+          _name, _args, body = *variable.scope.node
+          return if cop_config['IgnoreEmptyMethods'] && body.nil?
+          return if variable.name == :block && yield_called?(body)
 
           super
         end
@@ -44,6 +43,15 @@ module RuboCop
           end
 
           message
+        end
+
+        private
+
+        def yield_called?(node)
+          return false if node.nil?
+          return true if node.respond_to?(:yield_type?) && node.yield_type?
+          return true if node.each_node(:yield).any?
+          false
         end
       end
     end


### PR DESCRIPTION
I am not sure if this has been discussed before, but it has been bugging me for a little while. I feel as though there is a convention of using `yield` with `&block`. This will not capture a case where `yield` is used and the block is named something other than `&block`.