### PR TITLE
[Fix #3439] Properly check left assign from method when a block is used

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@
 [@groddeck]: https://github.com/groddeck
 * [#3456](https://github.com/bbatsov/rubocop/pull/3456): Don't crash on a multiline empty brace in `Style/MultilineMethodCallBraceLayout`. ([@pocke][])
 * [#3423](https://github.com/bbatsov/rubocop/issues/3423): Checks if .rubocop is a file before parsing. ([@joejuzl][])
+* [#3439](https://github.com/bbatsov/rubocop/issues/3439): Fix variable assignment check not working properly when a block is used in `Rails/SaveBang`. ([@QuinnHarris][])
 
 ### Changes
 

--- a/lib/rubocop/cop/rails/save_bang.rb
+++ b/lib/rubocop/cop/rails/save_bang.rb
@@ -60,6 +60,8 @@ module RuboCop
         def return_value_used?(node)
           return false unless node.parent
           node.parent.lvasgn_type? ||
+            (node.parent.block_type? && node.parent.parent &&
+              node.parent.parent.lvasgn_type?) ||
             (node.parent.if_type? && node.sibling_index.zero?)
         end
 

--- a/spec/rubocop/cop/rails/save_bang_spec.rb
+++ b/spec/rubocop/cop/rails/save_bang_spec.rb
@@ -50,6 +50,14 @@ describe RuboCop::Cop::Rails::SaveBang do
       expect(cop.messages).to be_empty
     end
 
+    it "when assigning the return value of #{method} with block" do
+      inspect_source(cop, "x = object.#{method} do |obj|\n" \
+                          "  obj.name = 'Tom'\n" \
+                          'end')
+
+      expect(cop.messages).to be_empty
+    end
+
     it "when using #{method} with if" do
       inspect_source(cop, "if object.#{method}; something; end")
 


### PR DESCRIPTION
This addresses https://github.com/bbatsov/rubocop/issues/3439 in a minimal way.
This ensures the ActiveRecord persistence methods are handled the same way if a block is used.
I intend a future PR to improve this cop to look specifically for use of persisted?