### PR TITLE
Read .ruby-version if present

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### New features
 
+* [#2956](https://github.com/bbatsov/rubocop/issues/2956): Prefer `.ruby-version` to `TargetRubyVersion`. ([@pclalv][])
 * [#3095](https://github.com/bbatsov/rubocop/issues/3095): Add `IndentationWidth` configuration parameter for `Style/AlignParameters` cop. ([@alexdowad][])
 * [#3066](https://github.com/bbatsov/rubocop/issues/3066): Add new `Style/ImplicitRuntimeError` cop which advises the use of an explicit exception class when raising an error. ([@alexdowad][])
 * [#3018](https://github.com/bbatsov/rubocop/issues/3018): Add new `Style/EachForSimpleLoop` cop which advises the use of `Integer#times` for simple loops which iterate a fixed number of times. ([@alexdowad][])
@@ -2208,3 +2209,4 @@
 [@jules2689]: https://github.com/jules2689
 [@giannileggio]: https://github.com/giannileggio
 [@deivid-rodriguez]: https://github.com/deivid-rodriguez
+[@pclalv]: https://github.com/pclalv

--- a/lib/rubocop/cop/cop.rb
+++ b/lib/rubocop/cop/cop.rb
@@ -193,7 +193,7 @@ module RuboCop
       end
 
       def target_ruby_version
-        @config.for_all_cops['TargetRubyVersion']
+        @config.target_ruby_version
       end
 
       def parse(source, path = nil)

--- a/lib/rubocop/runner.rb
+++ b/lib/rubocop/runner.rb
@@ -273,7 +273,7 @@ module RuboCop
     end
 
     def get_processed_source(file)
-      ruby_version = @config_store.for(file).for_all_cops['TargetRubyVersion']
+      ruby_version = @config_store.for(file).target_ruby_version
 
       if @options[:stdin]
         ProcessedSource.new(@options[:stdin], ruby_version, file)

--- a/manual/configuration.md
+++ b/manual/configuration.md
@@ -265,7 +265,9 @@ inspected code must run on. For example, using Ruby 2.0+ keyword arguments
 rather than an options hash can help make your code shorter and more
 expressive... _unless_ it must run on Ruby 1.9.
 
-Let RuboCop know the oldest version of Ruby which your project supports with:
+If `.ruby-version` exists in the directory RuboCop is invoked in, RuboCop
+will use the version specified by it. Otherwise, users may let RuboCop
+know the oldest version of Ruby which your project supports with:
 
 ```yaml
 AllCops:

--- a/spec/rubocop/config_spec.rb
+++ b/spec/rubocop/config_spec.rb
@@ -374,4 +374,43 @@ describe RuboCop::Config do
       end
     end
   end
+
+  describe '#target_ruby_version' do
+    context 'when .ruby-version is present' do
+      let(:ruby_version) { '2.2.4' }
+      let(:ruby_version_to_f) { 2.2 }
+
+      before do
+        allow(File).to receive(:file?).with('.ruby-version').and_return true
+        allow(File)
+          .to receive(:read)
+          .with('.ruby-version')
+          .and_return ruby_version
+      end
+
+      it 'reads it to determine the target ruby version' do
+        expect(configuration.target_ruby_version).to eq 2.2
+      end
+    end
+
+    context 'when .ruby-version is not present' do
+      let(:ruby_version) { 2.0 }
+
+      let(:hash) do
+        {
+          'AllCops' => {
+            'TargetRubyVersion' => ruby_version
+          }
+        }
+      end
+
+      before do
+        allow(File).to receive(:file?).with('.ruby-version').and_return false
+      end
+
+      it 'falls back to TargetRubyVersion' do
+        expect(configuration.target_ruby_version).to eq ruby_version
+      end
+    end
+  end
 end


### PR DESCRIPTION
for convenience's sake, it would be nice if Rubocop would prefer to use the version specified by `.ruby-version`, if present, instead of `TargetRubyVersion`. this way, those of us using `.ruby-version` will have one less thing to worry about when upgrading ruby. 