### PR TITLE
[Fix #3922] Prevent `Style/NegatedIf` from breaking on negated ternary

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 * [#3918](https://github.com/bbatsov/rubocop/issues/3918): Prevent `Rails/EnumUniqueness` from breaking on a non-literal hash value. ([@drenmi][])
 * [#3914](https://github.com/bbatsov/rubocop/pull/3914): Fix department resolution for third party cops required through configuration. ([@backus][])
 * [#3846](https://github.com/bbatsov/rubocop/issues/3846): `NodePattern` works for hyphenated node types. ([@alexdowad][])
+* [#3922](https://github.com/bbatsov/rubocop/issues/3922): Prevent `Style/NegatedIf` from breaking on negated ternary. ([@drenmi][])
 
 ## 0.47.0 (2017-01-16)
 

--- a/lib/rubocop/cop/style/negated_if.rb
+++ b/lib/rubocop/cop/style/negated_if.rb
@@ -11,7 +11,7 @@ module RuboCop
         MSG = 'Favor `%s` over `%s` for negative conditions.'.freeze
 
         def on_if(node)
-          return if node.elsif?
+          return if node.elsif? || node.ternary?
 
           check_negative_conditional(node)
         end

--- a/spec/rubocop/cop/style/negated_if_spec.rb
+++ b/spec/rubocop/cop/style/negated_if_spec.rb
@@ -94,6 +94,11 @@ describe RuboCop::Cop::Style::NegatedIf do
     expect(cop.offenses).to be_empty
   end
 
+  it 'does not blow up on a negated ternary operator' do
+    inspect_source(cop, '!foo.empty? ? :bar : :baz')
+    expect(cop.offenses).to be_empty
+  end
+
   it 'does not blow up for empty if condition' do
     inspect_source(cop,
                    ['if ()',


### PR DESCRIPTION
This cop would blow up on a negated ternary condition. Since ternaries don't have an `unless` equivalent, this was fixed by just returning early for ternary nodes.

-----------------

Before submitting the PR make sure the following are checked:

* [X] Wrote [good commit messages][1].
* [X] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [X] Used the same coding conventions as the rest of the project.
* [X] Feature branch is up-to-date with `master` (if not - rebase it).
* [X] Squashed related commits together.
* [X] Added tests.
* [X] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [X] All tests are passing.
* [X] The new code doesn't generate RuboCop offenses.
* [X] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.

[1]: http://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html
