### PR TITLE
[Fix #3788] Prevent bad auto-correct by `Style/Next` for nested conditionals

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@
 * [#3783](https://github.com/bbatsov/rubocop/pull/3783): Maintain parentheses in `Rails/HttpPositionalArguments` when methods are defined with them. ([@kevindew][])
 * [#3786](https://github.com/bbatsov/rubocop/pull/3786): Avoid crash `Style/ConditionalAssignment` cop with mass assign method. ([@pocke][])
 * [#3749](https://github.com/bbatsov/rubocop/pull/3749): Detect corner case of `Style/NumericLitterals`. ([@kamaradclimber][])
+* [#3788](https://github.com/bbatsov/rubocop/pull/3788): Prevent bad auto-correct in `Style/Next` when block has nested conditionals. ([@drenmi][])
 
 ## 0.46.0 (2016-11-30)
 

--- a/lib/rubocop/cop/style/next.rb
+++ b/lib/rubocop/cop/style/next.rb
@@ -82,10 +82,21 @@ module RuboCop
         def simple_if_without_break?(node)
           return false unless node
           return false unless if_without_else?(node)
-          return false if style == :skip_modifier_ifs && modifier_if?(node)
-          return false if !modifier_if?(node) && !min_body_length?(node)
+          return false if if_else_children?(node)
+          return false if allowed_modifier_if?(node)
 
           !exit_body_type?(node)
+        end
+
+        def allowed_modifier_if?(node)
+          style == :skip_modifier_ifs && modifier_if?(node) ||
+            !modifier_if?(node) && !min_body_length?(node)
+        end
+
+        def if_else_children?(node)
+          node.each_child_node(:if).any? do |child|
+            if_else?(child)
+          end
         end
 
         def if_without_else?(node)

--- a/spec/rubocop/cop/style/next_spec.rb
+++ b/spec/rubocop/cop/style/next_spec.rb
@@ -250,6 +250,21 @@ describe RuboCop::Cop::Style::Next, :config do
       expect(cop.offenses).to be_empty
     end
 
+    it "allows loops with #{condition} with else, nested in another " \
+       'condition' do
+      inspect_source(cop, ['[].each do |o|',
+                           '  if foo',
+                           "    #{condition} o == 1",
+                           '      puts o',
+                           '    else',
+                           "      puts 'no'",
+                           '    end',
+                           '  end',
+                           'end'])
+
+      expect(cop.offenses).to be_empty
+    end
+
     it "allows loops with #{condition} with else at the end" do
       inspect_source(cop, ['[].each do |o|',
                            '  puts o',


### PR DESCRIPTION
When inspecting and auto-correcting code with nested conditionals where the inner conditional has an `else` statement, but the outer conditional does not, the auto-correct messes up:

```
foos.each do |foo|
  unless foo[:bar]
    if baz
      do_something
    else
      do_something_else
    end
  end
end
```

was corrected to:

```
foos.each do |foo|
  unless foo[bar]
    next unless baz
      do_something
    else
      do_something_else
    end
end
```

This change fixes that.

-----------------

Before submitting the PR make sure the following are checked:

* [X] Wrote [good commit messages][1].
* [X] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [X] Used the same coding conventions as the rest of the project.
* [X] Feature branch is up-to-date with `master` (if not - rebase it).
* [X] Squashed related commits together.
* [X] Added tests.
* [X] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [X] All tests are passing.
* [X] The new code doesn't generate RuboCop offenses.
* [X] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [ ] Updated cop documentation with `rake generate_cops_documentation` (required only when you've added a new cop or changed the configuration/documentation of an existing cop).

[1]: http://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html