### PR TITLE
Minimal additions to test coverage with simplification of cop

### DIFF
--- a/lib/rubocop/cop/style/string_methods.rb
+++ b/lib/rubocop/cop/style/string_methods.rb
@@ -14,9 +14,7 @@ module RuboCop
           _receiver, method_name, *_args = *node
           return unless preferred_methods[method_name]
           add_offense(node, :selector,
-                      format(MSG,
-                             preferred_method(method_name),
-                             method_name))
+                      format(MSG, preferred_method(method_name), method_name))
         end
 
         def autocorrect(node)

--- a/spec/rubocop/cop/style/string_methods_spec.rb
+++ b/spec/rubocop/cop/style/string_methods_spec.rb
@@ -3,22 +3,20 @@
 require 'spec_helper'
 
 RSpec.describe RuboCop::Cop::Style::StringMethods, :config do
-  cop_config = {
-    'PreferredMethods' => {
-      'intern' => 'to_sym'
-    }
-  }
-
   subject(:cop) { described_class.new(config) }
-  let(:cop_config) { cop_config }
 
-  cop_config['PreferredMethods'].each do |method, preferred_method|
-    it "registers an offense for #{method}" do
-      inspect_source(cop, "'something'.#{method}")
-      expect(cop.offenses.size).to eq(1)
-      expect(cop.messages)
-        .to eq(["Prefer `#{preferred_method}` over `#{method}`."])
-      expect(cop.highlights).to eq(%w(intern))
-    end
+  let(:cop_config) { { 'intern' => 'to_sym' } }
+
+  let(:source) { "'something'.intern" }
+  let(:corrected) { autocorrect_source(cop, source) }
+
+  it 'registers an offense' do
+    inspect_source(cop, source)
+
+    expect(cop.offenses.size).to eq(1)
+    expect(cop.messages).to eq(['Prefer `to_sym` over `intern`.'])
+    expect(cop.highlights).to eq(%w(intern))
+
+    expect(corrected).to eq("'something'.to_sym")
   end
 end


### PR DESCRIPTION
As I was looking at other things, I noticed some minor improvements:

- `Style/StringMethods` was missing tests for auto-correct.
- `Rails/FindEach` had a duplicated guard clause and unneeded recursion.

This change fixes those, and some small housekeeping.

-----------------

Before submitting the PR make sure the following are checked:

* [X] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [X] Used the same coding conventions as the rest of the project.
* [X] Feature branch is up-to-date with `master` (if not - rebase it).
* [X] Squashed related commits together.
* [X] Added tests.
* [ ] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [X] All tests are passing.
* [X] The new code doesn't generate RuboCop offenses.
* [X] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [ ] Updated cop documentation with `rake generate_cops_documentation` (required only when you've added a new cop or changed the configuration/documentation of an existing cop).

[1]: http://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html
