### PR TITLE
[Fix #3183] Ensure `Style/SpaceInsideBlockBraces` works for multi-line blocks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,7 @@
 * [#3217](https://github.com/bbatsov/rubocop/pull/3217): Fix output of ellipses for multi-line offense ranges in HTML formatter. ([@jonas054][])
 * [#3207](https://github.com/bbatsov/rubocop/issues/3207): Accept modifier forms of `while`/`until` in `Style/InfiniteLoop`. ([@jonas054][])
 * [#3202](https://github.com/bbatsov/rubocop/issues/3202): Fix `Style/EmptyElse` registering wrong offenses and thus making RuboCop crash. ([@deivid-rodriguez][])
+* [#3183](https://github.com/bbatsov/rubocop/issues/3183): Ensure `Style/SpaceInsideBlockBraces` reports offenses for multi-line blocks. ([@owst][])
 * [#3017](https://github.com/bbatsov/rubocop/issues/3017): Fix `Style/StringLiterals` to register offenses on non-ascii strings. ([@deivid-rodriguez][])
 * [#3056](https://github.com/bbatsov/rubocop/issues/3056): Fix `Style/StringLiterals` to register offenses on non-ascii strings. ([@deivid-rodriguez][])
 

--- a/lib/rubocop/cop/style/space_inside_block_braces.rb
+++ b/lib/rubocop/cop/style/space_inside_block_braces.rb
@@ -37,7 +37,7 @@ module RuboCop
 
           if left_brace.end_pos == right_brace.begin_pos
             adjacent_braces(sb, left_brace, right_brace)
-          elsif left_brace.line == right_brace.line
+          else
             range = Parser::Source::Range.new(sb, left_brace.end_pos,
                                               right_brace.begin_pos)
             inner = range.source
@@ -70,7 +70,7 @@ module RuboCop
             space_inside_left_brace(left_brace, args_delimiter, sb)
           end
 
-          if inner =~ /\S$/
+          if inner =~ /\S$/ && block_length(node) == 0
             no_space(sb, right_brace.begin_pos, right_brace.end_pos,
                      'Space missing inside }.')
           else


### PR DESCRIPTION
The code was seemingly skipping multi-line blocks for no particular reason - other than fixing a false positive for "missing space before }" there was no real change to make!

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [x] Used the same coding conventions as the rest of the project.
* [x] Feature branch is up-to-date with `master` (if not - rebase it)
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] All tests are passing.
* [x] The new code doesn't generate RuboCop offenses.
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.

[1]: http://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html