### PR TITLE
[Fix #3248] Support 'ruby-' prefix in .ruby-version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## master (unreleased)
 
+### Bug fixes
+
+* [#3248](https://github.com/bbatsov/rubocop/issues/3248): Support 'ruby-' prefix in `.ruby-version`. ([@tjwp][])
+
 ## 0.41.1 (2016-06-26)
 
 ### Bug fixes

--- a/lib/rubocop/config.rb
+++ b/lib/rubocop/config.rb
@@ -199,7 +199,9 @@ module RuboCop
         if File.file?('.ruby-version')
           @target_ruby_version_source = :dot_ruby_version
 
-          File.read('.ruby-version').to_f
+          /(ruby-)?(?<ruby_version>\d.\d)/ =~ File.read('.ruby-version')
+
+          ruby_version.to_f if ruby_version
         else
           @target_ruby_version_source = :rubocop_yml
 

--- a/spec/rubocop/config_spec.rb
+++ b/spec/rubocop/config_spec.rb
@@ -389,7 +389,16 @@ describe RuboCop::Config do
       end
 
       it 'reads it to determine the target ruby version' do
-        expect(configuration.target_ruby_version).to eq 2.2
+        expect(configuration.target_ruby_version).to eq ruby_version_to_f
+      end
+
+      context 'when ruby version is prefixed by "ruby-"' do
+        let(:ruby_version) { 'ruby-2.3.0' }
+        let(:ruby_version_to_f) { 2.3 }
+
+        it 'correctly determines the target ruby version' do
+          expect(configuration.target_ruby_version).to eq ruby_version_to_f
+        end
       end
     end
 


### PR DESCRIPTION
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Used the same coding conventions as the rest of the project.
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] All tests are passing.
* [x] The new code doesn't generate RuboCop offenses.
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.

[1]: http://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html

