### PR TITLE
Enable Style/MutableConstants by default & fix violations

### DIFF
--- a/config/disabled.yml
+++ b/config/disabled.yml
@@ -85,10 +85,6 @@ Style/MultilineAssignmentLayout:
   StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#indent-conditional-assignment'
   Enabled: false
 
-Style/MutableConstant:
-  Description: 'Do not assign mutable objects to constants.'
-  Enabled: false
-
 Style/OptionHash:
   Description: "Don't use option hashes when you can use keyword arguments."
   Enabled: false

--- a/config/enabled.yml
+++ b/config/enabled.yml
@@ -436,6 +436,10 @@ Style/MultilineTernaryOperator:
   StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#no-multiline-ternary'
   Enabled: true
 
+Style/MutableConstant:
+  Description: 'Do not assign mutable objects to constants.'
+  Enabled: true
+
 Style/NegatedIf:
   Description: >-
                  Favor unless over if for negative conditions

--- a/lib/rubocop/comment_config.rb
+++ b/lib/rubocop/comment_config.rb
@@ -4,7 +4,7 @@ module RuboCop
   # This class parses the special `rubocop:disable` comments in a source
   # and provides a way to check if each cop is enabled at arbitrary line.
   class CommentConfig
-    UNNEEDED_DISABLE = 'Lint/UnneededDisable'
+    UNNEEDED_DISABLE = 'Lint/UnneededDisable'.freeze
     COMMENT_DIRECTIVE_REGEXP = Regexp.new(
       '\A# rubocop : ((?:dis|en)able)\b ((?:[\w/]+,? )+)'.gsub(' ', '\s*')
     )

--- a/lib/rubocop/config.rb
+++ b/lib/rubocop/config.rb
@@ -13,7 +13,8 @@ module RuboCop
   class Config < Hash
     include PathUtil
 
-    COMMON_PARAMS = %w(Exclude Include Severity AutoCorrect StyleGuide Details)
+    COMMON_PARAMS = %w(Exclude Include Severity
+                       AutoCorrect StyleGuide Details).freeze
     KNOWN_RUBIES = [1.9, 2.0, 2.1, 2.2, 2.3].freeze
 
     attr_reader :loaded_path

--- a/lib/rubocop/config_loader.rb
+++ b/lib/rubocop/config_loader.rb
@@ -10,10 +10,10 @@ module RuboCop
   # during a run of the rubocop program, if files in several
   # directories are inspected.
   class ConfigLoader
-    DOTFILE = '.rubocop.yml'
+    DOTFILE = '.rubocop.yml'.freeze
     RUBOCOP_HOME = File.realpath(File.join(File.dirname(__FILE__), '..', '..'))
     DEFAULT_FILE = File.join(RUBOCOP_HOME, 'config', 'default.yml')
-    AUTO_GENERATED_FILE = '.rubocop_todo.yml'
+    AUTO_GENERATED_FILE = '.rubocop_todo.yml'.freeze
 
     class << self
       attr_accessor :debug, :auto_gen_config

--- a/lib/rubocop/cop/lint/ambiguous_operator.rb
+++ b/lib/rubocop/cop/lint/ambiguous_operator.rb
@@ -31,7 +31,7 @@ module RuboCop
         MSG_FORMAT = 'Ambiguous %{actual} operator. Parenthesize the method ' \
                      "arguments if it's surely a %{actual} operator, or add " \
                      'a whitespace to the right of the `%{operator}` if it ' \
-                     'should be a %{possible}.'
+                     'should be a %{possible}.'.freeze
 
         private
 

--- a/lib/rubocop/cop/lint/ambiguous_regexp_literal.rb
+++ b/lib/rubocop/cop/lint/ambiguous_regexp_literal.rb
@@ -19,7 +19,7 @@ module RuboCop
 
         MSG = 'Ambiguous regexp literal. Parenthesize the method arguments ' \
               "if it's surely a regexp literal, or add a whitespace to the " \
-              'right of the `/` if it should be a division.'
+              'right of the `/` if it should be a division.'.freeze
 
         private
 

--- a/lib/rubocop/cop/lint/assignment_in_condition.rb
+++ b/lib/rubocop/cop/lint/assignment_in_condition.rb
@@ -8,8 +8,8 @@ module RuboCop
       class AssignmentInCondition < Cop
         include SafeAssignment
 
-        MSG = 'Assignment in condition - you probably meant to use `==`.'
-        ASGN_TYPES = [:begin, *EQUALS_ASGN_NODES, :send]
+        MSG = 'Assignment in condition - you probably meant to use `==`.'.freeze
+        ASGN_TYPES = [:begin, *EQUALS_ASGN_NODES, :send].freeze
 
         def on_if(node)
           check(node)

--- a/lib/rubocop/cop/lint/block_alignment.rb
+++ b/lib/rubocop/cop/lint/block_alignment.rb
@@ -12,7 +12,7 @@ module RuboCop
       #     i
       #   end
       class BlockAlignment < Cop
