### PR TITLE
Fix Style/EmptyLineAfterMagicComment message

### DIFF
--- a/config/enabled.yml
+++ b/config/enabled.yml
@@ -566,7 +566,7 @@ Style/NestedTernaryOperator:
   Enabled: true
 
 Style/EmptyLineAfterMagicComment:
-  Description: 'Add a newline after magic comments to separate them from code.'
+  Description: 'Add an empty line after magic comments to separate them from code.'
   StyleGuide: '#separate-magic-comments-from-code'
   Enabled: true
 

--- a/lib/rubocop/cop/style/empty_line_after_magic_comment.rb
+++ b/lib/rubocop/cop/style/empty_line_after_magic_comment.rb
@@ -21,7 +21,7 @@ module RuboCop
       #     # Some code
       #   end
       class EmptyLineAfterMagicComment < Cop
-        MSG = 'Add a space after magic comments.'.freeze
+        MSG = 'Add an empty line after magic comments.'.freeze
         BLANK_LINE = /\A\s*\z/
 
         def investigate(source)

--- a/spec/rubocop/cop/style/empty_line_after_magic_comment_spec.rb
+++ b/spec/rubocop/cop/style/empty_line_after_magic_comment_spec.rb
@@ -8,7 +8,7 @@ describe RuboCop::Cop::Style::EmptyLineAfterMagicComment do
     inspect_source(cop, ['# frozen_string_literal: true',
                          'class Foo; end'])
     expect(cop.offenses.size).to eq(1)
-    expect(cop.messages).to eq(['Add a space after magic comments.'])
+    expect(cop.messages).to eq(['Add an empty line after magic comments.'])
   end
 
   it 'registers an offense for documentation immediately following comment' do
@@ -16,7 +16,7 @@ describe RuboCop::Cop::Style::EmptyLineAfterMagicComment do
                          '# Documentation for Foo',
                          'class Foo; end'])
     expect(cop.offenses.size).to eq(1)
-    expect(cop.messages).to eq(['Add a space after magic comments.'])
+    expect(cop.messages).to eq(['Add an empty line after magic comments.'])
   end
 
   it 'registers an offense when multiple magic comments without empty line' do
@@ -24,7 +24,7 @@ describe RuboCop::Cop::Style::EmptyLineAfterMagicComment do
                          '# frozen_string_literal: true',
                          'class Foo; end'])
     expect(cop.offenses.size).to eq(1)
-    expect(cop.messages).to eq(['Add a space after magic comments.'])
+    expect(cop.messages).to eq(['Add an empty line after magic comments.'])
   end
 
   it 'accepts code that separates the comment from the code with a newline' do


### PR DESCRIPTION
The current message is little unclear. It doesn't mean that user must add a new line.

-----------------

Before submitting the PR make sure the following are checked:

* [ ] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [ ] Used the same coding conventions as the rest of the project.
* [ ] Feature branch is up-to-date with `master` (if not - rebase it).
* [ ] Squashed related commits together.
* [ ] Added tests.
* [ ] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [ ] All tests are passing.
* [ ] The new code doesn't generate RuboCop offenses.
* [ ] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [ ] Updated cop documentation with `rake generate_cops_documentation` (required only when you've added a new cop or changed the configuration/documentation of an existing cop).

[1]: http://chris.beams.io/posts/git-commit/
