### PR TITLE
Shadowed exception

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 * [#3250](https://github.com/bbatsov/rubocop/pull/3250): Make regexp for cop names less restrictive in CommentConfig lines. ([@tjwp][])
 * [#3261](https://github.com/bbatsov/rubocop/pull/3261): Prefer `TargetRubyVersion` to `.ruby-version`. ([@tjwp][])
 * [#3249](https://github.com/bbatsov/rubocop/issues/3249): Account for `rescue nil` in `Style/ShadowedException`. ([@rrosenblum][])
+* Modify the highlighting in `Style/ShadowedException` to be more useful. Highlight just `rescue` area. ([@rrosenblum][])
 
 ## 0.41.1 (2016-06-26)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 * [#3248](https://github.com/bbatsov/rubocop/issues/3248): Support 'ruby-' prefix in `.ruby-version`. ([@tjwp][])
 * [#3250](https://github.com/bbatsov/rubocop/pull/3250): Make regexp for cop names less restrictive in CommentConfig lines. ([@tjwp][])
 * [#3261](https://github.com/bbatsov/rubocop/pull/3261): Prefer `TargetRubyVersion` to `.ruby-version`. ([@tjwp][])
+* [#3249](https://github.com/bbatsov/rubocop/issues/3249): Account for `rescue nil` in `Style/ShadowedException`. ([@rrosenblum][])
 
 ## 0.41.1 (2016-06-26)
 

--- a/lib/rubocop/cop/lint/shadowed_exception.rb
+++ b/lib/rubocop/cop/lint/shadowed_exception.rb
@@ -45,10 +45,19 @@ module RuboCop
           return if !rescue_group_rescues_multiple_levels &&
                     rescued_groups == sort_rescued_groups(rescued_groups)
 
-          add_offense(node, :expression)
+          add_offense(node, offense_range(node, rescues))
         end
 
         private
+
+        def offense_range(node, rescues)
+          first_rescue = rescues.first
+          last_rescue = rescues.last
+          last_exceptions, = *last_rescue
+          Parser::Source::Range.new(node.loc.expression.source_buffer,
+                                    first_rescue.loc.expression.begin_pos,
+                                    last_exceptions.loc.expression.end_pos)
+        end
 
         def rescue_modifier?(node)
           node && node.rescue_type? &&

--- a/lib/rubocop/cop/lint/shadowed_exception.rb
+++ b/lib/rubocop/cop/lint/shadowed_exception.rb
@@ -73,7 +73,13 @@ module RuboCop
 
             rescued_exceptions.each_with_object([]) do |exception, converted|
               begin
-                converted << instance_eval(exception, __FILE__, __LINE__)
+                evaled_exception = instance_eval(exception, __FILE__, __LINE__)
+                # `rescue nil` is valid syntax in all versions of Ruby. In Ruby
+                # 1.9.3, it effectively disables the `rescue`. In versions
+                # after 1.9.3, a `TypeError` is thrown when the statement is
+                # rescued. In order to account for this, we convert `nil` to
+                # `NilClass`.
+                converted << (evaled_exception || NilClass)
               rescue StandardError, ScriptError
                 next
               end

--- a/lib/rubocop/cop/lint/shadowed_exception.rb
+++ b/lib/rubocop/cop/lint/shadowed_exception.rb
@@ -39,10 +39,10 @@ module RuboCop
           end
 
           rescue_group_rescues_multiple_levels = rescued_groups.any? do |group|
-            !contains_multiple_levels_of_exceptions?(group)
+            contains_multiple_levels_of_exceptions?(group)
           end
 
-          return if rescue_group_rescues_multiple_levels &&
+          return if !rescue_group_rescues_multiple_levels &&
                     rescued_groups == sort_rescued_groups(rescued_groups)
 
           add_offense(node, :expression)

--- a/spec/rubocop/cop/lint/shadowed_exception_spec.rb
+++ b/spec/rubocop/cop/lint/shadowed_exception_spec.rb
@@ -111,6 +111,7 @@ describe RuboCop::Cop::Lint::ShadowedException do
                            'end'])
 
       expect(cop.messages).to eq(['Do not shadow rescued Exceptions'])
+      expect(cop.highlights).to eq(['rescue StandardError, Exception'])
     end
 
     it 'accepts splat arguments passed to rescue' do
@@ -152,6 +153,7 @@ describe RuboCop::Cop::Lint::ShadowedException do
                            'end'])
 
       expect(cop.messages).to eq(['Do not shadow rescued Exceptions'])
+      expect(cop.highlights).to eq(['rescue nil, StandardError, Exception'])
     end
   end
 
@@ -167,6 +169,9 @@ describe RuboCop::Cop::Lint::ShadowedException do
                            'end'])
 
       expect(cop.messages).to eq(['Do not shadow rescued Exceptions'])
