### PR TITLE
Fix HEREDOCs in Style/Multiline*BraceLayout Cops

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,7 @@
 * [#3049](https://github.com/bbatsov/rubocop/issues/3049): Make `Lint/UselessAccessModifier` detect conditionally defined methods and correctly handle dynamically defined methods and singleton class methods. ([@owst][])
 * [#3004](https://github.com/bbatsov/rubocop/pull/3004): Don't add `Style/Alias` offenses for use of `alias` in `instance_eval` blocks, since object instances don't respond to `alias_method`. ([@magni-][])
 * [#3061](https://github.com/bbatsov/rubocop/pull/3061): Custom cops now show up in --show-cops. ([@ptarjan][])
+* [#3088](https://github.com/bbatsov/rubocop/pull/3088): Ignore offenses that involve conflicting HEREDOCs in the `Style/Multiline*BraceLayout` cops. ([@panthomakos][])
 
 ### Changes
 

--- a/spec/rubocop/cop/style/multiline_hash_brace_layout_spec.rb
+++ b/spec/rubocop/cop/style/multiline_hash_brace_layout_spec.rb
@@ -31,6 +31,7 @@ describe RuboCop::Cop::Style::MultilineHashBraceLayout, :config do
     let(:close) { '}' }
     let(:a) { 'a: 1' }
     let(:b) { 'b: 2' }
-    let(:multi) { ['b: [', '1', ']'] }
+    let(:multi_prefix) { 'b: ' }
+    let(:multi) { ['[', '1', ']'] }
   end
 end

--- a/spec/rubocop/cop/style/multiline_method_call_brace_layout_spec.rb
+++ b/spec/rubocop/cop/style/multiline_method_call_brace_layout_spec.rb
@@ -30,14 +30,4 @@ describe RuboCop::Cop::Style::MultilineMethodCallBraceLayout, :config do
     let(:open) { 'foo(' }
     let(:close) { ')' }
   end
-
-  it 'autocorrects method call with heredoc' do
-    new_source = autocorrect_source(cop, ['def foo',
-                                          '  bar(<<EOM',
-                                          '  baz',
-                                          'EOM',
-                                          '     )',
-                                          'end'])
-    expect(new_source).to eq("def foo\n  bar(<<EOM)\n  baz\nEOM\nend")
-  end
 end

--- a/spec/rubocop/cop/style/multiline_method_definition_brace_layout_spec.rb
+++ b/spec/rubocop/cop/style/multiline_method_definition_brace_layout_spec.rb
@@ -34,6 +34,6 @@ describe RuboCop::Cop::Style::MultilineMethodDefinitionBraceLayout, :config do
     let(:suffix) { 'end' }
     let(:open) { '(' }
     let(:close) { ')' }
-    let(:multi) { ['b: {', 'foo: bar', '}'] }
+    let(:multi_prefix) { 'b: ' }
   end
 end


### PR DESCRIPTION
@jonas054 this relates to a previous Pull Request you made. NOTE: I have not adjusted the comment correction behavior. The tests still exist for that and are not impacted by this change. This only relates to HEREDOC edits that can cause invalid code.

bbatsov/rubocop#2873 introduced some changes to HEREDOC handling. While
these changes fixed some issues with auto-correcting and comments, they
also broke the handling of some HEREDOC use-cases.

For example, this code cannot be corrected in the symmetrical or same
line style because `EOM)` on the last line would be invalid code.

    foo(a,
      b: <<-EOM
        bar
      EOM
    )

    # invalid
    foo(a,
      b: <<-EOM
        bar
      EOM)

Additionally, this code cannot be corrected in the symmetrical or same
line style because `<<-EOM).to(<<-EOM2` would not be valid code.

    foo(<<-EOM
        bar
      EOM
    ).to(<<-EOM2
      baz
    EOM2
    )

    # invalid
    foo(<<-EOM).to(<<-EOM2
        bar
      EOM
      baz
    EOM2
    )

This change simply ignores HEREDOCs that cannot be corrected. The
determination is made by checking the HEREDOC's last line.

For example, the following can be corrected because the HEREDOC ends on
a non-conflicting line.

    foo(a,
      b: {
        c: <<-EOM
          bar
        EOM
      }
    )

    # valid
    foo(a,
      b: {
        c: <<-EOM
          bar
        EOM
      })