### PR TITLE
Enable symmetrical braces for methods

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -27,7 +27,7 @@ Metrics/MethodLength:
 # Offense count: 10
 # Configuration parameters: CountComments.
 Metrics/ModuleLength:
-  Max: 154
+  Max: 156
 
 # Offense count: 55
 Metrics/PerceivedComplexity:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,7 @@
 * [#3028](https://github.com/bbatsov/rubocop/pull/3028): Add `define_method` to the default list of `IgnoredMethods` of `Style/SymbolProc`. ([@jastkand][])
 * [#3064](https://github.com/bbatsov/rubocop/pull/3064): `Style/SpaceAfterNot` highlights the entire expression instead of just the exlamation mark. ([@rrosenblum][])
 * [#3085](https://github.com/bbatsov/rubocop/pull/3085): Enable `Style/MultilineArrayBraceLayout` and `Style/MultilineHashBraceLayout` with the `symmetrical` style by default. ([@panthomakos][])
+* [#3091](https://github.com/bbatsov/rubocop/pull/3091): Enable `Style/MultilineMethodCallBraceLayout` and `Style/MultilineMethodDefinitionBraceLayout` with the `symmetrical` style by default. ([@panthomakos][])
 
 ## 0.39.0 (2016-03-27)
 

--- a/config/default.yml
+++ b/config/default.yml
@@ -675,6 +675,15 @@ Style/MultilineHashBraceLayout:
     - new_line
     - same_line
 
+Style/MultilineMethodCallBraceLayout:
+  EnforcedStyle: symmetrical
+  SupportedStyles:
+    # symmetrical: closing brace is positioned in same way as opening brace
+    # new_line: closing brace is always on a new line
+    # same_line: closing brace is always on the same line as last argument
+    - symmetrical
+    - new_line
+    - same_line
 
 Style/MultilineMethodCallIndentation:
   EnforcedStyle: aligned
@@ -684,6 +693,16 @@ Style/MultilineMethodCallIndentation:
   # By default, the indentation width from Style/IndentationWidth is used
   # But it can be overridden by setting this parameter
   IndentationWidth: ~
+
+Style/MultilineMethodDefinitionBraceLayout:
+  EnforcedStyle: symmetrical
+  SupportedStyles:
+    # symmetrical: closing brace is positioned in same way as opening brace
+    # new_line: closing brace is always on a new line
+    # same_line: closing brace is always on the same line as last parameter
+    - symmetrical
+    - new_line
+    - same_line
 
 Style/MultilineOperationIndentation:
   EnforcedStyle: aligned

--- a/config/disabled.yml
+++ b/config/disabled.yml
@@ -78,36 +78,6 @@ Style/MultilineAssignmentLayout:
   StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#indent-conditional-assignment'
   Enabled: false
 
-Style/MultilineMethodCallBraceLayout:
-  Description: >-
-                 Checks that the closing brace in a method call is
-                 either on the same line as the last method argument, or
-                 a new line.
-  Enabled: false
-  EnforcedStyle: symmetrical
-  SupportedStyles:
-    # symmetrical: closing brace is positioned in same way as opening brace
-    # new_line: closing brace is always on a new line
-    # same_line: closing brace is always on the same line as last argument
-    - symmetrical
-    - new_line
-    - same_line
-
-Style/MultilineMethodDefinitionBraceLayout:
-  Description: >-
-                 Checks that the closing brace in a method definition is
-                 either on the same line as the last method parameter, or
-                 a new line.
-  Enabled: false
-  EnforcedStyle: symmetrical
-  SupportedStyles:
-    # symmetrical: closing brace is positioned in same way as opening brace
-    # new_line: closing brace is always on a new line
-    # same_line: closing brace is always on the same line as last parameter
-    - symmetrical
-    - new_line
-    - same_line
-
 Style/OptionHash:
   Description: "Don't use option hashes when you can use keyword arguments."
   Enabled: false

--- a/config/enabled.yml
+++ b/config/enabled.yml
@@ -443,10 +443,24 @@ Style/MultilineIfThen:
   StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#no-then'
   Enabled: true
 
+Style/MultilineMethodCallBraceLayout:
+  Description: >-
+                 Checks that the closing brace in a method call is
+                 either on the same line as the last method argument, or
+                 a new line.
+  Enabled: true
+
 Style/MultilineMethodCallIndentation:
   Description: >-
                  Checks indentation of method calls with the dot operator
                  that span more than one line.
+  Enabled: true
+
+Style/MultilineMethodDefinitionBraceLayout:
+  Description: >-
+                 Checks that the closing brace in a method definition is
+                 either on the same line as the last method parameter, or
+                 a new line.
   Enabled: true
 
 Style/MultilineOperationIndentation:

--- a/lib/rubocop/cop/rails/action_filter.rb
+++ b/lib/rubocop/cop/rails/action_filter.rb
@@ -73,8 +73,7 @@ module RuboCop
           add_offense(node, :selector,
                       format(MSG,
                              preferred_method(method_name),
-                             method_name)
-                     )
+                             method_name))
         end
 
         def offending_method?(method_name)

--- a/lib/rubocop/cop/rails/date.rb
+++ b/lib/rubocop/cop/rails/date.rb
@@ -65,9 +65,7 @@ module RuboCop
 
           add_offense(node, :selector,
                       format(MSG_SEND,
-                             method_name
-                            )
-                     )
+                             method_name))
         end
 
         private
@@ -81,8 +79,7 @@ module RuboCop
           add_offense(node, :selector,
                       format(MSG,
                              "Date.#{method_name}",
-                             "Time.zone.#{method_name}")
-                     )
+                             "Time.zone.#{method_name}"))
         end
 
         def extract_method_chain(node)

--- a/lib/rubocop/cop/rails/time_zone.rb
+++ b/lib/rubocop/cop/rails/time_zone.rb
@@ -80,18 +80,15 @@ module RuboCop
           if acceptable?
             format(MSG_ACCEPTABLE,
                    "#{klass}.#{method_name}",
-                   acceptable_methods(klass, method_name, node).join(', ')
-                  )
+                   acceptable_methods(klass, method_name, node).join(', '))
           elsif method_name == 'current'
             format(MSG_CURRENT,
-                   "#{klass}.#{method_name}"
-                  )
+                   "#{klass}.#{method_name}")
           else
             safe_method_name = safe_method(method_name, node)
             format(MSG,
                    "#{klass}.#{method_name}",
-                   "Time.zone.#{safe_method_name}"
-                  )
+                   "Time.zone.#{safe_method_name}")
           end
         end
 

--- a/lib/rubocop/cop/style/collection_methods.rb
+++ b/lib/rubocop/cop/style/collection_methods.rb
@@ -44,8 +44,7 @@ module RuboCop
           add_offense(node, :selector,
                       format(MSG,
                              preferred_method(method_name),
-                             method_name)
-                     )
+                             method_name))
         end
       end
     end

--- a/lib/rubocop/cop/style/multiline_assignment_layout.rb
+++ b/lib/rubocop/cop/style/multiline_assignment_layout.rb
@@ -74,7 +74,8 @@ module RuboCop
             range = Parser::Source::Range.new(
               node.source_range.source_buffer,
               node.loc.operator.end_pos,
-              extract_rhs(node).source_range.begin_pos)
+              extract_rhs(node).source_range.begin_pos
+            )
 
             ->(corrector) { corrector.replace(range, ' ') }
           end

--- a/lib/rubocop/cop/style/negated_while.rb
+++ b/lib/rubocop/cop/style/negated_while.rb
@@ -37,7 +37,8 @@ module RuboCop
             pos_condition, _method, = *condition
             corrector.replace(
               node.loc.keyword,
-              node.type == :while ? 'until' : 'while')
+              node.type == :while ? 'until' : 'while'
+            )
             corrector.replace(condition.source_range, pos_condition.source)
           end
         end

--- a/lib/rubocop/cop/style/special_global_vars.rb
+++ b/lib/rubocop/cop/style/special_global_vars.rb
@@ -43,9 +43,11 @@ module RuboCop
           Hash[ENGLISH_VARS.flat_map { |k, vs| vs.map { |v| [v, [k]] } }]
 
         ENGLISH_VARS.merge!(
-          Hash[ENGLISH_VARS.flat_map { |_, vs| vs.map { |v| [v, [v]] } }])
+          Hash[ENGLISH_VARS.flat_map { |_, vs| vs.map { |v| [v, [v]] } }]
+        )
         PERL_VARS.merge!(
-          Hash[PERL_VARS.flat_map { |_, vs| vs.map { |v| [v, [v]] } }])
+          Hash[PERL_VARS.flat_map { |_, vs| vs.map { |v| [v, [v]] } }]
+        )
         ENGLISH_VARS.each { |_, v| v.freeze }.freeze
         PERL_VARS.each { |_, v| v.freeze }.freeze
 

--- a/lib/rubocop/cop/style/string_methods.rb
+++ b/lib/rubocop/cop/style/string_methods.rb
@@ -17,8 +17,7 @@ module RuboCop
           add_offense(node, :selector,
                       format(MSG,
                              preferred_method(method_name),
-                             method_name)
-                     )
+                             method_name))
         end
 
         def autocorrect(node)

--- a/spec/rubocop/cli/cli_options_spec.rb
+++ b/spec/rubocop/cli/cli_options_spec.rb
@@ -54,7 +54,8 @@ describe RuboCop::CLI, :isolated_environment do
         it 'prints known ruby files' do
           cli.run ['-L']
           expect($stdout.string.split("\n")).to contain_exactly(
-            'app.rb', 'Gemfile', 'lib/helper.rb')
+            'app.rb', 'Gemfile', 'lib/helper.rb'
+          )
         end
       end
 
