### PR TITLE
Add format as an acceptable Rails/HttpPositionalArguments keyword

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@
 * [#3662](https://github.com/bbatsov/rubocop/issues/3662): Fix the auto-correction of `Lint/UnneededSplatExpansion` when the splat expansion is inside of another array. ([@rrosenblum][])
 * [#3699](https://github.com/bbatsov/rubocop/issues/3699): Fix false positive in `Style/VariableNumber` on variable names ending with an underscore. ([@bquorning][])
 * [#3687](https://github.com/bbatsov/rubocop/issues/3687): Fix the fact that `Style/TernaryParentheses` cop claims to correct uncorrected offenses. ([@Ana06][])
+* Add `format` as an acceptable keyword argument for `Rails/HttpPositionalArguments`. ([@aesthetikx][])
 
 ## 0.45.0 (2016-10-31)
 
@@ -2495,3 +2496,4 @@
 [@tessi]: https://github.com/tessi
 [@ivanovaleksey]: https://github.com/ivanovaleksey
 [@Ana06]: https://github.com/Ana06
+[@aesthetikx]: https://github.com/aesthetikx

--- a/lib/rubocop/cop/rails/http_positional_arguments.rb
+++ b/lib/rubocop/cop/rails/http_positional_arguments.rb
@@ -18,7 +18,7 @@ module RuboCop
               'positional arguments for http call: `%s`.'.freeze
         KEYWORD_ARGS = [
           :headers, :env, :params, :body, :flash, :as,
-          :xhr, :session, :method
+          :xhr, :session, :method, :format
         ].freeze
         HTTP_METHODS = [:get, :post, :put, :patch, :delete, :head].freeze
 

--- a/spec/rubocop/cop/rails/http_positional_arguments_spec.rb
+++ b/spec/rubocop/cop/rails/http_positional_arguments_spec.rb
@@ -36,7 +36,8 @@ describe RuboCop::Cop::Rails::HttpPositionalArguments do
   [
     'params: { user_id: @user.id }',
     'xhr: true',
-    'session: { foo: \'bar\' }'
+    'session: { foo: \'bar\' }',
+    'format: :json'
   ].each do |keyword_args|
     describe 'when using keyword args' do
       let(:source) do


### PR DESCRIPTION
This adds `format` as an acceptable keyword argument in the `Rails/HttpPositionaArguments` cop.
I believe this is desired behavior, as I have been using `format: :json` in many of my controller specs.