### PR TITLE
Fix a regression in UselessAssignment with a single top level conditional

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -74,6 +74,7 @@
 * [#4124](https://github.com/bbatsov/rubocop/issues/4124): Fix auto correction bugs in `Style/SymbolArray` cop. ([@pocke][])
 * [#4128](https://github.com/bbatsov/rubocop/issues/4128): Prevent `Style/CaseIndentation` cop from registering offenses on single-line case statements. ([@drenmi][])
 * [#4143](https://github.com/bbatsov/rubocop/issues/4143): Prevent `Style/IdenticalConditionalBranches` from registering offenses when a case statement has an empty when. ([@dpostorivo][])
+* [#4160](https://github.com/bbatsov/rubocop/pull/4160): Fix a regression where `UselessAssignment` cop may not properly detect useless assignments when there's only a single conditional expression in the top level scope. ([@yujinakayama][])
 
 ## 0.47.1 (2017-01-18)
 

--- a/lib/rubocop/cop/variable_force/locatable.rb
+++ b/lib/rubocop/cop/variable_force/locatable.rb
@@ -166,7 +166,7 @@ module RuboCop
 
         def ancestor_nodes_in_scope
           node.each_ancestor.take_while do |ancestor_node|
-            !ancestor_node.equal?(scope.node)
+            scope.include?(ancestor_node)
           end
         end
 

--- a/spec/rubocop/cop/lint/useless_assignment_spec.rb
+++ b/spec/rubocop/cop/lint/useless_assignment_spec.rb
@@ -1748,6 +1748,25 @@ describe RuboCop::Cop::Lint::UselessAssignment do
     include_examples 'mimics MRI 2.1'
   end
 
+  # regression test, from problem in Locatable
+  context 'when a variable is assigned in 2 identical if branches' do
+    let(:source) do
+      ['def foo',
+       '  if bar',
+       '    foo = 1',
+       '  else',
+       '    foo = 1',
+       '  end',
+       '  foo.bar.baz',
+       'end']
+    end
+
+    it "doesn't think 1 of the 2 assignments is useless" do
+      inspect_source(cop, source)
+      expect(cop.offenses).to be_empty
+    end
+  end
+
   describe 'similar name suggestion' do
     context "when there's a similar variable-like method invocation" do
       let(:source) do
@@ -1867,25 +1886,6 @@ describe RuboCop::Cop::Lint::UselessAssignment do
         expect(cop.offenses.size).to eq(1)
         expect(cop.offenses.first.message)
           .to eq('Useless assignment to variable - `enviromnent`.')
-      end
-    end
-
-    # regression test, from problem in Locatable
-    context 'when a variable is assigned in 2 identical if branches' do
-      let(:source) do
-        ['def foo',
-         '  if bar',
-         '    foo = 1',
-         '  else',
-         '    foo = 1',
-         '  end',
-         '  foo.bar.baz',
-         'end']
-      end
-
-      it "doesn't think 1 of the 2 assignments is useless" do
-        inspect_source(cop, source)
-        expect(cop.offenses).to be_empty
       end
     end
   end

--- a/spec/rubocop/cop/lint/useless_assignment_spec.rb
+++ b/spec/rubocop/cop/lint/useless_assignment_spec.rb
@@ -807,6 +807,28 @@ describe RuboCop::Cop::Lint::UselessAssignment do
     end
   end
 
+  context "when there's an unreferenced assignment in top level if branch " \
+          'while the variable is referenced in the paired else branch' do
+    let(:source) do
+      [
+        'if flag',
+        '  foo = 1',
+        'else',
+        '  puts foo',
+        'end'
+      ]
+    end
+
+    it 'registers an offense for the assignment in the if branch' do
+      inspect_source(cop, source)
+      expect(cop.offenses.size).to eq(1)
+      expect(cop.offenses.first.message)
+        .to eq('Useless assignment to variable - `foo`.')
+      expect(cop.offenses.first.line).to eq(2)
+      expect(cop.highlights).to eq(['foo'])
+    end
+  end
+
   context 'when a variable is assigned in branch of modifier if ' \
           'that references the variable in its conditional clause' \
           'and referenced after the branching' do


### PR DESCRIPTION
This fixes a regression where `UselessAssignment` cop may not properly detect useless assignments when there's _only a single conditional expression_ in the top level scope:

```ruby
if flag
  foo = 1 # This is useless ...
else
  puts foo # ... since this will never run together with the assignment
end
```

This regression was introduced in https://github.com/bbatsov/rubocop/commit/8eecfe0cf41b1f1ddbb147ccc767ea9600c7280e.

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Used the same coding conventions as the rest of the project.
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] All tests are passing.
* [x] The new code doesn't generate RuboCop offenses.
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [ ] Updated cop documentation with `rake generate_cops_documentation` (required only when you've added a new cop or changed the configuration/documentation of an existing cop).

[1]: http://chris.beams.io/posts/git-commit/