### PR TITLE
Allow ignoring methods in Style/BlockDelimiters when using line_count_based style

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -106,6 +106,7 @@
 * Add missing examples in `Lint` cops documentation. ([@enriikke][])
 * Make `Style/EmptyMethod` cop aware of class methods. ([@drenmi][])
 * [#3871](https://github.com/bbatsov/rubocop/pull/3871): Add check for void `defined?` and `self` by `Lint/Void` cop. ([@pocke][])
+* Allow ignoring methods in `Style/BlockDelimiters` when using any style. ([@twe4ked][])
 
 ### Bug fixes
 
@@ -2672,3 +2673,4 @@
 [@ota42y]: https://github.com/ota42y
 [@smakagon]: https://github.com/smakagon
 [@musialik]: https://github.com/musialik
+[@twe4ked]: https://github.com/twe4ked

--- a/lib/rubocop/cop/style/block_delimiters.rb
+++ b/lib/rubocop/cop/style/block_delimiters.rb
@@ -129,6 +129,8 @@ module RuboCop
         end
 
         def proper_block_style?(node)
+          return true if ignored_method?(node.method_name)
+
           case style
           when :line_count_based    then line_count_based_block_style?(node)
           when :semantic            then semantic_block_style?(node)
@@ -144,9 +146,6 @@ module RuboCop
 
         def semantic_block_style?(node)
           method_name = node.method_name
-
-          return true if ignored_method?(method_name)
-
           block_begin = node.loc.begin.source
 
           if block_begin == '{'

--- a/spec/rubocop/cop/style/block_delimiters_spec.rb
+++ b/spec/rubocop/cop/style/block_delimiters_spec.rb
@@ -283,7 +283,12 @@ describe RuboCop::Cop::Style::BlockDelimiters, :config do
   end
 
   context 'line count-based style' do
-    let(:cop_config) { { 'EnforcedStyle' => 'line_count_based' } }
+    cop_config = {
+      'EnforcedStyle' => 'line_count_based',
+      'IgnoredMethods' => %w(proc)
+    }
+
+    let(:cop_config) { cop_config }
 
     include_examples 'syntactic styles'
 
@@ -333,6 +338,14 @@ describe RuboCop::Cop::Style::BlockDelimiters, :config do
                '}']
         inspect_source(cop, src)
         expect(cop.offenses).to be_empty
+      end
+
+      it 'accepts a multi-line functional block with {} if it is ' \
+         'an ignored method' do
+        inspect_source(cop, ['foo = proc {',
+                             '  puts 42',
+                             '}'])
+        expect(cop.messages).to be_empty
       end
 
       it 'registers an offense for braces if do-end would not change ' \
@@ -402,7 +415,12 @@ describe RuboCop::Cop::Style::BlockDelimiters, :config do
   end
 
   context 'braces for chaining style' do
-    let(:cop_config) { { 'EnforcedStyle' => 'braces_for_chaining' } }
+    cop_config = {
+      'EnforcedStyle' => 'braces_for_chaining',
+      'IgnoredMethods' => %w(proc)
+    }
+
+    let(:cop_config) { cop_config }
 
     include_examples 'syntactic styles'
 
@@ -419,6 +437,14 @@ describe RuboCop::Cop::Style::BlockDelimiters, :config do
              'end.map(&:to_s)']
       new_source = autocorrect_source(cop, src)
       expect(new_source).to eq("each { |x|\n}.map(&:to_s)")
+    end
+
+    it 'accepts a multi-line functional block with {} if it is ' \
+       'an ignored method' do
+      inspect_source(cop, ['foo = proc {',
+                           '  puts 42',
+                           '}'])
+      expect(cop.messages).to be_empty
     end
 
     context 'when there are braces around a multi-line block' do


### PR DESCRIPTION
See title.

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Used the same coding conventions as the rest of the project.
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] All tests are passing. (~~We'll see what the build server says.~~ Yep.)
* [x] The new code doesn't generate RuboCop offenses.
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Updated cop documentation with `rake generate_cops_documentation` (required only when you've added a new cop or changed the configuration/documentation of an existing cop).

[1]: http://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html
