### PR TITLE
Bugfix misreporting shadowed exception

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,8 @@
 * [#3421](https://github.com/bbatsov/rubocop/pull/3421): Fix clobbering `inherit_from` additions when not using Namespaces in the configs. ([@nicklamuro][])
 * [#3425](https://github.com/bbatsov/rubocop/pull/3425): Fix bug for invalid bytes in UTF-8 in `Lint/PercentStringArray` cop. ([@pocke][])
 * [#3374](https://github.com/bbatsov/rubocop/issues/3374): Make `SpaceInsideBlockBraces` and `SpaceBeforeBlockBraces` not depend on `BlockDelimiters` configuration. ([@jonas054][])
+* Fix error in `Lint/ShadowedException` cop for higher number of rescue groups. ([@groddeck][])
+[@groddeck]: https://github.com/groddeck
 
 ### Changes
 

--- a/lib/rubocop/cop/lint/shadowed_exception.rb
+++ b/lib/rubocop/cop/lint/shadowed_exception.rb
@@ -44,7 +44,7 @@ module RuboCop
           end
 
           return if !rescue_group_rescues_multiple_levels &&
-                    rescued_groups == sort_rescued_groups(rescued_groups)
+                    sorted?(rescued_groups)
 
           add_offense(node, offense_range(node, rescues))
         end
@@ -98,18 +98,18 @@ module RuboCop
           end
         end
 
-        def sort_rescued_groups(groups)
-          groups.sort do |x, y|
+        def sorted?(rescued_groups)
+          rescued_groups.each_cons(2).all? do |x, y|
             if x.include?(Exception)
-              1
+              false
             elsif y.include?(Exception)
-              -1
+              true
             elsif x.none? || y.none?
-              # do not change the order if a group is empty or only contains
+              # consider sorted if a group is empty or only contains
               # `nil`s
-              0
+              true
             else
-              x <=> y || 0
+              (x <=> y || 0) <= 0
             end
           end
         end

--- a/spec/rubocop/cop/lint/shadowed_exception_spec.rb
+++ b/spec/rubocop/cop/lint/shadowed_exception_spec.rb
@@ -269,15 +269,10 @@ describe RuboCop::Cop::Lint::ShadowedException do
     end
 
     it 'accepts many (>= 7) rescue groups' do
-      ErrorA = Class.new(RuntimeError)
-      ErrorB = Class.new(RuntimeError)
-      ErrorC = Class.new(RuntimeError)
-      ErrorD = Class.new(RuntimeError)
-      ErrorE = Class.new(RuntimeError)
-      ErrorF = Class.new(RuntimeError)
-      ErrorG = Class.new(RuntimeError)
       inspect_source(cop, ['begin',
                            '  something',
+                           'rescue StandardError',
+                           '  handle_error',
                            'rescue ErrorA',
                            '  handle_error',
                            'rescue ErrorB',
@@ -289,8 +284,6 @@ describe RuboCop::Cop::Lint::ShadowedException do
                            'rescue ErrorE',
                            '  handle_error',
                            'rescue ErrorF',
-                           '  handle_error',
-                           'rescue ErrorG',
                            '  handle_error',
                            'end'])
 

--- a/spec/rubocop/cop/lint/shadowed_exception_spec.rb
+++ b/spec/rubocop/cop/lint/shadowed_exception_spec.rb
@@ -268,6 +268,35 @@ describe RuboCop::Cop::Lint::ShadowedException do
       expect(cop.offenses).to be_empty
     end
 
+    it 'accepts many (>= 7) rescue groups' do
+      ErrorA = Class.new(RuntimeError)
+      ErrorB = Class.new(RuntimeError)
+      ErrorC = Class.new(RuntimeError)
+      ErrorD = Class.new(RuntimeError)
+      ErrorE = Class.new(RuntimeError)
+      ErrorF = Class.new(RuntimeError)
+      ErrorG = Class.new(RuntimeError)
+      inspect_source(cop, ['begin',
+                           '  something',
+                           'rescue ErrorA',
+                           '  handle_error',
+                           'rescue ErrorB',
+                           '  handle_error',
+                           'rescue ErrorC',
+                           '  handle_error',
+                           'rescue ErrorD',
+                           '  handle_error',
+                           'rescue ErrorE',
+                           '  handle_error',
+                           'rescue ErrorF',
+                           '  handle_error',
+                           'rescue ErrorG',
+                           '  handle_error',
+                           'end'])
+
+      expect(cop.offenses).to be_empty
+    end
+
     it 'accepts rescuing exceptions in order of level with multiple ' \
        'exceptions in a group' do
       inspect_source(cop, ['begin',


### PR DESCRIPTION
I discovered an unreported bug in the `Lint/ShadowedException` cop. It's an edge-case involving a high number of rescue groups.

The code responsible fails due to a strategy meant to determine if the rescue groups are properly ordered from most-specific to most-generic, reporting violations for, "shadowed" exceptions. However, the strategy relies on the assumption that sorting an array containing nested arrays of the error types within each rescue group will leave the outer array untouched after sorting if the groups are already sorted from most- to least-specific.

This assumption can fail when sorting a number of rescue groups greater than a certain threshold size. For error types `A` and `B`, where `A` would neither shadow, nor be shadowed by, `B`, `A <=> B` evaluates to 0. The prior implementation of `Lint/ShadowedException` takes the rescue groups, sorts them, and then compares the array prior to sorting with the output of the sorting. The error case occurs when the underlying sorting algorithm invoked by `Array#sort` is not in-place, which is required by the strategy in use, but which is not guaranteed by `sort` and changes depending on array size.

The fix offered here changes the strategy from that used previously, in which the pre-sorting and post-sorting rescue groups arrays are compared. Instead, the new code checks only to see if the array is already in an acceptably sorted state. That is, for all consecutive pairs of rescue groups, A and B, the error types in A would not "shadow" those in B.