### PR TITLE
[WIP] Markdown linter

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -4,6 +4,7 @@ source 'https://rubygems.org'
 
 gemspec
 
+gem 'mdl'
 gem 'pry'
 gem 'rake', '~> 12.0'
 gem 'rspec', '~> 3.5.0'

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@
   <img src="https://raw.githubusercontent.com/bbatsov/rubocop/master/logo/rubo-logo-horizontal.png" alt="RuboCop Logo"/>
 </p>
 
-> Role models are important. <br/>
+> Role models are important.<br>
 > ― Officer Alex J. Murphy / RoboCop
 
 **RuboCop** is a Ruby static code analyzer. Out of the box it will

--- a/README.md
+++ b/README.md
@@ -9,7 +9,6 @@
 [![OpenCollective](https://opencollective.com/rubocop/backers/badge.svg)](#open-collective-backers)
 [![OpenCollective](https://opencollective.com/rubocop/sponsors/badge.svg)](#open-collective-sponsors)
 
-
 <p align="center">
   <img src="https://raw.githubusercontent.com/bbatsov/rubocop/master/logo/rubo-logo-horizontal.png" alt="RuboCop Logo"/>
 </p>

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@
 </p>
 
 > Role models are important. <br/>
-> -- Officer Alex J. Murphy / RoboCop
+> ― Officer Alex J. Murphy / RoboCop
 
 **RuboCop** is a Ruby static code analyzer. Out of the box it will
 enforce many of the guidelines outlined in the community

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ automatically fix some of the problems for you.
 
 [![Gitter](https://badges.gitter.im/Join%20Chat.svg)](https://gitter.im/bbatsov/rubocop?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
 
-**Please consider [supporting financially its ongoing development](#funding).**
+- **Please consider [supporting financially its ongoing development](#funding).**
 
 ## Installation
 

--- a/Rakefile
+++ b/Rakefile
@@ -29,7 +29,7 @@ end
 desc 'Run RuboCop over itself'
 RuboCop::RakeTask.new(:internal_investigation)
 
-task default: [:spec, :ascii_spec, :internal_investigation]
+task default: [:spec, :ascii_spec, :internal_investigation, :markdown_lint]
 
 require 'yard'
 YARD::Rake::YardocTask.new

--- a/manual/basic_usage.md
+++ b/manual/basic_usage.md
@@ -91,10 +91,10 @@ Thus, the options have the following order of precedence (from highest to lowest
 
 RuboCop exits with the following status codes:
 
-- 0 if no offenses are found, or if the severity of all offenses are less than
+* 0 if no offenses are found, or if the severity of all offenses are less than
   `--fail-level`. (By default, if you use `--auto-correct`, offenses which are
   auto-corrected do not cause RuboCop to fail.)
-- 1 if one or more offenses equal or greater to `--fail-level` are found. (By
+* 1 if one or more offenses equal or greater to `--fail-level` are found. (By
   default, this is any offense which is not auto-corrected.)
-- 2 if RuboCop terminates abnormally due to invalid configuration, invalid CLI
+* 2 if RuboCop terminates abnormally due to invalid configuration, invalid CLI
   options, or an internal error.

--- a/manual/caching.md
+++ b/manual/caching.md
@@ -11,6 +11,7 @@ Later runs will be able to retrieve this information and present the
 stored information instead of inspecting the file again. This will be
 done if the cache for the file is still valid, which it is if there
 are no changes in:
+
 * the contents of the inspected file
 * RuboCop configuration for the file
 * the options given to `rubocop`, with some exceptions that have no

--- a/manual/configuration.md
+++ b/manual/configuration.md
@@ -63,9 +63,9 @@ server and shared between many projects.
 
 The remote config file is cached locally and is only updated if:
 
-- The file does not exist.
-- The file has not been updated in the last 24 hours.
-- The remote copy has a newer modification time than the local copy.
+* The file does not exist.
+* The file has not been updated in the last 24 hours.
+* The remote copy has a newer modification time than the local copy.
 
 You can inherit from both remote and local files in the same config and the
 same inheritance rules apply to remote URLs and inheriting from local

--- a/manual/cops_bundler.md
+++ b/manual/cops_bundler.md
@@ -69,4 +69,3 @@ gem 'rspec'
 Attribute | Value
 --- | ---
 Include | \*\*/Gemfile, \*\*/gems.rb
-

--- a/manual/cops_bundler.md
+++ b/manual/cops_bundler.md
@@ -39,7 +39,6 @@ Attribute | Value
 --- | ---
 Include | \*\*/Gemfile, \*\*/gems.rb
 
-
 ## Bundler/OrderedGems
 
 Enabled by default | Supports autocorrection

--- a/manual/cops_lint.md
+++ b/manual/cops_lint.md
@@ -1859,8 +1859,8 @@ end
 
 Attribute | Value
 --- | ---
-ContextCreatingMethods | 
-MethodCreatingMethods | 
+ContextCreatingMethods |
+MethodCreatingMethods |
 
 ## Lint/UselessAssignment
 

--- a/manual/cops_lint.md
+++ b/manual/cops_lint.md
@@ -87,7 +87,6 @@ Attribute | Value
 --- | ---
 AllowSafeAssignment | true
 
-
 ### References
 
 * [https://github.com/bbatsov/ruby-style-guide#safe-assignment-in-condition](https://github.com/bbatsov/ruby-style-guide#safe-assignment-in-condition)
@@ -159,7 +158,6 @@ Attribute | Value
 --- | ---
 EnforcedStyleAlignWith | either
 SupportedStylesAlignWith | either, start_of_block, start_of_line
-
 
 ## Lint/CircularArgumentReference
 
@@ -324,7 +322,6 @@ Attribute | Value
 EnforcedStyleAlignWith | start_of_line
 SupportedStylesAlignWith | start_of_line, def
 AutoCorrect | false
-
 
 ## Lint/DeprecatedClassMethods
 
@@ -545,7 +542,6 @@ Attribute | Value
 --- | ---
 AutoCorrect | false
 
-
 ## Lint/EmptyExpression
 
 Enabled by default | Supports autocorrection
@@ -681,7 +677,6 @@ Attribute | Value
 EnforcedStyleAlignWith | keyword
 SupportedStylesAlignWith | keyword, variable, start_of_line
 AutoCorrect | false
-
 
 ## Lint/EndInMethod
 
@@ -960,7 +955,6 @@ Attribute | Value
 --- | ---
 EnforcedStyle | runtime_error
 SupportedStyles | runtime_error, standard_error
-
 
 ## Lint/InvalidCharacterLiteral
 
@@ -1428,7 +1422,6 @@ Attribute | Value
 --- | ---
 Whitelist | present?, blank?, presence, try
 
-
 ## Lint/ShadowedException
 
 Enabled by default | Supports autocorrection
@@ -1727,7 +1720,6 @@ Attribute | Value
 IgnoreEmptyBlocks | true
 AllowUnusedKeywordArguments | false
 
-
 ### References
 
 * [https://github.com/bbatsov/ruby-style-guide#underscore-unused-vars](https://github.com/bbatsov/ruby-style-guide#underscore-unused-vars)
@@ -1763,7 +1755,6 @@ Attribute | Value
 --- | ---
 AllowUnusedKeywordArguments | false
 IgnoreEmptyMethods | true
-
 
 ### References
 
@@ -1870,7 +1861,6 @@ Attribute | Value
 --- | ---
 ContextCreatingMethods | 
 MethodCreatingMethods | 
-
 
 ## Lint/UselessAssignment
 

--- a/manual/cops_lint.md
+++ b/manual/cops_lint.md
@@ -18,6 +18,7 @@ method invocation without parentheses.
 # a `*` method invocation (i.e. `do_something.*(some_array)`).
 do_something *some_array
 ```
+
 ```ruby
 # good
 
@@ -48,6 +49,7 @@ a method invocation without parentheses.
 # (i.e. `do_something./(pattern)./(i)`)
 do_something /pattern/i
 ```
+
 ```ruby
 # good
 
@@ -73,6 +75,7 @@ if some_var = true
   do_something
 end
 ```
+
 ```ruby
 # good
 
@@ -122,6 +125,7 @@ foo.bar
      baz
        end
 ```
+
 ```ruby
 # EnforcedStyleAlignWith: either (default)
 
@@ -131,6 +135,7 @@ variable = lambda do |i|
   i
 end
 ```
+
 ```ruby
 # EnforcedStyleAlignWith: start_of_block
 
@@ -141,6 +146,7 @@ foo.bar
      baz
    end
 ```
+
 ```ruby
 # EnforcedStyleAlignWith: start_of_line
 
@@ -179,6 +185,7 @@ def bake(pie: pie)
   pie.heat_up
 end
 ```
+
 ```ruby
 # good
 
@@ -186,6 +193,7 @@ def bake(pie:)
   pie.refrigerate
 end
 ```
+
 ```ruby
 # good
 
@@ -193,6 +201,7 @@ def bake(pie: self.pie)
   pie.feed_to(user)
 end
 ```
+
 ```ruby
 # bad
 
@@ -200,6 +209,7 @@ def cook(dry_ingredients = dry_ingredients)
   dry_ingredients.reduce(&:+)
 end
 ```
+
 ```ruby
 # good
 
@@ -227,6 +237,7 @@ if
   do_something
 end
 ```
+
 ```ruby
 # good
 
@@ -258,6 +269,7 @@ def some_method
   do_something
 end
 ```
+
 ```ruby
 # bad (ok during development)
 
@@ -267,6 +279,7 @@ def some_method
   do_something
 end
 ```
+
 ```ruby
 # good
 
@@ -298,6 +311,7 @@ keyword is. If it's set to `def`, the `end` shall be aligned with the
 private def foo
             end
 ```
+
 ```ruby
 # EnforcedStyleAlignWith: start_of_line (default)
 
@@ -306,6 +320,7 @@ private def foo
 private def foo
 end
 ```
+
 ```ruby
 # EnforcedStyleAlignWith: def
 
@@ -338,6 +353,7 @@ This cop checks for uses of the deprecated class method usages.
 
 File.exists?(some_path)
 ```
+
 ```ruby
 # good
 
@@ -365,6 +381,7 @@ when 'first'
   do_something_else
 end
 ```
+
 ```ruby
 # good
 
@@ -398,6 +415,7 @@ def duplicated
   2
 end
 ```
+
 ```ruby
 # good
 
@@ -427,6 +445,7 @@ This cop mirrors a warning in Ruby 2.2.
 
 hash = { food: 'apple', food: 'orange' }
 ```
+
 ```ruby
 # good
 
@@ -452,6 +471,7 @@ It's definitely a bug.
 
 sum = numbers.each_with_object(0) { |e, a| a += e }
 ```
+
 ```ruby
 # good
 
@@ -480,6 +500,7 @@ else do_this
   do_that
 end
 ```
+
 ```ruby
 # good
 
@@ -509,6 +530,7 @@ def some_method
 ensure
 end
 ```
+
 ```ruby
 # bad
 
@@ -517,6 +539,7 @@ begin
 ensure
 end
 ```
+
 ```ruby
 # good
 
@@ -526,6 +549,7 @@ ensure
   do_something_else
 end
 ```
+
 ```ruby
 # good
 
@@ -560,6 +584,7 @@ if ()
   bar
 end
 ```
+
 ```ruby
 # good
 
@@ -584,6 +609,7 @@ This cop checks for empty interpolation.
 
 "result is #{}"
 ```
+
 ```ruby
 # good
 
@@ -608,6 +634,7 @@ when bar then 1
 when baz then # nothing
 end
 ```
+
 ```ruby
 # good
 
@@ -645,6 +672,7 @@ start of the line where the matching keyword appears.
 variable = if true
     end
 ```
+
 ```ruby
 # EnforcedStyleAlignWith: keyword (default)
 
@@ -653,6 +681,7 @@ variable = if true
 variable = if true
            end
 ```
+
 ```ruby
 # EnforcedStyleAlignWith: variable
 
@@ -661,6 +690,7 @@ variable = if true
 variable = if true
 end
 ```
+
 ```ruby
 # EnforcedStyleAlignWith: start_of_line
 
@@ -695,6 +725,7 @@ def some_method
   END { do_something }
 end
 ```
+
 ```ruby
 # good
 
@@ -702,6 +733,7 @@ def some_method
   at_exit { do_something }
 end
 ```
+
 ```ruby
 # good
 
@@ -729,6 +761,7 @@ ensure
   return
 end
 ```
+
 ```ruby
 # good
 
@@ -760,6 +793,7 @@ that big. If you need a float that big, something is wrong with you.
 
 float = 3.0e400
 ```
+
 ```ruby
 # good
 
@@ -783,6 +817,7 @@ passed as arguments.
 
 format('A value: %s and another: %i', a_value)
 ```
+
 ```ruby
 # good
 
@@ -808,6 +843,7 @@ rescue
   # do nothing
 end
 ```
+
 ```ruby
 # bad
 
@@ -817,6 +853,7 @@ rescue
   # do nothing
 end
 ```
+
 ```ruby
 # good
 
@@ -826,6 +863,7 @@ rescue
   handle_exception
 end
 ```
+
 ```ruby
 # good
 
@@ -856,6 +894,7 @@ which are on the same line.
 
 array = ['Item 1' 'Item 2']
 ```
+
 ```ruby
 # good
 
@@ -891,6 +930,7 @@ class C
   end
 end
 ```
+
 ```ruby
 # good
 
@@ -902,6 +942,7 @@ class C
   private_class_method :method
 end
 ```
+
 ```ruby
 # good
 
@@ -934,6 +975,7 @@ and its standard library subclasses, excluding subclasses of
 
 class C < Exception; end
 ```
+
 ```ruby
 # EnforcedStyle: runtime_error (default)
 
@@ -941,6 +983,7 @@ class C < Exception; end
 
 class C < RuntimeError; end
 ```
+
 ```ruby
 # EnforcedStyle: standard_error
 
@@ -1001,6 +1044,7 @@ if 20
   do_something
 end
 ```
+
 ```ruby
 # bad
 
@@ -1008,6 +1052,7 @@ if some_var && true
   do_something
 end
 ```
+
 ```ruby
 # good
 
@@ -1031,6 +1076,7 @@ This cop checks for interpolated literals.
 
 "result is #{10}"
 ```
+
 ```ruby
 # good
 
@@ -1055,6 +1101,7 @@ begin
   do_something
 end while some_condition
 ```
+
 ```ruby
 # bad
 
@@ -1063,6 +1110,7 @@ begin
   do_something
 end until some_condition
 ```
+
 ```ruby
 # good
 
@@ -1071,6 +1119,7 @@ while some_condition
   do_something
 end
 ```
+
 ```ruby
 # good
 
@@ -1103,6 +1152,7 @@ comparison operators.
 x < y < z
 10 <= x <= 20
 ```
+
 ```ruby
 # good
 
@@ -1131,6 +1181,7 @@ def foo
   end
 end
 ```
+
 ```ruby
 # good
 
@@ -1139,6 +1190,7 @@ def foo
   bar.call
 end
 ```
+
 ```ruby
 # good
 
@@ -1172,6 +1224,7 @@ result = (1..4).reduce(0) do |acc, i|
   acc + i
 end
 ```
+
 ```ruby
 # good
 
@@ -1240,6 +1293,7 @@ parenthesis.
 
 puts (x + y)
 ```
+
 ```ruby
 # good
 
@@ -1269,6 +1323,7 @@ rather than meant to be part of the resulting strings.
 
 %w('foo', "bar")
 ```
+
 ```ruby
 # good
 
@@ -1294,6 +1349,7 @@ rather than meant to be part of the resulting symbols.
 
 %i(:foo, :bar)
 ```
+
 ```ruby
 # good
 
@@ -1319,6 +1375,7 @@ Kernel.rand(-1)
 rand 1.0
 rand(-1.0)
 ```
+
 ```ruby
 # good
 
@@ -1349,6 +1406,7 @@ if day.is? :tuesday && month == :jan
   ...
 end
 ```
+
 ```ruby
 # good
 
@@ -1374,6 +1432,7 @@ rescue Exception
   handle_exception
 end
 ```
+
 ```ruby
 # good
 
@@ -1409,6 +1468,7 @@ x&.foo.bar
 x&.foo + bar
 x&.foo[bar]
 ```
+
 ```ruby
 # good
 
@@ -1445,6 +1505,7 @@ rescue StandardError
   handle_standard_error
 end
 ```
+
 ```ruby
 # good
 
@@ -1481,6 +1542,7 @@ def some_method
   end
 end
 ```
+
 ```ruby
 # good
 
@@ -1509,6 +1571,7 @@ which is redundant.
 
 "result is #{something.to_s}"
 ```
+
 ```ruby
 # good
 
@@ -1537,6 +1600,7 @@ used.
   do_something(_num)
 end
 ```
+
 ```ruby
 # good
 
@@ -1544,6 +1608,7 @@ end
   do_something(num)
 end
 ```
+
 ```ruby
 # good
 
@@ -1568,6 +1633,7 @@ This cop checks for using Fixnum or Bignum constant.
 1.is_a?(Fixnum)
 1.is_a?(Bignum)
 ```
+
 ```ruby
 # good
 
@@ -1620,6 +1686,7 @@ else
   baz
 end
 ```
+
 ```ruby
 # good
 
@@ -1664,6 +1731,7 @@ def some_method
   do_something
 end
 ```
+
 ```ruby
 # good
 
@@ -1697,6 +1765,7 @@ define_method(:foo) do |bar|
   puts :baz
 end
 ```
+
 ```ruby
 #good
 
@@ -1741,6 +1810,7 @@ def some_method(used, unused, _unused_but_allowed)
   puts used
 end
 ```
+
 ```ruby
 # good
 
@@ -1788,6 +1858,7 @@ class Foo
   private # this is redundant (no following methods are defined)
 end
 ```
+
 ```ruby
 class Foo
   # The following is not redundant (conditionally defined methods are
@@ -1819,6 +1890,7 @@ class Foo
   end
 end
 ```
+
 ```ruby
 # Lint/UselessAccessModifier:
 #   ContextCreatingMethods:
@@ -1842,6 +1914,7 @@ class Foo
   end
 end
 ```
+
 ```ruby
 # Lint/UselessAccessModifier:
 #   MethodCreatingMethods:
@@ -1888,6 +1961,7 @@ def some_method
   do_something
 end
 ```
+
 ```ruby
 # good
 
@@ -1936,6 +2010,7 @@ else
   do_something_else # This will never be run.
 end
 ```
+
 ```ruby
 # good
 
@@ -1967,6 +2042,7 @@ def something
   x.attr = 5
 end
 ```
+
 ```ruby
 # good
 
@@ -1996,6 +2072,7 @@ def some_method
   do_something
 end
 ```
+
 ```ruby
 # bad
 
@@ -2004,6 +2081,7 @@ def some_method
   do_something
 end
 ```
+
 ```ruby
 # good
 
@@ -2012,6 +2090,7 @@ def some_method
   some_num * 10
 end
 ```
+
 ```ruby
 # good
 

--- a/manual/cops_lint.md
+++ b/manual/cops_lint.md
@@ -1243,12 +1243,12 @@ Enabled | No
 This cop checks for non-local exits from iterators without a return
 value. It registers an offense under these conditions:
 
-- No value is returned,
-- the block is preceded by a method chain,
-- the block has arguments,
-- the method which receives the block is not `define_method`
+* No value is returned,
+* the block is preceded by a method chain,
+* the block has arguments,
+* the method which receives the block is not `define_method`
   or `define_singleton_method`,
-- the return is not contained in an inner scope, e.g. a lambda or a
+* the return is not contained in an inner scope, e.g. a lambda or a
   method definition.
 
 ### Example

--- a/manual/cops_lint.md
+++ b/manual/cops_lint.md
@@ -1243,13 +1243,13 @@ Enabled | No
 This cop checks for non-local exits from iterators without a return
 value. It registers an offense under these conditions:
 
- - No value is returned,
- - the block is preceded by a method chain,
- - the block has arguments,
- - the method which receives the block is not `define_method`
-   or `define_singleton_method`,
- - the return is not contained in an inner scope, e.g. a lambda or a
-   method definition.
+- No value is returned,
+- the block is preceded by a method chain,
+- the block has arguments,
+- the method which receives the block is not `define_method`
+  or `define_singleton_method`,
+- the return is not contained in an inner scope, e.g. a lambda or a
+  method definition.
 
 ### Example
 

--- a/manual/cops_metrics.md
+++ b/manual/cops_metrics.md
@@ -37,7 +37,7 @@ Attribute | Value
 --- | ---
 CountComments | false
 Max | 25
-ExcludedMethods | 
+ExcludedMethods |
 
 ## Metrics/BlockNesting
 
@@ -123,7 +123,7 @@ AllowHeredoc | true
 AllowURI | true
 URISchemes | http, https
 IgnoreCopDirectives | false
-IgnoredPatterns | 
+IgnoredPatterns |
 
 ### References
 

--- a/manual/cops_metrics.md
+++ b/manual/cops_metrics.md
@@ -8,7 +8,7 @@ Enabled | No
 
 This cop checks that the ABC size of methods is not higher than the
 configured maximum. The ABC size is based on assignments, branches
-(method calls), and conditions. See http://c2.com/cgi/wiki?AbcMetric
+(method calls), and conditions. See [wiki.c2.com/?AbcMetric](http://wiki.c2.com/?AbcMetric)
 
 ### Important attributes
 

--- a/manual/cops_metrics.md
+++ b/manual/cops_metrics.md
@@ -226,4 +226,3 @@ end                             # 7 complexity points
 Attribute | Value
 --- | ---
 Max | 7
-

--- a/manual/cops_metrics.md
+++ b/manual/cops_metrics.md
@@ -16,7 +16,6 @@ Attribute | Value
 --- | ---
 Max | 15
 
-
 ### References
 
 * [http://c2.com/cgi/wiki?AbcMetric](http://c2.com/cgi/wiki?AbcMetric)
@@ -40,7 +39,6 @@ CountComments | false
 Max | 25
 ExcludedMethods | 
 
-
 ## Metrics/BlockNesting
 
 Enabled by default | Supports autocorrection
@@ -63,7 +61,6 @@ Attribute | Value
 CountBlocks | false
 Max | 3
 
-
 ### References
 
 * [https://github.com/bbatsov/ruby-style-guide#three-is-the-number-thou-shalt-count](https://github.com/bbatsov/ruby-style-guide#three-is-the-number-thou-shalt-count)
@@ -84,7 +81,6 @@ Attribute | Value
 --- | ---
 CountComments | false
 Max | 100
-
 
 ## Metrics/CyclomaticComplexity
 
@@ -109,7 +105,6 @@ Attribute | Value
 --- | ---
 Max | 6
 
-
 ## Metrics/LineLength
 
 Enabled by default | Supports autocorrection
@@ -129,7 +124,6 @@ AllowURI | true
 URISchemes | http, https
 IgnoreCopDirectives | false
 IgnoredPatterns | 
-
 
 ### References
 
@@ -152,7 +146,6 @@ Attribute | Value
 CountComments | false
 Max | 10
 
-
 ### References
 
 * [https://github.com/bbatsov/ruby-style-guide#short-methods](https://github.com/bbatsov/ruby-style-guide#short-methods)
@@ -174,7 +167,6 @@ Attribute | Value
 CountComments | false
 Max | 100
 
-
 ## Metrics/ParameterLists
 
 Enabled by default | Supports autocorrection
@@ -192,7 +184,6 @@ Attribute | Value
 --- | ---
 Max | 5
 CountKeywordArgs | true
-
 
 ### References
 

--- a/manual/cops_performance.md
+++ b/manual/cops_performance.md
@@ -163,7 +163,6 @@ Attribute | Value
 --- | ---
 SafeMode | true
 
-
 ## Performance/Detect
 
 Enabled by default | Supports autocorrection
@@ -198,7 +197,6 @@ considered unsafe.
 Attribute | Value
 --- | ---
 SafeMode | true
-
 
 ### References
 
@@ -238,7 +236,6 @@ Attribute | Value
 --- | ---
 IncludeActiveSupportAliases | false
 
-
 ## Performance/EndWith
 
 Enabled by default | Supports autocorrection
@@ -265,7 +262,6 @@ would suffice.
 Attribute | Value
 --- | ---
 AutoCorrect | false
-
 
 ### References
 
@@ -306,7 +302,6 @@ Attribute | Value
 --- | ---
 EnabledForFlattenWithoutParams | false
 
-
 ### References
 
 * [https://github.com/JuanitoFatas/fast-ruby#enumerablemaparrayflatten-vs-enumerableflat_map-code](https://github.com/JuanitoFatas/fast-ruby#enumerablemaparrayflatten-vs-enumerableflat_map-code)
@@ -338,7 +333,6 @@ hash.each_value { |v| p v }
 Attribute | Value
 --- | ---
 AutoCorrect | false
-
 
 ### References
 
@@ -463,7 +457,6 @@ hash.merge!(a: 1, b: 2)
 Attribute | Value
 --- | ---
 MaxKeyValuePairs | 2
-
 
 ### References
 
@@ -675,7 +668,6 @@ This cop identifies unnecessary use of a regex where
 Attribute | Value
 --- | ---
 AutoCorrect | false
-
 
 ### References
 

--- a/manual/cops_rails.md
+++ b/manual/cops_rails.md
@@ -556,6 +556,7 @@ def change
   end
 end
 ```
+
 ```ruby
 # drop_table
 
@@ -571,6 +572,7 @@ def change
   end
 end
 ```
+
 ```ruby
 # change_column_default
 
@@ -584,6 +586,7 @@ def change
   change_column_default(:posts, :state, from: nil, to: "draft")
 end
 ```
+
 ```ruby
 # remove_column
 
@@ -597,6 +600,7 @@ def change
   remove_column(:suppliers, :qualification, :string)
 end
 ```
+
 ```ruby
 # remove_foreign_key
 
@@ -860,6 +864,7 @@ Model.pluck(:id).uniq
 # good
 Model.uniq.pluck(:id)
 ```
+
 ```ruby
 # this will return a Relation that pluck is called on
 Model.where(...).pluck(:id).uniq
@@ -889,4 +894,3 @@ This cop checks for the use of old-style attribute validation macros.
 Attribute | Value
 --- | ---
 Include | app/models/\*\*/\*.rb
-

--- a/manual/cops_rails.md
+++ b/manual/cops_rails.md
@@ -131,7 +131,7 @@ Enabled | Yes
 
 This cop checks dynamic `find_by_*` methods.
 Use `find_by` instead of dynamic method.
-See. https://github.com/bbatsov/rails-style-guide#find_by
+See. [rails-style-guide#find_by](https://github.com/bbatsov/rails-style-guide#find_by)
 
 ### Example
 
@@ -755,7 +755,7 @@ Enabled | No
 
 This cop checks for the use of methods which skip
 validations which are listed in
-http://guides.rubyonrails.org/active_record_validations.html#skipping-validations
+[guides.rubyonrails.org/active_record_validations](http://guides.rubyonrails.org/active_record_validations.html#skipping-validations)
 
 ### Example
 
@@ -794,8 +794,10 @@ Enabled | No
 
 This cop checks for the use of Time methods without zone.
 
-Built on top of Ruby on Rails style guide (https://github.com/bbatsov/rails-style-guide#time)
-and the article http://danilenko.org/2012/7/6/rails_timezones/ .
+Built on top of Ruby on Rails style guide
+[rails-style-guide#time](https://github.com/bbatsov/rails-style-guide#time)
+and the article
+[danilenko.org/2012/7/6/rails_timezones](http://danilenko.org/2012/7/6/rails_timezones/).
 
 Two styles are supported for this cop. When EnforcedStyle is 'strict'
 then only use of Time.zone is allowed.

--- a/manual/cops_rails.md
+++ b/manual/cops_rails.md
@@ -208,12 +208,12 @@ other form of stopping execution of current request.
 There are two obvious cases where 'exit' is particularly harmful:
 
 - Usage in library code for your application. Even though rails will
-rescue from a SystemExit and continue on, unit testing that library
-code will result in specs exiting (potentially silently if exit(0)
-is used.)
+  rescue from a SystemExit and continue on, unit testing that library
+  code will result in specs exiting (potentially silently if exit(0)
+  is used.)
 - Usage in application code outside of the web process could result in
-the program exiting, which could result in the code failing to run and
-do its job.
+  the program exiting, which could result in the code failing to run and
+  do its job.
 
 ### Important attributes
 

--- a/manual/cops_rails.md
+++ b/manual/cops_rails.md
@@ -207,11 +207,11 @@ other form of stopping execution of current request.
 
 There are two obvious cases where 'exit' is particularly harmful:
 
-- Usage in library code for your application. Even though rails will
+* Usage in library code for your application. Even though rails will
   rescue from a SystemExit and continue on, unit testing that library
   code will result in specs exiting (potentially silently if exit(0)
   is used.)
-- Usage in application code outside of the web process could result in
+* Usage in application code outside of the web process could result in
   the program exiting, which could result in the code failing to run and
   do its job.
 

--- a/manual/cops_rails.md
+++ b/manual/cops_rails.md
@@ -19,7 +19,6 @@ EnforcedStyle | action
 SupportedStyles | action, filter
 Include | app/controllers/\*\*/\*.rb
 
-
 ## Rails/Date
 
 Enabled by default | Supports autocorrection
@@ -68,7 +67,6 @@ Attribute | Value
 --- | ---
 EnforcedStyle | flexible
 SupportedStyles | strict, flexible
-
 
 ## Rails/Delegate
 
@@ -163,7 +161,6 @@ Attribute | Value
 --- | ---
 Whitelist | find_by_sql
 
-
 ### References
 
 * [https://github.com/bbatsov/rails-style-guide#find_by](https://github.com/bbatsov/rails-style-guide#find_by)
@@ -198,7 +195,6 @@ Attribute | Value
 --- | ---
 Include | app/models/\*\*/\*.rb
 
-
 ## Rails/Exit
 
 Enabled by default | Supports autocorrection
@@ -225,7 +221,6 @@ Attribute | Value
 --- | ---
 Include | app/\*\*/\*.rb, config/\*\*/\*.rb, lib/\*\*/\*.rb
 Exclude | lib/\*\*/\*.rake
-
 
 ## Rails/FilePath
 
@@ -274,7 +269,6 @@ Attribute | Value
 --- | ---
 Include | app/models/\*\*/\*.rb
 
-
 ### References
 
 * [https://github.com/bbatsov/rails-style-guide#find_by](https://github.com/bbatsov/rails-style-guide#find_by)
@@ -304,7 +298,6 @@ Attribute | Value
 --- | ---
 Include | app/models/\*\*/\*.rb
 
-
 ### References
 
 * [https://github.com/bbatsov/rails-style-guide#find-each](https://github.com/bbatsov/rails-style-guide#find-each)
@@ -322,7 +315,6 @@ This cop checks for the use of the has_and_belongs_to_many macro.
 Attribute | Value
 --- | ---
 Include | app/models/\*\*/\*.rb
-
 
 ### References
 
@@ -356,7 +348,6 @@ Attribute | Value
 --- | ---
 Include | spec/\*\*/\*, test/\*\*/\*
 
-
 ## Rails/NotNullColumn
 
 Enabled by default | Supports autocorrection
@@ -386,7 +377,6 @@ Attribute | Value
 --- | ---
 Include | db/migrate/\*.rb
 
-
 ## Rails/Output
 
 Enabled by default | Supports autocorrection
@@ -400,7 +390,6 @@ This cop checks for the use of output calls like puts and print
 Attribute | Value
 --- | ---
 Include | app/\*\*/\*.rb, config/\*\*/\*.rb, db/\*\*/\*.rb, lib/\*\*/\*.rb
-
 
 ## Rails/OutputSafety
 
@@ -481,7 +470,6 @@ Attribute | Value
 --- | ---
 Include | app/models/\*\*/\*.rb
 
-
 ### References
 
 * [https://github.com/bbatsov/rails-style-guide#read-attribute](https://github.com/bbatsov/rails-style-guide#read-attribute)
@@ -526,7 +514,6 @@ Attribute | Value
 --- | ---
 EnforcedStyle | referer
 SupportedStyles | referer, referrer
-
 
 ## Rails/ReversibleMigration
 
@@ -630,7 +617,6 @@ Attribute | Value
 --- | ---
 Include | db/migrate/\*.rb
 
-
 ### References
 
 * [https://github.com/bbatsov/rails-style-guide#reversible-migration](https://github.com/bbatsov/rails-style-guide#reversible-migration)
@@ -686,7 +672,6 @@ target Ruby version is set to 2.3+
 Attribute | Value
 --- | ---
 ConvertTry | false
-
 
 ## Rails/SaveBang
 
@@ -758,7 +743,6 @@ Attribute | Value
 --- | ---
 Include | app/models/\*\*/\*.rb
 
-
 ## Rails/SkipsModelValidations
 
 Enabled by default | Supports autocorrection
@@ -793,7 +777,6 @@ user.update_attributes(website: 'example.com')
 Attribute | Value
 --- | ---
 Blacklist | decrement!, decrement_counter, increment!, increment_counter, toggle!, touch, update_all, update_attribute, update_column, update_columns, update_counters
-
 
 ### References
 
@@ -839,7 +822,6 @@ Attribute | Value
 --- | ---
 EnforcedStyle | flexible
 SupportedStyles | strict, flexible
-
 
 ### References
 
@@ -893,7 +875,6 @@ Attribute | Value
 EnforcedStyle | conservative
 SupportedStyles | conservative, aggressive
 AutoCorrect | false
-
 
 ## Rails/Validation
 

--- a/manual/cops_security.md
+++ b/manual/cops_security.md
@@ -50,7 +50,6 @@ Attribute | Value
 --- | ---
 AutoCorrect | false
 
-
 ### References
 
 * [http://ruby-doc.org/stdlib-2.3.0/libdoc/json/rdoc/JSON.html#method-i-load](http://ruby-doc.org/stdlib-2.3.0/libdoc/json/rdoc/JSON.html#method-i-load)

--- a/manual/cops_style.md
+++ b/manual/cops_style.md
@@ -17,7 +17,6 @@ EnforcedStyle | indent
 SupportedStyles | outdent, indent
 IndentationWidth | 
 
-
 ### References
 
 * [https://github.com/bbatsov/ruby-style-guide#indent-public-private-protected](https://github.com/bbatsov/ruby-style-guide#indent-public-private-protected)
@@ -67,7 +66,6 @@ Attribute | Value
 --- | ---
 EnforcedStyle | prefer_alias
 SupportedStyles | prefer_alias, prefer_alias_method
-
 
 ### References
 
@@ -198,7 +196,6 @@ SupportedColonStyles | key, separator, table
 EnforcedLastArgumentHashStyle | always_inspect
 SupportedLastArgumentHashStyles | always_inspect, always_ignore, ignore_implicit, ignore_explicit
 
-
 ## Style/AlignParameters
 
 Enabled by default | Supports autocorrection
@@ -215,7 +212,6 @@ Attribute | Value
 EnforcedStyle | with_first_parameter
 SupportedStyles | with_first_parameter, with_fixed_indentation
 IndentationWidth | 
-
 
 ### References
 
@@ -235,7 +231,6 @@ Attribute | Value
 --- | ---
 EnforcedStyle | always
 SupportedStyles | always, conditionals
-
 
 ### References
 
@@ -331,7 +326,6 @@ Attribute | Value
 EnforcedStyle | bare_percent
 SupportedStyles | percent_q, bare_percent
 
-
 ### References
 
 * [https://github.com/bbatsov/ruby-style-guide#percent-q-shorthand](https://github.com/bbatsov/ruby-style-guide#percent-q-shorthand)
@@ -378,7 +372,6 @@ SupportedStyles | line_count_based, semantic, braces_for_chaining
 ProceduralMethods | benchmark, bm, bmbm, create, each_with_object, measure, new, realtime, tap, with_object
 FunctionalMethods | let, let!, subject, watch
 IgnoredMethods | lambda, proc, it
-
 
 ### References
 
@@ -431,7 +424,6 @@ Attribute | Value
 EnforcedStyle | no_braces
 SupportedStyles | braces, no_braces, context_dependent
 
-
 ## Style/CaseEquality
 
 Enabled by default | Supports autocorrection
@@ -463,7 +455,6 @@ EnforcedStyle | case
 SupportedStyles | case, end
 IndentOneStep | false
 IndentationWidth | 
-
 
 ### References
 
@@ -522,7 +513,6 @@ Attribute | Value
 EnforcedStyle | nested
 SupportedStyles | nested, compact
 
-
 ## Style/ClassCheck
 
 Enabled by default | Supports autocorrection
@@ -537,7 +527,6 @@ Attribute | Value
 --- | ---
 EnforcedStyle | is_a?
 SupportedStyles | is_a?, kind_of?
-
 
 ## Style/ClassMethods
 
@@ -634,7 +623,6 @@ Attribute | Value
 --- | ---
 PreferredMethods | {"collect"=>"map", "collect!"=>"map!", "inject"=>"reduce", "detect"=>"find", "find_all"=>"select"}
 
-
 ### References
 
 * [https://github.com/bbatsov/ruby-style-guide#map-find-select-reduce-size](https://github.com/bbatsov/ruby-style-guide#map-find-select-reduce-size)
@@ -693,7 +681,6 @@ EnforcedStyle | backticks
 SupportedStyles | backticks, percent_x, mixed
 AllowInnerBackticks | false
 
-
 ### References
 
 * [https://github.com/bbatsov/ruby-style-guide#percent-x](https://github.com/bbatsov/ruby-style-guide#percent-x)
@@ -712,7 +699,6 @@ to guidelines.
 Attribute | Value
 --- | ---
 Keywords | TODO, FIXME, OPTIMIZE, HACK, REVIEW
-
 
 ### References
 
@@ -840,7 +826,6 @@ SupportedStyles | assign_to_condition, assign_inside_condition
 SingleLineConditionsOnly | true
 IncludeTernaryExpressions | true
 
-
 ## Style/ConstantName
 
 Enabled by default | Supports autocorrection
@@ -882,7 +867,6 @@ Attribute | Value
 Notice | ^Copyright (\(c\) )?2[0-9]{3} .+
 AutocorrectNotice | 
 
-
 ## Style/DefWithParentheses
 
 Enabled by default | Supports autocorrection
@@ -917,7 +901,6 @@ same for all its children.
 Attribute | Value
 --- | ---
 Exclude | spec/\*\*/\*, test/\*\*/\*
-
 
 ## Style/DocumentationMethod
 
@@ -979,7 +962,6 @@ Attribute | Value
 Exclude | spec/\*\*/\*, test/\*\*/\*
 RequireForNonPublicMethods | false
 
-
 ## Style/DotPosition
 
 Enabled by default | Supports autocorrection
@@ -994,7 +976,6 @@ Attribute | Value
 --- | ---
 EnforcedStyle | leading
 SupportedStyles | leading, trailing
-
 
 ### References
 
@@ -1216,7 +1197,6 @@ Attribute | Value
 EnforcedStyle | both
 SupportedStyles | empty, nil, both
 
-
 ## Style/EmptyLineAfterMagicComment
 
 Enabled by default | Supports autocorrection
@@ -1262,7 +1242,6 @@ separated by empty lines.
 Attribute | Value
 --- | ---
 AllowAdjacentOneLineDefs | false
-
 
 ### References
 
@@ -1361,7 +1340,6 @@ Attribute | Value
 EnforcedStyle | no_empty_lines
 SupportedStyles | empty_lines, no_empty_lines
 
-
 ### References
 
 * [https://github.com/bbatsov/ruby-style-guide#empty-lines-around-bodies](https://github.com/bbatsov/ruby-style-guide#empty-lines-around-bodies)
@@ -1397,7 +1375,6 @@ Attribute | Value
 --- | ---
 EnforcedStyle | no_empty_lines
 SupportedStyles | empty_lines, empty_lines_except_namespace, empty_lines_special, no_empty_lines
-
 
 ### References
 
@@ -1543,7 +1520,6 @@ Attribute | Value
 EnforcedStyle | no_empty_lines
 SupportedStyles | empty_lines, empty_lines_except_namespace, empty_lines_special, no_empty_lines
 
-
 ### References
 
 * [https://github.com/bbatsov/ruby-style-guide#empty-lines-around-bodies](https://github.com/bbatsov/ruby-style-guide#empty-lines-around-bodies)
@@ -1613,7 +1589,6 @@ Attribute | Value
 EnforcedStyle | compact
 SupportedStyles | compact, expanded
 
-
 ### References
 
 * [https://github.com/bbatsov/ruby-style-guide#no-single-line-methods](https://github.com/bbatsov/ruby-style-guide#no-single-line-methods)
@@ -1642,7 +1617,6 @@ Attribute | Value
 EnforcedStyle | never
 SupportedStyles | when_needed, always, never
 AutoCorrectEncodingComment | # encoding: utf-8
-
 
 ### References
 
@@ -1674,7 +1648,6 @@ Attribute | Value
 --- | ---
 EnforcedStyle | native
 SupportedStyles | native, lf, crlf
-
 
 ### References
 
@@ -1733,7 +1706,6 @@ Attribute | Value
 AllowForAlignment | true
 ForceEqualSignAlignment | false
 
-
 ## Style/FileName
 
 Enabled by default | Supports autocorrection
@@ -1753,7 +1725,6 @@ ExpectMatchingDefinition | false
 Regex | 
 IgnoreExecutableScripts | true
 AllowedAcronyms | CLI, DSL, ACL, API, ASCII, CPU, CSS, DNS, EOF, GUID, HTML, HTTP, HTTPS, ID, IP, JSON, LHS, QPS, RAM, RHS, RPC, SLA, SMTP, SQL, SSH, TCP, TLS, TTL, UDP, UI, UID, UUID, URI, URL, UTF8, VM, XML, XMPP, XSRF, XSS
-
 
 ### References
 
@@ -1893,7 +1864,6 @@ EnforcedStyle | special_for_inner_method_call_in_parentheses
 SupportedStyles | consistent, special_for_inner_method_call, special_for_inner_method_call_in_parentheses
 IndentationWidth | 
 
-
 ## Style/FlipFlop
 
 Enabled by default | Supports autocorrection
@@ -1924,7 +1894,6 @@ Attribute | Value
 EnforcedStyle | each
 SupportedStyles | for, each
 
-
 ### References
 
 * [https://github.com/bbatsov/ruby-style-guide#no-for-loops](https://github.com/bbatsov/ruby-style-guide#no-for-loops)
@@ -1950,7 +1919,6 @@ Attribute | Value
 EnforcedStyle | format
 SupportedStyles | format, sprintf, percent
 
-
 ### References
 
 * [https://github.com/bbatsov/ruby-style-guide#sprintf](https://github.com/bbatsov/ruby-style-guide#sprintf)
@@ -1974,7 +1942,6 @@ Attribute | Value
 EnforcedStyle | when_needed
 SupportedStyles | when_needed, always, never
 
-
 ## Style/GlobalVars
 
 Enabled by default | Supports autocorrection
@@ -1993,7 +1960,6 @@ Note that backreferences like $1, $2, etc are not global variables.
 Attribute | Value
 --- | ---
 AllowedVariables | 
-
 
 ### References
 
@@ -2047,7 +2013,6 @@ ok
 Attribute | Value
 --- | ---
 MinBodyLength | 1
-
 
 ### References
 
@@ -2130,7 +2095,6 @@ EnforcedStyle | ruby19
 SupportedStyles | ruby19, hash_rockets, no_mixed_keys, ruby19_no_mixed_keys
 UseHashRocketsWithSymbolValues | false
 PreferHashRocketsForNonAlnumEndingSymbols | false
-
 
 ### References
 
@@ -2232,7 +2196,6 @@ The maximum line length is configurable.
 Attribute | Value
 --- | ---
 MaxLineLength | 80
-
 
 ### References
 
@@ -2348,7 +2311,6 @@ EnforcedStyle | special_inside_parentheses
 SupportedStyles | special_inside_parentheses, consistent, align_brackets
 IndentationWidth | 
 
-
 ## Style/IndentAssignment
 
 Enabled by default | Supports autocorrection
@@ -2382,7 +2344,6 @@ end
 Attribute | Value
 --- | ---
 IndentationWidth | 
-
 
 ## Style/IndentHash
 
@@ -2433,7 +2394,6 @@ EnforcedStyle | special_inside_parentheses
 SupportedStyles | special_inside_parentheses, consistent, align_braces
 IndentationWidth | 
 
-
 ## Style/IndentHeredoc
 
 Enabled by default | Supports autocorrection
@@ -2472,7 +2432,6 @@ Attribute | Value
 EnforcedStyle | ruby23
 SupportedStyles | ruby23, active_support, powerpack, unindent
 
-
 ### References
 
 * [https://github.com/bbatsov/ruby-style-guide#squiggly-heredocs](https://github.com/bbatsov/ruby-style-guide#squiggly-heredocs)
@@ -2503,7 +2462,6 @@ Attribute | Value
 EnforcedStyle | normal
 SupportedStyles | normal, rails
 
-
 ## Style/IndentationWidth
 
 Enabled by default | Supports autocorrection
@@ -2527,7 +2485,6 @@ end
 Attribute | Value
 --- | ---
 Width | 2
-
 
 ### References
 
@@ -2631,7 +2588,6 @@ Attribute | Value
 InverseMethods | {:any?=>:none?, :even?=>:odd?, :===>:!=, :=~=>:!~, :<=>:>=, :>=>:<=}
 InverseBlocks | {:select=>:reject, :select!=>:reject!}
 
-
 ## Style/Lambda
 
 Enabled by default | Supports autocorrection
@@ -2698,7 +2654,6 @@ Attribute | Value
 EnforcedStyle | line_count_dependent
 SupportedStyles | line_count_dependent, lambda, literal
 
-
 ### References
 
 * [https://github.com/bbatsov/ruby-style-guide#lambda-multi-line](https://github.com/bbatsov/ruby-style-guide#lambda-multi-line)
@@ -2727,7 +2682,6 @@ Attribute | Value
 --- | ---
 EnforcedStyle | call
 SupportedStyles | call, braces
-
 
 ### References
 
@@ -2804,7 +2758,6 @@ Attribute | Value
 --- | ---
 IgnoredMethods | 
 
-
 ### References
 
 * [https://github.com/bbatsov/ruby-style-guide#method-invocation-parens](https://github.com/bbatsov/ruby-style-guide#method-invocation-parens)
@@ -2869,7 +2822,6 @@ Attribute | Value
 EnforcedStyle | require_parentheses
 SupportedStyles | require_parentheses, require_no_parentheses, require_no_parentheses_except_multiline
 
-
 ### References
 
 * [https://github.com/bbatsov/ruby-style-guide#method-parens](https://github.com/bbatsov/ruby-style-guide#method-parens)
@@ -2923,7 +2875,6 @@ Attribute | Value
 EnforcedStyle | snake_case
 SupportedStyles | snake_case, camelCase
 
-
 ### References
 
 * [https://github.com/bbatsov/ruby-style-guide#snake-case-symbols-methods-vars](https://github.com/bbatsov/ruby-style-guide#snake-case-symbols-methods-vars)
@@ -2970,7 +2921,6 @@ Attribute | Value
 --- | ---
 EnforcedStyle | both
 SupportedStyles | if, case, both
-
 
 ## Style/MixinGrouping
 
@@ -3019,7 +2969,6 @@ Attribute | Value
 EnforcedStyle | separated
 SupportedStyles | separated, grouped
 
-
 ### References
 
 * [https://github.com/bbatsov/ruby-style-guide#mixin-grouping](https://github.com/bbatsov/ruby-style-guide#mixin-grouping)
@@ -3060,7 +3009,6 @@ Attribute | Value
 --- | ---
 EnforcedStyle | module_function
 SupportedStyles | module_function, extend_self
-
 
 ### References
 
@@ -3134,7 +3082,6 @@ Attribute | Value
 EnforcedStyle | symmetrical
 SupportedStyles | symmetrical, new_line, same_line
 
-
 ## Style/MultilineAssignmentLayout
 
 Enabled by default | Supports autocorrection
@@ -3179,7 +3126,6 @@ Attribute | Value
 SupportedTypes | block, case, class, if, kwbegin, module
 EnforcedStyle | new_line
 SupportedStyles | same_line, new_line
-
 
 ### References
 
@@ -3318,7 +3264,6 @@ Attribute | Value
 EnforcedStyle | symmetrical
 SupportedStyles | symmetrical, new_line, same_line
 
-
 ## Style/MultilineIfModifier
 
 Enabled by default | Supports autocorrection
@@ -3415,7 +3360,6 @@ Attribute | Value
 EnforcedStyle | keyword
 SupportedStyles | keyword, braces
 
-
 ## Style/MultilineMethodCallBraceLayout
 
 Enabled by default | Supports autocorrection
@@ -3484,7 +3428,6 @@ Attribute | Value
 EnforcedStyle | symmetrical
 SupportedStyles | symmetrical, new_line, same_line
 
-
 ## Style/MultilineMethodCallIndentation
 
 Enabled by default | Supports autocorrection
@@ -3528,7 +3471,6 @@ Attribute | Value
 EnforcedStyle | aligned
 SupportedStyles | aligned, indented, indented_relative_to_receiver
 IndentationWidth | 
-
 
 ## Style/MultilineMethodDefinitionBraceLayout
 
@@ -3598,7 +3540,6 @@ Attribute | Value
 EnforcedStyle | symmetrical
 SupportedStyles | symmetrical, new_line, same_line
 
-
 ## Style/MultilineOperationIndentation
 
 Enabled by default | Supports autocorrection
@@ -3625,7 +3566,6 @@ Attribute | Value
 EnforcedStyle | aligned
 SupportedStyles | aligned, indented
 IndentationWidth | 
-
 
 ## Style/MultilineTernaryOperator
 
@@ -3770,7 +3710,6 @@ EnforcedStyle | skip_modifier_ifs
 MinBodyLength | 3
 SupportedStyles | skip_modifier_ifs, always
 
-
 ### References
 
 * [https://github.com/bbatsov/ruby-style-guide#no-nested-conditionals](https://github.com/bbatsov/ruby-style-guide#no-nested-conditionals)
@@ -3832,7 +3771,6 @@ Attribute | Value
 --- | ---
 IncludeSemanticChanges | false
 
-
 ### References
 
 * [https://github.com/bbatsov/ruby-style-guide#no-non-nil-checks](https://github.com/bbatsov/ruby-style-guide#no-non-nil-checks)
@@ -3869,7 +3807,6 @@ Attribute | Value
 --- | ---
 EnforcedOctalStyle | zero_with_o
 SupportedOctalStyles | zero_with_o, zero_only
-
 
 ### References
 
@@ -3908,7 +3845,6 @@ of digits in them.
 Attribute | Value
 --- | ---
 MinDigits | 5
-
 
 ### References
 
@@ -3970,7 +3906,6 @@ AutoCorrect | false
 EnforcedStyle | predicate
 SupportedStyles | predicate, comparison
 Exclude | spec/\*\*/\*
-
 
 ### References
 
@@ -4043,7 +3978,6 @@ end
 Attribute | Value
 --- | ---
 SuspiciousParamNames | options, opts, args, params, parameters
-
 
 ## Style/OptionalArguments
 
@@ -4119,7 +4053,6 @@ Attribute | Value
 --- | ---
 AllowSafeAssignment | true
 
-
 ### References
 
 * [https://github.com/bbatsov/ruby-style-guide#no-parens-around-condition](https://github.com/bbatsov/ruby-style-guide#no-parens-around-condition)
@@ -4137,7 +4070,6 @@ This cop enforces the consistent usage of `%`-literal delimiters.
 Attribute | Value
 --- | ---
 PreferredDelimiters | {"%"=>"()", "%i"=>"()", "%I"=>"()", "%q"=>"()", "%Q"=>"()", "%r"=>"{}", "%s"=>"()", "%w"=>"()", "%W"=>"()", "%x"=>"()"}
-
 
 ### References
 
@@ -4157,7 +4089,6 @@ Attribute | Value
 --- | ---
 EnforcedStyle | lower_case_q
 SupportedStyles | lower_case_q, upper_case_q
-
 
 ## Style/PerlBackrefs
 
@@ -4205,7 +4136,6 @@ NamePrefixBlacklist | is_, has_, have_
 NameWhitelist | is_a?
 Exclude | spec/\*\*/\*
 
-
 ### References
 
 * [https://github.com/bbatsov/ruby-style-guide#bool-methods-qmark](https://github.com/bbatsov/ruby-style-guide#bool-methods-qmark)
@@ -4252,7 +4182,6 @@ Attribute | Value
 --- | ---
 EnforcedStyle | short
 SupportedStyles | short, verbose
-
 
 ### References
 
@@ -4320,7 +4249,6 @@ Attribute | Value
 --- | ---
 EnforcedStyle | exploded
 SupportedStyles | compact, exploded
-
 
 ### References
 
@@ -4455,7 +4383,6 @@ Attribute | Value
 --- | ---
 AllowMultipleReturnValues | false
 
-
 ### References
 
 * [https://github.com/bbatsov/ruby-style-guide#no-explicit-return](https://github.com/bbatsov/ruby-style-guide#no-explicit-return)
@@ -4552,7 +4479,6 @@ Attribute | Value
 EnforcedStyle | slashes
 SupportedStyles | slashes, percent_r, mixed
 AllowInnerSlashes | false
-
 
 ### References
 
@@ -4653,7 +4579,6 @@ Attribute | Value
 --- | ---
 ConvertCodeThatCanStartToReturnNil | false
 
-
 ## Style/SelfAssignment
 
 Enabled by default | Supports autocorrection
@@ -4691,7 +4616,6 @@ Attribute | Value
 --- | ---
 AllowAsExpressionSeparator | false
 
-
 ### References
 
 * [https://github.com/bbatsov/ruby-style-guide#no-semicolon](https://github.com/bbatsov/ruby-style-guide#no-semicolon)
@@ -4723,7 +4647,6 @@ Attribute | Value
 EnforcedStyle | only_raise
 SupportedStyles | only_raise, only_fail, semantic
 
-
 ### References
 
 * [https://github.com/bbatsov/ruby-style-guide#prefer-raise-over-fail](https://github.com/bbatsov/ruby-style-guide#prefer-raise-over-fail)
@@ -4746,7 +4669,6 @@ Attribute | Value
 --- | ---
 Methods | {"reduce"=>["acc", "elem"]}, {"inject"=>["acc", "elem"]}
 
-
 ## Style/SingleLineMethods
 
 Enabled by default | Supports autocorrection
@@ -4761,7 +4683,6 @@ It can optionally accept single-line methods with no body.
 Attribute | Value
 --- | ---
 AllowIfMethodIsEmpty | true
-
 
 ### References
 
@@ -4874,7 +4795,6 @@ Attribute | Value
 EnforcedStyleInsidePipes | no_space
 SupportedStylesInsidePipes | space, no_space
 
-
 ## Style/SpaceAroundEqualsInParameterDefault
 
 Enabled by default | Supports autocorrection
@@ -4890,7 +4810,6 @@ Attribute | Value
 --- | ---
 EnforcedStyle | space
 SupportedStyles | space, no_space
-
 
 ### References
 
@@ -4941,7 +4860,6 @@ Attribute | Value
 --- | ---
 AllowForAlignment | true
 
-
 ### References
 
 * [https://github.com/bbatsov/ruby-style-guide#spaces-operators](https://github.com/bbatsov/ruby-style-guide#spaces-operators)
@@ -4961,7 +4879,6 @@ Attribute | Value
 --- | ---
 EnforcedStyle | space
 SupportedStyles | space, no_space
-
 
 ## Style/SpaceBeforeComma
 
@@ -5011,7 +4928,6 @@ Attribute | Value
 --- | ---
 AllowForAlignment | true
 
-
 ## Style/SpaceBeforeSemicolon
 
 Enabled by default | Supports autocorrection
@@ -5057,7 +4973,6 @@ Attribute | Value
 EnforcedStyle | require_no_space
 SupportedStyles | require_no_space, require_space
 
-
 ## Style/SpaceInsideArrayPercentLiteral
 
 Enabled by default | Supports autocorrection
@@ -5098,7 +5013,6 @@ EnforcedStyleForEmptyBraces | no_space
 SupportedStylesForEmptyBraces | space, no_space
 SpaceBeforeBlockParameters | true
 
-
 ## Style/SpaceInsideBrackets
 
 Enabled by default | Supports autocorrection
@@ -5128,7 +5042,6 @@ EnforcedStyle | space
 SupportedStyles | space, no_space, compact
 EnforcedStyleForEmptyBraces | no_space
 SupportedStylesForEmptyBraces | space, no_space
-
 
 ### References
 
@@ -5221,7 +5134,6 @@ Attribute | Value
 EnforcedStyle | no_space
 SupportedStyles | space, no_space
 
-
 ### References
 
 * [https://github.com/bbatsov/ruby-style-guide#string-interpolation](https://github.com/bbatsov/ruby-style-guide#string-interpolation)
@@ -5240,7 +5152,6 @@ Attribute | Value
 --- | ---
 EnforcedStyle | use_english_names
 SupportedStyles | use_perl_names, use_english_names
-
 
 ### References
 
@@ -5278,7 +5189,6 @@ Attribute | Value
 EnforcedStyle | require_parentheses
 SupportedStyles | require_parentheses, require_no_parentheses
 
-
 ### References
 
 * [https://github.com/bbatsov/ruby-style-guide#stabby-lambda-with-args](https://github.com/bbatsov/ruby-style-guide#stabby-lambda-with-args)
@@ -5299,7 +5209,6 @@ EnforcedStyle | single_quotes
 SupportedStyles | single_quotes, double_quotes
 ConsistentQuotesInMultiline | false
 
-
 ### References
 
 * [https://github.com/bbatsov/ruby-style-guide#consistent-string-literals](https://github.com/bbatsov/ruby-style-guide#consistent-string-literals)
@@ -5319,7 +5228,6 @@ Attribute | Value
 EnforcedStyle | single_quotes
 SupportedStyles | single_quotes, double_quotes
 
-
 ## Style/StringMethods
 
 Enabled by default | Supports autocorrection
@@ -5334,7 +5242,6 @@ from the String class.
 Attribute | Value
 --- | ---
 PreferredMethods | {"intern"=>"to_sym"}
-
 
 ## Style/StructInheritance
 
@@ -5378,7 +5285,6 @@ Attribute | Value
 --- | ---
 EnforcedStyle | percent
 SupportedStyles | percent, brackets
-
 
 ### References
 
@@ -5425,7 +5331,6 @@ something.map(&:upcase)
 Attribute | Value
 --- | ---
 IgnoredMethods | respond_to, define_method
-
 
 ## Style/Tab
 
@@ -5499,7 +5404,6 @@ EnforcedStyle | require_no_parentheses
 SupportedStyles | require_parentheses, require_no_parentheses, require_parentheses_when_complex
 AllowSafeAssignment | true
 
-
 ## Style/TrailingBlankLines
 
 Enabled by default | Supports autocorrection
@@ -5515,7 +5419,6 @@ Attribute | Value
 --- | ---
 EnforcedStyle | final_newline
 SupportedStyles | final_newline, final_blank_line
-
 
 ### References
 
@@ -5561,7 +5464,6 @@ Attribute | Value
 EnforcedStyleForMultiline | no_comma
 SupportedStylesForMultiline | comma, consistent_comma, no_comma
 
-
 ### References
 
 * [https://github.com/bbatsov/ruby-style-guide#no-trailing-params-comma](https://github.com/bbatsov/ruby-style-guide#no-trailing-params-comma)
@@ -5606,7 +5508,6 @@ Attribute | Value
 EnforcedStyleForMultiline | no_comma
 SupportedStylesForMultiline | comma, consistent_comma, no_comma
 
-
 ### References
 
 * [https://github.com/bbatsov/ruby-style-guide#no-trailing-array-commas](https://github.com/bbatsov/ruby-style-guide#no-trailing-array-commas)
@@ -5644,7 +5545,6 @@ Attribute | Value
 --- | ---
 AllowNamedUnderscoreVariables | true
 
-
 ## Style/TrailingWhitespace
 
 Enabled by default | Supports autocorrection
@@ -5675,7 +5575,6 @@ AllowPredicates | true
 AllowDSLWriters | false
 IgnoreClassMethods | false
 Whitelist | to_ary, to_a, to_c, to_enum, to_h, to_hash, to_i, to_int, to_io, to_open, to_path, to_proc, to_r, to_regexp, to_str, to_s, to_sym
-
 
 ### References
 
@@ -5762,7 +5661,6 @@ Attribute | Value
 EnforcedStyle | snake_case
 SupportedStyles | snake_case, camelCase
 
-
 ### References
 
 * [https://github.com/bbatsov/ruby-style-guide#snake-case-symbols-methods-vars](https://github.com/bbatsov/ruby-style-guide#snake-case-symbols-methods-vars)
@@ -5824,7 +5722,6 @@ Attribute | Value
 EnforcedStyle | normalcase
 SupportedStyles | snake_case, normalcase, non_integer
 
-
 ## Style/WhenThen
 
 Enabled by default | Supports autocorrection
@@ -5865,7 +5762,6 @@ Attribute | Value
 --- | ---
 MaxLineLength | 80
 
-
 ### References
 
 * [https://github.com/bbatsov/ruby-style-guide#while-as-a-modifier](https://github.com/bbatsov/ruby-style-guide#while-as-a-modifier)
@@ -5890,7 +5786,6 @@ EnforcedStyle | percent
 SupportedStyles | percent, brackets
 MinSize | 0
 WordRegex | (?-mix:\A[\p{Word}\n\t]+\z)
-
 
 ### References
 

--- a/manual/cops_style.md
+++ b/manual/cops_style.md
@@ -15,7 +15,7 @@ Attribute | Value
 --- | ---
 EnforcedStyle | indent
 SupportedStyles | outdent, indent
-IndentationWidth | 
+IndentationWidth |
 
 ### References
 
@@ -211,7 +211,7 @@ Attribute | Value
 --- | ---
 EnforcedStyle | with_first_parameter
 SupportedStyles | with_first_parameter, with_fixed_indentation
-IndentationWidth | 
+IndentationWidth |
 
 ### References
 
@@ -454,7 +454,7 @@ Attribute | Value
 EnforcedStyle | case
 SupportedStyles | case, end
 IndentOneStep | false
-IndentationWidth | 
+IndentationWidth |
 
 ### References
 
@@ -865,7 +865,7 @@ an offense is reported.
 Attribute | Value
 --- | ---
 Notice | ^Copyright (\(c\) )?2[0-9]{3} .+
-AutocorrectNotice | 
+AutocorrectNotice |
 
 ## Style/DefWithParentheses
 
@@ -1720,9 +1720,9 @@ first line) are ignored.
 
 Attribute | Value
 --- | ---
-Exclude | 
+Exclude |
 ExpectMatchingDefinition | false
-Regex | 
+Regex |
 IgnoreExecutableScripts | true
 AllowedAcronyms | CLI, DSL, ACL, API, ASCII, CPU, CSS, DNS, EOF, GUID, HTML, HTTP, HTTPS, ID, IP, JSON, LHS, QPS, RAM, RHS, RPC, SLA, SMTP, SQL, SSH, TCP, TLS, TTL, UDP, UI, UID, UUID, URI, URL, UTF8, VM, XML, XMPP, XSRF, XSS
 
@@ -1862,7 +1862,7 @@ Attribute | Value
 --- | ---
 EnforcedStyle | special_for_inner_method_call_in_parentheses
 SupportedStyles | consistent, special_for_inner_method_call, special_for_inner_method_call_in_parentheses
-IndentationWidth | 
+IndentationWidth |
 
 ## Style/FlipFlop
 
@@ -1959,7 +1959,7 @@ Note that backreferences like $1, $2, etc are not global variables.
 
 Attribute | Value
 --- | ---
-AllowedVariables | 
+AllowedVariables |
 
 ### References
 
@@ -2309,7 +2309,7 @@ Attribute | Value
 --- | ---
 EnforcedStyle | special_inside_parentheses
 SupportedStyles | special_inside_parentheses, consistent, align_brackets
-IndentationWidth | 
+IndentationWidth |
 
 ## Style/IndentAssignment
 
@@ -2343,7 +2343,7 @@ end
 
 Attribute | Value
 --- | ---
-IndentationWidth | 
+IndentationWidth |
 
 ## Style/IndentHash
 
@@ -2392,7 +2392,7 @@ Attribute | Value
 --- | ---
 EnforcedStyle | special_inside_parentheses
 SupportedStyles | special_inside_parentheses, consistent, align_braces
-IndentationWidth | 
+IndentationWidth |
 
 ## Style/IndentHeredoc
 
@@ -2756,7 +2756,7 @@ puts 'test'
 
 Attribute | Value
 --- | ---
-IgnoredMethods | 
+IgnoredMethods |
 
 ### References
 
@@ -3470,7 +3470,7 @@ Attribute | Value
 --- | ---
 EnforcedStyle | aligned
 SupportedStyles | aligned, indented, indented_relative_to_receiver
-IndentationWidth | 
+IndentationWidth |
 
 ## Style/MultilineMethodDefinitionBraceLayout
 
@@ -3565,7 +3565,7 @@ Attribute | Value
 --- | ---
 EnforcedStyle | aligned
 SupportedStyles | aligned, indented
-IndentationWidth | 
+IndentationWidth |
 
 ## Style/MultilineTernaryOperator
 

--- a/manual/cops_style.md
+++ b/manual/cops_style.md
@@ -132,6 +132,7 @@ can also be configured. The options are:
    :ba => baz
 }
 ```
+
 ```ruby
 # EnforcedHashRocketStyle: separator
 # EnforcedColonStyle: separator
@@ -160,6 +161,7 @@ can also be configured. The options are:
   :ba  => baz
 }
 ```
+
 ```ruby
 # EnforcedHashRocketStyle: table
 # EnforcedColonStyle: table
@@ -1031,6 +1033,7 @@ This check only applies if the block takes no parameters.
 # good
 5.times { }
 ```
+
 ```ruby
 # bad
 (0...10).each {}
@@ -1141,6 +1144,7 @@ if condition
   statement
 end
 ```
+
 ```ruby
 # empty - warn only on empty else
 
@@ -1157,6 +1161,7 @@ else
   nil
 end
 ```
+
 ```ruby
 # nil - warn on else with nil in it
 
@@ -1173,6 +1178,7 @@ if condition
 else
 end
 ```
+
 ```ruby
 # both - warn on empty else and else with nil in it
 
@@ -2054,6 +2060,7 @@ The supported styles are:
 {:a => 2}
 {b: 1, :c => 2}
 ```
+
 ```ruby
 "EnforcedStyle => 'hash_rockets'"
 
@@ -2064,6 +2071,7 @@ The supported styles are:
 {a: 1, b: 2}
 {c: 1, 'd' => 5}
 ```
+
 ```ruby
 "EnforcedStyle => 'no_mixed_keys'"
 
@@ -2075,6 +2083,7 @@ The supported styles are:
 {:a => 1, b: 2}
 {c: 1, 'd' => 2}
 ```
+
 ```ruby
 "EnforcedStyle => 'ruby19_no_mixed_keys'"
 
@@ -2616,6 +2625,7 @@ f = lambda do |x|
       x
     end
 ```
+
 ```ruby
 # EnforcedStyle: lambda
 
@@ -2631,6 +2641,7 @@ f = lambda do |x|
       x
     end
 ```
+
 ```ruby
 # EnforcedStyle: literal
 
@@ -2899,6 +2910,7 @@ if condition
   statement
 end
 ```
+
 ```ruby
 # bad
 case var
@@ -2906,6 +2918,7 @@ when condition
   statement
 end
 ```
+
 ```ruby
 # good
 if condition
@@ -3302,6 +3315,7 @@ Checks for uses of the `then` keyword in multi-line if statements.
 if cond then
 end
 ```
+
 ```ruby
 if cond then a
 elsif cond then b
@@ -3337,6 +3351,7 @@ foo ||= begin
   baz
 end
 ```
+
 ```ruby
 # EnforcedStyle: braces
 
@@ -3882,6 +3897,7 @@ foo.zero?
 foo.negative?
 bar.baz.positive?
 ```
+
 ```ruby
 # EnforcedStyle: comparison
 
@@ -4164,6 +4180,7 @@ Hash#has_value?
 Hash#key?
 Hash#value?
 ```
+
 ```ruby
 # EnforcedStyle: verbose
 
@@ -4230,6 +4247,7 @@ fail "message"
 raise MyCustomError.new(arg1, arg2, arg3)
 raise MyKwArgError.new(key1: val1, key2: val2)
 ```
+
 ```ruby
 # EnforcedStyle: compact
 
@@ -4956,6 +4974,7 @@ EnforcedStyle: require_no_space (default)
   # good
   a = ->(x, y) { x + y }
 ```
+
 ```ruby
 EnforcedStyle: require_space
 
@@ -5369,6 +5388,7 @@ foo = bar? ? a : b
 foo = bar.baz? ? a : b
 foo = bar && baz ? a : b
 ```
+
 ```ruby
 EnforcedStyle: require_parentheses
 
@@ -5382,6 +5402,7 @@ foo = (bar?) ? a : b
 foo = (bar.baz?) ? a : b
 foo = (bar && baz) ? a : b
 ```
+
 ```ruby
 EnforcedStyle: require_parentheses_when_complex
 
@@ -5688,6 +5709,7 @@ variable1 = 1
 
 variable_1 = 1
 ```
+
 ```ruby
 "EnforcedStyle => 'normalcase'"
 
@@ -5699,6 +5721,7 @@ variable_1 = 1
 
 variable1 = 1
 ```
+
 ```ruby
 "EnforcedStyle => 'non_integer'"
 

--- a/manual/cops_style.md
+++ b/manual/cops_style.md
@@ -3761,10 +3761,12 @@ This cop checks for non-nil checks, which are usually redundant.
 
 Non-nil checks are allowed if they are the final nodes of predicate.
 
- # good
- def signed_in?
-   !current_user.nil?
- end
+```
+# good
+def signed_in?
+  !current_user.nil?
+end
+```
 
 ### Example
 

--- a/manual/cops_style.md
+++ b/manual/cops_style.md
@@ -94,17 +94,17 @@ Check that the keys, separators, and values of a multi-line hash
 literal are aligned according to configuration. The configuration
 options are:
 
-- key (left align keys)
-- separator (align hash rockets and colons, right align keys)
-- table (left align keys, hash rockets, and values)
+* key (left align keys)
+* separator (align hash rockets and colons, right align keys)
+* table (left align keys, hash rockets, and values)
 
 The treatment of hashes passed as the last argument to a method call
 can also be configured. The options are:
 
-- always_inspect
-- always_ignore
-- ignore_implicit (without curly braces)
-- ignore_explicit (with curly braces)
+* always_inspect
+* always_ignore
+* ignore_implicit (without curly braces)
+* ignore_explicit (with curly braces)
 
 ### Example
 

--- a/manual/cops_style.md
+++ b/manual/cops_style.md
@@ -94,17 +94,17 @@ Check that the keys, separators, and values of a multi-line hash
 literal are aligned according to configuration. The configuration
 options are:
 
-  - key (left align keys)
-  - separator (align hash rockets and colons, right align keys)
-  - table (left align keys, hash rockets, and values)
+- key (left align keys)
+- separator (align hash rockets and colons, right align keys)
+- table (left align keys, hash rockets, and values)
 
 The treatment of hashes passed as the last argument to a method call
 can also be configured. The options are:
 
-  - always_inspect
-  - always_ignore
-  - ignore_implicit (without curly braces)
-  - ignore_explicit (with curly braces)
+- always_inspect
+- always_ignore
+- ignore_implicit (without curly braces)
+- ignore_explicit (with curly braces)
 
 ### Example
 

--- a/manual/development.md
+++ b/manual/development.md
@@ -5,13 +5,13 @@ Use a rake task to generate a cop template.
 ```sh
 $ bundle exec rake new_cop[Category/Name]
 created
-- lib/rubocop/cop/category/name.rb
-- spec/rubocop/cop/category/name_spec.rb
+* lib/rubocop/cop/category/name.rb
+* spec/rubocop/cop/category/name_spec.rb
 
 Do 4 steps
-- Add an entry to `New feature` section in CHANGELOG.md
+* Add an entry to `New feature` section in CHANGELOG.md
   - e.g. Add new `Category/Name` cop. ([@your_id][])
-- Add `require 'lib/rubocop/cop/category/name'` into lib/rubocop.rb
-- Add an entry into config/enabled.yml or config/disabled.yml
-- Implement a new cop to the generated file!
+* Add `require 'lib/rubocop/cop/category/name'` into lib/rubocop.rb
+* Add an entry into config/enabled.yml or config/disabled.yml
+* Implement a new cop to the generated file!
 ```

--- a/manual/formatters.md
+++ b/manual/formatters.md
@@ -110,7 +110,7 @@ lib/bar.rb:13:14: W: File.exists? is deprecated in favor of File.exist?.
 
 ### Emacs Style Formatter
 
-**Machine-parsable**
+- **Machine-parsable**
 
 The `emacs` formatter displays the offenses in a format suitable for consumption by `Emacs` (and possibly other tools).
 
@@ -138,7 +138,7 @@ W:  4:  5: end at 4, 4 is not aligned with if at 2, 2
 
 ### File List Formatter
 
- **Machine-parsable**
+- **Machine-parsable**
 
 Sometimes you might want to just open all files with offenses in your
 favorite editor. This formatter outputs just the names of the files
@@ -150,7 +150,7 @@ $ rubocop --format files | xargs vim
 
 ### JSON Formatter
 
-**Machine-parsable**
+- **Machine-parsable**
 
 You can get RuboCop's inspection result in JSON format by passing `--format json` option in command line.
 The JSON structure is like the following example:

--- a/manual/index.md
+++ b/manual/index.md
@@ -2,7 +2,7 @@
   <img src="https://raw.githubusercontent.com/bbatsov/rubocop/master/logo/rubo-logo-horizontal.png" alt="RuboCop Logo"/>
 </p>
 
-> Role models are important. <br/>
+> Role models are important.<br>
 > ― Officer Alex J. Murphy / RoboCop
 
 **RuboCop** is a Ruby static code analyzer. Out of the box it will

--- a/manual/index.md
+++ b/manual/index.md
@@ -3,7 +3,7 @@
 </p>
 
 > Role models are important. <br/>
-> -- Officer Alex J. Murphy / RoboCop
+> ― Officer Alex J. Murphy / RoboCop
 
 **RuboCop** is a Ruby static code analyzer. Out of the box it will
 enforce many of the guidelines outlined in the community

--- a/relnotes/v0.21.0.md
+++ b/relnotes/v0.21.0.md
@@ -3,7 +3,6 @@ change is that we've changed the syntax for excluding/including to be closer to 
 
 Below is the list of all the gory details. Enjoy!
 
-
 ### New features
 
 * [#835](https://github.com/bbatsov/rubocop/issues/835): New cop `UnneededCapitalW` checks for `%W` when interpolation not necessary and `%w` would do. ([@sfeldon][])

--- a/relnotes/v0.23.0.md
+++ b/relnotes/v0.23.0.md
@@ -1,9 +1,10 @@
 This release is mostly about fixing bugs, but it also features a few prominent changes:
 
 * Cops are now namespace aware, which would it make it simpler to write RuboCop extensions without
-worrying about name collisions (e.g. you can now have `Style/Filename` and `RSpec/Filename` cops).
+  worrying about name collisions (e.g. you can now have `Style/Filename` and `RSpec/Filename` cops).
 * There's now logic which prevents auto-corrections from generated invalid Ruby code.
-* The `Rubocop` module was renamed to `RuboCop`, which will affect packages relying on RuboCop's public API.
+* The `Rubocop` module was renamed to `RuboCop`, which will affect packages relying
+  on RuboCop's public API.
 
 Below is the list of all the gory details. Enjoy!
 

--- a/relnotes/v0.23.0.md
+++ b/relnotes/v0.23.0.md
@@ -7,7 +7,6 @@ worrying about name collisions (e.g. you can now have `Style/Filename` and `RSpe
 
 Below is the list of all the gory details. Enjoy!
 
-
 ### New features
 
 * [#1117](https://github.com/bbatsov/rubocop/issues/1117): `BlockComments` cop does auto-correction. ([@jonas054][])

--- a/tasks/markdown_lint.rake
+++ b/tasks/markdown_lint.rake
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+require 'mdl'
+
+desc 'Lint markdown files'
+task :markdown_lint do
+  exclude = [
+    'MD002', # First header should be a top level header
+    'MD013', # Line length
+    'MD024', # Multiple headers with the same content
+    'MD033'  # Inline HTML
+  ]
+
+  ruleset = MarkdownLint::RuleSet.new
+  ruleset.load_default
+  rules = ruleset.rules
+  MarkdownLint::Style.load(MarkdownLint::Config[:style], rules)
+  rules = rules.map(&:first).reject { |name| exclude.include?(name) }.join(',')
+
+  begin
+    MarkdownLint.run(['-r', rules] + Dir['**/*.md'])
+  rescue SystemExit => e
+    exit 1 unless e.success?
+  end
+end

--- a/tasks/markdown_lint.rake
+++ b/tasks/markdown_lint.rake
@@ -8,7 +8,10 @@ task :markdown_lint do
     'MD002', # First header should be a top level header
     'MD013', # Line length
     'MD024', # Multiple headers with the same content
-    'MD033'  # Inline HTML
+    'MD033', # Inline HTML
+    'MD038', # Spaces inside code span elements
+    'MD014', # Dollar signs used before commands without showing output
+    'MD029'  # Ordered list item prefix
   ]
 
   ruleset = MarkdownLint::RuleSet.new


### PR DESCRIPTION
Add a markdown linter for a better markdown :)

Ok, so what do you think? Is having a markdown linter too much? Linting inside a linter is too meta? 😄 

- [x] Add to CI
- [x] No offenses left
- [ ] Fix rake task doc generation

Most common offenses are line length and headers with same content but I disabled them for now:

```ruby
>> puts `mdl -r #{`mdl -l`.lines[1..-1].map { |l| l.split.first }.join(',')} **/*.md`.lines.map { |l| l.split[1] }.group_by(&:itself).map { |a, b| [a, b.size] }.sort_by(&:last).reverse.map { |l| "- " + l.join(": ") }.join("\n")
```

```
# master
- MD013: 1188
- MD024: 530
- MD031: 214
- MD012: 155
- MD002: 54
- MD009: 18
- MD004: 14
- MD005: 12
- MD014: 11
- MD034: 5
- MD032: 5
- MD036: 3
- MD006: 3
- MD033: 3
- MD029: 2
- MD038: 1
- MD023: 1
- MD027: 1
- MD007: 1

# current markdown-linter branch
- MD013: 1187
- MD024: 530
- MD002: 54
- MD014: 11
- MD034: 5
- MD036: 3
- MD033: 3
- MD029: 2
- MD038: 1
- MD023: 1
```

- [RULES.md](https://github.com/mivok/markdownlint/blob/master/docs/RULES.md)
- [scripts I wrote/used](https://github.com/mivok/markdownlint/pull/161)

-----------------

Before submitting the PR make sure the following are checked:

* [ ] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Used the same coding conventions as the rest of the project.
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [ ] Squashed related commits together.
* [ ] Added tests.
* Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] All tests are passing.
* [x] The new code doesn't generate RuboCop offenses.
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* Updated cop documentation with `rake generate_cops_documentation` (required only when you've added a new cop or changed the configuration/documentation of an existing cop).

[1]: http://chris.beams.io/posts/git-commit/