### PR TITLE
Add support for MRI 2.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@
 * [#3308](https://github.com/bbatsov/rubocop/issues/3308): Make `Lint/NextWithoutAccumulator` aware of nested enumeration. ([@drenmi][])
 * Extend `Style/MethodMissing` cop to check for the conditions in the style guide. ([@drenmi][])
 * [#3325](https://github.com/bbatsov/rubocop/issues/3325): Drop support for MRI 1.9.3. ([@drenmi][])
+* Add support for MRI 2.4. ([@dvandersluis][])
 
 ## 0.41.2 (2016-07-07)
 
@@ -2285,3 +2286,4 @@
 [@sgringwe]: https://github.com/sgringwe
 [@Tei]: https://github.com/Tei
 [@haziqhafizuddin]: https://github.com/haziqhafizuddin
+[@dvandersluis]: https://github.com/dvandersluis

--- a/lib/rubocop/config.rb
+++ b/lib/rubocop/config.rb
@@ -18,7 +18,7 @@ module RuboCop
                        AutoCorrect StyleGuide Details).freeze
     # 2.0 is the oldest officially supported Ruby version.
     DEFAULT_RUBY_VERSION = 2.0
-    KNOWN_RUBIES = [1.9, 2.0, 2.1, 2.2, 2.3].freeze
+    KNOWN_RUBIES = [1.9, 2.0, 2.1, 2.2, 2.3, 2.4].freeze
     OBSOLETE_COPS = {
       'Style/TrailingComma' =>
         'The `Style/TrailingComma` cop no longer exists. Please use ' \

--- a/lib/rubocop/processed_source.rb
+++ b/lib/rubocop/processed_source.rb
@@ -120,6 +120,9 @@ module RuboCop
       when 2.3
         require 'parser/ruby23'
         Parser::Ruby23
+      when 2.4
+        require 'parser/ruby24'
+        Parser::Ruby24
       else
         raise ArgumentError, "Unknown Ruby version: #{ruby_version.inspect}"
       end

--- a/lib/rubocop/rspec/shared_contexts.rb
+++ b/lib/rubocop/rspec/shared_contexts.rb
@@ -73,3 +73,7 @@ end
 shared_context 'ruby 2.3', :ruby23 do
   let(:ruby_version) { 2.3 }
 end
+
+shared_context 'ruby 2.4', :ruby24 do
+  let(:ruby_version) { 2.4 }
+end

--- a/spec/rubocop/cli_spec.rb
+++ b/spec/rubocop/cli_spec.rb
@@ -1458,13 +1458,13 @@ describe RuboCop::CLI, :isolated_environment do
     context 'when configured with an unknown version' do
       it 'fails with an error message' do
         create_file('.rubocop.yml', ['AllCops:',
-                                     '  TargetRubyVersion: 2.4'])
+                                     '  TargetRubyVersion: 2.5'])
         expect(cli.run([])).to eq(2)
         expect($stderr.string.strip).to match(
-          /\AError: Unknown Ruby version 2.4 found in `TargetRubyVersion`/
+          /\AError: Unknown Ruby version 2.5 found in `TargetRubyVersion`/
         )
         expect($stderr.string.strip).to match(
-          /Known versions: 1.9, 2.0, 2.1, 2.2, 2.3/
+          /Known versions: 1.9, 2.0, 2.1, 2.2, 2.3, 2.4/
         )
       end
     end


### PR DESCRIPTION
With 2.4.0.preview1 released, and Ruby 2.4 already supported by the `Parser` gem, it would be helpful for rubocop to be able to parse projects when the ruby version is set to 2.4. As far as I know, there aren't any major syntax changes between 2.3 and 2.4, so I don't believe there is more to do here to enable checking 2.4. 

All tests pass, except for three pending tests. I'm not sure if there are other tests that need to be added here. I ran the tests on Ruby 2.4, and rubocop succeeded at inspecting itself.

If something is missing, please let me know, I'd be glad to fix it.