### PR TITLE
Usage composable matchers in specs

### DIFF
--- a/spec/rubocop/cli/cli_options_spec.rb
+++ b/spec/rubocop/cli/cli_options_spec.rb
@@ -53,9 +53,8 @@ describe RuboCop::CLI, :isolated_environment do
       context 'when there are no includes or excludes' do
         it 'prints known ruby files' do
           cli.run ['-L']
-          expect($stdout.string.split("\n")).to match_array ['app.rb',
-                                                             'Gemfile',
-                                                             'lib/helper.rb']
+          expect($stdout.string.split("\n")).to contain_exactly(
+            'app.rb', 'Gemfile', 'lib/helper.rb')
         end
       end
 
@@ -70,9 +69,8 @@ describe RuboCop::CLI, :isolated_environment do
 
         it 'prints the included files and not the excluded ones' do
           cli.run ['--list-target-files']
-          expect($stdout.string.split("\n")).to match_array ['app.rb',
-                                                             'lib/helper.rb',
-                                                             'show.rabl']
+          expect($stdout.string.split("\n")).to contain_exactly(
+            'app.rb', 'lib/helper.rb', 'show.rabl')
         end
       end
     end

--- a/spec/rubocop/cop/lint/duplicate_methods_spec.rb
+++ b/spec/rubocop/cop/lint/duplicate_methods_spec.rb
@@ -143,9 +143,9 @@ describe RuboCop::Cop::Lint::DuplicateMethods do
                       '  end',
                       'end'], 'dups.rb')
       expect(cop.offenses.size).to eq(2)
-      expect(cop.messages).to match_array(
-        ['Method `A#any_method` is defined at both dups.rb:8 and dups.rb:11.',
-         'Method `A#some_method` is defined at both dups.rb:2 and dups.rb:5.'])
+      expect(cop.messages).to contain_exactly(
+        'Method `A#any_method` is defined at both dups.rb:8 and dups.rb:11.',
+        'Method `A#some_method` is defined at both dups.rb:2 and dups.rb:5.')
     end
 
     it 'registers an offense for a duplicate instance method in separate ' \

--- a/spec/rubocop/cop/variable_force/variable_table_spec.rb
+++ b/spec/rubocop/cop/variable_force/variable_table_spec.rb
@@ -239,7 +239,7 @@ describe RuboCop::Cop::VariableForce::VariableTable do
       end
 
       it 'returns all the variables' do
-        expect(accessible_variable_names).to match_array([:foo, :bar])
+        expect(accessible_variable_names).to contain_exactly(:foo, :bar)
       end
     end
 
@@ -257,7 +257,7 @@ describe RuboCop::Cop::VariableForce::VariableTable do
 
         it 'returns the current and direct outer scope variables' do
           expect(accessible_variable_names)
-            .to match_array([:foo, :bar, :baz])
+            .to contain_exactly(:foo, :bar, :baz)
         end
       end
 
@@ -269,7 +269,7 @@ describe RuboCop::Cop::VariableForce::VariableTable do
         end
 
         it 'returns only the current scope variables' do
-          expect(accessible_variable_names).to match_array([:bar, :baz])
+          expect(accessible_variable_names).to contain_exactly(:bar, :baz)
         end
       end
     end


### PR DESCRIPTION
Change matchers implementation according to the [issue#2372](https://github.com/bbatsov/rubocop/issues/2372)