### PR TITLE
[Fix #3114] Fix alignment of end in EmptyElse

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## master (unreleased)
 
+### Bug fixes
+
+* [#3114](https://github.com/bbatsov/rubocop/issues/3114): Fix alignment `end` when auto-correcting `Style/EmptyElse`. ([@rrosenblum][])
+
 ## 0.40.0 (2016-05-09)
 
 ### New features

--- a/lib/rubocop/cop/style/empty_else.rb
+++ b/lib/rubocop/cop/style/empty_else.rb
@@ -98,18 +98,13 @@ module RuboCop
         end
 
         def nil_check(node, else_clause)
-          return unless else_clause && else_clause.type == :nil
+          return unless else_clause && else_clause.nil_type?
           add_offense(node, node.location, MSG)
         end
 
         def both_check(node, else_clause)
-          return if node.loc.else.nil?
-
-          if else_clause.nil?
-            add_offense(node, :else, MSG)
-          elsif else_clause.type == :nil
-            add_offense(node, :else, MSG)
-          end
+          empty_check(node, else_clause)
+          nil_check(node, else_clause)
         end
 
         def autocorrect(node)

--- a/lib/rubocop/cop/style/empty_else.rb
+++ b/lib/rubocop/cop/style/empty_else.rb
@@ -119,8 +119,9 @@ module RuboCop
             end_pos = if node.loc.end
                         node.loc.end.begin_pos
                       else
-                        node.source_range.end_pos + 1
+                        node.parent.loc.end.begin_pos
                       end
+
             range = Parser::Source::Range.new(node.source_range.source_buffer,
                                               node.loc.else.begin_pos,
                                               end_pos)

--- a/spec/rubocop/cop/style/empty_else_spec.rb
+++ b/spec/rubocop/cop/style/empty_else_spec.rb
@@ -46,15 +46,38 @@ describe RuboCop::Cop::Style::EmptyElse do
 
     context 'given an if-statement' do
       context 'with a completely empty else-clause' do
-        let(:source) { 'if a; foo else end' }
-        let(:corrected_source) { 'if a; foo end' }
+        context 'using semicolons' do
+          let(:source) { 'if a; foo else end' }
+          let(:corrected_source) { 'if a; foo end' }
 
-        it 'registers an offense' do
-          inspect_source(cop, source)
-          expect(cop.messages).to eq(['Redundant `else`-clause.'])
+          it 'registers an offense' do
+            inspect_source(cop, source)
+            expect(cop.messages).to eq(['Redundant `else`-clause.'])
+          end
+
+          it_behaves_like 'auto-correct', 'if'
         end
 
-        it_behaves_like 'auto-correct', 'if'
+        context 'when the result is assigned to a variable' do
+          let(:source) do
+            ['if a',
+             '  foo',
+             'else',
+             'end'].join("\n")
+          end
+          let(:corrected_source) do
+            ['if a',
+             '  foo',
+             'end'].join("\n")
+          end
+
+          it 'registers an offense' do
+            inspect_source(cop, source)
+            expect(cop.messages).to eq(['Redundant `else`-clause.'])
+          end
+
+          it_behaves_like 'auto-correct', 'if'
+        end
       end
 
       context 'with an else-clause containing only the literal nil' do
@@ -168,6 +191,63 @@ describe RuboCop::Cop::Style::EmptyElse do
       end
 
       context 'with an else-clause containing only the literal nil' do
+        context 'when standalone' do
+          let(:source) do
+            ['if a',
+             '  foo',
+             'elsif b',
+             '  bar',
+             'else',
+             '  nil',
+             'end'].join("\n")
+          end
+
+          let(:corrected_source) do
+            ['if a',
+             '  foo',
+             'elsif b',
+             '  bar',
+             'end'].join("\n")
+          end
+
+          it 'registers an offense' do
+            inspect_source(cop, source)
+            expect(cop.messages).to eq(['Redundant `else`-clause.'])
+          end
+
+          it_behaves_like 'auto-correct', 'if'
+        end
+
+        context 'when the result is assigned to a variable' do
+          let(:source) do
+            ['foobar = if a',
+             '           foo',
+             '         elsif b',
+             '           bar',
+             '         else',
+             '           nil',
+             '         end'].join("\n")
+          end
+
+          let(:corrected_source) do
+            ['foobar = if a',
+             '           foo',
+             '         elsif b',
+             '           bar',
+             '         end'].join("\n")
+          end
+
+          it 'registers an offense' do
+            inspect_source(cop, source)
+            expect(cop.messages).to eq(['Redundant `else`-clause.'])
+          end
+
+          it_behaves_like 'auto-correct', 'if'
+        end
+      end
+
+      context 'with an else-clause containing only the literal nil ' \
+              'using semicolons' do
         let(:source) { 'if a; foo elsif b; bar else nil end' }
         let(:corrected_source) { 'if a; foo elsif b; bar end' }
 
@@ -238,15 +318,46 @@ describe RuboCop::Cop::Style::EmptyElse do
       end
 
       context 'with an else-clause containing only the literal nil' do
-        let(:source) { 'case v; when a; foo; when b; bar; else nil end' }
-        let(:corrected_source) { 'case v; when a; foo; when b; bar; end' }
+        context 'using semicolons' do
+          let(:source) { 'case v; when a; foo; when b; bar; else nil end' }
+          let(:corrected_source) { 'case v; when a; foo; when b; bar; end' }
 
-        it 'registers an offense' do
-          inspect_source(cop, source)
-          expect(cop.messages).to eq(['Redundant `else`-clause.'])
+          it 'registers an offense' do
+            inspect_source(cop, source)
+            expect(cop.messages).to eq(['Redundant `else`-clause.'])
+          end
+
+          it_behaves_like 'auto-correct', 'case'
         end
 
-        it_behaves_like 'auto-correct', 'case'
+        context 'when the result is assigned to a variable' do
+          let(:source) do
+            ['foobar = case v',
+             '         when a',
+             '           foo',
+             '         when b',
+             '           bar',
+             '         else',
+             '           nil',
+             '         end'].join("\n")
+          end
+
+          let(:corrected_source) do
+            ['foobar = case v',
+             '         when a',
+             '           foo',
+             '         when b',
+             '           bar',
+             '         end'].join("\n")
+          end
+
+          it 'registers an offense' do
+            inspect_source(cop, source)
+            expect(cop.messages).to eq(['Redundant `else`-clause.'])
+          end
+
+          it_behaves_like 'auto-correct', 'case'
+        end
       end
 
       context 'with an else-clause with side-effects' do


### PR DESCRIPTION
This fixes #3114. I also found some redundancies in the `both` check.