### PR TITLE
[Fix #3383] RedundantSelf inner method bugfix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 
 ### Bug fixes
 
+* [#3383](https://github.com/bbatsov/rubocop/issues/3383): Fix the local variable reset issue with `Style/RedundantSelf` cop. ([@bankair][])
 * [#3445](https://github.com/bbatsov/rubocop/issues/3445): Fix bad autocorrect for `Style/AndOr` cop. ([@mikezter][])
 * [#3349](https://github.com/bbatsov/rubocop/issues/3349): Fix bad autocorrect for `Style/Lambda` cop. ([@metcalf][])
 * [#3351](https://github.com/bbatsov/rubocop/issues/3351): Fix bad auto-correct for `Performance/RedundantMatch` cop. ([@annaswims][])

--- a/spec/rubocop/cop/style/redundant_self_spec.rb
+++ b/spec/rubocop/cop/style/redundant_self_spec.rb
@@ -125,6 +125,23 @@ describe RuboCop::Cop::Style::RedundantSelf do
       inspect_source(cop, src)
       expect(cop.offenses).to be_empty
     end
+
+    it 'accepts a self receiver used to distinguish from an argument' do
+      src = ['def foo(bar)',
+             '  puts bar, self.bar',
+             'end']
+      inspect_source(cop, src)
+      expect(cop.offenses).to be_empty
+    end
+
+    it 'accepts a self receiver used to distinguish from an argument' do
+      src = ['def foo(bar)',
+             '  def inner_method(); end',
+             '  puts bar, self.bar',
+             'end']
+      inspect_source(cop, src)
+      expect(cop.offenses).to be_empty
+    end
   end
 
   describe 'class methods' do


### PR DESCRIPTION
As stated in issue #3383, having an inner method seems to break the Style/RedundantSelf cop detection, and the following code used to trigger a redundant self warning:

```ruby
def foo(bar)
  def inner_method(); end
  puts bar, self.bar
end
```

The issue was caused by the on_def and on_defs contents:

```ruby
def on_def(_node)
  @local_variables = []
end
```

By resetting the content of the @local_variables attribute to a new array at each def statement, we were trashing the previously encountered local variables.

In order to fix that, local variables are now stored in scopes, attached to each descendants of the def node. Plus, the on_send callback check in the right scope that the send target does not have a local var twin.

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Used the same coding conventions as the rest of the project.
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] All tests are passing.
* [x] The new code doesn't generate RuboCop offenses.
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.

[1]: http://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html
