### PR TITLE
[Fix #2975] Make comment indentation the same before ),  }, and ]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 * [#2983](https://github.com/bbatsov/rubocop/pull/2983): `Style/AlignParameters` message was clarified for `with_fixed_indentation` style. ([@dylanahsmith][])
 * [#2314](https://github.com/bbatsov/rubocop/pull/2314): Ignore `UnusedBlockArgument` for keyword arguments. ([@volkert][])
+* [#2975](https://github.com/bbatsov/rubocop/issues/2975): Make comment indentation before `)` consistent with comment indentation before `}` or `]`. ([@jonas054][])
 
 ## 0.39.0 (2016-03-27)
 

--- a/lib/rubocop/cop/style/comment_indentation.rb
+++ b/lib/rubocop/cop/style/comment_indentation.rb
@@ -52,7 +52,7 @@ module RuboCop
         end
 
         def less_indented?(line)
-          line =~ /^\s*(end\b|[\}\]])/
+          line =~ /^\s*(end\b|[)}\]])/
         end
 
         def two_alternatives?(line)

--- a/spec/rubocop/cop/style/comment_indentation_spec.rb
+++ b/spec/rubocop/cop/style/comment_indentation_spec.rb
@@ -119,9 +119,9 @@ describe RuboCop::Cop::Style::CommentIndentation do
                            '  ],',
                            '  #',
                            '  y: func(',
-                           '          1',
-                           '          #',
-                           '          )',
+                           '    1',
+                           '    #',
+                           '  )',
                            '  #',
                            '}',
                            '#'])


### PR DESCRIPTION
We already had special handling of comments before closing curly brace and closing square bracket. 

Handle a closing round parenthesis the same way, which is that the comment should be indented one step more than the following line.