### PR TITLE
[Fix #4102] Fix `Security` cops ignoring ::Const

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -62,6 +62,7 @@
 * [#4109](https://github.com/bbatsov/rubocop/issues/4109): Fix incorrect auto correction in `Style/SelfAssignment` cop. ([@pocke][])
 * [#4110](https://github.com/bbatsov/rubocop/issues/4110): Fix incorrect auto correction in `Style/BracesAroundHashParameters` cop. ([@musialik][])
 * [#4084](https://github.com/bbatsov/rubocop/issues/4084): Fix incorrect auto correction in `Style/TernaryParentheses` cop. ([@musialik][])
+* [#4102](https://github.com/bbatsov/rubocop/issues/4102): Fix `Security/JSONLoad`, `Security/MarshalLoad` and `Security/YAMLLoad` cops patterns not matching ::Const. ([@musialik][])
 
 ## 0.47.1 (2017-01-18)
 

--- a/lib/rubocop/cop/security/json_load.rb
+++ b/lib/rubocop/cop/security/json_load.rb
@@ -26,7 +26,7 @@ module RuboCop
         MSG = 'Prefer `JSON.parse` over `JSON.%s`.'.freeze
 
         def_node_matcher :json_load, <<-END
-          (send (const nil :JSON) ${:load :restore} ...)
+          (send (const {nil cbase} :JSON) ${:load :restore} ...)
         END
 
         def on_send(node)

--- a/lib/rubocop/cop/security/marshal_load.rb
+++ b/lib/rubocop/cop/security/marshal_load.rb
@@ -22,8 +22,8 @@ module RuboCop
         MSG = 'Avoid using `Marshal.%s`.'.freeze
 
         def_node_matcher :marshal_load, <<-END
-          (send (const nil :Marshal) ${:load :restore}
-          !(send (const nil :Marshal) :dump ...))
+          (send (const {nil cbase} :Marshal) ${:load :restore}
+          !(send (const {nil cbase} :Marshal) :dump ...))
         END
 
         def on_send(node)

--- a/lib/rubocop/cop/security/yaml_load.rb
+++ b/lib/rubocop/cop/security/yaml_load.rb
@@ -19,7 +19,7 @@ module RuboCop
         MSG = 'Prefer using `YAML.safe_load` over `YAML.load`.'.freeze
 
         def_node_matcher :yaml_load, <<-END
-          (send (const nil :YAML) :load ...)
+          (send (const {nil cbase} :YAML) :load ...)
         END
 
         def on_send(node)

--- a/spec/rubocop/cop/security/marshal_load_spec.rb
+++ b/spec/rubocop/cop/security/marshal_load_spec.rb
@@ -3,26 +3,60 @@
 describe RuboCop::Cop::Security::MarshalLoad, :config do
   subject(:cop) { described_class.new(config) }
 
-  it 'accepts Marshal.dump' do
-    inspect_source(cop, 'Marshal.dump({})')
-    expect(cop.offenses).to be_empty
+  before do
+    inspect_source(cop, source)
   end
 
-  it 'accepts Module::Marshal.dump' do
-    inspect_source(cop, 'Module::Marshal.dump({})')
-    expect(cop.offenses).to be_empty
-  end
+  shared_examples 'code with offense' do |code, message|
+    context "when checking #{code}" do
+      let(:source) { code }
 
-  [:load, :restore].each do |method|
-    it "registers an offense for Marshal.#{method}" do
-      inspect_source(cop, "Marshal.#{method}('{}')")
-      expect(cop.offenses.size).to eq(1)
-      expect(cop.offenses.first.message).to include("Marshal.#{method}")
-    end
-
-    it "accepts Marshal.#{method} if argument is a Marshal.dump" do
-      inspect_source(cop, "Marshal.#{method}(Marshal.dump({}))")
-      expect(cop.offenses).to be_empty
+      it 'registers an offense' do
+        expect(cop.offenses.size).to eq(1)
+        expect(cop.offenses.first.message).to eq(message)
+      end
     end
   end
+
+  shared_examples 'code without offense' do |code|
+    context "when checking #{code}" do
+      let(:source) { code }
+
+      it 'does not register any offense' do
+        expect(cop.offenses).to be_empty
+      end
+    end
+  end
+
+  shared_examples 'offensive method' do |method|
+    include_examples 'code with offense',
+                     "Marshal.#{method}('{}')",
+                     "Avoid using `Marshal.#{method}`."
+
+    include_examples 'code with offense',
+                     "::Marshal.#{method}('{}')",
+                     "Avoid using `Marshal.#{method}`."
+
+    include_examples 'code without offense',
+                     "Module::Marshal.#{method}('{}')"
+
+    include_examples 'code without offense',
+                     "Marshal.#{method}(Marshal.dump({}))"
+
+    include_examples 'code without offense',
+                     "::Marshal.#{method}(::Marshal.dump({}))"
+  end
+
+  include_examples 'code without offense',
+                   'Marshal.dump({})'
+
+  include_examples 'code without offense',
+                   '::Marshal.dump({})'
+
+  include_examples 'code without offense',
+                   'Module::Marshal.dump({})'
+
+  include_examples 'offensive method', :load
+
+  include_examples 'offensive method', :restore
 end


### PR DESCRIPTION
Fixes #4102. The issue describes `Security/MarshalLoad`, but it applies to other cops as well.

`Security/MarshalLoad`, `Security/JSONLoad` and `Security/YAMLLoad` weren't matching ::Const or Module::Const

This PR improves the patterns for each cop and adds specs for multiple combinations.

For example:
```ruby
# bad
Marshal.load("{}")
::Marshal.load("{}")
Module::Marshal.load("{}")

# okish - deep copy hack
Marshal.load(Marshal.dump({}))
Marshal.load(::Marshal.dump({}))
Marshal.load(Module::Marshal.dump({}))
::Marshal.load(Marshal.dump({}))
::Marshal.load(::Marshal.dump({}))
# etc.
```

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Used the same coding conventions as the rest of the project.
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] All tests are passing.
* [x] The new code doesn't generate RuboCop offenses.
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [ ] Updated cop documentation with `rake generate_cops_documentation` (required only when you've added a new cop or changed the configuration/documentation of an existing cop).

[1]: http://chris.beams.io/posts/git-commit/
