### PR TITLE
[Fix #2944] Make StringLiterals cop not crash on multiline strings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@
 * [#3140](https://github.com/bbatsov/rubocop/pull/3140): `Style/FrozenStringLiteralComment` works with file doesn't have any tokens. ([@pocke][])
 * [#3154](https://github.com/bbatsov/rubocop/issues/3154): Fix handling of `()` in `Style/RedundantParentheses`. ([@lumeet][])
 * [#3160](https://github.com/bbatsov/rubocop/pull/3160): `Style/Lambda` fix whitespacing when auto-correcting unparenthesized arguments. ([@palkan][])
+* [#2944](https://github.com/bbatsov/rubocop/issues/2944): Don't crash on strings that span multiple lines but only have one pair of delimiters in `Style/StringLiterals`. ([@jonas054][])
 
 ### Changes
 

--- a/lib/rubocop/cop/style/string_literals.rb
+++ b/lib/rubocop/cop/style/string_literals.rb
@@ -22,7 +22,17 @@ module RuboCop
           children = node.children
           return unless children.all? { |c| c.str_type? || c.dstr_type? }
 
-          quote_styles = children.map { |c| c.loc.begin.source }.uniq
+          quote_styles = children.map { |c| c.loc.begin }
+
+          quote_styles = if quote_styles.all?(&:nil?)
+                           # For multi-line strings that only have quote marks
+                           # at the beginning of the first line and the end of
+                           # the last, the begin and end region of each child
+                           # is nil. The quote marks are in the parent node.
+                           [node.loc.begin.source]
+                         else
+                           quote_styles.map(&:source).uniq
+                         end
           if quote_styles.size > 1
             add_offense(node, :expression, MSG_INCONSISTENT)
           else

--- a/spec/rubocop/cop/style/string_literals_spec.rb
+++ b/spec/rubocop/cop/style/string_literals_spec.rb
@@ -254,6 +254,17 @@ describe RuboCop::Cop::Style::StringLiterals, :config do
         }
       end
 
+      it 'does not crash on strings with line breaks in them' do
+        inspect_source(cop,
+                       ['"--',
+                        'SELECT *',
+                        'LEFT JOIN X on Y',
+                        'FROM Models"'])
+        # TODO: We should actually get an offense report here telling us to use
+        # single quotes. For now, we only check that we don't crash.
+        expect(cop.offenses).to be_empty
+      end
+
       it 'accepts continued strings using all single quotes' do
         inspect_source(cop, ["'abc' \\",
                              "'def'"])


### PR DESCRIPTION
This fixes the crash we can get on strings such as
```ruby
"first line
second line"
```
but it doesn't solve the problem that such strings are not reported (should be single quotes with default configuration). That one is harder to solve, so I'm leaving it for later.