### PR TITLE
[Fix #2674] Include check for Hash#update in Performance/RedundantMerge cop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 
 ### Bug fixes
 
+* [#2674](https://github.com/bbatsov/rubocop/issues/2674): Also check for Hash#update alias in `Performance/RedundantMerge`. ([@drenmi][])
 * [#2630](https://github.com/bbatsov/rubocop/issues/2630): Take frozen string literals into account in `Style/MutableConstant`. ([@segiddins][])
 * [#2642](https://github.com/bbatsov/rubocop/issues/2642): Support assignment via `||=` in `Style/MutableConstant`. ([@segiddins][])
 * [#2646](https://github.com/bbatsov/rubocop/issues/2646): Fix auto-correcting assignment to a constant in `Style/ConditionalAssignment`. ([@segiddins][])

--- a/config/enabled.yml
+++ b/config/enabled.yml
@@ -1238,7 +1238,7 @@ Performance/RedundantMatch:
   Enabled: true
 
 Performance/RedundantMerge:
-  Description: 'Use Hash#[]=, rather than Hash#merge! with a single key-value pair.'
+  Description: 'Use Hash#[]=, rather than Hash#merge! or Hash#update with a single key-value pair.'
   Reference: 'https://github.com/JuanitoFatas/fast-ruby#hashmerge-vs-hash-code'
   Enabled: true
 

--- a/lib/rubocop/cop/performance/redundant_merge.rb
+++ b/lib/rubocop/cop/performance/redundant_merge.rb
@@ -15,7 +15,8 @@ module RuboCop
         AREF_ASGN = '%s[%s] = %s'.freeze
         MSG = 'Use `%s` instead of `%s`.'.freeze
 
-        def_node_matcher :redundant_merge, '(send $_ :merge! (hash $...))'
+        def_node_matcher :redundant_merge,
+                         '(send $_ {:merge! :update} (hash $...))'
         def_node_matcher :modifier_flow_control, '[{if while until} #modifier?]'
 
         def on_send(node)

--- a/spec/rubocop/cop/performance/redundant_merge_spec.rb
+++ b/spec/rubocop/cop/performance/redundant_merge_spec.rb
@@ -6,58 +6,63 @@ require 'spec_helper'
 describe RuboCop::Cop::Performance::RedundantMerge do
   subject(:cop) { described_class.new }
 
-  it 'autocorrects hash.merge!(a: 1)' do
-    new_source = autocorrect_source(cop, 'hash.merge!(a: 1)')
-    expect(new_source).to eq 'hash[:a] = 1'
-  end
-
-  it 'autocorrects hash.merge!("abc" => "value")' do
-    new_source = autocorrect_source(cop, 'hash.merge!("abc" => "value")')
-    expect(new_source).to eq 'hash["abc"] = "value"'
-  end
-
-  context 'when receiver is a local variable' do
-    it 'autocorrects hash.merge!(a: 1, b: 2)' do
-      new_source = autocorrect_source(cop, ['hash = {}',
-                                            'hash.merge!(a: 1, b: 2)'])
-      expect(new_source).to eq(['hash = {}',
-                                'hash[:a] = 1',
-                                'hash[:b] = 2'].join("\n"))
+  shared_examples 'redundant_merge' do |method|
+    it "autocorrects hash.#{method}(a: 1)" do
+      new_source = autocorrect_source(cop, "hash.#{method}(a: 1)")
+      expect(new_source).to eq 'hash[:a] = 1'
     end
-  end
 
-  context 'when receiver is a method call' do
-    it "doesn't autocorrect hash.merge!(a: 1, b: 2)" do
-      new_source = autocorrect_source(cop, 'hash.merge!(a: 1, b: 2)')
-      expect(new_source).to eq('hash.merge!(a: 1, b: 2)')
+    it "autocorrects hash.#{method}('abc' => 'value')" do
+      new_source = autocorrect_source(cop, "hash.#{method}('abc' => 'value')")
+      expect(new_source).to eq "hash['abc'] = 'value'"
     end
-  end
 
-  %w(if unless while until).each do |kw|
-    context "when there is a modifier #{kw}, and more than 1 pair" do
-      it "autocorrects it to an #{kw} block" do
-        new_source = autocorrect_source(
-          cop,
-          ['hash = {}',
-           "hash.merge!(a: 1, b: 2) #{kw} condition1 && condition2"])
+    context 'when receiver is a local variable' do
+      it "autocorrects hash.#{method}(a: 1, b: 2)" do
+        new_source = autocorrect_source(cop, ['hash = {}',
+                                              "hash.#{method}(a: 1, b: 2)"])
         expect(new_source).to eq(['hash = {}',
-                                  "#{kw} condition1 && condition2",
-                                  '  hash[:a] = 1',
-                                  '  hash[:b] = 2',
-                                  'end'].join("\n"))
+                                  'hash[:a] = 1',
+                                  'hash[:b] = 2'].join("\n"))
       end
     end
+
+    context 'when receiver is a method call' do
+      it "doesn't autocorrect hash.#{method}(a: 1, b: 2)" do
+        new_source = autocorrect_source(cop, "hash.#{method}(a: 1, b: 2)")
+        expect(new_source).to eq("hash.#{method}(a: 1, b: 2)")
+      end
+    end
+
+    %w(if unless while until).each do |kw|
+      context "when there is a modifier #{kw}, and more than 1 pair" do
+        it "autocorrects it to an #{kw} block" do
+          new_source = autocorrect_source(
+            cop,
+            ['hash = {}',
+             "hash.#{method}(a: 1, b: 2) #{kw} condition1 && condition2"])
+          expect(new_source).to eq(['hash = {}',
+                                    "#{kw} condition1 && condition2",
+                                    '  hash[:a] = 1',
+                                    '  hash[:b] = 2',
+                                    'end'].join("\n"))
+        end
+      end
+    end
+
+    it "doesn't register an error when return value is used" do
+      inspect_source(cop, ["variable = hash.#{method}(a: 1)",
+                           'puts variable'])
+      expect(cop.offenses).to be_empty
+    end
+
+    it "formats the error message correctly for hash.#{method}(a: 1)" do
+      inspect_source(cop, "hash.#{method}(a: 1)")
+      expect(cop.messages).to eq(
+        ["Use `hash[:a] = 1` instead of `hash.#{method}(a: 1)`."])
+    end
   end
 
-  it "doesn't register an error when return value is used" do
-    inspect_source(cop, ['variable = hash.merge!(a: 1)',
-                         'puts variable'])
-    expect(cop.offenses).to be_empty
-  end
-
-  it 'formats the error message correctly for hash.merge!(a: 1)' do
-    inspect_source(cop, 'hash.merge!(a: 1)')
-    expect(cop.messages).to eq(
-      ['Use `hash[:a] = 1` instead of `hash.merge!(a: 1)`.'])
-  end
+  it_behaves_like('redundant_merge', 'merge!')
+  it_behaves_like('redundant_merge', 'update')
 end

--- a/spec/rubocop/cop/rails/action_filter_spec.rb
+++ b/spec/rubocop/cop/rails/action_filter_spec.rb
@@ -49,7 +49,7 @@ describe RuboCop::Cop::Rails::ActionFilter, :config do
 
   context 'when style is action' do
     before do
-      cop_config.update('EnforcedStyle' => 'action')
+      cop_config['EnforcedStyle'] = 'action'
     end
 
     described_class::FILTER_METHODS.each do |method|
@@ -79,7 +79,7 @@ describe RuboCop::Cop::Rails::ActionFilter, :config do
 
   context 'when style is filter' do
     before do
-      cop_config.update('EnforcedStyle' => 'filter')
+      cop_config['EnforcedStyle'] = 'filter'
     end
 
     described_class::ACTION_METHODS.each do |method|


### PR DESCRIPTION
The `Performance/RedundantMerge` cop used to check only for uses of [`Hash#merge!`](http://ruby-doc.org/core-2.3.0/Hash.html#method-i-merge-21), but not for the the alias [`Hash#update`](http://ruby-doc.org/core-2.3.0/Hash.html#method-i-update).

From [the documentation](http://ruby-doc.org/core-2.2.0/Hash.html#method-i-update):

> `merge!` and `update` are two names for the same method.

This PR applies the same treatment to `Hash#update` as well.