### PR TITLE
Pull request to fix some issues with normal case variable naming

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,7 +51,7 @@
 * [#3485](https://github.com/bbatsov/rubocop/issues/3485): Make OneLineConditional cop not register offense for empty else. ([@tejasbubane][])
 * [#3508](https://github.com/bbatsov/rubocop/pull/3508): Fix false negatives in `Rails/NotNullColumn`. ([@pocke][])
 * [#3462](https://github.com/bbatsov/rubocop/issues/3462): Don't create MultilineMethodCallBraceLayout offenses for single-line method calls when receiver spans multiple lines. ([@maxjacobson][])
-
+[#3514](https://github.com/bbatsov/rubocop/issues/3514) Changed the regular expression which defines normal case.
 ### Changes
 
 * [#3341](https://github.com/bbatsov/rubocop/issues/3341): Exclude RSpec tests from inspection by `Style/NumericPredicate` cop. ([@drenmi][])
@@ -2367,3 +2367,4 @@
 [@scottohara]: https://github.com/scottohara
 [@koic]: https://github.com/koic
 [@groddeck]: https://github.com/groddeck
+[@b-t-g]: https://github.com/b-t-g

--- a/lib/rubocop/cop/mixin/configurable_numbering.rb
+++ b/lib/rubocop/cop/mixin/configurable_numbering.rb
@@ -9,7 +9,7 @@ module RuboCop
       include ConfigurableEnforcedStyle
 
       SNAKE_CASE = /^@{0,2}[-_a-z]+[_\D]*(_\d)*[!?=]?$/
-      NORMAL_CASE = /^@{0,2}-{0,1}_{0,1}[a-zA-Z\d]*[_\D]*[!?=]?$/
+      NORMAL_CASE = /^@{0,2}-{0,1}_{0,1}[a-zA-Z\d]*(_[a-zA-Z]+[a-zA-Z\d])*[_\D]*[!?=]?$/
       NON_INTEGER = /^@{0,2}[-_a-z]+[_\D]*[!?=]?$/
 
       def check_name(node, name, name_range)

--- a/spec/rubocop/cop/style/variable_number_spec.rb
+++ b/spec/rubocop/cop/style/variable_number_spec.rb
@@ -97,6 +97,35 @@ describe RuboCop::Cop::Style::VariableNumber, :config do
       expect(cop.offenses.size).to eq(0)
     end
 
+    it 'does not register an offense for normal case number in local variable' do
+        inspect_source(cop, 'user1_id = 1')
+        expect(cop.offenses.size).to eq(0)
+      end
+
+    it 'does not register an offense for normal case number in local variable' do
+        inspect_source(cop, 'sha256 = 3')
+        expect(cop.offenses.size).to eq(0)
+      end
+
+    it 'does not register an offense for normal case number in local variable' do
+        inspect_source(cop, 'target_u2f_device = nil')
+        expect(cop.offenses.size).to eq(0)
+      end
+
+    it 'registers an offense for stuff' do
+        inspect_source(cop, 'user_1_id = 3')
+        expect(cop.offenses.size).to eq(1)
+        expect(cop.highlights).to eq(['user_1_id'])
+        expect(cop.messages).to eq(['Use normalcase for variable numbers.'])
+      end
+
+    it 'registers an offense for stuff' do
+        inspect_source(cop, 'sha_256 = 1')
+        expect(cop.offenses.size).to eq(1)
+        expect(cop.highlights).to eq(['sha_256'])
+        expect(cop.messages).to eq(['Use normalcase for variable numbers.'])
+      end
+
     it 'registers an offense for snake case numbering in instance variable' do
       inspect_source(cop, '@local_1 = 3')
       expect(cop.offenses.size).to eq(1)


### PR DESCRIPTION
I changed the regular expression which defined the normal case in configurable_numbering.rb  to fit some known valid examples of normal case variable names with tests added. 

This is my first time contributing to a github project; even though I checked the guidelines, please double check things :)

-----------------

Before submitting the PR make sure the following are checked:

* [ ] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [ ] Used the same coding conventions as the rest of the project.
* [ ] Feature branch is up-to-date with `master` (if not - rebase it).
* [ ] Squashed related commits together.
* [ ] Added tests.
* [ ] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [ ] All tests are passing.
* [ ] The new code doesn't generate RuboCop offenses.
* [ ] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.

[1]: http://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html
