### PR TITLE
Fix issue #3676: Ignore invocations of raw and html_safe when safe_join is used

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@
 * [#3660](https://github.com/bbatsov/rubocop/pull/3660): Fix false positive for Rails/SafeNavigation when without receiver. ([@pocke][])
 * [#3650](https://github.com/bbatsov/rubocop/issues/3650): Fix `Style/VariableNumber` registering an offense for variables with double digit numbers. ([@rrosenblum][])
 * [#3494](https://github.com/bbatsov/rubocop/issues/3494): Check `rails` style indentation also inside blocks in `Style/IndentationWidth`. ([@jonas054][])
+* [#3676](https://github.com/bbatsov/rubocop/issues/3676): Ignore raw and html_safe invocations when wrapped inside a safe_join. ([@b-t-g][])
 
 ### Changes
 

--- a/lib/rubocop/cop/rails/output_safety.rb
+++ b/lib/rubocop/cop/rails/output_safety.rb
@@ -41,13 +41,25 @@ module RuboCop
         def looks_like_rails_html_safe?(node)
           receiver, method_name, *args = *node
 
-          receiver && method_name == :html_safe && args.empty?
+          receiver && method_name == :html_safe && args.empty? &&
+            !called_from_safe_join?(node)
         end
 
         def looks_like_rails_raw?(node)
           receiver, method_name, *args = *node
 
-          receiver.nil? && method_name == :raw && args.one?
+          receiver.nil? && method_name == :raw && args.one? &&
+            !called_from_safe_join?(node)
+        end
+
+        def called_from_safe_join?(node)
+          from_safe_join = false
+          while node.parent.is_a? RuboCop::Node
+            node = node.parent
+            _receiver, method_name, *_args = *node
+            from_safe_join ||= (method_name == :safe_join)
+          end
+          from_safe_join
         end
       end
     end

--- a/spec/rubocop/cop/rails/output_safety_spec.rb
+++ b/spec/rubocop/cop/rails/output_safety_spec.rb
@@ -58,4 +58,32 @@ describe RuboCop::Cop::Rails::OutputSafety do
     inspect_source(cop, source)
     expect(cop.offenses).to be_empty
   end
+
+  it 'accepts raw methods when wrapped in a safe_join' do
+    source = 'safe_join([raw(i18n_text),
+              raw(i18n_mode_additional_markup(key))])'
+    inspect_source(cop, source)
+    expect(cop.offenses).to be_empty
+  end
+
+  it 'accepts html_safe methods when wrapped in a safe_join' do
+    source = 'safe_join([i18n_text.html_safe,
+              i18n_mode_additional_markup(key).html_safe])'
+    inspect_source(cop, source)
+    expect(cop.offenses).to be_empty
+  end
+
+  it 'accepts raw methods when wrapped in safe_join when not at the root' do
+    source = 'foo(safe_join([i18n_text.html_safe,
+              i18n_mode_additional_markup(key).html_safe]))'
+    inspect_source(cop, source)
+    expect(cop.offenses).to be_empty
+  end
+
+  it 'accepts raw methods when wrapped in a safe_join when not at the root' do
+    source = 'foo(safe_join([raw(i18n_text),
+              raw(i18n_mode_additional_markup(key))]))'
+    inspect_source(cop, source)
+    expect(cop.offenses).to be_empty
+  end
 end


### PR DESCRIPTION
I changed the logic for checking invocations of raw/html_safe to first go to the root node of where those methods were called to see if they were called inside of safe_join first.

-----------------

Before submitting the PR make sure the following are checked:

* [ ] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [ ] Used the same coding conventions as the rest of the project.
* [ ] Feature branch is up-to-date with `master` (if not - rebase it).
* [ ] Squashed related commits together.
* [ ] Added tests.
* [ ] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [ ] All tests are passing.
* [ ] The new code doesn't generate RuboCop offenses.
* [ ] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [ ] Updated cop documentation with `rake generate_cops_documentation` (required only when you've added a new cop or changed the configuration/documentation of an existing cop).

[1]: http://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html

inside safe_join.