### PR TITLE
Rewords the message for snake_case warning

### DIFF
--- a/lib/rubocop/cop/style/file_name.rb
+++ b/lib/rubocop/cop/style/file_name.rb
@@ -10,7 +10,8 @@ module RuboCop
       # names. Ruby scripts (i.e. source files with a shebang in the
       # first line) are ignored.
       class FileName < Cop
-        MSG_SNAKE_CASE = 'Use snake_case for source file names.'.freeze
+        MSG_SNAKE_CASE = 'The file name for this source (%s) ' \
+                         'should use snake_case.'.freeze
         MSG_NO_DEFINITION = '%s should define a class or module ' \
                             'called `%s`.'.freeze
         MSG_REGEX = '`%s` should match `%s`.'.freeze
@@ -55,7 +56,11 @@ module RuboCop
         end
 
         def other_message(basename)
-          regex ? format(MSG_REGEX, basename, regex) : MSG_SNAKE_CASE
+          if regex
+            format(MSG_REGEX, basename, regex)
+          else
+            format(MSG_SNAKE_CASE, basename)
+          end
         end
 
         def shebang?(line)

--- a/spec/rubocop/cop/style/file_name_spec.rb
+++ b/spec/rubocop/cop/style/file_name_spec.rb
@@ -162,7 +162,8 @@ describe RuboCop::Cop::Style::FileName do
 
       it 'registers an offense' do
         expect(cop.offenses.size).to eq(1)
-        expect(cop.messages).to eq(['Use snake_case for source file names.'])
+        expect(cop.messages).to eq(
+          ['The file name for this source (a file.rb) should use snake_case.'])
       end
     end
 


### PR DESCRIPTION
The original message was misleading, because it
seemed to refer to the contents of the source file,
not the source filename itself.

This commit rewords the message for this warning
from "Use snake_case for source file names."
to "The file name for this source should use snake_case."

Closes #2024