### PR TITLE
[Fix #2995] Remove deprecated path matching

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@
 
 ### Changes
 
+* [#2995](https://github.com/bbatsov/rubocop/issues/2995): Removed deprecated path matching syntax. ([@gerrywastaken][])
 * [#3025](https://github.com/bbatsov/rubocop/pull/3025): Removed deprecation warnings for `rubocop-todo.yml`. ([@ptarjan][])
 
 ## 0.39.0 (2016-03-27)

--- a/lib/rubocop/config.rb
+++ b/lib/rubocop/config.rb
@@ -146,8 +146,8 @@ module RuboCop
       absolute_file_path = File.expand_path(file)
 
       patterns_to_include.any? do |pattern|
-        match_path?(pattern, relative_file_path, loaded_path) ||
-          match_path?(pattern, absolute_file_path, loaded_path)
+        match_path?(pattern, relative_file_path) ||
+          match_path?(pattern, absolute_file_path)
       end
     end
 
@@ -162,7 +162,7 @@ module RuboCop
     def file_to_exclude?(file)
       file = File.expand_path(file)
       patterns_to_exclude.any? do |pattern|
-        match_path?(pattern, file, loaded_path)
+        match_path?(pattern, file)
       end
     end
 

--- a/lib/rubocop/cop/cop.rb
+++ b/lib/rubocop/cop/cop.rb
@@ -248,11 +248,11 @@ module RuboCop
         path = nil
         patterns.any? do |pattern|
           # Try to match the absolute path, as Exclude properties are absolute.
-          next true if match_path?(pattern, file, config.loaded_path)
+          next true if match_path?(pattern, file)
 
           # Try with relative path.
           path ||= config.path_relative_to_config(file)
-          match_path?(pattern, path, config.loaded_path)
+          match_path?(pattern, path)
         end
       end
 

--- a/lib/rubocop/path_util.rb
+++ b/lib/rubocop/path_util.rb
@@ -15,41 +15,13 @@ module RuboCop
       path_name.relative_path_from(Pathname.new(base_dir)).to_s
     end
 
-    # TODO: The old way of matching patterns is flawed, so a new one has been
-    # introduced. We keep supporting the old way for a while and issue
-    # deprecation warnings when a pattern is used that produced a match with
-    # the old way but doesn't match with the new.
-    def match_path?(pattern, path, config_path)
+    def match_path?(pattern, path)
       case pattern
       when String
-        basename = File.basename(path)
-        old_match = basename == pattern || File.fnmatch?(pattern, path)
-        new_match = File.fnmatch?(pattern, path, File::FNM_PATHNAME)
-        if old_match && !new_match
-          # Patterns like dir/**/* will produce an old match for files
-          # beginning with dot, but not a new match. That's a special case,
-          # though. Not what we want to handle here. And this is a match that
-          # we overrule. Only patterns like dir/**/.* can be used to match dot
-          # files. Hidden directories (starting with a dot) will also produce
-          # an old match, just like hidden files.
-          return false if path.split(File::SEPARATOR).any? { |s| hidden?(s) }
-
-          issue_deprecation_warning(basename, pattern, config_path)
-        end
-        old_match || new_match
+        File.fnmatch?(pattern, path, File::FNM_PATHNAME)
       when Regexp
         path =~ pattern
       end
-    end
-
-    def issue_deprecation_warning(basename, pattern, config_path)
-      instruction = if basename == pattern
-                      ". Change to '**/#{pattern}'."
-                    elsif pattern.end_with?('**')
-                      ". Change to '#{pattern}/*'."
-                    end
-      warn("Warning: Deprecated pattern style '#{pattern}' in " \
-           "#{config_path}#{instruction}")
     end
 
     def hidden?(path_component)

--- a/spec/rubocop/path_util_spec.rb
+++ b/spec/rubocop/path_util_spec.rb
@@ -31,70 +31,50 @@ describe RuboCop::PathUtil do
 
     after { $stderr = STDERR }
 
-    context 'with deprecated patterns' do
-      it 'matches dir/** and prints warning' do
-        expect(subject.match_path?('dir/**', 'dir/sub/file', '.rubocop.yml'))
-          .to be_truthy
-        expect($stderr.string)
-          .to eq(["Warning: Deprecated pattern style 'dir/**' in " \
-                  ".rubocop.yml. Change to 'dir/**/*'.",
-                  ''].join("\n"))
-      end
+    it 'does not match dir/** for file in hidden dir' do
+      expect(subject.match_path?('dir/**', 'dir/.hidden/file'))
+        .to be_falsey
+      expect($stderr.string).to eq('')
+    end
 
-      it 'does not match dir/** for file in hidden dir' do
-        expect(subject.match_path?('dir/**', 'dir/.hidden/file',
-                                   '.rubocop.yml'))
-          .to be_falsey
-        expect($stderr.string).to eq('')
-      end
+    it 'does not match dir/** for hidden file' do
+      expect(subject.match_path?('dir/**', 'dir/.hidden_file'))
+        .to be_falsey
+      expect($stderr.string).to eq('')
+    end
 
-      it 'does not match dir/** for hidden file' do
-        expect(subject.match_path?('dir/**', 'dir/.hidden_file',
-                                   '.rubocop.yml'))
-          .to be_falsey
-        expect($stderr.string).to eq('')
-      end
-
-      it 'matches strings to the basename and prints warning' do
-        expect(subject.match_path?('file', 'dir/file', '.rubocop.yml'))
-          .to be_truthy
-        expect($stderr.string)
-          .to eq(["Warning: Deprecated pattern style 'file' in .rubocop.yml. " \
-                  "Change to '**/file'.",
-                  ''].join("\n"))
-
-        expect(subject.match_path?('file', 'dir/files', '')).to be_falsey
-        expect(subject.match_path?('dir', 'dir/file', '')).to be_falsey
-      end
+    it 'does not match file in a subdirectory' do
+      expect(subject.match_path?('file', 'dir/files')).to be_falsey
+      expect(subject.match_path?('dir', 'dir/file')).to be_falsey
     end
 
     it 'matches strings to the full path' do
       expect(subject.match_path?("#{Dir.pwd}/dir/file",
-                                 "#{Dir.pwd}/dir/file", '')).to be_truthy
+                                 "#{Dir.pwd}/dir/file")).to be_truthy
       expect(subject.match_path?("#{Dir.pwd}/dir/file",
-                                 "#{Dir.pwd}/dir/dir/file", '')).to be_falsey
+                                 "#{Dir.pwd}/dir/dir/file")).to be_falsey
     end
 
     it 'matches glob expressions' do
