### PR TITLE
[Fix #2981] Avoid double trailing comma

### DIFF
--- a/lib/rubocop/cop/style/trailing_comma_in_arguments.rb
+++ b/lib/rubocop/cop/style/trailing_comma_in_arguments.rb
@@ -40,6 +40,31 @@ module RuboCop
           check(node, args, 'parameter of %s method call',
                 args.last.source_range.end_pos, node.source_range.end_pos)
         end
+
+        private
+
+        def avoid_autocorrect?(args)
+          hash_with_braces?(args.last) && braces_will_be_removed?(args)
+        end
+
+        def hash_with_braces?(node)
+          node.hash_type? && node.loc.begin
+        end
+
+        # Returns true if running with --auto-correct would remove the braces
+        # of the last argument.
+        def braces_will_be_removed?(args)
+          brace_config = config.for_cop('Style/BracesAroundHashParameters')
+          return false unless brace_config['Enabled']
+          return false if brace_config['AutoCorrect'] == false
+
+          brace_style = brace_config['EnforcedStyle']
+          return true if brace_style == 'no_braces'
+
+          return false unless brace_style == 'context_dependent'
+
+          args.size == 1 || !args[-2].hash_type?
+        end
       end
     end
   end

--- a/spec/rubocop/cop/style/trailing_comma_in_arguments_spec.rb
+++ b/spec/rubocop/cop/style/trailing_comma_in_arguments_spec.rb
@@ -162,6 +162,16 @@ describe RuboCop::Cop::Style::TrailingCommaInArguments, :config do
         expect(cop.offenses).to be_empty
       end
 
+      it 'accepts no trailing comma in a method call with a multiline' \
+         ' braceless hash at the end with more than one parameter on a line' do
+        inspect_source(cop, ['some_method(',
+                             '              a,',
+                             '              b: 0,',
+                             '              c: 0, d: 1',
+                             '           )'])
+        expect(cop.offenses).to be_empty
+      end
+
       it 'accepts a trailing comma in a method call with single ' \
          'line hashes' do
         inspect_source(cop, ['some_method(',
@@ -319,7 +329,7 @@ describe RuboCop::Cop::Style::TrailingCommaInArguments, :config do
       end
 
       it 'accepts a multiline call with arguments on a single line and' \
-         'trailing comma' do
+         ' trailing comma' do
         inspect_source(cop, ['method(',
                              '  1, 2,',
                              ')'])


### PR DESCRIPTION
The problem was the case when a comma is added by auto-correct at the end of a hash with braces that's the last argument in a method call, and a comma is also added after the closing brace, and then the closing brace is removed by auto-correct. You get two commas in a row.

My solution is to detect when this is about to happen, and avoid adding one of the commas.