### PR TITLE
Shadowed exception

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 * [#3307](https://github.com/bbatsov/rubocop/issues/3307): Fix exception when inspecting an operator assignment with `Style/MethodCallParentheses` cop. ([@drenmi][])
 * [#3316](https://github.com/bbatsov/rubocop/issues/3316): Fix error for blocks without arguments in `Style/SingleLineBlockParams` cop. ([@owst][])
 * [#3320](https://github.com/bbatsov/rubocop/issues/3320): Make `Style/OpMethod` aware of the backtick method. ([@drenmi][])
+* Do not register an offense in `Lint/ShadowedException` when rescuing an exception built into Ruby before a custom exception. ([@rrosenblum][])
 
 ### Changes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@
 * [#3325](https://github.com/bbatsov/rubocop/issues/3325): Drop support for MRI 1.9.3. ([@drenmi][])
 * Add support for MRI 2.4. ([@dvandersluis][])
 * [#3256](https://github.com/bbatsov/rubocop/issues/3256): Highlight the closing brace in `Style/Multiline...BraceLayout` cops. ([@jonas054][])
+* Always register an offense when rescuing `Exception` before or along with any other exception in `Lint/ShadowedException`. ([@rrosenblum][])
 
 ## 0.41.2 (2016-07-07)
 

--- a/lib/rubocop/cop/lint/shadowed_exception.rb
+++ b/lib/rubocop/cop/lint/shadowed_exception.rb
@@ -94,7 +94,15 @@ module RuboCop
 
         def sort_rescued_groups(groups)
           groups.sort do |x, y|
-            x <=> y || 0
+            if x.include?(Exception)
+              1
+            elsif y.include?(Exception)
+              -1
+            elsif x.empty? || y.empty?
+              0
+            else
+              x <=> y || 0
+            end
           end
         end
 

--- a/spec/rubocop/cop/lint/shadowed_exception_spec.rb
+++ b/spec/rubocop/cop/lint/shadowed_exception_spec.rb
@@ -328,6 +328,44 @@ describe RuboCop::Cop::Lint::ShadowedException do
       expect(cop.offenses).to be_empty
     end
 
+    it 'accepts rescuing a known exception after an unknown exceptions' do
+      inspect_source(cop, ['begin',
+                           '  a',
+                           'rescue UnknownException',
+                           '  b',
+                           'rescue StandardError',
+                           '  c',
+                           'end'])
+
+      expect(cop.offenses).to be_empty
+    end
+
+    it 'accepts rescuing a known exception before an unknown exceptions' do
+      inspect_source(cop, ['begin',
+                           '  a',
+                           'rescue StandardError',
+                           '  b',
+                           'rescue UnknownException',
+                           '  c',
+                           'end'])
+
+      expect(cop.offenses).to be_empty
+    end
+
+    it 'accepts rescuing a known exception between unknown exceptions' do
+      inspect_source(cop, ['begin',
+                           '  a',
+                           'rescue UnknownException',
+                           '  b',
+                           'rescue StandardError',
+                           '  c',
+                           'rescue AnotherUnknownException',
+                           '  d',
+                           'end'])
+
+      expect(cop.offenses).to be_empty
+    end
+
     it 'ignores expressions of non-const' do
       inspect_source(cop, ['begin',
                            '  a',

--- a/spec/rubocop/cop/lint/shadowed_exception_spec.rb
+++ b/spec/rubocop/cop/lint/shadowed_exception_spec.rb
@@ -55,6 +55,17 @@ describe RuboCop::Cop::Lint::ShadowedException do
       expect(cop.offenses).to be_empty
     end
 
+    it 'registers an offense rescuing Exception with any other error or ' \
+       'exception' do
+      inspect_source(cop, ['begin',
+                           '  something',
+                           'rescue NonStandardError, Exception',
+                           '  handle_exception',
+                           'end'])
+
+      expect(cop.messages).to eq(['Do not shadow rescued Exceptions'])
+    end
+
     it 'accepts rescuing a single exception that is assigned to a variable' do
       inspect_source(cop, ['begin',
                            '  something',
@@ -262,6 +273,19 @@ describe RuboCop::Cop::Lint::ShadowedException do
       end
 
       it 'registers an offense for splat arguments rescued after ' \
+         'rescuing a known exception' do
+        inspect_source(cop, ['begin',
+                             '  a',
+                             'rescue StandardError',
+                             '  b',
+                             'rescue *BAR',
+                             '  c',
+                             'end'])
+
+        expect(cop.offenses).to be_empty
+      end
+
+      it 'registers an offense for splat arguments rescued after ' \
          'rescuing Exception' do
         inspect_source(cop, ['begin',
                              '  a',
@@ -364,6 +388,21 @@ describe RuboCop::Cop::Lint::ShadowedException do
                            'end'])
 
       expect(cop.offenses).to be_empty
+    end
+
+    it 'registers an offense rescuing Exception before an unknown exceptions' do
+      inspect_source(cop, ['begin',
+                           '  a',
+                           'rescue Exception',
+                           '  b',
+                           'rescue UnknownException',
+                           '  c',
+                           'end'])
+
+      expect(cop.messages).to eq(['Do not shadow rescued Exceptions'])
+      expect(cop.highlights).to eq([['rescue Exception',
+                                     '  b',
+                                     'rescue UnknownException'].join("\n")])
     end
 
     it 'ignores expressions of non-const' do


### PR DESCRIPTION
This fixes a false positive that would register an offense when a known exception is rescued before an unknown exception. It also now treats `Exception` as the highest level exception. This means an offense will always be register if `Exception` is rescued in the same `rescue` as other exceptions, or if it is rescued before another exception.

This does not modify the message that was discussed in #3283 and #3333.