### PR TITLE
Mark `foo[:bar]` as not complex in Style/TernaryParentheses cop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 
 ### Changes
 
+* [#4012](https://github.com/bbatsov/rubocop/pull/4012): Mark `foo[:bar]` as not complex in `Style/TernaryParentheses` cop with `require_parentheses_when_complex` style. ([@onk][])
 * [#3915](https://github.com/bbatsov/rubocop/issues/3915): Make configurable whitelist for `Lint/SafeNavigationChain` cop. ([@pocke][])
 * [#3944](https://github.com/bbatsov/rubocop/issues/3944): Allow keyword arguments in `Style/RaiseArgs` cop. ([@mikegee][])
 * Add auto-correct to `Performance/DoubleStartEndWith`. ([@rrosenblum][])
@@ -2626,3 +2627,4 @@
 [@backus]: https://github.com/backus
 [@pat]: https://github.com/pat
 [@sinsoku]: https://github.com/sinsoku
+[@onk]: https://github.com/onk

--- a/lib/rubocop/cop/style/ternary_parentheses.rb
+++ b/lib/rubocop/cop/style/ternary_parentheses.rb
@@ -113,7 +113,8 @@ module RuboCop
         def non_complex_type?(condition)
           condition.variable? || condition.const_type? ||
             (condition.send_type? && !operator?(condition.method_name)) ||
-            condition.defined_type? || condition.yield_type?
+            condition.defined_type? || condition.yield_type? ||
+            square_brackets?(condition)
         end
 
         def message(node)
@@ -165,6 +166,9 @@ module RuboCop
           {(:defined? $...)
            (send {(send ...) nil} _ $(send nil _)...)}
         PATTERN
+
+        def_node_matcher :square_brackets?,
+                         '(send {(send _recv _msg) str array hash} :[] ...)'
       end
     end
   end

--- a/spec/rubocop/cop/style/ternary_parentheses_spec.rb
+++ b/spec/rubocop/cop/style/ternary_parentheses_spec.rb
@@ -79,6 +79,10 @@ describe RuboCop::Cop::Style::TernaryParentheses, :config do
       it_behaves_like 'code with offense',
                       'foo = yield ? a : b',
                       'foo = (yield) ? a : b'
+
+      it_behaves_like 'code with offense',
+                      'foo = bar[:baz] ? a : b',
+                      'foo = (bar[:baz]) ? a : b'
     end
 
     context 'with a complex condition' do
@@ -134,6 +138,10 @@ describe RuboCop::Cop::Style::TernaryParentheses, :config do
       it_behaves_like 'code with offense',
                       'foo = (yield) ? a : b',
                       'foo = yield ? a : b'
+
+      it_behaves_like 'code with offense',
+                      'foo = (bar[:baz]) ? a : b',
+                      'foo = bar[:baz] ? a : b'
     end
 
     context 'with a complex condition' do
@@ -214,6 +222,10 @@ describe RuboCop::Cop::Style::TernaryParentheses, :config do
       it_behaves_like 'code with offense',
                       'foo = (yield) ? a : b',
                       'foo = yield ? a : b'
+
+      it_behaves_like 'code with offense',
+                      'foo = (bar[:baz]) ? a : b',
+                      'foo = bar[:baz] ? a : b'
     end
 
     context 'with a complex condition' do


### PR DESCRIPTION
Square brackets behavior is now same as Style/RedundantParentheses.

```
# EnforcedStyle: require_parentheses_when_complex
#
# # bad
# foo = (bar[:baz]) ? a : b
#
# # good
# foo = bar[:baz] ? a : b
```

It seems better to extract `non_complex_type?` to mixin and
`Style/RedundantParentheses` and `Style/TernaryParentheses`
use it even if incompatibility comes.

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Used the same coding conventions as the rest of the project.
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] All tests are passing.
* [x] The new code doesn't generate RuboCop offenses.
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [ ] Updated cop documentation with `rake generate_cops_documentation` (required only when you've added a new cop or changed the configuration/documentation of an existing cop).

[1]: http://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html
