### PR TITLE
Style/IfUnlessModifier does not trigger if the body is another conditional

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@
 ### Changes
 
 * `require:` only does relative includes when it starts with a `.`. ([@ptarjan][])
+* `Style/IfUnlessModifier` does not trigger if the body is another conditional. ([@amuino][])
 
 ## 0.38.0 (09/03/2016)
 
@@ -2072,3 +2073,4 @@
 [@tbrisker]: https://github.com/tbrisker
 [@necojackarc]: https://github.com/necojackarc
 [@laurelfan]: https://github.com/laurelfan
+[@amuino]: https://github.com/amuino

--- a/lib/rubocop/cop/style/if_unless_modifier.rb
+++ b/lib/rubocop/cop/style/if_unless_modifier.rb
@@ -26,6 +26,7 @@ module RuboCop
           return if if_else?(node)
           return if node.chained?
           return unless fit_within_line_as_modifier_form?(node)
+          return if nested_conditional?(node)
           add_offense(node, :keyword, message(node.loc.keyword.source))
         end
 
@@ -63,6 +64,13 @@ module RuboCop
           oneline = "(#{oneline})" if parenthesize?(node)
 
           ->(corrector) { corrector.replace(node.source_range, oneline) }
+        end
+
+        private
+
+        # returns false if the then or else children are conditionals
+        def nested_conditional?(node)
+          node.children[1, 2].any? { |child| child && child.type == :if }
         end
       end
     end

--- a/spec/rubocop/cop/style/if_unless_modifier_spec.rb
+++ b/spec/rubocop/cop/style/if_unless_modifier_spec.rb
@@ -310,4 +310,30 @@ describe RuboCop::Cop::Style::IfUnlessModifier do
       expect(corrected).to eq 'puts "string", (1 if a)'
     end
   end
+
+  context 'if-end with conditional as body' do
+    let(:source) do
+      ['if condition',
+       '  foo ? "bar" : "baz"',
+       'end']
+    end
+
+    it 'accepts' do
+      inspect_source(cop, source)
+      expect(cop.offenses).to be_empty
+    end
+  end
+
+  context 'unless-end with conditional as body' do
+    let(:source) do
+      ['unless condition',
+       '  foo ? "bar" : "baz"',
+       'end']
+    end
+
+    it 'accepts' do
+      inspect_source(cop, source)
+      expect(cop.offenses).to be_empty
+    end
+  end
 end


### PR DESCRIPTION
This is a proposal to avoid adding an offense when the body of the conditional is another conditional (originally targeting the ternary operator), since the resulting one-liner is a lot harder to read.

When the content of an `if` sentence is a conditional (specially with the
ternary operator), the single line version is much harder to read.

Before, conditions like
```
if running?
  tired? ? "please stop" : "keep going"
end
```

become

```
tired? ? "please stop" : "keep going" if running?
```

With this PR, the original remains unchanged.