### PR TITLE
Windows Paths

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 * [#4019](https://github.com/bbatsov/rubocop/pull/4019): Make configurable `Style/MultilineMemoization` cop. ([@pocke][])
 * [#4018](https://github.com/bbatsov/rubocop/pull/4018): Add autocorrect `Lint/EmptyEnsure` cop. ([@pocke][])
 * [#4028](https://github.com/bbatsov/rubocop/pull/4028): Add new `Style/IndentHeredoc` cop. ([@pocke][])
+* [#3995](https://github.com/bbatsov/rubocop/pull/3955): Support analyzing files on different drives on Windows. ([@cfis][])
 
 ### Changes
 

--- a/lib/rubocop/path_util.rb
+++ b/lib/rubocop/path_util.rb
@@ -5,13 +5,30 @@ module RuboCop
   module PathUtil
     module_function
 
+    def same_drive(path1, path2)
+      if RuboCop::Platform.windows?
+        regex = /^[[:alpha:]]:/
+        path1_drive = path1.to_s.match(regex).to_s.downcase
+        path2_drive = path2.to_s.match(regex).to_s.downcase
+
+        path1_drive == path2_drive
+      else
+        true
+      end
+    end
+
     def relative_path(path, base_dir = Dir.pwd)
       # Optimization for the common case where path begins with the base
       # dir. Just cut off the first part.
       return path[(base_dir.length + 1)..-1] if path.start_with?(base_dir)
 
       path_name = Pathname.new(File.expand_path(path))
-      path_name.relative_path_from(Pathname.new(base_dir)).to_s
+
+      if same_drive(path_name, base_dir)
+        path_name.relative_path_from(Pathname.new(base_dir)).to_s
+      else
+        path_name.to_s
+      end
     end
 
     def match_path?(pattern, path)


### PR DESCRIPTION
Fix for #727.  Problem is the concept of a relative path does not make sense on Windows if the two paths are on different drives.  For example c:\path1 and d:\path2.
