### PR TITLE
[Fix #2694] Fix caching when using a different JSON gem

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@
 * [#2665](https://github.com/bbatsov/rubocop/pull/2665): Make specs pass when running on Windows. ([@jonas054][])
 * [#2691](https://github.com/bbatsov/rubocop/pull/2691): Do not register an offense in `Performance/TimesMap` for calling `map` or `collect` on a variable named `times`. ([@rrosenblum][])
 * [#2689](https://github.com/bbatsov/rubocop/pull/2689): Change `Performance/RedundantBlockCall` to respect parentheses usage. ([@rrosenblum][])
+* [#2694](https://github.com/bbatsov/rubocop/issues/2694): Fix caching when using a different JSON gem such as Oj. ([@stormbreakerbg][])
 
 ### Changes
 
@@ -1909,3 +1910,4 @@
 [@mvidner]: https://github.com/mvidner
 [@mattparlane]: https://github.com/mattparlane
 [@drenmi]: https://github.com/drenmi
+[@stormbreakerbg]: https://github.com/stormbreakerbg

--- a/lib/rubocop/cached_data.rb
+++ b/lib/rubocop/cached_data.rb
@@ -31,7 +31,10 @@ module RuboCop
                 end
 
       {
-        severity: offense.severity,
+        # Calling #to_s here ensures that the serialization works when using
+        # other json serializers such as Oj. Some of these gems do not call
+        # #to_s implicitly.
+        severity: offense.severity.to_s,
         location: {
           begin_pos: offense.location.begin_pos,
           end_pos: offense.location.end_pos


### PR DESCRIPTION
[The original issue](https://github.com/bbatsov/rubocop/issues/2694)

Some JSON generators (such as Oj) that try to mimic `JSON` do not call `#to_s` if they cannot serialize the object in any other way. This leads to generating an invalid JSON structure for the offense cache which made RuboCop crash when deserializing.

I could not find any documentation that states `JSON.dump` should call `#to_s` if the object cannot be serialized in another way. Because of this, I believe we should not rely on this behavior.
I am unsure of what your policy is regarding such compatibility issues and I will understand if you do not want to fix this here as it is caused by another gem replacing `JSON`.