### PR TITLE
Add missing DynamicFindBy to the Rails cop list

### DIFF
--- a/manual/cops.md
+++ b/manual/cops.md
@@ -164,6 +164,7 @@ In the following section you find all available cops:
 * [Rails/ActionFilter](cops_rails.md#railsactionfilter)
 * [Rails/Date](cops_rails.md#railsdate)
 * [Rails/Delegate](cops_rails.md#railsdelegate)
+* [Rails/DynamicFindBy](cops_rails.md#railsdynamicfindby)
 * [Rails/Exit](cops_rails.md#railsexit)
 * [Rails/FindBy](cops_rails.md#railsfindby)
 * [Rails/FindEach](cops_rails.md#railsfindeach)


### PR DESCRIPTION
This is a documentation change only (in the manuals).

This cop can be found at http://www.rubydoc.info/gems/rubocop/RuboCop/Cop/Rails/DynamicFindBy.

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* **(N/A)** Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Used the same coding conventions as the rest of the project.
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* **(N/A)** Added tests.
* **(N/A)** Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] All tests are passing.
* [x] The new code doesn't generate RuboCop offenses.
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* **(N/A)** Updated cop documentation with `rake generate_cops_documentation` (required only when you've added a new cop or changed the configuration/documentation of an existing cop).

[1]: http://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html