### PR TITLE
Make cop names more flexible in CommentConfig lines

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Bug fixes
 
 * [#3248](https://github.com/bbatsov/rubocop/issues/3248): Support 'ruby-' prefix in `.ruby-version`. ([@tjwp][])
+* [#3250](https://github.com/bbatsov/rubocop/pull/3250): Make regexp for cop names less restrictive in CommentConfig lines. ([@tjwp][])
 
 ## 0.41.1 (2016-06-26)
 

--- a/lib/rubocop/comment_config.rb
+++ b/lib/rubocop/comment_config.rb
@@ -7,7 +7,7 @@ module RuboCop
   class CommentConfig
     UNNEEDED_DISABLE = 'Lint/UnneededDisable'.freeze
 
-    COP_NAME_PATTERN = '([A-Z][a-z]+/)?(?:[A-Z][a-z]+)+'.freeze
+    COP_NAME_PATTERN = '([A-Z]\w+/)?(?:[A-Z]\w+)'.freeze
     COP_NAMES_PATTERN = "(?:#{COP_NAME_PATTERN} , )*#{COP_NAME_PATTERN}".freeze
     COPS_PATTERN = "(all|#{COP_NAMES_PATTERN})".freeze
 

--- a/spec/rubocop/comment_config_spec.rb
+++ b/spec/rubocop/comment_config_spec.rb
@@ -57,7 +57,9 @@ describe RuboCop::CommentConfig do
         '# rubocop:enable Lint/RandOne foo bar!',            # 45
         '# rubocop:disable FlatMap',
         '[1, 2, 3, 4].map { |e| [e, e] }.flatten(1)',
-        '# rubocop:enable FlatMap'
+        '# rubocop:enable FlatMap',
+        '# rubocop:disable RSpec/Example',
+        '# rubocop:disable Custom2/Number9'                  # 50
       ]
     end
 
@@ -155,6 +157,14 @@ describe RuboCop::CommentConfig do
     it 'can handle double disable of one cop' do
       expect(disabled_lines_of_cop('Style/ClassVars'))
         .to eq([9, 10, 11] + (33..source.size).to_a)
+    end
+
+    it 'supports disabling cops with multiple uppercase letters' do
+      expect(disabled_lines_of_cop('RSpec/Example')).to include(49)
+    end
+
+    it 'supports disabling cops with numbers in their name' do
+      expect(disabled_lines_of_cop('Custom2/Number9')).to include(50)
     end
   end
 end


### PR DESCRIPTION
https://github.com/bbatsov/rubocop/pull/3201 introduced support for arbitrary comments after cop names.

However, the previous regexp for cop names was roughly `[\w/]+`. The new regexp for a cop name is 
`([A-Z][a-z]+/)?(?:[A-Z][a-z]+)+`. 

This regexp is too restrictive for some existing custom cops. All of the cops in rubocop-rspec are in a `RSpec` department that does not match this regexp.

This change makes the cop name regexp `([A-Z]\w+/)?(?:[A-Z]\w+)` to allow better back compatibility with existing custom cops.

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Used the same coding conventions as the rest of the project.
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] All tests are passing.
* [x] The new code doesn't generate RuboCop offenses.
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.

[1]: http://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html