-        MSG = '`%s` at %d, %d is not aligned with `%s` at %d, %d%s.'
+        MSG = '`%s` at %d, %d is not aligned with `%s` at %d, %d%s.'.freeze
 
         def_node_matcher :block_end_align_target?, <<-PATTERN
           {assignment?

--- a/lib/rubocop/cop/lint/circular_argument_reference.rb
+++ b/lib/rubocop/cop/lint/circular_argument_reference.rb
@@ -34,7 +34,7 @@ module RuboCop
       #     dry_ingredients.combine
       #   end
       class CircularArgumentReference < Cop
-        MSG = 'Circular argument reference - `%s`.'
+        MSG = 'Circular argument reference - `%s`.'.freeze
 
         def on_kwoptarg(node)
           check_for_circular_argument_references(*node)

--- a/lib/rubocop/cop/lint/debugger.rb
+++ b/lib/rubocop/cop/lint/debugger.rb
@@ -5,7 +5,7 @@ module RuboCop
     module Lint
       # This cop checks for calls to debugger or pry.
       class Debugger < Cop
-        MSG = 'Remove debugger entry point `%s`.'
+        MSG = 'Remove debugger entry point `%s`.'.freeze
 
         def_node_matcher :debugger_call?, <<-END
           {(send nil {:debugger :byebug} ...)

--- a/lib/rubocop/cop/lint/def_end_alignment.rb
+++ b/lib/rubocop/cop/lint/def_end_alignment.rb
@@ -20,7 +20,7 @@ module RuboCop
         include OnMethodDef
         include EndKeywordAlignment
 
-        MSG = '`end` at %d, %d is not aligned with `%s` at %d, %d.'
+        MSG = '`end` at %d, %d is not aligned with `%s` at %d, %d.'.freeze
 
         def on_method_def(node, _method_name, _args, _body)
           check_end_kw_in_node(node)

--- a/lib/rubocop/cop/lint/deprecated_class_methods.rb
+++ b/lib/rubocop/cop/lint/deprecated_class_methods.rb
@@ -27,11 +27,11 @@ module RuboCop
           end
         end
 
-        MSG = '`%s` is deprecated in favor of `%s`.'
+        MSG = '`%s` is deprecated in favor of `%s`.'.freeze
         DEPRECATED_METHODS_OBJECT = [
           DeprecatedClassMethod.new(:File, :exists?, :exist?),
           DeprecatedClassMethod.new(:Dir, :exists?, :exist?)
-        ]
+        ].freeze
 
         def on_send(node)
           check(node) do |data|

--- a/lib/rubocop/cop/lint/duplicate_methods.rb
+++ b/lib/rubocop/cop/lint/duplicate_methods.rb
@@ -16,7 +16,7 @@ module RuboCop
       #     2
       #   end
       class DuplicateMethods < Cop
-        MSG = 'Method `%s` is defined at both %s and %s.'
+        MSG = 'Method `%s` is defined at both %s and %s.'.freeze
 
         def initialize(config = nil, options = nil)
           super

--- a/lib/rubocop/cop/lint/duplicated_key.rb
+++ b/lib/rubocop/cop/lint/duplicated_key.rb
@@ -10,9 +10,9 @@ module RuboCop
       # @example
       #   hash = { food: 'apple', food: 'orange' }
       class DuplicatedKey < Cop
-        MSG = 'Duplicated key in hash literal.'
+        MSG = 'Duplicated key in hash literal.'.freeze
 
-        LITERALS = [:sym, :str, :float, :int]
+        LITERALS = [:sym, :str, :float, :int].freeze
 
         def on_hash(node)
           keys = []

--- a/lib/rubocop/cop/lint/each_with_object_argument.rb
+++ b/lib/rubocop/cop/lint/each_with_object_argument.rb
@@ -13,7 +13,7 @@ module RuboCop
       #
       #   sum = numbers.each_with_object(0) { |e, a| a += e }
       class EachWithObjectArgument < Cop
-        MSG = 'The argument to each_with_object can not be immutable.'
+        MSG = 'The argument to each_with_object can not be immutable.'.freeze
 
         def on_send(node)
           _receiver, method_name, *args = *node

--- a/lib/rubocop/cop/lint/empty_ensure.rb
+++ b/lib/rubocop/cop/lint/empty_ensure.rb
@@ -5,7 +5,7 @@ module RuboCop
     module Lint
       # This cop checks for empty `ensure` blocks
       class EmptyEnsure < Cop
-        MSG = 'Empty `ensure` block detected.'
+        MSG = 'Empty `ensure` block detected.'.freeze
 
         def on_ensure(node)
           _body, ensure_body = *node

--- a/lib/rubocop/cop/lint/empty_interpolation.rb
+++ b/lib/rubocop/cop/lint/empty_interpolation.rb
@@ -9,7 +9,7 @@ module RuboCop
       #
       #   "result is #{}"
       class EmptyInterpolation < Cop
-        MSG = 'Empty interpolation detected.'
+        MSG = 'Empty interpolation detected.'.freeze
 
         def on_dstr(node)
           node.children.select { |n| n.type == :begin }.each do |begin_node|

--- a/lib/rubocop/cop/lint/end_in_method.rb
+++ b/lib/rubocop/cop/lint/end_in_method.rb
@@ -5,7 +5,7 @@ module RuboCop
     module Lint
       # This cop checks for END blocks in method definitions.
       class EndInMethod < Cop
-        MSG = '`END` found in method definition. Use `at_exit` instead.'
+        MSG = '`END` found in method definition. Use `at_exit` instead.'.freeze
 
         def on_postexe(node)
           inside_of_method = node.each_ancestor(:def, :defs).count.nonzero?

--- a/lib/rubocop/cop/lint/ensure_return.rb
+++ b/lib/rubocop/cop/lint/ensure_return.rb
@@ -5,7 +5,7 @@ module RuboCop
     module Lint
       # This cop checks for *return* from an *ensure* block.
       class EnsureReturn < Cop
-        MSG = 'Do not return from an `ensure` block.'
+        MSG = 'Do not return from an `ensure` block.'.freeze
 
         def on_ensure(node)
           _body, ensure_body = *node

--- a/lib/rubocop/cop/lint/eval.rb
+++ b/lib/rubocop/cop/lint/eval.rb
@@ -5,7 +5,7 @@ module RuboCop
     module Lint
       # This cop checks for the use of *Kernel#eval*.
       class Eval < Cop
-        MSG = 'The use of `eval` is a serious security risk.'
+        MSG = 'The use of `eval` is a serious security risk.'.freeze
 
         def on_send(node)
           receiver, method_name, *args = *node

--- a/lib/rubocop/cop/lint/float_out_of_range.rb
+++ b/lib/rubocop/cop/lint/float_out_of_range.rb
@@ -14,7 +14,7 @@ module RuboCop
       #   # good
       #   float = 42.9
       class FloatOutOfRange < Cop
-        MSG = 'Float out of range.'
+        MSG = 'Float out of range.'.freeze
 
         def on_float(node)
           value, = *node

--- a/lib/rubocop/cop/lint/format_parameter_mismatch.rb
+++ b/lib/rubocop/cop/lint/format_parameter_mismatch.rb
@@ -14,7 +14,7 @@ module RuboCop
       class FormatParameterMismatch < Cop
         # http://rubular.com/r/CvpbxkcTzy
         MSG = "Number of arguments (%i) to `%s` doesn't match the number of " \
-              'fields (%i).'
+              'fields (%i).'.freeze
         FIELD_REGEX =
           /(%(([\s#+-0\*]*)(\d*)?(.\d+)?[bBdiouxXeEfgGaAcps]|%))/.freeze
         NAMED_FIELD_REGEX = /%\{[_a-zA-Z][_a-zA-Z]+\}/.freeze

--- a/lib/rubocop/cop/lint/handle_exceptions.rb
+++ b/lib/rubocop/cop/lint/handle_exceptions.rb
@@ -5,7 +5,7 @@ module RuboCop
     module Lint
       # This cop checks for *rescue* blocks with no body.
       class HandleExceptions < Cop
-        MSG = 'Do not suppress exceptions.'
+        MSG = 'Do not suppress exceptions.'.freeze
 
         def on_resbody(node)
           _exc_list_node, _exc_var_node, body_node = *node

--- a/lib/rubocop/cop/lint/implicit_string_concatenation.rb
+++ b/lib/rubocop/cop/lint/implicit_string_concatenation.rb
@@ -19,11 +19,11 @@ module RuboCop
       #   ]
       class ImplicitStringConcatenation < Cop
         MSG = 'Combine %s and %s into a single string literal, rather than ' \
-              'using implicit string concatenation.'
+              'using implicit string concatenation.'.freeze
         FOR_ARRAY = ' Or, if they were intended to be separate array ' \
-                    'elements, separate them with a comma.'
+                    'elements, separate them with a comma.'.freeze
         FOR_METHOD = ' Or, if they were intended to be separate method ' \
-                     'arguments, separate them with a comma.'
+                     'arguments, separate them with a comma.'.freeze
 
         def on_dstr(node)
           node.children.each_cons(2) do |child1, child2|

--- a/lib/rubocop/cop/lint/ineffective_access_modifier.rb
+++ b/lib/rubocop/cop/lint/ineffective_access_modifier.rb
@@ -38,10 +38,11 @@ module RuboCop
       #   end
       class IneffectiveAccessModifier < Cop
         MSG = '`%s` (on line %d) does not make singleton methods %s. ' \
-              'Use %s instead.'
+              'Use %s instead.'.freeze
         ALTERNATIVE_PRIVATE = '`private_class_method` or `private` inside a ' \
-                              '`class << self` block'
-        ALTERNATIVE_PROTECTED = '`protected` inside a `class << self` block'
+                              '`class << self` block'.freeze
+        ALTERNATIVE_PROTECTED = '`protected` inside a `class << self` ' \
+                                'block'.freeze
 
         def_node_matcher :access_modifier, <<-PATTERN
           (send nil ${:public :protected :private})

--- a/lib/rubocop/cop/lint/literal_in_condition.rb
+++ b/lib/rubocop/cop/lint/literal_in_condition.rb
@@ -18,7 +18,7 @@ module RuboCop
       #   end
       #
       class LiteralInCondition < Cop
-        MSG = 'Literal `%s` appeared in a condition.'
+        MSG = 'Literal `%s` appeared in a condition.'.freeze
 
         def on_if(node)
           check_for_literal(node)

--- a/lib/rubocop/cop/lint/literal_in_interpolation.rb
+++ b/lib/rubocop/cop/lint/literal_in_interpolation.rb
@@ -9,7 +9,7 @@ module RuboCop
       #
       #   "result is #{10}"
       class LiteralInInterpolation < Cop
-        MSG = 'Literal interpolation detected.'
+        MSG = 'Literal interpolation detected.'.freeze
 
         def on_dstr(node)
           node.children.select { |n| n.type == :begin }.each do |begin_node|

--- a/lib/rubocop/cop/lint/loop.rb
+++ b/lib/rubocop/cop/lint/loop.rb
@@ -6,7 +6,7 @@ module RuboCop
       # This cop checks for uses of *begin...end while/until something*.
       class Loop < Cop
         MSG = 'Use `Kernel#loop` with `break` rather than ' \
-              '`begin/end/until`(or `while`).'
+              '`begin/end/until`(or `while`).'.freeze
 
         def on_while_post(node)
           register_offense(node)

--- a/lib/rubocop/cop/lint/nested_method_definition.rb
+++ b/lib/rubocop/cop/lint/nested_method_definition.rb
@@ -19,7 +19,7 @@ module RuboCop
         extend RuboCop::NodePattern::Macros
 
         MSG = 'Method definitions must not be nested. ' \
-              'Use `lambda` instead.'
+              'Use `lambda` instead.'.freeze
 
         def_node_matcher :eval_call?, <<-PATTERN
           (block (send _ {:instance_eval :class_eval :module_eval} ...) ...)

--- a/lib/rubocop/cop/lint/non_local_exit_from_iterator.rb
+++ b/lib/rubocop/cop/lint/non_local_exit_from_iterator.rb
@@ -34,7 +34,8 @@ module RuboCop
       #
       class NonLocalExitFromIterator < Cop
         MSG = 'Non-local exit from iterator, without return value. ' \
-          '`next`, `break`, `Array#find`, `Array#any?`, etc. is preferred.'
+              '`next`, `break`, `Array#find`, `Array#any?`, etc. ' \
+              'is preferred.'.freeze
 
         def on_return(return_node)
           return if return_value?(return_node)

--- a/lib/rubocop/cop/lint/parentheses_as_grouped_expression.rb
+++ b/lib/rubocop/cop/lint/parentheses_as_grouped_expression.rb
@@ -10,7 +10,7 @@ module RuboCop
       #
       #   puts (x + y)
       class ParenthesesAsGroupedExpression < Cop
-        MSG = '`(...)` interpreted as grouped expression.'
+        MSG = '`(...)` interpreted as grouped expression.'.freeze
 
         def on_send(node)
           _receiver, method_name, *args = *node

--- a/lib/rubocop/cop/lint/rand_one.rb
+++ b/lib/rubocop/cop/lint/rand_one.rb
@@ -17,7 +17,8 @@ module RuboCop
       #   @good
       #   0
       class RandOne < Cop
-        MSG = '`%s` always returns `0`. Perhaps you meant `rand(2)` or `rand`?'
+        MSG = '`%s` always returns `0`. ' \
+              'Perhaps you meant `rand(2)` or `rand`?'.freeze
 
         def_node_matcher :rand_one?, <<-PATTERN
           (send {(const nil :Kernel) nil} :rand {(int {-1 1}) (float {-1.0 1.0})})

--- a/lib/rubocop/cop/lint/require_parentheses.rb
+++ b/lib/rubocop/cop/lint/require_parentheses.rb
@@ -21,7 +21,7 @@ module RuboCop
         include IfNode
 
         MSG = 'Use parentheses in the method call to avoid confusion about ' \
-              'precedence.'
+              'precedence.'.freeze
 
         def on_send(node)
           _receiver, method_name, *args = *node

--- a/lib/rubocop/cop/lint/rescue_exception.rb
+++ b/lib/rubocop/cop/lint/rescue_exception.rb
@@ -6,7 +6,7 @@ module RuboCop
       # This cop checks for *rescue* blocks targeting the Exception class.
       class RescueException < Cop
         MSG = 'Avoid rescuing the `Exception` class. ' \
-              'Perhaps you meant to rescue `StandardError`?'
+              'Perhaps you meant to rescue `StandardError`?'.freeze
 
         def on_resbody(node)
           return unless node.children.first

--- a/lib/rubocop/cop/lint/shadowing_outer_local_variable.rb
+++ b/lib/rubocop/cop/lint/shadowing_outer_local_variable.rb
@@ -8,7 +8,7 @@ module RuboCop
       # This is a mimic of the warning
       # "shadowing outer local variable - foo" from `ruby -cw`.
       class ShadowingOuterLocalVariable < Cop
-        MSG = 'Shadowing outer local variable - `%s`.'
+        MSG = 'Shadowing outer local variable - `%s`.'.freeze
 
         def join_force?(force_class)
           force_class == VariableForce

--- a/lib/rubocop/cop/lint/string_conversion_in_interpolation.rb
+++ b/lib/rubocop/cop/lint/string_conversion_in_interpolation.rb
@@ -10,8 +10,9 @@ module RuboCop
       #
       #   "result is #{something.to_s}"
       class StringConversionInInterpolation < Cop
-        MSG_DEFAULT = 'Redundant use of `Object#to_s` in interpolation.'
-        MSG_SELF = 'Use `self` instead of `Object#to_s` in interpolation.'
+        MSG_DEFAULT = 'Redundant use of `Object#to_s` in interpolation.'.freeze
+        MSG_SELF = 'Use `self` instead of `Object#to_s` in ' \
+                   'interpolation.'.freeze
 
         def on_dstr(node)
           node.children.select { |n| n.type == :begin }.each do |begin_node|

--- a/lib/rubocop/cop/lint/underscore_prefixed_variable_name.rb
+++ b/lib/rubocop/cop/lint/underscore_prefixed_variable_name.rb
@@ -6,7 +6,7 @@ module RuboCop
       # This cop checks for underscore-prefixed variables that are actually
       # used.
       class UnderscorePrefixedVariableName < Cop
-        MSG = 'Do not use prefix `_` for a variable that is used.'
+        MSG = 'Do not use prefix `_` for a variable that is used.'.freeze
 
         def join_force?(force_class)
           force_class == VariableForce

--- a/lib/rubocop/cop/lint/unneeded_disable.rb
+++ b/lib/rubocop/cop/lint/unneeded_disable.rb
@@ -15,7 +15,7 @@ module RuboCop
       class UnneededDisable < Cop
         include NameSimilarity
 
-        COP_NAME = 'Lint/UnneededDisable'
+        COP_NAME = 'Lint/UnneededDisable'.freeze
 
         def check(offenses, cop_disabled_line_ranges, comments)
           unneeded_cops = Hash.new { |h, k| h[k] = Set.new }

--- a/lib/rubocop/cop/lint/unreachable_code.rb
+++ b/lib/rubocop/cop/lint/unreachable_code.rb
@@ -7,10 +7,10 @@ module RuboCop
       # The check are based on the presence of flow of control
       # statement in non-final position in *begin*(implicit) blocks.
       class UnreachableCode < Cop
-        MSG = 'Unreachable code detected.'
+        MSG = 'Unreachable code detected.'.freeze
 
-        NODE_TYPES = [:return, :next, :break, :retry, :redo]
-        FLOW_COMMANDS = [:throw, :raise, :fail]
+        NODE_TYPES = [:return, :next, :break, :retry, :redo].freeze
+        FLOW_COMMANDS = [:throw, :raise, :fail].freeze
 
         def on_begin(node)
           expressions = *node

--- a/lib/rubocop/cop/lint/useless_access_modifier.rb
+++ b/lib/rubocop/cop/lint/useless_access_modifier.rb
@@ -22,7 +22,7 @@ module RuboCop
       #     private # this is redundant
       #   end
       class UselessAccessModifier < Cop
-        MSG = 'Useless `%s` access modifier.'
+        MSG = 'Useless `%s` access modifier.'.freeze
 
         def_node_matcher :access_modifier, <<-PATTERN
           (send nil ${:public :protected :private})

--- a/lib/rubocop/cop/lint/useless_assignment.rb
+++ b/lib/rubocop/cop/lint/useless_assignment.rb
@@ -14,7 +14,7 @@ module RuboCop
       # rescue, ensure, etc.
       class UselessAssignment < Cop
         include NameSimilarity
-        MSG = 'Useless assignment to variable - `%s`.'
+        MSG = 'Useless assignment to variable - `%s`.'.freeze
 
         def join_force?(force_class)
           force_class == VariableForce

--- a/lib/rubocop/cop/lint/useless_comparison.rb
+++ b/lib/rubocop/cop/lint/useless_comparison.rb
@@ -9,9 +9,9 @@ module RuboCop
       #
       #  x.top >= x.top
       class UselessComparison < Cop
-        MSG = 'Comparison of something with itself detected.'
+        MSG = 'Comparison of something with itself detected.'.freeze
 
-        OPS = %w(== === != < > <= >= <=>)
+        OPS = %w(== === != < > <= >= <=>).freeze
 
         def on_send(node)
           # lambda.() does not have a selector

--- a/lib/rubocop/cop/lint/useless_else_without_rescue.rb
+++ b/lib/rubocop/cop/lint/useless_else_without_rescue.rb
@@ -14,7 +14,7 @@ module RuboCop
       class UselessElseWithoutRescue < Cop
         include ParserDiagnostic
 
-        MSG = '`else` without `rescue` is useless.'
+        MSG = '`else` without `rescue` is useless.'.freeze
 
         private
 

--- a/lib/rubocop/cop/lint/useless_setter_call.rb
+++ b/lib/rubocop/cop/lint/useless_setter_call.rb
@@ -15,7 +15,7 @@ module RuboCop
       class UselessSetterCall < Cop
         include OnMethodDef
 
-        MSG = 'Useless setter call to local variable `%s`.'
+        MSG = 'Useless setter call to local variable `%s`.'.freeze
         ASSIGNMENT_TYPES = [:lvasgn, :ivasgn, :cvasgn, :gvasgn].freeze
 
         private

--- a/lib/rubocop/cop/lint/void.rb
+++ b/lib/rubocop/cop/lint/void.rb
@@ -6,11 +6,11 @@ module RuboCop
       # This cop checks for operators, variables and literals used
       # in void context.
       class Void < Cop
-        OP_MSG = 'Operator `%s` used in void context.'
-        VAR_MSG = 'Variable `%s` used in void context.'
-        LIT_MSG = 'Literal `%s` used in void context.'
+        OP_MSG = 'Operator `%s` used in void context.'.freeze
+        VAR_MSG = 'Variable `%s` used in void context.'.freeze
+        LIT_MSG = 'Literal `%s` used in void context.'.freeze
 
-        OPS = %w(* / % + - == === != < > <= >= <=>)
+        OPS = %w(* / % + - == === != < > <= >= <=>).freeze
 
         def on_begin(node)
           check_begin(node)

--- a/lib/rubocop/cop/metrics/abc_size.rb
+++ b/lib/rubocop/cop/metrics/abc_size.rb
@@ -9,7 +9,8 @@ module RuboCop
       class AbcSize < Cop
         include MethodComplexity
 
-        MSG = 'Assignment Branch Condition size for %s is too high. [%.4g/%.4g]'
+        MSG = 'Assignment Branch Condition size for %s is too high. ' \
+              '[%.4g/%.4g]'.freeze
         BRANCH_NODES = [:send].freeze
         CONDITION_NODES = CyclomaticComplexity::COUNTED_NODES.freeze
 

--- a/lib/rubocop/cop/metrics/block_nesting.rb
+++ b/lib/rubocop/cop/metrics/block_nesting.rb
@@ -15,7 +15,7 @@ module RuboCop
         NESTING_BLOCKS = [
           :case, :if, :while, :while_post,
           :until, :until_post, :for, :resbody
-        ]
+        ].freeze
 
         def investigate(processed_source)
           return unless processed_source.ast

--- a/lib/rubocop/cop/metrics/cyclomatic_complexity.rb
+++ b/lib/rubocop/cop/metrics/cyclomatic_complexity.rb
@@ -16,8 +16,9 @@ module RuboCop
       class CyclomaticComplexity < Cop
         include MethodComplexity
 
-        MSG = 'Cyclomatic complexity for %s is too high. [%d/%d]'
-        COUNTED_NODES = [:if, :while, :until, :for, :rescue, :when, :and, :or]
+        MSG = 'Cyclomatic complexity for %s is too high. [%d/%d]'.freeze
+        COUNTED_NODES = [:if, :while, :until, :for,
+                         :rescue, :when, :and, :or].freeze
 
         private
 

--- a/lib/rubocop/cop/metrics/line_length.rb
+++ b/lib/rubocop/cop/metrics/line_length.rb
@@ -10,7 +10,7 @@ module RuboCop
       class LineLength < Cop
         include ConfigurableMax
 
-        MSG = 'Line is too long. [%d/%d]'
+        MSG = 'Line is too long. [%d/%d]'.freeze
 
         def investigate(processed_source)
           heredocs = extract_heredocs(processed_source.ast) if allow_heredoc?

--- a/lib/rubocop/cop/metrics/parameter_lists.rb
+++ b/lib/rubocop/cop/metrics/parameter_lists.rb
@@ -10,7 +10,7 @@ module RuboCop
       class ParameterLists < Cop
         include ConfigurableMax
 
-        MSG = 'Avoid parameter lists longer than %d parameters.'
+        MSG = 'Avoid parameter lists longer than %d parameters.'.freeze
 
         def on_args(node)
           count = args_count(node)

--- a/lib/rubocop/cop/metrics/perceived_complexity.rb
+++ b/lib/rubocop/cop/metrics/perceived_complexity.rb
@@ -30,8 +30,9 @@ module RuboCop
         include MethodComplexity
         include IfNode
 
-        MSG = 'Perceived complexity for %s is too high. [%d/%d]'
-        COUNTED_NODES = [:if, :case, :while, :until, :for, :rescue, :and, :or]
+        MSG = 'Perceived complexity for %s is too high. [%d/%d]'.freeze
+        COUNTED_NODES = [:if, :case, :while, :until,
+                         :for, :rescue, :and, :or].freeze
 
         private
 

--- a/lib/rubocop/cop/mixin/empty_lines_around_body.rb
+++ b/lib/rubocop/cop/mixin/empty_lines_around_body.rb
@@ -8,8 +8,8 @@ module RuboCop
       module EmptyLinesAroundBody
         include ConfigurableEnforcedStyle
 
-        MSG_EXTRA = 'Extra empty line detected at %s body %s.'
-        MSG_MISSING = 'Empty line missing at %s body %s.'
+        MSG_EXTRA = 'Extra empty line detected at %s body %s.'.freeze
+        MSG_MISSING = 'Empty line missing at %s body %s.'.freeze
 
         def autocorrect(range)
           lambda do |corrector|

--- a/lib/rubocop/cop/mixin/end_keyword_alignment.rb
+++ b/lib/rubocop/cop/mixin/end_keyword_alignment.rb
@@ -6,7 +6,7 @@ module RuboCop
     module EndKeywordAlignment
       include ConfigurableEnforcedStyle
 
-      MSG = '`end` at %d, %d is not aligned with `%s` at %d, %d.'
+      MSG = '`end` at %d, %d is not aligned with `%s` at %d, %d.'.freeze
 
       private
 

--- a/lib/rubocop/cop/mixin/space_after_punctuation.rb
+++ b/lib/rubocop/cop/mixin/space_after_punctuation.rb
@@ -5,7 +5,7 @@ module RuboCop
     # Common functionality for cops checking for missing space after
     # punctuation.
     module SpaceAfterPunctuation
-      MSG = 'Space missing after %s.'
+      MSG = 'Space missing after %s.'.freeze
 
       def investigate(processed_source)
         processed_source.tokens.each_cons(2) do |t1, t2|

--- a/lib/rubocop/cop/mixin/space_before_punctuation.rb
+++ b/lib/rubocop/cop/mixin/space_before_punctuation.rb
@@ -5,7 +5,7 @@ module RuboCop
     # Common functionality for cops checking for space before
     # punctuation.
     module SpaceBeforePunctuation
-      MSG = 'Space found before %s.'
+      MSG = 'Space found before %s.'.freeze
 
       def investigate(processed_source)
         processed_source.tokens.each_cons(2) do |t1, t2|

--- a/lib/rubocop/cop/mixin/space_inside.rb
+++ b/lib/rubocop/cop/mixin/space_inside.rb
@@ -6,7 +6,7 @@ module RuboCop
     # kinds of brackets.
     module SpaceInside
       include SurroundingSpace
-      MSG = 'Space inside %s detected.'
+      MSG = 'Space inside %s detected.'.freeze
 
       def investigate(processed_source)
         @processed_source = processed_source

--- a/lib/rubocop/cop/mixin/trailing_comma.rb
+++ b/lib/rubocop/cop/mixin/trailing_comma.rb
@@ -7,7 +7,7 @@ module RuboCop
     module TrailingComma
       include ConfigurableEnforcedStyle
 
-      MSG = '%s comma after the last %s'
+      MSG = '%s comma after the last %s'.freeze
 
       def parameter_name
         'EnforcedStyleForMultiline'

--- a/lib/rubocop/cop/offense.rb
+++ b/lib/rubocop/cop/offense.rb
@@ -7,7 +7,8 @@ module RuboCop
       include Comparable
 
       # @api private
-      COMPARISON_ATTRIBUTES = [:line, :column, :cop_name, :message, :severity]
+      COMPARISON_ATTRIBUTES = [:line, :column, :cop_name,
+                               :message, :severity].freeze
 
       # @api public
       #

--- a/lib/rubocop/cop/performance/casecmp.rb
+++ b/lib/rubocop/cop/performance/casecmp.rb
@@ -14,7 +14,7 @@ module RuboCop
       #   @good
       #   'abc'.casecmp('ABC')
       class Casecmp < Cop
-        MSG = 'Use `casecmp` instead of `%s %s`.'
+        MSG = 'Use `casecmp` instead of `%s %s`.'.freeze
 
         def_node_matcher :downcase_eq, <<-END
           (send $(send _ ${:downcase :upcase}) ${:== :eql?} _)

--- a/lib/rubocop/cop/performance/count.rb
+++ b/lib/rubocop/cop/performance/count.rb
@@ -24,10 +24,10 @@ module RuboCop
       #   Model.select('field AS field_one').count
       #   Model.select(:value).count
       class Count < Cop
-        MSG = 'Use `count` instead of `%s...%s`.'
+        MSG = 'Use `count` instead of `%s...%s`.'.freeze
 
-        SELECTORS = [:reject, :select]
-        COUNTERS = [:count, :length, :size]
+        SELECTORS = [:reject, :select].freeze
+        COUNTERS = [:count, :length, :size].freeze
 
         def on_send(node)
           selector, selector_loc, params, counter = parse(node)

--- a/lib/rubocop/cop/performance/detect.rb
+++ b/lib/rubocop/cop/performance/detect.rb
@@ -18,11 +18,11 @@ module RuboCop
       #   [].detect { |item| true }
       #   [].reverse.detect { |item| true }
       class Detect < Cop
-        MSG = 'Use `%s` instead of `%s.%s`.'
-        REVERSE_MSG = 'Use `reverse.%s` instead of `%s.%s`.'
+        MSG = 'Use `%s` instead of `%s.%s`.'.freeze
+        REVERSE_MSG = 'Use `reverse.%s` instead of `%s.%s`.'.freeze
 
-        SELECT_METHODS = [:select, :find_all]
-        DANGEROUS_METHODS = [:first, :last]
+        SELECT_METHODS = [:select, :find_all].freeze
+        DANGEROUS_METHODS = [:first, :last].freeze
 
         def on_send(node)
           receiver, second_method = *node

--- a/lib/rubocop/cop/performance/double_start_end_with.rb
+++ b/lib/rubocop/cop/performance/double_start_end_with.rb
@@ -24,7 +24,7 @@ module RuboCop
       #   str.end_with?(var1, var2)
       class DoubleStartEndWith < Cop
         MSG = 'Use `%{receiver}.%{method}(%{combined_args})` ' \
-              'instead of `%{original_code}`.'
+              'instead of `%{original_code}`.'.freeze
 
         def on_or(node)
           receiver,

--- a/lib/rubocop/cop/performance/end_with.rb
+++ b/lib/rubocop/cop/performance/end_with.rb
@@ -16,7 +16,7 @@ module RuboCop
       #   'abc' =~ /\w*\Z/
       class EndWith < Cop
         MSG = 'Use `String#end_with?` instead of a regex match anchored to ' \
-              'the end of the string.'
+              'the end of the string.'.freeze
         SINGLE_QUOTE = "'".freeze
 
         def_node_matcher :redundant_regex?, <<-END

--- a/lib/rubocop/cop/performance/flat_map.rb
+++ b/lib/rubocop/cop/performance/flat_map.rb
@@ -15,11 +15,11 @@ module RuboCop
       #   [1, 2, 3, 4].map { |e| [e, e] }.flatten
       #   [1, 2, 3, 4].collect { |e| [e, e] }.flatten
       class FlatMap < Cop
-        MSG = 'Use `flat_map` instead of `%s...%s`.'
+        MSG = 'Use `flat_map` instead of `%s...%s`.'.freeze
         FLATTEN_MULTIPLE_LEVELS = ' Beware, `flat_map` only flattens 1 level ' \
                                   'and `flatten` can be used to flatten ' \
-                                  'multiple levels.'
-        FLATTEN = [:flatten, :flatten!]
+                                  'multiple levels.'.freeze
+        FLATTEN = [:flatten, :flatten!].freeze
 
         def on_send(node)
           left, second_method, flatten_param = *node

--- a/lib/rubocop/cop/performance/lstrip_rstrip.rb
+++ b/lib/rubocop/cop/performance/lstrip_rstrip.rb
@@ -14,7 +14,7 @@ module RuboCop
       #   @good
       #   'abc'.strip
       class LstripRstrip < Cop
-        MSG = 'Use `strip` instead of `%s.%s`.'
+        MSG = 'Use `strip` instead of `%s.%s`.'.freeze
 
         def_node_matcher :lstrip_rstrip, <<-END
           {(send $(send _ $:rstrip) $:lstrip)

--- a/lib/rubocop/cop/performance/range_include.rb
+++ b/lib/rubocop/cop/performance/range_include.rb
@@ -15,7 +15,7 @@ module RuboCop
       #     ('a'..'z').cover?('yellow') # => true
       #
       class RangeInclude < Cop
-        MSG = 'Use `Range#cover?` instead of `Range#include?`.'
+        MSG = 'Use `Range#cover?` instead of `Range#include?`.'.freeze
 
         # TODO: If we traced out assignments of variables to their uses, we
         # might pick up on a few more instances of this issue

--- a/lib/rubocop/cop/performance/redundant_block_call.rb
+++ b/lib/rubocop/cop/performance/redundant_block_call.rb
@@ -23,7 +23,7 @@ module RuboCop
       #     yield 1, 2, 3
       #   end
       class RedundantBlockCall < Cop
-        MSG = 'Use `yield` instead of `%s.call`.'
+        MSG = 'Use `yield` instead of `%s.call`.'.freeze
 
         def_node_matcher :blockarg_def, <<-END
           {(def  _   (args ... (blockarg $_)) $_)

--- a/lib/rubocop/cop/performance/redundant_match.rb
+++ b/lib/rubocop/cop/performance/redundant_match.rb
@@ -18,7 +18,7 @@ module RuboCop
       #   return regex.match('str')
       class RedundantMatch < Cop
         MSG = 'Use `=~` in places where the `MatchData` returned by ' \
-              '`#match` will not be used.'
+              '`#match` will not be used.'.freeze
 
         # 'match' is a fairly generic name, so we don't flag it unless we see
         # a string or regexp literal on one side or the other

--- a/lib/rubocop/cop/performance/redundant_merge.rb
+++ b/lib/rubocop/cop/performance/redundant_merge.rb
@@ -11,8 +11,8 @@ module RuboCop
       #   hash.merge!({'key' => 'value'})
       #   hash.merge!(a: 1, b: 2)
       class RedundantMerge < Cop
-        AREF_ASGN = '%s[%s] = %s'
-        MSG = 'Use `%s` instead of `%s`.'
+        AREF_ASGN = '%s[%s] = %s'.freeze
+        MSG = 'Use `%s` instead of `%s`.'.freeze
 
         def_node_matcher :redundant_merge, '(send $_ :merge! (hash $...))'
         def_node_matcher :modifier_flow_control, '[{if while until} #modifier?]'

--- a/lib/rubocop/cop/performance/redundant_sort_by.rb
+++ b/lib/rubocop/cop/performance/redundant_sort_by.rb
@@ -16,7 +16,7 @@ module RuboCop
       #   @good
       #   array.sort
       class RedundantSortBy < Cop
-        MSG = 'Use `sort` instead of `sort_by { |%s| %s }`.'
+        MSG = 'Use `sort` instead of `sort_by { |%s| %s }`.'.freeze
 
         def_node_matcher :redundant_sort_by, <<-END
           (block $(send _ :sort_by) (args (arg $_x)) (lvar _x))

--- a/lib/rubocop/cop/performance/reverse_each.rb
+++ b/lib/rubocop/cop/performance/reverse_each.rb
@@ -13,7 +13,7 @@ module RuboCop
       #   # good
       #   [].reverse_each
       class ReverseEach < Cop
-        MSG = 'Use `reverse_each` instead of `reverse.each`.'
+        MSG = 'Use `reverse_each` instead of `reverse.each`.'.freeze
 
         def on_send(node)
           receiver, second_method = *node

--- a/lib/rubocop/cop/performance/sample.rb
+++ b/lib/rubocop/cop/performance/sample.rb
@@ -25,7 +25,7 @@ module RuboCop
       #   [1, 2, 3].shuffle[foo, bar]
       #   [1, 2, 3].shuffle(random: Random.new)
       class Sample < Cop
-        MSG = 'Use `%<correct>s` instead of `%<incorrect>s`.'
+        MSG = 'Use `%<correct>s` instead of `%<incorrect>s`.'.freeze
 
         def on_send(node)
           analyzer = ShuffleAnalyzer.new(node)

--- a/lib/rubocop/cop/performance/size.rb
+++ b/lib/rubocop/cop/performance/size.rb
@@ -24,7 +24,7 @@ module RuboCop
       # TODO: Add advanced detection of variables that could
       # have been assigned to an array or a hash.
       class Size < Cop
-        MSG = 'Use `size` instead of `count`.'
+        MSG = 'Use `size` instead of `count`.'.freeze
 
         def on_send(node)
           receiver, method, args = *node

--- a/lib/rubocop/cop/performance/start_with.rb
+++ b/lib/rubocop/cop/performance/start_with.rb
@@ -16,7 +16,7 @@ module RuboCop
       #   'abc' =~ /\A\w*/
       class StartWith < Cop
         MSG = 'Use `String#start_with?` instead of a regex match anchored to ' \
-              'the beginning of the string.'
+              'the beginning of the string.'.freeze
         SINGLE_QUOTE = "'".freeze
 
         def_node_matcher :redundant_regex?, <<-END

--- a/lib/rubocop/cop/performance/string_replacement.rb
+++ b/lib/rubocop/cop/performance/string_replacement.rb
@@ -19,7 +19,7 @@ module RuboCop
       #   'abc'.tr('b', 'd')
       #   'a b c'.delete(' ')
       class StringReplacement < Cop
-        MSG = 'Use `%s` instead of `%s`.'
+        MSG = 'Use `%s` instead of `%s`.'.freeze
         DETERMINISTIC_REGEX = /\A(?:#{LITERAL_REGEX})+\Z/
         REGEXP_CONSTRUCTOR_METHODS = [:new, :compile].freeze
         GSUB_METHODS = [:gsub, :gsub!].freeze

--- a/lib/rubocop/cop/performance/times_map.rb
+++ b/lib/rubocop/cop/performance/times_map.rb
@@ -19,7 +19,7 @@ module RuboCop
       #     i.to_s
       #   end
       class TimesMap < Cop
-        MSG = 'Use `Array.new` with a block instead of `.times.%s`.'
+        MSG = 'Use `Array.new` with a block instead of `.times.%s`.'.freeze
 
         def on_send(node)
           check(node)

--- a/lib/rubocop/cop/rails/action_filter.rb
+++ b/lib/rubocop/cop/rails/action_filter.rb
@@ -10,7 +10,7 @@ module RuboCop
       class ActionFilter < Cop
         include ConfigurableEnforcedStyle
 
-        MSG = 'Prefer `%s` over `%s`.'
+        MSG = 'Prefer `%s` over `%s`.'.freeze
 
         FILTER_METHODS = [
           :after_filter,
@@ -26,7 +26,7 @@ module RuboCop
           :skip_around_filter,
           :skip_before_filter,
           :skip_filter
-        ]
+        ].freeze
 
         ACTION_METHODS = [
           :after_action,
@@ -42,7 +42,7 @@ module RuboCop
           :skip_around_action,
           :skip_before_action,
           :skip_action_callback
-        ]
+        ].freeze
 
         def on_block(node)
           method, _args, _body = *node

--- a/lib/rubocop/cop/rails/date.rb
+++ b/lib/rubocop/cop/rails/date.rb
@@ -38,12 +38,12 @@ module RuboCop
       class Date < Cop
         include ConfigurableEnforcedStyle
 
-        MSG = 'Do not use `%s` without zone. Use `%s` instead.'
+        MSG = 'Do not use `%s` without zone. Use `%s` instead.'.freeze
 
-        MSG_SEND = 'Do not use `%s` on Date objects, ' \
-                   'because they know nothing about the time zone in use.'
+        MSG_SEND = 'Do not use `%s` on Date objects, because they ' \
+                   'know nothing about the time zone in use.'.freeze
 
-        BAD_DAYS = [:today, :current, :yesterday, :tomorrow]
+        BAD_DAYS = [:today, :current, :yesterday, :tomorrow].freeze
 
         def on_const(node)
           mod, klass = *node.children

--- a/lib/rubocop/cop/rails/delegate.rb
+++ b/lib/rubocop/cop/rails/delegate.rb
@@ -29,7 +29,7 @@ module RuboCop
       #     foo.bar
       #   end
       class Delegate < Cop
-        MSG = 'Use `delegate` to define delegations.'
+        MSG = 'Use `delegate` to define delegations.'.freeze
 
         def on_def(node)
           method_name, args, body = *node

--- a/lib/rubocop/cop/rails/find_by.rb
+++ b/lib/rubocop/cop/rails/find_by.rb
@@ -14,8 +14,8 @@ module RuboCop
       #   # good
       #   User.find_by(name: 'Bruce')
       class FindBy < Cop
-        MSG = 'Use `find_by` instead of `where.%s`.'
-        TARGET_SELECTORS = [:first, :take]
+        MSG = 'Use `find_by` instead of `where.%s`.'.freeze
+        TARGET_SELECTORS = [:first, :take].freeze
 
         def_node_matcher :where_first, <<-PATTERN
           (send $(send _ :where ...) ${:first :take})

--- a/lib/rubocop/cop/rails/find_each.rb
+++ b/lib/rubocop/cop/rails/find_each.rb
@@ -13,9 +13,9 @@ module RuboCop
       #   # good
       #   User.all.find_each
       class FindEach < Cop
-        MSG = 'Use `find_each` instead of `each`.'
+        MSG = 'Use `find_each` instead of `each`.'.freeze
 
-        SCOPE_METHODS = [:all, :where]
+        SCOPE_METHODS = [:all, :where].freeze
 
         def on_send(node)
           receiver, second_method, _selector = *node

--- a/lib/rubocop/cop/rails/has_and_belongs_to_many.rb
+++ b/lib/rubocop/cop/rails/has_and_belongs_to_many.rb
@@ -5,7 +5,7 @@ module RuboCop
     module Rails
       # This cop checks for the use of the has_and_belongs_to_many macro.
       class HasAndBelongsToMany < Cop
-        MSG = 'Prefer `has_many :through` to `has_and_belongs_to_many`.'
+        MSG = 'Prefer `has_many :through` to `has_and_belongs_to_many`.'.freeze
 
         def on_send(node)
           return unless node.command?(:has_and_belongs_to_many)

--- a/lib/rubocop/cop/rails/output.rb
+++ b/lib/rubocop/cop/rails/output.rb
@@ -5,13 +5,14 @@ module RuboCop
     module Rails
       # This cop checks for the use of output calls like puts and print
       class Output < Cop
-        MSG = 'Do not write to stdout. Use Rails\' logger if you want to log.'
+        MSG = 'Do not write to stdout. ' \
+              'Use Rails\' logger if you want to log.'.freeze
 
         BLACKLIST = [:puts,
                      :print,
                      :p,
                      :pp,
-                     :pretty_print]
+                     :pretty_print].freeze
 
         def on_send(node)
           receiver, method_name, *args = *node

--- a/lib/rubocop/cop/rails/pluralization_grammar.rb
+++ b/lib/rubocop/cop/rails/pluralization_grammar.rb
@@ -22,11 +22,11 @@ module RuboCop
                                       week: :weeks,
                                       fortnight: :fortnights,
                                       month: :months,
-                                      year: :years }
+                                      year: :years }.freeze
 
         PLURAL_DURATION_METHODS = SINGULAR_DURATION_METHODS.invert
 
-        MSG = 'Prefer `%s.%s`.'
+        MSG = 'Prefer `%s.%s`.'.freeze
 
         def on_send(node)
           receiver, method_name, *_args = *node

--- a/lib/rubocop/cop/rails/read_write_attribute.rb
+++ b/lib/rubocop/cop/rails/read_write_attribute.rb
@@ -16,7 +16,7 @@ module RuboCop
       #   x = self[:attr]
       #   self[:attr] = val
       class ReadWriteAttribute < Cop
-        MSG = 'Prefer `%s` over `%s`.'
+        MSG = 'Prefer `%s` over `%s`.'.freeze
 
         def on_send(node)
           receiver, method_name, *_args = *node

--- a/lib/rubocop/cop/rails/scope_args.rb
+++ b/lib/rubocop/cop/rails/scope_args.rb
@@ -14,7 +14,7 @@ module RuboCop
       #   # good
       #   scope :something, -> { where(something: true) }
       class ScopeArgs < Cop
-        MSG = 'Use `lambda`/`proc` instead of a plain method call.'
+        MSG = 'Use `lambda`/`proc` instead of a plain method call.'.freeze
 
         def on_send(node)
           return unless node.command?(:scope)

--- a/lib/rubocop/cop/rails/time_zone.rb
+++ b/lib/rubocop/cop/rails/time_zone.rb
@@ -30,22 +30,24 @@ module RuboCop
       class TimeZone < Cop
         include ConfigurableEnforcedStyle
 
-        MSG = 'Do not use `%s` without zone. Use `%s` instead.'
+        MSG = 'Do not use `%s` without zone. Use `%s` instead.'.freeze
 
-        MSG_ACCEPTABLE = 'Do not use `%s` without zone. Use one of %s instead.'
+        MSG_ACCEPTABLE = 'Do not use `%s` without zone. ' \
+                         'Use one of %s instead.'.freeze
 
-        MSG_LOCALTIME = 'Do not use `Time.localtime` without offset or zone.'
+        MSG_LOCALTIME = 'Do not use `Time.localtime` without ' \
+                        'offset or zone.'.freeze
 
-        MSG_CURRENT = 'Do not use `%s`. Use `Time.zone.now` instead.'
+        MSG_CURRENT = 'Do not use `%s`. Use `Time.zone.now` instead.'.freeze
 
-        TIMECLASS = [:Time, :DateTime]
+        TIMECLASS = [:Time, :DateTime].freeze
 
         DANGEROUS_METHODS = [:now, :local, :new, :strftime,
-                             :parse, :at, :current]
+                             :parse, :at, :current].freeze
 
         ACCEPTED_METHODS = [:in_time_zone, :utc, :getlocal,
                             :iso8601, :jisx0301, :rfc3339,
-                            :to_i, :to_f]
+                            :to_i, :to_f].freeze
 
         def on_const(node)
           mod, klass = *node

