### PR TITLE
[Fix #3048] Do not report defs in Struct.new block as nested

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@
 * [#3043](https://github.com/bbatsov/rubocop/issues/3043): `Style/SpaceAfterNot` will now register an offense for a receiver that is wrapped in parentheses. ([@rrosenblum][])
 * [#3039](https://github.com/bbatsov/rubocop/issues/3039): Accept `match` without a receiver in `Performance/EndWith`. ([@lumeet][])
 * [#3039](https://github.com/bbatsov/rubocop/issues/3039): Accept `match` without a receiver in `Performance/StartWith`. ([@lumeet][])
+* [#3048](https://github.com/bbatsov/rubocop/issues/3048): `Lint/NestedMethodDefinition` shouldn't flag methods defined on Structs. ([@owst][])
 
 ### Changes
 

--- a/lib/rubocop/cop/lint/nested_method_definition.rb
+++ b/lib/rubocop/cop/lint/nested_method_definition.rb
@@ -22,14 +22,6 @@ module RuboCop
         MSG = 'Method definitions must not be nested. ' \
               'Use `lambda` instead.'.freeze
 
-        def_node_matcher :eval_call?, <<-PATTERN
-          (block (send _ {:instance_eval :class_eval :module_eval} ...) ...)
-        PATTERN
-
-        def_node_matcher :class_or_module_or_struct_new_call?, <<-PATTERN
-          (block (send (const nil {:Class :Module :Struct}) :new ...) ...)
-        PATTERN
-
         def on_method_def(node, _method_name, _args, _body)
           find_nested_defs(node) do |nested_def_node|
             add_offense(nested_def_node, :expression)
@@ -44,11 +36,25 @@ module RuboCop
               subject, = *child
               next if subject.lvar_type?
               yield child
-            elsif !(eval_call?(child) || class_or_module_or_struct_new_call?(child))
+            elsif !ignored_child?(child)
               find_nested_defs(child, &block)
             end
           end
         end
+
+        private
+
+        def ignored_child?(child)
+          eval_call?(child) || class_or_module_or_struct_new_call?(child)
+        end
+
+        def_node_matcher :eval_call?, <<-PATTERN
+          (block (send _ {:instance_eval :class_eval :module_eval} ...) ...)
+        PATTERN
+
+        def_node_matcher :class_or_module_or_struct_new_call?, <<-PATTERN
+          (block (send (const nil {:Class :Module :Struct}) :new ...) ...)
+        PATTERN
       end
     end
   end

--- a/lib/rubocop/cop/lint/nested_method_definition.rb
+++ b/lib/rubocop/cop/lint/nested_method_definition.rb
@@ -26,8 +26,8 @@ module RuboCop
           (block (send _ {:instance_eval :class_eval :module_eval} ...) ...)
         PATTERN
 
-        def_node_matcher :class_or_module_new_call?, <<-PATTERN
-          (block (send (const nil {:Class :Module}) :new ...) ...)
+        def_node_matcher :class_or_module_or_struct_new_call?, <<-PATTERN
+          (block (send (const nil {:Class :Module :Struct}) :new ...) ...)
         PATTERN
 
         def on_method_def(node, _method_name, _args, _body)
@@ -44,7 +44,7 @@ module RuboCop
               subject, = *child
               next if subject.lvar_type?
               yield child
-            elsif !(eval_call?(child) || class_or_module_new_call?(child))
+            elsif !(eval_call?(child) || class_or_module_or_struct_new_call?(child))
               find_nested_defs(child, &block)
             end
           end

--- a/spec/rubocop/cop/lint/nested_method_definition_spec.rb
+++ b/spec/rubocop/cop/lint/nested_method_definition_spec.rb
@@ -128,4 +128,18 @@ describe RuboCop::Cop::Lint::NestedMethodDefinition do
                          'end'])
     expect(cop.offenses.size).to eq(0)
   end
+
+  it 'does not register offense for nested definition inside Struct.new' do
+    ['(:name)', ''].each do |constructor_args|
+      inspect_source(cop, ['class Foo',
+                           '  def self.define',
+                           "    Struct.new#{constructor_args} do",
+                           '      def y',
+                           '      end',
+                           '    end',
+                           '  end',
+                           'end'])
+      expect(cop.offenses.size).to eq(0)
+    end
+  end
 end

--- a/spec/rubocop/cop/lint/nested_method_definition_spec.rb
+++ b/spec/rubocop/cop/lint/nested_method_definition_spec.rb
@@ -29,14 +29,6 @@ describe RuboCop::Cop::Lint::NestedMethodDefinition do
     expect(cop.offenses.size).to eq(1)
   end
 
-  it 'does not register an offense for a lambda definition inside method' do
-    inspect_source(cop, ['def foo',
-                         '  bar = -> { puts  }',
-                         '  bar.call',
-                         'end'])
-    expect(cop.offenses.size).to eq(0)
-  end
-
   it 'registers an offense for a nested class method definition' do
     inspect_source(cop, ['class Foo',
                          '  def self.x',
@@ -45,6 +37,14 @@ describe RuboCop::Cop::Lint::NestedMethodDefinition do
                          '  end',
                          'end'])
     expect(cop.offenses.size).to eq(1)
+  end
+
+  it 'does not register an offense for a lambda definition inside method' do
+    inspect_source(cop, ['def foo',
+                         '  bar = -> { puts  }',
+                         '  bar.call',
+                         'end'])
+    expect(cop.offenses).to be_empty
   end
 
   it 'does not register offense for nested definition inside instance_eval' do
@@ -56,7 +56,7 @@ describe RuboCop::Cop::Lint::NestedMethodDefinition do
                          '    end',
                          '  end',
                          'end'])
-    expect(cop.offenses.size).to eq(0)
+    expect(cop.offenses).to be_empty
   end
 
   it 'does not register offense for definition of method on local var' do
@@ -78,7 +78,7 @@ describe RuboCop::Cop::Lint::NestedMethodDefinition do
                          '    end',
                          '  end',
                          'end'])
