### PR TITLE
[Fix #4110] Fix incorrect auto correction in `Style/BracesAroundHashParameters` cop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,6 +57,8 @@
 * [#3960](https://github.com/bbatsov/rubocop/issues/3960): Let `Include`/`Exclude` paths in all files beginning with `.rubocop` be relative to the configuration file's directory and not to the current directory. ([@jonas054][])
 * [#4049](https://github.com/bbatsov/rubocop/pull/4049): Bugfix for `Style/EmptyLiteral` cop. ([@ota42y][])
 * [#4109](https://github.com/bbatsov/rubocop/issues/4109): Fix incorrect auto correction in `Style/SelfAssignment` cop. ([@pocke][])
+* [#4110](https://github.com/bbatsov/rubocop/issues/4110): Fix incorrect auto correction in `Style/BracesAroundHashParameters` cop. ([@musialik][])
+
 
 ## 0.47.1 (2017-01-18)
 
@@ -2669,3 +2671,4 @@
 [@kddeisz]: https://github.com/kddeisz
 [@ota42y]: https://github.com/ota42y
 [@smakagon]: https://github.com/smakagon
+[@musialik]: https://github.com/musialik

--- a/lib/rubocop/cop/team.rb
+++ b/lib/rubocop/cop/team.rb
@@ -12,7 +12,8 @@ module RuboCop
         Style::LineEndConcatenation => [Style::UnneededInterpolation],
         Style::UnneededInterpolation => [Style::LineEndConcatenation],
         Style::SelfAssignment => [Style::SpaceAroundOperators],
-        Style::SpaceAroundOperators => [Style::SelfAssignment]
+        Style::SpaceAroundOperators => [Style::SelfAssignment],
+        Style::BracesAroundHashParameters => [Style::MultilineHashBraceLayout]
       }.freeze
 
       DEFAULT_OPTIONS = {

--- a/spec/rubocop/cli/cli_autocorrect_spec.rb
+++ b/spec/rubocop/cli/cli_autocorrect_spec.rb
@@ -1023,4 +1023,20 @@ describe RuboCop::CLI, :isolated_environment do
                                          'foo.each { bar; }',
                                          ''].join("\n"))
   end
+
+  it 'corrects BracesAroundHashParameters offenses leaving the ' \
+     'MultilineHashBraceLayout offense unchanged' do
+    create_file('example.rb', ['def method_a',
+                               '  do_something({ a: 1,',
+                               '  })',
+                               'end',
+                               ''])
+
+    expect($stderr.string).to eq('')
+    expect(cli.run(%w(--auto-correct))).to eq(0)
+    expect(IO.read('example.rb')).to eq(['def method_a',
+                                         '  do_something(a: 1)',
+                                         'end',
+                                         ''].join("\n"))
+  end
 end


### PR DESCRIPTION
Fixes #4110 which was caused by a conflict between `Style/BracesAroundHashParameters` and `Style/MultilineHashBraceLayout` cops.

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Used the same coding conventions as the rest of the project.
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] All tests are passing.
* [x] The new code doesn't generate RuboCop offenses.
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [ ] Updated cop documentation with `rake generate_cops_documentation` (required only when you've added a new cop or changed the configuration/documentation of an existing cop).

[1]: http://chris.beams.io/posts/git-commit/
