### PR TITLE
[Fix #4197] Fix false positive in `Style/RedundantSelf` with parallel assignment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 * [#4179](https://github.com/bbatsov/rubocop/pull/4179): Prevent `Rails/Blank` from breaking when LHS of `or` is a naked falsiness check. ([@rrosenblum][])
 * [#4172](https://github.com/bbatsov/rubocop/pull/4172): Fix false positives in `Style/MixinGrouping` cop. ([@drenmi][])
 * [#4185](https://github.com/bbatsov/rubocop/pull/4185): Make `Lint/NestedMethodDefinition` aware of `#*_exec` class of methods. ([@drenmi][])
+* [#4197](https://github.com/bbatsov/rubocop/pull/4197): Fix false positive in `Style/RedundantSelf` cop with parallel assignment. ([@drenmi][])
 
 ## 0.48.0 (2017-03-26)
 

--- a/lib/rubocop/cop/style/redundant_self.rb
+++ b/lib/rubocop/cop/style/redundant_self.rb
@@ -71,9 +71,7 @@ module RuboCop
           add_scope(node)
         end
 
-        def on_defs(node)
-          add_scope(node)
-        end
+        alias on_defs on_def
 
         def on_args(node)
           node.children.each { |arg| on_argument(arg) }
@@ -90,6 +88,7 @@ module RuboCop
 
         def on_send(node)
           return unless node.self_receiver? && regular_method_call?(node)
+          return if node.parent && node.parent.mlhs_type?
 
           return if @allowed_send_nodes.include?(node) ||
                     @local_variables_scopes[node].include?(node.method_name)

--- a/spec/rubocop/cop/style/redundant_self_spec.rb
+++ b/spec/rubocop/cop/style/redundant_self_spec.rb
@@ -21,6 +21,12 @@ describe RuboCop::Cop::Style::RedundantSelf do
     expect(cop.offenses).to be_empty
   end
 
+  it 'accepts a self receiver on an lvalue of a parallel assignment' do
+    src = 'a, self.b = c, d'
+    inspect_source(cop, src)
+    expect(cop.offenses).to be_empty
+  end
+
   it 'accepts a self receiver on an lvalue of an or-assignment' do
     src = 'self.logger ||= Rails.logger'
     inspect_source(cop, src)


### PR DESCRIPTION
This cop would incorrectly mark a `self` as redundant when used in the lhs expression of a parallel assignment.

This change fixes that.

-----------------

Before submitting the PR make sure the following are checked:

* [X] Wrote [good commit messages][1].
* [X] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [X] Used the same coding conventions as the rest of the project.
* [X] Feature branch is up-to-date with `master` (if not - rebase it).
* [X] Squashed related commits together.
* [X] Added tests.
* [X] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [X] All tests are passing.
* [X] The new code doesn't generate RuboCop offenses.
* [X] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [ ] Updated cop documentation with `rake generate_cops_documentation` (required only when you've added a new cop or changed the configuration/documentation of an existing cop).

[1]: http://chris.beams.io/posts/git-commit/
