### PR TITLE
[Fix #4039] Change `Style/PercentLiteralDelimiters` default configuration to match Style Guide update

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 * [#4219](https://github.com/bbatsov/rubocop/issues/4219): Add a link to style guide for `Style/IndentationConsistency` cop. ([@pocke][])
 * [#4168](https://github.com/bbatsov/rubocop/issues/4168): Removed `-n` option. ([@sadovnik][])
+* [#4039](https://github.com/bbatsov/rubocop/pull/4039): Change `Style/PercentLiteralDelimiters` default configuration to match Style Guide update. ([@drenmi][])
 
 ### Bug fixes
 

--- a/Rakefile
+++ b/Rakefile
@@ -29,7 +29,7 @@ end
 desc 'Run RuboCop over itself'
 RuboCop::RakeTask.new(:internal_investigation)
 
-task default: %i(spec ascii_spec internal_investigation)
+task default: %i[spec ascii_spec internal_investigation]
 
 require 'yard'
 YARD::Rake::YardocTask.new
@@ -43,7 +43,7 @@ task :repl do
 end
 
 desc 'Benchmark a cop on given source file/dir'
-task :bench_cop, %i(cop srcpath times) do |_task, args|
+task :bench_cop, %i[cop srcpath times] do |_task, args|
   require 'benchmark'
   require 'rubocop'
   include RuboCop

--- a/config/default.yml
+++ b/config/default.yml
@@ -939,7 +939,11 @@ Style/PercentLiteralDelimiters:
   # an individual key
   PreferredDelimiters:
     default: ()
+    '%i': '[]'
+    '%I': '[]'
     '%r': '{}'
+    '%w': '[]'
+    '%W': '[]'
 
 Style/PercentQLiterals:
   EnforcedStyle: lower_case_q

--- a/lib/rubocop/ast/builder.rb
+++ b/lib/rubocop/ast/builder.rb
@@ -26,9 +26,9 @@ module RuboCop
         PairNode         => [:pair],
         ResbodyNode      => [:resbody],
         SendNode         => [:send],
-        UntilNode        => %i(until until_post),
+        UntilNode        => %i[until until_post],
         WhenNode         => [:when],
-        WhileNode        => %i(while while_post)
+        WhileNode        => %i[while while_post]
       }.freeze
 
       # Generates {Node} from the given information.

--- a/lib/rubocop/ast/node.rb
+++ b/lib/rubocop/ast/node.rb
@@ -21,28 +21,28 @@ module RuboCop
     class Node < Parser::AST::Node # rubocop:disable Metrics/ClassLength
       include RuboCop::AST::Sexp
 
-      COMPARISON_OPERATORS = %i(! == === != <= >= > < <=>).freeze
+      COMPARISON_OPERATORS = %i[! == === != <= >= > < <=>].freeze
 
-      TRUTHY_LITERALS = %i(str dstr xstr int float sym dsym array
+      TRUTHY_LITERALS = %i[str dstr xstr int float sym dsym array
                            hash regexp true irange erange complex
-                           rational regopt).freeze
-      FALSEY_LITERALS = %i(false nil).freeze
+                           rational regopt].freeze
+      FALSEY_LITERALS = %i[false nil].freeze
       LITERALS = (TRUTHY_LITERALS + FALSEY_LITERALS).freeze
-      COMPOSITE_LITERALS = %i(dstr xstr dsym array hash irange
-                              erange regexp).freeze
+      COMPOSITE_LITERALS = %i[dstr xstr dsym array hash irange
+                              erange regexp].freeze
       BASIC_LITERALS = (LITERALS - COMPOSITE_LITERALS).freeze
-      MUTABLE_LITERALS = %i(str dstr xstr array hash).freeze
+      MUTABLE_LITERALS = %i[str dstr xstr array hash].freeze
       IMMUTABLE_LITERALS = (LITERALS - MUTABLE_LITERALS).freeze
 
-      VARIABLES = %i(ivar gvar cvar lvar).freeze
-      REFERENCES = %i(nth_ref back_ref).freeze
-      KEYWORDS = %i(alias and break case class def defs defined?
+      VARIABLES = %i[ivar gvar cvar lvar].freeze
+      REFERENCES = %i[nth_ref back_ref].freeze
+      KEYWORDS = %i[alias and break case class def defs defined?
                     kwbegin do else ensure for if module next
                     not or postexe redo rescue retry return self
                     super zsuper then undef until when while
-                    yield).freeze
-      OPERATOR_KEYWORDS = %i(and or).freeze
-      SPECIAL_KEYWORDS = %w(__FILE__ __LINE__ __ENCODING__).freeze
+                    yield].freeze
+      OPERATOR_KEYWORDS = %i[and or].freeze
+      SPECIAL_KEYWORDS = %w[__FILE__ __LINE__ __ENCODING__].freeze
 
       # def_matcher can be used to define a pattern-matching method on Node
       class << self
@@ -361,7 +361,7 @@ module RuboCop
         IMMUTABLE_LITERALS.include?(type)
       end
 
-      %i(literal basic_literal).each do |kind|
+      %i[literal basic_literal].each do |kind|
         recursive_kind = :"recursive_#{kind}?"
         kind_filter = :"#{kind}?"
         define_method(recursive_kind) do

--- a/lib/rubocop/ast/traversal.rb
+++ b/lib/rubocop/ast/traversal.rb
@@ -13,21 +13,21 @@ module RuboCop
         nil
       end
 
-      NO_CHILD_NODES    = %i(true false nil int float complex
+      NO_CHILD_NODES    = %i[true false nil int float complex
                              rational str sym regopt self lvar
                              ivar cvar gvar nth_ref back_ref cbase
                              arg restarg blockarg shadowarg
-                             kwrestarg zsuper lambda redo retry).freeze
-      ONE_CHILD_NODE    = %i(splat kwsplat block_pass not break next
+                             kwrestarg zsuper lambda redo retry].freeze
+      ONE_CHILD_NODE    = %i[splat kwsplat block_pass not break next
                              preexe postexe match_current_line defined?
-                             arg_expr).freeze
-      MANY_CHILD_NODES  = %i(dstr dsym xstr regexp array hash pair
+                             arg_expr].freeze
+      MANY_CHILD_NODES  = %i[dstr dsym xstr regexp array hash pair
                              irange erange mlhs masgn or_asgn and_asgn
                              undef alias args super yield or and
                              while_post until_post iflipflop eflipflop
-                             match_with_lvasgn begin kwbegin return).freeze
-      SECOND_CHILD_ONLY = %i(lvasgn ivasgn cvasgn gvasgn optarg kwarg
-                             kwoptarg).freeze
+                             match_with_lvasgn begin kwbegin return].freeze
+      SECOND_CHILD_ONLY = %i[lvasgn ivasgn cvasgn gvasgn optarg kwarg
+                             kwoptarg].freeze
 
       NO_CHILD_NODES.each do |type|
         module_eval("def on_#{type}(node); end")

--- a/lib/rubocop/config.rb
+++ b/lib/rubocop/config.rb
@@ -13,8 +13,8 @@ module RuboCop
   class Config
     include PathUtil
 
-    COMMON_PARAMS = %w(Exclude Include Severity
-                       AutoCorrect StyleGuide Details).freeze
+    COMMON_PARAMS = %w[Exclude Include Severity
+                       AutoCorrect StyleGuide Details].freeze
     # 2.1 is the oldest officially supported Ruby version.
     DEFAULT_RUBY_VERSION = 2.1
     KNOWN_RUBIES = [1.9, 2.0, 2.1, 2.2, 2.3, 2.4].freeze
@@ -178,7 +178,7 @@ module RuboCop
     end
 
     def deprecation_check
-      %w(Exclude Include).each do |key|
+      %w[Exclude Include].each do |key|
         plural = "#{key}s"
         next unless for_all_cops[plural]
 

--- a/lib/rubocop/config_loader.rb
+++ b/lib/rubocop/config_loader.rb
@@ -83,7 +83,7 @@ module RuboCop
 
       def base_configs(path, inherit_from)
         configs = Array(inherit_from).compact.map do |f|
-          if f =~ /\A#{URI::Parser.new.make_regexp(%w(http https))}\z/
+          if f =~ /\A#{URI::Parser.new.make_regexp(%w[http https])}\z/
             f = RemoteConfig.new(f, File.dirname(path)).file
           else
             f = File.expand_path(f, File.dirname(path))
@@ -187,7 +187,7 @@ module RuboCop
         if YAML.respond_to?(:safe_load) # Ruby 2.1+
           if defined?(SafeYAML) && SafeYAML.respond_to?(:load)
             SafeYAML.load(yaml_code, filename,
-                          whitelisted_tags: %w(!ruby/regexp))
+                          whitelisted_tags: %w[!ruby/regexp])
           else
             YAML.safe_load(yaml_code, [Regexp, Symbol], [], false, filename)
           end

--- a/lib/rubocop/cop/lint/format_parameter_mismatch.rb
+++ b/lib/rubocop/cop/lint/format_parameter_mismatch.rb
@@ -29,7 +29,7 @@ module RuboCop
         SHOVEL = '<<'.freeze
         PERCENT = '%'.freeze
         PERCENT_PERCENT = '%%'.freeze
-        STRING_TYPES = %i(str dstr).freeze
+        STRING_TYPES = %i[str dstr].freeze
         NAMED_INTERPOLATION = /%(?:<\w+>|\{\w+\})/
 
         def on_send(node)

--- a/lib/rubocop/cop/lint/inherit_exception.rb
+++ b/lib/rubocop/cop/lint/inherit_exception.rb
@@ -37,7 +37,7 @@ module RuboCop
           runtime_error: 'RuntimeError',
           standard_error: 'StandardError'
         }.freeze
-        ILLEGAL_CLASSES = %w(
+        ILLEGAL_CLASSES = %w[
           Exception
           SystemStackError
           NoMemoryError
@@ -49,7 +49,7 @@ module RuboCop
           Interrupt
           SignalException
           SystemExit
-        ).freeze
+        ].freeze
 
         def on_class(node)
           _class, base_class, _body = *node

--- a/lib/rubocop/cop/lint/literal_in_condition.rb
+++ b/lib/rubocop/cop/lint/literal_in_condition.rb
@@ -108,7 +108,7 @@ module RuboCop
         def handle_node(node)
           if node.literal?
             add_offense(node, :expression)
-          elsif %i(send and or begin).include?(node.type)
+          elsif %i[send and or begin].include?(node.type)
             check_node(node)
           end
         end

--- a/lib/rubocop/cop/lint/literal_in_interpolation.rb
+++ b/lib/rubocop/cop/lint/literal_in_interpolation.rb
@@ -18,7 +18,7 @@ module RuboCop
       #   "result is 10"
       class LiteralInInterpolation < Cop
         MSG = 'Literal interpolation detected.'.freeze
-        COMPOSITE = %i(array hash pair irange erange).freeze
+        COMPOSITE = %i[array hash pair irange erange].freeze
 
         def on_dstr(node)
           node.each_child_node(:begin) do |begin_node|

--- a/lib/rubocop/cop/lint/unneeded_splat_expansion.rb
+++ b/lib/rubocop/cop/lint/unneeded_splat_expansion.rb
@@ -57,7 +57,7 @@ module RuboCop
         PERCENT_I = '%i'.freeze
         PERCENT_CAPITAL_I = '%I'.freeze
         ARRAY_NEW_PATTERN = '$(send (const nil :Array) :new ...)'.freeze
-        ASSIGNMENT_TYPES = %i(lvasgn ivasgn cvasgn gvasgn).freeze
+        ASSIGNMENT_TYPES = %i[lvasgn ivasgn cvasgn gvasgn].freeze
 
         def_node_matcher :literal_expansion?, <<-PATTERN
           (splat {$({str dstr int float array} ...) (block #{ARRAY_NEW_PATTERN} ...) #{ARRAY_NEW_PATTERN}} ...)

--- a/lib/rubocop/cop/lint/unreachable_code.rb
+++ b/lib/rubocop/cop/lint/unreachable_code.rb
@@ -26,8 +26,8 @@ module RuboCop
       class UnreachableCode < Cop
         MSG = 'Unreachable code detected.'.freeze
 
-        NODE_TYPES = %i(return next break retry redo).freeze
-        FLOW_COMMANDS = %i(throw raise fail).freeze
+        NODE_TYPES = %i[return next break retry redo].freeze
+        FLOW_COMMANDS = %i[throw raise fail].freeze
 
         def on_begin(node)
           expressions = *node

--- a/lib/rubocop/cop/lint/useless_comparison.rb
+++ b/lib/rubocop/cop/lint/useless_comparison.rb
@@ -12,7 +12,7 @@ module RuboCop
       #   x.top >= x.top
       class UselessComparison < Cop
         MSG = 'Comparison of something with itself detected.'.freeze
-        OPS = %w(== === != < > <= >= <=>).freeze
+        OPS = %w[== === != < > <= >= <=>].freeze
 
         def_node_matcher :useless_comparison?,
                          "(send $_match {:#{OPS.join(' :')}} $_match)"

--- a/lib/rubocop/cop/lint/useless_setter_call.rb
+++ b/lib/rubocop/cop/lint/useless_setter_call.rb
@@ -28,7 +28,7 @@ module RuboCop
         include OnMethodDef
 
         MSG = 'Useless setter call to local variable `%s`.'.freeze
-        ASSIGNMENT_TYPES = %i(lvasgn ivasgn cvasgn gvasgn).freeze
+        ASSIGNMENT_TYPES = %i[lvasgn ivasgn cvasgn gvasgn].freeze
 
         private
 

--- a/lib/rubocop/cop/lint/void.rb
+++ b/lib/rubocop/cop/lint/void.rb
@@ -48,7 +48,7 @@ module RuboCop
         SELF_MSG = '`self` used in void context.'.freeze
         DEFINED_MSG = '`%s` used in void context.'.freeze
 
-        OPS = %w(* / % + - == === != < > <= >= <=>).freeze
+        OPS = %w[* / % + - == === != < > <= >= <=>].freeze
 
         def on_begin(node)
           check_begin(node)

--- a/lib/rubocop/cop/metrics/abc_size.rb
+++ b/lib/rubocop/cop/metrics/abc_size.rb
@@ -11,7 +11,7 @@ module RuboCop
 
         MSG = 'Assignment Branch Condition size for %s is too high. ' \
               '[%.4g/%.4g]'.freeze
-        BRANCH_NODES = %i(send csend).freeze
+        BRANCH_NODES = %i[send csend].freeze
         CONDITION_NODES = CyclomaticComplexity::COUNTED_NODES.freeze
 
         private

--- a/lib/rubocop/cop/metrics/block_nesting.rb
+++ b/lib/rubocop/cop/metrics/block_nesting.rb
@@ -14,10 +14,10 @@ module RuboCop
       class BlockNesting < Cop
         include ConfigurableMax
 
-        NESTING_BLOCKS = %i(
+        NESTING_BLOCKS = %i[
           case if while while_post
           until until_post for resbody
-        ).freeze
+        ].freeze
 
         def investigate(processed_source)
           return unless processed_source.ast

--- a/lib/rubocop/cop/metrics/cyclomatic_complexity.rb
+++ b/lib/rubocop/cop/metrics/cyclomatic_complexity.rb
@@ -17,8 +17,8 @@ module RuboCop
         include MethodComplexity
 
         MSG = 'Cyclomatic complexity for %s is too high. [%d/%d]'.freeze
-        COUNTED_NODES = %i(if while until for
-                           rescue when and or).freeze
+        COUNTED_NODES = %i[if while until for
+                           rescue when and or].freeze
 
         private
 

--- a/lib/rubocop/cop/metrics/parameter_lists.rb
+++ b/lib/rubocop/cop/metrics/parameter_lists.rb
@@ -28,7 +28,7 @@ module RuboCop
           if count_keyword_args?
             node.children.size
           else
-            node.children.count { |a| !%i(kwoptarg kwarg).include?(a.type) }
+            node.children.count { |a| !%i[kwoptarg kwarg].include?(a.type) }
           end
         end
 

--- a/lib/rubocop/cop/metrics/perceived_complexity.rb
+++ b/lib/rubocop/cop/metrics/perceived_complexity.rb
@@ -30,8 +30,8 @@ module RuboCop
         include MethodComplexity
 
         MSG = 'Perceived complexity for %s is too high. [%d/%d]'.freeze
-        COUNTED_NODES = %i(if case while until
-                           for rescue and or).freeze
+        COUNTED_NODES = %i[if case while until
+                           for rescue and or].freeze
 
         private
 

--- a/lib/rubocop/cop/mixin/access_modifier_node.rb
+++ b/lib/rubocop/cop/mixin/access_modifier_node.rb
@@ -32,7 +32,7 @@ module RuboCop
           if ancestor.block_type?
             return true if ancestor.class_constructor?
           elsif !ancestor.begin_type?
-            return %i(casgn sclass class module).include?(ancestor.type)
+            return %i[casgn sclass class module].include?(ancestor.type)
           end
         end
       end

--- a/lib/rubocop/cop/mixin/def_node.rb
+++ b/lib/rubocop/cop/mixin/def_node.rb
@@ -6,7 +6,7 @@ module RuboCop
     module DefNode
       extend NodePattern::Macros
 
-      NON_PUBLIC_MODIFIERS = %w(private protected).freeze
+      NON_PUBLIC_MODIFIERS = %w[private protected].freeze
 
       def non_public?(node)
         non_public_modifier?(node.parent) ||

--- a/lib/rubocop/cop/mixin/frozen_string_literal.rb
+++ b/lib/rubocop/cop/mixin/frozen_string_literal.rb
@@ -8,7 +8,7 @@ module RuboCop
 
       FROZEN_STRING_LITERAL = '# frozen_string_literal:'.freeze
       FROZEN_STRING_LITERAL_ENABLED = '# frozen_string_literal: true'.freeze
-      FROZEN_STRING_LITERAL_TYPES = %i(str dstr).freeze
+      FROZEN_STRING_LITERAL_TYPES = %i[str dstr].freeze
 
       def frozen_string_literal_comment_exists?
         leading_comment_lines.any? do |line|

--- a/lib/rubocop/cop/mixin/on_method_def.rb
+++ b/lib/rubocop/cop/mixin/on_method_def.rb
@@ -37,7 +37,7 @@ module RuboCop
         !send_node.receiver &&
           send_node.method_name != :def &&
           send_node.arguments.one? &&
-          %i(def defs).include?(send_node.first_argument.type)
+          %i[def defs].include?(send_node.first_argument.type)
       end
     end
   end

--- a/lib/rubocop/cop/mixin/percent_literal.rb
+++ b/lib/rubocop/cop/mixin/percent_literal.rb
@@ -4,7 +4,7 @@ module RuboCop
   module Cop
     # Common functionality for handling percent literals.
     module PercentLiteral
-      PERCENT_LITERAL_TYPES = %w(% %i %I %q %Q %r %s %w %W %x).freeze
+      PERCENT_LITERAL_TYPES = %w[% %i %I %q %Q %r %s %w %W %x].freeze
 
       private
 
@@ -65,7 +65,7 @@ module RuboCop
 
       def ensure_valid_preferred_delimiters
         invalid = preferred_delimiters_config.keys -
-                  (PERCENT_LITERAL_TYPES + %w(default))
+                  (PERCENT_LITERAL_TYPES + %w[default])
         return if invalid.empty?
 
         raise ArgumentError,

--- a/lib/rubocop/cop/mixin/space_after_punctuation.rb
+++ b/lib/rubocop/cop/mixin/space_after_punctuation.rb
@@ -33,7 +33,7 @@ module RuboCop
       end
 
       def allowed_type?(token)
-        %i(tRPAREN tRBRACK tPIPE).include?(token.type)
+        %i[tRPAREN tRBRACK tPIPE].include?(token.type)
       end
 
       def space_forbidden_before_rcurly?

--- a/lib/rubocop/cop/mixin/unused_argument.rb
+++ b/lib/rubocop/cop/mixin/unused_argument.rb
@@ -24,7 +24,7 @@ module RuboCop
         end
 
         def autocorrect(node)
-          return if %i(kwarg kwoptarg).include?(node.type)
+          return if %i[kwarg kwoptarg].include?(node.type)
 
           if node.blockarg_type?
             lambda do |corrector|

--- a/lib/rubocop/cop/offense.rb
+++ b/lib/rubocop/cop/offense.rb
@@ -7,8 +7,8 @@ module RuboCop
       include Comparable
 
       # @api private
-      COMPARISON_ATTRIBUTES = %i(line column cop_name
-                                 message severity).freeze
+      COMPARISON_ATTRIBUTES = %i[line column cop_name
+                                 message severity].freeze
 
       # @api public
       #

--- a/lib/rubocop/cop/performance/casecmp.rb
+++ b/lib/rubocop/cop/performance/casecmp.rb
@@ -19,7 +19,7 @@ module RuboCop
       #   'abc'.casecmp(str).zero?
       class Casecmp < Cop
         MSG = 'Use `casecmp` instead of `%s %s`.'.freeze
-        CASE_METHODS = %i(downcase upcase).freeze
+        CASE_METHODS = %i[downcase upcase].freeze
 
         def_node_matcher :downcase_eq, <<-END
           (send

--- a/lib/rubocop/cop/performance/regexp_match.rb
+++ b/lib/rubocop/cop/performance/regexp_match.rb
@@ -191,14 +191,14 @@ module RuboCop
         end
 
         def match_gvar?(sym)
-          %i(
+          %i[
             $~
             $MATCH
             $PREMATCH
             $POSTMATCH
             $LAST_PAREN_MATCH
             $LAST_MATCH_INFO
-          ).include?(sym)
+          ].include?(sym)
         end
 
         def correct_operator(corrector, recv, arg)

--- a/lib/rubocop/cop/rails/action_filter.rb
+++ b/lib/rubocop/cop/rails/action_filter.rb
@@ -16,7 +16,7 @@ module RuboCop
 
         MSG = 'Prefer `%s` over `%s`.'.freeze
 
-        FILTER_METHODS = %i(
+        FILTER_METHODS = %i[
           after_filter
           append_after_filter
           append_around_filter
@@ -30,9 +30,9 @@ module RuboCop
           skip_around_filter
           skip_before_filter
           skip_filter
-        ).freeze
+        ].freeze
 
-        ACTION_METHODS = %i(
+        ACTION_METHODS = %i[
           after_action
           append_after_action
           append_around_action
@@ -46,7 +46,7 @@ module RuboCop
           skip_around_action
           skip_before_action
           skip_action_callback
-        ).freeze
+        ].freeze
 
         minimum_target_rails_version 4.0
 

--- a/lib/rubocop/cop/rails/date.rb
+++ b/lib/rubocop/cop/rails/date.rb
@@ -43,7 +43,7 @@ module RuboCop
         MSG_SEND = 'Do not use `%s` on Date objects, because they ' \
                    'know nothing about the time zone in use.'.freeze
 
-        BAD_DAYS = %i(today current yesterday tomorrow).freeze
+        BAD_DAYS = %i[today current yesterday tomorrow].freeze
 
         def on_const(node)
           mod, klass = *node.children
@@ -107,7 +107,7 @@ module RuboCop
         end
 
         def good_days
-          style == :strict ? [] : %i(current yesterday tomorrow)
+          style == :strict ? [] : %i[current yesterday tomorrow]
         end
 
         def bad_days
@@ -115,7 +115,7 @@ module RuboCop
         end
 
         def bad_methods
-          style == :strict ? %i(to_time to_time_in_current_zone) : [:to_time]
+          style == :strict ? %i[to_time to_time_in_current_zone] : [:to_time]
         end
 
         def good_methods

--- a/lib/rubocop/cop/rails/delegate.rb
+++ b/lib/rubocop/cop/rails/delegate.rb
@@ -94,7 +94,7 @@ module RuboCop
         end
 
         def private_or_protected_before(line)
-          (processed_source[0..line].map(&:strip) & %w(private protected)).any?
+          (processed_source[0..line].map(&:strip) & %w[private protected]).any?
         end
 
         def private_or_protected_inline(line)

--- a/lib/rubocop/cop/rails/exit.rb
+++ b/lib/rubocop/cop/rails/exit.rb
@@ -20,8 +20,8 @@ module RuboCop
         include ConfigurableEnforcedStyle
 
         MSG = 'Do not use `exit` in Rails applications.'.freeze
-        TARGET_METHODS = %i(exit exit!).freeze
-        EXPLICIT_RECEIVERS = %i(Kernel Process).freeze
+        TARGET_METHODS = %i[exit exit!].freeze
+        EXPLICIT_RECEIVERS = %i[Kernel Process].freeze
 
         def on_send(node)
           add_offense(node, :selector) if offending_node?(node)

--- a/lib/rubocop/cop/rails/find_by.rb
+++ b/lib/rubocop/cop/rails/find_by.rb
@@ -15,7 +15,7 @@ module RuboCop
       #   User.find_by(name: 'Bruce')
       class FindBy < Cop
         MSG = 'Use `find_by` instead of `where.%s`.'.freeze
-        TARGET_SELECTORS = %i(first take).freeze
+        TARGET_SELECTORS = %i[first take].freeze
 
         def_node_matcher :where_first?, <<-PATTERN
           (send (send _ :where ...) {:first :take})

--- a/lib/rubocop/cop/rails/find_each.rb
+++ b/lib/rubocop/cop/rails/find_each.rb
@@ -15,8 +15,8 @@ module RuboCop
       class FindEach < Cop
         MSG = 'Use `find_each` instead of `each`.'.freeze
 
-        SCOPE_METHODS = %i(all where not).freeze
-        IGNORED_METHODS = %i(order limit select).freeze
+        SCOPE_METHODS = %i[all where not].freeze
+        IGNORED_METHODS = %i[order limit select].freeze
 
         def on_send(node)
           return unless node.receiver && node.method?(:each)

--- a/lib/rubocop/cop/rails/http_positional_arguments.rb
+++ b/lib/rubocop/cop/rails/http_positional_arguments.rb
@@ -21,10 +21,10 @@ module RuboCop
 
         MSG = 'Use keyword arguments instead of ' \
               'positional arguments for http call: `%s`.'.freeze
-        KEYWORD_ARGS = %i(
+        KEYWORD_ARGS = %i[
           headers env params body flash as xhr session method
-        ).freeze
-        HTTP_METHODS = %i(get post put patch delete head).freeze
+        ].freeze
+        HTTP_METHODS = %i[get post put patch delete head].freeze
 
         minimum_target_rails_version 5.0
 

--- a/lib/rubocop/cop/rails/relative_date_constant.rb
+++ b/lib/rubocop/cop/rails/relative_date_constant.rb
@@ -22,7 +22,7 @@ module RuboCop
         MSG = 'Do not assign %s to constants as it will be evaluated only ' \
               'once.'.freeze
 
-        RELATIVE_DATE_METHODS = %i(ago from_now since until).freeze
+        RELATIVE_DATE_METHODS = %i[ago from_now since until].freeze
 
         def on_casgn(node)
           bad_node = node.descendants.find { |n| bad_method?(n) }

--- a/lib/rubocop/cop/rails/save_bang.rb
+++ b/lib/rubocop/cop/rails/save_bang.rb
@@ -44,10 +44,10 @@ module RuboCop
         CREATE_CONDITIONAL_MSG = '`%s` returns a model which is always truthy.'
                                  .freeze
 
-        CREATE_PERSIST_METHODS = %i(create
-                                    first_or_create find_or_create_by).freeze
-        MODIFY_PERSIST_METHODS = %i(save
-                                    update update_attributes destroy).freeze
+        CREATE_PERSIST_METHODS = %i[create
+                                    first_or_create find_or_create_by].freeze
+        MODIFY_PERSIST_METHODS = %i[save
+                                    update update_attributes destroy].freeze
         PERSIST_METHODS = (CREATE_PERSIST_METHODS +
                            MODIFY_PERSIST_METHODS).freeze
 

--- a/lib/rubocop/cop/rails/skips_model_validations.rb
+++ b/lib/rubocop/cop/rails/skips_model_validations.rb
@@ -25,7 +25,7 @@ module RuboCop
       class SkipsModelValidations < Cop
         MSG = 'Avoid using `%s` because it skips validations.'.freeze
 
-        METHODS_WITH_ARGUMENTS = %w(decrement!
+        METHODS_WITH_ARGUMENTS = %w[decrement!
                                     decrement_counter
                                     increment!
                                     increment_counter
@@ -34,7 +34,7 @@ module RuboCop
                                     update_attribute
                                     update_column
                                     update_columns
-                                    update_counters).freeze
+                                    update_counters].freeze
 
         def on_send(node)
           return unless blacklist.include?(node.method_name.to_s)

--- a/lib/rubocop/cop/rails/time_zone.rb
+++ b/lib/rubocop/cop/rails/time_zone.rb
@@ -40,16 +40,16 @@ module RuboCop
 
         MSG_CURRENT = 'Do not use `%s`. Use `Time.zone.now` instead.'.freeze
 
-        TIMECLASS = %i(Time DateTime).freeze
+        TIMECLASS = %i[Time DateTime].freeze
 
-        GOOD_METHODS = %i(zone zone_default find_zone find_zone!).freeze
+        GOOD_METHODS = %i[zone zone_default find_zone find_zone!].freeze
 
-        DANGEROUS_METHODS = %i(now local new strftime
-                               parse at current).freeze
+        DANGEROUS_METHODS = %i[now local new strftime
+                               parse at current].freeze
 
-        ACCEPTED_METHODS = %i(in_time_zone utc getlocal
+        ACCEPTED_METHODS = %i[in_time_zone utc getlocal
                               iso8601 jisx0301 rfc3339
-                              to_i to_f).freeze
+                              to_i to_f].freeze
 
         def on_const(node)
           mod, klass = *node

--- a/lib/rubocop/cop/rails/validation.rb
+++ b/lib/rubocop/cop/rails/validation.rb
@@ -7,7 +7,7 @@ module RuboCop
       class Validation < Cop
         MSG = 'Prefer the new style validations `%s` over `%s`.'.freeze
 
-        TYPES = %w(
+        TYPES = %w[
           acceptance
           confirmation
           exclusion
@@ -18,7 +18,7 @@ module RuboCop
           presence
           size
           uniqueness
-        ).freeze
+        ].freeze
 
         BLACKLIST = TYPES.map { |p| "validates_#{p}_of".to_sym }.freeze
         WHITELIST = TYPES.map { |p| "validates :column, #{p}: value" }.freeze

--- a/lib/rubocop/cop/severity.rb
+++ b/lib/rubocop/cop/severity.rb
@@ -7,7 +7,7 @@ module RuboCop
       include Comparable
 
       # @api private
-      NAMES = %i(refactor convention warning error fatal).freeze
+      NAMES = %i[refactor convention warning error fatal].freeze
 
       # @api private
       CODE_TABLE = { R: :refactor, C: :convention,

--- a/lib/rubocop/cop/style/class_and_module_children.rb
+++ b/lib/rubocop/cop/style/class_and_module_children.rb
@@ -57,7 +57,7 @@ module RuboCop
         end
 
         def one_child?(body)
-          body && %i(module class).include?(body.type)
+          body && %i[module class].include?(body.type)
         end
 
         def compact_node_name?(node)

--- a/lib/rubocop/cop/style/command_literal.rb
+++ b/lib/rubocop/cop/style/command_literal.rb
@@ -105,7 +105,7 @@ module RuboCop
           replacement = if backtick_literal?(node)
                           ['%x', ''].zip(preferred_delimiters).map(&:join)
                         else
-                          %w(` `)
+                          %w[` `]
                         end
 
           lambda do |corrector|

--- a/lib/rubocop/cop/style/conditional_assignment.rb
+++ b/lib/rubocop/cop/style/conditional_assignment.rb
@@ -90,7 +90,7 @@ module RuboCop
 
         def setter_method?(method_name)
           method_name.to_s.end_with?(EQUAL) &&
-            !%i(!= == === >= <=).include?(method_name)
+            !%i[!= == === >= <=].include?(method_name)
         end
 
         def assignment_rhs_exist?(node)
@@ -205,9 +205,9 @@ module RuboCop
         ASSIGN_TO_CONDITION_MSG =
           'Assign variables inside of conditionals'.freeze
         VARIABLE_ASSIGNMENT_TYPES =
-          %i(casgn cvasgn gvasgn ivasgn lvasgn).freeze
+          %i[casgn cvasgn gvasgn ivasgn lvasgn].freeze
         ASSIGNMENT_TYPES = VARIABLE_ASSIGNMENT_TYPES +
-                           %i(and_asgn or_asgn op_asgn masgn).freeze
+                           %i[and_asgn or_asgn op_asgn masgn].freeze
         LINE_LENGTH = 'Metrics/LineLength'.freeze
         INDENTATION_WIDTH = 'Style/IndentationWidth'.freeze
         ENABLED = 'Enabled'.freeze

--- a/lib/rubocop/cop/style/constant_name.rb
+++ b/lib/rubocop/cop/style/constant_name.rb
@@ -19,7 +19,7 @@ module RuboCop
           # NewClass = something_that_returns_a_class
           # It's also ok to assign a class constant another class constant
           # SomeClass = SomeOtherClass
-          return if value && %i(send block const).include?(value.type)
+          return if value && %i[send block const].include?(value.type)
 
           add_offense(node, :name) if const_name !~ SNAKE_CASE
         end

--- a/lib/rubocop/cop/style/each_with_object.rb
+++ b/lib/rubocop/cop/style/each_with_object.rb
@@ -18,7 +18,7 @@ module RuboCop
       #   [1, 2].each_with_object({}) { |e, a| a[e] = e }
       class EachWithObject < Cop
         MSG = 'Use `each_with_object` instead of `%s`.'.freeze
-        METHODS = %i(inject reduce).freeze
+        METHODS = %i[inject reduce].freeze
 
         def_node_matcher :each_with_object_candidate?, <<-PATTERN
           (block $(send _ {:inject :reduce} _) $_ $_)

--- a/lib/rubocop/cop/style/file_name.rb
+++ b/lib/rubocop/cop/style/file_name.rb
@@ -91,7 +91,7 @@ module RuboCop
           return nil if node.nil?
           name = namespace.pop
 
-          on_node(%i(class module casgn), node) do |child|
+          on_node(%i[class module casgn], node) do |child|
             next unless (const = child.defined_module)
 
             const_namespace, const_name = *const
@@ -152,7 +152,7 @@ module RuboCop
           # But RC can be run from any working directory, and can check any path
           # We can't assume that the working directory, or any other, is the
           # "starting point" to build a namespace
-          start = %w(lib spec test src)
+          start = %w[lib spec test src]
           start_index = nil
 
           # To find the closest namespace root take the path components, and

--- a/lib/rubocop/cop/style/global_vars.rb
+++ b/lib/rubocop/cop/style/global_vars.rb
@@ -14,7 +14,7 @@ module RuboCop
 
         # predefined global variables their English aliases
         # http://www.zenspider.com/Languages/Ruby/QuickRef.html
-        BUILT_IN_VARS = %w(
+        BUILT_IN_VARS = %w[
           $: $LOAD_PATH
           $" $LOADED_FEATURES
           $0 $PROGRAM_NAME
@@ -41,7 +41,7 @@ module RuboCop
           $DEBUG $FILENAME $VERBOSE $SAFE
           $-0 $-a $-d $-F $-i $-I $-l $-p $-v $-w
           $CLASSPATH $JRUBY_VERSION $JRUBY_REVISION $ENV_JAVA
-        ).map(&:to_sym)
+        ].map(&:to_sym)
 
         def user_vars
           cop_config['AllowedVariables'].map(&:to_sym)

--- a/lib/rubocop/cop/style/if_unless_modifier.rb
+++ b/lib/rubocop/cop/style/if_unless_modifier.rb
@@ -13,8 +13,8 @@ module RuboCop
               'Another good alternative is the usage of control flow ' \
               '`&&`/`||`.'.freeze
 
-        ASSIGNMENT_TYPES = %i(lvasgn casgn cvasgn
-                              gvasgn ivasgn masgn).freeze
+        ASSIGNMENT_TYPES = %i[lvasgn casgn cvasgn
+                              gvasgn ivasgn masgn].freeze
 
         def on_if(node)
           return unless eligible_node?(node)

--- a/lib/rubocop/cop/style/indentation_width.rb
+++ b/lib/rubocop/cop/style/indentation_width.rb
@@ -53,7 +53,7 @@ module RuboCop
         include AccessModifierNode
         include IgnoredPattern
 
-        SPECIAL_MODIFIERS = %w(private protected).freeze
+        SPECIAL_MODIFIERS = %w[private protected].freeze
 
         def on_rescue(node)
           _begin_node, *_rescue_nodes, else_node = *node
@@ -259,7 +259,7 @@ module RuboCop
         def indentation_to_check?(base_loc, body_node)
           return false if skip_check?(base_loc, body_node)
 
-          if %i(rescue ensure).include?(body_node.type)
+          if %i[rescue ensure].include?(body_node.type)
             block_body, = *body_node
             return unless block_body
           end

--- a/lib/rubocop/cop/style/inverse_methods.rb
+++ b/lib/rubocop/cop/style/inverse_methods.rb
@@ -28,7 +28,7 @@ module RuboCop
       #   foo == bar
       class InverseMethods < Cop
         MSG = 'Use `%{inverse}` instead of inverting `%{method}`.'.freeze
-        EQUALITY_METHODS = %i(== != =~ !~ <= >= < >).freeze
+        EQUALITY_METHODS = %i[== != =~ !~ <= >= < >].freeze
 
         def_node_matcher :inverse_candidate?, <<-PATTERN
           {

--- a/lib/rubocop/cop/style/line_end_concatenation.rb
+++ b/lib/rubocop/cop/style/line_end_concatenation.rb
@@ -22,12 +22,12 @@ module RuboCop
       class LineEndConcatenation < Cop
         MSG = 'Use `\\` instead of `+` or `<<` to concatenate ' \
               'those strings.'.freeze
-        CONCAT_TOKEN_TYPES = %i(tPLUS tLSHFT).freeze
+        CONCAT_TOKEN_TYPES = %i[tPLUS tLSHFT].freeze
         SIMPLE_STRING_TOKEN_TYPE = :tSTRING
-        COMPLEX_STRING_EDGE_TOKEN_TYPES = %i(tSTRING_BEG tSTRING_END).freeze
-        HIGH_PRECEDENCE_OP_TOKEN_TYPES = %i(tSTAR2 tPERCENT tDOT
-                                            tLBRACK2).freeze
-        QUOTE_DELIMITERS = %w(' ").freeze
+        COMPLEX_STRING_EDGE_TOKEN_TYPES = %i[tSTRING_BEG tSTRING_END].freeze
+        HIGH_PRECEDENCE_OP_TOKEN_TYPES = %i[tSTAR2 tPERCENT tDOT
+                                            tLBRACK2].freeze
+        QUOTE_DELIMITERS = %w[' "].freeze
 
         def investigate(processed_source)
           processed_source.tokens.each_index do |index|

--- a/lib/rubocop/cop/style/method_call_without_args_parentheses.rb
+++ b/lib/rubocop/cop/style/method_call_without_args_parentheses.rb
@@ -15,7 +15,7 @@ module RuboCop
         MSG = 'Do not use parentheses for method calls with ' \
               'no arguments.'.freeze
 
-        ASGN_NODES = %i(lvasgn masgn) + SHORTHAND_ASGN_NODES
+        ASGN_NODES = %i[lvasgn masgn] + SHORTHAND_ASGN_NODES
 
         def on_send(node)
           return if node.camel_case_method?

--- a/lib/rubocop/cop/style/mixin_grouping.rb
+++ b/lib/rubocop/cop/style/mixin_grouping.rb
@@ -37,7 +37,7 @@ module RuboCop
       class MixinGrouping < Cop
         include ConfigurableEnforcedStyle
 
-        MIXIN_METHODS = %i(extend include prepend).freeze
+        MIXIN_METHODS = %i[extend include prepend].freeze
         MSG = 'Put `%s` mixins in %s.'.freeze
 
         def on_send(node)

--- a/lib/rubocop/cop/style/nested_parenthesized_calls.rb
+++ b/lib/rubocop/cop/style/nested_parenthesized_calls.rb
@@ -14,9 +14,9 @@ module RuboCop
       #   method1(method2 arg, method3, arg)
       class NestedParenthesizedCalls < Cop
         MSG = 'Add parentheses to nested method call `%s`.'.freeze
-        RSPEC_MATCHERS = %i(be eq eql equal be_kind_of be_instance_of
+        RSPEC_MATCHERS = %i[be eq eql equal be_kind_of be_instance_of
                             respond_to be_between match be_within
-                            start_with end_with include raise_error).freeze
+                            start_with end_with include raise_error].freeze
 
         def on_send(node)
           return unless node.parenthesized?

--- a/lib/rubocop/cop/style/next.rb
+++ b/lib/rubocop/cop/style/next.rb
@@ -23,12 +23,12 @@ module RuboCop
         include MinBodyLength
 
         MSG = 'Use `next` to skip iteration.'.freeze
-        EXIT_TYPES = %i(break return).freeze
+        EXIT_TYPES = %i[break return].freeze
         EACH_ = 'each_'.freeze
-        ENUMERATORS = %i(collect collect_concat detect downto each
+        ENUMERATORS = %i[collect collect_concat detect downto each
                          find find_all find_index inject loop map!
                          map reduce reject reject! reverse_each select
-                         select! times upto).freeze
+                         select! times upto].freeze
 
         def investigate(_processed_source)
           # When correcting nested offenses, we need to keep track of how much

--- a/lib/rubocop/cop/style/numeric_predicate.rb
+++ b/lib/rubocop/cop/style/numeric_predicate.rb
@@ -108,7 +108,7 @@ module RuboCop
         end
 
         def replacement_supported?(operator)
-          if %i(> <).include?(operator)
+          if %i[> <].include?(operator)
             target_ruby_version >= 2.3
           else
             true

--- a/lib/rubocop/cop/style/one_line_conditional.rb
+++ b/lib/rubocop/cop/style/one_line_conditional.rb
@@ -26,7 +26,7 @@ module RuboCop
         def replacement(node)
           return to_ternary(node) unless node.parent
 
-          if %i(and or).include?(node.parent.type)
+          if %i[and or].include?(node.parent.type)
             return "(#{to_ternary(node)})"
           end
 
@@ -48,7 +48,7 @@ module RuboCop
         end
 
         def requires_parentheses?(node)
-          return true if %i(and or if).include?(node.type)
+          return true if %i[and or if].include?(node.type)
           return true if node.assignment?
           return true if method_call_with_changed_precedence?(node)
 

--- a/lib/rubocop/cop/style/op_method.rb
+++ b/lib/rubocop/cop/style/op_method.rb
@@ -17,8 +17,8 @@ module RuboCop
         MSG = 'When defining the `%s` operator, ' \
               'name its argument `other`.'.freeze
 
-        OP_LIKE_METHODS = %i(eql? equal?).freeze
-        BLACKLISTED = %i(+@ -@ [] []= << `).freeze
+        OP_LIKE_METHODS = %i[eql? equal?].freeze
+        BLACKLISTED = %i[+@ -@ [] []= << `].freeze
 
         def_node_matcher :op_method_candidate?, <<-PATTERN
           (def $_ (args $(arg [!:other !:_other])) _)

--- a/lib/rubocop/cop/style/parallel_assignment.rb
+++ b/lib/rubocop/cop/style/parallel_assignment.rb
@@ -171,7 +171,7 @@ module RuboCop
 
         def modifier_while?(node)
           node.loc.respond_to?(:keyword) &&
-            %w(while until).include?(node.loc.keyword.source) &&
+            %w[while until].include?(node.loc.keyword.source) &&
             node.modifier_form?
         end
 

--- a/lib/rubocop/cop/style/percent_literal_delimiters.rb
+++ b/lib/rubocop/cop/style/percent_literal_delimiters.rb
@@ -12,17 +12,17 @@ module RuboCop
       # @example
       #   # Style/PercentLiteralDelimiters:
       #   #   PreferredDelimiters:
-      #   #     default: ()
-      #   #     %i:      []
+      #   #     default: []
+      #   #     %i:      ()
       #
       #   # good
-      #   %w(alpha beta) + %i[gamma delta]
+      #   %w[alpha beta] + %i(gamma delta)
       #
       #   # bad
-      #   %W[alpha #{beta}]
+      #   %W(alpha #{beta})
       #
       #   # bad
-      #   %I[alpha beta]
+      #   %I(alpha beta)
       class PercentLiteralDelimiters < Cop
         include PercentLiteral
 

--- a/lib/rubocop/cop/style/perl_backrefs.rb
+++ b/lib/rubocop/cop/style/perl_backrefs.rb
@@ -16,7 +16,7 @@ module RuboCop
           lambda do |corrector|
             backref, = *node
             parent_type = node.parent ? node.parent.type : nil
-            if %i(dstr xstr regexp).include?(parent_type)
+            if %i[dstr xstr regexp].include?(parent_type)
               corrector.replace(node.source_range,
                                 "{Regexp.last_match(#{backref})}")
             else

--- a/lib/rubocop/cop/style/preferred_hash_methods.rb
+++ b/lib/rubocop/cop/style/preferred_hash_methods.rb
@@ -37,8 +37,8 @@ module RuboCop
         MSG = 'Use `Hash#%s` instead of `Hash#%s`.'.freeze
 
         OFFENDING_SELECTORS = {
-          short: %i(has_key? has_value?),
-          verbose: %i(key? value?)
+          short: %i[has_key? has_value?],
+          verbose: %i[key? value?]
         }.freeze
 
         def on_send(node)

--- a/lib/rubocop/cop/style/redundant_parentheses.rb
+++ b/lib/rubocop/cop/style/redundant_parentheses.rb
@@ -16,7 +16,7 @@ module RuboCop
       class RedundantParentheses < Cop
         include Parentheses
 
-        ALLOWED_LITERALS = %i(irange erange).freeze
+        ALLOWED_LITERALS = %i[irange erange].freeze
 
         def_node_matcher :square_brackets?,
                          '(send {(send _recv _msg) str array hash} :[] ...)'

--- a/lib/rubocop/cop/style/redundant_self.rb
+++ b/lib/rubocop/cop/style/redundant_self.rb
@@ -126,11 +126,11 @@ module RuboCop
         end
 
         def keyword?(method_name)
-          %i(alias and begin break case class def defined? do
+          %i[alias and begin break case class def defined? do
              else elsif end ensure false for if in module
              next nil not or redo rescue retry return self
              super then true undef unless until when while
-             yield).include?(method_name)
+             yield].include?(method_name)
         end
 
         def allow_self(node)

--- a/lib/rubocop/cop/style/regexp_literal.rb
+++ b/lib/rubocop/cop/style/regexp_literal.rb
@@ -100,7 +100,7 @@ module RuboCop
           replacement = if slash_literal?(node)
                           ['%r', ''].zip(preferred_delimiters).map(&:join)
                         else
-                          %w(/ /)
+                          %w[/ /]
                         end
 
           lambda do |corrector|

--- a/lib/rubocop/cop/style/self_assignment.rb
+++ b/lib/rubocop/cop/style/self_assignment.rb
@@ -14,7 +14,7 @@ module RuboCop
       #   x += 1
       class SelfAssignment < Cop
         MSG = 'Use self-assignment shorthand `%s=`.'.freeze
-        OPS = %i(+ - * ** / | &).freeze
+        OPS = %i[+ - * ** / | &].freeze
 
         def on_lvasgn(node)
           check(node, :lvar)
@@ -36,7 +36,7 @@ module RuboCop
 
           if rhs.send_type?
             check_send_node(node, rhs, var_name, var_type)
-          elsif %i(and or).include?(rhs.type)
+          elsif %i[and or].include?(rhs.type)
             check_boolean_node(node, rhs, var_name, var_type)
           end
         end
@@ -66,7 +66,7 @@ module RuboCop
 
           if rhs.send_type?
             autocorrect_send_node(node, rhs)
-          elsif %i(and or).include?(rhs.type)
+          elsif %i[and or].include?(rhs.type)
             autocorrect_boolean_node(node, rhs)
           end
         end

--- a/lib/rubocop/cop/style/space_around_keyword.rb
+++ b/lib/rubocop/cop/style/space_around_keyword.rb
@@ -31,16 +31,16 @@ module RuboCop
         DO = 'do'.freeze
         SAFE_NAVIGATION = '&.'.freeze
         ACCEPT_LEFT_PAREN =
-          %w(break defined? next not rescue return super yield).freeze
+          %w[break defined? next not rescue return super yield].freeze
         ACCEPT_LEFT_SQUARE_BRACKET =
-          %w(super yield).freeze
+          %w[super yield].freeze
 
         def on_and(node)
           check(node, [:operator].freeze) if node.keyword?
         end
 
         def on_block(node)
-          check(node, %i(begin end).freeze)
+          check(node, %i[begin end].freeze)
         end
 
         def on_break(node)
@@ -48,7 +48,7 @@ module RuboCop
         end
 
         def on_case(node)
-          check(node, %i(keyword else).freeze)
+          check(node, %i[keyword else].freeze)
         end
 
         def on_ensure(node)
@@ -56,15 +56,15 @@ module RuboCop
         end
 
         def on_for(node)
-          check(node, %i(begin end).freeze)
+          check(node, %i[begin end].freeze)
         end
 
         def on_if(node)
-          check(node, %i(keyword else begin end).freeze, 'then'.freeze)
+          check(node, %i[keyword else begin end].freeze, 'then'.freeze)
         end
 
         def on_kwbegin(node)
-          check(node, %i(begin end).freeze, nil)
+          check(node, %i[begin end].freeze, nil)
         end
 
         def on_next(node)
@@ -108,7 +108,7 @@ module RuboCop
         end
 
         def on_until(node)
-          check(node, %i(begin end keyword).freeze)
+          check(node, %i[begin end keyword].freeze)
         end
 
         def on_when(node)
@@ -116,7 +116,7 @@ module RuboCop
         end
 
         def on_while(node)
-          check(node, %i(begin end keyword).freeze)
+          check(node, %i[begin end keyword].freeze)
         end
 
         def on_yield(node)

--- a/lib/rubocop/cop/style/space_around_operators.rb
+++ b/lib/rubocop/cop/style/space_around_operators.rb
@@ -8,7 +8,7 @@ module RuboCop
       class SpaceAroundOperators < Cop
         include PrecedingFollowingAlignment
 
-        IRREGULAR_METHODS = %i([] ! []=).freeze
+        IRREGULAR_METHODS = %i[[] ! []=].freeze
 
         def on_pair(node)
           return unless node.hash_rocket?

--- a/lib/rubocop/cop/style/space_inside_brackets.rb
+++ b/lib/rubocop/cop/style/space_inside_brackets.rb
@@ -9,7 +9,7 @@ module RuboCop
 
         def specifics
           [
-            %i(tLBRACK tLBRACK2),
+            %i[tLBRACK tLBRACK2],
             :tRBRACK,
             'square brackets'
           ]

--- a/lib/rubocop/cop/style/space_inside_parens.rb
+++ b/lib/rubocop/cop/style/space_inside_parens.rb
@@ -8,7 +8,7 @@ module RuboCop
         include SpaceInside
 
         def specifics
-          [%i(tLPAREN tLPAREN2), :tRPAREN, 'parentheses']
+          [%i[tLPAREN tLPAREN2], :tRPAREN, 'parentheses']
         end
       end
     end

--- a/lib/rubocop/cop/style/special_global_vars.rb
+++ b/lib/rubocop/cop/style/special_global_vars.rb
@@ -19,19 +19,19 @@ module RuboCop
           :$0 => [:$PROGRAM_NAME],
           :$! => [:$ERROR_INFO],
           :$@ => [:$ERROR_POSITION],
-          :$; => %i($FIELD_SEPARATOR $FS),
-          :$, => %i($OUTPUT_FIELD_SEPARATOR $OFS),
-          :$/ => %i($INPUT_RECORD_SEPARATOR $RS),
-          :$\ => %i($OUTPUT_RECORD_SEPARATOR $ORS),
-          :$. => %i($INPUT_LINE_NUMBER $NR),
+          :$; => %i[$FIELD_SEPARATOR $FS],
+          :$, => %i[$OUTPUT_FIELD_SEPARATOR $OFS],
+          :$/ => %i[$INPUT_RECORD_SEPARATOR $RS],
+          :$\ => %i[$OUTPUT_RECORD_SEPARATOR $ORS],
+          :$. => %i[$INPUT_LINE_NUMBER $NR],
           :$_ => [:$LAST_READ_LINE],
           :$> => [:$DEFAULT_OUTPUT],
           :$< => [:$DEFAULT_INPUT],
-          :$$ => %i($PROCESS_ID $PID),
+          :$$ => %i[$PROCESS_ID $PID],
           :$? => [:$CHILD_STATUS],
           :$~ => [:$LAST_MATCH_INFO],
           :$= => [:$IGNORECASE],
-          :$* => %i($ARGV ARGV),
+          :$* => %i[$ARGV ARGV],
           :$& => [:$MATCH],
           :$` => [:$PREMATCH],
           :$' => [:$POSTMATCH],
@@ -51,12 +51,12 @@ module RuboCop
         PERL_VARS.each { |_, v| v.freeze }.freeze
 
         # Anything *not* in this set is provided by the English library.
-        NON_ENGLISH_VARS = Set.new(%i(
+        NON_ENGLISH_VARS = Set.new(%i[
                                      $LOAD_PATH
                                      $LOADED_FEATURES
                                      $PROGRAM_NAME
                                      ARGV
-                                   )).freeze
+                                   ]).freeze
 
         def on_gvar(node)
           global_var, = *node
@@ -126,7 +126,7 @@ module RuboCop
           parent_type = node.parent && node.parent.type
           preferred_name = preferred_names(global_var).first
 
-          unless %i(dstr xstr regexp).include?(parent_type)
+          unless %i[dstr xstr regexp].include?(parent_type)
             return preferred_name.to_s
           end
 

--- a/lib/rubocop/cop/style/symbol_proc.rb
+++ b/lib/rubocop/cop/style/symbol_proc.rb
@@ -13,7 +13,7 @@ module RuboCop
       #   something.map(&:upcase)
       class SymbolProc < Cop
         MSG = 'Pass `&:%s` as an argument to `%s` instead of a block.'.freeze
-        SUPER_TYPES = %i(super zsuper).freeze
+        SUPER_TYPES = %i[super zsuper].freeze
 
         def_node_matcher :proc_node?, '(send (const nil :Proc) :new)'
         def_node_matcher :symbol_proc?, <<-PATTERN
@@ -31,7 +31,7 @@ module RuboCop
             # configurable - https://github.com/bbatsov/rubocop/issues/1485
             # we should ignore lambdas & procs
             return if proc_node?(send_or_super)
-            return if %i(lambda proc).include?(block_method_name)
+            return if %i[lambda proc].include?(block_method_name)
             return if ignored_method?(block_method_name)
             return unless can_shorten?(block_args, block_body)
 

--- a/lib/rubocop/cop/style/trivial_accessors.rb
+++ b/lib/rubocop/cop/style/trivial_accessors.rb
@@ -95,7 +95,7 @@ module RuboCop
 
         def looks_like_trivial_writer?(args, body)
           args.children.one? &&
-            !%i(restarg blockarg).include?(args.children[0].type) &&
+            !%i[restarg blockarg].include?(args.children[0].type) &&
             body && body.ivasgn_type? &&
             body.children[1] && body.children[1].lvar_type?
         end

--- a/lib/rubocop/cop/util.rb
+++ b/lib/rubocop/cop/util.rb
@@ -10,14 +10,14 @@ module RuboCop
 
       BYTE_ORDER_MARK = 0xfeff # The Unicode codepoint
 
-      EQUALS_ASGN_NODES = %i(lvasgn ivasgn cvasgn gvasgn
-                             casgn masgn).freeze
-      SHORTHAND_ASGN_NODES = %i(op_asgn or_asgn and_asgn).freeze
+      EQUALS_ASGN_NODES = %i[lvasgn ivasgn cvasgn gvasgn
+                             casgn masgn].freeze
+      SHORTHAND_ASGN_NODES = %i[op_asgn or_asgn and_asgn].freeze
       ASGN_NODES = (EQUALS_ASGN_NODES + SHORTHAND_ASGN_NODES).freeze
 
-      MODIFIER_NODES = %i(if while until).freeze
+      MODIFIER_NODES = %i[if while until].freeze
       CONDITIONAL_NODES = (MODIFIER_NODES + [:case]).freeze
-      LOGICAL_OPERATOR_NODES = %i(and or).freeze
+      LOGICAL_OPERATOR_NODES = %i[and or].freeze
 
       # http://phrogz.net/programmingruby/language.html#table_18.4
       # Backtick is added last just to help editors parse this code.
@@ -236,10 +236,10 @@ module RuboCop
       end
 
       def symbol_without_quote?(string)
-        special_gvars = %w(
+        special_gvars = %w[
           $! $" $$ $& $' $* $+ $, $/ $; $: $. $< $= $> $? $@ $\\ $_ $` $~ $0
           $-0 $-F $-I $-K $-W $-a $-d $-i $-l $-p $-v $-w
-        )
+        ]
         redefinable_operators = %w(
           | ^ & <=> == === =~ > >= < <= << >>
           + - * / % ** ~ +@ -@ [] []= ` ! != !~

--- a/lib/rubocop/cop/variable_force.rb
+++ b/lib/rubocop/cop/variable_force.rb
@@ -35,7 +35,7 @@ module RuboCop
         :shadowarg # This means block local variable (obj.each { |arg; this| }).
       ].freeze
 
-      LOGICAL_OPERATOR_ASSIGNMENT_TYPES = %i(or_asgn and_asgn).freeze
+      LOGICAL_OPERATOR_ASSIGNMENT_TYPES = %i[or_asgn and_asgn].freeze
       OPERATOR_ASSIGNMENT_TYPES =
         (LOGICAL_OPERATOR_ASSIGNMENT_TYPES + [:op_asgn]).freeze
 
@@ -43,15 +43,15 @@ module RuboCop
 
       VARIABLE_REFERENCE_TYPE = :lvar
 
-      POST_CONDITION_LOOP_TYPES = %i(while_post until_post).freeze
-      LOOP_TYPES = (POST_CONDITION_LOOP_TYPES + %i(while until for)).freeze
+      POST_CONDITION_LOOP_TYPES = %i[while_post until_post].freeze
+      LOOP_TYPES = (POST_CONDITION_LOOP_TYPES + %i[while until for]).freeze
 
       RESCUE_TYPE = :rescue
 
       ZERO_ARITY_SUPER_TYPE = :zsuper
 
-      TWISTED_SCOPE_TYPES = %i(block class sclass defs).freeze
-      SCOPE_TYPES = (TWISTED_SCOPE_TYPES + %i(module def)).freeze
+      TWISTED_SCOPE_TYPES = %i[block class sclass defs].freeze
+      SCOPE_TYPES = (TWISTED_SCOPE_TYPES + %i[module def]).freeze
 
       SEND_TYPE = :send
 
@@ -376,14 +376,14 @@ module RuboCop
       end
 
       # Hooks invoked by VariableTable.
-      %i(
+      %i[
         before_entering_scope
         after_entering_scope
         before_leaving_scope
         after_leaving_scope
         before_declaring_variable
         after_declaring_variable
-      ).each do |hook|
+      ].each do |hook|
         define_method(hook) do |arg|
           # Invoke hook in cops.
           run_hook(hook, arg, variable_table)

--- a/lib/rubocop/cop/variable_force/variable.rb
+++ b/lib/rubocop/cop/variable_force/variable.rb
@@ -83,7 +83,7 @@ module RuboCop
         end
 
         def method_argument?
-          argument? && %i(def defs).include?(@scope.node.type)
+          argument? && %i[def defs].include?(@scope.node.type)
         end
 
         def block_argument?
@@ -91,7 +91,7 @@ module RuboCop
         end
 
         def keyword_argument?
-          %i(kwarg kwoptarg).include?(@declaration_node.type)
+          %i[kwarg kwoptarg].include?(@declaration_node.type)
         end
 
         def explicit_block_local_variable?

--- a/lib/rubocop/formatter/colorizable.rb
+++ b/lib/rubocop/formatter/colorizable.rb
@@ -22,7 +22,7 @@ module RuboCop
         rainbow.wrap(string).color(*args)
       end
 
-      %i(
+      %i[
         black
         red
         green
@@ -31,7 +31,7 @@ module RuboCop
         magenta
         cyan
         white
-      ).each do |color|
+      ].each do |color|
         define_method(color) do |string|
           colorize(string, color)
         end

--- a/lib/rubocop/formatter/disabled_config_formatter.rb
+++ b/lib/rubocop/formatter/disabled_config_formatter.rb
@@ -102,7 +102,7 @@ module RuboCop
 
       def cop_config_params(default_cfg, cfg)
         default_cfg.keys -
-          %w(Description StyleGuide Reference Enabled Exclude) -
+          %w[Description StyleGuide Reference Enabled Exclude] -
           cfg.keys
       end
 

--- a/lib/rubocop/formatter/formatter_set.rb
+++ b/lib/rubocop/formatter/formatter_set.rb
@@ -22,7 +22,7 @@ module RuboCop
         'worst'    => WorstOffendersFormatter
       }.freeze
 
-      FORMATTER_APIS = %i(started finished).freeze
+      FORMATTER_APIS = %i[started finished].freeze
 
       FORMATTER_APIS.each do |method_name|
         define_method(method_name) do |*args|

--- a/lib/rubocop/options.rb
+++ b/lib/rubocop/options.rb
@@ -6,7 +6,7 @@ require 'shellwords'
 module RuboCop
   # This class handles command line options.
   class Options
-    EXITING_OPTIONS = %i(version verbose_version show_cops).freeze
+    EXITING_OPTIONS = %i[version verbose_version show_cops].freeze
     DEFAULT_MAXIMUM_EXCLUSION_ITEMS = 15
 
     def initialize
@@ -193,7 +193,7 @@ module RuboCop
       names.each do |name|
         next if Cop::Cop.registry.names.include?(name)
         next if departments.include?(name)
-        next if %w(Syntax Lint/Syntax).include?(name)
+        next if %w[Syntax Lint/Syntax].include?(name)
 
         raise ArgumentError, "Unrecognized cop or department: #{name}."
       end
@@ -224,16 +224,16 @@ module RuboCop
 
     def only_includes_unneeded_disable?
       @options.key?(:only) &&
-        (@options[:only] & %w(Lint/UnneededDisable UnneededDisable)).any?
+        (@options[:only] & %w[Lint/UnneededDisable UnneededDisable]).any?
     end
 
     def except_syntax?
       @options.key?(:except) &&
-        (@options[:except] & %w(Lint/Syntax Syntax)).any?
+        (@options[:except] & %w[Lint/Syntax Syntax]).any?
     end
 
     def boolean_or_empty_cache?
-      !@options.key?(:cache) || %w(true false).include?(@options[:cache])
+      !@options.key?(:cache) || %w[true false].include?(@options[:cache])
     end
 
     def no_offense_counts_without_auto_gen_config?

--- a/lib/rubocop/processed_source.rb
+++ b/lib/rubocop/processed_source.rb
@@ -70,7 +70,7 @@ module RuboCop
 
     def valid_syntax?
       return false if @parser_error
-      @diagnostics.none? { |d| %i(error fatal).include?(d.level) }
+      @diagnostics.none? { |d| %i[error fatal].include?(d.level) }
     end
 
     # Raw source checksum for tracking infinite loops.

--- a/lib/rubocop/result_cache.rb
+++ b/lib/rubocop/result_cache.rb
@@ -8,8 +8,8 @@ require 'etc'
 module RuboCop
   # Provides functionality for caching rubocop runs.
   class ResultCache
-    NON_CHANGING = %i(color format formatters out debug fail_level
-                      cache fail_fast stdin).freeze
+    NON_CHANGING = %i[color format formatters out debug fail_level
+                      cache fail_fast stdin].freeze
 
     # Remove old files so that the cache doesn't grow too big. When the
     # threshold MaxFilesInCache has been exceeded, the oldest 50% of all the

--- a/lib/rubocop/rspec/shared_examples.rb
+++ b/lib/rubocop/rspec/shared_examples.rb
@@ -22,7 +22,7 @@ shared_examples_for 'mimics MRI 2.1' do |grep_mri_warning|
         offense_by_mri = offenses_by_mri[index]
         # Exclude column attribute since MRI does not
         # output column number.
-        %i(severity line cop_name).each do |a|
+        %i[severity line cop_name].each do |a|
           expect(offense_by_cop.send(a)).to eq(offense_by_mri.send(a))
         end
       end

--- a/lib/rubocop/runner.rb
+++ b/lib/rubocop/runner.rb
@@ -261,7 +261,7 @@ module RuboCop
       @mobilized_cop_classes[config.object_id] ||= begin
         cop_classes = Cop::Cop.all
 
-        %i(only except).each do |opt|
+        %i[only except].each do |opt|
           OptionsValidator.validate_cop_list(@options[opt])
         end
 

--- a/lib/rubocop/target_finder.rb
+++ b/lib/rubocop/target_finder.rb
@@ -3,7 +3,7 @@
 require 'set'
 
 module RuboCop
-  RUBY_EXTENSIONS = %w(.rb
+  RUBY_EXTENSIONS = %w[.rb
                        .builder
                        .fcgi
                        .gemspec
@@ -21,15 +21,15 @@ module RuboCop
                        .ruby
                        .spec
                        .thor
-                       .watchr).freeze
+                       .watchr].freeze
 
-  RUBY_INTERPRETERS = %w(ruby
+  RUBY_INTERPRETERS = %w[ruby
                          macruby
                          rake
                          jruby
-                         rbx).freeze
+                         rbx].freeze
 
-  RUBY_FILENAMES = %w(.irbrc
+  RUBY_FILENAMES = %w[.irbrc
                       .pryrc
                       Appraisals
                       Berksfile
@@ -48,7 +48,7 @@ module RuboCop
                       Snapfile
                       Thorfile
                       Vagrantfile
-                      buildfile).freeze
+                      buildfile].freeze
 
   # This class finds target files to inspect by scanning the directory tree
   # and picking ruby files.

--- a/spec/project_spec.rb
+++ b/spec/project_spec.rb
@@ -14,7 +14,7 @@ describe 'RuboCop Project' do
     include_context 'configuration file', 'config/default.yml'
 
     it 'has configuration for all cops' do
-      expect(configuration_keys).to match_array(%w(AllCops Rails) + cop_names)
+      expect(configuration_keys).to match_array(%w[AllCops Rails] + cop_names)
     end
 
     it 'has a nicely formatted description for all cops' do

--- a/spec/rubocop/cli/cli_auto_gen_config_spec.rb
+++ b/spec/rubocop/cli/cli_auto_gen_config_spec.rb
@@ -325,7 +325,7 @@ describe RuboCop::CLI, :isolated_environment do
 
     it 'generates a todo list that removes the reports' do
       create_file('example.rb', 'y.gsub!(/abc\/xyz/, x)')
-      expect(cli.run(%w(--format emacs))).to eq(1)
+      expect(cli.run(%w[--format emacs])).to eq(1)
       expect($stdout.string).to eq("#{abs('example.rb')}:1:9: C: Use `%r` " \
                                    "around regular expression.\n")
       expect(cli.run(['--auto-gen-config'])).to eq(1)
@@ -356,7 +356,7 @@ describe RuboCop::CLI, :isolated_environment do
         end
       end
       $stdout = StringIO.new
-      result = cli.run(%w(--config .rubocop_todo.yml --format emacs))
+      result = cli.run(%w[--config .rubocop_todo.yml --format emacs])
       expect($stdout.string).to eq('')
       expect(result).to eq(0)
     end

--- a/spec/rubocop/cli/cli_autocorrect_spec.rb
+++ b/spec/rubocop/cli/cli_autocorrect_spec.rb
@@ -228,7 +228,7 @@ describe RuboCop::CLI, :isolated_environment do
     expect(IO.read('example.rb')).to eq(corrected.join("\n"))
   end
 
-  %i(line_count_based semantic braces_for_chaining).each do |style|
+  %i[line_count_based semantic braces_for_chaining].each do |style|
     context "when BlockDelimiters has #{style} style" do
       it 'corrects SpaceBeforeBlockBraces, SpaceInsideBlockBraces offenses' do
         source = ['r = foo.map{|a|',
@@ -316,7 +316,7 @@ describe RuboCop::CLI, :isolated_environment do
               'end',
               ''].join("\n")
     create_file('example.rb', source)
-    expect(cli.run(%w(--auto-correct --format simple))).to eq(1)
+    expect(cli.run(%w[--auto-correct --format simple])).to eq(1)
     expect($stdout.string)
       .to eq(['== example.rb ==',
               'C:  1:  1: Missing top-level class documentation comment.',
@@ -487,7 +487,7 @@ describe RuboCop::CLI, :isolated_environment do
               '  raise',
               'end']
     create_file('example.rb', source)
-    expect(cli.run(%w(--only IndentationWidth --auto-correct))).to eq(0)
+    expect(cli.run(%w[--only IndentationWidth --auto-correct])).to eq(0)
     corrected = ['foo = if bar',
                  '        something',
                  'elsif baz',
@@ -634,7 +634,7 @@ describe RuboCop::CLI, :isolated_environment do
   it 'can handle spaces when removing braces' do
     create_file('example.rb',
                 ["assert_post_status_code 400, 's', {:type => 'bad'}"])
-    expect(cli.run(%w(--auto-correct --format emacs))).to eq(0)
+    expect(cli.run(%w[--auto-correct --format emacs])).to eq(0)
     expect(IO.read('example.rb'))
       .to eq(["assert_post_status_code 400, 's', type: 'bad'",
               ''].join("\n"))
@@ -675,11 +675,11 @@ describe RuboCop::CLI, :isolated_environment do
                                'private',
                                '  A = ["git", "path",]',
                                'end'])
-    expect(cli.run(%w(--auto-correct --format emacs))).to eq(1)
+    expect(cli.run(%w[--auto-correct --format emacs])).to eq(1)
     expect(IO.read('example.rb')).to eq(['class Dsl',
                                          '  private',
                                          '',
-                                         '  A = %w(git path).freeze',
+                                         '  A = %w[git path].freeze',
                                          'end',
                                          ''].join("\n"))
     e = abs('example.rb')
@@ -726,7 +726,7 @@ describe RuboCop::CLI, :isolated_environment do
   it 'can correct single line methods' do
     create_file('example.rb', ['def func1; do_something end # comment',
                                'def func2() do_1; do_2; end'])
-    expect(cli.run(%w(--auto-correct --format offenses))).to eq(0)
+    expect(cli.run(%w[--auto-correct --format offenses])).to eq(0)
     expect(IO.read('example.rb')).to eq(['# comment',
                                          'def func1',
                                          '  do_something',
@@ -819,7 +819,7 @@ describe RuboCop::CLI, :isolated_environment do
                 ['def primes limit',
                  '  1.upto(limit).select { |i| i.even? }',
                  'end'])
-    expect(cli.run(%w(-D --auto-correct))).to eq(0)
+    expect(cli.run(%w[-D --auto-correct])).to eq(0)
     expect($stderr.string).to eq('')
     expect(IO.read('example.rb'))
       .to eq(['def primes(limit)',
@@ -851,7 +851,7 @@ describe RuboCop::CLI, :isolated_environment do
     create_file('example.rb',
                 ["f(type: ['offline','offline_payment'],",
                  "  bar_colors: ['958c12','953579','ff5800','0085cc'])"])
-    expect(cli.run(%w(-D --auto-correct --format o))).to eq(0)
+    expect(cli.run(%w[-D --auto-correct --format o])).to eq(0)
     expect($stdout.string)
       .to eq(['',
               '4  Style/SpaceAfterComma',
@@ -861,15 +861,15 @@ describe RuboCop::CLI, :isolated_environment do
               '',
               ''].join("\n"))
     expect(IO.read('example.rb'))
-      .to eq(['f(type: %w(offline offline_payment),',
-              '  bar_colors: %w(958c12 953579 ff5800 0085cc))',
+      .to eq(['f(type: %w[offline offline_payment],',
+              '  bar_colors: %w[958c12 953579 ff5800 0085cc])',
               ''].join("\n"))
   end
 
   it 'can correct SpaceAfterComma and HashSyntax offenses' do
     create_file('example.rb',
                 "I18n.t('description',:property_name => property.name)")
-    expect(cli.run(%w(-D --auto-correct --format emacs))).to eq(0)
+    expect(cli.run(%w[-D --auto-correct --format emacs])).to eq(0)
     expect($stdout.string)
       .to eq(["#{abs('example.rb')}:1:21: C: [Corrected] " \
               'Style/SpaceAfterComma: Space missing after comma.',
@@ -882,7 +882,7 @@ describe RuboCop::CLI, :isolated_environment do
 
   it 'can correct HashSyntax and SpaceAroundOperators offenses' do
     create_file('example.rb', '{ :b=>1 }')
-    expect(cli.run(%w(-D --auto-correct --format emacs))).to eq(0)
+    expect(cli.run(%w[-D --auto-correct --format emacs])).to eq(0)
     expect(IO.read('example.rb')).to eq("{ b: 1 }\n")
     expect($stdout.string)
       .to eq(["#{abs('example.rb')}:1:3: C: [Corrected] " \
@@ -895,8 +895,8 @@ describe RuboCop::CLI, :isolated_environment do
 
   it 'can correct HashSyntax when --only is used' do
     create_file('example.rb', '{ :b=>1 }')
-    expect(cli.run(%w(--auto-correct -f emacs
-                      --only Style/HashSyntax))).to eq(0)
+    expect(cli.run(%w[--auto-correct -f emacs
+                      --only Style/HashSyntax])).to eq(0)
     expect($stderr.string).to eq('')
     expect(IO.read('example.rb')).to eq("{ b: 1 }\n")
     expect($stdout.string)
@@ -912,7 +912,7 @@ describe RuboCop::CLI, :isolated_environment do
                  '  ',
                  '',
                  ''])
-    expect(cli.run(%w(--auto-correct --format emacs))).to eq(0)
+    expect(cli.run(%w[--auto-correct --format emacs])).to eq(0)
     expect(IO.read('example.rb')).to eq(['# encoding: utf-8',
                                          ''].join("\n"))
     expect($stdout.string)
@@ -925,7 +925,7 @@ describe RuboCop::CLI, :isolated_environment do
 
   it 'can correct MethodCallWithoutArgsParentheses and EmptyLiteral offenses' do
     create_file('example.rb', 'Hash.new()')
-    expect(cli.run(%w(--auto-correct --format emacs))).to eq(0)
+    expect(cli.run(%w[--auto-correct --format emacs])).to eq(0)
     expect($stderr.string).to eq('')
     expect(IO.read('example.rb')).to eq("{}\n")
     expect($stdout.string)
@@ -947,7 +947,7 @@ describe RuboCop::CLI, :isolated_environment do
     create_file('.rubocop.yml',
                 ['Style/AlignHash:',
                  '  EnforcedColonStyle: separator'])
-    expect(cli.run(%w(--auto-correct))).to eq(0)
+    expect(cli.run(%w[--auto-correct])).to eq(0)
     expect(IO.read('example.rb'))
       .to eq(['CONVERSION_CORRESPONDENCE = {',
               '                match_for_should: :match,',
@@ -978,7 +978,7 @@ describe RuboCop::CLI, :isolated_environment do
     create_file('.rubocop.yml', ['AllCops:',
                                  '  TargetRubyVersion: 2.1'])
     create_file('example.rb', src)
-    expect(cli.run(%w(-a -f simple))).to eq(1)
+    expect(cli.run(%w[-a -f simple])).to eq(1)
     expect($stderr.string).to eq('')
     expect(IO.read('example.rb')).to eq(corrected.join("\n") + "\n")
     expect($stdout.string)
@@ -988,7 +988,7 @@ describe RuboCop::CLI, :isolated_environment do
   it 'does not hang SpaceAfterPunctuation and SpaceInsideParens' do
     create_file('example.rb', 'some_method(a, )')
     Timeout.timeout(10) do
-      expect(cli.run(%w(--auto-correct))).to eq(0)
+      expect(cli.run(%w[--auto-correct])).to eq(0)
     end
     expect($stderr.string).to eq('')
     expect(IO.read('example.rb')).to eq("some_method(a)\n")
@@ -997,7 +997,7 @@ describe RuboCop::CLI, :isolated_environment do
   it 'does not hang SpaceAfterPunctuation and SpaceInsideBrackets' do
     create_file('example.rb', 'puts [1, ]')
     Timeout.timeout(10) do
-      expect(cli.run(%w(--auto-correct))).to eq(0)
+      expect(cli.run(%w[--auto-correct])).to eq(0)
     end
     expect($stderr.string).to eq('')
     expect(IO.read('example.rb')).to eq("puts [1]\n")
@@ -1007,7 +1007,7 @@ describe RuboCop::CLI, :isolated_environment do
     create_file('example.rb', 'puts "Hello", 123456')
     create_file('.rubocop.yml', ['Style/StringLiterals:',
                                  '  AutoCorrect: false'])
-    expect(cli.run(%w(--auto-correct))).to eq(1)
+    expect(cli.run(%w[--auto-correct])).to eq(1)
     expect($stderr.string).to eq('')
     expect(IO.read('example.rb')).to eq("puts \"Hello\", 123_456\n")
   end
@@ -1025,7 +1025,7 @@ describe RuboCop::CLI, :isolated_environment do
                   'Style/TrailingCommaInLiteral:',
                   '  EnforcedStyleForMultiline: consistent_comma'
                 ])
-    expect(cli.run(%w(--auto-correct))).to eq(1)
+    expect(cli.run(%w[--auto-correct])).to eq(1)
     expect($stderr.string).to eq('')
     expect(IO.read('example.rb')).to eq(['{foo: bar,',
                                          ' bar: baz,}',
@@ -1042,7 +1042,7 @@ describe RuboCop::CLI, :isolated_environment do
                                ''])
 
     expect($stderr.string).to eq('')
-    expect(cli.run(%w(--auto-correct))).to eq(0)
+    expect(cli.run(%w[--auto-correct])).to eq(0)
     expect(IO.read('example.rb')).to eq(['def method_a',
                                          '  do_something(a: 1)',
                                          'end',

--- a/spec/rubocop/cli/cli_options_spec.rb
+++ b/spec/rubocop/cli/cli_options_spec.rb
@@ -107,7 +107,7 @@ describe RuboCop::CLI, :isolated_environment do
         expect($stderr.string).to include('Unrecognized cop or department: .')
       end
 
-      %w(Syntax Lint/Syntax).each do |name|
+      %w[Syntax Lint/Syntax].each do |name|
         it "only checks syntax if #{name} is given" do
           create_file('example.rb', 'x ')
           expect(cli.run(['--only', name])).to eq(0)
@@ -115,7 +115,7 @@ describe RuboCop::CLI, :isolated_environment do
         end
       end
 
-      %w(Lint/UnneededDisable UnneededDisable).each do |name|
+      %w[Lint/UnneededDisable UnneededDisable].each do |name|
         it "exits with error if cop name #{name} is passed" do
           create_file('example.rb', ['if x== 0 ',
                                      "\ty",
@@ -251,7 +251,7 @@ describe RuboCop::CLI, :isolated_environment do
                                    '  ' + '#' * 100,
                                    "\ty",
                                    'end'])
-        expect(cli.run(%w(-f offenses --only Metrics example.rb))).to eq(1)
+        expect(cli.run(%w[-f offenses --only Metrics example.rb])).to eq(1)
         expect($stdout.string).to eq(['',
                                       '1  Metrics/LineLength',
                                       '--',
@@ -269,7 +269,7 @@ describe RuboCop::CLI, :isolated_environment do
                                    'end'])
         create_file('.rubocop.yml', ['Style/SpaceAroundOperators:',
                                      '  Enabled: false'])
-        expect(cli.run(%w(-f o --only Metrics,Style example.rb))).to eq(1)
+        expect(cli.run(%w[-f o --only Metrics,Style example.rb])).to eq(1)
         expect($stdout.string)
           .to eq(['',
                   '1  Metrics/LineLength',
@@ -303,7 +303,7 @@ describe RuboCop::CLI, :isolated_environment do
         expect($stderr.string).to include('Unrecognized cop or department: .')
       end
 
-      %w(Syntax Lint/Syntax).each do |name|
+      %w[Syntax Lint/Syntax].each do |name|
         it "exits with error if #{name} is given" do
           create_file('example.rb', 'x ')
           expect(cli.run(['--except', name])).to eq(2)
@@ -360,7 +360,7 @@ describe RuboCop::CLI, :isolated_environment do
     end
 
     context 'when several cops are given' do
-      %w(UnneededDisable Lint/UnneededDisable Lint).each do |cop_name|
+      %w[UnneededDisable Lint/UnneededDisable Lint].each do |cop_name|
         it "disables the given cops including #{cop_name}" do
           create_file('example.rb', ['if x== 100000000000000 ',
                                      "\ty",
@@ -662,7 +662,7 @@ describe RuboCop::CLI, :isolated_environment do
         end
       end
 
-      %w(html json).each do |format|
+      %w[html json].each do |format|
         context "when #{format} format is specified" do
           context 'and offenses come from the cache' do
             context 'and a message has binary encoding' do

--- a/spec/rubocop/cli_spec.rb
+++ b/spec/rubocop/cli_spec.rb
@@ -381,14 +381,14 @@ describe RuboCop::CLI, :isolated_environment do
 
   it 'finds a file with no .rb extension but has a shebang line' do
     create_file('example', ['#!/usr/bin/env ruby', 'x = 0', 'puts x'])
-    expect(cli.run(%w(--format simple))).to eq(0)
+    expect(cli.run(%w[--format simple])).to eq(0)
     expect($stdout.string)
       .to eq(['', '1 file inspected, no offenses detected', ''].join("\n"))
   end
 
   it 'does not register any offenses for an empty file' do
     create_file('example.rb', '')
-    expect(cli.run(%w(--format simple))).to eq(0)
+    expect(cli.run(%w[--format simple])).to eq(0)
     expect($stdout.string)
       .to eq(['', '1 file inspected, no offenses detected', ''].join("\n"))
   end
@@ -548,7 +548,7 @@ describe RuboCop::CLI, :isolated_environment do
                                           'Rails/ReadWriteAttribute:',
                                           '  Include:',
                                           '    - app/models/**/*.rb'])
-        expect(cli.run(%w(--format simple dir1 dir2))).to eq(1)
+        expect(cli.run(%w[--format simple dir1 dir2])).to eq(1)
         expect($stdout.string)
           .to eq(['== dir1/app/models/example1.rb ==',
                   'C:  1:  1: Prefer self[:attr] over read_attribute' \
@@ -610,7 +610,7 @@ describe RuboCop::CLI, :isolated_environment do
         # match.
         create_file('dir2/app/models/example4.rb', source)
 
-        expect(cli.run(%w(--format simple dir1 dir2))).to eq(1)
+        expect(cli.run(%w[--format simple dir1 dir2])).to eq(1)
         expect($stdout.string)
           .to eq(['== dir1/app/models/example1.rb ==',
                   'C:  1:  1: Prefer self[:attr] over read_attribute' \
@@ -634,7 +634,7 @@ describe RuboCop::CLI, :isolated_environment do
                                    '    - !ruby/regexp /regexp.rb\z/',
                                    '    - "exclude_*"',
                                    '    - "dir/*"'])
-      expect(cli.run(%w(--format simple))).to eq(0)
+      expect(cli.run(%w[--format simple])).to eq(0)
       expect($stdout.string)
         .to eq(['', '4 files inspected, no offenses detected',
                 ''].join("\n"))
@@ -669,7 +669,7 @@ describe RuboCop::CLI, :isolated_environment do
                                    '      rand < 0.8',
                                    '    end',
                                    'end'])
-        result = cli.run(%w(--format simple))
+        result = cli.run(%w[--format simple])
         expect($stderr.string).to eq('')
         expect(result).to eq(0)
         expect($stdout.string)
@@ -677,7 +677,7 @@ describe RuboCop::CLI, :isolated_environment do
                   ''].join("\n"))
       end
 
-      %w(class module).each do |parent|
+      %w[class module].each do |parent|
         it "registers offense for normal indentation in #{parent}" do
           create_file('.rubocop.yml', ['Style/IndentationConsistency:',
                                        '  EnforcedStyle: rails'])
@@ -704,7 +704,7 @@ describe RuboCop::CLI, :isolated_environment do
                                      '    rand < 0.8',
                                      '  end',
                                      'end'])
-          result = cli.run(%w(--format simple))
+          result = cli.run(%w[--format simple])
           expect($stderr.string).to eq('')
           expect(result).to eq(1)
           expect($stdout.string)
@@ -767,7 +767,7 @@ describe RuboCop::CLI, :isolated_environment do
       create_file('example.rb', ['x = 0', 'puts x'])
       create_file('.rubocop.yml', [])
 
-      expect(cli.run(%w(--format simple -c .rubocop.yml))).to eq(0)
+      expect(cli.run(%w[--format simple -c .rubocop.yml])).to eq(0)
       expect($stdout.string)
         .to eq(['', '1 file inspected, no offenses detected',
                 ''].join("\n"))
@@ -791,13 +791,13 @@ describe RuboCop::CLI, :isolated_environment do
       end
 
       context 'when no config file specified' do
-        let(:args) { %w(--format simple --force-default-config) }
+        let(:args) { %w[--format simple --force-default-config] }
         include_examples 'ignores config file'
       end
 
       context 'when config file specified with -c' do
         let(:args) do
-          %w(--format simple --force-default-config -c .rubocop.yml)
+          %w[--format simple --force-default-config -c .rubocop.yml]
         end
         include_examples 'ignores config file'
       end
@@ -814,7 +814,7 @@ describe RuboCop::CLI, :isolated_environment do
       create_file('dir/.rubocop.yml', ['AllCops:',
                                        '  DisplayCopNames: true'])
 
-      expect(cli.run(%w(--format simple))).to eq(1)
+      expect(cli.run(%w[--format simple])).to eq(1)
       expect($stdout.string)
         .to eq(['== example1.rb ==',
                 'C:  1:  6: Trailing whitespace detected.',
@@ -839,7 +839,7 @@ describe RuboCop::CLI, :isolated_environment do
 
       url = 'https://github.com/bbatsov/ruby-style-guide#no-trailing-whitespace'
 
-      expect(cli.run(%w(--format simple))).to eq(1)
+      expect(cli.run(%w[--format simple])).to eq(1)
       expect($stdout.string)
         .to eq(['== example1.rb ==',
                 'C:  1:  6: Trailing whitespace detected.',
@@ -877,7 +877,7 @@ describe RuboCop::CLI, :isolated_environment do
                                    '    - "**/*.rake"',
                                    '    - !ruby/regexp /regexp$/',
                                    '    - .dot1/**/*'])
-      expect(cli.run(%w(--format files))).to eq(1)
+      expect(cli.run(%w[--format files])).to eq(1)
       expect($stderr.string).to eq('')
       expect($stdout.string.split($RS).sort).to eq([abs('.dot1/file.rb'),
                                                     abs('example'),
@@ -894,7 +894,7 @@ describe RuboCop::CLI, :isolated_environment do
                                    '    - example.rb',
                                    '    - !ruby/regexp /regexp.rb$/',
                                    '    - "exclude_*"'])
-      expect(cli.run(%w(--format simple))).to eq(0)
+      expect(cli.run(%w[--format simple])).to eq(0)
       expect($stdout.string)
         .to eq(['', '0 files inspected, no offenses detected',
                 ''].join("\n"))
@@ -916,7 +916,7 @@ describe RuboCop::CLI, :isolated_environment do
       create_file('.rubocop.yml', ['AllCops:',
                                    '  Include:',
                                    '    - .other/**/*'])
-      expect(cli.run(%w(--format simple))).to eq(1)
+      expect(cli.run(%w[--format simple])).to eq(1)
       expect($stderr.string).to eq('')
       expect($stdout.string)
         .to eq(['== .other/example.rb ==',
@@ -931,7 +931,7 @@ describe RuboCop::CLI, :isolated_environment do
       create_file('dir/.rubocop.yml', ['AllCops:',
                                        '  Include:',
                                        '    - "*.ruby3"'])
-      expect(cli.run(%w(--format simple))).to eq(0)
+      expect(cli.run(%w[--format simple])).to eq(0)
       expect($stderr.string).to eq('')
       expect($stdout.string)
         .to eq(['',
@@ -947,7 +947,7 @@ describe RuboCop::CLI, :isolated_environment do
                                    '    - "*.dsl"',
                                    '  Exclude:',
                                    '    - example.rb'])
-      expect(cli.run(%w(--format simple .))).to eq(1)
+      expect(cli.run(%w[--format simple .])).to eq(1)
       expect($stdout.string)
         .to eq(['== special.dsl ==',
                 "C:  1:  9: Prefer single-quoted strings when you don't " \
@@ -960,7 +960,7 @@ describe RuboCop::CLI, :isolated_environment do
     # With rubinius 2.0.0.rc1 + rspec 2.13.1,
     # File.stub(:open).and_call_original causes SystemStackError.
     it 'does not read files in excluded list', broken: :rbx do
-      %w(rb.rb non-rb.ext without-ext).each do |filename|
+      %w[rb.rb non-rb.ext without-ext].each do |filename|
         create_file("example/ignored/#{filename}", '#' * 90)
       end
 
@@ -969,7 +969,7 @@ describe RuboCop::CLI, :isolated_environment do
                                            '    - ignored/**'])
       expect(File).not_to receive(:open).with(%r{/ignored/})
       allow(File).to receive(:open).and_call_original
-      expect(cli.run(%w(--format simple example))).to eq(0)
+      expect(cli.run(%w[--format simple example])).to eq(0)
       expect($stdout.string)
         .to eq(['', '0 files inspected, no offenses detected',
                 ''].join("\n"))
@@ -1136,13 +1136,13 @@ describe RuboCop::CLI, :isolated_environment do
     end
 
     it 'can have different config files in different directories' do
-      %w(src lib).each do |dir|
+      %w[src lib].each do |dir|
         create_file("example/#{dir}/example1.rb", '#' * 90)
       end
       create_file('example/src/.rubocop.yml', ['Metrics/LineLength:',
                                                '  Enabled: true',
                                                '  Max: 100'])
-      expect(cli.run(%w(--format simple example))).to eq(1)
+      expect(cli.run(%w[--format simple example])).to eq(1)
       expect($stdout.string).to eq(['== example/lib/example1.rb ==',
                                     'C:  1: 81: Line is too long. [90/80]',
                                     '',
@@ -1165,7 +1165,7 @@ describe RuboCop::CLI, :isolated_environment do
     end
 
     it 'can exclude directories relative to .rubocop.yml' do
-      %w(src etc/test etc/spec tmp/test tmp/spec).each do |dir|
+      %w[src etc/test etc/spec tmp/test tmp/spec].each do |dir|
         create_file("example/#{dir}/example1.rb", '#' * 90)
       end
 
@@ -1178,7 +1178,7 @@ describe RuboCop::CLI, :isolated_environment do
                                            '    - etc/**/*',
                                            '    - tmp/spec/**'])
 
-      expect(cli.run(%w(--format simple example))).to eq(1)
+      expect(cli.run(%w[--format simple example])).to eq(1)
       expect($stderr.string).to eq('')
       expect($stdout.string).to eq(['== example/tmp/test/example1.rb ==',
                                     'C:  1: 81: Line is too long. [90/80]',
@@ -1201,7 +1201,7 @@ describe RuboCop::CLI, :isolated_environment do
                    '  Exclude:',
                    '    - vendor/**/*'])
 
-      cli.run(%w(--format simple))
+      cli.run(%w[--format simple])
       expect($stdout.string)
         .to eq(['', '0 files inspected, no offenses detected',
                 ''].join("\n"))
@@ -1210,7 +1210,7 @@ describe RuboCop::CLI, :isolated_environment do
     it 'excludes the vendor directory by default' do
       create_file('vendor/ex.rb', '#' * 90)
 
-      cli.run(%w(--format simple))
+      cli.run(%w[--format simple])
       expect($stdout.string)
         .to eq(['', '0 files inspected, no offenses detected',
                 ''].join("\n"))
@@ -1233,7 +1233,7 @@ describe RuboCop::CLI, :isolated_environment do
                    '  Exclude:',
                    '    - vendor/**/*'])
 
-      cli.run(%w(--format simple))
+      cli.run(%w[--format simple])
       expect($stderr.string).to eq('')
       expect($stdout.string)
         .to eq(['', '0 files inspected, no offenses detected',
@@ -1260,7 +1260,7 @@ describe RuboCop::CLI, :isolated_environment do
                    '  Exclude:',
                    '    - vendor/**/*'])
 
-      cli.run(%w(--format simple))
+      cli.run(%w[--format simple])
       expect($stdout.string)
         .to eq(['', '0 files inspected, no offenses detected',
                 ''].join("\n"))
@@ -1273,7 +1273,7 @@ describe RuboCop::CLI, :isolated_environment do
                                            '  Enabled: true',
                                            '  Max: 100'])
 
-      expect(cli.run(%w(--format simple example))).to eq(1)
+      expect(cli.run(%w[--format simple example])).to eq(1)
       expect($stderr.string)
         .to eq(['Warning: unrecognized cop Style/LyneLenth found in ' +
                 abs('example/.rubocop.yml'),
@@ -1287,7 +1287,7 @@ describe RuboCop::CLI, :isolated_environment do
                                            '  Enabled: true',
                                            '  Min: 10'])
 
-      expect(cli.run(%w(--format simple example))).to eq(1)
+      expect(cli.run(%w[--format simple example])).to eq(1)
       expect($stderr.string)
         .to eq(['Warning: unrecognized parameter Metrics/LineLength:Min ' \
                 'found in ' + abs('example/.rubocop.yml'),
@@ -1299,7 +1299,7 @@ describe RuboCop::CLI, :isolated_environment do
       create_file('example/.rubocop.yml', ['Style/BracesAroundHashParameters:',
                                            '  EnforcedStyle: context'])
 
-      expect(cli.run(%w(--format simple example))).to eq(2)
+      expect(cli.run(%w[--format simple example])).to eq(2)
       expect($stderr.string)
         .to eq(["Error: invalid EnforcedStyle 'context' for " \
                 'Style/BracesAroundHashParameters found in ' +
@@ -1316,7 +1316,7 @@ describe RuboCop::CLI, :isolated_environment do
                                   '  Exclude:',
                                   '    - !ruby/regexp /example1\.rb$/'])
 
-      cli.run(%w(--format simple -c rubocop.yml))
+      cli.run(%w[--format simple -c rubocop.yml])
       expect($stdout.string)
         .to eq(['', '0 files inspected, no offenses detected',
                 ''].join("\n"))
@@ -1330,7 +1330,7 @@ describe RuboCop::CLI, :isolated_environment do
                                   '  Exclude:',
                                   '    - example/**'])
 
-      cli.run(%w(--format simple -c rubocop.yml))
+      cli.run(%w[--format simple -c rubocop.yml])
       expect($stdout.string)
         .to eq(['', '0 files inspected, no offenses detected',
                 ''].join("\n"))
@@ -1342,7 +1342,7 @@ describe RuboCop::CLI, :isolated_environment do
       create_file('rubocop.yml', ['Metrics/LineLength:',
                                   '  Severity: error'])
 
-      cli.run(%w(--format simple -c rubocop.yml))
+      cli.run(%w[--format simple -c rubocop.yml])
       expect($stdout.string)
         .to eq(['== example/example1.rb ==',
                 'E:  1: 81: Line is too long. [90/80]',
@@ -1358,7 +1358,7 @@ describe RuboCop::CLI, :isolated_environment do
       create_file('rubocop.yml', ['Metrics/LineLength:',
                                   '  Severity: superbad'])
 
-      cli.run(%w(--format simple -c rubocop.yml))
+      cli.run(%w[--format simple -c rubocop.yml])
       expect($stderr.string)
         .to eq(["Warning: Invalid severity 'superbad'. " \
                 'Valid severities are refactor, convention, ' \
@@ -1407,7 +1407,7 @@ describe RuboCop::CLI, :isolated_environment do
 
     it 'shows an error if the input file cannot be found' do
       begin
-        cli.run(%w(/tmp/not_a_file))
+        cli.run(%w[/tmp/not_a_file])
       rescue SystemExit => e
         expect(e.status).to eq(1)
         expect(e.message)

--- a/spec/rubocop/config_loader_spec.rb
+++ b/spec/rubocop/config_loader_spec.rb
@@ -259,7 +259,7 @@ describe RuboCop::ConfigLoader do
               'Max' => 77,
               'AllowHeredoc' => true,
               'AllowURI' => true,
-              'URISchemes' => %w(http https),
+              'URISchemes' => %w[http https],
               'IgnoreCopDirectives' => false,
               'IgnoredPatterns' => []
             },
@@ -340,7 +340,7 @@ describe RuboCop::ConfigLoader do
               'Max' => 120,             # overridden in line_length.yml
               'AllowHeredoc' => false,  # overridden in rubocop.yml
               'AllowURI' => true,
-              'URISchemes' => %w(http https),
+              'URISchemes' => %w[http https],
               'IgnoreCopDirectives' => false,
               'IgnoredPatterns' => []
             }
@@ -428,7 +428,7 @@ describe RuboCop::ConfigLoader do
 
       it 'returns values from the gem config with local overrides' do
         gem_class = Struct.new(:gem_dir)
-        %w(gemone gemtwo).each do |gem_name|
+        %w[gemone gemtwo].each do |gem_name|
           mock_spec = gem_class.new(gem_name)
           expect(Gem::Specification).to receive(:find_by_name)
             .at_least(:once).with(gem_name).and_return(mock_spec)

--- a/spec/rubocop/cop/commissioner_spec.rb
+++ b/spec/rubocop/cop/commissioner_spec.rb
@@ -20,16 +20,16 @@ describe RuboCop::Cop::Commissioner do
     context 'when a cop has no interest in the file' do
       it 'returns all offenses except the ones of the cop' do
         cops = []
-        cops << double('cop A', offenses: %w(foo), excluded_file?: false)
+        cops << double('cop A', offenses: %w[foo], excluded_file?: false)
         cops << double('cop B', excluded_file?: true)
-        cops << double('cop C', offenses: %w(baz), excluded_file?: false)
+        cops << double('cop C', offenses: %w[baz], excluded_file?: false)
         cops.each(&:as_null_object)
 
         commissioner = described_class.new(cops, [])
         source = []
         processed_source = parse_source(source)
 
-        expect(commissioner.investigate(processed_source)).to eq %w(foo baz)
+        expect(commissioner.investigate(processed_source)).to eq %w[foo baz]
       end
     end
 

--- a/spec/rubocop/cop/lint/circular_argument_reference_spec.rb
+++ b/spec/rubocop/cop/lint/circular_argument_reference_spec.rb
@@ -165,7 +165,7 @@ describe RuboCop::Cop::Lint::CircularArgumentReference do
             .to eq('Circular argument reference - `some_arg`.')
           expect(cop.offenses.last.message)
             .to eq('Circular argument reference - `other_arg`.')
-          expect(cop.highlights).to eq %w(some_arg other_arg)
+          expect(cop.highlights).to eq %w[some_arg other_arg]
         end
       end
     end

--- a/spec/rubocop/cop/lint/condition_position_spec.rb
+++ b/spec/rubocop/cop/lint/condition_position_spec.rb
@@ -3,7 +3,7 @@
 describe RuboCop::Cop::Lint::ConditionPosition do
   subject(:cop) { described_class.new }
 
-  %w(if unless while until).each do |keyword|
+  %w[if unless while until].each do |keyword|
     it 'registers an offense for condition on the next line' do
       inspect_source(cop,
                      [keyword,

--- a/spec/rubocop/cop/lint/debugger_spec.rb
+++ b/spec/rubocop/cop/lint/debugger_spec.rb
@@ -5,12 +5,12 @@ describe RuboCop::Cop::Lint::Debugger, :config do
 
   include_examples 'debugger', 'debugger', 'debugger'
   include_examples 'debugger', 'byebug', 'byebug'
-  include_examples 'debugger', 'pry binding', %w(binding.pry binding.remote_pry
-                                                 binding.pry_remote)
+  include_examples 'debugger', 'pry binding', %w[binding.pry binding.remote_pry
+                                                 binding.pry_remote]
   include_examples 'debugger',
-                   'capybara debug method', %w(save_and_open_page
+                   'capybara debug method', %w[save_and_open_page
                                                save_and_open_screenshot
-                                               save_screenshot)
+                                               save_screenshot]
   include_examples 'debugger', 'debugger with an argument', 'debugger foo'
   include_examples 'debugger', 'byebug with an argument', 'byebug foo'
   include_examples 'debugger',
@@ -24,9 +24,9 @@ describe RuboCop::Cop::Lint::Debugger, :config do
                     'save_screenshot foo']
   include_examples 'non-debugger', 'a non-pry binding', 'binding.pirate'
 
-  ALL_COMMANDS = %w(debugger byebug pry remote_pry pry_remote irb
+  ALL_COMMANDS = %w[debugger byebug pry remote_pry pry_remote irb
                     save_and_open_page save_and_open_screenshot
-                    save_screenshot).freeze
+                    save_screenshot].freeze
 
   ALL_COMMANDS.each do |src|
     include_examples 'non-debugger', "a #{src} in comments", "# #{src}"

--- a/spec/rubocop/cop/lint/duplicated_key_spec.rb
+++ b/spec/rubocop/cop/lint/duplicated_key_spec.rb
@@ -25,7 +25,7 @@ describe RuboCop::Cop::Lint::DuplicatedKey do
       inspect_source(cop, source)
       expect(cop.offenses.size).to eq(2)
       expect(cop.messages).to eq(['Duplicated key in hash literal.'] * 2)
-      expect(cop.highlights).to eq %w(veg fruit)
+      expect(cop.highlights).to eq %w[veg fruit]
     end
   end
 
@@ -38,7 +38,7 @@ describe RuboCop::Cop::Lint::DuplicatedKey do
       inspect_source(cop, source)
       expect(cop.offenses.size).to eq(2)
       expect(cop.messages).to eq(['Duplicated key in hash literal.'] * 2)
-      expect(cop.highlights).to eq %w(1 1)
+      expect(cop.highlights).to eq %w[1 1]
     end
   end
 

--- a/spec/rubocop/cop/lint/multiple_compare_spec.rb
+++ b/spec/rubocop/cop/lint/multiple_compare_spec.rb
@@ -26,7 +26,7 @@ describe RuboCop::Cop::Lint::MultipleCompare do
     end
   end
 
-  %w(< > <= >=).repeated_permutation(2) do |op1, op2|
+  %w[< > <= >=].repeated_permutation(2) do |op1, op2|
     include_examples 'Check to use two comparison operator', op1, op2
   end
 

--- a/spec/rubocop/cop/lint/non_local_exit_from_iterator_spec.rb
+++ b/spec/rubocop/cop/lint/non_local_exit_from_iterator_spec.rb
@@ -132,7 +132,7 @@ describe RuboCop::Cop::Lint::NonLocalExitFromIterator do
         expect(cop.offenses[1].message).to eq(message)
         expect(cop.offenses[1].severity.name).to eq(:warning)
         expect(cop.offenses[1].line).to eq(6)
-        expect(cop.highlights).to eq(%w(return return))
+        expect(cop.highlights).to eq(%w[return return])
       end
     end
 

--- a/spec/rubocop/cop/lint/percent_string_array_spec.rb
+++ b/spec/rubocop/cop/lint/percent_string_array_spec.rb
@@ -11,7 +11,7 @@ describe RuboCop::Cop::Lint::PercentStringArray do
   end
 
   context 'detecting quotes or commas in a %w/%W string' do
-    %w(w W).each do |char|
+    %w[w W].each do |char|
       it 'accepts tokens without quotes or commas' do
         inspect_source(cop, "%#{char}(foo bar baz)")
 

--- a/spec/rubocop/cop/lint/percent_symbol_array_spec.rb
+++ b/spec/rubocop/cop/lint/percent_symbol_array_spec.rb
@@ -11,7 +11,7 @@ describe RuboCop::Cop::Lint::PercentSymbolArray do
   end
 
   context 'detecting colons or commas in a %i/%I string' do
-    %w(i I).each do |char|
+    %w[i I].each do |char|
       it 'accepts tokens without colons or commas' do
         inspect_source(cop, "%#{char}(foo bar baz)")
 

--- a/spec/rubocop/cop/lint/safe_navigation_chain_spec.rb
+++ b/spec/rubocop/cop/lint/safe_navigation_chain_spec.rb
@@ -3,7 +3,7 @@
 describe RuboCop::Cop::Lint::SafeNavigationChain, :config do
   subject(:cop) { described_class.new(config) }
   let(:cop_config) do
-    { 'Whitelist' => %w(present? blank? try presence) }
+    { 'Whitelist' => %w[present? blank? try presence] }
   end
 
   shared_examples :accepts do |name, code|

--- a/spec/rubocop/cop/lint/underscore_prefixed_variable_name_spec.rb
+++ b/spec/rubocop/cop/lint/underscore_prefixed_variable_name_spec.rb
@@ -118,7 +118,7 @@ describe RuboCop::Cop::Lint::UnderscorePrefixedVariableName do
     end
   end
 
-  %w(super binding).each do |keyword|
+  %w[super binding].each do |keyword|
     context "in a method calling `#{keyword}` without arguments" do
       context 'when an underscore-prefixed argument is not used explicitly' do
         let(:source) { <<-END }

--- a/spec/rubocop/cop/lint/unneeded_disable_spec.rb
+++ b/spec/rubocop/cop/lint/unneeded_disable_spec.rb
@@ -207,7 +207,7 @@ describe RuboCop::Cop::Lint::UnneededDisable do
                 expect(cop.messages)
                   .to eq(['Unnecessary disabling of `Metrics/ClassLength`.',
                           'Unnecessary disabling of `Lint/Debugger`.'])
-                expect(cop.highlights).to eq(%w(ClassLength Debugger))
+                expect(cop.highlights).to eq(%w[ClassLength Debugger])
               end
             end
           end

--- a/spec/rubocop/cop/lint/unused_block_argument_spec.rb
+++ b/spec/rubocop/cop/lint/unused_block_argument_spec.rb
@@ -46,7 +46,7 @@ describe RuboCop::Cop::Lint::UnusedBlockArgument, :config do
             "You can omit all the arguments if you don't care about them."
           )
           expect(cop.offenses.first.line).to eq(2)
-          expect(cop.highlights).to eq(%w(key value))
+          expect(cop.highlights).to eq(%w[key value])
         end
       end
     end
@@ -126,7 +126,7 @@ describe RuboCop::Cop::Lint::UnusedBlockArgument, :config do
 
           )
           expect(cop.offenses.first.line).to eq(1)
-          expect(cop.highlights).to eq(%w(foo bar))
+          expect(cop.highlights).to eq(%w[foo bar])
         end
       end
 
@@ -259,7 +259,7 @@ describe RuboCop::Cop::Lint::UnusedBlockArgument, :config do
         it 'registers offenses' do
           expect(cop.offenses.size).to eq 2
           expect(cop.offenses.first.line).to eq(1)
-          expect(cop.highlights).to eq(%w(key value))
+          expect(cop.highlights).to eq(%w[key value])
         end
       end
     end
@@ -275,7 +275,7 @@ describe RuboCop::Cop::Lint::UnusedBlockArgument, :config do
         it 'registers an offense' do
           expect(cop.offenses.size).to eq(2)
           expect(cop.offenses.first.line).to eq(1)
-          expect(cop.highlights).to eq(%w(key value))
+          expect(cop.highlights).to eq(%w[key value])
         end
       end
     end

--- a/spec/rubocop/cop/lint/unused_method_argument_spec.rb
+++ b/spec/rubocop/cop/lint/unused_method_argument_spec.rb
@@ -202,7 +202,7 @@ describe RuboCop::Cop::Lint::UnusedMethodArgument, :config do
         it 'registers offenses' do
           expect(cop.offenses.size).to eq 2
           expect(cop.offenses.first.line).to eq(1)
-          expect(cop.highlights).to eq(%w(foo bar))
+          expect(cop.highlights).to eq(%w[foo bar])
         end
       end
     end

--- a/spec/rubocop/cop/lint/useless_access_modifier_spec.rb
+++ b/spec/rubocop/cop/lint/useless_access_modifier_spec.rb
@@ -200,7 +200,7 @@ describe RuboCop::Cop::Lint::UselessAccessModifier do
 
   context 'when only a constant or local variable is defined after the ' \
     'modifier' do
-    %w(CONSTANT some_var).each do |binding_name|
+    %w[CONSTANT some_var].each do |binding_name|
       let(:source) do
         [
           'class SomeClass',
@@ -542,7 +542,7 @@ describe RuboCop::Cop::Lint::UselessAccessModifier do
   end
 
   shared_examples 'conditionally defined method' do |keyword, modifier|
-    %w(if unless).each do |conditional_type|
+    %w[if unless].each do |conditional_type|
       it "doesn't register an offense for #{conditional_type}" do
         src = ["#{keyword} A",
                "  #{modifier}",
@@ -558,7 +558,7 @@ describe RuboCop::Cop::Lint::UselessAccessModifier do
   end
 
   shared_examples 'methods defined in an iteration' do |keyword, modifier|
-    %w(each map).each do |iteration_method|
+    %w[each map].each do |iteration_method|
       it "doesn't register an offense for #{iteration_method}" do
         src = ["#{keyword} A",
                "  #{modifier}",
@@ -585,7 +585,7 @@ describe RuboCop::Cop::Lint::UselessAccessModifier do
       expect(cop.offenses).to be_empty
     end
 
-    %w(lambda proc ->).each do |proc_type|
+    %w[lambda proc ->].each do |proc_type|
       it "doesn't register an offense if a #{proc_type} is passed" do
         src = ["#{keyword} A",
                "  #{modifier}",
@@ -862,23 +862,23 @@ describe RuboCop::Cop::Lint::UselessAccessModifier do
     end
   end
 
-  %w(protected private).each do |modifier|
+  %w[protected private].each do |modifier|
     it_behaves_like('method defined using class_eval', modifier)
     it_behaves_like('method defined using instance_eval', modifier)
   end
 
-  %w(Class Module Struct).each do |klass|
-    %w(protected private).each do |modifier|
+  %w[Class Module Struct].each do |klass|
+    %w[protected private].each do |modifier|
       it_behaves_like('def in new block', klass, modifier)
     end
   end
 
-  %w(module class).each do |keyword|
+  %w[module class].each do |keyword|
     it_behaves_like('at the top of the body', keyword)
     it_behaves_like('non-repeated visibility modifiers', keyword)
     it_behaves_like('unused visibility modifiers', keyword)
 
-    %w(public protected private).each do |modifier|
+    %w[public protected private].each do |modifier|
       it_behaves_like('repeated visibility modifiers', keyword, modifier)
       it_behaves_like('at the end of the body', keyword, modifier)
       it_behaves_like('nested in a begin..end block', keyword, modifier)

--- a/spec/rubocop/cop/lint/useless_assignment_spec.rb
+++ b/spec/rubocop/cop/lint/useless_assignment_spec.rb
@@ -262,7 +262,7 @@ describe RuboCop::Cop::Lint::UselessAssignment do
         .to eq('Useless assignment to variable - `foo`.')
       expect(cop.offenses[1].line).to eq(4)
 
-      expect(cop.highlights).to eq(%w(foo foo))
+      expect(cop.highlights).to eq(%w[foo foo])
     end
   end
 

--- a/spec/rubocop/cop/lint/void_spec.rb
+++ b/spec/rubocop/cop/lint/void_spec.rb
@@ -29,7 +29,7 @@ describe RuboCop::Cop::Lint::Void do
     end
   end
 
-  %w(var @var @@var VAR).each do |var|
+  %w[var @var @@var VAR].each do |var|
     it "registers an offense for void var #{var} if not on last line" do
       inspect_source(cop,
                      ["#{var} = 5",

--- a/spec/rubocop/cop/message_annotator_spec.rb
+++ b/spec/rubocop/cop/message_annotator_spec.rb
@@ -129,14 +129,14 @@ describe RuboCop::Cop::MessageAnnotator do
 
     it 'returns style guide url when it is specified' do
       config['Cop/Cop'] = { 'StyleGuide' => '#target_based_url' }
-      expect(urls).to eq(%w(http://example.org/styleguide#target_based_url))
+      expect(urls).to eq(%w[http://example.org/styleguide#target_based_url])
     end
 
     it 'returns reference url when it is specified' do
       config['Cop/Cop'] = {
         'Reference' => 'https://example.com/some_style_guide'
       }
-      expect(urls).to eq(%w(https://example.com/some_style_guide))
+      expect(urls).to eq(%w[https://example.com/some_style_guide])
     end
 
     it 'returns style guide and reference url when they are specified' do
@@ -144,7 +144,8 @@ describe RuboCop::Cop::MessageAnnotator do
         'StyleGuide' => '#target_based_url',
         'Reference' => 'https://example.com/some_style_guide'
       }
-      expect(urls).to eq(%w(http://example.org/styleguide#target_based_url https://example.com/some_style_guide))
+      expect(urls).to eq(%w[http://example.org/styleguide#target_based_url
+                            https://example.com/some_style_guide])
     end
   end
 end

--- a/spec/rubocop/cop/metrics/line_length_spec.rb
+++ b/spec/rubocop/cop/metrics/line_length_spec.rb
@@ -81,7 +81,7 @@ describe RuboCop::Cop::Metrics::LineLength, :config do
     context 'and an error other than URI::InvalidURIError is raised ' \
             'while validating an URI-ish string' do
       let(:cop_config) do
-        { 'Max' => 80, 'AllowURI' => true, 'URISchemes' => %w(LDAP) }
+        { 'Max' => 80, 'AllowURI' => true, 'URISchemes' => %w[LDAP] }
       end
 
       let(:source) { <<-END }
@@ -105,7 +105,7 @@ describe RuboCop::Cop::Metrics::LineLength, :config do
 
       context 'and the scheme has been configured' do
         let(:cop_config) do
-          { 'Max' => 80, 'AllowURI' => true, 'URISchemes' => %w(otherprotocol) }
+          { 'Max' => 80, 'AllowURI' => true, 'URISchemes' => %w[otherprotocol] }
         end
 
         it 'accepts the line' do
@@ -163,7 +163,7 @@ describe RuboCop::Cop::Metrics::LineLength, :config do
 
     context 'and only certain heredoc delimiters are whitelisted' do
       let(:cop_config) do
-        { 'Max' => 80, 'AllowHeredoc' => %w(SQL OK), 'IgnoredPatterns' => [] }
+        { 'Max' => 80, 'AllowHeredoc' => %w[SQL OK], 'IgnoredPatterns' => [] }
       end
 
       let(:source) { <<-END }

--- a/spec/rubocop/cop/offense_spec.rb
+++ b/spec/rubocop/cop/offense_spec.rb
@@ -42,7 +42,7 @@ describe RuboCop::Cop::Offense do
     expect(offense).to be_frozen
   end
 
-  %i(severity location message cop_name).each do |a|
+  %i[severity location message cop_name].each do |a|
     describe "##{a}" do
       it 'is frozen' do
         expect(offense.send(a)).to be_frozen
@@ -93,7 +93,7 @@ describe RuboCop::Cop::Offense do
       described_class.new(
         attrs[:sev],
         location(attrs[:line], attrs[:col],
-                 %w(aaaaaa bbbbbb cccccc dddddd eeeeee ffffff)),
+                 %w[aaaaaa bbbbbb cccccc dddddd eeeeee ffffff]),
         attrs[:mes],
         attrs[:cop]
       )

--- a/spec/rubocop/cop/performance/detect_spec.rb
+++ b/spec/rubocop/cop/performance/detect_spec.rb
@@ -16,7 +16,7 @@ describe RuboCop::Cop::Performance::Detect do
 
   # rspec will not let you use a variable assigned using let outside
   # of `it`
-  select_methods = %i(select find_all).freeze
+  select_methods = %i[select find_all].freeze
 
   select_methods.each do |method|
     it "registers an offense when first is called on #{method}" do

--- a/spec/rubocop/cop/performance/end_with_spec.rb
+++ b/spec/rubocop/cop/performance/end_with_spec.rb
@@ -19,7 +19,7 @@ describe RuboCop::Cop::Performance::EndWith do
       expect(new_source).to eq 'str.end_with?("\t")'
     end
 
-    %w(. $ ^ |).each do |str|
+    %w[. $ ^ |].each do |str|
       it "autocorrects #{method} /\\#{str}\\z/" do
         new_source = autocorrect_source(cop, "str#{method} /\\#{str}\\z/")
         expect(new_source).to eq "str.end_with?('#{str}')"
@@ -34,7 +34,7 @@ describe RuboCop::Cop::Performance::EndWith do
     # escapes like "\n"
     # note that "\b" is a literal backspace char in a double-quoted string...
     # but in a regex, it's an anchor on a word boundary
-    %w(a e f r t v).each do |str|
+    %w[a e f r t v].each do |str|
       it "autocorrects #{method} /\\#{str}\\z/" do
         new_source = autocorrect_source(cop, "str#{method} /\\#{str}\\z/")
         expect(new_source).to eq %{str.end_with?("\\#{str}")}
@@ -42,7 +42,7 @@ describe RuboCop::Cop::Performance::EndWith do
     end
 
     # character classes, anchors
-    %w(w W s S d D A Z z G b B h H R X S).each do |str|
+    %w[w W s S d D A Z z G b B h H R X S].each do |str|
       it "doesn't register an error for #{method} /\\#{str}\\z/" do
         inspect_source(cop, "str#{method} /\\#{str}\\z/")
         expect(cop.messages).to be_empty
@@ -50,7 +50,7 @@ describe RuboCop::Cop::Performance::EndWith do
     end
 
     # characters with no special meaning whatsoever
-    %w(i j l m o q y).each do |str|
+    %w[i j l m o q y].each do |str|
       it "autocorrects #{method} /\\#{str}\\z/" do
         new_source = autocorrect_source(cop, "str#{method} /\\#{str}\\z/")
         expect(new_source).to eq "str.end_with?('#{str}')"

--- a/spec/rubocop/cop/performance/redundant_merge_spec.rb
+++ b/spec/rubocop/cop/performance/redundant_merge_spec.rb
@@ -132,7 +132,7 @@ describe RuboCop::Cop::Performance::RedundantMerge, :config do
     end
   end
 
-  %w(if unless while until).each do |kw|
+  %w[if unless while until].each do |kw|
     context "when there is a modifier #{kw}, and more than 1 pair" do
       it "autocorrects it to an #{kw} block" do
         new_source = autocorrect_source(

--- a/spec/rubocop/cop/performance/regexp_match_spec.rb
+++ b/spec/rubocop/cop/performance/regexp_match_spec.rb
@@ -92,11 +92,11 @@ describe RuboCop::Cop::Performance::RegexpMatch, :config do
       end
     END2
 
-    %w(
+    %w[
       $& $' $` $~ $1 $2 $100
       $MATCH
       Regexp.last_match Regexp.last_match(1)
-    ).each do |var|
+    ].each do |var|
       include_examples :accepts, "#{name} in method with `#{var}`", <<-END
         def foo
           if #{cond}

--- a/spec/rubocop/cop/performance/start_with_spec.rb
+++ b/spec/rubocop/cop/performance/start_with_spec.rb
@@ -12,7 +12,7 @@ describe RuboCop::Cop::Performance::StartWith do
     # escapes like "\n"
     # note that "\b" is a literal backspace char in a double-quoted string...
     # but in a regex, it's an anchor on a word boundary
-    %w(a e f r t v).each do |str|
+    %w[a e f r t v].each do |str|
       it "autocorrects #{method} /\\A\\#{str}/" do
         new_source = autocorrect_source(cop, "str#{method} /\\A\\#{str}/")
         expect(new_source).to eq %{str.start_with?("\\#{str}")}
@@ -20,7 +20,7 @@ describe RuboCop::Cop::Performance::StartWith do
     end
 
     # regexp metacharacters
-    %w(. * ? $ ^ |).each do |str|
+    %w[. * ? $ ^ |].each do |str|
       it "autocorrects #{method} /\\A\\#{str}/" do
         new_source = autocorrect_source(cop, "str#{method} /\\A\\#{str}/")
         expect(new_source).to eq "str.start_with?('#{str}')"
@@ -33,7 +33,7 @@ describe RuboCop::Cop::Performance::StartWith do
     end
 
     # character classes, anchors
-    %w(w W s S d D A Z z G b B h H R X S).each do |str|
+    %w[w W s S d D A Z z G b B h H R X S].each do |str|
       it "doesn't register an error for #{method} /\\A\\#{str}/" do
         inspect_source(cop, "str#{method} /\\A\\#{str}/")
         expect(cop.messages).to be_empty
@@ -41,7 +41,7 @@ describe RuboCop::Cop::Performance::StartWith do
     end
 
     # characters with no special meaning whatsoever
-    %w(i j l m o q y).each do |str|
+    %w[i j l m o q y].each do |str|
       it "autocorrects #{method} /\\A\\#{str}/" do
         new_source = autocorrect_source(cop, "str#{method} /\\A\\#{str}/")
         expect(new_source).to eq "str.start_with?('#{str}')"

--- a/spec/rubocop/cop/performance/string_replacement_spec.rb
+++ b/spec/rubocop/cop/performance/string_replacement_spec.rb
@@ -128,8 +128,8 @@ describe RuboCop::Cop::Performance::StringReplacement do
         expect(cop.messages).to eq(['Use `delete` instead of `gsub`.'])
       end
 
-      %w(a b c ' " % ! = < > # & ; : ` ~ 1 2 3 - _ , \r \\\\ \y \u1234
-         \x65).each do |str|
+      %w[a b c ' " % ! = < > # & ; : ` ~ 1 2 3 - _ , \r \\\\ \y \u1234
+         \x65].each do |str|
         it "registers an offense when replacing #{str} with a literal" do
           inspect_source(cop, "'abc'.gsub(/#{str}/, 'a')")
           expect(cop.messages).to eq(['Use `tr` instead of `gsub`.'])

--- a/spec/rubocop/cop/rails/action_filter_spec.rb
+++ b/spec/rubocop/cop/rails/action_filter_spec.rb
@@ -3,7 +3,7 @@
 describe RuboCop::Cop::Rails::ActionFilter, :config do
   describe '::FILTER_METHODS' do
     it 'contains all of the filter methods' do
-      expect(described_class::FILTER_METHODS).to eq(%i(
+      expect(described_class::FILTER_METHODS).to eq(%i[
                                                       after_filter
                                                       append_after_filter
                                                       append_around_filter
@@ -17,13 +17,13 @@ describe RuboCop::Cop::Rails::ActionFilter, :config do
                                                       skip_around_filter
                                                       skip_before_filter
                                                       skip_filter
-                                                    ))
+                                                    ])
     end
   end
 
   describe '::ACTION_METHODS' do
     it 'contains all of the action methods' do
-      expect(described_class::ACTION_METHODS).to eq(%i(
+      expect(described_class::ACTION_METHODS).to eq(%i[
                                                       after_action
                                                       append_after_action
                                                       append_around_action
@@ -37,7 +37,7 @@ describe RuboCop::Cop::Rails::ActionFilter, :config do
                                                       skip_around_action
                                                       skip_before_action
                                                       skip_action_callback
-                                                    ))
+                                                    ])
     end
   end
 

--- a/spec/rubocop/cop/rails/date_spec.rb
+++ b/spec/rubocop/cop/rails/date_spec.rb
@@ -6,7 +6,7 @@ describe RuboCop::Cop::Rails::Date, :config do
   context 'when EnforcedStyle is "strict"' do
     let(:cop_config) { { 'EnforcedStyle' => 'strict' } }
 
-    %w(today current yesterday tomorrow).each do |day|
+    %w[today current yesterday tomorrow].each do |day|
       it "registers an offense for Date.#{day}" do
         inspect_source(cop, "Date.#{day}")
         expect(cop.offenses.size).to eq(1)
@@ -23,7 +23,7 @@ describe RuboCop::Cop::Rails::Date, :config do
       end
     end
 
-    %w(to_time to_time_in_current_zone).each do |method|
+    %w[to_time to_time_in_current_zone].each do |method|
       it "registers an offense for ##{method}" do
         inspect_source(cop, "date.#{method}")
         expect(cop.offenses.size).to eq(1)
@@ -77,7 +77,7 @@ describe RuboCop::Cop::Rails::Date, :config do
   context 'when EnforcedStyle is "flexible"' do
     let(:cop_config) { { 'EnforcedStyle' => 'flexible' } }
 
-    %w(current yesterday tomorrow).each do |day|
+    %w[current yesterday tomorrow].each do |day|
       it "accepts Date.#{day}" do
         inspect_source(cop, "Date.#{day}")
         expect(cop.offenses).to be_empty

--- a/spec/rubocop/cop/rails/dynamic_find_by_spec.rb
+++ b/spec/rubocop/cop/rails/dynamic_find_by_spec.rb
@@ -3,7 +3,7 @@
 describe RuboCop::Cop::Rails::DynamicFindBy, :config do
   subject(:cop) { described_class.new(config) }
   let(:cop_config) do
-    { 'Whitelist' => %w(find_by_sql) }
+    { 'Whitelist' => %w[find_by_sql] }
   end
 
   shared_examples 'register an offense and auto correct' do |message, corrected|

--- a/spec/rubocop/cop/rails/http_positional_arguments_spec.rb
+++ b/spec/rubocop/cop/rails/http_positional_arguments_spec.rb
@@ -132,7 +132,7 @@ describe RuboCop::Cop::Rails::HttpPositionalArguments do
       end
     end
 
-    %w(post get patch put delete).each do |keyword|
+    %w[post get patch put delete].each do |keyword|
       it 'does not register an offense when keyword' do
         source = "@user.#{keyword}.id = ''"
         inspect_source(cop, source)
@@ -405,7 +405,7 @@ describe RuboCop::Cop::Rails::HttpPositionalArguments do
       end
     end
 
-    %w(post get patch put delete).each do |keyword|
+    %w[post get patch put delete].each do |keyword|
       it 'does not register an offense when keyword' do
         source = "@user.#{keyword}.id = ''"
         inspect_source(cop, source)

--- a/spec/rubocop/cop/rails/output_spec.rb
+++ b/spec/rubocop/cop/rails/output_spec.rb
@@ -21,7 +21,7 @@ describe RuboCop::Cop::Rails::Output do
   end
 
   it 'does not record an offense for methods without arguments' do
-    source = %w(print pp puts)
+    source = %w[print pp puts]
     inspect_source(cop, source)
     expect(cop.offenses).to be_empty
   end

--- a/spec/rubocop/cop/rails/skips_model_validations_spec.rb
+++ b/spec/rubocop/cop/rails/skips_model_validations_spec.rb
@@ -2,7 +2,7 @@
 
 describe RuboCop::Cop::Rails::SkipsModelValidations, :config do
   cop_config = {
-    'Blacklist' => %w(decrement!
+    'Blacklist' => %w[decrement!
                       decrement_counter
                       increment!
                       increment_counter
@@ -12,7 +12,7 @@ describe RuboCop::Cop::Rails::SkipsModelValidations, :config do
                       update_attribute
                       update_column
                       update_columns
-                      update_counters)
+                      update_counters]
   }
 
   subject(:cop) { described_class.new(config) }
@@ -54,7 +54,7 @@ describe RuboCop::Cop::Rails::SkipsModelValidations, :config do
 
   context 'with `update_attribute` method in blacklist' do
     let(:cop_config) do
-      { 'Blacklist' => %w(update_attribute) }
+      { 'Blacklist' => %w[update_attribute] }
     end
 
     whitelist = cop_config['Blacklist'].reject do |val|

--- a/spec/rubocop/cop/rails/uniq_before_pluck_spec.rb
+++ b/spec/rubocop/cop/rails/uniq_before_pluck_spec.rb
@@ -67,7 +67,7 @@ describe RuboCop::Cop::Rails::UniqBeforePluck, :config do
                     "instance.assoc.#{method}.pluck(:id)"
   end
 
-  %w(uniq distinct).each do |method|
+  %w[uniq distinct].each do |method|
     context 'when the enforced mode is conservative' do
       let(:cop_config) do
         { 'EnforcedStyle' => 'conservative', 'AutoCorrect' => true }

--- a/spec/rubocop/cop/registry_spec.rb
+++ b/spec/rubocop/cop/registry_spec.rb
@@ -49,7 +49,7 @@ describe RuboCop::Cop::Registry do
   end
 
   it 'exposes cop departments' do
-    expect(registry.departments).to eql(%i(Lint Style Metrics RSpec Test))
+    expect(registry.departments).to eql(%i[Lint Style Metrics RSpec Test])
   end
 
   it 'can filter down to one type' do

--- a/spec/rubocop/cop/style/access_modifier_indentation_spec.rb
+++ b/spec/rubocop/cop/style/access_modifier_indentation_spec.rb
@@ -3,7 +3,7 @@
 describe RuboCop::Cop::Style::AccessModifierIndentation do
   subject(:cop) { described_class.new(config) }
   let(:config) do
-    c = cop_config.merge('SupportedStyles' => %w(indent outdent))
+    c = cop_config.merge('SupportedStyles' => %w[indent outdent])
     RuboCop::Config
       .new('Style/AccessModifierIndentation' => c,
            'Style/IndentationWidth' => { 'Width' => indentation_width })

--- a/spec/rubocop/cop/style/align_array_spec.rb
+++ b/spec/rubocop/cop/style/align_array_spec.rb
@@ -13,7 +13,7 @@ describe RuboCop::Cop::Style::AlignArray do
     expect(cop.messages).to eq(['Align the elements of an array ' \
                                 'literal if they span more than ' \
                                 'one line.'] * 2)
-    expect(cop.highlights).to eq(%w(b d))
+    expect(cop.highlights).to eq(%w[b d])
   end
 
   it 'accepts aligned array keys' do

--- a/spec/rubocop/cop/style/and_or_spec.rb
+++ b/spec/rubocop/cop/style/and_or_spec.rb
@@ -9,7 +9,7 @@ describe RuboCop::Cop::Style::AndOr, :config do
     subject(:cop) { described_class.new(config) }
     let(:cop_config) { cop_config }
 
-    %w(and or).each do |operator|
+    %w[and or].each do |operator|
       it "accepts \"#{operator}\" outside of conditional" do
         inspect_source(cop, "x = a + b #{operator} return x")
         expect(cop.offenses).to be_empty
@@ -46,7 +46,7 @@ describe RuboCop::Cop::Style::AndOr, :config do
       end
     end
 
-    %w(&& ||).each do |operator|
+    %w[&& ||].each do |operator|
       it "accepts #{operator} inside of conditional" do
         inspect_source(cop, "test if a #{operator} b")
         expect(cop.offenses).to be_empty

--- a/spec/rubocop/cop/style/block_delimiters_spec.rb
+++ b/spec/rubocop/cop/style/block_delimiters_spec.rb
@@ -32,9 +32,9 @@ describe RuboCop::Cop::Style::BlockDelimiters, :config do
   context 'Semantic style' do
     cop_config = {
       'EnforcedStyle' => 'semantic',
-      'ProceduralMethods' => %w(tap),
-      'FunctionalMethods' => %w(let),
-      'IgnoredMethods' => %w(lambda)
+      'ProceduralMethods' => %w[tap],
+      'FunctionalMethods' => %w[let],
+      'IgnoredMethods' => %w[lambda]
     }
 
     let(:cop_config) { cop_config }
@@ -285,7 +285,7 @@ describe RuboCop::Cop::Style::BlockDelimiters, :config do
   context 'line count-based style' do
     cop_config = {
       'EnforcedStyle' => 'line_count_based',
-      'IgnoredMethods' => %w(proc)
+      'IgnoredMethods' => %w[proc]
     }
 
     let(:cop_config) { cop_config }
@@ -417,7 +417,7 @@ describe RuboCop::Cop::Style::BlockDelimiters, :config do
   context 'braces for chaining style' do
     cop_config = {
       'EnforcedStyle' => 'braces_for_chaining',
-      'IgnoredMethods' => %w(proc)
+      'IgnoredMethods' => %w[proc]
     }
 
     let(:cop_config) { cop_config }

--- a/spec/rubocop/cop/style/command_literal_spec.rb
+++ b/spec/rubocop/cop/style/command_literal_spec.rb
@@ -4,7 +4,7 @@ describe RuboCop::Cop::Style::CommandLiteral, :config do
   subject(:cop) { described_class.new(config) }
   let(:config) do
     supported_styles = {
-      'SupportedStyles' => %w(backticks percent_x mixed)
+      'SupportedStyles' => %w[backticks percent_x mixed]
     }
     RuboCop::Config.new('Style/PercentLiteralDelimiters' =>
                           percent_literal_delimiters_config,

--- a/spec/rubocop/cop/style/comment_annotation_spec.rb
+++ b/spec/rubocop/cop/style/comment_annotation_spec.rb
@@ -3,7 +3,7 @@
 describe RuboCop::Cop::Style::CommentAnnotation, :config do
   subject(:cop) { described_class.new(config) }
   let(:cop_config) do
-    { 'Keywords' => %w(TODO FIXME OPTIMIZE HACK REVIEW) }
+    { 'Keywords' => %w[TODO FIXME OPTIMIZE HACK REVIEW] }
   end
 
   context 'missing colon' do
@@ -20,7 +20,7 @@ describe RuboCop::Cop::Style::CommentAnnotation, :config do
   end
 
   context 'with configured keyword' do
-    let(:cop_config) { { 'Keywords' => %w(ISSUE) } }
+    let(:cop_config) { { 'Keywords' => %w[ISSUE] } }
 
     it 'registers an offense for a missing colon after the word' do
       inspect_source(cop, '# ISSUE wrong order')
@@ -120,7 +120,7 @@ describe RuboCop::Cop::Style::CommentAnnotation, :config do
 
   context 'when a keyword is not in the configuration' do
     let(:cop_config) do
-      { 'Keywords' => %w(FIXME OPTIMIZE HACK REVIEW) }
+      { 'Keywords' => %w[FIXME OPTIMIZE HACK REVIEW] }
     end
 
     it 'accepts the word without colon' do

--- a/spec/rubocop/cop/style/conditional_assignment_assign_in_condition_spec.rb
+++ b/spec/rubocop/cop/style/conditional_assignment_assign_in_condition_spec.rb
@@ -553,8 +553,8 @@ describe RuboCop::Cop::Style::ConditionalAssignment do
                             'SingleLineConditionsOnly' => true,
                             'IncludeTernaryExpressions' => true,
                             'EnforcedStyle' => 'assign_inside_condition',
-                            'SupportedStyles' => %w(assign_to_condition
-                                                    assign_inside_condition)
+                            'SupportedStyles' => %w[assign_to_condition
+                                                    assign_inside_condition]
                           },
                           'Lint/EndAlignment' => {
                             'EnforcedStyleAlignWith' => 'keyword',
@@ -744,8 +744,8 @@ describe RuboCop::Cop::Style::ConditionalAssignment do
                             'SingleLineConditionsOnly' => false,
                             'IncludeTernaryExpressions' => true,
                             'EnforcedStyle' => 'assign_inside_condition',
-                            'SupportedStyles' => %w(assign_to_condition
-                                                    assign_inside_condition)
+                            'SupportedStyles' => %w[assign_to_condition
+                                                    assign_inside_condition]
                           },
                           'Lint/EndAlignment' => {
                             'EnforcedStyleAlignWith' => 'keyword',
@@ -997,8 +997,8 @@ describe RuboCop::Cop::Style::ConditionalAssignment do
                             'SingleLineConditionsOnly' => true,
                             'IncludeTernaryExpressions' => false,
                             'EnforcedStyle' => 'assign_inside_condition',
-                            'SupportedStyles' => %w(assign_to_condition
-                                                    assign_inside_condition)
+                            'SupportedStyles' => %w[assign_to_condition
+                                                    assign_inside_condition]
                           },
                           'Lint/EndAlignment' => {
                             'EnforcedStyleAlignWith' => 'keyword',

--- a/spec/rubocop/cop/style/conditional_assignment_assign_to_condition_spec.rb
+++ b/spec/rubocop/cop/style/conditional_assignment_assign_to_condition_spec.rb
@@ -8,8 +8,8 @@ describe RuboCop::Cop::Style::ConditionalAssignment do
                           'SingleLineConditionsOnly' => true,
                           'IncludeTernaryExpressions' => true,
                           'EnforcedStyle' => 'assign_to_condition',
-                          'SupportedStyles' => %w(assign_to_condition
-                                                  assign_inside_condition)
+                          'SupportedStyles' => %w[assign_to_condition
+                                                  assign_inside_condition]
                         },
                         'Lint/EndAlignment' => {
                           'EnforcedStyleAlignWith' => 'keyword',
@@ -1560,8 +1560,8 @@ describe RuboCop::Cop::Style::ConditionalAssignment do
                             'SingleLineConditionsOnly' => false,
                             'IncludeTernaryExpressions' => true,
                             'EnforcedStyle' => 'assign_to_condition',
-                            'SupportedStyles' => %w(assign_to_condition
-                                                    assign_inside_condition)
+                            'SupportedStyles' => %w[assign_to_condition
+                                                    assign_inside_condition]
                           },
                           'Lint/EndAlignment' => {
                             'EnforcedStyleAlignWith' => 'keyword',
@@ -2100,8 +2100,8 @@ describe RuboCop::Cop::Style::ConditionalAssignment do
                             'SingleLineConditionsOnly' => true,
                             'IncludeTernaryExpressions' => false,
                             'EnforcedStyle' => 'assign_to_condition',
-                            'SupportedStyles' => %w(assign_to_condition
-                                                    assign_inside_condition)
+                            'SupportedStyles' => %w[assign_to_condition
+                                                    assign_inside_condition]
                           },
                           'Lint/EndAlignment' => {
                             'EnforcedStyleAlignWith' => 'keyword',

--- a/spec/rubocop/cop/style/documentation_method_spec.rb
+++ b/spec/rubocop/cop/style/documentation_method_spec.rb
@@ -31,7 +31,7 @@ describe RuboCop::Cop::Style::DocumentationMethod, :config do
   let(:config) do
     RuboCop::Config.new(
       'Style/CommentAnnotation' => {
-        'Keywords' => %w(TODO FIXME OPTIMIZE HACK REVIEW)
+        'Keywords' => %w[TODO FIXME OPTIMIZE HACK REVIEW]
       },
       'Style/DocumentationMethod' => {
         'RequireForNonPublicMethods' => require_for_non_public_methods

--- a/spec/rubocop/cop/style/documentation_spec.rb
+++ b/spec/rubocop/cop/style/documentation_spec.rb
@@ -4,7 +4,7 @@ describe RuboCop::Cop::Style::Documentation do
   subject(:cop) { described_class.new(config) }
   let(:config) do
     RuboCop::Config.new('Style/CommentAnnotation' => {
-                          'Keywords' => %w(TODO FIXME OPTIMIZE HACK REVIEW)
+                          'Keywords' => %w[TODO FIXME OPTIMIZE HACK REVIEW]
                         })
   end
 
@@ -201,7 +201,7 @@ describe RuboCop::Cop::Style::Documentation do
   end
 
   context 'sparse and trailing comments' do
-    %w(class module).each do |keyword|
+    %w[class module].each do |keyword|
       it "ignores comments after #{keyword} node end" do
         inspect_source(cop,
                        ['module TestModule',
@@ -229,7 +229,7 @@ describe RuboCop::Cop::Style::Documentation do
   end
 
   context 'with # :nodoc:' do
-    %w(class module).each do |keyword|
+    %w[class module].each do |keyword|
       it "accepts non-namespace #{keyword} without documentation" do
         inspect_source(cop,
                        ["#{keyword} Test #:nodoc:",

--- a/spec/rubocop/cop/style/each_with_object_spec.rb
+++ b/spec/rubocop/cop/style/each_with_object_spec.rb
@@ -17,7 +17,7 @@ describe RuboCop::Cop::Style::EachWithObject do
     expect(cop.messages)
       .to eq(['Use `each_with_object` instead of `inject`.',
               'Use `each_with_object` instead of `reduce`.'])
-    expect(cop.highlights).to eq(%w(inject reduce))
+    expect(cop.highlights).to eq(%w[inject reduce])
   end
 
   it 'correctly autocorrects' do

--- a/spec/rubocop/cop/style/empty_else_spec.rb
+++ b/spec/rubocop/cop/style/empty_else_spec.rb
@@ -11,7 +11,7 @@ describe RuboCop::Cop::Style::EmptyElse do
       end
     end
 
-    %w(both if case).each do |missing_else_style|
+    %w[both if case].each do |missing_else_style|
       context "MissingElse is #{missing_else_style}" do
         let(:missing_else_config) do
           { 'Enabled' => true,
@@ -48,7 +48,7 @@ describe RuboCop::Cop::Style::EmptyElse do
     let(:config) do
       RuboCop::Config.new('Style/EmptyElse' => {
                             'EnforcedStyle' => 'empty',
-                            'SupportedStyles' => %w(empty nil both)
+                            'SupportedStyles' => %w[empty nil both]
                           },
                           'Style/MissingElse' => missing_else_config)
     end
@@ -170,7 +170,7 @@ describe RuboCop::Cop::Style::EmptyElse do
     let(:config) do
       RuboCop::Config.new('Style/EmptyElse' => {
                             'EnforcedStyle' => 'nil',
-                            'SupportedStyles' => %w(empty nil both)
+                            'SupportedStyles' => %w[empty nil both]
                           },
                           'Style/MissingElse' => missing_else_config)
     end
@@ -359,7 +359,7 @@ describe RuboCop::Cop::Style::EmptyElse do
     let(:config) do
       RuboCop::Config.new('Style/EmptyElse' => {
                             'EnforcedStyle' => 'both',
-                            'SupportedStyles' => %w(empty nil both)
+                            'SupportedStyles' => %w[empty nil both]
                           },
                           'Style/MissingElse' => missing_else_config)
     end

--- a/spec/rubocop/cop/style/empty_lines_around_access_modifier_spec.rb
+++ b/spec/rubocop/cop/style/empty_lines_around_access_modifier_spec.rb
@@ -3,7 +3,7 @@
 describe RuboCop::Cop::Style::EmptyLinesAroundAccessModifier do
   subject(:cop) { described_class.new }
 
-  %w(private protected public module_function).each do |access_modifier|
+  %w[private protected public module_function].each do |access_modifier|
     it "requires blank line before #{access_modifier}" do
       inspect_source(cop,
                      ['class Test',

--- a/spec/rubocop/cop/style/empty_lines_around_block_body_spec.rb
+++ b/spec/rubocop/cop/style/empty_lines_around_block_body_spec.rb
@@ -4,7 +4,7 @@ describe RuboCop::Cop::Style::EmptyLinesAroundBlockBody, :config do
   subject(:cop) { described_class.new(config) }
 
   # Test blocks using both {} and do..end
-  [%w({ }), %w(do end)].each do |open, close|
+  [%w[{ }], %w[do end]].each do |open, close|
     context "when EnforcedStyle is no_empty_lines for #{open} #{close} block" do
       let(:cop_config) { { 'EnforcedStyle' => 'no_empty_lines' } }
 

--- a/spec/rubocop/cop/style/file_name_spec.rb
+++ b/spec/rubocop/cop/style/file_name_spec.rb
@@ -119,7 +119,7 @@ describe RuboCop::Cop::Style::FileName do
     end
 
     context 'on a file which defines no class or module at all' do
-      %w(lib src test spec).each do |dir|
+      %w[lib src test spec].each do |dir|
         context "under #{dir}" do
           let(:filename) { "/some/dir/#{dir}/file/test_case.rb" }
 
@@ -166,7 +166,7 @@ describe RuboCop::Cop::Style::FileName do
     end
 
     shared_examples 'matching module or class' do
-      %w(lib src test spec).each do |dir|
+      %w[lib src test spec].each do |dir|
         context "in a matching directory under #{dir}" do
           let(:filename) { "/some/dir/#{dir}/a/b.rb" }
 

--- a/spec/rubocop/cop/style/first_parameter_indentation_spec.rb
+++ b/spec/rubocop/cop/style/first_parameter_indentation_spec.rb
@@ -7,8 +7,8 @@ describe RuboCop::Cop::Style::FirstParameterIndentation do
       .new('Style/FirstParameterIndentation' => {
              'EnforcedStyle' => style,
              'SupportedStyles' =>
-               %w(consistent special_for_inner_method_call
-                  special_for_inner_method_call_in_parentheses)
+               %w[consistent special_for_inner_method_call
+                  special_for_inner_method_call_in_parentheses]
            },
            'Style/IndentationWidth' => { 'Width' => indentation_width })
   end
@@ -217,8 +217,8 @@ describe RuboCop::Cop::Style::FirstParameterIndentation do
           .new('Style/FirstParameterIndentation' => {
                  'EnforcedStyle' => style,
                  'SupportedStyles' =>
-                   %w(consistent special_for_inner_method_call
-                      special_for_inner_method_call_in_parentheses),
+                   %w[consistent special_for_inner_method_call
+                      special_for_inner_method_call_in_parentheses],
                  'IndentationWidth' => 4
                },
                'Style/IndentationWidth' => { 'Width' => 2 })

--- a/spec/rubocop/cop/style/guard_clause_spec.rb
+++ b/spec/rubocop/cop/style/guard_clause_spec.rb
@@ -23,7 +23,7 @@ describe RuboCop::Cop::Style::GuardClause, :config do
       expect(cop.messages)
         .to eq(['Use a guard clause instead of wrapping ' \
                 'the code inside a conditional expression.'] * 2)
-      expect(cop.highlights).to eq(%w(if unless))
+      expect(cop.highlights).to eq(%w[if unless])
     end
 
     it 'reports an offense if method body is if / unless without else' do
@@ -44,7 +44,7 @@ describe RuboCop::Cop::Style::GuardClause, :config do
       expect(cop.messages)
         .to eq(['Use a guard clause instead of wrapping ' \
                 'the code inside a conditional expression.'] * 2)
-      expect(cop.highlights).to eq(%w(if unless))
+      expect(cop.highlights).to eq(%w[if unless])
     end
 
     it 'reports an offense if method body ends with if / unless without else' do
@@ -67,7 +67,7 @@ describe RuboCop::Cop::Style::GuardClause, :config do
       expect(cop.messages)
         .to eq(['Use a guard clause instead of wrapping ' \
                 'the code inside a conditional expression.'] * 2)
-      expect(cop.highlights).to eq(%w(if unless))
+      expect(cop.highlights).to eq(%w[if unless])
     end
   end
 
@@ -177,7 +177,7 @@ describe RuboCop::Cop::Style::GuardClause, :config do
       expect(cop.messages)
         .to eq(['Use a guard clause instead of wrapping ' \
                 'the code inside a conditional expression.'] * 2)
-      expect(cop.highlights).to eq(%w(if unless))
+      expect(cop.highlights).to eq(%w[if unless])
     end
   end
 

--- a/spec/rubocop/cop/style/hash_syntax_spec.rb
+++ b/spec/rubocop/cop/style/hash_syntax_spec.rb
@@ -18,7 +18,7 @@ describe RuboCop::Cop::Style::HashSyntax, :config do
       let(:cop_config) do
         {
           'EnforcedStyle'   => 'ruby19',
-          'SupportedStyles' => %w(ruby19 hash_rockets),
+          'SupportedStyles' => %w[ruby19 hash_rockets],
           'UseHashRocketsWithSymbolValues' => false,
           'PreferHashRocketsForNonAlnumEndingSymbols' => false
         }.merge(cop_config_overrides)
@@ -143,7 +143,7 @@ describe RuboCop::Cop::Style::HashSyntax, :config do
                             },
                             'Style/HashSyntax' => {
                               'EnforcedStyle'   => 'ruby19',
-                              'SupportedStyles' => %w(ruby19 hash_rockets),
+                              'SupportedStyles' => %w[ruby19 hash_rockets],
                               'UseHashRocketsWithSymbolValues' => false
                             },
                             'Style/SpaceAroundOperators' => {
@@ -161,7 +161,7 @@ describe RuboCop::Cop::Style::HashSyntax, :config do
       let(:config) do
         RuboCop::Config.new('Style/HashSyntax' => {
                               'EnforcedStyle' => 'ruby19',
-                              'SupportedStyles' => %w(ruby19 hash_rockets),
+                              'SupportedStyles' => %w[ruby19 hash_rockets],
                               'UseHashRocketsWithSymbolValues' => true
                             })
       end
@@ -242,7 +242,7 @@ describe RuboCop::Cop::Style::HashSyntax, :config do
     let(:cop_config) do
       {
         'EnforcedStyle' => 'hash_rockets',
-        'SupportedStyles' => %w(ruby19 hash_rockets),
+        'SupportedStyles' => %w[ruby19 hash_rockets],
         'UseHashRocketsWithSymbolValues' => false
       }
     end
@@ -288,7 +288,7 @@ describe RuboCop::Cop::Style::HashSyntax, :config do
       let(:cop_config) do
         {
           'EnforcedStyle' => 'hash_rockets',
-          'SupportedStyles' => %w(ruby19 hash_rockets),
+          'SupportedStyles' => %w[ruby19 hash_rockets],
           'UseHashRocketsWithSymbolValues' => true
         }
       end

--- a/spec/rubocop/cop/style/implicit_runtime_error_spec.rb
+++ b/spec/rubocop/cop/style/implicit_runtime_error_spec.rb
@@ -3,7 +3,7 @@
 describe RuboCop::Cop::Style::ImplicitRuntimeError do
   subject(:cop) { described_class.new }
 
-  %w(raise fail).each do |method|
+  %w[raise fail].each do |method|
     it "registers an offense for #{method} 'message'" do
       inspect_source(cop, "#{method} 'message'")
       expect(cop.offenses.size).to eq 1

--- a/spec/rubocop/cop/style/indent_array_spec.rb
+++ b/spec/rubocop/cop/style/indent_array_spec.rb
@@ -4,8 +4,8 @@ describe RuboCop::Cop::Style::IndentArray do
   subject(:cop) { described_class.new(config) }
   let(:config) do
     supported_styles = {
-      'SupportedStyles' => %w(special_inside_parentheses consistent
-                              align_brackets)
+      'SupportedStyles' => %w[special_inside_parentheses consistent
+                              align_brackets]
     }
     RuboCop::Config.new('Style/IndentArray' =>
                         cop_config.merge(supported_styles).merge(

--- a/spec/rubocop/cop/style/indent_hash_spec.rb
+++ b/spec/rubocop/cop/style/indent_hash_spec.rb
@@ -4,8 +4,8 @@ describe RuboCop::Cop::Style::IndentHash do
   subject(:cop) { described_class.new(config) }
   let(:config) do
     supported_styles = {
-      'SupportedStyles' => %w(special_inside_parentheses consistent
-                              align_braces)
+      'SupportedStyles' => %w[special_inside_parentheses consistent
+                              align_braces]
     }
     RuboCop::Config.new('Style/AlignHash' => align_hash_config,
                         'Style/IndentHash' =>

--- a/spec/rubocop/cop/style/infinite_loop_spec.rb
+++ b/spec/rubocop/cop/style/infinite_loop_spec.rb
@@ -17,7 +17,7 @@ describe RuboCop::Cop::Style::InfiniteLoop do
     end
   end
 
-  %w(false nil).each do |lit|
+  %w[false nil].each do |lit|
     it "registers an offense for a until loop with #{lit} as condition" do
       inspect_source(cop,
                      ["until #{lit}",

--- a/spec/rubocop/cop/style/method_call_with_args_parentheses_spec.rb
+++ b/spec/rubocop/cop/style/method_call_with_args_parentheses_spec.rb
@@ -3,7 +3,7 @@
 describe RuboCop::Cop::Style::MethodCallWithArgsParentheses, :config do
   subject(:cop) { described_class.new(config) }
   let(:cop_config) do
-    { 'IgnoredMethods' => %w(puts) }
+    { 'IgnoredMethods' => %w[puts] }
   end
 
   it 'accepts no parens in method call without args' do

--- a/spec/rubocop/cop/style/method_name_spec.rb
+++ b/spec/rubocop/cop/style/method_name_spec.rb
@@ -43,7 +43,7 @@ describe RuboCop::Cop::Style::MethodName, :config do
       expect(cop.offenses).to be_empty
     end
 
-    %w(class module).each do |kind|
+    %w[class module].each do |kind|
       it "accepts class emitter method in a #{kind}" do
         inspect_source(cop, ["#{kind} Sequel",
                              '  def self.Model(source)',

--- a/spec/rubocop/cop/style/missing_else_spec.rb
+++ b/spec/rubocop/cop/style/missing_else_spec.rb
@@ -8,7 +8,7 @@ describe RuboCop::Cop::Style::MissingElse do
       RuboCop::Config.new('Style/MissingElse' => {
                             'Enabled' => true,
                             'EnforcedStyle' => 'both',
-                            'SupportedStyles' => %w(if case both)
+                            'SupportedStyles' => %w[if case both]
                           },
                           'Style/UnlessElse' => { 'Enabled' => true })
     end
@@ -111,7 +111,7 @@ describe RuboCop::Cop::Style::MissingElse do
       RuboCop::Config.new('Style/MissingElse' => {
                             'Enabled' => true,
                             'EnforcedStyle' => 'both',
-                            'SupportedStyles' => %w(if case both)
+                            'SupportedStyles' => %w[if case both]
                           },
                           'Style/UnlessElse' => { 'Enabled' => false })
     end
@@ -212,7 +212,7 @@ describe RuboCop::Cop::Style::MissingElse do
 
   context 'EmptyElse enabled and set to warn on empty' do
     let(:config) do
-      styles = %w(if case both)
+      styles = %w[if case both]
       RuboCop::Config.new('Style/MissingElse' => {
                             'Enabled' => true,
                             'EnforcedStyle' => 'both',
@@ -222,7 +222,7 @@ describe RuboCop::Cop::Style::MissingElse do
                           'Style/EmptyElse' => {
                             'Enabled' => true,
                             'EnforcedStyle' => 'empty',
-                            'SupportedStyles' => %w(empty nil both)
+                            'SupportedStyles' => %w[empty nil both]
                           })
     end
 
@@ -330,7 +330,7 @@ describe RuboCop::Cop::Style::MissingElse do
 
   context 'EmptyElse enabled and set to warn on nil' do
     let(:config) do
-      styles = %w(if case both)
+      styles = %w[if case both]
       RuboCop::Config.new('Style/MissingElse' => {
                             'Enabled' => true,
                             'EnforcedStyle' => 'both',
@@ -340,7 +340,7 @@ describe RuboCop::Cop::Style::MissingElse do
                           'Style/EmptyElse' => {
                             'Enabled' => true,
                             'EnforcedStyle' => 'nil',
-                            'SupportedStyles' => %w(empty nil both)
+                            'SupportedStyles' => %w[empty nil both]
                           })
     end
 
@@ -440,7 +440,7 @@ describe RuboCop::Cop::Style::MissingElse do
 
   context 'configured to warn only on empty if' do
     let(:config) do
-      styles = %w(if case both)
+      styles = %w[if case both]
       RuboCop::Config.new('Style/MissingElse' => {
                             'Enabled' => true,
                             'EnforcedStyle' => 'if',
@@ -450,7 +450,7 @@ describe RuboCop::Cop::Style::MissingElse do
                           'Style/EmptyElse' => {
                             'Enabled' => true,
                             'EnforcedStyle' => 'nil',
-                            'SupportedStyles' => %w(empty nil both)
+                            'SupportedStyles' => %w[empty nil both]
                           })
     end
 
@@ -549,7 +549,7 @@ describe RuboCop::Cop::Style::MissingElse do
 
   context 'configured to warn only on empty case' do
     let(:config) do
-      styles = %w(if case both)
+      styles = %w[if case both]
       RuboCop::Config.new('Style/MissingElse' => {
                             'Enabled' => true,
                             'EnforcedStyle' => 'case',
@@ -559,7 +559,7 @@ describe RuboCop::Cop::Style::MissingElse do
                           'Style/EmptyElse' => {
                             'Enabled' => true,
                             'EnforcedStyle' => 'nil',
-                            'SupportedStyles' => %w(empty nil both)
+                            'SupportedStyles' => %w[empty nil both]
                           })
     end
 

--- a/spec/rubocop/cop/style/multiline_assignment_layout_spec.rb
+++ b/spec/rubocop/cop/style/multiline_assignment_layout_spec.rb
@@ -2,7 +2,7 @@
 
 describe RuboCop::Cop::Style::MultilineAssignmentLayout, :config do
   subject(:cop) { described_class.new(config) }
-  let(:supported_types) { %w(if) }
+  let(:supported_types) { %w[if] }
 
   let(:cop_config) do
     {
@@ -39,7 +39,7 @@ describe RuboCop::Cop::Style::MultilineAssignmentLayout, :config do
     end
 
     context 'configured supported types' do
-      let(:supported_types) { %w(array) }
+      let(:supported_types) { %w[array] }
 
       it 'allows supported types to be configured' do
         inspect_source(cop, ['a, b = 4,',
@@ -103,7 +103,7 @@ describe RuboCop::Cop::Style::MultilineAssignmentLayout, :config do
     end
 
     context 'configured supported types' do
-      let(:supported_types) { %w(array) }
+      let(:supported_types) { %w[array] }
 
       it 'allows supported types to be configured' do
         inspect_source(cop, ['a, b =',

--- a/spec/rubocop/cop/style/multiline_method_call_indentation_spec.rb
+++ b/spec/rubocop/cop/style/multiline_method_call_indentation_spec.rb
@@ -128,7 +128,7 @@ describe RuboCop::Cop::Style::MultilineMethodCallIndentation do
       expect(cop.messages)
         .to eq(['Use 2 (not 3) spaces for indenting an expression spanning ' \
                 'multiple lines.'] * 2)
-      expect(cop.highlights).to eq(%w(b d))
+      expect(cop.highlights).to eq(%w[b d])
     end
 
     it 'registers an offense for extra indentation of third line' do
@@ -591,7 +591,7 @@ describe RuboCop::Cop::Style::MultilineMethodCallIndentation do
       expect(cop.messages)
         .to eq(['Indent `b` 2 spaces more than `a` on line 1.',
                 'Indent `d` 2 spaces more than `c` on line 3.'])
-      expect(cop.highlights).to eq(%w(b d))
+      expect(cop.highlights).to eq(%w[b d])
     end
 
     it 'registers an offense for extra indentation of third line' do
@@ -701,10 +701,10 @@ describe RuboCop::Cop::Style::MultilineMethodCallIndentation do
     end
 
     [
-      %w(an if),
-      %w(an unless),
-      %w(a while),
-      %w(an until)
+      %w[an if],
+      %w[an unless],
+      %w[a while],
+      %w[an until]
     ].each do |article, keyword|
       it "accepts double indentation of #{keyword} condition" do
         inspect_source(cop,
@@ -738,7 +738,7 @@ describe RuboCop::Cop::Style::MultilineMethodCallIndentation do
       end
     end
 
-    %w(unless if).each do |keyword|
+    %w[unless if].each do |keyword|
       it "accepts special indentation of return #{keyword} condition" do
         inspect_source(cop,
                        ["return #{keyword} receiver.nil? &&",
@@ -786,7 +786,7 @@ describe RuboCop::Cop::Style::MultilineMethodCallIndentation do
                       '    d'])
       expect(cop.messages).to eq(['Use 2 (not 4) spaces for indenting an ' \
                                   'expression spanning multiple lines.'])
-      expect(cop.highlights).to eq(%w(d))
+      expect(cop.highlights).to eq(%w[d])
       expect(cop.config_to_allow_offenses).to eq('Enabled' => false)
     end
 
@@ -849,10 +849,10 @@ describe RuboCop::Cop::Style::MultilineMethodCallIndentation do
       end
 
       [
-        %w(an if),
-        %w(an unless),
-        %w(a while),
-        %w(an until)
+        %w[an if],
+        %w[an unless],
+        %w[a while],
+        %w[an until]
       ].each do |article, keyword|
         it "accepts indentation of #{keyword} condition which is offset " \
            'by a single normal indentation step' do

--- a/spec/rubocop/cop/style/multiline_operation_indentation_spec.rb
+++ b/spec/rubocop/cop/style/multiline_operation_indentation_spec.rb
@@ -80,7 +80,7 @@ describe RuboCop::Cop::Style::MultilineOperationIndentation do
                       '   d'])
       expect(cop.messages).to eq(['Use 2 (not 3) spaces for indenting an ' \
                                   'expression spanning multiple lines.'] * 2)
-      expect(cop.highlights).to eq(%w(b d))
+      expect(cop.highlights).to eq(%w[b d])
     end
 
     it 'registers an offense for extra indentation of third line' do
@@ -294,10 +294,10 @@ describe RuboCop::Cop::Style::MultilineOperationIndentation do
     end
 
     [
-      %w(an if),
-      %w(an unless),
-      %w(a while),
-      %w(an until)
+      %w[an if],
+      %w[an unless],
+      %w[a while],
+      %w[an until]
     ].each do |article, keyword|
       it "registers an offense for misaligned operands in #{keyword} " \
          'condition' do
@@ -421,10 +421,10 @@ describe RuboCop::Cop::Style::MultilineOperationIndentation do
     end
 
     [
-      %w(an if),
-      %w(an unless),
-      %w(a while),
-      %w(an until)
+      %w[an if],
+      %w[an unless],
+      %w[a while],
+      %w[an until]
     ].each do |article, keyword|
       it "accepts double indentation of #{keyword} condition" do
         inspect_source(cop,
@@ -462,7 +462,7 @@ describe RuboCop::Cop::Style::MultilineOperationIndentation do
       end
     end
 
-    %w(unless if).each do |keyword|
+    %w[unless if].each do |keyword|
       it "accepts special indentation of return #{keyword} condition" do
         inspect_source(cop,
                        ["return #{keyword} receiver.nil? &&",
@@ -507,7 +507,7 @@ describe RuboCop::Cop::Style::MultilineOperationIndentation do
                       '    d'])
       expect(cop.messages).to eq(['Use 2 (not 4) spaces for indenting an ' \
                                   'expression spanning multiple lines.'])
-      expect(cop.highlights).to eq(%w(d))
+      expect(cop.highlights).to eq(%w[d])
       expect(cop.config_to_allow_offenses).to eq('Enabled' => false)
     end
 
@@ -545,10 +545,10 @@ describe RuboCop::Cop::Style::MultilineOperationIndentation do
       end
 
       [
-        %w(an if),
-        %w(an unless),
-        %w(a while),
-        %w(an until)
+        %w[an if],
+        %w[an unless],
+        %w[a while],
+        %w[an until]
       ].each do |article, keyword|
         it "accepts indentation of #{keyword} condition which is offset " \
            'by a single normal indentation step' do

--- a/spec/rubocop/cop/style/negated_if_spec.rb
+++ b/spec/rubocop/cop/style/negated_if_spec.rb
@@ -4,7 +4,7 @@ describe RuboCop::Cop::Style::NegatedIf do
   subject(:cop) do
     config = RuboCop::Config.new(
       'Style/NegatedIf' => {
-        'SupportedStyles' => %w(both prefix postfix),
+        'SupportedStyles' => %w[both prefix postfix],
         'EnforcedStyle' => 'both'
       }
     )
@@ -133,7 +133,7 @@ describe RuboCop::Cop::Style::NegatedIf do
     subject(:cop) do
       config = RuboCop::Config.new(
         'Style/NegatedIf' => {
-          'SupportedStyles' => %w(both prefix postfix),
+          'SupportedStyles' => %w[both prefix postfix],
           'EnforcedStyle' => 'prefix'
         }
       )
@@ -173,7 +173,7 @@ describe RuboCop::Cop::Style::NegatedIf do
     subject(:cop) do
       config = RuboCop::Config.new(
         'Style/NegatedIf' => {
-          'SupportedStyles' => %w(both prefix postfix),
+          'SupportedStyles' => %w[both prefix postfix],
           'EnforcedStyle' => 'postfix'
         }
       )

--- a/spec/rubocop/cop/style/numeric_literal_prefix_spec.rb
+++ b/spec/rubocop/cop/style/numeric_literal_prefix_spec.rb
@@ -16,7 +16,7 @@ describe RuboCop::Cop::Style::NumericLiteralPrefix, :config do
                              'b(0O1234)'])
         expect(cop.offenses.size).to eq(2)
         expect(cop.messages.uniq).to eq(['Use 0o for octal literals.'])
-        expect(cop.highlights).to eq(%w(01234 0O1234))
+        expect(cop.highlights).to eq(%w[01234 0O1234])
       end
 
       it 'does not register offense for lowercase prefix' do
@@ -48,7 +48,7 @@ describe RuboCop::Cop::Style::NumericLiteralPrefix, :config do
                              'b(0o1234)'])
         expect(cop.offenses.size).to eq(2)
         expect(cop.messages.uniq).to eq(['Use 0 for octal literals.'])
-        expect(cop.highlights).to eq(%w(0O1234 0o1234))
+        expect(cop.highlights).to eq(%w[0O1234 0o1234])
       end
 
       it 'does not register offense for prefix `0`' do
@@ -75,7 +75,7 @@ describe RuboCop::Cop::Style::NumericLiteralPrefix, :config do
                            'b(0XABC)'])
       expect(cop.offenses.size).to eq(2)
       expect(cop.messages.uniq).to eq(['Use 0x for hexadecimal literals.'])
-      expect(cop.highlights).to eq(%w(0X1AC 0XABC))
+      expect(cop.highlights).to eq(%w[0X1AC 0XABC])
     end
 
     it 'does not register offense for lowercase prefix' do
@@ -95,7 +95,7 @@ describe RuboCop::Cop::Style::NumericLiteralPrefix, :config do
                            'b(0B111)'])
       expect(cop.offenses.size).to eq(2)
       expect(cop.messages.uniq).to eq(['Use 0b for binary literals.'])
-      expect(cop.highlights).to eq(%w(0B10101 0B111))
+      expect(cop.highlights).to eq(%w[0B10101 0B111])
     end
 
     it 'does not register offense for lowercase prefix' do
@@ -116,7 +116,7 @@ describe RuboCop::Cop::Style::NumericLiteralPrefix, :config do
       expect(cop.offenses.size).to eq(2)
       expect(cop.messages.uniq)
         .to eq(['Do not use prefixes for decimal literals.'])
-      expect(cop.highlights).to eq(%w(0d1234 0D1234))
+      expect(cop.highlights).to eq(%w[0d1234 0D1234])
     end
 
     it 'does not register offense for no prefix' do

--- a/spec/rubocop/cop/style/one_line_conditional_spec.rb
+++ b/spec/rubocop/cop/style/one_line_conditional_spec.rb
@@ -64,8 +64,8 @@ describe RuboCop::Cop::Style::OneLineConditional do
     include_examples 'no offense'
   end
 
-  %w(| ^ & <=> == === =~ > >= < <= << >> + - * / % ** ~ ! != !~
-     && ||).each do |operator|
+  %w[| ^ & <=> == === =~ > >= < <= << >> + - * / % ** ~ ! != !~
+     && ||].each do |operator|
     it 'parenthesizes the expression if it is preceded by an operator' do
       corrected =
         autocorrect_source(cop, "a #{operator} if cond then run else dont end")

--- a/spec/rubocop/cop/style/op_method_spec.rb
+++ b/spec/rubocop/cop/style/op_method_spec.rb
@@ -3,7 +3,7 @@
 describe RuboCop::Cop::Style::OpMethod do
   subject(:cop) { described_class.new }
 
-  %i(+ eql? equal?).each do |op|
+  %i[+ eql? equal?].each do |op|
     it "registers an offense for #{op} with arg not named other" do
       inspect_source(cop,
                      ["def #{op}(another)",

--- a/spec/rubocop/cop/style/parentheses_around_condition_spec.rb
+++ b/spec/rubocop/cop/style/parentheses_around_condition_spec.rb
@@ -92,7 +92,7 @@ describe RuboCop::Cop::Style::ParenthesesAroundCondition, :config do
     expect(cop.offenses).to be_empty
   end
 
-  %w(rescue if unless while until).each do |op|
+  %w[rescue if unless while until].each do |op|
     it "allows parens if the condition node is a modifier #{op} op" do
       inspect_source(cop, ["if (something #{op} top)",
                            'end'])

--- a/spec/rubocop/cop/style/predicate_name_spec.rb
+++ b/spec/rubocop/cop/style/predicate_name_spec.rb
@@ -5,11 +5,11 @@ describe RuboCop::Cop::Style::PredicateName, :config do
 
   context 'with blacklisted prefixes' do
     let(:cop_config) do
-      { 'NamePrefix' => %w(has_ is_),
-        'NamePrefixBlacklist' => %w(has_ is_) }
+      { 'NamePrefix' => %w[has_ is_],
+        'NamePrefixBlacklist' => %w[has_ is_] }
     end
 
-    %w(has is).each do |prefix|
+    %w[has is].each do |prefix|
       it 'registers an offense when method name starts with known prefix' do
         inspect_source(cop, ["def #{prefix}_attr",
                              '  # ...',
@@ -30,10 +30,10 @@ describe RuboCop::Cop::Style::PredicateName, :config do
 
   context 'without blacklisted prefixes' do
     let(:cop_config) do
-      { 'NamePrefix' => %w(has_ is_), 'NamePrefixBlacklist' => [] }
+      { 'NamePrefix' => %w[has_ is_], 'NamePrefixBlacklist' => [] }
     end
 
-    %w(has is).each do |prefix|
+    %w[has is].each do |prefix|
       it 'registers an offense when method name starts with known prefix' do
         inspect_source(cop, ["def #{prefix}_attr",
                              '  # ...',
@@ -55,8 +55,8 @@ describe RuboCop::Cop::Style::PredicateName, :config do
 
   context 'with whitelisted predicate names' do
     let(:cop_config) do
-      { 'NamePrefix' => %w(is_), 'NamePrefixBlacklist' => %w(is_),
-        'NameWhitelist' => %w(is_a?) }
+      { 'NamePrefix' => %w[is_], 'NamePrefixBlacklist' => %w[is_],
+        'NameWhitelist' => %w[is_a?] }
     end
 
     it 'accepts method name which is in whitelist' do

--- a/spec/rubocop/cop/style/regexp_literal_spec.rb
+++ b/spec/rubocop/cop/style/regexp_literal_spec.rb
@@ -4,7 +4,7 @@ describe RuboCop::Cop::Style::RegexpLiteral, :config do
   subject(:cop) { described_class.new(config) }
   let(:config) do
     supported_styles = {
-      'SupportedStyles' => %w(slashes percent_r mixed)
+      'SupportedStyles' => %w[slashes percent_r mixed]
     }
     RuboCop::Config.new('Style/PercentLiteralDelimiters' =>
                           percent_literal_delimiters_config,

--- a/spec/rubocop/cop/style/self_assignment_spec.rb
+++ b/spec/rubocop/cop/style/self_assignment_spec.rb
@@ -3,7 +3,7 @@
 describe RuboCop::Cop::Style::SelfAssignment do
   subject(:cop) { described_class.new }
 
-  %i(+ - * ** / | &).product(['x', '@x', '@@x']).each do |op, var|
+  %i[+ - * ** / | &].product(['x', '@x', '@@x']).each do |op, var|
     it "registers an offense for non-shorthand assignment #{op} and #{var}" do
       inspect_source(cop,
                      "#{var} = #{var} #{op} y")

--- a/spec/rubocop/cop/style/single_line_block_params_spec.rb
+++ b/spec/rubocop/cop/style/single_line_block_params_spec.rb
@@ -4,8 +4,8 @@ describe RuboCop::Cop::Style::SingleLineBlockParams, :config do
   subject(:cop) { described_class.new(config) }
   let(:cop_config) do
     { 'Methods' =>
-      [{ 'reduce' => %w(a e) },
-       { 'test' => %w(x y) }] }
+      [{ 'reduce' => %w[a e] },
+       { 'test' => %w[x y] }] }
   end
 
   it 'finds wrong argument names in calls with different syntax' do

--- a/spec/rubocop/cop/style/space_inside_array_percent_literal_spec.rb
+++ b/spec/rubocop/cop/style/space_inside_array_percent_literal_spec.rb
@@ -3,8 +3,8 @@
 describe RuboCop::Cop::Style::SpaceInsideArrayPercentLiteral do
   subject(:cop) { described_class.new }
 
-  %w(i I w W).each do |type|
-    [%w({ }), %w{( )}, %w([ ]), %w(! !)].each do |(ldelim, rdelim)|
+  %w[i I w W].each do |type|
+    [%w[{ }], %w[( )], %w([ ]), %w[! !]].each do |(ldelim, rdelim)|
       context "for #{type} type and #{[ldelim, rdelim]} delimiters" do
         define_method(:code_example) do |content|
           ['%', type, ldelim, content, rdelim].join

--- a/spec/rubocop/cop/style/space_inside_block_braces_spec.rb
+++ b/spec/rubocop/cop/style/space_inside_block_braces_spec.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 describe RuboCop::Cop::Style::SpaceInsideBlockBraces, :config do
-  SUPPORTED_STYLES = %w(space no_space).freeze
+  SUPPORTED_STYLES = %w[space no_space].freeze
 
   subject(:cop) { described_class.new(config) }
   let(:cop_config) do

--- a/spec/rubocop/cop/style/space_inside_percent_literal_delimiters_spec.rb
+++ b/spec/rubocop/cop/style/space_inside_percent_literal_delimiters_spec.rb
@@ -3,8 +3,8 @@
 describe RuboCop::Cop::Style::SpaceInsidePercentLiteralDelimiters do
   subject(:cop) { described_class.new }
 
-  %w(i I w W x).each do |type|
-    [%w({ }), %w{( )}, %w([ ]), %w(! !)].each do |(ldelim, rdelim)|
+  %w[i I w W x].each do |type|
+    [%w[{ }], %w[( )], %w([ ]), %w[! !]].each do |(ldelim, rdelim)|
       context "for #{type} type and #{[ldelim, rdelim]} delimiters" do
         define_method(:code_example) do |content|
           ['%', type, ldelim, content, rdelim].join
@@ -89,7 +89,7 @@ describe RuboCop::Cop::Style::SpaceInsidePercentLiteralDelimiters do
   end
 
   it 'accepts other percent literals' do
-    %w(q r s).each do |type|
+    %w[q r s].each do |type|
       inspect_source(cop, "%#{type}( a  b c )")
       expect(cop.messages).to be_empty
     end

--- a/spec/rubocop/cop/style/string_methods_spec.rb
+++ b/spec/rubocop/cop/style/string_methods_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe RuboCop::Cop::Style::StringMethods, :config do
 
     expect(cop.offenses.size).to eq(1)
     expect(cop.messages).to eq(['Prefer `to_sym` over `intern`.'])
-    expect(cop.highlights).to eq(%w(intern))
+    expect(cop.highlights).to eq(%w[intern])
 
     expect(corrected).to eq("'something'.to_sym")
   end

--- a/spec/rubocop/cop/style/symbol_proc_spec.rb
+++ b/spec/rubocop/cop/style/symbol_proc_spec.rb
@@ -3,7 +3,7 @@
 describe RuboCop::Cop::Style::SymbolProc, :config do
   subject(:cop) { described_class.new(config) }
 
-  let(:cop_config) { { 'IgnoredMethods' => %w(respond_to) } }
+  let(:cop_config) { { 'IgnoredMethods' => %w[respond_to] } }
 
   it 'registers an offense for a block with parameterless method call on ' \
      'param' do

--- a/spec/rubocop/cop/style/ternary_parentheses_spec.rb
+++ b/spec/rubocop/cop/style/ternary_parentheses_spec.rb
@@ -350,7 +350,7 @@ describe RuboCop::Cop::Style::TernaryParentheses, :config do
     let(:cop_config) do
       {
         'EnforcedStyle' => 'require_parentheses',
-        'SupportedStyles' => %w(require_parentheses require_no_parentheses)
+        'SupportedStyles' => %w[require_parentheses require_no_parentheses]
       }
     end
 

--- a/spec/rubocop/cop/style/variable_number_spec.rb
+++ b/spec/rubocop/cop/style/variable_number_spec.rb
@@ -37,7 +37,7 @@ describe RuboCop::Cop::Style::VariableNumber, :config do
     it_behaves_like :offense, 'snake_case', '@camelCase1', :normalcase
     it_behaves_like :offense, 'snake_case', '_unused1', :normalcase
     it_behaves_like :offense, 'snake_case', 'aB1', :normalcase
-    it_behaves_like :offense, 'snake_case', %w(a1 a_2), nil
+    it_behaves_like :offense, 'snake_case', %w[a1 a_2], nil
 
     it_behaves_like :accepts, 'snake_case', 'local_1'
     it_behaves_like :accepts, 'snake_case', 'local_12'
@@ -77,7 +77,7 @@ describe RuboCop::Cop::Style::VariableNumber, :config do
     it_behaves_like :offense, 'normalcase', '_myLocal_1', :snake_case
     it_behaves_like :offense, 'normalcase', 'localFOO_1', :snake_case
     it_behaves_like :offense, 'normalcase', 'local_FOO_1', :snake_case
-    it_behaves_like :offense, 'normalcase', %w(a_1 a2), nil
+    it_behaves_like :offense, 'normalcase', %w[a_1 a2], nil
 
     it_behaves_like :accepts, 'normalcase', 'local1'
     it_behaves_like :accepts, 'normalcase', 'local_'
@@ -120,7 +120,7 @@ describe RuboCop::Cop::Style::VariableNumber, :config do
     it_behaves_like :offense, 'non_integer', '@myAttribute1', :normalcase
     it_behaves_like :offense, 'non_integer', '_myLocal_1', :snake_case
     it_behaves_like :offense, 'non_integer', '_myLocal1', :normalcase
-    it_behaves_like :offense, 'non_integer', %w(a_1 aone), nil
+    it_behaves_like :offense, 'non_integer', %w[a_1 aone], nil
 
     it_behaves_like :accepts, 'non_integer', 'localone'
     it_behaves_like :accepts, 'non_integer', 'local_one'

--- a/spec/rubocop/cop/team_spec.rb
+++ b/spec/rubocop/cop/team_spec.rb
@@ -155,10 +155,10 @@ describe RuboCop::Cop::Team do
 
     context 'when some classes are disabled with config' do
       let(:disabled_config) do
-        %w(
+        %w[
           Lint/Void
           Metrics/LineLength
-        ).each_with_object(RuboCop::Config.new) do |cop_name, accum|
+        ].each_with_object(RuboCop::Config.new) do |cop_name, accum|
           accum[cop_name] = { 'Enabled' => false }
         end
       end

--- a/spec/rubocop/cop/variable_force/scope_spec.rb
+++ b/spec/rubocop/cop/variable_force/scope_spec.rb
@@ -241,7 +241,7 @@ describe RuboCop::Cop::VariableForce::Scope do
         END
 
         let(:scope_node_type) { :def }
-        let(:expected_types) { %w(args arg arg sym) }
+        let(:expected_types) { %w[args arg arg sym] }
         include_examples 'yields', 'the argument and the body nodes'
       end
 
@@ -253,7 +253,7 @@ describe RuboCop::Cop::VariableForce::Scope do
         END
 
         let(:scope_node_type) { :defs }
-        let(:expected_types) { %w(args arg arg sym) }
+        let(:expected_types) { %w[args arg arg sym] }
         include_examples 'yields', 'the argument and the body nodes'
       end
 
@@ -265,7 +265,7 @@ describe RuboCop::Cop::VariableForce::Scope do
         END
 
         let(:scope_node_type) { :module }
-        let(:expected_types) { %w(sym) }
+        let(:expected_types) { %w[sym] }
         include_examples 'yields', 'the body nodes'
       end
 
@@ -279,7 +279,7 @@ describe RuboCop::Cop::VariableForce::Scope do
         END
 
         let(:scope_node_type) { :class }
-        let(:expected_types) { %w(sym) }
+        let(:expected_types) { %w[sym] }
         include_examples 'yields', 'the body nodes'
       end
 
@@ -293,7 +293,7 @@ describe RuboCop::Cop::VariableForce::Scope do
         END
 
         let(:scope_node_type) { :sclass }
-        let(:expected_types) { %w(sym) }
+        let(:expected_types) { %w[sym] }
         include_examples 'yields', 'the body nodes'
       end
 
@@ -305,7 +305,7 @@ describe RuboCop::Cop::VariableForce::Scope do
         END
 
         let(:scope_node_type) { :block }
-        let(:expected_types) { %w(args arg arg sym) }
+        let(:expected_types) { %w[args arg arg sym] }
         include_examples 'yields', 'the argument and the body nodes'
       end
 
@@ -315,7 +315,7 @@ describe RuboCop::Cop::VariableForce::Scope do
         END
 
         let(:scope_node_type) { :sym }
-        let(:expected_types) { %w(sym) }
+        let(:expected_types) { %w[sym] }
         include_examples 'yields', 'the body nodes'
       end
     end
@@ -333,7 +333,7 @@ describe RuboCop::Cop::VariableForce::Scope do
         END
 
         let(:scope_node_type) { :begin }
-        let(:expected_types) { %w(begin lvasgn int block send int int lvar) }
+        let(:expected_types) { %w[begin lvasgn int block send int int lvar] }
         include_examples 'yields', 'only the block node and the child send node'
       end
 
@@ -349,7 +349,7 @@ describe RuboCop::Cop::VariableForce::Scope do
         END
 
         let(:scope_node_type) { :begin }
-        let(:expected_types) { %w(begin lvasgn int defs self lvar) }
+        let(:expected_types) { %w[begin lvasgn int defs self lvar] }
         include_examples 'yields', 'only the defs node and the method host node'
       end
     end

--- a/spec/rubocop/formatter/base_formatter_spec.rb
+++ b/spec/rubocop/formatter/base_formatter_spec.rb
@@ -35,7 +35,7 @@ module RuboCop
         describe 'invocation order' do
           subject(:formatter) do
             formatter = double('formatter')
-            %i(started file_started file_finished finished output)
+            %i[started file_started file_finished finished output]
               .each do |message|
               allow(formatter).to receive(message) do
                 puts message.to_s unless message == :output

--- a/spec/rubocop/formatter/colorizable_spec.rb
+++ b/spec/rubocop/formatter/colorizable_spec.rb
@@ -95,7 +95,7 @@ module RuboCop
         end
       end
 
-      %i(
+      %i[
         black
         red
         green
@@ -104,7 +104,7 @@ module RuboCop
         magenta
         cyan
         white
-      ).each do |color|
+      ].each do |color|
         describe "##{color}" do
           it "invokes #colorize(string, #{color}" do
             expect(formatter).to receive(:colorize).with('foo', color)

--- a/spec/rubocop/formatter/disabled_lines_formatter_spec.rb
+++ b/spec/rubocop/formatter/disabled_lines_formatter_spec.rb
@@ -7,7 +7,7 @@ module RuboCop
       let(:output) { StringIO.new }
 
       let(:files) do
-        %w(lib/rubocop.rb spec/spec_helper.rb bin/rubocop).map do |path|
+        %w[lib/rubocop.rb spec/spec_helper.rb bin/rubocop].map do |path|
           File.expand_path(path)
         end
       end

--- a/spec/rubocop/formatter/emacs_style_formatter_spec.rb
+++ b/spec/rubocop/formatter/emacs_style_formatter_spec.rb
@@ -10,7 +10,7 @@ module RuboCop
         it 'displays parsable text' do
           cop = Cop::Cop.new
           source_buffer = Parser::Source::Buffer.new('test', 1)
-          source_buffer.source = %w(a b cdefghi).join("\n")
+          source_buffer.source = %w[a b cdefghi].join("\n")
 
           cop.add_offense(nil,
                           Parser::Source::Range.new(source_buffer, 0, 1),

--- a/spec/rubocop/formatter/file_list_formatter_spec.rb
+++ b/spec/rubocop/formatter/file_list_formatter_spec.rb
@@ -10,7 +10,7 @@ module RuboCop
         it 'displays parsable text' do
           cop = Cop::Cop.new
           source_buffer = Parser::Source::Buffer.new('test', 1)
-          source_buffer.source = %w(a b cdefghi).join("\n")
+          source_buffer.source = %w[a b cdefghi].join("\n")
 
           cop.add_offense(nil,
                           Parser::Source::Range.new(source_buffer, 0, 1),

--- a/spec/rubocop/formatter/formatter_set_spec.rb
+++ b/spec/rubocop/formatter/formatter_set_spec.rb
@@ -6,7 +6,7 @@ module RuboCop
       subject(:formatter_set) { described_class.new }
 
       it 'responds to all formatter API methods' do
-        %i(started file_started file_finished finished).each do |method|
+        %i[started file_started file_finished finished].each do |method|
           expect(formatter_set).to respond_to(method)
         end
       end

--- a/spec/rubocop/formatter/fuubar_style_formatter_spec.rb
+++ b/spec/rubocop/formatter/fuubar_style_formatter_spec.rb
@@ -6,7 +6,7 @@ module RuboCop
     let(:output) { StringIO.new }
 
     let(:files) do
-      %w(lib/rubocop.rb spec/spec_helper.rb).map do |path|
+      %w[lib/rubocop.rb spec/spec_helper.rb].map do |path|
         File.expand_path(path)
       end
     end

--- a/spec/rubocop/formatter/json_formatter_spec.rb
+++ b/spec/rubocop/formatter/json_formatter_spec.rb
@@ -4,10 +4,10 @@ module RuboCop
   describe Formatter::JSONFormatter do
     subject(:formatter) { described_class.new(output) }
     let(:output) { StringIO.new }
-    let(:files) { %w(/path/to/file1 /path/to/file2) }
+    let(:files) { %w[/path/to/file1 /path/to/file2] }
     let(:location) do
       source_buffer = Parser::Source::Buffer.new('test', 1)
-      source_buffer.source = %w(a b cdefghi).join("\n")
+      source_buffer.source = %w[a b cdefghi].join("\n")
       Parser::Source::Range.new(source_buffer, 9, 10)
     end
     let(:offense) do
@@ -20,7 +20,7 @@ module RuboCop
 
       it 'sets target file count in summary' do
         expect(summary[:target_file_count]).to be_nil
-        formatter.started(%w(/path/to/file1 /path/to/file2))
+        formatter.started(%w[/path/to/file1 /path/to/file2])
         expect(summary[:target_file_count]).to eq(2)
       end
     end
@@ -66,7 +66,7 @@ module RuboCop
 
       it 'sets inspected file count in summary' do
         expect(summary[:inspected_file_count]).to be_nil
-        formatter.finished(%w(/path/to/file1 /path/to/file2))
+        formatter.finished(%w[/path/to/file1 /path/to/file2])
         expect(summary[:inspected_file_count]).to eq(2)
       end
 

--- a/spec/rubocop/formatter/offense_count_formatter_spec.rb
+++ b/spec/rubocop/formatter/offense_count_formatter_spec.rb
@@ -7,7 +7,7 @@ module RuboCop
       let(:output) { StringIO.new }
 
       let(:files) do
-        %w(lib/rubocop.rb spec/spec_helper.rb bin/rubocop).map do |path|
+        %w[lib/rubocop.rb spec/spec_helper.rb bin/rubocop].map do |path|
           File.expand_path(path)
         end
       end
@@ -47,7 +47,7 @@ module RuboCop
       describe '#finished' do
         context 'when there are many offenses' do
           let(:offenses) do
-            %w(CopB CopA CopC CopC).map { |c| double('offense', cop_name: c) }
+            %w[CopB CopA CopC CopC].map { |c| double('offense', cop_name: c) }
           end
 
           before do

--- a/spec/rubocop/formatter/progress_formatter_spec.rb
+++ b/spec/rubocop/formatter/progress_formatter_spec.rb
@@ -6,7 +6,7 @@ module RuboCop
     let(:output) { StringIO.new }
 
     let(:files) do
-      %w(lib/rubocop.rb spec/spec_helper.rb bin/rubocop).map do |path|
+      %w[lib/rubocop.rb spec/spec_helper.rb bin/rubocop].map do |path|
         File.expand_path(path)
       end
     end

--- a/spec/rubocop/formatter/worst_offenders_formatter_spec.rb
+++ b/spec/rubocop/formatter/worst_offenders_formatter_spec.rb
@@ -7,7 +7,7 @@ module RuboCop
       let(:output) { StringIO.new }
 
       let(:files) do
-        %w(lib/rubocop.rb spec/spec_helper.rb bin/rubocop).map do |path|
+        %w[lib/rubocop.rb spec/spec_helper.rb bin/rubocop].map do |path|
           File.expand_path(path)
         end
       end

--- a/spec/rubocop/node_pattern_spec.rb
+++ b/spec/rubocop/node_pattern_spec.rb
@@ -701,7 +701,7 @@ describe RuboCop::NodePattern do
 
     context 'in a nested sequence' do
       let(:pattern) { '(send (send _ %2) %1)' }
-      let(:params) { %i(inc dec) }
+      let(:params) { %i[inc dec] }
       let(:ruby) { '5.dec.inc' }
       it_behaves_like :matching
     end

--- a/spec/rubocop/options_spec.rb
+++ b/spec/rubocop/options_spec.rb
@@ -129,47 +129,47 @@ describe RuboCop::Options, :isolated_environment do
     describe 'incompatible cli options' do
       it 'rejects using -v with -V' do
         msg = 'Incompatible cli options: [:version, :verbose_version]'
-        expect { options.parse %w(-vV) }
+        expect { options.parse %w[-vV] }
           .to raise_error(ArgumentError, msg)
       end
 
       it 'rejects using -v with --show-cops' do
         msg = 'Incompatible cli options: [:version, :show_cops]'
-        expect { options.parse %w(-v --show-cops) }
+        expect { options.parse %w[-v --show-cops] }
           .to raise_error(ArgumentError, msg)
       end
 
       it 'rejects using -V with --show-cops' do
         msg = 'Incompatible cli options: [:verbose_version, :show_cops]'
-        expect { options.parse %w(-V --show-cops) }
+        expect { options.parse %w[-V --show-cops] }
           .to raise_error(ArgumentError, msg)
       end
 
       it 'mentions all incompatible options when more than two are used' do
         msg = ['Incompatible cli options: [:version, :verbose_version,',
                ' :show_cops]'].join
-        expect { options.parse %w(-vV --show-cops) }
+        expect { options.parse %w[-vV --show-cops] }
           .to raise_error(ArgumentError, msg)
       end
     end
 
     describe '--fail-level' do
       it 'accepts full severity names' do
-        %w(refactor convention warning error fatal).each do |severity|
+        %w[refactor convention warning error fatal].each do |severity|
           expect { options.parse(['--fail-level', severity]) }
             .not_to raise_error
         end
       end
 
       it 'accepts severity initial letters' do
-        %w(R C W E F).each do |severity|
+        %w[R C W E F].each do |severity|
           expect { options.parse(['--fail-level', severity]) }
             .not_to raise_error
         end
       end
 
       it 'accepts the "fake" severities A/autocorrect' do
-        %w(autocorrect A).each do |severity|
+        %w[autocorrect A].each do |severity|
           expect { options.parse(['--fail-level', severity]) }
             .not_to raise_error
         end
@@ -193,48 +193,48 @@ describe RuboCop::Options, :isolated_environment do
 
     describe '--cache' do
       it 'fails if no argument is given' do
-        expect { options.parse %w(--cache) }
+        expect { options.parse %w[--cache] }
           .to raise_error(OptionParser::MissingArgument)
       end
 
       it 'fails if unrecognized argument is given' do
-        expect { options.parse %w(--cache maybe) }.to raise_error(ArgumentError)
+        expect { options.parse %w[--cache maybe] }.to raise_error(ArgumentError)
       end
 
       it 'accepts true as argument' do
-        expect { options.parse %w(--cache true) }.not_to raise_error
+        expect { options.parse %w[--cache true] }.not_to raise_error
       end
 
       it 'accepts false as argument' do
-        expect { options.parse %w(--cache false) }.not_to raise_error
+        expect { options.parse %w[--cache false] }.not_to raise_error
       end
     end
 
     describe '--exclude-limit' do
       it 'fails if given last without argument' do
-        expect { options.parse %w(--auto-gen-config --exclude-limit) }
+        expect { options.parse %w[--auto-gen-config --exclude-limit] }
           .to raise_error(OptionParser::MissingArgument)
       end
 
       it 'fails if given alone without argument' do
-        expect { options.parse %w(--exclude-limit) }
+        expect { options.parse %w[--exclude-limit] }
           .to raise_error(OptionParser::MissingArgument)
       end
 
       it 'fails if given first without argument' do
-        expect { options.parse %w(--exclude-limit --auto-gen-config) }
+        expect { options.parse %w[--exclude-limit --auto-gen-config] }
           .to raise_error(OptionParser::MissingArgument)
       end
 
       it 'fails if given without --auto-gen-config' do
-        expect { options.parse %w(--exclude-limit 10) }
+        expect { options.parse %w[--exclude-limit 10] }
           .to raise_error(ArgumentError)
       end
     end
 
     describe '--auto-gen-config' do
       it 'accepts other options' do
-        expect { options.parse %w(--auto-gen-config --rails) }
+        expect { options.parse %w[--auto-gen-config --rails] }
           .not_to raise_error
       end
     end
@@ -247,16 +247,16 @@ describe RuboCop::Options, :isolated_environment do
       end
 
       it 'fails if no paths are given' do
-        expect { options.parse %w(-s) }
+        expect { options.parse %w[-s] }
           .to raise_error(OptionParser::MissingArgument)
       end
 
       it 'succeeds with exactly one path' do
-        expect { options.parse %w(--stdin foo) }.not_to raise_error
+        expect { options.parse %w[--stdin foo] }.not_to raise_error
       end
 
       it 'fails if more than one path is given' do
-        expect { options.parse %w(--stdin foo bar) }
+        expect { options.parse %w[--stdin foo bar] }
           .to raise_error(ArgumentError)
       end
     end
@@ -269,13 +269,13 @@ describe RuboCop::Options, :isolated_environment do
     ensure
       ENV.delete('RUBOCOP_OPTS')
     end
-    let(:command_line_options) { %w(--no-color) }
+    let(:command_line_options) { %w[--no-color] }
 
     subject { options.parse(command_line_options).first }
 
     context '.rubocop file' do
       before do
-        create_file('.rubocop', %w(--color --fail-level C))
+        create_file('.rubocop', %w[--color --fail-level C])
       end
 
       it 'has lower precedence then command line options' do
@@ -307,7 +307,7 @@ describe RuboCop::Options, :isolated_environment do
       end
 
       it 'has higher precedence then options from .rubocop file' do
-        create_file('.rubocop', %w(--color --fail-level C))
+        create_file('.rubocop', %w[--color --fail-level C])
 
         with_env_options '--fail-level W' do
           is_expected.to eq(color: false, fail_level: :warning)

--- a/spec/rubocop/processed_source_spec.rb
+++ b/spec/rubocop/processed_source_spec.rb
@@ -141,13 +141,13 @@ describe RuboCop::ProcessedSource do
 
     context 'when a range is passed' do
       it 'returns the array of lines' do
-        expect(processed_source[3..4]).to eq(%w(end some_method))
+        expect(processed_source[3..4]).to eq(%w[end some_method])
       end
     end
 
     context 'when start index and length are passed' do
       it 'returns the array of lines' do
-        expect(processed_source[3, 2]).to eq(%w(end some_method))
+        expect(processed_source[3, 2]).to eq(%w[end some_method])
       end
     end
   end

--- a/spec/rubocop/string_util_spec.rb
+++ b/spec/rubocop/string_util_spec.rb
@@ -4,10 +4,10 @@ module RuboCop
   module StringUtil
     describe Jaro do
       {
-        %w(foo foo)       => 1.000,
-        %w(foo bar)       => 0.000,
-        %w(martha marhta) => 0.944,
-        %w(dwayne duane)  => 0.822
+        %w[foo foo]       => 1.000,
+        %w[foo bar]       => 0.000,
+        %w[martha marhta] => 0.944,
+        %w[dwayne duane]  => 0.822
       }.each do |strings, expected|
         context "with #{strings.first.inspect} and #{strings.last.inspect}" do
           subject(:distance) { Jaro.distance(*strings) }
@@ -23,13 +23,13 @@ module RuboCop
       # These samples are derived from Apache Lucene project.
       # https://github.com/apache/lucene-solr/blob/lucene_solr_4_9_0/lucene/suggest/src/test/org/apache/lucene/search/spell/TestJaroWinklerDistance.java
       {
-        %w(al al)             => 1.000,
-        %w(martha marhta)     => 0.961,
-        %w(jones johnson)     => 0.832,
-        %w(abcvwxyz cabvwxyz) => 0.958,
-        %w(dwayne duane)      => 0.840,
-        %w(dixon dicksonx)    => 0.813,
-        %w(fvie ten)          => 0.000
+        %w[al al]             => 1.000,
+        %w[martha marhta]     => 0.961,
+        %w[jones johnson]     => 0.832,
+        %w[abcvwxyz cabvwxyz] => 0.958,
+        %w[dwayne duane]      => 0.840,
+        %w[dixon dicksonx]    => 0.813,
+        %w[fvie ten]          => 0.000
       }.each do |strings, expected|
         context "with #{strings.first.inspect} and #{strings.last.inspect}" do
           subject(:distance) { JaroWinkler.distance(*strings) }

--- a/spec/rubocop/target_finder_spec.rb
+++ b/spec/rubocop/target_finder_spec.rb
@@ -110,7 +110,7 @@ describe RuboCop::TargetFinder, :isolated_environment do
     end
 
     context 'when same paths are passed' do
-      let(:args) { %w(dir1 dir1) }
+      let(:args) { %w[dir1 dir1] }
 
       it 'does not return duplicated file paths' do
         count = found_basenames.count { |f| f == 'ruby1.rb' }

--- a/tasks/cops_documentation.rake
+++ b/tasks/cops_documentation.rake
@@ -101,7 +101,7 @@ task generate_cops_documentation: :yard do
 
   def print_cop_with_doc(cop, config)
     t = config.for_cop(cop)
-    non_display_keys = %w(Description Enabled StyleGuide Reference)
+    non_display_keys = %w[Description Enabled StyleGuide Reference]
     pars = t.reject { |k| non_display_keys.include? k }
     description = 'No documentation'
     examples_object = []


### PR DESCRIPTION
The Style Guide was changed to [prefer square brackets for word- and symbol array literals](https://github.com/bbatsov/ruby-style-guide/issues/526).

This change brings RuboCop's config back in line.

Prepare for a lot of questions about it in issues if we merge this. 😅 

-----------------

Before submitting the PR make sure the following are checked:

* [X] Wrote [good commit messages][1].
* [X] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [X] Used the same coding conventions as the rest of the project.
* [X] Feature branch is up-to-date with `master` (if not - rebase it).
* [X] Squashed related commits together.
* [X] Added tests.
* [X] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [X] All tests are passing.
* [X] The new code doesn't generate RuboCop offenses.
* [X] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [ ] Updated cop documentation with `rake generate_cops_documentation` (required only when you've added a new cop or changed the configuration/documentation of an existing cop).

[1]: http://chris.beams.io/posts/git-commit/
