### PR TITLE
[Fix #3725] Disable `Style/SingleLineBlockParams` by default

### DIFF
--- a/config/disabled.yml
+++ b/config/disabled.yml
@@ -121,4 +121,4 @@ Style/SymbolArray:
 
 Style/SingleLineBlockParams:
   Description: 'Enforces the names of some block params.'
-  Enabled: true
+  Enabled: false

--- a/manual/cops_style.md
+++ b/manual/cops_style.md
@@ -4018,7 +4018,7 @@ SupportedStyles | only_raise, only_fail, semantic
 
 Enabled by default | Supports autocorrection
 --- | ---
-Enabled | No
+Disabled | No
 
 This cop checks whether the block parameters of a single-line
 method accepting a block match the names specified via configuration.


### PR DESCRIPTION
`Style/SingleLineBlockParams` cop was supposed to be disabled in #3755 .
However, it seems to be enabled.

I fixed it.



-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Used the same coding conventions as the rest of the project.
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [ ] Added tests.
* [ ] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] All tests are passing.
* [x] The new code doesn't generate RuboCop offenses.
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Updated cop documentation with `rake generate_cops_documentation` (required only when you've added a new cop or changed the configuration/documentation of an existing cop).

[1]: http://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html