--- a/lib/rubocop/cop/rails/validation.rb
+++ b/lib/rubocop/cop/rails/validation.rb
@@ -5,7 +5,7 @@ module RuboCop
     module Rails
       # This cop checks for the use of old-style attribute validation macros.
       class Validation < Cop
-        MSG = 'Prefer the new style validations `%s` over `%s`.'
+        MSG = 'Prefer the new style validations `%s` over `%s`.'.freeze
 
         BLACKLIST = [:validates_acceptance_of,
                      :validates_confirmation_of,
@@ -16,7 +16,7 @@ module RuboCop
                      :validates_numericality_of,
                      :validates_presence_of,
                      :validates_size_of,
-                     :validates_uniqueness_of]
+                     :validates_uniqueness_of].freeze
 
         WHITELIST = [
           'validates :column, acceptance: value',
@@ -29,7 +29,7 @@ module RuboCop
           'validates :column, presence: value',
           'validates :column, size: value',
           'validates :column, uniqueness: value'
-        ]
+        ].freeze
 
         def on_send(node)
           receiver, method_name, *_args = *node

--- a/lib/rubocop/cop/severity.rb
+++ b/lib/rubocop/cop/severity.rb
@@ -7,11 +7,11 @@ module RuboCop
       include Comparable
 
       # @api private
