### PR TITLE
Fix `Style/RedundantReturn` cop for empty if body

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## master (unreleased)
 
+### Bug fixes
+
+* [#3607](https://github.com/bbatsov/rubocop/pull/3607): Fix `Style/RedundantReturn` cop for empty if body. ([@pocke][])
+
 ## 0.44.1 (2016-10-13)
 
 ### Bugs fixed

--- a/lib/rubocop/cop/style/redundant_return.rb
+++ b/lib/rubocop/cop/style/redundant_return.rb
@@ -106,7 +106,7 @@ module RuboCop
           return if modifier_if?(node) || ternary?(node)
 
           _cond, if_node, else_node = if_node_parts(node)
-          check_branch(if_node)
+          check_branch(if_node) if if_node
           check_branch(else_node) if else_node
         end
 

--- a/spec/rubocop/cop/style/redundant_return_spec.rb
+++ b/spec/rubocop/cop/style/redundant_return_spec.rb
@@ -57,6 +57,17 @@ describe RuboCop::Cop::Style::RedundantReturn, :config do
     expect(cop.offenses).to be_empty
   end
 
+  it 'does not blow up on empty if body' do
+    src = ['def func',
+           '  if x',
+           '  elsif y',
+           '  else',
+           '  end',
+           'end']
+    inspect_source(cop, src)
+    expect(cop.offenses).to be_empty
+  end
+
   it 'auto-corrects by removing redundant returns' do
     src = ['def func',
            '  one',


### PR DESCRIPTION


Problem
-------

`Style/RedundantReturn` cop crashes with empty if body.

e.g.

```ruby
# test.rb
def func
  if x
  elsif y
  else
  end
end
```

```
$ rubocop --only Style/RedundantReturn -d 2>&1
WARN: Unresolved specs during Gem::Specification.reset:
      ruby-progressbar (~> 1.7)
WARN: Clearing out unresolved specs.
Please report a bug if this causes problems.
An error occurred while Style/RedundantReturn cop was inspecting /tmp/tmp.rETz68SjL6/test.rb.

1 error occurred:
An error occurred while Style/RedundantReturn cop was inspecting /tmp/tmp.rETz68SjL6/test.rb.
Errors are usually caused by RuboCop bugs.
Please, report your problems to RuboCop's issue tracker.
Mention the following information in the issue report:
0.44.0 (using Parser 2.3.1.3, running on ruby 2.3.1 x86_64-linux)
For /tmp/tmp.rETz68SjL6: configuration from /home/pocke/.gem/ruby/2.3.0/gems/rubocop-0.44.0/config/default.yml
Inheriting configuration from /home/pocke/.gem/ruby/2.3.0/gems/rubocop-0.44.0/config/enabled.yml
Inheriting configuration from /home/pocke/.gem/ruby/2.3.0/gems/rubocop-0.44.0/config/disabled.yml
Inspecting 1 file
Scanning /tmp/tmp.rETz68SjL6/test.rb
undefined method `type' for nil:NilClass
/home/pocke/.gem/ruby/2.3.0/gems/rubocop-0.44.0/lib/rubocop/cop/style/redundant_return.rb:79:in `check_branch'
/home/pocke/.gem/ruby/2.3.0/gems/rubocop-0.44.0/lib/rubocop/cop/style/redundant_return.rb:109:in `check_if_node'
/home/pocke/.gem/ruby/2.3.0/gems/rubocop-0.44.0/lib/rubocop/cop/style/redundant_return.rb:82:in `check_branch'
/home/pocke/.gem/ruby/2.3.0/gems/rubocop-0.44.0/lib/rubocop/cop/style/redundant_return.rb:75:in `on_method_def'
/home/pocke/.gem/ruby/2.3.0/gems/rubocop-0.44.0/lib/rubocop/cop/mixin/on_method_def.rb:9:in `on_def'
/home/pocke/.gem/ruby/2.3.0/gems/rubocop-0.44.0/lib/rubocop/cop/commissioner.rb:41:in `block (2 levels) in on_def'
/home/pocke/.gem/ruby/2.3.0/gems/rubocop-0.44.0/lib/rubocop/cop/commissioner.rb:96:in `with_cop_error_handling'
/home/pocke/.gem/ruby/2.3.0/gems/rubocop-0.44.0/lib/rubocop/cop/commissioner.rb:40:in `block in on_def'
/home/pocke/.gem/ruby/2.3.0/gems/rubocop-0.44.0/lib/rubocop/cop/commissioner.rb:39:in `each'
/home/pocke/.gem/ruby/2.3.0/gems/rubocop-0.44.0/lib/rubocop/cop/commissioner.rb:39:in `on_def'
/home/pocke/.gem/ruby/2.3.0/gems/rubocop-0.44.0/lib/rubocop/ast_node/traversal.rb:12:in `walk'
/home/pocke/.gem/ruby/2.3.0/gems/rubocop-0.44.0/lib/rubocop/cop/commissioner.rb:58:in `investigate'
/home/pocke/.gem/ruby/2.3.0/gems/rubocop-0.44.0/lib/rubocop/cop/team.rb:120:in `investigate'
/home/pocke/.gem/ruby/2.3.0/gems/rubocop-0.44.0/lib/rubocop/cop/team.rb:108:in `offenses'
/home/pocke/.gem/ruby/2.3.0/gems/rubocop-0.44.0/lib/rubocop/cop/team.rb:51:in `inspect_file'
/home/pocke/.gem/ruby/2.3.0/gems/rubocop-0.44.0/lib/rubocop/runner.rb:243:in `inspect_file'
/home/pocke/.gem/ruby/2.3.0/gems/rubocop-0.44.0/lib/rubocop/runner.rb:190:in `block in do_inspection_loop'
/home/pocke/.gem/ruby/2.3.0/gems/rubocop-0.44.0/lib/rubocop/runner.rb:222:in `block in iterate_until_no_changes'
/home/pocke/.gem/ruby/2.3.0/gems/rubocop-0.44.0/lib/rubocop/runner.rb:215:in `loop'
/home/pocke/.gem/ruby/2.3.0/gems/rubocop-0.44.0/lib/rubocop/runner.rb:215:in `iterate_until_no_changes'
/home/pocke/.gem/ruby/2.3.0/gems/rubocop-0.44.0/lib/rubocop/runner.rb:186:in `do_inspection_loop'
/home/pocke/.gem/ruby/2.3.0/gems/rubocop-0.44.0/lib/rubocop/runner.rb:101:in `block in file_offenses'
/home/pocke/.gem/ruby/2.3.0/gems/rubocop-0.44.0/lib/rubocop/runner.rb:111:in `file_offense_cache'
/home/pocke/.gem/ruby/2.3.0/gems/rubocop-0.44.0/lib/rubocop/runner.rb:99:in `file_offenses'
/home/pocke/.gem/ruby/2.3.0/gems/rubocop-0.44.0/lib/rubocop/runner.rb:90:in `process_file'
/home/pocke/.gem/ruby/2.3.0/gems/rubocop-0.44.0/lib/rubocop/runner.rb:68:in `block in each_inspected_file'
/home/pocke/.gem/ruby/2.3.0/gems/rubocop-0.44.0/lib/rubocop/runner.rb:65:in `each'
/home/pocke/.gem/ruby/2.3.0/gems/rubocop-0.44.0/lib/rubocop/runner.rb:65:in `reduce'
/home/pocke/.gem/ruby/2.3.0/gems/rubocop-0.44.0/lib/rubocop/runner.rb:65:in `each_inspected_file'
/home/pocke/.gem/ruby/2.3.0/gems/rubocop-0.44.0/lib/rubocop/runner.rb:57:in `inspect_files'
/home/pocke/.gem/ruby/2.3.0/gems/rubocop-0.44.0/lib/rubocop/runner.rb:36:in `run'
/home/pocke/.gem/ruby/2.3.0/gems/rubocop-0.44.0/lib/rubocop/cli.rb:71:in `execute_runner'
/home/pocke/.gem/ruby/2.3.0/gems/rubocop-0.44.0/lib/rubocop/cli.rb:27:in `run'
/home/pocke/.gem/ruby/2.3.0/gems/rubocop-0.44.0/bin/rubocop:13:in `block in <top (required)>'
/usr/lib/ruby/2.3.0/benchmark.rb:308:in `realtime'
/home/pocke/.gem/ruby/2.3.0/gems/rubocop-0.44.0/bin/rubocop:12:in `<top (required)>'
/home/pocke/.gem/ruby/2.3.0/bin/rubocop:23:in `load'
/home/pocke/.gem/ruby/2.3.0/bin/rubocop:23:in `<main>'
.

1 file inspected, no offenses detected
Finished in 0.13733735296409577 seconds
```

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Used the same coding conventions as the rest of the project.
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] All tests are passing.
* [x] The new code doesn't generate RuboCop offenses.
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.

[1]: http://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html




Happy birthday to you! :tada: 