### PR TITLE
Add a test to check cop message style

### DIFF
--- a/lib/rubocop/cop/lint/shadowed_exception.rb
+++ b/lib/rubocop/cop/lint/shadowed_exception.rb
@@ -27,7 +27,7 @@ module RuboCop
       #     handle_exception
       #   end
       class ShadowedException < Cop
-        MSG = 'Do not shadow rescued Exceptions'.freeze
+        MSG = 'Do not shadow rescued Exceptions.'.freeze
 
         def on_rescue(node)
           return if rescue_modifier?(node)

--- a/lib/rubocop/cop/rails/not_null_column.rb
+++ b/lib/rubocop/cop/rails/not_null_column.rb
@@ -14,7 +14,7 @@ module RuboCop
       #   add_column :users, :name, :string, null: true
       #   add_column :users, :name, :string, null: false, default: ''
       class NotNullColumn < Cop
-        MSG = 'Do not add a NOT NULL column without a default value'.freeze
+        MSG = 'Do not add a NOT NULL column without a default value.'.freeze
 
         def_node_matcher :add_not_null_column?, <<-PATTERN
           (send nil :add_column _ _ _ (hash $...))

--- a/lib/rubocop/cop/rails/output_safety.rb
+++ b/lib/rubocop/cop/rails/output_safety.rb
@@ -27,7 +27,7 @@ module RuboCop
       #
       class OutputSafety < Cop
         MSG = 'Tagging a string as html safe may be a security risk, ' \
-              'prefer `safe_join` or other Rails tag helpers instead'.freeze
+              'prefer `safe_join` or other Rails tag helpers instead.'.freeze
 
         def on_send(node)
           receiver, method_name, *_args = *node

--- a/lib/rubocop/cop/rails/uniq_before_pluck.rb
+++ b/lib/rubocop/cop/rails/uniq_before_pluck.rb
@@ -35,7 +35,7 @@ module RuboCop
       # false positives.
       #
       class UniqBeforePluck < RuboCop::Cop::Cop
-        MSG = 'Use `%s` before `pluck`'.freeze
+        MSG = 'Use `%s` before `pluck`.'.freeze
         NEWLINE = "\n".freeze
         PATTERN = '[!^block (send (send %s :pluck ...) ${:uniq :distinct} ...)]'
                   .freeze

--- a/spec/project_spec.rb
+++ b/spec/project_spec.rb
@@ -23,6 +23,21 @@ describe 'RuboCop Project' do
     end
   end
 
+  describe 'cop message' do
+    let(:cops) { RuboCop::Cop::Cop.all }
+
+    it 'end with a period or a question mark' do
+      cops.each do |cop|
+        begin
+          msg = cop.const_get(:MSG)
+        rescue NameError
+          next
+        end
+        expect(msg).to match(/\.|\?|(?:\[.+\])|%s$/)
+      end
+    end
+  end
+
   describe 'changelog' do
     subject(:changelog) do
       path = File.join(File.dirname(__FILE__), '..', 'CHANGELOG.md')

--- a/spec/rubocop/cop/lint/shadowed_exception_spec.rb
+++ b/spec/rubocop/cop/lint/shadowed_exception_spec.rb
@@ -72,7 +72,7 @@ describe RuboCop::Cop::Lint::ShadowedException do
                            '  handle_exception',
                            'end'])
 
-      expect(cop.messages).to eq(['Do not shadow rescued Exceptions'])
+      expect(cop.messages).to eq(['Do not shadow rescued Exceptions.'])
     end
 
     it 'accepts rescuing a single exception that is assigned to a variable' do
@@ -130,7 +130,7 @@ describe RuboCop::Cop::Lint::ShadowedException do
                              '  foo',
                              'end'])
 
-        expect(cop.messages).to eq(['Do not shadow rescued Exceptions'])
+        expect(cop.messages).to eq(['Do not shadow rescued Exceptions.'])
         expect(cop.highlights).to eq(['rescue StandardError, NameError'])
       end
 
@@ -141,7 +141,7 @@ describe RuboCop::Cop::Lint::ShadowedException do
                              '  foo',
                              'end'])
 
-        expect(cop.messages).to eq(['Do not shadow rescued Exceptions'])
+        expect(cop.messages).to eq(['Do not shadow rescued Exceptions.'])
         expect(cop.highlights)
           .to eq(['rescue StandardError, NameError, NoMethodError'])
       end
@@ -154,7 +154,7 @@ describe RuboCop::Cop::Lint::ShadowedException do
                            '  foo',
                            'end'])
 
-      expect(cop.messages).to eq(['Do not shadow rescued Exceptions'])
+      expect(cop.messages).to eq(['Do not shadow rescued Exceptions.'])
       expect(cop.highlights)
         .to eq(['rescue NameError, NameError'])
     end
@@ -197,7 +197,7 @@ describe RuboCop::Cop::Lint::ShadowedException do
                            '  b',
                            'end'])
 
