### PR TITLE
Fix examples in the documentation for `Style/SymbolArray` cop

### DIFF
--- a/lib/rubocop/cop/style/symbol_array.rb
+++ b/lib/rubocop/cop/style/symbol_array.rb
@@ -11,24 +11,22 @@ module RuboCop
       # support a version of Ruby lower than 2.0.
       #
       # @example
+      #   EnforcedStyle: percent (default)
       #
-      # # EnforcedStyle: percent (default)
+      #   # good
+      #   %i[foo bar baz]
       #
-      # # good
-      # %i[foo bar baz]
-      #
-      # # bad
-      # [:foo, :bar, :baz]
+      #   # bad
+      #   [:foo, :bar, :baz]
       #
       # @example
+      #   EnforcedStyle: brackets
       #
-      # # EnforcedStyle: brackets
+      #   # good
+      #   [:foo, :bar, :baz]
       #
-      # # good
-      # [:foo, :bar, :baz]
-      #
-      # # bad
-      # %i[foo bar baz]
+      #   # bad
+      #   %i[foo bar baz]
       class SymbolArray < Cop
         include ConfigurableEnforcedStyle
         include ArraySyntax

--- a/manual/cops_style.md
+++ b/manual/cops_style.md
@@ -3651,25 +3651,60 @@ Checks for uses of if with a negated condition. Only ifs
 without else are considered. There are three different styles:
 
 both - enforces `unless` for `prefix` and `postfix` conditionals
+
+  # good
+
   unless foo
     bar
   end
 
-  bar unless foo
+  # bad
 
-prefix - enforces `unless` for just `prefix` conditionals
-  unless foo
-    bar
-  end
-
-  bar if !foo
-
-postfix - enforces `unless` for just `postfix` conditionals
   if !foo
     bar
   end
 
+  # good
+
   bar unless foo
+
+  # bad
+
+  bar if !foo
+
+prefix - enforces `unless` for just `prefix` conditionals
+
+  # good
+
+  unless foo
+    bar
+  end
+
+  # bad
+
+  if !foo
+    bar
+  end
+
+  # good
+
+  bar if !foo
+
+postfix - enforces `unless` for just `postfix` conditionals
+
+  # good
+
+  bar unless foo
+
+  # bad
+
+  bar if !foo
+
+  # good
+
+  if !foo
+    bar
+  end
 
 ### Important attributes
 
@@ -5372,21 +5407,26 @@ Alternatively, it checks for symbol arrays using the %i() syntax on
 projects which do not want to use that syntax, perhaps because they
 support a version of Ruby lower than 2.0.
 
-# EnforcedStyle: percent (default)
+### Example
+
+```ruby
+EnforcedStyle: percent (default)
 
 # good
 %i[foo bar baz]
 
 # bad
 [:foo, :bar, :baz]
-
-# EnforcedStyle: brackets
+```
+```ruby
+EnforcedStyle: brackets
 
 # good
 [:foo, :bar, :baz]
 
 # bad
 %i[foo bar baz]
+```
 
 ### Important attributes
 


### PR DESCRIPTION
Note: This change includes #4104's diff.


## Before

http://rubocop.readthedocs.io/en/latest/cops_style/#stylesymbolarray

![170320193921](https://cloud.githubusercontent.com/assets/4361134/24096411/f65368c6-0da4-11e7-87d6-ad1ac34bc18f.png)

## After

![170320193931](https://cloud.githubusercontent.com/assets/4361134/24096412/f653bf42-0da4-11e7-8764-ecc9484846f1.png)






