### PR TITLE
Fix DuplicateMethods with class_eval

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 * [#2647](https://github.com/bbatsov/rubocop/issues/2647): Allow `xstr` interpolations in `Lint/LiteralInInterpolation`. ([@segiddins][])
 * Report a violation when `freeze` is called on a frozen string literal in `Style/RedundantFreeze`. ([@segiddins][])
 * [#2641](https://github.com/bbatsov/rubocop/issues/2641): Fix crashing on empty methods with block args in `Perfomance/RedundantBlockCall`. ([@segiddins][])
+* `Lint/DuplicateMethods` doesn't crash when `class_eval` is used with an implicit receiver. ([@lumeet][])
 
 ### Changes
 

--- a/lib/rubocop/ast_node.rb
+++ b/lib/rubocop/ast_node.rb
@@ -326,7 +326,7 @@ module RuboCop
           # Known DSL methods which eval body inside an anonymous class/module
           return nil if [:describe, :it].include?(ancestor.method_name) &&
                         ancestor.receiver.nil?
-          if ancestor.method_name == :class_eval
+          if ancestor.method_name == :class_eval && ancestor.receiver
             return nil unless ancestor.receiver.const_type?
             ancestor.receiver.const_name
           end

--- a/lib/rubocop/ast_node.rb
+++ b/lib/rubocop/ast_node.rb
@@ -42,6 +42,8 @@ module RuboCop
     OPERATOR_KEYWORDS = [:and, :or].freeze
     SPECIAL_KEYWORDS = %w(__FILE__ __LINE__ __ENCODING__).freeze
 
+    RSPEC_METHODS = [:describe, :it].freeze
+
     # def_matcher can be used to define a pattern-matching method on Node
     class << self
       def def_matcher(method_name, pattern_str)
@@ -323,9 +325,7 @@ module RuboCop
           return "#<Class:#{ancestor.parent_module_name}>" if obj.self_type?
           return nil
         else # block
-          # Known DSL methods which eval body inside an anonymous class/module
-          return nil if [:describe, :it].include?(ancestor.method_name) &&
-                        ancestor.receiver.nil?
+          return nil if ancestor.known_dsl?
           if ancestor.method_name == :class_eval && ancestor.receiver
             return nil unless ancestor.receiver.const_type?
             ancestor.receiver.const_name
@@ -479,6 +479,11 @@ module RuboCop
       else
         false
       end
+    end
+
+    # Known DSL methods which eval body inside an anonymous class/module
+    def known_dsl?
+      RSPEC_METHODS.include?(method_name) && receiver.nil?
     end
 
     protected

--- a/spec/rubocop/cop/lint/duplicate_methods_spec.rb
+++ b/spec/rubocop/cop/lint/duplicate_methods_spec.rb
@@ -289,6 +289,22 @@ describe RuboCop::Cop::Lint::DuplicateMethods do
       ['Method `A.some_method` is defined at both test.rb:2 and test.rb:5.'])
   end
 
+  it 'handles class_eval with implicit receiver' do
+    inspect_source(cop, ['module A',
+                         '  class_eval do',
+                         '    def some_method',
+                         '      implement 1',
+                         '    end',
+                         '    def some_method',
+                         '      implement 2',
+                         '    end',
+                         '  end',
+                         'end'], 'test.rb')
+    expect(cop.offenses.size).to eq(1)
+    expect(cop.messages).to eq(
+      ['Method `A#some_method` is defined at both test.rb:3 and test.rb:6.'])
+  end
+
   it 'ignores method definitions in RSpec `describe` blocks' do
     inspect_source(cop,
                    ['describe "something" do',


### PR DESCRIPTION
The cop doesn't crash when `class_eval` is used with an implicit
receiver.