### PR TITLE
[Fix #3366] Make `Style/MutableConstant` cop aware of splat assignments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 * [#3351](https://github.com/bbatsov/rubocop/issues/3351): Fix bad auto-correct for `Performance/RedundantMatch` cop. ([@annaswims][])
 * [#3347](https://github.com/bbatsov/rubocop/issues/3347): Prevent infinite loop in `Style/TernaryParentheses` cop when used together with `Style/RedundantParentheses`. ([@drenmi][])
 * [#3209](https://github.com/bbatsov/rubocop/issues/3209): Remove faulty line length check from `Style/GuardClause` cop. ([@drenmi][])
+* [#3366](https://github.com/bbatsov/rubocop/issues/3366): Make `Style/MutableConstant` cop aware of splat assignments. ([@drenmi][])
 
 ### Changes
 

--- a/spec/rubocop/cop/style/mutable_constant_spec.rb
+++ b/spec/rubocop/cop/style/mutable_constant_spec.rb
@@ -66,6 +66,29 @@ describe RuboCop::Cop::Style::MutableConstant do
     expect(cop.offenses).to be_empty
   end
 
+  context 'when performing a splat assignment' do
+    it 'allows an immutable value' do
+      inspect_source(cop, 'FOO = *(1...10)')
+      expect(cop.offenses).to be_empty
+    end
+
+    it 'allows a frozen array value' do
+      inspect_source(cop, 'FOO = *[1...10].freeze')
+      expect(cop.offenses).to be_empty
+    end
+
+    it 'registers an offense for a mutable value' do
+      source = 'BAR = *[1, 2, 3]'
+
+      inspect_source(cop, source)
+      expect(cop.offenses.size).to eq(1)
+
+      corrected = autocorrect_source(cop, source)
+
+      expect(corrected).to eq('BAR = *[1, 2, 3].freeze')
+    end
+  end
+
   context 'when assigning an array without brackets' do
     it 'adds brackets when auto-correcting' do
       new_source = autocorrect_source(cop, 'XXX = YYY, ZZZ')


### PR DESCRIPTION
This cop would fenerate false positives on code like:

```
FOO = *(1...10)
```

and:

```
BAR = *[1...10].freeze
```

This change fixes that.