### PR TITLE
Fix StyleGuide links for method-invocation-parens

### DIFF
--- a/config/enabled.yml
+++ b/config/enabled.yml
@@ -402,7 +402,7 @@ Style/LineEndConcatenation:
 
 Style/MethodCallParentheses:
   Description: 'Do not use parentheses for method calls with no arguments.'
-  StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#no-args-no-parens'
+  StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#method-invocation-parens'
   Enabled: true
 
 Style/MethodDefParentheses:
@@ -998,7 +998,7 @@ Lint/AmbiguousOperator:
   Description: >-
                  Checks for ambiguous operators in the first argument of a
                  method invocation without parentheses.
-  StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#parens-as-args'
+  StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#method-invocation-parens'
   Enabled: true
 
 Lint/AmbiguousRegexpLiteral:


### PR DESCRIPTION
`#no-args-no-paren` and `#method-invocation-parens` anchors are gathered to `#method-invocations` in https://github.com/bbatsov/ruby-style-guide .
So, I've replaced them.

See. https://github.com/bbatsov/ruby-style-guide/pull/570

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] All tests are passing.
* [x] The new code doesn't generate RuboCop offenses.
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.

[1]: http://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html

