### PR TITLE
[Fix #3512] Change error message of `Lint/UnneededSplatExpansion` for array

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 * [#3513](https://github.com/bbatsov/rubocop/pull/3513): Fix false positive in `Style/TernaryParentheses` for a ternary with ranges. ([@dreyks][])
 
+### Changes
+
+* [#3512](https://github.com/bbatsov/rubocop/issues/3512): Change error message of `Lint/UnneededSplatExpansion` for array in method parameters. ([@tejasbubane][])
+
 ## 0.43.0 (2016-09-19)
 
 ### New features

--- a/lib/rubocop/cop/lint/unneeded_splat_expansion.rb
+++ b/lib/rubocop/cop/lint/unneeded_splat_expansion.rb
@@ -47,6 +47,7 @@ module RuboCop
       #   end
       class UnneededSplatExpansion < Cop
         MSG = 'Unnecessary splat expansion.'.freeze
+        ARRAY_PARAM_MSG = 'Pass array contents as separate arguments.'.freeze
         PERCENT_W = '%w'.freeze
         PERCENT_CAPITAL_W = '%W'.freeze
         PERCENT_I = '%i'.freeze
@@ -63,7 +64,12 @@ module RuboCop
             if object.send_type?
               return unless ASSIGNMENT_TYPES.include?(node.parent.parent.type)
             end
-            add_offense(node, :expression)
+
+            if array_splat?(node) && method_argument?(node)
+              add_offense(node, :expression, ARRAY_PARAM_MSG)
+            else
+              add_offense(node, :expression)
+            end
           end
         end
 
@@ -83,6 +89,14 @@ module RuboCop
               corrector.remove(loc.operator)
             end
           end
+        end
+
+        def array_splat?(node)
+          node.children.first.array_type?
+        end
+
+        def method_argument?(node)
+          node.parent.send_type?
         end
 
         def unneeded_brackets?(node)


### PR DESCRIPTION
In case of array splat for method parameter, the default message was
ambiguous. `Unnecessary splat expansion.` made people just remove the
splat expansion and pass the array as parameter which is obviously not
the same as passing splat arguments. Change the message to
`Pass array contents as separate arguments.` in such cases.

Fixes #3512 

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Used the same coding conventions as the rest of the project.
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] All tests are passing.
* [x] The new code doesn't generate RuboCop offenses.
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.

[1]: http://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html