### PR TITLE
Make UselessAccessModifier ActiveSupport aware

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 * [#3306](https://github.com/bbatsov/rubocop/issues/3306): Add autocorrection for `Style/EachWithObject`. ([@owst][])
 * Add new `Style/TernaryParentheses` cop. ([@drenmi][])
+* [#3136](https://github.com/bbatsov/rubocop/issues/3136): Add config for `UselessAccessModifier` so it can be made aware of ActiveSupport's `concerning` and `class_methods` methods. ([@maxjacobson][])
 
 ### Bug fixes
 

--- a/config/enabled.yml
+++ b/config/enabled.yml
@@ -1210,6 +1210,7 @@ Lint/UnreachableCode:
 Lint/UselessAccessModifier:
   Description: 'Checks for useless access modifiers.'
   Enabled: true
+  ContextCreatingMethods: []
 
 Lint/UselessArraySplat:
   Description: 'Checks for useless array splats.'


### PR DESCRIPTION
This PR makes the `Lint/UselessAccessModifier` cop aware of some ActiveSupport methods which do some metaprogramming, which makes a scenario where multiple access modifier keywords in one class is useful and not incorrect. This fixes a regression between 0.39 and 0.40 as described in #3136

cc @owst -- thanks for the tip on how to extend this.

Before submitting the PR make sure the following are checked:

* [ ] Wrote [good commit messages][1].
* [ ] Used the same coding conventions as the rest of the project.
* [ ] Feature branch is up-to-date with `master` (if not - rebase it)
* [ ] Squashed related commits together.
* [ ] Added tests.
* [ ] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [ ] All tests are passing.
* [ ] The new code doesn't generate RuboCop offenses.
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.

[1]: http://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html