### PR TITLE
Use comprehensive list of immutable literals

### DIFF
--- a/lib/rubocop/ast_node.rb
+++ b/lib/rubocop/ast_node.rb
@@ -20,6 +20,8 @@ module Astrolabe
     LITERALS = (TRUTHY_LITERALS + FALSEY_LITERALS).freeze
     BASIC_LITERALS = LITERALS - [:dstr, :xstr, :dsym, :array, :hash, :irange,
                                  :erange].freeze
+    MUTABLE_LITERALS = [:str, :dstr, :xstr, :array, :hash].freeze
+    IMMUTABLE_LITERALS = (LITERALS - MUTABLE_LITERALS).freeze
 
     VARIABLES = [:ivar, :gvar, :cvar, :lvar].freeze
     REFERENCES = [:nth_ref, :back_ref].freeze
@@ -155,6 +157,14 @@ module Astrolabe
 
     def falsey_literal?
       FALSEY_LITERALS.include?(type)
+    end
+
+    def mutable_literal?
+      MUTABLE_LITERALS.include?(type)
+    end
+
+    def immutable_literal?
+      IMMUTABLE_LITERALS.include?(type)
     end
 
     def variable?

--- a/lib/rubocop/cop/lint/each_with_object_argument.rb
+++ b/lib/rubocop/cop/lint/each_with_object_argument.rb
@@ -21,7 +21,7 @@ module RuboCop
           return unless args.length == 1
 
           arg = args.first
-          add_offense(node, :expression) if arg.int_type? || arg.float_type?
+          add_offense(node, :expression) if arg.immutable_literal?
         end
       end
     end

--- a/lib/rubocop/cop/lint/format_parameter_mismatch.rb
+++ b/lib/rubocop/cop/lint/format_parameter_mismatch.rb
@@ -16,8 +16,8 @@ module RuboCop
         MSG = "Number of arguments (%i) to `%s` doesn't match the number of " \
               'fields (%i).'.freeze
         FIELD_REGEX =
-          /(%(([\s#+-0\*]*)(\d*)?(.\d+)?[bBdiouxXeEfgGaAcps]|%))/.freeze
-        NAMED_FIELD_REGEX = /%\{[_a-zA-Z][_a-zA-Z]+\}/.freeze
+          /(%(([\s#+-0\*]*)(\d*)?(.\d+)?[bBdiouxXeEfgGaAcps]|%))/
+        NAMED_FIELD_REGEX = /%\{[_a-zA-Z][_a-zA-Z]+\}/
         KERNEL = 'Kernel'.freeze
         SHOVEL = '<<'.freeze
         PERCENT = '%'.freeze

--- a/lib/rubocop/cop/style/encoding.rb
+++ b/lib/rubocop/cop/style/encoding.rb
@@ -16,7 +16,7 @@ module RuboCop
 
         MSG_MISSING = 'Missing utf-8 encoding comment.'.freeze
         MSG_UNNECESSARY = 'Unnecessary utf-8 encoding comment.'.freeze
-        ENCODING_PATTERN = /#.*coding\s?[:=]\s?(?:UTF|utf)-8/.freeze
+        ENCODING_PATTERN = /#.*coding\s?[:=]\s?(?:UTF|utf)-8/
         AUTO_CORRECT_ENCODING_COMMENT = 'AutoCorrectEncodingComment'.freeze
         SHEBANG = '#!'.freeze
 

--- a/lib/rubocop/cop/style/mutable_constant.rb
+++ b/lib/rubocop/cop/style/mutable_constant.rb
@@ -15,12 +15,10 @@ module RuboCop
       class MutableConstant < Cop
         MSG = 'Freeze mutable objects assigned to constants.'.freeze
 
-        MUTABLE_TYPES = [:array, :hash, :str, :dstr].freeze
-
         def on_casgn(node)
           _scope, _const_name, value = *node
 
-          return if value && !MUTABLE_TYPES.include?(value.type)
+          return if value && !value.mutable_literal?
 
           add_offense(value, :expression)
         end

--- a/lib/rubocop/cop/style/redundant_freeze.rb
+++ b/lib/rubocop/cop/style/redundant_freeze.rb
@@ -14,13 +14,13 @@ module RuboCop
       class RedundantFreeze < Cop
         MSG = 'Freezing immutable objects is pointless.'.freeze
 
-        TARGET_NODES = [:int, :float, :sym, :dsym].freeze
-
         def on_send(node)
           receiver, method_name, *args = *node
 
-          return unless receiver && TARGET_NODES.include?(receiver.type)
-          return unless method_name == :freeze && args.empty?
+          return unless receiver &&
+                        method_name == :freeze &&
+                        args.empty? &&
+                        receiver.immutable_literal?
 
           add_offense(node, :expression)
         end

--- a/spec/rubocop/cop/style/redundant_freeze_spec.rb
+++ b/spec/rubocop/cop/style/redundant_freeze_spec.rb
@@ -21,6 +21,8 @@ describe RuboCop::Cop::Style::RedundantFreeze do
   it_behaves_like :immutable_objects, '1.5'
   it_behaves_like :immutable_objects, ':sym'
   it_behaves_like :immutable_objects, ':""'
+  it_behaves_like :immutable_objects, '/./'
+  it_behaves_like :immutable_objects, '1..5'
 
   shared_examples :mutable_objects do |o|
     it "allows #{o} with freeze" do


### PR DESCRIPTION
Makes Style/RedundantFreeze and Lint/EachWithObjectArgument
much more comprehensive