### PR TITLE
[FIX #3931] Implement a cop checking for ambiguous block association …

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,7 +20,6 @@ pkg
 # etags
 TAGS
 
-*.swp
 # Have editor/IDE/OS specific files you need to ignore? Consider using a global gitignore: 
 #
 # * Create a file at ~/.gitignore
@@ -46,7 +45,7 @@ TAGS
 #.\#*
 
 # For vim:
-#*.swp
+*.swp
 
 # For redcar:
 #.redcar

--- a/.gitignore
+++ b/.gitignore
@@ -20,6 +20,7 @@ pkg
 # etags
 TAGS
 
+*.swp
 # Have editor/IDE/OS specific files you need to ignore? Consider using a global gitignore: 
 #
 # * Create a file at ~/.gitignore

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -24,3 +24,6 @@ Metrics/BlockLength:
     - 'Rakefile'
     - '**/*.rake'
     - 'spec/**/*.rb'
+AmbiguousBlockAssociation:
+  Exclude:
+    - 'spec/**/*.rb'

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -24,6 +24,7 @@ Metrics/BlockLength:
     - 'Rakefile'
     - '**/*.rake'
     - 'spec/**/*.rb'
+
 AmbiguousBlockAssociation:
   Exclude:
     - 'spec/**/*.rb'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 * [#4019](https://github.com/bbatsov/rubocop/pull/4019): Make configurable `Style/MultilineMemoization` cop. ([@pocke][])
 * [#4018](https://github.com/bbatsov/rubocop/pull/4018): Add autocorrect `Lint/EmptyEnsure` cop. ([@pocke][])
 * [#4028](https://github.com/bbatsov/rubocop/pull/4028): Add new `Style/IndentHeredoc` cop. ([@pocke][])
+* [#3931](https://github.com/bbatsov/rubocop/issues/3931): Add new `Lint/AmbiguousBlockAssociation` cop. ([@smakagon][])
 * Add new `Style/InverseMethods` cop. ([@rrosenblum][])
 * [#4038](https://github.com/bbatsov/rubocop/pull/4038): Allow `default` key in the `Style/PercentLiteralDelimiters` cop config to set all preferred delimiters. ([@kddeisz][])
 
@@ -2659,3 +2660,4 @@
 [@droptheplot]: https://github.com/droptheplot
 [@wkurniawan07]: https://github.com/wkurniawan07
 [@kddeisz]: https://github.com/kddeisz
+[@smakagon]: https://github.com/smakagon

--- a/config/enabled.yml
+++ b/config/enabled.yml
@@ -1059,6 +1059,13 @@ Metrics/PerceivedComplexity:
 #################### Lint ##################################
 ### Warnings
 
+Lint/AmbiguousBlockAssociation:
+  Description: >-
+                 Checks for ambiguous block association with method when param passed without
+                 parentheses.
+  StyleGuide: '#syntax'
+  Enabled: true
+
 Lint/AmbiguousOperator:
   Description: >-
                  Checks for ambiguous operators in the first argument of a

--- a/lib/rubocop.rb
+++ b/lib/rubocop.rb
@@ -121,6 +121,7 @@ require 'rubocop/cop/mixin/unused_argument'
 require 'rubocop/cop/bundler/duplicated_gem'
 require 'rubocop/cop/bundler/ordered_gems'
 
+require 'rubocop/cop/lint/ambiguous_block_association'
 require 'rubocop/cop/lint/ambiguous_operator'
 require 'rubocop/cop/lint/ambiguous_regexp_literal'
 require 'rubocop/cop/lint/assignment_in_condition'

--- a/lib/rubocop/cop/lint/ambiguous_block_association.rb
+++ b/lib/rubocop/cop/lint/ambiguous_block_association.rb
@@ -1,0 +1,41 @@
+# frozen_string_literal: true
+
+module RuboCop
+  module Cop
+    module Lint
+      # This cop checks for ambiguous block association with method
+      # when param passed without parentheses.
+      #
+      # @example
+      #
+      #   # bad
+      #
+      #   # It's ambiguous because there is no parentheses around `a` param
+      #   some_method a { |val| puts val }
+      #
+      # @example
+      #
+      #   # good
+      #
+      #   # With parentheses, there's no ambiguity.
+      #   some_method(a) { |val| puts val }
+      class AmbiguousBlockAssociation < Cop
+        MSG = 'Parenthesize the param to make sure that block will be '\
+              'associated with method call.'.freeze
+
+        def on_send(node)
+          return unless node.arguments?
+
+          first_argument = node.arguments.first
+          return unless first_argument.block_type?
+
+          first_child = first_argument.children.first
+          return unless first_child.is_a?(RuboCop::AST::Node)
+          return unless first_child.send_type?
+
+          add_offense(node, :expression)
+        end
+      end
+    end
+  end
+end

--- a/lib/rubocop/cop/lint/ambiguous_block_association.rb
+++ b/lib/rubocop/cop/lint/ambiguous_block_association.rb
@@ -9,44 +9,41 @@ module RuboCop
       # @example
       #
       #   # bad
-      #
-      #   # It's ambiguous because there is no parentheses around `a` param
       #   some_method a { |val| puts val }
       #
       # @example
       #
       #   # good
-      #
       #   # With parentheses, there's no ambiguity.
       #   some_method(a) { |val| puts val }
       class AmbiguousBlockAssociation < Cop
         MSG = 'Parenthesize the param `%s` to make sure that block will be '\
-              'associated with `%s` method call.'.freeze
+              'associated with the `%s` method call.'.freeze
 
         def on_send(node)
           return if node.parenthesized? || node.assignment? || node.method?(:[])
 
           return unless method_with_block?(node.first_argument)
-          first_child = node.first_argument.children.first
-          return unless method_as_param?(first_child)
+          first_param = node.first_argument.children.first
+          return unless method_as_param?(first_param)
 
           add_offense(
-            node, :expression, format_error(first_child, node.method_name)
+            node, :expression, format_error(first_param, node.method_name)
           )
         end
 
         private
 
-        def method_with_block?(args)
-          return false unless args
+        def method_with_block?(param)
+          return false unless param
 
-          args.block_type?
+          param.block_type?
         end
 
-        def method_as_param?(node)
-          return false unless node.is_a?(RuboCop::AST::Node)
+        def method_as_param?(param)
+          return false unless param.is_a?(RuboCop::AST::Node)
 
-          node.send_type? && !node.arguments?
+          param.send_type? && !param.arguments?
         end
 
         def format_error(param, method_name)

--- a/lib/rubocop/cop/lint/ambiguous_block_association.rb
+++ b/lib/rubocop/cop/lint/ambiguous_block_association.rb
@@ -17,8 +17,8 @@ module RuboCop
       #   # With parentheses, there's no ambiguity.
       #   some_method(a) { |val| puts val }
       class AmbiguousBlockAssociation < Cop
-        MSG = 'Parenthesize the param `%s` to make sure that block will be '\
-              'associated with the `%s` method call.'.freeze
+        MSG = 'Parenthesize the param `%s` to make sure that the block will be'\
+              ' associated with the `%s` method call.'.freeze
 
         def on_send(node)
           return if node.parenthesized? || node.assignment? || node.method?(:[])

--- a/lib/rubocop/cop/lint/ambiguous_block_association.rb
+++ b/lib/rubocop/cop/lint/ambiguous_block_association.rb
@@ -26,14 +26,13 @@ module RuboCop
         def on_send(node)
           _klass, method_name, args = node.children
 
-          return if method_name == :[]
-          return if node.parenthesized? || node.assignment?
+          return if node.parenthesized? || node.assignment? || node.method?(:[])
+
           return unless method_with_block?(args)
+          first_arg = args.children.first
+          return unless method_as_param?(first_arg)
 
-          first_param = args.children.first
-          return unless method_as_param?(first_param)
-
-          add_offense(node, :expression, format_error(first_param, method_name))
+          add_offense(node, :expression, format_error(first_arg, method_name))
         end
 
         private
@@ -47,7 +46,7 @@ module RuboCop
         def method_as_param?(node)
           return false unless node.is_a?(RuboCop::AST::Node)
 
-          node.send_type? && node.children.size <= 2
+          node.send_type? && !node.arguments?
         end
 
         def format_error(param, method_name)

--- a/lib/rubocop/cop/lint/ambiguous_block_association.rb
+++ b/lib/rubocop/cop/lint/ambiguous_block_association.rb
@@ -24,15 +24,15 @@ module RuboCop
               'associated with `%s` method call.'.freeze
 
         def on_send(node)
-          _klass, method_name, args = node.children
-
           return if node.parenthesized? || node.assignment? || node.method?(:[])
 
-          return unless method_with_block?(args)
-          first_arg = args.children.first
-          return unless method_as_param?(first_arg)
+          return unless method_with_block?(node.first_argument)
+          first_child = node.first_argument.children.first
+          return unless method_as_param?(first_child)
 
-          add_offense(node, :expression, format_error(first_arg, method_name))
+          add_offense(
+            node, :expression, format_error(first_child, node.method_name)
+          )
         end
 
         private

--- a/lib/rubocop/cop/lint/ambiguous_block_association.rb
+++ b/lib/rubocop/cop/lint/ambiguous_block_association.rb
@@ -27,9 +27,7 @@ module RuboCop
           first_param = node.first_argument.children.first
           return unless method_as_param?(first_param)
 
-          add_offense(
-            node, :expression, format_error(first_param, node.method_name)
-          )
+          add_offense(node, :expression, message(first_param, node.method_name))
         end
 
         private
@@ -41,12 +39,12 @@ module RuboCop
         end
 
         def method_as_param?(param)
-          return false unless param.is_a?(RuboCop::AST::Node)
+          return false unless param
 
           param.send_type? && !param.arguments?
         end
 
-        def format_error(param, method_name)
+        def message(param, method_name)
           format(MSG, param.children[1], method_name)
         end
       end

--- a/manual/cops.md
+++ b/manual/cops.md
@@ -74,6 +74,7 @@ In the following section you find all available cops:
 
 #### Department [Lint](cops_lint.md)
 
+* [Lint/AmbiguousBlockAssociation](cops_lint.md#lintambiguousblockassociation)
 * [Lint/AmbiguousOperator](cops_lint.md#lintambiguousoperator)
 * [Lint/AmbiguousRegexpLiteral](cops_lint.md#lintambiguousregexpliteral)
 * [Lint/AssignmentInCondition](cops_lint.md#lintassignmentincondition)

--- a/manual/cops_lint.md
+++ b/manual/cops_lint.md
@@ -1,5 +1,33 @@
 # Lint
 
+## Lint/AmbiguousBlockAssociation
+
+Enabled by default | Supports autocorrection
+--- | ---
+Enabled | No
+
+This cop checks for ambiguous block association with method
+when param passed without parentheses.
+
+### Example
+
+```ruby
+# bad
+
+# It's ambiguous because there is no parentheses around `a` param
+some_method a { |val| puts val }
+```
+```ruby
+# good
+
+# With parentheses, there's no ambiguity.
+some_method(a) { |val| puts val }
+```
+
+### References
+
+* [https://github.com/bbatsov/ruby-style-guide#syntax](https://github.com/bbatsov/ruby-style-guide#syntax)
+
 ## Lint/AmbiguousOperator
 
 Enabled by default | Supports autocorrection

--- a/spec/rubocop/cop/lint/ambiguous_block_association_spec.rb
+++ b/spec/rubocop/cop/lint/ambiguous_block_association_spec.rb
@@ -4,14 +4,9 @@ require 'spec_helper'
 
 describe RuboCop::Cop::Lint::AmbiguousBlockAssociation do
   subject(:cop) { described_class.new }
-  subject(:error_message) do
-    'Parenthesize the param `%s` to make sure that block will be associated'\
-      ' with the `%s` method call.'
-  end
+  subject(:error_message) { described_class::MSG }
 
-  before do
-    inspect_source(cop, source)
-  end
+  before { inspect_source(cop, source) }
 
   shared_examples 'accepts' do |code|
     let(:source) { code }

--- a/spec/rubocop/cop/lint/ambiguous_block_association_spec.rb
+++ b/spec/rubocop/cop/lint/ambiguous_block_association_spec.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
 require 'spec_helper'
-require 'pry'
 
 describe RuboCop::Cop::Lint::AmbiguousBlockAssociation do
   subject(:cop) { described_class.new }

--- a/spec/rubocop/cop/lint/ambiguous_block_association_spec.rb
+++ b/spec/rubocop/cop/lint/ambiguous_block_association_spec.rb
@@ -1,35 +1,34 @@
 # frozen_string_literal: true
 
 require 'spec_helper'
+require 'pry'
 
 describe RuboCop::Cop::Lint::AmbiguousBlockAssociation do
   subject(:cop) { described_class.new }
   subject(:error_message) do
-    'Parenthesize the param to make sure that block will be associated'\
-    ' with method call.'
+    'Parenthesize the param `%s` to make sure that block will be associated'\
+      ' with `%s` method call.'
   end
 
   before do
     inspect_source(cop, source)
   end
 
-  context 'with method and block' do
+  context 'method without params and block' do
     context 'without receiver' do
       context 'without parentheses' do
-        let(:source) do
-          'some_method a { |el| puts el }'
-        end
+        let(:source) { 'some_method a { |el| puts el }' }
 
         it 'registers an offense' do
           expect(cop.offenses.size).to eq(1)
-          expect(cop.offenses.first.message).to eq(error_message)
+          expect(cop.offenses.first.message).to(
+            eq(format(error_message, 'a', 'some_method'))
+          )
         end
       end
 
-      context 'with a parentheses' do
-        let(:source) do
-          'some_method(a) { |el| puts el }'
-        end
+      context 'with parentheses' do
+        let(:source) { 'some_method(a) { |el| puts el }' }
 
         it 'accepts' do
           expect(cop.offenses).to be_empty
@@ -39,24 +38,162 @@ describe RuboCop::Cop::Lint::AmbiguousBlockAssociation do
 
     context 'with receiver' do
       context 'without parentheses' do
-        let(:source) do
-          'Foo.some_method a { |el| puts el }'
-        end
+        let(:source) { 'Foo.some_method a { |el| puts el }' }
 
         it 'registers an offense' do
           expect(cop.offenses.size).to eq(1)
-          expect(cop.offenses.first.message).to eq(error_message)
+          expect(cop.offenses.first.message).to(
+            eq(format(error_message, 'a', 'some_method'))
+          )
         end
       end
 
       context 'with a parentheses' do
+        let(:source) { 'Foo.some_method(a) { |el| puts el }' }
+
+        it 'accepts' do
+          expect(cop.offenses).to be_empty
+        end
+      end
+    end
+  end
+
+  context 'method with arguments and block' do
+    context 'without parantheses' do
+      context 'with receiver' do
+        let(:source) { 'environment ENV.fetch("RAILS_ENV") { "development" }' }
+
+        it 'accepts' do
+          expect(cop.offenses).to be_empty
+        end
+      end
+
+      context 'witout receiver' do
+        let(:source) { 'allow(cop).to receive(:on_int) { raise RuntimeError }' }
+
+        it 'accepts' do
+          expect(cop.offenses).to be_empty
+        end
+      end
+    end
+
+    context 'with parantheses' do
+      context 'with receiver' do
+        let(:source) { 'environment(ENV.fetch("RAILS_ENV") { "development" })' }
+
+        it 'accepts' do
+          expect(cop.offenses).to be_empty
+        end
+      end
+
+      context 'witout receiver' do
+        let(:source) { 'allow(cop).to(receive(:on_i) { raise RuntimeError })' }
+
+        it 'accepts' do
+          expect(cop.offenses).to be_empty
+        end
+      end
+    end
+  end
+
+  context 'multiline blocks' do
+    context 'without parentheses' do
+      context 'without block param' do
+        let(:source) { ['some_method a do', 'puts "here"', 'end'] }
+
+        it 'accepts' do
+          expect(cop.offenses).to be_empty
+        end
+      end
+
+      context 'with block param' do
+        let(:source) { ['some_method a do |el|', 'puts el', 'end'] }
+
+        it 'accepts' do
+          expect(cop.offenses).to be_empty
+        end
+      end
+    end
+
+    context 'rspec expect {}.to change {}' do
+      context 'without parentheses' do
         let(:source) do
-          'Foo.some_method(a) { |el| puts el }'
+          'expect { order.expire }.not_to change { order.unpublished_events }'
+        end
+
+        it 'registers an offense' do
+          expect(cop.offenses.size).to eq(1)
+          expect(cop.offenses.first.message).to(
+            eq(format(error_message, 'change', 'not_to'))
+          )
+        end
+      end
+
+      context 'with parentheses' do
+        let(:source) do
+          'expect { order.expire }.not_to(change { order.unpublished_events })'
         end
 
         it 'accepts' do
           expect(cop.offenses).to be_empty
         end
+      end
+    end
+
+    context 'with parentheses' do
+      context 'without block param' do
+        let(:source) do
+          ['some_method(a) do', 'puts "here"', 'end']
+        end
+
+        it 'accepts' do
+          expect(cop.offenses).to be_empty
+        end
+      end
+
+      context 'with block param' do
+        let(:source) do
+          ['{ foo: "bar"}.fetch(:a) do |el|', 'puts el', 'end']
+        end
+
+        it 'accepts' do
+          expect(cop.offenses).to be_empty
+        end
+      end
+    end
+  end
+
+  context 'inside Hash' do
+    context 'method with a block' do
+      let(:source) do
+        'Hash[some_method(a) { |el| el }]'
+      end
+
+      it 'accepts' do
+        expect(cop.offenses).to be_empty
+      end
+    end
+  end
+
+  context 'with assignment' do
+    context 'with lambda' do
+      let(:source) do
+        ['foo = lambda do |diagnostic|', 'end']
+      end
+
+      it 'accepts' do
+        expect(cop.offenses).to be_empty
+      end
+    end
+
+    context 'variable assignment' do
+      let(:source) { 'foo = some_method a { |el| puts el }' }
+
+      it 'registers an offense' do
+        expect(cop.offenses.size).to eq(1)
+        expect(cop.offenses.first.message).to(
+          eq(format(error_message, 'a', 'some_method'))
+        )
       end
     end
   end

--- a/spec/rubocop/cop/lint/ambiguous_block_association_spec.rb
+++ b/spec/rubocop/cop/lint/ambiguous_block_association_spec.rb
@@ -1,0 +1,63 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+describe RuboCop::Cop::Lint::AmbiguousBlockAssociation do
+  subject(:cop) { described_class.new }
+  subject(:error_message) do
+    'Parenthesize the param to make sure that block will be associated'\
+    ' with method call.'
+  end
+
+  before do
+    inspect_source(cop, source)
+  end
+
+  context 'with method and block' do
+    context 'without receiver' do
+      context 'without parentheses' do
+        let(:source) do
+          'some_method a { |el| puts el }'
+        end
+
+        it 'registers an offense' do
+          expect(cop.offenses.size).to eq(1)
+          expect(cop.offenses.first.message).to eq(error_message)
+        end
+      end
+
+      context 'with a parentheses' do
+        let(:source) do
+          'some_method(a) { |el| puts el }'
+        end
+
+        it 'accepts' do
+          expect(cop.offenses).to be_empty
+        end
+      end
+    end
+
+    context 'with receiver' do
+      context 'without parentheses' do
+        let(:source) do
+          'Foo.some_method a { |el| puts el }'
+        end
+
+        it 'registers an offense' do
+          expect(cop.offenses.size).to eq(1)
+          expect(cop.offenses.first.message).to eq(error_message)
+        end
+      end
+
+      context 'with a parentheses' do
+        let(:source) do
+          'Foo.some_method(a) { |el| puts el }'
+        end
+
+        it 'accepts' do
+          expect(cop.offenses).to be_empty
+        end
+      end
+    end
+  end
+end

--- a/spec/rubocop/formatter/offense_count_formatter_spec.rb
+++ b/spec/rubocop/formatter/offense_count_formatter_spec.rb
@@ -20,14 +20,14 @@ module RuboCop
         context 'when no offenses are detected' do
           let(:offenses) { [] }
           it 'does not add to offense_counts' do
-            expect { finish }.not_to(change { formatter.offense_counts })
+            expect { finish }.not_to change { formatter.offense_counts }
           end
         end
 
         context 'when any offenses are detected' do
           let(:offenses) { [double('offense', cop_name: 'OffendedCop')] }
           it 'increments the count for the cop in offense_counts' do
-            expect { finish }.to(change { formatter.offense_counts })
+            expect { finish }.to change { formatter.offense_counts }
           end
         end
       end

--- a/spec/rubocop/formatter/offense_count_formatter_spec.rb
+++ b/spec/rubocop/formatter/offense_count_formatter_spec.rb
@@ -20,14 +20,14 @@ module RuboCop
         context 'when no offenses are detected' do
           let(:offenses) { [] }
           it 'does not add to offense_counts' do
-            expect { finish }.not_to change { formatter.offense_counts }
+            expect { finish }.not_to(change { formatter.offense_counts })
           end
         end
 
         context 'when any offenses are detected' do
           let(:offenses) { [double('offense', cop_name: 'OffendedCop')] }
           it 'increments the count for the cop in offense_counts' do
-            expect { finish }.to change { formatter.offense_counts }
+            expect { finish }.to(change { formatter.offense_counts })
           end
         end
       end


### PR DESCRIPTION
…with a method

This cop checks for ambiguous block association with method when param passed without parentheses.

Example:
It's ambiguous because there is no parentheses around `a` param:
`some_method a { |val| puts val }`

With parentheses, there's no ambiguity:
`some_method(a) { |val| puts val }`

Cop will add warning message:
Parenthesize the param to make sure that block will be associated with method call.