### PR TITLE
Remove any references to rubocop-todo.yml

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,9 @@
 * [#3010](https://github.com/bbatsov/rubocop/issues/3010): Fix double reporting/correction of spaces after ternary operator colons (now only reported by `Style/SpaceAroundOperators`, and not `Style/SpaceAfterColon` too). ([@owst][])
 * [#3006](https://github.com/bbatsov/rubocop/issues/3006): Handle non-local variables as receivers inside `each_with_object` in `Performance/RedundantMerge`. ([@lumeet][])
 
+### Changes
+* [#3025](https://github.com/bbatsov/rubocop/pull/3025): Removed deprecation warnings for `rubocop-todo.yml`. ([@ptarjan][])
+
 ## 0.39.0 (2016-03-27)
 
 ### New features

--- a/lib/rubocop/config_loader.rb
+++ b/lib/rubocop/config_loader.rb
@@ -73,7 +73,6 @@ module RuboCop
 
             if auto_gen_config?
               next if f.include?(AUTO_GENERATED_FILE)
-              old_auto_config_file_warning if f.include?('rubocop-todo.yml')
             end
 
             print 'Inheriting ' if debug?
@@ -192,12 +191,6 @@ module RuboCop
         end
         dirs_to_search << Dir.home if ENV.key? 'HOME'
         dirs_to_search
-      end
-
-      def old_auto_config_file_warning
-        raise RuboCop::Error,
-              'rubocop-todo.yml is obsolete; it must be called' \
-              " #{AUTO_GENERATED_FILE} instead"
       end
     end
   end

--- a/spec/rubocop/cli_spec.rb
+++ b/spec/rubocop/cli_spec.rb
@@ -1424,25 +1424,6 @@ describe RuboCop::CLI, :isolated_environment do
                   \ numeric\ character/x)
     end
 
-    context 'when a file inherits from the old auto generated file' do
-      before do
-        create_file('rubocop-todo.yml', '')
-        create_file('.rubocop.yml', ['inherit_from: rubocop-todo.yml'])
-      end
-
-      it 'prints no warning when --auto-gen-config is not set' do
-        expect { cli.run(%w(-c .rubocop.yml)) }.not_to exit_with_code(1)
-      end
-
-      it 'prints a warning when --auto-gen-config is set' do
-        expect(cli.run(%w(-c .rubocop.yml --auto-gen-config))).to eq(2)
-        expect($stderr.string)
-          .to eq(['Error: rubocop-todo.yml is obsolete; it must be called ' \
-                  '.rubocop_todo.yml instead',
-                  ''].join("\n"))
-      end
-    end
-
     context 'when a file inherits from a higher level' do
       before do
         create_file('.rubocop.yml', ['Metrics/LineLength:',


### PR DESCRIPTION
As discussed in https://github.com/bbatsov/rubocop/pull/3013

* [x] Wrote [good commit messages][1].
* [x] Used the same coding conventions as the rest of the project.
* [x] Feature branch is up-to-date with `master` (if not - rebase it)
* [x] Squashed related commits together.
* [ ] Added tests.
* [x] Added an entry to the [Changelog](CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../CONTRIBUTING.md#changelog-entry-format).
* [x] All tests are passing.
* [x] The new code doesn't generate RuboCop offenses.
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.

[1]: http://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html