@@ -70,7 +71,8 @@ describe RuboCop::CLI, :isolated_environment do
         it 'prints the included files and not the excluded ones' do
           cli.run ['--list-target-files']
           expect($stdout.string.split("\n")).to contain_exactly(
-            'app.rb', 'lib/helper.rb', 'show.rabl')
+            'app.rb', 'lib/helper.rb', 'show.rabl'
+          )
         end
       end
     end
@@ -631,7 +633,8 @@ describe RuboCop::CLI, :isolated_environment do
            'https://github.com/bbatsov/ruby-style-guide#spaces-indentation',
            '  Enabled: true',
            '',
-           ''].join("\n"))
+           ''].join("\n")
+        )
       end
 
       include_examples :prints_config
@@ -654,7 +657,8 @@ describe RuboCop::CLI, :isolated_environment do
            'https://github.com/bbatsov/ruby-style-guide#spaces-indentation',
            '  Enabled: true',
            '',
-           ''].join("\n"))
+           ''].join("\n")
+        )
       end
     end
   end
@@ -1066,7 +1070,8 @@ describe RuboCop::CLI, :isolated_environment do
                   '--stdin']
         expect(cli.run(argv)).to eq(2)
         expect($stderr.string).to include(
-          '-s/--stdin requires exactly one path.')
+          '-s/--stdin requires exactly one path.'
+        )
       ensure
         $stdin = STDIN
       end
@@ -1082,7 +1087,8 @@ describe RuboCop::CLI, :isolated_environment do
                   'fake2.rb']
         expect(cli.run(argv)).to eq(2)
         expect($stderr.string).to include(
-          '-s/--stdin requires exactly one path.')
+          '-s/--stdin requires exactly one path.'
+        )
       ensure
         $stdin = STDIN
       end

--- a/spec/rubocop/cli_spec.rb
+++ b/spec/rubocop/cli_spec.rb
@@ -768,7 +768,8 @@ describe RuboCop::CLI, :isolated_environment do
         expect($stderr.string.strip).to eq(
           'Error: The `Style/MultilineMethodCallIndentation` cop only accepts' \
           ' an `IndentationWidth` configuration parameter when ' \
-          '`EnforcedStyle` is `indented`.')
+          '`EnforcedStyle` is `indented`.'
+        )
       end
     end
 
@@ -783,7 +784,8 @@ describe RuboCop::CLI, :isolated_environment do
         expect($stderr.string.strip).to eq(
           'Error: The `Style/MultilineOperationIndentation` cop only accepts' \
           ' an `IndentationWidth` configuration parameter when ' \
-          '`EnforcedStyle` is `indented`.')
+          '`EnforcedStyle` is `indented`.'
+        )
       end
     end
 
@@ -1045,7 +1047,8 @@ describe RuboCop::CLI, :isolated_environment do
                                    '  Enabled: false'])
       expect(cli.run(['--format', 'emacs', 'example.rb'])).to eq(2)
       expect($stderr.string).to include(
-        'Error: configuration for Syntax cop found')
+        'Error: configuration for Syntax cop found'
+      )
       expect($stderr.string).to include('This cop cannot be configured.')
     end
 
@@ -1457,9 +1460,11 @@ describe RuboCop::CLI, :isolated_environment do
                                      '  TargetRubyVersion: 2.4'])
         expect(cli.run([])).to eq(2)
         expect($stderr.string.strip).to match(
-          /\AError: Unknown Ruby version 2.4 found in `TargetRubyVersion`/)
+          /\AError: Unknown Ruby version 2.4 found in `TargetRubyVersion`/
+        )
         expect($stderr.string.strip).to match(
-          /Known versions: 1.9, 2.0, 2.1, 2.2, 2.3/)
+          /Known versions: 1.9, 2.0, 2.1, 2.2, 2.3/
+        )
       end
     end
 
@@ -1475,7 +1480,8 @@ describe RuboCop::CLI, :isolated_environment do
           ['Error: The `Style/OptionHash` cop is only compatible with Ruby ' \
            '2.0 and up, but the target Ruby version for your project is 1.9.',
            'Please disable this cop or adjust the `TargetRubyVersion` ' \
-           'parameter in your configuration.'].join("\n"))
+           'parameter in your configuration.'].join("\n")
+        )
       end
     end
 
@@ -1494,7 +1500,8 @@ describe RuboCop::CLI, :isolated_environment do
            ' version for your project is 1.9.',
            'Please either disable this cop, configure it to use `array` ' \
            'style, or adjust the `TargetRubyVersion` parameter in your ' \
-           'configuration.'].join("\n"))
+           'configuration.'].join("\n")
+        )
       end
     end
   end
@@ -1511,7 +1518,8 @@ describe RuboCop::CLI, :isolated_environment do
            'use `Style/TrailingCommaInLiteral` and/or ' \
            '`Style/TrailingCommaInArguments` instead.',
            "(obsolete configuration found in #{abs('.rubocop.yml')}, " \
-           'please update it)'].join("\n"))
+           'please update it)'].join("\n")
+        )
       end
     end
   end

--- a/spec/rubocop/config_loader_spec.rb
+++ b/spec/rubocop/config_loader_spec.rb
@@ -210,7 +210,8 @@ describe RuboCop::ConfigLoader do
               'Enabled' => true,
               'CountComments' => false,
               'Max' => 5
-            })
+            }
+          )
         expect(configuration_from_file).to eq(config)
       end
     end
@@ -469,7 +470,8 @@ describe RuboCop::ConfigLoader do
     context 'when no config file exists for the target file' do
       it 'is disabled' do
         expect(
-          config.cop_enabled?(RuboCop::Cop::Style::SymbolArray)).to be_falsey
+          config.cop_enabled?(RuboCop::Cop::Style::SymbolArray)
+        ).to be_falsey
       end
     end
 
@@ -480,7 +482,8 @@ describe RuboCop::ConfigLoader do
                       '  Max: 80'
                     ])
         expect(
-          config.cop_enabled?(RuboCop::Cop::Style::SymbolArray)).to be_falsey
+          config.cop_enabled?(RuboCop::Cop::Style::SymbolArray)
+        ).to be_falsey
       end
     end
 
@@ -491,7 +494,8 @@ describe RuboCop::ConfigLoader do
                       '  Enabled: true'
                     ])
         expect(
-          config.cop_enabled?(RuboCop::Cop::Style::SymbolArray)).to be_truthy
+          config.cop_enabled?(RuboCop::Cop::Style::SymbolArray)
+        ).to be_truthy
       end
     end
   end

--- a/spec/rubocop/config_spec.rb
+++ b/spec/rubocop/config_spec.rb
@@ -94,7 +94,8 @@ describe RuboCop::Config do
       it 'prints a warning message' do
         configuration # ConfigLoader.load_file will validate config
         expect($stderr.string).to match(
-          %r{unrecognized parameter Metrics/LineLength:Min})
+          %r{unrecognized parameter Metrics/LineLength:Min}
+        )
       end
     end
 

--- a/spec/rubocop/cop/lint/block_alignment_spec.rb
+++ b/spec/rubocop/cop/lint/block_alignment_spec.rb
@@ -144,7 +144,8 @@ describe RuboCop::Cop::Lint::BlockAlignment, :config do
         ['variable =',
          '  a_long_method_that_dont_fit_on_the_line do |v|',
          '    v.foo',
-         'end'])
+         'end']
+      )
 
       expect(new_source)
         .to eq(['variable =',

--- a/spec/rubocop/cop/lint/circular_argument_reference_spec.rb
+++ b/spec/rubocop/cop/lint/circular_argument_reference_spec.rb
@@ -69,7 +69,8 @@ describe RuboCop::Cop::Lint::CircularArgumentReference do
 
       it 'fails with a syntax error before the cop even comes into play' do
         expect { inspect_source(cop, source) }.to raise_error(
-          RuntimeError, /Error parsing/)
+          RuntimeError, /Error parsing/
+        )
         expect(cop.offenses).to be_empty
       end
     end

--- a/spec/rubocop/cop/lint/duplicate_methods_spec.rb
+++ b/spec/rubocop/cop/lint/duplicate_methods_spec.rb
@@ -45,7 +45,8 @@ describe RuboCop::Cop::Lint::DuplicateMethods do
                       'end'], 'src.rb')
       expect(cop.offenses.size).to eq(1)
       expect(cop.messages).to eq(
-        ['Method `A.some_method` is defined at both src.rb:2 and src.rb:5.'])
+        ['Method `A.some_method` is defined at both src.rb:2 and src.rb:5.']
+      )
     end
 
     it "doesn't register offense for non-duplicate class methods in #{type}" do
@@ -145,7 +146,8 @@ describe RuboCop::Cop::Lint::DuplicateMethods do
       expect(cop.offenses.size).to eq(2)
       expect(cop.messages).to contain_exactly(
         'Method `A#any_method` is defined at both dups.rb:8 and dups.rb:11.',
-        'Method `A#some_method` is defined at both dups.rb:2 and dups.rb:5.')
+        'Method `A#some_method` is defined at both dups.rb:2 and dups.rb:5.'
+      )
     end
 
     it 'registers an offense for a duplicate instance method in separate ' \
