### PR TITLE
Avoid crash in `Style/ConditionalAssignment` cop with masgn

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -13,7 +13,7 @@ Metrics/AbcSize:
 # Offense count: 33
 # Configuration parameters: CountComments.
 Metrics/ClassLength:
-  Max: 172
+  Max: 173
 
 # Offense count: 30
 Metrics/CyclomaticComplexity:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 ### Bug fixes
 
 * [#3751](https://github.com/bbatsov/rubocop/pull/3751): Avoid crash in `Rails/EnumUniqueness` cop. ([@pocke][])
+* [#3766](https://github.com/bbatsov/rubocop/pull/3766): Avoid crash in `Style/ConditionalAssignment` cop with masgn. ([@pocke][])
 
 ## 0.46.0 (2016-11-30)
 

--- a/lib/rubocop/cop/style/conditional_assignment.rb
+++ b/lib/rubocop/cop/style/conditional_assignment.rb
@@ -92,6 +92,15 @@ module RuboCop
           method_name.to_s.end_with?(EQUAL) &&
             ![:!=, :==, :===, :>=, :<=].include?(method_name)
         end
+
+        def part_of_masgn_type?(node)
+          masgn_count = if node.casgn_type?
+                          2
+                        else
+                          1
+                        end
+          node.children.size == masgn_count
+        end
       end
 
       # Check for `if` and `case` statements where each branch is used for
@@ -201,8 +210,8 @@ module RuboCop
           'Assign variables inside of conditionals'.freeze
         VARIABLE_ASSIGNMENT_TYPES =
           [:casgn, :cvasgn, :gvasgn, :ivasgn, :lvasgn].freeze
-        ASSIGNMENT_TYPES =
-          VARIABLE_ASSIGNMENT_TYPES + [:and_asgn, :or_asgn, :op_asgn].freeze
+        ASSIGNMENT_TYPES = VARIABLE_ASSIGNMENT_TYPES +
+                           [:and_asgn, :or_asgn, :op_asgn, :masgn].freeze
         IF = 'if'.freeze
         UNLESS = 'unless'.freeze
         LINE_LENGTH = 'Metrics/LineLength'.freeze
@@ -218,6 +227,7 @@ module RuboCop
           define_method "on_#{type}" do |node|
             return if part_of_ignored_node?(node)
             return unless style == :assign_inside_condition
+            return if part_of_masgn_type?(node)
 
             check_assignment_to_condition(node)
           end

--- a/spec/rubocop/cop/style/conditional_assignment_assign_in_condition_spec.rb
+++ b/spec/rubocop/cop/style/conditional_assignment_assign_in_condition_spec.rb
@@ -42,6 +42,30 @@ describe RuboCop::Cop::Style::ConditionalAssignment do
       expect(cop.messages).to eq([described_class::ASSIGN_TO_CONDITION_MSG])
     end
 
+    it 'registers an offense assigning any variable type to if else' \
+      'with multiple assignment' do
+      source = ["#{variable}, #{variable} = if foo",
+                '                something',
+                '              else',
+                '                something_else',
+                '              end']
+      inspect_source(cop, source)
+
+      expect(cop.messages).to eq([described_class::ASSIGN_TO_CONDITION_MSG])
+    end
+
+    it 'allows assigning any variable type inside if else' \
+      'with multiple assignment' do
+      source = ['if foo',
+                "  #{variable}, #{variable} = something",
+                'else',
+                "  #{variable}, #{variable} = something_else",
+                'end']
+      inspect_source(cop, source)
+
+      expect(cop.messages).to be_empty
+    end
+
     it 'allows assigning any variable type inside if else' do
       source = ['if foo',
                 "  #{variable} = 1",


### PR DESCRIPTION
Problem
======

`Style/ConditionalAssignment` cop crashes with multiple assignment when `EnforcedStyle` is `assign_to_condition`.

e.g. 

```yaml
# .rubocop.yml
Style/ConditionalAssignment:
  EnforcedStyle: assign_inside_condition
  Enabled: true
```

```ruby
# test.rb
x, y = a
```

```sh
$ rubocop -d
An error occurred while Style/ConditionalAssignment cop was inspecting /tmp/tmp.xqGCvflgnB/test.rb.
An error occurred while Style/ConditionalAssignment cop was inspecting /tmp/tmp.xqGCvflgnB/test.rb.
For /tmp/tmp.xqGCvflgnB: configuration from /tmp/tmp.xqGCvflgnB/.rubocop.yml
Default configuration from /home/pocke/.gem/ruby/2.3.0/gems/rubocop-0.46.0/config/default.yml
Inheriting configuration from /home/pocke/.gem/ruby/2.3.0/gems/rubocop-0.46.0/config/enabled.yml
Inheriting configuration from /home/pocke/.gem/ruby/2.3.0/gems/rubocop-0.46.0/config/disabled.yml
Inspecting 1 file
Scanning /tmp/tmp.xqGCvflgnB/test.rb
undefined method `begin_type?' for :x:Symbol
/home/pocke/.gem/ruby/2.3.0/gems/rubocop-0.46.0/lib/rubocop/cop/style/conditional_assignment.rb:289:in `assignment_node'
/home/pocke/.gem/ruby/2.3.0/gems/rubocop-0.46.0/lib/rubocop/cop/style/conditional_assignment.rb:236:in `check_assignment_to_condition'
/home/pocke/.gem/ruby/2.3.0/gems/rubocop-0.46.0/lib/rubocop/cop/style/conditional_assignment.rb:222:in `block (2 levels) in <class:ConditionalAssignment>'
/home/pocke/.gem/ruby/2.3.0/gems/rubocop-0.46.0/lib/rubocop/cop/commissioner.rb:41:in `block (2 levels) in on_lvasgn'
/home/pocke/.gem/ruby/2.3.0/gems/rubocop-0.46.0/lib/rubocop/cop/commissioner.rb:96:in `with_cop_error_handling'
/home/pocke/.gem/ruby/2.3.0/gems/rubocop-0.46.0/lib/rubocop/cop/commissioner.rb:40:in `block in on_lvasgn'
/home/pocke/.gem/ruby/2.3.0/gems/rubocop-0.46.0/lib/rubocop/cop/commissioner.rb:39:in `each'
/home/pocke/.gem/ruby/2.3.0/gems/rubocop-0.46.0/lib/rubocop/cop/commissioner.rb:39:in `on_lvasgn'
(eval):2:in `block in on_mlhs'
(eval):2:in `each'
(eval):2:in `on_mlhs'
/home/pocke/.gem/ruby/2.3.0/gems/rubocop-0.46.0/lib/rubocop/cop/commissioner.rb:45:in `on_mlhs'
(eval):2:in `block in on_masgn'
(eval):2:in `each'
(eval):2:in `on_masgn'
/home/pocke/.gem/ruby/2.3.0/gems/rubocop-0.46.0/lib/rubocop/cop/commissioner.rb:45:in `on_masgn'
/home/pocke/.gem/ruby/2.3.0/gems/rubocop-0.46.0/lib/rubocop/ast_node/traversal.rb:12:in `walk'
/home/pocke/.gem/ruby/2.3.0/gems/rubocop-0.46.0/lib/rubocop/cop/commissioner.rb:58:in `investigate'
/home/pocke/.gem/ruby/2.3.0/gems/rubocop-0.46.0/lib/rubocop/cop/team.rb:120:in `investigate'
/home/pocke/.gem/ruby/2.3.0/gems/rubocop-0.46.0/lib/rubocop/cop/team.rb:108:in `offenses'
/home/pocke/.gem/ruby/2.3.0/gems/rubocop-0.46.0/lib/rubocop/cop/team.rb:51:in `inspect_file'
/home/pocke/.gem/ruby/2.3.0/gems/rubocop-0.46.0/lib/rubocop/runner.rb:243:in `inspect_file'
/home/pocke/.gem/ruby/2.3.0/gems/rubocop-0.46.0/lib/rubocop/runner.rb:190:in `block in do_inspection_loop'
/home/pocke/.gem/ruby/2.3.0/gems/rubocop-0.46.0/lib/rubocop/runner.rb:222:in `block in iterate_until_no_changes'
/home/pocke/.gem/ruby/2.3.0/gems/rubocop-0.46.0/lib/rubocop/runner.rb:215:in `loop'
/home/pocke/.gem/ruby/2.3.0/gems/rubocop-0.46.0/lib/rubocop/runner.rb:215:in `iterate_until_no_changes'
/home/pocke/.gem/ruby/2.3.0/gems/rubocop-0.46.0/lib/rubocop/runner.rb:186:in `do_inspection_loop'
/home/pocke/.gem/ruby/2.3.0/gems/rubocop-0.46.0/lib/rubocop/runner.rb:101:in `block in file_offenses'
/home/pocke/.gem/ruby/2.3.0/gems/rubocop-0.46.0/lib/rubocop/runner.rb:111:in `file_offense_cache'
/home/pocke/.gem/ruby/2.3.0/gems/rubocop-0.46.0/lib/rubocop/runner.rb:99:in `file_offenses'
/home/pocke/.gem/ruby/2.3.0/gems/rubocop-0.46.0/lib/rubocop/runner.rb:90:in `process_file'
/home/pocke/.gem/ruby/2.3.0/gems/rubocop-0.46.0/lib/rubocop/runner.rb:68:in `block in each_inspected_file'
/home/pocke/.gem/ruby/2.3.0/gems/rubocop-0.46.0/lib/rubocop/runner.rb:65:in `each'
/home/pocke/.gem/ruby/2.3.0/gems/rubocop-0.46.0/lib/rubocop/runner.rb:65:in `reduce'
/home/pocke/.gem/ruby/2.3.0/gems/rubocop-0.46.0/lib/rubocop/runner.rb:65:in `each_inspected_file'
/home/pocke/.gem/ruby/2.3.0/gems/rubocop-0.46.0/lib/rubocop/runner.rb:57:in `inspect_files'
/home/pocke/.gem/ruby/2.3.0/gems/rubocop-0.46.0/lib/rubocop/runner.rb:36:in `run'
/home/pocke/.gem/ruby/2.3.0/gems/rubocop-0.46.0/lib/rubocop/cli.rb:72:in `execute_runner'
/home/pocke/.gem/ruby/2.3.0/gems/rubocop-0.46.0/lib/rubocop/cli.rb:27:in `run'
/home/pocke/.gem/ruby/2.3.0/gems/rubocop-0.46.0/bin/rubocop:13:in `block in <top (required)>'
/usr/lib/ruby/2.3.0/benchmark.rb:308:in `realtime'
/home/pocke/.gem/ruby/2.3.0/gems/rubocop-0.46.0/bin/rubocop:12:in `<top (required)>'
/home/pocke/.gem/ruby/2.3.0/bin//rubocop:22:in `load'
/home/pocke/.gem/ruby/2.3.0/bin//rubocop:22:in `<main>'
undefined method `begin_type?' for :y:Symbol
/home/pocke/.gem/ruby/2.3.0/gems/rubocop-0.46.0/lib/rubocop/cop/style/conditional_assignment.rb:289:in `assignment_node'
/home/pocke/.gem/ruby/2.3.0/gems/rubocop-0.46.0/lib/rubocop/cop/style/conditional_assignment.rb:236:in `check_assignment_to_condition'
/home/pocke/.gem/ruby/2.3.0/gems/rubocop-0.46.0/lib/rubocop/cop/style/conditional_assignment.rb:222:in `block (2 levels) in <class:ConditionalAssignment>'
/home/pocke/.gem/ruby/2.3.0/gems/rubocop-0.46.0/lib/rubocop/cop/commissioner.rb:41:in `block (2 levels) in on_lvasgn'
/home/pocke/.gem/ruby/2.3.0/gems/rubocop-0.46.0/lib/rubocop/cop/commissioner.rb:96:in `with_cop_error_handling'
/home/pocke/.gem/ruby/2.3.0/gems/rubocop-0.46.0/lib/rubocop/cop/commissioner.rb:40:in `block in on_lvasgn'
/home/pocke/.gem/ruby/2.3.0/gems/rubocop-0.46.0/lib/rubocop/cop/commissioner.rb:39:in `each'
/home/pocke/.gem/ruby/2.3.0/gems/rubocop-0.46.0/lib/rubocop/cop/commissioner.rb:39:in `on_lvasgn'
(eval):2:in `block in on_mlhs'
(eval):2:in `each'
(eval):2:in `on_mlhs'
/home/pocke/.gem/ruby/2.3.0/gems/rubocop-0.46.0/lib/rubocop/cop/commissioner.rb:45:in `on_mlhs'
(eval):2:in `block in on_masgn'
(eval):2:in `each'
(eval):2:in `on_masgn'
/home/pocke/.gem/ruby/2.3.0/gems/rubocop-0.46.0/lib/rubocop/cop/commissioner.rb:45:in `on_masgn'
/home/pocke/.gem/ruby/2.3.0/gems/rubocop-0.46.0/lib/rubocop/ast_node/traversal.rb:12:in `walk'
/home/pocke/.gem/ruby/2.3.0/gems/rubocop-0.46.0/lib/rubocop/cop/commissioner.rb:58:in `investigate'
/home/pocke/.gem/ruby/2.3.0/gems/rubocop-0.46.0/lib/rubocop/cop/team.rb:120:in `investigate'
/home/pocke/.gem/ruby/2.3.0/gems/rubocop-0.46.0/lib/rubocop/cop/team.rb:108:in `offenses'
/home/pocke/.gem/ruby/2.3.0/gems/rubocop-0.46.0/lib/rubocop/cop/team.rb:51:in `inspect_file'
/home/pocke/.gem/ruby/2.3.0/gems/rubocop-0.46.0/lib/rubocop/runner.rb:243:in `inspect_file'
/home/pocke/.gem/ruby/2.3.0/gems/rubocop-0.46.0/lib/rubocop/runner.rb:190:in `block in do_inspection_loop'
/home/pocke/.gem/ruby/2.3.0/gems/rubocop-0.46.0/lib/rubocop/runner.rb:222:in `block in iterate_until_no_changes'
/home/pocke/.gem/ruby/2.3.0/gems/rubocop-0.46.0/lib/rubocop/runner.rb:215:in `loop'
/home/pocke/.gem/ruby/2.3.0/gems/rubocop-0.46.0/lib/rubocop/runner.rb:215:in `iterate_until_no_changes'
/home/pocke/.gem/ruby/2.3.0/gems/rubocop-0.46.0/lib/rubocop/runner.rb:186:in `do_inspection_loop'
/home/pocke/.gem/ruby/2.3.0/gems/rubocop-0.46.0/lib/rubocop/runner.rb:101:in `block in file_offenses'
/home/pocke/.gem/ruby/2.3.0/gems/rubocop-0.46.0/lib/rubocop/runner.rb:111:in `file_offense_cache'
/home/pocke/.gem/ruby/2.3.0/gems/rubocop-0.46.0/lib/rubocop/runner.rb:99:in `file_offenses'
/home/pocke/.gem/ruby/2.3.0/gems/rubocop-0.46.0/lib/rubocop/runner.rb:90:in `process_file'
/home/pocke/.gem/ruby/2.3.0/gems/rubocop-0.46.0/lib/rubocop/runner.rb:68:in `block in each_inspected_file'
/home/pocke/.gem/ruby/2.3.0/gems/rubocop-0.46.0/lib/rubocop/runner.rb:65:in `each'
/home/pocke/.gem/ruby/2.3.0/gems/rubocop-0.46.0/lib/rubocop/runner.rb:65:in `reduce'
/home/pocke/.gem/ruby/2.3.0/gems/rubocop-0.46.0/lib/rubocop/runner.rb:65:in `each_inspected_file'
/home/pocke/.gem/ruby/2.3.0/gems/rubocop-0.46.0/lib/rubocop/runner.rb:57:in `inspect_files'
/home/pocke/.gem/ruby/2.3.0/gems/rubocop-0.46.0/lib/rubocop/runner.rb:36:in `run'
/home/pocke/.gem/ruby/2.3.0/gems/rubocop-0.46.0/lib/rubocop/cli.rb:72:in `execute_runner'
/home/pocke/.gem/ruby/2.3.0/gems/rubocop-0.46.0/lib/rubocop/cli.rb:27:in `run'
/home/pocke/.gem/ruby/2.3.0/gems/rubocop-0.46.0/bin/rubocop:13:in `block in <top (required)>'
/usr/lib/ruby/2.3.0/benchmark.rb:308:in `realtime'
/home/pocke/.gem/ruby/2.3.0/gems/rubocop-0.46.0/bin/rubocop:12:in `<top (required)>'
/home/pocke/.gem/ruby/2.3.0/bin//rubocop:22:in `load'
/home/pocke/.gem/ruby/2.3.0/bin//rubocop:22:in `<main>'
W

Offenses:

test.rb:2:1: W: Lint/UselessAssignment: Useless assignment to variable - x. Use _ or _x as a variable name to indicate that it won't be used.

2 errors occurred:
An error occurred while Style/ConditionalAssignment cop was inspecting /tmp/tmp.xqGCvflgnB/test.rb.
An error occurred while Style/ConditionalAssignment cop was inspecting /tmp/tmp.xqGCvflgnB/test.rb.
Errors are usually caused by RuboCop bugs.
Please, report your problems to RuboCop's issue tracker.
Mention the following information in the issue report:
0.46.0 (using Parser 2.3.3.1, running on ruby 2.3.2 x86_64-linux)
x, y = a
^
test.rb:2:4: W: Lint/UselessAssignment: Useless assignment to variable - y. Use _ or _y as a variable name to indicate that it won't be used.
x, y = a
   ^

1 file inspected, 2 offenses detected
Finished in 0.1687188179930672 seconds

```


Cause
======


`lvasgn`(and other asgn nodes) don't have assignment in `masgn` node.

```ruby
# normal assignment
x = 1
# multiple assignment
y, z = something

# AST for the above code
# s(:begin,
#   s(:lvasgn, :x,
#     s(:int, 1)),
#   s(:masgn,
#     s(:mlhs,
#       s(:lvasgn, :y),
#       s(:lvasgn, :z)),
#     s(:send, nil, :something)))
```

However, the cop did not handle the problem.

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Used the same coding conventions as the rest of the project.
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] All tests are passing.
* [x] The new code doesn't generate RuboCop offenses.
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [ ] Updated cop documentation with `rake generate_cops_documentation` (required only when you've added a new cop or changed the configuration/documentation of an existing cop).

[1]: http://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html

