### PR TITLE
Fix coverage reporting

### DIFF
--- a/lib/rubocop/rspec/host_environment_simulation_helper.rb
+++ b/lib/rubocop/rspec/host_environment_simulation_helper.rb
@@ -10,7 +10,7 @@ module HostEnvironmentSimulatorHelper
       pid = ::Process.fork do
         # Need to write coverage result under different name
         if defined?(SimpleCov)
-          SimpleCov.command_name "rspec_#{Process.pid}"
+          SimpleCov.coverage_dir "coverage/ignored_results_#{Process.pid}"
           SimpleCov.pid = Process.pid
         end
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -44,6 +44,3 @@ RSpec.configure do |config|
     mocks.verify_partial_doubles = true
   end
 end
-
-# Disable network connections
-WebMock.disable_net_connect!(allow: 'codeclimate.com')

--- a/spec/support/coverage.rb
+++ b/spec/support/coverage.rb
@@ -4,7 +4,6 @@ if ENV['TRAVIS'] || ENV['COVERAGE']
   require 'simplecov'
   SimpleCov.add_filter '/spec/'
   SimpleCov.add_filter '/vendor/bundle/'
+  SimpleCov.command_name 'rspec'
   SimpleCov.start
-
-  SimpleCov.command_name "rspec_#{Process.pid}"
 end


### PR DESCRIPTION
As noticed here:
https://github.com/bbatsov/rubocop/commit/f808d8da7efdeba57f11fd8b55e5fceca1071d79#commitcomment-19713872

The updated Code Climate test reporter changed the coverage percentage
from 99.2% to 0.5%. Sorry about that.

What's happening:

We're loading the SimpleCov coverage data from coverage/.resultset.json
and submitting it to Code Climate.

This repo has a really interesting test suite, which we didn't consider
in our QA. It has some tests which run in a separate process than the
main one. As configured, the test suite is telling simplecov that those
tests are part of a different test suite with a different name. Those
tests only cover a very small fraction of the code (0.5%). The main
process covers the vast majority of the code (99.2%).

A current limitation of the Code Climate ruby test reporter is that we
only submit coverage for one test suite, and don't merge the results
together. We may change that in a future version.

In the meantime, this commit acknowledges that those
in-their-own-process tests are being ignored by Code Climate, and makes
sure that the main process test suite is the one whose coverage gets
sent.

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Used the same coding conventions as the rest of the project.
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [ ] Added tests.
* [ ] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] All tests are passing.
* [x] The new code doesn't generate RuboCop offenses.
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [ ] Updated cop documentation with `rake generate_cops_documentation` (required only when you've added a new cop or changed the configuration/documentation of an existing cop).

[1]: http://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html
