### PR TITLE
[Fix #3230] Add smart highlighting for `Style/AsciiComments` cop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,10 @@
 * [#3247](https://github.com/bbatsov/rubocop/issues/3247): Ensure whitespace after beginning of block in `Style/BlockDelimiters`. ([@tjwp][])
 * [#2941](https://github.com/bbatsov/rubocop/issues/2941): Make sure `Lint/UnneededDisable` can do auto-correction. ([@jonas054][])
 
+### Changes
+
+* [#3230](https://github.com/bbatsov/rubocop/issues/3230): Improve highlighting for `Style/AsciiComments` cop. ([@drenmi][])
+
 ## 0.41.1 (2016-06-26)
 
 ### Bug fixes

--- a/lib/rubocop/cop/style/ascii_comments.rb
+++ b/lib/rubocop/cop/style/ascii_comments.rb
@@ -11,8 +11,28 @@ module RuboCop
 
         def investigate(processed_source)
           processed_source.comments.each do |comment|
-            add_offense(comment, :expression) unless comment.text.ascii_only?
+            unless comment.text.ascii_only?
+              add_offense(comment, first_offense_range(comment))
+            end
           end
+        end
+
+        private
+
+        def first_offense_range(comment)
+          expression    = comment.loc.expression
+          first_offense = first_non_ascii_chars(comment.text)
+
+          start_position = expression.begin_pos +
+                           comment.text.index(first_offense)
+          end_position   = start_position + first_offense.length
+
+          Parser::Source::Range.new(comment.loc.expression.source_buffer,
+                                    start_position, end_position)
+        end
+
+        def first_non_ascii_chars(string)
+          string.match(/[^[:ascii:]]+/).to_s
         end
       end
     end

--- a/spec/fixtures/html_formatter/expected.html
+++ b/spec/fixtures/html_formatter/expected.html
@@ -396,7 +396,7 @@ TvFXMeuCkZPcaEBLqvgPBhCuiZo8+sAAAAAASUVORK5CYII=
               <span class="message">Use only ascii symbols in comments.</span>
             </div>
             
-            <pre><code>  <span class="highlight convention"># “Test encoding issues by using curly quotes”</span></code></pre>
+            <pre><code>  # <span class="highlight convention">“</span>Test encoding issues by using curly quotes”</code></pre>
             
           </div>
           

--- a/spec/rubocop/cop/style/ascii_comments_spec.rb
+++ b/spec/rubocop/cop/style/ascii_comments_spec.rb
@@ -11,6 +11,17 @@ describe RuboCop::Cop::Style::AsciiComments do
                    ['# encoding: utf-8',
                     '# 这是什么？'])
     expect(cop.offenses.size).to eq(1)
+    expect(cop.highlights).to eq(['这是什么？'])
+    expect(cop.messages)
+      .to eq(['Use only ascii symbols in comments.'])
+  end
+
+  it 'registers an offense for commentes with mixed chars' do
+    inspect_source(cop,
+                   ['# encoding: utf-8',
+                    '# foo ∂ bar'])
+    expect(cop.offenses.size).to eq(1)
+    expect(cop.highlights).to eq(['∂'])
     expect(cop.messages)
       .to eq(['Use only ascii symbols in comments.'])
   end


### PR DESCRIPTION
This cop lets `Style/AsciiComments` highlight the first offense rather than the entire expression:

```
# ∂
  ^
```

It also works for mixed strings:

```
# foo ∂∂ bar
      ^^
```

Since a source range is continuous, we can only highlight the first offense:

```
# foo ∂∂∂ bar ∂∂∂
      ^^^
```