### PR TITLE
Cleanup Config’s hash-like API

### DIFF
--- a/lib/rubocop/config.rb
+++ b/lib/rubocop/config.rb
@@ -43,10 +43,6 @@ module RuboCop
 
     attr_reader :loaded_path
 
-    def self.[](hash)
-      new(hash)
-    end
-
     def initialize(hash = {}, loaded_path = nil)
       @loaded_path = loaded_path
       @for_cop = Hash.new do |h, cop|

--- a/lib/rubocop/config.rb
+++ b/lib/rubocop/config.rb
@@ -51,10 +51,6 @@ module RuboCop
       @hash = hash
     end
 
-    def ==(other)
-      other.is_a?(Hash) ? @hash == other : super
-    end
-
     def [](key)
       @hash[key]
     end
@@ -73,10 +69,6 @@ module RuboCop
 
     def each_key(&block)
       @hash.each_key(&block)
-    end
-
-    def eql?(other)
-      other.is_a?(Hash) ? @hash.eql?(other) : super
     end
 
     def fetch(key)

--- a/spec/rubocop/config_loader_spec.rb
+++ b/spec/rubocop/config_loader_spec.rb
@@ -84,7 +84,7 @@ describe RuboCop::ConfigLoader do
       it 'returns a configuration inheriting from default.yml' do
         config = default_config['Style/Encoding'].dup
         config['Enabled'] = false
-        expect(configuration_from_file)
+        expect(configuration_from_file.to_h)
           .to eql(default_config.merge('Style/Encoding' => config))
       end
     end
@@ -213,7 +213,7 @@ describe RuboCop::ConfigLoader do
               'Max' => 5
             }
           )
-        expect(configuration_from_file).to eq(config)
+        expect(configuration_from_file.to_h).to eq(config)
       end
     end
 
@@ -286,7 +286,7 @@ describe RuboCop::ConfigLoader do
             }
           )
 
-        expect(configuration_from_file).to eq(config)
+        expect(configuration_from_file.to_h).to eq(config)
       end
     end
 
@@ -453,13 +453,13 @@ describe RuboCop::ConfigLoader do
                                        'Style/Encoding:',
                                        '  Enabled: false'])
 
-      expect(load_file).to eq('Style/Encoding' => { 'Enabled' => false })
+      expect(load_file.to_h).to eq('Style/Encoding' => { 'Enabled' => false })
     end
 
     it 'returns an empty configuration loaded from an empty file' do
       create_file(configuration_path, '')
       configuration = load_file
-      expect(configuration).to eq({})
+      expect(configuration.to_h).to eq({})
     end
 
     context 'when SafeYAML is required' do

--- a/spec/rubocop/result_cache_spec.rb
+++ b/spec/rubocop/result_cache_spec.rb
@@ -101,11 +101,11 @@ describe RuboCop::ResultCache, :isolated_environment do
         context 'and symlink attack protection is disabled' do
           before do
             allow(config_store).to receive(:for).with('.').and_return(
-              RuboCop::Config[
+              RuboCop::Config.new(
                 'AllCops' => {
                   'AllowSymlinksInCacheRootDirectory' => true
                 }
-              ]
+              )
             )
           end
 
@@ -171,7 +171,7 @@ describe RuboCop::ResultCache, :isolated_environment do
 
   describe '.cleanup' do
     before do
-      cfg = RuboCop::Config[{ 'AllCops' => { 'MaxFilesInCache' => 1 } }]
+      cfg = RuboCop::Config.new('AllCops' => { 'MaxFilesInCache' => 1 })
       allow(config_store).to receive(:for).with('.').and_return(cfg)
       allow(config_store).to receive(:for).with('other.rb').and_return(cfg)
       create_file('other.rb', ['x = 1'])
@@ -209,7 +209,7 @@ describe RuboCop::ResultCache, :isolated_environment do
   describe 'the cache path when using a temp directory' do
     before do
       allow(config_store).to receive(:for).with('.').and_return(
-        RuboCop::Config['AllCops' => { 'CacheRootDirectory' => '/tmp' }]
+        RuboCop::Config.new('AllCops' => { 'CacheRootDirectory' => '/tmp' })
       )
     end
     it 'contains the process uid' do


### PR DESCRIPTION
This PR removes a few of the methods that `Config` inherited from `Hash` until #3482.

-----------------

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Used the same coding conventions as the rest of the project.
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [ ] Added tests.
* [x] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] All tests are passing.
* [x] The new code doesn't generate RuboCop offenses.
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.

[1]: http://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html
