### PR TITLE
Fix `IdenticalConditionalBranches` when branches have same line at leading

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@
 * [#3749](https://github.com/bbatsov/rubocop/pull/3749): Detect corner case of `Style/NumericLitterals`. ([@kamaradclimber][])
 * [#3788](https://github.com/bbatsov/rubocop/pull/3788): Prevent bad auto-correct in `Style/Next` when block has nested conditionals. ([@drenmi][])
 * [#3807](https://github.com/bbatsov/rubocop/pull/3807): Prevent `Style/Documentation` and `Style/DocumentationMethod` from mistaking RuboCop directives for class documentation. ([@drenmi][])
+* [#3815](https://github.com/bbatsov/rubocop/pull/3815): Fix false positive in `Style/IdenticalConditionalBranches` cop when branches have same line at leading. ([@pocke][])
 
 ## 0.46.0 (2016-11-30)
 

--- a/lib/rubocop/cop/style/identical_conditional_branches.rb
+++ b/lib/rubocop/cop/style/identical_conditional_branches.rb
@@ -37,7 +37,7 @@ module RuboCop
           # without an `else`, or a branch that contains only comments.
           return if branches.any?(&:nil?)
 
-          check_node(branches)
+          check_branches(branches)
         end
 
         def on_case(node)
@@ -46,17 +46,22 @@ module RuboCop
           return unless else_branch # empty else
           when_branches = expand_when_branches(when_branches)
 
-          check_node(when_branches.push(else_branch))
+          check_branches(when_branches.push(else_branch))
         end
 
         private
 
-        def check_node(branches)
-          branches = branches.map { |branch| tail(branch) }
+        def check_branches(branches)
+          tails = branches.map { |branch| tail(branch) }
+          check_sentences(tails)
+          heads = branches.map { |branch| head(branch) }
+          check_sentences(heads)
+        end
 
-          return unless branches.all? { |branch| branch == branches[0] }
-          branches.each do |branch|
-            add_offense(branch, :expression, format(MSG, branch.source))
+        def check_sentences(sentences)
+          return unless sentences.all? { |sentence| sentence == sentences[0] }
+          sentences.each do |sentence|
+            add_offense(sentence, :expression, format(MSG, sentence.source))
           end
         end
 
@@ -82,6 +87,14 @@ module RuboCop
         def tail(node)
           if node && node.begin_type?
             node.children.last
+          else
+            node
+          end
+        end
+
+        def head(node)
+          if node && node.begin_type?
+            node.children.first
           else
             node
           end

--- a/spec/rubocop/cop/style/identical_conditional_branches_spec.rb
+++ b/spec/rubocop/cop/style/identical_conditional_branches_spec.rb
@@ -47,6 +47,26 @@ describe RuboCop::Cop::Style::IdenticalConditionalBranches do
     end
   end
 
+  context 'on if..else with identical leading lines' do
+    let(:source) do
+      ['if something',
+       '  do_x',
+       '  method_call_here(1, 2, 3)',
+       'else',
+       '  do_x',
+       '  1 + 2 + 3',
+       'end']
+    end
+
+    it 'registers an offense' do
+      expect(cop.offenses.size).to eq(2)
+      expect(cop.messages).to eq([
+                                   'Move `do_x` out of the conditional.',
+                                   'Move `do_x` out of the conditional.'
+                                 ])
+    end
+  end
+
   context 'on if..elsif with no else' do
     let(:source) do
       ['if something',
@@ -75,7 +95,7 @@ describe RuboCop::Cop::Style::IdenticalConditionalBranches do
     end
   end
 
-  context 'on case with identical trailing lines' do
+  context 'on case with identical bodies' do
     let(:source) do
       ['case something',
        'when :a',
@@ -84,6 +104,56 @@ describe RuboCop::Cop::Style::IdenticalConditionalBranches do
        '  do_x',
        'else',
        '  do_x',
+       'end']
+    end
+
+    it 'registers an offense' do
+      expect(cop.offenses.size).to eq(3)
+      expect(cop.messages).to eq([
+                                   'Move `do_x` out of the conditional.',
+                                   'Move `do_x` out of the conditional.',
+                                   'Move `do_x` out of the conditional.'
+                                 ])
+    end
+  end
+
+  context 'on case with identical trailing lines' do
+    let(:source) do
+      ['case something',
+       'when :a',
+       '  x1',
+       '  do_x',
+       'when :b',
+       '  x2',
+       '  do_x',
+       'else',
+       '  x3',
+       '  do_x',
+       'end']
+    end
+
+    it 'registers an offense' do
+      expect(cop.offenses.size).to eq(3)
+      expect(cop.messages).to eq([
+                                   'Move `do_x` out of the conditional.',
+                                   'Move `do_x` out of the conditional.',
+                                   'Move `do_x` out of the conditional.'
+                                 ])
+    end
+  end
+
+  context 'on case with identical leading lines' do
+    let(:source) do
+      ['case something',
+       'when :a',
+       '  do_x',
+       '  x1',
+       'when :b',
+       '  do_x',
+       '  x2',
+       'else',
+       '  do_x',
+       '  x3',
        'end']
     end
 


### PR DESCRIPTION
```ruby
if cond
  foo
  foobar
else
  bar
  foobar
end
```

Currently, `Style/IdenticalConditionalBranches` cop registers offenses for the above code.

```sh
$ rubocop --only Style/IdenticalConditionalBranches
Inspecting 1 file
C

Offenses:

test.rb:3:3: C: Move foobar out of the conditional.
  foobar
  ^^^^^^
test.rb:6:3: C: Move foobar out of the conditional.
  foobar
  ^^^^^^

1 file inspected, 2 offenses detected

```

However, this cop doesn't register any offenses for the following code.

```ruby
if cond
  foobar
  foo
else
  foobar
  bar
end
```

```sh
$ rubocop --only Style/IdenticalConditionalBranches
Inspecting 1 file
.

1 file inspected, no offenses detected

```

In the second example, the `foobar` method can be put out outside of if.
So, I changed this cop to detect the problem.

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Used the same coding conventions as the rest of the project.
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] All tests are passing.
* [x] The new code doesn't generate RuboCop offenses.
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Updated cop documentation with `rake generate_cops_documentation` (required only when you've added a new cop or changed the configuration/documentation of an existing cop).

[1]: http://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html
