### PR TITLE
Changes Uncommunicatives Variable Names

### DIFF
--- a/lib/rubocop/cached_data.rb
+++ b/lib/rubocop/cached_data.rb
@@ -50,13 +50,13 @@ module RuboCop
     def deserialize_offenses(offenses)
       source_buffer = Parser::Source::Buffer.new(@filename)
       source_buffer.source = File.read(@filename, encoding: Encoding::UTF_8)
-      offenses.map! do |o|
+      offenses.map! do |offense|
         location = Parser::Source::Range.new(source_buffer,
-                                             o['location']['begin_pos'],
-                                             o['location']['end_pos'])
-        Cop::Offense.new(o['severity'], location,
-                         o['message'],
-                         o['cop_name'], o['status'].to_sym)
+                                             offense['location']['begin_pos'],
+                                             offense['location']['end_pos'])
+        Cop::Offense.new(offense['severity'], location,
+                         offense['message'],
+                         offense['cop_name'], offense['status'].to_sym)
       end
     end
   end

--- a/lib/rubocop/config_loader_resolver.rb
+++ b/lib/rubocop/config_loader_resolver.rb
@@ -19,8 +19,8 @@ module RuboCop
 
     def resolve_inheritance(path, hash)
       base_configs(path, hash['inherit_from']).reverse_each do |base_config|
-        base_config.each do |k, v|
-          hash[k] = hash.key?(k) ? merge(v, hash[k]) : v if v.is_a?(Hash)
+        base_config.each do |key, value|
+          hash[key] = hash.key?(key) ? merge(value, hash[key]) : value if value.is_a?(Hash)
         end
       end
     end


### PR DESCRIPTION
The variables changed had uncommunicative Names like `o`, `h` and `k`. They were changed to names that have more explicit meanings.

Based on reek's [Uncommunicative Variable Name](https://github.com/troessner/reek/blob/master/docs/Uncommunicative-Variable-Name.md)
## **working on not checked itens right now**

Before submitting the PR make sure the following are checked:
- [x] Wrote [good commit messages](http://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html).
- [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
- [x] Used the same coding conventions as the rest of the project.
- [x] Feature branch is up-to-date with `master` (if not - rebase it).
- [x] Squashed related commits together.
- [ ] Added tests.
- [ ] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
- [x] The new code doesn't generate RuboCop offenses.
- [x] The PR relates to _only_ one subject with a clear title
  and description in grammatically correct, complete sentences.
- [ ] All tests are passing.
- [ ] Updated cop documentation with `rake generate_cops_documentation` (required only when you've added a new cop or changed the configuration/documentation of an existing cop).
