### PR TITLE
Fix `UniqBeforePluck` cop by solving difference of config name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## master (unreleased)
 
+### Bug fixes
+
+* [#3245](https://github.com/bbatsov/rubocop/pull/3245): Fix `UniqBeforePluck` cop by solving difference of config name. ([@pocke][])
+
 ## 0.41.0 (2016-06-25)
 
 ### New features

--- a/config/default.yml
+++ b/config/default.yml
@@ -1226,7 +1226,7 @@ Rails/TimeZone:
     - flexible
 
 Rails/UniqBeforePluck:
-  EnforcementMode: conservative
+  EnforcedMode: conservative
   SupportedModes:
     - conservative
     - aggressive

--- a/lib/rubocop/cop/rails/uniq_before_pluck.rb
+++ b/lib/rubocop/cop/rails/uniq_before_pluck.rb
@@ -16,11 +16,11 @@ module RuboCop
       #   # good
       #   Model.uniq.pluck(:id)
       #
-      # This cop has two different enforcement modes. When the EnforcementMode
+      # This cop has two different enforcement modes. When the EnforcedMode
       # is conservative (the default) then only calls to pluck on a constant
       # (i.e. a model class) before uniq are added as offenses.
       #
-      # When the EnforcementMode is aggressive then all calls to pluck before
+      # When the EnforcedMode is aggressive then all calls to pluck before
       # uniq are added as offenses. This may lead to false positives as the cop
       # cannot distinguish between calls to pluck on an ActiveRecord::Relation
       # vs a call to pluck on an ActiveRecord::Associations::CollectionProxy.


### PR DESCRIPTION
RuboCop 0.41 doesn't work...


## repro

`test.rb`

```ruby
puts "a"
```

```sh
$ rubocop test.rb -d --rails --only Rails/UniqBeforePluck
An error occurred while Rails/UniqBeforePluck cop was inspecting /tmp/test/test.rb.

1 error occurred:
An error occurred while Rails/UniqBeforePluck cop was inspecting /tmp/test/test.rb.
Errors are usually caused by RuboCop bugs.
Please, report your problems to RuboCop's issue tracker.
Mention the following information in the issue report:
0.41.0 (using Parser 2.3.1.2, running on ruby 2.3.1 x86_64-linux)
For /tmp/test: configuration from /home/pocke/.gem/ruby/2.3.0/gems/rubocop-0.41.0/config/default.yml
Inheriting configuration from /home/pocke/.gem/ruby/2.3.0/gems/rubocop-0.41.0/config/enabled.yml
Inheriting configuration from /home/pocke/.gem/ruby/2.3.0/gems/rubocop-0.41.0/config/disabled.yml
Inspecting 1 file
Scanning /tmp/test/test.rb
undefined method `to_sym' for nil:NilClass
Did you mean?  to_s
/home/pocke/.gem/ruby/2.3.0/gems/rubocop-0.41.0/lib/rubocop/cop/rails/uniq_before_pluck.rb:71:in `mode'
/home/pocke/.gem/ruby/2.3.0/gems/rubocop-0.41.0/lib/rubocop/cop/rails/uniq_before_pluck.rb:51:in `on_send'
/home/pocke/.gem/ruby/2.3.0/gems/rubocop-0.41.0/lib/rubocop/cop/commissioner.rb:42:in `block (2 levels) in on_send'
/home/pocke/.gem/ruby/2.3.0/gems/rubocop-0.41.0/lib/rubocop/cop/commissioner.rb:97:in `with_cop_error_handling'
/home/pocke/.gem/ruby/2.3.0/gems/rubocop-0.41.0/lib/rubocop/cop/commissioner.rb:41:in `block in on_send'
/home/pocke/.gem/ruby/2.3.0/gems/rubocop-0.41.0/lib/rubocop/cop/commissioner.rb:40:in `each'
/home/pocke/.gem/ruby/2.3.0/gems/rubocop-0.41.0/lib/rubocop/cop/commissioner.rb:40:in `on_send'
/home/pocke/.gem/ruby/2.3.0/gems/rubocop-0.41.0/lib/rubocop/ast_node/traversal.rb:13:in `walk'
/home/pocke/.gem/ruby/2.3.0/gems/rubocop-0.41.0/lib/rubocop/cop/commissioner.rb:59:in `investigate'
/home/pocke/.gem/ruby/2.3.0/gems/rubocop-0.41.0/lib/rubocop/cop/team.rb:103:in `investigate'
/home/pocke/.gem/ruby/2.3.0/gems/rubocop-0.41.0/lib/rubocop/cop/team.rb:91:in `offenses'
/home/pocke/.gem/ruby/2.3.0/gems/rubocop-0.41.0/lib/rubocop/cop/team.rb:52:in `inspect_file'
/home/pocke/.gem/ruby/2.3.0/gems/rubocop-0.41.0/lib/rubocop/runner.rb:205:in `inspect_file'
/home/pocke/.gem/ruby/2.3.0/gems/rubocop-0.41.0/lib/rubocop/runner.rb:175:in `block in do_inspection_loop'
/home/pocke/.gem/ruby/2.3.0/gems/rubocop-0.41.0/lib/rubocop/runner.rb:165:in `loop'
/home/pocke/.gem/ruby/2.3.0/gems/rubocop-0.41.0/lib/rubocop/runner.rb:165:in `do_inspection_loop'
/home/pocke/.gem/ruby/2.3.0/gems/rubocop-0.41.0/lib/rubocop/runner.rb:87:in `process_file'
/home/pocke/.gem/ruby/2.3.0/gems/rubocop-0.41.0/lib/rubocop/runner.rb:59:in `block in inspect_files'
/home/pocke/.gem/ruby/2.3.0/gems/rubocop-0.41.0/lib/rubocop/runner.rb:57:in `each'
/home/pocke/.gem/ruby/2.3.0/gems/rubocop-0.41.0/lib/rubocop/runner.rb:57:in `inspect_files'
/home/pocke/.gem/ruby/2.3.0/gems/rubocop-0.41.0/lib/rubocop/runner.rb:35:in `run'
/home/pocke/.gem/ruby/2.3.0/gems/rubocop-0.41.0/lib/rubocop/cli.rb:72:in `execute_runner'
/home/pocke/.gem/ruby/2.3.0/gems/rubocop-0.41.0/lib/rubocop/cli.rb:28:in `run'
/home/pocke/.gem/ruby/2.3.0/gems/rubocop-0.41.0/bin/rubocop:14:in `block in <top (required)>'
/usr/lib/ruby/2.3.0/benchmark.rb:308:in `realtime'
/home/pocke/.gem/ruby/2.3.0/gems/rubocop-0.41.0/bin/rubocop:13:in `<top (required)>'
/home/pocke/.gem/ruby/2.3.0/bin/rubocop:23:in `load'
/home/pocke/.gem/ruby/2.3.0/bin/rubocop:23:in `<main>'
.

1 file inspected, no offenses detected
Finished in 0.06867309300287161 seconds

```

Cause
-----


In config file, config name is `EnforcementMode`.
However, in cop file, config name is `EnforcedMode`.
So, the cop can't reference the config. 

- https://github.com/bbatsov/rubocop/blob/26e1ff6abad5f5cb002cd1248a74a6f79cdcc7a0/config/default.yml#L1229
- https://github.com/bbatsov/rubocop/blob/26e1ff6abad5f5cb002cd1248a74a6f79cdcc7a0/lib/rubocop/cop/rails/uniq_before_pluck.rb#L71

https://github.com/bbatsov/rubocop/commit/13f2f5c8f25e3ec6b8b15372534293a5b06bf345


-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Used the same coding conventions as the rest of the project.
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [ ] Added tests.
* [x] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] All tests are passing.
* [x] The new code doesn't generate RuboCop offenses.
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.

[1]: http://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html

