### PR TITLE
[Fix #2950] Fix correcting in OneLineConditional

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 ### Bug fixes
 
 * [#2948](https://github.com/bbatsov/rubocop/issues/2948): `Style/SpaceAroundKeyword` should allow yield[n] and super[n]. ([@laurelfan][])
+* [#2950](https://github.com/bbatsov/rubocop/issues/2950): Fix auto-correcting cases in which precedence has changed in `Style/OneLineConditional`. ([@lumeet][])
 
 ## 0.38.0 (09/03/2016)
 

--- a/lib/rubocop/cop/style/one_line_conditional.rb
+++ b/lib/rubocop/cop/style/one_line_conditional.rb
@@ -28,18 +28,47 @@ module RuboCop
         end
 
         def replacement(node)
-          cond, body, else_clause = *node
-          ternary = "#{cond.source} ? #{body.source} : #{else_clause.source}"
+          return ternary(node) unless node.parent
+          return "(#{ternary(node)})" if [:and, :or].include?(node.parent.type)
 
-          return ternary unless node.parent
-          return "(#{ternary})" if [:and, :or].include?(node.parent.type)
-
-          if node.parent.send_type?
-            _receiver, method_name, = *node.parent
-            return "(#{ternary})" if operator?(method_name)
+          if node.parent.send_type? && operator?(node.parent.method_name)
+            return "(#{ternary(node)})"
           end
 
-          ternary
+          ternary(node)
+        end
+
+        def ternary(node)
+          cond, body, else_clause = *node
+          "#{expr_replacement(cond)} ? #{expr_replacement(body)} : " +
+            expr_replacement(else_clause)
+        end
+
+        def expr_replacement(node)
+          requires_parentheses?(node) ? "(#{node.source})" : node.source
+        end
+
+        def requires_parentheses?(node)
+          return true if [:and, :or, :if].include?(node.type)
+          return true if node.assignment?
+          return true if method_call_with_changed_precedence?(node)
+
+          keyword_with_changed_precedence?(node)
+        end
+
+        def method_call_with_changed_precedence?(node)
+          return false unless node.send_type?
+          return false if node.method_args.empty?
+          return false if parenthesized_call?(node)
+
+          !operator?(node.method_name)
+        end
+
+        def keyword_with_changed_precedence?(node)
+          return false unless node.keyword?
+          return true if node.keyword_not?
+
+          !parenthesized_call?(node)
         end
       end
     end

--- a/spec/rubocop/cop/style/one_line_conditional_spec.rb
+++ b/spec/rubocop/cop/style/one_line_conditional_spec.rb
@@ -54,4 +54,35 @@ describe RuboCop::Cop::Style::OneLineConditional do
       expect(corrected).to eq("a #{operator} (cond ? run : dont)")
     end
   end
+
+  shared_examples 'changed precedence' do |expr|
+    it "adds parentheses around `#{expr}`" do
+      corrected = autocorrect_source(cop,
+                                     "if #{expr} then #{expr} else #{expr} end")
+      expect(corrected).to eq("(#{expr}) ? (#{expr}) : (#{expr})")
+    end
+  end
+
+  it_behaves_like 'changed precedence', 'puts 1'
+  it_behaves_like 'changed precedence', 'defined? :A'
+  it_behaves_like 'changed precedence', 'yield a'
+  it_behaves_like 'changed precedence', 'super b'
+  it_behaves_like 'changed precedence', 'not a'
+  it_behaves_like 'changed precedence', 'a and b'
+  it_behaves_like 'changed precedence', 'a or b'
+  it_behaves_like 'changed precedence', 'a = b'
+  it_behaves_like 'changed precedence', 'a ? b : c'
+
+  it 'does not parenthesize expressions when they do not contain method ' \
+     'calls with unparenthesized arguments' do
+    corrected =
+      autocorrect_source(cop, 'if a(0) then puts(1) else yield(2) end')
+    expect(corrected).to eq('a(0) ? puts(1) : yield(2)')
+  end
+
+  it 'does not parenthesize expressions when they contain unparenthesized ' \
+     'operator method calls' do
+    corrected = autocorrect_source(cop, 'if 0 + 0 then 1 + 1 else 2 + 2 end')
+    expect(corrected).to eq('0 + 0 ? 1 + 1 : 2 + 2')
+  end
 end


### PR DESCRIPTION
Before submitting a PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [x] Used the same coding conventions as the rest of the project.
* [x] Feature branch is up-to-date with `master` (if not - rebase it)
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../CONTRIBUTING.md#changelog-entry-format).
* [x] All tests are passing.
* [x] The new code doesn't generate RuboCop offenses.
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.

[1]: http://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html

Auto-correting in `Style/OneLineConditional` handles method calls with
arguments correctly by using parentheses. E.g.

    if a then puts 1 else puts 2 end

...is auto-corrected to:

    a ? (puts 1) : (puts 2)