### PR TITLE
make PercentLiteralDelimiters enforce %I() too

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### New features
 
 * [#3615](https://github.com/bbatsov/rubocop/pull/3615): Add autocorrection for `Lint/EmptyInterpolation`. ([@pocke][])
+* Make `PercentLiteralDelimiters` enforce delimiters around `%I()` too. ([@bronson][])
 
 ### Bug fixes
 
@@ -2435,3 +2436,4 @@
 [@jmks]: https://github.com/jmks/
 [@connorjacobsen]: https://github.com/connorjacobsen
 [@legendetm]: https://github.com/legendetm
+[@bronson]: https://github.com/bronson

--- a/config/default.yml
+++ b/config/default.yml
@@ -788,6 +788,7 @@ Style/PercentLiteralDelimiters:
   PreferredDelimiters:
     '%':  ()
     '%i': ()
+    '%I': ()
     '%q': ()
     '%Q': ()
     '%r': '{}'

--- a/lib/rubocop/cop/style/percent_literal_delimiters.rb
+++ b/lib/rubocop/cop/style/percent_literal_delimiters.rb
@@ -8,7 +8,7 @@ module RuboCop
         include PercentLiteral
 
         def on_array(node)
-          process(node, '%w', '%W', '%i')
+          process(node, '%w', '%W', '%i', '%I')
         end
 
         def on_regexp(node)

--- a/spec/rubocop/cop/style/percent_literal_delimiters_spec.rb
+++ b/spec/rubocop/cop/style/percent_literal_delimiters_spec.rb
@@ -10,6 +10,7 @@ describe RuboCop::Cop::Style::PercentLiteralDelimiters, :config do
       'PreferredDelimiters' => {
         '%'  => '[]',
         '%i' => '[]',
+        '%I' => '[]',
         '%q' => '[]',
         '%Q' => '[]',
         '%r' => '[]',
@@ -175,6 +176,28 @@ describe RuboCop::Cop::Style::PercentLiteralDelimiters, :config do
       inspect_source(cop, '%i(some symbols)')
       expect(cop.messages).to eq(
         ['`%i`-literals should be delimited by `[` and `]`.']
+      )
+    end
+  end
+
+  context '`%I` interpolated symbol array' do
+    it 'does not register an offense for preferred delimiters' do
+      inspect_source(cop, '%I[some words]')
+      expect(cop.offenses).to be_empty
+    end
+
+    it 'registers an offense for other delimiters' do
+      inspect_source(cop, '%I(some words)')
+      expect(cop.messages).to eq(
+        ['`%I`-literals should be delimited by `[` and `]`.']
+      )
+    end
+
+    it 'registers an offense for other delimiters ' \
+       'when containing preferred delimiter characters in interpolation' do
+      inspect_source(cop, '%I(#{[1].first})')
+      expect(cop.messages).to eq(
+        ['`%I`-literals should be delimited by `[` and `]`.']
       )
     end
   end


### PR DESCRIPTION
It seems only natural to watch over %I() usage too.

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Used the same coding conventions as the rest of the project.
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] All tests are passing.
* [x] The new code doesn't generate RuboCop offenses.
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.

[1]: http://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html

