### PR TITLE
SPEC: Fix documentation example for ABC Size

### DIFF
--- a/spec/rubocop/cop/metrics/abc_size_spec.rb
+++ b/spec/rubocop/cop/metrics/abc_size_spec.rb
@@ -57,7 +57,7 @@ describe RuboCop::Cop::Metrics::AbcSize, :config do
                       'end'])
       expect(cop.messages)
         .to eq(['Assignment Branch Condition size for method_name is too ' \
-                'high. [6.4/0]']) # sqrt(1*1 + 5*5 + 2*2) => 6.4
+                'high. [6.4/0]']) # sqrt(1*1 + 6*6 + 2*2) => 6.4
     end
 
     context 'target_ruby_version >= 2.3', :ruby23 do


### PR DESCRIPTION
The given code example has an ABC size of 6.4, but comments list the
calculation as:

Math.sqrt(1*1 + 5*5 + 2*2)

which results in: 5.48.

The correct calculation for the given the example are:

Math.sqrt(1*1 + 6*6 + 2*2) = 6.40

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Used the same coding conventions as the rest of the project.
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [ ] Added tests.
* [ ] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] All tests are passing.
* [x] The new code doesn't generate RuboCop offenses.
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [ ] Updated cop documentation with `rake generate_cops_documentation` (required only when you've added a new cop or changed the configuration/documentation of an existing cop).

[1]: http://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html
