### PR TITLE
Fix bug with --auto-gen-config and a file that does not exist

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,6 +55,7 @@
 * [#3056](https://github.com/bbatsov/rubocop/issues/3056): Fix `Style/StringLiterals` to register offenses on non-ascii strings. ([@deivid-rodriguez][])
 * [#2986](https://github.com/bbatsov/rubocop/issues/2986): Fix `RedundantBlockCall` to not report calls that pass block arguments, or where the block has been overridden. ([@owst][])
 * [#3223](https://github.com/bbatsov/rubocop/issues/3223): Return can take many arguments. ([@ptarjan][])
+* [#3239](https://github.com/bbatsov/rubocop/pull/3239): Fix bug with --auto-gen-config and a file that does not exist. ([@meganemura][])
 
 ### Changes
 

--- a/lib/rubocop/formatter/disabled_config_formatter.rb
+++ b/lib/rubocop/formatter/disabled_config_formatter.rb
@@ -25,6 +25,12 @@ module RuboCop
         attr_accessor :config_to_allow_offenses, :detected_styles
       end
 
+      def initialize(output, options = {})
+        super
+        @cops_with_offenses ||= Hash.new(0)
+        @files_with_offenses ||= {}
+      end
+
       def file_started(_file, _file_info)
         @exclude_limit_option = @options[:exclude_limit]
         @exclude_limit = (
@@ -34,8 +40,6 @@ module RuboCop
       end
 
       def file_finished(file, offenses)
-        @cops_with_offenses ||= Hash.new(0)
-        @files_with_offenses ||= {}
         offenses.each do |o|
           @cops_with_offenses[o.cop_name] += 1
           @files_with_offenses[o.cop_name] ||= []

--- a/spec/rubocop/cli/cli_auto_gen_config_spec.rb
+++ b/spec/rubocop/cli/cli_auto_gen_config_spec.rb
@@ -490,5 +490,9 @@ describe RuboCop::CLI, :isolated_environment do
                 '  Enabled: false',
                 ''].join("\n"))
     end
+
+    it 'can be called when there are no files to inspection' do
+      expect(cli.run(['--auto-gen-config'])).to eq(0)
+    end
   end
 end

--- a/spec/rubocop/formatter/disabled_config_formatter_spec.rb
+++ b/spec/rubocop/formatter/disabled_config_formatter_spec.rb
@@ -125,6 +125,14 @@ module RuboCop
                                        ''].flatten.join("\n"))
         end
 
+        it 'creates a .rubocop_todo.yml even if RuboCop does not inspect ' \
+           'any files' do
+          formatter.finished([])
+          expect(output.string).to eq(format(described_class::HEADING,
+                                             'rubocop --auto-gen-config') +
+                                      "\n")
+        end
+
         context 'when exclude_limit option is passed into constructor' do
           let(:formatter) { described_class.new(output, exclude_limit: 5) }
 


### PR DESCRIPTION
`bundle exec rubocop --auto-gen-config nosuchfile` raises NoMethodError.
Because of the uninitialized instance variables.
This patche fixes it.

### with --auto-gen-config (not patched)

```
~/src/github.com/meganemura/rubocop$ ls nosuchfile
ls: nosuchfile: No such file or directory
~/src/github.com/meganemura/rubocop$ bundle exec rubocop --auto-gen-config nosuchfile
Inspecting 1 file


0 files inspected, no offenses detected
undefined method `delete' for nil:NilClass
/Users/meganemura/src/github.com/meganemura/rubocop/lib/rubocop/formatter/disabled_config_formatter.rb:50:in `finished'
/Users/meganemura/src/github.com/meganemura/rubocop/lib/rubocop/formatter/formatter_set.rb:30:in `block (3 levels) in <class:FormatterSet>'
/Users/meganemura/src/github.com/meganemura/rubocop/lib/rubocop/formatter/formatter_set.rb:30:in `each'
/Users/meganemura/src/github.com/meganemura/rubocop/lib/rubocop/formatter/formatter_set.rb:30:in `block (2 levels) in <class:FormatterSet>'
/Users/meganemura/src/github.com/meganemura/rubocop/lib/rubocop/runner.rb:68:in `ensure in inspect_files'
/Users/meganemura/src/github.com/meganemura/rubocop/lib/rubocop/runner.rb:69:in `inspect_files'
/Users/meganemura/src/github.com/meganemura/rubocop/lib/rubocop/runner.rb:35:in `run'
/Users/meganemura/src/github.com/meganemura/rubocop/lib/rubocop/cli.rb:72:in `execute_runner'
/Users/meganemura/src/github.com/meganemura/rubocop/lib/rubocop/cli.rb:28:in `run'
/Users/meganemura/src/github.com/meganemura/rubocop/bin/rubocop:14:in `block in <top (required)>'
/Users/meganemura/.rbenv/versions/2.2.0/lib/ruby/2.2.0/benchmark.rb:303:in `realtime'
/Users/meganemura/src/github.com/meganemura/rubocop/bin/rubocop:13:in `<top (required)>'
/Users/meganemura/src/github.com/meganemura/rubocop/vendor/bundle/ruby/2.2.0/bin/rubocop:23:in `load'
/Users/meganemura/src/github.com/meganemura/rubocop/vendor/bundle/ruby/2.2.0/bin/rubocop:23:in `<main>'
```

### with --auto-gen-config (patched)

```
~/src/github.com/meganemura/rubocop$ bundle exec rubocop --auto-gen-config nosuchfile
Inspecting 1 file


0 files inspected, no offenses detected
Created .rubocop_todo.yml.
Run `rubocop --config .rubocop_todo.yml`, or add `inherit_from: .rubocop_todo.yml` in a .rubocop.yml file.
Error: No such file or directory: /Users/meganemura/src/github.com/meganemura/rubocop/nosuchfile
```

### without --auto-gen-config

```
~/src/github.com/meganemura/rubocop$ bundle exec rubocop nosuchfile
Inspecting 1 file


0 files inspected, no offenses detected
Error: No such file or directory: /Users/meganemura/src/github.com/meganemura/rubocop/nosuchfile
```
-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [x] Used the same coding conventions as the rest of the project.
* [x] Feature branch is up-to-date with `master` (if not - rebase it)
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] All tests are passing.
* [x] The new code doesn't generate RuboCop offenses.
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.

[1]: http://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html

