### PR TITLE
Fix typo `@node` to `@note` in documentation comment

### DIFF
--- a/lib/rubocop/ast/node/hash_node.rb
+++ b/lib/rubocop/ast/node/hash_node.rb
@@ -75,7 +75,7 @@ module RuboCop
       # Checks whether any of the key value pairs in the `hash` literal are on
       # the same line.
       #
-      # @node A multiline `pair` is considered to be on the same line if it
+      # @note A multiline `pair` is considered to be on the same line if it
       #       shares any of its lines with another `pair`
       #
       # @return [Boolean] whether any `pair` nodes are on the same line

--- a/lib/rubocop/ast/node/mixin/hash_element_node.rb
+++ b/lib/rubocop/ast/node/mixin/hash_element_node.rb
@@ -25,7 +25,7 @@ module RuboCop
 
       # Checks whether this `hash` element is on the same line as `other`.
       #
-      # @node A multiline element is considered to be on the same line if it
+      # @note A multiline element is considered to be on the same line if it
       #       shares any of its lines with `other`
       #
       # @return [Boolean] whether this element is on the same line as `other`


### PR DESCRIPTION
Warnings are occurred when I execute `rake generate_cops_documentation`.

```sh
$ bundle exec rake generate_cops_documentation
[warn]: Unknown tag @node in file `lib/rubocop/ast/node/hash_node.rb` near line 82
[warn]: Unknown tag @node in file `lib/rubocop/ast/node/mixin/hash_element_node.rb` near line 32
```

I think the tag should be `@note`.

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Used the same coding conventions as the rest of the project.
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [ ] Added tests.
* [ ] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] All tests are passing.
* [x] The new code doesn't generate RuboCop offenses.
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Updated cop documentation with `rake generate_cops_documentation` (required only when you've added a new cop or changed the configuration/documentation of an existing cop).

[1]: http://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html