+      expect(cop.highlights).to eq([['rescue Exception',
+                                     '  handle_exception',
+                                     'rescue StandardError'].join("\n")])
     end
 
     it 'registers an offense when a higher level exception is rescued before ' \
@@ -181,6 +186,10 @@ describe RuboCop::Cop::Lint::ShadowedException do
                            'end'])
 
       expect(cop.messages).to eq(['Do not shadow rescued Exceptions'])
+      expect(cop.highlights).to eq([['rescue Exception',
+                                     '  handle_exception',
+                                     'rescue NoMethodError, ZeroDivisionError']
+                                     .join("\n")])
     end
 
     it 'registers an offense rescuing out of order exceptions when there ' \
@@ -196,6 +205,9 @@ describe RuboCop::Cop::Lint::ShadowedException do
                            'end'])
 
       expect(cop.messages).to eq(['Do not shadow rescued Exceptions'])
+      expect(cop.highlights).to eq([['rescue Exception',
+                                     '  handle_exception',
+                                     'rescue StandardError'].join("\n")])
     end
 
     it 'accepts rescuing exceptions in order of level' do
@@ -260,6 +272,9 @@ describe RuboCop::Cop::Lint::ShadowedException do
                              'end'])
 
         expect(cop.messages).to eq(['Do not shadow rescued Exceptions'])
+        expect(cop.highlights).to eq([['rescue Exception',
+                                       '  b',
+                                       'rescue *BAR'].join("\n")])
       end
     end
 

--- a/spec/rubocop/cop/lint/shadowed_exception_spec.rb
+++ b/spec/rubocop/cop/lint/shadowed_exception_spec.rb
@@ -122,6 +122,37 @@ describe RuboCop::Cop::Lint::ShadowedException do
 
       expect(cop.offenses).to be_empty
     end
+
+    it 'accepts rescuing nil' do
+      inspect_source(cop, ['begin',
+                           '  a',
+                           'rescue nil',
+                           '  b',
+                           'end'])
+
+      expect(cop.offenses).to be_empty
+    end
+
+    it 'accepts rescuing nil and another exception' do
+      inspect_source(cop, ['begin',
+                           '  a',
+                           'rescue nil, Exception',
+                           '  b',
+                           'end'])
+
+      expect(cop.offenses).to be_empty
+    end
+
+    it 'registers an offense when rescuing nil multiple exceptions of ' \
+       'different levels' do
+      inspect_source(cop, ['begin',
+                           '  a',
+                           'rescue nil, StandardError, Exception',
+                           '  b',
+                           'end'])
+
+      expect(cop.messages).to eq(['Do not shadow rescued Exceptions'])
+    end
   end
 
   context 'multiple rescues' do
@@ -256,6 +287,30 @@ describe RuboCop::Cop::Lint::ShadowedException do
 
         expect(cop.offenses).to be_empty
       end
+    end
+
+    it 'accepts rescuing nil before another exception' do
+      inspect_source(cop, ['begin',
+                           '  a',
+                           'rescue nil',
+                           '  b',
+                           'rescue',
+                           '  c',
+                           'end'])
+
+      expect(cop.offenses).to be_empty
+    end
+
+    it 'accepts rescuing nil after another exception' do
+      inspect_source(cop, ['begin',
+                           '  a',
+                           'rescue',
+                           '  b',
+                           'rescue nil',
+                           '  c',
+                           'end'])
+
+      expect(cop.offenses).to be_empty
     end
   end
 end


### PR DESCRIPTION
This fixes #3249. I also realized that I had a boolean variable stored as the opposite of its name. 

As mentioned in the issue, it appears that `rescue nil` will effectively disable the `rescue` in Ruby 1.9.3. In versions after 1.9.3, a `TypeError` is thrown when the statement is rescued. There is opportunity for us to add a new Lint cop to recommend against this.