### PR TITLE
[Fix #2977] Fix SpecialGlobalVars auto-correction

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@
 * [#2960](https://github.com/bbatsov/rubocop/issues/2960): `Lint/AssignmentInCondition` catches method assignments (like `obj.attr = val`) in a condition. ([@alexdowad][])
 * [#2871](https://github.com/bbatsov/rubocop/issues/2871): Second solution for possible encoding incompatibility when outputting an HTML report. ([@jonas054][])
 * [#2967](https://github.com/bbatsov/rubocop/pull/2967): Fix auto-correcting of `===`, `<=`, and `>=` in `Style/ConditionalAssignment`. ([@rrosenblum][])
+* [#2977](https://github.com/bbatsov/rubocop/issues/2977): Fix auto-correcting of `"#{$!}"` in `Style/SpecialGlobalVars`. ([@lumeet][])
 
 ### Changes
 

--- a/lib/rubocop/cop/style/special_global_vars.rb
+++ b/lib/rubocop/cop/style/special_global_vars.rb
@@ -118,7 +118,10 @@ module RuboCop
           unless [:dstr, :xstr, :regexp].include?(parent_type)
             return preferred_name.to_s
           end
-          return "{#{preferred_name}}" if style == :use_english_names
+
+          if style == :use_english_names
+            return english_name_replacement(preferred_name, node)
+          end
 
           "##{preferred_name}"
         end
@@ -129,6 +132,12 @@ module RuboCop
           else
             PERL_VARS[global]
           end
+        end
+
+        def english_name_replacement(preferred_name, node)
+          return "\#{#{preferred_name}}" if node.begin_type?
+
+          "{#{preferred_name}}"
         end
       end
     end

--- a/spec/rubocop/cop/style/special_global_vars_spec.rb
+++ b/spec/rubocop/cop/style/special_global_vars_spec.rb
@@ -65,6 +65,11 @@ describe RuboCop::Cop::Style::SpecialGlobalVars, :config do
       expect(new_source).to eq('"#{$LOAD_PATH}"')
     end
 
+    it 'auto-corrects #{$!} to #{$ERROR_INFO}' do
+      new_source = autocorrect_source(cop, '"#{$!}"')
+      expect(new_source).to eq('"#{$ERROR_INFO}"')
+    end
+
     it 'generates correct auto-config when Perl variable names are used' do
       inspect_source(cop, '$0')
       expect(cop.config_to_allow_offenses).to eq(


### PR DESCRIPTION
Before submitting a PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [x] Used the same coding conventions as the rest of the project.
* [x] Feature branch is up-to-date with `master` (if not - rebase it)
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../CONTRIBUTING.md#changelog-entry-format).
* [x] All tests are passing.
* [x] The new code doesn't generate RuboCop offenses.
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.

[1]: http://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html

`Style/SpecialGlobalVars` auto-corrects

    "#{$!}"

...correctly to...

    "#{$ERROR_INFO}"