### PR TITLE
[Fix #3283] Improve the offense message of Lint/ShadowedException

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 * [#3307](https://github.com/bbatsov/rubocop/issues/3307): Fix exception when inspecting an operator assignment with `Style/MethodCallParentheses` cop. ([@drenmi][])
 * [#3316](https://github.com/bbatsov/rubocop/issues/3316): Fix error for blocks without arguments in `Style/SingleLineBlockParams` cop. ([@owst][])
 * [#3320](https://github.com/bbatsov/rubocop/issues/3320): Make `Style/OpMethod` aware of the backtick method. ([@drenmi][])
+* [#3283](https://github.com/bbatsov/rubocop/issues/3283): Improve the offense message of Lint/ShadowedException. ([@akihiro17][])
 
 ### Changes
 

--- a/spec/rubocop/cop/lint/shadowed_exception_spec.rb
+++ b/spec/rubocop/cop/lint/shadowed_exception_spec.rb
@@ -110,7 +110,7 @@ describe RuboCop::Cop::Lint::ShadowedException do
                            '  foo',
                            'end'])
 
-      expect(cop.messages).to eq(['Do not shadow rescued Exceptions'])
+      expect(cop.messages).to eq(['Unnecessary rescued exceptions detected'])
       expect(cop.highlights).to eq(['rescue StandardError, Exception'])
     end
 
@@ -152,7 +152,7 @@ describe RuboCop::Cop::Lint::ShadowedException do
                            '  b',
                            'end'])
 
-      expect(cop.messages).to eq(['Do not shadow rescued Exceptions'])
+      expect(cop.messages).to eq(['Unnecessary rescued exceptions detected'])
       expect(cop.highlights).to eq(['rescue nil, StandardError, Exception'])
     end
   end
@@ -338,6 +338,19 @@ describe RuboCop::Cop::Lint::ShadowedException do
                            'end'])
 
       expect(cop.offenses).to be_empty
+    end
+  end
+
+  context 'unnecessary rescued exceptions' do
+    it 'registers an offense' do
+      inspect_source(cop, ['begin',
+                           '  something',
+                           'rescue Timeout::Error, StandardError',
+                           '  foo',
+                           'end'])
+
+      expect(cop.messages).to eq(['Unnecessary rescued exceptions detected'])
+      expect(cop.highlights).to eq(['rescue Timeout::Error, StandardError'])
     end
   end
 end


### PR DESCRIPTION
-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Used the same coding conventions as the rest of the project.
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] All tests are passing.
* [x] The new code doesn't generate RuboCop offenses.
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.

[1]: http://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html

Previously, Rubocop generates a little bit misleading message('Do not
shadow rescued Exceptions') when unnecessary rescued exceptions exist in a same rescue group.

From this commit, Rubocop outputs a different message when it detects unnecessary rescued exceptions.

This fixes #3283 