### PR TITLE
Add autocorrect for Rails/Validation cop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## master (unreleased)
 
+* [#2927](https://github.com/bbatsov/rubocop/issues/2927): Add autocorrect for `Rails/Validation` cop. ([@neodelf][])
+
 ### Bug fixes
 
 * [#3114](https://github.com/bbatsov/rubocop/issues/3114): Fix alignment `end` when auto-correcting `Style/EmptyElse`. ([@rrosenblum][])
@@ -30,6 +32,7 @@
 * [#2909](https://github.com/bbatsov/rubocop/issues/2909): `Style/Lambda` enforced style supports `lambda` option. ([@drenmi][])
 * [#3092](https://github.com/bbatsov/rubocop/pull/3092): Allow `Style/Encoding` to enforce using no encoding comments. ([@NobodysNightmare][])
 * New cop `Rails/UniqBeforePluck` checks that `uniq` is used before `pluck`. ([@tjwp][])
+* [#2927](https://github.com/bbatsov/rubocop/issues/2927): Add autocorrect for `Rails/Validation` cop. ([@neodelf][])
 
 ### Bug fixes
 
@@ -2158,3 +2161,4 @@
 [@NobodysNightmare]: https://github.com/NobodysNightmare
 [@gylaz]: https://github.com/gylaz
 [@tjwp]: https://github.com/tjwp
+[@neodelf]: https://github.com/neodelf

--- a/spec/rubocop/cop/rails/validation_spec.rb
+++ b/spec/rubocop/cop/rails/validation_spec.rb
@@ -8,22 +8,41 @@ describe RuboCop::Cop::Rails::Validation do
 
   described_class::BLACKLIST.each_with_index do |validation, number|
     it "registers an offense for #{validation}" do
-      inspect_source(cop,
-                     "#{validation} :name")
+      inspect_source(cop, "#{validation} :name")
       expect(cop.offenses.size).to eq(1)
     end
 
     it "outputs the correct message for #{validation}" do
-      inspect_source(cop,
-                     "#{validation} :name")
+      inspect_source(cop, "#{validation} :name")
       expect(cop.offenses.first.message)
         .to include(described_class::WHITELIST[number])
     end
   end
 
+  described_class::TYPES.each_with_index do |parameter|
+    it "autocorrect validates_#{parameter}_of" do
+      new_source = autocorrect_source(
+        cop,
+        "validates_#{parameter}_of :full_name, :birth_date"
+      )
+      expect(new_source).to eq(
+        "validates :full_name, :birth_date, #{parameter}: true"
+      )
+    end
+  end
+
   it 'accepts new style validations' do
-    inspect_source(cop,
-                   'validates :name')
+    inspect_source(cop, 'validates :name')
     expect(cop.offenses).to be_empty
+  end
+
+  it 'autocorrect validates_length_of' do
+    new_source = autocorrect_source(
+      cop,
+      'validates_numericality_of :age, minimum: 0, maximum: 122'
+    )
+    expect(new_source).to eq(
+      'validates :age, numericality: { minimum: 0, maximum: 122 }'
+    )
   end
 end


### PR DESCRIPTION
[Issue 2927](https://github.com/bbatsov/rubocop/issues/2927)

Before submitting a PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [x] Used the same coding conventions as the rest of the project.
* [x] Feature branch is up-to-date with `master` (if not - rebase it)
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../CONTRIBUTING.md#changelog-entry-format).
* [x] All tests are passing.
* [] The new code doesn't generate RuboCop offenses.
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.

[1]: http://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html
