### PR TITLE
[WIP] Add Try Cop for Rails

### DIFF
--- a/config/enabled.yml
+++ b/config/enabled.yml
@@ -1337,3 +1337,7 @@ Rails/TimeZone:
 Rails/Validation:
   Description: 'Use validates :attribute, hash of validations.'
   Enabled: true
+
+Rails/Try:
+  Description: 'Prefer to use the safe navigator instead of try'
+  Enabled: true

--- a/lib/rubocop.rb
+++ b/lib/rubocop.rb
@@ -366,6 +366,7 @@ require 'rubocop/cop/rails/read_write_attribute'
 require 'rubocop/cop/rails/scope_args'
 require 'rubocop/cop/rails/time_zone'
 require 'rubocop/cop/rails/validation'
+require 'rubocop/cop/rails/try'
 
 require 'rubocop/formatter/base_formatter'
 require 'rubocop/formatter/simple_text_formatter'

--- a/lib/rubocop/cop/rails/try.rb
+++ b/lib/rubocop/cop/rails/try.rb
@@ -1,0 +1,24 @@
+# encoding: utf-8
+# frozen_string_literal: true
+
+module RuboCop
+  module Cop
+    module Rails
+      # Look for things like params.try(:something).try(something_else)
+      # Ruby 2.3.x introduces the safe navigation operator which is much faster
+      class Try < Cop
+        MSG = 'prefer safe navigation operator'.freeze
+
+        def on_send(node)
+          _receiver, method_name, *_args = *node
+
+          # TODO: not too sure about this check - maybe this should be done at
+          # the top level in the requires.
+          if method_name == :try! && RUBY_VERSION.match(/^2.3/)
+            add_offense(node, :selector)
+          end
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
Hi! With the arrival of `ruby 2.3.x`, there has been introduced a [safe navigation][safenav] operator. I wanted a cop that would detect `try!` in rails projects, and would suggest the use of a safe navigator.

I was going to make this as a separate plugin, but it seemed more sensible to bundle it with the rest of the rails cops currently residing in the main repo.

[safenav]: https://bugs.ruby-lang.org/issues/11537