### PR TITLE
[Fix #2701] Consider loops as branching points

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@
 * [#2689](https://github.com/bbatsov/rubocop/pull/2689): Change `Performance/RedundantBlockCall` to respect parentheses usage. ([@rrosenblum][])
 * [#2694](https://github.com/bbatsov/rubocop/issues/2694): Fix caching when using a different JSON gem such as Oj. ([@stormbreakerbg][])
 * [#2707](https://github.com/bbatsov/rubocop/pull/2707): Change `Lint/NestedMethodDefinition` to respect `Class.new` and `Module.new`. ([@owst][])
+* [#2701](https://github.com/bbatsov/rubocop/pull/2701): Do not consider assignments to the same variable as useless if later assignments are within a loop. ([@owst][])
 
 ### Changes
 

--- a/spec/rubocop/cop/lint/useless_assignment_spec.rb
+++ b/spec/rubocop/cop/lint/useless_assignment_spec.rb
@@ -616,6 +616,103 @@ describe RuboCop::Cop::Lint::UselessAssignment do
     include_examples 'mimics MRI 2.1'
   end
 
+  context 'when a variable is reassigned in a loop' do
+    context 'while loop' do
+      let(:source) do
+        [
+          'def while(param)',
+          '  ret = 1',
+          '',
+          '  while param != 10',
+          '    param += 2',
+          '    ret = param + 1',
+          '  end',
+          '',
+          '  ret',
+          'end'
+        ]
+      end
+
+      include_examples 'accepts'
+    end
+
+    context 'post while loop' do
+      let(:source) do
+        [
+          'def post_while(param)',
+          '  ret = 1',
+          '',
+          '  begin',
+          '    param += 2',
+          '    ret = param + 1',
+          '  end while param < 40',
+          '',
+          '  ret',
+          'end'
+        ]
+      end
+
+      include_examples 'accepts'
+    end
+
+    context 'until loop' do
+      let(:source) do
+        [
+          'def until(param)',
+          '  ret = 1',
+          '',
+          '  until param == 10',
+          '    param += 2',
+          '    ret = param + 1',
+          '  end',
+          '',
+          '  ret',
+          'end'
+        ]
+      end
+
+      include_examples 'accepts'
+    end
+
+    context 'post until loop' do
+      let(:source) do
+        [
+          'def post_until(param)',
+          '  ret = 1',
+          '',
+          '  begin',
+          '    param += 2',
+          '    ret = param + 1',
+          '  end until param == 10',
+          '',
+          '  ret',
+          'end'
+        ]
+      end
+
+      include_examples 'accepts'
+    end
+
+    context 'for loop' do
+      let(:source) do
+        [
+          'def for(param)',
+          '  ret = 1',
+          '',
+          '  for x in param...10',
+          '    param += x',
+          '    ret = param + 1',
+          '  end',
+          '',
+          '  ret',
+          'end'
+        ]
+      end
+
+      include_examples 'accepts'
+    end
+  end
+
   context 'when a variable is assigned in each branch of if ' \
           'and referenced after the branching' do
     let(:source) do


### PR DESCRIPTION
Variable assignments made inside loops should be considered as
conditionally executed and therefore earlier assignments to the same
variables should not be marked as useless.