### PR TITLE
Fix failure to handle no right hand side for assignments in `Rails/SaveBang`

### DIFF
--- a/lib/rubocop/cop/rails/save_bang.rb
+++ b/lib/rubocop/cop/rails/save_bang.rb
@@ -65,6 +65,7 @@ module RuboCop
 
         def check_assignment(assignment)
           node = right_assignment_node(assignment)
+          return unless node
           return unless CREATE_PERSIST_METHODS.include?(node.method_name)
           return unless expected_signature?(node)
           return if persisted_referenced?(assignment)
@@ -99,7 +100,7 @@ module RuboCop
 
         def right_assignment_node(assignment)
           node = assignment.node.child_nodes.first
-          return node unless node.block_type?
+          return node unless node && node.block_type?
           node.child_nodes.first
         end
 

--- a/spec/rubocop/cop/rails/save_bang_spec.rb
+++ b/spec/rubocop/cop/rails/save_bang_spec.rb
@@ -120,4 +120,10 @@ describe RuboCop::Cop::Rails::SaveBang do
     it_behaves_like('checks_variable_return_use_offense', method, false)
     it_behaves_like('checks_create_offense', method)
   end
+
+  it 'properly ignores lvasign without right hand side' do
+    inspect_source(cop, 'variable += 1')
+
+    expect(cop.messages).to be_empty
+  end
 end


### PR DESCRIPTION
Recently merged PR https://github.com/bbatsov/rubocop/pull/3469 introduced a significant bug that this corrects.

I improperly assumed all lvasign nodes had a right hand side.
