### PR TITLE
[FIX #4181] AmbiguousBlockAssociation gives extended advice

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 * [#4219](https://github.com/bbatsov/rubocop/issues/4219): Add a link to style guide for `Style/IndentationConsistency` cop. ([@pocke][])
 * [#4168](https://github.com/bbatsov/rubocop/issues/4168): Removed `-n` option. ([@sadovnik][])
 * [#4039](https://github.com/bbatsov/rubocop/pull/4039): Change `Style/PercentLiteralDelimiters` default configuration to match Style Guide update. ([@drenmi][])
+* [#4235](https://github.com/bbatsov/rubocop/pull/4235): Improved copy of offense message in `Lint/AmbiguousBlockAssociation` cop. ([@smakagon][])
 
 ### Bug fixes
 

--- a/lib/rubocop/cop/lint/ambiguous_block_association.rb
+++ b/lib/rubocop/cop/lint/ambiguous_block_association.rb
@@ -36,7 +36,7 @@ module RuboCop
           last_param = node.last_argument.children.first
           return unless method_as_param?(last_param)
 
-          add_offense(node, :expression, message(last_param, node.method_name))
+          add_offense(node, :expression, message(node.last_argument))
         end
 
         private
@@ -53,8 +53,8 @@ module RuboCop
           param && param.send_type? && !param.arguments?
         end
 
-        def message(param, method_name)
-          format(MSG, param.children[1], method_name)
+        def message(param)
+          format(MSG, param.source, param.children.first.source)
         end
 
         def_node_matcher :lambda_argument?, <<-PATTERN

--- a/spec/rubocop/cop/lint/ambiguous_block_association_spec.rb
+++ b/spec/rubocop/cop/lint/ambiguous_block_association_spec.rb
@@ -58,7 +58,7 @@ describe RuboCop::Cop::Lint::AmbiguousBlockAssociation do
       it 'registers an offense' do
         expect(cop.offenses.size).to eq(1)
         expect(cop.offenses.first.message).to(
-          eq(format(error_message, 'a', 'some_method'))
+          eq(format(error_message, 'a { |el| puts el }', 'a'))
         )
       end
     end
@@ -69,7 +69,7 @@ describe RuboCop::Cop::Lint::AmbiguousBlockAssociation do
       it 'registers an offense' do
         expect(cop.offenses.size).to eq(1)
         expect(cop.offenses.first.message).to(
-          eq(format(error_message, 'a', 'some_method'))
+          eq(format(error_message, 'a { |el| puts el }', 'a'))
         )
       end
     end
@@ -82,7 +82,7 @@ describe RuboCop::Cop::Lint::AmbiguousBlockAssociation do
       it 'registers an offense' do
         expect(cop.offenses.size).to eq(1)
         expect(cop.offenses.first.message).to(
-          eq(format(error_message, 'change', 'to'))
+          eq(format(error_message, 'change { order.events }', 'change'))
         )
       end
     end
@@ -93,7 +93,7 @@ describe RuboCop::Cop::Lint::AmbiguousBlockAssociation do
       it 'registers an offense' do
         expect(cop.offenses.size).to eq(1)
         expect(cop.offenses.first.message).to(
-          eq(format(error_message, 'a', 'some_method'))
+          eq(format(error_message, 'a { |el| el }', 'a'))
         )
       end
     end
@@ -104,7 +104,7 @@ describe RuboCop::Cop::Lint::AmbiguousBlockAssociation do
       it 'registers an offense' do
         expect(cop.offenses.size).to eq(1)
         expect(cop.offenses.first.message).to(
-          eq(format(error_message, 'a', 'some_method'))
+          eq(format(error_message, 'a { |el| puts el }', 'a'))
         )
       end
     end


### PR DESCRIPTION
With this fix `Lint/AmbiguousBlockAssociation` gives extended advice.

For example for this code:
`Foo.some_method a { |el| puts el }`

It would return this message:

> Parenthesize the param `a { |el| puts el }` to make sure that the block will be associated with the `a` method call.

As suggested in #4181 
