### PR TITLE
Update the `Performance/RegexpMatch` cop

### DIFF
--- a/config/enabled.yml
+++ b/config/enabled.yml
@@ -1409,7 +1409,7 @@ Performance/RedundantSortBy:
   Enabled: true
 
 Performance/RegexpMatch:
-  Description: 'Use `match?` instead of `Regexp#match`, `String#match`, `Symbol#match` or `=~` when `MatchData` is not used.'
+  Description: 'Use `match?` instead of `Regexp#match`, `String#match`, `Symbol#match`, `Regexp#===` or `=~` when `MatchData` is not used.'
   Enabled: true
 
 Performance/ReverseEach:

--- a/manual/cops_performance.md
+++ b/manual/cops_performance.md
@@ -506,6 +506,13 @@ def foo
   end
 end
 
+# bad
+def foo
+  if /re/ === x
+    do_something
+  end
+end
+
 # good
 def foo
   if x.match?(/re/)
@@ -523,6 +530,13 @@ end
 # good
 def foo
   if x.match(/re/)
+    do_something($~)
+  end
+end
+
+# good
+def foo
+  if /re/ === x
     do_something($~)
   end
 end

--- a/spec/rubocop/cop/performance/regexp_match_spec.rb
+++ b/spec/rubocop/cop/performance/regexp_match_spec.rb
@@ -242,7 +242,9 @@ describe RuboCop::Cop::Performance::RegexpMatch, :config do
       ['matching by =~`', '/re/ =~ foo', '/re/.match?(foo)'],
       ['matching by =~`', 'foo =~ /re/', 'foo.match?(/re/)'],
       ['matching by =~`', '"foo" =~ re', '"foo".match?(re)'],
-      ['matching by =~`', ':foo =~ re', ':foo.match?(re)']
+      ['matching by =~`', ':foo =~ re', ':foo.match?(re)'],
+      ['matching by ===`', '/re/ === foo', '/re/.match?(foo)'],
+      ['matching by ===`', '/re/i === foo', '/re/i.match?(foo)']
     ].each do |name, code, correction|
       include_examples :all_legacy_match_methods, name, code, correction
     end


### PR DESCRIPTION
Follow up to https://github.com/bbatsov/rubocop/pull/3824.

Cc: @pocke

Thanks.

<details>
<summary>Benchmark</summary>
`Regexp#===` is also slower than `Regexp#match?`.

```sh
% ruby -v
ruby 2.4.0p0 (2016-12-24 revision 57164) [x86_64-darwin13]
% cat regexp_match.rb
require 'benchmark'

strings = 100000.times.map { "foo" }

Benchmark.bm(10) do |b|
  b.report("/regexp/.match(str)")  { strings.each { |s| /foo/.match(s) } }
  b.report("/regexp/ ~= str")      { strings.each { |s| /foo/ =~ s } }
  b.report("/regexp/ === str")     { strings.each { |s| /foo/ === s } }
  b.report("/regexp/.match?(str)") { strings.each { |s| /foo/.match?(s) } }
end

% ruby regexp_match.rb
                 user     system      total        real
/regexp/.match(str)  0.090000   0.000000   0.090000 (  0.091732)
/regexp/ ~= str  0.040000   0.010000   0.050000 (  0.036997)
/regexp/ === str  0.030000   0.000000   0.030000 (  0.030229)
/regexp/.match?(str)  0.010000   0.000000   0.010000 (  0.015933)
```
</details>
