### PR TITLE
[Fix #2679] Extend `MaxLineLength` to new cops

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### New features
 
 * `Style/UnlessElse` cop can auto-correct. ([@lumeet][])
+* [#2679](https://github.com/bbatsov/rubocop/issues/2679): Extend the `MaxLineLength` parameter to `Style/GuardClase` and `Style/ConditionalAssignment`. ([@TimMoore][])
 
 ### Bug fixes
 
@@ -2000,3 +2001,4 @@
 [@mmcguinn]: https://github.com/mmcguinn
 [@pocke]: https://github.com/pocke
 [@prsimp]: https://github.com/prsimp
+[@TimMoore]: https://github.com/TimMoore

--- a/config/default.yml
+++ b/config/default.yml
@@ -344,6 +344,9 @@ Style/CommentAnnotation:
     - HACK
     - REVIEW
 
+Style/ConditionalAssignment:
+  MaxLineLength: null
+
 # Checks that you have put a copyright in a comment before any code.
 #
 # You can override the default Notice in your .rubocop.yml file.
@@ -497,6 +500,7 @@ Style/GlobalVars:
 # `MinBodyLength` defines the number of lines of the a body of an if / unless
 # needs to have to trigger this cop
 Style/GuardClause:
+  MaxLineLength: null
   MinBodyLength: 1
 
 Style/HashSyntax:
@@ -509,7 +513,7 @@ Style/HashSyntax:
   UseHashRocketsWithSymbolValues: false
 
 Style/IfUnlessModifier:
-  MaxLineLength: 80
+  MaxLineLength: null
 
 Style/IndentationConsistency:
   # The difference between `rails` and `normal` is that the `rails` style
@@ -929,7 +933,7 @@ Style/VariableName:
     - camelCase
 
 Style/WhileUntilModifier:
-  MaxLineLength: 80
+  MaxLineLength: null
 
 Style/WordArray:
   EnforcedStyle: percent

--- a/lib/rubocop.rb
+++ b/lib/rubocop.rb
@@ -62,6 +62,7 @@ require 'rubocop/cop/mixin/first_element_line_break'
 require 'rubocop/cop/mixin/frozen_string_literal'
 require 'rubocop/cop/mixin/hash_node'
 require 'rubocop/cop/mixin/if_node'
+require 'rubocop/cop/mixin/max_line_length'
 require 'rubocop/cop/mixin/on_method_def'
 require 'rubocop/cop/mixin/method_complexity' # relies on on_method_def
 require 'rubocop/cop/mixin/method_preference'

--- a/lib/rubocop/cop/mixin/max_line_length.rb
+++ b/lib/rubocop/cop/mixin/max_line_length.rb
@@ -1,0 +1,17 @@
+# encoding: utf-8
+# frozen_string_literal: true
+
+module RuboCop
+  module Cop
+    # Common functionality for cops that need to check for long lines.
+    module MaxLineLength
+      LINE_LENGTH = 'Metrics/LineLength'.freeze
+      MAX = 'Max'.freeze
+      MAX_LINE_LENGTH = 'MaxLineLength'.freeze
+
+      def max_line_length
+        cop_config[MAX_LINE_LENGTH] || config.for_cop(LINE_LENGTH)[MAX]
+      end
+    end
+  end
+end

--- a/lib/rubocop/cop/mixin/statement_modifier.rb
+++ b/lib/rubocop/cop/mixin/statement_modifier.rb
@@ -6,6 +6,7 @@ module RuboCop
     # Common functionality for modifier cops.
     module StatementModifier
       include IfNode
+      include MaxLineLength
 
       def fit_within_line_as_modifier_form?(node)
         cond, body, _else = if_node_parts(node)
@@ -28,11 +29,6 @@ module RuboCop
                 cond_length
 
         total <= max_line_length
-      end
-
-      def max_line_length
-        cop_config['MaxLineLength'] ||
-          config.for_cop('Metrics/LineLength')['Max']
       end
 
       def length(node)

--- a/lib/rubocop/cop/style/conditional_assignment.rb
+++ b/lib/rubocop/cop/style/conditional_assignment.rb
@@ -148,6 +148,7 @@ module RuboCop
       class ConditionalAssignment < Cop
         include IfNode
         include ConditionalAssignmentHelper
+        include MaxLineLength
 
         MSG = 'Use the return of the conditional for variable assignment ' \
               'and comparison.'.freeze
@@ -157,10 +158,7 @@ module RuboCop
           VARIABLE_ASSIGNMENT_TYPES + [:and_asgn, :or_asgn, :op_asgn].freeze
         IF = 'if'.freeze
         UNLESS = 'unless'.freeze
-        LINE_LENGTH = 'Metrics/LineLength'.freeze
         INDENTATION_WIDTH = 'Style/IndentationWidth'.freeze
-        ENABLED = 'Enabled'.freeze
-        MAX = 'Max'.freeze
         SINGLE_LINE_CONDITIONS_ONLY = 'SingleLineConditionsOnly'.freeze
         WIDTH = 'Width'.freeze
         METHODS = [:[]=, :<<, :=~, :!~, :<=>].freeze
@@ -242,7 +240,8 @@ module RuboCop
           add_offense(node, :expression)
         end
 
-        # If `Metrics/LineLength` is enabled, we do not want to introduce an
+        # If the `MaxLineLength` configuration is specified, or
+        # `Metrics/LineLength` is enabled, we do not want to introduce an
         # offense by auto-correcting this cop. Find the max configured line
         # length. Find the longest line of condition. Remove the assignment
         # from lines that contain the offending assignment because after
@@ -250,10 +249,8 @@ module RuboCop
         # of the longest line + the length of the corrected assignment is
         # greater than the max configured line length
         def correction_exceeds_line_limit?(node, branches)
-          return false unless config.for_cop(LINE_LENGTH)[ENABLED]
           assignment = lhs(tail(branches[0]))
           assignment_regex = /#{assignment.gsub(' ', '\s*')}/
-          max_line_length = config.for_cop(LINE_LENGTH)[MAX]
           indentation_width = config.for_cop(INDENTATION_WIDTH)[WIDTH] || 2
           return true if longest_rhs(branches) + indentation_width +
                          assignment.length > max_line_length

--- a/lib/rubocop/cop/style/guard_clause.rb
+++ b/lib/rubocop/cop/style/guard_clause.rb
@@ -39,6 +39,7 @@ module RuboCop
       class GuardClause < Cop
         include ConfigurableEnforcedStyle
         include IfNode
+        include MaxLineLength
         include MinBodyLength
 
         MSG = 'Use a guard clause instead of wrapping the code inside a ' \
@@ -112,11 +113,14 @@ module RuboCop
         end
 
         def line_too_long?(node, body, keyword, condition)
-          max    = config.for_cop('Metrics/LineLength')['Max'] || 80
+          return false unless max_line_length
+
           indent = node.loc.column
           source = body && body.source || ''
+          correction = (source + keyword + condition.source)
           # 2 is for spaces on left and right of keyword
-          indent + (source + keyword + condition.source).length + 2 > max
+          line_length = indent + correction.length + 2
+          line_length > max_line_length
         end
       end
     end

--- a/spec/rubocop/cop/style/conditional_assignment_spec.rb
+++ b/spec/rubocop/cop/style/conditional_assignment_spec.rb
@@ -357,7 +357,7 @@ describe RuboCop::Cop::Style::ConditionalAssignment do
     expect(cop.offenses).to be_empty
   end
 
-  context 'correction would exceed max line length' do
+  shared_examples 'correction would exceed max line length' do
     it 'allows assignment to the same variable in if else if the correction ' \
        'would create a line longer than the configured LineLength' do
       source = ['if foo',
@@ -399,6 +399,20 @@ describe RuboCop::Cop::Style::ConditionalAssignment do
 
       expect(cop.offenses).to be_empty
     end
+  end
+
+  it_behaves_like('correction would exceed max line length')
+
+  context 'when the maximum line length is specified by the cop itself' do
+    let(:config) do
+      hash = {
+        'Metrics/LineLength' => { 'Max' => 100 },
+        'Style/ConditionalAssignment' => { 'MaxLineLength' => 80 }
+      }
+      RuboCop::Config.new(hash)
+    end
+
+    it_behaves_like('correction would exceed max line length')
   end
 
   shared_examples 'all variable types' do |variable|

--- a/spec/rubocop/cop/style/guard_clause_spec.rb
+++ b/spec/rubocop/cop/style/guard_clause_spec.rb
@@ -77,22 +77,47 @@ describe RuboCop::Cop::Style::GuardClause, :config do
   it_behaves_like('reports offense', 'work')
   it_behaves_like('reports offense', '# TODO')
 
-  it 'does not report an offense if corrected code would exceed line length' do
-    inspect_source(cop,
-                   ['def func',
-                    '  test',
-                    '  if something_quite_long_right_here_is_that_ok?',
-                    '    do_this_and_that_and_the_other_thing!',
-                    '  end',
-                    'end',
-                    '',
-                    'def func',
-                    '  test',
-                    '  unless something_quite_long_right_here_is_that_ok?',
-                    '    do_this_and_that_and_the_other_thing!',
-                    '  end',
-                    'end'])
-    expect(cop.offenses).to be_empty
+  shared_examples 'correction would exceed max line length' do
+    it 'does not report an offense' do
+      inspect_source(cop,
+                     ['def func',
+                      '  test',
+                      '  if something_quite_long_right_here_is_that_ok?',
+                      '    do_this_and_that_and_the_other_thing!',
+                      '  end',
+                      'end',
+                      '',
+                      'def func',
+                      '  test',
+                      '  unless something_quite_long_right_here_is_that_ok?',
+                      '    do_this_and_that_and_the_other_thing!',
+                      '  end',
+                      'end'])
+      expect(cop.offenses).to be_empty
+    end
+  end
+
+  context 'when the Metrics/LineLength cop has a max' do
+    let(:config) do
+      hash = {
+        'Metrics/LineLength' => { 'Max' => 80 }
+      }
+      RuboCop::Config.new(hash)
+    end
+
+    it_behaves_like('correction would exceed max line length')
+  end
+
+  context 'when the maximum line length is specified by the cop itself' do
+    let(:config) do
+      hash = {
+        'Metrics/LineLength' => { 'Max' => 100 },
+        'Style/GuardClause' => { 'MaxLineLength' => 80 }
+      }
+      RuboCop::Config.new(hash)
+    end
+
+    it_behaves_like('correction would exceed max line length')
   end
 
   it 'does not report an offense if body is if..elsif..end' do


### PR DESCRIPTION
- Add to `ConditionalAssignment`
- Add to `GuardClause`
- Extract `max_line_length` to a mixin

Fixes #2679