### PR TITLE
Do not HTML-escape the markup for ellipses in html formatter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,7 @@
 * [#3157](https://github.com/bbatsov/rubocop/issues/3157): Don't let `LineEndConcatenation` and `UnneededInterpolation` make changes to the same string during auto-correct. ([@jonas054][])
 * [#3187](https://github.com/bbatsov/rubocop/issues/3187): Let `Style/BlockDelimiters` ignore blocks in *all* method arguments. ([@jonas054][])
 * Modify `Style/ParallelAssignment` to use implicit begins when parallel assignment uses a `rescue` modifier and is the only thing in the method. ([@rrosenblum][])
+* [#3217](https://github.com/bbatsov/rubocop/pull/3217): Fix output of ellipses for multi-line offense ranges in HTML formatter. ([@jonas054][])
 
 ### Changes
 

--- a/lib/rubocop/formatter/html_formatter.rb
+++ b/lib/rubocop/formatter/html_formatter.rb
@@ -95,18 +95,14 @@ module RuboCop
 
         def highlighted_source_line(offense)
           location = offense.location
-
-          source_line = if location.first_line == location.last_line
-                          location.source_line
-                        else
-                          "#{location.source_line} #{ELLIPSES}"
-                        end
+          source_line = location.source_line
 
           escape(source_line[0...offense.highlighted_area.begin_pos]) +
             "<span class=\"highlight #{offense.severity}\">" +
             escape(offense.highlighted_area.source) +
             '</span>' +
-            escape(source_line[offense.highlighted_area.end_pos..-1])
+            escape(source_line[offense.highlighted_area.end_pos..-1]) +
+            (location.first_line == location.last_line ? '' : " #{ELLIPSES}")
         end
 
         def escape(s)

--- a/spec/fixtures/html_formatter/expected.html
+++ b/spec/fixtures/html_formatter/expected.html
@@ -472,7 +472,7 @@ TvFXMeuCkZPcaEBLqvgPBhCuiZo8+sAAAAAASUVORK5CYII=
               <span class="message">Inconsistent indentation detected.</span>
             </div>
             
-            <pre><code>    <span class="highlight convention">def set_book</span> &lt;span class=&quot;extra-code&quot;&gt;...&lt;/span&gt;</code></pre>
+            <pre><code>    <span class="highlight convention">def set_book</span> <span class="extra-code">...</span></code></pre>
             
           </div>
           
@@ -494,7 +494,7 @@ TvFXMeuCkZPcaEBLqvgPBhCuiZo8+sAAAAAASUVORK5CYII=
               <span class="message">Inconsistent indentation detected.</span>
             </div>
             
-            <pre><code>    <span class="highlight convention">def book_params</span> &lt;span class=&quot;extra-code&quot;&gt;...&lt;/span&gt;</code></pre>
+            <pre><code>    <span class="highlight convention">def book_params</span> <span class="extra-code">...</span></code></pre>
             
           </div>
           


### PR DESCRIPTION
There was a bug in the formatter causing HTML tags to appear on the generated page when `<span class="extra-code">...</span>` was added for offense locations spanning multiple lines.

For example:
```html
<span class="highlight convention">def set_book</span> &lt;span class=&quot;extra-code&quot;&gt;...&lt;/span&gt;
```