### PR TITLE
Fix for camelCase and unused argument name conflict

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,7 @@
 * [#2721](https://github.com/bbatsov/rubocop/issues/2721): Do not register an offense for constants wrapped in parentheses passed to `rescue` in `Style/RedundantParentheses`. ([@rrosenblum][])
 * [#2742](https://github.com/bbatsov/rubocop/issues/2742): Fix `Style/TrailingCommaInArguments` & `Style/TrailingCommaInLiteral` for inline single element arrays. ([@annih][])
 * [#2768](https://github.com/bbatsov/rubocop/issues/2768): Allow parentheses after keyword `not` in `Style/MethodCallParentheses`. ([@lumeet][])
+* [#2758](https://github.com/bbatsov/rubocop/issues/2758): Allow leading underscores in camel case variable names.([@mmcguinn][])
 
 ### Changes
 
@@ -1934,3 +1935,4 @@
 [@seikichi]: https://github.com/seikichi
 [@madwort]: https://github.com/madwort
 [@annih]: https://github.com/annih
+[@mmcguinn]: https://github.com/mmcguinn

--- a/lib/rubocop/cop/mixin/configurable_naming.rb
+++ b/lib/rubocop/cop/mixin/configurable_naming.rb
@@ -9,7 +9,7 @@ module RuboCop
       include ConfigurableEnforcedStyle
 
       SNAKE_CASE = /^@{0,2}[\da-z_]+[!?=]?$/
-      CAMEL_CASE = /^@{0,2}[a-z][\da-zA-Z]+[!?=]?$/
+      CAMEL_CASE = /^@{0,2}_?[a-z][\da-zA-Z]+[!?=]?$/
 
       def check_name(node, name, name_range)
         return if operator?(name)

--- a/spec/rubocop/cop/style/variable_name_spec.rb
+++ b/spec/rubocop/cop/style/variable_name_spec.rb
@@ -64,6 +64,12 @@ describe RuboCop::Cop::Style::VariableName, :config do
       expect(cop.highlights).to eq(['funnyArg'])
     end
 
+    it 'registers an offense for camel case local variables marked as unused' do
+      inspect_source(cop, '_myLocal = 1')
+      expect(cop.offenses.size).to eq(1)
+      expect(cop.highlights).to eq(['_myLocal'])
+    end
+
     include_examples 'always accepted'
   end
 
@@ -104,6 +110,11 @@ describe RuboCop::Cop::Style::VariableName, :config do
       inspect_source(cop, 'def method(funny_arg); end')
       expect(cop.offenses.size).to eq(1)
       expect(cop.highlights).to eq(['funny_arg'])
+    end
+
+    it 'accepts camel case local variables marked as unused' do
+      inspect_source(cop, '_myLocal = 1')
+      expect(cop.offenses).to be_empty
     end
 
     include_examples 'always accepted'


### PR DESCRIPTION
Previously, the the behavior was something like the following:
```
foo      -> snake_case or camelCase
foo_bar  -> snake_case
fooBar   -> camelCase
_foo     -> unused snake_case
_foo_bar -> unused snake_case
_fooBar  -> invalid
```

New behavior should be:

```
foo      -> snake_case or camelCase
foo_bar  -> snake_case
fooBar   -> camelCase
_foo     -> unused snake_case or camelCase
_foo_bar -> unused snake_case
_fooBar  -> unused camelCase
```

Please let me know if there an appropriate place to add a test(s) for this and I'd be happy to add them. I looked at the existing tests and it doesn't look like they test any integration like this (and this change passes existing unit tests).
