### PR TITLE
[Fix #3032] Autocorrect predicates without space before args - e.g. is_a?Integer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@
 * [#3003](https://github.com/bbatsov/rubocop/pull/3003): Read command line options from `.rubocop` file and `RUBOCOP_OPTS` environment variable. ([@bolshakov][])
 
 ### Bug fixes
-
+* [#3032](https://github.com/bbatsov/rubocop/issues/3032): Fix autocorrecting parentheses for predicate methods without space before args. ([@graemeboy][])
 * [#3000](https://github.com/bbatsov/rubocop/pull/3000): Fix encoding crash on HTML output. ([@gerrywastaken][])
 * [#2983](https://github.com/bbatsov/rubocop/pull/2983): `Style/AlignParameters` message was clarified for `with_fixed_indentation` style. ([@dylanahsmith][])
 * [#2314](https://github.com/bbatsov/rubocop/pull/2314): Ignore `UnusedBlockArgument` for keyword arguments. ([@volkert][])
@@ -2109,3 +2109,4 @@
 [@gerrywastaken]: https://github.com/gerrywastaken
 [@bolshakov]: https://github.com/bolshakov
 [@jastkand]: https://github.com/jastkand
+[@graemeboy]: https://github.com/graemeboy

--- a/lib/rubocop/cop/style/and_or.rb
+++ b/lib/rubocop/cop/style/and_or.rb
@@ -119,7 +119,11 @@ module RuboCop
         def whitespace_before_arg(node)
           sb = node.source_range.source_buffer
           begin_paren = node.loc.selector.end_pos
-          Parser::Source::Range.new(sb, begin_paren, begin_paren + 1)
+          end_paren = begin_paren
+          # Increment position of parenthesis, unless message is a predicate
+          # method followed by a non-whitespace char (e.g. is_a?String).
+          end_paren += 1 unless node.source =~ /\?[!\S]/
+          Parser::Source::Range.new(sb, begin_paren, end_paren)
         end
       end
     end

--- a/spec/rubocop/cop/style/and_or_spec.rb
+++ b/spec/rubocop/cop/style/and_or_spec.rb
@@ -253,6 +253,47 @@ describe RuboCop::Cop::Style::AndOr, :config do
       end
     end
 
+    context 'with predicate method with arg without space on right' do
+      it 'autocorrects "or" with || and adds parens' do
+        new_source = autocorrect_source(cop, 'false or 3.is_a?Integer')
+        expect(new_source).to eq('false || 3.is_a?(Integer)')
+      end
+
+      it 'autocorrects "and" with && and adds parens' do
+        new_source = autocorrect_source(cop, 'false and 3.is_a?Integer')
+        expect(new_source).to eq('false && 3.is_a?(Integer)')
+      end
+    end
+
+    context 'with two predicate methods with args without spaces on right' do
+      it 'autocorrects "or" with || and adds parens' do
+        new_source = autocorrect_source(cop, "'1'.is_a?Integer " \
+                                             'or 1.is_a?Integer')
+        expect(new_source).to eq('\'1\'.is_a?(Integer) || 1.is_a?(Integer)')
+      end
+
+      it 'autocorrects "and" with && and adds parens' do
+        new_source = autocorrect_source(cop, "'1'.is_a?Integer and" \
+                                             ' 1.is_a?Integer')
+        expect(new_source).to eq('\'1\'.is_a?(Integer) && 1.is_a?(Integer)')
+      end
+    end
+
+    context 'with one predicate method without space on right and another ' \
+            'method' do
+      it 'autocorrects "or" with || and adds parens' do
+        new_source = autocorrect_source(cop, "'1'.is_a?Integer or" \
+                                             ' 1.is_a? Integer')
+        expect(new_source).to eq("'1'.is_a?(Integer) || 1.is_a?(Integer)")
+      end
+
+      it 'autocorrects "and" with && and adds parens' do
+        new_source = autocorrect_source(cop, "'1'.is_a?Integer " \
+                                              'and 1.is_a? Integer')
+        expect(new_source).to eq('\'1\'.is_a?(Integer) && 1.is_a?(Integer)')
+      end
+    end
+
     context 'with `not` expression on right' do
       it 'autocorrects "and" with && and adds parens' do
         new_source = autocorrect_source(cop, 'x and not arg')


### PR DESCRIPTION
I've never seen this codebase before, so I don't know how hacky this solution is.

Summary of problem:

Using rubocop autocorrect on the following lines of code:

```ruby
false or 'a'.is_a?String
=> false || 'a'.is_a?(tring)

'1'.is_a?Integer or 1.is_a?Integer
=> '1'.is_a?(nteger) || 1.is_a?(nteger)
```

PR adds six example cases to the test specs, and some code that makes all pass.