### PR TITLE
[Fix #3388] Fix bug in ShadowedException when rescuing multiple custom exceptions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@
 * [#3358](https://github.com/bbatsov/rubocop/issues/3358): Make `Style/MethodMissing` cop aware of class scope. ([@drenmi][])
 * [#3342](https://github.com/bbatsov/rubocop/issues/3342): Fix error in `Lint/ShadowedException` cop if last rescue does not have parameter. ([@soutaro][])
 * [#3380](https://github.com/bbatsov/rubocop/issues/3380): Fix false positive in `Style/TrailingUnderscoreVariable` cop. ([@drenmi][])
+* [#3388](https://github.com/bbatsov/rubocop/issues/3388): Fix bug where `Lint/ShadowedException` would register an offense when rescuing different numbers of custom exceptions in multiple rescue groups. ([@rrosenblum][])
 
 ### Changes
 

--- a/lib/rubocop/cop/lint/shadowed_exception.rb
+++ b/lib/rubocop/cop/lint/shadowed_exception.rb
@@ -116,7 +116,9 @@ module RuboCop
               1
             elsif y.include?(Exception)
               -1
-            elsif x.empty? || y.empty?
+            elsif x.none? || y.none?
+              # do not change the order if a group is empty or only contains
+              # `nil`s
               0
             else
               x <=> y || 0

--- a/spec/rubocop/cop/lint/shadowed_exception_spec.rb
+++ b/spec/rubocop/cop/lint/shadowed_exception_spec.rb
@@ -55,6 +55,16 @@ describe RuboCop::Cop::Lint::ShadowedException do
       expect(cop.offenses).to be_empty
     end
 
+    it 'accepts rescuing multiple custom exceptions' do
+      inspect_source(cop, ['begin',
+                           '  something',
+                           'rescue CustomError, NonStandardException',
+                           '  handle_exception',
+                           'end'])
+
+      expect(cop.offenses).to be_empty
+    end
+
     it 'registers an offense rescuing Exception with any other error or ' \
        'exception' do
       inspect_source(cop, ['begin',
@@ -259,6 +269,18 @@ describe RuboCop::Cop::Lint::ShadowedException do
       expect(cop.offenses).to be_empty
     end
 
+    it 'accepts rescuing custom exceptions in multiple rescue groups' do
+      inspect_source(cop, ['begin',
+                           '  something',
+                           'rescue NonStandardError, OtherError',
+                           '  handle_standard_error',
+                           'rescue CustomError',
+                           '  handle_exception',
+                           'end'])
+
+      expect(cop.offenses).to be_empty
+    end
+
     context 'splat arguments' do
       it 'accepts splat arguments passed to multiple rescues' do
         inspect_source(cop, ['begin',
@@ -435,11 +457,7 @@ describe RuboCop::Cop::Lint::ShadowedException do
 
       it 'highlights range ending at rescue keyword' do
         inspect_source(cop, source)
-        expect(cop.highlights).to eq([['rescue A, B',
-                                       '  do_something',
-                                       'rescue C',
-                                       '  do_something',
-                                       'rescue'].join("\n")])
+        expect(cop.offenses).to be_empty
       end
     end
   end


### PR DESCRIPTION
This fixes #3388. The bug occurred when rescuing multiple custom exceptions in multiple rescue groups. If you rescued a larger number of custom exceptions, in a group, before rescuing a lower number of custom exceptions, then the sort would be thrown off.

Example:
```ruby
begin
  foo
rescue CustomError1, CustomError2
  bar
rescue CustomError3
  baz
end
```

This gets translated to `[[nil, nil], [nil]]`. Sorting that would flip the order to `[[nil], [nil, nil]]`. 