### PR TITLE
[Fix #3687] TernaryParentheses claims to correct uncorrected offenses

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@
 
 * [#3662](https://github.com/bbatsov/rubocop/issues/3662): Fix the auto-correction of `Lint/UnneededSplatExpansion` when the splat expansion is inside of another array. ([@rrosenblum][])
 * [#3699](https://github.com/bbatsov/rubocop/issues/3699): Fix false positive in `Style/VariableNumber` on variable names ending with an underscore. ([@bquorning][])
+* [#3687](https://github.com/bbatsov/rubocop/issues/3687): Fix the fact that `Style/TernaryParentheses` cop claims to correct uncorrected offenses. ([@Ana06][])
 
 ## 0.45.0 (2016-10-31)
 
@@ -2493,3 +2494,4 @@
 [@iGEL]: https://github.com/iGEL
 [@tessi]: https://github.com/tessi
 [@ivanovaleksey]: https://github.com/ivanovaleksey
+[@Ana06]: https://github.com/Ana06

--- a/lib/rubocop/cop/style/ternary_parentheses.rb
+++ b/lib/rubocop/cop/style/ternary_parentheses.rb
@@ -61,16 +61,16 @@ module RuboCop
         def autocorrect(node)
           condition, = *node
 
+          return nil if !require_parentheses? && (safe_assignment?(condition) ||
+                        unsafe_autocorrect?(condition))
+
           lambda do |corrector|
             if require_parentheses?
               corrector.insert_before(condition.source_range, '(')
               corrector.insert_after(condition.source_range, ')')
             else
-              unless safe_assignment?(condition) ||
-                     unsafe_autocorrect?(condition)
-                corrector.remove(condition.loc.begin)
-                corrector.remove(condition.loc.end)
-              end
+              corrector.remove(condition.loc.begin)
+              corrector.remove(condition.loc.end)
             end
           end
         end


### PR DESCRIPTION
`Style/TernaryParentheses` cop claims to correct uncorrected offenses (safe assignment or unsafe autocorrection). :relieved:

When `safe_assignment?(condition)` or `unsafe_autocorrect?(condition)` are `true`, the function `autocorrect()` still returns a `lambda,` so it is not marked as `:uncorrected` in https://github.com/bbatsov/rubocop/blob/master/lib/rubocop/cop/cop.rb#L197 although nothing has been corrected.
