### PR TITLE
[Fix #3450] Prevent `Style/TernaryParentheses` from making unsafe corrections

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,7 @@
 * [#3423](https://github.com/bbatsov/rubocop/issues/3423): Checks if .rubocop is a file before parsing. ([@joejuzl][])
 * [#3439](https://github.com/bbatsov/rubocop/issues/3439): Fix variable assignment check not working properly when a block is used in `Rails/SaveBang`. ([@QuinnHarris][])
 * [#3401](https://github.com/bbatsov/rubocop/issues/3401): Read file contents in binary mode so `Style/EndOfLine` works on Windows. ([@jonas054][])
+* [#3450](https://github.com/bbatsov/rubocop/issues/3450): Prevent `Style/TernaryParentheses` cop from making unsafe corrections. ([@drenmi][])
 
 ### Changes
 

--- a/spec/rubocop/cop/style/ternary_parentheses_spec.rb
+++ b/spec/rubocop/cop/style/ternary_parentheses_spec.rb
@@ -146,6 +146,28 @@ describe RuboCop::Cop::Style::TernaryParentheses, :config do
                         'foo = (bar = baz = find_baz) ? a : b'
       end
     end
+
+    context 'with an unparenthesized method call condition' do
+      it_behaves_like 'code with offense',
+                      'foo = (defined? bar) ? a : b',
+                      'foo = (defined? bar) ? a : b'
+
+      it_behaves_like 'code with offense',
+                      'foo = (baz? bar) ? a : b',
+                      'foo = (baz? bar) ? a : b'
+
+      context 'when calling method on a receiver' do
+        it_behaves_like 'code with offense',
+                        'foo = (baz.foo? bar) ? a : b',
+                        'foo = (baz.foo? bar) ? a : b'
+      end
+
+      context 'when calling method with multiple arguments' do
+        it_behaves_like 'code with offense',
+                        'foo = (baz.foo? bar, baz) ? a : b',
+                        'foo = (baz.foo? bar, baz) ? a : b'
+      end
+    end
   end
 
   context 'when `RedundantParenthesis` would cause an infinite loop' do


### PR DESCRIPTION
This cop, when configured to omit parentheses, would remove them even when the condition contained an unparenthesized method call, e.g.:

```
foo = (bar? baz) ? 'Yes' : 'No'
```

which would change the semantics of the expression. This change fixes that.

I also discovered that a `#defined?` call is parsed as a special node type (`defined?`) rather than as a `send`.