### PR TITLE
Fix bug in `Lint/EmptyWhen` with empty condition

### DIFF
--- a/lib/rubocop/cop/lint/empty_when.rb
+++ b/lib/rubocop/cop/lint/empty_when.rb
@@ -16,7 +16,7 @@ module RuboCop
         MSG = 'Avoid `when` branches without a body.'.freeze
 
         def on_case(node)
-          *when_nodes, _else_node = *node
+          _cond_node, *when_nodes, _else_node = *node
 
           when_nodes.each do |when_node|
             check_when(when_node)

--- a/spec/rubocop/cop/lint/empty_when_spec.rb
+++ b/spec/rubocop/cop/lint/empty_when_spec.rb
@@ -84,6 +84,16 @@ describe RuboCop::Cop::Lint::EmptyWhen, :config do
                      'else',
                      '  3',
                      'end'].join("\n")
+
+    it_behaves_like 'code with offense',
+                    ['case',
+                     'when :bar',
+                     '  1',
+                     'when :baz',
+                     '  # nothing',
+                     'else',
+                     '  3',
+                     'end'].join("\n")
   end
 
   context 'when a `when` body is present' do
@@ -110,6 +120,15 @@ describe RuboCop::Cop::Lint::EmptyWhen, :config do
 
     it_behaves_like 'code without offense',
                     ['case foo',
+                     'when :bar',
+                     '  1',
+                     'when :baz',
+                     '  2',
+                     'else',
+                     '  3',
+                     'end'].join("\n")
+    it_behaves_like 'code without offense',
+                    ['case',
                      'when :bar',
                      '  1',
                      'when :baz',


### PR DESCRIPTION
Problem
-------

```ruby
case
when x
end
```

When the cop analyses the above code, the cop crashes.

```sh
An error occurred while Lint/EmptyWhen cop was inspecting /tmp/tmp.H57uVQFcxq/test.rb.

1 error occurred:
An error occurred while Lint/EmptyWhen cop was inspecting /tmp/tmp.H57uVQFcxq/test.rb.
Errors are usually caused by RuboCop bugs.
Please, report your problems to RuboCop's issue tracker.
Mention the following information in the issue report:
0.44.1 (using Parser 2.3.1.4, running on ruby 2.3.1 x86_64-linux)
For /tmp/tmp.H57uVQFcxq: configuration from /home/pocke/.gem/ruby/2.3.0/gems/rubocop-0.44.1/config/default.yml
Inheriting configuration from /home/pocke/.gem/ruby/2.3.0/gems/rubocop-0.44.1/config/enabled.yml
Inheriting configuration from /home/pocke/.gem/ruby/2.3.0/gems/rubocop-0.44.1/config/disabled.yml
Inspecting 1 file
Scanning /tmp/tmp.H57uVQFcxq/test.rb
undefined method `source_range' for nil:NilClass
/home/pocke/.gem/ruby/2.3.0/gems/rubocop-0.44.1/lib/rubocop/cop/lint/empty_when.rb:31:in `check_when'
/home/pocke/.gem/ruby/2.3.0/gems/rubocop-0.44.1/lib/rubocop/cop/lint/empty_when.rb:22:in `block in on_case'
/home/pocke/.gem/ruby/2.3.0/gems/rubocop-0.44.1/lib/rubocop/cop/lint/empty_when.rb:21:in `each'
/home/pocke/.gem/ruby/2.3.0/gems/rubocop-0.44.1/lib/rubocop/cop/lint/empty_when.rb:21:in `on_case'
/home/pocke/.gem/ruby/2.3.0/gems/rubocop-0.44.1/lib/rubocop/cop/commissioner.rb:41:in `block (2 levels) in on_case'
/home/pocke/.gem/ruby/2.3.0/gems/rubocop-0.44.1/lib/rubocop/cop/commissioner.rb:96:in `with_cop_error_handling'
/home/pocke/.gem/ruby/2.3.0/gems/rubocop-0.44.1/lib/rubocop/cop/commissioner.rb:40:in `block in on_case'
/home/pocke/.gem/ruby/2.3.0/gems/rubocop-0.44.1/lib/rubocop/cop/commissioner.rb:39:in `each'
/home/pocke/.gem/ruby/2.3.0/gems/rubocop-0.44.1/lib/rubocop/cop/commissioner.rb:39:in `on_case'
/home/pocke/.gem/ruby/2.3.0/gems/rubocop-0.44.1/lib/rubocop/ast_node/traversal.rb:12:in `walk'
/home/pocke/.gem/ruby/2.3.0/gems/rubocop-0.44.1/lib/rubocop/cop/commissioner.rb:58:in `investigate'
/home/pocke/.gem/ruby/2.3.0/gems/rubocop-0.44.1/lib/rubocop/cop/team.rb:120:in `investigate'
/home/pocke/.gem/ruby/2.3.0/gems/rubocop-0.44.1/lib/rubocop/cop/team.rb:108:in `offenses'
/home/pocke/.gem/ruby/2.3.0/gems/rubocop-0.44.1/lib/rubocop/cop/team.rb:51:in `inspect_file'
/home/pocke/.gem/ruby/2.3.0/gems/rubocop-0.44.1/lib/rubocop/runner.rb:243:in `inspect_file'
/home/pocke/.gem/ruby/2.3.0/gems/rubocop-0.44.1/lib/rubocop/runner.rb:190:in `block in do_inspection_loop'
/home/pocke/.gem/ruby/2.3.0/gems/rubocop-0.44.1/lib/rubocop/runner.rb:222:in `block in iterate_until_no_changes'
/home/pocke/.gem/ruby/2.3.0/gems/rubocop-0.44.1/lib/rubocop/runner.rb:215:in `loop'
/home/pocke/.gem/ruby/2.3.0/gems/rubocop-0.44.1/lib/rubocop/runner.rb:215:in `iterate_until_no_changes'
/home/pocke/.gem/ruby/2.3.0/gems/rubocop-0.44.1/lib/rubocop/runner.rb:186:in `do_inspection_loop'
/home/pocke/.gem/ruby/2.3.0/gems/rubocop-0.44.1/lib/rubocop/runner.rb:101:in `block in file_offenses'
/home/pocke/.gem/ruby/2.3.0/gems/rubocop-0.44.1/lib/rubocop/runner.rb:111:in `file_offense_cache'
/home/pocke/.gem/ruby/2.3.0/gems/rubocop-0.44.1/lib/rubocop/runner.rb:99:in `file_offenses'
/home/pocke/.gem/ruby/2.3.0/gems/rubocop-0.44.1/lib/rubocop/runner.rb:90:in `process_file'
/home/pocke/.gem/ruby/2.3.0/gems/rubocop-0.44.1/lib/rubocop/runner.rb:68:in `block in each_inspected_file'
/home/pocke/.gem/ruby/2.3.0/gems/rubocop-0.44.1/lib/rubocop/runner.rb:65:in `each'
/home/pocke/.gem/ruby/2.3.0/gems/rubocop-0.44.1/lib/rubocop/runner.rb:65:in `reduce'
/home/pocke/.gem/ruby/2.3.0/gems/rubocop-0.44.1/lib/rubocop/runner.rb:65:in `each_inspected_file'
/home/pocke/.gem/ruby/2.3.0/gems/rubocop-0.44.1/lib/rubocop/runner.rb:57:in `inspect_files'
/home/pocke/.gem/ruby/2.3.0/gems/rubocop-0.44.1/lib/rubocop/runner.rb:36:in `run'
/home/pocke/.gem/ruby/2.3.0/gems/rubocop-0.44.1/lib/rubocop/cli.rb:72:in `execute_runner'
/home/pocke/.gem/ruby/2.3.0/gems/rubocop-0.44.1/lib/rubocop/cli.rb:27:in `run'
/home/pocke/.gem/ruby/2.3.0/gems/rubocop-0.44.1/bin/rubocop:13:in `block in <top (required)>'
/usr/lib/ruby/2.3.0/benchmark.rb:308:in `realtime'
/home/pocke/.gem/ruby/2.3.0/gems/rubocop-0.44.1/bin/rubocop:12:in `<top (required)>'
/home/pocke/.gem/ruby/2.3.0/bin//rubocop:23:in `load'
/home/pocke/.gem/ruby/2.3.0/bin//rubocop:23:in `<main>'
.

1 file inspected, no offenses detected
Finished in 0.05772199100465514 seconds
```

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Used the same coding conventions as the rest of the project.
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] All tests are passing.
* [x] The new code doesn't generate RuboCop offenses.
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [ ] Updated cop documentation with `rake generate_cops_documentation` (required only when you've added a new cop or changed the configuration/documentation of an existing cop).

[1]: http://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html

