### PR TITLE
[Fix #3960] Paths relative to file's dir for .rubocop*.yml

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,6 +49,7 @@
 * [#3457](https://github.com/bbatsov/rubocop/issues/3457): Clear a warning and prevent new warnings. ([@mikegee][])
 * [#4066](https://github.com/bbatsov/rubocop/issues/4066): Register an offense in `Lint/ShadowedException` when an exception is shadowed and there is an implicit begin. ([@rrosenblum][])
 * [#4001](https://github.com/bbatsov/rubocop/issues/4001): Lint/UnneededDisable of Metrics/LineLength that isn't unneeded. ([@wkurniawan07][])
+* [#3960](https://github.com/bbatsov/rubocop/issues/3960): Let `Include`/`Exclude` paths in all files beginning with `.rubocop` be relative to the configuration file's directory and not to the current directory. ([@jonas054][])
 
 ## 0.47.1 (2017-01-18)
 

--- a/lib/rubocop/config.rb
+++ b/lib/rubocop/config.rb
@@ -263,15 +263,14 @@ module RuboCop
       relative_path(path, base_dir_for_path_parameters)
     end
 
-    # Paths specified in .rubocop.yml and .rubocop_todo.yml files are relative
-    # to the directory where that file is. Paths in other config files are
-    # relative to the current directory. This is so that paths in
+    # Paths specified in configuration files starting with .rubocop are
+    # relative to the directory where that file is. Paths in other config files
+    # are relative to the current directory. This is so that paths in
     # config/default.yml, for example, are not relative to RuboCop's config
     # directory since that wouldn't work.
     def base_dir_for_path_parameters
-      config_files = [ConfigLoader::DOTFILE, ConfigLoader::AUTO_GENERATED_FILE]
       @base_dir_for_path_parameters ||=
-        if config_files.include?(File.basename(loaded_path)) &&
+        if File.basename(loaded_path).start_with?('.rubocop') &&
            loaded_path != File.join(Dir.home, ConfigLoader::DOTFILE)
           File.expand_path(File.dirname(loaded_path))
         else

--- a/manual/configuration.md
+++ b/manual/configuration.md
@@ -160,7 +160,11 @@ AllCops:
 # ...
 ```
 
-Files and directories are specified relative to the `.rubocop.yml` file.
+In `.rubocop.yml` and any other configuration file beginning with `.rubocop`,
+files and directories are specified relative to the directory where the
+configuration file is. In configuration files that don't begin with `.rubocop`,
+e.g. `our_company_defaults.yml`, paths are relative to the directory where
+`rubocop` is run.
 
 **Note**: Patterns that are just a file name, e.g. `Rakefile`, will match
 that file name in any directory, but this pattern style is deprecated. The

--- a/spec/rubocop/config_loader_spec.rb
+++ b/spec/rubocop/config_loader_spec.rb
@@ -630,6 +630,31 @@ describe RuboCop::ConfigLoader do
     end
   end
 
+  describe 'configuration for CharacterLiteral', :isolated_environment do
+    let(:dir_path) { 'test/blargh' }
+
+    let(:config) do
+      config_path = described_class.configuration_file_for(dir_path)
+      described_class.configuration_from_file(config_path)
+    end
+
+    context 'when .rubocop.yml inherits from a file with a name starting ' \
+            'with .rubocop' do
+      before do
+        create_file('test/.rubocop_rules.yml', ['Style/CharacterLiteral:',
+                                                '  Exclude:',
+                                                '    - blargh/blah.rb'])
+        create_file('test/.rubocop.yml', 'inherit_from: .rubocop_rules.yml')
+      end
+
+      it 'gets an Exclude relative to the inherited file converted to ' \
+         'absolute' do
+        expect(config.for_cop(RuboCop::Cop::Style::CharacterLiteral)['Exclude'])
+          .to eq([File.join(Dir.pwd, 'test/blargh/blah.rb')])
+      end
+    end
+  end
+
   describe 'configuration for AssignmentInCondition' do
     describe 'AllowSafeAssignment' do
       it 'is enabled by default' do


### PR DESCRIPTION
Before this change, `Include` and `Exclude` paths in `.rubocop.yml` and `.rubocop_todo.yml` were taken as relative to the config file's directory. This extends that behavior to any file beginning with `.rubocop`.