### PR TITLE
[Fix #4100] Rails/SaveBang should flag "update_attributes"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,8 @@
 
 ### Changes
 
+* [#4100](https://github.com/bbatsov/rubocop/issues/4100): Rails/SaveBang should flag `update_attributes`. ([@andriymosin][])
+* [#4100](https://github.com/bbatsov/rubocop/issues/4100): Rails/SaveBang should flag `update_attributes`. ([@rhys-vdw][])
 * [#4083](https://github.com/bbatsov/rubocop/pull/4083): `Style/EmptyLineBetweenDefs` doesn't allow more than one empty line between method definitions by default (see `NumberOfEmptyLines`). ([@dorian][])
 * [#3997](https://github.com/bbatsov/rubocop/pull/3997): Include all ruby files by default and exclude non-ruby files. ([@dorian][])
 * [#4012](https://github.com/bbatsov/rubocop/pull/4012): Mark `foo[:bar]` as not complex in `Style/TernaryParentheses` cop with `require_parentheses_when_complex` style. ([@onk][])

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2679,3 +2679,4 @@
 [@twe4ked]: https://github.com/twe4ked
 [@andriymosin]: https://github.com/andriymosin
 [@maxbeizer]: https://github.com/maxbeizer
+[@andriymosin]: https://github.com/andriymosin

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2675,4 +2675,5 @@
 [@smakagon]: https://github.com/smakagon
 [@musialik]: https://github.com/musialik
 [@twe4ked]: https://github.com/twe4ked
+[@andriymosin]: https://github.com/andriymosin
 [@maxbeizer]: https://github.com/maxbeizer


### PR DESCRIPTION
Fixes [#4100](https://github.com/bbatsov/rubocop/issues/4100). 

Added `:update_attributes` method to `Rails/SaveBang` `MODIFY_PERSIST_METHODS`. 
As described in the issue, `:update_attributes` is an alias for `:update` and should act the same.