### PR TITLE
WIP Parallel Rubocop

### DIFF
--- a/lib/rubocop/runner.rb
+++ b/lib/rubocop/runner.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+require 'parallel'
 
 module RuboCop
   # This class handles the processing of files, which includes dealing with
@@ -50,31 +51,21 @@ module RuboCop
     end
 
     def inspect_files(files)
-      inspected_files = []
-
+      results = []
       formatter_set.started(files)
 
-      each_inspected_file(files) { |file| inspected_files << file }
+      options = {
+        start: method(:file_started),
+        finish: method(:file_finished)
+      }
+
+      results = Parallel.map(files, options, &method(:process_file))
+      results.all? { |result| result[:passed] }
     ensure
       ResultCache.cleanup(@config_store, @options[:debug]) if cached_run?
+      inspected_files = results.map { |result| result[:file] }
       formatter_set.finished(inspected_files.freeze)
       formatter_set.close_output_files
-    end
-
-    def each_inspected_file(files)
-      files.reduce(true) do |all_passed, file|
-        break false if aborting?
-
-        offenses = process_file(file)
-        yield file
-
-        if offenses.any? { |o| considered_failure?(o) }
-          break false if @options[:fail_fast]
-          next false
-        end
-
-        all_passed
-      end
     end
 
     def list_files(paths)
@@ -84,15 +75,17 @@ module RuboCop
     end
 
     def process_file(file)
-      puts "Scanning #{file}" if @options[:debug]
-      file_started(file)
+      raise Parallel::Break if aborting?
 
-      offenses = file_offenses(file)
-      formatter_set.file_finished(file, offenses)
-      offenses
-    rescue InfiniteCorrectionLoop => e
-      formatter_set.file_finished(file, e.offenses.compact.sort.freeze)
-      raise
+      begin
+        offenses = file_offenses(file)
+      rescue InfiniteCorrectionLoop => e
+        offenses = e.offenses.compact.sort.freeze
+      end
+
+      passed = offenses.any? { |o| considered_failure?(o) }
+      raise Parallel::Break if !passed && @options[:fail_fast]
+      { file: file, offenses: offenses, passed: passed }
     end
 
     def file_offenses(file)
@@ -145,10 +138,15 @@ module RuboCop
       Cop::Team.new([], nil, @options).autocorrect(source.buffer, [cop])
     end
 
-    def file_started(file)
+    def file_started(file, _index)
+      puts "Scanning #{file}" if @options[:debug]
       formatter_set.file_started(file,
                                  cli_options: @options,
                                  config_store: @config_store)
+    end
+
+    def file_finished(file, _index, result)
+      formatter_set.file_finished(file, result[:offenses])
     end
 
     def cached_run?

--- a/rubocop.gemspec
+++ b/rubocop.gemspec
@@ -26,6 +26,7 @@ Gem::Specification.new do |s|
   s.summary = 'Automatic Ruby code style checking tool.'
 
   s.add_runtime_dependency('rainbow', '>= 1.99.1', '< 3.0')
+  s.add_runtime_dependency('parallel', '~> 1.10')
   s.add_runtime_dependency('parser', '>= 2.3.3.1', '< 3.0')
   s.add_runtime_dependency('powerpack', '~> 0.1')
   s.add_runtime_dependency('ruby-progressbar', '~> 1.7')


### PR DESCRIPTION
An attempt to resurrect #175 and #117. I'm not sure why exactly they were closed.

Timings on rubocop's own codebase.

**master**

```
$ time bin/rubocop --cache false
Inspecting 825 files

825 files inspected, no offenses detected

real	0m31.175s
user	0m30.929s
sys	0m0.199s
```

**parallel**

```
$ time bin/rubocop --cache false
Inspecting 825 files

825 files inspected, no offenses detected

real	0m7.727s
user	0m54.805s
sys	0m0.629s
```

The difference is huge when running on a large codebase. For an example, @github has 10,000+ Ruby files. It takes about 4 minutes in serial and 55s in parallel on a cold cache. Even with a warm cache, parallelism still helps. 10s serial vs 2s parallel on @github's codebase.

**Problems**

Theres a number of problems with this as is:

* Something is up with offense correction. Thats why the tests are failing. But it does seem to be working when running standalone from CLI. Still trying to figure that out.
* I'm not sure what other memory side effects there are when checking for offenses. These object mutations would happen in a worker fork and wouldn't be propagated back up to the main process.
* Read/write to cache probably needs to flock or be coordinated by the main process.

-----------------

Before submitting the PR make sure the following are checked:

* [ ] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [ ] Used the same coding conventions as the rest of the project.
* [ ] Feature branch is up-to-date with `master` (if not - rebase it).
* [ ] Squashed related commits together.
* [ ] Added tests.
* [ ] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [ ] All tests are passing.
* [ ] The new code doesn't generate RuboCop offenses.
* [ ] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [ ] Updated cop documentation with `rake generate_cops_documentation` (required only when you've added a new cop or changed the configuration/documentation of an existing cop).

[1]: http://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html

-----------------

CC: @aroben 