### PR TITLE
[Fix #2721] autocorrect parentheses in rescue call

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,7 @@
 * [#2710](https://github.com/bbatsov/rubocop/pull/2710): Fix handling of fullwidth characters in some cops. ([@seikichi][])
 * [#2690](https://github.com/bbatsov/rubocop/issues/2690): Fix alignment of operands that are part of an assignment in `Style/MultilineOperationIndentation`. ([@jonas054][])
 * [#2228](https://github.com/bbatsov/rubocop/issues/2228): Use the config of a related cop whether it's enabled or not. ([@madwort][])
+* [#2721](https://github.com/bbatsov/rubocop/issues/2721): Do not register an offense for constants wrapped in parentheses passed to `rescue` in `Style/RedundantParentheses`. ([@rrosenblum][])
 
 ### Changes
 

--- a/lib/rubocop/cop/style/redundant_parentheses.rb
+++ b/lib/rubocop/cop/style/redundant_parentheses.rb
@@ -31,6 +31,7 @@ module RuboCop
           return if child_node.hash_type? && first_argument?(node) &&
                     !parentheses?(node.parent)
 
+          return if rescue?(node)
           check(node, child_node)
         end
 
@@ -94,6 +95,10 @@ module RuboCop
 
           _receiver, _method_name, *args = *send_node
           node == args.first
+        end
+
+        def rescue?(node)
+          node.parent && node.parent.array_type?
         end
       end
     end

--- a/spec/rubocop/cop/style/redundant_parentheses_spec.rb
+++ b/spec/rubocop/cop/style/redundant_parentheses_spec.rb
@@ -155,4 +155,23 @@ describe RuboCop::Cop::Style::RedundantParentheses do
       expect(cop.offenses.size).to eq 1
     end
   end
+
+  it 'accepts parentheses around the error passed to rescue' do
+    inspect_source(cop, ['begin',
+                         '  some_method',
+                         'rescue(StandardError)',
+                         'end'])
+    expect(cop.offenses).to be_empty
+  end
+
+  it 'accepts parentheses around a constant passed to when' do
+    source = ['case foo',
+              'when(Const)',
+              '  bar',
+              'end']
+
+    inspect_source(cop, source)
+
+    expect(cop.offenses).to be_empty
+  end
 end


### PR DESCRIPTION
This fixes #2721. I am not sure if this is the best way to fix this, but it was the simplest solution. Alternatively, I thought about checking `node.parent.parent.resbody_type?`. I would be interested in feedback from @lumeet since he authored the cop. 