### PR TITLE
Add new configuration `NumberOfEmptyLines` for `Style/EmptyLineBetweenDefs`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### New features
 
+* [#4083](https://github.com/bbatsov/rubocop/pull/4083): Add new configuration `NumberOfEmptyLines` for `Style/EmptyLineBetweenDefs`. ([@dorian][])
 * [#4045](https://github.com/bbatsov/rubocop/pull/4045): Add new configuration `Strict` for `Style/NumericLiteral` to make the change to this cop in 0.47.0 configurable. ([@iGEL][])
 * [#3893](https://github.com/bbatsov/rubocop/issues/3893): Add a new configuration, `IncludeActiveSupportAliases`, to `Performance/DoublStartEndWith`. This configuration will check for ActiveSupport's `starts_with?` and `ends_with?`. ([@rrosenblum][])
 * [#3889](https://github.com/bbatsov/rubocop/pull/3889): Add new `Style/EmptyLineAfterMagicComment` cop. ([@backus][])
@@ -19,6 +20,7 @@
 
 ### Changes
 
+* [#4083](https://github.com/bbatsov/rubocop/pull/4083): `Style/EmptyLineBetweenDefs` doesn't allow more than one empty line between method definitions by default (see `NumberOfEmptyLines`). ([@dorian][])
 * [#3997](https://github.com/bbatsov/rubocop/pull/3997): Include all ruby files by default and exclude non-ruby files. ([@dorian][])
 * [#4012](https://github.com/bbatsov/rubocop/pull/4012): Mark `foo[:bar]` as not complex in `Style/TernaryParentheses` cop with `require_parentheses_when_complex` style. ([@onk][])
 * [#3915](https://github.com/bbatsov/rubocop/issues/3915): Make configurable whitelist for `Lint/SafeNavigationChain` cop. ([@pocke][])

--- a/config/default.yml
+++ b/config/default.yml
@@ -433,6 +433,8 @@ Style/EmptyLineBetweenDefs:
   # If `true`, this parameter means that single line method definitions don't
   # need an empty line between them.
   AllowAdjacentOneLineDefs: false
+  # Can be array to specify minimum and maximum number of empty lines, e.g. [1, 2]
+  NumberOfEmptyLines: 1
 
 Style/EmptyLinesAroundBlockBody:
   EnforcedStyle: no_empty_lines

--- a/manual/cops_style.md
+++ b/manual/cops_style.md
@@ -1255,13 +1255,39 @@ Enabled by default | Supports autocorrection
 Enabled | Yes
 
 This cop checks whether method definitions are
-separated by empty lines.
+separated by one empty line.
+
+`NumberOfEmptyLines` can be and integer (e.g. 1 by default) or
+an array (e.g. [1, 2]) to specificy a minimum and a maximum of
+empty lines.
+
+`AllowAdjacentOneLineDefs` can be used to configure is adjacent
+one line methods definitions are an offense
+
+### Example
+
+```ruby
+# bad
+def a
+end
+def b
+end
+```
+```ruby
+# good
+def a
+end
+
+def b
+end
+```
 
 ### Important attributes
 
 Attribute | Value
 --- | ---
 AllowAdjacentOneLineDefs | false
+NumberOfEmptyLines | 1
 
 
 ### References


### PR DESCRIPTION
Add new configuration `NumberOfEmptyLines` for `Style/EmptyLineBetweenDefs` 

Allows config for multiple consecutive empty lines, e.g. `NumberOfEmptyLines: 2`.

```ruby
# bad
def a
end

def b
end

# good
def a
end


def b
end
```

Also supports minimum and maximum (e.g. `NumberOfEmptyLines: [1, 2]`)

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Used the same coding conventions as the rest of the project.
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [ ] All tests are passing.
* [x] The new code doesn't generate RuboCop offenses.
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Updated cop documentation with `rake generate_cops_documentation` (required only when you've added a new cop or changed the configuration/documentation of an existing cop).

[1]: http://chris.beams.io/posts/git-commit/