### PR TITLE
[Fix #2986] `RedundantBlockCall` should ignore block args and overridden blocks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,7 @@
 * [#3202](https://github.com/bbatsov/rubocop/issues/3202): Fix `Style/EmptyElse` registering wrong offenses and thus making RuboCop crash. ([@deivid-rodriguez][])
 * [#3017](https://github.com/bbatsov/rubocop/issues/3017): Fix `Style/StringLiterals` to register offenses on non-ascii strings. ([@deivid-rodriguez][])
 * [#3056](https://github.com/bbatsov/rubocop/issues/3056): Fix `Style/StringLiterals` to register offenses on non-ascii strings. ([@deivid-rodriguez][])
+* [#2986](https://github.com/bbatsov/rubocop/issues/2986): Fix `RedundantBlockCall` to not report calls that pass block arguments, or where the block has been overridden. ([@owst][])
 
 ### Changes
 

--- a/spec/rubocop/cop/performance/redundant_block_call_spec.rb
+++ b/spec/rubocop/cop/performance/redundant_block_call_spec.rb
@@ -24,6 +24,17 @@ describe RuboCop::Cop::Performance::RedundantBlockCall do
                               'end'].join("\n"))
   end
 
+  it 'autocorrects multiple occurances of block.call with arguments' do
+    new_source = autocorrect_source(cop, ['def method(&block)',
+                                          '  block.call 1',
+                                          '  block.call 2',
+                                          'end'])
+    expect(new_source).to eq(['def method(&block)',
+                              '  yield 1',
+                              '  yield 2',
+                              'end'].join("\n"))
+  end
+
   it 'autocorrects even when block arg has a different name' do
     new_source = autocorrect_source(cop, ['def method(&func)',
                                           '  func.call',
@@ -33,15 +44,53 @@ describe RuboCop::Cop::Performance::RedundantBlockCall do
                               'end'].join("\n"))
   end
 
-  it "doesn't register an error when receiver of `call` was not block arg" do
+  it 'accepts a block that is not `call`ed' do
     inspect_source(cop, ['def method(&block)',
                          ' something.call',
                          'end'])
     expect(cop.messages).to be_empty
   end
 
-  it "doesn't register an error when block arg is unused" do
+  it 'accepts an empty method body' do
     inspect_source(cop, ['def method(&block)',
+                         'end'])
+    expect(cop.messages).to be_empty
+  end
+
+  it 'accepts another block being passed as the only arg' do
+    inspect_source(cop, ['def method(&block)',
+                         '  block.call(&some_proc)',
+                         'end'])
+    expect(cop.messages).to be_empty
+  end
+
+  it 'accepts another block being passed along with other args' do
+    inspect_source(cop, ['def method(&block)',
+                         '  block.call(1, &some_proc)',
+                         'end'])
+    expect(cop.messages).to be_empty
+  end
+
+  it 'accepts another block arg in at least one occurance of block.call' do
+    inspect_source(cop, ['def method(&block)',
+                         '  block.call(1, &some_proc)',
+                         '  block.call(2)',
+                         'end'])
+    expect(cop.messages).to be_empty
+  end
+
+  it 'accepts an optional block that is defaulted' do
+    inspect_source(cop, ['def method(&block)',
+                         '  block ||= ->(i) { puts i }',
+                         '  block.call(1)',
+                         'end'])
+    expect(cop.messages).to be_empty
+  end
+
+  it 'accepts an optional block that is overridden' do
+    inspect_source(cop, ['def method(&block)',
+                         '  block = ->(i) { puts i }',
+                         '  block.call(1)',
                          'end'])
     expect(cop.messages).to be_empty
   end


### PR DESCRIPTION
[Fix #2986] `RedundantBlockCall` should ignore block args and overridden block arguments.

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [x] Used the same coding conventions as the rest of the project.
* [x] Feature branch is up-to-date with `master` (if not - rebase it)
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] All tests are passing.
* [x] The new code doesn't generate RuboCop offenses.
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.

[1]: http://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html