### PR TITLE
Change misleading message of empty lines around access modifier

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@
 
 * [#3512](https://github.com/bbatsov/rubocop/issues/3512): Change error message of `Lint/UnneededSplatExpansion` for array in method parameters. ([@tejasbubane][])
 * [#3510](https://github.com/bbatsov/rubocop/issues/3510): Fix some issues with `Style/SafeNavigation`. Fix auto-correct of multiline if expressions, and do not register an offense for scenarios using `||` and ternary expression. ([@rrosenblum][])
+* [#3503](https://github.com/bbatsov/rubocop/issues/3503): Change misleading message of `Style/EmptyLinesAroundAccessModifier`. ([@bquorning][])
 
 ## 0.43.0 (2016-09-19)
 

--- a/lib/rubocop/cop/style/empty_lines_around_access_modifier.rb
+++ b/lib/rubocop/cop/style/empty_lines_around_access_modifier.rb
@@ -7,7 +7,8 @@ module RuboCop
       class EmptyLinesAroundAccessModifier < Cop
         include AccessModifierNode
 
-        MSG = 'Keep a blank line before and after `%s`.'.freeze
+        MSG_AFTER = 'Keep a blank line after `%s`.'.freeze
+        MSG_BEFORE_AND_AFTER = 'Keep a blank line before and after `%s`.'.freeze
 
         def on_send(node)
           return unless modifier_node?(node)
@@ -79,7 +80,14 @@ module RuboCop
         end
 
         def message(node)
-          format(MSG, node.loc.selector.source)
+          previous_line = processed_source[node.loc.line - 2]
+
+          if block_start?(previous_line) ||
+             class_def?(previous_line)
+            format(MSG_AFTER, node.loc.selector.source)
+          else
+            format(MSG_BEFORE_AND_AFTER, node.loc.selector.source)
+          end
         end
       end
     end

--- a/lib/rubocop/cop/style/empty_lines_around_access_modifier.rb
+++ b/lib/rubocop/cop/style/empty_lines_around_access_modifier.rb
@@ -48,13 +48,13 @@ module RuboCop
         end
 
         def previous_line_empty?(previous_line)
-          block_start?(previous_line.lstrip) ||
-            class_def?(previous_line.lstrip) ||
+          block_start?(previous_line) ||
+            class_def?(previous_line) ||
             previous_line.blank?
         end
 
         def next_line_empty?(next_line)
-          body_end?(next_line.lstrip) || next_line.blank?
+          body_end?(next_line) || next_line.blank?
         end
 
         def empty_lines_around?(node)
@@ -67,7 +67,7 @@ module RuboCop
         end
 
         def class_def?(line)
-          line.start_with?('class', 'module')
+          line =~ /^\s*(class|module)/
         end
 
         def block_start?(line)
@@ -75,7 +75,7 @@ module RuboCop
         end
 
         def body_end?(line)
-          line.start_with?('end')
+          line =~ /^\s*end/
         end
 
         def message(node)

--- a/spec/rubocop/cli/cli_autocorrect_spec.rb
+++ b/spec/rubocop/cli/cli_autocorrect_spec.rb
@@ -703,8 +703,7 @@ describe RuboCop::CLI, :isolated_environment do
               'comment.',
               "#{e}:2:1: C: [Corrected] Indent access modifiers like " \
               '`private`.',
-              "#{e}:2:1: C: [Corrected] Keep a blank line before and " \
-              'after `private`.',
+              "#{e}:2:1: C: [Corrected] Keep a blank line after `private`.",
               "#{e}:2:3: W: Useless `private` access modifier.",
               "#{e}:3:7: C: [Corrected] Freeze mutable objects assigned " \
               'to constants.',

--- a/spec/rubocop/cop/style/empty_lines_around_access_modifier_spec.rb
+++ b/spec/rubocop/cop/style/empty_lines_around_access_modifier_spec.rb
@@ -121,6 +121,19 @@ describe RuboCop::Cop::Style::EmptyLinesAroundAccessModifier do
       expect(cop.offenses).to be_empty
     end
 
+    it "requires blank line after, but not before, #{access_modifier} " \
+       'when at the beginning of class/module' do
+      inspect_source(cop,
+                     ['class Test',
+                      "  #{access_modifier}",
+                      '  def test',
+                      '  end',
+                      'end'])
+      expect(cop.offenses.size).to eq(1)
+      expect(cop.messages)
+        .to eq(["Keep a blank line after `#{access_modifier}`."])
+    end
+
     context 'at the beginning of block' do
       context 'for blocks defined with do' do
         it 'accepts missing blank line' do
@@ -141,6 +154,18 @@ describe RuboCop::Cop::Style::EmptyLinesAroundAccessModifier do
                           '  def test; end',
                           'end'])
           expect(cop.offenses).to be_empty
+        end
+
+        it "requires blank line after, but not before, #{access_modifier}" do
+          inspect_source(cop,
+                         ['included do',
+                          "  #{access_modifier}",
+                          '  def test',
+                          '  end',
+                          'end'])
+          expect(cop.offenses.size).to eq(1)
+          expect(cop.messages)
+            .to eq(["Keep a blank line after `#{access_modifier}`."])
         end
       end
 


### PR DESCRIPTION
The `Style/EmptyLinesAroundAccessModifier` would always say it needed a blank line both above and below an access modifier, even if it was at the beginning of a class, module, or block, where there actually shouldn't be a blank line above.

Fixed #3503.

I don’t particularly like how the `#message` method now duplicates logic from earlier in the class, i.e. the setting of `previous_line` and the calls to `block_start?` and `class_def?`. Input is much appreciated.

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Used the same coding conventions as the rest of the project.
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] All tests are passing.
* [x] The new code doesn't generate RuboCop offenses.
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.

[1]: http://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html
