### PR TITLE
Fix typo in EmptyMethod cop documentation

### DIFF
--- a/lib/rubocop/cop/style/empty_method.rb
+++ b/lib/rubocop/cop/style/empty_method.rb
@@ -5,7 +5,7 @@ module RuboCop
     module Style
       # This cop checks for the formatting of empty method definitions.
       # By default it enforces empty method definitions to go on a single
-      # line (compact style), but it cah be configured to enforce the `end`
+      # line (compact style), but it can be configured to enforce the `end`
       # to go on its own line (expanded style.)
       #
       # Note: A method definition is not considered empty if it contains

--- a/manual/cops_performance.md
+++ b/manual/cops_performance.md
@@ -483,9 +483,10 @@ Enabled by default | Supports autocorrection
 --- | ---
 Enabled | Yes
 
-In Ruby 2.4, `String#match?` and `Regexp#match?` have been added.
-The methods are faster than `match`. Because the methods avoid
-creating a `MatchData` object or saving backref.
+In Ruby 2.4, `String#match?`, `Regexp#match?` and `Symbol#match?`
+have been added. The methods are faster than `match`.
+Because the methods avoid creating a `MatchData` object or saving
+backref.
 So, when `MatchData` is not used, use `match?` instead of `match`.
 
 ### Example

--- a/manual/cops_rails.md
+++ b/manual/cops_rails.md
@@ -227,7 +227,7 @@ Exclude | lib/\*\*/\*.rake
 
 Enabled by default | Supports autocorrection
 --- | ---
-Disabled | Yes
+Disabled | No
 
 This cop is used to identify usages of file path joining process
 to use `Rails.root.join` clause.
@@ -243,7 +243,6 @@ File.join(Rails.root, 'app/models/goober')
 # good
 Rails.root.join('app', 'models', 'goober')
 ```
-
 
 ## Rails/FindBy
 
@@ -488,43 +487,48 @@ Enabled by default | Supports autocorrection
 --- | ---
 Disabled | Yes
 
-This cop converts usages of `try!` to `&.`. It can also be configured
-to convert `try`. It will convert code to use safe navigation if the
-target Ruby version is set to 2.3+
+This cop transforms usages of a method call safeguarded by a non `nil`
+check for the variable whose method is being called to
+safe navigation (`&.`).
+
+Configuration option: ConvertCodeThatCanStartToReturnNil
+The default for this is `false`. When configured to `true`, this will
+check for code in the format `!foo.nil? && foo.bar`. As it is written,
+the return of this code is limited to `false` and whatever the return
+of the method is. If this is converted to safe navigation,
+`foo&.bar` can start returning `nil` as well as what the method
+returns.
 
 ### Example
 
 ```ruby
-# ConvertTry: false
-  # bad
-  foo.try!(:bar)
-  foo.try!(:bar, baz)
-  foo.try!(:bar) { |e| e.baz }
+# bad
+foo.bar if foo
+foo.bar(param1, param2) if foo
+foo.bar { |e| e.something } if foo
+foo.bar(param) { |e| e.something } if foo
 
-  foo.try!(:[], 0)
+foo.bar if !foo.nil?
+foo.bar unless !foo
+foo.bar unless foo.nil?
 
-  # good
-  foo.try(:bar)
-  foo.try(:bar, baz)
-  foo.try(:bar) { |e| e.baz }
+foo && foo.bar
+foo && foo.bar(param1, param2)
+foo && foo.bar { |e| e.something }
+foo && foo.bar(param) { |e| e.something }
 
-  foo&.bar
-  foo&.bar(baz)
-  foo&.bar { |e| e.baz }
+# good
+foo&.bar
+foo&.bar(param1, param2)
+foo&.bar { |e| e.something }
+foo&.bar(param) { |e| e.something }
 
