### PR TITLE
Modify some cops to use `NodePattern`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 * [#3600](https://github.com/bbatsov/rubocop/issues/3600): Add new `Bundler/DuplicatedGem` cop. ([@jmks][])
 
+### Changes
+
+* The offense range for `Performance/FlatMap` now includes any parameters that are passed to `flatten`. ([@rrosenblum][])
+
 ### Bug fixes
 
 * [#3662](https://github.com/bbatsov/rubocop/issues/3662): Fix the auto-correction of `Lint/UnneededSplatExpansion` when the splat expansion is inside of another array. ([@rrosenblum][])

--- a/lib/rubocop/cop/performance/flat_map.rb
+++ b/lib/rubocop/cop/performance/flat_map.rb
@@ -63,7 +63,7 @@ module RuboCop
 
         def offense(node, map_node, first_method, flatten, message)
           range = range_between(map_node.loc.selector.begin_pos,
-                                node.loc.selector.end_pos)
+                                node.loc.expression.end_pos)
 
           add_offense(node, range, format(message, first_method, flatten))
         end

--- a/lib/rubocop/cop/performance/flat_map.rb
+++ b/lib/rubocop/cop/performance/flat_map.rb
@@ -19,65 +19,53 @@ module RuboCop
         FLATTEN_MULTIPLE_LEVELS = ' Beware, `flat_map` only flattens 1 level ' \
                                   'and `flatten` can be used to flatten ' \
                                   'multiple levels.'.freeze
-        FLATTEN_METHODS = [:flatten, :flatten!].freeze
-        MAP_METHODS = [:map, :collect].freeze
+
+        def_node_matcher :flat_map_candidate?, <<-PATTERN
+          (send (block $(send _ ${:collect :map}) ...) ${:flatten :flatten!} $...)
+        PATTERN
 
         def on_send(node)
-          left, second_method, flatten_param = *node
-          return unless flatten_method?(second_method)
-
-          flatten_level, = *flatten_param
-          expression, = *left
-          _array, first_method = *expression
-          return unless map_method?(first_method)
-
-          if cop_config['EnabledForFlattenWithoutParams'] && flatten_level.nil?
-            offense_for_levels(node, expression, first_method, second_method)
-          elsif flatten_level == 1
-            offense_for_method(node, expression, first_method, second_method)
+          flat_map_candidate?(node) do |map_node, first_method, flatten, params|
+            flatten_level, = *params.first
+            if cop_config['EnabledForFlattenWithoutParams'] &&
+               flatten_level.nil?
+              offense_for_levels(node, map_node, first_method, flatten)
+            elsif flatten_level == 1
+              offense_for_method(node, map_node, first_method, flatten)
+            end
           end
         end
 
         def autocorrect(node)
-          receiver, _flatten, flatten_param = *node
-          flatten_level, = *flatten_param
+          map_node, _first_method, _flatten, params = flat_map_candidate?(node)
+          flatten_level, = *params.first
           return if flatten_level.nil?
-
-          array, = *receiver
 
           lambda do |corrector|
             range = range_between(node.loc.dot.begin_pos,
                                   node.source_range.end_pos)
 
             corrector.remove(range)
-            corrector.replace(array.loc.selector, 'flat_map')
+            corrector.replace(map_node.loc.selector, 'flat_map')
           end
         end
 
         private
 
-        def flatten_method?(method_name)
-          FLATTEN_METHODS.include?(method_name)
-        end
-
-        def map_method?(method_name)
-          MAP_METHODS.include?(method_name)
-        end
-
-        def offense_for_levels(node, expression, first_method, second_method)
+        def offense_for_levels(node, map_node, first_method, flatten)
           message = MSG + FLATTEN_MULTIPLE_LEVELS
-          offense(node, expression, first_method, second_method, message)
+          offense(node, map_node, first_method, flatten, message)
         end
 
-        def offense_for_method(node, expression, first_method, second_method)
-          offense(node, expression, first_method, second_method, MSG)
+        def offense_for_method(node, map_node, first_method, flatten)
+          offense(node, map_node, first_method, flatten, MSG)
         end
 
-        def offense(node, expression, first_method, second_method, message)
-          range = range_between(expression.loc.selector.begin_pos,
+        def offense(node, map_node, first_method, flatten, message)
+          range = range_between(map_node.loc.selector.begin_pos,
                                 node.loc.selector.end_pos)
 
-          add_offense(node, range, format(message, first_method, second_method))
+          add_offense(node, range, format(message, first_method, flatten))
         end
       end
     end

--- a/lib/rubocop/cop/performance/sample.rb
+++ b/lib/rubocop/cop/performance/sample.rb
@@ -27,110 +27,112 @@ module RuboCop
       class Sample < Cop
         MSG = 'Use `%<correct>s` instead of `%<incorrect>s`.'.freeze
 
+        def_node_matcher :sample_candidate?, <<-PATTERN
+          (send $(send _ :shuffle $...) ${:first :last :[]} $...)
+        PATTERN
+
         def on_send(node)
-          analyzer = ShuffleAnalyzer.new(node)
-          return unless analyzer.offensive?
-          add_offense(node, analyzer.source_range, analyzer.message)
+          sample_candidate?(node) do |shuffle, shuffle_arg, method, method_args|
+            return unless offensive?(method, method_args)
+
+            range = source_range(shuffle, node)
+            message = message(shuffle_arg, method, method_args, range)
+            add_offense(node, range, message)
+          end
         end
 
         def autocorrect(node)
-          ShuffleAnalyzer.new(node).autocorrect
+          shuffle_node, shuffle_arg, method, method_args =
+            sample_candidate?(node)
+
+          lambda do |corrector|
+            corrector.replace(source_range(shuffle_node, node),
+                              correction(shuffle_arg, method, method_args))
+          end
         end
 
-        # An internal class for representing a shuffle + method node analyzer.
-        class ShuffleAnalyzer
-          def initialize(shuffle_node)
-            @shuffle_node = shuffle_node
-            @method_node  = shuffle_node.parent
+        private
+
+        def offensive?(method, method_args)
+          case method
+          when :first, :last
+            true
+          when :[]
+            sample_size(method_args) != :unknown
+          else
+            false
           end
+        end
 
-          def autocorrect
-            ->(corrector) { corrector.replace(source_range, correct) }
+        def sample_size(method_args)
+          case method_args.size
+          when 1
+            sample_size_for_one_arg(method_args.first)
+          when 2
+            sample_size_for_two_args(*method_args)
           end
+        end
 
-          def message
-            format(MSG, correct: correct, incorrect: source_range.source)
+        def sample_size_for_one_arg(arg)
+          case arg.type
+          when :erange, :irange
+            range_size(arg)
+          when :int
+            arg.to_a.first.zero? ? nil : :unknown
+          else
+            :unknown
           end
+        end
 
-          def offensive?
-            shuffle_node.to_a[1] == :shuffle && corrigible?
+        def sample_size_for_two_args(first, second)
+          return :unknown unless first.int_type? && first.to_a.first.zero?
+          second.int_type? ? second.to_a.first : :unknown
+        end
+
+        def range_size(range_node)
+          vals = range_node.to_a
+          return :unknown unless vals.all?(&:int_type?)
+          low, high = vals.map { |val| val.children[0] }
+          return :unknown unless low.zero? && high >= 0
+
+          case range_node.type
+          when :erange
+            (low...high).size
+          when :irange
+            (low..high).size
           end
+        end
 
-          def source_range
-            Parser::Source::Range.new(shuffle_node.source_range.source_buffer,
-                                      shuffle_node.loc.selector.begin_pos,
-                                      method_node.source_range.end_pos)
+        def source_range(shuffle_node, node)
+          Parser::Source::Range.new(shuffle_node.source_range.source_buffer,
+                                    shuffle_node.loc.selector.begin_pos,
+                                    node.source_range.end_pos)
+        end
+
+        def message(shuffle_arg, method, method_args, range)
+          format(MSG,
+                 correct: correction(shuffle_arg, method, method_args),
+                 incorrect: range.source)
+        end
+
+        def correction(shuffle_arg, method, method_args)
+          shuffle_arg = extract_source(shuffle_arg)
+          sample_arg = sample_arg(method, method_args)
+          args = [sample_arg, shuffle_arg].compact.join(', ')
+          args.empty? ? 'sample' : "sample(#{args})"
+        end
+
+        def sample_arg(method, method_args)
+          case method
+          when :first, :last
+            extract_source(method_args)
+          when :[]
+            sample_size(method_args)
           end
+        end
 
-          private
-
-          attr_reader :method_node, :shuffle_node
-
-          def correct
-            args = [sample_arg, shuffle_arg].compact.join(', ')
-            args.empty? ? 'sample' : "sample(#{args})"
-          end
-
-          def corrigible?
-            case method
-            when :first, :last then true
-            when :[]           then sample_size != :unknown
-            else false
-            end
-          end
-
-          def method
-            method_node.to_a[1]
-          end
-
-          def method_arg
-            _, _, arg = *method_node
-            arg.source if arg
-          end
-
-          def range_size(range_node)
-            vals = *range_node
-            return :unknown unless vals.all?(&:int_type?)
-            low, high = *vals.map { |val| val.to_a.first }
-            return :unknown unless low.zero? && high >= 0
-            case range_node.type
-            when :erange then high - low
-            when :irange then high - low + 1
-            end
-          end
-
-          def sample_arg
-            case method
-            when :first, :last then method_arg
-            when :[]           then sample_size
-            end
-          end
-
-          def sample_size
-            _, _, *args = *method_node
-            case args.size
-            when 1 then sample_size_for_one_arg(args.first)
-            when 2 then sample_size_for_two_args(*args)
-            end
-          end
-
-          def sample_size_for_one_arg(arg)
-            case arg.type
-            when :erange, :irange then range_size(arg)
-            when :int             then arg.to_a.first.zero? ? nil : :unknown
-            else :unknown
-            end
-          end
-
-          def sample_size_for_two_args(first, second)
-            return :unknown unless first.int_type? && first.to_a.first.zero?
-            second.int_type? ? second.to_a.first : :unknown
-          end
-
-          def shuffle_arg
-            _, _, arg = *shuffle_node
-            arg.source if arg
-          end
+        def extract_source(args)
+          args.empty? ? nil : args.first.source
         end
       end
     end

--- a/spec/rubocop/cop/performance/detect_spec.rb
+++ b/spec/rubocop/cop/performance/detect_spec.rb
@@ -6,7 +6,6 @@ describe RuboCop::Cop::Performance::Detect do
   subject(:cop) { described_class.new(config) }
 
   let(:collection_method) { nil }
-
   let(:config) do
     RuboCop::Config.new(
       'Style/CollectionMethods' => {
@@ -17,7 +16,11 @@ describe RuboCop::Cop::Performance::Detect do
     )
   end
 
-  described_class::SELECT_METHODS.each do |method|
+  # rspec will not let you use a variable assigned using let outside
+  # of `it`
+  select_methods = [:select, :find_all].freeze
+
+  select_methods.each do |method|
     it "registers an offense when first is called on #{method}" do
       inspect_source(cop, "[1, 2, 3].#{method} { |i| i % 2 == 0 }.first")
 
@@ -43,24 +46,17 @@ describe RuboCop::Cop::Performance::Detect do
     end
 
     it "registers an offense when first is called on multiline #{method}" do
-      inspect_source(
-        cop, %(
-        [1, 2, 3].#{method} do
-          |i| i % 2 == 0
-        end.first)
-      )
+      inspect_source(cop, ["[1, 2, 3].#{method} do |i|",
+                           '  i % 2 == 0',
+                           'end.first'])
 
-      expect(cop.messages)
-        .to eq(["Use `detect` instead of `#{method}.first`."])
+      expect(cop.messages).to eq(["Use `detect` instead of `#{method}.first`."])
     end
 
     it "registers an offense when first is called on multiline #{method}" do
-      inspect_source(
-        cop, %(
-        [1, 2, 3].#{method} do
-          |i| i % 2 == 0
-        end.last)
-      )
+      inspect_source(cop, ["[1, 2, 3].#{method} do |i|",
+                           '  i % 2 == 0',
+                           'end.last'])
 
       expect(cop.messages)
         .to eq(["Use `reverse.detect` instead of `#{method}.last`."])
@@ -69,8 +65,7 @@ describe RuboCop::Cop::Performance::Detect do
     it "registers an offense when first is called on #{method} short syntax" do
       inspect_source(cop, "[1, 2, 3].#{method}(&:even?).first")
 
-      expect(cop.messages)
-        .to eq(["Use `detect` instead of `#{method}.first`."])
+      expect(cop.messages).to eq(["Use `detect` instead of `#{method}.first`."])
     end
 
     it "registers an offense when last is called on #{method} short syntax" do
@@ -84,8 +79,7 @@ describe RuboCop::Cop::Performance::Detect do
        'on `lazy` without receiver' do
       inspect_source(cop, "lazy.#{method}(&:even?).first")
 
-      expect(cop.messages)
-        .to eq(["Use `detect` instead of `#{method}.first`."])
+      expect(cop.messages).to eq(["Use `detect` instead of `#{method}.first`."])
     end
 
     it "does not register an offense when #{method} is used " \
@@ -127,105 +121,87 @@ describe RuboCop::Cop::Performance::Detect do
     shared_examples 'detect_autocorrect' do |preferred_method|
       context "with #{preferred_method}" do
         let(:collection_method) { preferred_method }
-        described_class::SELECT_METHODS.each do |method|
-          it "corrects #{method}.first to #{preferred_method} (with block)" do
-            new_source = autocorrect_source(
-              cop,
-              "[1, 2, 3].#{method} { |i| i % 2 == 0 }.first"
-            )
 
-            expect(new_source).to eq(
-              "[1, 2, 3].#{preferred_method} { |i| i % 2 == 0 }"
-            )
+        select_methods.each do |method|
+          it "corrects #{method}.first to #{preferred_method} (with block)" do
+            source = "[1, 2, 3].#{method} { |i| i % 2 == 0 }.first"
+
+            new_source = autocorrect_source(cop, source)
+
+            expect(new_source)
+              .to eq("[1, 2, 3].#{preferred_method} { |i| i % 2 == 0 }")
           end
 
           it "corrects #{method}.last to reverse.#{preferred_method} " \
              '(with block)' do
-            new_source = autocorrect_source(
-              cop,
-              "[1, 2, 3].#{method} { |i| i % 2 == 0 }.last"
-            )
+            source = "[1, 2, 3].#{method} { |i| i % 2 == 0 }.last"
 
-            expect(new_source).to eq(
-              "[1, 2, 3].reverse.#{preferred_method} { |i| i % 2 == 0 }"
-            )
+            new_source = autocorrect_source(cop, source)
+
+            expect(new_source)
+              .to eq("[1, 2, 3].reverse.#{preferred_method} { |i| i % 2 == 0 }")
           end
 
           it "corrects #{method}.first to #{preferred_method} (short syntax)" do
-            new_source = autocorrect_source(
-              cop,
-              "[1, 2, 3].#{method}(&:even?).first"
-            )
+            source = "[1, 2, 3].#{method}(&:even?).first"
+
+            new_source = autocorrect_source(cop, source)
 
             expect(new_source).to eq("[1, 2, 3].#{preferred_method}(&:even?)")
           end
 
           it "corrects #{method}.last to reverse.#{preferred_method} " \
              '(short syntax)' do
-            new_source = autocorrect_source(
-              cop,
-              "[1, 2, 3].#{method}(&:even?).last"
-            )
+            source = "[1, 2, 3].#{method}(&:even?).last"
+
+            new_source = autocorrect_source(cop, source)
 
             expect(new_source)
               .to eq("[1, 2, 3].reverse.#{preferred_method}(&:even?)")
           end
 
           it "corrects #{method}.first to #{preferred_method} (multiline)" do
-            new_source = autocorrect_source(
-              cop,
-              %([1, 2, 3].#{method} do
-                  |i| i % 2 == 0
-                end.first)
-            )
+            source = ["[1, 2, 3].#{method} do |i|",
+                      '  i % 2 == 0',
+                      'end.first']
+            new_source = autocorrect_source(cop, source)
 
-            expect(new_source).to eq(
-              %([1, 2, 3].#{preferred_method} do
-                  |i| i % 2 == 0
-                end)
-            )
+            expect(new_source).to eq(["[1, 2, 3].#{preferred_method} do |i|",
+                                      '  i % 2 == 0',
+                                      'end'].join("\n"))
           end
 
           it "corrects #{method}.last to reverse.#{preferred_method} " \
              '(multiline)' do
-            new_source = autocorrect_source(
-              cop,
-              %([1, 2, 3].#{method} do
-                  |i| i % 2 == 0
-                end.last)
-            )
+            source = ["[1, 2, 3].#{method} do |i|",
+                      '  i % 2 == 0',
+                      'end.last']
+            new_source = autocorrect_source(cop, source)
 
-            expect(new_source).to eq(
-              %([1, 2, 3].reverse.#{preferred_method} do
-                  |i| i % 2 == 0
-                end)
-            )
+            expect(new_source)
+              .to eq(["[1, 2, 3].reverse.#{preferred_method} do |i|",
+                      '  i % 2 == 0',
+                      'end'].join("\n"))
           end
 
           it "corrects multiline #{method} to #{preferred_method} " \
-             'with \'first\' on the last line' do
-            new_source = autocorrect_source(
-              cop,
-              %([1, 2, 3].#{method} { true }
-                         .first['x'])
-            )
+             "with 'first' on the last line" do
+            source = ["[1, 2, 3].#{method} { true }",
+                      ".first['x']"]
+            new_source = autocorrect_source(cop, source)
 
-            expect(new_source).to eq(
-              %([1, 2, 3].#{preferred_method} { true }['x'])
-            )
+            expect(new_source)
+              .to eq("[1, 2, 3].#{preferred_method} { true }['x']")
           end
 
           it "corrects multiline #{method} to #{preferred_method} " \
-             'with \'first\' on the last line (short syntax)' do
-            new_source = autocorrect_source(
-              cop,
-              %([1, 2, 3].#{method}(&:blank?)
-                         .first['x'])
-            )
+             "with 'first' on the last line (short syntax)" do
+            source = ["[1, 2, 3].#{method}(&:blank?)",
+                      ".first['x']"]
+            new_source = autocorrect_source(cop, source)
 
-            expect(new_source).to eq(
-              %([1, 2, 3].#{preferred_method}(&:blank?)['x'])
-            )
+            expect(new_source)
+              .to eq("[1, 2, 3].#{preferred_method}(&:blank?)['x']")
           end
         end
       end
@@ -252,7 +228,7 @@ describe RuboCop::Cop::Performance::Detect do
       )
     end
 
-    described_class::SELECT_METHODS.each do |method|
+    select_methods.each do |method|
       it "doesn't register an offense when first is called on #{method}" do
         inspect_source(cop, "[1, 2, 3].#{method} { |i| i % 2 == 0 }.first")
 

--- a/spec/rubocop/cop/performance/flat_map_spec.rb
+++ b/spec/rubocop/cop/performance/flat_map_spec.rb
@@ -11,6 +11,7 @@ describe RuboCop::Cop::Performance::FlatMap, :config do
 
       expect(cop.messages)
         .to eq(["Use `flat_map` instead of `#{method}...#{flatten}`."])
+      expect(cop.highlights).to eq(["#{method} { |e| [e, e] }.#{flatten}(1)"])
     end
 
     it "does not register an offense when calling #{method}...#{flatten} " \
@@ -77,6 +78,7 @@ describe RuboCop::Cop::Performance::FlatMap, :config do
           .to eq(["Use `flat_map` instead of `map...#{flatten}`. " \
                'Beware, `flat_map` only flattens 1 level and `flatten` ' \
                'can be used to flatten multiple levels.'])
+        expect(cop.highlights).to eq(["map { |e| [e, e] }.#{flatten}"])
       end
 
       it "will not correct #{method}..#{flatten} to flat_map" do

--- a/spec/rubocop/cop/performance/sample_spec.rb
+++ b/spec/rubocop/cop/performance/sample_spec.rb
@@ -5,10 +5,17 @@ require 'spec_helper'
 describe RuboCop::Cop::Performance::Sample do
   subject(:cop) { described_class.new }
 
-  shared_examples 'registers offense' do |wrong, right|
+  shared_examples 'offense' do |wrong, right|
     it "when using #{wrong}" do
       inspect_source(cop, "[1, 2, 3].#{wrong}")
       expect(cop.messages).to eq(["Use `#{right}` instead of `#{wrong}`."])
+    end
+
+    context 'corrects' do
+      it "#{wrong} to #{right}" do
+        new_source = autocorrect_source(cop, "[1, 2, 3].#{wrong}")
+        expect(new_source).to eq("[1, 2, 3].#{right}")
+      end
     end
   end
 
@@ -19,34 +26,24 @@ describe RuboCop::Cop::Performance::Sample do
     end
   end
 
-  shared_examples 'corrects' do |wrong, right|
-    it "#{wrong} to #{right}" do
-      new_source = autocorrect_source(cop, "[1, 2, 3].#{wrong}")
-      expect(new_source).to eq("[1, 2, 3].#{right}")
-    end
-  end
-
-  fixes = {
-    'shuffle.first'      => 'sample',
-    'shuffle.last'       => 'sample',
-    'shuffle[0]'         => 'sample',
-    'shuffle[0, 3]'      => 'sample(3)',
-    'shuffle[0..3]'      => 'sample(4)',
-    'shuffle[0...3]'     => 'sample(3)',
-    'shuffle.first(2)'   => 'sample(2)',
-    'shuffle.last(3)'    => 'sample(3)',
-    'shuffle.first(foo)' => 'sample(foo)',
-    'shuffle.last(bar)'  => 'sample(bar)',
-    'shuffle(random: Random.new).first'    => 'sample(random: Random.new)',
-    'shuffle(random: Random.new).first(2)' => 'sample(2, random: Random.new)',
-    'shuffle(random: foo).last(bar)'       => 'sample(bar, random: foo)',
-    'shuffle(random: Random.new)[0..3]'    => 'sample(4, random: Random.new)'
-  }
-
-  fixes.each do |wrong, right|
-    it_behaves_like('registers offense', wrong, right)
-    it_behaves_like('corrects',          wrong, right)
-  end
+  it_behaves_like('offense', 'shuffle.first', 'sample')
+  it_behaves_like('offense', 'shuffle.last', 'sample')
+  it_behaves_like('offense', 'shuffle[0]', 'sample')
+  it_behaves_like('offense', 'shuffle[0, 3]', 'sample(3)')
+  it_behaves_like('offense', 'shuffle[0..3]', 'sample(4)')
+  it_behaves_like('offense', 'shuffle[0...3]', 'sample(3)')
+  it_behaves_like('offense', 'shuffle.first(2)', 'sample(2)')
+  it_behaves_like('offense', 'shuffle.last(3)', 'sample(3)')
+  it_behaves_like('offense', 'shuffle.first(foo)', 'sample(foo)')
+  it_behaves_like('offense', 'shuffle.last(bar)', 'sample(bar)')
+  it_behaves_like('offense', 'shuffle(random: Random.new).first',
+                  'sample(random: Random.new)')
+  it_behaves_like('offense', 'shuffle(random: Random.new).first(2)',
+                  'sample(2, random: Random.new)')
+  it_behaves_like('offense', 'shuffle(random: foo).last(bar)',
+                  'sample(bar, random: foo)')
+  it_behaves_like('offense', 'shuffle(random: Random.new)[0..3]',
+                  'sample(4, random: Random.new)')
 
   it_behaves_like('accepts', 'sample')
   it_behaves_like('accepts', 'shuffle')


### PR DESCRIPTION
It seems as though RuboCop has been trending towards using `NodePattern` whenever possible to make node parsing easier. These cops all seemed like good candidates to be converted to use `NodePattern`.