### PR TITLE
Tweak `Style/IndentHeredoc` cop

### DIFF
--- a/config/default.yml
+++ b/config/default.yml
@@ -694,9 +694,10 @@ Style/IndentHash:
   IndentationWidth: ~
 
 Style/IndentHeredoc:
-  EnforcedStyle: ruby23
+  EnforcedStyle: auto_detection
   SupportedStyles:
-    - ruby23
+    - auto_detection
+    - squiggly
     - active_support
     - powerpack
     - unindent

--- a/lib/rubocop/cop/style/indent_heredoc.rb
+++ b/lib/rubocop/cop/style/indent_heredoc.rb
@@ -123,12 +123,12 @@ module RuboCop
         def check_style!
           case style
           when nil
-            raise Warning, "Auto Correction does not work for #{cop_name}. " \
+            raise Warning, "Auto-correction does not work for #{cop_name}. " \
                            'Please configure EnforcedStyle.'
           when :squiggly
             if target_ruby_version < 2.3
-              raise Warning, '`squiggly` style is selectable only Ruby 2.3 ' \
-                             "or higher for #{cop_name}."
+              raise Warning, '`squiggly` style is selectable only on Ruby ' \
+                             "2.3 or higher for #{cop_name}."
             end
           end
         end

--- a/lib/rubocop/rspec/cop_helper.rb
+++ b/lib/rubocop/rspec/cop_helper.rb
@@ -7,6 +7,7 @@ module CopHelper
   extend RSpec::SharedContext
 
   let(:ruby_version) { 2.2 }
+  let(:enabled_rails) { false }
 
   def inspect_source_file(cop, source)
     Tempfile.open('tmp') { |f| inspect_source(cop, source, f) }

--- a/lib/rubocop/rspec/shared_contexts.rb
+++ b/lib/rubocop/rspec/shared_contexts.rb
@@ -42,6 +42,7 @@ shared_context 'config', :config do
     end
 
     hash = { 'AllCops' => { 'TargetRubyVersion' => ruby_version } }
+    hash['Rails'] = { 'Enabled' => true } if enabled_rails
     if respond_to?(:cop_config)
       cop_name = described_class.cop_name
       hash[cop_name] = RuboCop::ConfigLoader
@@ -75,4 +76,8 @@ end
 
 shared_context 'ruby 2.4', :ruby24 do
   let(:ruby_version) { 2.4 }
+end
+
+shared_context 'with Rails', :enabled_rails do
+  let(:enabled_rails) { true }
 end

--- a/manual/cops_style.md
+++ b/manual/cops_style.md
@@ -2455,12 +2455,16 @@ something
 END
 
 # good
+# When EnforcedStyle is ruby23, bad code is auto-corrected to the
+# following code.
 <<~END
   something
 END
 
 # good
-<<~END.strip_heredoc
+# When EnforcedStyle is active_support, bad code is auto-corrected to
+# the following code.
+<<-END.strip_heredoc
   something
 END
 ```

--- a/manual/cops_style.md
+++ b/manual/cops_style.md
@@ -2455,7 +2455,7 @@ something
 END
 
 # good
-# When EnforcedStyle is ruby23, bad code is auto-corrected to the
+# When EnforcedStyle is squiggly, bad code is auto-corrected to the
 # following code.
 <<~END
   something
@@ -2473,8 +2473,8 @@ END
 
 Attribute | Value
 --- | ---
-EnforcedStyle | ruby23
-SupportedStyles | ruby23, active_support, powerpack, unindent
+EnforcedStyle | auto_detection
+SupportedStyles | auto_detection, squiggly, active_support, powerpack, unindent
 
 
 ### References

--- a/spec/rubocop/cop/style/indent_heredoc_spec.rb
+++ b/spec/rubocop/cop/style/indent_heredoc_spec.rb
@@ -114,6 +114,40 @@ describe RuboCop::Cop::Style::IndentHeredoc, :config do
         end
       END
 
+      it 'displays message without how to configure' do
+        inspect_source(cop, <<-END.strip_indent)
+          <<-END2
+          foo
+          END2
+        END
+        expect(cop.messages).to eq(
+          [
+            'Use 2 spaces for indentation in a heredoc by using ' \
+            '`String#strip_heredoc` that is provided by ActiveSupport.'
+          ]
+        )
+      end
+
+      context 'EnforcedStyle is not configured' do
+        let(:cop_config) do
+          {}
+        end
+        it 'displays message about how to configure' do
+          inspect_source(cop, <<-END.strip_indent)
+          <<-END2
+          foo
+          END2
+          END
+          expect(cop.messages).to eq(
+            [
+              'Use 2 spaces for indentation in a heredoc by using ' \
+              '`String#strip_heredoc` that is provided by ActiveSupport. ' \
+              'You need to configure EnforcedStyle to use auto-correction.'
+            ]
+          )
+        end
+      end
+
       context 'Ruby 2.3', :ruby23 do
         let(:cop_config) do
           { 'EnforcedStyle' => :ruby23 }
