### PR TITLE
Allow visibility scoped node matchers

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -19,12 +19,17 @@ Style/FrozenStringLiteralComment:
 Style/IndentHeredoc:
   EnforcedStyle: powerpack
 
+Lint/AmbiguousBlockAssociation:
+  Exclude:
+    - 'spec/**/*.rb'
+
+Lint/UselessAccessModifier:
+  MethodCreatingMethods:
+    - 'def_matcher'
+    - 'def_node_matcher'
+
 Metrics/BlockLength:
   Exclude:
     - 'Rakefile'
     - '**/*.rake'
-    - 'spec/**/*.rb'
-
-AmbiguousBlockAssociation:
-  Exclude:
     - 'spec/**/*.rb'

--- a/lib/rubocop/ast/node/send_node.rb
+++ b/lib/rubocop/ast/node/send_node.rb
@@ -184,7 +184,7 @@ module RuboCop
         [*self]
       end
 
-      private # rubocop:disable Lint/UselessAccessModifier
+      private
 
       def_matcher :macro_scope?, <<-PATTERN
         {^({class module} ...)


### PR DESCRIPTION
`Lint/UselessAccessModifier` has a configuration option for methods that count towards a useful visibility scope. This change adds `#node_matcher` and `#def_node_matcher` to that list for the RuboCop project.

-----------------

Before submitting the PR make sure the following are checked:

* [X] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [X] Used the same coding conventions as the rest of the project.
* [X] Feature branch is up-to-date with `master` (if not - rebase it).
* [X] Squashed related commits together.
* [ ] Added tests.
* [ ] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [X] All tests are passing.
* [X] The new code doesn't generate RuboCop offenses.
* [ ] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [ ] Updated cop documentation with `rake generate_cops_documentation` (required only when you've added a new cop or changed the configuration/documentation of an existing cop).

[1]: http://chris.beams.io/posts/git-commit/
