### PR TITLE
[Fix #3271] Fix bad auto-correct for `Style/EachForSimpleLoop` cop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## master (unreleased)
 
+### Bug fixes
+
+* [#3271](https://github.com/bbatsov/rubocop/issues/3271): Fix bad auto-correct for `Style/EachForSimpleLoop` cop. ([@drenmi][])
+
 ## 0.41.2 (2016-07-07)
 
 ### Bug fixes

--- a/lib/rubocop/cop/style/each_for_simple_loop.rb
+++ b/lib/rubocop/cop/style/each_for_simple_loop.rb
@@ -12,30 +12,44 @@ module RuboCop
       #
       # @example
       #   @bad
-      #   (0..10).each { }
+      #   (1..5).each { }
       #
       #   @good
-      #   10.times { }
+      #   5.times { }
+      #
+      # @example
+      #   @bad
+      #   (0...10).each {}
+      #
+      #   @good
+      #   10.times {}
       class EachForSimpleLoop < Cop
+        MSG = 'Use `Integer#times` for a simple loop which iterates a fixed ' \
+              'number of times.'.freeze
+
         def on_block(node)
-          if bad_each_range(node)
+          if offending_each_range(node)
             send_node, = *node
             range = send_node.receiver.source_range.join(send_node.loc.selector)
-            add_offense(node, range, 'Use `Integer#times` for a simple loop ' \
-                                     'which iterates a fixed number of times.')
+            add_offense(node, range)
           end
         end
 
+        private
+
         def autocorrect(node)
           lambda do |corrector|
-            min, max = bad_each_range(node)
+            range_type, min, max = offending_each_range(node)
+
+            max += 1 if range_type == :irange
+
             corrector.replace(node.children.first.source_range,
                               "#{max - min}.times")
           end
         end
 
-        def_node_matcher :bad_each_range, <<-PATTERN
-          (block (send (begin ({irange erange} (int $_) (int $_))) :each) (args) ...)
+        def_node_matcher :offending_each_range, <<-PATTERN
+          (block (send (begin (${irange erange} (int $_) (int $_))) :each) (args) ...)
         PATTERN
       end
     end

--- a/spec/rubocop/cop/style/each_for_simple_loop_spec.rb
+++ b/spec/rubocop/cop/style/each_for_simple_loop_spec.rb
@@ -65,26 +65,53 @@ describe RuboCop::Cop::Style::EachForSimpleLoop do
     expect(cop.offenses).to be_empty
   end
 
-  it 'autocorrects the source with inline block' do
-    corrected = autocorrect_source(cop, '(0..10).each {}')
-    expect(corrected).to eq '10.times {}'
+  context 'when using an inclusive range' do
+    it 'autocorrects the source with inline block' do
+      corrected = autocorrect_source(cop, '(0..10).each {}')
+      expect(corrected).to eq '11.times {}'
+    end
+
+    it 'autocorrects the source with multiline block' do
+      corrected = autocorrect_source(cop, ['(0..10).each do',
+                                           'end'])
+      expect(corrected).to eq "11.times do\nend"
+    end
+
+    it 'autocorrects the range not starting with zero' do
+      corrected = autocorrect_source(cop, ['(3..7).each do',
+                                           'end'])
+      expect(corrected).to eq "5.times do\nend"
+    end
+
+    it 'does not autocorrect range not starting with zero and using param' do
+      corrected = autocorrect_source(cop, ['(3..7).each do |n|',
+                                           'end'])
+      expect(corrected).to eq "(3..7).each do |n|\nend"
+    end
   end
 
-  it 'autocorrects the source with multiline block' do
-    corrected = autocorrect_source(cop, ['(0..10).each do',
-                                         'end'])
-    expect(corrected).to eq "10.times do\nend"
-  end
+  context 'when using an exclusive range' do
+    it 'autocorrects the source with inline block' do
+      corrected = autocorrect_source(cop, '(0...10).each {}')
+      expect(corrected).to eq '10.times {}'
+    end
 
-  it 'autocorrects the range not starting with zero' do
-    corrected = autocorrect_source(cop, ['(3..7).each do',
-                                         'end'])
-    expect(corrected).to eq "4.times do\nend"
-  end
+    it 'autocorrects the source with multiline block' do
+      corrected = autocorrect_source(cop, ['(0...10).each do',
+                                           'end'])
+      expect(corrected).to eq "10.times do\nend"
+    end
 
-  it 'does not autocorrect range not starting with zero and using param' do
-    corrected = autocorrect_source(cop, ['(3..7).each do |n|',
-                                         'end'])
-    expect(corrected).to eq "(3..7).each do |n|\nend"
+    it 'autocorrects the range not starting with zero' do
+      corrected = autocorrect_source(cop, ['(3...7).each do',
+                                           'end'])
+      expect(corrected).to eq "4.times do\nend"
+    end
+
+    it 'does not autocorrect range not starting with zero and using param' do
+      corrected = autocorrect_source(cop, ['(3...7).each do |n|',
+                                           'end'])
+      expect(corrected).to eq "(3...7).each do |n|\nend"
+    end
   end
 end


### PR DESCRIPTION
There is a bug in `Style/EachForSimpleLoop`, where it auto-corrects with the wrong number of iterations. Consider:

```
(0..10).each { ... }
```

This is an inclusive range of 0 through 10, i.e. 11 iterations. This incorrectly gets auto-corrected to:

```
10.times { ... }
```

It turns out the tests for this auto-correct are incorrect, and missing test cases for the exclusive range cases.

This fix adds test coverage, and makes the auto-correct behave well for inclusive ranges.