### PR TITLE
[Fix #3981] Allow NumericLiterals to be less strict

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### New features
 
+* [#4045](https://github.com/bbatsov/rubocop/pull/4045): Add new configuration `Strict` for `Style/NumericLiteral` to make the change to this cop in 0.47.0 configurable. ([@iGEL][])
 * [#3893](https://github.com/bbatsov/rubocop/issues/3893): Add a new configuration, `IncludeActiveSupportAliases`, to `Performance/DoublStartEndWith`. This configuration will check for ActiveSupport's `starts_with?` and `ends_with?`. ([@rrosenblum][])
 * [#3889](https://github.com/bbatsov/rubocop/pull/3889): Add new `Style/EmptyLineAfterMagicComment` cop. ([@backus][])
 * [#3800](https://github.com/bbatsov/rubocop/issues/3800): Make `Style/EndOfLine` configurable with `lf`, `crlf`, and `native` (default) styles. ([@jonas054][])

--- a/manual/cops_style.md
+++ b/manual/cops_style.md
@@ -3884,6 +3884,25 @@ Enabled | Yes
 This cop checks for big numeric literals without _ between groups
 of digits in them.
 
+### Example
+
+```ruby
+# bad
+
+1000000
+1_00_000
+1_0000
+
+# good
+
+1_000_000
+1000
+
+# good unless Strict is set
+
+10_000_00 # typical representation of $10,000 in cents
+```
+
 ### Important attributes
 
 Attribute | Value

--- a/spec/rubocop/cop/style/numeric_literals_spec.rb
+++ b/spec/rubocop/cop/style/numeric_literals_spec.rb
@@ -18,9 +18,15 @@ describe RuboCop::Cop::Style::NumericLiterals, :config do
     expect(cop.config_to_allow_offenses).to eq('MinDigits' => 7)
   end
 
+  it 'accepts integers with less than three places at the end' do
+    inspect_source(cop, ['a = 123_456_789_00',
+                         'b = 819_2'])
+    expect(cop.offenses).to be_empty
+  end
+
   it 'registers an offense for an integer with misplaced underscore' do
     inspect_source(cop, ['a = 123_456_78_90_00',
-                         'b = 819_2'])
+                         'b = 1_8192'])
     expect(cop.offenses.size).to eq(2)
     expect(cop.config_to_allow_offenses).to eq('Enabled' => false)
   end
@@ -77,5 +83,21 @@ describe RuboCop::Cop::Style::NumericLiterals, :config do
   it 'autocorrects negative floating-point numbers' do
     corrected = autocorrect_source(cop, ['a = -123456.78'])
     expect(corrected).to eq 'a = -123_456.78'
+  end
+
+  context 'strict' do
+    let(:cop_config) do
+      {
+        'MinDigits' => 5,
+        'Strict' => true
+      }
+    end
+
+    it 'registers an offense for an integer with misplaced underscore' do
+      inspect_source(cop, ['a = 123_456_78_90_00',
+                           'b = 81_92'])
+      expect(cop.offenses.size).to eq(2)
+      expect(cop.config_to_allow_offenses).to eq('Enabled' => false)
+    end
   end
 end


### PR DESCRIPTION
This introduces a new configuration option for Style/NumericLiteral called `AllowLessPlacesAtEnd`, which allows numbers which don't have 3 places in the last group separated with underscores. This is useful when specifying monetary values in cents (e.g. $123,456.78 as `Money.new(123_456_78)` instead of `Money.new(12_345_678)`).

I also updated the message to make clearer, that the underscores should be used as a decimal mark.

This was the behavior of RuboCop until the 0.47.0 release, see #3749 for the change and #3981 for the issue discussing that change.

Questions:

* Should it be the default? As it was the behavior until recently, I'd say yes.
* Do I need to update the documentation for the new option and how do I do it? I ran the rake task, but nothing changed.

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Used the same coding conventions as the rest of the project.
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] All tests are passing.
* [x] The new code doesn't generate RuboCop offenses.
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Updated cop documentation with `rake generate_cops_documentation` (required only when you've added a new cop or changed the configuration/documentation of an existing cop).

[1]: http://chris.beams.io/posts/git-commit/
