### PR TITLE
[Fix #2723] Fix NoMethodError in Style/GuardClause cop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 
 ### Bug fixes
 
+* [#2723](https://github.com/bbatsov/rubocop/issues/2723): Fix NoMethodError in Style/GuardClause. ([@drenmi][])
 * [#2674](https://github.com/bbatsov/rubocop/issues/2674): Also check for Hash#update alias in `Performance/RedundantMerge`. ([@drenmi][])
 * [#2630](https://github.com/bbatsov/rubocop/issues/2630): Take frozen string literals into account in `Style/MutableConstant`. ([@segiddins][])
 * [#2642](https://github.com/bbatsov/rubocop/issues/2642): Support assignment via `||=` in `Style/MutableConstant`. ([@segiddins][])

--- a/lib/rubocop/cop/style/guard_clause.rb
+++ b/lib/rubocop/cop/style/guard_clause.rb
@@ -112,8 +112,9 @@ module RuboCop
         def line_too_long?(node, body, keyword, condition)
           max    = config.for_cop('Metrics/LineLength')['Max'] || 80
           indent = node.loc.column
+          source = body && body.source || ''
           # 2 is for spaces on left and right of keyword
-          indent + (body.source + keyword + condition.source).length + 2 > max
+          indent + (source + keyword + condition.source).length + 2 > max
         end
       end
     end

--- a/spec/rubocop/cop/style/guard_clause_spec.rb
+++ b/spec/rubocop/cop/style/guard_clause_spec.rb
@@ -7,49 +7,75 @@ describe RuboCop::Cop::Style::GuardClause, :config do
   let(:cop) { described_class.new(config) }
   let(:cop_config) { {} }
 
-  it 'reports an offense if method body is if / unless without else' do
-    inspect_source(cop,
-                   ['def func',
-                    '  if something',
-                    '    work',
-                    '  end',
-                    'end',
-                    '',
-                    'def func',
-                    '  unless something',
-                    '    work',
-                    '  end',
-                    'end'])
-    expect(cop.offenses.size).to eq(2)
-    expect(cop.offenses.map(&:line).sort).to eq([2, 8])
-    expect(cop.messages)
-      .to eq(['Use a guard clause instead of wrapping ' \
-              'the code inside a conditional expression.'] * 2)
-    expect(cop.highlights).to eq(%w(if unless))
+  shared_examples 'reports offense' do |body|
+    it 'reports an offense if method body is if / unless without else' do
+      inspect_source(cop,
+                     ['def func',
+                      '  if something',
+                      "    #{body}",
+                      '  end',
+                      'end',
+                      '',
+                      'def func',
+                      '  unless something',
+                      "    #{body}",
+                      '  end',
+                      'end'])
+      expect(cop.offenses.size).to eq(2)
+      expect(cop.offenses.map(&:line).sort).to eq([2, 8])
+      expect(cop.messages)
+        .to eq(['Use a guard clause instead of wrapping ' \
+                'the code inside a conditional expression.'] * 2)
+      expect(cop.highlights).to eq(%w(if unless))
+    end
+
+    it 'reports an offense if method body is if / unless without else' do
+      inspect_source(cop,
+                     ['def func',
+                      '  if something',
+                      "    #{body}",
+                      '  end',
+                      'end',
+                      '',
+                      'def func',
+                      '  unless something',
+                      "    #{body}",
+                      '  end',
+                      'end'])
+      expect(cop.offenses.size).to eq(2)
+      expect(cop.offenses.map(&:line).sort).to eq([2, 8])
+      expect(cop.messages)
+        .to eq(['Use a guard clause instead of wrapping ' \
+                'the code inside a conditional expression.'] * 2)
+      expect(cop.highlights).to eq(%w(if unless))
+    end
+
+    it 'reports an offense if method body ends with if / unless without else' do
+      inspect_source(cop,
+                     ['def func',
+                      '  test',
+                      '  if something',
+                      "    #{body}",
+                      '  end',
+                      'end',
+                      '',
+                      'def func',
+                      '  test',
+                      '  unless something',
+                      "    #{body}",
+                      '  end',
+                      'end'])
+      expect(cop.offenses.size).to eq(2)
+      expect(cop.offenses.map(&:line).sort).to eq([3, 10])
+      expect(cop.messages)
+        .to eq(['Use a guard clause instead of wrapping ' \
+                'the code inside a conditional expression.'] * 2)
+      expect(cop.highlights).to eq(%w(if unless))
+    end
   end
 
-  it 'reports an offense if method body ends with if / unless without else' do
-    inspect_source(cop,
-                   ['def func',
-                    '  test',
-                    '  if something',
-                    '    work',
-                    '  end',
-                    'end',
-                    '',
-                    'def func',
-                    '  test',
-                    '  unless something',
-                    '    work',
-                    '  end',
-                    'end'])
-    expect(cop.offenses.size).to eq(2)
-    expect(cop.offenses.map(&:line).sort).to eq([3, 10])
-    expect(cop.messages)
-      .to eq(['Use a guard clause instead of wrapping ' \
-              'the code inside a conditional expression.'] * 2)
-    expect(cop.highlights).to eq(%w(if unless))
-  end
+  it_behaves_like('reports offense', 'work')
+  it_behaves_like('reports offense', '# TODO')
 
   it 'does not report an offense if corrected code would exceed line length' do
     inspect_source(cop,


### PR DESCRIPTION
#### The problem

When the `Style/GuardClause` cop encounters a multi-line conditional with an empty body, it throws an error.

Examples:

```
def foo
  if bar
    # TODO
  end
end
```

and:

```
def foo
  if bar

  end
end
```
-----
#### Why this is happening

This happened because of how the `MinBodyLength` cop works, in combination with the checks in `Style/GuardClause`. Here's the relevant part of `MinBodyLength`:

```
module MinBodyLength
  def min_body_length?(node)
    (node.loc.end.line - node.loc.keyword.line) > min_body_length
  end
end
```

It only checks the line number of where the conditional ended and subtracts the starting line number. It doesn't take into account whether those lines have any code or not.

In `Style/GuardClause`, we have the following guard clauses (relevant part highlighted by me):

```
return if body && else_body
return if modifier_if?(node) || ternary_op?(node)
return if cond.multiline?
return unless min_body_length?(node) # Note! This will pass for empty conditionals of sufficient length
return if line_too_long_when_corrected?(node)
```

This results in a `node` with an empty `body` is passed to `line_too_long_when_corrected?`, where it is deconstructed, and we try to send `#source` to the `body`, which now happens to be `nil`.

-----

#### The proposed solution

I deliberated a bit, whether an empty conditional should trigger an offense, and in the end decided that I think it should (as technically, it could be replaced with a guard clause) but it gets a bit thorny to reason about the semantics of half-finished code. This decision also led to the simplest solution, as it works well with the existing code.