-      expect(subject.match_path?('dir/*',    'dir/file', '')).to be_truthy
-      expect(subject.match_path?('dir/*/*',  'dir/sub/file', '')).to be_truthy
-      expect(subject.match_path?('dir/**/*', 'dir/sub/file', '')).to be_truthy
-      expect(subject.match_path?('dir/**/*', 'dir/file', '')).to be_truthy
-      expect(subject.match_path?('**/*',     'dir/sub/file', '')).to be_truthy
-      expect(subject.match_path?('**/file',  'file', '')).to be_truthy
+      expect(subject.match_path?('dir/*',    'dir/file')).to be_truthy
+      expect(subject.match_path?('dir/*/*',  'dir/sub/file')).to be_truthy
+      expect(subject.match_path?('dir/**/*', 'dir/sub/file')).to be_truthy
+      expect(subject.match_path?('dir/**/*', 'dir/file')).to be_truthy
+      expect(subject.match_path?('**/*',     'dir/sub/file')).to be_truthy
+      expect(subject.match_path?('**/file',  'file')).to be_truthy
 
-      expect(subject.match_path?('sub/*',    'dir/sub/file', '')).to be_falsey
+      expect(subject.match_path?('sub/*',    'dir/sub/file')).to be_falsey
 
-      expect(subject.match_path?('**/*', 'dir/.hidden/file', '')).to be_falsey
-      expect(subject.match_path?('**/*', 'dir/.hidden_file', '')).to be_falsey
-      expect(subject.match_path?('**/.*/*', 'dir/.hidden/file', ''))
+      expect(subject.match_path?('**/*', 'dir/.hidden/file')).to be_falsey
+      expect(subject.match_path?('**/*', 'dir/.hidden_file')).to be_falsey
+      expect(subject.match_path?('**/.*/*', 'dir/.hidden/file'))
         .to be_truthy
-      expect(subject.match_path?('**/.*', 'dir/.hidden_file', '')).to be_truthy
+      expect(subject.match_path?('**/.*', 'dir/.hidden_file')).to be_truthy
     end
 
     it 'matches regexps' do
-      expect(subject.match_path?(/^d.*e$/, 'dir/file', '')).to be_truthy
-      expect(subject.match_path?(/^d.*e$/, 'dir/filez', '')).to be_falsey
+      expect(subject.match_path?(/^d.*e$/, 'dir/file')).to be_truthy
+      expect(subject.match_path?(/^d.*e$/, 'dir/filez')).to be_falsey
     end
   end
 end


### PR DESCRIPTION
This also fixes bug #2995, due to the deprecated code causing the issue.

~~Note: Metrics/ClassLength offense count was bumped up by a previous commit~~

Before submitting a PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [x] Used the same coding conventions as the rest of the project.
* [x] Feature branch is up-to-date with `master` (if not - rebase it)
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../CONTRIBUTING.md#changelog-entry-format).
* [x] All tests are passing.
* [x] The new code doesn't generate RuboCop offenses.
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.

[1]: http://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html