### PR TITLE
Fix Style/IndentationWidth errors when using start_of_line Lint/EndAlignment

### DIFF
--- a/lib/rubocop/cop/mixin/end_keyword_alignment.rb
+++ b/lib/rubocop/cop/mixin/end_keyword_alignment.rb
@@ -49,7 +49,7 @@ module RuboCop
       end
 
       def variable_alignment?(whole_expression, rhs, end_alignment_style)
-        end_alignment_style == :variable &&
+        [:start_of_line, :variable].include?(end_alignment_style) &&
           !line_break_before_keyword?(whole_expression, rhs)
       end
 

--- a/spec/rubocop/cop/style/indentation_width_spec.rb
+++ b/spec/rubocop/cop/style/indentation_width_spec.rb
@@ -596,6 +596,38 @@ describe RuboCop::Cop::Style::IndentationWidth do
 
           include_examples 'assignment and if with keyword alignment'
         end
+
+        context 'when alignment style is start_of_line' do
+          let(:end_alignment_config) do
+            { 'Enabled' => true, 'AlignWith' => 'start_of_line' }
+          end
+
+          it 'accepts an if' do
+            inspect_source(cop,
+                           ['var = if a',
+                            '  0',
+                            'end'])
+            expect(cop.offenses).to be_empty
+          end
+
+          it 'accepts a while' do
+            inspect_source(cop,
+                           ['var = while a',
+                            '  b',
+                            'end'])
+            expect(cop.offenses).to be_empty
+          end
+
+          it 'accepts an if/else' do
+            inspect_source(cop,
+                           ['var = if a',
+                            '  0',
+                            'else',
+                            '  1',
+                            'end'])
+            expect(cop.offenses).to be_empty
+          end
+        end
       end
 
       it 'accepts an if/else branches with rescue clauses' do


### PR DESCRIPTION
With the following configuration:

```yaml
Style/IndentationWidth:
  Enabled: true
Lint/EndAlignment:
  Enabled: true
  AlignWith: start_of_line
```

```ruby
# this
result = if some_cond
  calc_something
else
  calc_something_else
end

# get autocorrect to this
result = if some_cond
           calc_something
else
  calc_something_else
end
```

These changes will leave it in the first form, if the `Lint/EndAlignment`'s `AlignWith` is set to `start_of_line`.

-----------------

Before submitting the PR make sure the following are checked:

* [ ] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Used the same coding conventions as the rest of the project.
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [ ] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] All tests are passing.
* [x] The new code doesn't generate RuboCop offenses.
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [ ] Updated cop documentation with `rake generate_cops_documentation` (required only when you've added a new cop or changed the configuration/documentation of an existing cop).

[1]: http://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html
