### PR TITLE
[Fix #3209] Remove faulty line length check from `Style/GuardClause` cop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 * [#3349](https://github.com/bbatsov/rubocop/issues/3349): Fix bad autocorrect for `Style/Lambda` cop. ([@metcalf][])
 * [#3351](https://github.com/bbatsov/rubocop/issues/3351): Fix bad auto-correct for `Performance/RedundantMatch` cop. ([@annaswims][])
 * [#3347](https://github.com/bbatsov/rubocop/issues/3347): Prevent infinite loop in `Style/TernaryParentheses` cop when used together with `Style/RedundantParentheses`. ([@drenmi][])
+* [#3209](https://github.com/bbatsov/rubocop/issues/3209): Remove faulty line length check from `Style/GuardClause` cop. ([@drenmi][])
 
 ### Changes
 

--- a/lib/rubocop/cli.rb
+++ b/lib/rubocop/cli.rb
@@ -95,10 +95,10 @@ module RuboCop
         [[formatter, @options[:output_path]]]
       end
 
-      if @options[:auto_gen_config]
-        @options[:formatters] << [Formatter::DisabledConfigFormatter,
-                                  ConfigLoader::AUTO_GENERATED_FILE]
-      end
+      return unless @options[:auto_gen_config]
+
+      @options[:formatters] << [Formatter::DisabledConfigFormatter,
+                                ConfigLoader::AUTO_GENERATED_FILE]
     end
 
     def print_available_cops

--- a/lib/rubocop/config.rb
+++ b/lib/rubocop/config.rb
@@ -274,11 +274,11 @@ module RuboCop
     end
 
     def check_obsolete_parameter(cop, parameter, alternative = nil)
-      if self[cop] && self[cop].key?(parameter)
-        raise ValidationError, "obsolete parameter #{parameter} (for #{cop}) " \
-                              "found in #{loaded_path}" \
-                              "#{"\n" if alternative}#{alternative}"
-      end
+      return unless self[cop] && self[cop].key?(parameter)
+
+      raise ValidationError, "obsolete parameter #{parameter} (for #{cop}) " \
+                            "found in #{loaded_path}" \
+                            "#{"\n" if alternative}#{alternative}"
     end
 
     def reject_obsolete_cops
@@ -291,23 +291,21 @@ module RuboCop
     end
 
     def check_target_ruby
-      return unless target_ruby_version
+      return if KNOWN_RUBIES.include?(target_ruby_version)
 
-      unless KNOWN_RUBIES.include?(target_ruby_version)
-        msg = "Unknown Ruby version #{target_ruby_version.inspect} found "
+      msg = "Unknown Ruby version #{target_ruby_version.inspect} found "
 
-        msg +=
-          case @target_ruby_version_source
-          when :dot_ruby_version
-            'in `.ruby-version`.'
-          when :rubocop_yml
-            "in `TargetRubyVersion` parameter (in #{loaded_path})." \
-          end
+      msg +=
+        case @target_ruby_version_source
+        when :dot_ruby_version
+          'in `.ruby-version`.'
+        when :rubocop_yml
+          "in `TargetRubyVersion` parameter (in #{loaded_path})." \
+        end
 
-        msg += "\nKnown versions: #{KNOWN_RUBIES.join(', ')}"
+      msg += "\nKnown versions: #{KNOWN_RUBIES.join(', ')}"
 
-        raise ValidationError, msg
-      end
+      raise ValidationError, msg
     end
   end
 end

--- a/lib/rubocop/cop/lint/ineffective_access_modifier.rb
+++ b/lib/rubocop/cop/lint/ineffective_access_modifier.rb
@@ -69,14 +69,14 @@ module RuboCop
         end
 
         def check_node(node)
-          if node && node.begin_type?
-            clear
-            check_scope(node)
+          return unless node && node.begin_type?
 
-            @useless.each do |_name, (defs_node, visibility, modifier)|
-              add_offense(defs_node, :keyword,
-                          format_message(visibility, modifier))
-            end
+          clear
+          check_scope(node)
+
+          @useless.each do |_name, (defs_node, visibility, modifier)|
+            add_offense(defs_node, :keyword,
+                        format_message(visibility, modifier))
           end
         end
 

--- a/lib/rubocop/cop/lint/inherit_exception.rb
+++ b/lib/rubocop/cop/lint/inherit_exception.rb
@@ -49,9 +49,9 @@ module RuboCop
         private
 
         def check(node)
-          if node.const_name == 'Exception'
-            add_offense(node, :expression, format(MSG, preferred_base_class))
-          end
+          return unless node.const_name == 'Exception'
+
+          add_offense(node, :expression, format(MSG, preferred_base_class))
         end
 
         def autocorrect(node)

--- a/lib/rubocop/cop/lint/percent_string_array.rb
+++ b/lib/rubocop/cop/lint/percent_string_array.rb
@@ -22,9 +22,9 @@ module RuboCop
         end
 
         def on_percent_literal(node)
-          if contains_quotes_or_commas?(node)
-            add_offense(node, :expression, MSG)
-          end
+          return unless contains_quotes_or_commas?(node)
+
+          add_offense(node, :expression, MSG)
         end
 
         private

--- a/lib/rubocop/cop/lint/percent_symbol_array.rb
+++ b/lib/rubocop/cop/lint/percent_symbol_array.rb
@@ -22,9 +22,9 @@ module RuboCop
         end
 
         def on_percent_literal(node)
-          if contains_colons_or_commas?(node)
-            add_offense(node, :expression, MSG)
-          end
+          return unless contains_colons_or_commas?(node)
+
+          add_offense(node, :expression, MSG)
         end
 
         private

--- a/lib/rubocop/cop/lint/rand_one.rb
+++ b/lib/rubocop/cop/lint/rand_one.rb
@@ -26,9 +26,9 @@ module RuboCop
         PATTERN
 
         def on_send(node)
-          if rand_one?(node)
-            add_offense(node, :expression, format(MSG, node.source))
-          end
+          return unless rand_one?(node)
+
+          add_offense(node, :expression, format(MSG, node.source))
         end
       end
     end

--- a/lib/rubocop/cop/mixin/if_node.rb
+++ b/lib/rubocop/cop/mixin/if_node.rb
@@ -5,6 +5,8 @@ module RuboCop
   module Cop
     # Common functionality for checking if nodes.
     module IfNode
+      extend NodePattern::Macros
+
       def ternary?(node)
         node.loc.respond_to?(:question)
       end
@@ -32,6 +34,10 @@ module RuboCop
 
         [condition, body, else_clause]
       end
+
+      def_node_matcher :guard_clause?, <<-PATTERN
+          [{(send nil {:raise :fail} ...) return break next} single_line?]
+      PATTERN
     end
   end
 end

--- a/lib/rubocop/cop/performance/double_start_end_with.rb
+++ b/lib/rubocop/cop/performance/double_start_end_with.rb
@@ -33,10 +33,11 @@ module RuboCop
           first_call_args,
           second_call_args = two_start_end_with_calls(node)
 
-          if receiver && second_call_args.all?(&:pure?)
-            combined_args = combine_args(first_call_args, second_call_args)
-            add_offense_for_double_call(node, receiver, method, combined_args)
-          end
+          return unless receiver && second_call_args.all?(&:pure?)
+
+          combined_args = combine_args(first_call_args, second_call_args)
+
+          add_offense_for_double_call(node, receiver, method, combined_args)
         end
 
         private

--- a/lib/rubocop/cop/performance/redundant_match.rb
+++ b/lib/rubocop/cop/performance/redundant_match.rb
@@ -40,13 +40,14 @@ module RuboCop
         end
 
         def autocorrect(node)
+          receiver, _method, arg = *node
+
           # Regexp#match can take a second argument, but this cop doesn't
           # register an offense in that case
-          receiver, _method, arg = *node
-          if arg.type == :regexp
-            new_source = receiver.source + ' =~ ' + arg.source
-            ->(corrector) { corrector.replace(node.source_range, new_source) }
-          end
+          return unless arg.regexp_type?
+
+          new_source = receiver.source + ' =~ ' + arg.source
+          ->(corrector) { corrector.replace(node.source_range, new_source) }
         end
       end
     end

--- a/lib/rubocop/cop/rails/request_referer.rb
+++ b/lib/rubocop/cop/rails/request_referer.rb
@@ -10,9 +10,9 @@ module RuboCop
         include ConfigurableEnforcedStyle
 
         def on_send(node)
-          if offense?(node)
-            add_offense(node.source_range, node.source_range, message)
-          end
+          return unless offense?(node)
+
+          add_offense(node.source_range, node.source_range, message)
         end
 
         def autocorrect(node)

--- a/lib/rubocop/cop/style/block_delimiters.rb
+++ b/lib/rubocop/cop/style/block_delimiters.rb
@@ -6,7 +6,7 @@ module RuboCop
     module Style
       # Check for uses of braces or do/end around single line or
       # multi-line blocks.
-      class BlockDelimiters < Cop # rubocop:disable Metrics/ClassLength
+      class BlockDelimiters < Cop
         include ConfigurableEnforcedStyle
 
         def on_send(node)
@@ -160,13 +160,13 @@ module RuboCop
         end
 
         def correction_would_break_code?(node)
-          if node.loc.begin.is?('do')
-            # Converting `obj.method arg do |x| end` to use `{}` would cause
-            # a syntax error.
-            send = node.children.first
-            _receiver, _method_name, *args = *send
-            !args.empty? && !parentheses?(send)
-          end
+          return unless node.loc.begin.is?('do')
+
+          # Converting `obj.method arg do |x| end` to use `{}` would cause
+          # a syntax error.
+          send = node.children.first
+          _receiver, _method_name, *args = *send
+          !args.empty? && !parentheses?(send)
         end
 
         def ignored_method?(method_name)

--- a/lib/rubocop/cop/style/each_for_simple_loop.rb
+++ b/lib/rubocop/cop/style/each_for_simple_loop.rb
@@ -28,11 +28,12 @@ module RuboCop
               'number of times.'.freeze
 
         def on_block(node)
-          if offending_each_range(node)
-            send_node, = *node
-            range = send_node.receiver.source_range.join(send_node.loc.selector)
-            add_offense(node, range)
-          end
+          return unless offending_each_range(node)
+
+          send_node, = *node
+          range = send_node.receiver.source_range.join(send_node.loc.selector)
+
+          add_offense(node, range)
         end
 
         private

--- a/lib/rubocop/cop/style/encoding.rb
+++ b/lib/rubocop/cop/style/encoding.rb
@@ -35,13 +35,10 @@ module RuboCop
 
         def autocorrect(range)
           if @message == MSG_MISSING
-            encoding = cop_config[AUTO_CORRECT_ENCODING_COMMENT]
-            if encoding && encoding =~ ENCODING_PATTERN
-              lambda do |corrector|
-                corrector.insert_before(range, "#{encoding}\n")
-              end
-            else
-              raise "#{encoding} does not match #{ENCODING_PATTERN}"
+            raise encoding_mismatch_message unless matching_encoding?
+
+            lambda do |corrector|
+              corrector.insert_before(range, "#{encoding}\n")
             end
           else
             # Need to remove unnecessary encoding comment
@@ -52,6 +49,18 @@ module RuboCop
         end
 
         private
+
+        def encoding
+          cop_config[AUTO_CORRECT_ENCODING_COMMENT]
+        end
+
+        def matching_encoding?
+          encoding =~ ENCODING_PATTERN
+        end
+
+        def encoding_mismatch_message
+          "#{encoding} does not match #{ENCODING_PATTERN}"
+        end
 
         def offense(processed_source, line_number)
           line = processed_source[line_number]

--- a/lib/rubocop/cop/style/if_unless_modifier_of_if_unless.rb
+++ b/lib/rubocop/cop/style/if_unless_modifier_of_if_unless.rb
@@ -35,9 +35,9 @@ module RuboCop
         def on_if(node)
           return unless modifier_if?(node)
           _cond, body, _else = if_node_parts(node)
-          if body.type == :if
-            add_offense(node, :keyword, message(node.loc.keyword.source))
-          end
+          return unless body.if_type?
+
+          add_offense(node, :keyword, message(node.loc.keyword.source))
         end
       end
     end

--- a/lib/rubocop/cop/style/lambda.rb
+++ b/lib/rubocop/cop/style/lambda.rb
@@ -92,10 +92,9 @@ module RuboCop
 
           selector = block_method.source
 
-          if offending_selector?(node, selector)
-            add_offense(node, block_method.source_range,
-                        message(node, selector))
-          end
+          return unless offending_selector?(node, selector)
+
+          add_offense(node, block_method.source_range, message(node, selector))
         end
 
         def offending_selector?(node, selector)

--- a/lib/rubocop/cop/style/multiline_method_call_indentation.rb
+++ b/lib/rubocop/cop/style/multiline_method_call_indentation.rb
@@ -36,13 +36,13 @@ module RuboCop
         include MultilineExpressionIndentation
 
         def validate_config
-          if style == :aligned && cop_config['IndentationWidth']
-            raise ValidationError,
-                  'The `Style/MultilineMethodCallIndentation`' \
-                  ' cop only accepts an `IndentationWidth` ' \
-                  'configuration parameter when ' \
-                  '`EnforcedStyle` is `indented`.'
-          end
+          return unless style == :aligned && cop_config['IndentationWidth']
+
+          raise ValidationError,
+                'The `Style/MultilineMethodCallIndentation`' \
+                ' cop only accepts an `IndentationWidth` ' \
+                'configuration parameter when ' \
+                '`EnforcedStyle` is `indented`.'
         end
 
         private

--- a/lib/rubocop/cop/style/multiline_operation_indentation.rb
+++ b/lib/rubocop/cop/style/multiline_operation_indentation.rb
@@ -27,12 +27,12 @@ module RuboCop
         end
 
         def validate_config
-          if style == :aligned && cop_config['IndentationWidth']
-            raise ValidationError, 'The `Style/MultilineOperationIndentation`' \
-                                  ' cop only accepts an `IndentationWidth` ' \
-                                  'configuration parameter when ' \
-                                  '`EnforcedStyle` is `indented`.'
-          end
+          return unless style == :aligned && cop_config['IndentationWidth']
+
+          raise ValidationError, 'The `Style/MultilineOperationIndentation`' \
+                                ' cop only accepts an `IndentationWidth` ' \
+                                'configuration parameter when ' \
+                                '`EnforcedStyle` is `indented`.'
         end
 
         private

--- a/lib/rubocop/cop/style/multiline_ternary_operator.rb
+++ b/lib/rubocop/cop/style/multiline_ternary_operator.rb
@@ -12,13 +12,11 @@ module RuboCop
               'use `if` or `unless` instead.'.freeze
 
         def on_if(node)
-          _condition, _if_branch, else_branch = *node
+          _condition, _if_branch, = *node
 
-          return unless ternary?(node)
+          return unless ternary?(node) && node.multiline?
 
-          unless node.loc.line == else_branch.loc.line
-            add_offense(node, :expression)
-          end
+          add_offense(node, :expression)
         end
       end
     end

--- a/lib/rubocop/cop/style/numeric_literal_prefix.rb
+++ b/lib/rubocop/cop/style/numeric_literal_prefix.rb
@@ -47,11 +47,13 @@ module RuboCop
         def literal_type(node)
           literal = integer_part(node)
 
+          # rubocop:disable Style/GuardClause
           if literal =~ OCTAL_ZERO_ONLY_REGEX && octal_zero_only?
             return :octal_zero_only
           elsif literal =~ OCTAL_REGEX && !octal_zero_only?
             return :octal
           end
+          # rubocop:enable Style/GuardClause
 
           case literal
           when HEX_REGEX

--- a/lib/rubocop/cop/style/numeric_predicate.rb
+++ b/lib/rubocop/cop/style/numeric_predicate.rb
@@ -59,10 +59,10 @@ module RuboCop
         def on_send(node)
           numeric, replacement = check(node)
 
-          if numeric
-            add_offense(node, node.loc.expression,
-                        format(MSG, replacement, node.source))
-          end
+          return unless numeric
+
+          add_offense(node, node.loc.expression,
+                      format(MSG, replacement, node.source))
         end
 
         private
@@ -75,9 +75,9 @@ module RuboCop
               predicate(node)
             end
 
-          if numeric && operator && replacement_supported?(operator)
-            return numeric, replacement(numeric, operator)
-          end
+          return unless numeric && operator && replacement_supported?(operator)
+
+          [numeric, replacement(numeric, operator)]
         end
 
         def autocorrect(node)

--- a/lib/rubocop/cop/style/option_hash.rb
+++ b/lib/rubocop/cop/style/option_hash.rb
@@ -48,14 +48,14 @@ module RuboCop
         end
 
         def validate_config
-          if target_ruby_version < 2.0
-            raise ValidationError, 'The `Style/OptionHash` cop is only ' \
-                                  'compatible with Ruby 2.0 and up, but the ' \
-                                  'target Ruby version for your project is ' \
-                                  "1.9.\nPlease disable this cop or adjust " \
-                                  'the `TargetRubyVersion` parameter in your ' \
-                                  'configuration.'
-          end
+          return unless target_ruby_version < 2.0
+
+          raise ValidationError, 'The `Style/OptionHash` cop is only ' \
+                                'compatible with Ruby 2.0 and up, but the ' \
+                                'target Ruby version for your project is ' \
+                                "1.9.\nPlease disable this cop or adjust " \
+                                'the `TargetRubyVersion` parameter in your ' \
+                                'configuration.'
         end
 
         private

--- a/lib/rubocop/cop/style/signal_exception.rb
+++ b/lib/rubocop/cop/style/signal_exception.rb
@@ -84,11 +84,9 @@ module RuboCop
         end
 
         def check_send(method_name, node)
-          return unless node
+          return unless node && command_or_kernel_call?(method_name, node)
 
-          if command_or_kernel_call?(method_name, node)
-            add_offense(node, :selector, message(method_name))
-          end
+          add_offense(node, :selector, message(method_name))
         end
 
         def command_or_kernel_call?(name, node)

--- a/lib/rubocop/cop/style/space_after_not.rb
+++ b/lib/rubocop/cop/style/space_after_not.rb
@@ -16,9 +16,9 @@ module RuboCop
         MSG = 'Do not leave space between `!` and its argument.'.freeze
 
         def on_send(node)
-          if node.keyword_bang? && whitespace_after_bang_op?(node)
-            add_offense(node, :expression)
-          end
+          return unless node.keyword_bang? && whitespace_after_bang_op?(node)
+
+          add_offense(node, :expression)
         end
 
         def whitespace_after_bang_op?(node)

--- a/lib/rubocop/cop/style/space_around_operators.rb
+++ b/lib/rubocop/cop/style/space_around_operators.rb
@@ -19,6 +19,7 @@ module RuboCop
                     !any_pairs_on_the_same_line?(node.parent)
 
           _, right = *node
+
           check_operator(node.loc.operator, right.source_range)
         end
 
@@ -31,10 +32,10 @@ module RuboCop
         end
 
         def on_resbody(node)
-          if node.loc.assoc
-            _, variable, = *node
-            check_operator(node.loc.assoc, variable.source_range)
-          end
+          return unless node.loc.assoc
+          _, variable, = *node
+
+          check_operator(node.loc.assoc, variable.source_range)
         end
 
         def on_send(node)

--- a/lib/rubocop/cop/style/symbol_array.rb
+++ b/lib/rubocop/cop/style/symbol_array.rb
@@ -26,16 +26,16 @@ module RuboCop
         end
 
         def validate_config
-          if style == :percent && target_ruby_version < 2.0
-            raise ValidationError, 'The default `percent` style for the ' \
-                                  '`Style/SymbolArray` cop is only compatible' \
-                                  ' with Ruby 2.0 and up, but the target Ruby' \
-                                  " version for your project is 1.9.\nPlease " \
-                                  'either disable this cop, configure it to ' \
-                                  'use `array` style, or adjust the ' \
-                                  '`TargetRubyVersion` parameter in your ' \
-                                  'configuration.'
-          end
+          return unless style == :percent && target_ruby_version < 2.0
+
+          raise ValidationError, 'The default `percent` style for the ' \
+                                '`Style/SymbolArray` cop is only compatible' \
+                                ' with Ruby 2.0 and up, but the target Ruby' \
+                                " version for your project is 1.9.\nPlease " \
+                                'either disable this cop, configure it to ' \
+                                'use `array` style, or adjust the ' \
+                                '`TargetRubyVersion` parameter in your ' \
+                                'configuration.'
         end
 
         private

--- a/lib/rubocop/cop/style/word_array.rb
+++ b/lib/rubocop/cop/style/word_array.rb
@@ -50,9 +50,9 @@ module RuboCop
                     comments_in_array?(node)
           style_detected(:brackets, array_elems.size)
 
-          if style == :percent && array_elems.size >= min_size
-            add_offense(node, :expression, PERCENT_MSG)
-          end
+          return unless style == :percent && array_elems.size >= min_size
+
+          add_offense(node, :expression, PERCENT_MSG)
         end
 
         def check_percent(node)

--- a/lib/rubocop/cop/style/zero_length_predicate.rb
+++ b/lib/rubocop/cop/style/zero_length_predicate.rb
@@ -34,10 +34,12 @@ module RuboCop
 
           nonzero_length_predicate = nonzero_length_predicate(node)
 
+          # rubocop:disable Style/GuardClause
           if nonzero_length_predicate
             add_offense(node, :expression,
                         format(NONZERO_MSG, *nonzero_length_predicate))
           end
+          # rubocop:enable Style/GuardClause
         end
 
         def_node_matcher :zero_length_predicate, <<-END

--- a/lib/rubocop/formatter/worst_offenders_formatter.rb
+++ b/lib/rubocop/formatter/worst_offenders_formatter.rb
@@ -23,10 +23,10 @@ module RuboCop
       end
 
       def file_finished(file, offenses)
-        unless offenses.empty?
-          path = Pathname.new(file).relative_path_from(Pathname.new(Dir.pwd))
-          @offense_counts[path] = offenses.size
-        end
+        return if offenses.empty?
+
+        path = Pathname.new(file).relative_path_from(Pathname.new(Dir.pwd))
+        @offense_counts[path] = offenses.size
       end
 
       def finished(_inspected_files)

--- a/lib/rubocop/runner.rb
+++ b/lib/rubocop/runner.rb
@@ -254,9 +254,9 @@ module RuboCop
 
     def filter_cop_classes(cop_classes, config)
       # use only cops that link to a style guide if requested
-      if style_guide_cops_only?(config)
-        cop_classes.select! { |cop| config.for_cop(cop)['StyleGuide'] }
-      end
+      return unless style_guide_cops_only?(config)
+
+      cop_classes.select! { |cop| config.for_cop(cop)['StyleGuide'] }
     end
 
     def style_guide_cops_only?(config)

--- a/spec/rubocop/cop/style/guard_clause_spec.rb
+++ b/spec/rubocop/cop/style/guard_clause_spec.rb
@@ -77,24 +77,6 @@ describe RuboCop::Cop::Style::GuardClause, :config do
   it_behaves_like('reports offense', 'work')
   it_behaves_like('reports offense', '# TODO')
 
-  it 'does not report an offense if corrected code would exceed line length' do
-    inspect_source(cop,
-                   ['def func',
-                    '  test',
-                    '  if something_quite_long_right_here_is_that_ok?',
-                    '    do_this_and_that_and_the_other_thing!',
-                    '  end',
-                    'end',
-                    '',
-                    'def func',
-                    '  test',
-                    '  unless something_quite_long_right_here_is_that_ok?',
-                    '    do_this_and_that_and_the_other_thing!',
-                    '  end',
-                    'end'])
-    expect(cop.offenses).to be_empty
-  end
-
   it 'does not report an offense if body is if..elsif..end' do
     inspect_source(cop,
                    ['def func',


### PR DESCRIPTION
This cop would attempt to predict how long the line would be after turning an `if`- or `unless` statement into a guard clause.

Unfortunately, in many cases, this would reward poorly factored code that produced longer guard clauses.

It would also cause a large amount of false negatives. For example:

```
if rand_one?(node)
  add_offense(node, :expression, format(MSG, node.source))
end
```

at the end of a method definition, would not generate an offense.

Since this cop also does not implement auto-correct, and because the difficulty in getting such a feature correct in all cases, I suggest removing the attempted line length prediction altogether. This change does just that, revealing and fixing all the false positives within RuboCop in the process.