### PR TITLE
Move jruby first in travis matrix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,13 +3,13 @@ cache: bundler
 language: ruby
 matrix:
   include:
+     - rvm: jruby-9.0.1.0
+       env: JRUBY_OPTS='--debug' # get more accurate coverage data
      - rvm: 2.0.0
      - rvm: 2.1.10
      - rvm: 2.2.5
      - rvm: 2.3.1
      - rvm: ruby-head
-     - rvm: jruby-9.0.1.0
-       env: JRUBY_OPTS='--debug' # get more accurate coverage data
      - rvm: rbx-3
   allow_failures:
     - rvm: ruby-head


### PR DESCRIPTION
The jruby build takes the longest to run but is usually started last in the build. Many builds will run the first four tasks in parallel. All MRI tasks take about 8 minutes while jruby takes about 18 minutes. Starting with jruby first should hopefully reduce the build matrix time from 25 minutes to about 20 minutes.

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Used the same coding conventions as the rest of the project.
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] All tests are passing.
* [x] The new code doesn't generate RuboCop offenses.
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Updated cop documentation with `rake generate_cops_documentation` (required only when you've added a new cop or changed the configuration/documentation of an existing cop).

[1]: http://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html

The jruby build takes the longest to run but is usually started
last in the build. Many builds will run the first four tasks in
parallel. All MRI tasks take about 8 minutes while jruby takes
about 18 minutes. Starting with jruby first should hopefully reduce
the build matrix time from 25 minutes to about 20 minutes.