### PR TITLE
Call :expression on node instead of :keyword loc

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,10 @@
 * [#2631](https://github.com/bbatsov/rubocop/issues/2631): `Style/Encoding` can remove unneeded encoding comment when autocorrecting with `when_needed` style. ([@alexdowad][])
 * [#2860](https://github.com/bbatsov/rubocop/issues/2860): Fix false positive in `Rails/Date` when `to_time` is chained with safe method. ([@palkan][])
 
+### Changes
+
+* [#2629](https://github.com/bbatsov/rubocop/pull/2629): Change the offense range for metrics cops to default to `expression` instead of `keyword` (the offense now spans the entire method, class, or module). ([@rrosenblum][])
+
 ## 0.37.2 (11/02/2016)
 
 ### Bug fixes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### New features
 
 * `Style/UnlessElse` cop can auto-correct. ([@lumeet][])
+* [#2629](https://github.com/bbatsov/rubocop/pull/2629): Add a new public API method, `highlighted_area` to offense. This method returns the range of the highlighted portion of an offense. ([@rrosenblum][])
 
 ### Bug fixes
 

--- a/assets/output.html.erb
+++ b/assets/output.html.erb
@@ -161,6 +161,9 @@
     color: #777;
     text-align: right;
     }
+    .extra-code {
+      color: #ED9C28
+    }
     </style>
 
     <script>

--- a/lib/rubocop/cop/cop.rb
+++ b/lib/rubocop/cop/cop.rb
@@ -157,7 +157,7 @@ module RuboCop
       end
 
       def add_offense(node, loc, message = nil, severity = nil)
-        location = loc.is_a?(Symbol) ? node.loc.send(loc) : loc
+        location = loc.is_a?(Symbol) ? node.loc.public_send(loc) : loc
 
         # Don't include the same location twice for one cop.
         return if @offenses.any? { |o| o.location == location }

--- a/lib/rubocop/cop/mixin/code_length.rb
+++ b/lib/rubocop/cop/mixin/code_length.rb
@@ -19,7 +19,7 @@ module RuboCop
         length = code_length(node)
         return unless length > max_length
 
-        add_offense(node, :keyword, message(length, max_length)) do
+        add_offense(node, :expression, message(length, max_length)) do
           self.max = length
         end
       end

--- a/lib/rubocop/cop/offense.rb
+++ b/lib/rubocop/cop/offense.rb
@@ -87,6 +87,22 @@ module RuboCop
         @status == :disabled
       end
 
+      # @api public
+      #
+      # @return [Parser::Source::Range]
+      #   the range of the code that is highlighted
+      def highlighted_area
+        column_length = if location.first_line == location.last_line
+                          location.column_range.count
+                        else
+                          location.source_line.length - location.column
+                        end
+
+        Parser::Source::Range.new(location.source_line,
+                                  location.column,
+                                  location.column + column_length)
+      end
+
       # @api private
       # This is just for debugging purpose.
       def to_s

--- a/lib/rubocop/formatter/clang_style_formatter.rb
+++ b/lib/rubocop/formatter/clang_style_formatter.rb
@@ -22,13 +22,12 @@ module RuboCop
             next if source_line.blank?
 
             if location.first_line == location.last_line
-              column_length = location.column_range.count
               output.puts(source_line)
             else
-              column_length = location.source_line.length - location.column
               output.puts("#{source_line} #{ELLIPSES}")
             end
-            output.puts("#{' ' * location.column}#{'^' * column_length}")
+            output.puts("#{' ' * o.highlighted_area.begin_pos}" \
+                        "#{'^' * o.highlighted_area.size}")
           rescue IndexError
             # range is not on a valid line; perhaps the source file is empty
           end

--- a/lib/rubocop/formatter/clang_style_formatter.rb
+++ b/lib/rubocop/formatter/clang_style_formatter.rb
@@ -7,6 +7,8 @@ module RuboCop
     # The precise location of the problem is shown together with the
     # relevant source code.
     class ClangStyleFormatter < SimpleTextFormatter
+      ELLIPSES = Rainbow('...').yellow.freeze
+
       def report_file(file, offenses)
         offenses.each do |o|
           output.printf("%s:%d:%d: %s: %s\n",
@@ -15,26 +17,23 @@ module RuboCop
 
           # rubocop:disable Lint/HandleExceptions
           begin
-            source_line = o.location.source_line
+            location = o.location
+            source_line = location.source_line
             next if source_line.blank?
 
-            output.puts(source_line)
-            output.puts(highlight_line(o.location))
+            if location.first_line == location.last_line
+              column_length = location.column_range.count
+              output.puts(source_line)
+            else
+              column_length = location.source_line.length - location.column
+              output.puts("#{source_line} #{ELLIPSES}")
+            end
+            output.puts("#{' ' * location.column}#{'^' * column_length}")
           rescue IndexError
             # range is not on a valid line; perhaps the source file is empty
           end
           # rubocop:enable Lint/HandleExceptions
         end
-      end
-
-      def highlight_line(location)
-        column_length = if location.begin.line == location.end.line
-                          location.column_range.count
-                        else
-                          location.source_line.length - location.column
-                        end
-
-        ' ' * location.column + '^' * column_length
       end
     end
   end

--- a/lib/rubocop/formatter/html_formatter.rb
+++ b/lib/rubocop/formatter/html_formatter.rb
@@ -96,19 +96,17 @@ module RuboCop
         def highlighted_source_line(offense)
           location = offense.location
 
-          if location.first_line == location.last_line
-            column_range = location.column_range
-            source_line = location.source_line
-          else
-            column_range = location.column...location.source_line.length
-            source_line = "#{location.source_line} #{ELLIPSES}"
-          end
+          source_line = if location.first_line == location.last_line
+                          location.source_line
+                        else
+                          "#{location.source_line} #{ELLIPSES}"
+                        end
 
-          escape(source_line[0...column_range.begin]) +
+          escape(source_line[0...offense.highlighted_area.begin_pos]) +
             "<span class=\"highlight #{offense.severity}\">" +
-            escape(source_line[column_range]) +
+            escape(offense.highlighted_area.source) +
             '</span>' +
-            escape(source_line[column_range.end..-1])
+            escape(source_line[offense.highlighted_area.end_pos..-1])
         end
 
         def escape(s)

--- a/lib/rubocop/formatter/html_formatter.rb
+++ b/lib/rubocop/formatter/html_formatter.rb
@@ -11,6 +11,7 @@ module RuboCop
   module Formatter
     # This formatter saves the output as a html file.
     class HTMLFormatter < BaseFormatter
+      ELLIPSES = '<span class="extra-code">...</span>'.freeze
       TEMPLATE_PATH =
         File.expand_path('../../../../assets/output.html.erb', __FILE__)
 
@@ -95,13 +96,13 @@ module RuboCop
         def highlighted_source_line(offense)
           location = offense.location
 
-          column_range = if location.begin.line == location.end.line
-                           location.column_range
-                         else
-                           location.column...location.source_line.length
-                         end
-
-          source_line = location.source_line
+          if location.first_line == location.last_line
+            column_range = location.column_range
+            source_line = location.source_line
+          else
+            column_range = location.column...location.source_line.length
+            source_line = "#{location.source_line} #{ELLIPSES}"
+          end
 
           escape(source_line[0...column_range.begin]) +
             "<span class=\"highlight #{offense.severity}\">" +

--- a/spec/fixtures/html_formatter/expected.html
+++ b/spec/fixtures/html_formatter/expected.html
@@ -193,6 +193,9 @@
     color: #777;
     text-align: right;
     }
+    .extra-code {
+      color: #ED9C28
+    }
     </style>
 
     <script>
@@ -458,7 +461,7 @@ TvFXMeuCkZPcaEBLqvgPBhCuiZo8+sAAAAAASUVORK5CYII=
               <span class="message">Inconsistent indentation detected.</span>
             </div>
             
-            <pre><code>    <span class="highlight convention">def set_book</span></code></pre>
+            <pre><code>    <span class="highlight convention">def set_book</span> &lt;span class=&quot;extra-code&quot;&gt;...&lt;/span&gt;</code></pre>
             
           </div>
           
@@ -480,7 +483,7 @@ TvFXMeuCkZPcaEBLqvgPBhCuiZo8+sAAAAAASUVORK5CYII=
               <span class="message">Inconsistent indentation detected.</span>
             </div>
             
-            <pre><code>    <span class="highlight convention">def book_params</span></code></pre>
+            <pre><code>    <span class="highlight convention">def book_params</span> &lt;span class=&quot;extra-code&quot;&gt;...&lt;/span&gt;</code></pre>
             
           </div>
           

--- a/spec/rubocop/cli/cli_options_spec.rb
+++ b/spec/rubocop/cli/cli_options_spec.rb
@@ -730,7 +730,7 @@ describe RuboCop::CLI, :isolated_environment do
                     ' ^',
                     'example2.rb:3:1: C: Inconsistent indentation ' \
                     'detected.',
-                    'def a',
+                    'def a ...',
                     '^^^^^',
                     'example2.rb:4:1: C: Use 2 (not 3) spaces for ' \
                     'indentation.',

--- a/spec/rubocop/cop/metrics/class_length_spec.rb
+++ b/spec/rubocop/cop/metrics/class_length_spec.rb
@@ -21,6 +21,21 @@ describe RuboCop::Cop::Metrics::ClassLength, :config do
     expect(cop.config_to_allow_offenses).to eq('Max' => 6)
   end
 
+  it 'reports the correct beginning and end lines' do
+    inspect_source(cop, ['class Test',
+                         '  a = 1',
+                         '  a = 2',
+                         '  a = 3',
+                         '  a = 4',
+                         '  a = 5',
+                         '  a = 6',
+                         'end'])
+
+    offense = cop.offenses.first
+    expect(offense.location.first_line).to eq(1)
+    expect(offense.location.last_line).to eq(8)
+  end
+
   it 'accepts a class with 5 lines' do
     inspect_source(cop, ['class Test',
                          '  a = 1',

--- a/spec/rubocop/cop/metrics/method_length_spec.rb
+++ b/spec/rubocop/cop/metrics/method_length_spec.rb
@@ -21,6 +21,20 @@ describe RuboCop::Cop::Metrics::MethodLength, :config do
     expect(cop.config_to_allow_offenses).to eq('Max' => 6)
   end
 
+  it 'reports the correct beginning and end lines' do
+    inspect_source(cop, ['def m()',
+                         '  a = 1',
+                         '  a = 2',
+                         '  a = 3',
+                         '  a = 4',
+                         '  a = 5',
+                         '  a = 6',
+                         'end'])
+    offense = cop.offenses.first
+    expect(offense.location.first_line).to eq(1)
+    expect(offense.location.last_line).to eq(8)
+  end
+
   it 'accepts a method with less than 5 lines' do
     inspect_source(cop, ['def m()',
                          '  a = 1',

--- a/spec/rubocop/cop/metrics/module_length_spec.rb
+++ b/spec/rubocop/cop/metrics/module_length_spec.rb
@@ -21,6 +21,20 @@ describe RuboCop::Cop::Metrics::ModuleLength, :config do
     expect(cop.config_to_allow_offenses).to eq('Max' => 6)
   end
 
+  it 'reports the correct beginning and end lines' do
+    inspect_source(cop, ['module Test',
+                         '  a = 1',
+                         '  a = 2',
+                         '  a = 3',
+                         '  a = 4',
+                         '  a = 5',
+                         '  a = 6',
+                         'end'])
+    offense = cop.offenses.first
+    expect(offense.location.first_line).to eq(1)
+    expect(offense.location.last_line).to eq(8)
+  end
+
   it 'accepts a module with 5 lines' do
     inspect_source(cop, ['module Test',
                          '  a = 1',

--- a/spec/rubocop/cop/offense_spec.rb
+++ b/spec/rubocop/cop/offense_spec.rb
@@ -9,6 +9,7 @@ describe RuboCop::Cop::Offense do
     source_buffer.source = "a\n"
     Parser::Source::Range.new(source_buffer, 0, 1)
   end
+
   subject(:offense) do
     described_class.new(:convention, location, 'message', 'CopName', :corrected)
   end
@@ -19,6 +20,7 @@ describe RuboCop::Cop::Offense do
     expect(offense.message).to eq('message')
     expect(offense.cop_name).to eq('CopName')
     expect(offense.corrected?).to be_truthy
+    expect(offense.highlighted_area.source).to eq('a')
   end
 
   it 'overrides #to_s' do
@@ -130,6 +132,47 @@ describe RuboCop::Cop::Offense do
           expect(an_offense <=> other_offense).to eq(expectation)
         end
       end
+    end
+  end
+
+  context 'offenses that span multiple lines' do
+    let(:location) do
+      source_buffer = Parser::Source::Buffer.new('test', 1)
+      source_buffer.source = ['def foo',
+                              '  something',
+                              '  something_else',
+                              'end'].join("\n")
+      Parser::Source::Range.new(source_buffer, 0, source_buffer.source.length)
+    end
+
+    subject(:offense) do
+      described_class
+        .new(:convention, location, 'message', 'CopName', :corrected)
+    end
+
+    it 'highlights the first line' do
+      expect(offense.location.source).to eq(location.source_buffer.source)
+      expect(offense.highlighted_area.source).to eq('def foo')
+    end
+  end
+
+  context 'offenses that span part of a line' do
+    let(:location) do
+      source_buffer = Parser::Source::Buffer.new('test', 1)
+      source_buffer.source = ['def Foo',
+                              '  something',
+                              '  something_else',
+                              'end'].join("\n")
+      Parser::Source::Range.new(source_buffer, 4, 7)
+    end
+
+    subject(:offense) do
+      described_class
+        .new(:convention, location, 'message', 'CopName', :corrected)
+    end
+
+    it 'highlights the first line' do
+      expect(offense.highlighted_area.source).to eq('Foo')
     end
   end
 end

--- a/spec/rubocop/formatter/clang_style_formatter_spec.rb
+++ b/spec/rubocop/formatter/clang_style_formatter_spec.rb
@@ -53,7 +53,7 @@ module RuboCop
         end
 
         context 'when the offending source spans multiple lines' do
-          it 'displays the first line' do
+          it 'displays the first line with ellipses' do
             source = ['do_something([this,',
                       '              is,',
                       '              target])'].join($RS)
@@ -69,10 +69,11 @@ module RuboCop
             cop.add_offense(nil, location, 'message 1')
 
             formatter.report_file('test', cop.offenses)
-            expect(output.string).to eq ['test:1:14: C: message 1',
-                                         'do_something([this,',
-                                         '             ^^^^^^',
-                                         ''].join("\n")
+            expect(output.string)
+              .to eq ['test:1:14: C: message 1',
+                      "do_something([this, #{described_class::ELLIPSES}",
+                      '             ^^^^^^',
+                      ''].join("\n")
           end
         end
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,6 +1,10 @@
 # encoding: utf-8
 # frozen_string_literal: true
 
+# Disable colors in specs
+require 'rainbow'
+Rainbow.enabled = false
+
 # Coverage support needs to be required *before* the RuboCop code is required!
 require 'support/coverage'
 
@@ -38,9 +42,6 @@ RSpec.configure do |config|
     mocks.verify_partial_doubles = true
   end
 end
-
-# Disable colors in specs
-Rainbow.enabled = false
 
 # Disable network connections
 WebMock.disable_net_connect!(allow: 'codeclimate.com')


### PR DESCRIPTION
This is a continuation/replacement of #2414.

> Two things have to be done:
* there should be some indication in most formatters that the highlighted code spans beyond the line we've shown
* offenses should keep track of both the start and the end of the highlighted code region, so tools like CodeClimate could query this information.

I have modified the formatters to include ellipses (...) at the end of the highlighted code if the highlighted code spans more than one line. This could open up the html formatter to have an expand button that could show the entire highlighted offense.

I will work on adding `highlighted_area` to the offense.