### PR TITLE
Add option to Metrics/BlockNesting to actually check blocks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 * [#3795](https://github.com/bbatsov/rubocop/pull/3795): Add `Lint/MultipleCompare` cop. ([@pocke][])
 * [#3772](https://github.com/bbatsov/rubocop/issues/3772): Allow exclusion of certain methods for `Metrics/BlockLength`. ([@NobodysNightmare][])
 * [#3804](https://github.com/bbatsov/rubocop/pull/3804): Add new `Lint/SafeNavigationChain` cop. ([@pocke][])
+* [#3670](https://github.com/bbatsov/rubocop/pull/3670): Add `CountBlocks` boolean option to `Metrics/BlockNesting`. It allows blocks to be counted towards the nesting limit. ([@georgyangelov][])
 
 ### Changes
 
@@ -566,7 +567,7 @@
 * [#2665](https://github.com/bbatsov/rubocop/pull/2665): Make specs pass when running on Windows. ([@jonas054][])
 * [#2691](https://github.com/bbatsov/rubocop/pull/2691): Do not register an offense in `Performance/TimesMap` for calling `map` or `collect` on a variable named `times`. ([@rrosenblum][])
 * [#2689](https://github.com/bbatsov/rubocop/pull/2689): Change `Performance/RedundantBlockCall` to respect parentheses usage. ([@rrosenblum][])
-* [#2694](https://github.com/bbatsov/rubocop/issues/2694): Fix caching when using a different JSON gem such as Oj. ([@stormbreakerbg][])
+* [#2694](https://github.com/bbatsov/rubocop/issues/2694): Fix caching when using a different JSON gem such as Oj. ([@georgyangelov][])
 * [#2707](https://github.com/bbatsov/rubocop/pull/2707): Change `Lint/NestedMethodDefinition` to respect `Class.new` and `Module.new`. ([@owst][])
 * [#2701](https://github.com/bbatsov/rubocop/pull/2701): Do not consider assignments to the same variable as useless if later assignments are within a loop. ([@owst][])
 * [#2696](https://github.com/bbatsov/rubocop/issues/2696): `Style/NestedModifier` adds parentheses around a condition when needed. ([@lumeet][])
@@ -2468,7 +2469,7 @@
 [@mvidner]: https://github.com/mvidner
 [@mattparlane]: https://github.com/mattparlane
 [@drenmi]: https://github.com/drenmi
-[@stormbreakerbg]: https://github.com/stormbreakerbg
+[@georgyangelov]: https://github.com/georgyangelov
 [@owst]: https://github.com/owst
 [@seikichi]: https://github.com/seikichi
 [@madwort]: https://github.com/madwort

--- a/config/default.yml
+++ b/config/default.yml
@@ -1175,6 +1175,7 @@ Metrics/AbcSize:
   Max: 15
 
 Metrics/BlockNesting:
+  CountBlocks: false
   Max: 3
 
 Metrics/ClassLength:

--- a/lib/rubocop/cop/lint/block_alignment.rb
+++ b/lib/rubocop/cop/lint/block_alignment.rb
@@ -54,7 +54,7 @@ module RuboCop
           check_block_alignment(start_for_block_node(node), node)
         end
 
-        def parameter_name
+        def style_parameter_name
           'EnforcedStyleAlignWith'
         end
 

--- a/lib/rubocop/cop/metrics/block_nesting.rb
+++ b/lib/rubocop/cop/metrics/block_nesting.rb
@@ -4,8 +4,11 @@ module RuboCop
   module Cop
     module Metrics
       # This cop checks for excessive nesting of conditional and looping
-      # constructs. Despite the cop's name, blocks are not considered as an
-      # extra level of nesting.
+      # constructs.
+      #
+      # You can configure if blocks are considered using the `CountBlocks`
+      # option. When set to `false` (the default) blocks are not counted
+      # towards the nesting level. Set to `true` to count blocks as well.
       #
       # The maximum level of nesting allowed is configurable.
       class BlockNesting < Cop
@@ -26,7 +29,7 @@ module RuboCop
         private
 
         def check_nesting_level(node, max, current_level)
-          if NESTING_BLOCKS.include?(node.type)
+          if consider_node?(node)
             current_level += 1 unless elsif?(node)
             if current_level > max
               self.max = current_level
@@ -43,8 +46,18 @@ module RuboCop
           end
         end
 
+        def consider_node?(node)
+          return true if NESTING_BLOCKS.include?(node.type)
+
+          count_blocks? && node.block_type?
+        end
+
         def message(max)
           "Avoid more than #{max} levels of block nesting."
+        end
+
+        def count_blocks?
+          cop_config['CountBlocks']
         end
       end
     end

--- a/lib/rubocop/cop/mixin/configurable_enforced_style.rb
+++ b/lib/rubocop/cop/mixin/configurable_enforced_style.rb
@@ -55,7 +55,7 @@ module RuboCop
         return no_acceptable_style! if style.nil?
         return no_acceptable_style! if style.empty?
 
-        config_to_allow_offenses[parameter_name] = style.first
+        config_to_allow_offenses[style_parameter_name] = style.first
       end
 
       alias conflicting_styles_detected no_acceptable_style!
@@ -63,7 +63,7 @@ module RuboCop
 
       def style
         @enforced_style ||= begin
-          s = cop_config[parameter_name].to_sym
+          s = cop_config[style_parameter_name].to_sym
           unless supported_styles.include?(s)
             raise "Unknown style #{s} selected!"
           end
@@ -81,12 +81,12 @@ module RuboCop
 
       def supported_styles
         @supported_styles ||= begin
-          supported_styles = Util.to_supported_styles(parameter_name)
+          supported_styles = Util.to_supported_styles(style_parameter_name)
           cop_config[supported_styles].map(&:to_sym)
         end
       end
 
-      def parameter_name
+      def style_parameter_name
         'EnforcedStyle'
       end
     end

--- a/lib/rubocop/cop/mixin/configurable_max.rb
+++ b/lib/rubocop/cop/mixin/configurable_max.rb
@@ -7,11 +7,11 @@ module RuboCop
     module ConfigurableMax
       def max=(value)
         cfg = config_to_allow_offenses
-        value = [cfg[parameter_name], value].max if cfg[parameter_name]
-        cfg[parameter_name] = value
+        value = [cfg[max_parameter_name], value].max if cfg[max_parameter_name]
+        cfg[max_parameter_name] = value
       end
 
-      def parameter_name
+      def max_parameter_name
         'Max'
       end
     end

--- a/lib/rubocop/cop/mixin/end_keyword_alignment.rb
+++ b/lib/rubocop/cop/mixin/end_keyword_alignment.rb
@@ -44,7 +44,7 @@ module RuboCop
         add_offense(node, end_loc, msg)
       end
 
-      def parameter_name
+      def style_parameter_name
         'EnforcedStyleAlignWith'
       end
 

--- a/lib/rubocop/cop/mixin/trailing_comma.rb
+++ b/lib/rubocop/cop/mixin/trailing_comma.rb
@@ -9,7 +9,7 @@ module RuboCop
 
       MSG = '%s comma after the last %s'.freeze
 
-      def parameter_name
+      def style_parameter_name
         'EnforcedStyleForMultiline'
       end
 

--- a/lib/rubocop/cop/rails/uniq_before_pluck.rb
+++ b/lib/rubocop/cop/rails/uniq_before_pluck.rb
@@ -68,7 +68,7 @@ module RuboCop
 
         private
 
-        def parameter_name
+        def style_parameter_name
           'EnforcedStyle'
         end
 

--- a/lib/rubocop/cop/style/case_indentation.rb
+++ b/lib/rubocop/cop/style/case_indentation.rb
@@ -74,7 +74,7 @@ module RuboCop
 
         def replacement(node)
           case_node = node.each_ancestor(:case).first
-          base_type = cop_config[parameter_name] == 'end' ? :end : :case
+          base_type = cop_config[style_parameter_name] == 'end' ? :end : :case
           column = base_column(case_node, base_type)
           column += configured_indentation_width if cop_config['IndentOneStep']
           ' ' * column

--- a/lib/rubocop/cop/style/numeric_literals.rb
+++ b/lib/rubocop/cop/style/numeric_literals.rb
@@ -25,7 +25,7 @@ module RuboCop
 
         private
 
-        def parameter_name
+        def max_parameter_name
           'MinDigits'
         end
 

--- a/lib/rubocop/cop/style/space_around_block_parameters.rb
+++ b/lib/rubocop/cop/style/space_around_block_parameters.rb
@@ -33,7 +33,7 @@ module RuboCop
 
         private
 
-        def parameter_name
+        def style_parameter_name
           'EnforcedStyleInsidePipes'
         end
 

--- a/manual/cops_metrics.md
+++ b/manual/cops_metrics.md
@@ -45,8 +45,11 @@ Enabled by default | Supports autocorrection
 Enabled | No
 
 This cop checks for excessive nesting of conditional and looping
-constructs. Despite the cop's name, blocks are not considered as an
-extra level of nesting.
+constructs.
+
+You can configure if blocks are considered using the `CountBlocks`
+option. When set to `false` (the default) blocks are not counted
+towards the nesting level. Set to `true` to count blocks as well.
 
 The maximum level of nesting allowed is configurable.
 
@@ -54,6 +57,7 @@ The maximum level of nesting allowed is configurable.
 
 Attribute | Value
 --- | ---
+CountBlocks | false
 Max | 3
 
 

--- a/spec/rubocop/cop/metrics/block_nesting_spec.rb
+++ b/spec/rubocop/cop/metrics/block_nesting_spec.rb
@@ -158,4 +158,52 @@ describe RuboCop::Cop::Metrics::BlockNesting, :config do
                          'end'])
     expect(cop.offenses).to be_empty
   end
+
+  context 'when CountBlocks is false' do
+    let(:cop_config) { { 'Max' => 2, 'CountBlocks' => false } }
+
+    it 'accepts nested multiline blocks' do
+      inspect_source(cop, ['if a',
+                           '  if b',
+                           '    [1, 2].each do |c|',
+                           '      puts c',
+                           '    end',
+                           '  end',
+                           'end'])
+      expect(cop.offenses).to be_empty
+    end
+
+    it 'accepts nested inline blocks' do
+      inspect_source(cop, ['if a',
+                           '  if b',
+                           '    [1, 2].each { |c| puts c }',
+                           '  end',
+                           'end'])
+      expect(cop.offenses).to be_empty
+    end
+  end
+
+  context 'when CountBlocks is true' do
+    let(:cop_config) { { 'Max' => 2, 'CountBlocks' => true } }
+
+    context 'nested multiline block' do
+      source = ['if a',
+                '  if b',
+                '    [1, 2].each do |c|',
+                '      puts c',
+                '    end',
+                '  end',
+                'end']
+      it_behaves_like 'too deep', source, [3]
+    end
+
+    context 'nested inline block' do
+      source = ['if a',
+                '  if b',
+                '    [1, 2].each { |c| puts c }',
+                '  end',
+                'end']
+      it_behaves_like 'too deep', source, [3]
+    end
+  end
 end


### PR DESCRIPTION
Currently, the `Metrics/BlockNesting` cop does not consider blocks to be a nesting level. There are some cases where this is desirable.

This PR makes the block nesting cop configurable. The option is called `ConsideredBlocks` and can have a value of `none`, `multiline` and `all`.

`none` is the default which does not change the cop's current behavior. `multiline` considers multiline blocks as a nesting level and `all` counts both single-line and multiline blocks.

While implementing this, I saw that the two mixins `ConfigurableMax` and `ConfigurableEnforcedStyle` cannot be used both in a cop. They were both defining a `parameter_name` method and one was overriding the other. I have changed the name of these methods to `style_parameter_name` and `max_parameter_name`.

Please verify that my approach in the block detection is correct since this is my first time editing a cop and I'm not entirely familiar with Node's interface.

P.S. I changed my GitHub username and edited that in the contributor list.
