### PR TITLE
Fix incorrect regexp for checking cop's messages

### DIFF
--- a/spec/project_spec.rb
+++ b/spec/project_spec.rb
@@ -33,7 +33,7 @@ describe 'RuboCop Project' do
         rescue NameError
           next
         end
-        expect(msg).to match(/\.|\?|(?:\[.+\])|%s$/)
+        expect(msg).to match(/(?:[.?]|(?:\[.+\])|%s)$/)
       end
     end
   end


### PR DESCRIPTION
Currently, a regexp for checking cop's messages is incorrect.
The regexp should check messages *ends* with `.`, `?`, `[...]` or `%s`. However it checks *contains*.
https://github.com/bbatsov/rubocop/pull/3589#pullrequestreview-8317190


For example

```ruby
bad_re  = /\.|\?|(?:\[.+\])|%s$/
good_re = /(?:[.?]|(?:\[.+\])|%s)$/

p bad_re  =~ 'foo.bar' # => 3
p good_re =~ 'foo.bar' # => nil

p bad_re  =~ 'foobar.' # => 6
p good_re =~ 'foobar.' # => 6

p bad_re  =~ 'foo?bar' # => 3
p good_re =~ 'foo?bar' # => nil

p bad_re  =~ 'foobar?' # => 6
p good_re =~ 'foobar?' # => 6

p bad_re  =~ 'foobar[%.4g/%.4g]' # => 6
p good_re =~ 'foobar[%.4g/%.4g]' # => 6
```



Thanks @jonas054 !


-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Used the same coding conventions as the rest of the project.
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [ ] Added tests.
* [ ] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] All tests are passing.
* [x] The new code doesn't generate RuboCop offenses.
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [ ] Updated cop documentation with `rake generate_cops_documentation` (required only when you've added a new cop or changed the configuration/documentation of an existing cop).

[1]: http://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html

