### PR TITLE
Change misleading message of `Style/EmptyLinesAroundAccessModifier:`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,7 @@
 * No longer register an offense for splat expansion of an array literal in `Performance/CaseWhenSplat`. `Lint/UnneededSplatExpansion` now handles this behavior. ([@rrosenblum][])
 * `Lint/InheritException` restricts inheriting from standard library subclasses of `Exception`. ([@metcalf][])
 * No longer register an offense if the first line of code starts with `#\` in `Style/LeadingCommentSpace`. `config.ru` files consider such lines as options. ([@scottohara][])
+* Change misleading message for `Style/EmptyLinesAroundAccessModifier:`. ([@shockwavenn][])
 
 ## 0.42.0 (2016-07-25)
 
@@ -2350,3 +2351,4 @@
 [@hedgesky]: https://github.com/hedgesky
 [@tjwallace]: https://github.com/tjwallace
 [@scottohara]: https://github.com/scottohara
+[@shockwavenn]: https://github.com/shockwavenn

--- a/lib/rubocop/cop/style/empty_lines_around_access_modifier.rb
+++ b/lib/rubocop/cop/style/empty_lines_around_access_modifier.rb
@@ -8,7 +8,8 @@ module RuboCop
       class EmptyLinesAroundAccessModifier < Cop
         include AccessModifierNode
 
-        MSG = 'Keep a blank line before and after `%s`.'.freeze
+        MSG = 'Keep a blank line after `%s`. And before, '\
+              'if it is not first line of module.'.freeze
 
         def on_send(node)
           return unless modifier_node?(node)

--- a/spec/fixtures/html_formatter/expected.html
+++ b/spec/fixtures/html_formatter/expected.html
@@ -483,7 +483,7 @@ TvFXMeuCkZPcaEBLqvgPBhCuiZo8+sAAAAAASUVORK5CYII=
             <div class="meta">
               <span class="location">Line #64</span> –
               <span class="severity convention">convention:</span>
-              <span class="message">Keep a blank line before and after <code>private</code>.</span>
+              <span class="message">Keep a blank line after <code>private</code>. And before, if it is not first line of module.</span>
             </div>
             
             <pre><code>  <span class="highlight convention">private</span></code></pre>

--- a/spec/rubocop/cli/cli_autocorrect_spec.rb
+++ b/spec/rubocop/cli/cli_autocorrect_spec.rb
@@ -717,8 +717,8 @@ describe RuboCop::CLI, :isolated_environment do
               'comment.',
               "#{e}:3:1: C: [Corrected] Indent access modifiers like " \
               '`private`.',
-              "#{e}:3:1: C: [Corrected] Keep a blank line before and " \
-              'after `private`.',
+              "#{e}:3:1: C: [Corrected] Keep a blank line after " \
+              '`private`. And before, if it is not first line of module.',
               "#{e}:3:3: W: Useless `private` access modifier.",
               "#{e}:4:7: C: [Corrected] Freeze mutable objects assigned " \
               'to constants.',

--- a/spec/rubocop/cop/style/empty_lines_around_access_modifier_spec.rb
+++ b/spec/rubocop/cop/style/empty_lines_around_access_modifier_spec.rb
@@ -17,7 +17,8 @@ describe RuboCop::Cop::Style::EmptyLinesAroundAccessModifier do
                       'end'])
       expect(cop.offenses.size).to eq(1)
       expect(cop.messages)
-        .to eq(["Keep a blank line before and after `#{access_modifier}`."])
+        .to eq(["Keep a blank line after `#{access_modifier}`. "\
+                'And before, if it is not first line of module.'])
     end
 
     it "requires blank line after #{access_modifier}" do
@@ -30,7 +31,8 @@ describe RuboCop::Cop::Style::EmptyLinesAroundAccessModifier do
                       'end'])
       expect(cop.offenses.size).to eq(1)
       expect(cop.messages)
-        .to eq(["Keep a blank line before and after `#{access_modifier}`."])
+        .to eq(["Keep a blank line after `#{access_modifier}`. "\
+                'And before, if it is not first line of module.'])
     end
 
     it "ignores comment line before #{access_modifier}" do


### PR DESCRIPTION
If we have file `test.rb` with code:
```
module A
  private
  def a
  end
end
```
rubocop show warning: `test.rb:2:3: C: Keep a blank line before and after private.`
Ok, manually add blank line before and after private:
```
module A

  private

  def a
  end
end
```
No good: `test.rb:2:1: C: Extra empty line detected at module body beginning.`
So I changed message to 
`Keep a blank line after `%s`. And before, if it is not first line of module.`

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Used the same coding conventions as the rest of the project.
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] All tests are passing.
* [x] The new code doesn't generate RuboCop offenses.
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.

[1]: http://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html