### PR TITLE
[Fix #3457] Clear a warning and prevent regression

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,7 @@
 * [#3917](https://github.com/bbatsov/rubocop/issues/3917): Rails/FilePath Match nodes in a method call only once. ([@unmanbearpig][])
 * [#3673](https://github.com/bbatsov/rubocop/issues/3673): Fix regression on `Style/RedundantSelf` when assigning to same local variable. ([@bankair][])
 * [#4047](https://github.com/bbatsov/rubocop/issues/4047): Allow `find_zone` and `find_zone!` methods in `Rails/TimeZone`. ([@attilahorvath][])
+* [#3457](https://github.com/bbatsov/rubocop/issues/3457): Clear a warning and prevent new warnings. ([@mikegee][])
 
 ## 0.47.1 (2017-01-18)
 

--- a/lib/rubocop/magic_comment.rb
+++ b/lib/rubocop/magic_comment.rb
@@ -121,11 +121,10 @@ module RuboCop
     #
     # @example Emacs style comment
     #   comment = RuboCop::MagicComment.parse(
-    #     '# -*- encoding: ASCII-8BIT; frozen_string_literal: true -*-'
+    #     '# -*- encoding: ASCII-8BIT -*-'
     #   )
     #
-    #   comment.encoding              # => 'ascii-8bit'
-    #   comment.frozen_string_literal # => true
+    #   comment.encoding # => 'ascii-8bit'
     #
     # @see https://www.gnu.org/software/emacs/manual/html_node/emacs/Specify-Coding.html
     # @see https://git.io/vMCXh Emacs handling in Ruby's parse.y

--- a/spec/project_spec.rb
+++ b/spec/project_spec.rb
@@ -170,4 +170,16 @@ describe 'RuboCop Project' do
       end
     end
   end
+
+  describe 'requiring all of `lib` with verbose warnings enabled' do
+    it 'emits no warnings' do
+      whitelisted = ->(line) { line =~ /warning: private attribute\?$/ }
+
+      warnings = `ruby -Ilib -w -W2 lib/rubocop.rb 2>&1`
+                 .lines
+                 .grep(%r{/lib/rubocop}) # ignore warnings from dependencies
+                 .reject(&whitelisted)
+      expect(warnings).to be_empty
+    end
+  end
 end


### PR DESCRIPTION
This adds a test that fails if loading Rubocop's lib files emits any warnings.

The documentation for `MagicComment` produced:
```
lib/rubocop/magic_comment.rb:124: warning: `frozen_string_literal' is ignored after any tokens
```

fixes #3457

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Used the same coding conventions as the rest of the project.
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] All tests are passing.
* [x] The new code doesn't generate RuboCop offenses.
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Updated cop documentation with `rake generate_cops_documentation` (required only when you've added a new cop or changed the configuration/documentation of an existing cop).

[1]: http://chris.beams.io/posts/git-commit/