### PR TITLE
Batch cache file deletion

### DIFF
--- a/lib/rubocop/result_cache.rb
+++ b/lib/rubocop/result_cache.rb
@@ -41,7 +41,11 @@ module RuboCop
       private
 
       def remove_files(files, dirs, remove_count, verbose)
-        File.delete(*files[0, remove_count])
+        # Batch file deletions, deleting over 130,000+ files will crash
+        # File.delete.
+        files[0, remove_count].each_slice(10_000).each do |files_slice|
+          File.delete(*files_slice)
+        end
         dirs.each { |dir| Dir.rmdir(dir) if Dir["#{dir}/*"].empty? }
       rescue Errno::ENOENT
         # This can happen if parallel RuboCop invocations try to remove the


### PR DESCRIPTION
Calling `File.delete` with 130,000+ files will crash.

``` ruby
>> File.delete(*(["/tmp/foo"] * 135000))
SystemStackError: stack level too deep
```

-
CC: @bbatsov @mclark