-      NAMES = [:refactor, :convention, :warning, :error, :fatal]
+      NAMES = [:refactor, :convention, :warning, :error, :fatal].freeze
 
       # @api private
       CODE_TABLE = { R: :refactor, C: :convention,
-                     W: :warning, E: :error, F: :fatal }
+                     W: :warning, E: :error, F: :fatal }.freeze
 
       # @api public
       #

--- a/lib/rubocop/cop/style/access_modifier_indentation.rb
+++ b/lib/rubocop/cop/style/access_modifier_indentation.rb
@@ -10,7 +10,7 @@ module RuboCop
         include ConfigurableEnforcedStyle
         include AccessModifierNode
 
-        MSG = '%s access modifiers like `%s`.'
+        MSG = '%s access modifiers like `%s`.'.freeze
 
         def on_class(node)
           _name, _base_class, body = *node

--- a/lib/rubocop/cop/style/alias.rb
+++ b/lib/rubocop/cop/style/alias.rb
@@ -10,9 +10,9 @@ module RuboCop
       class Alias < Cop
         include ConfigurableEnforcedStyle
 
-        MSG_ALIAS = 'Use `alias_method` instead of `alias`.'
-        MSG_ALIAS_METHOD = 'Use `alias` instead of `alias_method` %s.'
-        MSG_SYMBOL_ARGS  = 'Use `alias %s` instead of `alias %s`.'
+        MSG_ALIAS = 'Use `alias_method` instead of `alias`.'.freeze
+        MSG_ALIAS_METHOD = 'Use `alias` instead of `alias_method` %s.'.freeze
+        MSG_SYMBOL_ARGS  = 'Use `alias %s` instead of `alias %s`.'.freeze
 
         def on_send(node)
           return unless node.method_name == :alias_method && node.receiver.nil?

--- a/lib/rubocop/cop/style/align_array.rb
+++ b/lib/rubocop/cop/style/align_array.rb
@@ -9,7 +9,7 @@ module RuboCop
         include AutocorrectAlignment
 
         MSG = 'Align the elements of an array literal if they span more ' \
-              'than one line.'
+              'than one line.'.freeze
 
         def on_array(node)
           check_alignment(node.children)

--- a/lib/rubocop/cop/style/align_hash.rb
+++ b/lib/rubocop/cop/style/align_hash.rb
@@ -139,7 +139,7 @@ module RuboCop
         end
 
         MSG = 'Align the elements of a hash literal if they span more than ' \
-              'one line.'
+              'one line.'.freeze
 
         def on_send(node)
           return unless (last_child = node.children.last) &&

--- a/lib/rubocop/cop/style/and_or.rb
+++ b/lib/rubocop/cop/style/and_or.rb
@@ -8,9 +8,9 @@ module RuboCop
         include AutocorrectUnlessChangingAST
         include ConfigurableEnforcedStyle
 
-        MSG = 'Use `%s` instead of `%s`.'
+        MSG = 'Use `%s` instead of `%s`.'.freeze
 
-        OPS = { 'and' => '&&', 'or' => '||' }
+        OPS = { 'and' => '&&', 'or' => '||' }.freeze
 
         def on_and(node)
           process_logical_op(node) if style == :always

--- a/lib/rubocop/cop/style/array_join.rb
+++ b/lib/rubocop/cop/style/array_join.rb
@@ -9,7 +9,7 @@ module RuboCop
       # types, so we consider only cases when the first argument is an
       # array literal or the second is a string literal.
       class ArrayJoin < Cop
-        MSG = 'Favor `Array#join` over `Array#*`.'
+        MSG = 'Favor `Array#join` over `Array#*`.'.freeze
 
         def on_send(node)
           receiver_node, method_name, *arg_nodes = *node

--- a/lib/rubocop/cop/style/ascii_comments.rb
+++ b/lib/rubocop/cop/style/ascii_comments.rb
@@ -6,7 +6,7 @@ module RuboCop
       # This cop checks for non-ascii (non-English) characters
       # in comments.
       class AsciiComments < Cop
-        MSG = 'Use only ascii symbols in comments.'
+        MSG = 'Use only ascii symbols in comments.'.freeze
 
         def investigate(processed_source)
           processed_source.comments.each do |comment|

--- a/lib/rubocop/cop/style/ascii_identifiers.rb
+++ b/lib/rubocop/cop/style/ascii_identifiers.rb
@@ -5,7 +5,7 @@ module RuboCop
     module Style
       # This cop checks for non-ascii characters in identifier names.
       class AsciiIdentifiers < Cop
-        MSG = 'Use only ascii symbols in identifiers.'
+        MSG = 'Use only ascii symbols in identifiers.'.freeze
 
         def investigate(processed_source)
           processed_source.tokens.each do |t|

--- a/lib/rubocop/cop/style/auto_resource_cleanup.rb
+++ b/lib/rubocop/cop/style/auto_resource_cleanup.rb
@@ -17,11 +17,11 @@ module RuboCop
       #     ...
       #   end
       class AutoResourceCleanup < Cop
-        MSG = 'Use the block version of `%s.%s`.'
+        MSG = 'Use the block version of `%s.%s`.'.freeze
 
         TARGET_METHODS = [
           [:File, :open]
-        ]
+        ].freeze
 
         def on_send(node)
           receiver_node, method_name, *arg_nodes = *node

--- a/lib/rubocop/cop/style/bare_percent_literals.rb
+++ b/lib/rubocop/cop/style/bare_percent_literals.rb
@@ -7,7 +7,7 @@ module RuboCop
       class BarePercentLiterals < Cop
         include ConfigurableEnforcedStyle
 
-        MSG = 'Use `%%%s` instead of `%%%s`.'
+        MSG = 'Use `%%%s` instead of `%%%s`.'.freeze
 
         def on_dstr(node)
           check(node)

--- a/lib/rubocop/cop/style/begin_block.rb
+++ b/lib/rubocop/cop/style/begin_block.rb
@@ -5,7 +5,7 @@ module RuboCop
     module Style
       # This cop checks for BEGIN blocks.
       class BeginBlock < Cop
-        MSG = 'Avoid the use of `BEGIN` blocks.'
+        MSG = 'Avoid the use of `BEGIN` blocks.'.freeze
 
         def on_preexe(node)
           add_offense(node, :keyword)

--- a/lib/rubocop/cop/style/block_comments.rb
+++ b/lib/rubocop/cop/style/block_comments.rb
@@ -5,7 +5,7 @@ module RuboCop
     module Style
       # This cop looks for uses of block comments (=begin...=end).
       class BlockComments < Cop
-        MSG = 'Do not use block comments.'
+        MSG = 'Do not use block comments.'.freeze
         BEGIN_LENGTH = "=begin\n".length
         END_LENGTH = "\n=end".length
 

--- a/lib/rubocop/cop/style/block_end_newline.rb
+++ b/lib/rubocop/cop/style/block_end_newline.rb
@@ -25,7 +25,7 @@ module RuboCop
       #     foo(i)
       #   }
       class BlockEndNewline < Cop
-        MSG = 'Expression at %d, %d should be on its own line.'
+        MSG = 'Expression at %d, %d should be on its own line.'.freeze
 
         def on_block(node)
           end_loc = node.loc.end

--- a/lib/rubocop/cop/style/braces_around_hash_parameters.rb
+++ b/lib/rubocop/cop/style/braces_around_hash_parameters.rb
@@ -9,7 +9,7 @@ module RuboCop
         include ConfigurableEnforcedStyle
         include AutocorrectUnlessChangingAST
 
-        MSG = '%s curly braces around a hash parameter.'
+        MSG = '%s curly braces around a hash parameter.'.freeze
 
         def on_send(node)
           _receiver, method_name, *args = *node

--- a/lib/rubocop/cop/style/case_equality.rb
+++ b/lib/rubocop/cop/style/case_equality.rb
@@ -5,7 +5,7 @@ module RuboCop
     module Style
       # This cop checks for uses of the case equality operator(===).
       class CaseEquality < Cop
-        MSG = 'Avoid the use of the case equality operator `===`.'
+        MSG = 'Avoid the use of the case equality operator `===`.'.freeze
 
         def on_send(node)
           _receiver, method_name, *_args = *node

--- a/lib/rubocop/cop/style/character_literal.rb
+++ b/lib/rubocop/cop/style/character_literal.rb
@@ -7,7 +7,8 @@ module RuboCop
       class CharacterLiteral < Cop
         include StringHelp
 
-        MSG = 'Do not use the character literal - use string literal instead.'
+        MSG = 'Do not use the character literal - ' \
+              'use string literal instead.'.freeze
 
         def offense?(node)
           # we don't register an offense for things like ?\C-\M-d

--- a/lib/rubocop/cop/style/class_and_module_camel_case.rb
+++ b/lib/rubocop/cop/style/class_and_module_camel_case.rb
@@ -6,7 +6,7 @@ module RuboCop
       # This cops checks for class and module names with
       # an underscore in them.
       class ClassAndModuleCamelCase < Cop
-        MSG = 'Use CamelCase for classes and modules.'
+        MSG = 'Use CamelCase for classes and modules.'.freeze
 
         def on_class(node)
           check_name(node)

--- a/lib/rubocop/cop/style/class_and_module_children.rb
+++ b/lib/rubocop/cop/style/class_and_module_children.rb
@@ -21,10 +21,10 @@ module RuboCop
         include ConfigurableEnforcedStyle
 
         NESTED_MSG = 'Use nested module/class definitions instead of ' \
-                     'compact style.'
+                     'compact style.'.freeze
 
         COMPACT_MSG = 'Use compact module/class definition instead of ' \
-                      'nested style.'
+                      'nested style.'.freeze
 
         def on_class(node)
           _name, _superclass, body = *node

--- a/lib/rubocop/cop/style/class_check.rb
+++ b/lib/rubocop/cop/style/class_check.rb
@@ -7,7 +7,7 @@ module RuboCop
       class ClassCheck < Cop
         include ConfigurableEnforcedStyle
 
-        MSG = 'Prefer `Object#%s` over `Object#%s`.'
+        MSG = 'Prefer `Object#%s` over `Object#%s`.'.freeze
 
         def on_send(node)
           _receiver, method_name, *_args = *node

--- a/lib/rubocop/cop/style/class_methods.rb
+++ b/lib/rubocop/cop/style/class_methods.rb
@@ -21,7 +21,7 @@ module RuboCop
       #     end
       #   end
       class ClassMethods < Cop
-        MSG = 'Use `self.%s` instead of `%s.%s`.'
+        MSG = 'Use `self.%s` instead of `%s.%s`.'.freeze
 
         def on_class(node)
           name, _superclass, body = *node

--- a/lib/rubocop/cop/style/class_vars.rb
+++ b/lib/rubocop/cop/style/class_vars.rb
@@ -7,7 +7,7 @@ module RuboCop
       # are signaled only on assignment to class variables to
       # reduced the number of offenses that would be reported.
       class ClassVars < Cop
-        MSG = 'Replace class var %s with a class instance var.'
+        MSG = 'Replace class var %s with a class instance var.'.freeze
 
         def on_cvasgn(node)
           add_offense(node, :name)

--- a/lib/rubocop/cop/style/closing_parenthesis_indentation.rb
+++ b/lib/rubocop/cop/style/closing_parenthesis_indentation.rb
@@ -30,8 +30,8 @@ module RuboCop
         include OnMethodDef
 
         MSG_INDENT =
-          'Indent `)` the same as the start of the line where `(` is.'
-        MSG_ALIGN = 'Align `)` with `(`.'
+          'Indent `)` the same as the start of the line where `(` is.'.freeze
+        MSG_ALIGN = 'Align `)` with `(`.'.freeze
 
         def on_send(node)
           _receiver, _method_name, *args = *node

--- a/lib/rubocop/cop/style/collection_methods.rb
+++ b/lib/rubocop/cop/style/collection_methods.rb
@@ -12,7 +12,7 @@ module RuboCop
       class CollectionMethods < Cop
         include MethodPreference
 
-        MSG = 'Prefer `%s` over `%s`.'
+        MSG = 'Prefer `%s` over `%s`.'.freeze
 
         def on_block(node)
           method, _args, _body = *node

--- a/lib/rubocop/cop/style/colon_method_call.rb
+++ b/lib/rubocop/cop/style/colon_method_call.rb
@@ -6,10 +6,10 @@ module RuboCop
       # This cop checks for methods invoked via the :: operator instead
       # of the . operator (like FileUtils::rmdir instead of FileUtils.rmdir).
       class ColonMethodCall < Cop
-        MSG = 'Do not use `::` for method calls.'
+        MSG = 'Do not use `::` for method calls.'.freeze
 
         JAVA_TYPES = [:byte, :boolean, :byte, :short, :char,
-                      :int, :long, :float, :double]
+                      :int, :long, :float, :double].freeze
 
         JAVA_TYPE_NODES =
           JAVA_TYPES.map { |t| s(:send, s(:const, nil, :Java), t) }

--- a/lib/rubocop/cop/style/command_literal.rb
+++ b/lib/rubocop/cop/style/command_literal.rb
@@ -29,8 +29,8 @@ module RuboCop
       class CommandLiteral < Cop
         include ConfigurableEnforcedStyle
 
-        MSG_USE_BACKTICKS = 'Use backticks around command string.'
-        MSG_USE_PERCENT_X = 'Use `%x` around command string.'
+        MSG_USE_BACKTICKS = 'Use backticks around command string.'.freeze
+        MSG_USE_PERCENT_X = 'Use `%x` around command string.'.freeze
 
         def on_xstr(node)
           return if heredoc_literal?(node)

--- a/lib/rubocop/cop/style/comment_annotation.rb
+++ b/lib/rubocop/cop/style/comment_annotation.rb
@@ -10,9 +10,9 @@ module RuboCop
 
         MSG = 'Annotation keywords like `%s` should be all upper case, ' \
               'followed by a colon, and a space, ' \
-              'then a note describing the problem.'
+              'then a note describing the problem.'.freeze
         MISSING_NOTE = 'Annotation comment, with keyword `%s`, ' \
-                       'is missing a note.'
+                       'is missing a note.'.freeze
 
         def investigate(processed_source)
           processed_source.comments.each_with_index do |comment, ix|

--- a/lib/rubocop/cop/style/comment_indentation.rb
+++ b/lib/rubocop/cop/style/comment_indentation.rb
@@ -7,7 +7,7 @@ module RuboCop
       class CommentIndentation < Cop
         include AutocorrectAlignment
 
-        MSG = 'Incorrect indentation detected (column %d instead of %d).'
+        MSG = 'Incorrect indentation detected (column %d instead of %d).'.freeze
 
         def investigate(processed_source)
           processed_source.comments.each { |comment| check(comment) }

--- a/lib/rubocop/cop/style/conditional_assignment.rb
+++ b/lib/rubocop/cop/style/conditional_assignment.rb
@@ -134,7 +134,7 @@ module RuboCop
         include ConditionalAssignmentHelper
 
         MSG = 'Use the return of the conditional for variable assignment ' \
-              'and comparison.'
+              'and comparison.'.freeze
         VARIABLE_ASSIGNMENT_TYPES =
           [:casgn, :cvasgn, :gvasgn, :ivasgn, :lvasgn].freeze
         ASSIGNMENT_TYPES =

--- a/lib/rubocop/cop/style/constant_name.rb
+++ b/lib/rubocop/cop/style/constant_name.rb
@@ -9,7 +9,7 @@ module RuboCop
       # To avoid false positives, it ignores cases in which we cannot know
       # for certain the type of value that would be assigned to a constant.
       class ConstantName < Cop
