### PR TITLE
Use `aggregate_failures` in cli specs

### DIFF
--- a/spec/isolated_environment_spec.rb
+++ b/spec/isolated_environment_spec.rb
@@ -3,14 +3,9 @@
 require 'spec_helper'
 
 describe 'isolated environment', :isolated_environment do
-  include FileHelper
-
   include_context 'cli spec behavior'
 
   let(:cli) { RuboCop::CLI.new }
-
-  before(:each) { $stdout = StringIO.new }
-  after(:each) { $stdout = STDOUT }
 
   # Configuration files above the work directory shall not disturb the
   # tests. This is especially important on Windows where the temporary

--- a/spec/isolated_environment_spec.rb
+++ b/spec/isolated_environment_spec.rb
@@ -5,6 +5,8 @@ require 'spec_helper'
 describe 'isolated environment', :isolated_environment do
   include FileHelper
 
+  include_context 'cli spec behavior'
+
   let(:cli) { RuboCop::CLI.new }
 
   before(:each) { $stdout = StringIO.new }

--- a/spec/rubocop/cli/cli_auto_gen_config_spec.rb
+++ b/spec/rubocop/cli/cli_auto_gen_config_spec.rb
@@ -4,31 +4,9 @@ require 'spec_helper'
 require 'timeout'
 
 describe RuboCop::CLI, :isolated_environment do
-  include FileHelper
-
   include_context 'cli spec behavior'
 
   subject(:cli) { described_class.new }
-
-  before(:each) do
-    $stdout = StringIO.new
-    $stderr = StringIO.new
-    RuboCop::ConfigLoader.debug = false
-
-    # OPTIMIZE: Makes these specs faster. Work directory (the parent of
-    # .rubocop_cache) is removed afterwards anyway.
-    RuboCop::ResultCache.inhibit_cleanup = true
-  end
-
-  after(:each) do
-    $stdout = STDOUT
-    $stderr = STDERR
-    RuboCop::ResultCache.inhibit_cleanup = false
-  end
-
-  def abs(path)
-    File.expand_path(path)
-  end
 
   describe '--auto-gen-config' do
     before(:each) do

--- a/spec/rubocop/cli/cli_auto_gen_config_spec.rb
+++ b/spec/rubocop/cli/cli_auto_gen_config_spec.rb
@@ -6,6 +6,8 @@ require 'timeout'
 describe RuboCop::CLI, :isolated_environment do
   include FileHelper
 
+  include_context 'cli spec behavior'
+
   subject(:cli) { described_class.new }
 
   before(:each) do

--- a/spec/rubocop/cli/cli_autocorrect_spec.rb
+++ b/spec/rubocop/cli/cli_autocorrect_spec.rb
@@ -5,6 +5,8 @@ require 'spec_helper'
 describe RuboCop::CLI, :isolated_environment do
   include FileHelper
 
+  include_context 'cli spec behavior'
+
   subject(:cli) { described_class.new }
 
   before(:each) do

--- a/spec/rubocop/cli/cli_autocorrect_spec.rb
+++ b/spec/rubocop/cli/cli_autocorrect_spec.rb
@@ -3,31 +3,9 @@
 require 'spec_helper'
 
 describe RuboCop::CLI, :isolated_environment do
-  include FileHelper
-
   include_context 'cli spec behavior'
 
   subject(:cli) { described_class.new }
-
-  before(:each) do
-    $stdout = StringIO.new
-    $stderr = StringIO.new
-    RuboCop::ConfigLoader.debug = false
-
-    # OPTIMIZE: Makes these specs faster. Work directory (the parent of
-    # .rubocop_cache) is removed afterwards anyway.
-    RuboCop::ResultCache.inhibit_cleanup = true
-  end
-
-  after(:each) do
-    $stdout = STDOUT
-    $stderr = STDERR
-    RuboCop::ResultCache.inhibit_cleanup = false
-  end
-
-  def abs(path)
-    File.expand_path(path)
-  end
 
   it 'does not correct ExtraSpacing in a hash that would be changed back' do
     create_file('.rubocop.yml', ['Style/AlignHash:',

--- a/spec/rubocop/cli/cli_options_spec.rb
+++ b/spec/rubocop/cli/cli_options_spec.rb
@@ -6,6 +6,8 @@ require 'spec_helper'
 describe RuboCop::CLI, :isolated_environment do
   include FileHelper
 
+  include_context 'cli spec behavior'
+
   subject(:cli) { described_class.new }
 
   before(:each) do

--- a/spec/rubocop/cli/cli_options_spec.rb
+++ b/spec/rubocop/cli/cli_options_spec.rb
@@ -4,31 +4,9 @@
 require 'spec_helper'
 
 describe RuboCop::CLI, :isolated_environment do
-  include FileHelper
-
   include_context 'cli spec behavior'
 
   subject(:cli) { described_class.new }
-
-  before(:each) do
-    $stdout = StringIO.new
-    $stderr = StringIO.new
-    RuboCop::ConfigLoader.debug = false
-
-    # OPTIMIZE: Makes these specs faster. Work directory (the parent of
-    # .rubocop_cache) is removed afterwards anyway.
-    RuboCop::ResultCache.inhibit_cleanup = true
-  end
-
-  after(:each) do
-    $stdout = STDOUT
-    $stderr = STDERR
-    RuboCop::ResultCache.inhibit_cleanup = false
-  end
-
-  def abs(path)
-    File.expand_path(path)
-  end
 
   describe '--list-target-files' do
     context 'when there are no files' do

--- a/spec/rubocop/cli_spec.rb
+++ b/spec/rubocop/cli_spec.rb
@@ -6,6 +6,8 @@ require 'timeout'
 describe RuboCop::CLI, :isolated_environment do
   include FileHelper
 
+  include_context 'cli spec behavior'
+
   subject(:cli) { described_class.new }
 
   before(:each) do

--- a/spec/rubocop/cli_spec.rb
+++ b/spec/rubocop/cli_spec.rb
@@ -4,31 +4,9 @@ require 'spec_helper'
 require 'timeout'
 
 describe RuboCop::CLI, :isolated_environment do
-  include FileHelper
-
   include_context 'cli spec behavior'
 
   subject(:cli) { described_class.new }
-
-  before(:each) do
-    $stdout = StringIO.new
-    $stderr = StringIO.new
-    RuboCop::ConfigLoader.debug = false
-
-    # OPTIMIZE: Makes these specs faster. Work directory (the parent of
-    # .rubocop_cache) is removed afterwards anyway.
-    RuboCop::ResultCache.inhibit_cleanup = true
-  end
-
-  after(:each) do
-    $stdout = STDOUT
-    $stderr = STDERR
-    RuboCop::ResultCache.inhibit_cleanup = false
-  end
-
-  def abs(path)
-    File.expand_path(path)
-  end
 
   context 'when interrupted' do
     it 'returns 1' do

--- a/spec/support/cli_spec_behavior.rb
+++ b/spec/support/cli_spec_behavior.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+RSpec.shared_context 'cli spec behavior' do
+  # Wrap all cli specs in `aggregate_failures` so that the expected and
+  # actual results of every expectation per example are shown. This is
+  # helpful because it shows information like expected and actual
+  # $stdout messages while not using `aggregate_failures` will only
+  # show information about expected and actual exit code
+  around do |example|
+    aggregate_failures(&example)
+  end
+end

--- a/spec/support/cli_spec_behavior.rb
+++ b/spec/support/cli_spec_behavior.rb
@@ -1,6 +1,23 @@
 # frozen_string_literal: true
 
 RSpec.shared_context 'cli spec behavior' do
+  include FileHelper
+
+  def abs(path)
+    File.expand_path(path)
+  end
+
+  before do
+    $stdout = StringIO.new
+    $stderr = StringIO.new
+
+    RuboCop::ConfigLoader.debug = false
+
+    # OPTIMIZE: Makes these specs faster. Work directory (the parent of
+    # .rubocop_cache) is removed afterwards anyway.
+    RuboCop::ResultCache.inhibit_cleanup = true
+  end
+
   # Wrap all cli specs in `aggregate_failures` so that the expected and
   # actual results of every expectation per example are shown. This is
   # helpful because it shows information like expected and actual
@@ -8,5 +25,11 @@ RSpec.shared_context 'cli spec behavior' do
   # show information about expected and actual exit code
   around do |example|
     aggregate_failures(&example)
+  end
+
+  after do
+    $stdout = STDOUT
+    $stderr = STDERR
+    RuboCop::ResultCache.inhibit_cleanup = false
   end
 end


### PR DESCRIPTION
I decided I would fix an issue in the specs that was bugging me while working on #3837. Often during that refactor I would break something that would not be caught by most of the unit tests but would be caught by the cli tests. This was frustrating because the cli specs would only say something cryptic like `expected: 1 got: 2` since the first expectation in the cli specs is the exit code assertion.

This change makes spec failures more helpful when they come from the
cli specs. Previously, when a CLI spec failed, it almost always failed
due to the first assertion about the exit code. The spec output
therefore usually looked like this:

    $ ag 'cli\.run' spec -l
    spec/isolated_environment_spec.rb
    spec/rubocop/cli/cli_auto_gen_config_spec.rb
    spec/rubocop/cli/cli_options_spec.rb
    spec/rubocop/cli/cli_autocorrect_spec.rb
    spec/rubocop/cli_spec.rb

    $ ag 'cli\.run' spec -l | xargs bundle exec rspec

    # ... snip ...

    Failures:

      1) RuboCop::CLI --except when ... block.
         Failure/Error:
           expect(cli.run([...])).to eq(1) # (snip)

           expected: 1
                got: 2

           (compared using ==)

    Finished in 8.19 seconds (files took 0.51121 seconds to load)
    224 examples, 9 failures

Almost all of the CLI specs seem to make an assertion about the exit
code, an assertion about the stdout, and then sometimes other
assertions about stderr or file contents. This change wraps all of
these specs in `aggregate_failures` which makes the spec output
more helpful:

    $ ag 'cli\.run' spec -l | xargs bundle exec rspec

    Failures:

      1) RuboCop::CLI --except when ... block.

         1.1) Failure/Error:
                expect(cli.run([...])).to eq(1) # (snip)

                expected: 1
                     got: 2

                (compared using ==)

         1.2) Failure/Error: expect($stderr.string).to eq('')

                expected: ""
                     got: "An error occurred while Style/..." (snip)

                (compared using ==)

                Diff:
                @@ -1 +1,102 @@
                snip

         1.3) Failure/Error:
                expect($stdout.string)
                  .to eq(['',
                          '1  Style/IndentationWidth',
                          '1  Style/NumericLiterals',
                          '1  Style/TrailingWhitespace',
                          '--',
                          '3  Total',
                          '',
                          ''].join("\n"))

                expected: "\n1  Style/IndentationWidth\n1  ..." (snip)
                     got: "\n--\n0  Total\n\n"

                (compared using ==)

                Diff:

                @@ -1,7 +1,4 @@

                -1  Style/IndentationWidth
                -1  Style/NumericLiterals
                -1  Style/TrailingWhitespace
                 --
                -3  Total
                snip

    Finished in 8.22 seconds (files took 0.57733 seconds to load)
    224 examples, 9 failures

Notes:

 - Both of these examples are heavily manually edited to fit within
   the standard git commit message template)

 - I made the following change to generate the failing spec examples

    ```diff
    --- i/lib/rubocop/comment_config.rb
    +++ w/lib/rubocop/comment_config.rb

    - @all_cop_names ||= Cop::Cop.registry.names - [UNNEEDED_DISABLE]
    + @all_cop_names ||= Cop::Cop.all.names - [UNNEEDED_DISABLE]
    ```

If you're curious, here is the full spec output before and after adding `aggregate_failures`. I think it is a massive difference:

### Before

<details>

```sh
$ git --no-pager diff
diff --git i/lib/rubocop/comment_config.rb w/lib/rubocop/comment_config.rb
index caa5178..6132dd0 100644
--- i/lib/rubocop/comment_config.rb
+++ w/lib/rubocop/comment_config.rb
@@ -133,7 +133,7 @@ module RuboCop
     end

     def all_cop_names
-      @all_cop_names ||= Cop::Cop.registry.names - [UNNEEDED_DISABLE]
+      @all_cop_names ||= Cop::Cop.all.names - [UNNEEDED_DISABLE]
     end

     def comment_only_line?(line_number)
$ ag 'cli\.run' spec -l
spec/isolated_environment_spec.rb
spec/rubocop/cli/cli_auto_gen_config_spec.rb
spec/rubocop/cli/cli_options_spec.rb
spec/rubocop/cli/cli_autocorrect_spec.rb
spec/rubocop/cli_spec.rb
$ ag 'cli\.run' spec -l | xargs bundle exec rspec
Run options:
  include {:focus=>true}
  exclude {:broken=>#<Proc:./spec/spec_helper.rb:32>}

All examples were filtered out; ignoring {:focus=>true}

Randomized with seed 25270
............................................................................................FF..FF.FF.........FFF...............................................................................................................

Failures:

  1) RuboCop::CLI rubocop:disable comment can disable all cops in a code section
     Failure/Error: expect(cli.run(['--format', 'emacs', 'example.rb'])).to eq(1)

       expected: 1
            got: 2

       (compared using ==)
     # ./spec/rubocop/cli_spec.rb:247:in `block (3 levels) in <top (required)>'
     # ./lib/rubocop/rspec/shared_contexts.rb:27:in `block (4 levels) in <top (required)>'
     # ./lib/rubocop/rspec/shared_contexts.rb:26:in `chdir'
     # ./lib/rubocop/rspec/shared_contexts.rb:26:in `block (3 levels) in <top (required)>'
     # ./lib/rubocop/rspec/shared_contexts.rb:8:in `block (2 levels) in <top (required)>'

  2) RuboCop::CLI rubocop:disable comment can disable all cops on a single line
     Failure/Error: expect(cli.run(['--format', 'emacs', 'example.rb'])).to eq(0)

       expected: 0
            got: 2

       (compared using ==)
     # ./spec/rubocop/cli_spec.rb:310:in `block (3 levels) in <top (required)>'
     # ./lib/rubocop/rspec/shared_contexts.rb:27:in `block (4 levels) in <top (required)>'
     # ./lib/rubocop/rspec/shared_contexts.rb:26:in `chdir'
     # ./lib/rubocop/rspec/shared_contexts.rb:26:in `block (3 levels) in <top (required)>'
     # ./lib/rubocop/rspec/shared_contexts.rb:8:in `block (2 levels) in <top (required)>'

  3) RuboCop::CLI rubocop:disable comment when not necessary causes an offense to be reported
     Failure/Error: expect(cli.run(['--format', 'emacs', 'example.rb'])).to eq(1)

       expected: 1
            got: 2

       (compared using ==)
     # ./spec/rubocop/cli_spec.rb:346:in `block (4 levels) in <top (required)>'
     # ./lib/rubocop/rspec/shared_contexts.rb:27:in `block (4 levels) in <top (required)>'
     # ./lib/rubocop/rspec/shared_contexts.rb:26:in `chdir'
     # ./lib/rubocop/rspec/shared_contexts.rb:26:in `block (3 levels) in <top (required)>'
     # ./lib/rubocop/rspec/shared_contexts.rb:8:in `block (2 levels) in <top (required)>'

  4) RuboCop::CLI rubocop:disable comment when not necessary and UnneededDisable is disabled through department does not report UnneededDisable offenses
     Failure/Error: expect(cli.run(['--format', 'emacs'])).to eq(1)

       expected: 1
            got: 2

       (compared using ==)
     Shared Example Group: "UnneededDisable not run" called from ./spec/rubocop/cli_spec.rb:391
     # ./spec/rubocop/cli_spec.rb:375:in `block (6 levels) in <top (required)>'
     # ./lib/rubocop/rspec/shared_contexts.rb:27:in `block (4 levels) in <top (required)>'
     # ./lib/rubocop/rspec/shared_contexts.rb:26:in `chdir'
     # ./lib/rubocop/rspec/shared_contexts.rb:26:in `block (3 levels) in <top (required)>'
     # ./lib/rubocop/rspec/shared_contexts.rb:8:in `block (2 levels) in <top (required)>'

  5) RuboCop::CLI rubocop:disable comment when not necessary and UnneededDisable is individually disabled does not report UnneededDisable offenses
     Failure/Error: expect(cli.run(['--format', 'emacs'])).to eq(1)

       expected: 1
            got: 2

       (compared using ==)
     Shared Example Group: "UnneededDisable not run" called from ./spec/rubocop/cli_spec.rb:384
     # ./spec/rubocop/cli_spec.rb:375:in `block (6 levels) in <top (required)>'
     # ./lib/rubocop/rspec/shared_contexts.rb:27:in `block (4 levels) in <top (required)>'
     # ./lib/rubocop/rspec/shared_contexts.rb:26:in `chdir'
     # ./lib/rubocop/rspec/shared_contexts.rb:26:in `block (3 levels) in <top (required)>'
     # ./lib/rubocop/rspec/shared_contexts.rb:8:in `block (2 levels) in <top (required)>'

  6) RuboCop::CLI rubocop:disable comment when not necessary and UnneededDisable is individually excluded does not report UnneededDisable offenses
     Failure/Error: expect(cli.run(['--format', 'emacs'])).to eq(1)

       expected: 1
            got: 2

       (compared using ==)
     Shared Example Group: "UnneededDisable not run" called from ./spec/rubocop/cli_spec.rb:387
     # ./spec/rubocop/cli_spec.rb:375:in `block (6 levels) in <top (required)>'
     # ./lib/rubocop/rspec/shared_contexts.rb:27:in `block (4 levels) in <top (required)>'
     # ./lib/rubocop/rspec/shared_contexts.rb:26:in `chdir'
     # ./lib/rubocop/rspec/shared_contexts.rb:26:in `block (3 levels) in <top (required)>'
     # ./lib/rubocop/rspec/shared_contexts.rb:8:in `block (2 levels) in <top (required)>'

  7) RuboCop::CLI --except when several cops are given disables the given cops including Lint
     Failure/Error:
       expect(cli.run(['--format', 'offenses',
                       '--except',
                       'Style/IfUnlessModifier,Style/Tab,' \
                       "Style/SpaceAroundOperators,#{cop_name}",
                       'example.rb'])).to eq(1)

       expected: 1
            got: 2

       (compared using ==)
     # ./spec/rubocop/cli/cli_options_spec.rb:386:in `block (5 levels) in <top (required)>'
     # ./lib/rubocop/rspec/shared_contexts.rb:27:in `block (4 levels) in <top (required)>'
     # ./lib/rubocop/rspec/shared_contexts.rb:26:in `chdir'
     # ./lib/rubocop/rspec/shared_contexts.rb:26:in `block (3 levels) in <top (required)>'
     # ./lib/rubocop/rspec/shared_contexts.rb:8:in `block (2 levels) in <top (required)>'

  8) RuboCop::CLI --except when several cops are given disables the given cops including Lint/UnneededDisable
     Failure/Error:
       expect(cli.run(['--format', 'offenses',
                       '--except',
                       'Style/IfUnlessModifier,Style/Tab,' \
                       "Style/SpaceAroundOperators,#{cop_name}",
                       'example.rb'])).to eq(1)

       expected: 1
            got: 2

       (compared using ==)
     # ./spec/rubocop/cli/cli_options_spec.rb:386:in `block (5 levels) in <top (required)>'
     # ./lib/rubocop/rspec/shared_contexts.rb:27:in `block (4 levels) in <top (required)>'
     # ./lib/rubocop/rspec/shared_contexts.rb:26:in `chdir'
     # ./lib/rubocop/rspec/shared_contexts.rb:26:in `block (3 levels) in <top (required)>'
     # ./lib/rubocop/rspec/shared_contexts.rb:8:in `block (2 levels) in <top (required)>'

  9) RuboCop::CLI --except when several cops are given disables the given cops including UnneededDisable
     Failure/Error:
       expect(cli.run(['--format', 'offenses',
                       '--except',
                       'Style/IfUnlessModifier,Style/Tab,' \
                       "Style/SpaceAroundOperators,#{cop_name}",
                       'example.rb'])).to eq(1)

       expected: 1
            got: 2

       (compared using ==)
     # ./spec/rubocop/cli/cli_options_spec.rb:386:in `block (5 levels) in <top (required)>'
     # ./lib/rubocop/rspec/shared_contexts.rb:27:in `block (4 levels) in <top (required)>'
     # ./lib/rubocop/rspec/shared_contexts.rb:26:in `chdir'
     # ./lib/rubocop/rspec/shared_contexts.rb:26:in `block (3 levels) in <top (required)>'
     # ./lib/rubocop/rspec/shared_contexts.rb:8:in `block (2 levels) in <top (required)>'

