### PR TITLE
`default` key in `Style/PercentLiteralDelimiters`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@
 * [#4018](https://github.com/bbatsov/rubocop/pull/4018): Add autocorrect `Lint/EmptyEnsure` cop. ([@pocke][])
 * [#4028](https://github.com/bbatsov/rubocop/pull/4028): Add new `Style/IndentHeredoc` cop. ([@pocke][])
 * Add new `Style/InverseMethods` cop. ([@rrosenblum][])
-* [#4038](https://github.com/bbatsov/rubocop/pull/4038): Allow `all` key in the `Style/PercentLiteralDelimiters` cop config to set all preferred delimiters. ([@kddeisz][])
+* [#4038](https://github.com/bbatsov/rubocop/pull/4038): Allow `default` key in the `Style/PercentLiteralDelimiters` cop config to set all preferred delimiters. ([@kddeisz][])
 
 ### Changes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
 * [#4018](https://github.com/bbatsov/rubocop/pull/4018): Add autocorrect `Lint/EmptyEnsure` cop. ([@pocke][])
 * [#4028](https://github.com/bbatsov/rubocop/pull/4028): Add new `Style/IndentHeredoc` cop. ([@pocke][])
 * Add new `Style/InverseMethods` cop. ([@rrosenblum][])
+* [#4038](https://github.com/bbatsov/rubocop/pull/4038): Allow `all` key in the `Style/PercentLiteralDelimiters` cop config to set all preferred delimiters. ([@kddeisz][])
 
 ### Changes
 
@@ -2657,3 +2658,4 @@
 [@attilahorvath]: https://github.com/attilahorvath
 [@droptheplot]: https://github.com/droptheplot
 [@wkurniawan07]: https://github.com/wkurniawan07
+[@kddeisz]: https://github.com/kddeisz

--- a/config/default.yml
+++ b/config/default.yml
@@ -912,16 +912,8 @@ Style/ParenthesesAroundCondition:
 
 Style/PercentLiteralDelimiters:
   PreferredDelimiters:
-    '%':  ()
-    '%i': ()
-    '%I': ()
-    '%q': ()
-    '%Q': ()
+    all: ()
     '%r': '{}'
-    '%s': ()
-    '%w': ()
-    '%W': ()
-    '%x': ()
 
 Style/PercentQLiterals:
   EnforcedStyle: lower_case_q

--- a/config/default.yml
+++ b/config/default.yml
@@ -911,6 +911,9 @@ Style/ParenthesesAroundCondition:
   AllowSafeAssignment: true
 
 Style/PercentLiteralDelimiters:
+  # Specify the default preferred delimiter for all types with the 'default' key
+  # Override individual delimiters (even with default specified) by specifying
+  # an individual key
   PreferredDelimiters:
     default: ()
     '%r': '{}'

--- a/config/default.yml
+++ b/config/default.yml
@@ -912,7 +912,7 @@ Style/ParenthesesAroundCondition:
 
 Style/PercentLiteralDelimiters:
   PreferredDelimiters:
-    all: ()
+    default: ()
     '%r': '{}'
 
 Style/PercentQLiterals:

--- a/lib/rubocop/cop/style/percent_literal_delimiters.rb
+++ b/lib/rubocop/cop/style/percent_literal_delimiters.rb
@@ -4,7 +4,9 @@ module RuboCop
   module Cop
     module Style
       # This cop enforces the consistent usage of `%`-literal delimiters.
-      # Specify the 'all' key to set all preferred delimiters at once.
+      # Specify the 'default' key to set all preferred delimiters at once. You
+      # can continue to specify individual preferred delimiters to override the
+      # default.
       class PercentLiteralDelimiters < Cop
         include PercentLiteral
 
@@ -60,10 +62,10 @@ module RuboCop
 
         def preferred_delimiters
           @preferred_delimiters ||=
-            if cop_config['PreferredDelimiters'].key?('all')
+            if cop_config['PreferredDelimiters'].key?('default')
               Hash[%w(% %i %I %q %Q %r %s %w %W %x).map do |type|
                 [type, cop_config['PreferredDelimiters'][type] ||
-                  cop_config['PreferredDelimiters']['all']]
+                  cop_config['PreferredDelimiters']['default']]
               end]
             else
               cop_config['PreferredDelimiters']

--- a/lib/rubocop/cop/style/percent_literal_delimiters.rb
+++ b/lib/rubocop/cop/style/percent_literal_delimiters.rb
@@ -4,9 +4,25 @@ module RuboCop
   module Cop
     module Style
       # This cop enforces the consistent usage of `%`-literal delimiters.
+      #
       # Specify the 'default' key to set all preferred delimiters at once. You
       # can continue to specify individual preferred delimiters to override the
       # default.
+      #
+      # @example
+      #   # Style/PercentLiteralDelimiters:
+      #   #   PreferredDelimiters:
+      #   #     default: ()
+      #   #     %i:      []
+      #
+      #   # good
+      #   %w(alpha beta) + %i[gamma delta]
+      #
+      #   # bad
+      #   %W[alpha #{beta}]
+      #
+      #   # bad
+      #   %I[alpha beta]
       class PercentLiteralDelimiters < Cop
         include PercentLiteral
 

--- a/manual/cops_style.md
+++ b/manual/cops_style.md
@@ -4131,12 +4131,13 @@ Enabled by default | Supports autocorrection
 Enabled | Yes
 
 This cop enforces the consistent usage of `%`-literal delimiters.
+Specify the 'all' key to set all preferred delimiters at once.
 
 ### Important attributes
 
 Attribute | Value
 --- | ---
-PreferredDelimiters | {"%"=>"()", "%i"=>"()", "%I"=>"()", "%q"=>"()", "%Q"=>"()", "%r"=>"{}", "%s"=>"()", "%w"=>"()", "%W"=>"()", "%x"=>"()"}
+PreferredDelimiters | {"all"=>"()", "%r"=>"{}"}
 
 
 ### References

--- a/manual/cops_style.md
+++ b/manual/cops_style.md
@@ -4131,13 +4131,15 @@ Enabled by default | Supports autocorrection
 Enabled | Yes
 
 This cop enforces the consistent usage of `%`-literal delimiters.
-Specify the 'all' key to set all preferred delimiters at once.
+Specify the 'default' key to set all preferred delimiters at once. You
+can continue to specify individual preferred delimiters to override the
+default.
 
 ### Important attributes
 
 Attribute | Value
 --- | ---
-PreferredDelimiters | {"all"=>"()", "%r"=>"{}"}
+PreferredDelimiters | {"default"=>"()", "%r"=>"{}"}
 
 
 ### References

--- a/manual/cops_style.md
+++ b/manual/cops_style.md
@@ -4131,9 +4131,28 @@ Enabled by default | Supports autocorrection
 Enabled | Yes
 
 This cop enforces the consistent usage of `%`-literal delimiters.
+
 Specify the 'default' key to set all preferred delimiters at once. You
 can continue to specify individual preferred delimiters to override the
 default.
+
+### Example
+
+```ruby
+# Style/PercentLiteralDelimiters:
+#   PreferredDelimiters:
+#     default: ()
+#     %i:      []
+
+# good
+%w(alpha beta) + %i[gamma delta]
+
+# bad
+%W[alpha #{beta}]
+
+# bad
+%I[alpha beta]
+```
 
 ### Important attributes
 

--- a/spec/rubocop/cop/style/percent_literal_delimiters_spec.rb
+++ b/spec/rubocop/cop/style/percent_literal_delimiters_spec.rb
@@ -4,14 +4,14 @@ describe RuboCop::Cop::Style::PercentLiteralDelimiters, :config do
   subject(:cop) { described_class.new(config) }
 
   let(:cop_config) do
-    { 'PreferredDelimiters' => { 'all' => '[]' } }
+    { 'PreferredDelimiters' => { 'default' => '[]' } }
   end
 
-  context '`all` override' do
+  context '`default` override' do
     let(:cop_config) do
       {
         'PreferredDelimiters' => {
-          'all' => '[]',
+          'default' => '[]',
           '%'   => '()'
         }
       }
@@ -22,7 +22,7 @@ describe RuboCop::Cop::Style::PercentLiteralDelimiters, :config do
       expect(cop.offenses).to be_empty
     end
 
-    it 'allows individual preferred delimiters to override `all`' do
+    it 'allows individual preferred delimiters to override `default`' do
       inspect_source(cop, '%w[string] + [%(string)]')
       expect(cop.offenses).to be_empty
     end

--- a/spec/rubocop/cop/style/percent_literal_delimiters_spec.rb
+++ b/spec/rubocop/cop/style/percent_literal_delimiters_spec.rb
@@ -12,7 +12,7 @@ describe RuboCop::Cop::Style::PercentLiteralDelimiters, :config do
       {
         'PreferredDelimiters' => {
           'default' => '[]',
-          '%'   => '()'
+          '%'       => '()'
         }
       }
     end
@@ -25,6 +25,14 @@ describe RuboCop::Cop::Style::PercentLiteralDelimiters, :config do
     it 'allows individual preferred delimiters to override `default`' do
       inspect_source(cop, '%w[string] + [%(string)]')
       expect(cop.offenses).to be_empty
+    end
+  end
+
+  context 'invalid cop config' do
+    let(:cop_config) { { 'PreferredDelimiters' => { 'foobar' => '()' } } }
+
+    it 'raises an error when invalid configuration is specified' do
+      expect { inspect_source(cop, '%w[string]') }.to raise_error(ArgumentError)
     end
   end
 

--- a/spec/rubocop/cop/style/percent_literal_delimiters_spec.rb
+++ b/spec/rubocop/cop/style/percent_literal_delimiters_spec.rb
@@ -4,20 +4,28 @@ describe RuboCop::Cop::Style::PercentLiteralDelimiters, :config do
   subject(:cop) { described_class.new(config) }
 
   let(:cop_config) do
-    {
-      'PreferredDelimiters' => {
-        '%'  => '[]',
-        '%i' => '[]',
-        '%I' => '[]',
-        '%q' => '[]',
-        '%Q' => '[]',
-        '%r' => '[]',
-        '%s' => '[]',
-        '%w' => '[]',
-        '%W' => '[]',
-        '%x' => '[]'
+    { 'PreferredDelimiters' => { 'all' => '[]' } }
+  end
+
+  context '`all` override' do
+    let(:cop_config) do
+      {
+        'PreferredDelimiters' => {
+          'all' => '[]',
+          '%'   => '()'
+        }
       }
-    }
+    end
+
+    it 'allows all preferred delimiters to be set with one key' do
+      inspect_source(cop, '%w[string] + %i[string]')
+      expect(cop.offenses).to be_empty
+    end
+
+    it 'allows individual preferred delimiters to override `all`' do
+      inspect_source(cop, '%w[string] + [%(string)]')
+      expect(cop.offenses).to be_empty
+    end
   end
 
   context '`%` interpolated string' do


### PR DESCRIPTION
Oftentimes people want to set the default percent literal delimiter to [], but have to override every available option in order to get that behavior. This commit adds the ability to specify an 'all' key that will specify the default for every possible delimiter, which you can then overwrite with others.