### PR TITLE
[Fix #3577] Fix `Style/RaiseArgs` not allowing raise with splatted args

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@
 * [#3382](https://github.com/bbatsov/rubocop/issues/3382): Avoid auto-correction crash for multiple elsifs in `Style/EmptyElse`. ([@lumeet][])
 * [#3334](https://github.com/bbatsov/rubocop/issues/3334): Do not register an offense for a literal space (`\s`) in `Style/UnneededCapitalW`. ([@rrosenblum][])
 * [#3390](https://github.com/bbatsov/rubocop/issues/3390): Fix SaveBang cop for multiple conditional. ([@tejasbubane][])
+* [#3577](https://github.com/bbatsov/rubocop/issues/3577): Fix `Style/RaiseArgs` not allowing compact raise with splatted args. ([@savef][])
 
 ### Changes
 

--- a/lib/rubocop/cop/style/raise_args.rb
+++ b/lib/rubocop/cop/style/raise_args.rb
@@ -105,21 +105,21 @@ module RuboCop
         def check_exploded(node)
           _receiver, selector, *args = *node
 
-          if args.one?
-            arg, = *args
+          return correct_style_detected unless args.one?
+          arg, = *args
 
-            if arg.send_type? && arg.loc.selector.is?('new')
-              _receiver, _selector, *constructor_args = *arg
+          return unless arg.send_type? && arg.loc.selector.is?('new')
+          _receiver, _selector, *constructor_args = *arg
 
-              # Allow code like `raise Ex.new(arg1, arg2)`.
-              if constructor_args.size <= 1
-                add_offense(node, :expression, message(selector)) do
-                  opposite_style_detected
-                end
-              end
-            end
-          else
-            correct_style_detected
+          # Allow code like `raise Ex.new(arg1, arg2)`.
+          return unless constructor_args.size <= 1
+
+          # Allow code like `raise Ex.new(*args)`
+          first_arg = constructor_args.first
+          return if first_arg && first_arg.splat_type?
+
+          add_offense(node, :expression, message(selector)) do
+            opposite_style_detected
           end
         end
 

--- a/spec/rubocop/cop/style/raise_args_spec.rb
+++ b/spec/rubocop/cop/style/raise_args_spec.rb
@@ -142,6 +142,11 @@ describe RuboCop::Cop::Style::RaiseArgs, :config do
       expect(cop.offenses).to be_empty
     end
 
+    it 'accepts a raise with splatted arguments' do
+      inspect_source(cop, 'raise RuntimeError.new(*args)')
+      expect(cop.offenses).to be_empty
+    end
+
     it 'accepts a raise with 3 args' do
       inspect_source(cop, 'raise RuntimeError, msg, caller')
       expect(cop.offenses).to be_empty


### PR DESCRIPTION
With the default style (exploded) one is typically allowed to use the compact style if passing multiple args into the constructor. However an offence was being generated if those args were splatted in, this changes that so there is no offence.

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Used the same coding conventions as the rest of the project.
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] All tests are passing.
* [x] The new code doesn't generate RuboCop offenses.
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.