### PR TITLE
[Fix #3103] Make Style/ExtraSpacing not ignore single line hash literals

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 
 ### Bug fixes
 
+* [#3103](https://github.com/bbatsov/rubocop/pull/3103): Make `Style/ExtraSpacing` cop register an offense for extra spaces present in single-line hash literals. ([@tcdowney][])
 * [#3513](https://github.com/bbatsov/rubocop/pull/3513): Fix false positive in `Style/TernaryParentheses` for a ternary with ranges. ([@dreyks][])
 * [#3520](https://github.com/bbatsov/rubocop/issues/3520): Fix regression causing `Lint/AssignmentInCondition` false positive. ([@savef][])
 * [#3514](https://github.com/bbatsov/rubocop/issues/3514): Make `Style/VariableNumber` cop not register an offense when valid normal case variable names have an integer after the first `_`. ([@b-t-g][])
@@ -2391,3 +2392,4 @@
 [@b-t-g]: https://github.com/b-t-g
 [@coorasse]: https://github.com/coorasse
 [@scottmatthewman]: https://github.com/scottmatthewman
+[@tcdowney]: https://github.com/tcdowney

--- a/lib/rubocop/cop/style/extra_spacing.rb
+++ b/lib/rubocop/cop/style/extra_spacing.rb
@@ -140,15 +140,17 @@ module RuboCop
         end
 
         # Returns an array of ranges that should not be reported. It's the
-        # extra spaces between the keys and values in a hash, since those are
-        # handled by the Style/AlignHash cop.
+        # extra spaces between the keys and values in a multiline hash,
+        # since those are handled by the Style/AlignHash cop.
         def ignored_ranges(ast)
           return [] unless ast
 
           @ignored_ranges ||= on_node(:pair, ast).map do |pair|
+            next if pair.parent.single_line?
+
             key, value = *pair
             key.source_range.end_pos...value.source_range.begin_pos
-          end
+          end.compact
         end
 
         def aligned_comments?(token)

--- a/spec/rubocop/cop/style/extra_spacing_spec.rb
+++ b/spec/rubocop/cop/style/extra_spacing_spec.rb
@@ -49,6 +49,25 @@ describe RuboCop::Cop::Style::ExtraSpacing, :config do
       expect(cop.offenses).to be_empty
     end
 
+    context 'when spaces are present in a single-line hash literal' do
+      it 'registers an offense for hashes with symbol keys' do
+        inspect_source(cop, 'hash = {a:   1,  b:    2}')
+        expect(cop.offenses.size).to eq(3)
+      end
+
+      it 'registers an offense for hashes with hash rockets' do
+        source = [
+          'let(:single_line_hash) {',
+          '  {"a"   => "1", "b" => "2"}',
+          '}'
+        ]
+
+        inspect_source(cop, source)
+        expect(cop.offenses.size).to eq(1)
+        expect(cop.offenses.first.line).to eq(2)
+      end
+    end
+
     it 'can handle extra space before a float' do
       source = ['{:a => "a",',
                 ' :b => [nil,  2.5]}']


### PR DESCRIPTION
This should fix issue #3103 where the `Style/ExtraSpacing` cop was ignoring extra whitespace within single line hash literals.

Thanks for taking a look at this PR!! 🌝 

-----------------

Before submitting the PR make sure the following are checked:

* [ ] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [ ] Used the same coding conventions as the rest of the project.
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] All tests are passing.
* [x] The new code doesn't generate RuboCop offenses.
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.

[1]: http://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html