### PR TITLE
[Fix #3307] Fix exception when inspecting operator assignment with `Style/MethodCallParentheses` cop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 
 * [#3271](https://github.com/bbatsov/rubocop/issues/3271): Fix bad auto-correct for `Style/EachForSimpleLoop` cop. ([@drenmi][])
 * [#3288](https://github.com/bbatsov/rubocop/issues/3288): Fix auto-correct of word and symbol arrays in `Style/ParallelAssignment` cop. ([@jonas054][])
+* [#3307](https://github.com/bbatsov/rubocop/issues/3307): Fix exception when inspecting an operator assignment with `Style/MethodCallParentheses` cop. ([@drenmi][])
 
 ## 0.41.2 (2016-07-07)
 

--- a/lib/rubocop/cop/style/method_call_parentheses.rb
+++ b/lib/rubocop/cop/style/method_call_parentheses.rb
@@ -38,10 +38,12 @@ module RuboCop
 
           node.each_ancestor(*ASGN_NODES).any? do |asgn_node|
             # `obj.method = value` parses as (send ... :method= ...), and will
-            # not be returned as an `asgn_node` here
-            # however, `obj.method ||= value` parses as (or-asgn (send ...) ...)
-            # which IS an `asgn_node`
-            if asgn_node.or_asgn_type? || asgn_node.and_asgn_type?
+            # not be returned as an `asgn_node` here, however,
+            # `obj.method ||= value` parses as (or-asgn (send ...) ...)
+            # which IS an `asgn_node`. Similarly, `obj.method += value` parses
+            # as (op-asgn (send ...) ...), which is also an `asgn_node`.
+            if asgn_node.or_asgn_type? || asgn_node.and_asgn_type? ||
+               asgn_node.op_asgn_type?
               asgn_node, _value = *asgn_node
               return false if asgn_node.send_type?
             end

--- a/spec/rubocop/cop/style/method_call_parentheses_spec.rb
+++ b/spec/rubocop/cop/style/method_call_parentheses_spec.rb
@@ -74,6 +74,11 @@ describe RuboCop::Cop::Style::MethodCallParentheses do
     expect(cop.offenses.size).to eq 1
   end
 
+  it 'registers an offense for `obj.method += func()`' do
+    inspect_source(cop, 'obj.method += func()')
+    expect(cop.offenses.size).to eq 1
+  end
+
   it 'auto-corrects by removing unneeded braces' do
     new_source = autocorrect_source(cop, 'test()')
     expect(new_source).to eq('test')


### PR DESCRIPTION
This cop would blow up when inspecting an operator assignment, e.g.:

```
foo += bar()
```

This small change fixes that, and adds a test case for the future.