### PR TITLE
make rubocop-todo.yml a warning not a error

### DIFF
--- a/lib/rubocop/config_loader.rb
+++ b/lib/rubocop/config_loader.rb
@@ -195,9 +195,8 @@ module RuboCop
       end
 
       def old_auto_config_file_warning
-        raise RuboCop::Error,
-              'rubocop-todo.yml is obsolete; it must be called' \
-              " #{AUTO_GENERATED_FILE} instead"
+        warn('rubocop-todo.yml is obsolete; it must be called' \
+          " #{AUTO_GENERATED_FILE} instead")
       end
     end
   end

--- a/spec/rubocop/cli_spec.rb
+++ b/spec/rubocop/cli_spec.rb
@@ -1436,10 +1436,10 @@ describe RuboCop::CLI, :isolated_environment do
 
       it 'prints a warning when --auto-gen-config is set' do
         expect(cli.run(%w(-c .rubocop.yml --auto-gen-config))).to eq(2)
-        expect($stderr.string)
-          .to eq(['Error: rubocop-todo.yml is obsolete; it must be called ' \
-                  '.rubocop_todo.yml instead',
-                  ''].join("\n"))
+        expect($stderr.string).to match(
+          '\Arubocop-todo.yml is obsolete; it must be called ' \
+          '.rubocop_todo.yml instead'
+        )
       end
     end
 


### PR DESCRIPTION
Our file naming convention is to use `-`. The autogenerated file won't be named the same as the one we have checked in, but that is ok. I don't think this should prohibit generating a new file.

Currently:

```
$ rubocop --auto-gen-config --exclude-limit 10000
Error: rubocop-todo.yml is obsolete; it must be called .rubocop_todo.yml instead
$
```

After this PR:

```
$ ~/projects/rubocop/bin/rubocop --auto-gen-config --exclude-limit 10000
rubocop-todo.yml is obsolete; it must be called .rubocop_todo.yml instead
... it does stuff ...
```

Before submitting a PR make sure the following are checked:

* [X] Wrote [good commit messages][1].
* [X] Used the same coding conventions as the rest of the project.
* [X] Feature branch is up-to-date with `master` (if not - rebase it)
* [X] Squashed related commits together.
* [x] Added tests.
* [ ] Added an entry to the [Changelog](CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../CONTRIBUTING.md#changelog-entry-format).
* [X] All tests are passing.
* [X] The new code doesn't generate RuboCop offenses.
* [X] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.

[1]: http://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html

