### PR TITLE
Don't crash on a multiline empty brace in Style/MultilineMethodCallBraceLayout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@
 * [#3374](https://github.com/bbatsov/rubocop/issues/3374): Make `SpaceInsideBlockBraces` and `SpaceBeforeBlockBraces` not depend on `BlockDelimiters` configuration. ([@jonas054][])
 * Fix error in `Lint/ShadowedException` cop for higher number of rescue groups. ([@groddeck][])
 [@groddeck]: https://github.com/groddeck
+* [#3456](https://github.com/bbatsov/rubocop/pull/3456): Don't crash on a multiline empty brace in `Style/MultilineMethodCallBraceLayout`. ([@pocke][])
 
 ### Changes
 

--- a/lib/rubocop/cop/mixin/multiline_literal_brace_layout.rb
+++ b/lib/rubocop/cop/mixin/multiline_literal_brace_layout.rb
@@ -77,7 +77,7 @@ module RuboCop
       end
 
       def empty_literal?(node)
-        node.children.empty?
+        children(node).empty?
       end
 
       def last_element_range_with_trailing_comma(node)

--- a/spec/rubocop/cop/style/multiline_method_call_brace_layout_spec.rb
+++ b/spec/rubocop/cop/style/multiline_method_call_brace_layout_spec.rb
@@ -26,6 +26,19 @@ describe RuboCop::Cop::Style::MultilineMethodCallBraceLayout, :config do
     expect(cop.offenses).to be_empty
   end
 
+  it 'ignores calls with an empty brace' do
+    inspect_source(cop, 'puts()')
+
+    expect(cop.offenses).to be_empty
+  end
+
+  it 'ignores calls with a multiline empty brace ' do
+    inspect_source(cop, ['puts(',
+                         ')'])
+
+    expect(cop.offenses).to be_empty
+  end
+
   include_examples 'multiline literal brace layout' do
     let(:open) { 'foo(' }
     let(:close) { ')' }


### PR DESCRIPTION
RuboCop crashes with the following code.

`test.rb`

```ruby
x(
)
```

```sh
$ rubocop --cache false -d test.rb
An error occurred while Style/MultilineMethodCallBraceLayout cop was inspecting /home/pocke/ghq/github.com/bbatsov/rubocop/test.rb.

1 error occurred:
An error occurred while Style/MultilineMethodCallBraceLayout cop was inspecting /home/pocke/ghq/github.com/bbatsov/rubocop/test.rb.
Errors are usually caused by RuboCop bugs.
Please, report your problems to RuboCop's issue tracker.
Mention the following information in the issue report:
0.42.0 (using Parser 2.3.1.2, running on ruby 2.3.1 x86_64-linux)
For /home/pocke/ghq/github.com/bbatsov/rubocop: configuration from /home/pocke/ghq/github.com/bbatsov/rubocop/.rubocop.yml
Inheriting configuration from /home/pocke/ghq/github.com/bbatsov/rubocop/.rubocop_todo.yml
Default configuration from /home/pocke/.gem/ruby/2.3.0/gems/rubocop-0.42.0/config/default.yml
Inheriting configuration from /home/pocke/.gem/ruby/2.3.0/gems/rubocop-0.42.0/config/enabled.yml
Inheriting configuration from /home/pocke/.gem/ruby/2.3.0/gems/rubocop-0.42.0/config/disabled.yml
Inspecting 1 file
Scanning /home/pocke/ghq/github.com/bbatsov/rubocop/test.rb
undefined method `loc' for nil:NilClass
/home/pocke/.gem/ruby/2.3.0/gems/rubocop-0.42.0/lib/rubocop/cop/mixin/multiline_literal_brace_layout.rb:105:in `opening_brace_on_same_line?'
/home/pocke/.gem/ruby/2.3.0/gems/rubocop-0.42.0/lib/rubocop/cop/mixin/multiline_literal_brace_layout.rb:60:in `check_symmetrical'
/home/pocke/.gem/ruby/2.3.0/gems/rubocop-0.42.0/lib/rubocop/cop/mixin/multiline_literal_brace_layout.rb:41:in `check'
/home/pocke/.gem/ruby/2.3.0/gems/rubocop-0.42.0/lib/rubocop/cop/mixin/multiline_literal_brace_layout.rb:18:in `check_brace_layout'
/home/pocke/.gem/ruby/2.3.0/gems/rubocop-0.42.0/lib/rubocop/cop/style/multiline_method_call_brace_layout.rb:77:in `on_send'
/home/pocke/.gem/ruby/2.3.0/gems/rubocop-0.42.0/lib/rubocop/cop/commissioner.rb:42:in `block (2 levels) in on_send'
/home/pocke/.gem/ruby/2.3.0/gems/rubocop-0.42.0/lib/rubocop/cop/commissioner.rb:97:in `with_cop_error_handling'
/home/pocke/.gem/ruby/2.3.0/gems/rubocop-0.42.0/lib/rubocop/cop/commissioner.rb:41:in `block in on_send'
/home/pocke/.gem/ruby/2.3.0/gems/rubocop-0.42.0/lib/rubocop/cop/commissioner.rb:40:in `each'
/home/pocke/.gem/ruby/2.3.0/gems/rubocop-0.42.0/lib/rubocop/cop/commissioner.rb:40:in `on_send'
/home/pocke/.gem/ruby/2.3.0/gems/rubocop-0.42.0/lib/rubocop/ast_node/traversal.rb:13:in `walk'
/home/pocke/.gem/ruby/2.3.0/gems/rubocop-0.42.0/lib/rubocop/cop/commissioner.rb:59:in `investigate'
/home/pocke/.gem/ruby/2.3.0/gems/rubocop-0.42.0/lib/rubocop/cop/team.rb:121:in `investigate'
/home/pocke/.gem/ruby/2.3.0/gems/rubocop-0.42.0/lib/rubocop/cop/team.rb:109:in `offenses'
/home/pocke/.gem/ruby/2.3.0/gems/rubocop-0.42.0/lib/rubocop/cop/team.rb:52:in `inspect_file'
/home/pocke/.gem/ruby/2.3.0/gems/rubocop-0.42.0/lib/rubocop/runner.rb:228:in `inspect_file'
/home/pocke/.gem/ruby/2.3.0/gems/rubocop-0.42.0/lib/rubocop/runner.rb:198:in `block in do_inspection_loop'
/home/pocke/.gem/ruby/2.3.0/gems/rubocop-0.42.0/lib/rubocop/runner.rb:188:in `loop'
/home/pocke/.gem/ruby/2.3.0/gems/rubocop-0.42.0/lib/rubocop/runner.rb:188:in `do_inspection_loop'
/home/pocke/.gem/ruby/2.3.0/gems/rubocop-0.42.0/lib/rubocop/runner.rb:93:in `block in file_offenses'
/home/pocke/.gem/ruby/2.3.0/gems/rubocop-0.42.0/lib/rubocop/runner.rb:103:in `file_offense_cache'
/home/pocke/.gem/ruby/2.3.0/gems/rubocop-0.42.0/lib/rubocop/runner.rb:91:in `file_offenses'
/home/pocke/.gem/ruby/2.3.0/gems/rubocop-0.42.0/lib/rubocop/runner.rb:82:in `process_file'
/home/pocke/.gem/ruby/2.3.0/gems/rubocop-0.42.0/lib/rubocop/runner.rb:59:in `block in inspect_files'
/home/pocke/.gem/ruby/2.3.0/gems/rubocop-0.42.0/lib/rubocop/runner.rb:57:in `each'
/home/pocke/.gem/ruby/2.3.0/gems/rubocop-0.42.0/lib/rubocop/runner.rb:57:in `inspect_files'
/home/pocke/.gem/ruby/2.3.0/gems/rubocop-0.42.0/lib/rubocop/runner.rb:35:in `run'
/home/pocke/.gem/ruby/2.3.0/gems/rubocop-0.42.0/lib/rubocop/cli.rb:72:in `execute_runner'
/home/pocke/.gem/ruby/2.3.0/gems/rubocop-0.42.0/lib/rubocop/cli.rb:28:in `run'
/home/pocke/.gem/ruby/2.3.0/gems/rubocop-0.42.0/bin/rubocop:14:in `block in <top (required)>'
/usr/lib/ruby/2.3.0/benchmark.rb:308:in `realtime'
/home/pocke/.gem/ruby/2.3.0/gems/rubocop-0.42.0/bin/rubocop:13:in `<top (required)>'
/home/pocke/.gem/ruby/2.3.0/bin/rubocop:23:in `load'
/home/pocke/.gem/ruby/2.3.0/bin/rubocop:23:in `<main>'
C

Offenses:

test.rb:1:1: C: Style/Encoding: Missing utf-8 encoding comment.
x(
^^
test.rb:1:1: C: Style/FrozenStringLiteralComment: Missing frozen string literal comment.
x(
^
test.rb:1:2: C: Style/MethodCallParentheses: Do not use parentheses for method calls with no arguments.
x(
 ^
test.rb:2:1: C: Style/ClosingParenthesisIndentation: Align ) with (.
)
^

1 file inspected, 4 offenses detected
Finished in 0.04562400601571426 seconds
```

So, I've fixed the bug, and I've added test cases. 

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Used the same coding conventions as the rest of the project.
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [ ] All tests are passing.
* [ ] The new code doesn't generate RuboCop offenses.
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.

[1]: http://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html

