### PR TITLE
Switch "before" and "after" in messages

### DIFF
--- a/lib/rubocop/cop/style/empty_lines_around_exception_handling_keywords.rb
+++ b/lib/rubocop/cop/style/empty_lines_around_exception_handling_keywords.rb
@@ -80,10 +80,13 @@ module RuboCop
           locations.each do |loc|
             line = loc.line
             keyword = loc.source
-            # on the keyword
-            check_line(style, line, format(MSG, 'before', keyword), &:empty?)
-            # under the keyword
-            check_line(style, line - 2, format(MSG, 'after', keyword), &:empty?)
+            # below the keyword
+            check_line(style, line, format(MSG, 'after', keyword), &:empty?)
+            # above the keyword
+            check_line(style,
+                       line - 2,
+                       format(MSG, 'before', keyword),
+                       &:empty?)
           end
         end
 

--- a/spec/rubocop/cop/style/empty_lines_around_exception_handling_keywords_spec.rb
+++ b/spec/rubocop/cop/style/empty_lines_around_exception_handling_keywords_spec.rb
@@ -4,10 +4,11 @@ describe RuboCop::Cop::Style::EmptyLinesAroundExceptionHandlingKeywords do
   let(:config) { RuboCop::Config.new }
   subject(:cop) { described_class.new(config) }
 
-  shared_examples :offense do |name, code, correction|
+  shared_examples :offense do |name, message, code, correction|
     it "registers an offense for #{name} with a blank" do
       inspect_source(cop, code.strip_indent)
       expect(cop.offenses.size).to eq(1)
+      expect(cop.messages).to eq(["Extra empty line detected #{message}."])
     end
 
     it "autocorrects for #{name} with a blank" do
@@ -23,7 +24,10 @@ describe RuboCop::Cop::Style::EmptyLinesAroundExceptionHandlingKeywords do
     end
   end
 
-  include_examples :offense, 'above rescue keyword', <<-CODE, <<-CORRECTION
+  include_examples :offense,
+                   'above rescue keyword',
+                   'before the `rescue`',
+                   <<-CODE, <<-CORRECTION
     begin
       f1
 
@@ -37,7 +41,11 @@ describe RuboCop::Cop::Style::EmptyLinesAroundExceptionHandlingKeywords do
       f2
     end
   CORRECTION
-  include_examples :offense, 'rescue section starting', <<-CODE, <<-CORRECTION
+
+  include_examples :offense,
+                   'rescue section starting',
+                   'after the `rescue`',
+                   <<-CODE, <<-CORRECTION
     begin
       f1
     rescue
@@ -51,7 +59,11 @@ describe RuboCop::Cop::Style::EmptyLinesAroundExceptionHandlingKeywords do
       f2
     end
   CORRECTION
-  include_examples :offense, 'rescue section ending', <<-CODE, <<-CORRECTION
+
+  include_examples :offense,
+                   'rescue section ending',
+                   'before the `else`',
+                   <<-CODE, <<-CORRECTION
     begin
       f1
     rescue
@@ -69,8 +81,10 @@ describe RuboCop::Cop::Style::EmptyLinesAroundExceptionHandlingKeywords do
       f3
     end
   CORRECTION
+
   include_examples :offense,
                    'rescue section ending for method definition',
+                   'before the `else`',
                    <<-CODE, <<-CORRECTION
     def foo
       f1
@@ -101,17 +115,20 @@ describe RuboCop::Cop::Style::EmptyLinesAroundExceptionHandlingKeywords do
       f4
     end
   END
-  include_examples :accepts, 'empty liens around begin body', <<-END
+
+  include_examples :accepts, 'empty lines around begin body', <<-END
     begin
 
       f1
 
     end
   END
+
   include_examples :accepts, 'empty begin', <<-END
     begin
     end
   END
+
   include_examples :accepts, 'empty method definition', <<-END
     def foo
     end
@@ -145,6 +162,7 @@ describe RuboCop::Cop::Style::EmptyLinesAroundExceptionHandlingKeywords do
 
       end
     END
+
     let(:correction) { <<-END.strip_indent }
       begin
 
@@ -202,6 +220,7 @@ describe RuboCop::Cop::Style::EmptyLinesAroundExceptionHandlingKeywords do
 
       end
     END
+
     let(:correction) { <<-END.strip_indent }
       def foo
 


### PR DESCRIPTION
The new cop `EmptyLinesAroundExceptionHandlingKeywords` would say “after” when it meant “before”, and vice versa:

```rb
# test.rb
def foo
  bar
rescue => e

  baz
end
```

```
» bin/rubocop --only Style/EmptyLinesAroundExceptionHandlingKeywords test.rb
Inspecting 1 file
C

Offenses:

test.rb:4:1: C: Extra empty line detected before the rescue.

1 file inspected, 1 offense detected
```

This PR adds specs for the cop messages in `EmptyLinesAroundExceptionHandlingKeywords`
cop, and switches around the usage of “before” and “after”.

Is it just me, or should those messages rather be “above” and “below”?

I won’t record it in the Changelog, since it’s a fix to an unreleased feature.

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [ x Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Used the same coding conventions as the rest of the project.
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] All tests are passing.
* [x] The new code doesn't generate RuboCop offenses.
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Updated cop documentation with `rake generate_cops_documentation` (required only when you've added a new cop or changed the configuration/documentation of an existing cop).

[1]: http://chris.beams.io/posts/git-commit/