### PR TITLE
Replace `Fixnum` to `Integer`

### DIFF
--- a/config/default.yml
+++ b/config/default.yml
@@ -1081,7 +1081,7 @@ Style/WordArray:
 ##################### Metrics ##################################
 
 Metrics/AbcSize:
-  # The ABC size is a calculated magnitude, so this number can be a Fixnum or
+  # The ABC size is a calculated magnitude, so this number can be an Integer or
   # a Float.
   Max: 15
 

--- a/config/enabled.yml
+++ b/config/enabled.yml
@@ -260,7 +260,7 @@ Style/EndOfLine:
   Enabled: true
 
 Style/EvenOdd:
-  Description: 'Favor the use of Fixnum#even? && Fixnum#odd?'
+  Description: 'Favor the use of Integer#even? && Integer#odd?'
   StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#predicate-methods'
   Enabled: true
 
@@ -1368,7 +1368,7 @@ Performance/ReverseEach:
 Performance/Sample:
   Description: >-
                   Use `sample` instead of `shuffle.first`,
-                  `shuffle.last`, and `shuffle[Fixnum]`.
+                  `shuffle.last`, and `shuffle[Integer]`.
   Reference: 'https://github.com/JuanitoFatas/fast-ruby#arrayshufflefirst-vs-arraysample-code'
   Enabled: true
 

--- a/lib/rubocop/cli.rb
+++ b/lib/rubocop/cli.rb
@@ -19,7 +19,7 @@ module RuboCop
     # Entry point for the application logic. Here we
     # do the command line arguments processing and inspect
     # the target files
-    # @return [Fixnum] UNIX exit code
+    # @return [Integer] UNIX exit code
     def run(args = ARGV)
       @options, paths = Options.new.parse(args)
       act_on_options

--- a/lib/rubocop/cop/style/even_odd.rb
+++ b/lib/rubocop/cop/style/even_odd.rb
@@ -4,7 +4,7 @@
 module RuboCop
   module Cop
     module Style
-      # This cop checks for places where Fixnum#even? or Fixnum#odd?
+      # This cop checks for places where Integer#even? or Integer#odd?
       # should have been used.
       #
       # @example
@@ -15,7 +15,7 @@ module RuboCop
       #   # good
       #   if x.even?
       class EvenOdd < Cop
-        MSG = 'Replace with `Fixnum#%s?`.'.freeze
+        MSG = 'Replace with `Integer#%s?`.'.freeze
 
         ZERO = s(:int, 0)
         ONE = s(:int, 1)

--- a/lib/rubocop/token.rb
+++ b/lib/rubocop/token.rb
@@ -15,7 +15,7 @@ module RuboCop
     def initialize(pos, type, text)
       @pos = pos
       @type = type
-      # Parser token "text" may be a Fixnum
+      # Parser token "text" may be an Integer
       @text = text.to_s
     end
 

