### PR TITLE
The sky loves a good joke

### DIFF
--- a/lib/rubocop.rb
+++ b/lib/rubocop.rb
@@ -21,6 +21,7 @@ require 'rubocop/node_pattern'
 require 'rubocop/ast_node/sexp'
 require 'rubocop/ast_node'
 require 'rubocop/ast_node/builder'
+require 'rubocop/ast_node/traversal'
 require 'rubocop/error'
 require 'rubocop/warning'
 

--- a/lib/rubocop/ast_node.rb
+++ b/lib/rubocop/ast_node.rb
@@ -269,8 +269,6 @@ module RuboCop
     def each_node(*types, &block)
       return to_enum(__method__, *types) unless block_given?
 
-      types.flatten!
-
       yield self if types.empty? || types.include?(type)
 
       if types.empty?

--- a/lib/rubocop/ast_node.rb
+++ b/lib/rubocop/ast_node.rb
@@ -71,7 +71,7 @@ module RuboCop
       # `ident` type node and fixed to the appropriate type later.
       # So, the #parent attribute needs to be mutable.
       each_child_node do |child_node|
-        child_node.parent = self
+        child_node.parent = self unless child_node.complete?
       end
     end
 
@@ -93,7 +93,27 @@ module RuboCop
       @mutable_attributes[:parent] = node
     end
 
+    def complete!
+      @mutable_attributes.freeze
+      each_child_node(&:complete!)
+    end
+
+    def complete?
+      @mutable_attributes.frozen?
+    end
+
     protected :parent=
+
+    # Override `AST::Node#updated` so that `AST::Processor` does not try to
+    # mutate our ASTs. Since we keep references from children to parents and
+    # not just the other way around, we cannot update an AST and share identical
+    # subtrees. Rather, the entire AST must be copied any time any part of it
+    # is changed.
+    #
+    def updated(type = nil, children = nil, properties = {})
+      properties[:location] ||= @location
+      Node.new(type || @type, children || @children, properties)
+    end
 
     # Returns the index of the receiver node in its siblings.
     #

