### PR TITLE
[Fix #3334] Fix false positive for space literal in UnneededCapitalW

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@
 * [#3286](https://github.com/bbatsov/rubocop/issues/3286): Allow `self.a, self.b = b, a` in `Style/ParallelAssignment`. ([@jonas054][])
 * [#3419](https://github.com/bbatsov/rubocop/issues/3419): Report offense for `unless x.nil?` in `Style/NonNilCheck` if `IncludeSemanticChanges` is `true`. ([@jonas054][])
 * [#3382](https://github.com/bbatsov/rubocop/issues/3382): Avoid auto-correction crash for multiple elsifs in `Style/EmptyElse`. ([@lumeet][])
+* [#3334](https://github.com/bbatsov/rubocop/issues/3334): Do not register an offense for a literal space (`\s`) in `Style/UnneededCapitalW`. ([@rrosenblum][])
 
 ### Changes
 

--- a/lib/rubocop/cop/style/unneeded_capital_w.rb
+++ b/lib/rubocop/cop/style/unneeded_capital_w.rb
@@ -24,7 +24,9 @@ module RuboCop
 
         def requires_interpolation?(node)
           node.child_nodes.any? do |string|
-            string.dstr_type? || double_quotes_acceptable?(string.str_content)
+            string.dstr_type? ||
+              double_quotes_acceptable?(string.str_content) ||
+              string.source == '\s'
           end
         end
 

--- a/spec/rubocop/cop/style/unneeded_capital_w_spec.rb
+++ b/spec/rubocop/cop/style/unneeded_capital_w_spec.rb
@@ -38,6 +38,8 @@ describe RuboCop::Cop::Style::UnneededCapitalW do
               '  %W(\007) +',
               '  %W(\00) +',
               '  %W(\a)',
+              '  %W(\s)',
+              '  %W(\n)',
               'end']
     inspect_source(cop, source)
     expect(cop.offenses).to be_empty


### PR DESCRIPTION
This fixes #3334. This was a bit weird to fix. `double_quotes_acceptable?` doesn't seem to work with `"\s"`. I didn't implement a fix inside of that method because `string.str_content` returns `' '` for the space literal string. 