### PR TITLE
TimesMap can auto-correct

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## master (unreleased)
 
+### New features
+
+* `Performance/TimesMap` cop can auto-correct. ([@lumeet][])
+
 ## 0.38.0 (09/03/2016)
 
 ### New features

--- a/lib/rubocop/cop/performance/times_map.rb
+++ b/lib/rubocop/cop/performance/times_map.rb
@@ -42,6 +42,20 @@ module RuboCop
           {(block (send (send !nil :times) ${:map :collect}) ...)
            (send (send !nil :times) ${:map :collect} (block_pass ...))}
         END
+
+        def autocorrect(node)
+          send_node = node.send_type? ? node : node.each_descendant(:send).first
+
+          receiver, _method_name, *args = *send_node
+          count, = *receiver
+
+          replacement = "Array.new(#{count.source}" \
+                        "#{args.map { |arg| ", #{arg.source}" }.join})"
+
+          lambda do |corrector|
+            corrector.replace(send_node.loc.expression, replacement)
+          end
+        end
       end
     end
   end

--- a/spec/rubocop/cop/performance/times_map_spec.rb
+++ b/spec/rubocop/cop/performance/times_map_spec.rb
@@ -22,6 +22,11 @@ describe RuboCop::Cop::Performance::TimesMap do
           )
           expect(cop.highlights).to eq(["4.times.#{method} { |i| i.to_s }"])
         end
+
+        it 'auto-corrects' do
+          corrected = autocorrect_source(cop, source)
+          expect(corrected).to eq('Array.new(4) { |i| i.to_s }')
+        end
       end
 
       context 'with an explicitly passed block' do
@@ -33,6 +38,11 @@ describe RuboCop::Cop::Performance::TimesMap do
             "Use `Array.new` with a block instead of `.times.#{method}`."
           )
           expect(cop.highlights).to eq(["4.times.#{method}(&method(:foo))"])
+        end
+
+        it 'auto-corrects' do
+          corrected = autocorrect_source(cop, source)
+          expect(corrected).to eq('Array.new(4, &method(:foo))')
         end
       end
 


### PR DESCRIPTION
Before submitting a PR make sure the following are checked:

* [X] Wrote [good commit messages][1].
* [X] Used the same coding conventions as the rest of the project.
* [X] Feature branch is up-to-date with `master` (if not - rebase it)
* [X] Squashed related commits together.
* [X] Added tests.
* [X] Added an entry to the [Changelog](CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../CONTRIBUTING.md#changelog-entry-format).
* [x] All tests are passing.
* [x] The new code doesn't generate RuboCop offenses.
* [X] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.

[1]: http://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html

The `Performance/TimesMap` cop auto-corrects `2.times.map { |i| i }` to `Array.new(2) { |i| i }`.