### PR TITLE
[Fix #3120] Fix #new visibility modifier scopes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Bug fixes
 
 * [#3114](https://github.com/bbatsov/rubocop/issues/3114): Fix alignment `end` when auto-correcting `Style/EmptyElse`. ([@rrosenblum][])
+* [#3120](https://github.com/bbatsov/rubocop/issues/3120): Fix `Lint/UselessAccessModifier` reporting useless access modifiers inside {Class,Module,Struct}.new blocks. ([@owst][])
 
 ## 0.40.0 (2016-05-09)
 

--- a/spec/rubocop/cop/lint/useless_access_modifier_spec.rb
+++ b/spec/rubocop/cop/lint/useless_access_modifier_spec.rb
@@ -603,6 +603,26 @@ describe RuboCop::Cop::Lint::UselessAccessModifier do
     end
   end
 
+  shared_examples 'def in new block' do |klass, modifier|
+    it "doesn't register an offense if a method is defined in #{klass}.new" do
+      src = ["#{klass}.new do",
+             "  #{modifier}",
+             '  def foo',
+             '  end',
+             'end']
+      inspect_source(cop, src)
+      expect(cop.offenses).to be_empty
+    end
+
+    it "registers an offense if no method is defined in #{klass}.new" do
+      src = ["#{klass}.new do",
+             "  #{modifier}",
+             'end']
+      inspect_source(cop, src)
+      expect(cop.offenses.size).to eq(1)
+    end
+  end
+
   shared_examples 'method defined using instance_eval' do |modifier|
     it "doesn't register an offense if a method is defined" do
       src = ['A.instance_eval do',
@@ -707,6 +727,12 @@ describe RuboCop::Cop::Lint::UselessAccessModifier do
   %w(protected private).each do |modifier|
     it_behaves_like('method defined using class_eval', modifier)
     it_behaves_like('method defined using instance_eval', modifier)
+  end
+
+  %w(Class Module Struct).each do |klass|
+    %w(protected private).each do |modifier|
+      it_behaves_like('def in new block', klass, modifier)
+    end
   end
 
   %w(module class).each do |keyword|


### PR DESCRIPTION
Blocks passed to `{Class,Module,Struct}.new` create a new scope, in a
similar way to Klass.class_eval. This was a regression introduced by my
PR #3060 where I forgot about these method calls.

Before submitting a PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [x] Used the same coding conventions as the rest of the project.
* [x] Feature branch is up-to-date with `master` (if not - rebase it)
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] All tests are passing.
* [x] The new code doesn't generate RuboCop offenses.
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.

[1]: http://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html
