### PR TITLE
[Fix #3690] Allow multiline content inside of braces

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@
 * [#3568](https://github.com/bbatsov/rubocop/issues/3568): Fix `--auto-gen-config` behavior for `Style/VariableNumber`. ([@jonas054][])
 * Add `format` as an acceptable keyword argument for `Rails/HttpPositionalArguments`. ([@aesthetikx][])
 * [#3598](https://github.com/bbatsov/rubocop/issues/3598): In `Style/NumericPredicate`, don't report `x != 0` or `x.nonzero?` as the expressions have different values. ([@jonas054][])
+* [#3690](https://github.com/bbatsov/rubocop/issues/3690): Do not register an offense for multiline braces with content in `Style/SpaceInsideBlockBraces`. ([@rrosenblum][])
 
 ## 0.45.0 (2016-10-31)
 

--- a/lib/rubocop/cop/style/space_inside_block_braces.rb
+++ b/lib/rubocop/cop/style/space_inside_block_braces.rb
@@ -54,7 +54,7 @@ module RuboCop
         end
 
         def check_left_brace(inner, left_brace, args_delimiter)
-          if inner =~ /^\S/
+          if inner =~ /\A\S/
             no_space_inside_left_brace(left_brace, args_delimiter)
           else
             space_inside_left_brace(left_brace, args_delimiter)

--- a/spec/rubocop/cop/style/space_inside_block_braces_spec.rb
+++ b/spec/rubocop/cop/style/space_inside_block_braces_spec.rb
@@ -19,13 +19,24 @@ describe RuboCop::Cop::Style::SpaceInsideBlockBraces, :config do
 
     it 'accepts empty braces with no space inside' do
       inspect_source(cop, 'each {}')
-      expect(cop.messages).to be_empty
+      expect(cop.offenses).to be_empty
+    end
+
+    it 'accepts braces with something inside' do
+      inspect_source(cop, 'each { "f" }')
+      expect(cop.offenses).to be_empty
+    end
+
+    it 'accepts multiline braces with content' do
+      inspect_source(cop, ['each { %(',
+                           ') }'])
+      expect(cop.offenses).to be_empty
     end
 
     it 'accepts empty braces with comment and line break inside' do
       inspect_source(cop, ['  each { # Comment',
                            '  }'])
-      expect(cop.messages).to be_empty
+      expect(cop.offenses).to be_empty
     end
 
     it 'registers an offense for empty braces with line break inside' do
@@ -62,7 +73,7 @@ describe RuboCop::Cop::Style::SpaceInsideBlockBraces, :config do
 
     it 'accepts empty braces with space inside' do
       inspect_source(cop, 'each { }')
-      expect(cop.messages).to be_empty
+      expect(cop.offenses).to be_empty
     end
 
     it 'registers an offense for empty braces with no space inside' do
@@ -88,13 +99,12 @@ describe RuboCop::Cop::Style::SpaceInsideBlockBraces, :config do
 
   it 'accepts braces surrounded by spaces' do
     inspect_source(cop, 'each { puts }')
-    expect(cop.messages).to be_empty
-    expect(cop.highlights).to be_empty
+    expect(cop.offenses).to be_empty
   end
 
   it 'accepts left brace without outer space' do
     inspect_source(cop, 'each{ puts }')
-    expect(cop.highlights).to be_empty
+    expect(cop.offenses).to be_empty
   end
 
   it 'registers an offense for left brace without inner space' do
@@ -136,8 +146,7 @@ describe RuboCop::Cop::Style::SpaceInsideBlockBraces, :config do
     context 'for single-line blocks' do
       it 'accepts left brace with inner space' do
         inspect_source(cop, 'each { |x| puts }')
-        expect(cop.messages).to be_empty
-        expect(cop.highlights).to be_empty
+        expect(cop.offenses).to be_empty
       end
 
       it 'registers an offense for left brace without inner space' do
@@ -153,8 +162,7 @@ describe RuboCop::Cop::Style::SpaceInsideBlockBraces, :config do
         inspect_source(cop, ['each { |x|',
                              'puts',
                              '}'])
-        expect(cop.messages).to be_empty
-        expect(cop.highlights).to be_empty
+        expect(cop.offenses).to be_empty
       end
 
       it 'registers an offense for left brace without inner space' do
@@ -183,7 +191,7 @@ describe RuboCop::Cop::Style::SpaceInsideBlockBraces, :config do
 
     it 'accepts new lambda syntax' do
       inspect_source(cop, '->(x) { x }')
-      expect(cop.messages).to be_empty
+      expect(cop.offenses).to be_empty
     end
 
     it 'auto-corrects missing space' do
@@ -231,7 +239,7 @@ describe RuboCop::Cop::Style::SpaceInsideBlockBraces, :config do
 
       it 'accepts new lambda syntax' do
         inspect_source(cop, '->(x) { x }')
-        expect(cop.messages).to be_empty
+        expect(cop.offenses).to be_empty
       end
 
       it 'auto-corrects unwanted space' do
@@ -241,8 +249,7 @@ describe RuboCop::Cop::Style::SpaceInsideBlockBraces, :config do
 
       it 'accepts left brace without inner space' do
         inspect_source(cop, 'each {|x| puts }')
-        expect(cop.messages).to be_empty
-        expect(cop.highlights).to be_empty
+        expect(cop.offenses).to be_empty
       end
     end
   end
@@ -258,8 +265,7 @@ describe RuboCop::Cop::Style::SpaceInsideBlockBraces, :config do
 
     it 'accepts braces without spaces inside' do
       inspect_source(cop, 'each {puts}')
-      expect(cop.messages).to be_empty
-      expect(cop.highlights).to be_empty
+      expect(cop.offenses).to be_empty
     end
 
     it 'registers an offense for left brace with inner space' do
@@ -287,7 +293,7 @@ describe RuboCop::Cop::Style::SpaceInsideBlockBraces, :config do
 
     it 'accepts left brace without outer space' do
       inspect_source(cop, 'each {puts}')
-      expect(cop.highlights).to be_empty
+      expect(cop.offenses).to be_empty
     end
 
     it 'auto-corrects unwanted space' do
@@ -312,7 +318,7 @@ describe RuboCop::Cop::Style::SpaceInsideBlockBraces, :config do
 
         it 'accepts new lambda syntax' do
           inspect_source(cop, '->(x) {x}')
-          expect(cop.messages).to be_empty
+          expect(cop.offenses).to be_empty
         end
 
         it 'auto-corrects missing space' do
@@ -339,7 +345,7 @@ describe RuboCop::Cop::Style::SpaceInsideBlockBraces, :config do
 
         it 'accepts new lambda syntax' do
           inspect_source(cop, '->(x) {x}')
-          expect(cop.messages).to be_empty
+          expect(cop.offenses).to be_empty
         end
 
         it 'auto-corrects unwanted space' do


### PR DESCRIPTION
This fixes #3690. The issue here was that the code snippet should not have registered an offense in `Style/SpaceInsideBlockBraces`.  
```ruby
def x
  a b {
    %(
-
    )
  }
end
```

The reason that it was registering an offense was that `/^\S/` looks for a non-white space character at the beginning of the line. When the string that it checks against contains multiple lines (`\n`), it throws this check off. Changing the pattern to `/\A\S/` will look for a non-white space character only at the beginning of the string.
