### PR TITLE
Remove the usage of &method

### DIFF
--- a/lib/rubocop/cop/style/empty_line_between_defs.rb
+++ b/lib/rubocop/cop/style/empty_line_between_defs.rb
@@ -14,9 +14,9 @@ module RuboCop
         # doing a linear scan over siblings, so we don't want to call
         # it on each def.
         def on_begin(node)
-          node.children.each_cons(2) do |prev, n|
-            nodes = [prev, n]
-            check_defs(nodes) if nodes.all?(&method(:def_node?))
+          node.children.each_cons(2) do |prev, child|
+            nodes = [prev, child]
+            check_defs(nodes) if nodes.all? { |n| def_node?(n) }
           end
         end
 


### PR DESCRIPTION
`&method` is a weird syntax in Ruby. It is also slower than an equivalently written function. I was hoping to update `Style/SymbolProc` to recommend against this syntax. Unfortunately, it may take a bit more work than I was hoping for. If you would like, I can create an issue for a feature request to track this and allow anyone to pick it up.

http://stackoverflow.com/questions/6976629/is-the-methodmethod-name-idiom-bad-for-perfomance-in-ruby