### PR TITLE
Add a validation for supported styles other than EnforcedStyle

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@
 ### Changes
 
 * [#3725](https://github.com/bbatsov/rubocop/issues/3725): Disable `Style/SingleLineBlockParams` by default. ([@tejasbubane][])
-* [#3765](https://github.com/bbatsov/rubocop/pull/3765): Add a validation for supported styles other than EnforcedStyle. ([@pocke][])
+* [#3765](https://github.com/bbatsov/rubocop/pull/3765): Add a validation for supported styles other than EnforcedStyle. `AlignWith`, `IndentWhenRelativeTo` and `EnforcedMode` configurations are renamed. ([@pocke][])
 
 ### Bug fixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 ### Changes
 
 * [#3725](https://github.com/bbatsov/rubocop/issues/3725): Disable `Style/SingleLineBlockParams` by default. ([@tejasbubane][])
+* [#3765](https://github.com/bbatsov/rubocop/pull/3765): Add a validation for supported styles other than EnforcedStyle. ([@pocke][])
 
 ### Bug fixes
 

--- a/config/default.yml
+++ b/config/default.yml
@@ -296,7 +296,7 @@ Style/BracesAroundHashParameters:
 
 # Indentation of `when`.
 Style/CaseIndentation:
-  IndentWhenRelativeTo: case
+  EnforcedStyle: case
   SupportedStyles:
     - case
     - end
@@ -1194,8 +1194,8 @@ Lint/BlockAlignment:
   # The value `start_of_line` means it should be aligned with the whole
   # expression's starting line.
   # The value `either` means both are allowed.
-  AlignWith: either
-  SupportedStyles:
+  EnforcedStyleAlignWith: either
+  SupportedStylesAlignWith:
     - either
     - start_of_block
     - start_of_line
@@ -1209,8 +1209,8 @@ Lint/EndAlignment:
   # situations, `end` should still be aligned with the keyword.
   # The value `start_of_line` means that `end` should be aligned with the start
   # of the line which the matching keyword appears on.
-  AlignWith: keyword
-  SupportedStyles:
+  EnforcedStyleAlignWith: keyword
+  SupportedStylesAlignWith:
     - keyword
     - variable
     - start_of_line
@@ -1221,8 +1221,8 @@ Lint/DefEndAlignment:
   # The value `start_of_line` means that `end` should be aligned with method
   # calls like `private`, `public`, etc, if present in front of the `def`
   # keyword on the same line.
-  AlignWith: start_of_line
-  SupportedStyles:
+  EnforcedStyleAlignWith: start_of_line
+  SupportedStylesAlignWith:
     - start_of_line
     - def
   AutoCorrect: false
@@ -1340,8 +1340,8 @@ Rails/TimeZone:
     - flexible
 
 Rails/UniqBeforePluck:
-  EnforcedMode: conservative
-  SupportedModes:
+  EnforcedStyle: conservative
+  SupportedStyles:
     - conservative
     - aggressive
   AutoCorrect: false

--- a/config/default.yml
+++ b/config/default.yml
@@ -113,6 +113,10 @@ Style/AlignHash:
   #   'a'  => 2
   #   'bb' => 3
   EnforcedHashRocketStyle: key
+  SupportedHashRocketStyles:
+    - key
+    - separator
+    - table
   # Alignment of entries using colon as separator. Valid values are:
   #
   # key - left alignment of keys
@@ -125,6 +129,10 @@ Style/AlignHash:
   #   a:  0
   #   bb: 1
   EnforcedColonStyle: key
+  SupportedColonStyles:
+    - key
+    - separator
+    - table
   # Select whether hashes that are the last argument in a method call should be
   # inspected? Valid values are:
   #
@@ -940,7 +948,7 @@ Style/StringMethods:
 
 Style/SpaceAroundBlockParameters:
   EnforcedStyleInsidePipes: no_space
-  SupportedStyles:
+  SupportedStylesInsidePipes:
     - space
     - no_space
 
@@ -967,20 +975,25 @@ Style/SpaceInsideBlockBraces:
   SupportedStyles:
     - space
     - no_space
-  # Valid values are: space, no_space
   EnforcedStyleForEmptyBraces: no_space
+  SupportedStylesForEmptyBraces:
+    - space
+    - no_space
   # Space between { and |. Overrides EnforcedStyle if there is a conflict.
   SpaceBeforeBlockParameters: true
 
 Style/SpaceInsideHashLiteralBraces:
   EnforcedStyle: space
-  EnforcedStyleForEmptyBraces: no_space
   SupportedStyles:
     - space
     - no_space
     # 'compact' normally requires a space inside hash braces, with the exception
     # that successive left braces or right braces are collapsed together
     - compact
+  EnforcedStyleForEmptyBraces: no_space
+  SupportedStylesForEmptyBraces:
+    - space
+    - no_space
 
 Style/SpaceInsideStringInterpolation:
   EnforcedStyle: no_space
@@ -1021,7 +1034,7 @@ Style/TrailingCommaInArguments:
   # If `consistent_comma`, the cop requires a comma after the last argument,
   # for all parenthesized method calls with arguments.
   EnforcedStyleForMultiline: no_comma
-  SupportedStyles:
+  SupportedStylesForMultiline:
     - comma
     - consistent_comma
     - no_comma
@@ -1032,7 +1045,7 @@ Style/TrailingCommaInLiteral:
   # If `consistent_comma`, the cop requires a comma after the last item of all
   # non-empty array and hash literals.
   EnforcedStyleForMultiline: no_comma
-  SupportedStyles:
+  SupportedStylesForMultiline:
     - comma
     - consistent_comma
     - no_comma

--- a/lib/rubocop/config.rb
+++ b/lib/rubocop/config.rb
@@ -286,14 +286,19 @@ module RuboCop
 
     def validate_enforced_styles(valid_cop_names)
       valid_cop_names.each do |name|
-        next unless (style = self[name]['EnforcedStyle'])
-        valid = ConfigLoader.default_configuration[name]['SupportedStyles']
-        next if valid.include?(style)
+        styles = self[name].select { |key, _| key.start_with?('Enforced') }
 
-        msg = "invalid EnforcedStyle '#{style}' for #{name} found in " \
-              "#{loaded_path}\n" \
-              "Valid choices are: #{valid.join(', ')}"
-        raise ValidationError, msg
+        styles.each do |style_name, style|
+          supported_key = RuboCop::Cop::Util.to_supported_styles(style_name)
+          valid = ConfigLoader.default_configuration[name][supported_key]
+          next unless valid
+          next if valid.include?(style)
+
+          msg = "invalid #{style_name} '#{style}' for #{name} found in " \
+            "#{loaded_path}\n" \
+            "Valid choices are: #{valid.join(', ')}"
+          raise ValidationError, msg
+        end
       end
     end
 

--- a/lib/rubocop/cop/lint/block_alignment.rb
+++ b/lib/rubocop/cop/lint/block_alignment.rb
@@ -6,8 +6,8 @@ module RuboCop
       # This cop checks whether the end keywords are aligned properly for do
       # end blocks.
       #
-      # Three modes are supported through the `AlignWith` configuration
-      # parameter:
+      # Three modes are supported through the `EnforcedStyleAlignWith`
+      # configuration parameter:
       #
       # `start_of_block` : the `end` shall be aligned with the
       # start of the line where the `do` appeared.
@@ -55,7 +55,7 @@ module RuboCop
         end
 
         def parameter_name
-          'AlignWith'
+          'EnforcedStyleAlignWith'
         end
 
         private

--- a/lib/rubocop/cop/lint/def_end_alignment.rb
+++ b/lib/rubocop/cop/lint/def_end_alignment.rb
@@ -6,7 +6,7 @@ module RuboCop
       # This cop checks whether the end keywords of method definitions are
       # aligned properly.
       #
-      # Two modes are supported through the AlignWith configuration
+      # Two modes are supported through the EnforcedStyleAlignWith configuration
       # parameter. If it's set to `start_of_line` (which is the default), the
       # `end` shall be aligned with the start of the line where the `def`
       # keyword is. If it's set to `def`, the `end` shall be aligned with the

--- a/lib/rubocop/cop/lint/end_alignment.rb
+++ b/lib/rubocop/cop/lint/end_alignment.rb
@@ -5,8 +5,8 @@ module RuboCop
     module Lint
       # This cop checks whether the end keywords are aligned properly.
       #
-      # Three modes are supported through the `AlignWith` configuration
-      # parameter:
+      # Three modes are supported through the `EnforcedStyleAlignWith`
+      # configuration parameter:
       #
       # If it's set to `keyword` (which is the default), the `end`
       # shall be aligned with the start of the keyword (if, class, etc.).

--- a/lib/rubocop/cop/mixin/configurable_enforced_style.rb
+++ b/lib/rubocop/cop/mixin/configurable_enforced_style.rb
@@ -80,7 +80,10 @@ module RuboCop
       end
 
       def supported_styles
-        @supported_styles ||= cop_config['SupportedStyles'].map(&:to_sym)
+        @supported_styles ||= begin
+          supported_styles = Util.to_supported_styles(parameter_name)
+          cop_config[supported_styles].map(&:to_sym)
+        end
       end
 
       def parameter_name

--- a/lib/rubocop/cop/mixin/end_keyword_alignment.rb
+++ b/lib/rubocop/cop/mixin/end_keyword_alignment.rb
@@ -45,7 +45,7 @@ module RuboCop
       end
 
       def parameter_name
-        'AlignWith'
+        'EnforcedStyleAlignWith'
       end
 
       def variable_alignment?(whole_expression, rhs, end_alignment_style)

--- a/lib/rubocop/cop/rails/uniq_before_pluck.rb
+++ b/lib/rubocop/cop/rails/uniq_before_pluck.rb
@@ -15,11 +15,11 @@ module RuboCop
       #   # good
       #   Model.uniq.pluck(:id)
       #
-      # This cop has two different enforcement modes. When the EnforcedMode
+      # This cop has two different enforcement modes. When the EnforcedStyle
       # is conservative (the default) then only calls to pluck on a constant
       # (i.e. a model class) before uniq are added as offenses.
       #
-      # When the EnforcedMode is aggressive then all calls to pluck before
+      # When the EnforcedStyle is aggressive then all calls to pluck before
       # uniq are added as offenses. This may lead to false positives as the cop
       # cannot distinguish between calls to pluck on an ActiveRecord::Relation
       # vs a call to pluck on an ActiveRecord::Associations::CollectionProxy.
@@ -35,6 +35,8 @@ module RuboCop
       # false positives.
       #
       class UniqBeforePluck < RuboCop::Cop::Cop
+        include ConfigurableEnforcedStyle
+
         MSG = 'Use `%s` before `pluck`.'.freeze
         NEWLINE = "\n".freeze
         PATTERN = '[!^block (send (send %s :pluck ...) ${:uniq :distinct} ...)]'
@@ -47,7 +49,7 @@ module RuboCop
                          format(PATTERN, '_')
 
         def on_send(node)
-          method = if mode == :conservative
+          method = if style == :conservative
                      conservative_node_match(node)
                    else
                      aggressive_node_match(node)
@@ -66,8 +68,8 @@ module RuboCop
 
         private
 
-        def mode
-          @mode ||= cop_config['EnforcedMode'].to_sym
+        def parameter_name
+          'EnforcedStyle'
         end
 
         def dot_method_with_whitespace(method, node)

--- a/lib/rubocop/cop/style/case_indentation.rb
+++ b/lib/rubocop/cop/style/case_indentation.rb
@@ -51,10 +51,6 @@ module RuboCop
           end
         end
 
-        def parameter_name
-          'IndentWhenRelativeTo'
-        end
-
         def base_column(case_node, base)
           case base
           when :case then case_node.location.keyword.column

--- a/lib/rubocop/cop/style/conditional_assignment.rb
+++ b/lib/rubocop/cop/style/conditional_assignment.rb
@@ -8,7 +8,7 @@ module RuboCop
       module ConditionalAssignmentHelper
         EQUAL = '='.freeze
         END_ALIGNMENT = 'Lint/EndAlignment'.freeze
-        ALIGN_WITH = 'AlignWith'.freeze
+        ALIGN_WITH = 'EnforcedStyleAlignWith'.freeze
         KEYWORD = 'keyword'.freeze
 
         # `elsif` branches show up in the `node` as an `else`. We need

--- a/lib/rubocop/cop/style/else_alignment.rb
+++ b/lib/rubocop/cop/style/else_alignment.rb
@@ -87,7 +87,7 @@ module RuboCop
           return unless rhs
 
           end_config = config.for_cop('Lint/EndAlignment')
-          style = end_config['AlignWith'] || 'keyword'
+          style = end_config['EnforcedStyleAlignWith'] || 'keyword'
           base = variable_alignment?(node.loc, rhs, style.to_sym) ? node : rhs
 
           return unless rhs.if_type?

--- a/lib/rubocop/cop/style/indentation_width.rb
+++ b/lib/rubocop/cop/style/indentation_width.rb
@@ -87,7 +87,7 @@ module RuboCop
           *_, body = *args.first
 
           def_end_config = config.for_cop('Lint/DefEndAlignment')
-          style = def_end_config['AlignWith'] || 'start_of_line'
+          style = def_end_config['EnforcedStyleAlignWith'] || 'start_of_line'
           base = style == 'def' ? args.first : node
 
           check_indentation(base.source_range, body)
@@ -188,7 +188,7 @@ module RuboCop
           return unless rhs
 
           end_config = config.for_cop('Lint/EndAlignment')
-          style = end_config['AlignWith'] || 'keyword'
+          style = end_config['EnforcedStyleAlignWith'] || 'keyword'
           base = variable_alignment?(node.loc, rhs, style.to_sym) ? node : rhs
 
           case rhs.type

--- a/lib/rubocop/cop/util.rb
+++ b/lib/rubocop/cop/util.rb
@@ -271,6 +271,15 @@ module RuboCop
         src = src.dup if RUBY_VERSION < '2.3'
         src.force_encoding(Encoding.default_external).valid_encoding?
       end
+
+      def to_supported_styles(enforced_style)
+        irregular_styles = %w(IndentWhenRelativeTo AlignWith)
+        return 'SupportedStyles' if irregular_styles.include?(enforced_style)
+        enforced_style
+          .sub(/^Enforced/, 'Supported')
+          .sub('Style', 'Styles')
+          .sub('Mode', 'Modes')
+      end
     end
   end
 end

--- a/lib/rubocop/cop/util.rb
+++ b/lib/rubocop/cop/util.rb
@@ -273,12 +273,9 @@ module RuboCop
       end
 
       def to_supported_styles(enforced_style)
-        irregular_styles = %w(IndentWhenRelativeTo AlignWith)
-        return 'SupportedStyles' if irregular_styles.include?(enforced_style)
         enforced_style
           .sub(/^Enforced/, 'Supported')
           .sub('Style', 'Styles')
-          .sub('Mode', 'Modes')
       end
     end
   end

--- a/lib/rubocop/rspec/shared_examples.rb
+++ b/lib/rubocop/rspec/shared_examples.rb
@@ -50,7 +50,7 @@ shared_examples_for 'misaligned' do |prefix, alignment_base, arg, end_kw, name|
     # style. In other cases, it won't match any style at all
     expect(cop.config_to_allow_offenses).to(
       eq('Enabled' => false).or(
-        satisfy { |h| other_styles.include?(h['AlignWith']) }
+        satisfy { |h| other_styles.include?(h['EnforcedStyleAlignWith']) }
       )
     )
   end

--- a/manual/cops_rails.md
+++ b/manual/cops_rails.md
@@ -630,11 +630,11 @@ Prefer the use of uniq (or distinct), before pluck instead of after.
 The use of uniq before pluck is preferred because it executes within
 the database.
 
-This cop has two different enforcement modes. When the EnforcedMode
+This cop has two different enforcement modes. When the EnforcedStyle
 is conservative (the default) then only calls to pluck on a constant
 (i.e. a model class) before uniq are added as offenses.
 
-When the EnforcedMode is aggressive then all calls to pluck before
+When the EnforcedStyle is aggressive then all calls to pluck before
 uniq are added as offenses. This may lead to false positives as the cop
 cannot distinguish between calls to pluck on an ActiveRecord::Relation
 vs a call to pluck on an ActiveRecord::Associations::CollectionProxy.
@@ -663,8 +663,8 @@ instance.assoc.pluck(:id).uniq
 
 Attribute | Value
 --- | ---
-EnforcedMode | conservative
-SupportedModes | conservative, aggressive
+EnforcedStyle | conservative
+SupportedStyles | conservative, aggressive
 AutoCorrect | false
 
 

--- a/manual/cops_style.md
+++ b/manual/cops_style.md
@@ -84,7 +84,9 @@ literal are aligned.
 Attribute | Value
 --- | ---
 EnforcedHashRocketStyle | key
+SupportedHashRocketStyles | key, separator, table
 EnforcedColonStyle | key
+SupportedColonStyles | key, separator, table
 EnforcedLastArgumentHashStyle | always_inspect
 SupportedLastArgumentHashStyles | always_inspect, always_ignore, ignore_implicit, ignore_explicit
 
@@ -3968,7 +3970,7 @@ Checks the spacing inside and after block parameters pipes.
 Attribute | Value
 --- | ---
 EnforcedStyleInsidePipes | no_space
-SupportedStyles | space, no_space
+SupportedStylesInsidePipes | space, no_space
 
 
 ## Style/SpaceAroundEqualsInParameterDefault
@@ -4179,6 +4181,7 @@ Attribute | Value
 EnforcedStyle | space
 SupportedStyles | space, no_space
 EnforcedStyleForEmptyBraces | no_space
+SupportedStylesForEmptyBraces | space, no_space
 SpaceBeforeBlockParameters | true
 
 
@@ -4204,8 +4207,9 @@ surrounding space depending on configuration.
 Attribute | Value
 --- | ---
 EnforcedStyle | space
-EnforcedStyleForEmptyBraces | no_space
 SupportedStyles | space, no_space, compact
+EnforcedStyleForEmptyBraces | no_space
+SupportedStylesForEmptyBraces | space, no_space
 
 
 ## Style/SpaceInsideParens
@@ -4593,7 +4597,7 @@ method(
 Attribute | Value
 --- | ---
 EnforcedStyleForMultiline | no_comma
-SupportedStyles | comma, consistent_comma, no_comma
+SupportedStylesForMultiline | comma, consistent_comma, no_comma
 
 
 ## Style/TrailingCommaInLiteral
@@ -4634,7 +4638,7 @@ a = [
 Attribute | Value
 --- | ---
 EnforcedStyleForMultiline | no_comma
-SupportedStyles | comma, consistent_comma, no_comma
+SupportedStylesForMultiline | comma, consistent_comma, no_comma
 
 
 ## Style/TrailingUnderscoreVariable

--- a/spec/project_spec.rb
+++ b/spec/project_spec.rb
@@ -21,6 +21,22 @@ describe 'RuboCop Project' do
         expect(description).not_to include("\n")
       end
     end
+
+    it 'has a SupportedStyles for all EnforcedStyle' \
+      'and EnforcedStyle is valid' do
+      errors = []
+      cop_names.each do |name|
+        enforced_styles = default_config[name]
+                          .select { |key, _| key.start_with?('Enforced') }
+        enforced_styles.each do |style_name, _style|
+          supported_key = RuboCop::Cop::Util.to_supported_styles(style_name)
+          valid = default_config[name][supported_key]
+          errors.push("#{supported_key} is missing for #{name}") unless valid
+        end
+      end
+
+      raise errors.join("\n") unless errors.empty?
+    end
   end
 
   describe 'cop message' do

--- a/spec/rubocop/config_spec.rb
+++ b/spec/rubocop/config_spec.rb
@@ -117,6 +117,87 @@ describe RuboCop::Config do
         expect { configuration.validate }.to_not raise_error
       end
     end
+
+    context 'when the configuration includes a valid EnforcedStyle' do
+      before do
+        create_file(configuration_path, [
+                      'Style/AndOr:',
+                      '  EnforcedStyle: conditionals'
+                    ])
+      end
+
+      it 'does not raise validation error' do
+        expect { configuration.validate }.to_not raise_error
+      end
+    end
+
+    context 'when the configration includes an invalid EnforcedStyle' do
+      before do
+        create_file(configuration_path, [
+                      'Style/AndOr:',
+                      '  EnforcedStyle: itisinvalid'
+                    ])
+      end
+
+      it 'raises validation error' do
+        expect { configuration.validate }
+          .to raise_error(RuboCop::ValidationError, /itisinvalid/)
+      end
+    end
+
+    context 'when the configration includes a valid Enforced.+Style' do
+      before do
+        create_file(configuration_path, [
+                      'Style/SpaceAroundBlockParameters:',
+                      '  EnforcedStyleInsidePipes: space'
+                    ])
+      end
+
+      it 'does not raise validation error' do
+        expect { configuration.validate }.to_not raise_error
+      end
+    end
+
+    context 'when the configration includes an invalid Enforced.+Style' do
+      before do
+        create_file(configuration_path, [
+                      'Style/SpaceAroundBlockParameters:',
+                      '  EnforcedStyleInsidePipes: itisinvalid'
+                    ])
+      end
+
+      it 'does not raise validation error' do
+        expect { configuration.validate }
+          .to raise_error(RuboCop::ValidationError, /itisinvalid/)
+      end
+    end
+
+    context 'when the configration includes a valid EnforcedMode' do
+      before do
+        create_file(configuration_path, [
+                      'Rails/UniqBeforePluck:',
+                      '  EnforcedMode: aggressive'
+                    ])
+      end
+
+      it 'does not raise validation error' do
+        expect { configuration.validate }.to_not raise_error
+      end
+    end
+
+    context 'when the configration includes an invalid EnforcedMode' do
+      before do
+        create_file(configuration_path, [
+                      'Rails/UniqBeforePluck:',
+                      '  EnforcedMode: itisinvalid'
+                    ])
+      end
+
+      it 'does not raise validation error' do
+        expect { configuration.validate }
+          .to raise_error(RuboCop::ValidationError, /itisinvalid/)
+      end
+    end
   end
 
   describe '#make_excludes_absolute' do

--- a/spec/rubocop/config_spec.rb
+++ b/spec/rubocop/config_spec.rb
@@ -171,33 +171,6 @@ describe RuboCop::Config do
           .to raise_error(RuboCop::ValidationError, /itisinvalid/)
       end
     end
-
-    context 'when the configration includes a valid EnforcedMode' do
-      before do
-        create_file(configuration_path, [
-                      'Rails/UniqBeforePluck:',
-                      '  EnforcedMode: aggressive'
-                    ])
-      end
-
-      it 'does not raise validation error' do
-        expect { configuration.validate }.to_not raise_error
-      end
-    end
-
-    context 'when the configration includes an invalid EnforcedMode' do
-      before do
-        create_file(configuration_path, [
-                      'Rails/UniqBeforePluck:',
-                      '  EnforcedMode: itisinvalid'
-                    ])
-      end
-
-      it 'does not raise validation error' do
-        expect { configuration.validate }
-          .to raise_error(RuboCop::ValidationError, /itisinvalid/)
-      end
-    end
   end
 
   describe '#make_excludes_absolute' do

--- a/spec/rubocop/cop/lint/block_alignment_spec.rb
+++ b/spec/rubocop/cop/lint/block_alignment_spec.rb
@@ -5,7 +5,7 @@ require 'spec_helper'
 describe RuboCop::Cop::Lint::BlockAlignment, :config do
   subject(:cop) { described_class.new(config) }
   let(:cop_config) do
-    { 'AlignWith' => 'either' }
+    { 'EnforcedStyleAlignWith' => 'either' }
   end
 
   context 'when the block has no arguments' do
@@ -638,7 +638,7 @@ describe RuboCop::Cop::Lint::BlockAlignment, :config do
 
   context 'when configured to align with start_of_line' do
     let(:cop_config) do
-      { 'AlignWith' => 'start_of_line' }
+      { 'EnforcedStyleAlignWith' => 'start_of_line' }
     end
 
     it 'allows when start_of_line aligned' do
@@ -686,7 +686,7 @@ describe RuboCop::Cop::Lint::BlockAlignment, :config do
 
   context 'when configured to align with do' do
     let(:cop_config) do
-      { 'AlignWith' => 'start_of_block' }
+      { 'EnforcedStyleAlignWith' => 'start_of_block' }
     end
 
     it 'allows when do aligned' do

--- a/spec/rubocop/cop/lint/def_end_alignment_spec.rb
+++ b/spec/rubocop/cop/lint/def_end_alignment_spec.rb
@@ -15,9 +15,9 @@ describe RuboCop::Cop::Lint::DefEndAlignment, :config do
      '    end']
   end
 
-  context 'when AlignWith is start_of_line' do
+  context 'when EnforcedStyleAlignWith is start_of_line' do
     let(:cop_config) do
-      { 'AlignWith' => 'start_of_line', 'AutoCorrect' => true }
+      { 'EnforcedStyleAlignWith' => 'start_of_line', 'AutoCorrect' => true }
     end
 
     include_examples 'misaligned', '', 'def', 'test',      '  end'
@@ -58,9 +58,9 @@ describe RuboCop::Cop::Lint::DefEndAlignment, :config do
     end
   end
 
-  context 'when AlignWith is def' do
+  context 'when EnforcedStyleAlignWith is def' do
     let(:cop_config) do
-      { 'AlignWith' => 'def', 'AutoCorrect' => true }
+      { 'EnforcedStyleAlignWith' => 'def', 'AutoCorrect' => true }
     end
 
     include_examples 'misaligned', '', 'def', 'test',      '  end'

--- a/spec/rubocop/cop/lint/end_alignment_spec.rb
+++ b/spec/rubocop/cop/lint/end_alignment_spec.rb
@@ -5,7 +5,7 @@ require 'spec_helper'
 describe RuboCop::Cop::Lint::EndAlignment, :config do
   subject(:cop) { described_class.new(config) }
   let(:cop_config) do
-    { 'AlignWith' => 'keyword', 'AutoCorrect' => true }
+    { 'EnforcedStyleAlignWith' => 'keyword', 'AutoCorrect' => true }
   end
 
   include_examples 'misaligned', '', 'class',  'Test',      '  end'
@@ -52,9 +52,9 @@ describe RuboCop::Cop::Lint::EndAlignment, :config do
     expect(cop.offenses).to be_empty
   end
 
-  context 'when AlignWith is start_of_line' do
+  context 'when EnforcedStyleAlignWith is start_of_line' do
     let(:cop_config) do
-      { 'AlignWith' => 'start_of_line', 'AutoCorrect' => true }
+      { 'EnforcedStyleAlignWith' => 'start_of_line', 'AutoCorrect' => true }
     end
 
     include_examples 'misaligned', '', 'class Test',    '', '  end'
@@ -82,11 +82,11 @@ describe RuboCop::Cop::Lint::EndAlignment, :config do
     include_examples 'misaligned', '', 'puts 1; case a when b', '', '  end'
   end
 
-  context 'when AlignWith is variable' do
-    # same as 'AlignWith' => 'keyword', as long as assignments or `case`
-    # are not involved
+  context 'when EnforcedStyleAlignWith is variable' do
+    # same as 'EnforcedStyleAlignWith' => 'keyword',
+    # as long as assignments or `case` are not involved
     let(:cop_config) do
-      { 'AlignWith' => 'variable', 'AutoCorrect' => true }
+      { 'EnforcedStyleAlignWith' => 'variable', 'AutoCorrect' => true }
     end
 
     include_examples 'misaligned', '', 'class',  'Test',      '  end'
@@ -174,27 +174,27 @@ describe RuboCop::Cop::Lint::EndAlignment, :config do
   end
 
   context 'case as argument' do
-    context 'when AlignWith is keyword' do
+    context 'when EnforcedStyleAlignWith is keyword' do
       let(:cop_config) do
-        { 'AlignWith' => 'keyword', 'AutoCorrect' => true }
+        { 'EnforcedStyleAlignWith' => 'keyword', 'AutoCorrect' => true }
       end
 
       include_examples 'aligned', 'test case', 'a when b', '     end'
       include_examples 'misaligned', 'test ', 'case', 'a when b', 'end'
     end
 
-    context 'when AlignWith is variable' do
+    context 'when EnforcedStyleAlignWith is variable' do
       let(:cop_config) do
-        { 'AlignWith' => 'variable', 'AutoCorrect' => true }
+        { 'EnforcedStyleAlignWith' => 'variable', 'AutoCorrect' => true }
       end
 
       include_examples 'aligned', 'test case', 'a when b', 'end'
       include_examples 'misaligned', '', 'test case', 'a when b', '     end'
     end
 
-    context 'when AlignWith is start_of_line' do
+    context 'when EnforcedStyleAlignWith is start_of_line' do
       let(:cop_config) do
-        { 'AlignWith' => 'start_of_line', 'AutoCorrect' => true }
+        { 'EnforcedStyleAlignWith' => 'start_of_line', 'AutoCorrect' => true }
       end
 
       include_examples 'aligned',        'test case a when b', '', 'end'
@@ -203,7 +203,7 @@ describe RuboCop::Cop::Lint::EndAlignment, :config do
   end
 
   context 'regarding assignment' do
-    context 'when AlignWith is keyword' do
+    context 'when EnforcedStyleAlignWith is keyword' do
       include_examples 'misaligned', 'var = ', 'if',     'test',     'end'
       include_examples 'misaligned', 'var = ', 'unless', 'test',     'end'
       include_examples 'misaligned', 'var = ', 'while',  'test',     'end'
@@ -217,9 +217,9 @@ describe RuboCop::Cop::Lint::EndAlignment, :config do
       include_examples 'aligned', 'var = case',   'a when b', '      end'
     end
 
-    context 'when AlignWith is variable' do
+    context 'when EnforcedStyleAlignWith is variable' do
       let(:cop_config) do
-        { 'AlignWith' => 'variable', 'AutoCorrect' => true }
+        { 'EnforcedStyleAlignWith' => 'variable', 'AutoCorrect' => true }
       end
 
       include_examples 'aligned', 'var = if',     'test',     'end'
@@ -263,9 +263,9 @@ describe RuboCop::Cop::Lint::EndAlignment, :config do
     end
   end
 
-  context 'when AlignWith is start_of_line' do
+  context 'when EnforcedStyleAlignWith is start_of_line' do
     let(:cop_config) do
-      { 'AlignWith' => 'start_of_line', 'AutoCorrect' => true }
+      { 'EnforcedStyleAlignWith' => 'start_of_line', 'AutoCorrect' => true }
     end
 
     include_examples 'misaligned', '', 'var = if test',       '', '      end'

--- a/spec/rubocop/cop/rails/uniq_before_pluck_spec.rb
+++ b/spec/rubocop/cop/rails/uniq_before_pluck_spec.rb
@@ -72,7 +72,7 @@ describe RuboCop::Cop::Rails::UniqBeforePluck, :config do
   %w(uniq distinct).each do |method|
     context 'when the enforced mode is conservative' do
       let(:cop_config) do
-        { 'EnforcedMode' => 'conservative', 'AutoCorrect' => true }
+        { 'EnforcedStyle' => 'conservative', 'AutoCorrect' => true }
       end
 
       it_behaves_like 'mode independent behavior', method
@@ -82,7 +82,7 @@ describe RuboCop::Cop::Rails::UniqBeforePluck, :config do
 
     context 'when the enforced mode is aggressive' do
       let(:cop_config) do
-        { 'EnforcedMode' => 'aggressive', 'AutoCorrect' => true }
+        { 'EnforcedStyle' => 'aggressive', 'AutoCorrect' => true }
       end
 
       it_behaves_like 'mode independent behavior', method

--- a/spec/rubocop/cop/style/case_indentation_spec.rb
+++ b/spec/rubocop/cop/style/case_indentation_spec.rb
@@ -11,10 +11,10 @@ describe RuboCop::Cop::Style::CaseIndentation do
                         'Style/IndentationWidth' => { 'Width' => 2 })
   end
 
-  context 'with IndentWhenRelativeTo: case' do
+  context 'with EnforcedStyle: case' do
     context 'with IndentOneStep: false' do
       let(:cop_config) do
-        { 'IndentWhenRelativeTo' => 'case', 'IndentOneStep' => false }
+        { 'EnforcedStyle' => 'case', 'IndentOneStep' => false }
       end
 
       context 'regarding assignment where the right hand side is a case' do
@@ -54,7 +54,7 @@ describe RuboCop::Cop::Style::CaseIndentation do
           it 'registers an offense' do
             inspect_source(cop, source)
             expect(cop.messages).to eq(['Indent `when` as deep as `case`.'])
-            expect(cop.config_to_allow_offenses).to eq('IndentWhenRelativeTo' =>
+            expect(cop.config_to_allow_offenses).to eq('EnforcedStyle' =>
                                                        'end')
           end
 
@@ -234,7 +234,7 @@ describe RuboCop::Cop::Style::CaseIndentation do
 
     context 'with IndentOneStep: true' do
       let(:cop_config) do
-        { 'IndentWhenRelativeTo' => 'case', 'IndentOneStep' => true }
+        { 'EnforcedStyle' => 'case', 'IndentOneStep' => true }
       end
 
       let(:correct_source) do
@@ -338,7 +338,7 @@ describe RuboCop::Cop::Style::CaseIndentation do
       context 'when indentation width is overridden for this cop only' do
         let(:cop_config) do
           {
-            'IndentWhenRelativeTo' => 'case',
+            'EnforcedStyle' => 'case',
             'IndentOneStep' => true,
             'IndentationWidth' => 5
           }
@@ -361,10 +361,10 @@ describe RuboCop::Cop::Style::CaseIndentation do
     end
   end
 
-  context 'with IndentWhenRelativeTo: end' do
+  context 'with EnforcedStyle: end' do
     context 'with IndentOneStep: false' do
       let(:cop_config) do
-        { 'IndentWhenRelativeTo' => 'end', 'IndentOneStep' => false }
+        { 'EnforcedStyle' => 'end', 'IndentOneStep' => false }
       end
 
       let(:correct_source) do
@@ -416,7 +416,7 @@ describe RuboCop::Cop::Style::CaseIndentation do
 
     context 'with IndentOneStep: true' do
       let(:cop_config) do
-        { 'IndentWhenRelativeTo' => 'end', 'IndentOneStep' => true }
+        { 'EnforcedStyle' => 'end', 'IndentOneStep' => true }
       end
 
       let(:correct_source) do
@@ -457,7 +457,7 @@ describe RuboCop::Cop::Style::CaseIndentation do
             inspect_source(cop, source)
             expect(cop.messages)
               .to eq(['Indent `when` one step more than `end`.'])
-            expect(cop.config_to_allow_offenses).to eq('IndentWhenRelativeTo' =>
+            expect(cop.config_to_allow_offenses).to eq('EnforcedStyle' =>
                                                        'case')
           end
 

--- a/spec/rubocop/cop/style/conditional_assignment_assign_in_condition_spec.rb
+++ b/spec/rubocop/cop/style/conditional_assignment_assign_in_condition_spec.rb
@@ -523,7 +523,7 @@ describe RuboCop::Cop::Style::ConditionalAssignment do
                                                     assign_inside_condition)
                           },
                           'Lint/EndAlignment' => {
-                            'AlignWith' => 'keyword',
+                            'EnforcedStyleAlignWith' => 'keyword',
                             'Enabled' => true
                           },
                           'Metrics/LineLength' => {
@@ -711,7 +711,7 @@ describe RuboCop::Cop::Style::ConditionalAssignment do
                                                     assign_inside_condition)
                           },
                           'Lint/EndAlignment' => {
-                            'AlignWith' => 'keyword',
+                            'EnforcedStyleAlignWith' => 'keyword',
                             'Enabled' => true
                           },
                           'Metrics/LineLength' => {

--- a/spec/rubocop/cop/style/conditional_assignment_assign_to_condition_spec.rb
+++ b/spec/rubocop/cop/style/conditional_assignment_assign_to_condition_spec.rb
@@ -13,7 +13,7 @@ describe RuboCop::Cop::Style::ConditionalAssignment do
                                                   assign_inside_condition)
                         },
                         'Lint/EndAlignment' => {
-                          'AlignWith' => 'keyword',
+                          'EnforcedStyleAlignWith' => 'keyword',
                           'Enabled' => true
                         },
                         'Metrics/LineLength' => {
@@ -1522,7 +1522,7 @@ describe RuboCop::Cop::Style::ConditionalAssignment do
                                                     assign_inside_condition)
                           },
                           'Lint/EndAlignment' => {
-                            'AlignWith' => 'keyword',
+                            'EnforcedStyleAlignWith' => 'keyword',
                             'Enabled' => true
                           },
                           'Metrics/LineLength' => {
@@ -1980,7 +1980,7 @@ describe RuboCop::Cop::Style::ConditionalAssignment do
                             'SingleLineConditionsOnly' => false
                           },
                           'Lint/EndAlignment' => {
-                            'AlignWith' => 'start_of_line',
+                            'EnforcedStyleAlignWith' => 'start_of_line',
                             'Enabled' => true
                           },
                           'Metrics/LineLength' => {

--- a/spec/rubocop/cop/style/else_alignment_spec.rb
+++ b/spec/rubocop/cop/style/else_alignment_spec.rb
@@ -8,7 +8,7 @@ describe RuboCop::Cop::Style::ElseAlignment do
     RuboCop::Config.new('Lint/EndAlignment' => end_alignment_config)
   end
   let(:end_alignment_config) do
-    { 'Enabled' => true, 'AlignWith' => 'variable' }
+    { 'Enabled' => true, 'EnforcedStyleAlignWith' => 'variable' }
   end
 
   it 'accepts a ternary if' do
@@ -284,7 +284,7 @@ describe RuboCop::Cop::Style::ElseAlignment do
 
       context 'when alignment style is keyword by choice' do
         let(:end_alignment_config) do
-          { 'Enabled' => true, 'AlignWith' => 'keyword' }
+          { 'Enabled' => true, 'EnforcedStyleAlignWith' => 'keyword' }
         end
 
         include_examples 'assignment and if with keyword alignment'

--- a/spec/rubocop/cop/style/indentation_width_spec.rb
+++ b/spec/rubocop/cop/style/indentation_width_spec.rb
@@ -12,10 +12,10 @@ describe RuboCop::Cop::Style::IndentationWidth do
   end
   let(:consistency_config) { { 'EnforcedStyle' => 'normal' } }
   let(:end_alignment_config) do
-    { 'Enabled' => true, 'AlignWith' => 'variable' }
+    { 'Enabled' => true, 'EnforcedStyleAlignWith' => 'variable' }
   end
   let(:def_end_alignment_config) do
-    { 'Enabled' => true, 'AlignWith' => 'start_of_line' }
+    { 'Enabled' => true, 'EnforcedStyleAlignWith' => 'start_of_line' }
   end
 
   context 'with Width set to 4' do
@@ -591,7 +591,7 @@ describe RuboCop::Cop::Style::IndentationWidth do
 
         context 'when alignment style is keyword by choice' do
           let(:end_alignment_config) do
-            { 'Enabled' => true, 'AlignWith' => 'keyword' }
+            { 'Enabled' => true, 'EnforcedStyleAlignWith' => 'keyword' }
           end
 
           include_examples 'assignment and if with keyword alignment'
@@ -809,7 +809,7 @@ describe RuboCop::Cop::Style::IndentationWidth do
 
       context 'when end is aligned with start of line' do
         let(:def_end_alignment_config) do
-          { 'Enabled' => true, 'AlignWith' => 'start_of_line' }
+          { 'Enabled' => true, 'EnforcedStyleAlignWith' => 'start_of_line' }
         end
 
         include_examples 'without modifier on the same line'
@@ -847,7 +847,7 @@ describe RuboCop::Cop::Style::IndentationWidth do
 
       context 'when end is aligned with def' do
         let(:def_end_alignment_config) do
-          { 'Enabled' => true, 'AlignWith' => 'def' }
+          { 'Enabled' => true, 'EnforcedStyleAlignWith' => 'def' }
         end
 
         include_examples 'without modifier on the same line'

--- a/spec/rubocop/cop/util_spec.rb
+++ b/spec/rubocop/cop/util_spec.rb
@@ -121,19 +121,9 @@ describe RuboCop::Cop::Util do
       it { is_expected.to eq('SupportedStyles') }
     end
 
-    context 'when EnforcedMode' do
-      let(:enforced_style) { 'EnforcedMode' }
-      it { is_expected.to eq('SupportedModes') }
-    end
-
     context 'when EnforcedStyleInsidePipes' do
       let(:enforced_style) { 'EnforcedStyleInsidePipes' }
       it { is_expected.to eq('SupportedStylesInsidePipes') }
-    end
-
-    context 'when AlignWith' do
-      let(:enforced_style) { 'AlignWith' }
-      it { is_expected.to eq('SupportedStyles') }
     end
   end
 end

--- a/spec/rubocop/cop/util_spec.rb
+++ b/spec/rubocop/cop/util_spec.rb
@@ -112,4 +112,28 @@ describe RuboCop::Cop::Util do
       end
     end
   end
+
+  describe '#to_supported_styles' do
+    subject { RuboCop::Cop::Util.to_supported_styles(enforced_style) }
+
+    context 'when EnforcedStyle' do
+      let(:enforced_style) { 'EnforcedStyle' }
+      it { is_expected.to eq('SupportedStyles') }
+    end
+
+    context 'when EnforcedMode' do
+      let(:enforced_style) { 'EnforcedMode' }
+      it { is_expected.to eq('SupportedModes') }
+    end
+
+    context 'when EnforcedStyleInsidePipes' do
+      let(:enforced_style) { 'EnforcedStyleInsidePipes' }
+      it { is_expected.to eq('SupportedStylesInsidePipes') }
+    end
+
+    context 'when AlignWith' do
+      let(:enforced_style) { 'AlignWith' }
+      it { is_expected.to eq('SupportedStyles') }
+    end
+  end
 end


### PR DESCRIPTION

I added a validation for supported styles other than EnforcedStyle.

Problem
======

Currently, EnforcedStyle value is validated by SupportedStyles.

e.g.

```sh
$ cat .rubocop.yml
Style/AlignParameters:
  EnforcedStyle: aaaaaaaaaaaaaaaaaaaaaa
$ rubocop
Error: invalid EnforcedStyle 'aaaaaaaaaaaaaaaaaaaaaa' for Style/AlignParameters found in /tmp/tmp.SyHaGtdT0U/.rubocop.yml
Valid choices are: with_first_parameter, with_fixed_indentation
```

However, other styles aren't validated.

e.g.

```sh
$ cat .rubocop.yml
Style/SpaceAroundBlockParameters:
  EnforcedStyleInsidePipes: aaaaaaaaaaaaaaaaaaaaaa
$ rubocop
Inspecting 0 files

0 files inspected, no offenses detected
```

Goal
======

Validate the invalid value.

e.g.

```sh
$ cat .rubocop.yml
Style/SpaceAroundBlockParameters:
  EnforcedStyleInsidePipes: aaaaaaaaaaaaaaaaaaaaaa
$ rubocop
Error: invalid EnforcedStyleInsidePipes 'aaaaaaaaaaaaaaaaaaaaaa' for Style/SpaceAroundBlockParameters found in /tmp/tmp.SyHaGtdT0U/.rubocop.yml
Valid choices are: space, no_space
```

Changes
=====

- Add validation for styles other than `EnforcedStyle`
  - And rename some `SupportedStyles` names to match EnforcedStyle name
    - e.g. `SupportedStyles` to `SupportedStylesInsidePipes` (for `EnforcedStyleInsidePipes`)
- Add `SupportedStyles` for missing styles in config/default.yml
- Add a spec to check existence of `SupportedStyles` into `project_spec.rb`
- Add test cases to check validation

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Used the same coding conventions as the rest of the project.
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] All tests are passing.
* [x] The new code doesn't generate RuboCop offenses.
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Updated cop documentation with `rake generate_cops_documentation` (required only when you've added a new cop or changed the configuration/documentation of an existing cop).

[1]: http://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html
