### PR TITLE
Add new style empty_lines_except_namespace for module and class body

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### New features
 
+* [#3560](https://github.com/bbatsov/rubocop/pull/3560): Add a configuration option `empty_lines_except_namespace` to `Style/EmptyLinesAroundClassBody` and `Style/EmptyLinesAroundModuleBody`. ([@legendetm][])
 * [#3370](https://github.com/bbatsov/rubocop/issues/3370): Add new `Rails/HttpPositionalArguments` cop to check your Rails 5 test code for existence of positional args usage. ([@logicminds][])
 * [#3510](https://github.com/bbatsov/rubocop/issues/3510): Add a configuration option, `ConvertCodeThatCanStartToReturnNil`, to `Style/SafeNavigation` to check for code that could start returning `nil` if safe navigation is used. ([@rrosenblum][])
 * Add a new `AllCops/StyleGuideBaseURL` setting that allows the use of relative paths and/or fragments within each cop's `StyleGuide` setting, to make forking of custom style guides easier. ([@scottmatthewman][])
@@ -2412,3 +2413,4 @@
 [@abrom]: https://github.com/abrom
 [@thegedge]: https://github.com/thegedge
 [@jmks]: https://github.com/jmks/
+[@legendetm]: https://github.com/legendetm

--- a/config/default.yml
+++ b/config/default.yml
@@ -435,12 +435,14 @@ Style/EmptyLinesAroundClassBody:
   EnforcedStyle: no_empty_lines
   SupportedStyles:
     - empty_lines
+    - empty_lines_except_namespace
     - no_empty_lines
 
 Style/EmptyLinesAroundModuleBody:
   EnforcedStyle: no_empty_lines
   SupportedStyles:
     - empty_lines
+    - empty_lines_except_namespace
     - no_empty_lines
 
 # Checks whether the source file has a utf-8 encoding comment or not

--- a/lib/rubocop/cop/mixin/empty_lines_around_body.rb
+++ b/lib/rubocop/cop/mixin/empty_lines_around_body.rb
@@ -6,16 +6,22 @@ module RuboCop
       # Common functionality for checking if presence/absence of empty lines
       # around some kind of body matches the configuration.
       module EmptyLinesAroundBody
+        extend NodePattern::Macros
         include ConfigurableEnforcedStyle
 
         MSG_EXTRA = 'Extra empty line detected at %s body %s.'.freeze
         MSG_MISSING = 'Empty line missing at %s body %s.'.freeze
 
-        def autocorrect(range)
+        def_node_matcher :constant_definition?, '{class module}'
+
+        def autocorrect(args)
+          offence_style, range = args
           lambda do |corrector|
-            case style
-            when :no_empty_lines then corrector.remove(range)
-            when :empty_lines    then corrector.insert_before(range, "\n")
+            case offence_style
+            when :no_empty_lines then
+              corrector.remove(range)
+            when :empty_lines then
+              corrector.insert_before(range, "\n")
             end
           end
         end
@@ -29,33 +35,53 @@ module RuboCop
           return unless body || style == :no_empty_lines
           return if node.single_line?
 
-          check_source(node.loc.expression.first_line,
-                       node.loc.expression.last_line)
+          first_line = node.source_range.first_line
+          last_line = node.source_range.last_line
+
+          case style
+          when :empty_lines_except_namespace
+            if namespace?(body, with_one_child: true)
+              check_source(:no_empty_lines, first_line, last_line)
+            else
+              check_source(:empty_lines, first_line, last_line)
+            end
+          else
+            check_source(style, first_line, last_line)
+          end
         end
 
-        def check_source(start_line, end_line)
+        def check_source(style, start_line, end_line)
           case style
           when :no_empty_lines
-            check_both(start_line, end_line, MSG_EXTRA, &:empty?)
+            check_both(style, start_line, end_line, MSG_EXTRA, &:empty?)
           when :empty_lines
-            check_both(start_line, end_line, MSG_MISSING) do |line|
+            check_both(style, start_line, end_line, MSG_MISSING) do |line|
               !line.empty?
             end
           end
         end
 
-        def check_both(start_line, end_line, msg, &block)
+        def check_both(style, start_line, end_line, msg, &block)
           kind = self.class::KIND
-          check_line(start_line, format(msg, kind, 'beginning'), &block)
-          check_line(end_line - 2, format(msg, kind, 'end'), &block)
+          check_line(style, start_line, format(msg, kind, 'beginning'), &block)
+          check_line(style, end_line - 2, format(msg, kind, 'end'), &block)
         end
 
-        def check_line(line, msg)
-          return unless yield processed_source.lines[line]
+        def check_line(style, line, msg)
+          return unless yield(processed_source.lines[line])
 
           offset = style == :empty_lines && msg.include?('end.') ? 2 : 1
           range = source_range(processed_source.buffer, line + offset, 0)
-          add_offense(range, range, msg)
+          add_offense([style, range], range, msg)
+        end
+
+        def namespace?(node, with_one_child: true)
+          if node.begin_type?
+            return false if with_one_child
+            node.children.all? { |child| constant_definition?(child) }
+          else
+            constant_definition?(node)
+          end
         end
       end
     end

--- a/spec/rubocop/cop/style/empty_lines_around_class_body_spec.rb
+++ b/spec/rubocop/cop/style/empty_lines_around_class_body_spec.rb
@@ -126,4 +126,163 @@ describe RuboCop::Cop::Style::EmptyLinesAroundClassBody, :config do
                                 'end'].join("\n"))
     end
   end
+
+  context 'when EnforcedStyle is empty_lines_except_namespace' do
+    let(:cop_config) { { 'EnforcedStyle' => 'empty_lines_except_namespace' } }
+    let(:extra_begin) { 'Extra empty line detected at class body beginning.' }
+    let(:extra_end) { 'Extra empty line detected at class body end.' }
+    let(:missing_begin) { 'Empty line missing at class body beginning.' }
+    let(:missing_end) { 'Empty line missing at class body end.' }
+
+    context 'when only child is class' do
+      it 'requires no empty lines for namespace' do
+        inspect_source(cop,
+                       ['class Parent < Base',
+                        '  class Child',
+                        '',
+                        '    do_something',
+                        '',
+                        '  end',
+                        'end'])
+        expect(cop.messages).to eq([])
+      end
+
+      it 'registers offence for namespace body starting with a blank' do
+        inspect_source(cop,
+                       ['class Parent',
+                        '',
+                        '  class Child',
+                        '',
+                        '    do_something',
+                        '',
+                        '  end',
+                        'end'])
+        expect(cop.messages).to eq([extra_begin])
+      end
+
+      it 'registers offence for namespace body ending with a blank' do
+        inspect_source(cop,
+                       ['class Parent',
+                        '  class Child',
+                        '',
+                        '    do_something',
+                        '',
+                        '  end',
+                        '',
+                        'end'])
+        expect(cop.messages).to eq([extra_end])
+      end
+
+      it 'registers offences for namespaced class body not starting '\
+          'with a blank' do
+        inspect_source(cop,
+                       ['class Parent',
+                        '  class Child',
+                        '    do_something',
+                        '',
+                        '  end',
+                        'end'])
+        expect(cop.messages).to eq([missing_begin])
+      end
+
+      it 'registers offences for namespaced class body not ending '\
+          'with a blank' do
+        inspect_source(cop,
+                       ['class Parent',
+                        '  class Child',
+                        '',
+                        '    do_something',
+                        '  end',
+                        'end'])
+        expect(cop.messages).to eq([missing_end])
+      end
+
+      it 'autocorrects beginning and end' do
+        new_source = autocorrect_source(cop,
+                                        ['class Parent < Base',
+                                         '',
+                                         '  class Child',
+                                         '    do_something',
+                                         '  end',
+                                         '',
+                                         'end'])
+        expect(new_source).to eq(['class Parent < Base',
+                                  '  class Child',
+                                  '',
+                                  '    do_something',
+                                  '',
+                                  '  end',
+                                  'end'].join("\n"))
+      end
+    end
+
+    context 'when only child is module' do
+      it 'requires no empty lines for namespace' do
+        inspect_source(cop,
+                       ['class Parent',
+                        '  module Child',
+                        '    do_something',
+                        '  end',
+                        'end'])
+        expect(cop.messages).to eq([])
+      end
+
+      it 'registers offence for namespace body starting with a blank' do
+        inspect_source(cop,
+                       ['class Parent',
+                        '',
+                        '  module Child',
+                        '    do_something',
+                        '  end',
+                        'end'])
+        expect(cop.messages).to eq([extra_begin])
+      end
+
+      it 'registers offence for namespace body ending with a blank' do
+        inspect_source(cop,
+                       ['class Parent',
+                        '  module Child',
+                        '    do_something',
+                        '  end',
+                        '',
+                        'end'])
+        expect(cop.messages).to eq([extra_end])
+      end
+    end
+
+    context 'when has multiple child classes' do
+      it 'requires empty lines for namespace' do
+        inspect_source(cop,
+                       ['class Parent',
+                        '',
+                        '  class Mom',
+                        '',
+                        '    do_something',
+                        '',
+                        '  end',
+                        '  class Dad',
+                        '',
+                        '  end',
+                        '',
+                        'end'])
+        expect(cop.messages).to eq([])
+      end
+
+      it 'registers offences for namespace body starting '\
+        'and ending without a blank' do
+        inspect_source(cop,
+                       ['class Parent',
+                        '  class Mom',
+                        '',
+                        '    do_something',
+                        '',
+                        '  end',
+                        '  class Dad',
+                        '',
+                        '  end',
+                        'end'])
+        expect(cop.messages).to eq([missing_begin, missing_end])
+      end
+    end
+  end
 end

--- a/spec/rubocop/cop/style/empty_lines_around_module_body_spec.rb
+++ b/spec/rubocop/cop/style/empty_lines_around_module_body_spec.rb
@@ -82,4 +82,163 @@ describe RuboCop::Cop::Style::EmptyLinesAroundModuleBody, :config do
       expect(corrected).to eq(source)
     end
   end
+
+  context 'when EnforcedStyle is empty_lines_except_namespace' do
+    let(:cop_config) { { 'EnforcedStyle' => 'empty_lines_except_namespace' } }
+    let(:extra_begin) { 'Extra empty line detected at module body beginning.' }
+    let(:extra_end) { 'Extra empty line detected at module body end.' }
+    let(:missing_begin) { 'Empty line missing at module body beginning.' }
+    let(:missing_end) { 'Empty line missing at module body end.' }
+
+    context 'when only child is class' do
+      it 'requires no empty lines for namespace' do
+        inspect_source(cop,
+                       ['module Parent',
+                        '  module Child',
+                        '',
+                        '    do_something',
+                        '',
+                        '  end',
+                        'end'])
+        expect(cop.messages).to eq([])
+      end
+
+      it 'registers offence for namespace body starting with a blank' do
+        inspect_source(cop,
+                       ['module Parent',
+                        '',
+                        '  module Child',
+                        '',
+                        '    do_something',
+                        '',
+                        '  end',
+                        'end'])
+        expect(cop.messages).to eq([extra_begin])
+      end
+
+      it 'registers offence for namespace body ending with a blank' do
+        inspect_source(cop,
+                       ['module Parent',
+                        '  module Child',
+                        '',
+                        '    do_something',
+                        '',
+                        '  end',
+                        '',
+                        'end'])
+        expect(cop.messages).to eq([extra_end])
+      end
+
+      it 'registers offences for namespaced module body not starting '\
+          'with a blank' do
+        inspect_source(cop,
+                       ['module Parent',
+                        '  module Child',
+                        '    do_something',
+                        '',
+                        '  end',
+                        'end'])
+        expect(cop.messages).to eq([missing_begin])
+      end
+
+      it 'registers offences for namespaced module body not ending '\
+          'with a blank' do
+        inspect_source(cop,
+                       ['module Parent',
+                        '  module Child',
+                        '',
+                        '    do_something',
+                        '  end',
+                        'end'])
+        expect(cop.messages).to eq([missing_end])
+      end
+
+      it 'autocorrects beginning and end' do
+        new_source = autocorrect_source(cop,
+                                        ['module Parent',
+                                         '',
+                                         '  module Child',
+                                         '    do_something',
+                                         '  end',
+                                         '',
+                                         'end'])
+        expect(new_source).to eq(['module Parent',
+                                  '  module Child',
+                                  '',
+                                  '    do_something',
+                                  '',
+                                  '  end',
+                                  'end'].join("\n"))
+      end
+    end
+
+    context 'when only child is class' do
+      it 'requires no empty lines for namespace' do
+        inspect_source(cop,
+                       ['module Parent',
+                        '  class SomeClass',
+                        '    do_something',
+                        '  end',
+                        'end'])
+        expect(cop.messages).to eq([])
+      end
+
+      it 'registers offence for namespace body starting with a blank' do
+        inspect_source(cop,
+                       ['module Parent',
+                        '',
+                        '  class SomeClass',
+                        '    do_something',
+                        '  end',
+                        'end'])
+        expect(cop.messages).to eq([extra_begin])
+      end
+
+      it 'registers offence for namespace body ending with a blank' do
+        inspect_source(cop,
+                       ['module Parent',
+                        '  class SomeClass',
+                        '    do_something',
+                        '  end',
+                        '',
+                        'end'])
+        expect(cop.messages).to eq([extra_end])
+      end
+    end
+
+    context 'when has multiple child modules' do
+      it 'requires empty lines for namespace' do
+        inspect_source(cop,
+                       ['module Parent',
+                        '',
+                        '  module Mom',
+                        '',
+                        '    do_something',
+                        '',
+                        '  end',
+                        '  module Dad',
+                        '',
+                        '  end',
+                        '',
+                        'end'])
+        expect(cop.messages).to eq([])
+      end
+
+      it 'registers offences for namespace body starting '\
+        'and ending without a blank' do
+        inspect_source(cop,
+                       ['module Parent',
+                        '  module Mom',
+                        '',
+                        '    do_something',
+                        '',
+                        '  end',
+                        '  module Dad',
+                        '',
+                        '  end',
+                        'end'])
+        expect(cop.messages).to eq([missing_begin, missing_end])
+      end
+    end
+  end
 end


### PR DESCRIPTION
Adds new style empty_lines_except_namespace for Style/EmptyLinesAroundClassBody and Style/EmptyLinesAroundModuleBody. It is related to #3452, but does not fix it entirely.

The new style requires empty lines around class/module body except for namespace classes/modules

```ruby
module Providers
  class ProviderA
    class Xml

      include Provides::Xml

      def to_xml
        ...
      end

    end
  end
end
```

If class/module has multiple classes/modules, then empty lines are required
```ruby
module Providers

  class ProviderA
   
  end

  class ProviderB

  end

end
```
-----------------

Before submitting the PR make sure the following are checked:

* [ ] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Used the same coding conventions as the rest of the project.
* [ ] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] All tests are passing.
* [x] The new code doesn't generate RuboCop offenses.
* [ ] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.

[1]: http://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html
