### PR TITLE
Fix #3043 - SpaceAfterNot offense with parentheses

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@
 * [#2995](https://github.com/bbatsov/rubocop/issues/2995): Removed deprecated path matching syntax. ([@gerrywastaken][])
 * [#3025](https://github.com/bbatsov/rubocop/pull/3025): Removed deprecation warnings for `rubocop-todo.yml`. ([@ptarjan][])
 * [#3028](https://github.com/bbatsov/rubocop/pull/3028): Add `define_method` to the default list of `IgnoredMethods` of `Style/SymbolProc`. ([@jastkand][])
+* [#3064](https://github.com/bbatsov/rubocop/pull/3064): `Style/SpaceAfterNot` highlights the entire expression instead of just the exlamation mark. ([@rrosenblum][])
 
 ## 0.39.0 (2016-03-27)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@
 * [#3010](https://github.com/bbatsov/rubocop/issues/3010): Fix double reporting/correction of spaces after ternary operator colons (now only reported by `Style/SpaceAroundOperators`, and not `Style/SpaceAfterColon` too). ([@owst][])
 * [#3006](https://github.com/bbatsov/rubocop/issues/3006): Register an offense for calling `merge!` on a method on a variable inside `each_with_object` in `Performance/RedundantMerge`. ([@lumeet][], [@rrosenblum][])
 * [#2886](https://github.com/bbatsov/rubocop/issues/2886): Custom cop changes now bust the cache. ([@ptarjan][])
+* [#3043](https://github.com/bbatsov/rubocop/issues/3043): `Style/SpaceAfterNot` will now register an offense for a receiver that is wrapped in parentheses. ([@rrosenblum][])
 
 ### Changes
 

--- a/lib/rubocop/cop/style/space_after_not.rb
+++ b/lib/rubocop/cop/style/space_after_not.rb
@@ -21,8 +21,7 @@ module RuboCop
           return unless method_name == :!
           return unless receiver.loc.column - node.loc.column > 1
 
-          # TODO: Improve source range to highlight the redundant whitespace.
-          add_offense(node, :selector)
+          add_offense(node, :expression)
         end
 
         def autocorrect(node)

--- a/lib/rubocop/cop/style/space_after_not.rb
+++ b/lib/rubocop/cop/style/space_after_not.rb
@@ -16,10 +16,10 @@ module RuboCop
         MSG = 'Do not leave space between `!` and its argument.'.freeze
 
         def on_send(node)
-          _receiver, method_name, *_args = *node
+          receiver, method_name, *_args = *node
 
           return unless method_name == :!
-          return unless node.source =~ /^!\s+\w+/
+          return unless receiver.loc.column - node.loc.column > 1
 
           # TODO: Improve source range to highlight the redundant whitespace.
           add_offense(node, :selector)

--- a/spec/rubocop/cop/style/space_after_not_spec.rb
+++ b/spec/rubocop/cop/style/space_after_not_spec.rb
@@ -16,6 +16,12 @@ describe RuboCop::Cop::Style::SpaceAfterNot do
     expect(cop.offenses).to be_empty
   end
 
+  it 'reports an offense for space after ! with the negated receiver ' \
+     'wrapped in parentheses' do
+    inspect_source(cop, '! (model)')
+    expect(cop.offenses.size).to eq(1)
+  end
+
   it 'auto-corrects by removing redundant space' do
     new_source = autocorrect_source(cop, '!  something')
     expect(new_source).to eq('!something')

--- a/spec/rubocop/cop/style/space_after_not_spec.rb
+++ b/spec/rubocop/cop/style/space_after_not_spec.rb
@@ -8,22 +8,38 @@ describe RuboCop::Cop::Style::SpaceAfterNot do
 
   it 'reports an offense for space after !' do
     inspect_source(cop, '! something')
-    expect(cop.offenses.size).to eq(1)
+
+    expect(cop.messages)
+      .to eq(['Do not leave space between `!` and its argument.'])
+    expect(cop.highlights).to eq(['! something'])
   end
 
   it 'accepts no space after !' do
     inspect_source(cop, '!something')
+
     expect(cop.offenses).to be_empty
   end
 
   it 'reports an offense for space after ! with the negated receiver ' \
      'wrapped in parentheses' do
     inspect_source(cop, '! (model)')
-    expect(cop.offenses.size).to eq(1)
+
+    expect(cop.messages)
+      .to eq(['Do not leave space between `!` and its argument.'])
+    expect(cop.highlights).to eq(['! (model)'])
   end
 
-  it 'auto-corrects by removing redundant space' do
-    new_source = autocorrect_source(cop, '!  something')
-    expect(new_source).to eq('!something')
+  context 'auto-correct' do
+    it 'removes redundant space' do
+      new_source = autocorrect_source(cop, '!  something')
+
+      expect(new_source).to eq('!something')
+    end
+
+    it 'removes redundant space when there is a parentheses' do
+      new_source = autocorrect_source(cop, '!  (model)')
+
+      expect(new_source).to eq('!(model)')
+    end
   end
 end


### PR DESCRIPTION
This fixes #3043. It appears that this cop would have never worked with parentheses. I am not sure why it wouldn't be configured to work that way. Maybe an oversight. 

I also knocked out the TODO and modified the highlight to include the entire expression.