### PR TITLE
Change order of example for Lint/UnusedBlockArgument

### DIFF
--- a/lib/rubocop/cop/lint/unused_block_argument.rb
+++ b/lib/rubocop/cop/lint/unused_block_argument.rb
@@ -7,22 +7,6 @@ module RuboCop
       #
       # @example
       #
-      #   #good
-      #
-      #   do_something do |used, unused|
-      #     puts used
-      #   end
-      #
-      #   do_something do
-      #     puts :foo
-      #   end
-      #
-      #   define_method(:foo) do |_bar|
-      #     puts :baz
-      #   end
-      #
-      # @example
-      #
       #   # bad
       #
       #   do_something do |used, _unused|
@@ -34,6 +18,22 @@ module RuboCop
       #   end
       #
       #   define_method(:foo) do |bar|
+      #     puts :baz
+      #   end
+      #
+      # @example
+      #
+      #   #good
+      #
+      #   do_something do |used, unused|
+      #     puts used
+      #   end
+      #
+      #   do_something do
+      #     puts :foo
+      #   end
+      #
+      #   define_method(:foo) do |_bar|
       #     puts :baz
       #   end
       class UnusedBlockArgument < Cop

--- a/manual/cops_lint.md
+++ b/manual/cops_lint.md
@@ -1690,21 +1690,6 @@ This cop checks for unused block arguments.
 ### Example
 
 ```ruby
-#good
-
-do_something do |used, unused|
-  puts used
-end
-
-do_something do
-  puts :foo
-end
-
-define_method(:foo) do |_bar|
-  puts :baz
-end
-```
-```ruby
 # bad
 
 do_something do |used, _unused|
@@ -1716,6 +1701,21 @@ do_something do |bar|
 end
 
 define_method(:foo) do |bar|
+  puts :baz
+end
+```
+```ruby
+#good
+
+do_something do |used, unused|
+  puts used
+end
+
+do_something do
+  puts :foo
+end
+
+define_method(:foo) do |_bar|
   puts :baz
 end
 ```


### PR DESCRIPTION
Cop example is should to bad case first.

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Used the same coding conventions as the rest of the project.
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [ ] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] All tests are passing.
* [x] The new code doesn't generate RuboCop offenses.
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Updated cop documentation with `rake generate_cops_documentation` (required only when you've added a new cop or changed the configuration/documentation of an existing cop).

[1]: http://chris.beams.io/posts/git-commit/
