### PR TITLE
Fix assignments in MultilineOperationIndentation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@
 * [#2729](https://github.com/bbatsov/rubocop/issues/2729): Fix handling of hash literal as the first argument in `Style/RedundantParentheses`. ([@lumeet][])
 * [#2703](https://github.com/bbatsov/rubocop/issues/2703): Handle byte order mark in `Style/IndentationWidth`, `Style/ElseAlignment`, `Lint/EndAlignment`, and `Lint/DefEndAlignment`. ([@jonas054][])
 * [#2710](https://github.com/bbatsov/rubocop/pull/2710): Fix handling of fullwidth characters in some cops. ([@seikichi][])
+* [#2690](https://github.com/bbatsov/rubocop/issues/2690): Fix alignment of operands that are part of an assignment in `Style/MultilineOperationIndentation`. ([@jonas054][])
 
 ### Changes
 

--- a/lib/rubocop/cop/mixin/check_assignment.rb
+++ b/lib/rubocop/cop/mixin/check_assignment.rb
@@ -21,7 +21,7 @@ module RuboCop
         check_assignment(node, rhs) if rhs.is_a?(AST::Node)
       end
 
-      private
+      module_function
 
       def extract_rhs(node)
         if node.casgn_type?

--- a/lib/rubocop/cop/style/multiline_operation_indentation.rb
+++ b/lib/rubocop/cop/style/multiline_operation_indentation.rb
@@ -53,7 +53,7 @@ module RuboCop
           return false if not_for_this_cop?(node)
 
           correct_column = if should_align?(node, rhs, given_style)
-                             lhs.loc.column
+                             node.loc.column
                            else
                              indentation(lhs) + correct_indentation(node)
                            end
@@ -62,8 +62,14 @@ module RuboCop
         end
 
         def should_align?(node, rhs, given_style)
+          assignment_node = part_of_assignment_rhs(node, rhs)
+          if assignment_node
+            assignment_rhs = CheckAssignment.extract_rhs(assignment_node)
+            return true if begins_its_line?(assignment_rhs.source_range)
+          end
+
           given_style == :aligned && (kw_node_with_special_indentation(node) ||
-                                      part_of_assignment_rhs(node, rhs) ||
+                                      assignment_node ||
                                       argument_in_method_call(node))
         end
 

--- a/spec/rubocop/cop/style/multiline_operation_indentation_spec.rb
+++ b/spec/rubocop/cop/style/multiline_operation_indentation_spec.rb
@@ -105,6 +105,22 @@ describe RuboCop::Cop::Style::MultilineOperationIndentation do
       expect(cop.offenses).to be_empty
     end
 
+    it 'accepts two spaces indentation in assignment of local variable' do
+      inspect_source(cop,
+                     ['a =',
+                      "  'foo' +",
+                      "  'bar'"])
+      expect(cop.messages).to be_empty
+    end
+
+    it 'accepts two spaces indentation in assignment of array element' do
+      inspect_source(cop,
+                     ["a['test'] =",
+                      "  'foo' +",
+                      "  'bar'"])
+      expect(cop.messages).to be_empty
+    end
+
     it 'accepts two spaces indentation of second line' do
       inspect_source(cop,
                      ['   a ||',


### PR DESCRIPTION
Operands in expressions that are the right-hand-side in an assignment where there's a line break after `=` should be aligned with each other, regardless of configured style.