### PR TITLE
Add a new configuration to ConditionalAssignment

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -13,7 +13,7 @@ Metrics/AbcSize:
 # Offense count: 32
 # Configuration parameters: CountComments.
 Metrics/ClassLength:
-  Max: 177
+  Max: 182
 
 # Offense count: 29
 Metrics/CyclomaticComplexity:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 * [#3772](https://github.com/bbatsov/rubocop/issues/3772): Allow exclusion of certain methods for `Metrics/BlockLength`. ([@NobodysNightmare][])
 * [#3804](https://github.com/bbatsov/rubocop/pull/3804): Add new `Lint/SafeNavigationChain` cop. ([@pocke][])
 * [#3670](https://github.com/bbatsov/rubocop/pull/3670): Add `CountBlocks` boolean option to `Metrics/BlockNesting`. It allows blocks to be counted towards the nesting limit. ([@georgyangelov][])
+* [#2992](https://github.com/bbatsov/rubocop/issues/2992): Add a configuration to `Style/ConditionalAssignment` to toggle offenses for ternary expressions. ([@rrosenblum][])
 
 ### Changes
 

--- a/config/default.yml
+++ b/config/default.yml
@@ -383,6 +383,7 @@ Style/ConditionalAssignment:
   # will only register an offense for assignment to a condition that has
   # at least one multiline branch.
   SingleLineConditionsOnly: true
+  IncludeTernaryExpressions: true
 
 # Checks that you have put a copyright in a comment before any code.
 #

--- a/lib/rubocop/cop/style/conditional_assignment.rb
+++ b/lib/rubocop/cop/style/conditional_assignment.rb
@@ -243,6 +243,7 @@ module RuboCop
 
           assignment = assignment_node(node)
           return unless condition?(assignment)
+          return if ternary?(assignment) && !include_ternary?
 
           _condition, *branches, else_branch = *assignment
           return unless else_branch # empty else
@@ -354,6 +355,7 @@ module RuboCop
         end
 
         def check_node(node, branches)
+          return if ternary?(node) && !include_ternary?
           return unless allowed_statements?(branches)
           return if single_line_conditions_only? && branches.any?(&:begin_type?)
           return if correction_exceeds_line_limit?(node, branches)
@@ -428,6 +430,10 @@ module RuboCop
 
         def single_line_conditions_only?
           cop_config[SINGLE_LINE_CONDITIONS_ONLY]
+        end
+
+        def include_ternary?
+          cop_config['IncludeTernaryExpressions']
         end
       end
 

--- a/spec/rubocop/cop/style/conditional_assignment_assign_in_condition_spec.rb
+++ b/spec/rubocop/cop/style/conditional_assignment_assign_in_condition_spec.rb
@@ -553,6 +553,7 @@ describe RuboCop::Cop::Style::ConditionalAssignment do
       RuboCop::Config.new('Style/ConditionalAssignment' => {
                             'Enabled' => true,
                             'SingleLineConditionsOnly' => true,
+                            'IncludeTernaryExpressions' => true,
                             'EnforcedStyle' => 'assign_inside_condition',
                             'SupportedStyles' => %w(assign_to_condition
                                                     assign_inside_condition)
@@ -743,6 +744,7 @@ describe RuboCop::Cop::Style::ConditionalAssignment do
       RuboCop::Config.new('Style/ConditionalAssignment' => {
                             'Enabled' => true,
                             'SingleLineConditionsOnly' => false,
+                            'IncludeTernaryExpressions' => true,
                             'EnforcedStyle' => 'assign_inside_condition',
                             'SupportedStyles' => %w(assign_to_condition
                                                     assign_inside_condition)
@@ -987,6 +989,33 @@ describe RuboCop::Cop::Style::ConditionalAssignment do
                                 '  something_else',
                                 '  bar = 3',
                                 'end'].join("\n"))
+    end
+  end
+
+  context 'IncludeTernaryExpressions false' do
+    let(:config) do
+      RuboCop::Config.new('Style/ConditionalAssignment' => {
+                            'Enabled' => true,
+                            'SingleLineConditionsOnly' => true,
+                            'IncludeTernaryExpressions' => false,
+                            'EnforcedStyle' => 'assign_inside_condition',
+                            'SupportedStyles' => %w(assign_to_condition
+                                                    assign_inside_condition)
+                          },
+                          'Lint/EndAlignment' => {
+                            'EnforcedStyleAlignWith' => 'keyword',
+                            'Enabled' => true
+                          },
+                          'Metrics/LineLength' => {
+                            'Max' => 80,
+                            'Enabled' => true
+                          })
+    end
+
+    it 'allows assigning any variable type to ternary' do
+      inspect_source(cop, 'bar = foo? ? 1 : 2')
+
+      expect(cop.offenses).to be_empty
     end
   end
 end

--- a/spec/rubocop/cop/style/conditional_assignment_assign_to_condition_spec.rb
+++ b/spec/rubocop/cop/style/conditional_assignment_assign_to_condition_spec.rb
@@ -8,6 +8,7 @@ describe RuboCop::Cop::Style::ConditionalAssignment do
     RuboCop::Config.new('Style/ConditionalAssignment' => {
                           'Enabled' => true,
                           'SingleLineConditionsOnly' => true,
+                          'IncludeTernaryExpressions' => true,
                           'EnforcedStyle' => 'assign_to_condition',
                           'SupportedStyles' => %w(assign_to_condition
                                                   assign_inside_condition)
@@ -1574,6 +1575,7 @@ describe RuboCop::Cop::Style::ConditionalAssignment do
       RuboCop::Config.new('Style/ConditionalAssignment' => {
                             'Enabled' => true,
                             'SingleLineConditionsOnly' => false,
+                            'IncludeTernaryExpressions' => true,
                             'EnforcedStyle' => 'assign_to_condition',
                             'SupportedStyles' => %w(assign_to_condition
                                                     assign_inside_condition)
@@ -2034,7 +2036,8 @@ describe RuboCop::Cop::Style::ConditionalAssignment do
     let(:config) do
       RuboCop::Config.new('Style/ConditionalAssignment' => {
                             'Enabled' => true,
-                            'SingleLineConditionsOnly' => false
+                            'SingleLineConditionsOnly' => false,
+                            'IncludeTernaryExpressions' => true
                           },
                           'Lint/EndAlignment' => {
                             'EnforcedStyleAlignWith' => 'start_of_line',
@@ -2104,6 +2107,34 @@ describe RuboCop::Cop::Style::ConditionalAssignment do
                                     'end'].join("\n"))
         end
       end
+    end
+  end
+
+  context 'IncludeTernaryExpressions false' do
+    let(:config) do
+      RuboCop::Config.new('Style/ConditionalAssignment' => {
+                            'Enabled' => true,
+                            'SingleLineConditionsOnly' => true,
+                            'IncludeTernaryExpressions' => false,
+                            'EnforcedStyle' => 'assign_to_condition',
+                            'SupportedStyles' => %w(assign_to_condition
+                                                    assign_inside_condition)
+                          },
+                          'Lint/EndAlignment' => {
+                            'EnforcedStyleAlignWith' => 'keyword',
+                            'Enabled' => true
+                          },
+                          'Metrics/LineLength' => {
+                            'Max' => 80,
+                            'Enabled' => true
+                          })
+    end
+
+    it 'allows assignment in ternary operation' do
+      source = 'foo? ? bar = "a" : bar = "b"'
+      inspect_source(cop, source)
+
+      expect(cop.offenses).to be_empty
     end
   end
 end


### PR DESCRIPTION
This addresses a request from #2992. It adds a configuration option to enable or disable offenses for ternary conditions.