### PR TITLE
Fix [#3272] Add escape character missing to LITERAL_REGEX

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@
 ### Changes
 
 * [#3230](https://github.com/bbatsov/rubocop/issues/3230): Improve highlighting for `Style/AsciiComments` cop. ([@drenmi][])
+* [#3272](https://github.com/bbatsov/rubocop/issues/3272): Add escape character missing to LITERAL_REGEX. ([@pocke][])
 
 ## 0.41.1 (2016-06-26)
 

--- a/lib/rubocop/cop/util.rb
+++ b/lib/rubocop/cop/util.rb
@@ -25,7 +25,7 @@ module RuboCop
 
       # Match literal regex characters, not including anchors, character
       # classes, alternatives, groups, repetitions, references, etc
-      LITERAL_REGEX = /[\w\s\-,"'!#%&<>=;:`~]|\\[^AbBdDgGkwWszZS0-9]/
+      LITERAL_REGEX = /[\w\s\-,"'!#%&<>=;:`~]|\\[^AbBdDgGhHkpPRwWXsSzZS0-9]/
 
       module_function
 

--- a/spec/rubocop/cop/performance/end_with_spec.rb
+++ b/spec/rubocop/cop/performance/end_with_spec.rb
@@ -45,7 +45,7 @@ describe RuboCop::Cop::Performance::EndWith do
     end
 
     # character classes, anchors
-    %w(w W s S d D A Z z G b B).each do |str|
+    %w(w W s S d D A Z z G b B h H R X S).each do |str|
       it "doesn't register an error for #{method} /\\#{str}\\z/" do
         inspect_source(cop, "str#{method} /\\#{str}\\z/")
         expect(cop.messages).to be_empty
@@ -53,7 +53,7 @@ describe RuboCop::Cop::Performance::EndWith do
     end
 
     # characters with no special meaning whatsoever
-    %w(h i j l m o q y).each do |str|
+    %w(i j l m o q y).each do |str|
       it "autocorrects #{method} /\\#{str}\\z/" do
         new_source = autocorrect_source(cop, "str#{method} /\\#{str}\\z/")
         expect(new_source).to eq "str.end_with?('#{str}')"

--- a/spec/rubocop/cop/performance/start_with_spec.rb
+++ b/spec/rubocop/cop/performance/start_with_spec.rb
@@ -36,7 +36,7 @@ describe RuboCop::Cop::Performance::StartWith do
     end
 
     # character classes, anchors
-    %w(w W s S d D A Z z G b B).each do |str|
+    %w(w W s S d D A Z z G b B h H R X S).each do |str|
       it "doesn't register an error for #{method} /\\A\\#{str}/" do
         inspect_source(cop, "str#{method} /\\A\\#{str}/")
         expect(cop.messages).to be_empty
@@ -44,7 +44,7 @@ describe RuboCop::Cop::Performance::StartWith do
     end
 
     # characters with no special meaning whatsoever
-    %w(h i j l m o q y).each do |str|
+    %w(i j l m o q y).each do |str|
       it "autocorrects #{method} /\\A\\#{str}/" do
         new_source = autocorrect_source(cop, "str#{method} /\\A\\#{str}/")
         expect(new_source).to eq "str.start_with?('#{str}')"


### PR DESCRIPTION
Add the following escape characters to LITERAL_REGEX.

- `\h` hex number class
- `\H` not hex number class
- `\p` Unicode property
- `\P` not Unicode property
- `\R` Linebreak
- `\X` Unicode extended grapheme cluster
- `\S` not white space

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Used the same coding conventions as the rest of the project.
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] All tests are passing.
* [x] The new code doesn't generate RuboCop offenses.
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.

[1]: http://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html

`