### PR TITLE
[Fix #3049] Improve Lint/UselessAccessModifier

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,7 @@
 * [#2912](https://github.com/bbatsov/rubocop/issues/2912): Check whether a line is aligned with the following line if the preceding line is not an assignment. ([@akihiro17][])
 * [#3036](https://github.com/bbatsov/rubocop/issues/3036): Don't let `Lint/UnneededDisable` inspect files that are excluded for the cop. ([@jonas054][])
 * [#2874](https://github.com/bbatsov/rubocop/issues/2874): Fix bug when the closing parenthesis is preceded by a newline in array and hash literals in `Style/RedundantParentheses`. ([@lumeet][])
+* [#3049](https://github.com/bbatsov/rubocop/issues/3049): Make `Lint/UselessAccessModifier` detect conditionally defined methods and correctly handle dynamically defined methods and singleton class methods. ([@owst][])
 
 ### Changes
 

--- a/lib/rubocop/cop/lint/useless_access_modifier.rb
+++ b/lib/rubocop/cop/lint/useless_access_modifier.rb
@@ -4,34 +4,60 @@
 module RuboCop
   module Cop
     module Lint
-      # This cop checks for redundant access modifiers, including those with
-      # no code, those which are repeated, and leading `public` modifiers in
-      # a class or module body.
+      # This cop checks for redundant access modifiers, including those with no
+      # code, those which are repeated, and leading `public` modifiers in a
+      # class or module body. Conditionally-defined methods are considered as
+      # always being defined, and thus access modifiers guarding such methods
+      # are not redundant.
       #
       # @example
       #
       #   class Foo
-      #     public # this is redundant
+      #     public # this is redundant (default access is public)
       #
       #     def method
       #     end
       #
-      #     private # this is not redundant
+      #     private # this is not redundant (a method is defined)
       #     def method2
       #     end
       #
-      #     private # this is redundant
+      #     private # this is redundant (no following methods are defined)
+      #   end
+      #
+      # @example
+      #
+      #   class Foo
+      #     # The following is not redundant (conditionally defined methods are
+      #     # considered as always defining a method)
+      #     private
+      #
+      #     if condition?
+      #       def method
+      #       end
+      #     end
+      #
+      #     protected # this is not redundant (method is defined)
+      #
+      #     define_method(:method2) do
+      #     end
+      #
+      #     protected # this is redundant (repeated from previous modifier)
+      #
+      #     [1,2,3].each do |i|
+      #       define_method("foo#{i}") do
+      #       end
+      #     end
+      #
+      #     # The following is redundant (methods defined on the class'
+      #     # singleton class are not affected by the public modifier)
+      #     public
+      #
+      #     def self.method3
+      #     end
       #   end
       class UselessAccessModifier < Cop
         MSG = 'Useless `%s` access modifier.'.freeze
-
-        def_node_matcher :access_modifier, <<-PATTERN
-          (send nil ${:public :protected :private})
-        PATTERN
-
-        def_node_matcher :method_definition?, <<-PATTERN
-          {def (send nil {:attr :attr_reader :attr_writer :attr_accessor} ...)}
-        PATTERN
 
         def on_class(node)
           check_node(node.children[2]) # class body
@@ -41,10 +67,37 @@ module RuboCop
           check_node(node.children[1]) # module body
         end
 
+        def on_block(node)
+          return unless class_or_instance_eval?(node)
+
+          check_node(node.children[2]) # block body
+        end
+
+        def on_sclass(node)
+          check_node(node.children[1]) # singleton class body
+        end
+
         private
+
+        def_node_matcher :access_modifier, <<-PATTERN
+          (send nil ${:public :protected :private})
+        PATTERN
+
+        def_node_matcher :static_method_definition?, <<-PATTERN
+          {def (send nil {:attr :attr_reader :attr_writer :attr_accessor} ...)}
+        PATTERN
+
+        def_node_matcher :dynamic_method_definition?, <<-PATTERN
+          {(send nil :define_method ...) (block (send nil :define_method ...) ...)}
+        PATTERN
+
+        def_node_matcher :class_or_instance_eval?, <<-PATTERN
+          (block (send _ {:class_eval :instance_eval}) ...)
+        PATTERN
 
         def check_node(node)
           return if node.nil?
+
           if node.begin_type?
             check_scope(node)
           elsif (vis = access_modifier(node))
@@ -52,9 +105,13 @@ module RuboCop
           end
         end
 
-        def check_scope(node, cur_vis = :public)
-          unused = nil
+        def check_scope(node)
+          cur_vis, unused = check_child_nodes(node, nil, :public)
 
+          add_offense(unused, :expression, format(MSG, cur_vis)) if unused
+        end
+
+        def check_child_nodes(node, unused, cur_vis)
           node.child_nodes.each do |child|
             if (new_vis = access_modifier(child))
               # does this modifier just repeat the existing visibility?
@@ -70,14 +127,23 @@ module RuboCop
               cur_vis = new_vis
             elsif method_definition?(child)
               unused = nil
-            elsif child.kwbegin_type? || child.send_type?
-              cur_vis, unused = check_scope(child, cur_vis)
+            elsif start_of_new_scope?(child)
+              check_scope(child)
+            elsif !child.defs_type?
+              cur_vis, unused = check_child_nodes(child, unused, cur_vis)
             end
           end
 
-          add_offense(unused, :expression, format(MSG, cur_vis)) if unused
-
           [cur_vis, unused]
+        end
+
+        def method_definition?(child)
+          static_method_definition?(child) || dynamic_method_definition?(child)
+        end
+
+        def start_of_new_scope?(child)
+          child.module_type? || child.class_type? ||
+            child.sclass_type? || class_or_instance_eval?(child)
         end
       end
     end


### PR DESCRIPTION
This PR expands `Lint/UselessAccessModifer`:

- Add detection of conditionally defined methods,
- Add detection of dynamically defined methods,
- Ensure singleton class methods are handled correctly,
- DRY up some repetition in specs.

Before submitting a PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [x] Used the same coding conventions as the rest of the project.
* [x] Feature branch is up-to-date with `master` (if not - rebase it)
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../CONTRIBUTING.md#changelog-entry-format).
* [x] All tests are passing.
* [x] The new code doesn't generate RuboCop offenses.
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.

[1]: http://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html