### PR TITLE
Fix task of cop generation task in case sensitive file system

### DIFF
--- a/tasks/cops_documentation.rake
+++ b/tasks/cops_documentation.rake
@@ -84,7 +84,7 @@ task generate_cops_documentation: :yard do
     selected_cops.each do |cop|
       content << print_cop_with_doc(cop, config)
     end
-    file_name = "#{Dir.pwd}/manual/cops_#{type}.md"
+    file_name = "#{Dir.pwd}/manual/cops_#{type.downcase}.md"
     file = File.open(file_name, 'w')
     puts "* generated #{file_name}"
     file.write(content)


### PR DESCRIPTION
`generate_cops_documentation` task generates camel cased documentation files.

```
$ bundle exec rake generate_cops_documentation
...

$ git status
On branch master
Your branch is up-to-date with 'origin/master'.
Untracked files:
  (use "git add <file>..." to include in what will be committed)

	manual/cops_Bundler.md
	manual/cops_Lint.md
	manual/cops_Metrics.md
	manual/cops_Performance.md
	manual/cops_Rails.md
	manual/cops_Security.md
	manual/cops_Style.md

nothing added to commit but untracked files present (use "git add" to track)
```

It is a problem in case sensitive file system(e.g. Linux).

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Used the same coding conventions as the rest of the project.
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [ ] Added tests.
* [ ] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] All tests are passing.
* [x] The new code doesn't generate RuboCop offenses.
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [ ] Updated cop documentation with `rake generate_cops_documentation` (required only when you've added a new cop or changed the configuration/documentation of an existing cop).

[1]: http://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html