--- a/lib/rubocop/ast_node/traversal.rb
+++ b/lib/rubocop/ast_node/traversal.rb
@@ -1,0 +1,171 @@
+# encoding: utf-8
+# frozen_string_literal: true
+
+module RuboCop
+  class Node
+    # Provides methods for traversing an AST.
+    # Does not transform an AST; for that, use Parser::AST::Processor.
+    # Override methods to perform custom processing. Remember to call `super`
+    # if you want to recursively process descendant nodes.
+    module Traversal
+      def walk(node)
+        return if node.nil?
+        send(:"on_#{node.type}", node)
+        nil
+      end
+
+      NO_CHILD_NODES    = [:true, :false, :nil, :int, :float, :complex,
+                           :rational, :str, :sym, :regopt, :self, :lvar,
+                           :ivar, :cvar, :gvar, :nth_ref, :back_ref, :cbase,
+                           :arg, :restarg, :blockarg, :shadowarg,
+                           :kwrestarg, :zsuper, :lambda, :redo, :retry].freeze
+      ONE_CHILD_NODE    = [:splat, :kwsplat, :block_pass, :not, :break, :next,
+                           :return, :preexe, :postexe, :match_current_line,
+                           :defined?, :arg_expr].freeze
+      MANY_CHILD_NODES  = [:dstr, :dsym, :xstr, :regexp, :array, :hash, :pair,
+                           :irange, :erange, :mlhs, :masgn, :or_asgn, :and_asgn,
+                           :undef, :alias, :args, :super, :yield, :or, :and,
+                           :while_post, :until_post, :iflipflop, :eflipflop,
+                           :match_with_lvasgn, :begin, :kwbegin].freeze
+      SECOND_CHILD_ONLY = [:lvasgn, :ivasgn, :cvasgn, :gvasgn, :optarg, :kwarg,
+                           :kwoptarg].freeze
+
+      NO_CHILD_NODES.each do |type|
+        module_eval("def on_#{type}(node); end")
+      end
+
+      ONE_CHILD_NODE.each do |type|
+        module_eval(<<-END)
+          def on_#{type}(node)
+            if (child = node.children[0])
+              send(:"on_\#{child.type}", child)
+            end
+          end
+        END
+      end
+
+      MANY_CHILD_NODES.each do |type|
+        module_eval(<<-END)
+          def on_#{type}(node)
+            node.children.each { |child| send(:"on_\#{child.type}", child) }
+            nil
+          end
+        END
+      end
+
+      SECOND_CHILD_ONLY.each do |type|
+        # Guard clause is for nodes nested within mlhs
+        module_eval(<<-END)
+          def on_#{type}(node)
+            if (child = node.children[1])
+              send(:"on_\#{child.type}", child)
+            end
+          end
+        END
+      end
+
+      def on_const(node)
+        return unless (child = node.children[0])
+        send(:"on_#{child.type}", child)
+      end
+
+      def on_casgn(node)
+        children = node.children
+        if (child = children[0]) # always const???
+          send(:"on_#{child.type}", child)
+        end
+        return unless (child = children[2])
+        send(:"on_#{child.type}", child)
+      end
+
+      def on_class(node)
+        children = node.children
+        child = children[0] # always const???
+        send(:"on_#{child.type}", child)
+        if (child = children[1])
+          send(:"on_#{child.type}", child)
+        end
+        return unless (child = children[2])
+        send(:"on_#{child.type}", child)
+      end
+
+      def on_def(node)
+        children = node.children
+        on_args(children[1])
+        return unless (child = children[2])
+        send(:"on_#{child.type}", child)
+      end
+
+      def on_send(node)
+        node.children.each_with_index do |child, i|
+          next if i == 1
+          send(:"on_#{child.type}", child) if child
+        end
+        nil
+      end
+
+      alias on_csend on_send
+
+      def on_op_asgn(node)
+        children = node.children
+        child = children[0]
+        send(:"on_#{child.type}", child)
+        child = children[2]
+        send(:"on_#{child.type}", child)
+      end
+
+      def on_defs(node)
+        children = node.children
+        child = children[0]
+        send(:"on_#{child.type}", child)
+        on_args(children[2])
+        return unless (child = children[3])
+        send(:"on_#{child.type}", child)
+      end
+
+      def on_if(node)
+        children = node.children
+        child = children[0]
+        send(:"on_#{child.type}", child)
+        if (child = children[1])
+          send(:"on_#{child.type}", child)
+        end
+        return unless (child = children[2])
+        send(:"on_#{child.type}", child)
+      end
+
+      def on_while(node)
+        children = node.children
+        child = children[0]
+        send(:"on_#{child.type}", child)
+        return unless (child = children[1])
+        send(:"on_#{child.type}", child)
+      end
+
+      alias on_until  on_while
+      alias on_when   on_while
+      alias on_module on_while
+      alias on_sclass on_while
+
+      def on_block(node)
+        children = node.children
+        on_send(children[0])
+        on_args(children[1])
+        return unless (child = children[2])
+        send(:"on_#{child.type}", child)
+      end
+
+      def on_case(node)
+        node.children.each do |child|
+          send(:"on_#{child.type}", child) if child
+        end
+        nil
+      end
+
+      alias on_rescue  on_case
+      alias on_resbody on_case
+      alias on_ensure  on_case
+      alias on_for     on_case
+    end
+  end
+end

--- a/lib/rubocop/config.rb
+++ b/lib/rubocop/config.rb
@@ -17,6 +17,27 @@ module RuboCop
     COMMON_PARAMS = %w(Exclude Include Severity
                        AutoCorrect StyleGuide Details).freeze
     KNOWN_RUBIES = [1.9, 2.0, 2.1, 2.2, 2.3].freeze
+    OBSOLETE_COPS = {
+      'Style/TrailingComma' =>
+        'The `Style/TrailingComma` cop no longer exists. Please use ' \
+        '`Style/TrailingCommaInLiteral` and/or ' \
+        '`Style/TrailingCommaInArguments` instead.',
+      'Rails/DefaultScope' =>
+        'The `Rails/DefaultScope` cop no longer exists.',
+      'Style/SingleSpaceBeforeFirstArg' =>
+        'The `Style/SingleSpaceBeforeFirstArg` cop has been renamed to ' \
+        '`Style/SpaceBeforeFirstArg. ',
+      'Lint/SpaceBeforeFirstArg' =>
+        'The `Lint/SpaceBeforeFirstArg` cop has been removed, since it was a ' \
+        'duplicate of `Style/SpaceBeforeFirstArg`. Please use ' \
+        '`Style/SpaceBeforeFirstArg` instead.',
+      'Style/SpaceAfterControlKeyword' =>
+        'The `Style/SpaceAfterControlKeyword` cop has been removed. Please ' \
+        'use `Style/SpaceAroundKeyword` instead.',
+      'Style/SpaceBeforeModifierKeyword' =>
+        'The `Style/SpaceBeforeModifierKeyword` cop has been removed. Please ' \
+        'use `Style/SpaceAroundKeyword` instead.'
+    }.freeze
 
     attr_reader :loaded_path
 
