### PR TITLE
Add Auto-Correct for `Bundler/OrderedGems` cop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change log
 
+### New features
+
+* [#3757](https://github.com/bbatsov/rubocop/pull/3757): Add Auto-Correct for `Bundler/OrderedGems` cop. ([@pocke][])
+
 ## master (unreleased)
 
 ## 0.46.0 (2016-11-30)

--- a/lib/rubocop/cop/bundler/ordered_gems.rb
+++ b/lib/rubocop/cop/bundler/ordered_gems.rb
@@ -45,6 +45,23 @@ module RuboCop
           )
         end
 
+        def autocorrect(node)
+          previous = previous_declaration(node)
+
+          current_content = node.source
+          previous_content = previous.source
+
+          lambda do |corrector|
+            corrector.replace(node.loc.expression, previous_content)
+            corrector.replace(previous.loc.expression, current_content)
+          end
+        end
+
+        def previous_declaration(node)
+          gem_declarations(processed_source.ast)
+            .find { |x| x.loc.line == node.loc.line - 1 }
+        end
+
         def_node_search :gem_declarations, <<-PATTERN
           (:send, nil, :gem, ...)
         PATTERN

--- a/lib/rubocop/rspec/cop_helper.rb
+++ b/lib/rubocop/rspec/cop_helper.rb
@@ -53,6 +53,15 @@ module CopHelper
     corrector.rewrite
   end
 
+  def autocorrect_source_with_loop(cop, source, file = nil)
+    loop do
+      cop.instance_variable_set(:@corrections, [])
+      new_source = autocorrect_source(cop, source, file)
+      return new_source if new_source == source
+      source = new_source
+    end
+  end
+
   def _investigate(cop, processed_source)
     forces = RuboCop::Cop::Force.all.each_with_object([]) do |klass, instances|
       next unless cop.join_force?(klass)

--- a/manual/cops_bundler.md
+++ b/manual/cops_bundler.md
@@ -44,7 +44,7 @@ Include | \*\*/Gemfile, \*\*/gems.rb
 
 Enabled by default | Supports autocorrection
 --- | ---
-Enabled | No
+Enabled | Yes
 
 Gems in consecutive lines should be alphabetically sorted
 

--- a/manual/cops_lint.md
+++ b/manual/cops_lint.md
@@ -712,7 +712,8 @@ Enabled | No
 This cop checks for non-local exit from iterator, without return value.
 It warns only when satisfies all of these: `return` doesn't have return
 value, the block is preceded by a method chain, the block has arguments,
-and the method which receives the block is not `define_method`.
+and the method which receives the block is not `define_method`
+or `define_singleton_method`.
 
 ### Example
 

--- a/spec/rubocop/cop/bundler/ordered_gems_spec.rb
+++ b/spec/rubocop/cop/bundler/ordered_gems_spec.rb
@@ -78,4 +78,34 @@ describe RuboCop::Cop::Bundler::OrderedGems, :config do
       expect(cop.offenses.size).to eq(0)
     end
   end
+
+  it 'autocorrects' do
+    source = <<-END
+      gem "d"
+      gem "b"
+      gem "e"
+      gem "a"
+      gem "c"
+
+      gem "h"
+      gem "g"
+      gem "j"
+      gem "f"
+      gem "i"
+    END
+
+    new_source = autocorrect_source_with_loop(cop, source)
+    expect(new_source).to eq(['      gem "a"',
+                              '      gem "b"',
+                              '      gem "c"',
+                              '      gem "d"',
+                              '      gem "e"',
+                              '',
+                              '      gem "f"',
+                              '      gem "g"',
+                              '      gem "h"',
+                              '      gem "i"',
+                              '      gem "j"',
+                              ''].join("\n"))
+  end
 end


### PR DESCRIPTION
Ref #3657 #3600

Goal
----

Auto Correct not sorted gems.

e.g.

```ruby
gem 'b'
gem 'd'
gem 'c'
gem 'a'

gem 'a'
gem 'b'
gem 'c'
gem 'd'
```

Note
-----

I added `autocorrect_source_with_loop` test helper method to execute auto-correction with loop.
This method is based on do_inspection_loop.
https://github.com/bbatsov/rubocop/blob/ed4aeb845bfcaaff0648d365c5b46a2e725347f7/lib/rubocop/runner.rb#L179-L202



-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Used the same coding conventions as the rest of the project.
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [ ] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] All tests are passing.
* [x] The new code doesn't generate RuboCop offenses.
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Updated cop documentation with `rake generate_cops_documentation` (required only when you've added a new cop or changed the configuration/documentation of an existing cop).

[1]: http://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html

