### PR TITLE
Improve Style/FrozenStringLiteralComment message

### DIFF
--- a/lib/rubocop/cop/style/frozen_string_literal_comment.rb
+++ b/lib/rubocop/cop/style/frozen_string_literal_comment.rb
@@ -12,7 +12,7 @@ module RuboCop
         include ConfigurableEnforcedStyle
         include FrozenStringLiteral
 
-        MSG = 'Missing frozen string literal comment.'.freeze
+        MSG = 'Missing magic comment `# frozen_string_literal: true`.'.freeze
         MSG_UNNECESSARY = 'Unnecessary frozen string literal comment.'.freeze
         SHEBANG = '#!'.freeze
 

--- a/spec/rubocop/cop/style/frozen_string_literal_comment_spec.rb
+++ b/spec/rubocop/cop/style/frozen_string_literal_comment_spec.rb
@@ -41,7 +41,8 @@ describe RuboCop::Cop::Style::FrozenStringLiteralComment, :config do
        'on the top line' do
       inspect_source(cop, 'puts 1')
 
-      expect(cop.messages).to eq(['Missing frozen string literal comment.'])
+      expect(cop.messages)
+        .to eq(['Missing magic comment `# frozen_string_literal: true`.'])
     end
 
     it 'registers an offense for not having a frozen string literal comment ' \
@@ -49,7 +50,8 @@ describe RuboCop::Cop::Style::FrozenStringLiteralComment, :config do
       inspect_source(cop, ['#!/usr/bin/env ruby',
                            'puts 1'])
 
-      expect(cop.messages).to eq(['Missing frozen string literal comment.'])
+      expect(cop.messages)
+        .to eq(['Missing magic comment `# frozen_string_literal: true`.'])
     end
 
     it 'accepts a frozen string literal below a shebang comment' do
@@ -73,7 +75,8 @@ describe RuboCop::Cop::Style::FrozenStringLiteralComment, :config do
       inspect_source(cop, ['# encoding: utf-8',
                            'puts 1'])
 
-      expect(cop.messages).to eq(['Missing frozen string literal comment.'])
+      expect(cop.messages)
+        .to eq(['Missing magic comment `# frozen_string_literal: true`.'])
     end
 
     it 'accepts a frozen string literal below an encoding comment' do
@@ -98,7 +101,8 @@ describe RuboCop::Cop::Style::FrozenStringLiteralComment, :config do
                            '# encoding: utf-8',
                            'puts 1'])
 
-      expect(cop.messages).to eq(['Missing frozen string literal comment.'])
+      expect(cop.messages)
+        .to eq(['Missing magic comment `# frozen_string_literal: true`.'])
     end
 
     it 'accepts a frozen string literal comment below shebang and encoding ' \
@@ -326,28 +330,28 @@ describe RuboCop::Cop::Style::FrozenStringLiteralComment, :config do
           inspect_source(cop, '"x".freeze')
 
           expect(cop.messages)
-            .to eq(['Missing frozen string literal comment.'])
+            .to eq(['Missing magic comment `# frozen_string_literal: true`.'])
         end
 
         it 'accepts calling << on a string' do
           inspect_source(cop, '"x" << "y"')
 
           expect(cop.messages)
-            .to eq(['Missing frozen string literal comment.'])
+            .to eq(['Missing magic comment `# frozen_string_literal: true`.'])
         end
 
         it 'accepts freezing a string with interpolation' do
           inspect_source(cop, '"#{foo}bar".freeze')
 
           expect(cop.messages)
-            .to eq(['Missing frozen string literal comment.'])
+            .to eq(['Missing magic comment `# frozen_string_literal: true`.'])
         end
 
         it 'accepts calling << on a string with interpolation' do
           inspect_source(cop, '"#{foo}bar" << "baz"')
 
           expect(cop.messages)
-            .to eq(['Missing frozen string literal comment.'])
+            .to eq(['Missing magic comment `# frozen_string_literal: true`.'])
         end
       end
     end


### PR DESCRIPTION
We've had a bunch of developers confused by the previous message; I think this one is more clear.

Specifically, unless the user knows about this specific cop being enabled, the annotation "Missing frozen string literal comment" on a line like `require 'test_helper'` doesn't really educate them on how to proceed.

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists). *(N/A)*
* [x] Used the same coding conventions as the rest of the project.
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests. *(N/A)*
* [x] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).  *(N/A)*
* [x] All tests are passing.
* [x] The new code doesn't generate RuboCop offenses.
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Updated cop documentation with `rake generate_cops_documentation` (required only when you've added a new cop or changed the configuration/documentation of an existing cop). *(N/A)*

[1]: http://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html
