### PR TITLE
Make Style/RedundantSelf accept self.()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 
 ### Bug fixes
 
+* [#3553](https://github.com/bbatsov/rubocop/pull/3553): Make `Style/RedundantSelf` cop to not register an offence for `self.()`. ([@iGEL][])
 * [#3474](https://github.com/bbatsov/rubocop/issues/3474): Make the `Rails/TimeZone` only analyze functions which have "Time" in the receiver. ([@b-t-g][])
 * [#3607](https://github.com/bbatsov/rubocop/pull/3607): Fix `Style/RedundantReturn` cop for empty if body. ([@pocke][])
 * [#3291](https://github.com/bbatsov/rubocop/issues/3291): Improve detection of `raw` and `html_safe` methods in `Rails/OutputSafety`. ([@lumeet][])
@@ -2460,3 +2461,4 @@
 [@swcraig]: https://github.com/swcraig
 [@jessieay]: https://github.com/jessieay
 [@tiagocasanovapt]: https://github.com/tiagocasanovapt
+[@iGEL]: https://github.com/iGEL

--- a/lib/rubocop/cop/style/redundant_self.rb
+++ b/lib/rubocop/cop/style/redundant_self.rb
@@ -123,7 +123,8 @@ module RuboCop
           !(operator?(method_name) ||
             keyword?(method_name) ||
             constant_name?(method_name) ||
-            node.asgn_method_call?)
+            node.asgn_method_call? ||
+            braces_style_call?(node))
         end
 
         def on_argument(node)
@@ -141,6 +142,10 @@ module RuboCop
 
         def constant_name?(method_name)
           method_name.match(/^[A-Z]/)
+        end
+
+        def braces_style_call?(node)
+          node.loc.selector.nil?
         end
 
         def allow_self(node)

--- a/spec/rubocop/cop/style/redundant_self_spec.rb
+++ b/spec/rubocop/cop/style/redundant_self_spec.rb
@@ -187,6 +187,18 @@ describe RuboCop::Cop::Style::RedundantSelf do
     expect(cop.offenses).to be_empty
   end
 
+  it 'accepts a self receiver of .()' do
+    src = 'self.()'
+    inspect_source(cop, src)
+    expect(cop.offenses).to be_empty
+  end
+
+  it 'reports an offence a self receiver of .call' do
+    src = 'self.call'
+    inspect_source(cop, src)
+    expect(cop.offenses.size).to eq(1)
+  end
+
   it 'auto-corrects by removing redundant self' do
     new_source = autocorrect_source(cop, 'self.x')
     expect(new_source).to eq('x')


### PR DESCRIPTION
To send `.()` (an alternative to `.call`) to `self`, you have to explicitly call `self`. However `Style/RedundantSelf` cop was registering an offence for `self.()`. Probably is also allows
`self.call`, but I hope we can live with that.