### PR TITLE
[Fix #3780] Maintain parentheses in auto-correcting Rails/HttpPositionalArguments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@
 * [#3766](https://github.com/bbatsov/rubocop/pull/3766): Avoid crash in `Style/ConditionalAssignment` cop with masgn. ([@pocke][])
 * [#3750](https://github.com/bbatsov/rubocop/issues/3750): Register an offense in `Style/ConditionalAssignment` when the assignment spans multiple lines. ([@rrosenblum][])
 * [#3775](https://github.com/bbatsov/rubocop/pull/3775): Avoid crash in `Style/HashSyntax` cop with an empty hash. ([@pocke][])
+* [#3783](https://github.com/bbatsov/rubocop/pull/3783): Maintain parentheses in `Rails/HttpPositionalArguments` when methods are defined with them. ([@kevindew][])
 
 ## 0.46.0 (2016-11-30)
 
@@ -2532,3 +2533,4 @@
 [@aesthetikx]: https://github.com/aesthetikx
 [@tdeo]: https://github.com/tdeo
 [@AlexWayfer]: https://github.com/AlexWayfer
+[@kevindew]: https://github.com/kevindew

--- a/lib/rubocop/cop/rails/http_positional_arguments.rb
+++ b/lib/rubocop/cop/rails/http_positional_arguments.rb
@@ -82,7 +82,8 @@ module RuboCop
           # the range of the text to replace, which is the whole line
           code_to_replace = node.loc.expression
           # what to replace with
-          new_code = format('%s %s%s%s', http_method, controller_action,
+          format = parentheses?(node) ? '%s(%s%s%s)' : '%s %s%s%s'
+          new_code = format(format, http_method, controller_action,
                             params, headers)
           ->(corrector) { corrector.replace(code_to_replace, new_code) }
         end

--- a/spec/rubocop/cop/rails/http_positional_arguments_spec.rb
+++ b/spec/rubocop/cop/rails/http_positional_arguments_spec.rb
@@ -176,6 +176,15 @@ post :create, params: { id: @user.id, ac: {
     expect(new_source).to eq(expected)
   end
 
+  it 'maintains parentheses in auto-correcting' do
+    source = 'post(:user_attrs, id: 1)'
+    inspect_source(cop, source)
+    expect(cop.offenses.size).to eq(1)
+    new_source = autocorrect_source(cop, source)
+    expected = 'post(:user_attrs, params: { id: 1 })'
+    expect(new_source).to eq(expected)
+  end
+
   it 'does not register when post is found' do
     source = "if post.stint_title.present? \n true\n end"
     inspect_source(cop, source)


### PR DESCRIPTION
Fix for: https://github.com/bbatsov/rubocop/issues/3780

During the autocorrect process for `Rails/HttpPositionalArguments`
this checks whether the original node had parentheses. If there are
parentheses these are included in the formatting of the autocorrected
method.

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Used the same coding conventions as the rest of the project.
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] All tests are passing.
* [x] The new code doesn't generate RuboCop offenses.
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Updated cop documentation with `rake generate_cops_documentation` (required only when you've added a new cop or changed the configuration/documentation of an existing cop).

[1]: http://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html