### PR TITLE
Fix memoization in RuboCop::Config

### DIFF
--- a/lib/rubocop/config.rb
+++ b/lib/rubocop/config.rb
@@ -208,7 +208,9 @@ module RuboCop
     # Returns true if there's a chance that an Include pattern matches hidden
     # files, false if that's definitely not possible.
     def possibly_include_hidden?
-      @possibly_include_hidden ||= patterns_to_include.any? do |s|
+      return @possibly_include_hidden if defined?(@possibly_include_hidden)
+
+      @possibly_include_hidden = patterns_to_include.any? do |s|
         s.is_a?(Regexp) || s.start_with?('.') || s.include?('/.')
       end
     end

--- a/lib/rubocop/config.rb
+++ b/lib/rubocop/config.rb
@@ -223,11 +223,11 @@ module RuboCop
     end
 
     def patterns_to_include
-      @patterns_to_include ||= for_all_cops['Include']
+      for_all_cops['Include']
     end
 
     def patterns_to_exclude
-      @patterns_to_exclude ||= for_all_cops['Exclude']
+      for_all_cops['Exclude']
     end
 
     def path_relative_to_config(path)

--- a/spec/rubocop/config_spec.rb
+++ b/spec/rubocop/config_spec.rb
@@ -275,6 +275,40 @@ describe RuboCop::Config do
     end
   end
 
+  describe '#possibly_include_hidden?' do
+    subject(:configuration) do
+      described_class.new(hash, loaded_path)
+    end
+
+    let(:loaded_path) { 'example/.rubocop.yml' }
+
+    it 'returns true when Include config only includes regular paths' do
+      configuration['AllCops'] = {
+        'Include' => ['**/Gemfile', 'config/unicorn.rb.example']
+      }
+
+      expect(configuration.possibly_include_hidden?).to be(false)
+    end
+
+    it 'returns true when Include config includes a regex' do
+      configuration['AllCops'] = { 'Include' => [/foo/] }
+
+      expect(configuration.possibly_include_hidden?).to be(true)
+    end
+
+    it 'returns true when Include config includes a toplevel dotfile' do
+      configuration['AllCops'] = { 'Include' => ['.foo'] }
+
+      expect(configuration.possibly_include_hidden?).to be(true)
+    end
+
+    it 'returns true when Include config includes a dotfile in a path' do
+      configuration['AllCops'] = { 'Include' => ['foo/.bar'] }
+
+      expect(configuration.possibly_include_hidden?).to be(true)
+    end
+  end
+
   describe '#patterns_to_exclude' do
     subject(:patterns_to_exclude) do
       configuration = described_class.new(hash, loaded_path)


### PR DESCRIPTION
I found 2 issues with the memoization in different `RuboCop::Config` methods:

 1. The `||=` memoization pattern doesn't work when the result is `false` or `nil`. In this particular case, the result is a boolean, so it definitely needs to work for `false` as well as for `true`.
 2. The methods `#patterns_to_include` and `#patterns_to_exclude` were memoizing a hash lookup. The hash is generated from a method call (`#for_all_cops`) which is itself memoized.

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Used the same coding conventions as the rest of the project.
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [ ] Added tests.
* [x] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] All tests are passing.
* [x] The new code doesn't generate RuboCop offenses.
* [ ] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.

[1]: http://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html