### PR TITLE
[Fix #3083] Allow splat block args in SymbolProc

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,7 @@
 * [#3004](https://github.com/bbatsov/rubocop/pull/3004): Don't add `Style/Alias` offenses for use of `alias` in `instance_eval` blocks, since object instances don't respond to `alias_method`. ([@magni-][])
 * [#3061](https://github.com/bbatsov/rubocop/pull/3061): Custom cops now show up in --show-cops. ([@ptarjan][])
 * [#3088](https://github.com/bbatsov/rubocop/pull/3088): Ignore offenses that involve conflicting HEREDOCs in the `Style/Multiline*BraceLayout` cops. ([@panthomakos][])
+* [#3083](https://github.com/bbatsov/rubocop/issues/3083): Do not register an offense for splat block args in `Style/SymbolProc`. ([@rrosenblum][])
 
 ### Changes
 

--- a/lib/rubocop/cop/style/symbol_proc.rb
+++ b/lib/rubocop/cop/style/symbol_proc.rb
@@ -113,7 +113,7 @@ module RuboCop
         def can_shorten?(block_args, block_body)
           # something { |x, y| ... }
           return false unless block_args.children.size == 1
-          return false if block_args.children.first.blockarg_type?
+          return false if non_shortenable_args?(block_args)
           return false unless block_body && block_body.type == :send
 
           receiver, _method_name, args = *block_body
@@ -130,6 +130,12 @@ module RuboCop
 
         def super?(node)
           [:super, :zsuper].include?(node.type)
+        end
+
+        def non_shortenable_args?(block_args)
+          # something { |&x| ... }
+          # something { |*x| ... }
+          [:blockarg, :restarg].include?(block_args.children.first.type)
         end
       end
     end

--- a/spec/rubocop/cop/style/symbol_proc_spec.rb
+++ b/spec/rubocop/cop/style/symbol_proc_spec.rb
@@ -84,6 +84,12 @@ describe RuboCop::Cop::Style::SymbolProc, :config do
     expect(cop.offenses).to be_empty
   end
 
+  it 'accepts block with splat params' do
+    inspect_source(cop, 'something { |*x| x.first }')
+
+    expect(cop.offenses).to be_empty
+  end
+
   context 'when the method has arguments' do
     let(:source) { 'method(one, 2) { |x| x.test }' }
 


### PR DESCRIPTION
This fixes #3083