### PR TITLE
[Fix #3511] Style/TernaryParentheses false positive

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## master (unreleased)
 
+### Bug fixes
+
+[#3513](https://github.com/bbatsov/rubocop/pull/3513): Fix false positive in `Style/TernaryParentheses` for a ternary with ranges. ([@dreyks][])
+
 ## 0.43.0 (2016-09-19)
 
 ### New features

--- a/lib/rubocop/cop/style/ternary_parentheses.rb
+++ b/lib/rubocop/cop/style/ternary_parentheses.rb
@@ -91,7 +91,7 @@ module RuboCop
         end
 
         def parenthesized?(node)
-          node.source =~ /^\(.*\)$/
+          node.begin_type?
         end
 
         # When this cop is configured to enforce parentheses and the

--- a/spec/rubocop/cop/style/ternary_parentheses_spec.rb
+++ b/spec/rubocop/cop/style/ternary_parentheses_spec.rb
@@ -168,6 +168,11 @@ describe RuboCop::Cop::Style::TernaryParentheses, :config do
                         'foo = (baz.foo? bar, baz) ? a : b'
       end
     end
+
+    context 'with condition including a range' do
+      it_behaves_like 'code without offense',
+                      '(foo..bar).include?(baz) ? a : b'
+    end
   end
 
   context 'when `RedundantParenthesis` would cause an infinite loop' do


### PR DESCRIPTION
Fix false positive for a ternary with ranges
-----------------

Fixes #3511

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Used the same coding conventions as the rest of the project.
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] All tests are passing.
* [x] The new code doesn't generate RuboCop offenses.
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.

