### PR TITLE
Use `Node#sibling_index` where appropriate

### DIFF
--- a/lib/rubocop/ast_node.rb
+++ b/lib/rubocop/ast_node.rb
@@ -113,7 +113,8 @@ module RuboCop
       Node.new(type || @type, children || @children, properties)
     end
 
-    # Returns the index of the receiver node in its siblings.
+    # Returns the index of the receiver node in its siblings. (Sibling index
+    # uses zero based numbering.)
     #
     # @return [Integer] the index of the receiver node in its siblings
     def sibling_index

--- a/lib/rubocop/cop/style/lambda.rb
+++ b/lib/rubocop/cop/style/lambda.rb
@@ -182,8 +182,7 @@ module RuboCop
           return false unless parent && parent.send_type?
           return false if parenthesized_call?(parent)
 
-          index = parent.children.index { |c| c.equal?(node) }
-          index >= 2
+          node.sibling_index > 1
         end
 
         def remove_unparenthesized_whitespaces(corrector, node)

--- a/lib/rubocop/cop/variable_force/assignment.rb
+++ b/lib/rubocop/cop/variable_force/assignment.rb
@@ -79,7 +79,7 @@ module RuboCop
         def operator_assignment_node
           return nil unless node.parent
           return nil unless OPERATOR_ASSIGNMENT_TYPES.include?(node.parent.type)
-          return nil unless node.parent.children.index(node) == 0
+          return nil unless node.sibling_index.zero?
           node.parent
         end
 

--- a/spec/rubocop/ast_node_spec.rb
+++ b/spec/rubocop/ast_node_spec.rb
@@ -365,4 +365,22 @@ describe RuboCop::Node do
       end
     end
   end
+
+  describe '#sibling_index' do
+    let(:node) { RuboCop::ProcessedSource.new(src, ruby_version).ast }
+
+    let(:src) do
+      [
+        'def foo; end',
+        'def bar; end',
+        'def baz; end'
+      ].join("\n")
+    end
+
+    it 'returns its sibling index' do
+      (0..2).each do |n|
+        expect(node.children[n].sibling_index).to eq(n)
+      end
+    end
+  end
 end


### PR DESCRIPTION
Some very minor housekeeping, changing cops with their own incarnations of `node.parent.children.index { ... }` to use the existing `Node#sibling_index` instead.

Also adds a very basic regression test for `Node#sibling_index`.