### PR TITLE
Support #distinct in UniqBeforePluck

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## master (unreleased)
 
+* `Rails/UniqBeforePluck` now recognizes `distinct` before `pluck` as well.
+
 ## 0.40.0 (2016-05-09)
 
 ### New features

--- a/spec/rubocop/cop/rails/uniq_before_pluck_spec.rb
+++ b/spec/rubocop/cop/rails/uniq_before_pluck_spec.rb
@@ -4,25 +4,35 @@
 require 'spec_helper'
 
 describe RuboCop::Cop::Rails::UniqBeforePluck do
-  let(:corrected) { 'Model.uniq.pluck(:id)' }
   subject(:cop) { described_class.new }
 
-  shared_examples_for 'UniqBeforePluck cop' do |source|
-    it 'finds and corrects use of uniq after pluck' do
+  shared_examples_for 'UniqBeforePluck cop' do |method_name, source|
+    let(:corrected) { "Model.#{method_name}.pluck(:id)" }
+
+    it "finds and corrects use of #{method_name} after pluck" do
       inspect_source(cop, source)
-      expect(cop.messages).to eq([described_class::MSG])
-      expect(cop.highlights).to eq(['uniq'])
+      expect(cop.messages).to eq([described_class::MSG % method_name])
+      expect(cop.highlights).to eq([method_name])
       expect(autocorrect_source(cop, source)).to eq(corrected)
     end
   end
 
-  it_behaves_like 'UniqBeforePluck cop',
+  it_behaves_like 'UniqBeforePluck cop', 'distinct',
+                  'Model.pluck(:id).distinct'
+
+  it_behaves_like 'UniqBeforePluck cop', 'distinct',
+                  ['Model.pluck(:id)', '  .distinct']
+
+  it_behaves_like 'UniqBeforePluck cop', 'distinct',
+                  ['Model.pluck(:id).', '  distinct']
+
+  it_behaves_like 'UniqBeforePluck cop', 'uniq',
                   'Model.pluck(:id).uniq'
 
-  it_behaves_like 'UniqBeforePluck cop',
+  it_behaves_like 'UniqBeforePluck cop', 'uniq',
                   ['Model.pluck(:id)', '  .uniq']
 
-  it_behaves_like 'UniqBeforePluck cop',
+  it_behaves_like 'UniqBeforePluck cop', 'uniq',
                   ['Model.pluck(:id).', '  uniq']
 
   it 'ignores use of uniq before pluck' do


### PR DESCRIPTION
* `#distinct` is a synonym for `#uniq` in ActiveRecord relations.

Maybe this is not useful because of #3122, but it's here in case there is also a good solution to that issue.