### PR TITLE
Add JSON dependency

### DIFF
--- a/rubocop.gemspec
+++ b/rubocop.gemspec
@@ -25,6 +25,7 @@ Gem::Specification.new do |s|
   s.licenses = ['MIT']
   s.summary = 'Automatic Ruby code style checking tool.'
 
+  s.add_runtime_dependency('json', '~> 2.0')
   s.add_runtime_dependency('rainbow', '>= 1.99.1', '< 3.0')
   s.add_runtime_dependency('parser', '>= 2.3.3.1', '< 3.0')
   s.add_runtime_dependency('powerpack', '~> 0.1')


### PR DESCRIPTION
Missing JSON dependency can cause problems with some configurations.

Cf : https://youtrack.jetbrains.com/issue/RUBY-19050
