### PR TITLE
Fix Rails/FilePath join argument misdetection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@
 * [#4198](https://github.com/bbatsov/rubocop/pull/4198): Make `Lint/AmbguousBlockAssociation` aware of operator methods. ([@drenmi][])
 * [#4152](https://github.com/bbatsov/rubocop/pull/4152): Make `Style/MethodCallWithArgsParentheses` not require parens on setter methods. ([@drenmi][])
 * [#4226](https://github.com/bbatsov/rubocop/pull/4226): Show in `--help` output that `--stdin` takes a file name argument. ([@jonas054][])
+* [#4217](https://github.com/bbatsov/rubocop/pull/4217): Fix false positive in `Rails/FilePath` cop with non string argument. ([@soutaro][])
 
 ## 0.48.0 (2017-03-26)
 

--- a/lib/rubocop/cop/rails/file_path.rb
+++ b/lib/rubocop/cop/rails/file_path.rb
@@ -51,9 +51,13 @@ module RuboCop
         def check_for_rails_root_join_with_slash_separated_path(node)
           return unless rails_root_nodes?(node)
           return unless rails_root_join_nodes?(node)
-          return unless node.method_args.any? { |arg| arg.source =~ %r{/} }
+          return unless node.method_args.any? { |arg| string_with_slash?(arg) }
 
           register_offense(node)
+        end
+
+        def string_with_slash?(node)
+          node.type == :str && node.source =~ %r{/}
         end
 
         def register_offense(node)

--- a/spec/rubocop/cop/rails/file_path_spec.rb
+++ b/spec/rubocop/cop/rails/file_path_spec.rb
@@ -56,4 +56,13 @@ describe RuboCop::Cop::Rails::FilePath do
       expect(cop.offenses.size).to eq(1)
     end
   end
+
+  context 'Rails.root.join with a non-string argument including "/"' do
+    let(:source) { 'Rails.root.join("tmp", "data", index/3, "data.csv")' }
+
+    it 'does not register an offense' do
+      inspect_source(cop, source)
+      expect(cop.offenses).to be_empty
+    end
+  end
 end


### PR DESCRIPTION
`Rails/FilePath` cop tests if `join` arguments contain `'/'` only using their `source`. It may cause a misdetection if its argument contains `/` operator of Ruby. This PR implements more strict test by checking if the node is a `:str`.

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Used the same coding conventions as the rest of the project.
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] All tests are passing.
* [x] The new code doesn't generate RuboCop offenses.
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Updated cop documentation with `rake generate_cops_documentation` (required only when you've added a new cop or changed the configuration/documentation of an existing cop).

[1]: http://chris.beams.io/posts/git-commit/
