### PR TITLE
Add missing examples in Lint cops documentation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@
 * [#3761](https://github.com/bbatsov/rubocop/pull/3761): Update `Style/RedundantFreeze` message from `Freezing immutable objects is pointless.` to `Do not freeze immutable objects, as freezing them has no effect.`. ([@lucasuyezu][])
 * [#3753](https://github.com/bbatsov/rubocop/issues/3753): Change error message of `Bundler/OrderedGems` to mention `Alphabetize Gems`. ([@tejasbubane][])
 * [#3802](https://github.com/bbatsov/rubocop/pull/3802): Ignore case when checking Gemfile order. ([@breckenedge][])
+* Add missing examples in `Lint` cops documentation. ([@enriikke][])
 
 ### Bug fixes
 
@@ -2552,3 +2553,4 @@
 [@kevindew]: https://github.com/kevindew
 [@lucasuyezu]: https://github.com/lucasuyezu
 [@breckenedge]: https://github.com/breckenedge
+[@enriikke] https://github.com/enriikke

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2553,4 +2553,4 @@
 [@kevindew]: https://github.com/kevindew
 [@lucasuyezu]: https://github.com/lucasuyezu
 [@breckenedge]: https://github.com/breckenedge
-[@enriikke] https://github.com/enriikke
+[@enriikke]: https://github.com/enriikke

--- a/lib/rubocop/cop/lint/ambiguous_operator.rb
+++ b/lib/rubocop/cop/lint/ambiguous_operator.rb
@@ -7,14 +7,19 @@ module RuboCop
       # method invocation without parentheses.
       #
       # @example
-      #   array = [1, 2, 3]
+      #
+      #   # bad
       #
       #   # The `*` is interpreted as a splat operator but it could possibly be
-      #   # a `*` method invocation (i.e. `do_something.*(array)`).
-      #   do_something *array
+      #   # a `*` method invocation (i.e. `do_something.*(some_array)`).
+      #   do_something *some_array
+      #
+      # @example
+      #
+      #   # good
       #
       #   # With parentheses, there's no ambiguity.
-      #   do_something(*array)
+      #   do_something(*some_array)
       class AmbiguousOperator < Cop
         include ParserDiagnostic
 

--- a/lib/rubocop/cop/lint/ambiguous_regexp_literal.rb
+++ b/lib/rubocop/cop/lint/ambiguous_regexp_literal.rb
@@ -7,10 +7,17 @@ module RuboCop
       # a method invocation without parentheses.
       #
       # @example
+      #
+      #   # bad
+      #
       #   # This is interpreted as a method invocation with a regexp literal,
       #   # but it could possibly be `/` method invocations.
       #   # (i.e. `do_something./(pattern)./(i)`)
       #   do_something /pattern/i
+      #
+      # @example
+      #
+      #   # good
       #
       #   # With parentheses, there's no ambiguity.
       #   do_something(/pattern/i)

--- a/lib/rubocop/cop/lint/assignment_in_condition.rb
+++ b/lib/rubocop/cop/lint/assignment_in_condition.rb
@@ -5,6 +5,22 @@ module RuboCop
     module Lint
       # This cop checks for assignments in the conditions of
       # if/while/until.
+      #
+      # @example
+      #
+      #   # bad
+      #
+      #   if some_var = true
+      #     do_something
+      #   end
+      #
+      # @example
+      #
+      #   # good
+      #
+      #   if some_var == true
+      #     do_something
+      #   end
       class AssignmentInCondition < Cop
         include SafeAssignment
 

--- a/lib/rubocop/cop/lint/block_alignment.rb
+++ b/lib/rubocop/cop/lint/block_alignment.rb
@@ -20,18 +20,40 @@ module RuboCop
       #
       # @example
       #
-      #   # either
+      #   # bad
+      #
+      #   foo.bar
+      #      .each do
+      #        baz
+      #          end
+      #
+      # @example
+      #
+      #   # EnforcedStyleAlignWith: either (default)
+      #
+      #   # good
+      #
       #   variable = lambda do |i|
       #     i
       #   end
       #
-      #   # start_of_block
+      # @example
+      #
+      #   # EnforcedStyleAlignWith: start_of_block
+      #
+      #   # good
+      #
       #   foo.bar
       #     .each do
       #        baz
       #      end
       #
-      #   # start_of_line
+      # @example
+      #
+      #   # EnforcedStyleAlignWith: start_of_line
+      #
+      #   # good
+      #
       #   foo.bar
       #     .each do
       #        baz

--- a/lib/rubocop/cop/lint/circular_argument_reference.rb
+++ b/lib/rubocop/cop/lint/circular_argument_reference.rb
@@ -9,27 +9,41 @@ module RuboCop
       # This cop mirrors a warning produced by MRI since 2.2.
       #
       # @example
+      #
       #   # bad
+      #
       #   def bake(pie: pie)
       #     pie.heat_up
       #   end
       #
+      # @example
+      #
       #   # good
+      #
       #   def bake(pie:)
       #     pie.refrigerate
       #   end
       #
+      # @example
+      #
       #   # good
+      #
       #   def bake(pie: self.pie)
       #     pie.feed_to(user)
       #   end
       #
+      # @example
+      #
       #   # bad
+      #
       #   def cook(dry_ingredients = dry_ingredients)
       #     dry_ingredients.reduce(&:+)
       #   end
       #
+      # @example
+      #
       #   # good
+      #
       #   def cook(dry_ingredients = self.dry_ingredients)
       #     dry_ingredients.combine
       #   end

--- a/lib/rubocop/cop/lint/condition_position.rb
+++ b/lib/rubocop/cop/lint/condition_position.rb
@@ -8,8 +8,18 @@ module RuboCop
       #
       # @example
       #
+      #   # bad
+      #
       #   if
       #     some_condition
+      #     do_something
+      #   end
+      #
+      # @example
+      #
+      #   # good
+      #
+      #   if some_condition
       #     do_something
       #   end
       class ConditionPosition < Cop

--- a/lib/rubocop/cop/lint/debugger.rb
+++ b/lib/rubocop/cop/lint/debugger.rb
@@ -4,6 +4,34 @@ module RuboCop
   module Cop
     module Lint
       # This cop checks for calls to debugger or pry.
+      #
+      # @example
+      #
+      #   # bad (ok during development)
+      #
+      #   # using pry
+      #   def some_method
+      #     binding.pry
+      #     do_something
+      #   end
+      #
+      # @example
+      #
+      #   # bad (ok during development)
+      #
+      #   # using byebug
+      #   def some_method
+      #     byebug
+      #     do_something
+      #   end
+      #
+      # @example
+      #
+      #   # good
+      #
+      #   def some_method
+      #     do_something
+      #   end
       class Debugger < Cop
         MSG = 'Remove debugger entry point `%s`.'.freeze
 

--- a/lib/rubocop/cop/lint/def_end_alignment.rb
+++ b/lib/rubocop/cop/lint/def_end_alignment.rb
@@ -14,8 +14,28 @@ module RuboCop
       #
       # @example
       #
+      #   # bad
+      #
+      #   private def foo
+      #               end
+      #
+      # @example
+      #
+      #   # EnforcedStyleAlignWith: start_of_line (default)
+      #
+      #   # good
+      #
       #   private def foo
       #   end
+      #
+      # @example
+      #
+      #   # EnforcedStyleAlignWith: def
+      #
+      #   # good
+      #
+      #   private def foo
+      #           end
       class DefEndAlignment < Cop
         include OnMethodDef
         include EndKeywordAlignment

--- a/lib/rubocop/cop/lint/deprecated_class_methods.rb
+++ b/lib/rubocop/cop/lint/deprecated_class_methods.rb
@@ -4,6 +4,18 @@ module RuboCop
   module Cop
     module Lint
       # This cop checks for uses of the deprecated class method usages.
+      #
+      # @example
+      #
+      #   # bad
+      #
+      #   File.exists?(some_path)
+      #
+      # @example
+      #
+      #   # good
+      #
+      #   File.exist?(some_path)
       class DeprecatedClassMethods < Cop
         # Inner class to DeprecatedClassMethods.
         # This class exists to add abstraction and clean naming to the

--- a/lib/rubocop/cop/lint/duplicate_case_condition.rb
+++ b/lib/rubocop/cop/lint/duplicate_case_condition.rb
@@ -8,14 +8,25 @@ module RuboCop
       #
       # @example
       #
-      #    # bad
-      #    case x
-      #    when 'first'
-      #      do_something
-      #    when 'first'
-      #      do_something_else
-      #    end
+      #   # bad
       #
+      #   case x
+      #   when 'first'
+      #     do_something
+      #   when 'first'
+      #     do_something_else
+      #   end
+      #
+      # @example
+      #
+      #   # good
+      #
+      #   case x
+      #   when 'first
+      #     do_something
+      #   when 'second'
+      #     do_something_else
+      #   end
       class DuplicateCaseCondition < Cop
         MSG = 'Duplicate `when` condition detected.'.freeze
 

--- a/lib/rubocop/cop/lint/duplicate_methods.rb
+++ b/lib/rubocop/cop/lint/duplicate_methods.rb
@@ -7,12 +7,26 @@ module RuboCop
       # definitions.
       #
       # @example
-      #   @bad
+      #
+      #   # bad
+      #
       #   def duplicated
       #     1
       #   end
       #
       #   def duplicated
+      #     2
+      #   end
+      #
+      # @example
+      #
+      #   # good
+      #
+      #   def duplicated
+      #     1
+      #   end
+      #
+      #   def other_duplicated
       #     2
       #   end
       class DuplicateMethods < Cop

--- a/lib/rubocop/cop/lint/duplicated_key.rb
+++ b/lib/rubocop/cop/lint/duplicated_key.rb
@@ -8,7 +8,16 @@ module RuboCop
       # This cop mirrors a warning in Ruby 2.2.
       #
       # @example
+      #
+      #   # bad
+      #
       #   hash = { food: 'apple', food: 'orange' }
+      #
+      # @example
+      #
+      #   # good
+      #
+      #   hash = { food: 'apple', other_food: 'orange' }
       class DuplicatedKey < Cop
         MSG = 'Duplicated key in hash literal.'.freeze
 

--- a/lib/rubocop/cop/lint/each_with_object_argument.rb
+++ b/lib/rubocop/cop/lint/each_with_object_argument.rb
@@ -11,7 +11,16 @@ module RuboCop
       #
       # @example
       #
+      #   # bad
+      #
       #   sum = numbers.each_with_object(0) { |e, a| a += e }
+      #
+      # @example
+      #
+      #   # good
+      #
+      #   num = 0
+      #   sum = numbers.each_with_object(num) { |e, a| a += e }
       class EachWithObjectArgument < Cop
         MSG = 'The argument to each_with_object can not be immutable.'.freeze
 

--- a/lib/rubocop/cop/lint/else_layout.rb
+++ b/lib/rubocop/cop/lint/else_layout.rb
@@ -9,9 +9,22 @@ module RuboCop
       #
       # @example
       #
+      #   # bad
+      #
       #   if something
       #     ...
       #   else do_this
+      #     do_that
+      #   end
+      #
+      # @example
+      #
+      #   # good
+      #
+      #   if something
+      #     ...
+      #   else
+      #     do_this
       #     do_that
       #   end
       class ElseLayout < Cop

--- a/lib/rubocop/cop/lint/empty_ensure.rb
+++ b/lib/rubocop/cop/lint/empty_ensure.rb
@@ -4,6 +4,44 @@ module RuboCop
   module Cop
     module Lint
       # This cop checks for empty `ensure` blocks
+      #
+      # @example
+      #
+      #   # bad
+      #
+      #   def some_method
+      #     do_something
+      #   ensure
+      #   end
+      #
+      # @example
+      #
+      #   # bad
+      #
+      #   begin
+      #     do_something
+      #   ensure
+      #   end
+      #
+      # @example
+      #
+      #   # good
+      #
+      #   def some_method
+      #     do_something
+      #   ensure
+      #     do_something_else
+      #   end
+      #
+      # @example
+      #
+      #   # good
+      #
+      #   begin
+      #     do_something
+      #   ensure
+      #     do_something_else
+      #   end
       class EmptyEnsure < Cop
         MSG = 'Empty `ensure` block detected.'.freeze
 

--- a/lib/rubocop/cop/lint/empty_expression.rb
+++ b/lib/rubocop/cop/lint/empty_expression.rb
@@ -7,9 +7,19 @@ module RuboCop
       #
       # @example
       #
-      #   @bad
+      #   # bad
+      #
       #   foo = ()
       #   if ()
+      #     bar
+      #   end
+      #
+      # @example
+      #
+      #   # good
+      #
+      #   foo = (some_expression)
+      #   if (some_expression)
       #     bar
       #   end
       class EmptyExpression < Cop

--- a/lib/rubocop/cop/lint/empty_interpolation.rb
+++ b/lib/rubocop/cop/lint/empty_interpolation.rb
@@ -7,7 +7,15 @@ module RuboCop
       #
       # @example
       #
+      #   # bad
+      #
       #   "result is #{}"
+      #
+      # @example
+      #
+      #   # good
+      #
+      #   "result is #{some_result}"
       class EmptyInterpolation < Cop
         MSG = 'Empty interpolation detected.'.freeze
 

--- a/lib/rubocop/cop/lint/empty_when.rb
+++ b/lib/rubocop/cop/lint/empty_when.rb
@@ -7,10 +7,20 @@ module RuboCop
       #
       # @example
       #
-      #   @bad
+      #   # bad
+      #
       #   case foo
       #   when bar then 1
       #   when baz then # nothing
+      #   end
+      #
+      # @example
+      #
+      #   # good
+      #
+      #   case foo
+      #   when bar then 1
+      #   when baz then 2
       #   end
       class EmptyWhen < Cop
         MSG = 'Avoid `when` branches without a body.'.freeze

--- a/lib/rubocop/cop/lint/end_alignment.rb
+++ b/lib/rubocop/cop/lint/end_alignment.rb
@@ -18,16 +18,36 @@ module RuboCop
       # start of the line where the matching keyword appears.
       #
       # @example
-      #   @good
-      #   # keyword style
+      #
+      #   # bad
+      #
+      #   variable = if true
+      #       end
+      #
+      # @example
+      #
+      #   # EnforcedStyleAlignWith: keyword (default)
+      #
+      #   # good
+      #
       #   variable = if true
       #              end
       #
-      #   # variable style
+      # @example
+      #
+      #   # EnforcedStyleAlignWith: variable
+      #
+      #   # good
+      #
       #   variable = if true
       #   end
       #
-      #   # start_of_line style
+      # @example
+      #
+      #   # EnforcedStyleAlignWith: start_of_line
+      #
+      #   # good
+      #
       #   puts(if true
       #   end)
       class EndAlignment < Cop

--- a/lib/rubocop/cop/lint/end_in_method.rb
+++ b/lib/rubocop/cop/lint/end_in_method.rb
@@ -4,6 +4,29 @@ module RuboCop
   module Cop
     module Lint
       # This cop checks for END blocks in method definitions.
+      #
+      # @example
+      #
+      #   # bad
+      #
+      #   def some_method
+      #     END { do_something }
+      #   end
+      #
+      # @example
+      #
+      #   # good
+      #
+      #   def some_method
+      #     at_exit { do_something }
+      #   end
+      #
+      # @example
+      #
+      #   # good
+      #
+      #   # outside defs
+      #   END { do_something }
       class EndInMethod < Cop
         MSG = '`END` found in method definition. Use `at_exit` instead.'.freeze
 

--- a/lib/rubocop/cop/lint/ensure_return.rb
+++ b/lib/rubocop/cop/lint/ensure_return.rb
@@ -4,6 +4,27 @@ module RuboCop
   module Cop
     module Lint
       # This cop checks for *return* from an *ensure* block.
+      #
+      # @example
+      #
+      #   # bad
+      #
+      #   begin
+      #     do_something
+      #   ensure
+      #     do_something_else
+      #     return
+      #   end
+      #
+      # @example
+      #
+      #   # good
+      #
+      #   begin
+      #     do_something
+      #   ensure
+      #     do_something_else
+      #   end
       class EnsureReturn < Cop
         MSG = 'Do not return from an `ensure` block.'.freeze
 

--- a/lib/rubocop/cop/lint/eval.rb
+++ b/lib/rubocop/cop/lint/eval.rb
@@ -4,6 +4,12 @@ module RuboCop
   module Cop
     module Lint
       # This cop checks for the use of *Kernel#eval*.
+      #
+      # @example
+      #
+      #   # bad
+      #
+      #   eval(something)
       class Eval < Cop
         MSG = 'The use of `eval` is a serious security risk.'.freeze
 

--- a/lib/rubocop/cop/lint/float_out_of_range.rb
+++ b/lib/rubocop/cop/lint/float_out_of_range.rb
@@ -8,10 +8,15 @@ module RuboCop
       # that big. If you need a float that big, something is wrong with you.
       #
       # @example
+      #
       #   # bad
+      #
       #   float = 3.0e400
       #
+      # @example
+      #
       #   # good
+      #
       #   float = 42.9
       class FloatOutOfRange < Cop
         MSG = 'Float out of range.'.freeze

--- a/lib/rubocop/cop/lint/format_parameter_mismatch.rb
+++ b/lib/rubocop/cop/lint/format_parameter_mismatch.rb
@@ -9,8 +9,15 @@ module RuboCop
       #
       # @example
       #
+      #   # bad
+      #
       #   format('A value: %s and another: %i', a_value)
       #
+      # @example
+      #
+      #   # good
+      #
+      #   format('A value: %s and another: %i', a_value, another)
       class FormatParameterMismatch < Cop
         # http://rubular.com/r/CvpbxkcTzy
         MSG = "Number of arguments (%i) to `%s` doesn't match the number of " \

--- a/lib/rubocop/cop/lint/handle_exceptions.rb
+++ b/lib/rubocop/cop/lint/handle_exceptions.rb
@@ -4,6 +4,46 @@ module RuboCop
   module Cop
     module Lint
       # This cop checks for *rescue* blocks with no body.
+      #
+      # @example
+      #
+      #   # bad
+      #
+      #   def some_method
+      #     do_something
+      #   rescue
+      #     # do nothing
+      #   end
+      #
+      # @example
+      #
+      #   # bad
+      #
+      #   begin
+      #     do_something
+      #   rescue
+      #     # do nothing
+      #   end
+      #
+      # @example
+      #
+      #   # good
+      #
+      #   def some_method
+      #     do_something
+      #   rescue
+      #     handle_exception
+      #   end
+      #
+      # @example
+      #
+      #   # good
+      #
+      #   begin
+      #     do_something
+      #   rescue
+      #     handle_exception
+      #   end
       class HandleExceptions < Cop
         MSG = 'Do not suppress exceptions.'.freeze
 

--- a/lib/rubocop/cop/lint/implicit_string_concatenation.rb
+++ b/lib/rubocop/cop/lint/implicit_string_concatenation.rb
@@ -7,10 +7,15 @@ module RuboCop
       # which are on the same line.
       #
       # @example
-      #   @bad
+      #
+      #   # bad
+      #
       #   array = ['Item 1' 'Item 2']
       #
-      #   @good
+      # @example
+      #
+      #   # good
+      #
       #   array = ['Item 1Item 2']
       #   array = ['Item 1' + 'Item 2']
       #   array = [

--- a/lib/rubocop/cop/lint/ineffective_access_modifier.rb
+++ b/lib/rubocop/cop/lint/ineffective_access_modifier.rb
@@ -9,7 +9,9 @@ module RuboCop
       # used for that.
       #
       # @example
-      #   @bad
+      #
+      #   # bad
+      #
       #   class C
       #     private
       #
@@ -18,7 +20,10 @@ module RuboCop
       #     end
       #   end
       #
-      #   @good
+      # @example
+      #
+      #   # good
+      #
       #   class C
       #     def self.method
       #       puts 'hi'
@@ -26,6 +31,10 @@ module RuboCop
       #
       #     private_class_method :method
       #   end
+      #
+      # @example
+      #
+      #   # good
       #
       #   class C
       #     class << self

--- a/lib/rubocop/cop/lint/invalid_character_literal.rb
+++ b/lib/rubocop/cop/lint/invalid_character_literal.rb
@@ -16,6 +16,9 @@ module RuboCop
       #        ^
       #
       # @example
+      #
+      #   # bad
+      #
       #   p(? )
       class InvalidCharacterLiteral < Cop
         include ParserDiagnostic

--- a/lib/rubocop/cop/lint/literal_in_condition.rb
+++ b/lib/rubocop/cop/lint/literal_in_condition.rb
@@ -9,14 +9,27 @@ module RuboCop
       #
       # @example
       #
+      #   # bad
+      #
       #   if 20
       #     do_something
       #   end
+      #
+      # @example
+      #
+      #   # bad
       #
       #   if some_var && true
       #     do_something
       #   end
       #
+      # @example
+      #
+      #   # good
+      #
+      #   if some_var && some_condition
+      #     do_something
+      #   end
       class LiteralInCondition < Cop
         MSG = 'Literal `%s` appeared in a condition.'.freeze
 

--- a/lib/rubocop/cop/lint/literal_in_interpolation.rb
+++ b/lib/rubocop/cop/lint/literal_in_interpolation.rb
@@ -7,7 +7,15 @@ module RuboCop
       #
       # @example
       #
+      #   # bad
+      #
       #   "result is #{10}"
+      #
+      # @example
+      #
+      #   # good
+      #
+      #   "result is 10"
       class LiteralInInterpolation < Cop
         MSG = 'Literal interpolation detected.'.freeze
         COMPOSITE = [:array, :hash, :pair, :irange, :erange].freeze

--- a/lib/rubocop/cop/lint/loop.rb
+++ b/lib/rubocop/cop/lint/loop.rb
@@ -4,6 +4,42 @@ module RuboCop
   module Cop
     module Lint
       # This cop checks for uses of *begin...end while/until something*.
+      #
+      # @example
+      #
+      #   # bad
+      #
+      #   # using while
+      #   begin
+      #     do_something
+      #   end while some_condition
+      #
+      # @example
+      #
+      #   # bad
+      #
+      #   # using until
+      #   begin
+      #     do_something
+      #   end until some_condition
+      #
+      # @example
+      #
+      #   # good
+      #
+      #   # using while
+      #   while some_condition
+      #     do_something
+      #   end
+      #
+      # @example
+      #
+      #   # good
+      #
+      #   # using until
+      #   until some_condition
+      #     do_something
+      #   end
       class Loop < Cop
         MSG = 'Use `Kernel#loop` with `break` rather than ' \
               '`begin/end/until`(or `while`).'.freeze

--- a/lib/rubocop/cop/lint/multiple_compare.rb
+++ b/lib/rubocop/cop/lint/multiple_compare.rb
@@ -9,11 +9,16 @@ module RuboCop
       # comparison operators.
       #
       # @example
+      #
       #   # bad
+      #
       #   x < y < z
       #   10 <= x <= 20
       #
+      # @example
+      #
       #   # good
+      #
       #   x < y && y < z
       #   10 <= x && x <= 20
       class MultipleCompare < Cop

--- a/lib/rubocop/cop/lint/nested_method_definition.rb
+++ b/lib/rubocop/cop/lint/nested_method_definition.rb
@@ -6,6 +6,9 @@ module RuboCop
       # This cop checks for nested method definitions.
       #
       # @example
+      #
+      #   # bad
+      #
       #   # `bar` definition actually produces methods in the same scope
       #   # as the outer `foo` method. Furthermore, the `bar` method
       #   # will be redefined every time `foo` is invoked.
@@ -14,6 +17,25 @@ module RuboCop
       #     end
       #   end
       #
+      # @example
+      #
+      #   # good
+      #
+      #   def foo
+      #     bar = -> { puts 'hello' }
+      #     bar.call
+      #   end
+      #
+      # @example
+      #
+      #   # good
+      #
+      #   def foo
+      #     self.class_eval do
+      #       def bar
+      #       end
+      #     end
+      #   end
       class NestedMethodDefinition < Cop
         include OnMethodDef
         extend RuboCop::NodePattern::Macros

--- a/lib/rubocop/cop/lint/next_without_accumulator.rb
+++ b/lib/rubocop/cop/lint/next_without_accumulator.rb
@@ -6,13 +6,18 @@ module RuboCop
       # Don't omit the accumulator when calling `next` in a `reduce` block.
       #
       # @example
+      #
       #   # bad
+      #
       #   result = (1..4).reduce(0) do |acc, i|
       #     next if i.odd?
       #     acc + i
       #   end
       #
+      # @example
+      #
       #   # good
+      #
       #   result = (1..4).reduce(0) do |acc, i|
       #     next acc if i.odd?
       #     acc + i

--- a/lib/rubocop/cop/lint/parentheses_as_grouped_expression.rb
+++ b/lib/rubocop/cop/lint/parentheses_as_grouped_expression.rb
@@ -8,7 +8,15 @@ module RuboCop
       #
       # @example
       #
+      #   # bad
+      #
       #   puts (x + y)
+      #
+      # @example
+      #
+      #   # good
+      #
+      #   puts(x + y)
       class ParenthesesAsGroupedExpression < Cop
         MSG = '`(...)` interpreted as grouped expression.'.freeze
 

--- a/lib/rubocop/cop/lint/percent_string_array.rb
+++ b/lib/rubocop/cop/lint/percent_string_array.rb
@@ -3,13 +3,23 @@
 module RuboCop
   module Cop
     module Lint
-      # This cop checks for quotes and commas in %w, e.g.
+      # This cop checks for quotes and commas in %w, e.g. `%w('foo', "bar")`
       #
-      #   `%w('foo', "bar")`
-      #
-      # it is more likely that the additional characters are unintended (for
+      # It is more likely that the additional characters are unintended (for
       # example, mistranslating an array of literals to percent string notation)
       # rather than meant to be part of the resulting strings.
+      #
+      # @example
+      #
+      #   # bad
+      #
+      #   %w('foo', "bar")
+      #
+      # @example
+      #
+      #   # good
+      #
+      #   %w(foo bar)
       class PercentStringArray < Cop
         include PercentLiteral
 

--- a/lib/rubocop/cop/lint/percent_symbol_array.rb
+++ b/lib/rubocop/cop/lint/percent_symbol_array.rb
@@ -3,13 +3,23 @@
 module RuboCop
   module Cop
     module Lint
-      # This cop checks for colons and commas in %i, e.g.
+      # This cop checks for colons and commas in %i, e.g. `%i(:foo, :bar)`
       #
-      #   `%i(:foo, :bar)`
-      #
-      # it is more likely that the additional characters are unintended (for
+      # It is more likely that the additional characters are unintended (for
       # example, mistranslating an array of literals to percent string notation)
       # rather than meant to be part of the resulting symbols.
+      #
+      # @example
+      #
+      #   # bad
+      #
+      #   %i(:foo, :bar)
+      #
+      # @example
+      #
+      #   # good
+      #
+      #   %i(foo bar)
       class PercentSymbolArray < Cop
         include PercentLiteral
 

--- a/lib/rubocop/cop/lint/rand_one.rb
+++ b/lib/rubocop/cop/lint/rand_one.rb
@@ -8,14 +8,18 @@ module RuboCop
       #
       # @example
       #
-      #   @bad
+      #   # bad
+      #
       #   rand 1
       #   Kernel.rand(-1)
       #   rand 1.0
       #   rand(-1.0)
       #
-      #   @good
-      #   0
+      # @example
+      #
+      #   # good
+      #
+      #   0 # just use 0 instead
       class RandOne < Cop
         MSG = '`%s` always returns `0`. ' \
               'Perhaps you meant `rand(2)` or `rand`?'.freeze

--- a/lib/rubocop/cop/lint/require_parentheses.rb
+++ b/lib/rubocop/cop/lint/require_parentheses.rb
@@ -14,9 +14,17 @@ module RuboCop
       #
       # @example
       #
+      #   # bad
+      #
       #   if day.is? :tuesday && month == :jan
       #     ...
       #   end
+      #
+      # @example
+      #
+      #   # good
+      #
+      #   if day.is?(:tuesday) && month == :jan
       class RequireParentheses < Cop
         include IfNode
 

--- a/lib/rubocop/cop/lint/rescue_exception.rb
+++ b/lib/rubocop/cop/lint/rescue_exception.rb
@@ -4,6 +4,26 @@ module RuboCop
   module Cop
     module Lint
       # This cop checks for *rescue* blocks targeting the Exception class.
+      #
+      # @example
+      #
+      #   # bad
+      #
+      #   begin
+      #     do_something
+      #   rescue Exception
+      #     handle_exception
+      #   end
+      #
+      # @example
+      #
+      #   # good
+      #
+      #   begin
+      #     do_something
+      #   rescue ArgumentError
+      #     handle_exception
+      #   end
       class RescueException < Cop
         MSG = 'Avoid rescuing the `Exception` class. ' \
               'Perhaps you meant to rescue `StandardError`?'.freeze

--- a/lib/rubocop/cop/lint/safe_navigation_chain.rb
+++ b/lib/rubocop/cop/lint/safe_navigation_chain.rb
@@ -10,12 +10,17 @@ module RuboCop
       # This cop checks for the problem outlined above.
       #
       # @example
+      #
       #   # bad
+      #
       #   x&.foo.bar
       #   x&.foo + bar
       #   x&.foo[bar]
       #
+      # @example
+      #
       #   # good
+      #
       #   x&.foo&.bar
       #   x&.foo || bar
       class SafeNavigationChain < Cop

--- a/lib/rubocop/cop/lint/shadowed_exception.rb
+++ b/lib/rubocop/cop/lint/shadowed_exception.rb
@@ -8,7 +8,9 @@ module RuboCop
       # exception is rescued.
       #
       # @example
+      #
       #   # bad
+      #
       #   begin
       #     something
       #   rescue Exception
@@ -17,7 +19,10 @@ module RuboCop
       #     handle_standard_error
       #   end
       #
+      # @example
+      #
       #   # good
+      #
       #   begin
       #     something
       #   rescue StandardError

--- a/lib/rubocop/cop/lint/shadowing_outer_local_variable.rb
+++ b/lib/rubocop/cop/lint/shadowing_outer_local_variable.rb
@@ -7,6 +7,30 @@ module RuboCop
       # for block arguments or block local variables.
       # This is a mimic of the warning
       # "shadowing outer local variable - foo" from `ruby -cw`.
+      #
+      # @example
+      #
+      #   # bad
+      #
+      #   def some_method
+      #     foo = 1
+      #
+      #     2.times do |foo| # shadowing outer `foo`
+      #       do_something(foo)
+      #     end
+      #   end
+      #
+      # @example
+      #
+      #   # good
+      #
+      #   def some_method
+      #     foo = 1
+      #
+      #     2.times do |bar|
+      #       do_something(bar)
+      #     end
+      #   end
       class ShadowingOuterLocalVariable < Cop
         MSG = 'Shadowing outer local variable - `%s`.'.freeze
 

--- a/lib/rubocop/cop/lint/string_conversion_in_interpolation.rb
+++ b/lib/rubocop/cop/lint/string_conversion_in_interpolation.rb
@@ -8,7 +8,15 @@ module RuboCop
       #
       # @example
       #
+      #   # bad
+      #
       #   "result is #{something.to_s}"
+      #
+      # @example
+      #
+      #   # good
+      #
+      #   "result is #{something}"
       class StringConversionInInterpolation < Cop
         MSG_DEFAULT = 'Redundant use of `Object#to_s` in interpolation.'.freeze
         MSG_SELF = 'Use `self` instead of `Object#to_s` in ' \

--- a/lib/rubocop/cop/lint/underscore_prefixed_variable_name.rb
+++ b/lib/rubocop/cop/lint/underscore_prefixed_variable_name.rb
@@ -5,6 +5,30 @@ module RuboCop
     module Lint
       # This cop checks for underscore-prefixed variables that are actually
       # used.
+      #
+      # @example
+      #
+      #   # bad
+      #
+      #   [1, 2, 3].each do |_num|
+      #     do_something(_num)
+      #   end
+      #
+      # @example
+      #
+      #   # good
+      #
+      #   [1, 2, 3].each do |num|
+      #     do_something(num)
+      #   end
+      #
+      # @example
+      #
+      #   # good
+      #
+      #   [1, 2, 3].each do |_num|
+      #     do_something # not using `_num`
+      #   end
       class UnderscorePrefixedVariableName < Cop
         MSG = 'Do not use prefix `_` for a variable that is used.'.freeze
 

--- a/lib/rubocop/cop/lint/unified_integer.rb
+++ b/lib/rubocop/cop/lint/unified_integer.rb
@@ -6,11 +6,16 @@ module RuboCop
       # This cop checks for using Fixnum or Bignum constant.
       #
       # @example
+      #
       #   # bad
+      #
       #   1.is_a?(Fixnum)
       #   1.is_a?(Bignum)
       #
+      # @example
+      #
       #   # good
+      #
       #   1.is_a?(Integer)
       class UnifiedInteger < Cop
         MSG = 'Use `Integer` instead of `%s`.'.freeze

--- a/lib/rubocop/cop/lint/unneeded_splat_expansion.rb
+++ b/lib/rubocop/cop/lint/unneeded_splat_expansion.rb
@@ -6,7 +6,9 @@ module RuboCop
       # This cop checks for unneeded usages of splat expansion
       #
       # @example
+      #
       #   # bad
+      #
       #   a = *[1, 2, 3]
       #   a = *'a'
       #   a = *1
@@ -24,7 +26,10 @@ module RuboCop
       #     baz
       #   end
       #
+      # @example
+      #
       #   # good
+      #
       #   c = [1, 2, 3]
       #   a = *c
       #   a, b = *c

--- a/lib/rubocop/cop/lint/unreachable_code.rb
+++ b/lib/rubocop/cop/lint/unreachable_code.rb
@@ -6,6 +6,23 @@ module RuboCop
       # This cop checks for unreachable code.
       # The check are based on the presence of flow of control
       # statement in non-final position in *begin*(implicit) blocks.
+      #
+      # @example
+      #
+      #   # bad
+      #
+      #   def some_method
+      #     return
+      #     do_something
+      #   end
+      #
+      # @example
+      #
+      #   # good
+      #
+      #   def some_method
+      #     do_something
+      #   end
       class UnreachableCode < Cop
         MSG = 'Unreachable code detected.'.freeze
 

--- a/lib/rubocop/cop/lint/unused_block_argument.rb
+++ b/lib/rubocop/cop/lint/unused_block_argument.rb
@@ -21,6 +21,8 @@ module RuboCop
       #     puts :baz
       #   end
       #
+      # @example
+      #
       #   # bad
       #
       #   do_something do |used, _unused|

--- a/lib/rubocop/cop/lint/unused_method_argument.rb
+++ b/lib/rubocop/cop/lint/unused_method_argument.rb
@@ -7,7 +7,17 @@ module RuboCop
       #
       # @example
       #
+      #   # bad
+      #
       #   def some_method(used, unused, _unused_but_allowed)
+      #     puts used
+      #   end
+      #
+      # @example
+      #
+      #   # good
+      #
+      #   def some_method(used, _unused, _unused_but_allowed)
       #     puts used
       #   end
       class UnusedMethodArgument < Cop

--- a/lib/rubocop/cop/lint/useless_assignment.rb
+++ b/lib/rubocop/cop/lint/useless_assignment.rb
@@ -12,6 +12,24 @@ module RuboCop
       # Currently this cop has advanced logic that detects unreferenced
       # reassignments and properly handles varied cases such as branch, loop,
       # rescue, ensure, etc.
+      #
+      # @example
+      #
+      #   # bad
+      #
+      #   def some_method
+      #     some_var = 1
+      #     do_something
+      #   end
+      #
+      # @example
+      #
+      #   # good
+      #
+      #   def some_method
+      #     some_var = 1
+      #     do_something(some_var)
+      #   end
       class UselessAssignment < Cop
         include NameSimilarity
         MSG = 'Useless assignment to variable - `%s`.'.freeze

--- a/lib/rubocop/cop/lint/useless_comparison.rb
+++ b/lib/rubocop/cop/lint/useless_comparison.rb
@@ -7,7 +7,9 @@ module RuboCop
       #
       # @example
       #
-      #  x.top >= x.top
+      #   # bad
+      #
+      #   x.top >= x.top
       class UselessComparison < Cop
         MSG = 'Comparison of something with itself detected.'.freeze
         OPS = %w(== === != < > <= >= <=>).freeze

--- a/lib/rubocop/cop/lint/useless_else_without_rescue.rb
+++ b/lib/rubocop/cop/lint/useless_else_without_rescue.rb
@@ -6,10 +6,25 @@ module RuboCop
       # This cop checks for useless `else` in `begin..end` without `rescue`.
       #
       # @example
+      #
+      #   # bad
+      #
       #   begin
       #     do_something
       #   else
-      #     handle_errors # This will never be run.
+      #     do_something_else # This will never be run.
+      #   end
+      #
+      # @example
+      #
+      #   # good
+      #
+      #   begin
+      #     do_something
+      #   rescue
+      #     handle_errors
+      #   else
+      #     do_something_else
       #   end
       class UselessElseWithoutRescue < Cop
         include ParserDiagnostic

--- a/lib/rubocop/cop/lint/useless_setter_call.rb
+++ b/lib/rubocop/cop/lint/useless_setter_call.rb
@@ -8,10 +8,22 @@ module RuboCop
       #
       # @example
       #
-      #  def something
-      #    x = Something.new
-      #    x.attr = 5
-      #  end
+      #   # bad
+      #
+      #   def something
+      #     x = Something.new
+      #     x.attr = 5
+      #   end
+      #
+      # @example
+      #
+      #   # good
+      #
+      #   def something
+      #     x = Something.new
+      #     x.attr = 5
+      #     x
+      #   end
       class UselessSetterCall < Cop
         include OnMethodDef
 

--- a/lib/rubocop/cop/lint/void.rb
+++ b/lib/rubocop/cop/lint/void.rb
@@ -5,6 +5,42 @@ module RuboCop
     module Lint
       # This cop checks for operators, variables and literals used
       # in void context.
+      #
+      # @example
+      #
+      #   # bad
+      #
+      #   def some_method
+      #     some_num * 10
+      #     do_something
+      #   end
+      #
+      # @example
+      #
+      #   # bad
+      #
+      #   def some_method
+      #     some_var
+      #     do_something
+      #   end
+      #
+      # @example
+      #
+      #   # good
+      #
+      #   def some_method
+      #     do_something
+      #     some_num * 10
+      #   end
+      #
+      # @example
+      #
+      #   # good
+      #
+      #   def some_method
+      #     do_something
+      #     some_var
+      #   end
       class Void < Cop
         OP_MSG = 'Operator `%s` used in void context.'.freeze
         VAR_MSG = 'Variable `%s` used in void context.'.freeze

--- a/manual/cops_lint.md
+++ b/manual/cops_lint.md
@@ -12,14 +12,17 @@ method invocation without parentheses.
 ### Example
 
 ```ruby
-array = [1, 2, 3]
+# bad
 
 # The `*` is interpreted as a splat operator but it could possibly be
-# a `*` method invocation (i.e. `do_something.*(array)`).
-do_something *array
+# a `*` method invocation (i.e. `do_something.*(some_array)`).
+do_something *some_array
+```
+```ruby
+# good
 
 # With parentheses, there's no ambiguity.
-do_something(*array)
+do_something(*some_array)
 ```
 
 ## Lint/AmbiguousRegexpLiteral
@@ -34,10 +37,15 @@ a method invocation without parentheses.
 ### Example
 
 ```ruby
+# bad
+
 # This is interpreted as a method invocation with a regexp literal,
 # but it could possibly be `/` method invocations.
 # (i.e. `do_something./(pattern)./(i)`)
 do_something /pattern/i
+```
+```ruby
+# good
 
 # With parentheses, there's no ambiguity.
 do_something(/pattern/i)
@@ -51,6 +59,23 @@ Enabled | No
 
 This cop checks for assignments in the conditions of
 if/while/until.
+
+### Example
+
+```ruby
+# bad
+
+if some_var = true
+  do_something
+end
+```
+```ruby
+# good
+
+if some_var == true
+  do_something
+end
+```
 
 ### Important attributes
 
@@ -83,18 +108,37 @@ location. The autofixer will default to `start_of_line`.
 ### Example
 
 ```ruby
-# either
+# bad
+
+foo.bar
+   .each do
+     baz
+       end
+```
+```ruby
+# EnforcedStyleAlignWith: either (default)
+
+# good
+
 variable = lambda do |i|
   i
 end
+```
+```ruby
+# EnforcedStyleAlignWith: start_of_block
 
-# start_of_block
+# good
+
 foo.bar
   .each do
      baz
    end
+```
+```ruby
+# EnforcedStyleAlignWith: start_of_line
 
-# start_of_line
+# good
+
 foo.bar
   .each do
      baz
@@ -124,26 +168,35 @@ This cop mirrors a warning produced by MRI since 2.2.
 
 ```ruby
 # bad
+
 def bake(pie: pie)
   pie.heat_up
 end
-
+```
+```ruby
 # good
+
 def bake(pie:)
   pie.refrigerate
 end
-
+```
+```ruby
 # good
+
 def bake(pie: self.pie)
   pie.feed_to(user)
 end
-
+```
+```ruby
 # bad
+
 def cook(dry_ingredients = dry_ingredients)
   dry_ingredients.reduce(&:+)
 end
-
+```
+```ruby
 # good
+
 def cook(dry_ingredients = self.dry_ingredients)
   dry_ingredients.combine
 end
@@ -161,8 +214,17 @@ if/while/until.
 ### Example
 
 ```ruby
+# bad
+
 if
   some_condition
+  do_something
+end
+```
+```ruby
+# good
+
+if some_condition
   do_something
 end
 ```
@@ -174,6 +236,34 @@ Enabled by default | Supports autocorrection
 Enabled | Yes
 
 This cop checks for calls to debugger or pry.
+
+### Example
+
+```ruby
+# bad (ok during development)
+
+# using pry
+def some_method
+  binding.pry
+  do_something
+end
+```
+```ruby
+# bad (ok during development)
+
+# using byebug
+def some_method
+  byebug
+  do_something
+end
+```
+```ruby
+# good
+
+def some_method
+  do_something
+end
+```
 
 ## Lint/DefEndAlignment
 
@@ -193,8 +283,26 @@ keyword is. If it's set to `def`, the `end` shall be aligned with the
 ### Example
 
 ```ruby
+# bad
+
+private def foo
+            end
+```
+```ruby
+# EnforcedStyleAlignWith: start_of_line (default)
+
+# good
+
 private def foo
 end
+```
+```ruby
+# EnforcedStyleAlignWith: def
+
+# good
+
+private def foo
+        end
 ```
 
 ### Important attributes
@@ -214,6 +322,19 @@ Enabled | Yes
 
 This cop checks for uses of the deprecated class method usages.
 
+### Example
+
+```ruby
+# bad
+
+File.exists?(some_path)
+```
+```ruby
+# good
+
+File.exist?(some_path)
+```
+
 ## Lint/DuplicateCaseCondition
 
 Enabled by default | Supports autocorrection
@@ -227,10 +348,21 @@ used in case 'when' expressions.
 
 ```ruby
 # bad
+
 case x
 when 'first'
   do_something
 when 'first'
+  do_something_else
+end
+```
+```ruby
+# good
+
+case x
+when 'first
+  do_something
+when 'second'
   do_something_else
 end
 ```
@@ -248,11 +380,23 @@ definitions.
 
 ```ruby
 # bad
+
 def duplicated
   1
 end
 
 def duplicated
+  2
+end
+```
+```ruby
+# good
+
+def duplicated
+  1
+end
+
+def other_duplicated
   2
 end
 ```
@@ -270,7 +414,14 @@ This cop mirrors a warning in Ruby 2.2.
 ### Example
 
 ```ruby
+# bad
+
 hash = { food: 'apple', food: 'orange' }
+```
+```ruby
+# good
+
+hash = { food: 'apple', other_food: 'orange' }
 ```
 
 ## Lint/EachWithObjectArgument
@@ -288,7 +439,15 @@ It's definitely a bug.
 ### Example
 
 ```ruby
+# bad
+
 sum = numbers.each_with_object(0) { |e, a| a += e }
+```
+```ruby
+# good
+
+num = 0
+sum = numbers.each_with_object(num) { |e, a| a += e }
 ```
 
 ## Lint/ElseLayout
@@ -304,9 +463,21 @@ which is usually a mistake.
 ### Example
 
 ```ruby
+# bad
+
 if something
   ...
 else do_this
+  do_that
+end
+```
+```ruby
+# good
+
+if something
+  ...
+else
+  do_this
   do_that
 end
 ```
@@ -318,6 +489,43 @@ Enabled by default | Supports autocorrection
 Enabled | No
 
 This cop checks for empty `ensure` blocks
+
+### Example
+
+```ruby
+# bad
+
+def some_method
+  do_something
+ensure
+end
+```
+```ruby
+# bad
+
+begin
+  do_something
+ensure
+end
+```
+```ruby
+# good
+
+def some_method
+  do_something
+ensure
+  do_something_else
+end
+```
+```ruby
+# good
+
+begin
+  do_something
+ensure
+  do_something_else
+end
+```
 
 ## Lint/EmptyExpression
 
@@ -331,8 +539,17 @@ This cop checks for the presence of empty expressions.
 
 ```ruby
 # bad
+
 foo = ()
 if ()
+  bar
+end
+```
+```ruby
+# good
+
+foo = (some_expression)
+if (some_expression)
   bar
 end
 ```
@@ -348,7 +565,14 @@ This cop checks for empty interpolation.
 ### Example
 
 ```ruby
+# bad
+
 "result is #{}"
+```
+```ruby
+# good
+
+"result is #{some_result}"
 ```
 
 ## Lint/EmptyWhen
@@ -363,9 +587,18 @@ This cop checks for the presence of `when` branches without a body.
 
 ```ruby
 # bad
+
 case foo
 when bar then 1
 when baz then # nothing
+end
+```
+```ruby
+# good
+
+case foo
+when bar then 1
+when baz then 2
 end
 ```
 
@@ -392,16 +625,32 @@ start of the line where the matching keyword appears.
 ### Example
 
 ```ruby
+# bad
+
+variable = if true
+    end
+```
+```ruby
+# EnforcedStyleAlignWith: keyword (default)
+
 # good
-# keyword style
+
 variable = if true
            end
+```
+```ruby
+# EnforcedStyleAlignWith: variable
 
-# variable style
+# good
+
 variable = if true
 end
+```
+```ruby
+# EnforcedStyleAlignWith: start_of_line
 
-# start_of_line style
+# good
+
 puts(if true
 end)
 ```
@@ -423,6 +672,29 @@ Enabled | No
 
 This cop checks for END blocks in method definitions.
 
+### Example
+
+```ruby
+# bad
+
+def some_method
+  END { do_something }
+end
+```
+```ruby
+# good
+
+def some_method
+  at_exit { do_something }
+end
+```
+```ruby
+# good
+
+# outside defs
+END { do_something }
+```
+
 ## Lint/EnsureReturn
 
 Enabled by default | Supports autocorrection
@@ -431,6 +703,28 @@ Enabled | No
 
 This cop checks for *return* from an *ensure* block.
 
+### Example
+
+```ruby
+# bad
+
+begin
+  do_something
+ensure
+  do_something_else
+  return
+end
+```
+```ruby
+# good
+
+begin
+  do_something
+ensure
+  do_something_else
+end
+```
+
 ## Lint/Eval
 
 Enabled by default | Supports autocorrection
@@ -438,6 +732,14 @@ Enabled by default | Supports autocorrection
 Enabled | No
 
 This cop checks for the use of *Kernel#eval*.
+
+### Example
+
+```ruby
+# bad
+
+eval(something)
+```
 
 ## Lint/FloatOutOfRange
 
@@ -453,9 +755,12 @@ that big. If you need a float that big, something is wrong with you.
 
 ```ruby
 # bad
-float = 3.0e400
 
+float = 3.0e400
+```
+```ruby
 # good
+
 float = 42.9
 ```
 
@@ -472,7 +777,14 @@ passed as arguments.
 ### Example
 
 ```ruby
+# bad
+
 format('A value: %s and another: %i', a_value)
+```
+```ruby
+# good
+
+format('A value: %s and another: %i', a_value, another)
 ```
 
 ## Lint/HandleExceptions
@@ -482,6 +794,45 @@ Enabled by default | Supports autocorrection
 Enabled | No
 
 This cop checks for *rescue* blocks with no body.
+
+### Example
+
+```ruby
+# bad
+
+def some_method
+  do_something
+rescue
+  # do nothing
+end
+```
+```ruby
+# bad
+
+begin
+  do_something
+rescue
+  # do nothing
+end
+```
+```ruby
+# good
+
+def some_method
+  do_something
+rescue
+  handle_exception
+end
+```
+```ruby
+# good
+
+begin
+  do_something
+rescue
+  handle_exception
+end
+```
 
 ## Lint/ImplicitStringConcatenation
 
@@ -496,9 +847,12 @@ which are on the same line.
 
 ```ruby
 # bad
-array = ['Item 1' 'Item 2']
 
+array = ['Item 1' 'Item 2']
+```
+```ruby
 # good
+
 array = ['Item 1Item 2']
 array = ['Item 1' + 'Item 2']
 array = [
@@ -522,6 +876,7 @@ used for that.
 
 ```ruby
 # bad
+
 class C
   private
 
@@ -529,8 +884,10 @@ class C
     puts 'hi'
   end
 end
-
+```
+```ruby
 # good
+
 class C
   def self.method
     puts 'hi'
@@ -538,6 +895,9 @@ class C
 
   private_class_method :method
 end
+```
+```ruby
+# good
 
 class C
   class << self
@@ -612,6 +972,8 @@ warning without syntax errors.
 ### Example
 
 ```ruby
+# bad
+
 p(? )
 ```
 
@@ -628,11 +990,23 @@ if/while/until.
 ### Example
 
 ```ruby
+# bad
+
 if 20
   do_something
 end
+```
+```ruby
+# bad
 
 if some_var && true
+  do_something
+end
+```
+```ruby
+# good
+
+if some_var && some_condition
   do_something
 end
 ```
@@ -648,7 +1022,14 @@ This cop checks for interpolated literals.
 ### Example
 
 ```ruby
+# bad
+
 "result is #{10}"
+```
+```ruby
+# good
+
+"result is 10"
 ```
 
 ## Lint/Loop
@@ -658,6 +1039,41 @@ Enabled by default | Supports autocorrection
 Enabled | No
 
 This cop checks for uses of *begin...end while/until something*.
+
+### Example
+
+```ruby
+# bad
+
+# using while
+begin
+  do_something
+end while some_condition
+```
+```ruby
+# bad
+
+# using until
+begin
+  do_something
+end until some_condition
+```
+```ruby
+# good
+
+# using while
+while some_condition
+  do_something
+end
+```
+```ruby
+# good
+
+# using until
+until some_condition
+  do_something
+end
+```
 
 ## Lint/MultipleCompare
 
@@ -674,10 +1090,13 @@ comparison operators.
 
 ```ruby
 # bad
+
 x < y < z
 10 <= x <= 20
-
+```
+```ruby
 # good
+
 x < y && y < z
 10 <= x && x <= 20
 ```
@@ -693,11 +1112,31 @@ This cop checks for nested method definitions.
 ### Example
 
 ```ruby
+# bad
+
 # `bar` definition actually produces methods in the same scope
 # as the outer `foo` method. Furthermore, the `bar` method
 # will be redefined every time `foo` is invoked.
 def foo
   def bar
+  end
+end
+```
+```ruby
+# good
+
+def foo
+  bar = -> { puts 'hello' }
+  bar.call
+end
+```
+```ruby
+# good
+
+def foo
+  self.class_eval do
+    def bar
+    end
   end
 end
 ```
@@ -714,12 +1153,15 @@ Don't omit the accumulator when calling `next` in a `reduce` block.
 
 ```ruby
 # bad
+
 result = (1..4).reduce(0) do |acc, i|
   next if i.odd?
   acc + i
 end
-
+```
+```ruby
 # good
+
 result = (1..4).reduce(0) do |acc, i|
   next acc if i.odd?
   acc + i
@@ -776,7 +1218,14 @@ parenthesis.
 ### Example
 
 ```ruby
+# bad
+
 puts (x + y)
+```
+```ruby
+# good
+
+puts(x + y)
 ```
 
 ## Lint/PercentStringArray
@@ -785,13 +1234,24 @@ Enabled by default | Supports autocorrection
 --- | ---
 Enabled | Yes
 
-This cop checks for quotes and commas in %w, e.g.
+This cop checks for quotes and commas in %w, e.g. `%w('foo', "bar")`
 
-  `%w('foo', "bar")`
-
-it is more likely that the additional characters are unintended (for
+It is more likely that the additional characters are unintended (for
 example, mistranslating an array of literals to percent string notation)
 rather than meant to be part of the resulting strings.
+
+### Example
+
+```ruby
+# bad
+
+%w('foo', "bar")
+```
+```ruby
+# good
+
+%w(foo bar)
+```
 
 ## Lint/PercentSymbolArray
 
@@ -799,13 +1259,24 @@ Enabled by default | Supports autocorrection
 --- | ---
 Enabled | Yes
 
-This cop checks for colons and commas in %i, e.g.
+This cop checks for colons and commas in %i, e.g. `%i(:foo, :bar)`
 
-  `%i(:foo, :bar)`
-
-it is more likely that the additional characters are unintended (for
+It is more likely that the additional characters are unintended (for
 example, mistranslating an array of literals to percent string notation)
 rather than meant to be part of the resulting symbols.
+
+### Example
+
+```ruby
+# bad
+
+%i(:foo, :bar)
+```
+```ruby
+# good
+
+%i(foo bar)
+```
 
 ## Lint/RandOne
 
@@ -820,13 +1291,16 @@ Such calls always return `0`.
 
 ```ruby
 # bad
+
 rand 1
 Kernel.rand(-1)
 rand 1.0
 rand(-1.0)
-
+```
+```ruby
 # good
-0
+
+0 # just use 0 instead
 ```
 
 ## Lint/RequireParentheses
@@ -847,9 +1321,16 @@ an operand of &&/||.
 ### Example
 
 ```ruby
+# bad
+
 if day.is? :tuesday && month == :jan
   ...
 end
+```
+```ruby
+# good
+
+if day.is?(:tuesday) && month == :jan
 ```
 
 ## Lint/RescueException
@@ -859,6 +1340,27 @@ Enabled by default | Supports autocorrection
 Enabled | No
 
 This cop checks for *rescue* blocks targeting the Exception class.
+
+### Example
+
+```ruby
+# bad
+
+begin
+  do_something
+rescue Exception
+  handle_exception
+end
+```
+```ruby
+# good
+
+begin
+  do_something
+rescue ArgumentError
+  handle_exception
+end
+```
 
 ## Lint/SafeNavigationChain
 
@@ -876,11 +1378,14 @@ This cop checks for the problem outlined above.
 
 ```ruby
 # bad
+
 x&.foo.bar
 x&.foo + bar
 x&.foo[bar]
-
+```
+```ruby
 # good
+
 x&.foo&.bar
 x&.foo || bar
 ```
@@ -899,6 +1404,7 @@ exception is rescued.
 
 ```ruby
 # bad
+
 begin
   something
 rescue Exception
@@ -906,8 +1412,10 @@ rescue Exception
 rescue StandardError
   handle_standard_error
 end
-
+```
+```ruby
 # good
+
 begin
   something
 rescue StandardError
@@ -928,6 +1436,31 @@ for block arguments or block local variables.
 This is a mimic of the warning
 "shadowing outer local variable - foo" from `ruby -cw`.
 
+### Example
+
+```ruby
+# bad
+
+def some_method
+  foo = 1
+
+  2.times do |foo| # shadowing outer `foo`
+    do_something(foo)
+  end
+end
+```
+```ruby
+# good
+
+def some_method
+  foo = 1
+
+  2.times do |bar|
+    do_something(bar)
+  end
+end
+```
+
 ## Lint/StringConversionInInterpolation
 
 Enabled by default | Supports autocorrection
@@ -940,7 +1473,14 @@ which is redundant.
 ### Example
 
 ```ruby
+# bad
+
 "result is #{something.to_s}"
+```
+```ruby
+# good
+
+"result is #{something}"
 ```
 
 ## Lint/UnderscorePrefixedVariableName
@@ -951,6 +1491,30 @@ Enabled | No
 
 This cop checks for underscore-prefixed variables that are actually
 used.
+
+### Example
+
+```ruby
+# bad
+
+[1, 2, 3].each do |_num|
+  do_something(_num)
+end
+```
+```ruby
+# good
+
+[1, 2, 3].each do |num|
+  do_something(num)
+end
+```
+```ruby
+# good
+
+[1, 2, 3].each do |_num|
+  do_something # not using `_num`
+end
+```
 
 ## Lint/UnifiedInteger
 
@@ -964,10 +1528,13 @@ This cop checks for using Fixnum or Bignum constant.
 
 ```ruby
 # bad
+
 1.is_a?(Fixnum)
 1.is_a?(Bignum)
-
+```
+```ruby
 # good
+
 1.is_a?(Integer)
 ```
 
@@ -999,6 +1566,7 @@ This cop checks for unneeded usages of splat expansion
 
 ```ruby
 # bad
+
 a = *[1, 2, 3]
 a = *'a'
 a = *1
@@ -1015,8 +1583,10 @@ when *[1, 2, 3]
 else
   baz
 end
-
+```
+```ruby
 # good
+
 c = [1, 2, 3]
 a = *c
 a, b = *c
@@ -1048,6 +1618,24 @@ This cop checks for unreachable code.
 The check are based on the presence of flow of control
 statement in non-final position in *begin*(implicit) blocks.
 
+### Example
+
+```ruby
+# bad
+
+def some_method
+  return
+  do_something
+end
+```
+```ruby
+# good
+
+def some_method
+  do_something
+end
+```
+
 ## Lint/UnusedBlockArgument
 
 Enabled by default | Supports autocorrection
@@ -1072,7 +1660,8 @@ end
 define_method(:foo) do |_bar|
   puts :baz
 end
-
+```
+```ruby
 # bad
 
 do_something do |used, _unused|
@@ -1107,7 +1696,16 @@ This cop checks for unused method arguments.
 ### Example
 
 ```ruby
+# bad
+
 def some_method(used, unused, _unused_but_allowed)
+  puts used
+end
+```
+```ruby
+# good
+
+def some_method(used, _unused, _unused_but_allowed)
   puts used
 end
 ```
@@ -1226,6 +1824,25 @@ Currently this cop has advanced logic that detects unreferenced
 reassignments and properly handles varied cases such as branch, loop,
 rescue, ensure, etc.
 
+### Example
+
+```ruby
+# bad
+
+def some_method
+  some_var = 1
+  do_something
+end
+```
+```ruby
+# good
+
+def some_method
+  some_var = 1
+  do_something(some_var)
+end
+```
+
 ## Lint/UselessComparison
 
 Enabled by default | Supports autocorrection
@@ -1237,6 +1854,8 @@ This cop checks for comparison of something with itself.
 ### Example
 
 ```ruby
+# bad
+
 x.top >= x.top
 ```
 
@@ -1251,10 +1870,23 @@ This cop checks for useless `else` in `begin..end` without `rescue`.
 ### Example
 
 ```ruby
+# bad
+
 begin
   do_something
 else
-  handle_errors # This will never be run.
+  do_something_else # This will never be run.
+end
+```
+```ruby
+# good
+
+begin
+  do_something
+rescue
+  handle_errors
+else
+  do_something_else
 end
 ```
 
@@ -1270,9 +1902,20 @@ expression of a function definition.
 ### Example
 
 ```ruby
+# bad
+
 def something
   x = Something.new
   x.attr = 5
+end
+```
+```ruby
+# good
+
+def something
+  x = Something.new
+  x.attr = 5
+  x
 end
 ```
 
@@ -1284,3 +1927,38 @@ Enabled | No
 
 This cop checks for operators, variables and literals used
 in void context.
+
+### Example
+
+```ruby
+# bad
+
+def some_method
+  some_num * 10
+  do_something
+end
+```
+```ruby
+# bad
+
+def some_method
+  some_var
+  do_something
+end
+```
+```ruby
+# good
+
+def some_method
+  do_something
+  some_num * 10
+end
+```
+```ruby
+# good
+
+def some_method
+  do_something
+  some_var
+end
+```

--- a/manual/cops_rails.md
+++ b/manual/cops_rails.md
@@ -466,43 +466,48 @@ Enabled by default | Supports autocorrection
 --- | ---
 Disabled | Yes
 
-This cop converts usages of `try!` to `&.`. It can also be configured
-to convert `try`. It will convert code to use safe navigation if the
-target Ruby version is set to 2.3+
+This cop transforms usages of a method call safeguarded by a non `nil`
+check for the variable whose method is being called to
+safe navigation (`&.`).
+
+Configuration option: ConvertCodeThatCanStartToReturnNil
+The default for this is `false`. When configured to `true`, this will
+check for code in the format `!foo.nil? && foo.bar`. As it is written,
+the return of this code is limited to `false` and whatever the return
+of the method is. If this is converted to safe navigation,
+`foo&.bar` can start returning `nil` as well as what the method
+returns.
 
 ### Example
 
 ```ruby
-# ConvertTry: false
-  # bad
-  foo.try!(:bar)
-  foo.try!(:bar, baz)
-  foo.try!(:bar) { |e| e.baz }
+# bad
+foo.bar if foo
+foo.bar(param1, param2) if foo
+foo.bar { |e| e.something } if foo
+foo.bar(param) { |e| e.something } if foo
 
-  foo.try!(:[], 0)
+foo.bar if !foo.nil?
+foo.bar unless !foo
+foo.bar unless foo.nil?
 
-  # good
-  foo.try(:bar)
-  foo.try(:bar, baz)
-  foo.try(:bar) { |e| e.baz }
+foo && foo.bar
+foo && foo.bar(param1, param2)
+foo && foo.bar { |e| e.something }
+foo && foo.bar(param) { |e| e.something }
 
-  foo&.bar
-  foo&.bar(baz)
-  foo&.bar { |e| e.baz }
+# good
+foo&.bar
+foo&.bar(param1, param2)
+foo&.bar { |e| e.something }
+foo&.bar(param) { |e| e.something }
 
-# ConvertTry: true
-  # bad
-  foo.try!(:bar)
-  foo.try!(:bar, baz)
-  foo.try!(:bar) { |e| e.baz }
-  foo.try(:bar)
-  foo.try(:bar, baz)
-  foo.try(:bar) { |e| e.baz }
+foo.nil? || foo.bar
+!foo || foo.bar
 
-  # good
-  foo&.bar
-  foo&.bar(baz)
-  foo&.bar { |e| e.baz }
+# Methods that `nil` will `respond_to?` should not be converted to
+# use safe navigation
+foo.to_i if foo
 ```
 
 ### Important attributes

--- a/manual/cops_style.md
+++ b/manual/cops_style.md
@@ -3757,43 +3757,48 @@ Enabled by default | Supports autocorrection
 --- | ---
 Enabled | Yes
 
-This cop converts usages of `try!` to `&.`. It can also be configured
-to convert `try`. It will convert code to use safe navigation if the
-target Ruby version is set to 2.3+
+This cop transforms usages of a method call safeguarded by a non `nil`
+check for the variable whose method is being called to
+safe navigation (`&.`).
+
+Configuration option: ConvertCodeThatCanStartToReturnNil
+The default for this is `false`. When configured to `true`, this will
+check for code in the format `!foo.nil? && foo.bar`. As it is written,
+the return of this code is limited to `false` and whatever the return
+of the method is. If this is converted to safe navigation,
+`foo&.bar` can start returning `nil` as well as what the method
+returns.
 
 ### Example
 
 ```ruby
-# ConvertTry: false
-  # bad
-  foo.try!(:bar)
-  foo.try!(:bar, baz)
-  foo.try!(:bar) { |e| e.baz }
+# bad
+foo.bar if foo
+foo.bar(param1, param2) if foo
+foo.bar { |e| e.something } if foo
+foo.bar(param) { |e| e.something } if foo
 
-  foo.try!(:[], 0)
+foo.bar if !foo.nil?
+foo.bar unless !foo
+foo.bar unless foo.nil?
 
-  # good
-  foo.try(:bar)
-  foo.try(:bar, baz)
-  foo.try(:bar) { |e| e.baz }
+foo && foo.bar
+foo && foo.bar(param1, param2)
+foo && foo.bar { |e| e.something }
+foo && foo.bar(param) { |e| e.something }
 
-  foo&.bar
-  foo&.bar(baz)
-  foo&.bar { |e| e.baz }
+# good
+foo&.bar
+foo&.bar(param1, param2)
+foo&.bar { |e| e.something }
+foo&.bar(param) { |e| e.something }
 
-# ConvertTry: true
-  # bad
-  foo.try!(:bar)
-  foo.try!(:bar, baz)
-  foo.try!(:bar) { |e| e.baz }
-  foo.try(:bar)
-  foo.try(:bar, baz)
-  foo.try(:bar) { |e| e.baz }
+foo.nil? || foo.bar
+!foo || foo.bar
 
-  # good
-  foo&.bar
-  foo&.bar(baz)
-  foo&.bar { |e| e.baz }
+# Methods that `nil` will `respond_to?` should not be converted to
+# use safe navigation
+foo.to_i if foo
 ```
 
 ### Important attributes


### PR DESCRIPTION
A few cops were missing examples in their documentation. This commit adds the
missing examples for `Lint` cops. Additionally, it attempts to be consistent
with the formatting in the documentation.

See also: #3808

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Used the same coding conventions as the rest of the project.
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [ ] Added tests.
* [x] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] All tests are passing.
* [x] The new code doesn't generate RuboCop offenses.
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Updated cop documentation with `rake generate_cops_documentation` (required only when you've added a new cop or changed the configuration/documentation of an existing cop).

[1]: http://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html
