### PR TITLE
[Fix #3242] Ignore cache files disappearing during cleanup even more

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@
 * [#2643](https://github.com/bbatsov/rubocop/issues/2643): Allow uppercase and dashes in `MagicComment`. ([@mikegee][])
 * [#3959](https://github.com/bbatsov/rubocop/issues/3959): Don't wrap "percent arrays" with extra brackets when autocorrecting `Style/MutableConstant`. ([@mikegee][])
 * [#3978](https://github.com/bbatsov/rubocop/pull/3978): Fix false positive in `Performance/RegexpMatch` with `English` module. ([@pocke][])
+* [#3242](https://github.com/bbatsov/rubocop/issues/3242): Ignore `Errno::ENOENT` during cache cleanup from `File.mtime` too. ([@mikegee][])
 
 ## 0.47.1 (2017-01-18)
 

--- a/lib/rubocop/result_cache.rb
+++ b/lib/rubocop/result_cache.rb
@@ -44,20 +44,20 @@ module RuboCop
           puts "Removing the #{remove_count} oldest files from #{cache_root}"
         end
         sorted = files.sort_by { |path| File.mtime(path) }
-        remove_files(sorted, dirs, remove_count, verbose)
+        remove_files(sorted, dirs, remove_count)
+      rescue Errno::ENOENT
+        # This can happen if parallel RuboCop invocations try to remove the
+        # same files. No problem.
+        puts $ERROR_INFO if verbose
       end
 
-      def remove_files(files, dirs, remove_count, verbose)
+      def remove_files(files, dirs, remove_count)
         # Batch file deletions, deleting over 130,000+ files will crash
         # File.delete.
         files[0, remove_count].each_slice(10_000).each do |files_slice|
           File.delete(*files_slice)
         end
         dirs.each { |dir| Dir.rmdir(dir) if Dir["#{dir}/*"].empty? }
-      rescue Errno::ENOENT
-        # This can happen if parallel RuboCop invocations try to remove the
-        # same files. No problem.
-        puts $ERROR_INFO if verbose
       end
     end
 


### PR DESCRIPTION
We already ignore `Errno::ENOENT` during cache cleanup, but `File.mtime` might raise too.

fixes #3242 

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Used the same coding conventions as the rest of the project.
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [ ] Added tests.
* [x] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] All tests are passing.
* [x] The new code doesn't generate RuboCop offenses.
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Updated cop documentation with `rake generate_cops_documentation` (required only when you've added a new cop or changed the configuration/documentation of an existing cop).

[1]: http://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html
