### PR TITLE
[Fix #3308] Make `Lint/NextWithoutAccumulator` aware of nested enumeration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@
 ### Changes
 
 * [#2645](https://github.com/bbatsov/rubocop/issues/2645): `Style/EmptyLiteral` no longer generates an offense for `String.new` when using frozen string literals. ([@drenmi][])
+* [#3308](https://github.com/bbatsov/rubocop/issues/3308): Make `Lint/NextWithoutAccumulator` aware of nested enumeration. ([@drenmi][])
 
 ## 0.41.2 (2016-07-07)
 

--- a/lib/rubocop/cop/lint/next_without_accumulator.rb
+++ b/lib/rubocop/cop/lint/next_without_accumulator.rb
@@ -27,10 +27,18 @@ module RuboCop
 
         def on_block(node)
           on_body_of_reduce(node) do |body|
-            void_next = body.each_node(:next).find { |n| n.children.empty? }
+            void_next = body.each_node(:next).find do |n|
+              n.children.empty? && parent_block_node(n) == node
+            end
 
             add_offense(void_next, :expression) if void_next
           end
+        end
+
+        private
+
+        def parent_block_node(node)
+          node.each_ancestor.find { |n| n.type == :block }
         end
       end
     end


### PR DESCRIPTION
This cop would register an offense if a nested block contained a `next` without an accumulator.

```
[(1..3), (4..6)].reduce(0) do |acc, elems|
  elems.each_with_index do |elem, i|
    next if i == 1
    acc << elem
  end
  acc
end
```

This fix addresses that, by checking if the direct block parent of any offending `next` is indeed the block that we were inspecting.