### PR TITLE
[Fix #3736] Fix to remove return value by auto-correction in `Style/EachWithObject`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,6 +56,7 @@
 * [#3870](https://github.com/bbatsov/rubocop/pull/3870): Avoid crash in `Rails/HttpPositionalArguments`. ([@pocke][])
 * [#3869](https://github.com/bbatsov/rubocop/pull/3869): Prevent `Lint/FormatParameterMismatch` from breaking when `#%` is passed an empty array. ([@drenmi][])
 * [#3879](https://github.com/bbatsov/rubocop/pull/3879): Properly handle Emacs and Vim magic comments for `FrozenStringLiteralComment`. ([@backus][])
+* [#3736](https://github.com/bbatsov/rubocop/issues/3736): Fix to remove accumulator return value by auto-correction in `Style/EachWithObject`. ([@pocke][])
 
 ## 0.46.0 (2016-11-30)
 

--- a/lib/rubocop/cop/style/each_with_object.rb
+++ b/lib/rubocop/cop/style/each_with_object.rb
@@ -40,11 +40,14 @@ module RuboCop
 
         def autocorrect(node)
           lambda do |corrector|
-            method, args, _body = *node
+            method, args, body = *node
             corrector.replace(method.loc.selector, 'each_with_object')
             first_arg, second_arg = *args
             corrector.replace(first_arg.loc.expression, second_arg.source)
             corrector.replace(second_arg.loc.expression, first_arg.source)
+
+            return_value = return_value(body)
+            corrector.remove(return_value.loc.expression)
           end
         end
 

--- a/spec/rubocop/cop/style/each_with_object_spec.rb
+++ b/spec/rubocop/cop/style/each_with_object_spec.rb
@@ -24,11 +24,23 @@ describe RuboCop::Cop::Style::EachWithObject do
 
   it 'correctly autocorrects' do
     corrected = autocorrect_source(cop, ['[1, 2, 3].inject({}) do |h, i|',
+                                         '  h[i] = i',
                                          '  h',
                                          'end'])
 
     expect(corrected).to eq(['[1, 2, 3].each_with_object({}) do |i, h|',
-                             '  h',
+                             '  h[i] = i',
+                             '  ',
+                             'end'].join("\n"))
+  end
+
+  it 'correctly autocorrects with return value only' do
+    corrected = autocorrect_source(cop, ['[1, 2, 3].inject({}) do |h, i|',
+                                         '  h',
+                                         'end'])
+
+    expect(corrected).to eq(['[1, 2, 3].each_with_object({}) do |i, h|',
+                             '  ',
                              'end'].join("\n"))
   end
 


### PR DESCRIPTION
Fix #3736

`each_with_object` doesn't use block return value.
So, the return value can be removed.

```ruby
[1, 2, 3].inject({}) do |h, i|
  h[i] = 1

  # It can't be removed.
  h
end

[1, 2, 3].each_with_object({}) do |i, h|
  h[i] = 1

  # It can be removed.
  h
end

 # Good code
[1, 2, 3].each_with_object({}) do |i, h|
  h[i] = 1
end
```



-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Used the same coding conventions as the rest of the project.
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] All tests are passing.
* [x] The new code doesn't generate RuboCop offenses.
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Updated cop documentation with `rake generate_cops_documentation` (required only when you've added a new cop or changed the configuration/documentation of an existing cop).

[1]: http://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html
