### PR TITLE
[Fix #3462] Don't flag single-line methods in MultilineMethodCallBraceLayout when EnforcedStyle is new_line

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,7 @@
 * [#3456](https://github.com/bbatsov/rubocop/pull/3456): Don't crash on a multiline empty brace in `Style/MultilineMethodCallBraceLayout`. ([@pocke][])
 * [#3423](https://github.com/bbatsov/rubocop/issues/3423): Checks if .rubocop is a file before parsing. ([@joejuzl][])
 * [#3439](https://github.com/bbatsov/rubocop/issues/3439): Fix variable assignment check not working properly when a block is used in `Rails/SaveBang`. ([@QuinnHarris][])
+* [#3462](https://github.com/bbatsov/rubocop/issues/3462): Don't create MultilineMethodCallBraceLayout offenses for single-line method calls when receiver spans multiple lines. ([@maxjacobson][])
 
 ### Changes
 

--- a/lib/rubocop/cop/mixin/multiline_literal_brace_layout.rb
+++ b/lib/rubocop/cop/mixin/multiline_literal_brace_layout.rb
@@ -69,16 +69,11 @@ module RuboCop
       end
 
       def ignored_literal?(node)
-        implicit_literal?(node) || empty_literal?(node) || single_line?(node)
+        implicit_literal?(node) || empty_literal?(node) || node.single_line?
       end
 
       def implicit_literal?(node)
         !node.loc.begin
-      end
-
-      def single_line?(node)
-        return true if node.single_line?
-        node.send_type? && node.loc.begin.line == node.loc.end.line
       end
 
       def empty_literal?(node)

--- a/lib/rubocop/cop/mixin/multiline_literal_brace_layout.rb
+++ b/lib/rubocop/cop/mixin/multiline_literal_brace_layout.rb
@@ -69,11 +69,16 @@ module RuboCop
       end
 
       def ignored_literal?(node)
-        implicit_literal?(node) || empty_literal?(node) || node.single_line?
+        implicit_literal?(node) || empty_literal?(node) || single_line?(node)
       end
 
       def implicit_literal?(node)
         !node.loc.begin
+      end
+
+      def single_line?(node)
+        return true if node.single_line?
+        node.send_type? && node.loc.begin.line == node.loc.end.line
       end
 
       def empty_literal?(node)

--- a/lib/rubocop/cop/style/multiline_method_call_brace_layout.rb
+++ b/lib/rubocop/cop/style/multiline_method_call_brace_layout.rb
@@ -84,6 +84,15 @@ module RuboCop
 
           args
         end
+
+        def ignored_literal?(node)
+          single_line_ignoring_receiver?(node) || super
+        end
+
+        def single_line_ignoring_receiver?(node)
+          return false unless node.loc.begin && node.loc.end
+          node.loc.begin.line == node.loc.end.line
+        end
       end
     end
   end

--- a/spec/rubocop/cop/style/multiline_method_call_brace_layout_spec.rb
+++ b/spec/rubocop/cop/style/multiline_method_call_brace_layout_spec.rb
@@ -56,5 +56,18 @@ describe RuboCop::Cop::Style::MultilineMethodCallBraceLayout, :config do
       inspect_source(cop, 'puts("Hello world!")')
       expect(cop.offenses).to be_empty
     end
+
+    it 'ignores single-line calls with multi-line receiver' do
+      inspect_source(cop, ['[',
+                           '].join(" ")'])
+      expect(cop.offenses).to be_empty
+    end
+
+    it 'ignores single-line calls with multi-line receiver with leading dot' do
+      inspect_source(cop, ['[',
+                           ']',
+                           '.join(" ")'])
+      expect(cop.offenses).to be_empty
+    end
   end
 end


### PR DESCRIPTION
Please see #3462 for more context on the issue

The idea is that we can still consider a method call "single line" even when the receiver spans multiple lines

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Used the same coding conventions as the rest of the project.
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] All tests are passing.
* [x] The new code doesn't generate RuboCop offenses.
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.

[1]: http://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html
