### PR TITLE
[Fix #1758] Let ClosingParenthesisIndentation follow AlignParameters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,7 @@
 ### Changes
 
 * [#3149](https://github.com/bbatsov/rubocop/pull/3149): Make `Style/HashSyntax` configurable to not report hash rocket syntax for symbols ending with ? or ! when using ruby19 style. ([@owst][])
+* [#1758](https://github.com/bbatsov/rubocop/issues/1758): Let `Style/ClosingParenthesisIndentation` follow `Style/AlignParameters` configuration for method calls. ([@jonas054][])
 
 ## 0.40.0 (2016-05-09)
 

--- a/lib/rubocop/cop/style/closing_parenthesis_indentation.rb
+++ b/lib/rubocop/cop/style/closing_parenthesis_indentation.rb
@@ -56,7 +56,8 @@ module RuboCop
 
           left_paren = node.loc.begin
 
-          correct_column = if line_break_after_left_paren?(left_paren, elements)
+          correct_column = if node.send_type? && fixed_parameter_indentation? ||
+                              line_break_after_left_paren?(left_paren, elements)
                              left_paren.source_line =~ /\S/
                            else
                              left_paren.column
@@ -66,6 +67,11 @@ module RuboCop
 
           msg = correct_column == left_paren.column ? MSG_ALIGN : MSG_INDENT
           add_offense(node.loc.end, node.loc.end, msg)
+        end
+
+        def fixed_parameter_indentation?
+          config.for_cop('Style/AlignParameters')['EnforcedStyle'] ==
+            'with_fixed_indentation'
         end
 
         def line_break_after_left_paren?(left_paren, elements)


### PR DESCRIPTION
When the `with_fixed_indentation` style is used by `Style/AlignParameters`, the hanging closing parenthesis should adapt. It's going to look weird otherwise.