### PR TITLE
Prefer square brackets for array literals instead of parens

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 * [#3615](https://github.com/bbatsov/rubocop/pull/3615): Add autocorrection for `Lint/EmptyInterpolation`. ([@pocke][])
 * Make `PercentLiteralDelimiters` enforce delimiters around `%I()` too. ([@bronson][])
+* Prefer square brackets for array literals to match the [updated style guide](https://github.com/bbatsov/ruby-style-guide/pull/563). ([@bronson][])
 
 ### Bug fixes
 

--- a/config/default.yml
+++ b/config/default.yml
@@ -787,14 +787,14 @@ Style/ParenthesesAroundCondition:
 Style/PercentLiteralDelimiters:
   PreferredDelimiters:
     '%':  ()
-    '%i': ()
-    '%I': ()
+    '%i': []
+    '%I': []
     '%q': ()
     '%Q': ()
-    '%r': '{}'
+    '%r': {}
     '%s': ()
-    '%w': ()
-    '%W': ()
+    '%w': []
+    '%W': []
     '%x': ()
 
 Style/PercentQLiterals:

--- a/lib/rubocop/ast_node.rb
+++ b/lib/rubocop/ast_node.rb
@@ -40,7 +40,7 @@ module RuboCop
                 :or, :postexe, :redo, :rescue, :retry, :return, :self, :super,
                 :zsuper, :then, :undef, :until, :when, :while, :yield].freeze
     OPERATOR_KEYWORDS = [:and, :or].freeze
-    SPECIAL_KEYWORDS = %w(__FILE__ __LINE__ __ENCODING__).freeze
+    SPECIAL_KEYWORDS = %w[__FILE__ __LINE__ __ENCODING__].freeze
 
     # def_matcher can be used to define a pattern-matching method on Node
     class << self

--- a/lib/rubocop/config.rb
+++ b/lib/rubocop/config.rb
@@ -13,8 +13,8 @@ module RuboCop
   class Config
     include PathUtil
 
-    COMMON_PARAMS = %w(Exclude Include Severity
-                       AutoCorrect StyleGuide Details).freeze
+    COMMON_PARAMS = %w[Exclude Include Severity
+                       AutoCorrect StyleGuide Details].freeze
     # 2.0 is the oldest officially supported Ruby version.
     DEFAULT_RUBY_VERSION = 2.0
     KNOWN_RUBIES = [1.9, 2.0, 2.1, 2.2, 2.3, 2.4].freeze
@@ -123,7 +123,7 @@ module RuboCop
     end
 
     def deprecation_check
-      %w(Exclude Include).each do |key|
+      %w[Exclude Include].each do |key|
         plural = "#{key}s"
         next unless for_all_cops[plural]
 

--- a/lib/rubocop/config_loader.rb
+++ b/lib/rubocop/config_loader.rb
@@ -66,7 +66,7 @@ module RuboCop
 
       def base_configs(path, inherit_from)
         configs = Array(inherit_from).compact.map do |f|
-          if f =~ /\A#{URI.regexp(%w(http https))}\z/
+          if f =~ /\A#{URI.regexp(%w[http https])}\z/
             f = RemoteConfig.new(f, File.dirname(path)).file
           else
             f = File.expand_path(f, File.dirname(path))
@@ -155,7 +155,7 @@ module RuboCop
         if YAML.respond_to?(:safe_load) # Ruby 2.1+
           if defined?(SafeYAML) && SafeYAML.respond_to?(:load)
             SafeYAML.load(yaml_code, filename,
-                          whitelisted_tags: %w(!ruby/regexp))
+                          whitelisted_tags: %w[!ruby/regexp])
           else
             YAML.safe_load(yaml_code, [Regexp], [], false, filename)
           end

--- a/lib/rubocop/cop/lint/else_layout.rb
+++ b/lib/rubocop/cop/lint/else_layout.rb
@@ -51,7 +51,7 @@ module RuboCop
 
         def if?(node)
           node.loc.respond_to?(:keyword) &&
-            %w(if elsif).include?(node.loc.keyword.source)
+            %w[if elsif].include?(node.loc.keyword.source)
         end
 
         def else?(node)

--- a/lib/rubocop/cop/lint/inherit_exception.rb
+++ b/lib/rubocop/cop/lint/inherit_exception.rb
@@ -37,7 +37,7 @@ module RuboCop
           runtime_error: 'RuntimeError',
           standard_error: 'StandardError'
         }.freeze
-        ILLEGAL_CLASSES = %w(
+        ILLEGAL_CLASSES = %w[
           Exception
           SystemStackError
           NoMemoryError
@@ -49,7 +49,7 @@ module RuboCop
           Interrupt
           SignalException
           SystemExit
-        ).freeze
+        ].freeze
 
         def on_class(node)
           _class, base_class, _body = *node

--- a/lib/rubocop/cop/lint/useless_comparison.rb
+++ b/lib/rubocop/cop/lint/useless_comparison.rb
@@ -11,7 +11,7 @@ module RuboCop
       class UselessComparison < Cop
         MSG = 'Comparison of something with itself detected.'.freeze
 
-        OPS = %w(== === != < > <= >= <=>).freeze
+        OPS = %w[== === != < > <= >= <=>].freeze
 
         def on_send(node)
           # lambda.() does not have a selector

--- a/lib/rubocop/cop/lint/void.rb
+++ b/lib/rubocop/cop/lint/void.rb
@@ -10,7 +10,7 @@ module RuboCop
         VAR_MSG = 'Variable `%s` used in void context.'.freeze
         LIT_MSG = 'Literal `%s` used in void context.'.freeze
 
-        OPS = %w(* / % + - == === != < > <= >= <=>).freeze
+        OPS = %w[* / % + - == === != < > <= >= <=>].freeze
 
         def on_begin(node)
           check_begin(node)

--- a/lib/rubocop/cop/mixin/def_node.rb
+++ b/lib/rubocop/cop/mixin/def_node.rb
@@ -6,7 +6,7 @@ module RuboCop
     module DefNode
       extend NodePattern::Macros
 
-      NON_PUBLIC_MODIFIERS = %w(private protected).freeze
+      NON_PUBLIC_MODIFIERS = %w[private protected].freeze
 
       def non_public?(node)
         non_public_modifier?(node.parent) ||

--- a/lib/rubocop/cop/mixin/if_node.rb
+++ b/lib/rubocop/cop/mixin/if_node.rb
@@ -12,7 +12,7 @@ module RuboCop
 
       def modifier_if?(node)
         node.loc.respond_to?(:keyword) &&
-          %w(if unless).include?(node.loc.keyword.source) && node.modifier_form?
+          %w[if unless].include?(node.loc.keyword.source) && node.modifier_form?
       end
 
       def elsif?(node)

--- a/lib/rubocop/cop/rails/delegate.rb
+++ b/lib/rubocop/cop/rails/delegate.rb
@@ -94,7 +94,7 @@ module RuboCop
         end
 
         def private_or_protected_before(line)
-          (processed_source[0..line].map(&:strip) & %w(private protected)).any?
+          (processed_source[0..line].map(&:strip) & %w[private protected]).any?
         end
 
         def private_or_protected_inline(line)

--- a/lib/rubocop/cop/rails/validation.rb
+++ b/lib/rubocop/cop/rails/validation.rb
@@ -7,7 +7,7 @@ module RuboCop
       class Validation < Cop
         MSG = 'Prefer the new style validations `%s` over `%s`.'.freeze
 
-        TYPES = %w(
+        TYPES = %w[
           acceptance
           confirmation
           exclusion
@@ -18,7 +18,7 @@ module RuboCop
           presence
           size
           uniqueness
-        ).freeze
+        ].freeze
 
         BLACKLIST = TYPES.map { |p| "validates_#{p}_of".to_sym }.freeze
 

--- a/lib/rubocop/cop/style/command_literal.rb
+++ b/lib/rubocop/cop/style/command_literal.rb
@@ -105,7 +105,7 @@ module RuboCop
           replacement = if backtick_literal?(node)
                           ['%x', ''].zip(preferred_delimiters).map(&:join)
                         else
-                          %w(` `)
+                          %w[` `]
                         end
 
           lambda do |corrector|

--- a/lib/rubocop/cop/style/else_alignment.rb
+++ b/lib/rubocop/cop/style/else_alignment.rb
@@ -63,7 +63,7 @@ module RuboCop
             base.source_range
           else
             base = node
-            until %w(if unless).include?(base.loc.keyword.source)
+            until %w[if unless].include?(base.loc.keyword.source)
               base = base.parent
             end
             base.loc.keyword

--- a/lib/rubocop/cop/style/file_name.rb
+++ b/lib/rubocop/cop/style/file_name.rb
@@ -132,7 +132,7 @@ module RuboCop
           # But RC can be run from any working directory, and can check any path
           # We can't assume that the working directory, or any other, is the
           # "starting point" to build a namespace
-          start = %w(lib spec test src)
+          start = %w[lib spec test src]
           start_index = nil
 
           # To find the closest namespace root take the path components, and

--- a/lib/rubocop/cop/style/global_vars.rb
+++ b/lib/rubocop/cop/style/global_vars.rb
@@ -14,7 +14,7 @@ module RuboCop
 
         # predefined global variables their English aliases
         # http://www.zenspider.com/Languages/Ruby/QuickRef.html
-        BUILT_IN_VARS = %w(
+        BUILT_IN_VARS = %w[
           $: $LOAD_PATH
           $" $LOADED_FEATURES
           $0 $PROGRAM_NAME
@@ -41,7 +41,7 @@ module RuboCop
           $DEBUG $FILENAME $VERBOSE $SAFE
           $-0 $-a $-d $-F $-i $-I $-l $-p $-v $-w
           $CLASSPATH $JRUBY_VERSION $JRUBY_REVISION $ENV_JAVA
-        ).map(&:to_sym)
+        ].map(&:to_sym)
 
         def user_vars
           cop_config['AllowedVariables'].map(&:to_sym)

--- a/lib/rubocop/cop/style/indentation_width.rb
+++ b/lib/rubocop/cop/style/indentation_width.rb
@@ -20,7 +20,7 @@ module RuboCop
         include IfNode
         include AccessModifierNode
 
-        SPECIAL_MODIFIERS = %w(private protected).freeze
+        SPECIAL_MODIFIERS = %w[private protected].freeze
 
         def on_rescue(node)
           _begin_node, *rescue_nodes, else_node = *node

--- a/lib/rubocop/cop/style/line_end_concatenation.rb
+++ b/lib/rubocop/cop/style/line_end_concatenation.rb
@@ -27,7 +27,7 @@ module RuboCop
         COMPLEX_STRING_EDGE_TOKEN_TYPES = [:tSTRING_BEG, :tSTRING_END].freeze
         HIGH_PRECEDENCE_OP_TOKEN_TYPES = [:tSTAR2, :tPERCENT, :tDOT,
                                           :tLBRACK2].freeze
