### PR TITLE
Fix reset of encoding after US_ASCII test

### DIFF
--- a/spec/rubocop/cop/style/end_of_line_spec.rb
+++ b/spec/rubocop/cop/style/end_of_line_spec.rb
@@ -51,9 +51,12 @@ describe RuboCop::Cop::Style::EndOfLine do
   end
 
   context 'when the default external encoding is US_ASCII' do
-    let(:orig_encoding) { Encoding.default_external }
-    before(:each) { Encoding.default_external = Encoding::US_ASCII }
-    after(:each) { Encoding.default_external = orig_encoding }
+    around(:each) do |example|
+      orig_encoding = Encoding.default_external
+      Encoding.default_external = Encoding::US_ASCII
+      example.run
+      Encoding.default_external = orig_encoding
+    end
 
     it 'does not crash on UTF-8 encoded non-ascii characters' do
       inspect_source_file(cop,


### PR DESCRIPTION
The test originally attempted to reset the encoding after each example
however due to the way let() works, orig_encoding was only set at the
time we wish to use it's value.

Due to this flaw the after(:each) call set the encoding to US_ASCII
again.



Before submitting a PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [x] Used the same coding conventions as the rest of the project.
* [x] Feature branch is up-to-date with `master` (if not - rebase it)
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../CONTRIBUTING.md#changelog-entry-format).
* [x] All tests are passing.
* [x] The new code doesn't generate RuboCop offenses.
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.

[1]: http://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html

