### PR TITLE
Move Ruby 2.4.0 towards the top of Travis' build matrix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,11 +5,11 @@ matrix:
   include:
      - rvm: jruby-9.0.1.0
        env: JRUBY_OPTS='--debug' # get more accurate coverage data
+     - rvm: 2.4.0 # Ruby 2.4.0 runs very slow, so let it start earlier
      - rvm: 2.0.0
      - rvm: 2.1.10
      - rvm: 2.2.6
      - rvm: 2.3.3
-     - rvm: 2.4.0
      - rvm: ruby-head
      - rvm: rbx-3
   allow_failures:


### PR DESCRIPTION
Because of the issue mentioned in #3877, running the test suite on Ruby 2.4.0 takes about twice as long as previous Ruby versions.

This change pushes 2.4.0 towards the top of the build matrix so that it has a chance to start earlier, and finish a single build quicker.

-----------------

Before submitting the PR make sure the following are checked:

* [X] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [ ] Used the same coding conventions as the rest of the project.
* [X] Feature branch is up-to-date with `master` (if not - rebase it).
* [X] Squashed related commits together.
* [ ] Added tests.
* [ ] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [X] All tests are passing.
* [X] The new code doesn't generate RuboCop offenses.
* [X] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [ ] Updated cop documentation with `rake generate_cops_documentation` (required only when you've added a new cop or changed the configuration/documentation of an existing cop).

[1]: http://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html
