### PR TITLE
Add check for void `defined?` and `self` by `Lint/Void` cop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@
 * [#3802](https://github.com/bbatsov/rubocop/pull/3802): Ignore case when checking Gemfile order. ([@breckenedge][])
 * Add missing examples in `Lint` cops documentation. ([@enriikke][])
 * Make `Style/EmptyMethod` cop aware of class methods. ([@drenmi][])
+* [#3871](https://github.com/bbatsov/rubocop/pull/3871): Add check for void `defined?` and `self` by `Lint/Void` cop. ([@pocke][])
 
 ### Bug fixes
 

--- a/lib/rubocop/cop/lint/void.rb
+++ b/lib/rubocop/cop/lint/void.rb
@@ -45,6 +45,8 @@ module RuboCop
         OP_MSG = 'Operator `%s` used in void context.'.freeze
         VAR_MSG = 'Variable `%s` used in void context.'.freeze
         LIT_MSG = 'Literal `%s` used in void context.'.freeze
+        SELF_MSG = '`self` used in void context.'.freeze
+        DEFINED_MSG = '`%s` used in void context.'.freeze
 
         OPS = %w(* / % + - == === != < > <= >= <=>).freeze
 
@@ -65,6 +67,8 @@ module RuboCop
             check_for_void_op(expr)
             check_for_literal(expr)
             check_for_var(expr)
+            check_for_self(expr)
+            check_for_defined(expr)
           end
         end
 
@@ -85,6 +89,18 @@ module RuboCop
           return if !node.literal? || node.xstr_type?
 
           add_offense(node, :expression, format(LIT_MSG, node.source))
+        end
+
+        def check_for_self(node)
+          return unless node.self_type?
+
+          add_offense(node, :expression, SELF_MSG)
+        end
+
+        def check_for_defined(node)
+          return unless node.defined_type?
+
+          add_offense(node, :expression, format(DEFINED_MSG, node.source))
         end
       end
     end

--- a/spec/rubocop/cop/lint/void_spec.rb
+++ b/spec/rubocop/cop/lint/void_spec.rb
@@ -50,6 +50,18 @@ describe RuboCop::Cop::Lint::Void do
     end
   end
 
+  it 'registers an offense for void `self` if not on last line' do
+    inspect_source(cop, 'self; top')
+    expect(cop.offenses.size).to eq(1)
+  end
+
+  it 'registers an offense for void `defined?` if not on last line' do
+    inspect_source(cop,
+                   ['defined?(x)',
+                    'top'])
+    expect(cop.offenses.size).to eq(1)
+  end
+
   it 'handles explicit begin blocks' do
     inspect_source(cop,
                    ['begin',


### PR DESCRIPTION
MRI checks void `defined?` and `self` expression.

See. https://github.com/ruby/ruby/blob/trunk/parse.y#L9571-L9654

However, `Lint/Void` cop does not check the expressions currently.

```ruby
 # test.rb
def foo
  self
  defined? Foo
  nil
end
```

```sh
$ rubocop --cache false --only Lint/Void
Inspecting 1 file
.

1 file inspected, no offenses detected
```

This PR changes the cop to check the expressions.



-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Used the same coding conventions as the rest of the project.
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] All tests are passing.
* [x] The new code doesn't generate RuboCop offenses.
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Updated cop documentation with `rake generate_cops_documentation` (required only when you've added a new cop or changed the configuration/documentation of an existing cop).

[1]: http://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html
