### PR TITLE
Fix documentation for `Style/MixinGrouping`

### DIFF
--- a/lib/rubocop/cop/style/mixin_grouping.rb
+++ b/lib/rubocop/cop/style/mixin_grouping.rb
@@ -18,8 +18,8 @@ module RuboCop
       #
       #   @good
       #   class Foo
-      #     include Bar
       #     include Qox
+      #     include Bar
       #   end
       #
       #   EnforcedStyle: grouped
@@ -32,7 +32,7 @@ module RuboCop
       #
       #   @good
       #   class Foo
-      #     extend Bar, Qox
+      #     extend Qox, Bar
       #   end
       class MixinGrouping < Cop
         include ConfigurableEnforcedStyle
@@ -41,9 +41,7 @@ module RuboCop
         MSG = 'Put `%s` mixins in %s.'.freeze
 
         def on_send(node)
-          _reciever, method_name, *_args = *node
-
-          return unless MIXIN_METHODS.include?(method_name)
+          return unless MIXIN_METHODS.include?(node.method_name)
 
           check(node)
         end
@@ -65,9 +63,7 @@ module RuboCop
         end
 
         def check_separated_style(send_node)
-          _reciever, _method_name, *args = *send_node
-
-          return if args.one?
+          return if send_node.arguments.one?
 
           add_offense(send_node, :expression)
         end

--- a/manual/cops_style.md
+++ b/manual/cops_style.md
@@ -2994,8 +2994,8 @@ end
 
 # good
 class Foo
-  include Bar
   include Qox
+  include Bar
 end
 
 EnforcedStyle: grouped
@@ -3008,7 +3008,7 @@ end
 
 # good
 class Foo
-  extend Bar, Qox
+  extend Qox, Bar
 end
 ```
 


### PR DESCRIPTION
The documentation suggested changing this:

```
class Foo
  include Bar, Qox
end
```

to this:

```
class Foo
  include Qox
  include Bar
end
```

which, because of how the `#include` method works in Ruby, would result
in the ancestors being reversed.

This change fixes that.

-----------------

Before submitting the PR make sure the following are checked:

* [X] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [X] Used the same coding conventions as the rest of the project.
* [X] Feature branch is up-to-date with `master` (if not - rebase it).
* [X] Squashed related commits together.
* [ ] Added tests.
* [ ] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [X] All tests are passing.
* [X] The new code doesn't generate RuboCop offenses.
* [X] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [X] Updated cop documentation with `rake generate_cops_documentation` (required only when you've added a new cop or changed the configuration/documentation of an existing cop).

[1]: http://chris.beams.io/posts/git-commit/
