### PR TITLE
[WIP] Generate Style::InverseMethods document

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,7 +27,6 @@
 * [#3951](https://github.com/bbatsov/rubocop/pull/3951): Make `Rails/Date` cop to register an offence for a string without timezone. ([@sinsoku][])
 * [#4020](https://github.com/bbatsov/rubocop/pull/4020): Fixed `new_cop.rake` suggested path. ([@dabroz][])
 * [#4055](https://github.com/bbatsov/rubocop/pull/4055): Add parameters count to offense message for `Metrics/ParameterLists` cop. ([@pocke][])
-* [#4077](https://github.com/bbatsov/rubocop/pull/4077): Generate Style::InverseMethods document ([@ota42y][])
 
 ### Bug fixes
 
@@ -2654,4 +2653,3 @@
 [@buenaventure]: https://github.com/buenaventure
 [@dorian]: https://github.com/dorian
 [@attilahorvath]: https://github.com/attilahorvath
-[@ota42y]: https://github.com/ota42y

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@
 * [#3951](https://github.com/bbatsov/rubocop/pull/3951): Make `Rails/Date` cop to register an offence for a string without timezone. ([@sinsoku][])
 * [#4020](https://github.com/bbatsov/rubocop/pull/4020): Fixed `new_cop.rake` suggested path. ([@dabroz][])
 * [#4055](https://github.com/bbatsov/rubocop/pull/4055): Add parameters count to offense message for `Metrics/ParameterLists` cop. ([@pocke][])
+* [#4077](https://github.com/bbatsov/rubocop/pull/4077): Generate Style::InverseMethods document ([@ota42y][])
 
 ### Bug fixes
 
@@ -2653,3 +2654,4 @@
 [@buenaventure]: https://github.com/buenaventure
 [@dorian]: https://github.com/dorian
 [@attilahorvath]: https://github.com/attilahorvath
+[@ota42y]: https://github.com/ota42y

--- a/manual/cops_style.md
+++ b/manual/cops_style.md
@@ -2629,7 +2629,7 @@ foo == bar
 Attribute | Value
 --- | ---
 InverseMethods | {:any?=>:none?, :even?=>:odd?, :===>:!=, :=~=>:!~, :<=>:>=, :>=>:<=}
-InverseBlocks | {:select=>:reject}
+InverseBlocks | {:select=>:reject, :select!=>:reject!}
 
 
 ## Style/Lambda


### PR DESCRIPTION
There are change in InverseMethods doc.
So I execute `rake generate_cops_documentation`

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Used the same coding conventions as the rest of the project.
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [ ] All tests are passing.
* [x] The new code doesn't generate RuboCop offenses.
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Updated cop documentation with `rake generate_cops_documentation` (required only when you've added a new cop or changed the configuration/documentation of an existing cop).

[1]: http://chris.beams.io/posts/git-commit/
