### PR TITLE
Only do relative requires when path starts with .

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@
 * [#2950](https://github.com/bbatsov/rubocop/issues/2950): Fix auto-correcting cases in which precedence has changed in `Style/OneLineConditional`. ([@lumeet][])
 * [#2947](https://github.com/bbatsov/rubocop/issues/2947): Fix auto-correcting `if-then` in `Style/Next`. ([@lumeet][])
 
+### Changes
+
+* `require:` only does relative includes when it starts with a `.`. ([@ptarjan][])
+
 ## 0.38.0 (09/03/2016)
 
 ### New features

--- a/README.md
+++ b/README.md
@@ -1017,7 +1017,8 @@ require:
 
 Note: The paths are directly passed to `Kernel.require`.  If your
 extension file is not in `$LOAD_PATH`, you need to specify the path as
-relative path prefixed with `./` explicitly, or absolute path.
+relative path prefixed with `./` explicitly, or absolute path. Paths 
+starting with a `.` are resolved relative to `.rubocop.yml`.
 
 ### Custom Cops
 

--- a/lib/rubocop.rb
+++ b/lib/rubocop.rb
@@ -387,6 +387,7 @@ require 'rubocop/formatter/formatter_set'
 
 require 'rubocop/cached_data'
 require 'rubocop/config'
+require 'rubocop/config_loader_resolver'
 require 'rubocop/config_loader'
 require 'rubocop/config_store'
 require 'rubocop/target_finder'

--- a/lib/rubocop/config_loader_resolver.rb
+++ b/lib/rubocop/config_loader_resolver.rb
@@ -1,0 +1,42 @@
+# encoding: utf-8
+# frozen_string_literal: true
+
+require 'yaml'
+require 'pathname'
+
+module RuboCop
+  # A mixin to break up ConfigLoader
+  module ConfigLoaderResolver
+    def resolve_requires(path, hash)
+      config_dir = File.dirname(path)
+      Array(hash.delete('require')).each do |r|
+        if r.start_with?('.')
+          require(File.join(config_dir, r))
+        else
+          require(r)
+        end
+      end
+    end
+
+    def resolve_inheritance(path, hash)
+      base_configs(path, hash['inherit_from']).reverse_each do |base_config|
+        base_config.each do |k, v|
+          hash[k] = hash.key?(k) ? merge(v, hash[k]) : v if v.is_a?(Hash)
+        end
+      end
+    end
+
+    def resolve_inheritance_from_gems(hash, gems)
+      (gems || {}).each_pair do |gem_name, config_path|
+        if gem_name == 'rubocop'
+          raise ArgumentError,
+                "can't inherit configuration from the rubocop gem"
+        end
+
+        hash['inherit_from'] = Array(hash['inherit_from'])
+        # Put gem configuration first so local configuration overrides it.
+        hash['inherit_from'].unshift gem_config_path(gem_name, config_path)
+      end
+    end
+  end
+end

--- a/spec/rubocop/config_loader_spec.rb
+++ b/spec/rubocop/config_loader_spec.rb
@@ -527,4 +527,22 @@ describe RuboCop::ConfigLoader do
       end
     end
   end
+
+  describe 'when a unqualified requirement is defined', :isolated_environment do
+    let(:required_file_path) { 'required_file' }
+
+    before do
+      create_file('.rubocop.yml', ['require:', "  - #{required_file_path}"])
+      create_file(required_file_path + '.rb', ['class MyClass', 'end'])
+    end
+
+    it 'works without a starting .' do
+      config_path = described_class.configuration_file_for('.')
+      $LOAD_PATH.unshift(File.dirname(config_path))
+      Dir.chdir '..' do
+        described_class.configuration_from_file(config_path)
+        expect(defined?(MyClass)).to be_truthy
+      end
+    end
+  end
 end


### PR DESCRIPTION
There are many other ways to require files which I didn't consider in https://github.com/bbatsov/rubocop/pull/2866

I tried doing `(Pathname.new foo).absolute?` but sadly that doesn't detect gems or URLs. I think this simple `.` prefix is a good balance between all the other methods and allowing relative includes. I can't think of a way you would do relative includes without starting with a `.`.

This should be released as a `0.38.1` soon since `0.38.0` breaks people with non-relative requires.

Fixes #2937 