### PR TITLE
Make to do not override existing files in `new_cop` task

### DIFF
--- a/tasks/new_cop.rake
+++ b/tasks/new_cop.rake
@@ -66,6 +66,7 @@ end
   END
 
   cop_path = "lib/rubocop/cop/#{to_snake(badge.to_s)}.rb"
+  raise "#{cop_path} already exists!" if File.exist?(cop_path)
   File.write(cop_path, cop_code)
 
   spec_code = <<-END
@@ -95,6 +96,7 @@ end
   END
 
   spec_path = "spec/rubocop/cop/#{to_snake(cop_name)}_spec.rb"
+  raise "#{spec_path} already exists!" if File.exist?(spec_path)
   File.write(spec_path, spec_code)
 
   puts <<-END


### PR DESCRIPTION
I've made mistakes that overrides existing files by the task many times.
The change prevents the mistake.


-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Used the same coding conventions as the rest of the project.
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [ ] Added tests.
* [ ] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] All tests are passing.
* [x] The new code doesn't generate RuboCop offenses.
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Updated cop documentation with `rake generate_cops_documentation` (required only when you've added a new cop or changed the configuration/documentation of an existing cop).

[1]: http://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html
