### PR TITLE
Remove memoization in Config#for_all_cops

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@
 * [#3568](https://github.com/bbatsov/rubocop/issues/3568): Fix `--auto-gen-config` behavior for `Style/VariableNumber`. ([@jonas054][])
 * Add `format` as an acceptable keyword argument for `Rails/HttpPositionalArguments`. ([@aesthetikx][])
 * [#3598](https://github.com/bbatsov/rubocop/issues/3598): In `Style/NumericPredicate`, don't report `x != 0` or `x.nonzero?` as the expressions have different values. ([@jonas054][])
+* Fix config inheritance of `AllCops`. ([@volmer][])
 
 ## 0.45.0 (2016-10-31)
 

--- a/lib/rubocop/config.rb
+++ b/lib/rubocop/config.rb
@@ -138,7 +138,7 @@ module RuboCop
     end
 
     def for_all_cops
-      @for_all_cops ||= self['AllCops'] || {}
+      self['AllCops'] || {}
     end
 
     def cop_enabled?(cop)

--- a/spec/rubocop/config_spec.rb
+++ b/spec/rubocop/config_spec.rb
@@ -509,4 +509,28 @@ describe RuboCop::Config do
       end
     end
   end
+
+  describe '#for_all_cops' do
+    let(:hash) do
+      { 'AllCops' => { 'UseCache' => true } }
+    end
+
+    it 'returns AllCops' do
+      expect(configuration.for_all_cops).to eq('UseCache' => true)
+    end
+
+    context 'when AllCops is not present in the hash' do
+      let(:hash) { {} }
+
+      it 'is an empty hash' do
+        expect(configuration.for_all_cops).to eq({})
+      end
+
+      it 'returns AllCops on later assignment' do
+        expect(configuration.for_all_cops).to eq({})
+        configuration['AllCops'] = { 'UseCache' => true }
+        expect(configuration.for_all_cops).to eq('UseCache' => true)
+      end
+    end
+  end
 end


### PR DESCRIPTION
Sometimes a `Config` instance has its internal hash mutated, and changes on `AllCops` don't get reflected in `#for_all_cops` due to its memoization.

This problem doesn't happen when `AllCops` is set initially, but when `AllCops` is set afterwards `@for_all_cops` already got instantiated with an empty hash.

This issue is noticeable in [`ConfigLoaderResolver#resolve_inheritance`](https://github.com/bbatsov/rubocop/blob/master/lib/rubocop/config_loader_resolver.rb#L23), which mutates the config to merge the values coming from the parent configuration. When the parent config defines `AllCops` the values don't get used [in places that rely on `#for_all_cops`](https://github.com/bbatsov/rubocop/blob/master/lib/rubocop/config_loader.rb#L119).

I checked the git history and I didn't find any reason to have had that method memoized. I also run this change in a fairly large codebase and I didn't notice any noticeable performance decrease.