### PR TITLE
Fix false positives about double quotes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,6 +56,7 @@
 * [#4001](https://github.com/bbatsov/rubocop/issues/4001): Lint/UnneededDisable of Metrics/LineLength that isn't unneeded. ([@wkurniawan07][])
 * [#3960](https://github.com/bbatsov/rubocop/issues/3960): Let `Include`/`Exclude` paths in all files beginning with `.rubocop` be relative to the configuration file's directory and not to the current directory. ([@jonas054][])
 * [#4049](https://github.com/bbatsov/rubocop/pull/4049): Bugfix for `Style/EmptyLiteral` cop. ([@ota42y][])
+* [#4112](https://github.com/bbatsov/rubocop/pull/4112): Fix false positives about double quotes in `Style/StringLiterals`, `Style/UnneededCapitalW` and `Style/UnneededPercentQ` cops. ([@pocke][])
 
 ## 0.47.1 (2017-01-18)
 

--- a/lib/rubocop/cop/style/string_literals.rb
+++ b/lib/rubocop/cop/style/string_literals.rb
@@ -93,7 +93,7 @@ module RuboCop
 
         def accept_child_double_quotes?(nodes)
           nodes.any? do |n|
-            n.dstr_type? || double_quotes_acceptable?(n.str_content)
+            n.dstr_type? || double_quotes_required?(n.source)
           end
         end
       end

--- a/lib/rubocop/cop/style/unneeded_capital_w.rb
+++ b/lib/rubocop/cop/style/unneeded_capital_w.rb
@@ -25,8 +25,7 @@ module RuboCop
         def requires_interpolation?(node)
           node.child_nodes.any? do |string|
             string.dstr_type? ||
-              double_quotes_acceptable?(string.str_content) ||
-              string.source == '\s'
+              double_quotes_required?(string.source)
           end
         end
 

--- a/lib/rubocop/cop/style/unneeded_percent_q.rb
+++ b/lib/rubocop/cop/style/unneeded_percent_q.rb
@@ -88,7 +88,7 @@ module RuboCop
           src = node.source
           src.include?(QUOTE) &&
             (src =~ STRING_INTERPOLATION_REGEXP ||
-            (node.str_type? && double_quotes_acceptable?(node.str_content)))
+            (node.str_type? && double_quotes_required?(src)))
         end
       end
     end

--- a/lib/rubocop/cop/util.rb
+++ b/lib/rubocop/cop/util.rb
@@ -219,16 +219,6 @@ module RuboCop
         string =~ /'|(?<! \\) \\{2}* \\ (?![\\"])/x
       end
 
-      # If double quoted string literals are found in Ruby code, and they are
-      # not the preferred style, should they be flagged?
-      def double_quotes_acceptable?(string)
-        needs_escaping?(string) || hard_to_type?(string)
-      end
-
-      def hard_to_type?(string)
-        string.codepoints.any? { |cp| cp < 32 || cp > 126 }
-      end
-
       def needs_escaping?(string)
         double_quotes_required?(escape_string(string))
       end

--- a/spec/rubocop/cop/style/string_literals_spec.rb
+++ b/spec/rubocop/cop/style/string_literals_spec.rb
@@ -296,15 +296,16 @@ describe RuboCop::Cop::Style::StringLiterals, :config do
         }
       end
 
-      it 'does not crash on strings with line breaks in them' do
+      it 'registers an offense for strings with line breaks in them' do
         inspect_source(cop,
                        ['"--',
                         'SELECT *',
                         'LEFT JOIN X on Y',
                         'FROM Models"'])
-        # TODO: We should actually get an offense report here telling us to use
-        # single quotes. For now, we only check that we don't crash.
-        expect(cop.offenses).to be_empty
+        expect(cop.offenses.size).to eq(1)
+        expect(cop.messages).to eq(['Prefer single-quoted strings when you ' \
+                                    "don't need string interpolation or " \
+                                    'special symbols.'])
       end
 
       it 'accepts continued strings using all single quotes' do
@@ -339,6 +340,18 @@ describe RuboCop::Cop::Style::StringLiterals, :config do
 
       it "doesn't register offense for double quotes with embedded single" do
         inspect_source(cop, ['"abc\'" \\',
+                             '"def"'])
+        expect(cop.offenses).to be_empty
+      end
+
+      it 'accepts for double quotes with an escaped special character' do
+        inspect_source(cop, ['"abc\\t" \\',
+                             '"def"'])
+        expect(cop.offenses).to be_empty
+      end
+
+      it 'accepts for double quotes with an escaped normal character' do
+        inspect_source(cop, ['"abc\\!" \\',
                              '"def"'])
         expect(cop.offenses).to be_empty
       end

--- a/spec/rubocop/cop/style/unneeded_capital_w_spec.rb
+++ b/spec/rubocop/cop/style/unneeded_capital_w_spec.rb
@@ -38,6 +38,7 @@ describe RuboCop::Cop::Style::UnneededCapitalW do
               '  %W(\a)',
               '  %W(\s)',
               '  %W(\n)',
+              '  %W(\!)',
               'end']
     inspect_source(cop, source)
     expect(cop.offenses).to be_empty

--- a/spec/rubocop/cop/style/unneeded_percent_q_spec.rb
+++ b/spec/rubocop/cop/style/unneeded_percent_q_spec.rb
@@ -110,8 +110,14 @@ describe RuboCop::Cop::Style::UnneededPercentQ do
       expect(cop.messages).to be_empty
     end
 
-    it 'accepts a string with double quotes and an escape' do
+    it 'accepts a string with double quotes and an escaped special character' do
       inspect_source(cop, '%Q("\\thi")')
+
+      expect(cop.messages).to be_empty
+    end
+
+    it 'accepts a string with double quotes and an escaped normal character' do
+      inspect_source(cop, '%Q("\\!thi")')
 
       expect(cop.messages).to be_empty
     end


### PR DESCRIPTION
`StringLiterals`, `UnneededCapitalW` and `UnneededPercentQ` cops have
false positives about double quotes.
If escaped normal character that is like `\!` exists in a literal, those
cops make false positives.

For examples
======

`UnneededPercentQ`
-------

```ruby
%Q{"foo\!"}
```

The above code can't be replaced with `'"foo\!"'`.

```ruby
%Q{"foo\!"} == '"foo\!"'  # => false
```

But the cop adds an offense for the code.

```sh
$ rubocop --only UnneededPercentQ
Inspecting 1 file
C

Offenses:

test.rb:1:1: C: Use %Q only for strings that contain both single quotes and double quotes, or for dynamic strings that contain double quotes.
%Q{"foo\!"}
^^^^^^^^^^^

1 file inspected, 1 offense detected
```

`UnneededCapitalW`
-----------

```ruby
%W(a \! b)
```

The above code can't be replaced with `%w(a \! b)`(small `w`).

```ruby
%W(a \! b) == %w(a \! b)  # => false
```

But the cop adds an offense for the code.

```sh
$ rubocop --only UnneededCapitalW
Inspecting 1 file
C

Offenses:

test.rb:1:1: C: Do not use %W unless interpolation is needed. If not, use %w.
%W(a \! b)
^^^^^^^^^^

1 file inspected, 1 offense detected
```

`StringLiterals`
----------

```yaml
 # .rubocop.yml
StringLiterals:
  ConsistentQuotesInMultiline: true
```

```ruby
"foo \!" \
  "\!"
```

The double quotes in the above code can't be replaced with single
quotes.
But the cop adds an offense for the code.

```sh
$ rubocop --only StringLiterals
Inspecting 1 file
C

Offenses:

test.rb:1:1: C: Prefer single-quoted strings when you don't need string interpolation or special symbols.
"foo \!" \ ...
^^^^^^^^^^

1 file inspected, 1 offense detected
```

------

The cause about this false positives is `double_quotes_acceptable?` method.
The method receives a string value. For example, when a literal is `"\!"`, the method receives `"!"`. So, the presence or absence of escape will be lost.

This change fixed the problems.

**Replace this text with a summary of the changes in your PR.
The more detailed you are, the better.**

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Used the same coding conventions as the rest of the project.
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] All tests are passing.
* [x] The new code doesn't generate RuboCop offenses.
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [ ] Updated cop documentation with `rake generate_cops_documentation` (required only when you've added a new cop or changed the configuration/documentation of an existing cop).

[1]: http://chris.beams.io/posts/git-commit/
