### PR TITLE
Move the #ternary? predicate method to IfNode module

### DIFF
--- a/lib/rubocop/cop/lint/condition_position.rb
+++ b/lib/rubocop/cop/lint/condition_position.rb
@@ -14,8 +14,10 @@ module RuboCop
       #     do_something
       #   end
       class ConditionPosition < Cop
+        include IfNode
+
         def on_if(node)
-          return if node.loc.respond_to?(:question)
+          return if ternary?(node)
 
           check(node)
         end

--- a/lib/rubocop/cop/lint/else_layout.rb
+++ b/lib/rubocop/cop/lint/else_layout.rb
@@ -16,9 +16,10 @@ module RuboCop
       #     do_that
       #   end
       class ElseLayout < Cop
+        include IfNode
+
         def on_if(node)
-          # ignore ternary ops
-          return if node.loc.respond_to?(:question)
+          return if ternary?(node)
           # ignore modifier ops & elsif nodes
           return unless node.loc.end
 

--- a/lib/rubocop/cop/lint/end_alignment.rb
+++ b/lib/rubocop/cop/lint/end_alignment.rb
@@ -45,7 +45,7 @@ module RuboCop
         end
 
         def on_if(node)
-          check_other_alignment(node) unless ternary_op?(node)
+          check_other_alignment(node) unless ternary?(node)
         end
 
         def on_while(node)
@@ -69,7 +69,7 @@ module RuboCop
           # we check if it's an if/unless/while/until.
           return unless (rhs = first_part_of_call_chain(rhs))
           return unless [:if, :while, :until, :case].include?(rhs.type)
-          return if ternary_op?(rhs)
+          return if ternary?(rhs)
 
           check_asgn_alignment(node, rhs)
         end

--- a/lib/rubocop/cop/lint/require_parentheses.rb
+++ b/lib/rubocop/cop/lint/require_parentheses.rb
@@ -30,7 +30,7 @@ module RuboCop
           return if parentheses?(node)
           return if args.empty?
 
-          if ternary_op?(args.first)
+          if ternary?(args.first)
             check_ternary(args.first, node)
           elsif predicate?(method_name)
             # We're only checking predicate methods. There would be false

--- a/lib/rubocop/cop/mixin/if_node.rb
+++ b/lib/rubocop/cop/mixin/if_node.rb
@@ -5,6 +5,10 @@ module RuboCop
   module Cop
     # Common functionality for checking if nodes.
     module IfNode
+      def ternary?(node)
+        node.loc.respond_to?(:question)
+      end
+
       def modifier_if?(node)
         node.loc.respond_to?(:keyword) &&
           %w(if unless).include?(node.loc.keyword.source) &&

--- a/lib/rubocop/cop/mixin/on_normal_if_unless.rb
+++ b/lib/rubocop/cop/mixin/on_normal_if_unless.rb
@@ -13,7 +13,7 @@ module RuboCop
 
       def invoke_hook_for_normal_if_unless(node)
         # We won't check modifier or ternary conditionals.
-        return if modifier_if?(node) || ternary_op?(node)
+        return if modifier_if?(node) || ternary?(node)
         on_normal_if_unless(node)
       end
 

--- a/lib/rubocop/cop/style/conditional_assignment.rb
+++ b/lib/rubocop/cop/style/conditional_assignment.rb
@@ -275,7 +275,7 @@ module RuboCop
         private
 
         def move_assignment_outside_condition(node)
-          if ternary_op?(node)
+          if ternary?(node)
             TernaryCorrector.correct(node)
           elsif node.loc.keyword.is?(IF)
             IfCorrector.correct(self, node)
@@ -288,7 +288,7 @@ module RuboCop
 
         def move_assignment_inside_condition(node)
           *_assignment, condition = *node
-          if ternary_op?(condition) || ternary_op?(condition.children[0])
+          if ternary?(condition) || ternary?(condition.children[0])
             TernaryCorrector.move_assignment_inside_condition(node)
           elsif condition.case_type?
             CaseCorrector.move_assignment_inside_condition(node)

--- a/lib/rubocop/cop/style/guard_clause.rb
+++ b/lib/rubocop/cop/style/guard_clause.rb
@@ -65,7 +65,7 @@ module RuboCop
 
           return unless body && else_body
           # discard modifier ifs and ternary_ops
