### PR TITLE
Enforce documentation is in sync

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,6 +21,8 @@ install:
 script:
   - bundle exec rake
   - bundle exec codeclimate-test-reporter
+  # Running YARD under jruby crashes so skip checking manual under jruby
+  - ruby -e "exit 1 unless RUBY_PLATFORM == 'java'" || bundle exec rake generate_cops_documentation
 addons:
   code_climate:
     repo_token: a11b66bfbb1acdf220d5cb317b2e945a986fd85adebe29a76d411ad6d74ec31f

--- a/Rakefile
+++ b/Rakefile
@@ -31,8 +31,8 @@ RuboCop::RakeTask.new(:internal_investigation)
 
 task default: [:spec, :ascii_spec, :internal_investigation]
 
-# require 'yard'
-# YARD::Rake::YardocTask.new
+require 'yard'
+YARD::Rake::YardocTask.new
 
 desc 'Open a REPL for experimentation'
 task :repl do

--- a/manual/cops_bundler.md
+++ b/manual/cops_bundler.md
@@ -6,11 +6,36 @@ Enabled by default | Supports autocorrection
 --- | ---
 Enabled | No
 
-This cop checks for duplicate gem entries in Gemfiles. Bundler currently
-only prints a warning (unless there is a requirements conflict).
+A Gem's requirements should be listed only once in a Gemfile.
+
+### Example
+
+```ruby
+# bad
+gem 'rubocop'
+gem 'rubocop'
+
+# bad
+group :development do
+  gem 'rubocop'
+end
+
+group :test do
+  gem 'rubocop'
+end
+
+# good
+group :development, :test do
+  gem 'rubocop'
+end
+
+# good
+gem 'rubocop', groups: [:development, :test]
+```
 
 ### Important attributes
 
-Attribute | Value |
---- | --- |
-Include | \*\*/Gemfile, \*\*/gems.rb |
+Attribute | Value
+--- | ---
+Include | \*\*/Gemfile, \*\*/gems.rb
+

--- a/manual/cops_rails.md
+++ b/manual/cops_rails.md
@@ -432,43 +432,48 @@ Enabled by default | Supports autocorrection
 --- | ---
 Disabled | Yes
 
-This cop converts usages of `try!` to `&.`. It can also be configured
-to convert `try`. It will convert code to use safe navigation if the
-target Ruby version is set to 2.3+
+This cop transforms usages of a method call safeguarded by a non `nil`
+check for the variable whose method is being called to
+safe navigation (`&.`).
+
+Configuration option: ConvertCodeThatCanStartToReturnNil
+The default for this is `false`. When configured to `true`, this will
+check for code in the format `!foo.nil? && foo.bar`. As it is written,
+the return of this code is limited to `false` and whatever the return
+of the method is. If this is converted to safe navigation,
+`foo&.bar` can start returning `nil` as well as what the method
+returns.
 
 ### Example
 
 ```ruby
-# ConvertTry: false
-  # bad
-  foo.try!(:bar)
-  foo.try!(:bar, baz)
-  foo.try!(:bar) { |e| e.baz }
+# bad
+foo.bar if foo
+foo.bar(param1, param2) if foo
+foo.bar { |e| e.something } if foo
+foo.bar(param) { |e| e.something } if foo
 
-  foo.try!(:[], 0)
+foo.bar if !foo.nil?
+foo.bar unless !foo
+foo.bar unless foo.nil?
 
-  # good
-  foo.try(:bar)
-  foo.try(:bar, baz)
-  foo.try(:bar) { |e| e.baz }
+foo && foo.bar
+foo && foo.bar(param1, param2)
+foo && foo.bar { |e| e.something }
+foo && foo.bar(param) { |e| e.something }
 
-  foo&.bar
-  foo&.bar(baz)
-  foo&.bar { |e| e.baz }
+# good
+foo&.bar
+foo&.bar(param1, param2)
+foo&.bar { |e| e.something }
+foo&.bar(param) { |e| e.something }
 
-# ConvertTry: true
-  # bad
-  foo.try!(:bar)
-  foo.try!(:bar, baz)
-  foo.try!(:bar) { |e| e.baz }
-  foo.try(:bar)
-  foo.try(:bar, baz)
-  foo.try(:bar) { |e| e.baz }
+foo.nil? || foo.bar
+!foo || foo.bar
 
-  # good
-  foo&.bar
-  foo&.bar(baz)
-  foo&.bar { |e| e.baz }
+# Methods that `nil` will `respond_to?` should not be converted to
+# use safe navigation
+foo.to_i if foo
 ```
 
 ### Important attributes

