### PR TITLE
Add no_mixed_keys style to HashSyntax cop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 * Add new `Rails/SafeNavigation` cop to convert `try!` to `&.`. ([@rrosenblum][])
 * [#3415](https://github.com/bbatsov/rubocop/pull/3415): Add new `Rails/NotNullColumn` cop. ([@pocke][])
 * [#3167](https://github.com/bbatsov/rubocop/issues/3167): Add new `Style/VariableNumber` cop. ([@sooyang][])
+* Add new style `no_mixed_keys` to `Style/HashSyntax` to only check for hashes with mixed keys. ([@daviddavis][])
 
 ### Bug fixes
 

--- a/config/default.yml
+++ b/config/default.yml
@@ -535,9 +535,14 @@ Style/GuardClause:
 Style/HashSyntax:
   EnforcedStyle: ruby19
   SupportedStyles:
+    # checks for 1.9 syntax (e.g. {a: 1}) for all symbol keys
     - ruby19
-    - ruby19_no_mixed_keys
+    # checks for hash rocket syntax for all hashes
     - hash_rockets
+    # forbids mixed key syntaxes (e.g. {a: 1, :b => 2})
+    - no_mixed_keys
+    # enforces both ruby19 and no_mixed_keys styles
+    - ruby19_no_mixed_keys
   # Force hashes that have a symbol value to use hash rockets
   UseHashRocketsWithSymbolValues: false
   # Do not suggest { a?: 1 } over { :a? => 1 } in ruby19 style


### PR DESCRIPTION
Adding a style `no_mixed_keys` to check for hashes with mixed keys. There's `ruby19_no_mixed_keys` but it forces usage of the ruby19 syntax. This just checks for hashes with mixed keys (e.g. `{ a: 1, :b => 2}`) without enforcing ruby19 hash syntax.