### PR TITLE
[Fix #3255] Make `Style/RaiseArgs` auto-correct work when constructing exception without argument

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@
 
 * [#3230](https://github.com/bbatsov/rubocop/issues/3230): Improve highlighting for `Style/AsciiComments` cop. ([@drenmi][])
 * [#3272](https://github.com/bbatsov/rubocop/issues/3272): Add escape character missing to LITERAL_REGEX. ([@pocke][])
+* [#3255](https://github.com/bbatsov/rubocop/issues/3255): Fix auto-correct for `Style/RaiseArgs` when constructing exception without arguments. ([@drenmi][])
 
 ## 0.41.1 (2016-06-26)
 

--- a/lib/rubocop/cop/style/raise_args.rb
+++ b/lib/rubocop/cop/style/raise_args.rb
@@ -75,7 +75,12 @@ module RuboCop
         def correction_compact_to_exploded(node)
           exception_node, _new, message_node = *node.first
 
-          "#{exception_node.const_name}, #{message_node.source}"
+          message = message_node && message_node.source
+
+          correction = exception_node.const_name.to_s
+          correction = "#{correction}, #{message}" if message
+
+          correction
         end
 
         def correction_exploded_to_compact(node)

--- a/spec/rubocop/cop/style/raise_args_spec.rb
+++ b/spec/rubocop/cop/style/raise_args_spec.rb
@@ -78,19 +78,38 @@ describe RuboCop::Cop::Style::RaiseArgs, :config do
     let(:cop_config) { { 'EnforcedStyle' => 'exploded' } }
 
     context 'with a raise with exception object' do
-      it 'reports an offense' do
-        inspect_source(cop, 'raise Ex.new(msg)')
-        expect(cop.offenses.size).to eq(1)
-        expect(cop.messages)
-          .to eq(['Provide an exception class and message ' \
-                  'as arguments to `raise`.'])
-        expect(cop.config_to_allow_offenses)
-          .to eq('EnforcedStyle' => 'compact')
+      context 'with one argument' do
+        it 'reports an offense' do
+          inspect_source(cop, 'raise Ex.new(msg)')
+          expect(cop.offenses.size).to eq(1)
+          expect(cop.messages)
+            .to eq(['Provide an exception class and message ' \
+                    'as arguments to `raise`.'])
+          expect(cop.config_to_allow_offenses)
+            .to eq('EnforcedStyle' => 'compact')
+        end
+
+        it 'auto-corrects to exploded style' do
+          new_source = autocorrect_source(cop, ['raise Ex.new(msg)'])
+          expect(new_source).to eq('raise Ex, msg')
+        end
       end
 
-      it 'auto-corrects to exploded style' do
-        new_source = autocorrect_source(cop, ['raise Ex.new(msg)'])
-        expect(new_source).to eq('raise Ex, msg')
+      context 'with no arguments' do
+        it 'reports an offense' do
+          inspect_source(cop, 'raise Ex.new')
+          expect(cop.offenses.size).to eq(1)
+          expect(cop.messages)
+            .to eq(['Provide an exception class and message ' \
+                    'as arguments to `raise`.'])
+          expect(cop.config_to_allow_offenses)
+            .to eq('EnforcedStyle' => 'compact')
+        end
+
+        it 'auto-corrects to exploded style' do
+          new_source = autocorrect_source(cop, ['raise Ex.new'])
+          expect(new_source).to eq('raise Ex')
+        end
       end
     end
 


### PR DESCRIPTION
Auto-correct for `Style/RaiseArgs` didn't work for situations where an exception was constructed without an argument, e.g.:

```
raise RuntimeError.new
```

This fix adds a test for the case, and allows auto-correcting to exploded style.