--- a/manual/cops_style.md
+++ b/manual/cops_style.md
@@ -1111,7 +1111,7 @@ end
 Attribute | Value
 --- | ---
 EnforcedStyle | no_empty_lines
-SupportedStyles | empty_lines, empty_lines_except_namespace, no_empty_lines
+SupportedStyles | empty_lines, empty_lines_except_namespace, empty_lines_special, no_empty_lines
 
 
 ## Style/EmptyLinesAroundMethodBody
@@ -1180,7 +1180,7 @@ end
 Attribute | Value
 --- | ---
 EnforcedStyle | no_empty_lines
-SupportedStyles | empty_lines, empty_lines_except_namespace, no_empty_lines
+SupportedStyles | empty_lines, empty_lines_except_namespace, empty_lines_special, no_empty_lines
 
 
 ## Style/EmptyLiteral
@@ -3697,43 +3697,48 @@ Enabled by default | Supports autocorrection
 --- | ---
 Enabled | Yes
 
-This cop converts usages of `try!` to `&.`. It can also be configured
-to convert `try`. It will convert code to use safe navigation if the
-target Ruby version is set to 2.3+
+This cop transforms usages of a method call safeguarded by a non `nil`
+check for the variable whose method is being called to
+safe navigation (`&.`).
+
+Configuration option: ConvertCodeThatCanStartToReturnNil
+The default for this is `false`. When configured to `true`, this will
+check for code in the format `!foo.nil? && foo.bar`. As it is written,
+the return of this code is limited to `false` and whatever the return
+of the method is. If this is converted to safe navigation,
+`foo&.bar` can start returning `nil` as well as what the method
+returns.
 
 ### Example
 
 ```ruby
-# ConvertTry: false
-  # bad
-  foo.try!(:bar)
-  foo.try!(:bar, baz)
-  foo.try!(:bar) { |e| e.baz }
+# bad
+foo.bar if foo
+foo.bar(param1, param2) if foo
+foo.bar { |e| e.something } if foo
+foo.bar(param) { |e| e.something } if foo
 
-  foo.try!(:[], 0)
+foo.bar if !foo.nil?
+foo.bar unless !foo
+foo.bar unless foo.nil?
 
-  # good
-  foo.try(:bar)
-  foo.try(:bar, baz)
-  foo.try(:bar) { |e| e.baz }
+foo && foo.bar
+foo && foo.bar(param1, param2)
+foo && foo.bar { |e| e.something }
+foo && foo.bar(param) { |e| e.something }
 
-  foo&.bar
-  foo&.bar(baz)
-  foo&.bar { |e| e.baz }
+# good
+foo&.bar
+foo&.bar(param1, param2)
+foo&.bar { |e| e.something }
+foo&.bar(param) { |e| e.something }
 
-# ConvertTry: true
-  # bad
-  foo.try!(:bar)
-  foo.try!(:bar, baz)
-  foo.try!(:bar) { |e| e.baz }
-  foo.try(:bar)
-  foo.try(:bar, baz)
-  foo.try(:bar) { |e| e.baz }
+foo.nil? || foo.bar
+!foo || foo.bar
 
-  # good
-  foo&.bar
-  foo&.bar(baz)
-  foo&.bar { |e| e.baz }
+# Methods that `nil` will `respond_to?` should not be converted to
+# use safe navigation
+foo.to_i if foo
 ```
 
 ### Important attributes


### PR DESCRIPTION
This is a simple addition to the `generate_cops_documentation` task which will use `git diff` to fail the build on CI if documentation is not in sync. I've included an update to the manual directory in this PR since it seems to be out of sync currently.

I have changed the YARD rake task to be a mandatory prerequisite. The task depends on `YARD::Registry.load!` which loads YARD information from the .yardoc/ directory. This conditional running of YARD is part of why the manual documentation seems to be frequently out of sync. Even if you remember to run the rake task, your YARD documentation cache might still be out of sync with your recent changes. Therefore, all manual generation should be preceded by an update of they YARD cache.

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Used the same coding conventions as the rest of the project.
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* ~~Added tests.~~ There are no tests for this rake task
* [x] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] All tests are passing.
* [x] The new code doesn't generate RuboCop offenses.
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Updated cop documentation with `rake generate_cops_documentation` (required only when you've added a new cop or changed the configuration/documentation of an existing cop).

[1]: http://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html
