### PR TITLE
[Fix #3036] Don't let UnneededDisable inspect excluded files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,7 @@
 * [#3039](https://github.com/bbatsov/rubocop/issues/3039): Accept `match` without a receiver in `Performance/StartWith`. ([@lumeet][])
 * [#3048](https://github.com/bbatsov/rubocop/issues/3048): `Lint/NestedMethodDefinition` shouldn't flag methods defined on Structs. ([@owst][])
 * [#2912](https://github.com/bbatsov/rubocop/issues/2912): Check whether a line is aligned with the following line if the preceding line is not an assignment. ([@akihiro17][])
+* [#3036](https://github.com/bbatsov/rubocop/issues/3036): Don't let `Lint/UnneededDisable` inspect files that are excluded for the cop. ([@jonas054][])
 
 ### Changes
 

--- a/lib/rubocop/runner.rb
+++ b/lib/rubocop/runner.rb
@@ -102,10 +102,12 @@ module RuboCop
          # given, because these options override configuration.
          (@options[:except] || []).empty? && (@options[:only] || []).empty?
         config = @config_store.for(file)
-        if config['Lint/UnneededDisable']['Enabled']
+        if config.cop_enabled?(Cop::Lint::UnneededDisable)
           cop = Cop::Lint::UnneededDisable.new(config, @options)
-          cop.check(offenses, source.disabled_line_ranges, source.comments)
-          offenses += cop.offenses
+          if cop.relevant_file?(file)
+            cop.check(offenses, source.disabled_line_ranges, source.comments)
+            offenses += cop.offenses
+          end
         end
       end
 


### PR DESCRIPTION
Check whether files are excluded before calling `UnneededDisable`, which is a special cop that's called after all the others are finished.