### PR TITLE
[Fix #3597] Fix the autocorrect of CaseWhenSplat

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,7 @@
 * [#3577](https://github.com/bbatsov/rubocop/issues/3577): Fix `Style/RaiseArgs` not allowing compact raise with splatted args. ([@savef][])
 * [#3578](https://github.com/bbatsov/rubocop/issues/3578): Fix safe navigation method call counting in `Metrics/AbcSize`. ([@savef][])
 * [#3592](https://github.com/bbatsov/rubocop/issues/3592): Fix `Style/RedundantParentheses` for indexing with literals. ([@thegedge][])
+* [#3597](https://github.com/bbatsov/rubocop/issues/3597): Fix the autocorrect of `Performance/CaseWhenSplat` when trying to rearange splat expanded variables to the end of a when condition. ([@rrosenblum][])
 
 ### Changes
 


### PR DESCRIPTION
This fixes #3597. The two issues that were mentioned seem to be related in that they occurred when there was a splat expansion and another variable in a single when condition. The cop has been updated to prevent the `NoMethodError` and to move splat expansions to the end of the condition list. The performance numbers backing moving the splat expansion to the end of single when condition are posted in the issue.