### PR TITLE
[Fix #3157] Incompatible cops: LineEndConcatenation and UnneededInterpolation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@
 * [#3155](https://github.com/bbatsov/rubocop/issues/3155): Fix `Style/SpaceAfterNot` reporting on the `not` keyword. ([@NobodysNightmare][])
 * [#3160](https://github.com/bbatsov/rubocop/pull/3160): `Style/Lambda` fix whitespacing when auto-correcting unparenthesized arguments. ([@palkan][])
 * [#2944](https://github.com/bbatsov/rubocop/issues/2944): Don't crash on strings that span multiple lines but only have one pair of delimiters in `Style/StringLiterals`. ([@jonas054][])
+* [#3157](https://github.com/bbatsov/rubocop/issues/3157): Don't let `LineEndConcatenation` and `UnneededInterpolation` make changes to the same string during auto-correct. ([@jonas054][])
 
 ### Changes
 

--- a/lib/rubocop/cop/team.rb
+++ b/lib/rubocop/cop/team.rb
@@ -9,7 +9,9 @@ module RuboCop
       # bad things are liable to happen
       INCOMPATIBLE_COPS = {
         Style::SymbolProc => [Style::SpaceBeforeBlockBraces],
-        Style::SpaceBeforeBlockBraces => [Style::SymbolProc]
+        Style::SpaceBeforeBlockBraces => [Style::SymbolProc],
+        Style::LineEndConcatenation => [Style::UnneededInterpolation],
+        Style::UnneededInterpolation => [Style::LineEndConcatenation]
       }.freeze
 
       DEFAULT_OPTIONS = {

--- a/spec/rubocop/cli/cli_autocorrect_spec.rb
+++ b/spec/rubocop/cli/cli_autocorrect_spec.rb
@@ -225,6 +225,28 @@ describe RuboCop::CLI, :isolated_environment do
     expect(IO.read('example.rb')).to eq(corrected.join("\n"))
   end
 
+  it 'corrects LineEndConcatenation offenses leaving the ' \
+     'UnneededInterpolation offense unchanged' do
+    # If we change string concatenation from plus to backslash, the string
+    # literal that follows must remain a string literal.
+    source = ["puts 'foo' +",
+              '     "#{bar}"',
+              "puts 'a' +",
+              "  'b'",
+              '"#{c}"']
+    create_file('example.rb', source)
+    expect(cli.run(['--auto-correct'])).to eq(0)
+    corrected = ["puts 'foo' \\",
+                 '     "#{bar}"',
+                 # Expressions that need correction from only one of these cops
+                 # are corrected as expected.
+                 "puts 'a' \\",
+                 "     'b'",
+                 'c.to_s',
+                 '']
+    expect(IO.read('example.rb')).to eq(corrected.join("\n"))
+  end
+
   it 'corrects InitialIndentation offenses' do
     source = ['  # comment 1',
               '',


### PR DESCRIPTION
Add these two cops to the table of incompatible cops in Team, as they will create invalid code if allowed to make changes in the same string.

The fix turned out to be really easy to make, as the infrastructure was already in place.