### PR TITLE
Add support for an EnabledByDefault option. fixes #4005

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 * [#4104](https://github.com/bbatsov/rubocop/pull/4104): Add `prefix` and `postfix` styles to `Style/NegatedIf`. ([@brandonweiss][])
 * [#4083](https://github.com/bbatsov/rubocop/pull/4083): Add new configuration `NumberOfEmptyLines` for `Style/EmptyLineBetweenDefs`. ([@dorian][])
 * [#4045](https://github.com/bbatsov/rubocop/pull/4045): Add new configuration `Strict` for `Style/NumericLiteral` to make the change to this cop in 0.47.0 configurable. ([@iGEL][])
+* [#4005](https://github.com/bbatsov/rubocop/issues/4005): Add new `AllCops/EnabledByDefault` option. ([@betesh][])
 * [#3893](https://github.com/bbatsov/rubocop/issues/3893): Add a new configuration, `IncludeActiveSupportAliases`, to `Performance/DoublStartEndWith`. This configuration will check for ActiveSupport's `starts_with?` and `ends_with?`. ([@rrosenblum][])
 * [#3889](https://github.com/bbatsov/rubocop/pull/3889): Add new `Style/EmptyLineAfterMagicComment` cop. ([@backus][])
 * [#3800](https://github.com/bbatsov/rubocop/issues/3800): Make `Style/EndOfLine` configurable with `lf`, `crlf`, and `native` (default) styles. ([@jonas054][])
@@ -2685,3 +2686,4 @@
 [@maxbeizer]: https://github.com/maxbeizer
 [@andriymosin]: https://github.com/andriymosin
 [@brandonweiss]: https://github.com/brandonweiss
+[@betesh]: https://github.com/betesh

--- a/config/default.yml
+++ b/config/default.yml
@@ -51,11 +51,17 @@ AllCops:
   # the `--only-guide-cops` option.
   StyleGuideCopsOnly: false
   # All cops except the ones in disabled.yml are enabled by default. Change
-  # this behavior by overriding `DisabledByDefault`. When `DisabledByDefault` is
-  # `true`, all cops in the default configuration are disabled, and only cops
-  # in user configuration are enabled. This makes cops opt-in instead of
-  # opt-out. Note that when `DisabledByDefault` is `true`, cops in user
-  # configuration will be enabled even if they don't set the Enabled parameter.
+  # this behavior by overriding either `DisabledByDefault` or `EnabledByDefault`.
+  # When `DisabledByDefault` is `true`, all cops in the default configuration
+  # are disabled, and only cops in user configuration are enabled. This makes
+  # cops opt-in instead of opt-out. Note that when `DisabledByDefault` is `true`,
+  # cops in user configuration will be enabled even if they don't set the
+  # Enabled parameter.
+  # When `EnabledByDefault` is `true`, all cops, even those in disabled.yml,
+  # are enabled by default.  Cops can still be disabled in user configuration.
+  # Note that it is invalid to set both EnabledByDefault and DisabledByDefault
+  # to true in the same configuration.
+  EnabledByDefault: false
   DisabledByDefault: false
   # Enables the result cache if `true`. Can be overridden by the `--cache` command
   # line option.

--- a/lib/rubocop/config.rb
+++ b/lib/rubocop/config.rb
@@ -97,7 +97,10 @@ module RuboCop
     def initialize(hash = {}, loaded_path = nil)
       @loaded_path = loaded_path
       @for_cop = Hash.new do |h, cop|
-        h[cop] = self[Cop::Cop.qualified_cop_name(cop, loaded_path)] || {}
+        qualified_cop_name = Cop::Cop.qualified_cop_name(cop, loaded_path)
+        cop_options = self[qualified_cop_name] || {}
+        cop_options['Enabled'] = enable_cop?(qualified_cop_name, cop_options)
+        h[cop] = cop_options
       end
       @hash = hash
     end
@@ -193,14 +196,6 @@ module RuboCop
       @for_all_cops ||= self['AllCops'] || {}
     end
 
-    def cop_enabled?(cop)
-      if (dept_config = self[cop.department.to_s])
-        return false if dept_config['Enabled'] == false
-      end
-
-      for_cop(cop).empty? || for_cop(cop).fetch('Enabled', true)
-    end
-
     def validate
       # Don't validate RuboCop's own files. Avoids infinite recursion.
       base_config_path = File.expand_path(File.join(ConfigLoader::RUBOCOP_HOME,
@@ -216,6 +211,7 @@ module RuboCop
       check_target_ruby
       validate_parameter_names(valid_cop_names)
       validate_enforced_styles(valid_cop_names)
+      reject_mutually_exclusive_defaults
     end
 
     def file_to_include?(file)
@@ -404,6 +400,29 @@ module RuboCop
       msg += "\nKnown versions: #{KNOWN_RUBIES.join(', ')}"
 
       raise ValidationError, msg
+    end
+
+    def reject_mutually_exclusive_defaults
+      disabled_by_default = for_all_cops['DisabledByDefault']
+      enabled_by_default = for_all_cops['EnabledByDefault']
+      return unless disabled_by_default && enabled_by_default
+
+      msg = 'Cops cannot be both enabled by default and disabled by default'
+      raise ValidationError, msg
+    end
+
+    def enable_cop?(qualified_cop_name, cop_options)
+      cop_department, cop_name = qualified_cop_name.split('/')
+      department = cop_name.nil?
+
+      unless department
+        department_options = self[cop_department]
+        if department_options && department_options.fetch('Enabled') == false
+          return false
+        end
+      end
+
+      cop_options.fetch('Enabled', true)
     end
   end
 end

--- a/lib/rubocop/cop/mixin/safe_mode.rb
+++ b/lib/rubocop/cop/mixin/safe_mode.rb
@@ -15,7 +15,7 @@ module RuboCop
       end
 
       def rails?
-        config['Rails'] && config['Rails']['Enabled']
+        config['Rails'] && config['Rails'].fetch('Enabled')
       end
     end
   end

--- a/lib/rubocop/cop/registry.rb
+++ b/lib/rubocop/cop/registry.rb
@@ -72,7 +72,7 @@ module RuboCop
       # @example namespaces bare cop identifiers
       #
       #   cops = RuboCop::Cop::Cop.all
-      #   cops.qualified_cop_name('IndentArray') # => 'IndentArray'
+      #   cops.qualified_cop_name('IndentArray') # => 'Style/IndentArray'
       #
       # @example passes back unrecognized cop names
       #
@@ -115,7 +115,7 @@ module RuboCop
 
       def enabled(config, only)
         select do |cop|
-          config.cop_enabled?(cop) || only.include?(cop.cop_name)
+          config.for_cop(cop).fetch('Enabled') || only.include?(cop.cop_name)
         end
       end
 

--- a/lib/rubocop/cop/style/empty_else.rb
+++ b/lib/rubocop/cop/style/empty_else.rb
@@ -129,8 +129,8 @@ module RuboCop
         end
 
         def missing_else_style
-          missing_config = config.for_cop('Style/MissingElse')
-          missing_config['Enabled'] ? missing_config['EnforcedStyle'] : nil
+          missing_cfg = config.for_cop('Style/MissingElse')
+          missing_cfg.fetch('Enabled') ? missing_cfg['EnforcedStyle'] : nil
         end
       end
     end

--- a/lib/rubocop/cop/style/missing_else.rb
+++ b/lib/rubocop/cop/style/missing_else.rb
@@ -75,7 +75,7 @@ module RuboCop
         end
 
         def unless_else_cop_enabled?
-          unless_else_config['Enabled'] if unless_else_config
+          unless_else_config.fetch('Enabled')
         end
 
         def unless_else_config
@@ -83,11 +83,12 @@ module RuboCop
         end
 
         def empty_else_cop_enabled?
-          empty_else_config['Enabled'] if empty_else_config
+          empty_else_config.fetch('Enabled')
         end
 
         def empty_else_style
-          empty_else_config['EnforcedStyle'].to_sym if empty_else_config
+          return unless empty_else_config.key?('EnforcedStyle')
+          empty_else_config['EnforcedStyle'].to_sym
         end
 
         def empty_else_config

--- a/lib/rubocop/cop/style/ternary_parentheses.rb
+++ b/lib/rubocop/cop/style/ternary_parentheses.rb
@@ -133,7 +133,7 @@ module RuboCop
         end
 
         def redundant_parentheses_enabled?
-          @config.for_cop('RedundantParentheses')['Enabled']
+          @config.for_cop('Style/RedundantParentheses').fetch('Enabled')
         end
 
         def parenthesized?(node)

--- a/lib/rubocop/cop/style/trailing_comma_in_arguments.rb
+++ b/lib/rubocop/cop/style/trailing_comma_in_arguments.rb
@@ -48,7 +48,7 @@ module RuboCop
         # of the last argument.
         def braces_will_be_removed?(args)
           brace_config = config.for_cop('Style/BracesAroundHashParameters')
-          return false unless brace_config['Enabled']
+          return false unless brace_config.fetch('Enabled')
           return false if brace_config['AutoCorrect'] == false
 
           brace_style = brace_config['EnforcedStyle']

--- a/lib/rubocop/rspec/shared_contexts.rb
+++ b/lib/rubocop/rspec/shared_contexts.rb
@@ -51,6 +51,8 @@ shared_context 'config', :config do
                        .merge(cop_config)
     end
 
+    hash = other_cops.merge hash if respond_to?(:other_cops)
+
     RuboCop::Config.new(hash, "#{Dir.pwd}/.rubocop.yml")
   end
 end

--- a/lib/rubocop/runner.rb
+++ b/lib/rubocop/runner.rb
@@ -118,7 +118,7 @@ module RuboCop
     def add_unneeded_disables(file, offenses, source)
       if check_for_unneded_disables?(source)
         config = @config_store.for(file)
-        if config.cop_enabled?(Cop::Lint::UnneededDisable)
+        if config.for_cop(Cop::Lint::UnneededDisable).fetch('Enabled')
           cop = Cop::Lint::UnneededDisable.new(config, @options)
           if cop.relevant_file?(file)
             cop.check(offenses, source.disabled_line_ranges, source.comments)

--- a/manual/configuration.md
+++ b/manual/configuration.md
@@ -220,7 +220,7 @@ Metrics/LineLength:
 Most cops are enabled by default. Some cops, configured in
 [config/disabled.yml](https://github.com/bbatsov/rubocop/blob/master/config/disabled.yml),
 are disabled by default. The cop enabling process can be altered by
-setting `DisabledByDefault` to `true`.
+setting `DisabledByDefault` or `EnabledByDefault` (but not both) to `true`.
 
 ```yaml
 AllCops:
@@ -230,6 +230,14 @@ AllCops:
 All cops are then disabled by default, and only cops appearing in user
 configuration files are enabled. `Enabled: true` does not have to be
 set for cops in user configuration. They will be enabled anyway.
+
+```yaml
+AllCops:
+  EnabledByDefault: true
+```
+
+All cops are then enabled by default, and only cops explicitly disabled
+using `Enabled: false` in user configuration files are enabled.
 
 #### Severity
 

--- a/spec/rubocop/cli/cli_autocorrect_spec.rb
+++ b/spec/rubocop/cli/cli_autocorrect_spec.rb
@@ -5,6 +5,10 @@ describe RuboCop::CLI, :isolated_environment do
 
   subject(:cli) { described_class.new }
 
+  before(:each) do
+    RuboCop::ConfigLoader.default_configuration = nil
+  end
+
   it 'does not correct ExtraSpacing in a hash that would be changed back' do
     create_file('.rubocop.yml', ['Style/AlignHash:',
                                  '  EnforcedColonStyle: table'])

--- a/spec/rubocop/cli/cli_options_spec.rb
+++ b/spec/rubocop/cli/cli_options_spec.rb
@@ -5,6 +5,10 @@ describe RuboCop::CLI, :isolated_environment do
 
   subject(:cli) { described_class.new }
 
+  before(:each) do
+    RuboCop::ConfigLoader.default_configuration = nil
+  end
+
   describe '--list-target-files' do
     context 'when there are no files' do
       it 'prints nothing with -L' do

--- a/spec/rubocop/cli_spec.rb
+++ b/spec/rubocop/cli_spec.rb
@@ -514,6 +514,10 @@ describe RuboCop::CLI, :isolated_environment do
   end
 
   describe 'rails cops' do
+    before(:each) do
+      RuboCop::ConfigLoader.default_configuration = nil
+    end
+
     describe 'enabling/disabling' do
       it 'by default does not run rails cops' do
         create_file('app/models/example1.rb', 'read_attribute(:test)')
@@ -638,6 +642,10 @@ describe RuboCop::CLI, :isolated_environment do
   end
 
   describe 'configuration from file' do
+    before(:each) do
+      RuboCop::ConfigLoader.default_configuration = nil
+    end
+
     context 'when configured for rails style indentation' do
       it 'accepts rails style indentation' do
         create_file('.rubocop.yml', ['Style/IndentationConsistency:',

--- a/spec/rubocop/config_spec.rb
+++ b/spec/rubocop/config_spec.rb
@@ -224,6 +224,24 @@ describe RuboCop::Config do
           .to raise_error(RuboCop::ValidationError, message_matcher)
       end
     end
+
+    context 'when all cops are both Enabled and Disabled by default' do
+      before do
+        create_file(configuration_path, [
+                      'AllCops:',
+                      '  EnabledByDefault: true',
+                      '  DisabledByDefault: true'
+                    ])
+      end
+
+      it 'raises validation error' do
+        expect { configuration.validate }
+          .to raise_error(
+            RuboCop::ValidationError,
+            /Cops cannot be both enabled by default and disabled by default/
+          )
+      end
+    end
   end
 
   describe '#make_excludes_absolute' do
@@ -479,7 +497,11 @@ describe RuboCop::Config do
     end
   end
 
-  describe '#cop_enabled?' do
+  context 'whether the cop is enabled' do
+    def cop_enabled(cop_class)
+      configuration.for_cop(cop_class).fetch('Enabled')
+    end
+
     context 'when an entire cop department is disabled' do
       context 'but an individual cop is enabled' do
         let(:hash) do
@@ -491,7 +513,7 @@ describe RuboCop::Config do
 
         it 'still disables the cop' do
           cop_class = RuboCop::Cop::Style::TrailingWhitespace
-          expect(configuration.cop_enabled?(cop_class)).to be false
+          expect(cop_enabled(cop_class)).to be false
         end
       end
     end
@@ -507,7 +529,7 @@ describe RuboCop::Config do
 
         it 'still disables the cop' do
           cop_class = RuboCop::Cop::Style::TrailingWhitespace
-          expect(configuration.cop_enabled?(cop_class)).to be false
+          expect(cop_enabled(cop_class)).to be false
         end
       end
     end
@@ -521,7 +543,7 @@ describe RuboCop::Config do
 
       it 'enables the cop by default' do
         cop_class = RuboCop::Cop::Style::TrailingWhitespace
-        expect(configuration.cop_enabled?(cop_class)).to be true
+        expect(cop_enabled(cop_class)).to be true
       end
     end
   end

--- a/spec/rubocop/cop/style/ternary_parentheses_spec.rb
+++ b/spec/rubocop/cop/style/ternary_parentheses_spec.rb
@@ -7,6 +7,13 @@ describe RuboCop::Cop::Style::TernaryParentheses, :config do
     inspect_source(cop, source)
   end
 
+  let(:redundant_parens_enabled) { false }
+  let(:other_cops) do
+    {
+      'Style/RedundantParentheses' => { 'Enabled' => redundant_parens_enabled }
+    }
+  end
+
   shared_examples 'code with offense' do |code, expected|
     context "when checking #{code}" do
       let(:source) { code }
@@ -339,14 +346,12 @@ describe RuboCop::Cop::Style::TernaryParentheses, :config do
   end
 
   context 'when `RedundantParenthesis` would cause an infinite loop' do
-    let(:config) do
-      RuboCop::Config.new(
-        'Style/RedundantParentheses' => { 'Enabled' => true },
-        'Style/TernaryParentheses' => {
-          'EnforcedStyle' => 'require_parentheses',
-          'SupportedStyles' => %w(require_parentheses require_no_parentheses)
-        }
-      )
+    let(:redundant_parens_enabled) { true }
+    let(:cop_config) do
+      {
+        'EnforcedStyle' => 'require_parentheses',
+        'SupportedStyles' => %w(require_parentheses require_no_parentheses)
+      }
     end
 
     it_behaves_like 'code without offense',

--- a/spec/rubocop/cop/team_spec.rb
+++ b/spec/rubocop/cop/team_spec.rb
@@ -8,6 +8,10 @@ describe RuboCop::Cop::Team do
   let(:options) { nil }
   let(:ruby_version) { RuboCop::Config::KNOWN_RUBIES.last }
 
+  before(:each) do
+    RuboCop::ConfigLoader.default_configuration = nil
+  end
+
   describe 'INCOMPATIBLE_COPS' do
     include FileHelper
 

--- a/tasks/cops_documentation.rake
+++ b/tasks/cops_documentation.rake
@@ -30,7 +30,8 @@ task generate_cops_documentation: :yard do
   def properties(config, cop)
     content = "Enabled by default | Supports autocorrection\n".dup
     content << "--- | ---\n"
-    default_status = config.cop_enabled?(cop) ? 'Enabled' : 'Disabled'
+    enabled_by_default = config.for_cop(cop).fetch('Enabled')
+    default_status = enabled_by_default ? 'Enabled' : 'Disabled'
     supports_autocorrect = cop.new.support_autocorrect? ? 'Yes' : 'No'
     content << "#{default_status} | #{supports_autocorrect}"
     content


### PR DESCRIPTION
Add support for an EnabledByDefault option

-----------------

Before submitting the PR make sure the following are checked:

* [X] Wrote good commit messages.
* [X] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [X] Used the same coding conventions as the rest of the project.
* [X] Feature branch is up-to-date with `master` (if not - rebase it).
* [X] Squashed related commits together.
* [X] Added tests.
* [X] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [X] All tests are passing.
* [X] The new code doesn't generate RuboCop offenses.
* [ ] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences. (**There are 2 inter-related changes here: Adding support for EnabledByDefault, and removing the `cop_enabled?` method.  @bbatsov approved doing this in one branch in a comment below**)
* [ ] Updated cop documentation with `rake generate_cops_documentation` (required only when you've added a new cop or changed the configuration/documentation of an existing cop).

--------------------------
~~Note that there is a failing test.  That test is not related to the new code I added but to a regression test I added to ensure that my code does not impact existing behavior in an unintended way.  This may be a bug in the existing code, but I'm not sure and would like input from the maintainers before digging deeper.~~