### PR TITLE
Remove pry from CaseWhenSplat

### DIFF
--- a/lib/rubocop/cop/performance/case_when_splat.rb
+++ b/lib/rubocop/cop/performance/case_when_splat.rb
@@ -1,6 +1,5 @@
 # frozen_string_literal: true
 
-require 'pry'
 module RuboCop
   module Cop
     module Performance


### PR DESCRIPTION
This commit removes 'require pry' from the CaseWhenSplat cop.

Since pry isn't in the dependencies, I was getting

```
...bundle/gems/rubocop-0.44.0/lib/rubocop/cop/performance/case_when_splat.rb:3:in `require': cannot load such file -- pry (LoadError)
	from ...bundle/gems/rubocop-0.44.0/lib/rubocop/cop/performance/case_when_splat.rb:3:in `<top (required)>'
	from ...bundle/gems/rubocop-0.44.0/lib/rubocop.rb:161:in `require'
	from ...bundle/gems/rubocop-0.44.0/lib/rubocop.rb:161:in `<top (required)>'
```
in fresh environments. All tests still pass.

Thanks for rubocop! It is a great help!