### PR TITLE
Avoid crash in `Style/HashSyntax` cop with an empty hash

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@
 * [#3751](https://github.com/bbatsov/rubocop/pull/3751): Avoid crash in `Rails/EnumUniqueness` cop. ([@pocke][])
 * [#3766](https://github.com/bbatsov/rubocop/pull/3766): Avoid crash in `Style/ConditionalAssignment` cop with masgn. ([@pocke][])
 * [#3750](https://github.com/bbatsov/rubocop/issues/3750): Register an offense in `Style/ConditionalAssignment` when the assignment spans multiple lines. ([@rrosenblum][])
+* [#3775](https://github.com/bbatsov/rubocop/pull/3775): Avoid crash in `Style/HashSyntax` cop with an empty hash. ([@pocke][])
 
 ## 0.46.0 (2016-11-30)
 

--- a/lib/rubocop/cop/style/hash_syntax.rb
+++ b/lib/rubocop/cop/style/hash_syntax.rb
@@ -75,37 +75,30 @@ module RuboCop
         end
 
         def on_hash(node)
-          if cop_config['UseHashRocketsWithSymbolValues']
-            pairs = *node
-            @force_hash_rockets = pairs.any? { |p| symbol_value?(p) }
-          end
+          pairs = *node
+          return if pairs.empty?
+          @force_hash_rockets = force_hash_rockets?(pairs)
 
           if style == :hash_rockets || @force_hash_rockets
-            hash_rockets_check(node)
+            hash_rockets_check(pairs)
           elsif style == :ruby19_no_mixed_keys
-            ruby19_no_mixed_keys_check(node)
+            ruby19_no_mixed_keys_check(pairs)
           elsif style == :no_mixed_keys
-            no_mixed_keys_check(node)
+            no_mixed_keys_check(pairs)
           else
-            ruby19_check(node)
+            ruby19_check(pairs)
           end
         end
 
-        def ruby19_check(node)
-          pairs = *node
-
+        def ruby19_check(pairs)
           check(pairs, '=>', MSG_19) if sym_indices?(pairs)
         end
 
-        def hash_rockets_check(node)
-          pairs = *node
-
+        def hash_rockets_check(pairs)
           check(pairs, ':', MSG_HASH_ROCKETS)
         end
 
-        def ruby19_no_mixed_keys_check(node)
-          pairs = *node
-
+        def ruby19_no_mixed_keys_check(pairs)
           if @force_hash_rockets
             check(pairs, ':', MSG_HASH_ROCKETS)
           elsif sym_indices?(pairs)
@@ -115,9 +108,7 @@ module RuboCop
           end
         end
 
-        def no_mixed_keys_check(node)
-          pairs = *node
-
+        def no_mixed_keys_check(pairs)
           if !sym_indices?(pairs)
             check(pairs, ':', MSG_NO_MIXED_KEYS)
           else
@@ -225,6 +216,11 @@ module RuboCop
           else
             autocorrect_ruby19(corrector, node)
           end
+        end
+
+        def force_hash_rockets?(pairs)
+          cop_config['UseHashRocketsWithSymbolValues'] &&
+            pairs.any? { |p| symbol_value?(p) }
         end
       end
     end

--- a/manual/cops_lint.md
+++ b/manual/cops_lint.md
@@ -68,8 +68,8 @@ Enabled | Yes
 This cop checks whether the end keywords are aligned properly for do
 end blocks.
 
-Three modes are supported through the `AlignWith` configuration
-parameter:
+Three modes are supported through the `EnforcedStyleAlignWith`
+configuration parameter:
 
 `start_of_block` : the `end` shall be aligned with the
 start of the line where the `do` appeared.
@@ -105,8 +105,8 @@ end
 
 Attribute | Value
 --- | ---
-AlignWith | either
-SupportedStyles | either, start_of_block, start_of_line
+EnforcedStyleAlignWith | either
+SupportedStylesAlignWith | either, start_of_block, start_of_line
 
 
 ## Lint/CircularArgumentReference
@@ -184,7 +184,7 @@ Enabled | Yes
 This cop checks whether the end keywords of method definitions are
 aligned properly.
 
-Two modes are supported through the AlignWith configuration
+Two modes are supported through the EnforcedStyleAlignWith configuration
 parameter. If it's set to `start_of_line` (which is the default), the
 `end` shall be aligned with the start of the line where the `def`
 keyword is. If it's set to `def`, the `end` shall be aligned with the
@@ -201,8 +201,8 @@ end
 
 Attribute | Value
 --- | ---
-AlignWith | start_of_line
-SupportedStyles | start_of_line, def
+EnforcedStyleAlignWith | start_of_line
+SupportedStylesAlignWith | start_of_line, def
 AutoCorrect | false
 
 
@@ -377,8 +377,8 @@ Enabled | Yes
 
 This cop checks whether the end keywords are aligned properly.
 
-Three modes are supported through the `AlignWith` configuration
-parameter:
+Three modes are supported through the `EnforcedStyleAlignWith`
+configuration parameter:
 
 If it's set to `keyword` (which is the default), the `end`
 shall be aligned with the start of the keyword (if, class, etc.).
@@ -410,8 +410,8 @@ end)
 
 Attribute | Value
 --- | ---
-AlignWith | keyword
-SupportedStyles | keyword, variable, start_of_line
+EnforcedStyleAlignWith | keyword
+SupportedStylesAlignWith | keyword, variable, start_of_line
 AutoCorrect | false
 
 

--- a/manual/cops_style.md
+++ b/manual/cops_style.md
@@ -307,7 +307,7 @@ It will register a separate offense for each misaligned *when*.
 
 Attribute | Value
 --- | ---
-IndentWhenRelativeTo | case
+EnforcedStyle | case
 SupportedStyles | case, end
 IndentOneStep | false
 IndentationWidth | 

--- a/spec/rubocop/cop/style/hash_syntax_spec.rb
+++ b/spec/rubocop/cop/style/hash_syntax_spec.rb
@@ -51,6 +51,11 @@ describe RuboCop::Cop::Style::HashSyntax, :config do
         expect(cop.messages).to be_empty
       end
 
+      it 'accepts an empty hash' do
+        inspect_source(cop, '{}')
+        expect(cop.messages).to be_empty
+      end
+
       context 'ruby < 2.2', :ruby21 do
         it 'accepts hash rockets when symbol keys have string in them' do
           inspect_source(cop, 'x = { :"string" => 0 }')
@@ -179,6 +184,11 @@ describe RuboCop::Cop::Style::HashSyntax, :config do
         expect(cop.messages).to be_empty
       end
 
+      it 'accepts an empty hash' do
+        inspect_source(cop, '{}')
+        expect(cop.messages).to be_empty
+      end
+
       it 'registers an offense when any element uses a symbol for the value' do
         inspect_source(cop, 'x = { a: 1, b: :c }')
         expect(cop.messages)
@@ -266,6 +276,11 @@ describe RuboCop::Cop::Style::HashSyntax, :config do
       expect(cop.messages).to be_empty
     end
 
+    it 'accepts an empty hash' do
+      inspect_source(cop, '{}')
+      expect(cop.messages).to be_empty
+    end
+
     it 'auto-corrects new style to hash rockets' do
       new_source = autocorrect_source(cop, '{ a: 1, b: 2}')
       expect(new_source).to eq('{ :a => 1, :b => 2}')
@@ -326,6 +341,11 @@ describe RuboCop::Cop::Style::HashSyntax, :config do
 
       it 'accepts hash rockets when keys have different types' do
         inspect_source(cop, 'x = { :a => 0, "b" => 1 }')
+        expect(cop.messages).to be_empty
+      end
+
+      it 'accepts an empty hash' do
+        inspect_source(cop, '{}')
         expect(cop.messages).to be_empty
       end
 
@@ -465,6 +485,11 @@ describe RuboCop::Cop::Style::HashSyntax, :config do
         expect(cop.messages).to be_empty
       end
 
+      it 'accepts an empty hash' do
+        inspect_source(cop, '{}')
+        expect(cop.messages).to be_empty
+      end
+
       it 'registers an offense when keys have different types and styles' do
         inspect_source(cop, 'x = { a: 0, "b" => 1 }')
         expect(cop.messages).to eq(["Don't mix styles in the same hash."])
@@ -572,6 +597,11 @@ describe RuboCop::Cop::Style::HashSyntax, :config do
 
     it 'accepts hash rockets when keys have different types' do
       inspect_source(cop, 'x = { :a => 0, "b" => 1 }')
+      expect(cop.messages).to be_empty
+    end
+
+    it 'accepts an empty hash' do
+      inspect_source(cop, '{}')
       expect(cop.messages).to be_empty
     end
 


### PR DESCRIPTION
Problem
=======

`Style/HashSyntax` cop crashes with an empty hash when `EnforcedStyle` is `no_mixed_keys`.

```yaml
 # .rubocop.yml
Style/HashSyntax:
  EnforcedStyle: no_mixed_keys
  Enabled: true
```

```ruby
 # test.rb
{}
```

```sh
$ rubocop --only Style/HashSyntax --debug
An error occurred while Style/HashSyntax cop was inspecting /tmp/tmp.iBl3LTfZjB/test.rb.

1 error occurred:
An error occurred while Style/HashSyntax cop was inspecting /tmp/tmp.iBl3LTfZjB/test.rb.
Errors are usually caused by RuboCop bugs.
Please, report your problems to RuboCop's issue tracker.
Mention the following information in the issue report:
0.46.0 (using Parser 2.3.3.1, running on ruby 2.3.3 x86_64-linux)
For /tmp/tmp.iBl3LTfZjB: configuration from /tmp/tmp.iBl3LTfZjB/.rubocop.yml
Default configuration from /home/pocke/.gem/ruby/2.3.0/gems/rubocop-0.46.0/config/default.yml
Inheriting configuration from /home/pocke/.gem/ruby/2.3.0/gems/rubocop-0.46.0/config/enabled.yml
Inheriting configuration from /home/pocke/.gem/ruby/2.3.0/gems/rubocop-0.46.0/config/disabled.yml
Inspecting 1 file
Scanning /tmp/tmp.iBl3LTfZjB/test.rb
undefined method `loc' for nil:NilClass
/home/pocke/.gem/ruby/2.3.0/gems/rubocop-0.46.0/lib/rubocop/cop/style/hash_syntax.rb:124:in `no_mixed_keys_check'
/home/pocke/.gem/ruby/2.3.0/gems/rubocop-0.46.0/lib/rubocop/cop/style/hash_syntax.rb:88:in `on_hash'
/home/pocke/.gem/ruby/2.3.0/gems/rubocop-0.46.0/lib/rubocop/cop/commissioner.rb:41:in `block (2 levels) in on_hash'
/home/pocke/.gem/ruby/2.3.0/gems/rubocop-0.46.0/lib/rubocop/cop/commissioner.rb:96:in `with_cop_error_handling'
/home/pocke/.gem/ruby/2.3.0/gems/rubocop-0.46.0/lib/rubocop/cop/commissioner.rb:40:in `block in on_hash'
/home/pocke/.gem/ruby/2.3.0/gems/rubocop-0.46.0/lib/rubocop/cop/commissioner.rb:39:in `each'
/home/pocke/.gem/ruby/2.3.0/gems/rubocop-0.46.0/lib/rubocop/cop/commissioner.rb:39:in `on_hash'
/home/pocke/.gem/ruby/2.3.0/gems/rubocop-0.46.0/lib/rubocop/ast_node/traversal.rb:12:in `walk'
/home/pocke/.gem/ruby/2.3.0/gems/rubocop-0.46.0/lib/rubocop/cop/commissioner.rb:58:in `investigate'
/home/pocke/.gem/ruby/2.3.0/gems/rubocop-0.46.0/lib/rubocop/cop/team.rb:120:in `investigate'
/home/pocke/.gem/ruby/2.3.0/gems/rubocop-0.46.0/lib/rubocop/cop/team.rb:108:in `offenses'
/home/pocke/.gem/ruby/2.3.0/gems/rubocop-0.46.0/lib/rubocop/cop/team.rb:51:in `inspect_file'
/home/pocke/.gem/ruby/2.3.0/gems/rubocop-0.46.0/lib/rubocop/runner.rb:243:in `inspect_file'
/home/pocke/.gem/ruby/2.3.0/gems/rubocop-0.46.0/lib/rubocop/runner.rb:190:in `block in do_inspection_loop'
/home/pocke/.gem/ruby/2.3.0/gems/rubocop-0.46.0/lib/rubocop/runner.rb:222:in `block in iterate_until_no_changes'
/home/pocke/.gem/ruby/2.3.0/gems/rubocop-0.46.0/lib/rubocop/runner.rb:215:in `loop'
/home/pocke/.gem/ruby/2.3.0/gems/rubocop-0.46.0/lib/rubocop/runner.rb:215:in `iterate_until_no_changes'
/home/pocke/.gem/ruby/2.3.0/gems/rubocop-0.46.0/lib/rubocop/runner.rb:186:in `do_inspection_loop'
/home/pocke/.gem/ruby/2.3.0/gems/rubocop-0.46.0/lib/rubocop/runner.rb:101:in `block in file_offenses'
/home/pocke/.gem/ruby/2.3.0/gems/rubocop-0.46.0/lib/rubocop/runner.rb:111:in `file_offense_cache'
/home/pocke/.gem/ruby/2.3.0/gems/rubocop-0.46.0/lib/rubocop/runner.rb:99:in `file_offenses'
/home/pocke/.gem/ruby/2.3.0/gems/rubocop-0.46.0/lib/rubocop/runner.rb:90:in `process_file'
/home/pocke/.gem/ruby/2.3.0/gems/rubocop-0.46.0/lib/rubocop/runner.rb:68:in `block in each_inspected_file'
/home/pocke/.gem/ruby/2.3.0/gems/rubocop-0.46.0/lib/rubocop/runner.rb:65:in `each'
/home/pocke/.gem/ruby/2.3.0/gems/rubocop-0.46.0/lib/rubocop/runner.rb:65:in `reduce'
/home/pocke/.gem/ruby/2.3.0/gems/rubocop-0.46.0/lib/rubocop/runner.rb:65:in `each_inspected_file'
/home/pocke/.gem/ruby/2.3.0/gems/rubocop-0.46.0/lib/rubocop/runner.rb:57:in `inspect_files'
/home/pocke/.gem/ruby/2.3.0/gems/rubocop-0.46.0/lib/rubocop/runner.rb:36:in `run'
/home/pocke/.gem/ruby/2.3.0/gems/rubocop-0.46.0/lib/rubocop/cli.rb:72:in `execute_runner'
/home/pocke/.gem/ruby/2.3.0/gems/rubocop-0.46.0/lib/rubocop/cli.rb:27:in `run'
/home/pocke/.gem/ruby/2.3.0/gems/rubocop-0.46.0/bin/rubocop:13:in `block in <top (required)>'
/usr/lib/ruby/2.3.0/benchmark.rb:308:in `realtime'
/home/pocke/.gem/ruby/2.3.0/gems/rubocop-0.46.0/bin/rubocop:12:in `<top (required)>'
/home/pocke/.gem/ruby/2.3.0/bin//rubocop:22:in `load'
/home/pocke/.gem/ruby/2.3.0/bin//rubocop:22:in `<main>'
.

1 file inspected, no offenses detected
Finished in 0.14013576700381236 seconds
```

I fixed the problem.

Note
----------

I've forgotten to run `rake generate_cops_documentation` in #3765 .

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Used the same coding conventions as the rest of the project.
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] All tests are passing.
* [x] The new code doesn't generate RuboCop offenses.
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Updated cop documentation with `rake generate_cops_documentation` (required only when you've added a new cop or changed the configuration/documentation of an existing cop).

[1]: http://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html

