### PR TITLE
[Fix #3868] Prevent `Style/WhenThen` from breaking on an empty branch

### DIFF
--- a/lib/rubocop/cop/style/when_then.rb
+++ b/lib/rubocop/cop/style/when_then.rb
@@ -8,7 +8,7 @@ module RuboCop
         MSG = 'Do not use `when x;`. Use `when x then` instead.'.freeze
 
         def on_when(node)
-          return if node.multiline? || node.then?
+          return if node.multiline? || node.then? || !node.body
 
           add_offense(node, :begin)
         end

--- a/spec/rubocop/cop/style/when_then_spec.rb
+++ b/spec/rubocop/cop/style/when_then_spec.rb
@@ -39,4 +39,15 @@ describe RuboCop::Cop::Style::WhenThen do
                               'when b then c',
                               'end'].join("\n"))
   end
+
+  # Regression: https://github.com/bbatsov/rubocop/issues/3868
+  context 'when inspecting a case statement with an empty branch' do
+    it 'does not register an offense' do
+      inspect_source(cop, ['case value',
+                           'when cond1',
+                           'end'])
+
+      expect(cop.offenses).to be_empty
+    end
+  end
 end


### PR DESCRIPTION
This cop would blow up when inspecting a `case` statement with an empty `when` branch. This was missing a test case, and a regression caused by the introduction of node extensions.

This change fixes it.

Note: Since this regression was never part of any release, I omitted the `CHANGELOG` entry. Let me know if it should still go in there. 😀 

-----------------

Before submitting the PR make sure the following are checked:

* [X] Wrote [good commit messages][1].
* [X] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [X] Used the same coding conventions as the rest of the project.
* [X] Feature branch is up-to-date with `master` (if not - rebase it).
* [X] Squashed related commits together.
* [X] Added tests.
* [ ] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [X] All tests are passing.
* [X] The new code doesn't generate RuboCop offenses.
* [X] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [ ] Updated cop documentation with `rake generate_cops_documentation` (required only when you've added a new cop or changed the configuration/documentation of an existing cop).

[1]: http://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html
