### PR TITLE
[Fixes #3661] Fix `Rails.SaveBang` to account for control flow

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@
 * Fix bug in `Style/SafeNavigation` where there is a check for an object in an elsif statement with a method call on that object in the branch. ([@rrosenblum][])
 * [#3660](https://github.com/bbatsov/rubocop/pull/3660): Fix false positive for Rails/SafeNavigation when without receiver. ([@pocke][])
 * [#3650](https://github.com/bbatsov/rubocop/issues/3650): Fix `Style/VariableNumber` registering an offense for variables with double digit numbers. ([@rrosenblum][])
+* [#3661](https://github.com/bbatsov/rubocop/issues/3661): Fix `Rails.SaveBang` to account for control flow. ([@tejasbubane][])
 
 ### Changes
 

--- a/lib/rubocop/cop/rails/save_bang.rb
+++ b/lib/rubocop/cop/rails/save_bang.rb
@@ -82,6 +82,7 @@ module RuboCop
           return if return_value_assigned?(node)
           return if check_used_in_conditional(node)
           return if last_call_of_method?(node)
+          return if non_last_clause_in_condition?(node)
 
           add_offense(node, node.loc.selector,
                       format(MSG,
@@ -131,6 +132,13 @@ module RuboCop
         def last_call_of_method?(node)
           !node.parent.nil? &&
             node.parent.children.count == node.sibling_index + 1
+        end
+
+        def non_last_clause_in_condition?(node)
+          parent = node.parent
+
+          parent && (parent.and_type? || parent.or_type?) &&
+            parent.children.last != node
         end
 
         # Ignore simple assignment or if condition

--- a/spec/rubocop/cop/rails/save_bang_spec.rb
+++ b/spec/rubocop/cop/rails/save_bang_spec.rb
@@ -128,6 +128,16 @@ describe RuboCop::Cop::Rails::SaveBang do
       inspect_source(cop, ['def foo', "object.#{method}", 'end'])
       expect(cop.messages).to be_empty
     end
+
+    it "when using #{method} in || conditional and not last clause" do
+      inspect_source(cop, "object.#{method} || do_this")
+      expect(cop.messages).to be_empty
+    end
+
+    it "when using #{method} in && conditional and not last clause" do
+      inspect_source(cop, "object.#{method} && do_this")
+      expect(cop.messages).to be_empty
+    end
   end
 
   described_class::MODIFY_PERSIST_METHODS.each do |method|


### PR DESCRIPTION
Unless the method call is not the last clause in the conditional.

Fixes #3661

---

Before submitting the PR make sure the following are checked:
- [x] Wrote [good commit messages](http://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html).
- [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
- [x] Used the same coding conventions as the rest of the project.
- [x] Feature branch is up-to-date with `master` (if not - rebase it).
- [x] Squashed related commits together.
- [x] Added tests.
- [x] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
- [x] All tests are passing.
- [x] The new code doesn't generate RuboCop offenses.
- [x] The PR relates to _only_ one subject with a clear title
  and description in grammatically correct, complete sentences.
- [ ] Updated cop documentation with `rake generate_cops_documentation` (required only when you've added a new cop or changed the configuration/documentation of an existing cop).
