### PR TITLE
[Fix #3347] Prevent infinite loop in `Style/TernaryParentheses` cop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 
 * [#3349](https://github.com/bbatsov/rubocop/issues/3349): Fix bad autocorrect for `Style/Lambda` cop. ([@metcalf][])
 * [#3351](https://github.com/bbatsov/rubocop/issues/3351): Fix bad auto-correct for `Performance/RedundantMatch` cop. ([@annaswims][])
+* [#3347](https://github.com/bbatsov/rubocop/issues/3347): Prevent infinite loop in `Style/TernaryParentheses` cop when used together with `Style/RedundantParentheses`. ([@drenmi][])
 
 ### Changes
 

--- a/lib/rubocop/cop/style/ternary_parentheses.rb
+++ b/lib/rubocop/cop/style/ternary_parentheses.rb
@@ -55,7 +55,8 @@ module RuboCop
 
           (require_parentheses? && !parenthesized?(condition) ||
             !require_parentheses? && parenthesized?(condition)) &&
-            !(safe_assignment?(condition) && safe_assignment_allowed?)
+            !(safe_assignment?(condition) && safe_assignment_allowed?) &&
+            !infinite_loop?
         end
 
         def autocorrect(node)
@@ -85,8 +86,20 @@ module RuboCop
           style == :require_parentheses
         end
 
+        def redundant_parentheses_enabled?
+          @config.for_cop('RedundantParentheses')['Enabled']
+        end
+
         def parenthesized?(node)
           node.source =~ /^\(.*\)$/
+        end
+
+        # When this cop is configured to enforce parentheses and the
+        # `RedundantParentheses` cop is enabled, it will cause an infinite loop
+        # as they compete to add and remove the parens respectively.
+        def infinite_loop?
+          require_parentheses? &&
+            redundant_parentheses_enabled?
         end
       end
     end

--- a/spec/rubocop/cop/style/ternary_parentheses_spec.rb
+++ b/spec/rubocop/cop/style/ternary_parentheses_spec.rb
@@ -147,4 +147,19 @@ describe RuboCop::Cop::Style::TernaryParentheses, :config do
       end
     end
   end
+
+  context 'when `RedundantParenthesis` would cause an infinite loop' do
+    let(:config) do
+      RuboCop::Config.new(
+        'Style/RedundantParentheses' => { 'Enabled' => true },
+        'Style/TernaryParentheses' => {
+          'EnforcedStyle' => 'require_parentheses',
+          'SupportedStyles' => %w(require_parentheses require_no_parentheses)
+        }
+      )
+    end
+
+    it_behaves_like 'code without offense',
+                    'foo = bar? ? a : b'
+  end
 end


### PR DESCRIPTION
When this cop was configured to enforce parentheses and the `Style/RedundantParentheses` cop was enabled, it would cause an infinite loop as they compete to add and remove the parens respectively.

As per @jonas054 suggestion, `Style/TernaryParentheses` is now aware of its incompatibility with `Style/RedundantParentheses`, and doesn't register an offense that would conflict with the latter.