### PR TITLE
[Fix #3286] Handle `self.a, self.b = b, a` in ParallelAssignment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@
 * [#3499](https://github.com/bbatsov/rubocop/issues/3499): Ensure `Lint/UnusedBlockArgument` doesn't make recommendations that would change arity for methods defined using `#define_method`. ([@drenmi][])
 * [#3430](https://github.com/bbatsov/rubocop/issues/3430): Fix exception in `Performance/RedundantMerge` when inspecting a `#merge!` with implicit receiver. ([@drenmi][])
 * [#3411](https://github.com/bbatsov/rubocop/issues/3411): Avoid auto-correction crash for single `when` in `Performance/CaseWhenSplat`. ([@jonas054][])
+* [#3286](https://github.com/bbatsov/rubocop/issues/3286): Allow `self.a, self.b = b, a` in `Style/ParallelAssignment`. ([@jonas054][])
 
 ### Changes
 

--- a/spec/rubocop/cop/style/parallel_assignment_spec.rb
+++ b/spec/rubocop/cop/style/parallel_assignment_spec.rb
@@ -10,7 +10,7 @@ describe RuboCop::Cop::Style::ParallelAssignment, :config do
   end
 
   shared_examples('offenses') do |source|
-    it "registers an offense for: #{source}" do
+    it "registers an offense for: #{source.gsub(/\s*\n\s*/, '; ')}" do
       inspect_source(cop, source)
 
       expect(cop.messages).to eq(['Do not use parallel assignment.'])
@@ -48,7 +48,7 @@ describe RuboCop::Cop::Style::ParallelAssignment, :config do
   it_behaves_like('offenses', 'a[0], a[1] = a[1], b[0]')
 
   shared_examples('allowed') do |source|
-    it "allows assignment of: #{source}" do
+    it "allows assignment of: #{source.gsub(/\s*\n\s*/, '; ')}" do
       inspect_source(cop, source)
 
       expect(cop.messages).to be_empty
@@ -99,301 +99,300 @@ describe RuboCop::Cop::Style::ParallelAssignment, :config do
     expect(cop.highlights).to eq(['a, b = 1, 2'])
   end
 
-  context 'autocorrect' do
-    describe 'can correct' do
-      it 'when the number of left hand variables matches ' \
-        'the number of right hand variables' do
-          new_source = autocorrect_source(cop, 'a, b, c = 1, 2, 3')
-
-          expect(new_source).to eq(['a = 1',
-                                    'b = 2',
-                                    'c = 3'].join("\n"))
-        end
-
-      it 'when the right variable is an array' do
-        new_source = autocorrect_source(cop, 'a, b, c = ["1", "2", :c]')
-
-        expect(new_source).to eq(['a = "1"',
-                                  'b = "2"',
-                                  'c = :c'].join("\n"))
-      end
-
-      it 'when the right variable is a word array' do
-        new_source = autocorrect_source(cop, 'a, b, c = %w(1 2 3)')
-
-        expect(new_source).to eq(["a = '1'",
-                                  "b = '2'",
-                                  "c = '3'"].join("\n"))
-      end
-
-      it 'when the right variable is a symbol array' do
-        new_source = autocorrect_source(cop, 'a, b, c = %i(a b c)')
-
-        expect(new_source).to eq(['a = :a',
-                                  'b = :b',
-                                  'c = :c'].join("\n"))
-      end
-
-      it 'when assigning to method returns' do
-        new_source = autocorrect_source(cop, 'a, b = foo(), bar()')
-
-        expect(new_source).to eq(['a = foo()',
-                                  'b = bar()'].join("\n"))
-      end
-
-      it 'when assigning from multiple methods with blocks' do
-        source = 'a, b = foo() { |c| puts c }, bar() { |d| puts d }'
-        new_source = autocorrect_source(cop, source)
-
-        expect(new_source).to eq(['a = foo() { |c| puts c }',
-                                  'b = bar() { |d| puts d }'].join("\n"))
-      end
-
-      it 'when using constants' do
-        source = 'CONSTANT1, CONSTANT2 = CONSTANT3, CONSTANT4'
-        new_source = autocorrect_source(cop, source)
-
-        expect(new_source).to eq(['CONSTANT1 = CONSTANT3',
-                                  'CONSTANT2 = CONSTANT4'].join("\n"))
-      end
-
-      it 'when the expression is missing spaces' do
-        new_source = autocorrect_source(cop, 'a,b,c=1,2,3')
+  describe 'autocorrect' do
+    it 'corrects when the number of left hand variables matches ' \
+      'the number of right hand variables' do
+        new_source = autocorrect_source(cop, 'a, b, c = 1, 2, 3')
 
         expect(new_source).to eq(['a = 1',
                                   'b = 2',
                                   'c = 3'].join("\n"))
       end
 
-      it 'when using single indentation' do
-        new_source = autocorrect_source(cop, ['def foo',
-                                              '  a, b, c = 1, 2, 3',
-                                              'end'].join("\n"))
+    it 'corrects when the right variable is an array' do
+      new_source = autocorrect_source(cop, 'a, b, c = ["1", "2", :c]')
 
-        expect(new_source).to eq(['def foo',
-                                  '  a = 1',
-                                  '  b = 2',
-                                  '  c = 3',
-                                  'end'].join("\n"))
-      end
+      expect(new_source).to eq(['a = "1"',
+                                'b = "2"',
+                                'c = :c'].join("\n"))
+    end
 
-      it 'when using nested indentation' do
-        new_source = autocorrect_source(cop, ['def foo',
-                                              '  if true',
-                                              '    a, b, c = 1, 2, 3',
-                                              '  end',
-                                              'end'].join("\n"))
+    it 'corrects when the right variable is a word array' do
+      new_source = autocorrect_source(cop, 'a, b, c = %w(1 2 3)')
 
-        expect(new_source).to eq(['def foo',
-                                  '  if true',
-                                  '    a = 1',
-                                  '    b = 2',
-                                  '    c = 3',
-                                  '  end',
-                                  'end'].join("\n"))
-      end
+      expect(new_source).to eq(["a = '1'",
+                                "b = '2'",
+                                "c = '3'"].join("\n"))
+    end
 
-      it 'when the expression uses a modifier if statement' do
-        new_source = autocorrect_source(cop, 'a, b = 1, 2 if foo')
+    it 'corrects when the right variable is a symbol array' do
+      new_source = autocorrect_source(cop, 'a, b, c = %i(a b c)')
 
-        expect(new_source).to eq(['if foo',
-                                  '  a = 1',
-                                  '  b = 2',
-                                  'end'].join("\n"))
-      end
+      expect(new_source).to eq(['a = :a',
+                                'b = :b',
+                                'c = :c'].join("\n"))
+    end
 
-      it 'when the expression uses a modifier if statement ' \
-         'inside a method' do
-        new_source = autocorrect_source(cop, ['def foo',
-                                              '  a, b = 1, 2 if foo',
-                                              'end'])
+    it 'corrects when assigning to method returns' do
+      new_source = autocorrect_source(cop, 'a, b = foo(), bar()')
 
-        expect(new_source).to eq(['def foo',
-                                  '  if foo',
-                                  '    a = 1',
-                                  '    b = 2',
-                                  '  end',
-                                  'end'].join("\n"))
-      end
+      expect(new_source).to eq(['a = foo()',
+                                'b = bar()'].join("\n"))
+    end
 
-      it 'parallel assignment in if statements' do
-        new_source = autocorrect_source(cop, ['if foo',
-                                              '  a, b = 1, 2',
-                                              'end'].join("\n"))
+    it 'corrects when assigning from multiple methods with blocks' do
+      source = 'a, b = foo() { |c| puts c }, bar() { |d| puts d }'
+      new_source = autocorrect_source(cop, source)
 
-        expect(new_source).to eq(['if foo',
-                                  '  a = 1',
-                                  '  b = 2',
-                                  'end'].join("\n"))
-      end
+      expect(new_source).to eq(['a = foo() { |c| puts c }',
+                                'b = bar() { |d| puts d }'].join("\n"))
+    end
 
-      it 'when the expression uses a modifier unless statement' do
-        new_source = autocorrect_source(cop, 'a, b = 1, 2 unless foo')
+    it 'corrects when using constants' do
+      source = 'CONSTANT1, CONSTANT2 = CONSTANT3, CONSTANT4'
+      new_source = autocorrect_source(cop, source)
 
-        expect(new_source).to eq(['unless foo',
-                                  '  a = 1',
-                                  '  b = 2',
-                                  'end'].join("\n"))
-      end
+      expect(new_source).to eq(['CONSTANT1 = CONSTANT3',
+                                'CONSTANT2 = CONSTANT4'].join("\n"))
+    end
 
-      it 'parallel assignment in unless statements' do
-        new_source = autocorrect_source(cop, ['unless foo',
-                                              '  a, b = 1, 2',
-                                              'end'].join("\n"))
+    it 'corrects when the expression is missing spaces' do
+      new_source = autocorrect_source(cop, 'a,b,c=1,2,3')
 
-        expect(new_source).to eq(['unless foo',
-                                  '  a = 1',
-                                  '  b = 2',
-                                  'end'].join("\n"))
-      end
+      expect(new_source).to eq(['a = 1',
+                                'b = 2',
+                                'c = 3'].join("\n"))
+    end
 
-      it 'when the expression uses a modifier while statement' do
-        new_source = autocorrect_source(cop, 'a, b = 1, 2 while foo')
+    it 'corrects when using single indentation' do
+      new_source = autocorrect_source(cop, ['def foo',
+                                            '  a, b, c = 1, 2, 3',
+                                            'end'].join("\n"))
 
-        expect(new_source).to eq(['while foo',
-                                  '  a = 1',
-                                  '  b = 2',
-                                  'end'].join("\n"))
-      end
+      expect(new_source).to eq(['def foo',
+                                '  a = 1',
+                                '  b = 2',
+                                '  c = 3',
+                                'end'].join("\n"))
+    end
 
-      it 'parallel assignment in while statements' do
-        new_source = autocorrect_source(cop, ['while foo',
-                                              '  a, b = 1, 2',
-                                              'end'].join("\n"))
+    it 'corrects when using nested indentation' do
+      new_source = autocorrect_source(cop, ['def foo',
+                                            '  if true',
+                                            '    a, b, c = 1, 2, 3',
+                                            '  end',
+                                            'end'].join("\n"))
 
-        expect(new_source).to eq(['while foo',
-                                  '  a = 1',
-                                  '  b = 2',
-                                  'end'].join("\n"))
-      end
+      expect(new_source).to eq(['def foo',
+                                '  if true',
+                                '    a = 1',
+                                '    b = 2',
+                                '    c = 3',
+                                '  end',
+                                'end'].join("\n"))
+    end
 
-      it 'when the expression uses a modifier until statement' do
-        new_source = autocorrect_source(cop, 'a, b = 1, 2 until foo')
+    it 'corrects when the expression uses a modifier if statement' do
+      new_source = autocorrect_source(cop, 'a, b = 1, 2 if foo')
 
-        expect(new_source).to eq(['until foo',
-                                  '  a = 1',
-                                  '  b = 2',
-                                  'end'].join("\n"))
-      end
+      expect(new_source).to eq(['if foo',
+                                '  a = 1',
+                                '  b = 2',
+                                'end'].join("\n"))
+    end
 
-      it 'parallel assignment in until statements' do
-        new_source = autocorrect_source(cop, ['until foo',
-                                              '  a, b = 1, 2',
-                                              'end'].join("\n"))
+    it 'corrects when the expression uses a modifier if statement ' \
+       'inside a method' do
+      new_source = autocorrect_source(cop, ['def foo',
+                                            '  a, b = 1, 2 if foo',
+                                            'end'])
 
-        expect(new_source).to eq(['until foo',
-                                  '  a = 1',
-                                  '  b = 2',
-                                  'end'].join("\n"))
-      end
+      expect(new_source).to eq(['def foo',
+                                '  if foo',
+                                '    a = 1',
+                                '    b = 2',
+                                '  end',
+                                'end'].join("\n"))
+    end
 
-      it 'when the expression uses a modifier rescue statement' do
-        new_source = autocorrect_source(cop, 'a, b = 1, 2 rescue foo')
+    it 'corrects parallel assignment in if statements' do
+      new_source = autocorrect_source(cop, ['if foo',
+                                            '  a, b = 1, 2',
+                                            'end'].join("\n"))
 
-        expect(new_source).to eq(['begin',
-                                  '  a = 1',
-                                  '  b = 2',
-                                  'rescue',
-                                  '  foo',
-                                  'end'].join("\n"))
-      end
+      expect(new_source).to eq(['if foo',
+                                '  a = 1',
+                                '  b = 2',
+                                'end'].join("\n"))
+    end
 
-      it 'parallel assignment in rescue statements' do
-        new_source = autocorrect_source(cop, ['def bar',
-                                              '  a, b = 1, 2',
-                                              'rescue',
-                                              "  'foo'",
-                                              'end'].join("\n"))
+    it 'corrects when the expression uses a modifier unless statement' do
+      new_source = autocorrect_source(cop, 'a, b = 1, 2 unless foo')
 
-        expect(new_source).to eq(['def bar',
-                                  '  a = 1',
-                                  '  b = 2',
-                                  'rescue',
-                                  "  'foo'",
-                                  'end'].join("\n"))
-      end
+      expect(new_source).to eq(['unless foo',
+                                '  a = 1',
+                                '  b = 2',
+                                'end'].join("\n"))
+    end
 
-      it 'parallel assignment in rescue statements' do
-        new_source = autocorrect_source(cop, ['begin',
-                                              '  a, b = 1, 2',
-                                              'rescue',
-                                              "  'foo'",
-                                              'end'].join("\n"))
+    it 'corrects parallel assignment in unless statements' do
+      new_source = autocorrect_source(cop, ['unless foo',
+                                            '  a, b = 1, 2',
+                                            'end'].join("\n"))
 
-        expect(new_source).to eq(['begin',
-                                  '  a = 1',
-                                  '  b = 2',
-                                  'rescue',
-                                  "  'foo'",
-                                  'end'].join("\n"))
-      end
+      expect(new_source).to eq(['unless foo',
+                                '  a = 1',
+                                '  b = 2',
+                                'end'].join("\n"))
+    end
 
-      it 'when the expression uses a modifier rescue statement ' \
-         'as the only thing inside of a method' do
-        new_source = autocorrect_source(cop, ['def foo',
-                                              '  a, b = 1, 2 rescue foo',
-                                              'end'])
+    it 'corrects when the expression uses a modifier while statement' do
+      new_source = autocorrect_source(cop, 'a, b = 1, 2 while foo')
 
-        expect(new_source).to eq(['def foo',
-                                  '  a = 1',
-                                  '  b = 2',
-                                  'rescue',
-                                  '  foo',
-                                  'end'].join("\n"))
-      end
+      expect(new_source).to eq(['while foo',
+                                '  a = 1',
+                                '  b = 2',
+                                'end'].join("\n"))
+    end
 
-      it 'when the expression uses a modifier rescue statement ' \
-         'inside of a method' do
-        new_source = autocorrect_source(cop, ['def foo',
-                                              '  a, b = %w(1 2) rescue foo',
-                                              '  something_else',
-                                              'end'])
+    it 'corrects parallel assignment in while statements' do
+      new_source = autocorrect_source(cop, ['while foo',
+                                            '  a, b = 1, 2',
+                                            'end'].join("\n"))
 
-        expect(new_source).to eq(['def foo',
-                                  '  begin',
-                                  "    a = '1'",
-                                  "    b = '2'",
-                                  '  rescue',
-                                  '    foo',
-                                  '  end',
-                                  '  something_else',
-                                  'end'].join("\n"))
-      end
+      expect(new_source).to eq(['while foo',
+                                '  a = 1',
+                                '  b = 2',
+                                'end'].join("\n"))
+    end
 
-      it 'when assignments must be reordered to avoid changing meaning' do
-        new_source = autocorrect_source(cop, ['a, b, c, d = 1, a + 1, b + 1, ' \
-          'a + b + c'])
+    it 'corrects when the expression uses a modifier until statement' do
+      new_source = autocorrect_source(cop, 'a, b = 1, 2 until foo')
 
-        expect(new_source).to eq(['d = a + b + c',
-                                  'c = b + 1',
-                                  'b = a + 1',
-                                  'a = 1'].join("\n"))
+      expect(new_source).to eq(['until foo',
+                                '  a = 1',
+                                '  b = 2',
+                                'end'].join("\n"))
+    end
+
+    it 'corrects parallel assignment in until statements' do
+      new_source = autocorrect_source(cop, ['until foo',
+                                            '  a, b = 1, 2',
+                                            'end'].join("\n"))
+
+      expect(new_source).to eq(['until foo',
+                                '  a = 1',
+                                '  b = 2',
+                                'end'].join("\n"))
+    end
+
+    it 'corrects when the expression uses a modifier rescue statement' do
+      new_source = autocorrect_source(cop, 'a, b = 1, 2 rescue foo')
+
+      expect(new_source).to eq(['begin',
+                                '  a = 1',
+                                '  b = 2',
+                                'rescue',
+                                '  foo',
+                                'end'].join("\n"))
+    end
+
+    it 'corrects parallel assignment in rescue statements' do
+      new_source = autocorrect_source(cop, ['def bar',
+                                            '  a, b = 1, 2',
+                                            'rescue',
+                                            "  'foo'",
+                                            'end'].join("\n"))
+
+      expect(new_source).to eq(['def bar',
+                                '  a = 1',
+                                '  b = 2',
+                                'rescue',
+                                "  'foo'",
+                                'end'].join("\n"))
+    end
+
+    it 'corrects parallel assignment in rescue statements' do
+      new_source = autocorrect_source(cop, ['begin',
+                                            '  a, b = 1, 2',
+                                            'rescue',
+                                            "  'foo'",
+                                            'end'].join("\n"))
+
+      expect(new_source).to eq(['begin',
+                                '  a = 1',
+                                '  b = 2',
+                                'rescue',
+                                "  'foo'",
+                                'end'].join("\n"))
+    end
+
+    it 'corrects when the expression uses a modifier rescue statement ' \
+       'as the only thing inside of a method' do
+      new_source = autocorrect_source(cop, ['def foo',
+                                            '  a, b = 1, 2 rescue foo',
+                                            'end'])
+
+      expect(new_source).to eq(['def foo',
+                                '  a = 1',
+                                '  b = 2',
+                                'rescue',
+                                '  foo',
+                                'end'].join("\n"))
+    end
+
+    it 'corrects when the expression uses a modifier rescue statement ' \
+       'inside of a method' do
+      new_source = autocorrect_source(cop, ['def foo',
+                                            '  a, b = %w(1 2) rescue foo',
+                                            '  something_else',
+                                            'end'])
+
+      expect(new_source).to eq(['def foo',
+                                '  begin',
+                                "    a = '1'",
+                                "    b = '2'",
+                                '  rescue',
+                                '    foo',
+                                '  end',
+                                '  something_else',
+                                'end'].join("\n"))
+    end
+
+    it 'corrects when assignments must be reordered to avoid changing ' \
+       'meaning' do
+      new_source = autocorrect_source(cop, ['a, b, c, d = 1, a + 1, b + 1, ' \
+        'a + b + c'])
+
+      expect(new_source).to eq(['d = a + b + c',
+                                'c = b + 1',
+                                'b = a + 1',
+                                'a = 1'].join("\n"))
+    end
+
+    shared_examples('no correction') do |description, source|
+      context description do
+        it "does not change: #{source.gsub(/\s*\n\s*/, '; ')}" do
+          new_source = autocorrect_source(cop, source)
+          expect(new_source).to eq(source)
+        end
       end
     end
 
-    describe 'does not correct' do
-      it 'when there are more left variables than right variables' do
-        new_source = autocorrect_source(cop, 'a, b, c, d = 1, 2')
+    it_behaves_like 'no correction',
+                    'when there are more left variables than right variables',
+                    'a, b, c, d = 1, 2'
 
-        expect(new_source).to eq('a, b, c, d = 1, 2')
-      end
+    it_behaves_like 'no correction',
+                    'when there are more right variables than left variables',
+                    'a, b = 1, 2, 3'
 
-      it 'when there are more right variables than left variables' do
-        new_source = autocorrect_source(cop, 'a, b = 1, 2, 3')
+    it_behaves_like 'no correction',
+                    'when expanding an assigned variable',
+                    ['foo = [1, 2, 3]',
+                     'a, b, c = foo'].join("\n")
 
-        expect(new_source).to eq('a, b = 1, 2, 3')
-      end
-
-      it 'when expanding an assigned variable' do
-        new_source = autocorrect_source(cop, ['foo = [1, 2, 3]',
-                                              'a, b, c = foo'].join("\n"))
-
-        expect(new_source).to eq(['foo = [1, 2, 3]',
-                                  'a, b, c = foo'].join("\n"))
-      end
-    end
-
-    describe 'Using custom indentation width' do
+    describe 'using custom indentation width' do
       let(:config) do
         RuboCop::Config.new('Performance/ParallelAssignment' => {
                               'Enabled' => true

--- a/spec/rubocop/cop/style/parallel_assignment_spec.rb
+++ b/spec/rubocop/cop/style/parallel_assignment_spec.rb
@@ -86,6 +86,8 @@ describe RuboCop::Cop::Style::ParallelAssignment, :config do
   it_behaves_like('allowed', 'obj.attr1, obj.attr2 = obj.attr2, obj.attr1')
   it_behaves_like('allowed', 'obj.attr1, ary[0] = ary[0], obj.attr1')
   it_behaves_like('allowed', 'ary[0], ary[1], ary[2] = ary[1], ary[2], ary[0]')
+  it_behaves_like('allowed', 'self.a, self.b = self.b, self.a')
+  it_behaves_like('allowed', 'self.a, self.b = b, a')
 
   it 'highlights the entire expression' do
     inspect_source(cop, 'a, b = 1, 2')


### PR DESCRIPTION
Add `self.` when it has been left out on the right hand side, so that we can determine that it's a swap kind of assignment, and thus allow it.

Github's diff algorithm has problems following my changes in the refactoring of the specs I see. But it's just some small adjustments to make them more readable.