### PR TITLE
[Fix #4179] Prevent Rails/Blank cop from breaking when LHS of  is a naked falsiness check

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Bug fixes
 
 * [#4171](https://github.com/bbatsov/rubocop/pull/4171): Prevent `Rails/Blank` from breaking when RHS of `or` is a naked falsiness check. ([@drenmi][])
+* [#4179](https://github.com/bbatsov/rubocop/pull/4179): Prevent `Rails/Blank` from breaking when LHS of `or` is a naked falsiness check. ([@rrosenblum][])
 
 ## 0.48.0 (2017-03-26)
 

--- a/lib/rubocop/cop/rails/blank.rb
+++ b/lib/rubocop/cop/rails/blank.rb
@@ -75,7 +75,7 @@ module RuboCop
 
         def on_or(node)
           return unless cop_config['NilOrEmpty']
-          return unless node.rhs.receiver
+          return unless node.lhs.receiver && node.rhs.receiver
 
           nil_or_empty?(node) do |variable1, variable2|
             return unless variable1 == variable2

--- a/spec/rubocop/cop/rails/blank_spec.rb
+++ b/spec/rubocop/cop/rails/blank_spec.rb
@@ -48,6 +48,12 @@ describe RuboCop::Cop::Rails::Blank, :config do
       expect(cop.offenses).to be_empty
     end
 
+    it 'does not break when LHS of `or` is a naked falsiness check' do
+      inspect_source(cop, 'bar || foo.empty?')
+
+      expect(cop.offenses).to be_empty
+    end
+
     context 'nil or empty' do
       it_behaves_like :offense, 'foo.nil? || foo.empty?',
                       'foo.blank?',


### PR DESCRIPTION
This fixes #4179. This is a similar fix to what was done to fix #4171. This issue does not seem to impact `Rails/Present`.