### PR TITLE
Fix regression in new_cop task

### DIFF
--- a/tasks/new_cop.rake
+++ b/tasks/new_cop.rake
@@ -65,7 +65,7 @@ module RuboCop
 end
   END
 
-  cop_path = "lib/rubocop/cop/#{to_snake(badge.cop_name)}.rb"
+  cop_path = "lib/rubocop/cop/#{to_snake(badge.to_s)}.rb"
   File.write(cop_path, cop_code)
 
   spec_code = <<-END


### PR DESCRIPTION
Fixes regression I accidentally introduced in e2ce5d8. Resulted in placing the cop in the wrong directory.

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Used the same coding conventions as the rest of the project.
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [ ] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [ ] All tests are passing.
* [x] The new code doesn't generate RuboCop offenses.
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Updated cop documentation with `rake generate_cops_documentation` (required only when you've added a new cop or changed the configuration/documentation of an existing cop).

[1]: http://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html
