### PR TITLE
[Fix #3908] Prevent `Style/AlignHash` from breaking on a keyword splat when using enforced `table` style

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Bug fixes
 
 * [#3911](https://github.com/bbatsov/rubocop/issues/3911): Prevent a crash in `Performance/RegexpMatch` cop with module definition. ([@pocke][])
+* [#3908](https://github.com/bbatsov/rubocop/issues/3908): Prevent `Style/AlignHash` from breaking on a keyword splat when using enforced `table` style. ([@drenmi][])
 
 ## 0.47.0 (2017-01-16)
 

--- a/lib/rubocop/cop/mixin/hash_alignment.rb
+++ b/lib/rubocop/cop/mixin/hash_alignment.rb
@@ -42,10 +42,10 @@ module RuboCop
         private
 
         def separator_delta(first_pair, current_pair, key_delta)
-          if current_pair.colon?
-            0
-          else
+          if current_pair.hash_rocket?
             hash_rocket_delta(first_pair, current_pair) - key_delta
+          else
+            0
           end
         end
       end
@@ -80,6 +80,8 @@ module RuboCop
         end
 
         def value_delta(first_pair, current_pair)
+          return 0 if current_pair.kwsplat_type?
+
           correct_value_column = first_pair.key.loc.column +
                                  current_pair.delimiter(true).length +
                                  max_key_width

--- a/spec/rubocop/cop/style/align_hash_spec.rb
+++ b/spec/rubocop/cop/style/align_hash_spec.rb
@@ -294,6 +294,14 @@ describe RuboCop::Cop::Style::AlignHash, :config do
                              '}'])
         expect(cop.offenses).to be_empty
       end
+
+      it 'accepts hashes that use different separators and double splats' do
+        inspect_source(cop, ['hash = {',
+                             '  a: 1,',
+                             '  **kw',
+                             '}'])
+        expect(cop.offenses).to be_empty
+      end
     end
 
     it 'registers an offense for misaligned hash values' do


### PR DESCRIPTION
After refactoring, a regression was introduced that would cause this cop to break under the following conditions:
    
- Enforced style is set to: `table`
- Hash does not contain mixed keys
- Hash contains a keyword splat element
    
This change fixes that.

-----------------

Before submitting the PR make sure the following are checked:

* [X] Wrote [good commit messages][1].
* [X] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [X] Used the same coding conventions as the rest of the project.
* [X] Feature branch is up-to-date with `master` (if not - rebase it).
* [X] Squashed related commits together.
* [X] Added tests.
* [X] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [X] All tests are passing.
* [X] The new code doesn't generate RuboCop offenses.
* [X] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [ ] Updated cop documentation with `rake generate_cops_documentation` (required only when you've added a new cop or changed the configuration/documentation of an existing cop).

[1]: http://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html
