### PR TITLE
Fix false positive in `Performance/RegexpMatch` with `English` module

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@
 * [#3855](https://github.com/bbatsov/rubocop/issues/3855): Make `Lint/NonLocalExitFromIterator` aware of method definitions. ([@drenmi][])
 * [#2643](https://github.com/bbatsov/rubocop/issues/2643): Allow uppercase and dashes in `MagicComment`. ([@mikegee][])
 * [#3959](https://github.com/bbatsov/rubocop/issues/3959): Don't wrap "percent arrays" with extra brackets when autocorrecting `Style/MutableConstant`. ([@mikegee][])
+* [#3978](https://github.com/bbatsov/rubocop/pull/3978): Fix false positive in `Performance/RegexpMatch` with `English` module. ([@pocke][])
 
 ## 0.47.1 (2017-01-18)
 

--- a/lib/rubocop/cop/performance/regexp_match.rb
+++ b/lib/rubocop/cop/performance/regexp_match.rb
@@ -102,7 +102,7 @@ module RuboCop
             (send (const nil :Regexp) :last_match)
             (send (const nil :Regexp) :last_match _)
             ({back_ref nth_ref} _)
-            (gvar #dollar_tilde)
+            (gvar #match_gvar?)
           }
         PATTERN
 
@@ -190,8 +190,15 @@ module RuboCop
           end
         end
 
-        def dollar_tilde(sym)
-          sym == :$~
+        def match_gvar?(sym)
+          %i(
+            $~
+            $MATCH
+            $PREMATCH
+            $POSTMATCH
+            $LAST_PAREN_MATCH
+            $LAST_MATCH_INFO
+          ).include?(sym)
         end
 
         def correct_operator(corrector, recv, arg)

--- a/spec/rubocop/cop/performance/regexp_match_spec.rb
+++ b/spec/rubocop/cop/performance/regexp_match_spec.rb
@@ -96,6 +96,7 @@ describe RuboCop::Cop::Performance::RegexpMatch, :config do
 
     %w(
       $& $' $` $~ $1 $2 $100
+      $MATCH
       Regexp.last_match Regexp.last_match(1)
     ).each do |var|
       include_examples :accepts, "#{name} in method with `#{var}`", <<-END


### PR DESCRIPTION
https://docs.ruby-lang.org/en/2.4.0/English.html

`English` module defines several aliases for global variables.
The change fixes false positive about the aliases.



-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Used the same coding conventions as the rest of the project.
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] All tests are passing.
* [x] The new code doesn't generate RuboCop offenses.
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Updated cop documentation with `rake generate_cops_documentation` (required only when you've added a new cop or changed the configuration/documentation of an existing cop).

[1]: http://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html
