### PR TITLE
Pass filename YAML loading to improve stack trace messages

### DIFF
--- a/lib/rubocop/config_loader.rb
+++ b/lib/rubocop/config_loader.rb
@@ -140,7 +140,7 @@ module RuboCop
 
       def load_yaml_configuration(absolute_path)
         yaml_code = IO.read(absolute_path, encoding: 'UTF-8')
-        hash = yaml_safe_load(yaml_code) || {}
+        hash = yaml_safe_load(yaml_code, absolute_path) || {}
 
         puts "configuration from #{absolute_path}" if debug?
 
@@ -151,15 +151,16 @@ module RuboCop
         hash
       end
 
-      def yaml_safe_load(yaml_code)
+      def yaml_safe_load(yaml_code, filename)
         if YAML.respond_to?(:safe_load) # Ruby 2.1+
           if defined?(SafeYAML) && SafeYAML.respond_to?(:load)
-            SafeYAML.load(yaml_code, nil, whitelisted_tags: %w(!ruby/regexp))
+            SafeYAML.load(yaml_code, filename,
+                          whitelisted_tags: %w(!ruby/regexp))
           else
-            YAML.safe_load(yaml_code, [Regexp])
+            YAML.safe_load(yaml_code, [Regexp], [], false, filename)
           end
         else
-          YAML.load(yaml_code)
+          YAML.load(yaml_code, filename)
         end
       end
 

--- a/spec/rubocop/cli_spec.rb
+++ b/spec/rubocop/cli_spec.rb
@@ -1412,8 +1412,8 @@ describe RuboCop::CLI, :isolated_environment do
       cli.run(['example'])
       # MRI and JRuby return slightly different error messages.
       expect($stderr.string)
-        .to match(/^\(<unknown>\):\ (did\ not\ find\ )?expected\ alphabetic\ or
-                  \ numeric\ character/x)
+        .to match(%r{^\(\S+example/\.rubocop\.yml\):\ (did\ not\ find\ )?
+                  expected\ alphabetic\ or \ numeric\ character}x)
     end
 
     context 'when a file inherits from a higher level' do


### PR DESCRIPTION
Pass the filename to to YAML load. When parsing yaml that contains an error, this will add the filename of the yaml to the stack trace.

Example: 
Remove the colon from line 895 of the `enabled.yml`

Before the change
```
:~/work/rubocop (capture_filename u-1)$ bundle exec rubocop
(<unknown>): could not find expected ':' while scanning a simple key at line 895 column 1
~/.rbenv/versions/2.3.0/lib/ruby/2.3.0/psych.rb:377:in `parse'
~/.rbenv/versions/2.3.0/lib/ruby/2.3.0/psych.rb:377:in `parse_stream'
~/.rbenv/versions/2.3.0/lib/ruby/2.3.0/psych.rb:325:in `parse'
~/.rbenv/versions/2.3.0/lib/ruby/2.3.0/psych.rb:291:in `safe_load'
```

After the change
```
:~/work/rubocop (capture_filename u=)$ bundle exec rubocop
(~/work/rubocop/config/enabled.yml): could not find expected ':' while scanning a simple key at line 895 column 1
~/.rbenv/versions/2.3.0/lib/ruby/2.3.0/psych.rb:377:in `parse'
~/.rbenv/versions/2.3.0/lib/ruby/2.3.0/psych.rb:377:in `parse_stream'
~/.rbenv/versions/2.3.0/lib/ruby/2.3.0/psych.rb:325:in `parse'
~/.rbenv/versions/2.3.0/lib/ruby/2.3.0/psych.rb:291:in `safe_load'

```