### PR TITLE
Add a new configuration to DoubleStartEndWith

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 * [#3915](https://github.com/bbatsov/rubocop/issues/3915): Make configurable whitelist for `Lint/SafeNavigationChain` cop. ([@pocke][])
 
+### New features
+
+* [#3893](https://github.com/bbatsov/rubocop/issues/3893): Add a new configuration, `IncludeActiveSupportAliases`, to `Performance/DoublStartEndWith`. This configuration will check for ActiveSupport's `starts_with?` and `ends_with?`. ([@rrosenblum][])
+
 ### Bug fixes
 
 * [#3923](https://github.com/bbatsov/rubocop/issues/3923): Allow asciibetical sorting in `Bundler/OrderedGems`. ([@mikegee][])

--- a/config/default.yml
+++ b/config/default.yml
@@ -1299,6 +1299,11 @@ Lint/UnusedMethodArgument:
 
 #################### Performance ###########################
 
+Performance/DoubleStartEndWith:
+  # Used to check for `starts_with?` and `ends_with?`.
+  # These methods are defined by `ActiveSupport`.
+  IncludeActiveSupportAliases: false
+
 Performance/RedundantMerge:
   # Max number of key-value pairs to consider an offense
   MaxKeyValuePairs: 2

--- a/manual/cops_performance.md
+++ b/manual/cops_performance.md
@@ -232,6 +232,13 @@ var2 = ...
 str.end_with?(var1, var2)
 ```
 
+### Important attributes
+
+Attribute | Value
+--- | ---
+IncludeActiveSupportAliases | false
+
+
 ## Performance/EndWith
 
 Enabled by default | Supports autocorrection

--- a/spec/rubocop/cop/performance/double_start_end_with_spec.rb
+++ b/spec/rubocop/cop/performance/double_start_end_with_spec.rb
@@ -3,31 +3,49 @@
 require 'spec_helper'
 
 describe RuboCop::Cop::Performance::DoubleStartEndWith do
-  subject(:cop) { described_class.new }
+  subject(:cop) { described_class.new(config) }
 
   before do
     inspect_source(cop, source)
   end
 
-  context 'two #start_with? calls' do
-    context 'with the same receiver' do
-      context 'all parameters of the second call are pure' do
-        let(:source) { 'x.start_with?(a, b) || x.start_with?("c", D)' }
+  context 'IncludeActiveSupportAliases: false' do
+    let(:config) do
+      RuboCop::Config.new(
+        'Performance/DoubleStartEndWith' => {
+          'IncludeActiveSupportAliases' => false
+        }
+      )
+    end
 
-        it 'registers an offense' do
-          expect(cop.offenses.size).to eq(1)
-          expect(cop.offenses.first.message).to eq(
-            'Use `x.start_with?(a, b, "c", D)` instead of ' \
-            '`x.start_with?(a, b) || x.start_with?("c", D)`.'
-          )
-          expect(cop.highlights).to eq(
-            ['x.start_with?(a, b) || x.start_with?("c", D)']
-          )
+    context 'two #start_with? calls' do
+      context 'with the same receiver' do
+        context 'all parameters of the second call are pure' do
+          let(:source) { 'x.start_with?(a, b) || x.start_with?("c", D)' }
+
+          it 'registers an offense' do
+            expect(cop.offenses.size).to eq(1)
+            expect(cop.offenses.first.message).to eq(
+              'Use `x.start_with?(a, b, "c", D)` instead of ' \
+              '`x.start_with?(a, b) || x.start_with?("c", D)`.'
+            )
+            expect(cop.highlights).to eq(
+              ['x.start_with?(a, b) || x.start_with?("c", D)']
+            )
+          end
+        end
+
+        context 'one of the parameters of the second call is not pure' do
+          let(:source) { 'x.start_with?(a, "b") || x.start_with?(C, d)' }
+
+          it "doesn't register an offense" do
+            expect(cop.offenses).to be_empty
+          end
         end
       end
 
-      context 'one of the parameters of the second call is not pure' do
-        let(:source) { 'x.start_with?(a, "b") || x.start_with?(C, d)' }
+      context 'with different receivers' do
+        let(:source) { 'x.start_with?("a") || y.start_with?("b")' }
 
         it "doesn't register an offense" do
           expect(cop.offenses).to be_empty
@@ -35,34 +53,34 @@ describe RuboCop::Cop::Performance::DoubleStartEndWith do
       end
     end
 
-    context 'with different receivers' do
-      let(:source) { 'x.start_with?("a") || y.start_with?("b")' }
+    context 'two #end_with? calls' do
+      context 'with the same receiver' do
+        context 'all parameters of the second call are pure' do
+          let(:source) { 'x.end_with?(a, b) || x.end_with?("c", D)' }
 
-      it "doesn't register an offense" do
-        expect(cop.offenses).to be_empty
-      end
-    end
-  end
+          it 'registers an offense' do
+            expect(cop.offenses.size).to eq(1)
+            expect(cop.offenses.first.message).to eq(
+              'Use `x.end_with?(a, b, "c", D)` instead of ' \
+              '`x.end_with?(a, b) || x.end_with?("c", D)`.'
+            )
+            expect(cop.highlights).to eq(
+              ['x.end_with?(a, b) || x.end_with?("c", D)']
+            )
+          end
+        end
 
-  context 'two #end_with? calls' do
-    context 'with the same receiver' do
-      context 'all parameters of the second call are pure' do
-        let(:source) { 'x.end_with?(a, b) || x.end_with?("c", D)' }
+        context 'one of the parameters of the second call is not pure' do
+          let(:source) { 'x.end_with?(a, "b") || x.end_with?(C, d)' }
 
-        it 'registers an offense' do
-          expect(cop.offenses.size).to eq(1)
-          expect(cop.offenses.first.message).to eq(
-            'Use `x.end_with?(a, b, "c", D)` instead of ' \
-            '`x.end_with?(a, b) || x.end_with?("c", D)`.'
-          )
-          expect(cop.highlights).to eq(
-            ['x.end_with?(a, b) || x.end_with?("c", D)']
-          )
+          it "doesn't register an offense" do
+            expect(cop.offenses).to be_empty
+          end
         end
       end
 
-      context 'one of the parameters of the second call is not pure' do
-        let(:source) { 'x.end_with?(a, "b") || x.end_with?(C, d)' }
+      context 'with different receivers' do
+        let(:source) { 'x.end_with?("a") || y.end_with?("b")' }
 
         it "doesn't register an offense" do
           expect(cop.offenses).to be_empty
@@ -70,8 +88,24 @@ describe RuboCop::Cop::Performance::DoubleStartEndWith do
       end
     end
 
-    context 'with different receivers' do
-      let(:source) { 'x.end_with?("a") || y.end_with?("b")' }
+    context 'a .start_with? and .end_with? call with the same receiver' do
+      let(:source) { 'x.start_with?("a") || x.end_with?("b")' }
+
+      it "doesn't register an offense" do
+        expect(cop.offenses).to be_empty
+      end
+    end
+
+    context 'two #starts_with? calls' do
+      let(:source) { 'x.starts_with?(a, b) || x.starts_with?("c", D)' }
+
+      it "doesn't register an offense" do
+        expect(cop.offenses).to be_empty
+      end
+    end
+
+    context 'two #ends_with? calls' do
+      let(:source) { 'x.ends_with?(a, b) || x.ends_with?("c", D)' }
 
       it "doesn't register an offense" do
         expect(cop.offenses).to be_empty
@@ -79,11 +113,117 @@ describe RuboCop::Cop::Performance::DoubleStartEndWith do
     end
   end
 
-  context 'a .start_with? and .end_with? call with the same receiver' do
-    let(:source) { 'x.start_with?("a") || x.end_with?("b")' }
+  context 'IncludeActiveSupportAliases: true' do
+    let(:config) do
+      RuboCop::Config.new(
+        'Performance/DoubleStartEndWith' => {
+          'IncludeActiveSupportAliases' => true
+        }
+      )
+    end
 
-    it "doesn't register an offense" do
-      expect(cop.offenses).to be_empty
+    context 'two #start_with? calls' do
+      context 'with the same receiver' do
+        context 'all parameters of the second call are pure' do
+          let(:source) { 'x.start_with?(a, b) || x.start_with?("c", D)' }
+
+          it 'registers an offense' do
+            expect(cop.offenses.size).to eq(1)
+            expect(cop.offenses.first.message)
+              .to eq('Use `x.start_with?(a, b, "c", D)` instead of ' \
+            '`x.start_with?(a, b) || x.start_with?("c", D)`.')
+            expect(cop.highlights)
+              .to eq(['x.start_with?(a, b) || x.start_with?("c", D)'])
+          end
+        end
+      end
+    end
+
+    context 'two #end_with? calls' do
+      context 'with the same receiver' do
+        context 'all parameters of the second call are pure' do
+          let(:source) { 'x.end_with?(a, b) || x.end_with?("c", D)' }
+
+          it 'registers an offense' do
+            expect(cop.offenses.size).to eq(1)
+            expect(cop.offenses.first.message)
+              .to eq('Use `x.end_with?(a, b, "c", D)` instead of ' \
+            '`x.end_with?(a, b) || x.end_with?("c", D)`.')
+            expect(cop.highlights)
+              .to eq(['x.end_with?(a, b) || x.end_with?("c", D)'])
+          end
+        end
+      end
+    end
+
+    context 'two #starts_with? calls' do
+      context 'with the same receiver' do
+        context 'all parameters of the second call are pure' do
+          let(:source) { 'x.starts_with?(a, b) || x.starts_with?("c", D)' }
+
+          it 'registers an offense' do
+            expect(cop.offenses.size).to eq(1)
+            expect(cop.offenses.first.message).to eq(
+              'Use `x.starts_with?(a, b, "c", D)` instead of ' \
+              '`x.starts_with?(a, b) || x.starts_with?("c", D)`.'
+            )
+            expect(cop.highlights).to eq(
+              ['x.starts_with?(a, b) || x.starts_with?("c", D)']
+            )
+          end
+        end
+
+        context 'one of the parameters of the second call is not pure' do
+          let(:source) { 'x.starts_with?(a, "b") || x.starts_with?(C, d)' }
+
+          it "doesn't register an offense" do
+            expect(cop.offenses).to be_empty
+          end
+        end
+      end
+
+      context 'with different receivers' do
+        let(:source) { 'x.starts_with?("a") || y.starts_with?("b")' }
+
+        it "doesn't register an offense" do
+          expect(cop.offenses).to be_empty
+        end
+      end
+    end
+
+    context 'two #ends_with? calls' do
+      context 'with the same receiver' do
+        context 'all parameters of the second call are pure' do
+          let(:source) { 'x.ends_with?(a, b) || x.ends_with?("c", D)' }
+
+          it 'registers an offense' do
+            expect(cop.offenses.size).to eq(1)
+            expect(cop.offenses.first.message).to eq(
+              'Use `x.ends_with?(a, b, "c", D)` instead of ' \
+              '`x.ends_with?(a, b) || x.ends_with?("c", D)`.'
+            )
+            expect(cop.highlights).to eq(
+              ['x.ends_with?(a, b) || x.ends_with?("c", D)']
+            )
+          end
+        end
+
+        context 'one of the parameters of the second call is not pure' do
+          let(:source) { 'x.ends_with?(a, "b") || x.ends_with?(C, d)' }
+
+          it "doesn't register an offense" do
+            expect(cop.offenses).to be_empty
+          end
+        end
+      end
+
+      context 'with different receivers' do
+        let(:source) { 'x.ends_with?("a") || y.ends_with?("b")' }
+
+        it "doesn't register an offense" do
+          expect(cop.offenses).to be_empty
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
This fixes #3893.

I noticed that this cop doesn't support auto-correct. After this PR is merged in, I can add support for auto-correct.