### PR TITLE
Add a link to reference for `MisinGrouping` cop in the documentation

### DIFF
--- a/manual/cops_style.md
+++ b/manual/cops_style.md
@@ -2813,6 +2813,10 @@ EnforcedStyle | separated
 SupportedStyles | separated, grouped
 
 
+### References
+
+* [https://github.com/bbatsov/ruby-style-guide#mixin-grouping](https://github.com/bbatsov/ruby-style-guide#mixin-grouping)
+
 ## Style/ModuleFunction
 
 Enabled by default | Supports autocorrection


### PR DESCRIPTION
Ref

- https://github.com/bbatsov/rubocop/pull/3982
- https://github.com/bbatsov/rubocop/pull/3941


