### PR TITLE
Do not register an offense when using try with an enumerable accessor

### DIFF
--- a/lib/rubocop/cop/rails/safe_navigation.rb
+++ b/lib/rubocop/cop/rails/safe_navigation.rb
@@ -15,6 +15,8 @@ module RuboCop
       #     foo.try!(:bar, baz)
       #     foo.try!(:bar) { |e| e.baz }
       #
+      #     foo.try!(:[], 0)
+      #
       #     # good
       #     foo.try(:bar)
       #     foo.try(:bar, baz)
@@ -42,30 +44,38 @@ module RuboCop
         MSG = 'Use safe navigation (`&.`) instead of `%s`.'.freeze
 
         def_node_matcher :try_call, <<-PATTERN
-          (send _ ${:try :try!} ...)
+          (send _ ${:try :try!} $_ ...)
         PATTERN
 
         def on_send(node)
           return if target_ruby_version < 2.3
 
-          try_call(node) do |method|
-            return if method == :try && !cop_config['ConvertTry']
-            add_offense(node, :expression, format(MSG, method))
+          try_call(node) do |try_method, method_to_try|
+            return if try_method == :try && !cop_config['ConvertTry']
+            return unless method_to_try.sym_type?
+            method, = *method_to_try
+            return unless method =~ /\w+[=!?]?/
+            add_offense(node, :expression, format(MSG, try_method))
           end
         end
 
         private
 
         def autocorrect(node)
-          _receiver, _try, method, *params = *node
+          _receiver, _try, method_node, *params = *node
+          method = method_node.source[1..-1]
 
           range = range_between(node.loc.dot.begin_pos,
                                 node.loc.expression.end_pos)
 
-          replacement = "&.#{method.source[1..-1]}"
-          unless params.empty?
-            replacement += "(#{params.map(&:source).join(', ')})"
-          end
+          new_params = params.map(&:source).join(', ')
+          replacement = if method.end_with?('=')
+                          "&.#{method[0...-1]} = #{new_params}"
+                        elsif params.empty?
+                          "&.#{method}"
+                        else
+                          "&.#{method}(#{new_params})"
+                        end
 
           lambda do |corrector|
             corrector.replace(range, replacement)

--- a/spec/rubocop/cop/rails/safe_navigation_spec.rb
+++ b/spec/rubocop/cop/rails/safe_navigation_spec.rb
@@ -59,6 +59,18 @@ describe RuboCop::Cop::Rails::SafeNavigation, :config do
                         ['(:each_with_object, []) do |e, acc|',
                          '  acc << e.some_method',
                          'end'].join("\n")
+        it_behaves_like :offense, 'try! with a question method', 'try!',
+                        '(:something?)'
+        it_behaves_like :offense, 'try! with a bang method', 'try!',
+                        '(:something!)'
+
+        it_behaves_like :accepts, 'try! used to call an enumerable accessor',
+                        'foo.try!(:[], :bar)'
+        it_behaves_like :accepts, 'try! with ==', 'foo.try!(:==, bar)'
+        it_behaves_like :accepts, 'try! with an operator', 'foo.try!(:+, bar)'
+        it_behaves_like :accepts, 'try! with a method stored as a variable',
+                        ['bar = :==',
+                         'foo.try!(baz, bar)'].join("\n")
       end
 
       context 'try' do
@@ -73,6 +85,8 @@ describe RuboCop::Cop::Rails::SafeNavigation, :config do
                          'end'].join("\n")
       end
 
+      it_behaves_like :autocorrect, 'try! a single parameter',
+                      'foo.try!(:thing=, bar)', 'foo&.thing = bar'
       it_behaves_like :autocorrect, 'try! a single parameter',
                       '[1, 2].try!(:join)', '[1, 2]&.join'
       it_behaves_like :autocorrect, 'try! with 2 parameters',
@@ -124,6 +138,9 @@ describe RuboCop::Cop::Rails::SafeNavigation, :config do
                          '  acc << e.some_method',
                          'end'].join("\n")
 
+        it_behaves_like :accepts, 'try! used to call an enumerable accessor',
+                        'foo.try!(:[], :bar)'
+
         it_behaves_like :autocorrect, 'try! a single parameter',
                         '[1, 2].try!(:join)', '[1, 2]&.join'
         it_behaves_like :autocorrect, 'try! with 2 parameters',
@@ -157,6 +174,9 @@ describe RuboCop::Cop::Rails::SafeNavigation, :config do
                         ['(:each_with_object, []) do |e, acc|',
                          '  acc << e.some_method',
                          'end'].join("\n")
+
+        it_behaves_like :accepts, 'try! used to call an enumerable accessor',
+                        'foo.try!(:[], :bar)'
 
         it_behaves_like :autocorrect, 'try a single parameter',
                         '[1, 2].try(:join)', '[1, 2]&.join'


### PR DESCRIPTION
I realized that I did not account for enumerable accessors in the `SafeNavigation` cops. I decided to not have them register an offense for now. As far as I know, safe navigation cannot be used directly on them. `foo&.[0]` is invalid. `foo&.public_send(:[], 0)` would work, but I am not sure that we want to suggest that as a replacement or not.

I will also need to account for this in `Style/SafeNavigation`.