### PR TITLE
Style/TrivialAccessor allows predicate methods by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@
 * [#2852](https://github.com/bbatsov/rubocop/issues/2852): `Performance/Casecmp` doesn't flag uses of `downcase`/`upcase` which are not redundant. ([@alexdowad][])
 * [#2850](https://github.com/bbatsov/rubocop/issues/2850): `Style/FileName` doesn't choke on empty files with spaces in their names. ([@alexdowad][])
 * [#2834](https://github.com/bbatsov/rubocop/issues/2834): When configured as `ConsistentQuotesInMultiline: true`, `Style/StringLiterals` doesn't error out when inspecting a heredoc with differing indentation across multiple lines. ([@alexdowad][])
+* [#2876](https://github.com/bbatsov/rubocop/issues/2876): `Style/ConditionalAssignment` behaves correctly when assignment statement uses a character which has a special meaning in a regex. ([@alexdowad][])
 
 ## 0.37.2 (11/02/2016)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 * [#2865](https://github.com/bbatsov/rubocop/issues/2865): Change `require:` in config to be relative to the `.rubocop.yml` file itself. ([@ptarjan][])
 * [#2845](https://github.com/bbatsov/rubocop/issues/2845): Handle heredocs in `Style/MultilineLiteralBraceLayout` auto-correct. ([@jonas054][])
 * [#2848](https://github.com/bbatsov/rubocop/issues/2848): Handle comments inside arrays in `Style/MultilineArrayBraceLayout` auto-correct. ([@jonas054][])
+* `Style/TrivialAccessors` allows predicate methods by default. ([@alexdowad][])
 
 ## 0.37.2 (11/02/2016)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@
 * [#2870](https://github.com/bbatsov/rubocop/issues/2870): `Lint/UselessAccessModifier` recognizes method definitions which are passed as an argument to a method call. ([@alexdowad][])
 * [#2859](https://github.com/bbatsov/rubocop/issues/2859): `Style/RedundantParentheses` doesn't consider the parentheses in `(!receiver.method arg)` to be redundant, since they might change the meaning of an expression, depending on precedence. ([@alexdowad][])
 * [#2852](https://github.com/bbatsov/rubocop/issues/2852): `Performance/Casecmp` doesn't flag uses of `downcase`/`upcase` which are not redundant. ([@alexdowad][])
+* [#2850](https://github.com/bbatsov/rubocop/issues/2850): `Style/FileName` doesn't choke on empty files with spaces in their names. ([@alexdowad][])
 
 ## 0.37.2 (11/02/2016)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@
 * [#2850](https://github.com/bbatsov/rubocop/issues/2850): `Style/FileName` doesn't choke on empty files with spaces in their names. ([@alexdowad][])
 * [#2834](https://github.com/bbatsov/rubocop/issues/2834): When configured as `ConsistentQuotesInMultiline: true`, `Style/StringLiterals` doesn't error out when inspecting a heredoc with differing indentation across multiple lines. ([@alexdowad][])
 * [#2876](https://github.com/bbatsov/rubocop/issues/2876): `Style/ConditionalAssignment` behaves correctly when assignment statement uses a character which has a special meaning in a regex. ([@alexdowad][])
+* [#2877](https://github.com/bbatsov/rubocop/issues/2877): `Style/SpaceAroundKeyword` doesn't flag `!super.method`, `!yield.method`, and so on. ([@alexdowad][])
 
 ## 0.37.2 (11/02/2016)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@
 * [#2869](https://github.com/bbatsov/rubocop/issues/2869): Offenses which occur in the body of a `when` clause with multiple arguments will not be missed. ([@alexdowad][])
 * `Lint/UselessAccessModifier` recognizes method defs inside a `begin` block. ([@alexdowad][])
 * [#2870](https://github.com/bbatsov/rubocop/issues/2870): `Lint/UselessAccessModifier` recognizes method definitions which are passed as an argument to a method call. ([@alexdowad][])
+* [#2859](https://github.com/bbatsov/rubocop/issues/2859): `Style/RedundantParentheses` doesn't consider the parentheses in `(!receiver.method arg)` to be redundant, since they might change the meaning of an expression, depending on precedence. ([@alexdowad][])
 
 ## 0.37.2 (11/02/2016)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@
 * `Style/TrivialAccessors` allows predicate methods by default. ([@alexdowad][])
 * [#2869](https://github.com/bbatsov/rubocop/issues/2869): Offenses which occur in the body of a `when` clause with multiple arguments will not be missed. ([@alexdowad][])
 * `Lint/UselessAccessModifier` recognizes method defs inside a `begin` block. ([@alexdowad][])
+* [#2870](https://github.com/bbatsov/rubocop/issues/2870): `Lint/UselessAccessModifier` recognizes method definitions which are passed as an argument to a method call. ([@alexdowad][])
 
 ## 0.37.2 (11/02/2016)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@
 * [#2859](https://github.com/bbatsov/rubocop/issues/2859): `Style/RedundantParentheses` doesn't consider the parentheses in `(!receiver.method arg)` to be redundant, since they might change the meaning of an expression, depending on precedence. ([@alexdowad][])
 * [#2852](https://github.com/bbatsov/rubocop/issues/2852): `Performance/Casecmp` doesn't flag uses of `downcase`/`upcase` which are not redundant. ([@alexdowad][])
 * [#2850](https://github.com/bbatsov/rubocop/issues/2850): `Style/FileName` doesn't choke on empty files with spaces in their names. ([@alexdowad][])
+* [#2834](https://github.com/bbatsov/rubocop/issues/2834): When configured as `ConsistentQuotesInMultiline: true`, `Style/StringLiterals` doesn't error out when inspecting a heredoc with differing indentation across multiple lines. ([@alexdowad][])
 
 ## 0.37.2 (11/02/2016)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
 * [#2848](https://github.com/bbatsov/rubocop/issues/2848): Handle comments inside arrays in `Style/MultilineArrayBraceLayout` auto-correct. ([@jonas054][])
 * `Style/TrivialAccessors` allows predicate methods by default. ([@alexdowad][])
 * [#2869](https://github.com/bbatsov/rubocop/issues/2869): Offenses which occur in the body of a `when` clause with multiple arguments will not be missed. ([@alexdowad][])
+* `Lint/UselessAccessModifier` recognizes method defs inside a `begin` block. ([@alexdowad][])
 
 ## 0.37.2 (11/02/2016)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@
 * `Lint/UselessAccessModifier` recognizes method defs inside a `begin` block. ([@alexdowad][])
 * [#2870](https://github.com/bbatsov/rubocop/issues/2870): `Lint/UselessAccessModifier` recognizes method definitions which are passed as an argument to a method call. ([@alexdowad][])
 * [#2859](https://github.com/bbatsov/rubocop/issues/2859): `Style/RedundantParentheses` doesn't consider the parentheses in `(!receiver.method arg)` to be redundant, since they might change the meaning of an expression, depending on precedence. ([@alexdowad][])
+* [#2852](https://github.com/bbatsov/rubocop/issues/2852): `Performance/Casecmp` doesn't flag uses of `downcase`/`upcase` which are not redundant. ([@alexdowad][])
 
 ## 0.37.2 (11/02/2016)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 * [#2845](https://github.com/bbatsov/rubocop/issues/2845): Handle heredocs in `Style/MultilineLiteralBraceLayout` auto-correct. ([@jonas054][])
 * [#2848](https://github.com/bbatsov/rubocop/issues/2848): Handle comments inside arrays in `Style/MultilineArrayBraceLayout` auto-correct. ([@jonas054][])
 * `Style/TrivialAccessors` allows predicate methods by default. ([@alexdowad][])
+* [#2869](https://github.com/bbatsov/rubocop/issues/2869): Offenses which occur in the body of a `when` clause with multiple arguments will not be missed. ([@alexdowad][])
 
 ## 0.37.2 (11/02/2016)
 

--- a/config/default.yml
+++ b/config/default.yml
@@ -892,7 +892,7 @@ Style/TrivialAccessors:
   #
   # This way you can uncover "hidden" attributes in your code.
   ExactNameMatch: true
-  AllowPredicates: false
+  AllowPredicates: true
   # Allows trivial writers that don't end in an equal sign. e.g.
   #
   # def on_exception(action)

--- a/lib/rubocop/ast_node/traversal.rb
+++ b/lib/rubocop/ast_node/traversal.rb
@@ -143,7 +143,6 @@ module RuboCop
       end
 
       alias on_until  on_while
-      alias on_when   on_while
       alias on_module on_while
       alias on_sclass on_while
 
@@ -167,6 +166,7 @@ module RuboCop
       alias on_resbody on_case
       alias on_ensure  on_case
       alias on_for     on_case
+      alias on_when    on_case
     end
   end
 end

--- a/lib/rubocop/cop/lint/useless_access_modifier.rb
+++ b/lib/rubocop/cop/lint/useless_access_modifier.rb
@@ -71,13 +71,13 @@ module RuboCop
             elsif method_definition?(child)
               unused = nil
             elsif child.kwbegin_type?
-              cur_vis = check_scope(child, cur_vis)
+              cur_vis, unused = check_scope(child, cur_vis)
             end
           end
 
           add_offense(unused, :expression, format(MSG, cur_vis)) if unused
 
-          cur_vis
+          [cur_vis, unused]
         end
       end
     end

--- a/lib/rubocop/cop/lint/useless_access_modifier.rb
+++ b/lib/rubocop/cop/lint/useless_access_modifier.rb
@@ -55,7 +55,7 @@ module RuboCop
         def check_scope(node, cur_vis = :public)
           unused = nil
 
-          node.children.each do |child|
+          node.child_nodes.each do |child|
             if (new_vis = access_modifier(child))
               # does this modifier just repeat the existing visibility?
               if new_vis == cur_vis
@@ -70,7 +70,7 @@ module RuboCop
               cur_vis = new_vis
             elsif method_definition?(child)
               unused = nil
-            elsif child.kwbegin_type?
+            elsif child.kwbegin_type? || child.send_type?
               cur_vis, unused = check_scope(child, cur_vis)
             end
           end

--- a/lib/rubocop/cop/performance/casecmp.rb
+++ b/lib/rubocop/cop/performance/casecmp.rb
@@ -9,26 +9,31 @@ module RuboCop
       #
       # @example
       #   @bad
-      #   'aBc'.downcase == 'abc'
-      #   'abc'.upcase.eql? 'ABC'
-      #   'abc' == 'ABC'.downcase
-      #   'ABC'.eql? 'abc'.upcase
-      #   'abc'.downcase == 'abc'.downcase
+      #   str.downcase == 'abc'
+      #   str.upcase.eql? 'ABC'
+      #   'abc' == str.downcase
+      #   'ABC'.eql? str.upcase
+      #   str.downcase == str.downcase
       #
       #   @good
-      #   'aBc'.casecmp('ABC').zero?
-      #   'abc'.casecmp('abc').zero?
-      #   'abc'.casecmp('ABC'.downcase).zero?
+      #   str.casecmp('ABC').zero?
+      #   'abc'.casecmp(str).zero?
       class Casecmp < Cop
         MSG = 'Use `casecmp` instead of `%s %s`.'.freeze
         CASE_METHODS = [:downcase, :upcase].freeze
 
         def_node_matcher :downcase_eq, <<-END
-          (send $(send _ ${:downcase :upcase}) ${:== :eql? :!=} $_)
+          (send
+            $(send _ ${:downcase :upcase})
+            ${:== :eql? :!=}
+            ${str (send _ {:downcase :upcase} ...) (begin str)})
         END
 
         def_node_matcher :eq_downcase, <<-END
-          (send _ ${:== :eql? :!=} $(send _ ${:downcase :upcase}))
+          (send
+            {str (send _ {:downcase :upcase} ...) (begin str)}
+            ${:== :eql? :!=}
+            $(send _ ${:downcase :upcase}))
         END
 
         def on_send(node)

--- a/lib/rubocop/cop/style/conditional_assignment.rb
+++ b/lib/rubocop/cop/style/conditional_assignment.rb
@@ -252,7 +252,7 @@ module RuboCop
         def correction_exceeds_line_limit?(node, branches)
           return false unless config.for_cop(LINE_LENGTH)[ENABLED]
           assignment = lhs(tail(branches[0]))
-          assignment_regex = /#{assignment.gsub(' ', '\s*')}/
+          assignment_regex = /#{Regexp.escape(assignment).gsub(' ', '\s*')}/
           max_line_length = config.for_cop(LINE_LENGTH)[MAX]
           indentation_width = config.for_cop(INDENTATION_WIDTH)[WIDTH] || 2
           return true if longest_rhs(branches) + indentation_width +

--- a/lib/rubocop/cop/style/file_name.rb
+++ b/lib/rubocop/cop/style/file_name.rb
@@ -49,7 +49,7 @@ module RuboCop
         end
 
         def shebang?(line)
-          line.start_with?('#!')
+          line && line.start_with?('#!')
         end
 
         def expect_matching_definition?

--- a/lib/rubocop/cop/style/method_def_parentheses.rb
+++ b/lib/rubocop/cop/style/method_def_parentheses.rb
@@ -71,10 +71,6 @@ module RuboCop
         def arguments?(args)
           !args.children.empty?
         end
-
-        def parentheses?(args)
-          args.loc.begin
-        end
       end
     end
   end

--- a/lib/rubocop/cop/style/redundant_parentheses.rb
+++ b/lib/rubocop/cop/style/redundant_parentheses.rb
@@ -58,7 +58,15 @@ module RuboCop
 
         def check_send(begin_node, node)
           if node.unary_operation?
-            offense(begin_node, 'an unary operation') unless begin_node.chained?
+            return if begin_node.chained?
+
+            # parens are not redundant in `(!recv.method arg)`
+            node = node.children.first while node.unary_operation?
+            if node.send_type?
+              return unless method_call_with_redundant_parentheses?(node)
+            end
+
+            offense(begin_node, 'an unary operation')
           else
             return unless method_call_with_redundant_parentheses?(node)
             offense(begin_node, 'a method call')

--- a/lib/rubocop/cop/style/string_literals.rb
+++ b/lib/rubocop/cop/style/string_literals.rb
@@ -17,6 +17,7 @@ module RuboCop
           # If one part of that continued string contains interpolations,
           # then it will be parsed as a nested `dstr` node
           return unless consistent_multiline?
+          return if node.loc.is_a?(Parser::Source::Map::Heredoc)
 
           children = node.children
           return unless children.all? { |c| c.str_type? || c.dstr_type? }

--- a/lib/rubocop/formatter/clang_style_formatter.rb
+++ b/lib/rubocop/formatter/clang_style_formatter.rb
@@ -13,11 +13,17 @@ module RuboCop
                         cyan(smart_path(file)), o.line, o.real_column,
                         colored_severity_code(o), message(o))
 
-          source_line = o.location.source_line
-          next if source_line.blank?
+          # rubocop:disable Lint/HandleExceptions
+          begin
+            source_line = o.location.source_line
+            next if source_line.blank?
 
-          output.puts(source_line)
-          output.puts(highlight_line(o.location))
+            output.puts(source_line)
+            output.puts(highlight_line(o.location))
+          rescue IndexError
+            # range is not on a valid line; perhaps the source file is empty
+          end
+          # rubocop:enable Lint/HandleExceptions
         end
       end
 

--- a/spec/rubocop/cop/lint/useless_access_modifier_spec.rb
+++ b/spec/rubocop/cop/lint/useless_access_modifier_spec.rb
@@ -318,6 +318,20 @@ describe RuboCop::Cop::Lint::UselessAccessModifier do
       inspect_source(cop, src)
       expect(cop.offenses.size).to eq(1)
     end
+
+    unless modifier == 'public'
+      it "doesn't flag an access modifier from surrounding scope" do
+        src = ["#{keyword} A",
+               "  #{modifier}",
+               '  begin',
+               '    def method1',
+               '    end',
+               '  end',
+               'end']
+        inspect_source(cop, src)
+        expect(cop.offenses).to be_empty
+      end
+    end
   end
 
   shared_examples 'unused visibility modifiers' do |keyword|

--- a/spec/rubocop/cop/lint/useless_access_modifier_spec.rb
+++ b/spec/rubocop/cop/lint/useless_access_modifier_spec.rb
@@ -200,6 +200,24 @@ describe RuboCop::Cop::Lint::UselessAccessModifier do
     end
   end
 
+  context 'when a def is an argument to a method call' do
+    let(:source) do
+      [
+        'class SomeClass',
+        '  private',
+        '  helper_method def some_method',
+        '    puts 10',
+        '  end',
+        'end'
+      ]
+    end
+
+    it 'does not register an offense' do
+      inspect_source(cop, source)
+      expect(cop.offenses).to be_empty
+    end
+  end
+
   shared_examples 'at the top of the body' do |keyword|
     it 'registers an offense for `public`' do
       src = ["#{keyword} A",

--- a/spec/rubocop/cop/performance/casecmp_spec.rb
+++ b/spec/rubocop/cop/performance/casecmp_spec.rb
@@ -42,37 +42,6 @@ describe RuboCop::Cop::Performance::Casecmp do
       expect(new_source).to eq "str.casecmp( 'string' ).zero?"
     end
 
-    it "autocorrects str.#{selector} == a variable" do
-      new_source = autocorrect_source(cop, ['other = "a"',
-                                            "str.#{selector} == other"])
-      expect(new_source).to eq(['other = "a"',
-                                'str.casecmp(other).zero?'].join("\n"))
-    end
-
-    it "autocorrects str.#{selector} == a method" do
-      new_source = autocorrect_source(cop, "str.#{selector} == method(foo)")
-      expect(new_source).to eq('str.casecmp(method(foo)).zero?')
-    end
-
-    it "autocorrects str.#{selector} == a method call on a variable" do
-      new_source = autocorrect_source(cop, "str.#{selector} == other.join")
-      expect(new_source).to eq('str.casecmp(other.join).zero?')
-    end
-
-    it "autocorrects str.#{selector} == a method call on a variable " \
-       'with params' do
-      new_source = autocorrect_source(cop,
-                                      "str.#{selector} == other.join(', ')")
-      expect(new_source).to eq("str.casecmp(other.join(', ')).zero?")
-    end
-
-    it "autocorrects str.#{selector} == a method call on a variable " \
-       'with a block' do
-      source = "str.#{selector} == other.method { |o| o.to_s }"
-      new_source = autocorrect_source(cop, source)
-      expect(new_source).to eq('str.casecmp(other.method { |o| o.to_s }).zero?')
-    end
-
     it "autocorrects == str.#{selector}" do
       new_source = autocorrect_source(cop, "'string' == str.#{selector}")
       expect(new_source).to eq "str.casecmp('string').zero?"
@@ -94,23 +63,6 @@ describe RuboCop::Cop::Performance::Casecmp do
       expect(new_source).to eq "str.casecmp( 'string' ).zero?"
     end
 
-    it "autocorrects a method call == str.#{selector}" do
-      new_source = autocorrect_source(cop, "other.join == str.#{selector}")
-      expect(new_source).to eq('str.casecmp(other.join).zero?')
-    end
-
-    it "autocorrects a method call with params == str.#{selector}" do
-      new_source = autocorrect_source(cop,
-                                      "other.join(', ') == str.#{selector}")
-      expect(new_source).to eq("str.casecmp(other.join(', ')).zero?")
-    end
-
-    it "autocorrects a method call with a block == str.#{selector}" do
-      source = "other.method { |o| o.to_s } == str.#{selector}"
-      new_source = autocorrect_source(cop, source)
-      expect(new_source).to eq('str.casecmp(other.method { |o| o.to_s }).zero?')
-    end
-
     it "autocorrects string.eql? str.#{selector} without parens " do
       new_source = autocorrect_source(cop, "'string'.eql? str.#{selector}")
       expect(new_source).to eq "str.casecmp('string').zero?"
@@ -119,13 +71,6 @@ describe RuboCop::Cop::Performance::Casecmp do
     it "autocorrects string.eql? str.#{selector} with parens " do
       new_source = autocorrect_source(cop, "'string'.eql?(str.#{selector})")
       expect(new_source).to eq "str.casecmp('string').zero?"
-    end
-
-    it "autocorrects variable == str.#{selector}" do
-      new_source = autocorrect_source(cop, ['other = "a"',
-                                            "other == str.#{selector}"])
-      expect(new_source).to eq(['other = "a"',
-                                'str.casecmp(other).zero?'].join("\n"))
     end
 
     it "autocorrects obj.#{selector} == str.#{selector}" do
@@ -156,6 +101,28 @@ describe RuboCop::Cop::Performance::Casecmp do
       inspect_source(cop, "obj.#{selector} == str.#{selector}")
       expect(cop.highlights).to eq(["obj.#{selector} == str.#{selector}"])
       expect(cop.messages).to eq(["Use `casecmp` instead of `#{selector} ==`."])
+    end
+
+    it "doesn't report an offense for variable == str.#{selector}" do
+      inspect_source(cop, ['var = "a"',
+                           "var == str.#{selector}"])
+      expect(cop.offenses).to be_empty
+    end
+
+    it "doesn't report an offense for str.#{selector} == variable" do
+      inspect_source(cop, ['var = "a"',
+                           "str.#{selector} == var"])
+      expect(cop.offenses).to be_empty
+    end
+
+    it "doesn't report an offense for obj.method == str.#{selector}" do
+      inspect_source(cop, "obj.method == str.#{selector}")
+      expect(cop.offenses).to be_empty
+    end
+
+    it "doesn't report an offense for str.#{selector} == obj.method" do
+      inspect_source(cop, "str.#{selector} == obj.method")
+      expect(cop.offenses).to be_empty
     end
   end
 

--- a/spec/rubocop/cop/style/conditional_assignment_spec.rb
+++ b/spec/rubocop/cop/style/conditional_assignment_spec.rb
@@ -99,6 +99,20 @@ describe RuboCop::Cop::Style::ConditionalAssignment do
     expect(cop.offenses).to be_empty
   end
 
+  it "doesn't crash when assignment statement uses chars which have " \
+     'special meaning in a regex' do
+    # regression test; see GH issue 2876
+    source = ['if condition',
+              "  default['key-with-dash'] << a",
+              'else',
+              "  default['key-with-dash'] << b",
+              'end']
+
+    inspect_source(cop, source)
+
+    expect(cop.offenses.size).to eq(1)
+  end
+
   shared_examples 'comparison methods' do |method|
     it 'registers an offense for comparison methods in if else' do
       source = ['if foo',

--- a/spec/rubocop/cop/style/conditional_assignment_spec.rb
+++ b/spec/rubocop/cop/style/conditional_assignment_spec.rb
@@ -1405,52 +1405,52 @@ describe RuboCop::Cop::Style::ConditionalAssignment do
           expect(cop.offenses).to be_empty
         end
       end
+    end
 
-      context 'self.attribute= assignment' do
-        it 'corrects if..else' do
-          new_source = autocorrect_source(cop, ['if something',
-                                                '  self.attribute = 1',
-                                                'else',
-                                                '  self.attribute = 2',
-                                                'end'])
-          expect(new_source).to eq(['self.attribute = if something',
-                                    '  1',
-                                    'else',
-                                    '  2',
-                                    '                 end'].join("\n"))
-        end
-
-        context 'with different receivers' do
-          it "doesn't register an offense" do
-            inspect_source(cop, ['if something',
-                                 '  obj1.attribute = 1',
-                                 'else',
-                                 '  obj2.attribute = 2',
-                                 'end'])
-            expect(cop.offenses).to be_empty
-          end
-        end
+    context 'self.attribute= assignment' do
+      it 'corrects if..else' do
+        new_source = autocorrect_source(cop, ['if something',
+                                              '  self.attribute = 1',
+                                              'else',
+                                              '  self.attribute = 2',
+                                              'end'])
+        expect(new_source).to eq(['self.attribute = if something',
+                                  '  1',
+                                  'else',
+                                  '  2',
+                                  '                 end'].join("\n"))
       end
 
-      context 'multiple assignment' do
-        it 'does not register an offense in if else' do
+      context 'with different receivers' do
+        it "doesn't register an offense" do
           inspect_source(cop, ['if something',
-                               '  a, b = 1, 2',
+                               '  obj1.attribute = 1',
                                'else',
-                               '  a, b = 2, 1',
+                               '  obj2.attribute = 2',
                                'end'])
           expect(cop.offenses).to be_empty
         end
+      end
+    end
 
-        it 'does not register an offense in case when' do
-          inspect_source(cop, ['case foo',
-                               'when bar',
-                               '  a, b = 1, 2',
-                               'else',
-                               '  a, b = 2, 1',
-                               'end'])
-          expect(cop.offenses).to be_empty
-        end
+    context 'multiple assignment' do
+      it 'does not register an offense in if else' do
+        inspect_source(cop, ['if something',
+                             '  a, b = 1, 2',
+                             'else',
+                             '  a, b = 2, 1',
+                             'end'])
+        expect(cop.offenses).to be_empty
+      end
+
+      it 'does not register an offense in case when' do
+        inspect_source(cop, ['case foo',
+                             'when bar',
+                             '  a, b = 1, 2',
+                             'else',
+                             '  a, b = 2, 1',
+                             'end'])
+        expect(cop.offenses).to be_empty
       end
     end
   end

--- a/spec/rubocop/cop/style/file_name_spec.rb
+++ b/spec/rubocop/cop/style/file_name_spec.rb
@@ -148,6 +148,16 @@ describe RuboCop::Cop::Style::FileName do
       end
     end
 
+    context 'on an empty file with a space in its filename' do
+      let(:source) { '' }
+      let(:filename) { 'a file.rb' }
+
+      it 'registers an offense' do
+        expect(cop.offenses.size).to eq(1)
+        expect(cop.messages).to eq(['Use snake_case for source file names.'])
+      end
+    end
+
     shared_examples 'matching module or class' do
       %w(lib src test spec).each do |dir|
         context "in a matching directory under #{dir}" do

--- a/spec/rubocop/cop/style/redundant_parentheses_spec.rb
+++ b/spec/rubocop/cop/style/redundant_parentheses_spec.rb
@@ -96,6 +96,7 @@ describe RuboCop::Cop::Style::RedundantParentheses do
   it_behaves_like 'redundant', '(~x)', '~x', 'an unary operation'
   it_behaves_like 'redundant', '(-x)', '-x', 'an unary operation'
   it_behaves_like 'redundant', '(+x)', '+x', 'an unary operation'
+  it_behaves_like 'plausible', '(!x.m arg)'
   it_behaves_like 'plausible', '(!x).y'
 
   it_behaves_like 'redundant', '[(1)]', '[1]', 'a literal', '(1)'

--- a/spec/rubocop/cop/style/space_around_keyword_spec.rb
+++ b/spec/rubocop/cop/style/space_around_keyword_spec.rb
@@ -161,6 +161,8 @@ describe RuboCop::Cop::Style::SpaceAroundKeyword do
   it_behaves_like 'accept around', '()', '(next)'
   it_behaves_like 'accept before', '!', '!yield'
   it_behaves_like 'accept after', '.', 'yield.method'
+  it_behaves_like 'accept before', '!', '!yield.method'
+  it_behaves_like 'accept before', '!', '!super.method'
 
   # Style/SpaceAroundBlockParameters
   it_behaves_like 'accept before', '|', 'loop { |x|break }'
@@ -169,6 +171,7 @@ describe RuboCop::Cop::Style::SpaceAroundKeyword do
   it_behaves_like 'accept before', '=', 'a=begin end'
   it_behaves_like 'accept before', '==', 'a==begin end'
   it_behaves_like 'accept before', '+', 'a+begin end'
+  it_behaves_like 'accept before', '+', 'a+begin; end.method'
   it_behaves_like 'accept before', '-', 'a-begin end'
   it_behaves_like 'accept before', '*', 'a*begin end'
   it_behaves_like 'accept before', '**', 'a**begin end'

--- a/spec/rubocop/cop/style/string_literals_spec.rb
+++ b/spec/rubocop/cop/style/string_literals_spec.rb
@@ -289,6 +289,14 @@ describe RuboCop::Cop::Style::StringLiterals, :config do
                              '"def"'])
         expect(cop.offenses).to be_empty
       end
+
+      it "doesn't choke on heredocs with inconsistent indentation" do
+        inspect_source(cop, ['<<-QUERY_STRING',
+                             '  DEFINE',
+                             '    BLAH',
+                             'QUERY_STRING'])
+        expect(cop.offenses).to be_empty
+      end
     end
 
     context 'and EnforcedStyle is double_quotes' do


### PR DESCRIPTION
This should cut down on the number of duplicate issues being raised on GitHub.