### PR TITLE
Remove redundant use of Util

### DIFF
--- a/lib/rubocop/cop/lint/unused_block_argument.rb
+++ b/lib/rubocop/cop/lint/unused_block_argument.rb
@@ -13,7 +13,6 @@ module RuboCop
       #   end
       class UnusedBlockArgument < Cop
         include UnusedArgument
-        include Util
 
         def check_argument(variable)
           return unless variable.block_argument?

--- a/lib/rubocop/cop/style/method_call_parentheses.rb
+++ b/lib/rubocop/cop/style/method_call_parentheses.rb
@@ -9,7 +9,7 @@ module RuboCop
         MSG = 'Do not use parentheses for method calls with ' \
               'no arguments.'.freeze
 
-        ASGN_NODES = [:lvasgn, :masgn] + Util::SHORTHAND_ASGN_NODES
+        ASGN_NODES = [:lvasgn, :masgn] + SHORTHAND_ASGN_NODES
 
         def on_send(node)
           _receiver, method_name, *args = *node


### PR DESCRIPTION
Remove explicit use of `Util` in cops as the module is included in `RuboCop:Cop::Cop`. Just minor cleanup.