### PR TITLE
Fix bug for string interpolation in `Lint/PercentStringArray`

### DIFF
--- a/lib/rubocop/cop/lint/percent_string_array.rb
+++ b/lib/rubocop/cop/lint/percent_string_array.rb
@@ -33,10 +33,10 @@ module RuboCop
           patterns = [/,$/, /^'.*'$/, /^".*"$/]
 
           node.children.any? do |child|
-            literal = scrub_string(child.children.first)
+            literal = scrub_string(child.children.first.to_s)
 
             # To avoid likely false positives (e.g. a single ' or ")
-            next if literal.to_s.gsub(/[^\p{Alnum}]/, '').empty?
+            next if literal.gsub(/[^\p{Alnum}]/, '').empty?
 
             patterns.any? { |pat| literal =~ pat }
           end

--- a/spec/rubocop/cop/lint/percent_string_array_spec.rb
+++ b/spec/rubocop/cop/lint/percent_string_array_spec.rb
@@ -22,7 +22,12 @@ describe RuboCop::Cop::Lint::PercentStringArray do
         expect(cop.offenses).to be_empty
       end
 
-      [%(%w(' ")), %(%w(' " ! = # ,)), ':"#{a}"'].each do |false_positive|
+      [
+        %(%#{char}(' ")),
+        %(%#{char}(' " ! = # ,)),
+        ':"#{a}"',
+        %(%#{char}(\#{a} b))
+      ].each do |false_positive|
         it "accepts likely false positive #{false_positive}" do
           inspect_source(cop, false_positive)
 


### PR DESCRIPTION
Sorry, #3425 has a bug. :bow: 
PercentStringArray cop is broken if code has a string interpolation.

I've fixed the bug and added / changed some tests.


Reproduce
--------

`test.rb`

```ruby
%W(#{x} y)
```

```sh
An error occurred while Lint/PercentStringArray cop was inspecting /home/pocke/ghq/github.com/bbatsov/rubocop/test.rb.

1 error occurred:
An error occurred while Lint/PercentStringArray cop was inspecting /home/pocke/ghq/github.com/bbatsov/rubocop/test.rb.
Errors are usually caused by RuboCop bugs.
Please, report your problems to RuboCop's issue tracker.
Mention the following information in the issue report:
0.42.0 (using Parser 2.3.1.2, running on ruby 2.3.1 x86_64-linux)
For /home/pocke/ghq/github.com/bbatsov/rubocop: configuration from /home/pocke/ghq/github.com/bbatsov/rubocop/.rubocop.yml
Inheriting configuration from /home/pocke/ghq/github.com/bbatsov/rubocop/.rubocop_todo.yml
Default configuration from /home/pocke/.gem/ruby/2.3.0/gems/rubocop-0.42.0/config/default.yml
Inheriting configuration from /home/pocke/.gem/ruby/2.3.0/gems/rubocop-0.42.0/config/enabled.yml
Inheriting configuration from /home/pocke/.gem/ruby/2.3.0/gems/rubocop-0.42.0/config/disabled.yml
Inspecting 1 file
Scanning /home/pocke/ghq/github.com/bbatsov/rubocop/test.rb
undefined method `encode' for "s(:begin,\n  s(:send, nil, :x))":RuboCop::Node
/home/pocke/.gem/ruby/2.3.0/gems/rubocop-0.42.0/lib/rubocop/cop/lint/percent_string_array.rb:63:in `scrub_string'
/home/pocke/.gem/ruby/2.3.0/gems/rubocop-0.42.0/lib/rubocop/cop/lint/percent_string_array.rb:36:in `block in contains_quotes_or_commas?'
/home/pocke/.gem/ruby/2.3.0/gems/rubocop-0.42.0/lib/rubocop/cop/lint/percent_string_array.rb:35:in `any?'
/home/pocke/.gem/ruby/2.3.0/gems/rubocop-0.42.0/lib/rubocop/cop/lint/percent_string_array.rb:35:in `contains_quotes_or_commas?'
/home/pocke/.gem/ruby/2.3.0/gems/rubocop-0.42.0/lib/rubocop/cop/lint/percent_string_array.rb:25:in `on_percent_literal'
/home/pocke/.gem/ruby/2.3.0/gems/rubocop-0.42.0/lib/rubocop/cop/mixin/percent_literal.rb:15:in `process'
/home/pocke/.gem/ruby/2.3.0/gems/rubocop-0.42.0/lib/rubocop/cop/lint/percent_string_array.rb:21:in `on_array'
/home/pocke/.gem/ruby/2.3.0/gems/rubocop-0.42.0/lib/rubocop/cop/commissioner.rb:42:in `block (2 levels) in on_array'
/home/pocke/.gem/ruby/2.3.0/gems/rubocop-0.42.0/lib/rubocop/cop/commissioner.rb:97:in `with_cop_error_handling'
/home/pocke/.gem/ruby/2.3.0/gems/rubocop-0.42.0/lib/rubocop/cop/commissioner.rb:41:in `block in on_array'
/home/pocke/.gem/ruby/2.3.0/gems/rubocop-0.42.0/lib/rubocop/cop/commissioner.rb:40:in `each'
/home/pocke/.gem/ruby/2.3.0/gems/rubocop-0.42.0/lib/rubocop/cop/commissioner.rb:40:in `on_array'
/home/pocke/.gem/ruby/2.3.0/gems/rubocop-0.42.0/lib/rubocop/ast_node/traversal.rb:13:in `walk'
/home/pocke/.gem/ruby/2.3.0/gems/rubocop-0.42.0/lib/rubocop/cop/commissioner.rb:59:in `investigate'
/home/pocke/.gem/ruby/2.3.0/gems/rubocop-0.42.0/lib/rubocop/cop/team.rb:121:in `investigate'
/home/pocke/.gem/ruby/2.3.0/gems/rubocop-0.42.0/lib/rubocop/cop/team.rb:109:in `offenses'
/home/pocke/.gem/ruby/2.3.0/gems/rubocop-0.42.0/lib/rubocop/cop/team.rb:52:in `inspect_file'
/home/pocke/.gem/ruby/2.3.0/gems/rubocop-0.42.0/lib/rubocop/runner.rb:228:in `inspect_file'
/home/pocke/.gem/ruby/2.3.0/gems/rubocop-0.42.0/lib/rubocop/runner.rb:198:in `block in do_inspection_loop'
/home/pocke/.gem/ruby/2.3.0/gems/rubocop-0.42.0/lib/rubocop/runner.rb:188:in `loop'
/home/pocke/.gem/ruby/2.3.0/gems/rubocop-0.42.0/lib/rubocop/runner.rb:188:in `do_inspection_loop'
/home/pocke/.gem/ruby/2.3.0/gems/rubocop-0.42.0/lib/rubocop/runner.rb:93:in `block in file_offenses'
/home/pocke/.gem/ruby/2.3.0/gems/rubocop-0.42.0/lib/rubocop/runner.rb:103:in `file_offense_cache'
/home/pocke/.gem/ruby/2.3.0/gems/rubocop-0.42.0/lib/rubocop/runner.rb:91:in `file_offenses'
/home/pocke/.gem/ruby/2.3.0/gems/rubocop-0.42.0/lib/rubocop/runner.rb:82:in `process_file'
/home/pocke/.gem/ruby/2.3.0/gems/rubocop-0.42.0/lib/rubocop/runner.rb:59:in `block in inspect_files'
/home/pocke/.gem/ruby/2.3.0/gems/rubocop-0.42.0/lib/rubocop/runner.rb:57:in `each'
/home/pocke/.gem/ruby/2.3.0/gems/rubocop-0.42.0/lib/rubocop/runner.rb:57:in `inspect_files'
/home/pocke/.gem/ruby/2.3.0/gems/rubocop-0.42.0/lib/rubocop/runner.rb:35:in `run'
/home/pocke/.gem/ruby/2.3.0/gems/rubocop-0.42.0/lib/rubocop/cli.rb:72:in `execute_runner'
/home/pocke/.gem/ruby/2.3.0/gems/rubocop-0.42.0/lib/rubocop/cli.rb:28:in `run'
/home/pocke/.gem/ruby/2.3.0/gems/rubocop-0.42.0/bin/rubocop:14:in `block in <top (required)>'
/usr/lib/ruby/2.3.0/benchmark.rb:308:in `realtime'
/home/pocke/.gem/ruby/2.3.0/gems/rubocop-0.42.0/bin/rubocop:13:in `<top (required)>'
/home/pocke/.gem/ruby/2.3.0/bin/rubocop:23:in `load'
/home/pocke/.gem/ruby/2.3.0/bin/rubocop:23:in `<main>'
C

Offenses:

test.rb:1:1: C: Style/Encoding: Missing utf-8 encoding comment.
%W(#{x} y)
^^^^^^^^^^
test.rb:1:1: C: Style/FrozenStringLiteralComment: Missing frozen string literal comment.
%W(#{x} y)
^

1 file inspected, 2 offenses detected
Finished in 0.055379716999595985 seconds
```



-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Used the same coding conventions as the rest of the project.
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [ ] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [ ] All tests are passing.
* [ ] The new code doesn't generate RuboCop offenses.
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.

[1]: http://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html

