### PR TITLE
Fix some cops errors when condition is empty brace

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 * [#3291](https://github.com/bbatsov/rubocop/issues/3291): Improve detection of `raw` and `html_safe` methods in `Rails/OutputSafety`. ([@lumeet][])
 * Redundant return style now properly handles empty `when` blocks. ([@albus522][])
 * [#3622](https://github.com/bbatsov/rubocop/pull/3622): Fix false positive for `Metrics/MethodLength` and `Metrics/BlockLength`. ([@meganemura][])
+* [#3625](https://github.com/bbatsov/rubocop/pull/3625): Fix some cops errors when condition is empty brace. ([@pocke][])
 
 ## 0.44.1 (2016-10-13)
 

--- a/lib/rubocop/cop/lint/assignment_in_condition.rb
+++ b/lib/rubocop/cop/lint/assignment_in_condition.rb
@@ -48,6 +48,7 @@ module RuboCop
 
         def skip_children?(asgn_node)
           (asgn_node.send_type? && asgn_node.method_name !~ /=\z/) ||
+            empty_condition?(asgn_node) ||
             (safe_assignment_allowed? && safe_assignment?(asgn_node))
         end
 

--- a/lib/rubocop/cop/mixin/negative_conditional.rb
+++ b/lib/rubocop/cop/mixin/negative_conditional.rb
@@ -9,9 +9,12 @@ module RuboCop
       include IfNode
 
       def_node_matcher :single_negative?, '(send !(send _ :!) :!)'
+      def_node_matcher :empty_condition?, '(begin)'
 
       def check_negative_conditional(node)
         condition, _body, _rest = *node
+
+        return if empty_condition?(condition)
 
         # Look at last expression of contents if there are parentheses
         # around condition.

--- a/lib/rubocop/cop/mixin/safe_assignment.rb
+++ b/lib/rubocop/cop/mixin/safe_assignment.rb
@@ -8,6 +8,7 @@ module RuboCop
     module SafeAssignment
       extend NodePattern::Macros
 
+      def_node_matcher :empty_condition?, '(begin)'
       def_node_matcher :safe_assignment?,
                        '(begin {equals_asgn? asgn_method_call?})'
 

--- a/lib/rubocop/cop/style/parentheses_around_condition.rb
+++ b/lib/rubocop/cop/style/parentheses_around_condition.rb
@@ -29,6 +29,8 @@ module RuboCop
           cond, _body = *node
 
           return unless cond.begin_type?
+          # handle `if () ...`
+          return if empty_condition?(cond)
           # handle `if (something rescue something_else) ...`
           return if modifier_op?(cond.children.first)
           # check if there's any whitespace between the keyword and the cond

--- a/spec/rubocop/cop/lint/assignment_in_condition_spec.rb
+++ b/spec/rubocop/cop/lint/assignment_in_condition_spec.rb
@@ -107,6 +107,20 @@ describe RuboCop::Cop::Lint::AssignmentInCondition, :config do
     expect(cop.offenses.size).to eq(1)
   end
 
+  it 'does not blow up for empty if condition' do
+    inspect_source(cop,
+                   ['if ()',
+                    'end'])
+    expect(cop.offenses).to be_empty
+  end
+
+  it 'does not blow up for empty unless condition' do
+    inspect_source(cop,
+                   ['unless ()',
+                    'end'])
+    expect(cop.offenses).to be_empty
+  end
+
   context 'safe assignment is allowed' do
     it 'accepts = in condition surrounded with braces' do
       inspect_source(cop,

--- a/spec/rubocop/cop/style/negated_if_spec.rb
+++ b/spec/rubocop/cop/style/negated_if_spec.rb
@@ -94,6 +94,20 @@ describe RuboCop::Cop::Style::NegatedIf do
     expect(cop.offenses).to be_empty
   end
 
+  it 'does not blow up for empty if condition' do
+    inspect_source(cop,
+                   ['if ()',
+                    'end'])
+    expect(cop.offenses).to be_empty
+  end
+
+  it 'does not blow up for empty unless condition' do
+    inspect_source(cop,
+                   ['unless ()',
+                    'end'])
+    expect(cop.offenses).to be_empty
+  end
+
   it 'autocorrects by replacing if not with unless' do
     corrected = autocorrect_source(cop, 'something if !x.even?')
     expect(corrected).to eq 'something unless x.even?'

--- a/spec/rubocop/cop/style/negated_while_spec.rb
+++ b/spec/rubocop/cop/style/negated_while_spec.rb
@@ -70,4 +70,18 @@ describe RuboCop::Cop::Style::NegatedWhile do
     corrected = autocorrect_source(cop, 'something until !x.even?')
     expect(corrected).to eq 'something while x.even?'
   end
+
+  it 'does not blow up for empty while condition' do
+    inspect_source(cop,
+                   ['while ()',
+                    'end'])
+    expect(cop.offenses).to be_empty
+  end
+
+  it 'does not blow up for empty until condition' do
+    inspect_source(cop,
+                   ['until ()',
+                    'end'])
+    expect(cop.offenses).to be_empty
+  end
 end

--- a/spec/rubocop/cop/style/parentheses_around_condition_spec.rb
+++ b/spec/rubocop/cop/style/parentheses_around_condition_spec.rb
@@ -107,6 +107,20 @@ describe RuboCop::Cop::Style::ParenthesesAroundCondition, :config do
     expect(cop.offenses.size).to eq(1)
   end
 
+  it 'does not blow up for empty if condition' do
+    inspect_source(cop,
+                   ['if ()',
+                    'end'])
+    expect(cop.offenses).to be_empty
+  end
+
+  it 'does not blow up for empty unless condition' do
+    inspect_source(cop,
+                   ['unless ()',
+                    'end'])
+    expect(cop.offenses).to be_empty
+  end
+
   context 'safe assignment is allowed' do
     it 'accepts variable assignment in condition surrounded with parentheses' do
       inspect_source(cop,


### PR DESCRIPTION
Problem
----

RuboCop crashes when `if` condition is an empty brace.

For example

```ruby
# test.rb
if ()
  a
end
```

```sh
$ rubocop -d --cache false test.rb
An error occurred while Lint/AssignmentInCondition cop was inspecting /home/pocke/ghq/github.com/bbatsov/rubocop/test.rb.
An error occurred while Style/NegatedIf cop was inspecting /home/pocke/ghq/github.com/bbatsov/rubocop/test.rb.
An error occurred while Style/ParenthesesAroundCondition cop was inspecting /home/pocke/ghq/github.com/bbatsov/rubocop/test.rb.
For /home/pocke/ghq/github.com/bbatsov/rubocop: configuration from /home/pocke/ghq/github.com/bbatsov/rubocop/.rubocop.yml
Inheriting configuration from /home/pocke/ghq/github.com/bbatsov/rubocop/.rubocop_todo.yml
Default configuration from /home/pocke/.gem/ruby/2.3.0/gems/rubocop-0.44.1/config/default.yml
Inheriting configuration from /home/pocke/.gem/ruby/2.3.0/gems/rubocop-0.44.1/config/enabled.yml
Inheriting configuration from /home/pocke/.gem/ruby/2.3.0/gems/rubocop-0.44.1/config/disabled.yml
Inspecting 1 file
Scanning /home/pocke/ghq/github.com/bbatsov/rubocop/test.rb
undefined method `equals_asgn?' for nil:NilClass
/home/pocke/.gem/ruby/2.3.0/gems/rubocop-0.44.1/lib/rubocop/cop/mixin/safe_assignment.rb:11:in `safe_assignment?'
/home/pocke/.gem/ruby/2.3.0/gems/rubocop-0.44.1/lib/rubocop/cop/lint/assignment_in_condition.rb:51:in `skip_children?'
/home/pocke/.gem/ruby/2.3.0/gems/rubocop-0.44.1/lib/rubocop/cop/lint/assignment_in_condition.rb:34:in `block in check'
/home/pocke/.gem/ruby/2.3.0/gems/rubocop-0.44.1/lib/rubocop/cop/lint/assignment_in_condition.rb:56:in `traverse_node'
/home/pocke/.gem/ruby/2.3.0/gems/rubocop-0.44.1/lib/rubocop/cop/lint/assignment_in_condition.rb:33:in `check'
/home/pocke/.gem/ruby/2.3.0/gems/rubocop-0.44.1/lib/rubocop/cop/lint/assignment_in_condition.rb:15:in `on_if'
/home/pocke/.gem/ruby/2.3.0/gems/rubocop-0.44.1/lib/rubocop/cop/commissioner.rb:41:in `block (2 levels) in on_if'
/home/pocke/.gem/ruby/2.3.0/gems/rubocop-0.44.1/lib/rubocop/cop/commissioner.rb:96:in `with_cop_error_handling'
/home/pocke/.gem/ruby/2.3.0/gems/rubocop-0.44.1/lib/rubocop/cop/commissioner.rb:40:in `block in on_if'
/home/pocke/.gem/ruby/2.3.0/gems/rubocop-0.44.1/lib/rubocop/cop/commissioner.rb:39:in `each'
/home/pocke/.gem/ruby/2.3.0/gems/rubocop-0.44.1/lib/rubocop/cop/commissioner.rb:39:in `on_if'
/home/pocke/.gem/ruby/2.3.0/gems/rubocop-0.44.1/lib/rubocop/ast_node/traversal.rb:12:in `walk'
/home/pocke/.gem/ruby/2.3.0/gems/rubocop-0.44.1/lib/rubocop/cop/commissioner.rb:58:in `investigate'
/home/pocke/.gem/ruby/2.3.0/gems/rubocop-0.44.1/lib/rubocop/cop/team.rb:120:in `investigate'
/home/pocke/.gem/ruby/2.3.0/gems/rubocop-0.44.1/lib/rubocop/cop/team.rb:108:in `offenses'
/home/pocke/.gem/ruby/2.3.0/gems/rubocop-0.44.1/lib/rubocop/cop/team.rb:51:in `inspect_file'
/home/pocke/.gem/ruby/2.3.0/gems/rubocop-0.44.1/lib/rubocop/runner.rb:243:in `inspect_file'
/home/pocke/.gem/ruby/2.3.0/gems/rubocop-0.44.1/lib/rubocop/runner.rb:190:in `block in do_inspection_loop'
/home/pocke/.gem/ruby/2.3.0/gems/rubocop-0.44.1/lib/rubocop/runner.rb:222:in `block in iterate_until_no_changes'
/home/pocke/.gem/ruby/2.3.0/gems/rubocop-0.44.1/lib/rubocop/runner.rb:215:in `loop'
/home/pocke/.gem/ruby/2.3.0/gems/rubocop-0.44.1/lib/rubocop/runner.rb:215:in `iterate_until_no_changes'
/home/pocke/.gem/ruby/2.3.0/gems/rubocop-0.44.1/lib/rubocop/runner.rb:186:in `do_inspection_loop'
/home/pocke/.gem/ruby/2.3.0/gems/rubocop-0.44.1/lib/rubocop/runner.rb:101:in `block in file_offenses'
/home/pocke/.gem/ruby/2.3.0/gems/rubocop-0.44.1/lib/rubocop/runner.rb:111:in `file_offense_cache'
/home/pocke/.gem/ruby/2.3.0/gems/rubocop-0.44.1/lib/rubocop/runner.rb:99:in `file_offenses'
/home/pocke/.gem/ruby/2.3.0/gems/rubocop-0.44.1/lib/rubocop/runner.rb:90:in `process_file'
/home/pocke/.gem/ruby/2.3.0/gems/rubocop-0.44.1/lib/rubocop/runner.rb:68:in `block in each_inspected_file'
/home/pocke/.gem/ruby/2.3.0/gems/rubocop-0.44.1/lib/rubocop/runner.rb:65:in `each'
/home/pocke/.gem/ruby/2.3.0/gems/rubocop-0.44.1/lib/rubocop/runner.rb:65:in `reduce'
/home/pocke/.gem/ruby/2.3.0/gems/rubocop-0.44.1/lib/rubocop/runner.rb:65:in `each_inspected_file'
/home/pocke/.gem/ruby/2.3.0/gems/rubocop-0.44.1/lib/rubocop/runner.rb:57:in `inspect_files'
/home/pocke/.gem/ruby/2.3.0/gems/rubocop-0.44.1/lib/rubocop/runner.rb:36:in `run'
/home/pocke/.gem/ruby/2.3.0/gems/rubocop-0.44.1/lib/rubocop/cli.rb:71:in `execute_runner'
/home/pocke/.gem/ruby/2.3.0/gems/rubocop-0.44.1/lib/rubocop/cli.rb:27:in `run'
/home/pocke/.gem/ruby/2.3.0/gems/rubocop-0.44.1/bin/rubocop:13:in `block in <top (required)>'
/usr/lib/ruby/2.3.0/benchmark.rb:308:in `realtime'
/home/pocke/.gem/ruby/2.3.0/gems/rubocop-0.44.1/bin/rubocop:12:in `<top (required)>'
/home/pocke/.gem/ruby/2.3.0/bin//rubocop:23:in `load'
/home/pocke/.gem/ruby/2.3.0/bin//rubocop:23:in `<main>'
undefined method `begin_type?' for nil:NilClass
/home/pocke/.gem/ruby/2.3.0/gems/rubocop-0.44.1/lib/rubocop/cop/mixin/negative_conditional.rb:18:in `check_negative_conditional'
/home/pocke/.gem/ruby/2.3.0/gems/rubocop-0.44.1/lib/rubocop/cop/style/negated_if.rb:17:in `on_if'
/home/pocke/.gem/ruby/2.3.0/gems/rubocop-0.44.1/lib/rubocop/cop/commissioner.rb:41:in `block (2 levels) in on_if'
/home/pocke/.gem/ruby/2.3.0/gems/rubocop-0.44.1/lib/rubocop/cop/commissioner.rb:96:in `with_cop_error_handling'
/home/pocke/.gem/ruby/2.3.0/gems/rubocop-0.44.1/lib/rubocop/cop/commissioner.rb:40:in `block in on_if'
/home/pocke/.gem/ruby/2.3.0/gems/rubocop-0.44.1/lib/rubocop/cop/commissioner.rb:39:in `each'
/home/pocke/.gem/ruby/2.3.0/gems/rubocop-0.44.1/lib/rubocop/cop/commissioner.rb:39:in `on_if'
/home/pocke/.gem/ruby/2.3.0/gems/rubocop-0.44.1/lib/rubocop/ast_node/traversal.rb:12:in `walk'
/home/pocke/.gem/ruby/2.3.0/gems/rubocop-0.44.1/lib/rubocop/cop/commissioner.rb:58:in `investigate'
/home/pocke/.gem/ruby/2.3.0/gems/rubocop-0.44.1/lib/rubocop/cop/team.rb:120:in `investigate'
/home/pocke/.gem/ruby/2.3.0/gems/rubocop-0.44.1/lib/rubocop/cop/team.rb:108:in `offenses'
/home/pocke/.gem/ruby/2.3.0/gems/rubocop-0.44.1/lib/rubocop/cop/team.rb:51:in `inspect_file'
/home/pocke/.gem/ruby/2.3.0/gems/rubocop-0.44.1/lib/rubocop/runner.rb:243:in `inspect_file'
/home/pocke/.gem/ruby/2.3.0/gems/rubocop-0.44.1/lib/rubocop/runner.rb:190:in `block in do_inspection_loop'
/home/pocke/.gem/ruby/2.3.0/gems/rubocop-0.44.1/lib/rubocop/runner.rb:222:in `block in iterate_until_no_changes'
/home/pocke/.gem/ruby/2.3.0/gems/rubocop-0.44.1/lib/rubocop/runner.rb:215:in `loop'
/home/pocke/.gem/ruby/2.3.0/gems/rubocop-0.44.1/lib/rubocop/runner.rb:215:in `iterate_until_no_changes'
/home/pocke/.gem/ruby/2.3.0/gems/rubocop-0.44.1/lib/rubocop/runner.rb:186:in `do_inspection_loop'
/home/pocke/.gem/ruby/2.3.0/gems/rubocop-0.44.1/lib/rubocop/runner.rb:101:in `block in file_offenses'
/home/pocke/.gem/ruby/2.3.0/gems/rubocop-0.44.1/lib/rubocop/runner.rb:111:in `file_offense_cache'
/home/pocke/.gem/ruby/2.3.0/gems/rubocop-0.44.1/lib/rubocop/runner.rb:99:in `file_offenses'
/home/pocke/.gem/ruby/2.3.0/gems/rubocop-0.44.1/lib/rubocop/runner.rb:90:in `process_file'
/home/pocke/.gem/ruby/2.3.0/gems/rubocop-0.44.1/lib/rubocop/runner.rb:68:in `block in each_inspected_file'
/home/pocke/.gem/ruby/2.3.0/gems/rubocop-0.44.1/lib/rubocop/runner.rb:65:in `each'
/home/pocke/.gem/ruby/2.3.0/gems/rubocop-0.44.1/lib/rubocop/runner.rb:65:in `reduce'
/home/pocke/.gem/ruby/2.3.0/gems/rubocop-0.44.1/lib/rubocop/runner.rb:65:in `each_inspected_file'
/home/pocke/.gem/ruby/2.3.0/gems/rubocop-0.44.1/lib/rubocop/runner.rb:57:in `inspect_files'
/home/pocke/.gem/ruby/2.3.0/gems/rubocop-0.44.1/lib/rubocop/runner.rb:36:in `run'
/home/pocke/.gem/ruby/2.3.0/gems/rubocop-0.44.1/lib/rubocop/cli.rb:71:in `execute_runner'
/home/pocke/.gem/ruby/2.3.0/gems/rubocop-0.44.1/lib/rubocop/cli.rb:27:in `run'
/home/pocke/.gem/ruby/2.3.0/gems/rubocop-0.44.1/bin/rubocop:13:in `block in <top (required)>'
/usr/lib/ruby/2.3.0/benchmark.rb:308:in `realtime'
/home/pocke/.gem/ruby/2.3.0/gems/rubocop-0.44.1/bin/rubocop:12:in `<top (required)>'
/home/pocke/.gem/ruby/2.3.0/bin//rubocop:23:in `load'
/home/pocke/.gem/ruby/2.3.0/bin//rubocop:23:in `<main>'
undefined method `loc' for nil:NilClass
/home/pocke/.gem/ruby/2.3.0/gems/rubocop-0.44.1/lib/rubocop/cop/mixin/if_node.rb:10:in `ternary?'
/home/pocke/.gem/ruby/2.3.0/gems/rubocop-0.44.1/lib/rubocop/cop/style/parentheses_around_condition.rb:43:in `modifier_op?'
/home/pocke/.gem/ruby/2.3.0/gems/rubocop-0.44.1/lib/rubocop/cop/style/parentheses_around_condition.rb:33:in `process_control_op'
/home/pocke/.gem/ruby/2.3.0/gems/rubocop-0.44.1/lib/rubocop/cop/style/parentheses_around_condition.rb:15:in `on_if'
/home/pocke/.gem/ruby/2.3.0/gems/rubocop-0.44.1/lib/rubocop/cop/commissioner.rb:41:in `block (2 levels) in on_if'
3 errors occurred:
An error occurred while Lint/AssignmentInCondition cop was inspecting /home/pocke/ghq/github.com/bbatsov/rubocop/test.rb.
An error occurred while Style/NegatedIf cop was inspecting /home/pocke/ghq/github.com/bbatsov/rubocop/test.rb.
An error occurred while Style/ParenthesesAroundCondition cop was inspecting /home/pocke/ghq/github.com/bbatsov/rubocop/test.rb.
Errors are usually caused by RuboCop bugs.
Please, report your problems to RuboCop's issue tracker.
Mention the following information in the issue report:
0.44.1 (using Parser 2.3.1.3, running on ruby 2.3.1 x86_64-linux)

/home/pocke/.gem/ruby/2.3.0/gems/rubocop-0.44.1/lib/rubocop/cop/commissioner.rb:96:in `with_cop_error_handling'
/home/pocke/.gem/ruby/2.3.0/gems/rubocop-0.44.1/lib/rubocop/cop/commissioner.rb:40:in `block in on_if'
/home/pocke/.gem/ruby/2.3.0/gems/rubocop-0.44.1/lib/rubocop/cop/commissioner.rb:39:in `each'
/home/pocke/.gem/ruby/2.3.0/gems/rubocop-0.44.1/lib/rubocop/cop/commissioner.rb:39:in `on_if'
/home/pocke/.gem/ruby/2.3.0/gems/rubocop-0.44.1/lib/rubocop/ast_node/traversal.rb:12:in `walk'
/home/pocke/.gem/ruby/2.3.0/gems/rubocop-0.44.1/lib/rubocop/cop/commissioner.rb:58:in `investigate'
/home/pocke/.gem/ruby/2.3.0/gems/rubocop-0.44.1/lib/rubocop/cop/team.rb:120:in `investigate'
/home/pocke/.gem/ruby/2.3.0/gems/rubocop-0.44.1/lib/rubocop/cop/team.rb:108:in `offenses'
/home/pocke/.gem/ruby/2.3.0/gems/rubocop-0.44.1/lib/rubocop/cop/team.rb:51:in `inspect_file'
/home/pocke/.gem/ruby/2.3.0/gems/rubocop-0.44.1/lib/rubocop/runner.rb:243:in `inspect_file'
/home/pocke/.gem/ruby/2.3.0/gems/rubocop-0.44.1/lib/rubocop/runner.rb:190:in `block in do_inspection_loop'
/home/pocke/.gem/ruby/2.3.0/gems/rubocop-0.44.1/lib/rubocop/runner.rb:222:in `block in iterate_until_no_changes'
/home/pocke/.gem/ruby/2.3.0/gems/rubocop-0.44.1/lib/rubocop/runner.rb:215:in `loop'
/home/pocke/.gem/ruby/2.3.0/gems/rubocop-0.44.1/lib/rubocop/runner.rb:215:in `iterate_until_no_changes'
/home/pocke/.gem/ruby/2.3.0/gems/rubocop-0.44.1/lib/rubocop/runner.rb:186:in `do_inspection_loop'
/home/pocke/.gem/ruby/2.3.0/gems/rubocop-0.44.1/lib/rubocop/runner.rb:101:in `block in file_offenses'
/home/pocke/.gem/ruby/2.3.0/gems/rubocop-0.44.1/lib/rubocop/runner.rb:111:in `file_offense_cache'
/home/pocke/.gem/ruby/2.3.0/gems/rubocop-0.44.1/lib/rubocop/runner.rb:99:in `file_offenses'
/home/pocke/.gem/ruby/2.3.0/gems/rubocop-0.44.1/lib/rubocop/runner.rb:90:in `process_file'
/home/pocke/.gem/ruby/2.3.0/gems/rubocop-0.44.1/lib/rubocop/runner.rb:68:in `block in each_inspected_file'
/home/pocke/.gem/ruby/2.3.0/gems/rubocop-0.44.1/lib/rubocop/runner.rb:65:in `each'
/home/pocke/.gem/ruby/2.3.0/gems/rubocop-0.44.1/lib/rubocop/runner.rb:65:in `reduce'
/home/pocke/.gem/ruby/2.3.0/gems/rubocop-0.44.1/lib/rubocop/runner.rb:65:in `each_inspected_file'
/home/pocke/.gem/ruby/2.3.0/gems/rubocop-0.44.1/lib/rubocop/runner.rb:57:in `inspect_files'
/home/pocke/.gem/ruby/2.3.0/gems/rubocop-0.44.1/lib/rubocop/runner.rb:36:in `run'
/home/pocke/.gem/ruby/2.3.0/gems/rubocop-0.44.1/lib/rubocop/cli.rb:71:in `execute_runner'
/home/pocke/.gem/ruby/2.3.0/gems/rubocop-0.44.1/lib/rubocop/cli.rb:27:in `run'
/home/pocke/.gem/ruby/2.3.0/gems/rubocop-0.44.1/bin/rubocop:13:in `block in <top (required)>'
/usr/lib/ruby/2.3.0/benchmark.rb:308:in `realtime'
/home/pocke/.gem/ruby/2.3.0/gems/rubocop-0.44.1/bin/rubocop:12:in `<top (required)>'
/home/pocke/.gem/ruby/2.3.0/bin//rubocop:23:in `load'
/home/pocke/.gem/ruby/2.3.0/bin//rubocop:23:in `<main>'
C

Offenses:

test.rb:1:1: C: Style/FrozenStringLiteralComment: Missing frozen string literal comment.
if ()
^
test.rb:1:1: C: Style/IfUnlessModifier: Favor modifier if usage when having a single-line body. Another good alternative is the usage of control flow &&/||.
if ()
^^

1 file inspected, 2 offenses detected
Finished in 0.0758015800092835 seconds
```

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Used the same coding conventions as the rest of the project.
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] All tests are passing.
* [x] The new code doesn't generate RuboCop offenses.
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.

[1]: http://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html