-          return if modifier_if?(node) || ternary_op?(node) || elsif?(node)
+          return if modifier_if?(node) || ternary?(node) || elsif?(node)
 
           return unless single_line_control_flow_exit?(body) ||
                         single_line_control_flow_exit?(else_body)
@@ -92,7 +92,7 @@ module RuboCop
 
           return if body && else_body
           # discard modifier ifs and ternary_ops
-          return if modifier_if?(node) || ternary_op?(node)
+          return if modifier_if?(node) || ternary?(node)
           return if cond.multiline?
           # discard short ifs
           return unless min_body_length?(node)

--- a/lib/rubocop/cop/style/if_inside_else.rb
+++ b/lib/rubocop/cop/style/if_inside_else.rb
@@ -37,7 +37,7 @@ module RuboCop
           _cond, _if_branch, else_branch = *node
           return unless else_branch
           return unless else_branch.if_type?
-          return if ternary_op?(node) || ternary_op?(else_branch)
+          return if ternary?(node) || ternary?(else_branch)
           return unless else_branch.loc.keyword.is?('if')
           return if node.loc.keyword.is?('unless')
 

--- a/lib/rubocop/cop/style/if_unless_modifier.rb
+++ b/lib/rubocop/cop/style/if_unless_modifier.rb
@@ -8,6 +8,7 @@ module RuboCop
       # if written as a modifier if/unless.
       # The maximum line length is configurable.
       class IfUnlessModifier < Cop
