### PR TITLE
Fix config for new codeclimate-test-reporter

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,6 +20,7 @@ install:
   - bundle install --retry=3
 script:
   - bundle exec rake
+  - bundle exec codeclimate-test-reporter
 addons:
   code_climate:
     repo_token: a11b66bfbb1acdf220d5cb317b2e945a986fd85adebe29a76d411ad6d74ec31f

--- a/Gemfile
+++ b/Gemfile
@@ -11,7 +11,7 @@ gem 'simplecov', '~> 0.10'
 gem 'pry'
 
 group :test do
-  gem 'codeclimate-test-reporter', require: false
+  gem 'codeclimate-test-reporter', '~> 1.0', require: false
   gem 'safe_yaml', require: false
   gem 'webmock', require: false
 end

--- a/spec/support/coverage.rb
+++ b/spec/support/coverage.rb
@@ -4,13 +4,7 @@ if ENV['TRAVIS'] || ENV['COVERAGE']
   require 'simplecov'
   SimpleCov.add_filter '/spec/'
   SimpleCov.add_filter '/vendor/bundle/'
-
-  if ENV['TRAVIS']
-    require 'codeclimate-test-reporter'
-    CodeClimate::TestReporter.start
-  else
-    SimpleCov.start
-  end
+  SimpleCov.start
 
   SimpleCov.command_name "rspec_#{Process.pid}"
 end


### PR DESCRIPTION
My PR #3701 failed on Travis because it was using the new version of codeclimate-test-reporter. On https://github.com/codeclimate/ruby-test-reporter#upgrading-from-pre-10-versions there is a guide on how to upgrade from pre-1.0 versions.

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Used the same coding conventions as the rest of the project.
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] All tests are passing.
* [x] The new code doesn't generate RuboCop offenses.
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Updated cop documentation with `rake generate_cops_documentation` (required only when you've added a new cop or changed the configuration/documentation of an existing cop).

[1]: http://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html