### PR TITLE
[FIX #4196] Rails/RelativeDate constant complains on lambda and proc

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@
 * [#4217](https://github.com/bbatsov/rubocop/pull/4217): Fix false positive in `Rails/FilePath` cop with non string argument. ([@soutaro][])
 * [#4106](https://github.com/bbatsov/rubocop/pull/4106): Make `Style/TernaryParentheses` unsafe autocorrect detector aware of literals and constants. ([@drenmi][])
 * [#4228](https://github.com/bbatsov/rubocop/pull/4228): Fix false positive in `Lint/AmbiguousBlockAssociation` cop. ([@smakagon][])
+* [#4234](https://github.com/bbatsov/rubocop/pull/4234): Fix false positive in `Rails/RelativeDate` for lambdas and procs. ([@smakagon][])
 
 ## 0.48.0 (2017-03-26)
 

--- a/lib/rubocop/cop/rails/relative_date_constant.rb
+++ b/lib/rubocop/cop/rails/relative_date_constant.rb
@@ -25,6 +25,8 @@ module RuboCop
         RELATIVE_DATE_METHODS = %i[ago from_now since until].freeze
 
         def on_casgn(node)
+          return if node.children.last.lambda_or_proc?
+
           bad_node = node.descendants.find { |n| bad_method?(n) }
           return unless bad_node
 

--- a/spec/rubocop/cop/rails/relative_date_constant_spec.rb
+++ b/spec/rubocop/cop/rails/relative_date_constant_spec.rb
@@ -19,6 +19,22 @@ describe RuboCop::Cop::Rails::RelativeDateConstant do
     expect(cop.offenses).to be_empty
   end
 
+  it 'accepts a lambda' do
+    inspect_source(cop,
+                   ['class SomeClass',
+                    '  EXPIRED_AT = -> { 1.year.ago }',
+                    'end'])
+    expect(cop.offenses).to be_empty
+  end
+
+  it 'accepts a proc' do
+    inspect_source(cop,
+                   ['class SomeClass',
+                    '  EXPIRED_AT = Proc.new { 1.year.ago }',
+                    'end'])
+    expect(cop.offenses).to be_empty
+  end
+
   it 'registers an offense for exclusive end range' do
     inspect_source(cop,
                    ['class SomeClass',


### PR DESCRIPTION
Fixes the following case for `Rails/RelativeDate` cop:

`CONST = -> { 1.year.ago }`

Before this fix it would show:

```
bug.rb:1:1: C: Rails/RelativeDateConstant: Do not assign ago to constants as it will be evaluated only once.
CONST = -> { 1.year.ago }
```

As reported [here](https://github.com/bbatsov/rubocop/issues/4196).