### PR TITLE
[Fix #3266] Handle empty parentheses in RedundantBlockCall

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 * [#3247](https://github.com/bbatsov/rubocop/issues/3247): Ensure whitespace after beginning of block in `Style/BlockDelimiters`. ([@tjwp][])
 * [#2941](https://github.com/bbatsov/rubocop/issues/2941): Make sure `Lint/UnneededDisable` can do auto-correction. ([@jonas054][])
 * [#3269](https://github.com/bbatsov/rubocop/pull/3269):  Fix `Lint/ShadowedException` to block arbitrary code execution. ([@pocke][])
+* [#3266](https://github.com/bbatsov/rubocop/issues/3266): Handle empty parentheses in `Performance/RedundantBlockCall` auto-correct. ([@jonas054][])
 
 ### Changes
 

--- a/lib/rubocop/cop/performance/redundant_block_call.rb
+++ b/lib/rubocop/cop/performance/redundant_block_call.rb
@@ -85,7 +85,7 @@ module RuboCop
             new_source << args.map(&:source).join(', ')
           end
 
-          new_source << CLOSE_PAREN if parentheses?(node)
+          new_source << CLOSE_PAREN if parentheses?(node) && !args.empty?
           ->(corrector) { corrector.replace(node.source_range, new_source) }
         end
       end

--- a/spec/rubocop/cop/performance/redundant_block_call_spec.rb
+++ b/spec/rubocop/cop/performance/redundant_block_call_spec.rb
@@ -15,6 +15,15 @@ describe RuboCop::Cop::Performance::RedundantBlockCall do
                               'end'].join("\n"))
   end
 
+  it 'autocorrects block.call with empty parentheses' do
+    new_source = autocorrect_source(cop, ['def method(&block)',
+                                          '  block.call()',
+                                          'end'])
+    expect(new_source).to eq(['def method(&block)',
+                              '  yield',
+                              'end'].join("\n"))
+  end
+
   it 'autocorrects block.call with arguments' do
     new_source = autocorrect_source(cop, ['def method(&block)',
                                           '  block.call 1, 2',


### PR DESCRIPTION
The `autocorrect` method should not assume that parentheses means there are arguments. If the block is called with empty parentheses, we replace it with a `yield` without parentheses.