### PR TITLE
Allow to use Time.zone_default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@
 * [#3272](https://github.com/bbatsov/rubocop/issues/3272): Add escape character missing to LITERAL_REGEX. ([@pocke][])
 * [#3255](https://github.com/bbatsov/rubocop/issues/3255): Fix auto-correct for `Style/RaiseArgs` when constructing exception without arguments. ([@drenmi][])
 * Improve highlighting for `Style/AsciiIdentifiers` cop. ([@drenmi][])
+* [#3294](https://github.com/bbatsov/rubocop/pull/3294): Allow to use `Time.zone_default`. ([@Tei][])
 
 ## 0.41.1 (2016-06-26)
 
@@ -2258,3 +2259,4 @@
 [@pclalv]: https://github.com/pclalv
 [@flexoid]: https://github.com/flexoid
 [@sgringwe]: https://github.com/sgringwe
+[@Tei]: https://github.com/Tei

--- a/lib/rubocop/cop/rails/time_zone.rb
+++ b/lib/rubocop/cop/rails/time_zone.rb
@@ -151,7 +151,11 @@ module RuboCop
         end
 
         def good_methods
-          style == :strict ? [:zone] : [:zone, :current] + ACCEPTED_METHODS
+          if style == :strict
+            [:zone, :zone_default]
+          else
+            [:zone, :zone_default, :current] + ACCEPTED_METHODS
+          end
         end
 
         def acceptable_methods(klass, method_name, node)

--- a/spec/rubocop/cop/rails/time_zone_spec.rb
+++ b/spec/rubocop/cop/rails/time_zone_spec.rb
@@ -16,7 +16,7 @@ describe RuboCop::Cop::Rails::TimeZone, :config do
         expect(cop.offenses.first.message).to include('`Time.zone.now`')
       end
 
-      it "registers an offense  for #{klass}.current" do
+      it "registers an offense for #{klass}.current" do
         inspect_source(cop, "#{klass}.current")
         expect(cop.offenses.size).to eq(1)
         expect(cop.offenses.first.message).to include('`Time.zone.now`')
@@ -164,6 +164,21 @@ describe RuboCop::Cop::Rails::TimeZone, :config do
       expect(cop.offenses).to be_empty
     end
 
+    it 'accepts Time.zone_default.now' do
+      inspect_source(cop, 'Time.zone_default.now')
+      expect(cop.offenses).to be_empty
+    end
+
+    it 'accepts Time.zone_default.today' do
+      inspect_source(cop, 'Time.zone_default.today')
+      expect(cop.offenses).to be_empty
+    end
+
+    it 'accepts Time.zone_default.local' do
+      inspect_source(cop, 'Time.zone_default.local(2012, 6, 10, 12, 00)')
+      expect(cop.offenses).to be_empty
+    end
+
     described_class::DANGEROUS_METHODS.each do |a_method|
       it "accepts Some::Time.#{a_method}" do
         inspect_source(cop, "Some::Time.#{a_method}")
@@ -203,6 +218,11 @@ describe RuboCop::Cop::Rails::TimeZone, :config do
       end
 
       it 'accepts #{klass}.zone.now' do
+        inspect_source(cop, "#{klass}.zone.now")
+        expect(cop.offenses).to be_empty
+      end
+
+      it 'accepts #{klass}.zone_default.now' do
         inspect_source(cop, "#{klass}.zone.now")
         expect(cop.offenses).to be_empty
       end


### PR DESCRIPTION
it contains data from [app.config.time_zone](https://github.com/rails/rails/blob/master/activesupport/lib/active_support/railtie.rb#L32)

Very useful when `Time.zone` in application is redefined for current_user