@@ -166,6 +200,33 @@ describe RuboCop::Cop::Style::IndentHeredoc, :config do
             something
           END2
         END
+
+        it 'displays message to use `<<~` instead of `<<`' do
+          inspect_source(cop, <<-END.strip_indent)
+          <<END2
+          foo
+          END2
+          END
+          expect(cop.messages).to eq(
+            [
+              'Use 2 spaces for indentation in a heredoc by using `<<~` ' \
+              'instead of `<<`.'
+            ]
+          )
+        end
+        it 'displays message to use `<<~` instead of `<<-`' do
+          inspect_source(cop, <<-END.strip_indent)
+          <<-END2
+          foo
+          END2
+          END
+          expect(cop.messages).to eq(
+            [
+              'Use 2 spaces for indentation in a heredoc by using `<<~` ' \
+              'instead of `<<-`.'
+            ]
+          )
+        end
       end
     end
   end

--- a/spec/rubocop/cop/style/indent_heredoc_spec.rb
+++ b/spec/rubocop/cop/style/indent_heredoc_spec.rb
@@ -152,7 +152,7 @@ describe RuboCop::Cop::Style::IndentHeredoc, :config do
         message = 'Use 2 spaces for indentation in a heredoc by using ' \
                   "some library(e.g. ActiveSupport's `String#strip_heredoc`)."
         include_examples :check_message, 'some library', [message]
-        warning = 'Auto Correction does not work for Style/IndentHeredoc. ' \
+        warning = 'Auto-correction does not work for Style/IndentHeredoc. ' \
                   'Please configure EnforcedStyle.'
         include_examples :warning, warning
 
@@ -272,8 +272,8 @@ describe RuboCop::Cop::Style::IndentHeredoc, :config do
         end
 
         context 'Ruby 2.2', :ruby22 do
-          warning = '`squiggly` style is selectable only Ruby 2.3 or higher ' \
-                    'for Style/IndentHeredoc.'
+          warning = '`squiggly` style is selectable only on Ruby 2.3 or ' \
+                    'higher for Style/IndentHeredoc.'
           include_examples :warning, warning
         end
       end


### PR DESCRIPTION
- Improve the offense message
- Update the documentation
- Fix typo in the documentation
- Fix typo in a method name

Improved messages
-------

When use Ruby 2.3 or newer

```
test.rb:2:1: C: Use 2 spaces for indentation in a heredoc by using <<~ instead of <<-.
```

When use Ruby 2.2 or older, and EnforcedStyle is not configured

```
test.rb:2:1: C: Use 2 spaces for indentation in a heredoc by using String#strip_heredoc that is provided by ActiveSupport. You need to configure EnforcedStyle to use auto-correction.
```

When use Ruby 2.2 or older, and EnforcedStyle is configured

```
test.rb:2:1: C: Use 2 spaces for indentation in a heredoc by using String#strip_heredoc that is provided by ActiveSupport.
```

Ref: https://github.com/bbatsov/rubocop/pull/4028


@deivid-rodriguez Could you review the Pull Request?

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Used the same coding conventions as the rest of the project.
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [ ] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] All tests are passing.
* [x] The new code doesn't generate RuboCop offenses.
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Updated cop documentation with `rake generate_cops_documentation` (required only when you've added a new cop or changed the configuration/documentation of an existing cop).

[1]: http://chris.beams.io/posts/git-commit/
