### PR TITLE
Add a never configuration to FrozenStringLiteralComment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### New features
 
 * [#3757](https://github.com/bbatsov/rubocop/pull/3757): Add Auto-Correct for `Bundler/OrderedGems` cop. ([@pocke][])
+* `Style/FrozenStringLiteralComment` now supports the style `never` that will remove the `frozen_string_literal` comment. ([@rrosenblum][])
 
 ### Changes
 

--- a/config/default.yml
+++ b/config/default.yml
@@ -535,6 +535,9 @@ Style/FrozenStringLiteralComment:
     # string literal. If you run code against multiple versions of Ruby, it is
     # possible that this will create errors in Ruby 2.3.0+.
     - always
+    # `never` will enforce that the frozen string literal comment does not
+    # exist in a file.
+    - never
 
 # Built-in global variables are allowed by default.
 Style/GlobalVars:

--- a/lib/rubocop/cop/style/frozen_string_literal_comment.rb
+++ b/lib/rubocop/cop/style/frozen_string_literal_comment.rb
@@ -13,31 +13,46 @@ module RuboCop
         include FrozenStringLiteral
 
         MSG = 'Missing frozen string literal comment.'.freeze
+        MSG_UNNECESSARY = 'Unnecessary frozen string literal comment.'.freeze
         SHEBANG = '#!'.freeze
 
         def investigate(processed_source)
           return if style == :when_needed && target_ruby_version < 2.3
           return if processed_source.tokens.empty?
 
-          return if frozen_string_literal_comment_exists?(processed_source)
-
-          offense(processed_source)
+          if frozen_string_literal_comment_exists?(processed_source)
+            check_for_no_comment(processed_source)
+          else
+            check_for_comment(processed_source)
+          end
         end
 
-        def autocorrect(_node)
+        def autocorrect(node)
           lambda do |corrector|
-            last_special_comment = last_special_comment(processed_source)
-            if last_special_comment.nil?
-              corrector.insert_before(processed_source.tokens[0].pos,
-                                      "#{FROZEN_STRING_LITERAL_ENABLED}\n")
+            if style == :never
+              corrector.remove(range_with_surrounding_space(node.pos, :right))
             else
-              corrector.insert_after(last_special_comment.pos,
-                                     "\n#{FROZEN_STRING_LITERAL_ENABLED}")
+              last_special_comment = last_special_comment(processed_source)
+              if last_special_comment.nil?
+                corrector.insert_before(processed_source.tokens[0].pos,
+                                        "#{FROZEN_STRING_LITERAL_ENABLED}\n")
+              else
+                corrector.insert_after(last_special_comment.pos,
+                                       "\n#{FROZEN_STRING_LITERAL_ENABLED}")
+              end
             end
           end
         end
 
         private
+
+        def check_for_no_comment(processed_source)
+          unnecessary_comment_offense(processed_source) if style == :never
+        end
+
+        def check_for_comment(processed_source)
+          offense(processed_source) unless style == :never
+        end
 
         def last_special_comment(processed_source)
           token_number = 0
@@ -54,12 +69,26 @@ module RuboCop
           token
         end
 
+        def frozen_string_literal_comment(processed_source)
+          processed_source.tokens.find do |token|
+            token.text.start_with?(FrozenStringLiteral::FROZEN_STRING_LITERAL)
+          end
+        end
+
         def offense(processed_source)
           last_special_comment = last_special_comment(processed_source)
-          last_special_comment ||= processed_source.tokens[0]
           range = source_range(processed_source.buffer, 0, 0)
 
           add_offense(last_special_comment, range, MSG)
+        end
+
+        def unnecessary_comment_offense(processed_source)
+          frozen_string_literal_comment =
+            frozen_string_literal_comment(processed_source)
+
+          add_offense(frozen_string_literal_comment,
+                      frozen_string_literal_comment.pos,
+                      MSG_UNNECESSARY)
         end
       end
     end

--- a/manual/cops_style.md
+++ b/manual/cops_style.md
@@ -1552,7 +1552,7 @@ comment. The frozen string literal comment is only valid in Ruby 2.3+.
 Attribute | Value
 --- | ---
 EnforcedStyle | when_needed
-SupportedStyles | when_needed, always
+SupportedStyles | when_needed, always, never
 
 
 ## Style/GlobalVars

--- a/spec/rubocop/cop/style/frozen_string_literal_comment_spec.rb
+++ b/spec/rubocop/cop/style/frozen_string_literal_comment_spec.rb
@@ -8,8 +8,7 @@ describe RuboCop::Cop::Style::FrozenStringLiteralComment, :config do
   context 'always' do
     let(:cop_config) do
       { 'Enabled'           => true,
-        'EnforcedStyle'     => 'always',
-        'SupportedStyles'   => %w(always when_needed) }
+        'EnforcedStyle'     => 'always' }
     end
 
     it 'accepts an empty source' do
