### PR TITLE
Register an offence in the case of the string without zone

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2616,3 +2616,4 @@
 [@zverok]: https://github.com/zverok
 [@backus]: https://github.com/backus
 [@pat]: https://github.com/pat
+[@sinsoku]: https://github.com/sinsoku

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 * [#3915](https://github.com/bbatsov/rubocop/issues/3915): Make configurable whitelist for `Lint/SafeNavigationChain` cop. ([@pocke][])
 * [#3944](https://github.com/bbatsov/rubocop/issues/3944): Allow keyword arguments in `Style/RaiseArgs` cop. ([@mikegee][])
+* [#3951](https://github.com/bbatsov/rubocop/pull/3951): Make `Rails/Date` cop to register an offence for the string without zone. ([@sinsoku][])
 
 ### New features
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@
 
 * [#3915](https://github.com/bbatsov/rubocop/issues/3915): Make configurable whitelist for `Lint/SafeNavigationChain` cop. ([@pocke][])
 * [#3944](https://github.com/bbatsov/rubocop/issues/3944): Allow keyword arguments in `Style/RaiseArgs` cop. ([@mikegee][])
-* [#3951](https://github.com/bbatsov/rubocop/pull/3951): Make `Rails/Date` cop to register an offence for the string without zone. ([@sinsoku][])
+* [#3951](https://github.com/bbatsov/rubocop/pull/3951): Make `Rails/Date` cop to register an offence for a string without timezone. ([@sinsoku][])
 
 ### New features
 

--- a/lib/rubocop/cop/rails/date.rb
+++ b/lib/rubocop/cop/rails/date.rb
@@ -54,13 +54,13 @@ module RuboCop
         end
 
         def on_send(node)
-          receiver, method_name, *args = *node
+          receiver, method_name = *node
           return unless receiver && bad_methods.include?(method_name)
 
           chain = extract_method_chain(node)
           return if safe_chain?(chain)
 
-          return if method_name == :to_time && args.length == 1
+          return if method_name == :to_time && safe_to_time?(node)
 
           add_offense(node, :selector,
                       format(MSG_SEND,
@@ -107,6 +107,16 @@ module RuboCop
 
         def safe_chain?(chain)
           (chain & bad_methods).empty? || !(chain & good_methods).empty?
+        end
+
+        def safe_to_time?(node)
+          receiver, _method_name, *args = *node
+          if receiver.str_type?
+            zone_regexp = /[\+-]{1}[\d:]+$/
+            receiver.str_content.match(zone_regexp)
+          else
+            args.length == 1
+          end
         end
 
         def good_days

--- a/lib/rubocop/cop/rails/date.rb
+++ b/lib/rubocop/cop/rails/date.rb
@@ -112,7 +112,7 @@ module RuboCop
         def safe_to_time?(node)
           receiver, _method_name, *args = *node
           if receiver.str_type?
-            zone_regexp = /[+-][\d:]+$/
+            zone_regexp = /[+-][\d:]+\z/
             receiver.str_content.match(zone_regexp)
           else
             args.length == 1

--- a/lib/rubocop/cop/rails/date.rb
+++ b/lib/rubocop/cop/rails/date.rb
@@ -112,7 +112,7 @@ module RuboCop
         def safe_to_time?(node)
           receiver, _method_name, *args = *node
           if receiver.str_type?
-            zone_regexp = /[\+-]{1}[\d:]+$/
+            zone_regexp = /[+-][\d:]+$/
             receiver.str_content.match(zone_regexp)
           else
             args.length == 1

--- a/spec/rubocop/cop/rails/date_spec.rb
+++ b/spec/rubocop/cop/rails/date_spec.rb
@@ -49,14 +49,14 @@ describe RuboCop::Cop::Rails::Date, :config do
       end
     end
 
-    context 'when the string literal with zone' do
+    context 'when a string literal with timezone' do
       it 'does not register an offense' do
         inspect_source(cop, '"2016-07-12 14:36:31 +0100".to_time(:utc)')
         expect(cop.offenses).to be_empty
       end
     end
 
-    context 'when the string literal without zone' do
+    context 'when a string literal without timezone' do
       it 'registers an offense' do
         inspect_source(cop, '"2016-07-12 14:36:31".to_time(:utc)')
         expect(cop.offenses.size).to eq(1)

--- a/spec/rubocop/cop/rails/date_spec.rb
+++ b/spec/rubocop/cop/rails/date_spec.rb
@@ -49,6 +49,20 @@ describe RuboCop::Cop::Rails::Date, :config do
       end
     end
 
+    context 'when the string literal with zone' do
+      it 'does not register an offense' do
+        inspect_source(cop, '"2016-07-12 14:36:31 +0100".to_time(:utc)')
+        expect(cop.offenses).to be_empty
+      end
+    end
+
+    context 'when the string literal without zone' do
+      it 'registers an offense' do
+        inspect_source(cop, '"2016-07-12 14:36:31".to_time(:utc)')
+        expect(cop.offenses.size).to eq(1)
+      end
+    end
+
     it 'does not blow up in the presence of a single constant to inspect' do
       inspect_source(cop, 'A')
       expect(cop.offenses).to be_empty


### PR DESCRIPTION
Using the string without zone is dangerous. It doesn't use Rails time zone, use the system timezone.

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Used the same coding conventions as the rest of the project.
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] All tests are passing.
* [x] The new code doesn't generate RuboCop offenses.
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [ ] Updated cop documentation with `rake generate_cops_documentation` (required only when you've added a new cop or changed the configuration/documentation of an existing cop).

[1]: http://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html
