### PR TITLE
Replace `cop_type` with `department`

### DIFF
--- a/lib/rubocop/cli.rb
+++ b/lib/rubocop/cli.rb
@@ -111,21 +111,28 @@ module RuboCop
         puts "# Available cops (#{cops.length}) + config for #{Dir.pwd}: "
       end
 
-      cops.types.sort!.each { |type| print_cops_of_type(cops, type, show_all) }
+      cops.departments.sort!.each do |department|
+        print_cops_of_department(cops, department, show_all)
+      end
     end
 
-    def print_cops_of_type(cops, type, show_all)
+    def print_cops_of_department(cops, department, show_all)
       selected_cops = if show_all
-                        cops_of_type(cops, type)
+                        cops_of_department(cops, department)
                       else
-                        selected_cops_of_type(cops, type)
+                        selected_cops_of_department(cops, department)
                       end
 
       if show_all
-        puts "# Type '#{type.to_s.capitalize}' (#{selected_cops.size}):"
+        puts "# Department '#{department.to_s.capitalize}' " \
+             "(#{selected_cops.size}):"
       end
 
-      selected_cops.each do |cop|
+      print_cop_details(selected_cops)
+    end
+
+    def print_cop_details(cops)
+      cops.each do |cop|
         puts '# Supports --auto-correct' if cop.new.support_autocorrect?
         puts "#{cop.cop_name}:"
         puts config_lines(cop)
@@ -133,14 +140,14 @@ module RuboCop
       end
     end
 
-    def selected_cops_of_type(cops, type)
-      cops_of_type(cops, type).select do |cop|
+    def selected_cops_of_department(cops, department)
+      cops_of_department(cops, department).select do |cop|
         @options[:show_cops].include?(cop.cop_name)
       end
     end
 
-    def cops_of_type(cops, type)
-      cops.with_type(type).sort_by!(&:cop_name)
+    def cops_of_department(cops, department)
+      cops.with_department(department).sort_by!(&:cop_name)
     end
 
     def config_lines(cop)

--- a/lib/rubocop/config.rb
+++ b/lib/rubocop/config.rb
@@ -142,7 +142,7 @@ module RuboCop
     end
 
     def cop_enabled?(cop)
-      department = cop.cop_type.to_s.capitalize!
+      department = cop.department.to_s.capitalize!
 
       if (dept_config = self[department])
         return false if dept_config['Enabled'] == false

--- a/lib/rubocop/cop/cop.rb
+++ b/lib/rubocop/cop/cop.rb
@@ -8,25 +8,25 @@ module RuboCop
     # Store for all cops with helper functions
     class CopStore < ::Array
       # @return [Array<String>] list of types for current cops.
-      def types
-        @types ||= map(&:cop_type).uniq!
+      def departments
+        @departments ||= map(&:department).uniq!
       end
 
       # @return [Array<Cop>] Cops for that specific type.
-      def with_type(type)
-        CopStore.new(select { |c| c.cop_type == type })
+      def with_department(department)
+        CopStore.new(select { |c| c.department == department })
       end
 
       # @return [Array<Cop>] Cops not for a specific type.
-      def without_type(type)
-        CopStore.new(reject { |c| c.cop_type == type })
+      def without_department(department)
+        CopStore.new(reject { |c| c.department == department })
       end
 
       def qualified_cop_name(name, origin)
         return name if cop_names.include?(name)
 
         basename = File.basename(name)
-        found_ns = types.map(&:capitalize).select do |ns|
+        found_ns = departments.map(&:capitalize).select do |ns|
           cop_names.include?("#{ns}/#{basename}")
         end
 
@@ -88,7 +88,7 @@ module RuboCop
       @all = CopStore.new
 
       def self.all
-        @all.without_type(:test)
+        @all.without_department(:test)
       end
 
       def self.qualified_cop_name(name, origin)
@@ -96,7 +96,7 @@ module RuboCop
       end
 
       def self.non_rails
-        all.without_type(:rails)
+        all.without_department(:rails)
       end
 
       def self.inherited(subclass)
@@ -107,12 +107,12 @@ module RuboCop
         @cop_name ||= name.split('::').last(2).join('/')
       end
 
-      def self.cop_type
-        @cop_type ||= name.split('::')[-2].downcase.to_sym
+      def self.department
+        @department ||= name.split('::')[-2].downcase.to_sym
       end
 
       def self.lint?
-        cop_type == :lint
+        department == :lint
       end
 
       # Returns true if the cop name or the cop namespace matches any of the
@@ -121,7 +121,7 @@ module RuboCop
         return false unless given_names
 
         given_names.include?(cop_name) ||
-          given_names.include?(cop_type.to_s.capitalize)
+          given_names.include?(department.to_s.capitalize)
       end
 
       def initialize(config = nil, options = nil)

--- a/lib/rubocop/cop/offense.rb
+++ b/lib/rubocop/cop/offense.rb
@@ -44,7 +44,7 @@ module RuboCop
       # @!attribute [r] cop_name
       #
       # @return [String]
