### PR TITLE
remove redundant module_function

### DIFF
--- a/lib/rubocop/platform.rb
+++ b/lib/rubocop/platform.rb
@@ -4,9 +4,7 @@ module RuboCop
   # This module provides information on the platform that RuboCop is being run
   # on.
   module Platform
-    module_function
-
-    def windows?
+    def self.windows?
       RUBY_PLATFORM =~ /cygwin|mswin|mingw|bccwin|wince|emx/
     end
   end

--- a/lib/rubocop/version.rb
+++ b/lib/rubocop/version.rb
@@ -7,9 +7,7 @@ module RuboCop
 
     MSG = '%s (using Parser %s, running on %s %s %s)'.freeze
 
-    module_function
-
-    def version(debug = false)
+    def self.version(debug = false)
       if debug
         format(MSG, STRING, Parser::VERSION,
                RUBY_ENGINE, RUBY_VERSION, RUBY_PLATFORM)


### PR DESCRIPTION
Replace `module_function` with `def self.*` in `Rubocop::Platform` and `Rubocop::Version` in sake of simplicity.

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Used the same coding conventions as the rest of the project.
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [ ] Added tests.
* [x] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] All tests are passing.
* [x] The new code doesn't generate RuboCop offenses.
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.

[1]: http://chris.beams.io/posts/git-commit/