### PR TITLE
Enable symmetrical braces for arrays and hashes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,7 @@
 * [#3025](https://github.com/bbatsov/rubocop/pull/3025): Removed deprecation warnings for `rubocop-todo.yml`. ([@ptarjan][])
 * [#3028](https://github.com/bbatsov/rubocop/pull/3028): Add `define_method` to the default list of `IgnoredMethods` of `Style/SymbolProc`. ([@jastkand][])
 * [#3064](https://github.com/bbatsov/rubocop/pull/3064): `Style/SpaceAfterNot` highlights the entire expression instead of just the exlamation mark. ([@rrosenblum][])
+* [#3085](https://github.com/bbatsov/rubocop/pull/3085): Enable `Style/MultilineArrayBraceLayout` and `Style/MultilineHashBraceLayout` with the `symmetrical` style by default. ([@panthomakos][])
 
 ## 0.39.0 (2016-03-27)
 

--- a/config/default.yml
+++ b/config/default.yml
@@ -637,6 +637,16 @@ Style/MethodName:
     - snake_case
     - camelCase
 
+Style/MultilineArrayBraceLayout:
+  EnforcedStyle: symmetrical
+  SupportedStyles:
+    # symmetrical: closing brace is positioned in same way as opening brace
+    # new_line: closing brace is always on a new line
+    # same_line: closing brace is always on the same line as last element
+    - symmetrical
+    - new_line
+    - same_line
+
 Style/MultilineAssignmentLayout:
   # The types of assignments which are subject to this rule.
   SupportedTypes:
@@ -654,6 +664,17 @@ Style/MultilineAssignmentLayout:
     # Ensures that the assignment operator and the rhs are on separate lines
     # for the set of supported types.
     - new_line
+
+Style/MultilineHashBraceLayout:
+  EnforcedStyle: symmetrical
+  SupportedStyles:
+    # symmetrical: closing brace is positioned in same way as opening brace
+    # new_line: closing brace is always on a new line
+    # same_line: closing brace is always on same line as last element
+    - symmetrical
+    - new_line
+    - same_line
+
 
 Style/MultilineMethodCallIndentation:
   EnforcedStyle: aligned

--- a/config/disabled.yml
+++ b/config/disabled.yml
@@ -73,40 +73,10 @@ Style/MissingElse:
     - case
     - both
 
-Style/MultilineArrayBraceLayout:
-  Description: >-
-                 Checks that the closing brace in an array literal is
-                 either on the same line as the last array element, or
-                 a new line.
-  Enabled: false
-  EnforcedStyle: symmetrical
-  SupportedStyles:
-    # symmetrical: closing brace is positioned in same way as opening brace
-    # new_line: closing brace is always on a new line
-    # same_line: closing brace is always on the same line as last element
-    - symmetrical
-    - new_line
-    - same_line
-
 Style/MultilineAssignmentLayout:
   Description: 'Check for a newline after the assignment operator in multi-line assignments.'
   StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#indent-conditional-assignment'
   Enabled: false
-
-Style/MultilineHashBraceLayout:
-  Description: >-
-                 Checks that the closing brace in a hash literal is
-                 either on the same line as the last hash element, or
-                 a new line.
-  Enabled: false
-  EnforcedStyle: symmetrical
-  SupportedStyles:
-    # symmetrical: closing brace is positioned in same way as opening brace
-    # new_line: closing brace is always on a new line
-    # same_line: closing brace is always on same line as last element
-    - symmetrical
-    - new_line
-    - same_line
 
 Style/MultilineMethodCallBraceLayout:
   Description: >-

--- a/config/enabled.yml
+++ b/config/enabled.yml
@@ -415,6 +415,13 @@ Style/ModuleFunction:
   StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#module-function'
   Enabled: true
 
+Style/MultilineArrayBraceLayout:
+  Description: >-
+                 Checks that the closing brace in an array literal is
+                 either on the same line as the last array element, or
+                 a new line.
+  Enabled: true
+
 Style/MultilineBlockChain:
   Description: 'Avoid multi-line chains of blocks.'
   StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#single-line-blocks'
@@ -422,6 +429,13 @@ Style/MultilineBlockChain:
 
 Style/MultilineBlockLayout:
   Description: 'Ensures newlines after multiline block do statements.'
+  Enabled: true
+
+Style/MultilineHashBraceLayout:
+  Description: >-
+                 Checks that the closing brace in a hash literal is
+                 either on the same line as the last hash element, or
+                 a new line.
   Enabled: true
 
 Style/MultilineIfThen:

--- a/lib/rubocop/cop/style/not.rb
+++ b/lib/rubocop/cop/style/not.rb
@@ -16,7 +16,8 @@ module RuboCop
           :<= => :>,
           :> => :<=,
           :< => :>=,
-          :>= => :< }.freeze
+          :>= => :<
+        }.freeze
 
         def on_send(node)
           return unless node.keyword_not?

--- a/spec/rubocop/cli/cli_autocorrect_spec.rb
+++ b/spec/rubocop/cli/cli_autocorrect_spec.rb
@@ -482,8 +482,7 @@ describe RuboCop::CLI, :isolated_environment do
                                '            },',
                                '          ]',
                                'end',
-                               'end'
-                              ])
+                               'end'])
     expect(cli.run(['--auto-correct'])).to eq(1)
     expect(IO.read('example.rb'))
       .to eq(['# encoding: utf-8',

--- a/spec/rubocop/cli/cli_options_spec.rb
+++ b/spec/rubocop/cli/cli_options_spec.rb
@@ -429,8 +429,7 @@ describe RuboCop::CLI, :isolated_environment do
         .to eq(["For #{abs('')}:" \
                 " configuration from #{home}/config/default.yml",
                 "Inheriting configuration from #{home}/config/enabled.yml",
-                "Inheriting configuration from #{home}/config/disabled.yml"
-               ])
+                "Inheriting configuration from #{home}/config/disabled.yml"])
     end
 
     it 'shows cop names' do
@@ -1052,7 +1051,8 @@ describe RuboCop::CLI, :isolated_environment do
           "stdlib 'English' module over $/.",
           '',
           '1 file inspected, 1 offense detected',
-          ''].join("\n"))
+          ''
+        ].join("\n"))
       ensure
         $stdin = STDIN
       end
@@ -1104,7 +1104,8 @@ describe RuboCop::CLI, :isolated_environment do
           '',
           '1 file inspected, 1 offense detected, 1 offense corrected',
           '====================',
-          'p $INPUT_RECORD_SEPARATOR'].join("\n"))
+          'p $INPUT_RECORD_SEPARATOR'
+        ].join("\n"))
       ensure
         $stdin = STDIN
       end

--- a/spec/rubocop/cli_spec.rb
+++ b/spec/rubocop/cli_spec.rb
@@ -302,8 +302,7 @@ describe RuboCop::CLI, :isolated_environment do
 
     it 'can disable all cops on a single line' do
       create_file('example.rb', ['# encoding: utf-8',
-                                 'y("123", 123456) # rubocop:disable all'
-                                ])
+                                 'y("123", 123456) # rubocop:disable all'])
       expect(cli.run(['--format', 'emacs', 'example.rb'])).to eq(0)
       expect($stdout.string).to be_empty
     end
@@ -314,8 +313,7 @@ describe RuboCop::CLI, :isolated_environment do
                    'a' * 90 + ' # rubocop:disable Metrics/LineLength',
                    '#' * 95,
                    'y("123", 123456) # rubocop:disable Style/StringLiterals,' \
-                   'Style/NumericLiterals'
-                  ])
+                   'Style/NumericLiterals'])
       expect(cli.run(['--format', 'emacs', 'example.rb'])).to eq(1)
       expect($stdout.string)
         .to eq(["#{abs('example.rb')}:3:81: C: Line is too long. [95/80]",
@@ -328,8 +326,7 @@ describe RuboCop::CLI, :isolated_environment do
                     ['# encoding: utf-8',
                      'a' * 90 + ' # rubocop:disable LineLength',
                      '#' * 95,
-                     'y("123") # rubocop:disable StringLiterals'
-                    ])
+                     'y("123") # rubocop:disable StringLiterals'])
         expect(cli.run(['--format', 'emacs', 'example.rb'])).to eq(1)
         expect($stdout.string)
           .to eq(["#{abs('example.rb')}:3:81: C: Line is too long. [95/80]",
@@ -403,8 +400,7 @@ describe RuboCop::CLI, :isolated_environment do
     create_file('example', ['#!/usr/bin/env ruby',
                             '# encoding: utf-8',
                             'x = 0',
-                            'puts x'
-                           ])
+                            'puts x'])
     expect(cli.run(%w(--format simple))).to eq(0)
     expect($stdout.string)
       .to eq(['', '1 file inspected, no offenses detected', ''].join("\n"))
@@ -794,8 +790,7 @@ describe RuboCop::CLI, :isolated_environment do
     it 'allows the default configuration file as the -c argument' do
       create_file('example.rb', ['# encoding: utf-8',
                                  'x = 0',
-                                 'puts x'
-                                ])
+                                 'puts x'])
       create_file('.rubocop.yml', [])
 
       expect(cli.run(%w(--format simple -c .rubocop.yml))).to eq(0)
@@ -883,8 +878,7 @@ describe RuboCop::CLI, :isolated_environment do
                                    '    - example',
                                    '    - "**/*.rake"',
                                    '    - !ruby/regexp /regexp$/',
-                                   '    - .dot1/**/*'
-                                  ])
+                                   '    - .dot1/**/*'])
       expect(cli.run(%w(--format files))).to eq(1)
       expect($stderr.string).to eq('')
       expect($stdout.string.split($RS).sort).to eq([abs('.dot1/file.rb'),
@@ -896,23 +890,19 @@ describe RuboCop::CLI, :isolated_environment do
     it 'ignores excluded files' do
       create_file('example.rb', ['# encoding: utf-8',
                                  'x = 0',
-                                 'puts x'
-                                ])
+                                 'puts x'])
       create_file('regexp.rb', ['# encoding: utf-8',
                                 'x = 0',
-                                'puts x'
-                               ])
+                                'puts x'])
       create_file('exclude_glob.rb', ['#!/usr/bin/env ruby',
                                       '# encoding: utf-8',
                                       'x = 0',
-                                      'puts x'
-                                     ])
+                                      'puts x'])
       create_file('.rubocop.yml', ['AllCops:',
                                    '  Exclude:',
                                    '    - example.rb',
                                    '    - !ruby/regexp /regexp.rb$/',
-                                   '    - "exclude_*"'
-                                  ])
+                                   '    - "exclude_*"'])
       expect(cli.run(%w(--format simple))).to eq(0)
       expect($stdout.string)
         .to eq(['', '0 files inspected, no offenses detected',
@@ -964,14 +954,12 @@ describe RuboCop::CLI, :isolated_environment do
     it 'matches included/excluded files correctly when . argument is given' do
       create_file('example.rb', 'x = 0')
       create_file('special.dsl', ['# encoding: utf-8',
-                                  'setup { "stuff" }'
-                                 ])
+                                  'setup { "stuff" }'])
       create_file('.rubocop.yml', ['AllCops:',
                                    '  Include:',
                                    '    - "*.dsl"',
                                    '  Exclude:',
-                                   '    - example.rb'
-                                  ])
+                                   '    - example.rb'])
       expect(cli.run(%w(--format simple .))).to eq(1)
       expect($stdout.string)
         .to eq(['== special.dsl ==',
@@ -987,8 +975,7 @@ describe RuboCop::CLI, :isolated_environment do
     it 'does not read files in excluded list', broken: :rbx do
       %w(rb.rb non-rb.ext without-ext).each do |filename|
         create_file("example/ignored/#{filename}", ['# encoding: utf-8',
-                                                    '#' * 90
-                                                   ])
+                                                    '#' * 90])
       end
 
       create_file('example/.rubocop.yml', ['AllCops:',
@@ -1045,8 +1032,7 @@ describe RuboCop::CLI, :isolated_environment do
                                    '  Enabled: false',
                                    '',
                                    'Lint/AmbiguousOperator:',
-                                   '  Enabled: false'
-                                  ])
+                                   '  Enabled: false'])
       expect(cli.run(['--format', 'emacs', 'example.rb'])).to eq(0)
     end
 
