### PR TITLE
[Fix #3288] Fix auto-correction bug for %w()/%i() in ParallelAssignment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Bug fixes
 
 * [#3271](https://github.com/bbatsov/rubocop/issues/3271): Fix bad auto-correct for `Style/EachForSimpleLoop` cop. ([@drenmi][])
+* [#3288](https://github.com/bbatsov/rubocop/issues/3288): Fix auto-correct of word and symbol arrays in `Style/ParallelAssignment` cop. ([@jonas054][])
 
 ## 0.41.2 (2016-07-07)
 

--- a/lib/rubocop/cop/style/parallel_assignment.rb
+++ b/lib/rubocop/cop/style/parallel_assignment.rb
@@ -179,12 +179,20 @@ module RuboCop
           protected
 
           def assignment
-            @new_elements.map do |lhs, rhs|
-              "#{lhs.source} = #{rhs.source}"
-            end
+            @new_elements.map { |lhs, rhs| "#{lhs.source} = #{source(rhs)}" }
           end
 
           private
+
+          def source(node)
+            if node.str_type? && node.loc.begin.nil?
+              "'#{node.source}'"
+            elsif node.sym_type? && node.loc.begin.nil?
+              ":#{node.source}"
+            else
+              node.source
+            end
+          end
 
           def extract_sources(node)
             node.children.map(&:source)


### PR DESCRIPTION
Add special handling of string and symbol nodes that don't have delimiters.