### PR TITLE
[Fix #3034] Report offenses also for compact style in RedundantException

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,7 @@
 * [#3088](https://github.com/bbatsov/rubocop/pull/3088): Ignore offenses that involve conflicting HEREDOCs in the `Style/Multiline*BraceLayout` cops. ([@panthomakos][])
 * [#3083](https://github.com/bbatsov/rubocop/issues/3083): Do not register an offense for splat block args in `Style/SymbolProc`. ([@rrosenblum][])
 * [#3063](https://github.com/bbatsov/rubocop/issues/3063): Don't auto-correct `a + \` into `a + \\` in `Style/LineEndConcatenation`. ([@jonas054][])
+* [#3034](https://github.com/bbatsov/rubocop/issues/3034): Report offenses for `RuntimeError.new(msg)` in `Style/RedundantException`. ([@jonas054][])
 
 ### Changes
 

--- a/spec/rubocop/cop/style/redundant_exception_spec.rb
+++ b/spec/rubocop/cop/style/redundant_exception_spec.rb
@@ -6,55 +6,66 @@ require 'spec_helper'
 describe RuboCop::Cop::Style::RedundantException do
   subject(:cop) { described_class.new }
 
-  it 'reports an offense for a raise with RuntimeError' do
-    inspect_source(cop, 'raise RuntimeError, msg')
-    expect(cop.offenses.size).to eq(1)
+  shared_examples 'common behavior' do |keyword|
+    it "reports an offense for a #{keyword} with RuntimeError" do
+      src = "#{keyword} RuntimeError, msg"
+      inspect_source(cop, src)
+      expect(cop.highlights).to eq([src])
+      expect(cop.messages)
+        .to eq(['Redundant `RuntimeError` argument can be removed.'])
+    end
+
+    it "reports an offense for a #{keyword} with RuntimeError.new" do
+      src = "#{keyword} RuntimeError.new(msg)"
+      inspect_source(cop, src)
+      expect(cop.highlights).to eq([src])
+      expect(cop.messages)
+        .to eq(['Redundant `RuntimeError.new` call can be replaced with ' \
+                'just the message.'])
+    end
+
+    it "accepts a #{keyword} with RuntimeError if it does not have 2 args" do
+      inspect_source(cop, "#{keyword} RuntimeError, msg, caller")
+      expect(cop.offenses).to be_empty
+    end
+
+    it "auto-corrects a #{keyword} RuntimeError by removing RuntimeError" do
+      src = "#{keyword} RuntimeError, msg"
+      result_src = "#{keyword} msg"
+      new_src = autocorrect_source(cop, src)
+      expect(new_src).to eq(result_src)
+    end
+
+    it "auto-corrects a #{keyword} RuntimeError.new with parentheses by " \
+       'removing RuntimeError.new' do
+      src = "#{keyword} RuntimeError.new(msg)"
+      result_src = "#{keyword} msg"
+      new_src = autocorrect_source(cop, src)
+      expect(new_src).to eq(result_src)
+    end
+
+    it "auto-corrects a #{keyword} RuntimeError.new without parentheses by " \
+       'removing RuntimeError.new' do
+      src = "#{keyword} RuntimeError.new msg"
+      result_src = "#{keyword} msg"
+      new_src = autocorrect_source(cop, src)
+      expect(new_src).to eq(result_src)
+    end
+
+    it "does not modify #{keyword} w/ RuntimeError if it does not have 2 " \
+       'args' do
+      src = "#{keyword} runtimeError, msg, caller"
+      new_src = autocorrect_source(cop, src)
+      expect(new_src).to eq(src)
+    end
+
+    it 'does not modify rescue w/ non redundant error' do
+      src = "#{keyword} OtherError, msg"
+      new_src = autocorrect_source(cop, src)
+      expect(new_src).to eq(src)
+    end
   end
 
-  it 'reports an offense for a fail with RuntimeError' do
-    inspect_source(cop, 'fail RuntimeError, msg')
-    expect(cop.offenses.size).to eq(1)
-  end
-
-  it 'accepts a raise with RuntimeError if it does not have 2 args' do
-    inspect_source(cop, 'raise RuntimeError, msg, caller')
-    expect(cop.offenses).to be_empty
-  end
-
-  it 'accepts a fail with RuntimeError if it does not have 2 args' do
-    inspect_source(cop, 'fail RuntimeError, msg, caller')
-    expect(cop.offenses).to be_empty
-  end
-
-  it 'auto-corrects a raise by removing RuntimeError' do
-    src = 'raise RuntimeError, msg'
-    result_src = 'raise msg'
-    new_src = autocorrect_source(cop, src)
-    expect(new_src).to eq(result_src)
-  end
-
-  it 'auto-corrects a fil by removing RuntimeError' do
-    src = 'fail RuntimeError, msg'
-    result_src = 'fail msg'
-    new_src = autocorrect_source(cop, src)
-    expect(new_src).to eq(result_src)
-  end
-
-  it 'does not modify raise w/ RuntimeError if it does not have 2 args' do
-    src = 'raise runtimeError, msg, caller'
-    new_src = autocorrect_source(cop, src)
-    expect(new_src).to eq(src)
-  end
-
-  it 'does not modify fail w/ RuntimeError if it does not have 2 args' do
-    src = 'fail RuntimeError, msg, caller'
-    new_src = autocorrect_source(cop, src)
-    expect(new_src).to eq(src)
-  end
-
-  it 'does not modify rescue w/ non redundant error' do
-    src = 'fail OtherError, msg'
-    new_src = autocorrect_source(cop, src)
-    expect(new_src).to eq(src)
-  end
+  include_examples 'common behavior', 'raise'
+  include_examples 'common behavior', 'fail'
 end


### PR DESCRIPTION
Until now we have only had support for reporting `raise RuntimeError, msg`. Add support for reporting
`raise RuntimeError.new(msg)`.