### PR TITLE
Fix false positive in `Lint/AssignmentInCondition` (#3520)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Bug fixes
 
 * [#3513](https://github.com/bbatsov/rubocop/pull/3513): Fix false positive in `Style/TernaryParentheses` for a ternary with ranges. ([@dreyks][])
+* [#3520](https://github.com/bbatsov/rubocop/issues/3520): Fix regression causing `Lint/AssignmentInCondition` false positive. ([@savef][])
 
 ## 0.43.0 (2016-09-19)
 

--- a/lib/rubocop/cop/lint/assignment_in_condition.rb
+++ b/lib/rubocop/cop/lint/assignment_in_condition.rb
@@ -48,7 +48,8 @@ module RuboCop
         end
 
         def skip_children?(asgn_node)
-          safe_assignment_allowed? && safe_assignment?(asgn_node)
+          (asgn_node.send_type? && asgn_node.method_name !~ /=\z/) ||
+            (safe_assignment_allowed? && safe_assignment?(asgn_node))
         end
 
         # each_node/visit_descendants_with_types with :skip_children

--- a/spec/rubocop/cop/lint/assignment_in_condition_spec.rb
+++ b/spec/rubocop/cop/lint/assignment_in_condition_spec.rb
@@ -83,6 +83,12 @@ describe RuboCop::Cop::Lint::AssignmentInCondition, :config do
     expect(cop.offenses).to be_empty
   end
 
+  it 'accepts = in a block followed by method call' do
+    inspect_source(cop,
+                   'return 1 if any_errors? { o = file }.present?')
+    expect(cop.offenses).to be_empty
+  end
+
   it 'accepts ||= in condition' do
     inspect_source(cop,
                    'raise StandardError unless foo ||= bar')


### PR DESCRIPTION
This regression was introduced in b0d8e0cf which was simply a refactoring commit. It looks like part of the code was omitted accidentally when porting to the new block. Specifically, the part which was dropped was: https://github.com/bbatsov/rubocop/blob/78de463f33992bce5b1ecf40e311958ad773bad5/lib/rubocop/cop/lint/assignment_in_condition.rb#L35-L38

I've ported the missing checks to the `#skip_children?` method, and added a test which would've caught the regression.

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Used the same coding conventions as the rest of the project.
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] All tests are passing.
* [x] The new code doesn't generate RuboCop offenses.
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.