### PR TITLE
[Fix #2871] Make HTML template path UTF-8 encoded

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
 * [#2958](https://github.com/bbatsov/rubocop/issues/2958): `Style/MultilineMethodCallIndentation` doesn't fail when inspecting unary ops which span multiple lines. ([@alexdowad][])
 * [#2959](https://github.com/bbatsov/rubocop/issues/2959): `Lint/LiteralInInterpolation` doesn't report offenses for iranges and eranges with non-literal endpoints. ([@alexdowad][])
 * [#2960](https://github.com/bbatsov/rubocop/issues/2960): `Lint/AssignmentInCondition` catches method assignments (like `obj.attr = val`) in a condition. ([@alexdowad][])
+* [#2871](https://github.com/bbatsov/rubocop/issues/2871): Second solution for possible encoding incompatibility when outputting an HTML report. ([@jonas054][])
 
 ### Changes
 

--- a/lib/rubocop/formatter/html_formatter.rb
+++ b/lib/rubocop/formatter/html_formatter.rb
@@ -9,11 +9,11 @@ require 'rubocop/formatter/text_util'
 
 module RuboCop
   module Formatter
-    # This formatter saves the output as a html file.
+    # This formatter saves the output as an html file.
     class HTMLFormatter < BaseFormatter
       ELLIPSES = '<span class="extra-code">...</span>'.freeze
-      TEMPLATE_PATH =
-        File.expand_path('../../../../assets/output.html.erb', __FILE__)
+      TEMPLATE_PATH = File.expand_path('../../../../assets/output.html.erb',
+                                       __FILE__).encode('utf-8')
 
       Color = Struct.new(:red, :green, :blue, :alpha) do
         def to_s


### PR DESCRIPTION
Apparently the path to the template can be `ASCII-8BIT` encoded, depending on environment, and apparently this can be a problem.

Applying solution suggested in issue report by @moritzschepp.

I can't reproduce the problem, so no added tests.