### PR TITLE
Remove more unnecessary magic encoding comments

### DIFF
--- a/spec/rubocop/cli/cli_auto_gen_config_spec.rb
+++ b/spec/rubocop/cli/cli_auto_gen_config_spec.rb
@@ -35,8 +35,7 @@ describe RuboCop::CLI, :isolated_environment do
     end
 
     it 'overwrites an existing todo file' do
-      create_file('example1.rb', ['# encoding: utf-8',
-                                  'x= 0 ',
+      create_file('example1.rb', ['x= 0 ',
                                   '#' * 85,
                                   'y ',
                                   'puts x'])
@@ -72,8 +71,7 @@ describe RuboCop::CLI, :isolated_environment do
     end
 
     it 'honors rubocop:disable comments' do
-      create_file('example1.rb', ['# encoding: utf-8',
-                                  '#' * 81,
+      create_file('example1.rb', ['#' * 81,
                                   '# rubocop:disable LineLength',
                                   '#' * 85,
                                   'y ',
@@ -102,8 +100,7 @@ describe RuboCop::CLI, :isolated_environment do
     end
 
     it 'can generate a todo list' do
-      create_file('example1.rb', ['# encoding: utf-8',
-                                  '$x= 0 ',
+      create_file('example1.rb', ['$x= 0 ',
                                   '#' * 90,
                                   '#' * 85,
                                   'y ',
@@ -206,8 +203,7 @@ describe RuboCop::CLI, :isolated_environment do
     end
 
     it 'can generate Exclude properties with a given limit' do
-      create_file('example1.rb', ['# encoding: utf-8',
-                                  '$x= 0 ',
+      create_file('example1.rb', ['$x= 0 ',
                                   '#' * 90,
                                   '#' * 85,
                                   'y ',
@@ -343,10 +339,9 @@ describe RuboCop::CLI, :isolated_environment do
     end
 
     it 'generates a todo list that removes the reports' do
-      create_file('example.rb', ['# encoding: utf-8',
-                                 'y.gsub!(/abc\/xyz/, x)'])
+      create_file('example.rb', 'y.gsub!(/abc\/xyz/, x)')
       expect(cli.run(%w(--format emacs))).to eq(1)
-      expect($stdout.string).to eq("#{abs('example.rb')}:2:9: C: Use `%r` " \
+      expect($stdout.string).to eq("#{abs('example.rb')}:1:9: C: Use `%r` " \
                                    "around regular expression.\n")
       expect(cli.run(['--auto-gen-config'])).to eq(1)
       expected =
@@ -382,8 +377,7 @@ describe RuboCop::CLI, :isolated_environment do
     end
 
     it 'does not include offense counts when --no-offense-counts is used' do
-      create_file('example1.rb', ['# encoding: utf-8',
-                                  '$x= 0 ',
+      create_file('example1.rb', ['$x= 0 ',
                                   '#' * 90,
                                   '#' * 85,
                                   'y ',

--- a/spec/rubocop/cli/cli_autocorrect_spec.rb
+++ b/spec/rubocop/cli/cli_autocorrect_spec.rb
@@ -520,8 +520,7 @@ describe RuboCop::CLI, :isolated_environment do
     # whitespace in the process, the combined changes don't interfere with
     # each other and the result is semantically the same as the starting
     # point.
-    source = ['# encoding: utf-8',
-              'expect(subject[:address]).to eq({',
+    source = ['expect(subject[:address]).to eq({',
               "  street1:     '1 Market',",
               "  street2:     '#200',",
               "  city:        'Some Town',",
@@ -531,8 +530,7 @@ describe RuboCop::CLI, :isolated_environment do
     create_file('example.rb', source)
     expect(cli.run(['-D', '--auto-correct'])).to eq(0)
     corrected =
-      ['# encoding: utf-8',
-       "expect(subject[:address]).to eq(street1:     '1 Market',",
+      ["expect(subject[:address]).to eq(street1:     '1 Market',",
        "                                street2:     '#200',",
        "                                city:        'Some Town',",
        "                                state:       'CA',",
@@ -541,20 +539,18 @@ describe RuboCop::CLI, :isolated_environment do
   end
 
   it 'honors Exclude settings in individual cops' do
-    source = ['# encoding: utf-8',
-              'puts %x(ls)']
+    source = 'puts %x(ls)'
     create_file('example.rb', source)
     create_file('.rubocop.yml', ['Style/CommandLiteral:',
                                  '  Exclude:',
                                  '    - example.rb'])
     expect(cli.run(['--auto-correct'])).to eq(0)
     expect($stdout.string).to include('no offenses detected')
-    expect(IO.read('example.rb')).to eq(source.join("\n") + "\n")
+    expect(IO.read('example.rb')).to eq("#{source}\n")
   end
 
   it 'corrects code with indentation problems' do
-    create_file('example.rb', ['# encoding: utf-8',
-                               'module Bar',
+    create_file('example.rb', ['module Bar',
                                'class Goo',
                                '  def something',
                                '    first call',
@@ -582,8 +578,7 @@ describe RuboCop::CLI, :isolated_environment do
                                'end'])
     expect(cli.run(['--auto-correct'])).to eq(1)
     expect(IO.read('example.rb'))
-      .to eq(['# encoding: utf-8',
-              'module Bar',
+      .to eq(['module Bar',
               '  class Goo',
               '    def something',
               '      first call',
@@ -610,8 +605,7 @@ describe RuboCop::CLI, :isolated_environment do
   end
 
   it 'can change block comments and indent them' do
-    create_file('example.rb', ['# encoding: utf-8',
-                               'module Foo',
+    create_file('example.rb', ['module Foo',
                                'class Bar',
                                '=begin',
                                'This is a nice long',
@@ -625,8 +619,7 @@ describe RuboCop::CLI, :isolated_environment do
                                'end'])
     expect(cli.run(['--auto-correct'])).to eq(1)
     expect(IO.read('example.rb'))
-      .to eq(['# encoding: utf-8',
-              'module Foo',
+      .to eq(['module Foo',
               '  class Bar',
               '    # This is a nice long',
               '    # comment',
@@ -641,14 +634,12 @@ describe RuboCop::CLI, :isolated_environment do
 
   it 'can correct two problems with blocks' do
     # {} should be do..end and space is missing.
-    create_file('example.rb', ['# encoding: utf-8',
-                               '(1..10).each{ |i|',
+    create_file('example.rb', ['(1..10).each{ |i|',
                                '  puts i',
                                '}'])
     expect(cli.run(['--auto-correct'])).to eq(0)
     expect(IO.read('example.rb'))
-      .to eq(['# encoding: utf-8',
-              '(1..10).each do |i|',
+      .to eq(['(1..10).each do |i|',
               '  puts i',
               'end',
               ''].join("\n"))
@@ -656,23 +647,21 @@ describe RuboCop::CLI, :isolated_environment do
 
   it 'can handle spaces when removing braces' do
     create_file('example.rb',
-                ['# encoding: utf-8',
-                 "assert_post_status_code 400, 's', {:type => 'bad'}"])
+                ["assert_post_status_code 400, 's', {:type => 'bad'}"])
     expect(cli.run(%w(--auto-correct --format emacs))).to eq(0)
     expect(IO.read('example.rb'))
-      .to eq(['# encoding: utf-8',
-              "assert_post_status_code 400, 's', type: 'bad'",
+      .to eq(["assert_post_status_code 400, 's', type: 'bad'",
               ''].join("\n"))
     e = abs('example.rb')
     expect($stdout.string)
-      .to eq(["#{e}:2:35: C: [Corrected] Redundant curly braces around " \
+      .to eq(["#{e}:1:35: C: [Corrected] Redundant curly braces around " \
               'a hash parameter.',
               # TODO: Don't report that a problem is corrected when it
               # actually went away due to another correction.
-              "#{e}:2:35: C: [Corrected] Space inside { missing.",
-              "#{e}:2:36: C: [Corrected] Use the new Ruby 1.9 hash " \
+              "#{e}:1:35: C: [Corrected] Space inside { missing.",
+              "#{e}:1:36: C: [Corrected] Use the new Ruby 1.9 hash " \
               'syntax.',
-              "#{e}:2:50: C: [Corrected] Space inside } missing.",
+              "#{e}:1:50: C: [Corrected] Space inside } missing.",
               ''].join("\n"))
   end
 
@@ -697,14 +686,12 @@ describe RuboCop::CLI, :isolated_environment do
   # A case where WordArray's correction can be clobbered by
   # AccessModifierIndentation's correction.
   it 'can correct indentation and another thing' do
-    create_file('example.rb', ['# encoding: utf-8',
-                               'class Dsl',
+    create_file('example.rb', ['class Dsl',
                                'private',
                                '  A = ["git", "path",]',
                                'end'])
     expect(cli.run(%w(--auto-correct --format emacs))).to eq(1)
-    expect(IO.read('example.rb')).to eq(['# encoding: utf-8',
-                                         'class Dsl',
+    expect(IO.read('example.rb')).to eq(['class Dsl',
                                          '  private',
                                          '',
                                          '  A = %w(git path).freeze',
@@ -712,26 +699,26 @@ describe RuboCop::CLI, :isolated_environment do
                                          ''].join("\n"))
     e = abs('example.rb')
     expect($stdout.string)
-      .to eq(["#{e}:2:1: C: Missing top-level class documentation " \
+      .to eq(["#{e}:1:1: C: Missing top-level class documentation " \
               'comment.',
-              "#{e}:3:1: C: [Corrected] Indent access modifiers like " \
+              "#{e}:2:1: C: [Corrected] Indent access modifiers like " \
               '`private`.',
-              "#{e}:3:1: C: [Corrected] Keep a blank line before and " \
+              "#{e}:2:1: C: [Corrected] Keep a blank line before and " \
               'after `private`.',
-              "#{e}:3:3: W: Useless `private` access modifier.",
-              "#{e}:4:7: C: [Corrected] Freeze mutable objects assigned " \
+              "#{e}:2:3: W: Useless `private` access modifier.",
+              "#{e}:3:7: C: [Corrected] Freeze mutable objects assigned " \
               'to constants.',
-              "#{e}:4:7: C: [Corrected] Use `%w` or `%W` " \
+              "#{e}:3:7: C: [Corrected] Use `%w` or `%W` " \
               'for an array of words.',
-              "#{e}:4:8: C: [Corrected] Prefer single-quoted strings " \
+              "#{e}:3:8: C: [Corrected] Prefer single-quoted strings " \
               "when you don't need string interpolation or special " \
               'symbols.',
-              "#{e}:4:15: C: [Corrected] Prefer single-quoted strings " \
+              "#{e}:3:15: C: [Corrected] Prefer single-quoted strings " \
               "when you don't need string interpolation or special " \
               'symbols.',
-              "#{e}:4:21: C: [Corrected] Avoid comma after the last item " \
+              "#{e}:3:21: C: [Corrected] Avoid comma after the last item " \
               'of an array.',
-              "#{e}:5:7: C: [Corrected] Use `%w` or `%W` " \
+              "#{e}:4:7: C: [Corrected] Use `%w` or `%W` " \
               'for an array of words.',
               ''].join("\n"))
   end
@@ -753,12 +740,10 @@ describe RuboCop::CLI, :isolated_environment do
   end
 
   it 'can correct single line methods' do
-    create_file('example.rb', ['# encoding: utf-8',
-                               'def func1; do_something end # comment',
+    create_file('example.rb', ['def func1; do_something end # comment',
                                'def func2() do_1; do_2; end'])
     expect(cli.run(%w(--auto-correct --format offenses))).to eq(0)
-    expect(IO.read('example.rb')).to eq(['# encoding: utf-8',
-                                         '# comment',
+    expect(IO.read('example.rb')).to eq(['# comment',
                                          'def func1',
                                          '  do_something',
                                          'end',
@@ -785,13 +770,11 @@ describe RuboCop::CLI, :isolated_environment do
   # corrected automatically.
   it 'can correct a problems and the problem it creates' do
     create_file('example.rb',
-                ['# encoding: utf-8',
-                 'fail NotImplementedError,',
+                ['fail NotImplementedError,',
                  "     'Method should be overridden in child classes'"])
     expect(cli.run(['--auto-correct'])).to eq(0)
     expect(IO.read('example.rb'))
-      .to eq(['# encoding: utf-8',
-              'raise NotImplementedError,',
+      .to eq(['raise NotImplementedError,',
               "      'Method should be overridden in child classes'",
               ''].join("\n"))
     expect($stdout.string)
@@ -800,11 +783,11 @@ describe RuboCop::CLI, :isolated_environment do
               '',
               'Offenses:',
               '',
-              'example.rb:2:1: C: [Corrected] Always use raise ' \
+              'example.rb:1:1: C: [Corrected] Always use raise ' \
               'to signal exceptions.',
               'fail NotImplementedError,',
               '^^^^',
-              'example.rb:3:6: C: [Corrected] Align the parameters of a ' \
+              'example.rb:2:6: C: [Corrected] Align the parameters of a ' \
               'method call if they span more than one line.',
               "     'Method should be overridden in child classes'",
               '     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^',
@@ -818,8 +801,7 @@ describe RuboCop::CLI, :isolated_environment do
   # spaces, and then the extra empty line.
   it 'can correct two problems in the same place' do
     create_file('example.rb',
-                ['# encoding: utf-8',
-                 '# Example class.',
+                ['# Example class.',
                  'class Klass',
                  '  ',
                  '  def f',
@@ -827,8 +809,7 @@ describe RuboCop::CLI, :isolated_environment do
                  'end'])
     expect(cli.run(['--auto-correct'])).to eq(0)
     expect(IO.read('example.rb'))
-      .to eq(['# encoding: utf-8',
-              '# Example class.',
+      .to eq(['# Example class.',
               'class Klass',
               '  def f',
               '  end',
@@ -841,9 +822,9 @@ describe RuboCop::CLI, :isolated_environment do
               '',
               'Offenses:',
               '',
-              'example.rb:4:1: C: [Corrected] Extra empty line detected ' \
+              'example.rb:3:1: C: [Corrected] Extra empty line detected ' \
               'at class body beginning.',
-              'example.rb:4:1: C: [Corrected] Trailing whitespace ' \
+              'example.rb:3:1: C: [Corrected] Trailing whitespace ' \
               'detected.',
               '',
               '1 file inspected, 2 offenses detected, 2 offenses ' \
@@ -853,15 +834,13 @@ describe RuboCop::CLI, :isolated_environment do
 
   it 'can correct MethodDefParentheses and other offense' do
     create_file('example.rb',
-                ['# encoding: utf-8',
-                 'def primes limit',
+                ['def primes limit',
                  '  1.upto(limit).select { |i| i.even? }',
                  'end'])
     expect(cli.run(%w(-D --auto-correct))).to eq(0)
     expect($stderr.string).to eq('')
     expect(IO.read('example.rb'))
-      .to eq(['# encoding: utf-8',
-              'def primes(limit)',
+      .to eq(['def primes(limit)',
               '  1.upto(limit).select(&:even?)',
               'end',
               ''].join("\n"))
@@ -871,12 +850,12 @@ describe RuboCop::CLI, :isolated_environment do
               '',
               'Offenses:',
               '',
-              'example.rb:2:12: C: [Corrected] ' \
+              'example.rb:1:12: C: [Corrected] ' \
               'Style/MethodDefParentheses: ' \
               'Use def with parentheses when there are parameters.',
               'def primes limit',
               '           ^^^^^',
-              'example.rb:3:24: C: [Corrected] Style/SymbolProc: ' \
+              'example.rb:2:24: C: [Corrected] Style/SymbolProc: ' \
               'Pass &:even? as an argument to select instead of a block.',
               '  1.upto(limit).select { |i| i.even? }',
               '                       ^^^^^^^^^^^^^^^',
@@ -888,8 +867,7 @@ describe RuboCop::CLI, :isolated_environment do
 
   it 'can correct WordArray and SpaceAfterComma offenses' do
     create_file('example.rb',
-                ['# encoding: utf-8',
-                 "f(type: ['offline','offline_payment'],",
+                ["f(type: ['offline','offline_payment'],",
                  "  bar_colors: ['958c12','953579','ff5800','0085cc'])"])
     expect(cli.run(%w(-D --auto-correct --format o))).to eq(0)
     expect($stdout.string)
@@ -901,58 +879,46 @@ describe RuboCop::CLI, :isolated_environment do
               '',
               ''].join("\n"))
     expect(IO.read('example.rb'))
-      .to eq(['# encoding: utf-8',
-              'f(type: %w(offline offline_payment),',
+      .to eq(['f(type: %w(offline offline_payment),',
               '  bar_colors: %w(958c12 953579 ff5800 0085cc))',
               ''].join("\n"))
   end
 
   it 'can correct SpaceAfterComma and HashSyntax offenses' do
     create_file('example.rb',
-                ['# encoding: utf-8',
-                 "I18n.t('description',:property_name => property.name)"])
+                "I18n.t('description',:property_name => property.name)")
     expect(cli.run(%w(-D --auto-correct --format emacs))).to eq(0)
     expect($stdout.string)
-      .to eq(["#{abs('example.rb')}:2:21: C: [Corrected] " \
+      .to eq(["#{abs('example.rb')}:1:21: C: [Corrected] " \
               'Style/SpaceAfterComma: Space missing after comma.',
-              "#{abs('example.rb')}:2:22: C: [Corrected] " \
+              "#{abs('example.rb')}:1:22: C: [Corrected] " \
               'Style/HashSyntax: Use the new Ruby 1.9 hash syntax.',
               ''].join("\n"))
     expect(IO.read('example.rb'))
-      .to eq(['# encoding: utf-8',
-              "I18n.t('description', property_name: property.name)",
-              ''].join("\n"))
+      .to eq("I18n.t('description', property_name: property.name)\n")
   end
 
   it 'can correct HashSyntax and SpaceAroundOperators offenses' do
-    create_file('example.rb',
-                ['# encoding: utf-8',
-                 '{ :b=>1 }'])
+    create_file('example.rb', '{ :b=>1 }')
     expect(cli.run(%w(-D --auto-correct --format emacs))).to eq(0)
-    expect(IO.read('example.rb')).to eq(['# encoding: utf-8',
-                                         '{ b: 1 }',
-                                         ''].join("\n"))
+    expect(IO.read('example.rb')).to eq("{ b: 1 }\n")
     expect($stdout.string)
-      .to eq(["#{abs('example.rb')}:2:3: C: [Corrected] " \
+      .to eq(["#{abs('example.rb')}:1:3: C: [Corrected] " \
               'Style/HashSyntax: Use the new Ruby 1.9 hash syntax.',
-              "#{abs('example.rb')}:2:5: C: [Corrected] " \
+              "#{abs('example.rb')}:1:5: C: [Corrected] " \
               'Style/SpaceAroundOperators: Surrounding space missing for ' \
               'operator `=>`.',
               ''].join("\n"))
   end
 
   it 'can correct HashSyntax when --only is used' do
-    create_file('example.rb',
-                ['# encoding: utf-8',
-                 '{ :b=>1 }'])
+    create_file('example.rb', '{ :b=>1 }')
     expect(cli.run(%w(--auto-correct -f emacs
                       --only Style/HashSyntax))).to eq(0)
     expect($stderr.string).to eq('')
-    expect(IO.read('example.rb')).to eq(['# encoding: utf-8',
-                                         '{ b: 1 }',
-                                         ''].join("\n"))
+    expect(IO.read('example.rb')).to eq("{ b: 1 }\n")
     expect($stdout.string)
-      .to eq(["#{abs('example.rb')}:2:3: C: [Corrected] Use the new " \
+      .to eq(["#{abs('example.rb')}:1:3: C: [Corrected] Use the new " \
               'Ruby 1.9 hash syntax.',
               ''].join("\n"))
   end
@@ -976,26 +942,21 @@ describe RuboCop::CLI, :isolated_environment do
   end
 
   it 'can correct MethodCallParentheses and EmptyLiteral offenses' do
-    create_file('example.rb',
-                ['# encoding: utf-8',
-                 'Hash.new()'])
+    create_file('example.rb', 'Hash.new()')
     expect(cli.run(%w(--auto-correct --format emacs))).to eq(0)
     expect($stderr.string).to eq('')
-    expect(IO.read('example.rb')).to eq(['# encoding: utf-8',
-                                         '{}',
-                                         ''].join("\n"))
+    expect(IO.read('example.rb')).to eq("{}\n")
     expect($stdout.string)
-      .to eq(["#{abs('example.rb')}:2:1: C: [Corrected] Use hash " \
+      .to eq(["#{abs('example.rb')}:1:1: C: [Corrected] Use hash " \
               'literal `{}` instead of `Hash.new`.',
-              "#{abs('example.rb')}:2:9: C: [Corrected] Do not use " \
+              "#{abs('example.rb')}:1:9: C: [Corrected] Do not use " \
               'parentheses for method calls with no arguments.',
               ''].join("\n"))
   end
 
   it 'can correct IndentHash offenses with separator style' do
     create_file('example.rb',
-                ['# encoding: utf-8',
-                 'CONVERSION_CORRESPONDENCE = {',
+                ['CONVERSION_CORRESPONDENCE = {',
                  '              match_for_should: :match,',
                  '          match_for_should_not: :match_when_negated,',
                  '    failure_message_for_should: :failure_message,',
@@ -1006,8 +967,7 @@ describe RuboCop::CLI, :isolated_environment do
                  '  EnforcedColonStyle: separator'])
     expect(cli.run(%w(--auto-correct))).to eq(0)
     expect(IO.read('example.rb'))
-      .to eq(['# encoding: utf-8',
-              'CONVERSION_CORRESPONDENCE = {',
+      .to eq(['CONVERSION_CORRESPONDENCE = {',
               '                match_for_should: :match,',
               '            match_for_should_not: :match_when_negated,',
               '      failure_message_for_should: :failure_message,',
@@ -1017,23 +977,21 @@ describe RuboCop::CLI, :isolated_environment do
   end
 
   it 'does not say [Corrected] if correction was avoided' do
-    src = ['# encoding: utf-8',
-           'func a do b end',
+    src = ['func a do b end',
            "Signal.trap('TERM') { system(cmd); exit }",
            'def self.some_method(foo, bar: 1)',
            '  log.debug(foo)',
            'end']
-    corrected = ['# encoding: utf-8',
-                 'func a do b end',
+    corrected = ['func a do b end',
                  "Signal.trap('TERM') { system(cmd); exit }",
                  'def self.some_method(foo, bar: 1)',
                  '  log.debug(foo)',
                  'end']
     offenses =
       ['== example.rb ==',
-       'C:  2:  8: Prefer {...} over do...end for single-line blocks.',
-       'C:  3: 34: Do not use semicolons to terminate expressions.',
-       'W:  4: 27: Unused method argument - bar.']
+       'C:  1:  8: Prefer {...} over do...end for single-line blocks.',
+       'C:  2: 34: Do not use semicolons to terminate expressions.',
+       'W:  3: 27: Unused method argument - bar.']
     summary = '1 file inspected, 3 offenses detected'
     create_file('.rubocop.yml', ['AllCops:',
                                  '  TargetRubyVersion: 2.0'])
@@ -1046,41 +1004,30 @@ describe RuboCop::CLI, :isolated_environment do
   end
 
   it 'does not hang SpaceAfterPunctuation and SpaceInsideParens' do
-    create_file('example.rb',
-                ['# encoding: utf-8',
-                 'some_method(a, )'])
+    create_file('example.rb', 'some_method(a, )')
     Timeout.timeout(10) do
       expect(cli.run(%w(--auto-correct))).to eq(0)
     end
     expect($stderr.string).to eq('')
-    expect(IO.read('example.rb')).to eq(['# encoding: utf-8',
-                                         'some_method(a)',
-                                         ''].join("\n"))
+    expect(IO.read('example.rb')).to eq("some_method(a)\n")
   end
 
   it 'does not hang SpaceAfterPunctuation and SpaceInsideBrackets' do
-    create_file('example.rb',
-                ['# encoding: utf-8',
-                 'puts [1, ]'])
+    create_file('example.rb', 'puts [1, ]')
     Timeout.timeout(10) do
       expect(cli.run(%w(--auto-correct))).to eq(0)
     end
     expect($stderr.string).to eq('')
-    expect(IO.read('example.rb')).to eq(['# encoding: utf-8',
-                                         'puts [1]',
-                                         ''].join("\n"))
+    expect(IO.read('example.rb')).to eq("puts [1]\n")
   end
 
   it 'can be disabled for any cop in configuration' do
-    create_file('example.rb', ['# encoding: utf-8',
-                               'puts "Hello", 123456'])
+    create_file('example.rb', 'puts "Hello", 123456')
     create_file('.rubocop.yml', ['Style/StringLiterals:',
                                  '  AutoCorrect: false'])
     expect(cli.run(%w(--auto-correct))).to eq(1)
     expect($stderr.string).to eq('')
-    expect(IO.read('example.rb')).to eq(['# encoding: utf-8',
-                                         'puts "Hello", 123_456',
-                                         ''].join("\n"))
+    expect(IO.read('example.rb')).to eq("puts \"Hello\", 123_456\n")
   end
 
   it 'handles different SpaceInsideBlockBraces and ' \

--- a/spec/rubocop/cli/cli_options_spec.rb
+++ b/spec/rubocop/cli/cli_options_spec.rb
@@ -281,8 +281,7 @@ describe RuboCop::CLI, :isolated_environment do
 
     context 'when two namespaces are given' do
       it 'runs all enabled cops in those namespaces' do
-        create_file('example.rb', ['# encoding: utf-8',
-                                   'if x== 100000000000000 ',
+        create_file('example.rb', ['if x== 100000000000000 ',
                                    '  # ' + '-' * 98,
                                    "\ty",
                                    'end'])
@@ -666,8 +665,7 @@ describe RuboCop::CLI, :isolated_environment do
     let(:target_file) { 'example.rb' }
 
     before do
-      create_file(target_file, ['# encoding: utf-8',
-                                '#' * 90])
+      create_file(target_file, '#' * 90)
     end
 
     describe 'builtin formatters' do
@@ -676,7 +674,7 @@ describe RuboCop::CLI, :isolated_environment do
           cli.run(['--format', 'simple', 'example.rb'])
           expect($stdout.string)
             .to include(["== #{target_file} ==",
-                         'C:  2: 81: Line is too long. [90/80]'].join("\n"))
+                         'C:  1: 81: Line is too long. [90/80]'].join("\n"))
         end
       end
 
@@ -702,8 +700,7 @@ describe RuboCop::CLI, :isolated_environment do
               end
 
               it "outputs #{format.upcase} code without crashing" do
-                create_file('example.rb', ['# encoding: utf-8',
-                                           'def 文',
+                create_file('example.rb', ['def 文',
                                            '  b if a',
                                            '  b if a',
                                            '  b if a',
@@ -733,8 +730,7 @@ describe RuboCop::CLI, :isolated_environment do
 
       context 'when clang format is specified' do
         it 'outputs with clang format' do
-          create_file('example1.rb', ['# encoding: utf-8',
-                                      'x= 0 ',
+          create_file('example1.rb', ['x= 0 ',
                                       '#' * 85,
                                       'y ',
                                       'puts x'])
@@ -743,8 +739,7 @@ describe RuboCop::CLI, :isolated_environment do
                                       'def a',
                                       '   puts',
                                       'end'])
-          create_file('example3.rb', ['# encoding: utf-8',
-                                      'def badName',
+          create_file('example3.rb', ['def badName',
                                       '  if something',
                                       '    test',
                                       '    end',
@@ -753,19 +748,19 @@ describe RuboCop::CLI, :isolated_environment do
                           'example2.rb', 'example3.rb']))
             .to eq(1)
           expect($stdout.string)
-            .to eq(['example1.rb:2:2: C: Surrounding space missing for ' \
+            .to eq(['example1.rb:1:2: C: Surrounding space missing for ' \
                     'operator =.',
                     'x= 0 ',
                     ' ^',
-                    'example1.rb:2:5: C: Trailing whitespace detected.',
+                    'example1.rb:1:5: C: Trailing whitespace detected.',
                     'x= 0 ',
                     '    ^',
-                    'example1.rb:3:81: C: Line is too long. [85/80]',
+                    'example1.rb:2:81: C: Line is too long. [85/80]',
                     '###################################################' \
                     '##################################',
                     '                                                   ' \
                     '                             ^^^^^',
-                    'example1.rb:4:2: C: Trailing whitespace detected.',
+                    'example1.rb:3:2: C: Trailing whitespace detected.',
                     'y ',
                     ' ^',
                     'example2.rb:1:1: C: Incorrect indentation detected' \
@@ -787,20 +782,20 @@ describe RuboCop::CLI, :isolated_environment do
                     'indentation.',
                     '   puts',
                     '^^^',
-                    'example3.rb:2:5: C: Use snake_case for method names.',
+                    'example3.rb:1:5: C: Use snake_case for method names.',
                     'def badName',
                     '    ^^^^^^^',
-                    'example3.rb:3:3: C: Use a guard clause instead of ' \
+                    'example3.rb:2:3: C: Use a guard clause instead of ' \
                     'wrapping the code inside a conditional expression.',
                     '  if something',
                     '  ^^',
-                    'example3.rb:3:3: C: Favor modifier if usage ' \
+                    'example3.rb:2:3: C: Favor modifier if usage ' \
                     'when having a single-line body. Another good ' \
                     'alternative is the usage of control flow &&/||.',
                     '  if something',
                     '  ^^',
-                    'example3.rb:5:5: W: end at 5, 4 is not aligned ' \
-                    'with if at 3, 2.',
+                    'example3.rb:4:5: W: end at 4, 4 is not aligned ' \
+                    'with if at 2, 2.',
                     '    end',
                     '    ^^^',
                     '',
@@ -902,8 +897,8 @@ describe RuboCop::CLI, :isolated_environment do
       cli.run(['--format', 'simple', '--format', 'emacs', 'example.rb'])
       expect($stdout.string)
         .to include(["== #{target_file} ==",
-                     'C:  2: 81: Line is too long. [90/80]',
-                     "#{abs(target_file)}:2:81: C: Line is too long. " \
+                     'C:  1: 81: Line is too long. [90/80]',
+                     "#{abs(target_file)}:1:81: C: Line is too long. " \
                      '[90/80]'].join("\n"))
     end
   end
@@ -912,8 +907,7 @@ describe RuboCop::CLI, :isolated_environment do
     let(:target_file) { 'example.rb' }
 
     before do
-      create_file(target_file, ['# encoding: utf-8',
-                                '#' * 90])
+      create_file(target_file, '#' * 90)
     end
 
     it 'redirects output to the specified file' do
@@ -927,13 +921,13 @@ describe RuboCop::CLI, :isolated_environment do
                target_file])
 
       expect($stdout.string).to eq(["== #{target_file} ==",
-                                    'C:  2: 81: Line is too long. [90/80]',
+                                    'C:  1: 81: Line is too long. [90/80]',
                                     '',
                                     '1 file inspected, 1 offense detected',
                                     ''].join("\n"))
 
       expect(File.read('emacs_output.txt'))
-        .to eq(["#{abs(target_file)}:2:81: C: Line is too long. [90/80]",
+        .to eq(["#{abs(target_file)}:1:81: C: Line is too long. [90/80]",
                 ''].join("\n"))
     end
   end
@@ -942,8 +936,7 @@ describe RuboCop::CLI, :isolated_environment do
     let(:target_file) { 'example.rb' }
 
     before do
-      create_file(target_file, ['# encoding: utf-8',
-                                'def f',
+      create_file(target_file, ['def f',
                                 ' x',
                                 'end'])
     end
@@ -1010,8 +1003,7 @@ describe RuboCop::CLI, :isolated_environment do
                "\n")
     end
     it 'succeeds when there is only a disabled offense' do
-      create_file(target_file, ['# encoding: utf-8',
-                                'def f',
+      create_file(target_file, ['def f',
                                 ' x # rubocop:disable Style/IndentationWidth',
                                 'end'])
 
@@ -1025,8 +1017,7 @@ describe RuboCop::CLI, :isolated_environment do
     let(:target_file) { 'example.rb' }
 
     before do
-      create_file(target_file, ['# encoding: utf-8',
-                                '#' * 90])
+      create_file(target_file, '#' * 90)
 
       create_file('.rubocop.yml', ['AllCops:',
                                    '  Exclude:',

--- a/spec/rubocop/cli_spec.rb
+++ b/spec/rubocop/cli_spec.rb
@@ -122,8 +122,7 @@ describe RuboCop::CLI, :isolated_environment do
 
   context 'when lines end with CR+LF' do
     it 'reports an offense' do
-      create_file('example.rb', ["# encoding: utf-8\r",
-                                 "x = 0\r",
+      create_file('example.rb', ["x = 0\r",
                                  "puts x\r"])
       result = cli.run(['--format', 'simple', 'example.rb'])
       expect(result).to eq(1)
@@ -138,9 +137,7 @@ describe RuboCop::CLI, :isolated_environment do
 
   context 'when checking a correct file' do
     it 'returns 0' do
-      create_file('example.rb', ['# encoding: utf-8',
-                                 'x = 0',
-                                 'puts x'])
+      create_file('example.rb', ['x = 0', 'puts x'])
       expect(cli.run(['--format', 'simple', 'example.rb'])).to eq(0)
       expect($stdout.string)
         .to eq(['',
@@ -150,8 +147,7 @@ describe RuboCop::CLI, :isolated_environment do
 
     context 'when super is used with a block' do
       it 'still returns 0' do
-        create_file('example.rb', ['# encoding: utf-8',
-                                   '# frozen_string_literal: true',
+        create_file('example.rb', ['# frozen_string_literal: true',
                                    '# this is a class',
                                    'class Thing',
                                    '  def super_with_block',
@@ -174,49 +170,42 @@ describe RuboCop::CLI, :isolated_environment do
   end
 
   it 'checks a given file with faults and returns 1' do
-    create_file('example.rb', ['# encoding: utf-8',
-                               'x = 0 ',
-                               'puts x'])
+    create_file('example.rb', ['x = 0 ', 'puts x'])
     expect(cli.run(['--format', 'simple', 'example.rb'])).to eq(1)
     expect($stdout.string)
       .to eq ['== example.rb ==',
-              'C:  2:  6: Trailing whitespace detected.',
+              'C:  1:  6: Trailing whitespace detected.',
               '',
               '1 file inspected, 1 offense detected',
               ''].join("\n")
   end
 
   it 'registers an offense for a syntax error' do
-    create_file('example.rb', ['# encoding: utf-8',
-                               'class Test',
-                               'en'])
+    create_file('example.rb', ['class Test', 'en'])
     expect(cli.run(['--format', 'emacs', 'example.rb'])).to eq(1)
     expect($stdout.string)
-      .to eq(["#{abs('example.rb')}:4:1: E: unexpected " \
+      .to eq(["#{abs('example.rb')}:3:1: E: unexpected " \
               'token $end (Using Ruby 2.0 parser; configure using ' \
               '`TargetRubyVersion` parameter, under `AllCops`)',
               ''].join("\n"))
   end
 
   it 'registers an offense for Parser warnings' do
-    create_file('example.rb', ['# encoding: utf-8',
-                               'puts *test',
-                               'if a then b else c end'])
+    create_file('example.rb', ['puts *test', 'if a then b else c end'])
     expect(cli.run(['--format', 'emacs', 'example.rb'])).to eq(1)
     expect($stdout.string)
-      .to eq(["#{abs('example.rb')}:2:6: W: " \
+      .to eq(["#{abs('example.rb')}:1:6: W: " \
               'Ambiguous splat operator. Parenthesize the method arguments ' \
               "if it's surely a splat operator, or add a whitespace to the " \
               'right of the `*` if it should be a multiplication.',
-              "#{abs('example.rb')}:3:1: C: " \
+              "#{abs('example.rb')}:2:1: C: " \
               'Favor the ternary operator (`?:`) over `if/then/else/end` ' \
               'constructs.',
               ''].join("\n"))
   end
 
   it 'can process a file with an invalid UTF-8 byte sequence' do
-    create_file('example.rb', ['# encoding: utf-8',
-                               "# #{'f9'.hex.chr}#{'29'.hex.chr}"])
+    create_file('example.rb', ["# #{'f9'.hex.chr}#{'29'.hex.chr}"])
     expect(cli.run(['--format', 'emacs', 'example.rb'])).to eq(1)
     expect($stdout.string)
       .to eq(["#{abs('example.rb')}:1:1: F: Invalid byte sequence in utf-8.",
@@ -242,8 +231,7 @@ describe RuboCop::CLI, :isolated_environment do
 
   describe 'rubocop:disable comment' do
     it 'can disable all cops in a code section' do
-      src = ['# encoding: utf-8',
-             '# rubocop:disable all',
+      src = ['# rubocop:disable all',
              '#' * 90,
              'x(123456)',
              'y("123")',
@@ -258,8 +246,8 @@ describe RuboCop::CLI, :isolated_environment do
       # all cops were disabled, then 2 were enabled again, so we
       # should get 2 offenses reported.
       expect($stdout.string)
-        .to eq(["#{abs('example.rb')}:8:81: C: Line is too long. [95/80]",
-                "#{abs('example.rb')}:10:5: C: Prefer single-quoted " \
+        .to eq(["#{abs('example.rb')}:7:81: C: Line is too long. [95/80]",
+                "#{abs('example.rb')}:9:5: C: Prefer single-quoted " \
                 "strings when you don't need string interpolation or " \
                 'special symbols.',
                 ''].join("\n"))
@@ -288,8 +276,7 @@ describe RuboCop::CLI, :isolated_environment do
 
     it 'can disable selected cops in a code section' do
       create_file('example.rb',
-                  ['# encoding: utf-8',
-                   '# rubocop:disable Style/LineLength,' \
+                  ['# rubocop:disable Style/LineLength,' \
                    'Style/NumericLiterals,Style/StringLiterals',
                    '#' * 90,
                    'x(123456)',
@@ -309,43 +296,40 @@ describe RuboCop::CLI, :isolated_environment do
       # 3 cops were disabled, then 2 were enabled again, so we
       # should get 2 offenses reported.
       expect($stdout.string)
-        .to eq(["#{abs('example.rb')}:8:81: C: Line is too long. [95/80]",
-                "#{abs('example.rb')}:10:5: C: Prefer single-quoted " \
+        .to eq(["#{abs('example.rb')}:7:81: C: Line is too long. [95/80]",
+                "#{abs('example.rb')}:9:5: C: Prefer single-quoted " \
                 "strings when you don't need string interpolation or " \
                 'special symbols.',
                 ''].join("\n"))
     end
 
     it 'can disable all cops on a single line' do
-      create_file('example.rb', ['# encoding: utf-8',
-                                 'y("123", 123456) # rubocop:disable all'])
+      create_file('example.rb', 'y("123", 123456) # rubocop:disable all')
       expect(cli.run(['--format', 'emacs', 'example.rb'])).to eq(0)
       expect($stdout.string).to be_empty
     end
 
     it 'can disable selected cops on a single line' do
       create_file('example.rb',
-                  ['# encoding: utf-8',
-                   'a' * 90 + ' # rubocop:disable Metrics/LineLength',
+                  ['a' * 90 + ' # rubocop:disable Metrics/LineLength',
                    '#' * 95,
                    'y("123", 123456) # rubocop:disable Style/StringLiterals,' \
                    'Style/NumericLiterals'])
       expect(cli.run(['--format', 'emacs', 'example.rb'])).to eq(1)
       expect($stdout.string)
-        .to eq(["#{abs('example.rb')}:3:81: C: Line is too long. [95/80]",
+        .to eq(["#{abs('example.rb')}:2:81: C: Line is too long. [95/80]",
                 ''].join("\n"))
     end
 
     context 'without using namespace' do
       it 'can disable selected cops on a single line' do
         create_file('example.rb',
-                    ['# encoding: utf-8',
-                     'a' * 90 + ' # rubocop:disable LineLength',
+                    ['a' * 90 + ' # rubocop:disable LineLength',
                      '#' * 95,
                      'y("123") # rubocop:disable StringLiterals'])
         expect(cli.run(['--format', 'emacs', 'example.rb'])).to eq(1)
         expect($stdout.string)
-          .to eq(["#{abs('example.rb')}:3:81: C: Line is too long. [95/80]",
+          .to eq(["#{abs('example.rb')}:2:81: C: Line is too long. [95/80]",
                   ''].join("\n"))
       end
     end
@@ -353,29 +337,26 @@ describe RuboCop::CLI, :isolated_environment do
     context 'when not necessary' do
       it 'causes an offense to be reported' do
         create_file('example.rb',
-                    ['# encoding: utf-8',
-                     '#' * 95,
+                    ['#' * 95,
                      '# rubocop:disable all',
                      'a' * 10 + ' # rubocop:disable LineLength,ClassLength',
                      'y(123) # rubocop:disable all'])
         expect(cli.run(['--format', 'emacs', 'example.rb'])).to eq(1)
         expect($stderr.string).to eq('')
         expect($stdout.string)
-          .to eq(["#{abs('example.rb')}:2:81: C: Line is too long. [95/80]",
-                  "#{abs('example.rb')}:3:1: W: Unnecessary disabling of " \
+          .to eq(["#{abs('example.rb')}:1:81: C: Line is too long. [95/80]",
+                  "#{abs('example.rb')}:2:1: W: Unnecessary disabling of " \
                   'all cops.',
-                  "#{abs('example.rb')}:4:12: W: Unnecessary disabling of " \
+                  "#{abs('example.rb')}:3:12: W: Unnecessary disabling of " \
                   '`Metrics/ClassLength`, `Metrics/LineLength`.',
-                  "#{abs('example.rb')}:5:8: W: Unnecessary disabling of " \
+                  "#{abs('example.rb')}:4:8: W: Unnecessary disabling of " \
                   'all cops.',
                   ''].join("\n"))
       end
 
       context 'and there are no other offenses' do
         it 'exits with error code' do
-          create_file('example.rb',
-                      ['# encoding: utf-8',
-                       'a' * 10 + ' # rubocop:disable LineLength'])
+          create_file('example.rb', 'a' * 10 + ' # rubocop:disable LineLength')
           expect(cli.run(['example.rb'])).to eq(1)
         end
       end
@@ -384,8 +365,7 @@ describe RuboCop::CLI, :isolated_environment do
         context "and UnneededDisable is #{state}" do
           it 'does not report UnneededDisable offenses' do
             create_file('example.rb',
-                        ['# encoding: utf-8',
-                         '#' * 95,
+                        ['#' * 95,
                          '# rubocop:disable all',
                          'a' * 10 + ' # rubocop:disable LineLength,ClassLength',
                          'y(123) # rubocop:disable all'])
@@ -393,7 +373,7 @@ describe RuboCop::CLI, :isolated_environment do
             expect(cli.run(['--format', 'emacs'])).to eq(1)
             expect($stderr.string).to eq('')
             expect($stdout.string)
-              .to eq(["#{abs('example.rb')}:2:81: C: Line is too long. [95/80]",
+              .to eq(["#{abs('example.rb')}:1:81: C: Line is too long. [95/80]",
                       ''].join("\n"))
           end
         end
@@ -413,10 +393,7 @@ describe RuboCop::CLI, :isolated_environment do
   end
 
   it 'finds a file with no .rb extension but has a shebang line' do
-    create_file('example', ['#!/usr/bin/env ruby',
-                            '# encoding: utf-8',
-                            'x = 0',
-                            'puts x'])
+    create_file('example', ['#!/usr/bin/env ruby', 'x = 0', 'puts x'])
     expect(cli.run(%w(--format simple))).to eq(0)
     expect($stdout.string)
       .to eq(['', '1 file inspected, no offenses detected', ''].join("\n"))
@@ -552,23 +529,20 @@ describe RuboCop::CLI, :isolated_environment do
   describe 'rails cops' do
     describe 'enabling/disabling' do
       it 'by default does not run rails cops' do
-        create_file('app/models/example1.rb', ['# encoding: utf-8',
-                                               'read_attribute(:test)'])
+        create_file('app/models/example1.rb', 'read_attribute(:test)')
         expect(cli.run(['--format', 'simple', 'app/models/example1.rb']))
           .to eq(0)
       end
 
       it 'with -R given runs rails cops' do
-        create_file('app/models/example1.rb', ['# encoding: utf-8',
-                                               'read_attribute(:test)'])
+        create_file('app/models/example1.rb', 'read_attribute(:test)')
         expect(cli.run(['--format', 'simple', '-R', 'app/models/example1.rb']))
           .to eq(1)
         expect($stdout.string).to include('Prefer self[:attr]')
       end
 
       it 'with configuration option true in one dir runs rails cops there' do
-        source = ['# encoding: utf-8',
-                  'read_attribute(:test)']
+        source = 'read_attribute(:test)'
         create_file('dir1/app/models/example1.rb', source)
         create_file('dir1/.rubocop.yml', ['Rails:',
                                           '  Enabled: true',
@@ -586,7 +560,7 @@ describe RuboCop::CLI, :isolated_environment do
         expect(cli.run(%w(--format simple dir1 dir2))).to eq(1)
         expect($stdout.string)
           .to eq(['== dir1/app/models/example1.rb ==',
-                  'C:  2:  1: Prefer self[:attr] over read_attribute' \
+                  'C:  1:  1: Prefer self[:attr] over read_attribute' \
                   '(:attr).',
                   '',
                   '2 files inspected, 1 offense detected',
@@ -594,8 +568,7 @@ describe RuboCop::CLI, :isolated_environment do
       end
 
       it 'with configuration option false but -R given runs rails cops' do
-        create_file('app/models/example1.rb', ['# encoding: utf-8',
-                                               'read_attribute(:test)'])
+        create_file('app/models/example1.rb', 'read_attribute(:test)')
         create_file('.rubocop.yml', ['Rails:',
                                      '  Enabled: false'])
         expect(cli.run(['--format', 'simple', '-R', 'app/models/example1.rb']))
@@ -616,8 +589,7 @@ describe RuboCop::CLI, :isolated_environment do
 
     describe 'including/excluding' do
       it 'honors Exclude settings in .rubocop_todo.yml one level up' do
-        create_file('lib/example.rb', ['# encoding: utf-8',
-                                       'puts %x(ls)'])
+        create_file('lib/example.rb', 'puts %x(ls)')
         create_file('.rubocop.yml', 'inherit_from: .rubocop_todo.yml')
         create_file('.rubocop_todo.yml', ['Style/CommandLiteral:',
                                           '  Exclude:',
@@ -627,9 +599,7 @@ describe RuboCop::CLI, :isolated_environment do
       end
 
       it 'includes some directories by default' do
-        source = ['# encoding: utf-8',
-                  'read_attribute(:test)',
-                  "default_scope order: 'position'"]
+        source = ['read_attribute(:test)', "default_scope order: 'position'"]
         # Several rails cops include app/models by default.
         create_file('dir1/app/models/example1.rb', source)
         create_file('dir1/app/models/example2.rb', source)
@@ -652,7 +622,7 @@ describe RuboCop::CLI, :isolated_environment do
         expect(cli.run(%w(--format simple dir1 dir2))).to eq(1)
         expect($stdout.string)
           .to eq(['== dir1/app/models/example1.rb ==',
-                  'C:  2:  1: Prefer self[:attr] over read_attribute' \
+                  'C:  1:  1: Prefer self[:attr] over read_attribute' \
                   '(:attr).',
                   '',
                   '4 files inspected, 1 offense detected',
@@ -663,15 +633,10 @@ describe RuboCop::CLI, :isolated_environment do
 
   describe 'cops can exclude files based on config' do
     it 'ignores excluded files' do
-      create_file('example.rb', ['# encoding: utf-8',
-                                 'x = 0'])
-      create_file('regexp.rb', ['# encoding: utf-8',
-                                'x = 0'])
-      create_file('exclude_glob.rb', ['#!/usr/bin/env ruby',
-                                      '# encoding: utf-8',
-                                      'x = 0'])
-      create_file('dir/thing.rb', ['# encoding: utf-8',
-                                   'x = 0'])
+      create_file('example.rb', 'x = 0')
+      create_file('regexp.rb', 'x = 0')
+      create_file('exclude_glob.rb', ['#!/usr/bin/env ruby', 'x = 0'])
+      create_file('dir/thing.rb', 'x = 0')
       create_file('.rubocop.yml', ['Lint/UselessAssignment:',
                                    '  Exclude:',
                                    '    - example.rb',
@@ -690,8 +655,7 @@ describe RuboCop::CLI, :isolated_environment do
       it 'accepts rails style indentation' do
         create_file('.rubocop.yml', ['Style/IndentationConsistency:',
                                      '  EnforcedStyle: rails'])
-        create_file('example.rb', ['# encoding: utf-8',
-                                   '',
+        create_file('example.rb', ['',
                                    '# A feline creature',
                                    'class Cat',
                                    '  def meow',
@@ -722,8 +686,7 @@ describe RuboCop::CLI, :isolated_environment do
         it "registers offense for normal indentation in #{parent}" do
           create_file('.rubocop.yml', ['Style/IndentationConsistency:',
                                        '  EnforcedStyle: rails'])
-          create_file('example.rb', ['# encoding: utf-8',
-                                     '',
+          create_file('example.rb', ['',
                                      '# A feline creature',
                                      "#{parent} Cat",
                                      '  def meow',
@@ -751,8 +714,8 @@ describe RuboCop::CLI, :isolated_environment do
           expect(result).to eq(1)
           expect($stdout.string)
             .to eq(['== example.rb ==',
-                    'C: 11:  3: Use 2 (not 0) spaces for rails indentation.',
-                    'C: 17:  3: Use 2 (not 0) spaces for rails indentation.',
+                    'C: 10:  3: Use 2 (not 0) spaces for rails indentation.',
+                    'C: 16:  3: Use 2 (not 0) spaces for rails indentation.',
                     '',
                     '1 file inspected, 2 offenses detected',
                     ''].join("\n"))
@@ -806,9 +769,7 @@ describe RuboCop::CLI, :isolated_environment do
     end
 
     it 'allows the default configuration file as the -c argument' do
-      create_file('example.rb', ['# encoding: utf-8',
-                                 'x = 0',
-                                 'puts x'])
+      create_file('example.rb', ['x = 0', 'puts x'])
       create_file('.rubocop.yml', [])
 
       expect(cli.run(%w(--format simple -c .rubocop.yml))).to eq(0)
@@ -818,9 +779,7 @@ describe RuboCop::CLI, :isolated_environment do
     end
 
     it 'displays cop names if DisplayCopNames is true' do
-      source = ['# encoding: utf-8',
-                'x = 0 ',
-                'puts x']
+      source = ['x = 0 ', 'puts x']
       create_file('example1.rb', source)
 
       # DisplayCopNames: false inherited from config/default.yml
@@ -833,9 +792,9 @@ describe RuboCop::CLI, :isolated_environment do
       expect(cli.run(%w(--format simple))).to eq(1)
       expect($stdout.string)
         .to eq(['== example1.rb ==',
-                'C:  2:  6: Trailing whitespace detected.',
+                'C:  1:  6: Trailing whitespace detected.',
                 '== dir/example2.rb ==',
-                'C:  2:  6: Style/TrailingWhitespace: Trailing whitespace' \
+                'C:  1:  6: Style/TrailingWhitespace: Trailing whitespace' \
                 ' detected.',
                 '',
                 '2 files inspected, 2 offenses detected',
@@ -843,9 +802,7 @@ describe RuboCop::CLI, :isolated_environment do
     end
 
     it 'displays style guide URLs if DisplayStyleGuide is true' do
-      source = ['# encoding: utf-8',
-                'x = 0 ',
-                'puts x']
+      source = ['x = 0 ', 'puts x']
       create_file('example1.rb', source)
 
       # DisplayCopNames: false inherited from config/default.yml
@@ -860,9 +817,9 @@ describe RuboCop::CLI, :isolated_environment do
       expect(cli.run(%w(--format simple))).to eq(1)
       expect($stdout.string)
         .to eq(['== example1.rb ==',
-                'C:  2:  6: Trailing whitespace detected.',
+                'C:  1:  6: Trailing whitespace detected.',
                 '== dir/example2.rb ==',
-                'C:  2:  6: Trailing whitespace' \
+                'C:  1:  6: Trailing whitespace' \
                 " detected. (#{url})",
                 '',
                 '2 files inspected, 2 offenses detected',
@@ -870,9 +827,7 @@ describe RuboCop::CLI, :isolated_environment do
     end
 
     it 'uses the DefaultFormatter if another formatter is not specified' do
-      source = ['# encoding: utf-8',
-                'x = 0 ',
-                'puts x']
+      source = ['x = 0 ', 'puts x']
       create_file('example1.rb', source)
       create_file('.rubocop.yml', ['AllCops:',
                                    '  DefaultFormatter: offenses'])
@@ -906,16 +861,9 @@ describe RuboCop::CLI, :isolated_environment do
     end
 
     it 'ignores excluded files' do
-      create_file('example.rb', ['# encoding: utf-8',
-                                 'x = 0',
-                                 'puts x'])
-      create_file('regexp.rb', ['# encoding: utf-8',
-                                'x = 0',
-                                'puts x'])
-      create_file('exclude_glob.rb', ['#!/usr/bin/env ruby',
-                                      '# encoding: utf-8',
-                                      'x = 0',
-                                      'puts x'])
+      create_file('example.rb', ['x = 0', 'puts x'])
+      create_file('regexp.rb', ['x = 0', 'puts x'])
+      create_file('exclude_glob.rb', ['#!/usr/bin/env ruby', 'x = 0', 'puts x'])
       create_file('.rubocop.yml', ['AllCops:',
                                    '  Exclude:',
                                    '    - example.rb',
@@ -928,16 +876,14 @@ describe RuboCop::CLI, :isolated_environment do
     end
 
     it 'only reads configuration in explicitly included hidden directories' do
-      create_file('.hidden/example.rb', ['# encoding: utf-8',
-                                         'x=0'])
+      create_file('.hidden/example.rb', 'x=0')
       # This file contains configuration for an unknown cop. This would cause a
       # warning to be printed on stderr if the file was read. But it's in a
       # hidden directory, so it's not read.
       create_file('.hidden/.rubocop.yml', ['SymbolName:',
                                            '  Enabled: false'])
 
-      create_file('.other/example.rb', ['# encoding: utf-8',
-                                        'x=0'])
+      create_file('.other/example.rb', 'x=0')
       # The .other directory is explicitly included, so the configuration file
       # is read, and modifies the behavior.
       create_file('.other/.rubocop.yml', ['Style/SpaceAroundOperators:',
@@ -949,15 +895,14 @@ describe RuboCop::CLI, :isolated_environment do
       expect($stderr.string).to eq('')
       expect($stdout.string)
         .to eq(['== .other/example.rb ==',
-                'W:  2:  1: Useless assignment to variable - x.',
+                'W:  1:  1: Useless assignment to variable - x.',
                 '',
                 '1 file inspected, 1 offense detected',
                 ''].join("\n"))
     end
 
     it 'does not consider Include parameters in subdirectories' do
-      create_file('dir/example.ruby', ['# encoding: utf-8',
-                                       'x=0'])
+      create_file('dir/example.ruby', 'x=0')
       create_file('dir/.rubocop.yml', ['AllCops:',
                                        '  Include:',
                                        '    - "*.ruby"'])
@@ -971,8 +916,7 @@ describe RuboCop::CLI, :isolated_environment do
 
     it 'matches included/excluded files correctly when . argument is given' do
       create_file('example.rb', 'x = 0')
-      create_file('special.dsl', ['# encoding: utf-8',
-                                  'setup { "stuff" }'])
+      create_file('special.dsl', 'setup { "stuff" }')
       create_file('.rubocop.yml', ['AllCops:',
                                    '  Include:',
                                    '    - "*.dsl"',
@@ -981,7 +925,7 @@ describe RuboCop::CLI, :isolated_environment do
       expect(cli.run(%w(--format simple .))).to eq(1)
       expect($stdout.string)
         .to eq(['== special.dsl ==',
-                "C:  2:  9: Prefer single-quoted strings when you don't " \
+                "C:  1:  9: Prefer single-quoted strings when you don't " \
                 'need string interpolation or special symbols.',
                 '',
                 '1 file inspected, 1 offense detected',
@@ -992,8 +936,7 @@ describe RuboCop::CLI, :isolated_environment do
     # File.stub(:open).and_call_original causes SystemStackError.
     it 'does not read files in excluded list', broken: :rbx do
       %w(rb.rb non-rb.ext without-ext).each do |filename|
-        create_file("example/ignored/#{filename}", ['# encoding: utf-8',
-                                                    '#' * 90])
+        create_file("example/ignored/#{filename}", '#' * 90)
       end
 
       create_file('example/.rubocop.yml', ['AllCops:',
@@ -1069,10 +1012,7 @@ describe RuboCop::CLI, :isolated_environment do
     end
 
     it 'can be configured to merge a parameter that is a hash' do
-      create_file('example1.rb',
-                  ['# encoding: utf-8',
-                   'puts %w(a b c)',
-                   'puts %q|hi|'])
+      create_file('example1.rb', ['puts %w(a b c)', 'puts %q|hi|'])
       # We want to change the preferred delimiters for word arrays. The other
       # settings from default.yml are unchanged.
       create_file('rubocop.yml',
@@ -1083,9 +1023,9 @@ describe RuboCop::CLI, :isolated_environment do
       cli.run(['--format', 'simple', '-c', 'rubocop.yml', 'example1.rb'])
       expect($stdout.string)
         .to eq(['== example1.rb ==',
-                'C:  2:  6: %w-literals should be delimited by [ and ].',
-                'C:  3:  6: %q-literals should be delimited by ( and ).',
-                'C:  3:  6: Use %q only for strings that contain both single ' \
+                'C:  1:  6: %w-literals should be delimited by [ and ].',
+                'C:  2:  6: %q-literals should be delimited by ( and ).',
+                'C:  2:  6: Use %q only for strings that contain both single ' \
                 'quotes and double quotes.',
                 '',
                 '1 file inspected, 3 offenses detected',
@@ -1095,8 +1035,7 @@ describe RuboCop::CLI, :isolated_environment do
     it 'can be configured to override a parameter that is a hash in a ' \
        'special case' do
       create_file('example1.rb',
-                  ['# encoding: utf-8',
-                   'arr.select { |e| e > 0 }.collect { |e| e * 2 }',
+                  ['arr.select { |e| e > 0 }.collect { |e| e * 2 }',
                    'a2.find_all { |e| e > 0 }'])
       # We prefer find_all over select. This setting overrides the default
       # select over find_all. Other preferred methods appearing in the default
@@ -1114,8 +1053,8 @@ describe RuboCop::CLI, :isolated_environment do
                'example1.rb'])
       expect($stdout.string)
         .to eq(['== example1.rb ==',
-                'C:  2:  5: Prefer find_all over select.',
-                'C:  2: 26: Prefer map over collect.',
+                'C:  1:  5: Prefer find_all over select.',
+                'C:  1: 26: Prefer map over collect.',
                 '',
                 '1 file inspected, 2 offenses detected',
                 ''].join("\n"))
@@ -1161,8 +1100,7 @@ describe RuboCop::CLI, :isolated_environment do
     end
 
     it 'can use an alternative max line length from a config file' do
-      create_file('example_src/example1.rb', ['# encoding: utf-8',
-                                              '#' * 90])
+      create_file('example_src/example1.rb', '#' * 90)
       create_file('example_src/.rubocop.yml', ['Metrics/LineLength:',
                                                '  Enabled: true',
                                                '  Max: 100'])
@@ -1174,23 +1112,21 @@ describe RuboCop::CLI, :isolated_environment do
 
     it 'can have different config files in different directories' do
       %w(src lib).each do |dir|
-        create_file("example/#{dir}/example1.rb", ['# encoding: utf-8',
-                                                   '#' * 90])
+        create_file("example/#{dir}/example1.rb", '#' * 90)
       end
       create_file('example/src/.rubocop.yml', ['Metrics/LineLength:',
                                                '  Enabled: true',
                                                '  Max: 100'])
       expect(cli.run(%w(--format simple example))).to eq(1)
       expect($stdout.string).to eq(['== example/lib/example1.rb ==',
-                                    'C:  2: 81: Line is too long. [90/80]',
+                                    'C:  1: 81: Line is too long. [90/80]',
                                     '',
                                     '2 files inspected, 1 offense detected',
                                     ''].join("\n"))
     end
 
     it 'prefers a config file in ancestor directory to another in home' do
-      create_file('example_src/example1.rb', ['# encoding: utf-8',
-                                              '#' * 90])
+      create_file('example_src/example1.rb', '#' * 90)
       create_file('example_src/.rubocop.yml', ['Metrics/LineLength:',
                                                '  Enabled: true',
                                                '  Max: 100'])
@@ -1205,13 +1141,11 @@ describe RuboCop::CLI, :isolated_environment do
 
     it 'can exclude directories relative to .rubocop.yml' do
       %w(src etc/test etc/spec tmp/test tmp/spec).each do |dir|
-        create_file("example/#{dir}/example1.rb", ['# encoding: utf-8',
-                                                   '#' * 90])
+        create_file("example/#{dir}/example1.rb", '#' * 90)
       end
 
       # Hidden subdirectories should also be excluded.
-      create_file('example/etc/.dot/example1.rb', ['# encoding: utf-8',
-                                                   '#' * 90])
+      create_file('example/etc/.dot/example1.rb', '#' * 90)
 
       create_file('example/.rubocop.yml', ['AllCops:',
                                            '  Exclude:',
@@ -1222,7 +1156,7 @@ describe RuboCop::CLI, :isolated_environment do
       expect(cli.run(%w(--format simple example))).to eq(1)
       expect($stderr.string).to eq('')
       expect($stdout.string).to eq(['== example/tmp/test/example1.rb ==',
-                                    'C:  2: 81: Line is too long. [90/80]',
+                                    'C:  1: 81: Line is too long. [90/80]',
                                     '',
                                     '1 file inspected, 1 offense detected',
                                     ''].join("\n"))
@@ -1235,8 +1169,7 @@ describe RuboCop::CLI, :isolated_environment do
                    '    - lib/parser/lexer.rb'])
 
       create_file('vendor/bundle/ruby/1.9.1/gems/parser-2.0.0/lib/ex.rb',
-                  ['# encoding: utf-8',
-                   '#' * 90])
+                  '#' * 90)
 
       create_file('.rubocop.yml',
                   ['AllCops:',
@@ -1250,9 +1183,7 @@ describe RuboCop::CLI, :isolated_environment do
     end
 
     it 'excludes the vendor directory by default' do
-      create_file('vendor/ex.rb',
-                  ['# encoding: utf-8',
-                   '#' * 90])
+      create_file('vendor/ex.rb', '#' * 90)
 
       cli.run(%w(--format simple))
       expect($stdout.string)
@@ -1270,8 +1201,7 @@ describe RuboCop::CLI, :isolated_environment do
                   ['inherit_from: non_existent.yml'])
 
       create_file('vendor/bundle/ruby/1.9.1/gems/parser-2.0.0/lib/ex.rb',
-                  ['# encoding: utf-8',
-                   '#' * 90])
+                  '#' * 90)
 
       create_file('.rubocop.yml',
                   ['AllCops:',
@@ -1295,8 +1225,7 @@ describe RuboCop::CLI, :isolated_environment do
                    '    - lib/parser/lexer.rb'])
 
       create_file('vendor/bundle/ruby/1.9.1/gems/parser-2.0.0/lib/ex.rb',
-                  ['# encoding: utf-8',
-                   '#' * 90])
+                  '#' * 90)
 
       create_file('.rubocop.yml',
                   ['inherit_from: config/default.yml'])
@@ -1313,8 +1242,7 @@ describe RuboCop::CLI, :isolated_environment do
     end
 
     it 'prints a warning for an unrecognized cop name in .rubocop.yml' do
-      create_file('example/example1.rb', ['# encoding: utf-8',
-                                          '#' * 90])
+      create_file('example/example1.rb', '#' * 90)
 
       create_file('example/.rubocop.yml', ['Style/LyneLenth:',
                                            '  Enabled: true',
@@ -1328,8 +1256,7 @@ describe RuboCop::CLI, :isolated_environment do
     end
 
     it 'prints a warning for an unrecognized configuration parameter' do
-      create_file('example/example1.rb', ['# encoding: utf-8',
-                                          '#' * 90])
+      create_file('example/example1.rb', '#' * 90)
 
       create_file('example/.rubocop.yml', ['Metrics/LineLength:',
                                            '  Enabled: true',
@@ -1343,8 +1270,7 @@ describe RuboCop::CLI, :isolated_environment do
     end
 
     it 'prints an error message for an unrecognized EnforcedStyle' do
-      create_file('example/example1.rb', ['# encoding: utf-8',
-                                          'puts "hello"'])
+      create_file('example/example1.rb', 'puts "hello"')
       create_file('example/.rubocop.yml', ['Style/BracesAroundHashParameters:',
                                            '  EnforcedStyle: context'])
 
@@ -1359,8 +1285,7 @@ describe RuboCop::CLI, :isolated_environment do
 
     it 'works when a configuration file passed by -c specifies Exclude ' \
        'with regexp' do
-      create_file('example/example1.rb', ['# encoding: utf-8',
-                                          '#' * 90])
+      create_file('example/example1.rb', '#' * 90)
 
       create_file('rubocop.yml', ['AllCops:',
                                   '  Exclude:',
@@ -1374,8 +1299,7 @@ describe RuboCop::CLI, :isolated_environment do
 
     it 'works when a configuration file passed by -c specifies Exclude ' \
        'with strings' do
-      create_file('example/example1.rb', ['# encoding: utf-8',
-                                          '#' * 90])
+      create_file('example/example1.rb', '#' * 90)
 
       create_file('rubocop.yml', ['AllCops:',
                                   '  Exclude:',
@@ -1388,8 +1312,7 @@ describe RuboCop::CLI, :isolated_environment do
     end
 
     it 'works when a configuration file specifies a Severity' do
-      create_file('example/example1.rb', ['# encoding: utf-8',
-                                          '#' * 90])
+      create_file('example/example1.rb', '#' * 90)
 
       create_file('rubocop.yml', ['Metrics/LineLength:',
                                   '  Severity: error'])
@@ -1397,7 +1320,7 @@ describe RuboCop::CLI, :isolated_environment do
       cli.run(%w(--format simple -c rubocop.yml))
       expect($stdout.string)
         .to eq(['== example/example1.rb ==',
-                'E:  2: 81: Line is too long. [90/80]',
+                'E:  1: 81: Line is too long. [90/80]',
                 '',
                 '1 file inspected, 1 offense detected',
                 ''].join("\n"))
@@ -1405,8 +1328,7 @@ describe RuboCop::CLI, :isolated_environment do
     end
 
     it 'fails when a configuration file specifies an invalid Severity' do
-      create_file('example/example1.rb', ['# encoding: utf-8',
-                                          '#' * 90])
+      create_file('example/example1.rb', '#' * 90)
 
       create_file('rubocop.yml', ['Metrics/LineLength:',
                                   '  Severity: superbad'])

--- a/spec/rubocop/comment_config_spec.rb
+++ b/spec/rubocop/comment_config_spec.rb
@@ -8,57 +8,55 @@ describe RuboCop::CommentConfig do
   describe '#cop_enabled_at_line?' do
     let(:source) do
       [
-        '# encoding: utf-8',
-        '',
         '# rubocop:disable Metrics/MethodLength with a comment why',
         'def some_method',
-        "  puts 'foo'",                                      # 5
+        "  puts 'foo'",                                      # 3
         'end',
         '# rubocop:enable Metrics/MethodLength',
         '',
         '# rubocop:disable all',
-        'some_method',                                       # 10
+        'some_method',                                       # 8
         '# rubocop:enable all',
         '',
         "code = 'This is evil.'",
         'eval(code) # rubocop:disable Lint/Eval',
-        "puts 'This is not evil.'",                          # 15
+        "puts 'This is not evil.'",                          # 12
         '',
         'def some_method',
         "  puts 'Disabling indented single line' # rubocop:disable " \
         'Metrics/LineLength',
         'end',
-        '',                                                  # 20
+        '',                                                  # 18
         'string = <<END',
         'This is a string not a real comment # rubocop:disable Style/Loop',
         'END',
         '',
-        'foo # rubocop:disable Style/MethodCallParentheses', # 25
+        'foo # rubocop:disable Style/MethodCallParentheses', # 23
         '',
         '# rubocop:enable Lint/Void',
         '',
         '# rubocop:disable Style/For, Style/Not,Style/Tab',
-        'foo',                                               # 30
+        'foo',                                               # 28
         '',
         'class One',
         '  # rubocop:disable Style/ClassVars',
         '  @@class_var = 1',
-        'end',                                               # 35
+        'end',                                               # 33
         '',
         'class Two',
         '  # rubocop:disable Style/ClassVars',
         '  @@class_var = 2',
-        'end',                                               # 40
+        'end',                                               # 38
         '# rubocop:enable Style/Not,Style/Tab',
         '# rubocop:disable Style/Send, Lint/RandOne some comment why',
         '# rubocop:disable Lint/BlockAlignment some comment why',
         '# rubocop:enable Style/Send, Lint/BlockAlignment but why?',
-        '# rubocop:enable Lint/RandOne foo bar!',            # 45
+        '# rubocop:enable Lint/RandOne foo bar!',            # 43
         '# rubocop:disable FlatMap',
         '[1, 2, 3, 4].map { |e| [e, e] }.flatten(1)',
         '# rubocop:enable FlatMap',
         '# rubocop:disable RSpec/Example',
-        '# rubocop:disable Custom2/Number9'                  # 50
+        '# rubocop:disable Custom2/Number9'                  # 48
       ]
     end
 
@@ -72,7 +70,7 @@ describe RuboCop::CommentConfig do
     it 'supports disabling multiple lines with a pair of directive' do
       method_length_disabled_lines =
         disabled_lines_of_cop('Metrics/MethodLength')
-      expected_part = (3..6).to_a
+      expected_part = (1..4).to_a
       expect(method_length_disabled_lines & expected_part).to eq(expected_part)
     end
 
@@ -81,15 +79,15 @@ describe RuboCop::CommentConfig do
       tab_disabled_lines = disabled_lines_of_cop('Style/Tab')
 
       expect(not_disabled_lines).to eq(tab_disabled_lines)
-      expected_part = (29..41).to_a
+      expected_part = (27..39).to_a
       expect(not_disabled_lines & expected_part).to eq(expected_part)
     end
 
     it 'supports enabling/disabling multiple cops along with a comment' do
       {
-        'Style/Send' => 42..44,
-        'Lint/RandOne' => 42..45,
-        'Lint/BlockAlignment' => 43..44
+        'Style/Send' => 40..42,
+        'Lint/RandOne' => 40..43,
+        'Lint/BlockAlignment' => 41..42
       }.each do |cop_name, expected|
         actual = disabled_lines_of_cop(cop_name)
         expect(actual & expected.to_a).to eq(expected.to_a)
@@ -99,44 +97,44 @@ describe RuboCop::CommentConfig do
     it 'supports enabling/disabling cops without a prefix' do
       flat_map_disabled_lines = disabled_lines_of_cop('Performance/FlatMap')
 
-      expected = (46..48).to_a
+      expected = (44..46).to_a
 
       expect(flat_map_disabled_lines & expected).to eq(expected)
     end
 
     it 'supports disabling all lines after a directive' do
       for_disabled_lines = disabled_lines_of_cop('Style/For')
-      expected_part = (29..source.size).to_a
+      expected_part = (27..source.size).to_a
       expect(for_disabled_lines & expected_part).to eq(expected_part)
     end
 
     it 'just ignores unpaired enabling directives' do
       void_disabled_lines = disabled_lines_of_cop('Lint/Void')
-      expected_part = (27..source.size).to_a
+      expected_part = (25..source.size).to_a
       expect(void_disabled_lines & expected_part).to be_empty
     end
 
     it 'supports disabling single line with a directive at end of line' do
       eval_disabled_lines = disabled_lines_of_cop('Lint/Eval')
-      expect(eval_disabled_lines).to include(14)
-      expect(eval_disabled_lines).not_to include(15)
+      expect(eval_disabled_lines).to include(12)
+      expect(eval_disabled_lines).not_to include(13)
     end
 
     it 'handles indented single line' do
       line_length_disabled_lines = disabled_lines_of_cop('Metrics/LineLength')
-      expect(line_length_disabled_lines).to include(18)
-      expect(line_length_disabled_lines).not_to include(19)
+      expect(line_length_disabled_lines).to include(16)
+      expect(line_length_disabled_lines).not_to include(18)
     end
 
     it 'does not confuse a comment directive embedded in a string literal ' \
        'with a real comment' do
       loop_disabled_lines = disabled_lines_of_cop('Loop')
-      expect(loop_disabled_lines).not_to include(22)
+      expect(loop_disabled_lines).not_to include(20)
     end
 
     it 'supports disabling all cops except Lint/UnneededDisable with ' \
        'keyword all' do
-      expected_part = (9..10).to_a
+      expected_part = (7..8).to_a
 
       cops = RuboCop::Cop::Cop.all.reject do |klass|
         klass == RuboCop::Cop::Lint::UnneededDisable
@@ -150,20 +148,20 @@ describe RuboCop::CommentConfig do
 
     it 'does not confuse a cop name including "all" with all cops' do
       alias_disabled_lines = disabled_lines_of_cop('Alias')
-      expect(alias_disabled_lines).not_to include(25)
+      expect(alias_disabled_lines).not_to include(23)
     end
 
     it 'can handle double disable of one cop' do
       expect(disabled_lines_of_cop('Style/ClassVars'))
-        .to eq([9, 10, 11] + (33..source.size).to_a)
+        .to eq([7, 8, 9] + (31..source.size).to_a)
     end
 
     it 'supports disabling cops with multiple uppercase letters' do
-      expect(disabled_lines_of_cop('RSpec/Example')).to include(49)
+      expect(disabled_lines_of_cop('RSpec/Example')).to include(47)
     end
 
     it 'supports disabling cops with numbers in their name' do
-      expect(disabled_lines_of_cop('Custom2/Number9')).to include(50)
+      expect(disabled_lines_of_cop('Custom2/Number9')).to include(48)
     end
   end
 end

--- a/spec/rubocop/cop/team_spec.rb
+++ b/spec/rubocop/cop/team_spec.rb
@@ -60,11 +60,7 @@ describe RuboCop::Cop::Team do
 
     context 'when Parser reports non-fatal warning for the file' do
       before do
-        create_file(file_path, [
-                      '# encoding: utf-8',
-                      '#' * 90,
-                      'puts *test'
-                    ])
+        create_file(file_path, ['#' * 90, 'puts *test'])
       end
 
       let(:cop_names) { offenses.map(&:cop_name) }
@@ -82,21 +78,14 @@ describe RuboCop::Cop::Team do
       let(:options) { { auto_correct: true } }
 
       before do
-        create_file(file_path, [
-                      '# encoding: utf-8',
-                      'puts "string"'
-                    ])
+        create_file(file_path, 'puts "string"')
       end
 
       it 'does autocorrection' do
         source = RuboCop::ProcessedSource.from_file(file_path, ruby_version)
         team.inspect_file(source)
         corrected_source = File.read(file_path)
-        expect(corrected_source).to eq([
-          '# encoding: utf-8',
-          "puts 'string'",
-          ''
-        ].join("\n"))
+        expect(corrected_source).to eq("puts 'string'\n")
       end
 
       it 'still returns offenses' do

--- a/spec/rubocop/formatter/base_formatter_spec.rb
+++ b/spec/rubocop/formatter/base_formatter_spec.rb
@@ -13,18 +13,9 @@ module RuboCop
         let(:output) { $stdout.string }
 
         before do
-          create_file('1_offense.rb', [
-                        '# encoding: utf-8',
-                        '#' * 90
-                      ])
+          create_file('1_offense.rb', '#' * 90)
 
-          create_file('4_offenses.rb', [
-                        '# encoding: utf-8',
-                        'puts x ',
-                        'test;',
-                        'top;',
-                        '#' * 90
-                      ])
+          create_file('4_offenses.rb', ['puts x ', 'test;', 'top;', '#' * 90])
 
           create_file('no_offense.rb', '# encoding: utf-8')
 

--- a/spec/rubocop/options_spec.rb
+++ b/spec/rubocop/options_spec.rb
@@ -182,8 +182,7 @@ Usage: rubocop [options] [file1, file2, ...]
       before do
         create_file('example.rb', '# encoding: utf-8')
 
-        create_file(required_file_path, ['# encoding: utf-8',
-                                         "puts 'Hello from required file!'"])
+        create_file(required_file_path, "puts 'Hello from required file!'")
       end
 
       it 'requires the passed path' do


### PR DESCRIPTION
This is a follow-up to #3550, and the end of my "encoding review" :)

Not a very easy or fun to review patch. I just removed all the unnecessary encoding lines in test code and updated the tests to catch up with the changes. I skipped some cases where the comment was necessary or made sense to me. For example, when testing the magic comment feature itself.

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Used the same coding conventions as the rest of the project.
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [ ] Squashed related commits together.
* [ ] Added tests.
* [ ] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] All tests are passing.
* [x] The new code doesn't generate RuboCop offenses.
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.

[1]: http://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html

