### PR TITLE
debugging `focus` statement should be detected

### DIFF
--- a/lib/rubocop/cop/lint/debugger.rb
+++ b/lib/rubocop/cop/lint/debugger.rb
@@ -14,7 +14,8 @@ module RuboCop
            (send (const nil :Pry) :rescue ...)
            (send nil {:save_and_open_page
                       :save_and_open_screenshot
-                      :save_screenshot} ...)}
+                      :save_screenshot} ...)
+           (send nil {:focus})}
         END
 
         def_node_matcher :binding_irb_call?, <<-END

--- a/spec/rubocop/cop/lint/debugger_spec.rb
+++ b/spec/rubocop/cop/lint/debugger_spec.rb
@@ -25,10 +25,11 @@ describe RuboCop::Cop::Lint::Debugger, :config do
                     'save_and_open_screenshot foo',
                     'save_screenshot foo']
   include_examples 'non-debugger', 'a non-pry binding', 'binding.pirate'
+  include_examples 'debugger', 'focus', 'focus'
 
   ALL_COMMANDS = %w(debugger byebug pry remote_pry pry_remote irb
                     save_and_open_page save_and_open_screenshot
-                    save_screenshot).freeze
+                    save_screenshot focus).freeze
 
   ALL_COMMANDS.each do |src|
     include_examples 'non-debugger', "a #{src} in comments", "# #{src}"


### PR DESCRIPTION
debugging `focus` statement is not caught by linting, while `binding.pry` and
`byebug` statements are correctly detected.

Pretty useful gem minitest-focus (https://github.com/seattlerb/minitest-focus)
helps run a single test by putting a `focus` statement above test:

```ruby
focus
test 'only run this test' do
  # debugging something important
end
```

These `focus` statements sometimes get accidentally left in commits, while
`binding.pry` and `byebug` are caught by cop `Cop::Lint::Debugger`

```
rubocop -V
0.46.0 (using Parser 2.3.1.2, running on ruby 2.3.0 x86_64-darwin15)
```
