### PR TITLE
[Fix #4006] Prevent `Style/WhileUntilModifier` from breaking on multiline modifier

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@
 * [#3959](https://github.com/bbatsov/rubocop/issues/3959): Don't wrap "percent arrays" with extra brackets when autocorrecting `Style/MutableConstant`. ([@mikegee][])
 * [#3978](https://github.com/bbatsov/rubocop/pull/3978): Fix false positive in `Performance/RegexpMatch` with `English` module. ([@pocke][])
 * [#3242](https://github.com/bbatsov/rubocop/issues/3242): Ignore `Errno::ENOENT` during cache cleanup from `File.mtime` too. ([@mikegee][])
+* [#4006](https://github.com/bbatsov/rubocop/issues/4006): Prevent `Style/WhileUntilModifier` from breaking on a multiline modifier. ([@drenmi][])
 
 ## 0.47.1 (2017-01-18)
 

--- a/lib/rubocop/cop/mixin/statement_modifier.rb
+++ b/lib/rubocop/cop/mixin/statement_modifier.rb
@@ -13,7 +13,8 @@ module RuboCop
       end
 
       def non_eligible_node?(node)
-        line_count(node) > 3 || commented?(node.loc.end)
+        line_count(node) > 3 ||
+          !node.modifier_form? && commented?(node.loc.end)
       end
 
       def non_eligible_body?(body)

--- a/spec/rubocop/cop/style/while_until_modifier_spec.rb
+++ b/spec/rubocop/cop/style/while_until_modifier_spec.rb
@@ -96,6 +96,16 @@ describe RuboCop::Cop::Style::WhileUntilModifier do
     expect(cop.offenses).to be_empty
   end
 
+  # Regression: https://github.com/bbatsov/rubocop/issues/4006
+  context 'when the modifier condition is multiline' do
+    it 'registers an offense' do
+      inspect_source(cop,
+                     ['foo while bar ||',
+                      '  baz'].join("\n"))
+      expect(cop.offenses.size).to eq(1)
+    end
+  end
+
   context 'when the maximum line length is specified by the cop itself' do
     let(:config) do
       hash = {


### PR DESCRIPTION
This cop would break when encountering a multiline, unparenthesized `while` or `until` modifier. This change fixes that.

-----------------

Before submitting the PR make sure the following are checked:

* [X] Wrote [good commit messages][1].
* [X] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [X] Used the same coding conventions as the rest of the project.
* [X] Feature branch is up-to-date with `master` (if not - rebase it).
* [X] Squashed related commits together.
* [X] Added tests.
* [X] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [X] All tests are passing.
* [X] The new code doesn't generate RuboCop offenses.
* [X] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [ ] Updated cop documentation with `rake generate_cops_documentation` (required only when you've added a new cop or changed the configuration/documentation of an existing cop).

[1]: http://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html
