### PR TITLE
[Fix #3807] Make documentation cops aware of RuboCop directives

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@
 * [#3786](https://github.com/bbatsov/rubocop/pull/3786): Avoid crash `Style/ConditionalAssignment` cop with mass assign method. ([@pocke][])
 * [#3749](https://github.com/bbatsov/rubocop/pull/3749): Detect corner case of `Style/NumericLitterals`. ([@kamaradclimber][])
 * [#3788](https://github.com/bbatsov/rubocop/pull/3788): Prevent bad auto-correct in `Style/Next` when block has nested conditionals. ([@drenmi][])
+* [#3807](https://github.com/bbatsov/rubocop/pull/3807): Prevent `Style/Documentation` and `Style/DocumentationMethod` from mistaking RuboCop directives for class documentation. ([@drenmi][])
 
 ## 0.46.0 (2016-11-30)
 

--- a/lib/rubocop/cop/mixin/documentation_comment.rb
+++ b/lib/rubocop/cop/mixin/documentation_comment.rb
@@ -17,7 +17,9 @@ module RuboCop
         return false unless preceding_comment?(node, preceding_lines.last)
 
         preceding_lines.any? do |comment|
-          !annotation?(comment) && !interpreter_directive_comment?(comment)
+          !annotation?(comment) &&
+            !interpreter_directive_comment?(comment) &&
+            !rubocop_directive_comment?(comment)
         end
       end
 
@@ -34,6 +36,10 @@ module RuboCop
 
       def interpreter_directive_comment?(comment)
         comment.text =~ /^#\s*(frozen_string_literal|encoding):/
+      end
+
+      def rubocop_directive_comment?(comment)
+        comment.text =~ CommentConfig::COMMENT_DIRECTIVE_REGEXP
       end
     end
   end

--- a/spec/rubocop/cop/style/documentation_method_spec.rb
+++ b/spec/rubocop/cop/style/documentation_method_spec.rb
@@ -310,6 +310,28 @@ describe RuboCop::Cop::Style::DocumentationMethod, :config do
         end
       end
 
+      context 'with annotation comment' do
+        it_behaves_like 'code with offense', <<-CODE
+                        class Foo
+                          # FIXME: offense
+                          def bar
+                            puts 'baz'
+                          end
+                        end
+        CODE
+      end
+
+      context 'with directive comment' do
+        it_behaves_like 'code with offense', <<-CODE
+                        class Foo
+                          # rubocop:disable Style/For
+                          def bar
+                            puts 'baz'
+                          end
+                        end
+        CODE
+      end
+
       context 'with both public and private methods' do
         it_behaves_like 'code with offense', <<-CODE
                         class Foo

--- a/spec/rubocop/cop/style/documentation_spec.rb
+++ b/spec/rubocop/cop/style/documentation_spec.rb
@@ -70,6 +70,16 @@ describe RuboCop::Cop::Style::Documentation do
     expect(cop.offenses.size).to eq(1)
   end
 
+  it 'registers an offense for non-empty class with directive comment' do
+    inspect_source(cop,
+                   ['# rubocop:disable Style/For',
+                    'class My_Class',
+                    '  def method',
+                    '  end',
+                    'end'])
+    expect(cop.offenses.size).to eq(1)
+  end
+
   it 'registers offense for non-empty class with frozen string comment' do
     inspect_source(cop,
                    ['# frozen_string_literal: true',


### PR DESCRIPTION
The documentation cops `Style/Documentation` and `Style/DocumentationMethod` would mistake RuboCop directives for class documentation. This change fixes that.

**Replace this text with a summary of the changes in your PR.
The more detailed you are, the better.**

-----------------

Before submitting the PR make sure the following are checked:

* [X] Wrote [good commit messages][1].
* [X] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [X] Used the same coding conventions as the rest of the project.
* [X] Feature branch is up-to-date with `master` (if not - rebase it).
* [X] Squashed related commits together.
* [X] Added tests.
* [X] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [X] All tests are passing.
* [X] The new code doesn't generate RuboCop offenses.
* [X] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [ ] Updated cop documentation with `rake generate_cops_documentation` (required only when you've added a new cop or changed the configuration/documentation of an existing cop).

[1]: http://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html
