### PR TITLE
[Fix #2874] Accept parentheses in hash and array

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,7 @@
 * [#3048](https://github.com/bbatsov/rubocop/issues/3048): `Lint/NestedMethodDefinition` shouldn't flag methods defined on Structs. ([@owst][])
 * [#2912](https://github.com/bbatsov/rubocop/issues/2912): Check whether a line is aligned with the following line if the preceding line is not an assignment. ([@akihiro17][])
 * [#3036](https://github.com/bbatsov/rubocop/issues/3036): Don't let `Lint/UnneededDisable` inspect files that are excluded for the cop. ([@jonas054][])
+* [#2874](https://github.com/bbatsov/rubocop/issues/2874): Fix bug when the closing parenthesis is preceded by a newline in array and hash literals in `Style/RedundantParentheses`. ([@lumeet][])
 
 ### Changes
 

--- a/spec/rubocop/cop/style/redundant_parentheses_spec.rb
+++ b/spec/rubocop/cop/style/redundant_parentheses_spec.rb
@@ -104,6 +104,11 @@ describe RuboCop::Cop::Style::RedundantParentheses do
   it_behaves_like 'plausible', '+(1.foo.bar)'
 
   it_behaves_like 'redundant', '[(1)]', '[1]', 'a literal', '(1)'
+  it_behaves_like 'redundant', "[(1\n)]", "[1\n]", 'a literal', "(1\n)"
+  it_behaves_like 'plausible', "[(1\n),]"
+  it_behaves_like 'redundant', '{a: (1)}', '{a: 1}', 'a literal', '(1)'
+  it_behaves_like 'redundant', "{a: (1\n)}", "{a: 1\n}", 'a literal', "(1\n)"
+  it_behaves_like 'plausible', "{a: (1\n),}"
 
   it 'accepts parentheses around a method call with unparenthesized ' \
      'arguments' do


### PR DESCRIPTION
Before submitting a PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [x] Used the same coding conventions as the rest of the project.
* [x] Feature branch is up-to-date with `master` (if not - rebase it)
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../CONTRIBUTING.md#changelog-entry-format).
* [x] All tests are passing.
* [x] The new code doesn't generate RuboCop offenses.
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.

[1]: http://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html

`Style/RedundantParentheses` doesn't register an offense for
parentheses in array and hash literals when the removal would cause
invalid syntax. For example, the following is accepted:

    array = [(
             <<-EOF
               something
             EOF
             ),
             'something']