### PR TITLE
Allow symlinks in cache directory if explicitly enabled in config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
 
 ### Bug fixes
 
+* [#3005](https://github.com/bbatsov/rubocop/issues/3005): Symlink protection prevents use of caching in CI context. ([@urbanautomaton][])
 * [#3037](https://github.com/bbatsov/rubocop/issues/3037): `Style/StringLiterals` understands that a bare '#', not '#@variable' or '#{interpolation}', does not require double quotes. ([@alexdowad][])
 * [#2722](https://github.com/bbatsov/rubocop/issues/2722): `Style/ExtraSpacing` does not attempt to align an equals sign in an argument list with one in an assignment statement. ([@alexdowad][])
 * [#3133](https://github.com/bbatsov/rubocop/issues/3133): `Style/MultilineMethodCallBraceLayout` does not register offenses for single-line calls. ([@alexdowad][])

--- a/config/default.yml
+++ b/config/default.yml
@@ -65,6 +65,14 @@ AllCops:
   # which is "/tmp" on Unix-like systems, but could be something else on other
   # systems.
   CacheRootDirectory: /tmp
+  # The default cache root directory is /tmp, which on most systems is
+  # writable by any system user. This means that it is possible for a
+  # malicious user to anticipate the location of Rubocop's cache directory,
+  # and create a symlink in its place that could cause Rubocop to overwrite
+  # unintended files, or read malicious input. If you are certain that your
+  # cache location is secure from this kind of attack, and wish to use a
+  # symlinked cache location, set this value to "true".
+  AllowSymlinksInCacheRootDirectory: false
   # What version of the Ruby interpreter is the inspected code intended to
   # run on? (If there is more than one, set this to the lowest version.)
   TargetRubyVersion: 2.0


### PR DESCRIPTION
See original issue: https://github.com/bbatsov/rubocop/issues/3005

The default location for RuboCop's result cache is `/tmp`, which on the vast majority of systems is a world-writable directory. This means that a malicious user might be able to create a symlink to either redirect RuboCop's output to an unintended location, or cause RuboCop to read malicious input.

Previous work[1,2] introduced protection against such symlink attacks by symlinks to be present in any cache locations.

However, often CI setups explicitly rely on the ability to symlink cache locations, so that persistent results can be placed in shared storage, and symlinked to a predictable location on build machines[3].

This commit adds a new configuration option, `AllowSymlinksInCacheRootDirectory`, which lets a user permit symlinks if they are certain that their cache location is secure.

I decided against the other option discussed in #3005, which was to allow symlinks if the cache location was user-specified. This was because there's no mechanism at the moment for determining whether a given setting has been set by the user, and the complexity of adding one seemed more than the fix was worth.

Hopefully the diff is reasonably clear - if there are any questions/feedback, just let me know. :)

[1] https://github.com/bbatsov/rubocop/issues/2484
[2] https://github.com/bbatsov/rubocop/pull/2516
[3] https://github.com/bbatsov/rubocop/issues/3005