### PR TITLE
Fix handling of fullwidth characters in AlignArray

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@
 * [#2664](https://github.com/bbatsov/rubocop/issues/2664): `Performance/Casecmp` can auto-correct case comparison to variables and method calls without error. ([@rrosenblum][])
 * [#2729](https://github.com/bbatsov/rubocop/issues/2729): Fix handling of hash literal as the first argument in `Style/RedundantParentheses`. ([@lumeet][])
 * [#2703](https://github.com/bbatsov/rubocop/issues/2703): Handle byte order mark in `Style/IndentationWidth`, `Style/ElseAlignment`, `Lint/EndAlignment`, and `Lint/DefEndAlignment`. ([@jonas054][])
+* [#2710](https://github.com/bbatsov/rubocop/pull/2710): Fix handling of fullwidth characters in some cops. ([@seikichi][])
 
 ### Changes
 
@@ -1921,3 +1922,4 @@
 [@drenmi]: https://github.com/drenmi
 [@stormbreakerbg]: https://github.com/stormbreakerbg
 [@owst]: https://github.com/owst
+[@seikichi]: https://github.com/seikichi

--- a/lib/rubocop.rb
+++ b/lib/rubocop.rb
@@ -11,6 +11,7 @@ require 'powerpack/enumerable/drop_last'
 require 'powerpack/hash/symbolize_keys'
 require 'powerpack/string/blank'
 require 'powerpack/string/strip_indent'
+require 'unicode/display_width'
 
 require 'rubocop/version'
 

--- a/lib/rubocop/cop/mixin/autocorrect_alignment.rb
+++ b/lib/rubocop/cop/mixin/autocorrect_alignment.rb
@@ -22,13 +22,20 @@ module RuboCop
         SPACE * node.loc.column
       end
 
+      def display_column(range)
+        line = processed_source.lines[range.line - 1]
+        line[0, range.column].display_width
+      end
+
       def check_alignment(items, base_column = nil)
-        base_column ||= items.first.loc.column unless items.empty?
+        unless items.empty?
+          base_column ||= display_column(items.first.source_range)
+        end
         prev_line = -1
         items.each do |current|
           if current.loc.line > prev_line &&
              begins_its_line?(current.source_range)
-            @column_delta = base_column - current.loc.column
+            @column_delta = base_column - display_column(current.source_range)
             if @column_delta != 0
               expr = current.source_range
               if offenses.any? { |o| within?(expr, o.location) }

--- a/lib/rubocop/cop/style/align_parameters.rb
+++ b/lib/rubocop/cop/style/align_parameters.rb
@@ -44,7 +44,7 @@ module RuboCop
             indentation_of_line = /\S.*/.match(line).begin(0)
             indentation_of_line + configured_indentation_width
           else
-            args.first.loc.column
+            display_column(args.first.source_range)
           end
         end
 

--- a/lib/rubocop/cop/style/first_parameter_indentation.rb
+++ b/lib/rubocop/cop/style/first_parameter_indentation.rb
@@ -86,7 +86,7 @@ module RuboCop
           if source.include?("\n")
             previous_code_line(range.line + source.count("\n") + 1) =~ /\S/
           else
-            range.column
+            display_column(range)
           end
         end
 

--- a/lib/rubocop/cop/style/indent_assignment.rb
+++ b/lib/rubocop/cop/style/indent_assignment.rb
@@ -34,7 +34,7 @@ module RuboCop
           return unless node.loc.operator
           return if node.loc.operator.line == rhs.loc.line
 
-          base = node.source_range.column
+          base = display_column(node.source_range)
           check_alignment([rhs], base + configured_indentation_width)
         end
       end

--- a/rubocop.gemspec
+++ b/rubocop.gemspec
@@ -43,6 +43,7 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency('parser', '>= 2.3.0.2', '< 3.0')
   s.add_runtime_dependency('powerpack', '~> 0.1')
   s.add_runtime_dependency('ruby-progressbar', '~> 1.7')
+  s.add_runtime_dependency('unicode-display_width', '~> 0.3')
 
   s.add_development_dependency('bundler', '~> 1.3')
 end

--- a/spec/rubocop/cop/style/align_array_spec.rb
+++ b/spec/rubocop/cop/style/align_array_spec.rb
@@ -40,6 +40,12 @@ describe RuboCop::Cop::Style::AlignArray do
     expect(cop.offenses).to be_empty
   end
 
+  it 'accepts aligned array with fullwidth characters' do
+    inspect_source(cop, ["puts 'Ｒｕｂｙ', [ a,",
+                         '                   b ]'])
+    expect(cop.offenses).to be_empty
+  end
+
   it 'auto-corrects alignment' do
     new_source = autocorrect_source(cop, ['array = [',
                                           '  a,',

--- a/spec/rubocop/cop/style/align_parameters_spec.rb
+++ b/spec/rubocop/cop/style/align_parameters_spec.rb
@@ -47,6 +47,12 @@ describe RuboCop::Cop::Style::AlignParameters do
       expect(cop.offenses).to be_empty
     end
 
+    it 'accepts correctly aligned parameters with fullwidth characters' do
+      inspect_source(cop, ["f 'Ｒｕｂｙ', g(a,",
+                           '                b)'])
+      expect(cop.offenses).to be_empty
+    end
+
     it 'accepts calls that only span one line' do
       inspect_source(cop, 'find(path, s, @special[sexp[0]])')
       expect(cop.offenses).to be_empty

--- a/spec/rubocop/cop/style/first_parameter_indentation_spec.rb
+++ b/spec/rubocop/cop/style/first_parameter_indentation_spec.rb
@@ -318,6 +318,13 @@ describe RuboCop::Cop::Style::FirstParameterIndentation do
                                ')'])
           expect(cop.offenses).to be_empty
         end
+
+        it 'accepts a correctly indented first parameter with fullwidth ' \
+           'characters' do
+          inspect_source(cop, ["puts('Ｒｕｂｙ', f(",
+                               '                   a))'])
+          expect(cop.offenses).to be_empty
+        end
       end
 
       context 'without outer parentheses' do

--- a/spec/rubocop/cop/style/indent_assignment_spec.rb
+++ b/spec/rubocop/cop/style/indent_assignment_spec.rb
@@ -37,6 +37,13 @@ describe RuboCop::Cop::Style::IndentAssignment, :config do
     expect(cop.offenses).to be_empty
   end
 
+  it 'allows a properly indented rhs with fullwidth characters' do
+    inspect_source(cop, ["f 'Ｒｕｂｙ', a =",
+                         '                b'])
+
+    expect(cop.offenses).to be_empty
+  end
+
   it 'registers an offense for multi-lhs' do
     inspect_source(cop, ['a,',
                          'b =',

--- a/spec/rubocop/cop/style/indentation_consistency_spec.rb
+++ b/spec/rubocop/cop/style/indentation_consistency_spec.rb
@@ -98,6 +98,14 @@ describe RuboCop::Cop::Style::IndentationConsistency, :config do
       expect(cop.offenses).to be_empty
     end
 
+    it 'accepts if/elsif/else/end with fullwidth characters' do
+      inspect_source(cop,
+                     ["p 'Ｒｕｂｙ', if a then b",
+                      '                        c',
+                      '              end'])
+      expect(cop.offenses).to be_empty
+    end
+
     it 'accepts an empty if' do
       inspect_source(cop,
                      ['if a',


### PR DESCRIPTION
I fixed the handling of fullwidth characters in `Style/AlignArray`.

The following code:

```ruby
puts 'Ｒｕｂｙ', [1,
                 2]

```

yield the offence:

```
tmp/fullwidth.rb:5:19: C: Align the elements of an array literal if they span more than one line.
                  2]
                  ^
```

I chose the gem [unicode-display_width](https://github.com/janlelis/unicode-display_width) to calculate display width because ...

- [unicode](https://github.com/blackwinter/unicode) does not support jruby ...
- [unicode_utils](https://github.com/lang/unicode_utils) is not active

```
$ rubocop -V                                                                                                                                                                                                                                    [~/src/rubocop]
0.36.0 (using Parser 2.3.0.1, running on ruby 2.1.8 x86_64-darwin15.0)
```