@@ -1056,8 +1042,7 @@ describe RuboCop::CLI, :isolated_environment do
                                    '  Enabled: false',
                                    '',
                                    'Syntax:',
-                                   '  Enabled: false'
-                                  ])
+                                   '  Enabled: false'])
       expect(cli.run(['--format', 'emacs', 'example.rb'])).to eq(2)
       expect($stderr.string).to include(
         'Error: configuration for Syntax cop found')
@@ -1125,8 +1110,7 @@ describe RuboCop::CLI, :isolated_environment do
                                   '  Enabled: false',
                                   '',
                                   'Metrics/LineLength:',
-                                  '  Enabled: false'
-                                 ])
+                                  '  Enabled: false'])
       result = cli.run(['--format', 'simple',
                         '-c', 'rubocop.yml', 'example1.rb'])
       expect($stdout.string)
@@ -1146,8 +1130,7 @@ describe RuboCop::CLI, :isolated_environment do
                                                '  Enabled: false',
                                                '',
                                                'Style/CaseIndentation:',
-                                               '  Enabled: false'
-                                              ])
+                                               '  Enabled: false'])
       expect(cli.run(['--format', 'simple',
                       'example_src/example1.rb'])).to eq(1)
       expect($stdout.string)
@@ -1160,12 +1143,10 @@ describe RuboCop::CLI, :isolated_environment do
 
     it 'can use an alternative max line length from a config file' do
       create_file('example_src/example1.rb', ['# encoding: utf-8',
-                                              '#' * 90
-                                             ])
+                                              '#' * 90])
       create_file('example_src/.rubocop.yml', ['Metrics/LineLength:',
                                                '  Enabled: true',
-                                               '  Max: 100'
-                                              ])
+                                               '  Max: 100'])
       expect(cli.run(['--format', 'simple',
                       'example_src/example1.rb'])).to eq(0)
       expect($stdout.string)
@@ -1175,13 +1156,11 @@ describe RuboCop::CLI, :isolated_environment do
     it 'can have different config files in different directories' do
       %w(src lib).each do |dir|
         create_file("example/#{dir}/example1.rb", ['# encoding: utf-8',
-                                                   '#' * 90
-                                                  ])
+                                                   '#' * 90])
       end
       create_file('example/src/.rubocop.yml', ['Metrics/LineLength:',
                                                '  Enabled: true',
-                                               '  Max: 100'
-                                              ])
+                                               '  Max: 100'])
       expect(cli.run(%w(--format simple example))).to eq(1)
       expect($stdout.string).to eq(['== example/lib/example1.rb ==',
                                     'C:  2: 81: Line is too long. [90/80]',
@@ -1192,16 +1171,13 @@ describe RuboCop::CLI, :isolated_environment do
 
     it 'prefers a config file in ancestor directory to another in home' do
       create_file('example_src/example1.rb', ['# encoding: utf-8',
-                                              '#' * 90
-                                             ])
+                                              '#' * 90])
       create_file('example_src/.rubocop.yml', ['Metrics/LineLength:',
                                                '  Enabled: true',
-                                               '  Max: 100'
-                                              ])
+                                               '  Max: 100'])
       create_file("#{Dir.home}/.rubocop.yml", ['Metrics/LineLength:',
                                                '  Enabled: true',
-                                               '  Max: 80'
-                                              ])
+                                               '  Max: 80'])
       expect(cli.run(['--format', 'simple',
                       'example_src/example1.rb'])).to eq(0)
       expect($stdout.string)

--- a/spec/rubocop/config_loader_spec.rb
+++ b/spec/rubocop/config_loader_spec.rb
@@ -95,13 +95,11 @@ describe RuboCop::ConfigLoader do
         create_file('.rubocop.yml',
                     ['AllCops:',
                      '  Exclude:',
-                     '    - vendor/**'
-                    ])
+                     '    - vendor/**'])
 
         create_file(file_path,
                     ['AllCops:',
-                     '  Exclude: []'
-                    ])
+                     '  Exclude: []'])
       end
 
       it 'gets AllCops/Exclude from the highest directory level' do
@@ -118,8 +116,7 @@ describe RuboCop::ConfigLoader do
                     ['AllCops:',
                      '  Exclude:',
                      '    - vendor/**',
-                     '    - !ruby/regexp /[A-Z]/'
-                    ])
+                     '    - !ruby/regexp /[A-Z]/'])
 
         create_file(file_path, ['inherit_from: ../.rubocop.yml'])
       end
@@ -151,8 +148,7 @@ describe RuboCop::ConfigLoader do
         create_file('src/.rubocop.yml',
                     ['AllCops:',
                      '  Exclude:',
-                     '    - vendor/**'
-                    ])
+                     '    - vendor/**'])
 
         create_file(file_path, ['inherit_from: ../src/.rubocop.yml'])
       end
@@ -180,8 +176,7 @@ describe RuboCop::ConfigLoader do
                      'Metrics/MethodLength:',
                      '  Enabled: true',
                      '  CountComments: false',
-                     '  Max: 10'
-                    ])
+                     '  Max: 10'])
 
         create_file(file_path,
                     ['inherit_from: ../.rubocop.yml',
@@ -190,8 +185,7 @@ describe RuboCop::ConfigLoader do
                      '  Enabled: true',
                      '',
                      'Metrics/MethodLength:',
-                     '  Max: 5'
-                    ])
+                     '  Max: 5'])
       end
 
       it 'returns the ancestor configuration plus local overrides' do
@@ -244,8 +238,7 @@ describe RuboCop::ConfigLoader do
                      '  - special.yml',
                      '',
                      'Metrics/MethodLength:',
-                     '  Enabled: true'
-                    ])
+                     '  Enabled: true'])
       end
 
       it 'returns values from the last one when possible' do
@@ -276,8 +269,7 @@ describe RuboCop::ConfigLoader do
       before do
         create_file(file_path,
                     ['inherit_gem:',
-                     '  not_a_real_gem: config/rubocop.yml'
-                    ])
+                     '  not_a_real_gem: config/rubocop.yml'])
       end
 
       it 'fails to load' do
@@ -291,8 +283,7 @@ describe RuboCop::ConfigLoader do
       before do
         create_file(file_path,
                     ['inherit_gem:',
-                     '  rubocop: config/default.yml'
-                    ])
+                     '  rubocop: config/default.yml'])
       end
 
       it 'fails to load' do
@@ -308,12 +299,10 @@ describe RuboCop::ConfigLoader do
                     ['Metrics/MethodLength:',
                      '  Enabled: false',
                      '  Max: 200',
-                     '  CountComments: false'
-                    ])
+                     '  CountComments: false'])
         create_file('local.yml',
                     ['Metrics/MethodLength:',
-                     '  CountComments: true'
-                    ])
+                     '  CountComments: true'])
         create_file(file_path,
                     ['inherit_gem:',
                      '  somegemname: config/rubocop.yml',
@@ -321,8 +310,7 @@ describe RuboCop::ConfigLoader do
                      'inherit_from: local.yml',
                      '',
                      'Metrics/MethodLength:',
-                     '  Enabled: true'
-                    ])
+                     '  Enabled: true'])
       end
 
       it 'returns values from the gem config with local overrides' do

--- a/spec/rubocop/cop/lint/assignment_in_condition_spec.rb
+++ b/spec/rubocop/cop/lint/assignment_in_condition_spec.rb
@@ -10,80 +10,70 @@ describe RuboCop::Cop::Lint::AssignmentInCondition, :config do
   it 'registers an offense for lvar assignment in condition' do
     inspect_source(cop,
                    ['if test = 10',
-                    'end'
-                   ])
+                    'end'])
     expect(cop.offenses.size).to eq(1)
   end
 
   it 'registers an offense for lvar assignment in while condition' do
     inspect_source(cop,
                    ['while test = 10',
-                    'end'
-                   ])
+                    'end'])
     expect(cop.offenses.size).to eq(1)
   end
 
   it 'registers an offense for lvar assignment in until condition' do
     inspect_source(cop,
                    ['until test = 10',
-                    'end'
-                   ])
+                    'end'])
     expect(cop.offenses.size).to eq(1)
   end
 
   it 'registers an offense for ivar assignment in condition' do
     inspect_source(cop,
                    ['if @test = 10',
-                    'end'
-                   ])
+                    'end'])
     expect(cop.offenses.size).to eq(1)
   end
 
   it 'registers an offense for clvar assignment in condition' do
     inspect_source(cop,
                    ['if @@test = 10',
-                    'end'
-                   ])
+                    'end'])
     expect(cop.offenses.size).to eq(1)
   end
 
   it 'registers an offense for gvar assignment in condition' do
     inspect_source(cop,
                    ['if $test = 10',
-                    'end'
-                   ])
+                    'end'])
     expect(cop.offenses.size).to eq(1)
   end
 
   it 'registers an offense for constant assignment in condition' do
     inspect_source(cop,
                    ['if TEST = 10',
-                    'end'
-                   ])
+                    'end'])
     expect(cop.offenses.size).to eq(1)
   end
 
   it 'registers an offense for collection element assignment in condition' do
     inspect_source(cop,
                    ['if a[3] = 10',
-                    'end'
-                   ])
+                    'end'])
     expect(cop.offenses.size).to eq(1)
   end
 
   it 'accepts == in condition' do
     inspect_source(cop,
                    ['if test == 10',
-                    'end'
-                   ])
+                    'end'])
     expect(cop.offenses).to be_empty
   end
 
   it 'registers an offense for assignment after == in condition' do
     inspect_source(cop,
                    ['if test == 10 || foobar = 1',
-                    'end'
-                   ])
+                    'end'])
     expect(cop.offenses.size).to eq(1)
   end
 
@@ -108,8 +98,7 @@ describe RuboCop::Cop::Lint::AssignmentInCondition, :config do
   it 'registers an offense for assignment methods' do
     inspect_source(cop,
                    ['if test.method = 10',
-                    'end'
-                   ])
+                    'end'])
     expect(cop.offenses.size).to eq(1)
   end
 
@@ -117,16 +106,14 @@ describe RuboCop::Cop::Lint::AssignmentInCondition, :config do
     it 'accepts = in condition surrounded with braces' do
       inspect_source(cop,
                      ['if (test = 10)',
-                      'end'
-                     ])
+                      'end'])
       expect(cop.offenses).to be_empty
     end
 
     it 'accepts []= in condition surrounded with braces' do
       inspect_source(cop,
                      ['if (test[0] = 10)',
-                      'end'
-                     ])
+                      'end'])
       expect(cop.offenses).to be_empty
     end
   end
