### PR TITLE
Fix clobbering `inherit_from` additions when not using Namespaces in the configs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@
 * [#3380](https://github.com/bbatsov/rubocop/issues/3380): Fix false positive in `Style/TrailingUnderscoreVariable` cop. ([@drenmi][])
 * [#3388](https://github.com/bbatsov/rubocop/issues/3388): Fix bug where `Lint/ShadowedException` would register an offense when rescuing different numbers of custom exceptions in multiple rescue groups. ([@rrosenblum][])
 * [#3386](https://github.com/bbatsov/rubocop/issues/3386): Make `VariableForce` understand an empty RegExp literal as LHS to `=~`. ([@drenmi][])
+* [#3421](https://github.com/bbatsov/rubocop/pull/3421): Fix clobbering `inherit_from` additions when not using Namespaces in the configs. ([@nicklamuro][])
 
 ### Changes
 
@@ -2327,3 +2328,4 @@
 [@metcalf]: https://github.com/metcalf
 [@annaswims]: https://github.com/annaswims
 [@soutaro]: https://github.com/soutaro
+[@nicklamuro]: https://github.com/nicklamuro

--- a/lib/rubocop/config_loader.rb
+++ b/lib/rubocop/config_loader.rb
@@ -33,12 +33,6 @@ module RuboCop
       def load_file(path)
         path = File.absolute_path(path)
         hash = load_yaml_configuration(path)
-
-        resolve_inheritance_from_gems(hash, hash.delete('inherit_gem'))
-        resolve_inheritance(path, hash)
-        resolve_requires(path, hash)
-
-        hash.delete('inherit_from')
         config = Config.new(hash, path)
 
         config.deprecation_check do |deprecation_message|
@@ -46,6 +40,13 @@ module RuboCop
         end
 
         config.add_missing_namespaces
+
+        resolve_inheritance_from_gems(config, config.delete('inherit_gem'))
+        resolve_inheritance(path, config)
+        resolve_requires(path, config)
+
+        config.delete('inherit_from')
+
         config.validate
         config.make_excludes_absolute
         config

--- a/spec/rubocop/config_loader_spec.rb
+++ b/spec/rubocop/config_loader_spec.rb
@@ -252,6 +252,44 @@ describe RuboCop::ConfigLoader do
       end
     end
 
+    context 'when a file inherits and overrides with non-namedspaced cops' do
+      let(:file_path) { '.rubocop.yml' }
+
+      before do
+        create_file('example.rb', '')
+
+        create_file('line_length.yml',
+                    ['LineLength:',
+                     '  Max: 120'])
+
+        create_file(file_path,
+                    ['inherit_from:',
+                     '  - line_length.yml',
+                     '',
+                     'LineLength:',
+                     '  AllowHeredoc: false'])
+      end
+
+      it 'returns includes both of the cop changes' do
+        config =
+          default_config.merge(
+            'Metrics/LineLength' => {
+              'Description' =>
+              default_config['Metrics/LineLength']['Description'],
+              'StyleGuide' =>
+              'https://github.com/bbatsov/ruby-style-guide#80-character-limits',
+              'Enabled' => true,
+              'Max' => 120,             # overridden in line_length.yml
+              'AllowHeredoc' => false,  # overridden in rubocop.yml
+              'AllowURI' => true,
+              'URISchemes' => %w(http https)
+            }
+          )
+
+        expect(configuration_from_file).to eq(config)
+      end
+    end
+
     context 'when a file inherits from an expanded path' do
       let(:file_path) { '.rubocop.yml' }
 


### PR DESCRIPTION
Overview
--------

The current implementation of `load_file` will load the hash from a config, then apply the base_configs to that hash, before converting it to a proper `Config` object, which means we are comparing a vanilla `Hash` with a `Config`, so one will have the converted namespace Cop names, and the other will not.  This can clobber inherited configuration since merging will happen in resolve_inheritance, but will just keep the keys from both and then when `add_missing_namespaces` is called, one will be dropped.

Since `Config` inherits from `Hash`, there shouldn't be a problem with doing the `resolve_*` methods after the `config = Config.new` line since all the normal Hash methods are available (.delete specifically).


Example (before this change)
----------------------------

Given the following files:

**.rubocop.yml**

```yaml
inherit_from: ["base.yml"]

LineLength:
  Exclude: ["Gemfile"]
```

**base.yml**
```yaml
LineLength:
  Max: 120
```

* `.rubocop.yml` is loaded through the `load_file` method
  
* it, in turn, loads `base.yml` when called in `base_configs` from `resovle_inheritance`
  
* When `add_missing_namespaces` is called on `base.yml`, it converts `{"LineLength" => {"Max" => 120}}` to have `"Metrics/LineLength"`, and deletes old `"LineLength"` key
  
* The unconverted hash of '.rubocop.yml` is then merged with the converted `base.yml`, and so the following hash exists:
  
  ```ruby
  {
    "LineLength"         => {"Exclude" => ["Gemfile"]},
    "Metrics/LineLength" => {"Max"     => 120}
  }
  ```
  
* When `add_missing_namespaces` is called on the now merged `.rubocop.yml` config, it will delete the changes from `"Metrics/LineLength" => {"Max"     => 120}` when converting `"LineLength"` to have a namespace, and the default `LineLength` max value will be used instead.

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Used the same coding conventions as the rest of the project.
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] All tests are passing.
* [x] The new code doesn't generate RuboCop offenses.
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.

[1]: http://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html