### PR TITLE
[Fix #3345] Fix String `WordRegex` in `WordArray`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@
 * [#3242](https://github.com/bbatsov/rubocop/issues/3242): Ignore `Errno::ENOENT` during cache cleanup from `File.mtime` too. ([@mikegee][])
 * [#3958](https://github.com/bbatsov/rubocop/issues/3958): `Style/SpaceInsideHashLiteralBraces` doesn't add and offence when checking an hash where a value is a left brace string (e.g. { k: '{' }). ([@nodo][])
 * [#4006](https://github.com/bbatsov/rubocop/issues/4006): Prevent `Style/WhileUntilModifier` from breaking on a multiline modifier. ([@drenmi][])
+* [#3345](https://github.com/bbatsov/rubocop/issues/3345): Allow `Style/WordArray`'s `WordRegex` configuration value to be an instance of `String`. ([@mikegee][])
 
 ## 0.47.1 (2017-01-18)
 

--- a/lib/rubocop/cop/style/word_array.rb
+++ b/lib/rubocop/cop/style/word_array.rb
@@ -81,7 +81,7 @@ module RuboCop
         end
 
         def word_regex
-          cop_config['WordRegex']
+          Regexp.new(cop_config['WordRegex'])
         end
 
         def correct_percent(node)

--- a/spec/rubocop/cop/style/word_array_spec.rb
+++ b/spec/rubocop/cop/style/word_array_spec.rb
@@ -227,6 +227,14 @@ describe RuboCop::Cop::Style::WordArray, :config do
     end
   end
 
+  context 'when the WordRegex configuration is not a Regexp' do
+    let(:cop_config) { { 'WordRegex' => 'just_a_string' } }
+
+    it 'still parses the code without raising an error' do
+      expect { inspect_source(cop, '') }.to_not raise_error
+    end
+  end
+
   context 'with a WordRegex configuration which accepts almost anything' do
     let(:cop_config) { { 'MinSize' => 0, 'WordRegex' => /\S+/ } }
 


### PR DESCRIPTION
When configured with a `String` value, parse it as a regular expression before assuming it is an instance of `Regexp`.

fixes #3345

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Used the same coding conventions as the rest of the project.
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] All tests are passing.
* [x] The new code doesn't generate RuboCop offenses.
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Updated cop documentation with `rake generate_cops_documentation` (required only when you've added a new cop or changed the configuration/documentation of an existing cop).

[1]: http://chris.beams.io/posts/git-commit/
