### PR TITLE
[Fix #3568] Detect style while handling offense in VariableNumber

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@
 * [#3662](https://github.com/bbatsov/rubocop/issues/3662): Fix the auto-correction of `Lint/UnneededSplatExpansion` when the splat expansion is inside of another array. ([@rrosenblum][])
 * [#3699](https://github.com/bbatsov/rubocop/issues/3699): Fix false positive in `Style/VariableNumber` on variable names ending with an underscore. ([@bquorning][])
 * [#3687](https://github.com/bbatsov/rubocop/issues/3687): Fix the fact that `Style/TernaryParentheses` cop claims to correct uncorrected offenses. ([@Ana06][])
+* [#3568](https://github.com/bbatsov/rubocop/issues/3568): Fix `--auto-gen-config` behavior for `Style/VariableNumber`. ([@jonas054][])
 
 ## 0.45.0 (2016-10-31)
 

--- a/lib/rubocop/cop/mixin/configurable_numbering.rb
+++ b/lib/rubocop/cop/mixin/configurable_numbering.rb
@@ -14,16 +14,23 @@ module RuboCop
       def check_name(node, name, name_range)
         return if operator?(name)
 
-        if valid_name?(node, name)
+        if valid_name?(node, name, style)
           correct_style_detected
         else
-          add_offense(node, name_range, message(style))
+          add_offense(node, name_range, message(style)) do
+            (supported_styles - [style]).each do |other_style|
+              if valid_name?(node, name, other_style)
+                unexpected_style_detected(other_style)
+                break
+              end
+            end
+          end
         end
       end
 
-      def valid_name?(node, name)
+      def valid_name?(node, name, given_style)
         pattern =
-          case style
+          case given_style
           when :snake_case
             SNAKE_CASE
           when :normalcase


### PR DESCRIPTION
When the variable name doesn't match the configured style, we should detect which style is used so that the right information is generated in `.rubocop_todo.yml`.