### PR TITLE
[Fix #3202] Register proper offense in `Style/EmptyElse`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,7 @@
 * Modify `Style/ParallelAssignment` to use implicit begins when parallel assignment uses a `rescue` modifier and is the only thing in the method. ([@rrosenblum][])
 * [#3217](https://github.com/bbatsov/rubocop/pull/3217): Fix output of ellipses for multi-line offense ranges in HTML formatter. ([@jonas054][])
 * [#3207](https://github.com/bbatsov/rubocop/issues/3207): Accept modifier forms of `while`/`until` in `Style/InfiniteLoop`. ([@jonas054][])
+* [#3202](https://github.com/bbatsov/rubocop/issues/3202): Fix `Style/EmptyElse` registering wrong offenses and thus making RuboCop crash. ([@deivid-rodriguez][])
 
 ### Changes
 
@@ -2204,3 +2205,4 @@
 [@natalzia-paperless]: https://github.com/natalzia-paperless
 [@jules2689]: https://github.com/jules2689
 [@giannileggio]: https://github.com/giannileggio
+[@deivid-rodriguez]: https://github.com/deivid-rodriguez

--- a/lib/rubocop/cop/style/empty_else.rb
+++ b/lib/rubocop/cop/style/empty_else.rb
@@ -99,7 +99,7 @@ module RuboCop
 
         def nil_check(node, else_clause)
           return unless else_clause && else_clause.nil_type?
-          add_offense(node, node.location, MSG)
+          add_offense(node, :else, MSG)
         end
 
         def both_check(node, else_clause)

--- a/spec/rubocop/cop/style/empty_else_spec.rb
+++ b/spec/rubocop/cop/style/empty_else_spec.rb
@@ -58,7 +58,7 @@ describe RuboCop::Cop::Style::EmptyElse do
           it_behaves_like 'auto-correct', 'if'
         end
 
-        context 'when the result is assigned to a variable' do
+        context 'not using semicolons' do
           let(:source) do
             ['if a',
              '  foo',

--- a/spec/rubocop/cop/style/empty_else_spec.rb
+++ b/spec/rubocop/cop/style/empty_else_spec.rb
@@ -35,6 +35,18 @@ describe RuboCop::Cop::Style::EmptyElse do
     end
   end
 
+  shared_examples_for 'offense registration' do
+    it 'registers an offense with correct message' do
+      inspect_source(cop, source)
+      expect(cop.messages).to eq(['Redundant `else`-clause.'])
+    end
+
+    it 'registers an offense with correct location' do
+      inspect_source(cop, source)
+      expect(cop.highlights).to eq(['else'])
+    end
+  end
+
   context 'configured to warn on empty else' do
     let(:config) do
       RuboCop::Config.new('Style/EmptyElse' => {
@@ -50,11 +62,7 @@ describe RuboCop::Cop::Style::EmptyElse do
           let(:source) { 'if a; foo else end' }
           let(:corrected_source) { 'if a; foo end' }
 
-          it 'registers an offense' do
-            inspect_source(cop, source)
-            expect(cop.messages).to eq(['Redundant `else`-clause.'])
-          end
-
+          it_behaves_like 'offense registration'
           it_behaves_like 'auto-correct', 'if'
         end
 
@@ -71,11 +79,7 @@ describe RuboCop::Cop::Style::EmptyElse do
              'end'].join("\n")
           end
 
-          it 'registers an offense' do
-            inspect_source(cop, source)
-            expect(cop.messages).to eq(['Redundant `else`-clause.'])
-          end
-
+          it_behaves_like 'offense registration'
           it_behaves_like 'auto-correct', 'if'
         end
       end
@@ -107,11 +111,7 @@ describe RuboCop::Cop::Style::EmptyElse do
         let(:source) { 'unless cond; foo else end' }
         let(:corrected_source) { 'unless cond; foo end' }
 
-        it 'registers an offense' do
-          inspect_source(cop, source)
-          expect(cop.messages).to eq(['Redundant `else`-clause.'])
-        end
-
+        it_behaves_like 'offense registration'
         it_behaves_like 'auto-correct', 'if'
       end
 
@@ -142,11 +142,7 @@ describe RuboCop::Cop::Style::EmptyElse do
         let(:source) { 'case v; when a; foo else end' }
         let(:corrected_source) { 'case v; when a; foo end' }
 
-        it 'registers an offense' do
-          inspect_source(cop, source)
-          expect(cop.messages).to eq(['Redundant `else`-clause.'])
-        end
-
+        it_behaves_like 'offense registration'
         it_behaves_like 'auto-correct', 'case'
       end
 
@@ -210,11 +206,7 @@ describe RuboCop::Cop::Style::EmptyElse do
              'end'].join("\n")
           end
 
-          it 'registers an offense' do
-            inspect_source(cop, source)
-            expect(cop.messages).to eq(['Redundant `else`-clause.'])
-          end
-
+          it_behaves_like 'offense registration'
           it_behaves_like 'auto-correct', 'if'
         end
 
@@ -237,11 +229,7 @@ describe RuboCop::Cop::Style::EmptyElse do
              '         end'].join("\n")
           end
 
-          it 'registers an offense' do
-            inspect_source(cop, source)
-            expect(cop.messages).to eq(['Redundant `else`-clause.'])
-          end
-
+          it_behaves_like 'offense registration'
           it_behaves_like 'auto-correct', 'if'
         end
       end
@@ -251,11 +239,7 @@ describe RuboCop::Cop::Style::EmptyElse do
         let(:source) { 'if a; foo elsif b; bar else nil end' }
         let(:corrected_source) { 'if a; foo elsif b; bar end' }
 
-        it 'registers an offense' do
-          inspect_source(cop, source)
-          expect(cop.messages).to eq(['Redundant `else`-clause.'])
-        end
-
+        it_behaves_like 'offense registration'
         it_behaves_like 'auto-correct', 'if'
       end
 
@@ -286,11 +270,7 @@ describe RuboCop::Cop::Style::EmptyElse do
         let(:source) { 'unless cond; foo else nil end' }
         let(:corrected_source) { 'unless cond; foo end' }
 
-        it 'registers an offense' do
-          inspect_source(cop, source)
-          expect(cop.messages).to eq(['Redundant `else`-clause.'])
-        end
-
+        it_behaves_like 'offense registration'
         it_behaves_like 'auto-correct', 'if'
       end
 
@@ -322,11 +302,7 @@ describe RuboCop::Cop::Style::EmptyElse do
           let(:source) { 'case v; when a; foo; when b; bar; else nil end' }
           let(:corrected_source) { 'case v; when a; foo; when b; bar; end' }
 
-          it 'registers an offense' do
-            inspect_source(cop, source)
-            expect(cop.messages).to eq(['Redundant `else`-clause.'])
-          end
-
+          it_behaves_like 'offense registration'
           it_behaves_like 'auto-correct', 'case'
         end
 
@@ -351,11 +327,7 @@ describe RuboCop::Cop::Style::EmptyElse do
              '         end'].join("\n")
           end
 
-          it 'registers an offense' do
-            inspect_source(cop, source)
-            expect(cop.messages).to eq(['Redundant `else`-clause.'])
-          end
-
+          it_behaves_like 'offense registration'
           it_behaves_like 'auto-correct', 'case'
         end
       end
@@ -390,11 +362,7 @@ describe RuboCop::Cop::Style::EmptyElse do
         let(:source) { 'if a; foo else end' }
         let(:corrected_source) { 'if a; foo end' }
 
-        it 'registers an offense' do
-          inspect_source(cop, source)
-          expect(cop.messages).to eq(['Redundant `else`-clause.'])
-        end
-
+        it_behaves_like 'offense registration'
         it_behaves_like 'auto-correct', 'if'
       end
 
@@ -402,11 +370,7 @@ describe RuboCop::Cop::Style::EmptyElse do
         let(:source) { 'if a; foo elsif b; bar else nil end' }
         let(:corrected_source) { 'if a; foo elsif b; bar end' }
 
-        it 'registers an offense' do
-          inspect_source(cop, source)
-          expect(cop.messages).to eq(['Redundant `else`-clause.'])
-        end
-
+        it_behaves_like 'offense registration'
         it_behaves_like 'auto-correct', 'if'
       end
 
@@ -430,11 +394,7 @@ describe RuboCop::Cop::Style::EmptyElse do
         let(:source) { 'unless cond; foo else end' }
         let(:corrected_source) { 'unless cond; foo end' }
 
-        it 'registers an offense' do
-          inspect_source(cop, source)
-          expect(cop.messages).to eq(['Redundant `else`-clause.'])
-        end
-
+        it_behaves_like 'offense registration'
         it_behaves_like 'auto-correct', 'if'
       end
 
@@ -442,11 +402,7 @@ describe RuboCop::Cop::Style::EmptyElse do
         let(:source) { 'unless cond; foo else nil end' }
         let(:corrected_source) { 'unless cond; foo end' }
 
-        it 'registers an offense' do
-          inspect_source(cop, source)
-          expect(cop.messages).to eq(['Redundant `else`-clause.'])
-        end
-
+        it_behaves_like 'offense registration'
         it_behaves_like 'auto-correct', 'if'
       end
 
@@ -470,11 +426,7 @@ describe RuboCop::Cop::Style::EmptyElse do
         let(:source) { 'case v; when a; foo else end' }
         let(:corrected_source) { 'case v; when a; foo end' }
 
-        it 'registers an offense' do
-          inspect_source(cop, source)
-          expect(cop.messages).to eq(['Redundant `else`-clause.'])
-        end
-
+        it_behaves_like 'offense registration'
         it_behaves_like 'auto-correct', 'case'
       end
 
@@ -482,11 +434,7 @@ describe RuboCop::Cop::Style::EmptyElse do
         let(:source) { 'case v; when a; foo; when b; bar; else nil end' }
         let(:corrected_source) { 'case v; when a; foo; when b; bar; end' }
 
-        it 'registers an offense' do
-          inspect_source(cop, source)
-          expect(cop.messages).to eq(['Redundant `else`-clause.'])
-        end
-
+        it_behaves_like 'offense registration'
         it_behaves_like 'auto-correct', 'case'
       end
 


### PR DESCRIPTION
Fixes #3202. Unfortunately I couldn't find a better way for a regression test than this one... :(

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [x] Used the same coding conventions as the rest of the project.
* [x] Feature branch is up-to-date with `master` (if not - rebase it)
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] All tests are passing.
* [x] The new code doesn't generate RuboCop offenses.
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.

[1]: http://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html
