### PR TITLE
Add Fastlane's Fastfile to Rubocop Includes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 * [#2927](https://github.com/bbatsov/rubocop/issues/2927): Add autocorrect for `Rails/Validation` cop. ([@neodelf][])
 * [#3135](https://github.com/bbatsov/rubocop/pull/3135): Add new `Rails/OutputSafety` cop. ([@josh][])
+* [#3164](https://github.com/bbatsov/rubocop/pull/3164): Add [Fastlane](https://fastlane.tools/)'s Fastfile to the default Includes. ([@jules2689][])
 
 ### Bug fixes
 
@@ -2171,3 +2172,4 @@
 [@neodelf]: https://github.com/neodelf
 [@josh]: https://github.com/josh
 [@natalzia-paperless]: https://github.com/natalzia-paperless
+[@jules2689]: https://github.com/jules2689

--- a/config/default.yml
+++ b/config/default.yml
@@ -25,6 +25,8 @@ AllCops:
     - '**/Berksfile'
     - '**/Cheffile'
     - '**/Vagabondfile'
+    - '**/Fastfile'
+    - '**/*Fastfile'
   Exclude:
     - 'vendor/**/*'
   # Default formatter will be used if no -f/--format option is given.


### PR DESCRIPTION
[Fastlane](https://fastlane.tools/) is a mobile pipeline management tool used by tons of companies and maintained by Twitter. By convention `fastlane/Fastfile` and `fastlane/*Fastfile` are commonly used.

This would add those to the default Include patterns.
Unsure of tests for this area.
If anything needs to be done, it is worth noting that I am away for 2 weeks on vacation - so I can't do anything for a little bit :)