### PR TITLE
Remove method that is needed only for compatibility with Ruby 1.9

### DIFF
--- a/lib/rubocop/cop/util.rb
+++ b/lib/rubocop/cop/util.rb
@@ -90,7 +90,7 @@ module RuboCop
       def source_range(source_buffer, line_number, column, length = 1)
         if column.is_a?(Range)
           column_index = column.begin
-          length = numeric_range_size(column)
+          length = column.size
         else
           column_index = column
         end
@@ -197,14 +197,6 @@ module RuboCop
           end
         end
         node
-      end
-
-      # Range#size is not available prior to Ruby 2.0.
-      def numeric_range_size(range)
-        size = range.end - range.begin
-        size += 1 unless range.exclude_end?
-        size = 0 if size < 0
-        size
       end
 
       # If converting a string to Ruby string literal source code, must

--- a/spec/rubocop/cop/util_spec.rb
+++ b/spec/rubocop/cop/util_spec.rb
@@ -99,18 +99,6 @@ describe RuboCop::Cop::Util do
     end
   end
 
-  # Test compatibility with Range#size in Ruby 2.0.
-  describe '#numeric_range_size' do
-    if RUBY_VERSION >= '2'
-      [1..1, 1...1, 1..2, 1...2, 1..3, 1...3, 1..-1, 1...-1].each do |range|
-        context "with range #{range}" do
-          subject { described_class.numeric_range_size(range) }
-          it { is_expected.to eq(range.size) }
-        end
-      end
-    end
-  end
-
   describe '#to_symbol_literal' do
     [
       ['foo', ':foo'],


### PR DESCRIPTION
This change removes `RuboCop::Cop::Util.numeric_range_size`. This method is needed only for compatibility with Ruby 1.9. 

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Used the same coding conventions as the rest of the project.
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [ ] Added tests.
* [ ] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] All tests are passing.
* [x] The new code doesn't generate RuboCop offenses.
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [ ] Updated cop documentation with `rake generate_cops_documentation` (required only when you've added a new cop or changed the configuration/documentation of an existing cop).

[1]: http://chris.beams.io/posts/git-commit/
