### PR TITLE
Fix link for Style/TrailingCommaInArguments

### DIFF
--- a/config/enabled.yml
+++ b/config/enabled.yml
@@ -826,7 +826,7 @@ Style/TrailingBlankLines:
 
 Style/TrailingCommaInArguments:
   Description: 'Checks for trailing comma in argument lists.'
-  StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#no-trailing-array-commas'
+  StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#no-trailing-params-comma'
   Enabled: true
 
 Style/TrailingCommaInLiteral:


### PR DESCRIPTION
The link previously linked to the docs for `Style/TrailingCommaInLiteral`. which is close, but not quite right. This PR changes the link to be the correct link.