### PR TITLE
Restrict inheriting from other subclasses of Exception

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@
 * [#3341](https://github.com/bbatsov/rubocop/issues/3341): Exclude RSpec tests from inspection by `Style/NumericPredicate` cop. ([@drenmi][])
 * Rename `Lint/UselessArraySplat` to `Lint/UnneededSplatExpansion`, and add functionality to check for unnecessary expansion of other literals. ([@rrosenblum][])
 * No longer register an offense for splat expansion of an array literal in `Performance/CaseWhenSplat`. `Lint/UnneededSplatExpansion` now handles this behavior. ([@rrosenblum][])
+* `Lint/InheritException` restricts inheriting from standard library subclasses of `Exception`. ([@metcalf][])
 
 ## 0.42.0 (2016-07-25)
 


### PR DESCRIPTION
The Lint/InheritException cop currently prevents inheriting from Exception and suggests inheriting from RuntimeError or StandardError instead. This updates it to restrict inheriting from the other subclasses of Exception in the standard library that aren't themselves subclasses of StandardError. I did not add a separate test for this behavior since it would be largely duplicative of the existing test logic.

