### PR TITLE
[Fix #3278] Lock json version for 1.9.3 builds

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -15,6 +15,8 @@ group :test do
   gem 'codeclimate-test-reporter', require: false
   gem 'safe_yaml', require: false
   gem 'webmock', require: false
+  # Json 2.0 requires Ruby >= 2.0
+  gem 'json', '~> 1.8', require: false, platforms: :ruby_19
 end
 
 local_gemfile = 'Gemfile.local'


### PR DESCRIPTION
Addresses failing builds: #3278 

I ran into the exact same issue with the builds on AwesomePrint. In the long run you will probably want to remove support for Ruby <= 2.0, but for now this should allow your builds to keep working (and thus keep accepting other pull requests) without needing to go through a deprecation process.

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Used the same coding conventions as the rest of the project.
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] All tests are passing.
* [x] The new code doesn't generate RuboCop offenses.
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.

[1]: http://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html

Recently the `json` gem was updated to require Ruby >= 2.0. This
causes our Ruby 1.9.3 build to fail. Here we lock the `json` gem
to the previously working version for 1.9 builds.