### PR TITLE
Deduplicate two similar name formatting mixins

### DIFF
--- a/lib/rubocop.rb
+++ b/lib/rubocop.rb
@@ -57,6 +57,7 @@ require 'rubocop/cop/mixin/configurable_max'
 require 'rubocop/cop/mixin/code_length' # relies on configurable_max
 require 'rubocop/cop/mixin/classish_length' # relies on code_length
 require 'rubocop/cop/mixin/configurable_enforced_style'
+require 'rubocop/cop/mixin/configurable_formatting'
 require 'rubocop/cop/mixin/configurable_naming'
 require 'rubocop/cop/mixin/configurable_numbering'
 require 'rubocop/cop/mixin/def_node'

--- a/lib/rubocop/cop/mixin/configurable_enforced_style.rb
+++ b/lib/rubocop/cop/mixin/configurable_enforced_style.rb
@@ -76,7 +76,11 @@ module RuboCop
           raise 'alternative_style can only be used when there are exactly ' \
                '2 SupportedStyles'
         end
-        (supported_styles - [style]).first
+        alternative_styles.first
+      end
+
+      def alternative_styles
+        (supported_styles - [style])
       end
 
       def supported_styles

--- a/lib/rubocop/cop/mixin/configurable_formatting.rb
+++ b/lib/rubocop/cop/mixin/configurable_formatting.rb
@@ -1,0 +1,48 @@
+# frozen_string_literal: true
+
+module RuboCop
+  module Cop
+    # Shared functionality between mixins that enforce naming conventions
+    module ConfigurableFormatting
+      include ConfigurableEnforcedStyle
+
+      def check_name(node, name, name_range)
+        return if operator?(name)
+
+        if valid_name?(node, name)
+          correct_style_detected
+        else
+          add_offense(node, name_range, message(style)) do
+            report_opposing_styles(node, name)
+          end
+        end
+      end
+
+      def report_opposing_styles(node, name)
+        alternative_styles.each do |alternative|
+          if valid_name?(node, name, alternative)
+            return unexpected_style_detected(alternative)
+          end
+        end
+      end
+
+      def valid_name?(node, name, given_style = style)
+        name.match(self.class::FORMATS.fetch(given_style)) ||
+          class_emitter_method?(node, name)
+      end
+
+      # A class emitter method is a singleton method in a class/module, where
+      # the method has the same name as a class defined in the class/module.
+      def class_emitter_method?(node, name)
+        return false unless node.parent && node.defs_type?
+        # a class emitter method may be defined inside `def self.included`,
+        # `def self.extended`, etc.
+        node = node.parent while node.parent.defs_type?
+
+        node.parent.each_child_node(:class).any? do |c|
+          c.loc.name.is?(name.to_s)
+        end
+      end
+    end
+  end
+end

--- a/lib/rubocop/cop/mixin/configurable_naming.rb
+++ b/lib/rubocop/cop/mixin/configurable_naming.rb
@@ -5,40 +5,12 @@ module RuboCop
     # This module provides functionality for checking if names match the
     # configured EnforcedStyle.
     module ConfigurableNaming
-      include ConfigurableEnforcedStyle
+      include ConfigurableFormatting
 
-      SNAKE_CASE = /^@{0,2}[\da-z_]+[!?=]?$/
-      CAMEL_CASE = /^@{0,2}_?[a-z][\da-zA-Z]+[!?=]?$/
-
-      def check_name(node, name, name_range)
-        return if operator?(name)
-
-        if valid_name?(node, name)
-          correct_style_detected
-        else
-          add_offense(node, name_range, message(style)) do
-            opposite_style_detected
-          end
-        end
-      end
-
-      def valid_name?(node, name)
-        pattern = (style == :snake_case ? SNAKE_CASE : CAMEL_CASE)
-        name.match(pattern) || class_emitter_method?(node, name)
-      end
-
-      # A class emitter method is a singleton method in a class/module, where
-      # the method has the same name as a class defined in the class/module.
-      def class_emitter_method?(node, name)
-        return false unless node.parent && node.defs_type?
-        # a class emitter method may be defined inside `def self.included`,
-        # `def self.extended`, etc.
-        node = node.parent while node.parent.defs_type?
-
-        node.parent.each_child_node(:class).any? do |c|
-          c.loc.name.is?(name.to_s)
-        end
-      end
+      FORMATS = {
+        snake_case: /^@{0,2}[\da-z_]+[!?=]?$/,
+        camelCase:  /^@{0,2}_?[a-z][\da-zA-Z]+[!?=]?$/
+      }.freeze
     end
   end
 end

--- a/lib/rubocop/cop/mixin/configurable_numbering.rb
+++ b/lib/rubocop/cop/mixin/configurable_numbering.rb
@@ -5,54 +5,13 @@ module RuboCop
     # This module provides functionality for checking if numbering match the
     # configured EnforcedStyle.
     module ConfigurableNumbering
-      include ConfigurableEnforcedStyle
+      include ConfigurableFormatting
 
-      SNAKE_CASE = /(?:[a-z_]|_\d+)$/
-      NORMAL_CASE = /(?:_\D*|[A-Za-z]\d*)$/
-      NON_INTEGER = /[A-Za-z_]$/
-
-      def check_name(node, name, name_range)
-        return if operator?(name)
-
-        if valid_name?(node, name, style)
-          correct_style_detected
-        else
-          add_offense(node, name_range, message(style)) do
-            (supported_styles - [style]).each do |other_style|
-              if valid_name?(node, name, other_style)
-                unexpected_style_detected(other_style)
-                break
-              end
-            end
-          end
-        end
-      end
-
-      def valid_name?(node, name, given_style)
-        pattern =
-          case given_style
-          when :snake_case
-            SNAKE_CASE
-          when :normalcase
-            NORMAL_CASE
-          when :non_integer
-            NON_INTEGER
-          end
-        name.match(pattern) || class_emitter_method?(node, name)
-      end
-
-      # A class emitter method is a singleton method in a class/module, where
-      # the method has the same name as a class defined in the class/module.
-      def class_emitter_method?(node, name)
-        return false unless node.parent && node.defs_type?
-        # a class emitter method may be defined inside `def self.included`,
-        # `def self.extended`, etc.
-        node = node.parent while node.parent.defs_type?
-
-        node.parent.each_child_node(:class).any? do |c|
-          c.loc.name.is?(name.to_s)
-        end
-      end
+      FORMATS = {
+        snake_case:  /(?:[a-z_]|_\d+)$/,
+        normalcase:  /(?:_\D*|[A-Za-z]\d*)$/,
+        non_integer: /[A-Za-z_]$/
+      }.freeze
     end
   end
 end


### PR DESCRIPTION
Resolves a lot of duplication between ConfigurableNaming and ConfigurableNumbering

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Used the same coding conventions as the rest of the project.
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] All tests are passing.
* [x] The new code doesn't generate RuboCop offenses.
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Updated cop documentation with `rake generate_cops_documentation` (required only when you've added a new cop or changed the configuration/documentation of an existing cop).

[1]: http://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html
