### PR TITLE
Add check for persisted? when using an ActiveRecord create method in Rails/SaveBang

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 * [#3167](https://github.com/bbatsov/rubocop/issues/3167): Add new `Style/VariableNumber` cop. ([@sooyang][])
 * Add new style `no_mixed_keys` to `Style/HashSyntax` to only check for hashes with mixed keys. ([@daviddavis][])
 * Allow including multiple configuration files from a single gem. ([@tjwallace][])
+* Add check for `persisted?` method call when using a create method in `Rails/SaveBang`. ([@QuinnHarris][])
 
 ### Bug fixes
 

--- a/lib/rubocop/cop/rails/save_bang.rb
+++ b/lib/rubocop/cop/rails/save_bang.rb
@@ -8,10 +8,12 @@ module RuboCop
       # should be used instead of save because the model might have failed to
       # save and an exception is better than unhandled failure.
       #
-      # This will ignore calls that are assigned to a variable or used as the
-      # condition in an if/unless statement.  It will also ignore any call with
-      # more than 2 arguments as that is likely not an Active Record call or
-      # if a Model.update(id, attributes) call.
+      # This will ignore calls that return a boolean for success if the result
+      # is assigned to a variable or used as the condition in an if/unless
+      # statement.  It will also ignore calls that return a model assigned to a
+      # variable that has a call to `persisted?`. Finally, it will ignore any
+      # call with more than 2 arguments as that is likely not an Active Record
+      # call or a Model.update(id, attributes) call.
       #
       # @example
       #
@@ -29,17 +31,53 @@ module RuboCop
       #   user.update!(name: 'Joe')
       #   user.find_or_create_by!(name: 'Joe')
       #   user.destroy!
+      #
+      #   user = User.find_or_create_by(name: 'Joe')
+      #   unless user.persisted?
+      #      . . .
+      #   end
       class SaveBang < Cop
         MSG = 'Use `%s` instead of `%s` if the return value is not checked.'
               .freeze
+        CREATE_MSG = (MSG +
+                      ' Or check `persisted?` on model returned from `%s`.')
+                     .freeze
 
-        PERSIST_METHODS = [:save, :create, :update, :destroy,
-                           :first_or_create, :find_or_create_by].freeze
+        CREATE_PERSIST_METHODS = [:create,
+                                  :first_or_create, :find_or_create_by].freeze
+        MODIFY_PERSIST_METHODS = [:save, :update, :destroy].freeze
+        PERSIST_METHODS = (CREATE_PERSIST_METHODS +
+                           MODIFY_PERSIST_METHODS).freeze
+
+        def join_force?(force_class)
+          force_class == VariableForce
+        end
+
+        def after_leaving_scope(scope, _variable_table)
+          scope.variables.each do |_name, variable|
+            variable.assignments.each do |assignment|
+              check_assignment(assignment)
+            end
+          end
+        end
+
+        def check_assignment(assignment)
+          node = right_assignment_node(assignment)
+          return unless CREATE_PERSIST_METHODS.include?(node.method_name)
+          return unless expected_signature?(node)
+          return if persisted_referenced?(assignment)
+
+          add_offense(node, node.loc.selector,
+                      format(CREATE_MSG,
+                             "#{node.method_name}!",
+                             node.method_name.to_s,
+                             node.method_name.to_s))
+        end
 
         def on_send(node)
           return unless PERSIST_METHODS.include?(node.method_name)
-          return if return_value_used?(node)
           return unless expected_signature?(node)
+          return if return_value_used?(node)
 
           add_offense(node, node.loc.selector,
                       format(MSG,
@@ -55,6 +93,19 @@ module RuboCop
         end
 
         private
+
+        def right_assignment_node(assignment)
+          node = assignment.node.child_nodes.first
+          return node unless node.block_type?
+          node.child_nodes.first
+        end
+
+        def persisted_referenced?(assignment)
+          return unless assignment.referenced?
+          assignment.variable.references.any? do |reference|
+            reference.node.parent.method_name == :persisted?
+          end
+        end
 
         # Ignore simple assignment or if condition
         def return_value_used?(node)

--- a/spec/rubocop/cop/rails/save_bang_spec.rb
+++ b/spec/rubocop/cop/rails/save_bang_spec.rb
@@ -5,7 +5,7 @@ require 'spec_helper'
 describe RuboCop::Cop::Rails::SaveBang do
   subject(:cop) { described_class.new }
 
-  shared_examples 'checks_offense' do |method|
+  shared_examples 'checks_common_offense' do |method|
     it "when using #{method} with arguments" do
       inspect_source(cop, "object.#{method}(name: 'Tom', age: 20)")
 
@@ -44,20 +44,6 @@ describe RuboCop::Cop::Rails::SaveBang do
       expect(cop.messages).to be_empty
     end
 
-    it "when assigning the return value of #{method}" do
-      inspect_source(cop, "x = object.#{method}")
-
-      expect(cop.messages).to be_empty
-    end
-
-    it "when assigning the return value of #{method} with block" do
-      inspect_source(cop, "x = object.#{method} do |obj|\n" \
-                          "  obj.name = 'Tom'\n" \
-                          'end')
-
-      expect(cop.messages).to be_empty
-    end
-
     it "when using #{method} with if" do
       inspect_source(cop, "if object.#{method}; something; end")
 
@@ -71,7 +57,62 @@ describe RuboCop::Cop::Rails::SaveBang do
     end
   end
 
-  described_class::PERSIST_METHODS.each do |method|
-    it_behaves_like('checks_offense', method)
+  shared_examples 'checks_variable_assign_only_offense' do |method, pass|
+    it "when assigning the return value of #{method}" do
+      inspect_source(cop, "x = object.#{method}\n")
+
+      if pass
+        expect(cop.messages).to be_empty
+      else
+        expect(cop.messages)
+          .to eq(["Use `#{method}!` instead of `#{method}` " \
+                  'if the return value is not checked.' \
+                  " Or check `persisted?` on model returned from `#{method}`."])
+      end
+    end
+
+    it "when assigning the return value of #{method} with block" do
+      inspect_source(cop, "x = object.#{method} do |obj|\n" \
+                          "  obj.name = 'Tom'\n" \
+                          'end')
+
+      if pass
+        expect(cop.messages).to be_empty
+      else
+        expect(cop.messages)
+          .to eq(["Use `#{method}!` instead of `#{method}` " \
+                  'if the return value is not checked.' \
+                  " Or check `persisted?` on model returned from `#{method}`."])
+      end
+    end
+  end
+
+  described_class::MODIFY_PERSIST_METHODS.each do |method|
+    it_behaves_like('checks_common_offense', method)
+    it_behaves_like('checks_variable_assign_only_offense', method, true)
+  end
+
+  shared_examples 'checks_create_offense' do |method|
+    it "when using persisted? after #{method}" do
+      inspect_source(cop, "x = object.#{method}\n" \
+                          'if x.persisted? then; something; end')
+
+      expect(cop.messages).to be_empty
+    end
+
+    it "when using persisted? after #{method} with block" do
+      inspect_source(cop, "x = object.#{method} do |obj|\n" \
+                          "  obj.name = 'Tom'\n" \
+                          "end\n" \
+                          'if x.persisted? then; something; end')
+
+      expect(cop.messages).to be_empty
+    end
+  end
+
+  described_class::CREATE_PERSIST_METHODS.each do |method|
+    it_behaves_like('checks_common_offense', method)
+    it_behaves_like('checks_variable_assign_only_offense', method, false)
+    it_behaves_like('checks_create_offense', method)
   end
 end


### PR DESCRIPTION
This uses the VariableForce to ensure persisted? is called on a model returned from an ActiveRecord create method that doesn't raise an exception.

This makes the `Rails/SaveBang` cop act more like expected on bug https://github.com/bbatsov/rubocop/issues/3439
and is currently built on that bug fix https://github.com/bbatsov/rubocop/pull/3466
