### PR TITLE
[Fix #2707] ignore nested method definitions within Class.new/Module.new

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@
 * [#2691](https://github.com/bbatsov/rubocop/pull/2691): Do not register an offense in `Performance/TimesMap` for calling `map` or `collect` on a variable named `times`. ([@rrosenblum][])
 * [#2689](https://github.com/bbatsov/rubocop/pull/2689): Change `Performance/RedundantBlockCall` to respect parentheses usage. ([@rrosenblum][])
 * [#2694](https://github.com/bbatsov/rubocop/issues/2694): Fix caching when using a different JSON gem such as Oj. ([@stormbreakerbg][])
+* [#2707](https://github.com/bbatsov/rubocop/pull/2707): Change `Lint/NestedMethodDefinition` to respect `Class.new` and `Module.new`. ([@owst][])
 
 ### Changes
 
@@ -1911,3 +1912,4 @@
 [@mattparlane]: https://github.com/mattparlane
 [@drenmi]: https://github.com/drenmi
 [@stormbreakerbg]: https://github.com/stormbreakerbg
+[@owst]: https://github.com/owst

--- a/lib/rubocop/cop/lint/nested_method_definition.rb
+++ b/lib/rubocop/cop/lint/nested_method_definition.rb
@@ -26,6 +26,10 @@ module RuboCop
           (block (send _ {:instance_eval :class_eval :module_eval} ...) ...)
         PATTERN
 
+        def_node_matcher :class_or_module_new_call?, <<-PATTERN
+          (block (send (const nil {:Class :Module}) :new) ...)
+        PATTERN
+
         def on_method_def(node, _method_name, _args, _body)
           find_nested_defs(node) do |nested_def_node|
             add_offense(nested_def_node, :expression)
@@ -36,7 +40,7 @@ module RuboCop
           node.each_child_node do |child|
             if child.def_type? || child.defs_type?
               yield child
-            elsif !eval_call?(child)
+            elsif !(eval_call?(child) || class_or_module_new_call?(child))
               find_nested_defs(child, &block)
             end
           end

--- a/spec/rubocop/cop/lint/nested_method_definition_spec.rb
+++ b/spec/rubocop/cop/lint/nested_method_definition_spec.rb
@@ -82,4 +82,28 @@ describe RuboCop::Cop::Lint::NestedMethodDefinition do
                          'end'])
     expect(cop.offenses.size).to eq(0)
   end
+
+  it 'does not register offense for nested definition inside Class.new' do
+    inspect_source(cop, ['class Foo',
+                         '  def self.define',
+                         '    Class.new do',
+                         '      def y',
+                         '      end',
+                         '    end',
+                         '  end',
+                         'end'])
+    expect(cop.offenses.size).to eq(0)
+  end
+
+  it 'does not register offense for nested definition inside Module.new' do
+    inspect_source(cop, ['class Foo',
+                         '  def self.define',
+                         '    Module.new do',
+                         '      def y',
+                         '      end',
+                         '    end',
+                         '  end',
+                         'end'])
+    expect(cop.offenses.size).to eq(0)
+  end
 end


### PR DESCRIPTION
Such method definitions syntactically appear nested, but are in fact
not, since `Class.new` is implemented using `class_eval` and thus the
nested definition defines a method on the new class, not the enclosing
one.