### PR TITLE
Add `require 'time'` to remote_config.rb

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 
 ### Bug fixes
 
+* Add `require 'time'` to `remote_config.rb` to avoid "undifined method `rfc2822'". ([@necojackarc][])
 * Replace `Rake::TaskManager#last_comment` with `Rake::TaskManager#last_description` for Rake 11 compatibility. ([@tbrisker][])
 * Fix false positive in `Style/TrailingCommaInArguments` & `Style/TrailingCommaInLiteral` cops with consistent_comma style. ([@meganemura][])
 * [#2861](https://github.com/bbatsov/rubocop/pull/2861): Fix false positive in `Style/SpaceAroundKeyword` for `rescue(...`. ([@rrosenblum][])
@@ -2046,3 +2047,4 @@
 [@Fryguy]: https://github.com/Fryguy
 [@mikegee]: https://github.com/mikegee
 [@tbrisker]: https://github.com/tbrisker
+[@necojackarc]: https://github.com/necojackarc

--- a/lib/rubocop/remote_config.rb
+++ b/lib/rubocop/remote_config.rb
@@ -2,6 +2,7 @@
 # frozen_string_literal: true
 
 require 'net/http'
+require 'time'
 
 module RuboCop
   # Common methods and behaviors for dealing with remote config files.


### PR DESCRIPTION
## Summary
It seems better to call `require 'time'` before using `rfc2822` because it is one of the additional methods of the `Time` extended by `time.rb`.

## Bug
When I used `.rubocop.yml` inferiting a remote configration file, the following error occured:

```bash
$ ruby -v
ruby 2.2.4p230 (2015-12-16 revision 53155) [x86_64-darwin15]

$ rubocop -V
0.37.0 (using Parser 2.3.0.6, running on ruby 2.2.4 x86_64-darwin15)

$ rubocop
undefined method `rfc2822' for 2016-03-02 19:36:38 +0900:Time
/Users/necojackarc/.rbenv/versions/2.2.4/lib/ruby/gems/2.2.0/gems/rubocop-0.37.0/lib/rubocop/remote_config.rb:23:in `file'
/Users/necojackarc/.rbenv/versions/2.2.4/lib/ruby/gems/2.2.0/gems/rubocop-0.37.0/lib/rubocop/config_loader.rb:69:in `block in base_configs'
/Users/necojackarc/.rbenv/versions/2.2.4/lib/ruby/gems/2.2.0/gems/rubocop-0.37.0/lib/rubocop/config_loader.rb:67:in `map'
/Users/necojackarc/.rbenv/versions/2.2.4/lib/ruby/gems/2.2.0/gems/rubocop-0.37.0/lib/rubocop/config_loader.rb:67:in `base_configs'
/Users/necojackarc/.rbenv/versions/2.2.4/lib/ruby/gems/2.2.0/gems/rubocop-0.37.0/lib/rubocop/config_loader.rb:172:in `resolve_inheritance'
/Users/necojackarc/.rbenv/versions/2.2.4/lib/ruby/gems/2.2
```

According to a document, we need `require 'time'` before calling the `Time#rfc2822`, but there is no `require 'time'` as far as I can see.

> ## time.rb

> When ‘time’ is required, Time is extended with additional methods for parsing and converting Times.

> ### Features

> This library extends the Time class with the following conversions between date strings and Time objects:

> * date-time defined by RFC 2822
> * HTTP-date defined by RFC 2616
> * dateTime defined by XML Schema Part 2: Datatypes (ISO 8601)
> * various formats handled by Date._parse
> * custom formats handled by Date._strptime

> <cite>[Class: Time (Ruby 2_2_3) ](http://ruby-doc.org/stdlib-2.2.3/libdoc/time/rdoc/Time.html)</cite>

## Issue
However, there is something weird; [specs cover the related lines correctly](https://codeclimate.com/github/bbatsov/rubocop/RuboCop::RemoteConfig).
So, I checked whether `time` was already required or not:

```ruby
From: /Users/necojackarc/work/rubocop/spec/rubocop/remote_config_spec.rb @ line 42 :

    37:       assert_not_requested :get, remote_config_url
    38:     end
    39:
    40:     it 'downloads the file if cache lifetime has been reached' do
    41:       require 'pry'
 => 42:       binding.pry
    43:       FileUtils.touch cached_file_path, mtime: Time.now - ((60 * 60) * 30)
    44:
    45:       expect(subject).to eq(cached_file_path)
    46:       assert_requested :get, remote_config_url
    47:     end

[1] pry(#<RSpec::ExampleGroups::RuboCopRemoteConfig::File>)> require "time"
=> false
```

It's already required, so I happen to think some stuff requires it without our realizing.
We might need to identify the cause of this weird thing before merging this PR.