### PR TITLE
EmptyLiteral autocorrector respects StringLiterals/EnforcedStyle config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -67,6 +67,7 @@
 
 ### Bug Fixes
 
+* [#2594](https://github.com/bbatsov/rubocop/issues/2594): `Style/EmptyLiteral` autocorrector respects `Style/StringLiterals:EnforcedStyle` config. ([@DNNX][])
 * [#2411](https://github.com/bbatsov/rubocop/issues/2411): Make local inherited configuration override configuration loaded from gems. ([@jonas054][])
 * [#2413](https://github.com/bbatsov/rubocop/issues/2413): Allow `%Q` for dynamic strings with double quotes inside them. ([@jonas054][])
 * [#2404](https://github.com/bbatsov/rubocop/issues/2404): `Style/Next` does not remove comments when auto-correcting. ([@lumeet][])

--- a/lib/rubocop/cop/style/empty_literal.rb
+++ b/lib/rubocop/cop/style/empty_literal.rb
@@ -54,9 +54,23 @@ module RuboCop
                    return if first_arg_in_method_call_without_parentheses?(node)
                    '{}'
                  when STR_NODE
-                   "''"
+                   if enforce_double_quotes?
+                     '""'
+                   else
+                     "''"
+                   end
                  end
           ->(corrector) { corrector.replace(node.source_range, name) }
+        end
+
+        private
+
+        def enforce_double_quotes?
+          string_literals_config['EnforcedStyle'] == 'double_quotes'
+        end
+
+        def string_literals_config
+          config.for_cop('Style/StringLiterals')
         end
 
         def first_arg_in_method_call_without_parentheses?(node)

--- a/spec/rubocop/cop/style/empty_literal_spec.rb
+++ b/spec/rubocop/cop/style/empty_literal_spec.rb
@@ -113,5 +113,22 @@ describe RuboCop::Cop::Style::EmptyLiteral do
       new_source = autocorrect_source(cop, 'test = String.new')
       expect(new_source).to eq("test = ''")
     end
+
+    context 'when double-quoted string literals are preferred' do
+      let(:config) do
+        RuboCop::Config.new(
+          'Style/StringLiterals' =>
+            {
+              'EnforcedStyle' => 'double_quotes'
+            }
+        )
+      end
+      subject(:cop) { described_class.new(config) }
+
+      it 'auto-corrects String.new to a double-quoted empty string literal' do
+        new_source = autocorrect_source(cop, 'test = String.new')
+        expect(new_source).to eq('test = ""')
+      end
+    end
   end
 end


### PR DESCRIPTION
Before this PR it would replace `String.new` with `''` even if double-quoted string were preferred.

Fixes https://github.com/bbatsov/rubocop/issues/2593