### PR TITLE
Style/EmptyLiteral autocorrect bugfix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,6 +53,7 @@
 * [#4066](https://github.com/bbatsov/rubocop/issues/4066): Register an offense in `Lint/ShadowedException` when an exception is shadowed and there is an implicit begin. ([@rrosenblum][])
 * [#4001](https://github.com/bbatsov/rubocop/issues/4001): Lint/UnneededDisable of Metrics/LineLength that isn't unneeded. ([@wkurniawan07][])
 * [#3960](https://github.com/bbatsov/rubocop/issues/3960): Let `Include`/`Exclude` paths in all files beginning with `.rubocop` be relative to the configuration file's directory and not to the current directory. ([@jonas054][])
+* [#4049](https://github.com/bbatsov/rubocop/pull/4049): Bugfix for `Style/EmptyLiteral` cop. ([@ota42y][])
 
 ## 0.47.1 (2017-01-18)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,6 @@
 * [#4038](https://github.com/bbatsov/rubocop/pull/4038): Allow `default` key in the `Style/PercentLiteralDelimiters` cop config to set all preferred delimiters. ([@kddeisz][])
 * Add `IgnoreMacros` option to `Style/MethodCallWithArgsParentheses`. ([@drenmi][])
 * [#3937](https://github.com/bbatsov/rubocop/issues/3937): Add new `Rails/ActiveSupportAliases` cop. ([@tdeo][])
-* [#4049](https://github.com/bbatsov/rubocop/pull/4049): Bugfix for `Style/EmptyLiteral` cop. ([@ota42y][])
 
 ### Changes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@
 * [#4038](https://github.com/bbatsov/rubocop/pull/4038): Allow `default` key in the `Style/PercentLiteralDelimiters` cop config to set all preferred delimiters. ([@kddeisz][])
 * Add `IgnoreMacros` option to `Style/MethodCallWithArgsParentheses`. ([@drenmi][])
 * [#3937](https://github.com/bbatsov/rubocop/issues/3937): Add new `Rails/ActiveSupportAliases` cop. ([@tdeo][])
+* [#4049](https://github.com/bbatsov/rubocop/pull/4049): Bugfix for `Style/EmptyLiteral` cop. ([@ota42y][])
 
 ### Changes
 
@@ -2662,3 +2663,4 @@
 [@droptheplot]: https://github.com/droptheplot
 [@wkurniawan07]: https://github.com/wkurniawan07
 [@kddeisz]: https://github.com/kddeisz
+[@ota42y]: https://github.com/ota42y

--- a/lib/rubocop/cop/style/empty_literal.rb
+++ b/lib/rubocop/cop/style/empty_literal.rb
@@ -21,9 +21,9 @@ module RuboCop
                          '(block (send (const nil :Hash) :new) args _)'
 
         def on_send(node)
-          add_offense(node, :expression, ARR_MSG) if offence_array_node?(node)
+          add_offense(node, :expression, ARR_MSG) if offense_array_node?(node)
 
-          add_offense(node, :expression, HASH_MSG) if offence_hash_node?(node)
+          add_offense(node, :expression, HASH_MSG) if offense_hash_node?(node)
 
           str_node(node) do
             return if frozen_string_literals_enabled?
@@ -76,21 +76,21 @@ module RuboCop
           end
         end
 
-        def offence_array_node?(node)
+        def offense_array_node?(node)
           array_node(node) && !array_with_block(node.parent)
         end
 
-        def offence_hash_node?(node)
+        def offense_hash_node?(node)
           # If Hash.new takes a block, it can't be changed to {}.
           hash_node(node) && !hash_with_block(node.parent)
         end
 
         def correction(node)
-          if offence_array_node?(node)
+          if offense_array_node?(node)
             '[]'
           elsif str_node(node)
             preferred_string_literal
-          elsif offence_hash_node?(node)
+          elsif offense_hash_node?(node)
             if first_argument_unparenthesized?(node)
               # `some_method {}` is not same as `some_method Hash.new`
               # because the braces are interpreted as a block. We will have

--- a/lib/rubocop/cop/style/empty_literal.rb
+++ b/lib/rubocop/cop/style/empty_literal.rb
@@ -19,7 +19,7 @@ module RuboCop
                          '(block (send (const nil :Array) :new) args _)'
 
         def on_send(node)
-          array_node(node) { add_offense(node, :expression, ARR_MSG) }
+          add_offense(node, :expression, ARR_MSG) if offence_array_node?(node)
 
           hash_node(node) do
             # If Hash.new takes a block, it can't be changed to {}.
@@ -83,12 +83,12 @@ module RuboCop
           end
         end
 
-        def array_need_correction?(node)
+        def offence_array_node?(node)
           array_node(node) && !array_with_block(node.parent)
         end
 
         def correction(node)
-          if array_need_correction?(node)
+          if offence_array_node?(node)
             '[]'
           elsif str_node(node)
             preferred_string_literal

--- a/lib/rubocop/cop/style/empty_literal.rb
+++ b/lib/rubocop/cop/style/empty_literal.rb
@@ -37,9 +37,12 @@ module RuboCop
         end
 
         def autocorrect(node)
+          result = correction(node)
+
+          return unless result
+
           lambda do |corrector|
-            result = correction(node)
-            corrector.replace(replacement_range(node), result) if result
+            corrector.replace(replacement_range(node), result)
           end
         end
 

--- a/lib/rubocop/cop/style/empty_literal.rb
+++ b/lib/rubocop/cop/style/empty_literal.rb
@@ -17,16 +17,13 @@ module RuboCop
         def_node_matcher :str_node, '(send (const nil :String) :new)'
         def_node_matcher :array_with_block,
                          '(block (send (const nil :Array) :new) args _)'
+        def_node_matcher :hash_with_block,
+                         '(block (send (const nil :Hash) :new) args _)'
 
         def on_send(node)
           add_offense(node, :expression, ARR_MSG) if offence_array_node?(node)
 
-          hash_node(node) do
-            # If Hash.new takes a block, it can't be changed to {}.
-            return if node.parent && node.parent.block_type?
-
-            add_offense(node, :expression, HASH_MSG)
-          end
+          add_offense(node, :expression, HASH_MSG) if offence_hash_node?(node)
 
           str_node(node) do
             return if frozen_string_literals_enabled?
@@ -37,12 +34,8 @@ module RuboCop
         end
 
         def autocorrect(node)
-          result = correction(node)
-
-          return unless result
-
           lambda do |corrector|
-            corrector.replace(replacement_range(node), result)
+            corrector.replace(replacement_range(node), correction(node))
           end
         end
 
@@ -87,12 +80,17 @@ module RuboCop
           array_node(node) && !array_with_block(node.parent)
         end
 
+        def offence_hash_node?(node)
+          # If Hash.new takes a block, it can't be changed to {}.
+          hash_node(node) && !hash_with_block(node.parent)
+        end
+
         def correction(node)
           if offence_array_node?(node)
             '[]'
           elsif str_node(node)
             preferred_string_literal
-          elsif hash_node(node)
+          elsif offence_hash_node?(node)
             if first_argument_unparenthesized?(node)
               # `some_method {}` is not same as `some_method Hash.new`
               # because the braces are interpreted as a block. We will have

--- a/spec/rubocop/cop/style/empty_literal_spec.rb
+++ b/spec/rubocop/cop/style/empty_literal_spec.rb
@@ -27,6 +27,24 @@ describe RuboCop::Cop::Style::EmptyLiteral do
       new_source = autocorrect_source(cop, 'test = Array.new')
       expect(new_source).to eq('test = []')
     end
+
+    it 'not auto-corrects Array.new with block' do
+      source = 'test = Array.new { 1 }'
+      new_source = autocorrect_source(cop, source)
+      expect(new_source).to eq(source)
+    end
+
+    it 'auto-corrects Array.new in block' do
+      source = 'puts { Array.new }'
+      new_source = autocorrect_source(cop, source)
+      expect(new_source).to eq('puts { [] }')
+    end
+
+    it 'not auto-corrects Array.new with block in other block' do
+      source = 'puts { Array.new { 1 } }'
+      new_source = autocorrect_source(cop, source)
+      expect(new_source).to eq(source)
+    end
   end
 
   describe 'Empty Hash' do

--- a/spec/rubocop/cop/style/empty_literal_spec.rb
+++ b/spec/rubocop/cop/style/empty_literal_spec.rb
@@ -28,7 +28,7 @@ describe RuboCop::Cop::Style::EmptyLiteral do
       expect(new_source).to eq('test = []')
     end
 
-    it 'not auto-corrects Array.new with block' do
+    it 'does not auto-correct Array.new with block' do
       source = 'test = Array.new { 1 }'
       new_source = autocorrect_source(cop, source)
       expect(new_source).to eq(source)
@@ -40,7 +40,7 @@ describe RuboCop::Cop::Style::EmptyLiteral do
       expect(new_source).to eq('puts { [] }')
     end
 
-    it 'not auto-corrects Array.new with block in other block' do
+    it 'does not auto-correct Array.new with block in other block' do
       source = 'puts { Array.new { 1 } }'
       new_source = autocorrect_source(cop, source)
       expect(new_source).to eq(source)

--- a/spec/rubocop/cop/style/empty_literal_spec.rb
+++ b/spec/rubocop/cop/style/empty_literal_spec.rb
@@ -31,19 +31,19 @@ describe RuboCop::Cop::Style::EmptyLiteral do
     it 'does not registers an offence Array.new with block' do
       source = 'test = Array.new { 1 }'
       inspect_source(cop, source)
-      expect(cop.offenses.size).to eq(0)
+      expect(cop.offenses).to be_empty
     end
 
     it 'registers an offence when Array.new in block' do
       source = 'puts { Array.new }'
-      inspect_source(cop, source)
-      expect(cop.offenses.size).to eq(1)
+      new_source = autocorrect_source(cop, source)
+      expect(new_source).to eq 'puts { [] }'
     end
 
     it 'does not register Array.new with block in other block' do
       source = 'puts { Array.new { 1 } }'
       inspect_source(cop, source)
-      expect(cop.offenses.size).to eq(0)
+      expect(cop.offenses).to be_empty
     end
   end
 
@@ -75,6 +75,12 @@ describe RuboCop::Cop::Style::EmptyLiteral do
     it 'auto-corrects Hash.new to {}' do
       new_source = autocorrect_source(cop, 'Hash.new')
       expect(new_source).to eq('{}')
+    end
+
+    it 'auto-corrects Hash.new in block ' do
+      source = 'puts { Hash.new }'
+      new_source = autocorrect_source(cop, source)
+      expect(new_source).to eq 'puts { {} }'
     end
 
     it 'auto-corrects Hash.new to {} in various contexts' do

--- a/spec/rubocop/cop/style/empty_literal_spec.rb
+++ b/spec/rubocop/cop/style/empty_literal_spec.rb
@@ -28,16 +28,16 @@ describe RuboCop::Cop::Style::EmptyLiteral do
       expect(new_source).to eq('test = []')
     end
 
-    it 'does not registers an offence Array.new with block' do
-      source = 'test = Array.new { 1 }'
-      inspect_source(cop, source)
-      expect(cop.offenses).to be_empty
-    end
-
-    it 'registers an offence when Array.new in block' do
+    it 'auto-corrects Array.new in block in block' do
       source = 'puts { Array.new }'
       new_source = autocorrect_source(cop, source)
       expect(new_source).to eq 'puts { [] }'
+    end
+
+    it 'does not registers an offense Array.new with block' do
+      source = 'test = Array.new { 1 }'
+      inspect_source(cop, source)
+      expect(cop.offenses).to be_empty
     end
 
     it 'does not register Array.new with block in other block' do

--- a/spec/rubocop/cop/style/empty_literal_spec.rb
+++ b/spec/rubocop/cop/style/empty_literal_spec.rb
@@ -28,22 +28,22 @@ describe RuboCop::Cop::Style::EmptyLiteral do
       expect(new_source).to eq('test = []')
     end
 
-    it 'does not auto-correct Array.new with block' do
+    it 'does not registers an offence Array.new with block' do
       source = 'test = Array.new { 1 }'
-      new_source = autocorrect_source(cop, source)
-      expect(new_source).to eq(source)
+      inspect_source(cop, source)
+      expect(cop.offenses.size).to eq(0)
     end
 
-    it 'auto-corrects Array.new in block' do
+    it 'registers an offence when Array.new in block' do
       source = 'puts { Array.new }'
-      new_source = autocorrect_source(cop, source)
-      expect(new_source).to eq('puts { [] }')
+      inspect_source(cop, source)
+      expect(cop.offenses.size).to eq(1)
     end
 
-    it 'does not auto-correct Array.new with block in other block' do
+    it 'does not register Array.new with block in other block' do
       source = 'puts { Array.new { 1 } }'
-      new_source = autocorrect_source(cop, source)
-      expect(new_source).to eq(source)
+      inspect_source(cop, source)
+      expect(cop.offenses.size).to eq(0)
     end
   end
 


### PR DESCRIPTION
Style/EmptyLiteral autocorrect `Array.new` to `[]`.

This code is valid code
`Array.new { 1 }`
but, autocorrect change to this and it's invalid code.
`[] { 1 }`

So, I change ignore autocorrect.
I think, this is bad code (`Array.new { 1 }` equal to `[]`) so I fix autocorrect only.

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Used the same coding conventions as the rest of the project.
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] All tests are passing.
* [x] The new code doesn't generate RuboCop offenses.
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Updated cop documentation with `rake generate_cops_documentation` (required only when you've added a new cop or changed the configuration/documentation of an existing cop).

[1]: http://chris.beams.io/posts/git-commit/
