### PR TITLE
Rails/SaveBang doesn't detect when method return value is passed up the stack

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 * [#3520](https://github.com/bbatsov/rubocop/issues/3520): Fix regression causing `Lint/AssignmentInCondition` false positive. ([@savef][])
 * [#3514](https://github.com/bbatsov/rubocop/issues/3514): Make `Style/VariableNumber` cop not register an offense when valid normal case variable names have an integer after the first `_`. ([@b-t-g][])
 * [#3516](https://github.com/bbatsov/rubocop/issues/3516): Make `Style/VariableNumber` cop not register an offense when valid normal case variable names have an integer in the middle. ([@b-t-g][])
+* [#3436](https://github.com/bbatsov/rubocop/issues/3436): Make `Rails/SaveBang` cop not register an offense when return value of a non-bang method is returned by the parent method. ([@coorasse][])
 
 ### Changes
 
@@ -2381,4 +2382,5 @@
 [@koic]: https://github.com/koic
 [@groddeck]: https://github.com/groddeck
 [@b-t-g]: https://github.com/b-t-g
+[@coorasse]: https://github.com/coorasse
 [@scottmatthewman]: https://github.com/scottmatthewman

--- a/lib/rubocop/cop/rails/save_bang.rb
+++ b/lib/rubocop/cop/rails/save_bang.rb
@@ -82,6 +82,7 @@ module RuboCop
           return unless expected_signature?(node)
           return if return_value_assigned?(node)
           return if check_used_in_conditional(node)
+          return if last_call_of_method?(node)
 
           add_offense(node, node.loc.selector,
                       format(MSG,
@@ -122,6 +123,11 @@ module RuboCop
           end
 
           true
+        end
+
+        def last_call_of_method?(node)
+          !node.parent.nil? &&
+            node.parent.children.count == node.sibling_index + 1
         end
 
         # Ignore simple assignment or if condition

--- a/spec/rubocop/cop/rails/save_bang_spec.rb
+++ b/spec/rubocop/cop/rails/save_bang_spec.rb
@@ -90,6 +90,11 @@ describe RuboCop::Cop::Rails::SaveBang do
           .to eq(["`#{method}` returns a model which is always truthy."])
       end
     end
+
+    it "when using #{method} as last method call" do
+      inspect_source(cop, ['def foo', "object.#{method}", 'end'])
+      expect(cop.messages).to be_empty
+    end
   end
 
   described_class::MODIFY_PERSIST_METHODS.each do |method|


### PR DESCRIPTION
Rails/SaveBang doesn't detect when method return value is passed up the stack.
This Pull Request solves the issue #3436 