@@ -137,16 +124,14 @@ describe RuboCop::Cop::Lint::AssignmentInCondition, :config do
     it 'does not accept = in condition surrounded with braces' do
       inspect_source(cop,
                      ['if (test = 10)',
-                      'end'
-                     ])
+                      'end'])
       expect(cop.offenses.size).to eq(1)
     end
 
     it 'does not accept []= in condition surrounded with braces' do
       inspect_source(cop,
                      ['if (test[0] = 10)',
-                      'end'
-                     ])
+                      'end'])
       expect(cop.offenses.size).to eq(1)
     end
   end

--- a/spec/rubocop/cop/lint/block_alignment_spec.rb
+++ b/spec/rubocop/cop/lint/block_alignment_spec.rb
@@ -13,16 +13,14 @@ describe RuboCop::Cop::Lint::BlockAlignment, :config do
     it 'registers an offense for mismatched block end' do
       inspect_source(cop,
                      ['test do',
-                      '  end'
-                     ])
+                      '  end'])
       expect(cop.messages)
         .to eq(['`end` at 2, 2 is not aligned with `test do` at 1, 0.'])
     end
 
     it 'auto-corrects alignment' do
       new_source = autocorrect_source(cop, ['test do',
-                                            '  end'
-                                           ])
+                                            '  end'])
 
       expect(new_source).to eq(['test do',
                                 'end'].join("\n"))
@@ -33,16 +31,14 @@ describe RuboCop::Cop::Lint::BlockAlignment, :config do
     it 'registers an offense for mismatched block end' do
       inspect_source(cop,
                      ['test do |ala|',
-                      '  end'
-                     ])
+                      '  end'])
       expect(cop.messages)
         .to eq(['`end` at 2, 2 is not aligned with `test do |ala|` at 1, 0.'])
     end
 
     it 'auto-corrects alignment' do
       new_source = autocorrect_source(cop, ['test do |ala|',
-                                            '  end'
-                                           ])
+                                            '  end'])
 
       expect(new_source).to eq(['test do |ala|',
                                 'end'].join("\n"))
@@ -52,8 +48,7 @@ describe RuboCop::Cop::Lint::BlockAlignment, :config do
   it 'accepts a block end that does not begin its line' do
     inspect_source(cop,
                    ['  scope :bar, lambda { joins(:baz)',
-                    '                       .distinct }'
-                   ])
+                    '                       .distinct }'])
     expect(cop.offenses).to be_empty
   end
 
@@ -64,8 +59,7 @@ describe RuboCop::Cop::Lint::BlockAlignment, :config do
                       '  type_check_value(subvalue, array_type)',
                       'end',
                       'a || b do',
-                      'end'
-                     ])
+                      'end'])
       expect(cop.offenses).to be_empty
     end
   end
@@ -73,8 +67,7 @@ describe RuboCop::Cop::Lint::BlockAlignment, :config do
   it 'accepts end aligned with a variable' do
     inspect_source(cop,
                    ['variable = test do |ala|',
-                    'end'
-                   ])
+                    'end'])
     expect(cop.offenses).to be_empty
   end
 
@@ -82,8 +75,7 @@ describe RuboCop::Cop::Lint::BlockAlignment, :config do
     it 'registers an offense for an end aligned with the 2nd variable' do
       inspect_source(cop,
                      ['a = b = c = test do |ala|',
-                      '    end'
-                     ])
+                      '    end'])
       expect(cop.messages)
         .to eq(['`end` at 2, 4 is not aligned with' \
                 ' `a = b = c = test do |ala|` at 1, 0.'])
@@ -92,20 +84,17 @@ describe RuboCop::Cop::Lint::BlockAlignment, :config do
     it 'accepts end aligned with the first variable' do
       inspect_source(cop,
                      ['a = b = c = test do |ala|',
-                      'end'
-                     ])
+                      'end'])
       expect(cop.offenses).to be_empty
     end
 
     it 'auto-corrects alignment to the first variable' do
       new_source = autocorrect_source(cop,
                                       ['a = b = c = test do |ala|',
-                                       '    end'
-                                      ])
+                                       '    end'])
 
       expect(new_source).to eq(['a = b = c = test do |ala|',
-                                'end'
-                               ].join("\n"))
+                                'end'].join("\n"))
     end
   end
 
@@ -114,8 +103,7 @@ describe RuboCop::Cop::Lint::BlockAlignment, :config do
       inspect_source(cop,
                      ['b = 1 + preceding_line.reduce(0) do |a, e|',
                       '  a + e.length + newline_length',
-                      'end + 1'
-                     ])
+                      'end + 1'])
       expect(cop.offenses).to be_empty
     end
   end
@@ -123,8 +111,7 @@ describe RuboCop::Cop::Lint::BlockAlignment, :config do
   it 'registers an offense for mismatched block end with a variable' do
     inspect_source(cop,
                    ['variable = test do |ala|',
-                    '  end'
-                   ])
+                    '  end'])
     expect(cop.messages)
       .to eq(['`end` at 2, 2 is not aligned with `variable = test do |ala|`' \
               ' at 1, 0.'])
@@ -136,8 +123,7 @@ describe RuboCop::Cop::Lint::BlockAlignment, :config do
                      ['variable =',
                       '  a_long_method_that_dont_fit_on_the_line do |v|',
                       '    v.foo',
-                      '  end'
-                     ])
+                      '  end'])
       expect(cop.offenses).to be_empty
     end
 
@@ -146,8 +132,7 @@ describe RuboCop::Cop::Lint::BlockAlignment, :config do
                      ['variable =',
                       '  a_long_method_that_dont_fit_on_the_line do |v|',
                       '    v.foo',
-                      'end'
-                     ])
+                      'end'])
       expect(cop.messages)
         .to eq(['`end` at 4, 0 is not aligned with' \
                 ' `a_long_method_that_dont_fit_on_the_line do |v|` at 2, 2.'])
@@ -159,15 +144,13 @@ describe RuboCop::Cop::Lint::BlockAlignment, :config do
         ['variable =',
          '  a_long_method_that_dont_fit_on_the_line do |v|',
          '    v.foo',
-         'end'
-        ])
+         'end'])
 
       expect(new_source)
         .to eq(['variable =',
                 '  a_long_method_that_dont_fit_on_the_line do |v|',
                 '    v.foo',
-                '  end'
-               ].join("\n"))
+                '  end'].join("\n"))
     end
   end
 
@@ -185,7 +168,8 @@ describe RuboCop::Cop::Lint::BlockAlignment, :config do
         '      .select do |stuff|',
         '        stuff.another_very_long_expression_that_doesnt_fit_the_line',
         '      end',
-        'end']
+        'end'
+      ]
       inspect_source(cop, src)
       expect(cop.offenses).to be_empty
     end
@@ -202,7 +186,8 @@ describe RuboCop::Cop::Lint::BlockAlignment, :config do
         '      .select do |stuff|',
         '        stuff.another_very_long_expression_that_doesnt_fit_the_line',
         '        end',
-        'end']
+        'end'
+      ]
       inspect_source(cop, src)
       expect(cop.messages)
         .to eq(['`end` at 5, 8 is not aligned with `bar.get_stuffs` at 2, 2' \
@@ -260,7 +245,8 @@ describe RuboCop::Cop::Lint::BlockAlignment, :config do
         '      .select do |stuff|',
         '        stuff.another_very_long_expression_that_doesnt_fit_the_line',
         '        end',
-        'end']
+        'end'
+      ]
 
       aligned_src = [
         'def foo(bar)',
@@ -273,7 +259,8 @@ describe RuboCop::Cop::Lint::BlockAlignment, :config do
         '      .select do |stuff|',
         '        stuff.another_very_long_expression_that_doesnt_fit_the_line',
         '  end',
-        'end'].join("\n")
+        'end'
+      ].join("\n")
 
       new_source = autocorrect_source(cop, src)
       expect(new_source).to eq(aligned_src)
@@ -318,8 +305,7 @@ describe RuboCop::Cop::Lint::BlockAlignment, :config do
   it 'accepts end aligned with an instance variable' do
     inspect_source(cop,
                    ['@variable = test do |ala|',
-                    'end'
-                   ])
+                    'end'])
     expect(cop.offenses).to be_empty
   end
 
@@ -327,8 +313,7 @@ describe RuboCop::Cop::Lint::BlockAlignment, :config do
      ' an instance variable' do
     inspect_source(cop,
                    ['@variable = test do |ala|',
-                    '  end'
-                   ])
+                    '  end'])
     expect(cop.messages)
       .to eq(['`end` at 2, 2 is not aligned with `@variable = test do |ala|`' \
               ' at 1, 0.'])
@@ -337,16 +322,14 @@ describe RuboCop::Cop::Lint::BlockAlignment, :config do
   it 'accepts end aligned with a class variable' do
     inspect_source(cop,
                    ['@@variable = test do |ala|',
-                    'end'
-                   ])
+                    'end'])
     expect(cop.offenses).to be_empty
   end
 
   it 'registers an offense for mismatched block end with a class variable' do
     inspect_source(cop,
                    ['@@variable = test do |ala|',
-                    '  end'
-                   ])
+                    '  end'])
     expect(cop.messages)
       .to eq(['`end` at 2, 2 is not aligned with `@@variable = test do |ala|`' \
               ' at 1, 0.'])
@@ -355,16 +338,14 @@ describe RuboCop::Cop::Lint::BlockAlignment, :config do
   it 'accepts end aligned with a global variable' do
     inspect_source(cop,
                    ['$variable = test do |ala|',
-                    'end'
-                   ])
+                    'end'])
     expect(cop.offenses).to be_empty
   end
 
   it 'registers an offense for mismatched block end with a global variable' do
     inspect_source(cop,
                    ['$variable = test do |ala|',
-                    '  end'
-                   ])
+                    '  end'])
     expect(cop.messages)
       .to eq(['`end` at 2, 2 is not aligned with `$variable = test do |ala|`' \
               ' at 1, 0.'])
@@ -373,16 +354,14 @@ describe RuboCop::Cop::Lint::BlockAlignment, :config do
   it 'accepts end aligned with a constant' do
     inspect_source(cop,
                    ['CONSTANT = test do |ala|',
-                    'end'
-                   ])
+                    'end'])
     expect(cop.offenses).to be_empty
   end
 
   it 'registers an offense for mismatched block end with a constant' do
     inspect_source(cop,
                    ['Module::CONSTANT = test do |ala|',
-                    '  end'
-                   ])
+                    '  end'])
     expect(cop.messages)
       .to eq(['`end` at 2, 2 is not aligned with' \
               ' `Module::CONSTANT = test do |ala|` at 1, 0.'])
@@ -392,8 +371,7 @@ describe RuboCop::Cop::Lint::BlockAlignment, :config do
     inspect_source(cop,
                    ['parser.children << lambda do |token|',
                     '  token << 1',
-                    'end'
-                   ])
+                    'end'])
     expect(cop.offenses).to be_empty
   end
 
@@ -401,8 +379,7 @@ describe RuboCop::Cop::Lint::BlockAlignment, :config do
     inspect_source(cop,
                    ['parser.children << lambda do |token|',
                     '  token << 1',
-                    '  end'
-                   ])
+                    '  end'])
     expect(cop.messages)
       .to eq(['`end` at 3, 2 is not aligned with' \
               ' `parser.children << lambda do |token|` at 1, 0.'])
