### PR TITLE
[Fix #3868] Prevent `Style/IdenticalConditionalBranches` from breaking on an empty branch

### DIFF
--- a/lib/rubocop/cop/style/identical_conditional_branches.rb
+++ b/lib/rubocop/cop/style/identical_conditional_branches.rb
@@ -64,14 +64,14 @@ module RuboCop
         private
 
         def check_branches(branches)
-          tails = branches.map { |branch| tail(branch) }
+          tails = branches.compact.map { |branch| tail(branch) }
           check_expressions(tails)
-          heads = branches.map { |branch| head(branch) }
+          heads = branches.compact.map { |branch| head(branch) }
           check_expressions(heads)
         end
 
         def check_expressions(expressions)
-          return unless expressions.uniq.one?
+          return unless expressions.size > 1 && expressions.uniq.one?
 
           expressions.each do |expression|
             add_offense(expression, :expression, format(MSG, expression.source))

--- a/spec/rubocop/cop/style/identical_conditional_branches_spec.rb
+++ b/spec/rubocop/cop/style/identical_conditional_branches_spec.rb
@@ -117,6 +117,23 @@ describe RuboCop::Cop::Style::IdenticalConditionalBranches do
     end
   end
 
+  # Regression: https://github.com/bbatsov/rubocop/issues/3868
+  context 'when one of the case branches is empty' do
+    let(:source) do
+      ['case value',
+       'when cond1',
+       'else',
+       '  if cond2',
+       '  else',
+       '  end',
+       'end']
+    end
+
+    it 'does not register an offense' do
+      expect(cop.offenses).to be_empty
+    end
+  end
+
   context 'on case with identical trailing lines' do
     let(:source) do
       ['case something',


### PR DESCRIPTION
This cop would fail when inspecting a case statement where one of the branches was empty. This was a missing test case, and is likely a regression caused by the introduction of node extensions.

This change fixes it.

Note: Since this regression was never part of any release, I omitted the `CHANGELOG` entry. Let me know if it should still go in there. 😀

-----------------

Before submitting the PR make sure the following are checked:

* [X] Wrote [good commit messages][1].
* [X] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [X] Used the same coding conventions as the rest of the project.
* [X] Feature branch is up-to-date with `master` (if not - rebase it).
* [X] Squashed related commits together.
* [X] Added tests.
* [ ] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [X] All tests are passing.
* [X] The new code doesn't generate RuboCop offenses.
* [X] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [ ] Updated cop documentation with `rake generate_cops_documentation` (required only when you've added a new cop or changed the configuration/documentation of an existing cop).

[1]: http://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html
