### PR TITLE
Handle blank top-level Exclude key

### DIFF
--- a/lib/rubocop/config.rb
+++ b/lib/rubocop/config.rb
@@ -173,7 +173,7 @@ module RuboCop
     end
 
     def patterns_to_exclude
-      @patterns_to_exclude ||= for_all_cops['Exclude']
+      @patterns_to_exclude ||= for_all_cops['Exclude'] || []
     end
 
     def path_relative_to_config(path)

--- a/lib/rubocop/target_finder.rb
+++ b/lib/rubocop/target_finder.rb
@@ -111,7 +111,8 @@ module RuboCop
 
     def excluded_dirs(base_dir)
       all_cops_config = @config_store.for(base_dir).for_all_cops
-      dir_tree_excludes = all_cops_config['Exclude'].select do |pattern|
+      excludes = all_cops_config['Exclude'] || []
+      dir_tree_excludes = excludes.select do |pattern|
         pattern.is_a?(String) && pattern.end_with?('/**/*')
       end
       dir_tree_excludes.map { |pattern| pattern.sub(%r{/\*\*/\*$}, '') }

--- a/spec/rubocop/config_spec.rb
+++ b/spec/rubocop/config_spec.rb
@@ -246,6 +246,18 @@ describe RuboCop::Config do
         expect(configuration.file_to_exclude?('baz.rb')).to be_falsey
       end
     end
+
+    context 'when the passed path is blank' do
+      it 'does not raise an error' do
+        loaded_path = '/tmp/.rubocop.yml'
+        create_file(loaded_path,
+                    ['AllCops:',
+                     '  Exclude:'])
+        configuration = described_class.new({}, loaded_path)
+
+        expect(configuration.file_to_exclude?('foo.rb')).to be_falsey
+      end
+    end
   end
 
   describe '#patterns_to_include' do


### PR DESCRIPTION
If the user provides a blank file exclusion config like:
```yaml
AllCops:
  Exclude:
```
then an exception will be raised.

This change ensures that if `Exclude` is parsed as `nil` that it
defaults exclude patterns to an empty array.