-        MSG = 'Use SCREAMING_SNAKE_CASE for constants.'
+        MSG = 'Use SCREAMING_SNAKE_CASE for constants.'.freeze
         SNAKE_CASE = /^[\dA-Z_]+$/
 
         def on_casgn(node)

--- a/lib/rubocop/cop/style/def_with_parentheses.rb
+++ b/lib/rubocop/cop/style/def_with_parentheses.rb
@@ -10,7 +10,7 @@ module RuboCop
         include OnMethodDef
 
         MSG = "Omit the parentheses in defs when the method doesn't accept " \
-              'any arguments.'
+              'any arguments.'.freeze
 
         def on_method_def(node, _method_name, args, _body)
           start_line = node.loc.keyword.line

--- a/lib/rubocop/cop/style/deprecated_hash_methods.rb
+++ b/lib/rubocop/cop/style/deprecated_hash_methods.rb
@@ -6,9 +6,9 @@ module RuboCop
       # This cop checks for uses of the deprecated methods Hash#has_key?
       # and Hash#has_value?
       class DeprecatedHashMethods < Cop
-        MSG = '`Hash#%s` is deprecated in favor of `Hash#%s`.'
+        MSG = '`Hash#%s` is deprecated in favor of `Hash#%s`.'.freeze
 
-        DEPRECATED_METHODS = [:has_key?, :has_value?]
+        DEPRECATED_METHODS = [:has_key?, :has_value?].freeze
 
         def on_send(node)
           _receiver, method_name, *args = *node

--- a/lib/rubocop/cop/style/documentation.rb
+++ b/lib/rubocop/cop/style/documentation.rb
@@ -14,7 +14,7 @@ module RuboCop
       class Documentation < Cop
         include AnnotationComment
 
-        MSG = 'Missing top-level %s documentation comment.'
+        MSG = 'Missing top-level %s documentation comment.'.freeze
 
         def_node_matcher :constant_definition?, '{class module casgn}'
 

--- a/lib/rubocop/cop/style/double_negation.rb
+++ b/lib/rubocop/cop/style/double_negation.rb
@@ -20,7 +20,7 @@ module RuboCop
       # As you're unlikely to write code that can accept values of any type
       # this is rarely a problem in practice.
       class DoubleNegation < Cop
-        MSG = 'Avoid the use of double negation (`!!`).'
+        MSG = 'Avoid the use of double negation (`!!`).'.freeze
 
         def_node_matcher :double_negative?, '(send (send _ :!) :!)'
 

--- a/lib/rubocop/cop/style/each_with_object.rb
+++ b/lib/rubocop/cop/style/each_with_object.rb
@@ -17,8 +17,8 @@ module RuboCop
       #   # good
       #   [1, 2].each_with_object({}) { |e, a| a[e] = e }
       class EachWithObject < Cop
-        MSG = 'Use `each_with_object` instead of `%s`.'
-        METHODS = [:inject, :reduce]
+        MSG = 'Use `each_with_object` instead of `%s`.'.freeze
+        METHODS = [:inject, :reduce].freeze
 
         def on_block(node)
           method, args, body = *node

--- a/lib/rubocop/cop/style/else_alignment.rb
+++ b/lib/rubocop/cop/style/else_alignment.rb
@@ -12,7 +12,7 @@ module RuboCop
         include AutocorrectAlignment
         include CheckAssignment
 
-        MSG = 'Align `%s` with `%s`.'
+        MSG = 'Align `%s` with `%s`.'.freeze
 
         def on_if(node, base = nil)
           return if ignored_node?(node)

--- a/lib/rubocop/cop/style/empty_else.rb
+++ b/lib/rubocop/cop/style/empty_else.rb
@@ -69,7 +69,7 @@ module RuboCop
         include OnNormalIfUnless
         include ConfigurableEnforcedStyle
 
-        MSG = 'Redundant `else`-clause.'
+        MSG = 'Redundant `else`-clause.'.freeze
 
         def on_normal_if_unless(node)
           check(node, if_else_clause(node))

--- a/lib/rubocop/cop/style/empty_line_between_defs.rb
+++ b/lib/rubocop/cop/style/empty_line_between_defs.rb
@@ -7,7 +7,7 @@ module RuboCop
       # separated by empty lines.
       class EmptyLineBetweenDefs < Cop
         include OnMethodDef
-        MSG = 'Use empty lines between method definitions.'
+        MSG = 'Use empty lines between method definitions.'.freeze
 
         def on_method_def(node, _method_name, _args, _body)
           return unless node.parent && node.parent.begin_type?

--- a/lib/rubocop/cop/style/empty_lines.rb
+++ b/lib/rubocop/cop/style/empty_lines.rb
@@ -7,7 +7,7 @@ module RuboCop
     module Style
       # This cops checks for two or more consecutive blank lines.
       class EmptyLines < Cop
-        MSG = 'Extra blank line detected.'
+        MSG = 'Extra blank line detected.'.freeze
         LINE_OFFSET = 2
 
         def investigate(processed_source)

--- a/lib/rubocop/cop/style/empty_lines_around_access_modifier.rb
+++ b/lib/rubocop/cop/style/empty_lines_around_access_modifier.rb
@@ -7,7 +7,7 @@ module RuboCop
       class EmptyLinesAroundAccessModifier < Cop
         include AccessModifierNode
 
-        MSG = 'Keep a blank line before and after `%s`.'
+        MSG = 'Keep a blank line before and after `%s`.'.freeze
 
         def on_send(node)
           return unless modifier_node?(node)

--- a/lib/rubocop/cop/style/empty_lines_around_block_body.rb
+++ b/lib/rubocop/cop/style/empty_lines_around_block_body.rb
@@ -16,7 +16,7 @@ module RuboCop
       class EmptyLinesAroundBlockBody < Cop
         include EmptyLinesAroundBody
 
-        KIND = 'block'
+        KIND = 'block'.freeze
 
         def on_block(node)
           _send, _args, body = *node

--- a/lib/rubocop/cop/style/empty_lines_around_class_body.rb
+++ b/lib/rubocop/cop/style/empty_lines_around_class_body.rb
@@ -19,7 +19,7 @@ module RuboCop
       class EmptyLinesAroundClassBody < Cop
         include EmptyLinesAroundBody
 
-        KIND = 'class'
+        KIND = 'class'.freeze
 
         def on_class(node)
           _name, _superclass, body = *node

--- a/lib/rubocop/cop/style/empty_lines_around_method_body.rb
+++ b/lib/rubocop/cop/style/empty_lines_around_method_body.rb
@@ -17,7 +17,7 @@ module RuboCop
         include EmptyLinesAroundBody
         include OnMethodDef
 
-        KIND = 'method'
+        KIND = 'method'.freeze
 
         private
 

--- a/lib/rubocop/cop/style/empty_lines_around_module_body.rb
+++ b/lib/rubocop/cop/style/empty_lines_around_module_body.rb
@@ -19,7 +19,7 @@ module RuboCop
       class EmptyLinesAroundModuleBody < Cop
         include EmptyLinesAroundBody
 
-        KIND = 'module'
+        KIND = 'module'.freeze
 
         def on_module(node)
           _name, body = *node

--- a/lib/rubocop/cop/style/empty_literal.rb
+++ b/lib/rubocop/cop/style/empty_literal.rb
@@ -6,9 +6,9 @@ module RuboCop
       # This cop checks for the use of a method, the result of which
       # would be a literal, like an empty array, hash or string.
       class EmptyLiteral < Cop
-        ARR_MSG = 'Use array literal `[]` instead of `Array.new`.'
-        HASH_MSG = 'Use hash literal `{}` instead of `Hash.new`.'
-        STR_MSG = "Use string literal `''` instead of `String.new`."
+        ARR_MSG = 'Use array literal `[]` instead of `Array.new`.'.freeze
+        HASH_MSG = 'Use hash literal `{}` instead of `Hash.new`.'.freeze
+        STR_MSG = "Use string literal `''` instead of `String.new`.".freeze
 
         # Empty array node
         #

--- a/lib/rubocop/cop/style/encoding.rb
+++ b/lib/rubocop/cop/style/encoding.rb
@@ -14,8 +14,8 @@ module RuboCop
       class Encoding < Cop
         include ConfigurableEnforcedStyle
 
-        MSG_MISSING = 'Missing utf-8 encoding comment.'
-        MSG_UNNECESSARY = 'Unnecessary utf-8 encoding comment.'
+        MSG_MISSING = 'Missing utf-8 encoding comment.'.freeze
+        MSG_UNNECESSARY = 'Unnecessary utf-8 encoding comment.'.freeze
         ENCODING_PATTERN = /#.*coding\s?[:=]\s?(?:UTF|utf)-8/.freeze
         AUTO_CORRECT_ENCODING_COMMENT = 'AutoCorrectEncodingComment'.freeze
         SHEBANG = '#!'.freeze

--- a/lib/rubocop/cop/style/end_block.rb
+++ b/lib/rubocop/cop/style/end_block.rb
@@ -5,7 +5,8 @@ module RuboCop
     module Style
       # This cop checks for END blocks.
       class EndBlock < Cop
-        MSG = 'Avoid the use of `END` blocks. Use `Kernel#at_exit` instead.'
+        MSG = 'Avoid the use of `END` blocks. ' \
+              'Use `Kernel#at_exit` instead.'.freeze
 
         def on_postexe(node)
           add_offense(node, :keyword)

--- a/lib/rubocop/cop/style/end_of_line.rb
+++ b/lib/rubocop/cop/style/end_of_line.rb
@@ -5,7 +5,7 @@ module RuboCop
     module Style
       # This cop checks for Windows-style line endings in the source code.
       class EndOfLine < Cop
-        MSG = 'Carriage return character detected.'
+        MSG = 'Carriage return character detected.'.freeze
 
         def investigate(processed_source)
           last_token = processed_source.tokens.last

--- a/lib/rubocop/cop/style/even_odd.rb
+++ b/lib/rubocop/cop/style/even_odd.rb
@@ -14,7 +14,7 @@ module RuboCop
       #   # good
       #   if x.even?
       class EvenOdd < Cop
-        MSG = 'Replace with `Fixnum#%s?`.'
+        MSG = 'Replace with `Fixnum#%s?`.'.freeze
 
         ZERO = s(:int, 0)
         ONE = s(:int, 1)

--- a/lib/rubocop/cop/style/extra_spacing.rb
+++ b/lib/rubocop/cop/style/extra_spacing.rb
@@ -22,8 +22,8 @@ module RuboCop
       class ExtraSpacing < Cop
         include PrecedingFollowingAlignment
 
-        MSG_UNNECESSARY = 'Unnecessary spacing detected.'
-        MSG_UNALIGNED_ASGN = '`=` is not aligned with the %s assignment.'
+        MSG_UNNECESSARY = 'Unnecessary spacing detected.'.freeze
+        MSG_UNALIGNED_ASGN = '`=` is not aligned with the %s assignment.'.freeze
 
         def investigate(processed_source)
           ast = processed_source.ast

--- a/lib/rubocop/cop/style/file_name.rb
+++ b/lib/rubocop/cop/style/file_name.rb
@@ -9,9 +9,10 @@ module RuboCop
       # names. Ruby scripts (i.e. source files with a shebang in the
       # first line) are ignored.
       class FileName < Cop
-        MSG_SNAKE_CASE = 'Use snake_case for source file names.'
-        MSG_NO_DEFINITION = '%s should define a class or module called `%s`.'
-        MSG_REGEX = '`%s` should match `%s`.'
+        MSG_SNAKE_CASE = 'Use snake_case for source file names.'.freeze
+        MSG_NO_DEFINITION = '%s should define a class or module ' \
+                            'called `%s`.'.freeze
+        MSG_REGEX = '`%s` should match `%s`.'.freeze
 
         SNAKE_CASE = /^[\da-z_]+$/
 

--- a/lib/rubocop/cop/style/first_array_element_line_break.rb
+++ b/lib/rubocop/cop/style/first_array_element_line_break.rb
@@ -21,7 +21,7 @@ module RuboCop
         include FirstElementLineBreak
 
         MSG = 'Add a line break before the first element of a ' \
-              'multi-line array.'
+              'multi-line array.'.freeze
 
         def on_array(node)
           return if !node.loc.begin && !assignment_on_same_line?(node)

--- a/lib/rubocop/cop/style/first_hash_element_line_break.rb
+++ b/lib/rubocop/cop/style/first_hash_element_line_break.rb
@@ -20,7 +20,7 @@ module RuboCop
         include FirstElementLineBreak
 
         MSG = 'Add a line break before the first element of a ' \
-              'multi-line hash.'
+              'multi-line hash.'.freeze
 
         def on_hash(node)
           # node.loc.begin tells us whether the hash opens with a {

--- a/lib/rubocop/cop/style/first_method_argument_line_break.rb
+++ b/lib/rubocop/cop/style/first_method_argument_line_break.rb
@@ -24,7 +24,7 @@ module RuboCop
         include FirstElementLineBreak
 
         MSG = 'Add a line break before the first argument of a ' \
-              'multi-line method argument list.'
+              'multi-line method argument list.'.freeze
 
         def on_send(node)
           _receiver, _name, *args = *node

--- a/lib/rubocop/cop/style/first_method_parameter_line_break.rb
+++ b/lib/rubocop/cop/style/first_method_parameter_line_break.rb
@@ -31,7 +31,7 @@ module RuboCop
         include FirstElementLineBreak
 
         MSG = 'Add a line break before the first parameter of a ' \
-              'multi-line method parameter list.'
+              'multi-line method parameter list.'.freeze
 
         def on_method_def(node, _method_name, args, _body)
           check_method_line_break(node, args.to_a)

--- a/lib/rubocop/cop/style/flip_flop.rb
+++ b/lib/rubocop/cop/style/flip_flop.rb
@@ -5,7 +5,7 @@ module RuboCop
     module Style
       # This cop looks for uses of flip flop operator
       class FlipFlop < Cop
-        MSG = 'Avoid the use of flip flop operators.'
+        MSG = 'Avoid the use of flip flop operators.'.freeze
 
         def on_iflipflop(node)
           add_offense(node, :expression)

--- a/lib/rubocop/cop/style/global_vars.rb
+++ b/lib/rubocop/cop/style/global_vars.rb
@@ -10,7 +10,7 @@ module RuboCop
       #
       # Note that backreferences like $1, $2, etc are not global variables.
       class GlobalVars < Cop
-        MSG = 'Do not introduce global variables.'
+        MSG = 'Do not introduce global variables.'.freeze
 
         # predefined global variables their English aliases
         # http://www.zenspider.com/Languages/Ruby/QuickRef.html

--- a/lib/rubocop/cop/style/guard_clause.rb
+++ b/lib/rubocop/cop/style/guard_clause.rb
@@ -41,7 +41,7 @@ module RuboCop
         include MinBodyLength
 
         MSG = 'Use a guard clause instead of wrapping the code inside a ' \
-              'conditional expression.'
+              'conditional expression.'.freeze
 
         def_node_matcher :single_line_control_flow_exit?, <<-PATTERN
           [{(send nil {:raise :fail} ...) return break next} single_line?]

--- a/lib/rubocop/cop/style/hash_syntax.rb
+++ b/lib/rubocop/cop/style/hash_syntax.rb
@@ -12,9 +12,9 @@ module RuboCop
       class HashSyntax < Cop
         include ConfigurableEnforcedStyle
 
-        MSG_19 = 'Use the new Ruby 1.9 hash syntax.'
-        MSG_RUBY19_NO_MIXED_KEYS = "Don't mix styles in the same hash."
-        MSG_HASH_ROCKETS = 'Use hash rockets syntax.'
+        MSG_19 = 'Use the new Ruby 1.9 hash syntax.'.freeze
+        MSG_RUBY19_NO_MIXED_KEYS = "Don't mix styles in the same hash.".freeze
+        MSG_HASH_ROCKETS = 'Use hash rockets syntax.'.freeze
 
         @force_hash_rockets = false
 

--- a/lib/rubocop/cop/style/identical_conditional_branches.rb
+++ b/lib/rubocop/cop/style/identical_conditional_branches.rb
@@ -26,7 +26,7 @@ module RuboCop
       class IdenticalConditionalBranches < Cop
         include IfNode
 
-        MSG = 'Move `%s` out of the conditional.'
+        MSG = 'Move `%s` out of the conditional.'.freeze
 
         def on_if(node)
           return if elsif?(node)

--- a/lib/rubocop/cop/style/if_inside_else.rb
+++ b/lib/rubocop/cop/style/if_inside_else.rb
@@ -30,7 +30,7 @@ module RuboCop
       class IfInsideElse < Cop
         include IfNode
 
-        MSG = 'Convert `if` nested inside `else` to `elsif`.'
+        MSG = 'Convert `if` nested inside `else` to `elsif`.'.freeze
 
         def on_if(node)
           _cond, _if_branch, else_branch = *node

--- a/lib/rubocop/cop/style/if_unless_modifier.rb
+++ b/lib/rubocop/cop/style/if_unless_modifier.rb
@@ -9,7 +9,8 @@ module RuboCop
       class IfUnlessModifier < Cop
         include StatementModifier
 
