### PR TITLE
Style::MultilineLiteralBraceLayout fixed: ignore single-line nodes

### DIFF
--- a/lib/rubocop/cop/mixin/multiline_literal_brace_layout.rb
+++ b/lib/rubocop/cop/mixin/multiline_literal_brace_layout.rb
@@ -9,6 +9,7 @@ module RuboCop
       include ConfigurableEnforcedStyle
 
       def check_brace_layout(node)
+        return unless node.multiline?
         return unless node.loc.begin # Ignore implicit literals.
         return if children(node).empty? # Ignore empty literals.
 

--- a/spec/rubocop/cop/style/multiline_array_brace_layout_spec.rb
+++ b/spec/rubocop/cop/style/multiline_array_brace_layout_spec.rb
@@ -5,29 +5,48 @@ require 'spec_helper'
 
 describe RuboCop::Cop::Style::MultilineArrayBraceLayout, :config do
   subject(:cop) { described_class.new(config) }
-  let(:cop_config) { { 'EnforcedStyle' => 'symmetrical' } }
 
-  it 'ignores implicit arrays' do
-    inspect_source(cop, ['foo = a,',
-                         'b'])
+  shared_examples 'common' do
+    it 'ignores implicit arrays' do
+      inspect_source(cop, ['foo = a,',
+                           'b'])
 
-    expect(cop.offenses).to be_empty
+      expect(cop.offenses).to be_empty
+    end
+
+    it 'ignores single-line arrays' do
+      inspect_source(cop, '[a, b, c]')
+
+      expect(cop.offenses).to be_empty
+    end
+
+    it 'ignores empty arrays' do
+      inspect_source(cop, '[]')
+
+      expect(cop.offenses).to be_empty
+    end
+
+    include_examples 'multiline literal brace layout' do
+      let(:open) { '[' }
+      let(:close) { ']' }
+    end
   end
 
-  it 'ignores single-line arrays' do
-    inspect_source(cop, '[a, b, c]')
+  context 'Symmetrical braces style' do
+    let(:cop_config) { { 'EnforcedStyle' => 'symmetrical' } }
 
-    expect(cop.offenses).to be_empty
+    it_behaves_like 'common'
   end
 
-  it 'ignores empty arrays' do
-    inspect_source(cop, '[]')
+  context 'Braces on a new line style' do
+    let(:cop_config) { { 'EnforcedStyle' => 'new_line' } }
 
-    expect(cop.offenses).to be_empty
+    it_behaves_like 'common'
   end
 
-  include_examples 'multiline literal brace layout' do
-    let(:open) { '[' }
-    let(:close) { ']' }
+  context 'Braces on the same line style' do
+    let(:cop_config) { { 'EnforcedStyle' => 'same_line' } }
+
+    it_behaves_like 'common'
   end
 end

--- a/spec/rubocop/cop/style/multiline_hash_brace_layout_spec.rb
+++ b/spec/rubocop/cop/style/multiline_hash_brace_layout_spec.rb
@@ -5,33 +5,52 @@ require 'spec_helper'
 
 describe RuboCop::Cop::Style::MultilineHashBraceLayout, :config do
   subject(:cop) { described_class.new(config) }
-  let(:cop_config) { { 'EnforcedStyle' => 'symmetrical' } }
 
-  it 'ignores implicit hashes' do
-    inspect_source(cop, ['foo(a: 1,',
-                         'b: 2)'])
+  shared_examples 'common' do
+    it 'ignores implicit hashes' do
+      inspect_source(cop, ['foo(a: 1,',
+                           'b: 2)'])
 
-    expect(cop.offenses).to be_empty
+      expect(cop.offenses).to be_empty
+    end
+
+    it 'ignores single-line hashes' do
+      inspect_source(cop, '{a: 1, b: 2}')
+
+      expect(cop.offenses).to be_empty
+    end
+
+    it 'ignores empty hashes' do
+      inspect_source(cop, '{}')
+
+      expect(cop.offenses).to be_empty
+    end
+
+    include_examples 'multiline literal brace layout' do
+      let(:open) { '{' }
+      let(:close) { '}' }
+      let(:a) { 'a: 1' }
+      let(:b) { 'b: 2' }
+      let(:multi_prefix) { 'b: ' }
+      let(:multi) { ['[', '1', ']'] }
+    end
   end
 
-  it 'ignores single-line hashes' do
-    inspect_source(cop, '{a: 1, b: 2}')
+  context 'Symmetrical braces style' do
+    let(:cop_config) { { 'EnforcedStyle' => 'symmetrical' } }
 
-    expect(cop.offenses).to be_empty
+    it_behaves_like 'common'
   end
 
-  it 'ignores empty hashes' do
-    inspect_source(cop, '{}')
+  context 'Braces on a new line style' do
+    let(:cop_config) { { 'EnforcedStyle' => 'new_line' } }
 
-    expect(cop.offenses).to be_empty
+    it_behaves_like 'common'
   end
 
-  include_examples 'multiline literal brace layout' do
-    let(:open) { '{' }
-    let(:close) { '}' }
-    let(:a) { 'a: 1' }
-    let(:b) { 'b: 2' }
-    let(:multi_prefix) { 'b: ' }
-    let(:multi) { ['[', '1', ']'] }
+  context 'Braces on the same line style' do
+    let(:cop_config) { { 'EnforcedStyle' => 'same_line' } }
+
+    it_behaves_like 'common'
   end
 end