Finished in 8.19 seconds (files took 0.51121 seconds to load)
224 examples, 9 failures

Failed examples:

rspec ./spec/rubocop/cli_spec.rb:235 # RuboCop::CLI rubocop:disable comment can disable all cops in a code section
rspec ./spec/rubocop/cli_spec.rb:308 # RuboCop::CLI rubocop:disable comment can disable all cops on a single line
rspec ./spec/rubocop/cli_spec.rb:340 # RuboCop::CLI rubocop:disable comment when not necessary causes an offense to be reported
rspec './spec/rubocop/cli_spec.rb[1:11:7:5:1]' # RuboCop::CLI rubocop:disable comment when not necessary and UnneededDisable is disabled through department does not report UnneededDisable offenses
rspec './spec/rubocop/cli_spec.rb[1:11:7:3:1]' # RuboCop::CLI rubocop:disable comment when not necessary and UnneededDisable is individually disabled does not report UnneededDisable offenses
rspec './spec/rubocop/cli_spec.rb[1:11:7:4:1]' # RuboCop::CLI rubocop:disable comment when not necessary and UnneededDisable is individually excluded does not report UnneededDisable offenses
rspec './spec/rubocop/cli/cli_options_spec.rb[1:4:4:3]' # RuboCop::CLI --except when several cops are given disables the given cops including Lint
rspec './spec/rubocop/cli/cli_options_spec.rb[1:4:4:2]' # RuboCop::CLI --except when several cops are given disables the given cops including Lint/UnneededDisable
rspec './spec/rubocop/cli/cli_options_spec.rb[1:4:4:1]' # RuboCop::CLI --except when several cops are given disables the given cops including UnneededDisable