@@ -412,8 +389,7 @@ describe RuboCop::Cop::Lint::BlockAlignment, :config do
     inspect_source(cop,
                    ['@h[:f] = f.each_pair.map do |f, v|',
                     '  v = 1',
-                    'end'
-                   ])
+                    'end'])
     expect(cop.offenses).to be_empty
   end
 
@@ -422,8 +398,7 @@ describe RuboCop::Cop::Lint::BlockAlignment, :config do
     inspect_source(cop,
                    ['@h[:f] = f.each_pair.map do |f, v|',
                     '  v = 1',
-                    '  end'
-                   ])
+                    '  end'])
     expect(cop.messages)
       .to eq(['`end` at 3, 2 is not aligned with' \
               ' `@h[:f] = f.each_pair.map do |f, v|` at 1, 0.'])
@@ -439,8 +414,7 @@ describe RuboCop::Cop::Lint::BlockAlignment, :config do
     inspect_source(cop,
                    ['expect(arr.all? do |o|',
                     '         o.valid?',
-                    '       end)'
-                   ])
+                    '       end)'])
     expect(cop.offenses).to be_empty
   end
 
@@ -449,8 +423,7 @@ describe RuboCop::Cop::Lint::BlockAlignment, :config do
     inspect_source(cop,
                    ['expect(arr.all? do |o|',
                     '  o.valid?',
-                    '  end)'
-                   ])
+                    '  end)'])
     expect(cop.messages)
       .to eq(['`end` at 3, 2 is not aligned with `arr.all? do |o|` at 1, 7 or' \
               ' `expect(arr.all? do |o|` at 1, 0.'])
@@ -460,8 +433,7 @@ describe RuboCop::Cop::Lint::BlockAlignment, :config do
     inspect_source(cop,
                    ['rb += files.select do |file|',
                     '  file << something',
-                    'end'
-                   ])
+                    'end'])
     expect(cop.offenses).to be_empty
   end
 
@@ -469,8 +441,7 @@ describe RuboCop::Cop::Lint::BlockAlignment, :config do
     inspect_source(cop,
                    ['rb += files.select do |file|',
                     '  file << something',
-                    '  end'
-                   ])
+                    '  end'])
     expect(cop.messages)
       .to eq(['`end` at 3, 2 is not aligned with `rb` at 1, 0.'])
   end
@@ -478,16 +449,14 @@ describe RuboCop::Cop::Lint::BlockAlignment, :config do
   it 'accepts end aligned with an and-asgn (&&=)' do
     inspect_source(cop,
                    ['variable &&= test do |ala|',
-                    'end'
-                   ])
+                    'end'])
     expect(cop.offenses).to be_empty
   end
 
   it 'registers an offense for mismatched block end with an and-asgn (&&=)' do
     inspect_source(cop,
                    ['variable &&= test do |ala|',
-                    '  end'
-                   ])
+                    '  end'])
     expect(cop.messages)
       .to eq(['`end` at 2, 2 is not aligned with `variable &&= test do |ala|`' \
               ' at 1, 0.'])
@@ -496,16 +465,14 @@ describe RuboCop::Cop::Lint::BlockAlignment, :config do
   it 'accepts end aligned with an or-asgn (||=)' do
     inspect_source(cop,
                    ['variable ||= test do |ala|',
-                    'end'
-                   ])
+                    'end'])
     expect(cop.offenses).to be_empty
   end
 
   it 'registers an offense for mismatched block end with an or-asgn (||=)' do
     inspect_source(cop,
                    ['variable ||= test do |ala|',
-                    '  end'
-                   ])
+                    '  end'])
     expect(cop.messages)
       .to eq(['`end` at 2, 2 is not aligned with `variable ||= test do |ala|`' \
               ' at 1, 0.'])
@@ -515,8 +482,7 @@ describe RuboCop::Cop::Lint::BlockAlignment, :config do
     inspect_source(cop,
                    ['var1, var2 = lambda do |test|',
                     '  [1, 2]',
-                    'end'
-                   ])
+                    'end'])
     expect(cop.offenses).to be_empty
   end
 
@@ -532,8 +498,7 @@ describe RuboCop::Cop::Lint::BlockAlignment, :config do
     inspect_source(cop,
                    ['var1, var2 = lambda do |test|',
                     '  [1, 2]',
-                    '  end'
-                   ])
+                    '  end'])
     expect(cop.messages)
       .to eq(['`end` at 3, 2 is not aligned with `var1, var2` at 1, 0.'])
   end
@@ -544,8 +509,7 @@ describe RuboCop::Cop::Lint::BlockAlignment, :config do
                      ['a = test do',
                       ' end',
                       'b = test do',
-                      ' end'
-                     ])
+                      ' end'])
       expect(cop.offenses.size).to eq 2
     end
   end
@@ -666,8 +630,7 @@ describe RuboCop::Cop::Lint::BlockAlignment, :config do
     it 'mentions } (not end) in the message' do
       inspect_source(cop,
                      ['test {',
-                      '  }'
-                     ])
+                      '  }'])
       expect(cop.messages)
         .to eq(['`}` at 2, 2 is not aligned with `test {` at 1, 0.'])
     end

--- a/spec/rubocop/cop/lint/condition_position_spec.rb
+++ b/spec/rubocop/cop/lint/condition_position_spec.rb
@@ -11,8 +11,7 @@ describe RuboCop::Cop::Lint::ConditionPosition do
       inspect_source(cop,
                      [keyword,
                       'x == 10',
-                      'end'
-                     ])
+                      'end'])
       expect(cop.offenses.size).to eq(1)
     end
 
@@ -20,8 +19,7 @@ describe RuboCop::Cop::Lint::ConditionPosition do
       inspect_source(cop,
                      ["#{keyword} x == 10",
                       ' bala',
-                      'end'
-                     ])
+                      'end'])
       expect(cop.offenses).to be_empty
     end
 
@@ -40,8 +38,7 @@ describe RuboCop::Cop::Lint::ConditionPosition do
                     'elsif',
                     '  something',
                     '  test',
-                    'end'
-                   ])
+                    'end'])
     expect(cop.offenses.size).to eq(1)
   end
 

--- a/spec/rubocop/cop/lint/else_layout_spec.rb
+++ b/spec/rubocop/cop/lint/else_layout_spec.rb
@@ -13,8 +13,7 @@ describe RuboCop::Cop::Lint::ElseLayout do
                     'else ala',
                     '  something',
                     '  test',
-                    'end'
-                   ])
+                    'end'])
     expect(cop.offenses.size).to eq(1)
   end
 
@@ -25,8 +24,7 @@ describe RuboCop::Cop::Lint::ElseLayout do
                     'else',
                     '  something',
                     '  test',
-                    'end'
-                   ])
+                    'end'])
     expect(cop.offenses).to be_empty
   end
 
@@ -35,8 +33,7 @@ describe RuboCop::Cop::Lint::ElseLayout do
                    ['if something',
                     '  test',
                     'else bala',
-                    'end'
-                   ])
+                    'end'])
     expect(cop.offenses).to be_empty
   end
 
@@ -49,8 +46,7 @@ describe RuboCop::Cop::Lint::ElseLayout do
                     'else ala',
                     '  something',
                     '  test',
-                    'end'
-                   ])
+                    'end'])
     expect(cop.offenses.size).to eq(1)
   end
 

--- a/spec/rubocop/cop/lint/literal_in_condition_spec.rb
+++ b/spec/rubocop/cop/lint/literal_in_condition_spec.rb
@@ -11,8 +11,7 @@ describe RuboCop::Cop::Lint::LiteralInCondition do
       inspect_source(cop,
                      ["if #{lit}",
                       '  top',
-                      'end'
-                     ])
+                      'end'])
       expect(cop.offenses.size).to eq(1)
     end
 
@@ -20,8 +19,7 @@ describe RuboCop::Cop::Lint::LiteralInCondition do
       inspect_source(cop,
                      ["while #{lit}",
                       '  top',
-                      'end'
-                     ])
+                      'end'])
       expect(cop.offenses.size).to eq(1)
     end
 
@@ -29,8 +27,7 @@ describe RuboCop::Cop::Lint::LiteralInCondition do
       inspect_source(cop,
                      ['begin',
                       '  top',
-                      "end while(#{lit})"
-                     ])
+                      "end while(#{lit})"])
       expect(cop.offenses.size).to eq(1)
     end
 
@@ -38,8 +35,7 @@ describe RuboCop::Cop::Lint::LiteralInCondition do
       inspect_source(cop,
                      ["until #{lit}",
                       '  top',
-                      'end'
-                     ])
+                      'end'])
       expect(cop.offenses.size).to eq(1)
     end
 
@@ -47,8 +43,7 @@ describe RuboCop::Cop::Lint::LiteralInCondition do
       inspect_source(cop,
                      ['begin',
                       '  top',
-                      "end until #{lit}"
-                     ])
+                      "end until #{lit}"])
       expect(cop.offenses.size).to eq(1)
     end
 
@@ -56,8 +51,7 @@ describe RuboCop::Cop::Lint::LiteralInCondition do
       inspect_source(cop,
                      ["case #{lit}",
                       'when x then top',
-                      'end'
-                     ])
+                      'end'])
       expect(cop.offenses.size).to eq(1)
     end
 
@@ -75,8 +69,7 @@ describe RuboCop::Cop::Lint::LiteralInCondition do
       inspect_source(cop,
                      ['case x',
                       "when #{lit} then top",
-                      'end'
-                     ])
+                      'end'])
       expect(cop.offenses).to be_empty
     end
 
@@ -84,8 +77,7 @@ describe RuboCop::Cop::Lint::LiteralInCondition do
       inspect_source(cop,
                      ["if x && #{lit}",
                       '  top',
-                      'end'
-                     ])
+                      'end'])
       expect(cop.offenses.size).to eq(1)
     end
 
@@ -93,8 +85,7 @@ describe RuboCop::Cop::Lint::LiteralInCondition do
       inspect_source(cop,
                      ["if x && !(a && #{lit}) && y && z",
                       '  top',
-                      'end'
-                     ])
+                      'end'])
       expect(cop.offenses.size).to eq(1)
     end
 
@@ -102,8 +93,7 @@ describe RuboCop::Cop::Lint::LiteralInCondition do
       inspect_source(cop,
                      ["if !#{lit}",
                       '  top',
-                      'end'
-                     ])
+                      'end'])
       expect(cop.offenses.size).to eq(1)
     end
 
@@ -111,8 +101,7 @@ describe RuboCop::Cop::Lint::LiteralInCondition do
       inspect_source(cop,
                      ["if !(x && (y && #{lit}))",
                       '  top',
-                      'end'
-                     ])
+                      'end'])
       expect(cop.offenses.size).to eq(1)
     end
 
@@ -120,8 +109,7 @@ describe RuboCop::Cop::Lint::LiteralInCondition do
       inspect_source(cop,
                      ["if test(#{lit})",
                       '  top',
-                      'end'
-                     ])
+                      'end'])
       expect(cop.offenses).to be_empty
     end
 
@@ -129,8 +117,7 @@ describe RuboCop::Cop::Lint::LiteralInCondition do
       inspect_source(cop,
                      ["if (a || #{lit}).something",
                       '  top',
-                      'end'
-                     ])
+                      'end'])
       expect(cop.offenses).to be_empty
     end
   end
@@ -139,8 +126,7 @@ describe RuboCop::Cop::Lint::LiteralInCondition do
     inspect_source(cop,
                    ['case [1, 2, x]',
                     'when [1, 2, 5] then top',
-                    'end'
-                   ])
+                    'end'])
     expect(cop.offenses).to be_empty
   end
 
