### PR TITLE
[Fix #3374] Don't check BlockDelimiters in SpaceInsideBlockBraces

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@
 * [#3386](https://github.com/bbatsov/rubocop/issues/3386): Make `VariableForce` understand an empty RegExp literal as LHS to `=~`. ([@drenmi][])
 * [#3421](https://github.com/bbatsov/rubocop/pull/3421): Fix clobbering `inherit_from` additions when not using Namespaces in the configs. ([@nicklamuro][])
 * [#3425](https://github.com/bbatsov/rubocop/pull/3425): Fix bug for invalid bytes in UTF-8 in `Lint/PercentStringArray` cop. ([@pocke][])
+* [#3374](https://github.com/bbatsov/rubocop/issues/3374): Make `SpaceInsideBlockBraces` and `SpaceBeforeBlockBraces` not depend on `BlockDelimiters` configuration. ([@jonas054][])
 
 ### Changes
 

--- a/lib/rubocop/cop/style/space_before_block_braces.rb
+++ b/lib/rubocop/cop/style/space_before_block_braces.rb
@@ -12,15 +12,6 @@ module RuboCop
         def on_block(node)
           return if node.loc.begin.is?('do') # No braces.
 
-          # If braces are on separate lines, and the BlockDelimiters cop is
-          # enabled, those braces will be changed to do..end by the user or by
-          # auto-correct, so reporting space issues is not useful, and it
-          # creates auto-correct conflicts.
-          if config.for_cop('Style/BlockDelimiters')['Enabled'] &&
-             block_length(node) > 0
-            return
-          end
-
           left_brace = node.loc.begin
           space_plus_brace = range_with_surrounding_space(left_brace)
           used_style =

--- a/lib/rubocop/cop/style/space_inside_block_braces.rb
+++ b/lib/rubocop/cop/style/space_inside_block_braces.rb
@@ -15,15 +15,6 @@ module RuboCop
         def on_block(node)
           return if node.loc.begin.is?('do') # No braces.
 
-          # If braces are on separate lines, and the BlockDelimiters cop is
-          # enabled, those braces will be changed to do..end by the user or by
-          # auto-correct, so reporting space issues is not useful, and it
-          # creates auto-correct conflicts.
-          if config.for_cop('Style/BlockDelimiters')['Enabled'] &&
-             block_length(node) > 0
-            return
-          end
-
           left_brace = node.loc.begin
           right_brace = node.loc.end
 

--- a/spec/rubocop/cop/style/space_before_block_braces_spec.rb
+++ b/spec/rubocop/cop/style/space_before_block_braces_spec.rb
@@ -3,15 +3,8 @@
 
 require 'spec_helper'
 
-describe RuboCop::Cop::Style::SpaceBeforeBlockBraces do
+describe RuboCop::Cop::Style::SpaceBeforeBlockBraces, :config do
   subject(:cop) { described_class.new(config) }
-  let(:config) do
-    merged = RuboCop::ConfigLoader
-             .default_configuration['Style/SpaceBeforeBlockBraces']
-             .merge(cop_config)
-    RuboCop::Config.new('Style/BlockDelimiters' => { 'Enabled' => false },
-                        'Style/SpaceBeforeBlockBraces' => merged)
-  end
   let(:cop_config) { { 'EnforcedStyle' => 'space' } }
 
   context 'when EnforcedStyle is space' do
@@ -34,6 +27,16 @@ describe RuboCop::Cop::Style::SpaceBeforeBlockBraces do
                       'each { puts }'])
       expect(cop.messages).to eq(['Space missing to the left of {.'])
       expect(cop.config_to_allow_offenses).to eq('Enabled' => false)
+    end
+
+    it 'registers an offense for multiline block where left brace has no ' \
+       'outer space' do
+      inspect_source(cop, ['foo.map{ |a|',
+                           '  a.bar.to_s',
+                           '}'])
+      expect(cop.messages).to eq(['Space missing to the left of {.'])
+      expect(cop.highlights).to eq(['{'])
+      expect(cop.config_to_allow_offenses).to eq('EnforcedStyle' => 'no_space')
     end
 
     it 'auto-corrects missing space' do

--- a/spec/rubocop/cop/style/space_inside_block_braces_spec.rb
+++ b/spec/rubocop/cop/style/space_inside_block_braces_spec.rb
@@ -3,17 +3,10 @@
 
 require 'spec_helper'
 
-describe RuboCop::Cop::Style::SpaceInsideBlockBraces do
+describe RuboCop::Cop::Style::SpaceInsideBlockBraces, :config do
   SUPPORTED_STYLES = %w(space no_space).freeze
 
   subject(:cop) { described_class.new(config) }
-  let(:config) do
-    merged = RuboCop::ConfigLoader
-             .default_configuration['Style/SpaceInsideBlockBraces']
-             .merge(cop_config)
-    RuboCop::Config.new('Style/BlockDelimiters' => { 'Enabled' => false },
-                        'Style/SpaceInsideBlockBraces' => merged)
-  end
   let(:cop_config) do
     {
       'EnforcedStyle' => 'space',
@@ -210,14 +203,14 @@ describe RuboCop::Cop::Style::SpaceInsideBlockBraces do
         expect(new_source).to eq('each { |x| puts }')
       end
 
-      it 'does not do auto-correction for multi-line blocks' do
-        # {} will be changed to do..end by the BlockDelimiters cop, and then
-        # this cop is not relevant anymore.
+      it 'does auto-correction for multi-line blocks' do
         old_source = ['each {|x|',
                       '  puts',
                       '}']
         new_source = autocorrect_source(cop, old_source)
-        expect(new_source).to eq(old_source.join("\n"))
+        expect(new_source).to eq(['each { |x|',
+                                  '  puts',
+                                  '}'].join("\n"))
       end
     end
 


### PR DESCRIPTION
Same in `SpaceBeforeBlockBraces`. The reason we needed this special handling seems to be gone now. Auto-correct has become smarter.