### PR TITLE
[Fix #3923] Allow asciibetical gem ordering

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## master (unreleased)
 
+### Bug fixes
+
+* [#3923](https://github.com/bbatsov/rubocop/issues/3923): Allow asciibetical sorting in `Bundler/OrderedGems`. ([@mikegee][])
+
 ## 0.47.1 (2017-01-18)
 
 ### Bug fixes

--- a/lib/rubocop/cop/bundler/ordered_gems.rb
+++ b/lib/rubocop/cop/bundler/ordered_gems.rb
@@ -34,7 +34,7 @@ module RuboCop
         end
 
         def case_insensitive_out_of_order?(string_a, string_b)
-          1 > string_a.casecmp(string_b)
+          string_a.downcase < string_b.downcase
         end
 
         def consecutive_lines(previous, current)

--- a/spec/rubocop/cop/bundler/ordered_gems_spec.rb
+++ b/spec/rubocop/cop/bundler/ordered_gems_spec.rb
@@ -168,6 +168,18 @@ describe RuboCop::Cop::Bundler::OrderedGems, :config do
     end
   end
 
+  context 'When gems are asciibetically sorted' do
+    let(:source) { <<-END }
+      gem 'paper_trail'
+      gem 'paperclip'
+    END
+
+    it 'does not register an offense' do
+      inspect_source(cop, source)
+      expect(cop.offenses).to be_empty
+    end
+  end
+
   context 'When a gem that starts with a capital letter is sorted' do
     let(:source) { <<-END }
       gem 'a'


### PR DESCRIPTION
The underscore character is between the uppercase and lowercase alphabetical characters in ASCII.

Folks expect "\_" to come before "a", but `String#casecmp` is implemented by uppercasing the inputs before comparing them. This leads to "\_" coming after alphabetical characters.

fixes #3923  

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Used the same coding conventions as the rest of the project.
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] All tests are passing.
* [x] The new code doesn't generate RuboCop offenses.
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [ ] Updated cop documentation with `rake generate_cops_documentation` (required only when you've added a new cop or changed the configuration/documentation of an existing cop).

[1]: http://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html
