### PR TITLE
Fixed `new_cop.rake` suggested path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@
 * [#3944](https://github.com/bbatsov/rubocop/issues/3944): Allow keyword arguments in `Style/RaiseArgs` cop. ([@mikegee][])
 * Add auto-correct to `Performance/DoubleStartEndWith`. ([@rrosenblum][])
 * [#3951](https://github.com/bbatsov/rubocop/pull/3951): Make `Rails/Date` cop to register an offence for a string without timezone. ([@sinsoku][])
+* [#4020](https://github.com/bbatsov/rubocop/pull/4020): Fixed `new_cop.rake` suggested path. ([@dabroz][])
 
 ### Bug fixes
 
@@ -2630,3 +2631,4 @@
 [@pat]: https://github.com/pat
 [@sinsoku]: https://github.com/sinsoku
 [@onk]: https://github.com/onk
+[@dabroz]: https://github.com/dabroz

--- a/tasks/new_cop.rake
+++ b/tasks/new_cop.rake
@@ -107,7 +107,7 @@ created
 Do 4 steps
 - Add an entry to `New feature` section in CHANGELOG.md
   - e.g. Add new `#{badge.cop_name}` cop. ([@your_id][])
-- Add `require '#{cop_path.gsub(/\.rb$/, '')}'` into lib/rubocop.rb
+- Add `require '#{cop_path.gsub(/\.rb$/, '').gsub(%r{^lib/}, '')}'` into lib/rubocop.rb
 - Add an entry into config/enabled.yml or config/disabled.yml
 - Implement a new cop to the generated file!
   END


### PR DESCRIPTION
`rake new_cop[Style/Foobar]` suggested to

    - Add `require 'lib/rubocop/cop/style/foobar'` into lib/rubocop.rb

while actually paths in `lib/rubocop.rb` don't start with `lib/`. This fixes the issue and suggests a correct path instead.

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [x] Used the same coding conventions as the rest of the project.
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] All tests are passing.
* [x] The new code doesn't generate RuboCop offenses.
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.

[1]: http://chris.beams.io/posts/git-commit/
