### PR TITLE
Fix false positive in TrailingCommaIn{Arguments/Literal} cops with consistent_comma style

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## master (unreleased)
 
+### Bug fixes
+
+* Fix false positive in `Style/TrailingCommaInArguments` & `Style/TrailingCommaInLiteral` cops with consistent_comma style. ([@meganemura][])
+
 ## 0.37.2 (11/02/2016)
 
 ### Bug fixes

--- a/lib/rubocop/cop/mixin/trailing_comma.rb
+++ b/lib/rubocop/cop/mixin/trailing_comma.rb
@@ -87,13 +87,13 @@ module RuboCop
         # expression can not be multiline.
         return if !node.multiline? || elements.empty?
 
+        # If brackets are on different lines and there is one item at least,
+        # then comma is needed anytime for consistent_comma.
+        return true if style == :consistent_comma
+
         items = elements.map(&:source_range)
-        if style == :consistent_comma
-          items.one? || items.each_cons(2).any? { |a, b| !on_same_line?(a, b) }
-        else
-          items << node.loc.end
-          items.each_cons(2).all? { |a, b| !on_same_line?(a, b) }
-        end
+        items << node.loc.end
+        items.each_cons(2).all? { |a, b| !on_same_line?(a, b) }
       end
 
       def on_same_line?(a, b)

--- a/spec/rubocop/cop/style/trailing_comma_in_arguments_spec.rb
+++ b/spec/rubocop/cop/style/trailing_comma_in_arguments_spec.rb
@@ -233,10 +233,13 @@ describe RuboCop::Cop::Style::TrailingCommaInArguments, :config do
         expect(cop.highlights).to eq(['d: 1'])
       end
 
-      it 'accepts a method call with two parameters on the same line' do
+      it 'registers an offense for no trailing comma in a method call with' \
+          'two parameters on the same line' do
         inspect_source(cop, ['some_method(a, b',
                              '           )'])
-        expect(cop.offenses).to be_empty
+        expect(cop.messages)
+          .to eq(['Put a comma after the last parameter of a multiline ' \
+                  'method call.'])
       end
 
       it 'accepts trailing comma in a method call with hash' \
@@ -311,6 +314,14 @@ describe RuboCop::Cop::Style::TrailingCommaInArguments, :config do
       it 'accepts a multiline call with a single argument and trailing comma' do
         inspect_source(cop, ['method(',
                              '  1,',
+                             ')'])
+        expect(cop.offenses).to be_empty
+      end
+
+      it 'accepts a multiline call with arguments on a single line and' \
+         'trailing comma' do
+        inspect_source(cop, ['method(',
+                             '  1, 2,',
                              ')'])
         expect(cop.offenses).to be_empty
       end

--- a/spec/rubocop/cop/style/trailing_comma_in_literal_spec.rb
+++ b/spec/rubocop/cop/style/trailing_comma_in_literal_spec.rb
@@ -447,6 +447,22 @@ describe RuboCop::Cop::Style::TrailingCommaInLiteral, :config do
                              '}'])
         expect(cop.offenses).to be_empty
       end
+
+      it 'accepts a multiline array with items on a single line and' \
+         'trailing comma' do
+        inspect_source(cop, ['foo = [',
+                             '  1, 2,',
+                             ']'])
+        expect(cop.offenses).to be_empty
+      end
+
+      it 'accepts a multiline hash with pairs on a single line and' \
+         'trailing comma' do
+        inspect_source(cop, ['bar = {',
+                             '  a: 1001, b: 2020,',
+                             '}'])
+        expect(cop.offenses).to be_empty
+      end
     end
   end
 end


### PR DESCRIPTION
With consistent_comma style, TrailingComma cops detect avoid comma offenses for items on a single line inside brackets unless that are multi-line (open/close brackets are on different lines).

This patch fixes it.

code to reproduce: [test.rb](https://gist.github.com/meganemura/05665b14a47724e17ab7)

## before

```
$ rubocop test.rb
Inspecting 1 file
C

Offenses:

test.rb:16:7: C: Avoid comma after the last item of an array, unless items are split onto multiple lines.
  1, 2,
      ^
test.rb:33:7: C: Avoid comma after the last parameter of a method call, unless items are split onto multiple lines.
  1, 2,
      ^

1 file inspected, 2 offenses detected
```

## after

```
$ rubocop test.rb
Inspecting 1 file
C

Offenses:

test.rb:11:6: C: Put a comma after the last item of a multiline array.
  1, 2
     ^
test.rb:28:6: C: Put a comma after the last parameter of a multiline method call.
  1, 2
     ^

1 file inspected, 2 offenses detected
```

## version
using master(b94e357).
```
$ bundle exec rubocop -V
0.37.2 (using Parser 2.3.0.5, running on ruby 2.2.0 x86_64-darwin13)
```