### PR TITLE
[Fix #3851] Group documentation by badge

### DIFF
--- a/manual/cops_rails.md
+++ b/manual/cops_rails.md
@@ -487,48 +487,43 @@ Enabled by default | Supports autocorrection
 --- | ---
 Disabled | Yes
 
-This cop transforms usages of a method call safeguarded by a non `nil`
-check for the variable whose method is being called to
-safe navigation (`&.`).
-
-Configuration option: ConvertCodeThatCanStartToReturnNil
-The default for this is `false`. When configured to `true`, this will
-check for code in the format `!foo.nil? && foo.bar`. As it is written,
-the return of this code is limited to `false` and whatever the return
-of the method is. If this is converted to safe navigation,
-`foo&.bar` can start returning `nil` as well as what the method
-returns.
+This cop converts usages of `try!` to `&.`. It can also be configured
+to convert `try`. It will convert code to use safe navigation if the
+target Ruby version is set to 2.3+
 
 ### Example
 
 ```ruby
-# bad
-foo.bar if foo
-foo.bar(param1, param2) if foo
-foo.bar { |e| e.something } if foo
-foo.bar(param) { |e| e.something } if foo
+# ConvertTry: false
+  # bad
+  foo.try!(:bar)
+  foo.try!(:bar, baz)
+  foo.try!(:bar) { |e| e.baz }
 
-foo.bar if !foo.nil?
-foo.bar unless !foo
-foo.bar unless foo.nil?
+  foo.try!(:[], 0)
 
-foo && foo.bar
-foo && foo.bar(param1, param2)
-foo && foo.bar { |e| e.something }
-foo && foo.bar(param) { |e| e.something }
+  # good
+  foo.try(:bar)
+  foo.try(:bar, baz)
+  foo.try(:bar) { |e| e.baz }
 
-# good
-foo&.bar
-foo&.bar(param1, param2)
-foo&.bar { |e| e.something }
-foo&.bar(param) { |e| e.something }
+  foo&.bar
+  foo&.bar(baz)
+  foo&.bar { |e| e.baz }
 
-foo.nil? || foo.bar
-!foo || foo.bar
+# ConvertTry: true
+  # bad
+  foo.try!(:bar)
+  foo.try!(:bar, baz)
+  foo.try!(:bar) { |e| e.baz }
+  foo.try(:bar)
+  foo.try(:bar, baz)
+  foo.try(:bar) { |e| e.baz }
 
-# Methods that `nil` will `respond_to?` should not be converted to
-# use safe navigation
-foo.to_i if foo
+  # good
+  foo&.bar
+  foo&.bar(baz)
+  foo&.bar { |e| e.baz }
 ```
 
 ### Important attributes

--- a/tasks/cops_documentation.rake
+++ b/tasks/cops_documentation.rake
@@ -5,10 +5,6 @@ require 'rubocop'
 desc 'Generate docs of all cops departments'
 
 task generate_cops_documentation: :yard do
-  def cop_name_without_department(cop_name)
-    RuboCop::Cop::Badge.parse(cop_name).cop_name.to_sym
-  end
-
   def cops_of_department(cops, department)
     cops.with_department(department).sort!
   end
@@ -95,11 +91,11 @@ task generate_cops_documentation: :yard do
     pars = t.reject { |k| %w(Description Enabled StyleGuide).include? k }
     description = 'No documentation'
     examples_object = []
-    YARD::Registry.all.select { |o| !o.docstring.blank? }.map do |o|
-      if o.name == cop_name_without_department(cop.cop_name)
-        description = o.docstring
-        examples_object = o.tags('example')
-      end
+    YARD::Registry.all(:class).detect do |code_object|
+      next unless RuboCop::Cop::Badge.for(code_object.to_s) == cop.badge
+
+      description = code_object.docstring unless code_object.docstring.blank?
+      examples_object = code_object.tags('example')
     end
     cops_body(config, cop, description, examples_object, pars)
   end


### PR DESCRIPTION
Previously the manual generator would group YARD code objects
if the name matched the cop name. This was a problem for cop names
that exist in two departments like Style/SafeNavigation and
Rails/SafeNavigation. This was the problem that led to #3851.

This change fixes #3851 by matching documentation by cop badge instead.
Also, I've made a change to the grouping which seems to have
significantly sped up documentation generation. The previous
implementation would continue to scan all yard documentation even after
a match was found while my replacement will stop scanning once it finds
documentation matching the given cop badge.

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Used the same coding conventions as the rest of the project.
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [ ] All tests are passing.
* [ ] The new code doesn't generate RuboCop offenses.
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Updated cop documentation with `rake generate_cops_documentation` (required only when you've added a new cop or changed the configuration/documentation of an existing cop).

[1]: http://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html
