### PR TITLE
[FIX #4145] Yoda conditions cop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 * [#4314](https://github.com/bbatsov/rubocop/pull/4314): Check slow hash accessing in `Array#sort` by `Performance/CompareWithBlock`. ([@pocke][])
 * [#3438](https://github.com/bbatsov/rubocop/issues/3438): Add new `Style/FormatStringToken` cop. ([@backus][])
 * [#4342](https://github.com/bbatsov/rubocop/pull/4342): Add new `Lint/ScriptPermission` cop. ([@yhirano55][])
+* [#4145](https://github.com/bbatsov/rubocop/issues/4145): Add new `Style/YodaCondition` cop. ([@smakagon][])
 
 ### Changes
 

--- a/config/enabled.yml
+++ b/config/enabled.yml
@@ -1013,6 +1013,10 @@ Style/WordArray:
   StyleGuide: '#percent-w'
   Enabled: true
 
+Style/YodaCondition:
+  Description: 'Do not use literals as the first operand of a comparison'
+  Enabled: true
+
 Style/ZeroLengthPredicate:
   Description: 'Use #empty? when testing for objects of length 0.'
   Enabled: true

--- a/lib/rubocop.rb
+++ b/lib/rubocop.rb
@@ -440,6 +440,7 @@ require 'rubocop/cop/style/when_then'
 require 'rubocop/cop/style/while_until_do'
 require 'rubocop/cop/style/while_until_modifier'
 require 'rubocop/cop/style/word_array'
+require 'rubocop/cop/style/yoda_condition'
 require 'rubocop/cop/style/zero_length_predicate'
 
 require 'rubocop/cop/rails/action_filter'

--- a/lib/rubocop/cop/style/yoda_condition.rb
+++ b/lib/rubocop/cop/style/yoda_condition.rb
@@ -1,0 +1,72 @@
+# frozen_string_literal: true
+
+module RuboCop
+  module Cop
+    module Style
+      # This cop checks for Yoda conditions, i.e. comparison operations where
+      # readability is reduced because the operands are not ordered the same
+      # way as they would be ordered in spoken English.
+      #
+      # @example
+      #
+      #   # bad
+      #   99 == foo
+      #   "bar" == foo
+      #
+      # @example
+      #
+      #   # good
+      #   foo == 99
+      #   foo == "bar"
+      class YodaCondition < Cop
+        MSG = 'Reverse the order in conditional statement: `%s`.'.freeze
+        WHITELIST_TYPES = %i[lvar ivar send const regexp begin].freeze
+
+        def on_send(node)
+          return unless yoda_condition?(node)
+
+          register_offense(node)
+        end
+
+        private
+
+        def yoda_condition?(node)
+          return false unless comparison_operator?(node)
+
+          !WHITELIST_TYPES.include?(node.receiver.type)
+        end
+
+        def comparison_operator?(node)
+          RuboCop::AST::Node::COMPARISON_OPERATORS.include?(node.method_name)
+        end
+
+        def register_offense(node)
+          add_offense(node, :expression, format(MSG, node.source))
+        end
+
+        def autocorrect(node)
+          lambda do |corrector|
+            corrector.replace(actual_code_range(node), corrected_code(node))
+          end
+        end
+
+        def corrected_code(node)
+          first, operator, last = node.children
+          "#{last.source} #{reverse_comparison(operator)} #{first.source}"
+        end
+
+        def actual_code_range(node)
+          range_between(
+            node.loc.expression.begin_pos, node.loc.expression.end_pos
+          )
+        end
+
+        def reverse_comparison(operator)
+          {
+            '<' => '>', '<=' => '>=', '>' => '<', '>=' => '<='
+          }.fetch(operator.to_s, operator)
+        end
+      end
+    end
+  end
+end

--- a/manual/cops.md
+++ b/manual/cops.md
@@ -447,6 +447,7 @@ In the following section you find all available cops:
 * [Style/WhileUntilDo](cops_style.md#stylewhileuntildo)
 * [Style/WhileUntilModifier](cops_style.md#stylewhileuntilmodifier)
 * [Style/WordArray](cops_style.md#stylewordarray)
+* [Style/YodaCondition](cops_style.md#styleyodacondition)
 * [Style/ZeroLengthPredicate](cops_style.md#stylezerolengthpredicate)
 
 <!-- END_COP_LIST -->

--- a/manual/cops_style.md
+++ b/manual/cops_style.md
@@ -4057,6 +4057,29 @@ WordRegex | (?-mix:\A[\p{Word}\n\t]+\z)
 
 * [https://github.com/bbatsov/ruby-style-guide#percent-w](https://github.com/bbatsov/ruby-style-guide#percent-w)
 
+## Style/YodaCondition
+
+Enabled by default | Supports autocorrection
+--- | ---
+Enabled | Yes
+
+This cop checks for Yoda conditions, i.e. comparison operations where
+readability is reduced because the operands are not ordered the same
+way as they would be ordered in spoken English.
+
+### Example
+
+```ruby
+# bad
+99 == foo
+"bar" == foo
+```
+```ruby
+# good
+foo == 99
+foo == "bar"
+```
+
 ## Style/ZeroLengthPredicate
 
 Enabled by default | Supports autocorrection

--- a/spec/rubocop/cop/style/yoda_condition_spec.rb
+++ b/spec/rubocop/cop/style/yoda_condition_spec.rb
@@ -1,0 +1,97 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+describe RuboCop::Cop::Style::YodaCondition do
+  subject(:cop) { described_class.new }
+  subject(:error_message) { described_class::MSG }
+
+  before { inspect_source(cop, source) }
+
+  shared_examples 'accepts' do |code|
+    let(:source) { code }
+
+    it 'does not register an offense' do
+      expect(cop.offenses).to be_empty
+    end
+  end
+
+  shared_examples 'offense' do |code, conditional|
+    let(:source) { code }
+
+    it "registers an offense for #{conditional}" do
+      expect(cop.offenses.size).to eq(1)
+      expect(cop.offenses.first.message).to(
+        eq(format(error_message, conditional))
+      )
+    end
+  end
+
+  shared_examples 'autocorrected' do |code, corrected|
+    let(:source) { code }
+    it 'autocorrects code' do
+      expect(autocorrect_source(cop, source)).to eq(corrected)
+    end
+  end
+
+  it_behaves_like 'accepts', ['if foo == "bar"', 'end']
+  it_behaves_like 'accepts', ['if foo[0] > "bar" || baz != "baz"', 'end']
+  it_behaves_like 'accepts', ['while (node = last_node.parent)', '"foo"', 'end']
+  it_behaves_like(
+    'accepts', ['FOO = "const"', 'if (FOO <= 10 && bar >= 20)', 'end']
+  )
+  it_behaves_like(
+    'accepts', ['@foo = "test"', 'if @foo != "bar" && baz <= "baz"', 'end']
+  )
+  it_behaves_like(
+    'accepts', ['if (Foo::BAR != 10 && bar <= 1) && (z >= 1 || b != 2)', 'end']
+  )
+  it_behaves_like(
+    'accepts', ['if (sprintf?(n) || format?(n)) && !heredoc?(n)', 'end']
+  )
+  it_behaves_like 'accepts', 'z = foo if foo === "bar"'
+  it_behaves_like 'accepts', 'z = foo if File.exists?(foo)'
+  it_behaves_like 'accepts', 'return if (chain & bad_days).empty?'
+  it_behaves_like 'accepts', 'return false unless param'
+  it_behaves_like 'accepts', 'return unless self[cop] && self[cop].key?(param)'
+  it_behaves_like 'accepts', 'foo.remove(range, 1) if /^:/ =~ range.source'
+  it_behaves_like 'accepts', 'return if %i(kwarg kwoptarg).include?(node.type)'
+  it_behaves_like 'accepts', '(first_line - second_line) > 0'
+
+  it_behaves_like 'offense', ['if "foo" == bar', 'end'], '"foo" == bar'
+  it_behaves_like 'offense', ['if x == bar && nil == bar', 'end'], 'nil == bar'
+  it_behaves_like 'offense', ['if false == active?', 'end'], 'false == active?'
+  it_behaves_like 'offense', ['@foo = 10', 'if 15 != @foo', 'end'], '15 != @foo'
+  it_behaves_like 'offense', 'foo = 42 if 42 < bar', '42 < bar'
+  it_behaves_like 'offense', '42 < foo ? bar : baz', '42 < foo'
+
+  context 'autocorrection' do
+    it_behaves_like(
+      'autocorrected', 'if 10 == my_var; end', 'if my_var == 10; end'
+    )
+
+    it_behaves_like(
+      'autocorrected', 'if 2 < bar;end', 'if bar > 2;end'
+    )
+
+    it_behaves_like(
+      'autocorrected', 'foo = 42 if 42 > bar', 'foo = 42 if bar < 42'
+    )
+
+    it_behaves_like(
+      'autocorrected', '42 <= foo ? bar : baz', 'foo >= 42 ? bar : baz'
+    )
+
+    it_behaves_like(
+      'autocorrected', '42 >= foo ? bar : baz', 'foo <= 42 ? bar : baz'
+    )
+
+    it_behaves_like(
+      'autocorrected', 'nil != foo ? bar : baz', 'foo != nil ? bar : baz'
+    )
+
+    it_behaves_like(
+      'autocorrected', 'false === foo ? bar : baz', 'foo === false ? bar : baz'
+    )
+  end
+end


### PR DESCRIPTION
This cop checks for Yoda conditions where the two parts of an expression
are reversed from the typical order in a conditional statement. (As discussed in #4145)
    
    # bad
    99 = foo
    "bar" == foo
 
    # good
    foo == 99
    foo == "bar"