### PR TITLE
Style/AlignParameters: Clarify the message for with_fixed_indentation style.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## master (unreleased)
 
+### Bug fixes
+
+* [#2983](https://github.com/bbatsov/rubocop/pull/2983): `Style/AlignParameters` message was clarified for `with_fixed_indentation` style. ([@dylanahsmith][])
+
 ## 0.39.0 (27/03/2016)
 
 ### New features
@@ -2082,3 +2086,4 @@
 [@necojackarc]: https://github.com/necojackarc
 [@laurelfan]: https://github.com/laurelfan
 [@amuino]: https://github.com/amuino
+[@dylanahsmith]: https://github.com/dylanahsmith

--- a/lib/rubocop/cop/style/align_parameters.rb
+++ b/lib/rubocop/cop/style/align_parameters.rb
@@ -10,6 +10,12 @@ module RuboCop
         include AutocorrectAlignment
         include OnMethodDef
 
+        ALIGN_PARAMS_MSG = 'Align the parameters of a method %s if they span ' \
+          'more than one line.'.freeze
+
+        FIXED_INDENT_MSG = 'Use one level of indentation for parameters ' \
+          'following the first line of a multi-line method %s.'.freeze
+
         def on_send(node)
           _receiver, method, *args = *node
 
@@ -27,8 +33,8 @@ module RuboCop
 
         def message(node)
           type = node && node.parent.send_type? ? 'call' : 'definition'
-          "Align the parameters of a method #{type} if they span " \
-          'more than one line.'
+          msg = fixed_indentation? ? FIXED_INDENT_MSG : ALIGN_PARAMS_MSG
+          format(msg, type)
         end
 
         private

--- a/spec/rubocop/cop/style/align_parameters_spec.rb
+++ b/spec/rubocop/cop/style/align_parameters_spec.rb
@@ -504,7 +504,10 @@ describe RuboCop::Cop::Style::AlignParameters do
                              '           b)',
                              'end'])
         expect(cop.offenses.size).to eq 1
-        expect(cop.offenses.first.to_s).to match(/method definition/)
+        expect(cop.messages)
+          .to eq(['Use one level of indentation for parameters ' \
+                  'following the first line of a multi-line method ' \
+                  'definition.'])
       end
 
       it 'registers an offense for parameters with double indent' do


### PR DESCRIPTION
## Problem

When using the following in .rubocop.yml

```
Style/AlignParameters:
  EnforcedStyle: with_fixed_indentation
```

code like

```ruby
method_call(arg1,
            arg2)
```

results in the offense message

```
tmp/style.rb:2:13: C: Align the parameters of a method call if they span more than one line.
            arg2)
            ^^^^
```

which is confusing, since the parameters of the method call **are** aligned.

## Solution

I changed the error message when using the with_fixed_indentation AlignParameters style to be the following for the above case to make it clearer what is wrong

```
tmp/style.rb:2:13: C: Use one level of indentation for parameters following the first line of a multi-line method call
            arg2)
            ^^^^
```