### PR TITLE
Add check for `add_reference` method by `Rails/NotNullColumn` cop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 
 * [#3725](https://github.com/bbatsov/rubocop/issues/3725): Disable `Style/SingleLineBlockParams` by default. ([@tejasbubane][])
 * [#3765](https://github.com/bbatsov/rubocop/pull/3765): Add a validation for supported styles other than EnforcedStyle. `AlignWith`, `IndentWhenRelativeTo` and `EnforcedMode` configurations are renamed. ([@pocke][])
+* [#3782](https://github.com/bbatsov/rubocop/pull/3782): Add check for `add_reference` method by `Rails/NotNullColumn` cop. ([@pocke][])
 
 ### Bug fixes
 

--- a/lib/rubocop/cop/rails/not_null_column.rb
+++ b/lib/rubocop/cop/rails/not_null_column.rb
@@ -9,15 +9,22 @@ module RuboCop
       # @example
       #   # bad
       #   add_column :users, :name, :string, null: false
+      #   add_reference :products, :category, null: false
       #
       #   # good
       #   add_column :users, :name, :string, null: true
       #   add_column :users, :name, :string, null: false, default: ''
+      #   add_reference :products, :category
+      #   add_reference :products, :category, null: false, default: 1
       class NotNullColumn < Cop
         MSG = 'Do not add a NOT NULL column without a default value.'.freeze
 
         def_node_matcher :add_not_null_column?, <<-PATTERN
           (send nil :add_column _ _ _ (hash $...))
+        PATTERN
+
+        def_node_matcher :add_not_null_reference?, <<-PATTERN
+          (send nil :add_reference _ _ (hash $...))
         PATTERN
 
         def_node_matcher :null_false?, <<-PATTERN
@@ -29,7 +36,23 @@ module RuboCop
         PATTERN
 
         def on_send(node)
+          check_add_column(node)
+          check_add_reference(node)
+        end
+
+        private
+
+        def check_add_column(node)
           pairs = add_not_null_column?(node)
+          check_pairs(pairs)
+        end
+
+        def check_add_reference(node)
+          pairs = add_not_null_reference?(node)
+          check_pairs(pairs)
+        end
+
+        def check_pairs(pairs)
           return unless pairs
           return if pairs.any? { |pair| has_default?(pair) }
 

--- a/manual/cops_rails.md
+++ b/manual/cops_rails.md
@@ -332,10 +332,12 @@ in migration file.
 ```ruby
 # bad
 add_column :users, :name, :string, null: false
+add_reference :products, :category, null: false
 
 # good
 add_column :users, :name, :string, null: true
 add_column :users, :name, :string, null: false, default: ''
+add_reference :products, :category
 ```
 
 ### Important attributes

--- a/spec/rubocop/cop/rails/not_null_column_spec.rb
+++ b/spec/rubocop/cop/rails/not_null_column_spec.rb
@@ -75,4 +75,28 @@ describe RuboCop::Cop::Rails::NotNullColumn, :config do
     end
     include_examples 'accepts'
   end
+
+  context 'with add_reference call' do
+    context 'with null: false' do
+      let(:source) { 'add_reference :products, :category, null: false' }
+      it 'reports an offense' do
+        expect(cop.offenses.size).to eq(1)
+        expect(cop.messages).to eq(
+          ['Do not add a NOT NULL column without a default value.']
+        )
+      end
+    end
+
+    context 'with default option' do
+      let(:source) do
+        'add_reference :products, :category, null: false, default: 1'
+      end
+      include_examples 'accepts'
+    end
+
+    context 'without any options' do
+      let(:source) { 'add_reference :products, :category' }
+      include_examples 'accepts'
+    end
+  end
 end


### PR DESCRIPTION
`add_reference` method has same problem as `add_column` method(see https://github.com/bbatsov/rubocop/pull/3415 ). So, `Rails/NotNullColum` cop also should detect the method.

For example

```ruby
class SomeMigration < ActiveRecord::Migration
  def change
    add_reference :products, :category, null: false
  end
end
```

The above migration crashes other than MySQL.
Then, in MySQL, the migration does not crash, but `category_id` is decided by MySQL without permission.


-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Used the same coding conventions as the rest of the project.
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] All tests are passing.
* [x] The new code doesn't generate RuboCop offenses.
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Updated cop documentation with `rake generate_cops_documentation` (required only when you've added a new cop or changed the configuration/documentation of an existing cop).

[1]: http://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html

