### PR TITLE
Structs don't trigger Lint/NestedMethodDefinition

### DIFF
--- a/lib/rubocop/cop/lint/nested_method_definition.rb
+++ b/lib/rubocop/cop/lint/nested_method_definition.rb
@@ -27,7 +27,7 @@ module RuboCop
         PATTERN
 
         def_node_matcher :class_or_module_new_call?, <<-PATTERN
-          (block (send (const nil {:Class :Module}) :new ...) ...)
+          (block (send (const nil {:Class :Module :Struct}) :new ...) ...)
         PATTERN
 
         def on_method_def(node, _method_name, _args, _body)

--- a/spec/rubocop/cop/lint/nested_method_definition_spec.rb
+++ b/spec/rubocop/cop/lint/nested_method_definition_spec.rb
@@ -128,4 +128,16 @@ describe RuboCop::Cop::Lint::NestedMethodDefinition do
                          'end'])
     expect(cop.offenses.size).to eq(0)
   end
+
+  it 'does not register offense for nested definition inside Struct.new' do
+    inspect_source(cop, ['class Foo',
+                         '  def self.define',
+                         '    Struct.new(:foo, :bar) do',
+                         '      def y',
+                         '      end',
+                         '    end',
+                         '  end',
+                         'end'])
+    expect(cop.offenses.size).to eq(0)
+  end
 end


### PR DESCRIPTION
Fixes #3048 

The recommended way to extend a Struct, per the Ruby documentation is

```ruby
Struct.new(:foo, :bar) do
  def some_method
    "#{foo} #{bar}"
  end
end
```
However, this code fails the Lint/NestedMethodDefinition cop. Add an exception
along the same lines as Class and Method so that Struct won't fail the cop.

Before submitting a PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [x] Used the same coding conventions as the rest of the project.
* [x] Feature branch is up-to-date with `master` (if not - rebase it)
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../CONTRIBUTING.md#changelog-entry-format).
* [x] All tests are passing.
* [x] The new code doesn't generate RuboCop offenses.
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.

[1]: http://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html