### PR TITLE
[Fix #3358] Fix crash on shadowed exception cop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 * [#3366](https://github.com/bbatsov/rubocop/issues/3366): Make `Style/MutableConstant` cop aware of splat assignments. ([@drenmi][])
 * [#3372](https://github.com/bbatsov/rubocop/pull/3372): Fix RuboCop crash with empty brackets in `Style/Next` cop. ([@pocke][])
 * [#3358](https://github.com/bbatsov/rubocop/issues/3358): Make `Style/MethodMissing` cop aware of class scope. ([@drenmi][])
+* [#3342](https://github.com/bbatsov/rubocop/issues/3342): Fix error in `Lint/ShadowedException` cop if last rescue does not have parameter. ([@soutaro][])
 
 ### Changes
 
@@ -2317,3 +2318,4 @@
 [@sooyang]: https://github.com/sooyang
 [@metcalf]: https://github.com/metcalf
 [@annaswims]: https://github.com/annaswims
+[@soutaro]: https://github.com/soutaro

--- a/lib/rubocop/cop/lint/shadowed_exception.rb
+++ b/lib/rubocop/cop/lint/shadowed_exception.rb
@@ -54,9 +54,15 @@ module RuboCop
           first_rescue = rescues.first
           last_rescue = rescues.last
           last_exceptions, = *last_rescue
+          # last_rescue clause may not specify exception class
+          end_pos = if last_exceptions
+                      last_exceptions.loc.expression.end_pos
+                    else
+                      last_rescue.loc.keyword.end_pos
+                    end
           Parser::Source::Range.new(node.loc.expression.source_buffer,
                                     first_rescue.loc.expression.begin_pos,
-                                    last_exceptions.loc.expression.end_pos)
+                                    end_pos)
         end
 
         def rescue_modifier?(node)

--- a/spec/rubocop/cop/lint/shadowed_exception_spec.rb
+++ b/spec/rubocop/cop/lint/shadowed_exception_spec.rb
@@ -416,5 +416,31 @@ describe RuboCop::Cop::Lint::ShadowedException do
 
       expect(cop.offenses).to be_empty
     end
+
+    context 'last rescue does not specify exception class' do
+      let(:source) do
+        ['begin',
+         'rescue A, B',
+         '  do_something',
+         'rescue C',
+         '  do_something',
+         'rescue',
+         '  do_something',
+         'end']
+      end
+
+      it 'does not raise error' do
+        expect { inspect_source(cop, source) }.not_to raise_error
+      end
+
+      it 'highlights range ending at rescue keyword' do
+        inspect_source(cop, source)
+        expect(cop.highlights).to eq([['rescue A, B',
+                                       '  do_something',
+                                       'rescue C',
+                                       '  do_something',
+                                       'rescue'].join("\n")])
+      end
+    end
   end
 end


### PR DESCRIPTION
`Lint/ShadowedException` cop crash if last `rescue` clause does not specify exception class.

```rb
begin
rescue A, B
rescue C
rescue
end
```

This is because offense location calculation is based on exception class specified by last `rescue` clause. This PR fixes the issue by using location of `rescue` keyword if last clause does not have exception class.

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Used the same coding conventions as the rest of the project.
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] All tests are passing.
* [x] The new code doesn't generate RuboCop offenses.
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.

[1]: http://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html

If last `rescue` is without parameter, location calculation of offense raises an `NoMethodError`.

This fixes that by using location of `rescue` keyword in that case.