### PR TITLE
[#3650] Fix registering an offense for variables with multiple digits

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@
 * [#3637](https://github.com/bbatsov/rubocop/issues/3637): Fix Style/NonNilCheck crashing for ternary condition. ([@tejasbubane][])
 * [#3654](https://github.com/bbatsov/rubocop/pull/3654): Add missing keywords for `Rails/HttpPositionalArguments`. ([@eitoball][])
 * [#3652](https://github.com/bbatsov/rubocop/issues/3652): Avoid crash Rails/HttpPositionalArguments for lvar params when auto-correct. ([@pocke][])
+* [#3650](https://github.com/bbatsov/rubocop/issues/3650): Fix `Style/VariableNumber` registering an offense for variables with double digit numbers. ([@rrosenblum][])
 
 ### Changes
 

--- a/lib/rubocop/cop/mixin/configurable_numbering.rb
+++ b/lib/rubocop/cop/mixin/configurable_numbering.rb
@@ -7,10 +7,9 @@ module RuboCop
     module ConfigurableNumbering
       include ConfigurableEnforcedStyle
 
-      SNAKE_CASE = /^@{0,2}[-_a-z]+[_\D]*(_\d)*[!?=]?$/
-      NORMAL_CASE = /^@{0,2}-{0,1}_{0,1}[a-zA-Z\d]*(_[a-zA-Z]+\d*)*
-                     [_\D]*[!?=]?$/x
-      NON_INTEGER = /^@{0,2}[-_a-z]+[_\D]*[!?=]?$/
+      SNAKE_CASE = /(^_|[a-z]|_\d+)$/
+      NORMAL_CASE = /(^_|[A-Za-z]\d*)$/
+      NON_INTEGER = /(^_|[A-Za-z])$/
 
       def check_name(node, name, name_range)
         return if operator?(name)


### PR DESCRIPTION
This fixes #3650. The regex that was checking variable names was slightly off. It was looking for zero or more underscores followed by a digit. It looks like the regex could use a bit more tweaking. I am seeing the warning `character class has duplicated range`