### PR TITLE
[fixes #3423] checks if .rubocop is a file before parsing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@
 * Fix error in `Lint/ShadowedException` cop for higher number of rescue groups. ([@groddeck][])
 [@groddeck]: https://github.com/groddeck
 * [#3456](https://github.com/bbatsov/rubocop/pull/3456): Don't crash on a multiline empty brace in `Style/MultilineMethodCallBraceLayout`. ([@pocke][])
+* [#3423](https://github.com/bbatsov/rubocop/issues/3423): Checks if .rubocop is a file before parsing. ([@joejuzl][])
 
 ### Changes
 
@@ -2338,3 +2339,4 @@
 [@soutaro]: https://github.com/soutaro
 [@nicklamuro]: https://github.com/nicklamuro
 [@mikezter]: https://github.com/mikezter
+[@joejuzl]: https://github.com/joejuzl

--- a/lib/rubocop/options.rb
+++ b/lib/rubocop/options.rb
@@ -34,7 +34,7 @@ module RuboCop
     private
 
     def args_from_file
-      if File.exist?('.rubocop')
+      if File.exist?('.rubocop') && !File.directory?('.rubocop')
         IO.readlines('.rubocop').map(&:strip)
       else
         []

--- a/spec/rubocop/options_spec.rb
+++ b/spec/rubocop/options_spec.rb
@@ -290,6 +290,16 @@ Usage: rubocop [options] [file1, file2, ...]
       end
     end
 
+    context '.rubocop directory' do
+      before do
+        FileUtils.mkdir '.rubocop'
+      end
+
+      it 'is ignored and command line options are used' do
+        is_expected.to eq(color: false)
+      end
+    end
+
     context 'RUBOCOP_OPTS environment variable' do
       it 'has lower precedence then command line options' do
         with_env_options '--color' do


### PR DESCRIPTION
### Problem:

Rubocop errors when there is a directory named .rubocop

### Expected behavior

Use the .rubocop.yml config

### Actual behavior

```
Is a directory @ io_fillbuf - fd:7 .rubocop
/Users/joejuzl/.rbenv/versions/2.2.3/lib/ruby/gems/2.2.0/gems/rubocop-0.42.0/lib/rubocop/options.rb:38:in `readlines'
/Users/joejuzl/.rbenv/versions/2.2.3/lib/ruby/gems/2.2.0/gems/rubocop-0.42.0/lib/rubocop/options.rb:38:in `args_from_file'
/Users/joejuzl/.rbenv/versions/2.2.3/lib/ruby/gems/2.2.0/gems/rubocop-0.42.0/lib/rubocop/options.rb:19:in `parse'
/Users/joejuzl/.rbenv/versions/2.2.3/lib/ruby/gems/2.2.0/gems/rubocop-0.42.0/lib/rubocop/cli.rb:24:in `run'
/Users/joejuzl/.rbenv/versions/2.2.3/lib/ruby/gems/2.2.0/gems/rubocop-0.42.0/bin/rubocop:14:in `block in <top (required)>'
/Users/joejuzl/.rbenv/versions/2.2.3/lib/ruby/2.2.0/benchmark.rb:303:in `realtime'
/Users/joejuzl/.rbenv/versions/2.2.3/lib/ruby/gems/2.2.0/gems/rubocop-0.42.0/bin/rubocop:13:in `<top (required)>'
/Users/joejuzl/.rbenv/versions/2.2.3/bin/rubocop:22:in `load'
/Users/joejuzl/.rbenv/versions/2.2.3/bin/rubocop:22:in `<main>'
```

## Solution:

Check that `.rubocop` is not a directory before parsing.

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Used the same coding conventions as the rest of the project.
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] All tests are passing.
* [x] The new code doesn't generate RuboCop offenses.
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.

[1]: http://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html

