### PR TITLE
[Fix #3419] Report `unless x.nil?` in NonNilCheck

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@
 * [#3430](https://github.com/bbatsov/rubocop/issues/3430): Fix exception in `Performance/RedundantMerge` when inspecting a `#merge!` with implicit receiver. ([@drenmi][])
 * [#3411](https://github.com/bbatsov/rubocop/issues/3411): Avoid auto-correction crash for single `when` in `Performance/CaseWhenSplat`. ([@jonas054][])
 * [#3286](https://github.com/bbatsov/rubocop/issues/3286): Allow `self.a, self.b = b, a` in `Style/ParallelAssignment`. ([@jonas054][])
+* [#3419](https://github.com/bbatsov/rubocop/issues/3419): Report offense for `unless x.nil?` in `Style/NonNilCheck` if `IncludeSemanticChanges` is `true`. ([@jonas054][])
 
 ### Changes
 

--- a/spec/rubocop/cop/style/non_nil_check_spec.rb
+++ b/spec/rubocop/cop/style/non_nil_check_spec.rb
@@ -106,6 +106,13 @@ describe RuboCop::Cop::Style::NonNilCheck, :config do
       expect(cop.highlights).to eq(['!x.nil?'])
     end
 
+    it 'registers an offense for unless x.nil?' do
+      inspect_source(cop, 'puts b unless x.nil?')
+      expect(cop.messages)
+        .to eq(['Explicit non-nil checks are usually redundant.'])
+      expect(cop.highlights).to eq(['x.nil?'])
+    end
+
     it 'does not register an offense for `x.nil?`' do
       inspect_source(cop, 'x.nil?')
       expect(cop.offenses).to be_empty
@@ -120,6 +127,11 @@ describe RuboCop::Cop::Style::NonNilCheck, :config do
       inspect_source(cop, 'not x.nil?')
       expect(cop.offenses.size).to eq(1)
       expect(cop.highlights).to eq(['not x.nil?'])
+    end
+
+    it 'autocorrects by changing unless x.nil? to if x' do
+      corrected = autocorrect_source(cop, 'puts a unless x.nil?')
+      expect(corrected).to eq 'puts a if x'
     end
 
     it 'autocorrects by changing `x != nil` to `x`' do


### PR DESCRIPTION
This reporting depends on `IncludeSemanticChanges` being `true`, which it's not by default. Auto-correct to `if x`.

Expressions such as `unless x.nil? && y.nil?` are still not reported.