### PR TITLE
[Close #2857] Make brace layouts configurable

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -31,4 +31,4 @@ Metrics/ModuleLength:
 
 # Offense count: 55
 Metrics/PerceivedComplexity:
-  Max: 10
+  Max: 11

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@
 * `Style/RaiseArgs` cop can auto-correct. ([@drenmi][])
 * [#2993](https://github.com/bbatsov/rubocop/pull/2993): `Style/SpaceAfterColon` now checks optional keyword arguments. ([@owst][])
 * [#3003](https://github.com/bbatsov/rubocop/pull/3003): Read command line options from `.rubocop` file and `RUBOCOP_OPTS` environment variable. ([@bolshakov][])
+* [#2857](https://github.com/bbatsov/rubocop/issues/2857): `Style/MultilineArrayBraceLayout` enforced style is configurable and supports `symmetrical` and `new_line` options. ([@panthomakos][])
+* [#2857](https://github.com/bbatsov/rubocop/issues/2857): `Style/MultilineHashBraceLayout` enforced style is configurable and supports `symmetrical` and `new_line` options. ([@panthomakos][])
+* [#2857](https://github.com/bbatsov/rubocop/issues/2857): `Style/MultilineMethodCallBraceLayout` enforced style is configurable and supports `symmetrical` and `new_line` options. ([@panthomakos][])
+* [#2857](https://github.com/bbatsov/rubocop/issues/2857): `Style/MultilineMethodDefinitionBraceLayout` enforced style is configurable and supports `symmetrical` and `new_line` options. ([@panthomakos][])
 
 ### Bug fixes
 

--- a/config/disabled.yml
+++ b/config/disabled.yml
@@ -76,9 +76,15 @@ Style/MissingElse:
 Style/MultilineArrayBraceLayout:
   Description: >-
                  Checks that the closing brace in an array literal is
-                 symmetrical with respect to the opening brace and the
-                 array elements.
+                 either on the same line as the last array element, or
+                 a new line.
   Enabled: false
+  EnforcedStyle: symmetrical
+  SupportedStyles:
+    # symmetrical: closing brace is positioned in same way as opening brace
+    # new_line: closing brace is always on a new line
+    - symmetrical
+    - new_line
 
 Style/MultilineAssignmentLayout:
   Description: 'Check for a newline after the assignment operator in multi-line assignments.'
@@ -88,23 +94,41 @@ Style/MultilineAssignmentLayout:
 Style/MultilineHashBraceLayout:
   Description: >-
                  Checks that the closing brace in a hash literal is
-                 symmetrical with respect to the opening brace and the
-                 hash elements.
+                 either on the same line as the last hash element, or
+                 a new line.
   Enabled: false
+  EnforcedStyle: symmetrical
+  SupportedStyles:
+    # symmetrical: closing brace is positioned in same way as opening brace
+    # new_line: closing brace is always on a new line
+    - symmetrical
+    - new_line
 
 Style/MultilineMethodCallBraceLayout:
   Description: >-
                  Checks that the closing brace in a method call is
-                 symmetrical with respect to the opening brace and the
-                 method arguments.
+                 either on the same line as the last method argument, or
+                 a new line.
   Enabled: false
+  EnforcedStyle: symmetrical
+  SupportedStyles:
+    # symmetrical: closing brace is positioned in same way as opening brace
+    # new_line: closing brace is always on a new line
+    - symmetrical
+    - new_line
 
 Style/MultilineMethodDefinitionBraceLayout:
   Description: >-
                  Checks that the closing brace in a method definition is
-                 symmetrical with respect to the opening brace and the
-                 method parameters.
+                 either on the same line as the last method parameter, or
+                 a new line.
   Enabled: false
+  EnforcedStyle: symmetrical
+  SupportedStyles:
+    # symmetrical: closing brace is positioned in same way as opening brace
+    # new_line: closing brace is always on a new line
+    - symmetrical
+    - new_line
 
 Style/OptionHash:
   Description: "Don't use option hashes when you can use keyword arguments."

--- a/lib/rubocop/cop/mixin/multiline_literal_brace_layout.rb
+++ b/lib/rubocop/cop/mixin/multiline_literal_brace_layout.rb
@@ -3,21 +3,29 @@
 
 module RuboCop
   module Cop
-    # Common functionality for checking that the closing brace of a literal is
-    # symmetrical with respect to the opening brace and contained elements.
+    # Common functionality for checking the closing brace of a literal is
+    # either on the same line as the last contained elements, or a new line.
     module MultilineLiteralBraceLayout
+      include ConfigurableEnforcedStyle
+
       def check_brace_layout(node)
         return unless node.loc.begin # Ignore implicit literals.
         return if children(node).empty? # Ignore empty literals.
 
-        if opening_brace_on_same_line?(node)
-          return if closing_brace_on_same_line?(node)
-
-          add_offense(node, :expression, self.class::SAME_LINE_MESSAGE)
-        else
+        if style == :new_line
           return unless closing_brace_on_same_line?(node)
 
-          add_offense(node, :expression, self.class::NEW_LINE_MESSAGE)
+          add_offense(node, :expression, self.class::ALWAYS_NEW_LINE_MESSAGE)
+        elsif style == :symmetrical
+          if opening_brace_on_same_line?(node)
+            return if closing_brace_on_same_line?(node)
+
+            add_offense(node, :expression, self.class::SAME_LINE_MESSAGE)
+          else
+            return unless closing_brace_on_same_line?(node)
+
+            add_offense(node, :expression, self.class::NEW_LINE_MESSAGE)
+          end
         end
       end
 

--- a/lib/rubocop/cop/style/multiline_array_brace_layout.rb
+++ b/lib/rubocop/cop/style/multiline_array_brace_layout.rb
@@ -4,35 +4,41 @@
 module RuboCop
   module Cop
     module Style
-      # This cop checks that the closing brace in an array literal is
-      # symmetrical with respect to the opening brace and the array
-      # elements.
+      # This cop checks that the closing brace in an array literal is either
+      # on the same line as the last array element, or a new line.
+      #
+      # When using the `symmetrical` (default) style:
       #
       # If an array's opening brace is on the same line as the first element
       # of the array, then the closing brace should be on the same line as
       # the last element of the array.
       #
-      # If an array's opening brace is on a separate line from the first
-      # element of the array, then the closing brace should be on the line
+      # If an array's opening brace is on the line above the first element
+      # of the array, then the closing brace should be on the line below
+      # the last element of the array.
+      #
+      # When using the `new_line` style:
+      #
+      # The closing brace of a multi-line array literal must be on the line
       # after the last element of the array.
       #
       # @example
       #
-      #     # bad
+      #     # bad with symmetrical, good with new_line
       #     [ :a,
       #       :b
       #     ]
       #
-      #     # bad
+      #     # always bad
       #     [
       #       :a,
       #       :b ]
       #
-      #     # good
+      #     # good with symmetrical, bad with new_line
       #     [ :a,
       #       :b ]
       #
-      #     #good
+      #     # always good
       #     [
       #       :a,
       #       :b
@@ -47,6 +53,9 @@ module RuboCop
         NEW_LINE_MESSAGE = 'Closing array brace must be on the line after ' \
           'the last array element when opening brace is on a separate line ' \
           'from the first array element.'.freeze
+
+        ALWAYS_NEW_LINE_MESSAGE = 'Closing array brace must be on the line ' \
+          'after the last array element.'.freeze
 
         def on_array(node)
           check_brace_layout(node)

--- a/lib/rubocop/cop/style/multiline_hash_brace_layout.rb
+++ b/lib/rubocop/cop/style/multiline_hash_brace_layout.rb
@@ -4,38 +4,44 @@
 module RuboCop
   module Cop
     module Style
-      # This cop checks that the closing brace in an a hash literal is
-      # symmetrical with respect to the opening brace and the hash
-      # elements.
+      # This cop checks that the closing brace in a hash literal is either
+      # on the same line as the last hash element, or a new line.
+      #
+      # When using the `symmetrical` (default) style:
       #
       # If a hash's opening brace is on the same line as the first element
       # of the hash, then the closing brace should be on the same line as
       # the last element of the hash.
       #
-      # If a hash's opening brace is on a separate line from the first
-      # element of the hash, then the closing brace should be on the line
+      # If a hash's opening brace is on the line above the first element
+      # of the hash, then the closing brace should be on the line below
+      # the last element of the hash.
+      #
+      # When using the `new_line` style:
+      #
+      # The closing brace of a multi-line hash literal must be on the line
       # after the last element of the hash.
       #
       # @example
       #
-      #     # bad
-      #     { a: 'a',
-      #       b: 'b'
+      #     # bad with symmetrical, good with new_line
+      #     { a: 1,
+      #       b: 2
       #     }
       #
-      #     # bad
+      #     # always bad
       #     {
-      #       a: 'a',
-      #       b: 'b' }
+      #       a: 1,
+      #       b: 2 }
       #
-      #     # good
-      #     { a: 'a',
-      #       b: 'b' }
+      #     # good with symmetrical, bad with new_line
+      #     { a: 1,
+      #       b: 2 }
       #
-      #     #good
+      #     # always good
       #     {
-      #       a: 'a',
-      #       b: 'b'
+      #       a: 1,
+      #       b: 2
       #     }
       class MultilineHashBraceLayout < Cop
         include MultilineLiteralBraceLayout
@@ -47,6 +53,9 @@ module RuboCop
         NEW_LINE_MESSAGE = 'Closing hash brace must be on the line after ' \
           'the last hash element when opening brace is on a separate line ' \
           'from the first hash element.'.freeze
+
+        ALWAYS_NEW_LINE_MESSAGE = 'Closing hash brace must be on the line ' \
+          'after the last hash element.'.freeze
 
         def on_hash(node)
           check_brace_layout(node)

--- a/lib/rubocop/cop/style/multiline_method_call_brace_layout.rb
+++ b/lib/rubocop/cop/style/multiline_method_call_brace_layout.rb
@@ -4,35 +4,41 @@
 module RuboCop
   module Cop
     module Style
-      # This cop checks that the closing brace in a method call is
-      # symmetrical with respect to the opening brace and the method
-      # arguments.
+      # This cop checks that the closing brace in a method call is either
+      # on the same line as the last method argument, or a new line.
       #
-      # If a method call's opening brace is on the same line as the
-      # first argument of the call, then the closing brace should be
-      # on the same line as the last argument of the call.
+      # When using the `symmetrical` (default) style:
       #
-      # If a method call's opening brace is on a separate line from
-      # the first argument of the call, then the closing brace should
-      # be on the line after the last argument of the call.
+      # If a method call's opening brace is on the same line as the first
+      # argument of the call, then the closing brace should be on the same
+      # line as the last argument of the call.
+      #
+      # If an method call's opening brace is on the line above the first
+      # argument of the call, then the closing brace should be on the line
+      # below the last argument of the call.
+      #
+      # When using the `new_line` style:
+      #
+      # The closing brace of a multi-line method call must be on the line
+      # after the last argument of the call.
       #
       # @example
       #
-      #     # bad
+      #     # bad with symmetrical, good with new_line
       #     foo(a,
       #       b
-      #       )
+      #     )
       #
-      #     # bad
+      #     # always bad
       #     foo(
       #       a,
       #       b)
       #
-      #     # good
+      #     # good with symmetrical, bad with new_line
       #     foo(a,
       #       b)
       #
-      #     #good
+      #     # always good
       #     foo(
       #       a,
       #       b
@@ -47,6 +53,9 @@ module RuboCop
         NEW_LINE_MESSAGE = 'Closing method call brace must be on the ' \
           'line after the last argument when opening brace is on a separate ' \
           'line from the first argument.'.freeze
+
+        ALWAYS_NEW_LINE_MESSAGE = 'Closing method call brace must be on ' \
+          'the line after the last argument.'.freeze
 
         def on_send(node)
           check_brace_layout(node)

--- a/lib/rubocop/cop/style/multiline_method_definition_brace_layout.rb
+++ b/lib/rubocop/cop/style/multiline_method_definition_brace_layout.rb
@@ -4,43 +4,45 @@
 module RuboCop
   module Cop
     module Style
-      # This cop checks that the closing brace in a method definition is
-      # symmetrical with respect to the opening brace and the method
-      # parameters.
+      # This cop checks that the closing brace in a method definition is either
+      # on the same line as the last method parameter, or a new line.
+      #
+      # When using the `symmetrical` (default) style:
       #
       # If a method definition's opening brace is on the same line as the
       # first parameter of the definition, then the closing brace should be
       # on the same line as the last parameter of the definition.
       #
-      # If a method definition's opening brace is on a separate line from
-      # the first parameter of the definition, then the closing brace should
-      # be on the line after the last parameter of the definition.
+      # If an method definition's opening brace is on the line above the first
+      # parameter of the definition, then the closing brace should be on the
+      # line below the last parameter of the definition.
+      #
+      # When using the `new_line` style:
+      #
+      # The closing brace of a multi-line method definition must be on the line
+      # after the last parameter of the definition.
       #
       # @example
       #
-      #     # bad
+      #     # bad with symmetrical, good with new_line
       #     def foo(a,
       #       b
-      #       )
-      #     end
+      #     )
       #
-      #     # bad
+      #     # always bad
       #     def foo(
       #       a,
       #       b)
-      #     end
       #
-      #     # good
+      #     # good with symmetrical, bad with new_line
       #     def foo(a,
       #       b)
-      #     end
       #
-      #     #good
+      #     # always good
       #     def foo(
       #       a,
       #       b
       #     )
-      #     end
       class MultilineMethodDefinitionBraceLayout < Cop
         include OnMethodDef
         include MultilineLiteralBraceLayout
@@ -52,6 +54,9 @@ module RuboCop
         NEW_LINE_MESSAGE = 'Closing method definition brace must be on the ' \
           'line after the last parameter when opening brace is on a separate ' \
           'line from the first parameter.'.freeze
+
+        ALWAYS_NEW_LINE_MESSAGE = 'Closing method definition brace must be ' \
+          'on the line after the last parameter.'.freeze
 
         def on_method_def(_node, _method_name, args, _body)
           check_brace_layout(args)

--- a/spec/rubocop/cop/style/multiline_array_brace_layout_spec.rb
+++ b/spec/rubocop/cop/style/multiline_array_brace_layout_spec.rb
@@ -3,8 +3,9 @@
 
 require 'spec_helper'
 
-describe RuboCop::Cop::Style::MultilineArrayBraceLayout do
-  subject(:cop) { described_class.new }
+describe RuboCop::Cop::Style::MultilineArrayBraceLayout, :config do
+  subject(:cop) { described_class.new(config) }
+  let(:cop_config) { { 'EnforcedStyle' => 'symmetrical' } }
 
   it 'ignores implicit arrays' do
     inspect_source(cop, ['foo = a,',
@@ -25,81 +26,8 @@ describe RuboCop::Cop::Style::MultilineArrayBraceLayout do
     expect(cop.offenses).to be_empty
   end
 
-  context 'opening brace on same line as first element' do
-    it 'allows closing brace on same line as last element' do
-      inspect_source(cop, ['[a,',
-                           'b]'])
-
-      expect(cop.offenses).to be_empty
-    end
-
-    it 'allows closing brace on same line as last multiline element' do
-      inspect_source(cop, ['[a,',
-                           '{',
-                           'foo: bar',
-                           '}]'])
-
-      expect(cop.offenses).to be_empty
-    end
-
-    it 'detects closing brace on different line from last element' do
-      inspect_source(cop, ['[a,',
-                           'b',
-                           ']'])
-
-      expect(cop.offenses.size).to eq(1)
-      expect(cop.offenses.first.line).to eq(1)
-      expect(cop.highlights).to eq(["[a,\nb\n]"])
-      expect(cop.messages).to eq([described_class::SAME_LINE_MESSAGE])
-    end
-
-    it 'autocorrects closing brace on different line from last element' do
-      new_source = autocorrect_source(cop, ['[a, # a',
-                                            'b # b',
-                                            ']'])
-
-      expect(new_source).to eq("[a, # a\nb] # b")
-    end
-  end
-
-  context 'opening brace on separate line from first element' do
-    it 'allows closing brace on separate line from last element' do
-      inspect_source(cop, ['[',
-                           'a,',
-                           'b',
-                           ']'])
-
-      expect(cop.offenses).to be_empty
-    end
-
-    it 'allows closing brace on separate line from last multiline element' do
-      inspect_source(cop, ['[',
-                           'a,',
-                           '{',
-                           'foo: bar',
-                           '}',
-                           ']'])
-
-      expect(cop.offenses).to be_empty
-    end
-
-    it 'detects closing brace on same line as last element' do
-      inspect_source(cop, ['[',
-                           'a,',
-                           'b]'])
-
-      expect(cop.offenses.size).to eq(1)
-      expect(cop.offenses.first.line).to eq(1)
-      expect(cop.highlights).to eq(["[\na,\nb]"])
-      expect(cop.messages).to eq([described_class::NEW_LINE_MESSAGE])
-    end
-
-    it 'autocorrects closing brace on different line from last element' do
-      new_source = autocorrect_source(cop, ['[',
-                                            'a,',
-                                            'b]'])
-
-      expect(new_source).to eq("[\na,\nb\n]")
-    end
+  include_examples 'multiline literal brace layout' do
+    let(:open) { '[' }
+    let(:close) { ']' }
   end
 end

--- a/spec/rubocop/cop/style/multiline_hash_brace_layout_spec.rb
+++ b/spec/rubocop/cop/style/multiline_hash_brace_layout_spec.rb
@@ -3,8 +3,9 @@
 
 require 'spec_helper'
 
-describe RuboCop::Cop::Style::MultilineHashBraceLayout do
-  subject(:cop) { described_class.new }
+describe RuboCop::Cop::Style::MultilineHashBraceLayout, :config do
+  subject(:cop) { described_class.new(config) }
+  let(:cop_config) { { 'EnforcedStyle' => 'symmetrical' } }
 
   it 'ignores implicit hashes' do
     inspect_source(cop, ['foo(a: 1,',
@@ -25,81 +26,11 @@ describe RuboCop::Cop::Style::MultilineHashBraceLayout do
     expect(cop.offenses).to be_empty
   end
 
-  context 'opening brace on same line as first element' do
-    it 'allows closing brace on same line as last element' do
-      inspect_source(cop, ['{a: 1,',
-                           'b: 2}'])
-
-      expect(cop.offenses).to be_empty
-    end
-
-    it 'allows closing brace on same line as last multiline element' do
-      inspect_source(cop, ['{a: 1,',
-                           'b: {',
-                           'foo: bar',
-                           '}}'])
-
-      expect(cop.offenses).to be_empty
-    end
-
-    it 'detects closing brace on different line from last element' do
-      inspect_source(cop, ['{a: 1,',
-                           'b: 2',
-                           '}'])
-
-      expect(cop.offenses.size).to eq(1)
-      expect(cop.offenses.first.line).to eq(1)
-      expect(cop.highlights).to eq(["{a: 1,\nb: 2\n}"])
-      expect(cop.messages).to eq([described_class::SAME_LINE_MESSAGE])
-    end
-
-    it 'autocorrects closing brace on different line from last element' do
-      new_source = autocorrect_source(cop, ['{a: 1,',
-                                            'b: 2',
-                                            '}'])
-
-      expect(new_source).to eq("{a: 1,\nb: 2}")
-    end
-  end
-
-  context 'opening brace on separate line from first element' do
-    it 'allows closing brace on separate line from last element' do
-      inspect_source(cop, ['{',
-                           'a: 1,',
-                           'b: 2',
-                           '}'])
-
-      expect(cop.offenses).to be_empty
-    end
-
-    it 'allows closing brace on separate line from last multiline element' do
-      inspect_source(cop, ['{',
-                           'a: 1,',
-                           'b: {',
-                           'foo: bar',
-                           '}',
-                           '}'])
-
-      expect(cop.offenses).to be_empty
-    end
-
-    it 'detects closing brace on same line as last element' do
-      inspect_source(cop, ['{',
-                           'a: 1,',
-                           'b: 2}'])
-
-      expect(cop.offenses.size).to eq(1)
-      expect(cop.offenses.first.line).to eq(1)
-      expect(cop.highlights).to eq(["{\na: 1,\nb: 2}"])
-      expect(cop.messages).to eq([described_class::NEW_LINE_MESSAGE])
-    end
-
-    it 'autocorrects closing brace on different line from last element' do
-      new_source = autocorrect_source(cop, ['{',
-                                            'a: 1,',
-                                            'b: 2}'])
-
-      expect(new_source).to eq("{\na: 1,\nb: 2\n}")
-    end
+  include_examples 'multiline literal brace layout' do
+    let(:open) { '{' }
+    let(:close) { '}' }
+    let(:a) { 'a: 1' }
+    let(:b) { 'b: 2' }
+    let(:multi) { ['b: {', 'foo: bar', '}'] }
   end
 end

--- a/spec/rubocop/cop/style/multiline_method_call_brace_layout_spec.rb
+++ b/spec/rubocop/cop/style/multiline_method_call_brace_layout_spec.rb
@@ -3,8 +3,9 @@
 
 require 'spec_helper'
 
-describe RuboCop::Cop::Style::MultilineMethodCallBraceLayout do
-  subject(:cop) { described_class.new }
+describe RuboCop::Cop::Style::MultilineMethodCallBraceLayout, :config do
+  subject(:cop) { described_class.new(config) }
+  let(:cop_config) { { 'EnforcedStyle' => 'symmetrical' } }
 
   it 'ignores implicit calls' do
     inspect_source(cop, ['foo 1,',
@@ -25,91 +26,18 @@ describe RuboCop::Cop::Style::MultilineMethodCallBraceLayout do
     expect(cop.offenses).to be_empty
   end
 
-  context 'opening brace on same line as first argument' do
-    it 'allows closing brace on same line as last argument' do
-      inspect_source(cop, ['foo(1,',
-                           '2)'])
-
-      expect(cop.offenses).to be_empty
-    end
-
-    it 'allows closing brace on same line as last multiline argument' do
-      inspect_source(cop, ['foo(1,',
-                           'b: {',
-                           'foo: 2',
-                           '})'])
-
-      expect(cop.offenses).to be_empty
-    end
-
-    it 'detects closing brace on different line from last argument' do
-      inspect_source(cop, ['foo(1,',
-                           '2',
-                           ')'])
-
-      expect(cop.offenses.size).to eq(1)
-      expect(cop.offenses.first.line).to eq(1)
-      expect(cop.highlights).to eq(["foo(1,\n2\n)"])
-      expect(cop.messages).to eq([described_class::SAME_LINE_MESSAGE])
-    end
-
-    it 'autocorrects closing brace on different line from last argument' do
-      new_source = autocorrect_source(cop, ['foo(1,',
-                                            '2',
-                                            ')'])
-
-      expect(new_source).to eq("foo(1,\n2)")
-    end
+  include_examples 'multiline literal brace layout' do
+    let(:open) { 'foo(' }
+    let(:close) { ')' }
   end
 
-  context 'opening brace on separate line from first argument' do
-    it 'allows closing brace on separate line from last argument' do
-      inspect_source(cop, ['foo(',
-                           '1,',
-                           '2',
-                           ')'])
-
-      expect(cop.offenses).to be_empty
-    end
-
-    it 'allows closing brace on separate line from last multiline argument' do
-      inspect_source(cop, ['foo(',
-                           '1,',
-                           'b: {',
-                           'bar: 2',
-                           '}',
-                           ')'])
-
-      expect(cop.offenses).to be_empty
-    end
-
-    it 'detects closing brace on same line as last argument' do
-      inspect_source(cop, ['foo(',
-                           '1,',
-                           '2)'])
-
-      expect(cop.offenses.size).to eq(1)
-      expect(cop.offenses.first.line).to eq(1)
-      expect(cop.highlights).to eq(["foo(\n1,\n2)"])
-      expect(cop.messages).to eq([described_class::NEW_LINE_MESSAGE])
-    end
-
-    it 'autocorrects closing brace on different line from last argument' do
-      new_source = autocorrect_source(cop, ['foo(',
-                                            '1,',
-                                            '2)'])
-
-      expect(new_source).to eq("foo(\n1,\n2\n)")
-    end
-
-    it 'autocorrects method call with heredoc' do
-      new_source = autocorrect_source(cop, ['def foo',
-                                            '  bar(<<EOM',
-                                            '  baz',
-                                            'EOM',
-                                            '     )',
-                                            'end'])
-      expect(new_source).to eq("def foo\n  bar(<<EOM)\n  baz\nEOM\nend")
-    end
+  it 'autocorrects method call with heredoc' do
+    new_source = autocorrect_source(cop, ['def foo',
+                                          '  bar(<<EOM',
+                                          '  baz',
+                                          'EOM',
+                                          '     )',
+                                          'end'])
+    expect(new_source).to eq("def foo\n  bar(<<EOM)\n  baz\nEOM\nend")
   end
 end

--- a/spec/rubocop/cop/style/multiline_method_definition_brace_layout_spec.rb
+++ b/spec/rubocop/cop/style/multiline_method_definition_brace_layout_spec.rb
@@ -3,8 +3,9 @@
 
 require 'spec_helper'
 
-describe RuboCop::Cop::Style::MultilineMethodDefinitionBraceLayout do
-  subject(:cop) { described_class.new }
+describe RuboCop::Cop::Style::MultilineMethodDefinitionBraceLayout, :config do
+  subject(:cop) { described_class.new(config) }
+  let(:cop_config) { { 'EnforcedStyle' => 'symmetrical' } }
 
   it 'ignores implicit defs' do
     inspect_source(cop, ['def foo a: 1,',
@@ -28,89 +29,11 @@ describe RuboCop::Cop::Style::MultilineMethodDefinitionBraceLayout do
     expect(cop.offenses).to be_empty
   end
 
-  context 'opening brace on same line as first parameter' do
-    it 'allows closing brace on same line as last parameter' do
-      inspect_source(cop, ['def foo(a,',
-                           'b)',
-                           'end'])
-
-      expect(cop.offenses).to be_empty
-    end
-
-    it 'allows closing brace on same line as last multiline parameter' do
-      inspect_source(cop, ['def foo(a,',
-                           'b: {',
-                           'foo: bar',
-                           '})',
-                           'end'])
-
-      expect(cop.offenses).to be_empty
-    end
-
-    it 'detects closing brace on different line from last parameter' do
-      inspect_source(cop, ['def foo(a,',
-                           'b',
-                           ')',
-                           'end'])
-
-      expect(cop.offenses.size).to eq(1)
-      expect(cop.offenses.first.line).to eq(1)
-      expect(cop.highlights).to eq(["(a,\nb\n)"])
-      expect(cop.messages).to eq([described_class::SAME_LINE_MESSAGE])
-    end
-
-    it 'autocorrects closing brace on different line from last parameter' do
-      new_source = autocorrect_source(cop, ['def foo(a,',
-                                            'b',
-                                            ')',
-                                            'end'])
-
-      expect(new_source).to eq("def foo(a,\nb)\nend")
-    end
-  end
-
-  context 'opening brace on separate line from first parameter' do
-    it 'allows closing brace on separate line from last parameter' do
-      inspect_source(cop, ['def foo(',
-                           'a,',
-                           'b',
-                           ')',
-                           'end'])
-
-      expect(cop.offenses).to be_empty
-    end
-
-    it 'allows closing brace on separate line from last multiline parameter' do
-      inspect_source(cop, ['def foo(',
-                           'a,',
-                           'b: {',
-                           'foo: bar',
-                           '}',
-                           ')',
-                           'end'])
-
-      expect(cop.offenses).to be_empty
-    end
-
-    it 'detects closing brace on same line as last parameter' do
-      inspect_source(cop, ['def foo(',
-                           'a,',
-                           'b)',
-                           'end'])
-
-      expect(cop.offenses.size).to eq(1)
-      expect(cop.offenses.first.line).to eq(1)
-      expect(cop.highlights).to eq(["(\na,\nb)"])
-      expect(cop.messages).to eq([described_class::NEW_LINE_MESSAGE])
-    end
-
-    it 'autocorrects closing brace on different line from last parameter' do
-      new_source = autocorrect_source(cop, ['def foo(',
-                                            'a,',
-                                            'b)',
-                                            'end'])
-
-      expect(new_source).to eq("def foo(\na,\nb\n)\nend")
-    end
+  include_examples 'multiline literal brace layout' do
+    let(:prefix) { 'def foo' }
+    let(:suffix) { 'end' }
+    let(:open) { '(' }
+    let(:close) { ')' }
+    let(:multi) { ['b: {', 'foo: bar', '}'] }
   end
 end

--- a/spec/support/multiline_literal_brace_layout_examples.rb
+++ b/spec/support/multiline_literal_brace_layout_examples.rb
@@ -1,0 +1,187 @@
+# encoding: utf-8
+# frozen_string_literal: true
+
+shared_examples_for 'multiline literal brace layout' do
+  let(:prefix) { '' } # A prefix before the opening brace.
+  let(:suffix) { '' } # A suffix for the line after the closing brace.
+  let(:open) { nil } # The opening brace.
+  let(:close) { nil } # The closing brace.
+  let(:a) { 'a' } # The first element.
+  let(:b) { 'b' } # The second element.
+  let(:multi) { ['{', 'foo: bar', '}'] } # A viable multi-line element.
+
+  # Construct the source code for the braces. For instance, for an array
+  # the `open` brace would be `[` and the `close` brace would be `]`, so
+  # you could construct the following:
+  #
+  #     braces(true, 'a', 'b', 'c', false)
+  #
+  #     [ # line break indicated by `true` as the first argument.
+  #     a,
+  #     b,
+  #     c] # no line break indicated by `false` as the last argument.
+  #
+  # This method also supports multi-line arguments. For example:
+  #
+  #     braces(true, 'a', ['{', 'foo: bar', '}'], true)
+  #
+  #     [ # line break indicated by `true` as the first argument.
+  #     a,
+  #     {
+  #     foo: bar
+  #     } # line break indicated by `true` as the last argument.
+  #     ]
+  def braces(open_line_break, *args, close_line_break)
+    args = [a, b] if args.empty?
+
+    open + (open_line_break ? "\n" : '') +
+      args.map { |a| a.respond_to?(:join) ? a.join("\n") : a }.join(",\n") +
+      (close_line_break ? "\n" : '') + close
+  end
+
+  # Construct a piece of source code for brace layout testing. This farms
+  # out most of the work to `#braces` but it also includes a prefix and suffix.
+  def construct(*args)
+    (prefix + braces(*args) + "\n" + suffix).split("\n")
+  end
+
+  context 'symmetrical style' do
+    let(:cop_config) { { 'EnforcedStyle' => 'symmetrical' } }
+
+    context 'opening brace on same line as first element' do
+      it 'allows closing brace on same line as last element' do
+        inspect_source(cop, construct(false, false))
+
+        expect(cop.offenses).to be_empty
+      end
+
+      it 'allows closing brace on same line as last multiline element' do
+        inspect_source(cop, construct(false, a, multi, false))
+
+        expect(cop.offenses).to be_empty
+      end
+
+      it 'detects closing brace on different line from last element' do
+        inspect_source(cop, construct(false, true))
+
+        expect(cop.offenses.size).to eq(1)
+        expect(cop.offenses.first.line).to eq(1)
+        expect(cop.highlights).to eq([braces(false, true)])
+        expect(cop.messages).to eq([described_class::SAME_LINE_MESSAGE])
+      end
+
+      it 'autocorrects closing brace on different line from last element' do
+        new_source = autocorrect_source(cop, ["#{prefix}#{open}#{a}, # a",
+                                              "#{b} # b",
+                                              close,
+                                              suffix])
+
+        expect(new_source)
+          .to eq("#{prefix}#{open}#{a}, # a\n#{b}#{close} # b\n#{suffix}")
+      end
+    end
+
+    context 'opening brace on separate line from first element' do
+      it 'allows closing brace on separate line from last element' do
+        inspect_source(cop, construct(true, true))
+
+        expect(cop.offenses).to be_empty
+      end
+
+      it 'allows closing brace on separate line from last multiline element' do
+        inspect_source(cop, construct(true, a, multi, true))
+
+        expect(cop.offenses).to be_empty
+      end
+
+      it 'detects closing brace on same line as last element' do
+        inspect_source(cop, construct(true, false))
+
+        expect(cop.offenses.size).to eq(1)
+        expect(cop.offenses.first.line).to eq(1)
+        expect(cop.highlights).to eq([braces(true, false)])
+        expect(cop.messages).to eq([described_class::NEW_LINE_MESSAGE])
+      end
+
+      it 'autocorrects closing brace on different line from last element' do
+        new_source = autocorrect_source(cop, construct(true, false))
+
+        expect(new_source).to eq(construct(true, true).join("\n"))
+      end
+    end
+  end
+
+  context 'new_line style' do
+    let(:cop_config) { { 'EnforcedStyle' => 'new_line' } }
+
+    context 'opening brace on same line as first element' do
+      it 'allows closing brace on different line from last element' do
+        inspect_source(cop, construct(false, true))
+
+        expect(cop.offenses).to be_empty
+      end
+
+      it 'allows closing brace on different line from multi-line element' do
+        inspect_source(cop, construct(false, a, multi, true))
+
+        expect(cop.offenses).to be_empty
+      end
+
+      it 'detects closing brace on same line as last element' do
+        inspect_source(cop, construct(false, false))
+
+        expect(cop.offenses.size).to eq(1)
+        expect(cop.offenses.first.line).to eq(1)
+        expect(cop.highlights).to eq([braces(false, false)])
+        expect(cop.messages).to eq([described_class::ALWAYS_NEW_LINE_MESSAGE])
+      end
+
+      it 'detects closing brace on same line as last multiline element' do
+        inspect_source(cop, construct(false, a, multi, false))
+
+        expect(cop.offenses.size).to eq(1)
+        expect(cop.offenses.first.line).to eq(1)
+        expect(cop.highlights).to eq([braces(false, a, multi, false)])
+        expect(cop.messages).to eq([described_class::ALWAYS_NEW_LINE_MESSAGE])
+      end
+
+      it 'autocorrects closing brace on different same line as last element' do
+        new_source = autocorrect_source(cop, ["#{prefix}#{open}#{a}, # a",
+                                              "#{b}#{close} # b",
+                                              suffix])
+
+        expect(new_source)
+          .to eq("#{prefix}#{open}#{a}, # a\n#{b}\n#{close} # b\n#{suffix}")
+      end
+    end
+
+    context 'opening brace on separate line from first element' do
+      it 'allows closing brace on separate line from last element' do
+        inspect_source(cop, construct(true, true))
+
+        expect(cop.offenses).to be_empty
+      end
+
+      it 'allows closing brace on separate line from last multiline element' do
+        inspect_source(cop, construct(true, a, multi, true))
+
+        expect(cop.offenses).to be_empty
+      end
+
+      it 'detects closing brace on same line as last element' do
+        inspect_source(cop, construct(true, false))
+
+        expect(cop.offenses.size).to eq(1)
+        expect(cop.offenses.first.line).to eq(1)
+        expect(cop.highlights).to eq([braces(true, false)])
+        expect(cop.messages).to eq([described_class::ALWAYS_NEW_LINE_MESSAGE])
+      end
+
+      it 'autocorrects closing brace on different line from last element' do
+        new_source = autocorrect_source(cop, construct(true, false))
+
+        expect(new_source).to eq(construct(true, true).join("\n"))
+      end
+    end
+  end
+end


### PR DESCRIPTION
The `Style/Multiline*BraceLayout` cops now support two configuration
styles. The `symmetrical` option is the default in which the closing
brace mirrors the open brace. The `new_line` option forces the closing
brace to always be on a new line.

* I have clarified the descriptions and comments for all of the cops.
* I have moved the common specs into a shared example that constructs
  the source code for each test using some simple input: the opening
  brace, closing brace, and literal elements.