### PR TITLE
[Fix #2871] Make sure messages read back from cache are UTF-8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@
 * [#2898](https://github.com/bbatsov/rubocop/issues/2898): `Lint/NestedMethodDefinition` allows methods defined inside `Class.new(S)` blocks. ([@segiddins][])
 * [#2894](https://github.com/bbatsov/rubocop/issues/2894): Fix auto-correct an unless with a comparison operator. ([@jweir][])
 * [#2911](https://github.com/bbatsov/rubocop/issues/2911): `Style/ClassAndModuleChildren` doesn't flag nested class definitions, where the outer class has an explicit superclass (because such definitions can't be converted to `compact` style). ([@alexdowad][])
+* [#2871](https://github.com/bbatsov/rubocop/issues/2871): Don't crash when offense messages are read back from cache with `ASCII-8BIT` encoding and output as HTML or JSON. ([@jonas054][])
 
 ### Changes
 

--- a/lib/rubocop/cached_data.rb
+++ b/lib/rubocop/cached_data.rb
@@ -53,8 +53,12 @@ module RuboCop
         location = Parser::Source::Range.new(source_buffer,
                                              o['location']['begin_pos'],
                                              o['location']['end_pos'])
-        Cop::Offense.new(o['severity'], location, o['message'], o['cop_name'],
-                         o['status'].to_sym)
+        Cop::Offense.new(o['severity'], location,
+                         # We know that we wrote a UTF-8 encoded string to the
+                         # cache file, so it's safe to force-encode it back to
+                         # UTF-8 if it happens to be ASCII-8BIT.
+                         o['message'].force_encoding('UTF-8'),
+                         o['cop_name'], o['status'].to_sym)
       end
     end
   end


### PR DESCRIPTION
It happens is some environments that `JSON.load` produces binary (ASCII-8BIT) encoded strings when the cache is read. If those strings contain "special", i.e. non-7bit-ASCII characters, then we run into trouble in the `html` and `json` formatters when they are concatenated with UTF-8 encoded strings.