@@ -212,7 +214,8 @@ describe RuboCop::Cop::Lint::DuplicateMethods do
                       'end'], 'test.rb')
       expect(cop.offenses.size).to eq(1)
       expect(cop.messages).to eq(
-        ['Method `A.some_method` is defined at both test.rb:3 and test.rb:6.'])
+        ['Method `A.some_method` is defined at both test.rb:3 and test.rb:6.']
+      )
     end
 
     it 'understands nested modules' do
@@ -235,7 +238,8 @@ describe RuboCop::Cop::Lint::DuplicateMethods do
       expect(cop.messages).to eq(
         ['Method `B::A#some_method` is defined at both test.rb:3 and ' \
          'test.rb:6.',
-         'Method `B::A.another` is defined at both test.rb:9 and test.rb:11.'])
+         'Method `B::A.another` is defined at both test.rb:9 and test.rb:11.']
+      )
     end
 
     it "doesn't register an offense when class << exp is used" do
@@ -271,7 +275,8 @@ describe RuboCop::Cop::Lint::DuplicateMethods do
     expect(cop.offenses.size).to eq(1)
     expect(cop.messages).to eq(
       ['Method `Object#some_method` is defined at both toplevel.rb:1 and ' \
-       'toplevel.rb:4.'])
+       'toplevel.rb:4.']
+    )
   end
 
   it 'understands class << A' do
@@ -286,7 +291,8 @@ describe RuboCop::Cop::Lint::DuplicateMethods do
                     'end'], 'test.rb')
     expect(cop.offenses.size).to eq(1)
     expect(cop.messages).to eq(
-      ['Method `A.some_method` is defined at both test.rb:2 and test.rb:5.'])
+      ['Method `A.some_method` is defined at both test.rb:2 and test.rb:5.']
+    )
   end
 
   it 'handles class_eval with implicit receiver' do
@@ -302,7 +308,8 @@ describe RuboCop::Cop::Lint::DuplicateMethods do
                          'end'], 'test.rb')
     expect(cop.offenses.size).to eq(1)
     expect(cop.messages).to eq(
-      ['Method `A#some_method` is defined at both test.rb:3 and test.rb:6.'])
+      ['Method `A#some_method` is defined at both test.rb:3 and test.rb:6.']
+    )
   end
 
   it 'ignores method definitions in RSpec `describe` blocks' do

--- a/spec/rubocop/cop/lint/format_parameter_mismatch_spec.rb
+++ b/spec/rubocop/cop/lint/format_parameter_mismatch_spec.rb
@@ -41,7 +41,8 @@ describe RuboCop::Cop::Lint::FormatParameterMismatch do
     expect(cop.offenses.size).to eq(1)
     expect(cop.messages).to eq(
       ["Number of arguments (1) to `format` doesn't match the number of " \
-       'fields (2).'])
+       'fields (2).']
+    )
   end
 
   it 'registers an offense when calling Kernel.sprintf ' \
@@ -50,7 +51,8 @@ describe RuboCop::Cop::Lint::FormatParameterMismatch do
     expect(cop.offenses.size).to eq(1)
     expect(cop.messages).to eq(
       ["Number of arguments (1) to `sprintf` doesn't match the number of " \
-       'fields (2).'])
+       'fields (2).']
+    )
   end
 
   it 'registers an offense when there are less arguments than expected' do
@@ -58,7 +60,8 @@ describe RuboCop::Cop::Lint::FormatParameterMismatch do
     expect(cop.offenses.size).to eq(1)
     expect(cop.messages).to eq(
       ["Number of arguments (1) to `format` doesn't match the number of " \
-       'fields (2).'])
+       'fields (2).']
+    )
   end
 
   it 'registers an offense when there are more arguments than expected' do
@@ -66,7 +69,8 @@ describe RuboCop::Cop::Lint::FormatParameterMismatch do
     expect(cop.offenses.size).to eq(1)
     expect(cop.messages).to eq(
       ["Number of arguments (3) to `format` doesn't match the number of " \
-       'fields (2).'])
+       'fields (2).']
+    )
   end
 
   it 'does not register an offense when arguments and fields match' do
@@ -89,7 +93,8 @@ describe RuboCop::Cop::Lint::FormatParameterMismatch do
     expect(cop.offenses.size).to eq(1)
     expect(cop.messages).to eq(
       ["Number of arguments (3) to `sprintf` doesn't match the number of " \
-       'fields (2).'])
+       'fields (2).']
+    )
   end
 
   it 'correctly parses different sprintf formats' do
@@ -103,7 +108,8 @@ describe RuboCop::Cop::Lint::FormatParameterMismatch do
     expect(cop.offenses.size).to eq(1)
     expect(cop.messages).to eq(
       ["Number of arguments (3) to `String#%` doesn't match the number of " \
-       'fields (2).'])
+       'fields (2).']
+    )
   end
 
   it 'does not register offense for `String#%` when arguments, fields match' do

--- a/spec/rubocop/cop/lint/ineffective_access_modifier_spec.rb
+++ b/spec/rubocop/cop/lint/ineffective_access_modifier_spec.rb
@@ -26,7 +26,8 @@ describe RuboCop::Cop::Lint::IneffectiveAccessModifier do
       expect(cop.messages).to eq(
         ['`private` (on line 2) does not make singleton methods private. ' \
          'Use `private_class_method` or `private` inside a `class << self` ' \
-         'block instead.'])
+         'block instead.']
+      )
       expect(cop.highlights).to eq(['def'])
     end
   end
@@ -46,7 +47,8 @@ describe RuboCop::Cop::Lint::IneffectiveAccessModifier do
       expect(cop.offenses.size).to eq(1)
       expect(cop.messages).to eq(
         ['`protected` (on line 2) does not make singleton methods protected. ' \
-         'Use `protected` inside a `class << self` block instead.'])
+         'Use `protected` inside a `class << self` block instead.']
+      )
       expect(cop.highlights).to eq(['def'])
     end
   end
@@ -107,7 +109,8 @@ describe RuboCop::Cop::Lint::IneffectiveAccessModifier do
       expect(cop.messages).to eq(
         ['`private` (on line 3) does not make singleton methods private. ' \
          'Use `private_class_method` or `private` inside a `class << self` ' \
-         'block instead.'])
+         'block instead.']
+      )
       expect(cop.highlights).to eq(['def'])
     end
   end

--- a/spec/rubocop/cop/lint/syntax_spec.rb
+++ b/spec/rubocop/cop/lint/syntax_spec.rb
@@ -26,7 +26,8 @@ describe RuboCop::Cop::Lint::Syntax do
       expect(offense.message).to eq(
         ['odd number of entries for a hash',
          '(Using Ruby 2.0 parser; configure using `TargetRubyVersion` ' \
-         'parameter, under `AllCops`)'].join("\n"))
+         'parameter, under `AllCops`)'].join("\n")
+      )
     end
 
     it "sets diagnostic's location to offense's location" do

--- a/spec/rubocop/cop/lint/unneeded_disable_spec.rb
+++ b/spec/rubocop/cop/lint/unneeded_disable_spec.rb
@@ -152,7 +152,8 @@ describe RuboCop::Cop::Lint::UnneededDisable do
 
             it 'autocorrects' do
               expect(corrected_source).to eq(
-                '# rubocop:disable Metrics/ClassLength')
+                '# rubocop:disable Metrics/ClassLength'
+              )
             end
           end
 
@@ -181,7 +182,8 @@ describe RuboCop::Cop::Lint::UnneededDisable do
 
             it 'autocorrects' do
               expect(corrected_source).to eq(
-                '# rubocop:disable Metrics/MethodLength')
+                '# rubocop:disable Metrics/MethodLength'
+              )
             end
           end
 
@@ -234,7 +236,8 @@ describe RuboCop::Cop::Lint::UnneededDisable do
 
               it 'registers an offense' do
                 expect(cop.messages).to eq(
-                  ['Unnecessary disabling of `Metrics/ClassLength`.'])
+                  ['Unnecessary disabling of `Metrics/ClassLength`.']
+                )
                 expect(cop.highlights).to eq(['ClassLength'])
               end
             end

--- a/spec/rubocop/cop/lint/unused_method_argument_spec.rb
+++ b/spec/rubocop/cop/lint/unused_method_argument_spec.rb
@@ -48,7 +48,8 @@ describe RuboCop::Cop::Lint::UnusedMethodArgument, :config do
             "If it's necessary, use `_` or `_foo` " \
             "as an argument name to indicate that it won't be used. " \
             'You can also write as `some_method(*)` if you want the method ' \
-            "to accept any arguments but don't care about them.")
+            "to accept any arguments but don't care about them."
+          )
         end
       end
     end

--- a/spec/rubocop/cop/metrics/block_nesting_spec.rb
+++ b/spec/rubocop/cop/metrics/block_nesting_spec.rb
@@ -149,7 +149,8 @@ describe RuboCop::Cop::Metrics::BlockNesting, :config do
     inspect_source(cop, source)
     expect(cop.offenses.map(&:line)).to eq(lines)
     expect(cop.messages).to eq(
-      ['Avoid more than 2 levels of block nesting.'] * lines.length)
+      ['Avoid more than 2 levels of block nesting.'] * lines.length
+    )
     return if cop.offenses.empty?
 
     expect(cop.config_to_allow_offenses['Max']).to eq(max_to_allow)

