### PR TITLE
Fix Lint/Void offence with backtick literal.

### DIFF
--- a/lib/rubocop/cop/lint/void.rb
+++ b/lib/rubocop/cop/lint/void.rb
@@ -49,6 +49,8 @@ module RuboCop
 
         def check_for_literal(node)
           return unless node.literal?
+          return if node.xstr_type?
+
           add_offense(node, :expression, format(LIT_MSG, node.source))
         end
       end

--- a/spec/rubocop/cop/lint/void_spec.rb
+++ b/spec/rubocop/cop/lint/void_spec.rb
@@ -72,4 +72,20 @@ describe RuboCop::Cop::Lint::Void do
                    ])
     expect(cop.offenses).to be_empty
   end
+
+  it 'accepts backtick commands' do
+    inspect_source(cop,
+                   ['`touch x`',
+                    'nil'
+                   ])
+    expect(cop.offenses).to be_empty
+  end
+
+  it 'accepts percent-x commands' do
+    inspect_source(cop,
+                   ['%x(touch x)',
+                    'nil'
+                   ])
+    expect(cop.offenses).to be_empty
+  end
 end


### PR DESCRIPTION
Since 27325df8 backtick literals in a void context have been giving an offence. This fixes that and adds a test.