### PR TITLE
Add support for an 'Ignore' directive in MethodLength

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Change log
 
 ## master (unreleased)
+* [#3023](https://github.com/bbatsov/rubocop/issues/3023): Add `Ignore` directive to `MethodLength` to ignore lines containing matching strings e.g. for logging debug. ([@footok][])
 
 ### New features
 
@@ -2137,3 +2138,4 @@
 [@graemeboy]: https://github.com/graemeboy
 [@akihiro17]: https://github.com/akihiro17
 [@magni-]: https://github.com/magni-
+[@footok]: https://github.com/footok

--- a/lib/rubocop/cop/mixin/code_length.rb
+++ b/lib/rubocop/cop/mixin/code_length.rb
@@ -24,9 +24,19 @@ module RuboCop
         end
       end
 
+      def ignore_list
+        cop_config['Ignore'] || []
+      end
+
+      def ignore_line?(source_line)
+        ignore_list.find { |o| source_line.include?(o) }
+      end
+
       # Returns true for lines that shall not be included in the count.
       def irrelevant_line(source_line)
-        source_line.blank? || !count_comments? && comment_line?(source_line)
+        source_line.blank? ||
+          (!count_comments? && comment_line?(source_line)) ||
+          ignore_line?(source_line)
       end
     end
   end

--- a/spec/rubocop/cop/metrics/method_length_spec.rb
+++ b/spec/rubocop/cop/metrics/method_length_spec.rb
@@ -143,6 +143,23 @@ describe RuboCop::Cop::Metrics::MethodLength, :config do
     expect(cop.offenses).to be_empty
   end
 
+  context 'when Ignore is configurd' do
+    before { cop_config['Ignore'] = ['.debug'] }
+
+    it 'does not count lines with strings in the ignore list' do
+      inspect_source(cop, ['def m()',
+                           'logger.debug{"abc"}',
+                           'logger.debug{"abc"}',
+                           'logger.debug{"abc"}',
+                           'logger.debug{"abc"}',
+                           'logger.debug{"abc"}',
+                           'logger.debug{"abc"}',
+                           'logger.debug{"abc"}',
+                           'end'])
+      expect(cop.offenses).to be_empty
+    end
+  end
+
   context 'when CountComments is enabled' do
     before { cop_config['CountComments'] = true }
 


### PR DESCRIPTION
Before submitting a PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [x] Used the same coding conventions as the rest of the project.
* [x] Feature branch is up-to-date with `master` (if not - rebase it)
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] All tests are passing.
* [x] The new code doesn't generate RuboCop offenses.
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.

[1]: http://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html

Please refer to the discussion in #3023 .

Commonly, we get Rubocop metric warnings for long methods, however many
times we have a high percentage of logging lines.

Rather than exclude particular logging lines, allow a user to ignore lines
containing particular strings from the metric calculation.