@@ -246,12 +267,11 @@ module RuboCop
     end
 
     def reject_obsolete_cops
-      if key?('Style/TrailingComma')
-        fail ValidationError, 'The `Style/TrailingComma` cop no longer ' \
-                              'exists. Please use ' \
-                              '`Style/TrailingCommaInLiteral` and/or ' \
-                              "`Style/TrailingCommaInArguments` instead.\n" \
-                              "(configuration found in #{loaded_path})"
+      OBSOLETE_COPS.each do |cop_name, message|
+        next unless key?(cop_name) || key?(cop_name.split('/').last)
+        message += "\n(obsolete configuration found in #{loaded_path}, please" \
+                   ' update it)'
+        fail ValidationError, message
       end
     end
 

--- a/lib/rubocop/cop/commissioner.rb
+++ b/lib/rubocop/cop/commissioner.rb
@@ -14,7 +14,7 @@ module RuboCop
         Parser::Meta::NODE_TYPES.map { |type| "on_#{type}" }
       end
 
-      def initialize(cops, forces, options = {})
+      def initialize(cops, forces = [], options = {})
         @cops = cops
         @forces = forces
         @options = options

--- a/lib/rubocop/cop/commissioner.rb
+++ b/lib/rubocop/cop/commissioner.rb
@@ -5,22 +5,13 @@ module RuboCop
   module Cop
     # Commissioner class is responsible for processing the AST and delegating
     # work to the specified cops.
-    class Commissioner < Parser::AST::Processor
+    class Commissioner
+      include RuboCop::Node::Traversal
+
       attr_reader :errors
 
       def self.callback_methods
         Parser::Meta::NODE_TYPES.map { |type| "on_#{type}" }
-      end
-
-      # Methods that are not defined in Parser::AST::Processor
-      # won't have a `super` to call. So we should not attempt
-      # to invoke `super` when defining them.
-      def self.call_super(callback)
-        if Parser::AST::Processor.method_defined?(callback)
-          'super'
-        else
-          ''
-        end
       end
 
       def initialize(cops, forces, options = {})
@@ -31,6 +22,7 @@ module RuboCop
       end
 
       callback_methods.each do |callback|
+        next unless RuboCop::Node::Traversal.method_defined?(callback)
         class_eval <<-EOS, __FILE__, __LINE__
           def #{callback}(node)
             @cops.each do |cop|
@@ -40,7 +32,8 @@ module RuboCop
               end
             end
 
-            #{call_super(callback)}
+            #{!RuboCop::Node::Traversal::NO_CHILD_NODES.include?(callback) &&
+              'super'}
           end
         EOS
       end
@@ -51,7 +44,7 @@ module RuboCop
         prepare(processed_source)
         invoke_custom_processing(@cops, processed_source)
         invoke_custom_processing(@forces, processed_source)
-        process(processed_source.ast) if processed_source.ast
+        walk(processed_source.ast) if processed_source.ast
         @cops.flat_map(&:offenses)
       end
 

--- a/lib/rubocop/cop/cop.rb
+++ b/lib/rubocop/cop/cop.rb
@@ -128,7 +128,7 @@ module RuboCop
       end
 
       def cop_config
-        @config.for_cop(self)
+        @cop_config ||= @config.for_cop(self)
       end
 
       def debug?

--- a/lib/rubocop/cop/cop.rb
+++ b/lib/rubocop/cop/cop.rb
@@ -95,7 +95,7 @@ module RuboCop
       end
 
       def self.cop_name
-        @cop_name ||= name.to_s.split('::').last(2).join('/')
+        @cop_name ||= name.split('::').last(2).join('/')
       end
 
       def self.cop_type

--- a/lib/rubocop/cop/cop.rb
+++ b/lib/rubocop/cop/cop.rb
@@ -201,7 +201,7 @@ module RuboCop
       end
 
       def cop_name
-        self.class.cop_name
+        @cop_name ||= self.class.cop_name
       end
 
       alias name cop_name

--- a/lib/rubocop/cop/cop.rb
+++ b/lib/rubocop/cop/cop.rb
@@ -99,7 +99,7 @@ module RuboCop
       end
 
       def self.cop_type
