### PR TITLE
Fix indentation of the documentation for `Style/IndentAssignment` cop

### DIFF
--- a/lib/rubocop/cop/style/indent_assignment.rb
+++ b/lib/rubocop/cop/style/indent_assignment.rb
@@ -16,8 +16,8 @@ module RuboCop
       #   # good
       #   value =
       #     if foo
-      #     'bar'
-      #   end
+      #       'bar'
+      #     end
       #
       # The indentation of the remaining lines can be corrected with
       # other cops such as `IndentationConsistency` and `EndAlignment`.

--- a/manual/cops_style.md
+++ b/manual/cops_style.md
@@ -2361,8 +2361,8 @@ end
 # good
 value =
   if foo
-  'bar'
-end
+    'bar'
+  end
 ```
 
 ### Important attributes


### PR DESCRIPTION
The current example is unnatural, and other cops add offense for the code.

```ruby
value =
  if foo
  'bar'
end
```

```sh
$ rubocop
Inspecting 1 file
W

Offenses:

test.rb:1:1: W: Lint/UselessAssignment: Useless assignment to variable - value.
value =
^^^^^
test.rb:2:3: C: Style/IfUnlessModifier: Favor modifier if usage when having a single-line body. Another good alternative is the usage of control flow &&/||.
  if foo
  ^^
test.rb:3:3: C: Style/IndentationWidth: Use 2 (not 0) spaces for indentation.
  'bar'

test.rb:4:1: W: Lint/EndAlignment: end at 4, 0 is not aligned with if at 2, 2.
end
^^^

1 file inspected, 4 offenses detected
```

`Style/IndentationWidth` and `Lint/EndAlignment` cops say about "This style is not good".

This change fixes the issue.



-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Used the same coding conventions as the rest of the project.
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [ ] Added tests.
* [ ] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] All tests are passing.
* [x] The new code doesn't generate RuboCop offenses.
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Updated cop documentation with `rake generate_cops_documentation` (required only when you've added a new cop or changed the configuration/documentation of an existing cop).

[1]: http://chris.beams.io/posts/git-commit/
