### PR TITLE
Don't inherit from Hash

### DIFF
--- a/lib/rubocop/config.rb
+++ b/lib/rubocop/config.rb
@@ -11,7 +11,7 @@ module RuboCop
   # file from which it was read. Several different Configs can be used
   # during a run of the rubocop program, if files in several
   # directories are inspected.
-  class Config < Hash
+  class Config
     include PathUtil
 
     COMMON_PARAMS = %w(Exclude Include Severity
@@ -43,12 +43,76 @@ module RuboCop
 
     attr_reader :loaded_path
 
+    def self.[](hash)
+      new(hash)
+    end
+
     def initialize(hash = {}, loaded_path = nil)
       @loaded_path = loaded_path
       @for_cop = Hash.new do |h, cop|
         h[cop] = self[Cop::Cop.qualified_cop_name(cop, loaded_path)] || {}
       end
-      replace(hash)
+      @hash = hash
+    end
+
+    def ==(other)
+      other.is_a?(Hash) ? @hash == other : super
+    end
+
+    def [](key)
+      @hash[key]
+    end
+
+    def []=(key, value)
+      @hash[key] = value
+    end
+
+    def delete(key)
+      @hash.delete(key)
+    end
+
+    def each(&block)
+      @hash.each(&block)
+    end
+
+    def each_key(&block)
+      @hash.each_key(&block)
+    end
+
+    def eql?(other)
+      other.is_a?(Hash) ? @hash.eql?(other) : super
+    end
+
+    def fetch(key)
+      @hash.fetch(key)
+    end
+
+    def key?(key)
+      @hash.key?(key)
+    end
+
+    def keys
+      @hash.keys
+    end
+
+    def map(&block)
+      @hash.map(&block)
+    end
+
+    def merge(other_hash)
+      @hash.merge(other_hash)
+    end
+
+    def to_h
+      @hash
+    end
+
+    def to_hash
+      @hash
+    end
+
+    def to_s
+      @hash.to_s
     end
 
     def make_excludes_absolute

--- a/lib/rubocop/config.rb
+++ b/lib/rubocop/config.rb
@@ -112,7 +112,7 @@ module RuboCop
     end
 
     def to_s
-      @hash.to_s
+      @to_s ||= @hash.to_s
     end
 
     def make_excludes_absolute

--- a/spec/rubocop/config_store_spec.rb
+++ b/spec/rubocop/config_store_spec.rb
@@ -20,7 +20,7 @@ describe RuboCop::ConfigStore do
     allow(RuboCop::ConfigLoader)
       .to receive(:load_file) { |arg| RuboCop::Config.new(arg) }
     allow(RuboCop::ConfigLoader)
-      .to receive(:merge_with_default) { |config| "merged #{config}" }
+      .to receive(:merge_with_default) { |config| "merged #{config.to_h}" }
   end
 
   describe '.for' do


### PR DESCRIPTION
Inheriting from Ruby base classes [is problematic](https://tenderlovemaking.com/2014/06/02/yagni-methods-are-killing-me.html) and should be avoided, in my opinion.

With the current implementation, we are actually setting instance variables on an instance of `Hash`…

~~I have a performance optimization for the Config class that depends on this commit, but due to the “The PR relates to *only* one subject” constraint, that’ll have to wait~~

The 2nd commit is a performance optimization of `RuboCop::Config#to_s` that was previously introduced in 5806b71f43a7c959afd42c970f82f25870105edf, but accidentally removed in 0a74efa4accc6557c8cafb63bb249b67c73c30bc. Including the 2nd commit into this PR violates the “The PR relates to *only* one subject” decree, but on the other hand it’s what legitimizes removing the Hash superclass.

The runtime improvements when running on ~2500 files:
```
Before, cold cache
bin/rubocop  119.72s user 4.35s system 99% cpu 2:05.31 total

After, cold cache
bin/rubocop  117.67s user 4.53s system 96% cpu 2:06.31 total

Before, warm cache
bin/rubocop  12.72s user 1.55s system 97% cpu 14.582 total

After, warm cache
bin/rubocop  3.51s user 1.08s system 97% cpu 4.691 total
```

As you see, warm cache runtime improves by 2/3. On smaller projects, of course, the benefits are smaller.

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Used the same coding conventions as the rest of the project.
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [ ] Added tests.
* [x] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] All tests are passing.
* [x] The new code doesn't generate RuboCop offenses.
* [ ] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.

[1]: http://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html
