### PR TITLE
Fix range docstrings in EachForSimpleLoop spec

### DIFF
--- a/spec/rubocop/cop/style/each_for_simple_loop_spec.rb
+++ b/spec/rubocop/cop/style/each_for_simple_loop_spec.rb
@@ -8,21 +8,21 @@ describe RuboCop::Cop::Style::EachForSimpleLoop do
   OFFENSE_MSG = 'Use `Integer#times` for a simple loop ' \
                 'which iterates a fixed number of times.'.freeze
 
-  it 'registers offense for exclusive end range' do
+  it 'registers offense for inclusive end range' do
     inspect_source(cop, '(0..10).each {}')
     expect(cop.offenses.size).to eq 1
     expect(cop.messages).to eq([OFFENSE_MSG])
     expect(cop.highlights).to eq(['(0..10).each'])
   end
 
-  it 'registers offense for inclusive end range' do
+  it 'registers offense for exclusive end range' do
     inspect_source(cop, '(0...10).each {}')
     expect(cop.offenses.size).to eq 1
     expect(cop.messages).to eq([OFFENSE_MSG])
     expect(cop.highlights).to eq(['(0...10).each'])
   end
 
-  it 'registers offense for inclusive end range with do ... end syntax' do
+  it 'registers offense for exclusive end range with do ... end syntax' do
     inspect_source(cop, ['(0...10).each do',
                          'end'])
     expect(cop.offenses.size).to eq 1


### PR DESCRIPTION
I happened to notice the EachForSimpleLoop spec incorrectly called inclusive ranges exclusive and exclusive ranges inclusive.

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Used the same coding conventions as the rest of the project.
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [ ] Added tests.
* [ ] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] All tests are passing.
* [x] The new code doesn't generate RuboCop offenses.
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [ ] Updated cop documentation with `rake generate_cops_documentation` (required only when you've added a new cop or changed the configuration/documentation of an existing cop).

[1]: http://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html
