### PR TITLE
[Fix #4152] Make `Style/MethodCallWithArgsParentheses` not require parens on setters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@
 * [#4199](https://github.com/bbatsov/rubocop/issues/4199): Fix incorrect auto correction in `Style/SymbolArray` and `Style/WordArray` cop. ([@pocke][])
 * [#4218](https://github.com/bbatsov/rubocop/pull/4218): Make `Lint/NestedMethodDefinition` aware of class shovel scope. ([@drenmi][])
 * [#4198](https://github.com/bbatsov/rubocop/pull/4198): Make `Lint/AmbguousBlockAssociation` aware of operator methods. ([@drenmi][])
+* [#4152](https://github.com/bbatsov/rubocop/pull/4152): Make `Style/MethodCallWithArgsParentheses` not require parens on setter methods. ([@drenmi][])
 
 ## 0.48.0 (2017-03-26)
 

--- a/manual/cops_style.md
+++ b/manual/cops_style.md
@@ -2874,6 +2874,14 @@ array.delete e
 # good
 array.delete(e)
 
+# good
+# Operators don't need parens
+foo == bar
+
+# good
+# Setter methods don't need parens
+foo.bar = baz
+
 # okay with `puts` listed in `IgnoredMethods`
 puts 'test'
 

--- a/spec/rubocop/cop/style/method_call_with_args_parentheses_spec.rb
+++ b/spec/rubocop/cop/style/method_call_with_args_parentheses_spec.rb
@@ -16,48 +16,53 @@ describe RuboCop::Cop::Style::MethodCallWithArgsParentheses, :config do
     expect(cop.offenses).to be_empty
   end
 
-  it 'register an offence for method call without parens' do
+  it 'register an offense for method call without parens' do
     inspect_source(cop, 'top.test a, b')
     expect(cop.offenses.size).to eq(1)
   end
 
-  it 'register an offence for non-reciever method call without parens' do
+  it 'register an offense for non-reciever method call without parens' do
     inspect_source(cop, 'test a, b')
     expect(cop.offenses.size).to eq(1)
   end
 
-  it 'register an offence for methods starting with a capital without parens' do
+  it 'register an offense for methods starting with a capital without parens' do
     inspect_source(cop, 'Test a, b')
     expect(cop.offenses.size).to eq(1)
   end
 
-  it 'register an offence for superclass call without parens' do
+  it 'register an offense for superclass call without parens' do
     inspect_source(cop, 'super a')
     expect(cop.offenses.size).to eq(1)
   end
 
-  it 'register no offence for superclass call without args' do
+  it 'register no offense for superclass call without args' do
     inspect_source(cop, 'super')
     expect(cop.offenses).to be_empty
   end
 
-  it 'register no offence for yield without args' do
+  it 'register no offense for yield without args' do
     inspect_source(cop, 'yield')
     expect(cop.offenses).to be_empty
   end
 
-  it 'register no offence for superclass call with parens' do
+  it 'register no offense for superclass call with parens' do
     inspect_source(cop, 'super(a)')
     expect(cop.offenses).to be_empty
   end
 
-  it 'register an offence for yield without parens' do
+  it 'register an offense for yield without parens' do
     inspect_source(cop, 'yield a')
     expect(cop.offenses.size).to eq(1)
   end
 
   it 'accepts no parens for operators' do
     inspect_source(cop, 'top.test + a')
+    expect(cop.offenses).to be_empty
+  end
+
+  it 'accepts no parens for setter methods' do
+    inspect_source(cop, 'top.test = a')
     expect(cop.offenses).to be_empty
   end
 


### PR DESCRIPTION
This cop would register an offense for setter methods without parens, e.g.:

```
foo.bar = baz
```

This change fixes that.

-----------------

Before submitting the PR make sure the following are checked:

* [X] Wrote [good commit messages][1].
* [X] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [X] Used the same coding conventions as the rest of the project.
* [X] Feature branch is up-to-date with `master` (if not - rebase it).
* [X] Squashed related commits together.
* [X] Added tests.
* [X] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [X] All tests are passing.
* [X] The new code doesn't generate RuboCop offenses.
* [X] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [X] Updated cop documentation with `rake generate_cops_documentation` (required only when you've added a new cop or changed the configuration/documentation of an existing cop).

[1]: http://chris.beams.io/posts/git-commit/
