### PR TITLE
adds additional docs to rails cop

### DIFF
--- a/lib/rubocop/cop/rails/http_positional_arguments.rb
+++ b/lib/rubocop/cop/rails/http_positional_arguments.rb
@@ -5,7 +5,9 @@ module RuboCop
     module Rails
       # This cop is used to identify usages of http methods like `get`, `post`,
       # `put`, `patch` without the usage of keyword arguments in your tests and
-      # change them to use keyword arguments.
+      # change them to use keyword args.  This cop only applies to Rails >= 5
+      # If you are not running Rails >=5 you should disable
+      # the Rails/HttpPositionalArguments cop.
       #
       # @example
       #   # bad

--- a/manual/cops_rails.md
+++ b/manual/cops_rails.md
@@ -320,7 +320,9 @@ Enabled | Yes
 
 This cop is used to identify usages of http methods like `get`, `post`,
 `put`, `patch` without the usage of keyword arguments in your tests and
-change them to use keyword arguments.
+change them to use keyword args.  This cop only applies to Rails >= 5
+If you are not running Rails >=5 you should disable
+the Rails/HttpPositionalArguments cop.
 
 ### Example
 


### PR DESCRIPTION
This commit adds some more documentation inside the cop to alert the user that this cop is a rails5 only cop.

-----------------

Before submitting the PR make sure the following are checked:

* [ x ] Wrote [good commit messages][1].
* [ x ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [ x ] Used the same coding conventions as the rest of the project.
* [ x ] Feature branch is up-to-date with `master` (if not - rebase it).
* [ x ] Squashed related commits together.
* [ x ] Added tests.
* [ x ] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [ x ] All tests are passing.
* [ x  ] The new code doesn't generate RuboCop offenses.
* [ x ] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [ x ] Updated cop documentation with `rake generate_cops_documentation` (required only when you've added a new cop or changed the configuration/documentation of an existing cop).

[1]: http://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html
