### PR TITLE
Change merge driver for CHANGELOG.md to resolve conflict problem

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+CHANGELOG.md merge=union


### PR DESCRIPTION
Currently Problem
------

CHANGELOG.md is very often conflict when PR.
It's very troublesome.
e.g. https://github.com/bbatsov/rubocop/pull/3588#issuecomment-252417890

Solution
-----

I've added a `.gitattributes` file.
The file changes a merge driver to union for CHANGELOG.md.

The union driver has what it takes to merge CHANGELOG.md.
With the setting, CHANGELOG doesn't conflict!
Always both of the addition is chosen.

However, this solution has a problem.
GitHub doesn't support the feature.
So, We can't merge a PR at GitHub Web if CHANGELOG.md conflicts.

Don't worry, `hub` command supports the feature.
Maintainer can merge a conflicted PR by hub command.
For example.

```sh
$ git branch
* master
some-feature-branch-1

# merge a branch
$ hub merge https://github.com/bbatsov/rubocop/pull/xxxx # specify a PR url
# push merge commit and merge a PR in GitHub
$ git push
```

I think this method is not complete, but it is better than now.
What do you think?

More Information
-----

- http://krlmlr.github.io/using-gitattributes-to-avoid-merge-conflicts/



-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Used the same coding conventions as the rest of the project.
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [ ] Added tests.
* [ ] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] All tests are passing.
* [x] The new code doesn't generate RuboCop offenses.
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.

[1]: http://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html

