### PR TITLE
[Fix #3382] Fix EmptyElse with multiple elsifs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@
 * [#3411](https://github.com/bbatsov/rubocop/issues/3411): Avoid auto-correction crash for single `when` in `Performance/CaseWhenSplat`. ([@jonas054][])
 * [#3286](https://github.com/bbatsov/rubocop/issues/3286): Allow `self.a, self.b = b, a` in `Style/ParallelAssignment`. ([@jonas054][])
 * [#3419](https://github.com/bbatsov/rubocop/issues/3419): Report offense for `unless x.nil?` in `Style/NonNilCheck` if `IncludeSemanticChanges` is `true`. ([@jonas054][])
+* [#3382](https://github.com/bbatsov/rubocop/issues/3382): Avoid auto-correction crash for multiple elsifs in `Style/EmptyElse`. ([@lumeet][])
 
 ### Changes
 

--- a/lib/rubocop/cop/style/empty_else.rb
+++ b/lib/rubocop/cop/style/empty_else.rb
@@ -110,14 +110,16 @@ module RuboCop
           return false if autocorrect_forbidden?(node.type.to_s)
 
           lambda do |corrector|
-            end_pos = if node.loc.end
-                        node.loc.end.begin_pos
-                      else
-                        node.parent.loc.end.begin_pos
-                      end
+            end_pos = base_if_node(node).loc.end.begin_pos
 
             corrector.remove(range_between(node.loc.else.begin_pos, end_pos))
           end
+        end
+
+        def base_if_node(node)
+          parent_node = node
+          parent_node = parent_node.parent until parent_node.loc.end
+          parent_node
         end
 
         def autocorrect_forbidden?(type)

--- a/spec/rubocop/cop/style/empty_else_spec.rb
+++ b/spec/rubocop/cop/style/empty_else_spec.rb
@@ -235,11 +235,21 @@ describe RuboCop::Cop::Style::EmptyElse do
 
       context 'with an else-clause containing only the literal nil ' \
               'using semicolons' do
-        let(:source) { 'if a; foo elsif b; bar else nil end' }
-        let(:corrected_source) { 'if a; foo elsif b; bar end' }
+        context 'with one elsif' do
+          let(:source) { 'if a; foo elsif b; bar else nil end' }
+          let(:corrected_source) { 'if a; foo elsif b; bar end' }
 
-        it_behaves_like 'offense registration'
-        it_behaves_like 'auto-correct', 'if'
+          it_behaves_like 'offense registration'
+          it_behaves_like 'auto-correct', 'if'
+        end
+
+        context 'with multiple elsifs' do
+          let(:source) { 'if a; foo elsif b; bar; elsif c; bar else nil end' }
+          let(:corrected_source) { 'if a; foo elsif b; bar; elsif c; bar end' }
+
+          it_behaves_like 'offense registration'
+          it_behaves_like 'auto-correct', 'if'
+        end
       end
 
       context 'with an else-clause with side-effects' do
@@ -366,11 +376,21 @@ describe RuboCop::Cop::Style::EmptyElse do
       end
 
       context 'with an else-clause containing only the literal nil' do
-        let(:source) { 'if a; foo elsif b; bar else nil end' }
-        let(:corrected_source) { 'if a; foo elsif b; bar end' }
+        context 'with one elsif' do
+          let(:source) { 'if a; foo elsif b; bar else nil end' }
+          let(:corrected_source) { 'if a; foo elsif b; bar end' }
 
-        it_behaves_like 'offense registration'
-        it_behaves_like 'auto-correct', 'if'
+          it_behaves_like 'offense registration'
+          it_behaves_like 'auto-correct', 'if'
+        end
+
+        context 'with multiple elsifs' do
+          let(:source) { 'if a; foo elsif b; bar; elsif c; bar else nil end' }
+          let(:corrected_source) { 'if a; foo elsif b; bar; elsif c; bar end' }
+
+          it_behaves_like 'offense registration'
+          it_behaves_like 'auto-correct', 'if'
+        end
       end
 
       context 'with an else-clause with side-effects' do


### PR DESCRIPTION
An `if-elsif-else` expression containing multiple elsifs does not crash
when auto-correcting.

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Used the same coding conventions as the rest of the project.
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] All tests are passing.
* [x] The new code doesn't generate RuboCop offenses.
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.

[1]: http://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html