### PR TITLE
[Fix #3380] Fix false positive in `Style/TrailingUnderscoreVariable` cop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
 * [#3372](https://github.com/bbatsov/rubocop/pull/3372): Fix RuboCop crash with empty brackets in `Style/Next` cop. ([@pocke][])
 * [#3358](https://github.com/bbatsov/rubocop/issues/3358): Make `Style/MethodMissing` cop aware of class scope. ([@drenmi][])
 * [#3342](https://github.com/bbatsov/rubocop/issues/3342): Fix error in `Lint/ShadowedException` cop if last rescue does not have parameter. ([@soutaro][])
+* [#3380](https://github.com/bbatsov/rubocop/issues/3380): Fix false positive in `Style/TrailingUnderscoreVariable` cop. ([@drenmi][])
 
 ### Changes
 

--- a/spec/rubocop/cop/style/trailing_underscore_variable_spec.rb
+++ b/spec/rubocop/cop/style/trailing_underscore_variable_spec.rb
@@ -86,6 +86,13 @@ describe RuboCop::Cop::Style::TrailingUnderscoreVariable do
       expect(cop.messages).to be_empty
     end
 
+    it 'does not register an offense for an underscore preceded by a ' \
+       'splat variable and another underscore' do
+      inspect_source(cop, '_, *b, _ = *foo')
+
+      expect(cop.messages).to be_empty
+    end
+
     it 'does not register an offense for multiple underscores preceded by a ' \
        'splat variable' do
       inspect_source(cop, 'a, *b, _, _ = foo()')


### PR DESCRIPTION
This cop would report offenses on destructuring code like:

```
_, *rest, _ = *arr
```

but the trailing `_` is needed to indicate how many tail nodes should be dropped when destructuring.

The reason was that when indexing into the child nodes, the first and last node are considered equal.

This change fixes that and adds a test case for the future.