### PR TITLE
Rewrite repeated, wrong, and redundant spec descriptions

### DIFF
--- a/spec/rubocop/cop/lint/empty_interpolation_spec.rb
+++ b/spec/rubocop/cop/lint/empty_interpolation_spec.rb
@@ -22,12 +22,12 @@ describe RuboCop::Cop::Lint::EmptyInterpolation do
     expect(cop.offenses).to be_empty
   end
 
-  it 'autocorrects' do
+  it 'autocorrects empty interpolation' do
     new_source = autocorrect_source(cop, '"this is the #{}"')
     expect(new_source).to eq('"this is the "')
   end
 
-  it 'autocorrects' do
+  it 'autocorrects empty interpolation containing a space' do
     new_source = autocorrect_source(cop, '"this is the #{ }"')
     expect(new_source).to eq('"this is the "')
   end

--- a/spec/rubocop/cop/lint/literal_in_condition_spec.rb
+++ b/spec/rubocop/cop/lint/literal_in_condition_spec.rb
@@ -129,7 +129,7 @@ describe RuboCop::Cop::Lint::LiteralInCondition do
     expect(cop.offenses).to be_empty
   end
 
-  it 'accepts array literal in case, if it has non-literal elements' do
+  it 'accepts array literal in case, if it has nested non-literal element' do
     inspect_source(cop,
                    ['case [1, 2, [x, 1]]',
                     'when [1, 2, 5] then top',

--- a/spec/rubocop/cop/lint/unneeded_splat_expansion_spec.rb
+++ b/spec/rubocop/cop/lint/unneeded_splat_expansion_spec.rb
@@ -213,25 +213,25 @@ describe RuboCop::Cop::Lint::UnneededSplatExpansion do
         expect(new_source).to eq('a = %W(one two three)')
       end
 
-      it 'convert an expanded string to an array' do
+      it 'converts an expanded string to an array' do
         new_source = autocorrect_source(cop, "a = *'a'")
 
         expect(new_source).to eq("a = ['a']")
       end
 
-      it 'convert an expanded string to an array' do
+      it 'converts an expanded string with interpolation to an array' do
         new_source = autocorrect_source(cop, 'a = *"#{a}"')
 
         expect(new_source).to eq('a = ["#{a}"]')
       end
 
-      it 'convert an expanded string to an array' do
+      it 'converts an expanded integer to an array' do
         new_source = autocorrect_source(cop, 'a = *1')
 
         expect(new_source).to eq('a = [1]')
       end
 
-      it 'convert an expanded string to an array' do
+      it 'converts an expanded float to an array' do
         new_source = autocorrect_source(cop, 'a = *1.1')
 
         expect(new_source).to eq('a = [1.1]')

--- a/spec/rubocop/cop/performance/detect_spec.rb
+++ b/spec/rubocop/cop/performance/detect_spec.rb
@@ -53,7 +53,7 @@ describe RuboCop::Cop::Performance::Detect do
       expect(cop.messages).to eq(["Use `detect` instead of `#{method}.first`."])
     end
 
-    it "registers an offense when first is called on multiline #{method}" do
+    it "registers an offense when last is called on multiline #{method}" do
       inspect_source(cop, ["[1, 2, 3].#{method} do |i|",
                            '  i % 2 == 0',
                            'end.last'])

--- a/spec/rubocop/cop/rails/delegate_spec.rb
+++ b/spec/rubocop/cop/rails/delegate_spec.rb
@@ -68,7 +68,7 @@ describe RuboCop::Cop::Rails::Delegate do
     expect(cop.offenses).to be_empty
   end
 
-  it 'ignores trivial delegate with mismatched arguments' do
+  it 'ignores trivial delegate with optional argument with a default value' do
     inspect_source(cop,
                    ['def fox(foo = nil)',
                     '  bar.fox(foo || 5)',
@@ -76,7 +76,7 @@ describe RuboCop::Cop::Rails::Delegate do
     expect(cop.offenses).to be_empty
   end
 
-  it 'ignores trivial delegate with mismatched arguments' do
+  it 'ignores trivial delegate with mismatched number of arguments' do
     inspect_source(cop,
                    ['def fox(a, baz)',
                     '  bar.fox(a)',

--- a/spec/rubocop/cop/rails/exit_spec.rb
+++ b/spec/rubocop/cop/rails/exit_spec.rb
@@ -24,7 +24,8 @@ describe RuboCop::Cop::Rails::Exit, :config do
       expect(cop.offenses).to be_empty
     end
 
-    it 'does not register an offense for an explicit exit call on an object' do
+    it 'does not register an offense for an explicit exit call '\
+      'with an argument on an object' do
       inspect_source(cop,
                      'Object.new.exit(0)')
       expect(cop.offenses).to be_empty

--- a/spec/rubocop/cop/rails/scope_args_spec.rb
+++ b/spec/rubocop/cop/rails/scope_args_spec.rb
@@ -35,7 +35,7 @@ describe RuboCop::Cop::Rails::ScopeArgs do
     expect(cop.offenses).to be_empty
   end
 
-  it 'accepts a lambda' do
+  it 'accepts a lambda with a block argument' do
     inspect_source(cop,
                    'scope :active, lambda { |active| where(active: active) }')
 

--- a/spec/rubocop/cop/style/conditional_assignment_assign_to_condition_spec.rb
+++ b/spec/rubocop/cop/style/conditional_assignment_assign_to_condition_spec.rb
@@ -576,7 +576,7 @@ describe RuboCop::Cop::Style::ConditionalAssignment do
     expect(cop.messages).to eq([described_class::MSG])
   end
 
-  it 'registers an offense for assignment in if elsif else' do
+  it 'registers an offense for assignment in if elsif elsif else' do
     source = ['if foo',
               '  bar = 1',
               'elsif baz',
@@ -841,7 +841,7 @@ describe RuboCop::Cop::Style::ConditionalAssignment do
       expect(cop.offenses).to be_empty
     end
 
-    it 'allows multiple assignment in if elsif else when the last ' \
+    it 'allows multiple assignment in case statements when the last ' \
        'assignment is the same and the earlier assignments do not appear in ' \
        'all branches' do
       source = ['case foo',
@@ -963,21 +963,6 @@ describe RuboCop::Cop::Style::ConditionalAssignment do
   it 'registers an offense for assignment in if then else' do
     source = ['if foo then bar = 1',
               'else bar = 2',
-              'end']
-    inspect_source(cop, source)
-
-    expect(cop.messages).to eq([described_class::MSG])
-  end
-
-  it 'registers an offense for assignment in if elsif else' do
-    source = ['if foo',
-              '  bar = 1',
-              'elsif foobar',
-              '  bar = 2',
-              'elsif baz',
-              '  bar = 3',
-              'else',
-              '  bar = 4',
               'end']
     inspect_source(cop, source)
 

--- a/spec/rubocop/cop/style/each_for_simple_loop_spec.rb
+++ b/spec/rubocop/cop/style/each_for_simple_loop_spec.rb
@@ -22,7 +22,7 @@ describe RuboCop::Cop::Style::EachForSimpleLoop do
     expect(cop.highlights).to eq(['(0...10).each'])
   end
 
-  it 'registers offense for inclusive end range' do
+  it 'registers offense for inclusive end range with do ... end syntax' do
     inspect_source(cop, ['(0...10).each do',
                          'end'])
     expect(cop.offenses.size).to eq 1
@@ -43,7 +43,7 @@ describe RuboCop::Cop::Style::EachForSimpleLoop do
     expect(cop.offenses).to be_empty
   end
 
-  it 'does not register offense if range startpoint is not constant' do
+  it 'does not register offense if range endpoint is not constant' do
     inspect_source(cop, '(0..b).each {}')
     expect(cop.offenses).to be_empty
   end

--- a/spec/rubocop/cop/style/empty_lines_around_class_body_spec.rb
+++ b/spec/rubocop/cop/style/empty_lines_around_class_body_spec.rb
@@ -120,7 +120,7 @@ describe RuboCop::Cop::Style::EmptyLinesAroundClassBody, :config do
       expect(corrected).to eq(source)
     end
 
-    it 'autocorrects beginning and end' do
+    it 'autocorrects beginning and end for `class << self`' do
       new_source = autocorrect_source(cop,
                                       ['class << self',
                                        '  do_something',

--- a/spec/rubocop/cop/style/multiline_method_call_indentation_spec.rb
+++ b/spec/rubocop/cop/style/multiline_method_call_indentation_spec.rb
@@ -376,7 +376,7 @@ describe RuboCop::Cop::Style::MultilineMethodCallIndentation do
       expect(cop.highlights).to eq(['.with'])
     end
 
-    it 'does not check binary operations' do
+    it 'does not check binary operations when string wrapped with backslash' do
       inspect_source(cop,
                      ["flash[:error] = 'Here is a string ' \\",
                       "                'That spans' <<",
@@ -384,7 +384,7 @@ describe RuboCop::Cop::Style::MultilineMethodCallIndentation do
       expect(cop.offenses).to be_empty
     end
 
-    it 'does not check binary operations' do
+    it 'does not check binary operations when string wrapped with +' do
       inspect_source(cop,
                      ["flash[:error] = 'Here is a string ' +",
                       "                'That spans' <<",

--- a/spec/rubocop/cop/style/parallel_assignment_spec.rb
+++ b/spec/rubocop/cop/style/parallel_assignment_spec.rb
@@ -299,7 +299,8 @@ describe RuboCop::Cop::Style::ParallelAssignment, :config do
                                 'end'].join("\n"))
     end
 
-    it 'corrects parallel assignment in rescue statements' do
+    it 'corrects parallel assignment inside rescue statements '\
+       'within method definitions' do
       new_source = autocorrect_source(cop, ['def bar',
                                             '  a, b = 1, 2',
                                             'rescue',
@@ -314,7 +315,8 @@ describe RuboCop::Cop::Style::ParallelAssignment, :config do
                                 'end'].join("\n"))
     end
 
-    it 'corrects parallel assignment in rescue statements' do
+    it 'corrects parallel assignment in rescue statements '\
+       'within begin ... rescue' do
       new_source = autocorrect_source(cop, ['begin',
                                             '  a, b = 1, 2',
                                             'rescue',

--- a/spec/rubocop/cop/style/redundant_begin_spec.rb
+++ b/spec/rubocop/cop/style/redundant_begin_spec.rb
@@ -61,7 +61,8 @@ describe RuboCop::Cop::Style::RedundantBegin do
     expect(cop.offenses).to be_empty
   end
 
-  it 'auto-corrects by removing redundant begin blocks' do
+  it 'auto-corrects source separated by newlines ' \
+     'by removing redundant begin blocks' do
     src = ['  def func',
            '    begin',
            '      foo',
@@ -82,7 +83,8 @@ describe RuboCop::Cop::Style::RedundantBegin do
     expect(new_source).to eq(result_src)
   end
 
-  it 'auto-corrects by removing redundant begin blocks' do
+  it 'auto-corrects source separated by semicolons ' \
+     'by removing redundant begin blocks' do
     src = '  def func; begin; x; y; rescue; z end end'
     result_src = '  def func; ; x; y; rescue; z  end'
     new_source = autocorrect_source(cop, src)

--- a/spec/rubocop/cop/style/redundant_self_spec.rb
+++ b/spec/rubocop/cop/style/redundant_self_spec.rb
@@ -105,7 +105,7 @@ describe RuboCop::Cop::Style::RedundantSelf do
       expect(cop.offenses).to be_empty
     end
 
-    it 'accepts a self receiver used to distinguish from argument' do
+    it 'accepts a self receiver used to distinguish from optional argument' do
       src = ['def requested_specs(final = true)',
              '  something if self.final != final',
              'end']
@@ -133,7 +133,8 @@ describe RuboCop::Cop::Style::RedundantSelf do
       expect(cop.offenses).to be_empty
     end
 
-    it 'accepts a self receiver used to distinguish from an argument' do
+    it 'accepts a self receiver used to distinguish from an argument' \
+      ' when an inner method is defined' do
       src = ['def foo(bar)',
              '  def inner_method(); end',
              '  puts bar, self.bar',
@@ -160,7 +161,7 @@ describe RuboCop::Cop::Style::RedundantSelf do
       expect(cop.offenses).to be_empty
     end
 
-    it 'accepts a self receiver used to distinguish from argument' do
+    it 'accepts a self receiver used to distinguish from optional argument' do
       src = ['def self.requested_specs(final = true)',
              '  something if self.final != final',
              'end']

--- a/spec/rubocop/cop/style/safe_navigation_spec.rb
+++ b/spec/rubocop/cop/style/safe_navigation_spec.rb
@@ -315,15 +315,6 @@ describe RuboCop::Cop::Style::SafeNavigation, :config do
 
             expect(cop.messages).to eq([described_class::MSG])
           end
-
-          it 'registers an offense for a check for the object followed by a ' \
-            'method call in the condition for an if expression' do
-            inspect_source(cop, ["if #{variable} && #{variable}.bar",
-                                 '  something',
-                                 'end'])
-
-            expect(cop.messages).to eq([described_class::MSG])
-          end
         end
 
         context 'ConvertCodeThatCanStartToReturnNil false' do
@@ -385,15 +376,6 @@ describe RuboCop::Cop::Style::SafeNavigation, :config do
             source = "#{variable} && #{variable}.bar(baz) { |e| e.qux }"
 
             inspect_source(cop, source)
-
-            expect(cop.offenses).to be_empty
-          end
-
-          it 'registers an offense for a check for the object followed by a ' \
-            'method call in the condition for an if expression' do
-            inspect_source(cop, ["if #{variable} && #{variable}.bar",
-                                 '  something',
-                                 'end'])
 
             expect(cop.offenses).to be_empty
           end

--- a/spec/rubocop/cop/style/space_around_block_parameters_spec.rb
+++ b/spec/rubocop/cop/style/space_around_block_parameters_spec.rb
@@ -133,7 +133,7 @@ describe RuboCop::Cop::Style::SpaceAroundBlockParameters, :config do
       expect(cop.highlights).to eq([' '])
     end
 
-    it 'registers an offense for no space after last parameter' do
+    it 'registers an offense for multiple spaces after last parameter' do
       inspect_source(cop, '{}.each { | x, y   | puts x }')
       expect(cop.messages)
         .to eq(['Extra space after last block parameter detected.'])

--- a/spec/rubocop/cop/style/space_around_equals_in_parameter_default_spec.rb
+++ b/spec/rubocop/cop/style/space_around_equals_in_parameter_default_spec.rb
@@ -41,13 +41,13 @@ describe RuboCop::Cop::Style::SpaceAroundEqualsInParameterDefault, :config do
       expect(new_source).to eq(['def f(x, y = 0, z = 1)', 'end'].join("\n"))
     end
 
-    it 'accepts default value assignment with space' do
+    it 'accepts default value assignment with spaces and unary + operator' do
       inspect_source(cop, ['def f(x, y = +1, z = {})',
                            'end'])
       expect(cop.messages).to be_empty
     end
 
-    it 'auto-corrects missing space' do
+    it 'auto-corrects missing space for arguments with unary operators' do
       new_source = autocorrect_source(cop, ['def f(x=-1, y= 0, z =+1)', 'end'])
       expect(new_source).to eq(['def f(x = -1, y = 0, z = +1)',
                                 'end'].join("\n"))

--- a/spec/rubocop/cop/style/struct_inheritance_spec.rb
+++ b/spec/rubocop/cop/style/struct_inheritance_spec.rb
@@ -12,7 +12,7 @@ describe RuboCop::Cop::Style::StructInheritance do
     expect(cop.offenses.size).to eq(1)
   end
 
-  it 'registers an offense when extending instance of Struct' do
+  it 'registers an offense when extending instance of Struct with do ... end' do
     inspect_source(cop,
                    ['class Person < Struct.new(:first_name, :last_name) do end',
                     'end'])

--- a/spec/rubocop/cop/style/trailing_underscore_variable_spec.rb
+++ b/spec/rubocop/cop/style/trailing_underscore_variable_spec.rb
@@ -148,7 +148,7 @@ describe RuboCop::Cop::Style::TrailingUnderscoreVariable do
         expect(new_source).to eq('a, = foo()')
       end
 
-      it 'removes multiple trailing underscores and commas' do
+      it 'removes trailing underscores and commas and preserves assignments' do
         new_source = autocorrect_source(cop, 'a, _, _, = foo()')
 
         expect(new_source).to eq('a, = foo()')
@@ -160,7 +160,7 @@ describe RuboCop::Cop::Style::TrailingUnderscoreVariable do
         expect(new_source).to eq('foo()')
       end
 
-      it 'removes multiple trailing underscores and commas' do
+      it 'removes all assignments when every assignment is to `_`' do
         new_source = autocorrect_source(cop, '_, _, _, = foo()')
 
         expect(new_source).to eq('foo()')

--- a/spec/rubocop/options_spec.rb
+++ b/spec/rubocop/options_spec.rb
@@ -129,25 +129,25 @@ Usage: rubocop [options] [file1, file2, ...]
     end
 
     describe 'incompatible cli options' do
-      it 'fails with argument correct error' do
+      it 'rejects using -v with -V' do
         msg = 'Incompatible cli options: [:version, :verbose_version]'
         expect { options.parse %w(-vV) }
           .to raise_error(ArgumentError, msg)
       end
 
-      it 'fails with argument correct error' do
+      it 'rejects using -v with --show-cops' do
         msg = 'Incompatible cli options: [:version, :show_cops]'
         expect { options.parse %w(-v --show-cops) }
           .to raise_error(ArgumentError, msg)
       end
 
-      it 'fails with argument correct error' do
+      it 'rejects using -V with --show-cops' do
         msg = 'Incompatible cli options: [:verbose_version, :show_cops]'
         expect { options.parse %w(-V --show-cops) }
           .to raise_error(ArgumentError, msg)
       end
 
-      it 'fails with argument correct error' do
+      it 'mentions all incompatible options when more than two are used' do
         msg = ['Incompatible cli options: [:version, :verbose_version,',
                ' :show_cops]'].join
         expect { options.parse %w(-vV --show-cops) }

--- a/spec/rubocop/target_finder_spec.rb
+++ b/spec/rubocop/target_finder_spec.rb
@@ -173,10 +173,6 @@ describe RuboCop::TargetFinder, :isolated_environment do
       expect(found_basenames).not_to include('file')
     end
 
-    it 'picks ruby executable files with no extension' do
-      expect(found_basenames).to include('executable')
-    end
-
     it 'does not pick directories' do
       found_basenames = found_files.map { |f| File.basename(f) }
       expect(found_basenames).not_to include('dir1')


### PR DESCRIPTION
I found these offending spec descriptions while testing out backus/rubocop-rspec#259. Searching for duplicate spec descriptions revealed a few categories of issues:

1. Examples with repeated descriptions that tested different cases but didn't describe the specific difference. For example:

    ```ruby
    it 'autocorrects' do
      new_source = autocorrect_source(cop, '"this is the #{}"')
      expect(new_source).to eq('"this is the "')
    end

    it 'autocorrects' do
      new_source = autocorrect_source(cop, '"this is the #{ }"')
      expect(new_source).to eq('"this is the "')
    end
    ```

2. Examples with repeated descriptions where one or more descriptions were wrong. For example:

    ```ruby
    it 'does not register offense if range startpoint is not constant' do
      inspect_source(cop, '(a..10).each {}')
      expect(cop.offenses).to be_empty
    end

    it 'does not register offense if range startpoint is not constant' do
      inspect_source(cop, '(0..b).each {}')
      expect(cop.offenses).to be_empty
    end
    ```

3. Redundant examples where the spec and its corresponding description showed up twice in the same context. For example:

    ```ruby
    it 'picks ruby executable files with no extension' do
      expect(found_basenames).to include('executable')
    end

    # ...

    it 'picks ruby executable files with no extension' do
      expect(found_basenames).to include('executable')
    end
    ```

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Used the same coding conventions as the rest of the project.
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] All tests are passing.
* [x] The new code doesn't generate RuboCop offenses.
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Updated cop documentation with `rake generate_cops_documentation` (required only when you've added a new cop or changed the configuration/documentation of an existing cop).

[1]: http://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html
