### PR TITLE
[Fix #2643] `MagicComment` uppercase and dashes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 
 * [#3923](https://github.com/bbatsov/rubocop/issues/3923): Allow asciibetical sorting in `Bundler/OrderedGems`. ([@mikegee][])
 * [#3855](https://github.com/bbatsov/rubocop/issues/3855): Make `Lint/NonLocalExitFromIterator` aware of method definitions. ([@drenmi][])
+* [#2643](https://github.com/bbatsov/rubocop/issues/2643): Allow uppercase and dashes in `MagicComment`. ([@mikegee][])
 
 ## 0.47.1 (2017-01-18)
 

--- a/lib/rubocop/magic_comment.rb
+++ b/lib/rubocop/magic_comment.rb
@@ -179,7 +179,7 @@ module RuboCop
     class SimpleComment < MagicComment
       # Match `encoding` or `coding`
       def encoding
-        extract(/\b(?:en)?coding: (#{TOKEN})/)
+        extract(/\b(?:en)?coding: (#{TOKEN})/i)
       end
 
       private
@@ -188,8 +188,11 @@ module RuboCop
       #
       # The `frozen_string_literal` magic comment only works if it
       # is the only text in the comment.
+      #
+      # Case-insensitive and dashes/underscores are acceptable.
+      # @see https://git.io/vM7Mg
       def extract_frozen_string_literal
-        extract(/^#\s*frozen_string_literal:\s*(#{TOKEN})\s*$/)
+        extract(/\A#\s*frozen[_-]string[_-]literal:\s*(#{TOKEN})\s*\z/i)
       end
     end
   end

--- a/spec/rubocop/magic_comment_spec.rb
+++ b/spec/rubocop/magic_comment_spec.rb
@@ -25,6 +25,14 @@ RSpec.describe RuboCop::MagicComment do
                    encoding: 'utf-8'
 
   include_examples 'magic comment',
+                   '# ENCODING: utf-8',
+                   encoding: 'utf-8'
+
+  include_examples 'magic comment',
+                   '# eNcOdInG: utf-8',
+                   encoding: 'utf-8'
+
+  include_examples 'magic comment',
                    '# coding: utf-8',
                    encoding: 'utf-8'
 
@@ -46,6 +54,18 @@ RSpec.describe RuboCop::MagicComment do
   include_examples 'magic comment',
                    '# frozen_string_literal: false',
                    frozen_string_literal: false
+
+  include_examples 'magic comment',
+                   '# frozen-string-literal: true',
+                   frozen_string_literal: true
+
+  include_examples 'magic comment',
+                   '# FROZEN-STRING-LITERAL: true',
+                   frozen_string_literal: true
+
+  include_examples 'magic comment',
+                   '# fRoZeN-sTrInG_lItErAl: true',
+                   frozen_string_literal: true
 
   include_examples 'magic comment',
                    '# frozen_string_literal: invalid',


### PR DESCRIPTION
Ruby's "magic comments" [may use dashes instead of underscores](https://github.com/ruby/ruby/blob/78b95b49f8715a4782f5b9bdc4c163e445cdc303/parse.y#L7134-L7136) and [are case-insensitive](https://github.com/ruby/ruby/blob/78b95b49f8715a4782f5b9bdc4c163e445cdc303/parse.y#L7138).

fixes #2643 

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Used the same coding conventions as the rest of the project.
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] All tests are passing.
* [x] The new code doesn't generate RuboCop offenses.
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Updated cop documentation with `rake generate_cops_documentation` (required only when you've added a new cop or changed the configuration/documentation of an existing cop).

[1]: http://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html
