### PR TITLE
[Fix #3937] Add new Rails/StartEndWith cop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@
 * Add new `Style/InverseMethods` cop. ([@rrosenblum][])
 * [#4038](https://github.com/bbatsov/rubocop/pull/4038): Allow `default` key in the `Style/PercentLiteralDelimiters` cop config to set all preferred delimiters. ([@kddeisz][])
 * Add `IgnoreMacros` option to `Style/MethodCallWithArgsParentheses`. ([@drenmi][])
+* [#3937](https://github.com/bbatsov/rubocop/issues/3937): Add new `Rails/ActiveSupportAliases` cop. ([@tdeo][])
 
 ### Changes
 

--- a/config/enabled.yml
+++ b/config/enabled.yml
@@ -1503,6 +1503,13 @@ Rails/ActionFilter:
   Description: 'Enforces consistent use of action filter methods.'
   Enabled: true
 
+Rails/ActiveSupportAliases:
+  Description: >-
+                  Avoid ActiveSupport aliases of standard ruby methods:
+                  `String#starts_with?`, `String#ends_with?`,
+                  `Array#append`, `Array#prepend`.
+  Enabled: true
+
 Rails/Date:
   Description: >-
                   Checks the correct usage of date aware methods,

--- a/lib/rubocop.rb
+++ b/lib/rubocop.rb
@@ -429,6 +429,7 @@ require 'rubocop/cop/style/word_array'
 require 'rubocop/cop/style/zero_length_predicate'
 
 require 'rubocop/cop/rails/action_filter'
+require 'rubocop/cop/rails/active_support_aliases'
 require 'rubocop/cop/rails/date'
 require 'rubocop/cop/rails/dynamic_find_by'
 require 'rubocop/cop/rails/delegate'

--- a/lib/rubocop/cop/rails/active_support_aliases.rb
+++ b/lib/rubocop/cop/rails/active_support_aliases.rb
@@ -1,0 +1,68 @@
+# frozen_string_literal: true
+
+module RuboCop
+  module Cop
+    module Rails
+      # This cop checks that ActiveSupport aliases to core ruby methods
+      # are not used.
+      #
+      # @example
+      #   # good
+      #   'some_string'.start_with?('prefix')
+      #   'some_string'.end_with?('suffix')
+      #   [1, 2, 'a'] << 'b'
+      #   [1, 2, 'a'].unshift('b')
+      #
+      #   # bad
+      #   'some_string'.starts_with?('prefix')
+      #   'some_string'.ends_with?('suffix')
+      #   [1, 2, 'a'].append('b')
+      #   [1, 2, 'a'].prepend('b')
+      #
+      class ActiveSupportAliases < Cop
+        MSG = 'Use `%s` instead of `%s`.'.freeze
+
+        ALIASES = {
+          starts_with?: {
+            original: :start_with?, matcher: '(send str :starts_with? _)'
+          },
+          ends_with?: {
+            original: :end_with?, matcher: '(send str :ends_with? _)'
+          },
+          append: { original: :<<, matcher: '(send array :append _)' },
+          prepend: { original: :unshift, matcher: '(send array :prepend _)' }
+        }.freeze
+
+        ALIASES.each do |aliased_method, options|
+          def_node_matcher aliased_method, options[:matcher]
+        end
+
+        def on_send(node)
+          ALIASES.keys.each do |aliased_method|
+            register_offense(node, aliased_method) if
+              public_send(aliased_method, node)
+          end
+        end
+
+        private
+
+        def autocorrect(node)
+          return false if append(node)
+          lambda do |corrector|
+            method_name = node.loc.selector.source
+            replacement = ALIASES[method_name.to_sym][:original]
+            corrector.replace(node.loc.selector, replacement.to_s)
+          end
+        end
+
+        def register_offense(node, method_name)
+          add_offense(
+            node,
+            :expression,
+            format(MSG, ALIASES[method_name][:original], method_name)
+          )
+        end
+      end
+    end
+  end
+end

--- a/manual/cops.md
+++ b/manual/cops.md
@@ -175,6 +175,7 @@ In the following section you find all available cops:
 #### Department [Rails](cops_rails.md)
 
 * [Rails/ActionFilter](cops_rails.md#railsactionfilter)
+* [Rails/ActiveSupportAliases](cops_rails.md#railsactivesupportaliases)
 * [Rails/Date](cops_rails.md#railsdate)
 * [Rails/Delegate](cops_rails.md#railsdelegate)
 * [Rails/DelegateAllowBlank](cops_rails.md#railsdelegateallowblank)

--- a/manual/cops_rails.md
+++ b/manual/cops_rails.md
@@ -19,6 +19,31 @@ EnforcedStyle | action
 SupportedStyles | action, filter
 Include | app/controllers/\*\*/\*.rb
 
+## Rails/ActiveSupportAliases
+
+Enabled by default | Supports autocorrection
+--- | ---
+Enabled | Yes
+
+This cop checks that ActiveSupport aliases to core ruby methods
+are not used.
+
+### Example
+
+```ruby
+# good
+'some_string'.start_with?('prefix')
+'some_string'.end_with?('suffix')
+[1, 2, 'a'] << 'b'
+[1, 2, 'a'].unshift('b')
+
+# bad
+'some_string'.starts_with?('prefix')
+'some_string'.ends_with?('suffix')
+[1, 2, 'a'].append('b')
+[1, 2, 'a'].prepend('b')
+```
+
 ## Rails/Date
 
 Enabled by default | Supports autocorrection

--- a/spec/rubocop/cop/rails/active_support_aliases_spec.rb
+++ b/spec/rubocop/cop/rails/active_support_aliases_spec.rb
@@ -1,0 +1,102 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+describe RuboCop::Cop::Rails::ActiveSupportAliases do
+  subject(:cop) { described_class.new }
+
+  describe 'String' do
+    describe '#starts_with?' do
+      it 'is registered as an offence' do
+        inspect_source(cop, "'some_string'.starts_with?('prefix')")
+        expect(cop.offenses.size).to eq(1)
+        expect(cop.messages)
+          .to eq(['Use `start_with?` instead of `starts_with?`.'])
+      end
+
+      it 'is autocorrected' do
+        new_source = autocorrect_source(
+          cop, "'some_string'.starts_with?('prefix')"
+        )
+        expect(new_source).to eq "'some_string'.start_with?('prefix')"
+      end
+    end
+
+    describe '#start_with?' do
+      it 'is not registered as an offense' do
+        inspect_source(cop, "'some_string'.start_with?('prefix')")
+        expect(cop.offenses.size).to eq(0)
+      end
+    end
+
+    describe '#ends_with?' do
+      it 'it is registered as an offense' do
+        inspect_source(cop, "'some_string'.ends_with?('prefix')")
+        expect(cop.offenses.size).to eq(1)
+        expect(cop.messages)
+          .to eq(['Use `end_with?` instead of `ends_with?`.'])
+      end
+
+      it 'is autocorrected' do
+        new_source = autocorrect_source(
+          cop, "'some_string'.ends_with?('prefix')"
+        )
+        expect(new_source).to eq "'some_string'.end_with?('prefix')"
+      end
+    end
+
+    describe '#end_with?' do
+      it 'is not registered as an offense' do
+        inspect_source(cop, "'some_string'.end_with?('prefix')")
+        expect(cop.offenses.size).to eq(0)
+      end
+    end
+  end
+
+  describe 'Array' do
+    describe '#append' do
+      it 'is registered as an offence' do
+        inspect_source(cop, "[1, 'a', 3].append('element')")
+        expect(cop.offenses.size).to eq(1)
+        expect(cop.messages)
+          .to eq(['Use `<<` instead of `append`.'])
+      end
+
+      it 'is not autocorrected' do
+        source = "[1, 'a', 3].append('element')"
+        new_source = autocorrect_source(cop, source)
+        expect(new_source).to eq source
+      end
+    end
+
+    describe '#<<' do
+      it 'is not registered as an offense' do
+        inspect_source(cop, "[1, 'a', 3] << 'element'")
+        expect(cop.offenses.size).to eq(0)
+      end
+    end
+
+    describe '#prepend' do
+      it 'is registered as an offence' do
+        inspect_source(cop, "[1, 'a', 3].prepend('element')")
+        expect(cop.offenses.size).to eq(1)
+        expect(cop.messages)
+          .to eq(['Use `unshift` instead of `prepend`.'])
+      end
+
+      it 'is autocorrected' do
+        new_source = autocorrect_source(
+          cop, "[1, 'a', 3].prepend('element')"
+        )
+        expect(new_source).to eq "[1, 'a', 3].unshift('element')"
+      end
+    end
+
+    describe '#unshift' do
+      it 'is not registered as an offense' do
+        inspect_source(cop, "[1, 'a', 3].unshift('element')")
+        expect(cop.offenses.size).to eq(0)
+      end
+    end
+  end
+end


### PR DESCRIPTION
This cop checks for consistent use of `starts_with?` and `ends_with?` string
methods or consistent use of `start_with?` and `end_with?`

No option to mix consistent use of `starts_with?` and `end_with?` or the opposite.

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Used the same coding conventions as the rest of the project.
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [ ] All tests are passing.
* [ ] The new code doesn't generate RuboCop offenses.
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Updated cop documentation with `rake generate_cops_documentation` (required only when you've added a new cop or changed the configuration/documentation of an existing cop).

[1]: http://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html
