### PR TITLE
[Fix #2729] Fix hash bug in RedundantParentheses

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@
 * [#2696](https://github.com/bbatsov/rubocop/issues/2696): `Style/NestedModifier` adds parentheses around a condition when needed. ([@lumeet][])
 * [#2666](https://github.com/bbatsov/rubocop/issues/2666): Fix bug when auto-correcting symbol literals in `Lint/LiteralInInterpolation`. ([@lumeet][])
 * [#2664](https://github.com/bbatsov/rubocop/issues/2664): `Performance/Casecmp` can auto-correct case comparison to variables and method calls without error. ([@rrosenblum][])
+* [#2729](https://github.com/bbatsov/rubocop/issues/2729): Fix handling of hash literal as the first argument in `Style/RedundantParentheses`. ([@lumeet][])
 
 ### Changes
 

--- a/spec/rubocop/cop/style/redundant_parentheses_spec.rb
+++ b/spec/rubocop/cop/style/redundant_parentheses_spec.rb
@@ -143,4 +143,16 @@ describe RuboCop::Cop::Style::RedundantParentheses do
     inspect_source(cop, 'if x; y else (1)end')
     expect(cop.offenses).to be_empty
   end
+
+  context 'when a hash literal is the first argument in a method call' do
+    it 'accepts parentheses if the argument list is not parenthesized ' do
+      inspect_source(cop, 'x ({ y: 1 }), z')
+      expect(cop.offenses).to be_empty
+    end
+
+    it 'registers an offense if the argument list is parenthesized ' do
+      inspect_source(cop, 'x(({ y: 1 }), z)')
+      expect(cop.offenses.size).to eq 1
+    end
+  end
 end


### PR DESCRIPTION
Accept parentheses around a hash literal if it's the first argument in
a method call and the argument list isn't parenthesized. This will
prevent invalid syntax or changed AST after auto-correction.