### PR TITLE
Detect degenerated workarounds for Style/NumericLiterals

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@
 * [#3775](https://github.com/bbatsov/rubocop/pull/3775): Avoid crash in `Style/HashSyntax` cop with an empty hash. ([@pocke][])
 * [#3783](https://github.com/bbatsov/rubocop/pull/3783): Maintain parentheses in `Rails/HttpPositionalArguments` when methods are defined with them. ([@kevindew][])
 * [#3786](https://github.com/bbatsov/rubocop/pull/3786): Avoid crash `Style/ConditionalAssignment` cop with mass assign method. ([@pocke][])
+* [#3749](https://github.com/bbatsov/rubocop/pull/3749): Detect corner case of `Style/NumericLitterals`. ([@kamaradclimber][])
 
 ## 0.46.0 (2016-11-30)
 
@@ -2524,6 +2525,7 @@
 [@bronson]: https://github.com/bronson
 [@albus522]: https://github.com/albus522
 [@sihu]: https://github.com/sihu
+[@kamaradclimber]: https://github.com/kamaradclimber
 [@swcraig]: https://github.com/swcraig
 [@jessieay]: https://github.com/jessieay
 [@tiagocasanovapt]: https://github.com/tiagocasanovapt

--- a/lib/rubocop/cop/style/numeric_literals.rb
+++ b/lib/rubocop/cop/style/numeric_literals.rb
@@ -39,7 +39,7 @@ module RuboCop
           case int
           when /^\d+$/
             add_offense(node, :expression) { self.max = int.size + 1 }
-          when /\d{4}/, /_\d{1,2}_/
+          when /\d{4}/, /_\d{1,2}(_|$)/
             add_offense(node, :expression) do
               self.config_to_allow_offenses = { 'Enabled' => false }
             end

--- a/spec/rubocop/cop/style/numeric_literals_spec.rb
+++ b/spec/rubocop/cop/style/numeric_literals_spec.rb
@@ -19,8 +19,9 @@ describe RuboCop::Cop::Style::NumericLiterals, :config do
   end
 
   it 'registers an offense for an integer with misplaced underscore' do
-    inspect_source(cop, 'a = 123_456_78_90_00')
-    expect(cop.offenses.size).to eq(1)
+    inspect_source(cop, ['a = 123_456_78_90_00',
+                         'b = 819_2'])
+    expect(cop.offenses.size).to eq(2)
     expect(cop.config_to_allow_offenses).to eq('Enabled' => false)
   end
 


### PR DESCRIPTION
Users might be tempted to replace 8192 by 819_2 without
understanding the underscore as a thousand separator

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Used the same coding conventions as the rest of the project.
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] All tests are passing.
* [x] The new code doesn't generate RuboCop offenses.
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Updated cop documentation with `rake generate_cops_documentation` (required only when you've added a new cop or changed the configuration/documentation of an existing cop).

[1]: http://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html