### PR TITLE
Remove methods from RuboCop::Config

### DIFF
--- a/lib/rubocop/config.rb
+++ b/lib/rubocop/config.rb
@@ -71,10 +71,6 @@ module RuboCop
       @hash.each_key(&block)
     end
 
-    def fetch(key)
-      @hash.fetch(key)
-    end
-
     def key?(key)
       @hash.key?(key)
     end

--- a/lib/rubocop/config.rb
+++ b/lib/rubocop/config.rb
@@ -67,10 +67,6 @@ module RuboCop
       @hash.each(&block)
     end
 
-    def each_key(&block)
-      @hash.each_key(&block)
-    end
-
     def key?(key)
       @hash.key?(key)
     end
@@ -100,7 +96,7 @@ module RuboCop
     end
 
     def make_excludes_absolute
-      each_key do |key|
+      each do |key, _|
         validate_section_presence(key)
         next unless self[key]['Exclude']
 

--- a/spec/project_spec.rb
+++ b/spec/project_spec.rb
@@ -17,7 +17,7 @@ describe 'RuboCop Project' do
 
     it 'has a nicely formatted description for all cops' do
       cop_names.each do |name|
-        description = default_config.fetch(name).fetch('Description')
+        description = default_config[name]['Description']
         expect(description).not_to be_nil
         expect(description).not_to include("\n")
       end


### PR DESCRIPTION
`RuboCop::Config` is no longer a `Hash`, so there is no need to implement all of the `Hash` API any more. We can use `#[]` instead of `#fetch` and `#each` instead of `#each_key`.

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Used the same coding conventions as the rest of the project.
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [ ] Added tests.
* [ ] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] All tests are passing.
* [x] The new code doesn't generate RuboCop offenses.
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.

[1]: http://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html