### PR TITLE
[Fixes #4103] Support patch version for TargetRubyVersion option in .…

### DIFF
--- a/lib/rubocop/config_loader.rb
+++ b/lib/rubocop/config_loader.rb
@@ -37,11 +37,17 @@ module RuboCop
         resolve_requires(path, hash)
 
         add_missing_namespaces(path, hash)
+        target_ruby_version_to_f!(hash)
 
         resolve_inheritance_from_gems(hash, hash.delete('inherit_gem'))
         resolve_inheritance(path, hash)
 
         hash.delete('inherit_from')
+
+        create_config(hash, path)
+      end
+
+      def create_config(hash, path)
         config = Config.new(hash, path)
 
         config.deprecation_check do |deprecation_message|
@@ -139,6 +145,13 @@ module RuboCop
             [default_configuration, config]
           end
         Config.new(merge(configs.first, configs.last), config_file)
+      end
+
+      def target_ruby_version_to_f!(hash)
+        version = 'TargetRubyVersion'
+        return unless hash['AllCops'] && hash['AllCops'][version]
+
+        hash['AllCops'][version] = hash['AllCops'][version].to_f
       end
 
       private

--- a/spec/rubocop/config_loader_spec.rb
+++ b/spec/rubocop/config_loader_spec.rb
@@ -507,6 +507,13 @@ describe RuboCop::ConfigLoader do
       )
     end
 
+    it 'changes target ruby version with a patch to float' do
+      create_file(configuration_path, ['AllCops:',
+                                       '  TargetRubyVersion: 2.3.4'])
+
+      expect(load_file.to_h).to eq('AllCops' => { 'TargetRubyVersion' => 2.3 })
+    end
+
     it 'loads configuration properly when it includes non-ascii characters ' do
       create_file(configuration_path, ['# All these cops of mine are ❤',
                                        'Style/Encoding:',


### PR DESCRIPTION
…rubocop.yml

These changes allow to specify TargetRubyVersion in .rubocop.yml with patch version:
AllCops:
  TargetRubyVersion: 2.3.3

Without these changes you would get an error:
> Error: Unknown Ruby version "2.3.3" found in `TargetRubyVersion` parameter (in /Users/nandersen/Projects/myproject/.rubocop.yml).
Known versions: 1.9, 2.0, 2.1, 2.2, 2.3, 2.4

It converts string value of ruby version (for example: "2.3.3") to float: 2.3
