### PR TITLE
Improve the documentation of ZeroLengthPredicate

### DIFF
--- a/lib/rubocop/cop/style/zero_length_predicate.rb
+++ b/lib/rubocop/cop/style/zero_length_predicate.rb
@@ -3,21 +3,28 @@
 module RuboCop
   module Cop
     module Style
-      # This cop checks for receiver.length == 0 predicates and the
-      # negated versions receiver.length > 0 and receiver.length != 0.
-      # These can be replaced with receiver.empty? and
-      # !receiver.empty? respectively.
+      # This cop checks for numeric comparisons that can be replaced
+      # by a predicate method, such as receiver.length == 0,
+      # receiver.length > 0, receiver.length != 0,
+      # receiver.length < 1 and receiver.size == 0 that can be
+      # replaced by receiver.empty? and !receiver.empty
       #
       # @example
       #
       #   @bad
       #   [1, 2, 3].length == 0
       #   0 == "foobar".length
+      #   array.length < 1
+      #   {a: 1, b: 2}.length != 0
+      #   string.length > 0
       #   hash.size > 0
       #
       #   @good
       #   [1, 2, 3].empty?
       #   "foobar".empty?
+      #   array.empty?
+      #   !{a: 1, b: 2}.empty?
+      #   !string.empty?
       #   !hash.empty?
       class ZeroLengthPredicate < Cop
         ZERO_MSG = 'Use `empty?` instead of `%s %s %s`.'.freeze

--- a/manual/cops_style.md
+++ b/manual/cops_style.md
@@ -5053,10 +5053,11 @@ Enabled by default | Supports autocorrection
 --- | ---
 Enabled | Yes
 
-This cop checks for receiver.length == 0 predicates and the
-negated versions receiver.length > 0 and receiver.length != 0.
-These can be replaced with receiver.empty? and
-!receiver.empty? respectively.
+This cop checks for numeric comparisons that can be replaced
+by a predicate method, such as receiver.length == 0,
+receiver.length > 0, receiver.length != 0,
+receiver.length < 1 and receiver.size == 0 that can be
+replaced by receiver.empty? and !receiver.empty
 
 ### Example
 
@@ -5064,10 +5065,16 @@ These can be replaced with receiver.empty? and
 # bad
 [1, 2, 3].length == 0
 0 == "foobar".length
+array.length < 1
+{a: 1, b: 2}.length != 0
+string.length > 0
 hash.size > 0
 
 # good
 [1, 2, 3].empty?
 "foobar".empty?
+array.empty?
+!{a: 1, b: 2}.empty?
+!string.empty?
 !hash.empty?
 ```


### PR DESCRIPTION
The ZeroLengthPredicate cop  not only checks for `receiver.length == 0`, `receiver.length > 0` and `receiver.length != 0`, but also things like `receiver.length < 1` and `receiver.size == 0`. Documentation updated to include these cases. :bowtie: 

