### PR TITLE
Disable autocorrect for unsafe rules by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -79,6 +79,7 @@
 * `Lint/InheritException` restricts inheriting from standard library subclasses of `Exception`. ([@metcalf][])
 * No longer register an offense if the first line of code starts with `#\` in `Style/LeadingCommentSpace`. `config.ru` files consider such lines as options. ([@scottohara][])
 * [#3292](https://github.com/bbatsov/rubocop/issues/3292): Remove `Performance/PushSplat` as it can produce code that is slower or even cause failure. ([@jonas054][])
+* [#3407](https://github.com/bbatsov/rubocop/issues/3407): Turn off autocorrect for unsafe rules by default. ([@ptarjan][])
 
 ## 0.42.0 (2016-07-25)
 

--- a/config/enabled.yml
+++ b/config/enabled.yml
@@ -557,6 +557,10 @@ Style/NumericPredicate:
                  Checks for the use of predicate- or comparison methods for
                  numeric comparisons.
   StyleGuide: '#predicate-methods'
+  # This will change to a new a method call which isn't guaranteed to be on the
+  # object. Switching these methods has to be done with knowledge of the types
+  # of the variables which rubocop doesn't have.
+  Autocorrect: false
   Enabled: true
 
 Style/OneLineConditional:
@@ -1311,6 +1315,10 @@ Performance/DoubleStartEndWith:
 Performance/EndWith:
   Description: 'Use `end_with?` instead of a regex match anchored to the end of a string.'
   Reference: 'https://github.com/JuanitoFatas/fast-ruby#stringmatch-vs-stringstart_withstringend_with-code-start-code-end'
+  # This will change to a new a method call which isn't guaranteed to be on the
+  # object. Switching these methods has to be done with knowledge of the types
+  # of the variables which rubocop doesn't have.
+  Autocorrect: false
   Enabled: true
 
 Performance/FixedSize:
@@ -1393,6 +1401,10 @@ Performance/SortWithBlock:
 Performance/StartWith:
   Description: 'Use `start_with?` instead of a regex match anchored to the beginning of a string.'
   Reference: 'https://github.com/JuanitoFatas/fast-ruby#stringmatch-vs-stringstart_withstringend_with-code-start-code-end'
+  # This will change to a new a method call which isn't guaranteed to be on the
+  # object. Switching these methods has to be done with knowledge of the types
+  # of the variables which rubocop doesn't have.
+  Autocorrect: false
   Enabled: true
 
 Performance/StringReplacement:


### PR DESCRIPTION
These changes are unsound and introduce bugs into peoples code if they just do `-a` over an existing codebase. You have to think carefuly about if they object you are operating on has the methods these are adding.

These are the ones I ran into doing a large rubocop migration of our codebase.

Do you know of other rules with this same property (changing one operation to another which isn't guaranteed to be present)?

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Used the same coding conventions as the rest of the project.
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] All tests are passing.
* [x] The new code doesn't generate RuboCop offenses.
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.

[1]: http://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html

