### PR TITLE
[Fix #2768] Allow parentheses after keyword not

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,7 @@
 * [#2228](https://github.com/bbatsov/rubocop/issues/2228): Use the config of a related cop whether it's enabled or not. ([@madwort][])
 * [#2721](https://github.com/bbatsov/rubocop/issues/2721): Do not register an offense for constants wrapped in parentheses passed to `rescue` in `Style/RedundantParentheses`. ([@rrosenblum][])
 * [#2742](https://github.com/bbatsov/rubocop/issues/2742): Fix `Style/TrailingCommaInArguments` & `Style/TrailingCommaInLiteral` for inline single element arrays. ([@annih][])
+* [#2768](https://github.com/bbatsov/rubocop/issues/2768): Allow parentheses after keyword `not` in `Style/MethodCallParentheses`. ([@lumeet][])
 
 ### Changes
 

--- a/lib/rubocop/cop/style/method_call_parentheses.rb
+++ b/lib/rubocop/cop/style/method_call_parentheses.rb
@@ -19,6 +19,7 @@ module RuboCop
           return unless args.empty? && node.loc.begin
           return if same_name_assignment?(node)
           return if lambda_call_syntax?(node)
+          return if node.keyword_not?
 
           add_offense(node, :begin)
         end

--- a/lib/rubocop/cop/style/space_around_keyword.rb
+++ b/lib/rubocop/cop/style/space_around_keyword.rb
@@ -30,7 +30,7 @@ module RuboCop
         MSG_AFTER = 'Space after keyword `%s` is missing.'.freeze
 
         DO = 'do'.freeze
-        ACCEPT_LEFT_PAREN = %w(break next return super yield).freeze
+        ACCEPT_LEFT_PAREN = %w(break next not return super yield).freeze
 
         def on_and(node)
           check(node, [:operator].freeze) if node.keyword?

--- a/spec/rubocop/cop/style/method_call_parentheses_spec.rb
+++ b/spec/rubocop/cop/style/method_call_parentheses_spec.rb
@@ -32,6 +32,11 @@ describe RuboCop::Cop::Style::MethodCallParentheses do
     expect(cop.offenses).to be_empty
   end
 
+  it 'accepts parens after not' do
+    inspect_source(cop, 'not(something)')
+    expect(cop.offenses).to be_empty
+  end
+
   context 'assignment to a variable with the same name' do
     it 'accepts parens in local variable assignment ' do
       inspect_source(cop, 'test = test()')

--- a/spec/rubocop/cop/style/space_around_keyword_spec.rb
+++ b/spec/rubocop/cop/style/space_around_keyword_spec.rb
@@ -120,6 +120,7 @@ describe RuboCop::Cop::Style::SpaceAroundKeyword do
   it_behaves_like 'missing after', 'next', 'next""', 'next ""'
   it_behaves_like 'accept after', '(', 'next(1)'
   it_behaves_like 'missing after', 'not', 'not""', 'not ""'
+  it_behaves_like 'accept after', '(', 'not(1)'
   it_behaves_like 'missing before', 'or', '1or 2', '1 or 2'
   it_behaves_like 'missing after', 'or', '1 or(2)', '1 or (2)'
 


### PR DESCRIPTION
Keyword `not` needs special handling in a couple of cops. `Style/SpaceAroundKeyword` is still unreleased, so there's no need for another changelog entry.