### PR TITLE
[Fix #4100] Rails/SaveBang should flag "update_attributes"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@
 
 ### Changes
 
+* [#4100](https://github.com/bbatsov/rubocop/issues/4100): Rails/SaveBang should flag `update_attributes`. ([@andriymosin][])
 * [#4083](https://github.com/bbatsov/rubocop/pull/4083): `Style/EmptyLineBetweenDefs` doesn't allow more than one empty line between method definitions by default (see `NumberOfEmptyLines`). ([@dorian][])
 * [#3997](https://github.com/bbatsov/rubocop/pull/3997): Include all ruby files by default and exclude non-ruby files. ([@dorian][])
 * [#4012](https://github.com/bbatsov/rubocop/pull/4012): Mark `foo[:bar]` as not complex in `Style/TernaryParentheses` cop with `require_parentheses_when_complex` style. ([@onk][])
@@ -2676,3 +2677,4 @@
 [@musialik]: https://github.com/musialik
 [@twe4ked]: https://github.com/twe4ked
 [@maxbeizer]: https://github.com/maxbeizer
+[@andriymosin]: https://github.com/andriymosin

--- a/lib/rubocop/cop/rails/save_bang.rb
+++ b/lib/rubocop/cop/rails/save_bang.rb
@@ -46,7 +46,8 @@ module RuboCop
 
         CREATE_PERSIST_METHODS = [:create,
                                   :first_or_create, :find_or_create_by].freeze
-        MODIFY_PERSIST_METHODS = [:save, :update, :destroy].freeze
+        MODIFY_PERSIST_METHODS = [:save,
+                                  :update, :update_attributes, :destroy].freeze
         PERSIST_METHODS = (CREATE_PERSIST_METHODS +
                            MODIFY_PERSIST_METHODS).freeze
 


### PR DESCRIPTION
Fixes [#4100](https://github.com/bbatsov/rubocop/issues/4100). 

Added `:update_attributes` method to `Rails/SaveBang` `MODIFY_PERSIST_METHODS`. 
As described in the issue, `:update_attributes` is an alias for `:update` and should act the same.