### PR TITLE
Un-flush autocorrection performance

### DIFF
--- a/lib/rubocop/cop/team.rb
+++ b/lib/rubocop/cop/team.rb
@@ -86,12 +86,6 @@ module RuboCop
 
         if cop_with_corrections
           corrections = cop_with_corrections.corrections
-          # Be extra careful if there are tabs in the source and just correct
-          # one offense, because inserting or removing space next to a tab has
-          # special implications, and existing ranges can't be used after such
-          # a change.
-          corrections = [corrections.first] if buffer.source =~ /\t/
-
           corrector = Corrector.new(buffer, corrections)
           corrector.rewrite
         else


### PR DESCRIPTION
In e0fce7e, @jonas054 adjusted autocorrection to only correct a single offense
at a time (rather than all offenses for a single cop) if the source file
contains tabs.

The comments indicate that autocorrecting files which contains tabs may be
problematic somehow, but it's hard to see how that is the case. All specs,
including the specs which were added in e0fce7e, still pass when the added
code is removed.

What prompted the addition of that code in the first place? It was made in
response to GH issue #1928. But all the "problem" code which was posted in that
thread is still autocorrected without problems, even when this "fix" is removed.

Why is removing this code desirable? Because, simply put, it flushes
autocorrection performance right down the toilet, and straight into the sewer.
It's hard to overstate how bad it is for perf. It takes what was just mildly
terrible and makes it appallingly, disastrously horrendous. And when I say
"horrendous", what I mean is "hideously atrocious".

If we still have trouble with tabs, it would be better to do a pass which
replaces tabs first, before any other cops get a crack at autocorrection. But
it remains to be seen whether that is actually necessary.

(@jonas054 Some exaggeration for humorous effect here, no offense intended!)