### PR TITLE
[Fix #2703] Calculate column on first line when BOM is present

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@
 * [#2666](https://github.com/bbatsov/rubocop/issues/2666): Fix bug when auto-correcting symbol literals in `Lint/LiteralInInterpolation`. ([@lumeet][])
 * [#2664](https://github.com/bbatsov/rubocop/issues/2664): `Performance/Casecmp` can auto-correct case comparison to variables and method calls without error. ([@rrosenblum][])
 * [#2729](https://github.com/bbatsov/rubocop/issues/2729): Fix handling of hash literal as the first argument in `Style/RedundantParentheses`. ([@lumeet][])
+* [#2703](https://github.com/bbatsov/rubocop/issues/2703): Handle byte order mark in `Style/IndentationWidth`, `Style/ElseAlignment`, `Lint/EndAlignment`, and `Lint/DefEndAlignment`. ([@jonas054][])
 
 ### Changes
 

--- a/lib/rubocop/cop/mixin/end_keyword_alignment.rb
+++ b/lib/rubocop/cop/mixin/end_keyword_alignment.rb
@@ -22,7 +22,8 @@ module RuboCop
         return unless end_loc # Discard modifier forms of if/while/until.
 
         matching = align_ranges.select do |_, range|
-          range.line == end_loc.line || range.column == end_loc.column
+          range.line == end_loc.line ||
+            effective_column(range) == end_loc.column
         end
 
         if matching.key?(style)

--- a/lib/rubocop/cop/style/else_alignment.rb
+++ b/lib/rubocop/cop/style/else_alignment.rb
@@ -99,7 +99,7 @@ module RuboCop
         def check_alignment(base_range, else_range)
           return unless begins_its_line?(else_range)
 
-          @column_delta = base_range.column - else_range.column
+          @column_delta = effective_column(base_range) - else_range.column
           return if @column_delta == 0
 
           add_offense(else_range, else_range,

--- a/lib/rubocop/cop/style/indentation_width.rb
+++ b/lib/rubocop/cop/style/indentation_width.rb
@@ -202,7 +202,7 @@ module RuboCop
         def check_indentation(base_loc, body_node, style = 'normal')
           return unless indentation_to_check?(base_loc, body_node)
 
-          indentation = body_node.loc.column - base_loc.column
+          indentation = body_node.loc.column - effective_column(base_loc)
           @column_delta = configured_indentation_width - indentation
           return if @column_delta == 0
 

--- a/spec/rubocop/cop/lint/def_end_alignment_spec.rb
+++ b/spec/rubocop/cop/lint/def_end_alignment_spec.rb
@@ -19,6 +19,8 @@ describe RuboCop::Cop::Lint::DefEndAlignment, :config do
      '    end']
   end
 
+  BOM = "\xef\xbb\xbf".freeze
+
   context 'when AlignWith is start_of_line' do
     let(:cop_config) do
       { 'AlignWith' => 'start_of_line', 'AutoCorrect' => true }
@@ -27,8 +29,9 @@ describe RuboCop::Cop::Lint::DefEndAlignment, :config do
     include_examples 'misaligned', '', 'def', 'test',      '  end'
     include_examples 'misaligned', '', 'def', 'Test.test', '  end', 'defs'
 
-    include_examples 'aligned', 'def', 'test',      'end'
-    include_examples 'aligned', 'def', 'Test.test', 'end', 'defs'
+    include_examples 'aligned', "#{BOM}def", 'test',      'end'
+    include_examples 'aligned', 'def',       'test',      'end'
+    include_examples 'aligned', 'def',       'Test.test', 'end', 'defs'
 
     context 'in ruby 2.1 or later' do
       include_examples 'aligned', 'foo def', 'test', 'end'

--- a/spec/rubocop/cop/lint/end_alignment_spec.rb
+++ b/spec/rubocop/cop/lint/end_alignment_spec.rb
@@ -8,6 +8,7 @@ describe RuboCop::Cop::Lint::EndAlignment, :config do
   let(:cop_config) do
     { 'AlignWith' => 'keyword', 'AutoCorrect' => true }
   end
+  BOM = "\xef\xbb\xbf".freeze
 
   include_examples 'misaligned', '', 'class',  'Test',      '  end'
   include_examples 'misaligned', '', 'module', 'Test',      '  end'
@@ -16,6 +17,8 @@ describe RuboCop::Cop::Lint::EndAlignment, :config do
   include_examples 'misaligned', '', 'while',  'test',      '  end'
   include_examples 'misaligned', '', 'until',  'test',      '  end'
   include_examples 'misaligned', '', 'case',   'a when b',  '  end'
+
+  include_examples 'aligned', "#{BOM}class", 'Test', 'end'
 
   include_examples 'aligned', 'class',  'Test',      'end'
   include_examples 'aligned', 'module', 'Test',      'end'

--- a/spec/rubocop/cop/style/else_alignment_spec.rb
+++ b/spec/rubocop/cop/style/else_alignment_spec.rb
@@ -92,6 +92,22 @@ describe RuboCop::Cop::Style::ElseAlignment do
       expect(cop.offenses).to be_empty
     end
 
+    context 'for a file with byte order mark' do
+      let(:bom) { "\xef\xbb\xbf" }
+
+      it 'accepts a correctly aligned if/elsif/else/end' do
+        inspect_source(cop,
+                       ["#{bom}if a1",
+                        '  b1',
+                        'elsif a2',
+                        '  b2',
+                        'else',
+                        '  c',
+                        'end'])
+        expect(cop.offenses).to be_empty
+      end
+    end
+
     context 'with assignment' do
       context 'when alignment style is variable' do
         context 'and end is aligned with variable' do

--- a/spec/rubocop/cop/style/indentation_width_spec.rb
+++ b/spec/rubocop/cop/style/indentation_width_spec.rb
@@ -22,6 +22,18 @@ describe RuboCop::Cop::Style::IndentationWidth do
   context 'with Width set to 4' do
     let(:cop_config) { { 'Width' => 4 } }
 
+    context 'for a file with byte order mark' do
+      let(:bom) { "\xef\xbb\xbf" }
+
+      it 'accepts correctly indented method definition' do
+        inspect_source(cop, ["#{bom}class Test",
+                             '    def method',
+                             '    end',
+                             'end'])
+        expect(cop.offenses).to be_empty
+      end
+    end
+
     context 'with if statement' do
       it 'registers an offense for bad indentation of an if body' do
         inspect_source(cop,


### PR DESCRIPTION
Subtract 1 if there's a byte order mark. This is needed when checking alignment. If we just go by the raw column number of the range of something on line 1, we will get column 1 instead of 0 for the first visible character of the file and conclude that something further down is misaligned when it's not.