### PR TITLE
Fix auto-correction of not with parentheses

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## master (unreleased)
 
+### Bug fixes
+
+* Fix auto-correction of `not` with parentheses in `Style/Not`. ([@lumeet][])
+
 ## 0.37.0 (04/02/2016)
 
 ### New features

--- a/lib/rubocop/cop/style/not.rb
+++ b/lib/rubocop/cop/style/not.rb
@@ -19,7 +19,7 @@ module RuboCop
         private
 
         def correction(node)
-          new_source = node.source.sub(/not\s+/, '!')
+          new_source = node.source.sub(/not\s*/, '!')
           ->(corrector) { corrector.replace(node.source_range, new_source) }
         end
       end

--- a/spec/rubocop/cop/style/not_spec.rb
+++ b/spec/rubocop/cop/style/not_spec.rb
@@ -21,6 +21,11 @@ describe RuboCop::Cop::Style::Not, :config do
     expect(new_source).to eq('x = 10 if !y')
   end
 
+  it 'auto-corrects "not" followed by parens with !' do
+    new_source = autocorrect_source(cop, 'not(test)')
+    expect(new_source).to eq('!(test)')
+  end
+
   it 'leaves "not" as is if auto-correction changes the meaning' do
     src = 'not x < y'
     new_source = autocorrect_source(cop, src)


### PR DESCRIPTION
`Style/Not` auto-corrects `not(a)` to `!(a)`.