### PR TITLE
Allow including multiple configuration files from a single gem

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 * [#3415](https://github.com/bbatsov/rubocop/pull/3415): Add new `Rails/NotNullColumn` cop. ([@pocke][])
 * [#3167](https://github.com/bbatsov/rubocop/issues/3167): Add new `Style/VariableNumber` cop. ([@sooyang][])
 * Add new style `no_mixed_keys` to `Style/HashSyntax` to only check for hashes with mixed keys. ([@daviddavis][])
+* Allow including multiple configuration files from a single gem. ([@tjwallace][])
 
 ### Bug fixes
 
@@ -2345,3 +2346,4 @@
 [@mikezter]: https://github.com/mikezter
 [@joejuzl]: https://github.com/joejuzl
 [@hedgesky]: https://github.com/hedgesky
+[@tjwallace]: https://github.com/tjwallace

--- a/lib/rubocop/config_loader_resolver.rb
+++ b/lib/rubocop/config_loader_resolver.rb
@@ -34,8 +34,10 @@ module RuboCop
         end
 
         hash['inherit_from'] = Array(hash['inherit_from'])
-        # Put gem configuration first so local configuration overrides it.
-        hash['inherit_from'].unshift gem_config_path(gem_name, config_path)
+        Array(config_path).reverse.each do |path|
+          # Put gem configuration first so local configuration overrides it.
+          hash['inherit_from'].unshift gem_config_path(gem_name, path)
+        end
       end
     end
   end

--- a/manual/configuration.md
+++ b/manual/configuration.md
@@ -102,6 +102,16 @@ inherit_gem:
   cucumber: conf/rubocop.yml
 ```
 
+An array can also be used as the value to include multiple configuration files
+from a single gem:
+
+```yaml
+inherit_gem:
+  my-shared-gem:
+    - default.yml
+    - strict.yml
+```
+
 **Note**: If the shared dependency is declared using a [Bundler](http://bundler.io/)
 Gemfile and the gem was installed using `bundle install`, it would be
 necessary to also invoke RuboCop using Bundler in order to find the

--- a/spec/rubocop/config_loader_spec.rb
+++ b/spec/rubocop/config_loader_spec.rb
@@ -335,33 +335,56 @@ describe RuboCop::ConfigLoader do
       let(:file_path) { '.rubocop.yml' }
 
       before do
-        create_file('somegemname/config/rubocop.yml',
+        create_file('gemone/config/rubocop.yml',
                     ['Metrics/MethodLength:',
                      '  Enabled: false',
                      '  Max: 200',
                      '  CountComments: false'])
+        create_file('gemtwo/config/default.yml',
+                    ['Metrics/LineLength:',
+                     '  Enabled: true'])
+        create_file('gemtwo/config/strict.yml',
+                    ['Metrics/LineLength:',
+                     '  Max: 72',
+                     '  AllowHeredoc: false'])
         create_file('local.yml',
                     ['Metrics/MethodLength:',
                      '  CountComments: true'])
         create_file(file_path,
                     ['inherit_gem:',
-                     '  somegemname: config/rubocop.yml',
+                     '  gemone: config/rubocop.yml',
+                     '  gemtwo:',
+                     '    - config/default.yml',
+                     '    - config/strict.yml',
                      '',
                      'inherit_from: local.yml',
                      '',
                      'Metrics/MethodLength:',
-                     '  Enabled: true'])
+                     '  Enabled: true',
+                     '',
+                     'Metrics/LineLength:',
+                     '  AllowURI: false'])
       end
 
       it 'returns values from the gem config with local overrides' do
-        mock_spec = Struct.new(:gem_dir).new('somegemname')
-        expect(Gem::Specification).to receive(:find_by_name)
-          .at_least(:once).with('somegemname').and_return(mock_spec)
+        gem_class = Struct.new(:gem_dir)
+        %w(gemone gemtwo).each do |gem_name|
+          mock_spec = gem_class.new(gem_name)
+          expect(Gem::Specification).to receive(:find_by_name)
+            .at_least(:once).with(gem_name).and_return(mock_spec)
+        end
 
         expected = { 'Enabled' => true,        # overridden in .rubocop.yml
                      'CountComments' => true,  # overridden in local.yml
                      'Max' => 200 }            # inherited from somegem
         expect(configuration_from_file['Metrics/MethodLength'].to_set)
+          .to be_superset(expected.to_set)
+
+        expected = { 'Enabled' => true,        # gemtwo/config/default.yml
+                     'Max' => 72,              # gemtwo/config/strict.yml
+                     'AllowHeredoc' => false,  # gemtwo/config/strict.yml
+                     'AllowURI' => false }     # overridden in .rubocop.yml
+        expect(configuration_from_file['Metrics/LineLength'].to_set)
           .to be_superset(expected.to_set)
       end
     end


### PR DESCRIPTION
This allows more granularity in shared configuration files. For example, you could have `default.yml` and a `rails.yml` configuration files and include them appropriately depending on the project.