### PR TITLE
Fix cops_documentation task crashes with Ruby 2.3

### DIFF
--- a/tasks/cops_documentation.rake
+++ b/tasks/cops_documentation.rake
@@ -30,7 +30,7 @@ task :generate_cops_documentation do |_task|
   end
 
   def properties(config, cop)
-    content = "Enabled by default | Supports autocorrection\n"
+    content = "Enabled by default | Supports autocorrection\n".dup
     content << "--- | ---\n"
     default_status = config.cop_enabled?(cop) ? 'Enabled' : 'Disabled'
     supports_autocorrect = cop.new.support_autocorrect? ? 'Yes' : 'No'
@@ -39,21 +39,21 @@ task :generate_cops_documentation do |_task|
   end
 
   def h2(title)
-    content = "\n"
+    content = "\n".dup
     content << "## #{title}\n"
     content << "\n"
     content
   end
 
   def h3(title)
-    content = "\n"
+    content = "\n".dup
     content << "### #{title}\n"
     content << "\n"
     content
   end
 
   def code_example(ruby_code)
-    content = "```ruby\n"
+    content = "```ruby\n".dup
     content << ruby_code.text.gsub('@good', '# good')
                .gsub('@bad', '# bad').strip
     content << "\n```\n"
@@ -80,7 +80,7 @@ task :generate_cops_documentation do |_task|
 
   def print_cops_of_type(cops, type, config)
     selected_cops = cops_of_type(cops, type)
-    content = "# #{type.capitalize}\n"
+    content = "# #{type.capitalize}\n".dup
     selected_cops.each do |cop|
       content << print_cop_with_doc(cop, config)
     end


### PR DESCRIPTION
cop documentation task is not work with Ruby 2.3

```sh
$ be rake generate_cops_documentation
This generator uses the comments and tags (`@example`) from the source files to generate the cops-specification. Please use `yardoc` before running this script to make sure, that all your changes were rendered.
Would you like to run `yardoc` before you generate? [Y/N]
rake aborted!
can't modify frozen String
tasks/cops_documentation.rake:43:in `h2'
tasks/cops_documentation.rake:17:in `cops_body'
tasks/cops_documentation.rake:104:in `print_cop_with_doc'
tasks/cops_documentation.rake:85:in `block in print_cops_of_type'
tasks/cops_documentation.rake:84:in `each'
tasks/cops_documentation.rake:84:in `print_cops_of_type'
tasks/cops_documentation.rake:120:in `block (2 levels) in <top (required)>'
tasks/cops_documentation.rake:120:in `each'
tasks/cops_documentation.rake:120:in `block in <top (required)>'
/home/pocke/.gem/ruby/2.3.0/gems/rake-11.2.2/exe/rake:27:in `<top (required)>'
/home/pocke/.gem/ruby/2.3.0/gems/bundler-1.13.5/lib/bundler/cli/exec.rb:74:in `load'
/home/pocke/.gem/ruby/2.3.0/gems/bundler-1.13.5/lib/bundler/cli/exec.rb:74:in `kernel_load'
/home/pocke/.gem/ruby/2.3.0/gems/bundler-1.13.5/lib/bundler/cli/exec.rb:27:in `run'
/home/pocke/.gem/ruby/2.3.0/gems/bundler-1.13.5/lib/bundler/cli.rb:332:in `exec'
/home/pocke/.gem/ruby/2.3.0/gems/bundler-1.13.5/lib/bundler/vendor/thor/lib/thor/command.rb:27:in `run'
/home/pocke/.gem/ruby/2.3.0/gems/bundler-1.13.5/lib/bundler/vendor/thor/lib/thor/invocation.rb:126:in `invoke_command'
/home/pocke/.gem/ruby/2.3.0/gems/bundler-1.13.5/lib/bundler/vendor/thor/lib/thor.rb:359:in `dispatch'
/home/pocke/.gem/ruby/2.3.0/gems/bundler-1.13.5/lib/bundler/cli.rb:20:in `dispatch'
/home/pocke/.gem/ruby/2.3.0/gems/bundler-1.13.5/lib/bundler/vendor/thor/lib/thor/base.rb:440:in `start'
/home/pocke/.gem/ruby/2.3.0/gems/bundler-1.13.5/lib/bundler/cli.rb:11:in `start'
/home/pocke/.gem/ruby/2.3.0/gems/bundler-1.13.5/exe/bundle:34:in `block in <top (required)>'
/home/pocke/.gem/ruby/2.3.0/gems/bundler-1.13.5/lib/bundler/friendly_errors.rb:100:in `with_friendly_errors'
/home/pocke/.gem/ruby/2.3.0/gems/bundler-1.13.5/exe/bundle:26:in `<top (required)>'
/home/pocke/.gem/ruby/2.3.0/bin/bundle:23:in `load'
/home/pocke/.gem/ruby/2.3.0/bin/bundle:23:in `<main>'
Tasks: TOP => generate_cops_documentation
(See full trace by running task with --trace)
```

-----------------

Before submitting the PR make sure the following are checked:

* [ ] Documentation updated with `rake generate_cops_documentation`
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Used the same coding conventions as the rest of the project.
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [ ] Added tests.
* [ ] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] All tests are passing.
* [x] The new code doesn't generate RuboCop offenses.
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.

[1]: http://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html

