### PR TITLE
Add parameters count to offense message for `Metrics/ParameterLists` cop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@
 * Add auto-correct to `Performance/DoubleStartEndWith`. ([@rrosenblum][])
 * [#3951](https://github.com/bbatsov/rubocop/pull/3951): Make `Rails/Date` cop to register an offence for a string without timezone. ([@sinsoku][])
 * [#4020](https://github.com/bbatsov/rubocop/pull/4020): Fixed `new_cop.rake` suggested path. ([@dabroz][])
+* [#4055](https://github.com/bbatsov/rubocop/pull/4055): Add parameters count to offense message for `Metrics/ParameterLists` cop. ([@pocke][])
 
 ### Bug fixes
 

--- a/lib/rubocop/cop/metrics/parameter_lists.rb
+++ b/lib/rubocop/cop/metrics/parameter_lists.rb
@@ -10,13 +10,14 @@ module RuboCop
       class ParameterLists < Cop
         include ConfigurableMax
 
-        MSG = 'Avoid parameter lists longer than %d parameters.'.freeze
+        MSG = 'Avoid parameter lists longer than %d parameters. [%d/%d]'.freeze
 
         def on_args(node)
           count = args_count(node)
           return unless count > max_params
 
-          add_offense(node, :expression, format(MSG, max_params)) do
+          message = format(MSG, max_params, count, max_params)
+          add_offense(node, :expression, message) do
             self.max = count
           end
         end

--- a/spec/rubocop/cop/metrics/parameter_lists_spec.rb
+++ b/spec/rubocop/cop/metrics/parameter_lists_spec.rb
@@ -15,6 +15,9 @@ describe RuboCop::Cop::Metrics::ParameterLists, :config do
     inspect_source(cop, ['def meth(a, b, c, d, e)',
                          'end'])
     expect(cop.offenses.size).to eq(1)
+    expect(cop.messages).to eq(
+      ['Avoid parameter lists longer than 4 parameters. [5/4]']
+    )
     expect(cop.config_to_allow_offenses).to eq('Max' => 5)
   end
 
@@ -28,6 +31,9 @@ describe RuboCop::Cop::Metrics::ParameterLists, :config do
     it 'counts keyword arguments as well' do
       inspect_source(cop, ['def meth(a, b, c, d: 1, e: 2)',
                            'end'])
+      expect(cop.messages).to eq(
+        ['Avoid parameter lists longer than 4 parameters. [5/4]']
+      )
       expect(cop.offenses.size).to eq(1)
     end
   end


### PR DESCRIPTION
Most Metrics cops display `[%d/%d]`.
However, `Metrics/ParameterLists` and `Metrics/BlockNesting` don't display this.

For example:

```sh
$ rubocop --only Metrics -D
Inspecting 1 file
C

Offenses:

test.rb:1:1: C: Metrics/MethodLength: Method has too many lines. [12/10]
def foo(x, y, z, a, b, c, d, e) ...
^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
test.rb:1:8: C: Metrics/ParameterLists: Avoid parameter lists longer than 5 parameters.
def foo(x, y, z, a, b, c, d, e)
       ^^^^^^^^^^^^^^^^^^^^^^^^
test.rb:5:9: C: Metrics/BlockNesting: Avoid more than 3 levels of block nesting.
        if cond4 ...
        ^^^^^^^^

1 file inspected, 3 offenses detected
```

I think those cops should display count/max.
However, `Metrics/BlockNesting` cop doesn't have the count value.
So, this change make to display the count only `Metrics/ParameterLists` cop.


-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Used the same coding conventions as the rest of the project.
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [ ] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] All tests are passing.
* [x] The new code doesn't generate RuboCop offenses.
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Updated cop documentation with `rake generate_cops_documentation` (required only when you've added a new cop or changed the configuration/documentation of an existing cop).

[1]: http://chris.beams.io/posts/git-commit/
