### PR TITLE
Improvements for Style/ImplicitRuntimeError

### DIFF
--- a/config/disabled.yml
+++ b/config/disabled.yml
@@ -49,8 +49,8 @@ Style/FirstMethodParameterLineBreak:
 
 Style/ImplicitRuntimeError:
   Description: >-
-                 Use `raise` with an explicit exception class and message,
-                 rather than just a message.
+                 Use `raise` or `fail` with an explicit exception class and
+                 message, rather than just a message.
   Enabled: false
 
 Style/InlineComment:

--- a/lib/rubocop/cop/style/implicit_runtime_error.rb
+++ b/lib/rubocop/cop/style/implicit_runtime_error.rb
@@ -4,9 +4,9 @@
 module RuboCop
   module Cop
     module Style
-      # This cop checks for `raise` statements which do not specify an explicit
-      # exception class. (This raises a `RuntimeError`. Some projects might
-      # prefer to use exception classes which more precisely identify the
+      # This cop checks for `raise` or `fail` statements which do not specify an
+      # explicit exception class. (This raises a `RuntimeError`. Some projects
+      # might prefer to use exception classes which more precisely identify the
       # nature of the error.)
       #
       # @example
@@ -16,11 +16,12 @@ module RuboCop
       #   @good
       #   raise ArgumentError, 'Error message here'
       class ImplicitRuntimeError < Cop
-        def_node_matcher :implicit_runtime_error_raise, '(send nil :raise str)'
+        def_node_matcher :implicit_runtime_error_raise_or_fail,
+                         '(send nil ${:raise :fail} {str dstr})'
 
         def on_send(node)
-          if implicit_runtime_error_raise(node)
-            add_offense(node, :expression, 'Use `raise` with an explicit ' \
+          implicit_runtime_error_raise_or_fail(node) do |method|
+            add_offense(node, :expression, "Use `#{method}` with an explicit " \
                                            'exception class and message, ' \
                                            'rather than just a message.')
           end

--- a/spec/rubocop/cop/style/implicit_runtime_error_spec.rb
+++ b/spec/rubocop/cop/style/implicit_runtime_error_spec.rb
@@ -6,17 +6,33 @@ require 'spec_helper'
 describe RuboCop::Cop::Style::ImplicitRuntimeError do
   subject(:cop) { described_class.new }
 
-  it 'registers an offense for raise "message"' do
-    inspect_source(cop, 'raise "message"')
-    expect(cop.offenses.size).to eq 1
-    expect(cop.messages).to eq(['Use `raise` with an explicit exception ' \
-                                'class and message, rather than just a ' \
-                                'message.'])
-    expect(cop.highlights).to eq(['raise "message"'])
-  end
+  %w(raise fail).each do |method|
+    it "registers an offense for #{method} 'message'" do
+      inspect_source(cop, "#{method} 'message'")
+      expect(cop.offenses.size).to eq 1
+      expect(cop.messages).to eq(["Use `#{method}` with an explicit " \
+                                 'exception class and message, rather than ' \
+                                 'just a message.'])
+      expect(cop.highlights).to eq(["#{method} 'message'"])
+    end
 
-  it "doesn't register an offense for raise StandardError, 'message'" do
-    inspect_source(cop, 'raise StandardError, "message"')
-    expect(cop.offenses).to be_empty
+    it "registers an offense for #{method} with a multiline string" do
+      inspect_source(cop, ["#{method} 'message' \\", "'2nd line'"])
+      expect(cop.offenses.size).to eq 1
+      expect(cop.messages).to eq(["Use `#{method}` with an explicit " \
+                                 'exception class and message, rather than ' \
+                                 'just a message.'])
+      expect(cop.highlights).to eq(["#{method} 'message' \\\n'2nd line'"])
+    end
+
+    it "doesn't register an offense for #{method} StandardError, 'message'" do
+      inspect_source(cop, "#{method} StandardError, 'message'")
+      expect(cop.offenses).to be_empty
+    end
+
+    it "doesn't register an offense for #{method} with no arguments" do
+      inspect_source(cop, method)
+      expect(cop.offenses).to be_empty
+    end
   end
 end


### PR DESCRIPTION
With this change offenses for `fail` are caught in addition to
`raise` and offenses with `dstr` are detected.

There is no changelog entry since `Style/ImplicitRuntimeError` is
a new cop.

* [x] Wrote [good commit messages][1].
* [x] Used the same coding conventions as the rest of the project.
* [x] Feature branch is up-to-date with `master` (if not - rebase it)
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] All tests are passing.
* [x] The new code doesn't generate RuboCop offenses.
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.

[1]: http://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html

