### PR TITLE
Fix `Style/SpaceAroundOperators` cop with a hash rocket

### DIFF
--- a/lib/rubocop/cop/style/space_around_operators.rb
+++ b/lib/rubocop/cop/style/space_around_operators.rb
@@ -13,7 +13,7 @@ module RuboCop
 
           return if hash_table_style? && !node.parent.pairs_on_same_line?
 
-          check_operator(node.loc.operator, node.value)
+          check_operator(node.loc.operator, node.source_range)
         end
 
         def on_if(node)

--- a/spec/rubocop/cop/style/space_around_operators_spec.rb
+++ b/spec/rubocop/cop/style/space_around_operators_spec.rb
@@ -6,9 +6,15 @@ describe RuboCop::Cop::Style::SpaceAroundOperators do
   subject(:cop) { described_class.new(config) }
   let(:config) do
     RuboCop::Config
-      .new('Style/AlignHash' => { 'EnforcedHashRocketStyle' => hash_style })
+      .new(
+        'Style/AlignHash' => { 'EnforcedHashRocketStyle' => hash_style },
+        'Style/SpaceAroundOperators' => {
+          'AllowForAlignment' => allow_for_alignment
+        }
+      )
   end
   let(:hash_style) { 'key' }
+  let(:allow_for_alignment) { true }
 
   it 'accepts operator surrounded by tabs' do
     inspect_source(cop, "a\t+\tb")
@@ -558,6 +564,39 @@ describe RuboCop::Cop::Style::SpaceAroundOperators do
       expect(cop.messages).to eq(
         ['Operator `=>` should be surrounded by a single space.']
       )
+    end
+
+    it 'registers an offense for a hash rocket with an extra space' \
+      'on multiple line' do
+      inspect_source(cop, ['{',
+                           '  1 =>  2',
+                           '}'])
+      expect(cop.messages).to eq(
+        ['Operator `=>` should be surrounded by a single space.']
+      )
+    end
+
+    it 'accepts for a hash rocket with an extra space for alignment' \
+      'on multiple line' do
+      inspect_source(cop, ['{',
+                           '  1 =>  2,',
+                           '  11 => 3',
+                           '}'])
+      expect(cop.offenses).to be_empty
+    end
+
+    context 'when does not allowed for alignment' do
+      let(:allow_for_alignment) { false }
+
+      it 'accepts an extra space' do
+        inspect_source(cop, ['{',
+                             '  1 =>  2,',
+                             '  11 => 3',
+                             '}'])
+        expect(cop.messages).to eq(
+          ['Operator `=>` should be surrounded by a single space.']
+        )
+      end
     end
 
     it 'registers an offense for match operators with too many spaces' do


### PR DESCRIPTION
Currently, `Style/SpaceAroundOperators` cop crashes with the following code.

```ruby
{
  1 =>  2
}
```

