### PR TITLE
[Fix #3316] Do not process no-arg blocks in `Style/SingleLineBlockParams`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 * [#3271](https://github.com/bbatsov/rubocop/issues/3271): Fix bad auto-correct for `Style/EachForSimpleLoop` cop. ([@drenmi][])
 * [#3288](https://github.com/bbatsov/rubocop/issues/3288): Fix auto-correct of word and symbol arrays in `Style/ParallelAssignment` cop. ([@jonas054][])
 * [#3307](https://github.com/bbatsov/rubocop/issues/3307): Fix exception when inspecting an operator assignment with `Style/MethodCallParentheses` cop. ([@drenmi][])
+* [#3316](https://github.com/bbatsov/rubocop/issues/3316): Fix error for blocks without arguments in `Style/SingleLineBlockParams` cop. ([@owst][])
 
 ## 0.41.2 (2016-07-07)
 

--- a/lib/rubocop/cop/style/single_line_block_params.rb
+++ b/lib/rubocop/cop/style/single_line_block_params.rb
@@ -21,9 +21,10 @@ module RuboCop
           return unless receiver
           return unless method_names.include?(method_name)
 
-          # discard cases with argument destructuring
           args = *args_node
 
+          return if args.empty?
+          # discard cases with argument destructuring
           return true unless args.all? { |n| n.type == :arg }
           return if args_match?(method_name, args)
 

--- a/spec/rubocop/cop/style/single_line_block_params_spec.rb
+++ b/spec/rubocop/cop/style/single_line_block_params_spec.rb
@@ -79,4 +79,12 @@ describe RuboCop::Cop::Style::SingleLineBlockParams, :config do
                     'end'])
     expect(cop.offenses).to be_empty
   end
+
+  it 'does not report if no block arguments are present' do
+    inspect_source(cop,
+                   ['def m',
+                    '  test.reduce { true }',
+                    'end'])
+    expect(cop.offenses).to be_empty
+  end
 end


### PR DESCRIPTION
Fix an ecxeption caused by attempting to process an empty node in  `Style/SingleLineBlockParams`

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Used the same coding conventions as the rest of the project.
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] All tests are passing.
* [x] The new code doesn't generate RuboCop offenses.
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.

[1]: http://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html
