### PR TITLE
Display line number when RuboCop crashes

### DIFF
--- a/lib/rubocop/cop/team.rb
+++ b/lib/rubocop/cop/team.rb
@@ -151,27 +151,32 @@ module RuboCop
 
       def process_commissioner_errors(file, file_errors)
         file_errors.each do |cop, errors|
-          errors.each do |e|
+          errors.each do |cop_error|
+            e = cop_error.error
+            line = ":#{cop_error.line}" if cop_error.line
+            column = ":#{cop_error.column}" if cop_error.column
+            location = "#{file}#{line}#{column}"
+
             if e.is_a?(Warning)
-              handle_warning(e,
-                             Rainbow("#{e.message} (from file: " \
-                             "#{file})").yellow)
+              handle_warning(e, location)
             else
-              handle_error(e,
-                           Rainbow("An error occurred while #{cop.name}" \
-                           " cop was inspecting #{file}.").red)
+              handle_error(e, location, cop)
             end
           end
         end
       end
 
-      def handle_warning(e, message)
+      def handle_warning(e, location)
+        message = Rainbow("#{e.message} (from file: #{location})").yellow
+
         @warnings << message
         warn message
         puts e.backtrace if debug?
       end
 
-      def handle_error(e, message)
+      def handle_error(e, location, cop)
+        message = Rainbow("An error occurred while #{cop.name}" \
+                           " cop was inspecting #{location}.").red
         @errors << message
         warn message
         if debug?

--- a/spec/rubocop/cop/commissioner_spec.rb
+++ b/spec/rubocop/cop/commissioner_spec.rb
@@ -58,7 +58,7 @@ describe RuboCop::Cop::Commissioner do
     end
 
     it 'stores all errors raised by the cops' do
-      allow(cop).to receive(:on_def) { raise RuntimeError }
+      allow(cop).to receive(:on_int) { raise RuntimeError }
 
       commissioner = described_class.new([cop], [])
       source = ['def method', '1', 'end']
@@ -67,12 +67,14 @@ describe RuboCop::Cop::Commissioner do
       commissioner.investigate(processed_source)
 
       expect(commissioner.errors[cop].size).to eq(1)
-      expect(commissioner.errors[cop][0]).to be_instance_of(RuntimeError)
+      expect(commissioner.errors[cop][0].error).to be_instance_of(RuntimeError)
+      expect(commissioner.errors[cop][0].line).to eq 2
+      expect(commissioner.errors[cop][0].column).to eq 0
     end
 
     context 'when passed :raise_error option' do
       it 're-raises the exception received while processing' do
-        allow(cop).to receive(:on_def) { raise RuntimeError }
+        allow(cop).to receive(:on_int) { raise RuntimeError }
 
         commissioner = described_class.new([cop], [], raise_error: true)
         source = ['def method', '1', 'end']


### PR DESCRIPTION
Currently, when RuboCop crashes, it prints filename that is a target of analysis.
e.g. `An error occurred while Style/IdenticalConditionalBranches cop was inspecting /tmp/test.rb.`

I think it is not enough for debugging.
Because, we need to narrow down the cause from the whole file.
It is a laborious task.

This change makes to display a line number.
e.g. `An error occurred while Style/IdenticalConditionalBranches cop was inspecting /tmp/test.rb:42.`

This change will make debugging easier.



-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Used the same coding conventions as the rest of the project.
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [ ] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] All tests are passing.
* [x] The new code doesn't generate RuboCop offenses.
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [ ] Updated cop documentation with `rake generate_cops_documentation` (required only when you've added a new cop or changed the configuration/documentation of an existing cop).

[1]: http://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html
