### PR TITLE
[Fix #3947] Fix Rails/FilePath for dstr calling Rails.root without path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@
 * [#4198](https://github.com/bbatsov/rubocop/pull/4198): Make `Lint/AmbguousBlockAssociation` aware of operator methods. ([@drenmi][])
 * [#4152](https://github.com/bbatsov/rubocop/pull/4152): Make `Style/MethodCallWithArgsParentheses` not require parens on setter methods. ([@drenmi][])
 * [#4226](https://github.com/bbatsov/rubocop/pull/4226): Show in `--help` output that `--stdin` takes a file name argument. ([@jonas054][])
+* [#3947](https://github.com/bbatsov/rubocop/issues/3947): Fix a false positive in `Rails/FilePath` cop for Rails.root without path in dstr. ([@jspanjers][], [@lucascaton][])
 
 ## 0.48.0 (2017-03-26)
 
@@ -2720,3 +2721,4 @@
 [@dpostorivo]: https://github.com/dpostorivo
 [@konto-andrzeja]: https://github.com/konto-andrzeja
 [@sadovnik]: https://github.com/sadovnik
+[@lucascaton]: https://github.com/lucascaton

--- a/lib/rubocop/cop/rails/file_path.rb
+++ b/lib/rubocop/cop/rails/file_path.rb
@@ -29,9 +29,14 @@ module RuboCop
           (send (send (const nil :Rails) :root) :join ...)
         PATTERN
 
+        def_node_matcher :dstr_rails_root_with_str_node?, <<-PATTERN
+          (dstr (begin (send (const nil :Rails) :root)) str)
+        PATTERN
+
         def on_dstr(node)
-          return unless rails_root_nodes?(node)
-          register_offense(node)
+          return unless dstr_rails_root_with_str_node?(node)
+
+          register_offense(node) if node.child_nodes[1].source[0] == '/'
         end
 
         def on_send(node)

--- a/spec/rubocop/cop/rails/file_path_spec.rb
+++ b/spec/rubocop/cop/rails/file_path_spec.rb
@@ -30,7 +30,38 @@ describe RuboCop::Cop::Rails::FilePath do
     end
   end
 
-  context 'when using Rails.root called by double quoted string' do
+  context 'when using Rails.root without path called by double quoted string' do
+    let(:source) { '"#{Rails.root}"' }
+
+    it 'does not registers an offense' do
+      inspect_source(cop, source)
+      expect(cop.offenses).to be_empty
+    end
+  end
+
+  context 'when interpolating Rails.root in a rm system call' do
+    let :source do
+      'system "rm -rf #{Rails.root.join(\'public\', \'system\')}"'
+    end
+
+    it 'does not registers an offense' do
+      inspect_source(cop, source)
+      expect(cop.offenses).to be_empty
+    end
+  end
+
+  context 'when interpolating Rails.root in a wheneverize system call' do
+    let :source do
+      'system "wheneverize \'#{Rails.root}\'" unless File.exist? @filepath'
+    end
+
+    it 'does not registers an offense' do
+      inspect_source(cop, source)
+      expect(cop.offenses).to be_empty
+    end
+  end
+
+  context 'when using Rails.root with path called by double quoted string' do
     let(:source) { '"#{Rails.root}/app/models/goober"' }
 
     it 'registers an offense' do


### PR DESCRIPTION
Fix a false positive in `Rails/FilePath` cop for Rails.root without path in dstr.

Fixes #3947 and #3974 (duplicated).

-----------------

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]`
* [x] Used the same coding conventions as the rest of the project.
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] All tests are passing.
* [x] The new code doesn't generate RuboCop offenses.
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.

[1]: http://chris.beams.io/posts/git-commit/