### PR TITLE
Fix Windows problems

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@
 * `Lint/DuplicateMethods` doesn't crash when `class_eval` is used with an implicit receiver. ([@lumeet][])
 * [#2654](https://github.com/bbatsov/rubocop/issues/2654): Fix handling of unary operations in `Style/RedundantParentheses`. ([@lumeet][])
 * [#2661](https://github.com/bbatsov/rubocop/issues/2661): `Style/Next` doesn't crash when auto-correcting modifier `if/unless`. ([@lumeet][])
+* [#2665](https://github.com/bbatsov/rubocop/pull/2665): Make specs pass when running on Windows. ([@jonas054][])
 
 ### Changes
 

--- a/lib/rubocop/config.rb
+++ b/lib/rubocop/config.rb
@@ -34,7 +34,7 @@ module RuboCop
         next unless self[key]['Exclude']
 
         self[key]['Exclude'].map! do |exclude_elem|
-          if exclude_elem.is_a?(String) && !exclude_elem.start_with?('/')
+          if exclude_elem.is_a?(String) && !absolute?(exclude_elem)
             File.expand_path(File.join(base_dir_for_path_parameters,
                                        exclude_elem))
           else
@@ -51,7 +51,7 @@ module RuboCop
       self['AllCops'] ||= {}
       excludes = self['AllCops']['Exclude'] ||= []
       highest_config['AllCops']['Exclude'].each do |path|
-        unless path.is_a?(Regexp) || path.start_with?('/')
+        unless path.is_a?(Regexp) || absolute?(path)
           path = File.join(File.dirname(highest_config.loaded_path), path)
         end
         excludes << path unless excludes.include?(path)

--- a/lib/rubocop/path_util.rb
+++ b/lib/rubocop/path_util.rb
@@ -55,5 +55,10 @@ module RuboCop
     def hidden?(path_component)
       path_component =~ /^\.[^.]/
     end
+
+    # Returns true for an absolute Unix or Windows path.
+    def absolute?(path)
+      path =~ %r{\A([A-Z]:)?/}
+    end
   end
 end

--- a/spec/rubocop/config_spec.rb
+++ b/spec/rubocop/config_spec.rb
@@ -129,7 +129,9 @@ describe RuboCop::Config do
       end
 
       it 'should generate valid absolute directory' do
-        expect(configuration['AllCops']['Exclude'])
+        excludes = configuration['AllCops']['Exclude']
+                   .map { |e| e.sub(/^[A-Z]:/, '') }
+        expect(excludes)
           .to eq [
             '/home/foo/project/config/environment',
             '/home/foo/project/spec'
@@ -157,7 +159,9 @@ describe RuboCop::Config do
       end
 
       it 'should generate valid absolute directory' do
-        expect(configuration['AllCops']['Exclude'])
+        excludes = configuration['AllCops']['Exclude']
+                   .map { |e| e.sub(/^[A-Z]:/, '') }
+        expect(excludes)
           .to eq [
             '/home/foo/project/config/environment',
             '/home/foo/project/spec'

--- a/spec/rubocop/formatter/formatter_set_spec.rb
+++ b/spec/rubocop/formatter/formatter_set_spec.rb
@@ -63,8 +63,11 @@ module RuboCop
             expect(formatter_set.first.output.path).to eq(output_path)
           end
 
-          it "creates parent directories if they don't exist" do
-            Dir.mktmpdir do |tmpdir|
+          context "when parent directories don't exist" do
+            let(:tmpdir) { Dir.mktmpdir }
+            after { FileUtils.rm_rf(tmpdir) }
+
+            it 'creates them' do
               output_path = File.join(tmpdir, 'path/does/not/exist')
               formatter_set.add_formatter('simple', output_path)
               expect(formatter_set.first.output.class).to eq(File)

--- a/spec/rubocop/result_cache_spec.rb
+++ b/spec/rubocop/result_cache_spec.rb
@@ -59,6 +59,12 @@ describe RuboCop::ResultCache, :isolated_environment do
 
       context 'when a symlink attack is made' do
         before(:each) do
+          # Avoid getting "symlink() function is unimplemented on this
+          # machine" on Windows.
+          if RUBY_PLATFORM =~ /cygwin|mswin|mingw|bccwin|wince|emx/
+            skip 'Symlinks not implemented on Windows'
+          end
+
           cache.save(offenses)
           Find.find(cache_root) do |path|
             next unless File.basename(path) == '_'

--- a/spec/rubocop/target_finder_spec.rb
+++ b/spec/rubocop/target_finder_spec.rb
@@ -31,7 +31,7 @@ describe RuboCop::TargetFinder, :isolated_environment do
     it 'returns absolute paths' do
       expect(found_files).not_to be_empty
       found_files.each do |file|
-        expect(file).to start_with('/')
+        expect(file.sub(/^[A-Z]:/, '')).to start_with('/')
       end
     end
 


### PR DESCRIPTION
I did some testing on Windows (mingw) for the first time ever and tried to find solutions for the problems I encountered. The support for drive letter and the skipping of the symlink example are pretty straight forward. Then there's the strange behavior around backticks and temporary directories. Slightly more ugly solutions. See what you think.

Anyway, after these changes I was able to run `bundle` and `rake` in a Windows `cmd` window.