### PR TITLE
[Fix #3154] Fix handling of () in RedundantParentheses

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@
 * [#3131](https://github.com/bbatsov/rubocop/issues/3131): Fix `Style/ZeroLengthPredicate` to ignore `size` and `length` variables. ([@tejasbubane][])
 * [#3146](https://github.com/bbatsov/rubocop/pull/3146): Fix `NegatedIf` and `NegatedWhile` to ignore double negations. ([@natalzia-paperless][])
 * [#3140](https://github.com/bbatsov/rubocop/pull/3140): `Style/FrozenStringLiteralComment` works with file doesn't have any tokens. ([@pocke][])
+* [#3154](https://github.com/bbatsov/rubocop/issues/3154): Fix handling of `()` in `Style/RedundantParentheses`. ([@lumeet][])
 
 ## 0.40.0 (2016-05-09)
 

--- a/lib/rubocop/cop/style/redundant_parentheses.rb
+++ b/lib/rubocop/cop/style/redundant_parentheses.rb
@@ -32,7 +32,9 @@ module RuboCop
         end
 
         def parens_allowed?(node)
-          child  = node.children.first
+          child = node.children.first
+          return true unless child
+
           parent = node.parent
 
           # don't flag `break(1)`, etc

--- a/spec/rubocop/cop/style/redundant_parentheses_spec.rb
+++ b/spec/rubocop/cop/style/redundant_parentheses_spec.rb
@@ -102,6 +102,7 @@ describe RuboCop::Cop::Style::RedundantParentheses do
   it_behaves_like 'plausible', '+(1.foo)'
   it_behaves_like 'plausible', '-(1.foo.bar)'
   it_behaves_like 'plausible', '+(1.foo.bar)'
+  it_behaves_like 'plausible', '()'
 
   it_behaves_like 'redundant', '[(1)]', '[1]', 'a literal', '(1)'
   it_behaves_like 'redundant', "[(1\n)]", "[1\n]", 'a literal', "(1\n)"


### PR DESCRIPTION
* Prevent `Style/RedundantParentheses` from crashing when handling `()`.
* Refactor the `parens_allowed?` method as it exceeded the limits of several cops in the metrics category.

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [x] Used the same coding conventions as the rest of the project.
* [x] Feature branch is up-to-date with `master` (if not - rebase it)
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] All tests are passing.
* [x] The new code doesn't generate RuboCop offenses.
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.

[1]: http://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html