-        ASSIGNMENT_TYPES = [:lvasgn, :casgn, :cvasgn, :gvasgn, :ivasgn, :masgn]
+        ASSIGNMENT_TYPES = [:lvasgn, :casgn, :cvasgn,
+                            :gvasgn, :ivasgn, :masgn].freeze
 
         def message(keyword)
           "Favor modifier `#{keyword}` usage when having a single-line body." \

--- a/lib/rubocop/cop/style/if_with_semicolon.rb
+++ b/lib/rubocop/cop/style/if_with_semicolon.rb
@@ -7,7 +7,7 @@ module RuboCop
       class IfWithSemicolon < Cop
         include OnNormalIfUnless
 
-        MSG = 'Do not use if x; Use the ternary operator instead.'
+        MSG = 'Do not use if x; Use the ternary operator instead.'.freeze
 
         def on_normal_if_unless(node)
           beginning = node.loc.begin

--- a/lib/rubocop/cop/style/indent_assignment.rb
+++ b/lib/rubocop/cop/style/indent_assignment.rb
@@ -26,7 +26,7 @@ module RuboCop
         include AutocorrectAlignment
 
         MSG = 'Indent the first line of the right-hand-side of a ' \
-              'multi-line assignment.'
+              'multi-line assignment.'.freeze
 
         def check_assignment(node, rhs)
           return unless rhs

--- a/lib/rubocop/cop/style/indentation_consistency.rb
+++ b/lib/rubocop/cop/style/indentation_consistency.rb
@@ -18,7 +18,7 @@ module RuboCop
         include AccessModifierNode
         include ConfigurableEnforcedStyle
 
-        MSG = 'Inconsistent indentation detected.'
+        MSG = 'Inconsistent indentation detected.'.freeze
 
         def on_begin(node)
           check(node)

--- a/lib/rubocop/cop/style/infinite_loop.rb
+++ b/lib/rubocop/cop/style/infinite_loop.rb
@@ -16,7 +16,7 @@ module RuboCop
       #     work
       #   end
       class InfiniteLoop < Cop
-        MSG = 'Use `Kernel#loop` for infinite loops.'
+        MSG = 'Use `Kernel#loop` for infinite loops.'.freeze
 
         def on_while(node)
           condition, = *node

--- a/lib/rubocop/cop/style/initial_indentation.rb
+++ b/lib/rubocop/cop/style/initial_indentation.rb
@@ -6,7 +6,7 @@ module RuboCop
       # This cops checks for indentation of the first non-blank non-comment
       # line in a file.
       class InitialIndentation < Cop
-        MSG = 'Indentation of first line in file detected.'
+        MSG = 'Indentation of first line in file detected.'.freeze
 
         def investigate(processed_source)
           first_token = processed_source.tokens.find do |t|

--- a/lib/rubocop/cop/style/inline_comment.rb
+++ b/lib/rubocop/cop/style/inline_comment.rb
@@ -5,7 +5,7 @@ module RuboCop
     module Style
       # This cop checks for inline comments.
       class InlineComment < Cop
-        MSG = 'Avoid inline comments.'
+        MSG = 'Avoid inline comments.'.freeze
 
         def investigate(processed_source)
           processed_source.comments.each do |comment|

--- a/lib/rubocop/cop/style/lambda.rb
+++ b/lib/rubocop/cop/style/lambda.rb
@@ -9,9 +9,11 @@ module RuboCop
       class Lambda < Cop
         include AutocorrectUnlessChangingAST
 
-        SINGLE_MSG = 'Use the new lambda literal syntax `->(params) {...}`.'
-        SINGLE_NO_ARG_MSG = 'Use the new lambda literal syntax `-> {...}`.'
-        MULTI_MSG = 'Use the `lambda` method for multi-line lambdas.'
+        SINGLE_MSG = 'Use the new lambda literal syntax ' \
+                     '`->(params) {...}`.'.freeze
+        SINGLE_NO_ARG_MSG = 'Use the new lambda literal syntax ' \
+                            '`-> {...}`.'.freeze
+        MULTI_MSG = 'Use the `lambda` method for multi-line lambdas.'.freeze
 
         TARGET = s(:send, nil, :lambda)
 

--- a/lib/rubocop/cop/style/leading_comment_space.rb
+++ b/lib/rubocop/cop/style/leading_comment_space.rb
@@ -9,7 +9,7 @@ module RuboCop
       # like #++, #--, #:nodoc, etc. Neither is it required for
       # =begin/=end comments.
       class LeadingCommentSpace < Cop
-        MSG = 'Missing space after #.'
+        MSG = 'Missing space after #.'.freeze
 
         def investigate(processed_source)
           processed_source.comments.each do |comment|

--- a/lib/rubocop/cop/style/line_end_concatenation.rb
+++ b/lib/rubocop/cop/style/line_end_concatenation.rb
@@ -20,7 +20,8 @@ module RuboCop
       #              'bala'
       #
       class LineEndConcatenation < Cop
-        MSG = 'Use `\\` instead of `+` or `<<` to concatenate those strings.'
+        MSG = 'Use `\\` instead of `+` or `<<` to concatenate ' \
+              'those strings.'.freeze
         CONCAT_TOKEN_TYPES = [:tPLUS, :tLSHFT].freeze
         SIMPLE_STRING_TOKEN_TYPE = :tSTRING
         COMPLEX_STRING_EDGE_TOKEN_TYPES = [:tSTRING_BEG, :tSTRING_END].freeze

--- a/lib/rubocop/cop/style/method_call_parentheses.rb
+++ b/lib/rubocop/cop/style/method_call_parentheses.rb
@@ -5,7 +5,8 @@ module RuboCop
     module Style
       # This cop checks for unwanted parentheses in parameterless method calls.
       class MethodCallParentheses < Cop
-        MSG = 'Do not use parentheses for method calls with no arguments.'
+        MSG = 'Do not use parentheses for method calls with ' \
+              'no arguments.'.freeze
 
         ASGN_NODES = [:lvasgn, :masgn] + Util::SHORTHAND_ASGN_NODES
 

--- a/lib/rubocop/cop/style/method_called_on_do_end_block.rb
+++ b/lib/rubocop/cop/style/method_called_on_do_end_block.rb
@@ -13,7 +13,7 @@ module RuboCop
       #     b
       #   end.c
       class MethodCalledOnDoEndBlock < Cop
-        MSG = 'Avoid chaining a method call on a do...end block.'
+        MSG = 'Avoid chaining a method call on a do...end block.'.freeze
 
         def on_block(node)
           method, _args, _body = *node

--- a/lib/rubocop/cop/style/missing_else.rb
+++ b/lib/rubocop/cop/style/missing_else.rb
@@ -32,9 +32,10 @@ module RuboCop
         include OnNormalIfUnless
         include ConfigurableEnforcedStyle
 
-        MSG = '`%s` condition requires an `else`-clause.'
-        MSG_NIL = '`%s` condition requires an `else`-clause with `nil` in it.'
-        MSG_EMPTY = '`%s` condition requires an empty `else`-clause.'
+        MSG = '`%s` condition requires an `else`-clause.'.freeze
+        MSG_NIL = '`%s` condition requires an `else`-clause with ' \
+                  '`nil` in it.'.freeze
+        MSG_EMPTY = '`%s` condition requires an empty `else`-clause.'.freeze
 
         def on_normal_if_unless(node)
           unless_else_cop = config.for_cop('Style/UnlessElse')

--- a/lib/rubocop/cop/style/module_function.rb
+++ b/lib/rubocop/cop/style/module_function.rb
@@ -13,7 +13,7 @@ module RuboCop
       #     ...
       # end
       class ModuleFunction < Cop
-        MSG = 'Use `module_function` instead of `extend self`.'
+        MSG = 'Use `module_function` instead of `extend self`.'.freeze
 
         TARGET_NODE = s(:send, nil, :extend, s(:self))
 

--- a/lib/rubocop/cop/style/multiline_array_brace_layout.rb
+++ b/lib/rubocop/cop/style/multiline_array_brace_layout.rb
@@ -39,11 +39,11 @@ module RuboCop
       class MultilineArrayBraceLayout < Cop
         SAME_LINE_MESSAGE = 'Closing array brace must be on the same line as ' \
           'the last array element when opening brace is on the same line as ' \
-          'the first array element.'
+          'the first array element.'.freeze
 
         NEW_LINE_MESSAGE = 'Closing array brace must be on the line after ' \
           'the last array element when opening brace is on a separate line ' \
-          'from the first array element.'
+          'from the first array element.'.freeze
 
         def on_array(node)
           return unless node.loc.begin # Ignore implicit arrays.

--- a/lib/rubocop/cop/style/multiline_assignment_layout.rb
+++ b/lib/rubocop/cop/style/multiline_assignment_layout.rb
@@ -35,10 +35,10 @@ module RuboCop
         include ConfigurableEnforcedStyle
 
         NEW_LINE_OFFENSE = 'Right hand side of multi-line assignment is on ' \
-          'the same line as the assignment operator `=`.'
+          'the same line as the assignment operator `=`.'.freeze
 
         SAME_LINE_OFFENSE = 'Right hand side of multi-line assignment is not ' \
-          'on the same line as the assignment operator `=`.'
+          'on the same line as the assignment operator `=`.'.freeze
 
         def check_assignment(node, rhs)
           return unless rhs

--- a/lib/rubocop/cop/style/multiline_block_chain.rb
+++ b/lib/rubocop/cop/style/multiline_block_chain.rb
@@ -14,7 +14,7 @@ module RuboCop
       #     t.object_id
       #   end
       class MultilineBlockChain < Cop
-        MSG = 'Avoid multi-line chains of blocks.'
+        MSG = 'Avoid multi-line chains of blocks.'.freeze
 
         def on_block(node)
           method, _args, _body = *node

--- a/lib/rubocop/cop/style/multiline_block_layout.rb
+++ b/lib/rubocop/cop/style/multiline_block_layout.rb
@@ -36,9 +36,10 @@ module RuboCop
       #     bar(i)
       #   }
       class MultilineBlockLayout < Cop
-        MSG = 'Block body expression is on the same line as the block start.'
+        MSG = 'Block body expression is on the same line as ' \
+              'the block start.'.freeze
         ARG_MSG = 'Block argument expression is not on the same line as the ' \
-                  'block start.'
+                  'block start.'.freeze
 
         def on_block(node)
           end_loc = node.loc.end

--- a/lib/rubocop/cop/style/multiline_ternary_operator.rb
+++ b/lib/rubocop/cop/style/multiline_ternary_operator.rb
@@ -6,7 +6,7 @@ module RuboCop
       # This cop checks for multi-line ternary op expressions.
       class MultilineTernaryOperator < Cop
         MSG = 'Avoid multi-line ?: (the ternary operator);' \
-              ' use `if`/`unless` instead.'
+              ' use `if`/`unless` instead.'.freeze
 
         def on_if(node)
           _condition, _if_branch, else_branch = *node

--- a/lib/rubocop/cop/style/mutable_constant.rb
+++ b/lib/rubocop/cop/style/mutable_constant.rb
@@ -13,7 +13,7 @@ module RuboCop
       #   # good
       #   CONST = [1, 2, 3].freeze
       class MutableConstant < Cop
-        MSG = 'Freeze mutable objects assigned to constants.'
+        MSG = 'Freeze mutable objects assigned to constants.'.freeze
 
         MUTABLE_TYPES = [:array, :hash, :str, :dstr].freeze
 

--- a/lib/rubocop/cop/style/negated_if.rb
+++ b/lib/rubocop/cop/style/negated_if.rb
@@ -8,7 +8,7 @@ module RuboCop
       class NegatedIf < Cop
         include NegativeConditional
 
-        MSG = 'Favor `%s` over `%s` for negative conditions.'
+        MSG = 'Favor `%s` over `%s` for negative conditions.'.freeze
 
         def on_if(node)
           return unless node.loc.respond_to?(:keyword)

--- a/lib/rubocop/cop/style/negated_while.rb
+++ b/lib/rubocop/cop/style/negated_while.rb
@@ -7,7 +7,7 @@ module RuboCop
       class NegatedWhile < Cop
         include NegativeConditional
 
-        MSG = 'Favor `%s` over `%s` for negative conditions.'
+        MSG = 'Favor `%s` over `%s` for negative conditions.'.freeze
 
         def on_while(node)
           check_negative_conditional(node)

--- a/lib/rubocop/cop/style/nested_modifier.rb
+++ b/lib/rubocop/cop/style/nested_modifier.rb
@@ -16,7 +16,7 @@ module RuboCop
       class NestedModifier < Cop
         include IfNode
 
-        MSG = 'Avoid using nested modifiers.'
+        MSG = 'Avoid using nested modifiers.'.freeze
 
         def on_while(node)
           check(node)

--- a/lib/rubocop/cop/style/nested_parenthesized_calls.rb
+++ b/lib/rubocop/cop/style/nested_parenthesized_calls.rb
@@ -13,10 +13,10 @@ module RuboCop
       #   @bad
       #   method1(method2 arg, method3, arg)
       class NestedParenthesizedCalls < Cop
-        MSG = 'Add parentheses to nested method call `%s`.'
+        MSG = 'Add parentheses to nested method call `%s`.'.freeze
         RSPEC_MATCHERS = [:be, :eq, :eql, :equal, :be_kind_of, :be_instance_of,
                           :respond_to, :be_between, :match, :be_within,
-                          :start_with, :end_with, :include, :raise_error]
+                          :start_with, :end_with, :include, :raise_error].freeze
 
         def on_send(node)
           return unless parenthesized_call?(node)

--- a/lib/rubocop/cop/style/nested_ternary_operator.rb
+++ b/lib/rubocop/cop/style/nested_ternary_operator.rb
@@ -6,7 +6,7 @@ module RuboCop
       # This cop checks for nested ternary op expressions.
       class NestedTernaryOperator < Cop
         MSG = 'Ternary operators must not be nested. Prefer `if`/`else` ' \
-              'constructs instead.'
+              'constructs instead.'.freeze
 
         def on_if(node)
           loc = node.loc

--- a/lib/rubocop/cop/style/nil_comparison.rb
+++ b/lib/rubocop/cop/style/nil_comparison.rb
@@ -13,9 +13,9 @@ module RuboCop
       #  # good
       #  if x.nil?
       class NilComparison < Cop
-        MSG = 'Prefer the use of the `nil?` predicate.'
+        MSG = 'Prefer the use of the `nil?` predicate.'.freeze
 
-        OPS = [:==, :===]
+        OPS = [:==, :===].freeze
 
         NIL_NODE = s(:nil)
 

--- a/lib/rubocop/cop/style/not.rb
+++ b/lib/rubocop/cop/style/not.rb
@@ -7,7 +7,7 @@ module RuboCop
       class Not < Cop
         include AutocorrectUnlessChangingAST
 
-        MSG = 'Use `!` instead of `not`.'
+        MSG = 'Use `!` instead of `not`.'.freeze
 
         def on_send(node)
           return unless node.keyword_not?

--- a/lib/rubocop/cop/style/numeric_literals.rb
+++ b/lib/rubocop/cop/style/numeric_literals.rb
@@ -12,7 +12,7 @@ module RuboCop
         include ConfigurableMax
 
         MSG = 'Separate every 3 digits in the integer portion of a number ' \
-              'with underscores(_).'
+              'with underscores(_).'.freeze
 
         def on_int(node)
           check(node)

--- a/lib/rubocop/cop/style/one_line_conditional.rb
+++ b/lib/rubocop/cop/style/one_line_conditional.rb
@@ -9,7 +9,7 @@ module RuboCop
         include OnNormalIfUnless
 
         MSG = 'Favor the ternary operator (`?:`) ' \
-              'over `%s/then/else/end` constructs.'
+              'over `%s/then/else/end` constructs.'.freeze
 
         def on_normal_if_unless(node)
           exp = node.source

--- a/lib/rubocop/cop/style/op_method.rb
+++ b/lib/rubocop/cop/style/op_method.rb
@@ -6,13 +6,15 @@ module RuboCop
       # This cop makes sure that certain operator methods have their sole
       # parameter named `other`.
       class OpMethod < Cop
-        MSG = 'When defining the `%s` operator, name its argument `other`.'
+        MSG = 'When defining the `%s` operator, ' \
+              'name its argument `other`.'.freeze
 
-        OP_LIKE_METHODS = [:eql?, :equal?]
+        OP_LIKE_METHODS = [:eql?, :equal?].freeze
 
-        BLACKLISTED = [:+@, :-@, :[], :[]=, :<<]
+        BLACKLISTED = [:+@, :-@, :[], :[]=, :<<].freeze
 
-        TARGET_ARGS = [s(:args, s(:arg, :other)), s(:args, s(:arg, :_other))]
+        TARGET_ARGS = [s(:args, s(:arg, :other)),
+                       s(:args, s(:arg, :_other))].freeze
 
         def on_def(node)
           name, args, _body = *node

--- a/lib/rubocop/cop/style/option_hash.rb
+++ b/lib/rubocop/cop/style/option_hash.rb
@@ -20,7 +20,7 @@ module RuboCop
       #     ...
       #   end
       class OptionHash < Cop
