### PR TITLE
[Fix #3499] Make `Lint/UnusedBlockArgument` aware of `#define_method`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
 * [#3436](https://github.com/bbatsov/rubocop/issues/3436): Make `Rails/SaveBang` cop not register an offense when return value of a non-bang method is returned by the parent method. ([@coorasse][])
 * [#3540](https://github.com/bbatsov/rubocop/issues/3540): Fix `Style/GuardClause` to register offense for instance and singleton methods. ([@tejasbubane][])
 * [#3311](https://github.com/bbatsov/rubocop/issues/3311): Detect incompatibilities with the external encoding to prevent bad autocorrections in `Style/StringLiterals`. ([@deivid-rodriguez][])
+* [#3499](https://github.com/bbatsov/rubocop/issues/3499): Ensure `Lint/UnusedBlockArgument` doesn't make recommendations that would change arity for methods defined using `#define_method`. ([@drenmi][])
 
 ### Changes
 

--- a/lib/rubocop/cop/lint/unused_block_argument.rb
+++ b/lib/rubocop/cop/lint/unused_block_argument.rb
@@ -7,43 +7,76 @@ module RuboCop
       #
       # @example
       #
-      #   do_something do |used, unused, _unused_but_allowed|
+      #   #good
+      #
+      #   do_something do |used, unused|
       #     puts used
+      #   end
+      #
+      #   do_something do
+      #     puts :foo
+      #   end
+      #
+      #   define_method(:foo) do |_bar|
+      #     puts :baz
+      #   end
+      #
+      #   # bad
+      #
+      #   do_something do |used, _unused|
+      #     puts used
+      #   end
+      #
+      #   do_something do |bar|
+      #     puts :foo
+      #   end
+      #
+      #   define_method(:foo) do |bar|
+      #     puts :baz
       #   end
       class UnusedBlockArgument < Cop
         include UnusedArgument
 
-        def check_argument(variable)
-          return unless variable.block_argument?
-          return if variable.keyword_argument? &&
-                    cop_config && cop_config['AllowUnusedKeywordArguments']
+        private
 
-          if cop_config['IgnoreEmptyBlocks']
-            _send, _args, body = *variable.scope.node
-            return if body.nil?
-          end
+        def check_argument(variable)
+          return if allowed_block?(variable) ||
+                    allowed_keyword_argument?(variable)
 
           super
         end
 
+        def allowed_block?(variable)
+          !variable.block_argument? ||
+            (ignore_empty_blocks? && empty_block?(variable))
+        end
+
+        def allowed_keyword_argument?(variable)
+          variable.keyword_argument? &&
+            allow_unused_keyword_arguments?
+        end
+
         def message(variable)
-          message = String.new("Unused #{variable_type(variable)} - " \
-                               "`#{variable.name}`.")
+          message = "Unused #{variable_type(variable)} - `#{variable.name}`."
 
-          return message if variable.explicit_block_local_variable?
+          if variable.explicit_block_local_variable?
+            message
+          else
+            augment_message(message, variable)
+          end
+        end
 
-          message << ' '
-
+        def augment_message(message, variable)
           scope = variable.scope
           all_arguments = scope.variables.each_value.select(&:block_argument?)
 
-          message << if scope.node.lambda?
-                       message_for_lambda(variable, all_arguments)
-                     else
-                       message_for_normal_block(variable, all_arguments)
-                     end
+          augmentation = if scope.node.lambda?
+                           message_for_lambda(variable, all_arguments)
+                         else
+                           message_for_normal_block(variable, all_arguments)
+                         end
 
-          message
+          [message, augmentation].join(' ')
         end
 
         def variable_type(variable)
@@ -55,7 +88,8 @@ module RuboCop
         end
 
         def message_for_normal_block(variable, all_arguments)
-          if all_arguments.none?(&:referenced?)
+          if all_arguments.none?(&:referenced?) &&
+             !define_method_call?(variable)
             if all_arguments.count > 1
               "You can omit all the arguments if you don't care about them."
             else
@@ -67,20 +101,41 @@ module RuboCop
         end
 
         def message_for_lambda(variable, all_arguments)
-          message = String.new(message_for_underscore_prefix(variable))
+          message = message_for_underscore_prefix(variable)
 
           if all_arguments.none?(&:referenced?)
-            message << ' Also consider using a proc without arguments ' \
-                       'instead of a lambda if you want it ' \
-                        "to accept any arguments but don't care about them."
+            proc_message = 'Also consider using a proc without arguments ' \
+                           'instead of a lambda if you want it ' \
+                           "to accept any arguments but don't care about them."
           end
 
-          message
+          [message, proc_message].compact.join(' ')
         end
 
         def message_for_underscore_prefix(variable)
           "If it's necessary, use `_` or `_#{variable.name}` " \
           "as an argument name to indicate that it won't be used."
+        end
+
+        def define_method_call?(variable)
+          call, = *variable.scope.node
+          _, method, = *call
+
+          method == :define_method
+        end
+
+        def empty_block?(variable)
+          _send, _args, body = *variable.scope.node
+
+          body.nil?
+        end
+
+        def allow_unused_keyword_arguments?
+          cop_config['AllowUnusedKeywordArguments']
+        end
+
+        def ignore_empty_blocks?
+          cop_config['IgnoreEmptyBlocks']
         end
       end
     end


### PR DESCRIPTION
This cop would make recommendations that, if followed, would change the arity of methods defined using `#define_method`. This change fixes that.

It also does some "boy scout" work, by adding more examples to the documentation, factoring the cop, and replacing use of instances of `String` with string literals.

-----------------

Before submitting the PR make sure the following are checked:

* [X] Wrote [good commit messages][1].
* [X] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [X] Used the same coding conventions as the rest of the project.
* [X] Feature branch is up-to-date with `master` (if not - rebase it).
* [X] Squashed related commits together.
* [X] Added tests.
* [X] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [X] All tests are passing.
* [X] The new code doesn't generate RuboCop offenses.
* [X] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.

[1]: http://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html