### PR TITLE
Fix bug when empty case nodes are present

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@
 * [#3625](https://github.com/bbatsov/rubocop/pull/3625): Fix some cops errors when condition is empty brace. ([@pocke][])
 * [#3468](https://github.com/bbatsov/rubocop/issues/3468): Fix bug regarding alignment inside `begin`..`end` block in `Style/MultilineMethodCallIndentation`. ([@jonas054][])
 * [#3644](https://github.com/bbatsov/rubocop/pull/3644): Fix generation incorrect documentation. ([@pocke][])
+* [#3645](https://github.com/bbatsov/rubocop/pull/3645): Fix bug with empty case when nodes in `Style/RedundantReturn`. ([@tiagocasanovapt][])
 
 ## 0.44.1 (2016-10-13)
 
@@ -2448,3 +2449,4 @@
 [@albus522]: https://github.com/albus522
 [@sihu]: https://github.com/sihu
 [@swcraig]: https://github.com/swcraig
+[@tiagocasanovapt]: https://github.com/tiagocasanovapt

--- a/lib/rubocop/cop/style/redundant_return.rb
+++ b/lib/rubocop/cop/style/redundant_return.rb
@@ -98,6 +98,7 @@ module RuboCop
         end
 
         def check_when_node(node)
+          return unless node
           _cond, body = *node
           check_branch(body) if body
         end

--- a/spec/rubocop/cop/style/redundant_return_spec.rb
+++ b/spec/rubocop/cop/style/redundant_return_spec.rb
@@ -296,4 +296,22 @@ describe RuboCop::Cop::Style::RedundantReturn, :config do
                                'end'].join("\n")
     end
   end
+
+  context 'when case nodes are empty' do
+    let(:src) do
+      ['def func',
+       '  case x',
+       '  when y then 1',
+       '  when z # do nothing',
+       '  else',
+       '    3',
+       '  end',
+       'end']
+    end
+
+    it 'accepts empty when nodes' do
+      inspect_source(cop, src)
+      expect(cop.offenses).to be_empty
+    end
+  end
 end


### PR DESCRIPTION
When defined inside a function, an empty _when_ block from a _case_ switch caused line 79 at _lib/rubocop/cop/style/redundant_return.rb_ to fail due to a _nil_ node.

I didn't add an _IF_ in line 96 (check_case_node) to match similar cases because it failed to pass the tests, namely on line length.

-----------------

Before submitting the PR make sure the following are checked:

* [X] Documentation updated with `rake generate_cops_documentation`
* [X] Wrote [good commit messages][1].  
* ~~[ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).~~
* [X] Used the same coding conventions as the rest of the project.
* [X] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [X] Added tests.
* [x] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [X] All tests are passing.
* [X] The new code doesn't generate RuboCop offenses.
* [X] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.

[1]: http://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html

Fix bug when empty case nodes are present
