### PR TITLE
Add new cop Rails/UniqBeforePluck

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@
 * [#3022](https://github.com/bbatsov/rubocop/issues/3022): `Style/Lambda` enforced style supports `literal` option. ([@drenmi][])
 * [#2909](https://github.com/bbatsov/rubocop/issues/2909): `Style/Lambda` enforced style supports `lambda` option. ([@drenmi][])
 * [#3092](https://github.com/bbatsov/rubocop/pull/3092): Allow `Style/Encoding` to enforce using no encoding comments. ([@NobodysNightmare][])
+* New cop `Rails/UniqBeforePluck` checks that `uniq` is used before `pluck`. ([@tjwp][])
 
 ### Bug fixes
 
@@ -2147,3 +2148,4 @@
 [@magni-]: https://github.com/magni-
 [@NobodysNightmare]: https://github.com/NobodysNightmare
 [@gylaz]: https://github.com/gylaz
+[@tjwp]: https://github.com/tjwp

--- a/config/enabled.yml
+++ b/config/enabled.yml
@@ -1383,6 +1383,10 @@ Rails/TimeZone:
   Reference: 'http://danilenko.org/2012/7/6/rails_timezones'
   Enabled: true
 
+Rails/UniqBeforePluck:
+  Description: 'Prefer the use of uniq before pluck.'
+  Enabled: true
+
 Rails/Validation:
   Description: 'Use validates :attribute, hash of validations.'
   Enabled: true

--- a/lib/rubocop.rb
+++ b/lib/rubocop.rb
@@ -368,6 +368,7 @@ require 'rubocop/cop/rails/pluralization_grammar'
 require 'rubocop/cop/rails/read_write_attribute'
 require 'rubocop/cop/rails/scope_args'
 require 'rubocop/cop/rails/time_zone'
+require 'rubocop/cop/rails/uniq_before_pluck'
 require 'rubocop/cop/rails/validation'
 
 require 'rubocop/cop/team'

--- a/lib/rubocop/cop/rails/uniq_before_pluck.rb
+++ b/lib/rubocop/cop/rails/uniq_before_pluck.rb
@@ -25,6 +25,7 @@ module RuboCop
           receiver, method_name, *_args = *node
 
           unless method_name == :uniq &&
+                 !receiver.nil? &&
                  receiver.send_type? &&
                  receiver.children[1] == :pluck
             return

--- a/lib/rubocop/cop/rails/uniq_before_pluck.rb
+++ b/lib/rubocop/cop/rails/uniq_before_pluck.rb
@@ -1,0 +1,56 @@
+# encoding: utf-8
+# frozen_string_literal: true
+
+module RuboCop
+  module Cop
+    module Rails
+      # Prefer the use of uniq before pluck instead of after.
+      #
+      # The use of uniq before pluck is preferred because it executes
+      # within the database.
+      #
+      # @example
+      #   # bad
+      #   Model.where(...).pluck(:id).uniq
+      #
+      #   # good
+      #   Model.where(...).uniq.pluck(:id)
+      #
+      class UniqBeforePluck < RuboCop::Cop::Cop
+        MSG = 'Use uniq before pluck'.freeze
+        DOT_UNIQ = '.uniq'.freeze
+        NEWLINE = "\n".freeze
+
+        def on_send(node)
+          receiver, method_name, *_args = *node
+
+          unless method_name == :uniq &&
+                 receiver.send_type? &&
+                 receiver.children[1] == :pluck
+            return
+          end
+          add_offense(node, :selector, MSG)
+        end
+
+        def autocorrect(node)
+          lines = node.source.split(NEWLINE)
+          begin_remove_pos = if lines.last.strip == DOT_UNIQ
+                               node.source.rindex(NEWLINE)
+                             else
+                               node.loc.dot.begin_pos
+                             end
+          receiver = node.children.first
+
+          lambda do |corrector|
+            corrector.remove(
+              Parser::Source::Range.new(node.loc.expression.source_buffer,
+                                        begin_remove_pos,
+                                        node.loc.selector.end_pos)
+            )
+            corrector.insert_before(receiver.loc.dot.begin, DOT_UNIQ)
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/rubocop/cop/rails/uniq_before_pluck_spec.rb
+++ b/spec/rubocop/cop/rails/uniq_before_pluck_spec.rb
@@ -7,12 +7,11 @@ describe RuboCop::Cop::Rails::UniqBeforePluck do
   let(:corrected) { 'Model.uniq.pluck(:id)' }
   subject(:cop) { described_class.new }
 
-  shared_examples_for 'UniqBeforePluck cop' do |source, line_no = 1|
+  shared_examples_for 'UniqBeforePluck cop' do |source|
     it 'finds and corrects use of uniq after pluck' do
       inspect_source(cop, source)
       expect(cop.messages).to eq([described_class::MSG])
       expect(cop.highlights).to eq(['uniq'])
-      expect(cop.offenses.map(&:line)).to eq([line_no])
       expect(autocorrect_source(cop, source)).to eq(corrected)
     end
   end
@@ -21,10 +20,10 @@ describe RuboCop::Cop::Rails::UniqBeforePluck do
                   'Model.pluck(:id).uniq'
 
   it_behaves_like 'UniqBeforePluck cop',
-                  ['Model.pluck(:id)', '  .uniq'], 2
+                  ['Model.pluck(:id)', '  .uniq']
 
   it_behaves_like 'UniqBeforePluck cop',
-                  ['Model.pluck(:id).', '  uniq'], 2
+                  ['Model.pluck(:id).', '  uniq']
 
   it 'ignores use of uniq before pluck' do
     source = 'Model.where(foo: 1).uniq.pluck(:something)'
@@ -33,5 +32,11 @@ describe RuboCop::Cop::Rails::UniqBeforePluck do
     expect(cop.highlights).to be_empty
     expect(cop.offenses).to be_empty
     expect(autocorrect_source(cop, source)).to eq(source)
+  end
+
+  it 'ignores the use of uniq without a receiver' do
+    source = 'uniq.something'
+    inspect_source(cop, source)
+    expect(cop.offenses).to be_empty
   end
 end

--- a/spec/rubocop/cop/rails/uniq_before_pluck_spec.rb
+++ b/spec/rubocop/cop/rails/uniq_before_pluck_spec.rb
@@ -1,0 +1,37 @@
+# encoding: utf-8
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+describe RuboCop::Cop::Rails::UniqBeforePluck do
+  let(:corrected) { 'Model.uniq.pluck(:id)' }
+  subject(:cop) { described_class.new }
+
+  shared_examples_for 'UniqBeforePluck cop' do |source, line_no = 1|
+    it 'finds and corrects use of uniq after pluck' do
+      inspect_source(cop, source)
+      expect(cop.messages).to eq([described_class::MSG])
+      expect(cop.highlights).to eq(['uniq'])
+      expect(cop.offenses.map(&:line)).to eq([line_no])
+      expect(autocorrect_source(cop, source)).to eq(corrected)
+    end
+  end
+
+  it_behaves_like 'UniqBeforePluck cop',
+                  'Model.pluck(:id).uniq'
+
+  it_behaves_like 'UniqBeforePluck cop',
+                  ['Model.pluck(:id)', '  .uniq'], 2
+
+  it_behaves_like 'UniqBeforePluck cop',
+                  ['Model.pluck(:id).', '  uniq'], 2
+
+  it 'ignores use of uniq before pluck' do
+    source = 'Model.where(foo: 1).uniq.pluck(:something)'
+    inspect_source(cop, source)
+    expect(cop.messages).to be_empty
+    expect(cop.highlights).to be_empty
+    expect(cop.offenses).to be_empty
+    expect(autocorrect_source(cop, source)).to eq(source)
+  end
+end


### PR DESCRIPTION
Prefer the use of `uniq` before `pluck` instead of after.
The use of `uniq` before `pluck` is preferred because it executes
within the database. Only the use of `uniq` immediately
after `pluck` is detected and corrected.

Example:

```ruby
# bad
Model.where(...).pluck(:id).uniq

# good
Model.where(...).uniq.pluck(:id)
```