### PR TITLE
Add --no-color to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -198,6 +198,7 @@ Command flag              | Description
 `--show-cops`             | Shows available cops and their configuration.
 `--fail-level`            | Minimum [severity](#severity) for exit with error code. Full severity name or upper case initial can be given. Normally, auto-corrected offenses are ignored. Use `A` or `autocorrect` if you'd like them to trigger failure.
 `-s/--stdin`              | Pipe source from STDIN. This is useful for editor integration.
+`--[no-]color`            | Force color output on or off.
 
 ### Cops
 


### PR DESCRIPTION
This wasn't in the README and we were looking for it. Wanted to help the next
person find it faster