### PR TITLE
[Fix #4047] Allow `find_zone` and `find_zone!` methods in `Rails/TimeZone`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,7 @@
 * [#4006](https://github.com/bbatsov/rubocop/issues/4006): Prevent `Style/WhileUntilModifier` from breaking on a multiline modifier. ([@drenmi][])
 * [#3345](https://github.com/bbatsov/rubocop/issues/3345): Allow `Style/WordArray`'s `WordRegex` configuration value to be an instance of `String`. ([@mikegee][])
 * [#4013](https://github.com/bbatsov/rubocop/pull/4013): Follow redirects for RemoteConfig. ([@buenaventure][])
+* [#4047](https://github.com/bbatsov/rubocop/issues/4047): Allow `find_zone` and `find_zone!` methods in `Rails/TimeZone`. ([@attilahorvath][])
 
 ## 0.47.1 (2017-01-18)
 
@@ -2645,3 +2646,4 @@
 [@dabroz]: https://github.com/dabroz
 [@buenaventure]: https://github.com/buenaventure
 [@dorian]: https://github.com/dorian
+[@attilahorvath]: https://github.com/attilahorvath

--- a/lib/rubocop/cop/rails/time_zone.rb
+++ b/lib/rubocop/cop/rails/time_zone.rb
@@ -42,6 +42,8 @@ module RuboCop
 
         TIMECLASS = [:Time, :DateTime].freeze
 
+        GOOD_METHODS = [:zone, :zone_default, :find_zone, :find_zone!].freeze
+
         DANGEROUS_METHODS = [:now, :local, :new, :strftime,
                              :parse, :at, :current].freeze
 
@@ -163,9 +165,9 @@ module RuboCop
 
         def good_methods
           if style == :strict
-            [:zone, :zone_default]
+            GOOD_METHODS
           else
-            [:zone, :zone_default, :current] + ACCEPTED_METHODS
+            GOOD_METHODS + [:current] + ACCEPTED_METHODS
           end
         end
 

--- a/spec/rubocop/cop/rails/time_zone_spec.rb
+++ b/spec/rubocop/cop/rails/time_zone_spec.rb
@@ -186,6 +186,36 @@ describe RuboCop::Cop::Rails::TimeZone, :config do
       expect(cop.offenses).to be_empty
     end
 
+    it 'accepts Time.find_zone(time_zone).now' do
+      inspect_source(cop, "Time.find_zone('EST').now")
+      expect(cop.offenses).to be_empty
+    end
+
+    it 'accepts Time.find_zone(time_zone).today' do
+      inspect_source(cop, "Time.find_zone('EST').today")
+      expect(cop.offenses).to be_empty
+    end
+
+    it 'accepts Time.find_zone(time_zone).local' do
+      inspect_source(cop, "Time.find_zone('EST').local(2012, 6, 10, 12, 00)")
+      expect(cop.offenses).to be_empty
+    end
+
+    it 'accepts Time.find_zone!(time_zone).now' do
+      inspect_source(cop, "Time.find_zone!('EST').now")
+      expect(cop.offenses).to be_empty
+    end
+
+    it 'accepts Time.find_zone!(time_zone).today' do
+      inspect_source(cop, "Time.find_zone!('EST').today")
+      expect(cop.offenses).to be_empty
+    end
+
+    it 'accepts Time.find_zone!(time_zone).local' do
+      inspect_source(cop, "Time.find_zone!('EST').local(2012, 6, 10, 12, 00)")
+      expect(cop.offenses).to be_empty
+    end
+
     described_class::DANGEROUS_METHODS.each do |a_method|
       it "accepts Some::Time.#{a_method}" do
         inspect_source(cop, "Some::Time.#{a_method}")
@@ -231,6 +261,16 @@ describe RuboCop::Cop::Rails::TimeZone, :config do
 
       it "accepts #{klass}.zone_default.now" do
         inspect_source(cop, "#{klass}.zone_default.now")
+        expect(cop.offenses).to be_empty
+      end
+
+      it "accepts #{klass}.find_zone(time_zone).now" do
+        inspect_source(cop, "#{klass}.find_zone('EST').now")
+        expect(cop.offenses).to be_empty
+      end
+
+      it "accepts #{klass}.find_zone!(time_zone).now" do
+        inspect_source(cop, "#{klass}.find_zone!('EST').now")
         expect(cop.offenses).to be_empty
       end
 


### PR DESCRIPTION
The `Rails/TimeZone` cop forbids the usage of `#find_zone` and `#find_zone!` in Rails code, wrongly assuming that they would produce a `Time` object without a time zone.

However, these two methods are perfectly safe to use. In fact, they produce the same results as `#zone` or `#default_zone` would but they let you specify the requested time zone as a string, instead of reading it from the configuration.

The methods are documented [here in the Rails docs](http://edgeapi.rubyonrails.org/classes/Time.html#method-c-find_zone).

For some usage examples, see [this StackOverflow answer](http://stackoverflow.com/a/13447137/3463845).

-----------------

Before submitting the PR make sure the following are checked:

* [X] Wrote [good commit messages][1].
* [X] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [X] Used the same coding conventions as the rest of the project.
* [X] Feature branch is up-to-date with `master` (if not - rebase it).
* [X] Squashed related commits together.
* [X] Added tests.
* [X] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [X] All tests are passing.
* [X] The new code doesn't generate RuboCop offenses.
* [X] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [X] Updated cop documentation with `rake generate_cops_documentation` (required only when you've added a new cop or changed the configuration/documentation of an existing cop).

[1]: http://chris.beams.io/posts/git-commit/
