### PR TITLE
[Fix #4041] Fix invalid offense for `Style/IndentHeredoc` with emtpy line

### DIFF
--- a/lib/rubocop/cop/style/indent_heredoc.rb
+++ b/lib/rubocop/cop/style/indent_heredoc.rb
@@ -156,7 +156,7 @@ module RuboCop
         end
 
         def indent_level(str)
-          str.scan(/^\s*/).min_by(&:size).size
+          str.scan(/^\s*/).reject { |line| line == "\n" }.min_by(&:size).size
         end
 
         # Returns '~', '-' or nil

--- a/spec/rubocop/cop/style/indent_heredoc_spec.rb
+++ b/spec/rubocop/cop/style/indent_heredoc_spec.rb
@@ -241,6 +241,14 @@ describe RuboCop::Cop::Style::IndentHeredoc, :config do
             something
           END2
         END
+        include_examples :accept, 'include empty line', <<-END
+          <<~#{quote}MSG#{quote}
+            foo
+
+              bar
+
+          MSG
+        END
 
         it 'displays message to use `<<~` instead of `<<`' do
           inspect_source(cop, <<-END.strip_indent)


### PR DESCRIPTION


See https://github.com/bbatsov/rubocop/issues/4041



-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Used the same coding conventions as the rest of the project.
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [ ] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] All tests are passing.
* [x] The new code doesn't generate RuboCop offenses.
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Updated cop documentation with `rake generate_cops_documentation` (required only when you've added a new cop or changed the configuration/documentation of an existing cop).

[1]: http://chris.beams.io/posts/git-commit/
