### PR TITLE
[Fix #3291] Improve Rails safety method detection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Bug fixes
 
 * [#3607](https://github.com/bbatsov/rubocop/pull/3607): Fix `Style/RedundantReturn` cop for empty if body. ([@pocke][])
+* [#3291](https://github.com/bbatsov/rubocop/issues/3291): Improve detection of `raw` and `html_safe` methods in `Rails/OutputSafety`. ([@lumeet][])
 
 ## 0.44.1 (2016-10-13)
 

--- a/lib/rubocop/cop/rails/output_safety.rb
+++ b/lib/rubocop/cop/rails/output_safety.rb
@@ -30,13 +30,24 @@ module RuboCop
               'prefer `safe_join` or other Rails tag helpers instead.'.freeze
 
         def on_send(node)
-          receiver, method_name, *_args = *node
+          return unless looks_like_rails_html_safe?(node) ||
+                        looks_like_rails_raw?(node)
 
-          if receiver && method_name == :html_safe
-            add_offense(node, :selector)
-          elsif receiver.nil? && method_name == :raw
-            add_offense(node, :selector)
-          end
+          add_offense(node, :selector)
+        end
+
+        private
+
+        def looks_like_rails_html_safe?(node)
+          receiver, method_name, *args = *node
+
+          receiver && method_name == :html_safe && args.empty?
+        end
+
+        def looks_like_rails_raw?(node)
+          receiver, method_name, *args = *node
+
+          receiver.nil? && method_name == :raw && args.one?
         end
       end
     end

--- a/spec/rubocop/cop/rails/output_safety_spec.rb
+++ b/spec/rubocop/cop/rails/output_safety_spec.rb
@@ -5,35 +5,54 @@ require 'spec_helper'
 describe RuboCop::Cop::Rails::OutputSafety do
   subject(:cop) { described_class.new }
 
-  it 'records an offense for html_safe methods with a receiver' do
+  it 'registers an offense for html_safe methods with a receiver and no ' \
+     'arguments' do
     source = ['foo.html_safe',
               '"foo".html_safe']
     inspect_source(cop, source)
     expect(cop.offenses.size).to eq(2)
   end
 
-  it 'does not record an offense for html_safe methods without a receiver' do
-    source = ['html_safe foo',
-              'html_safe "foo"']
+  it 'accepts html_safe methods without a receiver' do
+    source = 'html_safe'
     inspect_source(cop, source)
     expect(cop.offenses).to be_empty
   end
 
-  it 'records an offense for raw methods without a receiver' do
+  it 'accepts html_safe methods with arguments' do
+    source = ['foo.html_safe one',
+              '"foo".html_safe two']
+    inspect_source(cop, source)
+    expect(cop.offenses).to be_empty
+  end
+
+  it 'registers an offense for raw methods without a receiver' do
     source = ['raw(foo)',
               'raw "foo"']
     inspect_source(cop, source)
     expect(cop.offenses.size).to eq(2)
   end
 
-  it 'does not record an offense for raw methods with a receiver' do
-    source = ['foo.raw',
-              '"foo".raw']
+  it 'accepts raw methods with a receiver' do
+    source = ['foo.raw(foo)',
+              '"foo".raw "foo"']
     inspect_source(cop, source)
     expect(cop.offenses).to be_empty
   end
 
-  it 'does not record an offense for comments' do
+  it 'accepts raw methods without arguments' do
+    source = 'raw'
+    inspect_source(cop, source)
+    expect(cop.offenses).to be_empty
+  end
+
+  it 'accepts raw methods with more than one arguments' do
+    source = 'raw one, two'
+    inspect_source(cop, source)
+    expect(cop.offenses).to be_empty
+  end
+
+  it 'accepts comments' do
     source = ['# foo.html_safe',
               '# raw foo']
     inspect_source(cop, source)


### PR DESCRIPTION
Only assume `raw` and `html_safe` to be a Rails helpers if calls have
one and zero arguments respectively.

Also unify related test descriptions.

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Used the same coding conventions as the rest of the project.
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] All tests are passing.
* [x] The new code doesn't generate RuboCop offenses.
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.

[1]: http://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html