Randomized with seed 25270
```


</details>

### After

<details>

```sh
$ ag 'cli\.run' spec -l | xargs bundle exec rspec
Run options:
  include {:focus=>true}
  exclude {:broken=>#<Proc:./spec/spec_helper.rb:32>}

All examples were filtered out; ignoring {:focus=>true}

Randomized with seed 64364
...................................................................................................................FFF.................................................................................F.F..FF.FF...............

Failures:

  1) RuboCop::CLI --except when several cops are given disables the given cops including Lint
     Got 3 failures from failure aggregation block.
     # ./spec/support/cli_spec_behavior.rb:3:in `block (2 levels) in <top (required)>'
     # ./lib/rubocop/rspec/shared_contexts.rb:27:in `block (4 levels) in <top (required)>'
     # ./lib/rubocop/rspec/shared_contexts.rb:26:in `chdir'
     # ./lib/rubocop/rspec/shared_contexts.rb:26:in `block (3 levels) in <top (required)>'
     # ./lib/rubocop/rspec/shared_contexts.rb:8:in `block (2 levels) in <top (required)>'

     1.1) Failure/Error:
            expect(cli.run(['--format', 'offenses',
                            '--except',
                            'Style/IfUnlessModifier,Style/Tab,' \
                            "Style/SpaceAroundOperators,#{cop_name}",
                            'example.rb'])).to eq(1)

            expected: 1
                 got: 2

            (compared using ==)
          # ./spec/rubocop/cli/cli_options_spec.rb:388:in `block (5 levels) in <top (required)>'

     1.2) Failure/Error: expect($stderr.string).to eq('')

            expected: ""
                 got: "An error occurred while Style/TrailingWhitespace cop was inspecting /private/var/folders/wq/h965ll7s...m/ruby/2.3.1/bin/bundle:23:in `load'\n/Users/johnbackus/.gem/ruby/2.3.1/bin/bundle:23:in `<main>'\n"

            (compared using ==)

            Diff:
            @@ -1 +1,102 @@
            +An error occurred while Style/TrailingWhitespace cop was inspecting /private/var/folders/wq/h965ll7s5bqcpzcd58b__pw00000gn/T/d20170102-5582-13yvbur/work/example.rb.
            +To see the complete backtrace run rubocop -d.
            +An error occurred while Style/IndentationWidth cop was inspecting /private/var/folders/wq/h965ll7s5bqcpzcd58b__pw00000gn/T/d20170102-5582-13yvbur/work/example.rb.
            +To see the complete backtrace run rubocop -d.
            +An error occurred while Style/NumericLiterals cop was inspecting /private/var/folders/wq/h965ll7s5bqcpzcd58b__pw00000gn/T/d20170102-5582-13yvbur/work/example.rb.
            +To see the complete backtrace run rubocop -d.
            +undefined method `names' for #<Array:0x007fc38ab19a90>
            +/Users/johnbackus/Projects/rubocop/lib/rubocop/comment_config.rb:136:in `all_cop_names'
            +/Users/johnbackus/Projects/rubocop/lib/rubocop/comment_config.rb:124:in `directive_parts'
            +/Users/johnbackus/Projects/rubocop/lib/rubocop/comment_config.rb:110:in `block in each_directive'
            +/Users/johnbackus/Projects/rubocop/lib/rubocop/comment_config.rb:109:in `each'
            +/Users/johnbackus/Projects/rubocop/lib/rubocop/comment_config.rb:109:in `each_directive'
            +/Users/johnbackus/Projects/rubocop/lib/rubocop/comment_config.rb:95:in `each_mentioned_cop'
            +/Users/johnbackus/Projects/rubocop/lib/rubocop/comment_config.rb:42:in `analyze'
            +/Users/johnbackus/Projects/rubocop/lib/rubocop/comment_config.rb:34:in `cop_disabled_line_ranges'
            +/Users/johnbackus/Projects/rubocop/lib/rubocop/processed_source.rb:44:in `disabled_line_ranges'
            +/Users/johnbackus/Projects/rubocop/lib/rubocop/runner.rb:136:in `check_for_unneded_disables?'
            +/Users/johnbackus/Projects/rubocop/lib/rubocop/runner.rb:119:in `add_unneeded_disables'
            +/Users/johnbackus/Projects/rubocop/lib/rubocop/runner.rb:102:in `block in file_offenses'
            +/Users/johnbackus/Projects/rubocop/lib/rubocop/runner.rb:111:in `file_offense_cache'
            +/Users/johnbackus/Projects/rubocop/lib/rubocop/runner.rb:99:in `file_offenses'
            +/Users/johnbackus/Projects/rubocop/lib/rubocop/runner.rb:90:in `process_file'
            +/Users/johnbackus/Projects/rubocop/lib/rubocop/runner.rb:68:in `block in each_inspected_file'
            +/Users/johnbackus/Projects/rubocop/lib/rubocop/runner.rb:65:in `each'
            +/Users/johnbackus/Projects/rubocop/lib/rubocop/runner.rb:65:in `reduce'
            +/Users/johnbackus/Projects/rubocop/lib/rubocop/runner.rb:65:in `each_inspected_file'
            +/Users/johnbackus/Projects/rubocop/lib/rubocop/runner.rb:57:in `inspect_files'
            +/Users/johnbackus/Projects/rubocop/lib/rubocop/runner.rb:36:in `run'
            +/Users/johnbackus/Projects/rubocop/lib/rubocop/cli.rb:72:in `execute_runner'
            +/Users/johnbackus/Projects/rubocop/lib/rubocop/cli.rb:27:in `run'
            +/Users/johnbackus/Projects/rubocop/spec/rubocop/cli/cli_options_spec.rb:388:in `block (5 levels) in <top (required)>'
            +/Users/johnbackus/.gem/ruby/2.3.1/gems/rspec-core-3.5.4/lib/rspec/core/example.rb:254:in `instance_exec'
            +/Users/johnbackus/.gem/ruby/2.3.1/gems/rspec-core-3.5.4/lib/rspec/core/example.rb:254:in `block in run'
            +/Users/johnbackus/.gem/ruby/2.3.1/gems/rspec-core-3.5.4/lib/rspec/core/example.rb:496:in `block in with_around_and_singleton_context_hooks'
            +/Users/johnbackus/.gem/ruby/2.3.1/gems/rspec-core-3.5.4/lib/rspec/core/example.rb:453:in `block in with_around_example_hooks'
            +/Users/johnbackus/.gem/ruby/2.3.1/gems/rspec-core-3.5.4/lib/rspec/core/hooks.rb:464:in `block in run'
            +/Users/johnbackus/.gem/ruby/2.3.1/gems/rspec-core-3.5.4/lib/rspec/core/hooks.rb:604:in `block in run_around_example_hooks_for'
            +/Users/johnbackus/.gem/ruby/2.3.1/gems/rspec-core-3.5.4/lib/rspec/core/example.rb:338:in `call'
            +/Users/johnbackus/.gem/ruby/2.3.1/gems/rspec-expectations-3.5.0/lib/rspec/expectations/failure_aggregator.rb:10:in `block in aggregate'
            +/Users/johnbackus/.gem/ruby/2.3.1/gems/rspec-support-3.5.0/lib/rspec/support.rb:103:in `with_failure_notifier'
            +/Users/johnbackus/.gem/ruby/2.3.1/gems/rspec-expectations-3.5.0/lib/rspec/expectations/failure_aggregator.rb:8:in `aggregate'
            +/Users/johnbackus/.gem/ruby/2.3.1/gems/rspec-expectations-3.5.0/lib/rspec/matchers.rb:313:in `aggregate_failures'
            +/Users/johnbackus/Projects/rubocop/spec/support/cli_spec_behavior.rb:3:in `block (2 levels) in <top (required)>'
            +/Users/johnbackus/.gem/ruby/2.3.1/gems/rspec-core-3.5.4/lib/rspec/core/example.rb:443:in `instance_exec'
            +/Users/johnbackus/.gem/ruby/2.3.1/gems/rspec-core-3.5.4/lib/rspec/core/example.rb:443:in `instance_exec'
            +/Users/johnbackus/.gem/ruby/2.3.1/gems/rspec-core-3.5.4/lib/rspec/core/hooks.rb:375:in `execute_with'
            +/Users/johnbackus/.gem/ruby/2.3.1/gems/rspec-core-3.5.4/lib/rspec/core/hooks.rb:606:in `block (2 levels) in run_around_example_hooks_for'
            +/Users/johnbackus/.gem/ruby/2.3.1/gems/rspec-core-3.5.4/lib/rspec/core/example.rb:338:in `call'
            +/Users/johnbackus/Projects/rubocop/lib/rubocop/rspec/shared_contexts.rb:27:in `block (4 levels) in <top (required)>'
            +/Users/johnbackus/Projects/rubocop/lib/rubocop/rspec/shared_contexts.rb:26:in `chdir'
            +/Users/johnbackus/Projects/rubocop/lib/rubocop/rspec/shared_contexts.rb:26:in `block (3 levels) in <top (required)>'
            +/Users/johnbackus/.rubies/ruby-2.3.1/lib/ruby/2.3.0/tmpdir.rb:89:in `mktmpdir'
            +/Users/johnbackus/Projects/rubocop/lib/rubocop/rspec/shared_contexts.rb:8:in `block (2 levels) in <top (required)>'
            +/Users/johnbackus/.gem/ruby/2.3.1/gems/rspec-core-3.5.4/lib/rspec/core/example.rb:443:in `instance_exec'
            +/Users/johnbackus/.gem/ruby/2.3.1/gems/rspec-core-3.5.4/lib/rspec/core/example.rb:443:in `instance_exec'
            +/Users/johnbackus/.gem/ruby/2.3.1/gems/rspec-core-3.5.4/lib/rspec/core/hooks.rb:375:in `execute_with'
            +/Users/johnbackus/.gem/ruby/2.3.1/gems/rspec-core-3.5.4/lib/rspec/core/hooks.rb:606:in `block (2 levels) in run_around_example_hooks_for'
            +/Users/johnbackus/.gem/ruby/2.3.1/gems/rspec-core-3.5.4/lib/rspec/core/example.rb:338:in `call'
            +/Users/johnbackus/.gem/ruby/2.3.1/gems/rspec-core-3.5.4/lib/rspec/core/hooks.rb:607:in `run_around_example_hooks_for'
            +/Users/johnbackus/.gem/ruby/2.3.1/gems/rspec-core-3.5.4/lib/rspec/core/hooks.rb:464:in `run'
            +/Users/johnbackus/.gem/ruby/2.3.1/gems/rspec-core-3.5.4/lib/rspec/core/example.rb:453:in `with_around_example_hooks'
            +/Users/johnbackus/.gem/ruby/2.3.1/gems/rspec-core-3.5.4/lib/rspec/core/example.rb:496:in `with_around_and_singleton_context_hooks'
            +/Users/johnbackus/.gem/ruby/2.3.1/gems/rspec-core-3.5.4/lib/rspec/core/example.rb:251:in `run'
            +/Users/johnbackus/.gem/ruby/2.3.1/gems/rspec-core-3.5.4/lib/rspec/core/example_group.rb:627:in `block in run_examples'
            +/Users/johnbackus/.gem/ruby/2.3.1/gems/rspec-core-3.5.4/lib/rspec/core/example_group.rb:623:in `map'
            +/Users/johnbackus/.gem/ruby/2.3.1/gems/rspec-core-3.5.4/lib/rspec/core/example_group.rb:623:in `run_examples'
            +/Users/johnbackus/.gem/ruby/2.3.1/gems/rspec-core-3.5.4/lib/rspec/core/example_group.rb:589:in `run'
            +/Users/johnbackus/.gem/ruby/2.3.1/gems/rspec-core-3.5.4/lib/rspec/core/example_group.rb:590:in `block in run'
            +/Users/johnbackus/.gem/ruby/2.3.1/gems/rspec-core-3.5.4/lib/rspec/core/example_group.rb:590:in `map'
            +/Users/johnbackus/.gem/ruby/2.3.1/gems/rspec-core-3.5.4/lib/rspec/core/example_group.rb:590:in `run'
            +/Users/johnbackus/.gem/ruby/2.3.1/gems/rspec-core-3.5.4/lib/rspec/core/example_group.rb:590:in `block in run'
            +/Users/johnbackus/.gem/ruby/2.3.1/gems/rspec-core-3.5.4/lib/rspec/core/example_group.rb:590:in `map'
            +/Users/johnbackus/.gem/ruby/2.3.1/gems/rspec-core-3.5.4/lib/rspec/core/example_group.rb:590:in `run'
            +/Users/johnbackus/.gem/ruby/2.3.1/gems/rspec-core-3.5.4/lib/rspec/core/runner.rb:113:in `block (3 levels) in run_specs'
            +/Users/johnbackus/.gem/ruby/2.3.1/gems/rspec-core-3.5.4/lib/rspec/core/runner.rb:113:in `map'
            +/Users/johnbackus/.gem/ruby/2.3.1/gems/rspec-core-3.5.4/lib/rspec/core/runner.rb:113:in `block (2 levels) in run_specs'
            +/Users/johnbackus/.gem/ruby/2.3.1/gems/rspec-core-3.5.4/lib/rspec/core/configuration.rb:1835:in `with_suite_hooks'
            +/Users/johnbackus/.gem/ruby/2.3.1/gems/rspec-core-3.5.4/lib/rspec/core/runner.rb:112:in `block in run_specs'
            +/Users/johnbackus/.gem/ruby/2.3.1/gems/rspec-core-3.5.4/lib/rspec/core/reporter.rb:77:in `report'
            +/Users/johnbackus/.gem/ruby/2.3.1/gems/rspec-core-3.5.4/lib/rspec/core/runner.rb:111:in `run_specs'
            +/Users/johnbackus/.gem/ruby/2.3.1/gems/rspec-core-3.5.4/lib/rspec/core/runner.rb:87:in `run'
            +/Users/johnbackus/.gem/ruby/2.3.1/gems/rspec-core-3.5.4/lib/rspec/core/runner.rb:71:in `run'
            +/Users/johnbackus/.gem/ruby/2.3.1/gems/rspec-core-3.5.4/lib/rspec/core/runner.rb:45:in `invoke'
            +/Users/johnbackus/.gem/ruby/2.3.1/gems/rspec-core-3.5.4/exe/rspec:4:in `<top (required)>'
            +/Users/johnbackus/.gem/ruby/2.3.1/bin/rspec:23:in `load'
            +/Users/johnbackus/.gem/ruby/2.3.1/bin/rspec:23:in `<top (required)>'
            +/Users/johnbackus/.gem/ruby/2.3.1/gems/bundler-1.13.2/lib/bundler/cli/exec.rb:74:in `load'
            +/Users/johnbackus/.gem/ruby/2.3.1/gems/bundler-1.13.2/lib/bundler/cli/exec.rb:74:in `kernel_load'
            +/Users/johnbackus/.gem/ruby/2.3.1/gems/bundler-1.13.2/lib/bundler/cli/exec.rb:27:in `run'
            +/Users/johnbackus/.gem/ruby/2.3.1/gems/bundler-1.13.2/lib/bundler/cli.rb:332:in `exec'
            +/Users/johnbackus/.gem/ruby/2.3.1/gems/bundler-1.13.2/lib/bundler/vendor/thor/lib/thor/command.rb:27:in `run'
            +/Users/johnbackus/.gem/ruby/2.3.1/gems/bundler-1.13.2/lib/bundler/vendor/thor/lib/thor/invocation.rb:126:in `invoke_command'
            +/Users/johnbackus/.gem/ruby/2.3.1/gems/bundler-1.13.2/lib/bundler/vendor/thor/lib/thor.rb:359:in `dispatch'
            +/Users/johnbackus/.gem/ruby/2.3.1/gems/bundler-1.13.2/lib/bundler/cli.rb:20:in `dispatch'
            +/Users/johnbackus/.gem/ruby/2.3.1/gems/bundler-1.13.2/lib/bundler/vendor/thor/lib/thor/base.rb:440:in `start'
            +/Users/johnbackus/.gem/ruby/2.3.1/gems/bundler-1.13.2/lib/bundler/cli.rb:11:in `start'
            +/Users/johnbackus/.gem/ruby/2.3.1/gems/bundler-1.13.2/exe/bundle:34:in `block in <top (required)>'
            +/Users/johnbackus/.gem/ruby/2.3.1/gems/bundler-1.13.2/lib/bundler/friendly_errors.rb:100:in `with_friendly_errors'
            +/Users/johnbackus/.gem/ruby/2.3.1/gems/bundler-1.13.2/exe/bundle:26:in `<top (required)>'
            +/Users/johnbackus/.gem/ruby/2.3.1/bin/bundle:23:in `load'
            +/Users/johnbackus/.gem/ruby/2.3.1/bin/bundle:23:in `<main>'

          # ./spec/rubocop/cli/cli_options_spec.rb:393:in `block (5 levels) in <top (required)>'

     1.3) Failure/Error:
            expect($stdout.string)
              .to eq(['',
                      '1  Style/IndentationWidth',
                      '1  Style/NumericLiterals',
                      '1  Style/TrailingWhitespace',
                      '--',
                      '3  Total',
                      '',
                      ''].join("\n"))

            expected: "\n1  Style/IndentationWidth\n1  Style/NumericLiterals\n1  Style/TrailingWhitespace\n--\n3  Total\n\n"
                 got: "\n--\n0  Total\n\n"

            (compared using ==)

            Diff:

            @@ -1,7 +1,4 @@

            -1  Style/IndentationWidth
            -1  Style/NumericLiterals
            -1  Style/TrailingWhitespace
             --
            -3  Total
            +0  Total

          # ./spec/rubocop/cli/cli_options_spec.rb:394:in `block (5 levels) in <top (required)>'

  2) RuboCop::CLI --except when several cops are given disables the given cops including UnneededDisable
     Got 3 failures from failure aggregation block.
     # ./spec/support/cli_spec_behavior.rb:3:in `block (2 levels) in <top (required)>'
     # ./lib/rubocop/rspec/shared_contexts.rb:27:in `block (4 levels) in <top (required)>'
     # ./lib/rubocop/rspec/shared_contexts.rb:26:in `chdir'
     # ./lib/rubocop/rspec/shared_contexts.rb:26:in `block (3 levels) in <top (required)>'
     # ./lib/rubocop/rspec/shared_contexts.rb:8:in `block (2 levels) in <top (required)>'

     2.1) Failure/Error:
            expect(cli.run(['--format', 'offenses',
                            '--except',
                            'Style/IfUnlessModifier,Style/Tab,' \
                            "Style/SpaceAroundOperators,#{cop_name}",
                            'example.rb'])).to eq(1)

            expected: 1
                 got: 2

            (compared using ==)
          # ./spec/rubocop/cli/cli_options_spec.rb:388:in `block (5 levels) in <top (required)>'

     2.2) Failure/Error: expect($stderr.string).to eq('')

            expected: ""
                 got: "An error occurred while Style/TrailingWhitespace cop was inspecting /private/var/folders/wq/h965ll7s...m/ruby/2.3.1/bin/bundle:23:in `load'\n/Users/johnbackus/.gem/ruby/2.3.1/bin/bundle:23:in `<main>'\n"

            (compared using ==)

            Diff:
            @@ -1 +1,102 @@
            +An error occurred while Style/TrailingWhitespace cop was inspecting /private/var/folders/wq/h965ll7s5bqcpzcd58b__pw00000gn/T/d20170102-5582-17m7ya6/work/example.rb.
            +To see the complete backtrace run rubocop -d.
            +An error occurred while Style/IndentationWidth cop was inspecting /private/var/folders/wq/h965ll7s5bqcpzcd58b__pw00000gn/T/d20170102-5582-17m7ya6/work/example.rb.
            +To see the complete backtrace run rubocop -d.
            +An error occurred while Style/NumericLiterals cop was inspecting /private/var/folders/wq/h965ll7s5bqcpzcd58b__pw00000gn/T/d20170102-5582-17m7ya6/work/example.rb.
            +To see the complete backtrace run rubocop -d.
            +undefined method `names' for #<Array:0x007fc389448168>
            +/Users/johnbackus/Projects/rubocop/lib/rubocop/comment_config.rb:136:in `all_cop_names'
            +/Users/johnbackus/Projects/rubocop/lib/rubocop/comment_config.rb:124:in `directive_parts'
            +/Users/johnbackus/Projects/rubocop/lib/rubocop/comment_config.rb:110:in `block in each_directive'
            +/Users/johnbackus/Projects/rubocop/lib/rubocop/comment_config.rb:109:in `each'
            +/Users/johnbackus/Projects/rubocop/lib/rubocop/comment_config.rb:109:in `each_directive'
            +/Users/johnbackus/Projects/rubocop/lib/rubocop/comment_config.rb:95:in `each_mentioned_cop'
            +/Users/johnbackus/Projects/rubocop/lib/rubocop/comment_config.rb:42:in `analyze'
            +/Users/johnbackus/Projects/rubocop/lib/rubocop/comment_config.rb:34:in `cop_disabled_line_ranges'
            +/Users/johnbackus/Projects/rubocop/lib/rubocop/processed_source.rb:44:in `disabled_line_ranges'
            +/Users/johnbackus/Projects/rubocop/lib/rubocop/runner.rb:136:in `check_for_unneded_disables?'
            +/Users/johnbackus/Projects/rubocop/lib/rubocop/runner.rb:119:in `add_unneeded_disables'
            +/Users/johnbackus/Projects/rubocop/lib/rubocop/runner.rb:102:in `block in file_offenses'
            +/Users/johnbackus/Projects/rubocop/lib/rubocop/runner.rb:111:in `file_offense_cache'
            +/Users/johnbackus/Projects/rubocop/lib/rubocop/runner.rb:99:in `file_offenses'
            +/Users/johnbackus/Projects/rubocop/lib/rubocop/runner.rb:90:in `process_file'
            +/Users/johnbackus/Projects/rubocop/lib/rubocop/runner.rb:68:in `block in each_inspected_file'
            +/Users/johnbackus/Projects/rubocop/lib/rubocop/runner.rb:65:in `each'
            +/Users/johnbackus/Projects/rubocop/lib/rubocop/runner.rb:65:in `reduce'
            +/Users/johnbackus/Projects/rubocop/lib/rubocop/runner.rb:65:in `each_inspected_file'
            +/Users/johnbackus/Projects/rubocop/lib/rubocop/runner.rb:57:in `inspect_files'
            +/Users/johnbackus/Projects/rubocop/lib/rubocop/runner.rb:36:in `run'
            +/Users/johnbackus/Projects/rubocop/lib/rubocop/cli.rb:72:in `execute_runner'
            +/Users/johnbackus/Projects/rubocop/lib/rubocop/cli.rb:27:in `run'
            +/Users/johnbackus/Projects/rubocop/spec/rubocop/cli/cli_options_spec.rb:388:in `block (5 levels) in <top (required)>'
            +/Users/johnbackus/.gem/ruby/2.3.1/gems/rspec-core-3.5.4/lib/rspec/core/example.rb:254:in `instance_exec'
            +/Users/johnbackus/.gem/ruby/2.3.1/gems/rspec-core-3.5.4/lib/rspec/core/example.rb:254:in `block in run'
            +/Users/johnbackus/.gem/ruby/2.3.1/gems/rspec-core-3.5.4/lib/rspec/core/example.rb:496:in `block in with_around_and_singleton_context_hooks'
            +/Users/johnbackus/.gem/ruby/2.3.1/gems/rspec-core-3.5.4/lib/rspec/core/example.rb:453:in `block in with_around_example_hooks'
            +/Users/johnbackus/.gem/ruby/2.3.1/gems/rspec-core-3.5.4/lib/rspec/core/hooks.rb:464:in `block in run'
            +/Users/johnbackus/.gem/ruby/2.3.1/gems/rspec-core-3.5.4/lib/rspec/core/hooks.rb:604:in `block in run_around_example_hooks_for'
            +/Users/johnbackus/.gem/ruby/2.3.1/gems/rspec-core-3.5.4/lib/rspec/core/example.rb:338:in `call'
            +/Users/johnbackus/.gem/ruby/2.3.1/gems/rspec-expectations-3.5.0/lib/rspec/expectations/failure_aggregator.rb:10:in `block in aggregate'
            +/Users/johnbackus/.gem/ruby/2.3.1/gems/rspec-support-3.5.0/lib/rspec/support.rb:103:in `with_failure_notifier'
            +/Users/johnbackus/.gem/ruby/2.3.1/gems/rspec-expectations-3.5.0/lib/rspec/expectations/failure_aggregator.rb:8:in `aggregate'
            +/Users/johnbackus/.gem/ruby/2.3.1/gems/rspec-expectations-3.5.0/lib/rspec/matchers.rb:313:in `aggregate_failures'
            +/Users/johnbackus/Projects/rubocop/spec/support/cli_spec_behavior.rb:3:in `block (2 levels) in <top (required)>'
            +/Users/johnbackus/.gem/ruby/2.3.1/gems/rspec-core-3.5.4/lib/rspec/core/example.rb:443:in `instance_exec'
            +/Users/johnbackus/.gem/ruby/2.3.1/gems/rspec-core-3.5.4/lib/rspec/core/example.rb:443:in `instance_exec'
            +/Users/johnbackus/.gem/ruby/2.3.1/gems/rspec-core-3.5.4/lib/rspec/core/hooks.rb:375:in `execute_with'
            +/Users/johnbackus/.gem/ruby/2.3.1/gems/rspec-core-3.5.4/lib/rspec/core/hooks.rb:606:in `block (2 levels) in run_around_example_hooks_for'
            +/Users/johnbackus/.gem/ruby/2.3.1/gems/rspec-core-3.5.4/lib/rspec/core/example.rb:338:in `call'
            +/Users/johnbackus/Projects/rubocop/lib/rubocop/rspec/shared_contexts.rb:27:in `block (4 levels) in <top (required)>'
            +/Users/johnbackus/Projects/rubocop/lib/rubocop/rspec/shared_contexts.rb:26:in `chdir'
            +/Users/johnbackus/Projects/rubocop/lib/rubocop/rspec/shared_contexts.rb:26:in `block (3 levels) in <top (required)>'
            +/Users/johnbackus/.rubies/ruby-2.3.1/lib/ruby/2.3.0/tmpdir.rb:89:in `mktmpdir'
            +/Users/johnbackus/Projects/rubocop/lib/rubocop/rspec/shared_contexts.rb:8:in `block (2 levels) in <top (required)>'
            +/Users/johnbackus/.gem/ruby/2.3.1/gems/rspec-core-3.5.4/lib/rspec/core/example.rb:443:in `instance_exec'
            +/Users/johnbackus/.gem/ruby/2.3.1/gems/rspec-core-3.5.4/lib/rspec/core/example.rb:443:in `instance_exec'
            +/Users/johnbackus/.gem/ruby/2.3.1/gems/rspec-core-3.5.4/lib/rspec/core/hooks.rb:375:in `execute_with'
            +/Users/johnbackus/.gem/ruby/2.3.1/gems/rspec-core-3.5.4/lib/rspec/core/hooks.rb:606:in `block (2 levels) in run_around_example_hooks_for'
            +/Users/johnbackus/.gem/ruby/2.3.1/gems/rspec-core-3.5.4/lib/rspec/core/example.rb:338:in `call'
            +/Users/johnbackus/.gem/ruby/2.3.1/gems/rspec-core-3.5.4/lib/rspec/core/hooks.rb:607:in `run_around_example_hooks_for'
            +/Users/johnbackus/.gem/ruby/2.3.1/gems/rspec-core-3.5.4/lib/rspec/core/hooks.rb:464:in `run'
            +/Users/johnbackus/.gem/ruby/2.3.1/gems/rspec-core-3.5.4/lib/rspec/core/example.rb:453:in `with_around_example_hooks'
            +/Users/johnbackus/.gem/ruby/2.3.1/gems/rspec-core-3.5.4/lib/rspec/core/example.rb:496:in `with_around_and_singleton_context_hooks'
            +/Users/johnbackus/.gem/ruby/2.3.1/gems/rspec-core-3.5.4/lib/rspec/core/example.rb:251:in `run'
            +/Users/johnbackus/.gem/ruby/2.3.1/gems/rspec-core-3.5.4/lib/rspec/core/example_group.rb:627:in `block in run_examples'
            +/Users/johnbackus/.gem/ruby/2.3.1/gems/rspec-core-3.5.4/lib/rspec/core/example_group.rb:623:in `map'
            +/Users/johnbackus/.gem/ruby/2.3.1/gems/rspec-core-3.5.4/lib/rspec/core/example_group.rb:623:in `run_examples'
            +/Users/johnbackus/.gem/ruby/2.3.1/gems/rspec-core-3.5.4/lib/rspec/core/example_group.rb:589:in `run'
            +/Users/johnbackus/.gem/ruby/2.3.1/gems/rspec-core-3.5.4/lib/rspec/core/example_group.rb:590:in `block in run'
            +/Users/johnbackus/.gem/ruby/2.3.1/gems/rspec-core-3.5.4/lib/rspec/core/example_group.rb:590:in `map'
            +/Users/johnbackus/.gem/ruby/2.3.1/gems/rspec-core-3.5.4/lib/rspec/core/example_group.rb:590:in `run'
            +/Users/johnbackus/.gem/ruby/2.3.1/gems/rspec-core-3.5.4/lib/rspec/core/example_group.rb:590:in `block in run'
            +/Users/johnbackus/.gem/ruby/2.3.1/gems/rspec-core-3.5.4/lib/rspec/core/example_group.rb:590:in `map'
            +/Users/johnbackus/.gem/ruby/2.3.1/gems/rspec-core-3.5.4/lib/rspec/core/example_group.rb:590:in `run'
            +/Users/johnbackus/.gem/ruby/2.3.1/gems/rspec-core-3.5.4/lib/rspec/core/runner.rb:113:in `block (3 levels) in run_specs'
            +/Users/johnbackus/.gem/ruby/2.3.1/gems/rspec-core-3.5.4/lib/rspec/core/runner.rb:113:in `map'
            +/Users/johnbackus/.gem/ruby/2.3.1/gems/rspec-core-3.5.4/lib/rspec/core/runner.rb:113:in `block (2 levels) in run_specs'
            +/Users/johnbackus/.gem/ruby/2.3.1/gems/rspec-core-3.5.4/lib/rspec/core/configuration.rb:1835:in `with_suite_hooks'
            +/Users/johnbackus/.gem/ruby/2.3.1/gems/rspec-core-3.5.4/lib/rspec/core/runner.rb:112:in `block in run_specs'
            +/Users/johnbackus/.gem/ruby/2.3.1/gems/rspec-core-3.5.4/lib/rspec/core/reporter.rb:77:in `report'
            +/Users/johnbackus/.gem/ruby/2.3.1/gems/rspec-core-3.5.4/lib/rspec/core/runner.rb:111:in `run_specs'
            +/Users/johnbackus/.gem/ruby/2.3.1/gems/rspec-core-3.5.4/lib/rspec/core/runner.rb:87:in `run'
            +/Users/johnbackus/.gem/ruby/2.3.1/gems/rspec-core-3.5.4/lib/rspec/core/runner.rb:71:in `run'
            +/Users/johnbackus/.gem/ruby/2.3.1/gems/rspec-core-3.5.4/lib/rspec/core/runner.rb:45:in `invoke'
            +/Users/johnbackus/.gem/ruby/2.3.1/gems/rspec-core-3.5.4/exe/rspec:4:in `<top (required)>'
            +/Users/johnbackus/.gem/ruby/2.3.1/bin/rspec:23:in `load'
            +/Users/johnbackus/.gem/ruby/2.3.1/bin/rspec:23:in `<top (required)>'
            +/Users/johnbackus/.gem/ruby/2.3.1/gems/bundler-1.13.2/lib/bundler/cli/exec.rb:74:in `load'
            +/Users/johnbackus/.gem/ruby/2.3.1/gems/bundler-1.13.2/lib/bundler/cli/exec.rb:74:in `kernel_load'
            +/Users/johnbackus/.gem/ruby/2.3.1/gems/bundler-1.13.2/lib/bundler/cli/exec.rb:27:in `run'
            +/Users/johnbackus/.gem/ruby/2.3.1/gems/bundler-1.13.2/lib/bundler/cli.rb:332:in `exec'
            +/Users/johnbackus/.gem/ruby/2.3.1/gems/bundler-1.13.2/lib/bundler/vendor/thor/lib/thor/command.rb:27:in `run'
            +/Users/johnbackus/.gem/ruby/2.3.1/gems/bundler-1.13.2/lib/bundler/vendor/thor/lib/thor/invocation.rb:126:in `invoke_command'
            +/Users/johnbackus/.gem/ruby/2.3.1/gems/bundler-1.13.2/lib/bundler/vendor/thor/lib/thor.rb:359:in `dispatch'
            +/Users/johnbackus/.gem/ruby/2.3.1/gems/bundler-1.13.2/lib/bundler/cli.rb:20:in `dispatch'
            +/Users/johnbackus/.gem/ruby/2.3.1/gems/bundler-1.13.2/lib/bundler/vendor/thor/lib/thor/base.rb:440:in `start'
            +/Users/johnbackus/.gem/ruby/2.3.1/gems/bundler-1.13.2/lib/bundler/cli.rb:11:in `start'
            +/Users/johnbackus/.gem/ruby/2.3.1/gems/bundler-1.13.2/exe/bundle:34:in `block in <top (required)>'
            +/Users/johnbackus/.gem/ruby/2.3.1/gems/bundler-1.13.2/lib/bundler/friendly_errors.rb:100:in `with_friendly_errors'
            +/Users/johnbackus/.gem/ruby/2.3.1/gems/bundler-1.13.2/exe/bundle:26:in `<top (required)>'
            +/Users/johnbackus/.gem/ruby/2.3.1/bin/bundle:23:in `load'
            +/Users/johnbackus/.gem/ruby/2.3.1/bin/bundle:23:in `<main>'

          # ./spec/rubocop/cli/cli_options_spec.rb:393:in `block (5 levels) in <top (required)>'

     2.3) Failure/Error:
            expect($stdout.string)
              .to eq(['',
                      '1  Style/IndentationWidth',
                      '1  Style/NumericLiterals',
                      '1  Style/TrailingWhitespace',
                      '--',
                      '3  Total',
                      '',
                      ''].join("\n"))

            expected: "\n1  Style/IndentationWidth\n1  Style/NumericLiterals\n1  Style/TrailingWhitespace\n--\n3  Total\n\n"
                 got: "\n--\n0  Total\n\n"

            (compared using ==)

            Diff:

            @@ -1,7 +1,4 @@

            -1  Style/IndentationWidth
            -1  Style/NumericLiterals
            -1  Style/TrailingWhitespace
             --
            -3  Total
            +0  Total

          # ./spec/rubocop/cli/cli_options_spec.rb:394:in `block (5 levels) in <top (required)>'

  3) RuboCop::CLI --except when several cops are given disables the given cops including Lint/UnneededDisable
     Got 3 failures from failure aggregation block.
     # ./spec/support/cli_spec_behavior.rb:3:in `block (2 levels) in <top (required)>'
     # ./lib/rubocop/rspec/shared_contexts.rb:27:in `block (4 levels) in <top (required)>'
     # ./lib/rubocop/rspec/shared_contexts.rb:26:in `chdir'
     # ./lib/rubocop/rspec/shared_contexts.rb:26:in `block (3 levels) in <top (required)>'
     # ./lib/rubocop/rspec/shared_contexts.rb:8:in `block (2 levels) in <top (required)>'

     3.1) Failure/Error:
            expect(cli.run(['--format', 'offenses',
                            '--except',
                            'Style/IfUnlessModifier,Style/Tab,' \
                            "Style/SpaceAroundOperators,#{cop_name}",
                            'example.rb'])).to eq(1)

            expected: 1
                 got: 2

            (compared using ==)
          # ./spec/rubocop/cli/cli_options_spec.rb:388:in `block (5 levels) in <top (required)>'

     3.2) Failure/Error: expect($stderr.string).to eq('')

            expected: ""
                 got: "An error occurred while Style/TrailingWhitespace cop was inspecting /private/var/folders/wq/h965ll7s...m/ruby/2.3.1/bin/bundle:23:in `load'\n/Users/johnbackus/.gem/ruby/2.3.1/bin/bundle:23:in `<main>'\n"

            (compared using ==)

            Diff:
            @@ -1 +1,102 @@
            +An error occurred while Style/TrailingWhitespace cop was inspecting /private/var/folders/wq/h965ll7s5bqcpzcd58b__pw00000gn/T/d20170102-5582-1xe95ql/work/example.rb.
            +To see the complete backtrace run rubocop -d.
            +An error occurred while Style/IndentationWidth cop was inspecting /private/var/folders/wq/h965ll7s5bqcpzcd58b__pw00000gn/T/d20170102-5582-1xe95ql/work/example.rb.
            +To see the complete backtrace run rubocop -d.
            +An error occurred while Style/NumericLiterals cop was inspecting /private/var/folders/wq/h965ll7s5bqcpzcd58b__pw00000gn/T/d20170102-5582-1xe95ql/work/example.rb.
            +To see the complete backtrace run rubocop -d.
            +undefined method `names' for #<Array:0x007fc38beb4ed8>
            +/Users/johnbackus/Projects/rubocop/lib/rubocop/comment_config.rb:136:in `all_cop_names'
            +/Users/johnbackus/Projects/rubocop/lib/rubocop/comment_config.rb:124:in `directive_parts'
            +/Users/johnbackus/Projects/rubocop/lib/rubocop/comment_config.rb:110:in `block in each_directive'
            +/Users/johnbackus/Projects/rubocop/lib/rubocop/comment_config.rb:109:in `each'
            +/Users/johnbackus/Projects/rubocop/lib/rubocop/comment_config.rb:109:in `each_directive'
            +/Users/johnbackus/Projects/rubocop/lib/rubocop/comment_config.rb:95:in `each_mentioned_cop'
            +/Users/johnbackus/Projects/rubocop/lib/rubocop/comment_config.rb:42:in `analyze'
            +/Users/johnbackus/Projects/rubocop/lib/rubocop/comment_config.rb:34:in `cop_disabled_line_ranges'
            +/Users/johnbackus/Projects/rubocop/lib/rubocop/processed_source.rb:44:in `disabled_line_ranges'
            +/Users/johnbackus/Projects/rubocop/lib/rubocop/runner.rb:136:in `check_for_unneded_disables?'
            +/Users/johnbackus/Projects/rubocop/lib/rubocop/runner.rb:119:in `add_unneeded_disables'
            +/Users/johnbackus/Projects/rubocop/lib/rubocop/runner.rb:102:in `block in file_offenses'
            +/Users/johnbackus/Projects/rubocop/lib/rubocop/runner.rb:111:in `file_offense_cache'
            +/Users/johnbackus/Projects/rubocop/lib/rubocop/runner.rb:99:in `file_offenses'
            +/Users/johnbackus/Projects/rubocop/lib/rubocop/runner.rb:90:in `process_file'
            +/Users/johnbackus/Projects/rubocop/lib/rubocop/runner.rb:68:in `block in each_inspected_file'
            +/Users/johnbackus/Projects/rubocop/lib/rubocop/runner.rb:65:in `each'
            +/Users/johnbackus/Projects/rubocop/lib/rubocop/runner.rb:65:in `reduce'
            +/Users/johnbackus/Projects/rubocop/lib/rubocop/runner.rb:65:in `each_inspected_file'
            +/Users/johnbackus/Projects/rubocop/lib/rubocop/runner.rb:57:in `inspect_files'
            +/Users/johnbackus/Projects/rubocop/lib/rubocop/runner.rb:36:in `run'
            +/Users/johnbackus/Projects/rubocop/lib/rubocop/cli.rb:72:in `execute_runner'
            +/Users/johnbackus/Projects/rubocop/lib/rubocop/cli.rb:27:in `run'
            +/Users/johnbackus/Projects/rubocop/spec/rubocop/cli/cli_options_spec.rb:388:in `block (5 levels) in <top (required)>'
            +/Users/johnbackus/.gem/ruby/2.3.1/gems/rspec-core-3.5.4/lib/rspec/core/example.rb:254:in `instance_exec'
            +/Users/johnbackus/.gem/ruby/2.3.1/gems/rspec-core-3.5.4/lib/rspec/core/example.rb:254:in `block in run'
            +/Users/johnbackus/.gem/ruby/2.3.1/gems/rspec-core-3.5.4/lib/rspec/core/example.rb:496:in `block in with_around_and_singleton_context_hooks'
            +/Users/johnbackus/.gem/ruby/2.3.1/gems/rspec-core-3.5.4/lib/rspec/core/example.rb:453:in `block in with_around_example_hooks'
            +/Users/johnbackus/.gem/ruby/2.3.1/gems/rspec-core-3.5.4/lib/rspec/core/hooks.rb:464:in `block in run'
            +/Users/johnbackus/.gem/ruby/2.3.1/gems/rspec-core-3.5.4/lib/rspec/core/hooks.rb:604:in `block in run_around_example_hooks_for'
            +/Users/johnbackus/.gem/ruby/2.3.1/gems/rspec-core-3.5.4/lib/rspec/core/example.rb:338:in `call'
            +/Users/johnbackus/.gem/ruby/2.3.1/gems/rspec-expectations-3.5.0/lib/rspec/expectations/failure_aggregator.rb:10:in `block in aggregate'
            +/Users/johnbackus/.gem/ruby/2.3.1/gems/rspec-support-3.5.0/lib/rspec/support.rb:103:in `with_failure_notifier'
            +/Users/johnbackus/.gem/ruby/2.3.1/gems/rspec-expectations-3.5.0/lib/rspec/expectations/failure_aggregator.rb:8:in `aggregate'
            +/Users/johnbackus/.gem/ruby/2.3.1/gems/rspec-expectations-3.5.0/lib/rspec/matchers.rb:313:in `aggregate_failures'
            +/Users/johnbackus/Projects/rubocop/spec/support/cli_spec_behavior.rb:3:in `block (2 levels) in <top (required)>'
            +/Users/johnbackus/.gem/ruby/2.3.1/gems/rspec-core-3.5.4/lib/rspec/core/example.rb:443:in `instance_exec'
            +/Users/johnbackus/.gem/ruby/2.3.1/gems/rspec-core-3.5.4/lib/rspec/core/example.rb:443:in `instance_exec'
            +/Users/johnbackus/.gem/ruby/2.3.1/gems/rspec-core-3.5.4/lib/rspec/core/hooks.rb:375:in `execute_with'
            +/Users/johnbackus/.gem/ruby/2.3.1/gems/rspec-core-3.5.4/lib/rspec/core/hooks.rb:606:in `block (2 levels) in run_around_example_hooks_for'
            +/Users/johnbackus/.gem/ruby/2.3.1/gems/rspec-core-3.5.4/lib/rspec/core/example.rb:338:in `call'
            +/Users/johnbackus/Projects/rubocop/lib/rubocop/rspec/shared_contexts.rb:27:in `block (4 levels) in <top (required)>'
            +/Users/johnbackus/Projects/rubocop/lib/rubocop/rspec/shared_contexts.rb:26:in `chdir'
            +/Users/johnbackus/Projects/rubocop/lib/rubocop/rspec/shared_contexts.rb:26:in `block (3 levels) in <top (required)>'
            +/Users/johnbackus/.rubies/ruby-2.3.1/lib/ruby/2.3.0/tmpdir.rb:89:in `mktmpdir'
            +/Users/johnbackus/Projects/rubocop/lib/rubocop/rspec/shared_contexts.rb:8:in `block (2 levels) in <top (required)>'
            +/Users/johnbackus/.gem/ruby/2.3.1/gems/rspec-core-3.5.4/lib/rspec/core/example.rb:443:in `instance_exec'
            +/Users/johnbackus/.gem/ruby/2.3.1/gems/rspec-core-3.5.4/lib/rspec/core/example.rb:443:in `instance_exec'
            +/Users/johnbackus/.gem/ruby/2.3.1/gems/rspec-core-3.5.4/lib/rspec/core/hooks.rb:375:in `execute_with'
            +/Users/johnbackus/.gem/ruby/2.3.1/gems/rspec-core-3.5.4/lib/rspec/core/hooks.rb:606:in `block (2 levels) in run_around_example_hooks_for'
            +/Users/johnbackus/.gem/ruby/2.3.1/gems/rspec-core-3.5.4/lib/rspec/core/example.rb:338:in `call'
            +/Users/johnbackus/.gem/ruby/2.3.1/gems/rspec-core-3.5.4/lib/rspec/core/hooks.rb:607:in `run_around_example_hooks_for'
            +/Users/johnbackus/.gem/ruby/2.3.1/gems/rspec-core-3.5.4/lib/rspec/core/hooks.rb:464:in `run'
            +/Users/johnbackus/.gem/ruby/2.3.1/gems/rspec-core-3.5.4/lib/rspec/core/example.rb:453:in `with_around_example_hooks'
            +/Users/johnbackus/.gem/ruby/2.3.1/gems/rspec-core-3.5.4/lib/rspec/core/example.rb:496:in `with_around_and_singleton_context_hooks'
            +/Users/johnbackus/.gem/ruby/2.3.1/gems/rspec-core-3.5.4/lib/rspec/core/example.rb:251:in `run'
            +/Users/johnbackus/.gem/ruby/2.3.1/gems/rspec-core-3.5.4/lib/rspec/core/example_group.rb:627:in `block in run_examples'
            +/Users/johnbackus/.gem/ruby/2.3.1/gems/rspec-core-3.5.4/lib/rspec/core/example_group.rb:623:in `map'
            +/Users/johnbackus/.gem/ruby/2.3.1/gems/rspec-core-3.5.4/lib/rspec/core/example_group.rb:623:in `run_examples'
            +/Users/johnbackus/.gem/ruby/2.3.1/gems/rspec-core-3.5.4/lib/rspec/core/example_group.rb:589:in `run'
            +/Users/johnbackus/.gem/ruby/2.3.1/gems/rspec-core-3.5.4/lib/rspec/core/example_group.rb:590:in `block in run'
            +/Users/johnbackus/.gem/ruby/2.3.1/gems/rspec-core-3.5.4/lib/rspec/core/example_group.rb:590:in `map'
            +/Users/johnbackus/.gem/ruby/2.3.1/gems/rspec-core-3.5.4/lib/rspec/core/example_group.rb:590:in `run'
            +/Users/johnbackus/.gem/ruby/2.3.1/gems/rspec-core-3.5.4/lib/rspec/core/example_group.rb:590:in `block in run'
            +/Users/johnbackus/.gem/ruby/2.3.1/gems/rspec-core-3.5.4/lib/rspec/core/example_group.rb:590:in `map'
            +/Users/johnbackus/.gem/ruby/2.3.1/gems/rspec-core-3.5.4/lib/rspec/core/example_group.rb:590:in `run'
            +/Users/johnbackus/.gem/ruby/2.3.1/gems/rspec-core-3.5.4/lib/rspec/core/runner.rb:113:in `block (3 levels) in run_specs'
            +/Users/johnbackus/.gem/ruby/2.3.1/gems/rspec-core-3.5.4/lib/rspec/core/runner.rb:113:in `map'
            +/Users/johnbackus/.gem/ruby/2.3.1/gems/rspec-core-3.5.4/lib/rspec/core/runner.rb:113:in `block (2 levels) in run_specs'
            +/Users/johnbackus/.gem/ruby/2.3.1/gems/rspec-core-3.5.4/lib/rspec/core/configuration.rb:1835:in `with_suite_hooks'
            +/Users/johnbackus/.gem/ruby/2.3.1/gems/rspec-core-3.5.4/lib/rspec/core/runner.rb:112:in `block in run_specs'
            +/Users/johnbackus/.gem/ruby/2.3.1/gems/rspec-core-3.5.4/lib/rspec/core/reporter.rb:77:in `report'
            +/Users/johnbackus/.gem/ruby/2.3.1/gems/rspec-core-3.5.4/lib/rspec/core/runner.rb:111:in `run_specs'
            +/Users/johnbackus/.gem/ruby/2.3.1/gems/rspec-core-3.5.4/lib/rspec/core/runner.rb:87:in `run'
            +/Users/johnbackus/.gem/ruby/2.3.1/gems/rspec-core-3.5.4/lib/rspec/core/runner.rb:71:in `run'
            +/Users/johnbackus/.gem/ruby/2.3.1/gems/rspec-core-3.5.4/lib/rspec/core/runner.rb:45:in `invoke'
            +/Users/johnbackus/.gem/ruby/2.3.1/gems/rspec-core-3.5.4/exe/rspec:4:in `<top (required)>'
            +/Users/johnbackus/.gem/ruby/2.3.1/bin/rspec:23:in `load'
            +/Users/johnbackus/.gem/ruby/2.3.1/bin/rspec:23:in `<top (required)>'
            +/Users/johnbackus/.gem/ruby/2.3.1/gems/bundler-1.13.2/lib/bundler/cli/exec.rb:74:in `load'
            +/Users/johnbackus/.gem/ruby/2.3.1/gems/bundler-1.13.2/lib/bundler/cli/exec.rb:74:in `kernel_load'
            +/Users/johnbackus/.gem/ruby/2.3.1/gems/bundler-1.13.2/lib/bundler/cli/exec.rb:27:in `run'
            +/Users/johnbackus/.gem/ruby/2.3.1/gems/bundler-1.13.2/lib/bundler/cli.rb:332:in `exec'
            +/Users/johnbackus/.gem/ruby/2.3.1/gems/bundler-1.13.2/lib/bundler/vendor/thor/lib/thor/command.rb:27:in `run'
            +/Users/johnbackus/.gem/ruby/2.3.1/gems/bundler-1.13.2/lib/bundler/vendor/thor/lib/thor/invocation.rb:126:in `invoke_command'
            +/Users/johnbackus/.gem/ruby/2.3.1/gems/bundler-1.13.2/lib/bundler/vendor/thor/lib/thor.rb:359:in `dispatch'
            +/Users/johnbackus/.gem/ruby/2.3.1/gems/bundler-1.13.2/lib/bundler/cli.rb:20:in `dispatch'
            +/Users/johnbackus/.gem/ruby/2.3.1/gems/bundler-1.13.2/lib/bundler/vendor/thor/lib/thor/base.rb:440:in `start'
            +/Users/johnbackus/.gem/ruby/2.3.1/gems/bundler-1.13.2/lib/bundler/cli.rb:11:in `start'
            +/Users/johnbackus/.gem/ruby/2.3.1/gems/bundler-1.13.2/exe/bundle:34:in `block in <top (required)>'
            +/Users/johnbackus/.gem/ruby/2.3.1/gems/bundler-1.13.2/lib/bundler/friendly_errors.rb:100:in `with_friendly_errors'
            +/Users/johnbackus/.gem/ruby/2.3.1/gems/bundler-1.13.2/exe/bundle:26:in `<top (required)>'
            +/Users/johnbackus/.gem/ruby/2.3.1/bin/bundle:23:in `load'
            +/Users/johnbackus/.gem/ruby/2.3.1/bin/bundle:23:in `<main>'

          # ./spec/rubocop/cli/cli_options_spec.rb:393:in `block (5 levels) in <top (required)>'

     3.3) Failure/Error:
            expect($stdout.string)
              .to eq(['',
                      '1  Style/IndentationWidth',
                      '1  Style/NumericLiterals',
                      '1  Style/TrailingWhitespace',
                      '--',
                      '3  Total',
                      '',
                      ''].join("\n"))

            expected: "\n1  Style/IndentationWidth\n1  Style/NumericLiterals\n1  Style/TrailingWhitespace\n--\n3  Total\n\n"
                 got: "\n--\n0  Total\n\n"

            (compared using ==)

            Diff:

            @@ -1,7 +1,4 @@

            -1  Style/IndentationWidth
            -1  Style/NumericLiterals
            -1  Style/TrailingWhitespace
             --
            -3  Total
            +0  Total

          # ./spec/rubocop/cli/cli_options_spec.rb:394:in `block (5 levels) in <top (required)>'

  4) RuboCop::CLI rubocop:disable comment can disable all cops on a single line
     Failure/Error: expect(cli.run(['--format', 'emacs', 'example.rb'])).to eq(0)

       expected: 0
            got: 2

       (compared using ==)
     # ./spec/rubocop/cli_spec.rb:312:in `block (3 levels) in <top (required)>'
     # ./spec/support/cli_spec_behavior.rb:3:in `block (2 levels) in <top (required)>'
     # ./lib/rubocop/rspec/shared_contexts.rb:27:in `block (4 levels) in <top (required)>'
     # ./lib/rubocop/rspec/shared_contexts.rb:26:in `chdir'
     # ./lib/rubocop/rspec/shared_contexts.rb:26:in `block (3 levels) in <top (required)>'
     # ./lib/rubocop/rspec/shared_contexts.rb:8:in `block (2 levels) in <top (required)>'

  5) RuboCop::CLI rubocop:disable comment can disable all cops in a code section
     Got 2 failures from failure aggregation block.
     # ./spec/support/cli_spec_behavior.rb:3:in `block (2 levels) in <top (required)>'
     # ./lib/rubocop/rspec/shared_contexts.rb:27:in `block (4 levels) in <top (required)>'
     # ./lib/rubocop/rspec/shared_contexts.rb:26:in `chdir'
     # ./lib/rubocop/rspec/shared_contexts.rb:26:in `block (3 levels) in <top (required)>'
     # ./lib/rubocop/rspec/shared_contexts.rb:8:in `block (2 levels) in <top (required)>'

     5.1) Failure/Error: expect(cli.run(['--format', 'emacs', 'example.rb'])).to eq(1)

            expected: 1
                 got: 2

            (compared using ==)
          # ./spec/rubocop/cli_spec.rb:249:in `block (3 levels) in <top (required)>'

     5.2) Failure/Error:
            expect($stdout.string)
              .to eq(["#{abs('example.rb')}:7:81: C: Line is too long. [95/80]",
                      "#{abs('example.rb')}:9:5: C: Prefer single-quoted " \
                      "strings when you don't need string interpolation or " \
                      'special symbols.',
                      ''].join("\n"))

            expected: "/private/var/folders/wq/h965ll7s5bqcpzcd58b__pw00000gn/T/d20170102-5582-1iwyvc5/work/example.rb:7:81...9:5: C: Prefer single-quoted strings when you don't need string interpolation or special symbols.\n"
                 got: ""

            (compared using ==)

            Diff:
            @@ -1,3 +1 @@
            -/private/var/folders/wq/h965ll7s5bqcpzcd58b__pw00000gn/T/d20170102-5582-1iwyvc5/work/example.rb:7:81: C: Line is too long. [95/80]
            -/private/var/folders/wq/h965ll7s5bqcpzcd58b__pw00000gn/T/d20170102-5582-1iwyvc5/work/example.rb:9:5: C: Prefer single-quoted strings when you don't need string interpolation or special symbols.

          # ./spec/rubocop/cli_spec.rb:252:in `block (3 levels) in <top (required)>'

  6) RuboCop::CLI rubocop:disable comment when not necessary causes an offense to be reported
     Got 3 failures from failure aggregation block.
     # ./spec/support/cli_spec_behavior.rb:3:in `block (2 levels) in <top (required)>'
     # ./lib/rubocop/rspec/shared_contexts.rb:27:in `block (4 levels) in <top (required)>'
     # ./lib/rubocop/rspec/shared_contexts.rb:26:in `chdir'
     # ./lib/rubocop/rspec/shared_contexts.rb:26:in `block (3 levels) in <top (required)>'
     # ./lib/rubocop/rspec/shared_contexts.rb:8:in `block (2 levels) in <top (required)>'

     6.1) Failure/Error: expect(cli.run(['--format', 'emacs', 'example.rb'])).to eq(1)

            expected: 1
                 got: 2

            (compared using ==)
          # ./spec/rubocop/cli_spec.rb:348:in `block (4 levels) in <top (required)>'

     6.2) Failure/Error: expect($stderr.string).to eq('')

            expected: ""
                 got: "An error occurred while Metrics/LineLength cop was inspecting /private/var/folders/wq/h965ll7s5bqcpz...m/ruby/2.3.1/bin/bundle:23:in `load'\n/Users/johnbackus/.gem/ruby/2.3.1/bin/bundle:23:in `<main>'\n"

            (compared using ==)

            Diff:
            @@ -1 +1,98 @@
            +An error occurred while Metrics/LineLength cop was inspecting /private/var/folders/wq/h965ll7s5bqcpzcd58b__pw00000gn/T/d20170102-5582-na7xni/work/example.rb.
            +To see the complete backtrace run rubocop -d.
            +undefined method `names' for #<Array:0x007fc38bc369b8>
            +/Users/johnbackus/Projects/rubocop/lib/rubocop/comment_config.rb:136:in `all_cop_names'
            +/Users/johnbackus/Projects/rubocop/lib/rubocop/comment_config.rb:124:in `directive_parts'
            +/Users/johnbackus/Projects/rubocop/lib/rubocop/comment_config.rb:110:in `block in each_directive'
            +/Users/johnbackus/Projects/rubocop/lib/rubocop/comment_config.rb:109:in `each'
            +/Users/johnbackus/Projects/rubocop/lib/rubocop/comment_config.rb:109:in `each_directive'
            +/Users/johnbackus/Projects/rubocop/lib/rubocop/comment_config.rb:95:in `each_mentioned_cop'
            +/Users/johnbackus/Projects/rubocop/lib/rubocop/comment_config.rb:42:in `analyze'
            +/Users/johnbackus/Projects/rubocop/lib/rubocop/comment_config.rb:34:in `cop_disabled_line_ranges'
            +/Users/johnbackus/Projects/rubocop/lib/rubocop/processed_source.rb:44:in `disabled_line_ranges'
            +/Users/johnbackus/Projects/rubocop/lib/rubocop/runner.rb:136:in `check_for_unneded_disables?'
            +/Users/johnbackus/Projects/rubocop/lib/rubocop/runner.rb:119:in `add_unneeded_disables'
            +/Users/johnbackus/Projects/rubocop/lib/rubocop/runner.rb:102:in `block in file_offenses'
            +/Users/johnbackus/Projects/rubocop/lib/rubocop/runner.rb:111:in `file_offense_cache'
            +/Users/johnbackus/Projects/rubocop/lib/rubocop/runner.rb:99:in `file_offenses'
            +/Users/johnbackus/Projects/rubocop/lib/rubocop/runner.rb:90:in `process_file'
            +/Users/johnbackus/Projects/rubocop/lib/rubocop/runner.rb:68:in `block in each_inspected_file'
            +/Users/johnbackus/Projects/rubocop/lib/rubocop/runner.rb:65:in `each'
            +/Users/johnbackus/Projects/rubocop/lib/rubocop/runner.rb:65:in `reduce'
            +/Users/johnbackus/Projects/rubocop/lib/rubocop/runner.rb:65:in `each_inspected_file'
            +/Users/johnbackus/Projects/rubocop/lib/rubocop/runner.rb:57:in `inspect_files'
            +/Users/johnbackus/Projects/rubocop/lib/rubocop/runner.rb:36:in `run'
            +/Users/johnbackus/Projects/rubocop/lib/rubocop/cli.rb:72:in `execute_runner'
            +/Users/johnbackus/Projects/rubocop/lib/rubocop/cli.rb:27:in `run'
            +/Users/johnbackus/Projects/rubocop/spec/rubocop/cli_spec.rb:348:in `block (4 levels) in <top (required)>'
            +/Users/johnbackus/.gem/ruby/2.3.1/gems/rspec-core-3.5.4/lib/rspec/core/example.rb:254:in `instance_exec'
            +/Users/johnbackus/.gem/ruby/2.3.1/gems/rspec-core-3.5.4/lib/rspec/core/example.rb:254:in `block in run'
            +/Users/johnbackus/.gem/ruby/2.3.1/gems/rspec-core-3.5.4/lib/rspec/core/example.rb:496:in `block in with_around_and_singleton_context_hooks'
            +/Users/johnbackus/.gem/ruby/2.3.1/gems/rspec-core-3.5.4/lib/rspec/core/example.rb:453:in `block in with_around_example_hooks'
            +/Users/johnbackus/.gem/ruby/2.3.1/gems/rspec-core-3.5.4/lib/rspec/core/hooks.rb:464:in `block in run'
            +/Users/johnbackus/.gem/ruby/2.3.1/gems/rspec-core-3.5.4/lib/rspec/core/hooks.rb:604:in `block in run_around_example_hooks_for'
            +/Users/johnbackus/.gem/ruby/2.3.1/gems/rspec-core-3.5.4/lib/rspec/core/example.rb:338:in `call'
            +/Users/johnbackus/.gem/ruby/2.3.1/gems/rspec-expectations-3.5.0/lib/rspec/expectations/failure_aggregator.rb:10:in `block in aggregate'
            +/Users/johnbackus/.gem/ruby/2.3.1/gems/rspec-support-3.5.0/lib/rspec/support.rb:103:in `with_failure_notifier'
            +/Users/johnbackus/.gem/ruby/2.3.1/gems/rspec-expectations-3.5.0/lib/rspec/expectations/failure_aggregator.rb:8:in `aggregate'
            +/Users/johnbackus/.gem/ruby/2.3.1/gems/rspec-expectations-3.5.0/lib/rspec/matchers.rb:313:in `aggregate_failures'
            +/Users/johnbackus/Projects/rubocop/spec/support/cli_spec_behavior.rb:3:in `block (2 levels) in <top (required)>'
            +/Users/johnbackus/.gem/ruby/2.3.1/gems/rspec-core-3.5.4/lib/rspec/core/example.rb:443:in `instance_exec'
            +/Users/johnbackus/.gem/ruby/2.3.1/gems/rspec-core-3.5.4/lib/rspec/core/example.rb:443:in `instance_exec'
            +/Users/johnbackus/.gem/ruby/2.3.1/gems/rspec-core-3.5.4/lib/rspec/core/hooks.rb:375:in `execute_with'
            +/Users/johnbackus/.gem/ruby/2.3.1/gems/rspec-core-3.5.4/lib/rspec/core/hooks.rb:606:in `block (2 levels) in run_around_example_hooks_for'
            +/Users/johnbackus/.gem/ruby/2.3.1/gems/rspec-core-3.5.4/lib/rspec/core/example.rb:338:in `call'
            +/Users/johnbackus/Projects/rubocop/lib/rubocop/rspec/shared_contexts.rb:27:in `block (4 levels) in <top (required)>'
            +/Users/johnbackus/Projects/rubocop/lib/rubocop/rspec/shared_contexts.rb:26:in `chdir'
            +/Users/johnbackus/Projects/rubocop/lib/rubocop/rspec/shared_contexts.rb:26:in `block (3 levels) in <top (required)>'
            +/Users/johnbackus/.rubies/ruby-2.3.1/lib/ruby/2.3.0/tmpdir.rb:89:in `mktmpdir'
            +/Users/johnbackus/Projects/rubocop/lib/rubocop/rspec/shared_contexts.rb:8:in `block (2 levels) in <top (required)>'
            +/Users/johnbackus/.gem/ruby/2.3.1/gems/rspec-core-3.5.4/lib/rspec/core/example.rb:443:in `instance_exec'
            +/Users/johnbackus/.gem/ruby/2.3.1/gems/rspec-core-3.5.4/lib/rspec/core/example.rb:443:in `instance_exec'
            +/Users/johnbackus/.gem/ruby/2.3.1/gems/rspec-core-3.5.4/lib/rspec/core/hooks.rb:375:in `execute_with'
            +/Users/johnbackus/.gem/ruby/2.3.1/gems/rspec-core-3.5.4/lib/rspec/core/hooks.rb:606:in `block (2 levels) in run_around_example_hooks_for'
            +/Users/johnbackus/.gem/ruby/2.3.1/gems/rspec-core-3.5.4/lib/rspec/core/example.rb:338:in `call'
            +/Users/johnbackus/.gem/ruby/2.3.1/gems/rspec-core-3.5.4/lib/rspec/core/hooks.rb:607:in `run_around_example_hooks_for'
            +/Users/johnbackus/.gem/ruby/2.3.1/gems/rspec-core-3.5.4/lib/rspec/core/hooks.rb:464:in `run'
            +/Users/johnbackus/.gem/ruby/2.3.1/gems/rspec-core-3.5.4/lib/rspec/core/example.rb:453:in `with_around_example_hooks'
            +/Users/johnbackus/.gem/ruby/2.3.1/gems/rspec-core-3.5.4/lib/rspec/core/example.rb:496:in `with_around_and_singleton_context_hooks'
            +/Users/johnbackus/.gem/ruby/2.3.1/gems/rspec-core-3.5.4/lib/rspec/core/example.rb:251:in `run'
            +/Users/johnbackus/.gem/ruby/2.3.1/gems/rspec-core-3.5.4/lib/rspec/core/example_group.rb:627:in `block in run_examples'
            +/Users/johnbackus/.gem/ruby/2.3.1/gems/rspec-core-3.5.4/lib/rspec/core/example_group.rb:623:in `map'
            +/Users/johnbackus/.gem/ruby/2.3.1/gems/rspec-core-3.5.4/lib/rspec/core/example_group.rb:623:in `run_examples'
            +/Users/johnbackus/.gem/ruby/2.3.1/gems/rspec-core-3.5.4/lib/rspec/core/example_group.rb:589:in `run'
            +/Users/johnbackus/.gem/ruby/2.3.1/gems/rspec-core-3.5.4/lib/rspec/core/example_group.rb:590:in `block in run'
            +/Users/johnbackus/.gem/ruby/2.3.1/gems/rspec-core-3.5.4/lib/rspec/core/example_group.rb:590:in `map'
            +/Users/johnbackus/.gem/ruby/2.3.1/gems/rspec-core-3.5.4/lib/rspec/core/example_group.rb:590:in `run'
            +/Users/johnbackus/.gem/ruby/2.3.1/gems/rspec-core-3.5.4/lib/rspec/core/example_group.rb:590:in `block in run'
            +/Users/johnbackus/.gem/ruby/2.3.1/gems/rspec-core-3.5.4/lib/rspec/core/example_group.rb:590:in `map'
            +/Users/johnbackus/.gem/ruby/2.3.1/gems/rspec-core-3.5.4/lib/rspec/core/example_group.rb:590:in `run'
            +/Users/johnbackus/.gem/ruby/2.3.1/gems/rspec-core-3.5.4/lib/rspec/core/runner.rb:113:in `block (3 levels) in run_specs'
            +/Users/johnbackus/.gem/ruby/2.3.1/gems/rspec-core-3.5.4/lib/rspec/core/runner.rb:113:in `map'
            +/Users/johnbackus/.gem/ruby/2.3.1/gems/rspec-core-3.5.4/lib/rspec/core/runner.rb:113:in `block (2 levels) in run_specs'
            +/Users/johnbackus/.gem/ruby/2.3.1/gems/rspec-core-3.5.4/lib/rspec/core/configuration.rb:1835:in `with_suite_hooks'
            +/Users/johnbackus/.gem/ruby/2.3.1/gems/rspec-core-3.5.4/lib/rspec/core/runner.rb:112:in `block in run_specs'
            +/Users/johnbackus/.gem/ruby/2.3.1/gems/rspec-core-3.5.4/lib/rspec/core/reporter.rb:77:in `report'
            +/Users/johnbackus/.gem/ruby/2.3.1/gems/rspec-core-3.5.4/lib/rspec/core/runner.rb:111:in `run_specs'
            +/Users/johnbackus/.gem/ruby/2.3.1/gems/rspec-core-3.5.4/lib/rspec/core/runner.rb:87:in `run'
            +/Users/johnbackus/.gem/ruby/2.3.1/gems/rspec-core-3.5.4/lib/rspec/core/runner.rb:71:in `run'
            +/Users/johnbackus/.gem/ruby/2.3.1/gems/rspec-core-3.5.4/lib/rspec/core/runner.rb:45:in `invoke'
            +/Users/johnbackus/.gem/ruby/2.3.1/gems/rspec-core-3.5.4/exe/rspec:4:in `<top (required)>'
            +/Users/johnbackus/.gem/ruby/2.3.1/bin/rspec:23:in `load'
            +/Users/johnbackus/.gem/ruby/2.3.1/bin/rspec:23:in `<top (required)>'
            +/Users/johnbackus/.gem/ruby/2.3.1/gems/bundler-1.13.2/lib/bundler/cli/exec.rb:74:in `load'
            +/Users/johnbackus/.gem/ruby/2.3.1/gems/bundler-1.13.2/lib/bundler/cli/exec.rb:74:in `kernel_load'
            +/Users/johnbackus/.gem/ruby/2.3.1/gems/bundler-1.13.2/lib/bundler/cli/exec.rb:27:in `run'
            +/Users/johnbackus/.gem/ruby/2.3.1/gems/bundler-1.13.2/lib/bundler/cli.rb:332:in `exec'
            +/Users/johnbackus/.gem/ruby/2.3.1/gems/bundler-1.13.2/lib/bundler/vendor/thor/lib/thor/command.rb:27:in `run'
            +/Users/johnbackus/.gem/ruby/2.3.1/gems/bundler-1.13.2/lib/bundler/vendor/thor/lib/thor/invocation.rb:126:in `invoke_command'
            +/Users/johnbackus/.gem/ruby/2.3.1/gems/bundler-1.13.2/lib/bundler/vendor/thor/lib/thor.rb:359:in `dispatch'
            +/Users/johnbackus/.gem/ruby/2.3.1/gems/bundler-1.13.2/lib/bundler/cli.rb:20:in `dispatch'
            +/Users/johnbackus/.gem/ruby/2.3.1/gems/bundler-1.13.2/lib/bundler/vendor/thor/lib/thor/base.rb:440:in `start'
            +/Users/johnbackus/.gem/ruby/2.3.1/gems/bundler-1.13.2/lib/bundler/cli.rb:11:in `start'
            +/Users/johnbackus/.gem/ruby/2.3.1/gems/bundler-1.13.2/exe/bundle:34:in `block in <top (required)>'
            +/Users/johnbackus/.gem/ruby/2.3.1/gems/bundler-1.13.2/lib/bundler/friendly_errors.rb:100:in `with_friendly_errors'
            +/Users/johnbackus/.gem/ruby/2.3.1/gems/bundler-1.13.2/exe/bundle:26:in `<top (required)>'
            +/Users/johnbackus/.gem/ruby/2.3.1/bin/bundle:23:in `load'
            +/Users/johnbackus/.gem/ruby/2.3.1/bin/bundle:23:in `<main>'

          # ./spec/rubocop/cli_spec.rb:349:in `block (4 levels) in <top (required)>'

     6.3) Failure/Error:
            expect($stdout.string)
              .to eq(["#{abs('example.rb')}:1:81: C: Line is too long. [95/80]",
                      "#{abs('example.rb')}:2:1: W: Unnecessary disabling of " \
                      'all cops.',
                      "#{abs('example.rb')}:3:12: W: Unnecessary disabling of " \
                      '`Metrics/ClassLength`, `Metrics/LineLength`.',
                      "#{abs('example.rb')}:4:8: W: Unnecessary disabling of " \
                      'all cops.',
                      ''].join("\n"))

            expected: "/private/var/folders/wq/h965ll7s5bqcpzcd58b__pw00000gn/T/d20170102-5582-na7xni/work/example.rb:1:81:...58b__pw00000gn/T/d20170102-5582-na7xni/work/example.rb:4:8: W: Unnecessary disabling of all cops.\n"
                 got: ""

            (compared using ==)

            Diff:
            @@ -1,5 +1 @@
            -/private/var/folders/wq/h965ll7s5bqcpzcd58b__pw00000gn/T/d20170102-5582-na7xni/work/example.rb:1:81: C: Line is too long. [95/80]
            -/private/var/folders/wq/h965ll7s5bqcpzcd58b__pw00000gn/T/d20170102-5582-na7xni/work/example.rb:2:1: W: Unnecessary disabling of all cops.
            -/private/var/folders/wq/h965ll7s5bqcpzcd58b__pw00000gn/T/d20170102-5582-na7xni/work/example.rb:3:12: W: Unnecessary disabling of `Metrics/ClassLength`, `Metrics/LineLength`.
            -/private/var/folders/wq/h965ll7s5bqcpzcd58b__pw00000gn/T/d20170102-5582-na7xni/work/example.rb:4:8: W: Unnecessary disabling of all cops.

          # ./spec/rubocop/cli_spec.rb:350:in `block (4 levels) in <top (required)>'

  7) RuboCop::CLI rubocop:disable comment when not necessary and UnneededDisable is individually disabled does not report UnneededDisable offenses
     Got 3 failures from failure aggregation block.
     Shared Example Group: "UnneededDisable not run" called from ./spec/rubocop/cli_spec.rb:386
     # ./spec/support/cli_spec_behavior.rb:3:in `block (2 levels) in <top (required)>'
     # ./lib/rubocop/rspec/shared_contexts.rb:27:in `block (4 levels) in <top (required)>'
     # ./lib/rubocop/rspec/shared_contexts.rb:26:in `chdir'
     # ./lib/rubocop/rspec/shared_contexts.rb:26:in `block (3 levels) in <top (required)>'
     # ./lib/rubocop/rspec/shared_contexts.rb:8:in `block (2 levels) in <top (required)>'

     7.1) Failure/Error: expect(cli.run(['--format', 'emacs'])).to eq(1)

            expected: 1
                 got: 2

            (compared using ==)
          # ./spec/rubocop/cli_spec.rb:377:in `block (6 levels) in <top (required)>'

     7.2) Failure/Error: expect($stderr.string).to eq('')

            expected: ""
                 got: "An error occurred while Metrics/LineLength cop was inspecting /private/var/folders/wq/h965ll7s5bqcpz...m/ruby/2.3.1/bin/bundle:23:in `load'\n/Users/johnbackus/.gem/ruby/2.3.1/bin/bundle:23:in `<main>'\n"

            (compared using ==)

            Diff:
            @@ -1 +1,101 @@
            +An error occurred while Metrics/LineLength cop was inspecting /private/var/folders/wq/h965ll7s5bqcpzcd58b__pw00000gn/T/d20170102-5582-gpxzk6/work/example.rb.
            +To see the complete backtrace run rubocop -d.
            +undefined method `names' for #<Array:0x007fc389d34948>
            +/Users/johnbackus/Projects/rubocop/lib/rubocop/comment_config.rb:136:in `all_cop_names'
            +/Users/johnbackus/Projects/rubocop/lib/rubocop/comment_config.rb:124:in `directive_parts'
            +/Users/johnbackus/Projects/rubocop/lib/rubocop/comment_config.rb:110:in `block in each_directive'
            +/Users/johnbackus/Projects/rubocop/lib/rubocop/comment_config.rb:109:in `each'
            +/Users/johnbackus/Projects/rubocop/lib/rubocop/comment_config.rb:109:in `each_directive'
            +/Users/johnbackus/Projects/rubocop/lib/rubocop/comment_config.rb:95:in `each_mentioned_cop'
            +/Users/johnbackus/Projects/rubocop/lib/rubocop/comment_config.rb:42:in `analyze'
            +/Users/johnbackus/Projects/rubocop/lib/rubocop/comment_config.rb:34:in `cop_disabled_line_ranges'
            +/Users/johnbackus/Projects/rubocop/lib/rubocop/processed_source.rb:44:in `disabled_line_ranges'
            +/Users/johnbackus/Projects/rubocop/lib/rubocop/runner.rb:136:in `check_for_unneded_disables?'
            +/Users/johnbackus/Projects/rubocop/lib/rubocop/runner.rb:119:in `add_unneeded_disables'
            +/Users/johnbackus/Projects/rubocop/lib/rubocop/runner.rb:102:in `block in file_offenses'
            +/Users/johnbackus/Projects/rubocop/lib/rubocop/runner.rb:111:in `file_offense_cache'
            +/Users/johnbackus/Projects/rubocop/lib/rubocop/runner.rb:99:in `file_offenses'
            +/Users/johnbackus/Projects/rubocop/lib/rubocop/runner.rb:90:in `process_file'
            +/Users/johnbackus/Projects/rubocop/lib/rubocop/runner.rb:68:in `block in each_inspected_file'
            +/Users/johnbackus/Projects/rubocop/lib/rubocop/runner.rb:65:in `each'
            +/Users/johnbackus/Projects/rubocop/lib/rubocop/runner.rb:65:in `reduce'
            +/Users/johnbackus/Projects/rubocop/lib/rubocop/runner.rb:65:in `each_inspected_file'
            +/Users/johnbackus/Projects/rubocop/lib/rubocop/runner.rb:57:in `inspect_files'
            +/Users/johnbackus/Projects/rubocop/lib/rubocop/runner.rb:36:in `run'
            +/Users/johnbackus/Projects/rubocop/lib/rubocop/cli.rb:72:in `execute_runner'
            +/Users/johnbackus/Projects/rubocop/lib/rubocop/cli.rb:27:in `run'
            +/Users/johnbackus/Projects/rubocop/spec/rubocop/cli_spec.rb:377:in `block (6 levels) in <top (required)>'
            +/Users/johnbackus/.gem/ruby/2.3.1/gems/rspec-core-3.5.4/lib/rspec/core/example.rb:254:in `instance_exec'
            +/Users/johnbackus/.gem/ruby/2.3.1/gems/rspec-core-3.5.4/lib/rspec/core/example.rb:254:in `block in run'
            +/Users/johnbackus/.gem/ruby/2.3.1/gems/rspec-core-3.5.4/lib/rspec/core/example.rb:496:in `block in with_around_and_singleton_context_hooks'
            +/Users/johnbackus/.gem/ruby/2.3.1/gems/rspec-core-3.5.4/lib/rspec/core/example.rb:453:in `block in with_around_example_hooks'
            +/Users/johnbackus/.gem/ruby/2.3.1/gems/rspec-core-3.5.4/lib/rspec/core/hooks.rb:464:in `block in run'
            +/Users/johnbackus/.gem/ruby/2.3.1/gems/rspec-core-3.5.4/lib/rspec/core/hooks.rb:604:in `block in run_around_example_hooks_for'
            +/Users/johnbackus/.gem/ruby/2.3.1/gems/rspec-core-3.5.4/lib/rspec/core/example.rb:338:in `call'
            +/Users/johnbackus/.gem/ruby/2.3.1/gems/rspec-expectations-3.5.0/lib/rspec/expectations/failure_aggregator.rb:10:in `block in aggregate'
            +/Users/johnbackus/.gem/ruby/2.3.1/gems/rspec-support-3.5.0/lib/rspec/support.rb:103:in `with_failure_notifier'
            +/Users/johnbackus/.gem/ruby/2.3.1/gems/rspec-expectations-3.5.0/lib/rspec/expectations/failure_aggregator.rb:8:in `aggregate'
            +/Users/johnbackus/.gem/ruby/2.3.1/gems/rspec-expectations-3.5.0/lib/rspec/matchers.rb:313:in `aggregate_failures'
            +/Users/johnbackus/Projects/rubocop/spec/support/cli_spec_behavior.rb:3:in `block (2 levels) in <top (required)>'
            +/Users/johnbackus/.gem/ruby/2.3.1/gems/rspec-core-3.5.4/lib/rspec/core/example.rb:443:in `instance_exec'
            +/Users/johnbackus/.gem/ruby/2.3.1/gems/rspec-core-3.5.4/lib/rspec/core/example.rb:443:in `instance_exec'
            +/Users/johnbackus/.gem/ruby/2.3.1/gems/rspec-core-3.5.4/lib/rspec/core/hooks.rb:375:in `execute_with'
            +/Users/johnbackus/.gem/ruby/2.3.1/gems/rspec-core-3.5.4/lib/rspec/core/hooks.rb:606:in `block (2 levels) in run_around_example_hooks_for'
            +/Users/johnbackus/.gem/ruby/2.3.1/gems/rspec-core-3.5.4/lib/rspec/core/example.rb:338:in `call'
            +/Users/johnbackus/Projects/rubocop/lib/rubocop/rspec/shared_contexts.rb:27:in `block (4 levels) in <top (required)>'
            +/Users/johnbackus/Projects/rubocop/lib/rubocop/rspec/shared_contexts.rb:26:in `chdir'
            +/Users/johnbackus/Projects/rubocop/lib/rubocop/rspec/shared_contexts.rb:26:in `block (3 levels) in <top (required)>'
            +/Users/johnbackus/.rubies/ruby-2.3.1/lib/ruby/2.3.0/tmpdir.rb:89:in `mktmpdir'
            +/Users/johnbackus/Projects/rubocop/lib/rubocop/rspec/shared_contexts.rb:8:in `block (2 levels) in <top (required)>'
            +/Users/johnbackus/.gem/ruby/2.3.1/gems/rspec-core-3.5.4/lib/rspec/core/example.rb:443:in `instance_exec'
            +/Users/johnbackus/.gem/ruby/2.3.1/gems/rspec-core-3.5.4/lib/rspec/core/example.rb:443:in `instance_exec'
            +/Users/johnbackus/.gem/ruby/2.3.1/gems/rspec-core-3.5.4/lib/rspec/core/hooks.rb:375:in `execute_with'
            +/Users/johnbackus/.gem/ruby/2.3.1/gems/rspec-core-3.5.4/lib/rspec/core/hooks.rb:606:in `block (2 levels) in run_around_example_hooks_for'
            +/Users/johnbackus/.gem/ruby/2.3.1/gems/rspec-core-3.5.4/lib/rspec/core/example.rb:338:in `call'
            +/Users/johnbackus/.gem/ruby/2.3.1/gems/rspec-core-3.5.4/lib/rspec/core/hooks.rb:607:in `run_around_example_hooks_for'
            +/Users/johnbackus/.gem/ruby/2.3.1/gems/rspec-core-3.5.4/lib/rspec/core/hooks.rb:464:in `run'
            +/Users/johnbackus/.gem/ruby/2.3.1/gems/rspec-core-3.5.4/lib/rspec/core/example.rb:453:in `with_around_example_hooks'
            +/Users/johnbackus/.gem/ruby/2.3.1/gems/rspec-core-3.5.4/lib/rspec/core/example.rb:496:in `with_around_and_singleton_context_hooks'
            +/Users/johnbackus/.gem/ruby/2.3.1/gems/rspec-core-3.5.4/lib/rspec/core/example.rb:251:in `run'
            +/Users/johnbackus/.gem/ruby/2.3.1/gems/rspec-core-3.5.4/lib/rspec/core/example_group.rb:627:in `block in run_examples'
            +/Users/johnbackus/.gem/ruby/2.3.1/gems/rspec-core-3.5.4/lib/rspec/core/example_group.rb:623:in `map'
            +/Users/johnbackus/.gem/ruby/2.3.1/gems/rspec-core-3.5.4/lib/rspec/core/example_group.rb:623:in `run_examples'
            +/Users/johnbackus/.gem/ruby/2.3.1/gems/rspec-core-3.5.4/lib/rspec/core/example_group.rb:589:in `run'
            +/Users/johnbackus/.gem/ruby/2.3.1/gems/rspec-core-3.5.4/lib/rspec/core/example_group.rb:590:in `block in run'
            +/Users/johnbackus/.gem/ruby/2.3.1/gems/rspec-core-3.5.4/lib/rspec/core/example_group.rb:590:in `map'
            +/Users/johnbackus/.gem/ruby/2.3.1/gems/rspec-core-3.5.4/lib/rspec/core/example_group.rb:590:in `run'
            +/Users/johnbackus/.gem/ruby/2.3.1/gems/rspec-core-3.5.4/lib/rspec/core/example_group.rb:590:in `block in run'
            +/Users/johnbackus/.gem/ruby/2.3.1/gems/rspec-core-3.5.4/lib/rspec/core/example_group.rb:590:in `map'
            +/Users/johnbackus/.gem/ruby/2.3.1/gems/rspec-core-3.5.4/lib/rspec/core/example_group.rb:590:in `run'
            +/Users/johnbackus/.gem/ruby/2.3.1/gems/rspec-core-3.5.4/lib/rspec/core/example_group.rb:590:in `block in run'
            +/Users/johnbackus/.gem/ruby/2.3.1/gems/rspec-core-3.5.4/lib/rspec/core/example_group.rb:590:in `map'
            +/Users/johnbackus/.gem/ruby/2.3.1/gems/rspec-core-3.5.4/lib/rspec/core/example_group.rb:590:in `run'
            +/Users/johnbackus/.gem/ruby/2.3.1/gems/rspec-core-3.5.4/lib/rspec/core/runner.rb:113:in `block (3 levels) in run_specs'
            +/Users/johnbackus/.gem/ruby/2.3.1/gems/rspec-core-3.5.4/lib/rspec/core/runner.rb:113:in `map'
            +/Users/johnbackus/.gem/ruby/2.3.1/gems/rspec-core-3.5.4/lib/rspec/core/runner.rb:113:in `block (2 levels) in run_specs'
            +/Users/johnbackus/.gem/ruby/2.3.1/gems/rspec-core-3.5.4/lib/rspec/core/configuration.rb:1835:in `with_suite_hooks'
            +/Users/johnbackus/.gem/ruby/2.3.1/gems/rspec-core-3.5.4/lib/rspec/core/runner.rb:112:in `block in run_specs'
            +/Users/johnbackus/.gem/ruby/2.3.1/gems/rspec-core-3.5.4/lib/rspec/core/reporter.rb:77:in `report'
            +/Users/johnbackus/.gem/ruby/2.3.1/gems/rspec-core-3.5.4/lib/rspec/core/runner.rb:111:in `run_specs'
            +/Users/johnbackus/.gem/ruby/2.3.1/gems/rspec-core-3.5.4/lib/rspec/core/runner.rb:87:in `run'
            +/Users/johnbackus/.gem/ruby/2.3.1/gems/rspec-core-3.5.4/lib/rspec/core/runner.rb:71:in `run'
            +/Users/johnbackus/.gem/ruby/2.3.1/gems/rspec-core-3.5.4/lib/rspec/core/runner.rb:45:in `invoke'
            +/Users/johnbackus/.gem/ruby/2.3.1/gems/rspec-core-3.5.4/exe/rspec:4:in `<top (required)>'
            +/Users/johnbackus/.gem/ruby/2.3.1/bin/rspec:23:in `load'
            +/Users/johnbackus/.gem/ruby/2.3.1/bin/rspec:23:in `<top (required)>'
            +/Users/johnbackus/.gem/ruby/2.3.1/gems/bundler-1.13.2/lib/bundler/cli/exec.rb:74:in `load'
            +/Users/johnbackus/.gem/ruby/2.3.1/gems/bundler-1.13.2/lib/bundler/cli/exec.rb:74:in `kernel_load'
            +/Users/johnbackus/.gem/ruby/2.3.1/gems/bundler-1.13.2/lib/bundler/cli/exec.rb:27:in `run'
            +/Users/johnbackus/.gem/ruby/2.3.1/gems/bundler-1.13.2/lib/bundler/cli.rb:332:in `exec'
            +/Users/johnbackus/.gem/ruby/2.3.1/gems/bundler-1.13.2/lib/bundler/vendor/thor/lib/thor/command.rb:27:in `run'
            +/Users/johnbackus/.gem/ruby/2.3.1/gems/bundler-1.13.2/lib/bundler/vendor/thor/lib/thor/invocation.rb:126:in `invoke_command'
            +/Users/johnbackus/.gem/ruby/2.3.1/gems/bundler-1.13.2/lib/bundler/vendor/thor/lib/thor.rb:359:in `dispatch'
            +/Users/johnbackus/.gem/ruby/2.3.1/gems/bundler-1.13.2/lib/bundler/cli.rb:20:in `dispatch'
            +/Users/johnbackus/.gem/ruby/2.3.1/gems/bundler-1.13.2/lib/bundler/vendor/thor/lib/thor/base.rb:440:in `start'
            +/Users/johnbackus/.gem/ruby/2.3.1/gems/bundler-1.13.2/lib/bundler/cli.rb:11:in `start'
            +/Users/johnbackus/.gem/ruby/2.3.1/gems/bundler-1.13.2/exe/bundle:34:in `block in <top (required)>'
            +/Users/johnbackus/.gem/ruby/2.3.1/gems/bundler-1.13.2/lib/bundler/friendly_errors.rb:100:in `with_friendly_errors'
            +/Users/johnbackus/.gem/ruby/2.3.1/gems/bundler-1.13.2/exe/bundle:26:in `<top (required)>'
            +/Users/johnbackus/.gem/ruby/2.3.1/bin/bundle:23:in `load'
            +/Users/johnbackus/.gem/ruby/2.3.1/bin/bundle:23:in `<main>'

          # ./spec/rubocop/cli_spec.rb:378:in `block (6 levels) in <top (required)>'

     7.3) Failure/Error:
            expect($stdout.string)
              .to eq(["#{abs('example.rb')}:1:81: C: Line is too long. [95/80]",
                      ''].join("\n"))

            expected: "/private/var/folders/wq/h965ll7s5bqcpzcd58b__pw00000gn/T/d20170102-5582-gpxzk6/work/example.rb:1:81: C: Line is too long. [95/80]\n"
                 got: ""

            (compared using ==)

            Diff:
            @@ -1,2 +1 @@
            -/private/var/folders/wq/h965ll7s5bqcpzcd58b__pw00000gn/T/d20170102-5582-gpxzk6/work/example.rb:1:81: C: Line is too long. [95/80]

          # ./spec/rubocop/cli_spec.rb:379:in `block (6 levels) in <top (required)>'

  8) RuboCop::CLI rubocop:disable comment when not necessary and UnneededDisable is disabled through department does not report UnneededDisable offenses
     Got 3 failures from failure aggregation block.
     Shared Example Group: "UnneededDisable not run" called from ./spec/rubocop/cli_spec.rb:393
     # ./spec/support/cli_spec_behavior.rb:3:in `block (2 levels) in <top (required)>'
     # ./lib/rubocop/rspec/shared_contexts.rb:27:in `block (4 levels) in <top (required)>'
     # ./lib/rubocop/rspec/shared_contexts.rb:26:in `chdir'
     # ./lib/rubocop/rspec/shared_contexts.rb:26:in `block (3 levels) in <top (required)>'
     # ./lib/rubocop/rspec/shared_contexts.rb:8:in `block (2 levels) in <top (required)>'

     8.1) Failure/Error: expect(cli.run(['--format', 'emacs'])).to eq(1)

            expected: 1
                 got: 2

            (compared using ==)
          # ./spec/rubocop/cli_spec.rb:377:in `block (6 levels) in <top (required)>'

     8.2) Failure/Error: expect($stderr.string).to eq('')

            expected: ""
                 got: "An error occurred while Metrics/LineLength cop was inspecting /private/var/folders/wq/h965ll7s5bqcpz...m/ruby/2.3.1/bin/bundle:23:in `load'\n/Users/johnbackus/.gem/ruby/2.3.1/bin/bundle:23:in `<main>'\n"

            (compared using ==)

            Diff:
            @@ -1 +1,101 @@
            +An error occurred while Metrics/LineLength cop was inspecting /private/var/folders/wq/h965ll7s5bqcpzcd58b__pw00000gn/T/d20170102-5582-nyhzrl/work/example.rb.
            +To see the complete backtrace run rubocop -d.
            +undefined method `names' for #<Array:0x007fc38bec64f8>
            +/Users/johnbackus/Projects/rubocop/lib/rubocop/comment_config.rb:136:in `all_cop_names'
            +/Users/johnbackus/Projects/rubocop/lib/rubocop/comment_config.rb:124:in `directive_parts'
            +/Users/johnbackus/Projects/rubocop/lib/rubocop/comment_config.rb:110:in `block in each_directive'
            +/Users/johnbackus/Projects/rubocop/lib/rubocop/comment_config.rb:109:in `each'
            +/Users/johnbackus/Projects/rubocop/lib/rubocop/comment_config.rb:109:in `each_directive'
            +/Users/johnbackus/Projects/rubocop/lib/rubocop/comment_config.rb:95:in `each_mentioned_cop'
            +/Users/johnbackus/Projects/rubocop/lib/rubocop/comment_config.rb:42:in `analyze'
            +/Users/johnbackus/Projects/rubocop/lib/rubocop/comment_config.rb:34:in `cop_disabled_line_ranges'
            +/Users/johnbackus/Projects/rubocop/lib/rubocop/processed_source.rb:44:in `disabled_line_ranges'
            +/Users/johnbackus/Projects/rubocop/lib/rubocop/runner.rb:136:in `check_for_unneded_disables?'
            +/Users/johnbackus/Projects/rubocop/lib/rubocop/runner.rb:119:in `add_unneeded_disables'
            +/Users/johnbackus/Projects/rubocop/lib/rubocop/runner.rb:102:in `block in file_offenses'
            +/Users/johnbackus/Projects/rubocop/lib/rubocop/runner.rb:111:in `file_offense_cache'
            +/Users/johnbackus/Projects/rubocop/lib/rubocop/runner.rb:99:in `file_offenses'
            +/Users/johnbackus/Projects/rubocop/lib/rubocop/runner.rb:90:in `process_file'
            +/Users/johnbackus/Projects/rubocop/lib/rubocop/runner.rb:68:in `block in each_inspected_file'
            +/Users/johnbackus/Projects/rubocop/lib/rubocop/runner.rb:65:in `each'
            +/Users/johnbackus/Projects/rubocop/lib/rubocop/runner.rb:65:in `reduce'
            +/Users/johnbackus/Projects/rubocop/lib/rubocop/runner.rb:65:in `each_inspected_file'
            +/Users/johnbackus/Projects/rubocop/lib/rubocop/runner.rb:57:in `inspect_files'
            +/Users/johnbackus/Projects/rubocop/lib/rubocop/runner.rb:36:in `run'
            +/Users/johnbackus/Projects/rubocop/lib/rubocop/cli.rb:72:in `execute_runner'
            +/Users/johnbackus/Projects/rubocop/lib/rubocop/cli.rb:27:in `run'
            +/Users/johnbackus/Projects/rubocop/spec/rubocop/cli_spec.rb:377:in `block (6 levels) in <top (required)>'
            +/Users/johnbackus/.gem/ruby/2.3.1/gems/rspec-core-3.5.4/lib/rspec/core/example.rb:254:in `instance_exec'
            +/Users/johnbackus/.gem/ruby/2.3.1/gems/rspec-core-3.5.4/lib/rspec/core/example.rb:254:in `block in run'
            +/Users/johnbackus/.gem/ruby/2.3.1/gems/rspec-core-3.5.4/lib/rspec/core/example.rb:496:in `block in with_around_and_singleton_context_hooks'
            +/Users/johnbackus/.gem/ruby/2.3.1/gems/rspec-core-3.5.4/lib/rspec/core/example.rb:453:in `block in with_around_example_hooks'
            +/Users/johnbackus/.gem/ruby/2.3.1/gems/rspec-core-3.5.4/lib/rspec/core/hooks.rb:464:in `block in run'
            +/Users/johnbackus/.gem/ruby/2.3.1/gems/rspec-core-3.5.4/lib/rspec/core/hooks.rb:604:in `block in run_around_example_hooks_for'
            +/Users/johnbackus/.gem/ruby/2.3.1/gems/rspec-core-3.5.4/lib/rspec/core/example.rb:338:in `call'
            +/Users/johnbackus/.gem/ruby/2.3.1/gems/rspec-expectations-3.5.0/lib/rspec/expectations/failure_aggregator.rb:10:in `block in aggregate'
            +/Users/johnbackus/.gem/ruby/2.3.1/gems/rspec-support-3.5.0/lib/rspec/support.rb:103:in `with_failure_notifier'
            +/Users/johnbackus/.gem/ruby/2.3.1/gems/rspec-expectations-3.5.0/lib/rspec/expectations/failure_aggregator.rb:8:in `aggregate'
            +/Users/johnbackus/.gem/ruby/2.3.1/gems/rspec-expectations-3.5.0/lib/rspec/matchers.rb:313:in `aggregate_failures'
            +/Users/johnbackus/Projects/rubocop/spec/support/cli_spec_behavior.rb:3:in `block (2 levels) in <top (required)>'
            +/Users/johnbackus/.gem/ruby/2.3.1/gems/rspec-core-3.5.4/lib/rspec/core/example.rb:443:in `instance_exec'
            +/Users/johnbackus/.gem/ruby/2.3.1/gems/rspec-core-3.5.4/lib/rspec/core/example.rb:443:in `instance_exec'
            +/Users/johnbackus/.gem/ruby/2.3.1/gems/rspec-core-3.5.4/lib/rspec/core/hooks.rb:375:in `execute_with'
            +/Users/johnbackus/.gem/ruby/2.3.1/gems/rspec-core-3.5.4/lib/rspec/core/hooks.rb:606:in `block (2 levels) in run_around_example_hooks_for'
            +/Users/johnbackus/.gem/ruby/2.3.1/gems/rspec-core-3.5.4/lib/rspec/core/example.rb:338:in `call'
            +/Users/johnbackus/Projects/rubocop/lib/rubocop/rspec/shared_contexts.rb:27:in `block (4 levels) in <top (required)>'
            +/Users/johnbackus/Projects/rubocop/lib/rubocop/rspec/shared_contexts.rb:26:in `chdir'
            +/Users/johnbackus/Projects/rubocop/lib/rubocop/rspec/shared_contexts.rb:26:in `block (3 levels) in <top (required)>'
            +/Users/johnbackus/.rubies/ruby-2.3.1/lib/ruby/2.3.0/tmpdir.rb:89:in `mktmpdir'
            +/Users/johnbackus/Projects/rubocop/lib/rubocop/rspec/shared_contexts.rb:8:in `block (2 levels) in <top (required)>'
            +/Users/johnbackus/.gem/ruby/2.3.1/gems/rspec-core-3.5.4/lib/rspec/core/example.rb:443:in `instance_exec'
            +/Users/johnbackus/.gem/ruby/2.3.1/gems/rspec-core-3.5.4/lib/rspec/core/example.rb:443:in `instance_exec'
            +/Users/johnbackus/.gem/ruby/2.3.1/gems/rspec-core-3.5.4/lib/rspec/core/hooks.rb:375:in `execute_with'
            +/Users/johnbackus/.gem/ruby/2.3.1/gems/rspec-core-3.5.4/lib/rspec/core/hooks.rb:606:in `block (2 levels) in run_around_example_hooks_for'
            +/Users/johnbackus/.gem/ruby/2.3.1/gems/rspec-core-3.5.4/lib/rspec/core/example.rb:338:in `call'
            +/Users/johnbackus/.gem/ruby/2.3.1/gems/rspec-core-3.5.4/lib/rspec/core/hooks.rb:607:in `run_around_example_hooks_for'
            +/Users/johnbackus/.gem/ruby/2.3.1/gems/rspec-core-3.5.4/lib/rspec/core/hooks.rb:464:in `run'
            +/Users/johnbackus/.gem/ruby/2.3.1/gems/rspec-core-3.5.4/lib/rspec/core/example.rb:453:in `with_around_example_hooks'
            +/Users/johnbackus/.gem/ruby/2.3.1/gems/rspec-core-3.5.4/lib/rspec/core/example.rb:496:in `with_around_and_singleton_context_hooks'
            +/Users/johnbackus/.gem/ruby/2.3.1/gems/rspec-core-3.5.4/lib/rspec/core/example.rb:251:in `run'
            +/Users/johnbackus/.gem/ruby/2.3.1/gems/rspec-core-3.5.4/lib/rspec/core/example_group.rb:627:in `block in run_examples'
            +/Users/johnbackus/.gem/ruby/2.3.1/gems/rspec-core-3.5.4/lib/rspec/core/example_group.rb:623:in `map'
            +/Users/johnbackus/.gem/ruby/2.3.1/gems/rspec-core-3.5.4/lib/rspec/core/example_group.rb:623:in `run_examples'
            +/Users/johnbackus/.gem/ruby/2.3.1/gems/rspec-core-3.5.4/lib/rspec/core/example_group.rb:589:in `run'
            +/Users/johnbackus/.gem/ruby/2.3.1/gems/rspec-core-3.5.4/lib/rspec/core/example_group.rb:590:in `block in run'
            +/Users/johnbackus/.gem/ruby/2.3.1/gems/rspec-core-3.5.4/lib/rspec/core/example_group.rb:590:in `map'
            +/Users/johnbackus/.gem/ruby/2.3.1/gems/rspec-core-3.5.4/lib/rspec/core/example_group.rb:590:in `run'
            +/Users/johnbackus/.gem/ruby/2.3.1/gems/rspec-core-3.5.4/lib/rspec/core/example_group.rb:590:in `block in run'
            +/Users/johnbackus/.gem/ruby/2.3.1/gems/rspec-core-3.5.4/lib/rspec/core/example_group.rb:590:in `map'
            +/Users/johnbackus/.gem/ruby/2.3.1/gems/rspec-core-3.5.4/lib/rspec/core/example_group.rb:590:in `run'
            +/Users/johnbackus/.gem/ruby/2.3.1/gems/rspec-core-3.5.4/lib/rspec/core/example_group.rb:590:in `block in run'
            +/Users/johnbackus/.gem/ruby/2.3.1/gems/rspec-core-3.5.4/lib/rspec/core/example_group.rb:590:in `map'
            +/Users/johnbackus/.gem/ruby/2.3.1/gems/rspec-core-3.5.4/lib/rspec/core/example_group.rb:590:in `run'
            +/Users/johnbackus/.gem/ruby/2.3.1/gems/rspec-core-3.5.4/lib/rspec/core/runner.rb:113:in `block (3 levels) in run_specs'
            +/Users/johnbackus/.gem/ruby/2.3.1/gems/rspec-core-3.5.4/lib/rspec/core/runner.rb:113:in `map'
            +/Users/johnbackus/.gem/ruby/2.3.1/gems/rspec-core-3.5.4/lib/rspec/core/runner.rb:113:in `block (2 levels) in run_specs'
            +/Users/johnbackus/.gem/ruby/2.3.1/gems/rspec-core-3.5.4/lib/rspec/core/configuration.rb:1835:in `with_suite_hooks'
            +/Users/johnbackus/.gem/ruby/2.3.1/gems/rspec-core-3.5.4/lib/rspec/core/runner.rb:112:in `block in run_specs'
            +/Users/johnbackus/.gem/ruby/2.3.1/gems/rspec-core-3.5.4/lib/rspec/core/reporter.rb:77:in `report'
            +/Users/johnbackus/.gem/ruby/2.3.1/gems/rspec-core-3.5.4/lib/rspec/core/runner.rb:111:in `run_specs'
            +/Users/johnbackus/.gem/ruby/2.3.1/gems/rspec-core-3.5.4/lib/rspec/core/runner.rb:87:in `run'
            +/Users/johnbackus/.gem/ruby/2.3.1/gems/rspec-core-3.5.4/lib/rspec/core/runner.rb:71:in `run'
            +/Users/johnbackus/.gem/ruby/2.3.1/gems/rspec-core-3.5.4/lib/rspec/core/runner.rb:45:in `invoke'
            +/Users/johnbackus/.gem/ruby/2.3.1/gems/rspec-core-3.5.4/exe/rspec:4:in `<top (required)>'
            +/Users/johnbackus/.gem/ruby/2.3.1/bin/rspec:23:in `load'
            +/Users/johnbackus/.gem/ruby/2.3.1/bin/rspec:23:in `<top (required)>'
            +/Users/johnbackus/.gem/ruby/2.3.1/gems/bundler-1.13.2/lib/bundler/cli/exec.rb:74:in `load'
            +/Users/johnbackus/.gem/ruby/2.3.1/gems/bundler-1.13.2/lib/bundler/cli/exec.rb:74:in `kernel_load'
            +/Users/johnbackus/.gem/ruby/2.3.1/gems/bundler-1.13.2/lib/bundler/cli/exec.rb:27:in `run'
            +/Users/johnbackus/.gem/ruby/2.3.1/gems/bundler-1.13.2/lib/bundler/cli.rb:332:in `exec'
            +/Users/johnbackus/.gem/ruby/2.3.1/gems/bundler-1.13.2/lib/bundler/vendor/thor/lib/thor/command.rb:27:in `run'
            +/Users/johnbackus/.gem/ruby/2.3.1/gems/bundler-1.13.2/lib/bundler/vendor/thor/lib/thor/invocation.rb:126:in `invoke_command'
            +/Users/johnbackus/.gem/ruby/2.3.1/gems/bundler-1.13.2/lib/bundler/vendor/thor/lib/thor.rb:359:in `dispatch'
            +/Users/johnbackus/.gem/ruby/2.3.1/gems/bundler-1.13.2/lib/bundler/cli.rb:20:in `dispatch'
            +/Users/johnbackus/.gem/ruby/2.3.1/gems/bundler-1.13.2/lib/bundler/vendor/thor/lib/thor/base.rb:440:in `start'
            +/Users/johnbackus/.gem/ruby/2.3.1/gems/bundler-1.13.2/lib/bundler/cli.rb:11:in `start'
            +/Users/johnbackus/.gem/ruby/2.3.1/gems/bundler-1.13.2/exe/bundle:34:in `block in <top (required)>'
            +/Users/johnbackus/.gem/ruby/2.3.1/gems/bundler-1.13.2/lib/bundler/friendly_errors.rb:100:in `with_friendly_errors'
            +/Users/johnbackus/.gem/ruby/2.3.1/gems/bundler-1.13.2/exe/bundle:26:in `<top (required)>'
            +/Users/johnbackus/.gem/ruby/2.3.1/bin/bundle:23:in `load'
            +/Users/johnbackus/.gem/ruby/2.3.1/bin/bundle:23:in `<main>'

          # ./spec/rubocop/cli_spec.rb:378:in `block (6 levels) in <top (required)>'

     8.3) Failure/Error:
            expect($stdout.string)
              .to eq(["#{abs('example.rb')}:1:81: C: Line is too long. [95/80]",
                      ''].join("\n"))

            expected: "/private/var/folders/wq/h965ll7s5bqcpzcd58b__pw00000gn/T/d20170102-5582-nyhzrl/work/example.rb:1:81: C: Line is too long. [95/80]\n"
                 got: ""

            (compared using ==)

            Diff:
            @@ -1,2 +1 @@
            -/private/var/folders/wq/h965ll7s5bqcpzcd58b__pw00000gn/T/d20170102-5582-nyhzrl/work/example.rb:1:81: C: Line is too long. [95/80]

          # ./spec/rubocop/cli_spec.rb:379:in `block (6 levels) in <top (required)>'

  9) RuboCop::CLI rubocop:disable comment when not necessary and UnneededDisable is individually excluded does not report UnneededDisable offenses
     Got 3 failures from failure aggregation block.
     Shared Example Group: "UnneededDisable not run" called from ./spec/rubocop/cli_spec.rb:389
     # ./spec/support/cli_spec_behavior.rb:3:in `block (2 levels) in <top (required)>'
     # ./lib/rubocop/rspec/shared_contexts.rb:27:in `block (4 levels) in <top (required)>'
     # ./lib/rubocop/rspec/shared_contexts.rb:26:in `chdir'
     # ./lib/rubocop/rspec/shared_contexts.rb:26:in `block (3 levels) in <top (required)>'
     # ./lib/rubocop/rspec/shared_contexts.rb:8:in `block (2 levels) in <top (required)>'

     9.1) Failure/Error: expect(cli.run(['--format', 'emacs'])).to eq(1)

            expected: 1
                 got: 2

            (compared using ==)
          # ./spec/rubocop/cli_spec.rb:377:in `block (6 levels) in <top (required)>'

     9.2) Failure/Error: expect($stderr.string).to eq('')

            expected: ""
                 got: "An error occurred while Metrics/LineLength cop was inspecting /private/var/folders/wq/h965ll7s5bqcpz...m/ruby/2.3.1/bin/bundle:23:in `load'\n/Users/johnbackus/.gem/ruby/2.3.1/bin/bundle:23:in `<main>'\n"

            (compared using ==)

            Diff:
            @@ -1 +1,101 @@
            +An error occurred while Metrics/LineLength cop was inspecting /private/var/folders/wq/h965ll7s5bqcpzcd58b__pw00000gn/T/d20170102-5582-1665rvi/work/example.rb.
            +To see the complete backtrace run rubocop -d.
            +undefined method `names' for #<Array:0x007fc389483da8>
            +/Users/johnbackus/Projects/rubocop/lib/rubocop/comment_config.rb:136:in `all_cop_names'
            +/Users/johnbackus/Projects/rubocop/lib/rubocop/comment_config.rb:124:in `directive_parts'
            +/Users/johnbackus/Projects/rubocop/lib/rubocop/comment_config.rb:110:in `block in each_directive'
            +/Users/johnbackus/Projects/rubocop/lib/rubocop/comment_config.rb:109:in `each'
            +/Users/johnbackus/Projects/rubocop/lib/rubocop/comment_config.rb:109:in `each_directive'
            +/Users/johnbackus/Projects/rubocop/lib/rubocop/comment_config.rb:95:in `each_mentioned_cop'
            +/Users/johnbackus/Projects/rubocop/lib/rubocop/comment_config.rb:42:in `analyze'
            +/Users/johnbackus/Projects/rubocop/lib/rubocop/comment_config.rb:34:in `cop_disabled_line_ranges'
            +/Users/johnbackus/Projects/rubocop/lib/rubocop/processed_source.rb:44:in `disabled_line_ranges'
            +/Users/johnbackus/Projects/rubocop/lib/rubocop/runner.rb:136:in `check_for_unneded_disables?'
            +/Users/johnbackus/Projects/rubocop/lib/rubocop/runner.rb:119:in `add_unneeded_disables'
            +/Users/johnbackus/Projects/rubocop/lib/rubocop/runner.rb:102:in `block in file_offenses'
            +/Users/johnbackus/Projects/rubocop/lib/rubocop/runner.rb:111:in `file_offense_cache'
            +/Users/johnbackus/Projects/rubocop/lib/rubocop/runner.rb:99:in `file_offenses'
            +/Users/johnbackus/Projects/rubocop/lib/rubocop/runner.rb:90:in `process_file'
            +/Users/johnbackus/Projects/rubocop/lib/rubocop/runner.rb:68:in `block in each_inspected_file'
            +/Users/johnbackus/Projects/rubocop/lib/rubocop/runner.rb:65:in `each'
            +/Users/johnbackus/Projects/rubocop/lib/rubocop/runner.rb:65:in `reduce'
            +/Users/johnbackus/Projects/rubocop/lib/rubocop/runner.rb:65:in `each_inspected_file'
            +/Users/johnbackus/Projects/rubocop/lib/rubocop/runner.rb:57:in `inspect_files'
            +/Users/johnbackus/Projects/rubocop/lib/rubocop/runner.rb:36:in `run'
            +/Users/johnbackus/Projects/rubocop/lib/rubocop/cli.rb:72:in `execute_runner'
            +/Users/johnbackus/Projects/rubocop/lib/rubocop/cli.rb:27:in `run'
            +/Users/johnbackus/Projects/rubocop/spec/rubocop/cli_spec.rb:377:in `block (6 levels) in <top (required)>'
            +/Users/johnbackus/.gem/ruby/2.3.1/gems/rspec-core-3.5.4/lib/rspec/core/example.rb:254:in `instance_exec'
            +/Users/johnbackus/.gem/ruby/2.3.1/gems/rspec-core-3.5.4/lib/rspec/core/example.rb:254:in `block in run'
            +/Users/johnbackus/.gem/ruby/2.3.1/gems/rspec-core-3.5.4/lib/rspec/core/example.rb:496:in `block in with_around_and_singleton_context_hooks'
            +/Users/johnbackus/.gem/ruby/2.3.1/gems/rspec-core-3.5.4/lib/rspec/core/example.rb:453:in `block in with_around_example_hooks'
            +/Users/johnbackus/.gem/ruby/2.3.1/gems/rspec-core-3.5.4/lib/rspec/core/hooks.rb:464:in `block in run'
            +/Users/johnbackus/.gem/ruby/2.3.1/gems/rspec-core-3.5.4/lib/rspec/core/hooks.rb:604:in `block in run_around_example_hooks_for'
            +/Users/johnbackus/.gem/ruby/2.3.1/gems/rspec-core-3.5.4/lib/rspec/core/example.rb:338:in `call'
            +/Users/johnbackus/.gem/ruby/2.3.1/gems/rspec-expectations-3.5.0/lib/rspec/expectations/failure_aggregator.rb:10:in `block in aggregate'
            +/Users/johnbackus/.gem/ruby/2.3.1/gems/rspec-support-3.5.0/lib/rspec/support.rb:103:in `with_failure_notifier'
            +/Users/johnbackus/.gem/ruby/2.3.1/gems/rspec-expectations-3.5.0/lib/rspec/expectations/failure_aggregator.rb:8:in `aggregate'
            +/Users/johnbackus/.gem/ruby/2.3.1/gems/rspec-expectations-3.5.0/lib/rspec/matchers.rb:313:in `aggregate_failures'
            +/Users/johnbackus/Projects/rubocop/spec/support/cli_spec_behavior.rb:3:in `block (2 levels) in <top (required)>'
            +/Users/johnbackus/.gem/ruby/2.3.1/gems/rspec-core-3.5.4/lib/rspec/core/example.rb:443:in `instance_exec'
            +/Users/johnbackus/.gem/ruby/2.3.1/gems/rspec-core-3.5.4/lib/rspec/core/example.rb:443:in `instance_exec'
            +/Users/johnbackus/.gem/ruby/2.3.1/gems/rspec-core-3.5.4/lib/rspec/core/hooks.rb:375:in `execute_with'
            +/Users/johnbackus/.gem/ruby/2.3.1/gems/rspec-core-3.5.4/lib/rspec/core/hooks.rb:606:in `block (2 levels) in run_around_example_hooks_for'
            +/Users/johnbackus/.gem/ruby/2.3.1/gems/rspec-core-3.5.4/lib/rspec/core/example.rb:338:in `call'
            +/Users/johnbackus/Projects/rubocop/lib/rubocop/rspec/shared_contexts.rb:27:in `block (4 levels) in <top (required)>'
            +/Users/johnbackus/Projects/rubocop/lib/rubocop/rspec/shared_contexts.rb:26:in `chdir'
            +/Users/johnbackus/Projects/rubocop/lib/rubocop/rspec/shared_contexts.rb:26:in `block (3 levels) in <top (required)>'
            +/Users/johnbackus/.rubies/ruby-2.3.1/lib/ruby/2.3.0/tmpdir.rb:89:in `mktmpdir'
            +/Users/johnbackus/Projects/rubocop/lib/rubocop/rspec/shared_contexts.rb:8:in `block (2 levels) in <top (required)>'
            +/Users/johnbackus/.gem/ruby/2.3.1/gems/rspec-core-3.5.4/lib/rspec/core/example.rb:443:in `instance_exec'
            +/Users/johnbackus/.gem/ruby/2.3.1/gems/rspec-core-3.5.4/lib/rspec/core/example.rb:443:in `instance_exec'
            +/Users/johnbackus/.gem/ruby/2.3.1/gems/rspec-core-3.5.4/lib/rspec/core/hooks.rb:375:in `execute_with'
            +/Users/johnbackus/.gem/ruby/2.3.1/gems/rspec-core-3.5.4/lib/rspec/core/hooks.rb:606:in `block (2 levels) in run_around_example_hooks_for'
            +/Users/johnbackus/.gem/ruby/2.3.1/gems/rspec-core-3.5.4/lib/rspec/core/example.rb:338:in `call'
            +/Users/johnbackus/.gem/ruby/2.3.1/gems/rspec-core-3.5.4/lib/rspec/core/hooks.rb:607:in `run_around_example_hooks_for'
            +/Users/johnbackus/.gem/ruby/2.3.1/gems/rspec-core-3.5.4/lib/rspec/core/hooks.rb:464:in `run'
            +/Users/johnbackus/.gem/ruby/2.3.1/gems/rspec-core-3.5.4/lib/rspec/core/example.rb:453:in `with_around_example_hooks'
            +/Users/johnbackus/.gem/ruby/2.3.1/gems/rspec-core-3.5.4/lib/rspec/core/example.rb:496:in `with_around_and_singleton_context_hooks'
            +/Users/johnbackus/.gem/ruby/2.3.1/gems/rspec-core-3.5.4/lib/rspec/core/example.rb:251:in `run'
            +/Users/johnbackus/.gem/ruby/2.3.1/gems/rspec-core-3.5.4/lib/rspec/core/example_group.rb:627:in `block in run_examples'
            +/Users/johnbackus/.gem/ruby/2.3.1/gems/rspec-core-3.5.4/lib/rspec/core/example_group.rb:623:in `map'
            +/Users/johnbackus/.gem/ruby/2.3.1/gems/rspec-core-3.5.4/lib/rspec/core/example_group.rb:623:in `run_examples'
            +/Users/johnbackus/.gem/ruby/2.3.1/gems/rspec-core-3.5.4/lib/rspec/core/example_group.rb:589:in `run'
            +/Users/johnbackus/.gem/ruby/2.3.1/gems/rspec-core-3.5.4/lib/rspec/core/example_group.rb:590:in `block in run'
            +/Users/johnbackus/.gem/ruby/2.3.1/gems/rspec-core-3.5.4/lib/rspec/core/example_group.rb:590:in `map'
            +/Users/johnbackus/.gem/ruby/2.3.1/gems/rspec-core-3.5.4/lib/rspec/core/example_group.rb:590:in `run'
            +/Users/johnbackus/.gem/ruby/2.3.1/gems/rspec-core-3.5.4/lib/rspec/core/example_group.rb:590:in `block in run'
            +/Users/johnbackus/.gem/ruby/2.3.1/gems/rspec-core-3.5.4/lib/rspec/core/example_group.rb:590:in `map'
            +/Users/johnbackus/.gem/ruby/2.3.1/gems/rspec-core-3.5.4/lib/rspec/core/example_group.rb:590:in `run'
            +/Users/johnbackus/.gem/ruby/2.3.1/gems/rspec-core-3.5.4/lib/rspec/core/example_group.rb:590:in `block in run'
            +/Users/johnbackus/.gem/ruby/2.3.1/gems/rspec-core-3.5.4/lib/rspec/core/example_group.rb:590:in `map'
            +/Users/johnbackus/.gem/ruby/2.3.1/gems/rspec-core-3.5.4/lib/rspec/core/example_group.rb:590:in `run'
            +/Users/johnbackus/.gem/ruby/2.3.1/gems/rspec-core-3.5.4/lib/rspec/core/runner.rb:113:in `block (3 levels) in run_specs'
            +/Users/johnbackus/.gem/ruby/2.3.1/gems/rspec-core-3.5.4/lib/rspec/core/runner.rb:113:in `map'
            +/Users/johnbackus/.gem/ruby/2.3.1/gems/rspec-core-3.5.4/lib/rspec/core/runner.rb:113:in `block (2 levels) in run_specs'
            +/Users/johnbackus/.gem/ruby/2.3.1/gems/rspec-core-3.5.4/lib/rspec/core/configuration.rb:1835:in `with_suite_hooks'
            +/Users/johnbackus/.gem/ruby/2.3.1/gems/rspec-core-3.5.4/lib/rspec/core/runner.rb:112:in `block in run_specs'
            +/Users/johnbackus/.gem/ruby/2.3.1/gems/rspec-core-3.5.4/lib/rspec/core/reporter.rb:77:in `report'
            +/Users/johnbackus/.gem/ruby/2.3.1/gems/rspec-core-3.5.4/lib/rspec/core/runner.rb:111:in `run_specs'
            +/Users/johnbackus/.gem/ruby/2.3.1/gems/rspec-core-3.5.4/lib/rspec/core/runner.rb:87:in `run'
            +/Users/johnbackus/.gem/ruby/2.3.1/gems/rspec-core-3.5.4/lib/rspec/core/runner.rb:71:in `run'
            +/Users/johnbackus/.gem/ruby/2.3.1/gems/rspec-core-3.5.4/lib/rspec/core/runner.rb:45:in `invoke'
            +/Users/johnbackus/.gem/ruby/2.3.1/gems/rspec-core-3.5.4/exe/rspec:4:in `<top (required)>'
            +/Users/johnbackus/.gem/ruby/2.3.1/bin/rspec:23:in `load'
            +/Users/johnbackus/.gem/ruby/2.3.1/bin/rspec:23:in `<top (required)>'
            +/Users/johnbackus/.gem/ruby/2.3.1/gems/bundler-1.13.2/lib/bundler/cli/exec.rb:74:in `load'
            +/Users/johnbackus/.gem/ruby/2.3.1/gems/bundler-1.13.2/lib/bundler/cli/exec.rb:74:in `kernel_load'
            +/Users/johnbackus/.gem/ruby/2.3.1/gems/bundler-1.13.2/lib/bundler/cli/exec.rb:27:in `run'
            +/Users/johnbackus/.gem/ruby/2.3.1/gems/bundler-1.13.2/lib/bundler/cli.rb:332:in `exec'
            +/Users/johnbackus/.gem/ruby/2.3.1/gems/bundler-1.13.2/lib/bundler/vendor/thor/lib/thor/command.rb:27:in `run'
            +/Users/johnbackus/.gem/ruby/2.3.1/gems/bundler-1.13.2/lib/bundler/vendor/thor/lib/thor/invocation.rb:126:in `invoke_command'
            +/Users/johnbackus/.gem/ruby/2.3.1/gems/bundler-1.13.2/lib/bundler/vendor/thor/lib/thor.rb:359:in `dispatch'
            +/Users/johnbackus/.gem/ruby/2.3.1/gems/bundler-1.13.2/lib/bundler/cli.rb:20:in `dispatch'
            +/Users/johnbackus/.gem/ruby/2.3.1/gems/bundler-1.13.2/lib/bundler/vendor/thor/lib/thor/base.rb:440:in `start'
            +/Users/johnbackus/.gem/ruby/2.3.1/gems/bundler-1.13.2/lib/bundler/cli.rb:11:in `start'
            +/Users/johnbackus/.gem/ruby/2.3.1/gems/bundler-1.13.2/exe/bundle:34:in `block in <top (required)>'
            +/Users/johnbackus/.gem/ruby/2.3.1/gems/bundler-1.13.2/lib/bundler/friendly_errors.rb:100:in `with_friendly_errors'
            +/Users/johnbackus/.gem/ruby/2.3.1/gems/bundler-1.13.2/exe/bundle:26:in `<top (required)>'
            +/Users/johnbackus/.gem/ruby/2.3.1/bin/bundle:23:in `load'
            +/Users/johnbackus/.gem/ruby/2.3.1/bin/bundle:23:in `<main>'

          # ./spec/rubocop/cli_spec.rb:378:in `block (6 levels) in <top (required)>'

     9.3) Failure/Error:
            expect($stdout.string)
              .to eq(["#{abs('example.rb')}:1:81: C: Line is too long. [95/80]",
                      ''].join("\n"))

            expected: "/private/var/folders/wq/h965ll7s5bqcpzcd58b__pw00000gn/T/d20170102-5582-1665rvi/work/example.rb:1:81: C: Line is too long. [95/80]\n"
                 got: ""

            (compared using ==)

            Diff:
            @@ -1,2 +1 @@
            -/private/var/folders/wq/h965ll7s5bqcpzcd58b__pw00000gn/T/d20170102-5582-1665rvi/work/example.rb:1:81: C: Line is too long. [95/80]

          # ./spec/rubocop/cli_spec.rb:379:in `block (6 levels) in <top (required)>'

