### PR TITLE
Follow-up for 5e820eb

### DIFF
--- a/rubocop.gemspec
+++ b/rubocop.gemspec
@@ -27,7 +27,7 @@ Gem::Specification.new do |s|
   s.summary = 'Automatic Ruby code style checking tool.'
 
   s.add_runtime_dependency('rainbow', '>= 1.99.1', '< 3.0')
-  s.add_runtime_dependency('parser', '>= 2.3.0.6', '< 3.0')
+  s.add_runtime_dependency('parser', '>= 2.3.0.7', '< 3.0')
   s.add_runtime_dependency('powerpack', '~> 0.1')
   s.add_runtime_dependency('ruby-progressbar', '~> 1.7')
   s.add_runtime_dependency('unicode-display_width', '~> 1.0', '>= 1.0.1')

--- a/spec/rubocop/processed_source_spec.rb
+++ b/spec/rubocop/processed_source_spec.rb
@@ -195,6 +195,19 @@ describe RuboCop::ProcessedSource do
       end
     end
 
+    # https://github.com/whitequark/parser/issues/283
+    context 'when the source itself is valid encoding but includes strange ' \
+            'encoding literals that are accepted by MRI' do
+      let(:source) do
+        'p "\xff"'
+      end
+
+      it 'returns true' do
+        expect(processed_source.diagnostics).to be_empty
+        expect(processed_source).to be_valid_syntax
+      end
+    end
+
     context 'when a line starts with an integer literal' do
       let(:source) { '1 + 1' }
 


### PR DESCRIPTION
@bbatsov You just pushed the exactly the same change in 5e820eb 1 minute before I tried to push it :)

The invalid encoding literals are probably something we should warn of (as offenses), but we should not treat them as syntax error and abort processing since MRI accepts them.