### PR TITLE
Bump default Ruby version to 2.1

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -7,7 +7,7 @@ AllCops:
     - 'vendor/**/*'
     - 'spec/fixtures/**/*'
     - 'tmp/**/*'
-  TargetRubyVersion: 2.0
+  TargetRubyVersion: 2.1
 
 Style/Encoding:
   EnforcedStyle: when_needed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,7 @@
 * [#3601](https://github.com/bbatsov/rubocop/pull/3601): Change default args for `Style/SingleLineBlockParams`. This cop checks that `reduce` and `inject` use the variable names `a` and `e` for block arguments. These defaults are uncommunicative variable names and thus conflict with the ["Uncommunicative Variable Name" check in Reek](https://github.com/troessner/reek/blob/master/docs/Uncommunicative-Variable-Name.md). Default args changed to `acc` and `elem`.([@jessieay][])
 * [#3645](https://github.com/bbatsov/rubocop/pull/3645): Fix bug with empty case when nodes in `Style/RedundantReturn`. ([@tiagocasanovapt][])
 * [#3263](https://github.com/bbatsov/rubocop/issues/3263): Fix auto-correct of if statements inside of unless else statements in `Style/ConditionalAssignment`. ([@rrosenblum][])
+* Bump default Ruby version to 2.1. ([@drenmi][])
 
 ## 0.44.1 (2016-10-13)
 

--- a/config/default.yml
+++ b/config/default.yml
@@ -80,7 +80,7 @@ AllCops:
   # run on? (If there is more than one, set this to the lowest version.)
   # If a value is specified for TargetRubyVersion then it is used.
   # Else if .ruby-version exists and it contains an MRI version it is used.
-  # Otherwise we fallback to the oldest officially supported Ruby version (2.0).
+  # Otherwise we fallback to the oldest officially supported Ruby version (2.1).
   TargetRubyVersion: ~
 
 # Indent private/protected/public as deep as method definitions

--- a/lib/rubocop/config.rb
+++ b/lib/rubocop/config.rb
@@ -15,8 +15,8 @@ module RuboCop
 
     COMMON_PARAMS = %w(Exclude Include Severity
                        AutoCorrect StyleGuide Details).freeze
-    # 2.0 is the oldest officially supported Ruby version.
-    DEFAULT_RUBY_VERSION = 2.0
+    # 2.1 is the oldest officially supported Ruby version.
+    DEFAULT_RUBY_VERSION = 2.1
     KNOWN_RUBIES = [1.9, 2.0, 2.1, 2.2, 2.3, 2.4].freeze
     OBSOLETE_COPS = {
       'Style/TrailingComma' =>

--- a/spec/rubocop/cli/cli_autocorrect_spec.rb
+++ b/spec/rubocop/cli/cli_autocorrect_spec.rb
@@ -993,7 +993,7 @@ describe RuboCop::CLI, :isolated_environment do
        'W:  3: 27: Unused method argument - bar.']
     summary = '1 file inspected, 3 offenses detected'
     create_file('.rubocop.yml', ['AllCops:',
-                                 '  TargetRubyVersion: 2.0'])
+                                 '  TargetRubyVersion: 2.1'])
     create_file('example.rb', src)
     expect(cli.run(%w(-a -f simple))).to eq(1)
     expect($stderr.string).to eq('')

--- a/spec/rubocop/cli_spec.rb
+++ b/spec/rubocop/cli_spec.rb
@@ -185,7 +185,7 @@ describe RuboCop::CLI, :isolated_environment do
     expect(cli.run(['--format', 'emacs', 'example.rb'])).to eq(1)
     expect($stdout.string)
       .to eq(["#{abs('example.rb')}:3:1: E: unexpected " \
-              'token $end (Using Ruby 2.0 parser; configure using ' \
+              'token $end (Using Ruby 2.1 parser; configure using ' \
               '`TargetRubyVersion` parameter, under `AllCops`)',
               ''].join("\n"))
   end


### PR DESCRIPTION
Ruby 2.0 is [EOL](https://www.ruby-lang.org/en/news/2016/02/24/support-plan-of-ruby-2-0-0-and-2-1/) 2016-02-24. This change bumps RuboCop's default Ruby to 2.1.

Note! This does *not* drop support for Ruby 2.0.

-----------------

Before submitting the PR make sure the following are checked:

* [X] Wrote [good commit messages][1].
* [X] Used the same coding conventions as the rest of the project.
* [X] Feature branch is up-to-date with `master` (if not - rebase it).
* [X] Squashed related commits together.
* [ ] Added tests.
* [X] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [X] All tests are passing.
* [X] The new code doesn't generate RuboCop offenses.
* [X] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [ ] Updated cop documentation with `rake generate_cops_documentation` (required only when you've added a new cop or changed the configuration/documentation of an existing cop).

[1]: http://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html