### PR TITLE
Declare --stdin with FILE argument for better help text

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@
 * [#4218](https://github.com/bbatsov/rubocop/pull/4218): Make `Lint/NestedMethodDefinition` aware of class shovel scope. ([@drenmi][])
 * [#4198](https://github.com/bbatsov/rubocop/pull/4198): Make `Lint/AmbguousBlockAssociation` aware of operator methods. ([@drenmi][])
 * [#4152](https://github.com/bbatsov/rubocop/pull/4152): Make `Style/MethodCallWithArgsParentheses` not require parens on setter methods. ([@drenmi][])
+* [#4226](https://github.com/bbatsov/rubocop/pull/4226): Show in `--help` output that `--stdin` takes a file name argument. ([@jonas054][])
 
 ## 0.48.0 (2017-03-26)
 

--- a/spec/rubocop/cli/cli_options_spec.rb
+++ b/spec/rubocop/cli/cli_options_spec.rb
@@ -1061,9 +1061,7 @@ describe RuboCop::CLI, :isolated_environment do
                   '--format=simple',
                   '--stdin']
         expect(cli.run(argv)).to eq(2)
-        expect($stderr.string).to include(
-          '-s/--stdin requires exactly one path.'
-        )
+        expect($stderr.string).to include('missing argument: --stdin')
       ensure
         $stdin = STDIN
       end

--- a/spec/rubocop/options_spec.rb
+++ b/spec/rubocop/options_spec.rb
@@ -93,8 +93,8 @@ describe RuboCop::Options, :isolated_environment do
                   --[no-]color                 Force color output on or off.
               -v, --version                    Display version.
               -V, --verbose-version            Display verbose version.
-              -s, --stdin                      Pipe source from STDIN.
-                                               This is useful for editor integration.
+              -s, --stdin FILE                 Pipe source from STDIN, using FILE in offense
+                                               reports. This is useful for editor integration.
         END
 
         expect($stdout.string).to eq(expected_help)
@@ -247,7 +247,8 @@ describe RuboCop::Options, :isolated_environment do
       end
 
       it 'fails if no paths are given' do
-        expect { options.parse %w(-s) }.to raise_error(ArgumentError)
+        expect { options.parse %w(-s) }
+          .to raise_error(OptionParser::MissingArgument)
       end
 
       it 'succeeds with exactly one path' do


### PR DESCRIPTION
Before this change it is not apparent from the help text that `-s`/`--stdin` takes a file name argument.