### PR TITLE
Fix bug in SafeNavigation where an elsif branch mimics an if branch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@
 * [#3637](https://github.com/bbatsov/rubocop/issues/3637): Fix Style/NonNilCheck crashing for ternary condition. ([@tejasbubane][])
 * [#3654](https://github.com/bbatsov/rubocop/pull/3654): Add missing keywords for `Rails/HttpPositionalArguments`. ([@eitoball][])
 * [#3652](https://github.com/bbatsov/rubocop/issues/3652): Avoid crash Rails/HttpPositionalArguments for lvar params when auto-correct. ([@pocke][])
+* Fix bug in `Style/SafeNavigation` where there is a check for an object in an elsif statement with a method call on that object in the branch. ([@rrosenblum][])
 
 ### Changes
 

--- a/lib/rubocop/cop/style/safe_navigation.rb
+++ b/lib/rubocop/cop/style/safe_navigation.rb
@@ -85,7 +85,8 @@ module RuboCop
 
         def check_node(node)
           return if target_ruby_version < 2.3
-          return if node.loc.respond_to?(:else) && !node.loc.else.nil?
+          return if if_else?(node)
+          return if elsif?(node)
           checked_variable, receiver, method = extract_parts(node)
           return unless receiver == checked_variable
           return if NIL_METHODS.include?(method)

--- a/spec/rubocop/cop/style/safe_navigation_spec.rb
+++ b/spec/rubocop/cop/style/safe_navigation_spec.rb
@@ -38,6 +38,17 @@ describe RuboCop::Cop::Style::SafeNavigation, :config do
       expect(cop.offenses).to be_empty
     end
 
+    it 'allows object checks in the condition of an elsif statement ' \
+      'and a method call on that object in the body' do
+      inspect_source(cop, ['if foo',
+                           '  something',
+                           'elsif bar',
+                           '  bar.baz',
+                           'end'])
+
+      expect(cop.offenses).to be_empty
+    end
+
     shared_examples 'all variable types' do |variable|
       context 'modifier if' do
         it 'registers an offense for a method call on an accessor ' \


### PR DESCRIPTION
I came across a bug with `Style/SafeNavigation` where an `elsif` branch can mimic an `if` branch and lead to a false positive and invalid auto-correction.