### PR TITLE
[Fix #3468] Handle kwbegin in MultilineMethodCallIndentation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 * Redundant return style now properly handles empty `when` blocks. ([@albus522][])
 * [#3622](https://github.com/bbatsov/rubocop/pull/3622): Fix false positive for `Metrics/MethodLength` and `Metrics/BlockLength`. ([@meganemura][])
 * [#3625](https://github.com/bbatsov/rubocop/pull/3625): Fix some cops errors when condition is empty brace. ([@pocke][])
+* [#3468](https://github.com/bbatsov/rubocop/issues/3468): Fix bug regarding alignment inside `begin`..`end` block in `Style/MultilineMethodCallIndentation`. ([@jonas054][])
 
 ## 0.44.1 (2016-10-13)
 

--- a/lib/rubocop/cop/mixin/multiline_expression_indentation.rb
+++ b/lib/rubocop/cop/mixin/multiline_expression_indentation.rb
@@ -125,7 +125,7 @@ module RuboCop
       def part_of_assignment_rhs(node, candidate)
         node.each_ancestor.find do |a|
           case a.type
-          when :if, :while, :until, :for, :return, :array
+          when :if, :while, :until, :for, :return, :array, :kwbegin
             break # other kinds of alignment
           when :block
             break if part_of_block_body?(candidate, a)

--- a/spec/rubocop/cop/style/multiline_method_call_indentation_spec.rb
+++ b/spec/rubocop/cop/style/multiline_method_call_indentation_spec.rb
@@ -342,6 +342,16 @@ describe RuboCop::Cop::Style::MultilineMethodCallIndentation do
       expect(cop.messages).to be_empty
     end
 
+    it 'accepts aligned methods in a begin..end block' do
+      inspect_source(cop,
+                     ['@dependencies ||= begin',
+                      '  DEFAULT_DEPENDENCIES',
+                      '    .reject { |e| e }',
+                      '    .map { |e| e }',
+                      'end'])
+      expect(cop.messages).to be_empty
+    end
+
     it 'registers an offense for misaligned methods in if condition' do
       inspect_source(cop,
                      ['if a.',


### PR DESCRIPTION
We already have special handling for a number of keywords when it comes to multiline indentation/alignment. Add `kwbegin` to the list.