### PR TITLE
[Fix #3944] Allow keyword args in Style/RaiseArgs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Changes
 
 * [#3915](https://github.com/bbatsov/rubocop/issues/3915): Make configurable whitelist for `Lint/SafeNavigationChain` cop. ([@pocke][])
+* [#3944](https://github.com/bbatsov/rubocop/issues/3944): Allow keyword arguments in `Style/RaiseArgs` cop. ([@mikegee][])
 
 ### New features
 

--- a/manual/cops_style.md
+++ b/manual/cops_style.md
@@ -3957,7 +3957,8 @@ raise StandardError.new("message")
 # good
 raise StandardError, "message"
 fail "message"
-raise RuntimeError.new(arg1, arg2, arg3)
+raise MyCustomError.new(arg1, arg2, arg3)
+raise MyKwArgError.new(key1: val1, key2: val2)
 ```
 ```ruby
 # EnforcedStyle: compact
@@ -3968,7 +3969,7 @@ raise RuntimeError, arg1, arg2, arg3
 
 # good
 raise StandardError.new("message")
-raise RuntimeError.new(arg1, arg2, arg3)
+raise MyCustomError.new(arg1, arg2, arg3)
 fail "message"
 ```
 

--- a/spec/rubocop/cop/style/raise_args_spec.rb
+++ b/spec/rubocop/cop/style/raise_args_spec.rb
@@ -138,12 +138,17 @@ describe RuboCop::Cop::Style::RaiseArgs, :config do
     end
 
     it 'accepts exception constructor with more than 1 argument' do
-      inspect_source(cop, 'raise RuntimeError.new(a1, a2, a3)')
+      inspect_source(cop, 'raise MyCustomError.new(a1, a2, a3)')
+      expect(cop.offenses).to be_empty
+    end
+
+    it 'accepts exception constructor with keyword arguments' do
+      inspect_source(cop, 'raise MyKwArgError.new(a: 1, b: 2)')
       expect(cop.offenses).to be_empty
     end
 
     it 'accepts a raise with splatted arguments' do
-      inspect_source(cop, 'raise RuntimeError.new(*args)')
+      inspect_source(cop, 'raise MyCustomError.new(*args)')
       expect(cop.offenses).to be_empty
     end
 


### PR DESCRIPTION
Allow code like `raise MyError.new(keyword: argument, kw: arg)` by default.

fixes #3944 

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Used the same coding conventions as the rest of the project.
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] All tests are passing.
* [x] The new code doesn't generate RuboCop offenses.
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Updated cop documentation with `rake generate_cops_documentation` (required only when you've added a new cop or changed the configuration/documentation of an existing cop).

[1]: http://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html
