### PR TITLE
Change `TargetRubyVersion` to 2.0 in order to check the RuboCop project

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -7,7 +7,7 @@ AllCops:
     - 'vendor/**/*'
     - 'spec/fixtures/**/*'
     - 'tmp/**/*'
-  TargetRubyVersion: 2.1
+  TargetRubyVersion: 2.0
 
 Style/Encoding:
   EnforcedStyle: never


### PR DESCRIPTION
RuboCop supports Ruby 2.0. https://github.com/bbatsov/rubocop/blob/master/rubocop.gemspec#L11
So, `TargetRubyVersion` should be `2.0`.