### PR TITLE
[Fix #3662] Remove brackets from an array literal being expanded in another array

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### Bug fixes
 
+* [#3662](https://github.com/bbatsov/rubocop/issues/3662): Fix the auto-correction of `Lint/UnneededSplatExpansion` when the splat expansion is inside of another array. ([@rrosenblum][])
+
 ## 0.45.0 (2016-10-31)
 
 ### New features


### PR DESCRIPTION
This fixes #3662.
