### PR TITLE
Handle paths where multiple potential roots exist

### DIFF
--- a/lib/rubocop/cop/style/file_name.rb
+++ b/lib/rubocop/cop/style/file_name.rb
@@ -125,11 +125,23 @@ module RuboCop
           # We can't assume that the working directory, or any other, is the
           # "starting point" to build a namespace
           start = %w(lib spec test src)
-          if components.find { |c| start.include?(c) }
-            components = components.drop_while { |c| !start.include?(c) }
-            components.drop(1).map { |fn| to_module_name(fn) }
-          else
+          start_index = nil
+
+          # To find the closest namespace root take the path components, and
+          # then work through them backwards until we find a candidate. This
+          # makes sure we work from the actual root in the case of a path like
+          # /home/user/src/project_name/lib.
+          components.reverse.each_with_index do |c, i|
+            if start.include?(c)
+              start_index = components.size - i
+              break
+            end
+          end
+
+          if start_index.nil?
             [to_module_name(components.last)]
+          else
+            components[start_index..-1].map { |c| to_module_name(c) }
           end
         end
 

--- a/spec/rubocop/cop/style/file_name_spec.rb
+++ b/spec/rubocop/cop/style/file_name_spec.rb
@@ -187,6 +187,14 @@ describe RuboCop::Cop::Style::FileName do
                                         'or module called `C::B`.'])
           end
         end
+
+        context "in a directory with multiple instances of #{dir}" do
+          let(:filename) { "/some/dir/#{dir}/project/#{dir}/a/b.rb" }
+
+          it 'does not register an offense' do
+            expect(cop.offenses).to be_empty
+          end
+        end
       end
 
       context 'in a directory elsewhere which only matches the module name' do


### PR DESCRIPTION
Update `Style/FileName` to be able to cope with files which sit at a path in which there are multiple namespace roots present. The specific instance this was written to deal with is our Codeship CI run, which places the source in `~/src/`, making the full path `~/src/project/lib/file.rb`. This resulted in failures with the message "file.rb should define a class or module called Project::Lib::File" because it was rooting the namespace at the `src`.