### PR TITLE
[Fix #3746] `Lint/NonLocalExitFromIterator` doesn't warn about block passed to `Object#define_singleton_method`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@
 * Add `format` as an acceptable keyword argument for `Rails/HttpPositionalArguments`. ([@aesthetikx][])
 * [#3598](https://github.com/bbatsov/rubocop/issues/3598): In `Style/NumericPredicate`, don't report `x != 0` or `x.nonzero?` as the expressions have different values. ([@jonas054][])
 * [#3690](https://github.com/bbatsov/rubocop/issues/3690): Do not register an offense for multiline braces with content in `Style/SpaceInsideBlockBraces`. ([@rrosenblum][])
+* [#3746](https://github.com/bbatsov/rubocop/issues/3746): `Lint/NonLocalExitFromIterator` does not warn about `return` in a block which is passed to `Object#define_singleton_method`. ([@AlexWayfer][])
 
 ## 0.45.0 (2016-10-31)
 
@@ -2511,3 +2512,4 @@
 [@olliebennett]: https://github.com/olliebennett
 [@aesthetikx]: https://github.com/aesthetikx
 [@tdeo]: https://github.com/tdeo
+[@AlexWayfer]: https://github.com/AlexWayfer

--- a/lib/rubocop/cop/lint/non_local_exit_from_iterator.rb
+++ b/lib/rubocop/cop/lint/non_local_exit_from_iterator.rb
@@ -6,7 +6,8 @@ module RuboCop
       # This cop checks for non-local exit from iterator, without return value.
       # It warns only when satisfies all of these: `return` doesn't have return
       # value, the block is preceded by a method chain, the block has arguments,
-      # and the method which receives the block is not `define_method`.
+      # and the method which receives the block is not `define_method`
+      # or `define_singleton_method`.
       #
       # @example
       #
@@ -44,8 +45,9 @@ module RuboCop
 
             # `return` does not exit to outside of lambda block, this is safe.
             break if block_node.lambda?
-            # if a proc is passed to `Module#define_method`, `return` will not
-            # cause a non-local exit error
+            # if a proc is passed to `Module#define_method` or
+            # `Object#define_singleton_method`, `return` will not cause a
+            # non-local exit error
             break if define_method?(send_node)
 
             next if args_node.children.empty?
@@ -67,7 +69,7 @@ module RuboCop
 
         def define_method?(send_node)
           _receiver, selector = *send_node
-          selector == :define_method
+          %i(define_method define_singleton_method).include? selector
         end
       end
     end

--- a/spec/rubocop/cop/lint/non_local_exit_from_iterator_spec.rb
+++ b/spec/rubocop/cop/lint/non_local_exit_from_iterator_spec.rb
@@ -162,5 +162,17 @@ describe RuboCop::Cop::Lint::NonLocalExitFromIterator do
 
       it { expect(cop.offenses).to be_empty }
     end
+
+    context 'when the message is define_singleton_method' do
+      let(:source) { <<-END }
+        str = 'foo'
+        str.define_singleton_method :bar do |baz|
+          return unless baz
+          replace baz
+        end
+      END
+
+      it { expect(cop.offenses).to be_empty }
+    end
   end
 end


### PR DESCRIPTION
`return`s don't cause problems in blocks passed to `define_singleton_method`.