### PR TITLE
[Fix #3894] Prevent to colorize `Style/EndOfLine` cop with `--no-color`

### DIFF
--- a/lib/rubocop/formatter/clang_style_formatter.rb
+++ b/lib/rubocop/formatter/clang_style_formatter.rb
@@ -6,7 +6,7 @@ module RuboCop
     # The precise location of the problem is shown together with the
     # relevant source code.
     class ClangStyleFormatter < SimpleTextFormatter
-      ELLIPSES = Rainbow('...').yellow.freeze
+      ELLIPSES = '...'.freeze
 
       def report_file(file, offenses)
         offenses.each { |offense| report_offense(file, offense) }
@@ -41,7 +41,7 @@ module RuboCop
         if location.first_line == location.last_line
           output.puts(source_line)
         else
-          output.puts("#{source_line} #{ELLIPSES}")
+          output.puts("#{source_line} #{yellow(ELLIPSES)}")
         end
       end
 


### PR DESCRIPTION
Fix #3894 

Reproduce
=============

`test.rb`

```ruby
foo
bar
```

```sh
 # Convert line endings to CRLF
$ nkf -Lw test.rb > crlf.rb
$ rubocop --no-color crlf.rb
Inspecting 1 file
C

Offenses:

crlf.rb:1:1: C: Carriage return character detected.
foo ...
^^^

1 file inspected, 1 offense detected
```

The `...` is colorized.

Cause
=========

Clang formatter uses `Rainbow.yellow` directly.



-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Used the same coding conventions as the rest of the project.
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [ ] Added tests.
* [ ] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] All tests are passing.
* [x] The new code doesn't generate RuboCop offenses.
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Updated cop documentation with `rake generate_cops_documentation` (required only when you've added a new cop or changed the configuration/documentation of an existing cop).

[1]: http://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html
