### PR TITLE
Fix documentation typos in two cops

### DIFF
--- a/lib/rubocop/cop/style/numeric_predicate.rb
+++ b/lib/rubocop/cop/style/numeric_predicate.rb
@@ -4,8 +4,8 @@
 module RuboCop
   module Cop
     module Style
-      # This cop checks for using of comparison operators (`==`, `!=`,
-      # `>`, `<`), to test numbers as zero, nonzero, positive, or negative.
+      # This cop checks for usage of comparison operators (`==`, `!=`,
+      # `>`, `<`) to test numbers as zero, nonzero, positive, or negative.
       # These can be replaced by their respective predicate methods.
       # The cop can also be configured to do the reverse.
       #

--- a/lib/rubocop/cop/style/ternary_parentheses.rb
+++ b/lib/rubocop/cop/style/ternary_parentheses.rb
@@ -4,13 +4,13 @@
 module RuboCop
   module Cop
     module Style
-      # This cop checks for the presence of arentheses around ternary
+      # This cop checks for the presence of parentheses around ternary
       # conditions. It is configurable to enforce inclusion or omission of
       # parentheses using `EnforcedStyle`.
       #
       # @example
       #
-      #   EnforcedStyle: require_no_parentheses (deafault)
+      #   EnforcedStyle: require_no_parentheses (default)
       #
       #   @bad
       #   foo = (bar?) ? a : b
@@ -96,7 +96,7 @@ module RuboCop
 
         # When this cop is configured to enforce parentheses and the
         # `RedundantParentheses` cop is enabled, it will cause an infinite loop
-        # as they compete to add and remove the parens respectively.
+        # as they compete to add and remove the parentheses respectively.
         def infinite_loop?
           require_parentheses? &&
             redundant_parentheses_enabled?


### PR DESCRIPTION
Fix documentation typos in the `Style/NumericPredicate` and `Style/TernaryParentheses` cops.

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Used the same coding conventions as the rest of the project.
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [ ] Added tests. 👉 **N/A**
* [ ] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format). 👉 **Should this be done for minor stuff like this one?**
* [x] All tests are passing.
* [x] The new code doesn't generate RuboCop offenses.
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.

[1]: http://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html