### PR TITLE
[Fix #3598] Don't auto-correct between x.nonzero? and x != 0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@
 * [#3687](https://github.com/bbatsov/rubocop/issues/3687): Fix the fact that `Style/TernaryParentheses` cop claims to correct uncorrected offenses. ([@Ana06][])
 * [#3568](https://github.com/bbatsov/rubocop/issues/3568): Fix `--auto-gen-config` behavior for `Style/VariableNumber`. ([@jonas054][])
 * Add `format` as an acceptable keyword argument for `Rails/HttpPositionalArguments`. ([@aesthetikx][])
+* [#3598](https://github.com/bbatsov/rubocop/issues/3598): In `Style/NumericPredicate`, don't report `x != 0` or `x.nonzero?` as the expressions have different values. ([@jonas054][])
 
 ## 0.45.0 (2016-10-31)
 

--- a/manual/cops_rails.md
+++ b/manual/cops_rails.md
@@ -460,48 +460,43 @@ Enabled by default | Supports autocorrection
 --- | ---
 Disabled | Yes
 
-This cop transforms usages of a method call safeguarded by a non `nil`
-check for the variable whose method is being called to
-safe navigation (`&.`).
-
-Configuration option: ConvertCodeThatCanStartToReturnNil
-The default for this is `false`. When configured to `true`, this will
-check for code in the format `!foo.nil? && foo.bar`. As it is written,
-the return of this code is limited to `false` and whatever the return
-of the method is. If this is converted to safe navigation,
-`foo&.bar` can start returning `nil` as well as what the method
-returns.
+This cop converts usages of `try!` to `&.`. It can also be configured
+to convert `try`. It will convert code to use safe navigation if the
+target Ruby version is set to 2.3+
 
 ### Example
 
 ```ruby
-# bad
-foo.bar if foo
-foo.bar(param1, param2) if foo
-foo.bar { |e| e.something } if foo
-foo.bar(param) { |e| e.something } if foo
+# ConvertTry: false
+  # bad
+  foo.try!(:bar)
+  foo.try!(:bar, baz)
+  foo.try!(:bar) { |e| e.baz }
 
-foo.bar if !foo.nil?
-foo.bar unless !foo
-foo.bar unless foo.nil?
+  foo.try!(:[], 0)
 
-foo && foo.bar
-foo && foo.bar(param1, param2)
-foo && foo.bar { |e| e.something }
-foo && foo.bar(param) { |e| e.something }
+  # good
+  foo.try(:bar)
+  foo.try(:bar, baz)
+  foo.try(:bar) { |e| e.baz }
 
-# good
-foo&.bar
-foo&.bar(param1, param2)
-foo&.bar { |e| e.something }
-foo&.bar(param) { |e| e.something }
+  foo&.bar
+  foo&.bar(baz)
+  foo&.bar { |e| e.baz }
 
-foo.nil? || foo.bar
-!foo || foo.bar
+# ConvertTry: true
+  # bad
+  foo.try!(:bar)
+  foo.try!(:bar, baz)
+  foo.try!(:bar) { |e| e.baz }
+  foo.try(:bar)
+  foo.try(:bar, baz)
+  foo.try(:bar) { |e| e.baz }
 
-# Methods that `nil` will `respond_to?` should not be converted to
-# use safe navigation
-foo.to_i if foo
+  # good
+  foo&.bar
+  foo&.bar(baz)
+  foo&.bar { |e| e.baz }
 ```
 
 ### Important attributes

--- a/spec/rubocop/cop/style/numeric_predicate_spec.rb
+++ b/spec/rubocop/cop/style/numeric_predicate_spec.rb
@@ -66,22 +66,18 @@ describe RuboCop::Cop::Style::NumericPredicate, :config do
     end
 
     context 'with checking if a number is not zero' do
-      it_behaves_like 'code with offense',
-                      'number != 0',
-                      'number.nonzero?'
+      it_behaves_like 'code without offense',
+                      'number != 0'
 
-      it_behaves_like 'code with offense',
-                      '0 != number',
-                      'number.nonzero?'
+      it_behaves_like 'code without offense',
+                      '0 != number'
 
       context 'with a complex expression' do
-        it_behaves_like 'code with offense',
-                        'foo - 1 != 0',
-                        '(foo - 1).nonzero?'
+        it_behaves_like 'code without offense',
+                        'foo - 1 != 0'
 
-        it_behaves_like 'code with offense',
-                        '0 != foo - 1',
-                        '(foo - 1).nonzero?'
+        it_behaves_like 'code without offense',
+                        '0 != foo - 1'
       end
     end
 
@@ -158,9 +154,8 @@ describe RuboCop::Cop::Style::NumericPredicate, :config do
     end
 
     context 'with checking if a number is not zero' do
-      it_behaves_like 'code with offense',
-                      'number.nonzero?',
-                      'number != 0'
+      it_behaves_like 'code without offense',
+                      'number.nonzero?'
     end
 
     context 'when checking if a number is positive' do


### PR DESCRIPTION
The two expressions are not equivalent. `x != 0` returns `true` or `false` while `x.nonzero?` returns `self`, i.e. `x`, or `nil`. The user needs to be aware of these changes by making them manually. That way a breaking change is easier to spot.