-        name.to_s.split('::')[-2].downcase.to_sym
+        @cop_type ||= name.split('::')[-2].downcase.to_sym
       end
 
       def self.lint?

--- a/lib/rubocop/cop/mixin/classish_length.rb
+++ b/lib/rubocop/cop/mixin/classish_length.rb
@@ -26,7 +26,7 @@ module RuboCop
       def line_numbers_of_inner_thing(node, type)
         line_numbers = Set.new
 
-        node.each_descendant(:module, type) do |inner_node|
+        node.each_descendant(type) do |inner_node|
           line_range = line_range(inner_node)
           line_numbers.merge(line_range)
         end

--- a/lib/rubocop/cop/mixin/classish_length.rb
+++ b/lib/rubocop/cop/mixin/classish_length.rb
@@ -13,8 +13,7 @@ module RuboCop
         body_line_numbers = line_range(node).to_a[1...-1]
 
         target_line_numbers = body_line_numbers -
-                              line_numbers_of_inner_thing(node, :module) -
-                              line_numbers_of_inner_thing(node, :class)
+                              line_numbers_of_inner_nodes(node, :module, :class)
 
         target_line_numbers.reduce(0) do |length, line_number|
           source_line = processed_source[line_number]
@@ -23,10 +22,10 @@ module RuboCop
         end
       end
 
-      def line_numbers_of_inner_thing(node, type)
+      def line_numbers_of_inner_nodes(node, *types)
         line_numbers = Set.new
 
-        node.each_descendant(type) do |inner_node|
+        node.each_descendant(*types) do |inner_node|
           line_range = line_range(inner_node)
           line_numbers.merge(line_range)
         end

--- a/lib/rubocop/cop/mixin/configurable_enforced_style.rb
+++ b/lib/rubocop/cop/mixin/configurable_enforced_style.rb
@@ -77,9 +77,13 @@ module RuboCop
       alias unrecognized_style_detected no_acceptable_style!
 
       def style
-        s = cop_config[parameter_name].to_sym
-        return s if supported_styles.include?(s)
-        fail "Unknown style #{s} selected!"
+        @enforced_style ||= begin
+          s = cop_config[parameter_name].to_sym
+          unless supported_styles.include?(s)
+            fail "Unknown style #{s} selected!"
+          end
+          s
+        end
       end
 
       def alternative_style

--- a/lib/rubocop/cop/mixin/method_complexity.rb
+++ b/lib/rubocop/cop/mixin/method_complexity.rb
@@ -22,7 +22,7 @@ module RuboCop
       end
 
       def complexity(node)
-        node.each_node(self.class::COUNTED_NODES).reduce(1) do |score, n|
+        node.each_node(*self.class::COUNTED_NODES).reduce(1) do |score, n|
           score + complexity_score_for(n)
         end
       end

--- a/lib/rubocop/cop/style/documentation.rb
+++ b/lib/rubocop/cop/style/documentation.rb
@@ -69,8 +69,6 @@ module RuboCop
         end
 
         def preceding_comments(node, ast_with_comments)
-          return [] unless node && ast_with_comments
-
           ast_with_comments[node].select { |c| c.loc.line < node.loc.line }
         end
 

--- a/lib/rubocop/cop/style/documentation.rb
+++ b/lib/rubocop/cop/style/documentation.rb
@@ -26,7 +26,7 @@ module RuboCop
 
           ast_with_comments = processed_source.ast_with_comments
           return if associated_comment?(node, ast_with_comments)
-          return if nodoc?(node, ast_with_comments)
+          return if nodoc_comment?(node, ast_with_comments)
           add_offense(node, :keyword, format(MSG, :class))
         end
 
@@ -36,7 +36,7 @@ module RuboCop
 
           ast_with_comments = processed_source.ast_with_comments
           return if associated_comment?(node, ast_with_comments)
-          return if nodoc?(node, ast_with_comments)
+          return if nodoc_comment?(node, ast_with_comments)
           add_offense(node, :keyword, format(MSG, :module))
         end
 
@@ -83,7 +83,7 @@ module RuboCop
         # proceeds to check its ancestors for :nodoc: all.
         # Note: How end-of-line comments are associated with code changed in
         # parser-2.2.0.4.
-        def nodoc?(node, ast_with_comments, require_all = false)
+        def nodoc_comment?(node, ast_with_comments, require_all = false)
           return false unless node
           nodoc_node = node.children.first
           return false unless nodoc_node
