### PR TITLE
Checks `binding.irb` call by `Lint/Debugger` cop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@
 
 * The offense range for `Performance/FlatMap` now includes any parameters that are passed to `flatten`. ([@rrosenblum][])
 * [#1747](https://github.com/bbatsov/rubocop/issues/1747): Update `Style/SpecialGlobalVars` messages with a reminder to `require 'English'`. ([@ivanovaleksey][])
+* Checks `binding.irb` call by `Lint/Debugger` cop. ([@pocke][])
 
 ### Bug fixes
 

--- a/lib/rubocop/cop/lint/debugger.rb
+++ b/lib/rubocop/cop/lint/debugger.rb
@@ -17,10 +17,14 @@ module RuboCop
                       :save_screenshot} ...)}
         END
 
+        def_node_matcher :binding_irb_call?, <<-END
+          (send (send nil :binding) :irb ...)
+        END
+
         def_node_matcher :pry_rescue?, '(send (const nil :Pry) :rescue ...)'
 
         def on_send(node)
-          return unless debugger_call?(node)
+          return unless debugger_call?(node) || binding_irb?(node)
           add_offense(node, :expression, format(MSG, node.source))
         end
 
@@ -37,6 +41,10 @@ module RuboCop
               corrector.remove(range)
             end
           end
+        end
+
+        def binding_irb?(node)
+          target_ruby_version >= 2.4 && binding_irb_call?(node)
         end
       end
     end

--- a/spec/rubocop/cop/lint/debugger_spec.rb
+++ b/spec/rubocop/cop/lint/debugger_spec.rb
@@ -2,8 +2,8 @@
 
 require 'spec_helper'
 
-describe RuboCop::Cop::Lint::Debugger do
-  subject(:cop) { described_class.new }
+describe RuboCop::Cop::Lint::Debugger, :config do
+  subject(:cop) { described_class.new(config) }
 
   include_examples 'debugger', 'debugger', 'debugger'
   include_examples 'debugger', 'byebug', 'byebug'
@@ -26,7 +26,7 @@ describe RuboCop::Cop::Lint::Debugger do
                     'save_screenshot foo']
   include_examples 'non-debugger', 'a non-pry binding', 'binding.pirate'
 
-  ALL_COMMANDS = %w(debugger byebug pry remote_pry pry_remote
+  ALL_COMMANDS = %w(debugger byebug pry remote_pry pry_remote irb
                     save_and_open_page save_and_open_screenshot
                     save_screenshot).freeze
 
@@ -50,5 +50,14 @@ describe RuboCop::Cop::Lint::Debugger do
     expect(new_source).to eq(['def method',
                               '  puts 1',
                               'end'].join("\n"))
+  end
+
+  context 'target_ruby_version >= 2.4', :ruby24 do
+    include_examples 'debugger', 'irb binding', 'binding.irb'
+
+    ALL_COMMANDS.each do |src|
+      include_examples 'non-debugger', "a #{src} in comments", "# #{src}"
+      include_examples 'non-debugger', "a #{src} method", "code.#{src}"
+    end
   end
 end


### PR DESCRIPTION
From Ruby 2.4, `binding.irb` will be added.
This method is like `binding.pry`.

- https://www.ruby-lang.org/en/news/2016/11/09/ruby-2-4-0-preview3-released/
- https://github.com/ruby/ruby/commit/493e48897421d176a8faf0f0820323d79ecdf94a

For example

```sh
$ cat test.rb
require 'irb'

foo = 1
binding.irb

$ ruby test.rb
irb(main):001:0> foo
=> 1
irb(main):002:0>
```

This PR adds detection of `binding.irb` as a debugger.

For example

```sh
$ rubocop
Inspecting 1 file
W

Offenses:

test.rb:4:1: W: Remove debugger entry point binding.irb.
binding.irb
^^^^^^^^^^^

1 file inspected, 1 offenses detected
```

The check works only Ruby 2.4 or higher.

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Used the same coding conventions as the rest of the project.
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] All tests are passing.
* [x] The new code doesn't generate RuboCop offenses.
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [ ] Updated cop documentation with `rake generate_cops_documentation` (required only when you've added a new cop or changed the configuration/documentation of an existing cop).

[1]: http://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html

