### PR TITLE
[Fix #3855] Make `Lint/NonLocalExitFromIterator` cop aware of method definitions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 ### Bug fixes
 
 * [#3923](https://github.com/bbatsov/rubocop/issues/3923): Allow asciibetical sorting in `Bundler/OrderedGems`. ([@mikegee][])
+* [#3855](https://github.com/bbatsov/rubocop/issues/3855): Make `Lint/NonLocalExitFromIterator` aware of method definitions. ([@drenmi][])
 
 ## 0.47.1 (2017-01-18)
 

--- a/manual/cops_lint.md
+++ b/manual/cops_lint.md
@@ -1186,11 +1186,16 @@ Enabled by default | Supports autocorrection
 --- | ---
 Enabled | No
 
-This cop checks for non-local exit from iterator, without return value.
-It warns only when satisfies all of these: `return` doesn't have return
-value, the block is preceded by a method chain, the block has arguments,
-and the method which receives the block is not `define_method`
-or `define_singleton_method`.
+This cop checks for non-local exits from iterators without a return
+value. It registers an offense under these conditions:
+
+ - No value is returned,
+ - the block is preceded by a method chain,
+ - the block has arguments,
+ - the method which receives the block is not `define_method`
+   or `define_singleton_method`,
+ - the return is not contained in an inner scope, e.g. a lambda or a
+   method definition.
 
 ### Example
 

--- a/spec/rubocop/cop/lint/non_local_exit_from_iterator_spec.rb
+++ b/spec/rubocop/cop/lint/non_local_exit_from_iterator_spec.rb
@@ -174,5 +174,31 @@ describe RuboCop::Cop::Lint::NonLocalExitFromIterator do
 
       it { expect(cop.offenses).to be_empty }
     end
+
+    context 'when the return is within a nested method definition' do
+      context 'with an instance method definition' do
+        let(:source) { <<-END }
+          Foo.configure do |c|
+            def bar
+              return if baz?
+            end
+          end
+        END
+
+        it { expect(cop.offenses).to be_empty }
+      end
+
+      context 'with a class method definition' do
+        let(:source) { <<-END }
+          Foo.configure do |c|
+            def self.bar
+              return if baz?
+            end
+          end
+        END
+
+        it { expect(cop.offenses).to be_empty }
+      end
+    end
   end
 end


### PR DESCRIPTION
This cop would report an offense if it found a `return` statement inside a method definition inside a block, even though the `return` is scoped to the method definition. This change fixes that.

-----------------

Before submitting the PR make sure the following are checked:

* [X] Wrote [good commit messages][1].
* [X] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [X] Used the same coding conventions as the rest of the project.
* [X] Feature branch is up-to-date with `master` (if not - rebase it).
* [X] Squashed related commits together.
* [X] Added tests.
* [X] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [X] All tests are passing.
* [X] The new code doesn't generate RuboCop offenses.
* [X] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [X] Updated cop documentation with `rake generate_cops_documentation` (required only when you've added a new cop or changed the configuration/documentation of an existing cop).

[1]: http://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html
