### PR TITLE
Make configurable `Style/MultilineMemoization` cop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 * [#3936](https://github.com/bbatsov/rubocop/issues/3936): Add new `Style/MixinGrouping` cop. ([@drenmi][])
 * [#3984](https://github.com/bbatsov/rubocop/pull/3984): Add new `Style/EmptyLinesAroundBeginBody` cop. ([@pocke][])
 * [#3995](https://github.com/bbatsov/rubocop/pull/3995): Add new `Style/EmptyLinesAroundExceptionHandlingKeywords` cop. ([@pocke][])
+* [#4019](https://github.com/bbatsov/rubocop/pull/4019): Make configurable `Style/MultilineMemoization` cop. ([@pocke][])
 
 ### Changes
 

--- a/config/default.yml
+++ b/config/default.yml
@@ -782,6 +782,12 @@ Style/MultilineHashBraceLayout:
     - new_line
     - same_line
 
+Style/MultilineMemoization:
+  EnforcedStyle: keyword
+  SupportedStyles:
+    - keyword
+    - braces
+
 Style/MultilineMethodCallBraceLayout:
   EnforcedStyle: symmetrical
   SupportedStyles:

--- a/manual/cops_style.md
+++ b/manual/cops_style.md
@@ -3257,12 +3257,13 @@ Enabled by default | Supports autocorrection
 --- | ---
 Enabled | Yes
 
-This cop checks that multiline memoizations are wrapped in a `begin`
-and `end` block.
+This cop checks expressions wrapping styles for multiline memoization.
 
 ### Example
 
 ```ruby
+# EnforcedStyle: keyword (default)
+
 # bad
 foo ||= (
   bar
@@ -3275,6 +3276,29 @@ foo ||= begin
   baz
 end
 ```
+```ruby
+# EnforcedStyle: braces
+
+# bad
+foo ||= begin
+  bar
+  baz
+end
+
+# good
+foo ||= (
+  bar
+  baz
+)
+```
+
+### Important attributes
+
+Attribute | Value
+--- | ---
+EnforcedStyle | keyword
+SupportedStyles | keyword, braces
+
 
 ## Style/MultilineMethodCallBraceLayout
 


### PR DESCRIPTION
Currently, `Style/MultilineMemoization` cop is not configurable.
This change makes configurable this cop.


-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Used the same coding conventions as the rest of the project.
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] All tests are passing.
* [x] The new code doesn't generate RuboCop offenses.
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Updated cop documentation with `rake generate_cops_documentation` (required only when you've added a new cop or changed the configuration/documentation of an existing cop).

[1]: http://chris.beams.io/posts/git-commit/
