### PR TITLE
[#2894] fix autocorrecting an unless with a comparison operator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@
 * [#2631](https://github.com/bbatsov/rubocop/issues/2631): `Style/Encoding` can remove unneeded encoding comment when autocorrecting with `when_needed` style. ([@alexdowad][])
 * [#2860](https://github.com/bbatsov/rubocop/issues/2860): Fix false positive in `Rails/Date` when `to_time` is chained with safe method. ([@palkan][])
 * [#2898](https://github.com/bbatsov/rubocop/issues/2898): `Lint/NestedMethodDefinition` allows methods defined inside `Class.new(S)` blocks. ([@segiddins][])
+* [#2894](https://github.com/bbatsov/rubocop/issues/2894): Fix auto-correct an unless with a comparison operator. ([@jweir][])
 
 ### Changes
 
@@ -2025,3 +2026,4 @@
 [@pocke]: https://github.com/pocke
 [@prsimp]: https://github.com/prsimp
 [@ptarjan]: https://github.com/ptarjan
+[@jweir]: https://github.com/jweir

--- a/lib/rubocop/cop/style/nested_modifier.rb
+++ b/lib/rubocop/cop/style/nested_modifier.rb
@@ -89,11 +89,17 @@ module RuboCop
           outer_expr = "(#{outer_expr})" if outer_cond.or_type? &&
                                             operator == '&&'.freeze
           inner_expr = inner_cond.source
-          inner_expr = "(#{inner_expr})" if inner_cond.or_type?
+
+          inner_expr = "(#{inner_expr})" if requires_parens?(inner_cond)
           inner_expr = "!#{inner_expr}" unless outer_keyword == inner_keyword
 
           "#{outer_node.loc.keyword.source} " \
           "#{outer_expr} #{operator} #{inner_expr}"
+        end
+
+        def requires_parens?(node)
+          node.or_type? ||
+            !(RuboCop::Node::COMPARISON_OPERATORS & node.children).empty?
         end
       end
     end

--- a/spec/rubocop/cop/style/nested_modifier_spec.rb
+++ b/spec/rubocop/cop/style/nested_modifier_spec.rb
@@ -53,6 +53,11 @@ describe RuboCop::Cop::Style::NestedModifier do
     expect(corrected).to eq 'something unless b || !a'
   end
 
+  it 'auto-corrects unless with a comparison operator + if' do
+    corrected = autocorrect_source(cop, 'something unless b > 1 if true')
+    expect(corrected).to eq 'something if true && !(b > 1)'
+  end
+
   it 'auto-corrects unless + if' do
     corrected = autocorrect_source(cop, 'something unless a if b')
     expect(corrected).to eq 'something if b && !a'


### PR DESCRIPTION
Prior to this fix
  something unless b > 1 if true

would be autocorrected to
  something if true && !b > 1
which is incorrect.

This fix wraps the unless expression in parens:
  something if true && !(b > 1)

Thought, it might be better to just not autocorrect this case and raise a big flag that this code smells.