### PR TITLE
Fix already initialized constant warning

### DIFF
--- a/spec/rubocop/cop/lint/def_end_alignment_spec.rb
+++ b/spec/rubocop/cop/lint/def_end_alignment_spec.rb
@@ -19,8 +19,6 @@ describe RuboCop::Cop::Lint::DefEndAlignment, :config do
      '    end']
   end
 
-  BOM = "\xef\xbb\xbf".freeze
-
   context 'when AlignWith is start_of_line' do
     let(:cop_config) do
       { 'AlignWith' => 'start_of_line', 'AutoCorrect' => true }
@@ -29,9 +27,9 @@ describe RuboCop::Cop::Lint::DefEndAlignment, :config do
     include_examples 'misaligned', '', 'def', 'test',      '  end'
     include_examples 'misaligned', '', 'def', 'Test.test', '  end', 'defs'
 
-    include_examples 'aligned', "#{BOM}def", 'test',      'end'
-    include_examples 'aligned', 'def',       'test',      'end'
-    include_examples 'aligned', 'def',       'Test.test', 'end', 'defs'
+    include_examples 'aligned', "\xef\xbb\xbfdef", 'test', 'end'
+    include_examples 'aligned', 'def',       'test',       'end'
+    include_examples 'aligned', 'def',       'Test.test',  'end', 'defs'
 
     context 'in ruby 2.1 or later' do
       include_examples 'aligned', 'foo def', 'test', 'end'

--- a/spec/rubocop/cop/lint/end_alignment_spec.rb
+++ b/spec/rubocop/cop/lint/end_alignment_spec.rb
@@ -8,7 +8,6 @@ describe RuboCop::Cop::Lint::EndAlignment, :config do
   let(:cop_config) do
     { 'AlignWith' => 'keyword', 'AutoCorrect' => true }
   end
-  BOM = "\xef\xbb\xbf".freeze
 
   include_examples 'misaligned', '', 'class',  'Test',      '  end'
   include_examples 'misaligned', '', 'module', 'Test',      '  end'
@@ -18,7 +17,7 @@ describe RuboCop::Cop::Lint::EndAlignment, :config do
   include_examples 'misaligned', '', 'until',  'test',      '  end'
   include_examples 'misaligned', '', 'case',   'a when b',  '  end'
 
-  include_examples 'aligned', "#{BOM}class", 'Test', 'end'
+  include_examples 'aligned', "\xef\xbb\xbfclass", 'Test', 'end'
 
   include_examples 'aligned', 'class',  'Test',      'end'
   include_examples 'aligned', 'module', 'Test',      'end'


### PR DESCRIPTION
We have run into this before. Rspec has a weird scope when it comes to constants.