### PR TITLE
[Fix #4168] Remove `-n` option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Changes
 
 * [#4219](https://github.com/bbatsov/rubocop/issues/4219): Add a link to style guide for `Style/IndentationConsistency` cop. ([@pocke][])
+* [#4168](https://github.com/bbatsov/rubocop/issues/4168): Removed `-n` option. ([@sadovnik][])
 
 ### Bug fixes
 
@@ -2716,3 +2717,4 @@
 [@betesh]: https://github.com/betesh
 [@dpostorivo]: https://github.com/dpostorivo
 [@konto-andrzeja]: https://github.com/konto-andrzeja
+[@sadovnik]: https://github.com/sadovnik

--- a/lib/rubocop/options.rb
+++ b/lib/rubocop/options.rb
@@ -142,7 +142,7 @@ module RuboCop
       end
       option(opts, '-a', '--auto-correct')
 
-      option(opts, '-n', '--[no-]color') { |c| @options[:color] = c }
+      option(opts, '--[no-]color') { |c| @options[:color] = c }
 
       option(opts, '-v', '--version')
       option(opts, '-V', '--verbose-version')

--- a/spec/rubocop/options_spec.rb
+++ b/spec/rubocop/options_spec.rb
@@ -90,7 +90,7 @@ describe RuboCop::Options, :isolated_environment do
               -R, --rails                      Run extra Rails cops.
               -l, --lint                       Run only lint cops.
               -a, --auto-correct               Auto-correct offenses.
-              -n, --[no-]color                 Force color output on or off.
+                  --[no-]color                 Force color output on or off.
               -v, --version                    Display version.
               -V, --verbose-version            Display verbose version.
               -s, --stdin                      Pipe source from STDIN.


### PR DESCRIPTION
This option was broken in a5ce6d and the community decided to remove it. Here's why:
* Nobody used it. It has been broken for over a year before it was noticed it's broken
* `-n` is not the most intuitive option for disabling color
* There is no plain way to fix it

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Used the same coding conventions as the rest of the project.
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] All tests are passing.
* [x] The new code doesn't generate RuboCop offenses.
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Updated cop documentation with `rake generate_cops_documentation` (required only when you've added a new cop or changed the configuration/documentation of an existing cop).

[1]: http://chris.beams.io/posts/git-commit/
