### PR TITLE
CI against Ruby 2.4.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,7 @@ matrix:
      - rvm: 2.1.10
      - rvm: 2.2.6
      - rvm: 2.3.3
+     - rvm: 2.4.0
      - rvm: ruby-head
      - rvm: rbx-3
   allow_failures:


### PR DESCRIPTION
[Ruby 2.4.0 has been released](https://www.ruby-lang.org/en/news/2016/12/25/ruby-2-4-0-released). Then this Ruby version is available on Travis CI.

http://rubies.travis-ci.org