-# ConvertTry: true
-  # bad
-  foo.try!(:bar)
-  foo.try!(:bar, baz)
-  foo.try!(:bar) { |e| e.baz }
-  foo.try(:bar)
-  foo.try(:bar, baz)
-  foo.try(:bar) { |e| e.baz }
+foo.nil? || foo.bar
+!foo || foo.bar
 
-  # good
-  foo&.bar
-  foo&.bar(baz)
-  foo&.bar { |e| e.baz }
+# Methods that `nil` will `respond_to?` should not be converted to
+# use safe navigation
+foo.to_i if foo
 ```
 
 ### Important attributes
@@ -706,3 +710,4 @@ This cop checks for the use of old-style attribute validation macros.
 Attribute | Value
 --- | ---
 Include | app/models/\*\*/\*.rb
+

--- a/manual/cops_style.md
+++ b/manual/cops_style.md
@@ -3781,43 +3781,48 @@ Enabled by default | Supports autocorrection
 --- | ---
 Enabled | Yes
 
-This cop converts usages of `try!` to `&.`. It can also be configured
-to convert `try`. It will convert code to use safe navigation if the
-target Ruby version is set to 2.3+
+This cop transforms usages of a method call safeguarded by a non `nil`
+check for the variable whose method is being called to
+safe navigation (`&.`).
+
+Configuration option: ConvertCodeThatCanStartToReturnNil
+The default for this is `false`. When configured to `true`, this will
+check for code in the format `!foo.nil? && foo.bar`. As it is written,
+the return of this code is limited to `false` and whatever the return
+of the method is. If this is converted to safe navigation,
+`foo&.bar` can start returning `nil` as well as what the method
+returns.
 
 ### Example
 
 ```ruby
-# ConvertTry: false
-  # bad
-  foo.try!(:bar)
-  foo.try!(:bar, baz)
-  foo.try!(:bar) { |e| e.baz }
+# bad
+foo.bar if foo
+foo.bar(param1, param2) if foo
+foo.bar { |e| e.something } if foo
+foo.bar(param) { |e| e.something } if foo
 
-  foo.try!(:[], 0)
+foo.bar if !foo.nil?
+foo.bar unless !foo
+foo.bar unless foo.nil?
 
-  # good
-  foo.try(:bar)
-  foo.try(:bar, baz)
-  foo.try(:bar) { |e| e.baz }
+foo && foo.bar
+foo && foo.bar(param1, param2)
+foo && foo.bar { |e| e.something }
+foo && foo.bar(param) { |e| e.something }
 
-  foo&.bar
-  foo&.bar(baz)
-  foo&.bar { |e| e.baz }
+# good
+foo&.bar
+foo&.bar(param1, param2)
+foo&.bar { |e| e.something }
+foo&.bar(param) { |e| e.something }
 
-# ConvertTry: true
-  # bad
-  foo.try!(:bar)
-  foo.try!(:bar, baz)
-  foo.try!(:bar) { |e| e.baz }
-  foo.try(:bar)
-  foo.try(:bar, baz)
-  foo.try(:bar) { |e| e.baz }
+foo.nil? || foo.bar
+!foo || foo.bar
 
-  # good
-  foo&.bar
-  foo&.bar(baz)
-  foo&.bar { |e| e.baz }
+# Methods that `nil` will `respond_to?` should not be converted to
+# use safe navigation
+foo.to_i if foo
 ```
 
 ### Important attributes

--- a/manual/cops_style.md
+++ b/manual/cops_style.md
@@ -1203,7 +1203,7 @@ Enabled | Yes
 
 This cop checks for the formatting of empty method definitions.
 By default it enforces empty method definitions to go on a single
-line (compact style), but it cah be configured to enforce the `end`
+line (compact style), but it can be configured to enforce the `end`
 to go on its own line (expanded style.)
 
 Note: A method definition is not considered empty if it contains


### PR DESCRIPTION
Wery trivial fix for typo in EmptyMethod cop: `cah` -> `can`
