### PR TITLE
[Fix #3802] Ignore case when checking Gemfile order

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@
 * [#3782](https://github.com/bbatsov/rubocop/pull/3782): Add check for `add_reference` method by `Rails/NotNullColumn` cop. ([@pocke][])
 * [#3761](https://github.com/bbatsov/rubocop/pull/3761): Update `Style/RedundantFreeze` message from `Freezing immutable objects is pointless.` to `Do not freeze immutable objects, as freezing them has no effect.`. ([@lucasuyezu][])
 * [#3753](https://github.com/bbatsov/rubocop/issues/3753): Change error message of `Bundler/OrderedGems` to mention `Alphabetize Gems`. ([@tejasbubane][])
+* [#3802](https://github.com/bbatsov/rubocop/pull/3802): Ignore case when checking Gemfile order. ([@breckenedge][])
 
 ### Bug fixes
 
@@ -2549,3 +2550,4 @@
 [@amogil]: https://github.com/amogil
 [@kevindew]: https://github.com/kevindew
 [@lucasuyezu]: https://github.com/lucasuyezu
+[@breckenedge]: https://github.com/breckenedge

--- a/lib/rubocop/cop/bundler/ordered_gems.rb
+++ b/lib/rubocop/cop/bundler/ordered_gems.rb
@@ -25,10 +25,16 @@ module RuboCop
           gem_declarations(processed_source.ast)
             .each_cons(2) do |previous, current|
             next unless consecutive_lines(previous, current)
-            next unless current.children[2].children.first.to_s <
-                        previous.children[2].children.first.to_s
+            next unless case_insensitive_out_of_order?(
+              current.children[2].children.first.to_s,
+              previous.children[2].children.first.to_s
+            )
             register_offense(previous, current)
           end
+        end
+
+        def case_insensitive_out_of_order?(string_a, string_b)
+          1 > string_a.casecmp(string_b)
         end
 
         def consecutive_lines(previous, current)

--- a/spec/rubocop/cop/bundler/ordered_gems_spec.rb
+++ b/spec/rubocop/cop/bundler/ordered_gems_spec.rb
@@ -167,4 +167,35 @@ describe RuboCop::Cop::Bundler::OrderedGems, :config do
                                 ''].join("\n"))
     end
   end
+
+  context 'When a gem that starts with a capital letter is sorted' do
+    let(:source) { <<-END }
+      gem 'a'
+      gem 'Z'
+    END
+
+    it 'does not register an offense' do
+      inspect_source(cop, source)
+      expect(cop.offenses).to be_empty
+    end
+  end
+
+  context 'When a gem that starts with a capital letter is not sorted' do
+    let(:source) { <<-END }
+      gem 'Z'
+      gem 'a'
+    END
+
+    it 'registers an offense' do
+      inspect_source(cop, source)
+      expect(cop.offenses.size).to eq(1)
+    end
+
+    it 'autocorrects' do
+      new_source = autocorrect_source_with_loop(cop, source)
+      expect(new_source).to eq(["      gem 'a'",
+                                "      gem 'Z'",
+                                ''].join("\n"))
+    end
+  end
 end


### PR DESCRIPTION
Updates the Bundler/OrderedGems cop to not consider case when checking if a Gemfile is alphabetized.