### PR TITLE
Enable --only-failures and --next-failure options in RSpec

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,13 +14,16 @@ doc
 Gemfile.lock
 Gemfile.local
 
+# rspec
+/spec/examples.txt
+
 # jeweler generated
 pkg
 
 # etags
 TAGS
 
-# Have editor/IDE/OS specific files you need to ignore? Consider using a global gitignore: 
+# Have editor/IDE/OS specific files you need to ignore? Consider using a global gitignore:
 #
 # * Create a file at ~/.gitignore
 # * Include files you want ignored

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -26,6 +26,8 @@ RSpec.configure do |config|
   config.filter_run :focus
   config.run_all_when_everything_filtered = true
 
+  config.example_status_persistence_file_path = 'spec/examples.txt'
+
   config.order = :random
   Kernel.srand config.seed
 


### PR DESCRIPTION
... so that we can effectively run specs during the trial-and-error process.

https://relishapp.com/rspec/rspec-core/docs/command-line/only-failures

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Used the same coding conventions as the rest of the project.
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [ ] Added tests.
* [ ] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] All tests are passing.
* [x] The new code doesn't generate RuboCop offenses.
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [ ] Updated cop documentation with `rake generate_cops_documentation` (required only when you've added a new cop or changed the configuration/documentation of an existing cop).

[1]: http://chris.beams.io/posts/git-commit/