-        MSG = 'Prefer keyword arguments to options hashes.'
+        MSG = 'Prefer keyword arguments to options hashes.'.freeze
 
         def on_args(node)
           *_but_last, last_arg = *node

--- a/lib/rubocop/cop/style/optional_arguments.rb
+++ b/lib/rubocop/cop/style/optional_arguments.rb
@@ -18,8 +18,8 @@ module RuboCop
       #   def foobar(a = 1, b = 2, c = 3)
       #   end
       class OptionalArguments < Cop
-        MSG =
-          'Optional arguments should appear at the end of the argument list.'
+        MSG = 'Optional arguments should appear at the end ' \
+              'of the argument list.'.freeze
 
         def on_def(node)
           _method, arguments, = *node

--- a/lib/rubocop/cop/style/parallel_assignment.rb
+++ b/lib/rubocop/cop/style/parallel_assignment.rb
@@ -25,7 +25,7 @@ module RuboCop
       class ParallelAssignment < Cop
         include IfNode
 
-        MSG = 'Do not use parallel assignment.'
+        MSG = 'Do not use parallel assignment.'.freeze
 
         def on_masgn(node)
           left, right = *node

--- a/lib/rubocop/cop/style/perl_backrefs.rb
+++ b/lib/rubocop/cop/style/perl_backrefs.rb
@@ -6,7 +6,7 @@ module RuboCop
       # This cop looks for uses of Perl-style regexp match
       # backreferences like $1, $2, etc.
       class PerlBackrefs < Cop
-        MSG = 'Avoid the use of Perl-style backrefs.'
+        MSG = 'Avoid the use of Perl-style backrefs.'.freeze
 
         def on_nth_ref(node)
           add_offense(node, :expression)

--- a/lib/rubocop/cop/style/proc.rb
+++ b/lib/rubocop/cop/style/proc.rb
@@ -6,7 +6,7 @@ module RuboCop
       # This cops checks for uses of Proc.new where Kernel#proc
       # would be more appropriate.
       class Proc < Cop
-        MSG = 'Use `proc` instead of `Proc.new`.'
+        MSG = 'Use `proc` instead of `Proc.new`.'.freeze
 
         TARGET = s(:send, s(:const, nil, :Proc), :new)
 

--- a/lib/rubocop/cop/style/redundant_begin.rb
+++ b/lib/rubocop/cop/style/redundant_begin.rb
@@ -27,7 +27,7 @@ module RuboCop
       class RedundantBegin < Cop
         include OnMethodDef
 
-        MSG = 'Redundant `begin` block detected.'
+        MSG = 'Redundant `begin` block detected.'.freeze
 
         def on_method_def(_node, _method_name, _args, body)
           return unless body && body.type == :kwbegin

--- a/lib/rubocop/cop/style/redundant_exception.rb
+++ b/lib/rubocop/cop/style/redundant_exception.rb
@@ -11,7 +11,7 @@ module RuboCop
       #
       #   raise RuntimeError, 'message'
       class RedundantException < Cop
-        MSG = 'Redundant `RuntimeError` argument can be removed.'
+        MSG = 'Redundant `RuntimeError` argument can be removed.'.freeze
 
         TARGET_NODE = s(:const, nil, :RuntimeError)
 

--- a/lib/rubocop/cop/style/redundant_return.rb
+++ b/lib/rubocop/cop/style/redundant_return.rb
@@ -23,7 +23,7 @@ module RuboCop
       class RedundantReturn < Cop
         include OnMethodDef
 
-        MSG = 'Redundant `return` detected.'
+        MSG = 'Redundant `return` detected.'.freeze
 
         private
 

--- a/lib/rubocop/cop/style/redundant_self.rb
+++ b/lib/rubocop/cop/style/redundant_self.rb
@@ -43,7 +43,7 @@ module RuboCop
       # We allow uses of `self` with operators because it would be awkward
       # otherwise.
       class RedundantSelf < Cop
-        MSG = 'Redundant `self` detected.'
+        MSG = 'Redundant `self` detected.'.freeze
 
         def initialize(config = nil, options = nil)
           super

--- a/lib/rubocop/cop/style/regexp_literal.rb
+++ b/lib/rubocop/cop/style/regexp_literal.rb
@@ -31,8 +31,8 @@ module RuboCop
       class RegexpLiteral < Cop
         include ConfigurableEnforcedStyle
 
-        MSG_USE_SLASHES = 'Use `//` around regular expression.'
-        MSG_USE_PERCENT_R = 'Use `%r` around regular expression.'
+        MSG_USE_SLASHES = 'Use `//` around regular expression.'.freeze
+        MSG_USE_PERCENT_R = 'Use `%r` around regular expression.'.freeze
 
         def on_regexp(node)
           if slash_literal?(node)

--- a/lib/rubocop/cop/style/rescue_ensure_alignment.rb
+++ b/lib/rubocop/cop/style/rescue_ensure_alignment.rb
@@ -22,7 +22,7 @@ module RuboCop
       #     puts 'error'
       #   end
       class RescueEnsureAlignment < Cop
-        MSG = '`%s` at %d, %d is not aligned with `end` at %d, %d.'
+        MSG = '`%s` at %d, %d is not aligned with `end` at %d, %d.'.freeze
 
         def on_resbody(node)
           check(node) unless modifier?(node)

--- a/lib/rubocop/cop/style/rescue_modifier.rb
+++ b/lib/rubocop/cop/style/rescue_modifier.rb
@@ -7,7 +7,7 @@ module RuboCop
       class RescueModifier < Cop
         include AutocorrectAlignment
 
-        MSG = 'Avoid using `rescue` in its modifier form.'
+        MSG = 'Avoid using `rescue` in its modifier form.'.freeze
 
         def investigate(processed_source)
           @modifier_locations = processed_source

--- a/lib/rubocop/cop/style/self_assignment.rb
+++ b/lib/rubocop/cop/style/self_assignment.rb
@@ -13,8 +13,8 @@ module RuboCop
       #   # good
       #   x += 1
       class SelfAssignment < Cop
-        MSG = 'Use self-assignment shorthand `%s=`.'
-        OPS = [:+, :-, :*, :**, :/, :|, :&]
+        MSG = 'Use self-assignment shorthand `%s=`.'.freeze
+        OPS = [:+, :-, :*, :**, :/, :|, :&].freeze
 
         def on_lvasgn(node)
           check(node, :lvar)

--- a/lib/rubocop/cop/style/semicolon.rb
+++ b/lib/rubocop/cop/style/semicolon.rb
@@ -6,7 +6,7 @@ module RuboCop
       # This cop checks for multiple expressions placed on the same line.
       # It also checks for lines terminated with a semicolon.
       class Semicolon < Cop
-        MSG = 'Do not use semicolons to terminate expressions.'
+        MSG = 'Do not use semicolons to terminate expressions.'.freeze
 
         def investigate(processed_source)
           return unless processed_source.ast

--- a/lib/rubocop/cop/style/send.rb
+++ b/lib/rubocop/cop/style/send.rb
@@ -5,7 +5,8 @@ module RuboCop
     module Style
       # This cop checks for the use of the send method.
       class Send < Cop
-        MSG = 'Prefer `Object#__send__` or `Object#public_send` to `send`.'
+        MSG = 'Prefer `Object#__send__` or `Object#public_send` to ' \
+              '`send`.'.freeze
 
         def on_send(node)
           _receiver, method_name, *args = *node

--- a/lib/rubocop/cop/style/signal_exception.rb
+++ b/lib/rubocop/cop/style/signal_exception.rb
@@ -7,8 +7,9 @@ module RuboCop
       class SignalException < Cop
         include ConfigurableEnforcedStyle
 
-        FAIL_MSG = 'Use `fail` instead of `raise` to signal exceptions.'
-        RAISE_MSG = 'Use `raise` instead of `fail` to rethrow exceptions.'
+        FAIL_MSG = 'Use `fail` instead of `raise` to signal exceptions.'.freeze
+        RAISE_MSG = 'Use `raise` instead of `fail` to ' \
+                    'rethrow exceptions.'.freeze
 
         def on_rescue(node)
           return unless style == :semantic

--- a/lib/rubocop/cop/style/single_line_methods.rb
+++ b/lib/rubocop/cop/style/single_line_methods.rb
@@ -9,7 +9,7 @@ module RuboCop
         include AutocorrectAlignment
         include OnMethodDef
 
-        MSG = 'Avoid single-line method definitions.'
+        MSG = 'Avoid single-line method definitions.'.freeze
 
         def allow_empty?
           cop_config['AllowIfMethodIsEmpty']

--- a/lib/rubocop/cop/style/space_after_colon.rb
+++ b/lib/rubocop/cop/style/space_after_colon.rb
@@ -7,7 +7,7 @@ module RuboCop
       class SpaceAfterColon < Cop
         include IfNode
 
-        MSG = 'Space missing after colon.'
+        MSG = 'Space missing after colon.'.freeze
 
         def on_pair(node)
           oper = node.loc.operator

--- a/lib/rubocop/cop/style/space_after_control_keyword.rb
+++ b/lib/rubocop/cop/style/space_after_control_keyword.rb
@@ -5,9 +5,9 @@ module RuboCop
     module Style
       # Checks for various control keywords missing a space after them.
       class SpaceAfterControlKeyword < Cop
-        MSG = 'Use space after control keywords.'
+        MSG = 'Use space after control keywords.'.freeze
         # elsif and unless are handled by on_if.
-        KEYWORDS = %w(if case when while until)
+        KEYWORDS = %w(if case when while until).freeze
 
         def on_keyword(node)
           return if node.loc.is_a?(Parser::Source::Map::Ternary)

--- a/lib/rubocop/cop/style/space_after_method_name.rb
+++ b/lib/rubocop/cop/style/space_after_method_name.rb
@@ -16,7 +16,7 @@ module RuboCop
         include OnMethodDef
 
         MSG = 'Do not put a space between a method name and the opening ' \
-              'parenthesis.'
+              'parenthesis.'.freeze
 
         def on_method_def(_node, _method_name, args, _body)
           return unless args.loc.begin && args.loc.begin.is?('(')

--- a/lib/rubocop/cop/style/space_after_not.rb
+++ b/lib/rubocop/cop/style/space_after_not.rb
@@ -12,7 +12,7 @@ module RuboCop
       #   # good
       #   !something
       class SpaceAfterNot < Cop
-        MSG = 'Do not leave space between `!` and its argument.'
+        MSG = 'Do not leave space between `!` and its argument.'.freeze
 
         def on_send(node)
           _receiver, method_name, *_args = *node

--- a/lib/rubocop/cop/style/space_before_comment.rb
+++ b/lib/rubocop/cop/style/space_before_comment.rb
@@ -6,7 +6,7 @@ module RuboCop
       # This cop checks for missing space between a token and a comment on the
       # same line.
       class SpaceBeforeComment < Cop
-        MSG = 'Put a space before an end-of-line comment.'
+        MSG = 'Put a space before an end-of-line comment.'.freeze
 
         def investigate(processed_source)
           processed_source.tokens.each_cons(2) do |t1, t2|

--- a/lib/rubocop/cop/style/space_before_first_arg.rb
+++ b/lib/rubocop/cop/style/space_before_first_arg.rb
@@ -18,7 +18,8 @@ module RuboCop
       class SpaceBeforeFirstArg < Cop
         include PrecedingFollowingAlignment
 
-        MSG = 'Put one space between the method name and the first argument.'
+        MSG = 'Put one space between the method name and ' \
+              'the first argument.'.freeze
 
         def on_send(node)
           return if parentheses?(node)

--- a/lib/rubocop/cop/style/space_before_modifier_keyword.rb
+++ b/lib/rubocop/cop/style/space_before_modifier_keyword.rb
@@ -5,7 +5,7 @@ module RuboCop
     module Style
       # Here we check if modifier keywords are preceded by a space.
       class SpaceBeforeModifierKeyword < Cop
-        MSG = 'Put a space before the modifier keyword.'
+        MSG = 'Put a space before the modifier keyword.'.freeze
 
         def on_if(node)
           return unless modifier?(node)

--- a/lib/rubocop/cop/style/space_inside_hash_literal_braces.rb
+++ b/lib/rubocop/cop/style/space_inside_hash_literal_braces.rb
@@ -9,7 +9,7 @@ module RuboCop
         include SurroundingSpace
         include ConfigurableEnforcedStyle
 
-        MSG = 'Space inside %s.'
+        MSG = 'Space inside %s.'.freeze
 
         def on_hash(node)
           b_ix = index_of_first_token(node)

--- a/lib/rubocop/cop/style/space_inside_range_literal.rb
+++ b/lib/rubocop/cop/style/space_inside_range_literal.rb
@@ -18,7 +18,7 @@ module RuboCop
       #   # good
       #   'a'..'z'
       class SpaceInsideRangeLiteral < Cop
-        MSG = 'Space inside range literal.'
+        MSG = 'Space inside range literal.'.freeze
 
         def on_irange(node)
           check(node)

--- a/lib/rubocop/cop/style/space_inside_string_interpolation.rb
+++ b/lib/rubocop/cop/style/space_inside_string_interpolation.rb
@@ -14,8 +14,8 @@ module RuboCop
       class SpaceInsideStringInterpolation < Cop
         include ConfigurableEnforcedStyle
 
-        NO_SPACE_MSG = 'Space inside string interpolation detected.'
-        SPACE_MSG = 'Missing space around string interpolation detected.'
+        NO_SPACE_MSG = 'Space inside string interpolation detected.'.freeze
+        SPACE_MSG = 'Missing space around string interpolation detected.'.freeze
 
         def on_dstr(node)
           node.children.select { |n| n.type == :begin }.each do |begin_node|

--- a/lib/rubocop/cop/style/special_global_vars.rb
+++ b/lib/rubocop/cop/style/special_global_vars.rb
@@ -8,12 +8,12 @@ module RuboCop
         include ConfigurableEnforcedStyle
 
         MSG_BOTH = 'Prefer `%s` from the stdlib \'English\' module, ' \
-        'or `%s` over `%s`.'
+        'or `%s` over `%s`.'.freeze
         MSG_ENGLISH = 'Prefer `%s` from the stdlib \'English\' module ' \
-        'over `%s`.'
-        MSG_REGULAR = 'Prefer `%s` over `%s`.'
+        'over `%s`.'.freeze
+        MSG_REGULAR = 'Prefer `%s` over `%s`.'.freeze
 
-        ENGLISH_VARS = {
+        ENGLISH_VARS = { # rubocop:disable Style/MutableConstant
           :$: => [:$LOAD_PATH],
           :$" => [:$LOADED_FEATURES],
           :$0 => [:$PROGRAM_NAME],
@@ -45,8 +45,8 @@ module RuboCop
           Hash[ENGLISH_VARS.flat_map { |_, vs| vs.map { |v| [v, [v]] } }])
         PERL_VARS.merge!(
           Hash[PERL_VARS.flat_map { |_, vs| vs.map { |v| [v, [v]] } }])
-        ENGLISH_VARS.freeze
-        PERL_VARS.freeze
+        ENGLISH_VARS.each { |_, v| v.freeze }.freeze
+        PERL_VARS.each { |_, v| v.freeze }.freeze
 
         # Anything *not* in this set is provided by the English library.
         NON_ENGLISH_VARS = Set.new([
@@ -54,7 +54,7 @@ module RuboCop
                                      :$LOADED_FEATURES,
                                      :$PROGRAM_NAME,
                                      :ARGV
-                                   ])
+                                   ]).freeze
 
         def on_gvar(node)
           global_var, = *node

--- a/lib/rubocop/cop/style/stabby_lambda_parentheses.rb
+++ b/lib/rubocop/cop/style/stabby_lambda_parentheses.rb
@@ -20,8 +20,9 @@ module RuboCop
       class StabbyLambdaParentheses < Cop
         include ConfigurableEnforcedStyle
 
-        MSG_REQUIRE = 'Wrap stabby lambda arguments with parentheses.'
-        MSG_NO_REQUIRE = 'Do not wrap stabby lambda arguments with parentheses.'
+        MSG_REQUIRE = 'Wrap stabby lambda arguments with parentheses.'.freeze
+        MSG_NO_REQUIRE = 'Do not wrap stabby lambda arguments ' \
+                         'with parentheses.'.freeze
         ARROW = '->'.freeze
 
         def on_send(node)

--- a/lib/rubocop/cop/style/string_literals.rb
+++ b/lib/rubocop/cop/style/string_literals.rb
@@ -8,7 +8,7 @@ module RuboCop
         include ConfigurableEnforcedStyle
         include StringLiteralsHelp
 
-        MSG_INCONSISTENT = 'Inconsistent quote style.'
+        MSG_INCONSISTENT = 'Inconsistent quote style.'.freeze
 
         def on_dstr(node)
           # Strings which are continued across multiple lines using \

--- a/lib/rubocop/cop/style/string_methods.rb
+++ b/lib/rubocop/cop/style/string_methods.rb
@@ -8,7 +8,7 @@ module RuboCop
       class StringMethods < Cop
         include MethodPreference
 
-        MSG = 'Prefer `%s` over `%s`.'
+        MSG = 'Prefer `%s` over `%s`.'.freeze
 
         def on_send(node)
           _receiver, method_name, *_args = *node

