### PR TITLE
[Fix #2731] Customise method-creating methods.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@
 * Renamed `MethodCallParentheses` to `MethodCallWithoutArgsParentheses`. ([@dominh][])
 * [#3854](https://github.com/bbatsov/rubocop/pull/3854): Add new `Rails/ReversibleMigration` cop. ([@sue445][])
 * [#3872](https://github.com/bbatsov/rubocop/pull/3872): Detect `String#%` with hash literal. ([@backus][])
+* [#2731](https://github.com/bbatsov/rubocop/issues/2731): Allow configuration of method calls that create methods for `Lint/UselessAccessModifier`. ([@pat][])
 
 ### Changes
 
@@ -2584,3 +2585,4 @@
 [@sue445]: https://github.com/sue445
 [@zverok]: https://github.com/zverok
 [@backus]: https://github.com/backus
+[@pat]: https://github.com/pat

--- a/config/enabled.yml
+++ b/config/enabled.yml
@@ -1279,6 +1279,7 @@ Lint/UselessAccessModifier:
   Description: 'Checks for useless access modifiers.'
   Enabled: true
   ContextCreatingMethods: []
+  MethodCreatingMethods: []
 
 Lint/UselessAssignment:
   Description: 'Checks for useless assignment to a local variable.'

--- a/manual/cops_lint.md
+++ b/manual/cops_lint.md
@@ -1784,12 +1784,25 @@ class Foo
   end
 end
 ```
+```ruby
+# Lint/UselessAccessModifier:
+#   MethodCreatingMethods:
+#     - delegate
+require 'active_support/core_ext/module/delegation'
+class Foo
+  # this is not redundant because `delegate` creates methods
+  private
+
+  delegate :method_a, to: :method_b
+end
+```
 
 ### Important attributes
 
 Attribute | Value
 --- | ---
 ContextCreatingMethods | 
+MethodCreatingMethods | 
 
 
 ## Lint/UselessAssignment

--- a/spec/rubocop/cop/lint/useless_access_modifier_spec.rb
+++ b/spec/rubocop/cop/lint/useless_access_modifier_spec.rb
@@ -347,6 +347,36 @@ describe RuboCop::Cop::Lint::UselessAccessModifier do
     end
   end
 
+  context 'when using a known method-creating method' do
+    let(:config) do
+      RuboCop::Config.new(
+        'Lint/UselessAccessModifier' => {
+          'MethodCreatingMethods' => ['delegate']
+        }
+      )
+    end
+    it 'is aware that this creates a new method' do
+      src = ['class SomeClass',
+             '  private',
+             '  ',
+             '  delegate :foo, to: :bar',
+             'end']
+      inspect_source(cop, src)
+      expect(cop.offenses).to be_empty
+    end
+
+    it 'still points out redundant uses within the module' do
+      src = ['class SomeClass',
+             '  delegate :foo, to: :bar',
+             '  ',
+             '  private',
+             'end']
+      inspect_source(cop, src)
+      expect(cop.offenses.size).to eq(1)
+      expect(cop.offenses.first.line).to eq(4)
+    end
+  end
+
   shared_examples 'at the top of the body' do |keyword|
     it 'registers an offense for `public`' do
       src = ["#{keyword} A",


### PR DESCRIPTION
This addresses the issue raised in #2731 where methods (often from outside of Ruby itself) may be called within the context of a module that in turn define methods. The `Lint/UselessAccessModifier` wasn’t taking these into account.

Much like the existing approach taken with blocks/context-creating methods, there’s now a configuration option `MethodCreatingMethods` for the cop. This setting is an array of methods which, when called, are known to create other methods in the module’s current access context.

```ruby
# Lint/UselessAccessModifier:
#   MethodCreatingMethods:
#     - delegate
require 'active_support/core_ext/module/delegation'
class Foo
  # this is not redundant because `delegate` defines methods
  private

  delegate :method_a, to: :method_b
end
```

I realise the option `MethodCreatingMethods` is not the most obvious of names, so I welcome suggestions on alternatives! Also, if there's anything I've missed (this is my first time mucking about with Rubocop's internals) do let me know.

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Used the same coding conventions as the rest of the project.
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] All tests are passing.
* [x] The new code doesn't generate RuboCop offenses.
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Updated cop documentation with `rake generate_cops_documentation` (required only when you've added a new cop or changed the configuration/documentation of an existing cop).

[1]: http://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html