### PR TITLE
[Fix #4218] Make `Lint/NestedMethodDefinition` aware of class shovel scope

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 * [#4185](https://github.com/bbatsov/rubocop/pull/4185): Make `Lint/NestedMethodDefinition` aware of `#*_exec` class of methods. ([@drenmi][])
 * [#4197](https://github.com/bbatsov/rubocop/pull/4197): Fix false positive in `Style/RedundantSelf` cop with parallel assignment. ([@drenmi][])
 * [#4199](https://github.com/bbatsov/rubocop/issues/4199): Fix incorrect auto correction in `Style/SymbolArray` and `Style/WordArray` cop. ([@pocke][])
+* [#4218](https://github.com/bbatsov/rubocop/pull/4218): Make `Lint/NestedMethodDefinition` aware of class shovel scope. ([@drenmi][])
 
 ## 0.48.0 (2017-03-26)
 

--- a/lib/rubocop/cop/lint/nested_method_definition.rb
+++ b/lib/rubocop/cop/lint/nested_method_definition.rb
@@ -43,6 +43,17 @@ module RuboCop
       #       end
       #     end
       #   end
+      #
+      # @example
+      #
+      #   # good
+      #
+      #   def foo
+      #     class << self
+      #       def bar
+      #       end
+      #     end
+      #   end
       class NestedMethodDefinition < Cop
         include OnMethodDef
         extend RuboCop::NodePattern::Macros
@@ -73,7 +84,7 @@ module RuboCop
         private
 
         def scoping_method_call?(child)
-          eval_call?(child) || exec_call?(child) ||
+          eval_call?(child) || exec_call?(child) || child.sclass_type? ||
             class_or_module_or_struct_new_call?(child)
         end
 

--- a/manual/cops_lint.md
+++ b/manual/cops_lint.md
@@ -1181,6 +1181,16 @@ def foo
   end
 end
 ```
+```ruby
+# good
+
+def foo
+  class << self
+    def bar
+    end
+  end
+end
+```
 
 ### References
 

--- a/spec/rubocop/cop/lint/nested_method_definition_spec.rb
+++ b/spec/rubocop/cop/lint/nested_method_definition_spec.rb
@@ -126,6 +126,18 @@ describe RuboCop::Cop::Lint::NestedMethodDefinition do
     expect(cop.offenses).to be_empty
   end
 
+  it 'does not register offense for nested definition inside class shovel' do
+    inspect_source(cop, ['class Foo',
+                         '  def bar',
+                         '    class << self',
+                         '      def baz',
+                         '      end',
+                         '    end',
+                         '  end',
+                         'end'])
+    expect(cop.offenses).to be_empty
+  end
+
   it 'does not register offense for nested definition inside Class.new' do
     ['(S)', ''].each do |constructor_args|
       inspect_source(cop, ['class Foo',


### PR DESCRIPTION
This cop would register an offense on nested method definitions when the inner definition was inside a "class shovel" scope, e.g.:

```
def foo
  class << self
    def bar; end
  end
end
```

This change fixes that.

-----------------

Before submitting the PR make sure the following are checked:

* [X] Wrote [good commit messages][1].
* [X] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [X] Used the same coding conventions as the rest of the project.
* [X] Feature branch is up-to-date with `master` (if not - rebase it).
* [X] Squashed related commits together.
* [X] Added tests.
* [X] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [X] All tests are passing.
* [X] The new code doesn't generate RuboCop offenses.
* [X] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [X] Updated cop documentation with `rake generate_cops_documentation` (required only when you've added a new cop or changed the configuration/documentation of an existing cop).

[1]: http://chris.beams.io/posts/git-commit/
