### PR TITLE
Read command line options from ./.rubocop file and RUBOCOP_OPTS environment variable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 * [#2928](https://github.com/bbatsov/rubocop/issues/2928): `Style/NestedParenthesizedCalls` cop can auto-correct. ([@drenmi][])
 * `Style/RaiseArgs` cop can auto-correct. ([@drenmi][])
 * [#2993](https://github.com/bbatsov/rubocop/pull/2993): `Style/SpaceAfterColon` now checks optional keyword arguments. ([@owst][])
+* [#3003](https://github.com/bbatsov/rubocop/pull/3003): Read command line options from `.rubocop` file and `RUBOCOP_OPTS` environment variable. ([@bolshakov][])
 
 ### Bug fixes
 
@@ -2104,3 +2105,4 @@
 [@amuino]: https://github.com/amuino
 [@dylanahsmith]: https://github.com/dylanahsmith
 [@gerrywastaken]: https://github.com/gerrywastaken
+[@bolshakov]: https://github.com/bolshakov

--- a/README.md
+++ b/README.md
@@ -203,6 +203,13 @@ Command flag              | Description
 `-s/--stdin`              | Pipe source from STDIN. This is useful for editor integration.
 `--[no-]color`            | Force color output on or off.
 
+Default command-line options are loaded from `.rubocop` and `RUBOCOP_OPTS` and are combined with command-line options that are explicitly passed to `rubocop`.
+Thus, the options have the following order of precedence (from highest to lowest):
+
+1. Explicit command-line options
+2. Options from `RUBOCOP_OPTS` environment variable
+3. Options from `.rubocop` file.
+
 ### Cops
 
 In RuboCop lingo the various checks performed on the code are called cops. There are several cop departments.

--- a/lib/rubocop/options.rb
+++ b/lib/rubocop/options.rb
@@ -2,6 +2,7 @@
 # frozen_string_literal: true
 
 require 'optparse'
+require 'shellwords'
 
 module RuboCop
   # This class handles command line options.
@@ -14,7 +15,8 @@ module RuboCop
       @validator = OptionsValidator.new(@options)
     end
 
-    def parse(args)
+    def parse(command_line_args)
+      args = args_from_file.concat(args_from_env).concat(command_line_args)
       define_options(args).parse!(args)
       # The --no-color CLI option sets `color: false` so we don't want the
       # `no_color` key, which is created automatically.
@@ -30,6 +32,18 @@ module RuboCop
     end
 
     private
+
+    def args_from_file
+      if File.exist?('.rubocop')
+        IO.readlines('.rubocop').map(&:strip)
+      else
+        []
+      end
+    end
+
+    def args_from_env
+      Shellwords.split(ENV.fetch('RUBOCOP_OPTS', ''))
+    end
 
     def define_options(args)
       OptionParser.new do |opts|


### PR DESCRIPTION
This may be useful when running rubocop using another tool, for example [pronto](https://github.com/mmozuras/pronto) or on CI server.

Place one option per line:

```sh
$ cat .rubocop
--no-color
--fail-fast
```

Configuration options are loaded from `.rubocop`, command line switches, and the `RUBOCOP_OPTS` environment variable (listed in
lowest to highest precedence; for example, an option in `.rubocop` can be overridden by an option in `RUBOCOP_OPTS`).

I borrowed idea from [the similar rspec feature](https://www.relishapp.com/rspec/rspec-core/docs/configuration/read-command-line-configuration-options-from-files).