### PR TITLE
Fix generation incorrect documentation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@
 * [#3622](https://github.com/bbatsov/rubocop/pull/3622): Fix false positive for `Metrics/MethodLength` and `Metrics/BlockLength`. ([@meganemura][])
 * [#3625](https://github.com/bbatsov/rubocop/pull/3625): Fix some cops errors when condition is empty brace. ([@pocke][])
 * [#3468](https://github.com/bbatsov/rubocop/issues/3468): Fix bug regarding alignment inside `begin`..`end` block in `Style/MultilineMethodCallIndentation`. ([@jonas054][])
+* [#3644](https://github.com/bbatsov/rubocop/pull/3644): Fix generation incorrect documentation. ([@pocke][])
 
 ## 0.44.1 (2016-10-13)
 

--- a/manual/cops_lint.md
+++ b/manual/cops_lint.md
@@ -47,7 +47,7 @@ do_something(/pattern/i)
 
 Enabled by default | Supports autocorrection
 --- | ---
-Disabled | No
+Enabled | No
 
 This cop checks for assignments in the conditions of
 if/while/until.
@@ -63,7 +63,7 @@ AllowSafeAssignment | true
 
 Enabled by default | Supports autocorrection
 --- | ---
-Disabled | Yes
+Enabled | Yes
 
 This cop checks whether the end keywords are aligned properly for do
 end blocks.
@@ -179,7 +179,7 @@ This cop checks for calls to debugger or pry.
 
 Enabled by default | Supports autocorrection
 --- | ---
-Disabled | Yes
+Enabled | Yes
 
 This cop checks whether the end keywords of method definitions are
 aligned properly.
@@ -213,6 +213,27 @@ Enabled by default | Supports autocorrection
 Enabled | Yes
 
 This cop checks for uses of the deprecated class method usages.
+
+## Lint/DuplicateCaseCondition
+
+Enabled by default | Supports autocorrection
+--- | ---
+Enabled | No
+
+This cop checks that there are no repeated conditions
+used in case 'when' expressions.
+
+### Example
+
+```ruby
+# bad
+case x
+when 'first'
+  do_something
+when 'first'
+  do_something_else
+end
+```
 
 ## Lint/DuplicateMethods
 
@@ -316,7 +337,7 @@ This cop checks for empty interpolation.
 
 Enabled by default | Supports autocorrection
 --- | ---
-Disabled | Yes
+Enabled | Yes
 
 This cop checks whether the end keywords are aligned properly.
 
@@ -497,7 +518,7 @@ end
 
 Enabled by default | Supports autocorrection
 --- | ---
-Disabled | Yes
+Enabled | Yes
 
 This cop looks for error classes inheriting from `Exception`
 and its standard library subclasses, excluding subclasses of
@@ -946,7 +967,7 @@ statement in non-final position in *begin*(implicit) blocks.
 
 Enabled by default | Supports autocorrection
 --- | ---
-Disabled | Yes
+Enabled | Yes
 
 This cop checks for unused block arguments.
 
@@ -994,7 +1015,7 @@ AllowUnusedKeywordArguments | false
 
 Enabled by default | Supports autocorrection
 --- | ---
-Disabled | Yes
+Enabled | Yes
 
 This cop checks for unused method arguments.
 
@@ -1018,7 +1039,7 @@ IgnoreEmptyMethods | true
 
 Enabled by default | Supports autocorrection
 --- | ---
-Disabled | No
+Enabled | No
 
 This cop checks for redundant access modifiers, including those with no
 code, those which are repeated, and leading `public` modifiers in a

--- a/manual/cops_metrics.md
+++ b/manual/cops_metrics.md
@@ -4,7 +4,7 @@
 
 Enabled by default | Supports autocorrection
 --- | ---
-Disabled | No
+Enabled | No
 
 This cop checks that the ABC size of methods is not higher than the
 configured maximum. The ABC size is based on assignments, branches
@@ -15,14 +15,14 @@ configured maximum. The ABC size is based on assignments, branches
 Attribute | Value
 --- | ---
 Reference | http://c2.com/cgi/wiki?AbcMetric
-Max | 19
+Max | 15
 
 
 ## Metrics/BlockLength
 
 Enabled by default | Supports autocorrection
 --- | ---
-Disabled | No
+Enabled | No
 
 This cop checks if the length of a block exceeds some maximum value.
 Comment lines can optionally be ignored.
@@ -41,7 +41,7 @@ Exclude | Rakefile, \*\*/\*.rake, spec/\*\*/\*.rb
 
 Enabled by default | Supports autocorrection
 --- | ---
-Disabled | No
+Enabled | No
 
 This cop checks for excessive nesting of conditional and looping
 constructs. Despite the cop's name, blocks are not considered as an
@@ -60,7 +60,7 @@ Max | 3
 
 Enabled by default | Supports autocorrection
 --- | ---
-Disabled | No
+Enabled | No
 
 This cop checks if the length a class exceeds some maximum value.
 Comment lines can optionally be ignored.
@@ -71,14 +71,14 @@ The maximum allowed length is configurable.
 Attribute | Value
 --- | ---
 CountComments | false
-Max | 168
+Max | 100
 
 
 ## Metrics/CyclomaticComplexity
 
 Enabled by default | Supports autocorrection
 --- | ---
-Disabled | No
+Enabled | No
 
 This cop checks that the cyclomatic complexity of methods is not higher
 than the configured maximum. The cyclomatic complexity is the number of
@@ -95,14 +95,14 @@ Loops can be said to have an exit condition, so they add one.
 
 Attribute | Value
 --- | ---
-Max | 7
+Max | 6
 
 
 ## Metrics/LineLength
 
 Enabled by default | Supports autocorrection
 --- | ---
-Disabled | No
+Enabled | No
 
 This cop checks the length of lines in the source code.
 The maximum length is configurable.
@@ -122,7 +122,7 @@ IgnoreCopDirectives | false
 
 Enabled by default | Supports autocorrection
 --- | ---
-Disabled | No
+Enabled | No
 
 This cop checks if the length of a method exceeds some maximum value.
 Comment lines can optionally be ignored.
@@ -133,14 +133,14 @@ The maximum allowed length is configurable.
 Attribute | Value
 --- | ---
 CountComments | false
-Max | 14
+Max | 10
 
 
 ## Metrics/ModuleLength
 
 Enabled by default | Supports autocorrection
 --- | ---
-Disabled | No
+Enabled | No
 
 This cop checks if the length a module exceeds some maximum value.
 Comment lines can optionally be ignored.
@@ -151,14 +151,14 @@ The maximum allowed length is configurable.
 Attribute | Value
 --- | ---
 CountComments | false
-Max | 156
+Max | 100
 
 
 ## Metrics/ParameterLists
 
 Enabled by default | Supports autocorrection
 --- | ---
-Disabled | No
+Enabled | No
 
 This cop checks for methods with too many parameters.
 The maximum number of parameters is configurable.
@@ -177,7 +177,7 @@ CountKeywordArgs | true
 
 Enabled by default | Supports autocorrection
 --- | ---
-Disabled | No
+Enabled | No
 
 This cop tries to produce a complexity score that's a measure of the
 complexity the reader experiences when looking at a method. For that

--- a/manual/cops_performance.md
+++ b/manual/cops_performance.md
@@ -61,7 +61,7 @@ end
 
 Enabled by default | Supports autocorrection
 --- | ---
-Disabled | Yes
+Enabled | Yes
 
 This cop identifies places where a case-insensitive string comparison
 can better be implemented using `casecmp`.
@@ -92,7 +92,7 @@ Reference | https://github.com/JuanitoFatas/fast-ruby#stringcasecmp-vs-stringdow
 
 Enabled by default | Supports autocorrection
 --- | ---
-Disabled | Yes
+Enabled | Yes
 
 This cop is used to identify usages of `count` on an `Enumerable` that
 follow calls to `select` or `reject`. Querying logic can instead be
@@ -143,7 +143,7 @@ SafeMode | true
 
 Enabled by default | Supports autocorrection
 --- | ---
-Disabled | Yes
+Enabled | Yes
 
 This cop is used to identify usages of
 `select.first`, `select.last`, `find_all.first`, and `find_all.last`
@@ -208,7 +208,7 @@ str.end_with?(var1, var2)
 
 Enabled by default | Supports autocorrection
 --- | ---
-Disabled | Yes
+Enabled | Yes
 
 This cop identifies unnecessary use of a regex where `String#end_with?`
 would suffice.
@@ -245,7 +245,7 @@ Do not compute the size of statically sized objects.
 
 Enabled by default | Supports autocorrection
 --- | ---
-Disabled | Yes
+Enabled | Yes
 
 This cop is used to identify usages of
 
@@ -274,7 +274,7 @@ EnabledForFlattenWithoutParams | false
 
 Enabled by default | Supports autocorrection
 --- | ---
-Disabled | Yes
+Enabled | Yes
 
 This cop checks for uses of `each_key` & `each_value` Hash methods.
 
@@ -323,7 +323,7 @@ This cop identifies places where `lstrip.rstrip` can be replaced by
 
 Enabled by default | Supports autocorrection
 --- | ---
-Disabled | Yes
+Enabled | Yes
 
 This cop identifies uses of `Range#include?`, which iterates over each
 item in a `Range` to see if a specified item is there. In contrast,
@@ -347,7 +347,7 @@ Reference | https://github.com/JuanitoFatas/fast-ruby#cover-vs-include-code
 
 Enabled by default | Supports autocorrection
 --- | ---
-Disabled | Yes
+Enabled | Yes
 
 This cop identifies the use of a `&block` parameter and `block.call`
 where `yield` would do just as well.
@@ -406,7 +406,7 @@ return regex.match('str')
 
 Enabled by default | Supports autocorrection
 --- | ---
-Disabled | Yes
+Enabled | Yes
 
 This cop identifies places where `Hash#merge!` can be replaced by
 `Hash#[]=`.
@@ -453,7 +453,7 @@ array.sort
 
 Enabled by default | Supports autocorrection
 --- | ---
-Disabled | Yes
+Enabled | Yes
 
 This cop is used to identify usages of `reverse.each` and
 change them to use `reverse_each` instead.
@@ -479,7 +479,7 @@ Reference | https://github.com/JuanitoFatas/fast-ruby#enumerablereverseeach-vs-e
 
 Enabled by default | Supports autocorrection
 --- | ---
-Disabled | Yes
+Enabled | Yes
 
 This cop is used to identify usages of `shuffle.first`, `shuffle.last`
 and `shuffle[]` and change them to use `sample` instead.
@@ -517,7 +517,7 @@ Reference | https://github.com/JuanitoFatas/fast-ruby#arrayshufflefirst-vs-array
 
 Enabled by default | Supports autocorrection
 --- | ---
-Disabled | Yes
+Enabled | Yes
 
 This cop is used to identify usages of `count` on an
 `Array` and `Hash` and change them to `size`.
@@ -578,7 +578,7 @@ end
 
 Enabled by default | Supports autocorrection
 --- | ---
-Disabled | Yes
+Enabled | Yes
 
 This cop identifies unnecessary use of a regex where
 `String#start_with?` would suffice.
@@ -607,7 +607,7 @@ AutoCorrect | false
 
 Enabled by default | Supports autocorrection
 --- | ---
-Disabled | Yes
+Enabled | Yes
 
 This cop identifies places where `gsub` can be replaced by
 `tr` or `delete`.

--- a/manual/cops_rails.md
+++ b/manual/cops_rails.md
@@ -432,48 +432,43 @@ Enabled by default | Supports autocorrection
 --- | ---
 Disabled | Yes
 
-This cop transforms usages of a method call safeguarded by a non `nil`
-check for the variable whose method is being called to
-safe navigation (`&.`).
-
-Configuration option: ConvertCodeThatCanStartToReturnNil
-The default for this is `false`. When configured to `true`, this will
-check for code in the format `!foo.nil? && foo.bar`. As it is written,
-the return of this code is limited to `false` and whatever the return
-of the method is. If this is converted to safe navigation,
-`foo&.bar` can start returning `nil` as well as what the method
-returns.
+This cop converts usages of `try!` to `&.`. It can also be configured
+to convert `try`. It will convert code to use safe navigation if the
+target Ruby version is set to 2.3+
 
 ### Example
 
 ```ruby
-# bad
-foo.bar if foo
-foo.bar(param1, param2) if foo
-foo.bar { |e| e.something } if foo
-foo.bar(param) { |e| e.something } if foo
+# ConvertTry: false
+  # bad
+  foo.try!(:bar)
+  foo.try!(:bar, baz)
+  foo.try!(:bar) { |e| e.baz }
 
-foo.bar if !foo.nil?
-foo.bar unless !foo
-foo.bar unless foo.nil?
+  foo.try!(:[], 0)
 
-foo && foo.bar
-foo && foo.bar(param1, param2)
-foo && foo.bar { |e| e.something }
-foo && foo.bar(param) { |e| e.something }
+  # good
+  foo.try(:bar)
+  foo.try(:bar, baz)
+  foo.try(:bar) { |e| e.baz }
 
-# good
-foo&.bar
-foo&.bar(param1, param2)
-foo&.bar { |e| e.something }
-foo&.bar(param) { |e| e.something }
+  foo&.bar
+  foo&.bar(baz)
+  foo&.bar { |e| e.baz }
 
-foo.nil? || foo.bar
-!foo || foo.bar
+# ConvertTry: true
+  # bad
+  foo.try!(:bar)
+  foo.try!(:bar, baz)
+  foo.try!(:bar) { |e| e.baz }
+  foo.try(:bar)
+  foo.try(:bar, baz)
+  foo.try(:bar) { |e| e.baz }
 
-# Methods that `nil` will `respond_to?` should not be converted to
-# use safe navigation
-foo.to_i if foo
+  # good
+  foo&.bar
+  foo&.bar(baz)
+  foo&.bar { |e| e.baz }
 ```
 
 ### Important attributes

--- a/manual/cops_security.md
+++ b/manual/cops_security.md
@@ -4,7 +4,7 @@
 
 Enabled by default | Supports autocorrection
 --- | ---
-Disabled | Yes
+Enabled | Yes
 
 This cop checks for the use of JSON class methods which have potential
 security issues.

--- a/manual/cops_style.md
+++ b/manual/cops_style.md
@@ -4,7 +4,7 @@
 
 Enabled by default | Supports autocorrection
 --- | ---
-Disabled | Yes
+Enabled | Yes
 
 Modifiers should be indented as deep as method definitions, or as deep
 as the class/module keyword, depending on configuration.
@@ -46,7 +46,7 @@ def attribute ...
 
 Enabled by default | Supports autocorrection
 --- | ---
-Disabled | Yes
+Enabled | Yes
 
 This cop finds uses of `alias` where `alias_method` would be more
 appropriate (or is simply preferred due to configuration), and vice
@@ -74,7 +74,7 @@ aligned.
 
 Enabled by default | Supports autocorrection
 --- | ---
-Disabled | Yes
+Enabled | Yes
 
 Here we check if the keys, separators, and values of a multi-line hash
 literal are aligned.
@@ -93,7 +93,7 @@ SupportedLastArgumentHashStyles | always_inspect, always_ignore, ignore_implicit
 
 Enabled by default | Supports autocorrection
 --- | ---
-Disabled | Yes
+Enabled | Yes
 
 Here we check if the parameters on a multi-line method call or
 definition are aligned.
@@ -111,7 +111,7 @@ IndentationWidth |
 
 Enabled by default | Supports autocorrection
 --- | ---
-Disabled | Yes
+Enabled | Yes
 
 This cop checks for uses of *and* and *or*.
 
@@ -164,7 +164,7 @@ This cop checks for uses of Module#attr.
 
 Enabled by default | Supports autocorrection
 --- | ---
-Enabled | No
+Disabled | No
 
 This cop checks for cases when you could use a block
 accepting version of a method that does automatic
@@ -186,7 +186,7 @@ end
 
 Enabled by default | Supports autocorrection
 --- | ---
-Disabled | Yes
+Enabled | Yes
 
 This cop checks if usage of %() or %Q() matches configuration.
 
@@ -218,7 +218,7 @@ This cop looks for uses of block comments (=begin...=end).
 
 Enabled by default | Supports autocorrection
 --- | ---
-Disabled | Yes
+Enabled | Yes
 
 Check for uses of braces or do/end around single line or
 multi-line blocks.
@@ -269,7 +269,7 @@ blah { |i|
 
 Enabled by default | Supports autocorrection
 --- | ---
-Disabled | Yes
+Enabled | Yes
 
 This cop checks for braces around the last parameter in a method call
 if the last parameter is a hash.
@@ -294,7 +294,7 @@ This cop checks for uses of the case equality operator(===).
 
 Enabled by default | Supports autocorrection
 --- | ---
-Disabled | Yes
+Enabled | Yes
 
 This cop checks how the *when*s of a *case* expression
 are indented in relation to its *case* or *end* keyword.
@@ -332,7 +332,7 @@ an underscore in them.
 
 Enabled by default | Supports autocorrection
 --- | ---
-Disabled | No
+Enabled | No
 
 This cop checks the style of children definitions at classes and
 modules. Basically there are two different styles:
@@ -361,7 +361,7 @@ SupportedStyles | nested, compact
 
 Enabled by default | Supports autocorrection
 --- | ---
-Disabled | Yes
+Enabled | Yes
 
 This cop enforces consistent use of `Object#is_a?` or `Object#kind_of?`.
 
@@ -474,7 +474,7 @@ of the . operator (like FileUtils::rmdir instead of FileUtils.rmdir).
 
 Enabled by default | Supports autocorrection
 --- | ---
-Disabled | Yes
+Enabled | Yes
 
 This cop enforces using `` or %x around command literals.
 
@@ -516,7 +516,7 @@ AllowInnerBackticks | false
 
 Enabled by default | Supports autocorrection
 --- | ---
-Disabled | Yes
+Enabled | Yes
 
 This cop checks that comment annotation keywords are written according
 to guidelines.
@@ -540,7 +540,7 @@ This cops checks the indentation of comments.
 
 Enabled by default | Supports autocorrection
 --- | ---
-Disabled | Yes
+Enabled | Yes
 
 Check for `if` and `case` statements where each branch is used for
 assignment to the same variable when using the return of the
@@ -702,7 +702,7 @@ class/singleton methods are checked.
 
 Enabled by default | Supports autocorrection
 --- | ---
-Disabled | No
+Enabled | No
 
 This cop checks for missing top-level documentation of
 classes and modules. Classes with no body are exempt from the
@@ -785,7 +785,7 @@ RequireForNonPublicMethods | false
 
 Enabled by default | Supports autocorrection
 --- | ---
-Disabled | Yes
+Enabled | Yes
 
 This cop checks the . position in multi-line method calls.
 
@@ -930,7 +930,7 @@ end
 
 Enabled by default | Supports autocorrection
 --- | ---
-Disabled | Yes
+Enabled | Yes
 
 Checks for empty else-clauses, possibly including comments and/or an
 explicit `nil` depending on the EnforcedStyle.
@@ -1014,7 +1014,7 @@ SupportedStyles | empty, nil, both
 
 Enabled by default | Supports autocorrection
 --- | ---
-Disabled | Yes
+Enabled | Yes
 
 This cop checks whether method definitions are
 separated by empty lines.
@@ -1046,7 +1046,7 @@ Access modifiers should be surrounded by blank lines.
 
 Enabled by default | Supports autocorrection
 --- | ---
-Disabled | Yes
+Enabled | Yes
 
 This cops checks if empty lines around the bodies of blocks match
 the configuration.
@@ -1085,7 +1085,7 @@ SupportedStyles | empty_lines, no_empty_lines
 
 Enabled by default | Supports autocorrection
 --- | ---
-Disabled | Yes
+Enabled | Yes
 
 This cops checks if empty lines around the bodies of classes match
 the configuration.
@@ -1144,7 +1144,7 @@ end
 
 Enabled by default | Supports autocorrection
 --- | ---
-Disabled | Yes
+Enabled | Yes
 
 This cops checks if empty lines around the bodies of modules match
 the configuration.
@@ -1213,7 +1213,7 @@ never - enforce no encoding comment in all files
 
 Attribute | Value
 --- | ---
-EnforcedStyle | when_needed
+EnforcedStyle | never
 SupportedStyles | when_needed, always, never
 AutoCorrectEncodingComment | # encoding: utf-8
 
@@ -1257,7 +1257,7 @@ if x.even?
 
 Enabled by default | Supports autocorrection
 --- | ---
-Disabled | Yes
+Enabled | Yes
 
 This cop checks for extra/unnecessary whitespace.
 
@@ -1288,7 +1288,7 @@ ForceEqualSignAlignment | false
 
 Enabled by default | Supports autocorrection
 --- | ---
-Disabled | No
+Enabled | No
 
 This cop makes sure that Ruby source files have snake_case
 names. Ruby scripts (i.e. source files with a shebang in the
@@ -1308,7 +1308,7 @@ IgnoreExecutableScripts | true
 
 Enabled by default | Supports autocorrection
 --- | ---
-Enabled | Yes
+Disabled | Yes
 
 This cop checks for a line break before the first element in a
 multi-line array.
@@ -1330,7 +1330,7 @@ multi-line array.
 
 Enabled by default | Supports autocorrection
 --- | ---
-Enabled | Yes
+Disabled | Yes
 
 This cop checks for a line break before the first element in a
 multi-line hash.
@@ -1352,7 +1352,7 @@ multi-line hash.
 
 Enabled by default | Supports autocorrection
 --- | ---
-Enabled | Yes
+Disabled | Yes
 
 This cop checks for a line break before the first argument in a
 multi-line method call.
@@ -1378,7 +1378,7 @@ method foo, bar,
 
 Enabled by default | Supports autocorrection
 --- | ---
-Enabled | Yes
+Disabled | Yes
 
 This cop checks for a line break before the first parameter in a
 multi-line method parameter definition.
@@ -1410,7 +1410,7 @@ end
 
 Enabled by default | Supports autocorrection
 --- | ---
-Disabled | Yes
+Enabled | Yes
 
 This cop checks the indentation of the first parameter in a method call.
 Parameters after the first one are checked by Style/AlignParameters, not
@@ -1451,7 +1451,7 @@ This cop looks for uses of flip flop operator
 
 Enabled by default | Supports autocorrection
 --- | ---
-Disabled | No
+Enabled | No
 
 This cop looks for uses of the *for* keyword, or *each* method. The
 preferred alternative is set in the EnforcedStyle configuration
@@ -1470,7 +1470,7 @@ SupportedStyles | for, each
 
 Enabled by default | Supports autocorrection
 --- | ---
-Disabled | No
+Enabled | No
 
 This cop enforces the use of a single string formatting utility.
 Valid options include Kernel#format, Kernel#sprintf and String#%.
@@ -1492,7 +1492,7 @@ SupportedStyles | format, sprintf, percent
 
 Enabled by default | Supports autocorrection
 --- | ---
-Disabled | Yes
+Enabled | Yes
 
 This cop is designed to help upgrade to Ruby 3.0. It will add the
 comment `# frozen_string_literal: true` to the top of files to
@@ -1504,7 +1504,7 @@ comment. The frozen string literal comment is only valid in Ruby 2.3+.
 
 Attribute | Value
 --- | ---
-EnforcedStyle | always
+EnforcedStyle | when_needed
 SupportedStyles | when_needed, always
 
 
@@ -1512,7 +1512,7 @@ SupportedStyles | when_needed, always
 
 Enabled by default | Supports autocorrection
 --- | ---
-Disabled | No
+Enabled | No
 
 This cops looks for uses of global variables.
 It does not report offenses for built-in global variables.
@@ -1533,7 +1533,7 @@ AllowedVariables |
 
 Enabled by default | Supports autocorrection
 --- | ---
-Disabled | No
+Enabled | No
 
 Use a guard clause instead of wrapping the code inside a conditional
 expression
@@ -1582,7 +1582,7 @@ MinBodyLength | 1
 
 Enabled by default | Supports autocorrection
 --- | ---
-Disabled | Yes
+Enabled | Yes
 
 This cop checks hash literal syntax.
 
@@ -1725,7 +1725,7 @@ end
 
 Enabled by default | Supports autocorrection
 --- | ---
-Disabled | Yes
+Enabled | Yes
 
 Checks for if and unless statements that would fit on one line
 if written as a modifier if/unless.
@@ -1778,7 +1778,7 @@ Checks for uses of semicolon in if statements.
 
 Enabled by default | Supports autocorrection
 --- | ---
-Enabled | No
+Disabled | No
 
 This cop checks for `raise` or `fail` statements which do not specify an
 explicit exception class. (This raises a `RuntimeError`. Some projects
@@ -1799,7 +1799,7 @@ raise ArgumentError, 'Error message here'
 
 Enabled by default | Supports autocorrection
 --- | ---
-Disabled | Yes
+Enabled | Yes
 
 This cop checks the indentation of the first element in an array literal
 where the opening bracket and the first element are on separate lines.
@@ -1849,7 +1849,7 @@ IndentationWidth |
 
 Enabled by default | Supports autocorrection
 --- | ---
-Disabled | Yes
+Enabled | Yes
 
 This cop checks the indentation of the first line of the
 right-hand-side of a multi-line assignment.
@@ -1884,7 +1884,7 @@ IndentationWidth |
 
 Enabled by default | Supports autocorrection
 --- | ---
-Disabled | Yes
+Enabled | Yes
 
 This cops checks the indentation of the first key in a hash literal
 where the opening brace and the first key are on separate lines. The
@@ -1934,7 +1934,7 @@ IndentationWidth |
 
 Enabled by default | Supports autocorrection
 --- | ---
-Disabled | Yes
+Enabled | Yes
 
 This cops checks for inconsistent indentation.
 
@@ -1961,7 +1961,7 @@ SupportedStyles | normal, rails
 
 Enabled by default | Supports autocorrection
 --- | ---
-Disabled | Yes
+Enabled | Yes
 
 This cops checks for indentation that doesn't use two spaces.
 
@@ -2017,7 +2017,7 @@ line in a file.
 
 Enabled by default | Supports autocorrection
 --- | ---
-Enabled | No
+Disabled | No
 
 This cop checks for trailing inline comments.
 
@@ -2040,7 +2040,7 @@ end
 
 Enabled by default | Supports autocorrection
 --- | ---
-Disabled | Yes
+Enabled | Yes
 
 This cop (by default) checks for uses of the lambda literal syntax for
 single line lambdas, and the method call syntax for multiline lambdas.
@@ -2107,7 +2107,7 @@ SupportedStyles | line_count_dependent, lambda, literal
 
 Enabled by default | Supports autocorrection
 --- | ---
-Disabled | Yes
+Enabled | Yes
 
 This cop checks for use of the lambda.(args) syntax.
 
@@ -2177,7 +2177,7 @@ This cop checks for unwanted parentheses in parameterless method calls.
 
 Enabled by default | Supports autocorrection
 --- | ---
-Enabled | No
+Disabled | No
 
 This cop checks for methods called on a do...end block. The point of
 this check is that it's easy to miss the call tacked on to the block
@@ -2195,7 +2195,7 @@ end.c
 
 Enabled by default | Supports autocorrection
 --- | ---
-Disabled | Yes
+Enabled | Yes
 
 This cops checks for parentheses around the arguments in method
 definitions. Both instance and class/singleton methods are checked.
@@ -2240,7 +2240,7 @@ end
 
 Enabled by default | Supports autocorrection
 --- | ---
-Disabled | No
+Enabled | No
 
 This cop makes sure that all methods use the configured style,
 snake_case or camelCase, for their names. Some special arrangements
@@ -2302,7 +2302,7 @@ SupportedStyles | if, case, both
 
 Enabled by default | Supports autocorrection
 --- | ---
-Disabled | No
+Enabled | No
 
 This cops checks for use of `extend self` or `module_function` in a
 module.
@@ -2340,7 +2340,7 @@ SupportedStyles | module_function, extend_self
 
 Enabled by default | Supports autocorrection
 --- | ---
-Disabled | Yes
+Enabled | Yes
 
 This cop checks that the closing brace in an array literal is either
 on the same line as the last array element, or a new line.
@@ -2516,7 +2516,7 @@ blah { |i|
 
 Enabled by default | Supports autocorrection
 --- | ---
-Disabled | Yes
+Enabled | Yes
 
 This cop checks that the closing brace in a hash literal is either
 on the same line as the last hash element, or a new line.
@@ -2630,7 +2630,7 @@ end
 
 Enabled by default | Supports autocorrection
 --- | ---
-Disabled | Yes
+Enabled | Yes
 
 This cop checks that the closing brace in a method call is either
 on the same line as the last method argument, or a new line.
@@ -2699,7 +2699,7 @@ SupportedStyles | symmetrical, new_line, same_line
 
 Enabled by default | Supports autocorrection
 --- | ---
-Disabled | Yes
+Enabled | Yes
 
 This cop checks the indentation of the method name part in method calls
 that span more than one line.
@@ -2744,7 +2744,7 @@ IndentationWidth |
 
 Enabled by default | Supports autocorrection
 --- | ---
-Disabled | Yes
+Enabled | Yes
 
 This cop checks that the closing brace in a method definition is either
 on the same line as the last method parameter, or a new line.
@@ -2813,7 +2813,7 @@ SupportedStyles | symmetrical, new_line, same_line
 
 Enabled by default | Supports autocorrection
 --- | ---
-Disabled | Yes
+Enabled | Yes
 
 This cop checks the indentation of the right hand side operand in
 binary operations that span more than one line.
@@ -2931,7 +2931,7 @@ This cop checks for nested ternary op expressions.
 
 Enabled by default | Supports autocorrection
 --- | ---
-Disabled | Yes
+Enabled | Yes
 
 Use `next` to skip iteration instead of a condition at the end.
 
@@ -2983,7 +2983,7 @@ if x.nil?
 
 Enabled by default | Supports autocorrection
 --- | ---
-Disabled | Yes
+Enabled | Yes
 
 This cop checks for non-nil checks, which are usually redundant.
 
@@ -3027,7 +3027,7 @@ This cop checks for uses if the keyword *not* instead of !.
 
 Enabled by default | Supports autocorrection
 --- | ---
-Disabled | Yes
+Enabled | Yes
 
 This cop checks for octal, hex, binary and decimal literals using
 uppercase prefixes and corrects them to lowercase prefix
@@ -3049,7 +3049,7 @@ SupportedOctalStyles | zero_with_o, zero_only
 
 Enabled by default | Supports autocorrection
 --- | ---
-Disabled | Yes
+Enabled | Yes
 
 This cop checks for big numeric literals without _ between groups
 of digits in them.
@@ -3065,7 +3065,7 @@ MinDigits | 5
 
 Enabled by default | Supports autocorrection
 --- | ---
-Disabled | Yes
+Enabled | Yes
 
 This cop checks for usage of comparison operators (`==`, `!=`,
 `>`, `<`) to test numbers as zero, nonzero, positive, or negative.
@@ -3235,7 +3235,7 @@ c = 3
 
 Enabled by default | Supports autocorrection
 --- | ---
-Disabled | Yes
+Enabled | Yes
 
 This cop checks for the presence of superfluous parentheses around the
 condition of if/unless/while/until.
@@ -3251,7 +3251,7 @@ AllowSafeAssignment | true
 
 Enabled by default | Supports autocorrection
 --- | ---
-Disabled | Yes
+Enabled | Yes
 
 This cop enforces the consistent usage of `%`-literal delimiters.
 
@@ -3266,7 +3266,7 @@ PreferredDelimiters | {"%"=>"()", "%i"=>"()", "%I"=>"()", "%q"=>"()", "%Q"=>"()"
 
 Enabled by default | Supports autocorrection
 --- | ---
-Disabled | Yes
+Enabled | Yes
 
 This cop checks for usage of the %Q() syntax when %q() would do.
 
@@ -3291,7 +3291,7 @@ backreferences like $1, $2, etc.
 
 Enabled by default | Supports autocorrection
 --- | ---
-Disabled | No
+Enabled | No
 
 This cop makes sure that predicates are named properly.
 
@@ -3325,7 +3325,7 @@ Exclude | spec/\*\*/\*
 
 Enabled by default | Supports autocorrection
 --- | ---
-Disabled | Yes
+Enabled | Yes
 
 This cop (by default) checks for uses of methods Hash#has_key? and
 Hash#has_value? where it enforces Hash#key? and Hash#value?
@@ -3378,7 +3378,7 @@ would be more appropriate.
 
 Enabled by default | Supports autocorrection
 --- | ---
-Disabled | Yes
+Enabled | Yes
 
 This cop checks the args passed to `fail` and `raise`. For exploded
 style (default), it recommends passing the exception class and message
@@ -3517,7 +3517,7 @@ x if y.z.nil?
 
 Enabled by default | Supports autocorrection
 --- | ---
-Disabled | Yes
+Enabled | Yes
 
 This cop checks for redundant `return` expressions.
 
@@ -3596,7 +3596,7 @@ otherwise.
 
 Enabled by default | Supports autocorrection
 --- | ---
-Disabled | Yes
+Enabled | Yes
 
 This cop enforces using // or %r around regular expressions.
 
@@ -3675,50 +3675,45 @@ This cop checks for uses of rescue in its modifier form.
 
 Enabled by default | Supports autocorrection
 --- | ---
-Disabled | Yes
+Enabled | Yes
 
-This cop transforms usages of a method call safeguarded by a non `nil`
-check for the variable whose method is being called to
-safe navigation (`&.`).
-
-Configuration option: ConvertCodeThatCanStartToReturnNil
-The default for this is `false`. When configured to `true`, this will
-check for code in the format `!foo.nil? && foo.bar`. As it is written,
-the return of this code is limited to `false` and whatever the return
-of the method is. If this is converted to safe navigation,
-`foo&.bar` can start returning `nil` as well as what the method
-returns.
+This cop converts usages of `try!` to `&.`. It can also be configured
+to convert `try`. It will convert code to use safe navigation if the
+target Ruby version is set to 2.3+
 
 ### Example
 
 ```ruby
-# bad
-foo.bar if foo
-foo.bar(param1, param2) if foo
-foo.bar { |e| e.something } if foo
-foo.bar(param) { |e| e.something } if foo
+# ConvertTry: false
+  # bad
+  foo.try!(:bar)
+  foo.try!(:bar, baz)
+  foo.try!(:bar) { |e| e.baz }
 
-foo.bar if !foo.nil?
-foo.bar unless !foo
-foo.bar unless foo.nil?
+  foo.try!(:[], 0)
 
-foo && foo.bar
-foo && foo.bar(param1, param2)
-foo && foo.bar { |e| e.something }
-foo && foo.bar(param) { |e| e.something }
+  # good
+  foo.try(:bar)
+  foo.try(:bar, baz)
+  foo.try(:bar) { |e| e.baz }
 
-# good
-foo&.bar
-foo&.bar(param1, param2)
-foo&.bar { |e| e.something }
-foo&.bar(param) { |e| e.something }
+  foo&.bar
+  foo&.bar(baz)
+  foo&.bar { |e| e.baz }
 
-foo.nil? || foo.bar
-!foo || foo.bar
+# ConvertTry: true
+  # bad
+  foo.try!(:bar)
+  foo.try!(:bar, baz)
+  foo.try!(:bar) { |e| e.baz }
+  foo.try(:bar)
+  foo.try(:bar, baz)
+  foo.try(:bar) { |e| e.baz }
 
-# Methods that `nil` will `respond_to?` should not be converted to
-# use safe navigation
-foo.to_i if foo
+  # good
+  foo&.bar
+  foo&.bar(baz)
+  foo&.bar { |e| e.baz }
 ```
 
 ### Important attributes
@@ -3750,7 +3745,7 @@ x += 1
 
 Enabled by default | Supports autocorrection
 --- | ---
-Disabled | Yes
+Enabled | Yes
 
 This cop checks for multiple expressions placed on the same line.
 It also checks for lines terminated with a semicolon.
@@ -3766,7 +3761,7 @@ AllowAsExpressionSeparator | false
 
 Enabled by default | Supports autocorrection
 --- | ---
-Enabled | No
+Disabled | No
 
 This cop checks for the use of the send method.
 
@@ -3774,7 +3769,7 @@ This cop checks for the use of the send method.
 
 Enabled by default | Supports autocorrection
 --- | ---
-Disabled | Yes
+Enabled | Yes
 
 This cop checks for uses of `fail` and `raise`.
 
@@ -3790,7 +3785,7 @@ SupportedStyles | only_raise, only_fail, semantic
 
 Enabled by default | Supports autocorrection
 --- | ---
-Disabled | No
+Enabled | No
 
 This cop checks whether the block parameters of a single-line
 method accepting a block match the names specified via configuration.
@@ -3809,7 +3804,7 @@ Methods | {"reduce"=>["a", "e"]}, {"inject"=>["a", "e"]}
 
 Enabled by default | Supports autocorrection
 --- | ---
-Disabled | Yes
+Enabled | Yes
 
 This cop checks for single-line method definitions.
 It can optionally accept single-line methods with no body.
@@ -3887,7 +3882,7 @@ Checks for semicolon (;) not followed by some kind of space.
 
 Enabled by default | Supports autocorrection
 --- | ---
-Disabled | Yes
+Enabled | Yes
 
 Checks the spacing inside and after block parameters pipes.
 
@@ -3913,7 +3908,7 @@ SupportedStyles | space, no_space
 
 Enabled by default | Supports autocorrection
 --- | ---
-Disabled | Yes
+Enabled | Yes
 
 Checks that the equals signs in parameter default assignments
 have or don't have surrounding space depending on configuration.
@@ -3960,7 +3955,7 @@ something = 123 if test
 
 Enabled by default | Supports autocorrection
 --- | ---
-Disabled | Yes
+Enabled | Yes
 
 Checks that operators have space around them, except for **
 which should not have surrounding space.
@@ -3976,7 +3971,7 @@ AllowForAlignment | true
 
 Enabled by default | Supports autocorrection
 --- | ---
-Disabled | Yes
+Enabled | Yes
 
 Checks that block braces have or don't have a space before the opening
 brace depending on configuration.
@@ -4010,7 +4005,7 @@ same line.
 
 Enabled by default | Supports autocorrection
 --- | ---
-Disabled | Yes
+Enabled | Yes
 
 Checks that exactly one space is used between a method name and the
 first argument for method calls without parentheses.
@@ -4065,7 +4060,7 @@ Checks for unnecessary additional spaces inside array percent literals
 
 Enabled by default | Supports autocorrection
 --- | ---
-Disabled | Yes
+Enabled | Yes
 
 Checks that block braces have or don't have surrounding space inside
 them on configuration. For blocks taking parameters, it checks that the
@@ -4094,7 +4089,7 @@ Checks for spaces inside square brackets.
 
 Enabled by default | Supports autocorrection
 --- | ---
-Disabled | Yes
+Enabled | Yes
 
 Checks that braces used for hash literals have or don't have
 surrounding space depending on configuration.
@@ -4166,7 +4161,7 @@ Checks for spaces inside range literals.
 
 Enabled by default | Supports autocorrection
 --- | ---
-Disabled | Yes
+Enabled | Yes
 
 This cop checks for whitespace within string interpolations.
 
@@ -4192,7 +4187,7 @@ SupportedStyles | space, no_space
 
 Enabled by default | Supports autocorrection
 --- | ---
-Disabled | Yes
+Enabled | Yes
 
 This cop looks for uses of Perl-style global variables.
 
@@ -4208,7 +4203,7 @@ SupportedStyles | use_perl_names, use_english_names
 
 Enabled by default | Supports autocorrection
 --- | ---
-Disabled | Yes
+Enabled | Yes
 
 Check for parentheses around stabby lambda arguments.
 There are two different styles. Defaults to `require_parentheses`.
@@ -4241,7 +4236,7 @@ SupportedStyles | require_parentheses, require_no_parentheses
 
 Enabled by default | Supports autocorrection
 --- | ---
-Disabled | Yes
+Enabled | Yes
 
 Checks if uses of quotes match the configured preference.
 
@@ -4258,7 +4253,7 @@ ConsistentQuotesInMultiline | false
 
 Enabled by default | Supports autocorrection
 --- | ---
-Disabled | Yes
+Enabled | Yes
 
 Checks if uses of quotes match the configured preference.
 
@@ -4348,7 +4343,7 @@ This cop checks symbol literal syntax.
 
 Enabled by default | Supports autocorrection
 --- | ---
-Disabled | Yes
+Enabled | Yes
 
 Use symbols as procs when possible.
 
@@ -4381,7 +4376,7 @@ This cop checks for tabs inside the source code.
 
 Enabled by default | Supports autocorrection
 --- | ---
-Disabled | Yes
+Enabled | Yes
 
 This cop checks for the presence of parentheses around ternary
 conditions. It is configurable to enforce inclusion or omission of
@@ -4429,7 +4424,7 @@ AllowSafeAssignment | true
 
 Enabled by default | Supports autocorrection
 --- | ---
-Disabled | Yes
+Enabled | Yes
 
 This cop looks for trailing blank lines and a final newline in the
 source code.
@@ -4446,7 +4441,7 @@ SupportedStyles | final_newline, final_blank_line
 
 Enabled by default | Supports autocorrection
 --- | ---
-Disabled | Yes
+Enabled | Yes
 
 This cop checks for trailing comma in argument lists.
 
@@ -4487,7 +4482,7 @@ SupportedStyles | comma, consistent_comma, no_comma
 
 Enabled by default | Supports autocorrection
 --- | ---
-Disabled | Yes
+Enabled | Yes
 
 This cop checks for trailing comma in array and hash literals.
 
@@ -4528,7 +4523,7 @@ SupportedStyles | comma, consistent_comma, no_comma
 
 Enabled by default | Supports autocorrection
 --- | ---
-Disabled | Yes
+Enabled | Yes
 
 This cop checks for extra underscores in variable assignment.
 
@@ -4567,7 +4562,7 @@ This cop looks for trailing whitespace in the source code.
 
 Enabled by default | Supports autocorrection
 --- | ---
-Disabled | Yes
+Enabled | Yes
 
 This cop looks for trivial reader/writer methods, that could
 have been created with the attr_* family of functions automatically.
@@ -4640,7 +4635,7 @@ This cop checks for variable interpolation (like "#@ivar").
 
 Enabled by default | Supports autocorrection
 --- | ---
-Disabled | No
+Enabled | No
 
 This cop makes sure that all variables use the configured style,
 snake_case or camelCase, for their names.
@@ -4657,7 +4652,7 @@ SupportedStyles | snake_case, camelCase
 
 Enabled by default | Supports autocorrection
 --- | ---
-Disabled | No
+Enabled | No
 
 This cop makes sure that all numbered variables use the
 configured style, snake_case, normalcase or non_integer,
@@ -4731,7 +4726,7 @@ Checks for uses of `do` in multi-line `while/until` statements.
 
 Enabled by default | Supports autocorrection
 --- | ---
-Disabled | Yes
+Enabled | Yes
 
 Checks for while and until statements that would fit on one line
 if written as a modifier while/until.
@@ -4748,7 +4743,7 @@ MaxLineLength | 80
 
 Enabled by default | Supports autocorrection
 --- | ---
-Disabled | Yes
+Enabled | Yes
 
 This cop can check for array literals made up of word-like
 strings, that are not using the %w() syntax.

--- a/tasks/cops_documentation.rake
+++ b/tasks/cops_documentation.rake
@@ -92,7 +92,7 @@ task :generate_cops_documentation do |_task|
 
   def print_cop_with_doc(cop, config)
     t = config.for_cop(cop)
-    pars = t.reject! { |k| %w(Description Enabled StyleGuide).include? k }
+    pars = t.reject { |k| %w(Description Enabled StyleGuide).include? k }
     description = 'No documentation'
     examples_object = []
     YARD::Registry.all.select { |o| !o.docstring.blank? }.map do |o|
@@ -115,7 +115,7 @@ task :generate_cops_documentation do |_task|
   end
   system('exec yardoc') if answer == 'Y'
   cops = RuboCop::Cop::Cop.all
-  config = RuboCop::ConfigStore.new.for(Dir.pwd)
+  config = RuboCop::ConfigLoader.default_configuration
   YARD::Registry.load!
   cops.types.sort!.each { |type| print_cops_of_type(cops, type, config) }
 end


### PR DESCRIPTION
Problems and Solutions
------

The task has two problems.

### Problem 1

First, in metrics cops, default value of `max` are incorrect.
The task used `.rubocop_todo.yml` for this repository.
And the configuration has some config for metrics.
So, the configuration is applied by mistake.

e.g.

```markdown
## Metrics/AbcSize

...

### Important attributes

Attribute | Value
--- | ---
Reference | http://c2.com/cgi/wiki?AbcMetric
Max | 19
```

The max should be `15`, but it's 19.

### Solution 1

```diff
-  config = RuboCop::ConfigStore.new.for(Dir.pwd)
+  config = RuboCop::ConfigLoader.default_configuration
```

Use `default_configuration` instead of config for current directory.

### Problem 2

In many cops, `Enabled by default` is incorrectly disabled.

### Solution 2

`Enabled` is rejected from config destructively.
So, I've fixed it.

```diff
-    pars = t.reject! { |k| %w(Description Enabled StyleGuide).include? k }
+    pars = t.reject { |k| %w(Description Enabled StyleGuide).include? k }
```

Note
-------

I think this PR has update of documentation content unrelated this PR.
Because, `rake generate_cops_documentation` is forgotten in some PR.

-----------------

Before submitting the PR make sure the following are checked:

* [x] Documentation updated with `rake generate_cops_documentation`
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Used the same coding conventions as the rest of the project.
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] All tests are passing.
* [x] The new code doesn't generate RuboCop offenses.
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.

[1]: http://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html

