### PR TITLE
[Fix #2845] Handle heredocs in MultilineLiteralBraceLayout auto-correct

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@
 * [#2861](https://github.com/bbatsov/rubocop/pull/2861): Fix false positive in `Style/SpaceAroundKeyword` for `rescue(...`. ([@rrosenblum][])
 * [#2832](https://github.com/bbatsov/rubocop/issues/2832): `Style/MultilineOperationIndentation` treats operations inside blocks inside other operations correctly. ([@jonas054][])
 * [#2865](https://github.com/bbatsov/rubocop/issues/2865): Change `require:` in config to be relative to the `.rubocop.yml` file itself. ([@ptarjan][])
+* [#2845](https://github.com/bbatsov/rubocop/issues/2845): Handle heredocs in `Style/MultilineLiteralBraceLayout` auto-correct. ([@jonas054][])
+* [#2848](https://github.com/bbatsov/rubocop/issues/2848): Handle comments inside arrays in `Style/MultilineArrayBraceLayout` auto-correct. ([@jonas054][])
 
 ## 0.37.2 (11/02/2016)
 

--- a/lib/rubocop/cop/mixin/multiline_literal_brace_layout.rb
+++ b/lib/rubocop/cop/mixin/multiline_literal_brace_layout.rb
@@ -27,12 +27,12 @@ module RuboCop
             corrector.insert_before(node.loc.end, "\n".freeze)
           end
         else
-          range = Parser::Source::Range.new(
-            node.source_range.source_buffer,
-            children(node).last.source_range.end_pos,
-            node.loc.end.begin_pos)
-
-          ->(corrector) { corrector.remove(range) }
+          lambda do |corrector|
+            corrector.remove(range_with_surrounding_space(node.loc.end,
+                                                          :left))
+            corrector.insert_after(children(node).last.source_range,
+                                   node.loc.end.source)
+          end
         end
       end
 

--- a/spec/rubocop/cop/style/multiline_array_brace_layout_spec.rb
+++ b/spec/rubocop/cop/style/multiline_array_brace_layout_spec.rb
@@ -54,11 +54,11 @@ describe RuboCop::Cop::Style::MultilineArrayBraceLayout do
     end
 
     it 'autocorrects closing brace on different line from last element' do
-      new_source = autocorrect_source(cop, ['[a,',
-                                            'b',
+      new_source = autocorrect_source(cop, ['[a, # a',
+                                            'b # b',
                                             ']'])
 
-      expect(new_source).to eq("[a,\nb]")
+      expect(new_source).to eq("[a, # a\nb] # b")
     end
   end
 

--- a/spec/rubocop/cop/style/multiline_method_call_brace_layout_spec.rb
+++ b/spec/rubocop/cop/style/multiline_method_call_brace_layout_spec.rb
@@ -101,5 +101,15 @@ describe RuboCop::Cop::Style::MultilineMethodCallBraceLayout do
 
       expect(new_source).to eq("foo(\n1,\n2\n)")
     end
+
+    it 'autocorrects method call with heredoc' do
+      new_source = autocorrect_source(cop, ['def foo',
+                                            '  bar(<<EOM',
+                                            '  baz',
+                                            'EOM',
+                                            '     )',
+                                            'end'])
+      expect(new_source).to eq("def foo\n  bar(<<EOM)\n  baz\nEOM\nend")
+    end
   end
 end


### PR DESCRIPTION
Instead of removing the range preceding the `)`, which can contain a heredoc, remove the `)` and insert another one in the correct place.

Also fixes #2848 where it's comments instead of heredocs and `]` instead of `)` but the principle is the same.