### PR TITLE
Make `yield` is not complex in Style/TernaryParentheses cop

### DIFF
--- a/lib/rubocop/cop/style/ternary_parentheses.rb
+++ b/lib/rubocop/cop/style/ternary_parentheses.rb
@@ -113,7 +113,7 @@ module RuboCop
         def non_complex_type?(condition)
           condition.variable? || condition.const_type? ||
             (condition.send_type? && !operator?(condition.method_name)) ||
-            condition.defined_type?
+            condition.defined_type? || condition.yield_type?
         end
 
         def message(node)

--- a/spec/rubocop/cop/style/ternary_parentheses_spec.rb
+++ b/spec/rubocop/cop/style/ternary_parentheses_spec.rb
@@ -75,6 +75,10 @@ describe RuboCop::Cop::Style::TernaryParentheses, :config do
       it_behaves_like 'code with offense',
                       'foo = bar? ? a : b',
                       'foo = (bar?) ? a : b'
+
+      it_behaves_like 'code with offense',
+                      'foo = yield ? a : b',
+                      'foo = (yield) ? a : b'
     end
 
     context 'with a complex condition' do
@@ -126,6 +130,10 @@ describe RuboCop::Cop::Style::TernaryParentheses, :config do
       it_behaves_like 'code with offense',
                       'foo = (bar?) ? a : b',
                       'foo = bar? ? a : b'
+
+      it_behaves_like 'code with offense',
+                      'foo = (yield) ? a : b',
+                      'foo = yield ? a : b'
     end
 
     context 'with a complex condition' do
@@ -202,6 +210,10 @@ describe RuboCop::Cop::Style::TernaryParentheses, :config do
       it_behaves_like 'code with offense',
                       'foo = (bar?) ? a : b',
                       'foo = bar? ? a : b'
+
+      it_behaves_like 'code with offense',
+                      'foo = (yield) ? a : b',
+                      'foo = yield ? a : b'
     end
 
     context 'with a complex condition' do


### PR DESCRIPTION
`yield` is simple enough.

```
# EnforcedStyle: require_parentheses_when_complex
#
# # bad
# foo = (yield) ? a : b
#
# # good
# foo = yield ? a : b
```

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Used the same coding conventions as the rest of the project.
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [ ] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] All tests are passing.
* [x] The new code doesn't generate RuboCop offenses.
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [ ] Updated cop documentation with `rake generate_cops_documentation` (required only when you've added a new cop or changed the configuration/documentation of an existing cop).

[1]: http://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html
