### PR TITLE
[Fix #2926] ZeroLengthPredicate can auto-correct

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### New features
 
 * `Performance/TimesMap` cop can auto-correct. ([@lumeet][])
+* `Style/ZeroLengthPredicate` cop can auto-correct. ([@lumeet][])
 
 ### Bug fixes
 

--- a/spec/rubocop/cop/style/zero_length_predicate_spec.rb
+++ b/spec/rubocop/cop/style/zero_length_predicate_spec.rb
@@ -10,7 +10,7 @@ describe RuboCop::Cop::Style::ZeroLengthPredicate do
     inspect_source(cop, source)
   end
 
-  shared_examples 'registers offense' do |code, message|
+  shared_examples 'registers offense' do |code, message, expected|
     context "when checking #{code}" do
       let(:source) { code }
 
@@ -19,42 +19,62 @@ describe RuboCop::Cop::Style::ZeroLengthPredicate do
         expect(cop.offenses.first.message).to eq(message)
         expect(cop.highlights).to eq([code])
       end
+
+      it 'auto-corrects' do
+        expect(autocorrect_source(cop, code)).to eq expected
+      end
     end
   end
 
   it_behaves_like 'registers offense', '[1, 2, 3].length == 0',
-                  'Use `empty?` instead of `length == 0`.'
+                  'Use `empty?` instead of `length == 0`.',
+                  '[1, 2, 3].empty?'
   it_behaves_like 'registers offense', '[1, 2, 3].size == 0',
-                  'Use `empty?` instead of `size == 0`.'
+                  'Use `empty?` instead of `size == 0`.',
+                  '[1, 2, 3].empty?'
   it_behaves_like 'registers offense', '0 == [1, 2, 3].length',
-                  'Use `empty?` instead of `0 == length`.'
+                  'Use `empty?` instead of `0 == length`.',
+                  '[1, 2, 3].empty?'
   it_behaves_like 'registers offense', '0 == [1, 2, 3].size',
-                  'Use `empty?` instead of `0 == size`.'
+                  'Use `empty?` instead of `0 == size`.',
+                  '[1, 2, 3].empty?'
 
   it_behaves_like 'registers offense', '[1, 2, 3].length < 1',
-                  'Use `empty?` instead of `length < 1`.'
+                  'Use `empty?` instead of `length < 1`.',
+                  '[1, 2, 3].empty?'
   it_behaves_like 'registers offense', '[1, 2, 3].size < 1',
-                  'Use `empty?` instead of `size < 1`.'
+                  'Use `empty?` instead of `size < 1`.',
+                  '[1, 2, 3].empty?'
   it_behaves_like 'registers offense', '1 > [1, 2, 3].length',
-                  'Use `empty?` instead of `1 > length`.'
+                  'Use `empty?` instead of `1 > length`.',
+                  '[1, 2, 3].empty?'
   it_behaves_like 'registers offense', '1 > [1, 2, 3].size',
-                  'Use `empty?` instead of `1 > size`.'
+                  'Use `empty?` instead of `1 > size`.',
+                  '[1, 2, 3].empty?'
 
   it_behaves_like 'registers offense', '[1, 2, 3].length > 0',
-                  'Use `!empty?` instead of `length > 0`.'
+                  'Use `!empty?` instead of `length > 0`.',
+                  '![1, 2, 3].empty?'
   it_behaves_like 'registers offense', '[1, 2, 3].size > 0',
-                  'Use `!empty?` instead of `size > 0`.'
+                  'Use `!empty?` instead of `size > 0`.',
+                  '![1, 2, 3].empty?'
   it_behaves_like 'registers offense', '[1, 2, 3].length != 0',
-                  'Use `!empty?` instead of `length != 0`.'
+                  'Use `!empty?` instead of `length != 0`.',
+                  '![1, 2, 3].empty?'
   it_behaves_like 'registers offense', '[1, 2, 3].size != 0',
-                  'Use `!empty?` instead of `size != 0`.'
+                  'Use `!empty?` instead of `size != 0`.',
+                  '![1, 2, 3].empty?'
 
   it_behaves_like 'registers offense', '0 < [1, 2, 3].length',
-                  'Use `!empty?` instead of `0 < length`.'
+                  'Use `!empty?` instead of `0 < length`.',
+                  '![1, 2, 3].empty?'
   it_behaves_like 'registers offense', '0 < [1, 2, 3].size',
-                  'Use `!empty?` instead of `0 < size`.'
+                  'Use `!empty?` instead of `0 < size`.',
+                  '![1, 2, 3].empty?'
   it_behaves_like 'registers offense', '0 != [1, 2, 3].length',
-                  'Use `!empty?` instead of `0 != length`.'
+                  'Use `!empty?` instead of `0 != length`.',
+                  '![1, 2, 3].empty?'
   it_behaves_like 'registers offense', '0 != [1, 2, 3].size',
-                  'Use `!empty?` instead of `0 != size`.'
+                  'Use `!empty?` instead of `0 != size`.',
+                  '![1, 2, 3].empty?'
 end


### PR DESCRIPTION
Before submitting a PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [x] Used the same coding conventions as the rest of the project.
* [x] Feature branch is up-to-date with `master` (if not - rebase it)
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../CONTRIBUTING.md#changelog-entry-format).
* [x] All tests are passing.
* [x] The new code doesn't generate RuboCop offenses.
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.

[1]: http://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html

`Style/ZeroLengthPredicate` auto-corrects

    [1, 2, 3] == 0

...to...

    [1, 2, 3].empty?