### PR TITLE
Fix disabling of autocorrect for unsafe rules by default.

### DIFF
--- a/config/enabled.yml
+++ b/config/enabled.yml
@@ -557,10 +557,10 @@ Style/NumericPredicate:
                  Checks for the use of predicate- or comparison methods for
                  numeric comparisons.
   StyleGuide: '#predicate-methods'
-  # This will change to a new a method call which isn't guaranteed to be on the
+  # This will change to a new method call which isn't guaranteed to be on the
   # object. Switching these methods has to be done with knowledge of the types
   # of the variables which rubocop doesn't have.
-  Autocorrect: false
+  AutoCorrect: false
   Enabled: true
 
 Style/OneLineConditional:
@@ -1315,10 +1315,10 @@ Performance/DoubleStartEndWith:
 Performance/EndWith:
   Description: 'Use `end_with?` instead of a regex match anchored to the end of a string.'
   Reference: 'https://github.com/JuanitoFatas/fast-ruby#stringmatch-vs-stringstart_withstringend_with-code-start-code-end'
-  # This will change to a new a method call which isn't guaranteed to be on the
+  # This will change to a new method call which isn't guaranteed to be on the
   # object. Switching these methods has to be done with knowledge of the types
   # of the variables which rubocop doesn't have.
-  Autocorrect: false
+  AutoCorrect: false
   Enabled: true
 
 Performance/FixedSize:
@@ -1401,10 +1401,10 @@ Performance/SortWithBlock:
 Performance/StartWith:
   Description: 'Use `start_with?` instead of a regex match anchored to the beginning of a string.'
   Reference: 'https://github.com/JuanitoFatas/fast-ruby#stringmatch-vs-stringstart_withstringend_with-code-start-code-end'
-  # This will change to a new a method call which isn't guaranteed to be on the
+  # This will change to a new method call which isn't guaranteed to be on the
   # object. Switching these methods has to be done with knowledge of the types
   # of the variables which rubocop doesn't have.
-  Autocorrect: false
+  AutoCorrect: false
   Enabled: true
 
 Performance/StringReplacement:

--- a/spec/rubocop/cop/style/numeric_predicate_spec.rb
+++ b/spec/rubocop/cop/style/numeric_predicate_spec.rb
@@ -41,7 +41,9 @@ describe RuboCop::Cop::Style::NumericPredicate, :config do
   end
 
   context 'when configured to enforce numeric predicate methods' do
-    let(:cop_config) { { 'EnforcedStyle' => 'predicate' } }
+    let(:cop_config) do
+      { 'EnforcedStyle' => 'predicate', 'AutoCorrect' => true }
+    end
 
     context 'when checking if a number is zero' do
       it_behaves_like 'code with offense',
@@ -145,7 +147,9 @@ describe RuboCop::Cop::Style::NumericPredicate, :config do
   end
 
   context 'when configured to enforce numeric comparison methods' do
-    let(:cop_config) { { 'EnforcedStyle' => 'comparison' } }
+    let(:cop_config) do
+      { 'EnforcedStyle' => 'comparison', 'AutoCorrect' => true }
+    end
 
     context 'when checking if a number is zero' do
       it_behaves_like 'code with offense',


### PR DESCRIPTION
This fixes PR#3398 which was supposed to disable these cops but accidentally used the wrong name for the config option.

I don't think this needs a CHANGELOG entry 'cause the previous work haven't been in an actual release yet.

Also slightly changed the comment for each of these cop configs because _this will change to a new a method call_ doesn't make sense to me.

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Used the same coding conventions as the rest of the project.
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [ ] Added tests.
* [ ] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] All tests are passing.
* [x] The new code doesn't generate RuboCop offenses.
* [ ] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.