### PR TITLE
New option: EnforcedStyleAfterStabbyArrow for Style/SpaceBeforeBlockBraces

### DIFF
--- a/config/default.yml
+++ b/config/default.yml
@@ -814,7 +814,12 @@ Style/SpaceAroundOperators:
 
 Style/SpaceBeforeBlockBraces:
   EnforcedStyle: space
+  EnforcedStyleAfterStabbyArrow: inherit
   SupportedStyles:
+    - space
+    - no_space
+  SupportedStylesAfterStabbyArrow:
+    - inherit
     - space
     - no_space
 

--- a/lib/rubocop/cop/util.rb
+++ b/lib/rubocop/cop/util.rb
@@ -150,6 +150,10 @@ module RuboCop
         pos
       end
 
+      def match_at(range, regexp)
+        range.source_buffer.source.match(regexp, range.begin_pos)
+      end
+
       def directions(side)
         if side == :both
           [true, true]

--- a/spec/rubocop/cop/style/space_before_block_braces_spec.rb
+++ b/spec/rubocop/cop/style/space_before_block_braces_spec.rb
@@ -12,7 +12,12 @@ describe RuboCop::Cop::Style::SpaceBeforeBlockBraces do
     RuboCop::Config.new('Style/BlockDelimiters' => { 'Enabled' => false },
                         'Style/SpaceBeforeBlockBraces' => merged)
   end
-  let(:cop_config) { { 'EnforcedStyle' => 'space' } }
+  let(:cop_config) do
+    {
+      'EnforcedStyle' => 'space',
+      'EnforcedStyleAfterStabbyArrow' => 'inherit'
+    }
+  end
 
   context 'when EnforcedStyle is space' do
     it 'accepts braces surrounded by spaces' do
@@ -40,10 +45,65 @@ describe RuboCop::Cop::Style::SpaceBeforeBlockBraces do
       new_source = autocorrect_source(cop, 'each{}')
       expect(new_source).to eq('each {}')
     end
+
+    it 'accepts braces after stabby arrow surrounded by spaces' do
+      inspect_source(cop, '-> { puts "->" }')
+      expect(cop.messages).to be_empty
+      expect(cop.highlights).to be_empty
+    end
+
+    it 'auto-corrects missing space after stabby arrow' do
+      new_source = autocorrect_source(cop, '->{ puts "->" }')
+      expect(new_source).to eq('-> { puts "->" }')
+    end
+
+    it 'registers an offense for left brace after stabby arrow ' \
+       'without outer space' do
+      inspect_source(cop, '->{ puts "->" }')
+      expect(cop.messages).to eq(['Space missing to the left of {.'])
+      expect(cop.highlights).to eq(['{'])
+      expect(cop.config_to_allow_offenses).to eq('EnforcedStyle' => 'no_space')
+    end
+
+    context 'with EnforcedStyleAfterStabbyArrow set to no_space' do
+      let(:cop_config) do
+        {
+          'EnforcedStyle' => 'space',
+          'EnforcedStyleAfterStabbyArrow' => 'no_space'
+        }
+      end
+
+      it 'accepts missing space after stabby arrow' do
+        inspect_source(cop, '->{ puts "->" }')
+        expect(cop.messages).to be_empty
+        expect(cop.highlights).to be_empty
+      end
+
+      it 'registers an offense for braces surrounded by spaces ' \
+         'after stabby arrow' do
+        inspect_source(cop, '-> { puts "->" }')
+        expect(cop.messages).to eq(['Space detected to the left of {.'])
+        expect(cop.highlights).to eq([' '])
+        expect(cop.config_to_allow_offenses).to eq(
+          'EnforcedStyle' => 'space',
+          'EnforcedStyleAfterStabbyArrow' => %w(inherit space)
+        )
+      end
+
+      it 'auto-corrects unwanted space' do
+        new_source = autocorrect_source(cop, '-> { puts "->" }')
+        expect(new_source).to eq('->{ puts "->" }')
+      end
+    end
   end
 
   context 'when EnforcedStyle is no_space' do
-    let(:cop_config) { { 'EnforcedStyle' => 'no_space' } }
+    let(:cop_config) do
+      {
+        'EnforcedStyle' => 'no_space',
+        'EnforcedStyleAfterStabbyArrow' => 'inherit'
+      }
+    end
 
     it 'registers an offense for braces surrounded by spaces' do
       inspect_source(cop, 'each { puts }')
@@ -69,6 +129,56 @@ describe RuboCop::Cop::Style::SpaceBeforeBlockBraces do
       inspect_source(cop, 'each{ puts }')
       expect(cop.messages).to be_empty
       expect(cop.highlights).to be_empty
+    end
+
+    it 'accepts left brace after stabby arrow without outer space' do
+      inspect_source(cop, '->{ puts "->" }')
+      expect(cop.messages).to be_empty
+      expect(cop.highlights).to be_empty
+    end
+
+    it 'registers an offense for braces surrounded by spaces ' \
+       'after stabby arrow' do
+      inspect_source(cop, '-> { puts "->" }')
+      expect(cop.messages).to eq(['Space detected to the left of {.'])
+      expect(cop.highlights).to eq([' '])
+      expect(cop.config_to_allow_offenses).to eq('EnforcedStyle' => 'space')
+    end
+
+    it 'auto-corrects unwanted space after stabby arrow' do
+      new_source = autocorrect_source(cop, '-> { puts "->" }')
+      expect(new_source).to eq('->{ puts "->" }')
+    end
+
+    context 'with EnforcedStyleAfterStabbyArrow set to space' do
+      let(:cop_config) do
+        {
+          'EnforcedStyle' => 'no_space',
+          'EnforcedStyleAfterStabbyArrow' => 'space'
+        }
+      end
+
+      it 'accepts braces after stabby arrow surrounded by spaces' do
+        inspect_source(cop, '-> { puts "->" }')
+        expect(cop.messages).to be_empty
+        expect(cop.highlights).to be_empty
+      end
+
+      it 'auto-corrects missing space after stabby arrow' do
+        new_source = autocorrect_source(cop, '->{ puts "->" }')
+        expect(new_source).to eq('-> { puts "->" }')
+      end
+
+      it 'registers an offense for left brace after stabby arrow ' \
+         'without outer space' do
+        inspect_source(cop, '->{ puts "->" }')
+        expect(cop.messages).to eq(['Space missing to the left of {.'])
+        expect(cop.highlights).to eq(['{'])
+        expect(cop.config_to_allow_offenses).to eq(
+          'EnforcedStyle' => 'no_space',
+          'EnforcedStyleAfterStabbyArrow' => %w(inherit no_space)
+        )
+      end
     end
   end
 end


### PR DESCRIPTION
Omitting a space between `->` and `{ ... }` is quite common, so I've added an option to allow that style while you could still require a space after any other token.