### PR TITLE
[Fix #3300] Do not replace `%q()`s containing escaped non-backslashes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@
 * [#3272](https://github.com/bbatsov/rubocop/issues/3272): Add escape character missing to LITERAL_REGEX. ([@pocke][])
 * [#3255](https://github.com/bbatsov/rubocop/issues/3255): Fix auto-correct for `Style/RaiseArgs` when constructing exception without arguments. ([@drenmi][])
 * [#3294](https://github.com/bbatsov/rubocop/pull/3294): Allow to use `Time.zone_default`. ([@Tei][])
+* [#3300](https://github.com/bbatsov/rubocop/issues/3300): Do not replace `%q()`s containing escaped non-backslashes. ([@owst][])
 
 ### Changes
 

--- a/spec/rubocop/cop/style/unneeded_percent_q_spec.rb
+++ b/spec/rubocop/cop/style/unneeded_percent_q_spec.rb
@@ -34,24 +34,22 @@ describe RuboCop::Cop::Style::UnneededPercentQ do
       expect(cop.messages).to be_empty
     end
 
-    it 'registers an offense for a string with single quotes and what appears' \
-       ' to be an escape' do
-      # There is no such thing as escapes in a %q() string
-      # So this can just as well be written with double quotes
-      inspect_source(cop, "%q('hi\\t')")
+    it 'registers an offfense for a string containing escaped backslashes' do
+      inspect_source(cop, '%q(\\\\foo\\\\)')
 
-      expect(cop.messages).to eq(['Use `%q` only for strings that contain ' \
-                                  'both single quotes and double quotes.'])
+      expect(cop.messages.length).to eq 1
     end
 
-    it 'registers an offense for a string with double quotes and what appears' \
-       ' to be an escape' do
-      # There is no such thing as escapes in a %q() string
-      # So this can just as well be written with single quotes
-      inspect_source(cop, '%q("hi\\t")')
+    it 'accepts a string with escaped non-backslash characters' do
+      inspect_source(cop, "%q(\\'foo\\')")
 
-      expect(cop.messages).to eq(['Use `%q` only for strings that contain ' \
-                                  'both single quotes and double quotes.'])
+      expect(cop.messages).to be_empty
+    end
+
+    it 'accepts a string with escaped backslash and non-backslash characters' do
+      inspect_source(cop, "%q(\\\\ \\'foo\\' \\\\)") # This is \\ \'foo\' \\
+
+      expect(cop.messages).to be_empty
     end
 
     it 'accepts regular expressions starting with %q' do


### PR DESCRIPTION
In `%q(...)` `\\` is the only escape (evaluating to a single `\`), so if a `%q` literal contains escaped characters that are not `\` we should not change to double quotes, since that will change the string:
```
irb(main):001:0> puts %q(\\ \')
\ \'
irb(main):002:0> puts "\\ \'"
\ '
```
Notice how the first prints `\'` but the second just `'`

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Used the same coding conventions as the rest of the project.
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] All tests are passing.
* [x] The new code doesn't generate RuboCop offenses.
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.

[1]: http://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html

