### PR TITLE
Add smart highlighting for `Style/AsciiIdentifiers` cop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@
 * [#3230](https://github.com/bbatsov/rubocop/issues/3230): Improve highlighting for `Style/AsciiComments` cop. ([@drenmi][])
 * [#3272](https://github.com/bbatsov/rubocop/issues/3272): Add escape character missing to LITERAL_REGEX. ([@pocke][])
 * [#3255](https://github.com/bbatsov/rubocop/issues/3255): Fix auto-correct for `Style/RaiseArgs` when constructing exception without arguments. ([@drenmi][])
+* Improve highlighting for `Style/AsciiIdentifiers` cop. ([@drenmi][])
 
 ## 0.41.1 (2016-06-26)
 

--- a/lib/rubocop/cop/style/ascii_identifiers.rb
+++ b/lib/rubocop/cop/style/ascii_identifiers.rb
@@ -9,10 +9,28 @@ module RuboCop
         MSG = 'Use only ascii symbols in identifiers.'.freeze
 
         def investigate(processed_source)
-          processed_source.tokens.each do |t|
-            next unless t.type == :tIDENTIFIER && !t.text.ascii_only?
-            add_offense(nil, t.pos)
+          processed_source.tokens.each do |token|
+            next unless token.type == :tIDENTIFIER && !token.text.ascii_only?
+            add_offense(token, first_offense_range(token))
           end
+        end
+
+        private
+
+        def first_offense_range(identifier)
+          expression    = identifier.pos
+          first_offense = first_non_ascii_chars(identifier.text)
+
+          start_position = expression.begin_pos +
+                           identifier.text.index(first_offense)
+          end_position   = start_position + first_offense.length
+
+          Parser::Source::Range.new(identifier.pos.source_buffer,
+                                    start_position, end_position)
+        end
+
+        def first_non_ascii_chars(string)
+          string.match(/[^[:ascii:]]+/).to_s
         end
       end
     end

--- a/spec/rubocop/cop/style/ascii_identifiers_spec.rb
+++ b/spec/rubocop/cop/style/ascii_identifiers_spec.rb
@@ -11,6 +11,17 @@ describe RuboCop::Cop::Style::AsciiIdentifiers do
                    ['# encoding: utf-8',
                     'älg = 1'])
     expect(cop.offenses.size).to eq(1)
+    expect(cop.highlights).to eq(['ä'])
+    expect(cop.messages)
+      .to eq(['Use only ascii symbols in identifiers.'])
+  end
+
+  it 'registers an offense for a variable name with mixed chars' do
+    inspect_source(cop,
+                   ['# encoding: utf-8',
+                    'foo∂∂bar = baz'])
+    expect(cop.offenses.size).to eq(1)
+    expect(cop.highlights).to eq(['∂∂'])
     expect(cop.messages)
       .to eq(['Use only ascii symbols in identifiers.'])
   end


### PR DESCRIPTION
As requested in https://github.com/bbatsov/rubocop/pull/3279, let's give `Style/AsciiIdentifiers` the same treatment as `Style/AsciiComments`.

I'm opting to duplicate some of the method bodies for now, as I'd much rather have a bit of duplication than haphazardly choosing the wrong abstraction.