### PR TITLE
[Fix #2947] Next handles then keyword

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 
 * [#2948](https://github.com/bbatsov/rubocop/issues/2948): `Style/SpaceAroundKeyword` should allow yield[n] and super[n]. ([@laurelfan][])
 * [#2950](https://github.com/bbatsov/rubocop/issues/2950): Fix auto-correcting cases in which precedence has changed in `Style/OneLineConditional`. ([@lumeet][])
+* [#2947](https://github.com/bbatsov/rubocop/issues/2947): Fix auto-correcting `if-then` in `Style/Next`. ([@lumeet][])
 
 ## 0.38.0 (09/03/2016)
 

--- a/lib/rubocop/cop/style/next.rb
+++ b/lib/rubocop/cop/style/next.rb
@@ -146,9 +146,14 @@ module RuboCop
         end
 
         def cond_range(node, cond)
+          end_pos = if node.loc.begin
+                      node.loc.begin.end_pos # after "then"
+                    else
+                      cond.source_range.end_pos
+                    end
           Parser::Source::Range.new(node.source_range.source_buffer,
                                     node.source_range.begin_pos,
-                                    cond.source_range.end_pos)
+                                    end_pos)
         end
 
         def end_range(node)

--- a/spec/rubocop/cop/style/next_spec.rb
+++ b/spec/rubocop/cop/style/next_spec.rb
@@ -338,6 +338,18 @@ describe RuboCop::Cop::Style::Next, :config do
                               'end'].join("\n"))
   end
 
+  it 'handles `then` when autocorrecting' do
+    new_source = autocorrect_source(cop, ['loop do',
+                                          '  if test then',
+                                          '    something',
+                                          '  end',
+                                          'end'])
+    expect(new_source).to eq(['loop do',
+                              '  next unless test',
+                              '  something',
+                              'end'].join("\n"))
+  end
+
   it "doesn't reindent heredoc bodies when autocorrecting" do
     new_source = autocorrect_source(cop, ['loop do',
                                           '  if test',


### PR DESCRIPTION
Before submitting a PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [x] Used the same coding conventions as the rest of the project.
* [x] Feature branch is up-to-date with `master` (if not - rebase it)
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../CONTRIBUTING.md#changelog-entry-format).
* [x] All tests are passing.
* [x] The new code doesn't generate RuboCop offenses.
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.

[1]: http://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html

`Style/Next` removes the `then` keyword when auto-correcting to avoid
syntax errors.