### PR TITLE
Remove redundant 'it' in example docstrings

### DIFF
--- a/spec/rubocop/cop/style/while_until_do_spec.rb
+++ b/spec/rubocop/cop/style/while_until_do_spec.rb
@@ -25,13 +25,13 @@ describe RuboCop::Cop::Style::WhileUntilDo do
     expect(cop.offenses).to be_empty
   end
 
-  it 'it accepts multi-line while without do' do
+  it 'accepts multi-line while without do' do
     inspect_source(cop, ['while cond',
                          'end'])
     expect(cop.offenses).to be_empty
   end
 
-  it 'it accepts multi-line until without do' do
+  it 'accepts multi-line until without do' do
     inspect_source(cop, ['until cond',
                          'end'])
     expect(cop.offenses).to be_empty


### PR DESCRIPTION
Removes redundant information in test docstrings. Found these while test-driving a new `rubocop-rspec` cop.

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Used the same coding conventions as the rest of the project.
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [ ] Added tests.
* [ ] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] All tests are passing.
* [x] The new code doesn't generate RuboCop offenses.
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [ ] Updated cop documentation with `rake generate_cops_documentation` (required only when you've added a new cop or changed the configuration/documentation of an existing cop).

[1]: http://chris.beams.io/posts/git-commit/
