### PR TITLE
Fix link

### DIFF
--- a/config/enabled.yml
+++ b/config/enabled.yml
@@ -602,7 +602,7 @@ Style/ParenthesesAroundCondition:
   Description: >-
                  Don't use parentheses around the condition of an
                  if/unless/while.
-  StyleGuide: '#no-parens-if'
+  StyleGuide: '#no-parens-around-condition'
   Enabled: true
 
 Style/PercentLiteralDelimiters:


### PR DESCRIPTION
Style/ParenthesesAroundCondition cop has broken link to ruby style guide.
