### PR TITLE
[Fix #3426] Fixes Style/RedundantParentheses for indexing with literals.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@
 * [#3390](https://github.com/bbatsov/rubocop/issues/3390): Fix SaveBang cop for multiple conditional. ([@tejasbubane][])
 * [#3577](https://github.com/bbatsov/rubocop/issues/3577): Fix `Style/RaiseArgs` not allowing compact raise with splatted args. ([@savef][])
 * [#3578](https://github.com/bbatsov/rubocop/issues/3578): Fix safe navigation method call counting in `Metrics/AbcSize`. ([@savef][])
+* [#3592](https://github.com/bbatsov/rubocop/issues/3592): Fix `Style/RedundantParentheses` for indexing with literals. ([@thegedge][])
 
 ### Changes
 
@@ -2408,3 +2409,4 @@
 [@tcdowney]: https://github.com/tcdowney
 [@logicminds]: https://github.com/logicminds
 [@abrom]: https://github.com/abrom
+[@thegedge]: https://github.com/thegedge

--- a/lib/rubocop/cop/style/redundant_parentheses.rb
+++ b/lib/rubocop/cop/style/redundant_parentheses.rb
@@ -18,7 +18,8 @@ module RuboCop
 
         ALLOWED_LITERALS = [:irange, :erange].freeze
 
-        def_node_matcher :square_brackets?, '(send (send _recv _msg) :[] ...)'
+        def_node_matcher :square_brackets?,
+                         '(send {(send _recv _msg) str array hash} :[] ...)'
         def_node_matcher :range_end?, '^^{irange erange}'
         def_node_matcher :method_node_and_args, '$(send _recv _msg $...)'
         def_node_matcher :rescue?, '{^resbody ^^resbody}'

--- a/spec/rubocop/cop/style/redundant_parentheses_spec.rb
+++ b/spec/rubocop/cop/style/redundant_parentheses_spec.rb
@@ -90,6 +90,9 @@ describe RuboCop::Cop::Style::RedundantParentheses do
   it_behaves_like 'redundant', '(x(1, 2))', 'x(1, 2)', 'a method call'
   it_behaves_like 'redundant', '("x".to_sym)', '"x".to_sym', 'a method call'
   it_behaves_like 'redundant', '(x[:y])', 'x[:y]', 'a method call'
+  it_behaves_like 'redundant', '("foo"[0])', '"foo"[0]', 'a method call'
+  it_behaves_like 'redundant', '(["foo"][0])', '["foo"][0]', 'a method call'
+  it_behaves_like 'redundant', '({0 => :a}[0])', '{0 => :a}[0]', 'a method call'
 
   it_behaves_like 'redundant', '(!x)', '!x', 'an unary operation'
   it_behaves_like 'redundant', '(~x)', '~x', 'an unary operation'


### PR DESCRIPTION
`Style/RedundantParentheses` would not report an offense when parentheses surrounded an indexing operation for a literal, but would work with a regular function call. This PR fixes this issue by also including strings, arrays, and hashes in the node matcher.

I stuck with the `a method call` offense, but perhaps there's a better wording (even though technically it _is_ a method call to `:[]`)?

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Used the same coding conventions as the rest of the project.
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] All tests are passing.
* [x] The new code doesn't generate RuboCop offenses.
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.

[1]: http://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html