### PR TITLE
Redundant block call parentheses

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@
 * [#2661](https://github.com/bbatsov/rubocop/issues/2661): `Style/Next` doesn't crash when auto-correcting modifier `if/unless`. ([@lumeet][])
 * [#2665](https://github.com/bbatsov/rubocop/pull/2665): Make specs pass when running on Windows. ([@jonas054][])
 * [#2691](https://github.com/bbatsov/rubocop/pull/2691): Do not register an offense in `Performance/TimesMap` for calling `map` or `collect` on a variable named `times`. ([@rrosenblum][])
+* [#2689](https://github.com/bbatsov/rubocop/pull/2689): Change `Performance/RedundantBlockCall` to respect parentheses usage. ([@rrosenblum][])
 
 ### Changes
 

--- a/lib/rubocop/cop/performance/redundant_block_call.rb
+++ b/lib/rubocop/cop/performance/redundant_block_call.rb
@@ -25,6 +25,10 @@ module RuboCop
       #   end
       class RedundantBlockCall < Cop
         MSG = 'Use `yield` instead of `%s.call`.'.freeze
+        YIELD = 'yield'.freeze
+        OPEN_PAREN = '('.freeze
+        CLOSE_PAREN = ')'.freeze
+        SPACE = ' '.freeze
 
         def_node_matcher :blockarg_def, <<-END
           {(def  _   (args ... (blockarg $_)) $_)
@@ -47,18 +51,18 @@ module RuboCop
         # offenses are registered on the `block.call` nodes
         def autocorrect(node)
           _receiver, _method, *args = *node
-          new_source = 'yield'
+          new_source = String.new(YIELD)
           unless args.empty?
             new_source += if parentheses?(node)
-                            '('
+                            OPEN_PAREN
                           else
-                            ' '
+                            SPACE
                           end
 
-            new_source += args.map(&:source).join(', ')
+            new_source << args.map(&:source).join(', ')
           end
 
-          new_source += ')' if parentheses?(node)
+          new_source << CLOSE_PAREN if parentheses?(node)
           ->(corrector) { corrector.replace(node.source_range, new_source) }
         end
       end

--- a/lib/rubocop/cop/performance/redundant_block_call.rb
+++ b/lib/rubocop/cop/performance/redundant_block_call.rb
@@ -48,8 +48,17 @@ module RuboCop
         def autocorrect(node)
           _receiver, _method, *args = *node
           new_source = 'yield'
-          new_source += ' ' unless args.empty?
-          new_source += args.map(&:source).join(', ')
+          unless args.empty?
+            new_source += if parentheses?(node)
+                            '('
+                          else
+                            ' '
+                          end
+
+            new_source += args.map(&:source).join(', ')
+          end
+
+          new_source += ')' if parentheses?(node)
           ->(corrector) { corrector.replace(node.source_range, new_source) }
         end
       end

--- a/spec/rubocop/cop/performance/redundant_block_call_spec.rb
+++ b/spec/rubocop/cop/performance/redundant_block_call_spec.rb
@@ -52,4 +52,31 @@ describe RuboCop::Cop::Performance::RedundantBlockCall do
                          'end'])
     expect(cop.messages).to eq(['Use `yield` instead of `func.call`.'])
   end
+
+  it 'autocorrects using parentheses when block.call uses parentheses' do
+    new_source = autocorrect_source(cop, ['def method(&block)',
+                                          '  block.call(a, b)',
+                                          'end'])
+
+    expect(new_source).to eq(['def method(&block)',
+                              '  yield(a, b)',
+                              'end'].join("\n"))
+  end
+
+  it 'autocorrects when the result of the call is used in a scope that ' \
+     'requires parentheses' do
+    source = ['def method(&block)',
+              '  each_with_object({}) do |(key, value), acc|',
+              '    acc.merge!(block.call(key) => rhs[value])',
+              '  end',
+              'end']
+
+    new_source = autocorrect_source(cop, source)
+
+    expect(new_source).to eq(['def method(&block)',
+                              '  each_with_object({}) do |(key, value), acc|',
+                              '    acc.merge!(yield(key) => rhs[value])',
+                              '  end',
+                              'end'].join("\n"))
+  end
 end


### PR DESCRIPTION
I came across an edge case that caused auto-correct to break the code. Take a look at the second test case for the example code.