### PR TITLE
Remove `LiteralInInterpolation` from `disabled.yml`

### DIFF
--- a/config/disabled.yml
+++ b/config/disabled.yml
@@ -123,7 +123,3 @@ Style/SymbolArray:
   Description: 'Use %i or %I for arrays of symbols.'
   StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#percent-i'
   Enabled: false
-
-Lint/LiteralInInterpolation:
-  Description: 'Avoid interpolating literals in strings'
-  AutoCorrect: false


### PR DESCRIPTION
It's also in `enabled.yml`, and the check ends up running.