### PR TITLE
[Fix #1646] MultilineMethodCallInd. indented_relative_to_receiver style

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@
 * [#3179](https://github.com/bbatsov/rubocop/pull/3179): Expose files to support testings Cops using RSpec. ([@tjwp][])
 * [#3191](https://github.com/bbatsov/rubocop/issues/3191): Allow arbitrary comments after cop names in CommentConfig lines (e.g. rubocop:enable). ([@owst][])
 * [#3177](https://github.com/bbatsov/rubocop/pull/3177): Add new `Style/NumericLiteralPrefix` cop. ([@tejasbubane][])
+* [#1646](https://github.com/bbatsov/rubocop/issues/1646): Add configuration style `indented_relative_to_receiver` for `Style/MultilineMethodCallIndentation`. ([@jonas054][])
 
 ### Bug fixes
 

--- a/config/default.yml
+++ b/config/default.yml
@@ -712,6 +712,7 @@ Style/MultilineMethodCallIndentation:
   SupportedStyles:
     - aligned
     - indented
+    - indented_relative_to_receiver
   # By default, the indentation width from Style/IndentationWidth is used
   # But it can be overridden by setting this parameter
   IndentationWidth: ~

--- a/lib/rubocop/cop/mixin/multiline_expression_indentation.rb
+++ b/lib/rubocop/cop/mixin/multiline_expression_indentation.rb
@@ -71,7 +71,8 @@ module RuboCop
 
       def incorrect_style_detected(range, node, lhs, rhs)
         add_offense(range, range, message(node, lhs, rhs)) do
-          if offending_range(node, lhs, rhs, alternative_style)
+          if supported_styles.size > 2 ||
+             offending_range(node, lhs, rhs, alternative_style)
             unrecognized_style_detected
           else
             opposite_style_detected


### PR DESCRIPTION
Add the style `indented_relative_to_receiver` in `Style/MultilineMethodCallIndentation` for indentation of method calls so that each new line of a call chain is indented one step more than the ultimate receiver.