### PR TITLE
[Fix #4199] Fix incorrect auto correction in `Style/SymbolArray` cop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 * [#4172](https://github.com/bbatsov/rubocop/pull/4172): Fix false positives in `Style/MixinGrouping` cop. ([@drenmi][])
 * [#4185](https://github.com/bbatsov/rubocop/pull/4185): Make `Lint/NestedMethodDefinition` aware of `#*_exec` class of methods. ([@drenmi][])
 * [#4197](https://github.com/bbatsov/rubocop/pull/4197): Fix false positive in `Style/RedundantSelf` cop with parallel assignment. ([@drenmi][])
+* [#4199](https://github.com/bbatsov/rubocop/issues/4199): Fix incorrect auto correction in `Style/SymbolArray` and `Style/WordArray` cop. ([@pocke][])
 
 ## 0.48.0 (2017-03-26)
 

--- a/lib/rubocop/cop/style/percent_literal_delimiters.rb
+++ b/lib/rubocop/cop/style/percent_literal_delimiters.rb
@@ -26,8 +26,6 @@ module RuboCop
       class PercentLiteralDelimiters < Cop
         include PercentLiteral
 
-        PERCENT_LITERAL_TYPES = %w(% %i %I %q %Q %r %s %w %W %x).freeze
-
         def on_array(node)
           process(node, '%w', '%W', '%i', '%I')
         end
@@ -76,35 +74,6 @@ module RuboCop
                     contains_preferred_delimiter?(node, type)
 
           add_offense(node, :expression)
-        end
-
-        def preferred_delimiters
-          @preferred_delimiters ||=
-            begin
-              ensure_valid_preferred_delimiters
-
-              if cop_config['PreferredDelimiters'].key?('default')
-                Hash[PERCENT_LITERAL_TYPES.map do |type|
-                  [type, cop_config['PreferredDelimiters'][type] ||
-                    cop_config['PreferredDelimiters']['default']]
-                end]
-              else
-                cop_config['PreferredDelimiters']
-              end
-            end
-        end
-
-        def ensure_valid_preferred_delimiters
-          invalid = cop_config['PreferredDelimiters'].keys -
-                    (PERCENT_LITERAL_TYPES + %w(default))
-          return if invalid.empty?
-
-          raise ArgumentError,
-                "Invalid preferred delimiter config key: #{invalid.join(', ')}"
-        end
-
-        def preferred_delimiters_for(type)
-          preferred_delimiters[type].split(//)
         end
 
         def uses_preferred_delimiter?(node, type)

--- a/spec/rubocop/cop/style/symbol_array_spec.rb
+++ b/spec/rubocop/cop/style/symbol_array_spec.rb
@@ -3,6 +3,16 @@
 describe RuboCop::Cop::Style::SymbolArray, :config do
   subject(:cop) { described_class.new(config) }
 
+  let(:other_cops) do
+    {
+      'Style/PercentLiteralDelimiters' => {
+        'PreferredDelimiters' => {
+          'default' => '()'
+        }
+      }
+    }
+  end
+
   context 'when EnforcedStyle is percent' do
     let(:cop_config) { { 'EnforcedStyle' => 'percent' } }
 
@@ -28,8 +38,9 @@ describe RuboCop::Cop::Style::SymbolArray, :config do
     end
 
     it "doesn't break when a symbol contains )" do
-      new_source = autocorrect_source(cop, '[:one, :")", :three]')
-      expect(new_source).to eq('%i(one \\) three)')
+      source = '[:one, :")", :three, :"(", :"]", :"["]'
+      new_source = autocorrect_source(cop, source)
+      expect(new_source).to eq('%i(one \\) three \\( ] [)')
     end
 
     it 'does not register an offense for array with non-syms' do
@@ -56,6 +67,24 @@ describe RuboCop::Cop::Style::SymbolArray, :config do
       it 'accepts arrays of smybols' do
         inspect_source(cop, '[:one, :two, :three]')
         expect(cop.offenses).to be_empty
+      end
+    end
+
+    context 'when PreferredDelimiters is specified' do
+      let(:other_cops) do
+        {
+          'Style/PercentLiteralDelimiters' => {
+            'PreferredDelimiters' => {
+              'default' => '[]'
+            }
+          }
+        }
+      end
+
+      it 'autocorrects an array with delimiters' do
+        source = '[:one, :")", :three, :"(", :"]", :"["]'
+        new_source = autocorrect_source(cop, source)
+        expect(new_source).to eq('%i[one ) three ( \\] \\[]')
       end
     end
   end

--- a/spec/rubocop/cop/style/word_array_spec.rb
+++ b/spec/rubocop/cop/style/word_array_spec.rb
@@ -8,6 +8,16 @@ describe RuboCop::Cop::Style::WordArray, :config do
     described_class.largest_brackets = -Float::INFINITY
   end
 
+  let(:other_cops) do
+    {
+      'Style/PercentLiteralDelimiters' => {
+        'PreferredDelimiters' => {
+          'default' => '()'
+        }
+      }
+    }
+  end
+
   context 'when EnforcedStyle is percent' do
     let(:cop_config) do
       { 'MinSize' => 0,
@@ -255,8 +265,25 @@ describe RuboCop::Cop::Style::WordArray, :config do
     end
 
     it "doesn't break when words contain delimiters" do
-      new_source = autocorrect_source(cop, "[')', ']']")
-      expect(new_source).to eq('%w(\\) ])')
+      new_source = autocorrect_source(cop, "[')', ']', '(']")
+      expect(new_source).to eq('%w(\\) ] \\()')
+    end
+
+    context 'when PreferredDelimiters is specified' do
+      let(:other_cops) do
+        {
+          'Style/PercentLiteralDelimiters' => {
+            'PreferredDelimiters' => {
+              'default' => '[]'
+            }
+          }
+        }
+      end
+
+      it 'autocorrects an array with delimiters' do
+        new_source = autocorrect_source(cop, "[')', ']', '(', '[']")
+        expect(new_source).to eq('%w[) \\] ( \\[]')
+      end
     end
   end
 end


### PR DESCRIPTION
See #4199

If `PreferredDelimiters` option is specified, `Style/SymbolArray` and `Style/WordArray` cops auto correct to not expected code.
The option is ignored.

For example

```ruby
 # PreferredDelimiters is []

 # Before
 [:a, :b, :c]
 ['a', 'b', 'c']

 # Corrected
 %i(a b c) # Not %i[]
 %w(a b c) # Not %w[]
```



-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Used the same coding conventions as the rest of the project.
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] All tests are passing.
* [x] The new code doesn't generate RuboCop offenses.
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Updated cop documentation with `rake generate_cops_documentation` (required only when you've added a new cop or changed the configuration/documentation of an existing cop).

[1]: http://chris.beams.io/posts/git-commit/
