### PR TITLE
[Fix #3542] Add IgnoreCopDirectives option to Metrics/LineLength

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 * [#3566](https://github.com/bbatsov/rubocop/issues/3566): Add new `Metric/BlockLength` cop to ensure blocks don't get too long. ([@savef][])
 * [#3428](https://github.com/bbatsov/rubocop/issues/3428): Add support for configuring `Style/PreferredHashMethods` with either `short` or `verbose` style method names. ([@abrom][])
 * [#3455](https://github.com/bbatsov/rubocop/issues/3455): Add new `Rails/DynamicFindBy` cop. ([@pocke][])
+* [#3542](https://github.com/bbatsov/rubocop/issues/3542): Add a configuration option, `IgnoreCopDirectives`, to `Metrics/LineLength` to stop cop directives (`# rubocop:disable Metrics/AbcSize`) from being counted when considering line length. ([@jmks][])
 
 ### Bug fixes
 
@@ -2410,3 +2411,4 @@
 [@logicminds]: https://github.com/logicminds
 [@abrom]: https://github.com/abrom
 [@thegedge]: https://github.com/thegedge
+[@jmks]: https://github.com/jmks/

--- a/config/default.yml
+++ b/config/default.yml
@@ -1123,6 +1123,9 @@ Metrics/LineLength:
   URISchemes:
     - http
     - https
+  # The IgnoreCopDirectives option causes the LineLength rule to ignore cop
+  # directives like '# rubocop: enable ...' when calculating a line's length.
+  IgnoreCopDirectives: false
 
 Metrics/MethodLength:
   CountComments: false  # count full line comments?

--- a/lib/rubocop/cop/metrics/line_length.rb
+++ b/lib/rubocop/cop/metrics/line_length.rb
@@ -19,17 +19,21 @@ module RuboCop
           end
         end
 
+        private
+
         def check_line(line, index, heredocs)
-          return unless line.length > max
+          return if line.length <= max
+          if ignore_cop_directives? && directive_on_source_line?(index)
+            return check_directive_line(line, index)
+          end
           return if heredocs &&
                     line_in_whitelisted_heredoc?(heredocs, index.succ)
+          return check_uri_line(line, index) if allow_uri?
 
-          if allow_uri?
-            uri_range = find_excessive_uri_range(line)
-            return if uri_range && allowed_uri_position?(line, uri_range)
-          end
-
-          offense(excess_range(uri_range, line, index), line)
+          offense(
+            source_range(processed_source.buffer, index + 1, 0...line.length),
+            line
+          )
         end
 
         def offense(loc, line)
@@ -81,6 +85,10 @@ module RuboCop
           cop_config['AllowURI']
         end
 
+        def ignore_cop_directives?
+          cop_config['IgnoreCopDirectives']
+        end
+
         def allowed_uri_position?(line, uri_range)
           uri_range.begin < max && uri_range.end == line.length
         end
@@ -110,6 +118,36 @@ module RuboCop
 
         def uri_regexp
           @regexp ||= URI.regexp(cop_config['URISchemes'])
+        end
+
+        def check_directive_line(line, index)
+          return if line_length_without_directive(line) <= max
+
+          range = max..(line_length_without_directive(line) - 1)
+          offense(source_range(processed_source.buffer, index + 1, range), line)
+        end
+
+        def directive_on_source_line?(index)
+          source_line_number = index + processed_source.buffer.first_line
+          comment =
+            processed_source
+            .comments
+            .detect { |e| e.location.line == source_line_number }
+
+          return false unless comment
+          comment.text.match(CommentConfig::COMMENT_DIRECTIVE_REGEXP)
+        end
+
+        def line_length_without_directive(line)
+          before_comment, = line.split('#')
+          before_comment.rstrip.length
+        end
+
+        def check_uri_line(line, index)
+          uri_range = find_excessive_uri_range(line)
+          return if uri_range && allowed_uri_position?(line, uri_range)
+
+          offense(excess_range(uri_range, line, index), line)
         end
       end
     end

--- a/spec/rubocop/cli/cli_auto_gen_config_spec.rb
+++ b/spec/rubocop/cli/cli_auto_gen_config_spec.rb
@@ -46,7 +46,7 @@ describe RuboCop::CLI, :isolated_environment do
       expect(IO.readlines('.rubocop_todo.yml')[8..-1].map(&:chomp))
         .to eq(['# Offense count: 1',
                 '# Configuration parameters: AllowHeredoc, AllowURI, ' \
-                'URISchemes.',
+                'URISchemes, IgnoreCopDirectives.',
                 '# URISchemes: http, https',
                 'Metrics/LineLength:',
                 '  Max: 85',
@@ -81,7 +81,7 @@ describe RuboCop::CLI, :isolated_environment do
       expect(IO.readlines('.rubocop_todo.yml')[8..-1].join)
         .to eq(['# Offense count: 1',
                 '# Configuration parameters: AllowHeredoc, AllowURI, ' \
-                'URISchemes.',
+                'URISchemes, IgnoreCopDirectives.',
                 '# URISchemes: http, https',
                 'Metrics/LineLength:',
                 '  Max: 81',
@@ -136,7 +136,8 @@ describe RuboCop::CLI, :isolated_environment do
          'again.',
          '',
          '# Offense count: 2',
-         '# Configuration parameters: AllowHeredoc, AllowURI, URISchemes.',
+         '# Configuration parameters: AllowHeredoc, AllowURI, URISchemes, '\
+         'IgnoreCopDirectives.',
          '# URISchemes: http, https',
          'Metrics/LineLength:',
          '  Max: 90',
@@ -224,7 +225,8 @@ describe RuboCop::CLI, :isolated_environment do
          'again.',
          '',
          '# Offense count: 3',
-         '# Configuration parameters: AllowHeredoc, AllowURI, URISchemes.',
+         '# Configuration parameters: AllowHeredoc, AllowURI, URISchemes, '\
+         'IgnoreCopDirectives.',
          '# URISchemes: http, https',
          'Metrics/LineLength:',
          '  Max: 90', # Offense occurs in 2 files, limit is 1, so no Exclude.
@@ -412,7 +414,8 @@ describe RuboCop::CLI, :isolated_environment do
          '# versions of RuboCop, may require this file to be generated ' \
          'again.',
          '',
-         '# Configuration parameters: AllowHeredoc, AllowURI, URISchemes.',
+         '# Configuration parameters: AllowHeredoc, AllowURI, URISchemes, '\
+         'IgnoreCopDirectives.',
          '# URISchemes: http, https',
          'Metrics/LineLength:',
          '  Max: 90',

--- a/spec/rubocop/config_loader_spec.rb
+++ b/spec/rubocop/config_loader_spec.rb
@@ -200,7 +200,8 @@ describe RuboCop::ConfigLoader do
               'Max' => 77,
               'AllowHeredoc' => true,
               'AllowURI' => true,
-              'URISchemes' => %w(http https)
+              'URISchemes' => %w(http https),
+              'IgnoreCopDirectives' => false
             },
             'Metrics/MethodLength' => {
               'Description' =>
@@ -279,7 +280,8 @@ describe RuboCop::ConfigLoader do
               'Max' => 120,             # overridden in line_length.yml
               'AllowHeredoc' => false,  # overridden in rubocop.yml
               'AllowURI' => true,
-              'URISchemes' => %w(http https)
+              'URISchemes' => %w(http https),
+              'IgnoreCopDirectives' => false
             }
           )
 

--- a/spec/rubocop/cop/metrics/line_length_spec.rb
+++ b/spec/rubocop/cop/metrics/line_length_spec.rb
@@ -188,4 +188,102 @@ describe RuboCop::Cop::Metrics::LineLength, :config do
       end
     end
   end
+
+  context 'when IgnoreCopDirectives is disabled' do
+    let(:cop_config) { { 'Max' => 80, 'IgnoreCopDirectives' => false } }
+
+    context 'and the source is acceptable length' do
+      let(:acceptable_source) { 'a' * 80 }
+
+      context 'with a trailing Rubocop directive' do
+        let(:cop_directive) { ' # rubcop:disable Metrics/SomeCop' }
+        let(:source) { acceptable_source + cop_directive }
+
+        it 'registers an offense for the line' do
+          inspect_source(cop, source)
+          expect(cop.offenses.size).to eq(1)
+        end
+
+        it 'highlights the excess directive' do
+          inspect_source(cop, source)
+          expect(cop.highlights).to eq([cop_directive])
+        end
+      end
+
+      context 'with an inline comment' do
+        let(:excess_comment) { ' ###' }
+        let(:source) { acceptable_source + excess_comment }
+
+        it 'highlights the excess comment' do
+          inspect_source(cop, source)
+          expect(cop.highlights).to eq([excess_comment])
+        end
+      end
+    end
+
+    context 'and the source is too long and has a trailing cop directive' do
+      let(:excess_with_directive) { 'b # rubocop:disable Metrics/AbcSize' }
+      let(:source) { 'a' * 80 + excess_with_directive }
+
+      it 'highlights the excess source and cop directive' do
+        inspect_source(cop, source)
+        expect(cop.highlights).to eq([excess_with_directive])
+      end
+    end
+  end
+
+  context 'when IgnoreCopDirectives is enabled' do
+    let(:cop_config) { { 'Max' => 80, 'IgnoreCopDirectives' => true } }
+
+    context 'and the Rubocop directive is excessively long' do
+      let(:source) { <<-END }
+        # rubocop:disable Metrics/SomeReallyLongMetricNameThatShouldBeMuchShorterAndNeedsANameChange
+      END
+
+      it 'accepts the line' do
+        inspect_source(cop, source)
+        expect(cop.offenses).to be_empty
+      end
+    end
+
+    context 'and the Rubocop directive causes an excessive line length' do
+      let(:source) { <<-END }
+        def method_definition_that_is_just_under_the_line_length_limit(foo, bar) # rubocop:disable Metrics/AbcSize
+          # complex method
+        end
+      END
+
+      it 'accepts the line' do
+        inspect_source(cop, source)
+        expect(cop.offenses).to be_empty
+      end
+
+      context 'and has explanatory text' do
+        let(:source) { <<-END }
+          def method_definition_that_is_just_under_the_line_length_limit(foo) # rubocop:disable Metrics/AbcSize inherently complex!
+            # complex
+          end
+        END
+
+        it 'accepts the line' do
+          inspect_source(cop, source)
+          expect(cop.offenses).to be_empty
+        end
+      end
+    end
+
+    context 'and the source is too long' do
+      let(:source) { 'a' * 80 + 'bcd' + ' # rubocop:enable Style/ClassVars' }
+
+      it 'registers an offense for the line' do
+        inspect_source(cop, source)
+        expect(cop.offenses.size).to eq(1)
+      end
+
+      it 'highlights only the non-directive part' do
+        inspect_source(cop, source)
+        expect(cop.highlights).to eq(['bcd'])
+      end
+    end
+  end
 end


### PR DESCRIPTION
Fix #3542 Since it's Hackoberfest, I thought I'd give this a shot.

This adds a `IgnoreCopDirectives` option to `Metrics\LineLength` that ignores directives like `# rubocop:disable ...` from counting against the line length max.

I'm unsure of a couple things:

- Not sure if `# rubocop:[dis]able` type comments already have a name. In the source they seem to be called directives, so I went with that when naming the option `IgnoreCopDirectives`
- I tried to run the tests/rubocop in Rubinius but all I got was seg faults. I have never tried jruby. CI has me covered?

Thanks!

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Used the same coding conventions as the rest of the project.
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] All tests are passing.
* [x] The new code doesn't generate RuboCop offenses.
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.

[1]: http://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html