### PR TITLE
[Implement #3379] Add table of contents at the beginning of HTML formatted output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### New features
 
+* [#3379](https://github.com/bbatsov/rubocop/issues/3379): Add table of contents at the beginning of HTML formatted output. ([@hedgesky][])
 * [#2968](https://github.com/bbatsov/rubocop/issues/2968): Add new `Style/DocumentationMethod` cop. ([@sooyang][])
 * [#3360](https://github.com/bbatsov/rubocop/issues/3360): Add `RequireForNonPublicMethods` configuration option to `Style/DocumentationMethod` cop. ([@drenmi][])
 * Add new `Rails/SafeNavigation` cop to convert `try!` to `&.`. ([@rrosenblum][])
@@ -2343,3 +2344,4 @@
 [@nicklamuro]: https://github.com/nicklamuro
 [@mikezter]: https://github.com/mikezter
 [@joejuzl]: https://github.com/joejuzl
+[@hedgesky]: https://github.com/hedgesky

--- a/assets/output.html.erb
+++ b/assets/output.html.erb
@@ -70,13 +70,12 @@
     line-height: 2.2rem;
     margin: 0 0 0.5em;
     }
-    .information .infobox ul {
-    list-style: none;
-    margin: 0;
-    padding: 0;
-    }
-    .information .infobox ul li {
+    .information .offenses-list li {
     line-height: 1.8rem
+    }
+    .information .offenses-list {
+    padding-left: 20px;
+    margin-bottom: 0;
     }
 
     #offenses .offense-box {
@@ -191,7 +190,7 @@
           idx,
           scrollY = window.scrollY;
         for (i = 0; i < boxPositions.length; i++) {
-          if (scrollY <= boxPositions[i]) {
+          if (scrollY <= boxPositions[i] - 1) {
             idx = i;
             break;
           }
@@ -214,14 +213,26 @@
     </div>
     <div class="information">
       <div class="infobox">
-        <%= pluralize(files.count, 'file') %> inspected,
-        <%= pluralize(summary.offense_count, 'offense', no_for_zero: true) %> detected
+        <div class="total">
+          <%= pluralize(files.count, 'file') %> inspected,
+          <%= pluralize(summary.offense_count, 'offense', no_for_zero: true) %> detected:
+        </div>
+        <ul class="offenses-list">
+          <% files.each do |file| %>
+            <% next if file.offenses.none? %>
+            <li>
+              <a href="#offense_<%= relative_path(file.path) %>">
+                <%= relative_path(file.path) %> - <%= pluralize(file.offenses.count, 'offense') %>
+              </a>
+            </li>
+          <% end %>
+        </ul>
       </div>
     </div>
     <div id="offenses">
       <% files.each do |file| %>
       <% if file.offenses.any? %>
-      <div class="offense-box">
+      <div class="offense-box" id="offense_<%= relative_path(file.path) %>">
         <div class="box-title-placeholder"><h3>&nbsp;</h3></div>
         <div class="box-title"><h3><%= relative_path(file.path) %> - <%= pluralize(file.offenses.count, 'offense') %></h3></div>
         <div class="offense-reports">

--- a/spec/fixtures/html_formatter/expected.html
+++ b/spec/fixtures/html_formatter/expected.html
@@ -70,13 +70,12 @@
     line-height: 2.2rem;
     margin: 0 0 0.5em;
     }
-    .information .infobox ul {
-    list-style: none;
-    margin: 0;
-    padding: 0;
-    }
-    .information .infobox ul li {
+    .information .offenses-list li {
     line-height: 1.8rem
+    }
+    .information .offenses-list {
+    padding-left: 20px;
+    margin-bottom: 0;
     }
 
     #offenses .offense-box {
@@ -223,7 +222,7 @@
           idx,
           scrollY = window.scrollY;
         for (i = 0; i < boxPositions.length; i++) {
-          if (scrollY <= boxPositions[i]) {
+          if (scrollY <= boxPositions[i] - 1) {
             idx = i;
             break;
           }
@@ -366,14 +365,40 @@ TvFXMeuCkZPcaEBLqvgPBhCuiZo8+sAAAAAASUVORK5CYII=
     </div>
     <div class="information">
       <div class="infobox">
-        3 files inspected,
-        16 offenses detected
+        <div class="total">
+          3 files inspected,
+          16 offenses detected:
+        </div>
+        <ul class="offenses-list">
+          
+            
+            <li>
+              <a href="#offense_app/controllers/application_controller.rb">
+                app/controllers/application_controller.rb - 2 offenses
+              </a>
+            </li>
+          
+            
+            <li>
+              <a href="#offense_app/controllers/books_controller.rb">
+                app/controllers/books_controller.rb - 8 offenses
+              </a>
+            </li>
+          
+            
+            <li>
+              <a href="#offense_app/models/book.rb">
+                app/models/book.rb - 6 offenses
+              </a>
+            </li>
+          
+        </ul>
       </div>
     </div>
     <div id="offenses">
       
       
-      <div class="offense-box">
+      <div class="offense-box" id="offense_app/controllers/application_controller.rb">
         <div class="box-title-placeholder"><h3>&nbsp;</h3></div>
         <div class="box-title"><h3>app/controllers/application_controller.rb - 2 offenses</h3></div>
         <div class="offense-reports">
@@ -405,7 +430,7 @@ TvFXMeuCkZPcaEBLqvgPBhCuiZo8+sAAAAAASUVORK5CYII=
       
       
       
-      <div class="offense-box">
+      <div class="offense-box" id="offense_app/controllers/books_controller.rb">
         <div class="box-title-placeholder"><h3>&nbsp;</h3></div>
         <div class="box-title"><h3>app/controllers/books_controller.rb - 8 offenses</h3></div>
         <div class="offense-reports">
@@ -503,7 +528,7 @@ TvFXMeuCkZPcaEBLqvgPBhCuiZo8+sAAAAAASUVORK5CYII=
       
       
       
-      <div class="offense-box">
+      <div class="offense-box" id="offense_app/models/book.rb">
         <div class="box-title-placeholder"><h3>&nbsp;</h3></div>
         <div class="box-title"><h3>app/models/book.rb - 6 offenses</h3></div>
         <div class="offense-reports">


### PR DESCRIPTION
This PR implements #3379: now the list of offended files with links to them is generated at the beginning of HTML formatted output, giving us ability to quickly navigate to a particular place. As a nice side effect, now it's easy to craft a link to a certain place in report. It could be handy in some situations.