### PR TITLE
Improve the performance of alignment cops

### DIFF
--- a/lib/rubocop/cop/mixin/preceding_following_alignment.rb
+++ b/lib/rubocop/cop/mixin/preceding_following_alignment.rb
@@ -36,8 +36,9 @@ module RuboCop
         line_nos.each do |lineno|
           next if comment_lines.include?(lineno + 1)
           line = processed_source.lines[lineno]
-          next if line =~ /\A\s*\Z/
-          next if indent && indent != (line =~ /\S/)
+          index = line =~ /\S/
+          next unless index
+          next if indent && indent != index
           return yield(range, line)
         end
         false


### PR DESCRIPTION
I have removed one regex comparison.

Benchmark
-------

### code

in rubocop repository

```sh
$ rubocop --only Style/ExtraSpacing,Style/SpaceAroundOperators,Style/SpaceBeforeFirstArg --debug --cache false
```

Try 3 times. 


### before

- Finished in 19.22800659799759 seconds
- Finished in 19.06494819999716 seconds
- Finished in 19.32700561100137 seconds

Average: 19.206653469665373

### After

- Finished in 16.72149716000058 seconds
- Finished in 16.58760976600024 seconds
- Finished in 16.84783971899742 seconds

Average: 16.718982214999414



-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Used the same coding conventions as the rest of the project.
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [ ] Added tests.
* [ ] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] All tests are passing.
* [x] The new code doesn't generate RuboCop offenses.
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.

[1]: http://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html