-      #   a cop class name without namespace.
+      #   a cop class name without department.
       #   i.e. type of the violation.
       #
       # @example

--- a/lib/rubocop/options.rb
+++ b/lib/rubocop/options.rb
@@ -179,10 +179,11 @@ module RuboCop
     def self.validate_cop_list(names)
       return unless names
 
-      namespaces = Cop::Cop.all.types.map { |t| t.to_s.capitalize }
+      departments = Cop::Cop.all.departments.map { |t| t.to_s.capitalize }
+
       names.each do |name|
         next if Cop::Cop.all.any? { |c| c.cop_name == name }
-        next if namespaces.include?(name)
+        next if departments.include?(name)
         next if %w(Syntax Lint/Syntax).include?(name)
 
         raise ArgumentError, "Unrecognized cop or namespace: #{name}."

--- a/manual/cops.md
+++ b/manual/cops.md
@@ -67,12 +67,12 @@ Bundler cops check for style or bad practices in Bundler files, e.g. `Gemfile`.
 In the following section you find all available cops:
 
 <!-- START_COP_LIST -->
-#### Type [Bundler](cops_bundler.md)
+#### Department [Bundler](cops_bundler.md)
 
 * [Bundler/DuplicatedGem](cops_bundler.md#bundlerduplicatedgem)
 * [Bundler/OrderedGems](cops_bundler.md#bundlerorderedgems)
 
-#### Type [Lint](cops_lint.md)
+#### Department [Lint](cops_lint.md)
 
 * [Lint/AmbiguousOperator](cops_lint.md#lintambiguousoperator)
 * [Lint/AmbiguousRegexpLiteral](cops_lint.md#lintambiguousregexpliteral)
@@ -133,7 +133,7 @@ In the following section you find all available cops:
 * [Lint/UselessSetterCall](cops_lint.md#lintuselesssettercall)
 * [Lint/Void](cops_lint.md#lintvoid)
 
-#### Type [Metrics](cops_metrics.md)
+#### Department [Metrics](cops_metrics.md)
 
 * [Metrics/AbcSize](cops_metrics.md#metricsabcsize)
 * [Metrics/BlockLength](cops_metrics.md#metricsblocklength)
@@ -146,7 +146,7 @@ In the following section you find all available cops:
 * [Metrics/ParameterLists](cops_metrics.md#metricsparameterlists)
 * [Metrics/PerceivedComplexity](cops_metrics.md#metricsperceivedcomplexity)
 
-#### Type [Performance](cops_performance.md)
+#### Department [Performance](cops_performance.md)
 
 * [Performance/CaseWhenSplat](cops_performance.md#performancecasewhensplat)
 * [Performance/Casecmp](cops_performance.md#performancecasecmp)
@@ -172,7 +172,7 @@ In the following section you find all available cops:
 * [Performance/StringReplacement](cops_performance.md#performancestringreplacement)
 * [Performance/TimesMap](cops_performance.md#performancetimesmap)
 
-#### Type [Rails](cops_rails.md)
+#### Department [Rails](cops_rails.md)
 
 * [Rails/ActionFilter](cops_rails.md#railsactionfilter)
 * [Rails/Date](cops_rails.md#railsdate)
@@ -199,14 +199,14 @@ In the following section you find all available cops:
 * [Rails/UniqBeforePluck](cops_rails.md#railsuniqbeforepluck)
 * [Rails/Validation](cops_rails.md#railsvalidation)
 
-#### Type [Security](cops_security.md)
+#### Department [Security](cops_security.md)
 
 * [Security/Eval](cops_security.md#securityeval)
 * [Security/JSONLoad](cops_security.md#securityjsonload)
 * [Security/MarshalLoad](cops_security.md#securitymarshalload)
 * [Security/YAMLLoad](cops_security.md#securityyamlload)
 
-#### Type [Style](cops_style.md)
+#### Department [Style](cops_style.md)
 
 * [Style/AccessModifierIndentation](cops_style.md#styleaccessmodifierindentation)
 * [Style/AccessorMethodName](cops_style.md#styleaccessormethodname)

--- a/spec/rubocop/cli/cli_options_spec.rb
+++ b/spec/rubocop/cli/cli_options_spec.rb
@@ -591,24 +591,28 @@ describe RuboCop::CLI, :isolated_environment do
         end
       end
 
-      it 'prints all types' do
-        cops.types
-            .each { |type| expect(stdout).to include(type.to_s.capitalize) }
+      it 'prints all departments' do
+        cops.departments.each do |department|
+          expect(stdout).to include(department.to_s.capitalize)
+        end
       end
 
-      it 'prints all cops in their right type listing' do
+      it 'prints all cops in their right department listing' do
         lines = stdout.lines
-        lines.slice_before(/Type /).each do |slice|
-          types = cops.types.map { |type| type.to_s.capitalize }
-          current = types.delete(slice.shift[/Type '(?<c>[^']+)'/, 'c'])
-          # all cops in their type listing
-          cops.with_type(current).each do |cop|
+        lines.slice_before(/Department /).each do |slice|
+          departments = cops.departments.map do |department|
+            department.to_s.capitalize
+          end
+          current =
+            departments.delete(slice.shift[/Department '(?<c>[^']+)'/, 'c'])
+          # all cops in their department listing
+          cops.with_department(current).each do |cop|
             expect(slice.any? { |l| l.include? cop.cop_name }).to be_truthy
           end
 
-          # no cop in wrong type listing
-          types.each do |type|
-            cops.with_type(type).each do |cop|
+          # no cop in wrong department listing
+          departments.each do |department|
+            cops.with_department(department).each do |cop|
               expect(slice.any? { |l| l.include? cop.cop_name }).to be_falsey
             end
           end

--- a/spec/rubocop/config_spec.rb
+++ b/spec/rubocop/config_spec.rb
@@ -427,7 +427,7 @@ describe RuboCop::Config do
   end
 
   describe '#cop_enabled?' do
-    context 'when an entire cop type is disabled' do
+    context 'when an entire cop department is disabled' do
       context 'but an individual cop is enabled' do
         let(:hash) do
           {
@@ -443,7 +443,7 @@ describe RuboCop::Config do
       end
     end
 
-    context 'when an entire cop type is enabled' do
+    context 'when an entire cop department is enabled' do
       context 'but an individual cop is disabled' do
         let(:hash) do
           {

--- a/spec/rubocop/cop/cop_spec.rb
+++ b/spec/rubocop/cop/cop_spec.rb
@@ -152,31 +152,31 @@ describe RuboCop::Cop::Cop do
   context 'with no submodule' do
     subject(:cop) { described_class }
     it('has right name') { expect(cop.cop_name).to eq('Cop/Cop') }
-    it('has right type') { expect(cop.cop_type).to eq(:cop) }
+    it('has right department') { expect(cop.department).to eq(:cop) }
   end
 
   context 'with style cops' do
     subject(:cop) { RuboCop::Cop::Style::For }
     it('has right name') { expect(cop.cop_name).to eq('Style/For') }
-    it('has right type') { expect(cop.cop_type).to eq(:style) }
+    it('has right department') { expect(cop.department).to eq(:style) }
   end
 
   context 'with lint cops' do
     subject(:cop) { RuboCop::Cop::Lint::Loop }
     it('has right name') { expect(cop.cop_name).to eq('Lint/Loop') }
-    it('has right type') { expect(cop.cop_type).to eq(:lint) }
+    it('has right department') { expect(cop.department).to eq(:lint) }
   end
 
   context 'with rails cops' do
     subject(:cop) { RuboCop::Cop::Rails::Validation }
     it('has right name') { expect(cop.cop_name).to eq('Rails/Validation') }
-    it('has right type') { expect(cop.cop_type).to eq(:rails) }
+    it('has right department') { expect(cop.department).to eq(:rails) }
   end
 
   describe 'CopStore' do
-    context '#types' do
-      subject { described_class.all.types }
-      it('has types') { expect(subject.length).not_to eq(0) }
+    context '#departments' do
+      subject { described_class.all.departments }
+      it('has departments') { expect(subject.length).not_to eq(0) }
       it { is_expected.to include(:lint) }
       it { is_expected.to include(:rails) }
       it { is_expected.to include(:style) }
@@ -184,24 +184,24 @@ describe RuboCop::Cop::Cop do
         expect(subject.length).to eq(subject.uniq.length)
       end
     end
-    context '#with_type' do
-      let(:types) { described_class.all.types }
+    context '#with_department' do
+      let(:departments) { described_class.all.departments }
       it 'has at least one cop per type' do
-        types.each do |c|
-          expect(described_class.all.with_type(c).length).to be > 0
+        departments.each do |c|
+          expect(described_class.all.with_department(c).length).to be > 0
         end
       end
 
       it 'has each cop in exactly one type' do
         sum = 0
-        types.each do |c|
-          sum += described_class.all.with_type(c).length
+        departments.each do |c|
+          sum += described_class.all.with_department(c).length
         end
         expect(sum).to be described_class.all.length
       end
 
       it 'returns 0 for an invalid type' do
-        expect(described_class.all.with_type('x').length).to be 0
+        expect(described_class.all.with_department('x').length).to be 0
       end
     end
   end


### PR DESCRIPTION
@bbatsov said while reviewing #3837 that `cop_type`, `namespace`, and `department` are used interchangeably when we should just be using `department`. #3837 was getting big so I've extracted this PR for just updating all existing code to use `department`

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Used the same coding conventions as the rest of the project.
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] All tests are passing.
* [x] The new code doesn't generate RuboCop offenses.
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Updated cop documentation with `rake generate_cops_documentation` (required only when you've added a new cop or changed the configuration/documentation of an existing cop).

[1]: http://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html