@@ -148,8 +134,7 @@ describe RuboCop::Cop::Lint::LiteralInCondition do
     inspect_source(cop,
                    ['case [1, 2, [x, 1]]',
                     'when [1, 2, 5] then top',
-                    'end'
-                   ])
+                    'end'])
     expect(cop.offenses).to be_empty
   end
 
@@ -157,8 +142,7 @@ describe RuboCop::Cop::Lint::LiteralInCondition do
     inspect_source(cop,
                    ['case [1, 2, [3, 4]]',
                     'when [1, 2, 5] then top',
-                    'end'
-                   ])
+                    'end'])
     expect(cop.offenses.size).to eq(1)
   end
 
@@ -166,8 +150,7 @@ describe RuboCop::Cop::Lint::LiteralInCondition do
     inspect_source(cop,
                    ['case "#{x}"',
                     'when [1, 2, 5] then top',
-                    'end'
-                   ])
+                    'end'])
     expect(cop.offenses).to be_empty
   end
 end

--- a/spec/rubocop/cop/lint/unreachable_code_spec.rb
+++ b/spec/rubocop/cop/lint/unreachable_code_spec.rb
@@ -11,8 +11,7 @@ describe RuboCop::Cop::Lint::UnreachableCode do
       inspect_source(cop,
                      ['foo = 5',
                       t.to_s,
-                      'bar'
-                     ])
+                      'bar'])
       expect(cop.offenses.size).to eq(1)
     end
 
@@ -20,16 +19,14 @@ describe RuboCop::Cop::Lint::UnreachableCode do
       inspect_source(cop,
                      ['foo = 5',
                       "#{t} if test",
-                      'bar'
-                     ])
+                      'bar'])
       expect(cop.offenses).to be_empty
     end
 
     it "accepts #{t} as the final expression" do
       inspect_source(cop,
                      ['foo = 5',
-                      "#{t} if test"
-                     ])
+                      "#{t} if test"])
       expect(cop.offenses).to be_empty
     end
   end
@@ -39,8 +36,7 @@ describe RuboCop::Cop::Lint::UnreachableCode do
       inspect_source(cop,
                      ['foo = 5',
                       "#{t} something",
-                      'bar'
-                     ])
+                      'bar'])
       expect(cop.offenses.size).to eq(1)
     end
 
@@ -48,16 +44,14 @@ describe RuboCop::Cop::Lint::UnreachableCode do
       inspect_source(cop,
                      ['foo = 5',
                       "#{t} something if test",
-                      'bar'
-                     ])
+                      'bar'])
       expect(cop.offenses).to be_empty
     end
 
     it "accepts #{t} as the final expression" do
       inspect_source(cop,
                      ['foo = 5',
-                      "#{t} something if test"
-                     ])
+                      "#{t} something if test"])
       expect(cop.offenses).to be_empty
     end
   end

--- a/spec/rubocop/cop/lint/useless_comparison_spec.rb
+++ b/spec/rubocop/cop/lint/useless_comparison_spec.rb
@@ -10,16 +10,14 @@ describe RuboCop::Cop::Lint::UselessComparison do
     it "registers an offense for a simple comparison with #{op}" do
       inspect_source(cop,
                      ["5 #{op} 5",
-                      "a #{op} a"
-                     ])
+                      "a #{op} a"])
       expect(cop.offenses.size).to eq(2)
     end
 
     it "registers an offense for a complex comparison with #{op}" do
       inspect_source(cop,
                      ["5 + 10 * 30 #{op} 5 + 10 * 30",
-                      "a.top(x) #{op} a.top(x)"
-                     ])
+                      "a.top(x) #{op} a.top(x)"])
       expect(cop.offenses.size).to eq(2)
     end
   end

--- a/spec/rubocop/cop/lint/useless_setter_call_spec.rb
+++ b/spec/rubocop/cop/lint/useless_setter_call_spec.rb
@@ -12,8 +12,7 @@ describe RuboCop::Cop::Lint::UselessSetterCall do
                      ['def test',
                       '  top = Top.new',
                       '  top.attr = 5',
-                      'end'
-                     ])
+                      'end'])
       expect(cop.offenses.size).to eq(1)
       expect(cop.messages)
         .to eq(['Useless setter call to local variable `top`.'])
@@ -26,8 +25,7 @@ describe RuboCop::Cop::Lint::UselessSetterCall do
                      ['def Top.test',
                       '  top = Top.new',
                       '  top.attr = 5',
-                      'end'
-                     ])
+                      'end'])
       expect(cop.offenses.size).to eq(1)
     end
   end
@@ -38,8 +36,7 @@ describe RuboCop::Cop::Lint::UselessSetterCall do
                      ['def test',
                       '  top = Top.new',
                       '  top[:attr] = 5',
-                      'end'
-                     ])
+                      'end'])
       expect(cop.offenses.size).to eq(1)
       expect(cop.messages)
         .to eq(['Useless setter call to local variable `top`.'])
@@ -52,8 +49,7 @@ describe RuboCop::Cop::Lint::UselessSetterCall do
                      ['def test',
                       '  something',
                       '  @top = 5',
-                      'end'
-                     ])
+                      'end'])
       expect(cop.offenses).to be_empty
     end
   end
@@ -64,8 +60,7 @@ describe RuboCop::Cop::Lint::UselessSetterCall do
                      ['def test',
                       '  something',
                       '  @top.attr = 5',
-                      'end'
-                     ])
+                      'end'])
       expect(cop.offenses).to be_empty
     end
   end
@@ -76,8 +71,7 @@ describe RuboCop::Cop::Lint::UselessSetterCall do
                      ['def test(some_arg)',
                       '  unrelated_local_variable = Top.new',
                       '  some_arg.attr = 5',
-                      'end'
-                     ])
+                      'end'])
       expect(cop.offenses).to be_empty
     end
   end
@@ -92,8 +86,7 @@ describe RuboCop::Cop::Lint::UselessSetterCall do
                       '  some_lvar = @some_ivar',
                       '  some_lvar.do_something',
                       '  some_lvar.attr = 5',
-                      'end'
-                     ])
+                      'end'])
       expect(cop.offenses).to be_empty
     end
   end
@@ -105,8 +98,7 @@ describe RuboCop::Cop::Lint::UselessSetterCall do
                      ['def test(some_arg)',
                       '  _first, some_lvar, _third  = 1, some_arg, 3',
                       '  some_lvar.attr = 5',
-                      'end'
-                     ])
+                      'end'])
       expect(cop.offenses).to be_empty
     end
   end
@@ -118,8 +110,7 @@ describe RuboCop::Cop::Lint::UselessSetterCall do
                      ['def test(some_arg)',
                       '  _first, some_lvar, _third  = do_something',
                       '  some_lvar.attr = 5',
-                      'end'
-                     ])
+                      'end'])
       expect(cop.offenses.size).to eq(1)
     end
   end
@@ -132,8 +123,7 @@ describe RuboCop::Cop::Lint::UselessSetterCall do
                       '  some_lvar = nil',
                       '  some_lvar ||= some_arg',
                       '  some_lvar.attr = 5',
-                      'end'
-                     ])
+                      'end'])
       expect(cop.offenses).to be_empty
     end
   end
@@ -146,8 +136,7 @@ describe RuboCop::Cop::Lint::UselessSetterCall do
                       '  some_lvar = some_arg',
                       '  some_lvar += some_arg',
                       '  some_lvar.attr = 5',
-                      'end'
-                     ])
+                      'end'])
       expect(cop.offenses.size).to eq(1)
     end
   end
@@ -159,8 +148,7 @@ describe RuboCop::Cop::Lint::UselessSetterCall do
                      ['def test(some_arg)',
                       '  some_arg = Top.new',
                       '  some_arg.attr = 5',
-                      'end'
-                     ])
+                      'end'])
       expect(cop.offenses.size).to eq(1)
     end
   end
@@ -171,8 +159,7 @@ describe RuboCop::Cop::Lint::UselessSetterCall do
                      ['def test',
                       '  some_arg = {}',
                       '  some_arg[:attr] = 1',
-                      'end'
-                     ])
+                      'end'])
       expect(cop.offenses.size).to eq(1)
     end
   end
@@ -183,8 +170,7 @@ describe RuboCop::Cop::Lint::UselessSetterCall do
                      ['def test',
                       '  some_lvar = Foo.shared_object',
                       '  some_lvar[:attr] = 1',
-                      'end'
-                     ])
+                      'end'])
       expect(cop.offenses).to be_empty
     end
   end
@@ -193,8 +179,7 @@ describe RuboCop::Cop::Lint::UselessSetterCall do
     inspect_source(cop,
                    ['def test',
                     '  top.attr == 5',
-                    'end'
-                   ])
+                    'end'])
     expect(cop.offenses).to be_empty
   end
 
@@ -205,8 +190,7 @@ describe RuboCop::Cop::Lint::UselessSetterCall do
                     '  rescue StandardError => _',
                     '  end',
                     '  bar[:baz] = true',
-                    'end'
-                   ])
+                    'end'])
     expect(cop.offenses).to be_empty
   end
 end

--- a/spec/rubocop/cop/lint/void_spec.rb
+++ b/spec/rubocop/cop/lint/void_spec.rb
@@ -11,8 +11,7 @@ describe RuboCop::Cop::Lint::Void do
       inspect_source(cop,
                      ["a #{op} b",
                       "a #{op} b",
-                      "a #{op} b"
-                     ])
+                      "a #{op} b"])
       expect(cop.offenses.size).to eq(2)
     end
   end
@@ -21,8 +20,7 @@ describe RuboCop::Cop::Lint::Void do
     it "accepts void op #{op} if on last line" do
       inspect_source(cop,
                      ['something',
-                      "a #{op} b"
-                     ])
+                      "a #{op} b"])
       expect(cop.offenses).to be_empty
     end
   end
@@ -39,8 +37,7 @@ describe RuboCop::Cop::Lint::Void do
       inspect_source(cop,
                      ["#{var} = 5",
                       var,
-                      'top'
-                     ])
+                      'top'])
       expect(cop.offenses.size).to eq(1)
     end
   end
@@ -49,8 +46,7 @@ describe RuboCop::Cop::Lint::Void do
     it "registers an offense for void lit #{lit} if not on last line" do
       inspect_source(cop,
                      [lit,
-                      'top'
-                     ])
+                      'top'])
       expect(cop.offenses.size).to eq(1)
     end
   end
@@ -60,32 +56,28 @@ describe RuboCop::Cop::Lint::Void do
                    ['begin',
                     ' 1',
                     ' 2',
-                    'end'
-                   ])
+                    'end'])
     expect(cop.offenses.size).to eq(1)
   end
 
   it 'accepts short call syntax' do
     inspect_source(cop,
                    ['lambda.(a)',
-                    'top'
-                   ])
+                    'top'])
     expect(cop.offenses).to be_empty
   end
 
   it 'accepts backtick commands' do
     inspect_source(cop,
                    ['`touch x`',
-                    'nil'
-                   ])
+                    'nil'])
     expect(cop.offenses).to be_empty
   end
 
   it 'accepts percent-x commands' do
     inspect_source(cop,
                    ['%x(touch x)',
-                    'nil'
-                   ])
+                    'nil'])
     expect(cop.offenses).to be_empty
   end
 end

