### PR TITLE
Be compatible with the `RUBY_VERSION` format

### DIFF
--- a/lib/rubocop/config.rb
+++ b/lib/rubocop/config.rb
@@ -268,7 +268,7 @@ module RuboCop
     end
 
     def matches_known_versions?(target)
-      KNOWN_RUBIES.any? { |ruby| /^#{(ruby)}/ =~ target.to_s }
+      KNOWN_RUBIES.any? { |ruby| /^#{ruby}/ =~ target.to_s }
     end
   end
 end

--- a/lib/rubocop/config.rb
+++ b/lib/rubocop/config.rb
@@ -16,7 +16,7 @@ module RuboCop
 
     COMMON_PARAMS = %w(Exclude Include Severity
                        AutoCorrect StyleGuide Details).freeze
-    KNOWN_RUBIES = [1.9, 2.0, 2.1, 2.2, 2.3].freeze
+    KNOWN_RUBIES = %w(1.9 2.0 2.1 2.2 2.3).freeze
 
     attr_reader :loaded_path
 
@@ -259,7 +259,7 @@ module RuboCop
       target = self['AllCops'] && self['AllCops']['TargetRubyVersion']
       return unless target
 
-      unless KNOWN_RUBIES.include?(target)
+      unless KNOWN_RUBIES.any? { |ruby| Regexp.new(ruby) =~ target.to_s }
         fail ValidationError, "Unknown Ruby version #{target.inspect} found " \
                               'in `TargetRubyVersion` parameter (in ' \
                               "#{loaded_path}).\nKnown versions: " \

--- a/lib/rubocop/config.rb
+++ b/lib/rubocop/config.rb
@@ -259,7 +259,7 @@ module RuboCop
       target = self['AllCops'] && self['AllCops']['TargetRubyVersion']
       return unless target
 
-      unless KNOWN_RUBIES.any? { |ruby| Regexp.new(ruby) =~ target.to_s }
+      unless KNOWN_RUBIES.any? { |ruby| /^#{(ruby)}/ =~ target.to_s }
         fail ValidationError, "Unknown Ruby version #{target.inspect} found " \
                               'in `TargetRubyVersion` parameter (in ' \
                               "#{loaded_path}).\nKnown versions: " \

--- a/lib/rubocop/config.rb
+++ b/lib/rubocop/config.rb
@@ -259,12 +259,16 @@ module RuboCop
       target = self['AllCops'] && self['AllCops']['TargetRubyVersion']
       return unless target
 
-      unless KNOWN_RUBIES.any? { |ruby| /^#{(ruby)}/ =~ target.to_s }
+      unless matches_known_versions?(target)
         fail ValidationError, "Unknown Ruby version #{target.inspect} found " \
                               'in `TargetRubyVersion` parameter (in ' \
                               "#{loaded_path}).\nKnown versions: " \
                               "#{KNOWN_RUBIES.join(', ')}"
       end
+    end
+
+    def matches_known_versions?(target)
+      KNOWN_RUBIES.any? { |ruby| /^#{(ruby)}/ =~ target.to_s }
     end
   end
 end

--- a/lib/rubocop/processed_source.rb
+++ b/lib/rubocop/processed_source.rb
@@ -98,20 +98,20 @@ module RuboCop
     end
 
     def parser_class(ruby_version)
-      case ruby_version
-      when 1.9
+      case ruby_version.to_s
+      when /1.9/
         require 'parser/ruby19'
         Parser::Ruby19
-      when 2.0
+      when /2.0/
         require 'parser/ruby20'
         Parser::Ruby20
-      when 2.1
+      when /2.1/
         require 'parser/ruby21'
         Parser::Ruby21
-      when 2.2
+      when /2.2/
         require 'parser/ruby22'
         Parser::Ruby22
-      when 2.3
+      when /2.3/
         require 'parser/ruby23'
         Parser::Ruby23
       else

--- a/lib/rubocop/processed_source.rb
+++ b/lib/rubocop/processed_source.rb
@@ -99,19 +99,19 @@ module RuboCop
 
     def parser_class(ruby_version)
       case ruby_version.to_s
-      when /1.9/
+      when /^1\.9/
         require 'parser/ruby19'
         Parser::Ruby19
-      when /2.0/
+      when /^2\.0/
         require 'parser/ruby20'
         Parser::Ruby20
-      when /2.1/
+      when /^2\.1/
         require 'parser/ruby21'
         Parser::Ruby21
-      when /2.2/
+      when /^2\.2/
         require 'parser/ruby22'
         Parser::Ruby22
-      when /2.3/
+      when /^2\.3/
         require 'parser/ruby23'
         Parser::Ruby23
       else

--- a/spec/rubocop/processed_source_spec.rb
+++ b/spec/rubocop/processed_source_spec.rb
@@ -34,6 +34,12 @@ describe RuboCop::ProcessedSource do
       it "sets the file path to the instance's #path" do
         expect(processed_source.path).to eq(path)
       end
+
+      it 'handles a ruby version from RUBY_VERSION' do
+        processed_source = described_class.new(source, RUBY_VERSION, path)
+
+        expect(processed_source).to be_a(described_class)
+      end
     end
 
     it 'raises RuboCop::Error when the file does not exist' do


### PR DESCRIPTION
This change makes it so that a user of Rubocop, can pass in
the constant `RUBY_VERSION` as the given ruby version for
`ProcessedSource`. The constant follows the format of i.e `"2.3.0"`.

This also is backwards compatible with the current behavior of passing
in a version in the format of `1.9` Or passing the version as an
`Integer` or `String`.