### PR TITLE
[Fix #3959] Fix MutableConstant for percent arrays

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
 * [#3923](https://github.com/bbatsov/rubocop/issues/3923): Allow asciibetical sorting in `Bundler/OrderedGems`. ([@mikegee][])
 * [#3855](https://github.com/bbatsov/rubocop/issues/3855): Make `Lint/NonLocalExitFromIterator` aware of method definitions. ([@drenmi][])
 * [#2643](https://github.com/bbatsov/rubocop/issues/2643): Allow uppercase and dashes in `MagicComment`. ([@mikegee][])
+* [#3959](https://github.com/bbatsov/rubocop/issues/3959): Don't wrap "percent arrays" with extra brackets when autocorrecting `Style/MutableConstant`. ([@mikegee][])
 
 ## 0.47.1 (2017-01-18)
 

--- a/lib/rubocop/cop/style/mutable_constant.rb
+++ b/lib/rubocop/cop/style/mutable_constant.rb
@@ -46,13 +46,17 @@ module RuboCop
           expr = node.source_range
 
           lambda do |corrector|
-            if node.array_type? && !node.square_brackets?
+            if unbracketed_array?(node)
               corrector.insert_before(expr, '[')
               corrector.insert_after(expr, '].freeze')
             else
               corrector.insert_after(expr, '.freeze')
             end
           end
+        end
+
+        def unbracketed_array?(node)
+          node.array_type? && !node.square_brackets? && !node.percent_literal?
         end
 
         def_node_matcher :splat_value, <<-PATTERN

--- a/spec/rubocop/cop/style/mutable_constant_spec.rb
+++ b/spec/rubocop/cop/style/mutable_constant_spec.rb
@@ -93,6 +93,11 @@ describe RuboCop::Cop::Style::MutableConstant do
       new_source = autocorrect_source(cop, 'XXX = YYY, ZZZ')
       expect(new_source).to eq 'XXX = [YYY, ZZZ].freeze'
     end
+
+    it 'does not add brackets to %w() arrays' do
+      new_source = autocorrect_source(cop, 'XXX = %w(YYY ZZZ)')
+      expect(new_source).to eq 'XXX = %w(YYY ZZZ).freeze'
+    end
   end
 
   context 'when the constant is a frozen string literal' do


### PR DESCRIPTION
`Style/MutableConstant` shouldn't wrap "percent arrays" (`%w`, `%W`, `%i`, etc.) with extra brackets when autocorrecting.

fixes #3959 

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Used the same coding conventions as the rest of the project.
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] All tests are passing.
* [x] The new code doesn't generate RuboCop offenses.
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Updated cop documentation with `rake generate_cops_documentation` (required only when you've added a new cop or changed the configuration/documentation of an existing cop).

[1]: http://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html