Finished in 8.22 seconds (files took 0.57733 seconds to load)
224 examples, 9 failures

Failed examples:

rspec './spec/rubocop/cli/cli_options_spec.rb[1:4:4:3]' # RuboCop::CLI --except when several cops are given disables the given cops including Lint
rspec './spec/rubocop/cli/cli_options_spec.rb[1:4:4:1]' # RuboCop::CLI --except when several cops are given disables the given cops including UnneededDisable
rspec './spec/rubocop/cli/cli_options_spec.rb[1:4:4:2]' # RuboCop::CLI --except when several cops are given disables the given cops including Lint/UnneededDisable
rspec ./spec/rubocop/cli_spec.rb:310 # RuboCop::CLI rubocop:disable comment can disable all cops on a single line
rspec ./spec/rubocop/cli_spec.rb:237 # RuboCop::CLI rubocop:disable comment can disable all cops in a code section
rspec ./spec/rubocop/cli_spec.rb:342 # RuboCop::CLI rubocop:disable comment when not necessary causes an offense to be reported
rspec './spec/rubocop/cli_spec.rb[1:11:7:3:1]' # RuboCop::CLI rubocop:disable comment when not necessary and UnneededDisable is individually disabled does not report UnneededDisable offenses
rspec './spec/rubocop/cli_spec.rb[1:11:7:5:1]' # RuboCop::CLI rubocop:disable comment when not necessary and UnneededDisable is disabled through department does not report UnneededDisable offenses
rspec './spec/rubocop/cli_spec.rb[1:11:7:4:1]' # RuboCop::CLI rubocop:disable comment when not necessary and UnneededDisable is individually excluded does not report UnneededDisable offenses

Randomized with seed 64364
```

</details>

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Used the same coding conventions as the rest of the project.
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [ ] All tests are passing.
* [ ] The new code doesn't generate RuboCop offenses.
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Updated cop documentation with `rake generate_cops_documentation` (required only when you've added a new cop or changed the configuration/documentation of an existing cop).

[1]: http://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html
