### PR TITLE
Change the caching of remote configs to live alongside the parent file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,7 @@
 ### Changes
 
 * [#2629](https://github.com/bbatsov/rubocop/pull/2629): Change the offense range for metrics cops to default to `expression` instead of `keyword` (the offense now spans the entire method, class, or module). ([@rrosenblum][])
+* [#2891](https://github.com/bbatsov/rubocop/pull/2891): Change the caching of remote configs to live alongside the parent file. ([@Fryguy][])
 
 ## 0.37.2 (11/02/2016)
 
@@ -2027,3 +2028,4 @@
 [@prsimp]: https://github.com/prsimp
 [@ptarjan]: https://github.com/ptarjan
 [@jweir]: https://github.com/jweir
+[@Fryguy]: https://github.com/Fryguy

--- a/lib/rubocop/config_loader.rb
+++ b/lib/rubocop/config_loader.rb
@@ -69,7 +69,7 @@ module RuboCop
       def base_configs(path, inherit_from)
         configs = Array(inherit_from).compact.map do |f|
           if f =~ /\A#{URI.regexp(%w(http https))}\z/
-            f = RemoteConfig.new(f).file
+            f = RemoteConfig.new(f, File.dirname(path)).file
           else
             f = File.expand_path(f, File.dirname(path))
 

--- a/lib/rubocop/remote_config.rb
+++ b/lib/rubocop/remote_config.rb
@@ -8,8 +8,9 @@ module RuboCop
   class RemoteConfig
     CACHE_LIFETIME = 24 * 60 * 60
 
-    def initialize(url)
+    def initialize(url, base_dir)
       @uri = URI.parse(url)
+      @base_dir = base_dir
     end
 
     def file
@@ -36,7 +37,7 @@ module RuboCop
     private
 
     def cache_path
-      ".rubocop-#{cache_name_from_uri}"
+      File.expand_path(".rubocop-#{cache_name_from_uri}", @base_dir)
     end
 
     def cache_path_exists?

--- a/spec/rubocop/config_loader_spec.rb
+++ b/spec/rubocop/config_loader_spec.rb
@@ -332,17 +332,22 @@ describe RuboCop::ConfigLoader do
 
     context 'when a file inherits from a url' do
       let(:file_path) { '.rubocop.yml' }
+      let(:cache_file) { '.rubocop-http---example-com-rubocop-yml' }
 
       before do
         stub_request(:get, /example.com/)
           .to_return(status: 200, body: "Style/Encoding:\n    Enabled: true")
 
-        create_file('~/.rubocop.yml', [''])
         create_file(file_path, ['inherit_from: http://example.com/rubocop.yml'])
       end
 
-      it 'does not fail to load the resulting path' do
-        expect { configuration_from_file }.not_to raise_error
+      after do
+        File.unlink cache_file if File.exist? cache_file
+      end
+
+      it 'creates the cached file alongside the owning file' do
+        configuration_from_file
+        expect(File.exist?(cache_file)).to be true
       end
     end
 

--- a/spec/rubocop/remote_config_spec.rb
+++ b/spec/rubocop/remote_config_spec.rb
@@ -7,9 +7,13 @@ describe RuboCop::RemoteConfig do
   include FileHelper
 
   let(:remote_config_url) { 'http://example.com/rubocop.yml' }
+  let(:base_dir) { '.' }
   let(:cached_file_name) { '.rubocop-http---example-com-rubocop-yml' }
+  let(:cached_file_path) { File.expand_path(cached_file_name, base_dir) }
 
-  subject(:remote_config) { described_class.new(remote_config_url).file }
+  subject(:remote_config) do
+    described_class.new(remote_config_url, base_dir).file
+  end
 
   before do
     stub_request(:get, /example.com/)
@@ -17,26 +21,26 @@ describe RuboCop::RemoteConfig do
   end
 
   after do
-    File.unlink cached_file_name if File.exist? cached_file_name
+    File.unlink cached_file_path if File.exist? cached_file_path
   end
 
   describe '.file' do
     it 'downloads the file if the file does not exist' do
-      expect(subject).to eq(cached_file_name)
-      expect(File.exist?(cached_file_name)).to be_truthy
+      expect(subject).to eq(cached_file_path)
+      expect(File.exist?(cached_file_path)).to be_truthy
     end
 
     it 'does not download the file if cache lifetime has not been reached' do
-      FileUtils.touch cached_file_name, mtime: Time.now - ((60 * 60) * 20)
+      FileUtils.touch cached_file_path, mtime: Time.now - ((60 * 60) * 20)
 
-      expect(subject).to eq(cached_file_name)
+      expect(subject).to eq(cached_file_path)
       assert_not_requested :get, remote_config_url
     end
 
     it 'downloads the file if cache lifetime has been reached' do
-      FileUtils.touch cached_file_name, mtime: Time.now - ((60 * 60) * 30)
+      FileUtils.touch cached_file_path, mtime: Time.now - ((60 * 60) * 30)
 
-      expect(subject).to eq(cached_file_name)
+      expect(subject).to eq(cached_file_path)
       assert_requested :get, remote_config_url
     end
   end


### PR DESCRIPTION
If a user `cd`s into a different directory, then the cached file for inherit_from with a remote URL would live in that directory.  This PR changes that to have it live alongside the rubocop.yml that defined the inherit_from.

This issue affected me in an interesting way in that I use SublimeLinter to run rubocop in Sublime Text.  I believe SublimeLinter must be `cd`ing to the directory of the file in question, and so the inherit_from caching of remote URLs is littering my directory structure with .rubocop-http---example-com-rubocop-yml files.  With this change the user can just .gitignore the one cache file.

I've spoken to vim users using syntastic, and they have same problem as well.  If they cd into a directory and then start vim from that directory, then the cache file will live there, ultimately littering a number of directories.