### PR TITLE
[Fix #4143] Prevent `Style/IdenticalConditionalBranches` from registering offenses when a case statement has an empty when.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -71,6 +71,7 @@
 * [#3580](https://github.com/bbatsov/rubocop/issues/3580): Handle combinations of `# rubocop:disable all` and `# rubocop:disable SomeCop`. ([@jonas054][])
 * [#4124](https://github.com/bbatsov/rubocop/issues/4124): Fix auto correction bugs in `Style/SymbolArray` cop. ([@pocke][])
 * [#4128](https://github.com/bbatsov/rubocop/issues/4128): Prevent `Style/CaseIndentation` cop from registering offenses on single-line case statements. ([@drenmi][])
+* [#4143](https://github.com/bbatsov/rubocop/issues/4143): Prevent `Style/IdenticalConditionalBranches` from registering offenses when a case statement has an empty when. ([@dpostorivo][])
 
 ## 0.47.1 (2017-01-18)
 
@@ -2690,3 +2691,4 @@
 [@andriymosin]: https://github.com/andriymosin
 [@brandonweiss]: https://github.com/brandonweiss
 [@betesh]: https://github.com/betesh
+[@dpostorivo]: https://github.com/dpostorivo

--- a/lib/rubocop/cop/style/identical_conditional_branches.rb
+++ b/lib/rubocop/cop/style/identical_conditional_branches.rb
@@ -40,6 +40,28 @@ module RuboCop
       #   else
       #     do_y
       #   end
+      #
+      #   @bad
+      #   switch foo
+      #   when 1
+      #     do_x
+      #   when 2
+      #     do_x
+      #   else
+      #     do_x
+      #   end
+      #
+      #   @good
+      #   switch foo
+      #   when 1
+      #     do_x
+      #     do_y
+      #   when 2
+      #     # nothing
+      #   else
+      #     do_x
+      #     do_z
+      #   end
       class IdenticalConditionalBranches < Cop
         MSG = 'Move `%s` out of the conditional.'.freeze
 
@@ -58,7 +80,11 @@ module RuboCop
         def on_case(node)
           return unless node.else? && node.else_branch
 
-          check_branches(node.when_branches.map(&:body).push(node.else_branch))
+          branches = node.when_branches.map(&:body).push(node.else_branch)
+
+          return if branches.any?(&:nil?)
+
+          check_branches(branches)
         end
 
         private

--- a/spec/rubocop/cop/style/identical_conditional_branches_spec.rb
+++ b/spec/rubocop/cop/style/identical_conditional_branches_spec.rb
@@ -196,4 +196,22 @@ describe RuboCop::Cop::Style::IdenticalConditionalBranches do
       expect(cop.offenses).to be_empty
     end
   end
+
+  context 'on case with empty when' do
+    let(:source) do
+      ['case something',
+       'when :a',
+       '  do_x',
+       '  do_y',
+       'when :b',
+       'else',
+       '  do_x',
+       '  do_z',
+       'end']
+    end
+
+    it "doesn't register an offense" do
+      expect(cop.offenses).to be_empty
+    end
+  end
 end


### PR DESCRIPTION
Fixes the issue seen in [#4143](https://github.com/bbatsov/rubocop/issues/4143) where empty cases are not accounted for in the Stype/IdenticalConditionalBanrches cop. The case below will no longer registered as an offense:

```
case foo
when 1
  3
when 2
else
  3
end
```

The same as this case:

```
case foo
when 1
  3
when 2
nil
else
  3
end
```


-----------------

Before submitting the PR make sure the following are checked:

* [X] Wrote [good commit messages][1].
* [X] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [X] Used the same coding conventions as the rest of the project.
* [X] Feature branch is up-to-date with `master` (if not - rebase it).
* [X] Squashed related commits together.
* [X] Added tests.
* [X] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [X] All tests are passing.
* [X] The new code doesn't generate RuboCop offenses.
* [X] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [X] Updated cop documentation with `rake generate_cops_documentation` (required only when you've added a new cop or changed the configuration/documentation of an existing cop).

[1]: http://chris.beams.io/posts/git-commit/
