### PR TITLE
[Fix #3148] Make Rails/UniqBeforePluck more conservative

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -61,6 +61,7 @@
 * [#3239](https://github.com/bbatsov/rubocop/pull/3239): Fix bug with --auto-gen-config and a file that does not exist. ([@meganemura][])
 * [#3138](https://github.com/bbatsov/rubocop/issues/3138): Fix RuboCop crashing when config file contains utf-8 characters and external encoding is not utf-8. ([@deivid-rodriguez][])
 * [#3175](https://github.com/bbatsov/rubocop/pull/3175): Generate 'Exclude' list for the cops with configurable enforced style to `.rubocop_todo.yml` if different styles are used. ([@flexoid][])
+* [#3231](https://github.com/bbatsov/rubocop/pull/3231): Make `Rails/UniqBeforePluck` more conservative. ([@tjwp][])
 
 ### Changes
 

--- a/config/default.yml
+++ b/config/default.yml
@@ -1217,6 +1217,13 @@ Rails/TimeZone:
     - strict
     - flexible
 
+Rails/UniqBeforePluck:
+  EnforcementMode: conservative
+  SupportedModes:
+    - conservative
+    - aggressive
+  AutoCorrect: false
+
 Rails/Validation:
   Include:
     - app/models/**/*.rb

--- a/config/enabled.yml
+++ b/config/enabled.yml
@@ -1436,7 +1436,7 @@ Rails/TimeZone:
   Enabled: true
 
 Rails/UniqBeforePluck:
-  Description: 'Prefer the use of uniq before pluck.'
+  Description: 'Prefer the use of uniq or distinct before pluck.'
   Enabled: true
 
 Rails/Validation:


### PR DESCRIPTION
This change is to address Issue https://github.com/bbatsov/rubocop/issues/3148

Autocorrect is disabled by default for this cop since it can potentially generate false positives.

Add offenses for `distinct` as well as `uniq`.

By default only add offenses for calls to `pluck` directly
on constants.

Add an 'aggressive' mode that adds all offenses as the cop did
originally.

* [x] Wrote [good commit messages][1].
* [x] Used the same coding conventions as the rest of the project.
* [x] Feature branch is up-to-date with `master` (if not - rebase it)
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] All tests are passing.
* [x] The new code doesn't generate RuboCop offenses.
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.

[1]: http://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html
