### PR TITLE
RedundantReturn looks for redundant return inside conditional branches

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,7 @@
 * [#3503](https://github.com/bbatsov/rubocop/issues/3503): Change misleading message of `Style/EmptyLinesAroundAccessModifier`. ([@bquorning][])
 * [#3407](https://github.com/bbatsov/rubocop/issues/3407): Turn off autocorrect for unsafe rules by default. ([@ptarjan][])
 * [#3521](https://github.com/bbatsov/rubocop/issues/3521): Turn off autocorrect for `Security/JSONLoad` by default. ([@savef][])
+* [#2903](https://github.com/bbatsov/rubocop/issues/2903): `Style/RedundantReturn` looks for redundant `return` inside conditional branches. ([@lumeet][])
 
 ## 0.43.0 (2016-09-19)
 

--- a/lib/rubocop/cop/style/numeric_literal_prefix.rb
+++ b/lib/rubocop/cop/style/numeric_literal_prefix.rb
@@ -50,13 +50,11 @@ module RuboCop
         end
 
         def octal_literal_type(literal)
-          # rubocop:disable Style/GuardClause
           if literal =~ OCTAL_ZERO_ONLY_REGEX && octal_zero_only?
-            return :octal_zero_only
+            :octal_zero_only
           elsif literal =~ OCTAL_REGEX && !octal_zero_only?
-            return :octal
+            :octal
           end
-          # rubocop:enable Style/GuardClause
         end
 
         def hex_bin_dec_literal_type(literal)

--- a/spec/rubocop/cop/style/redundant_return_spec.rb
+++ b/spec/rubocop/cop/style/redundant_return_spec.rb
@@ -221,4 +221,66 @@ describe RuboCop::Cop::Style::RedundantReturn, :config do
       expect(new_source).to eq(src)
     end
   end
+
+  context 'when return is inside an if-branch' do
+    let(:src) do
+      ['def func',
+       '  if x',
+       '    return 1',
+       '  elsif y',
+       '    return 2',
+       '  else',
+       '    return 3',
+       '  end',
+       'end']
+    end
+
+    it 'registers an offense' do
+      inspect_source(cop, src)
+      expect(cop.offenses.size).to eq 3
+    end
+
+    it 'auto-corrects' do
+      corrected = autocorrect_source(cop, src)
+      expect(corrected).to eq ['def func',
+                               '  if x',
+                               '    1',
+                               '  elsif y',
+                               '    2',
+                               '  else',
+                               '    3',
+                               '  end',
+                               'end'].join("\n")
+    end
+  end
+
+  context 'when return is inside a when-branch' do
+    let(:src) do
+      ['def func',
+       '  case x',
+       '  when y then return 1',
+       '  when z then return 2',
+       '  else',
+       '    return 3',
+       '  end',
+       'end']
+    end
+
+    it 'registers an offense' do
+      inspect_source(cop, src)
+      expect(cop.offenses.size).to eq 3
+    end
+
+    it 'auto-corrects' do
+      corrected = autocorrect_source(cop, src)
+      expect(corrected).to eq ['def func',
+                               '  case x',
+                               '  when y then 1',
+                               '  when z then 2',
+                               '  else',
+                               '    3',
+                               '  end',
+                               'end'].join("\n")
+    end
+  end
 end


### PR DESCRIPTION
`Style/RedundantReturn` looks into conditional branches in order to
find redundant `return`. E.g. the following will be flagged:

    def func
      if x
        return 1
      else
        return 2
      end
    end

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Used the same coding conventions as the rest of the project.
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] All tests are passing.
* [x] The new code doesn't generate RuboCop offenses.
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.

[1]: http://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html