### PR TITLE
Add same_line style for multiline brace layouts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,10 @@
 * [#2857](https://github.com/bbatsov/rubocop/issues/2857): `Style/MultilineHashBraceLayout` enforced style is configurable and supports `symmetrical` and `new_line` options. ([@panthomakos][])
 * [#2857](https://github.com/bbatsov/rubocop/issues/2857): `Style/MultilineMethodCallBraceLayout` enforced style is configurable and supports `symmetrical` and `new_line` options. ([@panthomakos][])
 * [#2857](https://github.com/bbatsov/rubocop/issues/2857): `Style/MultilineMethodDefinitionBraceLayout` enforced style is configurable and supports `symmetrical` and `new_line` options. ([@panthomakos][])
+* [#3052](https://github.com/bbatsov/rubocop/pull/3052): `Style/MultilineArrayBraceLayout` enforced style supports `same_line` option. ([@panthomakos][])
+* [#3052](https://github.com/bbatsov/rubocop/pull/3052): `Style/MultilineHashBraceLayout` enforced style supports `same_line` option. ([@panthomakos][])
+* [#3052](https://github.com/bbatsov/rubocop/pull/3052): `Style/MultilineMethodCallBraceLayout` enforced style supports `same_line` option. ([@panthomakos][])
+* [#3052](https://github.com/bbatsov/rubocop/pull/3052): `Style/MultilineMethodDefinitionBraceLayout` enforced style supports `same_line` option. ([@panthomakos][])
 
 ### Bug fixes
 * [#3032](https://github.com/bbatsov/rubocop/issues/3032): Fix autocorrecting parentheses for predicate methods without space before args. ([@graemeboy][])

--- a/config/disabled.yml
+++ b/config/disabled.yml
@@ -83,8 +83,10 @@ Style/MultilineArrayBraceLayout:
   SupportedStyles:
     # symmetrical: closing brace is positioned in same way as opening brace
     # new_line: closing brace is always on a new line
+    # same_line: closing brace is always on the same line as last element
     - symmetrical
     - new_line
+    - same_line
 
 Style/MultilineAssignmentLayout:
   Description: 'Check for a newline after the assignment operator in multi-line assignments.'
@@ -101,8 +103,10 @@ Style/MultilineHashBraceLayout:
   SupportedStyles:
     # symmetrical: closing brace is positioned in same way as opening brace
     # new_line: closing brace is always on a new line
+    # same_line: closing brace is always on same line as last element
     - symmetrical
     - new_line
+    - same_line
 
 Style/MultilineMethodCallBraceLayout:
   Description: >-
@@ -114,8 +118,10 @@ Style/MultilineMethodCallBraceLayout:
   SupportedStyles:
     # symmetrical: closing brace is positioned in same way as opening brace
     # new_line: closing brace is always on a new line
+    # same_line: closing brace is always on the same line as last argument
     - symmetrical
     - new_line
+    - same_line
 
 Style/MultilineMethodDefinitionBraceLayout:
   Description: >-
@@ -127,8 +133,10 @@ Style/MultilineMethodDefinitionBraceLayout:
   SupportedStyles:
     # symmetrical: closing brace is positioned in same way as opening brace
     # new_line: closing brace is always on a new line
+    # same_line: closing brace is always on the same line as last parameter
     - symmetrical
     - new_line
+    - same_line
 
 Style/OptionHash:
   Description: "Don't use option hashes when you can use keyword arguments."

--- a/lib/rubocop/cop/mixin/multiline_literal_brace_layout.rb
+++ b/lib/rubocop/cop/mixin/multiline_literal_brace_layout.rb
@@ -12,20 +12,10 @@ module RuboCop
         return unless node.loc.begin # Ignore implicit literals.
         return if children(node).empty? # Ignore empty literals.
 
-        if style == :new_line
-          return unless closing_brace_on_same_line?(node)
-
-          add_offense(node, :expression, self.class::ALWAYS_NEW_LINE_MESSAGE)
-        elsif style == :symmetrical
-          if opening_brace_on_same_line?(node)
-            return if closing_brace_on_same_line?(node)
-
-            add_offense(node, :expression, self.class::SAME_LINE_MESSAGE)
-          else
-            return unless closing_brace_on_same_line?(node)
-
-            add_offense(node, :expression, self.class::NEW_LINE_MESSAGE)
-          end
+        case style
+        when :symmetrical then handle_symmetrical(node)
+        when :new_line then handle_new_line(node)
+        when :same_line then handle_same_line(node)
         end
       end
 
@@ -45,6 +35,30 @@ module RuboCop
       end
 
       private
+
+      def handle_new_line(node)
+        return unless closing_brace_on_same_line?(node)
+
+        add_offense(node, :expression, self.class::ALWAYS_NEW_LINE_MESSAGE)
+      end
+
+      def handle_same_line(node)
+        return if closing_brace_on_same_line?(node)
+
+        add_offense(node, :expression, self.class::ALWAYS_SAME_LINE_MESSAGE)
+      end
+
+      def handle_symmetrical(node)
+        if opening_brace_on_same_line?(node)
+          return if closing_brace_on_same_line?(node)
+
+          add_offense(node, :expression, self.class::SAME_LINE_MESSAGE)
+        else
+          return unless closing_brace_on_same_line?(node)
+
+          add_offense(node, :expression, self.class::NEW_LINE_MESSAGE)
+        end
+      end
 
       def children(node)
         node.children

--- a/lib/rubocop/cop/style/multiline_array_brace_layout.rb
+++ b/lib/rubocop/cop/style/multiline_array_brace_layout.rb
@@ -22,23 +22,36 @@ module RuboCop
       # The closing brace of a multi-line array literal must be on the line
       # after the last element of the array.
       #
+      # When using the `same_line` style:
+      #
+      # The closing brace of a multi-line array literal must be on the same
+      # line as the last element of the array.
+      #
       # @example
       #
-      #     # bad with symmetrical, good with new_line
+      #     # symmetrical: bad
+      #     # new_line: good
+      #     # same_line: bad
       #     [ :a,
       #       :b
       #     ]
       #
-      #     # always bad
+      #     # symmetrical: bad
+      #     # new_line: bad
+      #     # same_line: good
       #     [
       #       :a,
       #       :b ]
       #
-      #     # good with symmetrical, bad with new_line
+      #     # symmetrical: good
+      #     # new_line: bad
+      #     # same_line: good
       #     [ :a,
       #       :b ]
       #
-      #     # always good
+      #     # symmetrical: good
+      #     # new_line: good
+      #     # same_line: bad
       #     [
       #       :a,
       #       :b
@@ -56,6 +69,9 @@ module RuboCop
 
         ALWAYS_NEW_LINE_MESSAGE = 'Closing array brace must be on the line ' \
           'after the last array element.'.freeze
+
+        ALWAYS_SAME_LINE_MESSAGE = 'Closing array brace must be on the same ' \
+          'line as teh last array element.'.freeze
 
         def on_array(node)
           check_brace_layout(node)

--- a/lib/rubocop/cop/style/multiline_hash_brace_layout.rb
+++ b/lib/rubocop/cop/style/multiline_hash_brace_layout.rb
@@ -22,23 +22,36 @@ module RuboCop
       # The closing brace of a multi-line hash literal must be on the line
       # after the last element of the hash.
       #
+      # When using the `same_line` style:
+      #
+      # The closing brace of a multi-line hash literal must be on the same
+      # line as the last element of the hash.
+      #
       # @example
       #
-      #     # bad with symmetrical, good with new_line
+      #     # symmetrical: bad
+      #     # new_line: good
+      #     # same_line: bad
       #     { a: 1,
       #       b: 2
       #     }
       #
-      #     # always bad
+      #     # symmetrical: bad
+      #     # new_line: bad
+      #     # same_line: good
       #     {
       #       a: 1,
       #       b: 2 }
       #
-      #     # good with symmetrical, bad with new_line
+      #     # symmetrical: good
+      #     # new_line: bad
+      #     # same_line: good
       #     { a: 1,
       #       b: 2 }
       #
-      #     # always good
+      #     # symmetrical: good
+      #     # new_line: good
+      #     # same_line: bad
       #     {
       #       a: 1,
       #       b: 2
@@ -56,6 +69,9 @@ module RuboCop
 
         ALWAYS_NEW_LINE_MESSAGE = 'Closing hash brace must be on the line ' \
           'after the last hash element.'.freeze
+
+        ALWAYS_SAME_LINE_MESSAGE = 'Closing hash brace must be on the same ' \
+          'line as the last hash element.'.freeze
 
         def on_hash(node)
           check_brace_layout(node)

--- a/lib/rubocop/cop/style/multiline_method_call_brace_layout.rb
+++ b/lib/rubocop/cop/style/multiline_method_call_brace_layout.rb
@@ -22,23 +22,36 @@ module RuboCop
       # The closing brace of a multi-line method call must be on the line
       # after the last argument of the call.
       #
+      # When using the `same_line` style:
+      #
+      # The closing brace of a multi-line method call must be on the same
+      # line as the last argument of the call.
+      #
       # @example
       #
-      #     # bad with symmetrical, good with new_line
+      #     # symmetrical: bad
+      #     # new_line: good
+      #     # same_line: bad
       #     foo(a,
       #       b
       #     )
       #
-      #     # always bad
+      #     # symmetrical: bad
+      #     # new_line: bad
+      #     # same_line: good
       #     foo(
       #       a,
       #       b)
       #
-      #     # good with symmetrical, bad with new_line
+      #     # symmetrical: good
+      #     # new_line: bad
+      #     # same_line: good
       #     foo(a,
       #       b)
       #
-      #     # always good
+      #     # symmetrical: good
+      #     # new_line: good
+      #     # same_line: bad
       #     foo(
       #       a,
       #       b
@@ -56,6 +69,9 @@ module RuboCop
 
         ALWAYS_NEW_LINE_MESSAGE = 'Closing method call brace must be on ' \
           'the line after the last argument.'.freeze
+
+        ALWAYS_SAME_LINE_MESSAGE = 'Closing method call brace must be on ' \
+          'the same line as the last argument.'.freeze
 
         def on_send(node)
           check_brace_layout(node)

--- a/lib/rubocop/cop/style/multiline_method_definition_brace_layout.rb
+++ b/lib/rubocop/cop/style/multiline_method_definition_brace_layout.rb
@@ -22,23 +22,36 @@ module RuboCop
       # The closing brace of a multi-line method definition must be on the line
       # after the last parameter of the definition.
       #
+      # When using the `same_line` style:
+      #
+      # The closing brace of a multi-line method definition must be on the same
+      # line as the last parameter of the definition.
+      #
       # @example
       #
-      #     # bad with symmetrical, good with new_line
+      #     # symmetrical: bad
+      #     # new_line: good
+      #     # same_line: bad
       #     def foo(a,
       #       b
       #     )
       #
-      #     # always bad
+      #     # symmetrical: bad
+      #     # new_line: bad
+      #     # same_line: good
       #     def foo(
       #       a,
       #       b)
       #
-      #     # good with symmetrical, bad with new_line
+      #     # symmetrical: good
+      #     # new_line: bad
+      #     # same_line: good
       #     def foo(a,
       #       b)
       #
-      #     # always good
+      #     # symmetrical: good
+      #     # new_line: good
+      #     # same_line: bad
       #     def foo(
       #       a,
       #       b
@@ -57,6 +70,9 @@ module RuboCop
 
         ALWAYS_NEW_LINE_MESSAGE = 'Closing method definition brace must be ' \
           'on the line after the last parameter.'.freeze
+
+        ALWAYS_SAME_LINE_MESSAGE = 'Closing method definition brace must be ' \
+          'on the same line as the last parameter.'.freeze
 
         def on_method_def(_node, _method_name, args, _body)
           check_brace_layout(args)

--- a/spec/rubocop/cop/style/multiline_hash_brace_layout_spec.rb
+++ b/spec/rubocop/cop/style/multiline_hash_brace_layout_spec.rb
@@ -31,6 +31,6 @@ describe RuboCop::Cop::Style::MultilineHashBraceLayout, :config do
     let(:close) { '}' }
     let(:a) { 'a: 1' }
     let(:b) { 'b: 2' }
-    let(:multi) { ['b: {', 'foo: bar', '}'] }
+    let(:multi) { ['b: [', '1', ']'] }
   end
 end

--- a/spec/support/multiline_literal_brace_layout_examples.rb
+++ b/spec/support/multiline_literal_brace_layout_examples.rb
@@ -103,7 +103,7 @@ shared_examples_for 'multiline literal brace layout' do
         expect(cop.messages).to eq([described_class::NEW_LINE_MESSAGE])
       end
 
-      it 'autocorrects closing brace on different line from last element' do
+      it 'autocorrects closing brace on same line from last element' do
         new_source = autocorrect_source(cop, construct(true, false))
 
         expect(new_source).to eq(construct(true, true).join("\n"))
@@ -145,7 +145,7 @@ shared_examples_for 'multiline literal brace layout' do
         expect(cop.messages).to eq([described_class::ALWAYS_NEW_LINE_MESSAGE])
       end
 
-      it 'autocorrects closing brace on different same line as last element' do
+      it 'autocorrects closing brace on same line as last element' do
         new_source = autocorrect_source(cop, ["#{prefix}#{open}#{a}, # a",
                                               "#{b}#{close} # b",
                                               suffix])
@@ -177,10 +177,85 @@ shared_examples_for 'multiline literal brace layout' do
         expect(cop.messages).to eq([described_class::ALWAYS_NEW_LINE_MESSAGE])
       end
 
-      it 'autocorrects closing brace on different line from last element' do
+      it 'autocorrects closing brace on same line from last element' do
         new_source = autocorrect_source(cop, construct(true, false))
 
         expect(new_source).to eq(construct(true, true).join("\n"))
+      end
+    end
+  end
+
+  context 'same_line style' do
+    let(:cop_config) { { 'EnforcedStyle' => 'same_line' } }
+
+    context 'opening brace on same line as first element' do
+      it 'allows closing brace on same line from last element' do
+        inspect_source(cop, construct(false, false))
+
+        expect(cop.offenses).to be_empty
+      end
+
+      it 'allows closing brace on same line as multi-line element' do
+        inspect_source(cop, construct(false, a, multi, false))
+
+        expect(cop.offenses).to be_empty
+      end
+
+      it 'detects closing brace on different line from last element' do
+        inspect_source(cop, construct(false, true))
+
+        expect(cop.offenses.size).to eq(1)
+        expect(cop.offenses.first.line).to eq(1)
+        expect(cop.highlights).to eq([braces(false, true)])
+        expect(cop.messages).to eq([described_class::ALWAYS_SAME_LINE_MESSAGE])
+      end
+
+      it 'detects closing brace on different line from multiline element' do
+        inspect_source(cop, construct(false, a, multi, true))
+
+        expect(cop.offenses.size).to eq(1)
+        expect(cop.offenses.first.line).to eq(1)
+        expect(cop.highlights).to eq([braces(false, a, multi, true)])
+        expect(cop.messages).to eq([described_class::ALWAYS_SAME_LINE_MESSAGE])
+      end
+
+      it 'autocorrects closing brace on different line as last element' do
+        new_source = autocorrect_source(cop, ["#{prefix}#{open}#{a}, # a",
+                                              "#{b} # b",
+                                              close,
+                                              suffix])
+
+        expect(new_source)
+          .to eq("#{prefix}#{open}#{a}, # a\n#{b}#{close} # b\n#{suffix}")
+      end
+    end
+
+    context 'opening brace on separate line from first element' do
+      it 'allows closing brace on same line as last element' do
+        inspect_source(cop, construct(true, false))
+
+        expect(cop.offenses).to be_empty
+      end
+
+      it 'allows closing brace on same line as last multiline element' do
+        inspect_source(cop, construct(true, a, multi, false))
+
+        expect(cop.offenses).to be_empty
+      end
+
+      it 'detects closing brace on different line from last element' do
+        inspect_source(cop, construct(true, true))
+
+        expect(cop.offenses.size).to eq(1)
+        expect(cop.offenses.first.line).to eq(1)
+        expect(cop.highlights).to eq([braces(true, true)])
+        expect(cop.messages).to eq([described_class::ALWAYS_SAME_LINE_MESSAGE])
+      end
+
+      it 'autocorrects closing brace on different line from last element' do
+        new_source = autocorrect_source(cop, construct(true, true))
+
+        expect(new_source).to eq(construct(true, false).join("\n"))
       end
     end
   end


### PR DESCRIPTION
The `Style/Multiline*BraceLayout` cops now supports the `same_line`
enforced style. This style forces the closing brace to always be on the
same line as the last element.

For reference see #2914