### PR TITLE
Fix `Style/MethodCallParentheses` to work with multiple assignments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 * [#3261](https://github.com/bbatsov/rubocop/pull/3261): Prefer `TargetRubyVersion` to `.ruby-version`. ([@tjwp][])
 * [#3249](https://github.com/bbatsov/rubocop/issues/3249): Account for `rescue nil` in `Style/ShadowedException`. ([@rrosenblum][])
 * Modify the highlighting in `Style/ShadowedException` to be more useful. Highlight just `rescue` area. ([@rrosenblum][])
+* [#3129](https://github.com/bbatsov/rubocop/issues/3129): Fix `Style/MethodCallParentheses` to work with multiple assignments. ([@tejasbubane][])
 
 ## 0.41.1 (2016-06-26)
 

--- a/spec/rubocop/cop/style/method_call_parentheses_spec.rb
+++ b/spec/rubocop/cop/style/method_call_parentheses_spec.rb
@@ -90,4 +90,21 @@ describe RuboCop::Cop::Style::MethodCallParentheses do
                               'Array.new',
                               'String.new'].join("\n"))
   end
+
+  context 'method call as argument' do
+    it 'accepts without parens' do
+      inspect_source(cop, '_a = c(d.e)')
+      expect(cop.offenses).to be_empty
+    end
+
+    it 'registers an offense with empty parens' do
+      inspect_source(cop, '_a = c(d())')
+      expect(cop.offenses.size).to eq 1
+    end
+
+    it 'registers an empty parens offense for multiple assignment' do
+      inspect_source(cop, '_a, _b, _c = d(e())')
+      expect(cop.offenses.size).to eq 1
+    end
+  end
 end


### PR DESCRIPTION
Closes #3129. 

`Style/MethodCallParenthesis` cop failed abruptly for multiple assignments. This PR fixes the issue.

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [x] Used the same coding conventions as the rest of the project.
* [x] Feature branch is up-to-date with `master` (if not - rebase it)
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] All tests are passing.
* [x] The new code doesn't generate RuboCop offenses.
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.

[1]: http://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html