### PR TITLE
improve Cop::Lint::ShadowedException documentation

### DIFF
--- a/lib/rubocop/cop/lint/shadowed_exception.rb
+++ b/lib/rubocop/cop/lint/shadowed_exception.rb
@@ -8,24 +8,25 @@ module RuboCop
       # less specific exception being rescued before a more specific
       # exception is rescued.
       #
-      # @example
-      # # bad
-      # begin
-      #   something
-      # rescue Exception
-      #   handle_exception
-      # rescue StandardError
-      #   handle_standard_error
-      # end
+      #   @example
       #
-      # #good
-      # begin
-      #   something
-      # rescue StandardError
-      #   handle_standard_error
-      # rescue Exception
-      #   handle_exception
-      # end
+      #   # bad
+      #   begin
+      #     something
+      #   rescue Exception
+      #     handle_exception
+      #   rescue StandardError
+      #     handle_standard_error
+      #   end
+      #
+      #   # good
+      #   begin
+      #     something
+      #   rescue StandardError
+      #     handle_standard_error
+      #   rescue Exception
+      #     handle_exception
+      #   end
       class ShadowedException < Cop
         MSG = 'Do not shadow rescued Exceptions'.freeze
 


### PR DESCRIPTION
There is an example code in docs which isn't properly RDoc formatted ([link](http://www.rubydoc.info/gems/rubocop/RuboCop/Cop/Lint/ShadowedException)). This PR fixes that.

You could preview generated docs with following command (`open` is OS X specific):

```bash
rdoc lib/rubocop/cop/lint/shadowed_exception.rb -o ./result && open result/index.html
```