### PR TITLE
Extend `Style/MethodMissing` cop to check for the conditions in the style guide

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@
 
 * [#2645](https://github.com/bbatsov/rubocop/issues/2645): `Style/EmptyLiteral` no longer generates an offense for `String.new` when using frozen string literals. ([@drenmi][])
 * [#3308](https://github.com/bbatsov/rubocop/issues/3308): Make `Lint/NextWithoutAccumulator` aware of nested enumeration. ([@drenmi][])
+* Extend `Style/MethodMissing` cop to check for the conditions in the style guide. ([@drenmi][])
 
 ## 0.41.2 (2016-07-07)
 

--- a/spec/rubocop/formatter/base_formatter_spec.rb
+++ b/spec/rubocop/formatter/base_formatter_spec.rb
@@ -47,9 +47,11 @@ module RuboCop
         describe 'invocation order' do
           subject(:formatter) do
             formatter = double('formatter')
-            def formatter.method_missing(method_name, *)
-              return if method_name == :output
-              puts method_name
+            [:started, :file_started, :file_finished, :finished, :output]
+              .each do |message|
+              allow(formatter).to receive(message) do
+                puts message.to_s unless message == :output
+              end
             end
             formatter
           end


### PR DESCRIPTION
As promised in https://github.com/bbatsov/rubocop/pull/3244, here's an extension to `Style/MethodMissing`.

This cop was very basic, and would only check for definitions of `#method_missing`. This addresses that by checking for the following conditions outlined in the style guide:

 - The parent class or module also implements `#respond_to_missing?`
 - The `#method_missing` definition falls back on `#super`

I decided not to add the third condition at this point in time, as it proved quite prone to false positives.

Note that this cop will give a false positive if `#method_missing` and `#respond_to_missing?` are defined in separate class definitions. (Why anyone would do that, I don't know, but still thought it's worth mentioning. 😁 )