### PR TITLE
Fixes HTML formatter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Bug fixes
 
 * Fix auto-correction of array and hash literals in `Lint/LiteralInInterpolation`. ([@lumeet][])
+* [#2815](https://github.com/bbatsov/rubocop/pull/2815): Fix missing assets for html formatter. ([@prsimp][])
 
 ### Changes
 
@@ -1979,3 +1980,4 @@
 [@annih]: https://github.com/annih
 [@mmcguinn]: https://github.com/mmcguinn
 [@pocke]: https://github.com/pocke
+[@prsimp]: https://github.com/prsimp

--- a/rubocop.gemspec
+++ b/rubocop.gemspec
@@ -17,7 +17,8 @@ Gem::Specification.new do |s|
   EOF
 
   s.email = 'rubocop@googlegroups.com'
-  s.files = `git ls-files lib bin LICENSE.txt README.md config`.split($RS)
+  s.files = `git ls-files assets bin config lib LICENSE.txt README.md`
+            .split($RS)
   s.executables = s.files.grep(%r{^bin/}) { |f| File.basename(f) }
   s.extra_rdoc_files = ['LICENSE.txt', 'README.md']
   s.homepage = 'http://github.com/bbatsov/rubocop'


### PR DESCRIPTION
First off, thanks for all your hard work, Rubocop-team!

It seems the `assets` directory was inadvertently removed from the list of files to include with the gem in https://github.com/bbatsov/rubocop/commit/e23cac6d778735ce6cab333cccc1c9aff2a99770. Without the `assets` directory, the `--format html` option is broken:

```
No such file or directory @ rb_sysopen - ~/.rbenv/versions/2.3.0/lib/ruby/gems/2.3.0/gems/rubocop-0.37.1/assets/output.html.erb
~/.rbenv/versions/2.3.0/lib/ruby/gems/2.3.0/gems/rubocop-0.37.1/lib/rubocop/formatter/html_formatter.rb:55:in `read'
~/.rbenv/versions/2.3.0/lib/ruby/gems/2.3.0/gems/rubocop-0.37.1/lib/rubocop/formatter/html_formatter.rb:55:in `render_html'
~/.rbenv/versions/2.3.0/lib/ruby/gems/2.3.0/gems/rubocop-0.37.1/lib/rubocop/formatter/html_formatter.rb:49:in `finished'
~/.rbenv/versions/2.3.0/lib/ruby/gems/2.3.0/gems/rubocop-0.37.1/lib/rubocop/formatter/formatter_set.rb:30:in `block (3 levels) in <class:FormatterSet>'
~/.rbenv/versions/2.3.0/lib/ruby/gems/2.3.0/gems/rubocop-0.37.1/lib/rubocop/formatter/formatter_set.rb:30:in `each'
~/.rbenv/versions/2.3.0/lib/ruby/gems/2.3.0/gems/rubocop-0.37.1/lib/rubocop/formatter/formatter_set.rb:30:in `block (2 levels) in <class:FormatterSet>'
~/.rbenv/versions/2.3.0/lib/ruby/gems/2.3.0/gems/rubocop-0.37.1/lib/rubocop/runner.rb:68:in `inspect_files'
~/.rbenv/versions/2.3.0/lib/ruby/gems/2.3.0/gems/rubocop-0.37.1/lib/rubocop/runner.rb:35:in `run'
~/.rbenv/versions/2.3.0/lib/ruby/gems/2.3.0/gems/rubocop-0.37.1/lib/rubocop/cli.rb:30:in `run'
~/.rbenv/versions/2.3.0/lib/ruby/gems/2.3.0/gems/rubocop-0.37.1/bin/rubocop:14:in `block in <top (required)>'
~/.rbenv/versions/2.3.0/lib/ruby/2.3.0/benchmark.rb:308:in `realtime'
~/.rbenv/versions/2.3.0/lib/ruby/gems/2.3.0/gems/rubocop-0.37.1/bin/rubocop:13:in `<top (required)>'
~/.rbenv/versions/2.3.0/lib/ruby/gems/2.3.0/bin/rubocop:23:in `load'
~/.rbenv/versions/2.3.0/lib/ruby/gems/2.3.0/bin/rubocop:23:in `<main>'
```

I haven't tested exhaustively to ensure that no other required files are missing, I just happened to notice this as it broke one of my scripts.

This change does introduce one new Rubocop issue (line length) but I wasn't sure what sort of formatting you'd prefer, so I've left it as-is for now:

```
rubocop.gemspec:20:81: C: Line is too long. [81/80]
  s.files = `git ls-files assets bin config lib LICENSE.txt README.md`.split($RS)
```