### PR TITLE
Fix SpaceAroundKeyword to allow yield[n] and super[n]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 * `Performance/TimesMap` cop can auto-correct. ([@lumeet][])
 
+### Bug fixes
+
+* [#2948](https://github.com/bbatsov/rubocop/issues/2948): `Style/SpaceAroundKeyword` should allow yield[n] and super[n]. ([@laurelfan][])
+
 ## 0.38.0 (09/03/2016)
 
 ### New features
@@ -2054,3 +2058,4 @@
 [@mikegee]: https://github.com/mikegee
 [@tbrisker]: https://github.com/tbrisker
 [@necojackarc]: https://github.com/necojackarc
+[@laurelfan]: https://github.com/laurelfan

--- a/lib/rubocop/cop/style/space_around_keyword.rb
+++ b/lib/rubocop/cop/style/space_around_keyword.rb
@@ -32,6 +32,8 @@ module RuboCop
         DO = 'do'.freeze
         ACCEPT_LEFT_PAREN =
           %w(break defined? next not rescue return super yield).freeze
+        ACCEPT_LEFT_SQUARE_BRACKET =
+          %w(super yield).freeze
 
         def on_and(node)
           check(node, [:operator].freeze) if node.keyword?
@@ -177,13 +179,20 @@ module RuboCop
           pos = range.end_pos
           char = range.source_buffer.source[pos]
           return false unless char
-          return false if accept_left_parenthesis?(range) && char == '('.freeze
+          return false if accept_left_parenthesis?(range) &&
+                          char == '('.freeze
+          return false if accept_left_square_bracket?(range) &&
+                          char == '['.freeze
 
           char !~ /[\s;,#\\\)\}\]\.]/
         end
 
         def accept_left_parenthesis?(range)
           ACCEPT_LEFT_PAREN.include?(range.source)
+        end
+
+        def accept_left_square_bracket?(range)
+          ACCEPT_LEFT_SQUARE_BRACKET.include?(range.source)
         end
 
         def preceded_by_operator?(node, _range)

--- a/spec/rubocop/cop/style/space_around_keyword_spec.rb
+++ b/spec/rubocop/cop/style/space_around_keyword_spec.rb
@@ -164,6 +164,9 @@ describe RuboCop::Cop::Style::SpaceAroundKeyword do
   it_behaves_like 'accept before', '!', '!yield.method'
   it_behaves_like 'accept before', '!', '!super.method'
 
+  it_behaves_like 'accept after', '[', 'super[1]'
+  it_behaves_like 'accept after', '[', 'yield[1]'
+
   # Style/SpaceAroundBlockParameters
   it_behaves_like 'accept before', '|', 'loop { |x|break }'
 


### PR DESCRIPTION
Fix #2948.

`super[n]` and `yield[n]` are valid since super and yield can return a value and adding a space before the `[` causes ArgumentError or changes the meaning.

----

Before submitting a PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [x] Used the same coding conventions as the rest of the project.
* [x] Feature branch is up-to-date with `master` (if not - rebase it)
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../CONTRIBUTING.md#changelog-entry-format).
* [x] All tests are passing.
* [x] The new code doesn't generate RuboCop offenses.
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.

[1]: http://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html