--- a/spec/rubocop/cop/performance/detect_spec.rb
+++ b/spec/rubocop/cop/performance/detect_spec.rb
@@ -132,7 +132,8 @@ describe RuboCop::Cop::Performance::Detect do
           it "corrects #{method}.first to #{preferred_method} (with block)" do
             new_source = autocorrect_source(
               cop,
-              "[1, 2, 3].#{method} { |i| i % 2 == 0 }.first")
+              "[1, 2, 3].#{method} { |i| i % 2 == 0 }.first"
+            )
 
             expect(new_source).to eq(
               "[1, 2, 3].#{preferred_method} { |i| i % 2 == 0 }"
@@ -143,7 +144,8 @@ describe RuboCop::Cop::Performance::Detect do
              '(with block)' do
             new_source = autocorrect_source(
               cop,
-              "[1, 2, 3].#{method} { |i| i % 2 == 0 }.last")
+              "[1, 2, 3].#{method} { |i| i % 2 == 0 }.last"
+            )
 
             expect(new_source).to eq(
               "[1, 2, 3].reverse.#{preferred_method} { |i| i % 2 == 0 }"
@@ -153,7 +155,8 @@ describe RuboCop::Cop::Performance::Detect do
           it "corrects #{method}.first to #{preferred_method} (short syntax)" do
             new_source = autocorrect_source(
               cop,
-              "[1, 2, 3].#{method}(&:even?).first")
+              "[1, 2, 3].#{method}(&:even?).first"
+            )
 
             expect(new_source).to eq("[1, 2, 3].#{preferred_method}(&:even?)")
           end
@@ -162,7 +165,8 @@ describe RuboCop::Cop::Performance::Detect do
              '(short syntax)' do
             new_source = autocorrect_source(
               cop,
-              "[1, 2, 3].#{method}(&:even?).last")
+              "[1, 2, 3].#{method}(&:even?).last"
+            )
 
             expect(new_source)
               .to eq("[1, 2, 3].reverse.#{preferred_method}(&:even?)")

--- a/spec/rubocop/cop/performance/range_include_spec.rb
+++ b/spec/rubocop/cop/performance/range_include_spec.rb
@@ -29,6 +29,7 @@ describe RuboCop::Cop::Performance::RangeInclude do
   it 'formats the error message correctly for (a..b).include? 1' do
     inspect_source(cop, '(a..b).include? 1')
     expect(cop.messages).to eq(
-      ['Use `Range#cover?` instead of `Range#include?`.'])
+      ['Use `Range#cover?` instead of `Range#include?`.']
+    )
   end
 end

--- a/spec/rubocop/cop/performance/redundant_merge_spec.rb
+++ b/spec/rubocop/cop/performance/redundant_merge_spec.rb
@@ -134,7 +134,8 @@ describe RuboCop::Cop::Performance::RedundantMerge, :config do
         new_source = autocorrect_source(
           cop,
           ['hash = {}',
-           "hash.merge!(a: 1, b: 2) #{kw} condition1 && condition2"])
+           "hash.merge!(a: 1, b: 2) #{kw} condition1 && condition2"]
+        )
         expect(new_source).to eq(['hash = {}',
                                   "#{kw} condition1 && condition2",
                                   '  hash[:a] = 1',
@@ -149,7 +150,8 @@ describe RuboCop::Cop::Performance::RedundantMerge, :config do
             ['hash = {}',
              'begin',
              "  hash.merge!(a: 1, b: 2) #{kw} condition1",
-             'end'])
+             'end']
+          )
           expect(new_source).to eq(['hash = {}',
                                     'begin',
                                     "  #{kw} condition1",
@@ -185,7 +187,8 @@ describe RuboCop::Cop::Performance::RedundantMerge, :config do
   it 'formats the error message correctly for hash.merge!(a: 1)' do
     inspect_source(cop, 'hash.merge!(a: 1)')
     expect(cop.messages).to eq(
-      ['Use `hash[:a] = 1` instead of `hash.merge!(a: 1)`.'])
+      ['Use `hash[:a] = 1` instead of `hash.merge!(a: 1)`.']
+    )
   end
 
   context 'with MaxKeyValuePairs of 1' do

--- a/spec/rubocop/cop/rails/pluralization_grammar_spec.rb
+++ b/spec/rubocop/cop/rails/pluralization_grammar_spec.rb
@@ -34,7 +34,8 @@ describe RuboCop::Cop::Rails::PluralizationGrammar do
           expect(cop.offenses.size).to eq(1)
           expect(cop.highlights).to eq(["#{singular_literal}.#{method_name}s"])
           expect(cop.messages).to eq(
-            ["Prefer `#{singular_literal}.#{method_name}`."])
+            ["Prefer `#{singular_literal}.#{method_name}`."]
+          )
         end
 
         it 'autocorrects to be grammatically correct' do
@@ -71,7 +72,8 @@ describe RuboCop::Cop::Rails::PluralizationGrammar do
             expect(cop.offenses.size).to eq(1)
             expect(cop.highlights).to eq(["#{plural_number}.#{method_name}"])
             expect(cop.messages).to eq(
-              ["Prefer `#{plural_number}.#{method_name}s`."])
+              ["Prefer `#{plural_number}.#{method_name}s`."]
+            )
           end
 
           it 'autocorrects to be grammatically correct' do

--- a/spec/rubocop/cop/style/and_or_spec.rb
+++ b/spec/rubocop/cop/style/and_or_spec.rb
@@ -357,7 +357,8 @@ describe RuboCop::Cop::Style::AndOr, :config do
         new_source = autocorrect_source(cop, source)
         expect(new_source).to eq(
           ["APP_ROOT = Pathname.new File.expand_path('../../', __FILE__)",
-           "system('bundle check') || system!('bundle install')"].join("\n"))
+           "system('bundle check') || system!('bundle install')"].join("\n")
+        )
       end
     end
   end

--- a/spec/rubocop/cop/style/block_delimiters_spec.rb
+++ b/spec/rubocop/cop/style/block_delimiters_spec.rb
@@ -374,7 +374,8 @@ describe RuboCop::Cop::Style::BlockDelimiters, :config do
       inspect_source(cop, ['each do |x|',
                            'end.map(&:to_s)'])
       expect(cop.messages).to eq(
-        ['Prefer `{...}` over `do...end` for multi-line chained blocks.'])
+        ['Prefer `{...}` over `do...end` for multi-line chained blocks.']
+      )
     end
 
     it 'auto-corrects do-end for chained blocks' do

--- a/spec/rubocop/cop/style/encoding_spec.rb
+++ b/spec/rubocop/cop/style/encoding_spec.rb
@@ -24,7 +24,8 @@ describe RuboCop::Cop::Style::Encoding, :config do
 
       expect(cop.offenses.size).to eq(1)
       expect(cop.messages).to eq(
-        ['Missing utf-8 encoding comment.'])
+        ['Missing utf-8 encoding comment.']
+      )
     end
 
     it 'registers an offense when encoding present but only ASCII ' \
@@ -34,7 +35,8 @@ describe RuboCop::Cop::Style::Encoding, :config do
 
       expect(cop.offenses.size).to eq(1)
       expect(cop.messages).to eq(
-        ['Unnecessary utf-8 encoding comment.'])
+        ['Unnecessary utf-8 encoding comment.']
+      )
     end
 
     it 'accepts an empty file' do
@@ -64,7 +66,8 @@ describe RuboCop::Cop::Style::Encoding, :config do
 
       expect(cop.offenses.size).to eq(1)
       expect(cop.messages).to eq(
-        ['Missing utf-8 encoding comment.'])
+        ['Missing utf-8 encoding comment.']
+      )
     end
 
     it 'accepts encoding inserted by magic_encoding gem' do
@@ -107,7 +110,8 @@ describe RuboCop::Cop::Style::Encoding, :config do
 
       expect(cop.offenses.size).to eq(1)
       expect(cop.messages).to eq(
-        ['Missing utf-8 encoding comment.'])
+        ['Missing utf-8 encoding comment.']
+      )
     end
 
     it 'accepts an empty file' do
@@ -137,7 +141,8 @@ describe RuboCop::Cop::Style::Encoding, :config do
 
       expect(cop.offenses.size).to eq(1)
       expect(cop.messages).to eq(
-        ['Missing utf-8 encoding comment.'])
+        ['Missing utf-8 encoding comment.']
+      )
     end
 
     it 'accepts encoding inserted by magic_encoding gem' do

--- a/spec/rubocop/cop/style/extra_spacing_spec.rb
+++ b/spec/rubocop/cop/style/extra_spacing_spec.rb
@@ -235,7 +235,8 @@ describe RuboCop::Cop::Style::ExtraSpacing, :config do
       expect(cop.messages).to eq(
         ['`=` is not aligned with the following assignment.',
          '`=` is not aligned with the preceding assignment.',
-         '`=` is not aligned with the preceding assignment.'])
+         '`=` is not aligned with the preceding assignment.']
+      )
     end
 
     it 'does not register an offense if assignments are separated by blanks' do

--- a/spec/rubocop/cop/style/file_name_spec.rb
+++ b/spec/rubocop/cop/style/file_name_spec.rb
@@ -274,7 +274,8 @@ describe RuboCop::Cop::Style::FileName do
       it 'registers an offense' do
         expect(cop.offenses.size).to eq(1)
         expect(cop.messages).to eq(
-          ['`z.rb` should match `(?i-mx:\\A[aeiou]\\z)`.'])
+          ['`z.rb` should match `(?i-mx:\\A[aeiou]\\z)`.']
+        )
       end
     end
   end