--- a/spec/rubocop/cop/style/multiline_method_call_brace_layout_spec.rb
+++ b/spec/rubocop/cop/style/multiline_method_call_brace_layout_spec.rb
@@ -5,29 +5,48 @@ require 'spec_helper'
 
 describe RuboCop::Cop::Style::MultilineMethodCallBraceLayout, :config do
   subject(:cop) { described_class.new(config) }
-  let(:cop_config) { { 'EnforcedStyle' => 'symmetrical' } }
 
-  it 'ignores implicit calls' do
-    inspect_source(cop, ['foo 1,',
-                         '2'])
+  shared_examples 'common' do
+    it 'ignores implicit calls' do
+      inspect_source(cop, ['foo 1,',
+                           '2'])
 
-    expect(cop.offenses).to be_empty
+      expect(cop.offenses).to be_empty
+    end
+
+    it 'ignores single-line calls' do
+      inspect_source(cop, 'foo(1,2)')
+
+      expect(cop.offenses).to be_empty
+    end
+
+    it 'ignores calls without arguments' do
+      inspect_source(cop, 'puts')
+
+      expect(cop.offenses).to be_empty
+    end
+
+    include_examples 'multiline literal brace layout' do
+      let(:open) { 'foo(' }
+      let(:close) { ')' }
+    end
   end
 
-  it 'ignores single-line calls' do
-    inspect_source(cop, 'foo(1,2)')
+  context 'Symmetrical braces style' do
+    let(:cop_config) { { 'EnforcedStyle' => 'symmetrical' } }
 
-    expect(cop.offenses).to be_empty
+    it_behaves_like 'common'
   end
 
-  it 'ignores calls without arguments' do
-    inspect_source(cop, 'puts')
+  context 'Braces on a new line style' do
+    let(:cop_config) { { 'EnforcedStyle' => 'new_line' } }
 
-    expect(cop.offenses).to be_empty
+    it_behaves_like 'common'
   end
 
-  include_examples 'multiline literal brace layout' do
-    let(:open) { 'foo(' }
-    let(:close) { ')' }
+  context 'Braces on the same line style' do
+    let(:cop_config) { { 'EnforcedStyle' => 'same_line' } }
+
+    it_behaves_like 'common'
   end
 end

--- a/spec/rubocop/cop/style/multiline_method_definition_brace_layout_spec.rb
+++ b/spec/rubocop/cop/style/multiline_method_definition_brace_layout_spec.rb
@@ -5,35 +5,54 @@ require 'spec_helper'
 
 describe RuboCop::Cop::Style::MultilineMethodDefinitionBraceLayout, :config do
   subject(:cop) { described_class.new(config) }
-  let(:cop_config) { { 'EnforcedStyle' => 'symmetrical' } }
 
-  it 'ignores implicit defs' do
-    inspect_source(cop, ['def foo a: 1,',
-                         'b: 2',
-                         'end'])
+  shared_examples 'common' do
+    it 'ignores implicit defs' do
+      inspect_source(cop, ['def foo a: 1,',
+                           'b: 2',
+                           'end'])
 
-    expect(cop.offenses).to be_empty
+      expect(cop.offenses).to be_empty
+    end
+
+    it 'ignores single-line defs' do
+      inspect_source(cop, ['def foo(a,b)',
+                           'end'])
+
+      expect(cop.offenses).to be_empty
+    end
+
+    it 'ignores defs without params' do
+      inspect_source(cop, ['def foo',
+                           'end'])
+
+      expect(cop.offenses).to be_empty
+    end
+
+    include_examples 'multiline literal brace layout' do
+      let(:prefix) { 'def foo' }
+      let(:suffix) { 'end' }
+      let(:open) { '(' }
+      let(:close) { ')' }
+      let(:multi_prefix) { 'b: ' }
+    end
   end
 
-  it 'ignores single-line defs' do
-    inspect_source(cop, ['def foo(a,b)',
-                         'end'])
+  context 'Symmetrical braces style' do
+    let(:cop_config) { { 'EnforcedStyle' => 'symmetrical' } }
 
-    expect(cop.offenses).to be_empty
+    it_behaves_like 'common'
   end
 
-  it 'ignores defs without params' do
-    inspect_source(cop, ['def foo',
-                         'end'])
+  context 'Braces on a new line style' do
+    let(:cop_config) { { 'EnforcedStyle' => 'new_line' } }
 
-    expect(cop.offenses).to be_empty
+    it_behaves_like 'common'
   end
 
-  include_examples 'multiline literal brace layout' do
-    let(:prefix) { 'def foo' }
-    let(:suffix) { 'end' }
-    let(:open) { '(' }
-    let(:close) { ')' }
-    let(:multi_prefix) { 'b: ' }
+  context 'Braces on the same line style' do
+    let(:cop_config) { { 'EnforcedStyle' => 'same_line' } }
+
+    it_behaves_like 'common'
   end
 end


### PR DESCRIPTION
The style has had a behavior conflicting with its name.