@@ -94,7 +94,7 @@ module RuboCop
             return true if comment.text =~ regex
           end
 
-          nodoc?(node.ancestors.first, ast_with_comments, true)
+          nodoc_comment?(node.ancestors.first, ast_with_comments, true)
         end
       end
     end

--- a/lib/rubocop/cop/style/documentation.rb
+++ b/lib/rubocop/cop/style/documentation.rb
@@ -20,15 +20,9 @@ module RuboCop
         def_node_matcher :constant_definition?, '{class module casgn}'
 
         def investigate(processed_source)
-          ast = processed_source.ast
-          return unless ast
-
-          ast_with_comments = Parser::Source::Comment.associate(
-            ast,
-            processed_source.comments
-          )
-
-          check(ast, ast_with_comments)
+          return unless processed_source.ast
+          return unless processed_source.ast_with_comments
+          check(processed_source.ast, processed_source.ast_with_comments)
         end
 
         private

--- a/lib/rubocop/cop/variable_force.rb
+++ b/lib/rubocop/cop/variable_force.rb
@@ -56,14 +56,6 @@ module RuboCop
 
       SEND_TYPE = :send
 
-      def self.wrap_with_top_level_scope_node(root_node)
-        if root_node.begin_type?
-          root_node
-        else
-          Node.new(:begin, [root_node])
-        end
-      end
-
       def variable_table
         @variable_table ||= VariableTable.new(self)
       end
@@ -73,10 +65,9 @@ module RuboCop
         root_node = processed_source.ast
         return unless root_node
 
-        # Wrap the root node with begin node if it's a standalone node.
-        root_node = self.class.wrap_with_top_level_scope_node(root_node)
-
-        inspect_variables_in_scope(root_node)
+        variable_table.push_scope(root_node)
+        process_node(root_node)
+        variable_table.pop_scope
       end
 
       # This is called for each scope recursively.

--- a/lib/rubocop/processed_source.rb
+++ b/lib/rubocop/processed_source.rb
@@ -44,6 +44,11 @@ module RuboCop
       comment_config.cop_disabled_line_ranges
     end
 
+    def ast_with_comments
+      return if !ast || !comments
+      @ast_with_comments ||= Parser::Source::Comment.associate(ast, comments)
+    end
+
     # Returns the source lines, line break characters removed, excluding a
     # possible __END__ and everything that comes after.
     def lines

--- a/lib/rubocop/processed_source.rb
+++ b/lib/rubocop/processed_source.rb
@@ -95,6 +95,7 @@ module RuboCop
 
       begin
         @ast, @comments, tokens = parser.tokenize(@buffer)
+        @ast.complete! if @ast
       rescue Parser::SyntaxError # rubocop:disable Lint/HandleExceptions
         # All errors are in diagnostics. No need to handle exception.
       end

--- a/lib/rubocop/processed_source.rb
+++ b/lib/rubocop/processed_source.rb
@@ -53,7 +53,7 @@ module RuboCop
     # possible __END__ and everything that comes after.
     def lines
       @lines ||= begin
-        all_lines = raw_source.lines.map(&:chomp)
+        all_lines = @buffer.source_lines
         last_token_line = tokens.any? ? tokens.last.pos.line : all_lines.size
         result = []
         all_lines.each_with_index do |line, ix|

--- a/lib/rubocop/result_cache.rb
+++ b/lib/rubocop/result_cache.rb
@@ -56,7 +56,7 @@ module RuboCop
 
     def initialize(file, options, config_store, cache_root = nil)
       cache_root ||= ResultCache.cache_root(config_store)
-      @path = File.join(cache_root, rubocop_checksum, RUBY_VERSION,
+      @path = File.join(cache_root, rubocop_checksum,
                         relevant_options(options),
                         file_checksum(file, config_store))
       @cached_data = CachedData.new(file)

--- a/spec/rubocop/cli_spec.rb
+++ b/spec/rubocop/cli_spec.rb
@@ -1515,7 +1515,8 @@ describe RuboCop::CLI, :isolated_environment do
           ['Error: The `Style/TrailingComma` cop no longer exists. Please ' \
            'use `Style/TrailingCommaInLiteral` and/or ' \
            '`Style/TrailingCommaInArguments` instead.',
-           "(configuration found in #{abs('.rubocop.yml')})"].join("\n"))
+           "(obsolete configuration found in #{abs('.rubocop.yml')}, " \
+           'please update it)'].join("\n"))
       end
     end
   end

