### PR TITLE
Add Security/Marshal cop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### New features
 
+* [#3816](https://github.com/bbatsov/rubocop/pull/3816): Add `Security/MarshalLoad` cop. ([@cyberdelia][])
 * [#3757](https://github.com/bbatsov/rubocop/pull/3757): Add Auto-Correct for `Bundler/OrderedGems` cop. ([@pocke][])
 * `Style/FrozenStringLiteralComment` now supports the style `never` that will remove the `frozen_string_literal` comment. ([@rrosenblum][])
 * [#3795](https://github.com/bbatsov/rubocop/pull/3795): Add `Lint/MultipleCompare` cop. ([@pocke][])
@@ -2343,6 +2344,7 @@
 [@pmenglund]: https://github.com/pmenglund
 [@chulkilee]: https://github.com/chulkilee
 [@codez]: https://github.com/codez
+[@cyberdelia]: https://github.com/cyberdelia
 [@emou]: https://github.com/emou
 [@skanev]: http://github.com/skanev
 [@claco]: http://github.com/claco

--- a/config/enabled.yml
+++ b/config/enabled.yml
@@ -1573,6 +1573,13 @@ Security/JSONLoad:
   # on the value of the argument.
   AutoCorrect: false
 
+Security/MarshalLoad:
+  Description: >-
+                 Avoid using of `Marshal.load` or `Marshal.restore` due to potential
+                 security issues. See reference for more information.
+  Reference: 'http://ruby-doc.org/core-2.3.3/Marshal.html#module-Marshal-label-Security+considerations'
+  Enabled: true
+
 ##################### Bundler #############################
 
 Bundler/DuplicatedGem:

--- a/lib/rubocop.rb
+++ b/lib/rubocop.rb
@@ -420,6 +420,7 @@ require 'rubocop/cop/rails/uniq_before_pluck'
 require 'rubocop/cop/rails/validation'
 
 require 'rubocop/cop/security/json_load'
+require 'rubocop/cop/security/marshal_load'
 
 require 'rubocop/cop/team'
 

--- a/lib/rubocop/cop/security/marshal_load.rb
+++ b/lib/rubocop/cop/security/marshal_load.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+module RuboCop
+  module Cop
+    module Security
+      # This cop checks for the use of Marshal class methods which have
+      # potential security issues leading to remote code execution when
+      # loading from an untrusted source.
+      #
+      # @example
+      #   # bad
+      #   Marshal.load("{}")
+      #   Marshal.restore("{}")
+      #
+      #   # good
+      #   Marshal.dump("{}")
+      #
+      class MarshalLoad < Cop
+        MSG = 'Avoid using `Marshal.%s`.'.freeze
+
+        def_node_matcher :marshal_load, <<-END
+          (send (const nil :Marshal) ${:load :restore} ...)
+        END
+
+        def on_send(node)
+          marshal_load(node) do |method|
+            add_offense(node, :selector, format(MSG, method))
+          end
+        end
+      end
+    end
+  end
+end

--- a/manual/cops.md
+++ b/manual/cops.md
@@ -201,6 +201,7 @@ In the following section you find all available cops:
 #### Type [Security](cops_security.md)
 
 * [Security/JSONLoad](cops_security.md#securityjsonload)
+* [Security/MarshalLoad](cops_security.md#securitymarshalload)
 
 #### Type [Style](cops_style.md)
 

--- a/manual/cops_security.md
+++ b/manual/cops_security.md
@@ -35,3 +35,31 @@ Attribute | Value
 Reference | http://ruby-doc.org/stdlib-2.3.0/libdoc/json/rdoc/JSON.html#method-i-load
 AutoCorrect | false
 
+
+## Security/MarshalLoad
+
+Enabled by default | Supports autocorrection
+--- | ---
+Enabled | No
+
+This cop checks for the use of Marshal class methods which have
+potential security issues leading to remote code execution when
+loading from an untrusted source.
+
+### Example
+
+```ruby
+# bad
+Marshal.load("{}")
+Marshal.restore("{}")
+
+# good
+Marshal.dump("{}")
+```
+
+### Important attributes
+
+Attribute | Value
+--- | ---
+Reference | http://ruby-doc.org/core-2.3.3/Marshal.html#module-Marshal-label-Security+considerations
+

--- a/manual/cops_style.md
+++ b/manual/cops_style.md
@@ -650,6 +650,7 @@ Attribute | Value
 EnforcedStyle | assign_to_condition
 SupportedStyles | assign_to_condition, assign_inside_condition
 SingleLineConditionsOnly | true
+IncludeTernaryExpressions | true
 
 
 ## Style/ConstantName

--- a/spec/rubocop/cop/security/json_load_spec.rb
+++ b/spec/rubocop/cop/security/json_load_spec.rb
@@ -10,7 +10,7 @@ describe RuboCop::Cop::Security::JSONLoad, :config do
     expect(cop.offenses).to be_empty
   end
 
-  it 'accepts JSON.parse' do
+  it 'accepts Module::JSON.parse' do
     inspect_source(cop, 'Module::JSON.parse("{}")')
     expect(cop.offenses).to be_empty
   end
@@ -20,7 +20,7 @@ describe RuboCop::Cop::Security::JSONLoad, :config do
     expect(cop.offenses).to be_empty
   end
 
-  it 'accepts JSON.dump' do
+  it 'accepts Module::JSON.dump' do
     inspect_source(cop, 'Module::JSON.load({})')
     expect(cop.offenses).to be_empty
   end

--- a/spec/rubocop/cop/security/marshal_load_spec.rb
+++ b/spec/rubocop/cop/security/marshal_load_spec.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+describe RuboCop::Cop::Security::MarshalLoad, :config do
+  subject(:cop) { described_class.new(config) }
+
+  it 'accepts Marshal.dump' do
+    inspect_source(cop, 'Marshal.dump({})')
+    expect(cop.offenses).to be_empty
+  end
+
+  it 'accepts Module::Marshal.dump' do
+    inspect_source(cop, 'Module::Marshal.dump({})')
+    expect(cop.offenses).to be_empty
+  end
+
+  [:load, :restore].each do |method|
+    it "registers an offense for Marshal.#{method}" do
+      inspect_source(cop, "Marshal.#{method}('{}')")
+      expect(cop.offenses.size).to eq(1)
+      expect(cop.offenses.first.message).to include("Marshal.#{method}")
+    end
+  end
+end


### PR DESCRIPTION
Add a new Security cop, that look for usage of `Marshal.load` and `Marshal.restore`, as they are both potentially dangerous: http://ruby-doc.org/core-2.3.3/Marshal.html#module-Marshal-label-Security+considerations

There is no alternative for theses methods, as `Marshal` is inherently dangerous. 

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Used the same coding conventions as the rest of the project.
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] All tests are passing.
* [x] The new code doesn't generate RuboCop offenses.
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Updated cop documentation with `rake generate_cops_documentation` (required only when you've added a new cop or changed the configuration/documentation of an existing cop).

[1]: http://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html