### PR TITLE
[#3600] Add new `Bundler/OrderedGems` cop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 * New cop `Rails/EnumUniqueness` checks for duplicate values defined in enum config. ([@olliebennett][])
 * New cop `Rails/EnumUniqueness` checks for duplicate values defined in enum config hash. ([@olliebennett][])
 * [#3451](https://github.com/bbatsov/rubocop/issues/3451): Add new `require_parentheses_when_complex` style to `Style/TernaryParentheses` cop. ([@swcraig][])
+* [#3600](https://github.com/bbatsov/rubocop/issues/3600): Add new `Bundler/OrderedGems` cop. ([@tdeo][])
 
 ### Changes
 
@@ -2505,3 +2506,4 @@
 [@aroben]: https://github.com/aroben
 [@olliebennett]: https://github.com/olliebennett
 [@aesthetikx]: https://github.com/aesthetikx
+[@tdeo]: https://github.com/tdeo

--- a/Gemfile
+++ b/Gemfile
@@ -4,11 +4,11 @@ source 'https://rubygems.org'
 
 gemspec
 
+gem 'pry'
 gem 'rake', '~> 11.0'
 gem 'rspec', '~> 3.5.0'
-gem 'yard', '~> 0.8'
 gem 'simplecov', '~> 0.10'
-gem 'pry'
+gem 'yard', '~> 0.8'
 
 group :test do
   gem 'codeclimate-test-reporter', '~> 1.0', require: false

--- a/config/enabled.yml
+++ b/config/enabled.yml
@@ -1577,3 +1577,12 @@ Bundler/DuplicatedGem:
   Include:
     - '**/Gemfile'
     - '**/gems.rb'
+
+Bundler/OrderedGems:
+  Description: >-
+                 Sort alphabetically gems appearing within a contiguous set
+                 of lines in the Gemfile
+  Enabled: true
+  Include:
+    - '**/Gemfile'
+    - '**/gems.rb'

--- a/lib/rubocop.rb
+++ b/lib/rubocop.rb
@@ -92,6 +92,7 @@ require 'rubocop/cop/mixin/trailing_comma'
 require 'rubocop/cop/mixin/unused_argument'
 
 require 'rubocop/cop/bundler/duplicated_gem'
+require 'rubocop/cop/bundler/ordered_gems'
 
 require 'rubocop/cop/lint/ambiguous_operator'
 require 'rubocop/cop/lint/ambiguous_regexp_literal'

--- a/lib/rubocop/cop/bundler/ordered_gems.rb
+++ b/lib/rubocop/cop/bundler/ordered_gems.rb
@@ -1,0 +1,54 @@
+# frozen_string_literal: true
+module RuboCop
+  module Cop
+    module Bundler
+      # Gems in consecutive lines should be alphabetically sorted
+      # @example
+      #   # bad
+      #   gem 'rubocop'
+      #   gem 'rspec'
+      #
+      #   # good
+      #   gem 'rspec'
+      #   gem 'rubocop'
+      #
+      #   # good
+      #   gem 'rubocop'
+      #
+      #   gem 'rspec'
+      class OrderedGems < Cop
+        MSG = 'Gem `%s` should appear before `%s` in their gem group.'.freeze
+        def investigate(processed_source)
+          return if processed_source.ast.nil?
+          gem_declarations(processed_source.ast)
+            .each_cons(2) do |previous, current|
+            next unless consecutive_lines(previous, current)
+            next unless current.children[2].children.first.to_s <
+                        previous.children[2].children.first.to_s
+            register_offense(previous, current)
+          end
+        end
+
+        def consecutive_lines(previous, current)
+          previous.source_range.last_line == current.source_range.first_line - 1
+        end
+
+        def register_offense(previous, current)
+          add_offense(
+            current,
+            current.source_range,
+            format(
+              MSG,
+              current.children[2].children.first,
+              previous.children[2].children.first
+            )
+          )
+        end
+
+        def_node_search :gem_declarations, <<-PATTERN
+          (:send, nil, :gem, ...)
+        PATTERN
+      end
+    end
+  end
+end

--- a/manual/cops_bundler.md
+++ b/manual/cops_bundler.md
@@ -39,3 +39,35 @@ Attribute | Value
 --- | ---
 Include | \*\*/Gemfile, \*\*/gems.rb
 
+
+## Bundler/OrderedGems
+
+Enabled by default | Supports autocorrection
+--- | ---
+Enabled | No
+
+Gems in consecutive lines should be alphabetically sorted
+
+### Example
+
+```ruby
+# bad
+gem 'rubocop'
+gem 'rspec'
+
+# good
+gem 'rspec'
+gem 'rubocop'
+
+# good
+gem 'rubocop'
+
+gem 'rspec'
+```
+
+### Important attributes
+
+Attribute | Value
+--- | ---
+Include | \*\*/Gemfile, \*\*/gems.rb
+

--- a/spec/rubocop/cop/bundler/ordered_gems_spec.rb
+++ b/spec/rubocop/cop/bundler/ordered_gems_spec.rb
@@ -1,0 +1,81 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+describe RuboCop::Cop::Bundler::OrderedGems, :config do
+  subject(:cop) { described_class.new(config) }
+
+  context 'When gems are alphabetically sorted' do
+    let(:source) { <<-END }
+      gem 'rspec'
+      gem 'rubocop'
+    END
+
+    it 'does not register any offenses' do
+      inspect_source(cop, source)
+      expect(cop.offenses).to be_empty
+    end
+  end
+
+  context 'When gems are not alphabetically sorted' do
+    let(:source) { <<-END }
+      gem 'rubocop'
+      gem 'rspec'
+    END
+
+    it 'registers an offense' do
+      inspect_source(cop, source)
+      expect(cop.offenses.size).to eq(1)
+    end
+
+    it 'mentions both gem names in message' do
+      inspect_source(cop, source)
+      expect(cop.offenses.first.message).to include('rspec')
+      expect(cop.offenses.first.message).to include('rubocop')
+    end
+
+    it 'highlights the second gem' do
+      inspect_source(cop, source)
+      expect(cop.highlights).to eq(["gem 'rspec'"])
+    end
+  end
+
+  context 'When each individual group of line is sorted' do
+    let(:source) { <<-END }
+      gem 'rspec'
+      gem 'rubocop'
+
+      gem 'hello'
+      gem 'world'
+    END
+
+    it 'does not register any offenses' do
+      inspect_source(cop, source)
+      expect(cop.offenses).to be_empty
+    end
+  end
+
+  context 'When a gem declaration takes several lines' do
+    let(:source) { <<-END }
+      gem 'rubocop',
+          '0.1.1'
+      gem 'rspec'
+    END
+
+    it 'registers an offense' do
+      inspect_source(cop, source)
+      expect(cop.offenses.size).to eq(1)
+    end
+  end
+
+  context 'When the gemfile is empty' do
+    let(:source) { <<-END }
+      # Gemfile
+    END
+
+    it 'does not register any offenses' do
+      inspect_source(cop, source)
+      expect(cop.offenses.size).to eq(0)
+    end
+  end
+end


### PR DESCRIPTION
Implementing some part of https://github.com/bbatsov/rubocop/issues/3600.

Actually, I couldn't a good wording for the "groups" of gems as groups are a specific Gemfile notion already

---

Before submitting the PR make sure the following are checked:
- [x] Wrote [good commit messages](http://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html).
- [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
- [x] Used the same coding conventions as the rest of the project.
- [x] Feature branch is up-to-date with `master` (if not - rebase it).
- [x] Squashed related commits together.
- [x] Added tests.
- [x] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
- [x] All tests are passing.
- [x] The new code doesn't generate RuboCop offenses.
- [x] The PR relates to _only_ one subject with a clear title
  and description in grammatically correct, complete sentences.
- [x] Updated cop documentation with `rake generate_cops_documentation` (required only when you've added a new cop or changed the configuration/documentation of an existing cop).

This Cop checks that all gem entries belonging in consecutive lines in
the Gemfile appear in alphabetically sorted order.
