### PR TITLE
FrozenStringLiteralComment cop works with file doesn't have any token

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 * [#3116](https://github.com/bbatsov/rubocop/issues/3116): `Style/SpaceAroundKeyword` allows `&.` method calls after `super` and `yield`. ([@segiddins][])
 * [#3131](https://github.com/bbatsov/rubocop/issues/3131): Fix `Style/ZeroLengthPredicate` to ignore `size` and `length` variables. ([@tejasbubane][])
 * [#3146](https://github.com/bbatsov/rubocop/pull/3146): Fix `NegatedIf` and `NegatedWhile` to ignore double negations. ([@natalzia-paperless][])
+* [#3140](https://github.com/bbatsov/rubocop/pull/3140): `Style/FrozenStringLiteralComment` works with file doesn't have any tokens. ([@pocke][])
 
 ## 0.40.0 (2016-05-09)
 

--- a/lib/rubocop/cop/style/frozen_string_literal_comment.rb
+++ b/lib/rubocop/cop/style/frozen_string_literal_comment.rb
@@ -18,7 +18,7 @@ module RuboCop
 
         def investigate(processed_source)
           return if style == :when_needed && target_ruby_version < 2.3
-          return if processed_source.buffer.source.empty?
+          return if processed_source.tokens.empty?
 
           return if frozen_string_literal_comment_exists?(processed_source)
 

--- a/spec/rubocop/cop/style/frozen_string_literal_comment_spec.rb
+++ b/spec/rubocop/cop/style/frozen_string_literal_comment_spec.rb
@@ -19,6 +19,12 @@ describe RuboCop::Cop::Style::FrozenStringLiteralComment, :config do
       expect(cop.offenses).to be_empty
     end
 
+    it 'accepts a source with no tokens' do
+      inspect_source(cop, ' ')
+
+      expect(cop.offenses).to be_empty
+    end
+
     it 'accepts a frozen string literal on the top line' do
       inspect_source(cop, ['# frozen_string_literal: true',
                            'puts 1'])


### PR DESCRIPTION
## Problem

FrozenStringLiteralComment cop doesn't work with space only file.

e.g.)

```sh
$ ruby -e 'print " "' > test.rb
$ rubocop test.rb --debug
An error occurred while Style/FrozenStringLiteralComment cop was inspecting /home/pocke/ghq/github.com/bbatsov/rubocop/test.rb.

1 error occurred:
An error occurred while Style/FrozenStringLiteralComment cop was inspecting /home/pocke/ghq/github.com/bbatsov/rubocop/test.rb.
Errors are usually caused by RuboCop bugs.
Please, report your problems to RuboCop's issue tracker.
Mention the following information in the issue report:
0.40.0 (using Parser 2.3.1.0, running on ruby 2.3.1 x86_64-linux)
For /home/pocke/ghq/github.com/bbatsov/rubocop: configuration from /home/pocke/ghq/github.com/bbatsov/rubocop/.rubocop.yml
Inheriting configuration from /home/pocke/ghq/github.com/bbatsov/rubocop/.rubocop_todo.yml
Default configuration from /home/pocke/.gem/ruby/2.3.0/gems/rubocop-0.40.0/config/default.yml
Inheriting configuration from /home/pocke/.gem/ruby/2.3.0/gems/rubocop-0.40.0/config/enabled.yml
Inheriting configuration from /home/pocke/.gem/ruby/2.3.0/gems/rubocop-0.40.0/config/disabled.yml
Inspecting 1 file
Scanning /home/pocke/ghq/github.com/bbatsov/rubocop/test.rb
undefined method `text' for nil:NilClass
/home/pocke/.gem/ruby/2.3.0/gems/rubocop-0.40.0/lib/rubocop/cop/style/frozen_string_literal_comment.rb:45:in `last_special_comment'
/home/pocke/.gem/ruby/2.3.0/gems/rubocop-0.40.0/lib/rubocop/cop/style/frozen_string_literal_comment.rb:59:in `offense'
/home/pocke/.gem/ruby/2.3.0/gems/rubocop-0.40.0/lib/rubocop/cop/style/frozen_string_literal_comment.rb:25:in `investigate'
/home/pocke/.gem/ruby/2.3.0/gems/rubocop-0.40.0/lib/rubocop/cop/commissioner.rb:91:in `block (2 levels) in invoke_custom_processing'
/home/pocke/.gem/ruby/2.3.0/gems/rubocop-0.40.0/lib/rubocop/cop/commissioner.rb:97:in `with_cop_error_handling'
/home/pocke/.gem/ruby/2.3.0/gems/rubocop-0.40.0/lib/rubocop/cop/commissioner.rb:90:in `block in invoke_custom_processing'
/home/pocke/.gem/ruby/2.3.0/gems/rubocop-0.40.0/lib/rubocop/cop/commissioner.rb:87:in `each'
/home/pocke/.gem/ruby/2.3.0/gems/rubocop-0.40.0/lib/rubocop/cop/commissioner.rb:87:in `invoke_custom_processing'
/home/pocke/.gem/ruby/2.3.0/gems/rubocop-0.40.0/lib/rubocop/cop/commissioner.rb:57:in `investigate'
/home/pocke/.gem/ruby/2.3.0/gems/rubocop-0.40.0/lib/rubocop/cop/team.rb:70:in `inspect_file'
/home/pocke/.gem/ruby/2.3.0/gems/rubocop-0.40.0/lib/rubocop/runner.rb:205:in `inspect_file'
/home/pocke/.gem/ruby/2.3.0/gems/rubocop-0.40.0/lib/rubocop/runner.rb:175:in `block in do_inspection_loop'
/home/pocke/.gem/ruby/2.3.0/gems/rubocop-0.40.0/lib/rubocop/runner.rb:165:in `loop'
/home/pocke/.gem/ruby/2.3.0/gems/rubocop-0.40.0/lib/rubocop/runner.rb:165:in `do_inspection_loop'
/home/pocke/.gem/ruby/2.3.0/gems/rubocop-0.40.0/lib/rubocop/runner.rb:87:in `process_file'
/home/pocke/.gem/ruby/2.3.0/gems/rubocop-0.40.0/lib/rubocop/runner.rb:59:in `block in inspect_files'
/home/pocke/.gem/ruby/2.3.0/gems/rubocop-0.40.0/lib/rubocop/runner.rb:57:in `each'
/home/pocke/.gem/ruby/2.3.0/gems/rubocop-0.40.0/lib/rubocop/runner.rb:57:in `inspect_files'
/home/pocke/.gem/ruby/2.3.0/gems/rubocop-0.40.0/lib/rubocop/runner.rb:35:in `run'
/home/pocke/.gem/ruby/2.3.0/gems/rubocop-0.40.0/lib/rubocop/cli.rb:30:in `run'
/home/pocke/.gem/ruby/2.3.0/gems/rubocop-0.40.0/bin/rubocop:14:in `block in <top (required)>'
/usr/lib/ruby/2.3.0/benchmark.rb:308:in `realtime'
/home/pocke/.gem/ruby/2.3.0/gems/rubocop-0.40.0/bin/rubocop:13:in `<top (required)>'
/home/pocke/.gem/ruby/2.3.0/bin/rubocop:23:in `load'
/home/pocke/.gem/ruby/2.3.0/bin/rubocop:23:in `<main>'
C

Offenses:

test.rb:1:1: C: Style/Encoding: Missing utf-8 encoding comment.
test.rb:1:1: C: Style/TrailingWhitespace: Trailing whitespace detected.
test.rb:1:2: C: Style/TrailingBlankLines: Final newline missing.

1 file inspected, 3 offenses detected
Finished in 0.06579167600284563 seconds
```

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [x] Used the same coding conventions as the rest of the project.
* [x] Feature branch is up-to-date with `master` (if not - rebase it)
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] All tests are passing.
* [x] The new code doesn't generate RuboCop offenses.
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.

[1]: http://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html

