### PR TITLE
[Fix #3451] Add new `require_parentheses_when_complex` style to `Styl…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 * `Style/EmptyLiteral` will now auto-correct `Hash.new` when it is the first argument being passed to a method. The arguments will be wrapped with parenthesis. ([@rrosenblum][])
 * [#3713](https://github.com/bbatsov/rubocop/pull/3713): Respect `DisabledByDefault` in parent configs. ([@aroben][])
 * New cop `Rails/EnumUniqueness` checks for duplicate values defined in enum config hash. ([@olliebennett][])
+* [#3451](https://github.com/bbatsov/rubocop/issues/3451): Add new `require_parentheses_when_complex` style to `Style/TernaryParentheses` cop. ([@swcraig][])
 
 ### Changes
 

--- a/config/default.yml
+++ b/config/default.yml
@@ -1006,6 +1006,7 @@ Style/TernaryParentheses:
   SupportedStyles:
     - require_parentheses
     - require_no_parentheses
+    - require_parentheses_when_complex
   AllowSafeAssignment: true
 
 Style/TrailingBlankLines:

--- a/lib/rubocop/cop/style/ternary_parentheses.rb
+++ b/lib/rubocop/cop/style/ternary_parentheses.rb
@@ -34,17 +34,32 @@ module RuboCop
       #   foo = (bar?) ? a : b
       #   foo = (bar.baz) ? a : b
       #   foo = (bar && baz) ? a : b
+      #
+      # @example
+      #
+      #   EnforcedStyle: require_parentheses_when_complex
+      #
+      #   @bad
+      #   foo = (bar?) ? a : b
+      #   foo = (bar.baz?) ? a : b
+      #   foo = bar && baz ? a : b
+      #
+      #   @good
+      #   foo = bar? ? a : b
+      #   foo = bar.baz ? a : b
+      #   foo = (bar && baz) ? a : b
       class TernaryParentheses < Cop
         include IfNode
         include SafeAssignment
         include ConfigurableEnforcedStyle
 
         MSG = '%s parentheses for ternary conditions.'.freeze
+        MSG_COMPLEX = '%s parentheses for ternary expressions with' \
+          ' complex conditions.'.freeze
 
         def on_if(node)
-          return unless ternary?(node)
-
-          add_offense(node, node.source_range, message) if offense?(node)
+          return unless ternary?(node) && !infinite_loop? && offense?(node)
+          add_offense(node, node.source_range, message(node))
         end
 
         private
@@ -52,37 +67,72 @@ module RuboCop
         def offense?(node)
           condition, = *node
 
-          (require_parentheses? && !parenthesized?(condition) ||
-            !require_parentheses? && parenthesized?(condition)) &&
-            !(safe_assignment?(condition) && safe_assignment_allowed?) &&
-            !infinite_loop?
+          if safe_assignment?(condition)
+            !safe_assignment_allowed?
+          else
+            parens = parenthesized?(condition)
+            case style
+            when :require_parentheses_when_complex
+              complex_condition?(condition) ? !parens : parens
+            else
+              require_parentheses? ? !parens : parens
+            end
+          end
         end
 
         def autocorrect(node)
           condition, = *node
 
-          return nil if !require_parentheses? && (safe_assignment?(condition) ||
+          return nil if parenthesized?(condition) &&
+                        (safe_assignment?(condition) ||
                         unsafe_autocorrect?(condition))
 
           lambda do |corrector|
-            if require_parentheses?
-              corrector.insert_before(condition.source_range, '(')
-              corrector.insert_after(condition.source_range, ')')
-            else
+            if parenthesized?(condition)
               corrector.remove(condition.loc.begin)
               corrector.remove(condition.loc.end)
+            else
+              corrector.insert_before(condition.source_range, '(')
+              corrector.insert_after(condition.source_range, ')')
             end
           end
         end
 
-        def message
-          verb = require_parentheses? ? 'Use' : 'Omit'
+        # If the condition is parenthesized we recurse and check for any
+        # complex expressions within it.
+        def complex_condition?(condition)
+          if condition.type == :begin
+            condition.to_a.any? { |x| complex_condition?(x) }
+          else
+            non_complex_type?(condition) ? false : true
+          end
+        end
 
-          format(MSG, verb)
+        # Anything that is not a variable, constant, or method/.method call
+        # will be counted as a complex expression.
+        def non_complex_type?(condition)
+          condition.variable? || condition.const_type? ||
+            (condition.send_type? && !operator?(condition.method_name)) ||
+            condition.defined_type?
+        end
+
+        def message(node)
+          if require_parentheses_when_complex?
+            condition, = *node
+            omit = parenthesized?(condition) ? 'Only use' : 'Use'
+            format(MSG_COMPLEX, omit)
+          else
+            verb = require_parentheses? ? 'Use' : 'Omit'
+            format(MSG, verb)
+          end
         end
 
         def require_parentheses?
           style == :require_parentheses
+        end
+
+        def require_parentheses_when_complex?
+          style == :require_parentheses_when_complex
         end
 
         def redundant_parentheses_enabled?
@@ -109,7 +159,6 @@ module RuboCop
 
         def unparenthesized_method_call?(child)
           argument = method_call_argument(child)
-
           argument && argument !~ /^\(/
         end
 

--- a/manual/cops_style.md
+++ b/manual/cops_style.md
@@ -4520,13 +4520,26 @@ foo = (bar?) ? a : b
 foo = (bar.baz) ? a : b
 foo = (bar && baz) ? a : b
 ```
+```ruby
+EnforcedStyle: require_parentheses_when_complex
+
+# bad
+foo = (bar?) ? a : b
+foo = (bar.baz?) ? a : b
+foo = bar && baz ? a : b
+
+# good
+foo = bar? ? a : b
+foo = bar.baz ? a : b
+foo = (bar && baz) ? a : b
+```
 
 ### Important attributes
 
 Attribute | Value
 --- | ---
 EnforcedStyle | require_no_parentheses
-SupportedStyles | require_parentheses, require_no_parentheses
+SupportedStyles | require_parentheses, require_no_parentheses, require_parentheses_when_complex
 AllowSafeAssignment | true
 
 


### PR DESCRIPTION
The new style acts like `require_no_parentheses` when dealing with ternary conditions that are not complex, and therefore should not have parentheses.

Doesn't touch on #3399 in the sense that it is not checking for redundant parentheses yet.

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Used the same coding conventions as the rest of the project.
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] All tests are passing.
* [x] The new code doesn't generate RuboCop offenses.
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Updated cop documentation with `rake generate_cops_documentation` (required only when you've added a new cop or changed the configuration/documentation of an existing cop).

[1]: http://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html

…e/TernaryParentheses` cop