### PR TITLE
Add autocorrect for `Lint/EmptyEnsure` cop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 * [#3984](https://github.com/bbatsov/rubocop/pull/3984): Add new `Style/EmptyLinesAroundBeginBody` cop. ([@pocke][])
 * [#3995](https://github.com/bbatsov/rubocop/pull/3995): Add new `Style/EmptyLinesAroundExceptionHandlingKeywords` cop. ([@pocke][])
 * [#4019](https://github.com/bbatsov/rubocop/pull/4019): Make configurable `Style/MultilineMemoization` cop. ([@pocke][])
+* [#4018](https://github.com/bbatsov/rubocop/pull/4018): Add autocorrect `Lint/EmptyEnsure` cop. ([@pocke][])
 
 ### Changes
 

--- a/config/enabled.yml
+++ b/config/enabled.yml
@@ -1108,6 +1108,7 @@ Lint/ElseLayout:
 Lint/EmptyEnsure:
   Description: 'Checks for empty ensure block.'
   Enabled: true
+  AutoCorrect: false
 
 Lint/EmptyExpression:
   Description: 'Checks for empty expressions.'

--- a/lib/rubocop/cop/lint/empty_ensure.rb
+++ b/lib/rubocop/cop/lint/empty_ensure.rb
@@ -50,6 +50,12 @@ module RuboCop
 
           add_offense(node, :keyword) unless ensure_body
         end
+
+        def autocorrect(node)
+          lambda do |corrector|
+            corrector.remove(node.loc.keyword)
+          end
+        end
       end
     end
   end

--- a/manual/cops_lint.md
+++ b/manual/cops_lint.md
@@ -498,7 +498,7 @@ end
 
 Enabled by default | Supports autocorrection
 --- | ---
-Enabled | No
+Enabled | Yes
 
 This cop checks for empty `ensure` blocks
 
@@ -538,6 +538,13 @@ ensure
   do_something_else
 end
 ```
+
+### Important attributes
+
+Attribute | Value
+--- | ---
+AutoCorrect | false
+
 
 ## Lint/EmptyExpression
 

--- a/spec/rubocop/cop/lint/empty_ensure_spec.rb
+++ b/spec/rubocop/cop/lint/empty_ensure_spec.rb
@@ -14,6 +14,20 @@ describe RuboCop::Cop::Lint::EmptyEnsure do
     expect(cop.offenses.size).to eq(1)
   end
 
+  it 'autocorrects for empty ensure' do
+    corrected = autocorrect_source(cop,
+                                   ['begin',
+                                    '  something',
+                                    'ensure',
+                                    'end'])
+    expect(corrected).to eq([
+      'begin',
+      '  something',
+      '',
+      'end'
+    ].join("\n"))
+  end
+
   it 'does not register an offense for non-empty ensure' do
     inspect_source(cop,
                    ['begin',


### PR DESCRIPTION
```
$ cat test.rb
begin
  something
ensure
end

$ rubocop -a
Inspecting 1 file
W

Offenses:

test.rb:3:1: W: [Corrected] Empty ensure block detected.
ensure
^^^^^^
test.rb:3:1: C: [Corrected] Extra empty line detected at begin body end.

1 file inspected, 2 offenses detected, 2 offenses corrected

$ cat test.rb
begin
  something
end
```

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Used the same coding conventions as the rest of the project.
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] All tests are passing.
* [x] The new code doesn't generate RuboCop offenses.
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Updated cop documentation with `rake generate_cops_documentation` (required only when you've added a new cop or changed the configuration/documentation of an existing cop).

[1]: http://chris.beams.io/posts/git-commit/
