### PR TITLE
Improve Rails/EnumUniqueness cop to also handle array duplicates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@
 * Add new `Style/EmptyMethod` cop. ([@drenmi][])
 * `Style/EmptyLiteral` will now auto-correct `Hash.new` when it is the first argument being passed to a method. The arguments will be wrapped with parenthesis. ([@rrosenblum][])
 * [#3713](https://github.com/bbatsov/rubocop/pull/3713): Respect `DisabledByDefault` in parent configs. ([@aroben][])
-* New cop `Rails/EnumUniqueness` checks for duplicate values defined in enum config hash. ([@olliebennett][])
+* New cop `Rails/EnumUniqueness` checks for duplicate values defined in enum config. ([@olliebennett][])
 
 ### Changes
 

--- a/lib/rubocop/cop/rails/enum_uniqueness.rb
+++ b/lib/rubocop/cop/rails/enum_uniqueness.rb
@@ -12,6 +12,9 @@ module RuboCop
       #   # good
       #   enum status: { active: 0, archived: 1 }
       #
+      #   # bad
+      #   enum status: [:active, :archived, :active]
+      #
       #   # good
       #   enum status: [:active, :archived]
       class EnumUniqueness < Cop
@@ -22,21 +25,33 @@ module RuboCop
 
           return unless method_name == :enum
 
-          enum_name, enum_opts = parse_args(args)
+          enum_name, enum_args = parse_args(args)
 
-          return if enum_opts.type == :array
-
-          enum_values = enum_opts.each_child_node.map do |child_node|
-            child_node.child_nodes.last.source
-          end
-
-          dupes = arr_dupes(enum_values)
+          dupes = arr_dupes(enum_values(enum_args))
           return if dupes.empty?
 
           add_offense(node, :selector, format(MSG, dupes.join(','), enum_name))
         end
 
         private
+
+        def enum_values(enum_args)
+          if enum_args.type == :array
+            enum_array_keys(enum_args)
+          else
+            enum_hash_values(enum_args)
+          end
+        end
+
+        def enum_array_keys(array_node)
+          array_node.each_child_node.map(&:source)
+        end
+
+        def enum_hash_values(hash_node)
+          hash_node.each_child_node.map do |child_node|
+            child_node.child_nodes.last.source
+          end
+        end
 
         def arr_dupes(array)
           array.select { |element| array.count(element) > 1 }.uniq

--- a/manual/cops_rails.md
+++ b/manual/cops_rails.md
@@ -181,6 +181,9 @@ enum status: { active: 0, archived: 0 }
 # good
 enum status: { active: 0, archived: 1 }
 
+# bad
+enum status: [:active, :archived, :active]
+
 # good
 enum status: [:active, :archived]
 ```

--- a/spec/rubocop/cop/rails/enum_uniqueness_spec.rb
+++ b/spec/rubocop/cop/rails/enum_uniqueness_spec.rb
@@ -6,14 +6,15 @@ describe RuboCop::Cop::Rails::EnumUniqueness, :config do
   subject(:cop) { described_class.new }
 
   context 'when array syntax is used' do
-    it 'does not register an offense' do
-      inspect_source(cop, 'enum status: [ :active, :archived ]')
+    it 'registers an offense for duplicate enum values' do
+      inspect_source(cop, 'enum status: [:active, :archived, :active]')
 
-      expect(cop.messages).to be_empty
+      msg = 'Duplicate value `:active` found in `status` enum declaration.'
+      expect(cop.messages).to eq([msg])
     end
 
-    it 'does not register an offense given additional enum configuration' do
-      inspect_source(cop, 'enum status: [:active, :archived], _suffix: true')
+    it 'does not register an offense for unique enum values' do
+      inspect_source(cop, 'enum status: [:active, :archived]')
 
       expect(cop.messages).to be_empty
     end
@@ -21,17 +22,9 @@ describe RuboCop::Cop::Rails::EnumUniqueness, :config do
 
   context 'when hash syntax is used' do
     it 'registers an offense for duplicate enum values' do
-      inspect_source(cop, 'enum status: { active: 4, archived: 4 }')
+      inspect_source(cop, 'enum status: { active: 0, archived: 0 }')
 
-      msg = 'Duplicate value `4` found in `status` enum declaration.'
-      expect(cop.messages).to eq([msg])
-    end
-
-    it 'registers an offense when given enum configuration' do
-      src = 'enum test_status: { x: 7, y: 7 }, _prefix: :test'
-      inspect_source(cop, src)
-
-      msg = 'Duplicate value `7` found in `test_status` enum declaration.'
+      msg = 'Duplicate value `0` found in `status` enum declaration.'
       expect(cop.messages).to eq([msg])
     end
 


### PR DESCRIPTION
An extension of the `Rails/EnumUniqueness` cop (see #3724) to additionally detect duplicate enum keys defined using array syntax.

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [ ] Used the same coding conventions as the rest of the project.
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [ ] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] All tests are passing.
* [x] The new code doesn't generate RuboCop offenses.
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Updated cop documentation with `rake generate_cops_documentation` (required only when you've added a new cop or changed the configuration/documentation of an existing cop).

[1]: http://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html

