### PR TITLE
[Fix #3320] Make `Style/OpMethod` aware of the backtick method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 * [#3288](https://github.com/bbatsov/rubocop/issues/3288): Fix auto-correct of word and symbol arrays in `Style/ParallelAssignment` cop. ([@jonas054][])
 * [#3307](https://github.com/bbatsov/rubocop/issues/3307): Fix exception when inspecting an operator assignment with `Style/MethodCallParentheses` cop. ([@drenmi][])
 * [#3316](https://github.com/bbatsov/rubocop/issues/3316): Fix error for blocks without arguments in `Style/SingleLineBlockParams` cop. ([@owst][])
+* [#3320](https://github.com/bbatsov/rubocop/issues/3320): Make `Style/OpMethod` aware of the backtick method. ([@drenmi][])
 
 ### Changes
 

--- a/lib/rubocop/cop/style/op_method.rb
+++ b/lib/rubocop/cop/style/op_method.rb
@@ -4,15 +4,23 @@
 module RuboCop
   module Cop
     module Style
-      # This cop makes sure that certain operator methods have their sole
-      # parameter named `other`.
+      # This cop makes sure that certain binary operator methods have their
+      # sole  parameter named `other`.
+      #
+      # @example
+      #
+      #   # bad
+      #   def +(amount); end
+      #
+      #   # good
+      #   def +(other); end
       class OpMethod < Cop
         MSG = 'When defining the `%s` operator, ' \
               'name its argument `other`.'.freeze
 
         OP_LIKE_METHODS = [:eql?, :equal?].freeze
 
-        BLACKLISTED = [:+@, :-@, :[], :[]=, :<<].freeze
+        BLACKLISTED = [:+@, :-@, :[], :[]=, :<<, :`].freeze
 
         TARGET_ARGS = [s(:args, s(:arg, :other)),
                        s(:args, s(:arg, :_other))].freeze
@@ -20,7 +28,7 @@ module RuboCop
         def on_def(node)
           name, args, _body = *node
           return unless op_method?(name) &&
-                        args.children.size == 1 &&
+                        args.children.one? &&
                         !TARGET_ARGS.include?(args)
 
           add_offense(args.children[0], :expression, format(MSG, name))

--- a/spec/rubocop/cop/style/op_method_spec.rb
+++ b/spec/rubocop/cop/style/op_method_spec.rb
@@ -71,16 +71,12 @@ describe RuboCop::Cop::Style::OpMethod do
 
   it 'does not register an offense for non binary operators' do
     inspect_source(cop,
-                   ['def -@', # Unary minus
-                    'end',
-                    '',
+                   ['def -@; end',
                     # This + is not a unary operator. It can only be
                     # called with dot notation.
-                    'def +',
-                    'end',
-                    '',
-                    'def *(a, b)', # Quite strange, but legal ruby.
-                    'end'])
+                    'def +; end',
+                    'def *(a, b); end', # Quite strange, but legal ruby.
+                    'def `(cmd); end'])
     expect(cop.offenses).to be_empty
   end
 end


### PR DESCRIPTION
This cop would incorrectly register an offense when the backtick method argument was not named `other`. This change fixes that.