### PR TITLE
Fix Style/EachForSimpleLoop for ranges not starting with zero

### DIFF
--- a/lib/rubocop/cop/style/each_for_simple_loop.rb
+++ b/lib/rubocop/cop/style/each_for_simple_loop.rb
@@ -18,7 +18,7 @@ module RuboCop
       #   10.times { }
       class EachForSimpleLoop < Cop
         def on_block(node)
-          if bad_each_count(node)
+          if bad_each_range(node)
             send_node, = *node
             range = send_node.receiver.source_range.join(send_node.loc.selector)
             add_offense(node, range, 'Use `Integer#times` for a simple loop ' \
@@ -28,13 +28,14 @@ module RuboCop
 
         def autocorrect(node)
           lambda do |corrector|
+            min, max = bad_each_range(node)
             corrector.replace(node.children.first.source_range,
-                              "#{bad_each_count(node)}.times")
+                              "#{max - min}.times")
           end
         end
 
-        def_node_matcher :bad_each_count, <<-PATTERN
-          (block (send (begin ({irange erange} int (int $_))) :each) (args) ...)
+        def_node_matcher :bad_each_range, <<-PATTERN
+          (block (send (begin ({irange erange} (int $_) (int $_))) :each) (args) ...)
         PATTERN
       end
     end

--- a/spec/rubocop/cop/style/each_for_simple_loop_spec.rb
+++ b/spec/rubocop/cop/style/each_for_simple_loop_spec.rb
@@ -31,6 +31,14 @@ describe RuboCop::Cop::Style::EachForSimpleLoop do
     expect(cop.highlights).to eq(['(0...10).each'])
   end
 
+  it 'registers an offense for range not starting with zero' do
+    inspect_source(cop, ['(3..7).each do',
+                         'end'])
+    expect(cop.offenses.size).to eq 1
+    expect(cop.messages).to eq([OFFENSE_MSG])
+    expect(cop.highlights).to eq(['(3..7).each'])
+  end
+
   it 'does not register offense if range startpoint is not constant' do
     inspect_source(cop, '(a..10).each {}')
     expect(cop.offenses).to be_empty
@@ -66,5 +74,17 @@ describe RuboCop::Cop::Style::EachForSimpleLoop do
     corrected = autocorrect_source(cop, ['(0..10).each do',
                                          'end'])
     expect(corrected).to eq "10.times do\nend"
+  end
+
+  it 'autocorrects the range not starting with zero' do
+    corrected = autocorrect_source(cop, ['(3..7).each do',
+                                         'end'])
+    expect(corrected).to eq "4.times do\nend"
+  end
+
+  it 'does not autocorrect range not starting with zero and using param' do
+    corrected = autocorrect_source(cop, ['(3..7).each do |n|',
+                                         'end'])
+    expect(corrected).to eq "(3..7).each do |n|\nend"
   end
 end


### PR DESCRIPTION
The autocorrect naively used the max of the range. This would work when
ranges started with zero. But for non-zero ranges to work, it should use
`max - min`. Credits to @nav16 for pointing out this bug.

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [x] Used the same coding conventions as the rest of the project.
* [x] Feature branch is up-to-date with `master` (if not - rebase it)
* [x] Squashed related commits together.
* [x] Added tests.
* [ ] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] All tests are passing.
* [x] The new code doesn't generate RuboCop offenses.
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.

[1]: http://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html
