### PR TITLE
[Fix #2696] NestedModifier adds parentheses

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@
 * [#2694](https://github.com/bbatsov/rubocop/issues/2694): Fix caching when using a different JSON gem such as Oj. ([@stormbreakerbg][])
 * [#2707](https://github.com/bbatsov/rubocop/pull/2707): Change `Lint/NestedMethodDefinition` to respect `Class.new` and `Module.new`. ([@owst][])
 * [#2701](https://github.com/bbatsov/rubocop/pull/2701): Do not consider assignments to the same variable as useless if later assignments are within a loop. ([@owst][])
+* [#2696](https://github.com/bbatsov/rubocop/issues/2696): `Style/NestedModifier` adds parentheses around a condition when needed. ([@lumeet][])
 
 ### Changes
 

--- a/lib/rubocop/cop/style/nested_modifier.rb
+++ b/lib/rubocop/cop/style/nested_modifier.rb
@@ -83,14 +83,17 @@ module RuboCop
           outer_keyword = outer_node.loc.keyword.source
           inner_keyword = inner_node.loc.keyword.source
 
-          operator = outer_keyword == 'if' ? '&&' : '||'
+          operator = outer_keyword == 'if'.freeze ? '&&'.freeze : '||'.freeze
 
+          outer_expr = outer_cond.source
+          outer_expr = "(#{outer_expr})" if outer_cond.or_type? &&
+                                            operator == '&&'.freeze
           inner_expr = inner_cond.source
           inner_expr = "(#{inner_expr})" if inner_cond.or_type?
           inner_expr = "!#{inner_expr}" unless outer_keyword == inner_keyword
 
           "#{outer_node.loc.keyword.source} " \
-          "#{outer_cond.source} #{operator} #{inner_expr}"
+          "#{outer_expr} #{operator} #{inner_expr}"
         end
       end
     end

--- a/spec/rubocop/cop/style/nested_modifier_spec.rb
+++ b/spec/rubocop/cop/style/nested_modifier_spec.rb
@@ -59,8 +59,13 @@ describe RuboCop::Cop::Style::NestedModifier do
   end
 
   it 'adds parentheses when needed in auto-correction' do
-    corrected = autocorrect_source(cop, 'something if a || b if c')
-    expect(corrected).to eq 'something if c && (a || b)'
+    corrected = autocorrect_source(cop, 'something if a || b if c || d')
+    expect(corrected).to eq 'something if (c || d) && (a || b)'
+  end
+
+  it 'does not add redundant parentheses in auto-correction' do
+    corrected = autocorrect_source(cop, 'something if a unless c || d')
+    expect(corrected).to eq 'something unless c || d || !a'
   end
 
   context 'while' do


### PR DESCRIPTION
Auto-correction in `Style/NestedModifier` handles operator precedence
by adding parentheses when needed.