### PR TITLE
[Fix #3247] Ensure whitespace after beginning of block in Style/BlockDelimiters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 * [#3249](https://github.com/bbatsov/rubocop/issues/3249): Account for `rescue nil` in `Style/ShadowedException`. ([@rrosenblum][])
 * Modify the highlighting in `Style/ShadowedException` to be more useful. Highlight just `rescue` area. ([@rrosenblum][])
 * [#3129](https://github.com/bbatsov/rubocop/issues/3129): Fix `Style/MethodCallParentheses` to work with multiple assignments. ([@tejasbubane][])
+* [#3247](https://github.com/bbatsov/rubocop/issues/3247): Ensure whitespace after beginning of block in `Style/BlockDelimiters`. ([@tjwp][])
 
 ## 0.41.1 (2016-06-26)
 

--- a/lib/rubocop/cop/style/block_delimiters.rb
+++ b/lib/rubocop/cop/style/block_delimiters.rb
@@ -6,7 +6,7 @@ module RuboCop
     module Style
       # Check for uses of braces or do/end around single line or
       # multi-line blocks.
-      class BlockDelimiters < Cop
+      class BlockDelimiters < Cop # rubocop:disable Metrics/ClassLength
         include ConfigurableEnforcedStyle
 
         def on_send(node)
@@ -79,9 +79,11 @@ module RuboCop
             if b.is?('{')
               corrector.insert_before(b, ' ') unless whitespace_before?(b)
               corrector.insert_before(e, ' ') unless whitespace_before?(e)
+              corrector.insert_after(b, ' ') unless whitespace_after?(b)
               corrector.replace(b, 'do')
               corrector.replace(e, 'end')
             else
+              corrector.insert_after(b, ' ') unless whitespace_after?(b, 2)
               corrector.replace(b, '{')
               corrector.replace(e, '}')
             end
@@ -90,6 +92,10 @@ module RuboCop
 
         def whitespace_before?(node)
           node.source_buffer.source[node.begin_pos - 1, 1] =~ /\s/
+        end
+
+        def whitespace_after?(node, length = 1)
+          node.source_buffer.source[node.begin_pos + length, 1] =~ /\s/
         end
 
         def get_blocks(node, &block)

--- a/spec/rubocop/cop/style/block_delimiters_spec.rb
+++ b/spec/rubocop/cop/style/block_delimiters_spec.rb
@@ -176,21 +176,36 @@ describe RuboCop::Cop::Style::BlockDelimiters, :config do
       expect(cop.messages).to be_empty
     end
 
-    it 'auto-corrects { and } to do and end if it is a procedural block' do
-      source = <<-END.strip_indent
-        each { |x|
-          x
-        }
-      END
-
-      expected_source = <<-END.strip_indent
+    context 'with a procedural block' do
+      let(:corrected_source) do
+        <<-END.strip_indent
         each do |x|
           x
         end
-      END
+        END
+      end
 
-      new_source = autocorrect_source(cop, source)
-      expect(new_source).to eq(expected_source)
+      it 'auto-corrects { and } to do and end' do
+        source = <<-END.strip_indent
+        each { |x|
+          x
+        }
+        END
+
+        new_source = autocorrect_source(cop, source)
+        expect(new_source).to eq(corrected_source)
+      end
+
+      it 'auto-corrects { and } to do and end with appropriate spacing' do
+        source = <<-END.strip_indent
+        each {|x|
+          x
+        }
+        END
+
+        new_source = autocorrect_source(cop, source)
+        expect(new_source).to eq(corrected_source)
+      end
     end
 
     it 'does not auto-correct {} to do-end if it is a known functional ' \
@@ -220,6 +235,23 @@ describe RuboCop::Cop::Style::BlockDelimiters, :config do
     it 'auto-corrects do-end to {} if it is a functional block' do
       source = <<-END.strip_indent
         foo = map do |x|
+          x
+        end
+      END
+
+      expected_source = <<-END.strip_indent
+        foo = map { |x|
+          x
+        }
+      END
+
+      new_source = autocorrect_source(cop, source)
+      expect(new_source).to eq(expected_source)
+    end
+
+    it 'auto-corrects do-end to {} with appropriate spacing' do
+      source = <<-END.strip_indent
+        foo = map do|x|
           x
         end
       END


### PR DESCRIPTION

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Used the same coding conventions as the rest of the project.
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] All tests are passing.
* [x] The new code doesn't generate RuboCop offenses.
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.

[1]: http://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html
