### PR TITLE
Fix double negative conditional bug in `NegatedIf` and `NegatedWhile` style rules

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 * [#3125](https://github.com/bbatsov/rubocop/issues/3125): Fix `Rails/UniqBeforePluck` to ignore `uniq` with block. ([@tejasbubane][])
 * [#3116](https://github.com/bbatsov/rubocop/issues/3116): `Style/SpaceAroundKeyword` allows `&.` method calls after `super` and `yield`. ([@segiddins][])
 * [#3131](https://github.com/bbatsov/rubocop/issues/3131): Fix `Style/ZeroLengthPredicate` to ignore `size` and `length` variables. ([@tejasbubane][])
+* [#3146](https://github.com/bbatsov/rubocop/pull/3146): Fix `NegatedIf` and `NegatedWhile` to ignore double negations. ([@natalzia-paperless][])
 
 ## 0.40.0 (2016-05-09)
 
@@ -2168,3 +2169,4 @@
 [@tjwp]: https://github.com/tjwp
 [@neodelf]: https://github.com/neodelf
 [@josh]: https://github.com/josh
+[@natalzia-paperless]: https://github.com/natalzia-paperless

--- a/lib/rubocop/cop/mixin/negative_conditional.rb
+++ b/lib/rubocop/cop/mixin/negative_conditional.rb
@@ -6,17 +6,19 @@ module RuboCop
     # Some common code shared between FavorUnlessOverNegatedIf and
     # FavorUntilOverNegatedWhile.
     module NegativeConditional
+      def self.included(mod)
+        mod.def_node_matcher :single_negative?, '(send !(send _ :!) :!)'
+      end
+
       def check_negative_conditional(node)
         condition, _body, _rest = *node
 
         # Look at last expression of contents if there are parentheses
         # around condition.
         condition = condition.children.last while condition.type == :begin
-        return unless condition.type == :send
 
-        _object, method = *condition
-        return unless method == :! && !(node.loc.respond_to?(:else) &&
-                                        node.loc.else)
+        return unless single_negative?(condition) &&
+                      !(node.loc.respond_to?(:else) && node.loc.else)
 
         add_offense(node, :expression)
       end

--- a/spec/rubocop/cop/style/negated_if_spec.rb
+++ b/spec/rubocop/cop/style/negated_if_spec.rb
@@ -68,6 +68,15 @@ describe RuboCop::Cop::Style::NegatedIf do
     expect(cop.offenses).to be_empty
   end
 
+  it 'accepts an if where the condition is doubly negated' do
+    inspect_source(cop,
+                   ['if !!condition',
+                    '  some_method',
+                    'end',
+                    'some_method if !!condition'])
+    expect(cop.offenses).to be_empty
+  end
+
   it 'is not confused by negated elsif' do
     inspect_source(cop,
                    ['if test.is_a?(String)',

--- a/spec/rubocop/cop/style/negated_while_spec.rb
+++ b/spec/rubocop/cop/style/negated_while_spec.rb
@@ -39,7 +39,7 @@ describe RuboCop::Cop::Style::NegatedWhile do
     expect(cop.offenses.map(&:line)).to eq([1, 4])
   end
 
-  it 'accepts an while where only part of the condition is negated' do
+  it 'accepts a while where only part of the condition is negated' do
     inspect_source(cop,
                    ['while !a_condition && another_condition',
                     '  some_method',
@@ -48,6 +48,15 @@ describe RuboCop::Cop::Style::NegatedWhile do
                     '  some_method',
                     'end',
                     'some_method while not a_condition or other_cond'])
+    expect(cop.messages).to be_empty
+  end
+
+  it 'accepts a while where the condition is doubly negated' do
+    inspect_source(cop,
+                   ['while !!a_condition',
+                    '  some_method',
+                    'end',
+                    'some_method while !!a_condition'])
     expect(cop.messages).to be_empty
   end
 


### PR DESCRIPTION
Currently you receive a negated if/while error from Rubocop if you have a conditional that is double negated. Rubocop should have awareness of whether there is a single `!` or two. In the event that your line reads something akin to `if !!conditional` Rubocop should only fail on the DoubleNegation rule.

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [x] Used the same coding conventions as the rest of the project.
* [x] Feature branch is up-to-date with `master` (if not - rebase it)
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] All tests are passing.
* [x] The new code doesn't generate RuboCop offenses.
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.

[1]: http://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html