### PR TITLE
Fix `Rails/UniqBeforePluck` to ignore uniq with block

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 * [#3114](https://github.com/bbatsov/rubocop/issues/3114): Fix alignment `end` when auto-correcting `Style/EmptyElse`. ([@rrosenblum][])
 * [#3120](https://github.com/bbatsov/rubocop/issues/3120): Fix `Lint/UselessAccessModifier` reporting useless access modifiers inside {Class,Module,Struct}.new blocks. ([@owst][])
+* [#3125](https://github.com/bbatsov/rubocop/issues/3125): Fix `Rails/UniqBeforePluck` to ignore `uniq` with block. ([@tejasbubane][])
 
 ## 0.40.0 (2016-05-09)
 

--- a/lib/rubocop/cop/rails/uniq_before_pluck.rb
+++ b/lib/rubocop/cop/rails/uniq_before_pluck.rb
@@ -23,13 +23,14 @@ module RuboCop
 
         def on_send(node)
           receiver, method_name, *_args = *node
-
           unless method_name == :uniq &&
                  !receiver.nil? &&
                  receiver.send_type? &&
-                 receiver.children[1] == :pluck
+                 receiver.children[1] == :pluck &&
+                 !with_block?(node)
             return
           end
+
           add_offense(node, :selector, MSG)
         end
 
@@ -50,6 +51,12 @@ module RuboCop
             )
             corrector.insert_before(receiver.loc.dot.begin, DOT_UNIQ)
           end
+        end
+
+        private
+
+        def with_block?(node)
+          node.parent && node.parent.block_type?
         end
       end
     end

--- a/spec/rubocop/cop/rails/uniq_before_pluck_spec.rb
+++ b/spec/rubocop/cop/rails/uniq_before_pluck_spec.rb
@@ -7,36 +7,51 @@ describe RuboCop::Cop::Rails::UniqBeforePluck do
   let(:corrected) { 'Model.uniq.pluck(:id)' }
   subject(:cop) { described_class.new }
 
-  shared_examples_for 'UniqBeforePluck cop' do |source|
-    it 'finds and corrects use of uniq after pluck' do
-      inspect_source(cop, source)
-      expect(cop.messages).to eq([described_class::MSG])
-      expect(cop.highlights).to eq(['uniq'])
-      expect(autocorrect_source(cop, source)).to eq(corrected)
+  shared_examples_for 'UniqBeforePluck cop' do |source, action|
+    if action == :correct
+      it 'finds and corrects use of uniq after pluck' do
+        inspect_source(cop, source)
+        expect(cop.messages).to eq([described_class::MSG])
+        expect(cop.highlights).to eq(['uniq'])
+        expect(autocorrect_source(cop, source)).to eq(corrected)
+      end
+    else
+      it 'ignores the source without any errors' do
+        inspect_source(cop, source)
+        expect(cop.messages).to be_empty
+        expect(cop.highlights).to be_empty
+        expect(cop.offenses).to be_empty
+        expect(autocorrect_source(cop, source)).to eq(source)
+      end
     end
   end
 
   it_behaves_like 'UniqBeforePluck cop',
-                  'Model.pluck(:id).uniq'
+                  'Model.pluck(:id).uniq', :correct
 
   it_behaves_like 'UniqBeforePluck cop',
-                  ['Model.pluck(:id)', '  .uniq']
+                  ['Model.pluck(:id)', '  .uniq'], :correct
 
   it_behaves_like 'UniqBeforePluck cop',
-                  ['Model.pluck(:id).', '  uniq']
+                  ['Model.pluck(:id).', '  uniq'], :correct
 
-  it 'ignores use of uniq before pluck' do
-    source = 'Model.where(foo: 1).uniq.pluck(:something)'
-    inspect_source(cop, source)
-    expect(cop.messages).to be_empty
-    expect(cop.highlights).to be_empty
-    expect(cop.offenses).to be_empty
-    expect(autocorrect_source(cop, source)).to eq(source)
+  context 'uniq before pluck' do
+    it_behaves_like 'UniqBeforePluck cop',
+                    'Model.where(foo: 1).uniq.pluck(:something)', :ignore
   end
 
-  it 'ignores the use of uniq without a receiver' do
-    source = 'uniq.something'
-    inspect_source(cop, source)
-    expect(cop.offenses).to be_empty
+  context 'uniq without a receiver' do
+    it_behaves_like 'UniqBeforePluck cop',
+                    'uniq.something', :ignore
+  end
+
+  context 'uniq without pluck' do
+    it_behaves_like 'UniqBeforePluck cop',
+                    'Model.uniq', :ignore
+  end
+
+  context 'uniq with a block' do
+    it_behaves_like 'UniqBeforePluck cop',
+                    'Model.where(foo: 1).pluck(:id).uniq { |k| k[0] }', :ignore
   end
 end


### PR DESCRIPTION
Before submitting a PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [x] Used the same coding conventions as the rest of the project.
* [x] Feature branch is up-to-date with `master` (if not - rebase it)
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] All tests are passing.
* [x] The new code doesn't generate RuboCop offenses.
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.

[1]: http://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html

Issue #3122 
Also moved around some code in specs to use shared_context for ignored cases
Might conflict with https://github.com/bbatsov/rubocop/pull/3124