### PR TITLE
Change default args for`Style/SingleLineBlockParams`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,10 @@
 * [#3468](https://github.com/bbatsov/rubocop/issues/3468): Fix bug regarding alignment inside `begin`..`end` block in `Style/MultilineMethodCallIndentation`. ([@jonas054][])
 * [#3644](https://github.com/bbatsov/rubocop/pull/3644): Fix generation incorrect documentation. ([@pocke][])
 
+### Changes
+
+* [#3601](https://github.com/bbatsov/rubocop/pull/3601): Change default args for `Style/SingleLineBlockParams`. This cop checks that `reduce` and `inject` use the variable names `a` and `e` for block arguments. These defaults are uncommunicative variable names and thus conflict with the ["Uncommunicative Variable Name" check in Reek](https://github.com/troessner/reek/blob/master/docs/Uncommunicative-Variable-Name.md). Default args changed to `acc` and `elem`.([@jessieay][])
+
 ## 0.44.1 (2016-10-13)
 
 ### Bug fixes
@@ -2448,3 +2452,4 @@
 [@albus522]: https://github.com/albus522
 [@sihu]: https://github.com/sihu
 [@swcraig]: https://github.com/swcraig
+[@jessieay]: https://github.com/jessieay

--- a/config/default.yml
+++ b/config/default.yml
@@ -872,11 +872,11 @@ Style/SignalException:
 Style/SingleLineBlockParams:
   Methods:
     - reduce:
-        - a
-        - e
+        - acc
+        - elem
     - inject:
-        - a
-        - e
+        - acc
+        - elem
 
 Style/SingleLineMethods:
   AllowIfMethodIsEmpty: true

--- a/lib/rubocop/cop/lint/format_parameter_mismatch.rb
+++ b/lib/rubocop/cop/lint/format_parameter_mismatch.rb
@@ -117,7 +117,7 @@ module RuboCop
             .source
             .scan(FIELD_REGEX)
             .select { |x| x.first != PERCENT_PERCENT }
-            .reduce(0) { |a, e| a + (e[2] =~ /\*/ ? 2 : 1) }
+            .reduce(0) { |acc, elem| acc + (elem[2] =~ /\*/ ? 2 : 1) }
         end
 
         def format?(node)

--- a/lib/rubocop/cop/style/comment_annotation.rb
+++ b/lib/rubocop/cop/style/comment_annotation.rb
@@ -50,7 +50,7 @@ module RuboCop
         end
 
         def concat_length(*args)
-          args.reduce(0) { |a, e| a + e.to_s.length }
+          args.reduce(0) { |acc, elem| acc + elem.to_s.length }
         end
 
         def correct_annotation?(first_word, colon, space, note)


### PR DESCRIPTION
**Why**:
* This cop enforces block args of `a` and `e` by default
* This suggestion causes an "Uncommunicative Variable Name" error from
  Reek
* Source: https://github.com/troessner/reek/blob/master/docs/Uncommunicative-Variable-Name.md
* I tend to agree with Reek on this one. I like expressive variables.
* New default arg names: `acc` and `elem` per bbatsov#3601 (comment)