### PR TITLE
Remove unused lets from specs

### DIFF
--- a/spec/rubocop/config_spec.rb
+++ b/spec/rubocop/config_spec.rb
@@ -254,7 +254,6 @@ describe RuboCop::Config do
       configuration.patterns_to_include
     end
 
-    let(:hash) { {} }
     let(:loaded_path) { 'example/.rubocop.yml' }
 
     context 'when config file has AllCops => Include key' do
@@ -281,7 +280,6 @@ describe RuboCop::Config do
       configuration.patterns_to_exclude
     end
 
-    let(:hash) { {} }
     let(:loaded_path) { 'example/.rubocop.yml' }
 
     context 'when config file has AllCops => Exclude key' do
@@ -467,8 +465,6 @@ describe RuboCop::Config do
       end
 
       context 'when .ruby-version is not present' do
-        let(:ruby_version) { described_class::DEFAULT_RUBY_VERSION }
-
         before do
           allow(File).to receive(:file?).with('.ruby-version').and_return false
         end

--- a/spec/rubocop/cop/cop_spec.rb
+++ b/spec/rubocop/cop/cop_spec.rb
@@ -189,7 +189,6 @@ describe RuboCop::Cop::Cop do
   describe '#autocorrect?' do
     # dummy config for a generic cop instance
     let(:config) { RuboCop::Config.new({}) }
-    let(:options) { nil }
     let(:cop) { described_class.new(config, options) }
     let(:support_autocorrect) { true }
     subject { cop.autocorrect? }

--- a/spec/rubocop/cop/lint/def_end_alignment_spec.rb
+++ b/spec/rubocop/cop/lint/def_end_alignment_spec.rb
@@ -5,9 +5,6 @@ require 'spec_helper'
 
 describe RuboCop::Cop::Lint::DefEndAlignment, :config do
   subject(:cop) { described_class.new(config) }
-  let(:opposite) do
-    cop_config['AlignWith'] == 'def' ? 'start_of_line' : 'def'
-  end
 
   let(:source) do
     ['foo def a',

--- a/spec/rubocop/cop/performance/hash_each_spec.rb
+++ b/spec/rubocop/cop/performance/hash_each_spec.rb
@@ -5,7 +5,6 @@ require 'spec_helper'
 
 describe RuboCop::Cop::Performance::HashEachMethods do
   subject(:cop) { described_class.new }
-  let(:hash) { { key: 'value' } }
 
   it 'registers an offense for Hash#keys.each' do
     inspect_source(cop, 'hash.keys.each { |k| p k }')

--- a/spec/rubocop/cop/style/first_array_element_line_break_spec.rb
+++ b/spec/rubocop/cop/style/first_array_element_line_break_spec.rb
@@ -142,14 +142,6 @@ describe RuboCop::Cop::Style::FirstArrayElementLineBreak do
     expect(cop.offenses).to be_empty
   end
 
-  context 'array assignment' do
-    let(:source) do
-      ['a,',
-       'b = [1,',
-       '2]']
-    end
-  end
-
   it 'ignores elements listed on a single line' do
     inspect_source(
       cop,

--- a/spec/rubocop/cop/style/multiline_assignment_layout_spec.rb
+++ b/spec/rubocop/cop/style/multiline_assignment_layout_spec.rb
@@ -5,7 +5,6 @@ require 'spec_helper'
 
 describe RuboCop::Cop::Style::MultilineAssignmentLayout, :config do
   subject(:cop) { described_class.new(config) }
-  let(:enforced_style) { 'new_line' }
   let(:supported_types) { %w(if) }
 
   let(:cop_config) do

--- a/spec/rubocop/cop/variable_force/scope_spec.rb
+++ b/spec/rubocop/cop/variable_force/scope_spec.rb
@@ -26,8 +26,6 @@ describe RuboCop::Cop::VariableForce::Scope do
     RuboCop::ProcessedSource.new(source, ruby_version).ast
   end
 
-  let(:scope_node_type) { :def }
-
   let(:scope_node) { ast.each_node(scope_node_type).first }
 
   subject(:scope) { described_class.new(scope_node) }

--- a/spec/rubocop/node_pattern_spec.rb
+++ b/spec/rubocop/node_pattern_spec.rb
@@ -819,6 +819,7 @@ describe RuboCop::NodePattern do
       let(:pattern) { '{^send ^^send}' }
       let(:ruby) { '"str".concat(local += "abc")' }
       let(:node) { root_node.children[2].children[2] }
+      it_behaves_like :matching
     end
 
     # NOTE!! a pitfall of doing this is that unification is done using #==


### PR DESCRIPTION
I'm working on a small tool for detecting rspec mistakes like `let(...)` definitions that are not used in any examples. This PR removes the let definitions I found that were obviously easy to remove. The tool also detected this unused let: https://github.com/backus/rubocop/blob/remove-unused-lets/spec/rubocop/cop/style/conditional_assignment_assign_to_condition_spec.rb#L1949-L2022 but I'm not sure how to tackle that one.

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Used the same coding conventions as the rest of the project.
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] All tests are passing.
* [x] The new code doesn't generate RuboCop offenses.
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.

[1]: http://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html