--- a/spec/rubocop/cop/style/align_hash_spec.rb
+++ b/spec/rubocop/cop/style/align_hash_spec.rb
@@ -195,8 +195,7 @@ describe RuboCop::Cop::Style::AlignHash, :config do
                                             '           ccc: 2 }',
                                             'hash2 = { :a   => 0,',
                                             '     :bb  => 1,',
-                                            '          :ccc  =>2 }'
-                                           ])
+                                            '          :ccc  =>2 }'])
       expect(new_source).to eq(['hash1 = { a: 0,',
                                 '          bb: 1,',
                                 '          ccc: 2 }',
@@ -258,8 +257,7 @@ describe RuboCop::Cop::Style::AlignHash, :config do
                            'hash2 = {',
                            '  a:   0,',
                            '  bbb: 1',
-                           '}'
-                          ])
+                           '}'])
       expect(cop.offenses).to be_empty
     end
 
@@ -307,8 +305,7 @@ describe RuboCop::Cop::Style::AlignHash, :config do
                            'hash2 = {',
                            '  a:   0,',
                            '  bbb:1',
-                           '}'
-                          ])
+                           '}'])
       expect(cop.highlights).to eq(["'a'   =>  0",
                                     'bbb:1'])
     end
@@ -321,8 +318,7 @@ describe RuboCop::Cop::Style::AlignHash, :config do
                            'hash2 = {',
                            '   a:  0,',
                            '  bbb: 1',
-                           '}'
-                          ])
+                           '}'])
       expect(cop.highlights).to eq(["'a'   =>  0",
                                     "'bbb'  =>  1",
                                     'a:  0',

--- a/spec/rubocop/cop/style/align_parameters_spec.rb
+++ b/spec/rubocop/cop/style/align_parameters_spec.rb
@@ -71,8 +71,7 @@ describe RuboCop::Cop::Style::AlignParameters do
                            'func2(a,',
                            '     *b,',
                            '      c)',
-                           'func3(*a)'
-                          ])
+                           'func3(*a)'])
       expect(cop.offenses.map(&:to_s))
         .to eq(['C:  5:  6: Align the parameters of a method call if ' \
                 'they span more than one line.'])

--- a/spec/rubocop/cop/style/block_end_newline_spec.rb
+++ b/spec/rubocop/cop/style/block_end_newline_spec.rb
@@ -23,8 +23,7 @@ describe RuboCop::Cop::Style::BlockEndNewline do
   it 'registers an offense when multiline block end is not on its own line' do
     inspect_source(cop,
                    ['test do',
-                    '  foo end'
-                   ])
+                    '  foo end'])
     expect(cop.messages)
       .to eq(['Expression at 2, 7 should be on its own line.'])
   end
@@ -32,8 +31,7 @@ describe RuboCop::Cop::Style::BlockEndNewline do
   it 'registers an offense when multiline block } is not on its own line' do
     inspect_source(cop,
                    ['test {',
-                    '  foo }'
-                   ])
+                    '  foo }'])
     expect(cop.messages)
       .to eq(['Expression at 2, 7 should be on its own line.'])
   end

--- a/spec/rubocop/cop/style/case_indentation_spec.rb
+++ b/spec/rubocop/cop/style/case_indentation_spec.rb
@@ -164,8 +164,7 @@ describe RuboCop::Cop::Style::CaseIndentation do
                                    '        case b',
                                    '        when 1 then return',
                                    '        end',
-                                   'end'
-                                  ].join("\n"))
+                                   'end'].join("\n"))
         end
       end
 

--- a/spec/rubocop/cop/style/class_and_module_camel_case_spec.rb
+++ b/spec/rubocop/cop/style/class_and_module_camel_case_spec.rb
@@ -12,8 +12,7 @@ describe RuboCop::Cop::Style::ClassAndModuleCamelCase do
                     'end',
                     '',
                     'module My_Module',
-                    'end'
-                   ])
+                    'end'])
     expect(cop.offenses.size).to eq(2)
   end
 
@@ -23,8 +22,7 @@ describe RuboCop::Cop::Style::ClassAndModuleCamelCase do
                     'end',
                     '',
                     'module My_Module::Ala',
-                    'end'
-                   ])
+                    'end'])
     expect(cop.offenses.size).to eq(2)
   end
 
@@ -34,8 +32,7 @@ describe RuboCop::Cop::Style::ClassAndModuleCamelCase do
                     'end',
                     '',
                     'module Mine',
-                    'end'
-                   ])
+                    'end'])
     expect(cop.offenses).to be_empty
   end
 end

--- a/spec/rubocop/cop/style/class_and_module_children_spec.rb
+++ b/spec/rubocop/cop/style/class_and_module_children_spec.rb
@@ -41,8 +41,7 @@ describe RuboCop::Cop::Style::ClassAndModuleChildren, :config do
                       'module FooModule',
                       '  module BarModule',
                       '  end',
-                      'end'
-                     ])
+                      'end'])
       expect(cop.offenses).to be_empty
     end
 
@@ -54,8 +53,7 @@ describe RuboCop::Cop::Style::ClassAndModuleChildren, :config do
                       'end',
                       '',
                       'class BazClass < FooClass::BarClass',
-                      'end'
-                     ])
+                      'end'])
       expect(cop.offenses).to be_empty
     end
   end
@@ -68,8 +66,7 @@ describe RuboCop::Cop::Style::ClassAndModuleChildren, :config do
                      ['class FooClass',
                       '  class BarClass',
                       '  end',
-                      'end'
-                     ])
+                      'end'])
       expect(cop.offenses.size).to eq 1
       expect(cop.messages).to eq [
         'Use compact module/class definition instead of nested style.'
@@ -82,8 +79,7 @@ describe RuboCop::Cop::Style::ClassAndModuleChildren, :config do
                      ['module FooModule',
                       '  module BarModule',
                       '  end',
-                      'end'
-                     ])
+                      'end'])
       expect(cop.offenses.size).to eq 1
       expect(cop.messages).to eq [
         'Use compact module/class definition instead of nested style.'
@@ -97,8 +93,7 @@ describe RuboCop::Cop::Style::ClassAndModuleChildren, :config do
                       'end',
                       '',
                       'module FooClass::BarModule',
-                      'end'
-                     ])
+                      'end'])
       expect(cop.offenses).to be_empty
     end
 
@@ -116,8 +111,7 @@ describe RuboCop::Cop::Style::ClassAndModuleChildren, :config do
                       '  end',
                       '  class BazModule',
                       '  end',
-                      'end'
-                     ])
+                      'end'])
       expect(cop.offenses).to be_empty
     end
 
@@ -126,8 +120,7 @@ describe RuboCop::Cop::Style::ClassAndModuleChildren, :config do
                      ['class FooClass',
                       '  def bar_method',
                       '  end',
-                      'end'
-                     ])
+                      'end'])
       expect(cop.offenses).to be_empty
     end
 
@@ -136,8 +129,7 @@ describe RuboCop::Cop::Style::ClassAndModuleChildren, :config do
                      ['class FooClass < Super',
                       '  class BarClass',
                       '  end',
-                      'end'
-                     ])
+                      'end'])
       expect(cop.offenses).to be_empty
     end
   end

--- a/spec/rubocop/cop/style/constant_name_spec.rb
+++ b/spec/rubocop/cop/style/constant_name_spec.rb
@@ -46,8 +46,7 @@ describe RuboCop::Cop::Style::ConstantName do
     inspect_source(cop,
                    ['AnythingGoes = test do',
                     '  do_something',
-                    'end'
-                   ])
+                    'end'])
     expect(cop.offenses).to be_empty
   end
 

--- a/spec/rubocop/cop/style/documentation_spec.rb
+++ b/spec/rubocop/cop/style/documentation_spec.rb
@@ -16,8 +16,7 @@ describe RuboCop::Cop::Style::Documentation do
                    ['class My_Class',
                     '  def method',
                     '  end',
-                    'end'
-                   ])
+                    'end'])
     expect(cop.offenses.size).to eq(1)
   end
 
@@ -30,8 +29,7 @@ describe RuboCop::Cop::Style::Documentation do
                     'class My_Class',
                     '  def method',
                     '  end',
-                    'end'
-                   ])
+                    'end'])
     expect(cop.offenses.size).to eq(1)
   end
 
@@ -40,8 +38,7 @@ describe RuboCop::Cop::Style::Documentation do
                    ['module My_Class',
                     '  def method',
                     '  end',
-                    'end'
-                   ])
+                    'end'])
     expect(cop.offenses.size).to eq(1)
   end
 
@@ -50,8 +47,7 @@ describe RuboCop::Cop::Style::Documentation do
     # explanation.
     inspect_source(cop,
                    ['module Test',
-                    'end'
-                   ])
+                    'end'])
     expect(cop.offenses.size).to eq(1)
   end
 
@@ -61,8 +57,7 @@ describe RuboCop::Cop::Style::Documentation do
                     'class My_Class',
                     '  def method',
                     '  end',
-                    'end'
-                   ])
+                    'end'])
     expect(cop.offenses).to be_empty
   end
 
@@ -72,8 +67,7 @@ describe RuboCop::Cop::Style::Documentation do
                     'class My_Class',
                     '  def method',
                     '  end',
-                    'end'
-                   ])
+                    'end'])
     expect(cop.offenses.size).to eq(1)
   end
 
@@ -85,8 +79,7 @@ describe RuboCop::Cop::Style::Documentation do
                     'class My_Class',
                     '  def method',
                     '  end',
-                    'end'
-                   ])
+                    'end'])
     expect(cop.offenses).to be_empty
   end
 
@@ -97,8 +90,7 @@ describe RuboCop::Cop::Style::Documentation do
                     'class Foo',
                     '  def initialize',
                     '  end',
-                    'end'
-                   ])
+                    'end'])
     expect(cop.offenses).to be_empty
   end
 
@@ -108,16 +100,14 @@ describe RuboCop::Cop::Style::Documentation do
                     'module My_Class',
                     '  def method',
                     '  end',
-                    'end'
-                   ])
+                    'end'])
     expect(cop.offenses).to be_empty
   end
 
   it 'accepts empty class without documentation' do
     inspect_source(cop,
                    ['class My_Class',
-                    'end'
-                   ])
+                    'end'])
     expect(cop.offenses).to be_empty
   end
 
@@ -126,8 +116,7 @@ describe RuboCop::Cop::Style::Documentation do
                    ['module Test',
                     '  class A; end',
                     '  class B; end',
-                    'end'
-                   ])
+                    'end'])
     expect(cop.offenses).to be_empty
   end
 
@@ -136,8 +125,7 @@ describe RuboCop::Cop::Style::Documentation do
                    ['class Test',
                     '  class A; end',
                     '  class B; end',
-                    'end'
-                   ])
+                    'end'])
     expect(cop.offenses).to be_empty
   end
 
@@ -169,8 +157,7 @@ describe RuboCop::Cop::Style::Documentation do
                      ['class Test',
                       '  if //',
                       '  end',
-                      'end'
-                     ])
+                      'end'])
     end.to_not raise_error
   end
 
@@ -182,8 +169,7 @@ describe RuboCop::Cop::Style::Documentation do
                     '    def method',
                     '    end',
                     '  end',
-                    'end'
-                   ])
+                    'end'])
     expect(cop.offenses.size).to eq 1
   end
 
@@ -197,8 +183,7 @@ describe RuboCop::Cop::Style::Documentation do
                         '    def method',
                         '    end',
                         '  end # decorating comment',
-                        'end'
-                       ])
+                        'end'])
         expect(cop.offenses).to be_empty
       end
 
