### PR TITLE
Add limit to remote config handle response

### DIFF
--- a/lib/rubocop/remote_config.rb
+++ b/lib/rubocop/remote_config.rb
@@ -38,10 +38,10 @@ module RuboCop
         request['If-Modified-Since'] = File.stat(cache_path).mtime.rfc2822
       end
 
-      handle_response(http.request(request), &block)
+      handle_response(http.request(request), limit, &block)
     end
 
-    def handle_response(response, &block)
+    def handle_response(response, limit, &block)
       case response
       when Net::HTTPSuccess
         yield response


### PR DESCRIPTION
Correctly handle redirection when fetching a remote config with redirection. handle_response references the limit, but it doesn't get passed through so it fails with `undefined local variable or method `limit' for #<RuboCop::RemoteConfig:0x007fb91babb068>`

This PR just passes through the limit so we can actually make use of it.

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Used the same coding conventions as the rest of the project.
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [ ] Added tests.
* [ ] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [ ] All tests are passing.
* [x] The new code doesn't generate RuboCop offenses.
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [ ] Updated cop documentation with `rake generate_cops_documentation` (required only when you've added a new cop or changed the configuration/documentation of an existing cop).

[1]: http://chris.beams.io/posts/git-commit/
