### PR TITLE
Remove requiring pry

### DIFF
--- a/lib/rubocop/cop/style/numeric_literal_prefix.rb
+++ b/lib/rubocop/cop/style/numeric_literal_prefix.rb
@@ -1,8 +1,6 @@
 # encoding: utf-8
 # frozen_string_literal: true
 
-require 'pry'
-
 module RuboCop
   module Cop
     module Style


### PR DESCRIPTION
I found `require 'pry'` in `lib/rubocop/cop/style/numeric_literal_prefix.rb`.
There is no need to require pry, and pry is not runtime dependency for rubocop.
It causes a LoadError.

```
~/test$ bundle init
Writing new Gemfile to /Users/meganemura/test/Gemfile
~/test$ echo "gem 'rubocop', github: 'bbatsov/rubocop'" >> Gemfile
~/test$ bundle install --path=gems --quiet
~/test$ bundle exec rubocop Gemfile
bundler: failed to load command: rubocop (/Users/meganemura/test/gems/ruby/2.3.0/bin/rubocop)
LoadError: cannot load such file -- pry
  /Users/meganemura/test/gems/ruby/2.3.0/bundler/gems/rubocop-efadc8eb9be1/lib/rubocop/cop/style/numeric_literal_prefix.rb:4:in `require'
  /Users/meganemura/test/gems/ruby/2.3.0/bundler/gems/rubocop-efadc8eb9be1/lib/rubocop/cop/style/numeric_literal_prefix.rb:4:in `<top (required)>'
  /Users/meganemura/test/gems/ruby/2.3.0/bundler/gems/rubocop-efadc8eb9be1/lib/rubocop.rb:292:in `require'
  /Users/meganemura/test/gems/ruby/2.3.0/bundler/gems/rubocop-efadc8eb9be1/lib/rubocop.rb:292:in `<top (required)>'
  /Users/meganemura/test/gems/ruby/2.3.0/bundler/gems/rubocop-efadc8eb9be1/bin/rubocop:7:in `require'
  /Users/meganemura/test/gems/ruby/2.3.0/bundler/gems/rubocop-efadc8eb9be1/bin/rubocop:7:in `<top (required)>'
  /Users/meganemura/test/gems/ruby/2.3.0/bin/rubocop:23:in `load'
  /Users/meganemura/test/gems/ruby/2.3.0/bin/rubocop:23:in `<top (required)>'
```

So I removed it.

`StyleNumericLiteralPrefix` is unreleased feature. Therefore I didn't write CHANGELOG.md.

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [x] Used the same coding conventions as the rest of the project.
* [x] Feature branch is up-to-date with `master` (if not - rebase it)
* [x] Squashed related commits together.
* [ ] Added tests.
* [ ] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] All tests are passing.
* [x] The new code doesn't generate RuboCop offenses.
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.

[1]: http://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html