### PR TITLE
Remove `ruby: 2` from rspec contexts

### DIFF
--- a/spec/rubocop/cop/lint/unused_block_argument_spec.rb
+++ b/spec/rubocop/cop/lint/unused_block_argument_spec.rb
@@ -162,7 +162,7 @@ describe RuboCop::Cop::Lint::UnusedBlockArgument, :config do
       end
     end
 
-    context 'when an optional keyword argument is unused', ruby: 2 do
+    context 'when an optional keyword argument is unused' do
       context 'when the method call is `define_method`' do
         let(:source) { <<-END }
           define_method(:foo) do |bar: 'default'|

--- a/spec/rubocop/cop/lint/unused_method_argument_spec.rb
+++ b/spec/rubocop/cop/lint/unused_method_argument_spec.rb
@@ -68,7 +68,7 @@ describe RuboCop::Cop::Lint::UnusedMethodArgument, :config do
       end
     end
 
-    context 'when an optional keyword argument is unused', ruby: 2 do
+    context 'when an optional keyword argument is unused' do
       let(:source) { <<-END }
         def self.some_method(foo, bar: 1)
           puts foo
@@ -319,7 +319,7 @@ describe RuboCop::Cop::Lint::UnusedMethodArgument, :config do
       end
     end
 
-    context 'when a keyword argument is unused', ruby: 2 do
+    context 'when a keyword argument is unused' do
       let(:source) { <<-END }
         def some_method(foo, bar: 1)
           puts foo

--- a/spec/rubocop/cop/metrics/parameter_lists_spec.rb
+++ b/spec/rubocop/cop/metrics/parameter_lists_spec.rb
@@ -25,7 +25,7 @@ describe RuboCop::Cop::Metrics::ParameterLists, :config do
   end
 
   context 'When CountKeywordArgs is true' do
-    it 'counts keyword arguments as well', ruby: 2 do
+    it 'counts keyword arguments as well' do
       inspect_source(cop, ['def meth(a, b, c, d: 1, e: 2)',
                            'end'])
       expect(cop.offenses.size).to eq(1)
@@ -35,7 +35,7 @@ describe RuboCop::Cop::Metrics::ParameterLists, :config do
   context 'When CountKeywordArgs is false' do
     before { cop_config['CountKeywordArgs'] = false }
 
-    it 'does not count keyword arguments', ruby: 2 do
+    it 'does not count keyword arguments' do
       inspect_source(cop, ['def meth(a, b, c, d: 1, e: 2)',
                            'end'])
       expect(cop.offenses).to be_empty

--- a/spec/rubocop/cop/style/percent_literal_delimiters_spec.rb
+++ b/spec/rubocop/cop/style/percent_literal_delimiters_spec.rb
@@ -165,7 +165,7 @@ describe RuboCop::Cop::Style::PercentLiteralDelimiters, :config do
     end
   end
 
-  context '`%i` symbol array', ruby: 2 do
+  context '`%i` symbol array' do
     it 'does not register an offense for preferred delimiters' do
       inspect_source(cop, '%i[some symbols]')
       expect(cop.offenses).to be_empty


### PR DESCRIPTION
They're redundant since Ruby 2.0 or higher is now mandatory

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Used the same coding conventions as the rest of the project.
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] All tests are passing.
* [x] The new code doesn't generate RuboCop offenses.
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.

[1]: http://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html

