### PR TITLE
Fix false-positive for single item array and hash when consistent_comma

### DIFF
--- a/lib/rubocop/cop/mixin/trailing_comma.rb
+++ b/lib/rubocop/cop/mixin/trailing_comma.rb
@@ -65,6 +65,11 @@ module RuboCop
       # on different lines, and each item within is on its own line, and the
       # closing bracket is on its own line.
       def multiline?(node)
+        if node.type == :array || node.type == :hash
+          # Checks if start and end of brackets are on same line
+          return false if node.source_range.first_line == node.source_range.last_line
+        end
+
         elements = if node.type == :send
                      _receiver, _method_name, *args = *node
                      args.flat_map do |a|

--- a/spec/rubocop/cop/style/trailing_comma_in_literal_spec.rb
+++ b/spec/rubocop/cop/style/trailing_comma_in_literal_spec.rb
@@ -25,6 +25,11 @@ describe RuboCop::Cop::Style::TrailingCommaInLiteral, :config do
       expect(cop.offenses).to be_empty
     end
 
+    it 'accepts single item Array literal without trailing comma' do
+      inspect_source(cop, 'VALUES = [1001]')
+      expect(cop.offenses).to be_empty
+    end
+
     it 'accepts empty Array literal' do
       inspect_source(cop, 'VALUES = []')
       expect(cop.offenses).to be_empty
@@ -41,6 +46,11 @@ describe RuboCop::Cop::Style::TrailingCommaInLiteral, :config do
 
     it 'accepts Hash literal without trailing comma' do
       inspect_source(cop, 'MAP = { a: 1001, b: 2020, c: 3333 }')
+      expect(cop.offenses).to be_empty
+    end
+
+    it 'accepts single item Hash literal without trailing comma' do
+      inspect_source(cop, 'MAP = { a: 1001 }')
       expect(cop.offenses).to be_empty
     end
 


### PR DESCRIPTION
consistent_comma warns for array or hash with only one item even if open and close brackets are on same line.

```ruby
VALUES = [1001]
MAP = { a: 1001 }
```