### PR TITLE
[Fix #3637] Fix Style/NonNilCheck crashing for ternary condition

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@
 * [#3625](https://github.com/bbatsov/rubocop/pull/3625): Fix some cops errors when condition is empty brace. ([@pocke][])
 * [#3468](https://github.com/bbatsov/rubocop/issues/3468): Fix bug regarding alignment inside `begin`..`end` block in `Style/MultilineMethodCallIndentation`. ([@jonas054][])
 * [#3644](https://github.com/bbatsov/rubocop/pull/3644): Fix generation incorrect documentation. ([@pocke][])
+* [#3637](https://github.com/bbatsov/rubocop/issues/3637): Fix Style/NonNilCheck crashing for ternary condition. ([@tejasbubane][])
 
 ## 0.44.1 (2016-10-13)
 

--- a/lib/rubocop/cop/style/non_nil_check.rb
+++ b/lib/rubocop/cop/style/non_nil_check.rb
@@ -25,6 +25,7 @@ module RuboCop
       #  end
       class NonNilCheck < Cop
         include OnMethodDef
+        include IfNode
 
         NIL_NODE = s(:nil)
 
@@ -55,7 +56,8 @@ module RuboCop
           return unless method == :nil?
 
           parent = send_node.parent
-          parent && parent.if_type? && parent.loc.keyword.is?('unless')
+          parent && parent.if_type? && !ternary?(parent) &&
+            parent.loc.keyword.is?('unless')
         end
 
         def message(node)

--- a/spec/rubocop/cop/style/non_nil_check_spec.rb
+++ b/spec/rubocop/cop/style/non_nil_check_spec.rb
@@ -129,6 +129,11 @@ describe RuboCop::Cop::Style::NonNilCheck, :config do
       expect(cop.highlights).to eq(['not x.nil?'])
     end
 
+    it 'does not blow up with ternary operators' do
+      inspect_source(cop, 'my_var.nil? ? 1 : 0')
+      expect(cop.offenses).to be_empty
+    end
+
     it 'autocorrects by changing unless x.nil? to if x' do
       corrected = autocorrect_source(cop, 'puts a unless x.nil?')
       expect(corrected).to eq 'puts a if x'


### PR DESCRIPTION
Fixes #3637 

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Used the same coding conventions as the rest of the project.
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] All tests are passing.
* [x] The new code doesn't generate RuboCop offenses.
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Updated cop documentation with `rake generate_cops_documentation` (required only when you've added a new cop or changed the configuration/documentation of an existing cop).

[1]: http://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html

