### PR TITLE
fix a breaking changelog spec

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@
 
 ### Bugs fixed
 
-* Remove a debug `require`.
+* Remove a debug `require`. ([@bbatsov][])
 
 ## 0.44.0 (2016-10-13)
 


### PR DESCRIPTION
The changelog spec was breaking due to an overly modest maintainer.

```
Failures:

  1) RuboCop Project changelog entry after version 0.14.0 has a link to the contributors at the end
     Failure/Error: expect(entry).to match(/\(\[@\S+\]\[\](?:, \[@\S+\]\[\])*\)$/)
     
       expected "* Remove a debug `require`." to match /\(\[@\S+\]\[\](?:, \[@\S+\]\[\])*\)$/
       Diff:
       @@ -1,2 +1,2 @@
       -/\(\[@\S+\]\[\](?:, \[@\S+\]\[\])*\)$/
       +"* Remove a debug `require`."
       
     # ./spec/project_spec.rb:73:in `block (6 levels) in <top (required)>'
     # ./spec/project_spec.rb:72:in `each'
     # ./spec/project_spec.rb:72:in `block (5 levels) in <top (required)>'

Finished in 16.59 seconds (files took 2.69 seconds to load)
11739 examples, 1 failure, 2 pending
```

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Used the same coding conventions as the rest of the project.
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [ ] Added tests.  (already tested)
* [x] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] All tests are passing.
* [x] The new code doesn't generate RuboCop offenses.
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.

[1]: http://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html

The changelog format spec wanted an attribution