### PR TITLE
Turn up the heat

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@
 * [#2761](https://github.com/bbatsov/rubocop/pull/2761): New cop `Style/MultilineMethodDefinitionBraceLayout` checks that the closing brace in a method definition is symmetrical with respect to the opening brace and the method parameters. ([@panthomakos][])
 * [#2699](https://github.com/bbatsov/rubocop/pull/2699): `Performance/Casecmp` can register offenses when `str.downcase` or `str.upcase` are passed to an equality method. ([@rrosenblum][])
 * [#2766](https://github.com/bbatsov/rubocop/pull/2766): New cop `Style/MultilineMethodCallBraceLayout` checks that the closing brace in a method call is symmetrical with respect to the opening brace and the method arguments. ([@panthomakos][])
+* `Style/Semicolon` can autocorrect useless semicolons at the beginning of a line. ([@alexdowad][])
 
 ### Bug fixes
 

--- a/lib/rubocop.rb
+++ b/lib/rubocop.rb
@@ -34,7 +34,6 @@ require 'rubocop/cop/cop'
 require 'rubocop/cop/commissioner'
 require 'rubocop/cop/corrector'
 require 'rubocop/cop/force'
-require 'rubocop/cop/team'
 require 'rubocop/cop/severity'
 
 require 'rubocop/cop/variable_force'
@@ -368,6 +367,8 @@ require 'rubocop/cop/rails/read_write_attribute'
 require 'rubocop/cop/rails/scope_args'
 require 'rubocop/cop/rails/time_zone'
 require 'rubocop/cop/rails/validation'
+
+require 'rubocop/cop/team'
 
 require 'rubocop/formatter/base_formatter'
 require 'rubocop/formatter/simple_text_formatter'

--- a/lib/rubocop/cop/style/semicolon.rb
+++ b/lib/rubocop/cop/style/semicolon.rb
@@ -13,7 +13,7 @@ module RuboCop
           return unless processed_source.ast
           @processed_source = processed_source
 
-          check_for_line_terminator
+          check_for_line_terminator_or_opener
         end
 
         def on_begin(node)
@@ -33,28 +33,33 @@ module RuboCop
             # if the first semicolon on the line is a separator of
             # expressions. It's just a guess.
             column = @processed_source[line - 1].index(';')
-            convention_on(line, column, !:last_on_line)
+            convention_on(line, column, false)
           end
         end
 
         private
 
-        def check_for_line_terminator
+        def check_for_line_terminator_or_opener
           tokens_for_lines = @processed_source.tokens.group_by do |token|
             token.pos.line
           end
 
           tokens_for_lines.each do |line, tokens|
-            next unless tokens.last.type == :tSEMI
-            convention_on(line, tokens.last.pos.column, :last_on_line)
+            if tokens.last.type == :tSEMI
+              convention_on(line, tokens.last.pos.column, true)
+            end
+
+            if tokens.first.type == :tSEMI
+              convention_on(line, tokens.first.pos.column, true)
+            end
           end
         end
 
-        def convention_on(line, column, last_on_line)
+        def convention_on(line, column, autocorrect)
           range = source_range(@processed_source.buffer, line, column)
           # Don't attempt to autocorrect if semicolon is separating statements
           # on the same line
-          add_offense(last_on_line ? range : nil, range)
+          add_offense(autocorrect ? range : nil, range)
         end
 
         def autocorrect(range)

--- a/lib/rubocop/cop/style/semicolon.rb
+++ b/lib/rubocop/cop/style/semicolon.rb
@@ -52,6 +52,8 @@ module RuboCop
 
         def convention_on(line, column, last_on_line)
           range = source_range(@processed_source.buffer, line, column)
+          # Don't attempt to autocorrect if semicolon is separating statements
+          # on the same line
           add_offense(last_on_line ? range : nil, range)
         end
 

--- a/rubocop.gemspec
+++ b/rubocop.gemspec
@@ -25,7 +25,7 @@ Gem::Specification.new do |s|
   s.summary = 'Automatic Ruby code style checking tool.'
 
   s.add_runtime_dependency('rainbow', '>= 1.99.1', '< 3.0')
-  s.add_runtime_dependency('parser', '>= 2.3.0.2', '< 3.0')
+  s.add_runtime_dependency('parser', '>= 2.3.0.3', '< 3.0')
   s.add_runtime_dependency('powerpack', '~> 0.1')
   s.add_runtime_dependency('ruby-progressbar', '~> 1.7')
   s.add_runtime_dependency('unicode-display_width', '~> 0.3')

--- a/spec/rubocop/cli/cli_autocorrect_spec.rb
+++ b/spec/rubocop/cli/cli_autocorrect_spec.rb
@@ -448,12 +448,9 @@ describe RuboCop::CLI, :isolated_environment do
     expect($stdout.string)
       .to eq(["#{e}:2:35: C: [Corrected] Redundant curly braces around " \
               'a hash parameter.',
-              "#{e}:2:35: C: [Corrected] Use the new Ruby 1.9 hash " \
-              'syntax.',
               # TODO: Don't report that a problem is corrected when it
               # actually went away due to another correction.
               "#{e}:2:35: C: [Corrected] Space inside { missing.",
-              # TODO: Don't report duplicates (HashSyntax in this case).
               "#{e}:2:36: C: [Corrected] Use the new Ruby 1.9 hash " \
               'syntax.',
               "#{e}:2:50: C: [Corrected] Space inside } missing.",
@@ -503,8 +500,6 @@ describe RuboCop::CLI, :isolated_environment do
               "#{e}:3:1: C: [Corrected] Keep a blank line before and " \
               'after `private`.',
               "#{e}:3:3: W: Useless `private` access modifier.",
-              "#{e}:3:3: C: [Corrected] Keep a blank line before and " \
-              'after `private`.',
               "#{e}:4:7: C: [Corrected] Freeze mutable objects assigned " \
               'to constants.',
               "#{e}:4:7: C: [Corrected] Use `%w` or `%W` " \
@@ -517,8 +512,6 @@ describe RuboCop::CLI, :isolated_environment do
               'symbols.',
               "#{e}:4:21: C: [Corrected] Avoid comma after the last item " \
               'of an array.',
-              "#{e}:5:7: C: [Corrected] Freeze mutable objects assigned " \
-              'to constants.',
               "#{e}:5:7: C: [Corrected] Use `%w` or `%W` " \
               'for an array of words.',
               "#{e}:5:8: C: [Corrected] Prefer single-quoted strings " \
@@ -565,13 +558,13 @@ describe RuboCop::CLI, :isolated_environment do
                                          'end',
                                          ''].join("\n"))
     expect($stdout.string).to eq(['',
-                                  '10  Style/TrailingWhitespace',
+                                  '6   Style/TrailingWhitespace',
                                   '3   Style/Semicolon',
-                                  '3   Style/SingleLineMethods',
+                                  '2   Style/SingleLineMethods',
                                   '1   Style/DefWithParentheses',
                                   '1   Style/EmptyLineBetweenDefs',
                                   '--',
-                                  '18  Total',
+                                  '13  Total',
                                   '',
                                   ''].join("\n"))
   end

--- a/spec/rubocop/cop/performance/redundant_match_spec.rb
+++ b/spec/rubocop/cop/performance/redundant_match_spec.rb
@@ -34,7 +34,7 @@ describe RuboCop::Cop::Performance::RedundantMatch do
                               'end'].join("\n"))
   end
 
-  it 'autocorrects .match in condition condition' do
+  it 'autocorrects .match in until condition' do
     new_source = autocorrect_source(cop, ['until str.match(/regex/)',
                                           '  do_something',
                                           'end'])

--- a/spec/rubocop/cop/style/semicolon_spec.rb
+++ b/spec/rubocop/cop/style/semicolon_spec.rb
@@ -83,18 +83,25 @@ describe RuboCop::Cop::Style::Semicolon, :config do
     expect(cop.offenses).to be_empty
   end
 
+  it 'registers an offense for a semicolon at the beginning of a line' do
+    inspect_source(cop, '; puts 1')
+    expect(cop.offenses.size).to eq(1)
+  end
+
   it 'auto-corrects semicolons when syntactically possible' do
     corrected =
       autocorrect_source(cop,
                          ['module Foo; end;',
                           'puts "this is a test";',
                           'puts "this is a test"; puts "So is this"',
-                          'def foo(a) x(1); y(2); z(3); end'])
+                          'def foo(a) x(1); y(2); z(3); end',
+                          ';puts 1'])
     expect(corrected)
       .to eq(['module Foo; end',
               'puts "this is a test"',
               'puts "this is a test"; puts "So is this"',
-              'def foo(a) x(1); y(2); z(3); end'].join("\n"))
+              'def foo(a) x(1); y(2); z(3); end',
+              'puts 1'].join("\n"))
   end
 
   context 'when AllowAsExpressionSeparator is true' do


### PR DESCRIPTION
The new `parser` has a much improved `Source::Rewriter` which makes it much more practical to apply autocorrections from all cops at once, rather than only one cop per iteration of the inspection loop. Previously, it would hideously mangle your code if you tried this.

This vastly decreases the number of iterations required until there are no corrections left to perform.

With this patch, I can autocorrect Rails' `actionpack` in 10 minutes. (19804 offenses detected, 15735 offenses corrected... :sweat:) Not impressed? Last time I tried, it took about 2 hours.

I'm still too scared to try autocorrecting all of Rails... :fearful: