### PR TITLE
[Fix #3540] Make `Style/GuardClause` register offense for instance & singleton methods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 * [#3514](https://github.com/bbatsov/rubocop/issues/3514): Make `Style/VariableNumber` cop not register an offense when valid normal case variable names have an integer after the first `_`. ([@b-t-g][])
 * [#3516](https://github.com/bbatsov/rubocop/issues/3516): Make `Style/VariableNumber` cop not register an offense when valid normal case variable names have an integer in the middle. ([@b-t-g][])
 * [#3436](https://github.com/bbatsov/rubocop/issues/3436): Make `Rails/SaveBang` cop not register an offense when return value of a non-bang method is returned by the parent method. ([@coorasse][])
+* [#3540](https://github.com/bbatsov/rubocop/issues/3540): Fix `Style/GuardClause` to register offense for instance and singleton methods. ([@tejasbubane][])
 
 ### Changes
 

--- a/lib/rubocop/cop/style/guard_clause.rb
+++ b/lib/rubocop/cop/style/guard_clause.rb
@@ -39,13 +39,12 @@ module RuboCop
       class GuardClause < Cop
         include IfNode
         include MinBodyLength
+        include OnMethodDef
 
         MSG = 'Use a guard clause instead of wrapping the code inside a ' \
               'conditional expression.'.freeze
 
-        def on_def(node)
-          _, _, body = *node
-
+        def on_method_def(_node, _method_name, _args, body)
           return unless body
 
           if body.if_type?

--- a/spec/rubocop/cop/style/guard_clause_spec.rb
+++ b/spec/rubocop/cop/style/guard_clause_spec.rb
@@ -307,4 +307,28 @@ describe RuboCop::Cop::Style::GuardClause, :config do
   include_examples('on if nodes which exit current scope', 'next')
   include_examples('on if nodes which exit current scope', 'break')
   include_examples('on if nodes which exit current scope', 'raise "error"')
+
+  context 'method in module' do
+    it 'registers an offense for instance method' do
+      inspect_source(cop, ['module CopTest',
+                           '  def test',
+                           '    if something',
+                           '      work',
+                           '    end',
+                           '  end',
+                           'end'])
+      expect(cop.offenses.size).to eq(1)
+    end
+
+    it 'registers an offense for singleton methods' do
+      inspect_source(cop, ['module CopTest',
+                           '  def self.test',
+                           '    if something',
+                           '      work',
+                           '    end',
+                           '  end',
+                           'end'])
+      expect(cop.offenses.size).to eq(1)
+    end
+  end
 end


### PR DESCRIPTION
Fixes #3540  

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Used the same coding conventions as the rest of the project.
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] All tests are passing.
* [x] The new code doesn't generate RuboCop offenses.
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.

[1]: http://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html