### PR TITLE
[Fix #4109] Fix incorrect auto correction in `Style/SelfAssignment` cop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,6 +56,7 @@
 * [#4001](https://github.com/bbatsov/rubocop/issues/4001): Lint/UnneededDisable of Metrics/LineLength that isn't unneeded. ([@wkurniawan07][])
 * [#3960](https://github.com/bbatsov/rubocop/issues/3960): Let `Include`/`Exclude` paths in all files beginning with `.rubocop` be relative to the configuration file's directory and not to the current directory. ([@jonas054][])
 * [#4049](https://github.com/bbatsov/rubocop/pull/4049): Bugfix for `Style/EmptyLiteral` cop. ([@ota42y][])
+* [#4109](https://github.com/bbatsov/rubocop/issues/4109): Fix incorrect auto correction in `Style/SelfAssignment` cop. ([@pocke][])
 
 ## 0.47.1 (2017-01-18)
 

--- a/lib/rubocop/cop/team.rb
+++ b/lib/rubocop/cop/team.rb
@@ -10,7 +10,8 @@ module RuboCop
         Style::SymbolProc => [Style::SpaceBeforeBlockBraces],
         Style::SpaceBeforeBlockBraces => [Style::SymbolProc],
         Style::LineEndConcatenation => [Style::UnneededInterpolation],
-        Style::UnneededInterpolation => [Style::LineEndConcatenation]
+        Style::UnneededInterpolation => [Style::LineEndConcatenation],
+        Style::SelfAssignment => [Style::SpaceAroundOperators]
       }.freeze
 
       DEFAULT_OPTIONS = {

--- a/lib/rubocop/cop/team.rb
+++ b/lib/rubocop/cop/team.rb
@@ -11,7 +11,8 @@ module RuboCop
         Style::SpaceBeforeBlockBraces => [Style::SymbolProc],
         Style::LineEndConcatenation => [Style::UnneededInterpolation],
         Style::UnneededInterpolation => [Style::LineEndConcatenation],
-        Style::SelfAssignment => [Style::SpaceAroundOperators]
+        Style::SelfAssignment => [Style::SpaceAroundOperators],
+        Style::SpaceAroundOperators => [Style::SelfAssignment]
       }.freeze
 
       DEFAULT_OPTIONS = {

--- a/spec/rubocop/cop/team_spec.rb
+++ b/spec/rubocop/cop/team_spec.rb
@@ -8,6 +8,39 @@ describe RuboCop::Cop::Team do
   let(:options) { nil }
   let(:ruby_version) { RuboCop::Config::KNOWN_RUBIES.last }
 
+  describe 'INCOMPATIBLE_COPS' do
+    include FileHelper
+
+    let(:options) { { formatters: [], auto_correct: true } }
+    let(:runner) { RuboCop::Runner.new(options, RuboCop::ConfigStore.new) }
+    let(:file_path) { 'example.rb' }
+
+    it 'auto corrects without SyntaxError', :isolated_environment do
+      source = <<-'END'.strip_indent
+        foo.map{ |a| a.nil? }
+
+        'foo' +
+          'bar' +
+          "#{baz}"
+
+        i=i+1
+      END
+      corrected = <<-'END'.strip_indent
+        foo.map(&:nil?)
+
+        'foo' \
+          'bar' \
+          "#{baz}"
+
+        i += 1
+      END
+
+      create_file(file_path, source)
+      runner.run([])
+      expect(File.read(file_path)).to eq(corrected)
+    end
+  end
+
   describe '#autocorrect?' do
     subject { team.autocorrect? }
 


### PR DESCRIPTION
See #4109 

If `Style/SelfAssignment` cop and `Style/SpaceAroundOperators` cop are try to autocorrect the same time, incorrect code may be generated. This change prevents this problem.

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Used the same coding conventions as the rest of the project.
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [ ] Added tests.
* [x] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] All tests are passing.
* [x] The new code doesn't generate RuboCop offenses.
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [ ] Updated cop documentation with `rake generate_cops_documentation` (required only when you've added a new cop or changed the configuration/documentation of an existing cop).

[1]: http://chris.beams.io/posts/git-commit/
