### PR TITLE
[Fix #2666] Fix correcting symbol interpolation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@
 * [#2707](https://github.com/bbatsov/rubocop/pull/2707): Change `Lint/NestedMethodDefinition` to respect `Class.new` and `Module.new`. ([@owst][])
 * [#2701](https://github.com/bbatsov/rubocop/pull/2701): Do not consider assignments to the same variable as useless if later assignments are within a loop. ([@owst][])
 * [#2696](https://github.com/bbatsov/rubocop/issues/2696): `Style/NestedModifier` adds parentheses around a condition when needed. ([@lumeet][])
+* [#2666](https://github.com/bbatsov/rubocop/issues/2666): Fix bug when auto-correcting symbol literals in `Lint/LiteralInInterpolation`. ([@lumeet][])
 
 ### Changes
 

--- a/lib/rubocop/cop/lint/literal_in_interpolation.rb
+++ b/lib/rubocop/cop/lint/literal_in_interpolation.rb
@@ -38,7 +38,23 @@ module RuboCop
         end
 
         def autocorrected_value(node)
-          node.str_type? ? node.children.last : node.source
+          case node.type
+          when :str
+            node.children.last
+          when :sym
+            autocorrected_value_for_symbol(node)
+          else
+            node.source
+          end
+        end
+
+        def autocorrected_value_for_symbol(node)
+          end_pos =
+            node.loc.end ? node.loc.end.begin_pos : node.loc.expression.end_pos
+
+          Parser::Source::Range.new(node.source_range.source_buffer,
+                                    node.loc.begin.end_pos,
+                                    end_pos).source
         end
       end
     end

--- a/spec/rubocop/cop/lint/literal_in_interpolation_spec.rb
+++ b/spec/rubocop/cop/lint/literal_in_interpolation_spec.rb
@@ -16,7 +16,7 @@ describe RuboCop::Cop::Lint::LiteralInInterpolation do
     expect(cop.offenses).to be_empty
   end
 
-  shared_examples 'literal interpolation' do |literal|
+  shared_examples 'literal interpolation' do |literal, expected = literal|
     it "registers an offense for #{literal} in interpolation" do
       inspect_source(cop, %("this is the \#{#{literal}}"))
       expect(cop.offenses.size).to eq(1)
@@ -29,20 +29,20 @@ describe RuboCop::Cop::Lint::LiteralInInterpolation do
 
     it "removes interpolation around #{literal}" do
       corrected = autocorrect_source(cop, %("this is the \#{#{literal}}"))
-      expect(corrected).to eq(%("this is the #{literal}"))
+      expect(corrected).to eq(%("this is the #{expected}"))
     end
 
     it "removes interpolation around #{literal} when there is more text" do
       corrected =
         autocorrect_source(cop, %("this is the \#{#{literal}} literally"))
-      expect(corrected).to eq(%("this is the #{literal} literally"))
+      expect(corrected).to eq(%("this is the #{expected} literally"))
     end
 
     it "removes interpolation around multiple #{literal}" do
       corrected =
         autocorrect_source(cop,
                            %("some \#{#{literal}} with \#{#{literal}} too"))
-      expect(corrected).to eq(%("some #{literal} with #{literal} too"))
+      expect(corrected).to eq(%("some #{expected} with #{expected} too"))
     end
 
     context 'when there is non-literal and literal interpolation' do
@@ -50,7 +50,7 @@ describe RuboCop::Cop::Lint::LiteralInInterpolation do
         it 'only remove interpolation around literal' do
           corrected =
             autocorrect_source(cop, %("this is \#{#{literal}} with \#{a} now"))
-          expect(corrected).to eq(%("this is #{literal} with \#{a} now"))
+          expect(corrected).to eq(%("this is #{expected} with \#{a} now"))
         end
       end
 
@@ -58,7 +58,7 @@ describe RuboCop::Cop::Lint::LiteralInInterpolation do
         it 'only remove interpolation around literal' do
           corrected =
             autocorrect_source(cop, %("this is \#{a} with \#{#{literal}} now"))
-          expect(corrected).to eq(%("this is \#{a} with #{literal} now"))
+          expect(corrected).to eq(%("this is \#{a} with #{expected} now"))
         end
       end
     end
@@ -77,11 +77,13 @@ describe RuboCop::Cop::Lint::LiteralInInterpolation do
   it_behaves_like('literal interpolation', 0xaabb)
   it_behaves_like('literal interpolation', 0377)
   it_behaves_like('literal interpolation', 2.0)
-  it_behaves_like('literal interpolation', [])
-  it_behaves_like('literal interpolation', [1])
+  it_behaves_like('literal interpolation', '[]')
+  it_behaves_like('literal interpolation', '[1]')
   it_behaves_like('literal interpolation', true)
   it_behaves_like('literal interpolation', false)
   it_behaves_like('literal interpolation', 'nil')
+  it_behaves_like('literal interpolation', ':symbol', 'symbol')
+  it_behaves_like('literal interpolation', ':"symbol"', 'symbol')
 
   shared_examples 'special keywords' do |keyword|
     it "accepts strings like #{keyword}" do


### PR DESCRIPTION
`Lint/LiteralInInterpolation` auto-corrects symbol literals correctly.

I think there are issues with other types as well. At least more complex cases of array and hash literals seem suspicious. I'll have a look a bit later.