### PR TITLE
[Fix #3918] Prevent `Rails/EnumUniqueness` from breaking on a non-literal hash value

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 * [#3911](https://github.com/bbatsov/rubocop/issues/3911): Prevent a crash in `Performance/RegexpMatch` cop with module definition. ([@pocke][])
 * [#3908](https://github.com/bbatsov/rubocop/issues/3908): Prevent `Style/AlignHash` from breaking on a keyword splat when using enforced `table` style. ([@drenmi][])
+* [#3918](https://github.com/bbatsov/rubocop/issues/3918): Prevent `Rails/EnumUniqueness` from breaking on a non-literal hash value. ([@drenmi][])
 
 ## 0.47.0 (2017-01-16)
 

--- a/lib/rubocop/cop/rails/enum_uniqueness.rb
+++ b/lib/rubocop/cop/rails/enum_uniqueness.rb
@@ -23,7 +23,7 @@ module RuboCop
         MSG = 'Duplicate value `%s` found in `%s` enum declaration.'.freeze
 
         def_node_matcher :enum_declaration, <<-END
-          (send nil :enum (hash (pair (_ $_) $_)))
+          (send nil :enum (hash (pair (_ $_) ${array hash})))
         END
 
         def on_send(node)

--- a/spec/rubocop/cop/rails/enum_uniqueness_spec.rb
+++ b/spec/rubocop/cop/rails/enum_uniqueness_spec.rb
@@ -64,11 +64,37 @@ describe RuboCop::Cop::Rails::EnumUniqueness, :config do
   end
 
   context 'when receiving a variable' do
-    it 'does not register an offence' do
+    it 'does not register an offense' do
       inspect_source(cop, ['var = { status: { active: 0, archived: 1 } }',
                            'enum var'])
 
       expect(cop.offenses).to be_empty
+    end
+  end
+
+  context 'when receiving a hash without literal values' do
+    context 'when value is a variable' do
+      it 'does not register an offense' do
+        inspect_source(cop, 'enum status: statuses')
+
+        expect(cop.offenses).to be_empty
+      end
+    end
+
+    context 'when value is a method chain' do
+      it 'does not register an offense' do
+        inspect_source(cop, 'enum status: User.statuses.keys')
+
+        expect(cop.offenses).to be_empty
+      end
+    end
+
+    context 'when value is a constant' do
+      it 'does not register an offense' do
+        inspect_source(cop, 'enum status: STATUSES')
+
+        expect(cop.offenses).to be_empty
+      end
     end
   end
 end


### PR DESCRIPTION
This cop would break on any enum hash that did not have a literal value. This change fixes that.

-----------------

Before submitting the PR make sure the following are checked:

* [X] Wrote [good commit messages][1].
* [X] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [X] Used the same coding conventions as the rest of the project.
* [X] Feature branch is up-to-date with `master` (if not - rebase it).
* [X] Squashed related commits together.
* [X] Added tests.
* [X] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [X] All tests are passing.
* [X] The new code doesn't generate RuboCop offenses.
* [X] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [ ] Updated cop documentation with `rake generate_cops_documentation` (required only when you've added a new cop or changed the configuration/documentation of an existing cop).

[1]: http://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html
