### PR TITLE
[Fix #3979] Excluded non-ruby files from files explicitly passed in arguments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@
 
 ### Changes
 
+* [#4007](https://github.com/bbatsov/rubocop/pull/4007): Include all ruby files by default and exclude non-ruby files. ([@dorian][])
 * [#4012](https://github.com/bbatsov/rubocop/pull/4012): Mark `foo[:bar]` as not complex in `Style/TernaryParentheses` cop with `require_parentheses_when_complex` style. ([@onk][])
 * [#3915](https://github.com/bbatsov/rubocop/issues/3915): Make configurable whitelist for `Lint/SafeNavigationChain` cop. ([@pocke][])
 * [#3944](https://github.com/bbatsov/rubocop/issues/3944): Allow keyword arguments in `Style/RaiseArgs` cop. ([@mikegee][])
@@ -2641,3 +2642,4 @@
 [@onk]: https://github.com/onk
 [@dabroz]: https://github.com/dabroz
 [@buenaventure]: https://github.com/buenaventure
+[@dorian]: https://github.com/dorian

--- a/spec/rubocop/cli_spec.rb
+++ b/spec/rubocop/cli_spec.rb
@@ -920,10 +920,10 @@ describe RuboCop::CLI, :isolated_environment do
     end
 
     it 'does not consider Include parameters in subdirectories' do
-      create_file('dir/example.ruby', 'x=0')
+      create_file('dir/example.ruby3', 'x=0')
       create_file('dir/.rubocop.yml', ['AllCops:',
                                        '  Include:',
-                                       '    - "*.ruby"'])
+                                       '    - "*.ruby3"'])
       expect(cli.run(%w(--format simple))).to eq(0)
       expect($stderr.string).to eq('')
       expect($stdout.string)


### PR DESCRIPTION
Exclude ruby files from files paths passed directly. Makes the behavior between `rubocop` and `rubocop [FILES...]` consistent. (e.g. doesn't try to find offenses in `.md` files).

The source issue is #3979.

-----------------

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Used the same coding conventions as the rest of the project.
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [ ] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] All tests are passing.
* [x] The new code doesn't generate RuboCop offenses.
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [ ] Updated cop documentation with `rake generate_cops_documentation` (required only when you've added a new cop or changed the configuration/documentation of an existing cop).

[1]: http://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html