### PR TITLE
Fix invalid yard documentation

### DIFF
--- a/lib/rubocop/ast/node/array_node.rb
+++ b/lib/rubocop/ast/node/array_node.rb
@@ -29,9 +29,12 @@ module RuboCop
       #
       # @overload percent_literal?
       #   Check for any percent literal.
+      #
       # @overload percent_literal?(type)
       #   Check for percent literaly of type `type`.
-      # @param type [Symbol] an optional percent literal type
+      #
+      #   @param type [Symbol] an optional percent literal type
+      #
       # @return [Boolean] whether the array is enclosed in percent brackets
       def percent_literal?(type = nil)
         if type

--- a/lib/rubocop/ast/node/case_node.rb
+++ b/lib/rubocop/ast/node/case_node.rb
@@ -40,6 +40,7 @@ module RuboCop
       # Returns the else branch of the `case` statement, if any.
       #
       # @return [Node] the else branch node of the `case` statement
+      # @return [nil] if the case statement does not have an else branch.
       def else_branch
         node_parts[-1]
       end

--- a/lib/rubocop/ast/node/hash_node.rb
+++ b/lib/rubocop/ast/node/hash_node.rb
@@ -37,7 +37,7 @@ module RuboCop
 
       # Returns an array of all the keys in the `hash` literal.
       #
-      # @return [Node] an array of keys in the `hash` literal
+      # @return [Array<Node>] an array of keys in the `hash` literal
       def keys
         each_key.to_a
       end
@@ -59,7 +59,7 @@ module RuboCop
 
       # Returns an array of all the values in the `hash` literal.
       #
-      # @return [Node] an array of values in the `hash` literal
+      # @return [Array<Node>] an array of values in the `hash` literal
       def values
         each_pair.map(&:value)
       end

--- a/lib/rubocop/ast/node/if_node.rb
+++ b/lib/rubocop/ast/node/if_node.rb
@@ -104,6 +104,7 @@ module RuboCop
       # @note This is normalized for `unless` nodes.
       #
       # @return [Node] the truthy branch node of the `if` node
+      # @return [nil] if the truthy branch is empty
       def if_branch
         node_parts[1]
       end
@@ -114,6 +115,7 @@ module RuboCop
       # @note This is normalized for `unless` nodes.
       #
       # @return [Node] the falsey branch node of the `if` node
+      # @return [nil] when there is no else branch
       def else_branch
         node_parts[2]
       end

--- a/lib/rubocop/ast/node/send_node.rb
+++ b/lib/rubocop/ast/node/send_node.rb
@@ -24,7 +24,7 @@ module RuboCop
 
       # Checks whether the method name matches the argument.
       #
-      # @param [Symbol|String] name the method name to check for
+      # @param [Symbol, String] name the method name to check for
       # @return [Boolean] whether the method name matches the argument
       def method?(name)
         method_name == name.to_sym
@@ -44,7 +44,7 @@ module RuboCop
       # Checks whether the method name matches the argument and has an
       # implicit receiver.
       #
-      # @param [Symbol|String] name the method name to check for
+      # @param [Symbol, String] name the method name to check for
       # @return [Boolean] whether the method name matches the argument
       def command?(name)
         !receiver && method?(name)

--- a/lib/rubocop/ast/node/when_node.rb
+++ b/lib/rubocop/ast/node/when_node.rb
@@ -44,7 +44,7 @@ module RuboCop
 
       # Returns the body of the `when` node.
       #
-      # @return [Node] the body of the `when` node
+      # @return [Node, nil] the body of the `when` node
       def body
         node_parts[-1]
       end

--- a/lib/rubocop/cop/message_annotator.rb
+++ b/lib/rubocop/cop/message_annotator.rb
@@ -28,7 +28,7 @@ module RuboCop
       # @option cop_config [String] :Reference Full reference URL
       # @option cop_config [String] :Details
       #
-      # @param [Hash] options
+      # @param [Hash, nil] optional options
       # @option option [Boolean] :display_style_guide
       #   Include style guide and reference URLs
       # @option option [Boolean] :extra_details

--- a/lib/rubocop/cop/mixin/duplication.rb
+++ b/lib/rubocop/cop/mixin/duplication.rb
@@ -37,7 +37,7 @@ module RuboCop
       # element and all duplicate instances.
       #
       # @param [Array] collection an array to group duplicates for
-      # @return [Hash] the grouped duplicates
+      # @return [Array] the grouped duplicates
       def grouped_duplicates(collection)
         collection.group_by { |item| item }.values.reject(&:one?)
       end

--- a/lib/rubocop/cop/offense.rb
+++ b/lib/rubocop/cop/offense.rb
@@ -72,7 +72,7 @@ module RuboCop
       # @return [Boolean]
       #   whether this offense is automatically corrected.
       def corrected
-        @status == :unsupported ? nil : @status == :corrected
+        @status == :unsupported ? false : @status == :corrected
       end
       alias corrected? corrected
 

--- a/lib/rubocop/cop/registry.rb
+++ b/lib/rubocop/cop/registry.rb
@@ -80,7 +80,7 @@ module RuboCop
       #   cops.qualified_cop_name('NotACop') # => 'NotACop'
       #
       # @param name [String] Cop name extracted from config
-      # @param path [String] Path of file that `name` was extracted from
+      # @param path [String, nil] Path of file that `name` was extracted from
       #
       # @raise [AmbiguousCopName]
       #   if a bare identifier with two possible namespaces is provided

--- a/spec/rubocop/cop/cop_spec.rb
+++ b/spec/rubocop/cop/cop_spec.rb
@@ -101,7 +101,7 @@ describe RuboCop::Cop::Cop do
 
       it 'is not specified (set to nil)' do
         cop.add_offense(nil, location, 'message')
-        expect(cop.offenses.first.corrected?).to be_nil
+        expect(cop.offenses.first.corrected?).to be(false)
       end
     end
 


### PR DESCRIPTION
I've been working on a tool that verifies YARD documentation by tracing test execution. You can check that out here: [backus/yardcheck](https://github.com/backus/yardcheck).

I ran yardcheck on RuboCop and found some documentation to improve. I've split the changes out into separate commits but I'm happy to squash it down after it has been reviewed.

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Used the same coding conventions as the rest of the project.
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [ ] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [ ] All tests are passing.
* [x] The new code doesn't generate RuboCop offenses.
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Updated cop documentation with `rake generate_cops_documentation` (required only when you've added a new cop or changed the configuration/documentation of an existing cop).

[1]: http://chris.beams.io/posts/git-commit/
