### PR TITLE
[Fix #3351] Fix bad auto-correct for `Performance/RedundantMatch` cop.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 ### Bug fixes
 
 * [#3349](https://github.com/bbatsov/rubocop/issues/3349): Fix bad autocorrect for `Style/Lambda` cop. ([@metcalf][])
+* [#3351](https://github.com/bbatsov/rubocop/issues/3351): Fix bad auto-correct for `Performance/RedundantMatch` cop. ([@annaswims][])
 
 ### Changes
 
@@ -2310,3 +2311,4 @@
 [@QuinnHarris]: https://github.com/QuinnHarris
 [@sooyang]: https://github.com/sooyang
 [@metcalf]: https://github.com/metcalf
+[@annaswims]: https://github.com/annaswims

--- a/lib/rubocop/cop/performance/redundant_match.rb
+++ b/lib/rubocop/cop/performance/redundant_match.rb
@@ -43,8 +43,10 @@ module RuboCop
           # Regexp#match can take a second argument, but this cop doesn't
           # register an offense in that case
           receiver, _method, arg = *node
-          new_source = receiver.source + ' =~ ' + arg.source
-          ->(corrector) { corrector.replace(node.source_range, new_source) }
+          if arg.type == :regexp
+            new_source = receiver.source + ' =~ ' + arg.source
+            ->(corrector) { corrector.replace(node.source_range, new_source) }
+          end
         end
       end
     end

--- a/spec/rubocop/cop/performance/redundant_match_spec.rb
+++ b/spec/rubocop/cop/performance/redundant_match_spec.rb
@@ -54,6 +54,11 @@ describe RuboCop::Cop::Performance::RedundantMatch do
                               'end'].join("\n"))
   end
 
+  it 'does not autocorrect if .match has a string agrgument' do
+    new_source = autocorrect_source(cop, 'something if str.match("string")')
+    expect(new_source).to eq 'something if str.match("string")'
+  end
+
   it 'does not register an error when return value of .match is passed ' \
      'to another method' do
     inspect_source(cop, ['def method(str)',


### PR DESCRIPTION
The `match` method takes an argument of either a regex or a string. However, when we run auto correct, `do_something if "foo.txt".match(".txt")`  gets autocorrected to `do_something if "foo.txt" =~ ".txt"`,  which results in `TypeError: type mismatch: String given`.  We should only autocorrect if `match`'s argument is a regex.

Fixes https://github.com/bbatsov/rubocop/issues/3351

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Used the same coding conventions as the rest of the project.
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] All tests are passing.
* [x] The new code doesn't generate RuboCop offenses.
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.

[1]: http://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html
