### PR TITLE
Add autocorrection for `Style/EachWithObject`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## master (unreleased)
 
+### New features
+
+* [#3306](https://github.com/bbatsov/rubocop/issues/3306): Add autocorrection for `Style/EachWithObject`. ([@owst][])
+
 ### Bug fixes
 
 * [#3271](https://github.com/bbatsov/rubocop/issues/3271): Fix bad auto-correct for `Style/EachForSimpleLoop` cop. ([@drenmi][])

--- a/lib/rubocop/cop/style/each_with_object.rb
+++ b/lib/rubocop/cop/style/each_with_object.rb
@@ -33,7 +33,17 @@ module RuboCop
           return unless first_argument_returned?(args, return_value)
           return if accumulator_param_assigned_to?(body, args)
 
-          add_offense(method, :selector, format(MSG, method_name))
+          add_offense(node, method.loc.selector, format(MSG, method_name))
+        end
+
+        def autocorrect(node)
+          lambda do |corrector|
+            method, args, _body = *node
+            corrector.replace(method.loc.selector, 'each_with_object')
+            first_arg, second_arg = *args
+            corrector.replace(first_arg.loc.expression, second_arg.source)
+            corrector.replace(second_arg.loc.expression, first_arg.source)
+          end
         end
 
         private

--- a/spec/rubocop/cop/style/each_with_object_spec.rb
+++ b/spec/rubocop/cop/style/each_with_object_spec.rb
@@ -23,6 +23,16 @@ describe RuboCop::Cop::Style::EachWithObject do
     expect(cop.highlights).to eq(%w(inject reduce))
   end
 
+  it 'correctly autocorrects' do
+    corrected = autocorrect_source(cop, ['[1, 2, 3].inject({}) do |h, i|',
+                                         '  h',
+                                         'end'])
+
+    expect(corrected).to eq(['[1, 2, 3].each_with_object({}) do |i, h|',
+                             '  h',
+                             'end'].join("\n"))
+  end
+
   it 'ignores inject and reduce with passed in, but not returned hash' do
     inspect_source(cop,
                    ['[].inject({}) do |a, e|',


### PR DESCRIPTION
Simple change to add autocorrection for `Style/EachWithObject`.

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Used the same coding conventions as the rest of the project.
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] All tests are passing.
* [x] The new code doesn't generate RuboCop offenses.
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.

[1]: http://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html

