### PR TITLE
Fix documentations of Performance/StartWith and Performance/EndWith

### DIFF
--- a/lib/rubocop/cop/performance/end_with.rb
+++ b/lib/rubocop/cop/performance/end_with.rb
@@ -12,8 +12,7 @@ module RuboCop
       #   'abc'.match(/bc\Z/)
       #
       #   @good
-      #   'abc' =~ /ab/
-      #   'abc' =~ /\w*\Z/
+      #   'abc'.end_with?('bc')
       class EndWith < Cop
         MSG = 'Use `String#end_with?` instead of a regex match anchored to ' \
               'the end of the string.'.freeze

--- a/lib/rubocop/cop/performance/start_with.rb
+++ b/lib/rubocop/cop/performance/start_with.rb
@@ -12,8 +12,7 @@ module RuboCop
       #   'abc'.match(/\Aab/)
       #
       #   @good
-      #   'abc' =~ /ab/
-      #   'abc' =~ /\A\w*/
+      #   'abc'.start_with?('ab')
       class StartWith < Cop
         MSG = 'Use `String#start_with?` instead of a regex match anchored to ' \
               'the beginning of the string.'.freeze

--- a/manual/cops_performance.md
+++ b/manual/cops_performance.md
@@ -253,8 +253,7 @@ would suffice.
 'abc'.match(/bc\Z/)
 
 # good
-'abc' =~ /ab/
-'abc' =~ /\w*\Z/
+'abc'.end_with?('bc')
 ```
 
 ### Important attributes

--- a/manual/cops_performance.md
+++ b/manual/cops_performance.md
@@ -659,8 +659,7 @@ This cop identifies unnecessary use of a regex where
 'abc'.match(/\Aab/)
 
 # good
-'abc' =~ /ab/
-'abc' =~ /\A\w*/
+'abc'.start_with?('ab')
 ```
 
 ### Important attributes


### PR DESCRIPTION
I fixed good examples in Performance/StartWith and Performance/EndWith documentations.

The cop Performance/StartWith and Performance/EndWith prefer `#start_with?` / `#end_with?` than `#~=` or `#match`. So its good examples in documents should use `#start_with?` / `#end_with?` and I fixed.

Please check my PR.
Thanks.

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [x] (There are no issues) Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Used the same coding conventions as the rest of the project.
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] (Fix documentation only) Added tests.
* [x] (Fix documentation only) Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] All tests are passing.
* [x] The new code doesn't generate RuboCop offenses.
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Updated cop documentation with `rake generate_cops_documentation` (required only when you've added a new cop or changed the configuration/documentation of an existing cop).

[1]: http://chris.beams.io/posts/git-commit/
