### PR TITLE
[FIX #4227] AmbiguousBlockAssociation False Positive

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@
 * [#4226](https://github.com/bbatsov/rubocop/pull/4226): Show in `--help` output that `--stdin` takes a file name argument. ([@jonas054][])
 * [#4217](https://github.com/bbatsov/rubocop/pull/4217): Fix false positive in `Rails/FilePath` cop with non string argument. ([@soutaro][])
 * [#4106](https://github.com/bbatsov/rubocop/pull/4106): Make `Style/TernaryParentheses` unsafe autocorrect detector aware of literals and constants. ([@drenmi][])
+* [#4228](https://github.com/bbatsov/rubocop/pull/4228): Fix false positive in `Lint/AmbiguousBlockAssociation` cop. ([@smakagon][])
 
 ## 0.48.0 (2017-03-26)
 

--- a/lib/rubocop/cop/lint/ambiguous_block_association.rb
+++ b/lib/rubocop/cop/lint/ambiguous_block_association.rb
@@ -32,11 +32,11 @@ module RuboCop
           return if node.parenthesized? || allowed_method?(node)
           return if lambda_argument?(node.first_argument)
 
-          return unless method_with_block?(node.first_argument)
-          first_param = node.first_argument.children.first
-          return unless method_as_param?(first_param)
+          return unless method_with_block?(node.last_argument)
+          last_param = node.last_argument.children.first
+          return unless method_as_param?(last_param)
 
-          add_offense(node, :expression, message(first_param, node.method_name))
+          add_offense(node, :expression, message(last_param, node.method_name))
         end
 
         private

--- a/spec/rubocop/cop/lint/ambiguous_block_association_spec.rb
+++ b/spec/rubocop/cop/lint/ambiguous_block_association_spec.rb
@@ -32,6 +32,18 @@ describe RuboCop::Cop::Lint::AmbiguousBlockAssociation do
   it_behaves_like('accepts', 'expect { order.save }.to(change { orders.size })')
   it_behaves_like(
     'accepts',
+    'assert_equal posts.find { |p| p.title == "Foo" }, results.first'
+  )
+  it_behaves_like(
+    'accepts',
+    'assert_equal(posts.find { |p| p.title == "Foo" }, results.first)'
+  )
+  it_behaves_like(
+    'accepts',
+    'assert_equal(results.first, posts.find { |p| p.title == "Foo" })'
+  )
+  it_behaves_like(
+    'accepts',
     'allow(cop).to receive(:on_int) { raise RuntimeError }'
   )
   it_behaves_like(


### PR DESCRIPTION
Fixes false positive of `AmbiguousBlockAssociation` cop reported in #4227 

`assert_equal site.posts.find { |p| p.title == "Foo Bar" }, results.first`
