### PR TITLE
Modify ParallelAssignment to use implicit begins

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,7 @@
 * [#2944](https://github.com/bbatsov/rubocop/issues/2944): Don't crash on strings that span multiple lines but only have one pair of delimiters in `Style/StringLiterals`. ([@jonas054][])
 * [#3157](https://github.com/bbatsov/rubocop/issues/3157): Don't let `LineEndConcatenation` and `UnneededInterpolation` make changes to the same string during auto-correct. ([@jonas054][])
 * [#3187](https://github.com/bbatsov/rubocop/issues/3187): Let `Style/BlockDelimiters` ignore blocks in *all* method arguments. ([@jonas054][])
+* Modify `Style/ParallelAssignment` to use implicit begins when parallel assignment uses a `rescue` modifier and is the only thing in the method. ([@rrosenblum][])
 
 ### Changes
 

--- a/spec/rubocop/cop/style/parallel_assignment_spec.rb
+++ b/spec/rubocop/cop/style/parallel_assignment_spec.rb
@@ -290,6 +290,21 @@ describe RuboCop::Cop::Style::ParallelAssignment, :config do
       end
 
       it 'parallel assignment in rescue statements' do
+        new_source = autocorrect_source(cop, ['def bar',
+                                              '  a, b = 1, 2',
+                                              'rescue',
+                                              "  'foo'",
+                                              'end'].join("\n"))
+
+        expect(new_source).to eq(['def bar',
+                                  '  a = 1',
+                                  '  b = 2',
+                                  'rescue',
+                                  "  'foo'",
+                                  'end'].join("\n"))
+      end
+
+      it 'parallel assignment in rescue statements' do
         new_source = autocorrect_source(cop, ['begin',
                                               '  a, b = 1, 2',
                                               'rescue',
@@ -305,9 +320,24 @@ describe RuboCop::Cop::Style::ParallelAssignment, :config do
       end
 
       it 'when the expression uses a modifier rescue statement ' \
-         'inside a method' do
+         'as the only thing inside of a method' do
         new_source = autocorrect_source(cop, ['def foo',
                                               '  a, b = 1, 2 rescue foo',
+                                              'end'])
+
+        expect(new_source).to eq(['def foo',
+                                  '  a = 1',
+                                  '  b = 2',
+                                  'rescue',
+                                  '  foo',
+                                  'end'].join("\n"))
+      end
+
+      it 'when the expression uses a modifier rescue statement ' \
+         'inside of a method' do
+        new_source = autocorrect_source(cop, ['def foo',
+                                              '  a, b = 1, 2 rescue foo',
+                                              '  something_else',
                                               'end'])
 
         expect(new_source).to eq(['def foo',
@@ -317,6 +347,7 @@ describe RuboCop::Cop::Style::ParallelAssignment, :config do
                                   '  rescue',
                                   '    foo',
                                   '  end',
+                                  '  something_else',
                                   'end'].join("\n"))
       end
 


### PR DESCRIPTION
I realized that there was a case where the correction of `ParallelAssignment` would produce an offense for `RedundantBegin`.

I also needed to tweak the implementation of `rescue_modifier?` to match that of the one in `Lint/ShadowedException`. My next step is to modify the implementation in `RescueModifier` and extract all of them out to a common place.