### PR TITLE
[Fix #3325] Drop support for MRI 1.9.3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,13 +2,11 @@ sudo: false
 cache: bundler
 language: ruby
 rvm:
-  - 1.9.3
   - 2.0.0
   - 2.1
   - 2.2
   - 2.3.0
   - ruby-head
-  - jruby-19mode
   - jruby-9.0.1.0
   - rbx-3
 env:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@
 * [#2645](https://github.com/bbatsov/rubocop/issues/2645): `Style/EmptyLiteral` no longer generates an offense for `String.new` when using frozen string literals. ([@drenmi][])
 * [#3308](https://github.com/bbatsov/rubocop/issues/3308): Make `Lint/NextWithoutAccumulator` aware of nested enumeration. ([@drenmi][])
 * Extend `Style/MethodMissing` cop to check for the conditions in the style guide. ([@drenmi][])
+* [#3325](https://github.com/bbatsov/rubocop/issues/3325): Drop support for MRI 1.9.3. ([@drenmi][])
 
 ## 0.41.2 (2016-07-07)
 

--- a/Gemfile
+++ b/Gemfile
@@ -15,8 +15,6 @@ group :test do
   gem 'codeclimate-test-reporter', require: false
   gem 'safe_yaml', require: false
   gem 'webmock', require: false
-  # Json 2.0 requires Ruby >= 2.0
-  gem 'json', '~> 1.8', require: false, platforms: :ruby_19
 end
 
 local_gemfile = 'Gemfile.local'

--- a/README.md
+++ b/README.md
@@ -71,12 +71,11 @@ You can read a ton more about RuboCop in its [official manual](http://rubocop.re
 
 RuboCop supports the following Ruby implementations:
 
-* MRI 1.9.3
 * MRI 2.0
 * MRI 2.1
 * MRI 2.2
 * MRI 2.3
-* JRuby in 1.9 mode
+* JRuby 9.0+
 * Rubinius 2.0+
 
 ## Team

--- a/lib/rubocop/config_loader.rb
+++ b/lib/rubocop/config_loader.rb
@@ -140,13 +140,8 @@ module RuboCop
 
       def load_yaml_configuration(absolute_path)
         yaml_code = IO.read(absolute_path, encoding: 'UTF-8')
-        # At one time, there was a problem with the psych YAML engine under
-        # Ruby 1.9.3. YAML.load_file would crash when reading empty .yml files
-        # or files that only contained comments and blank lines. This problem
-        # is not possible to reproduce now, but we want to avoid it in case
-        # it's still there. So we only load the YAML code if we find some real
-        # code in there.
-        hash = yaml_code =~ /^[A-Z]/i ? yaml_safe_load(yaml_code) : {}
+        hash = yaml_safe_load(yaml_code) || {}
+
         puts "configuration from #{absolute_path}" if debug?
 
         unless hash.is_a?(Hash)

--- a/lib/rubocop/cop/performance/sample.rb
+++ b/lib/rubocop/cop/performance/sample.rb
@@ -89,7 +89,6 @@ module RuboCop
             arg.source if arg
           end
 
-          # FIXME: use Range#size once Ruby 1.9 support is dropped
           def range_size(range_node)
             vals = *range_node
             return :unknown unless vals.all?(&:int_type?)

--- a/lib/rubocop/formatter/disabled_config_formatter.rb
+++ b/lib/rubocop/formatter/disabled_config_formatter.rb
@@ -170,9 +170,6 @@ module RuboCop
             output.puts "    - '#{file}'"
           end
         end
-      rescue LoadError
-        # Fallback to Enabled: false for Ruby < 1.9.3
-        output.puts '  Enabled: false'
       end
     end
   end

--- a/lib/rubocop/formatter/html_formatter.rb
+++ b/lib/rubocop/formatter/html_formatter.rb
@@ -106,8 +106,7 @@ module RuboCop
         end
 
         def escape(s)
-          # Single quotes not escaped in Ruby 1.9, so add extra substitution.
-          CGI.escapeHTML(s).gsub(/'/, '&#39;')
+          CGI.escapeHTML(s)
         end
 
         def base64_encoded_logo_image

--- a/lib/rubocop/string_util.rb
+++ b/lib/rubocop/string_util.rb
@@ -55,12 +55,9 @@ module RuboCop
         common_chars_of_shorter = Array.new(shorter.size)
         common_chars_of_longer = Array.new(longer.size)
 
-        # In Ruby 1.9 String#chars returns Enumerator rather than Array.
-        longer_chars = longer.each_char.to_a
-
         shorter.each_char.with_index do |shorter_char, shorter_index|
           matching_index_range(shorter_index).each do |longer_index|
-            longer_char = longer_chars[longer_index]
+            longer_char = longer.chars[longer_index]
 
             next unless shorter_char == longer_char
 
@@ -68,7 +65,7 @@ module RuboCop
             common_chars_of_longer[longer_index] = longer_char
 
             # Mark the matching character as already used
-            longer_chars[longer_index] = nil
+            longer.chars[longer_index] = nil
 
             break
           end

--- a/rubocop.gemspec
+++ b/rubocop.gemspec
@@ -9,7 +9,7 @@ Gem::Specification.new do |s|
   s.name = 'rubocop'
   s.version = RuboCop::Version::STRING
   s.platform = Gem::Platform::RUBY
-  s.required_ruby_version = '>= 1.9.3'
+  s.required_ruby_version = '>= 2.0.0'
   s.authors = ['Bozhidar Batsov', 'Jonas Arvidsson', 'Yuji Nakayama']
   s.description = <<-EOF
     Automatic Ruby code style checking tool.


### PR DESCRIPTION
This change drops support for EOL MRI 1.9.3.

- Update `rubocop.gemspec` required Ruby version
- Remove MRI 1.9.3 from the supported platforms in the `README`
- Remove the version constraint for `json` in the `Gemfile`