### PR TITLE
TargetRubyVersion takes precedence over .ruby-version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 * [#3248](https://github.com/bbatsov/rubocop/issues/3248): Support 'ruby-' prefix in `.ruby-version`. ([@tjwp][])
 * [#3250](https://github.com/bbatsov/rubocop/pull/3250): Make regexp for cop names less restrictive in CommentConfig lines. ([@tjwp][])
+* [#3261](https://github.com/bbatsov/rubocop/pull/3261): Prefer `TargetRubyVersion` to `.ruby-version`. ([@tjwp][])
 
 ## 0.41.1 (2016-06-26)
 

--- a/config/default.yml
+++ b/config/default.yml
@@ -73,9 +73,12 @@ AllCops:
   # cache location is secure from this kind of attack, and wish to use a
   # symlinked cache location, set this value to "true".
   AllowSymlinksInCacheRootDirectory: false
-  # What version of the Ruby interpreter is the inspected code intended to
+  # What MRI version of the Ruby interpreter is the inspected code intended to
   # run on? (If there is more than one, set this to the lowest version.)
-  TargetRubyVersion: 2.0
+  # If a value is specified for TargetRubyVersion then it is used.
+  # Else if .ruby-version exists and it contains an MRI version it is used.
+  # Otherwise we fallback to the oldest officially supported Ruby version (2.0).
+  TargetRubyVersion: ~
 
 # Indent private/protected/public as deep as method definitions
 Style/AccessModifierIndentation:

--- a/lib/rubocop/config.rb
+++ b/lib/rubocop/config.rb
@@ -16,6 +16,8 @@ module RuboCop
 
     COMMON_PARAMS = %w(Exclude Include Severity
                        AutoCorrect StyleGuide Details).freeze
+    # 2.0 is the oldest officially supported Ruby version.
+    DEFAULT_RUBY_VERSION = 2.0
     KNOWN_RUBIES = [1.9, 2.0, 2.1, 2.2, 2.3].freeze
     OBSOLETE_COPS = {
       'Style/TrailingComma' =>
@@ -196,16 +198,18 @@ module RuboCop
 
     def target_ruby_version
       @target_ruby_version ||=
-        if File.file?('.ruby-version')
-          @target_ruby_version_source = :dot_ruby_version
-
-          /(ruby-)?(?<ruby_version>\d.\d)/ =~ File.read('.ruby-version')
-
-          ruby_version.to_f if ruby_version
-        else
+        if for_all_cops['TargetRubyVersion']
           @target_ruby_version_source = :rubocop_yml
 
           for_all_cops['TargetRubyVersion']
+        elsif File.file?('.ruby-version') &&
+              /\A(ruby-)?(?<version>\d+\.\d+)/ =~ File.read('.ruby-version')
+
+          @target_ruby_version_source = :dot_ruby_version
+
+          version.to_f
+        else
+          DEFAULT_RUBY_VERSION
         end
     end
 


### PR DESCRIPTION
Based on the discussion on https://github.com/bbatsov/rubocop/pull/3251 regarding JRuby and other values that can appear in .ruby-version, I made this change to see if it can help to resolve the situation.

In order to change the precedence, I had to move the default for `TargetRubyVersion` from `default.yml` to code.

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Used the same coding conventions as the rest of the project.
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] All tests are passing.
* [x] The new code doesn't generate RuboCop offenses.
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.

[1]: http://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html