+        include IfNode
         include StatementModifier
 
         ASSIGNMENT_TYPES = [:lvasgn, :casgn, :cvasgn,
@@ -20,7 +21,7 @@ module RuboCop
 
         def on_if(node)
           # discard ternary ops, if/else and modifier if/unless nodes
-          return if ternary_op?(node)
+          return if ternary?(node)
           return if modifier_if?(node)
           return if elsif?(node)
           return if if_else?(node)

--- a/lib/rubocop/cop/style/indentation_width.rb
+++ b/lib/rubocop/cop/style/indentation_width.rb
@@ -152,7 +152,7 @@ module RuboCop
 
         def on_if(node, base = node)
           return if ignored_node?(node)
-          return if ternary_op?(node)
+          return if ternary?(node)
           return if modifier_if?(node)
 
           _condition, body, else_clause = if_node_parts(node)
@@ -183,7 +183,7 @@ module RuboCop
         end
 
         def check_if(node, body, else_clause, base_loc)
-          return if ternary_op?(node)
+          return if ternary?(node)
 
           check_indentation(base_loc, body)
           return unless else_clause

--- a/lib/rubocop/cop/style/multiline_ternary_operator.rb
+++ b/lib/rubocop/cop/style/multiline_ternary_operator.rb
@@ -6,17 +6,19 @@ module RuboCop
     module Style
       # This cop checks for multi-line ternary op expressions.
       class MultilineTernaryOperator < Cop
-        MSG = 'Avoid multi-line ?: (the ternary operator);' \
-              ' use `if`/`unless` instead.'.freeze
+        include IfNode
+
+        MSG = 'Avoid multi-line ternary operators, ' \
+              'use `if` or `unless` instead.'.freeze
 
         def on_if(node)
           _condition, _if_branch, else_branch = *node
-          loc = node.loc
 
-          # discard non-ternary ops
-          return unless loc.respond_to?(:question)
+          return unless ternary?(node)
 
-          add_offense(node, :expression) if loc.line != else_branch.loc.line
+          unless node.loc.line == else_branch.loc.line
+            add_offense(node, :expression)
+          end
         end
       end
     end

--- a/lib/rubocop/cop/style/nested_ternary_operator.rb
+++ b/lib/rubocop/cop/style/nested_ternary_operator.rb
@@ -6,19 +6,16 @@ module RuboCop
     module Style
       # This cop checks for nested ternary op expressions.
       class NestedTernaryOperator < Cop
-        MSG = 'Ternary operators must not be nested. Prefer `if`/`else` ' \
+        include IfNode
+
+        MSG = 'Ternary operators must not be nested. Prefer `if` or `else` ' \
               'constructs instead.'.freeze
 
         def on_if(node)
-          loc = node.loc
-
-          # discard non-ternary ops
-          return unless loc.respond_to?(:question)
+          return unless ternary?(node)
 
           node.each_descendant(:if) do |nested_if_node|
-            if nested_if_node.loc.respond_to?(:question)
-              add_offense(nested_if_node, :expression)
-            end
+            add_offense(nested_if_node, :expression) if ternary?(nested_if_node)
           end
         end
       end

--- a/lib/rubocop/cop/style/next.rb
+++ b/lib/rubocop/cop/style/next.rb
@@ -82,7 +82,7 @@ module RuboCop
 
         def simple_if_without_break?(node)
           return false unless node.if_type?
-          return false if ternary_op?(node)
+          return false if ternary?(node)
           return false if if_else?(node)
           return false if style == :skip_modifier_ifs && modifier_if?(node)
           return false if !modifier_if?(node) && !min_body_length?(node)

--- a/lib/rubocop/cop/style/not.rb
+++ b/lib/rubocop/cop/style/not.rb
@@ -6,6 +6,8 @@ module RuboCop
     module Style
       # This cop checks for uses if the keyword *not* instead of !.
       class Not < Cop
+        include IfNode
+
         MSG = 'Use `!` instead of `not`.'.freeze
 
         OPPOSITE_METHODS = {
@@ -35,7 +37,7 @@ module RuboCop
                                 OPPOSITE_METHODS[child.method_name].to_s)
             end
           elsif child.and_type? || child.or_type? || child.binary_operation? ||
-                ternary_op?(child)
+                ternary?(child)
             lambda do |corrector|
               corrector.replace(range, '!(')
               corrector.insert_after(node.source_range, ')')

--- a/lib/rubocop/cop/style/parentheses_around_condition.rb
+++ b/lib/rubocop/cop/style/parentheses_around_condition.rb
@@ -12,7 +12,7 @@ module RuboCop
         include Parentheses
 
         def on_if(node)
-          return if ternary_op?(node)
+          return if ternary?(node)
           process_control_op(node)
         end
 
@@ -41,7 +41,7 @@ module RuboCop
         end
 
         def modifier_op?(node)
-          return false if ternary_op?(node)
+          return false if ternary?(node)
           return true if node.type == :rescue
 
           [:if, :while, :until].include?(node.type) &&

--- a/lib/rubocop/cop/style/space_after_colon.rb
+++ b/lib/rubocop/cop/style/space_after_colon.rb
@@ -18,7 +18,7 @@ module RuboCop
         end
 
         def on_if(node)
-          return unless ternary_op?(node)
+          return unless ternary?(node)
 
           colon = node.loc.colon
           return unless followed_by_space?(colon)

--- a/lib/rubocop/cop/style/space_around_operators.rb
+++ b/lib/rubocop/cop/style/space_around_operators.rb
@@ -7,6 +7,7 @@ module RuboCop
       # Checks that operators have space around them, except for **
       # which should not have surrounding space.
       class SpaceAroundOperators < Cop
+        include IfNode
         include PrecedingFollowingAlignment
         include HashNode # any_pairs_on_the_same_line?
 
@@ -22,7 +23,7 @@ module RuboCop
         end
 
         def on_if(node)
-          return unless node.loc.respond_to?(:question)
+          return unless ternary?(node)
           _, if_branch, else_branch = *node
 
           check_operator(node.loc.question, if_branch.source_range)

--- a/lib/rubocop/cop/util.rb
+++ b/lib/rubocop/cop/util.rb
@@ -46,10 +46,6 @@ module RuboCop
         OPERATOR_METHODS.include?(symbol)
       end
 
-      def ternary_op?(node)
-        node.loc.respond_to?(:question)
-      end
-
       def strip_quotes(str)
         if str[0] == '"' || str[0] == "'"
           str[0] = ''


### PR DESCRIPTION
I was playing around with some ternary stuff, and realized that there was quite an inconsistent treatment of ternary checks in the code base. Some instances had inlined the predicate (`node.loc.respond_to?(:question)`) in the code, while others used the `#ternary_op?` helper that was defined in a generic `Util` module, rather than `IfNode`, where I'd expect to find it.

This change suggests cleaning some of that up.

---

This change removes the old method from:

`RuboCop::Cop::Util#ternary_op?`

and moves its functionality into:

`RuboCop::Cop::Mixin::IfNode#ternary?`

It also replaces all use of the former, as well as all occurences of inlined duplication of the logic, with the latter.