### PR TITLE
Add Style/NumericLiterals's default parameter

### DIFF
--- a/config/default.yml
+++ b/config/default.yml
@@ -902,6 +902,7 @@ Style/NonNilCheck:
 
 Style/NumericLiterals:
   MinDigits: 5
+  Strict: false
 
 Style/NumericLiteralPrefix:
   EnforcedOctalStyle: zero_with_o

--- a/manual/cops_style.md
+++ b/manual/cops_style.md
@@ -4039,6 +4039,7 @@ of digits in them.
 Attribute | Value
 --- | ---
 MinDigits | 5
+Strict | false
 
 ### References
 

--- a/spec/rubocop/cli/cli_auto_gen_config_spec.rb
+++ b/spec/rubocop/cli/cli_auto_gen_config_spec.rb
@@ -67,6 +67,7 @@ describe RuboCop::CLI, :isolated_environment do
                 '',
                 '# Offense count: 1',
                 '# Cop supports --auto-correct.',
+                '# Configuration parameters: Strict.',
                 'Style/NumericLiterals:',
                 '  MinDigits: 7',
                 '',


### PR DESCRIPTION
`Strict` parameter was added in #4045, but `default.yml` has not changed.

I saw the following warnings if set `Strict` to my `.rubocop.yml`.

```
Warning: unrecognized parameter Style/NumericLiterals:Strict found in /Users/onaka/src/github.com/onk/onkcop/.rubocop.yml
```

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Used the same coding conventions as the rest of the project.
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [ ] Added tests.
* [ ] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] All tests are passing.
* [x] The new code doesn't generate RuboCop offenses.
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Updated cop documentation with `rake generate_cops_documentation` (required only when you've added a new cop or changed the configuration/documentation of an existing cop).

[1]: http://chris.beams.io/posts/git-commit/
