### PR TITLE
[Fix #3917] Rails/FilePath Match nodes in a method call only once

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,7 @@
 * [#4006](https://github.com/bbatsov/rubocop/issues/4006): Prevent `Style/WhileUntilModifier` from breaking on a multiline modifier. ([@drenmi][])
 * [#3345](https://github.com/bbatsov/rubocop/issues/3345): Allow `Style/WordArray`'s `WordRegex` configuration value to be an instance of `String`. ([@mikegee][])
 * [#4013](https://github.com/bbatsov/rubocop/pull/4013): Follow redirects for RemoteConfig. ([@buenaventure][])
+* [#3917](https://github.com/bbatsov/rubocop/issues/3917): Rails/FilePath Match nodes in a method call only once. ([@unmanbearpig][])
 
 ## 0.47.1 (2017-01-18)
 

--- a/lib/rubocop/cop/rails/file_path.rb
+++ b/lib/rubocop/cop/rails/file_path.rb
@@ -17,11 +17,7 @@ module RuboCop
       class FilePath < Cop
         MSG = 'Please use `Rails.root.join(\'path\', \'to\')` instead.'.freeze
 
-        def_node_search :file_join_nodes, <<-PATTERN
-          (send (const nil :File) :join ...)
-        PATTERN
-
-        def_node_search :file_join_nodes?, <<-PATTERN
+        def_node_matcher :file_join_nodes?, <<-PATTERN
           (send (const nil :File) :join ...)
         PATTERN
 
@@ -29,7 +25,7 @@ module RuboCop
           (send (const nil :Rails) :root)
         PATTERN
 
-        def_node_search :rails_root_join_nodes, <<-PATTERN
+        def_node_matcher :rails_root_join_nodes?, <<-PATTERN
           (send (send (const nil :Rails) :root) :join ...)
         PATTERN
 
@@ -47,20 +43,15 @@ module RuboCop
 
         def check_for_file_join_with_rails_root(node)
           return unless file_join_nodes?(node)
-          return unless file_join_nodes(node).map(&:method_args)
-                                             .flatten
-                                             .any? { |e| rails_root_nodes?(e) }
+          return unless node.method_args.any? { |e| rails_root_nodes?(e) }
 
           register_offense(node)
         end
 
         def check_for_rails_root_join_with_slash_separated_path(node)
           return unless rails_root_nodes?(node)
-          return unless rails_root_join_nodes(node).map(&:method_args)
-                                                   .flatten
-                                                   .any? do |arg|
-                                                     arg.source =~ %r{/}
-                                                   end
+          return unless rails_root_join_nodes?(node)
+          return unless node.method_args.any? { |arg| arg.source =~ %r{/} }
 
           register_offense(node)
         end

--- a/spec/rubocop/cop/rails/file_path_spec.rb
+++ b/spec/rubocop/cop/rails/file_path_spec.rb
@@ -40,4 +40,22 @@ describe RuboCop::Cop::Rails::FilePath do
       expect(cop.offenses.size).to eq(1)
     end
   end
+
+  context 'Rails.root is used as a method argument' do
+    let(:source) { 'foo(bar(File.join(Rails.root, "app", "models")))' }
+
+    it 'registers an offense once' do
+      inspect_source(cop, source)
+      expect(cop.offenses.size).to eq(1)
+    end
+  end
+
+  context 'Rails.root.join used as an argument' do
+    let(:source) { 'foo(Rails.root.join(\'app/models\'))' }
+
+    it 'registers an offense once' do
+      inspect_source(cop, source)
+      expect(cop.offenses.size).to eq(1)
+    end
+  end
 end


### PR DESCRIPTION
When we were using `def_node_search` it was matching both the parent and a child node when used in a method call. We only care about the child, and it seems like `def_node_macher` does that job.