### PR TITLE
[Fix #3341] Exclude RSpec tests from inspection by `Style/NumericPredicate` cop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## master (unreleased)
 
+### Changes
+
+* [#3341](https://github.com/bbatsov/rubocop/issues/3341): Exclude RSpec tests from inspection by `Style/NumericPredicate` cop. ([@drenmi][])
+
 ## 0.42.0 (2016-07-25)
 
 ### New features

--- a/config/default.yml
+++ b/config/default.yml
@@ -648,6 +648,10 @@ Style/NumericPredicate:
   SupportedStyles:
     - predicate
     - comparison
+  # Exclude RSpec specs because assertions like `expect(1).to be > 0` cause
+  # false positives.
+  Exclude:
+    - 'spec/**/*'
 
 Style/MethodDefParentheses:
   EnforcedStyle: require_parentheses


### PR DESCRIPTION
This cop causes false positives on assertions like `expect(1).to be > 0`.

This change excludes RSpec tests from inspection.