### PR TITLE
switch SpaceAfterPunctuation mixin to use SpaceInsideHashLiteralBraces config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,7 @@
 * [#3083](https://github.com/bbatsov/rubocop/issues/3083): Do not register an offense for splat block args in `Style/SymbolProc`. ([@rrosenblum][])
 * [#3063](https://github.com/bbatsov/rubocop/issues/3063): Don't auto-correct `a + \` into `a + \\` in `Style/LineEndConcatenation`. ([@jonas054][])
 * [#3034](https://github.com/bbatsov/rubocop/issues/3034): Report offenses for `RuntimeError.new(msg)` in `Style/RedundantException`. ([@jonas054][])
+* [#3016](https://github.com/bbatsov/rubocop/issues/3016): `Style/SpaceAfterComma` now uses `Style/SpaceInsideHashLiteralBraces`'s setting. ([@ptarjan][])
 
 ### Changes
 

--- a/lib/rubocop/cop/mixin/space_after_punctuation.rb
+++ b/lib/rubocop/cop/mixin/space_after_punctuation.rb
@@ -20,8 +20,7 @@ module RuboCop
       end
 
       def space_forbidden_before_rcurly?
-        cfg = config.for_cop('Style/SpaceInsideBlockBraces')
-        style = cfg['EnforcedStyle'] || 'space'
+        style = space_style_before_rcurly
         style == 'no_space'
       end
 

--- a/lib/rubocop/cop/style/space_after_comma.rb
+++ b/lib/rubocop/cop/style/space_after_comma.rb
@@ -8,6 +8,11 @@ module RuboCop
       class SpaceAfterComma < Cop
         include SpaceAfterPunctuation
 
+        def space_style_before_rcurly
+          cfg = config.for_cop('Style/SpaceInsideHashLiteralBraces')
+          cfg['EnforcedStyle'] || 'space'
+        end
+
         def kind(token)
           'comma' if token.type == :tCOMMA
         end

--- a/lib/rubocop/cop/style/space_after_semicolon.rb
+++ b/lib/rubocop/cop/style/space_after_semicolon.rb
@@ -8,6 +8,11 @@ module RuboCop
       class SpaceAfterSemicolon < Cop
         include SpaceAfterPunctuation
 
+        def space_style_before_rcurly
+          cfg = config.for_cop('Style/SpaceInsideBlockBraces')
+          cfg['EnforcedStyle'] || 'space'
+        end
+
         def kind(token)
           'semicolon' if token.type == :tSEMI
         end

--- a/spec/rubocop/cli/cli_autocorrect_spec.rb
+++ b/spec/rubocop/cli/cli_autocorrect_spec.rb
@@ -993,4 +993,25 @@ describe RuboCop::CLI, :isolated_environment do
                                          'puts "Hello", 123_456',
                                          ''].join("\n"))
   end
+
+  it 'handles different SpaceInsideBlockBraces and ' \
+     'SpaceInsideHashLiteralBraces' do
+    create_file('example.rb', ['{foo: bar,',
+                               ' bar: baz,}',
+                               'foo.each {bar;}'])
+    create_file('.rubocop.yml', [
+                  'Style/SpaceInsideBlockBraces:',
+                  '  EnforcedStyle: space',
+                  'Style/SpaceInsideHashLiteralBraces:',
+                  '  EnforcedStyle: no_space',
+                  'Style/TrailingCommaInLiteral:',
+                  '  EnforcedStyleForMultiline: consistent_comma'
+                ])
+    expect(cli.run(%w(--auto-correct))).to eq(1)
+    expect($stderr.string).to eq('')
+    expect(IO.read('example.rb')).to eq(['{foo: bar,',
+                                         ' bar: baz,}',
+                                         'foo.each { bar; }',
+                                         ''].join("\n"))
+  end
 end

--- a/spec/rubocop/cop/style/space_after_comma_spec.rb
+++ b/spec/rubocop/cop/style/space_after_comma_spec.rb
@@ -4,7 +4,11 @@
 require 'spec_helper'
 
 describe RuboCop::Cop::Style::SpaceAfterComma do
-  subject(:cop) { described_class.new }
+  subject(:cop) { described_class.new(config) }
+  let(:config) do
+    RuboCop::Config.new('Style/SpaceInsideHashLiteralBraces' => brace_config)
+  end
+  let(:brace_config) { {} }
 
   shared_examples 'ends with an item' do |items, correct_items|
     it 'registers an offense' do
@@ -45,5 +49,41 @@ describe RuboCop::Cop::Style::SpaceAfterComma do
     let(:source) { ->(args) { "a(#{args})" } }
 
     it_behaves_like 'ends with an item', '1,2', '1, 2'
+  end
+
+  context 'inside hash braces' do
+    shared_examples 'common behavior' do
+      it 'accepts a space between a comma and a closing brace' do
+        inspect_source(cop, '{ foo:bar, }')
+        expect(cop.messages).to be_empty
+      end
+    end
+
+    context 'when EnforcedStyle for SpaceInsideBlockBraces is space' do
+      let(:brace_config) do
+        { 'Enabled' => true, 'EnforcedStyle' => 'space' }
+      end
+
+      it_behaves_like 'common behavior'
+
+      it 'registers an offense for no space between a comma and a ' \
+         'closing brace' do
+        inspect_source(cop, '{ foo:bar,}')
+        expect(cop.messages).to eq(['Space missing after comma.'])
+      end
+    end
+
+    context 'when EnforcedStyle for SpaceInsideBlockBraces is no_space' do
+      let(:brace_config) do
+        { 'Enabled' => true, 'EnforcedStyle' => 'no_space' }
+      end
+
+      it_behaves_like 'common behavior'
+
+      it 'accepts no space between a comma and a closing brace' do
+        inspect_source(cop, '{foo:bar,}')
+        expect(cop.messages).to be_empty
+      end
+    end
   end
 end


### PR DESCRIPTION
Having a trailing `,` in a Block won't compile and having a trailing `;` in a hash won't compile. So they should use their respective configs.

Before submitting a PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [x] Used the same coding conventions as the rest of the project.
* [x] Feature branch is up-to-date with `master` (if not - rebase it)
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../CONTRIBUTING.md#changelog-entry-format).
* [x] All tests are passing.
* [x] The new code doesn't generate RuboCop offenses.
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.

[1]: http://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html