### PR TITLE
Fix false positive for Metrics/MethodLength and Metrics/BlockLength

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 * [#3607](https://github.com/bbatsov/rubocop/pull/3607): Fix `Style/RedundantReturn` cop for empty if body. ([@pocke][])
 * [#3291](https://github.com/bbatsov/rubocop/issues/3291): Improve detection of `raw` and `html_safe` methods in `Rails/OutputSafety`. ([@lumeet][])
 * Redundant return style now properly handles empty `when` blocks. ([@albus522][])
+* [#3622](https://github.com/bbatsov/rubocop/pull/3622): Fix false positive for `Metrics/MethodLength` and `Metrics/BlockLength`. ([@meganemura][])
 
 ## 0.44.1 (2016-10-13)
 

--- a/lib/rubocop/cop/mixin/too_many_lines.rb
+++ b/lib/rubocop/cop/mixin/too_many_lines.rb
@@ -16,9 +16,23 @@ module RuboCop
       end
 
       def code_length(node)
-        lines = node.source.lines.to_a[1...-1] || []
+        body = extract_body(node)
+        lines = body && body.source.lines || []
 
         lines.count { |line| !irrelevant_line(line) }
+      end
+
+      def extract_body(node)
+        case node.type
+        when :block, :def
+          _receiver_or_method, _args, body = *node
+        when :defs
+          _self, _method, _args, body = *node
+        else
+          body = node
+        end
+
+        body
       end
     end
   end

--- a/spec/rubocop/cop/metrics/block_length_spec.rb
+++ b/spec/rubocop/cop/metrics/block_length_spec.rb
@@ -47,6 +47,18 @@ describe RuboCop::Cop::Metrics::BlockLength, :config do
     expect(cop.offenses).to be_empty
   end
 
+  it 'accepts a block with multiline receiver and less than 3 lines of body' do
+    inspect_source(cop, ['[',
+                         '  :a,',
+                         '  :b,',
+                         '  :c,',
+                         '].each do',
+                         '  a = 1',
+                         '  a = 2',
+                         'end'])
+    expect(cop.offenses).to be_empty
+  end
+
   it 'accepts empty blocks' do
     inspect_source(cop, ['something do',
                          'end'])

--- a/spec/rubocop/cop/metrics/method_length_spec.rb
+++ b/spec/rubocop/cop/metrics/method_length_spec.rb
@@ -45,6 +45,19 @@ describe RuboCop::Cop::Metrics::MethodLength, :config do
     expect(cop.offenses).to be_empty
   end
 
+  it 'accepts a method with multiline arguments ' \
+     'and less than 5 lines of body' do
+    inspect_source(cop, ['def m(x,',
+                         '      y,',
+                         '      z)',
+                         '  a = 1',
+                         '  a = 2',
+                         '  a = 3',
+                         '  a = 4',
+                         'end'])
+    expect(cop.offenses).to be_empty
+  end
+
   it 'does not count blank lines' do
     inspect_source(cop, ['def m()',
                          '  a = 1',


### PR DESCRIPTION
`Metrics/MethodLength` and `Metrics/BlockLength` cops count lines of code incorrectly.
These cops count not only inside body but also definition/receiver.

Example for Metrics/BlockLength:
```ruby
# frozen_string_literal: true
[    # This line is treated as beginning of the block in counting logic
  1,
  2,
  3,
  4,
  5,
  6,
  7,
  8,
  9,
  10,
  11,
  12,
  13,
  14,
  15,
  16,
  17,
  18,
  19,
  20,
  21,
  22,
  23,
  24
].each do |x|  # 25
  puts x       # 26
end
```

RuboCop says
```
test.rb:2:1: C: Metrics/BlockLength: Block has too many lines. [26/25]
[ ...
^
```

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Used the same coding conventions as the rest of the project.
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] All tests are passing.
* [x] The new code doesn't generate RuboCop offenses.
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.

[1]: http://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html

