### PR TITLE
[Fix #2645] Make `Style/EmptyLiteral` aware of frozen string literal pragma

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@
 * [#3271](https://github.com/bbatsov/rubocop/issues/3271): Fix bad auto-correct for `Style/EachForSimpleLoop` cop. ([@drenmi][])
 * [#3288](https://github.com/bbatsov/rubocop/issues/3288): Fix auto-correct of word and symbol arrays in `Style/ParallelAssignment` cop. ([@jonas054][])
 
+### Changes
+
+* [#2645](https://github.com/bbatsov/rubocop/issues/2645): `Style/EmptyLiteral` no longer generates an offense for `String.new` when using frozen string literals. ([@drenmi][])
+
 ## 0.41.2 (2016-07-07)
 
 ### Bug fixes

--- a/spec/rubocop/cop/style/empty_literal_spec.rb
+++ b/spec/rubocop/cop/style/empty_literal_spec.rb
@@ -89,24 +89,24 @@ describe RuboCop::Cop::Style::EmptyLiteral do
 
   describe 'Empty String' do
     it 'registers an offense for String.new()' do
-      inspect_source(cop,
-                     'test = String.new()')
+      inspect_source(cop, 'test = String.new()')
+
       expect(cop.offenses.size).to eq(1)
       expect(cop.messages)
         .to eq(["Use string literal `''` instead of `String.new`."])
     end
 
     it 'registers an offense for String.new' do
-      inspect_source(cop,
-                     'test = String.new')
+      inspect_source(cop, 'test = String.new')
+
       expect(cop.offenses.size).to eq(1)
       expect(cop.messages)
         .to eq(["Use string literal `''` instead of `String.new`."])
     end
 
     it 'does not register an offense for String.new("top")' do
-      inspect_source(cop,
-                     'test = String.new("top")')
+      inspect_source(cop, 'test = String.new("top")')
+
       expect(cop.offenses).to be_empty
     end
 
@@ -126,9 +126,29 @@ describe RuboCop::Cop::Style::EmptyLiteral do
       end
       subject(:cop) { described_class.new(config) }
 
+      it 'registers an offense for String.new' do
+        inspect_source(cop, 'test = String.new')
+
+        expect(cop.offenses.size).to eq(1)
+        expect(cop.messages)
+          .to eq(['Use string literal `""` instead of `String.new`.'])
+      end
+
       it 'auto-corrects String.new to a double-quoted empty string literal' do
         new_source = autocorrect_source(cop, 'test = String.new')
         expect(new_source).to eq('test = ""')
+      end
+    end
+
+    context 'when frozen string literals is enabled' do
+      let(:ruby_version) { 2.3 }
+
+      it 'does not register an offense for String.new' do
+        inspect_source(cop, ['# encoding: utf-8',
+                             '# frozen_string_literal: true',
+                             'test = String.new'])
+
+        expect(cop.offenses.size).to eq(0)
       end
     end
   end


### PR DESCRIPTION
Since in MRI >= 2.3, `String.new` and `""` are not interchangeable when frozen string literal pragma is enabled. (The former is a mutable string, and the latter a frozen one.)

This change makes `Style/EmptyLiteral` aware of this and doesn't generate an offense for `String.new` when frozen string literal pragma is enabled.