### PR TITLE
[Fix #3063] Don't auto-correct `a + \\` into `a + \\\\`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,7 @@
 * [#3061](https://github.com/bbatsov/rubocop/pull/3061): Custom cops now show up in --show-cops. ([@ptarjan][])
 * [#3088](https://github.com/bbatsov/rubocop/pull/3088): Ignore offenses that involve conflicting HEREDOCs in the `Style/Multiline*BraceLayout` cops. ([@panthomakos][])
 * [#3083](https://github.com/bbatsov/rubocop/issues/3083): Do not register an offense for splat block args in `Style/SymbolProc`. ([@rrosenblum][])
+* [#3063](https://github.com/bbatsov/rubocop/issues/3063): Don't auto-correct `a + \` into `a + \\` in `Style/LineEndConcatenation`. ([@jonas054][])
 
 ### Changes
 

--- a/lib/rubocop/cop/style/line_end_concatenation.rb
+++ b/lib/rubocop/cop/style/line_end_concatenation.rb
@@ -41,6 +41,11 @@ module RuboCop
           operator_range = range_with_surrounding_space(operator_range,
                                                         :right,
                                                         !:with_newline)
+          one_more_char = operator_range.resize(operator_range.size + 1)
+          # Don't create a double backslash at the end of the line, in case
+          # there already was a backslash after the concatenation operator.
+          operator_range = one_more_char if one_more_char.source.end_with?('\\')
+
           ->(corrector) { corrector.replace(operator_range, '\\') }
         end
 

--- a/spec/rubocop/cop/style/line_end_concatenation_spec.rb
+++ b/spec/rubocop/cop/style/line_end_concatenation_spec.rb
@@ -163,6 +163,13 @@ describe RuboCop::Cop::Style::LineEndConcatenation do
     expect(corrected).to eq ['top = "test" \\', '"top"'].join("\n")
   end
 
+  it 'autocorrects a + with \\ to just \\' do
+    corrected = autocorrect_source(cop,
+                                   ['top = "test" + \\',
+                                    '"top"'])
+    expect(corrected).to eq ['top = "test" \\', '"top"'].join("\n")
+  end
+
   it 'autocorrects for chained concatenations and << calls' do
     corrected = autocorrect_source(cop,
                                    ['top = "test#{x}" <<',


### PR DESCRIPTION
Take care not to create a double backslash (a syntax error) when auto-correcting a + used for string concatenation into a backslash.

The reporting of the offense remains the same, i.e., no special message for "you already have a backslash, just remove the +".