### PR TITLE
Fix RuboCop crash with empty brackets in Style/Next cop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 * [#3347](https://github.com/bbatsov/rubocop/issues/3347): Prevent infinite loop in `Style/TernaryParentheses` cop when used together with `Style/RedundantParentheses`. ([@drenmi][])
 * [#3209](https://github.com/bbatsov/rubocop/issues/3209): Remove faulty line length check from `Style/GuardClause` cop. ([@drenmi][])
 * [#3366](https://github.com/bbatsov/rubocop/issues/3366): Make `Style/MutableConstant` cop aware of splat assignments. ([@drenmi][])
+* [#3372](https://github.com/bbatsov/rubocop/pull/3372): Fix RuboCop crash with empty brackets in `Style/Next` cop. ([@pocke][])
 
 ### Changes
 

--- a/lib/rubocop/cop/style/next.rb
+++ b/lib/rubocop/cop/style/next.rb
@@ -81,6 +81,7 @@ module RuboCop
         end
 
         def simple_if_without_break?(node)
+          return false unless node
           return false unless if_without_else?(node)
           return false if style == :skip_modifier_ifs && modifier_if?(node)
           return false if !modifier_if?(node) && !min_body_length?(node)

--- a/spec/rubocop/cop/style/next_spec.rb
+++ b/spec/rubocop/cop/style/next_spec.rb
@@ -443,6 +443,13 @@ describe RuboCop::Cop::Style::Next, :config do
     expect(cop.offenses).to be_empty
   end
 
+  it 'does not crash with empty brackets' do
+    inspect_source(cop, ['loop do',
+                         '  ()',
+                         'end'])
+    expect(cop.offenses).to be_empty
+  end
+
   context 'MinBodyLength: 3' do
     let(:cop_config) do
       { 'MinBodyLength' => 3 }


### PR DESCRIPTION
Problem
---------

RuboCop crashes with empty brackets on Style/Next cop.

Reproduce
---------

`test.rb`

```ruby
loop do
  ()
end
```

```sh
$ rubocop -v
0.42.0
$ rubocop -d test.rb --cache false
For /home/pocke/ghq/github.com/bbatsov/rubocop: configuration from /home/pocke/ghq/github.com/bbatsov/rubocop/.rubocop.yml
Inheriting configuration from /home/pocke/ghq/github.com/bbatsov/rubocop/.rubocop_todo.yml
Default configuration from /home/pocke/.gem/ruby/2.3.0/gems/rubocop-0.42.0/config/default.yml
Inheriting configuration from /home/pocke/.gem/ruby/2.3.0/gems/rubocop-0.42.0/config/enabled.yml
Inheriting configuration from /home/pocke/.gem/ruby/2.3.0/gems/rubocop-0.42.0/config/disabled.yml
Inspecting 1 file
Scanning /home/pocke/ghq/github.com/bbatsov/rubocop/test.rb
An error occurred while Style/Next cop was inspecting /home/pocke/ghq/github.com/bbatsov/rubocop/test.rb.
undefined method `if_type?' for nil:NilClass
/home/pocke/.gem/ruby/2.3.0/gems/rubocop-0.42.0/lib/rubocop/cop/style/next.rb:92:in `if_without_else?'
/home/pocke/.gem/ruby/2.3.0/gems/rubocop-0.42.0/lib/rubocop/cop/style/next.rb:84:in `simple_if_without_break?'
/home/pocke/.gem/ruby/2.3.0/gems/rubocop-0.42.0/lib/rubocop/cop/style/next.rb:80:in `ends_with_condition?'
/home/pocke/.gem/ruby/2.3.0/gems/rubocop-0.42.0/lib/rubocop/cop/style/next.rb:44:in `on_block'
/home/pocke/.gem/ruby/2.3.0/gems/rubocop-0.42.0/lib/rubocop/cop/commissioner.rb:42:in `block (2 levels) in on_block'
/home/pocke/.gem/ruby/2.3.0/gems/rubocop-0.42.0/lib/rubocop/cop/commissioner.rb:97:in `with_cop_error_handling'
/home/pocke/.gem/ruby/2.3.0/gems/rubocop-0.42.0/lib/rubocop/cop/commissioner.rb:41:in `block in on_block'
/home/pocke/.gem/ruby/2.3.0/gems/rubocop-0.42.0/lib/rubocop/cop/commissioner.rb:40:in `each'
/home/pocke/.gem/ruby/2.3.0/gems/rubocop-0.42.0/lib/rubocop/cop/commissioner.rb:40:in `on_block'
/home/pocke/.gem/ruby/2.3.0/gems/rubocop-0.42.0/lib/rubocop/ast_node/traversal.rb:13:in `walk'
/home/pocke/.gem/ruby/2.3.0/gems/rubocop-0.42.0/lib/rubocop/cop/commissioner.rb:59:in `investigate'
/home/pocke/.gem/ruby/2.3.0/gems/rubocop-0.42.0/lib/rubocop/cop/team.rb:121:in `investigate'
/home/pocke/.gem/ruby/2.3.0/gems/rubocop-0.42.0/lib/rubocop/cop/team.rb:109:in `offenses'
/home/pocke/.gem/ruby/2.3.0/gems/rubocop-0.42.0/lib/rubocop/cop/team.rb:52:in `inspect_file'
/home/pocke/.gem/ruby/2.3.0/gems/rubocop-0.42.0/lib/rubocop/runner.rb:223:in `inspect_file'
/home/pocke/.gem/ruby/2.3.0/gems/rubocop-0.42.0/lib/rubocop/runner.rb:193:in `block in do_inspection_loop'
/home/pocke/.gem/ruby/2.3.0/gems/rubocop-0.42.0/lib/rubocop/runner.rb:183:in `loop'
/home/pocke/.gem/ruby/2.3.0/gems/rubocop-0.42.0/lib/rubocop/runner.rb:183:in `do_inspection_loop'
/home/pocke/.gem/ruby/2.3.0/gems/rubocop-0.42.0/lib/rubocop/runner.rb:93:in `block in file_offenses'
/home/pocke/.gem/ruby/2.3.0/gems/rubocop-0.42.0/lib/rubocop/runner.rb:103:in `file_offense_cache'
/home/pocke/.gem/ruby/2.3.0/gems/rubocop-0.42.0/lib/rubocop/runner.rb:91:in `file_offenses'
/home/pocke/.gem/ruby/2.3.0/gems/rubocop-0.42.0/lib/rubocop/runner.rb:82:in `process_file'
/home/pocke/.gem/ruby/2.3.0/gems/rubocop-0.42.0/lib/rubocop/runner.rb:59:in `block in inspect_files'
/home/pocke/.gem/ruby/2.3.0/gems/rubocop-0.42.0/lib/rubocop/runner.rb:57:in `each'
/home/pocke/.gem/ruby/2.3.0/gems/rubocop-0.42.0/lib/rubocop/runner.rb:57:in `inspect_files'
/home/pocke/.gem/ruby/2.3.0/gems/rubocop-0.42.0/lib/rubocop/runner.rb:35:in `run'
/home/pocke/.gem/ruby/2.3.0/gems/rubocop-0.42.0/lib/rubocop/cli.rb:72:in `execute_runner'
/home/pocke/.gem/ruby/2.3.0/gems/rubocop-0.42.0/lib/rubocop/cli.rb:28:in `run'
/home/pocke/.gem/ruby/2.3.0/gems/rubocop-0.42.0/bin/rubocop:14:in `block in <top (required)>'
/usr/lib/ruby/2.3.0/benchmark.rb:308:in `realtime'
/home/pocke/.gem/ruby/2.3.0/gems/rubocop-0.42.0/bin/rubocop:13:in `<top (required)>'
/home/pocke/.gem/ruby/2.3.0/bin//rubocop:23:in `load'
/home/pocke/.gem/ruby/2.3.0/bin//rubocop:23:in `<main>'
C

Offenses:

test.rb:1:1: C: Style/Encoding: Missing utf-8 encoding comment.
loop do
^^^^^^^
test.rb:1:1: C: Style/FrozenStringLiteralComment: Missing frozen string literal comment.
loop do
^

1 file inspected, 2 offenses detected

1 error occurred:
An error occurred while Style/Next cop was inspecting /home/pocke/ghq/github.com/bbatsov/rubocop/test.rb.
Errors are usually caused by RuboCop bugs.
Please, report your problems to RuboCop's issue tracker.
Mention the following information in the issue report:
0.42.0 (using Parser 2.3.1.2, running on ruby 2.3.1 x86_64-linux)
Finished in 0.06772538200311828 seconds
```

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Used the same coding conventions as the rest of the project.
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [ ] All tests are passing.
* [ ] The new code doesn't generate RuboCop offenses.
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.

[1]: http://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html

