### PR TITLE
Generate 'Exclude' list if different styles is used

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -59,6 +59,7 @@
 * [#3223](https://github.com/bbatsov/rubocop/issues/3223): Return can take many arguments. ([@ptarjan][])
 * [#3239](https://github.com/bbatsov/rubocop/pull/3239): Fix bug with --auto-gen-config and a file that does not exist. ([@meganemura][])
 * [#3138](https://github.com/bbatsov/rubocop/issues/3138): Fix RuboCop crashing when config file contains utf-8 characters and external encoding is not utf-8. ([@deivid-rodriguez][])
+* [#3175](https://github.com/bbatsov/rubocop/pull/3175): Generate 'Exclude' list for the cops with configurable enforced style to `.rubocop_todo.yml` if different styles are used. ([@flexoid][])
 
 ### Changes
 
@@ -2224,3 +2225,4 @@
 [@giannileggio]: https://github.com/giannileggio
 [@deivid-rodriguez]: https://github.com/deivid-rodriguez
 [@pclalv]: https://github.com/pclalv
+[@flexoid]: https://github.com/flexoid

--- a/lib/rubocop/formatter/disabled_config_formatter.rb
+++ b/lib/rubocop/formatter/disabled_config_formatter.rb
@@ -109,12 +109,17 @@ module RuboCop
       end
 
       def output_cop_config(output, cfg, cop_name)
+        # 'Enabled' option will be put into file only if exclude
+        # limit is exceeded.
+        cfg_without_enabled = cfg.reject { |key| key == 'Enabled' }
+
         output.puts "#{cop_name}:"
-        cfg.each do |key, value|
+        cfg_without_enabled.each do |key, value|
           value = value[0] if value.is_a?(Array)
           output.puts "  #{key}: #{value}"
         end
-        output_offending_files(output, cfg, cop_name)
+
+        output_offending_files(output, cfg_without_enabled, cop_name)
       end
 
       def output_offending_files(output, cfg, cop_name)


### PR DESCRIPTION
If mixed styles of the specific cop is used across project files, 
some of the cops (probably all style cops) now set 'Enabled: false' 
regardless of the count of files with offense and "--exclude-limit" argument.

For example:
```ruby
class Test
  def m1(a=1)
  end

  def m2(a = 1)
  end
end
```

`.rubocop_todo.yml` for the following ruby code was (with any `--exclude-limit` value):

```
# Offense count: 1
# Cop supports --auto-correct.
# Configuration parameters: EnforcedStyle, SupportedStyles.
# SupportedStyles: space, no_space
Style/SpaceAroundEqualsInParameterDefault:
  Enabled: false
```

Now it will be like this, as expected:

```
# Offense count: 1
# Cop supports --auto-correct.
# Configuration parameters: EnforcedStyle, SupportedStyles.
# SupportedStyles: space, no_space
Style/SpaceAroundEqualsInParameterDefault:
  Exclude:
    - 'test.rb'
```
With `--exclude-limit 0`: 

```
# Offense count: 1
# Cop supports --auto-correct.
# Configuration parameters: EnforcedStyle, SupportedStyles.
# SupportedStyles: space, no_space
Style/SpaceAroundEqualsInParameterDefault:
  Enabled: false
```

And with `m2` method commented:

```
# Offense count: 1
# Cop supports --auto-correct.
# Configuration parameters: SupportedStyles.
# SupportedStyles: space, no_space
Style/SpaceAroundEqualsInParameterDefault:
  EnforcedStyle: no_space
```