### PR TITLE
Add auto-correct for Style/RaiseArgs cop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 * [#2997](https://github.com/bbatsov/rubocop/pull/2997): `Performance/CaseWhenSplat` can now identify multiple offenses in the same branch and offenses that do not occur as the first argument. ([@rrosenblum][])
 * [#2928](https://github.com/bbatsov/rubocop/issues/2928): `Style/NestedParenthesizedCalls` cop can auto-correct. ([@drenmi][])
+* `Style/RaiseArgs` cop can auto-correct. ([@drenmi][])
 
 ### Bug fixes
 

--- a/lib/rubocop/cop/style/raise_args.rb
+++ b/lib/rubocop/cop/style/raise_args.rb
@@ -4,9 +4,47 @@
 module RuboCop
   module Cop
     module Style
-      # This cop checks the args passed to `fail` and `raise`.
+      # This cop checks the args passed to `fail` and `raise`. For exploded
+      # style (default), it recommends passing the exception class and message
+      # to `raise`, rather than construct an instance of the error. It will
+      # still allow passing just a message, or the construction of an error
+      # with more than one argument.
+      #
+      # The exploded style works identically, but with the addition that it
+      # will also suggest constructing error objects when the exception is
+      # passed multiple arguments.
+      #
+      # @example
+      #
+      #   # EnforcedStyle: exploded
+      #
+      #   # bad
+      #   raise StandardError.new("message")
+      #
+      #   # good
+      #   raise StandardError, "message"
+      #   fail "message"
+      #   raise RuntimeError.new(arg1, arg2, arg3)
+      #
+      # @example
+      #
+      #   # EnforcedStyle: compact
+      #
+      #   # bad
+      #   raise StandardError, "message"
+      #   raise RuntimeError, arg1, arg2, arg3
+      #
+      #   # good
+      #   raise StandardError.new("message")
+      #   raise RuntimeError.new(arg1, arg2, arg3)
+      #   fail "message"
       class RaiseArgs < Cop
         include ConfigurableEnforcedStyle
+
+        EXPLODED_MSG = 'Provide an exception class and message ' \
+          'as arguments to `%s`.'.freeze
+        COMPACT_MSG = 'Provide an exception object ' \
+          'as an argument to `%s`.'.freeze
 
         def on_send(node)
           return unless node.command?(:raise) || node.command?(:fail)
@@ -20,6 +58,33 @@ module RuboCop
         end
 
         private
+
+        def autocorrect(node)
+          _scope, method, *args = *node
+
+          new_exception = if style == :compact
+                            correction_exploded_to_compact(args)
+                          else
+                            correction_compact_to_exploded(args)
+                          end
+          replacement = "#{method} #{new_exception}"
+
+          ->(corrector) { corrector.replace(node.source_range, replacement) }
+        end
+
+        def correction_compact_to_exploded(node)
+          exception_node, _new, message_node = *node.first
+
+          "#{exception_node.const_name}, #{message_node.source}"
+        end
+
+        def correction_exploded_to_compact(node)
+          exception_node, *message_nodes = *node
+
+          messages = message_nodes.map(&:source).join(', ')
+
+          "#{exception_node.const_name}.new(#{messages})"
+        end
 
         def check_compact(node)
           _receiver, selector, *args = *node
@@ -55,12 +120,10 @@ module RuboCop
         end
 
         def message(method)
-          case style
-          when :compact
-            "Provide an exception object as an argument to `#{method}`."
-          when :exploded
-            'Provide an exception class and message as ' \
-            "arguments to `#{method}`."
+          if style == :compact
+            format(COMPACT_MSG, method)
+          else
+            format(EXPLODED_MSG, method)
           end
         end
       end


### PR DESCRIPTION
This change adds auto-correct for `Style/RaiseArgs`. I also took the opportunity to add some more documentation to the cop.

Examples:

```
raise StandardError.new("message")
```

will be corrected to:

```
raise StandardError, "message"
```

... and ...

```
raise StandardError, "message"
raise StanrardError, arg1, arg2, arg3
```

will be corrected to:

```
raise StandardError.new("message")
raise StandardError.new(arg1, arg2, arg3)
```