### PR TITLE
[Fix #3460] Fix false positives in `Style/InlineComment` cop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,7 @@
 * [#3439](https://github.com/bbatsov/rubocop/issues/3439): Fix variable assignment check not working properly when a block is used in `Rails/SaveBang`. ([@QuinnHarris][])
 * [#3401](https://github.com/bbatsov/rubocop/issues/3401): Read file contents in binary mode so `Style/EndOfLine` works on Windows. ([@jonas054][])
 * [#3450](https://github.com/bbatsov/rubocop/issues/3450): Prevent `Style/TernaryParentheses` cop from making unsafe corrections. ([@drenmi][])
+* [#3460](https://github.com/bbatsov/rubocop/issues/3460): Fix false positives in `Style/InlineComment` cop. ([@drenmi][])
 
 ### Changes
 

--- a/config/disabled.yml
+++ b/config/disabled.yml
@@ -66,7 +66,7 @@ Style/ImplicitRuntimeError:
   Enabled: false
 
 Style/InlineComment:
-  Description: 'Avoid inline comments.'
+  Description: 'Avoid trailing inline comments.'
   Enabled: false
 
 Style/MethodCalledOnDoEndBlock:

--- a/lib/rubocop/cop/style/inline_comment.rb
+++ b/lib/rubocop/cop/style/inline_comment.rb
@@ -4,13 +4,26 @@
 module RuboCop
   module Cop
     module Style
-      # This cop checks for inline comments.
+      # This cop checks for trailing inline comments.
+      #
+      # @example
+      #
+      #   # good
+      #   foo.each do |f|
+      #     # Standalone comment
+      #     f.bar
+      #   end
+      #
+      #   # bad
+      #   foo.each do |f|
+      #     f.bar # Trailing inline comment
+      #   end
       class InlineComment < Cop
-        MSG = 'Avoid inline comments.'.freeze
+        MSG = 'Avoid trailing inline comments.'.freeze
 
         def investigate(processed_source)
           processed_source.comments.each do |comment|
-            next unless comment.inline?
+            next if comment_line?(processed_source[comment.loc.line - 1])
             add_offense(comment, :expression)
           end
         end

--- a/spec/rubocop/cop/style/inline_comment_spec.rb
+++ b/spec/rubocop/cop/style/inline_comment_spec.rb
@@ -6,10 +6,17 @@ require 'spec_helper'
 describe RuboCop::Cop::Style::InlineComment do
   subject(:cop) { described_class.new }
 
-  it 'registers an offense for a inline comment' do
-    inspect_source(cop, 'two = 1 + 1 # An inline comment')
+  it 'registers an offense for a trailing inline comment' do
+    inspect_source(cop, 'two = 1 + 1 # A trailing inline comment')
 
-    expect(cop.messages).to eq(['Avoid inline comments.'])
-    expect(cop.highlights).to eq(['# An inline comment'])
+    expect(cop.offenses.size).to eq(1)
+    expect(cop.messages).to eq(['Avoid trailing inline comments.'])
+    expect(cop.highlights).to eq(['# A trailing inline comment'])
+  end
+
+  it 'does not register an offense for a standalone comment' do
+    inspect_source(cop, '# A standalone comment')
+
+    expect(cop.offenses).to be_empty
   end
 end


### PR DESCRIPTION
This cop's check was based on a misunderstanding of how [`Parser::Source::Comment#inline?`](https://github.com/whitequark/parser/blob/master/lib/parser/source/comment.rb#L62) works, and was missing a test case for the negative case.

This change fixes the cop and adds a test for the future.

I also changed internal references to `inline` to use the word `trailing` instead. (We might possibly want to consider renaming the cop for 1.0.0 to minimize ambiguity.)