### PR TITLE
[Fix #4001] Fix bug in Metrics/LineLength

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,7 @@
 * [#4047](https://github.com/bbatsov/rubocop/issues/4047): Allow `find_zone` and `find_zone!` methods in `Rails/TimeZone`. ([@attilahorvath][])
 * [#3457](https://github.com/bbatsov/rubocop/issues/3457): Clear a warning and prevent new warnings. ([@mikegee][])
 * [#4066](https://github.com/bbatsov/rubocop/issues/4066): Register an offense in `Lint/ShadowedException` when an exception is shadowed and there is an implicit begin. ([@rrosenblum][])
+* [#4001](https://github.com/bbatsov/rubocop/issues/4001): Lint/UnneededDisable of Metrics/LineLength that isn't unneeded. ([@wkurniawan07][])
 
 ## 0.47.1 (2017-01-18)
 
@@ -2655,3 +2656,4 @@
 [@dorian]: https://github.com/dorian
 [@attilahorvath]: https://github.com/attilahorvath
 [@droptheplot]: https://github.com/droptheplot
+[@wkurniawan07]: https://github.com/wkurniawan07

--- a/lib/rubocop/comment_config.rb
+++ b/lib/rubocop/comment_config.rb
@@ -11,7 +11,7 @@ module RuboCop
     COPS_PATTERN = "(all|#{COP_NAMES_PATTERN})".freeze
 
     COMMENT_DIRECTIVE_REGEXP = Regexp.new(
-      ('\A# rubocop : ((?:dis|en)able)\b ' + COPS_PATTERN).gsub(' ', '\s*')
+      ('# rubocop : ((?:dis|en)able)\b ' + COPS_PATTERN).gsub(' ', '\s*')
     )
 
     CopAnalysis = Struct.new(:line_ranges, :start_line_number)

--- a/lib/rubocop/cop/metrics/line_length.rb
+++ b/lib/rubocop/cop/metrics/line_length.rb
@@ -159,7 +159,7 @@ module RuboCop
         end
 
         def line_length_without_directive(line)
-          before_comment, = line.split('#')
+          before_comment, = line.split(CommentConfig::COMMENT_DIRECTIVE_REGEXP)
           before_comment.rstrip.length
         end
 

--- a/spec/rubocop/cop/metrics/line_length_spec.rb
+++ b/spec/rubocop/cop/metrics/line_length_spec.rb
@@ -305,6 +305,38 @@ describe RuboCop::Cop::Metrics::LineLength, :config do
         inspect_source(cop, source)
         expect(cop.highlights).to eq(['bcd'])
       end
+
+      context 'and the source contains non-directive # as comment' do
+        let(:source) { <<-END }
+          aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa # bbbbbbbbbbbbbb # rubocop:enable Style/ClassVars'
+        END
+
+        it 'registers an offense for the line' do
+          inspect_source(cop, source)
+          expect(cop.offenses.size).to eq(1)
+        end
+
+        it 'highlights only the non-directive part' do
+          inspect_source(cop, source)
+          expect(cop.highlights).to eq(['bbbbbbb'])
+        end
+      end
+
+      context 'and the source contains non-directive #s as non-comment' do
+        let(:source) { <<-END }
+          LARGE_DATA_STRING_PATTERN = %r{\A([A-Za-z0-9\+\/#]*\={0,2})#([A-Za-z0-9\+\/#]*\={0,2})#([A-Za-z0-9\+\/#]*\={0,2})\z} # rubocop:disable LineLength
+        END
+
+        it 'registers an offense for the line' do
+          inspect_source(cop, source)
+          expect(cop.offenses.size).to eq(1)
+        end
+
+        it 'highlights only the non-directive part' do
+          inspect_source(cop, source)
+          expect(cop.highlights).to eq([']*={0,2})#([A-Za-z0-9+/#]*={0,2})z}'])
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
Metrics/LineLength had a bug when configured with “ignoreCopDirectives” set to true AND checking a line with both directive # and non-directive # present.

For example:
```rb
aaa … aaa # bbb … bbb # rubocop:disable CopName
```
where (aaa … aaa # bbb … bbb) exceeds the specified line length.
The cop would correctly detect it as a violation, but would return the extraneous characters AND the directive in the error message.

```rb
LARGE_DATA_STRING_PATTERN = %r{\A([A-Za-z0-9\+\/#]…)} # rubocop:disable CopName
```
The above line has # as part of regexp and the line is longer than the permissible line length before the directive.
The cop did not detect it as a violation.

**Outline of Solution**

The problem lied in two places, both of which are fixed:
1. Regex for directive comment marked with `\A` assertion. This causes things like `# NOT A DIRECTIVE # rubocop:disable CopName` not to be recognized as a cop directive.
1. When constructing an error message, the line is split by the first # found. This is a clear slip up: the line should be split by the directive comment regexp.

I realize that my solution for (1), which is removing the assertion altogether, might be an overkill and might cause some unintended regressions (the `\A` should be there for a reason, shouldn't it?). I would like to hear from the project team if this is the correct thing to do. If it is not, I will prepare an alternative solution.

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Used the same coding conventions as the rest of the project.
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] All tests are passing.
* [x] The new code doesn't generate RuboCop offenses.
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Updated cop documentation with `rake generate_cops_documentation` (required only when you've added a new cop or changed the configuration/documentation of an existing cop).

[1]: http://chris.beams.io/posts/git-commit/
