### PR TITLE
[Fix #2641] Dont crash on empty methods with block args in Perfomance…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 * [#2630](https://github.com/bbatsov/rubocop/issues/2630): Take frozen string literals into account in `Style/MutableConstant`. ([@segiddins][])
 * [#2642](https://github.com/bbatsov/rubocop/issues/2642): Support assignment via `||=` in `Style/MutableConstant`. ([@segiddins][])
 * [#2646](https://github.com/bbatsov/rubocop/issues/2646): Fix auto-correcting assignment to a constant in `Style/ConditionalAssignment`. ([@segiddins][])
+* [#2641](https://github.com/bbatsov/rubocop/issues/2641): Fix crashing on empty methods with block args in `Perfomance/RedundantBlockCall`. ([@segiddins][])
 
 ### Changes
 

--- a/lib/rubocop/cop/performance/redundant_block_call.rb
+++ b/lib/rubocop/cop/performance/redundant_block_call.rb
@@ -37,6 +37,7 @@ module RuboCop
 
         def on_def(node)
           blockarg_def(node) do |argname, body|
+            next unless body
             blockarg_calls(body, argname) do |blockcall|
               add_offense(blockcall, :expression, format(MSG, argname))
             end

--- a/spec/rubocop/cop/performance/redundant_block_call_spec.rb
+++ b/spec/rubocop/cop/performance/redundant_block_call_spec.rb
@@ -40,6 +40,12 @@ describe RuboCop::Cop::Performance::RedundantBlockCall do
     expect(cop.messages).to be_empty
   end
 
+  it "doesn't register an error when block arg is unused" do
+    inspect_source(cop, ['def method(&block)',
+                         'end'])
+    expect(cop.messages).to be_empty
+  end
+
   it 'formats the error message for func.call(1) correctly' do
     inspect_source(cop, ['def method(&func)',
                          '  func.call(1)',


### PR DESCRIPTION
…/RedundantBlockCall