### PR TITLE
Add a link to SideCI into the documentation

### DIFF
--- a/manual/automated_code_review.md
+++ b/manual/automated_code_review.md
@@ -1,15 +1,22 @@
 ## Automated Code Review
 
+The section describes SaaS that provides automated code reviews.
+
 ### Codacy
 
-[Codacy](https://www.codacy.com/) is a service that provides automated code reviews.
-It checks your code from style to security, duplication, complexity, and also integrates with coverage.
+[Codacy](https://www.codacy.com/) checks your code from style to security, duplication, complexity, and also integrates with coverage.
 Codacy is free for open source, and it provides RuboCop analysis out-of-the-box.
 
 ### Code Climate
 
-[Code Climate](https://github.com/codeclimate) is another alternative for automated code reviews.
+[Code Climate](https://codeclimate.com/) provides automated code review for test coverage, complexity, duplication, security, style, and more, and merge with confidence.
 
 ### Hound
 
-[Hound](https://github.com/houndci/hound) is yet another alternative, but their main focus is code style.
+[Hound](https://houndci.com/) comments on style violations in GitHub pull requests, allowing you and your team to better review and maintain a clean codebase.
+It is open source software.
+
+### SideCI
+
+[SideCI](https://sideci.com) improves your team's productivity by automating code analysis.
+It supports Auto-correction.


### PR DESCRIPTION
I work at Actcat inc. and we develop SideCI in this company. https://sideci.com
This service is similar to Codacy and Hound.


I added SideCI section into rubocop documentation.