### PR TITLE
Make cops with Rails compatibility issue dependant on Rails cops being disabled

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 * `Performance/TimesMap` cop can auto-correct. ([@lumeet][])
 * `Style/ZeroLengthPredicate` cop can auto-correct. ([@lumeet][])
 * [#2828](https://github.com/bbatsov/rubocop/issues/2828): `Style/ConditionalAssignment` is now configurable to enforce assignment inside of conditions or to enforce assignment to conditions. ([@rrosenblum][])
+* [#2862](https://github.com/bbatsov/rubocop/pull/2862): `Performance/Detect` and `Performance/Count` have a new configuration `SafeMode` that is defaulted to `true`. These cops have known issues with `Rails` and other ORM frameworks. With this default configuration, these cops will not run if the `Rails` cops are enabled. ([@rrosenblum][])
 
 ### Bug fixes
 

--- a/config/enabled.yml
+++ b/config/enabled.yml
@@ -1170,6 +1170,11 @@ Performance/Count:
                   Use `count` instead of `select...size`, `reject...size`,
                   `select...count`, `reject...count`, `select...length`,
                   and `reject...length`.
+  # This cop has known compatibility issues with `ActiveRecord` and other
+  # frameworks. ActiveRecord's `count` ignores the block that is passed to it.
+  # For more information, see the documentation in the cop itself.
+  # If you understand the known risk, you can disable `SafeMode`.
+  SafeMode: true
   Enabled: true
 
 Performance/Detect:
@@ -1177,6 +1182,11 @@ Performance/Detect:
                   Use `detect` instead of `select.first`, `find_all.first`,
                   `select.last`, and `find_all.last`.
   Reference: 'https://github.com/JuanitoFatas/fast-ruby#enumerabledetect-vs-enumerableselectfirst-code'
+  # This cop has known compatibility issues with `ActiveRecord` and other
+  # frameworks. `ActiveRecord` does not implement a `detect` method and `find`
+  # has its own meaning. Correcting `ActiveRecord` methods with this cop
+  # should be considered unsafe.
+  SafeMode: true
   Enabled: true
 
 Performance/DoubleStartEndWith:

--- a/lib/rubocop/cop/performance/count.rb
+++ b/lib/rubocop/cop/performance/count.rb
@@ -25,6 +25,19 @@ module RuboCop
       #   [1, 2, 3].count { |e| e < 2 && e.even? }
       #   Model.select('field AS field_one').count
       #   Model.select(:value).count
+      #
+      # `ActiveRecord` compatibility:
+      # `ActiveRecord` will ignore the block that is passed to `count`.
+      # Other methods, such as `select`, will convert the association to an
+      # array and then run the block on the array. A simple work around to
+      # make `count` work with a block is to call `to_a.count {...}`.
+      #
+      # Example:
+      #   Model.where(id: [1, 2, 3].select { |m| m.method == true }.size
+      #
+      #   becomes:
+      #
+      #   Model.where(id: [1, 2, 3]).to_a.count { |m| m.method == true }
       class Count < Cop
         MSG = 'Use `count` instead of `%s...%s`.'.freeze
 
@@ -32,6 +45,7 @@ module RuboCop
         COUNTERS = [:count, :length, :size].freeze
 
         def on_send(node)
+          return unless should_run?
           selector, selector_loc, params, counter = parse(node)
           return unless COUNTERS.include?(counter)
           return unless SELECTORS.include?(selector)
@@ -61,6 +75,12 @@ module RuboCop
         end
 
         private
+
+        def should_run?
+          !(cop_config['SafeMode'.freeze] ||
+            config['Rails'.freeze] &&
+            config['Rails'.freeze]['Enabled'.freeze])
+        end
 
         def parse(node)
           left, counter = *node

--- a/spec/rubocop/cop/performance/count_spec.rb
+++ b/spec/rubocop/cop/performance/count_spec.rb
@@ -296,4 +296,30 @@ describe RuboCop::Cop::Performance::Count do
       end
     end
   end
+
+  context 'SafeMode true' do
+    subject(:cop) { described_class.new(config) }
+
+    let(:config) do
+      RuboCop::Config.new(
+        'Rails' => {
+          'Enabled' => true
+        },
+        'Performance/Count' => {
+          'SafeMode' => true
+        }
+      )
+    end
+
+    shared_examples 'selectors' do |selector|
+      it "allows using array.#{selector}...size" do
+        inspect_source(cop, "[1, 2, 3].#{selector} { |e| e.even? }.size")
+
+        expect(cop.offenses).to be_empty
+      end
+    end
+
+    it_behaves_like('selectors', 'select')
+    it_behaves_like('selectors', 'reject')
+  end
 end

--- a/spec/rubocop/cop/performance/detect_spec.rb
+++ b/spec/rubocop/cop/performance/detect_spec.rb
@@ -10,12 +10,11 @@ describe RuboCop::Cop::Performance::Detect do
 
   let(:config) do
     RuboCop::Config.new(
-      'Style/CollectionMethods' =>
-        {
-          'PreferredMethods' => {
-            'detect' => collection_method
-          }
+      'Style/CollectionMethods' => {
+        'PreferredMethods' => {
+          'detect' => collection_method
         }
+      }
     )
   end
 
@@ -231,5 +230,31 @@ describe RuboCop::Cop::Performance::Detect do
 
     it_behaves_like 'detect_autocorrect', 'detect'
     it_behaves_like 'detect_autocorrect', 'find'
+  end
+
+  context 'SafeMode true' do
+    let(:config) do
+      RuboCop::Config.new(
+        'Rails' => {
+          'Enabled' => true
+        },
+        'Style/CollectionMethods' => {
+          'PreferredMethods' => {
+            'detect' => collection_method
+          }
+        },
+        'Performance/Detect' => {
+          'SafeMode' => true
+        }
+      )
+    end
+
+    described_class::SELECT_METHODS.each do |method|
+      it "doesn't register an offense when first is called on #{method}" do
+        inspect_source(cop, "[1, 2, 3].#{method} { |i| i % 2 == 0 }.first")
+
+        expect(cop.offenses).to be_empty
+      end
+    end
   end
 end


### PR DESCRIPTION
It has been a while since this has come up, but it is still a known issue. Since we cannot determine if the method comes from Ruby or Rails, the next best thing is to determine if Rails is going to be in used and not run these cops if it is. Short of scanning the Gemfile for a rails entry, this seemed like the easiest and most self contained approach. If anyone has an alternative idea, I am open to suggestions.