### PR TITLE
Add a security based cop for JSON.load

### DIFF
--- a/config/enabled.yml
+++ b/config/enabled.yml
@@ -1482,3 +1482,7 @@ Rails/UniqBeforePluck:
 Rails/Validation:
   Description: 'Use validates :attribute, hash of validations.'
   Enabled: true
+
+Security/JSONLoad:
+  Description : 'Prefer usage of JSON.parse'
+  Enabled: true

--- a/lib/rubocop.rb
+++ b/lib/rubocop.rb
@@ -399,6 +399,8 @@ require 'rubocop/cop/rails/time_zone'
 require 'rubocop/cop/rails/uniq_before_pluck'
 require 'rubocop/cop/rails/validation'
 
+require 'rubocop/cop/security/json_load'
+
 require 'rubocop/cop/team'
 
 require 'rubocop/formatter/base_formatter'

--- a/lib/rubocop/cached_data.rb
+++ b/lib/rubocop/cached_data.rb
@@ -11,7 +11,7 @@ module RuboCop
     end
 
     def from_json(text)
-      deserialize_offenses(JSON.load(text))
+      deserialize_offenses(JSON.parse(text))
     end
 
     def to_json(offenses)

--- a/lib/rubocop/cop/security/json_load.rb
+++ b/lib/rubocop/cop/security/json_load.rb
@@ -1,0 +1,36 @@
+# encoding: utf-8
+# frozen_string_literal: true
+
+module RuboCop
+  module Cop
+    module Security
+      # This cop checks for the use of unsecure JSON methods.
+      #
+      # @example
+      #   # always offense
+      #   JSON.load("{}")
+      #   JSON.restore("{}")
+      #
+      #   # no offense
+      #   JSON.parse("{}")
+      #
+      class JSONLoad < Cop
+        MSG = 'Prefer `JSON.parse` instead of `JSON#%s`.'.freeze
+
+        def_node_matcher :json_load, <<-END
+          (send (const nil :JSON) ${:load :restore} ...)
+        END
+
+        def on_send(node)
+          json_load(node) do |method|
+            add_offense(node, :selector, format(MSG, method))
+          end
+        end
+
+        def autocorrect(node)
+          ->(corrector) { corrector.replace(node.loc.selector, 'parse') }
+        end
+      end
+    end
+  end
+end

--- a/spec/rubocop/cop/security/json_load_spec.rb
+++ b/spec/rubocop/cop/security/json_load_spec.rb
@@ -1,0 +1,41 @@
+# encoding: utf-8
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+describe RuboCop::Cop::Security::JSONLoad, :config do
+  subject(:cop) { described_class.new(config) }
+
+  it 'accepts JSON.parse' do
+    inspect_source(cop, 'JSON.parse("{}")')
+    expect(cop.offenses).to be_empty
+  end
+
+  it 'accepts JSON.parse' do
+    inspect_source(cop, 'Module::JSON.parse("{}")')
+    expect(cop.offenses).to be_empty
+  end
+
+  it 'accepts JSON.dump' do
+    inspect_source(cop, 'JSON.dump({})')
+    expect(cop.offenses).to be_empty
+  end
+
+  it 'accepts JSON.dump' do
+    inspect_source(cop, 'Module::JSON.load({})')
+    expect(cop.offenses).to be_empty
+  end
+
+  [:load, :restore].each do |method|
+    it "registers an offense for JSON.#{method}" do
+      inspect_source(cop, "JSON.#{method}('{}')")
+      expect(cop.offenses.size).to eq(1)
+      expect(cop.offenses.first.message).to include("JSON##{method}")
+    end
+
+    it "autocorrects '.#{method}' to '.parse'" do
+      corrected = autocorrect_source(cop, "JSON.#{method}('{}')")
+      expect(corrected).to eq("JSON.parse('{}')")
+    end
+  end
+end


### PR DESCRIPTION
Adds a cop to detect usage of ``JSON.load``, which shouldn't be used with [untrusted data](http://ruby-doc.org/stdlib-2.3.1/libdoc/json/rdoc/JSON.html#method-i-load) and suggest to replace it with usage of ``JSON.parse``.

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [ ] Used the same coding conventions as the rest of the project.
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [ ] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] All tests are passing.
* [x] The new code doesn't generate RuboCop offenses.
* [ ] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.

[1]: http://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html
