### PR TITLE
Respect DisabledByDefault in parent configs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 * [#3624](https://github.com/bbatsov/rubocop/pull/3624): Add new configuration option `empty_lines_special` to `Style/EmptyLinesAroundClassBody` and `Style/EmptyLinesAroundModuleBody`. ([@legendetm][])
 * Add new `Style/EmptyMethod` cop. ([@drenmi][])
 * `Style/EmptyLiteral` will now auto-correct `Hash.new` when it is the first argument being passed to a method. The arguments will be wrapped with parenthesis. ([@rrosenblum][])
+* [#3713](https://github.com/bbatsov/rubocop/pull/3713): Respect `DisabledByDefault` in parent configs. ([@aroben][])
 
 ### Changes
 
@@ -2495,3 +2496,4 @@
 [@tessi]: https://github.com/tessi
 [@ivanovaleksey]: https://github.com/ivanovaleksey
 [@Ana06]: https://github.com/Ana06
+[@aroben]: https://github.com/aroben

--- a/lib/rubocop/config.rb
+++ b/lib/rubocop/config.rb
@@ -151,16 +151,6 @@ module RuboCop
       for_cop(cop).empty? || for_cop(cop)['Enabled']
     end
 
-    def add_missing_namespaces
-      keys.each do |k|
-        q = Cop::Cop.qualified_cop_name(k, loaded_path)
-        next if q == k
-
-        self[q] = self[k]
-        delete(k)
-      end
-    end
-
     def validate
       # Don't validate RuboCop's own files. Avoids infinite recursion.
       base_config_path = File.expand_path(File.join(ConfigLoader::RUBOCOP_HOME,

--- a/spec/rubocop/config_loader_spec.rb
+++ b/spec/rubocop/config_loader_spec.rb
@@ -109,6 +109,22 @@ describe RuboCop::ConfigLoader do
       end
     end
 
+    context 'when a parent file specifies DisabledByDefault: true' do
+      let(:file_path) { '.rubocop.yml' }
+
+      before do
+        create_file('disable.yml',
+                    ['AllCops:',
+                     '  DisabledByDefault: true'])
+
+        create_file(file_path, ['inherit_from: disable.yml'])
+      end
+
+      it 'disables cops by default' do
+        expect(configuration_from_file['Style/Alias']['Enabled']).to eql(false)
+      end
+    end
+
     context 'when a file inherits from a parent file' do
       let(:file_path) { 'dir/.rubocop.yml' }
 


### PR DESCRIPTION
d956705defbe85037bd0c2dd8ec5ab0ee4398985 changed `Config` initialization such that `Config#deprecation_check` was called before resolving inheritance. `Config#deprecation_check` causes `Config#for_all_cops` to be lazily initialized to a new hash disconnected from `Config`'s primary hash. `Config#for_all_cops` would thus not reflect any settings inherited from parent configs.

Essentially, it's an error for `Config#for_all_cops` to be called before inheritance is resolved. Perhaps this code could be made more robust. For now I've just rearranged config initialization such that things happen in the same order as prior to d956705defbe85037bd0c2dd8ec5ab0ee4398985.

/cc @NickLaMuro 

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Used the same coding conventions as the rest of the project.
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] All tests are passing.
* [x] The new code doesn't generate RuboCop offenses.
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Updated cop documentation with `rake generate_cops_documentation` (required only when you've added a new cop or changed the configuration/documentation of an existing cop).

[1]: http://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html
