### PR TITLE
[Fix #3358] Make `Style/MethodMissing` cop aware of class scope

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 * [#3209](https://github.com/bbatsov/rubocop/issues/3209): Remove faulty line length check from `Style/GuardClause` cop. ([@drenmi][])
 * [#3366](https://github.com/bbatsov/rubocop/issues/3366): Make `Style/MutableConstant` cop aware of splat assignments. ([@drenmi][])
 * [#3372](https://github.com/bbatsov/rubocop/pull/3372): Fix RuboCop crash with empty brackets in `Style/Next` cop. ([@pocke][])
+* [#3358](https://github.com/bbatsov/rubocop/issues/3358): Make `Style/MethodMissing` cop aware of class scope. ([@drenmi][])
 
 ### Changes
 

--- a/lib/rubocop/cop/style/method_missing.rb
+++ b/lib/rubocop/cop/style/method_missing.rb
@@ -60,13 +60,21 @@ module RuboCop
         end
 
         def implements_respond_to_missing?(node)
-          node.parent.each_child_node(:def).any? do |sibling|
-            respond_to_missing_def?(sibling)
+          node.parent.each_child_node(node.type).any? do |sibling|
+            if node.def_type?
+              respond_to_missing_def?(sibling)
+            elsif node.defs_type?
+              respond_to_missing_defs?(sibling)
+            end
           end
         end
 
         def_node_matcher :respond_to_missing_def?, <<-PATTERN
           (def :respond_to_missing? (...) ...)
+        PATTERN
+
+        def_node_matcher :respond_to_missing_defs?, <<-PATTERN
+          (defs (self) :respond_to_missing? (...) ...)
         PATTERN
       end
     end

--- a/spec/rubocop/cop/style/method_missing_spec.rb
+++ b/spec/rubocop/cop/style/method_missing_spec.rb
@@ -65,12 +65,38 @@ describe RuboCop::Cop::Style::MethodMissing do
   end
 
   describe 'when implementing #respond_to_missing? and calling #super' do
-    it_behaves_like 'code without offense',
-                    ['class Test',
-                     '  def respond_to_missing?; end',
-                     '  def method_missing',
-                     '    super',
-                     '  end',
-                     'end'].join("\n")
+    context 'when implemented as instance methods' do
+      it_behaves_like 'code without offense',
+                      ['class Test',
+                       '  def respond_to_missing?; end',
+                       '  def method_missing',
+                       '    super',
+                       '  end',
+                       'end'].join("\n")
+    end
+
+    context 'when implemented as class methods' do
+      it_behaves_like 'code without offense',
+                      ['class Test',
+                       '  def self.respond_to_missing?; end',
+                       '  def self.method_missing',
+                       '    super',
+                       '  end',
+                       'end'].join("\n")
+    end
+
+    context 'when implemented with different scopes' do
+      let(:message) do
+        'When using `method_missing`, define `respond_to_missing?`.'
+      end
+
+      it_behaves_like 'code with offense',
+                      ['class Test',
+                       '  def respond_to_missing?; end',
+                       '  def self.method_missing',
+                       '    super',
+                       '  end',
+                       'end'].join("\n")
+    end
   end
 end


### PR DESCRIPTION
This cop would check for an instance method named `#respond_to_missing?` even if `#method_missing` was implemented as a class method.

This fixes that by ensuring that the cop looks in the same scope, and adds some test cases for the future.