### PR TITLE
Allow Marshal.load if argument is a Marshal.dump

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@
 * [#3951](https://github.com/bbatsov/rubocop/pull/3951): Make `Rails/Date` cop to register an offence for a string without timezone. ([@sinsoku][])
 * [#4020](https://github.com/bbatsov/rubocop/pull/4020): Fixed `new_cop.rake` suggested path. ([@dabroz][])
 * [#4055](https://github.com/bbatsov/rubocop/pull/4055): Add parameters count to offense message for `Metrics/ParameterLists` cop. ([@pocke][])
+* [#4081](https://github.com/bbatsov/rubocop/pull/4081): Allow `Marshal.load` if argument is a `Marshal.dump` in `Security/MarshalLoad` cop. ([@droptheplot][])
 
 ### Bug fixes
 
@@ -2653,3 +2654,4 @@
 [@buenaventure]: https://github.com/buenaventure
 [@dorian]: https://github.com/dorian
 [@attilahorvath]: https://github.com/attilahorvath
+[@droptheplot]: https://github.com/droptheplot

--- a/lib/rubocop/cop/security/marshal_load.rb
+++ b/lib/rubocop/cop/security/marshal_load.rb
@@ -15,11 +15,15 @@ module RuboCop
       #   # good
       #   Marshal.dump("{}")
       #
+      #   # okish - deep copy hack
+      #   Marshal.load(Marshal.dump({}))
+      #
       class MarshalLoad < Cop
         MSG = 'Avoid using `Marshal.%s`.'.freeze
 
         def_node_matcher :marshal_load, <<-END
-          (send (const nil :Marshal) ${:load :restore} ...)
+          (send (const nil :Marshal) ${:load :restore}
+          !(send (const nil :Marshal) :dump ...))
         END
 
         def on_send(node)

--- a/manual/cops_security.md
+++ b/manual/cops_security.md
@@ -74,6 +74,9 @@ Marshal.restore("{}")
 
 # good
 Marshal.dump("{}")
+
+# okish - deep copy hack
+Marshal.load(Marshal.dump({}))
 ```
 
 ### References

--- a/spec/rubocop/cop/security/marshal_load_spec.rb
+++ b/spec/rubocop/cop/security/marshal_load_spec.rb
@@ -21,5 +21,10 @@ describe RuboCop::Cop::Security::MarshalLoad, :config do
       expect(cop.offenses.size).to eq(1)
       expect(cop.offenses.first.message).to include("Marshal.#{method}")
     end
+
+    it "accepts Marshal.#{method} if argument is a Marshal.dump" do
+      inspect_source(cop, "Marshal.#{method}(Marshal.dump({}))")
+      expect(cop.offenses).to be_empty
+    end
   end
 end


### PR DESCRIPTION
Despite `Marshal.load(Marshal.dump(my_object))` being ugly and slow hack it's still an easiest way to make a deep copy of an object. And using result of `Marshal.dump` we can be sure there would be trustable code inside `Marshal.load`.

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Used the same coding conventions as the rest of the project.
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] All tests are passing.
* [x] The new code doesn't generate RuboCop offenses.
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Updated cop documentation with `rake generate_cops_documentation` (required only when you've added a new cop or changed the configuration/documentation of an existing cop).

[1]: http://chris.beams.io/posts/git-commit/
