### PR TITLE
[Fix #2676] Add single value hash only switch to RedundantMerge cop

### DIFF
--- a/config/default.yml
+++ b/config/default.yml
@@ -1026,6 +1026,12 @@ Lint/UnusedMethodArgument:
   AllowUnusedKeywordArguments: false
   IgnoreEmptyMethods: true
 
+##################### Performance ############################
+
+Performance/RedundantMerge:
+  # Max number of key-value pairs to consider an offense
+  MaxKeyValuePairs: 2
+
 ##################### Rails ##################################
 
 Rails/ActionFilter:

--- a/lib/rubocop/cop/performance/redundant_merge.rb
+++ b/lib/rubocop/cop/performance/redundant_merge.rb
@@ -23,6 +23,7 @@ module RuboCop
           redundant_merge(node) do |receiver, pairs|
             next if node.value_used?
             next if pairs.size > 1 && !receiver.pure?
+            next if pairs.size > max_key_value_pairs
 
             assignments = to_assignments(receiver, pairs).join('; ')
             message = format(MSG, assignments, node.source)
@@ -79,6 +80,10 @@ module RuboCop
 
         def modifier?(node)
           node.loc.respond_to?(:end) && node.loc.end.nil?
+        end
+
+        def max_key_value_pairs
+          cop_config['MaxKeyValuePairs'].to_i
         end
       end
     end

--- a/spec/rubocop/cop/performance/redundant_merge_spec.rb
+++ b/spec/rubocop/cop/performance/redundant_merge_spec.rb
@@ -3,8 +3,12 @@
 
 require 'spec_helper'
 
-describe RuboCop::Cop::Performance::RedundantMerge do
-  subject(:cop) { described_class.new }
+describe RuboCop::Cop::Performance::RedundantMerge, :config do
+  subject(:cop) { described_class.new(config) }
+
+  let(:cop_config) do
+    { 'MaxKeyValuePairs' => 2 }
+  end
 
   shared_examples 'redundant_merge' do |method|
     it "autocorrects hash.#{method}(a: 1)" do
@@ -60,6 +64,18 @@ describe RuboCop::Cop::Performance::RedundantMerge do
       inspect_source(cop, "hash.#{method}(a: 1)")
       expect(cop.messages).to eq(
         ["Use `hash[:a] = 1` instead of `hash.#{method}(a: 1)`."])
+    end
+
+    context 'with MaxKeyValuePairs of 1' do
+      let(:cop_config) do
+        { 'MaxKeyValuePairs' => 1 }
+      end
+
+      it "doesn't register errors for multi-value hash merges" do
+        inspect_source(cop, ['hash = {}',
+                             "hash.#{method}(a: 1, b: 2)"])
+        expect(cop.offenses).to be_empty
+      end
     end
   end
 


### PR DESCRIPTION
The discussion in the related issue explains the situation better, but essentially this cop seems too aggressive to some of us so this commit adds a switch so it doesn't make changes that autocorrect to more than 1 line.

Thanks.