### PR TITLE
Fix MultilineMethodCallIndentation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,7 @@
 * [#4055](https://github.com/bbatsov/rubocop/pull/4055): Add parameters count to offense message for `Metrics/ParameterLists` cop. ([@pocke][])
 * [#4081](https://github.com/bbatsov/rubocop/pull/4081): Allow `Marshal.load` if argument is a `Marshal.dump` in `Security/MarshalLoad` cop. ([@droptheplot][])
 * [#4124](https://github.com/bbatsov/rubocop/issues/4124): Make `Style/SymbolArray` cop to enable by default. ([@pocke][])
+* [#3331](https://github.com/bbatsov/rubocop/issues/3331): Change `Style/MultilineMethodCallIndentation` `indented_relative_to_receiver` to indent relative to the reciever and not relative to the caller. ([@jfelchner][])
 
 ### Bug fixes
 

--- a/manual/cops_style.md
+++ b/manual/cops_style.md
@@ -3484,15 +3484,15 @@ that span more than one line.
 
 ```ruby
 # bad
-while a
+while myvariable
 .b
-  something
+  # do something
 end
 
 # good, EnforcedStyle: aligned
-while a
+while myvariable
       .b
-  something
+  # do something
 end
 
 # good, EnforcedStyle: aligned
@@ -3500,11 +3500,29 @@ Thing.a
      .b
      .c
 
-# good, EnforcedStyle: indented
-while a
-    .b
-  something
+# good, EnforcedStyle:    indented,
+        IndentationWidth: 2
+while myvariable
+  .b
+
+  # do something
 end
+
+# good, EnforcedStyle:    indented_relative_to_receiver,
+        IndentationWidth: 2
+while myvariable
+        .a
+        .b
+
+  # do something
+end
+
+# good, EnforcedStyle:    indented_relative_to_receiver,
+        IndentationWidth: 2
+myvariable = Thing
+               .a
+               .b
+               .c
 ```
 
 ### Important attributes

--- a/spec/rubocop/cop/style/multiline_method_call_indentation_spec.rb
+++ b/spec/rubocop/cop/style/multiline_method_call_indentation_spec.rb
@@ -50,24 +50,6 @@ describe RuboCop::Cop::Style::MultilineMethodCallIndentation do
       expect(cop.messages).to be_empty
     end
 
-    it 'registers an offense for one space indentation of second line' do
-      inspect_source(cop,
-                     ['a',
-                      ' .b'])
-      expect(cop.messages).to eq(['Use 2 (not 1) spaces for indenting an ' \
-                                  'expression spanning multiple lines.'])
-      expect(cop.highlights).to eq(['.b'])
-    end
-
-    it 'registers an offense for proc call without a selector' do
-      inspect_source(cop,
-                     ['a',
-                      ' .(args)'])
-      expect(cop.messages).to eq(['Use 2 (not 1) spaces for indenting an ' \
-                                  'expression spanning multiple lines.'])
-      expect(cop.highlights).to eq(['.('])
-    end
-
     it 'accepts no extra indentation of third line' do
       inspect_source(cop,
                      ['   a.',
@@ -100,31 +82,12 @@ describe RuboCop::Cop::Style::MultilineMethodCallIndentation do
       expect(cop.messages).to be_empty
     end
 
-    it 'accepts even indentation of consecutive lines in typical RSpec code' do
-      inspect_source(cop,
-                     ['expect { Foo.new }.',
-                      '  to change { Bar.count }.',
-                      '  from(1).to(2)'])
-      expect(cop.messages).to be_empty
-    end
-
     it 'accepts any indentation of parameters to #[]' do
       inspect_source(cop,
                      ['payment = Models::IncomingPayments[',
                       "        id:      input['incoming-payment-id'],",
                       '           user_id: @user[:id]]'])
       expect(cop.messages).to be_empty
-    end
-
-    it 'registers an offense for extra indentation of 3rd line in typical ' \
-       'RSpec code' do
-      inspect_source(cop,
-                     ['expect { Foo.new }.',
-                      '  to change { Bar.count }.',
-                      '      from(1).to(2)'])
-      expect(cop.messages).to eq(['Use 2 (not 6) spaces for indenting an ' \
-                                  'expression spanning multiple lines.'])
-      expect(cop.highlights).to eq(['from'])
     end
 
     it "doesn't fail on unary operators" do
@@ -138,6 +101,14 @@ describe RuboCop::Cop::Style::MultilineMethodCallIndentation do
   end
 
   shared_examples 'common for aligned and indented' do
+    it 'accepts even indentation of consecutive lines in typical RSpec code' do
+      inspect_source(cop,
+                     ['expect { Foo.new }.',
+                      '  to change { Bar.count }.',
+                      '  from(1).to(2)'])
+      expect(cop.messages).to be_empty
+    end
+
     it 'registers an offense for no indentation of second line' do
       inspect_source(cop,
                      ['a.',
@@ -182,6 +153,35 @@ describe RuboCop::Cop::Style::MultilineMethodCallIndentation do
         .to eq(['Use 2 (not 0) spaces for indenting an expression spanning ' \
                 'multiple lines.'])
       expect(cop.highlights).to eq(['b'])
+    end
+
+    it 'registers an offense for extra indentation of 3rd line in typical ' \
+       'RSpec code' do
+      inspect_source(cop,
+                     ['expect { Foo.new }.',
+                      '  to change { Bar.count }.',
+                      '      from(1).to(2)'])
+      expect(cop.messages).to eq(['Use 2 (not 6) spaces for indenting an ' \
+                                  'expression spanning multiple lines.'])
+      expect(cop.highlights).to eq(['from'])
+    end
+
+    it 'registers an offense for proc call without a selector' do
+      inspect_source(cop,
+                     ['a',
+                      ' .(args)'])
+      expect(cop.messages).to eq(['Use 2 (not 1) spaces for indenting an ' \
+                                  'expression spanning multiple lines.'])
+      expect(cop.highlights).to eq(['.('])
+    end
+
+    it 'registers an offense for one space indentation of second line' do
+      inspect_source(cop,
+                     ['a',
+                      ' .b'])
+      expect(cop.messages).to eq(['Use 2 (not 1) spaces for indenting an ' \
+                                  'expression spanning multiple lines.'])
+      expect(cop.highlights).to eq(['.b'])
     end
   end
 
@@ -531,6 +531,19 @@ describe RuboCop::Cop::Style::MultilineMethodCallIndentation do
       expect(cop.offenses).to be_empty
     end
 
+    it 'accepts indentation of consecutive lines in typical RSpec code' do
+      inspect_source(cop,
+                     ['expect { Foo.new }.',
+                      '  to change { Bar.count }.',
+                      '       from(1).to(2)'])
+      expect(cop.messages).to be_empty
+
+      inspect_source(cop,
+                     ['expect { Foo.new }.to change { Bar.count }',
+                      '                        .from(1).to(2)'])
+      expect(cop.messages).to be_empty
+    end
+
     it 'registers an offense for no indentation of second line' do
       inspect_source(cop,
                      ['a.',
@@ -538,6 +551,35 @@ describe RuboCop::Cop::Style::MultilineMethodCallIndentation do
       expect(cop.messages)
         .to eq(['Indent `b` 2 spaces more than `a` on line 1.'])
       expect(cop.highlights).to eq(['b'])
+    end
+
+    it 'registers an offense for extra indentation of 3rd line in typical ' \
+       'RSpec code' do
+      inspect_source(cop,
+                     ['expect { Foo.new }.',
+                      '  to change { Bar.count }.',
+                      '      from(1).to(2)'])
+      expect(cop.messages).to eq(['Indent `from` 2 spaces more than `change ' \
+                                  '{ Bar.count }` on line 2.'])
+      expect(cop.highlights).to eq(['from'])
+    end
+
+    it 'registers an offense for proc call without a selector' do
+      inspect_source(cop,
+                     ['a',
+                      ' .(args)'])
+      expect(cop.messages).to eq(['Indent `.(` 2 spaces more than `a` on ' \
+                                  'line 1.'])
+      expect(cop.highlights).to eq(['.('])
+    end
+
+    it 'registers an offense for one space indentation of second line' do
+      inspect_source(cop,
+                     ['a',
+                      ' .b'])
+      expect(cop.messages).to eq(['Indent `.b` 2 spaces more than `a` on ' \
+                                  'line 1.'])
+      expect(cop.highlights).to eq(['.b'])
     end
 
     it 'registers an offense for 3 spaces indentation of second line' do


### PR DESCRIPTION
It appears as if the current behavior was potentially desired by the
original author, however I feel as if it's incorrect.

Not only does `aligned` and `indented` already behave the same as the
current behavior of `indented_relative_to_receiver`, but the name of
`indented_relative_to_receiver` is completely misleading to what the
current behavior actually does.

The current code looks all the way up the call stack such that if it's an
_argument_ to a method call, it traverses up _that_ method's call chain
until it can go no further.

Take this code as an example:

```ruby
existing_customer = Customer.find(customer_id)
order             = existing_customer
.orders
.status(SUCCESSFUL_STATES)
.order(:scheduled_delivery_date)
```

Whereas before it would have wanted this:

```ruby
existing_customer = Customer.find(customer_id)
order             = existing_customer
  .orders
  .status(SUCCESSFUL_STATES)
  .order(:scheduled_delivery_date)
```

Now it wants this:

```ruby
existing_customer = Customer.find(customer_id)
order             = existing_customer
                      .orders
                      .status(SUCCESSFUL_STATES)
                      .order(:scheduled_delivery_date)
```

Or this:

```ruby
expect(my_reading).to be.within(.005)
.of(5.0)
```

Whereas before it would have wanted this:

```ruby
expect(my_reading).to be.within(.005)
  .of(5.0)
```

Now it wants this:

```ruby
expect(my_reading).to be.within(.005)
                        .of(5.0)
```

if you want to always indent relative to the leftmost character or column
0, then this cop _already_ has a style for those scenarios: `aligned` and
`indented`.

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Used the same coding conventions as the rest of the project.
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] All tests are passing.
* [x] The new code doesn't generate RuboCop offenses.
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [ ] Updated cop documentation with `rake generate_cops_documentation` (required only when you've added a new cop or changed the configuration/documentation of an existing cop).

[1]: http://chris.beams.io/posts/git-commit/
