### PR TITLE
Support non-ASCII characters in 'Style/VariableName' cop

### DIFF
--- a/lib/rubocop/cop/mixin/configurable_naming.rb
+++ b/lib/rubocop/cop/mixin/configurable_naming.rb
@@ -8,8 +8,8 @@ module RuboCop
       include ConfigurableFormatting
 
       FORMATS = {
-        snake_case: /^@{0,2}[\da-z_]+[!?=]?$/,
-        camelCase:  /^@{0,2}_?[a-z][\da-zA-Z]+[!?=]?$/
+        snake_case: /^@{0,2}[\d[[:lower:]]_]+[!?=]?$/,
+        camelCase:  /^@{0,2}_?[[:lower:]][\d[[:lower:]][[:upper:]]]+[!?=]?$/
       }.freeze
     end
   end

--- a/spec/rubocop/cop/style/variable_name_spec.rb
+++ b/spec/rubocop/cop/style/variable_name_spec.rb
@@ -1,3 +1,4 @@
+# encoding: utf-8
 # frozen_string_literal: true
 
 describe RuboCop::Cop::Style::VariableName, :config do
@@ -67,6 +68,11 @@ describe RuboCop::Cop::Style::VariableName, :config do
       expect(cop.highlights).to eq(['_myLocal'])
     end
 
+    it 'does not register an offence for non-ascii variable names' do
+      inspect_source(cop, 'рубо_коп = 1')
+      expect(cop.offenses.size).to eq(0)
+    end
+
     include_examples 'always accepted'
   end
 
@@ -112,6 +118,11 @@ describe RuboCop::Cop::Style::VariableName, :config do
     it 'accepts camel case local variables marked as unused' do
       inspect_source(cop, '_myLocal = 1')
       expect(cop.offenses).to be_empty
+    end
+
+    it 'does not register an offence for non-ascii variable names' do
+      inspect_source(cop, 'рубоKоп = 1')
+      expect(cop.offenses.size).to eq(0)
     end
 
     include_examples 'always accepted'


### PR DESCRIPTION
I guess PR title speaks for itself.
Only note I'd add is that this doesn't include support for non-ASCII digits. It's dead simple, just swap `\d` to `[[:digit]]`, although I don't know how to test it.