### PR TITLE
Add new style empty_lines_special to module and class body

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### New features
 
 * [#3600](https://github.com/bbatsov/rubocop/issues/3600): Add new `Bundler/DuplicatedGem` cop. ([@jmks][])
+* [#3624](https://github.com/bbatsov/rubocop/pull/3624): Add new configuration option `empty_lines_special` to `Style/EmptyLinesAroundClassBody` and `Style/EmptyLinesAroundModuleBody`. ([@legendetm][])
 
 ### Changes
 

--- a/config/default.yml
+++ b/config/default.yml
@@ -436,6 +436,7 @@ Style/EmptyLinesAroundClassBody:
   SupportedStyles:
     - empty_lines
     - empty_lines_except_namespace
+    - empty_lines_special
     - no_empty_lines
 
 Style/EmptyLinesAroundModuleBody:
@@ -443,6 +444,7 @@ Style/EmptyLinesAroundModuleBody:
   SupportedStyles:
     - empty_lines
     - empty_lines_except_namespace
+    - empty_lines_special
     - no_empty_lines
 
 # Checks whether the source file has a utf-8 encoding comment or not

--- a/lib/rubocop/cop/mixin/empty_lines_around_body.rb
+++ b/lib/rubocop/cop/mixin/empty_lines_around_body.rb
@@ -11,13 +11,15 @@ module RuboCop
 
         MSG_EXTRA = 'Extra empty line detected at %s body %s.'.freeze
         MSG_MISSING = 'Empty line missing at %s body %s.'.freeze
+        MSG_DEFERRED = 'Empty line missing before first %s definition'.freeze
 
         def_node_matcher :constant_definition?, '{class module}'
+        def_node_matcher :empty_line_required?, '{def defs class module}'
 
         def autocorrect(args)
-          offence_style, range = args
+          offense_style, range = args
           lambda do |corrector|
-            case offence_style
+            case offense_style
             when :no_empty_lines then
               corrector.remove(range)
             when :empty_lines then
@@ -40,31 +42,59 @@ module RuboCop
 
           case style
           when :empty_lines_except_namespace
-            if namespace?(body, with_one_child: true)
-              check_source(:no_empty_lines, first_line, last_line)
-            else
-              check_source(:empty_lines, first_line, last_line)
-            end
+            check_empty_lines_except_namespace(body, first_line, last_line)
+          when :empty_lines_special
+            check_empty_lines_special(body, first_line, last_line)
           else
-            check_source(style, first_line, last_line)
+            check_both(style, first_line, last_line)
           end
         end
 
-        def check_source(style, start_line, end_line)
+        def check_empty_lines_except_namespace(body, first_line, last_line)
+          if namespace?(body, with_one_child: true)
+            check_both(:no_empty_lines, first_line, last_line)
+          else
+            check_both(:empty_lines, first_line, last_line)
+          end
+        end
+
+        def check_empty_lines_special(body, first_line, last_line)
+          return unless body
+          if namespace?(body, with_one_child: true)
+            check_both(:no_empty_lines, first_line, last_line)
+          else
+            if first_child_requires_empty_line?(body)
+              check_beginning(:empty_lines, first_line)
+            else
+              check_beginning(:no_empty_lines, first_line)
+              check_deferred_empty_line(body)
+            end
+            check_ending(:empty_lines, last_line)
+          end
+        end
+
+        def check_both(style, first_line, last_line)
+          check_beginning(style, first_line)
+          check_ending(style, last_line)
+        end
+
+        def check_beginning(style, first_line)
+          check_source(style, first_line, 'beginning')
+        end
+
+        def check_ending(style, last_line)
+          check_source(style, last_line - 2, 'end')
+        end
+
+        def check_source(style, line_no, desc)
           case style
           when :no_empty_lines
-            check_both(style, start_line, end_line, MSG_EXTRA, &:empty?)
+            check_line(style, line_no, message(MSG_EXTRA, desc), &:empty?)
           when :empty_lines
-            check_both(style, start_line, end_line, MSG_MISSING) do |line|
+            check_line(style, line_no, message(MSG_MISSING, desc)) do |line|
               !line.empty?
             end
           end
-        end
-
-        def check_both(style, start_line, end_line, msg, &block)
-          kind = self.class::KIND
-          check_line(style, start_line, format(msg, kind, 'beginning'), &block)
-          check_line(style, end_line - 2, format(msg, kind, 'end'), &block)
         end
 
         def check_line(style, line, msg)
@@ -75,13 +105,55 @@ module RuboCop
           add_offense([style, range], range, msg)
         end
 
-        def namespace?(node, with_one_child: true)
-          if node.begin_type?
+        def check_deferred_empty_line(body)
+          node = first_empty_line_required_child(body)
+          return unless node
+
+          line = previous_line_ignoring_comments(node.loc.first_line)
+          return if processed_source[line].empty?
+
+          range = source_range(processed_source.buffer, line + 2, 0)
+          add_offense([:empty_lines, range], range, deferred_message(node))
+        end
+
+        def namespace?(body, with_one_child: false)
+          if body.begin_type?
             return false if with_one_child
-            node.children.all? { |child| constant_definition?(child) }
+            body.children.all? { |child| constant_definition?(child) }
           else
-            constant_definition?(node)
+            constant_definition?(body)
           end
+        end
+
+        def first_child_requires_empty_line?(body)
+          if body.begin_type?
+            empty_line_required?(body.children.first)
+          else
+            empty_line_required?(body)
+          end
+        end
+
+        def first_empty_line_required_child(body)
+          if body.begin_type?
+            body.children.find { |child| empty_line_required?(child) }
+          elsif empty_line_required?(body)
+            body
+          end
+        end
+
+        def previous_line_ignoring_comments(send_line)
+          (send_line - 2).downto(0) do |line|
+            return line unless comment_line?(processed_source[line])
+          end
+          0
+        end
+
+        def message(type, desc)
+          format(type, self.class::KIND, desc)
+        end
+
+        def deferred_message(node)
+          format(MSG_DEFERRED, node.type)
         end
       end
     end

--- a/spec/rubocop/cop/style/empty_lines_around_class_body_spec.rb
+++ b/spec/rubocop/cop/style/empty_lines_around_class_body_spec.rb
@@ -4,6 +4,12 @@ require 'spec_helper'
 
 describe RuboCop::Cop::Style::EmptyLinesAroundClassBody, :config do
   subject(:cop) { described_class.new(config) }
+  let(:extra_begin) { 'Extra empty line detected at class body beginning.' }
+  let(:extra_end) { 'Extra empty line detected at class body end.' }
+  let(:missing_begin) { 'Empty line missing at class body beginning.' }
+  let(:missing_end) { 'Empty line missing at class body end.' }
+  let(:missing_def) { 'Empty line missing before first def definition' }
+  let(:missing_type) { 'Empty line missing before first class definition' }
 
   context 'when EnforcedStyle is no_empty_lines' do
     let(:cop_config) { { 'EnforcedStyle' => 'no_empty_lines' } }
@@ -129,10 +135,6 @@ describe RuboCop::Cop::Style::EmptyLinesAroundClassBody, :config do
 
   context 'when EnforcedStyle is empty_lines_except_namespace' do
     let(:cop_config) { { 'EnforcedStyle' => 'empty_lines_except_namespace' } }
-    let(:extra_begin) { 'Extra empty line detected at class body beginning.' }
-    let(:extra_end) { 'Extra empty line detected at class body end.' }
-    let(:missing_begin) { 'Empty line missing at class body beginning.' }
-    let(:missing_end) { 'Empty line missing at class body end.' }
 
     context 'when only child is class' do
       it 'requires no empty lines for namespace' do
@@ -285,4 +287,6 @@ describe RuboCop::Cop::Style::EmptyLinesAroundClassBody, :config do
       end
     end
   end
+
+  include_examples 'empty_lines_around_class_or_module_body', 'class'
 end

--- a/spec/rubocop/cop/style/empty_lines_around_module_body_spec.rb
+++ b/spec/rubocop/cop/style/empty_lines_around_module_body_spec.rb
@@ -4,6 +4,12 @@ require 'spec_helper'
 
 describe RuboCop::Cop::Style::EmptyLinesAroundModuleBody, :config do
   subject(:cop) { described_class.new(config) }
+  let(:extra_begin) { 'Extra empty line detected at module body beginning.' }
+  let(:extra_end) { 'Extra empty line detected at module body end.' }
+  let(:missing_begin) { 'Empty line missing at module body beginning.' }
+  let(:missing_end) { 'Empty line missing at module body end.' }
+  let(:missing_def) { 'Empty line missing before first def definition' }
+  let(:missing_type) { 'Empty line missing before first module definition' }
 
   context 'when EnforcedStyle is no_empty_lines' do
     let(:cop_config) { { 'EnforcedStyle' => 'no_empty_lines' } }
@@ -85,10 +91,6 @@ describe RuboCop::Cop::Style::EmptyLinesAroundModuleBody, :config do
 
   context 'when EnforcedStyle is empty_lines_except_namespace' do
     let(:cop_config) { { 'EnforcedStyle' => 'empty_lines_except_namespace' } }
-    let(:extra_begin) { 'Extra empty line detected at module body beginning.' }
-    let(:extra_end) { 'Extra empty line detected at module body end.' }
-    let(:missing_begin) { 'Empty line missing at module body beginning.' }
-    let(:missing_end) { 'Empty line missing at module body end.' }
 
     context 'when only child is class' do
       it 'requires no empty lines for namespace' do
@@ -241,4 +243,6 @@ describe RuboCop::Cop::Style::EmptyLinesAroundModuleBody, :config do
       end
     end
   end
+
+  include_examples 'empty_lines_around_class_or_module_body', 'module'
 end

--- a/spec/support/empty_lines_around_body_shared_examples.rb
+++ b/spec/support/empty_lines_around_body_shared_examples.rb
@@ -1,0 +1,401 @@
+# frozen_string_literal: true
+
+shared_examples_for 'empty_lines_around_class_or_module_body' do |type|
+  context 'when EnforcedStyle is empty_lines_special' do
+    let(:cop_config) { { 'EnforcedStyle' => 'empty_lines_special' } }
+
+    context 'when first child is method' do
+      it "requires blank line at the beginning and ending of #{type} body" do
+        inspect_source(cop,
+                       ["#{type} SomeObject",
+                        '',
+                        '  def do_something; end',
+                        '',
+                        'end'])
+        expect(cop.messages).to eq([])
+      end
+
+      context 'source without blank lines' do
+        let(:source) do
+          ["#{type} SomeObject",
+           '  def do_something; end',
+           'end']
+        end
+
+        it "registers an offense for #{type} not beginning "\
+          'and ending with a blank line' do
+          inspect_source(cop, source)
+          expect(cop.messages).to eq([missing_begin, missing_end])
+        end
+
+        it 'autocorrects the offenses' do
+          new_source = autocorrect_source(cop, source)
+          expect(new_source).to eq(["#{type} SomeObject",
+                                    '',
+                                    '  def do_something; end',
+                                    '',
+                                    'end'].join("\n"))
+        end
+      end
+
+      context "when #{type} has a namespace" do
+        it 'requires no empty lines for namespace but '\
+          "requires blank line at the beginning and ending of #{type} body" do
+          inspect_source(cop,
+                         ["#{type} Parent",
+                          "  #{type} SomeObject",
+                          '',
+                          '    def do_something',
+                          '    end',
+                          '',
+                          '  end',
+                          'end'])
+          expect(cop.messages).to eq([])
+        end
+
+        context 'source without blank lines' do
+          let(:source) do
+            ["#{type} Parent",
+             "  #{type} SomeObject",
+             '    def do_something',
+             '    end',
+             '  end',
+             'end']
+          end
+
+          it 'autocorrects the offenses' do
+            new_source = autocorrect_source(cop, source)
+            expect(new_source).to eq(["#{type} Parent",
+                                      "  #{type} SomeObject",
+                                      '',
+                                      '    def do_something',
+                                      '    end',
+                                      '',
+                                      '  end',
+                                      'end'].join("\n"))
+          end
+        end
+
+        context 'source with blank lines' do
+          let(:source) do
+            ["#{type} Parent",
+             '',
+             "  #{type} SomeObject",
+             '',
+             '    def do_something',
+             '    end',
+             '',
+             '  end',
+             '',
+             'end']
+          end
+
+          it 'autocorrects the offenses' do
+            new_source = autocorrect_source(cop, source)
+            expect(new_source).to eq(["#{type} Parent",
+                                      "  #{type} SomeObject",
+                                      '',
+                                      '    def do_something',
+                                      '    end',
+                                      '',
+                                      '  end',
+                                      'end'].join("\n"))
+          end
+        end
+      end
+    end
+
+    context 'when first child is NOT a method' do
+      it "does not require blank line at the beginning of #{type} body "\
+        'but requires blank line before first def definition '\
+        "and requires blank line at the end of #{type} body" do
+        inspect_source(cop,
+                       ["#{type} SomeObject",
+                        '  include Something',
+                        '',
+                        '  def do_something; end',
+                        '',
+                        'end'])
+        expect(cop.messages).to eq([])
+      end
+
+      context 'source without blank lines' do
+        let(:source) do
+          ["#{type} SomeObject",
+           '  include Something',
+           '  def do_something; end',
+           'end']
+        end
+
+        it "registers an offense for #{type} not ending with a blank line" do
+          inspect_source(cop, source)
+          expect(cop.messages).to eq([missing_def, missing_end])
+        end
+
+        it 'autocorrects the offenses' do
+          new_source = autocorrect_source(cop, source)
+          expect(new_source).to eq(["#{type} SomeObject",
+                                    '  include Something',
+                                    '',
+                                    '  def do_something; end',
+                                    '',
+                                    'end'].join("\n"))
+        end
+      end
+
+      context 'source with blank lines' do
+        let(:source) do
+          ["#{type} SomeObject",
+           '',
+           '  include Something',
+           '  def do_something; end',
+           '',
+           'end']
+        end
+
+        it "registers an offense for #{type} beginning with a blank line" do
+          inspect_source(cop, source)
+          expect(cop.messages).to eq([extra_begin, missing_def])
+        end
+
+        it 'autocorrects the offenses' do
+          new_source = autocorrect_source(cop, source)
+          expect(new_source).to eq(["#{type} SomeObject",
+                                    '  include Something',
+                                    '',
+                                    '  def do_something; end',
+                                    '',
+                                    'end'].join("\n"))
+        end
+      end
+
+      context 'source with comment before method definition' do
+        let(:source) do
+          ["#{type} SomeObject",
+           '',
+           '  include Something',
+           '  # Comment',
+           '  def do_something; end',
+           '',
+           'end']
+        end
+
+        it "registers an offense for #{type} beginning with a blank line" do
+          inspect_source(cop, source)
+          expect(cop.messages).to eq([extra_begin, missing_def])
+        end
+
+        it 'autocorrects the offenses' do
+          new_source = autocorrect_source(cop, source)
+          expect(new_source).to eq(["#{type} SomeObject",
+                                    '  include Something',
+                                    '',
+                                    '  # Comment',
+                                    '  def do_something; end',
+                                    '',
+                                    'end'].join("\n"))
+        end
+      end
+
+      context "when #{type} has a namespace" do
+        it 'requires no empty lines for namespace '\
+          "and does not require blank line at the beginning of #{type} body "\
+          "but requires blank line at the end of #{type} body" do
+          inspect_source(cop,
+                         ["#{type} Parent",
+                          "  #{type} SomeObject",
+                          '    include Something',
+                          '',
+                          '    def do_something',
+                          '    end',
+                          '',
+                          '  end',
+                          'end'])
+          expect(cop.messages).to eq([])
+        end
+
+        context 'source without blank lines' do
+          let(:source) do
+            ["#{type} Parent",
+             "  #{type} SomeObject",
+             '    include Something',
+             '    def do_something',
+             '    end',
+             '  end',
+             'end']
+          end
+
+          it 'autocorrects the offenses' do
+            new_source = autocorrect_source(cop, source)
+            expect(new_source).to eq(["#{type} Parent",
+                                      "  #{type} SomeObject",
+                                      '    include Something',
+                                      '',
+                                      '    def do_something',
+                                      '    end',
+                                      '',
+                                      '  end',
+                                      'end'].join("\n"))
+          end
+        end
+
+        context 'source with blank lines' do
+          let(:source) do
+            ["#{type} Parent",
+             '',
+             "  #{type} SomeObject",
+             '',
+             '    include Something',
+             '',
+             '    def do_something',
+             '    end',
+             '',
+             '  end',
+             '',
+             'end']
+          end
+
+          it 'autocorrects the offenses' do
+            new_source = autocorrect_source(cop, source)
+            expect(new_source).to eq(["#{type} Parent",
+                                      "  #{type} SomeObject",
+                                      '    include Something',
+                                      '',
+                                      '    def do_something',
+                                      '    end',
+                                      '',
+                                      '  end',
+                                      'end'].join("\n"))
+          end
+        end
+
+        context 'source with constants' do
+          let(:source) do
+            ["#{type} Parent",
+             "  #{type} SomeObject",
+             '    URL = %q(http://example.com)',
+             '    def do_something',
+             '    end',
+             '  end',
+             'end']
+          end
+
+          it 'autocorrects the offenses' do
+            new_source = autocorrect_source(cop, source)
+            expect(new_source).to eq(["#{type} Parent",
+                                      "  #{type} SomeObject",
+                                      '    URL = %q(http://example.com)',
+                                      '',
+                                      '    def do_something',
+                                      '    end',
+                                      '',
+                                      '  end',
+                                      'end'].join("\n"))
+          end
+        end
+      end
+    end
+
+    context 'when namespace has multiple children' do
+      it 'requires empty lines for namespace' do
+        inspect_source(cop,
+                       ["#{type} Parent",
+                        '',
+                        "  #{type} Mom",
+                        '',
+                        '    def do_something',
+                        '    end',
+                        '',
+                        '  end',
+                        "  #{type} Dad",
+                        '',
+                        '  end',
+                        '',
+                        'end'])
+        expect(cop.messages).to eq([])
+      end
+    end
+
+    context "#{type} with only constants" do
+      let(:source) do
+        ["#{type} Parent",
+         "  #{type} SomeObject",
+         '    URL = %q(http://example.com)',
+         '    WSDL = %q(http://example.com/wsdl)',
+         '  end',
+         'end']
+      end
+
+      it 'autocorrects the offenses' do
+        new_source = autocorrect_source(cop, source)
+        expect(new_source).to eq(["#{type} Parent",
+                                  "  #{type} SomeObject",
+                                  '    URL = %q(http://example.com)',
+                                  '    WSDL = %q(http://example.com/wsdl)',
+                                  '',
+                                  '  end',
+                                  'end'].join("\n"))
+      end
+    end
+
+    context "#{type} with constant and child #{type}" do
+      let(:source) do
+        ["#{type} Parent",
+         '  URL = %q(http://example.com)',
+         "  #{type} SomeObject",
+         '    def do_something; end',
+         '  end',
+         'end']
+      end
+
+      it 'registers offenses' do
+        inspect_source(cop, source)
+        expect(cop.messages).to eq([missing_type,
+                                    missing_begin,
+                                    missing_end,
+                                    missing_end])
+      end
+
+      it 'autocorrects the offenses' do
+        new_source = autocorrect_source(cop, source)
+        expect(new_source).to eq(["#{type} Parent",
+                                  '  URL = %q(http://example.com)',
+                                  '',
+                                  "  #{type} SomeObject",
+                                  '',
+                                  '    def do_something; end',
+                                  '',
+                                  '  end',
+                                  '',
+                                  'end'].join("\n"))
+      end
+    end
+
+    context "#{type} with empty body" do
+      context 'with empty line' do
+        let(:source) do
+          ["#{type} SomeObject",
+           '',
+           'end']
+        end
+
+        it 'does NOT register offenses' do
+          inspect_source(cop, source)
+          expect(cop.messages).to eq([])
+        end
+      end
+
+      context 'without empty line' do
+        let(:source) do
+          ["#{type} SomeObject",
+           'end']
+        end
+
+        it 'does NOT register offenses' do
+          inspect_source(cop, source)
+          expect(cop.messages).to eq([])
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
Adds new style `empty_lines_special` to `Style/EmptyLinesAroundClassBody` and `Style/EmptyLinesAroundModuleBody`. It is related to #3452.

It works like `empty_lines_except_namespace` in #3560, except if the first line is not a method definition, it
- does NOT require an empty line at the beginning of a class/module, but
- requires an empty line before the first method definition.

I'm not sure, whether I should check the empty line before the first method definition in this cop or somewhere else, so currently I made 2 separate commits. If that's fine, I will squash the commits and then this PR fixes #3452.

``` ruby
module Providers
  class ProviderA
    class Xml
      include Provides::Xml

      def to_xml
        ...
      end

    end
  end
end
```
---

Before submitting the PR make sure the following are checked:
- [x] Wrote [good commit messages](http://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html).
- [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
- [x] Used the same coding conventions as the rest of the project.
- [x] Feature branch is up-to-date with `master` (if not - rebase it).
- [x] Squashed related commits together.
- [x] Added tests.
- [x] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
- [x] All tests are passing.
- [x] The new code doesn't generate RuboCop offenses.
- [x] The PR relates to _only_ one subject with a clear title
  and description in grammatically correct, complete sentences.
