### PR TITLE
[Fix #2742] Fix TrailingComma cop for single element arrays

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,7 @@
 * [#2690](https://github.com/bbatsov/rubocop/issues/2690): Fix alignment of operands that are part of an assignment in `Style/MultilineOperationIndentation`. ([@jonas054][])
 * [#2228](https://github.com/bbatsov/rubocop/issues/2228): Use the config of a related cop whether it's enabled or not. ([@madwort][])
 * [#2721](https://github.com/bbatsov/rubocop/issues/2721): Do not register an offense for constants wrapped in parentheses passed to `rescue` in `Style/RedundantParentheses`. ([@rrosenblum][])
+* [#2742](https://github.com/bbatsov/rubocop/issues/2742): Fix `Style/TrailingCommaInArguments` & `Style/TrailingCommaInLiteral` for inline single element arrays. ([@annih][])
 
 ### Changes
 
@@ -1929,3 +1930,4 @@
 [@owst]: https://github.com/owst
 [@seikichi]: https://github.com/seikichi
 [@madwort]: https://github.com/madwort
+[@annih]: https://github.com/annih

--- a/lib/rubocop/cop/mixin/trailing_comma.rb
+++ b/lib/rubocop/cop/mixin/trailing_comma.rb
@@ -81,10 +81,11 @@ module RuboCop
                      node.children
                    end
 
-        # Without this check, Foo.new({}) is considered multiline, which
+        # No need to process anything if the whole node is not multiline
+        # Without the 2nd check, Foo.new({}) is considered multiline, which
         # it should not be. Essentially, if there are no elements, the
         # expression can not be multiline.
-        return if elements.empty?
+        return if !node.multiline? || elements.empty?
 
         items = elements.map(&:source_range)
         if style == :consistent_comma

--- a/spec/rubocop/cop/style/trailing_comma_in_arguments_spec.rb
+++ b/spec/rubocop/cop/style/trailing_comma_in_arguments_spec.rb
@@ -29,6 +29,12 @@ describe RuboCop::Cop::Style::TrailingCommaInArguments, :config do
       expect(cop.offenses).to be_empty
     end
 
+    it 'accepts method call without trailing comma with single element hash' \
+        ' parameters at the end' do
+      inspect_source(cop, 'some_method(a: 1)')
+      expect(cop.offenses).to be_empty
+    end
+
     it 'accepts method call without parameters' do
       inspect_source(cop, 'some_method')
       expect(cop.offenses).to be_empty

--- a/spec/rubocop/cop/style/trailing_comma_in_literal_spec.rb
+++ b/spec/rubocop/cop/style/trailing_comma_in_literal_spec.rb
@@ -26,6 +26,11 @@ describe RuboCop::Cop::Style::TrailingCommaInLiteral, :config do
       expect(cop.offenses).to be_empty
     end
 
+    it 'accepts single element Array literal without trailing comma' do
+      inspect_source(cop, 'VALUES = [1001]')
+      expect(cop.offenses).to be_empty
+    end
+
     it 'accepts empty Array literal' do
       inspect_source(cop, 'VALUES = []')
       expect(cop.offenses).to be_empty
@@ -42,6 +47,11 @@ describe RuboCop::Cop::Style::TrailingCommaInLiteral, :config do
 
     it 'accepts Hash literal without trailing comma' do
       inspect_source(cop, 'MAP = { a: 1001, b: 2020, c: 3333 }')
+      expect(cop.offenses).to be_empty
+    end
+
+    it 'accepts single element Hash literal without trailing comma' do
+      inspect_source(cop, 'MAP = { a: 10001 }')
       expect(cop.offenses).to be_empty
     end
 


### PR DESCRIPTION
Single line arrays with only one element were detected as multiline.
Multiline detection fixed and optmized by returning if the whole node
is single line.

I first wanted to return at a different position in the code... but I got:
> lib/rubocop/cop/mixin/trailing_comma.rb:67:7: C: Method has too many lines. [21/20]
      def multiline?(node)
      ^^^

So I ended up using the existing return statement.

I hope it'll fit your criteria, let me know if you need any change.

Regards.