--- a/relnotes/v0.30.0.md
+++ b/relnotes/v0.30.0.md
@@ -28,7 +28,7 @@ Thanks to everyone who contributed to this release!
 * New cop `Performance/Detect` to detect usage of `select.first`, `select.last`, `find_all.first`, and `find_all.last` and convert them to use `detect` instead. ([@palkan][], [@rrosenblum][])
 * [#1728](https://github.com/bbatsov/rubocop/pull/1728): New cop `NonLocalExitFromIterator` checks for misused `return` in block. ([@ypresto][])
 * New cop `Performance/Size` to convert calls to `count` on `Array` and `Hash` to `size`. ([@rrosenblum][])
-* New cop `Performance/Sample` to convert usages of `shuffle.first`, `shuffle.last`, and `shuffle[Fixnum]` to `sample`. ([@rrosenblum][])
+* New cop `Performance/Sample` to convert usages of `shuffle.first`, `shuffle.last`, and `shuffle[Integer]` to `sample`. ([@rrosenblum][])
 * New cop `Performance/FlatMap` to convert `Enumerable#map...Array#flatten` and `Enumerable#collect...Array#flatten` to `Enumerable#flat_map`. ([@rrosenblum][])
 * [#1144](https://github.com/bbatsov/rubocop/issues/1144): New cop `ClosingParenthesisIndentation` checks the indentation of hanging closing parentheses. ([@jonas054][])
 * New Rails cop `FindBy` identifies usages of `where.first` and `where.take`. ([@bbatsov][])

--- a/spec/rubocop/cop/style/even_odd_spec.rb
+++ b/spec/rubocop/cop/style/even_odd_spec.rb
@@ -9,61 +9,61 @@ describe RuboCop::Cop::Style::EvenOdd do
   it 'registers an offense for x % 2 == 0' do
     inspect_source(cop, 'x % 2 == 0')
     expect(cop.offenses.size).to eq(1)
-    expect(cop.messages).to eq(['Replace with `Fixnum#even?`.'])
+    expect(cop.messages).to eq(['Replace with `Integer#even?`.'])
   end
 
   it 'registers an offense for x % 2 != 0' do
     inspect_source(cop, 'x % 2 != 0')
     expect(cop.offenses.size).to eq(1)
-    expect(cop.messages).to eq(['Replace with `Fixnum#odd?`.'])
+    expect(cop.messages).to eq(['Replace with `Integer#odd?`.'])
   end
 
   it 'registers an offense for (x % 2) == 0' do
     inspect_source(cop, '(x % 2) == 0')
     expect(cop.offenses.size).to eq(1)
-    expect(cop.messages).to eq(['Replace with `Fixnum#even?`.'])
+    expect(cop.messages).to eq(['Replace with `Integer#even?`.'])
   end
 
   it 'registers an offense for (x % 2) != 0' do
     inspect_source(cop, '(x % 2) != 0')
     expect(cop.offenses.size).to eq(1)
-    expect(cop.messages).to eq(['Replace with `Fixnum#odd?`.'])
+    expect(cop.messages).to eq(['Replace with `Integer#odd?`.'])
   end
 
   it 'registers an offense for x % 2 == 1' do
     inspect_source(cop, 'x % 2 == 1')
     expect(cop.offenses.size).to eq(1)
-    expect(cop.messages).to eq(['Replace with `Fixnum#odd?`.'])
+    expect(cop.messages).to eq(['Replace with `Integer#odd?`.'])
   end
 
   it 'registers an offense for x % 2 != 1' do
     inspect_source(cop, 'x % 2 != 1')
     expect(cop.offenses.size).to eq(1)
-    expect(cop.messages).to eq(['Replace with `Fixnum#even?`.'])
+    expect(cop.messages).to eq(['Replace with `Integer#even?`.'])
   end
 
   it 'registers an offense for (x % 2) == 1' do
     inspect_source(cop, '(x % 2) == 1')
     expect(cop.offenses.size).to eq(1)
-    expect(cop.messages).to eq(['Replace with `Fixnum#odd?`.'])
+    expect(cop.messages).to eq(['Replace with `Integer#odd?`.'])
   end
 
   it 'registers an offense for (x % 2) != 1' do
     inspect_source(cop, '(x % 2) != 1')
     expect(cop.offenses.size).to eq(1)
-    expect(cop.messages).to eq(['Replace with `Fixnum#even?`.'])
+    expect(cop.messages).to eq(['Replace with `Integer#even?`.'])
   end
 
   it 'registers an offense for (x.y % 2) != 1' do
     inspect_source(cop, '(x.y % 2) != 1')
     expect(cop.offenses.size).to eq(1)
-    expect(cop.messages).to eq(['Replace with `Fixnum#even?`.'])
+    expect(cop.messages).to eq(['Replace with `Integer#even?`.'])
   end
 
   it 'registers an offense for (x(y) % 2) != 1' do
     inspect_source(cop, '(x(y) % 2) != 1')
     expect(cop.offenses.size).to eq(1)
-    expect(cop.messages).to eq(['Replace with `Fixnum#even?`.'])
+    expect(cop.messages).to eq(['Replace with `Integer#even?`.'])
   end
 
   it 'accepts x % 3 == 0' do


### PR DESCRIPTION
In Ruby 2.4, `Fixnum` and `Bignum` will be unified into `Integer`.
See. https://bugs.ruby-lang.org/issues/12005

So, I've replaced `Fixnum` to `Integer` in RuboCop's code.
(`Bignum` haven't exist in the code.)

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Used the same coding conventions as the rest of the project.
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [ ] Added tests.
* [ ] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] All tests are passing.
* [x] The new code doesn't generate RuboCop offenses.
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.

[1]: http://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html