-      expect(cop.messages).to eq(['Do not shadow rescued Exceptions'])
+      expect(cop.messages).to eq(['Do not shadow rescued Exceptions.'])
       expect(cop.highlights).to eq(['rescue nil, StandardError, Exception'])
     end
   end
@@ -213,7 +213,7 @@ describe RuboCop::Cop::Lint::ShadowedException do
                            '  handle_standard_error',
                            'end'])
 
-      expect(cop.messages).to eq(['Do not shadow rescued Exceptions'])
+      expect(cop.messages).to eq(['Do not shadow rescued Exceptions.'])
       expect(cop.highlights).to eq([['rescue Exception',
                                      '  handle_exception',
                                      'rescue StandardError'].join("\n")])
@@ -230,7 +230,7 @@ describe RuboCop::Cop::Lint::ShadowedException do
                            '  handle_standard_error',
                            'end'])
 
-      expect(cop.messages).to eq(['Do not shadow rescued Exceptions'])
+      expect(cop.messages).to eq(['Do not shadow rescued Exceptions.'])
       expect(cop.highlights).to eq([['rescue Exception',
                                      '  handle_exception',
                                      'rescue NoMethodError, ZeroDivisionError']
@@ -249,7 +249,7 @@ describe RuboCop::Cop::Lint::ShadowedException do
                            '  everything_is_ok',
                            'end'])
 
-      expect(cop.messages).to eq(['Do not shadow rescued Exceptions'])
+      expect(cop.messages).to eq(['Do not shadow rescued Exceptions.'])
       expect(cop.highlights).to eq([['rescue Exception',
                                      '  handle_exception',
                                      'rescue StandardError'].join("\n")])
@@ -363,7 +363,7 @@ describe RuboCop::Cop::Lint::ShadowedException do
                              '  c',
                              'end'])
 
-        expect(cop.messages).to eq(['Do not shadow rescued Exceptions'])
+        expect(cop.messages).to eq(['Do not shadow rescued Exceptions.'])
         expect(cop.highlights).to eq([['rescue Exception',
                                        '  b',
                                        'rescue *BAR'].join("\n")])
@@ -467,7 +467,7 @@ describe RuboCop::Cop::Lint::ShadowedException do
                            '  c',
                            'end'])
 
-      expect(cop.messages).to eq(['Do not shadow rescued Exceptions'])
+      expect(cop.messages).to eq(['Do not shadow rescued Exceptions.'])
       expect(cop.highlights).to eq([['rescue Exception',
                                      '  b',
                                      'rescue UnknownException'].join("\n")])

--- a/spec/rubocop/cop/rails/not_null_column_spec.rb
+++ b/spec/rubocop/cop/rails/not_null_column_spec.rb
@@ -16,7 +16,7 @@ describe RuboCop::Cop::Rails::NotNullColumn, :config do
       it 'reports an offense' do
         expect(cop.offenses.size).to eq(1)
         expect(cop.messages).to eq(
-          ['Do not add a NOT NULL column without a default value']
+          ['Do not add a NOT NULL column without a default value.']
         )
       end
     end
@@ -35,7 +35,7 @@ describe RuboCop::Cop::Rails::NotNullColumn, :config do
       it 'reports an offense' do
         expect(cop.offenses.size).to eq(1)
         expect(cop.messages).to eq(
-          ['Do not add a NOT NULL column without a default value']
+          ['Do not add a NOT NULL column without a default value.']
         )
       end
     end

--- a/spec/rubocop/cop/rails/uniq_before_pluck_spec.rb
+++ b/spec/rubocop/cop/rails/uniq_before_pluck_spec.rb
@@ -10,7 +10,7 @@ describe RuboCop::Cop::Rails::UniqBeforePluck, :config do
       if action == :correct
         it "finds the use of #{method} after pluck in #{source}" do
           inspect_source(cop, source)
-          expect(cop.messages).to eq(["Use `#{method}` before `pluck`"])
+          expect(cop.messages).to eq(["Use `#{method}` before `pluck`."])
           expect(cop.highlights).to eq([method])
           corrected_source = corrected || "Model.#{method}.pluck(:id)"
           expect(autocorrect_source(cop, source)).to eq(corrected_source)


### PR DESCRIPTION
Add a project spec.
This spec checks cop message style.

For example

```ruby
# good
MSG = 'Do not shadow rescued Exceptions.'
MSG = 'Avoid rescuing the `Exception` class. Perhaps you meant to rescue `StandardError`?'
MSG = 'Cyclomatic complexity for %s is too high. [%d/%d]'
MSG = '%s comma after the last %s'

# bad
MSG = 'Do not shadow rescued Exceptions'
```

e.g. https://github.com/bbatsov/rubocop/pull/3588#discussion_r82498148

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Used the same coding conventions as the rest of the project.
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [ ] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] All tests are passing.
* [x] The new code doesn't generate RuboCop offenses.
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.

[1]: http://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html

