### PR TITLE
[Fix 4084] Fix `Style/TernaryParentheses` invalid auto-correct

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -61,6 +61,7 @@
 * [#4112](https://github.com/bbatsov/rubocop/pull/4112): Fix false positives about double quotes in `Style/StringLiterals`, `Style/UnneededCapitalW` and `Style/UnneededPercentQ` cops. ([@pocke][])
 * [#4109](https://github.com/bbatsov/rubocop/issues/4109): Fix incorrect auto correction in `Style/SelfAssignment` cop. ([@pocke][])
 * [#4110](https://github.com/bbatsov/rubocop/issues/4110): Fix incorrect auto correction in `Style/BracesAroundHashParameters` cop. ([@musialik][])
+* [#4084](https://github.com/bbatsov/rubocop/issues/4084): Fix incorrect auto correction in `Style/TernaryParentheses` cop. ([@musialik][])
 
 ## 0.47.1 (2017-01-18)
 

--- a/spec/rubocop/cop/style/ternary_parentheses_spec.rb
+++ b/spec/rubocop/cop/style/ternary_parentheses_spec.rb
@@ -201,6 +201,12 @@ describe RuboCop::Cop::Style::TernaryParentheses, :config do
       it_behaves_like 'code without offense',
                       '(foo..bar).include?(baz) ? a : b'
     end
+
+    context 'with no space between the parentheses and question mark' do
+      it_behaves_like 'code with offense',
+                      '(foo)? a : b',
+                      'foo ? a : b'
+    end
   end
 
   context 'configured for parentheses on complex and there are parens' do


### PR DESCRIPTION
Fixes #4084
The space between ternary condition and question mark is not required if the condition is parenthesized. Auto-correct would remove the parentheses and generate invalid Ruby code.

```ruby
(foo)? bar : baz # valid Ruby code
foo? bar : baz   # invalid auto-correct before
foo ? bar : baz  # after the fix
```

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Used the same coding conventions as the rest of the project.
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] All tests are passing.
* [x] The new code doesn't generate RuboCop offenses.
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [ ] Updated cop documentation with `rake generate_cops_documentation` (required only when you've added a new cop or changed the configuration/documentation of an existing cop).

[1]: http://chris.beams.io/posts/git-commit/
