### PR TITLE
[#3263] Fix auto-correct of nested statements in ConditionalAssignment

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -13,7 +13,7 @@ Metrics/AbcSize:
 # Offense count: 32
 # Configuration parameters: CountComments.
 Metrics/ClassLength:
-  Max: 168
+  Max: 172
 
 # Offense count: 28
 Metrics/CyclomaticComplexity:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@
 
 * [#3601](https://github.com/bbatsov/rubocop/pull/3601): Change default args for `Style/SingleLineBlockParams`. This cop checks that `reduce` and `inject` use the variable names `a` and `e` for block arguments. These defaults are uncommunicative variable names and thus conflict with the ["Uncommunicative Variable Name" check in Reek](https://github.com/troessner/reek/blob/master/docs/Uncommunicative-Variable-Name.md). Default args changed to `acc` and `elem`.([@jessieay][])
 * [#3645](https://github.com/bbatsov/rubocop/pull/3645): Fix bug with empty case when nodes in `Style/RedundantReturn`. ([@tiagocasanovapt][])
+* [#3263](https://github.com/bbatsov/rubocop/issues/3263): Fix auto-correct of if statements inside of unless else statements in `Style/ConditionalAssignment`. ([@rrosenblum][])
 
 ## 0.44.1 (2016-10-13)
 

--- a/lib/rubocop/cop/style/conditional_assignment.rb
+++ b/lib/rubocop/cop/style/conditional_assignment.rb
@@ -248,7 +248,12 @@ module RuboCop
           return unless style == :assign_to_condition
           return if elsif?(node)
 
-          _condition, if_branch, else_branch = *node
+          if ternary?(node) || node.loc.keyword.is?('if')
+            _condition, if_branch, else_branch = *node
+          else
+            _condition, else_branch, if_branch = *node
+          end
+
           elsif_branches, else_branch = expand_elses(else_branch)
           return unless else_branch # empty else
 

--- a/spec/rubocop/cop/style/conditional_assignment_assign_to_condition_spec.rb
+++ b/spec/rubocop/cop/style/conditional_assignment_assign_to_condition_spec.rb
@@ -1940,6 +1940,35 @@ describe RuboCop::Cop::Style::ConditionalAssignment do
                                   '  2',
                                   '      end'].join("\n"))
       end
+
+      it 'corrects assignment in an if statement that is nested ' \
+        'in unless else' do
+        source = ['unless foo',
+                  '  if foobar',
+                  '    baz = 1',
+                  '  elsif qux',
+                  '    baz = 2',
+                  '  else',
+                  '    baz = 3',
+                  '  end',
+                  'else',
+                  '  baz = 4',
+                  'end']
+
+        new_source = autocorrect_source(cop, source)
+
+        expect(new_source).to eq(['unless foo',
+                                  '  baz = if foobar',
+                                  '    1',
+                                  '  elsif qux',
+                                  '    2',
+                                  '  else',
+                                  '    3',
+                                  '        end',
+                                  'else',
+                                  '  baz = 4',
+                                  'end'].join("\n"))
+      end
     end
   end
 


### PR DESCRIPTION
Fix #3263. The problem stemmed from if statements and unless statements parsing the if branch and the else branch in opposite orders.

Example from the issue
```ruby
def unit_kmg(s)
  s = s.to_f
  unless(s.nil? || s.blank? || s == 0)
    if(s / 1024 / 1024 >=  1)
      speed = [s/1024/1024, "G"]
    elsif(s / 1024 >= 1)
      speed = [s/1024, "M"]
    else
      speed = [s, "k"]
    end
  else
    speed = [s, ""]
  end
  speed[0] = floating(speed[0]).to_s
  return speed
end
```
Will no auto-correct to
```ruby
def unit_kmg(s)
  s = s.to_f
  if s.nil? || s.blank? || s == 0
    speed = [s, '']
  else
    speed = if s / 1024 / 1024 >= 1
              [s / 1024 / 1024, 'G']
            elsif s / 1024 >= 1
              [s / 1024, 'M']
            else
              [s, 'k']
            end
  end
  speed[0] = floating(speed[0]).to_s
  speed
end
```