### PR TITLE
Remove unused argument for `format` in `Security/YAMLLoad` cop

### DIFF
--- a/lib/rubocop/cop/security/yaml_load.rb
+++ b/lib/rubocop/cop/security/yaml_load.rb
@@ -23,8 +23,8 @@ module RuboCop
         END
 
         def on_send(node)
-          yaml_load(node) do |method|
-            add_offense(node, :selector, format(MSG, method))
+          yaml_load(node) do
+            add_offense(node, :selector)
           end
         end
 


### PR DESCRIPTION
With `ruby -w`, a warning is occurred in `Security/YAMLLoad` cop.

```sh
$ RUBYOPT=-w
/home/pocke/.gem/ruby/2.4.0/gems/parser-2.3.3.1/lib/parser/lexer.rb:10922: warning: assigned but unused variable - testEof
/home/pocke/.gem/ruby/2.4.0/gems/rubocop-0.47.1/lib/rubocop/magic_comment.rb:124: warning: `frozen_string_literal' is ignored after any tokens
Inspecting 888 files
............................/home/pocke/.gem/ruby/2.4.0/gems/rubocop-0.47.1/lib/rubocop/cop/security/yaml_load.rb:27: warning: too many arguments for format string
........................................................................................................................................................................................................................................................................................................................................................................................................................................................./home/pocke/.gem/ruby/2.4.0/gems/rubocop-0.47.1/lib/rubocop/cop/security/yaml_load.rb:27: warning: too many arguments for format string
...................................................................................................................................................................................................................................................................................................................................................................................................................................

888 files inspected, no offenses detected
```

The argument is not used. So, I've remove it.

Note
-----

Other warnings are occurred, however, this change ignores the warnings.

- `/home/pocke/.gem/ruby/2.4.0/gems/parser-2.3.3.1/lib/parser/lexer.rb:10922: warning: assigned but unused variable - testEof`
  - It's a parser gem's problem.
- `/home/pocke/.gem/ruby/2.4.0/gems/rubocop-0.47.1/lib/rubocop/magic_comment.rb:124: warning: `frozen_string_literal' is ignored after any tokens`
  - It's a false positive.


-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Used the same coding conventions as the rest of the project.
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [ ] Added tests.
* [ ] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] All tests are passing.
* [x] The new code doesn't generate RuboCop offenses.
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [ ] Updated cop documentation with `rake generate_cops_documentation` (required only when you've added a new cop or changed the configuration/documentation of an existing cop).

[1]: http://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html