--- a/lib/rubocop/cop/style/struct_inheritance.rb
+++ b/lib/rubocop/cop/style/struct_inheritance.rb
@@ -13,7 +13,7 @@ module RuboCop
       #   # good
       #   Person = Struct.new(:first_name, :last_name)
       class StructInheritance < Cop
-        MSG = "Don't extend an instance initialized by `Struct.new`."
+        MSG = "Don't extend an instance initialized by `Struct.new`.".freeze
 
         def on_class(node)
           _name, superclass, _body = *node

--- a/lib/rubocop/cop/style/symbol_array.rb
+++ b/lib/rubocop/cop/style/symbol_array.rb
@@ -13,8 +13,8 @@ module RuboCop
         include ConfigurableEnforcedStyle
         include ArraySyntax
 
-        PERCENT_MSG = 'Use `%i` or `%I` for an array of symbols.'
-        ARRAY_MSG = 'Use `[]` for an array of symbols.'
+        PERCENT_MSG = 'Use `%i` or `%I` for an array of symbols.'.freeze
+        ARRAY_MSG = 'Use `[]` for an array of symbols.'.freeze
 
         def on_array(node)
           if bracketed_array_of?(:sym, node)

--- a/lib/rubocop/cop/style/symbol_literal.rb
+++ b/lib/rubocop/cop/style/symbol_literal.rb
@@ -13,7 +13,7 @@ module RuboCop
       #   # good
       #   :symbol
       class SymbolLiteral < Cop
-        MSG = 'Do not use strings for word-like symbol literals.'
+        MSG = 'Do not use strings for word-like symbol literals.'.freeze
 
         def on_sym(node)
           return unless node.source =~ /\A:["'][A-Za-z_]\w*["']\z/

--- a/lib/rubocop/cop/style/symbol_proc.rb
+++ b/lib/rubocop/cop/style/symbol_proc.rb
@@ -12,7 +12,7 @@ module RuboCop
       #   # good
       #   something.map(&:upcase)
       class SymbolProc < Cop
-        MSG = 'Pass `&:%s` as an argument to `%s` instead of a block.'
+        MSG = 'Pass `&:%s` as an argument to `%s` instead of a block.'.freeze
 
         PROC_NODE = s(:send, s(:const, nil, :Proc), :new)
 

--- a/lib/rubocop/cop/style/tab.rb
+++ b/lib/rubocop/cop/style/tab.rb
@@ -7,7 +7,7 @@ module RuboCop
     module Style
       # This cop checks for tabs inside the source code.
       class Tab < Cop
-        MSG = 'Tab detected.'
+        MSG = 'Tab detected.'.freeze
 
         def investigate(processed_source)
           str_lines = string_literal_lines(processed_source.ast)

--- a/lib/rubocop/cop/style/trailing_whitespace.rb
+++ b/lib/rubocop/cop/style/trailing_whitespace.rb
@@ -5,7 +5,7 @@ module RuboCop
     module Style
       # This cop looks for trailing whitespace in the source code.
       class TrailingWhitespace < Cop
-        MSG = 'Trailing whitespace detected.'
+        MSG = 'Trailing whitespace detected.'.freeze
 
         def investigate(processed_source)
           processed_source.lines.each_with_index do |line, index|

--- a/lib/rubocop/cop/style/trivial_accessors.rb
+++ b/lib/rubocop/cop/style/trivial_accessors.rb
@@ -6,7 +6,7 @@ module RuboCop
       # This cop looks for trivial reader/writer methods, that could
       # have been created with the attr_* family of functions automatically.
       class TrivialAccessors < Cop
-        MSG = 'Use `attr_%s` to define trivial %s methods.'
+        MSG = 'Use `attr_%s` to define trivial %s methods.'.freeze
 
         def on_def(node)
           return if in_module_or_instance_eval?(node)

--- a/lib/rubocop/cop/style/unless_else.rb
+++ b/lib/rubocop/cop/style/unless_else.rb
@@ -6,7 +6,7 @@ module RuboCop
       # This cop looks for *unless* expressions with *else* clauses.
       class UnlessElse < Cop
         MSG = 'Do not use `unless` with `else`. Rewrite these with the ' \
-              'positive case first.'
+              'positive case first.'.freeze
 
         def on_if(node)
           loc = node.loc

--- a/lib/rubocop/cop/style/unneeded_capital_w.rb
+++ b/lib/rubocop/cop/style/unneeded_capital_w.rb
@@ -7,8 +7,8 @@ module RuboCop
       class UnneededCapitalW < Cop
         include PercentLiteral
 
-        MSG =
-          'Do not use `%W` unless interpolation is needed.  If not, use `%w`.'
+        MSG = 'Do not use `%W` unless interpolation is needed. ' \
+              'If not, use `%w`.'.freeze
 
         def on_array(node)
           process(node, '%W')

--- a/lib/rubocop/cop/style/unneeded_interpolation.rb
+++ b/lib/rubocop/cop/style/unneeded_interpolation.rb
@@ -18,7 +18,7 @@ module RuboCop
       class UnneededInterpolation < Cop
         include PercentLiteral
 
-        MSG = 'Prefer `to_s` over string interpolation.'
+        MSG = 'Prefer `to_s` over string interpolation.'.freeze
 
         def on_dstr(node)
           add_offense(node, :expression, MSG) if single_interpolation?(node)

--- a/lib/rubocop/cop/style/unneeded_percent_q.rb
+++ b/lib/rubocop/cop/style/unneeded_percent_q.rb
@@ -6,8 +6,9 @@ module RuboCop
       # This cop checks for usage of the %q/%Q syntax when '' or "" would do.
       class UnneededPercentQ < Cop
         MSG = 'Use `%s` only for strings that contain both single quotes and ' \
-              'double quotes%s.'
-        DYNAMIC_MSG = ', or for dynamic strings that contain double quotes'
+              'double quotes%s.'.freeze
+        DYNAMIC_MSG = ', or for dynamic strings that contain ' \
+                      'double quotes'.freeze
         SINGLE_QUOTE = "'".freeze
         QUOTE = '"'.freeze
         EMPTY = ''.freeze

--- a/lib/rubocop/cop/style/variable_interpolation.rb
+++ b/lib/rubocop/cop/style/variable_interpolation.rb
@@ -5,7 +5,8 @@ module RuboCop
     module Style
       # This cop checks for variable interpolation (like "#@ivar").
       class VariableInterpolation < Cop
-        MSG = 'Replace interpolated variable `%s` with expression `#{%s}`.'
+        MSG = 'Replace interpolated variable `%s` ' \
+              'with expression `#{%s}`.'.freeze
 
         def on_dstr(node)
           check_for_interpolation(node)

--- a/lib/rubocop/cop/style/when_then.rb
+++ b/lib/rubocop/cop/style/when_then.rb
@@ -5,7 +5,7 @@ module RuboCop
     module Style
       # This cop checks for *when;* uses in *case* expressions.
       class WhenThen < Cop
-        MSG = 'Do not use `when x;`. Use `when x then` instead.'
+        MSG = 'Do not use `when x;`. Use `when x then` instead.'.freeze
 
         def on_when(node)
           return unless node.loc.begin && node.loc.begin.is?(';')

--- a/lib/rubocop/cop/style/word_array.rb
+++ b/lib/rubocop/cop/style/word_array.rb
@@ -11,8 +11,8 @@ module RuboCop
       class WordArray < Cop
         include ArraySyntax
 
-        PERCENT_MSG = 'Use `%w` or `%W` for an array of words.'
-        ARRAY_MSG = 'Use `[]` for an array of words.'
+        PERCENT_MSG = 'Use `%w` or `%W` for an array of words.'.freeze
+        ARRAY_MSG = 'Use `[]` for an array of words.'.freeze
         QUESTION_MARK_SIZE = '?'.size
 
         def on_array(node)

--- a/lib/rubocop/cop/util.rb
+++ b/lib/rubocop/cop/util.rb
@@ -8,16 +8,17 @@ module RuboCop
       include PathUtil
       extend Astrolabe::Sexp
 
-      EQUALS_ASGN_NODES = [:lvasgn, :ivasgn, :cvasgn, :gvasgn, :casgn, :masgn]
-      SHORTHAND_ASGN_NODES = [:op_asgn, :or_asgn, :and_asgn]
-      ASGN_NODES = EQUALS_ASGN_NODES + SHORTHAND_ASGN_NODES
+      EQUALS_ASGN_NODES = [:lvasgn, :ivasgn, :cvasgn, :gvasgn,
+                           :casgn, :masgn].freeze
+      SHORTHAND_ASGN_NODES = [:op_asgn, :or_asgn, :and_asgn].freeze
+      ASGN_NODES = (EQUALS_ASGN_NODES + SHORTHAND_ASGN_NODES).freeze
 
       # http://phrogz.net/programmingruby/language.html#table_18.4
       # Backtick is added last just to help editors parse this code.
       OPERATOR_METHODS = %w(
         | ^ & <=> == === =~ > >= < <= << >>
         + - * / % ** ~ +@ -@ [] []= ! != !~
-      ).map(&:to_sym) + [:'`']
+      ).map(&:to_sym).push(:'`').freeze
 
       STRING_ESCAPES = {
         '\a' => "\a", '\b' => "\b", '\e' => "\e", '\f' => "\f", '\n' => "\n",

--- a/lib/rubocop/cop/variable_force/scope.rb
+++ b/lib/rubocop/cop/variable_force/scope.rb
@@ -13,7 +13,7 @@ module RuboCop
           class:  0..1,
           sclass: 0..0,
           block:  0..0
-        }
+        }.freeze
 
         attr_reader :node, :variables
 

--- a/lib/rubocop/formatter/formatter_set.rb
+++ b/lib/rubocop/formatter/formatter_set.rb
@@ -20,9 +20,9 @@ module RuboCop
         'offenses' => OffenseCountFormatter,
         'disabled' => DisabledLinesFormatter,
         'worst'    => WorstOffendersFormatter
-      }
+      }.freeze
 
-      FORMATTER_APIS = [:started, :finished]
+      FORMATTER_APIS = [:started, :finished].freeze
 
       FORMATTER_APIS.each do |method_name|
         define_method(method_name) do |*args|

--- a/lib/rubocop/formatter/fuubar_style_formatter.rb
+++ b/lib/rubocop/formatter/fuubar_style_formatter.rb
@@ -9,7 +9,7 @@ module RuboCop
     # This is inspired by the Fuubar formatter for RSpec by Jeff Kreeftmeijer.
     # https://github.com/jeffkreeftmeijer/fuubar
     class FuubarStyleFormatter < ClangStyleFormatter
-      RESET_SEQUENCE = "\e[0m"
+      RESET_SEQUENCE = "\e[0m".freeze
 
       def started(target_files)
         super

--- a/lib/rubocop/formatter/html_formatter.rb
+++ b/lib/rubocop/formatter/html_formatter.rb
@@ -68,7 +68,7 @@ module RuboCop
           warning:    Color.new(0x96, 0x28, 0xEF, 1.0),
           error:      Color.new(0xD2, 0x32, 0x2D, 1.0),
           fatal:      Color.new(0xD2, 0x32, 0x2D, 1.0)
-        }
+        }.freeze
 
         LOGO_IMAGE_PATH =
           File.expand_path('../../../../assets/logo.png', __FILE__)

--- a/lib/rubocop/options.rb
+++ b/lib/rubocop/options.rb
@@ -5,7 +5,7 @@ require 'optparse'
 module RuboCop
   # This class handles command line options.
   class Options
-    EXITING_OPTIONS = [:version, :verbose_version, :show_cops]
+    EXITING_OPTIONS = [:version, :verbose_version, :show_cops].freeze
     DEFAULT_MAXIMUM_EXCLUSION_ITEMS = 15
 
     def initialize
@@ -276,6 +276,6 @@ module RuboCop
       verbose_version:      'Display verbose version.',
       stdin:                ['Pipe source from STDIN.',
                              'This is useful for editor integration.']
-    }
+    }.freeze
   end
 end

--- a/lib/rubocop/processed_source.rb
+++ b/lib/rubocop/processed_source.rb
@@ -8,7 +8,7 @@ module RuboCop
   # and other information such as disabled lines for cops.
   # It also provides a convenient way to access source lines.
   class ProcessedSource
-    STRING_SOURCE_NAME = '(string)'
+    STRING_SOURCE_NAME = '(string)'.freeze
 
     attr_reader :path, :buffer, :ast, :comments, :tokens, :diagnostics,
                 :parser_error, :raw_source, :ruby_version

--- a/lib/rubocop/result_cache.rb
+++ b/lib/rubocop/result_cache.rb
@@ -9,7 +9,7 @@ module RuboCop
   # Provides functionality for caching rubocop runs.
   class ResultCache
     NON_CHANGING = [:color, :format, :formatters, :out, :debug, :fail_level,
-                    :cache, :fail_fast, :stdin]
+                    :cache, :fail_fast, :stdin].freeze
 
     # Remove old files so that the cache doesn't grow too big. When the
     # threshold MaxFilesInCache has been exceeded, the oldest 50% of all the

--- a/lib/rubocop/version.rb
+++ b/lib/rubocop/version.rb
@@ -3,9 +3,9 @@
 module RuboCop
   # This module holds the RuboCop version information.
   module Version
-    STRING = '0.35.1'
+    STRING = '0.35.1'.freeze
 
-    MSG = '%s (using Parser %s, running on %s %s %s)'
+    MSG = '%s (using Parser %s, running on %s %s %s)'.freeze
 
     module_function
 

--- a/spec/rubocop/cli/cli_autocorrect_spec.rb
+++ b/spec/rubocop/cli/cli_autocorrect_spec.rb
@@ -490,7 +490,7 @@ describe RuboCop::CLI, :isolated_environment do
                                          'class Dsl',
                                          '  private',
                                          '',
-                                         '  A = %w(git path)',
+                                         '  A = %w(git path).freeze',
                                          'end',
                                          ''].join("\n"))
     e = abs('example.rb')
@@ -504,6 +504,8 @@ describe RuboCop::CLI, :isolated_environment do
               "#{e}:3:3: W: Useless `private` access modifier.",
               "#{e}:3:3: C: [Corrected] Keep a blank line before and " \
               'after `private`.',
+              "#{e}:4:7: C: [Corrected] Freeze mutable objects assigned " \
+              'to constants.',
               "#{e}:4:7: C: [Corrected] Use `%w` or `%W` " \
               'for an array of words.',
               "#{e}:4:8: C: [Corrected] Prefer single-quoted strings " \
@@ -514,6 +516,8 @@ describe RuboCop::CLI, :isolated_environment do
               'symbols.',
               "#{e}:4:21: C: [Corrected] Avoid comma after the last item " \
               'of an array.',
+              "#{e}:5:7: C: [Corrected] Freeze mutable objects assigned " \
+              'to constants.',
               "#{e}:5:7: C: [Corrected] Use `%w` or `%W` " \
               'for an array of words.',
               "#{e}:5:8: C: [Corrected] Prefer single-quoted strings " \
@@ -803,7 +807,7 @@ describe RuboCop::CLI, :isolated_environment do
               '            match_for_should_not: :match_when_negated,',
               '      failure_message_for_should: :failure_message,',
               '  failure_message_for_should_not: :failure_message_when',
-              '}',
+              '}.freeze',
               ''].join("\n"))
   end
 

--- a/spec/rubocop/cop/lint/debugger_spec.rb
+++ b/spec/rubocop/cop/lint/debugger_spec.rb
@@ -28,7 +28,7 @@ describe RuboCop::Cop::Lint::Debugger do
 
   ALL_COMMANDS = %w(debugger byebug pry remote_pry pry_remote
                     save_and_open_page save_and_open_screenshot
-                    save_screenshot)
+                    save_screenshot).freeze
 
   ALL_COMMANDS.each do |src|
     include_examples 'non-debugger', "a #{src} in comments", "# #{src}"

--- a/spec/rubocop/cop/style/extra_spacing_spec.rb
+++ b/spec/rubocop/cop/style/extra_spacing_spec.rb
@@ -180,7 +180,7 @@ describe RuboCop::Cop::Style::ExtraSpacing, :config do
       "                                            name:   'Carrier',",
       '                                            values: %w{verizon})'
     ]
-  }
+  }.freeze
 
   context 'when AllowForAlignment is true' do
     let(:cop_config) do

--- a/spec/rubocop/cop/style/space_inside_block_braces_spec.rb
+++ b/spec/rubocop/cop/style/space_inside_block_braces_spec.rb
@@ -3,7 +3,7 @@
 require 'spec_helper'
 
 describe RuboCop::Cop::Style::SpaceInsideBlockBraces do
-  SUPPORTED_STYLES = %w(space no_space)
+  SUPPORTED_STYLES = %w(space no_space).freeze
 
   subject(:cop) { described_class.new(config) }
   let(:config) do


### PR DESCRIPTION
The commit message on https://github.com/bbatsov/rubocop/commit/0d954122206f1bbf7ab5c859bdfb7ee327db7ea0 implied that making it enabled by default would happen eventually, so I hope this OK!