### PR TITLE
[Fix #3022][Fix #2909]: Add EnforcedStyle configuration to Style/Lambda cop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,8 @@
 * [#3052](https://github.com/bbatsov/rubocop/pull/3052): `Style/MultilineMethodDefinitionBraceLayout` enforced style supports `same_line` option. ([@panthomakos][])
 * [#3019](https://github.com/bbatsov/rubocop/issues/3019): Add new `Style/EmptyCaseCondition` cop. ([@owst][])
 * [#3072](https://github.com/bbatsov/rubocop/pull/3072): Add new `Lint/UselessArraySplat` cop. ([@owst][])
+* [#3022](https://github.com/bbatsov/rubocop/issues/3022): `Style/Lambda` enforced style supports `literal` option. ([@drenmi][])
+* [#2909](https://github.com/bbatsov/rubocop/issues/2909): `Style/Lambda` enforced style supports `lambda` option. ([@drenmi][])
 
 ### Bug fixes
 

--- a/config/default.yml
+++ b/config/default.yml
@@ -590,6 +590,13 @@ Style/IndentHash:
   # But it can be overridden by setting this parameter
   IndentationWidth: ~
 
+Style/Lambda:
+  EnforcedStyle: line_count_dependent
+  SupportedStyles:
+    - line_count_dependent
+    - lambda
+    - literal
+
 Style/LambdaCall:
   EnforcedStyle: call
   SupportedStyles:
@@ -1013,7 +1020,7 @@ Lint/AssignmentInCondition:
 Lint/BlockAlignment:
   # The value `start_of_block` means that the `end` should be aligned with line
   # where the `do` keyword appears.
-  # The value `start_of_line` means it should be aligned with the whole 
+  # The value `start_of_line` means it should be aligned with the whole
   # expression's starting line.
   # The value `either` means both are allowed.
   AlignWith: either

--- a/spec/rubocop/cop/style/lambda_spec.rb
+++ b/spec/rubocop/cop/style/lambda_spec.rb
@@ -6,151 +6,305 @@ require 'spec_helper'
 describe RuboCop::Cop::Style::Lambda, :config do
   subject(:cop) { described_class.new(config) }
 
-  it 'registers an offense for an old single-line lambda call' do
-    inspect_source(cop, 'f = lambda { |x| x }')
-    expect(cop.offenses.size).to eq(1)
-    expect(cop.messages)
-      .to eq(['Use the new lambda literal syntax `->(params) {...}`.'])
-  end
-
-  it 'registers an offense for an old single-line no-argument lambda call' do
-    inspect_source(cop, 'f = lambda { x }')
-    expect(cop.offenses.size).to eq(1)
-    expect(cop.messages)
-      .to eq(['Use the new lambda literal syntax `-> {...}`.'])
-  end
-
-  it 'accepts the new lambda literal with single-line body' do
-    inspect_source(cop, ['lambda = ->(x) { x }',
-                         'lambda.(1)'])
-    expect(cop.offenses).to be_empty
-  end
-
-  it 'registers an offense for a new multi-line lambda call' do
-    inspect_source(cop, ['f = ->(x) do',
-                         '  x',
-                         'end'])
-    expect(cop.offenses.size).to eq(1)
-    expect(cop.messages)
-      .to eq(['Use the `lambda` method for multi-line lambdas.'])
-  end
-
-  it 'accepts the old lambda syntax with multi-line body' do
-    inspect_source(cop, ['l = lambda do |x|',
-                         '  x',
-                         'end'])
-    expect(cop.offenses).to be_empty
-  end
-
-  it 'accepts the lambda call outside of block' do
-    inspect_source(cop, 'l = lambda.test')
-    expect(cop.offenses).to be_empty
-  end
-
-  it 'auto-corrects an old single-line lambda call' do
-    new_source = autocorrect_source(cop, 'f = lambda { |x| x }')
-    expect(new_source).to eq('f = ->(x) { x }')
-  end
-
-  it 'auto-corrects an old single-line no-argument lambda call' do
-    new_source = autocorrect_source(cop, 'f = lambda { x }')
-    expect(new_source).to eq('f = -> { x }')
-  end
-
-  it 'auto-corrects a new multi-line lambda call' do
-    new_source = autocorrect_source(cop, ['f = ->(x) do',
-                                          '  x',
-                                          'end'])
-    expect(new_source).to eq(['f = lambda do |x|',
-                              '  x',
-                              'end'].join("\n"))
-  end
-
-  it 'auto-corrects a new multi-line no-argument lambda call' do
-    new_source = autocorrect_source(cop, ['f = -> do',
-                                          '  x',
-                                          'end'])
-    expect(new_source).to eq(['f = lambda do',
-                              '  x',
-                              'end'].join("\n"))
-  end
-
-  context 'unusual lack of spacing' do
-    # The lack of spacing shown here is valid ruby syntax,
-    # and can be the result of previous autocorrects re-writing
-    # a multi-line `->(x){ ... }` to `->(x)do ... end`.
-    # See rubocop/cop/style/block_delimiters.rb.
-    # Tests correction of an issue resulting in `lambdado` syntax errors.
-    it 'auto-corrects a multi-line lambda' do
-      new_source = autocorrect_source(cop, ['->(x)do',
-                                            '  x',
-                                            'end'])
-      expect(new_source).to eq(['lambda do |x|',
-                                '  x',
-                                'end'].join("\n"))
-    end
-
-    it 'auto-corrects a multi-line lambda with no spacing after args' do
-      new_source = autocorrect_source(cop, ['-> (x)do',
-                                            '  x',
-                                            'end'])
-      expect(new_source).to eq(['lambda do |x|',
-                                '  x',
-                                'end'].join("\n"))
-    end
-
-    it 'auto-corrects a multi-line lambda with no spacing before args' do
-      new_source = autocorrect_source(cop, ['->(x) do',
-                                            '  x',
-                                            'end'])
-      expect(new_source).to eq(['lambda do |x|',
-                                '  x',
-                                'end'].join("\n"))
-    end
-
-    it 'auto-corrects a multi-line lambda with empty args' do
-      new_source = autocorrect_source(cop, ['->()do',
-                                            '  x',
-                                            'end'])
-      expect(new_source).to eq(['lambda do',
-                                '  x',
-                                'end'].join("\n"))
-    end
-
-    it 'auto-corrects a multi-line lambda with empty args and bad spacing' do
-      new_source = autocorrect_source(cop, ['-> ()do',
-                                            '  x',
-                                            'end'])
-      expect(new_source).to eq(['lambda do',
-                                '  x',
-                                'end'].join("\n"))
-    end
-
-    it 'auto-corrects a new multi-line lambda with no args' do
-      new_source = autocorrect_source(cop, ['->do',
-                                            '  x',
-                                            'end'])
-      expect(new_source).to eq(['lambda do',
-                                '  x',
-                                'end'].join("\n"))
-    end
-  end
-
-  context 'new multi-line lambda as an argument' do
-    let(:source) do
-      ['has_many :kittens, -> do',
-       '  where(cats: Cat.young.where_values_hash)',
-       'end, source: cats']
-    end
-
+  shared_examples 'registers an offense' do |message|
     it 'registers an offense' do
       inspect_source(cop, source)
-      expect(cop.offenses.size).to eq 1
+
+      expect(cop.offenses.size).to eq(1)
+      expect(cop.messages).to eq([message])
+    end
+  end
+
+  shared_examples 'auto-correct' do |expected|
+    it 'auto-corrects' do
+      new_source = autocorrect_source(cop, source)
+
+      expect(new_source).to eq(expected)
+    end
+  end
+
+  context 'with enforced `lambda` style' do
+    let(:cop_config) { { 'EnforcedStyle' => 'lambda' } }
+
+    context 'with a single line lambda literal' do
+      context 'with arguments' do
+        let(:source) { 'f = ->(x) { x }' }
+
+        it_behaves_like 'registers an offense',
+                        'Use the `lambda` method for all lambdas.'
+        it_behaves_like 'auto-correct', 'f = lambda { |x| x }'
+      end
+
+      context 'without arguments' do
+        let(:source) { 'f = -> { x }' }
+
+        it_behaves_like 'registers an offense',
+                        'Use the `lambda` method for all lambdas.'
+        it_behaves_like 'auto-correct', 'f = lambda { x }'
+      end
     end
 
-    it 'does not auto-correct' do
-      expect(autocorrect_source(cop, source)).to eq(source.join("\n"))
-      expect(cop.offenses.map(&:corrected?)).to eq [false]
+    context 'with a multiline lambda literal' do
+      context 'with arguments' do
+        let(:source) do
+          ['f = ->(x) do',
+           '  x',
+           'end']
+        end
+
+        it_behaves_like 'registers an offense',
+                        'Use the `lambda` method for all lambdas.'
+        it_behaves_like 'auto-correct', ['f = lambda do |x|',
+                                         '  x',
+                                         'end'].join("\n")
+      end
+
+      context 'without arguments' do
+        let(:source) do
+          ['f = -> do',
+           '  x',
+           'end']
+        end
+
+        it_behaves_like 'registers an offense',
+                        'Use the `lambda` method for all lambdas.'
+        it_behaves_like 'auto-correct', ['f = lambda do',
+                                         '  x',
+                                         'end'].join("\n")
+      end
+    end
+  end
+
+  context 'with enforced `literal` style' do
+    let(:cop_config) { { 'EnforcedStyle' => 'literal' } }
+
+    context 'with a single line lambda method call' do
+      context 'with arguments' do
+        let(:source) { 'f = lambda { |x| x }' }
+
+        it_behaves_like 'registers an offense',
+                        'Use the `-> { ... }` lambda literal syntax for ' \
+                        'all lambdas.'
+        it_behaves_like 'auto-correct', 'f = ->(x) { x }'
+      end
+
+      context 'without arguments' do
+        let(:source) { 'f = lambda { x }' }
+
+        it_behaves_like 'registers an offense',
+                        'Use the `-> { ... }` lambda literal syntax for ' \
+                        'all lambdas.'
+        it_behaves_like 'auto-correct', 'f = -> { x }'
+      end
+    end
+
+    context 'with a multiline lambda method call' do
+      context 'with arguments' do
+        let(:source) do
+          ['f = lambda do |x|',
+           '  x',
+           'end']
+        end
+
+        it_behaves_like 'registers an offense',
+                        'Use the `-> { ... }` lambda literal syntax for ' \
+                        'all lambdas.'
+        it_behaves_like 'auto-correct', ['f = ->(x) do',
+                                         '  x',
+                                         'end'].join("\n")
+      end
+
+      context 'without arguments' do
+        let(:source) do
+          ['f = lambda do',
+           '  x',
+           'end']
+        end
+
+        it_behaves_like 'registers an offense',
+                        'Use the `-> { ... }` lambda literal syntax for ' \
+                        'all lambdas.'
+        it_behaves_like 'auto-correct', ['f = -> do',
+                                         '  x',
+                                         'end'].join("\n")
+      end
+    end
+  end
+
+  context 'with default `line_count_dependent` style' do
+    let(:cop_config) { { 'EnforcedStyle' => 'line_count_dependent' } }
+
+    context 'with a single line lambda method call' do
+      context 'with arguments' do
+        let(:source) { 'f = lambda { |x| x }' }
+
+        it_behaves_like 'registers an offense',
+                        'Use the `-> { ... }` lambda literal syntax for ' \
+                        'single line lambdas.'
+        it_behaves_like 'auto-correct', 'f = ->(x) { x }'
+      end
+
+      context 'without arguments' do
+        let(:source) { 'f = lambda { x }' }
+
+        it_behaves_like 'registers an offense',
+                        'Use the `-> { ... }` lambda literal syntax for ' \
+                        'single line lambdas.'
+        it_behaves_like 'auto-correct', 'f = -> { x }'
+      end
+    end
+
+    context 'with a multiline lambda method call' do
+      it 'does not register an offense' do
+        inspect_source(cop, ['l = lambda do |x|',
+                             '  x',
+                             'end'])
+        expect(cop.offenses).to be_empty
+      end
+    end
+
+    context 'with a single line lambda literal' do
+      it 'does not register an offense' do
+        inspect_source(cop, ['lambda = ->(x) { x }',
+                             'lambda.(1)'])
+        expect(cop.offenses).to be_empty
+      end
+    end
+
+    context 'with a multiline lambda literal' do
+      context 'with arguments' do
+        let(:source) do
+          ['f = ->(x) do',
+           '  x',
+           'end']
+        end
+
+        it_behaves_like 'registers an offense',
+                        'Use the `lambda` method for multiline lambdas.'
+        it_behaves_like 'auto-correct', ['f = lambda do |x|',
+                                         '  x',
+                                         'end'].join("\n")
+      end
+
+      context 'without arguments' do
+        let(:source) do
+          ['f = -> do',
+           '  x',
+           'end']
+        end
+
+        it_behaves_like 'registers an offense',
+                        'Use the `lambda` method for multiline lambdas.'
+        it_behaves_like 'auto-correct', ['f = lambda do',
+                                         '  x',
+                                         'end'].join("\n")
+      end
+    end
+
+    context 'unusual lack of spacing' do
+      # The lack of spacing shown here is valid ruby syntax,
+      # and can be the result of previous autocorrects re-writing
+      # a multi-line `->(x){ ... }` to `->(x)do ... end`.
+      # See rubocop/cop/style/block_delimiters.rb.
+      # Tests correction of an issue resulting in `lambdado` syntax errors.
+      context 'without any spacing' do
+        let(:source) do
+          ['->(x)do',
+           '  x',
+           'end']
+        end
+
+        it_behaves_like 'auto-correct', ['lambda do |x|',
+                                         '  x',
+                                         'end'].join("\n")
+      end
+
+      context 'without spacing after arguments' do
+        let(:source) do
+          ['-> (x)do',
+           '  x',
+           'end']
+        end
+
+        it_behaves_like 'auto-correct', ['lambda do |x|',
+                                         '  x',
+                                         'end'].join("\n")
+      end
+
+      context 'without spacing before arguments' do
+        let(:source) do
+          ['->(x) do',
+           '  x',
+           'end']
+        end
+
+        it_behaves_like 'auto-correct', ['lambda do |x|',
+                                         '  x',
+                                         'end'].join("\n")
+      end
+
+      context 'with a multiline lambda literal' do
+        context 'with empty arguments' do
+          let(:source) do
+            ['->()do',
+             '  x',
+             'end']
+          end
+
+          it_behaves_like 'auto-correct', ['lambda do',
+                                           '  x',
+                                           'end'].join("\n")
+        end
+
+        context 'with no arguments and bad spacing' do
+          let(:source) do
+            ['-> ()do',
+             '  x',
+             'end']
+          end
+
+          it_behaves_like 'auto-correct', ['lambda do',
+                                           '  x',
+                                           'end'].join("\n")
+        end
+
+        context 'with no arguments and no spacing' do
+          let(:source) do
+            ['->do',
+             '  x',
+             'end']
+          end
+
+          it_behaves_like 'auto-correct', ['lambda do',
+                                           '  x',
+                                           'end'].join("\n")
+        end
+      end
+    end
+
+    context 'when calling a lambda method without a block' do
+      it 'does not register an offense' do
+        inspect_source(cop, 'l = lambda.test')
+        expect(cop.offenses).to be_empty
+      end
+    end
+
+    context 'with a multiline lambda literal as an argument' do
+      let(:source) do
+        ['has_many :kittens, -> do',
+         '  where(cats: Cat.young.where_values_hash)',
+         'end, source: cats']
+      end
+
+      it 'registers an offense' do
+        inspect_source(cop, source)
+        expect(cop.offenses.size).to eq 1
+      end
+
+      it 'does not auto-correct' do
+        expect(autocorrect_source(cop, source)).to eq(source.join("\n"))
+        expect(cop.offenses.map(&:corrected?)).to eq [false]
+      end
     end
   end
 end


### PR DESCRIPTION
#### Overview of the change

This change implements configurable styles for the `Style/Lambda` cop, allowing you to indicate that you want the old, method style (`lambda`) or new, literal style (`->`) lambdas for both single line and multiline lambdas. The new configuration options are:

- `line_count_dependent`

  This is the old, default configuration. It enforces `literal` style for single line lambdas, and `lambda` style for multiline lambdas.
  
- `lambda`

  This configuration enforces `lambda` style for all lambdas.

- `literal`

  This configuration enforces `literal` style for all lambdas.

===

#### Suggestion messages

The messages will adjust to whatever configuration you're using, to make it clear what the user needs to do. With either of the optional styles, the message will tell the user to use the enforced style in all cases:

> Use the old `lambda` method for **all** lambdas.

With the default style, it will advise the user in which cases to use which style:

> Use the old `lambda` method for **multiline** lambdas.

With this change, I removed the part that would format the message to either contain arguments or not, depending on the actual offense, i.e. `-> { ... }` vs. `->(x) { ... }`. Reason being that correctly constructing this would now take a lot more conditional logic, due to the added dimension of single line vs. multiline, and possibly require reading the configuration for `Style/BlockDelimiters`. In my opinion, the message is still very comprehensible, and I don't think it's worth the additional complexity of making it more specific.

====

#### Slight changes in semantics

Internally, I changed references to "new" and "old" to "literal" and "method", which is more semantic, and won't cause issues if a third style is introduced. In the messages presented to the users, I kept the "new" and "old" wording, in addition to mentioning "literals" or "methods".