### PR TITLE
Fix warning: indent block to match opening statement

### DIFF
--- a/lib/rubocop/cop/performance/case_when_splat.rb
+++ b/lib/rubocop/cop/performance/case_when_splat.rb
@@ -65,9 +65,9 @@ module RuboCop
           _case_branch, *when_branches, _else_branch = *node
           when_conditions =
             when_branches.each_with_object([]) do |branch, conditions|
-            *condition, _ = *branch
-            condition.each { |c| conditions << c }
-          end
+              *condition, _ = *branch
+              condition.each { |c| conditions << c }
+            end
 
           splat_offenses(when_conditions).reverse_each do |condition|
             range = condition.parent.loc.keyword.join(condition.source_range)


### PR DESCRIPTION
Fixes Rubocop warning:

```
Offenses:

lib/rubocop/cop/performance/case_when_splat.rb:70:11: W: end at 70, 10 is not aligned with when_branches.each_with_object([]) do |branch, conditions| at 67, 12.
          end
          ^^^

805 files inspected, 1 offense detected
```

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Used the same coding conventions as the rest of the project.
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [ ] Added tests.  (no need)
* [x] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] All tests are passing.
* [x] The new code doesn't generate RuboCop offenses.
* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.

[1]: http://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html


