### PR TITLE
Fix #3474: Do not add methods to the method chain if the receiver doe…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -71,6 +71,7 @@
 * [#3578](https://github.com/bbatsov/rubocop/issues/3578): Fix safe navigation method call counting in `Metrics/AbcSize`. ([@savef][])
 * [#3592](https://github.com/bbatsov/rubocop/issues/3592): Fix `Style/RedundantParentheses` for indexing with literals. ([@thegedge][])
 * [#3597](https://github.com/bbatsov/rubocop/issues/3597): Fix the autocorrect of `Performance/CaseWhenSplat` when trying to rearange splat expanded variables to the end of a when condition. ([@rrosenblum][])
+* [#3474](https://github.com/bbatsov/rubocop/issues/3474): Make the `Rails/TimeZone` only analyze functions which have "Time" in the receiver. ([@b-t-g][])
 
 ### Changes
 

--- a/lib/rubocop/cop/rails/time_zone.rb
+++ b/lib/rubocop/cop/rails/time_zone.rb
@@ -94,7 +94,7 @@ module RuboCop
         def extract_method_chain(node)
           chain = []
           while !node.nil? && node.send_type?
-            chain << extract_method(node)
+            chain << extract_method(node) if method_from_time_class?(node)
             node = node.parent
           end
           chain
@@ -103,6 +103,17 @@ module RuboCop
         def extract_method(node)
           _receiver, method_name, *_args = *node
           method_name
+        end
+
+        # Only add the method to the chain if the method being
+        # called is part of the time class.
+        def method_from_time_class?(node)
+          receiver, method_name, *_args = *node
+          if (receiver.is_a? RuboCop::Node) && !receiver.cbase_type?
+            method_from_time_class?(receiver)
+          else
+            TIMECLASS.include? method_name
+          end
         end
 
         # checks that parent node of send_type

--- a/spec/rubocop/cop/rails/time_zone_spec.rb
+++ b/spec/rubocop/cop/rails/time_zone_spec.rb
@@ -33,6 +33,14 @@ describe RuboCop::Cop::Rails::TimeZone, :config do
         expect(cop.offenses.first.message).to include('`Time.zone.local`')
       end
 
+      it 'does not register an offense when a .new method is made
+        independently of the Time class' do
+        inspect_source(cop,
+                       'Range.new(1,
+                                  Time.days_in_month(date.month, date.year))')
+        expect(cop.offenses).to be_empty
+      end
+
       it "does not register an offense for #{klass}.new with zone argument" do
         inspect_source(cop, "#{klass}.new(1988, 3, 15, 3, 0, 0, '-05:00')")
         expect(cop.offenses).to be_empty


### PR DESCRIPTION
It appears that the "extract_method_chain(node)" function added methods regardless of whether they had anything to do with the time class at all.

I added a function called "add_to_chain(node)" which returns true if "Time" occurs anywhere in the receiver (and false otherwise).
-----------------

Before submitting the PR make sure the following are checked:

* [ ] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Used the same coding conventions as the rest of the project.
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] All tests are passing.
* [x] The new code doesn't generate RuboCop offenses.
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.

[1]: http://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html

…s not contain an element of the Time class.