### PR TITLE
Auto-correct more kinds of infinite loops

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,7 +47,7 @@
 * [#3187](https://github.com/bbatsov/rubocop/issues/3187): Let `Style/BlockDelimiters` ignore blocks in *all* method arguments. ([@jonas054][])
 * Modify `Style/ParallelAssignment` to use implicit begins when parallel assignment uses a `rescue` modifier and is the only thing in the method. ([@rrosenblum][])
 * [#3217](https://github.com/bbatsov/rubocop/pull/3217): Fix output of ellipses for multi-line offense ranges in HTML formatter. ([@jonas054][])
-* [#3207](https://github.com/bbatsov/rubocop/issues/3207): Accept modifier forms of `while`/`until` in `Style/InfiniteLoop`. ([@jonas054][])
+* [#3207](https://github.com/bbatsov/rubocop/issues/3207): Auto-correct modifier `while`/`until` and `begin`..`end` + `while`/`until` in `Style/InfiniteLoop`. ([@jonas054][])
 * [#3202](https://github.com/bbatsov/rubocop/issues/3202): Fix `Style/EmptyElse` registering wrong offenses and thus making RuboCop crash. ([@deivid-rodriguez][])
 * [#3183](https://github.com/bbatsov/rubocop/issues/3183): Ensure `Style/SpaceInsideBlockBraces` reports offenses for multi-line blocks. ([@owst][])
 * [#3017](https://github.com/bbatsov/rubocop/issues/3017): Fix `Style/StringLiterals` to register offenses on non-ascii strings. ([@deivid-rodriguez][])

--- a/lib/rubocop/cop/style/infinite_loop.rb
+++ b/lib/rubocop/cop/style/infinite_loop.rb
@@ -20,8 +20,6 @@ module RuboCop
         MSG = 'Use `Kernel#loop` for infinite loops.'.freeze
 
         def on_while(node)
-          return if node.modifier_form?
-
           condition, = *node
           return unless condition.truthy_literal?
 
@@ -29,15 +27,50 @@ module RuboCop
         end
 
         def on_until(node)
-          return if node.modifier_form?
-
           condition, = *node
           return unless condition.falsey_literal?
 
           add_offense(node, :keyword)
         end
 
+        alias on_while_post on_while
+        alias on_until_post on_until
+
         def autocorrect(node)
+          if node.while_post_type? || node.until_post_type?
+            _, body = *node
+            return lambda do |corrector|
+              corrector.replace(body.loc.begin, 'loop do')
+              corrector.remove(body.loc.end.end.join(node.source_range.end))
+            end
+          end
+
+          if node.modifier_form?
+            range = node.source_range
+            replacement = modifier_replacement(node)
+          else
+            range = non_modifier_range(node)
+            replacement = 'loop do'
+          end
+
+          ->(corrector) { corrector.replace(range, replacement) }
+        end
+
+        private
+
+        def modifier_replacement(node)
+          _, body = *node
+          if node.single_line?
+            'loop { ' + body.source + ' }'
+          else
+            indentation = body.loc.expression.source_line[/\A(\s*)/]
+            "loop do\n" + indentation +
+              body.source.gsub(/^/, ' ' * configured_indentation_width) +
+              "\n#{indentation}end"
+          end
+        end
+
+        def non_modifier_range(node)
           condition_node, = *node
           start_range = node.loc.keyword.begin
           end_range = if node.loc.begin
@@ -45,9 +78,11 @@ module RuboCop
                       else
                         condition_node.source_range.end
                       end
-          lambda do |corrector|
-            corrector.replace(start_range.join(end_range), 'loop do')
-          end
+          start_range.join(end_range)
+        end
+
+        def configured_indentation_width
+          config.for_cop('IndentationWidth')['Width']
         end
       end
     end


### PR DESCRIPTION
Second correction for #3207. Change it so we auto-correct instead of accept modifier forms. Also add handling of `begin`-`end`-`while`.