### PR TITLE
Fix false positive in `RedundantParentheses` cop with multiple expression

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,6 +49,7 @@
 * Fix false negative in `Rails/HttpPositionalArguments` where offense would go undetected if the `:format` keyword was used with other non-special keywords. ([@deivid-rodriguez][])
 * [#3406](https://github.com/bbatsov/rubocop/issues/3406): Enable cops if Enabled is not explicitly set to false. ([@metcalf][])
 * Fix `Lint/FormatParameterMismatch` for splatted last argument. ([@zverok][])
+* [#3853](https://github.com/bbatsov/rubocop/pull/3853): Fix false positive in `RedundantParentheses` cop with multiple expression. ([@pocke][])
 
 ## 0.46.0 (2016-11-30)
 

--- a/lib/rubocop/cop/style/redundant_parentheses.rb
+++ b/lib/rubocop/cop/style/redundant_parentheses.rb
@@ -37,7 +37,8 @@ module RuboCop
             hash_literal_as_first_arg?(node) ||
             rescue?(node) ||
             allowed_method_call?(node) ||
-            allowed_array_or_hash_element?(node)
+            allowed_array_or_hash_element?(node) ||
+            allowed_multiple_expression?(node)
         end
 
         def allowed_ancestor?(node)
@@ -48,6 +49,13 @@ module RuboCop
         def allowed_method_call?(node)
           # Don't flag `method (arg) { }`
           arg_in_call_with_block?(node) && !parentheses?(node.parent)
+        end
+
+        def allowed_multiple_expression?(node)
+          return false if node.children.size == 1
+          ancestor = node.ancestors.first
+          return false unless ancestor
+          !ancestor.begin_type? && !ancestor.def_type? && !ancestor.block_type?
         end
 
         def empty_parentheses?(node)

--- a/spec/rubocop/cop/style/redundant_parentheses_spec.rb
+++ b/spec/rubocop/cop/style/redundant_parentheses_spec.rb
@@ -52,6 +52,8 @@ describe RuboCop::Cop::Style::RedundantParentheses do
   it_behaves_like 'redundant', '(true)', 'true', 'a literal'
   it_behaves_like 'redundant', '(false)', 'false', 'a literal'
   it_behaves_like 'redundant', '(/regexp/)', '/regexp/', 'a literal'
+  it_behaves_like 'redundant', '("x"; "y")', '"x"; "y"', 'a literal'
+  it_behaves_like 'redundant', '(1; 2)', '1; 2', 'a literal'
   if RUBY_VERSION >= '2.1'
     it_behaves_like 'redundant', '(1i)', '1i', 'a literal'
     it_behaves_like 'redundant', '(1r)', '1r', 'a literal'
@@ -93,6 +95,7 @@ describe RuboCop::Cop::Style::RedundantParentheses do
   it_behaves_like 'redundant', '("foo"[0])', '"foo"[0]', 'a method call'
   it_behaves_like 'redundant', '(["foo"][0])', '["foo"][0]', 'a method call'
   it_behaves_like 'redundant', '({0 => :a}[0])', '{0 => :a}[0]', 'a method call'
+  it_behaves_like 'redundant', '(x; y)', 'x; y', 'a method call'
 
   it_behaves_like 'redundant', '(!x)', '!x', 'an unary operation'
   it_behaves_like 'redundant', '(~x)', '~x', 'an unary operation'
@@ -119,6 +122,51 @@ describe RuboCop::Cop::Style::RedundantParentheses do
   it_behaves_like 'redundant', '2**(2)', '2**2', 'a literal', '(2)'
   it_behaves_like 'plausible', '(-2)**2'
   it_behaves_like 'plausible', '(-2.1)**2'
+
+  it_behaves_like 'plausible', 'x = (foo; bar)'
+  it_behaves_like 'plausible', 'x += (foo; bar)'
+  it_behaves_like 'plausible', 'x + (foo; bar)'
+  it_behaves_like 'plausible', 'x((foo; bar))'
+  it_behaves_like 'redundant', <<-END, <<-END2, 'a method call', '(foo; bar)'
+    def x
+      (foo; bar)
+    end
+  END
+    def x
+      foo; bar
+    end
+  END2
+  it_behaves_like 'redundant', <<-END, <<-END2, 'a method call', '(foo; bar)'
+    def x
+      baz
+      (foo; bar)
+    end
+  END
+    def x
+      baz
+      foo; bar
+    end
+  END2
+  it_behaves_like 'redundant', <<-END, <<-END2, 'a method call', '(foo; bar)'
+    x do
+      (foo; bar)
+    end
+  END
+    x do
+      foo; bar
+    end
+  END2
+  it_behaves_like 'redundant', <<-END, <<-END2, 'a method call', '(foo; bar)'
+    x do
+      baz
+      (foo; bar)
+    end
+  END
+    x do
+      baz
+      foo; bar
+    end
+  END2
 
   it 'accepts parentheses around a method call with unparenthesized ' \
      'arguments' do


### PR DESCRIPTION


Style/RedundantParentheses cop has a false positive.

For example.

```ruby
 # test.rb
x ||= (
  foo
  bar
)
```

```sh
$ rubocop --only Style/RedundantParentheses test.rb
Inspecting 1 file
C

Offenses:

test.rb:2:7: C: Don't use parentheses around a method call.
x ||= ( ...
      ^

1 file inspected, 1 offense detected
```

However, the parentheses can't be omitted.


-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Used the same coding conventions as the rest of the project.
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] All tests are passing.
* [x] The new code doesn't generate RuboCop offenses.
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Updated cop documentation with `rake generate_cops_documentation` (required only when you've added a new cop or changed the configuration/documentation of an existing cop).

[1]: http://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html
