### PR TITLE
[Fix #4128] Prevent Style/CaseIndentation from registering offenses on single line case statements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -68,6 +68,7 @@
 * [#4102](https://github.com/bbatsov/rubocop/issues/4102): Fix `Security/JSONLoad`, `Security/MarshalLoad` and `Security/YAMLLoad` cops patterns not matching ::Const. ([@musialik][])
 * [#3580](https://github.com/bbatsov/rubocop/issues/3580): Handle combinations of `# rubocop:disable all` and `# rubocop:disable SomeCop`. ([@jonas054][])
 * [#4124](https://github.com/bbatsov/rubocop/issues/4124): Fix auto correction bugs in `Style/SymbolArray` cop. ([@pocke][])
+* [#4128](https://github.com/bbatsov/rubocop/issues/4128): Prevent `Style/CaseIndentation` cop from registering offenses on single-line case statements. ([@drenmi][])
 
 ## 0.47.1 (2017-01-18)
 

--- a/lib/rubocop/cop/style/case_indentation.rb
+++ b/lib/rubocop/cop/style/case_indentation.rb
@@ -14,6 +14,8 @@ module RuboCop
         MSG = 'Indent `when` %s `%s`.'.freeze
 
         def on_case(case_node)
+          return if case_node.single_line?
+
           case_node.each_when do |when_node|
             check_when(when_node)
           end

--- a/spec/rubocop/cop/style/case_indentation_spec.rb
+++ b/spec/rubocop/cop/style/case_indentation_spec.rb
@@ -15,6 +15,15 @@ describe RuboCop::Cop::Style::CaseIndentation do
         { 'EnforcedStyle' => 'case', 'IndentOneStep' => false }
       end
 
+      context 'with everything on a single line' do
+        let(:source) { 'case foo; when :bar then 1; else 0; end' }
+
+        it 'does not register an offense' do
+          inspect_source(cop, source)
+          expect(cop.offenses).to be_empty
+        end
+      end
+
       context 'regarding assignment where the right hand side is a case' do
         let(:correct_source) do
           ['output = case variable',
@@ -235,6 +244,15 @@ describe RuboCop::Cop::Style::CaseIndentation do
         { 'EnforcedStyle' => 'case', 'IndentOneStep' => true }
       end
 
+      context 'with everything on a single line' do
+        let(:source) { 'case foo; when :bar then 1; else 0; end' }
+
+        it 'does not register an offense' do
+          inspect_source(cop, source)
+          expect(cop.offenses).to be_empty
+        end
+      end
+
       let(:correct_source) do
         ['output = case variable',
          "           when 'value1'",
@@ -365,6 +383,15 @@ describe RuboCop::Cop::Style::CaseIndentation do
         { 'EnforcedStyle' => 'end', 'IndentOneStep' => false }
       end
 
+      context 'with everything on a single line' do
+        let(:source) { 'case foo; when :bar then 1; else 0; end' }
+
+        it 'does not register an offense' do
+          inspect_source(cop, source)
+          expect(cop.offenses).to be_empty
+        end
+      end
+
       let(:correct_source) do
         ['output = case variable',
          "when 'value1'",
@@ -415,6 +442,15 @@ describe RuboCop::Cop::Style::CaseIndentation do
     context 'with IndentOneStep: true' do
       let(:cop_config) do
         { 'EnforcedStyle' => 'end', 'IndentOneStep' => true }
+      end
+
+      context 'with everything on a single line' do
+        let(:source) { 'case foo; when :bar then 1; else 0; end' }
+
+        it 'does not register an offense' do
+          inspect_source(cop, source)
+          expect(cop.offenses).to be_empty
+        end
       end
 
       let(:correct_source) do


### PR DESCRIPTION
This cop would register indentation offenses on single-line case statements. This change fixes that, since the relative indentation of individual `when` statements is not meaningful in this form.

-----------------

Before submitting the PR make sure the following are checked:

* [X] Wrote [good commit messages][1].
* [X] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [X] Used the same coding conventions as the rest of the project.
* [X] Feature branch is up-to-date with `master` (if not - rebase it).
* [X] Squashed related commits together.
* [X] Added tests.
* [X] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [X] All tests are passing.
* [X] The new code doesn't generate RuboCop offenses.
* [X] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [ ] Updated cop documentation with `rake generate_cops_documentation` (required only when you've added a new cop or changed the configuration/documentation of an existing cop).

[1]: http://chris.beams.io/posts/git-commit/
