### PR TITLE
Add define_method to the list of IgnoredMethods of Style/SymbolProc

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@
 ### Changes
 
 * [#3025](https://github.com/bbatsov/rubocop/pull/3025): Removed deprecation warnings for `rubocop-todo.yml`. ([@ptarjan][])
+* [#3028](https://github.com/bbatsov/rubocop/pull/3028): Add `define_method` to the default list of `IgnoredMethods` of `Style/SymbolProc`. ([@jastkand][])
 
 ## 0.39.0 (2016-03-27)
 
@@ -2106,3 +2107,4 @@
 [@dylanahsmith]: https://github.com/dylanahsmith
 [@gerrywastaken]: https://github.com/gerrywastaken
 [@bolshakov]: https://github.com/bolshakov
+[@jastkand]: https://github.com/jastkand

--- a/config/default.yml
+++ b/config/default.yml
@@ -864,6 +864,7 @@ Style/SymbolProc:
   # The names should be fairly unique, otherwise you'll end up ignoring lots of code.
   IgnoredMethods:
     - respond_to
+    - define_method
 
 Style/TrailingBlankLines:
   EnforcedStyle: final_newline


### PR DESCRIPTION
There is a code-sample:
```ruby
[:block_code, :block_quote].each do |method|
  define_method(method) do |*args|
    args.first
  end
end
```
Using the default rubocop settings it produces such warning:
> Pass `&:first` as an argument to `define_method` instead of a block. (Style/SymbolProc)

I think `define_method` should be added to a list of default IgnoredMethods of Style/SymbolicProc cop.