### PR TITLE
[Fix #3696] modified empty_when lint to not warn when branches with body as comments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@
 
 * [#3662](https://github.com/bbatsov/rubocop/issues/3662): Fix the auto-correction of `Lint/UnneededSplatExpansion` when the splat expansion is inside of another array. ([@rrosenblum][])
 * [#3699](https://github.com/bbatsov/rubocop/issues/3699): Fix false positive in `Style/VariableNumber` on variable names ending with an underscore. ([@bquorning][])
+* [#3696](https://github.com/bbatsov/rubocop/issues/3696): Fix to avoid warning `when` branches without a body if it has comments. ([@hanumakanthvvn][])
 
 ## 0.45.0 (2016-10-31)
 
@@ -2492,3 +2493,4 @@
 [@iGEL]: https://github.com/iGEL
 [@tessi]: https://github.com/tessi
 [@ivanovaleksey]: https://github.com/ivanovaleksey
+[@hanumakanthvvn]: https://github.com/hanumakanthvvn

--- a/lib/rubocop/cop/lint/empty_when.rb
+++ b/lib/rubocop/cop/lint/empty_when.rb
@@ -15,6 +15,10 @@ module RuboCop
       class EmptyWhen < Cop
         MSG = 'Avoid `when` branches without a body.'.freeze
 
+        def investigate(processed_source)
+          @processed_source = processed_source
+        end
+
         def on_case(node)
           _cond_node, *when_nodes, _else_node = *node
 

--- a/lib/rubocop/cop/lint/empty_when.rb
+++ b/lib/rubocop/cop/lint/empty_when.rb
@@ -15,6 +15,10 @@ module RuboCop
       class EmptyWhen < Cop
         MSG = 'Avoid `when` branches without a body.'.freeze
 
+        def investigate(processed_source)
+          @processed_source = processed_source
+        end
+
         def on_case(node)
           _cond_node, *when_nodes, _else_node = *node
 
@@ -27,12 +31,12 @@ module RuboCop
 
         def check_when(when_node)
           return unless empty_when_body?(when_node)
-
           add_offense(when_node, when_node.source_range, MSG)
         end
 
         def empty_when_body?(when_node)
-          !when_node.to_a.last
+          node_comment = @processed_source[when_node.loc.first_line]
+          !(when_node.to_a.last || comment_line?(node_comment))
         end
       end
     end

--- a/lib/rubocop/cop/lint/empty_when.rb
+++ b/lib/rubocop/cop/lint/empty_when.rb
@@ -15,10 +15,6 @@ module RuboCop
       class EmptyWhen < Cop
         MSG = 'Avoid `when` branches without a body.'.freeze
 
-        def investigate(processed_source)
-          @processed_source = processed_source
-        end
-
         def on_case(node)
           _cond_node, *when_nodes, _else_node = *node
 

--- a/spec/rubocop/cop/lint/empty_when_spec.rb
+++ b/spec/rubocop/cop/lint/empty_when_spec.rb
@@ -44,45 +44,43 @@ describe RuboCop::Cop::Lint::EmptyWhen, :config do
     it_behaves_like 'code with offense',
                     ['case foo',
                      'when :bar then 1',
-                     'when :baz # nothing',
-                     'end'].join("\n")
-
-    it_behaves_like 'code with offense',
-                    ['case foo',
-                     'when :bar then 1',
-                     'when :baz # nothing',
-                     'else 3',
-                     'end'].join("\n")
-
-    it_behaves_like 'code with offense',
-                    ['case foo',
-                     'when :bar then 1',
-                     'when :baz then # nothing',
-                     'end'].join("\n")
-
-    it_behaves_like 'code with offense',
-                    ['case foo',
-                     'when :bar then 1',
-                     'when :baz then # nothing',
-                     'else 3',
-                     'end'].join("\n")
-
-    it_behaves_like 'code with offense',
-                    ['case foo',
-                     'when :bar',
-                     '  1',
                      'when :baz',
-                     '  # nothing',
                      'end'].join("\n")
 
     it_behaves_like 'code with offense',
                     ['case foo',
-                     'when :bar',
-                     '  1',
-                     'when :baz',
-                     '  # nothing',
+                     'when :bar then 1',
+                     'when :baz # nothing',
                      'else',
-                     '  3',
+                     'end'].join("\n")
+
+    it_behaves_like 'code with offense',
+                    ['case foo',
+                     'when :bar then 1',
+                     'when :baz then',
+                     'end'].join("\n")
+
+    it_behaves_like 'code with offense',
+                    ['case foo',
+                     'when :bar then 1',
+                     'when :baz then',
+                     'else 3',
+                     'end'].join("\n")
+
+    it_behaves_like 'code with offense',
+                    ['case foo',
+                     'when :bar',
+                     '  1',
+                     'when :baz',
+                     'end'].join("\n")
+
+    it_behaves_like 'code with offense',
+                    ['case foo',
+                     'when :bar',
+                     '  1',
+                     'when :baz',
+                     '  ',
+                     'else',
                      'end'].join("\n")
 
     it_behaves_like 'code with offense',
@@ -90,7 +88,6 @@ describe RuboCop::Cop::Lint::EmptyWhen, :config do
                      'when :bar',
                      '  1',
                      'when :baz',
-                     '  # nothing',
                      'else',
                      '  3',
                      'end'].join("\n")
@@ -133,6 +130,15 @@ describe RuboCop::Cop::Lint::EmptyWhen, :config do
                      '  1',
                      'when :baz',
                      '  2',
+                     'else',
+                     '  3',
+                     'end'].join("\n")
+    it_behaves_like 'code without offense',
+                    ['case',
+                     'when :bar',
+                     '  1',
+                     'when :baz',
+                     '  # nothing',
                      'else',
                      '  3',
                      'end'].join("\n")

--- a/spec/rubocop/cop/lint/empty_when_spec.rb
+++ b/spec/rubocop/cop/lint/empty_when_spec.rb
@@ -50,13 +50,6 @@ describe RuboCop::Cop::Lint::EmptyWhen, :config do
     it_behaves_like 'code with offense',
                     ['case foo',
                      'when :bar then 1',
-                     'when :baz # nothing',
-                     'else',
-                     'end'].join("\n")
-
-    it_behaves_like 'code with offense',
-                    ['case foo',
-                     'when :bar then 1',
                      'when :baz then',
                      'end'].join("\n")
 
@@ -138,6 +131,16 @@ describe RuboCop::Cop::Lint::EmptyWhen, :config do
                      'when :bar',
                      '  1',
                      'when :baz',
+                     '  # nothing',
+                     'else',
+                     '  3',
+                     'end'].join("\n")
+    it_behaves_like 'code without offense',
+                    ['case',
+                     'when :bar',
+                     '  1',
+                     'when :baz',
+                     '',
                      '  # nothing',
                      'else',
                      '  3',

--- a/spec/rubocop/cop/lint/empty_when_spec.rb
+++ b/spec/rubocop/cop/lint/empty_when_spec.rb
@@ -50,13 +50,6 @@ describe RuboCop::Cop::Lint::EmptyWhen, :config do
     it_behaves_like 'code with offense',
                     ['case foo',
                      'when :bar then 1',
-                     'when :baz # nothing',
-                     'else',
-                     'end'].join("\n")
-
-    it_behaves_like 'code with offense',
-                    ['case foo',
-                     'when :bar then 1',
                      'when :baz then',
                      'end'].join("\n")
 

--- a/spec/rubocop/cop/lint/empty_when_spec.rb
+++ b/spec/rubocop/cop/lint/empty_when_spec.rb
@@ -50,6 +50,13 @@ describe RuboCop::Cop::Lint::EmptyWhen, :config do
     it_behaves_like 'code with offense',
                     ['case foo',
                      'when :bar then 1',
+                     'when :baz # nothing',
+                     'else',
+                     'end'].join("\n")
+
+    it_behaves_like 'code with offense',
+                    ['case foo',
+                     'when :bar then 1',
                      'when :baz then',
                      'end'].join("\n")
 


### PR DESCRIPTION
**Modified empty_when lint to not warn when branches with body as comments**

-----------------

Before submitting the PR make sure the following are checked:

- [x] Wrote [good commit messages][1].
- [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
- [x] Used the same coding conventions as the rest of the project.
- [x] Feature branch is up-to-date with `master` (if not - rebase it).
- [x] Squashed related commits together.
- [x] Added tests.
- [x] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
- [x] All tests are passing.
- [x] The new code doesn't generate RuboCop offenses.
- [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [ ] Updated cop documentation with `rake generate_cops_documentation` (required only when you've added a new cop or changed the configuration/documentation of an existing cop).

[1]: http://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html

…ody has comments