### PR TITLE
[Fix #4172] Fix false positives in Style/MixinGrouping cop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 * [#4171](https://github.com/bbatsov/rubocop/pull/4171): Prevent `Rails/Blank` from breaking when RHS of `or` is a naked falsiness check. ([@drenmi][])
 * [#4189](https://github.com/bbatsov/rubocop/pull/4189): Make `Lint/AmbiguousBlockAssociation` aware of lambdas passed as arguments. ([@drenmi][])
 * [#4179](https://github.com/bbatsov/rubocop/pull/4179): Prevent `Rails/Blank` from breaking when LHS of `or` is a naked falsiness check. ([@rrosenblum][])
+* [#4172](https://github.com/bbatsov/rubocop/pull/4172): Fix false positives in `Style/MixinGrouping` cop. ([@drenmi][])
 
 ## 0.48.0 (2017-03-26)
 

--- a/lib/rubocop/ast/node/send_node.rb
+++ b/lib/rubocop/ast/node/send_node.rb
@@ -6,8 +6,6 @@ module RuboCop
     # node when the builder constructs the AST, making its methods available
     # to all `send` nodes within RuboCop.
     class SendNode < Node
-      MACRO_PARENT_NODES = %i(class module).freeze
-
       # The receiving node of the method invocation.
       #
       # @return [Node, nil] the receiver of the invoked method or `nil`
@@ -38,7 +36,7 @@ module RuboCop
       #
       # @return [Boolean] whether the method is a macro method
       def macro?
-        !receiver && MACRO_PARENT_NODES.include?(parent && parent.type)
+        !receiver && macro_scope?
       end
 
       # Checks whether the method name matches the argument and has an
@@ -185,6 +183,13 @@ module RuboCop
       def node_parts
         [*self]
       end
+
+      private # rubocop:disable Lint/UselessAccessModifier
+
+      def_matcher :macro_scope?, <<-PATTERN
+        {^({class module} ...)
+         ^^({class module} ... (begin ...))}
+      PATTERN
     end
   end
 end

--- a/lib/rubocop/cop/style/mixin_grouping.rb
+++ b/lib/rubocop/cop/style/mixin_grouping.rb
@@ -41,7 +41,7 @@ module RuboCop
         MSG = 'Put `%s` mixins in %s.'.freeze
 
         def on_send(node)
-          return unless MIXIN_METHODS.include?(node.method_name)
+          return unless node.macro? && MIXIN_METHODS.include?(node.method_name)
 
           check(node)
         end

--- a/spec/rubocop/ast/send_node_spec.rb
+++ b/spec/rubocop/ast/send_node_spec.rb
@@ -88,11 +88,12 @@ describe RuboCop::AST::SendNode do
   describe '#macro?' do
     context 'without a receiver' do
       context 'when parent is a class' do
-        let(:send_node) { parse_source(source).ast.children[2] }
+        let(:send_node) { parse_source(source).ast.children[2].children[0] }
 
         let(:source) do
           ['class Foo',
            '  bar :baz',
+           '  bar :qux',
            'end'].join("\n")
         end
 
@@ -100,11 +101,12 @@ describe RuboCop::AST::SendNode do
       end
 
       context 'when parent is a module' do
-        let(:send_node) { parse_source(source).ast.children[1] }
+        let(:send_node) { parse_source(source).ast.children[1].children[0] }
 
         let(:source) do
           ['module Foo',
            '  bar :baz',
+           '  bar :qux',
            'end'].join("\n")
         end
 

--- a/spec/rubocop/cop/style/mixin_grouping_spec.rb
+++ b/spec/rubocop/cop/style/mixin_grouping_spec.rb
@@ -58,6 +58,11 @@ describe RuboCop::Cop::Style::MixinGrouping, :config do
                          '  include Qux',
                          'end'].join("\n")
       end
+
+      context 'when include call is an argument to another method' do
+        it_behaves_like 'code without offense',
+                        'expect(foo).to include(bar, baz)'
+      end
     end
 
     context 'when using `extend`' do
@@ -141,6 +146,12 @@ describe RuboCop::Cop::Style::MixinGrouping, :config do
                         ['class Foo',
                          '  include Bar, Qux',
                          'end'].join("\n")
+      end
+
+      context 'when include has an explicit receiver' do
+        it_behaves_like 'code without offense',
+                        ['config.include Foo',
+                         'config.include Bar'].join("\n")
       end
     end
 


### PR DESCRIPTION
This cop would register an offense when one of the methods `#include`, `#extend`, or `#prepend` was sent to an explicit receiver, or used as an argument to another method.

This change fixes that.

-----------------

Before submitting the PR make sure the following are checked:

* [X] Wrote [good commit messages][1].
* [X] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [X] Used the same coding conventions as the rest of the project.
* [X] Feature branch is up-to-date with `master` (if not - rebase it).
* [X] Squashed related commits together.
* [X] Added tests.
* [X] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [X] All tests are passing.
* [X] The new code doesn't generate RuboCop offenses.
* [X] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [ ] Updated cop documentation with `rake generate_cops_documentation` (required only when you've added a new cop or changed the configuration/documentation of an existing cop).

[1]: http://chris.beams.io/posts/git-commit/
