### PR TITLE
Test on rbx-3 in Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ rvm:
   - ruby-head
   - jruby-19mode
   - jruby-9.0.1.0
-  - rbx-2
+  - rbx-3
 env:
   # this doesn't do anything for MRI or RBX, but it doesn't hurt them either
   # for JRuby, it enables us to get more accurate coverage data
@@ -18,7 +18,7 @@ env:
 matrix:
   allow_failures:
     - rvm: ruby-head
-    - rvm: rbx-2
+    - rvm: rbx-3
   fast_finish: true
 before_install: gem update --remote bundler
 install:


### PR DESCRIPTION
As of 3.12, Rubinius will now at least run the tests, after this issue was fixed: https://github.com/rubinius/rubinius/issues/3586

Still keeping it under allowed failures for now because a few tests were flapping locally.