### PR TITLE
How about exclude .git/ diretory by default?

### DIFF
--- a/config/default.yml
+++ b/config/default.yml
@@ -26,6 +26,7 @@ AllCops:
     - '**/Cheffile'
     - '**/Vagabondfile'
   Exclude:
+    - '.git/**/*'
     - 'vendor/**/*'
   # Default formatter will be used if no -f/--format option is given.
   DefaultFormatter: progress


### PR DESCRIPTION
.git/ files is extracted by following line.
https://github.com/bbatsov/rubocop/blob/master/lib/rubocop/target_finder.rb#L62

and filtered by inspect_file? following line
https://github.com/bbatsov/rubocop/blob/master/lib/rubocop/target_finder.rb#L77

In most case, I think, it's waste time to search under .git/ directory.
In large project, .git/ is very large. So ignoring .git/ is value for it.
