### PR TITLE
Fix incorrect spec descriptions

### DIFF
--- a/spec/rubocop/cop/rails/time_zone_spec.rb
+++ b/spec/rubocop/cop/rails/time_zone_spec.rb
@@ -224,13 +224,13 @@ describe RuboCop::Cop::Rails::TimeZone, :config do
         end
       end
 
-      it 'accepts #{klass}.zone.now' do
+      it "accepts #{klass}.zone.now" do
         inspect_source(cop, "#{klass}.zone.now")
         expect(cop.offenses).to be_empty
       end
 
-      it 'accepts #{klass}.zone_default.now' do
-        inspect_source(cop, "#{klass}.zone.now")
+      it "accepts #{klass}.zone_default.now" do
+        inspect_source(cop, "#{klass}.zone_default.now")
         expect(cop.offenses).to be_empty
       end
 

--- a/spec/rubocop/cop/style/redundant_return_spec.rb
+++ b/spec/rubocop/cop/style/redundant_return_spec.rb
@@ -33,7 +33,7 @@ describe RuboCop::Cop::Style::RedundantReturn, :config do
   end
 
   it 'reports an offense for defs ending with return' do
-    src = ['def func',
+    src = ['def self.func',
            '  one',
            '  two',
            '  return something',
@@ -142,7 +142,7 @@ describe RuboCop::Cop::Style::RedundantReturn, :config do
     end
 
     it 'reports an offense for defs ending with return' do
-      src = ['def func',
+      src = ['def self.func',
              '  one',
              '  two',
              '  return something, test',
@@ -215,7 +215,7 @@ describe RuboCop::Cop::Style::RedundantReturn, :config do
     end
 
     it 'accepts defs ending with return' do
-      src = ['def func',
+      src = ['def self.func',
              '  one',
              '  two',
              '  return something, test',

--- a/spec/rubocop/cop/style/space_inside_block_braces_spec.rb
+++ b/spec/rubocop/cop/style/space_inside_block_braces_spec.rb
@@ -292,7 +292,7 @@ describe RuboCop::Cop::Style::SpaceInsideBlockBraces, :config do
     end
 
     it 'accepts left brace without outer space' do
-      inspect_source(cop, 'each {puts}')
+      inspect_source(cop, 'each{puts}')
       expect(cop.offenses).to be_empty
     end
 


### PR DESCRIPTION
While working on a cop for detecting repeated example bodies
I found a handful of duplicates examples which were either
mislabeled or seem to be unintentionally testing the wrong thing.

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Used the same coding conventions as the rest of the project.
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [ ] All tests are passing.
* [ ] The new code doesn't generate RuboCop offenses.
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Updated cop documentation with `rake generate_cops_documentation` (required only when you've added a new cop or changed the configuration/documentation of an existing cop).

[1]: http://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html
