### PR TITLE
[Fix #3406] Enable cops if Enabled is not explicitly set

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,7 @@
 * [#3815](https://github.com/bbatsov/rubocop/pull/3815): Fix false positive in `Style/IdenticalConditionalBranches` cop when branches have same line at leading. ([@pocke][])
 * Fix false negative in `Rails/HttpPositionalArguments` where offense would go undetected if one of the request parameter names matched one of the special keyword arguments. ([@deivid-rodriguez][])
 * Fix false negative in `Rails/HttpPositionalArguments` where offense would go undetected if the `:format` keyword was used with other non-special keywords. ([@deivid-rodriguez][])
+* [#3406](https://github.com/bbatsov/rubocop/issues/3406): Enable cops if Enabled is not explicitly set to false. ([@metcalf][])
 
 ## 0.46.0 (2016-11-30)
 

--- a/lib/rubocop/config.rb
+++ b/lib/rubocop/config.rb
@@ -146,7 +146,7 @@ module RuboCop
         return false if dept_config['Enabled'] == false
       end
 
-      for_cop(cop).empty? || for_cop(cop)['Enabled']
+      for_cop(cop).empty? || for_cop(cop).fetch('Enabled', true)
     end
 
     def validate

--- a/spec/rubocop/config_spec.rb
+++ b/spec/rubocop/config_spec.rb
@@ -458,6 +458,19 @@ describe RuboCop::Config do
         end
       end
     end
+
+    context 'when a cop has configuration but no explicit Enabled setting' do
+      let(:hash) do
+        {
+          'Style/TrailingWhitespace' => { 'Exclude' => ['foo'] }
+        }
+      end
+
+      it 'enables the cop by default' do
+        cop_class = RuboCop::Cop::Style::TrailingWhitespace
+        expect(configuration.cop_enabled?(cop_class)).to be true
+      end
+    end
   end
 
   describe '#target_ruby_version' do


### PR DESCRIPTION
Previously, cops that have no configuration were treated as enabled by default but cops with configuration needed to have Enabled explicitly set. This means that adding Exclude configuration for a custom cop has the unintuitive result of disabling it unless you also explicitly configure it to be enabled.

This fixes #3406 by defaulting the value of Enabled to true.