### PR TITLE
[Fix #3578] Fix safe navigation counting in `Metrics/AbcSize`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@
 * [#3334](https://github.com/bbatsov/rubocop/issues/3334): Do not register an offense for a literal space (`\s`) in `Style/UnneededCapitalW`. ([@rrosenblum][])
 * [#3390](https://github.com/bbatsov/rubocop/issues/3390): Fix SaveBang cop for multiple conditional. ([@tejasbubane][])
 * [#3577](https://github.com/bbatsov/rubocop/issues/3577): Fix `Style/RaiseArgs` not allowing compact raise with splatted args. ([@savef][])
+* [#3578](https://github.com/bbatsov/rubocop/issues/3578): Fix safe navigation method call counting in `Metrics/AbcSize`. ([@savef][])
 
 ### Changes
 

--- a/lib/rubocop/cop/metrics/abc_size.rb
+++ b/lib/rubocop/cop/metrics/abc_size.rb
@@ -11,7 +11,7 @@ module RuboCop
 
         MSG = 'Assignment Branch Condition size for %s is too high. ' \
               '[%.4g/%.4g]'.freeze
-        BRANCH_NODES = [:send].freeze
+        BRANCH_NODES = [:send, :csend].freeze
         CONDITION_NODES = CyclomaticComplexity::COUNTED_NODES.freeze
 
         private

--- a/spec/rubocop/cop/metrics/abc_size_spec.rb
+++ b/spec/rubocop/cop/metrics/abc_size_spec.rb
@@ -57,7 +57,19 @@ describe RuboCop::Cop::Metrics::AbcSize, :config do
                       'end'])
       expect(cop.messages)
         .to eq(['Assignment Branch Condition size for method_name is too ' \
-                'high. [6.4/0]']) # square root of 1*1 + 5*5 + 2*2 => 6.4
+                'high. [6.4/0]']) # sqrt(1*1 + 5*5 + 2*2) => 6.4
+    end
+
+    context 'target_ruby_version >= 2.3', :ruby23 do
+      it 'treats safe navigation method calls like regular method calls' do
+        inspect_source(cop,
+                       ['def method_name',
+                        '  object&.do_something',
+                        'end'])
+        expect(cop.messages)
+          .to eq(['Assignment Branch Condition size for method_name is too ' \
+                  'high. [2/0]']) # sqrt(0 + 2*2 + 0) => 2
+      end
     end
   end
 


### PR DESCRIPTION
This cop wasn't correctly counting method calls that happen with the safe navigation operator (`x&.y`), it has been changed so that they are treated the same as other method calls (like `x.y`).

Adds a test which checks the score of a method with the safe navigation operator. The test would fail without the change in the cop. I'm not sure if it needs a parallel cop with a regular method call scoring the same thing right next to it...

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Used the same coding conventions as the rest of the project.
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] All tests are passing.
* [x] The new code doesn't generate RuboCop offenses.
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
