### PR TITLE
Only surround '--cache' with backticks in defaults.yml

### DIFF
--- a/config/default.yml
+++ b/config/default.yml
@@ -57,7 +57,7 @@ AllCops:
   # opt-out. Note that when `DisabledByDefault` is `true`, cops in user
   # configuration will be enabled even if they don't set the Enabled parameter.
   DisabledByDefault: false
-  # Enables the result cache if `true`. Can be overridden by the `--cache command`
+  # Enables the result cache if `true`. Can be overridden by the `--cache` command
   # line option.
   UseCache: true
   # Threshold for how many files can be stored in the result cache before some


### PR DESCRIPTION
TLDR:
Only backtick escape `--cache` in the `defaults.yml` instead of the mistaken `--cache command`

Noticed a small markdown error while reviewing changes and figured I'd upstream the fix. I'm somewhat afraid that changes on this small a scale aren't appreciated/accepted but I figured it was worth the 10 minutes to try. If the scope of this PR is "too small" then I'm willing to find a few other `default.yml` documentation fixes to include, either as part of this one or as a bar for future PRs.

The scope of the change was so small that I didn't make changes to the `CHANGELOG` though I'm willing to add a line if it's suggested.

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Used the same coding conventions as the rest of the project.
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] All tests are passing.
* [x] The new code doesn't generate RuboCop offenses.
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Updated cop documentation with `rake generate_cops_documentation` (required only when you've added a new cop or changed the configuration/documentation of an existing cop).

[1]: http://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html
