### PR TITLE
Fix spelling mistakes in comments and code

### DIFF
--- a/lib/rubocop/ast/node/if_node.rb
+++ b/lib/rubocop/ast/node/if_node.rb
@@ -36,7 +36,7 @@ module RuboCop
       # Checks whether the `if` node has an `else` clause.
       #
       # @note This returns `true` for nodes containing an `elsif` clause.
-      #       This is legacy behaviour, and many cops rely on it.
+      #       This is legacy behavior, and many cops rely on it.
       #
       # @return [Boolean] whether the node has an `else` clause
       def else?

--- a/lib/rubocop/cop/bundler/duplicated_gem.rb
+++ b/lib/rubocop/cop/bundler/duplicated_gem.rb
@@ -54,13 +54,13 @@ module RuboCop
             .values
         end
 
-        def register_offense(node, gem_name, line_of_first_occurence)
+        def register_offense(node, gem_name, line_of_first_occurrence)
           line_range = node.loc.column...node.loc.last_column
 
           add_offense(
             node,
             source_range(processed_source.buffer, node.loc.line, line_range),
-            format(MSG, gem_name, line_of_first_occurence)
+            format(MSG, gem_name, line_of_first_occurrence)
           )
         end
       end

--- a/lib/rubocop/cop/mixin/hash_alignment.rb
+++ b/lib/rubocop/cop/mixin/hash_alignment.rb
@@ -2,7 +2,7 @@
 
 module RuboCop
   module Cop
-    # Common funcitonality for checking hash alignment.
+    # Common functionality for checking hash alignment.
     module HashAlignment
       # Handles calculation of deltas when the enforced style is 'key'.
       class KeyAlignment

--- a/lib/rubocop/cop/style/documentation_method.rb
+++ b/lib/rubocop/cop/style/documentation_method.rb
@@ -43,7 +43,7 @@ module RuboCop
       #     end
       #   end
       #
-      #   # Documenation
+      #   # Documentation
       #   def foo.bar
       #     puts baz
       #   end

--- a/lib/rubocop/cop/style/if_unless_modifier_of_if_unless.rb
+++ b/lib/rubocop/cop/style/if_unless_modifier_of_if_unless.rb
@@ -3,7 +3,7 @@
 module RuboCop
   module Cop
     module Style
-      # Checks for if and unless statements used as modifers of other if or
+      # Checks for if and unless statements used as modifiers of other if or
       # unless statements.
       #
       # @example

--- a/lib/rubocop/cop/style/indent_heredoc.rb
+++ b/lib/rubocop/cop/style/indent_heredoc.rb
@@ -105,8 +105,8 @@ module RuboCop
             if heredoc_indent_type(node) == '~'
               corrector.replace(node.loc.heredoc_body, indented_body(node))
             else
-              heredoc_begenning = node.loc.expression.source
-              corrected = heredoc_begenning.sub(/<<-?/, '<<~')
+              heredoc_beginning = node.loc.expression.source
+              corrected = heredoc_beginning.sub(/<<-?/, '<<~')
               corrector.replace(node.loc.expression, corrected)
             end
           end

--- a/lib/rubocop/cop/style/lambda.rb
+++ b/lib/rubocop/cop/style/lambda.rb
@@ -189,13 +189,13 @@ module RuboCop
         def remove_unparenthesized_whitespaces(corrector, node)
           block_method, args = *node
           return unless unparenthesized_literal_args?(args)
-          # First, remove leading whitespaces (beetween arrow and args)
+          # First, remove leading whitespaces (between arrow and args)
           corrector.remove_preceding(
             args.source_range,
             args.source_range.begin_pos - block_method.source_range.end_pos
           )
 
-          # Then, remove trailing whitespaces (beetween args and 'do')
+          # Then, remove trailing whitespaces (between args and 'do')
           delta = node.loc.begin.begin_pos - args.source_range.end_pos - 1
           corrector.remove_preceding(node.loc.begin, delta)
         end

--- a/lib/rubocop/cop/style/ternary_parentheses.rb
+++ b/lib/rubocop/cop/style/ternary_parentheses.rb
@@ -6,7 +6,7 @@ module RuboCop
       # This cop checks for the presence of parentheses around ternary
       # conditions. It is configurable to enforce inclusion or omission of
       # parentheses using `EnforcedStyle`. Omission is only enforced when
-      # removing the parentheses won't cause a different behaviour.
+      # removing the parentheses won't cause a different behavior.
       #
       # @example
       #

--- a/spec/rubocop/ast/if_node_spec.rb
+++ b/spec/rubocop/ast/if_node_spec.rb
@@ -171,7 +171,7 @@ describe RuboCop::AST::IfNode do
          'end'].join("\n")
       end
 
-      # Note: This is a legacy behaviour.
+      # Note: This is a legacy behavior.
       it { expect(if_node.else?).to be_truthy }
     end
 

--- a/spec/rubocop/cop/style/documentation_method_spec.rb
+++ b/spec/rubocop/cop/style/documentation_method_spec.rb
@@ -143,7 +143,7 @@ describe RuboCop::Cop::Style::DocumentationMethod, :config do
 
     context 'with documentation comment' do
       it_behaves_like 'code without offense', <<-CODE
-                      # Documenation
+                      # Documentation
                       def foo
                         puts 'bar'
                       end
@@ -169,7 +169,7 @@ describe RuboCop::Cop::Style::DocumentationMethod, :config do
       CODE
 
       it_behaves_like 'code without offense', <<-CODE
-                      # Documenation
+                      # Documentation
                       def foo
                         puts 'bar'
                       end
@@ -185,7 +185,7 @@ describe RuboCop::Cop::Style::DocumentationMethod, :config do
         let(:require_for_non_public_methods) { true }
 
         it_behaves_like 'code with offense', <<-CODE
-                        # Documenation
+                        # Documentation
                         def foo
                           puts 'bar'
                         end


### PR DESCRIPTION
I used my patented (not really) [spell checker script](https://github.com/bbatsov/rubocop/issues/846#issuecomment-36426793) to root out a few mistakes that sneaked in lately. This includes some cases of correct British spelling that I've changed to American.