### PR TITLE
Adding “prefix” and “postfix” styles to Style/NegatedIf

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### New features
 
 * [#4107](https://github.com/bbatsov/rubocop/pull/4107): New `TargetRailsVersion` configuration parameter can be used to specify which version of Rails the inspected code is intended to run on. ([@maxbeizer][])
+* [#4104](https://github.com/bbatsov/rubocop/pull/4104): Add `prefix` and `postfix` styles to `Style/NegatedIf`. ([@brandonweiss][])
 * [#4083](https://github.com/bbatsov/rubocop/pull/4083): Add new configuration `NumberOfEmptyLines` for `Style/EmptyLineBetweenDefs`. ([@dorian][])
 * [#4045](https://github.com/bbatsov/rubocop/pull/4045): Add new configuration `Strict` for `Style/NumericLiteral` to make the change to this cop in 0.47.0 configurable. ([@iGEL][])
 * [#3893](https://github.com/bbatsov/rubocop/issues/3893): Add a new configuration, `IncludeActiveSupportAliases`, to `Performance/DoublStartEndWith`. This configuration will check for ActiveSupport's `starts_with?` and `ends_with?`. ([@rrosenblum][])
@@ -2681,3 +2682,4 @@
 [@twe4ked]: https://github.com/twe4ked
 [@maxbeizer]: https://github.com/maxbeizer
 [@andriymosin]: https://github.com/andriymosin
+[@brandonweiss]: https://github.com/brandonweiss

--- a/config/default.yml
+++ b/config/default.yml
@@ -862,6 +862,16 @@ Style/MultilineOperationIndentation:
   # But it can be overridden by setting this parameter
   IndentationWidth: ~
 
+Style/NegatedIf:
+  EnforcedStyle: both
+  SupportedStyles:
+    # both: prefix and postfix negated `if` should both use `unless`
+    # prefix: only use `unless` for negated `if` statements positioned before the body of the statement
+    # postfix: only use `unless` for negated `if` statements positioned after the body of the statement
+    - both
+    - prefix
+    - postfix
+
 Style/Next:
   # With `always` all conditions at the end of an iteration needs to be
   # replaced by next - with `skip_modifier_ifs` the modifier if like this one

--- a/lib/rubocop/cop/style/negated_if.rb
+++ b/lib/rubocop/cop/style/negated_if.rb
@@ -4,14 +4,75 @@ module RuboCop
   module Cop
     module Style
       # Checks for uses of if with a negated condition. Only ifs
-      # without else are considered.
+      # without else are considered. There are three different styles:
+      #
+      # @example
+      #
+      # both - enforces `unless` for `prefix` and `postfix` conditionals
+      #
+      #   # good
+      #
+      #   unless foo
+      #     bar
+      #   end
+      #
+      #   # bad
+      #
+      #   if !foo
+      #     bar
+      #   end
+      #
+      #   # good
+      #
+      #   bar unless foo
+      #
+      #   # bad
+      #
+      #   bar if !foo
+      #
+      # prefix - enforces `unless` for just `prefix` conditionals
+      #
+      #   # good
+      #
+      #   unless foo
+      #     bar
+      #   end
+      #
+      #   # bad
+      #
+      #   if !foo
+      #     bar
+      #   end
+      #
+      #   # good
+      #
+      #   bar if !foo
+      #
+      # postfix - enforces `unless` for just `postfix` conditionals
+      #
+      #   # good
+      #
+      #   bar unless foo
+      #
+      #   # bad
+      #
+      #   bar if !foo
+      #
+      #   # good
+      #
+      #   if !foo
+      #     bar
+      #   end
       class NegatedIf < Cop
+        include ConfigurableEnforcedStyle
         include NegativeConditional
 
         MSG = 'Favor `%s` over `%s` for negative conditions.'.freeze
 
         def on_if(node)
           return if node.elsif? || node.ternary?
+          return if style == :prefix && node.modifier_form?
+          return if style == :postfix && !node.modifier_form?
 
           check_negative_conditional(node)
         end

--- a/manual/cops_style.md
+++ b/manual/cops_style.md
@@ -3648,7 +3648,35 @@ Enabled by default | Supports autocorrection
 Enabled | Yes
 
 Checks for uses of if with a negated condition. Only ifs
-without else are considered.
+without else are considered. There are three different styles:
+
+both - enforces `unless` for `prefix` and `postfix` conditionals
+  unless foo
+    bar
+  end
+
+  bar unless foo
+
+prefix - enforces `unless` for just `prefix` conditionals
+  unless foo
+    bar
+  end
+
+  bar if !foo
+
+postfix - enforces `unless` for just `postfix` conditionals
+  if !foo
+    bar
+  end
+
+  bar unless foo
+
+### Important attributes
+
+Attribute | Value
+--- | ---
+EnforcedStyle | both
+SupportedStyles | both, prefix, postfix
 
 ### References
 

--- a/spec/rubocop/cop/style/negated_if_spec.rb
+++ b/spec/rubocop/cop/style/negated_if_spec.rb
@@ -1,90 +1,207 @@
 # frozen_string_literal: true
 
 describe RuboCop::Cop::Style::NegatedIf do
-  subject(:cop) { described_class.new }
-
-  it 'registers an offense for if with exclamation point condition' do
-    inspect_source(cop,
-                   ['if !a_condition',
-                    '  some_method',
-                    'end',
-                    'some_method if !a_condition'])
-    expect(cop.messages).to eq(
-      ['Favor `unless` over `if` for negative ' \
-       'conditions.'] * 2
+  subject(:cop) do
+    config = RuboCop::Config.new(
+      'Style/NegatedIf' => {
+        'SupportedStyles' => %w(both prefix postfix),
+        'EnforcedStyle' => 'both'
+      }
     )
+    described_class.new(config)
   end
 
-  it 'registers an offense for unless with exclamation point condition' do
-    inspect_source(cop,
-                   ['unless !a_condition',
-                    '  some_method',
-                    'end',
-                    'some_method unless !a_condition'])
-    expect(cop.messages).to eq(['Favor `if` over `unless` for negative ' \
-                                'conditions.'] * 2)
+  describe 'with “both” style' do
+    it 'registers an offense for if with exclamation point condition' do
+      inspect_source(cop,
+                     ['if !a_condition',
+                      '  some_method',
+                      'end',
+                      'some_method if !a_condition'])
+      expect(cop.messages).to eq(
+        ['Favor `unless` over `if` for negative ' \
+         'conditions.'] * 2
+      )
+    end
+
+    it 'registers an offense for unless with exclamation point condition' do
+      inspect_source(cop,
+                     ['unless !a_condition',
+                      '  some_method',
+                      'end',
+                      'some_method unless !a_condition'])
+      expect(cop.messages).to eq(['Favor `if` over `unless` for negative ' \
+                                  'conditions.'] * 2)
+    end
+
+    it 'registers an offense for if with "not" condition' do
+      inspect_source(cop,
+                     ['if not a_condition',
+                      '  some_method',
+                      'end',
+                      'some_method if not a_condition'])
+      expect(cop.messages).to eq(
+        ['Favor `unless` over `if` for negative ' \
+         'conditions.'] * 2
+      )
+      expect(cop.offenses.map(&:line)).to eq([1, 4])
+    end
+
+    it 'accepts an if/else with negative condition' do
+      inspect_source(cop,
+                     ['if !a_condition',
+                      '  some_method',
+                      'else',
+                      '  something_else',
+                      'end',
+                      'if not a_condition',
+                      '  some_method',
+                      'elsif other_condition',
+                      '  something_else',
+                      'end'])
+      expect(cop.offenses).to be_empty
+    end
+
+    it 'accepts an if where only part of the condition is negated' do
+      inspect_source(cop,
+                     ['if !condition && another_condition',
+                      '  some_method',
+                      'end',
+                      'if not condition or another_condition',
+                      '  some_method',
+                      'end',
+                      'some_method if not condition or another_condition'])
+      expect(cop.offenses).to be_empty
+    end
+
+    it 'accepts an if where the condition is doubly negated' do
+      inspect_source(cop,
+                     ['if !!condition',
+                      '  some_method',
+                      'end',
+                      'some_method if !!condition'])
+      expect(cop.offenses).to be_empty
+    end
+
+    it 'is not confused by negated elsif' do
+      inspect_source(cop,
+                     ['if test.is_a?(String)',
+                      '  3',
+                      'elsif test.is_a?(Array)',
+                      '  2',
+                      'elsif !test.nil?',
+                      '  1',
+                      'end'])
+
+      expect(cop.offenses).to be_empty
+    end
+
+    it 'autocorrects for postfix' do
+      corrected = autocorrect_source(cop, 'bar if !foo')
+
+      expect(corrected).to eq 'bar unless foo'
+    end
+
+    it 'autocorrects by replacing if not with unless' do
+      corrected = autocorrect_source(cop, 'something if !x.even?')
+      expect(corrected).to eq 'something unless x.even?'
+    end
+
+    it 'autocorrects by replacing parenthesized if not with unless' do
+      corrected = autocorrect_source(cop, 'something if (!x.even?)')
+      expect(corrected).to eq 'something unless (x.even?)'
+    end
+
+    it 'autocorrects by replacing unless not with if' do
+      corrected = autocorrect_source(cop, 'something unless !x.even?')
+      expect(corrected).to eq 'something if x.even?'
+    end
+
+    it 'autocorrects for prefix' do
+      corrected = autocorrect_source(cop,
+                                     ['if !foo',
+                                      'end'])
+
+      expect(corrected).to eq [
+        'unless foo',
+        'end'
+      ].join("\n")
+    end
   end
 
-  it 'registers an offense for if with "not" condition' do
-    inspect_source(cop,
-                   ['if not a_condition',
-                    '  some_method',
-                    'end',
-                    'some_method if not a_condition'])
-    expect(cop.messages).to eq(
-      ['Favor `unless` over `if` for negative ' \
-       'conditions.'] * 2
-    )
-    expect(cop.offenses.map(&:line)).to eq([1, 4])
+  describe 'with “prefix” style' do
+    subject(:cop) do
+      config = RuboCop::Config.new(
+        'Style/NegatedIf' => {
+          'SupportedStyles' => %w(both prefix postfix),
+          'EnforcedStyle' => 'prefix'
+        }
+      )
+
+      described_class.new(config)
+    end
+
+    it 'registers an offence for prefix' do
+      inspect_source(cop,
+                     ['if !foo',
+                      'end'])
+
+      expect(cop.messages).to eq(
+        ['Favor `unless` over `if` for negative conditions.']
+      )
+    end
+
+    it 'does not register an offence for postfix' do
+      inspect_source(cop, 'foo if !bar')
+
+      expect(cop.offenses).to be_empty
+    end
+
+    it 'autocorrects for prefix' do
+      corrected = autocorrect_source(cop,
+                                     ['if !foo',
+                                      'end'])
+
+      expect(corrected).to eq [
+        'unless foo',
+        'end'
+      ].join("\n")
+    end
   end
 
-  it 'accepts an if/else with negative condition' do
-    inspect_source(cop,
-                   ['if !a_condition',
-                    '  some_method',
-                    'else',
-                    '  something_else',
-                    'end',
-                    'if not a_condition',
-                    '  some_method',
-                    'elsif other_condition',
-                    '  something_else',
-                    'end'])
-    expect(cop.offenses).to be_empty
-  end
+  describe 'with “postfix” style' do
+    subject(:cop) do
+      config = RuboCop::Config.new(
+        'Style/NegatedIf' => {
+          'SupportedStyles' => %w(both prefix postfix),
+          'EnforcedStyle' => 'postfix'
+        }
+      )
 
-  it 'accepts an if where only part of the condition is negated' do
-    inspect_source(cop,
-                   ['if !condition && another_condition',
-                    '  some_method',
-                    'end',
-                    'if not condition or another_condition',
-                    '  some_method',
-                    'end',
-                    'some_method if not condition or another_condition'])
-    expect(cop.offenses).to be_empty
-  end
+      described_class.new(config)
+    end
 
-  it 'accepts an if where the condition is doubly negated' do
-    inspect_source(cop,
-                   ['if !!condition',
-                    '  some_method',
-                    'end',
-                    'some_method if !!condition'])
-    expect(cop.offenses).to be_empty
-  end
+    it 'registers an offence for postfix' do
+      inspect_source(cop, 'foo if !bar')
 
-  it 'is not confused by negated elsif' do
-    inspect_source(cop,
-                   ['if test.is_a?(String)',
-                    '  3',
-                    'elsif test.is_a?(Array)',
-                    '  2',
-                    'elsif !test.nil?',
-                    '  1',
-                    'end'])
+      expect(cop.messages).to eq(
+        ['Favor `unless` over `if` for negative conditions.']
+      )
+    end
 
-    expect(cop.offenses).to be_empty
+    it 'does not register an offence for prefix' do
+      inspect_source(cop,
+                     ['if !foo',
+                      'end'])
+
+      expect(cop.offenses).to be_empty
+    end
+
+    it 'autocorrects for postfix' do
+      corrected = autocorrect_source(cop, 'bar if !foo')
+
+      expect(corrected).to eq 'bar unless foo'
+    end
   end
 
   it 'does not blow up for ternary ops' do
@@ -109,20 +226,5 @@ describe RuboCop::Cop::Style::NegatedIf do
                    ['unless ()',
                     'end'])
     expect(cop.offenses).to be_empty
-  end
-
-  it 'autocorrects by replacing if not with unless' do
-    corrected = autocorrect_source(cop, 'something if !x.even?')
-    expect(corrected).to eq 'something unless x.even?'
-  end
-
-  it 'autocorrects by replacing parenthesized if not with unless' do
-    corrected = autocorrect_source(cop, 'something if (!x.even?)')
-    expect(corrected).to eq 'something unless (x.even?)'
-  end
-
-  it 'autocorrects by replacing unless not with if' do
-    corrected = autocorrect_source(cop, 'something unless !x.even?')
-    expect(corrected).to eq 'something if x.even?'
   end
 end


### PR DESCRIPTION
[Fixes bbatsov/rubocop#3961]

Some people have a strong preference against using unless with an `if`
statement in multi-line/block form:

```ruby
unless foo
  bar
end
```

But they think it still makes sense to use it in single-line/modifier
form:

```ruby
bar unless foo
```

I’ve added three supported styles:

* `prefix` will only enforce using `unless` in the multi-line/block form
* `postfix` will only enforce using `unless` in the
single-line/modifier form
* `both` will enforce using `unless` in both the `prefix` and `postfix`
forms