### PR TITLE
[Fix #4171] Prevent Rails/Blank cop from breaking when RHS of `or` is a naked falsiness check

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## master (unreleased)
 
+### Bug fixes
+
+* [#4171](https://github.com/bbatsov/rubocop/pull/4171): Prevent `Rails/Blank` from breaking when RHS of `or` is a naked falsiness check. ([@drenmi][])
+
 ## 0.48.0 (2017-03-26)
 
 ### New features

--- a/lib/rubocop/cop/rails/blank.rb
+++ b/lib/rubocop/cop/rails/blank.rb
@@ -75,6 +75,7 @@ module RuboCop
 
         def on_or(node)
           return unless cop_config['NilOrEmpty']
+          return unless node.rhs.receiver
 
           nil_or_empty?(node) do |variable1, variable2|
             return unless variable1 == variable2

--- a/spec/rubocop/cop/rails/blank_spec.rb
+++ b/spec/rubocop/cop/rails/blank_spec.rb
@@ -41,6 +41,13 @@ describe RuboCop::Cop::Rails::Blank, :config do
       expect(cop.offenses).to be_empty
     end
 
+    # Bug: https://github.com/bbatsov/rubocop/issues/4171
+    it 'does not break when RHS of `or` is a naked falsiness check' do
+      inspect_source(cop, 'foo.empty? || bar')
+
+      expect(cop.offenses).to be_empty
+    end
+
     context 'nil or empty' do
       it_behaves_like :offense, 'foo.nil? || foo.empty?',
                       'foo.blank?',


### PR DESCRIPTION
This cop would break if the RHS of the `||` operator was a naked falsiness check, e.g.:

```
foo.nil? || bar
```

This change fixes that.

-----------------

Before submitting the PR make sure the following are checked:

* [X] Wrote [good commit messages][1].
* [X] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [X] Used the same coding conventions as the rest of the project.
* [X] Feature branch is up-to-date with `master` (if not - rebase it).
* [X] Squashed related commits together.
* [X] Added tests.
* [X] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [X] All tests are passing.
* [X] The new code doesn't generate RuboCop offenses.
* [X] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [ ] Updated cop documentation with `rake generate_cops_documentation` (required only when you've added a new cop or changed the configuration/documentation of an existing cop).

[1]: http://chris.beams.io/posts/git-commit/
