### PR TITLE
Add configuration options to Lint/BlockAlignment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 * [#2629](https://github.com/bbatsov/rubocop/pull/2629): Add a new public API method, `highlighted_area` to offense. This method returns the range of the highlighted portion of an offense. ([@rrosenblum][])
 * `Style/OneLineConditional` cop can auto-correct. ([@lumeet][])
 * [#2905](https://github.com/bbatsov/rubocop/issues/2905): `Style/ZeroLengthConditional` flags code like `array.length < 1`, `1 > array.length`, and so on. ([@alexdowad][])
+* [#2892](https://github.com/bbatsov/rubocop/issues/2892): `Lint/BlockAlignment` cop can be configured to be stricter. ([@ptarjan][])
 
 ### Bug fixes
 

--- a/config/default.yml
+++ b/config/default.yml
@@ -989,6 +989,19 @@ Metrics/PerceivedComplexity:
 Lint/AssignmentInCondition:
   AllowSafeAssignment: true
 
+# checks whether the end keywords are aligned properly for `do` `end` blocks.
+Lint/BlockAlignment:
+  # The value `start_of_block` means that the `end` should be aligned with line
+  # where the `do` keyword appears.
+  # The value `start_of_line` means it should be aligned with the whole 
+  # expression's starting line.
+  # The value `either` means both are allowed.
+  AlignWith: either
+  SupportedStyles:
+    - either
+    - start_of_block
+    - start_of_line
+
 # Align ends correctly.
 Lint/EndAlignment:
   # The value `keyword` means that `end` should be aligned with the matching

--- a/spec/rubocop/cop/lint/block_alignment_spec.rb
+++ b/spec/rubocop/cop/lint/block_alignment_spec.rb
@@ -3,8 +3,11 @@
 
 require 'spec_helper'
 
-describe RuboCop::Cop::Lint::BlockAlignment do
-  subject(:cop) { described_class.new }
+describe RuboCop::Cop::Lint::BlockAlignment, :config do
+  subject(:cop) { described_class.new(config) }
+  let(:cop_config) do
+    { 'AlignWith' => 'either' }
+  end
 
   context 'when the block has no arguments' do
     it 'registers an offense for mismatched block end' do
@@ -667,6 +670,102 @@ describe RuboCop::Cop::Lint::BlockAlignment do
                      ])
       expect(cop.messages)
         .to eq(['`}` at 2, 2 is not aligned with `test {` at 1, 0.'])
+    end
+  end
+
+  context 'when configured to align with start_of_line' do
+    let(:cop_config) do
+      { 'AlignWith' => 'start_of_line' }
+    end
+
+    it 'allows when start_of_line aligned' do
+      src = [
+        'foo.bar',
+        '  .each do',
+        '    baz',
+        'end'
+      ]
+      inspect_source(cop, src)
+      expect(cop.messages).to be_empty
+    end
+
+    it 'errors when do aligned' do
+      src = [
+        'foo.bar',
+        '  .each do',
+        '    baz',
+        '  end'
+      ]
+      inspect_source(cop, src)
+      expect(cop.messages)
+        .to eq(['`end` at 4, 2 is not aligned with ' \
+                '`foo.bar` at 1, 0.'])
+    end
+
+    it 'autocorrects' do
+      src = [
+        'foo.bar',
+        '  .each do',
+        '    baz',
+        '  end'
+      ]
+      corrected = [
+        'foo.bar',
+        '  .each do',
+        '    baz',
+        'end'
+      ]
+
+      new_source = autocorrect_source(cop, src)
+      expect(new_source).to eq(corrected.join("\n"))
+    end
+  end
+
+  context 'when configured to align with do' do
+    let(:cop_config) do
+      { 'AlignWith' => 'start_of_block' }
+    end
+
+    it 'allows when do aligned' do
+      src = [
+        'foo.bar',
+        '  .each do',
+        '    baz',
+        '  end'
+      ]
+      inspect_source(cop, src)
+      expect(cop.messages).to be_empty
+    end
+
+    it 'errors when start_of_line aligned' do
+      src = [
+        'foo.bar',
+        '  .each do',
+        '    baz',
+        'end'
+      ]
+      inspect_source(cop, src)
+      expect(cop.messages)
+        .to eq(['`end` at 4, 0 is not aligned with ' \
+                '`.each do` at 2, 2.'])
+    end
+
+    it 'autocorrects' do
+      src = [
+        'foo.bar',
+        '  .each do',
+        '    baz',
+        'end'
+      ]
+      corrected = [
+        'foo.bar',
+        '  .each do',
+        '    baz',
+        '  end'
+      ]
+
+      new_source = autocorrect_source(cop, src)
+      expect(new_source).to eq(corrected.join("\n"))
     end
   end
 end


### PR DESCRIPTION
This Cop already supported both of these styles, but we only wanted the `do` style in our codebase. So I added the option to limit the cop to be tighter.

This is backwards compatible.

It looks like a big refactor because I was fighting with the ABC Cop.

Closes #2884 #2892