### PR TITLE
Don't apply SpaceAfterNot cop on `not` keywords

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@
 * [#3140](https://github.com/bbatsov/rubocop/pull/3140): `Style/FrozenStringLiteralComment` works with file doesn't have any tokens. ([@pocke][])
 * [#3154](https://github.com/bbatsov/rubocop/issues/3154): Fix handling of `()` in `Style/RedundantParentheses`. ([@lumeet][])
 * [#3160](https://github.com/bbatsov/rubocop/pull/3160): `Style/Lambda` fix whitespacing when auto-correcting unparenthesized arguments. ([@palkan][])
+* [#31174](https://github.com/bbatsov/rubocop/pull/31174): `Style/SpaceAfterNot` don't register offences on `not` keywords. ([@gsamokovarov][])
 
 ### Changes
 
@@ -2179,3 +2180,4 @@
 [@josh]: https://github.com/josh
 [@natalzia-paperless]: https://github.com/natalzia-paperless
 [@jules2689]: https://github.com/jules2689
+[@gsamokovarov]: https://github.com/gsamokovarov

--- a/lib/rubocop/cop/style/space_after_not.rb
+++ b/lib/rubocop/cop/style/space_after_not.rb
@@ -16,10 +16,11 @@ module RuboCop
         MSG = 'Do not leave space between `!` and its argument.'.freeze
 
         def on_send(node)
-          receiver, method_name, *_args = *node
+          receiver, method_name, *args = *node
 
           return unless method_name == :!
           return unless receiver.loc.column - node.loc.column > 1
+          return if node.loc.selector.is?('not'.freeze) && args.empty?
 
           add_offense(node, :expression)
         end

--- a/spec/rubocop/cop/style/space_after_not_spec.rb
+++ b/spec/rubocop/cop/style/space_after_not_spec.rb
@@ -20,6 +20,12 @@ describe RuboCop::Cop::Style::SpaceAfterNot do
     expect(cop.offenses).to be_empty
   end
 
+  it 'accepts space after keyword not' do
+    inspect_source(cop, 'not something')
+
+    expect(cop.offenses).to be_empty
+  end
+
   it 'reports an offense for space after ! with the negated receiver ' \
      'wrapped in parentheses' do
     inspect_source(cop, '! (model)')


### PR DESCRIPTION
I have a project that prefers `and`, `or` and `not` over `&&`, `||`, and
`!`. With 0.40.0 I started having those cop reports on any `not` usage.