### PR TITLE
Fix a false positive in `Lint/SafeNavigationChain` cop with `try` method.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 * [#3914](https://github.com/bbatsov/rubocop/pull/3914): Fix department resolution for third party cops required through configuration. ([@backus][])
 * [#3846](https://github.com/bbatsov/rubocop/issues/3846): `NodePattern` works for hyphenated node types. ([@alexdowad][])
 * [#3922](https://github.com/bbatsov/rubocop/issues/3922): Prevent `Style/NegatedIf` from breaking on negated ternary. ([@drenmi][])
+* [#3915](https://github.com/bbatsov/rubocop/issues/3915): Fix a false positive in `Lint/SafeNavigationChain` cop with `try` method. ([@pocke][])
 
 ## 0.47.0 (2017-01-16)
 

--- a/lib/rubocop/cop/lint/safe_navigation_chain.rb
+++ b/lib/rubocop/cop/lint/safe_navigation_chain.rb
@@ -29,7 +29,7 @@ module RuboCop
         MSG = 'Do not chain ordinary method call' \
               ' after safe navigation operator.'.freeze
 
-        ADDITIONAL_NIL_METHODS = %i(present? blank?).freeze
+        ADDITIONAL_NIL_METHODS = %i(present? blank? try).freeze
 
         def_node_matcher :bad_method?, <<-PATTERN
           (send (csend ...) $_ ...)

--- a/spec/rubocop/cop/lint/safe_navigation_chain_spec.rb
+++ b/spec/rubocop/cop/lint/safe_navigation_chain_spec.rb
@@ -50,6 +50,7 @@ describe RuboCop::Cop::Lint::SafeNavigationChain, :config do
       ['safe navigation with `nil?` method', 'x&.foo.nil?'],
       ['safe navigation with `present?` method', 'x&.foo.present?'],
       ['safe navigation with `blank?` method', 'x&.foo.blank?'],
+      ['safe navigation with `try` method', 'a&.b.try(:c)'],
       ['safe navigation with assignment method', 'x&.foo = bar'],
       ['safe navigation with self assignment method', 'x&.foo += bar']
     ].each do |name, code|


### PR DESCRIPTION


Fix https://github.com/bbatsov/rubocop/issues/3915 . See the issue for details.



-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Used the same coding conventions as the rest of the project.
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] All tests are passing.
* [x] The new code doesn't generate RuboCop offenses.
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Updated cop documentation with `rake generate_cops_documentation` (required only when you've added a new cop or changed the configuration/documentation of an existing cop).

[1]: http://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html
