### PR TITLE
Allow Style/Encoding to enforce using no encoding comment

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -10,6 +10,7 @@ AllCops:
   TargetRubyVersion: 1.9
 
 Style/Encoding:
+  EnforcedStyle: always
   Enabled: true
 
 Style/FrozenStringLiteralComment:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@
 * [#3072](https://github.com/bbatsov/rubocop/pull/3072): Add new `Lint/UselessArraySplat` cop. ([@owst][])
 * [#3022](https://github.com/bbatsov/rubocop/issues/3022): `Style/Lambda` enforced style supports `literal` option. ([@drenmi][])
 * [#2909](https://github.com/bbatsov/rubocop/issues/2909): `Style/Lambda` enforced style supports `lambda` option. ([@drenmi][])
+* [#3092](https://github.com/bbatsov/rubocop/pull/3092): Allow `Style/Encoding` to enforce using no encoding comments. ([@NobodysNightmare][])
 
 ### Bug fixes
 
@@ -2140,3 +2141,4 @@
 [@graemeboy]: https://github.com/graemeboy
 [@akihiro17]: https://github.com/akihiro17
 [@magni-]: https://github.com/magni-
+[@NobodysNightmare]: https://github.com/NobodysNightmare

--- a/config/default.yml
+++ b/config/default.yml
@@ -425,10 +425,11 @@ Style/EmptyLinesAroundModuleBody:
 # AutoCorrectEncodingComment must match the regex
 # /#.*coding\s?[:=]\s?(?:UTF|utf)-8/
 Style/Encoding:
-  EnforcedStyle: always
+  EnforcedStyle: never
   SupportedStyles:
     - when_needed
     - always
+    - never
   AutoCorrectEncodingComment: '# encoding: utf-8'
 
 Style/ExtraSpacing:

--- a/lib/rubocop/cop/style/encoding.rb
+++ b/lib/rubocop/cop/style/encoding.rb
@@ -5,13 +5,15 @@ module RuboCop
   module Cop
     module Style
       # This cop checks whether the source file has a utf-8 encoding
-      # comment or not. This check makes sense only for code that
-      # should support Ruby 1.9, since in 2.0+ utf-8 is the default
-      # source file encoding. There are two styles:
+      # comment or not.
+      # Setting this check to "always" and "when_needed" makes sense only
+      # for code that should support Ruby 1.9, since in 2.0+ utf-8 is the
+      # default source file encoding. There are three styles:
       #
       # when_needed - only enforce an encoding comment if there are non ASCII
       #               characters, otherwise report an offense
       # always - enforce encoding comment in all files
+      # never - enforce no encoding comment in all files
       class Encoding < Cop
         include ConfigurableEnforcedStyle
 
@@ -56,10 +58,12 @@ module RuboCop
           encoding_present = line =~ ENCODING_PATTERN
           ascii_only = processed_source.buffer.source.ascii_only?
           always_encode = style == :always
+          never_encode = style == :never
+          encoding_omitable = never_encode || (!always_encode && ascii_only)
 
-          if !encoding_present && (always_encode || !ascii_only)
+          if !encoding_present && !encoding_omitable
             MSG_MISSING
-          elsif !always_encode && ascii_only && encoding_present
+          elsif encoding_present && encoding_omitable
             MSG_UNNECESSARY
           end
         end

--- a/spec/rubocop/cli_spec.rb
+++ b/spec/rubocop/cli_spec.rb
@@ -254,17 +254,18 @@ describe RuboCop::CLI, :isolated_environment do
       it 'does not trigger UnneededDisable due to lines moving around' do
         src = ['a = 1 # rubocop:disable Lint/UselessAssignment']
         create_file('example.rb', src)
-        create_file('.rubocop.yml', ['Style/Encoding:',
-                                     '  Enabled: true'])
+        create_file('.rubocop.yml', ['Style/FrozenStringLiteralComment:',
+                                     '  Enabled: true',
+                                     '  EnforcedStyle: always'])
         expect(cli.run(['--format', 'offenses', '-a', 'example.rb'])).to eq(0)
         expect($stdout.string).to eq(['',
-                                      '1  Style/Encoding',
+                                      '1  Style/FrozenStringLiteralComment',
                                       '--',
                                       '1  Total',
                                       '',
                                       ''].join("\n"))
         expect(IO.read('example.rb'))
-          .to eq(['# encoding: utf-8',
+          .to eq(['# frozen_string_literal: true',
                   'a = 1 # rubocop:disable Lint/UselessAssignment',
                   ''].join("\n"))
       end


### PR DESCRIPTION
## Whats in

You can now configure rubocop to enforce having **no** encoding comments:
````yml
Style/Encoding:
  EnforcedStyle: never
  Enabled: true
````

This means even if there are non-ASCII characters in a file, rubocop will offend on an `# encoding: utf-8` comment.
I deem this useful for applications that are running on a recent ruby version and therefore do not need the comment anymore. Since many applications used to be running on 1.9, they may still contain those comments, even if they are unneccessary.