### PR TITLE
Don't add Style/Alias offense for use of alias in eval_instance blocks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,7 @@
 * [#3048](https://github.com/bbatsov/rubocop/issues/3048): `Lint/NestedMethodDefinition` shouldn't flag methods defined on Structs. ([@owst][])
 * [#2912](https://github.com/bbatsov/rubocop/issues/2912): Check whether a line is aligned with the following line if the preceding line is not an assignment. ([@akihiro17][])
 * [#3036](https://github.com/bbatsov/rubocop/issues/3036): Don't let `Lint/UnneededDisable` inspect files that are excluded for the cop. ([@jonas054][])
+* [#3004](https://github.com/bbatsov/rubocop/pull/3004): Don't add `Style/Alias` offenses for use of `alias` in `instance_eval` blocks, since object instances don't respond to `alias_method`. ([@magni-][])
 
 ### Changes
 
@@ -2130,3 +2131,4 @@
 [@jastkand]: https://github.com/jastkand
 [@graemeboy]: https://github.com/graemeboy
 [@akihiro17]: https://github.com/akihiro17
+[@magni-]: https://github.com/magni-

--- a/spec/rubocop/cop/style/alias_spec.rb
+++ b/spec/rubocop/cop/style/alias_spec.rb
@@ -42,6 +42,17 @@ describe RuboCop::Cop::Style::Alias, :config do
       inspect_source(cop, 'alias $ala $bala')
       expect(cop.offenses).to be_empty
     end
+
+    it 'does not register an offense for alias in an instance_eval block' do
+      inspect_source(cop, ['module M',
+                           '  def foo',
+                           '    instance_eval {',
+                           '      alias bar baz',
+                           '    }',
+                           '  end',
+                           'end'])
+      expect(cop.offenses).to be_empty
+    end
   end
 
   context 'when EnforcedStyle is prefer_alias' do
@@ -136,6 +147,17 @@ describe RuboCop::Cop::Style::Alias, :config do
     it 'does not register an offense for alias_method in a block' do
       inspect_source(cop, ['dsl_method do',
                            '  alias_method :ala, :bala',
+                           'end'])
+      expect(cop.offenses).to be_empty
+    end
+
+    it 'does not register an offense for alias in an instance_eval block' do
+      inspect_source(cop, ['module M',
+                           '  def foo',
+                           '    instance_eval {',
+                           '      alias bar baz',
+                           '    }',
+                           '  end',
                            'end'])
       expect(cop.offenses).to be_empty
     end


### PR DESCRIPTION
This fixes an issue with the `Style/Alias` cop. `instance_eval` blocks are found to be dynamic scope, so Rubocop currently adds an offense when using `alias` instead of `alias_method`, but object instances do not respond to `alias_method`.

---

Before submitting a PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [x] Used the same coding conventions as the rest of the project.
* [x] Feature branch is up-to-date with `master` (if not - rebase it)
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../CONTRIBUTING.md#changelog-entry-format).
* [x] All tests are passing.
* [x] The new code doesn't generate RuboCop offenses.
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.

[1]: http://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html
