### PR TITLE
[Fix #2928] Add auto-correct for Style/NestedParenthesizedCalls cop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### New features
 
 * [#2997](https://github.com/bbatsov/rubocop/pull/2997): `Performance/CaseWhenSplat` can now identify multiple offenses in the same branch and offenses that do not occur as the first argument. ([@rrosenblum][])
+* [#2928](https://github.com/bbatsov/rubocop/issues/2928): `Style/NestedParenthesizedCalls` cop can auto-correct. ([@drenmi][])
 
 ### Bug fixes
 

--- a/lib/rubocop/cop/style/nested_parenthesized_calls.rb
+++ b/lib/rubocop/cop/style/nested_parenthesized_calls.rb
@@ -39,6 +39,21 @@ module RuboCop
             RSPEC_MATCHERS.include?(send.method_name) &&
             send.method_args.one?
         end
+
+        def autocorrect(nested)
+          _scope, _method_name, *args = *nested
+
+          first_arg = args.first.source_range
+          last_arg = args.last.source_range
+
+          first_arg_with_space = range_with_surrounding_space(first_arg, :left)
+          leading_space = first_arg_with_space.begin.resize(1)
+
+          lambda do |corrector|
+            corrector.replace(leading_space, '(')
+            corrector.insert_after(last_arg, ')')
+          end
+        end
       end
     end
   end

--- a/spec/rubocop/cop/style/nested_parenthesized_calls_spec.rb
+++ b/spec/rubocop/cop/style/nested_parenthesized_calls_spec.rb
@@ -35,13 +35,36 @@ describe RuboCop::Cop::Style::NestedParenthesizedCalls do
   end
 
   context 'on a non-parenthesized call nested in a parenthesized one' do
-    let(:source) { 'puts(compute something)' }
+    context 'with a single argument to the nested call' do
+      let(:source) { 'puts(compute something)' }
 
-    it 'registers an offense' do
-      expect(cop.offenses.size).to eq(1)
-      expect(cop.messages).to eq(
-        ['Add parentheses to nested method call `compute something`.'])
-      expect(cop.highlights).to eq(['compute something'])
+      it 'registers an offense' do
+        expect(cop.offenses.size).to eq(1)
+        expect(cop.messages).to eq(
+          ['Add parentheses to nested method call `compute something`.'])
+        expect(cop.highlights).to eq(['compute something'])
+      end
+
+      it 'auto-corrects by adding parentheses' do
+        new_source = autocorrect_source(cop, source)
+        expect(new_source).to eq('puts(compute(something))')
+      end
+    end
+
+    context 'with multiple arguments to the nested call' do
+      let(:source) { 'puts(compute first, second)' }
+
+      it 'registers an offense' do
+        expect(cop.offenses.size).to eq(1)
+        expect(cop.messages).to eq(
+          ['Add parentheses to nested method call `compute first, second`.'])
+        expect(cop.highlights).to eq(['compute first, second'])
+      end
+
+      it 'auto-corrects by adding parentheses' do
+        new_source = autocorrect_source(cop, 'puts(compute first, second)')
+        expect(new_source).to eq('puts(compute(first, second))')
+      end
     end
   end
 


### PR DESCRIPTION
This is a fairly straight-forward change. It simply adds auto-correct for `Style/NestedParenthesizedCalls` as was requested in https://github.com/bbatsov/rubocop/issues/2928.

Example:

```
expect(shorten url).to be short_url
```

will be auto-corrected to:

```
expect(shorten(url)).to be short_url
```