### PR TITLE
[Fix #4185] Make `Lint/NextedMethodDefinition` aware of exec methods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 * [#4189](https://github.com/bbatsov/rubocop/pull/4189): Make `Lint/AmbiguousBlockAssociation` aware of lambdas passed as arguments. ([@drenmi][])
 * [#4179](https://github.com/bbatsov/rubocop/pull/4179): Prevent `Rails/Blank` from breaking when LHS of `or` is a naked falsiness check. ([@rrosenblum][])
 * [#4172](https://github.com/bbatsov/rubocop/pull/4172): Fix false positives in `Style/MixinGrouping` cop. ([@drenmi][])
+* [#4185](https://github.com/bbatsov/rubocop/pull/4185): Make `Lint/NestedMethodDefinition` aware of `#*_exec` class of methods. ([@drenmi][])
 
 ## 0.48.0 (2017-03-26)
 

--- a/manual/cops_lint.md
+++ b/manual/cops_lint.md
@@ -1173,6 +1173,13 @@ def foo
     end
   end
 end
+
+def foo
+  self.module_exec do
+    def bar
+    end
+  end
+end
 ```
 
 ### References

--- a/spec/rubocop/cop/lint/nested_method_definition_spec.rb
+++ b/spec/rubocop/cop/lint/nested_method_definition_spec.rb
@@ -56,6 +56,18 @@ describe RuboCop::Cop::Lint::NestedMethodDefinition do
     expect(cop.offenses).to be_empty
   end
 
+  it 'does not register offense for nested definition inside instance_exec' do
+    inspect_source(cop, ['class Foo',
+                         '  def x(obj)',
+                         '    obj.instance_exec do',
+                         '      def y',
+                         '      end',
+                         '    end',
+                         '  end',
+                         'end'])
+    expect(cop.offenses).to be_empty
+  end
+
   it 'does not register offense for definition of method on local var' do
     inspect_source(cop, ['class Foo',
                          '  def x(obj)',
@@ -78,10 +90,34 @@ describe RuboCop::Cop::Lint::NestedMethodDefinition do
     expect(cop.offenses).to be_empty
   end
 
+  it 'does not register offense for nested definition inside class_exec' do
+    inspect_source(cop, ['class Foo',
+                         '  def x(klass)',
+                         '    klass.class_exec do',
+                         '      def y',
+                         '      end',
+                         '    end',
+                         '  end',
+                         'end'])
+    expect(cop.offenses).to be_empty
+  end
+
   it 'does not register offense for nested definition inside module_eval' do
     inspect_source(cop, ['class Foo',
                          '  def self.define(mod)',
                          '    mod.module_eval do',
+                         '      def y',
+                         '      end',
+                         '    end',
+                         '  end',
+                         'end'])
+    expect(cop.offenses).to be_empty
+  end
+
+  it 'does not register offense for nested definition inside module_eval' do
+    inspect_source(cop, ['class Foo',
+                         '  def self.define(mod)',
+                         '    mod.module_exec do',
                          '      def y',
                          '      end',
                          '    end',


### PR DESCRIPTION
This cop would incorrectly register an offense encountering a nested method definition within a `#*_exec` method, which scopes the definition to the instance, class, or module.

This change fixes that.

-----------------

Before submitting the PR make sure the following are checked:

* [X] Wrote [good commit messages][1].
* [X] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [X] Used the same coding conventions as the rest of the project.
* [X] Feature branch is up-to-date with `master` (if not - rebase it).
* [X] Squashed related commits together.
* [X] Added tests.
* [X] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [X] All tests are passing.
* [X] The new code doesn't generate RuboCop offenses.
* [X] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [X] Updated cop documentation with `rake generate_cops_documentation` (required only when you've added a new cop or changed the configuration/documentation of an existing cop).

[1]: http://chris.beams.io/posts/git-commit/