--- a/spec/rubocop/cop/style/first_array_element_line_break_spec.rb
+++ b/spec/rubocop/cop/style/first_array_element_line_break_spec.rb
@@ -67,7 +67,8 @@ describe RuboCop::Cop::Style::FirstArrayElementLineBreak do
       expect(new_source).to eq(
         "method([\n" \
         ":foo,\n" \
-        '        :bar])')
+        '        :bar])'
+      )
     end
   end
 
@@ -135,7 +136,8 @@ describe RuboCop::Cop::Style::FirstArrayElementLineBreak do
       ['a, b,',
        'c =',
        '1, 2,',
-       '3'])
+       '3']
+    )
 
     expect(cop.offenses).to be_empty
   end
@@ -153,7 +155,8 @@ describe RuboCop::Cop::Style::FirstArrayElementLineBreak do
       cop,
       ['b = [',
        '  :a,',
-       '  :b]'])
+       '  :b]']
+    )
 
     expect(cop.offenses).to be_empty
   end

--- a/spec/rubocop/cop/style/first_hash_element_line_break_spec.rb
+++ b/spec/rubocop/cop/style/first_hash_element_line_break_spec.rb
@@ -26,7 +26,8 @@ describe RuboCop::Cop::Style::FirstHashElementLineBreak do
       expect(new_source).to eq(
         "a = { \n" \
         "a: 1,\n" \
-        '      b: 2}')
+        '      b: 2}'
+      )
     end
   end
 
@@ -50,7 +51,8 @@ describe RuboCop::Cop::Style::FirstHashElementLineBreak do
       expect(new_source).to eq(
         "method({ \n" \
         "foo: 1,\n" \
-        '         bar: 2 })')
+        '         bar: 2 })'
+      )
     end
   end
 
@@ -59,7 +61,8 @@ describe RuboCop::Cop::Style::FirstHashElementLineBreak do
       cop,
       ['method(',
        '  foo: 1,',
-       '  bar: 2)'])
+       '  bar: 2)']
+    )
 
     expect(cop.offenses).to be_empty
   end
@@ -68,7 +71,8 @@ describe RuboCop::Cop::Style::FirstHashElementLineBreak do
     inspect_source(
       cop,
       ['method foo: 1,',
-       ' bar:2'])
+       ' bar:2']
+    )
 
     expect(cop.offenses).to be_empty
   end
@@ -78,7 +82,8 @@ describe RuboCop::Cop::Style::FirstHashElementLineBreak do
     inspect_source(
       cop,
       ['method(foo: 1,',
-       '  bar: 2)'])
+       '  bar: 2)']
+    )
 
     expect(cop.offenses).to be_empty
   end
@@ -88,7 +93,8 @@ describe RuboCop::Cop::Style::FirstHashElementLineBreak do
       cop,
       ['b = {',
        '  a: 1,',
-       '  b: 2}'])
+       '  b: 2}']
+    )
 
     expect(cop.offenses).to be_empty
   end

--- a/spec/rubocop/cop/style/first_method_argument_line_break_spec.rb
+++ b/spec/rubocop/cop/style/first_method_argument_line_break_spec.rb
@@ -26,7 +26,8 @@ describe RuboCop::Cop::Style::FirstMethodArgumentLineBreak do
       expect(new_source).to eq(
         "foo(\n" \
         "bar,\n" \
-        '  baz)')
+        '  baz)'
+      )
     end
   end
 
@@ -50,7 +51,8 @@ describe RuboCop::Cop::Style::FirstMethodArgumentLineBreak do
       expect(new_source).to eq(
         "something(\n" \
         "3, bar: 1,\n" \
-        'baz: 2)')
+        'baz: 2)'
+      )
     end
   end
 
@@ -74,7 +76,8 @@ describe RuboCop::Cop::Style::FirstMethodArgumentLineBreak do
       expect(new_source).to eq(
         "something(\n" \
         "bar: 1,\n" \
-        'baz: 2)')
+        'baz: 2)'
+      )
     end
   end
 
@@ -88,7 +91,8 @@ describe RuboCop::Cop::Style::FirstMethodArgumentLineBreak do
     inspect_source(
       cop,
       ['foo bar,',
-       '  baz'])
+       '  baz']
+    )
 
     expect(cop.offenses).to be_empty
   end

--- a/spec/rubocop/cop/style/first_method_parameter_line_break_spec.rb
+++ b/spec/rubocop/cop/style/first_method_parameter_line_break_spec.rb
@@ -30,7 +30,8 @@ describe RuboCop::Cop::Style::FirstMethodParameterLineBreak do
         "bar,\n" \
         "  baz)\n" \
         "  do_something\n" \
-        'end')
+        'end'
+      )
     end
   end
 
@@ -58,7 +59,8 @@ describe RuboCop::Cop::Style::FirstMethodParameterLineBreak do
         "bar,\n" \
         "  baz)\n" \
         "  do_something\n" \
-        'end')
+        'end'
+      )
     end
   end
 
@@ -67,7 +69,8 @@ describe RuboCop::Cop::Style::FirstMethodParameterLineBreak do
       cop,
       ['def foo(bar, baz, bing)',
        '  do_something',
-       'end'])
+       'end']
+    )
 
     expect(cop.offenses).to be_empty
   end
@@ -78,7 +81,8 @@ describe RuboCop::Cop::Style::FirstMethodParameterLineBreak do
       ['def foo bar,',
        '  baz',
        '  do_something',
-       'end'])
+       'end']
+    )
 
     expect(cop.offenses).to be_empty
   end
@@ -86,7 +90,8 @@ describe RuboCop::Cop::Style::FirstMethodParameterLineBreak do
   it 'ignores single-line methods' do
     inspect_source(
       cop,
-      'def foo(bar, baz) ; bing ; end')
+      'def foo(bar, baz) ; bing ; end'
+    )
 
     expect(cop.offenses).to be_empty
   end
@@ -96,7 +101,8 @@ describe RuboCop::Cop::Style::FirstMethodParameterLineBreak do
       cop,
       ['def foo',
        '  bing',
-       'end'])
+       'end']
+    )
 
     expect(cop.offenses).to be_empty
   end
@@ -125,7 +131,8 @@ describe RuboCop::Cop::Style::FirstMethodParameterLineBreak do
         "bar = [],\n" \
         "  baz = 2)\n" \
         "  do_something\n" \
-        'end')
+        'end'
+      )
     end
   end
 end

--- a/spec/rubocop/cop/style/if_inside_else_spec.rb
+++ b/spec/rubocop/cop/style/if_inside_else_spec.rb
@@ -16,7 +16,8 @@ describe RuboCop::Cop::Style::IfInsideElse do
                          'end'])
     expect(cop.offenses.size).to eq(1)
     expect(cop.messages).to eq(
-      ['Convert `if` nested inside `else` to `elsif`.'])
+      ['Convert `if` nested inside `else` to `elsif`.']
+    )
     expect(cop.highlights).to eq(['if'])
   end
 
@@ -32,7 +33,8 @@ describe RuboCop::Cop::Style::IfInsideElse do
                          'end'])
     expect(cop.offenses.size).to eq(1)
     expect(cop.messages).to eq(
-      ['Convert `if` nested inside `else` to `elsif`.'])
+      ['Convert `if` nested inside `else` to `elsif`.']
+    )
     expect(cop.highlights).to eq(['if'])
   end
 
@@ -44,7 +46,8 @@ describe RuboCop::Cop::Style::IfInsideElse do
                          'end'])
     expect(cop.offenses.size).to eq(1)
     expect(cop.messages).to eq(
-      ['Convert `if` nested inside `else` to `elsif`.'])
+      ['Convert `if` nested inside `else` to `elsif`.']
+    )
     expect(cop.highlights).to eq(['if'])
   end
 

--- a/spec/rubocop/cop/style/if_unless_modifier_spec.rb
+++ b/spec/rubocop/cop/style/if_unless_modifier_spec.rb
@@ -32,7 +32,8 @@ describe RuboCop::Cop::Style::IfUnlessModifier do
       expect(cop.messages).to eq(
         ['Favor modifier `if` usage when having a single-line' \
          ' body. Another good alternative is the usage of control flow' \
-         ' `&&`/`||`.'])
+         ' `&&`/`||`.']
+      )
     end
 
     it 'does auto-correction' do
@@ -66,7 +67,8 @@ describe RuboCop::Cop::Style::IfUnlessModifier do
       expect(cop.messages).to eq(
         ['Favor modifier `if` usage when having a single-line' \
          ' body. Another good alternative is the usage of control flow' \
-         ' `&&`/`||`.'])
+         ' `&&`/`||`.']
+      )
     end
 
     it 'does auto-correction and preserves comment' do
@@ -150,7 +152,8 @@ describe RuboCop::Cop::Style::IfUnlessModifier do
       expect(cop.messages).to eq(
         ['Favor modifier `unless` usage when having a single-line' \
          ' body. Another good alternative is the usage of control flow' \
-         ' `&&`/`||`.'])
+         ' `&&`/`||`.']
+      )
     end
 
     it 'does auto-correction' do

--- a/spec/rubocop/cop/style/if_with_semicolon_spec.rb
+++ b/spec/rubocop/cop/style/if_with_semicolon_spec.rb
@@ -9,7 +9,8 @@ describe RuboCop::Cop::Style::IfWithSemicolon do
   it 'registers an offense for one line if/;/end' do
     inspect_source(cop, 'if cond; run else dont end')
     expect(cop.messages).to eq(
-      ['Do not use if x; Use the ternary operator instead.'])
+      ['Do not use if x; Use the ternary operator instead.']
+    )
   end
 
   it 'accepts one line if/then/end' do

