### PR TITLE
Fix `Style/ClassAndModuleChildren` for nested classes with explicit superclass

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@
 
 ### Bug fixes
 
+* [#3112](https://github.com/bbatsov/rubocop/issues/3112): Fix `Style/ClassAndModuleChildren` for nested classes with explicit superclass. ([@jspanjers][])
 * [#3032](https://github.com/bbatsov/rubocop/issues/3032): Fix autocorrecting parentheses for predicate methods without space before args. ([@graemeboy][])
 * [#3000](https://github.com/bbatsov/rubocop/pull/3000): Fix encoding crash on HTML output. ([@gerrywastaken][])
 * [#2983](https://github.com/bbatsov/rubocop/pull/2983): `Style/AlignParameters` message was clarified for `with_fixed_indentation` style. ([@dylanahsmith][])

--- a/lib/rubocop/cop/style/class_and_module_children.rb
+++ b/lib/rubocop/cop/style/class_and_module_children.rb
@@ -28,7 +28,7 @@ module RuboCop
 
         def on_class(node)
           _name, superclass, body = *node
-          return if superclass
+          return if superclass && style != :nested
           check_style(node, body)
         end
 

--- a/spec/rubocop/cop/style/class_and_module_children_spec.rb
+++ b/spec/rubocop/cop/style/class_and_module_children_spec.rb
@@ -20,6 +20,17 @@ describe RuboCop::Cop::Style::ClassAndModuleChildren, :config do
       expect(cop.highlights).to eq ['FooClass::BarClass']
     end
 
+    it 'registers an offense for not nested classes with explicit superclass' do
+      inspect_source(cop, ['class FooClass::BarClass < Super',
+                           'end'])
+
+      expect(cop.offenses.size).to eq 1
+      expect(cop.messages).to eq [
+        'Use nested module/class definitions instead of compact style.'
+      ]
+      expect(cop.highlights).to eq ['FooClass::BarClass']
+    end
+
     it 'registers an offense for not nested modules' do
       inspect_source(cop, ['module FooModule::BarModule',
                            'end'])


### PR DESCRIPTION
Fixes https://github.com/bbatsov/rubocop/issues/3112