### PR TITLE
Fix typo in the documentation for some Rails cops

### DIFF
--- a/lib/rubocop/cop/rails/date.rb
+++ b/lib/rubocop/cop/rails/date.rb
@@ -25,7 +25,7 @@ module RuboCop
       #   Time.zone.today
       #   Time.zone.today - 1.day
       #
-      #   # acceptable
+      #   # flexible
       #   Date.current
       #   Date.yesterday
       #

--- a/lib/rubocop/cop/rails/time_zone.rb
+++ b/lib/rubocop/cop/rails/time_zone.rb
@@ -23,7 +23,7 @@ module RuboCop
       #   Time.zone.now
       #   Time.zone.parse('2015-03-02 19:05:37')
       #
-      #   # no offense only if style is 'acceptable'
+      #   # no offense only if style is 'flexible'
       #   Time.current
       #   DateTime.strptime(str, "%Y-%m-%d %H:%M %Z").in_time_zone
       #   Time.at(timestamp).in_time_zone

--- a/manual/cops_rails.md
+++ b/manual/cops_rails.md
@@ -50,7 +50,7 @@ and only 'to_time' is reported as warning.
 Time.zone.today
 Time.zone.today - 1.day
 
-# acceptable
+# flexible
 Date.current
 Date.yesterday
 
@@ -802,7 +802,7 @@ Time.parse('2015-03-02 19:05:37')
 Time.zone.now
 Time.zone.parse('2015-03-02 19:05:37')
 
-# no offense only if style is 'acceptable'
+# no offense only if style is 'flexible'
 Time.current
 DateTime.strptime(str, "%Y-%m-%d %H:%M %Z").in_time_zone
 Time.at(timestamp).in_time_zone


### PR DESCRIPTION
`Rails/Date` and `Rails/TimeZone` cops support `flexible` style.

- https://github.com/bbatsov/rubocop/blob/08217fe1fd8442d1cd8013577b59bdc2502af3ac/config/default.yml#L1325
- https://github.com/bbatsov/rubocop/blob/08217fe1fd8442d1cd8013577b59bdc2502af3ac/config/default.yml#L1397

However, in the documentation, the style is `acceptable`.
This change fixes the mismatch.



-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Used the same coding conventions as the rest of the project.
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [ ] Added tests.
* [ ] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] All tests are passing.
* [x] The new code doesn't generate RuboCop offenses.
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Updated cop documentation with `rake generate_cops_documentation` (required only when you've added a new cop or changed the configuration/documentation of an existing cop).

[1]: http://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html
