### PR TITLE
Fix Lint/FormatParameterMismatch for splatted last argument

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,7 @@
 * Fix false negative in `Rails/HttpPositionalArguments` where offense would go undetected if one of the request parameter names matched one of the special keyword arguments. ([@deivid-rodriguez][])
 * Fix false negative in `Rails/HttpPositionalArguments` where offense would go undetected if the `:format` keyword was used with other non-special keywords. ([@deivid-rodriguez][])
 * [#3406](https://github.com/bbatsov/rubocop/issues/3406): Enable cops if Enabled is not explicitly set to false. ([@metcalf][])
+* Fix `Lint/FormatParameterMismatch` for splatted last argument. ([@zverok][])
 
 ## 0.46.0 (2016-11-30)
 
@@ -2573,3 +2574,4 @@
 [@vergenzt]: https://github.com/vergenzt
 [@rahulcs]: https://github.com/rahulcs
 [@dominh]: https://github.com/dominh
+[@zverok]: https://github.com/zverok

--- a/spec/rubocop/cop/lint/format_parameter_mismatch_spec.rb
+++ b/spec/rubocop/cop/lint/format_parameter_mismatch_spec.rb
@@ -138,6 +138,26 @@ describe RuboCop::Cop::Lint::FormatParameterMismatch do
     expect(cop.offenses).to be_empty
   end
 
+  context 'when splat argument is present' do
+    it 'does not register an offense when args count is less than expected' do
+      inspect_source(cop, '"%s, %s, %s" % [1, *arr]')
+      expect(cop.offenses).to be_empty
+      inspect_source(cop, 'format("%s, %s, %s", 1, *arr)')
+      expect(cop.offenses).to be_empty
+      inspect_source(cop, 'sprintf("%s, %s, %s", 1, *arr)')
+      expect(cop.offenses).to be_empty
+    end
+
+    it 'does register an offense when args count is more than expected' do
+      inspect_source(cop, 'puts "%s, %s, %s" % [1, 2, 3, 4, *arr]')
+      expect(cop.offenses).not_to be_empty
+      inspect_source(cop, 'format("%s, %s, %s", 1, 2, 3, 4, *arr)')
+      expect(cop.offenses).not_to be_empty
+      inspect_source(cop, 'sprintf("%s, %s, %s", 1, 2, 3, 4, *arr)')
+      expect(cop.offenses).not_to be_empty
+    end
+  end
+
   context 'when multiple arguments are called for' do
     context 'and a single variable argument is passed' do
       it 'does not register an offense' do


### PR DESCRIPTION
Previously, cases like `'#<%s (%s-%s)>' % [self.class, *values.minmax]` gave false offense (too low argument number) for this cop. With this commit, only when provided arguments count is definitely more than expected (even considering splat), offense is generated:

```ruby
# code
array = [1, 2]
puts '#<%s (%s-%s)>' % [1, *array]
# rubocop: no offenses

# code
array = [1, 2]
puts '#<%s>' % [1, 2, *array]
# rubocop: 
# Number of arguments (-2) to String#% doesn't match the number of fields (1).
```
Negative arguments count report, to be honest, is not the most intuitive, yet in line with Ruby's `Method#arity`, which is negative with splat.