### PR TITLE
fixed Cop::TrailingComma accepting chained single-line method calls

### DIFF
--- a/spec/rubocop/cop/style/trailing_comma_in_arguments_spec.rb
+++ b/spec/rubocop/cop/style/trailing_comma_in_arguments_spec.rb
@@ -40,6 +40,12 @@ describe RuboCop::Cop::Style::TrailingCommaInArguments, :config do
       expect(cop.offenses).to be_empty
     end
 
+    it 'accepts chained single-line method calls' do
+      inspect_source(cop, ['target',
+                           '  .some_method(a)'])
+      expect(cop.offenses).to be_empty
+    end
+
     it 'auto-corrects unwanted comma in a method call' do
       new_source = autocorrect_source(cop, 'some_method(a, b, c, )')
       expect(new_source).to eq('some_method(a, b, c )')


### PR DESCRIPTION
The following code was considered wrong if having `Style/TrailingCommaInArguments` style set to `comma` or `consistent_comma`:
```ruby
target
  .some_method(1)
```
