### PR TITLE
[Fix #3494] Check rails indentation inside blocks in IndentationWidth

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@
 * Fix bug in `Style/SafeNavigation` where there is a check for an object in an elsif statement with a method call on that object in the branch. ([@rrosenblum][])
 * [#3660](https://github.com/bbatsov/rubocop/pull/3660): Fix false positive for Rails/SafeNavigation when without receiver. ([@pocke][])
 * [#3650](https://github.com/bbatsov/rubocop/issues/3650): Fix `Style/VariableNumber` registering an offense for variables with double digit numbers. ([@rrosenblum][])
+* [#3494](https://github.com/bbatsov/rubocop/issues/3494): Check `rails` style indentation also inside blocks in `Style/IndentationWidth`. ([@jonas054][])
 
 ### Changes
 

--- a/lib/rubocop/cop/style/indentation_width.rb
+++ b/lib/rubocop/cop/style/indentation_width.rb
@@ -49,21 +49,26 @@ module RuboCop
           # assignments, etc, would be more difficult. The end/} must be at the
           # beginning of its line.
           loc = node.loc
-          check_indentation(loc.end, body) if begins_its_line?(loc.end)
+          return unless begins_its_line?(loc.end)
+
+          check_indentation(loc.end, body)
+          return unless indentation_consistency_style == 'rails'
+
+          check_members(loc.end, [body])
         end
 
         def on_module(node)
           _module_name, *members = *node
-          check_members(node, members)
+          check_members(node.loc.keyword, members)
         end
 
         def on_class(node)
           _class_name, _base_class, *members = *node
-          check_members(node, members)
+          check_members(node.loc.keyword, members)
         end
 
-        def check_members(node, members)
-          check_indentation(node.loc.keyword, members.first)
+        def check_members(base, members)
+          check_indentation(base, members.first)
 
           return unless members.any? && members.first.begin_type?
           return unless indentation_consistency_style == 'rails'

--- a/spec/rubocop/cop/style/indentation_width_spec.rb
+++ b/spec/rubocop/cop/style/indentation_width_spec.rb
@@ -1054,6 +1054,27 @@ describe RuboCop::Cop::Style::IndentationWidth do
     end
 
     context 'with block' do
+      context 'when consistency style is rails' do
+        let(:consistency_config) { { 'EnforcedStyle' => 'rails' } }
+
+        it 'registers an offense for bad indentation in a do/end body' do
+          inspect_source(cop,
+                         ['concern :Authenticatable do',
+                          '  def foo',
+                          '    puts "foo"',
+                          '  end',
+                          '',
+                          '  private',
+                          '',
+                          '  def bar',
+                          '    puts "bar"',
+                          '  end',
+                          'end'])
+          expect(cop.messages)
+            .to eq(['Use 2 (not 0) spaces for rails indentation.'])
+        end
+      end
+
       it 'registers an offense for bad indentation of a do/end body' do
         inspect_source(cop,
                        ['a = func do',


### PR DESCRIPTION
`IndentationWidth` already checks the first statement inside a block, and `IndentationConsistency` checks that each statement is aligned with the previous one, but the special indentation that is indicated by `IndentationConsistency: EnforcedStyle: rails` needs to be done for blocks too, not just classes and modules.