--- a/spec/rubocop/cop/variable_force/assignment_spec.rb
+++ b/spec/rubocop/cop/variable_force/assignment_spec.rb
@@ -4,7 +4,7 @@
 require 'spec_helper'
 
 describe RuboCop::Cop::VariableForce::Assignment do
-  include AST::Sexp
+  include RuboCop::Sexp
 
   let(:ast) do
     RuboCop::ProcessedSource.new(source, ruby_version).ast

--- a/spec/rubocop/cop/variable_force/locatable_spec.rb
+++ b/spec/rubocop/cop/variable_force/locatable_spec.rb
@@ -4,7 +4,7 @@
 require 'spec_helper'
 
 describe RuboCop::Cop::VariableForce::Locatable do
-  include AST::Sexp
+  include RuboCop::Sexp
 
   class LocatableObject
     include RuboCop::Cop::VariableForce::Locatable

--- a/spec/rubocop/cop/variable_force/variable_table_spec.rb
+++ b/spec/rubocop/cop/variable_force/variable_table_spec.rb
@@ -4,7 +4,7 @@
 require 'spec_helper'
 
 describe RuboCop::Cop::VariableForce::VariableTable do
-  include AST::Sexp
+  include RuboCop::Sexp
 
   subject(:variable_table) { described_class.new }
 

--- a/spec/rubocop/processed_source_spec.rb
+++ b/spec/rubocop/processed_source_spec.rb
@@ -127,7 +127,8 @@ describe RuboCop::ProcessedSource do
     end
 
     it 'has same number of elements as line count' do
-      expect(processed_source.lines.size).to eq(5)
+      # Since the source has a trailing newline, there is a final empty line
+      expect(processed_source.lines.size).to eq(6)
     end
 
     it 'contains lines as string without linefeed' do

--- a/spec/rubocop/result_cache_spec.rb
+++ b/spec/rubocop/result_cache_spec.rb
@@ -143,12 +143,12 @@ describe RuboCop::ResultCache, :isolated_environment do
       cache.save(offenses)
       cache2 = described_class.new('other.rb', options, config_store,
                                    cache_root)
-      expect(Dir["#{cache_root}/*/*/_/*"].size).to eq(1)
+      expect(Dir["#{cache_root}/*/_/*"].size).to eq(1)
       cache.class.cleanup(config_store, :verbose, cache_root)
       expect($stdout.string).to eq('')
 
       cache2.save(offenses)
-      underscore_dir = Dir["#{cache_root}/*/*/_"].first
+      underscore_dir = Dir["#{cache_root}/*/_"].first
       expect(Dir["#{underscore_dir}/*"].size).to eq(2)
       cache.class.cleanup(config_store, :verbose, cache_root)
       expect(File.exist?(underscore_dir)).to be_falsey


### PR DESCRIPTION
This PR is a significant step towards fast autocorrection. The big optimization here is running all auto-correcting cops *separately* from non-autocorrecting cops.

When there are a number of offenses, the whole inspection process can be repeated many times, with just the autocorrections from a single cop applied on each round. This means that the non-autocorrecting cops (redundantly) perform inspection many times, when all we care about is what they find on the *last* round.

In a couple of performance tests, I observed this optimization to knock about 1/3 off of total runtime when autocorrecting.

When working on this optimization, I made a discovery. We are mangling our ASTs, so they can only be traversed a single time.

This is not the way it should be. The ASTs are supposed to be mutable. BUT, there are these fateful lines in `ast_node.rb` (which we inherited from Astrolabe):

```ruby
      each_child_node do |child_node|
        child_node.parent = self
      end
```

Because of these lines, just instantiating a temporary AST node *mutates* any existing nodes which you give it as children, causing those children to "lose" their original parent and point to a new parent. The old parent still points to its original child, but the child doesn't point back. Our AST has become an "ASG" (for "graph").

`VariableForce` caused this to happen by instantiating temporary nodes. But what really ravaged the ASTs was `Commissioner`, and its use of `AST::Processor` to traverse an AST. `Processor` is designed, not for *traversing* an AST, but for *transforming* one. After each hook returns, it optionally initializes a new node. Since `Commissioner` was not designed to actually create meaningful AST nodes, we end up with a bunch of random nodes with `parent` pointers going to garbage nodes.

I have fixed things up so that ASTs are not mutated after being completely initialized. This makes it possible to split up the inspection process into stages.