### PR TITLE
Don't flag raised to a power negative numeric literals.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 
 * [#3751](https://github.com/bbatsov/rubocop/pull/3751): Avoid crash in `Rails/EnumUniqueness` cop. ([@pocke][])
 * [#3766](https://github.com/bbatsov/rubocop/pull/3766): Avoid crash in `Style/ConditionalAssignment` cop with masgn. ([@pocke][])
+* [#xxxx](https://github.com/bbatsov/rubocop/pull/xxxx): `Style/RedundantParentheses` Don't flag raised to a power negative numeric literals, since removing the parentheses would change the meaning of the expressions. ([@amogil][])
 
 ## 0.46.0 (2016-11-30)
 
@@ -2528,3 +2529,4 @@
 [@aesthetikx]: https://github.com/aesthetikx
 [@tdeo]: https://github.com/tdeo
 [@AlexWayfer]: https://github.com/AlexWayfer
+[@amogil]: https://github.com/amogil

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@
 
 * [#3751](https://github.com/bbatsov/rubocop/pull/3751): Avoid crash in `Rails/EnumUniqueness` cop. ([@pocke][])
 * [#3766](https://github.com/bbatsov/rubocop/pull/3766): Avoid crash in `Style/ConditionalAssignment` cop with masgn. ([@pocke][])
-* [#xxxx](https://github.com/bbatsov/rubocop/pull/xxxx): `Style/RedundantParentheses` Don't flag raised to a power negative numeric literals, since removing the parentheses would change the meaning of the expressions. ([@amogil][])
+* [#3770](https://github.com/bbatsov/rubocop/pull/3770): `Style/RedundantParentheses` Don't flag raised to a power negative numeric literals, since removing the parentheses would change the meaning of the expressions. ([@amogil][])
 
 ## 0.46.0 (2016-11-30)
 

--- a/lib/rubocop/ast_node.rb
+++ b/lib/rubocop/ast_node.rb
@@ -441,6 +441,10 @@ module RuboCop
       equal?(receiver)
     end
 
+    def numeric_type?
+      int_type? || float_type?
+    end
+
     def_matcher :command?, '(send nil %1 ...)'
     def_matcher :lambda?,  '(block (send nil :lambda) ...)'
     def_matcher :proc?, <<-PATTERN

--- a/lib/rubocop/cop/style/redundant_parentheses.rb
+++ b/lib/rubocop/cop/style/redundant_parentheses.rb
@@ -135,10 +135,14 @@ module RuboCop
         end
 
         def raised_to_power_negative_numeric?(begin_node, node)
-          return false unless node.int_type? || node.float_type?
-          return false if node.children.first >= 0 || begin_node.parent.nil?
+          return false unless node.numeric_type?
 
-          begin_node.parent.children[begin_node.sibling_index + 1] == :**
+          siblings = begin_node.parent && begin_node.parent.children
+          return false if siblings.nil?
+          next_sibling = siblings[begin_node.sibling_index + 1]
+          base_value = node.children.first
+
+          base_value < 0 && next_sibling == :**
         end
 
         def keyword_with_redundant_parentheses?(node)

--- a/lib/rubocop/cop/style/redundant_parentheses.rb
+++ b/lib/rubocop/cop/style/redundant_parentheses.rb
@@ -138,7 +138,7 @@ module RuboCop
           return false unless node.int_type? || node.float_type?
           return false if node.children.first >= 0 || begin_node.parent.nil?
 
-          begin_node.parent.children[node.sibling_index + 1] == :**
+          begin_node.parent.children[begin_node.sibling_index + 1] == :**
         end
 
         def keyword_with_redundant_parentheses?(node)

--- a/spec/rubocop/cop/style/redundant_parentheses_spec.rb
+++ b/spec/rubocop/cop/style/redundant_parentheses_spec.rb
@@ -112,6 +112,11 @@ describe RuboCop::Cop::Style::RedundantParentheses do
   it_behaves_like 'redundant', '{a: (1)}', '{a: 1}', 'a literal', '(1)'
   it_behaves_like 'redundant', "{a: (1\n)}", "{a: 1\n}", 'a literal', "(1\n)"
   it_behaves_like 'plausible', "{a: (1\n),}"
+  it_behaves_like 'redundant', '(0)**2', '0**2', 'a literal', '(0)'
+  it_behaves_like 'redundant', '(2)**2', '2**2', 'a literal', '(2)'
+  it_behaves_like 'redundant', '(2.1)**2', '2.1**2', 'a literal', '(2.1)'
+  it_behaves_like 'plausible', '(-2)**2'
+  it_behaves_like 'plausible', '(-2.1)**2'
 
   it 'accepts parentheses around a method call with unparenthesized ' \
      'arguments' do

--- a/spec/rubocop/cop/style/redundant_parentheses_spec.rb
+++ b/spec/rubocop/cop/style/redundant_parentheses_spec.rb
@@ -116,6 +116,7 @@ describe RuboCop::Cop::Style::RedundantParentheses do
   it_behaves_like 'redundant', '(2)**2', '2**2', 'a literal', '(2)'
   it_behaves_like 'redundant', '(2.1)**2', '2.1**2', 'a literal', '(2.1)'
   it_behaves_like 'redundant', '2**(-2)', '2**-2', 'a literal', '(-2)'
+  it_behaves_like 'redundant', '2**(2)', '2**2', 'a literal', '(2)'
   it_behaves_like 'plausible', '(-2)**2'
   it_behaves_like 'plausible', '(-2.1)**2'
 

--- a/spec/rubocop/cop/style/redundant_parentheses_spec.rb
+++ b/spec/rubocop/cop/style/redundant_parentheses_spec.rb
@@ -115,6 +115,7 @@ describe RuboCop::Cop::Style::RedundantParentheses do
   it_behaves_like 'redundant', '(0)**2', '0**2', 'a literal', '(0)'
   it_behaves_like 'redundant', '(2)**2', '2**2', 'a literal', '(2)'
   it_behaves_like 'redundant', '(2.1)**2', '2.1**2', 'a literal', '(2.1)'
+  it_behaves_like 'redundant', '2**(-2)', '2**-2', 'a literal', '(-2)'
   it_behaves_like 'plausible', '(-2)**2'
   it_behaves_like 'plausible', '(-2.1)**2'
 


### PR DESCRIPTION
Currently `(-2)**2` is flagged as "Don't use parentheses around a literal" offense. But removing the parentheses would change the meaning:

`(-2)**2 #=> 4`
`-2**2 #=> -4`

`Style/RedundantParentheses` fixed by adding the exception for raised to a power negative numeric literals.

`rubocop -V #=> 0.46.0 (using Parser 2.3.3.1, running on ruby 2.2.2 x86_64-darwin14)`

---

- [x] Wrote good commit messages.
- [x] Commit message starts with [Fix #issue-number] (if the related issue exists).
- [x] Used the same coding conventions as the rest of the project.
- [x] Feature branch is up-to-date with master (if not - rebase it).
- [x] Squashed related commits together.
- [x] Added tests.
- [x] Added an entry to the Changelog if the new code introduces user-observable changes. See changelog entry format.
- [x] All tests are passing.
- [x] The new code doesn't generate RuboCop offenses.
- [x] The PR relates to only one subject with a clear title and description in grammatically correct, complete sentences.
- [x] Updated cop documentation with rake generate_cops_documentation (required only when you've added a new cop or changed the configuration/documentation of an existing cop).