### PR TITLE
Fix false positive in `Style/MixinGrouping` when not using Module methods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@
 * [#3242](https://github.com/bbatsov/rubocop/issues/3242): Ignore `Errno::ENOENT` during cache cleanup from `File.mtime` too. ([@mikegee][])
 * [#3958](https://github.com/bbatsov/rubocop/issues/3958): `Style/SpaceInsideHashLiteralBraces` doesn't add and offence when checking an hash where a value is a left brace string (e.g. { k: '{' }). ([@nodo][])
 * [#4006](https://github.com/bbatsov/rubocop/issues/4006): Prevent `Style/WhileUntilModifier` from breaking on a multiline modifier. ([@drenmi][])
+* [#3990](https://github.com/bbatsov/rubocop/pull/3990): Fix false positive in `Style/MixinGrouping` when not using Module methods. ([@meganemura][])
 
 ## 0.47.1 (2017-01-18)
 

--- a/spec/rubocop/cop/style/mixin_grouping_spec.rb
+++ b/spec/rubocop/cop/style/mixin_grouping_spec.rb
@@ -120,6 +120,22 @@ describe RuboCop::Cop::Style::MixinGrouping, :config do
                          'end'].join("\n")
       end
     end
+
+    context 'with module class' do
+      it_behaves_like 'code without offense',
+                      ['module Foo',
+                       '  include Bar',
+                       '  prepend Baz',
+                       '  extend Baz',
+                       'end'].join("\n")
+    end
+
+    context 'when not using Module methods' do
+      it_behaves_like 'code without offense',
+                      ['RSpec.configure do |config|',
+                       '  config.include MyHelpers, type: :controller',
+                       'end'].join("\n")
+    end
   end
 
   context 'when configured with grouped style' do
@@ -205,6 +221,24 @@ describe RuboCop::Cop::Style::MixinGrouping, :config do
                          '  include Bar',
                          '  prepend Baz',
                          '  extend Baz',
+                         'end'].join("\n")
+      end
+    end
+
+    context 'when not using Module methods' do
+      context 'when using a instance method named `include`' do
+        it_behaves_like 'code without offense',
+                        ['RSpec.configure do |config|',
+                         '  config.include Foo',
+                         '  config.include Bar',
+                         'end'].join("\n")
+      end
+
+      context 'when using a method with literal node arguments' do
+        it_behaves_like 'code without offense',
+                        ['RSpec.configure do |config|',
+                         '  config.include Foo: :bar',
+                         '  config.include Foo',
                          'end'].join("\n")
       end
     end


### PR DESCRIPTION
`include` and `extend` are defined in some classses other than Module.

example:
```
RSpec.configure do |config|
  config.include Devise::TestHelpers, type: :controller
end
```
The cop detects this as an offence for "grouped style".

This PR makes the cop to check whether the mixin methods are called in the module/class or not.

~~So, how about making the scope narrow to allow these sort of codes.~~
~~This commit includes 2 guards.~~
1. ~~Treat as mixin methods when the node's receiver is nil type~~
2. ~~Not treat as mixin methods when the arguments contain literal type nodes~~

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Used the same coding conventions as the rest of the project.
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] All tests are passing.
* [x] The new code doesn't generate RuboCop offenses.
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [ ] Updated cop documentation with `rake generate_cops_documentation` (required only when you've added a new cop or changed the configuration/documentation of an existing cop).

[1]: http://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html