-        QUOTE_DELIMITERS = %w(' ").freeze
+        QUOTE_DELIMITERS = %w[' "].freeze
 
         def investigate(processed_source)
           processed_source.tokens.each_index do |index|

--- a/lib/rubocop/cop/style/nested_modifier.rb
+++ b/lib/rubocop/cop/style/nested_modifier.rb
@@ -49,7 +49,7 @@ module RuboCop
 
         def modifier_while_or_until?(node)
           node.loc.respond_to?(:keyword) &&
-            %w(while until).include?(node.loc.keyword.source) &&
+            %w[while until].include?(node.loc.keyword.source) &&
             node.modifier_form?
         end
 

--- a/lib/rubocop/cop/style/parallel_assignment.rb
+++ b/lib/rubocop/cop/style/parallel_assignment.rb
@@ -170,7 +170,7 @@ module RuboCop
 
         def modifier_while?(node)
           node.loc.respond_to?(:keyword) &&
-            %w(while until).include?(node.loc.keyword.source) &&
+            %w[while until].include?(node.loc.keyword.source) &&
             node.modifier_form?
         end
 

--- a/lib/rubocop/cop/style/percent_literal_delimiters.rb
+++ b/lib/rubocop/cop/style/percent_literal_delimiters.rb
@@ -58,7 +58,13 @@ module RuboCop
         end
 
         def preferred_delimiters(type)
-          cop_config['PreferredDelimiters'][type].split(//)
+          delimiters = cop_config['PreferredDelimiters'][type]
+          case delimiters
+          when String then delimiters.split(//)
+          when [] then ['[', ']']
+          when {} then ['{', '}']
+          else delimiters # explicit ['{', '}']
+          end
         end
 
         def uses_preferred_delimiter?(node, type)

--- a/lib/rubocop/cop/style/regexp_literal.rb
+++ b/lib/rubocop/cop/style/regexp_literal.rb
@@ -100,7 +100,7 @@ module RuboCop
           replacement = if slash_literal?(node)
                           ['%r', ''].zip(preferred_delimiters).map(&:join)
                         else
-                          %w(/ /)
+                          %w[/ /]
                         end
 
           lambda do |corrector|

--- a/lib/rubocop/cop/style/space_around_keyword.rb
+++ b/lib/rubocop/cop/style/space_around_keyword.rb
@@ -31,9 +31,9 @@ module RuboCop
         DO = 'do'.freeze
         SAFE_NAVIGATION = '&.'.freeze
         ACCEPT_LEFT_PAREN =
-          %w(break defined? next not rescue return super yield).freeze
+          %w[break defined? next not rescue return super yield].freeze
         ACCEPT_LEFT_SQUARE_BRACKET =
-          %w(super yield).freeze
+          %w[super yield].freeze
 
         def on_and(node)
           check(node, [:operator].freeze) if node.keyword?

--- a/lib/rubocop/cop/style/word_array.rb
+++ b/lib/rubocop/cop/style/word_array.rb
@@ -91,7 +91,7 @@ module RuboCop
           contents = autocorrect_words(words, escape, node.loc.line)
 
           lambda do |corrector|
-            corrector.replace(node.source_range, "%#{char}(#{contents})")
+            corrector.replace(node.source_range, "%#{char}[#{contents}]")
           end
         end
 
@@ -111,7 +111,7 @@ module RuboCop
             previous_node_line_number = node.loc.line
             content = node.children.first
             content = escape ? escape_string(content) : content
-            content.gsub!(/\)/, '\\)')
+            content.gsub!(/\]/, '\\]')
             line_breaks + content
           end.join(' ')
         end

--- a/lib/rubocop/cop/variable_force/assignment.rb
+++ b/lib/rubocop/cop/variable_force/assignment.rb
@@ -8,7 +8,7 @@ module RuboCop
         include Locatable
 
         MULTIPLE_LEFT_HAND_SIDE_TYPE = :mlhs
-        REFERENCE_PENETRABLE_BRANCH_TYPES = %w(rescue_main ensure_main).freeze
+        REFERENCE_PENETRABLE_BRANCH_TYPES = %w[rescue_main ensure_main].freeze
 
         attr_reader :node, :variable, :referenced
         alias referenced? referenced

--- a/lib/rubocop/formatter/disabled_config_formatter.rb
+++ b/lib/rubocop/formatter/disabled_config_formatter.rb
@@ -101,7 +101,7 @@ module RuboCop
 
       def cop_config_params(default_cfg, cfg)
         default_cfg.keys -
-          %w(Description StyleGuide Reference Enabled Exclude) -
+          %w[Description StyleGuide Reference Enabled Exclude] -
           cfg.keys
       end
 

--- a/lib/rubocop/options.rb
+++ b/lib/rubocop/options.rb
@@ -181,7 +181,7 @@ module RuboCop
       names.each do |name|
         next if Cop::Cop.all.any? { |c| c.cop_name == name }
         next if namespaces.include?(name)
-        next if %w(Syntax Lint/Syntax).include?(name)
+        next if %w[Syntax Lint/Syntax].include?(name)
 
         raise ArgumentError, "Unrecognized cop or namespace: #{name}."
       end
@@ -212,16 +212,16 @@ module RuboCop
 
     def only_includes_unneeded_disable?
       @options.key?(:only) &&
-        (@options[:only] & %w(Lint/UnneededDisable UnneededDisable)).any?
+        (@options[:only] & %w[Lint/UnneededDisable UnneededDisable]).any?
     end
 
     def except_syntax?
       @options.key?(:except) &&
-        (@options[:except] & %w(Lint/Syntax Syntax)).any?
+        (@options[:except] & %w[Lint/Syntax Syntax]).any?
     end
 
     def boolean_or_empty_cache?
-      !@options.key?(:cache) || %w(true false).include?(@options[:cache])
+      !@options.key?(:cache) || %w[true false].include?(@options[:cache])
     end
 
     def no_offense_counts_without_auto_gen_config?

--- a/spec/project_spec.rb
+++ b/spec/project_spec.rb
@@ -11,7 +11,7 @@ describe 'RuboCop Project' do
     end
 
     it 'has configuration for all cops' do
-      expect(default_config.keys).to match_array(%w(AllCops Rails) + cop_names)
+      expect(default_config.keys).to match_array(%w[AllCops Rails] + cop_names)
     end
 
     it 'has a nicely formatted description for all cops' do

--- a/spec/rubocop/cli/cli_auto_gen_config_spec.rb
+++ b/spec/rubocop/cli/cli_auto_gen_config_spec.rb
@@ -342,7 +342,7 @@ describe RuboCop::CLI, :isolated_environment do
 
     it 'generates a todo list that removes the reports' do
       create_file('example.rb', 'y.gsub!(/abc\/xyz/, x)')
-      expect(cli.run(%w(--format emacs))).to eq(1)
+      expect(cli.run(%w[--format emacs])).to eq(1)
       expect($stdout.string).to eq("#{abs('example.rb')}:1:9: C: Use `%r` " \
                                    "around regular expression.\n")
       expect(cli.run(['--auto-gen-config'])).to eq(1)
@@ -373,7 +373,7 @@ describe RuboCop::CLI, :isolated_environment do
         end
       end
       $stdout = StringIO.new
-      result = cli.run(%w(--config .rubocop_todo.yml --format emacs))
+      result = cli.run(%w[--config .rubocop_todo.yml --format emacs])
       expect($stdout.string).to eq('')
       expect(result).to eq(0)
     end

--- a/spec/rubocop/cli/cli_autocorrect_spec.rb
+++ b/spec/rubocop/cli/cli_autocorrect_spec.rb
@@ -332,7 +332,7 @@ describe RuboCop::CLI, :isolated_environment do
               'end',
               ''].join("\n")
     create_file('example.rb', source)
-    expect(cli.run(%w(--auto-correct --format simple))).to eq(1)
+    expect(cli.run(%w[--auto-correct --format simple])).to eq(1)
     expect($stdout.string)
       .to eq(['== example.rb ==',
               'C:  1:  1: Missing top-level class documentation comment.',
@@ -501,7 +501,7 @@ describe RuboCop::CLI, :isolated_environment do
               '  raise',
               'end']
     create_file('example.rb', source)
-    expect(cli.run(%w(--only IndentationWidth --auto-correct))).to eq(0)
+    expect(cli.run(%w[--only IndentationWidth --auto-correct])).to eq(0)
     corrected = ['foo = if bar',
                  '        something',
                  'elsif baz',
@@ -648,7 +648,7 @@ describe RuboCop::CLI, :isolated_environment do
   it 'can handle spaces when removing braces' do
     create_file('example.rb',
                 ["assert_post_status_code 400, 's', {:type => 'bad'}"])
-    expect(cli.run(%w(--auto-correct --format emacs))).to eq(0)
+    expect(cli.run(%w[--auto-correct --format emacs])).to eq(0)
     expect(IO.read('example.rb'))
       .to eq(["assert_post_status_code 400, 's', type: 'bad'",
               ''].join("\n"))
@@ -690,7 +690,7 @@ describe RuboCop::CLI, :isolated_environment do
                                'private',
                                '  A = ["git", "path",]',
                                'end'])
-    expect(cli.run(%w(--auto-correct --format emacs))).to eq(1)
+    expect(cli.run(%w[--auto-correct --format emacs])).to eq(1)
     expect(IO.read('example.rb')).to eq(['class Dsl',
                                          '  private',
                                          '',
@@ -741,7 +741,7 @@ describe RuboCop::CLI, :isolated_environment do
   it 'can correct single line methods' do
     create_file('example.rb', ['def func1; do_something end # comment',
                                'def func2() do_1; do_2; end'])
-    expect(cli.run(%w(--auto-correct --format offenses))).to eq(0)
+    expect(cli.run(%w[--auto-correct --format offenses])).to eq(0)
     expect(IO.read('example.rb')).to eq(['# comment',
                                          'def func1',
                                          '  do_something',
@@ -836,7 +836,7 @@ describe RuboCop::CLI, :isolated_environment do
                 ['def primes limit',
                  '  1.upto(limit).select { |i| i.even? }',
                  'end'])
-    expect(cli.run(%w(-D --auto-correct))).to eq(0)
+    expect(cli.run(%w[-D --auto-correct])).to eq(0)
     expect($stderr.string).to eq('')
     expect(IO.read('example.rb'))
       .to eq(['def primes(limit)',
@@ -868,7 +868,7 @@ describe RuboCop::CLI, :isolated_environment do
     create_file('example.rb',
                 ["f(type: ['offline','offline_payment'],",
                  "  bar_colors: ['958c12','953579','ff5800','0085cc'])"])
-    expect(cli.run(%w(-D --auto-correct --format o))).to eq(0)
+    expect(cli.run(%w[-D --auto-correct --format o])).to eq(0)
     expect($stdout.string)
       .to eq(['',
               '4  Style/SpaceAfterComma',
@@ -886,7 +886,7 @@ describe RuboCop::CLI, :isolated_environment do
   it 'can correct SpaceAfterComma and HashSyntax offenses' do
     create_file('example.rb',
                 "I18n.t('description',:property_name => property.name)")
-    expect(cli.run(%w(-D --auto-correct --format emacs))).to eq(0)
+    expect(cli.run(%w[-D --auto-correct --format emacs])).to eq(0)
     expect($stdout.string)
       .to eq(["#{abs('example.rb')}:1:21: C: [Corrected] " \
               'Style/SpaceAfterComma: Space missing after comma.',
@@ -899,7 +899,7 @@ describe RuboCop::CLI, :isolated_environment do
 
   it 'can correct HashSyntax and SpaceAroundOperators offenses' do
     create_file('example.rb', '{ :b=>1 }')
-    expect(cli.run(%w(-D --auto-correct --format emacs))).to eq(0)
+    expect(cli.run(%w[-D --auto-correct --format emacs])).to eq(0)
     expect(IO.read('example.rb')).to eq("{ b: 1 }\n")
     expect($stdout.string)
       .to eq(["#{abs('example.rb')}:1:3: C: [Corrected] " \
@@ -912,8 +912,8 @@ describe RuboCop::CLI, :isolated_environment do
 
   it 'can correct HashSyntax when --only is used' do
     create_file('example.rb', '{ :b=>1 }')
-    expect(cli.run(%w(--auto-correct -f emacs
-                      --only Style/HashSyntax))).to eq(0)
+    expect(cli.run(%w[--auto-correct -f emacs
+                      --only Style/HashSyntax])).to eq(0)
     expect($stderr.string).to eq('')
     expect(IO.read('example.rb')).to eq("{ b: 1 }\n")
     expect($stdout.string)
@@ -929,7 +929,7 @@ describe RuboCop::CLI, :isolated_environment do
                  '  ',
                  '',
                  ''])
-    expect(cli.run(%w(--auto-correct --format emacs))).to eq(0)
+    expect(cli.run(%w[--auto-correct --format emacs])).to eq(0)
     expect(IO.read('example.rb')).to eq(['# encoding: utf-8',
                                          ''].join("\n"))
     expect($stdout.string)
@@ -942,7 +942,7 @@ describe RuboCop::CLI, :isolated_environment do
 
   it 'can correct MethodCallParentheses and EmptyLiteral offenses' do
     create_file('example.rb', 'Hash.new()')
-    expect(cli.run(%w(--auto-correct --format emacs))).to eq(0)
+    expect(cli.run(%w[--auto-correct --format emacs])).to eq(0)
     expect($stderr.string).to eq('')
     expect(IO.read('example.rb')).to eq("{}\n")
     expect($stdout.string)
@@ -964,7 +964,7 @@ describe RuboCop::CLI, :isolated_environment do
     create_file('.rubocop.yml',
                 ['Style/AlignHash:',
                  '  EnforcedColonStyle: separator'])
-    expect(cli.run(%w(--auto-correct))).to eq(0)
+    expect(cli.run(%w[--auto-correct])).to eq(0)
     expect(IO.read('example.rb'))
       .to eq(['CONVERSION_CORRESPONDENCE = {',
               '                match_for_should: :match,',
@@ -995,7 +995,7 @@ describe RuboCop::CLI, :isolated_environment do
     create_file('.rubocop.yml', ['AllCops:',
                                  '  TargetRubyVersion: 2.0'])
     create_file('example.rb', src)
-    expect(cli.run(%w(-a -f simple))).to eq(1)
+    expect(cli.run(%w[-a -f simple])).to eq(1)
     expect($stderr.string).to eq('')
     expect(IO.read('example.rb')).to eq(corrected.join("\n") + "\n")
     expect($stdout.string)
@@ -1005,7 +1005,7 @@ describe RuboCop::CLI, :isolated_environment do
   it 'does not hang SpaceAfterPunctuation and SpaceInsideParens' do
     create_file('example.rb', 'some_method(a, )')
     Timeout.timeout(10) do
-      expect(cli.run(%w(--auto-correct))).to eq(0)
+      expect(cli.run(%w[--auto-correct])).to eq(0)
     end
     expect($stderr.string).to eq('')
     expect(IO.read('example.rb')).to eq("some_method(a)\n")
@@ -1014,7 +1014,7 @@ describe RuboCop::CLI, :isolated_environment do
   it 'does not hang SpaceAfterPunctuation and SpaceInsideBrackets' do
     create_file('example.rb', 'puts [1, ]')
     Timeout.timeout(10) do
-      expect(cli.run(%w(--auto-correct))).to eq(0)
+      expect(cli.run(%w[--auto-correct])).to eq(0)
     end
     expect($stderr.string).to eq('')
     expect(IO.read('example.rb')).to eq("puts [1]\n")
@@ -1024,7 +1024,7 @@ describe RuboCop::CLI, :isolated_environment do
     create_file('example.rb', 'puts "Hello", 123456')
     create_file('.rubocop.yml', ['Style/StringLiterals:',
                                  '  AutoCorrect: false'])
-    expect(cli.run(%w(--auto-correct))).to eq(1)
+    expect(cli.run(%w[--auto-correct])).to eq(1)
     expect($stderr.string).to eq('')
     expect(IO.read('example.rb')).to eq("puts \"Hello\", 123_456\n")
   end
@@ -1042,7 +1042,7 @@ describe RuboCop::CLI, :isolated_environment do
                   'Style/TrailingCommaInLiteral:',
                   '  EnforcedStyleForMultiline: consistent_comma'
                 ])
-    expect(cli.run(%w(--auto-correct))).to eq(1)
+    expect(cli.run(%w[--auto-correct])).to eq(1)
     expect($stderr.string).to eq('')
     expect(IO.read('example.rb')).to eq(['{foo: bar,',
                                          ' bar: baz,}',

--- a/spec/rubocop/cli/cli_autocorrect_spec.rb
+++ b/spec/rubocop/cli/cli_autocorrect_spec.rb
@@ -694,7 +694,7 @@ describe RuboCop::CLI, :isolated_environment do
     expect(IO.read('example.rb')).to eq(['class Dsl',
                                          '  private',
                                          '',
-                                         '  A = %w(git path).freeze',
+                                         '  A = %w[git path].freeze',
                                          'end',
                                          ''].join("\n"))
     e = abs('example.rb')
@@ -878,8 +878,8 @@ describe RuboCop::CLI, :isolated_environment do
               '',
               ''].join("\n"))
     expect(IO.read('example.rb'))
-      .to eq(['f(type: %w(offline offline_payment),',
-              '  bar_colors: %w(958c12 953579 ff5800 0085cc))',
+      .to eq(['f(type: %w[offline offline_payment],',
+              '  bar_colors: %w[958c12 953579 ff5800 0085cc])',
               ''].join("\n"))
   end
 

--- a/spec/rubocop/cli/cli_options_spec.rb
+++ b/spec/rubocop/cli/cli_options_spec.rb
@@ -125,7 +125,7 @@ describe RuboCop::CLI, :isolated_environment do
         expect($stderr.string).to include('Unrecognized cop or namespace: .')
       end
 
-      %w(Syntax Lint/Syntax).each do |name|
+      %w[Syntax Lint/Syntax].each do |name|
         it "only checks syntax if #{name} is given" do
           create_file('example.rb', 'x ')
           expect(cli.run(['--only', name])).to eq(0)
@@ -133,7 +133,7 @@ describe RuboCop::CLI, :isolated_environment do
         end
       end
 
-      %w(Lint/UnneededDisable UnneededDisable).each do |name|
+      %w[Lint/UnneededDisable UnneededDisable].each do |name|
         it "exits with error if cop name #{name} is passed" do
           create_file('example.rb', ['if x== 0 ',
                                      "\ty",
@@ -269,7 +269,7 @@ describe RuboCop::CLI, :isolated_environment do
                                    '  ' + '#' * 100,
                                    "\ty",
                                    'end'])
-        expect(cli.run(%w(-f offenses --only Metrics example.rb))).to eq(1)
+        expect(cli.run(%w[-f offenses --only Metrics example.rb])).to eq(1)
         expect($stdout.string).to eq(['',
                                       '1  Metrics/LineLength',
                                       '--',
@@ -287,7 +287,7 @@ describe RuboCop::CLI, :isolated_environment do
                                    'end'])
         create_file('.rubocop.yml', ['Style/SpaceAroundOperators:',
                                      '  Enabled: false'])
-        expect(cli.run(%w(-f o --only Metrics,Style example.rb))).to eq(1)
+        expect(cli.run(%w[-f o --only Metrics,Style example.rb])).to eq(1)
         expect($stdout.string)
           .to eq(['',
                   '1  Metrics/LineLength',
@@ -321,7 +321,7 @@ describe RuboCop::CLI, :isolated_environment do
         expect($stderr.string).to include('Unrecognized cop or namespace: .')
       end
 
-      %w(Syntax Lint/Syntax).each do |name|
+      %w[Syntax Lint/Syntax].each do |name|
         it "exits with error if #{name} is given" do
           create_file('example.rb', 'x ')
           expect(cli.run(['--except', name])).to eq(2)
@@ -378,7 +378,7 @@ describe RuboCop::CLI, :isolated_environment do
     end
 
     context 'when several cops are given' do
-      %w(UnneededDisable Lint/UnneededDisable Lint).each do |cop_name|
+      %w[UnneededDisable Lint/UnneededDisable Lint].each do |cop_name|
         it "disables the given cops including #{cop_name}" do
           create_file('example.rb', ['if x== 100000000000000 ',
                                      "\ty",
@@ -675,7 +675,7 @@ describe RuboCop::CLI, :isolated_environment do
         end
       end
 
-      %w(html json).each do |format|
+      %w[html json].each do |format|
         context "when #{format} format is specified" do
           context 'and offenses come from the cache' do
             context 'and a message has binary encoding' do

--- a/spec/rubocop/cli_spec.rb
+++ b/spec/rubocop/cli_spec.rb
@@ -394,14 +394,14 @@ describe RuboCop::CLI, :isolated_environment do
 
   it 'finds a file with no .rb extension but has a shebang line' do
     create_file('example', ['#!/usr/bin/env ruby', 'x = 0', 'puts x'])
-    expect(cli.run(%w(--format simple))).to eq(0)
+    expect(cli.run(%w[--format simple])).to eq(0)
     expect($stdout.string)
       .to eq(['', '1 file inspected, no offenses detected', ''].join("\n"))
   end
 
   it 'does not register any offenses for an empty file' do
     create_file('example.rb', '')
-    expect(cli.run(%w(--format simple))).to eq(0)
+    expect(cli.run(%w[--format simple])).to eq(0)
     expect($stdout.string)
       .to eq(['', '1 file inspected, no offenses detected', ''].join("\n"))
   end
@@ -557,7 +557,7 @@ describe RuboCop::CLI, :isolated_environment do
                                           'Rails/ReadWriteAttribute:',
                                           '  Include:',
                                           '    - app/models/**/*.rb'])
-        expect(cli.run(%w(--format simple dir1 dir2))).to eq(1)
+        expect(cli.run(%w[--format simple dir1 dir2])).to eq(1)
         expect($stdout.string)
           .to eq(['== dir1/app/models/example1.rb ==',
                   'C:  1:  1: Prefer self[:attr] over read_attribute' \
@@ -619,7 +619,7 @@ describe RuboCop::CLI, :isolated_environment do
         # match.
         create_file('dir2/app/models/example4.rb', source)
 
-        expect(cli.run(%w(--format simple dir1 dir2))).to eq(1)
+        expect(cli.run(%w[--format simple dir1 dir2])).to eq(1)
         expect($stdout.string)
           .to eq(['== dir1/app/models/example1.rb ==',
                   'C:  1:  1: Prefer self[:attr] over read_attribute' \
@@ -643,7 +643,7 @@ describe RuboCop::CLI, :isolated_environment do
                                    '    - !ruby/regexp /regexp.rb\z/',
                                    '    - "exclude_*"',
                                    '    - "dir/*"'])
-      expect(cli.run(%w(--format simple))).to eq(0)
+      expect(cli.run(%w[--format simple])).to eq(0)
       expect($stdout.string)
         .to eq(['', '4 files inspected, no offenses detected',
                 ''].join("\n"))
@@ -674,7 +674,7 @@ describe RuboCop::CLI, :isolated_environment do
                                    '      rand < 0.8',
                                    '    end',
                                    'end'])
-        result = cli.run(%w(--format simple))
+        result = cli.run(%w[--format simple])
         expect($stderr.string).to eq('')
         expect(result).to eq(0)
         expect($stdout.string)
@@ -682,7 +682,7 @@ describe RuboCop::CLI, :isolated_environment do
                   ''].join("\n"))
       end
 
-      %w(class module).each do |parent|
+      %w[class module].each do |parent|
         it "registers offense for normal indentation in #{parent}" do
           create_file('.rubocop.yml', ['Style/IndentationConsistency:',
                                        '  EnforcedStyle: rails'])
@@ -709,7 +709,7 @@ describe RuboCop::CLI, :isolated_environment do
                                      '    rand < 0.8',
                                      '  end',
                                      'end'])
-          result = cli.run(%w(--format simple))
+          result = cli.run(%w[--format simple])
           expect($stderr.string).to eq('')
           expect(result).to eq(1)
           expect($stdout.string)
@@ -772,7 +772,7 @@ describe RuboCop::CLI, :isolated_environment do
       create_file('example.rb', ['x = 0', 'puts x'])
       create_file('.rubocop.yml', [])
 
-      expect(cli.run(%w(--format simple -c .rubocop.yml))).to eq(0)
+      expect(cli.run(%w[--format simple -c .rubocop.yml])).to eq(0)
       expect($stdout.string)
         .to eq(['', '1 file inspected, no offenses detected',
                 ''].join("\n"))
@@ -789,7 +789,7 @@ describe RuboCop::CLI, :isolated_environment do
       create_file('dir/.rubocop.yml', ['AllCops:',
                                        '  DisplayCopNames: true'])
 
-      expect(cli.run(%w(--format simple))).to eq(1)
+      expect(cli.run(%w[--format simple])).to eq(1)
       expect($stdout.string)
         .to eq(['== example1.rb ==',
                 'C:  1:  6: Trailing whitespace detected.',
@@ -814,7 +814,7 @@ describe RuboCop::CLI, :isolated_environment do
 
       url = 'https://github.com/bbatsov/ruby-style-guide#no-trailing-whitespace'
 
-      expect(cli.run(%w(--format simple))).to eq(1)
+      expect(cli.run(%w[--format simple])).to eq(1)
       expect($stdout.string)
         .to eq(['== example1.rb ==',
                 'C:  1:  6: Trailing whitespace detected.',
@@ -852,7 +852,7 @@ describe RuboCop::CLI, :isolated_environment do
                                    '    - "**/*.rake"',
                                    '    - !ruby/regexp /regexp$/',
                                    '    - .dot1/**/*'])
-      expect(cli.run(%w(--format files))).to eq(1)
+      expect(cli.run(%w[--format files])).to eq(1)
       expect($stderr.string).to eq('')
       expect($stdout.string.split($RS).sort).to eq([abs('.dot1/file.rb'),
                                                     abs('example'),
@@ -869,7 +869,7 @@ describe RuboCop::CLI, :isolated_environment do
                                    '    - example.rb',
                                    '    - !ruby/regexp /regexp.rb$/',
                                    '    - "exclude_*"'])
-      expect(cli.run(%w(--format simple))).to eq(0)
+      expect(cli.run(%w[--format simple])).to eq(0)
       expect($stdout.string)
         .to eq(['', '0 files inspected, no offenses detected',
                 ''].join("\n"))
@@ -891,7 +891,7 @@ describe RuboCop::CLI, :isolated_environment do
       create_file('.rubocop.yml', ['AllCops:',
                                    '  Include:',
                                    '    - .other/**/*'])
-      expect(cli.run(%w(--format simple))).to eq(1)
+      expect(cli.run(%w[--format simple])).to eq(1)
       expect($stderr.string).to eq('')
       expect($stdout.string)
         .to eq(['== .other/example.rb ==',
@@ -906,7 +906,7 @@ describe RuboCop::CLI, :isolated_environment do
       create_file('dir/.rubocop.yml', ['AllCops:',
                                        '  Include:',
                                        '    - "*.ruby"'])
-      expect(cli.run(%w(--format simple))).to eq(0)
+      expect(cli.run(%w[--format simple])).to eq(0)
       expect($stderr.string).to eq('')
       expect($stdout.string)
         .to eq(['',
@@ -922,7 +922,7 @@ describe RuboCop::CLI, :isolated_environment do
                                    '    - "*.dsl"',
                                    '  Exclude:',
                                    '    - example.rb'])
-      expect(cli.run(%w(--format simple .))).to eq(1)
+      expect(cli.run(%w[--format simple .])).to eq(1)
       expect($stdout.string)
         .to eq(['== special.dsl ==',
                 "C:  1:  9: Prefer single-quoted strings when you don't " \
@@ -935,7 +935,7 @@ describe RuboCop::CLI, :isolated_environment do
     # With rubinius 2.0.0.rc1 + rspec 2.13.1,
     # File.stub(:open).and_call_original causes SystemStackError.
     it 'does not read files in excluded list', broken: :rbx do
-      %w(rb.rb non-rb.ext without-ext).each do |filename|
+      %w[rb.rb non-rb.ext without-ext].each do |filename|
         create_file("example/ignored/#{filename}", '#' * 90)
       end
 
@@ -944,7 +944,7 @@ describe RuboCop::CLI, :isolated_environment do
                                            '    - ignored/**'])
       expect(File).not_to receive(:open).with(%r{/ignored/})
       allow(File).to receive(:open).and_call_original
-      expect(cli.run(%w(--format simple example))).to eq(0)
+      expect(cli.run(%w[--format simple example])).to eq(0)
       expect($stdout.string)
         .to eq(['', '0 files inspected, no offenses detected',
                 ''].join("\n"))
@@ -1111,13 +1111,13 @@ describe RuboCop::CLI, :isolated_environment do
     end
 
     it 'can have different config files in different directories' do
-      %w(src lib).each do |dir|
+      %w[src lib].each do |dir|
         create_file("example/#{dir}/example1.rb", '#' * 90)
       end
       create_file('example/src/.rubocop.yml', ['Metrics/LineLength:',
                                                '  Enabled: true',
                                                '  Max: 100'])
-      expect(cli.run(%w(--format simple example))).to eq(1)
+      expect(cli.run(%w[--format simple example])).to eq(1)
       expect($stdout.string).to eq(['== example/lib/example1.rb ==',
                                     'C:  1: 81: Line is too long. [90/80]',
                                     '',
@@ -1140,7 +1140,7 @@ describe RuboCop::CLI, :isolated_environment do
     end
 
     it 'can exclude directories relative to .rubocop.yml' do
-      %w(src etc/test etc/spec tmp/test tmp/spec).each do |dir|
+      %w[src etc/test etc/spec tmp/test tmp/spec].each do |dir|
         create_file("example/#{dir}/example1.rb", '#' * 90)
       end
 
@@ -1153,7 +1153,7 @@ describe RuboCop::CLI, :isolated_environment do
                                            '    - etc/**/*',
                                            '    - tmp/spec/**'])
 
-      expect(cli.run(%w(--format simple example))).to eq(1)
+      expect(cli.run(%w[--format simple example])).to eq(1)
       expect($stderr.string).to eq('')
       expect($stdout.string).to eq(['== example/tmp/test/example1.rb ==',
                                     'C:  1: 81: Line is too long. [90/80]',
@@ -1176,7 +1176,7 @@ describe RuboCop::CLI, :isolated_environment do
                    '  Exclude:',
                    '    - vendor/**/*'])
 
-      cli.run(%w(--format simple))
+      cli.run(%w[--format simple])
       expect($stdout.string)
         .to eq(['', '0 files inspected, no offenses detected',
                 ''].join("\n"))
@@ -1185,7 +1185,7 @@ describe RuboCop::CLI, :isolated_environment do
     it 'excludes the vendor directory by default' do
       create_file('vendor/ex.rb', '#' * 90)
 
-      cli.run(%w(--format simple))
+      cli.run(%w[--format simple])
       expect($stdout.string)
         .to eq(['', '0 files inspected, no offenses detected',
                 ''].join("\n"))
@@ -1208,7 +1208,7 @@ describe RuboCop::CLI, :isolated_environment do
                    '  Exclude:',
                    '    - vendor/**/*'])
 
-      cli.run(%w(--format simple))
+      cli.run(%w[--format simple])
       expect($stderr.string).to eq('')
       expect($stdout.string)
         .to eq(['', '0 files inspected, no offenses detected',
@@ -1235,7 +1235,7 @@ describe RuboCop::CLI, :isolated_environment do
                    '  Exclude:',
                    '    - vendor/**/*'])
 
-      cli.run(%w(--format simple))
+      cli.run(%w[--format simple])
       expect($stdout.string)
         .to eq(['', '0 files inspected, no offenses detected',
                 ''].join("\n"))
@@ -1248,7 +1248,7 @@ describe RuboCop::CLI, :isolated_environment do
                                            '  Enabled: true',
                                            '  Max: 100'])
 
-      expect(cli.run(%w(--format simple example))).to eq(1)
+      expect(cli.run(%w[--format simple example])).to eq(1)
       expect($stderr.string)
         .to eq(['Warning: unrecognized cop Style/LyneLenth found in ' +
                 abs('example/.rubocop.yml'),
@@ -1262,7 +1262,7 @@ describe RuboCop::CLI, :isolated_environment do
                                            '  Enabled: true',
                                            '  Min: 10'])
 
-      expect(cli.run(%w(--format simple example))).to eq(1)
+      expect(cli.run(%w[--format simple example])).to eq(1)
       expect($stderr.string)
         .to eq(['Warning: unrecognized parameter Metrics/LineLength:Min ' \
                 'found in ' + abs('example/.rubocop.yml'),
@@ -1274,7 +1274,7 @@ describe RuboCop::CLI, :isolated_environment do
       create_file('example/.rubocop.yml', ['Style/BracesAroundHashParameters:',
                                            '  EnforcedStyle: context'])
 
-      expect(cli.run(%w(--format simple example))).to eq(2)
+      expect(cli.run(%w[--format simple example])).to eq(2)
       expect($stderr.string)
         .to eq(["Error: invalid EnforcedStyle 'context' for " \
                 'Style/BracesAroundHashParameters found in ' +
@@ -1291,7 +1291,7 @@ describe RuboCop::CLI, :isolated_environment do
                                   '  Exclude:',
                                   '    - !ruby/regexp /example1\.rb$/'])
 
-      cli.run(%w(--format simple -c rubocop.yml))
+      cli.run(%w[--format simple -c rubocop.yml])
       expect($stdout.string)
         .to eq(['', '0 files inspected, no offenses detected',
                 ''].join("\n"))
@@ -1305,7 +1305,7 @@ describe RuboCop::CLI, :isolated_environment do
                                   '  Exclude:',
                                   '    - example/**'])
 
-      cli.run(%w(--format simple -c rubocop.yml))
+      cli.run(%w[--format simple -c rubocop.yml])
       expect($stdout.string)
         .to eq(['', '0 files inspected, no offenses detected',
                 ''].join("\n"))
@@ -1317,7 +1317,7 @@ describe RuboCop::CLI, :isolated_environment do
       create_file('rubocop.yml', ['Metrics/LineLength:',
                                   '  Severity: error'])
 
-      cli.run(%w(--format simple -c rubocop.yml))
+      cli.run(%w[--format simple -c rubocop.yml])
       expect($stdout.string)
         .to eq(['== example/example1.rb ==',
                 'E:  1: 81: Line is too long. [90/80]',
@@ -1333,7 +1333,7 @@ describe RuboCop::CLI, :isolated_environment do
       create_file('rubocop.yml', ['Metrics/LineLength:',
                                   '  Severity: superbad'])
 
-      cli.run(%w(--format simple -c rubocop.yml))
+      cli.run(%w[--format simple -c rubocop.yml])
       expect($stderr.string)
         .to eq(["Warning: Invalid severity 'superbad'. " \
                 'Valid severities are refactor, convention, ' \
@@ -1382,7 +1382,7 @@ describe RuboCop::CLI, :isolated_environment do
 
     it 'shows an error if the input file cannot be found' do
       begin
-        cli.run(%w(/tmp/not_a_file))
+        cli.run(%w[/tmp/not_a_file])
       rescue SystemExit => e
         expect(e.status).to eq(1)
         expect(e.message)

--- a/spec/rubocop/config_loader_spec.rb
+++ b/spec/rubocop/config_loader_spec.rb
@@ -200,7 +200,7 @@ describe RuboCop::ConfigLoader do
               'Max' => 77,
               'AllowHeredoc' => true,
               'AllowURI' => true,
-              'URISchemes' => %w(http https),
+              'URISchemes' => %w[http https],
               'IgnoreCopDirectives' => false
             },
             'Metrics/MethodLength' => {
@@ -280,7 +280,7 @@ describe RuboCop::ConfigLoader do
               'Max' => 120,             # overridden in line_length.yml
               'AllowHeredoc' => false,  # overridden in rubocop.yml
               'AllowURI' => true,
-              'URISchemes' => %w(http https),
+              'URISchemes' => %w[http https],
               'IgnoreCopDirectives' => false
             }
           )
@@ -367,7 +367,7 @@ describe RuboCop::ConfigLoader do
 
       it 'returns values from the gem config with local overrides' do
         gem_class = Struct.new(:gem_dir)
-        %w(gemone gemtwo).each do |gem_name|
+        %w[gemone gemtwo].each do |gem_name|
           mock_spec = gem_class.new(gem_name)
           expect(Gem::Specification).to receive(:find_by_name)
             .at_least(:once).with(gem_name).and_return(mock_spec)

--- a/spec/rubocop/cop/commissioner_spec.rb
+++ b/spec/rubocop/cop/commissioner_spec.rb
@@ -22,16 +22,16 @@ describe RuboCop::Cop::Commissioner do
     context 'when a cop has no interest in the file' do
       it 'returns all offenses except the ones of the cop' do
         cops = []
-        cops << double('cop A', offenses: %w(foo), excluded_file?: false)
+        cops << double('cop A', offenses: %w[foo], excluded_file?: false)
         cops << double('cop B', excluded_file?: true)
-        cops << double('cop C', offenses: %w(baz), excluded_file?: false)
+        cops << double('cop C', offenses: %w[baz], excluded_file?: false)
         cops.each(&:as_null_object)
 
         commissioner = described_class.new(cops, [])
         source = []
         processed_source = parse_source(source)
 
-        expect(commissioner.investigate(processed_source)).to eq %w(foo baz)
+        expect(commissioner.investigate(processed_source)).to eq %w[foo baz]
       end
     end
 

--- a/spec/rubocop/cop/lint/circular_argument_reference_spec.rb
+++ b/spec/rubocop/cop/lint/circular_argument_reference_spec.rb
@@ -167,7 +167,7 @@ describe RuboCop::Cop::Lint::CircularArgumentReference do
             .to eq('Circular argument reference - `some_arg`.')
           expect(cop.offenses.last.message)
             .to eq('Circular argument reference - `other_arg`.')
-          expect(cop.highlights).to eq %w(some_arg other_arg)
+          expect(cop.highlights).to eq %w[some_arg other_arg]
         end
       end
     end

--- a/spec/rubocop/cop/lint/condition_position_spec.rb
+++ b/spec/rubocop/cop/lint/condition_position_spec.rb
@@ -5,7 +5,7 @@ require 'spec_helper'
 describe RuboCop::Cop::Lint::ConditionPosition do
   subject(:cop) { described_class.new }
 
-  %w(if unless while until).each do |keyword|
+  %w[if unless while until].each do |keyword|
     it 'registers an offense for condition on the next line' do
       inspect_source(cop,
                      [keyword,

--- a/spec/rubocop/cop/lint/debugger_spec.rb
+++ b/spec/rubocop/cop/lint/debugger_spec.rb
@@ -7,12 +7,12 @@ describe RuboCop::Cop::Lint::Debugger do
 
   include_examples 'debugger', 'debugger', 'debugger'
   include_examples 'debugger', 'byebug', 'byebug'
-  include_examples 'debugger', 'pry binding', %w(binding.pry binding.remote_pry
-                                                 binding.pry_remote)
+  include_examples 'debugger', 'pry binding', %w[binding.pry binding.remote_pry
+                                                 binding.pry_remote]
   include_examples 'debugger',
-                   'capybara debug method', %w(save_and_open_page
+                   'capybara debug method', %w[save_and_open_page
                                                save_and_open_screenshot
-                                               save_screenshot)
+                                               save_screenshot]
   include_examples 'debugger', 'debugger with an argument', 'debugger foo'
   include_examples 'debugger', 'byebug with an argument', 'byebug foo'
   include_examples 'debugger',
@@ -26,9 +26,9 @@ describe RuboCop::Cop::Lint::Debugger do
                     'save_screenshot foo']
   include_examples 'non-debugger', 'a non-pry binding', 'binding.pirate'
 
-  ALL_COMMANDS = %w(debugger byebug pry remote_pry pry_remote
+  ALL_COMMANDS = %w[debugger byebug pry remote_pry pry_remote
                     save_and_open_page save_and_open_screenshot
-                    save_screenshot).freeze
+                    save_screenshot].freeze
 
   ALL_COMMANDS.each do |src|
     include_examples 'non-debugger', "a #{src} in comments", "# #{src}"

--- a/spec/rubocop/cop/lint/duplicated_key_spec.rb
+++ b/spec/rubocop/cop/lint/duplicated_key_spec.rb
@@ -27,7 +27,7 @@ describe RuboCop::Cop::Lint::DuplicatedKey do
       inspect_source(cop, source)
       expect(cop.offenses.size).to eq(2)
       expect(cop.messages).to eq(['Duplicated key in hash literal.'] * 2)
-      expect(cop.highlights).to eq %w(veg fruit)
+      expect(cop.highlights).to eq %w[veg fruit]
     end
   end
 
@@ -40,7 +40,7 @@ describe RuboCop::Cop::Lint::DuplicatedKey do
       inspect_source(cop, source)
       expect(cop.offenses.size).to eq(2)
       expect(cop.messages).to eq(['Duplicated key in hash literal.'] * 2)
-      expect(cop.highlights).to eq %w(1 1)
+      expect(cop.highlights).to eq %w[1 1]
     end
   end
 

--- a/spec/rubocop/cop/lint/non_local_exit_from_iterator_spec.rb
+++ b/spec/rubocop/cop/lint/non_local_exit_from_iterator_spec.rb
@@ -134,7 +134,7 @@ describe RuboCop::Cop::Lint::NonLocalExitFromIterator do
         expect(cop.offenses[1].message).to eq(message)
         expect(cop.offenses[1].severity.name).to eq(:warning)
         expect(cop.offenses[1].line).to eq(6)
-        expect(cop.highlights).to eq(%w(return return))
+        expect(cop.highlights).to eq(%w[return return])
       end
     end
 

--- a/spec/rubocop/cop/lint/percent_string_array_spec.rb
+++ b/spec/rubocop/cop/lint/percent_string_array_spec.rb
@@ -13,7 +13,7 @@ describe RuboCop::Cop::Lint::PercentStringArray do
   end
 
   context 'detecting quotes or commas in a %w/%W string' do
-    %w(w W).each do |char|
+    %w[w W].each do |char|
       it 'accepts tokens without quotes or commas' do
         inspect_source(cop, "%#{char}(foo bar baz)")
 

--- a/spec/rubocop/cop/lint/percent_symbol_array_spec.rb
+++ b/spec/rubocop/cop/lint/percent_symbol_array_spec.rb
@@ -13,7 +13,7 @@ describe RuboCop::Cop::Lint::PercentSymbolArray do
   end
 
   context 'detecting colons or commas in a %i/%I string' do
-    %w(i I).each do |char|
+    %w[i I].each do |char|
       it 'accepts tokens without colons or commas' do
         inspect_source(cop, "%#{char}(foo bar baz)")
 

--- a/spec/rubocop/cop/lint/underscore_prefixed_variable_name_spec.rb
+++ b/spec/rubocop/cop/lint/underscore_prefixed_variable_name_spec.rb
@@ -120,7 +120,7 @@ describe RuboCop::Cop::Lint::UnderscorePrefixedVariableName do
     end
   end
 
-  %w(super binding).each do |keyword|
+  %w[super binding].each do |keyword|
     context "in a method calling `#{keyword}` without arguments" do
       context 'when an underscore-prefixed argument is not used explicitly' do
         let(:source) { <<-END }

--- a/spec/rubocop/cop/lint/unneeded_disable_spec.rb
+++ b/spec/rubocop/cop/lint/unneeded_disable_spec.rb
@@ -209,7 +209,7 @@ describe RuboCop::Cop::Lint::UnneededDisable do
                 expect(cop.messages)
                   .to eq(['Unnecessary disabling of `Metrics/ClassLength`.',
                           'Unnecessary disabling of `Lint/Debugger`.'])
-                expect(cop.highlights).to eq(%w(ClassLength Debugger))
+                expect(cop.highlights).to eq(%w[ClassLength Debugger])
               end
             end
           end

--- a/spec/rubocop/cop/lint/unused_block_argument_spec.rb
+++ b/spec/rubocop/cop/lint/unused_block_argument_spec.rb
@@ -48,7 +48,7 @@ describe RuboCop::Cop::Lint::UnusedBlockArgument, :config do
             "You can omit all the arguments if you don't care about them."
           )
           expect(cop.offenses.first.line).to eq(2)
-          expect(cop.highlights).to eq(%w(key value))
+          expect(cop.highlights).to eq(%w[key value])
         end
       end
     end
@@ -128,7 +128,7 @@ describe RuboCop::Cop::Lint::UnusedBlockArgument, :config do
 
           )
           expect(cop.offenses.first.line).to eq(1)
-          expect(cop.highlights).to eq(%w(foo bar))
+          expect(cop.highlights).to eq(%w[foo bar])
         end
       end
 
@@ -261,7 +261,7 @@ describe RuboCop::Cop::Lint::UnusedBlockArgument, :config do
         it 'registers offenses' do
           expect(cop.offenses.size).to eq 2
           expect(cop.offenses.first.line).to eq(1)
-          expect(cop.highlights).to eq(%w(key value))
+          expect(cop.highlights).to eq(%w[key value])
         end
       end
     end
@@ -277,7 +277,7 @@ describe RuboCop::Cop::Lint::UnusedBlockArgument, :config do
         it 'registers an offense' do
           expect(cop.offenses.size).to eq(2)
           expect(cop.offenses.first.line).to eq(1)
-          expect(cop.highlights).to eq(%w(key value))
+          expect(cop.highlights).to eq(%w[key value])
         end
       end
     end

--- a/spec/rubocop/cop/lint/unused_method_argument_spec.rb
+++ b/spec/rubocop/cop/lint/unused_method_argument_spec.rb
@@ -204,7 +204,7 @@ describe RuboCop::Cop::Lint::UnusedMethodArgument, :config do
         it 'registers offenses' do
           expect(cop.offenses.size).to eq 2
           expect(cop.offenses.first.line).to eq(1)
-          expect(cop.highlights).to eq(%w(foo bar))
+          expect(cop.highlights).to eq(%w[foo bar])
         end
       end
     end

--- a/spec/rubocop/cop/lint/useless_access_modifier_spec.rb
+++ b/spec/rubocop/cop/lint/useless_access_modifier_spec.rb
@@ -202,7 +202,7 @@ describe RuboCop::Cop::Lint::UselessAccessModifier do
 
   context 'when only a constant or local variable is defined after the ' \
     'modifier' do
-    %w(CONSTANT some_var).each do |binding_name|
+    %w[CONSTANT some_var].each do |binding_name|
       let(:source) do
         [
           'class SomeClass',
@@ -514,7 +514,7 @@ describe RuboCop::Cop::Lint::UselessAccessModifier do
   end
 
   shared_examples 'conditionally defined method' do |keyword, modifier|
-    %w(if unless).each do |conditional_type|
+    %w[if unless].each do |conditional_type|
       it "doesn't register an offense for #{conditional_type}" do
         src = ["#{keyword} A",
                "  #{modifier}",
@@ -530,7 +530,7 @@ describe RuboCop::Cop::Lint::UselessAccessModifier do
   end
 
   shared_examples 'methods defined in an iteration' do |keyword, modifier|
-    %w(each map).each do |iteration_method|
+    %w[each map].each do |iteration_method|
       it "doesn't register an offense for #{iteration_method}" do
         src = ["#{keyword} A",
                "  #{modifier}",
@@ -557,7 +557,7 @@ describe RuboCop::Cop::Lint::UselessAccessModifier do
       expect(cop.offenses).to be_empty
     end
 
-    %w(lambda proc ->).each do |proc_type|
+    %w[lambda proc ->].each do |proc_type|
       it "doesn't register an offense if a #{proc_type} is passed" do
         src = ["#{keyword} A",
                "  #{modifier}",
@@ -834,23 +834,23 @@ describe RuboCop::Cop::Lint::UselessAccessModifier do
     end
   end
 
-  %w(protected private).each do |modifier|
+  %w[protected private].each do |modifier|
     it_behaves_like('method defined using class_eval', modifier)
     it_behaves_like('method defined using instance_eval', modifier)
   end
 
-  %w(Class Module Struct).each do |klass|
-    %w(protected private).each do |modifier|
+  %w[Class Module Struct].each do |klass|
+    %w[protected private].each do |modifier|
       it_behaves_like('def in new block', klass, modifier)
     end
   end
 
-  %w(module class).each do |keyword|
+  %w[module class].each do |keyword|
     it_behaves_like('at the top of the body', keyword)
     it_behaves_like('non-repeated visibility modifiers', keyword)
     it_behaves_like('unused visibility modifiers', keyword)
 
-    %w(public protected private).each do |modifier|
+    %w[public protected private].each do |modifier|
       it_behaves_like('repeated visibility modifiers', keyword, modifier)
       it_behaves_like('at the end of the body', keyword, modifier)
       it_behaves_like('nested in a begin..end block', keyword, modifier)

--- a/spec/rubocop/cop/lint/useless_assignment_spec.rb
+++ b/spec/rubocop/cop/lint/useless_assignment_spec.rb
@@ -264,7 +264,7 @@ describe RuboCop::Cop::Lint::UselessAssignment do
         .to eq('Useless assignment to variable - `foo`.')
       expect(cop.offenses[1].line).to eq(4)
 
-      expect(cop.highlights).to eq(%w(foo foo))
+      expect(cop.highlights).to eq(%w[foo foo])
     end
   end
 

--- a/spec/rubocop/cop/lint/void_spec.rb
+++ b/spec/rubocop/cop/lint/void_spec.rb
@@ -31,7 +31,7 @@ describe RuboCop::Cop::Lint::Void do
     end
   end
 
-  %w(var @var @@var VAR).each do |var|
+  %w[var @var @@var VAR].each do |var|
     it "registers an offense for void var #{var} if not on last line" do
       inspect_source(cop,
                      ["#{var} = 5",

--- a/spec/rubocop/cop/metrics/line_length_spec.rb
+++ b/spec/rubocop/cop/metrics/line_length_spec.rb
@@ -83,7 +83,7 @@ describe RuboCop::Cop::Metrics::LineLength, :config do
     context 'and an error other than URI::InvalidURIError is raised ' \
             'while validating an URI-ish string' do
       let(:cop_config) do
-        { 'Max' => 80, 'AllowURI' => true, 'URISchemes' => %w(LDAP) }
+        { 'Max' => 80, 'AllowURI' => true, 'URISchemes' => %w[LDAP] }
       end
 
       let(:source) { <<-END }
@@ -107,7 +107,7 @@ describe RuboCop::Cop::Metrics::LineLength, :config do
 
       context 'and the scheme has been configured' do
         let(:cop_config) do
-          { 'Max' => 80, 'AllowURI' => true, 'URISchemes' => %w(otherprotocol) }
+          { 'Max' => 80, 'AllowURI' => true, 'URISchemes' => %w[otherprotocol] }
         end
 
         it 'accepts the line' do
@@ -142,7 +142,7 @@ describe RuboCop::Cop::Metrics::LineLength, :config do
 
     context 'and only certain heredoc delimiters are whitelisted' do
       let(:cop_config) do
-        { 'Max' => 80, 'AllowHeredoc' => %w(SQL OK) }
+        { 'Max' => 80, 'AllowHeredoc' => %w[SQL OK] }
       end
 
       let(:source) { <<-END }

--- a/spec/rubocop/cop/offense_spec.rb
+++ b/spec/rubocop/cop/offense_spec.rb
@@ -95,7 +95,7 @@ describe RuboCop::Cop::Offense do
       described_class.new(
         attrs[:sev],
         location(attrs[:line], attrs[:col],
-                 %w(aaaaaa bbbbbb cccccc dddddd eeeeee ffffff)),
+                 %w[aaaaaa bbbbbb cccccc dddddd eeeeee ffffff]),
         attrs[:mes],
         attrs[:cop]
       )

--- a/spec/rubocop/cop/performance/end_with_spec.rb
+++ b/spec/rubocop/cop/performance/end_with_spec.rb
@@ -21,7 +21,7 @@ describe RuboCop::Cop::Performance::EndWith do
       expect(new_source).to eq 'str.end_with?("\t")'
     end
 
-    %w(. $ ^ |).each do |str|
+    %w[. $ ^ |].each do |str|
       it "autocorrects #{method} /\\#{str}\\z/" do
         new_source = autocorrect_source(cop, "str#{method} /\\#{str}\\z/")
         expect(new_source).to eq "str.end_with?('#{str}')"
@@ -36,7 +36,7 @@ describe RuboCop::Cop::Performance::EndWith do
     # escapes like "\n"
     # note that "\b" is a literal backspace char in a double-quoted string...
     # but in a regex, it's an anchor on a word boundary
-    %w(a e f r t v).each do |str|
+    %w[a e f r t v].each do |str|
       it "autocorrects #{method} /\\#{str}\\z/" do
         new_source = autocorrect_source(cop, "str#{method} /\\#{str}\\z/")
         expect(new_source).to eq %{str.end_with?("\\#{str}")}
@@ -44,7 +44,7 @@ describe RuboCop::Cop::Performance::EndWith do
     end
 
     # character classes, anchors
-    %w(w W s S d D A Z z G b B h H R X S).each do |str|
+    %w[w W s S d D A Z z G b B h H R X S].each do |str|
       it "doesn't register an error for #{method} /\\#{str}\\z/" do
         inspect_source(cop, "str#{method} /\\#{str}\\z/")
         expect(cop.messages).to be_empty
@@ -52,7 +52,7 @@ describe RuboCop::Cop::Performance::EndWith do
     end
 
     # characters with no special meaning whatsoever
-    %w(i j l m o q y).each do |str|
+    %w[i j l m o q y].each do |str|
       it "autocorrects #{method} /\\#{str}\\z/" do
         new_source = autocorrect_source(cop, "str#{method} /\\#{str}\\z/")
         expect(new_source).to eq "str.end_with?('#{str}')"

--- a/spec/rubocop/cop/performance/redundant_merge_spec.rb
+++ b/spec/rubocop/cop/performance/redundant_merge_spec.rb
@@ -134,7 +134,7 @@ describe RuboCop::Cop::Performance::RedundantMerge, :config do
     end
   end
 
-  %w(if unless while until).each do |kw|
+  %w[if unless while until].each do |kw|
     context "when there is a modifier #{kw}, and more than 1 pair" do
       it "autocorrects it to an #{kw} block" do
         new_source = autocorrect_source(

--- a/spec/rubocop/cop/performance/start_with_spec.rb
+++ b/spec/rubocop/cop/performance/start_with_spec.rb
@@ -14,7 +14,7 @@ describe RuboCop::Cop::Performance::StartWith do
     # escapes like "\n"
     # note that "\b" is a literal backspace char in a double-quoted string...
     # but in a regex, it's an anchor on a word boundary
-    %w(a e f r t v).each do |str|
+    %w[a e f r t v].each do |str|
       it "autocorrects #{method} /\\A\\#{str}/" do
         new_source = autocorrect_source(cop, "str#{method} /\\A\\#{str}/")
         expect(new_source).to eq %{str.start_with?("\\#{str}")}
@@ -22,7 +22,7 @@ describe RuboCop::Cop::Performance::StartWith do
     end
 
     # regexp metacharacters
-    %w(. * ? $ ^ |).each do |str|
+    %w[. * ? $ ^ |].each do |str|
       it "autocorrects #{method} /\\A\\#{str}/" do
         new_source = autocorrect_source(cop, "str#{method} /\\A\\#{str}/")
         expect(new_source).to eq "str.start_with?('#{str}')"
@@ -35,7 +35,7 @@ describe RuboCop::Cop::Performance::StartWith do
     end
 
     # character classes, anchors
-    %w(w W s S d D A Z z G b B h H R X S).each do |str|
+    %w[w W s S d D A Z z G b B h H R X S].each do |str|
       it "doesn't register an error for #{method} /\\A\\#{str}/" do
         inspect_source(cop, "str#{method} /\\A\\#{str}/")
         expect(cop.messages).to be_empty
@@ -43,7 +43,7 @@ describe RuboCop::Cop::Performance::StartWith do
     end
 
     # characters with no special meaning whatsoever
-    %w(i j l m o q y).each do |str|
+    %w[i j l m o q y].each do |str|
       it "autocorrects #{method} /\\A\\#{str}/" do
         new_source = autocorrect_source(cop, "str#{method} /\\A\\#{str}/")
         expect(new_source).to eq "str.start_with?('#{str}')"

--- a/spec/rubocop/cop/performance/string_replacement_spec.rb
+++ b/spec/rubocop/cop/performance/string_replacement_spec.rb
@@ -130,8 +130,8 @@ describe RuboCop::Cop::Performance::StringReplacement do
         expect(cop.messages).to eq(['Use `delete` instead of `gsub`.'])
       end
 
-      %w(a b c ' " % ! = < > # & ; : ` ~ 1 2 3 - _ , \r \\\\ \y \u1234
-         \x65).each do |str|
+      %w[a b c ' " % ! = < > # & ; : ` ~ 1 2 3 - _ , \r \\\\ \y \u1234
+         \x65].each do |str|
         it "registers an offense when replacing #{str} with a literal" do
           inspect_source(cop, "'abc'.gsub(/#{str}/, 'a')")
           expect(cop.messages).to eq(['Use `tr` instead of `gsub`.'])

--- a/spec/rubocop/cop/rails/date_spec.rb
+++ b/spec/rubocop/cop/rails/date_spec.rb
@@ -8,7 +8,7 @@ describe RuboCop::Cop::Rails::Date, :config do
   context 'when EnforcedStyle is "strict"' do
     let(:cop_config) { { 'EnforcedStyle' => 'strict' } }
 
-    %w(today current yesterday tomorrow).each do |day|
+    %w[today current yesterday tomorrow].each do |day|
       it "registers an offense for Date.#{day}" do
         inspect_source(cop, "Date.#{day}")
         expect(cop.offenses.size).to eq(1)
@@ -25,7 +25,7 @@ describe RuboCop::Cop::Rails::Date, :config do
       end
     end
 
-    %w(to_time to_time_in_current_zone).each do |method|
+    %w[to_time to_time_in_current_zone].each do |method|
       it "registers an offense for ##{method}" do
         inspect_source(cop, "date.#{method}")
         expect(cop.offenses.size).to eq(1)
@@ -65,7 +65,7 @@ describe RuboCop::Cop::Rails::Date, :config do
   context 'when EnforcedStyle is "flexible"' do
     let(:cop_config) { { 'EnforcedStyle' => 'flexible' } }
 
-    %w(current yesterday tomorrow).each do |day|
+    %w[current yesterday tomorrow].each do |day|
       it "accepts Date.#{day}" do
         inspect_source(cop, "Date.#{day}")
         expect(cop.offenses).to be_empty

--- a/spec/rubocop/cop/rails/dynamic_find_by_spec.rb
+++ b/spec/rubocop/cop/rails/dynamic_find_by_spec.rb
@@ -5,7 +5,7 @@ require 'spec_helper'
 describe RuboCop::Cop::Rails::DynamicFindBy, :config do
   subject(:cop) { described_class.new(config) }
   let(:cop_config) do
-    { 'Whitelist' => %w(find_by_sql) }
+    { 'Whitelist' => %w[find_by_sql] }
   end
 
   shared_examples 'register an offense and auto correct' do |message, corrected|

--- a/spec/rubocop/cop/rails/http_positional_arguments_spec.rb
+++ b/spec/rubocop/cop/rails/http_positional_arguments_spec.rb
@@ -143,7 +143,7 @@ post :create, params: { id: @user.id, ac: {
     end
   end
 
-  %w(post get patch put delete).each do |keyword|
+  %w[post get patch put delete].each do |keyword|
     it 'does not register an offense when keyword' do
       source = "@user.#{keyword}.id = ''"
       inspect_source(cop, source)

--- a/spec/rubocop/cop/rails/output_spec.rb
+++ b/spec/rubocop/cop/rails/output_spec.rb
@@ -23,7 +23,7 @@ describe RuboCop::Cop::Rails::Output do
   end
 
   it 'does not record an offense for methods without arguments' do
-    source = %w(print pp puts)
+    source = %w[print pp puts]
     inspect_source(cop, source)
     expect(cop.offenses).to be_empty
   end

--- a/spec/rubocop/cop/rails/uniq_before_pluck_spec.rb
+++ b/spec/rubocop/cop/rails/uniq_before_pluck_spec.rb
@@ -69,7 +69,7 @@ describe RuboCop::Cop::Rails::UniqBeforePluck, :config do
                     "instance.assoc.#{method}.pluck(:id)"
   end
 
-  %w(uniq distinct).each do |method|
+  %w[uniq distinct].each do |method|
     context 'when the enforced mode is conservative' do
       let(:cop_config) do
         { 'EnforcedMode' => 'conservative', 'AutoCorrect' => true }

--- a/spec/rubocop/cop/style/access_modifier_indentation_spec.rb
+++ b/spec/rubocop/cop/style/access_modifier_indentation_spec.rb
@@ -5,7 +5,7 @@ require 'spec_helper'
 describe RuboCop::Cop::Style::AccessModifierIndentation do
   subject(:cop) { described_class.new(config) }
   let(:config) do
-    c = cop_config.merge('SupportedStyles' => %w(indent outdent))
+    c = cop_config.merge('SupportedStyles' => %w[indent outdent])
     RuboCop::Config
       .new('Style/AccessModifierIndentation' => c,
            'Style/IndentationWidth' => { 'Width' => indentation_width })

--- a/spec/rubocop/cop/style/align_array_spec.rb
+++ b/spec/rubocop/cop/style/align_array_spec.rb
@@ -16,7 +16,7 @@ describe RuboCop::Cop::Style::AlignArray do
     expect(cop.messages).to eq(['Align the elements of an array ' \
                                 'literal if they span more than ' \
                                 'one line.'] * 2)
-    expect(cop.highlights).to eq(%w(b d))
+    expect(cop.highlights).to eq(%w[b d])
   end
 
   it 'accepts aligned array keys' do

--- a/spec/rubocop/cop/style/and_or_spec.rb
+++ b/spec/rubocop/cop/style/and_or_spec.rb
@@ -11,7 +11,7 @@ describe RuboCop::Cop::Style::AndOr, :config do
     subject(:cop) { described_class.new(config) }
     let(:cop_config) { cop_config }
 
-    %w(and or).each do |operator|
+    %w[and or].each do |operator|
       it "accepts \"#{operator}\" outside of conditional" do
         inspect_source(cop, "x = a + b #{operator} return x")
         expect(cop.offenses).to be_empty
@@ -48,7 +48,7 @@ describe RuboCop::Cop::Style::AndOr, :config do
       end
     end
 
-    %w(&& ||).each do |operator|
+    %w[&& ||].each do |operator|
       it "accepts #{operator} inside of conditional" do
         inspect_source(cop, "test if a #{operator} b")
         expect(cop.offenses).to be_empty

--- a/spec/rubocop/cop/style/block_delimiters_spec.rb
+++ b/spec/rubocop/cop/style/block_delimiters_spec.rb
@@ -34,9 +34,9 @@ describe RuboCop::Cop::Style::BlockDelimiters, :config do
   context 'Semantic style' do
     cop_config = {
       'EnforcedStyle' => 'semantic',
-      'ProceduralMethods' => %w(tap),
-      'FunctionalMethods' => %w(let),
-      'IgnoredMethods' => %w(lambda)
+      'ProceduralMethods' => %w[tap],
+      'FunctionalMethods' => %w[let],
+      'IgnoredMethods' => %w[lambda]
     }
 
     let(:cop_config) { cop_config }

--- a/spec/rubocop/cop/style/command_literal_spec.rb
+++ b/spec/rubocop/cop/style/command_literal_spec.rb
@@ -6,7 +6,7 @@ describe RuboCop::Cop::Style::CommandLiteral, :config do
   subject(:cop) { described_class.new(config) }
   let(:config) do
     supported_styles = {
-      'SupportedStyles' => %w(backticks percent_x mixed)
+      'SupportedStyles' => %w[backticks percent_x mixed]
     }
     RuboCop::Config.new('Style/PercentLiteralDelimiters' =>
                           percent_literal_delimiters_config,

--- a/spec/rubocop/cop/style/comment_annotation_spec.rb
+++ b/spec/rubocop/cop/style/comment_annotation_spec.rb
@@ -5,7 +5,7 @@ require 'spec_helper'
 describe RuboCop::Cop::Style::CommentAnnotation, :config do
   subject(:cop) { described_class.new(config) }
   let(:cop_config) do
-    { 'Keywords' => %w(TODO FIXME OPTIMIZE HACK REVIEW) }
+    { 'Keywords' => %w[TODO FIXME OPTIMIZE HACK REVIEW] }
   end
 
   context 'missing colon' do
@@ -22,7 +22,7 @@ describe RuboCop::Cop::Style::CommentAnnotation, :config do
   end
 
   context 'with configured keyword' do
-    let(:cop_config) { { 'Keywords' => %w(ISSUE) } }
+    let(:cop_config) { { 'Keywords' => %w[ISSUE] } }
 
     it 'registers an offense for a missing colon after the word' do
       inspect_source(cop, '# ISSUE wrong order')
@@ -122,7 +122,7 @@ describe RuboCop::Cop::Style::CommentAnnotation, :config do
 
   context 'when a keyword is not in the configuration' do
     let(:cop_config) do
-      { 'Keywords' => %w(FIXME OPTIMIZE HACK REVIEW) }
+      { 'Keywords' => %w[FIXME OPTIMIZE HACK REVIEW] }
     end
 
     it 'accepts the word without colon' do

--- a/spec/rubocop/cop/style/conditional_assignment_assign_in_condition_spec.rb
+++ b/spec/rubocop/cop/style/conditional_assignment_assign_in_condition_spec.rb
@@ -519,8 +519,8 @@ describe RuboCop::Cop::Style::ConditionalAssignment do
                             'Enabled' => true,
                             'SingleLineConditionsOnly' => true,
                             'EnforcedStyle' => 'assign_inside_condition',
-                            'SupportedStyles' => %w(assign_to_condition
-                                                    assign_inside_condition)
+                            'SupportedStyles' => %w[assign_to_condition
+                                                    assign_inside_condition]
                           },
                           'Lint/EndAlignment' => {
                             'AlignWith' => 'keyword',
@@ -707,8 +707,8 @@ describe RuboCop::Cop::Style::ConditionalAssignment do
                             'Enabled' => true,
                             'SingleLineConditionsOnly' => false,
                             'EnforcedStyle' => 'assign_inside_condition',
-                            'SupportedStyles' => %w(assign_to_condition
-                                                    assign_inside_condition)
+                            'SupportedStyles' => %w[assign_to_condition
+                                                    assign_inside_condition]
                           },
                           'Lint/EndAlignment' => {
                             'AlignWith' => 'keyword',

--- a/spec/rubocop/cop/style/conditional_assignment_assign_to_condition_spec.rb
+++ b/spec/rubocop/cop/style/conditional_assignment_assign_to_condition_spec.rb
@@ -9,8 +9,8 @@ describe RuboCop::Cop::Style::ConditionalAssignment do
                           'Enabled' => true,
                           'SingleLineConditionsOnly' => true,
                           'EnforcedStyle' => 'assign_to_condition',
-                          'SupportedStyles' => %w(assign_to_condition
-                                                  assign_inside_condition)
+                          'SupportedStyles' => %w[assign_to_condition
+                                                  assign_inside_condition]
                         },
                         'Lint/EndAlignment' => {
                           'AlignWith' => 'keyword',
@@ -1518,8 +1518,8 @@ describe RuboCop::Cop::Style::ConditionalAssignment do
                             'Enabled' => true,
                             'SingleLineConditionsOnly' => false,
                             'EnforcedStyle' => 'assign_to_condition',
-                            'SupportedStyles' => %w(assign_to_condition
-                                                    assign_inside_condition)
+                            'SupportedStyles' => %w[assign_to_condition
+                                                    assign_inside_condition]
                           },
                           'Lint/EndAlignment' => {
                             'AlignWith' => 'keyword',

--- a/spec/rubocop/cop/style/documentation_method_spec.rb
+++ b/spec/rubocop/cop/style/documentation_method_spec.rb
@@ -33,7 +33,7 @@ describe RuboCop::Cop::Style::DocumentationMethod, :config do
   let(:config) do
     RuboCop::Config.new(
       'Style/CommentAnnotation' => {
-        'Keywords' => %w(TODO FIXME OPTIMIZE HACK REVIEW)
+        'Keywords' => %w[TODO FIXME OPTIMIZE HACK REVIEW]
       },
       'Style/DocumentationMethod' => {
         'RequireForNonPublicMethods' => require_for_non_public_methods

--- a/spec/rubocop/cop/style/documentation_spec.rb
+++ b/spec/rubocop/cop/style/documentation_spec.rb
@@ -6,7 +6,7 @@ describe RuboCop::Cop::Style::Documentation do
   subject(:cop) { described_class.new(config) }
   let(:config) do
     RuboCop::Config.new('Style/CommentAnnotation' => {
-                          'Keywords' => %w(TODO FIXME OPTIMIZE HACK REVIEW)
+                          'Keywords' => %w[TODO FIXME OPTIMIZE HACK REVIEW]
                         })
   end
 
@@ -193,7 +193,7 @@ describe RuboCop::Cop::Style::Documentation do
   end
 
   context 'sparse and trailing comments' do
-    %w(class module).each do |keyword|
+    %w[class module].each do |keyword|
       it "ignores comments after #{keyword} node end" do
         inspect_source(cop,
                        ['module TestModule',
@@ -221,7 +221,7 @@ describe RuboCop::Cop::Style::Documentation do
   end
 
   context 'with # :nodoc:' do
-    %w(class module).each do |keyword|
+    %w[class module].each do |keyword|
       it "accepts non-namespace #{keyword} without documentation" do
         inspect_source(cop,
                        ["#{keyword} Test #:nodoc:",

--- a/spec/rubocop/cop/style/each_with_object_spec.rb
+++ b/spec/rubocop/cop/style/each_with_object_spec.rb
@@ -19,7 +19,7 @@ describe RuboCop::Cop::Style::EachWithObject do
     expect(cop.messages)
       .to eq(['Use `each_with_object` instead of `inject`.',
               'Use `each_with_object` instead of `reduce`.'])
-    expect(cop.highlights).to eq(%w(inject reduce))
+    expect(cop.highlights).to eq(%w[inject reduce])
   end
 
   it 'correctly autocorrects' do

--- a/spec/rubocop/cop/style/empty_else_spec.rb
+++ b/spec/rubocop/cop/style/empty_else_spec.rb
@@ -13,7 +13,7 @@ describe RuboCop::Cop::Style::EmptyElse do
       end
     end
 
-    %w(both if case).each do |missing_else_style|
+    %w[both if case].each do |missing_else_style|
       context "MissingElse is #{missing_else_style}" do
         let(:missing_else_config) do
           { 'Enabled' => true,
@@ -50,7 +50,7 @@ describe RuboCop::Cop::Style::EmptyElse do
     let(:config) do
       RuboCop::Config.new('Style/EmptyElse' => {
                             'EnforcedStyle' => 'empty',
-                            'SupportedStyles' => %w(empty nil both)
+                            'SupportedStyles' => %w[empty nil both]
                           },
                           'Style/MissingElse' => missing_else_config)
     end
@@ -172,7 +172,7 @@ describe RuboCop::Cop::Style::EmptyElse do
     let(:config) do
       RuboCop::Config.new('Style/EmptyElse' => {
                             'EnforcedStyle' => 'nil',
-                            'SupportedStyles' => %w(empty nil both)
+                            'SupportedStyles' => %w[empty nil both]
                           },
                           'Style/MissingElse' => missing_else_config)
     end
@@ -361,7 +361,7 @@ describe RuboCop::Cop::Style::EmptyElse do
     let(:config) do
       RuboCop::Config.new('Style/EmptyElse' => {
                             'EnforcedStyle' => 'both',
-                            'SupportedStyles' => %w(empty nil both)
+                            'SupportedStyles' => %w[empty nil both]
                           },
                           'Style/MissingElse' => missing_else_config)
     end

--- a/spec/rubocop/cop/style/empty_lines_around_access_modifier_spec.rb
+++ b/spec/rubocop/cop/style/empty_lines_around_access_modifier_spec.rb
@@ -5,7 +5,7 @@ require 'spec_helper'
 describe RuboCop::Cop::Style::EmptyLinesAroundAccessModifier do
   subject(:cop) { described_class.new }
 
-  %w(private protected public module_function).each do |access_modifier|
+  %w[private protected public module_function].each do |access_modifier|
     it "requires blank line before #{access_modifier}" do
       inspect_source(cop,
                      ['class Test',

--- a/spec/rubocop/cop/style/empty_lines_around_block_body_spec.rb
+++ b/spec/rubocop/cop/style/empty_lines_around_block_body_spec.rb
@@ -6,7 +6,7 @@ describe RuboCop::Cop::Style::EmptyLinesAroundBlockBody, :config do
   subject(:cop) { described_class.new(config) }
 
   # Test blocks using both {} and do..end
-  [%w({ }), %w(do end)].each do |open, close|
+  [%w[{ }], %w[do end]].each do |open, close|
     context "when EnforcedStyle is no_empty_lines for #{open} #{close} block" do
       let(:cop_config) { { 'EnforcedStyle' => 'no_empty_lines' } }
 

--- a/spec/rubocop/cop/style/file_name_spec.rb
+++ b/spec/rubocop/cop/style/file_name_spec.rb
@@ -121,7 +121,7 @@ describe RuboCop::Cop::Style::FileName do
     end
 
     context 'on a file which defines no class or module at all' do
-      %w(lib src test spec).each do |dir|
+      %w[lib src test spec].each do |dir|
         context "under #{dir}" do
           let(:filename) { "/some/dir/#{dir}/file/test_case.rb" }
 
@@ -168,7 +168,7 @@ describe RuboCop::Cop::Style::FileName do
     end
 
     shared_examples 'matching module or class' do
-      %w(lib src test spec).each do |dir|
+      %w[lib src test spec].each do |dir|
         context "in a matching directory under #{dir}" do
           let(:filename) { "/some/dir/#{dir}/a/b.rb" }
 

--- a/spec/rubocop/cop/style/first_parameter_indentation_spec.rb
+++ b/spec/rubocop/cop/style/first_parameter_indentation_spec.rb
@@ -10,8 +10,8 @@ describe RuboCop::Cop::Style::FirstParameterIndentation do
       .new('Style/FirstParameterIndentation' => {
              'EnforcedStyle' => style,
              'SupportedStyles' =>
-               %w(consistent special_for_inner_method_call
-                  special_for_inner_method_call_in_parentheses)
+               %w[consistent special_for_inner_method_call
+                  special_for_inner_method_call_in_parentheses]
            },
            'Style/IndentationWidth' => { 'Width' => indentation_width })
   end
@@ -220,8 +220,8 @@ describe RuboCop::Cop::Style::FirstParameterIndentation do
           .new('Style/FirstParameterIndentation' => {
                  'EnforcedStyle' => style,
                  'SupportedStyles' =>
-                   %w(consistent special_for_inner_method_call
-                      special_for_inner_method_call_in_parentheses),
+                   %w[consistent special_for_inner_method_call
+                      special_for_inner_method_call_in_parentheses],
                  'IndentationWidth' => 4
                },
                'Style/IndentationWidth' => { 'Width' => 2 })

--- a/spec/rubocop/cop/style/frozen_string_literal_comment_spec.rb
+++ b/spec/rubocop/cop/style/frozen_string_literal_comment_spec.rb
@@ -9,7 +9,7 @@ describe RuboCop::Cop::Style::FrozenStringLiteralComment, :config do
     let(:cop_config) do
       { 'Enabled'           => true,
         'EnforcedStyle'     => 'always',
-        'SupportedStyles'   => %w(always when_needed) }
+        'SupportedStyles'   => %w[always when_needed] }
     end
 
     it 'accepts an empty source' do
@@ -213,7 +213,7 @@ describe RuboCop::Cop::Style::FrozenStringLiteralComment, :config do
     let(:cop_config) do
       { 'Enabled'           => true,
         'EnforcedStyle'     => 'when_needed',
-        'SupportedStyles'   => %w(always when_needed) }
+        'SupportedStyles'   => %w[always when_needed] }
     end
 
     it 'accepts an empty source' do

--- a/spec/rubocop/cop/style/guard_clause_spec.rb
+++ b/spec/rubocop/cop/style/guard_clause_spec.rb
@@ -25,7 +25,7 @@ describe RuboCop::Cop::Style::GuardClause, :config do
       expect(cop.messages)
         .to eq(['Use a guard clause instead of wrapping ' \
                 'the code inside a conditional expression.'] * 2)
-      expect(cop.highlights).to eq(%w(if unless))
+      expect(cop.highlights).to eq(%w[if unless])
     end
 
     it 'reports an offense if method body is if / unless without else' do
@@ -46,7 +46,7 @@ describe RuboCop::Cop::Style::GuardClause, :config do
       expect(cop.messages)
         .to eq(['Use a guard clause instead of wrapping ' \
                 'the code inside a conditional expression.'] * 2)
-      expect(cop.highlights).to eq(%w(if unless))
+      expect(cop.highlights).to eq(%w[if unless])
     end
 
     it 'reports an offense if method body ends with if / unless without else' do
@@ -69,7 +69,7 @@ describe RuboCop::Cop::Style::GuardClause, :config do
       expect(cop.messages)
         .to eq(['Use a guard clause instead of wrapping ' \
                 'the code inside a conditional expression.'] * 2)
-      expect(cop.highlights).to eq(%w(if unless))
+      expect(cop.highlights).to eq(%w[if unless])
     end
   end
 
@@ -179,7 +179,7 @@ describe RuboCop::Cop::Style::GuardClause, :config do
       expect(cop.messages)
         .to eq(['Use a guard clause instead of wrapping ' \
                 'the code inside a conditional expression.'] * 2)
-      expect(cop.highlights).to eq(%w(if unless))
+      expect(cop.highlights).to eq(%w[if unless])
     end
   end
 

--- a/spec/rubocop/cop/style/hash_syntax_spec.rb
+++ b/spec/rubocop/cop/style/hash_syntax_spec.rb
@@ -20,7 +20,7 @@ describe RuboCop::Cop::Style::HashSyntax, :config do
       let(:cop_config) do
         {
           'EnforcedStyle'   => 'ruby19',
-          'SupportedStyles' => %w(ruby19 hash_rockets),
+          'SupportedStyles' => %w[ruby19 hash_rockets],
           'UseHashRocketsWithSymbolValues' => false,
           'PreferHashRocketsForNonAlnumEndingSymbols' => false
         }.merge(cop_config_overrides)
@@ -140,7 +140,7 @@ describe RuboCop::Cop::Style::HashSyntax, :config do
                             },
                             'Style/HashSyntax' => {
                               'EnforcedStyle'   => 'ruby19',
-                              'SupportedStyles' => %w(ruby19 hash_rockets),
+                              'SupportedStyles' => %w[ruby19 hash_rockets],
                               'UseHashRocketsWithSymbolValues' => false
                             },
                             'Style/SpaceAroundOperators' => {
@@ -158,7 +158,7 @@ describe RuboCop::Cop::Style::HashSyntax, :config do
       let(:config) do
         RuboCop::Config.new('Style/HashSyntax' => {
                               'EnforcedStyle' => 'ruby19',
-                              'SupportedStyles' => %w(ruby19 hash_rockets),
+                              'SupportedStyles' => %w[ruby19 hash_rockets],
                               'UseHashRocketsWithSymbolValues' => true
                             })
       end
@@ -234,7 +234,7 @@ describe RuboCop::Cop::Style::HashSyntax, :config do
     let(:cop_config) do
       {
         'EnforcedStyle' => 'hash_rockets',
-        'SupportedStyles' => %w(ruby19 hash_rockets),
+        'SupportedStyles' => %w[ruby19 hash_rockets],
         'UseHashRocketsWithSymbolValues' => false
       }
     end
@@ -275,7 +275,7 @@ describe RuboCop::Cop::Style::HashSyntax, :config do
       let(:cop_config) do
         {
           'EnforcedStyle' => 'hash_rockets',
-          'SupportedStyles' => %w(ruby19 hash_rockets),
+          'SupportedStyles' => %w[ruby19 hash_rockets],
           'UseHashRocketsWithSymbolValues' => true
         }
       end

--- a/spec/rubocop/cop/style/implicit_runtime_error_spec.rb
+++ b/spec/rubocop/cop/style/implicit_runtime_error_spec.rb
@@ -5,7 +5,7 @@ require 'spec_helper'
 describe RuboCop::Cop::Style::ImplicitRuntimeError do
   subject(:cop) { described_class.new }
 
-  %w(raise fail).each do |method|
+  %w[raise fail].each do |method|
     it "registers an offense for #{method} 'message'" do
       inspect_source(cop, "#{method} 'message'")
       expect(cop.offenses.size).to eq 1

--- a/spec/rubocop/cop/style/indent_array_spec.rb
+++ b/spec/rubocop/cop/style/indent_array_spec.rb
@@ -6,8 +6,8 @@ describe RuboCop::Cop::Style::IndentArray do
   subject(:cop) { described_class.new(config) }
   let(:config) do
     supported_styles = {
-      'SupportedStyles' => %w(special_inside_parentheses consistent
-                              align_brackets)
+      'SupportedStyles' => %w[special_inside_parentheses consistent
+                              align_brackets]
     }
     RuboCop::Config.new('Style/IndentArray' =>
                         cop_config.merge(supported_styles).merge(

--- a/spec/rubocop/cop/style/indent_hash_spec.rb
+++ b/spec/rubocop/cop/style/indent_hash_spec.rb
@@ -6,8 +6,8 @@ describe RuboCop::Cop::Style::IndentHash do
   subject(:cop) { described_class.new(config) }
   let(:config) do
     supported_styles = {
-      'SupportedStyles' => %w(special_inside_parentheses consistent
-                              align_braces)
+      'SupportedStyles' => %w[special_inside_parentheses consistent
+                              align_braces]
     }
     RuboCop::Config.new('Style/AlignHash' => align_hash_config,
                         'Style/IndentHash' =>

--- a/spec/rubocop/cop/style/infinite_loop_spec.rb
+++ b/spec/rubocop/cop/style/infinite_loop_spec.rb
@@ -19,7 +19,7 @@ describe RuboCop::Cop::Style::InfiniteLoop do
     end
   end
 
-  %w(false nil).each do |lit|
+  %w[false nil].each do |lit|
     it "registers an offense for a until loop with #{lit} as condition" do
       inspect_source(cop,
                      ["until #{lit}",

--- a/spec/rubocop/cop/style/method_name_spec.rb
+++ b/spec/rubocop/cop/style/method_name_spec.rb
@@ -45,7 +45,7 @@ describe RuboCop::Cop::Style::MethodName, :config do
       expect(cop.offenses).to be_empty
     end
 
-    %w(class module).each do |kind|
+    %w[class module].each do |kind|
       it "accepts class emitter method in a #{kind}" do
         inspect_source(cop, ["#{kind} Sequel",
                              '  def self.Model(source)',

--- a/spec/rubocop/cop/style/missing_else_spec.rb
+++ b/spec/rubocop/cop/style/missing_else_spec.rb
@@ -10,7 +10,7 @@ describe RuboCop::Cop::Style::MissingElse do
       RuboCop::Config.new('Style/MissingElse' => {
                             'Enabled' => true,
                             'EnforcedStyle' => 'both',
-                            'SupportedStyles' => %w(if case both)
+                            'SupportedStyles' => %w[if case both]
                           },
                           'Style/UnlessElse' => { 'Enabled' => true })
     end
@@ -113,7 +113,7 @@ describe RuboCop::Cop::Style::MissingElse do
       RuboCop::Config.new('Style/MissingElse' => {
                             'Enabled' => true,
                             'EnforcedStyle' => 'both',
-                            'SupportedStyles' => %w(if case both)
+                            'SupportedStyles' => %w[if case both]
                           },
                           'Style/UnlessElse' => { 'Enabled' => false })
     end
@@ -214,7 +214,7 @@ describe RuboCop::Cop::Style::MissingElse do
 
   context 'EmptyElse enabled and set to warn on empty' do
     let(:config) do
-      styles = %w(if case both)
+      styles = %w[if case both]
       RuboCop::Config.new('Style/MissingElse' => {
                             'Enabled' => true,
                             'EnforcedStyle' => 'both',
@@ -224,7 +224,7 @@ describe RuboCop::Cop::Style::MissingElse do
                           'Style/EmptyElse' => {
                             'Enabled' => true,
                             'EnforcedStyle' => 'empty',
-                            'SupportedStyles' => %w(empty nil both)
+                            'SupportedStyles' => %w[empty nil both]
                           })
     end
 
@@ -332,7 +332,7 @@ describe RuboCop::Cop::Style::MissingElse do
 
   context 'EmptyElse enabled and set to warn on nil' do
     let(:config) do
-      styles = %w(if case both)
+      styles = %w[if case both]
       RuboCop::Config.new('Style/MissingElse' => {
                             'Enabled' => true,
                             'EnforcedStyle' => 'both',
@@ -342,7 +342,7 @@ describe RuboCop::Cop::Style::MissingElse do
                           'Style/EmptyElse' => {
                             'Enabled' => true,
                             'EnforcedStyle' => 'nil',
-                            'SupportedStyles' => %w(empty nil both)
+                            'SupportedStyles' => %w[empty nil both]
                           })
     end
 
@@ -442,7 +442,7 @@ describe RuboCop::Cop::Style::MissingElse do
 
   context 'configured to warn only on empty if' do
     let(:config) do
-      styles = %w(if case both)
+      styles = %w[if case both]
       RuboCop::Config.new('Style/MissingElse' => {
                             'Enabled' => true,
                             'EnforcedStyle' => 'if',
@@ -452,7 +452,7 @@ describe RuboCop::Cop::Style::MissingElse do
                           'Style/EmptyElse' => {
                             'Enabled' => true,
                             'EnforcedStyle' => 'nil',
-                            'SupportedStyles' => %w(empty nil both)
+                            'SupportedStyles' => %w[empty nil both]
                           })
     end
 
@@ -551,7 +551,7 @@ describe RuboCop::Cop::Style::MissingElse do
 
   context 'configured to warn only on empty case' do
     let(:config) do
-      styles = %w(if case both)
+      styles = %w[if case both]
       RuboCop::Config.new('Style/MissingElse' => {
                             'Enabled' => true,
                             'EnforcedStyle' => 'case',
@@ -561,7 +561,7 @@ describe RuboCop::Cop::Style::MissingElse do
                           'Style/EmptyElse' => {
                             'Enabled' => true,
                             'EnforcedStyle' => 'nil',
-                            'SupportedStyles' => %w(empty nil both)
+                            'SupportedStyles' => %w[empty nil both]
                           })
     end
 

--- a/spec/rubocop/cop/style/multiline_assignment_layout_spec.rb
+++ b/spec/rubocop/cop/style/multiline_assignment_layout_spec.rb
@@ -4,7 +4,7 @@ require 'spec_helper'
 
 describe RuboCop::Cop::Style::MultilineAssignmentLayout, :config do
   subject(:cop) { described_class.new(config) }
-  let(:supported_types) { %w(if) }
+  let(:supported_types) { %w[if] }
 
   let(:cop_config) do
     {
@@ -41,7 +41,7 @@ describe RuboCop::Cop::Style::MultilineAssignmentLayout, :config do
     end
 
     context 'configured supported types' do
-      let(:supported_types) { %w(array) }
+      let(:supported_types) { %w[array] }
 
       it 'allows supported types to be configured' do
         inspect_source(cop, ['a, b = 4,',
@@ -105,7 +105,7 @@ describe RuboCop::Cop::Style::MultilineAssignmentLayout, :config do
     end
 
     context 'configured supported types' do
-      let(:supported_types) { %w(array) }
+      let(:supported_types) { %w[array] }
 
       it 'allows supported types to be configured' do
         inspect_source(cop, ['a, b =',

--- a/spec/rubocop/cop/style/multiline_method_call_indentation_spec.rb
+++ b/spec/rubocop/cop/style/multiline_method_call_indentation_spec.rb
@@ -159,7 +159,7 @@ describe RuboCop::Cop::Style::MultilineMethodCallIndentation do
       expect(cop.messages)
         .to eq(['Use 2 (not 3) spaces for indenting an expression spanning ' \
                 'multiple lines.'] * 2)
-      expect(cop.highlights).to eq(%w(b d))
+      expect(cop.highlights).to eq(%w[b d])
     end
 
     it 'registers an offense for extra indentation of third line' do
@@ -541,7 +541,7 @@ describe RuboCop::Cop::Style::MultilineMethodCallIndentation do
       expect(cop.messages)
         .to eq(['Indent `b` 2 spaces more than `a` on line 1.',
                 'Indent `d` 2 spaces more than `c` on line 3.'])
-      expect(cop.highlights).to eq(%w(b d))
+      expect(cop.highlights).to eq(%w[b d])
     end
 
     it 'registers an offense for extra indentation of third line' do
@@ -651,10 +651,10 @@ describe RuboCop::Cop::Style::MultilineMethodCallIndentation do
     end
 
     [
-      %w(an if),
-      %w(an unless),
-      %w(a while),
-      %w(an until)
+      %w[an if],
+      %w[an unless],
+      %w[a while],
+      %w[an until]
     ].each do |article, keyword|
       it "accepts double indentation of #{keyword} condition" do
         inspect_source(cop,
@@ -688,7 +688,7 @@ describe RuboCop::Cop::Style::MultilineMethodCallIndentation do
       end
     end
 
-    %w(unless if).each do |keyword|
+    %w[unless if].each do |keyword|
       it "accepts special indentation of return #{keyword} condition" do
         inspect_source(cop,
                        ["return #{keyword} receiver.nil? &&",
@@ -736,7 +736,7 @@ describe RuboCop::Cop::Style::MultilineMethodCallIndentation do
                       '    d'])
       expect(cop.messages).to eq(['Use 2 (not 4) spaces for indenting an ' \
                                   'expression spanning multiple lines.'])
-      expect(cop.highlights).to eq(%w(d))
+      expect(cop.highlights).to eq(%w[d])
       expect(cop.config_to_allow_offenses).to eq('Enabled' => false)
     end
 
@@ -799,10 +799,10 @@ describe RuboCop::Cop::Style::MultilineMethodCallIndentation do
       end
 
       [
-        %w(an if),
-        %w(an unless),
-        %w(a while),
-        %w(an until)
+        %w[an if],
+        %w[an unless],
+        %w[a while],
+        %w[an until]
       ].each do |article, keyword|
         it "accepts indentation of #{keyword} condition which is offset " \
            'by a single normal indentation step' do

--- a/spec/rubocop/cop/style/multiline_operation_indentation_spec.rb
+++ b/spec/rubocop/cop/style/multiline_operation_indentation_spec.rb
@@ -82,7 +82,7 @@ describe RuboCop::Cop::Style::MultilineOperationIndentation do
                       '   d'])
       expect(cop.messages).to eq(['Use 2 (not 3) spaces for indenting an ' \
                                   'expression spanning multiple lines.'] * 2)
-      expect(cop.highlights).to eq(%w(b d))
+      expect(cop.highlights).to eq(%w[b d])
     end
 
     it 'registers an offense for extra indentation of third line' do
@@ -296,10 +296,10 @@ describe RuboCop::Cop::Style::MultilineOperationIndentation do
     end
 
     [
-      %w(an if),
-      %w(an unless),
-      %w(a while),
-      %w(an until)
+      %w[an if],
+      %w[an unless],
+      %w[a while],
+      %w[an until]
     ].each do |article, keyword|
       it "registers an offense for misaligned operands in #{keyword} " \
          'condition' do
@@ -423,10 +423,10 @@ describe RuboCop::Cop::Style::MultilineOperationIndentation do
     end
 
     [
-      %w(an if),
-      %w(an unless),
-      %w(a while),
-      %w(an until)
+      %w[an if],
+      %w[an unless],
+      %w[a while],
+      %w[an until]
     ].each do |article, keyword|
       it "accepts double indentation of #{keyword} condition" do
         inspect_source(cop,
@@ -464,7 +464,7 @@ describe RuboCop::Cop::Style::MultilineOperationIndentation do
       end
     end
 
-    %w(unless if).each do |keyword|
+    %w[unless if].each do |keyword|
       it "accepts special indentation of return #{keyword} condition" do
         inspect_source(cop,
                        ["return #{keyword} receiver.nil? &&",
@@ -509,7 +509,7 @@ describe RuboCop::Cop::Style::MultilineOperationIndentation do
                       '    d'])
       expect(cop.messages).to eq(['Use 2 (not 4) spaces for indenting an ' \
                                   'expression spanning multiple lines.'])
-      expect(cop.highlights).to eq(%w(d))
+      expect(cop.highlights).to eq(%w[d])
       expect(cop.config_to_allow_offenses).to eq('Enabled' => false)
     end
 
@@ -547,10 +547,10 @@ describe RuboCop::Cop::Style::MultilineOperationIndentation do
       end
 
       [
-        %w(an if),
-        %w(an unless),
-        %w(a while),
-        %w(an until)
+        %w[an if],
+        %w[an unless],
+        %w[a while],
+        %w[an until]
       ].each do |article, keyword|
         it "accepts indentation of #{keyword} condition which is offset " \
            'by a single normal indentation step' do

--- a/spec/rubocop/cop/style/numeric_literal_prefix_spec.rb
+++ b/spec/rubocop/cop/style/numeric_literal_prefix_spec.rb
@@ -18,7 +18,7 @@ describe RuboCop::Cop::Style::NumericLiteralPrefix, :config do
                              'b(0O1234)'])
         expect(cop.offenses.size).to eq(2)
         expect(cop.messages.uniq).to eq(['Use 0o for octal literals.'])
-        expect(cop.highlights).to eq(%w(01234 0O1234))
+        expect(cop.highlights).to eq(%w[01234 0O1234])
       end
 
       it 'does not register offense for lowercase prefix' do
@@ -50,7 +50,7 @@ describe RuboCop::Cop::Style::NumericLiteralPrefix, :config do
                              'b(0o1234)'])
         expect(cop.offenses.size).to eq(2)
         expect(cop.messages.uniq).to eq(['Use 0 for octal literals.'])
-        expect(cop.highlights).to eq(%w(0O1234 0o1234))
+        expect(cop.highlights).to eq(%w[0O1234 0o1234])
       end
 
       it 'does not register offense for prefix `0`' do
@@ -77,7 +77,7 @@ describe RuboCop::Cop::Style::NumericLiteralPrefix, :config do
                            'b(0XABC)'])
       expect(cop.offenses.size).to eq(2)
       expect(cop.messages.uniq).to eq(['Use 0x for hexadecimal literals.'])
-      expect(cop.highlights).to eq(%w(0X1AC 0XABC))
+      expect(cop.highlights).to eq(%w[0X1AC 0XABC])
     end
 
     it 'does not register offense for lowercase prefix' do
@@ -97,7 +97,7 @@ describe RuboCop::Cop::Style::NumericLiteralPrefix, :config do
                            'b(0B111)'])
       expect(cop.offenses.size).to eq(2)
       expect(cop.messages.uniq).to eq(['Use 0b for binary literals.'])
-      expect(cop.highlights).to eq(%w(0B10101 0B111))
+      expect(cop.highlights).to eq(%w[0B10101 0B111])
     end
 
     it 'does not register offense for lowercase prefix' do
@@ -118,7 +118,7 @@ describe RuboCop::Cop::Style::NumericLiteralPrefix, :config do
       expect(cop.offenses.size).to eq(2)
       expect(cop.messages.uniq)
         .to eq(['Do not use prefixes for decimal literals.'])
-      expect(cop.highlights).to eq(%w(0d1234 0D1234))
+      expect(cop.highlights).to eq(%w[0d1234 0D1234])
     end
 
     it 'does not register offense for no prefix' do

--- a/spec/rubocop/cop/style/one_line_conditional_spec.rb
+++ b/spec/rubocop/cop/style/one_line_conditional_spec.rb
@@ -66,8 +66,8 @@ describe RuboCop::Cop::Style::OneLineConditional do
     include_examples 'no offense'
   end
 
-  %w(| ^ & <=> == === =~ > >= < <= << >> + - * / % ** ~ ! != !~
-     && ||).each do |operator|
+  %w[| ^ & <=> == === =~ > >= < <= << >> + - * / % ** ~ ! != !~
+     && ||].each do |operator|
     it 'parenthesizes the expression if it is preceded by an operator' do
       corrected =
         autocorrect_source(cop, "a #{operator} if cond then run else dont end")

--- a/spec/rubocop/cop/style/parentheses_around_condition_spec.rb
+++ b/spec/rubocop/cop/style/parentheses_around_condition_spec.rb
@@ -94,7 +94,7 @@ describe RuboCop::Cop::Style::ParenthesesAroundCondition, :config do
     expect(cop.offenses).to be_empty
   end
 
-  %w(rescue if unless while until).each do |op|
+  %w[rescue if unless while until].each do |op|
     it "allows parens if the condition node is a modifier #{op} op" do
       inspect_source(cop, ["if (something #{op} top)",
                            'end'])

--- a/spec/rubocop/cop/style/predicate_name_spec.rb
+++ b/spec/rubocop/cop/style/predicate_name_spec.rb
@@ -7,11 +7,11 @@ describe RuboCop::Cop::Style::PredicateName, :config do
 
   context 'with blacklisted prefixes' do
     let(:cop_config) do
-      { 'NamePrefix' => %w(has_ is_),
-        'NamePrefixBlacklist' => %w(has_ is_) }
+      { 'NamePrefix' => %w[has_ is_],
+        'NamePrefixBlacklist' => %w[has_ is_] }
     end
 
-    %w(has is).each do |prefix|
+    %w[has is].each do |prefix|
       it 'registers an offense when method name starts with known prefix' do
         inspect_source(cop, ["def #{prefix}_attr",
                              '  # ...',
@@ -32,10 +32,10 @@ describe RuboCop::Cop::Style::PredicateName, :config do
 
   context 'without blacklisted prefixes' do
     let(:cop_config) do
-      { 'NamePrefix' => %w(has_ is_), 'NamePrefixBlacklist' => [] }
+      { 'NamePrefix' => %w[has_ is_], 'NamePrefixBlacklist' => [] }
     end
 
-    %w(has is).each do |prefix|
+    %w[has is].each do |prefix|
       it 'registers an offense when method name starts with known prefix' do
         inspect_source(cop, ["def #{prefix}_attr",
                              '  # ...',
@@ -57,8 +57,8 @@ describe RuboCop::Cop::Style::PredicateName, :config do
 
   context 'with whitelisted predicate names' do
     let(:cop_config) do
-      { 'NamePrefix' => %w(is_), 'NamePrefixBlacklist' => %w(is_),
-        'NameWhitelist' => %w(is_a?) }
+      { 'NamePrefix' => %w[is_], 'NamePrefixBlacklist' => %w[is_],
+        'NameWhitelist' => %w[is_a?] }
     end
 
     it 'accepts method name which is in whitelist' do

--- a/spec/rubocop/cop/style/regexp_literal_spec.rb
+++ b/spec/rubocop/cop/style/regexp_literal_spec.rb
@@ -6,7 +6,7 @@ describe RuboCop::Cop::Style::RegexpLiteral, :config do
   subject(:cop) { described_class.new(config) }
   let(:config) do
     supported_styles = {
-      'SupportedStyles' => %w(slashes percent_r mixed)
+      'SupportedStyles' => %w[slashes percent_r mixed]
     }
     RuboCop::Config.new('Style/PercentLiteralDelimiters' =>
                           percent_literal_delimiters_config,

--- a/spec/rubocop/cop/style/single_line_block_params_spec.rb
+++ b/spec/rubocop/cop/style/single_line_block_params_spec.rb
@@ -6,8 +6,8 @@ describe RuboCop::Cop::Style::SingleLineBlockParams, :config do
   subject(:cop) { described_class.new(config) }
   let(:cop_config) do
     { 'Methods' =>
-      [{ 'reduce' => %w(a e) },
-       { 'test' => %w(x y) }] }
+      [{ 'reduce' => %w[a e] },
+       { 'test' => %w[x y] }] }
   end
 
   it 'finds wrong argument names in calls with different syntax' do

--- a/spec/rubocop/cop/style/space_inside_array_percent_literal_spec.rb
+++ b/spec/rubocop/cop/style/space_inside_array_percent_literal_spec.rb
@@ -5,8 +5,8 @@ require 'spec_helper'
 describe RuboCop::Cop::Style::SpaceInsideArrayPercentLiteral do
   subject(:cop) { described_class.new }
 
-  %w(i I w W).each do |type|
-    [%w({ }), %w{( )}, %w([ ]), %w(! !)].each do |(ldelim, rdelim)|
+  %w[i I w W].each do |type|
+    [%w[{ }], %w[( )], %w([ ]), %w[! !]].each do |(ldelim, rdelim)|
       context "for #{type} type and #{[ldelim, rdelim]} delimiters" do
         define_method(:example) do |content|
           ['%', type, ldelim, content, rdelim].join

--- a/spec/rubocop/cop/style/space_inside_block_braces_spec.rb
+++ b/spec/rubocop/cop/style/space_inside_block_braces_spec.rb
@@ -3,7 +3,7 @@
 require 'spec_helper'
 
 describe RuboCop::Cop::Style::SpaceInsideBlockBraces, :config do
-  SUPPORTED_STYLES = %w(space no_space).freeze
+  SUPPORTED_STYLES = %w[space no_space].freeze
 
   subject(:cop) { described_class.new(config) }
   let(:cop_config) do

--- a/spec/rubocop/cop/style/space_inside_percent_literal_delimiters_spec.rb
+++ b/spec/rubocop/cop/style/space_inside_percent_literal_delimiters_spec.rb
@@ -6,7 +6,7 @@ describe RuboCop::Cop::Style::SpaceInsidePercentLiteralDelimiters do
   subject(:cop) { described_class.new }
 
   %w(i I w W x).each do |type|
-    [%w({ }), %w{( )}, %w([ ]), %w(! !)].each do |(ldelim, rdelim)|
+    [%w[{ }], %w[( )], %w([ ]), %w[! !]].each do |(ldelim, rdelim)|
       context "for #{type} type and #{[ldelim, rdelim]} delimiters" do
         define_method(:example) do |content|
           ['%', type, ldelim, content, rdelim].join

--- a/spec/rubocop/cop/style/space_inside_percent_literal_delimiters_spec.rb
+++ b/spec/rubocop/cop/style/space_inside_percent_literal_delimiters_spec.rb
@@ -5,7 +5,7 @@ require 'spec_helper'
 describe RuboCop::Cop::Style::SpaceInsidePercentLiteralDelimiters do
   subject(:cop) { described_class.new }
 
-  %w(i I w W x).each do |type|
+  %w[i I w W x].each do |type|
     [%w[{ }], %w[( )], %w([ ]), %w[! !]].each do |(ldelim, rdelim)|
       context "for #{type} type and #{[ldelim, rdelim]} delimiters" do
         define_method(:example) do |content|
@@ -91,7 +91,7 @@ describe RuboCop::Cop::Style::SpaceInsidePercentLiteralDelimiters do
   end
 
   it 'accepts other percent literals' do
-    %w(q r s).each do |type|
+    %w[q r s].each do |type|
       inspect_source(cop, "%#{type}( a  b c )")
       expect(cop.messages).to be_empty
     end

--- a/spec/rubocop/cop/style/string_methods_spec.rb
+++ b/spec/rubocop/cop/style/string_methods_spec.rb
@@ -18,7 +18,7 @@ RSpec.describe RuboCop::Cop::Style::StringMethods, :config do
       expect(cop.offenses.size).to eq(1)
       expect(cop.messages)
         .to eq(["Prefer `#{preferred_method}` over `#{method}`."])
-      expect(cop.highlights).to eq(%w(intern))
+      expect(cop.highlights).to eq(%w[intern])
     end
   end
 end

--- a/spec/rubocop/cop/style/symbol_proc_spec.rb
+++ b/spec/rubocop/cop/style/symbol_proc_spec.rb
@@ -5,7 +5,7 @@ require 'spec_helper'
 describe RuboCop::Cop::Style::SymbolProc, :config do
   subject(:cop) { described_class.new(config) }
 
-  let(:cop_config) { { 'IgnoredMethods' => %w(respond_to) } }
+  let(:cop_config) { { 'IgnoredMethods' => %w[respond_to] } }
 
   it 'registers an offense for a block with parameterless method call on ' \
      'param' do

--- a/spec/rubocop/cop/style/ternary_parentheses_spec.rb
+++ b/spec/rubocop/cop/style/ternary_parentheses_spec.rb
@@ -180,7 +180,7 @@ describe RuboCop::Cop::Style::TernaryParentheses, :config do
         'Style/RedundantParentheses' => { 'Enabled' => true },
         'Style/TernaryParentheses' => {
           'EnforcedStyle' => 'require_parentheses',
-          'SupportedStyles' => %w(require_parentheses require_no_parentheses)
+          'SupportedStyles' => %w[require_parentheses require_no_parentheses]
         }
       )
     end

--- a/spec/rubocop/cop/style/word_array_spec.rb
+++ b/spec/rubocop/cop/style/word_array_spec.rb
@@ -47,7 +47,7 @@ describe RuboCop::Cop::Style::WordArray, :config do
 
     it 'uses %W when autocorrecting strings with newlines and tabs' do
       new_source = autocorrect_source(cop, %(["one\\n", "hi\\tthere"]))
-      expect(new_source).to eq('%W(one\\n hi\\tthere)')
+      expect(new_source).to eq('%W[one\\n hi\\tthere]')
     end
 
     it 'does not register an offense for array of non-words' do
@@ -105,20 +105,20 @@ describe RuboCop::Cop::Style::WordArray, :config do
 
     it 'auto-corrects an array of words' do
       new_source = autocorrect_source(cop, "['one', %q(two), 'three']")
-      expect(new_source).to eq('%w(one two three)')
+      expect(new_source).to eq('%w[one two three]')
     end
 
     it 'auto-corrects an array of words and character constants' do
       new_source = autocorrect_source(cop, '[%{one}, %Q(two), ?\n, ?\t]')
-      expect(new_source).to eq('%W(one two \n \t)')
+      expect(new_source).to eq('%W[one two \n \t]')
     end
 
     it 'keeps the line breaks in place after auto-correct' do
       new_source = autocorrect_source(cop,
                                       ["['one',",
                                        "'two', 'three']"])
-      expect(new_source).to eq(['%w(one ',
-                                'two three)'].join("\n"))
+      expect(new_source).to eq(['%w[one ',
+                                'two three]'].join("\n"))
     end
 
     it 'detects right value of MinSize to use for --auto-gen-config' do
@@ -204,7 +204,7 @@ describe RuboCop::Cop::Style::WordArray, :config do
 
     it 'auto-corrects an array of email addresses' do
       new_source = autocorrect_source(cop, "['a@example.com', 'b@example.com']")
-      expect(new_source).to eq('%w(a@example.com b@example.com)')
+      expect(new_source).to eq('%w[a@example.com b@example.com]')
     end
   end
 
@@ -213,12 +213,12 @@ describe RuboCop::Cop::Style::WordArray, :config do
 
     it 'uses %W when autocorrecting strings with non-printable chars' do
       new_source = autocorrect_source(cop, '["\x1f\x1e", "hello"]')
-      expect(new_source).to eq('%W(\u001F\u001E hello)')
+      expect(new_source).to eq('%W[\u001F\u001E hello]')
     end
 
     it 'uses %w for strings which only appear to have an escape' do
       new_source = autocorrect_source(cop, "['hi\\tthere', 'again\\n']")
-      expect(new_source).to eq('%w(hi\\tthere again\\n)')
+      expect(new_source).to eq('%w[hi\\tthere again\\n]')
     end
   end
 
@@ -232,7 +232,7 @@ describe RuboCop::Cop::Style::WordArray, :config do
 
     it "doesn't break when words contain delimiters" do
       new_source = autocorrect_source(cop, "[')', ']']")
-      expect(new_source).to eq('%w(\\) ])')
+      expect(new_source).to eq('%w[) \\]]')
     end
   end
 end

--- a/spec/rubocop/cop/team_spec.rb
+++ b/spec/rubocop/cop/team_spec.rb
@@ -117,10 +117,10 @@ describe RuboCop::Cop::Team do
 
     context 'when some classes are disabled with config' do
       let(:disabled_config) do
-        %w(
+        %w[
           Lint/Void
           Metrics/LineLength
-        ).each_with_object(RuboCop::Config.new) do |cop_name, accum|
+        ].each_with_object(RuboCop::Config.new) do |cop_name, accum|
           accum[cop_name] = { 'Enabled' => false }
         end
       end

--- a/spec/rubocop/cop/variable_force/scope_spec.rb
+++ b/spec/rubocop/cop/variable_force/scope_spec.rb
@@ -183,7 +183,7 @@ describe RuboCop::Cop::VariableForce::Scope do
         END
 
         let(:scope_node_type) { :def }
-        let(:expected_types) { %w(def args arg arg sym) }
+        let(:expected_types) { %w[def args arg arg sym] }
         include_examples 'yields', 'the argument and the body nodes'
       end
 
@@ -195,7 +195,7 @@ describe RuboCop::Cop::VariableForce::Scope do
         END
 
         let(:scope_node_type) { :defs }
-        let(:expected_types) { %w(defs args arg arg sym) }
+        let(:expected_types) { %w[defs args arg arg sym] }
         include_examples 'yields', 'the argument and the body nodes'
       end
 
@@ -207,7 +207,7 @@ describe RuboCop::Cop::VariableForce::Scope do
         END
 
         let(:scope_node_type) { :module }
-        let(:expected_types) { %w(module sym) }
+        let(:expected_types) { %w[module sym] }
         include_examples 'yields', 'the body nodes'
       end
 
@@ -221,7 +221,7 @@ describe RuboCop::Cop::VariableForce::Scope do
         END
 
         let(:scope_node_type) { :class }
-        let(:expected_types) { %w(sym) }
+        let(:expected_types) { %w[sym] }
         include_examples 'yields', 'the body nodes'
       end
 
@@ -235,7 +235,7 @@ describe RuboCop::Cop::VariableForce::Scope do
         END
 
         let(:scope_node_type) { :sclass }
-        let(:expected_types) { %w(sym) }
+        let(:expected_types) { %w[sym] }
         include_examples 'yields', 'the body nodes'
       end
 
@@ -247,7 +247,7 @@ describe RuboCop::Cop::VariableForce::Scope do
         END
 
         let(:scope_node_type) { :block }
-        let(:expected_types) { %w(block args arg arg sym) }
+        let(:expected_types) { %w[block args arg arg sym] }
         include_examples 'yields', 'the argument and the body nodes'
       end
 
@@ -257,7 +257,7 @@ describe RuboCop::Cop::VariableForce::Scope do
         END
 
         let(:scope_node_type) { :sym }
-        let(:expected_types) { %w(sym) }
+        let(:expected_types) { %w[sym] }
         include_examples 'yields', 'the body nodes'
       end
     end
@@ -275,7 +275,7 @@ describe RuboCop::Cop::VariableForce::Scope do
         END
 
         let(:scope_node_type) { :begin }
-        let(:expected_types) { %w(begin lvasgn int block send int int lvar) }
+        let(:expected_types) { %w[begin lvasgn int block send int int lvar] }
         include_examples 'yields', 'only the block node and the child send node'
       end
 
@@ -291,7 +291,7 @@ describe RuboCop::Cop::VariableForce::Scope do
         END
 
         let(:scope_node_type) { :begin }
-        let(:expected_types) { %w(begin lvasgn int defs self lvar) }
+        let(:expected_types) { %w[begin lvasgn int defs self lvar] }
         include_examples 'yields', 'only the defs node and the method host node'
       end
 
@@ -309,7 +309,7 @@ describe RuboCop::Cop::VariableForce::Scope do
 
         let(:scope_node_type) { :begin }
         let(:expected_types) do
-          %w(begin lvasgn int if true begin send send lvar)
+          %w[begin lvasgn int if true begin send send lvar]
         end
         include_examples 'yields', 'them without confused with top level scope'
       end

--- a/spec/rubocop/formatter/disabled_lines_formatter_spec.rb
+++ b/spec/rubocop/formatter/disabled_lines_formatter_spec.rb
@@ -9,7 +9,7 @@ module RuboCop
       let(:output) { StringIO.new }
 
       let(:files) do
-        %w(lib/rubocop.rb spec/spec_helper.rb bin/rubocop).map do |path|
+        %w[lib/rubocop.rb spec/spec_helper.rb bin/rubocop].map do |path|
           File.expand_path(path)
         end
       end

--- a/spec/rubocop/formatter/emacs_style_formatter_spec.rb
+++ b/spec/rubocop/formatter/emacs_style_formatter_spec.rb
@@ -12,7 +12,7 @@ module RuboCop
         it 'displays parsable text' do
           cop = Cop::Cop.new
           source_buffer = Parser::Source::Buffer.new('test', 1)
-          source_buffer.source = %w(a b cdefghi).join("\n")
+          source_buffer.source = %w[a b cdefghi].join("\n")
 
           cop.add_offense(nil,
                           Parser::Source::Range.new(source_buffer, 0, 1),

--- a/spec/rubocop/formatter/file_list_formatter_spec.rb
+++ b/spec/rubocop/formatter/file_list_formatter_spec.rb
@@ -12,7 +12,7 @@ module RuboCop
         it 'displays parsable text' do
           cop = Cop::Cop.new
           source_buffer = Parser::Source::Buffer.new('test', 1)
-          source_buffer.source = %w(a b cdefghi).join("\n")
+          source_buffer.source = %w[a b cdefghi].join("\n")
 
           cop.add_offense(nil,
                           Parser::Source::Range.new(source_buffer, 0, 1),

--- a/spec/rubocop/formatter/fuubar_style_formatter_spec.rb
+++ b/spec/rubocop/formatter/fuubar_style_formatter_spec.rb
@@ -8,7 +8,7 @@ module RuboCop
     let(:output) { StringIO.new }
 
     let(:files) do
-      %w(lib/rubocop.rb spec/spec_helper.rb).map do |path|
+      %w[lib/rubocop.rb spec/spec_helper.rb].map do |path|
         File.expand_path(path)
       end
     end

--- a/spec/rubocop/formatter/json_formatter_spec.rb
+++ b/spec/rubocop/formatter/json_formatter_spec.rb
@@ -6,10 +6,10 @@ module RuboCop
   describe Formatter::JSONFormatter do
     subject(:formatter) { described_class.new(output) }
     let(:output) { StringIO.new }
-    let(:files) { %w(/path/to/file1 /path/to/file2) }
+    let(:files) { %w[/path/to/file1 /path/to/file2] }
     let(:location) do
       source_buffer = Parser::Source::Buffer.new('test', 1)
-      source_buffer.source = %w(a b cdefghi).join("\n")
+      source_buffer.source = %w[a b cdefghi].join("\n")
       Parser::Source::Range.new(source_buffer, 9, 10)
     end
     let(:offense) do
@@ -22,7 +22,7 @@ module RuboCop
 
       it 'sets target file count in summary' do
         expect(summary[:target_file_count]).to be_nil
-        formatter.started(%w(/path/to/file1 /path/to/file2))
+        formatter.started(%w[/path/to/file1 /path/to/file2])
         expect(summary[:target_file_count]).to eq(2)
       end
     end
@@ -68,7 +68,7 @@ module RuboCop
 
       it 'sets inspected file count in summary' do
         expect(summary[:inspected_file_count]).to be_nil
-        formatter.finished(%w(/path/to/file1 /path/to/file2))
+        formatter.finished(%w[/path/to/file1 /path/to/file2])
         expect(summary[:inspected_file_count]).to eq(2)
       end
 

--- a/spec/rubocop/formatter/offense_count_formatter_spec.rb
+++ b/spec/rubocop/formatter/offense_count_formatter_spec.rb
@@ -9,7 +9,7 @@ module RuboCop
       let(:output) { StringIO.new }
 
       let(:files) do
-        %w(lib/rubocop.rb spec/spec_helper.rb bin/rubocop).map do |path|
+        %w[lib/rubocop.rb spec/spec_helper.rb bin/rubocop].map do |path|
           File.expand_path(path)
         end
       end
@@ -49,7 +49,7 @@ module RuboCop
       describe '#finished' do
         context 'when there are many offenses' do
           let(:offenses) do
-            %w(CopB CopA CopC CopC).map { |c| double('offense', cop_name: c) }
+            %w[CopB CopA CopC CopC].map { |c| double('offense', cop_name: c) }
           end
 
           before do

--- a/spec/rubocop/formatter/progress_formatter_spec.rb
+++ b/spec/rubocop/formatter/progress_formatter_spec.rb
@@ -8,7 +8,7 @@ module RuboCop
     let(:output) { StringIO.new }
 
     let(:files) do
-      %w(lib/rubocop.rb spec/spec_helper.rb bin/rubocop).map do |path|
+      %w[lib/rubocop.rb spec/spec_helper.rb bin/rubocop].map do |path|
         File.expand_path(path)
       end
     end

--- a/spec/rubocop/formatter/worst_offenders_formatter_spec.rb
+++ b/spec/rubocop/formatter/worst_offenders_formatter_spec.rb
@@ -9,7 +9,7 @@ module RuboCop
       let(:output) { StringIO.new }
 
       let(:files) do
-        %w(lib/rubocop.rb spec/spec_helper.rb bin/rubocop).map do |path|
+        %w[lib/rubocop.rb spec/spec_helper.rb bin/rubocop].map do |path|
           File.expand_path(path)
         end
       end

--- a/spec/rubocop/options_spec.rb
+++ b/spec/rubocop/options_spec.rb
@@ -129,47 +129,47 @@ Usage: rubocop [options] [file1, file2, ...]
     describe 'incompatible cli options' do
       it 'fails with argument correct error' do
         msg = 'Incompatible cli options: [:version, :verbose_version]'
-        expect { options.parse %w(-vV) }
+        expect { options.parse %w[-vV] }
           .to raise_error(ArgumentError, msg)
       end
 
       it 'fails with argument correct error' do
         msg = 'Incompatible cli options: [:version, :show_cops]'
-        expect { options.parse %w(-v --show-cops) }
+        expect { options.parse %w[-v --show-cops] }
           .to raise_error(ArgumentError, msg)
       end
 
       it 'fails with argument correct error' do
         msg = 'Incompatible cli options: [:verbose_version, :show_cops]'
-        expect { options.parse %w(-V --show-cops) }
+        expect { options.parse %w[-V --show-cops] }
           .to raise_error(ArgumentError, msg)
       end
 
       it 'fails with argument correct error' do
         msg = ['Incompatible cli options: [:version, :verbose_version,',
                ' :show_cops]'].join
-        expect { options.parse %w(-vV --show-cops) }
+        expect { options.parse %w[-vV --show-cops] }
           .to raise_error(ArgumentError, msg)
       end
     end
 
     describe '--fail-level' do
       it 'accepts full severity names' do
-        %w(refactor convention warning error fatal).each do |severity|
+        %w[refactor convention warning error fatal].each do |severity|
           expect { options.parse(['--fail-level', severity]) }
             .not_to raise_error
         end
       end
 
       it 'accepts severity initial letters' do
-        %w(R C W E F).each do |severity|
+        %w[R C W E F].each do |severity|
           expect { options.parse(['--fail-level', severity]) }
             .not_to raise_error
         end
       end
 
       it 'accepts the "fake" severities A/autocorrect' do
-        %w(autocorrect A).each do |severity|
+        %w[autocorrect A].each do |severity|
           expect { options.parse(['--fail-level', severity]) }
             .not_to raise_error
         end
@@ -193,48 +193,48 @@ Usage: rubocop [options] [file1, file2, ...]
 
     describe '--cache' do
       it 'fails if no argument is given' do
-        expect { options.parse %w(--cache) }
+        expect { options.parse %w[--cache] }
           .to raise_error(OptionParser::MissingArgument)
       end
 
       it 'fails if unrecognized argument is given' do
-        expect { options.parse %w(--cache maybe) }.to raise_error(ArgumentError)
+        expect { options.parse %w[--cache maybe] }.to raise_error(ArgumentError)
       end
 
       it 'accepts true as argument' do
-        expect { options.parse %w(--cache true) }.to_not raise_error
+        expect { options.parse %w[--cache true] }.to_not raise_error
       end
 
       it 'accepts false as argument' do
-        expect { options.parse %w(--cache false) }.to_not raise_error
+        expect { options.parse %w[--cache false] }.to_not raise_error
       end
     end
 
     describe '--exclude-limit' do
       it 'fails if given last without argument' do
-        expect { options.parse %w(--auto-gen-config --exclude-limit) }
+        expect { options.parse %w[--auto-gen-config --exclude-limit] }
           .to raise_error(OptionParser::MissingArgument)
       end
 
       it 'fails if given alone without argument' do
-        expect { options.parse %w(--exclude-limit) }
+        expect { options.parse %w[--exclude-limit] }
           .to raise_error(OptionParser::MissingArgument)
       end
 
       it 'fails if given first without argument' do
-        expect { options.parse %w(--exclude-limit --auto-gen-config) }
+        expect { options.parse %w[--exclude-limit --auto-gen-config] }
           .to raise_error(OptionParser::MissingArgument)
       end
 
       it 'fails if given without --auto-gen-config' do
-        expect { options.parse %w(--exclude-limit 10) }
+        expect { options.parse %w[--exclude-limit 10] }
           .to raise_error(ArgumentError)
       end
     end
 
     describe '--auto-gen-config' do
       it 'accepts other options' do
-        expect { options.parse %w(--auto-gen-config --rails) }
+        expect { options.parse %w[--auto-gen-config --rails] }
           .not_to raise_error
       end
     end
@@ -247,15 +247,15 @@ Usage: rubocop [options] [file1, file2, ...]
       end
 
       it 'fails if no paths are given' do
-        expect { options.parse %w(-s) }.to raise_error(ArgumentError)
+        expect { options.parse %w[-s] }.to raise_error(ArgumentError)
       end
 
       it 'succeeds with exactly one path' do
-        expect { options.parse %w(--stdin foo) }.not_to raise_error
+        expect { options.parse %w[--stdin foo] }.not_to raise_error
       end
 
       it 'fails if more than one path is given' do
-        expect { options.parse %w(--stdin foo bar) }
+        expect { options.parse %w[--stdin foo bar] }
           .to raise_error(ArgumentError)
       end
     end
@@ -268,13 +268,13 @@ Usage: rubocop [options] [file1, file2, ...]
     ensure
       ENV.delete('RUBOCOP_OPTS')
     end
-    let(:command_line_options) { %w(--no-color) }
+    let(:command_line_options) { %w[--no-color] }
 
     subject { options.parse(command_line_options).first }
 
     context '.rubocop file' do
       before do
-        create_file('.rubocop', %w(--color --fail-level C))
+        create_file('.rubocop', %w[--color --fail-level C])
       end
 
       it 'has lower precedence then command line options' do
@@ -306,7 +306,7 @@ Usage: rubocop [options] [file1, file2, ...]
       end
 
       it 'has higher precedence then options from .rubocop file' do
-        create_file('.rubocop', %w(--color --fail-level C))
+        create_file('.rubocop', %w[--color --fail-level C])
 
         with_env_options '--fail-level W' do
           is_expected.to eq(color: false, fail_level: :warning)

--- a/spec/rubocop/processed_source_spec.rb
+++ b/spec/rubocop/processed_source_spec.rb
@@ -144,13 +144,13 @@ describe RuboCop::ProcessedSource do
 
     context 'when a range is passed' do
       it 'returns the array of lines' do
-        expect(processed_source[3..4]).to eq(%w(end some_method))
+        expect(processed_source[3..4]).to eq(%w[end some_method])
       end
     end
 
     context 'when start index and length are passed' do
       it 'returns the array of lines' do
-        expect(processed_source[3, 2]).to eq(%w(end some_method))
+        expect(processed_source[3, 2]).to eq(%w[end some_method])
       end
     end
   end

--- a/spec/rubocop/string_util_spec.rb
+++ b/spec/rubocop/string_util_spec.rb
@@ -6,10 +6,10 @@ module RuboCop
   module StringUtil
     describe Jaro do
       {
-        %w(foo foo)       => 1.000,
-        %w(foo bar)       => 0.000,
-        %w(martha marhta) => 0.944,
-        %w(dwayne duane)  => 0.822
+        %w[foo foo]       => 1.000,
+        %w[foo bar]       => 0.000,
+        %w[martha marhta] => 0.944,
+        %w[dwayne duane]  => 0.822
       }.each do |strings, expected|
         context "with #{strings.first.inspect} and #{strings.last.inspect}" do
           subject(:distance) { Jaro.distance(*strings) }
@@ -25,13 +25,13 @@ module RuboCop
       # These samples are derived from Apache Lucene project.
       # https://github.com/apache/lucene-solr/blob/lucene_solr_4_9_0/lucene/suggest/src/test/org/apache/lucene/search/spell/TestJaroWinklerDistance.java
       {
-        %w(al al)             => 1.000,
-        %w(martha marhta)     => 0.961,
-        %w(jones johnson)     => 0.832,
-        %w(abcvwxyz cabvwxyz) => 0.958,
-        %w(dwayne duane)      => 0.840,
-        %w(dixon dicksonx)    => 0.813,
-        %w(fvie ten)          => 0.000
+        %w[al al]             => 1.000,
+        %w[martha marhta]     => 0.961,
+        %w[jones johnson]     => 0.832,
+        %w[abcvwxyz cabvwxyz] => 0.958,
+        %w[dwayne duane]      => 0.840,
+        %w[dixon dicksonx]    => 0.813,
+        %w[fvie ten]          => 0.000
       }.each do |strings, expected|
         context "with #{strings.first.inspect} and #{strings.last.inspect}" do
           subject(:distance) { JaroWinkler.distance(*strings) }

--- a/spec/rubocop/target_finder_spec.rb
+++ b/spec/rubocop/target_finder_spec.rb
@@ -79,7 +79,7 @@ describe RuboCop::TargetFinder, :isolated_environment do
     end
 
     context 'when same paths are passed' do
-      let(:args) { %w(dir1 dir1) }
+      let(:args) { %w[dir1 dir1] }
 
       it 'does not return duplicated file paths' do
         count = found_basenames.count { |f| f == 'ruby1.rb' }


### PR DESCRIPTION
This is an attempt to make https://github.com/bbatsov/ruby-style-guide/pull/563 easier to merge.

To me, square brackets look like arrays and round brackets look like functions/grouping.  I appreciate the visual distinction.

This PR also allows bare `[]` and `{}` in the yaml config, potentially helping https://github.com/bbatsov/rubocop/issues/3541.

It is meant as a demonstration and to hopefully encourage discussion.  The style guide should be updated first of course.

---

Before submitting the PR make sure the following are checked:
- [x] Wrote [good commit messages](http://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html).
- [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
- [x] Used the same coding conventions as the rest of the project.
- [x] Feature branch is up-to-date with `master` (if not - rebase it).
- [x] Squashed related commits together.
- [x] Added tests.
- [x] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
- [x] All tests are passing.
- [x] The new code doesn't generate RuboCop offenses.
- [x] The PR relates to _only_ one subject with a clear title
  and description in grammatically correct, complete sentences.
