### PR TITLE
[Fix 3699] VariableNumber on variables ending with underscore

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 ### Bug fixes
 
 * [#3662](https://github.com/bbatsov/rubocop/issues/3662): Fix the auto-correction of `Lint/UnneededSplatExpansion` when the splat expansion is inside of another array. ([@rrosenblum][])
+* [#3699](https://github.com/bbatsov/rubocop/issues/3699): Fix false positive in `Style/VariableNumber` on variable names ending with an underscore. ([@bquorning][])
 
 ## 0.45.0 (2016-10-31)
 

--- a/lib/rubocop/cop/mixin/configurable_numbering.rb
+++ b/lib/rubocop/cop/mixin/configurable_numbering.rb
@@ -7,9 +7,9 @@ module RuboCop
     module ConfigurableNumbering
       include ConfigurableEnforcedStyle
 
-      SNAKE_CASE = /(?:^_|[a-z]|_\d+)$/
-      NORMAL_CASE = /(?:^_|[A-Za-z]\d*)$/
-      NON_INTEGER = /(?:^_|[A-Za-z])$/
+      SNAKE_CASE = /(?:[a-z_]|_\d+)$/
+      NORMAL_CASE = /(?:_\D*|[A-Za-z]\d*)$/
+      NON_INTEGER = /[A-Za-z_]$/
 
       def check_name(node, name, name_range)
         return if operator?(name)

--- a/lib/rubocop/cop/mixin/configurable_numbering.rb
+++ b/lib/rubocop/cop/mixin/configurable_numbering.rb
@@ -7,9 +7,9 @@ module RuboCop
     module ConfigurableNumbering
       include ConfigurableEnforcedStyle
 
-      SNAKE_CASE = /(^_|[a-z]|_\d+)$/
-      NORMAL_CASE = /(^_|[A-Za-z]\d*)$/
-      NON_INTEGER = /(^_|[A-Za-z])$/
+      SNAKE_CASE = /(?:^_|[a-z]|_\d+)$/
+      NORMAL_CASE = /(?:^_|[A-Za-z]\d*)$/
+      NON_INTEGER = /(?:^_|[A-Za-z])$/
 
       def check_name(node, name, name_range)
         return if operator?(name)

--- a/spec/rubocop/cop/style/variable_number_spec.rb
+++ b/spec/rubocop/cop/style/variable_number_spec.rb
@@ -26,7 +26,6 @@ describe RuboCop::Cop::Style::VariableNumber, :config do
     let(:cop_config) { { 'EnforcedStyle' => 'snake_case' } }
 
     it_behaves_like :offense, 'snake_case', 'local1'
-    it_behaves_like :offense, 'snake_case', 'local_'
     it_behaves_like :offense, 'snake_case', '@local1'
     it_behaves_like :offense, 'snake_case', '@@local1'
     it_behaves_like :offense, 'snake_case', 'camelCase1'
@@ -37,11 +36,14 @@ describe RuboCop::Cop::Style::VariableNumber, :config do
     it_behaves_like :accepts, 'snake_case', 'local_1'
     it_behaves_like :accepts, 'snake_case', 'local_12'
     it_behaves_like :accepts, 'snake_case', 'local_123'
+    it_behaves_like :accepts, 'snake_case', 'local_'
     it_behaves_like :accepts, 'snake_case', 'aB_1'
     it_behaves_like :accepts, 'snake_case', 'a_1_b'
     it_behaves_like :accepts, 'snake_case', 'a_1_b_1'
     it_behaves_like :accepts, 'snake_case', '_'
     it_behaves_like :accepts, 'snake_case', '_foo'
+    it_behaves_like :accepts, 'snake_case', '@foo'
+    it_behaves_like :accepts, 'snake_case', '@__foo__'
 
     it 'registers an offense for normal case numbering in method parameter' do
       inspect_source(cop, 'def method(arg1); end')
@@ -61,7 +63,6 @@ describe RuboCop::Cop::Style::VariableNumber, :config do
     let(:cop_config) { { 'EnforcedStyle' => 'normalcase' } }
 
     it_behaves_like :offense, 'normalcase', 'local_1'
-    it_behaves_like :offense, 'normalcase', 'local_'
     it_behaves_like :offense, 'normalcase', 'sha_256'
     it_behaves_like :offense, 'normalcase', '@local_1'
     it_behaves_like :offense, 'normalcase', '@@local_1'
@@ -72,6 +73,7 @@ describe RuboCop::Cop::Style::VariableNumber, :config do
     it_behaves_like :offense, 'normalcase', 'local_FOO_1'
 
     it_behaves_like :accepts, 'normalcase', 'local1'
+    it_behaves_like :accepts, 'normalcase', 'local_'
     it_behaves_like :accepts, 'normalcase', 'user1_id'
     it_behaves_like :accepts, 'normalcase', 'sha256'
     it_behaves_like :accepts, 'normalcase', 'foo10_bar'
@@ -81,6 +83,8 @@ describe RuboCop::Cop::Style::VariableNumber, :config do
     it_behaves_like :accepts, 'normalcase', 'user_1_id'
     it_behaves_like :accepts, 'normalcase', '_'
     it_behaves_like :accepts, 'normalcase', '_foo'
+    it_behaves_like :accepts, 'normalcase', '@foo'
+    it_behaves_like :accepts, 'normalcase', '@__foo__'
 
     it 'registers an offense for snake case numbering in method parameter' do
       inspect_source(cop, 'def method(arg_1); end')
@@ -100,7 +104,6 @@ describe RuboCop::Cop::Style::VariableNumber, :config do
     let(:cop_config) { { 'EnforcedStyle' => 'non_integer' } }
 
     it_behaves_like :offense, 'non_integer', 'local_1'
-    it_behaves_like :offense, 'non_integer', 'local_'
     it_behaves_like :offense, 'non_integer', 'local1'
     it_behaves_like :offense, 'non_integer', '@local_1'
     it_behaves_like :offense, 'non_integer', '@local1'
@@ -113,11 +116,13 @@ describe RuboCop::Cop::Style::VariableNumber, :config do
 
     it_behaves_like :accepts, 'non_integer', 'localone'
     it_behaves_like :accepts, 'non_integer', 'local_one'
+    it_behaves_like :accepts, 'non_integer', 'local_'
     it_behaves_like :accepts, 'non_integer', '@foo'
     it_behaves_like :accepts, 'non_integer', '@@foo'
     it_behaves_like :accepts, 'non_integer', 'fooBar'
     it_behaves_like :accepts, 'non_integer', '_'
     it_behaves_like :accepts, 'non_integer', '_foo'
+    it_behaves_like :accepts, 'non_integer', '@__foo__'
 
     it 'registers an offense for snake case numbering in method parameter' do
       inspect_source(cop, 'def method(arg_1); end')


### PR DESCRIPTION
`Style/VariableNumber` would report false positives on variable names ending with an underscore, e.g. `@__foo__` or `local_`.

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Used the same coding conventions as the rest of the project.
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] All tests are passing.
* [x] The new code doesn't generate RuboCop offenses.
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Updated cop documentation with `rake generate_cops_documentation` (required only when you've added a new cop or changed the configuration/documentation of an existing cop).

[1]: http://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html
