### PR TITLE
[Fix #2739] FrozenStringLiteralComment when_needed adds a comment to all files targeted to Ruby 2.3+

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@
 
 * Fix auto-correction of `not` with parentheses in `Style/Not`. ([@lumeet][])
 
+### Changes
+
+* [#2739](https://github.com/bbatsov/rubocop/issues/2739): Change the configuration option `when_needed` in `Style/FrozenStringLiteralComment` to add a `frozen_string_literal` comment to all files when the `TargetRubyVersion` is set to 2.3+. ([@rrosenblum][])
+
 ## 0.37.0 (04/02/2016)
 
 ### New features

--- a/config/default.yml
+++ b/config/default.yml
@@ -481,9 +481,8 @@ Style/FormatString:
 Style/FrozenStringLiteralComment:
   EnforcedStyle: when_needed
   SupportedStyles:
-    # `when_needed` will add the frozen string literal comment to files that call
-    # `freeze` or `<<` on a string literal. It will only add the comment to files
-    # when running Ruby 2.3.0+.
+    # `when_needed` will add the frozen string literal comment to files
+    # only when the `TargetRubyVersion` is set to 2.3.0+.
     - when_needed
     # `always` will always add the frozen string literal comment to a file
     # regardless of the Ruby version or if `freeze` or `<<` are called on a

--- a/lib/rubocop/cop/style/frozen_string_literal_comment.rb
+++ b/lib/rubocop/cop/style/frozen_string_literal_comment.rb
@@ -16,24 +16,13 @@ module RuboCop
         MSG = 'Missing frozen string literal comment.'.freeze
         SHEBANG = '#!'.freeze
 
-        def_node_matcher :frozen_strings, '{(send {dstr str} :<< ...)
-                                            (send {dstr str} :freeze)}'
-
         def investigate(processed_source)
-          return unless style == :always
+          return if style == :when_needed && target_ruby_version < 2.3
           return if processed_source.buffer.source.empty?
 
           return if frozen_string_literal_comment_exists?(processed_source)
 
           offense(processed_source)
-        end
-
-        def on_send(node)
-          return unless style == :when_needed
-          return if target_ruby_version < 2.3
-          return if frozen_string_literal_comment_exists?(processed_source)
-
-          frozen_strings(node) { offense(processed_source) }
         end
 
         def autocorrect(_node)

--- a/spec/rubocop/cop/style/frozen_string_literal_comment_spec.rb
+++ b/spec/rubocop/cop/style/frozen_string_literal_comment_spec.rb
@@ -277,62 +277,60 @@ describe RuboCop::Cop::Style::FrozenStringLiteralComment, :config do
       end
     end
 
-    if RUBY_VERSION < '2.3.0'
-      context 'ruby < 2.3' do
-        context 'target_ruby_version < 2.3', :ruby19 do
-          it 'accepts freezing a string' do
-            inspect_source(cop, '"x".freeze')
+    context 'ruby < 2.3' do
+      context 'target_ruby_version < 2.3', :ruby19 do
+        it 'accepts freezing a string' do
+          inspect_source(cop, '"x".freeze')
 
-            expect(cop.offenses).to be_empty
-          end
-
-          it 'accepts calling << on a string' do
-            inspect_source(cop, '"x" << "y"')
-
-            expect(cop.offenses).to be_empty
-          end
-
-          it 'accepts freezing a string with interpolation' do
-            inspect_source(cop, '"#{foo}bar".freeze')
-
-            expect(cop.offenses).to be_empty
-          end
-
-          it 'accepts calling << on a string with interpolation' do
-            inspect_source(cop, '"#{foo}bar" << "baz"')
-
-            expect(cop.offenses).to be_empty
-          end
+          expect(cop.offenses).to be_empty
         end
 
-        context 'target_ruby_version 2.3+', :ruby23 do
-          it 'accepts freezing a string' do
-            inspect_source(cop, '"x".freeze')
+        it 'accepts calling << on a string' do
+          inspect_source(cop, '"x" << "y"')
 
-            expect(cop.messages)
-              .to eq(['Missing frozen string literal comment.'])
-          end
+          expect(cop.offenses).to be_empty
+        end
 
-          it 'accepts calling << on a string' do
-            inspect_source(cop, '"x" << "y"')
+        it 'accepts freezing a string with interpolation' do
+          inspect_source(cop, '"#{foo}bar".freeze')
 
-            expect(cop.messages)
-              .to eq(['Missing frozen string literal comment.'])
-          end
+          expect(cop.offenses).to be_empty
+        end
 
-          it 'accepts freezing a string with interpolation' do
-            inspect_source(cop, '"#{foo}bar".freeze')
+        it 'accepts calling << on a string with interpolation' do
+          inspect_source(cop, '"#{foo}bar" << "baz"')
 
-            expect(cop.messages)
-              .to eq(['Missing frozen string literal comment.'])
-          end
+          expect(cop.offenses).to be_empty
+        end
+      end
 
-          it 'accepts calling << on a string with interpolation' do
-            inspect_source(cop, '"#{foo}bar" << "baz"')
+      context 'target_ruby_version 2.3+', :ruby23 do
+        it 'accepts freezing a string' do
+          inspect_source(cop, '"x".freeze')
 
-            expect(cop.messages)
-              .to eq(['Missing frozen string literal comment.'])
-          end
+          expect(cop.messages)
+            .to eq(['Missing frozen string literal comment.'])
+        end
+
+        it 'accepts calling << on a string' do
+          inspect_source(cop, '"x" << "y"')
+
+          expect(cop.messages)
+            .to eq(['Missing frozen string literal comment.'])
+        end
+
+        it 'accepts freezing a string with interpolation' do
+          inspect_source(cop, '"#{foo}bar".freeze')
+
+          expect(cop.messages)
+            .to eq(['Missing frozen string literal comment.'])
+        end
+
+        it 'accepts calling << on a string with interpolation' do
+          inspect_source(cop, '"#{foo}bar" << "baz"')
+
+          expect(cop.messages)
+            .to eq(['Missing frozen string literal comment.'])
         end
       end
     end


### PR DESCRIPTION
This fixes #2739. I changed `when_needed` (the default) to added the `frozen_string_literal` comment to all files if the `TargetRubyVersion` is set to 2.3+. I considered getting rid of the configuration all together and relying solely on the user to enable the cop. With frozen string literals being the default in Ruby 3, I felt that offering a configuration that enables the cop for Ruby 2.3 was important. 