### PR TITLE
[Fix #2941] Make sure UnneededDisable#autocorrect is called

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 * Modify the highlighting in `Style/ShadowedException` to be more useful. Highlight just `rescue` area. ([@rrosenblum][])
 * [#3129](https://github.com/bbatsov/rubocop/issues/3129): Fix `Style/MethodCallParentheses` to work with multiple assignments. ([@tejasbubane][])
 * [#3247](https://github.com/bbatsov/rubocop/issues/3247): Ensure whitespace after beginning of block in `Style/BlockDelimiters`. ([@tjwp][])
+* [#2941](https://github.com/bbatsov/rubocop/issues/2941): Make sure `Lint/UnneededDisable` can do auto-correction. ([@jonas054][])
 
 ## 0.41.1 (2016-06-26)
 

--- a/lib/rubocop/cop/lint/unneeded_disable.rb
+++ b/lib/rubocop/cop/lint/unneeded_disable.rb
@@ -31,27 +31,34 @@ module RuboCop
 
         def autocorrect(args)
           lambda do |corrector|
-            ranges, range = *args # ranges are sorted by position
+            ranges, range = *args # Ranges are sorted by position.
 
             if range.source.start_with?('#')
-              # eat the entire comment and following newline
-              corrector.remove(range_with_surrounding_space(range, :right))
+              # Eat the entire comment, the preceding space, and the preceding
+              # newline if there is one.
+              original_begin = range.begin_pos
+              range = range_with_surrounding_space(range, :left, true)
+              range = range_with_surrounding_space(range, :right,
+                                                   # Special for a comment that
+                                                   # begins the file: remove
+                                                   # the newline at the end.
+                                                   original_begin == 0)
             else
-              # is there any cop between this one and the end of the line, which
+              # Is there any cop between this one and the end of the line, which
               # is NOT being removed?
 
               if ends_its_line?(ranges.last) && trailing_range?(ranges, range)
-                # eat the comma on the left
+                # Eat the comma on the left.
                 range = range_with_surrounding_space(range, :left)
                 range = range_with_surrounding_comma(range, :left)
               end
 
               range = range_with_surrounding_comma(range, :right)
-              # eat following spaces up to EOL, but not the newline itself
+              # Eat following spaces up to EOL, but not the newline itself.
               range = range_with_surrounding_space(range, :right, false)
-
-              corrector.remove(range)
             end
+
+            corrector.remove(range)
           end
         end
 

--- a/lib/rubocop/cop/team.rb
+++ b/lib/rubocop/cop/team.rb
@@ -70,6 +70,24 @@ module RuboCop
         end
       end
 
+      def autocorrect(buffer, cops)
+        @updated_source_file = false
+        return unless autocorrect?
+
+        new_source = autocorrect_all_cops(buffer, cops)
+
+        return if new_source == buffer.source
+
+        if @options[:stdin]
+          # holds source read in from stdin, when --stdin option is used
+          @options[:stdin] = new_source
+        else
+          filename = buffer.name
+          File.open(filename, 'wb') { |f| f.write(new_source) }
+        end
+        @updated_source_file = true
+      end
+
       private
 
       def offenses(processed_source)
@@ -109,24 +127,6 @@ module RuboCop
       def cop_enabled?(cop_class)
         @config.cop_enabled?(cop_class) ||
           (@options[:only] || []).include?(cop_class.cop_name)
-      end
-
-      def autocorrect(buffer, cops)
-        @updated_source_file = false
-        return unless autocorrect?
-
-        new_source = autocorrect_all_cops(buffer, cops)
-
-        return if new_source == buffer.source
-
-        if @options[:stdin]
-          # holds source read in from stdin, when --stdin option is used
-          @options[:stdin] = new_source
-        else
-          filename = buffer.name
-          File.open(filename, 'wb') { |f| f.write(new_source) }
-        end
-        @updated_source_file = true
       end
 
       def autocorrect_all_cops(buffer, cops)

--- a/lib/rubocop/cop/util.rb
+++ b/lib/rubocop/cop/util.rb
@@ -151,7 +151,7 @@ module RuboCop
       def move_pos(src, pos, step, condition, regexp)
         offset = step == -1 ? -1 : 0
         pos += step while condition && src[pos + offset] =~ regexp
-        pos
+        pos < 0 ? 0 : pos
       end
 
       def directions(side)

--- a/lib/rubocop/runner.rb
+++ b/lib/rubocop/runner.rb
@@ -107,11 +107,18 @@ module RuboCop
           if cop.relevant_file?(file)
             cop.check(offenses, source.disabled_line_ranges, source.comments)
             offenses += cop.offenses
+            autocorrect_unneeded_disables(source, cop)
           end
         end
+        offenses
       end
 
       offenses.sort.reject(&:disabled?).freeze
+    end
+
+    def autocorrect_unneeded_disables(source, cop)
+      cop.processed_source = source
+      Cop::Team.new([], nil, @options).autocorrect(source.buffer, [cop])
     end
 
     def file_started(file)


### PR DESCRIPTION
Since `UnneededDisable` isn't a normal cop, but a special one that gets called after the other ones have finished, we need to take extra steps so that its `autocorrect` method gets called.