### PR TITLE
[Fix #2832] Handle blocks in expressions in MultilineOperationIndentation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 
 * Fix false positive in `Style/TrailingCommaInArguments` & `Style/TrailingCommaInLiteral` cops with consistent_comma style. ([@meganemura][])
 * [#2861](https://github.com/bbatsov/rubocop/pull/2861): Fix false positive in `Style/SpaceAroundKeyword` for `rescue(...`. ([@rrosenblum][])
+* [#2832](https://github.com/bbatsov/rubocop/issues/2832): `Style/MultilineOperationIndentation` treats operations inside blocks inside other operations correctly. ([@jonas054][])
 
 ## 0.37.2 (11/02/2016)
 

--- a/lib/rubocop/cop/mixin/multiline_expression_indentation.rb
+++ b/lib/rubocop/cop/mixin/multiline_expression_indentation.rb
@@ -109,7 +109,11 @@ module RuboCop
       end
 
       def argument_in_method_call(node)
-        node.each_ancestor(:send).find do |a|
+        node.each_ancestor(:send, :block).find do |a|
+          # If the node is inside a block, it makes no difference if that block
+          # is an argument in a method call. It doesn't count.
+          break false if a.block_type?
+
           _, method_name, *args = *a
           next if assignment_call?(method_name)
           args.any? { |arg| within_node?(node, arg) }

--- a/spec/rubocop/cop/style/multiline_method_call_indentation_spec.rb
+++ b/spec/rubocop/cop/style/multiline_method_call_indentation_spec.rb
@@ -25,6 +25,19 @@ describe RuboCop::Cop::Style::MultilineMethodCallIndentation do
       expect(cop.offenses).to be_empty
     end
 
+    it 'accepts indented methods inside and outside a block' do
+      inspect_source(cop,
+                     ['a = b.map do |c|',
+                      '  c',
+                      '    .b',
+                      '    .d do',
+                      '      x',
+                      '        .y',
+                      '    end',
+                      'end'])
+      expect(cop.messages).to be_empty
+    end
+
     it 'accepts indentation relative to first receiver' do
       inspect_source(cop,
                      ['node',

--- a/spec/rubocop/cop/style/multiline_operation_indentation_spec.rb
+++ b/spec/rubocop/cop/style/multiline_operation_indentation_spec.rb
@@ -25,6 +25,19 @@ describe RuboCop::Cop::Style::MultilineOperationIndentation do
       expect(cop.messages).to be_empty
     end
 
+    it 'accepts indented operands inside and outside a block' do
+      inspect_source(cop,
+                     ['a = b.map do |c|',
+                      '  c +',
+                      '    b +',
+                      '    d do',
+                      '      x +',
+                      '        y',
+                      '    end',
+                      'end'])
+      expect(cop.messages).to be_empty
+    end
+
     it 'registers an offense for no indentation of second line' do
       inspect_source(cop,
                      ['a +',


### PR DESCRIPTION
Inside a block, we do normal indentation/alignment relative to the block, even if that block is part of some expression. Goes for `MultilineMethodCallIndentation` too.