### PR TITLE
Add `IgnoreDslMethods` option to `Style/MethodCallWithArgsParentheses`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@
 * [#4028](https://github.com/bbatsov/rubocop/pull/4028): Add new `Style/IndentHeredoc` cop. ([@pocke][])
 * Add new `Style/InverseMethods` cop. ([@rrosenblum][])
 * [#4038](https://github.com/bbatsov/rubocop/pull/4038): Allow `default` key in the `Style/PercentLiteralDelimiters` cop config to set all preferred delimiters. ([@kddeisz][])
+* Add `IgnoreMacros` option to `Style/MethodCallWithArgsParentheses`. ([@drenmi][])
 
 ### Changes
 

--- a/config/default.yml
+++ b/config/default.yml
@@ -743,7 +743,7 @@ Style/LambdaCall:
     - braces
 
 Style/MethodCallWithArgsParentheses:
-  IgnoreDslMethods: true
+  IgnoreMacros: true
   IgnoredMethods: []
 
 Style/MethodDefParentheses:

--- a/config/default.yml
+++ b/config/default.yml
@@ -743,6 +743,7 @@ Style/LambdaCall:
     - braces
 
 Style/MethodCallWithArgsParentheses:
+  IgnoreDslMethods: true
   IgnoredMethods: []
 
 Style/MethodDefParentheses:

--- a/lib/rubocop/ast/node/send_node.rb
+++ b/lib/rubocop/ast/node/send_node.rb
@@ -6,6 +6,8 @@ module RuboCop
     # node when the builder constructs the AST, making its methods available
     # to all `send` nodes within RuboCop.
     class SendNode < Node
+      DSL_PARENT_NODES = [:class, :module].freeze
+
       # The receiving node of the method invocation.
       #
       # @return [Node, nil] the receiver of the invoked method or `nil`
@@ -26,6 +28,15 @@ module RuboCop
       # @return [Boolean] whether the method name matches the argument
       def method?(name)
         method_name == name.to_sym
+      end
+
+      # Checks whether the method is a DSL method. A DSL method is defined as
+      # a method that sits in a class- or module body and has an implicit
+      # receiver.
+      #
+      # @return [Boolean] whether the method is a DSL method
+      def dsl?
+        !receiver && DSL_PARENT_NODES.include?(parent && parent.type)
       end
 
       # Checks whether the method name matches the argument and has an

--- a/lib/rubocop/ast/node/send_node.rb
+++ b/lib/rubocop/ast/node/send_node.rb
@@ -6,7 +6,7 @@ module RuboCop
     # node when the builder constructs the AST, making its methods available
     # to all `send` nodes within RuboCop.
     class SendNode < Node
-      DSL_PARENT_NODES = [:class, :module].freeze
+      MACRO_PARENT_NODES = [:class, :module].freeze
 
       # The receiving node of the method invocation.
       #
@@ -30,13 +30,15 @@ module RuboCop
         method_name == name.to_sym
       end
 
-      # Checks whether the method is a DSL method. A DSL method is defined as
-      # a method that sits in a class- or module body and has an implicit
+      # Checks whether the method is a macro method. A macro method is defined
+      # as a method that sits in a class- or module body and has an implicit
       # receiver.
       #
-      # @return [Boolean] whether the method is a DSL method
-      def dsl?
-        !receiver && DSL_PARENT_NODES.include?(parent && parent.type)
+      # @note This does not include DSLs that use nested blocks, like RSpec
+      #
+      # @return [Boolean] whether the method is a macro method
+      def macro?
+        !receiver && MACRO_PARENT_NODES.include?(parent && parent.type)
       end
 
       # Checks whether the method name matches the argument and has an

--- a/lib/rubocop/cop/style/method_call_with_args_parentheses.rb
+++ b/lib/rubocop/cop/style/method_call_with_args_parentheses.rb
@@ -4,20 +4,33 @@ module RuboCop
   module Cop
     module Style
       # This cop checks presence of parentheses in method calls containing
-      # parameters.
-      # As in popular Ruby's frameworks a lot of methods should always be
-      # called without parentheses,
-      # users can ignore them by passing their names to IgnoredMethods option.
+      # parameters. By default, macro methods are ignored. Additional methods
+      # can be added to the `IgnoredMethods` list.
       #
       # @example
+      #
       #   # bad
       #   array.delete e
       #
       #   # good
       #   array.delete(e)
       #
-      #   # good if `puts` is listed in IgnoredMethods
+      #   # okay with `puts` listed in `IgnoredMethods`
       #   puts 'test'
+      #
+      #   # IgnoreMacros: true (default)
+      #
+      #   # good
+      #   class Foo
+      #     bar :baz
+      #   end
+      #
+      #   # IgnoreMacros: false
+      #
+      #   # bad
+      #   class Foo
+      #     bar :baz
+      #   end
       class MethodCallWithArgsParentheses < Cop
         MSG = 'Use parentheses for method calls with arguments.'.freeze
 
@@ -25,6 +38,7 @@ module RuboCop
           return if ignored_list.include?(node.method_name)
           return unless node.arguments? && !node.parenthesized?
           return if operator_call?(node)
+          return if ignore_macros? && node.macro?
 
           add_offense(node, :selector)
         end
@@ -55,6 +69,10 @@ module RuboCop
 
         def ignored_list
           cop_config['IgnoredMethods'].map(&:to_sym)
+        end
+
+        def ignore_macros?
+          cop_config['IgnoreMacros']
         end
 
         def parentheses?(node)

--- a/manual/cops_style.md
+++ b/manual/cops_style.md
@@ -2734,10 +2734,8 @@ Enabled by default | Supports autocorrection
 Disabled | Yes
 
 This cop checks presence of parentheses in method calls containing
-parameters.
-As in popular Ruby's frameworks a lot of methods should always be
-called without parentheses,
-users can ignore them by passing their names to IgnoredMethods option.
+parameters. By default, macro methods are ignored. Additional methods
+can be added to the `IgnoredMethods` list.
 
 ### Example
 
@@ -2748,14 +2746,29 @@ array.delete e
 # good
 array.delete(e)
 
-# good if `puts` is listed in IgnoredMethods
+# okay with `puts` listed in `IgnoredMethods`
 puts 'test'
+
+# IgnoreMacros: true (default)
+
+# good
+class Foo
+  bar :baz
+end
+
+# IgnoreMacros: false
+
+# bad
+class Foo
+  bar :baz
+end
 ```
 
 ### Important attributes
 
 Attribute | Value
 --- | ---
+IgnoreMacros | true
 IgnoredMethods |
 
 ### References

--- a/spec/rubocop/ast/send_node_spec.rb
+++ b/spec/rubocop/ast/send_node_spec.rb
@@ -85,6 +85,78 @@ describe RuboCop::AST::SendNode do
     end
   end
 
+  describe '#dsl?' do
+    context 'without a receiver' do
+      context 'when parent is a class' do
+        let(:send_node) { parse_source(source).ast.children[2] }
+
+        let(:source) do
+          ['class Foo',
+           '  bar :baz',
+           'end'].join("\n")
+        end
+
+        it { expect(send_node.dsl?).to be_truthy }
+      end
+
+      context 'when parent is a module' do
+        let(:send_node) { parse_source(source).ast.children[1] }
+
+        let(:source) do
+          ['module Foo',
+           '  bar :baz',
+           'end'].join("\n")
+        end
+
+        it { expect(send_node.dsl?).to be_truthy }
+      end
+
+      context 'when parent is a method definition' do
+        let(:send_node) { parse_source(source).ast.children[2] }
+
+        let(:source) do
+          ['def foo',
+           '  bar :baz',
+           'end'].join("\n")
+        end
+
+        it { expect(send_node.dsl?).to be_falsey }
+      end
+
+      context 'without a parent' do
+        let(:source) { 'bar :baz' }
+
+        it { expect(send_node.dsl?).to be_falsey }
+      end
+    end
+
+    context 'with a receiver' do
+      context 'when parent is a class' do
+        let(:send_node) { parse_source(source).ast.children[2] }
+
+        let(:source) do
+          ['class Foo',
+           '  qux.bar :baz',
+           'end'].join("\n")
+        end
+
+        it { expect(send_node.dsl?).to be_falsey }
+      end
+
+      context 'when parent is a module' do
+        let(:send_node) { parse_source(source).ast.children[1] }
+
+        let(:source) do
+          ['module Foo',
+           '  qux.bar :baz',
+           'end'].join("\n")
+        end
+
+        it { expect(send_node.dsl?).to be_falsey }
+      end
+    end
+  end
+
   describe '#command?' do
     context 'when argument is a symbol' do
       context 'with an explicit receiver' do

--- a/spec/rubocop/ast/send_node_spec.rb
+++ b/spec/rubocop/ast/send_node_spec.rb
@@ -85,7 +85,7 @@ describe RuboCop::AST::SendNode do
     end
   end
 
-  describe '#dsl?' do
+  describe '#macro?' do
     context 'without a receiver' do
       context 'when parent is a class' do
         let(:send_node) { parse_source(source).ast.children[2] }
@@ -96,7 +96,7 @@ describe RuboCop::AST::SendNode do
            'end'].join("\n")
         end
 
-        it { expect(send_node.dsl?).to be_truthy }
+        it { expect(send_node.macro?).to be_truthy }
       end
 
       context 'when parent is a module' do
@@ -108,7 +108,7 @@ describe RuboCop::AST::SendNode do
            'end'].join("\n")
         end
 
-        it { expect(send_node.dsl?).to be_truthy }
+        it { expect(send_node.macro?).to be_truthy }
       end
 
       context 'when parent is a method definition' do
@@ -120,13 +120,13 @@ describe RuboCop::AST::SendNode do
            'end'].join("\n")
         end
 
-        it { expect(send_node.dsl?).to be_falsey }
+        it { expect(send_node.macro?).to be_falsey }
       end
 
       context 'without a parent' do
         let(:source) { 'bar :baz' }
 
-        it { expect(send_node.dsl?).to be_falsey }
+        it { expect(send_node.macro?).to be_falsey }
       end
     end
 
@@ -140,7 +140,7 @@ describe RuboCop::AST::SendNode do
            'end'].join("\n")
         end
 
-        it { expect(send_node.dsl?).to be_falsey }
+        it { expect(send_node.macro?).to be_falsey }
       end
 
       context 'when parent is a module' do
@@ -152,7 +152,7 @@ describe RuboCop::AST::SendNode do
            'end'].join("\n")
         end
 
-        it { expect(send_node.dsl?).to be_falsey }
+        it { expect(send_node.macro?).to be_falsey }
       end
     end
   end

--- a/spec/rubocop/cop/style/method_call_with_args_parentheses_spec.rb
+++ b/spec/rubocop/cop/style/method_call_with_args_parentheses_spec.rb
@@ -81,9 +81,9 @@ describe RuboCop::Cop::Style::MethodCallWithArgsParentheses, :config do
     expect(cop.offenses).to be_empty
   end
 
-  context 'with DSL like methods' do
+  context 'when inspecting macro methods' do
     let(:cop_config) do
-      { 'IgnoreDslMethods' => 'true' }
+      { 'IgnoreMacros' => 'true' }
     end
 
     context 'in a class body' do

--- a/spec/rubocop/cop/style/method_call_with_args_parentheses_spec.rb
+++ b/spec/rubocop/cop/style/method_call_with_args_parentheses_spec.rb
@@ -80,4 +80,34 @@ describe RuboCop::Cop::Style::MethodCallWithArgsParentheses, :config do
     inspect_source(cop, 'puts :test')
     expect(cop.offenses).to be_empty
   end
+
+  context 'with DSL like methods' do
+    let(:cop_config) do
+      { 'IgnoreDslMethods' => 'true' }
+    end
+
+    context 'in a class body' do
+      it 'does not register an offense' do
+        inspect_source(cop, [
+          'class Foo',
+          '  bar :baz',
+          'end'
+        ].join("\n"))
+
+        expect(cop.offenses).to be_empty
+      end
+    end
+
+    context 'in a module body' do
+      it 'does not register an offense' do
+        inspect_source(cop, [
+          'module Foo',
+          '  bar :baz',
+          'end'
+        ].join("\n"))
+
+        expect(cop.offenses).to be_empty
+      end
+    end
+  end
 end


### PR DESCRIPTION
This cop was almost unusable in its current state, registering hundreds of false positives in a relatively simple application. 😅 

This change introduces a `IgnoreDslMethods` option (enabled by default) that ignores method calls that:

 - don't have a receiver, and
 - whose parent is a class- or module body.

-----------------

Before submitting the PR make sure the following are checked:

* [X] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [X] Used the same coding conventions as the rest of the project.
* [X] Feature branch is up-to-date with `master` (if not - rebase it).
* [X] Squashed related commits together.
* [x] Added tests.
* [X] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [X] All tests are passing.
* [X] The new code doesn't generate RuboCop offenses.
* [X] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [X] Updated cop documentation with `rake generate_cops_documentation` (required only when you've added a new cop or changed the configuration/documentation of an existing cop).

[1]: http://chris.beams.io/posts/git-commit/
