### PR TITLE
Empty case improvements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,7 @@
 * [#3052](https://github.com/bbatsov/rubocop/pull/3052): `Style/MultilineHashBraceLayout` enforced style supports `same_line` option. ([@panthomakos][])
 * [#3052](https://github.com/bbatsov/rubocop/pull/3052): `Style/MultilineMethodCallBraceLayout` enforced style supports `same_line` option. ([@panthomakos][])
 * [#3052](https://github.com/bbatsov/rubocop/pull/3052): `Style/MultilineMethodDefinitionBraceLayout` enforced style supports `same_line` option. ([@panthomakos][])
-* [#3019](https://github.com/bbatsov/rubocop/issues/3019): Add new `Style/EmptyCaseCondition` cop. ([@owst][])
+* [#3019](https://github.com/bbatsov/rubocop/issues/3019): Add new `Style/EmptyCaseCondition` cop. ([@owst][], [@rrosenblum][])
 * [#3072](https://github.com/bbatsov/rubocop/pull/3072): Add new `Lint/UselessArraySplat` cop. ([@owst][])
 * [#3022](https://github.com/bbatsov/rubocop/issues/3022): `Style/Lambda` enforced style supports `literal` option. ([@drenmi][])
 * [#2909](https://github.com/bbatsov/rubocop/issues/2909): `Style/Lambda` enforced style supports `lambda` option. ([@drenmi][])

--- a/lib/rubocop/cop/style/empty_case_condition.rb
+++ b/lib/rubocop/cop/style/empty_case_condition.rb
@@ -77,10 +77,14 @@ module RuboCop
 
             # In `when a; r` we have two children: [a, r].
             # In `when a, b, c; r` we have 4.
-            next unless children.count > 2
+            next unless children.size > 2
 
-            corrector.insert_before(children.first.loc.expression, '[')
-            corrector.insert_after(children[-2].loc.expression, '].any?')
+            range =
+              Parser::Source::Range.new(when_node.loc.expression.source_buffer,
+                                        children[0].loc.expression.begin_pos,
+                                        children[-2].loc.expression.end_pos)
+
+            corrector.replace(range, children[0..-2].map(&:source).join(' || '))
           end
         end
       end

--- a/spec/rubocop/cop/style/empty_case_condition_spec.rb
+++ b/spec/rubocop/cop/style/empty_case_condition_spec.rb
@@ -128,5 +128,23 @@ describe RuboCop::Cop::Style::EmptyCaseCondition do
 
       it_behaves_like 'detect/correct empty case, accept non-empty case'
     end
+
+    context 'with when branches using then' do
+      let(:source) do
+        ['case',
+         'when false then foo',
+         'when nil, false, 1 then bar',
+         'when false, 1 then baz',
+         'end']
+      end
+      let(:corrected_source) do
+        ['if false then foo',
+         'elsif [nil, false, 1].any? then bar',
+         'elsif [false, 1].any? then baz',
+         'end']
+      end
+
+      it_behaves_like 'detect/correct empty case, accept non-empty case'
+    end
   end
 end

--- a/spec/rubocop/cop/style/empty_case_condition_spec.rb
+++ b/spec/rubocop/cop/style/empty_case_condition_spec.rb
@@ -119,9 +119,9 @@ describe RuboCop::Cop::Style::EmptyCaseCondition do
       let(:corrected_source) do
         ['if false',
          '  foo',
-         'elsif [nil, false, 1].any?',
+         'elsif nil || false || 1',
          '  bar',
-         'elsif [false, 1].any?',
+         'elsif false || 1',
          '  baz',
          'end']
       end
@@ -139,8 +139,8 @@ describe RuboCop::Cop::Style::EmptyCaseCondition do
       end
       let(:corrected_source) do
         ['if false then foo',
-         'elsif [nil, false, 1].any? then bar',
-         'elsif [false, 1].any? then baz',
+         'elsif nil || false || 1 then bar',
+         'elsif false || 1 then baz',
          'end']
       end
 


### PR DESCRIPTION
This modifies the fix for #3019.

It seemed a little weird to me to be using `.any?` in an `if` condition. I think that using `||` is a more standard way of writing these conditions.

I also added a test case using `then`.

@owst, let me know what you think of the changes.