### PR TITLE
[Fix #3430] Prevent exception in `Performance/RedundantMerge` when receiver is implicit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@
 * [#3540](https://github.com/bbatsov/rubocop/issues/3540): Fix `Style/GuardClause` to register offense for instance and singleton methods. ([@tejasbubane][])
 * [#3311](https://github.com/bbatsov/rubocop/issues/3311): Detect incompatibilities with the external encoding to prevent bad autocorrections in `Style/StringLiterals`. ([@deivid-rodriguez][])
 * [#3499](https://github.com/bbatsov/rubocop/issues/3499): Ensure `Lint/UnusedBlockArgument` doesn't make recommendations that would change arity for methods defined using `#define_method`. ([@drenmi][])
+* [#3430](https://github.com/bbatsov/rubocop/issues/3430): Fix exception in `Performance/RedundantMerge` when inspecting a `#merge!` with implicit receiver. ([@drenmi][])
 
 ### Changes
 

--- a/lib/rubocop/cop/performance/redundant_merge.rb
+++ b/lib/rubocop/cop/performance/redundant_merge.rb
@@ -44,6 +44,7 @@ module RuboCop
 
         def each_redundant_merge(node)
           redundant_merge(node) do |receiver, pairs|
+            next unless receiver
             next if node.value_used? &&
                     !EachWithObjectInspector.new(node, receiver).value_used?
             next if pairs.size > 1 && !receiver.pure?

--- a/spec/rubocop/cop/performance/redundant_merge_spec.rb
+++ b/spec/rubocop/cop/performance/redundant_merge_spec.rb
@@ -36,6 +36,13 @@ describe RuboCop::Cop::Performance::RedundantMerge, :config do
     end
   end
 
+  context 'when receiver is implicit' do
+    it "doesn't autocorrect" do
+      new_source = autocorrect_source(cop, 'merge!(foo: 1, bar: 2)')
+      expect(new_source).to eq('merge!(foo: 1, bar: 2)')
+    end
+  end
+
   context 'when internal to each_with_object' do
     it 'autocorrects when the receiver is the object being built' do
       source = ['foo.each_with_object({}) do |f, hash|',


### PR DESCRIPTION
This cop would blow up when inspecting code that involved sending
`#merge!` to `self` implicitly, e.g.:

```
class Foo
  def bar(baz)
    merge!(baz)
  end
end
```

This change fixes that.

-----------------

Before submitting the PR make sure the following are checked:

* [X] Wrote [good commit messages][1].
* [X] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [X] Used the same coding conventions as the rest of the project.
* [X] Feature branch is up-to-date with `master` (if not - rebase it).
* [X] Squashed related commits together.
* [X] Added tests.
* [X] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [X] All tests are passing.
* [X] The new code doesn't generate RuboCop offenses.
* [X] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.

[1]: http://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html