--- a/spec/rubocop/cop/style/indent_array_spec.rb
+++ b/spec/rubocop/cop/style/indent_array_spec.rb
@@ -12,7 +12,8 @@ describe RuboCop::Cop::Style::IndentArray do
     }
     RuboCop::Config.new('Style/IndentArray' =>
                         cop_config.merge(supported_styles).merge(
-                          'IndentationWidth' => cop_indent),
+                          'IndentationWidth' => cop_indent
+                        ),
                         'Style/IndentationWidth' => { 'Width' => 2 })
   end
   let(:cop_config) { { 'EnforcedStyle' => 'special_inside_parentheses' } }

--- a/spec/rubocop/cop/style/indent_assignment_spec.rb
+++ b/spec/rubocop/cop/style/indent_assignment_spec.rb
@@ -64,7 +64,8 @@ describe RuboCop::Cop::Style::IndentAssignment, :config do
   it 'auto-corrects indentation' do
     new_source = autocorrect_source(
       cop, ['a =',
-            'if b ; end'])
+            'if b ; end']
+    )
 
     expect(new_source)
       .to eq(['a =',
@@ -84,7 +85,8 @@ describe RuboCop::Cop::Style::IndentAssignment, :config do
     it 'auto-corrects indentation' do
       new_source = autocorrect_source(
         cop, ['a =',
-              '  if b ; end'])
+              '  if b ; end']
+      )
 
       expect(new_source)
         .to eq(['a =',

--- a/spec/rubocop/cop/style/indent_hash_spec.rb
+++ b/spec/rubocop/cop/style/indent_hash_spec.rb
@@ -13,7 +13,8 @@ describe RuboCop::Cop::Style::IndentHash do
     RuboCop::Config.new('Style/AlignHash' => align_hash_config,
                         'Style/IndentHash' =>
                         cop_config.merge(supported_styles).merge(
-                          'IndentationWidth' => cop_indent),
+                          'IndentationWidth' => cop_indent
+                        ),
                         'Style/IndentationWidth' => { 'Width' => 2 })
   end
   let(:align_hash_config) do

--- a/spec/rubocop/cop/style/multiline_if_then_spec.rb
+++ b/spec/rubocop/cop/style/multiline_if_then_spec.rb
@@ -93,7 +93,8 @@ describe RuboCop::Cop::Style::MultilineIfThen do
     inspect_source(cop, ['unless cond then',
                          'end'])
     expect(cop.messages).to eq(
-      ['Do not use `then` for multi-line `unless`.'])
+      ['Do not use `then` for multi-line `unless`.']
+    )
   end
 
   it 'accepts multiline unless without then' do

--- a/spec/rubocop/cop/style/negated_if_spec.rb
+++ b/spec/rubocop/cop/style/negated_if_spec.rb
@@ -14,7 +14,8 @@ describe RuboCop::Cop::Style::NegatedIf do
                     'some_method if !a_condition'])
     expect(cop.messages).to eq(
       ['Favor `unless` over `if` for negative ' \
-       'conditions.'] * 2)
+       'conditions.'] * 2
+    )
   end
 
   it 'registers an offense for unless with exclamation point condition' do
@@ -35,7 +36,8 @@ describe RuboCop::Cop::Style::NegatedIf do
                     'some_method if not a_condition'])
     expect(cop.messages).to eq(
       ['Favor `unless` over `if` for negative ' \
-       'conditions.'] * 2)
+       'conditions.'] * 2
+    )
     expect(cop.offenses.map(&:line)).to eq([1, 4])
   end
 

--- a/spec/rubocop/cop/style/negated_while_spec.rb
+++ b/spec/rubocop/cop/style/negated_while_spec.rb
@@ -13,7 +13,8 @@ describe RuboCop::Cop::Style::NegatedWhile do
                     'end',
                     'some_method while !a_condition'])
     expect(cop.messages).to eq(
-      ['Favor `until` over `while` for negative conditions.'] * 2)
+      ['Favor `until` over `while` for negative conditions.'] * 2
+    )
   end
 
   it 'registers an offense for until with exclamation point condition' do
@@ -33,7 +34,8 @@ describe RuboCop::Cop::Style::NegatedWhile do
                     'end',
                     'some_method while not a_condition'])
     expect(cop.messages).to eq(
-      ['Favor `until` over `while` for negative conditions.'] * 2)
+      ['Favor `until` over `while` for negative conditions.'] * 2
+    )
     expect(cop.offenses.map(&:line)).to eq([1, 4])
   end
 

--- a/spec/rubocop/cop/style/nested_parenthesized_calls_spec.rb
+++ b/spec/rubocop/cop/style/nested_parenthesized_calls_spec.rb
@@ -41,7 +41,8 @@ describe RuboCop::Cop::Style::NestedParenthesizedCalls do
       it 'registers an offense' do
         expect(cop.offenses.size).to eq(1)
         expect(cop.messages).to eq(
-          ['Add parentheses to nested method call `compute something`.'])
+          ['Add parentheses to nested method call `compute something`.']
+        )
         expect(cop.highlights).to eq(['compute something'])
       end
 
@@ -57,7 +58,8 @@ describe RuboCop::Cop::Style::NestedParenthesizedCalls do
       it 'registers an offense' do
         expect(cop.offenses.size).to eq(1)
         expect(cop.messages).to eq(
-          ['Add parentheses to nested method call `compute first, second`.'])
+          ['Add parentheses to nested method call `compute first, second`.']
+        )
         expect(cop.highlights).to eq(['compute first, second'])
       end
 

--- a/spec/rubocop/cop/style/percent_literal_delimiters_spec.rb
+++ b/spec/rubocop/cop/style/percent_literal_delimiters_spec.rb
@@ -31,7 +31,8 @@ describe RuboCop::Cop::Style::PercentLiteralDelimiters, :config do
     it 'registers an offense for other delimiters' do
       inspect_source(cop, '%(string)')
       expect(cop.messages).to eq(
-        ['`%`-literals should be delimited by `[` and `]`.'])
+        ['`%`-literals should be delimited by `[` and `]`.']
+      )
     end
 
     it 'does not register an offense for other delimiters ' \
@@ -56,7 +57,8 @@ describe RuboCop::Cop::Style::PercentLiteralDelimiters, :config do
     it 'registers an offense for other delimiters' do
       inspect_source(cop, '%q(string)')
       expect(cop.messages).to eq(
-        ['`%q`-literals should be delimited by `[` and `]`.'])
+        ['`%q`-literals should be delimited by `[` and `]`.']
+      )
     end
 
     it 'does not register an offense for other delimiters ' \
@@ -75,7 +77,8 @@ describe RuboCop::Cop::Style::PercentLiteralDelimiters, :config do
     it 'registers an offense for other delimiters' do
       inspect_source(cop, '%Q(string)')
       expect(cop.messages).to eq(
-        ['`%Q`-literals should be delimited by `[` and `]`.'])
+        ['`%Q`-literals should be delimited by `[` and `]`.']
+      )
     end
 
     it 'does not register an offense for other delimiters ' \
@@ -100,7 +103,8 @@ describe RuboCop::Cop::Style::PercentLiteralDelimiters, :config do
     it 'registers an offense for other delimiters' do
       inspect_source(cop, '%w(some words)')
       expect(cop.messages).to eq(
-        ['`%w`-literals should be delimited by `[` and `]`.'])
+        ['`%w`-literals should be delimited by `[` and `]`.']
+      )
     end
 
     it 'does not register an offense for other delimiters ' \
@@ -119,7 +123,8 @@ describe RuboCop::Cop::Style::PercentLiteralDelimiters, :config do
     it 'registers an offense for other delimiters' do
       inspect_source(cop, '%W(some words)')
       expect(cop.messages).to eq(
-        ['`%W`-literals should be delimited by `[` and `]`.'])
+        ['`%W`-literals should be delimited by `[` and `]`.']
+      )
     end
 
     it 'does not register an offense for other delimiters ' \
@@ -144,7 +149,8 @@ describe RuboCop::Cop::Style::PercentLiteralDelimiters, :config do
     it 'registers an offense for other delimiters' do
       inspect_source(cop, '%r(regexp)')
       expect(cop.messages).to eq(
-        ['`%r`-literals should be delimited by `[` and `]`.'])
+        ['`%r`-literals should be delimited by `[` and `]`.']
+      )
     end
 
     it 'does not register an offense for other delimiters ' \
@@ -169,7 +175,8 @@ describe RuboCop::Cop::Style::PercentLiteralDelimiters, :config do
     it 'registers an offense for other delimiters' do
       inspect_source(cop, '%i(some symbols)')
       expect(cop.messages).to eq(
-        ['`%i`-literals should be delimited by `[` and `]`.'])
+        ['`%i`-literals should be delimited by `[` and `]`.']
+      )
     end
   end
 
@@ -182,7 +189,8 @@ describe RuboCop::Cop::Style::PercentLiteralDelimiters, :config do
     it 'registers an offense for other delimiters' do
       inspect_source(cop, '%s(symbol)')
       expect(cop.messages).to eq(
-        ['`%s`-literals should be delimited by `[` and `]`.'])
+        ['`%s`-literals should be delimited by `[` and `]`.']
+      )
     end
   end
 
