### PR TITLE
[fix #3445] by special casing setter methods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 
 ### Bug fixes
 
+* [#3445](https://github.com/bbatsov/rubocop/issues/3445): Fix bad autocorrect for `Style/AndOr` cop. ([@mikezter][])
 * [#3349](https://github.com/bbatsov/rubocop/issues/3349): Fix bad autocorrect for `Style/Lambda` cop. ([@metcalf][])
 * [#3351](https://github.com/bbatsov/rubocop/issues/3351): Fix bad auto-correct for `Performance/RedundantMatch` cop. ([@annaswims][])
 * [#3347](https://github.com/bbatsov/rubocop/issues/3347): Prevent infinite loop in `Style/TernaryParentheses` cop when used together with `Style/RedundantParentheses`. ([@drenmi][])
@@ -2334,3 +2335,4 @@
 [@annaswims]: https://github.com/annaswims
 [@soutaro]: https://github.com/soutaro
 [@nicklamuro]: https://github.com/nicklamuro
+[@mikezter]: https://github.com/mikezter

--- a/lib/rubocop/cop/style/and_or.rb
+++ b/lib/rubocop/cop/style/and_or.rb
@@ -78,9 +78,7 @@ module RuboCop
         def correct_send(node, corrector)
           receiver, method_name, *args = *node
           return correct_not(node, receiver, corrector) if method_name == :!
-          if method_name.to_s.end_with?('=')
-            return correct_setter(node, corrector)
-          end
+          return correct_setter(node, corrector) if setter_method?(method_name)
           return unless correctable_send?(node)
 
           corrector.replace(whitespace_before_arg(node), '('.freeze)
@@ -113,6 +111,10 @@ module RuboCop
           return unless node.source_range.begin.source != '('
           corrector.insert_before(node.source_range, '(')
           corrector.insert_after(node.source_range, ')')
+        end
+
+        def setter_method?(method_name)
+          method_name.to_s.end_with?('=')
         end
 
         def correctable_send?(node)

--- a/lib/rubocop/cop/style/and_or.rb
+++ b/lib/rubocop/cop/style/and_or.rb
@@ -78,9 +78,18 @@ module RuboCop
         def correct_send(node, corrector)
           receiver, method_name, *args = *node
           return correct_not(node, receiver, corrector) if method_name == :!
+          if method_name.to_s.end_with?('=')
+            return correct_setter(node, corrector)
+          end
           return unless correctable_send?(node)
 
           corrector.replace(whitespace_before_arg(node), '('.freeze)
+          corrector.insert_after(args.last.source_range, ')'.freeze)
+        end
+
+        def correct_setter(node, corrector)
+          receiver, _method_name, *args = *node
+          corrector.insert_before(receiver.source_range, '('.freeze)
           corrector.insert_after(args.last.source_range, ')'.freeze)
         end
 

--- a/spec/rubocop/cop/style/and_or_spec.rb
+++ b/spec/rubocop/cop/style/and_or_spec.rb
@@ -253,6 +253,20 @@ describe RuboCop::Cop::Style::AndOr, :config do
       end
     end
 
+    context 'with obj.method = arg on left' do
+      it 'autocorrects "and" with && and adds parens' do
+        new_source = autocorrect_source(cop, 'obj.method = arg and x')
+        expect(new_source).to eq('(obj.method = arg) && x')
+      end
+    end
+
+    context 'with obj.method= arg on left' do
+      it 'autocorrects "and" with && and adds parens' do
+        new_source = autocorrect_source(cop, 'obj.method= arg and x')
+        expect(new_source).to eq('(obj.method= arg) && x')
+      end
+    end
+
     context 'with predicate method with arg without space on right' do
       it 'autocorrects "or" with || and adds parens' do
         new_source = autocorrect_source(cop, 'false or 3.is_a?Integer')


### PR DESCRIPTION
Style/AndOr breaks for setter-methods as described in #3445. 

This PR fixes this by adding parens around the method call expression.
