### PR TITLE
Add AllowImplicitReceiver switch to `Lint/StringConversionInterpolation`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## master (unreleased)
 
+### New features
+
+* Add switch to `Lint/StringConversionInInterpolation` to allow `#to_s` with an implicit receiver. ([@savef][])
+
 ### Bug fixes
 
 * [#3513](https://github.com/bbatsov/rubocop/pull/3513): Fix false positive in `Style/TernaryParentheses` for a ternary with ranges. ([@dreyks][])

--- a/config/default.yml
+++ b/config/default.yml
@@ -1184,6 +1184,10 @@ Lint/UnusedMethodArgument:
   AllowUnusedKeywordArguments: false
   IgnoreEmptyMethods: true
 
+Lint/StringConversionInInterpolation:
+  # Whether to allow `#to_s` with an implicit receiver
+  AllowImplicitReceiver: false
+
 ##################### Performance ############################
 
 Performance/RedundantMerge:

--- a/lib/rubocop/cop/lint/string_conversion_in_interpolation.rb
+++ b/lib/rubocop/cop/lint/string_conversion_in_interpolation.rb
@@ -21,6 +21,7 @@ module RuboCop
             next unless final_node && final_node.send_type?
 
             receiver, method_name, *args = *final_node
+            next if allow_implicit_receiver?(receiver)
             next unless method_name == :to_s && args.empty?
 
             add_offense(
@@ -45,6 +46,10 @@ module RuboCop
               end
             )
           end
+        end
+
+        def allow_implicit_receiver?(receiver)
+          cop_config['AllowImplicitReceiver'] && receiver.nil?
         end
       end
     end

--- a/spec/rubocop/cop/lint/string_conversion_in_interpolation_spec.rb
+++ b/spec/rubocop/cop/lint/string_conversion_in_interpolation_spec.rb
@@ -3,8 +3,8 @@
 
 require 'spec_helper'
 
-describe RuboCop::Cop::Lint::StringConversionInInterpolation do
-  subject(:cop) { described_class.new }
+describe RuboCop::Cop::Lint::StringConversionInInterpolation, :config do
+  subject(:cop) { described_class.new(config) }
 
   it 'registers an offense for #to_s in interpolation' do
     inspect_source(cop, '"this is the #{result.to_s}"')
@@ -48,5 +48,19 @@ describe RuboCop::Cop::Lint::StringConversionInInterpolation do
   it 'autocorrects implicit receiver by replacing to_s with self' do
     corrected = autocorrect_source(cop, ['"some #{to_s}"'])
     expect(corrected).to eq '"some #{self}"'
+  end
+
+  context 'with AllowImplicitReceiver' do
+    let(:cop_config) { { 'AllowImplicitReceiver' => true } }
+
+    it 'allows implicit receiver' do
+      inspect_source(cop, '"#{to_s}"')
+      expect(cop.offenses).to be_empty
+    end
+
+    it 'still registers an offence when there is a receiver' do
+      inspect_source(cop, '"this is the #{result.to_s}"')
+      expect(cop.offenses.size).to eq(1)
+    end
   end
 end


### PR DESCRIPTION
The default behaviour of this cop should not have changed at all. This adds a configuration option `AllowImplicitReceiver` to `Lint/StringConversionInterpolation` so that one can use #to_s with no receiver in string interpolation, i.e. `"Hello, #{to_s}!"`.

My reasoning for wanting this switch is that I have the following code:
```ruby
def hierarchy
  parent_category ? "#{parent_category.hierarchy} > #{to_s}" : to_s
end
```
And I think it looks mildly more readable than:
```ruby
def hierarchy
  parent_category ? "#{parent_category.hierarchy} > #{self}" : to_s
end
```
Because you can spot at a glance the difference (or rather, the similarity) between the two outputs.

-----------------

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Used the same coding conventions as the rest of the project.
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] All tests are passing.
* [x] The new code doesn't generate RuboCop offenses.
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.