### PR TITLE
[Fix #4198] Make `Lint/AmbguousBlockAssociation` aware of operator methods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 * [#4185](https://github.com/bbatsov/rubocop/pull/4185): Make `Lint/NestedMethodDefinition` aware of `#*_exec` class of methods. ([@drenmi][])
 * [#4197](https://github.com/bbatsov/rubocop/pull/4197): Fix false positive in `Style/RedundantSelf` cop with parallel assignment. ([@drenmi][])
 * [#4199](https://github.com/bbatsov/rubocop/issues/4199): Fix incorrect auto correction in `Style/SymbolArray` and `Style/WordArray` cop. ([@pocke][])
+* [#4198](https://github.com/bbatsov/rubocop/pull/4198): Make `Lint/AmbguousBlockAssociation` aware of operator methods. ([@drenmi][])
 
 ## 0.48.0 (2017-03-26)
 

--- a/manual/cops_lint.md
+++ b/manual/cops_lint.md
@@ -19,6 +19,14 @@ some_method a { |val| puts val }
 # good
 # With parentheses, there's no ambiguity.
 some_method(a) { |val| puts val }
+
+# good
+# Operator methods require no disambiguation
+foo == bar { |b| b.baz }
+
+# good
+# Lambda arguments require no disambiguation
+foo = ->(bar) { bar.baz }
 ```
 
 ### References

--- a/spec/rubocop/cop/lint/ambiguous_block_association_spec.rb
+++ b/spec/rubocop/cop/lint/ambiguous_block_association_spec.rb
@@ -16,6 +16,7 @@ describe RuboCop::Cop::Lint::AmbiguousBlockAssociation do
     end
   end
 
+  it_behaves_like 'accepts', 'foo == bar { baz a }'
   it_behaves_like 'accepts', 'foo ->(a) { bar a }'
   it_behaves_like 'accepts', 'some_method(a) { |el| puts el }'
   it_behaves_like 'accepts', 'some_method(a) do;puts a;end'


### PR DESCRIPTION
This cop would register an offense when the outer method is an operator, e.g.:

```ruby
foo == bar { |b| b.baz }
```

However, this is idiomatic Ruby, and disambiguation isn't needed in these cases.

This change fixes that.

-----------------

Before submitting the PR make sure the following are checked:

* [X] Wrote [good commit messages][1].
* [X] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [X] Used the same coding conventions as the rest of the project.
* [X] Feature branch is up-to-date with `master` (if not - rebase it).
* [X] Squashed related commits together.
* [X] Added tests.
* [X] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [X] All tests are passing.
* [X] The new code doesn't generate RuboCop offenses.
* [X] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [X] Updated cop documentation with `rake generate_cops_documentation` (required only when you've added a new cop or changed the configuration/documentation of an existing cop).

[1]: http://chris.beams.io/posts/git-commit/
