### PR TITLE
Register an offense for RedundantMerge inside each_with_object

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@
 
 * `require:` only does relative includes when it starts with a `.`. ([@ptarjan][])
 * `Style/IfUnlessModifier` does not trigger if the body is another conditional. ([@amuino][])
+* [#2963](https://github.com/bbatsov/rubocop/pull/2963): `Performance/RedundantMerge` will now register an offense inside of `each_with_object`. ([@rrosenblum][])
 
 ## 0.38.0 (09/03/2016)
 


### PR DESCRIPTION
Part of the benefit of `each_with_object` is using mutable objects. `value_used?` isn't actual accurate in this condition.

What do you think about accounting for this inside of `value_used?` instead of only in `RedundantMerge`?