### PR TITLE
[Fix #4096] Rails/FindBy checks arguments to where

### DIFF
--- a/lib/rubocop/cop/rails/find_by.rb
+++ b/lib/rubocop/cop/rails/find_by.rb
@@ -23,6 +23,7 @@ module RuboCop
 
         def on_send(node)
           return unless where_first?(node)
+          return if where_with_method_as_param?(node)
 
           range = range_between(node.receiver.loc.selector.begin_pos,
                                 node.loc.selector.end_pos)
@@ -44,6 +45,15 @@ module RuboCop
             corrector.replace(where_loc, 'find_by')
             corrector.replace(first_loc, '')
           end
+        end
+
+        private
+
+        def where_with_method_as_param?(node)
+          where = node.children.find { |el| el.method?(:where) }
+          return unless where
+
+          where.arguments.size == 1 && where.arguments.first.send_type?
         end
       end
     end

--- a/lib/rubocop/cop/rails/find_by.rb
+++ b/lib/rubocop/cop/rails/find_by.rb
@@ -50,10 +50,14 @@ module RuboCop
         private
 
         def where_with_method_as_param?(node)
-          where = node.children.find { |el| el.method?(:where) }
+          where = node.each_child_node(:send).find { |n| n.method?(:where) }
           return unless where
 
-          where.arguments.size == 1 && where.arguments.first.send_type?
+          where.arguments.one? && variable_or_method?(where.first_argument)
+        end
+
+        def variable_or_method?(param)
+          param.send_type? || param.lvar_type? || param.ivar_type?
         end
       end
     end

--- a/spec/rubocop/cop/rails/find_by_spec.rb
+++ b/spec/rubocop/cop/rails/find_by_spec.rb
@@ -21,6 +21,19 @@ describe RuboCop::Cop::Rails::FindBy do
     expect(cop.messages).to be_empty
   end
 
+  it 'does not register an offense if when uses one method as an argument' do
+    inspect_source(cop, 'User.where(complex_query).first')
+
+    expect(cop.messages).to be_empty
+  end
+
+  it 'registers an offense if method one of the params' do
+    inspect_source(cop, 'User.where(status: complex_query).first')
+
+    expect(cop.offenses.size).to eq(1)
+    expect(cop.messages.first).to eq('Use `find_by` instead of `where.first`.')
+  end
+
   it 'autocorrects where.take to find_by' do
     new_source = autocorrect_source(cop, 'User.where(id: x).take')
 


### PR DESCRIPTION
Rails/FindBy cop will not register this case as an offense:
`User.where(complex_query).first`

For other cases, such as:
`User.where(status: complex_query).first`
`User.where(id: x).take`

It will add a warning:
> Use `find_by` instead of `where.first`.