### PR TITLE
Fix failing builds on Travis CI by using latest rubygems

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,9 @@ matrix:
     - rvm: ruby-head
     - rvm: rbx-3
   fast_finish: true
-before_install: gem update --remote bundler
+before_install:
+  - gem update --remote bundler
+  - gem update --system
 install:
   - bundle install --retry=3
 script:


### PR DESCRIPTION
Currently, builds are failing on Travis CI. e.g.) https://travis-ci.org/bbatsov/rubocop/jobs/194136460

The cause is from rubygems, and it has been fixed.

See also. https://github.com/sickill/rainbow/issues/48

Note
------

Builds seem to be failing for different reason in JRuby.
https://travis-ci.org/bbatsov/rubocop/jobs/194136459

This change hasn't fixed the problem.
Maybe the problem will be fixed by https://github.com/bundler/bundler/issues/5340 , However, I don't try it.

