### PR TITLE
[Fix #3510] Various bug fixes for SafeNavigation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## master (unreleased)
 
+### New features
+
+* [#3510](https://github.com/bbatsov/rubocop/issues/3510): Add a configuration option, `ConvertCodeThatCanStartToReturnNil`, to `Style/SafeNavigation` to check for code that could start returning `nil` if safe navigation is used. ([@rrosenblum][])
+
 ### Bug fixes
 
 * [#3513](https://github.com/bbatsov/rubocop/pull/3513): Fix false positive in `Style/TernaryParentheses` for a ternary with ranges. ([@dreyks][])
@@ -10,6 +14,7 @@
 ### Changes
 
 * [#3512](https://github.com/bbatsov/rubocop/issues/3512): Change error message of `Lint/UnneededSplatExpansion` for array in method parameters. ([@tejasbubane][])
+* [#3510](https://github.com/bbatsov/rubocop/issues/3510): Fix some issues with `Style/SafeNavigation`. Fix auto-correct of multiline if expressions, and do not register an offense for scenarios using `||` and ternary expression. ([@rrosenblum][])
 
 ## 0.43.0 (2016-09-19)
 

--- a/config/default.yml
+++ b/config/default.yml
@@ -841,6 +841,11 @@ Style/RegexpLiteral:
   # are found in the regexp string.
   AllowInnerSlashes: false
 
+Style/SafeNavigation:
+  # Safe navigation may cause a statement to start returning `nil` in addition
+  # to whatever it used to return.
+  ConvertCodeThatCanStartToReturnNil: false
+
 Style/Semicolon:
   # Allow ; to separate several expressions on the same line.
   AllowAsExpressionSeparator: false

--- a/lib/rubocop/cop/style/safe_navigation.rb
+++ b/lib/rubocop/cop/style/safe_navigation.rb
@@ -8,6 +8,14 @@ module RuboCop
       # check for the variable whose method is being called to
       # safe navigation (`&.`).
       #
+      # Configuration option: ConvertCodeThatCanStartToReturnNil
+      # The default for this is `false`. When configured to `true`, this will
+      # check for code in the format `!foo.nil? && foo.bar`. As it is written,
+      # the return of this code is limited to `false` and whatever the return
+      # of the method is. If this is converted to safe navigation,
+      # `foo&.bar` can start returning `nil` as well as what the method
+      # returns.
+      #
       # @example
       #   # bad
       #   foo.bar if foo
@@ -24,19 +32,21 @@ module RuboCop
       #   foo && foo.bar { |e| e.something }
       #   foo && foo.bar(param) { |e| e.something }
       #
-      #   foo.nil? || foo.bar
-      #   !foo || foo.bar
-      #
       #   # good
       #   foo&.bar
       #   foo&.bar(param1, param2)
       #   foo&.bar { |e| e.something }
       #   foo&.bar(param) { |e| e.something }
       #
+      #   foo.nil? || foo.bar
+      #   !foo || foo.bar
+      #
       #   # Methods that `nil` will `respond_to?` should not be converted to
       #   # use safe navigation
       #   foo.to_i if foo
       class SafeNavigation < Cop
+        include IfNode
+
         MSG = 'Use safe navigation (`&.`) instead of checking if an object ' \
               'exists before calling the method.'.freeze
         NIL_METHODS = nil.methods.freeze
@@ -51,18 +61,18 @@ module RuboCop
               (send $_ {:nil? :!}) nil
               {(send $_ $_ ...) (block (send $_ $_ ...) ...)}
             ...)
-            (and
-              {(send (send $_ :nil?) :!) $_}
-              {(send $_ $_ ...) (block (send $_ $_ ...) ...)}
-            ...)
-            (or
-              (send $_ {:nil? :!})
-              {(send $_ $_ ...) (block (send $_ $_ ...) ...)}
-            ...)
           }
         PATTERN
 
+        def_node_matcher :candidate_that_may_introduce_nil, <<-PATTERN
+          (and
+            {(send (send $_ :nil?) :!) $_}
+            {(send $_ $_ ...) (block (send $_ $_ ...) ...)}
+          ...)
+        PATTERN
+
         def on_if(node)
+          return if ternary?(node)
           check_node(node)
         end
 
@@ -76,48 +86,51 @@ module RuboCop
 
         def check_node(node)
           return if target_ruby_version < 2.3
-          checked_variable, receiver, method = safe_navigation_candidate(node)
+          return if node.loc.respond_to?(:else) && !node.loc.else.nil?
+          checked_variable, receiver, method = extract_parts(node)
           return unless receiver == checked_variable
           return if NIL_METHODS.include?(method)
           return unless method =~ /\w+[=!?]?/
           add_offense(node, :expression)
         end
 
+        def extract_parts(node)
+          if cop_config['ConvertCodeThatCanStartToReturnNil']
+            safe_navigation_candidate(node) ||
+              candidate_that_may_introduce_nil(node)
+          else
+            safe_navigation_candidate(node)
+          end
+        end
+
         def autocorrect(node)
+          if node.loc.respond_to?(:keyword) && node.loc.keyword.is?('unless')
+            _check, _else, body = *node
+          else
+            _check, body = *node
+          end
+
+          method_call, = *body if body.block_type?
+
           lambda do |corrector|
-            if node.loc.respond_to?(:keyword) && node.loc.keyword.is?('unless')
-              _variable_check, _else, method_call = *node
-            else
-              _variable_check, method_call = *node
-            end
-
-            if method_call.block_type?
-              method, = *method_call
-              corrector.insert_before(method.loc.dot, '&')
-            else
-              corrector.insert_before(method_call.loc.dot, '&')
-            end
-
-            corrector.remove(range(node, method_call))
+            corrector.remove(begin_range(node, body))
+            corrector.remove(end_range(node, body))
+            corrector.insert_before((method_call || body).loc.dot, '&')
           end
         end
 
         private
 
-        def range(node, method_call)
-          source_buffer = node.loc.expression.source_buffer
-          node_expression = node.loc.expression
-          method_expression = method_call.loc.expression
+        def begin_range(node, method_call)
+          Parser::Source::Range.new(node.loc.expression.source_buffer,
+                                    node.loc.expression.begin_pos,
+                                    method_call.loc.expression.begin_pos)
+        end
 
-          if node.and_type? || node.or_type?
-            Parser::Source::Range.new(source_buffer,
-                                      node_expression.begin_pos,
-                                      method_expression.begin_pos)
-          else
-            Parser::Source::Range.new(source_buffer,
-                                      method_expression.end_pos,
-                                      node_expression.end_pos)
-          end
+        def end_range(node, method_call)
+          Parser::Source::Range.new(node.loc.expression,
+                                    method_call.loc.expression.end_pos,
+                                    node.loc.expression.end_pos)
         end
       end
     end


### PR DESCRIPTION
This fixes #3510. Stop registering an offense for ternary operators, non modifier if statements, and scenarios using `||`.

There is an outstanding enhancement to register an offense for and correct simple multiline if statements.
```ruby
if foo
  foo.bar
end
```
Registering an offense for this scenario is easy. The auto-correct is bit difficult compared to what is being done in the other scenarios. It is taking a little longer than I expected it to, and I know that this cop is broken for people so the fix seems more important than the enhancement. 