### PR TITLE
Configurable EOL

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 * [#3893](https://github.com/bbatsov/rubocop/issues/3893): Add a new configuration, `IncludeActiveSupportAliases`, to `Performance/DoublStartEndWith`. This configuration will check for ActiveSupport's `starts_with?` and `ends_with?`. ([@rrosenblum][])
 * [#3889](https://github.com/bbatsov/rubocop/pull/3889): Add new `Style/EmptyLineAfterMagicComment` cop. ([@backus][])
+* [#3800](https://github.com/bbatsov/rubocop/issues/3800): Make `Style/EndOfLine` configurable with `lf`, `crlf`, and `native` (default) styles. ([@jonas054][])
 
 ### Changes
 

--- a/config/default.yml
+++ b/config/default.yml
@@ -474,8 +474,12 @@ Style/Encoding:
   AutoCorrectEncodingComment: '# encoding: utf-8'
 
 Style/EndOfLine:
-  EnforcedStyle: lf
+  # The `native` style means that CR+LF (Carriage Return + Line Feed) is
+  # enforced on Windows, and LF is enforced on other platforms. The other styles
+  # mean LF and CR+LF, respectively.
+  EnforcedStyle: native
   SupportedStyles:
+    - native
     - lf
     - crlf
 

--- a/config/default.yml
+++ b/config/default.yml
@@ -473,6 +473,12 @@ Style/Encoding:
     - never
   AutoCorrectEncodingComment: '# encoding: utf-8'
 
+Style/EndOfLine:
+  EnforcedStyle: lf
+  SupportedStyles:
+    - lf
+    - crlf
+
 Style/ExtraSpacing:
   # When true, allows most uses of extra spacing if the intent is to align
   # things with the previous or next line, not counting empty lines or comment

--- a/lib/rubocop.rb
+++ b/lib/rubocop.rb
@@ -15,6 +15,7 @@ require 'unicode/display_width'
 require 'rubocop/version'
 
 require 'rubocop/path_util'
+require 'rubocop/platform'
 require 'rubocop/string_util'
 require 'rubocop/name_similarity'
 require 'rubocop/node_pattern'

--- a/lib/rubocop/cop/style/end_of_line.rb
+++ b/lib/rubocop/cop/style/end_of_line.rb
@@ -36,7 +36,12 @@ module RuboCop
         end
 
         def offense_message(line)
-          case style
+          effective_style = if style == :native
+                              Platform.windows? ? :crlf : :lf
+                            else
+                              style
+                            end
+          case effective_style
           when :lf then MSG_DETECTED if line =~ /\r$/
           else MSG_MISSING if line !~ /\r$/
           end

--- a/lib/rubocop/cop/style/end_of_line.rb
+++ b/lib/rubocop/cop/style/end_of_line.rb
@@ -5,7 +5,10 @@ module RuboCop
     module Style
       # This cop checks for Windows-style line endings in the source code.
       class EndOfLine < Cop
-        MSG = 'Carriage return character detected.'.freeze
+        include ConfigurableEnforcedStyle
+
+        MSG_DETECTED = 'Carriage return character detected.'.freeze
+        MSG_MISSING = 'Carriage return character missing.'.freeze
 
         def investigate(processed_source)
           last_token = processed_source.tokens.last
@@ -14,14 +17,28 @@ module RuboCop
 
           processed_source.raw_source.each_line.with_index do |line, index|
             break if index >= last_line
-            next unless line =~ /\r$/
+            msg = offense_message(line)
+            next unless msg
+            next if unimportant_missing_cr?(index, last_line, line)
 
             range =
               source_range(processed_source.buffer, index + 1, 0, line.length)
-            add_offense(nil, range, MSG)
+            add_offense(nil, range, msg)
             # Usually there will be carriage return characters on all or none
             # of the lines in a file, so we report only one offense.
             break
+          end
+        end
+
+        # If there is no LF on the last line, we don't care if there's no CR.
+        def unimportant_missing_cr?(index, last_line, line)
+          style == :crlf && index == last_line - 1 && line !~ /\n$/
+        end
+
+        def offense_message(line)
+          case style
+          when :lf then MSG_DETECTED if line =~ /\r$/
+          else MSG_MISSING if line !~ /\r$/
           end
         end
       end

--- a/lib/rubocop/platform.rb
+++ b/lib/rubocop/platform.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+module RuboCop
+  # This module provides information on the platform that RuboCop is being run
+  # on.
+  module Platform
+    module_function
+
+    def windows?
+      RUBY_PLATFORM =~ /cygwin|mswin|mingw|bccwin|wince|emx/
+    end
+  end
+end

--- a/manual/cops_style.md
+++ b/manual/cops_style.md
@@ -1244,6 +1244,10 @@ class Person
 end
 ```
 
+### References
+
+* [https://github.com/bbatsov/ruby-style-guide#separate-magic-comments-from-code](https://github.com/bbatsov/ruby-style-guide#separate-magic-comments-from-code)
+
 ## Style/EmptyLineBetweenDefs
 
 Enabled by default | Supports autocorrection
@@ -1540,6 +1544,14 @@ Enabled by default | Supports autocorrection
 Enabled | No
 
 This cop checks for Windows-style line endings in the source code.
+
+### Important attributes
+
+Attribute | Value
+--- | ---
+EnforcedStyle | native
+SupportedStyles | native, lf, crlf
+
 
 ### References
 

--- a/spec/rubocop/cli/cli_options_spec.rb
+++ b/spec/rubocop/cli/cli_options_spec.rb
@@ -1095,6 +1095,9 @@ describe RuboCop::CLI, :isolated_environment do
     it 'detects CR at end of line' do
       begin
         create_file('example.rb', "puts 'hello world'\r")
+        # Make Style/EndOfLine give same output regardless of platform.
+        create_file('.rubocop.yml', ['Style/EndOfLine:',
+                                     '  EnforcedStyle: lf'])
         File.open('example.rb') do |file|
           # We must use a File object to simulate the behavior of
           # STDIN, which is an IO object. StringIO won't do in this

--- a/spec/rubocop/cli_spec.rb
+++ b/spec/rubocop/cli_spec.rb
@@ -104,6 +104,9 @@ describe RuboCop::CLI, :isolated_environment do
     it 'reports an offense' do
       create_file('example.rb', ["x = 0\r",
                                  "puts x\r"])
+      # Make Style/EndOfLine give same output regardless of platform.
+      create_file('.rubocop.yml', ['Style/EndOfLine:',
+                                   '  EnforcedStyle: lf'])
       result = cli.run(['--format', 'simple', 'example.rb'])
       expect(result).to eq(1)
       expect($stdout.string)

--- a/spec/rubocop/cop/style/end_of_line_spec.rb
+++ b/spec/rubocop/cop/style/end_of_line_spec.rb
@@ -3,78 +3,152 @@
 
 require 'spec_helper'
 
-describe RuboCop::Cop::Style::EndOfLine do
-  subject(:cop) { described_class.new }
+describe RuboCop::Cop::Style::EndOfLine, :config do
+  subject(:cop) { described_class.new(config) }
 
-  it 'accepts an empty file' do
-    inspect_source_file(cop, '')
-    expect(cop.offenses).to be_empty
+  shared_examples 'all configurations' do
+    it 'accepts an empty file' do
+      inspect_source_file(cop, '')
+      expect(cop.offenses).to be_empty
+    end
   end
 
-  it 'registers an offense for CR+LF' do
-    inspect_source_file(cop, ['x=0', '', "y=1\r"])
-    expect(cop.messages).to eq(['Carriage return character detected.'])
-  end
-
-  it 'highlights the whole offending line' do
-    inspect_source_file(cop, ['x=0', '', "y=1\r"])
-    expect(cop.highlights).to eq(["y=1\r"])
-  end
-
-  it 'registers an offense for CR at end of file' do
-    inspect_source_file(cop, "x=0\r")
-    expect(cop.messages).to eq(['Carriage return character detected.'])
-  end
-
-  it 'does not register offenses after __END__' do
-    inspect_source(cop, ['x=0',
-                         '__END__',
-                         "x=0\r"])
-    expect(cop.offenses).to be_empty
-  end
-
-  shared_examples 'iso-8859-15' do
+  shared_examples 'iso-8859-15' do |eol|
     it 'can inspect non-UTF-8 encoded source with proper encoding comment' do
-      inspect_source_file(cop, ['# coding: ISO-8859-15\r',
-                                "# Euro symbol: \xa4\r"])
+      inspect_source_file(cop, ["# coding: ISO-8859-15#{eol}",
+                                "# Euro symbol: \xa4#{eol}"])
       expect(cop.offenses.size).to eq(1)
     end
   end
 
-  context 'when there are many lines ending with CR+LF' do
-    it 'registers only one offense' do
-      inspect_source_file(cop, ['x=0', '', 'y=1'].join("\r\n"))
-      expect(cop.messages.size).to eq(1)
+  context 'when EnforcedStyle is crlf' do
+    let(:cop_config) { { 'EnforcedStyle' => 'crlf' } }
+    let(:messages) { ['Carriage return character missing.'] }
+    include_examples 'all configurations'
+
+    it 'registers an offense for CR+LF' do
+      inspect_source_file(cop, ['x=0', '', "y=1\r"])
+      expect(cop.messages).to eq(messages)
+      expect(cop.offenses.map(&:line)).to eq([1])
     end
 
-    include_examples 'iso-8859-15'
-  end
-
-  context 'when the default external encoding is US_ASCII' do
-    around do |example|
-      orig_encoding = Encoding.default_external
-      Encoding.default_external = Encoding::US_ASCII
-      example.run
-      Encoding.default_external = orig_encoding
+    it 'highlights the whole offending line' do
+      inspect_source_file(cop, ['x=0', '', "y=1\r"])
+      expect(cop.highlights).to eq(["x=0\n"])
     end
 
-    it 'does not crash on UTF-8 encoded non-ascii characters' do
-      inspect_source_file(cop,
-                          ['# encoding: UTF-8',
-                           'class Epd::ReportsController < EpdAreaController',
-                           "  'terecht bij uw ROM-coördinator.'",
-                           'end'].join("\n"))
+    it 'does not register offense for no CR at end of file' do
+      inspect_source_file(cop, 'x=0')
       expect(cop.offenses).to be_empty
     end
 
-    include_examples 'iso-8859-15'
+    it 'does not register offenses after __END__' do
+      inspect_source(cop, ["x=0\r",
+                           '__END__',
+                           'x=0'])
+      expect(cop.offenses).to be_empty
+    end
+
+    context 'and there are many lines ending with LF' do
+      it 'registers only one offense' do
+        inspect_source_file(cop, ['x=0', '', 'y=1'].join("\n"))
+        expect(cop.messages.size).to eq(1)
+      end
+
+      include_examples 'iso-8859-15', ''
+    end
+
+    context 'and the default external encoding is US_ASCII' do
+      around do |example|
+        orig_encoding = Encoding.default_external
+        Encoding.default_external = Encoding::US_ASCII
+        example.run
+        Encoding.default_external = orig_encoding
+      end
+
+      it 'does not crash on UTF-8 encoded non-ascii characters' do
+        source = ['# encoding: UTF-8',
+                  'class Epd::ReportsController < EpdAreaController',
+                  "  'terecht bij uw ROM-coördinator.'",
+                  'end'].join("\r\n")
+        inspect_source_file(cop, source)
+        expect(cop.offenses).to be_empty
+      end
+
+      include_examples 'iso-8859-15', ''
+    end
+
+    context 'and source is a string' do
+      it 'registers an offense' do
+        inspect_source(cop, "x=0\ny=1")
+
+        expect(cop.messages).to eq(['Carriage return character missing.'])
+      end
+    end
   end
 
-  context 'when source is a string' do
-    it 'registers an offense' do
-      inspect_source(cop, "x=0\r")
+  context 'when EnforcedStyle is lf' do
+    let(:cop_config) { { 'EnforcedStyle' => 'lf' } }
+    include_examples 'all configurations'
 
+    it 'registers an offense for CR+LF' do
+      inspect_source_file(cop, ['x=0', '', "y=1\r"])
       expect(cop.messages).to eq(['Carriage return character detected.'])
+      expect(cop.offenses.map(&:line)).to eq([3])
+    end
+
+    it 'highlights the whole offending line' do
+      inspect_source_file(cop, ['x=0', '', "y=1\r"])
+      expect(cop.highlights).to eq(["y=1\r"])
+    end
+
+    it 'registers an offense for CR at end of file' do
+      inspect_source_file(cop, "x=0\r")
+      expect(cop.messages).to eq(['Carriage return character detected.'])
+    end
+
+    it 'does not register offenses after __END__' do
+      inspect_source(cop, ['x=0',
+                           '__END__',
+                           "x=0\r"])
+      expect(cop.offenses).to be_empty
+    end
+
+    context 'and there are many lines ending with CR+LF' do
+      it 'registers only one offense' do
+        inspect_source_file(cop, ['x=0', '', 'y=1'].join("\r\n"))
+        expect(cop.messages.size).to eq(1)
+      end
+
+      include_examples 'iso-8859-15', "\r"
+    end
+
+    context 'and the default external encoding is US_ASCII' do
+      around do |example|
+        orig_encoding = Encoding.default_external
+        Encoding.default_external = Encoding::US_ASCII
+        example.run
+        Encoding.default_external = orig_encoding
+      end
+
+      it 'does not crash on UTF-8 encoded non-ascii characters' do
+        source = ['# encoding: UTF-8',
+                  'class Epd::ReportsController < EpdAreaController',
+                  "  'terecht bij uw ROM-coördinator.'",
+                  'end'].join("\n")
+        inspect_source_file(cop, source)
+        expect(cop.offenses).to be_empty
+      end
+
+      include_examples 'iso-8859-15', "\r"
+    end
+
+    context 'and source is a string' do
+      it 'registers an offense' do
+        inspect_source(cop, "x=0\r")
+
+        expect(cop.messages).to eq(['Carriage return character detected.'])
+      end
     end
   end
 end

--- a/spec/rubocop/cop/style/end_of_line_spec.rb
+++ b/spec/rubocop/cop/style/end_of_line_spec.rb
@@ -21,6 +21,21 @@ describe RuboCop::Cop::Style::EndOfLine, :config do
     end
   end
 
+  context 'when EnforcedStyle is native' do
+    let(:cop_config) { { 'EnforcedStyle' => 'native' } }
+    let(:messages) do
+      ['Carriage return character ' \
+        "#{RuboCop::Platform.windows? ? 'missing' : 'detected'}."]
+    end
+
+    it 'registers an offense for an incorrect EOL' do
+      inspect_source_file(cop, ['x=0', '', "y=1\r"])
+      expect(cop.messages).to eq(messages)
+      expect(cop.offenses.map(&:line))
+        .to eq([RuboCop::Platform.windows? ? 1 : 3])
+    end
+  end
+
   context 'when EnforcedStyle is crlf' do
     let(:cop_config) { { 'EnforcedStyle' => 'crlf' } }
     let(:messages) { ['Carriage return character missing.'] }

--- a/spec/rubocop/formatter/html_formatter_spec.rb
+++ b/spec/rubocop/formatter/html_formatter_spec.rb
@@ -18,13 +18,19 @@ module RuboCop
 
       let(:actual_html_path) do
         path = File.expand_path('result.html')
-        CLI.new.run(['--format', 'html', '--out', path])
+        # Run without Style/EndOfLine as it gives different results on
+        # different platforms.
+        CLI.new.run(['--except', 'Style/EndOfLine', '--format', 'html',
+                     '--out', path])
         path
       end
 
       let(:actual_html_path_cached) do
         path = File.expand_path('result_cached.html')
-        2.times { CLI.new.run(['--format', 'html', '--out', path]) }
+        2.times do
+          CLI.new.run(['--except', 'Style/EndOfLine', '--format', 'html',
+                       '--out', path])
+        end
         path
       end
 

--- a/spec/rubocop/result_cache_spec.rb
+++ b/spec/rubocop/result_cache_spec.rb
@@ -67,7 +67,7 @@ describe RuboCop::ResultCache, :isolated_environment do
         before do
           # Avoid getting "symlink() function is unimplemented on this
           # machine" on Windows.
-          if RUBY_PLATFORM =~ /cygwin|mswin|mingw|bccwin|wince|emx/
+          if RuboCop::Platform.windows?
             skip 'Symlinks not implemented on Windows'
           end
 

--- a/spec/rubocop/runner_spec.rb
+++ b/spec/rubocop/runner_spec.rb
@@ -82,6 +82,12 @@ describe RuboCop::Runner, :isolated_environment do
     end
 
     context 'if -s/--stdin is used with an offense' do
+      before do
+        # Make Style/EndOfLine give same output regardless of platform.
+        create_file('.rubocop.yml', ['Style/EndOfLine:',
+                                     '  EnforcedStyle: lf'])
+      end
+
       let(:options) do
         {
           formatters: [['progress', formatter_output_path]],


### PR DESCRIPTION
Tested on Windows and Linux. Enforcing different styles on different platforms through the `native` style makes the most sense, as discussed in #3800.