### PR TITLE
Skip Rails/SkipsModelValidations for methods that don't accept arguments.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@
 
 ### Bug fixes
 
+* [#4007](https://github.com/bbatsov/rubocop/pull/4007): Skip `Rails/SkipsModelValidations` for methods that don't accept arguments. ([@dorian][])
 * [#3923](https://github.com/bbatsov/rubocop/issues/3923): Allow asciibetical sorting in `Bundler/OrderedGems`. ([@mikegee][])
 * [#3855](https://github.com/bbatsov/rubocop/issues/3855): Make `Lint/NonLocalExitFromIterator` aware of method definitions. ([@drenmi][])
 * [#2643](https://github.com/bbatsov/rubocop/issues/2643): Allow uppercase and dashes in `MagicComment`. ([@mikegee][])
@@ -2641,3 +2642,4 @@
 [@onk]: https://github.com/onk
 [@dabroz]: https://github.com/dabroz
 [@buenaventure]: https://github.com/buenaventure
+[@dorian]: https://github.com/dorian

--- a/lib/rubocop/cop/rails/skips_model_validations.rb
+++ b/lib/rubocop/cop/rails/skips_model_validations.rb
@@ -25,8 +25,25 @@ module RuboCop
       class SkipsModelValidations < Cop
         MSG = 'Avoid using `%s` because it skips validations.'.freeze
 
+        METHODS_WITH_ARGUMENTS = %w(decrement!
+                                    decrement_counter
+                                    increment!
+                                    increment_counter
+                                    toggle!
+                                    update_all
+                                    update_attribute
+                                    update_column
+                                    update_columns
+                                    update_counters).freeze
+
         def on_send(node)
           return unless blacklist.include?(node.method_name.to_s)
+
+          _receiver, method_name, *args = *node
+
+          if METHODS_WITH_ARGUMENTS.include?(method_name.to_s) && args.empty?
+            return
+          end
 
           add_offense(node, :selector)
         end

--- a/spec/rubocop/cop/rails/skips_model_validations_spec.rb
+++ b/spec/rubocop/cop/rails/skips_model_validations_spec.rb
@@ -21,8 +21,30 @@ describe RuboCop::Cop::Rails::SkipsModelValidations, :config do
   let(:msg) { 'Avoid using `%s` because it skips validations.' }
   let(:cop_config) { cop_config }
 
+  methods_with_arguments = described_class::METHODS_WITH_ARGUMENTS
+
   context 'with default blacklist' do
     cop_config['Blacklist'].each do |method_name|
+      it "registers an offense for `#{method_name}`" do
+        inspect_source(cop, "User.#{method_name}(:attr)")
+        expect(cop.offenses.size).to eq(1)
+        expect(cop.messages)
+          .to eq([format(msg, method_name)])
+      end
+    end
+  end
+
+  context 'with methods that require at least an argument' do
+    methods_with_arguments.each do |method_name|
+      it "doesn't register an offense for `#{method_name}`" do
+        inspect_source(cop, "User.#{method_name}")
+        expect(cop.offenses).to be_empty
+      end
+    end
+  end
+
+  context "with methods that don't require an argument" do
+    (cop_config['Blacklist'] - methods_with_arguments).each do |method_name|
       it "registers an offense for `#{method_name}`" do
         inspect_source(cop, "User.#{method_name}")
         expect(cop.offenses.size).to eq(1)


### PR DESCRIPTION
So, I have methods in my codebase with the same name as some blacklisted methods (e.g. `update_all`) but in my case they don't receive arguments so they can be easily ignored and not appear as false positive (or make me need to rename them).

```ruby
class Things
  def self.update_all
    puts "Update all the things"
  end
end

Things.update_all
```

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Used the same coding conventions as the rest of the project.
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] All tests are passing.
* [x] The new code doesn't generate RuboCop offenses.
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* Updated cop documentation with `rake generate_cops_documentation` (required only when you've added a new cop or changed the configuration/documentation of an existing cop).

[1]: http://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html