-    expect(cop.offenses.size).to eq(0)
+    expect(cop.offenses).to be_empty
   end
 
   it 'does not register offense for nested definition inside module_eval' do
@@ -90,31 +90,21 @@ describe RuboCop::Cop::Lint::NestedMethodDefinition do
                          '    end',
                          '  end',
                          'end'])
-    expect(cop.offenses.size).to eq(0)
+    expect(cop.offenses).to be_empty
   end
 
   it 'does not register offense for nested definition inside Class.new' do
-    inspect_source(cop, ['class Foo',
-                         '  def self.define',
-                         '    Class.new do',
-                         '      def y',
-                         '      end',
-                         '    end',
-                         '  end',
-                         'end'])
-    expect(cop.offenses.size).to eq(0)
-  end
-
-  it 'does not register offense for nested definition inside Class.new(S)' do
-    inspect_source(cop, ['class Foo',
-                         '  def self.define',
-                         '    Class.new(S) do',
-                         '      def y',
-                         '      end',
-                         '    end',
-                         '  end',
-                         'end'])
-    expect(cop.offenses.size).to eq(0)
+    ['(S)', ''].each do |constructor_args|
+      inspect_source(cop, ['class Foo',
+                           '  def self.define',
+                           "    Class.new#{constructor_args} do",
+                           '      def y',
+                           '      end',
+                           '    end',
+                           '  end',
+                           'end'])
+      expect(cop.offenses).to be_empty
+    end
   end
 
   it 'does not register offense for nested definition inside Module.new' do
@@ -126,7 +116,7 @@ describe RuboCop::Cop::Lint::NestedMethodDefinition do
                          '    end',
                          '  end',
                          'end'])
-    expect(cop.offenses.size).to eq(0)
+    expect(cop.offenses).to be_empty
   end
 
   it 'does not register offense for nested definition inside Struct.new' do
@@ -139,7 +129,7 @@ describe RuboCop::Cop::Lint::NestedMethodDefinition do
                            '    end',
                            '  end',
                            'end'])
-      expect(cop.offenses.size).to eq(0)
+      expect(cop.offenses).to be_empty
     end
   end
 end


### PR DESCRIPTION
This PR ensures that defs inside the block passed to `Struct.new` are not reported as nested. I also took the opportunity to make some helper methods private and slightly refactor the specs.


Before submitting a PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [x] Used the same coding conventions as the rest of the project.
* [x] Feature branch is up-to-date with `master` (if not - rebase it)
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../CONTRIBUTING.md#changelog-entry-format).
* [x] All tests are passing.
* [x] The new code doesn't generate RuboCop offenses.
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.

[1]: http://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html