@@ -195,7 +203,8 @@ describe RuboCop::Cop::Style::PercentLiteralDelimiters, :config do
     it 'registers an offense for other delimiters' do
       inspect_source(cop, '%x(command)')
       expect(cop.messages).to eq(
-        ['`%x`-literals should be delimited by `[` and `]`.'])
+        ['`%x`-literals should be delimited by `[` and `]`.']
+      )
     end
 
     it 'does not register an offense for other delimiters ' \

--- a/spec/rubocop/cop/style/single_line_methods_spec.rb
+++ b/spec/rubocop/cop/style/single_line_methods_spec.rb
@@ -17,7 +17,8 @@ describe RuboCop::Cop::Style::SingleLineMethods do
                     'def link_to(name, url); {:name => name}; end',
                     'def @table.columns; super; end'])
     expect(cop.messages).to eq(
-      ['Avoid single-line method definitions.'] * 3)
+      ['Avoid single-line method definitions.'] * 3
+    )
   end
 
   context 'when AllowIfMethodIsEmpty is disabled' do

--- a/spec/rubocop/cop/style/space_after_comma_spec.rb
+++ b/spec/rubocop/cop/style/space_after_comma_spec.rb
@@ -10,7 +10,8 @@ describe RuboCop::Cop::Style::SpaceAfterComma do
     it 'registers an offense' do
       inspect_source(cop, source.call(items))
       expect(cop.messages).to eq(
-        ['Space missing after comma.'])
+        ['Space missing after comma.']
+      )
     end
 
     it 'does auto-correction' do

--- a/spec/rubocop/cop/style/space_after_semicolon_spec.rb
+++ b/spec/rubocop/cop/style/space_after_semicolon_spec.rb
@@ -13,7 +13,8 @@ describe RuboCop::Cop::Style::SpaceAfterSemicolon do
   it 'registers an offense for semicolon without space after it' do
     inspect_source(cop, 'x = 1;y = 2')
     expect(cop.messages).to eq(
-      ['Space missing after semicolon.'])
+      ['Space missing after semicolon.']
+    )
   end
 
   it 'does not crash if semicolon is the last character of the file' do

--- a/spec/rubocop/cop/style/space_around_operators_spec.rb
+++ b/spec/rubocop/cop/style/space_around_operators_spec.rb
@@ -41,7 +41,8 @@ describe RuboCop::Cop::Style::SpaceAroundOperators do
   it 'accepts exclamation point negation' do
     inspect_source(cop, 'x = !a&&!b')
     expect(cop.messages).to eq(
-      ['Surrounding space missing for operator `&&`.'])
+      ['Surrounding space missing for operator `&&`.']
+    )
   end
 
   it 'accepts exclamation point definition' do
@@ -128,7 +129,8 @@ describe RuboCop::Cop::Style::SpaceAroundOperators do
   it 'registers an offenses for exponent operator with spaces' do
     inspect_source(cop, 'x = a * b ** 2')
     expect(cop.messages).to eq(
-      ['Space around operator `**` detected.'])
+      ['Space around operator `**` detected.']
+    )
   end
 
   it 'auto-corrects unwanted space around **' do
@@ -202,7 +204,8 @@ describe RuboCop::Cop::Style::SpaceAroundOperators do
 
         expect(cop.messages).to eq(
           ['Surrounding space missing for operator `?`.',
-           'Surrounding space missing for operator `:`.'])
+           'Surrounding space missing for operator `:`.']
+        )
       end
 
       it 'registers an offense for operators with just a trailing space' do
@@ -210,7 +213,8 @@ describe RuboCop::Cop::Style::SpaceAroundOperators do
 
         expect(cop.messages).to eq(
           ['Surrounding space missing for operator `?`.',
-           'Surrounding space missing for operator `:`.'])
+           'Surrounding space missing for operator `:`.']
+        )
       end
 
       it 'registers an offense for operators with just a leading space' do
@@ -218,7 +222,8 @@ describe RuboCop::Cop::Style::SpaceAroundOperators do
 
         expect(cop.messages).to eq(
           ['Surrounding space missing for operator `?`.',
-           'Surrounding space missing for operator `:`.'])
+           'Surrounding space missing for operator `:`.']
+        )
       end
 
       it 'auto-corrects a ternary operator without space' do
@@ -249,7 +254,8 @@ describe RuboCop::Cop::Style::SpaceAroundOperators do
       inspect_source(cop, src)
       expect(cop.offenses.map(&:line)).to eq([1, 2])
       expect(cop.messages).to eq(
-        ['Surrounding space missing for operator `=`.'] * 2)
+        ['Surrounding space missing for operator `=`.'] * 2
+      )
 
       new_source = autocorrect_source(cop, src)
       expect(new_source)
@@ -261,7 +267,8 @@ describe RuboCop::Cop::Style::SpaceAroundOperators do
       expect(cop.messages).to eq(
         ['Surrounding space missing for operator `-`.',
          'Surrounding space missing for operator `&`.',
-         'Surrounding space missing for operator `+`.'])
+         'Surrounding space missing for operator `+`.']
+      )
     end
 
     it 'auto-corrects missing space in binary operators that could be unary' do
@@ -272,7 +279,8 @@ describe RuboCop::Cop::Style::SpaceAroundOperators do
     it 'registers an offense for arguments to a method' do
       inspect_source(cop, 'puts 1+2')
       expect(cop.messages).to eq(
-        ['Surrounding space missing for operator `+`.'])
+        ['Surrounding space missing for operator `+`.']
+      )
     end
 
     it 'auto-corrects missing space in arguments to a method' do
@@ -309,7 +317,8 @@ describe RuboCop::Cop::Style::SpaceAroundOperators do
     it 'registers an offense for a setter call without spaces' do
       inspect_source(cop, 'x.y=2')
       expect(cop.messages).to eq(
-        ['Surrounding space missing for operator `=`.'])
+        ['Surrounding space missing for operator `=`.']
+      )
     end
 
     context 'when a hash literal is on a single line' do
@@ -458,7 +467,8 @@ describe RuboCop::Cop::Style::SpaceAroundOperators do
       inspect_source(cop, 'x == 0  ? 1 :  2')
       expect(cop.messages).to eq(
         ['Operator `?` should be surrounded by a single space.',
-         'Operator `:` should be surrounded by a single space.'])
+         'Operator `:` should be surrounded by a single space.']
+      )
     end
 
     it 'auto-corrects a ternary operator too many spaces' do
@@ -488,7 +498,8 @@ describe RuboCop::Cop::Style::SpaceAroundOperators do
       inspect_source(cop, src)
       expect(cop.offenses.map(&:line)).to eq([1, 2])
       expect(cop.messages).to eq(
-        ['Operator `=` should be surrounded by a single space.'] * 2)
+        ['Operator `=` should be surrounded by a single space.'] * 2
+      )
 
       new_source = autocorrect_source(cop, src)
       expect(new_source)
@@ -502,7 +513,8 @@ describe RuboCop::Cop::Style::SpaceAroundOperators do
       expect(cop.messages).to eq(
         ['Operator `-` should be surrounded by a single space.',
          'Operator `&` should be surrounded by a single space.',
-         'Operator `+` should be surrounded by a single space.'])
+         'Operator `+` should be surrounded by a single space.']
+      )
     end
 
     it 'auto-corrects missing space in binary operators that could be unary' do
@@ -515,7 +527,8 @@ describe RuboCop::Cop::Style::SpaceAroundOperators do
     it 'registers an offense for arguments to a method' do
       inspect_source(cop, 'puts 1 +  2')
       expect(cop.messages).to eq(
-        ['Operator `+` should be surrounded by a single space.'])
+        ['Operator `+` should be surrounded by a single space.']
+      )
     end
 
     it 'auto-corrects missing space in arguments to a method' do
@@ -555,13 +568,15 @@ describe RuboCop::Cop::Style::SpaceAroundOperators do
     it 'registers an offense for a setter call with too many spaces' do
       inspect_source(cop, 'x.y  =  2')
       expect(cop.messages).to eq(
-        ['Operator `=` should be surrounded by a single space.'])
+        ['Operator `=` should be surrounded by a single space.']
+      )
     end
 
     it 'registers an offense for a hash rocket with too many spaces' do
       inspect_source(cop, '{ 1  =>   2, a: b }')
       expect(cop.messages).to eq(
-        ['Operator `=>` should be surrounded by a single space.'])
+        ['Operator `=>` should be surrounded by a single space.']
+      )
     end
 
     it 'registers an offense for match operators with too many spaces' do

--- a/spec/rubocop/cop/style/space_before_comma_spec.rb
+++ b/spec/rubocop/cop/style/space_before_comma_spec.rb
@@ -9,19 +9,22 @@ describe RuboCop::Cop::Style::SpaceBeforeComma do
   it 'registers an offense for block argument with space before comma' do
     inspect_source(cop, 'each { |s , t| }')
     expect(cop.messages).to eq(
-      ['Space found before comma.'])
+      ['Space found before comma.']
+    )
   end
 
   it 'registers an offense for array index with space before comma' do
     inspect_source(cop, 'formats[0 , 1]')
     expect(cop.messages).to eq(
-      ['Space found before comma.'])
+      ['Space found before comma.']
+    )
   end
 
   it 'registers an offense for method call arg with space before comma' do
     inspect_source(cop, 'a(1 , 2)')
     expect(cop.messages).to eq(
-      ['Space found before comma.'])
+      ['Space found before comma.']
+    )
   end
 
   it 'does not register an offense for no spaces before comma' do

