### PR TITLE
Fix bug for invalid bytes in UTF-8 in `Lint/PercentStringArray` cop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@
 * [#3388](https://github.com/bbatsov/rubocop/issues/3388): Fix bug where `Lint/ShadowedException` would register an offense when rescuing different numbers of custom exceptions in multiple rescue groups. ([@rrosenblum][])
 * [#3386](https://github.com/bbatsov/rubocop/issues/3386): Make `VariableForce` understand an empty RegExp literal as LHS to `=~`. ([@drenmi][])
 * [#3421](https://github.com/bbatsov/rubocop/pull/3421): Fix clobbering `inherit_from` additions when not using Namespaces in the configs. ([@nicklamuro][])
+* [#3425](https://github.com/bbatsov/rubocop/pull/3425): Fix bug for invalid bytes in UTF-8 in `Lint/PercentStringArray` cop. ([@pocke][])
 
 ### Changes
 

--- a/lib/rubocop/cop/lint/percent_string_array.rb
+++ b/lib/rubocop/cop/lint/percent_string_array.rb
@@ -33,7 +33,7 @@ module RuboCop
           patterns = [/,$/, /^'.*'$/, /^".*"$/]
 
           node.children.any? do |child|
-            literal = child.children.first
+            literal = scrub_string(child.children.first)
 
             # To avoid likely false positives (e.g. a single ' or ")
             next if literal.to_s.gsub(/[^\p{Alnum}]/, '').empty?
@@ -52,6 +52,17 @@ module RuboCop
 
               corrector.remove_leading(range, 1) if /^['"]/ =~ range.source
             end
+          end
+        end
+
+        def scrub_string(string)
+          if string.respond_to?(:scrub)
+            string.scrub
+          else
+            string
+              .encode('UTF-16BE', 'UTF-8',
+                      invalid: :replace, undef: :replace, replace: '?')
+              .encode('UTF-8')
           end
         end
       end

--- a/spec/rubocop/cop/lint/percent_string_array_spec.rb
+++ b/spec/rubocop/cop/lint/percent_string_array_spec.rb
@@ -22,7 +22,7 @@ describe RuboCop::Cop::Lint::PercentStringArray do
         expect(cop.offenses).to be_empty
       end
 
-      [%(%w(' ")), %(%w(' " ! = #)), ':"#{a}"'].each do |false_positive|
+      [%(%w(' ")), %(%w(' " ! = # ,)), ':"#{a}"'].each do |false_positive|
         it "accepts likely false positive #{false_positive}" do
           inspect_source(cop, false_positive)
 
@@ -64,6 +64,18 @@ describe RuboCop::Cop::Lint::PercentStringArray do
 
     it 'removes undesireable characters' do
       expect(autocorrect_source(cop, source)).to eq(expected_corrected_source)
+    end
+  end
+
+  context 'with invalid byte sequence in UTF-8' do
+    it 'add an offences if tokens contain quotes' do
+      expect_offense('%W("a\255\255")')
+    end
+
+    it 'accepts if tokens contain invalid byte sequence only' do
+      inspect_source(cop, '%W(\255)')
+
+      expect(cop.offenses).to be_empty
     end
   end
 end


### PR DESCRIPTION
When RuboCop analyses the following code, RuboCop crashes.

`test.rb`

```
%W(\255)
```


Reproduce
------

```sh
$ rubocop --debug test.rb
```

## Expected behavior

RuboCop doesn't crash.

## Actual behavior

got the following error.

```
For /Users/masataka-kuwabara/ghq/github.com/bbatsov/rubocop: configuration from /Users/masataka-kuwabara/ghq/github.com/bbatsov/rubocop/.rubocop.yml
Inheriting configuration from /Users/masataka-kuwabara/ghq/github.com/bbatsov/rubocop/.rubocop_todo.yml
Default configuration from /Users/masataka-kuwabara/.gem/ruby/2.3.0/gems/rubocop-0.42.0/config/default.yml
Inheriting configuration from /Users/masataka-kuwabara/.gem/ruby/2.3.0/gems/rubocop-0.42.0/config/enabled.yml
Inheriting configuration from /Users/masataka-kuwabara/.gem/ruby/2.3.0/gems/rubocop-0.42.0/config/disabled.yml
Inspecting 1 file
Scanning /Users/masataka-kuwabara/ghq/github.com/bbatsov/rubocop/test.rb
invalid byte sequence in UTF-8
/Users/masataka-kuwabara/.gem/ruby/2.3.0/gems/rubocop-0.42.0/lib/rubocop/cop/lint/percent_string_array.rb:39:in `gsub'
/Users/masataka-kuwabara/.gem/ruby/2.3.0/gems/rubocop-0.42.0/lib/rubocop/cop/lint/percent_string_array.rb:39:in `block in contains_quotes_or_commas?'
/Users/masataka-kuwabara/.gem/ruby/2.3.0/gems/rubocop-0.42.0/lib/rubocop/cop/lint/percent_string_array.rb:35:in `any?'
/Users/masataka-kuwabara/.gem/ruby/2.3.0/gems/rubocop-0.42.0/lib/rubocop/cop/lint/percent_string_array.rb:35:in `contains_quotes_or_commas?'
/Users/masataka-kuwabara/.gem/ruby/2.3.0/gems/rubocop-0.42.0/lib/rubocop/cop/lint/percent_string_array.rb:25:in `on_percent_literal'
/Users/masataka-kuwabara/.gem/ruby/2.3.0/gems/rubocop-0.42.0/lib/rubocop/cop/mixin/percent_literal.rb:15:in `process'
/Users/masataka-kuwabara/.gem/ruby/2.3.0/gems/rubocop-0.42.0/lib/rubocop/cop/lint/percent_string_array.rb:21:in `on_array'
/Users/masataka-kuwabara/.gem/ruby/2.3.0/gems/rubocop-0.42.0/lib/rubocop/cop/commissioner.rb:42:in `block (2 levels) in on_array'
/Users/masataka-kuwabara/.gem/ruby/2.3.0/gems/rubocop-0.42.0/lib/rubocop/cop/commissioner.rb:97:in `with_cop_error_handling'
/Users/masataka-kuwabara/.gem/ruby/2.3.0/gems/rubocop-0.42.0/lib/rubocop/cop/commissioner.rb:41:in `block in on_array'
/Users/masataka-kuwabara/.gem/ruby/2.3.0/gems/rubocop-0.42.0/lib/rubocop/cop/commissioner.rb:40:in `each'
/Users/masataka-kuwabara/.gem/ruby/2.3.0/gems/rubocop-0.42.0/lib/rubocop/cop/commissioner.rb:40:in `on_array'
/Users/masataka-kuwabara/.gem/ruby/2.3.0/gems/rubocop-0.42.0/lib/rubocop/ast_node/traversal.rb:13:in `walk'
/Users/masataka-kuwabara/.gem/ruby/2.3.0/gems/rubocop-0.42.0/lib/rubocop/cop/commissioner.rb:59:in `investigate'
/Users/masataka-kuwabara/.gem/ruby/2.3.0/gems/rubocop-0.42.0/lib/rubocop/cop/team.rb:121:in `investigate'
/Users/masataka-kuwabara/.gem/ruby/2.3.0/gems/rubocop-0.42.0/lib/rubocop/cop/team.rb:109:in `offenses'
/Users/masataka-kuwabara/.gem/ruby/2.3.0/gems/rubocop-0.42.0/lib/rubocop/cop/team.rb:52:in `inspect_file'
/Users/masataka-kuwabara/.gem/ruby/2.3.0/gems/rubocop-0.42.0/lib/rubocop/runner.rb:228:in `inspect_file'
/Users/masataka-kuwabara/.gem/ruby/2.3.0/gems/rubocop-0.42.0/lib/rubocop/runner.rb:198:in `block in do_inspection_loop'
/Users/masataka-kuwabara/.gem/ruby/2.3.0/gems/rubocop-0.42.0/lib/rubocop/runner.rb:188:in `loop'
/Users/masataka-kuwabara/.gem/ruby/2.3.0/gems/rubocop-0.42.0/lib/rubocop/runner.rb:188:in `do_inspection_loop'
/Users/masataka-kuwabara/.gem/ruby/2.3.0/gems/rubocop-0.42.0/lib/rubocop/runner.rb:93:in `block in file_offenses'
/Users/masataka-kuwabara/.gem/ruby/2.3.0/gems/rubocop-0.42.0/lib/rubocop/runner.rb:103:in `file_offense_cache'
/Users/masataka-kuwabara/.gem/ruby/2.3.0/gems/rubocop-0.42.0/lib/rubocop/runner.rb:91:in `file_offenses'
/Users/masataka-kuwabara/.gem/ruby/2.3.0/gems/rubocop-0.42.0/lib/rubocop/runner.rb:82:in `process_file'
/Users/masataka-kuwabara/.gem/ruby/2.3.0/gems/rubocop-0.42.0/lib/rubocop/runner.rb:59:in `block in inspect_files'
/Users/masataka-kuwabara/.gem/ruby/2.3.0/gems/rubocop-0.42.0/lib/rubocop/runner.rb:57:in `each'
/Users/masataka-kuwabara/.gem/ruby/2.3.0/gems/rubocop-0.42.0/lib/rubocop/runner.rb:57:in `inspect_files'
/Users/masataka-kuwabara/.gem/ruby/2.3.0/gems/rubocop-0.42.0/lib/rubocop/runner.rb:35:in `run'
/Users/masataka-kuwabara/.gem/ruby/2.3.0/gems/rubocop-0.42.0/lib/rubocop/cli.rb:72:in `execute_runner'
/Users/masataka-kuwabara/.gem/ruby/2.3.0/gems/rubocop-0.42.0/lib/rubocop/cli.rb:28:in `run'
/Users/masataka-kuwabara/.gem/ruby/2.3.0/gems/rubocop-0.42.0/bin/rubocop:14:in `block in <top (required)>'
/Users/masataka-kuwabara/.rbenv/versions/2.3.1/lib/ruby/2.3.0/benchmark.rb:308:in `realtime'
/Users/masataka-kuwabara/.gem/ruby/2.3.0/gems/rubocop-0.42.0/bin/rubocop:13:in `<top (required)>'
/Users/masataka-kuwabara/.rbenv/versions/2.3/bin/rubocop:23:in `load'
/Users/masataka-kuwabara/.rbenv/versions/2.3/bin/rubocop:23:in `<main>'
C

Offenses:

test.rb:1:1: C: Style/Encoding: Missing utf-8 encoding comment.
%W(\255)
^^^^^^^^
test.rb:1:1: C: Style/FrozenStringLiteralComment: Missing frozen string literal comment.
%W(\255)
^

1 file inspected, 2 offenses detected
Finished in 0.10227428999860422 seconds
```


## Note


~~`scrub_rb` gem is an implementation of `String#scrub` by pure ruby. `String#scrub` doesn't exist older than ruby 2.0. So, I've added the gem as a new runtime_dependency.~~

## RuboCop version

current HEAD of master branch.


```
$ rubocop -V
0.42.0 (using Parser 2.3.1.2, running on ruby 2.3.1 x86_64-darwin15)
```

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Used the same coding conventions as the rest of the project.
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] All tests are passing.
* [x] The new code doesn't generate RuboCop offenses.
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.

[1]: http://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html

