### PR TITLE
Fix `Lint/ShadowedException` to block arbitrary code execution

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 * [#3129](https://github.com/bbatsov/rubocop/issues/3129): Fix `Style/MethodCallParentheses` to work with multiple assignments. ([@tejasbubane][])
 * [#3247](https://github.com/bbatsov/rubocop/issues/3247): Ensure whitespace after beginning of block in `Style/BlockDelimiters`. ([@tjwp][])
 * [#2941](https://github.com/bbatsov/rubocop/issues/2941): Make sure `Lint/UnneededDisable` can do auto-correction. ([@jonas054][])
+* [#3269](https://github.com/bbatsov/rubocop/pull/3269):  Fix `Lint/ShadowedException` to block arbitrary code execution. ([@pocke][])
 
 ## 0.41.1 (2016-06-26)
 

--- a/lib/rubocop/cop/lint/shadowed_exception.rb
+++ b/lib/rubocop/cop/lint/shadowed_exception.rb
@@ -78,17 +78,10 @@ module RuboCop
 
         def evaluate_exceptions(rescue_group)
           if rescue_group
-            rescued_exceptions = rescue_group.source.delete(' ').split(',')
-
+            rescued_exceptions = rescued_exceptions(rescue_group)
             rescued_exceptions.each_with_object([]) do |exception, converted|
               begin
-                evaled_exception = instance_eval(exception, __FILE__, __LINE__)
-                # `rescue nil` is valid syntax in all versions of Ruby. In Ruby
-                # 1.9.3, it effectively disables the `rescue`. In versions
-                # after 1.9.3, a `TypeError` is thrown when the statement is
-                # rescued. In order to account for this, we convert `nil` to
-                # `NilClass`.
-                converted << (evaled_exception || NilClass)
+                converted << instance_eval(exception, __FILE__, __LINE__)
               rescue StandardError, ScriptError
                 next
               end
@@ -103,6 +96,21 @@ module RuboCop
           groups.sort do |x, y|
             x <=> y || 0
           end
+        end
+
+        # @param [RuboCop::Node] rescue_group is a node of array_type
+        def rescued_exceptions(rescue_group)
+          klasses = *rescue_group
+          klasses.map do |klass|
+            # `rescue nil` is valid syntax in all versions of Ruby. In Ruby
+            # 1.9.3, it effectively disables the `rescue`. In versions
+            # after 1.9.3, a `TypeError` is thrown when the statement is
+            # rescued. In order to account for this, we convert `nil` to
+            # `NilClass`.
+            next 'NilClass' if klass.nil_type?
+            next unless klass.const_type?
+            klass.source
+          end.compact
         end
       end
     end

--- a/spec/rubocop/cop/lint/shadowed_exception_spec.rb
+++ b/spec/rubocop/cop/lint/shadowed_exception_spec.rb
@@ -327,5 +327,17 @@ describe RuboCop::Cop::Lint::ShadowedException do
 
       expect(cop.offenses).to be_empty
     end
+
+    it 'ignores expressions of non-const' do
+      inspect_source(cop, ['begin',
+                           '  a',
+                           'rescue foo',
+                           '  b',
+                           'rescue [bar]',
+                           '  c',
+                           'end'])
+
+      expect(cop.offenses).to be_empty
+    end
   end
 end


### PR DESCRIPTION
## Problem

`Lint/ShadowedException` cop has an security risk.
An attacker can execute arbitrary code on a rubocop executing computer.

## Reproduce

```ruby
# test.rb
begin
  something
rescue puts('Arbitrary-code-execution!')
  handle_exception
rescue RuntimeError
  handle_standard_error
end
```

```sh
$ rubocop test.rb  --only Lint/ShadowedException --cache false
Inspecting 1 file
Arbitrary-code-execution!
.

1 file inspected, no offenses detected
```


## Change


The cop evaluates const expressions only.
Other expressions(variables, method call, ....) are ignored.

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Used the same coding conventions as the rest of the project.
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] All tests are passing.
* [x] The new code doesn't generate RuboCop offenses.
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.

[1]: http://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html

