### PR TITLE
[Fix #3869] Prevent `Lint/FormatParameterMismatch` from breaking when `#%` is passed an empty array

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,6 +53,7 @@
 * Fix `Lint/FormatParameterMismatch` for splatted last argument. ([@zverok][])
 * [#3853](https://github.com/bbatsov/rubocop/pull/3853): Fix false positive in `RedundantParentheses` cop with multiple expression. ([@pocke][])
 * [#3870](https://github.com/bbatsov/rubocop/pull/3870): Avoid crash in `Rails/HttpPositionalArguments`. ([@pocke][])
+* [#3869](https://github.com/bbatsov/rubocop/pull/3869): Prevent `Lint/FormatParameterMismatch` from breaking when `#%` is passed an empty array. ([@drenmi][])
 
 ## 0.46.0 (2016-11-30)
 

--- a/lib/rubocop/cop/lint/format_parameter_mismatch.rb
+++ b/lib/rubocop/cop/lint/format_parameter_mismatch.rb
@@ -136,7 +136,9 @@ module RuboCop
         end
 
         def arguments_count(args)
-          if args.last.type == :splat
+          if args.empty?
+            0
+          elsif args.last.type == :splat
             -(args.count - 1)
           else
             args.count

--- a/spec/rubocop/cop/lint/format_parameter_mismatch_spec.rb
+++ b/spec/rubocop/cop/lint/format_parameter_mismatch_spec.rb
@@ -182,6 +182,14 @@ describe RuboCop::Cop::Lint::FormatParameterMismatch do
     end
   end
 
+  # Regression: https://github.com/bbatsov/rubocop/issues/3869
+  context 'when passed an empty array' do
+    it 'does not register an offense' do
+      inspect_source(cop, "'%' % []")
+      expect(cop.offenses).to be_empty
+    end
+  end
+
   it 'ignores percent right next to format string' do
     inspect_source(cop, 'format("%0.1f%% percent", 22.5)')
     expect(cop.offenses).to be_empty


### PR DESCRIPTION
This cop would break if `#%` was passed an empty array, as it attempted to check the type of the last element of the array (which would be `nil`.) This seems to be a regression that appeared in #3858.

This change fixes that.

-----------------

Before submitting the PR make sure the following are checked:

* [X] Wrote [good commit messages][1].
* [X] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [X] Used the same coding conventions as the rest of the project.
* [X] Feature branch is up-to-date with `master` (if not - rebase it).
* [X] Squashed related commits together.
* [X] Added tests.
* [X] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [X] All tests are passing.
* [X] The new code doesn't generate RuboCop offenses.
* [X] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [ ] Updated cop documentation with `rake generate_cops_documentation` (required only when you've added a new cop or changed the configuration/documentation of an existing cop).

[1]: http://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html