```sh
$ rubocop --cache false -d --only Style/SpaceAroundOperators
An error occurred while Style/SpaceAroundOperators cop was inspecting /tmp/tmp.Ivr3Ez7zI5/test.rb:2:2.

1 error occurred:
An error occurred while Style/SpaceAroundOperators cop was inspecting /tmp/tmp.Ivr3Ez7zI5/test.rb:2:2.
Errors are usually caused by RuboCop bugs.
Please, report your problems to RuboCop's issue tracker.
Mention the following information in the issue report:
0.46.0 (using Parser 2.3.3.1, running on ruby 2.3.3 x86_64-linux)
For /tmp/tmp.Ivr3Ez7zI5: configuration from /home/pocke/.gem/ruby/2.3.0/gems/rubocop-0.46.0/config/default.yml
Inheriting configuration from /home/pocke/.gem/ruby/2.3.0/gems/rubocop-0.46.0/config/enabled.yml
Inheriting configuration from /home/pocke/.gem/ruby/2.3.0/gems/rubocop-0.46.0/config/disabled.yml
Inspecting 1 file
Scanning /tmp/tmp.Ivr3Ez7zI5/test.rb
undefined method `line' for s(:int, 2):RuboCop::AST::Node
/home/pocke/.gem/ruby/2.3.0/gems/rubocop-0.46.0/lib/rubocop/cop/mixin/preceding_following_alignment.rb:22:in `aligned_with_adjacent_line?'
/home/pocke/.gem/ruby/2.3.0/gems/rubocop-0.46.0/lib/rubocop/cop/mixin/preceding_following_alignment.rb:13:in `aligned_with_something?'
/home/pocke/.gem/ruby/2.3.0/gems/rubocop-0.46.0/lib/rubocop/cop/style/space_around_operators.rb:112:in `excess_trailing_space?'
/home/pocke/.gem/ruby/2.3.0/gems/rubocop-0.46.0/lib/rubocop/cop/style/space_around_operators.rb:100:in `offense_message'
/home/pocke/.gem/ruby/2.3.0/gems/rubocop-0.46.0/lib/rubocop/cop/style/space_around_operators.rb:90:in `offense'
/home/pocke/.gem/ruby/2.3.0/gems/rubocop-0.46.0/lib/rubocop/cop/style/space_around_operators.rb:84:in `check_operator'
/home/pocke/.gem/ruby/2.3.0/gems/rubocop-0.46.0/lib/rubocop/cop/style/space_around_operators.rb:16:in `on_pair'
/home/pocke/.gem/ruby/2.3.0/gems/rubocop-0.46.0/lib/rubocop/cop/commissioner.rb:43:in `block (2 levels) in on_pair'
/home/pocke/.gem/ruby/2.3.0/gems/rubocop-0.46.0/lib/rubocop/cop/commissioner.rb:102:in `with_cop_error_handling'
/home/pocke/.gem/ruby/2.3.0/gems/rubocop-0.46.0/lib/rubocop/cop/commissioner.rb:42:in `block in on_pair'
/home/pocke/.gem/ruby/2.3.0/gems/rubocop-0.46.0/lib/rubocop/cop/commissioner.rb:41:in `each'
/home/pocke/.gem/ruby/2.3.0/gems/rubocop-0.46.0/lib/rubocop/cop/commissioner.rb:41:in `on_pair'
(eval):2:in `block in on_hash'
(eval):2:in `each'
(eval):2:in `on_hash'
/home/pocke/.gem/ruby/2.3.0/gems/rubocop-0.46.0/lib/rubocop/cop/commissioner.rb:47:in `on_hash'
/home/pocke/.gem/ruby/2.3.0/gems/rubocop-0.46.0/lib/rubocop/ast/traversal.rb:12:in `walk'
/home/pocke/.gem/ruby/2.3.0/gems/rubocop-0.46.0/lib/rubocop/cop/commissioner.rb:60:in `investigate'
/home/pocke/.gem/ruby/2.3.0/gems/rubocop-0.46.0/lib/rubocop/cop/team.rb:121:in `investigate'
/home/pocke/.gem/ruby/2.3.0/gems/rubocop-0.46.0/lib/rubocop/cop/team.rb:109:in `offenses'
/home/pocke/.gem/ruby/2.3.0/gems/rubocop-0.46.0/lib/rubocop/cop/team.rb:51:in `inspect_file'
/home/pocke/.gem/ruby/2.3.0/gems/rubocop-0.46.0/lib/rubocop/runner.rb:248:in `inspect_file'
/home/pocke/.gem/ruby/2.3.0/gems/rubocop-0.46.0/lib/rubocop/runner.rb:195:in `block in do_inspection_loop'
/home/pocke/.gem/ruby/2.3.0/gems/rubocop-0.46.0/lib/rubocop/runner.rb:227:in `block in iterate_until_no_changes'
/home/pocke/.gem/ruby/2.3.0/gems/rubocop-0.46.0/lib/rubocop/runner.rb:220:in `loop'
/home/pocke/.gem/ruby/2.3.0/gems/rubocop-0.46.0/lib/rubocop/runner.rb:220:in `iterate_until_no_changes'
/home/pocke/.gem/ruby/2.3.0/gems/rubocop-0.46.0/lib/rubocop/runner.rb:191:in `do_inspection_loop'
/home/pocke/.gem/ruby/2.3.0/gems/rubocop-0.46.0/lib/rubocop/runner.rb:101:in `block in file_offenses'
/home/pocke/.gem/ruby/2.3.0/gems/rubocop-0.46.0/lib/rubocop/runner.rb:111:in `file_offense_cache'
/home/pocke/.gem/ruby/2.3.0/gems/rubocop-0.46.0/lib/rubocop/runner.rb:99:in `file_offenses'
/home/pocke/.gem/ruby/2.3.0/gems/rubocop-0.46.0/lib/rubocop/runner.rb:90:in `process_file'
/home/pocke/.gem/ruby/2.3.0/gems/rubocop-0.46.0/lib/rubocop/runner.rb:68:in `block in each_inspected_file'
/home/pocke/.gem/ruby/2.3.0/gems/rubocop-0.46.0/lib/rubocop/runner.rb:65:in `each'
/home/pocke/.gem/ruby/2.3.0/gems/rubocop-0.46.0/lib/rubocop/runner.rb:65:in `reduce'
/home/pocke/.gem/ruby/2.3.0/gems/rubocop-0.46.0/lib/rubocop/runner.rb:65:in `each_inspected_file'
/home/pocke/.gem/ruby/2.3.0/gems/rubocop-0.46.0/lib/rubocop/runner.rb:57:in `inspect_files'
/home/pocke/.gem/ruby/2.3.0/gems/rubocop-0.46.0/lib/rubocop/runner.rb:36:in `run'
/home/pocke/.gem/ruby/2.3.0/gems/rubocop-0.46.0/lib/rubocop/cli.rb:72:in `execute_runner'
/home/pocke/.gem/ruby/2.3.0/gems/rubocop-0.46.0/lib/rubocop/cli.rb:27:in `run'
/home/pocke/.gem/ruby/2.3.0/gems/rubocop-0.46.0/bin/rubocop:13:in `block in <top (required)>'
/usr/lib/ruby/2.3.0/benchmark.rb:308:in `realtime'
/home/pocke/.gem/ruby/2.3.0/gems/rubocop-0.46.0/bin/rubocop:12:in `<top (required)>'
/home/pocke/.gem/ruby/2.3.0/bin//rubocop:22:in `load'
/home/pocke/.gem/ruby/2.3.0/bin//rubocop:22:in `<main>'
.

1 file inspected, no offenses detected
Finished in 0.05824336898513138 seconds
```

This change fix the error. And I added some missing test cases.

Note: The bug is not released. So, I skip CHANGELOG.


-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Used the same coding conventions as the rest of the project.
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [ ] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] All tests are passing.
* [x] The new code doesn't generate RuboCop offenses.
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Updated cop documentation with `rake generate_cops_documentation` (required only when you've added a new cop or changed the configuration/documentation of an existing cop).

[1]: http://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html