@@ -210,8 +195,7 @@ describe RuboCop::Cop::Style::Documentation do
                         '    end',
                         '    # sparse comment',
                         '  end',
-                        'end'
-                       ])
+                        'end'])
         expect(cop.offenses.size).to eq(1)
       end
     end
@@ -224,8 +208,7 @@ describe RuboCop::Cop::Style::Documentation do
                        ["#{keyword} Test #:nodoc:",
                         '  def method',
                         '  end',
-                        'end'
-                       ])
+                        'end'])
         expect(cop.offenses).to be_empty
       end
 
@@ -237,8 +220,7 @@ describe RuboCop::Cop::Style::Documentation do
                         '    def method',
                         '    end',
                         '  end',
-                        'end'
-                       ])
+                        'end'])
         expect(cop.offenses.size).to eq(1)
       end
 
@@ -252,8 +234,7 @@ describe RuboCop::Cop::Style::Documentation do
                           '      TEST = 20',
                           '    end',
                           '  end',
-                          'end'
-                         ])
+                          'end'])
           expect(cop.offenses).to be_empty
         end
       end
@@ -265,8 +246,7 @@ describe RuboCop::Cop::Style::Documentation do
                        ['class Test < Parent #:nodoc:',
                         '  def method',
                         '  end',
-                        'end'
-                       ])
+                        'end'])
         expect(cop.offenses).to be_empty
       end
 
@@ -278,8 +258,7 @@ describe RuboCop::Cop::Style::Documentation do
                         '    def method',
                         '    end',
                         '  end',
-                        'end'
-                       ])
+                        'end'])
         expect(cop.offenses.size).to eq(1)
       end
 
@@ -293,8 +272,7 @@ describe RuboCop::Cop::Style::Documentation do
                           '      TEST = 20',
                           '    end',
                           '  end',
-                          'end'
-                         ])
+                          'end'])
           expect(cop.offenses).to be_empty
         end
       end

--- a/spec/rubocop/cop/style/empty_line_between_defs_spec.rb
+++ b/spec/rubocop/cop/style/empty_line_between_defs_spec.rb
@@ -196,8 +196,7 @@ describe RuboCop::Cop::Style::EmptyLineBetweenDefs, :config do
               '  # calculates size',
               '  def n',
               '  end',
-              'end'
-             ]
+              'end']
     inspect_source(cop, source)
     expect(cop.offenses).to be_empty
   end
@@ -208,8 +207,7 @@ describe RuboCop::Cop::Style::EmptyLineBetweenDefs, :config do
               '  #',
               '  def html_escape(s)',
               '  end',
-              'end'
-             ]
+              'end']
     inspect_source(cop, source)
     expect(cop.messages).to be_empty
   end
@@ -220,8 +218,7 @@ describe RuboCop::Cop::Style::EmptyLineBetweenDefs, :config do
               '    def initialize(attrs)',
               '    end',
               '  end',
-              'end'
-             ]
+              'end']
     inspect_source(cop, source)
     expect(cop.messages).to be_empty
   end
@@ -269,8 +266,7 @@ describe RuboCop::Cop::Style::EmptyLineBetweenDefs, :config do
                 'def c', # Not a one-liner, so this is an offense.
                 'end',
                 # Also an offense since previous was multi-line:
-                'def d; end'
-               ]
+                'def d; end']
       inspect_source(cop, source)
       expect(cop.offenses.map(&:line)).to eq([3, 5])
     end

--- a/spec/rubocop/cop/style/extra_spacing_spec.rb
+++ b/spec/rubocop/cop/style/extra_spacing_spec.rb
@@ -44,7 +44,8 @@ describe RuboCop::Cop::Style::ExtraSpacing, :config do
         "    'port-channel100' => {",
         "      area: '3.2.2.29', cost: 25, hello: 50, pass: false }",
         '  }',
-        '}']
+        '}'
+      ]
       inspect_source(cop, source)
       expect(cop.offenses).to be_empty
     end

--- a/spec/rubocop/cop/style/identical_conditional_branches_spec.rb
+++ b/spec/rubocop/cop/style/identical_conditional_branches_spec.rb
@@ -23,7 +23,8 @@ describe RuboCop::Cop::Style::IdenticalConditionalBranches do
       expect(cop.offenses.size).to eq(2)
       expect(cop.messages).to eq([
                                    'Move `do_x` out of the conditional.',
-                                   'Move `do_x` out of the conditional.'])
+                                   'Move `do_x` out of the conditional.'
+                                 ])
     end
   end
 
@@ -42,7 +43,8 @@ describe RuboCop::Cop::Style::IdenticalConditionalBranches do
       expect(cop.offenses.size).to eq(2)
       expect(cop.messages).to eq([
                                    'Move `do_x` out of the conditional.',
-                                   'Move `do_x` out of the conditional.'])
+                                   'Move `do_x` out of the conditional.'
+                                 ])
     end
   end
 
@@ -91,7 +93,8 @@ describe RuboCop::Cop::Style::IdenticalConditionalBranches do
       expect(cop.messages).to eq([
                                    'Move `do_x` out of the conditional.',
                                    'Move `do_x` out of the conditional.',
-                                   'Move `do_x` out of the conditional.'])
+                                   'Move `do_x` out of the conditional.'
+                                 ])
     end
   end
 

--- a/spec/rubocop/cop/style/infinite_loop_spec.rb
+++ b/spec/rubocop/cop/style/infinite_loop_spec.rb
@@ -11,8 +11,7 @@ describe RuboCop::Cop::Style::InfiniteLoop do
       inspect_source(cop,
                      ["while #{lit}",
                       '  top',
-                      'end'
-                     ])
+                      'end'])
       expect(cop.offenses.size).to eq(1)
     end
   end
@@ -22,8 +21,7 @@ describe RuboCop::Cop::Style::InfiniteLoop do
       inspect_source(cop,
                      ["until #{lit}",
                       '  top',
-                      'end'
-                     ])
+                      'end'])
       expect(cop.offenses.size).to eq(1)
     end
   end

--- a/spec/rubocop/cop/style/missing_else_spec.rb
+++ b/spec/rubocop/cop/style/missing_else_spec.rb
@@ -216,10 +216,11 @@ describe RuboCop::Cop::Style::MissingElse do
   context 'EmptyElse enabled and set to warn on empty' do
     let(:config) do
       styles = %w(if case both)
-      RuboCop::Config.new('Style/MissingElse' => { 'Enabled' => true,
-                                                   'EnforcedStyle' => 'both',
-                                                   'SupportedStyles' => styles
-      },
+      RuboCop::Config.new('Style/MissingElse' => {
+                            'Enabled' => true,
+                            'EnforcedStyle' => 'both',
+                            'SupportedStyles' => styles
+                          },
                           'Style/UnlessElse' => { 'Enabled' => false },
                           'Style/EmptyElse' => {
                             'Enabled' => true,
@@ -333,10 +334,11 @@ describe RuboCop::Cop::Style::MissingElse do
   context 'EmptyElse enabled and set to warn on nil' do
     let(:config) do
       styles = %w(if case both)
-      RuboCop::Config.new('Style/MissingElse' => { 'Enabled' => true,
-                                                   'EnforcedStyle' => 'both',
-                                                   'SupportedStyles' => styles
-      },
+      RuboCop::Config.new('Style/MissingElse' => {
+                            'Enabled' => true,
+                            'EnforcedStyle' => 'both',
+                            'SupportedStyles' => styles
+                          },
                           'Style/UnlessElse' => { 'Enabled' => false },
                           'Style/EmptyElse' => {
                             'Enabled' => true,
@@ -442,10 +444,11 @@ describe RuboCop::Cop::Style::MissingElse do
   context 'configured to warn only on empty if' do
     let(:config) do
       styles = %w(if case both)
-      RuboCop::Config.new('Style/MissingElse' => { 'Enabled' => true,
-                                                   'EnforcedStyle' => 'if',
-                                                   'SupportedStyles' => styles
-      },
+      RuboCop::Config.new('Style/MissingElse' => {
+                            'Enabled' => true,
+                            'EnforcedStyle' => 'if',
+                            'SupportedStyles' => styles
+                          },
                           'Style/UnlessElse' => { 'Enabled' => false },
                           'Style/EmptyElse' => {
                             'Enabled' => true,
@@ -550,10 +553,11 @@ describe RuboCop::Cop::Style::MissingElse do
   context 'configured to warn only on empty case' do
     let(:config) do
       styles = %w(if case both)
-      RuboCop::Config.new('Style/MissingElse' => { 'Enabled' => true,
-                                                   'EnforcedStyle' => 'case',
-                                                   'SupportedStyles' => styles
-      },
+      RuboCop::Config.new('Style/MissingElse' => {
+                            'Enabled' => true,
+                            'EnforcedStyle' => 'case',
+                            'SupportedStyles' => styles
+                          },
                           'Style/UnlessElse' => { 'Enabled' => false },
                           'Style/EmptyElse' => {
                             'Enabled' => true,

--- a/spec/rubocop/cop/style/multiline_block_layout_spec.rb
+++ b/spec/rubocop/cop/style/multiline_block_layout_spec.rb
@@ -9,8 +9,7 @@ describe RuboCop::Cop::Style::MultilineBlockLayout do
   it 'registers an offense for missing newline in do/end block w/o params' do
     inspect_source(cop,
                    ['test do foo',
-                    'end'
-                   ])
+                    'end'])
     expect(cop.messages)
       .to eq(['Block body expression is on the same line as the block start.'])
   end
@@ -18,8 +17,7 @@ describe RuboCop::Cop::Style::MultilineBlockLayout do
   it 'registers an offense for missing newline in {} block w/o params' do
     inspect_source(cop,
                    ['test { foo',
-                    '}'
-                   ])
+                    '}'])
     expect(cop.messages)
       .to eq(['Block body expression is on the same line as the block start.'])
   end
@@ -27,8 +25,7 @@ describe RuboCop::Cop::Style::MultilineBlockLayout do
   it 'registers an offense for missing newline in do/end block with params' do
     inspect_source(cop,
                    ['test do |x| foo',
-                    'end'
-                   ])
+                    'end'])
     expect(cop.messages)
       .to eq(['Block body expression is on the same line as the block start.'])
   end
@@ -36,8 +33,7 @@ describe RuboCop::Cop::Style::MultilineBlockLayout do
   it 'registers an offense for missing newline in {} block with params' do
     inspect_source(cop,
                    ['test { |x| foo',
-                    '}'
-                   ])
+                    '}'])
     expect(cop.messages)
       .to eq(['Block body expression is on the same line as the block start.'])
   end
@@ -56,16 +52,14 @@ describe RuboCop::Cop::Style::MultilineBlockLayout do
     inspect_source(cop,
                    ['test do',
                     '  foo',
-                    'end'
-                   ])
+                    'end'])
     expect(cop.offenses).to be_empty
   end
 
   it 'does not error out when the block is empty' do
     inspect_source(cop,
                    ['test do |x|',
-                    'end'
-                   ])
+                    'end'])
     expect(cop.offenses).to be_empty
   end
 
@@ -73,8 +67,7 @@ describe RuboCop::Cop::Style::MultilineBlockLayout do
     inspect_source(cop,
                    ['test {',
                     '  foo',
-                    '}'
-                   ])
+                    '}'])
     expect(cop.offenses).to be_empty
   end
 
