### PR TITLE
Add autocorrection for `Lint/EmptyInterpolation`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## master (unreleased)
 
+### New features
+
+* [#3615](https://github.com/bbatsov/rubocop/pull/3615): Add autocorrection for `Lint/EmptyInterpolation`. ([@pocke][])
+
 ### Bug fixes
 
 * [#3607](https://github.com/bbatsov/rubocop/pull/3607): Fix `Style/RedundantReturn` cop for empty if body. ([@pocke][])

--- a/lib/rubocop/cop/lint/empty_interpolation.rb
+++ b/lib/rubocop/cop/lint/empty_interpolation.rb
@@ -16,6 +16,12 @@ module RuboCop
             add_offense(begin_node, :expression) if begin_node.children.empty?
           end
         end
+
+        def autocorrect(node)
+          lambda do |collector|
+            collector.remove(node.loc.expression)
+          end
+        end
       end
     end
   end

--- a/spec/rubocop/cop/lint/empty_interpolation_spec.rb
+++ b/spec/rubocop/cop/lint/empty_interpolation_spec.rb
@@ -11,8 +11,24 @@ describe RuboCop::Cop::Lint::EmptyInterpolation do
     expect(cop.highlights).to eq(['#{}'])
   end
 
+  it 'registers an offense for #{ } in interpolation' do
+    inspect_source(cop, '"this is the #{ }"')
+    expect(cop.offenses.size).to eq(1)
+    expect(cop.highlights).to eq(['#{ }'])
+  end
+
   it 'accepts non-empty interpolation' do
     inspect_source(cop, '"this is #{top} silly"')
     expect(cop.offenses).to be_empty
+  end
+
+  it 'autocorrects' do
+    new_source = autocorrect_source(cop, '"this is the #{}"')
+    expect(new_source).to eq('"this is the "')
+  end
+
+  it 'autocorrects' do
+    new_source = autocorrect_source(cop, '"this is the #{ }"')
+    expect(new_source).to eq('"this is the "')
   end
 end


### PR DESCRIPTION
Add an auto correction for `Lint/EmptyInterpolation`.


For example

```ruby
"hello #{}" # before

"hello "    # after
```

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Used the same coding conventions as the rest of the project.
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] All tests are passing.
* [x] The new code doesn't generate RuboCop offenses.
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.

[1]: http://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html

