### PR TITLE
Single line and item consistent comma

### DIFF
--- a/lib/rubocop/cop/mixin/trailing_comma.rb
+++ b/lib/rubocop/cop/mixin/trailing_comma.rb
@@ -84,7 +84,7 @@ module RuboCop
         # Without this check, Foo.new({}) is considered multiline, which
         # it should not be. Essentially, if there are no elements, the
         # expression can not be multiline.
-        return if elements.empty?
+        return if elements.empty? || !node.multiline?
 
         items = elements.map(&:source_range)
         if style == :consistent_comma

--- a/spec/rubocop/cop/style/trailing_comma_in_arguments_spec.rb
+++ b/spec/rubocop/cop/style/trailing_comma_in_arguments_spec.rb
@@ -302,6 +302,12 @@ describe RuboCop::Cop::Style::TrailingCommaInArguments, :config do
                                   '           )'].join("\n"))
       end
 
+      it 'accepts a single line call with a single argument and' \
+         'without trailing comma' do
+        inspect_source(cop, 'some_method(a)')
+        expect(cop.offenses).to be_empty
+      end
+
       it 'accepts a multiline call with a single argument and trailing comma' do
         inspect_source(cop, ['method(',
                              '  1,',

--- a/spec/rubocop/cop/style/trailing_comma_in_literal_spec.rb
+++ b/spec/rubocop/cop/style/trailing_comma_in_literal_spec.rb
@@ -424,6 +424,18 @@ describe RuboCop::Cop::Style::TrailingCommaInLiteral, :config do
                                   '}'].join("\n"))
       end
 
+      it 'accepts a signle line array with a single item' \
+         'and without trailing comma' do
+        inspect_source(cop, 'VALUES = [1001]')
+        expect(cop.offenses).to be_empty
+      end
+
+      it 'accepts a single line hash with a single pair' \
+         'and without trailing comma' do
+        inspect_source(cop, 'MAP = { a: 1001 }')
+        expect(cop.offenses).to be_empty
+      end
+
       it 'accepts a multiline array with a single item and trailing comma' do
         inspect_source(cop, ['foo = [',
                              '  1,',


### PR DESCRIPTION
rubocop.yml

```yaml
Style/TrailingCommaInArguments:
    EnforcedStyleForMultiline: consistent_comma

Style/TrailingCommaInLiteral:
    EnforcedStyleForMultiline: consistent_comma
```

before file

```ruby
some(a)
some(a, b)

[100]
[100, 200]

{ a: 1 }
{ a: 1, b: 2 }
```

after `rubocop -a`

```ruby
some(a,)
some(a, b)

[100,]
[100, 200]

{ a: 1, }
{ a: 1, b: 2 }
```

But style guid say this is the bad case https://github.com/bbatsov/ruby-style-guide#no-trailing-array-commas

Is it intentional?

I fix that not put trailing comma in this case.