### PR TITLE
[Fix #2901] Account for no `ENV['HOME']`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@
 * [#2894](https://github.com/bbatsov/rubocop/issues/2894): Fix auto-correct an unless with a comparison operator. ([@jweir][])
 * [#2911](https://github.com/bbatsov/rubocop/issues/2911): `Style/ClassAndModuleChildren` doesn't flag nested class definitions, where the outer class has an explicit superclass (because such definitions can't be converted to `compact` style). ([@alexdowad][])
 * [#2871](https://github.com/bbatsov/rubocop/issues/2871): Don't crash when offense messages are read back from cache with `ASCII-8BIT` encoding and output as HTML or JSON. ([@jonas054][])
+* [#2901](https://github.com/bbatsov/rubocop/issues/2901): Don't crash when `ENV['HOME']` is undefined. ([@mikegee][])
 
 ### Changes
 
@@ -2033,3 +2034,4 @@
 [@ptarjan]: https://github.com/ptarjan
 [@jweir]: https://github.com/jweir
 [@Fryguy]: https://github.com/Fryguy
+[@mikegee]: https://github.com/mikegee

--- a/lib/rubocop/config_loader.rb
+++ b/lib/rubocop/config_loader.rb
@@ -213,7 +213,8 @@ module RuboCop
           break if dir_pathname.to_s == @root_level
           dirs_to_search << dir_pathname.to_s
         end
-        dirs_to_search << Dir.home
+        dirs_to_search << Dir.home if ENV.key? 'HOME'
+        dirs_to_search
       end
 
       def old_auto_config_file_warning

--- a/spec/rubocop/config_loader_spec.rb
+++ b/spec/rubocop/config_loader_spec.rb
@@ -30,6 +30,14 @@ describe RuboCop::ConfigLoader do
           expect(configuration_file_for).to end_with('config/default.yml')
         end
       end
+
+      context 'and ENV has no `HOME` defined' do
+        before { ENV.delete 'HOME' }
+
+        it 'falls back to the provided default file' do
+          expect(configuration_file_for).to end_with('config/default.yml')
+        end
+      end
     end
 
     context 'when a config file exists in the parent directory' do


### PR DESCRIPTION
Before submitting a PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [x] Used the same coding conventions as the rest of the project.
* [x] Feature branch is up-to-date with `master` (if not - rebase it)
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../CONTRIBUTING.md#changelog-entry-format).
* [x] All tests are passing.
* [x] The new code doesn't generate RuboCop offenses.
* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.

[1]: http://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html

Don't try to call `Dir.home` when `ENV` has no `'HOME'` key.

When `ENV['HOME']` isn't defined, `Dir.home` raises:

```
ArgumentError: couldn't find HOME environment -- expanding `~'
```