### PR TITLE
Performance/CaseWhenSplat reorders 'when' clauses one at a time

### DIFF
--- a/lib/rubocop/cop/performance/case_when_splat.rb
+++ b/lib/rubocop/cop/performance/case_when_splat.rb
@@ -63,6 +63,11 @@ module RuboCop
         PERCENT_I = '%i'.freeze
         PERCENT_CAPITAL_I = '%I'.freeze
 
+        def initialize(*)
+          super
+          @reordered_splat_condition = false
+        end
+
         def on_case(node)
           _case_branch, *when_branches, _else_branch = *node
           when_conditions =
@@ -85,6 +90,8 @@ module RuboCop
           if variable.array_type?
             correct_array_literal(condition, variable)
           else
+            return if @reordered_splat_condition
+            @reordered_splat_condition = true
             reorder_splat_condition(node)
           end
         end

--- a/spec/rubocop/cop/performance/case_when_splat_spec.rb
+++ b/spec/rubocop/cop/performance/case_when_splat_spec.rb
@@ -217,6 +217,11 @@ describe RuboCop::Cop::Performance::CaseWhenSplat do
                                             '  baz',
                                             'end'])
 
+      # CaseWhenSplat requires multiple rounds of correction to avoid
+      # "clobbering errors" from Source::Rewriter
+      cop = described_class.new
+      new_source = autocorrect_source(cop, new_source)
+
       expect(new_source).to eq(['case foo',
                                 'when 5',
                                 '  baz',
@@ -239,6 +244,11 @@ describe RuboCop::Cop::Performance::CaseWhenSplat do
                                             'when 6',
                                             '  baz',
                                             'end'])
+
+      # CaseWhenSplat requires multiple rounds of correction to avoid
+      # "clobbering errors" from Source::Rewriter
+      cop = described_class.new
+      new_source = autocorrect_source(cop, new_source)
 
       expect(new_source).to eq(['case foo',
                                 'when 3',


### PR DESCRIPTION
The next release of `parser` will include an updated `Source::Rewriter` with
adjusted rules as regards what updates "clobber" each other, and what updates
can be quietly merged. One of the adjustments is that 2 insertions cannot be
made at the exact same point. Why? Because it is impossible to know for sure
how to merge them correctly. If the same text is inserted, it is also difficult
to tell whether 1 copy or 2 should be added.

The one cop which violates this rule is Performance/CaseWhenSplat. This commit
adjusts CaseWhenSplat so that each instance will only attempt to autocorrect
a single out-of-order `when` clause.

Since autocorrection runs in a loop until there are no more corrections,
all instances of this problem will still be corrected; it may just take a
couple more iterations of the autocorrection loop.