@@ -212,8 +211,7 @@ describe RuboCop::Cop::Style::FrozenStringLiteralComment, :config do
   context 'when_needed' do
     let(:cop_config) do
       { 'Enabled'           => true,
-        'EnforcedStyle'     => 'when_needed',
-        'SupportedStyles'   => %w(always when_needed) }
+        'EnforcedStyle'     => 'when_needed' }
     end
 
     it 'accepts an empty source' do
@@ -337,6 +335,258 @@ describe RuboCop::Cop::Style::FrozenStringLiteralComment, :config do
           expect(cop.messages)
             .to eq(['Missing frozen string literal comment.'])
         end
+      end
+    end
+  end
+
+  context 'never' do
+    let(:cop_config) do
+      { 'Enabled'           => true,
+        'EnforcedStyle'     => 'never' }
+    end
+
+    it 'accepts an empty source' do
+      inspect_source(cop, '')
+
+      expect(cop.offenses).to be_empty
+    end
+
+    it 'accepts a source with no tokens' do
+      inspect_source(cop, ' ')
+
+      expect(cop.offenses).to be_empty
+    end
+
+    it 'registers an offense for a frozen string literal comment ' \
+      'on the top line' do
+      inspect_source(cop, ['# frozen_string_literal: true',
+                           'puts 1'])
+
+      expect(cop.messages).to eq(['Unnecessary frozen string literal comment.'])
+      expect(cop.highlights).to eq(['# frozen_string_literal: true'])
+    end
+
+    it 'registers an offense for a disabled frozen string literal comment ' \
+      'on the top line' do
+      inspect_source(cop, ['# frozen_string_literal: false',
+                           'puts 1'])
+
+      expect(cop.messages).to eq(['Unnecessary frozen string literal comment.'])
+      expect(cop.highlights).to eq(['# frozen_string_literal: false'])
+    end
+
+    it 'accepts not having a frozen string literal comment on the top line' do
+      inspect_source(cop, 'puts 1')
+
+      expect(cop.offenses).to be_empty
+    end
+
+    it 'accepts not having not having a frozen string literal comment ' \
+      'under a shebang' do
+      inspect_source(cop, ['#!/usr/bin/env ruby',
+                           'puts 1'])
+
+      expect(cop.offenses).to be_empty
+    end
+
+    it 'registers an offense for a frozen string literal comment ' \
+      'below a shebang comment' do
+      inspect_source(cop, ['#!/usr/bin/env ruby',
+                           '# frozen_string_literal: true',
+                           'puts 1'])
+
+      expect(cop.messages).to eq(['Unnecessary frozen string literal comment.'])
+      expect(cop.highlights).to eq(['# frozen_string_literal: true'])
+    end
+
+    it 'registers an offense for a disabled frozen string literal ' \
+      'below a shebang comment' do
+      inspect_source(cop, ['#!/usr/bin/env ruby',
+                           '# frozen_string_literal: false',
+                           'puts 1'])
+
+      expect(cop.messages).to eq(['Unnecessary frozen string literal comment.'])
+      expect(cop.highlights).to eq(['# frozen_string_literal: false'])
+    end
+
+    it 'allows not having a frozen string literal comment ' \
+      'under an encoding comment' do
+      inspect_source(cop, ['# encoding: utf-8',
+                           'puts 1'])
+
+      expect(cop.offenses).to be_empty
+    end
+
+    it 'registers an offense for a frozen string literal comment below ' \
+      'an encoding comment' do
+      inspect_source(cop, ['# encoding: utf-8',
+                           '# frozen_string_literal: true',
+                           'puts 1'])
+
+      expect(cop.messages).to eq(['Unnecessary frozen string literal comment.'])
+      expect(cop.highlights).to eq(['# frozen_string_literal: true'])
+    end
+
+    it 'registers an offense for a dsabled frozen string literal below ' \
+      'an encoding comment' do
+      inspect_source(cop, ['# encoding: utf-8',
+                           '# frozen_string_literal: false',
+                           'puts 1'])
+
+      expect(cop.messages).to eq(['Unnecessary frozen string literal comment.'])
+      expect(cop.highlights).to eq(['# frozen_string_literal: false'])
+    end
+
+    it 'allows not having a frozen string literal comment ' \
+      'under a shebang and an encoding comment' do
+      inspect_source(cop, ['#!/usr/bin/env ruby',
+                           '# encoding: utf-8',
+                           'puts 1'])
+
+      expect(cop.offenses).to be_empty
+    end
+
+    it 'registers an offense for a frozen string literal comment ' \
+      'below shebang and encoding comments' do
+      inspect_source(cop, ['#!/usr/bin/env ruby',
+                           '# encoding: utf-8',
+                           '# frozen_string_literal: true',
+                           'puts 1'])
+
+      expect(cop.messages).to eq(['Unnecessary frozen string literal comment.'])
+      expect(cop.highlights).to eq(['# frozen_string_literal: true'])
+    end
+
+    it 'registers an offense for a disabled frozen string literal comment ' \
+      'below shebang and encoding comments' do
+      inspect_source(cop, ['#!/usr/bin/env ruby',
+                           '# encoding: utf-8',
+                           '# frozen_string_literal: false',
+                           'puts 1'])
+
+      expect(cop.messages).to eq(['Unnecessary frozen string literal comment.'])
+      expect(cop.highlights).to eq(['# frozen_string_literal: false'])
+    end
+
+    it 'registers an offense for a frozen string literal comment ' \
+      'below shebang above an encoding comments' do
+      inspect_source(cop, ['#!/usr/bin/env ruby',
+                           '# frozen_string_literal: true',
+                           '# encoding: utf-8',
+                           'puts 1'])
+
+      expect(cop.messages).to eq(['Unnecessary frozen string literal comment.'])
+      expect(cop.highlights).to eq(['# frozen_string_literal: true'])
+    end
+
+    it 'registers an offense for a disabled frozen string literal comment ' \
+      'below shebang above an encoding comments' do
+      inspect_source(cop, ['#!/usr/bin/env ruby',
+                           '# frozen_string_literal: false',
+                           '# encoding: utf-8',
+                           'puts 1'])
+
+      expect(cop.messages).to eq(['Unnecessary frozen string literal comment.'])
+      expect(cop.highlights).to eq(['# frozen_string_literal: false'])
+    end
+
+    context 'auto-correct' do
+      it 'removes the frozen string literal comment from the top line' do
+        new_source = autocorrect_source(cop, ['# frozen_string_literal: true',
+                                              'puts 1'])
+
+        expect(new_source).to eq('puts 1')
+      end
+
+      it 'removes a disabled frozen string literal comment on the top line' do
+        new_source = autocorrect_source(cop, ['# frozen_string_literal: false',
+                                              'puts 1'])
+
+        expect(new_source).to eq('puts 1')
+      end
+
+      it 'removes a frozen string literal comment below a shebang comment' do
+        new_source = autocorrect_source(cop, ['#!/usr/bin/env ruby',
+                                              '# frozen_string_literal: true',
+                                              'puts 1'])
+
+        expect(new_source).to eq(['#!/usr/bin/env ruby',
+                                  'puts 1'].join("\n"))
+      end
+
+      it 'removes a disabled frozen string literal below a shebang comment' do
+        new_source = autocorrect_source(cop, ['#!/usr/bin/env ruby',
+                                              '# frozen_string_literal: false',
+                                              'puts 1'])
+
+        expect(new_source).to eq(['#!/usr/bin/env ruby',
+                                  'puts 1'].join("\n"))
+      end
+
+      it 'removes a frozen string literal comment below an encoding comment' do
+        new_source = autocorrect_source(cop, ['# encoding: utf-8',
+                                              '# frozen_string_literal: true',
+                                              'puts 1'])
+
+        expect(new_source).to eq(['# encoding: utf-8',
+                                  'puts 1'].join("\n"))
+      end
+
+      it 'removes a dsabled frozen string literal below an encoding comment' do
+        new_source = autocorrect_source(cop, ['# encoding: utf-8',
+                                              '# frozen_string_literal: false',
+                                              'puts 1'])
+
+        expect(new_source).to eq(['# encoding: utf-8',
+                                  'puts 1'].join("\n"))
+      end
+
+      it 'removes a frozen string literal comment ' \
+        'below shebang and encoding comments' do
+        new_source = autocorrect_source(cop, ['#!/usr/bin/env ruby',
+                                              '# encoding: utf-8',
+                                              '# frozen_string_literal: true',
+                                              'puts 1'])
+
+        expect(new_source).to eq(['#!/usr/bin/env ruby',
+                                  '# encoding: utf-8',
+                                  'puts 1'].join("\n"))
+      end
+
+      it 'removes a disabled frozen string literal comment from ' \
+        'below shebang and encoding comments' do
+        new_source = autocorrect_source(cop, ['#!/usr/bin/env ruby',
+                                              '# encoding: utf-8',
+                                              '# frozen_string_literal: false',
+                                              'puts 1'])
+
+        expect(new_source).to eq(['#!/usr/bin/env ruby',
+                                  '# encoding: utf-8',
+                                  'puts 1'].join("\n"))
+      end
+
+      it 'removes a frozen string literal comment ' \
+        'below shebang above an encoding comments' do
+        new_source = autocorrect_source(cop, ['#!/usr/bin/env ruby',
+                                              '# frozen_string_literal: true',
+                                              '# encoding: utf-8',
+                                              'puts 1'])
+
+        expect(new_source).to eq(['#!/usr/bin/env ruby',
+                                  '# encoding: utf-8',
+                                  'puts 1'].join("\n"))
+      end
+
+      it 'removes a disabled frozen string literal comment ' \
+        'below shebang above an encoding comments' do
+        new_source = autocorrect_source(cop, ['#!/usr/bin/env ruby',
+                                              '# frozen_string_literal: false',
+                                              '# encoding: utf-8',
+                                              'puts 1'])
+
+        expect(new_source).to eq(['#!/usr/bin/env ruby',
+                                  '# encoding: utf-8',
+                                  'puts 1'].join("\n"))
       end
     end
   end


### PR DESCRIPTION
This configuration will remove the magic comment from files. This is preemptive for when the magic comment is not longer needed.

I have also been thinking about adding support for the `warn_indent` magic comment. I was considering breaking this, warn_indent, and encoding out to a new cop section since they don't really belong in style. This might also be beneficial for adding a group configuration to determine if all comments should be on the same line or not.

http://idiosyncratic-ruby.com/58-magic-instructions.html