### PR TITLE
Make `Style/EmptyMethod` cop aware of class methods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@
 * [#3753](https://github.com/bbatsov/rubocop/issues/3753): Change error message of `Bundler/OrderedGems` to mention `Alphabetize Gems`. ([@tejasbubane][])
 * [#3802](https://github.com/bbatsov/rubocop/pull/3802): Ignore case when checking Gemfile order. ([@breckenedge][])
 * Add missing examples in `Lint` cops documentation. ([@enriikke][])
+* Make `Style/EmptyMethod` cop aware of class methods. ([@drenmi][])
 
 ### Bug fixes
 

--- a/lib/rubocop/cop/mixin/on_method_def.rb
+++ b/lib/rubocop/cop/mixin/on_method_def.rb
@@ -14,6 +14,20 @@ module RuboCop
         on_method_def(node, method_name, args, body)
       end
 
+      # This method provides scope agnostic method node destructuring by moving
+      # the scope to the end where it can easily be ignored.
+      def method_def_node_parts(node)
+        if node.def_type?
+          method_name, args, body = *node
+        elsif node.defs_type?
+          scope, method_name, args, body = *node
+        else
+          return []
+        end
+
+        [method_name, args, body, scope]
+      end
+
       private
 
       # Returns true for constructs such as

--- a/manual/cops_style.md
+++ b/manual/cops_style.md
@@ -650,6 +650,7 @@ Attribute | Value
 EnforcedStyle | assign_to_condition
 SupportedStyles | assign_to_condition, assign_inside_condition
 SingleLineConditionsOnly | true
+IncludeTernaryExpressions | true
 
 
 ## Style/ConstantName
@@ -1216,20 +1217,26 @@ EnforcedStyle: compact (default)
 # bad
 def foo(bar)
 end
+def self.foo(bar)
+end
 
 # good
 def foo(bar); end
 def foo(bar)
   # baz
 end
+def self.foo(bar); end
 
 EnforcedStyle: expanded
 
 # bad
 def foo(bar); end
+def self.foo(bar); end
 
 # good
 def foo(bar)
+end
+def self.foo(bar)
 end
 ```
 

--- a/spec/rubocop/cop/style/empty_method_spec.rb
+++ b/spec/rubocop/cop/style/empty_method_spec.rb
@@ -43,7 +43,7 @@ describe RuboCop::Cop::Style::EmptyMethod, :config do
 
     let(:message) { 'Put empty method definitions on a single line.' }
 
-    context 'with an empty method definition' do
+    context 'with an empty instance method definition' do
       it_behaves_like 'code with offense',
                       ['def foo',
                        'end'].join("\n"),
@@ -64,7 +64,7 @@ describe RuboCop::Cop::Style::EmptyMethod, :config do
                       'def foo; end'
     end
 
-    context 'with a non-empty method definition' do
+    context 'with a non-empty instance method definition' do
       it_behaves_like 'code without offense',
                       ['def foo',
                        '  bar',
@@ -78,6 +78,42 @@ describe RuboCop::Cop::Style::EmptyMethod, :config do
                        '  # bar',
                        'end']
     end
+
+    context 'with an empty class method definition' do
+      it_behaves_like 'code with offense',
+                      ['def self.foo',
+                       'end'].join("\n"),
+                      'def self.foo; end'
+
+      it_behaves_like 'code with offense',
+                      ['def self.foo(bar, baz)',
+                       'end'].join("\n"),
+                      'def self.foo(bar, baz); end'
+
+      it_behaves_like 'code with offense',
+                      ['def self.foo',
+                       '',
+                       'end'].join("\n"),
+                      'def self.foo; end'
+
+      it_behaves_like 'code without offense',
+                      'def self.foo; end'
+    end
+
+    context 'with a non-empty class method definition' do
+      it_behaves_like 'code without offense',
+                      ['def self.foo',
+                       '  bar',
+                       'end']
+
+      it_behaves_like 'code without offense',
+                      'def self.foo; bar; end'
+
+      it_behaves_like 'code without offense',
+                      ['def self.foo',
+                       '  # bar',
+                       'end']
+    end
   end
 
   context 'when configured with expanded style' do
@@ -87,7 +123,7 @@ describe RuboCop::Cop::Style::EmptyMethod, :config do
       'Put the `end` of empty method definitions on the next line.'
     end
 
-    context 'with an empty method definition' do
+    context 'with an empty instance method definition' do
       it_behaves_like 'code without offense',
                       ['def foo',
                        'end'].join("\n")
@@ -103,7 +139,7 @@ describe RuboCop::Cop::Style::EmptyMethod, :config do
                        'end'].join("\n")
     end
 
-    context 'with a non-empty method definition' do
+    context 'with a non-empty instance method definition' do
       it_behaves_like 'code without offense',
                       ['def foo',
                        '  bar',
@@ -114,6 +150,37 @@ describe RuboCop::Cop::Style::EmptyMethod, :config do
 
       it_behaves_like 'code without offense',
                       ['def foo',
+                       '  # bar',
+                       'end']
+    end
+
+    context 'with an empty class method definition' do
+      it_behaves_like 'code without offense',
+                      ['def self.foo',
+                       'end'].join("\n")
+
+      it_behaves_like 'code without offense',
+                      ['def self.foo',
+                       '',
+                       'end'].join("\n")
+
+      it_behaves_like 'code with offense',
+                      'def self.foo; end',
+                      ['def self.foo',
+                       'end'].join("\n")
+    end
+
+    context 'with a non-empty class method definition' do
+      it_behaves_like 'code without offense',
+                      ['def self.foo',
+                       '  bar',
+                       'end']
+
+      it_behaves_like 'code without offense',
+                      'def self.foo; bar; end'
+
+      it_behaves_like 'code without offense',
+                      ['def self.foo',
                        '  # bar',
                        'end']
     end


### PR DESCRIPTION
This cop would not inspect class methods, which was an oversight in the initial implementation. This change adds class methods to the inspected nodes.

-----------------

Before submitting the PR make sure the following are checked:

* [X] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [X] Used the same coding conventions as the rest of the project.
* [X] Feature branch is up-to-date with `master` (if not - rebase it).
* [X] Squashed related commits together.
* [X] Added tests.
* [X] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [X] All tests are passing.
* [X] The new code doesn't generate RuboCop offenses.
* [X] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [X] Updated cop documentation with `rake generate_cops_documentation` (required only when you've added a new cop or changed the configuration/documentation of an existing cop).

[1]: http://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html
