### PR TITLE
Update RubyMine integration details

### DIFF
--- a/manual/integration_with_other_tools.md
+++ b/manual/integration_with_other_tools.md
@@ -49,7 +49,7 @@ provides LightTable integration.
 
 ### RubyMine / Intellij IDEA
 
-RuboCop is [available](https://www.jetbrains.com/help/idea/2017.1/rubocop.html) as of the 2017.1 releases.
+RuboCop support is [available](https://www.jetbrains.com/help/idea/2017.1/rubocop.html) as of the 2017.1 releases.
 
 ### Visual Studio Code
 

--- a/manual/integration_with_other_tools.md
+++ b/manual/integration_with_other_tools.md
@@ -47,10 +47,9 @@ The [linter-rubocop](https://github.com/AtomLinter/linter-rubocop) plugin for At
 The [lt-rubocop](https://github.com/seancaffery/lt-rubocop) plugin
 provides LightTable integration.
 
-### RubyMine
+### RubyMine / Intellij IDEA
 
-The [rubocop-for-rubymine](https://github.com/sirlantis/rubocop-for-rubymine) plugin
-provides basic RuboCop integration for RubyMine/IntelliJ IDEA.
+RuboCop is [available](https://www.jetbrains.com/help/idea/2017.1/rubocop.html) as of the 2017.1 releases.
 
 ### Visual Studio Code
 


### PR DESCRIPTION
RubyMine (as well as Intellij IDEA) supports RuboCop as of the 2017.1. (I deleted the plugin info b/c it seems to be busted for supported versions of RubyMine – the plugin code hasn't been updated since 2015.)
