### PR TITLE
Use `const_get` instead of `eval` to get an exception

### DIFF
--- a/lib/rubocop/cop/lint/shadowed_exception.rb
+++ b/lib/rubocop/cop/lint/shadowed_exception.rb
@@ -84,8 +84,8 @@ module RuboCop
             rescued_exceptions = rescued_exceptions(rescue_group)
             rescued_exceptions.each_with_object([]) do |exception, converted|
               begin
-                converted << instance_eval(exception, __FILE__, __LINE__)
-              rescue StandardError, ScriptError
+                converted << Kernel.const_get(exception)
+              rescue NameError
                 converted << nil
               end
             end


### PR DESCRIPTION
It a refactoring.

`instance_eval` method is danger and slow.
`instance_eval` interprets Ruby code.
So, the method can receive non constant string. It's a security risk.
However, `const_get` allows constant string. So, it's safety.

And `instance_eval` is slower than `const_get` method.

```ruby
require 'benchmark'
Benchmark.bm 20 do |x|
  x.report('instance_eval'){1000000.times{instance_eval('StandardError')}}
  x.report('const_get'){1000000.times{Kernel.const_get('StandardError')}}
end
```

```sh
$ ruby test.rb
                           user     system      total        real
instance_eval          2.640000   0.000000   2.640000 (  2.645263)
const_get              0.170000   0.000000   0.170000 (  0.161186)
```

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Used the same coding conventions as the rest of the project.
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [ ] Added tests.
* [ ] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] All tests are passing.
* [x] The new code doesn't generate RuboCop offenses.
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [ ] Updated cop documentation with `rake generate_cops_documentation` (required only when you've added a new cop or changed the configuration/documentation of an existing cop).

[1]: http://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html

