### PR TITLE
[Fix #3386] Make `VariableForce` understand empty RegExp as LHS of `=~`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@
 * [#3342](https://github.com/bbatsov/rubocop/issues/3342): Fix error in `Lint/ShadowedException` cop if last rescue does not have parameter. ([@soutaro][])
 * [#3380](https://github.com/bbatsov/rubocop/issues/3380): Fix false positive in `Style/TrailingUnderscoreVariable` cop. ([@drenmi][])
 * [#3388](https://github.com/bbatsov/rubocop/issues/3388): Fix bug where `Lint/ShadowedException` would register an offense when rescuing different numbers of custom exceptions in multiple rescue groups. ([@rrosenblum][])
+* [#3386](https://github.com/bbatsov/rubocop/issues/3386): Make `VariableForce` understand an empty RegExp literal as LHS to `=~`. ([@drenmi][])
 
 ### Changes
 

--- a/lib/rubocop/cop/variable_force.rb
+++ b/lib/rubocop/cop/variable_force.rb
@@ -159,7 +159,7 @@ module RuboCop
       def process_regexp_named_captures(node)
         regexp_node, rhs_node = *node
 
-        regexp_string = regexp_node.children[0].children[0]
+        regexp_string = regexp_node.children[0].children[0] || ''
         regexp = Regexp.new(regexp_string)
         variable_names = regexp.named_captures.keys
 

--- a/spec/rubocop/cop/variable_force_spec.rb
+++ b/spec/rubocop/cop/variable_force_spec.rb
@@ -23,5 +23,13 @@ describe RuboCop::Cop::VariableForce do
         end
       end
     end
+
+    context 'when processing an empty regex' do
+      let(:node) { s(:match_with_lvasgn, s(:regexp, s(:regopt)), s(:str)) }
+
+      it 'does not raise an error' do
+        expect { force.process_node(node) }.not_to raise_error
+      end
+    end
   end
 end


### PR DESCRIPTION
This cop would blow up on code like:

```
if // =~ 'foo'
```

This change fixes that.