### PR TITLE
[Fix #3652] Avoid crash Rails/HttpPositionalArguments for lvar params when auto-correct

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@
 * [#3468](https://github.com/bbatsov/rubocop/issues/3468): Fix bug regarding alignment inside `begin`..`end` block in `Style/MultilineMethodCallIndentation`. ([@jonas054][])
 * [#3644](https://github.com/bbatsov/rubocop/pull/3644): Fix generation incorrect documentation. ([@pocke][])
 * [#3637](https://github.com/bbatsov/rubocop/issues/3637): Fix Style/NonNilCheck crashing for ternary condition. ([@tejasbubane][])
+* [#3652](https://github.com/bbatsov/rubocop/issues/3652): Avoid crash Rails/HttpPositionalArguments for lvar params when auto-correct. ([@pocke][])
 
 ### Changes
 

--- a/lib/rubocop/cop/rails/http_positional_arguments.rb
+++ b/lib/rubocop/cop/rails/http_positional_arguments.rb
@@ -51,12 +51,12 @@ module RuboCop
         def convert_hash_data(data, type)
           # empty hash or no hash return empty string
           return '' if data.nil? || data.children.count < 1
-          hash_data = if data.type == :send
+          hash_data = if data.hash_type?
+                        format('{ %s }', data.children.map(&:source).join(', '))
+                      else
                         # user supplies an object,
                         # no need to surround with braces
                         data.source
-                      else
-                        format('{ %s }', data.children.map(&:source).join(', '))
                       end
           format(', %s: %s', type, hash_data)
         end

--- a/spec/rubocop/cop/rails/http_positional_arguments_spec.rb
+++ b/spec/rubocop/cop/rails/http_positional_arguments_spec.rb
@@ -215,4 +215,16 @@ post :create, params: { id: @user.id, ac: {
     output = 'post :create, params: confirmation_data'
     expect(new_source).to eq(output)
   end
+
+  it 'auto-corrects http action when params is a lvar' do
+    source = [
+      'params = { id: 1 }',
+      'post user_attrs, params'
+    ]
+    inspect_source(cop, source)
+    expect(cop.offenses.size).to eq(1)
+    new_source = autocorrect_source(cop, source)
+    expected = "params = { id: 1 }\npost user_attrs, params: params"
+    expect(new_source).to eq(expected)
+  end
 end


### PR DESCRIPTION
Fix #3652  




-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Used the same coding conventions as the rest of the project.
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] All tests are passing.
* [x] The new code doesn't generate RuboCop offenses.
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [ ] Updated cop documentation with `rake generate_cops_documentation` (required only when you've added a new cop or changed the configuration/documentation of an existing cop).

[1]: http://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html

