### PR TITLE
[Fix #3566] Add new `Metrics/BlockLength` cop. 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 * [#3370](https://github.com/bbatsov/rubocop/issues/3370): Add new `Rails/HttpPositionalArguments` cop to check your Rails 5 test code for existence of positional args usage. ([@logicminds][])
 * [#3510](https://github.com/bbatsov/rubocop/issues/3510): Add a configuration option, `ConvertCodeThatCanStartToReturnNil`, to `Style/SafeNavigation` to check for code that could start returning `nil` if safe navigation is used. ([@rrosenblum][])
 * Add a new `AllCops/StyleGuideBaseURL` setting that allows the use of relative paths and/or fragments within each cop's `StyleGuide` setting, to make forking of custom style guides easier. ([@scottmatthewman][])
+* [#3566](https://github.com/bbatsov/rubocop/issues/3566): Add new `Metric/BlockLength` cop to ensure blocks don't get too long. ([@savef][])
 
 ### Bug fixes
 

--- a/config/default.yml
+++ b/config/default.yml
@@ -1122,6 +1122,14 @@ Metrics/MethodLength:
   CountComments: false  # count full line comments?
   Max: 10
 
+Metrics/BlockLength:
+  CountComments: false  # count full line comments?
+  Max: 25
+  Exclude:
+    - 'Rakefile'
+    - '**/*.rake'
+    - 'spec/**/*.rb'
+
 Metrics/ParameterLists:
   Max: 5
   CountKeywordArgs: true

--- a/config/enabled.yml
+++ b/config/enabled.yml
@@ -991,6 +991,10 @@ Metrics/MethodLength:
   StyleGuide: '#short-methods'
   Enabled: true
 
+Metrics/BlockLength:
+  Description: 'Avoid long blocks with many lines.'
+  Enabled: true
+
 Metrics/ParameterLists:
   Description: 'Avoid parameter lists longer than three or four parameters.'
   StyleGuide: '#too-many-params'

--- a/lib/rubocop.rb
+++ b/lib/rubocop.rb
@@ -148,6 +148,7 @@ require 'rubocop/cop/lint/void'
 
 require 'rubocop/cop/metrics/cyclomatic_complexity'
 require 'rubocop/cop/metrics/abc_size' # relies on cyclomatic_complexity
+require 'rubocop/cop/metrics/block_length'
 require 'rubocop/cop/metrics/block_nesting'
 require 'rubocop/cop/metrics/class_length'
 require 'rubocop/cop/metrics/line_length'

--- a/lib/rubocop.rb
+++ b/lib/rubocop.rb
@@ -87,6 +87,7 @@ require 'rubocop/cop/mixin/space_inside' # relies on surrounding_space
 require 'rubocop/cop/mixin/statement_modifier'
 require 'rubocop/cop/mixin/string_help'
 require 'rubocop/cop/mixin/string_literals_help'
+require 'rubocop/cop/mixin/too_many_lines'
 require 'rubocop/cop/mixin/trailing_comma'
 require 'rubocop/cop/mixin/unused_argument'
 

--- a/lib/rubocop/cop/metrics/block_length.rb
+++ b/lib/rubocop/cop/metrics/block_length.rb
@@ -7,7 +7,9 @@ module RuboCop
       # Comment lines can optionally be ignored.
       # The maximum allowed length is configurable.
       class BlockLength < Cop
-        include CodeLength
+        include TooManyLines
+
+        LABEL = 'Block'.freeze
 
         def on_block(node)
           check_code_length(node)
@@ -15,14 +17,8 @@ module RuboCop
 
         private
 
-        def message(length, max_length)
-          format('Block has too many lines. [%d/%d]', length, max_length)
-        end
-
-        def code_length(node)
-          lines = node.source.lines.to_a[1..-2] || []
-
-          lines.count { |line| !irrelevant_line(line) }
+        def cop_label
+          LABEL
         end
       end
     end

--- a/lib/rubocop/cop/metrics/block_length.rb
+++ b/lib/rubocop/cop/metrics/block_length.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+module RuboCop
+  module Cop
+    module Metrics
+      # This cop checks if the length of a block exceeds some maximum value.
+      # Comment lines can optionally be ignored.
+      # The maximum allowed length is configurable.
+      class BlockLength < Cop
+        include CodeLength
+
+        def on_block(node)
+          check_code_length(node)
+        end
+
+        private
+
+        def message(length, max_length)
+          format('Block has too many lines. [%d/%d]', length, max_length)
+        end
+
+        def code_length(node)
+          lines = node.source.lines.to_a[1..-2] || []
+
+          lines.count { |line| !irrelevant_line(line) }
+        end
+      end
+    end
+  end
+end

--- a/lib/rubocop/cop/metrics/method_length.rb
+++ b/lib/rubocop/cop/metrics/method_length.rb
@@ -8,7 +8,9 @@ module RuboCop
       # The maximum allowed length is configurable.
       class MethodLength < Cop
         include OnMethodDef
-        include CodeLength
+        include TooManyLines
+
+        LABEL = 'Method'.freeze
 
         private
 
@@ -16,14 +18,8 @@ module RuboCop
           check_code_length(node)
         end
 
-        def message(length, max_length)
-          format('Method has too many lines. [%d/%d]', length, max_length)
-        end
-
-        def code_length(node)
-          lines = node.source.lines.to_a[1..-2] || []
-
-          lines.count { |line| !irrelevant_line(line) }
+        def cop_label
+          LABEL
         end
       end
     end

--- a/lib/rubocop/cop/mixin/code_length.rb
+++ b/lib/rubocop/cop/mixin/code_length.rb
@@ -14,7 +14,7 @@ module RuboCop
         cop_config['CountComments']
       end
 
-      def check_code_length(node, *_)
+      def check_code_length(node)
         length = code_length(node)
         return unless length > max_length
 

--- a/lib/rubocop/cop/mixin/too_many_lines.rb
+++ b/lib/rubocop/cop/mixin/too_many_lines.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+module RuboCop
+  module Cop
+    # Common functionality for checking for too many lines.
+    module TooManyLines
+      include ConfigurableMax
+      include CodeLength
+
+      MSG = '%s has too many lines. [%d/%d]'.freeze
+
+      private
+
+      def message(length, max_length)
+        format(MSG, cop_label, length, max_length)
+      end
+
+      def code_length(node)
+        lines = node.source.lines.to_a[1...-1] || []
+
+        lines.count { |line| !irrelevant_line(line) }
+      end
+    end
+  end
+end

--- a/spec/rubocop/cop/metrics/block_length_spec.rb
+++ b/spec/rubocop/cop/metrics/block_length_spec.rb
@@ -1,0 +1,100 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+describe RuboCop::Cop::Metrics::BlockLength, :config do
+  subject(:cop) { described_class.new(config) }
+  let(:cop_config) { { 'Max' => 2, 'CountComments' => false } }
+
+  it 'rejects a block with more than 5 lines' do
+    inspect_source(cop, ['something do',
+                         '  a = 1',
+                         '  a = 2',
+                         '  a = 3',
+                         'end'])
+    expect(cop.offenses.size).to eq(1)
+    expect(cop.offenses.map(&:line).sort).to eq([1])
+    expect(cop.config_to_allow_offenses).to eq('Max' => 3)
+  end
+
+  it 'reports the correct beginning and end lines' do
+    inspect_source(cop, ['something do',
+                         '  a = 1',
+                         '  a = 2',
+                         '  a = 3',
+                         'end'])
+    offense = cop.offenses.first
+    expect(offense.location.first_line).to eq(1)
+    expect(offense.location.last_line).to eq(5)
+  end
+
+  it 'accepts a block with less than 3 lines' do
+    inspect_source(cop, ['something do',
+                         '  a = 1',
+                         '  a = 2',
+                         'end'])
+    expect(cop.offenses).to be_empty
+  end
+
+  it 'does not count blank lines' do
+    inspect_source(cop, ['something do',
+                         '  a = 1',
+                         '',
+                         '',
+                         '  a = 4',
+                         'end'])
+    expect(cop.offenses).to be_empty
+  end
+
+  it 'accepts empty blocks' do
+    inspect_source(cop, ['something do',
+                         'end'])
+    expect(cop.offenses).to be_empty
+  end
+
+  it 'rejects brace blocks too' do
+    inspect_source(cop, ['something {',
+                         '  a = 1',
+                         '  a = 2',
+                         '  a = 3',
+                         '}'])
+    expect(cop.offenses.size).to eq(1)
+  end
+
+  it 'properly counts nested blocks' do
+    inspect_source(cop, ['something do',
+                         '  something do',
+                         '    a = 2',
+                         '    a = 3',
+                         '    a = 4',
+                         '    a = 5',
+                         '  end',
+                         'end'])
+    expect(cop.offenses.size).to eq(2)
+    expect(cop.offenses.map(&:line).sort).to eq([1, 2])
+  end
+
+  it 'does not count commented lines by default' do
+    inspect_source(cop, ['something do',
+                         '  a = 1',
+                         '  #a = 2',
+                         '  #a = 3',
+                         '  a = 4',
+                         'end'])
+    expect(cop.offenses).to be_empty
+  end
+
+  context 'when CountComments is enabled' do
+    before { cop_config['CountComments'] = true }
+
+    it 'also counts commented lines' do
+      inspect_source(cop, ['something do',
+                           '  a = 1',
+                           '  #a = 2',
+                           '  a = 3',
+                           'end'])
+      expect(cop.offenses.size).to eq(1)
+      expect(cop.offenses.map(&:line).sort).to eq([1])
+    end
+  end
+end

--- a/spec/rubocop/cop/metrics/block_length_spec.rb
+++ b/spec/rubocop/cop/metrics/block_length_spec.rb
@@ -15,6 +15,7 @@ describe RuboCop::Cop::Metrics::BlockLength, :config do
     expect(cop.offenses.size).to eq(1)
     expect(cop.offenses.map(&:line).sort).to eq([1])
     expect(cop.config_to_allow_offenses).to eq('Max' => 3)
+    expect(cop.messages.first).to eq('Block has too many lines. [3/2]')
   end
 
   it 'reports the correct beginning and end lines' do

--- a/spec/rubocop/cop/metrics/method_length_spec.rb
+++ b/spec/rubocop/cop/metrics/method_length_spec.rb
@@ -18,6 +18,7 @@ describe RuboCop::Cop::Metrics::MethodLength, :config do
     expect(cop.offenses.size).to eq(1)
     expect(cop.offenses.map(&:line).sort).to eq([1])
     expect(cop.config_to_allow_offenses).to eq('Max' => 6)
+    expect(cop.messages.first).to eq('Method has too many lines. [6/5]')
   end
 
   it 'reports the correct beginning and end lines' do


### PR DESCRIPTION
This cop checks there aren't too many lines in blocks, much like `Metric/MethodLength` checks for too many lines in methods.

By default the max lines has been set to 25 which seems a decent starting point as the Rubocop library passes without having to change our config file (but only due to the default excluded files).

The cop is excluded from checking the `Rakefile`, all `.rake` files, and all Ruby files in `spec` by default. All of these are pretty much intended to be large blocks, the length of classes or modules, and will easily breach a lowish limit.

I've left this as 2 separate commits, the first of which adds the cop, and the second of which refactors shared parts into a mixin. I'm not sure if there's a nicer way to make each cop's message work without having to have a method in each cop to pass its _label_ through, like [this](https://github.com/bbatsov/rubocop/commit/5e7ec0a4e705e107e0ff40ffbaaf0909d40bb66e#diff-a64b3e014b24e7468d72040c8c5f2243R20).

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [ ] Used the same coding conventions as the rest of the project.
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [ ] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] All tests are passing.
* [x] The new code doesn't generate RuboCop offenses.
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.