### PR TITLE
Add cop_helper to packaged files

### DIFF
--- a/rubocop.gemspec
+++ b/rubocop.gemspec
@@ -17,7 +17,8 @@ Gem::Specification.new do |s|
   EOF
 
   s.email = 'rubocop@googlegroups.com'
-  s.files = `git ls-files assets bin config lib LICENSE.txt README.md`
+  s.files = `git ls-files assets bin config lib LICENSE.txt README.md \
+             spec/support/cop_helper.rb`
             .split($RS)
   s.executables = s.files.grep(%r{^bin/}) { |f| File.basename(f) }
   s.extra_rdoc_files = ['LICENSE.txt', 'README.md']


### PR DESCRIPTION
`spec/support/cop_helper.rb` is required for testing the https://github.com/lovewithfood/rubocop-rspec-focused gem.