@@ -82,8 +75,7 @@ describe RuboCop::Cop::Style::MultilineBlockLayout do
     inspect_source(cop,
                    ['-> (x) do foo',
                     '  bar',
-                    'end'
-                   ])
+                    'end'])
     expect(cop.messages)
       .to eq(['Block body expression is on the same line as the block start.'])
   end
@@ -92,8 +84,7 @@ describe RuboCop::Cop::Style::MultilineBlockLayout do
     inspect_source(cop,
                    ['-> x do foo',
                     '  bar',
-                    'end'
-                   ])
+                    'end'])
     expect(cop.messages)
       .to eq(['Block body expression is on the same line as the block start.'])
   end

--- a/spec/rubocop/cop/style/multiline_if_then_spec.rb
+++ b/spec/rubocop/cop/style/multiline_if_then_spec.rb
@@ -111,8 +111,7 @@ describe RuboCop::Cop::Style::MultilineIfThen do
     inspect_source(cop,
                    ['if two',
                     '  puts 1',
-                    'end unless two'
-                   ])
+                    'end unless two'])
     expect(cop.offenses).to be_empty
   end
 

--- a/spec/rubocop/cop/style/negated_if_spec.rb
+++ b/spec/rubocop/cop/style/negated_if_spec.rb
@@ -11,8 +11,7 @@ describe RuboCop::Cop::Style::NegatedIf do
                    ['if !a_condition',
                     '  some_method',
                     'end',
-                    'some_method if !a_condition'
-                   ])
+                    'some_method if !a_condition'])
     expect(cop.messages).to eq(
       ['Favor `unless` over `if` for negative ' \
        'conditions.'] * 2)
@@ -23,8 +22,7 @@ describe RuboCop::Cop::Style::NegatedIf do
                    ['unless !a_condition',
                     '  some_method',
                     'end',
-                    'some_method unless !a_condition'
-                   ])
+                    'some_method unless !a_condition'])
     expect(cop.messages).to eq(['Favor `if` over `unless` for negative ' \
                                 'conditions.'] * 2)
   end

--- a/spec/rubocop/cop/style/negated_while_spec.rb
+++ b/spec/rubocop/cop/style/negated_while_spec.rb
@@ -11,8 +11,7 @@ describe RuboCop::Cop::Style::NegatedWhile do
                    ['while !a_condition',
                     '  some_method',
                     'end',
-                    'some_method while !a_condition'
-                   ])
+                    'some_method while !a_condition'])
     expect(cop.messages).to eq(
       ['Favor `until` over `while` for negative conditions.'] * 2)
   end
@@ -22,8 +21,7 @@ describe RuboCop::Cop::Style::NegatedWhile do
                    ['until !a_condition',
                     '  some_method',
                     'end',
-                    'some_method until !a_condition'
-                   ])
+                    'some_method until !a_condition'])
     expect(cop.messages)
       .to eq(['Favor `while` over `until` for negative conditions.'] * 2)
   end

--- a/spec/rubocop/cop/style/parentheses_around_condition_spec.rb
+++ b/spec/rubocop/cop/style/parentheses_around_condition_spec.rb
@@ -20,8 +20,7 @@ describe RuboCop::Cop::Style::ParenthesesAroundCondition, :config do
                          'x += 1 if (x < 10)',
                          'x += 1 unless (x < 10)',
                          'x += 1 until (x < 10)',
-                         'x += 1 while (x < 10)'
-                        ])
+                         'x += 1 while (x < 10)'])
     expect(cop.offenses.size).to eq(9)
     expect(cop.messages.first)
       .to eq("Don't use parentheses around the condition of an `if`.")
@@ -48,8 +47,7 @@ describe RuboCop::Cop::Style::ParenthesesAroundCondition, :config do
                                          'x += 1 if (x < 10)',
                                          'x += 1 unless (x < 10)',
                                          'x += 1 while (x < 10)',
-                                         'x += 1 until (x < 10)'
-                                        ])
+                                         'x += 1 until (x < 10)'])
     expect(corrected).to eq ['if x > 10',
                              'elsif x < 3',
                              'end',
@@ -62,8 +60,7 @@ describe RuboCop::Cop::Style::ParenthesesAroundCondition, :config do
                              'x += 1 if x < 10',
                              'x += 1 unless x < 10',
                              'x += 1 while x < 10',
-                             'x += 1 until x < 10'
-                            ].join("\n")
+                             'x += 1 until x < 10'].join("\n")
   end
 
   it 'accepts condition without parentheses' do
@@ -78,8 +75,7 @@ describe RuboCop::Cop::Style::ParenthesesAroundCondition, :config do
                          'x += 1 if x < 10',
                          'x += 1 unless x < 10',
                          'x += 1 while x < 10',
-                         'x += 1 until x < 10'
-                        ])
+                         'x += 1 until x < 10'])
     expect(cop.offenses).to be_empty
   end
 
@@ -116,24 +112,21 @@ describe RuboCop::Cop::Style::ParenthesesAroundCondition, :config do
     it 'accepts variable assignment in condition surrounded with parentheses' do
       inspect_source(cop,
                      ['if (test = 10)',
-                      'end'
-                     ])
+                      'end'])
       expect(cop.offenses).to be_empty
     end
 
     it 'accepts element assignment in condition surrounded with parentheses' do
       inspect_source(cop,
                      ['if (test[0] = 10)',
-                      'end'
-                     ])
+                      'end'])
       expect(cop.offenses).to be_empty
     end
 
     it 'accepts setter in condition surrounded with parentheses' do
       inspect_source(cop,
                      ['if (self.test = 10)',
-                      'end'
-                     ])
+                      'end'])
       expect(cop.offenses).to be_empty
     end
   end
@@ -145,8 +138,7 @@ describe RuboCop::Cop::Style::ParenthesesAroundCondition, :config do
        'parentheses' do
       inspect_source(cop,
                      ['if (test = 10)',
-                      'end'
-                     ])
+                      'end'])
       expect(cop.offenses.size).to eq(1)
     end
 
@@ -154,8 +146,7 @@ describe RuboCop::Cop::Style::ParenthesesAroundCondition, :config do
        'parentheses' do
       inspect_source(cop,
                      ['if (test[0] = 10)',
-                      'end'
-                     ])
+                      'end'])
       expect(cop.offenses.size).to eq(1)
     end
   end

--- a/spec/rubocop/cop/style/redundant_self_spec.rb
+++ b/spec/rubocop/cop/style/redundant_self_spec.rb
@@ -84,8 +84,7 @@ describe RuboCop::Cop::Style::RedundantSelf do
            'self.until',
            'self.when',
            'self.while',
-           'self.yield'
-          ]
+           'self.yield']
     inspect_source(cop, src)
     expect(cop.offenses).to be_empty
   end
@@ -94,8 +93,7 @@ describe RuboCop::Cop::Style::RedundantSelf do
     it 'accepts a self receiver used to distinguish from blockarg' do
       src = ['def requested_specs(&groups)',
              '  some_method(self.groups)',
-             'end'
-            ]
+             'end']
       inspect_source(cop, src)
       expect(cop.offenses).to be_empty
     end
@@ -103,8 +101,7 @@ describe RuboCop::Cop::Style::RedundantSelf do
     it 'accepts a self receiver used to distinguish from argument' do
       src = ['def requested_specs(groups)',
              '  some_method(self.groups)',
-             'end'
-            ]
+             'end']
       inspect_source(cop, src)
       expect(cop.offenses).to be_empty
     end
@@ -112,8 +109,7 @@ describe RuboCop::Cop::Style::RedundantSelf do
     it 'accepts a self receiver used to distinguish from argument' do
       src = ['def requested_specs(final = true)',
              '  something if self.final != final',
-             'end'
-            ]
+             'end']
       inspect_source(cop, src)
       expect(cop.offenses).to be_empty
     end
@@ -125,8 +121,7 @@ describe RuboCop::Cop::Style::RedundantSelf do
              '    groups.map! { |g| g.to_sym }',
              '    specs_for(groups)',
              '  end',
-             'end'
-            ]
+             'end']
       inspect_source(cop, src)
       expect(cop.offenses).to be_empty
     end
@@ -136,8 +131,7 @@ describe RuboCop::Cop::Style::RedundantSelf do
     it 'accepts a self receiver used to distinguish from blockarg' do
       src = ['def self.requested_specs(&groups)',
              '  some_method(self.groups)',
-             'end'
-            ]
+             'end']
       inspect_source(cop, src)
       expect(cop.offenses).to be_empty
     end
@@ -145,8 +139,7 @@ describe RuboCop::Cop::Style::RedundantSelf do
     it 'accepts a self receiver used to distinguish from argument' do
       src = ['def self.requested_specs(groups)',
              '  some_method(self.groups)',
-             'end'
-            ]
+             'end']
       inspect_source(cop, src)
       expect(cop.offenses).to be_empty
     end
@@ -154,8 +147,7 @@ describe RuboCop::Cop::Style::RedundantSelf do
     it 'accepts a self receiver used to distinguish from argument' do
       src = ['def self.requested_specs(final = true)',
              '  something if self.final != final',
-             'end'
-            ]
+             'end']
       inspect_source(cop, src)
       expect(cop.offenses).to be_empty
     end
@@ -167,8 +159,7 @@ describe RuboCop::Cop::Style::RedundantSelf do
              '    groups.map! { |g| g.to_sym }',
              '    specs_for(groups)',
              '  end',
-             'end'
-            ]
+             'end']
       inspect_source(cop, src)
       expect(cop.offenses).to be_empty
     end

--- a/spec/rubocop/cop/style/single_line_block_params_spec.rb
+++ b/spec/rubocop/cop/style/single_line_block_params_spec.rb
@@ -8,8 +8,7 @@ describe RuboCop::Cop::Style::SingleLineBlockParams, :config do
   let(:cop_config) do
     { 'Methods' =>
       [{ 'reduce' => %w(a e) },
-       { 'test' => %w(x y) }]
-    }
+       { 'test' => %w(x y) }] }
   end
 
   it 'finds wrong argument names in calls with different syntax' do

--- a/spec/rubocop/cop/style/struct_inheritance_spec.rb
+++ b/spec/rubocop/cop/style/struct_inheritance_spec.rb
@@ -9,32 +9,28 @@ describe RuboCop::Cop::Style::StructInheritance do
   it 'registers an offense when extending instance of Struct' do
     inspect_source(cop,
                    ['class Person < Struct.new(:first_name, :last_name)',
-                    'end'
-                   ])
+                    'end'])
     expect(cop.offenses.size).to eq(1)
   end
 
   it 'registers an offense when extending instance of Struct' do
     inspect_source(cop,
                    ['class Person < Struct.new(:first_name, :last_name) do end',
-                    'end'
-                   ])
+                    'end'])
     expect(cop.offenses.size).to eq(1)
   end
 
   it 'accepts plain class' do
     inspect_source(cop,
                    ['class Person',
-                    'end'
-                   ])
+                    'end'])
     expect(cop.offenses).to be_empty
   end
 
   it 'accepts extending DelegateClass' do
     inspect_source(cop,
                    ['class Person < DelegateClass(Animal)',
-                    'end'
-                   ])
+                    'end'])
     expect(cop.offenses).to be_empty
   end
 


### PR DESCRIPTION
As discussed in #2914 this change enables
`Style/MultilineArrayBraceLayout` and `Style/MultilineHashBraceLayout`
with `EnforcedStyle: symmetrical` by default.

All existing RuboCop code has been auto-corrected.