### PR TITLE
[Fix #3010] Remove warning/correction duplication

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 * [#2983](https://github.com/bbatsov/rubocop/pull/2983): `Style/AlignParameters` message was clarified for `with_fixed_indentation` style. ([@dylanahsmith][])
 * [#2314](https://github.com/bbatsov/rubocop/pull/2314): Ignore `UnusedBlockArgument` for keyword arguments. ([@volkert][])
 * [#2975](https://github.com/bbatsov/rubocop/issues/2975): Make comment indentation before `)` consistent with comment indentation before `}` or `]`. ([@jonas054][])
+* [#3010](https://github.com/bbatsov/rubocop/issues/3010): Fix double reporting/correction of spaces after ternary operator colons (now only reported by `Style/SpaceAroundOperators`, and not `Style/SpaceAfterColon` too). ([@owst][])
 
 ## 0.39.0 (2016-03-27)
 

--- a/lib/rubocop/cop/style/space_after_colon.rb
+++ b/lib/rubocop/cop/style/space_after_colon.rb
@@ -5,6 +5,8 @@ module RuboCop
   module Cop
     module Style
       # Checks for colon (:) not followed by some kind of space.
+      # N.B. this cop does not handle spaces after a ternary operator, which are
+      # instead handled by Style/SpaceAroundOperators.
       class SpaceAfterColon < Cop
         include IfNode
 
@@ -15,15 +17,6 @@ module RuboCop
           return unless oper.is?(':') && followed_by_space?(oper)
 
           add_offense(oper, oper)
-        end
-
-        def on_if(node)
-          return unless ternary?(node)
-
-          colon = node.loc.colon
-          return unless followed_by_space?(colon)
-
-          add_offense(colon, colon)
         end
 
         def followed_by_space?(colon)

--- a/spec/rubocop/cop/style/space_after_colon_spec.rb
+++ b/spec/rubocop/cop/style/space_after_colon_spec.rb
@@ -7,11 +7,9 @@ describe RuboCop::Cop::Style::SpaceAfterColon do
   subject(:cop) { described_class.new }
 
   it 'registers an offense for colon without space after it' do
-    # TODO: There is double reporting of the last colon (also from
-    # SpaceAroundOperators).
-    inspect_source(cop, 'x = w ? {a:3}:4')
-    expect(cop.messages).to eq(['Space missing after colon.'] * 2)
-    expect(cop.highlights).to eq([':'] * 2)
+    inspect_source(cop, '{a:3}')
+    expect(cop.messages).to eq(['Space missing after colon.'])
+    expect(cop.highlights).to eq([':'])
   end
 
   it 'accepts colons in symbols' do
@@ -21,6 +19,11 @@ describe RuboCop::Cop::Style::SpaceAfterColon do
 
   it 'accepts colon in ternary followed by space' do
     inspect_source(cop, 'x = w ? a : b')
+    expect(cop.messages).to be_empty
+  end
+
+  it 'accepts hashes with a space after colons' do
+    inspect_source(cop, '{a: 3}')
     expect(cop.messages).to be_empty
   end
 
@@ -36,6 +39,16 @@ describe RuboCop::Cop::Style::SpaceAfterColon do
     expect(cop.messages).to be_empty
   end
 
+  it 'accepts colons in strings' do
+    inspect_source(cop, "str << ':'")
+    expect(cop.messages).to be_empty
+  end
+
+  it 'accepts ternary operators without a trailing space' do
+    inspect_source(cop, 'x == b ? 1 :2')
+    expect(cop.messages).to be_empty
+  end
+
   if RUBY_VERSION >= '2.1'
     it 'accepts colons denoting required keyword argument' do
       inspect_source(cop, ['def initialize(table:, nodes:)',
@@ -44,13 +57,8 @@ describe RuboCop::Cop::Style::SpaceAfterColon do
     end
   end
 
-  it 'accepts colons in strings' do
-    inspect_source(cop, "str << ':'")
-    expect(cop.messages).to be_empty
-  end
-
   it 'auto-corrects missing space' do
-    new_source = autocorrect_source(cop, 'x = w ? {a:3}:4')
-    expect(new_source).to eq('x = w ? {a: 3}: 4')
+    new_source = autocorrect_source(cop, '{a:3}')
+    expect(new_source).to eq('{a: 3}')
   end
 end

--- a/spec/rubocop/cop/style/space_around_operators_spec.rb
+++ b/spec/rubocop/cop/style/space_around_operators_spec.rb
@@ -196,16 +196,35 @@ describe RuboCop::Cop::Style::SpaceAroundOperators do
       expect(new_source).to eq(['x = 0', 'y = 0', 'z = 0'].join("\n"))
     end
 
-    it 'registers an offense for ternary operator without space' do
-      inspect_source(cop, 'x == 0?1:2')
-      expect(cop.messages).to eq(
-        ['Surrounding space missing for operator `?`.',
-         'Surrounding space missing for operator `:`.'])
-    end
+    context 'ternary operators' do
+      it 'registers an offense for operators with no spaces' do
+        inspect_source(cop, 'x == 0?1:2')
 
-    it 'auto-corrects a ternary operator without space' do
-      new_source = autocorrect_source(cop, 'x == 0?1:2')
-      expect(new_source).to eq('x == 0 ? 1 : 2')
+        expect(cop.messages).to eq(
+          ['Surrounding space missing for operator `?`.',
+           'Surrounding space missing for operator `:`.'])
+      end
+
+      it 'registers an offense for operators with just a trailing space' do
+        inspect_source(cop, 'x == 0? 1: 2')
+
+        expect(cop.messages).to eq(
+          ['Surrounding space missing for operator `?`.',
+           'Surrounding space missing for operator `:`.'])
+      end
+
+      it 'registers an offense for operators with just a leading space' do
+        inspect_source(cop, 'x == 0 ?1 :2')
+
+        expect(cop.messages).to eq(
+          ['Surrounding space missing for operator `?`.',
+           'Surrounding space missing for operator `:`.'])
+      end
+
+      it 'auto-corrects a ternary operator without space' do
+        new_source = autocorrect_source(cop, 'x == 0?1:2')
+        expect(new_source).to eq('x == 0 ? 1 : 2')
+      end
     end
 
     it 'registers an offense in presence of modifier if statement' do


### PR DESCRIPTION
Before submitting a PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [x] Used the same coding conventions as the rest of the project.
* [x] Feature branch is up-to-date with `master` (if not - rebase it)
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../CONTRIBUTING.md#changelog-entry-format).
* [x] All tests are passing.
* [x] The new code doesn't generate RuboCop offenses.
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.

[1]: http://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html

Both Style/SpaceAfterColon and Style/SpaceAroundOperators were detecting
the missing space after a colon in a ternary operator, this led to
redundant warnings and corrections. To fix, the ternary handling from
Style/SpaceAfterColon was removed.