### PR TITLE
Fix Style/Lambda whitespacing when auto-correct unparenthesized args

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@
 * [#3146](https://github.com/bbatsov/rubocop/pull/3146): Fix `NegatedIf` and `NegatedWhile` to ignore double negations. ([@natalzia-paperless][])
 * [#3140](https://github.com/bbatsov/rubocop/pull/3140): `Style/FrozenStringLiteralComment` works with file doesn't have any tokens. ([@pocke][])
 * [#3154](https://github.com/bbatsov/rubocop/issues/3154): Fix handling of `()` in `Style/RedundantParentheses`. ([@lumeet][])
+* [#3160](https://github.com/bbatsov/rubocop/pull/3160): `Style/Lambda` fix whitespacing when auto-correcting unparenthesized arguments. ([@palkan][])
 
 ## 0.40.0 (2016-05-09)
 

--- a/spec/rubocop/cop/style/lambda_spec.rb
+++ b/spec/rubocop/cop/style/lambda_spec.rb
@@ -279,6 +279,48 @@ describe RuboCop::Cop::Style::Lambda, :config do
                                            '  x',
                                            'end'].join("\n")
         end
+
+        context 'without parentheses' do
+          let(:source) do
+            ['-> hello do',
+             '  puts hello',
+             'end']
+          end
+
+          it_behaves_like 'registers an offense',
+                          'Use the `lambda` method for multiline lambdas.'
+          it_behaves_like 'auto-correct', ['lambda do |hello|',
+                                           '  puts hello',
+                                           'end'].join("\n")
+        end
+
+        context 'with no parentheses and bad spacing' do
+          let(:source) do
+            ['->   hello  do',
+             '  puts hello',
+             'end']
+          end
+
+          it_behaves_like 'registers an offense',
+                          'Use the `lambda` method for multiline lambdas.'
+          it_behaves_like 'auto-correct', ['lambda do |hello|',
+                                           '  puts hello',
+                                           'end'].join("\n")
+        end
+
+        context 'with no parentheses and many args' do
+          let(:source) do
+            ['->   hello, user  do',
+             '  puts hello',
+             'end']
+          end
+
+          it_behaves_like 'registers an offense',
+                          'Use the `lambda` method for multiline lambdas.'
+          it_behaves_like 'auto-correct', ['lambda do |hello, user|',
+                                           '  puts hello',
+                                           'end'].join("\n")
+        end
       end
     end
 


### PR DESCRIPTION
This PR makes autocorrect more accurate and replace

```ruby
# bad
-> hello do
  puts hello
end
```

with

```ruby
# good
lambda do |hello|
  puts hello
end
```

instead of

```ruby
# not so good
lambda  do |hello|
  puts hello
end
```