--- a/spec/rubocop/cop/style/space_before_semicolon_spec.rb
+++ b/spec/rubocop/cop/style/space_before_semicolon_spec.rb
@@ -13,7 +13,8 @@ describe RuboCop::Cop::Style::SpaceBeforeSemicolon do
   it 'registers an offense for space before semicolon' do
     inspect_source(cop, 'x = 1 ; y = 2')
     expect(cop.messages).to eq(
-      ['Space found before semicolon.'])
+      ['Space found before semicolon.']
+    )
   end
 
   it 'does not register an offense for no space before semicolons' do

--- a/spec/rubocop/cop/style/space_inside_brackets_spec.rb
+++ b/spec/rubocop/cop/style/space_inside_brackets_spec.rb
@@ -11,7 +11,8 @@ describe RuboCop::Cop::Style::SpaceInsideBrackets do
                          'b = [ 1, 2]'])
     expect(cop.messages).to eq(
       ['Space inside square brackets detected.',
-       'Space inside square brackets detected.'])
+       'Space inside square brackets detected.']
+    )
   end
 
   it 'registers an offense for Hash#[] with symbol key and spaces inside' do
@@ -19,7 +20,8 @@ describe RuboCop::Cop::Style::SpaceInsideBrackets do
                          'b[:key ]'])
     expect(cop.messages).to eq(
       ['Space inside square brackets detected.',
-       'Space inside square brackets detected.'])
+       'Space inside square brackets detected.']
+    )
   end
 
   it 'registers an offense for Hash#[] with string key and spaces inside' do
@@ -27,7 +29,8 @@ describe RuboCop::Cop::Style::SpaceInsideBrackets do
                          'b[ \'key\']'])
     expect(cop.messages).to eq(
       ['Space inside square brackets detected.',
-       'Space inside square brackets detected.'])
+       'Space inside square brackets detected.']
+    )
   end
 
   it 'accepts space inside strings within square brackets' do
@@ -64,7 +67,8 @@ describe RuboCop::Cop::Style::SpaceInsideBrackets do
   it 'only reports a single space once' do
     inspect_source(cop, '[ ]')
     expect(cop.messages).to eq(
-      ['Space inside square brackets detected.'])
+      ['Space inside square brackets detected.']
+    )
   end
 
   it 'auto-corrects unwanted space' do

--- a/spec/rubocop/cop/style/special_global_vars_spec.rb
+++ b/spec/rubocop/cop/style/special_global_vars_spec.rb
@@ -73,7 +73,8 @@ describe RuboCop::Cop::Style::SpecialGlobalVars, :config do
     it 'generates correct auto-config when Perl variable names are used' do
       inspect_source(cop, '$0')
       expect(cop.config_to_allow_offenses).to eq(
-        'EnforcedStyle' => 'use_perl_names')
+        'EnforcedStyle' => 'use_perl_names'
+      )
     end
 
     it 'generates correct auto-config when mixed styles are used' do

--- a/spec/rubocop/cop/style/trivial_accessors_spec.rb
+++ b/spec/rubocop/cop/style/trivial_accessors_spec.rb
@@ -247,7 +247,8 @@ describe RuboCop::Cop::Style::TrivialAccessors, :config do
 
     expect(cop.offenses.size).to eq(1)
     expect(cop.messages).to eq(
-      ['Use `attr_reader` to define trivial reader methods.'])
+      ['Use `attr_reader` to define trivial reader methods.']
+    )
   end
   context 'exact name match disabled' do
     let(:cop_config) { { 'ExactNameMatch' => false } }

--- a/spec/rubocop/formatter/disabled_lines_formatter_spec.rb
+++ b/spec/rubocop/formatter/disabled_lines_formatter_spec.rb
@@ -26,7 +26,8 @@ module RuboCop
           let(:cop_disabled_line_ranges) { {} }
           it 'does not add to cop_disabled_line_ranges' do
             expect { file_started }.to_not(
-              change { formatter.cop_disabled_line_ranges })
+              change { formatter.cop_disabled_line_ranges }
+            )
           end
         end
 
@@ -36,7 +37,8 @@ module RuboCop
           end
           it 'merges the changes into cop_disabled_line_ranges' do
             expect { file_started }.to(
-              change { formatter.cop_disabled_line_ranges })
+              change { formatter.cop_disabled_line_ranges }
+            )
           end
         end
       end

--- a/spec/rubocop/formatter/emacs_style_formatter_spec.rb
+++ b/spec/rubocop/formatter/emacs_style_formatter_spec.rb
@@ -71,7 +71,8 @@ module RuboCop
             formatter.file_finished(file, [offense])
             expect(output.string).to eq(
               '/path/to/file:1:1: E: unmatched close parenthesis: /    ' \
-              "world # Some comment containing a ) /\n")
+              "world # Some comment containing a ) /\n"
+            )
           end
         end
       end

--- a/spec/rubocop/formatter/offense_count_formatter_spec.rb
+++ b/spec/rubocop/formatter/offense_count_formatter_spec.rb
@@ -41,7 +41,8 @@ module RuboCop
           it 'shows the cop and the offense count' do
             formatter.report_summary(cop_counts)
             expect(output.string).to include(
-              "\n1  OffendedCop\n--\n1  Total")
+              "\n1  OffendedCop\n--\n1  Total"
+            )
           end
         end
       end

--- a/spec/rubocop/formatter/progress_formatter_spec.rb
+++ b/spec/rubocop/formatter/progress_formatter_spec.rb
@@ -116,7 +116,8 @@ module RuboCop
                 'foo',
                 'Cop'
               )
-            ])
+            ]
+          )
 
           formatter.file_started(files[1], {})
           formatter.file_finished(files[1], [])
@@ -141,7 +142,8 @@ module RuboCop
                 'foo',
                 'Cop'
               )
-            ])
+            ]
+          )
         end
 
         it 'reports all detected offenses for all failed files' do

--- a/spec/rubocop/formatter/simple_text_formatter_spec.rb
+++ b/spec/rubocop/formatter/simple_text_formatter_spec.rb
@@ -80,7 +80,8 @@ module RuboCop
             expect(output.string).to eq(
               ['',
                '0 files inspected, no offenses detected',
-               ''].join("\n"))
+               ''].join("\n")
+            )
           end
         end
 
@@ -90,7 +91,8 @@ module RuboCop
             expect(output.string).to eq(
               ['',
                '1 file inspected, no offenses detected',
-               ''].join("\n"))
+               ''].join("\n")
+            )
           end
         end
 
@@ -100,7 +102,8 @@ module RuboCop
             expect(output.string).to eq(
               ['',
                '1 file inspected, 1 offense detected',
-               ''].join("\n"))
+               ''].join("\n")
+            )
           end
         end
 
@@ -110,7 +113,8 @@ module RuboCop
             expect(output.string).to eq(
               ['',
                '2 files inspected, 2 offenses detected',
-               ''].join("\n"))
+               ''].join("\n")
+            )
           end
         end
 
@@ -120,7 +124,8 @@ module RuboCop
             expect(output.string).to eq(
               ['',
                '1 file inspected, 1 offense detected, 1 offense corrected',
-               ''].join("\n"))
+               ''].join("\n")
+            )
           end
         end
 
@@ -130,7 +135,8 @@ module RuboCop
             expect(output.string).to eq(
               ['',
                '1 file inspected, 1 offense detected, 2 offenses corrected',
-               ''].join("\n"))
+               ''].join("\n")
+            )
           end
         end
       end

--- a/spec/support/multiline_literal_brace_layout_examples.rb
+++ b/spec/support/multiline_literal_brace_layout_examples.rb
@@ -75,7 +75,8 @@ shared_examples_for 'multiline literal brace layout' do
 
     it 'auto-corrects safe heredoc offenses' do
       new_source = autocorrect_source(
-        cop, construct(false, a, make_multi(safe_heredoc), true))
+        cop, construct(false, a, make_multi(safe_heredoc), true)
+      )
 
       expect(new_source)
         .to eq(construct(false, a, make_multi(safe_heredoc), false).join("\n"))

--- a/spec/support/shared_examples.rb
+++ b/spec/support/shared_examples.rb
@@ -51,7 +51,9 @@ shared_examples_for 'misaligned' do |prefix, alignment_base, arg, end_kw, name|
     # style. In other cases, it won't match any style at all
     expect(cop.config_to_allow_offenses).to(
       eq('Enabled' => false).or(
-        satisfy { |h| other_styles.include?(h['AlignWith']) }))
+        satisfy { |h| other_styles.include?(h['AlignWith']) }
+      )
+    )
   end
 
   it "auto-corrects mismatched #{name} ... end" do

--- a/spec/support/statement_modifier_helper.rb
+++ b/spec/support/statement_modifier_helper.rb
@@ -13,7 +13,8 @@ module StatementModifierHelper
                          '  b',
                          'end'])
     expect(cop.messages).to eq(
-      ["Favor modifier `#{keyword}` usage when having a single-line body."])
+      ["Favor modifier `#{keyword}` usage when having a single-line body."]
+    )
     expect(cop.offenses.map { |o| o.location.source }).to eq([keyword])
   end
 


### PR DESCRIPTION
Related to #2914 this change enables
`Style/MultilineMethodCallBraceLayout` and
`Style/MultilineMethodDefinitionBraceLayout` with `EnforcedStyle:
symmetrical` by default.

All existing RuboCop code has been auto-corrected.