### PR TITLE
[Fix #4189] Make `Lint/AmbiguousBlockAssociation` aware of lambda arguments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Bug fixes
 
 * [#4171](https://github.com/bbatsov/rubocop/pull/4171): Prevent `Rails/Blank` from breaking when RHS of `or` is a naked falsiness check. ([@drenmi][])
+* [#4189](https://github.com/bbatsov/rubocop/pull/4189): Make `Lint/AmbiguousBlockAssociation` aware of lambdas passed as arguments. ([@drenmi][])
 
 ## 0.48.0 (2017-03-26)
 

--- a/lib/rubocop/cop/lint/ambiguous_block_association.rb
+++ b/lib/rubocop/cop/lint/ambiguous_block_association.rb
@@ -22,6 +22,7 @@ module RuboCop
 
         def on_send(node)
           return if node.parenthesized? || node.assignment? || node.method?(:[])
+          return if lambda_argument?(node.first_argument)
 
           return unless method_with_block?(node.first_argument)
           first_param = node.first_argument.children.first
@@ -47,6 +48,10 @@ module RuboCop
         def message(param, method_name)
           format(MSG, param.children[1], method_name)
         end
+
+        def_node_matcher :lambda_argument?, <<-PATTERN
+          (block (send _ :lambda) ...)
+        PATTERN
       end
     end
   end

--- a/spec/rubocop/cop/lint/ambiguous_block_association_spec.rb
+++ b/spec/rubocop/cop/lint/ambiguous_block_association_spec.rb
@@ -16,6 +16,7 @@ describe RuboCop::Cop::Lint::AmbiguousBlockAssociation do
     end
   end
 
+  it_behaves_like 'accepts', 'foo ->(a) { bar a }'
   it_behaves_like 'accepts', 'some_method(a) { |el| puts el }'
   it_behaves_like 'accepts', 'some_method(a) do;puts a;end'
   it_behaves_like 'accepts', 'some_method a do;puts "dev";end'


### PR DESCRIPTION
This cop would register an offense for lambdas passed as an argument to a method, suggesting an awkward parentheses placement. I.e.:

```ruby
foo(->(b) { bar b })
   ^               ^
```

This change fixes that.

-----------------

Before submitting the PR make sure the following are checked:

* [X] Wrote [good commit messages][1].
* [X] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [X] Used the same coding conventions as the rest of the project.
* [X] Feature branch is up-to-date with `master` (if not - rebase it).
* [X] Squashed related commits together.
* [X] Added tests.
* [X] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [X] All tests are passing.
* [X] The new code doesn't generate RuboCop offenses.
* [X] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [ ] Updated cop documentation with `rake generate_cops_documentation` (required only when you've added a new cop or changed the configuration/documentation of an existing cop).

[1]: http://chris.beams.io/posts/git-commit/
