### PR TITLE
prevent commas/quotes in percentage word array

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 
 ### Bug fixes
 
+* [#2807](https://github.com/bbatsov/rubocop/pull/2807): `Style/WordArray` checks for commas and quotes on percent style arrays ([@karlhungus][])
 * Fix auto-correction of `not` with parentheses in `Style/Not`. ([@lumeet][])
 * [#2784](https://github.com/bbatsov/rubocop/issues/2784): RuboCop can inspect `super { ... }` and `super(arg) { ... }`. ([@alexdowad][])
 * [#2781](https://github.com/bbatsov/rubocop/issues/2781): `Performance/RedundantMerge` doesn't flag calls to `#update`, since many classes have methods by this name (not only `Hash`). ([@alexdowad][])

--- a/spec/rubocop/cop/style/word_array_spec.rb
+++ b/spec/rubocop/cop/style/word_array_spec.rb
@@ -45,6 +45,36 @@ describe RuboCop::Cop::Style::WordArray, :config do
       expect(cop.offenses.size).to eq(1)
     end
 
+    it 'registers an offense for word arrays with double quotes' do
+      inspect_source(cop, '%w("one", "two")')
+      expect(cop.offenses.size).to eq(1)
+    end
+
+    it 'registers an offense for word arrays with single quotes' do
+      inspect_source(cop, "%w('one', 'two')")
+      expect(cop.offenses.size).to eq(1)
+    end
+
+    it 'registers an offense for word arrays with commas' do
+      inspect_source(cop, '%w(one, two)')
+      expect(cop.offenses.size).to eq(1)
+    end
+
+    it 'does not register an offense for array with commas' do
+      inspect_source(cop, '["one,", "two", "three"]')
+      expect(cop.offenses).to be_empty
+    end
+
+    it 'does not register an offense for array with quotes' do
+      inspect_source(cop, '["one\'", "two", "three"]')
+      expect(cop.offenses).to be_empty
+    end
+
+    it 'does not register an offense for array with double quotes' do
+      inspect_source(cop, '["one\"", "two", "three"]')
+      expect(cop.offenses).to be_empty
+    end
+
     it 'uses %W when autocorrecting strings with newlines and tabs' do
       new_source = autocorrect_source(cop, %(["one\\n", "hi\\tthere"]))
       expect(new_source).to eq('%W(one\\n hi\\tthere)')


### PR DESCRIPTION
##### Problem
Using percentage style word arrays reminds you to switch from bracketed arrays, but doesn't warn
on miss translations i.e.

`['foo', 'bar']`

gets translated

`%w('foo', 'bar')`

##### Solution
prevent this mistake by warning when commas's or quotes are detected, this will force people who want commas in their string arrays to be explicit, and will prevent this mistake

