### PR TITLE
[Fix #3911] Prevent to crash in `Performance/RegexpMatch` cop with module definition

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## master (unreleased)
 
+### Bug fixes
+
+* [#3911](https://github.com/bbatsov/rubocop/issues/3911): Prevent a crash in `Performance/RegexpMatch` cop with module definition. ([@pocke][])
+
 ## 0.47.0 (2017-01-16)
 
 ### New features

--- a/lib/rubocop/cop/performance/regexp_match.rb
+++ b/lib/rubocop/cop/performance/regexp_match.rb
@@ -172,12 +172,19 @@ module RuboCop
         end
 
         def scope_body(node)
-          node.children[2]
+          children = node.children
+          case node.type
+          when :module
+            children[1]
+          else
+            children[2]
+          end
         end
 
         def scope_root(node)
           node.each_ancestor.find do |ancestor|
             ancestor.def_type? ||
+              ancestor.defs_type? ||
               ancestor.class_type? ||
               ancestor.module_type?
           end

--- a/spec/rubocop/cop/performance/regexp_match_spec.rb
+++ b/spec/rubocop/cop/performance/regexp_match_spec.rb
@@ -160,6 +160,30 @@ describe RuboCop::Cop::Performance::RegexpMatch, :config do
       END2
 
       include_examples :offense,
+                       "#{name} in class method" \
+                       ", `#{var}` is in other method", <<-END, <<-END2
+        def self.foo
+          if #{cond}
+            do_something2
+          end
+        end
+
+        def self.bar
+          do_something(#{var})
+        end
+      END
+        def self.foo
+          if #{correction}
+            do_something2
+          end
+        end
+
+        def self.bar
+          do_something(#{var})
+        end
+      END2
+
+      include_examples :offense,
                        "#{name} in class" \
                        ", `#{var}` is in method", <<-END, <<-END2
         class Foo
@@ -173,6 +197,30 @@ describe RuboCop::Cop::Performance::RegexpMatch, :config do
         end
       END
         class Foo
+          if #{correction}
+            do_something
+          end
+
+          def foo
+            #{var}
+          end
+        end
+      END2
+
+      include_examples :offense,
+                       "#{name} in module" \
+                       ", `#{var}` is in method", <<-END, <<-END2
+        module Foo
+          if #{cond}
+            do_something
+          end
+
+          def foo
+            #{var}
+          end
+        end
+      END
+        module Foo
           if #{correction}
             do_something
           end


### PR DESCRIPTION
Fix #3911 

`Performance/RegexpMatch` cop crashes with the following code.

```ruby
module Foo
  def self.foo
    if x =~ /re/
    end
  end
end
```

```sh
$ rubocop -d --only Performance/RegexpMatch --cache false
For /tmp/tmp.xjn7er9KIk: configuration from /tmp/tmp.xjn7er9KIk/.rubocop.yml
Default configuration from /home/pocke/.gem/ruby/2.4.0/gems/rubocop-0.47.0/config/default.yml
Inheriting configuration from /home/pocke/.gem/ruby/2.4.0/gems/rubocop-0.47.0/config/enabled.yml
Inheriting configuration from /home/pocke/.gem/ruby/2.4.0/gems/rubocop-0.47.0/config/disabled.yml
Inspecting 1 file
Scanning /tmp/tmp.xjn7er9KIk/test.rb
An error occurred while Performance/RegexpMatch cop was inspecting /tmp/tmp.xjn7er9KIk/test.rb:3:4.
undefined method `each_node' for nil:NilClass
/home/pocke/.gem/ruby/2.4.0/gems/rubocop-0.47.0/lib/rubocop/cop/performance/regexp_match.rb:100:in `search_match_nodes'
/home/pocke/.gem/ruby/2.4.0/gems/rubocop-0.47.0/lib/rubocop/cop/performance/regexp_match.rb:159:in `each'
/home/pocke/.gem/ruby/2.4.0/gems/rubocop-0.47.0/lib/rubocop/cop/performance/regexp_match.rb:159:in `find'
/home/pocke/.gem/ruby/2.4.0/gems/rubocop-0.47.0/lib/rubocop/cop/performance/regexp_match.rb:159:in `next_match_pos'
/home/pocke/.gem/ruby/2.4.0/gems/rubocop-0.47.0/lib/rubocop/cop/performance/regexp_match.rb:152:in `last_match_used?'
/home/pocke/.gem/ruby/2.4.0/gems/rubocop-0.47.0/lib/rubocop/cop/performance/regexp_match.rb:141:in `block in check_condition'
/home/pocke/.gem/ruby/2.4.0/gems/rubocop-0.47.0/lib/rubocop/cop/performance/regexp_match.rb:98:in `match_node?'
/home/pocke/.gem/ruby/2.4.0/gems/rubocop-0.47.0/lib/rubocop/cop/performance/regexp_match.rb:140:in `check_condition'
/home/pocke/.gem/ruby/2.4.0/gems/rubocop-0.47.0/lib/rubocop/cop/performance/regexp_match.rb:110:in `on_if'
/home/pocke/.gem/ruby/2.4.0/gems/rubocop-0.47.0/lib/rubocop/cop/commissioner.rb:43:in `block (2 levels) in on_if'
/home/pocke/.gem/ruby/2.4.0/gems/rubocop-0.47.0/lib/rubocop/cop/commissioner.rb:102:in `with_cop_error_handling'
/home/pocke/.gem/ruby/2.4.0/gems/rubocop-0.47.0/lib/rubocop/cop/commissioner.rb:42:in `block in on_if'
/home/pocke/.gem/ruby/2.4.0/gems/rubocop-0.47.0/lib/rubocop/cop/commissioner.rb:41:in `each'
/home/pocke/.gem/ruby/2.4.0/gems/rubocop-0.47.0/lib/rubocop/cop/commissioner.rb:41:in `on_if'
/home/pocke/.gem/ruby/2.4.0/gems/rubocop-0.47.0/lib/rubocop/ast/traversal.rb:122:in `on_defs'
/home/pocke/.gem/ruby/2.4.0/gems/rubocop-0.47.0/lib/rubocop/cop/commissioner.rb:47:in `on_defs'
/home/pocke/.gem/ruby/2.4.0/gems/rubocop-0.47.0/lib/rubocop/ast/traversal.rb:141:in `on_while'
/home/pocke/.gem/ruby/2.4.0/gems/rubocop-0.47.0/lib/rubocop/cop/commissioner.rb:47:in `on_module'
/home/pocke/.gem/ruby/2.4.0/gems/rubocop-0.47.0/lib/rubocop/ast/traversal.rb:12:in `walk'
/home/pocke/.gem/ruby/2.4.0/gems/rubocop-0.47.0/lib/rubocop/cop/commissioner.rb:60:in `investigate'
/home/pocke/.gem/ruby/2.4.0/gems/rubocop-0.47.0/lib/rubocop/cop/team.rb:121:in `investigate'
/home/pocke/.gem/ruby/2.4.0/gems/rubocop-0.47.0/lib/rubocop/cop/team.rb:109:in `offenses'
/home/pocke/.gem/ruby/2.4.0/gems/rubocop-0.47.0/lib/rubocop/cop/team.rb:51:in `inspect_file'
/home/pocke/.gem/ruby/2.4.0/gems/rubocop-0.47.0/lib/rubocop/runner.rb:248:in `inspect_file'
/home/pocke/.gem/ruby/2.4.0/gems/rubocop-0.47.0/lib/rubocop/runner.rb:195:in `block in do_inspection_loop'
/home/pocke/.gem/ruby/2.4.0/gems/rubocop-0.47.0/lib/rubocop/runner.rb:227:in `block in iterate_until_no_changes'
/home/pocke/.gem/ruby/2.4.0/gems/rubocop-0.47.0/lib/rubocop/runner.rb:220:in `loop'
/home/pocke/.gem/ruby/2.4.0/gems/rubocop-0.47.0/lib/rubocop/runner.rb:220:in `iterate_until_no_changes'
/home/pocke/.gem/ruby/2.4.0/gems/rubocop-0.47.0/lib/rubocop/runner.rb:191:in `do_inspection_loop'
/home/pocke/.gem/ruby/2.4.0/gems/rubocop-0.47.0/lib/rubocop/runner.rb:101:in `block in file_offenses'
/home/pocke/.gem/ruby/2.4.0/gems/rubocop-0.47.0/lib/rubocop/runner.rb:111:in `file_offense_cache'
/home/pocke/.gem/ruby/2.4.0/gems/rubocop-0.47.0/lib/rubocop/runner.rb:99:in `file_offenses'
/home/pocke/.gem/ruby/2.4.0/gems/rubocop-0.47.0/lib/rubocop/runner.rb:90:in `process_file'
/home/pocke/.gem/ruby/2.4.0/gems/rubocop-0.47.0/lib/rubocop/runner.rb:68:in `block in each_inspected_file'
/home/pocke/.gem/ruby/2.4.0/gems/rubocop-0.47.0/lib/rubocop/runner.rb:65:in `each'
/home/pocke/.gem/ruby/2.4.0/gems/rubocop-0.47.0/lib/rubocop/runner.rb:65:in `reduce'
/home/pocke/.gem/ruby/2.4.0/gems/rubocop-0.47.0/lib/rubocop/runner.rb:65:in `each_inspected_file'
/home/pocke/.gem/ruby/2.4.0/gems/rubocop-0.47.0/lib/rubocop/runner.rb:57:in `inspect_files'
/home/pocke/.gem/ruby/2.4.0/gems/rubocop-0.47.0/lib/rubocop/runner.rb:36:in `run'
/home/pocke/.gem/ruby/2.4.0/gems/rubocop-0.47.0/lib/rubocop/cli.rb:72:in `execute_runner'
/home/pocke/.gem/ruby/2.4.0/gems/rubocop-0.47.0/lib/rubocop/cli.rb:27:in `run'
/home/pocke/.gem/ruby/2.4.0/gems/rubocop-0.47.0/bin/rubocop:13:in `block in <top (required)>'
/usr/lib/ruby/2.4.0/benchmark.rb:308:in `realtime'
/home/pocke/.gem/ruby/2.4.0/gems/rubocop-0.47.0/bin/rubocop:12:in `<top (required)>'
/home/pocke/.gem/ruby/2.4.0/bin//rubocop:22:in `load'
/home/pocke/.gem/ruby/2.4.0/bin//rubocop:22:in `<main>'
.

1 file inspected, no offenses detected

1 error occurred:
An error occurred while Performance/RegexpMatch cop was inspecting /tmp/tmp.xjn7er9KIk/test.rb:3:4.
Errors are usually caused by RuboCop bugs.
Please, report your problems to RuboCop's issue tracker.
Mention the following information in the issue report:
0.47.0 (using Parser 2.3.3.1, running on ruby 2.4.0 x86_64-linux)
Finished in 0.060496986989164725 seconds
```

This cause is difference between `module` and `class`.
`module` body is `node.children[1]`, however, `class` body is
`node.children[2]`.

The change fixes this problem.

And the cop does not check `def self`. This change fixes the problem also.



-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Used the same coding conventions as the rest of the project.
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] All tests are passing.
* [x] The new code doesn't generate RuboCop offenses.
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Updated cop documentation with `rake generate_cops_documentation` (required only when you've added a new cop or changed the configuration/documentation of an existing cop).

[1]: http://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html
