### PR TITLE
Fix false positive for Rails/SafeNavigation when without receiver

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@
 * [#3654](https://github.com/bbatsov/rubocop/pull/3654): Add missing keywords for `Rails/HttpPositionalArguments`. ([@eitoball][])
 * [#3652](https://github.com/bbatsov/rubocop/issues/3652): Avoid crash Rails/HttpPositionalArguments for lvar params when auto-correct. ([@pocke][])
 * Fix bug in `Style/SafeNavigation` where there is a check for an object in an elsif statement with a method call on that object in the branch. ([@rrosenblum][])
+* [#3660](https://github.com/bbatsov/rubocop/pull/3660): Fix false positive for Rails/SafeNavigation when without receiver. ([@pocke][])
 
 ### Changes
 

--- a/lib/rubocop/cop/rails/safe_navigation.rb
+++ b/lib/rubocop/cop/rails/safe_navigation.rb
@@ -43,7 +43,7 @@ module RuboCop
         MSG = 'Use safe navigation (`&.`) instead of `%s`.'.freeze
 
         def_node_matcher :try_call, <<-PATTERN
-          (send _ ${:try :try!} $_ ...)
+          (send !nil ${:try :try!} $_ ...)
         PATTERN
 
         def on_send(node)

--- a/spec/rubocop/cop/rails/safe_navigation_spec.rb
+++ b/spec/rubocop/cop/rails/safe_navigation_spec.rb
@@ -70,6 +70,12 @@ describe RuboCop::Cop::Rails::SafeNavigation, :config do
         it_behaves_like :accepts, 'try! with a method stored as a variable',
                         ['bar = :==',
                          'foo.try!(baz, bar)'].join("\n")
+
+        it 'accepts usages of try! without receiver' do
+          inspect_source(cop, 'try!(:something)')
+
+          expect(cop.offenses).to be_empty
+        end
       end
 
       context 'try' do


### PR DESCRIPTION
Problem
-------

```ruby
try!(:something)
```

In the above code, `try!` method doesn't have a receiver.
It can't replace by safe navigation operator. e.g. `&.try!(:something)` is a syntax error.

And the cop crashes when auto correct with the code.

```sh
$ rubocop --rails -d -a
An error occurred while Rails/SafeNavigation cop was inspecting /tmp/tmp.CZrMPwYlbn/test.rb.

1 error occurred:
An error occurred while Rails/SafeNavigation cop was inspecting /tmp/tmp.CZrMPwYlbn/test.rb.
Errors are usually caused by RuboCop bugs.
Please, report your problems to RuboCop's issue tracker.
Mention the following information in the issue report:
0.44.1 (using Parser 2.3.1.4, running on ruby 2.3.1 x86_64-linux)
For /tmp/tmp.CZrMPwYlbn: configuration from /tmp/tmp.CZrMPwYlbn/.rubocop.yml
Default configuration from /home/pocke/.gem/ruby/2.3.0/gems/rubocop-0.44.1/config/default.yml
Inheriting configuration from /home/pocke/.gem/ruby/2.3.0/gems/rubocop-0.44.1/config/enabled.yml
Inheriting configuration from /home/pocke/.gem/ruby/2.3.0/gems/rubocop-0.44.1/config/disabled.yml
Inspecting 1 file
Scanning /tmp/tmp.CZrMPwYlbn/test.rb
undefined method `begin_pos' for nil:NilClass
/home/pocke/.gem/ruby/2.3.0/gems/rubocop-0.44.1/lib/rubocop/cop/rails/safe_navigation.rb:66:in `autocorrect'
/home/pocke/.gem/ruby/2.3.0/gems/rubocop-0.44.1/lib/rubocop/cop/cop.rb:195:in `correct'
/home/pocke/.gem/ruby/2.3.0/gems/rubocop-0.44.1/lib/rubocop/cop/cop.rb:176:in `add_offense'
/home/pocke/.gem/ruby/2.3.0/gems/rubocop-0.44.1/lib/rubocop/cop/rails/safe_navigation.rb:57:in `block in on_send'
/home/pocke/.gem/ruby/2.3.0/gems/rubocop-0.44.1/lib/rubocop/cop/rails/safe_navigation.rb:46:in `try_call'
/home/pocke/.gem/ruby/2.3.0/gems/rubocop-0.44.1/lib/rubocop/cop/rails/safe_navigation.rb:52:in `on_send'
/home/pocke/.gem/ruby/2.3.0/gems/rubocop-0.44.1/lib/rubocop/cop/commissioner.rb:41:in `block (2 levels) in on_send'
/home/pocke/.gem/ruby/2.3.0/gems/rubocop-0.44.1/lib/rubocop/cop/commissioner.rb:96:in `with_cop_error_handling'
/home/pocke/.gem/ruby/2.3.0/gems/rubocop-0.44.1/lib/rubocop/cop/commissioner.rb:40:in `block in on_send'
/home/pocke/.gem/ruby/2.3.0/gems/rubocop-0.44.1/lib/rubocop/cop/commissioner.rb:39:in `each'
/home/pocke/.gem/ruby/2.3.0/gems/rubocop-0.44.1/lib/rubocop/cop/commissioner.rb:39:in `on_send'
/home/pocke/.gem/ruby/2.3.0/gems/rubocop-0.44.1/lib/rubocop/ast_node/traversal.rb:12:in `walk'
/home/pocke/.gem/ruby/2.3.0/gems/rubocop-0.44.1/lib/rubocop/cop/commissioner.rb:58:in `investigate'
/home/pocke/.gem/ruby/2.3.0/gems/rubocop-0.44.1/lib/rubocop/cop/team.rb:120:in `investigate'
/home/pocke/.gem/ruby/2.3.0/gems/rubocop-0.44.1/lib/rubocop/cop/team.rb:100:in `offenses'
/home/pocke/.gem/ruby/2.3.0/gems/rubocop-0.44.1/lib/rubocop/cop/team.rb:51:in `inspect_file'
/home/pocke/.gem/ruby/2.3.0/gems/rubocop-0.44.1/lib/rubocop/runner.rb:243:in `inspect_file'
/home/pocke/.gem/ruby/2.3.0/gems/rubocop-0.44.1/lib/rubocop/runner.rb:190:in `block in do_inspection_loop'
/home/pocke/.gem/ruby/2.3.0/gems/rubocop-0.44.1/lib/rubocop/runner.rb:222:in `block in iterate_until_no_changes'
/home/pocke/.gem/ruby/2.3.0/gems/rubocop-0.44.1/lib/rubocop/runner.rb:215:in `loop'
/home/pocke/.gem/ruby/2.3.0/gems/rubocop-0.44.1/lib/rubocop/runner.rb:215:in `iterate_until_no_changes'
/home/pocke/.gem/ruby/2.3.0/gems/rubocop-0.44.1/lib/rubocop/runner.rb:186:in `do_inspection_loop'
/home/pocke/.gem/ruby/2.3.0/gems/rubocop-0.44.1/lib/rubocop/runner.rb:101:in `block in file_offenses'
/home/pocke/.gem/ruby/2.3.0/gems/rubocop-0.44.1/lib/rubocop/runner.rb:111:in `file_offense_cache'
/home/pocke/.gem/ruby/2.3.0/gems/rubocop-0.44.1/lib/rubocop/runner.rb:99:in `file_offenses'
/home/pocke/.gem/ruby/2.3.0/gems/rubocop-0.44.1/lib/rubocop/runner.rb:90:in `process_file'
/home/pocke/.gem/ruby/2.3.0/gems/rubocop-0.44.1/lib/rubocop/runner.rb:68:in `block in each_inspected_file'
/home/pocke/.gem/ruby/2.3.0/gems/rubocop-0.44.1/lib/rubocop/runner.rb:65:in `each'
/home/pocke/.gem/ruby/2.3.0/gems/rubocop-0.44.1/lib/rubocop/runner.rb:65:in `reduce'
/home/pocke/.gem/ruby/2.3.0/gems/rubocop-0.44.1/lib/rubocop/runner.rb:65:in `each_inspected_file'
/home/pocke/.gem/ruby/2.3.0/gems/rubocop-0.44.1/lib/rubocop/runner.rb:57:in `inspect_files'
/home/pocke/.gem/ruby/2.3.0/gems/rubocop-0.44.1/lib/rubocop/runner.rb:36:in `run'
/home/pocke/.gem/ruby/2.3.0/gems/rubocop-0.44.1/lib/rubocop/cli.rb:71:in `execute_runner'
/home/pocke/.gem/ruby/2.3.0/gems/rubocop-0.44.1/lib/rubocop/cli.rb:27:in `run'
/home/pocke/.gem/ruby/2.3.0/gems/rubocop-0.44.1/bin/rubocop:13:in `block in <top (required)>'
/usr/lib/ruby/2.3.0/benchmark.rb:308:in `realtime'
/home/pocke/.gem/ruby/2.3.0/gems/rubocop-0.44.1/bin/rubocop:12:in `<top (required)>'
/home/pocke/.gem/ruby/2.3.0/bin//rubocop:23:in `load'
/home/pocke/.gem/ruby/2.3.0/bin//rubocop:23:in `<main>'
.

1 file inspected, no offenses detected
Finished in 0.0625507760050823 seconds
```

Solution
--------

the cop accepts `try!` if it doesn't have a receiver.

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Used the same coding conventions as the rest of the project.
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] All tests are passing.
* [x] The new code doesn't generate RuboCop offenses.
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [ ] Updated cop documentation with `rake generate_cops_documentation` (required only when you've added a new cop or changed the configuration/documentation of an existing cop).

[1]: http://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html

