### PR TITLE
[Fix #2935] Make config loading work if SafeYAML.load is private

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@
 * [#2871](https://github.com/bbatsov/rubocop/issues/2871): Second solution for possible encoding incompatibility when outputting an HTML report. ([@jonas054][])
 * [#2967](https://github.com/bbatsov/rubocop/pull/2967): Fix auto-correcting of `===`, `<=`, and `>=` in `Style/ConditionalAssignment`. ([@rrosenblum][])
 * [#2977](https://github.com/bbatsov/rubocop/issues/2977): Fix auto-correcting of `"#{$!}"` in `Style/SpecialGlobalVars`. ([@lumeet][])
+* [#2935](https://github.com/bbatsov/rubocop/issues/2935): Make configuration loading work if `SafeYAML.load` is private. ([@jonas054][])
 
 ### Changes
 

--- a/lib/rubocop/config_loader.rb
+++ b/lib/rubocop/config_loader.rb
@@ -159,7 +159,7 @@ module RuboCop
 
       def yaml_safe_load(yaml_code)
         if YAML.respond_to?(:safe_load) # Ruby 2.1+
-          if defined?(SafeYAML)
+          if defined?(SafeYAML) && SafeYAML.respond_to?(:load)
             SafeYAML.load(yaml_code, nil, whitelisted_tags: %w(!ruby/regexp))
           else
             YAML.safe_load(yaml_code, [Regexp])

--- a/spec/rubocop/config_loader_spec.rb
+++ b/spec/rubocop/config_loader_spec.rb
@@ -431,6 +431,20 @@ describe RuboCop::ConfigLoader do
             expect(word_regexp).to be_a(::Regexp)
           end
         end
+
+        context 'and SafeYAML.load is private' do
+          # According to issue #2935, SafeYAML.load can be private in some
+          # circumstances.
+          it 'does not raise private method load called for SafeYAML:Module' do
+            in_its_own_process_with('safe_yaml/load') do
+              SafeYAML.send :private_class_method, :load
+              configuration = described_class.load_file('.rubocop.yml')
+
+              word_regexp = configuration['Style/WordArray']['WordRegex']
+              expect(word_regexp).to be_a(::Regexp)
+            end
+          end
+        end
       end
     end
   end


### PR DESCRIPTION
It looks like this can happen. We don't know why, but let's handle it.