### PR TITLE
Fix end of line on Windows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,7 @@
 * [#3456](https://github.com/bbatsov/rubocop/pull/3456): Don't crash on a multiline empty brace in `Style/MultilineMethodCallBraceLayout`. ([@pocke][])
 * [#3423](https://github.com/bbatsov/rubocop/issues/3423): Checks if .rubocop is a file before parsing. ([@joejuzl][])
 * [#3439](https://github.com/bbatsov/rubocop/issues/3439): Fix variable assignment check not working properly when a block is used in `Rails/SaveBang`. ([@QuinnHarris][])
+* [#3401](https://github.com/bbatsov/rubocop/issues/3401): Read file contents in binary mode so `Style/EndOfLine` works on Windows. ([@jonas054][])
 
 ### Changes
 

--- a/lib/rubocop/options.rb
+++ b/lib/rubocop/options.rb
@@ -145,7 +145,7 @@ module RuboCop
 
       option(opts, '-v', '--version')
       option(opts, '-V', '--verbose-version')
-      option(opts, '-s', '--stdin') { @options[:stdin] = $stdin.read }
+      option(opts, '-s', '--stdin') { @options[:stdin] = $stdin.binmode.read }
     end
 
     def add_list_options(opts)

--- a/lib/rubocop/processed_source.rb
+++ b/lib/rubocop/processed_source.rb
@@ -14,7 +14,7 @@ module RuboCop
                 :parser_error, :raw_source, :ruby_version
 
     def self.from_file(path, ruby_version)
-      file = File.read(path)
+      file = File.read(path, mode: 'rb')
       new(file, ruby_version, path)
     rescue Errno::ENOENT
       raise RuboCop::Error, "No such file or directory: #{path}"

--- a/lib/rubocop/target_finder.rb
+++ b/lib/rubocop/target_finder.rb
@@ -56,7 +56,7 @@ module RuboCop
     def target_files_in_dir(base_dir = Dir.pwd)
       # Support Windows: Backslashes from command-line -> forward slashes
       if File::ALT_SEPARATOR
-        base_dir.gsub!(File::ALT_SEPARATOR, File::SEPARATOR)
+        base_dir = base_dir.gsub(File::ALT_SEPARATOR, File::SEPARATOR)
       end
       all_files = find_files(base_dir, File::FNM_DOTMATCH)
       hidden_files = Set.new(all_files - find_files(base_dir, 0))

--- a/spec/rubocop/cli/cli_options_spec.rb
+++ b/spec/rubocop/cli/cli_options_spec.rb
@@ -1117,5 +1117,31 @@ describe RuboCop::CLI, :isolated_environment do
         $stdin = STDIN
       end
     end
+
+    it 'detects CR at end of line' do
+      begin
+        create_file('example.rb', "puts 'hello world'\r")
+        File.open('example.rb') do |file|
+          # We must use a File object to simulate the behavior of
+          # STDIN, which is an IO object. StringIO won't do in this
+          # case, as its read() method doesn't handle line endings the
+          # same way IO#read() does.
+          $stdin = file
+          argv = ['--only=Style/EndOfLine',
+                  '--format=simple',
+                  '--stdin',
+                  'fake.rb']
+          expect(cli.run(argv)).to eq(1)
+          expect($stdout.string)
+            .to eq(['== fake.rb ==',
+                    'C:  1:  1: Carriage return character detected.',
+                    '',
+                    '1 file inspected, 1 offense detected',
+                    ''].join("\n"))
+        end
+      ensure
+        $stdin = STDIN
+      end
+    end
   end
 end

--- a/spec/rubocop/cli_spec.rb
+++ b/spec/rubocop/cli_spec.rb
@@ -121,6 +121,22 @@ describe RuboCop::CLI, :isolated_environment do
     end
   end
 
+  context 'when lines end with CR+LF' do
+    it 'reports an offense' do
+      create_file('example.rb', ["# encoding: utf-8\r",
+                                 "x = 0\r",
+                                 "puts x\r"])
+      result = cli.run(['--format', 'simple', 'example.rb'])
+      expect(result).to eq(1)
+      expect($stdout.string)
+        .to eq(['== example.rb ==',
+                'C:  1:  1: Carriage return character detected.',
+                '',
+                '1 file inspected, 1 offense detected',
+                ''].join("\n"))
+    end
+  end
+
   context 'when checking a correct file' do
     it 'returns 0' do
       create_file('example.rb', ['# encoding: utf-8',

--- a/spec/support/file_helper.rb
+++ b/spec/support/file_helper.rb
@@ -10,7 +10,7 @@ module FileHelper
     dir_path = File.dirname(file_path)
     FileUtils.makedirs dir_path unless File.exist?(dir_path)
 
-    File.open(file_path, 'w') do |file|
+    File.open(file_path, 'wb') do |file|
       case content
       when ''
         # Write nothing. Create empty file.


### PR DESCRIPTION
Followed suggestion in #3401 how to resolve the problem. Tested on Windows.

Make sure file/stdin contents are read in binary mode so that CR+LF line endings are preserved. Otherwise `Style/EndOfLine` will never report on Windows.