### PR TITLE
[Fix #4106] Make `Style/TernaryParentheses` unsafe autocorrect detector smarter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@
 * [#4152](https://github.com/bbatsov/rubocop/pull/4152): Make `Style/MethodCallWithArgsParentheses` not require parens on setter methods. ([@drenmi][])
 * [#4226](https://github.com/bbatsov/rubocop/pull/4226): Show in `--help` output that `--stdin` takes a file name argument. ([@jonas054][])
 * [#4217](https://github.com/bbatsov/rubocop/pull/4217): Fix false positive in `Rails/FilePath` cop with non string argument. ([@soutaro][])
+* [#4106](https://github.com/bbatsov/rubocop/pull/4106): Make `Style/TernaryParentheses` unsafe autocorrect detector aware of literals and constants. ([@drenmi][])
 
 ## 0.48.0 (2017-03-26)
 

--- a/lib/rubocop/cop/style/ternary_parentheses.rb
+++ b/lib/rubocop/cop/style/ternary_parentheses.rb
@@ -5,7 +5,8 @@ module RuboCop
     module Style
       # This cop checks for the presence of parentheses around ternary
       # conditions. It is configurable to enforce inclusion or omission of
-      # parentheses using `EnforcedStyle`.
+      # parentheses using `EnforcedStyle`. Omission is only enforced when
+      # removing the parentheses won't cause a different behaviour.
       #
       # @example
       #
@@ -161,7 +162,7 @@ module RuboCop
 
         def_node_matcher :method_call_argument, <<-PATTERN
           {(:defined? $...)
-           (send {(send ...) nil} _ $(send nil _)...)}
+           (send {_ nil} _ $(send nil _)...)}
         PATTERN
 
         def_node_matcher :square_brackets?,

--- a/manual/cops_style.md
+++ b/manual/cops_style.md
@@ -5639,7 +5639,8 @@ Enabled | Yes
 
 This cop checks for the presence of parentheses around ternary
 conditions. It is configurable to enforce inclusion or omission of
-parentheses using `EnforcedStyle`.
+parentheses using `EnforcedStyle`. Omission is only enforced when
+removing the parentheses won't cause a different behaviour.
 
 ### Example
 

--- a/spec/rubocop/cop/style/ternary_parentheses_spec.rb
+++ b/spec/rubocop/cop/style/ternary_parentheses_spec.rb
@@ -198,6 +198,16 @@ describe RuboCop::Cop::Style::TernaryParentheses, :config do
                         'foo = (baz.foo? bar) ? a : b'
       end
 
+      context 'when calling method on a literal receiver' do
+        it_behaves_like 'code with offense',
+                        'foo = ("bar".foo? bar) ? a : b'
+      end
+
+      context 'when calling method on a constant receiver' do
+        it_behaves_like 'code with offense',
+                        'foo = (Bar.foo? bar) ? a : b'
+      end
+
       context 'when calling method with multiple arguments' do
         it_behaves_like 'code with offense',
                         'foo = (baz.foo? bar, baz) ? a : b'


### PR DESCRIPTION
This cop, despite checking for unsafe autocorrects, did not recognize methods sent to constants or literals, leading to inappropriate omission recommendations.

For example, this was correctly identified as being unsafe to correct:

```ruby
(foo.bar baz) ? 1 : 2
```

but none of these were:

```ruby
(Foo.bar baz) ? 1 : 2
```

```ruby
("foo".bar baz) ? 1 : 2
```

This change fixes that.

-----------------

Before submitting the PR make sure the following are checked:

* [X] Wrote [good commit messages][1].
* [X] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [X] Used the same coding conventions as the rest of the project.
* [X] Feature branch is up-to-date with `master` (if not - rebase it).
* [X] Squashed related commits together.
* [X] Added tests.
* [X] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [X] All tests are passing.
* [X] The new code doesn't generate RuboCop offenses.
* [X] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [X] Updated cop documentation with `rake generate_cops_documentation` (required only when you've added a new cop or changed the configuration/documentation of an existing cop).

[1]: http://chris.beams.io/posts/git-commit/
