### PR TITLE
Remove empty trailing spaces in markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,6 @@
 [![OpenCollective](https://opencollective.com/rubocop/backers/badge.svg)](#open-collective-backers)
 [![OpenCollective](https://opencollective.com/rubocop/sponsors/badge.svg)](#open-collective-sponsors)
 
-
 <p align="center">
   <img src="https://raw.githubusercontent.com/bbatsov/rubocop/master/logo/rubo-logo-horizontal.png" alt="RuboCop Logo"/>
 </p>

--- a/manual/cops_bundler.md
+++ b/manual/cops_bundler.md
@@ -39,7 +39,6 @@ Attribute | Value
 --- | ---
 Include | \*\*/Gemfile, \*\*/gems.rb
 
-
 ## Bundler/OrderedGems
 
 Enabled by default | Supports autocorrection
@@ -70,4 +69,3 @@ gem 'rspec'
 Attribute | Value
 --- | ---
 Include | \*\*/Gemfile, \*\*/gems.rb
-

--- a/manual/cops_lint.md
+++ b/manual/cops_lint.md
@@ -87,7 +87,6 @@ Attribute | Value
 --- | ---
 AllowSafeAssignment | true
 
-
 ### References
 
 * [https://github.com/bbatsov/ruby-style-guide#safe-assignment-in-condition](https://github.com/bbatsov/ruby-style-guide#safe-assignment-in-condition)
@@ -159,7 +158,6 @@ Attribute | Value
 --- | ---
 EnforcedStyleAlignWith | either
 SupportedStylesAlignWith | either, start_of_block, start_of_line
-
 
 ## Lint/CircularArgumentReference
 
@@ -324,7 +322,6 @@ Attribute | Value
 EnforcedStyleAlignWith | start_of_line
 SupportedStylesAlignWith | start_of_line, def
 AutoCorrect | false
-
 
 ## Lint/DeprecatedClassMethods
 
@@ -545,7 +542,6 @@ Attribute | Value
 --- | ---
 AutoCorrect | false
 
-
 ## Lint/EmptyExpression
 
 Enabled by default | Supports autocorrection
@@ -681,7 +677,6 @@ Attribute | Value
 EnforcedStyleAlignWith | keyword
 SupportedStylesAlignWith | keyword, variable, start_of_line
 AutoCorrect | false
-
 
 ## Lint/EndInMethod
 
@@ -960,7 +955,6 @@ Attribute | Value
 --- | ---
 EnforcedStyle | runtime_error
 SupportedStyles | runtime_error, standard_error
-
 
 ## Lint/InvalidCharacterLiteral
 
@@ -1428,7 +1422,6 @@ Attribute | Value
 --- | ---
 Whitelist | present?, blank?, presence, try
 
-
 ## Lint/ShadowedException
 
 Enabled by default | Supports autocorrection
@@ -1727,7 +1720,6 @@ Attribute | Value
 IgnoreEmptyBlocks | true
 AllowUnusedKeywordArguments | false
 
-
 ### References
 
 * [https://github.com/bbatsov/ruby-style-guide#underscore-unused-vars](https://github.com/bbatsov/ruby-style-guide#underscore-unused-vars)
@@ -1763,7 +1755,6 @@ Attribute | Value
 --- | ---
 AllowUnusedKeywordArguments | false
 IgnoreEmptyMethods | true
-
 
 ### References
 
@@ -1868,9 +1859,8 @@ end
 
 Attribute | Value
 --- | ---
-ContextCreatingMethods | 
-MethodCreatingMethods | 
-
+ContextCreatingMethods |
+MethodCreatingMethods |
 
 ## Lint/UselessAssignment
 

--- a/manual/cops_metrics.md
+++ b/manual/cops_metrics.md
@@ -16,7 +16,6 @@ Attribute | Value
 --- | ---
 Max | 15
 
-
 ### References
 
 * [http://c2.com/cgi/wiki?AbcMetric](http://c2.com/cgi/wiki?AbcMetric)
@@ -38,8 +37,7 @@ Attribute | Value
 --- | ---
 CountComments | false
 Max | 25
-ExcludedMethods | 
-
+ExcludedMethods |
 
 ## Metrics/BlockNesting
 
@@ -63,7 +61,6 @@ Attribute | Value
 CountBlocks | false
 Max | 3
 
-
 ### References
 
 * [https://github.com/bbatsov/ruby-style-guide#three-is-the-number-thou-shalt-count](https://github.com/bbatsov/ruby-style-guide#three-is-the-number-thou-shalt-count)
@@ -84,7 +81,6 @@ Attribute | Value
 --- | ---
 CountComments | false
 Max | 100
-
 
 ## Metrics/CyclomaticComplexity
 
@@ -109,7 +105,6 @@ Attribute | Value
 --- | ---
 Max | 6
 
-
 ## Metrics/LineLength
 
 Enabled by default | Supports autocorrection
@@ -128,8 +123,7 @@ AllowHeredoc | true
 AllowURI | true
 URISchemes | http, https
 IgnoreCopDirectives | false
-IgnoredPatterns | 
-
+IgnoredPatterns |
 
 ### References
 
@@ -152,7 +146,6 @@ Attribute | Value
 CountComments | false
 Max | 10
 
-
 ### References
 
 * [https://github.com/bbatsov/ruby-style-guide#short-methods](https://github.com/bbatsov/ruby-style-guide#short-methods)
@@ -174,7 +167,6 @@ Attribute | Value
 CountComments | false
 Max | 100
 
-
 ## Metrics/ParameterLists
 
 Enabled by default | Supports autocorrection
@@ -192,7 +184,6 @@ Attribute | Value
 --- | ---
 Max | 5
 CountKeywordArgs | true
-
 
 ### References
 
@@ -235,4 +226,3 @@ end                             # 7 complexity points
 Attribute | Value
 --- | ---
 Max | 7
-

--- a/manual/cops_performance.md
+++ b/manual/cops_performance.md
@@ -163,7 +163,6 @@ Attribute | Value
 --- | ---
 SafeMode | true
 
-
 ## Performance/Detect
 
 Enabled by default | Supports autocorrection
@@ -198,7 +197,6 @@ considered unsafe.
 Attribute | Value
 --- | ---
 SafeMode | true
-
 
 ### References
 
@@ -238,7 +236,6 @@ Attribute | Value
 --- | ---
 IncludeActiveSupportAliases | false
 
-
 ## Performance/EndWith
 
 Enabled by default | Supports autocorrection
@@ -265,7 +262,6 @@ would suffice.
 Attribute | Value
 --- | ---
 AutoCorrect | false
-
 
 ### References
 
@@ -306,7 +302,6 @@ Attribute | Value
 --- | ---
 EnabledForFlattenWithoutParams | false
 
-
 ### References
 
 * [https://github.com/JuanitoFatas/fast-ruby#enumerablemaparrayflatten-vs-enumerableflat_map-code](https://github.com/JuanitoFatas/fast-ruby#enumerablemaparrayflatten-vs-enumerableflat_map-code)
@@ -338,7 +333,6 @@ hash.each_value { |v| p v }
 Attribute | Value
 --- | ---
 AutoCorrect | false
-
 
 ### References
 
@@ -463,7 +457,6 @@ hash.merge!(a: 1, b: 2)
 Attribute | Value
 --- | ---
 MaxKeyValuePairs | 2
-
 
 ### References
 
@@ -675,7 +668,6 @@ This cop identifies unnecessary use of a regex where
 Attribute | Value
 --- | ---
 AutoCorrect | false
-
 
 ### References
 

--- a/manual/cops_rails.md
+++ b/manual/cops_rails.md
@@ -19,7 +19,6 @@ EnforcedStyle | action
 SupportedStyles | action, filter
 Include | app/controllers/\*\*/\*.rb
 
-
 ## Rails/Date
 
 Enabled by default | Supports autocorrection
@@ -68,7 +67,6 @@ Attribute | Value
 --- | ---
 EnforcedStyle | flexible
 SupportedStyles | strict, flexible
-
 
 ## Rails/Delegate
 
@@ -163,7 +161,6 @@ Attribute | Value
 --- | ---
 Whitelist | find_by_sql
 
-
 ### References
 
 * [https://github.com/bbatsov/rails-style-guide#find_by](https://github.com/bbatsov/rails-style-guide#find_by)
@@ -198,7 +195,6 @@ Attribute | Value
 --- | ---
 Include | app/models/\*\*/\*.rb
 
-
 ## Rails/Exit
 
 Enabled by default | Supports autocorrection
@@ -225,7 +221,6 @@ Attribute | Value
 --- | ---
 Include | app/\*\*/\*.rb, config/\*\*/\*.rb, lib/\*\*/\*.rb
 Exclude | lib/\*\*/\*.rake
-
 
 ## Rails/FilePath
 
@@ -274,7 +269,6 @@ Attribute | Value
 --- | ---
 Include | app/models/\*\*/\*.rb
 
-
 ### References
 
 * [https://github.com/bbatsov/rails-style-guide#find_by](https://github.com/bbatsov/rails-style-guide#find_by)
@@ -304,7 +298,6 @@ Attribute | Value
 --- | ---
 Include | app/models/\*\*/\*.rb
 
-
 ### References
 
 * [https://github.com/bbatsov/rails-style-guide#find-each](https://github.com/bbatsov/rails-style-guide#find-each)
@@ -322,7 +315,6 @@ This cop checks for the use of the has_and_belongs_to_many macro.
 Attribute | Value
 --- | ---
 Include | app/models/\*\*/\*.rb
-
 
 ### References
 
@@ -356,7 +348,6 @@ Attribute | Value
 --- | ---
 Include | spec/\*\*/\*, test/\*\*/\*
 
-
 ## Rails/NotNullColumn
 
 Enabled by default | Supports autocorrection
@@ -386,7 +377,6 @@ Attribute | Value
 --- | ---
 Include | db/migrate/\*.rb
 
-
 ## Rails/Output
 
 Enabled by default | Supports autocorrection
@@ -400,7 +390,6 @@ This cop checks for the use of output calls like puts and print
 Attribute | Value
 --- | ---
 Include | app/\*\*/\*.rb, config/\*\*/\*.rb, db/\*\*/\*.rb, lib/\*\*/\*.rb
-
 
 ## Rails/OutputSafety
 
@@ -481,7 +470,6 @@ Attribute | Value
 --- | ---
 Include | app/models/\*\*/\*.rb
 
-
 ### References
 
 * [https://github.com/bbatsov/rails-style-guide#read-attribute](https://github.com/bbatsov/rails-style-guide#read-attribute)
@@ -526,7 +514,6 @@ Attribute | Value
 --- | ---
 EnforcedStyle | referer
 SupportedStyles | referer, referrer
-
 
 ## Rails/ReversibleMigration
 
@@ -630,7 +617,6 @@ Attribute | Value
 --- | ---
 Include | db/migrate/\*.rb
 
-
 ### References
 
 * [https://github.com/bbatsov/rails-style-guide#reversible-migration](https://github.com/bbatsov/rails-style-guide#reversible-migration)
@@ -686,7 +672,6 @@ target Ruby version is set to 2.3+
 Attribute | Value
 --- | ---
 ConvertTry | false
-
 
 ## Rails/SaveBang
 
@@ -758,7 +743,6 @@ Attribute | Value
 --- | ---
 Include | app/models/\*\*/\*.rb
 
-
 ## Rails/SkipsModelValidations
 
 Enabled by default | Supports autocorrection
@@ -793,7 +777,6 @@ user.update_attributes(website: 'example.com')
 Attribute | Value
 --- | ---
 Blacklist | decrement!, decrement_counter, increment!, increment_counter, toggle!, touch, update_all, update_attribute, update_column, update_columns, update_counters
-
 
 ### References
 
@@ -839,7 +822,6 @@ Attribute | Value
 --- | ---
 EnforcedStyle | flexible
 SupportedStyles | strict, flexible
-
 
 ### References
 
@@ -894,7 +876,6 @@ EnforcedStyle | conservative
 SupportedStyles | conservative, aggressive
 AutoCorrect | false
 
-
 ## Rails/Validation
 
 Enabled by default | Supports autocorrection
@@ -908,4 +889,3 @@ This cop checks for the use of old-style attribute validation macros.
 Attribute | Value
 --- | ---
 Include | app/models/\*\*/\*.rb
-

--- a/manual/cops_security.md
+++ b/manual/cops_security.md
@@ -50,7 +50,6 @@ Attribute | Value
 --- | ---
 AutoCorrect | false
 
-
 ### References
 
 * [http://ruby-doc.org/stdlib-2.3.0/libdoc/json/rdoc/JSON.html#method-i-load](http://ruby-doc.org/stdlib-2.3.0/libdoc/json/rdoc/JSON.html#method-i-load)

--- a/manual/cops_style.md
+++ b/manual/cops_style.md
@@ -15,8 +15,7 @@ Attribute | Value
 --- | ---
 EnforcedStyle | indent
 SupportedStyles | outdent, indent
-IndentationWidth | 
-
+IndentationWidth |
 
 ### References
 
@@ -67,7 +66,6 @@ Attribute | Value
 --- | ---
 EnforcedStyle | prefer_alias
 SupportedStyles | prefer_alias, prefer_alias_method
-
 
 ### References
 
@@ -198,7 +196,6 @@ SupportedColonStyles | key, separator, table
 EnforcedLastArgumentHashStyle | always_inspect
 SupportedLastArgumentHashStyles | always_inspect, always_ignore, ignore_implicit, ignore_explicit
 
-
 ## Style/AlignParameters
 
 Enabled by default | Supports autocorrection
@@ -214,8 +211,7 @@ Attribute | Value
 --- | ---
 EnforcedStyle | with_first_parameter
 SupportedStyles | with_first_parameter, with_fixed_indentation
-IndentationWidth | 
-
+IndentationWidth |
 
 ### References
 
@@ -235,7 +231,6 @@ Attribute | Value
 --- | ---
 EnforcedStyle | always
 SupportedStyles | always, conditionals
-
 
 ### References
 
@@ -331,7 +326,6 @@ Attribute | Value
 EnforcedStyle | bare_percent
 SupportedStyles | percent_q, bare_percent
 
-
 ### References
 
 * [https://github.com/bbatsov/ruby-style-guide#percent-q-shorthand](https://github.com/bbatsov/ruby-style-guide#percent-q-shorthand)
@@ -378,7 +372,6 @@ SupportedStyles | line_count_based, semantic, braces_for_chaining
 ProceduralMethods | benchmark, bm, bmbm, create, each_with_object, measure, new, realtime, tap, with_object
 FunctionalMethods | let, let!, subject, watch
 IgnoredMethods | lambda, proc, it
-
 
 ### References
 
@@ -431,7 +424,6 @@ Attribute | Value
 EnforcedStyle | no_braces
 SupportedStyles | braces, no_braces, context_dependent
 
-
 ## Style/CaseEquality
 
 Enabled by default | Supports autocorrection
@@ -462,8 +454,7 @@ Attribute | Value
 EnforcedStyle | case
 SupportedStyles | case, end
 IndentOneStep | false
-IndentationWidth | 
-
+IndentationWidth |
 
 ### References
 
@@ -522,7 +513,6 @@ Attribute | Value
 EnforcedStyle | nested
 SupportedStyles | nested, compact
 
-
 ## Style/ClassCheck
 
 Enabled by default | Supports autocorrection
@@ -537,7 +527,6 @@ Attribute | Value
 --- | ---
 EnforcedStyle | is_a?
 SupportedStyles | is_a?, kind_of?
-
 
 ## Style/ClassMethods
 
@@ -634,7 +623,6 @@ Attribute | Value
 --- | ---
 PreferredMethods | {"collect"=>"map", "collect!"=>"map!", "inject"=>"reduce", "detect"=>"find", "find_all"=>"select"}
 
-
 ### References
 
 * [https://github.com/bbatsov/ruby-style-guide#map-find-select-reduce-size](https://github.com/bbatsov/ruby-style-guide#map-find-select-reduce-size)
@@ -693,7 +681,6 @@ EnforcedStyle | backticks
 SupportedStyles | backticks, percent_x, mixed
 AllowInnerBackticks | false
 
-
 ### References
 
 * [https://github.com/bbatsov/ruby-style-guide#percent-x](https://github.com/bbatsov/ruby-style-guide#percent-x)
@@ -712,7 +699,6 @@ to guidelines.
 Attribute | Value
 --- | ---
 Keywords | TODO, FIXME, OPTIMIZE, HACK, REVIEW
-
 
 ### References
 
@@ -840,7 +826,6 @@ SupportedStyles | assign_to_condition, assign_inside_condition
 SingleLineConditionsOnly | true
 IncludeTernaryExpressions | true
 
-
 ## Style/ConstantName
 
 Enabled by default | Supports autocorrection
@@ -880,8 +865,7 @@ an offense is reported.
 Attribute | Value
 --- | ---
 Notice | ^Copyright (\(c\) )?2[0-9]{3} .+
-AutocorrectNotice | 
-
+AutocorrectNotice |
 
 ## Style/DefWithParentheses
 
@@ -917,7 +901,6 @@ same for all its children.
 Attribute | Value
 --- | ---
 Exclude | spec/\*\*/\*, test/\*\*/\*
-
 
 ## Style/DocumentationMethod
 
@@ -979,7 +962,6 @@ Attribute | Value
 Exclude | spec/\*\*/\*, test/\*\*/\*
 RequireForNonPublicMethods | false
 
-
 ## Style/DotPosition
 
 Enabled by default | Supports autocorrection
@@ -994,7 +976,6 @@ Attribute | Value
 --- | ---
 EnforcedStyle | leading
 SupportedStyles | leading, trailing
-
 
 ### References
 
@@ -1216,7 +1197,6 @@ Attribute | Value
 EnforcedStyle | both
 SupportedStyles | empty, nil, both
 
-
 ## Style/EmptyLineAfterMagicComment
 
 Enabled by default | Supports autocorrection
@@ -1262,7 +1242,6 @@ separated by empty lines.
 Attribute | Value
 --- | ---
 AllowAdjacentOneLineDefs | false
-
 
 ### References
 
@@ -1361,7 +1340,6 @@ Attribute | Value
 EnforcedStyle | no_empty_lines
 SupportedStyles | empty_lines, no_empty_lines
 
-
 ### References
 
 * [https://github.com/bbatsov/ruby-style-guide#empty-lines-around-bodies](https://github.com/bbatsov/ruby-style-guide#empty-lines-around-bodies)
@@ -1397,7 +1375,6 @@ Attribute | Value
 --- | ---
 EnforcedStyle | no_empty_lines
 SupportedStyles | empty_lines, empty_lines_except_namespace, empty_lines_special, no_empty_lines
-
 
 ### References
 
@@ -1543,7 +1520,6 @@ Attribute | Value
 EnforcedStyle | no_empty_lines
 SupportedStyles | empty_lines, empty_lines_except_namespace, empty_lines_special, no_empty_lines
 
-
 ### References
 
 * [https://github.com/bbatsov/ruby-style-guide#empty-lines-around-bodies](https://github.com/bbatsov/ruby-style-guide#empty-lines-around-bodies)
@@ -1613,7 +1589,6 @@ Attribute | Value
 EnforcedStyle | compact
 SupportedStyles | compact, expanded
 
-
 ### References
 
 * [https://github.com/bbatsov/ruby-style-guide#no-single-line-methods](https://github.com/bbatsov/ruby-style-guide#no-single-line-methods)
@@ -1642,7 +1617,6 @@ Attribute | Value
 EnforcedStyle | never
 SupportedStyles | when_needed, always, never
 AutoCorrectEncodingComment | # encoding: utf-8
-
 
 ### References
 
@@ -1674,7 +1648,6 @@ Attribute | Value
 --- | ---
 EnforcedStyle | native
 SupportedStyles | native, lf, crlf
-
 
 ### References
 
@@ -1733,7 +1706,6 @@ Attribute | Value
 AllowForAlignment | true
 ForceEqualSignAlignment | false
 
-
 ## Style/FileName
 
 Enabled by default | Supports autocorrection
@@ -1748,12 +1720,11 @@ first line) are ignored.
 
 Attribute | Value
 --- | ---
-Exclude | 
+Exclude |
 ExpectMatchingDefinition | false
-Regex | 
+Regex |
 IgnoreExecutableScripts | true
 AllowedAcronyms | CLI, DSL, ACL, API, ASCII, CPU, CSS, DNS, EOF, GUID, HTML, HTTP, HTTPS, ID, IP, JSON, LHS, QPS, RAM, RHS, RPC, SLA, SMTP, SQL, SSH, TCP, TLS, TTL, UDP, UI, UID, UUID, URI, URL, UTF8, VM, XML, XMPP, XSRF, XSS
-
 
 ### References
 
@@ -1891,8 +1862,7 @@ Attribute | Value
 --- | ---
 EnforcedStyle | special_for_inner_method_call_in_parentheses
 SupportedStyles | consistent, special_for_inner_method_call, special_for_inner_method_call_in_parentheses
-IndentationWidth | 
-
+IndentationWidth |
 
 ## Style/FlipFlop
 
@@ -1924,7 +1894,6 @@ Attribute | Value
 EnforcedStyle | each
 SupportedStyles | for, each
 
-
 ### References
 
 * [https://github.com/bbatsov/ruby-style-guide#no-for-loops](https://github.com/bbatsov/ruby-style-guide#no-for-loops)
@@ -1950,7 +1919,6 @@ Attribute | Value
 EnforcedStyle | format
 SupportedStyles | format, sprintf, percent
 
-
 ### References
 
 * [https://github.com/bbatsov/ruby-style-guide#sprintf](https://github.com/bbatsov/ruby-style-guide#sprintf)
@@ -1974,7 +1942,6 @@ Attribute | Value
 EnforcedStyle | when_needed
 SupportedStyles | when_needed, always, never
 
-
 ## Style/GlobalVars
 
 Enabled by default | Supports autocorrection
@@ -1992,8 +1959,7 @@ Note that backreferences like $1, $2, etc are not global variables.
 
 Attribute | Value
 --- | ---
-AllowedVariables | 
-
+AllowedVariables |
 
 ### References
 
@@ -2047,7 +2013,6 @@ ok
 Attribute | Value
 --- | ---
 MinBodyLength | 1
-
 
 ### References
 
@@ -2130,7 +2095,6 @@ EnforcedStyle | ruby19
 SupportedStyles | ruby19, hash_rockets, no_mixed_keys, ruby19_no_mixed_keys
 UseHashRocketsWithSymbolValues | false
 PreferHashRocketsForNonAlnumEndingSymbols | false
-
 
 ### References
 
@@ -2232,7 +2196,6 @@ The maximum line length is configurable.
 Attribute | Value
 --- | ---
 MaxLineLength | 80
-
 
 ### References
 
@@ -2346,8 +2309,7 @@ Attribute | Value
 --- | ---
 EnforcedStyle | special_inside_parentheses
 SupportedStyles | special_inside_parentheses, consistent, align_brackets
-IndentationWidth | 
-
+IndentationWidth |
 
 ## Style/IndentAssignment
 
@@ -2381,8 +2343,7 @@ end
 
 Attribute | Value
 --- | ---
-IndentationWidth | 
-
+IndentationWidth |
 
 ## Style/IndentHash
 
@@ -2431,8 +2392,7 @@ Attribute | Value
 --- | ---
 EnforcedStyle | special_inside_parentheses
 SupportedStyles | special_inside_parentheses, consistent, align_braces
-IndentationWidth | 
-
+IndentationWidth |
 
 ## Style/IndentHeredoc
 
@@ -2472,7 +2432,6 @@ Attribute | Value
 EnforcedStyle | ruby23
 SupportedStyles | ruby23, active_support, powerpack, unindent
 
-
 ### References
 
 * [https://github.com/bbatsov/ruby-style-guide#squiggly-heredocs](https://github.com/bbatsov/ruby-style-guide#squiggly-heredocs)
@@ -2503,7 +2462,6 @@ Attribute | Value
 EnforcedStyle | normal
 SupportedStyles | normal, rails
 
-
 ## Style/IndentationWidth
 
 Enabled by default | Supports autocorrection
@@ -2527,7 +2485,6 @@ end
 Attribute | Value
 --- | ---
 Width | 2
-
 
 ### References
 
@@ -2631,7 +2588,6 @@ Attribute | Value
 InverseMethods | {:any?=>:none?, :even?=>:odd?, :===>:!=, :=~=>:!~, :<=>:>=, :>=>:<=}
 InverseBlocks | {:select=>:reject, :select!=>:reject!}
 
-
 ## Style/Lambda
 
 Enabled by default | Supports autocorrection
@@ -2698,7 +2654,6 @@ Attribute | Value
 EnforcedStyle | line_count_dependent
 SupportedStyles | line_count_dependent, lambda, literal
 
-
 ### References
 
 * [https://github.com/bbatsov/ruby-style-guide#lambda-multi-line](https://github.com/bbatsov/ruby-style-guide#lambda-multi-line)
@@ -2727,7 +2682,6 @@ Attribute | Value
 --- | ---
 EnforcedStyle | call
 SupportedStyles | call, braces
-
 
 ### References
 
@@ -2802,8 +2756,7 @@ puts 'test'
 
 Attribute | Value
 --- | ---
-IgnoredMethods | 
-
+IgnoredMethods |
 
 ### References
 
@@ -2869,7 +2822,6 @@ Attribute | Value
 EnforcedStyle | require_parentheses
 SupportedStyles | require_parentheses, require_no_parentheses, require_no_parentheses_except_multiline
 
-
 ### References
 
 * [https://github.com/bbatsov/ruby-style-guide#method-parens](https://github.com/bbatsov/ruby-style-guide#method-parens)
@@ -2923,7 +2875,6 @@ Attribute | Value
 EnforcedStyle | snake_case
 SupportedStyles | snake_case, camelCase
 
-
 ### References
 
 * [https://github.com/bbatsov/ruby-style-guide#snake-case-symbols-methods-vars](https://github.com/bbatsov/ruby-style-guide#snake-case-symbols-methods-vars)
@@ -2970,7 +2921,6 @@ Attribute | Value
 --- | ---
 EnforcedStyle | both
 SupportedStyles | if, case, both
-
 
 ## Style/MixinGrouping
 
@@ -3019,7 +2969,6 @@ Attribute | Value
 EnforcedStyle | separated
 SupportedStyles | separated, grouped
 
-
 ### References
 
 * [https://github.com/bbatsov/ruby-style-guide#mixin-grouping](https://github.com/bbatsov/ruby-style-guide#mixin-grouping)
@@ -3060,7 +3009,6 @@ Attribute | Value
 --- | ---
 EnforcedStyle | module_function
 SupportedStyles | module_function, extend_self
-
 
 ### References
 
@@ -3134,7 +3082,6 @@ Attribute | Value
 EnforcedStyle | symmetrical
 SupportedStyles | symmetrical, new_line, same_line
 
-
 ## Style/MultilineAssignmentLayout
 
 Enabled by default | Supports autocorrection
@@ -3179,7 +3126,6 @@ Attribute | Value
 SupportedTypes | block, case, class, if, kwbegin, module
 EnforcedStyle | new_line
 SupportedStyles | same_line, new_line
-
 
 ### References
 
@@ -3318,7 +3264,6 @@ Attribute | Value
 EnforcedStyle | symmetrical
 SupportedStyles | symmetrical, new_line, same_line
 
-
 ## Style/MultilineIfModifier
 
 Enabled by default | Supports autocorrection
@@ -3415,7 +3360,6 @@ Attribute | Value
 EnforcedStyle | keyword
 SupportedStyles | keyword, braces
 
-
 ## Style/MultilineMethodCallBraceLayout
 
 Enabled by default | Supports autocorrection
@@ -3484,7 +3428,6 @@ Attribute | Value
 EnforcedStyle | symmetrical
 SupportedStyles | symmetrical, new_line, same_line
 
-
 ## Style/MultilineMethodCallIndentation
 
 Enabled by default | Supports autocorrection
@@ -3527,8 +3470,7 @@ Attribute | Value
 --- | ---
 EnforcedStyle | aligned
 SupportedStyles | aligned, indented, indented_relative_to_receiver
-IndentationWidth | 
-
+IndentationWidth |
 
 ## Style/MultilineMethodDefinitionBraceLayout
 
@@ -3598,7 +3540,6 @@ Attribute | Value
 EnforcedStyle | symmetrical
 SupportedStyles | symmetrical, new_line, same_line
 
-
 ## Style/MultilineOperationIndentation
 
 Enabled by default | Supports autocorrection
@@ -3624,8 +3565,7 @@ Attribute | Value
 --- | ---
 EnforcedStyle | aligned
 SupportedStyles | aligned, indented
-IndentationWidth | 
-
+IndentationWidth |
 
 ## Style/MultilineTernaryOperator
 
@@ -3770,7 +3710,6 @@ EnforcedStyle | skip_modifier_ifs
 MinBodyLength | 3
 SupportedStyles | skip_modifier_ifs, always
 
-
 ### References
 
 * [https://github.com/bbatsov/ruby-style-guide#no-nested-conditionals](https://github.com/bbatsov/ruby-style-guide#no-nested-conditionals)
@@ -3832,7 +3771,6 @@ Attribute | Value
 --- | ---
 IncludeSemanticChanges | false
 
-
 ### References
 
 * [https://github.com/bbatsov/ruby-style-guide#no-non-nil-checks](https://github.com/bbatsov/ruby-style-guide#no-non-nil-checks)
@@ -3869,7 +3807,6 @@ Attribute | Value
 --- | ---
 EnforcedOctalStyle | zero_with_o
 SupportedOctalStyles | zero_with_o, zero_only
-
 
 ### References
 
@@ -3908,7 +3845,6 @@ of digits in them.
 Attribute | Value
 --- | ---
 MinDigits | 5
-
 
 ### References
 
@@ -3970,7 +3906,6 @@ AutoCorrect | false
 EnforcedStyle | predicate
 SupportedStyles | predicate, comparison
 Exclude | spec/\*\*/\*
-
 
 ### References
 
@@ -4043,7 +3978,6 @@ end
 Attribute | Value
 --- | ---
 SuspiciousParamNames | options, opts, args, params, parameters
-
 
 ## Style/OptionalArguments
 
@@ -4119,7 +4053,6 @@ Attribute | Value
 --- | ---
 AllowSafeAssignment | true
 
-
 ### References
 
 * [https://github.com/bbatsov/ruby-style-guide#no-parens-around-condition](https://github.com/bbatsov/ruby-style-guide#no-parens-around-condition)
@@ -4137,7 +4070,6 @@ This cop enforces the consistent usage of `%`-literal delimiters.
 Attribute | Value
 --- | ---
 PreferredDelimiters | {"%"=>"()", "%i"=>"()", "%I"=>"()", "%q"=>"()", "%Q"=>"()", "%r"=>"{}", "%s"=>"()", "%w"=>"()", "%W"=>"()", "%x"=>"()"}
-
 
 ### References
 
@@ -4157,7 +4089,6 @@ Attribute | Value
 --- | ---
 EnforcedStyle | lower_case_q
 SupportedStyles | lower_case_q, upper_case_q
-
 
 ## Style/PerlBackrefs
 
@@ -4205,7 +4136,6 @@ NamePrefixBlacklist | is_, has_, have_
 NameWhitelist | is_a?
 Exclude | spec/\*\*/\*
 
-
 ### References
 
 * [https://github.com/bbatsov/ruby-style-guide#bool-methods-qmark](https://github.com/bbatsov/ruby-style-guide#bool-methods-qmark)
@@ -4252,7 +4182,6 @@ Attribute | Value
 --- | ---
 EnforcedStyle | short
 SupportedStyles | short, verbose
-
 
 ### References
 
@@ -4320,7 +4249,6 @@ Attribute | Value
 --- | ---
 EnforcedStyle | exploded
 SupportedStyles | compact, exploded
-
 
 ### References
 
@@ -4455,7 +4383,6 @@ Attribute | Value
 --- | ---
 AllowMultipleReturnValues | false
 
-
 ### References
 
 * [https://github.com/bbatsov/ruby-style-guide#no-explicit-return](https://github.com/bbatsov/ruby-style-guide#no-explicit-return)
@@ -4552,7 +4479,6 @@ Attribute | Value
 EnforcedStyle | slashes
 SupportedStyles | slashes, percent_r, mixed
 AllowInnerSlashes | false
-
 
 ### References
 
@@ -4653,7 +4579,6 @@ Attribute | Value
 --- | ---
 ConvertCodeThatCanStartToReturnNil | false
 
-
 ## Style/SelfAssignment
 
 Enabled by default | Supports autocorrection
@@ -4691,7 +4616,6 @@ Attribute | Value
 --- | ---
 AllowAsExpressionSeparator | false
 
-
 ### References
 
 * [https://github.com/bbatsov/ruby-style-guide#no-semicolon](https://github.com/bbatsov/ruby-style-guide#no-semicolon)
@@ -4723,7 +4647,6 @@ Attribute | Value
 EnforcedStyle | only_raise
 SupportedStyles | only_raise, only_fail, semantic
 
-
 ### References
 
 * [https://github.com/bbatsov/ruby-style-guide#prefer-raise-over-fail](https://github.com/bbatsov/ruby-style-guide#prefer-raise-over-fail)
@@ -4746,7 +4669,6 @@ Attribute | Value
 --- | ---
 Methods | {"reduce"=>["acc", "elem"]}, {"inject"=>["acc", "elem"]}
 
-
 ## Style/SingleLineMethods
 
 Enabled by default | Supports autocorrection
@@ -4761,7 +4683,6 @@ It can optionally accept single-line methods with no body.
 Attribute | Value
 --- | ---
 AllowIfMethodIsEmpty | true
-
 
 ### References
 
@@ -4874,7 +4795,6 @@ Attribute | Value
 EnforcedStyleInsidePipes | no_space
 SupportedStylesInsidePipes | space, no_space
 
-
 ## Style/SpaceAroundEqualsInParameterDefault
 
 Enabled by default | Supports autocorrection
@@ -4890,7 +4810,6 @@ Attribute | Value
 --- | ---
 EnforcedStyle | space
 SupportedStyles | space, no_space
-
 
 ### References
 
@@ -4941,7 +4860,6 @@ Attribute | Value
 --- | ---
 AllowForAlignment | true
 
-
 ### References
 
 * [https://github.com/bbatsov/ruby-style-guide#spaces-operators](https://github.com/bbatsov/ruby-style-guide#spaces-operators)
@@ -4961,7 +4879,6 @@ Attribute | Value
 --- | ---
 EnforcedStyle | space
 SupportedStyles | space, no_space
-
 
 ## Style/SpaceBeforeComma
 
@@ -5011,7 +4928,6 @@ Attribute | Value
 --- | ---
 AllowForAlignment | true
 
-
 ## Style/SpaceBeforeSemicolon
 
 Enabled by default | Supports autocorrection
@@ -5057,7 +4973,6 @@ Attribute | Value
 EnforcedStyle | require_no_space
 SupportedStyles | require_no_space, require_space
 
-
 ## Style/SpaceInsideArrayPercentLiteral
 
 Enabled by default | Supports autocorrection
@@ -5098,7 +5013,6 @@ EnforcedStyleForEmptyBraces | no_space
 SupportedStylesForEmptyBraces | space, no_space
 SpaceBeforeBlockParameters | true
 
-
 ## Style/SpaceInsideBrackets
 
 Enabled by default | Supports autocorrection
@@ -5128,7 +5042,6 @@ EnforcedStyle | space
 SupportedStyles | space, no_space, compact
 EnforcedStyleForEmptyBraces | no_space
 SupportedStylesForEmptyBraces | space, no_space
-
 
 ### References
 
@@ -5221,7 +5134,6 @@ Attribute | Value
 EnforcedStyle | no_space
 SupportedStyles | space, no_space
 
-
 ### References
 
 * [https://github.com/bbatsov/ruby-style-guide#string-interpolation](https://github.com/bbatsov/ruby-style-guide#string-interpolation)
@@ -5240,7 +5152,6 @@ Attribute | Value
 --- | ---
 EnforcedStyle | use_english_names
 SupportedStyles | use_perl_names, use_english_names
-
 
 ### References
 
@@ -5278,7 +5189,6 @@ Attribute | Value
 EnforcedStyle | require_parentheses
 SupportedStyles | require_parentheses, require_no_parentheses
 
-
 ### References
 
 * [https://github.com/bbatsov/ruby-style-guide#stabby-lambda-with-args](https://github.com/bbatsov/ruby-style-guide#stabby-lambda-with-args)
@@ -5299,7 +5209,6 @@ EnforcedStyle | single_quotes
 SupportedStyles | single_quotes, double_quotes
 ConsistentQuotesInMultiline | false
 
-
 ### References
 
 * [https://github.com/bbatsov/ruby-style-guide#consistent-string-literals](https://github.com/bbatsov/ruby-style-guide#consistent-string-literals)
@@ -5319,7 +5228,6 @@ Attribute | Value
 EnforcedStyle | single_quotes
 SupportedStyles | single_quotes, double_quotes
 
-
 ## Style/StringMethods
 
 Enabled by default | Supports autocorrection
@@ -5334,7 +5242,6 @@ from the String class.
 Attribute | Value
 --- | ---
 PreferredMethods | {"intern"=>"to_sym"}
-
 
 ## Style/StructInheritance
 
@@ -5378,7 +5285,6 @@ Attribute | Value
 --- | ---
 EnforcedStyle | percent
 SupportedStyles | percent, brackets
-
 
 ### References
 
@@ -5425,7 +5331,6 @@ something.map(&:upcase)
 Attribute | Value
 --- | ---
 IgnoredMethods | respond_to, define_method
-
 
 ## Style/Tab
 
@@ -5499,7 +5404,6 @@ EnforcedStyle | require_no_parentheses
 SupportedStyles | require_parentheses, require_no_parentheses, require_parentheses_when_complex
 AllowSafeAssignment | true
 
-
 ## Style/TrailingBlankLines
 
 Enabled by default | Supports autocorrection
@@ -5515,7 +5419,6 @@ Attribute | Value
 --- | ---
 EnforcedStyle | final_newline
 SupportedStyles | final_newline, final_blank_line
-
 
 ### References
 
@@ -5561,7 +5464,6 @@ Attribute | Value
 EnforcedStyleForMultiline | no_comma
 SupportedStylesForMultiline | comma, consistent_comma, no_comma
 
-
 ### References
 
 * [https://github.com/bbatsov/ruby-style-guide#no-trailing-params-comma](https://github.com/bbatsov/ruby-style-guide#no-trailing-params-comma)
@@ -5606,7 +5508,6 @@ Attribute | Value
 EnforcedStyleForMultiline | no_comma
 SupportedStylesForMultiline | comma, consistent_comma, no_comma
 
-
 ### References
 
 * [https://github.com/bbatsov/ruby-style-guide#no-trailing-array-commas](https://github.com/bbatsov/ruby-style-guide#no-trailing-array-commas)
@@ -5644,7 +5545,6 @@ Attribute | Value
 --- | ---
 AllowNamedUnderscoreVariables | true
 
-
 ## Style/TrailingWhitespace
 
 Enabled by default | Supports autocorrection
@@ -5675,7 +5575,6 @@ AllowPredicates | true
 AllowDSLWriters | false
 IgnoreClassMethods | false
 Whitelist | to_ary, to_a, to_c, to_enum, to_h, to_hash, to_i, to_int, to_io, to_open, to_path, to_proc, to_r, to_regexp, to_str, to_s, to_sym
-
 
 ### References
 
@@ -5762,7 +5661,6 @@ Attribute | Value
 EnforcedStyle | snake_case
 SupportedStyles | snake_case, camelCase
 
-
 ### References
 
 * [https://github.com/bbatsov/ruby-style-guide#snake-case-symbols-methods-vars](https://github.com/bbatsov/ruby-style-guide#snake-case-symbols-methods-vars)
@@ -5824,7 +5722,6 @@ Attribute | Value
 EnforcedStyle | normalcase
 SupportedStyles | snake_case, normalcase, non_integer
 
-
 ## Style/WhenThen
 
 Enabled by default | Supports autocorrection
@@ -5865,7 +5762,6 @@ Attribute | Value
 --- | ---
 MaxLineLength | 80
 
-
 ### References
 
 * [https://github.com/bbatsov/ruby-style-guide#while-as-a-modifier](https://github.com/bbatsov/ruby-style-guide#while-as-a-modifier)
@@ -5890,7 +5786,6 @@ EnforcedStyle | percent
 SupportedStyles | percent, brackets
 MinSize | 0
 WordRegex | (?-mix:\A[\p{Word}\n\t]+\z)
-
 
 ### References
 

--- a/relnotes/v0.21.0.md
+++ b/relnotes/v0.21.0.md
@@ -3,7 +3,6 @@ change is that we've changed the syntax for excluding/including to be closer to 
 
 Below is the list of all the gory details. Enjoy!
 
-
 ### New features
 
 * [#835](https://github.com/bbatsov/rubocop/issues/835): New cop `UnneededCapitalW` checks for `%W` when interpolation not necessary and `%w` would do. ([@sfeldon][])

--- a/relnotes/v0.23.0.md
+++ b/relnotes/v0.23.0.md
@@ -7,7 +7,6 @@ worrying about name collisions (e.g. you can now have `Style/Filename` and `RSpe
 
 Below is the list of all the gory details. Enjoy!
 
-
 ### New features
 
 * [#1117](https://github.com/bbatsov/rubocop/issues/1117): `BlockComments` cop does auto-correction. ([@jonas054][])

--- a/tasks/cops_documentation.rake
+++ b/tasks/cops_documentation.rake
@@ -64,16 +64,15 @@ task generate_cops_documentation: :yard do
     content << "Attribute | Value\n"
     content << "--- | ---\n"
     pars.each do |par|
-      content << "#{par.first} | #{format_table_value(par.last)}\n"
+      content << "#{par.first} |#{format_table_value(par.last)}\n"
     end
-    content << "\n"
     content
   end
 
   def format_table_value(v)
     value = v.is_a?(Array) ? v.join(', ') : v.to_s
-    value.gsub("#{Dir.pwd}/", '')
-         .gsub('*', '\*')
+    value = value.gsub("#{Dir.pwd}/", '').gsub('*', '\*')
+    " #{value}".rstrip
   end
 
   def references(config, cop)
@@ -96,7 +95,7 @@ task generate_cops_documentation: :yard do
     file_name = "#{Dir.pwd}/manual/cops_#{department.downcase}.md"
     file = File.open(file_name, 'w')
     puts "* generated #{file_name}"
-    file.write(content)
+    file.write(content.strip + "\n")
   end
 
   def print_cop_with_doc(cop, config)


### PR DESCRIPTION
They have no useful purpose (and by default my vim config removes them :) )

One-liner used:

```
Dir['**/*.md'].each { |f| File.write(f, File.read(f).lines.map(&:rstrip).join("\n") + "\n") }
```

(I tried configuring [`markdownlint`](https://github.com/mivok/markdownlint) but it didn't work, would be nice to have a markdown linter as part of the CI)