### PR TITLE
Do not register an offence when first line starts with #\

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,7 @@
 * Rename `Lint/UselessArraySplat` to `Lint/UnneededSplatExpansion`, and add functionality to check for unnecessary expansion of other literals. ([@rrosenblum][])
 * No longer register an offense for splat expansion of an array literal in `Performance/CaseWhenSplat`. `Lint/UnneededSplatExpansion` now handles this behavior. ([@rrosenblum][])
 * `Lint/InheritException` restricts inheriting from standard library subclasses of `Exception`. ([@metcalf][])
+* No longer register an offense if the first line of code starts with `#\` in `Style/LeadingCommentSpace`. `config.ru` files consider such lines as options. ([@scottohara][])
 
 ## 0.42.0 (2016-07-25)
 
@@ -2347,3 +2348,4 @@
 [@joejuzl]: https://github.com/joejuzl
 [@hedgesky]: https://github.com/hedgesky
 [@tjwallace]: https://github.com/tjwallace
+[@scottohara]: https://github.com/scottohara

--- a/lib/rubocop/cop/style/leading_comment_space.rb
+++ b/lib/rubocop/cop/style/leading_comment_space.rb
@@ -17,6 +17,11 @@ module RuboCop
             next unless comment.text =~ /\A#+[^#\s=:+-]/
             next if comment.text.start_with?('#!') && comment.loc.line == 1
 
+            # in config.ru files, if the first line starts with #\ it is treated
+            # as options (e.g. `#\ -p 8765` sets the request port to 8765)
+            next if comment.text.start_with?('#\\') && comment.loc.line == 1 &&
+                    config_ru?(processed_source.buffer.name)
+
             add_offense(comment, :expression)
           end
         end
@@ -26,6 +31,12 @@ module RuboCop
           b = expr.begin_pos
           hash_mark = range_between(b, b + 1)
           ->(corrector) { corrector.insert_after(hash_mark, ' ') }
+        end
+
+        private
+
+        def config_ru?(file_path)
+          File.basename(file_path).eql?('config.ru')
         end
       end
     end

--- a/spec/rubocop/cop/style/leading_comment_space_spec.rb
+++ b/spec/rubocop/cop/style/leading_comment_space_spec.rb
@@ -44,6 +44,42 @@ describe RuboCop::Cop::Style::LeadingCommentSpace do
     expect(cop.offenses.size).to eq(1)
   end
 
+  context 'file named config.ru' do
+    it 'does not register an offense for #\ on first line' do
+      inspect_source(cop,
+                     ['#\ -w -p 8765',
+                      'test'],
+                     '/some/dir/config.ru')
+      expect(cop.offenses).to be_empty
+    end
+
+    it 'registers an offense for #\ after the first line' do
+      inspect_source(cop,
+                     ['test',
+                      '#\ -w -p 8765'],
+                     '/some/dir/config.ru')
+      expect(cop.offenses.size).to eq(1)
+    end
+  end
+
+  context 'file not named config.ru' do
+    it 'registers an offense for #\ on first line' do
+      inspect_source(cop,
+                     ['#\ -w -p 8765',
+                      'test'],
+                     '/some/dir/test_case.rb')
+      expect(cop.offenses.size).to eq(1)
+    end
+
+    it 'registers an offense for #\ after the first line' do
+      inspect_source(cop,
+                     ['test',
+                      '#\ -w -p 8765'],
+                     '/some/dir/test_case.rb')
+      expect(cop.offenses.size).to eq(1)
+    end
+  end
+
   it 'accepts rdoc syntax' do
     inspect_source(cop,
                    ['#++',


### PR DESCRIPTION
The first line in `config.ru` starting with `#\` is treated as if it was options, e.g.

```
#\ -w -p 8765
run app
``` 

...would run with Ruby warnings enabled, and request port 8765.

However this triggers a `Style/LeadingCommentSpace` cop offense:

```
$ rubocop config.ru
Inspecting 1 file
C

Offenses:

config.ru:2:1: C: Missing space after #.
#\ -w -p 8765
^^^^^^^^^^^^^

1 file inspected, 1 offense detected
```

This PR adds an exception to the `Style/LeadingCommentSpace` copy for `#\`, but _only_ for the first line in the file.