### PR TITLE
Configure Travis to automatically test against the latest revisions of Ruby versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,10 +5,10 @@ matrix:
   include:
      - rvm: jruby-9.0.1.0
        env: JRUBY_OPTS='--debug' # get more accurate coverage data
-     - rvm: 2.0.0
-     - rvm: 2.1.10
-     - rvm: 2.2.5
-     - rvm: 2.3.1
+     - rvm: 2.0
+     - rvm: 2.1
+     - rvm: 2.2
+     - rvm: 2.3
      - rvm: ruby-head
      - rvm: rbx-3
   allow_failures:


### PR DESCRIPTION
By not specifying a revision number, Travis is supposed to test against the latest revision. This way we don't have to update the configuration every time a new revision is released.