### PR TITLE
[Fix #3485] Make OneLineConditional cop not register offense for empty else

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,7 @@
 * [#3401](https://github.com/bbatsov/rubocop/issues/3401): Read file contents in binary mode so `Style/EndOfLine` works on Windows. ([@jonas054][])
 * [#3450](https://github.com/bbatsov/rubocop/issues/3450): Prevent `Style/TernaryParentheses` cop from making unsafe corrections. ([@drenmi][])
 * [#3460](https://github.com/bbatsov/rubocop/issues/3460): Fix false positives in `Style/InlineComment` cop. ([@drenmi][])
+* [#3485](https://github.com/bbatsov/rubocop/issues/3485): Make OneLineConditional cop not register offense for empty else. ([@tejasbubane][])
 
 ### Changes
 

--- a/lib/rubocop/cop/style/one_line_conditional.rb
+++ b/lib/rubocop/cop/style/one_line_conditional.rb
@@ -15,8 +15,11 @@ module RuboCop
         def on_normal_if_unless(node)
           exp = node.source
           return if exp.include?("\n")
-          return unless node.loc.respond_to?(:else) && node.loc.else
+
           condition = exp.include?('if') ? 'if' : 'unless'
+          return unless node.loc.respond_to?(:else) &&
+                        node.loc.else &&
+                        else_branch_present?(node, condition)
 
           add_offense(node, :expression, format(MSG, condition))
         end
@@ -69,6 +72,13 @@ module RuboCop
           return true if node.keyword_not?
 
           !parenthesized_call?(node)
+        end
+
+        private
+
+        def else_branch_present?(node, condition)
+          _, if_branch, else_branch = *node
+          condition == 'if' ? else_branch : if_branch
         end
       end
     end

--- a/spec/rubocop/cop/style/one_line_conditional_spec.rb
+++ b/spec/rubocop/cop/style/one_line_conditional_spec.rb
@@ -6,44 +6,65 @@ require 'spec_helper'
 describe RuboCop::Cop::Style::OneLineConditional do
   subject(:cop) { described_class.new }
 
-  context 'one line if/then/else/end' do
-    let(:source) { 'if cond then run else dont end' }
-
+  shared_examples 'offense' do |condition|
     it 'registers an offense' do
       inspect_source(cop, source)
-      expect(cop.messages).to eq(['Favor the ternary operator (`?:`)' \
-                                  ' over `if/then/else/end` constructs.'])
-    end
-
-    it 'auto-corrects' do
-      corrected = autocorrect_source(cop, source)
-      expect(corrected).to eq('cond ? run : dont')
+      expect(cop.messages)
+        .to eq(['Favor the ternary operator (`?:`)' \
+                " over `#{condition}/then/else/end` constructs."])
     end
   end
 
-  it 'does not register an offense for if/then/end' do
-    inspect_source(cop, 'if cond then run end')
-    expect(cop.messages).to be_empty
+  shared_examples 'no offense' do
+    it 'does not register an offense' do
+      inspect_source(cop, source)
+      expect(cop.messages).to be_empty
+    end
+  end
+
+  shared_examples 'autocorrect' do |correct_code|
+    it 'auto-corrects' do
+      corrected = autocorrect_source(cop, source)
+      expect(corrected).to eq(correct_code)
+    end
+  end
+
+  context 'one line if/then/else/end' do
+    let(:source) { 'if cond then run else dont end' }
+
+    include_examples 'offense', 'if'
+    include_examples 'autocorrect', 'cond ? run : dont'
+
+    context 'empty else' do
+      let(:source) { 'if cond then run else end' }
+
+      include_examples 'no offense'
+    end
+  end
+
+  context 'one line if/then/end' do
+    let(:source) { 'if cond then run end' }
+
+    include_examples 'no offense'
   end
 
   context 'one line unless/then/else/end' do
     let(:source) { 'unless cond then run else dont end' }
 
-    it 'does register an offense for ' do
-      inspect_source(cop, source)
-      expect(cop.messages).to eq(['Favor the ternary operator (`?:`)' \
-                                  ' over `unless/then/else/end` constructs.'])
-    end
+    include_examples 'offense', 'unless'
+    include_examples 'autocorrect', 'cond ? dont : run'
 
-    it 'auto-corrects' do
-      corrected = autocorrect_source(cop, source)
-      expect(corrected).to eq('cond ? dont : run')
+    context 'empty else' do
+      let(:source) { 'unless cond then run else end' }
+
+      include_examples 'no offense'
     end
   end
 
-  it 'does not register an offense for one line unless/then/end' do
-    inspect_source(cop, 'unless cond then run end')
-    expect(cop.messages).to be_empty
+  context 'one line unless/then/end' do
+    let(:source) { 'unless cond then run end' }
+
+    include_examples 'no offense'
   end
 
   %w(| ^ & <=> == === =~ > >= < <= << >> + - * / % ** ~ ! != !~


### PR DESCRIPTION
This will let other cops like `EmptyElse` (for `if`) and `UnlessElse` (for `unless`) take priority over `OneLineConditional`.

Also refactored specs for the cop.

Closes #3485 

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Used the same coding conventions as the rest of the project.
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] All tests are passing.
* [x] The new code doesn't generate RuboCop offenses.
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.

[1]: http://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html