### PR TITLE
Fix false negatives in `Rails/NotNullColumn` cop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,7 @@
 * [#3450](https://github.com/bbatsov/rubocop/issues/3450): Prevent `Style/TernaryParentheses` cop from making unsafe corrections. ([@drenmi][])
 * [#3460](https://github.com/bbatsov/rubocop/issues/3460): Fix false positives in `Style/InlineComment` cop. ([@drenmi][])
 * [#3485](https://github.com/bbatsov/rubocop/issues/3485): Make OneLineConditional cop not register offense for empty else. ([@tejasbubane][])
+* [#3508](https://github.com/bbatsov/rubocop/pull/3508): Fix false negatives in `Rails/NotNullColumn`. ([@pocke][])
 
 ### Changes
 

--- a/lib/rubocop/cop/rails/not_null_column.rb
+++ b/lib/rubocop/cop/rails/not_null_column.rb
@@ -26,7 +26,7 @@ module RuboCop
         PATTERN
 
         def_node_matcher :has_default?, <<-PATTERN
-          (pair (sym :default) _)
+          (pair (sym :default) !(:nil))
         PATTERN
 
         def on_send(node)

--- a/spec/rubocop/cop/rails/not_null_column_spec.rb
+++ b/spec/rubocop/cop/rails/not_null_column_spec.rb
@@ -26,23 +26,29 @@ describe RuboCop::Cop::Rails::NotNullColumn, :config do
       let(:source) do
         'add_column :users, :name, :string, null: false, default: ""'
       end
-      it 'accepts' do
-        expect(cop.offenses).to be_empty
+      include_examples 'accepts'
+    end
+
+    context 'with null: false and default: nil' do
+      let(:source) do
+        'add_column :users, :name, :string, null: false, default: nil'
+      end
+      it 'reports an offense' do
+        expect(cop.offenses.size).to eq(1)
+        expect(cop.messages).to eq(
+          ['Do not add a NOT NULL column without a default value']
+        )
       end
     end
 
     context 'with null: true' do
       let(:source) { 'add_column :users, :name, :string, null: true' }
-      it 'accepts' do
-        expect(cop.offenses).to be_empty
-      end
+      include_examples 'accepts'
     end
 
     context 'without any options' do
       let(:source) { 'add_column :users, :name, :string' }
-      it 'accepts' do
-        expect(cop.offenses).to be_empty
-      end
+      include_examples 'accepts'
     end
   end
 
@@ -54,9 +60,7 @@ describe RuboCop::Cop::Rails::NotNullColumn, :config do
         'change_column :users, :name, :string, null: false'
       ]
     end
-    it 'accepts' do
-      expect(cop.offenses).to be_empty
-    end
+    include_examples 'accepts'
   end
 
   context 'with create_table call' do
@@ -70,8 +74,6 @@ describe RuboCop::Cop::Rails::NotNullColumn, :config do
        '  end',
        'end']
     end
-    it 'accepts' do
-      expect(cop.offenses).to be_empty
-    end
+    include_examples 'accepts'
   end
 end


### PR DESCRIPTION
`Rails/NotNullColumn` should register an offence for the following code.

```ruby
add_column :users, :email, :string, null: false, default: nil
```

However, the cop currently doesn't register.

This PR solves the problem. 

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Used the same coding conventions as the rest of the project.
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] All tests are passing.
* [x] The new code doesn't generate RuboCop offenses.
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.

[1]: http://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html

