### PR TITLE
Ignore symbols ending with ?/! in `Style/HashSyntax`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,10 @@
 * [#3140](https://github.com/bbatsov/rubocop/pull/3140): `Style/FrozenStringLiteralComment` works with file doesn't have any tokens. ([@pocke][])
 * [#3154](https://github.com/bbatsov/rubocop/issues/3154): Fix handling of `()` in `Style/RedundantParentheses`. ([@lumeet][])
 
+### Changes
+
+* [#3149](https://github.com/bbatsov/rubocop/pull/3149): Make `Style/HashSyntax` configurable to not report hash rocket syntax for symbols ending with ? or ! when using ruby19 style. ([@owst][])
+
 ## 0.40.0 (2016-05-09)
 
 ### New features

--- a/config/default.yml
+++ b/config/default.yml
@@ -521,8 +521,10 @@ Style/HashSyntax:
     - ruby19
     - ruby19_no_mixed_keys
     - hash_rockets
-# Force hashes that have a symbol value to use hash rockets
+  # Force hashes that have a symbol value to use hash rockets
   UseHashRocketsWithSymbolValues: false
+  # Do not suggest { a?: 1 } over { :a? => 1 } in ruby19 style
+  PreferHashRocketsForNonAlnumEndingSymbols: false
 
 Style/IfUnlessModifier:
   MaxLineLength: 80

--- a/lib/rubocop/cop/style/hash_syntax.rb
+++ b/lib/rubocop/cop/style/hash_syntax.rb
@@ -96,11 +96,18 @@ module RuboCop
 
           return false unless key.sym_type?
 
-          valid_19_syntax_symbol?(key.source)
+          acceptable_19_syntax_symbol?(key.source)
         end
 
-        def valid_19_syntax_symbol?(sym_name)
+        def acceptable_19_syntax_symbol?(sym_name)
           sym_name.sub!(/\A:/, '')
+
+          if cop_config['PreferHashRocketsForNonAlnumEndingSymbols']
+            # Prefer { :production? => false } over { production?: false } and
+            # similarly for other non-alnum final characters (except quotes,
+            # to prefer { "x y": 1 } over { :"x y" => 1 }).
+            return false unless sym_name =~ /[\p{Alnum}"']\z/
+          end
 
           # Most hash keys can be matched against a simple regex.
           return true if sym_name =~ /\A[_a-z]\w*[?!]?\z/i


### PR DESCRIPTION
Perhaps a slightly personal taste, but I think 
```
{ :development? => true }
```
 reads better/is clearer than 
```
{ development?: true }
```
and therefore Rubocop shouldn't suggest changing the former to the latter. (Similarly for symbols ending in `!` e.g. `{ :raise_on_invalid! => true }`.

As an example, the original line I wrote that triggered this was:
```
expect(Rails).to receive(:env).and_return(double(:production? => true)) 
```

I'd be interested to know what others think of this one.

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [x] Used the same coding conventions as the rest of the project.
* [x] Feature branch is up-to-date with `master` (if not - rebase it)
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] All tests are passing.
* [x] The new code doesn't generate RuboCop offenses.
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.

[1]: http://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html

