### PR TITLE
Fix #3349: Skip autocorrect for multiline lambda keyword arguments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 * [#2968](https://github.com/bbatsov/rubocop/issues/2968): Add new `Style/DocumentationMethod` cop. ([@sooyang][])
 
+### Bug fixes
+
+* [#3349](https://github.com/bbatsov/rubocop/issues/3349): Fix bad autocorrect for `Style/Lambda` cop. ([@metcalf][])
+
 ### Changes
 
 * [#3341](https://github.com/bbatsov/rubocop/issues/3341): Exclude RSpec tests from inspection by `Style/NumericPredicate` cop. ([@drenmi][])
@@ -2304,3 +2308,4 @@
 [@dvandersluis]: https://github.com/dvandersluis
 [@QuinnHarris]: https://github.com/QuinnHarris
 [@sooyang]: https://github.com/sooyang
+[@metcalf]: https://github.com/metcalf

--- a/lib/rubocop/cop/style/lambda.rb
+++ b/lib/rubocop/cop/style/lambda.rb
@@ -177,12 +177,18 @@ module RuboCop
           args.children.map(&:source).join(', ')
         end
 
-        def arg_to_unparenthesized_call?(node)
-          parent = node.parent
+        def arg_to_unparenthesized_call?(arg_node)
+          parent = arg_node.parent
+
+          if parent && parent.pair_type?
+            arg_node = parent.parent
+            parent = arg_node.parent
+          end
+
           return false unless parent && parent.send_type?
           return false if parenthesized_call?(parent)
 
-          node.sibling_index > 1
+          arg_node.sibling_index > 1
         end
 
         def remove_unparenthesized_whitespaces(corrector, node)

--- a/spec/rubocop/cop/style/lambda_spec.rb
+++ b/spec/rubocop/cop/style/lambda_spec.rb
@@ -206,18 +206,6 @@ describe RuboCop::Cop::Style::Lambda, :config do
                                          '  x',
                                          'end'].join("\n")
       end
-
-      context 'in a send' do
-        let(:source) do
-          ['f -> do',
-           '  x',
-           'end']
-        end
-
-        it_behaves_like 'registers an offense',
-                        'Use the `lambda` method for multiline lambdas.'
-        it_behaves_like 'does not auto-correct'
-      end
     end
 
     context 'unusual lack of spacing' do
@@ -355,6 +343,18 @@ describe RuboCop::Cop::Style::Lambda, :config do
         ['has_many :kittens, -> do',
          '  where(cats: Cat.young.where_values_hash)',
          'end, source: cats']
+      end
+
+      it_behaves_like 'registers an offense',
+                      'Use the `lambda` method for multiline lambdas.'
+      it_behaves_like 'does not auto-correct'
+    end
+
+    context 'with a multiline lambda literal as a keyword argument' do
+      let(:source) do
+        ['has_many opt: -> do',
+         '  where(cats: Cat.young.where_values_hash)',
+         'end']
       end
 
       it_behaves_like 'registers an offense',

--- a/spec/rubocop/cop/style/lambda_spec.rb
+++ b/spec/rubocop/cop/style/lambda_spec.rb
@@ -23,6 +23,13 @@ describe RuboCop::Cop::Style::Lambda, :config do
     end
   end
 
+  shared_examples 'does not auto-correct' do
+    it 'does not autocorrect' do
+      expect(autocorrect_source(cop, source)).to eq(source.join("\n"))
+      expect(cop.offenses.map(&:corrected?)).to eq [false]
+    end
+  end
+
   context 'with enforced `lambda` style' do
     let(:cop_config) { { 'EnforcedStyle' => 'lambda' } }
 
@@ -199,6 +206,18 @@ describe RuboCop::Cop::Style::Lambda, :config do
                                          '  x',
                                          'end'].join("\n")
       end
+
+      context 'in a send' do
+        let(:source) do
+          ['f -> do',
+           '  x',
+           'end']
+        end
+
+        it_behaves_like 'registers an offense',
+                        'Use the `lambda` method for multiline lambdas.'
+        it_behaves_like 'does not auto-correct'
+      end
     end
 
     context 'unusual lack of spacing' do
@@ -338,15 +357,9 @@ describe RuboCop::Cop::Style::Lambda, :config do
          'end, source: cats']
       end
 
-      it 'registers an offense' do
-        inspect_source(cop, source)
-        expect(cop.offenses.size).to eq 1
-      end
-
-      it 'does not auto-correct' do
-        expect(autocorrect_source(cop, source)).to eq(source.join("\n"))
-        expect(cop.offenses.map(&:corrected?)).to eq [false]
-      end
+      it_behaves_like 'registers an offense',
+                      'Use the `lambda` method for multiline lambdas.'
+      it_behaves_like 'does not auto-correct'
     end
   end
 end


### PR DESCRIPTION
Style/Lambda currently skips autocorrection for multiline lambdas that are arguments to unparenthesized sends. It does not correctly identify keyword arguments as belonging to this class, causing #3349. This updates the skipping code to correctly handle keyword arguments. 

This is split into two commits. The first refactors the existing tests to consistently use `it_behaves_like` and the second fixes the bug with tests.