### PR TITLE
`Rails/HttpPositionalArguments` fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,7 @@
 * [#3788](https://github.com/bbatsov/rubocop/pull/3788): Prevent bad auto-correct in `Style/Next` when block has nested conditionals. ([@drenmi][])
 * [#3807](https://github.com/bbatsov/rubocop/pull/3807): Prevent `Style/Documentation` and `Style/DocumentationMethod` from mistaking RuboCop directives for class documentation. ([@drenmi][])
 * [#3815](https://github.com/bbatsov/rubocop/pull/3815): Fix false positive in `Style/IdenticalConditionalBranches` cop when branches have same line at leading. ([@pocke][])
+* Fix false negative in `Rails/HttpPositionalArguments` where offense would go undetected if one of the request parameter names matched one of the special keyword arguments. ([@deivid-rodriguez][])
 
 ## 0.46.0 (2016-11-30)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,7 @@
 * [#3807](https://github.com/bbatsov/rubocop/pull/3807): Prevent `Style/Documentation` and `Style/DocumentationMethod` from mistaking RuboCop directives for class documentation. ([@drenmi][])
 * [#3815](https://github.com/bbatsov/rubocop/pull/3815): Fix false positive in `Style/IdenticalConditionalBranches` cop when branches have same line at leading. ([@pocke][])
 * Fix false negative in `Rails/HttpPositionalArguments` where offense would go undetected if one of the request parameter names matched one of the special keyword arguments. ([@deivid-rodriguez][])
+* Fix false negative in `Rails/HttpPositionalArguments` where offense would go undetected if the `:format` keyword was used with other non-special keywords. ([@deivid-rodriguez][])
 
 ## 0.46.0 (2016-11-30)
 

--- a/lib/rubocop/cop/rails/http_positional_arguments.rb
+++ b/lib/rubocop/cop/rails/http_positional_arguments.rb
@@ -3,9 +3,9 @@
 module RuboCop
   module Cop
     module Rails
-      # This cop is used to identify usages of http methods
-      # like `get`, `post`, `put`, `path` without the usage of keyword arguments
-      # in your tests and change them to use keyword arguments.
+      # This cop is used to identify usages of http methods like `get`, `post`,
+      # `put`, `path` without the usage of keyword arguments in your tests and
+      # change them to use keyword arguments.
       #
       # @example
       #   # bad
@@ -17,8 +17,8 @@ module RuboCop
         MSG = 'Use keyword arguments instead of ' \
               'positional arguments for http call: `%s`.'.freeze
         KEYWORD_ARGS = [
-          :headers, :env, :params, :body, :flash, :as,
-          :xhr, :session, :method, :format
+          :headers, :env, :params, :body, :flash, :as, :xhr, :session, :method,
+          :format
         ].freeze
         HTTP_METHODS = [:get, :post, :put, :patch, :delete, :head].freeze
 

--- a/lib/rubocop/cop/rails/http_positional_arguments.rb
+++ b/lib/rubocop/cop/rails/http_positional_arguments.rb
@@ -4,7 +4,7 @@ module RuboCop
   module Cop
     module Rails
       # This cop is used to identify usages of http methods like `get`, `post`,
-      # `put`, `path` without the usage of keyword arguments in your tests and
+      # `put`, `patch` without the usage of keyword arguments in your tests and
       # change them to use keyword arguments.
       #
       # @example

--- a/lib/rubocop/cop/rails/http_positional_arguments.rb
+++ b/lib/rubocop/cop/rails/http_positional_arguments.rb
@@ -42,13 +42,14 @@ module RuboCop
 
         # @return [Boolean] true if the line needs to be converted
         def needs_conversion?(data)
-          # if the line has already been converted to use keyword args
-          # then skip
-          # ie. get :new, params: { user_id: 1 }  (looking for keyword arg)
           value = data.descendants.find do |d|
-            KEYWORD_ARGS.include?(d.children.first) if d.type == :sym
+            special_keyword_arg?(d)
           end
           value.nil?
+        end
+
+        def special_keyword_arg?(node)
+          KEYWORD_ARGS.include?(node.children.first) if node.type == :sym
         end
 
         def convert_hash_data(data, type)

--- a/lib/rubocop/cop/rails/http_positional_arguments.rb
+++ b/lib/rubocop/cop/rails/http_positional_arguments.rb
@@ -17,8 +17,7 @@ module RuboCop
         MSG = 'Use keyword arguments instead of ' \
               'positional arguments for http call: `%s`.'.freeze
         KEYWORD_ARGS = [
-          :headers, :env, :params, :body, :flash, :as, :xhr, :session, :method,
-          :format
+          :headers, :env, :params, :body, :flash, :as, :xhr, :session, :method
         ].freeze
         HTTP_METHODS = [:get, :post, :put, :patch, :delete, :head].freeze
 
@@ -42,14 +41,22 @@ module RuboCop
 
         # @return [Boolean] true if the line needs to be converted
         def needs_conversion?(data)
-          value = data.child_nodes.find do |d|
-            special_keyword_arg?(d.children.first)
+          children = data.child_nodes
+
+          value = children.find do |d|
+            special_keyword_arg?(d.children.first) ||
+              (format_arg?(d.children.first) && children.size == 1)
           end
+
           value.nil?
         end
 
         def special_keyword_arg?(node)
           KEYWORD_ARGS.include?(node.children.first) if node.type == :sym
+        end
+
+        def format_arg?(node)
+          node.children.first == :format if node.type == :sym
         end
 
         def convert_hash_data(data, type)

--- a/lib/rubocop/cop/rails/http_positional_arguments.rb
+++ b/lib/rubocop/cop/rails/http_positional_arguments.rb
@@ -42,8 +42,8 @@ module RuboCop
 
         # @return [Boolean] true if the line needs to be converted
         def needs_conversion?(data)
-          value = data.descendants.find do |d|
-            special_keyword_arg?(d)
+          value = data.child_nodes.find do |d|
+            special_keyword_arg?(d.children.first)
           end
           value.nil?
         end

--- a/manual/cops_rails.md
+++ b/manual/cops_rails.md
@@ -318,9 +318,9 @@ Enabled by default | Supports autocorrection
 --- | ---
 Disabled | Yes
 
-This cop is used to identify usages of http methods
-like `get`, `post`, `put`, `path` without the usage of keyword arguments
-in your tests and change them to use keyword arguments.
+This cop is used to identify usages of http methods like `get`, `post`,
+`put`, `patch` without the usage of keyword arguments in your tests and
+change them to use keyword arguments.
 
 ### Example
 
@@ -487,48 +487,43 @@ Enabled by default | Supports autocorrection
 --- | ---
 Disabled | Yes
 
-This cop transforms usages of a method call safeguarded by a non `nil`
-check for the variable whose method is being called to
-safe navigation (`&.`).
-
-Configuration option: ConvertCodeThatCanStartToReturnNil
-The default for this is `false`. When configured to `true`, this will
-check for code in the format `!foo.nil? && foo.bar`. As it is written,
-the return of this code is limited to `false` and whatever the return
-of the method is. If this is converted to safe navigation,
-`foo&.bar` can start returning `nil` as well as what the method
-returns.
+This cop converts usages of `try!` to `&.`. It can also be configured
+to convert `try`. It will convert code to use safe navigation if the
+target Ruby version is set to 2.3+
 
 ### Example
 
 ```ruby
-# bad
-foo.bar if foo
-foo.bar(param1, param2) if foo
-foo.bar { |e| e.something } if foo
-foo.bar(param) { |e| e.something } if foo
+# ConvertTry: false
+  # bad
+  foo.try!(:bar)
+  foo.try!(:bar, baz)
+  foo.try!(:bar) { |e| e.baz }
 
-foo.bar if !foo.nil?
-foo.bar unless !foo
-foo.bar unless foo.nil?
+  foo.try!(:[], 0)
 
-foo && foo.bar
-foo && foo.bar(param1, param2)
-foo && foo.bar { |e| e.something }
-foo && foo.bar(param) { |e| e.something }
+  # good
+  foo.try(:bar)
+  foo.try(:bar, baz)
+  foo.try(:bar) { |e| e.baz }
 
-# good
-foo&.bar
-foo&.bar(param1, param2)
-foo&.bar { |e| e.something }
-foo&.bar(param) { |e| e.something }
+  foo&.bar
+  foo&.bar(baz)
+  foo&.bar { |e| e.baz }
 
-foo.nil? || foo.bar
-!foo || foo.bar
+# ConvertTry: true
+  # bad
+  foo.try!(:bar)
+  foo.try!(:bar, baz)
+  foo.try!(:bar) { |e| e.baz }
+  foo.try(:bar)
+  foo.try(:bar, baz)
+  foo.try(:bar) { |e| e.baz }
 
-# Methods that `nil` will `respond_to?` should not be converted to
-# use safe navigation
-foo.to_i if foo
+  # good
+  foo&.bar
+  foo&.bar(baz)
+  foo&.bar { |e| e.baz }
 ```
 
 ### Important attributes

--- a/manual/cops_style.md
+++ b/manual/cops_style.md
@@ -3873,48 +3873,43 @@ Enabled by default | Supports autocorrection
 --- | ---
 Enabled | Yes
 
-This cop transforms usages of a method call safeguarded by a non `nil`
-check for the variable whose method is being called to
-safe navigation (`&.`).
-
-Configuration option: ConvertCodeThatCanStartToReturnNil
-The default for this is `false`. When configured to `true`, this will
-check for code in the format `!foo.nil? && foo.bar`. As it is written,
-the return of this code is limited to `false` and whatever the return
-of the method is. If this is converted to safe navigation,
-`foo&.bar` can start returning `nil` as well as what the method
-returns.
+This cop converts usages of `try!` to `&.`. It can also be configured
+to convert `try`. It will convert code to use safe navigation if the
+target Ruby version is set to 2.3+
 
 ### Example
 
 ```ruby
-# bad
-foo.bar if foo
-foo.bar(param1, param2) if foo
-foo.bar { |e| e.something } if foo
-foo.bar(param) { |e| e.something } if foo
+# ConvertTry: false
+  # bad
+  foo.try!(:bar)
+  foo.try!(:bar, baz)
+  foo.try!(:bar) { |e| e.baz }
 
-foo.bar if !foo.nil?
-foo.bar unless !foo
-foo.bar unless foo.nil?
+  foo.try!(:[], 0)
 
-foo && foo.bar
-foo && foo.bar(param1, param2)
-foo && foo.bar { |e| e.something }
-foo && foo.bar(param) { |e| e.something }
+  # good
+  foo.try(:bar)
+  foo.try(:bar, baz)
+  foo.try(:bar) { |e| e.baz }
 
-# good
-foo&.bar
-foo&.bar(param1, param2)
-foo&.bar { |e| e.something }
-foo&.bar(param) { |e| e.something }
+  foo&.bar
+  foo&.bar(baz)
+  foo&.bar { |e| e.baz }
 
-foo.nil? || foo.bar
-!foo || foo.bar
+# ConvertTry: true
+  # bad
+  foo.try!(:bar)
+  foo.try!(:bar, baz)
+  foo.try!(:bar) { |e| e.baz }
+  foo.try(:bar)
+  foo.try(:bar, baz)
+  foo.try(:bar) { |e| e.baz }
 
-# Methods that `nil` will `respond_to?` should not be converted to
-# use safe navigation
-foo.to_i if foo
+  # good
+  foo&.bar
+  foo&.bar(baz)
+  foo&.bar { |e| e.baz }
 ```
 
 ### Important attributes

--- a/spec/rubocop/cop/rails/http_positional_arguments_spec.rb
+++ b/spec/rubocop/cop/rails/http_positional_arguments_spec.rb
@@ -241,6 +241,15 @@ post :create, params: { id: @user.id, ac: {
     expect(new_source).to eq(output)
   end
 
+  it 'auto-corrects http action when format keyword included but not alone' do
+    source = 'post :create, id: 7, format: :rss'
+    inspect_source(cop, source)
+    expect(cop.offenses.size).to eq(1)
+    new_source = autocorrect_source(cop, source)
+    output = 'post :create, params: { id: 7, format: :rss }'
+    expect(new_source).to eq(output)
+  end
+
   it 'auto-corrects http action when params is a lvar' do
     source = [
       'params = { id: 1 }',

--- a/spec/rubocop/cop/rails/http_positional_arguments_spec.rb
+++ b/spec/rubocop/cop/rails/http_positional_arguments_spec.rb
@@ -223,7 +223,7 @@ post :create, params: { id: @user.id, ac: {
     expect(new_source).to eq(output)
   end
 
-  it 'does not register an offense for process method' do
+  it 'auto-corrects http action when params is a method call' do
     source = 'post :create, confirmation_data'
     inspect_source(cop, source)
     expect(cop.offenses.size).to eq(1)

--- a/spec/rubocop/cop/rails/http_positional_arguments_spec.rb
+++ b/spec/rubocop/cop/rails/http_positional_arguments_spec.rb
@@ -39,7 +39,7 @@ describe RuboCop::Cop::Rails::HttpPositionalArguments do
     'session: { foo: \'bar\' }',
     'format: :json'
   ].each do |keyword_args|
-    describe 'when using keyword args' do
+    describe "when using keyword args #{keyword_args}" do
       let(:source) do
         "get :new, #{keyword_args}"
       end

--- a/spec/rubocop/cop/rails/http_positional_arguments_spec.rb
+++ b/spec/rubocop/cop/rails/http_positional_arguments_spec.rb
@@ -232,6 +232,15 @@ post :create, params: { id: @user.id, ac: {
     expect(new_source).to eq(output)
   end
 
+  it 'auto-corrects http action when parameter matches special keyword name' do
+    source = 'post :create, id: 7, comment: { body: "hei" }'
+    inspect_source(cop, source)
+    expect(cop.offenses.size).to eq(1)
+    new_source = autocorrect_source(cop, source)
+    output = 'post :create, params: { id: 7, comment: { body: "hei" } }'
+    expect(new_source).to eq(output)
+  end
+
   it 'auto-corrects http action when params is a lvar' do
     source = [
       'params = { id: 1 }',


### PR DESCRIPTION
I used this cop today to upgrade a Rails application to Rails 5 and it proved to be very useful. However, two deprecation warnings went unnoticed. This PR should fix both of them.

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Used the same coding conventions as the rest of the project.
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] All tests are passing.
* [x] The new code doesn't generate RuboCop offenses.
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Updated cop documentation with `rake generate_cops_documentation` (required only when you've added a new cop or changed the configuration/documentation of an existing cop).

[1]: http://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html
