### PR TITLE
Add missing keywords for Rails/HttpPositionalArguments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@
 * [#3468](https://github.com/bbatsov/rubocop/issues/3468): Fix bug regarding alignment inside `begin`..`end` block in `Style/MultilineMethodCallIndentation`. ([@jonas054][])
 * [#3644](https://github.com/bbatsov/rubocop/pull/3644): Fix generation incorrect documentation. ([@pocke][])
 * [#3637](https://github.com/bbatsov/rubocop/issues/3637): Fix Style/NonNilCheck crashing for ternary condition. ([@tejasbubane][])
+* [#3654](https://github.com/bbatsov/rubocop/pull/3654): Add missing keywords for `Rails/HttpPositionalArguments`. ([@eitoball][])
 
 ### Changes
 

--- a/lib/rubocop/cop/rails/http_positional_arguments.rb
+++ b/lib/rubocop/cop/rails/http_positional_arguments.rb
@@ -16,7 +16,10 @@ module RuboCop
       class HttpPositionalArguments < Cop
         MSG = 'Use keyword arguments instead of ' \
               'positional arguments for http call: `%s`.'.freeze
-        KEYWORD_ARGS = [:headers, :env, :params, :body, :flash, :as].freeze
+        KEYWORD_ARGS = [
+          :headers, :env, :params, :body, :flash, :as,
+          :xhr, :session, :method
+        ].freeze
         HTTP_METHODS = [:get, :post, :put, :patch, :delete, :head].freeze
 
         def on_send(node)

--- a/spec/rubocop/cop/rails/http_positional_arguments_spec.rb
+++ b/spec/rubocop/cop/rails/http_positional_arguments_spec.rb
@@ -33,14 +33,20 @@ describe RuboCop::Cop::Rails::HttpPositionalArguments do
     end
   end
 
-  describe 'when using keyword args' do
-    let(:source) do
-      'get :new, params: { user_id: @user.id }'
-    end
+  [
+    'params: { user_id: @user.id }',
+    'xhr: true',
+    'session: { foo: \'bar\' }'
+  ].each do |keyword_args|
+    describe 'when using keyword args' do
+      let(:source) do
+        "get :new, #{keyword_args}"
+      end
 
-    it 'does not register an offense' do
-      inspect_source(cop, source)
-      expect(cop.messages).to be_empty
+      it 'does not register an offense' do
+        inspect_source(cop, source)
+        expect(cop.messages).to be_empty
+      end
     end
   end
 


### PR DESCRIPTION
This PR adds more keywords for Rails/HttpPositionalArgument cop.

The warning for positional arguments exists in both `ActionDispatch::IntegrationTest` and `ActionController::TestCase`.  There are missing keywords in #3365.

<details>
```
$ git clone git@github.com:rails/rails.git
$ cd rails
$ git checkout v5.0.0.1
$ ag  REQUEST_KWARGS
actionpack/lib/action_controller/test_case.rb
638:      REQUEST_KWARGS = %i(params session flash method body xhr)
642:          args[0].keys.any? { |k| REQUEST_KWARGS.include?(k) }

actionpack/lib/action_dispatch/testing/integration.rb
303:        REQUEST_KWARGS = %i(params headers env xhr as)
305:          args[0].respond_to?(:keys) && args[0].keys.any? { |k| REQUEST_KWARGS.include?(k) }
312:            #{REQUEST_KWARGS.join(', ')}
```
</details>