### PR TITLE
Make `EmptyLinesAroundBody` mixin work for the whole family of cops

### DIFF
--- a/lib/rubocop/cop/mixin/empty_lines_around_body.rb
+++ b/lib/rubocop/cop/mixin/empty_lines_around_body.rb
@@ -28,12 +28,10 @@ module RuboCop
           # the presence OR absence of an empty line
           # But if style is `no_empty_lines`, there must not be an empty line
           return unless body || style == :no_empty_lines
+          return if node.single_line?
 
-          start_line = node.loc.keyword.line
-          end_line = node.loc.end.line
-          return if start_line == end_line
-
-          check_source(start_line, end_line)
+          check_source(node.loc.expression.first_line,
+                       node.loc.expression.last_line)
         end
 
         def check_source(start_line, end_line)

--- a/lib/rubocop/cop/style/empty_lines_around_block_body.rb
+++ b/lib/rubocop/cop/style/empty_lines_around_block_body.rb
@@ -9,11 +9,23 @@ module RuboCop
       #
       # @example
       #
-      #   something do
+      #   # EnforcedStyle: empty_lines
+      #
+      #   # good
+      #
+      #   foo do |bar|
       #
       #     ...
+      #
       #   end
       #
+      #   # EnforcedStyle: no_empty_lines
+      #
+      #   # good
+      #
+      #   foo do |bar|
+      #     ...
+      #   end
       class EmptyLinesAroundBlockBody < Cop
         include EmptyLinesAroundBody
 
@@ -21,20 +33,8 @@ module RuboCop
 
         def on_block(node)
           _send, _args, body = *node
+
           check(node, body)
-        end
-
-        private
-
-        def check(node, body)
-          return unless body || style == :no_empty_lines
-
-          start_line = node.loc.begin.line
-          end_line = node.loc.end.line
-
-          return if start_line == end_line
-
-          check_source(start_line, end_line)
         end
       end
     end

--- a/lib/rubocop/cop/style/empty_lines_around_class_body.rb
+++ b/lib/rubocop/cop/style/empty_lines_around_class_body.rb
@@ -4,19 +4,22 @@
 module RuboCop
   module Cop
     module Style
-      # This cops checks if empty lines around the bodies of classes match the
-      # configuration.
+      # This cops checks if empty lines around the bodies of classes match
+      # the configuration.
       #
       # @example
       #
-      #   class Test
+      #   EnforcedStyle: empty_lines
       #
-      #      def something
+      #   # good
+      #
+      #   class Foo
+      #
+      #      def bar
       #        ...
       #      end
       #
       #   end
-      #
       class EmptyLinesAroundClassBody < Cop
         include EmptyLinesAroundBody
 

--- a/lib/rubocop/cop/style/empty_lines_around_method_body.rb
+++ b/lib/rubocop/cop/style/empty_lines_around_method_body.rb
@@ -4,31 +4,35 @@
 module RuboCop
   module Cop
     module Style
-      # This cops checks if empty lines around the bodies of methods match
-      # the configuration.
+      # This cops checks if empty lines exist around the bodies of methods.
       #
       # @example
       #
-      #   def something(arg)
+      #   # good
       #
+      #   def foo
       #     ...
       #   end
       #
+      #   # bad
+      #
+      #   def bar
+      #
+      #     ...
+      #
+      #   end
       class EmptyLinesAroundMethodBody < Cop
         include EmptyLinesAroundBody
         include OnMethodDef
 
         KIND = 'method'.freeze
 
-        private
-
         def on_method_def(node, _method_name, _args, body)
           check(node, body)
         end
 
-        # Override ConfigurableEnforcedStyle#style and hard-code
-        # configuration. It's difficult to imagine that anybody would want
-        # empty lines around a method body, so we don't make it configurable.
+        private
+
         def style
           :no_empty_lines
         end

--- a/lib/rubocop/cop/style/empty_lines_around_module_body.rb
+++ b/lib/rubocop/cop/style/empty_lines_around_module_body.rb
@@ -9,14 +9,27 @@ module RuboCop
       #
       # @example
       #
-      #   module Test
+      #   EnforcedStyle: empty_lines
       #
-      #      def something
-      #        ...
-      #      end
+      #   # good
+      #
+      #   module Foo
+      #
+      #     def bar
+      #       ...
+      #     end
       #
       #   end
       #
+      #   EnforcedStyle: no_empty_lines
+      #
+      #   # good
+      #
+      #   module Foo
+      #     def bar
+      #       ...
+      #     end
+      #   end
       class EmptyLinesAroundModuleBody < Cop
         include EmptyLinesAroundBody
 


### PR DESCRIPTION
Some more housekeeping.

Because of how the starting- and ending lines were referenced in the `EmptyLinesAroundBody` mixin, `EmptyLinesAroundBlockBody` was considered a special case, and needed its own implementation.

This change makes `EmptyLinesAroundBody` work for any node type, and allows us to remove the custom logic from `EmptyLinesAroundBlockBody`.

It also improves the examples a bit.