### PR TITLE
[Fix #4004] Allow not treating comment lines as gem group separators in `Bundler/OrderedGems` cop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@
 * [#3937](https://github.com/bbatsov/rubocop/issues/3937): Add new `Rails/ActiveSupportAliases` cop. ([@tdeo][])
 * Add new `Rails/Blank` cop. ([@rrosenblum][])
 * Add new `Rails/Present` cop. ([@rrosenblum][])
+* [#4004](https://github.com/bbatsov/rubocop/issues/4004): Allow not treating comment lines as group separators in `Bundler/OrderedGems` cop. ([@konto-andrzeja][])
 
 ### Changes
 
@@ -2695,3 +2696,4 @@
 [@brandonweiss]: https://github.com/brandonweiss
 [@betesh]: https://github.com/betesh
 [@dpostorivo]: https://github.com/dpostorivo
+[@konto-andrzeja]: https://github.com/konto-andrzeja

--- a/config/default.yml
+++ b/config/default.yml
@@ -1498,3 +1498,6 @@ Rails/SkipsModelValidations:
 Rails/Validation:
   Include:
     - app/models/**/*.rb
+
+Bundler/OrderedGems:
+  TreatCommentsAsGroupSeparators: true

--- a/config/enabled.yml
+++ b/config/enabled.yml
@@ -1705,8 +1705,7 @@ Bundler/DuplicatedGem:
 
 Bundler/OrderedGems:
   Description: >-
-                 Sort alphabetically gems appearing within a contiguous set
-                 of lines in the Gemfile
+                 Gems within groups in the Gemfile should be alphabetically sorted.
   Enabled: true
   Include:
     - '**/Gemfile'

--- a/manual/cops_bundler.md
+++ b/manual/cops_bundler.md
@@ -45,7 +45,7 @@ Enabled by default | Supports autocorrection
 --- | ---
 Enabled | Yes
 
-Gems in consecutive lines should be alphabetically sorted
+Gems should be alphabetically sorted within groups.
 
 ### Example
 
@@ -62,6 +62,12 @@ gem 'rubocop'
 gem 'rubocop'
 
 gem 'rspec'
+
+# good only if TreatCommentsAsGroupSeparators is true
+# For code quality
+gem 'rubocop'
+# For tests
+gem 'rspec'
 ```
 
 ### Important attributes
@@ -69,3 +75,4 @@ gem 'rspec'
 Attribute | Value
 --- | ---
 Include | \*\*/Gemfile, \*\*/gems.rb
+TreatCommentsAsGroupSeparators | true


### PR DESCRIPTION
Fixes [[#4004]](https://github.com/bbatsov/rubocop/issues/4004)

Added `TreatCommentsAsGroupSeparators` option to `Bundler/OrderedGems`.

When it's `false` something like this:
```
# Use sqlite3 as the database for Active Record
gem 'sqlite3'
# Use Puma as the app server
gem 'puma', '~> 3.0'
```
will be autocorrected to this:
```
# Use Puma as the app server
gem 'puma', '~> 3.0'
# Use sqlite3 as the database for Active Record
gem 'sqlite3'
```
When it's `true` no offences will be registered.

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Used the same coding conventions as the rest of the project.
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] All tests are passing.
* [x] The new code doesn't generate RuboCop offenses.
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Updated cop documentation with `rake generate_cops_documentation` (required only when you've added a new cop or changed the configuration/documentation of an existing cop).

[1]: http://chris.beams.io/posts/git-commit/
