### PR TITLE
[Fixes #3753] Change error message of `Bundler/OrderedGems`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 * [#3725](https://github.com/bbatsov/rubocop/issues/3725): Disable `Style/SingleLineBlockParams` by default. ([@tejasbubane][])
 * [#3765](https://github.com/bbatsov/rubocop/pull/3765): Add a validation for supported styles other than EnforcedStyle. `AlignWith`, `IndentWhenRelativeTo` and `EnforcedMode` configurations are renamed. ([@pocke][])
 * [#3782](https://github.com/bbatsov/rubocop/pull/3782): Add check for `add_reference` method by `Rails/NotNullColumn` cop. ([@pocke][])
+* [#3753](https://github.com/bbatsov/rubocop/issues/3753): Change error message of `Bundler/OrderedGems` to mention `Alphabetize Gems`. ([@tejasbubane][])
 
 ### Bug fixes
 

--- a/lib/rubocop/cop/bundler/ordered_gems.rb
+++ b/lib/rubocop/cop/bundler/ordered_gems.rb
@@ -17,7 +17,9 @@ module RuboCop
       #
       #   gem 'rspec'
       class OrderedGems < Cop
-        MSG = 'Gem `%s` should appear before `%s` in their gem group.'.freeze
+        MSG = 'Gems should be sorted in an alphabetical order within their '\
+              'section of the Gemfile. '\
+              'Gem `%s` should appear before `%s`.'.freeze
         def investigate(processed_source)
           return if processed_source.ast.nil?
           gem_declarations(processed_source.ast)

--- a/spec/rubocop/cop/bundler/ordered_gems_spec.rb
+++ b/spec/rubocop/cop/bundler/ordered_gems_spec.rb
@@ -28,10 +28,12 @@ describe RuboCop::Cop::Bundler::OrderedGems, :config do
       expect(cop.offenses.size).to eq(1)
     end
 
-    it 'mentions both gem names in message' do
+    it 'has the correct offense message' do
       inspect_source(cop, source)
-      expect(cop.offenses.first.message).to include('rspec')
-      expect(cop.offenses.first.message).to include('rubocop')
+      expect(cop.messages)
+        .to eq(['Gems should be sorted in an alphabetical '\
+                'order within their section of the Gemfile. '\
+                'Gem `rspec` should appear before `rubocop`.'])
     end
 
     it 'highlights the second gem' do


### PR DESCRIPTION
To mention `Alphabetize Gems`.

Original error message:
```
Gem `rspec` should appear before `rubocop` in their gem group.
```

New error message:
```
Alphabetize gems: Gem `rspec` should appear before `rubocop` in their gem group.
```

Fixes #3753 
-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Used the same coding conventions as the rest of the project.
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] All tests are passing.
* [x] The new code doesn't generate RuboCop offenses.
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [ ] Updated cop documentation with `rake generate_cops_documentation` (required only when you've added a new cop or changed the configuration/documentation of an existing cop).

[1]: http://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html