### PR TITLE
Remove unused doubled methods

### DIFF
--- a/spec/rubocop/cop/commissioner_spec.rb
+++ b/spec/rubocop/cop/commissioner_spec.rb
@@ -24,7 +24,7 @@ describe RuboCop::Cop::Commissioner do
       it 'returns all offenses except the ones of the cop' do
         cops = []
         cops << double('cop A', offenses: %w(foo), excluded_file?: false)
-        cops << double('cop B', offenses: %w(bar), excluded_file?: true)
+        cops << double('cop B', excluded_file?: true)
         cops << double('cop C', offenses: %w(baz), excluded_file?: false)
         cops.each(&:as_null_object)
 

--- a/spec/rubocop/formatter/worst_offenders_formatter_spec.rb
+++ b/spec/rubocop/formatter/worst_offenders_formatter_spec.rb
@@ -17,7 +17,7 @@ module RuboCop
 
       describe '#finished' do
         context 'when there are many offenses' do
-          let(:offense) { double('offense', cop_name: 'SomeCop') }
+          let(:offense) { double('offense') }
 
           before do
             formatter.started(files)


### PR DESCRIPTION
I found a few test doubles that unnecessarily define methods that are not required to make the test pass.

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Used the same coding conventions as the rest of the project.
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] All tests are passing.
* [x] The new code doesn't generate RuboCop offenses.
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.

[1]: http://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html

These methods can be safely removed from their test doubles without
breaking the test case