### PR TITLE
Use here-document for example sources in specs for readability

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -33,3 +33,7 @@ Metrics/BlockLength:
     - 'Rakefile'
     - '**/*.rake'
     - 'spec/**/*.rb'
+
+Metrics/ModuleLength:
+  Exclude:
+    - 'spec/**/*.rb'

--- a/spec/rubocop/cli/cli_auto_gen_config_spec.rb
+++ b/spec/rubocop/cli/cli_auto_gen_config_spec.rb
@@ -18,8 +18,10 @@ describe RuboCop::CLI, :isolated_environment do
                                   '#' * 85,
                                   'y ',
                                   'puts x'])
-      create_file('.rubocop_todo.yml', ['Metrics/LineLength:',
-                                        '  Enabled: false'])
+      create_file('.rubocop_todo.yml', <<-END.strip_indent)
+        Metrics/LineLength:
+          Enabled: false
+      END
       create_file('.rubocop.yml', ['inherit_from: .rubocop_todo.yml'])
       expect(cli.run(['--auto-gen-config'])).to eq(1)
       expect(IO.readlines('.rubocop_todo.yml')[8..-1].map(&:chomp))
@@ -85,14 +87,16 @@ describe RuboCop::CLI, :isolated_environment do
                                   '#' * 85,
                                   'y ',
                                   'puts x'])
-      create_file('example2.rb', ['# encoding: utf-8',
-                                  '',
-                                  "\tx = 0",
-                                  'puts x',
-                                  '',
-                                  'class A',
-                                  '  def a; end',
-                                  'end'])
+      create_file('example2.rb', <<-END.strip_indent)
+        # encoding: utf-8
+
+        \tx = 0
+        puts x
+
+        class A
+          def a; end
+        end
+      END
       # Make ConfigLoader reload the default configuration so that its
       # absolute Exclude paths will point into this example's work directory.
       RuboCop::ConfigLoader.default_configuration = nil
@@ -267,14 +271,18 @@ describe RuboCop::CLI, :isolated_environment do
     end
 
     it 'does not generate configuration for the Syntax cop' do
-      create_file('example1.rb', ['# encoding: utf-8',
-                                  '',
-                                  'x = < ', # Syntax error
-                                  'puts x'])
-      create_file('example2.rb', ['# encoding: utf-8',
-                                  '',
-                                  "\tx = 0",
-                                  'puts x'])
+      create_file('example1.rb', <<-END.strip_indent)
+        # encoding: utf-8
+
+        x = <  # Syntax error
+        puts x
+      END
+      create_file('example2.rb', <<-END.strip_indent)
+        # encoding: utf-8
+
+        \tx = 0
+        puts x
+      END
       expect(cli.run(['--auto-gen-config'])).to eq(1)
       expect($stderr.string).to eq('')
       expected =
@@ -367,14 +375,16 @@ describe RuboCop::CLI, :isolated_environment do
                                   '#' * 85,
                                   'y ',
                                   'puts x'])
-      create_file('example2.rb', ['# encoding: utf-8',
-                                  '',
-                                  "\tx = 0",
-                                  'puts x',
-                                  '',
-                                  'class A',
-                                  '  def a; end',
-                                  'end'])
+      create_file('example2.rb', <<-END.strip_indent)
+        # encoding: utf-8
+
+        \tx = 0
+        puts x
+
+        class A
+          def a; end
+        end
+      END
       # Make ConfigLoader reload the default configuration so that its
       # absolute Exclude paths will point into this example's work directory.
       RuboCop::ConfigLoader.default_configuration = nil
@@ -466,29 +476,31 @@ describe RuboCop::CLI, :isolated_environment do
       it 'disables cop if --exclude-limit is exceeded' do
         expect(cli.run(['--auto-gen-config', '--exclude-limit', '1'])).to eq(1)
         expect(IO.readlines('.rubocop_todo.yml')[8..-1].join)
-          .to eq(['# Offense count: 2',
-                  '# Cop supports --auto-correct.',
-                  '# Configuration parameters: EnforcedStyle, SupportedStyles.',
-                  '# SupportedStyles: use_perl_names, use_english_names',
-                  'Style/SpecialGlobalVars:',
-                  '  Enabled: false',
-                  ''].join("\n"))
+          .to eq(<<-END.strip_indent)
+            # Offense count: 2
+            # Cop supports --auto-correct.
+            # Configuration parameters: EnforcedStyle, SupportedStyles.
+            # SupportedStyles: use_perl_names, use_english_names
+            Style/SpecialGlobalVars:
+              Enabled: false
+          END
       end
 
       it 'generates Exclude list if --exclude-limit is not exceeded' do
         create_file('example4.rb', ['$!'])
         expect(cli.run(['--auto-gen-config', '--exclude-limit', '10'])).to eq(1)
         expect(IO.readlines('.rubocop_todo.yml')[8..-1].join)
-          .to eq(['# Offense count: 3',
-                  '# Cop supports --auto-correct.',
-                  '# Configuration parameters: EnforcedStyle, SupportedStyles.',
-                  '# SupportedStyles: use_perl_names, use_english_names',
-                  'Style/SpecialGlobalVars:',
-                  '  Exclude:',
-                  "    - 'example1.rb'",
-                  "    - 'example2.rb'",
-                  "    - 'example4.rb'",
-                  ''].join("\n"))
+          .to eq(<<-END.strip_indent)
+            # Offense count: 3
+            # Cop supports --auto-correct.
+            # Configuration parameters: EnforcedStyle, SupportedStyles.
+            # SupportedStyles: use_perl_names, use_english_names
+            Style/SpecialGlobalVars:
+              Exclude:
+                - 'example1.rb'
+                - 'example2.rb'
+                - 'example4.rb'
+          END
       end
     end
 

--- a/spec/rubocop/cli/cli_autocorrect_spec.rb
+++ b/spec/rubocop/cli/cli_autocorrect_spec.rb
@@ -10,76 +10,88 @@ describe RuboCop::CLI, :isolated_environment do
   end
 
   it 'does not correct ExtraSpacing in a hash that would be changed back' do
-    create_file('.rubocop.yml', ['Style/AlignHash:',
-                                 '  EnforcedColonStyle: table'])
-    source = ['hash = {',
-              '  alice: {',
-              '    age:  23,',
-              "    role: 'Director'",
-              '  },',
-              '  bob:   {',
-              '    age:  25,',
-              "    role: 'Consultant'",
-              '  }',
-              '}']
+    create_file('.rubocop.yml', <<-END.strip_indent)
+      Style/AlignHash:
+        EnforcedColonStyle: table
+    END
+    source = <<-END.strip_indent
+      hash = {
+        alice: {
+          age:  23,
+          role: 'Director'
+        },
+        bob:   {
+          age:  25,
+          role: 'Consultant'
+        }
+      }
+    END
     create_file('example.rb', source)
     expect(cli.run(['--auto-correct'])).to eq(1)
-    expect(IO.read('example.rb')).to eq(source.join("\n") + "\n")
+    expect(IO.read('example.rb')).to eq(source)
   end
 
   it 'does not correct SpaceAroundOperators in a hash that would be ' \
      'changed back' do
-    create_file('.rubocop.yml', ['Style/HashSyntax:',
-                                 '  EnforcedStyle: hash_rockets',
-                                 '',
-                                 'Style/AlignHash:',
-                                 '  EnforcedHashRocketStyle: table'])
-    source = ['a = { 1=>2, a => b }',
-              'hash = {',
-              '  :alice => {',
-              '    :age  => 23,',
-              "    :role => 'Director'",
-              '  },',
-              '  :bob   => {',
-              '    :age  => 25,',
-              "    :role => 'Consultant'",
-              '  }',
-              '}']
+    create_file('.rubocop.yml', <<-END.strip_indent)
+      Style/HashSyntax:
+        EnforcedStyle: hash_rockets
+
+      Style/AlignHash:
+        EnforcedHashRocketStyle: table
+    END
+    source = <<-END.strip_indent
+      a = { 1=>2, a => b }
+      hash = {
+        :alice => {
+          :age  => 23,
+          :role => 'Director'
+        },
+        :bob   => {
+          :age  => 25,
+          :role => 'Consultant'
+        }
+      }
+    END
     create_file('example.rb', source)
     expect(cli.run(['--auto-correct'])).to eq(1)
 
     # 1=>2 is changed to 1 => 2. The rest is unchanged.
     # SpaceAroundOperators leaves it to AlignHash when the style is table.
-    expect(IO.read('example.rb')).to eq(['a = { 1 => 2, a => b }',
-                                         'hash = {',
-                                         '  :alice => {',
-                                         '    :age  => 23,',
-                                         "    :role => 'Director'",
-                                         '  },',
-                                         '  :bob   => {',
-                                         '    :age  => 25,',
-                                         "    :role => 'Consultant'",
-                                         '  }',
-                                         '}'].join("\n") + "\n")
+    expect(IO.read('example.rb')).to eq(<<-END.strip_indent)
+      a = { 1 => 2, a => b }
+      hash = {
+        :alice => {
+          :age  => 23,
+          :role => 'Director'
+        },
+        :bob   => {
+          :age  => 25,
+          :role => 'Consultant'
+        }
+      }
+    END
   end
 
   describe 'trailing comma cops' do
     let(:source) do
-      ['func({',
-       '  @abc => 0,',
-       '  @xyz => 1',
-       '})',
-       'func(',
-       '  {',
-       '    abc: 0',
-       '  }',
-       ')',
-       'func(',
-       '  {},',
-       '  {',
-       '    xyz: 1',
-       '  }',
-       ')']
+      <<-END.strip_indent
+        func({
+          @abc => 0,
+          @xyz => 1
+        })
+        func(
+          {
+            abc: 0
+          }
+        )
+        func(
+          {},
+          {
+            xyz: 1
+          }
+        )
+      END
     end
 
     let(:config) do
@@ -109,7 +121,7 @@ describe RuboCop::CLI, :isolated_environment do
         cli.run(['--auto-correct'])
 
         expect(IO.read('example.rb'))
-          .to eq(expected_corrected_source.join("\n") + "\n")
+          .to eq(expected_corrected_source)
 
         expect($stderr.string).to eq('')
       end
@@ -130,21 +142,23 @@ describe RuboCop::CLI, :isolated_environment do
         end
 
         let(:expected_corrected_source) do
-          ['func({',
-           '       @abc => 0,',
-           '       @xyz => 1,', # comma added
-           '     })',
-           'func(',
-           '  {',
-           '    abc: 0,', # comma added
-           '  },', # comma added
-           ')',
-           'func(',
-           '  {},',
-           '  {',
-           '    xyz: 1,', # comma added
-           '  },', # comma added
-           ')']
+          <<-END.strip_indent
+            func({
+                   @abc => 0,
+                   @xyz => 1,
+                 })
+            func(
+              {
+                abc: 0,
+              },
+            )
+            func(
+              {},
+              {
+                xyz: 1,
+              },
+            )
+          END
         end
 
         include_examples 'corrects offenses without producing a double comma'
@@ -158,15 +172,17 @@ describe RuboCop::CLI, :isolated_environment do
         end
 
         let(:expected_corrected_source) do
-          ['func(@abc => 0,',
-           '     @xyz => 1)',
-           'func(',
-           '  abc: 0,', # comma added
-           ')',
-           'func(',
-           '  {},',
-           '  xyz: 1,', # comma added
-           ')']
+          <<-END.strip_indent
+            func(@abc => 0,
+                 @xyz => 1)
+            func(
+              abc: 0,
+            )
+            func(
+              {},
+              xyz: 1,
+            )
+          END
         end
 
         include_examples 'corrects offenses without producing a double comma'
@@ -180,17 +196,19 @@ describe RuboCop::CLI, :isolated_environment do
         end
 
         let(:expected_corrected_source) do
-          ['func(@abc => 0,',
-           '     @xyz => 1)',
-           'func(',
-           '  abc: 0,', # comma added
-           ')',
-           'func(',
-           '  {},',
-           '  {',
-           '    xyz: 1,', # comma added
-           '  },', # comma added
-           ')']
+          <<-END.strip_indent
+            func(@abc => 0,
+                 @xyz => 1)
+            func(
+              abc: 0,
+            )
+            func(
+              {},
+              {
+                xyz: 1,
+              },
+            )
+          END
         end
 
         include_examples 'corrects offenses without producing a double comma'
@@ -212,21 +230,23 @@ describe RuboCop::CLI, :isolated_environment do
         end
 
         let(:expected_corrected_source) do
-          ['func({',
-           '       @abc => 0,',
-           '       @xyz => 1,', # comma added
-           '     },)', # comma added
-           'func(',
-           '  {',
-           '    abc: 0,', # comma added
-           '  },', # comma added
-           ')',
-           'func(',
-           '  {},',
-           '  {',
-           '    xyz: 1,', # comma added
-           '  },', # comma added
-           ')']
+          <<-END.strip_indent
+            func({
+                   @abc => 0,
+                   @xyz => 1,
+                 },)
+            func(
+              {
+                abc: 0,
+              },
+            )
+            func(
+              {},
+              {
+                xyz: 1,
+              },
+            )
+          END
         end
 
         include_examples 'corrects offenses without producing a double comma'
@@ -240,15 +260,17 @@ describe RuboCop::CLI, :isolated_environment do
         end
 
         let(:expected_corrected_source) do
-          ['func(@abc => 0,',
-           '     @xyz => 1,)', # comma added
-           'func(',
-           '  abc: 0,', # comma added
-           ')',
-           'func(',
-           '  {},',
-           '  xyz: 1,', # comma added
-           ')']
+          <<-END.strip_indent
+            func(@abc => 0,
+                 @xyz => 1,)
+            func(
+              abc: 0,
+            )
+            func(
+              {},
+              xyz: 1,
+            )
+          END
         end
 
         include_examples 'corrects offenses without producing a double comma'
@@ -262,17 +284,19 @@ describe RuboCop::CLI, :isolated_environment do
         end
 
         let(:expected_corrected_source) do
-          ['func(@abc => 0,',
-           '     @xyz => 1,)', # comma added
-           'func(',
-           '  abc: 0,', # comma added
-           ')',
-           'func(',
-           '  {},',
-           '  {',
-           '    xyz: 1,', # comma added
-           '  },', # comma added
-           ')']
+          <<-END.strip_indent
+            func(@abc => 0,
+                 @xyz => 1,)
+            func(
+              abc: 0,
+            )
+            func(
+              {},
+              {
+                xyz: 1,
+              },
+            )
+          END
         end
 
         include_examples 'corrects offenses without producing a double comma'
@@ -282,33 +306,38 @@ describe RuboCop::CLI, :isolated_environment do
 
   it 'corrects IndentationWidth, RedundantBegin, and ' \
      'RescueEnsureAlignment offenses' do
-    source = ['def verify_section',
-              '      begin',
-              '      scroll_down_until_element_exists',
-              '      rescue',
-              '        scroll_down_until_element_exists',
-              '        end',
-              'end']
+    source = <<-END.strip_indent
+      def verify_section
+            begin
+            scroll_down_until_element_exists
+            rescue
+              scroll_down_until_element_exists
+              end
+      end
+    END
     create_file('example.rb', source)
     expect(cli.run(['--auto-correct'])).to eq(0)
-    corrected = ['def verify_section',
-                 '  scroll_down_until_element_exists',
-                 'rescue',
-                 '  scroll_down_until_element_exists',
-                 'end',
-                 '']
-    expect(IO.read('example.rb')).to eq(corrected.join("\n"))
+    corrected = <<-END.strip_indent
+      def verify_section
+        scroll_down_until_element_exists
+      rescue
+        scroll_down_until_element_exists
+      end
+    END
+    expect(IO.read('example.rb')).to eq(corrected)
   end
 
   it 'corrects LineEndConcatenation offenses leaving the ' \
      'UnneededInterpolation offense unchanged' do
     # If we change string concatenation from plus to backslash, the string
     # literal that follows must remain a string literal.
-    source = ["puts 'foo' +",
-              '     "#{bar}"',
-              "puts 'a' +",
-              "  'b'",
-              '"#{c}"']
+    source = <<-'END'.strip_indent
+      puts 'foo' +
+           "#{bar}"
+      puts 'a' +
+        'b'
+      "#{c}"
+    END
     create_file('example.rb', source)
     expect(cli.run(['--auto-correct'])).to eq(0)
     corrected = ["puts 'foo' \\",
@@ -318,246 +347,264 @@ describe RuboCop::CLI, :isolated_environment do
                  "puts 'a' \\",
                  "     'b'",
                  'c.to_s',
-                 '']
-    expect(IO.read('example.rb')).to eq(corrected.join("\n"))
+                 ''].join("\n")
+    expect(IO.read('example.rb')).to eq(corrected)
   end
 
   %i[line_count_based semantic braces_for_chaining].each do |style|
     context "when BlockDelimiters has #{style} style" do
       it 'corrects SpaceBeforeBlockBraces, SpaceInsideBlockBraces offenses' do
-        source = ['r = foo.map{|a|',
-                  '  a.bar.to_s',
-                  '}',
-                  'foo.map{|a|',
-                  '  a.bar.to_s',
-                  '}.baz']
+        source = <<-END.strip_indent
+          r = foo.map{|a|
+            a.bar.to_s
+          }
+          foo.map{|a|
+            a.bar.to_s
+          }.baz
+        END
         create_file('example.rb', source)
-        create_file('.rubocop.yml', ['Style/BlockDelimiters:',
-                                     "  EnforcedStyle: #{style}"])
+        create_file('.rubocop.yml', <<-END.strip_indent)
+          Style/BlockDelimiters:
+            EnforcedStyle: #{style}
+        END
         expect(cli.run(['--auto-correct'])).to eq(1)
         corrected = case style
                     when :semantic
-                      ['r = foo.map { |a|',
-                       '  a.bar.to_s',
-                       '}',
-                       'foo.map { |a|',
-                       '  a.bar.to_s',
-                       '}.baz',
-                       '']
+                      <<-END.strip_indent
+                        r = foo.map { |a|
+                          a.bar.to_s
+                        }
+                        foo.map { |a|
+                          a.bar.to_s
+                        }.baz
+                      END
                     when :braces_for_chaining
-                      ['r = foo.map do |a|',
-                       '  a.bar.to_s',
-                       'end',
-                       'foo.map { |a|',
-                       '  a.bar.to_s',
-                       '}.baz',
-                       '']
+                      <<-END.strip_indent
+                        r = foo.map do |a|
+                          a.bar.to_s
+                        end
+                        foo.map { |a|
+                          a.bar.to_s
+                        }.baz
+                      END
                     when :line_count_based
-                      ['r = foo.map do |a|',
-                       '  a.bar.to_s',
-                       'end',
-                       'foo.map do |a|',
-                       '  a.bar.to_s',
-                       'end.baz',
-                       '']
+                      <<-END.strip_indent
+                        r = foo.map do |a|
+                          a.bar.to_s
+                        end
+                        foo.map do |a|
+                          a.bar.to_s
+                        end.baz
+                      END
                     end
         expect($stderr.string).to eq('')
-        expect(IO.read('example.rb')).to eq(corrected.join("\n"))
+        expect(IO.read('example.rb')).to eq(corrected)
       end
     end
   end
 
   it 'corrects InitialIndentation offenses' do
-    source = ['  # comment 1',
-              '',
-              '  # comment 2',
-              '  def func',
-              '    begin',
-              '      foo',
-              '      bar',
-              '    rescue',
-              '      baz',
-              '    end',
-              '  end',
-              ''].join("\n")
+    source = <<-END.strip_indent
+        # comment 1
+
+        # comment 2
+        def func
+          begin
+            foo
+            bar
+          rescue
+            baz
+          end
+        end
+    END
     create_file('example.rb', source)
-    create_file('.rubocop.yml', ['Lint/DefEndAlignment:',
-                                 '  AutoCorrect: true'])
+    create_file('.rubocop.yml', <<-END.strip_indent)
+      Lint/DefEndAlignment:
+        AutoCorrect: true
+    END
     expect(cli.run(['--auto-correct'])).to eq(0)
-    corrected = ['# comment 1',
-                 '',
-                 '# comment 2',
-                 'def func',
-                 '  foo',
-                 '  bar',
-                 'rescue',
-                 '  baz',
-                 'end',
-                 '']
+    corrected = <<-END.strip_indent
+      # comment 1
+
+      # comment 2
+      def func
+        foo
+        bar
+      rescue
+        baz
+      end
+    END
     expect($stderr.string).to eq('')
-    expect(IO.read('example.rb')).to eq(corrected.join("\n"))
+    expect(IO.read('example.rb')).to eq(corrected)
   end
 
   it 'corrects UnneededDisable offenses' do
-    source = ['class A',
-              '  # rubocop:disable Metrics/MethodLength',
-              '  def func',
-              '    x = foo # rubocop:disable Lint/UselessAssignment,Style/For',
-              '    # rubocop:disable all',
-              '    # rubocop:disable Style/ClassVars',
-              '    @@bar = "3"',
-              '  end',
-              'end',
-              ''].join("\n")
+    source = <<-END.strip_indent
+      class A
+        # rubocop:disable Metrics/MethodLength
+        def func
+          x = foo # rubocop:disable Lint/UselessAssignment,Style/For
+          # rubocop:disable all
+          # rubocop:disable Style/ClassVars
+          @@bar = "3"
+        end
+      end
+    END
     create_file('example.rb', source)
     expect(cli.run(%w[--auto-correct --format simple])).to eq(1)
-    expect($stdout.string)
-      .to eq(['== example.rb ==',
-              'C:  1:  1: Missing top-level class documentation comment.',
-              'W:  2:  3: [Corrected] Unnecessary disabling of ' \
-              'Metrics/MethodLength.',
-              'W:  4: 54: [Corrected] Unnecessary disabling of Style/For.',
-              'W:  6:  5: [Corrected] Unnecessary disabling of ' \
-              'Style/ClassVars.',
-              '',
-              '1 file inspected, 4 offenses detected, 3 offenses corrected',
-              ''].join("\n"))
-    corrected = ['class A',
-                 '  def func',
-                 '    x = foo # rubocop:disable Lint/UselessAssignment',
-                 '    # rubocop:disable all',
-                 '    @@bar = "3"',
-                 '  end',
-                 'end',
-                 '']
+    expect($stdout.string).to eq(<<-END.strip_indent)
+      == example.rb ==
+      C:  1:  1: Missing top-level class documentation comment.
+      W:  2:  3: [Corrected] Unnecessary disabling of Metrics/MethodLength.
+      W:  4: 54: [Corrected] Unnecessary disabling of Style/For.
+      W:  6:  5: [Corrected] Unnecessary disabling of Style/ClassVars.
+
+      1 file inspected, 4 offenses detected, 3 offenses corrected
+    END
+    corrected = <<-END.strip_indent
+      class A
+        def func
+          x = foo # rubocop:disable Lint/UselessAssignment
+          # rubocop:disable all
+          @@bar = "3"
+        end
+      end
+    END
     expect($stderr.string).to eq('')
-    expect(IO.read('example.rb')).to eq(corrected.join("\n"))
+    expect(IO.read('example.rb')).to eq(corrected)
   end
 
   it 'corrects RedundantBegin offenses and fixes indentation etc' do
-    source = ['  def func',
-              '    begin',
-              '      foo',
-              '      bar',
-              '    rescue',
-              '      baz',
-              '    end',
-              '  end',
-              '',
-              '  def func; begin; x; y; rescue; z end end',
-              '',
-              'def method',
-              '  begin',
-              '    BlockA do |strategy|',
-              '      foo',
-              '    end',
-              '',
-              '    BlockB do |portfolio|',
-              '      foo',
-              '    end',
-              '',
-              '  rescue => e # some problem',
-              '    bar',
-              '  end',
-              'end',
-              '',
-              'def method',
-              '  begin # comment 1',
-              '    do_some_stuff',
-              '  rescue # comment 2',
-              '  end # comment 3',
-              'end',
-              ''].join("\n")
+    source = <<-END.strip_indent
+        def func
+          begin
+            foo
+            bar
+          rescue
+            baz
+          end
+        end
+
+        def func; begin; x; y; rescue; z end end
+
+      def method
+        begin
+          BlockA do |strategy|
+            foo
+          end
+
+          BlockB do |portfolio|
+            foo
+          end
+
+        rescue => e # some problem
+          bar
+        end
+      end
+
+      def method
+        begin # comment 1
+          do_some_stuff
+        rescue # comment 2
+        end # comment 3
+      end
+    END
     create_file('example.rb', source)
     expect(cli.run(['--auto-correct'])).to eq(1)
-    corrected = ['def func',
-                 '  foo',
-                 '  bar',
-                 '  rescue',
-                 '    baz',
-                 '  end',
-                 '',
-                 'def func',
-                 '  x; y; rescue; z',
-                 'end',
-                 '',
-                 'def method',
-                 '  BlockA do |_strategy|',
-                 '    foo',
-                 '  end',
-                 '',
-                 '  BlockB do |_portfolio|',
-                 '    foo',
-                 '  end',
-                 'rescue => e # some problem',
-                 '  bar',
-                 'end',
-                 '',
-                 'def method',
-                 '  # comment 1',
-                 '  do_some_stuff',
-                 'rescue # comment 2',
-                 '  # comment 3',
-                 'end',
-                 '']
-    expect(IO.read('example.rb')).to eq(corrected.join("\n"))
+    corrected = <<-END.strip_indent
+      def func
+        foo
+        bar
+        rescue
+          baz
+        end
+
+      def func
+        x; y; rescue; z
+      end
+
+      def method
+        BlockA do |_strategy|
+          foo
+        end
+
+        BlockB do |_portfolio|
+          foo
+        end
+      rescue => e # some problem
+        bar
+      end
+
+      def method
+        # comment 1
+        do_some_stuff
+      rescue # comment 2
+        # comment 3
+      end
+    END
+    expect(IO.read('example.rb')).to eq(corrected)
   end
 
   it 'corrects Tab and IndentationConsistency offenses' do
-    source = ['  render_views',
-              "    describe 'GET index' do",
-              "\t    it 'returns http success' do",
-              "\t    end",
-              "\tdescribe 'admin user' do",
-              '     before(:each) do',
-              "\t    end",
-              "\tend",
-              '    end',
-              '']
+    source = <<-END.strip_indent
+        render_views
+          describe 'GET index' do
+      \t    it 'returns http success' do
+      \t    end
+      \tdescribe 'admin user' do
+           before(:each) do
+      \t    end
+      \tend
+          end
+    END
     create_file('example.rb', source)
     expect(cli.run(['--auto-correct'])).to eq(0)
-    corrected = ['render_views',
-                 "describe 'GET index' do",
-                 "  it 'returns http success' do",
-                 '  end',
-                 "  describe 'admin user' do",
-                 '    before(:each) do',
-                 '    end',
-                 '  end',
-                 'end',
-                 '']
-    expect(IO.read('example.rb')).to eq(corrected.join("\n"))
+    corrected = <<-END.strip_indent
+      render_views
+      describe 'GET index' do
+        it 'returns http success' do
+        end
+        describe 'admin user' do
+          before(:each) do
+          end
+        end
+      end
+    END
+    expect(IO.read('example.rb')).to eq(corrected)
   end
 
   it 'corrects IndentationWidth and IndentationConsistency offenses' do
-    source = ["require 'spec_helper'",
-              'describe ArticlesController do',
-              '  render_views',
-              '    describe "GET \'index\'" do',
-              '            it "returns http success" do',
-              '            end',
-              '        describe "admin user" do',
-              '             before(:each) do',
-              '            end',
-              '        end',
-              '    end',
-              'end']
+    source = <<-END.strip_indent
+      require 'spec_helper'
+      describe ArticlesController do
+        render_views
+          describe "GET \'index\'" do
+                  it "returns http success" do
+                  end
+              describe "admin user" do
+                   before(:each) do
+                  end
+              end
+          end
+      end
+    END
     create_file('example.rb', source)
     expect(cli.run(['--auto-correct'])).to eq(0)
-    corrected = ["require 'spec_helper'",
-                 'describe ArticlesController do',
-                 '  render_views',
-                 "  describe \"GET 'index'\" do",
-                 "    it 'returns http success' do",
-                 '    end',
-                 "    describe 'admin user' do",
-                 '      before(:each) do',
-                 '      end',
-                 '    end',
-                 '  end',
-                 'end',
-                 '']
-    expect(IO.read('example.rb')).to eq(corrected.join("\n"))
+    corrected = <<-END.strip_indent
+      require 'spec_helper'
+      describe ArticlesController do
+        render_views
+        describe \"GET 'index'\" do
+          it 'returns http success' do
+          end
+          describe 'admin user' do
+            before(:each) do
+            end
+          end
+        end
+      end
+    END
+    expect(IO.read('example.rb')).to eq(corrected)
   end
 
   it 'corrects SymbolProc and SpaceBeforeBlockBraces offenses' do
@@ -573,23 +620,26 @@ describe RuboCop::CLI, :isolated_environment do
   end
 
   it 'corrects only IndentationWidth without crashing' do
-    source = ['foo = if bar',
-              '  something',
-              'elsif baz',
-              '  other_thing',
-              'else',
-              '  raise',
-              'end']
+    source = <<-END.strip_indent
+      foo = if bar
+        something
+      elsif baz
+        other_thing
+      else
+        raise
+      end
+    END
     create_file('example.rb', source)
     expect(cli.run(%w[--only IndentationWidth --auto-correct])).to eq(0)
-    corrected = ['foo = if bar',
-                 '        something',
-                 'elsif baz',
-                 '  other_thing',
-                 'else',
-                 '  raise',
-                 'end',
-                 ''].join("\n")
+    corrected = <<-END.strip_indent
+      foo = if bar
+              something
+      elsif baz
+        other_thing
+      else
+        raise
+      end
+    END
     expect(IO.read('example.rb')).to eq(corrected)
   end
 
@@ -600,129 +650,144 @@ describe RuboCop::CLI, :isolated_environment do
     # whitespace in the process, the combined changes don't interfere with
     # each other and the result is semantically the same as the starting
     # point.
-    source = ['expect(subject[:address]).to eq({',
-              "  street1:     '1 Market',",
-              "  street2:     '#200',",
-              "  city:        'Some Town',",
-              "  state:       'CA',",
-              "  postal_code: '99999-1111'",
-              '})']
+    source = <<-END.strip_indent
+      expect(subject[:address]).to eq({
+        street1:     '1 Market',
+        street2:     '#200',
+        city:        'Some Town',
+        state:       'CA',
+        postal_code: '99999-1111'
+      })
+    END
     create_file('example.rb', source)
     expect(cli.run(['-D', '--auto-correct'])).to eq(0)
     corrected =
-      ["expect(subject[:address]).to eq(street1:     '1 Market',",
-       "                                street2:     '#200',",
-       "                                city:        'Some Town',",
-       "                                state:       'CA',",
-       "                                postal_code: '99999-1111')"]
-    expect(IO.read('example.rb')).to eq(corrected.join("\n") + "\n")
+      <<-END.strip_indent
+        expect(subject[:address]).to eq(street1:     '1 Market',
+                                        street2:     '#200',
+                                        city:        'Some Town',
+                                        state:       'CA',
+                                        postal_code: '99999-1111')
+      END
+    expect(IO.read('example.rb')).to eq(corrected)
   end
 
   it 'honors Exclude settings in individual cops' do
     source = 'puts %x(ls)'
     create_file('example.rb', source)
-    create_file('.rubocop.yml', ['Style/CommandLiteral:',
-                                 '  Exclude:',
-                                 '    - example.rb'])
+    create_file('.rubocop.yml', <<-END.strip_indent)
+      Style/CommandLiteral:
+        Exclude:
+          - example.rb
+    END
     expect(cli.run(['--auto-correct'])).to eq(0)
     expect($stdout.string).to include('no offenses detected')
     expect(IO.read('example.rb')).to eq("#{source}\n")
   end
 
   it 'corrects code with indentation problems' do
-    create_file('example.rb', ['module Bar',
-                               'class Goo',
-                               '  def something',
-                               '    first call',
-                               "      do_other 'things'",
-                               '      if other > 34',
-                               '        more_work',
-                               '      end',
-                               '  end',
-                               'end',
-                               'end',
-                               '',
-                               'module Foo',
-                               'class Bar',
-                               '',
-                               '  stuff = [',
-                               '            {',
-                               "              some: 'hash',",
-                               '            },',
-                               '                 {',
-                               "              another: 'hash',",
-                               "              with: 'more'",
-                               '            },',
-                               '          ]',
-                               'end',
-                               'end'])
+    create_file('example.rb', <<-END.strip_indent)
+      module Bar
+      class Goo
+        def something
+          first call
+            do_other 'things'
+            if other > 34
+              more_work
+            end
+        end
+      end
+      end
+
+      module Foo
+      class Bar
+
+        stuff = [
+                  {
+                    some: 'hash',
+                  },
+                       {
+                    another: 'hash',
+                    with: 'more'
+                  },
+                ]
+      end
+      end
+    END
     expect(cli.run(['--auto-correct'])).to eq(1)
     expect(IO.read('example.rb'))
-      .to eq(['module Bar',
-              '  class Goo',
-              '    def something',
-              '      first call',
-              "      do_other 'things'",
-              '      more_work if other > 34',
-              '    end',
-              '  end',
-              'end',
-              '',
-              'module Foo',
-              '  class Bar',
-              '    stuff = [',
-              '      {',
-              "        some: 'hash'",
-              '      },',
-              '      {',
-              "        another: 'hash',",
-              "        with: 'more'",
-              '      }',
-              '    ]',
-              '  end',
-              'end',
-              ''].join("\n"))
+      .to eq(<<-END.strip_indent)
+        module Bar
+          class Goo
+            def something
+              first call
+              do_other 'things'
+              more_work if other > 34
+            end
+          end
+        end
+
+        module Foo
+          class Bar
+            stuff = [
+              {
+                some: 'hash'
+              },
+              {
+                another: 'hash',
+                with: 'more'
+              }
+            ]
+          end
+        end
+      END
   end
 
   it 'can change block comments and indent them' do
-    create_file('example.rb', ['module Foo',
-                               'class Bar',
-                               '=begin',
-                               'This is a nice long',
-                               'comment',
-                               'which spans a few lines',
-                               '=end',
-                               '  def baz',
-                               '    do_something',
-                               '  end',
-                               'end',
-                               'end'])
+    create_file('example.rb', <<-END.strip_indent)
+      module Foo
+      class Bar
+      =begin
+      This is a nice long
+      comment
+      which spans a few lines
+      =end
+        def baz
+          do_something
+        end
+      end
+      end
+    END
     expect(cli.run(['--auto-correct'])).to eq(1)
     expect(IO.read('example.rb'))
-      .to eq(['module Foo',
-              '  class Bar',
-              '    # This is a nice long',
-              '    # comment',
-              '    # which spans a few lines',
-              '    def baz',
-              '      do_something',
-              '    end',
-              '  end',
-              'end',
-              ''].join("\n"))
+      .to eq(<<-END.strip_indent)
+        module Foo
+          class Bar
+            # This is a nice long
+            # comment
+            # which spans a few lines
+            def baz
+              do_something
+            end
+          end
+        end
+      END
   end
 
   it 'can correct two problems with blocks' do
     # {} should be do..end and space is missing.
-    create_file('example.rb', ['(1..10).each{ |i|',
-                               '  puts i',
-                               '}'])
+    create_file('example.rb', <<-END.strip_indent)
+      (1..10).each{ |i|
+        puts i
+      }
+    END
     expect(cli.run(['--auto-correct'])).to eq(0)
     expect(IO.read('example.rb'))
-      .to eq(['(1..10).each do |i|',
-              '  puts i',
-              'end',
-              ''].join("\n"))
+      .to eq(<<-END.strip_indent)
+        (1..10).each do |i|
+          puts i
+        end
+      END
   end
 
   it 'can handle spaces when removing braces' do
@@ -730,8 +795,9 @@ describe RuboCop::CLI, :isolated_environment do
                 ["assert_post_status_code 400, 's', {:type => 'bad'}"])
     expect(cli.run(%w[--auto-correct --format emacs])).to eq(0)
     expect(IO.read('example.rb'))
-      .to eq(["assert_post_status_code 400, 's', type: 'bad'",
-              ''].join("\n"))
+      .to eq(<<-END.strip_indent)
+        assert_post_status_code 400, 's', type: 'bad'
+      END
     e = abs('example.rb')
     expect($stdout.string)
       .to eq(["#{e}:1:35: C: [Corrected] Redundant curly braces around " \
@@ -748,34 +814,40 @@ describe RuboCop::CLI, :isolated_environment do
   # A case where two cops, EmptyLinesAroundBody and EmptyLines, try to
   # remove the same line in autocorrect.
   it 'can correct two empty lines at end of class body' do
-    create_file('example.rb', ['class Test',
-                               '  def f',
-                               '  end',
-                               '',
-                               '',
-                               'end'])
+    create_file('example.rb', <<-END.strip_indent)
+      class Test
+        def f
+        end
+
+
+      end
+    END
     expect(cli.run(['--auto-correct'])).to eq(1)
     expect($stderr.string).to eq('')
-    expect(IO.read('example.rb')).to eq(['class Test',
-                                         '  def f; end',
-                                         'end',
-                                         ''].join("\n"))
+    expect(IO.read('example.rb')).to eq(<<-END.strip_indent)
+      class Test
+        def f; end
+      end
+    END
   end
 
   # A case where WordArray's correction can be clobbered by
   # AccessModifierIndentation's correction.
   it 'can correct indentation and another thing' do
-    create_file('example.rb', ['class Dsl',
-                               'private',
-                               '  A = ["git", "path",]',
-                               'end'])
+    create_file('example.rb', <<-END.strip_indent)
+      class Dsl
+      private
+        A = ["git", "path",]
+      end
+    END
     expect(cli.run(%w[--auto-correct --format emacs])).to eq(1)
-    expect(IO.read('example.rb')).to eq(['class Dsl',
-                                         '  private',
-                                         '',
-                                         '  A = %w[git path].freeze',
-                                         'end',
-                                         ''].join("\n"))
+    expect(IO.read('example.rb')).to eq(<<-END.strip_indent)
+      class Dsl
+        private
+
+        A = %w[git path].freeze
+      end
+    END
     e = abs('example.rb')
     expect($stdout.string)
       .to eq(["#{e}:1:1: C: Missing top-level class documentation " \
@@ -804,13 +876,16 @@ describe RuboCop::CLI, :isolated_environment do
   # A case where the same cop could try to correct an offense twice in one
   # place.
   it 'can correct empty line inside special form of nested modules' do
-    create_file('example.rb', ['module A module B',
-                               '',
-                               'end end'])
+    create_file('example.rb', <<-END.strip_indent)
+      module A module B
+
+      end end
+    END
     expect(cli.run(['--auto-correct'])).to eq(1)
-    expect(IO.read('example.rb')).to eq(['module A module B',
-                                         'end end',
-                                         ''].join("\n"))
+    expect(IO.read('example.rb')).to eq(<<-END.strip_indent)
+      module A module B
+      end end
+    END
     uncorrected = $stdout.string.split($RS).select do |line|
       line.include?('example.rb:') && !line.include?('[Corrected]')
     end
@@ -818,43 +893,49 @@ describe RuboCop::CLI, :isolated_environment do
   end
 
   it 'can correct single line methods' do
-    create_file('example.rb', ['def func1; do_something end # comment',
-                               'def func2() do_1; do_2; end'])
+    create_file('example.rb', <<-END.strip_indent)
+      def func1; do_something end # comment
+      def func2() do_1; do_2; end
+    END
     expect(cli.run(%w[--auto-correct --format offenses])).to eq(0)
-    expect(IO.read('example.rb')).to eq(['# comment',
-                                         'def func1',
-                                         '  do_something',
-                                         'end',
-                                         '',
-                                         'def func2',
-                                         '  do_1',
-                                         '  do_2',
-                                         'end',
-                                         ''].join("\n"))
-    expect($stdout.string).to eq(['',
-                                  '6   Style/TrailingWhitespace',
-                                  '3   Style/Semicolon',
-                                  '2   Style/SingleLineMethods',
-                                  '1   Style/DefWithParentheses',
-                                  '1   Style/EmptyLineBetweenDefs',
-                                  '--',
-                                  '13  Total',
-                                  '',
-                                  ''].join("\n"))
+    expect(IO.read('example.rb')).to eq(<<-END.strip_indent)
+      # comment
+      def func1
+        do_something
+      end
+
+      def func2
+        do_1
+        do_2
+      end
+    END
+    expect($stdout.string).to eq(<<-END.strip_indent)
+
+      6   Style/TrailingWhitespace
+      3   Style/Semicolon
+      2   Style/SingleLineMethods
+      1   Style/DefWithParentheses
+      1   Style/EmptyLineBetweenDefs
+      --
+      13  Total
+
+    END
   end
 
   # In this example, the auto-correction (changing "fail" to "raise")
   # creates a new problem (alignment of parameters), which is also
   # corrected automatically.
   it 'can correct a problems and the problem it creates' do
-    create_file('example.rb',
-                ['fail NotImplementedError,',
-                 "     'Method should be overridden in child classes'"])
+    create_file('example.rb', <<-END.strip_indent)
+      fail NotImplementedError,
+           'Method should be overridden in child classes'
+    END
     expect(cli.run(['--auto-correct'])).to eq(0)
     expect(IO.read('example.rb'))
-      .to eq(['raise NotImplementedError,',
-              "      'Method should be overridden in child classes'",
-              ''].join("\n"))
+      .to eq(<<-END.strip_indent)
+        raise NotImplementedError,
+              'Method should be overridden in child classes'
+      END
     expect($stdout.string)
       .to eq(['Inspecting 1 file',
               'C',
@@ -886,11 +967,12 @@ describe RuboCop::CLI, :isolated_environment do
                  'end'])
     expect(cli.run(['--auto-correct'])).to eq(0)
     expect(IO.read('example.rb'))
-      .to eq(['# Example class.',
-              'class Klass',
-              '  def f; end',
-              'end',
-              ''].join("\n"))
+      .to eq(<<-END.strip_indent)
+        # Example class.
+        class Klass
+          def f; end
+        end
+      END
     expect($stderr.string).to eq('')
     expect($stdout.string)
       .to eq(['Inspecting 1 file',
@@ -909,17 +991,19 @@ describe RuboCop::CLI, :isolated_environment do
   end
 
   it 'can correct MethodDefParentheses and other offense' do
-    create_file('example.rb',
-                ['def primes limit',
-                 '  1.upto(limit).select { |i| i.even? }',
-                 'end'])
+    create_file('example.rb', <<-END.strip_indent)
+      def primes limit
+        1.upto(limit).select { |i| i.even? }
+      end
+    END
     expect(cli.run(%w[-D --auto-correct])).to eq(0)
     expect($stderr.string).to eq('')
     expect(IO.read('example.rb'))
-      .to eq(['def primes(limit)',
-              '  1.upto(limit).select(&:even?)',
-              'end',
-              ''].join("\n"))
+      .to eq(<<-END.strip_indent)
+        def primes(limit)
+          1.upto(limit).select(&:even?)
+        end
+      END
     expect($stdout.string)
       .to eq(['Inspecting 1 file',
               'C',
@@ -942,22 +1026,25 @@ describe RuboCop::CLI, :isolated_environment do
   end
 
   it 'can correct WordArray and SpaceAfterComma offenses' do
-    create_file('example.rb',
-                ["f(type: ['offline','offline_payment'],",
-                 "  bar_colors: ['958c12','953579','ff5800','0085cc'])"])
+    create_file('example.rb', <<-END.strip_indent)
+      f(type: ['offline','offline_payment'],
+        bar_colors: ['958c12','953579','ff5800','0085cc'])
+    END
     expect(cli.run(%w[-D --auto-correct --format o])).to eq(0)
     expect($stdout.string)
-      .to eq(['',
-              '4  Style/SpaceAfterComma',
-              '2  Style/WordArray',
-              '--',
-              '6  Total',
-              '',
-              ''].join("\n"))
+      .to eq(<<-END.strip_indent)
+
+        4  Style/SpaceAfterComma
+        2  Style/WordArray
+        --
+        6  Total
+
+      END
     expect(IO.read('example.rb'))
-      .to eq(['f(type: %w[offline offline_payment],',
-              '  bar_colors: %w[958c12 953579 ff5800 0085cc])',
-              ''].join("\n"))
+      .to eq(<<-END.strip_indent)
+        f(type: %w[offline offline_payment],
+          bar_colors: %w[958c12 953579 ff5800 0085cc])
+      END
   end
 
   it 'can correct SpaceAfterComma and HashSyntax offenses' do
@@ -1007,8 +1094,9 @@ describe RuboCop::CLI, :isolated_environment do
                  '',
                  ''])
     expect(cli.run(%w[--auto-correct --format emacs])).to eq(0)
-    expect(IO.read('example.rb')).to eq(['# encoding: utf-8',
-                                         ''].join("\n"))
+    expect(IO.read('example.rb')).to eq(<<-END.strip_indent)
+      # encoding: utf-8
+    END
     expect($stdout.string)
       .to eq(["#{abs('example.rb')}:2:1: C: [Corrected] 3 trailing " \
               'blank lines detected.',
@@ -1031,52 +1119,61 @@ describe RuboCop::CLI, :isolated_environment do
   end
 
   it 'can correct IndentHash offenses with separator style' do
-    create_file('example.rb',
-                ['CONVERSION_CORRESPONDENCE = {',
-                 '              match_for_should: :match,',
-                 '          match_for_should_not: :match_when_negated,',
-                 '    failure_message_for_should: :failure_message,',
-                 'failure_message_for_should_not: :failure_message_when',
-                 '}'])
-    create_file('.rubocop.yml',
-                ['Style/AlignHash:',
-                 '  EnforcedColonStyle: separator'])
+    create_file('example.rb', <<-END.strip_indent)
+      CONVERSION_CORRESPONDENCE = {
+                    match_for_should: :match,
+                match_for_should_not: :match_when_negated,
+          failure_message_for_should: :failure_message,
+      failure_message_for_should_not: :failure_message_when
+      }
+    END
+    create_file('.rubocop.yml', <<-END.strip_indent)
+      Style/AlignHash:
+        EnforcedColonStyle: separator
+    END
     expect(cli.run(%w[--auto-correct])).to eq(0)
     expect(IO.read('example.rb'))
-      .to eq(['CONVERSION_CORRESPONDENCE = {',
-              '                match_for_should: :match,',
-              '            match_for_should_not: :match_when_negated,',
-              '      failure_message_for_should: :failure_message,',
-              '  failure_message_for_should_not: :failure_message_when',
-              '}.freeze',
-              ''].join("\n"))
+      .to eq(<<-END.strip_indent)
+        CONVERSION_CORRESPONDENCE = {
+                        match_for_should: :match,
+                    match_for_should_not: :match_when_negated,
+              failure_message_for_should: :failure_message,
+          failure_message_for_should_not: :failure_message_when
+        }.freeze
+      END
   end
 
   it 'does not say [Corrected] if correction was avoided' do
-    src = ['func a do b end',
-           "Signal.trap('TERM') { system(cmd); exit }",
-           'def self.some_method(foo, bar: 1)',
-           '  log.debug(foo)',
-           'end']
-    corrected = ['func a do b end',
-                 "Signal.trap('TERM') { system(cmd); exit }",
-                 'def self.some_method(foo, bar: 1)',
-                 '  log.debug(foo)',
-                 'end']
-    offenses =
-      ['== example.rb ==',
-       'C:  1:  8: Prefer {...} over do...end for single-line blocks.',
-       'C:  2: 34: Do not use semicolons to terminate expressions.',
-       'W:  3: 27: Unused method argument - bar.']
-    summary = '1 file inspected, 3 offenses detected'
-    create_file('.rubocop.yml', ['AllCops:',
-                                 '  TargetRubyVersion: 2.1'])
+    src = <<-END.strip_indent
+      func a do b end
+      Signal.trap('TERM') { system(cmd); exit }
+      def self.some_method(foo, bar: 1)
+        log.debug(foo)
+      end
+    END
+    corrected = <<-END.strip_indent
+      func a do b end
+      Signal.trap('TERM') { system(cmd); exit }
+      def self.some_method(foo, bar: 1)
+        log.debug(foo)
+      end
+    END
+    create_file('.rubocop.yml', <<-END.strip_indent)
+      AllCops:
+        TargetRubyVersion: 2.1
+    END
     create_file('example.rb', src)
     expect(cli.run(%w[-a -f simple])).to eq(1)
     expect($stderr.string).to eq('')
-    expect(IO.read('example.rb')).to eq(corrected.join("\n") + "\n")
-    expect($stdout.string)
-      .to eq((offenses + ['', summary, '']).join("\n"))
+    expect(IO.read('example.rb')).to eq(corrected)
+    expect($stdout.string).to eq(<<-END.strip_indent)
+      == example.rb ==
+      C:  1:  8: Prefer {...} over do...end for single-line blocks.
+      C:  2: 34: Do not use semicolons to terminate expressions.
+      W:  3: 27: Unused method argument - bar.
+
+      1 file inspected, 3 offenses detected
+    END
   end
 
   it 'does not hang SpaceAfterPunctuation and SpaceInsideParens' do
@@ -1099,8 +1196,10 @@ describe RuboCop::CLI, :isolated_environment do
 
   it 'can be disabled for any cop in configuration' do
     create_file('example.rb', 'puts "Hello", 123456')
-    create_file('.rubocop.yml', ['Style/StringLiterals:',
-                                 '  AutoCorrect: false'])
+    create_file('.rubocop.yml', <<-END.strip_indent)
+      Style/StringLiterals:
+        AutoCorrect: false
+    END
     expect(cli.run(%w[--auto-correct])).to eq(1)
     expect($stderr.string).to eq('')
     expect(IO.read('example.rb')).to eq("puts \"Hello\", 123_456\n")
@@ -1108,38 +1207,43 @@ describe RuboCop::CLI, :isolated_environment do
 
   it 'handles different SpaceInsideBlockBraces and ' \
      'SpaceInsideHashLiteralBraces' do
-    create_file('example.rb', ['{foo: bar,',
-                               ' bar: baz,}',
-                               'foo.each {bar;}'])
-    create_file('.rubocop.yml', [
-                  'Style/SpaceInsideBlockBraces:',
-                  '  EnforcedStyle: space',
-                  'Style/SpaceInsideHashLiteralBraces:',
-                  '  EnforcedStyle: no_space',
-                  'Style/TrailingCommaInLiteral:',
-                  '  EnforcedStyleForMultiline: consistent_comma'
-                ])
+    create_file('example.rb', <<-END.strip_indent)
+      {foo: bar,
+       bar: baz,}
+      foo.each {bar;}
+    END
+    create_file('.rubocop.yml', <<-END.strip_indent)
+      Style/SpaceInsideBlockBraces:
+        EnforcedStyle: space
+      Style/SpaceInsideHashLiteralBraces:
+        EnforcedStyle: no_space
+      Style/TrailingCommaInLiteral:
+        EnforcedStyleForMultiline: consistent_comma
+    END
     expect(cli.run(%w[--auto-correct])).to eq(1)
     expect($stderr.string).to eq('')
-    expect(IO.read('example.rb')).to eq(['{foo: bar,',
-                                         ' bar: baz,}',
-                                         'foo.each { bar; }',
-                                         ''].join("\n"))
+    expect(IO.read('example.rb')).to eq(<<-END.strip_indent)
+      {foo: bar,
+       bar: baz,}
+      foo.each { bar; }
+    END
   end
 
   it 'corrects BracesAroundHashParameters offenses leaving the ' \
      'MultilineHashBraceLayout offense unchanged' do
-    create_file('example.rb', ['def method_a',
-                               '  do_something({ a: 1,',
-                               '  })',
-                               'end',
-                               ''])
+    create_file('example.rb', <<-END.strip_indent)
+      def method_a
+        do_something({ a: 1,
+        })
+      end
+    END
 
     expect($stderr.string).to eq('')
     expect(cli.run(%w[--auto-correct])).to eq(0)
-    expect(IO.read('example.rb')).to eq(['def method_a',
-                                         '  do_something(a: 1)',
-                                         'end',
-                                         ''].join("\n"))
+    expect(IO.read('example.rb')).to eq(<<-END.strip_indent)
+      def method_a
+        do_something(a: 1)
+      end
+    END
   end
 end

--- a/spec/rubocop/config_loader_spec.rb
+++ b/spec/rubocop/config_loader_spec.rb
@@ -74,8 +74,10 @@ describe RuboCop::ConfigLoader do
       let(:file_path) { '.rubocop.yml' }
 
       before do
-        create_file(file_path, ['Style/Encoding:',
-                                '  Enabled: false'])
+        create_file(file_path, <<-END.strip_indent)
+          Style/Encoding:
+            Enabled: false
+        END
       end
 
       it 'returns a configuration inheriting from default.yml' do
@@ -90,14 +92,16 @@ describe RuboCop::ConfigLoader do
       let(:file_path) { 'dir/.rubocop.yml' }
 
       before do
-        create_file('.rubocop.yml',
-                    ['AllCops:',
-                     '  Exclude:',
-                     '    - vendor/**'])
+        create_file('.rubocop.yml', <<-END.strip_indent)
+          AllCops:
+            Exclude:
+              - vendor/**
+        END
 
-        create_file(file_path,
-                    ['AllCops:',
-                     '  Exclude: []'])
+        create_file(file_path, <<-END.strip_indent)
+          AllCops:
+            Exclude: []
+        END
       end
 
       it 'gets AllCops/Exclude from the highest directory level' do
@@ -110,9 +114,10 @@ describe RuboCop::ConfigLoader do
       let(:file_path) { '.rubocop.yml' }
 
       before do
-        create_file('disable.yml',
-                    ['AllCops:',
-                     '  DisabledByDefault: true'])
+        create_file('disable.yml', <<-END.strip_indent)
+          AllCops:
+            DisabledByDefault: true
+        END
 
         create_file(file_path, ['inherit_from: disable.yml'])
       end
@@ -127,11 +132,12 @@ describe RuboCop::ConfigLoader do
       let(:file_path) { 'dir/.rubocop.yml' }
 
       before do
-        create_file('.rubocop.yml',
-                    ['AllCops:',
-                     '  Exclude:',
-                     '    - vendor/**',
-                     '    - !ruby/regexp /[A-Z]/'])
+        create_file('.rubocop.yml', <<-END.strip_indent)
+          AllCops:
+            Exclude:
+              - vendor/**
+              - !ruby/regexp /[A-Z]/
+        END
 
         create_file(file_path, ['inherit_from: ../.rubocop.yml'])
       end
@@ -160,10 +166,11 @@ describe RuboCop::ConfigLoader do
       let(:file_path) { 'dir/.rubocop.yml' }
 
       before do
-        create_file('src/.rubocop.yml',
-                    ['AllCops:',
-                     '  Exclude:',
-                     '    - vendor/**'])
+        create_file('src/.rubocop.yml', <<-END.strip_indent)
+          AllCops:
+            Exclude:
+              - vendor/**
+        END
 
         create_file(file_path, ['inherit_from: ../src/.rubocop.yml'])
       end
@@ -182,24 +189,27 @@ describe RuboCop::ConfigLoader do
             RuboCop::Cop::Registry.new(RuboCop::Cop::Cop.registry.cops)
           )
 
-        create_file('third_party/gem.rb',
-                    ['module RuboCop',
-                     '  module Cop',
-                     '    module Custom',
-                     '      class FilePath < Cop',
-                     '      end',
-                     '    end',
-                     '  end',
-                     'end'])
+        create_file('third_party/gem.rb', <<-END.strip_indent)
+          module RuboCop
+            module Cop
+              module Custom
+                class FilePath < Cop
+                end
+              end
+            end
+          end
+        END
 
-        create_file('.rubocop.yml',
-                    ['Custom/FilePath:',
-                     '  Enabled: false'])
+        create_file('.rubocop.yml', <<-END.strip_indent)
+          Custom/FilePath:
+            Enabled: false
+        END
 
-        create_file('.rubocop_with_require.yml',
-                    ['require: ./third_party/gem',
-                     'Custom/FilePath:',
-                     '  Enabled: false'])
+        create_file('.rubocop_with_require.yml', <<-END.strip_indent)
+          require: ./third_party/gem
+          Custom/FilePath:
+            Enabled: false
+        END
       end
 
       it 'does not emit a warning' do
@@ -225,27 +235,30 @@ describe RuboCop::ConfigLoader do
       before do
         create_file('dir/subdir/example.rb', '')
 
-        create_file('.rubocop.yml',
-                    ['Metrics/LineLength:',
-                     '  Enabled: false',
-                     '  Max: 77'])
+        create_file('.rubocop.yml', <<-END.strip_indent)
+          Metrics/LineLength:
+            Enabled: false
+            Max: 77
+        END
 
-        create_file('dir/.rubocop.yml',
-                    ['inherit_from: ../.rubocop.yml',
-                     '',
-                     'Metrics/MethodLength:',
-                     '  Enabled: true',
-                     '  CountComments: false',
-                     '  Max: 10'])
+        create_file('dir/.rubocop.yml', <<-END.strip_indent)
+          inherit_from: ../.rubocop.yml
 
-        create_file(file_path,
-                    ['inherit_from: ../.rubocop.yml',
-                     '',
-                     'Metrics/LineLength:',
-                     '  Enabled: true',
-                     '',
-                     'Metrics/MethodLength:',
-                     '  Max: 5'])
+          Metrics/MethodLength:
+            Enabled: true
+            CountComments: false
+            Max: 10
+        END
+
+        create_file(file_path, <<-END.strip_indent)
+          inherit_from: ../.rubocop.yml
+
+          Metrics/LineLength:
+            Enabled: true
+
+          Metrics/MethodLength:
+            Max: 5
+        END
       end
 
       it 'returns the ancestor configuration plus local overrides' do
@@ -282,24 +295,27 @@ describe RuboCop::ConfigLoader do
       before do
         create_file('example.rb', '')
 
-        create_file('normal.yml',
-                    ['Metrics/MethodLength:',
-                     '  Enabled: false',
-                     '  CountComments: true',
-                     '  Max: 80'])
+        create_file('normal.yml', <<-END.strip_indent)
+          Metrics/MethodLength:
+            Enabled: false
+            CountComments: true
+            Max: 80
+        END
 
-        create_file('special.yml',
-                    ['Metrics/MethodLength:',
-                     '  Enabled: false',
-                     '  Max: 200'])
+        create_file('special.yml', <<-END.strip_indent)
+          Metrics/MethodLength:
+            Enabled: false
+            Max: 200
+        END
 
-        create_file(file_path,
-                    ['inherit_from:',
-                     '  - normal.yml',
-                     '  - special.yml',
-                     '',
-                     'Metrics/MethodLength:',
-                     '  Enabled: true'])
+        create_file(file_path, <<-END.strip_indent)
+          inherit_from:
+            - normal.yml
+            - special.yml
+
+          Metrics/MethodLength:
+            Enabled: true
+        END
       end
 
       it 'returns values from the last one when possible' do
@@ -317,16 +333,18 @@ describe RuboCop::ConfigLoader do
       before do
         create_file('example.rb', '')
 
-        create_file('line_length.yml',
-                    ['LineLength:',
-                     '  Max: 120'])
+        create_file('line_length.yml', <<-END.strip_indent)
+          LineLength:
+            Max: 120
+        END
 
-        create_file(file_path,
-                    ['inherit_from:',
-                     '  - line_length.yml',
-                     '',
-                     'LineLength:',
-                     '  AllowHeredoc: false'])
+        create_file(file_path, <<-END.strip_indent)
+          inherit_from:
+            - line_length.yml
+
+          LineLength:
+            AllowHeredoc: false
+        END
       end
 
       it 'returns includes both of the cop changes' do
@@ -367,9 +385,10 @@ describe RuboCop::ConfigLoader do
       let(:file_path) { '.rubocop.yml' }
 
       before do
-        create_file(file_path,
-                    ['inherit_gem:',
-                     '  not_a_real_gem: config/rubocop.yml'])
+        create_file(file_path, <<-END.strip_indent)
+          inherit_gem:
+            not_a_real_gem: config/rubocop.yml
+        END
       end
 
       it 'fails to load' do
@@ -381,9 +400,10 @@ describe RuboCop::ConfigLoader do
       let(:file_path) { '.rubocop.yml' }
 
       before do
-        create_file(file_path,
-                    ['inherit_gem:',
-                     '  rubocop: config/default.yml'])
+        create_file(file_path, <<-END.strip_indent)
+          inherit_gem:
+            rubocop: config/default.yml
+        END
       end
 
       it 'fails to load' do
@@ -395,35 +415,40 @@ describe RuboCop::ConfigLoader do
       let(:file_path) { '.rubocop.yml' }
 
       before do
-        create_file('gemone/config/rubocop.yml',
-                    ['Metrics/MethodLength:',
-                     '  Enabled: false',
-                     '  Max: 200',
-                     '  CountComments: false'])
-        create_file('gemtwo/config/default.yml',
-                    ['Metrics/LineLength:',
-                     '  Enabled: true'])
-        create_file('gemtwo/config/strict.yml',
-                    ['Metrics/LineLength:',
-                     '  Max: 72',
-                     '  AllowHeredoc: false'])
-        create_file('local.yml',
-                    ['Metrics/MethodLength:',
-                     '  CountComments: true'])
-        create_file(file_path,
-                    ['inherit_gem:',
-                     '  gemone: config/rubocop.yml',
-                     '  gemtwo:',
-                     '    - config/default.yml',
-                     '    - config/strict.yml',
-                     '',
-                     'inherit_from: local.yml',
-                     '',
-                     'Metrics/MethodLength:',
-                     '  Enabled: true',
-                     '',
-                     'Metrics/LineLength:',
-                     '  AllowURI: false'])
+        create_file('gemone/config/rubocop.yml', <<-END.strip_indent)
+          Metrics/MethodLength:
+            Enabled: false
+            Max: 200
+            CountComments: false
+        END
+        create_file('gemtwo/config/default.yml', <<-END.strip_indent)
+          Metrics/LineLength:
+            Enabled: true
+        END
+        create_file('gemtwo/config/strict.yml', <<-END.strip_indent)
+          Metrics/LineLength:
+            Max: 72
+            AllowHeredoc: false
+        END
+        create_file('local.yml', <<-END.strip_indent)
+          Metrics/MethodLength:
+            CountComments: true
+        END
+        create_file(file_path, <<-END.strip_indent)
+          inherit_gem:
+            gemone: config/rubocop.yml
+            gemtwo:
+              - config/default.yml
+              - config/strict.yml
+
+          inherit_from: local.yml
+
+          Metrics/MethodLength:
+            Enabled: true
+
+          Metrics/LineLength:
+            AllowURI: false
+        END
       end
 
       it 'returns values from the gem config with local overrides' do
@@ -495,11 +520,13 @@ describe RuboCop::ConfigLoader do
 
       context 'when DisabledByDefault is true' do
         let(:config) do
-          ['AllCops:',
-           '  DisabledByDefault: true',
-           'Style/Copyright:',
-           '  Exclude:',
-           '  - foo']
+          <<-END.strip_indent
+            AllCops:
+              DisabledByDefault: true
+            Style/Copyright:
+              Exclude:
+              - foo
+          END
         end
 
         it 'enables cops that are explicitly in the config file '\
@@ -516,10 +543,12 @@ describe RuboCop::ConfigLoader do
 
       context 'when EnabledByDefault is true' do
         let(:config) do
-          ['AllCops:',
-           '  EnabledByDefault: true',
-           'Style/TrailingWhitespace:',
-           '  Enabled: false']
+          <<-END.strip_indent
+            AllCops:
+              EnabledByDefault: true
+            Style/TrailingWhitespace:
+              Enabled: false
+          END
         end
 
         it 'enables cops that are disabled by default' do
@@ -543,10 +572,10 @@ describe RuboCop::ConfigLoader do
     let(:configuration_path) { '.rubocop.yml' }
 
     it 'returns a configuration loaded from the passed path' do
-      create_file(configuration_path, [
-                    'Style/Encoding:',
-                    '  Enabled: true'
-                  ])
+      create_file(configuration_path, <<-END.strip_indent)
+        Style/Encoding:
+          Enabled: true
+      END
       configuration = load_file
       expect(configuration['Style/Encoding']).to eq(
         'Enabled' => true
@@ -561,16 +590,20 @@ describe RuboCop::ConfigLoader do
     end
 
     it 'changes target ruby version with a patch to float' do
-      create_file(configuration_path, ['AllCops:',
-                                       '  TargetRubyVersion: 2.3.4'])
+      create_file(configuration_path, <<-END.strip_indent)
+        AllCops:
+          TargetRubyVersion: 2.3.4
+      END
 
       expect(load_file.to_h).to eq('AllCops' => { 'TargetRubyVersion' => 2.3 })
     end
 
     it 'loads configuration properly when it includes non-ascii characters ' do
-      create_file(configuration_path, ['# All these cops of mine are ❤',
-                                       'Style/Encoding:',
-                                       '  Enabled: false'])
+      create_file(configuration_path, <<-END.strip_indent)
+        # All these cops of mine are ❤
+        Style/Encoding:
+          Enabled: false
+      END
 
       expect(load_file.to_h).to eq('Style/Encoding' => { 'Enabled' => false })
     end
@@ -583,10 +616,10 @@ describe RuboCop::ConfigLoader do
 
     context 'when SafeYAML is required' do
       before do
-        create_file(configuration_path, [
-                      'Style/WordArray:',
-                      "  WordRegex: !ruby/regexp '/\\A[\\p{Word}]+\\z/'"
-                    ])
+        create_file(configuration_path, <<-END.strip_indent)
+          Style/WordArray:
+            WordRegex: !ruby/regexp '/\\A[\\p{Word}]+\\z/'
+        END
       end
 
       context 'when it is fully required' do
@@ -661,9 +694,11 @@ describe RuboCop::ConfigLoader do
     context 'when .rubocop.yml inherits from a file with a name starting ' \
             'with .rubocop' do
       before do
-        create_file('test/.rubocop_rules.yml', ['Style/CharacterLiteral:',
-                                                '  Exclude:',
-                                                '    - blargh/blah.rb'])
+        create_file('test/.rubocop_rules.yml', <<-END.strip_indent)
+          Style/CharacterLiteral:
+            Exclude:
+              - blargh/blah.rb
+        END
         create_file('test/.rubocop.yml', 'inherit_from: .rubocop_rules.yml')
       end
 

--- a/spec/rubocop/config_spec.rb
+++ b/spec/rubocop/config_spec.rb
@@ -16,11 +16,11 @@ describe RuboCop::Config do
 
     context 'when the configuration includes any unrecognized cop name' do
       before do
-        create_file(configuration_path, [
-                      'LyneLenth:',
-                      '  Enabled: true',
-                      '  Max: 100'
-                    ])
+        create_file(configuration_path, <<-END.strip_indent)
+          LyneLenth:
+            Enabled: true
+            Max: 100
+        END
         $stderr = StringIO.new
       end
 
@@ -59,10 +59,10 @@ describe RuboCop::Config do
 
     context 'when the configuration is in the base RuboCop config folder' do
       before do
-        create_file(configuration_path, [
-                      'InvalidProperty:',
-                      '  Enabled: true'
-                    ])
+        create_file(configuration_path, <<-END.strip_indent)
+          InvalidProperty:
+            Enabled: true
+        END
         stub_const('RuboCop::ConfigLoader::RUBOCOP_HOME', rubocop_home_path)
       end
 
@@ -76,11 +76,11 @@ describe RuboCop::Config do
 
     context 'when the configuration includes any unrecognized parameter' do
       before do
-        create_file(configuration_path, [
-                      'Metrics/LineLength:',
-                      '  Enabled: true',
-                      '  Min: 10'
-                    ])
+        create_file(configuration_path, <<-END.strip_indent)
+          Metrics/LineLength:
+            Enabled: true
+            Min: 10
+        END
         $stderr = StringIO.new
       end
 
@@ -100,15 +100,15 @@ describe RuboCop::Config do
       # Common parameters are parameters that are not in the default
       # configuration, but are nonetheless allowed for any cop.
       before do
-        create_file(configuration_path, [
-                      'Metrics/ModuleLength:',
-                      '  Exclude:',
-                      '    - lib/file.rb',
-                      '  Include:',
-                      '    - lib/file.xyz',
-                      '  Severity: warning',
-                      '  StyleGuide: https://example.com/some-style.html'
-                    ])
+        create_file(configuration_path, <<-END.strip_indent)
+          Metrics/ModuleLength:
+            Exclude:
+              - lib/file.rb
+            Include:
+              - lib/file.xyz
+            Severity: warning
+            StyleGuide: https://example.com/some-style.html
+        END
       end
 
       it 'does not raise validation error' do
@@ -118,10 +118,10 @@ describe RuboCop::Config do
 
     context 'when the configuration includes a valid EnforcedStyle' do
       before do
-        create_file(configuration_path, [
-                      'Style/AndOr:',
-                      '  EnforcedStyle: conditionals'
-                    ])
+        create_file(configuration_path, <<-END.strip_indent)
+          Style/AndOr:
+            EnforcedStyle: conditionals
+        END
       end
 
       it 'does not raise validation error' do
@@ -131,10 +131,10 @@ describe RuboCop::Config do
 
     context 'when the configration includes an invalid EnforcedStyle' do
       before do
-        create_file(configuration_path, [
-                      'Style/AndOr:',
-                      '  EnforcedStyle: itisinvalid'
-                    ])
+        create_file(configuration_path, <<-END.strip_indent)
+          Style/AndOr:
+            EnforcedStyle: itisinvalid
+        END
       end
 
       it 'raises validation error' do
@@ -145,10 +145,10 @@ describe RuboCop::Config do
 
     context 'when the configration includes a valid Enforced.+Style' do
       before do
-        create_file(configuration_path, [
-                      'Style/SpaceAroundBlockParameters:',
-                      '  EnforcedStyleInsidePipes: space'
-                    ])
+        create_file(configuration_path, <<-END.strip_indent)
+          Style/SpaceAroundBlockParameters:
+            EnforcedStyleInsidePipes: space
+        END
       end
 
       it 'does not raise validation error' do
@@ -158,10 +158,10 @@ describe RuboCop::Config do
 
     context 'when the configration includes an invalid Enforced.+Style' do
       before do
-        create_file(configuration_path, [
-                      'Style/SpaceAroundBlockParameters:',
-                      '  EnforcedStyleInsidePipes: itisinvalid'
-                    ])
+        create_file(configuration_path, <<-END.strip_indent)
+          Style/SpaceAroundBlockParameters:
+            EnforcedStyleInsidePipes: itisinvalid
+        END
       end
 
       it 'raises validation error' do
@@ -172,10 +172,10 @@ describe RuboCop::Config do
 
     context 'when the configuration includes an obsolete cop' do
       before do
-        create_file(configuration_path, [
-                      'Style/MethodCallParentheses:',
-                      '  Enabled: true'
-                    ])
+        create_file(configuration_path, <<-END.strip_indent)
+          Style/MethodCallParentheses:
+            Enabled: true
+        END
       end
 
       it 'raises validation error' do
@@ -187,10 +187,10 @@ describe RuboCop::Config do
 
     context 'when the configuration includes an obsolete parameter' do
       before do
-        create_file(configuration_path, [
-                      'Rails/UniqBeforePluck:',
-                      '  EnforcedMode: conservative'
-                    ])
+        create_file(configuration_path, <<-END.strip_indent)
+          Rails/UniqBeforePluck:
+            EnforcedMode: conservative
+        END
       end
 
       it 'raises validation error' do
@@ -201,16 +201,16 @@ describe RuboCop::Config do
 
     context 'when the configuration includes obsolete parameters and cops' do
       before do
-        create_file(configuration_path, [
-                      'Rails/UniqBeforePluck:',
-                      '  EnforcedMode: conservative',
-                      'Style/MethodCallParentheses:',
-                      '  Enabled: false',
-                      'Lint/BlockAlignment:',
-                      '  AlignWith: either',
-                      'Style/SpaceBeforeModifierKeyword:',
-                      '  Enabled: false'
-                    ])
+        create_file(configuration_path, <<-END.strip_indent)
+          Rails/UniqBeforePluck:
+            EnforcedMode: conservative
+          Style/MethodCallParentheses:
+            Enabled: false
+          Lint/BlockAlignment:
+            AlignWith: either
+          Style/SpaceBeforeModifierKeyword:
+            Enabled: false
+        END
       end
 
       it 'raises validation error' do
@@ -227,11 +227,11 @@ describe RuboCop::Config do
 
     context 'when all cops are both Enabled and Disabled by default' do
       before do
-        create_file(configuration_path, [
-                      'AllCops:',
-                      '  EnabledByDefault: true',
-                      '  DisabledByDefault: true'
-                    ])
+        create_file(configuration_path, <<-END.strip_indent)
+          AllCops:
+            EnabledByDefault: true
+            DisabledByDefault: true
+        END
       end
 
       it 'raises validation error' do

--- a/spec/rubocop/cop/bundler/ordered_gems_spec.rb
+++ b/spec/rubocop/cop/bundler/ordered_gems_spec.rb
@@ -11,7 +11,7 @@ describe RuboCop::Cop::Bundler::OrderedGems, :config do
   subject(:cop) { described_class.new(config) }
 
   context 'When gems are alphabetically sorted' do
-    let(:source) { <<-END }
+    let(:source) { <<-END.strip_indent }
       gem 'rspec'
       gem 'rubocop'
     END
@@ -23,7 +23,7 @@ describe RuboCop::Cop::Bundler::OrderedGems, :config do
   end
 
   context 'When gems are not alphabetically sorted' do
-    let(:source) { <<-END }
+    let(:source) { <<-END.strip_indent }
       gem 'rubocop'
       gem 'rspec'
     END
@@ -48,14 +48,15 @@ describe RuboCop::Cop::Bundler::OrderedGems, :config do
 
     it 'autocorrects' do
       new_source = autocorrect_source_with_loop(cop, source)
-      expect(new_source).to eq(["      gem 'rspec'",
-                                "      gem 'rubocop'",
-                                ''].join("\n"))
+      expect(new_source).to eq(<<-END.strip_indent)
+        gem 'rspec'
+        gem 'rubocop'
+      END
     end
   end
 
   context 'When each individual group of line is sorted' do
-    let(:source) { <<-END }
+    let(:source) { <<-END.strip_indent }
       gem 'rspec'
       gem 'rubocop'
 
@@ -70,7 +71,7 @@ describe RuboCop::Cop::Bundler::OrderedGems, :config do
   end
 
   context 'When a gem declaration takes several lines' do
-    let(:source) { <<-END }
+    let(:source) { <<-END.strip_indent }
       gem 'rubocop',
           '0.1.1'
       gem 'rspec'
@@ -83,15 +84,16 @@ describe RuboCop::Cop::Bundler::OrderedGems, :config do
 
     it 'autocorrects' do
       new_source = autocorrect_source_with_loop(cop, source)
-      expect(new_source).to eq(["      gem 'rspec'",
-                                "      gem 'rubocop',",
-                                "          '0.1.1'",
-                                ''].join("\n"))
+      expect(new_source).to eq(<<-END.strip_indent)
+        gem 'rspec'
+        gem 'rubocop',
+            '0.1.1'
+      END
     end
   end
 
   context 'When the gemfile is empty' do
-    let(:source) { <<-END }
+    let(:source) { <<-END.strip_indent }
       # Gemfile
     END
 
@@ -102,7 +104,7 @@ describe RuboCop::Cop::Bundler::OrderedGems, :config do
   end
 
   context 'When each individual group of line is not sorted' do
-    let(:source) { <<-END }
+    let(:source) { <<-END.strip_indent }
         gem "d"
         gem "b"
         gem "e"
@@ -123,23 +125,24 @@ describe RuboCop::Cop::Bundler::OrderedGems, :config do
 
     it 'autocorrects' do
       new_source = autocorrect_source_with_loop(cop, source)
-      expect(new_source).to eq(['        gem "a"',
-                                '        gem "b"',
-                                '        gem "c"',
-                                '        gem "d"',
-                                '        gem "e"',
-                                '',
-                                '        gem "f"',
-                                '        gem "g"',
-                                '        gem "h"',
-                                '        gem "i"',
-                                '        gem "j"',
-                                ''].join("\n"))
+      expect(new_source).to eq(<<-END.strip_indent)
+        gem "a"
+        gem "b"
+        gem "c"
+        gem "d"
+        gem "e"
+
+        gem "f"
+        gem "g"
+        gem "h"
+        gem "i"
+        gem "j"
+      END
     end
   end
 
   context 'When gem groups is separated by multiline comment' do
-    let(:source) { <<-END }
+    let(:source) { <<-END.strip_indent }
       # For code quality
       gem 'rubocop'
       # For
@@ -177,18 +180,19 @@ describe RuboCop::Cop::Bundler::OrderedGems, :config do
 
       it 'autocorrects' do
         new_source = autocorrect_source_with_loop(cop, source)
-        expect(new_source).to eq(['      # For',
-                                  '      # test',
-                                  "      gem 'rspec'",
-                                  '      # For code quality',
-                                  "      gem 'rubocop'",
-                                  ''].join("\n"))
+        expect(new_source).to eq(<<-END.strip_indent)
+          # For
+          # test
+          gem 'rspec'
+          # For code quality
+          gem 'rubocop'
+        END
       end
     end
   end
 
   context 'When gems have an inline comment, and not sorted' do
-    let(:source) { <<-END }
+    let(:source) { <<-END.strip_indent }
       gem 'rubocop' # For code quality
       gem 'pry'
       gem 'rspec'   # For test
@@ -201,15 +205,16 @@ describe RuboCop::Cop::Bundler::OrderedGems, :config do
 
     it 'autocorrects' do
       new_source = autocorrect_source_with_loop(cop, source)
-      expect(new_source).to eq(["      gem 'pry'",
-                                "      gem 'rspec'   # For test",
-                                "      gem 'rubocop' # For code quality",
-                                ''].join("\n"))
+      expect(new_source).to eq(<<-END.strip_indent)
+        gem 'pry'
+        gem 'rspec'   # For test
+        gem 'rubocop' # For code quality
+      END
     end
   end
 
   context 'When gems are asciibetically sorted' do
-    let(:source) { <<-END }
+    let(:source) { <<-END.strip_indent }
       gem 'paper_trail'
       gem 'paperclip'
     END
@@ -221,7 +226,7 @@ describe RuboCop::Cop::Bundler::OrderedGems, :config do
   end
 
   context 'When a gem that starts with a capital letter is sorted' do
-    let(:source) { <<-END }
+    let(:source) { <<-END.strip_indent }
       gem 'a'
       gem 'Z'
     END
@@ -233,7 +238,7 @@ describe RuboCop::Cop::Bundler::OrderedGems, :config do
   end
 
   context 'When a gem that starts with a capital letter is not sorted' do
-    let(:source) { <<-END }
+    let(:source) { <<-END.strip_indent }
       gem 'Z'
       gem 'a'
     END
@@ -245,9 +250,10 @@ describe RuboCop::Cop::Bundler::OrderedGems, :config do
 
     it 'autocorrects' do
       new_source = autocorrect_source_with_loop(cop, source)
-      expect(new_source).to eq(["      gem 'a'",
-                                "      gem 'Z'",
-                                ''].join("\n"))
+      expect(new_source).to eq(<<-END.strip_indent)
+        gem 'a'
+        gem 'Z'
+      END
     end
   end
 end

--- a/spec/rubocop/cop/lint/ambiguous_operator_spec.rb
+++ b/spec/rubocop/cop/lint/ambiguous_operator_spec.rb
@@ -11,10 +11,10 @@ describe RuboCop::Cop::Lint::AmbiguousOperator do
     context 'without parentheses' do
       context 'without whitespaces on the right of the operator' do
         let(:source) do
-          [
-            'array = [1, 2, 3]',
-            'puts *array'
-          ]
+          <<-END.strip_indent
+            array = [1, 2, 3]
+            puts *array
+          END
         end
 
         it 'registers an offense' do
@@ -32,10 +32,10 @@ describe RuboCop::Cop::Lint::AmbiguousOperator do
 
       context 'with a whitespace on the right of the operator' do
         let(:source) do
-          [
-            'array = [1, 2, 3]',
-            'puts * array'
-          ]
+          <<-END.strip_indent
+            array = [1, 2, 3]
+            puts * array
+          END
         end
 
         it 'accepts' do
@@ -46,10 +46,10 @@ describe RuboCop::Cop::Lint::AmbiguousOperator do
 
     context 'with parentheses' do
       let(:source) do
-        [
-          'array = [1, 2, 3]',
-          'puts(*array)'
-        ]
+        <<-END.strip_indent
+          array = [1, 2, 3]
+          puts(*array)
+        END
       end
 
       it 'accepts' do
@@ -62,10 +62,10 @@ describe RuboCop::Cop::Lint::AmbiguousOperator do
     context 'without parentheses' do
       context 'without whitespaces on the right of the operator' do
         let(:source) do
-          [
-            'process = proc { do_something }',
-            '2.times &process'
-          ]
+          <<-END.strip_indent
+            process = proc { do_something }
+            2.times &process
+          END
         end
 
         it 'registers an offense' do
@@ -83,10 +83,10 @@ describe RuboCop::Cop::Lint::AmbiguousOperator do
 
       context 'with a whitespace on the right of the operator' do
         let(:source) do
-          [
-            'process = proc { do_something }',
-            '2.times & process'
-          ]
+          <<-END.strip_indent
+            process = proc { do_something }
+            2.times & process
+          END
         end
 
         it 'accepts' do
@@ -97,10 +97,10 @@ describe RuboCop::Cop::Lint::AmbiguousOperator do
 
     context 'with parentheses' do
       let(:source) do
-        [
-          'process = proc { do_something }',
-          '2.times(&process)'
-        ]
+        <<-END.strip_indent
+          process = proc { do_something }
+          2.times(&process)
+        END
       end
 
       it 'accepts' do

--- a/spec/rubocop/cop/lint/assignment_in_condition_spec.rb
+++ b/spec/rubocop/cop/lint/assignment_in_condition_spec.rb
@@ -5,72 +5,82 @@ describe RuboCop::Cop::Lint::AssignmentInCondition, :config do
   let(:cop_config) { { 'AllowSafeAssignment' => true } }
 
   it 'registers an offense for lvar assignment in condition' do
-    inspect_source(cop,
-                   ['if test = 10',
-                    'end'])
+    inspect_source(cop, <<-END.strip_indent)
+      if test = 10
+      end
+    END
     expect(cop.offenses.size).to eq(1)
   end
 
   it 'registers an offense for lvar assignment in while condition' do
-    inspect_source(cop,
-                   ['while test = 10',
-                    'end'])
+    inspect_source(cop, <<-END.strip_indent)
+      while test = 10
+      end
+    END
     expect(cop.offenses.size).to eq(1)
   end
 
   it 'registers an offense for lvar assignment in until condition' do
-    inspect_source(cop,
-                   ['until test = 10',
-                    'end'])
+    inspect_source(cop, <<-END.strip_indent)
+      until test = 10
+      end
+    END
     expect(cop.offenses.size).to eq(1)
   end
 
   it 'registers an offense for ivar assignment in condition' do
-    inspect_source(cop,
-                   ['if @test = 10',
-                    'end'])
+    inspect_source(cop, <<-END.strip_indent)
+      if @test = 10
+      end
+    END
     expect(cop.offenses.size).to eq(1)
   end
 
   it 'registers an offense for clvar assignment in condition' do
-    inspect_source(cop,
-                   ['if @@test = 10',
-                    'end'])
+    inspect_source(cop, <<-END.strip_indent)
+      if @@test = 10
+      end
+    END
     expect(cop.offenses.size).to eq(1)
   end
 
   it 'registers an offense for gvar assignment in condition' do
-    inspect_source(cop,
-                   ['if $test = 10',
-                    'end'])
+    inspect_source(cop, <<-END.strip_indent)
+      if $test = 10
+      end
+    END
     expect(cop.offenses.size).to eq(1)
   end
 
   it 'registers an offense for constant assignment in condition' do
-    inspect_source(cop,
-                   ['if TEST = 10',
-                    'end'])
+    inspect_source(cop, <<-END.strip_indent)
+      if TEST = 10
+      end
+    END
     expect(cop.offenses.size).to eq(1)
   end
 
   it 'registers an offense for collection element assignment in condition' do
-    inspect_source(cop,
-                   ['if a[3] = 10',
-                    'end'])
+    inspect_source(cop, <<-END.strip_indent)
+      if a[3] = 10
+      end
+    END
     expect(cop.offenses.size).to eq(1)
   end
 
   it 'accepts == in condition' do
-    inspect_source(cop,
-                   ['if test == 10',
-                    'end'])
+    inspect_source(cop, <<-END.strip_indent)
+      if test == 10
+      end
+    END
     expect(cop.offenses).to be_empty
   end
 
   it 'registers an offense for assignment after == in condition' do
-    inspect_source(cop,
-                   ['if test == 10 || foobar = 1',
-                    'end'])
+    inspect_source(cop, <<-END.strip_indent)
+      if test == 10 || foobar = 1
+      end
+    END
     expect(cop.offenses.size).to eq(1)
   end
 
@@ -99,38 +109,43 @@ describe RuboCop::Cop::Lint::AssignmentInCondition, :config do
   end
 
   it 'registers an offense for assignment methods' do
-    inspect_source(cop,
-                   ['if test.method = 10',
-                    'end'])
+    inspect_source(cop, <<-END.strip_indent)
+      if test.method = 10
+      end
+    END
     expect(cop.offenses.size).to eq(1)
   end
 
   it 'does not blow up for empty if condition' do
-    inspect_source(cop,
-                   ['if ()',
-                    'end'])
+    inspect_source(cop, <<-END.strip_indent)
+      if ()
+      end
+    END
     expect(cop.offenses).to be_empty
   end
 
   it 'does not blow up for empty unless condition' do
-    inspect_source(cop,
-                   ['unless ()',
-                    'end'])
+    inspect_source(cop, <<-END.strip_indent)
+      unless ()
+      end
+    END
     expect(cop.offenses).to be_empty
   end
 
   context 'safe assignment is allowed' do
     it 'accepts = in condition surrounded with braces' do
-      inspect_source(cop,
-                     ['if (test = 10)',
-                      'end'])
+      inspect_source(cop, <<-END.strip_indent)
+        if (test = 10)
+        end
+      END
       expect(cop.offenses).to be_empty
     end
 
     it 'accepts []= in condition surrounded with braces' do
-      inspect_source(cop,
-                     ['if (test[0] = 10)',
-                      'end'])
+      inspect_source(cop, <<-END.strip_indent)
+        if (test[0] = 10)
+        end
+      END
       expect(cop.offenses).to be_empty
     end
   end
@@ -139,16 +154,18 @@ describe RuboCop::Cop::Lint::AssignmentInCondition, :config do
     let(:cop_config) { { 'AllowSafeAssignment' => false } }
 
     it 'does not accept = in condition surrounded with braces' do
-      inspect_source(cop,
-                     ['if (test = 10)',
-                      'end'])
+      inspect_source(cop, <<-END.strip_indent)
+        if (test = 10)
+        end
+      END
       expect(cop.offenses.size).to eq(1)
     end
 
     it 'does not accept []= in condition surrounded with braces' do
-      inspect_source(cop,
-                     ['if (test[0] = 10)',
-                      'end'])
+      inspect_source(cop, <<-END.strip_indent)
+        if (test[0] = 10)
+        end
+      END
       expect(cop.offenses.size).to eq(1)
     end
   end

--- a/spec/rubocop/cop/lint/block_alignment_spec.rb
+++ b/spec/rubocop/cop/lint/block_alignment_spec.rb
@@ -8,107 +8,127 @@ describe RuboCop::Cop::Lint::BlockAlignment, :config do
 
   context 'when the block has no arguments' do
     it 'registers an offense for mismatched block end' do
-      inspect_source(cop,
-                     ['test do',
-                      '  end'])
+      inspect_source(cop, <<-END.strip_indent)
+        test do
+          end
+      END
       expect(cop.messages)
         .to eq(['`end` at 2, 2 is not aligned with `test do` at 1, 0.'])
     end
 
     it 'auto-corrects alignment' do
-      new_source = autocorrect_source(cop, ['test do',
-                                            '  end'])
+      new_source = autocorrect_source(cop, <<-END.strip_indent)
+        test do
+          end
+      END
 
-      expect(new_source).to eq(['test do',
-                                'end'].join("\n"))
+      expect(new_source).to eq(<<-END.strip_indent)
+        test do
+        end
+      END
     end
   end
 
   context 'when the block has arguments' do
     it 'registers an offense for mismatched block end' do
-      inspect_source(cop,
-                     ['test do |ala|',
-                      '  end'])
+      inspect_source(cop, <<-END.strip_indent)
+        test do |ala|
+          end
+      END
       expect(cop.messages)
         .to eq(['`end` at 2, 2 is not aligned with `test do |ala|` at 1, 0.'])
     end
 
     it 'auto-corrects alignment' do
-      new_source = autocorrect_source(cop, ['test do |ala|',
-                                            '  end'])
+      new_source = autocorrect_source(cop, <<-END.strip_indent)
+        test do |ala|
+          end
+      END
 
-      expect(new_source).to eq(['test do |ala|',
-                                'end'].join("\n"))
+      expect(new_source).to eq(<<-END.strip_indent)
+        test do |ala|
+        end
+      END
     end
   end
 
   it 'accepts a block end that does not begin its line' do
-    inspect_source(cop,
-                   ['  scope :bar, lambda { joins(:baz)',
-                    '                       .distinct }'])
+    inspect_source(cop, <<-END.strip_margin('|'))
+      |  scope :bar, lambda { joins(:baz)
+      |                       .distinct }
+    END
     expect(cop.offenses).to be_empty
   end
 
   context 'when the block is a logical operand' do
     it 'accepts a correctly aligned block end' do
-      inspect_source(cop,
-                     ['(value.is_a? Array) && value.all? do |subvalue|',
-                      '  type_check_value(subvalue, array_type)',
-                      'end',
-                      'a || b do',
-                      'end'])
+      inspect_source(cop, <<-END.strip_indent)
+        (value.is_a? Array) && value.all? do |subvalue|
+          type_check_value(subvalue, array_type)
+        end
+        a || b do
+        end
+      END
       expect(cop.offenses).to be_empty
     end
   end
 
   it 'accepts end aligned with a variable' do
-    inspect_source(cop,
-                   ['variable = test do |ala|',
-                    'end'])
+    inspect_source(cop, <<-END.strip_indent)
+      variable = test do |ala|
+      end
+    END
     expect(cop.offenses).to be_empty
   end
 
   context 'when there is an assignment chain' do
     it 'registers an offense for an end aligned with the 2nd variable' do
-      inspect_source(cop,
-                     ['a = b = c = test do |ala|',
-                      '    end'])
+      inspect_source(cop, <<-END.strip_indent)
+        a = b = c = test do |ala|
+            end
+      END
       expect(cop.messages)
         .to eq(['`end` at 2, 4 is not aligned with' \
                 ' `a = b = c = test do |ala|` at 1, 0.'])
     end
 
     it 'accepts end aligned with the first variable' do
-      inspect_source(cop,
-                     ['a = b = c = test do |ala|',
-                      'end'])
+      inspect_source(cop, <<-END.strip_indent)
+        a = b = c = test do |ala|
+        end
+      END
       expect(cop.offenses).to be_empty
     end
 
     it 'auto-corrects alignment to the first variable' do
-      new_source = autocorrect_source(cop,
-                                      ['a = b = c = test do |ala|',
-                                       '    end'])
+      new_source = autocorrect_source(cop, <<-END.strip_indent)
+        a = b = c = test do |ala|
+            end
+      END
 
-      expect(new_source).to eq(['a = b = c = test do |ala|',
-                                'end'].join("\n"))
+      expect(new_source).to eq(<<-END.strip_indent)
+        a = b = c = test do |ala|
+        end
+      END
     end
   end
 
   context 'and the block is an operand' do
     it 'accepts end aligned with a variable' do
-      inspect_source(cop,
-                     ['b = 1 + preceding_line.reduce(0) do |a, e|',
-                      '  a + e.length + newline_length',
-                      'end + 1'])
+      inspect_source(cop, <<-END.strip_indent)
+        b = 1 + preceding_line.reduce(0) do |a, e|
+          a + e.length + newline_length
+        end + 1
+      END
       expect(cop.offenses).to be_empty
     end
   end
 
   it 'registers an offense for mismatched block end with a variable' do
-    inspect_source(cop,
-                   ['variable = test do |ala|',
-                    '  end'])
+    inspect_source(cop, <<-END.strip_indent)
+      variable = test do |ala|
+        end
+    END
     expect(cop.messages)
       .to eq(['`end` at 2, 2 is not aligned with `variable = test do |ala|`' \
               ' at 1, 0.'])
@@ -116,20 +136,22 @@ describe RuboCop::Cop::Lint::BlockAlignment, :config do
 
   context 'when the block is defined on the next line' do
     it 'accepts end aligned with the block expression' do
-      inspect_source(cop,
-                     ['variable =',
-                      '  a_long_method_that_dont_fit_on_the_line do |v|',
-                      '    v.foo',
-                      '  end'])
+      inspect_source(cop, <<-END.strip_indent)
+        variable =
+          a_long_method_that_dont_fit_on_the_line do |v|
+            v.foo
+          end
+      END
       expect(cop.offenses).to be_empty
     end
 
     it 'registers an offenses for mismatched end alignment' do
-      inspect_source(cop,
-                     ['variable =',
-                      '  a_long_method_that_dont_fit_on_the_line do |v|',
-                      '    v.foo',
-                      'end'])
+      inspect_source(cop, <<-END.strip_indent)
+        variable =
+          a_long_method_that_dont_fit_on_the_line do |v|
+            v.foo
+        end
+      END
       expect(cop.messages)
         .to eq(['`end` at 4, 0 is not aligned with' \
                 ' `a_long_method_that_dont_fit_on_the_line do |v|` at 2, 2.'])
@@ -138,17 +160,21 @@ describe RuboCop::Cop::Lint::BlockAlignment, :config do
     it 'auto-corrects alignment' do
       new_source = autocorrect_source(
         cop,
-        ['variable =',
-         '  a_long_method_that_dont_fit_on_the_line do |v|',
-         '    v.foo',
-         'end']
+        <<-END.strip_indent
+          variable =
+            a_long_method_that_dont_fit_on_the_line do |v|
+              v.foo
+          end
+        END
       )
 
       expect(new_source)
-        .to eq(['variable =',
-                '  a_long_method_that_dont_fit_on_the_line do |v|',
-                '    v.foo',
-                '  end'].join("\n"))
+        .to eq(<<-END.strip_indent)
+          variable =
+            a_long_method_that_dont_fit_on_the_line do |v|
+              v.foo
+            end
+        END
     end
   end
 
@@ -173,19 +199,19 @@ describe RuboCop::Cop::Lint::BlockAlignment, :config do
     end
 
     it 'registers offenses for misaligned ends' do
-      src = [
-        'def foo(bar)',
-        '  bar.get_stuffs',
-        '      .reject do |stuff|',
-        '        stuff.with_a_very_long_expression_that_doesnt_fit_the_line',
-        '        end.select do |stuff|',
-        '        stuff.another_very_long_expression_that_doesnt_fit_the_line',
-        '    end',
-        '      .select do |stuff|',
-        '        stuff.another_very_long_expression_that_doesnt_fit_the_line',
-        '        end',
-        'end'
-      ]
+      src = <<-END.strip_indent
+        def foo(bar)
+          bar.get_stuffs
+              .reject do |stuff|
+                stuff.with_a_very_long_expression_that_doesnt_fit_the_line
+                end.select do |stuff|
+                stuff.another_very_long_expression_that_doesnt_fit_the_line
+            end
+              .select do |stuff|
+                stuff.another_very_long_expression_that_doesnt_fit_the_line
+                end
+        end
+      END
       inspect_source(cop, src)
       expect(cop.messages)
         .to eq(['`end` at 5, 8 is not aligned with `bar.get_stuffs` at 2, 2' \
@@ -198,67 +224,69 @@ describe RuboCop::Cop::Lint::BlockAlignment, :config do
 
     # Example from issue 393 of bbatsov/rubocop on github:
     it 'accepts end indented as the start of the block' do
-      src = ['my_object.chaining_this_very_long_method(with_a_parameter)',
-             '    .and_one_with_a_block do',
-             '  do_something',
-             'end',
-             '', # Other variant:
-             'my_object.chaining_this_very_long_method(',
-             '    with_a_parameter).and_one_with_a_block do',
-             '  do_something',
-             'end']
+      src = <<-END.strip_indent
+        my_object.chaining_this_very_long_method(with_a_parameter)
+            .and_one_with_a_block do
+          do_something
+        end
+ # Other variant:
+        my_object.chaining_this_very_long_method(
+            with_a_parameter).and_one_with_a_block do
+          do_something
+        end
+      END
       inspect_source(cop, src)
       expect(cop.offenses).to be_empty
     end
 
     # Example from issue 447 of bbatsov/rubocop on github:
     it 'accepts two kinds of end alignment' do
-      src = [
+      src = <<-END.strip_indent
         # Aligned with start of line where do is:
-        'params = default_options.merge(options)',
-        '          .delete_if { |k, v| v.nil? }',
-        '          .each_with_object({}) do |(k, v), new_hash|',
-        '            new_hash[k.to_s] = v.to_s',
-        '          end',
+        params = default_options.merge(options)
+                  .delete_if { |k, v| v.nil? }
+                  .each_with_object({}) do |(k, v), new_hash|
+                    new_hash[k.to_s] = v.to_s
+                  end
         # Aligned with start of the whole expression:
-        'params = default_options.merge(options)',
-        '          .delete_if { |k, v| v.nil? }',
-        '          .each_with_object({}) do |(k, v), new_hash|',
-        '            new_hash[k.to_s] = v.to_s',
-        'end'
-      ]
+        params = default_options.merge(options)
+                  .delete_if { |k, v| v.nil? }
+                  .each_with_object({}) do |(k, v), new_hash|
+                    new_hash[k.to_s] = v.to_s
+        end
+      END
       inspect_source(cop, src)
       expect(cop.offenses).to be_empty
     end
 
     it 'auto-corrects misaligned ends with the start of the expression' do
-      src = [
-        'def foo(bar)',
-        '  bar.get_stuffs',
-        '      .reject do |stuff|',
-        '        stuff.with_a_very_long_expression_that_doesnt_fit_the_line',
-        '        end.select do |stuff|',
-        '        stuff.another_very_long_expression_that_doesnt_fit_the_line',
-        '    end',
-        '      .select do |stuff|',
-        '        stuff.another_very_long_expression_that_doesnt_fit_the_line',
-        '        end',
-        'end'
-      ]
+      src = <<-END.strip_indent
+        def foo(bar)
+          bar.get_stuffs
+              .reject do |stuff|
+                stuff.with_a_very_long_expression_that_doesnt_fit_the_line
+                end.select do |stuff|
+                stuff.another_very_long_expression_that_doesnt_fit_the_line
+            end
+              .select do |stuff|
+                stuff.another_very_long_expression_that_doesnt_fit_the_line
+                end
+        end
+      END
 
-      aligned_src = [
-        'def foo(bar)',
-        '  bar.get_stuffs',
-        '      .reject do |stuff|',
-        '        stuff.with_a_very_long_expression_that_doesnt_fit_the_line',
-        '  end.select do |stuff|',
-        '        stuff.another_very_long_expression_that_doesnt_fit_the_line',
-        '  end',
-        '      .select do |stuff|',
-        '        stuff.another_very_long_expression_that_doesnt_fit_the_line',
-        '  end',
-        'end'
-      ].join("\n")
+      aligned_src = <<-END.strip_indent
+        def foo(bar)
+          bar.get_stuffs
+              .reject do |stuff|
+                stuff.with_a_very_long_expression_that_doesnt_fit_the_line
+          end.select do |stuff|
+                stuff.another_very_long_expression_that_doesnt_fit_the_line
+          end
+              .select do |stuff|
+                stuff.another_very_long_expression_that_doesnt_fit_the_line
+          end
+        end
+      END
 
       new_source = autocorrect_source(cop, src)
       expect(new_source).to eq(aligned_src)
@@ -267,19 +295,23 @@ describe RuboCop::Cop::Lint::BlockAlignment, :config do
 
   context 'when variables of a mass assignment spans several lines' do
     it 'accepts end aligned with the variables' do
-      src = ['e,',
-             'f = [5, 6].map do |i|',
-             '  i - 5',
-             'end']
+      src = <<-END.strip_indent
+        e,
+        f = [5, 6].map do |i|
+          i - 5
+        end
+      END
       inspect_source(cop, src)
       expect(cop.offenses).to be_empty
     end
 
     it 'registers an offense for end aligned with the block' do
-      src = ['e,',
-             'f = [5, 6].map do |i|',
-             '  i - 5',
-             '    end']
+      src = <<-END.strip_indent
+        e,
+        f = [5, 6].map do |i|
+          i - 5
+            end
+      END
       inspect_source(cop, src)
       expect(cop.messages)
         .to eq(['`end` at 4, 4 is not aligned with `e,` at 1, 0 or' \
@@ -287,116 +319,132 @@ describe RuboCop::Cop::Lint::BlockAlignment, :config do
     end
 
     it 'auto-corrects' do
-      src = ['e,',
-             'f = [5, 6].map do |i|',
-             '  i - 5',
-             '    end']
-      corrected = ['e,',
-                   'f = [5, 6].map do |i|',
-                   '  i - 5',
-                   'end']
+      src = <<-END.strip_indent
+        e,
+        f = [5, 6].map do |i|
+          i - 5
+            end
+      END
+      corrected = <<-END.strip_indent
+        e,
+        f = [5, 6].map do |i|
+          i - 5
+        end
+      END
       new_source = autocorrect_source(cop, src)
-      expect(new_source).to eq(corrected.join("\n"))
+      expect(new_source).to eq(corrected)
     end
   end
 
   it 'accepts end aligned with an instance variable' do
-    inspect_source(cop,
-                   ['@variable = test do |ala|',
-                    'end'])
+    inspect_source(cop, <<-END.strip_indent)
+      @variable = test do |ala|
+      end
+    END
     expect(cop.offenses).to be_empty
   end
 
   it 'registers an offense for mismatched block end with' \
      ' an instance variable' do
-    inspect_source(cop,
-                   ['@variable = test do |ala|',
-                    '  end'])
+    inspect_source(cop, <<-END.strip_indent)
+      @variable = test do |ala|
+        end
+    END
     expect(cop.messages)
       .to eq(['`end` at 2, 2 is not aligned with `@variable = test do |ala|`' \
               ' at 1, 0.'])
   end
 
   it 'accepts end aligned with a class variable' do
-    inspect_source(cop,
-                   ['@@variable = test do |ala|',
-                    'end'])
+    inspect_source(cop, <<-END.strip_indent)
+      @@variable = test do |ala|
+      end
+    END
     expect(cop.offenses).to be_empty
   end
 
   it 'registers an offense for mismatched block end with a class variable' do
-    inspect_source(cop,
-                   ['@@variable = test do |ala|',
-                    '  end'])
+    inspect_source(cop, <<-END.strip_indent)
+      @@variable = test do |ala|
+        end
+    END
     expect(cop.messages)
       .to eq(['`end` at 2, 2 is not aligned with `@@variable = test do |ala|`' \
               ' at 1, 0.'])
   end
 
   it 'accepts end aligned with a global variable' do
-    inspect_source(cop,
-                   ['$variable = test do |ala|',
-                    'end'])
+    inspect_source(cop, <<-END.strip_indent)
+      $variable = test do |ala|
+      end
+    END
     expect(cop.offenses).to be_empty
   end
 
   it 'registers an offense for mismatched block end with a global variable' do
-    inspect_source(cop,
-                   ['$variable = test do |ala|',
-                    '  end'])
+    inspect_source(cop, <<-END.strip_indent)
+      $variable = test do |ala|
+        end
+    END
     expect(cop.messages)
       .to eq(['`end` at 2, 2 is not aligned with `$variable = test do |ala|`' \
               ' at 1, 0.'])
   end
 
   it 'accepts end aligned with a constant' do
-    inspect_source(cop,
-                   ['CONSTANT = test do |ala|',
-                    'end'])
+    inspect_source(cop, <<-END.strip_indent)
+      CONSTANT = test do |ala|
+      end
+    END
     expect(cop.offenses).to be_empty
   end
 
   it 'registers an offense for mismatched block end with a constant' do
-    inspect_source(cop,
-                   ['Module::CONSTANT = test do |ala|',
-                    '  end'])
+    inspect_source(cop, <<-END.strip_indent)
+      Module::CONSTANT = test do |ala|
+        end
+    END
     expect(cop.messages)
       .to eq(['`end` at 2, 2 is not aligned with' \
               ' `Module::CONSTANT = test do |ala|` at 1, 0.'])
   end
 
   it 'accepts end aligned with a method call' do
-    inspect_source(cop,
-                   ['parser.children << lambda do |token|',
-                    '  token << 1',
-                    'end'])
+    inspect_source(cop, <<-END.strip_indent)
+      parser.children << lambda do |token|
+        token << 1
+      end
+    END
     expect(cop.offenses).to be_empty
   end
 
   it 'registers an offense for mismatched block end with a method call' do
-    inspect_source(cop,
-                   ['parser.children << lambda do |token|',
-                    '  token << 1',
-                    '  end'])
+    inspect_source(cop, <<-END.strip_indent)
+      parser.children << lambda do |token|
+        token << 1
+        end
+    END
     expect(cop.messages)
       .to eq(['`end` at 3, 2 is not aligned with' \
               ' `parser.children << lambda do |token|` at 1, 0.'])
   end
 
   it 'accepts end aligned with a method call with arguments' do
-    inspect_source(cop,
-                   ['@h[:f] = f.each_pair.map do |f, v|',
-                    '  v = 1',
-                    'end'])
+    inspect_source(cop, <<-END.strip_indent)
+      @h[:f] = f.each_pair.map do |f, v|
+        v = 1
+      end
+    END
     expect(cop.offenses).to be_empty
   end
 
   it 'registers an offense for mismatched end with a method call' \
      ' with arguments' do
-    inspect_source(cop,
-                   ['@h[:f] = f.each_pair.map do |f, v|',
-                    '  v = 1',
-                    '  end'])
+    inspect_source(cop, <<-END.strip_indent)
+      @h[:f] = f.each_pair.map do |f, v|
+        v = 1
+        end
+    END
     expect(cop.messages)
       .to eq(['`end` at 3, 2 is not aligned with' \
               ' `@h[:f] = f.each_pair.map do |f, v|` at 1, 0.'])
@@ -409,226 +457,259 @@ describe RuboCop::Cop::Lint::BlockAlignment, :config do
   end
 
   it 'accepts end aligned with the block when the block is a method argument' do
-    inspect_source(cop,
-                   ['expect(arr.all? do |o|',
-                    '         o.valid?',
-                    '       end)'])
+    inspect_source(cop, <<-END.strip_indent)
+      expect(arr.all? do |o|
+               o.valid?
+             end)
+    END
     expect(cop.offenses).to be_empty
   end
 
   it 'registers an offense for mismatched end not aligned with the block' \
      ' that is an argument' do
-    inspect_source(cop,
-                   ['expect(arr.all? do |o|',
-                    '  o.valid?',
-                    '  end)'])
+    inspect_source(cop, <<-END.strip_indent)
+      expect(arr.all? do |o|
+        o.valid?
+        end)
+    END
     expect(cop.messages)
       .to eq(['`end` at 3, 2 is not aligned with `arr.all? do |o|` at 1, 7 or' \
               ' `expect(arr.all? do |o|` at 1, 0.'])
   end
 
   it 'accepts end aligned with an op-asgn (+=, -=)' do
-    inspect_source(cop,
-                   ['rb += files.select do |file|',
-                    '  file << something',
-                    'end'])
+    inspect_source(cop, <<-END.strip_indent)
+      rb += files.select do |file|
+        file << something
+      end
+    END
     expect(cop.offenses).to be_empty
   end
 
   it 'registers an offense for mismatched block end with an op-asgn (+=, -=)' do
-    inspect_source(cop,
-                   ['rb += files.select do |file|',
-                    '  file << something',
-                    '  end'])
+    inspect_source(cop, <<-END.strip_indent)
+      rb += files.select do |file|
+        file << something
+        end
+    END
     expect(cop.messages)
       .to eq(['`end` at 3, 2 is not aligned with `rb` at 1, 0.'])
   end
 
   it 'accepts end aligned with an and-asgn (&&=)' do
-    inspect_source(cop,
-                   ['variable &&= test do |ala|',
-                    'end'])
+    inspect_source(cop, <<-END.strip_indent)
+      variable &&= test do |ala|
+      end
+    END
     expect(cop.offenses).to be_empty
   end
 
   it 'registers an offense for mismatched block end with an and-asgn (&&=)' do
-    inspect_source(cop,
-                   ['variable &&= test do |ala|',
-                    '  end'])
+    inspect_source(cop, <<-END.strip_indent)
+      variable &&= test do |ala|
+        end
+    END
     expect(cop.messages)
       .to eq(['`end` at 2, 2 is not aligned with `variable &&= test do |ala|`' \
               ' at 1, 0.'])
   end
 
   it 'accepts end aligned with an or-asgn (||=)' do
-    inspect_source(cop,
-                   ['variable ||= test do |ala|',
-                    'end'])
+    inspect_source(cop, <<-END.strip_indent)
+      variable ||= test do |ala|
+      end
+    END
     expect(cop.offenses).to be_empty
   end
 
   it 'registers an offense for mismatched block end with an or-asgn (||=)' do
-    inspect_source(cop,
-                   ['variable ||= test do |ala|',
-                    '  end'])
+    inspect_source(cop, <<-END.strip_indent)
+      variable ||= test do |ala|
+        end
+    END
     expect(cop.messages)
       .to eq(['`end` at 2, 2 is not aligned with `variable ||= test do |ala|`' \
               ' at 1, 0.'])
   end
 
   it 'accepts end aligned with a mass assignment' do
-    inspect_source(cop,
-                   ['var1, var2 = lambda do |test|',
-                    '  [1, 2]',
-                    'end'])
+    inspect_source(cop, <<-END.strip_indent)
+      var1, var2 = lambda do |test|
+        [1, 2]
+      end
+    END
     expect(cop.offenses).to be_empty
   end
 
   it 'accepts end aligned with a call chain left hand side' do
-    inspect_source(cop,
-                   ['parser.diagnostics.consumer = lambda do |diagnostic|',
-                    '  diagnostics << diagnostic',
-                    'end'])
+    inspect_source(cop, <<-END.strip_indent)
+      parser.diagnostics.consumer = lambda do |diagnostic|
+        diagnostics << diagnostic
+      end
+    END
     expect(cop.offenses).to be_empty
   end
 
   it 'registers an offense for mismatched block end with a mass assignment' do
-    inspect_source(cop,
-                   ['var1, var2 = lambda do |test|',
-                    '  [1, 2]',
-                    '  end'])
+    inspect_source(cop, <<-END.strip_indent)
+      var1, var2 = lambda do |test|
+        [1, 2]
+        end
+    END
     expect(cop.messages)
       .to eq(['`end` at 3, 2 is not aligned with `var1, var2` at 1, 0.'])
   end
 
   context 'when multiple similar-looking blocks have misaligned ends' do
     it 'registers an offense for each of them' do
-      inspect_source(cop,
-                     ['a = test do',
-                      ' end',
-                      'b = test do',
-                      ' end'])
+      inspect_source(cop, <<-END.strip_indent)
+        a = test do
+         end
+        b = test do
+         end
+      END
       expect(cop.offenses.size).to eq 2
     end
   end
 
   context 'on a splatted method call' do
     it 'aligns end with the splat operator' do
-      inspect_source(cop,
-                     ['def get_gems_by_name',
-                      '  @gems ||= Hash[*get_latest_gems.map { |gem|',
-                      '                   [gem.name, gem, gem.full_name, gem]',
-                      '                 }.flatten]',
-                      'end'])
+      inspect_source(cop, <<-END.strip_indent)
+        def get_gems_by_name
+          @gems ||= Hash[*get_latest_gems.map { |gem|
+                           [gem.name, gem, gem.full_name, gem]
+                         }.flatten]
+        end
+      END
       expect(cop.offenses).to be_empty
     end
 
     it 'autocorrects' do
-      source = ['def get_gems_by_name',
-                '  @gems ||= Hash[*get_latest_gems.map { |gem|',
-                '                   [gem.name, gem, gem.full_name, gem]',
-                '              }.flatten]',
-                'end']
-      corrected = ['def get_gems_by_name',
-                   '  @gems ||= Hash[*get_latest_gems.map { |gem|',
-                   '                   [gem.name, gem, gem.full_name, gem]',
-                   '                 }.flatten]',
-                   'end']
+      source = <<-END.strip_indent
+        def get_gems_by_name
+          @gems ||= Hash[*get_latest_gems.map { |gem|
+                           [gem.name, gem, gem.full_name, gem]
+                      }.flatten]
+        end
+      END
+      corrected = <<-END.strip_indent
+        def get_gems_by_name
+          @gems ||= Hash[*get_latest_gems.map { |gem|
+                           [gem.name, gem, gem.full_name, gem]
+                         }.flatten]
+        end
+      END
 
       new_source = autocorrect_source(cop, source)
-      expect(new_source).to eq(corrected.join("\n"))
+      expect(new_source).to eq(corrected)
     end
   end
 
   context 'on a bit-flipped method call' do
     it 'aligns end with the ~ operator' do
-      inspect_source(cop,
-                     ['def abc',
-                      '  @abc ||= A[~xyz { |x|',
-                      '               x',
-                      '             }.flatten]',
-                      'end'])
+      inspect_source(cop, <<-END.strip_indent)
+        def abc
+          @abc ||= A[~xyz { |x|
+                       x
+                     }.flatten]
+        end
+      END
       expect(cop.offenses).to be_empty
     end
 
     it 'autocorrects' do
-      source = ['def abc',
-                '  @abc ||= A[~xyz { |x|',
-                '               x',
-                '                        }.flatten]',
-                'end']
-      corrected = ['def abc',
-                   '  @abc ||= A[~xyz { |x|',
-                   '               x',
-                   '             }.flatten]',
-                   'end']
+      source = <<-END.strip_indent
+        def abc
+          @abc ||= A[~xyz { |x|
+                       x
+                                }.flatten]
+        end
+      END
+      corrected = <<-END.strip_indent
+        def abc
+          @abc ||= A[~xyz { |x|
+                       x
+                     }.flatten]
+        end
+      END
 
       new_source = autocorrect_source(cop, source)
-      expect(new_source).to eq(corrected.join("\n"))
+      expect(new_source).to eq(corrected)
     end
   end
 
   context 'on a logically negated method call' do
     it 'aligns end with the ! operator' do
-      inspect_source(cop,
-                     ['def abc',
-                      '  @abc ||= A[!xyz { |x|',
-                      '               x',
-                      '             }.flatten]',
-                      'end'])
+      inspect_source(cop, <<-END.strip_indent)
+        def abc
+          @abc ||= A[!xyz { |x|
+                       x
+                     }.flatten]
+        end
+      END
       expect(cop.offenses).to be_empty
     end
 
     it 'autocorrects' do
-      source = ['def abc',
-                '  @abc ||= A[!xyz { |x|',
-                '               x',
-                '}.flatten]',
-                'end']
-      corrected = ['def abc',
-                   '  @abc ||= A[!xyz { |x|',
-                   '               x',
-                   '             }.flatten]',
-                   'end']
+      source = <<-END.strip_indent
+        def abc
+          @abc ||= A[!xyz { |x|
+                       x
+        }.flatten]
+        end
+      END
+      corrected = <<-END.strip_indent
+        def abc
+          @abc ||= A[!xyz { |x|
+                       x
+                     }.flatten]
+        end
+      END
 
       new_source = autocorrect_source(cop, source)
-      expect(new_source).to eq(corrected.join("\n"))
+      expect(new_source).to eq(corrected)
     end
   end
 
   context 'on an arithmetically negated method call' do
     it 'aligns end with the - operator' do
-      inspect_source(cop,
-                     ['def abc',
-                      '  @abc ||= A[-xyz { |x|',
-                      '               x',
-                      '             }.flatten]',
-                      'end'])
+      inspect_source(cop, <<-END.strip_indent)
+        def abc
+          @abc ||= A[-xyz { |x|
+                       x
+                     }.flatten]
+        end
+      END
       expect(cop.offenses).to be_empty
     end
 
     it 'autocorrects' do
-      source = ['def abc',
-                '  @abc ||= A[-xyz { |x|',
-                '               x',
-                '                  }.flatten]',
-                'end']
-      corrected = ['def abc',
-                   '  @abc ||= A[-xyz { |x|',
-                   '               x',
-                   '             }.flatten]',
-                   'end']
+      source = <<-END.strip_indent
+        def abc
+          @abc ||= A[-xyz { |x|
+                       x
+                          }.flatten]
+        end
+      END
+      corrected = <<-END.strip_indent
+        def abc
+          @abc ||= A[-xyz { |x|
+                       x
+                     }.flatten]
+        end
+      END
 
       new_source = autocorrect_source(cop, source)
-      expect(new_source).to eq(corrected.join("\n"))
+      expect(new_source).to eq(corrected)
     end
   end
 
   context 'when the block is terminated by }' do
     it 'mentions } (not end) in the message' do
-      inspect_source(cop,
-                     ['test {',
-                      '  }'])
+      inspect_source(cop, <<-END.strip_indent)
+        test {
+          }
+      END
       expect(cop.messages)
         .to eq(['`}` at 2, 2 is not aligned with `test {` at 1, 0.'])
     end
@@ -640,23 +721,23 @@ describe RuboCop::Cop::Lint::BlockAlignment, :config do
     end
 
     it 'allows when start_of_line aligned' do
-      src = [
-        'foo.bar',
-        '  .each do',
-        '    baz',
-        'end'
-      ]
+      src = <<-END.strip_indent
+        foo.bar
+          .each do
+            baz
+        end
+      END
       inspect_source(cop, src)
       expect(cop.messages).to be_empty
     end
 
     it 'errors when do aligned' do
-      src = [
-        'foo.bar',
-        '  .each do',
-        '    baz',
-        '  end'
-      ]
+      src = <<-END.strip_indent
+        foo.bar
+          .each do
+            baz
+          end
+      END
       inspect_source(cop, src)
       expect(cop.messages)
         .to eq(['`end` at 4, 2 is not aligned with ' \
@@ -664,21 +745,21 @@ describe RuboCop::Cop::Lint::BlockAlignment, :config do
     end
 
     it 'autocorrects' do
-      src = [
-        'foo.bar',
-        '  .each do',
-        '    baz',
-        '  end'
-      ]
-      corrected = [
-        'foo.bar',
-        '  .each do',
-        '    baz',
-        'end'
-      ]
+      src = <<-END.strip_indent
+        foo.bar
+          .each do
+            baz
+          end
+      END
+      corrected = <<-END.strip_indent
+        foo.bar
+          .each do
+            baz
+        end
+      END
 
       new_source = autocorrect_source(cop, src)
-      expect(new_source).to eq(corrected.join("\n"))
+      expect(new_source).to eq(corrected)
     end
   end
 
@@ -688,23 +769,23 @@ describe RuboCop::Cop::Lint::BlockAlignment, :config do
     end
 
     it 'allows when do aligned' do
-      src = [
-        'foo.bar',
-        '  .each do',
-        '    baz',
-        '  end'
-      ]
+      src = <<-END.strip_indent
+        foo.bar
+          .each do
+            baz
+          end
+      END
       inspect_source(cop, src)
       expect(cop.messages).to be_empty
     end
 
     it 'errors when start_of_line aligned' do
-      src = [
-        'foo.bar',
-        '  .each do',
-        '    baz',
-        'end'
-      ]
+      src = <<-END.strip_indent
+        foo.bar
+          .each do
+            baz
+        end
+      END
       inspect_source(cop, src)
       expect(cop.messages)
         .to eq(['`end` at 4, 0 is not aligned with ' \
@@ -712,21 +793,21 @@ describe RuboCop::Cop::Lint::BlockAlignment, :config do
     end
 
     it 'autocorrects' do
-      src = [
-        'foo.bar',
-        '  .each do',
-        '    baz',
-        'end'
-      ]
-      corrected = [
-        'foo.bar',
-        '  .each do',
-        '    baz',
-        '  end'
-      ]
+      src = <<-END.strip_indent
+        foo.bar
+          .each do
+            baz
+        end
+      END
+      corrected = <<-END.strip_indent
+        foo.bar
+          .each do
+            baz
+          end
+      END
 
       new_source = autocorrect_source(cop, src)
-      expect(new_source).to eq(corrected.join("\n"))
+      expect(new_source).to eq(corrected)
     end
   end
 end

--- a/spec/rubocop/cop/lint/circular_argument_reference_spec.rb
+++ b/spec/rubocop/cop/lint/circular_argument_reference_spec.rb
@@ -10,11 +10,11 @@ describe RuboCop::Cop::Lint::CircularArgumentReference do
 
     context 'when the method contains a circular argument reference' do
       let(:source) do
-        [
-          'def omg_wow(msg = msg)',
-          '  puts msg',
-          'end'
-        ]
+        <<-END.strip_indent
+          def omg_wow(msg = msg)
+            puts msg
+          end
+        END
       end
 
       it 'registers an offense' do
@@ -27,11 +27,11 @@ describe RuboCop::Cop::Lint::CircularArgumentReference do
 
     context 'when the method does not contain a circular argument reference' do
       let(:source) do
-        [
-          'def omg_wow(msg)',
-          '  puts msg',
-          'end'
-        ]
+        <<-END.strip_indent
+          def omg_wow(msg)
+            puts msg
+          end
+        END
       end
 
       it 'does not register an offense' do
@@ -41,11 +41,11 @@ describe RuboCop::Cop::Lint::CircularArgumentReference do
 
     context 'when the seemingly-circular default value is a method call' do
       let(:source) do
-        [
-          'def omg_wow(msg = self.msg)',
-          '  puts msg',
-          'end'
-        ]
+        <<-END.strip_indent
+          def omg_wow(msg = self.msg)
+            puts msg
+          end
+        END
       end
 
       it 'does not register an offense' do
@@ -57,11 +57,11 @@ describe RuboCop::Cop::Lint::CircularArgumentReference do
   describe 'circular argument references in keyword arguments' do
     context 'ruby < 2.0, which has no keyword arguments', :ruby19 do
       let(:source) do
-        [
-          'def some_method(some_arg: some_method)',
-          '  puts some_arg',
-          'end'
-        ]
+        <<-END.strip_indent
+          def some_method(some_arg: some_method)
+            puts some_arg
+          end
+        END
       end
 
       it 'fails with a syntax error before the cop even comes into play' do
@@ -79,11 +79,11 @@ describe RuboCop::Cop::Lint::CircularArgumentReference do
 
       context 'when the keyword argument is not circular' do
         let(:source) do
-          [
-            'def some_method(some_arg: nil)',
-            '  puts some_arg',
-            'end'
-          ]
+          <<-END.strip_indent
+            def some_method(some_arg: nil)
+              puts some_arg
+            end
+          END
         end
 
         it 'does not register an offense' do
@@ -93,11 +93,11 @@ describe RuboCop::Cop::Lint::CircularArgumentReference do
 
       context 'when the keyword argument is not circular, and calls a method' do
         let(:source) do
-          [
-            'def some_method(some_arg: some_method)',
-            '  puts some_arg',
-            'end'
-          ]
+          <<-END.strip_indent
+            def some_method(some_arg: some_method)
+              puts some_arg
+            end
+          END
         end
         it 'does not register an offense' do
           expect(cop.offenses).to be_empty
@@ -106,11 +106,11 @@ describe RuboCop::Cop::Lint::CircularArgumentReference do
 
       context 'when there is one circular argument reference' do
         let(:source) do
-          [
-            'def some_method(some_arg: some_arg)',
-            '  puts some_arg',
-            'end'
-          ]
+          <<-END.strip_indent
+            def some_method(some_arg: some_arg)
+              puts some_arg
+            end
+          END
         end
         it 'registers an offense' do
           expect(cop.offenses.size).to eq(1)
@@ -123,11 +123,11 @@ describe RuboCop::Cop::Lint::CircularArgumentReference do
       context 'when the keyword argument is not circular, but calls a method ' \
               'of its own class with a self specification' do
         let(:source) do
-          [
-            'def puts_value(value: self.class.value, smile: self.smile)',
-            '  puts value',
-            'end'
-          ]
+          <<-END.strip_indent
+            def puts_value(value: self.class.value, smile: self.smile)
+              puts value
+            end
+          END
         end
 
         it 'does not register an offense' do
@@ -138,11 +138,11 @@ describe RuboCop::Cop::Lint::CircularArgumentReference do
       context 'when the keyword argument is not circular, but calls a method ' \
               'of some other object with the same name' do
         let(:source) do
-          [
-            'def puts_length(length: mystring.length)',
-            '  puts length',
-            'end'
-          ]
+          <<-END.strip_indent
+            def puts_length(length: mystring.length)
+              puts length
+            end
+          END
         end
 
         it 'does not register an offense' do
@@ -152,11 +152,11 @@ describe RuboCop::Cop::Lint::CircularArgumentReference do
 
       context 'when there are multiple offensive keyword arguments' do
         let(:source) do
-          [
-            'def some_method(some_arg: some_arg, other_arg: other_arg)',
-            '  puts [some_arg, other_arg]',
-            'end'
-          ]
+          <<-END.strip_indent
+            def some_method(some_arg: some_arg, other_arg: other_arg)
+              puts [some_arg, other_arg]
+            end
+          END
         end
 
         it 'registers two offenses' do

--- a/spec/rubocop/cop/lint/condition_position_spec.rb
+++ b/spec/rubocop/cop/lint/condition_position_spec.rb
@@ -13,29 +13,32 @@ describe RuboCop::Cop::Lint::ConditionPosition do
     end
 
     it 'accepts condition on the same line' do
-      inspect_source(cop,
-                     ["#{keyword} x == 10",
-                      ' bala',
-                      'end'])
+      inspect_source(cop, <<-END.strip_indent)
+        #{keyword} x == 10
+         bala
+        end
+      END
       expect(cop.offenses).to be_empty
     end
 
     it 'accepts condition on a different line for modifiers' do
-      inspect_source(cop,
-                     ["do_something #{keyword}",
-                      '  something && something_else'])
+      inspect_source(cop, <<-END.strip_indent)
+        do_something #{keyword}
+          something && something_else
+      END
       expect(cop.offenses).to be_empty
     end
   end
 
   it 'registers an offense for elsif condition on the next line' do
-    inspect_source(cop,
-                   ['if something',
-                    '  test',
-                    'elsif',
-                    '  something',
-                    '  test',
-                    'end'])
+    inspect_source(cop, <<-END.strip_indent)
+      if something
+        test
+      elsif
+        something
+        test
+      end
+    END
     expect(cop.offenses.size).to eq(1)
   end
 

--- a/spec/rubocop/cop/lint/debugger_spec.rb
+++ b/spec/rubocop/cop/lint/debugger_spec.rb
@@ -34,20 +34,26 @@ describe RuboCop::Cop::Lint::Debugger, :config do
   end
 
   it 'reports an offense for a Pry.rescue call' do
-    inspect_source(cop, ['def method',
-                         '  Pry.rescue { puts 1 }',
-                         'end'])
+    inspect_source(cop, <<-END.strip_indent)
+      def method
+        Pry.rescue { puts 1 }
+      end
+    END
     expect(cop.offenses.size).to eq(1)
     expect(cop.messages).to eq(['Remove debugger entry point `Pry.rescue`.'])
   end
 
   it 'can autocorrect Pry.rescue' do
-    new_source = autocorrect_source(cop, ['def method',
-                                          '  Pry.rescue { puts 1 }',
-                                          'end'])
-    expect(new_source).to eq(['def method',
-                              '  puts 1',
-                              'end'].join("\n"))
+    new_source = autocorrect_source(cop, <<-END.strip_indent)
+      def method
+        Pry.rescue { puts 1 }
+      end
+    END
+    expect(new_source).to eq(<<-END.strip_indent)
+      def method
+        puts 1
+      end
+    END
   end
 
   context 'target_ruby_version >= 2.4', :ruby24 do

--- a/spec/rubocop/cop/lint/def_end_alignment_spec.rb
+++ b/spec/rubocop/cop/lint/def_end_alignment_spec.rb
@@ -4,13 +4,15 @@ describe RuboCop::Cop::Lint::DefEndAlignment, :config do
   subject(:cop) { described_class.new(config) }
 
   let(:source) do
-    ['foo def a',
-     '  a1',
-     'end',
-     '',
-     'foo def b',
-     '      b1',
-     '    end']
+    <<-END.strip_indent
+      foo def a
+        a1
+      end
+
+      foo def b
+            b1
+          end
+    END
   end
 
   context 'when EnforcedStyleAlignWith is start_of_line' do
@@ -45,13 +47,15 @@ describe RuboCop::Cop::Lint::DefEndAlignment, :config do
 
       it 'does auto-correction' do
         corrected = autocorrect_source(cop, source)
-        expect(corrected).to eq(['foo def a',
-                                 '  a1',
-                                 'end',
-                                 '',
-                                 'foo def b',
-                                 '      b1',
-                                 'end'].join("\n"))
+        expect(corrected).to eq(<<-END.strip_indent)
+          foo def a
+            a1
+          end
+
+          foo def b
+                b1
+          end
+        END
       end
     end
   end
@@ -88,13 +92,15 @@ describe RuboCop::Cop::Lint::DefEndAlignment, :config do
 
         it 'does auto-correction' do
           corrected = autocorrect_source(cop, source)
-          expect(corrected).to eq(['foo def a',
-                                   '  a1',
-                                   '    end',
-                                   '',
-                                   'foo def b',
-                                   '      b1',
-                                   '    end'].join("\n"))
+          expect(corrected).to eq(<<-END.strip_indent)
+            foo def a
+              a1
+                end
+
+            foo def b
+                  b1
+                end
+          END
         end
       end
     end

--- a/spec/rubocop/cop/lint/duplicate_case_condition_spec.rb
+++ b/spec/rubocop/cop/lint/duplicate_case_condition_spec.rb
@@ -4,98 +4,116 @@ describe RuboCop::Cop::Lint::DuplicateCaseCondition do
   subject(:cop) { described_class.new }
 
   it 'registers an offense for repeated case conditionals' do
-    inspect_source(cop, ['case x',
-                         'when false',
-                         '  first_method',
-                         'when true',
-                         '  second_method',
-                         'when false',
-                         '  third_method',
-                         'end'])
+    inspect_source(cop, <<-END.strip_indent)
+      case x
+      when false
+        first_method
+      when true
+        second_method
+      when false
+        third_method
+      end
+    END
     expect(cop.offenses.size).to eq(1)
   end
 
   it 'registers an offense for subsequent repeated case conditionals' do
-    inspect_source(cop, ['case x',
-                         'when false',
-                         '  first_method',
-                         'when false',
-                         '  second_method',
-                         'end'])
+    inspect_source(cop, <<-END.strip_indent)
+      case x
+      when false
+        first_method
+      when false
+        second_method
+      end
+    END
     expect(cop.offenses.size).to eq(1)
   end
 
   it 'registers multiple offenses for multiple repeated case conditionals' do
-    inspect_source(cop, ['case x',
-                         'when false',
-                         '  first_method',
-                         'when true',
-                         '  second_method',
-                         'when false',
-                         '  third_method',
-                         'when true',
-                         '  fourth_method',
-                         'end'])
+    inspect_source(cop, <<-END.strip_indent)
+      case x
+      when false
+        first_method
+      when true
+        second_method
+      when false
+        third_method
+      when true
+        fourth_method
+      end
+    END
     expect(cop.offenses.size).to eq(2)
   end
 
   it 'registers multiple offenses for repeated multi-value condtionals' do
-    inspect_source(cop, ['case x',
-                         'when a, b',
-                         '  first_method',
-                         'when b, a',
-                         '  second_method',
-                         'end'])
+    inspect_source(cop, <<-END.strip_indent)
+      case x
+      when a, b
+        first_method
+      when b, a
+        second_method
+      end
+    END
     expect(cop.offenses.size).to eq(2)
   end
 
   it 'registers an offense for repeated logical operator when expressions' do
-    inspect_source(cop, ['case x',
-                         'when a && b',
-                         '  first_method',
-                         'when a && b',
-                         '  second_method',
-                         'end'])
+    inspect_source(cop, <<-END.strip_indent)
+      case x
+      when a && b
+        first_method
+      when a && b
+        second_method
+      end
+    END
     expect(cop.offenses.size).to eq(1)
   end
 
   it 'accepts trivial case expressions' do
-    inspect_source(cop, ['case x',
-                         'when false',
-                         '  first_method',
-                         'end'])
+    inspect_source(cop, <<-END.strip_indent)
+      case x
+      when false
+        first_method
+      end
+    END
     expect(cop.messages).to be_empty
   end
 
   it 'accepts non-redundant case expressions' do
-    inspect_source(cop, ['case x',
-                         'when false',
-                         '  first_method',
-                         'when true',
-                         '  second_method',
-                         'end'])
+    inspect_source(cop, <<-END.strip_indent)
+      case x
+      when false
+        first_method
+      when true
+        second_method
+      end
+    END
     expect(cop.messages).to be_empty
   end
 
   it 'accepts non-redundant case expressions with an else expression' do
-    inspect_source(cop, ['case x',
-                         'when false',
-                         '  method_name',
-                         'when true',
-                         '  second_method',
-                         'else',
-                         '  third_method',
-                         'end'])
+    inspect_source(cop, <<-END.strip_indent)
+      case x
+      when false
+        method_name
+      when true
+        second_method
+      else
+        third_method
+      end
+    END
     expect(cop.messages).to be_empty
   end
 
   it 'accepts similar but not equivalent && expressions' do
-    inspect_source(cop, ['case x',
-                         'when something && another && other',
-                         '  first_method',
-                         'when something && another',
-                         '  second_method',
-                         'end'])
+    inspect_source(cop, <<-END.strip_indent)
+      case x
+      when something && another && other
+        first_method
+      when something && another
+        second_method
+      end
+    END
     expect(cop.messages).to be_empty
   end
 end

--- a/spec/rubocop/cop/lint/duplicate_methods_spec.rb
+++ b/spec/rubocop/cop/lint/duplicate_methods_spec.rb
@@ -323,14 +323,16 @@ describe RuboCop::Cop::Lint::DuplicateMethods do
   end
 
   it 'ignores Class.new blocks which are assigned to local variables' do
-    inspect_source(cop, ['a = Class.new do',
-                         '  def foo',
-                         '  end',
-                         'end',
-                         'b = Class.new do',
-                         '  def foo',
-                         '  end',
-                         'end'])
+    inspect_source(cop, <<-END.strip_indent)
+      a = Class.new do
+        def foo
+        end
+      end
+      b = Class.new do
+        def foo
+        end
+      end
+    END
     expect(cop.offenses).to be_empty
   end
 end

--- a/spec/rubocop/cop/lint/else_layout_spec.rb
+++ b/spec/rubocop/cop/lint/else_layout_spec.rb
@@ -4,46 +4,50 @@ describe RuboCop::Cop::Lint::ElseLayout do
   subject(:cop) { described_class.new }
 
   it 'registers an offense for expr on same line as else' do
-    inspect_source(cop,
-                   ['if something',
-                    '  test',
-                    'else ala',
-                    '  something',
-                    '  test',
-                    'end'])
+    inspect_source(cop, <<-END.strip_indent)
+      if something
+        test
+      else ala
+        something
+        test
+      end
+    END
     expect(cop.offenses.size).to eq(1)
   end
 
   it 'accepts proper else' do
-    inspect_source(cop,
-                   ['if something',
-                    '  test',
-                    'else',
-                    '  something',
-                    '  test',
-                    'end'])
+    inspect_source(cop, <<-END.strip_indent)
+      if something
+        test
+      else
+        something
+        test
+      end
+    END
     expect(cop.offenses).to be_empty
   end
 
   it 'accepts single-expr else regardless of layout' do
-    inspect_source(cop,
-                   ['if something',
-                    '  test',
-                    'else bala',
-                    'end'])
+    inspect_source(cop, <<-END.strip_indent)
+      if something
+        test
+      else bala
+      end
+    END
     expect(cop.offenses).to be_empty
   end
 
   it 'can handle elsifs' do
-    inspect_source(cop,
-                   ['if something',
-                    '  test',
-                    'elsif something',
-                    '  bala',
-                    'else ala',
-                    '  something',
-                    '  test',
-                    'end'])
+    inspect_source(cop, <<-END.strip_indent)
+      if something
+        test
+      elsif something
+        bala
+      else ala
+        something
+        test
+      end
+    END
     expect(cop.offenses.size).to eq(1)
   end
 

--- a/spec/rubocop/cop/lint/empty_ensure_spec.rb
+++ b/spec/rubocop/cop/lint/empty_ensure_spec.rb
@@ -4,36 +4,39 @@ describe RuboCop::Cop::Lint::EmptyEnsure do
   subject(:cop) { described_class.new }
 
   it 'registers an offense for empty ensure' do
-    inspect_source(cop,
-                   ['begin',
-                    '  something',
-                    'ensure',
-                    'end'])
+    inspect_source(cop, <<-END.strip_indent)
+      begin
+        something
+      ensure
+      end
+    END
     expect(cop.offenses.size).to eq(1)
   end
 
   it 'autocorrects for empty ensure' do
-    corrected = autocorrect_source(cop,
-                                   ['begin',
-                                    '  something',
-                                    'ensure',
-                                    'end'])
-    expect(corrected).to eq([
-      'begin',
-      '  something',
-      '',
-      'end'
-    ].join("\n"))
+    corrected = autocorrect_source(cop, <<-END.strip_indent)
+      begin
+        something
+      ensure
+      end
+    END
+    expect(corrected).to eq(<<-END.strip_indent)
+      begin
+        something
+
+      end
+    END
   end
 
   it 'does not register an offense for non-empty ensure' do
-    inspect_source(cop,
-                   ['begin',
-                    '  something',
-                    '  return',
-                    'ensure',
-                    '  file.close',
-                    'end'])
+    inspect_source(cop, <<-END.strip_indent)
+      begin
+        something
+        return
+      ensure
+        file.close
+      end
+    END
     expect(cop.offenses).to be_empty
   end
 end

--- a/spec/rubocop/cop/lint/empty_expression_spec.rb
+++ b/spec/rubocop/cop/lint/empty_expression_spec.rb
@@ -52,22 +52,25 @@ describe RuboCop::Cop::Lint::EmptyExpression, :config do
     it_behaves_like 'code with offense',
                     'if (); end'
 
-    it_behaves_like 'code with offense',
-                    ['if foo',
-                     '  1',
-                     'elsif ()',
-                     '  2',
-                     'end'].join("\n")
+    it_behaves_like 'code with offense', <<-END.strip_indent
+      if foo
+        1
+      elsif ()
+        2
+      end
+    END
 
-    it_behaves_like 'code with offense',
-                    ['case ()',
-                     'when :foo then 1',
-                     'end'].join("\n")
+    it_behaves_like 'code with offense', <<-END.strip_indent
+      case ()
+      when :foo then 1
+      end
+    END
 
-    it_behaves_like 'code with offense',
-                    ['case foo',
-                     'when () then 1',
-                     'end'].join("\n")
+    it_behaves_like 'code with offense', <<-END.strip_indent
+      case foo
+      when () then 1
+      end
+    END
 
     it_behaves_like 'code with offense',
                     '() ? true : false'
@@ -77,20 +80,23 @@ describe RuboCop::Cop::Lint::EmptyExpression, :config do
   end
 
   context 'when used as a return value' do
-    it_behaves_like 'code with offense',
-                    ['def foo',
-                     '  ()',
-                     'end'].join("\n")
+    it_behaves_like 'code with offense', <<-END.strip_indent
+      def foo
+        ()
+      end
+    END
 
-    it_behaves_like 'code with offense',
-                    ['if foo',
-                     '  ()',
-                     'end'].join("\n")
+    it_behaves_like 'code with offense', <<-END.strip_indent
+      if foo
+        ()
+      end
+    END
 
-    it_behaves_like 'code with offense',
-                    ['case foo',
-                     'when :bar then ()',
-                     'end'].join("\n")
+    it_behaves_like 'code with offense', <<-END.strip_indent
+      case foo
+      when :bar then ()
+      end
+    END
   end
 
   context 'when used as an assignment' do

--- a/spec/rubocop/cop/lint/empty_when_spec.rb
+++ b/spec/rubocop/cop/lint/empty_when_spec.rb
@@ -39,100 +39,112 @@ describe RuboCop::Cop::Lint::EmptyWhen, :config do
   let(:message) { described_class::MSG }
 
   context 'when a `when` body is missing' do
-    it_behaves_like 'code with offense',
-                    ['case foo',
-                     'when :bar then 1',
-                     'when :baz # nothing',
-                     'end'].join("\n")
+    it_behaves_like 'code with offense', <<-END.strip_indent
+      case foo
+      when :bar then 1
+      when :baz # nothing
+      end
+    END
 
-    it_behaves_like 'code with offense',
-                    ['case foo',
-                     'when :bar then 1',
-                     'when :baz # nothing',
-                     'else 3',
-                     'end'].join("\n")
+    it_behaves_like 'code with offense', <<-END.strip_indent
+      case foo
+      when :bar then 1
+      when :baz # nothing
+      else 3
+      end
+    END
 
-    it_behaves_like 'code with offense',
-                    ['case foo',
-                     'when :bar then 1',
-                     'when :baz then # nothing',
-                     'end'].join("\n")
+    it_behaves_like 'code with offense', <<-END.strip_indent
+      case foo
+      when :bar then 1
+      when :baz then # nothing
+      end
+    END
 
-    it_behaves_like 'code with offense',
-                    ['case foo',
-                     'when :bar then 1',
-                     'when :baz then # nothing',
-                     'else 3',
-                     'end'].join("\n")
+    it_behaves_like 'code with offense', <<-END.strip_indent
+      case foo
+      when :bar then 1
+      when :baz then # nothing
+      else 3
+      end
+    END
 
-    it_behaves_like 'code with offense',
-                    ['case foo',
-                     'when :bar',
-                     '  1',
-                     'when :baz',
-                     '  # nothing',
-                     'end'].join("\n")
+    it_behaves_like 'code with offense', <<-END.strip_indent
+      case foo
+      when :bar
+        1
+      when :baz
+        # nothing
+      end
+    END
 
-    it_behaves_like 'code with offense',
-                    ['case foo',
-                     'when :bar',
-                     '  1',
-                     'when :baz',
-                     '  # nothing',
-                     'else',
-                     '  3',
-                     'end'].join("\n")
+    it_behaves_like 'code with offense', <<-END.strip_indent
+      case foo
+      when :bar
+        1
+      when :baz
+        # nothing
+      else
+        3
+      end
+    END
 
-    it_behaves_like 'code with offense',
-                    ['case',
-                     'when :bar',
-                     '  1',
-                     'when :baz',
-                     '  # nothing',
-                     'else',
-                     '  3',
-                     'end'].join("\n")
+    it_behaves_like 'code with offense', <<-END.strip_indent
+      case
+      when :bar
+        1
+      when :baz
+        # nothing
+      else
+        3
+      end
+    END
   end
 
   context 'when a `when` body is present' do
-    it_behaves_like 'code without offense',
-                    ['case foo',
-                     'when :bar then 1',
-                     'when :baz then 2',
-                     'end'].join("\n")
+    it_behaves_like 'code without offense', <<-END.strip_indent
+      case foo
+      when :bar then 1
+      when :baz then 2
+      end
+    END
 
-    it_behaves_like 'code without offense',
-                    ['case foo',
-                     'when :bar then 1',
-                     'when :baz then 2',
-                     'else 3',
-                     'end'].join("\n")
+    it_behaves_like 'code without offense', <<-END.strip_indent
+      case foo
+      when :bar then 1
+      when :baz then 2
+      else 3
+      end
+    END
 
-    it_behaves_like 'code without offense',
-                    ['case foo',
-                     'when :bar',
-                     '  1',
-                     'when :baz',
-                     '  2',
-                     'end'].join("\n")
+    it_behaves_like 'code without offense', <<-END.strip_indent
+      case foo
+      when :bar
+        1
+      when :baz
+        2
+      end
+    END
 
-    it_behaves_like 'code without offense',
-                    ['case foo',
-                     'when :bar',
-                     '  1',
-                     'when :baz',
-                     '  2',
-                     'else',
-                     '  3',
-                     'end'].join("\n")
-    it_behaves_like 'code without offense',
-                    ['case',
-                     'when :bar',
-                     '  1',
-                     'when :baz',
-                     '  2',
-                     'else',
-                     '  3',
-                     'end'].join("\n")
+    it_behaves_like 'code without offense', <<-END.strip_indent
+      case foo
+      when :bar
+        1
+      when :baz
+        2
+      else
+        3
+      end
+    END
+    it_behaves_like 'code without offense', <<-END.strip_indent
+      case
+      when :bar
+        1
+      when :baz
+        2
+      else
+        3
+      end
+    END
   end
 end

--- a/spec/rubocop/cop/lint/end_alignment_spec.rb
+++ b/spec/rubocop/cop/lint/end_alignment_spec.rb
@@ -122,12 +122,14 @@ describe RuboCop::Cop::Lint::EndAlignment, :config do
 
   context 'correct + opposite' do
     let(:source) do
-      ['x = if a',
-       '      a1',
-       '    end',
-       'y = if b',
-       '  b1',
-       'end']
+      <<-END.strip_indent
+        x = if a
+              a1
+            end
+        y = if b
+          b1
+        end
+      END
     end
 
     it 'registers an offense' do
@@ -141,19 +143,23 @@ describe RuboCop::Cop::Lint::EndAlignment, :config do
 
     it 'does auto-correction' do
       corrected = autocorrect_source(cop, source)
-      expect(corrected).to eq(['x = if a',
-                               '      a1',
-                               '    end',
-                               'y = if b',
-                               '  b1',
-                               '    end'].join("\n"))
+      expect(corrected).to eq(<<-END.strip_indent)
+        x = if a
+              a1
+            end
+        y = if b
+          b1
+            end
+      END
     end
   end
 
   context 'when end is preceded by something else than whitespace' do
     let(:source) do
-      ['module A',
-       'puts a end']
+      <<-END.strip_indent
+        module A
+        puts a end
+      END
     end
 
     it 'registers an offense' do
@@ -166,7 +172,7 @@ describe RuboCop::Cop::Lint::EndAlignment, :config do
 
     it "doesn't auto-correct" do
       expect(autocorrect_source(cop, source))
-        .to eq(source.join("\n"))
+        .to eq(source)
       expect(cop.offenses.map(&:corrected?)).to eq [false]
     end
   end

--- a/spec/rubocop/cop/lint/end_in_method_spec.rb
+++ b/spec/rubocop/cop/lint/end_in_method_spec.rb
@@ -4,17 +4,21 @@ describe RuboCop::Cop::Lint::EndInMethod do
   subject(:cop) { described_class.new }
 
   it 'reports an offense for def with an END inside' do
-    src = ['def test',
-           '  END { something }',
-           'end']
+    src = <<-END.strip_indent
+      def test
+        END { something }
+      end
+    END
     inspect_source(cop, src)
     expect(cop.offenses.size).to eq(1)
   end
 
   it 'reports an offense for defs with an END inside' do
-    src = ['def self.test',
-           '  END { something }',
-           'end']
+    src = <<-END.strip_indent
+      def self.test
+        END { something }
+      end
+    END
     inspect_source(cop, src)
     expect(cop.offenses.size).to eq(1)
   end

--- a/spec/rubocop/cop/lint/ensure_return_spec.rb
+++ b/spec/rubocop/cop/lint/ensure_return_spec.rb
@@ -4,34 +4,37 @@ describe RuboCop::Cop::Lint::EnsureReturn do
   subject(:cop) { described_class.new }
 
   it 'registers an offense for return in ensure' do
-    inspect_source(cop,
-                   ['begin',
-                    '  something',
-                    'ensure',
-                    '  file.close',
-                    '  return',
-                    'end'])
+    inspect_source(cop, <<-END.strip_indent)
+      begin
+        something
+      ensure
+        file.close
+        return
+      end
+    END
     expect(cop.offenses.size).to eq(1)
   end
 
   it 'does not register an offense for return outside ensure' do
-    inspect_source(cop,
-                   ['begin',
-                    '  something',
-                    '  return',
-                    'ensure',
-                    '  file.close',
-                    'end'])
+    inspect_source(cop, <<-END.strip_indent)
+      begin
+        something
+        return
+      ensure
+        file.close
+      end
+    END
     expect(cop.offenses).to be_empty
   end
 
   it 'does not check when ensure block has no body' do
     expect do
-      inspect_source(cop,
-                     ['begin',
-                      '  something',
-                      'ensure',
-                      'end'])
+      inspect_source(cop, <<-END.strip_indent)
+        begin
+          something
+        ensure
+        end
+      END
     end.not_to raise_exception
   end
 end

--- a/spec/rubocop/cop/lint/format_parameter_mismatch_spec.rb
+++ b/spec/rubocop/cop/lint/format_parameter_mismatch_spec.rb
@@ -5,22 +5,28 @@ describe RuboCop::Cop::Lint::FormatParameterMismatch do
 
   shared_examples 'variables' do |variable|
     it 'does not register an offense for % called on a variable' do
-      inspect_source(cop, ["#{variable} = '%s'",
-                           "#{variable} % [foo]"])
+      inspect_source(cop, <<-END.strip_indent)
+        #{variable} = '%s'
+        #{variable} % [foo]
+      END
 
       expect(cop.messages).to be_empty
     end
 
     it 'does not register an offense for format called on a variable' do
-      inspect_source(cop, ["#{variable} = '%s'",
-                           "format(#{variable}, foo)"])
+      inspect_source(cop, <<-END.strip_indent)
+        #{variable} = '%s'
+        format(#{variable}, foo)
+      END
 
       expect(cop.messages).to be_empty
     end
 
     it 'does not register an offense for format called on a variable' do
-      inspect_source(cop, ["#{variable} = '%s'",
-                           "sprintf(#{variable}, foo)"])
+      inspect_source(cop, <<-END.strip_indent)
+        #{variable} = '%s'
+        sprintf(#{variable}, foo)
+      END
 
       expect(cop.messages).to be_empty
     end
@@ -252,16 +258,20 @@ describe RuboCop::Cop::Lint::FormatParameterMismatch do
   context 'on format with %{} interpolations' do
     context 'and 1 argument' do
       it 'does not register an offense' do
-        inspect_source(cop, ["params = { y: '2015', m: '01', d: '01' }",
-                             "puts format('%{y}-%{m}-%{d}', params)"])
+        inspect_source(cop, <<-END.strip_indent)
+          params = { y: '2015', m: '01', d: '01' }
+          puts format('%{y}-%{m}-%{d}', params)
+        END
         expect(cop.offenses).to be_empty
       end
     end
 
     context 'and multiple arguments' do
       it 'registers an offense' do
-        inspect_source(cop, ["params = { y: '2015', m: '01', d: '01' }",
-                             "puts format('%{y}-%{m}-%{d}', 2015, 1, 1)"])
+        inspect_source(cop, <<-END.strip_indent)
+          params = { y: '2015', m: '01', d: '01' }
+          puts format('%{y}-%{m}-%{d}', 2015, 1, 1)
+        END
         expect(cop.messages).to eq(['Number of arguments (3) to `format` ' \
                                     "doesn't match the number of fields (1)."])
       end
@@ -271,16 +281,20 @@ describe RuboCop::Cop::Lint::FormatParameterMismatch do
   context 'on format with %<> interpolations' do
     context 'and 1 argument' do
       it 'does not register an offense' do
-        inspect_source(cop, ["params = { y: '2015', m: '01', d: '01' }",
-                             "puts format('%<y>d-%<m>d-%<d>d', params)"])
+        inspect_source(cop, <<-END.strip_indent)
+          params = { y: '2015', m: '01', d: '01' }
+          puts format('%<y>d-%<m>d-%<d>d', params)
+        END
         expect(cop.offenses).to be_empty
       end
     end
 
     context 'and multiple arguments' do
       it 'registers an offense' do
-        inspect_source(cop, ["params = { y: '2015', m: '01', d: '01' }",
-                             "puts format('%<y>d-%<m>d-%<d>d', 2015, 1, 1)"])
+        inspect_source(cop, <<-END.strip_indent)
+          params = { y: '2015', m: '01', d: '01' }
+          puts format('%<y>d-%<m>d-%<d>d', 2015, 1, 1)
+        END
         expect(cop.messages).to eq(['Number of arguments (3) to `format` ' \
                                     "doesn't match the number of fields (1)."])
       end

--- a/spec/rubocop/cop/lint/handle_exceptions_spec.rb
+++ b/spec/rubocop/cop/lint/handle_exceptions_spec.rb
@@ -4,25 +4,27 @@ describe RuboCop::Cop::Lint::HandleExceptions do
   subject(:cop) { described_class.new }
 
   it 'registers an offense for empty rescue block' do
-    inspect_source(cop,
-                   ['begin',
-                    '  something',
-                    'rescue',
-                    '  #do nothing',
-                    'end'])
+    inspect_source(cop, <<-END.strip_indent)
+      begin
+        something
+      rescue
+        #do nothing
+      end
+    END
     expect(cop.offenses.size).to eq(1)
     expect(cop.messages)
       .to eq(['Do not suppress exceptions.'])
   end
 
   it 'does not register an offense for rescue with body' do
-    inspect_source(cop,
-                   ['begin',
-                    '  something',
-                    '  return',
-                    'rescue',
-                    '  file.close',
-                    'end'])
+    inspect_source(cop, <<-END.strip_indent)
+      begin
+        something
+        return
+      rescue
+        file.close
+      end
+    END
     expect(cop.offenses).to be_empty
   end
 end

--- a/spec/rubocop/cop/lint/ineffective_access_modifier_spec.rb
+++ b/spec/rubocop/cop/lint/ineffective_access_modifier_spec.rb
@@ -9,13 +9,15 @@ describe RuboCop::Cop::Lint::IneffectiveAccessModifier do
 
   context 'when `private` is applied to a class method' do
     let(:source) do
-      ['class C',
-       '  private',
-       '',
-       '  def self.method',
-       '    puts "hi"',
-       '  end',
-       'end']
+      <<-END.strip_indent
+        class C
+          private
+
+          def self.method
+            puts "hi"
+          end
+        end
+      END
     end
 
     it 'registers an offense' do
@@ -31,13 +33,15 @@ describe RuboCop::Cop::Lint::IneffectiveAccessModifier do
 
   context 'when `protected` is applied to a class method' do
     let(:source) do
-      ['class C',
-       '  protected',
-       '',
-       '  def self.method',
-       '    puts "hi"',
-       '  end',
-       'end']
+      <<-END.strip_indent
+        class C
+          protected
+
+          def self.method
+            puts "hi"
+          end
+        end
+      END
     end
 
     it 'registers an offense' do
@@ -52,15 +56,17 @@ describe RuboCop::Cop::Lint::IneffectiveAccessModifier do
 
   context 'when `private_class_method` is used' do
     let(:source) do
-      ['class C',
-       '  private',
-       '',
-       '  def self.method',
-       '    puts "hi"',
-       '  end',
-       '',
-       '  private_class_method :method',
-       'end']
+      <<-END.strip_indent
+        class C
+          private
+
+          def self.method
+            puts "hi"
+          end
+
+          private_class_method :method
+        end
+      END
     end
 
     it "doesn't register an offense" do
@@ -70,15 +76,17 @@ describe RuboCop::Cop::Lint::IneffectiveAccessModifier do
 
   context 'when a `class << self` block is used' do
     let(:source) do
-      ['class C',
-       '  private',
-       '',
-       '  class << self',
-       '    def self.method',
-       '      puts "hi"',
-       '    end',
-       '  end',
-       'end']
+      <<-END.strip_indent
+        class C
+          private
+
+          class << self
+            def self.method
+              puts "hi"
+            end
+          end
+        end
+      END
     end
 
     it "doesn't register an offense" do
@@ -88,17 +96,19 @@ describe RuboCop::Cop::Lint::IneffectiveAccessModifier do
 
   context 'when there is an intervening instance method' do
     let(:source) do
-      ['class C',
-       '',
-       '  private',
-       '',
-       '  def instance_method',
-       '  end',
-       '',
-       '  def self.method',
-       '    puts "hi"',
-       '  end',
-       'end']
+      <<-END.strip_indent
+        class C
+
+          private
+
+          def instance_method
+          end
+
+          def self.method
+            puts "hi"
+          end
+        end
+      END
     end
 
     it 'still registers an offense' do

--- a/spec/rubocop/cop/lint/literal_in_condition_spec.rb
+++ b/spec/rubocop/cop/lint/literal_in_condition_spec.rb
@@ -5,149 +5,167 @@ describe RuboCop::Cop::Lint::LiteralInCondition do
 
   %w(1 2.0 [1] {} :sym :"#{a}").each do |lit|
     it "registers an offense for literal #{lit} in if" do
-      inspect_source(cop,
-                     ["if #{lit}",
-                      '  top',
-                      'end'])
+      inspect_source(cop, <<-END.strip_indent)
+        if #{lit}
+          top
+        end
+      END
       expect(cop.offenses.size).to eq(1)
     end
 
     it "registers an offense for literal #{lit} in while" do
-      inspect_source(cop,
-                     ["while #{lit}",
-                      '  top',
-                      'end'])
+      inspect_source(cop, <<-END.strip_indent)
+        while #{lit}
+          top
+        end
+      END
       expect(cop.offenses.size).to eq(1)
     end
 
     it "registers an offense for literal #{lit} in post-loop while" do
-      inspect_source(cop,
-                     ['begin',
-                      '  top',
-                      "end while(#{lit})"])
+      inspect_source(cop, <<-END.strip_indent)
+        begin
+          top
+        end while(#{lit})
+      END
       expect(cop.offenses.size).to eq(1)
     end
 
     it "registers an offense for literal #{lit} in until" do
-      inspect_source(cop,
-                     ["until #{lit}",
-                      '  top',
-                      'end'])
+      inspect_source(cop, <<-END.strip_indent)
+        until #{lit}
+          top
+        end
+      END
       expect(cop.offenses.size).to eq(1)
     end
 
     it "registers an offense for literal #{lit} in post-loop until" do
-      inspect_source(cop,
-                     ['begin',
-                      '  top',
-                      "end until #{lit}"])
+      inspect_source(cop, <<-END.strip_indent)
+        begin
+          top
+        end until #{lit}
+      END
       expect(cop.offenses.size).to eq(1)
     end
 
     it "registers an offense for literal #{lit} in case" do
-      inspect_source(cop,
-                     ["case #{lit}",
-                      'when x then top',
-                      'end'])
+      inspect_source(cop, <<-END.strip_indent)
+        case #{lit}
+        when x then top
+        end
+      END
       expect(cop.offenses.size).to eq(1)
     end
 
     it "registers an offense for literal #{lit} in a when " \
        'of a case without anything after case keyword' do
-      inspect_source(cop,
-                     ['case',
-                      "when #{lit} then top",
-                      'end'])
+      inspect_source(cop, <<-END.strip_indent)
+        case
+        when #{lit} then top
+        end
+      END
       expect(cop.offenses.size).to eq(1)
     end
 
     it "accepts literal #{lit} in a when of a case with " \
        'something after case keyword' do
-      inspect_source(cop,
-                     ['case x',
-                      "when #{lit} then top",
-                      'end'])
+      inspect_source(cop, <<-END.strip_indent)
+        case x
+        when #{lit} then top
+        end
+      END
       expect(cop.offenses).to be_empty
     end
 
     it "registers an offense for literal #{lit} in &&" do
-      inspect_source(cop,
-                     ["if x && #{lit}",
-                      '  top',
-                      'end'])
+      inspect_source(cop, <<-END.strip_indent)
+        if x && #{lit}
+          top
+        end
+      END
       expect(cop.offenses.size).to eq(1)
     end
 
     it "registers an offense for literal #{lit} in complex cond" do
-      inspect_source(cop,
-                     ["if x && !(a && #{lit}) && y && z",
-                      '  top',
-                      'end'])
+      inspect_source(cop, <<-END.strip_indent)
+        if x && !(a && #{lit}) && y && z
+          top
+        end
+      END
       expect(cop.offenses.size).to eq(1)
     end
 
     it "registers an offense for literal #{lit} in !" do
-      inspect_source(cop,
-                     ["if !#{lit}",
-                      '  top',
-                      'end'])
+      inspect_source(cop, <<-END.strip_indent)
+        if !#{lit}
+          top
+        end
+      END
       expect(cop.offenses.size).to eq(1)
     end
 
     it "registers an offense for literal #{lit} in complex !" do
-      inspect_source(cop,
-                     ["if !(x && (y && #{lit}))",
-                      '  top',
-                      'end'])
+      inspect_source(cop, <<-END.strip_indent)
+        if !(x && (y && #{lit}))
+          top
+        end
+      END
       expect(cop.offenses.size).to eq(1)
     end
 
     it "accepts literal #{lit} if it's not an and/or operand" do
-      inspect_source(cop,
-                     ["if test(#{lit})",
-                      '  top',
-                      'end'])
+      inspect_source(cop, <<-END.strip_indent)
+        if test(#{lit})
+          top
+        end
+      END
       expect(cop.offenses).to be_empty
     end
 
     it "accepts literal #{lit} in non-toplevel and/or" do
-      inspect_source(cop,
-                     ["if (a || #{lit}).something",
-                      '  top',
-                      'end'])
+      inspect_source(cop, <<-END.strip_indent)
+        if (a || #{lit}).something
+          top
+        end
+      END
       expect(cop.offenses).to be_empty
     end
   end
 
   it 'accepts array literal in case, if it has non-literal elements' do
-    inspect_source(cop,
-                   ['case [1, 2, x]',
-                    'when [1, 2, 5] then top',
-                    'end'])
+    inspect_source(cop, <<-END.strip_indent)
+      case [1, 2, x]
+      when [1, 2, 5] then top
+      end
+    END
     expect(cop.offenses).to be_empty
   end
 
   it 'accepts array literal in case, if it has nested non-literal element' do
-    inspect_source(cop,
-                   ['case [1, 2, [x, 1]]',
-                    'when [1, 2, 5] then top',
-                    'end'])
+    inspect_source(cop, <<-END.strip_indent)
+      case [1, 2, [x, 1]]
+      when [1, 2, 5] then top
+      end
+    END
     expect(cop.offenses).to be_empty
   end
 
   it 'registers an offense for case with a primitive array condition' do
-    inspect_source(cop,
-                   ['case [1, 2, [3, 4]]',
-                    'when [1, 2, 5] then top',
-                    'end'])
+    inspect_source(cop, <<-END.strip_indent)
+      case [1, 2, [3, 4]]
+      when [1, 2, 5] then top
+      end
+    END
     expect(cop.offenses.size).to eq(1)
   end
 
   it 'accepts dstr literal in case' do
-    inspect_source(cop,
-                   ['case "#{x}"',
-                    'when [1, 2, 5] then top',
-                    'end'])
+    inspect_source(cop, <<-'END'.strip_indent)
+      case "#{x}"
+      when [1, 2, 5] then top
+      end
+    END
     expect(cop.offenses).to be_empty
   end
 end

--- a/spec/rubocop/cop/lint/nested_method_definition_spec.rb
+++ b/spec/rubocop/cop/lint/nested_method_definition_spec.rb
@@ -9,171 +9,201 @@ describe RuboCop::Cop::Lint::NestedMethodDefinition do
   end
 
   it 'registers an offense for a nested singleton method definition' do
-    inspect_source(cop, ['class Foo',
-                         'end',
-                         'foo = Foo.new',
-                         'def foo.bar',
-                         '  def baz',
-                         '  end',
-                         'end'])
+    inspect_source(cop, <<-END.strip_indent)
+      class Foo
+      end
+      foo = Foo.new
+      def foo.bar
+        def baz
+        end
+      end
+    END
     expect(cop.offenses.size).to eq(1)
   end
 
   it 'registers an offense for a nested method definition inside lambda' do
-    inspect_source(cop, ['def foo',
-                         '  bar = -> { def baz; puts; end }',
-                         'end'])
+    inspect_source(cop, <<-END.strip_indent)
+      def foo
+        bar = -> { def baz; puts; end }
+      end
+    END
     expect(cop.offenses.size).to eq(1)
   end
 
   it 'registers an offense for a nested class method definition' do
-    inspect_source(cop, ['class Foo',
-                         '  def self.x',
-                         '    def self.y',
-                         '    end',
-                         '  end',
-                         'end'])
+    inspect_source(cop, <<-END.strip_indent)
+      class Foo
+        def self.x
+          def self.y
+          end
+        end
+      end
+    END
     expect(cop.offenses.size).to eq(1)
   end
 
   it 'does not register an offense for a lambda definition inside method' do
-    inspect_source(cop, ['def foo',
-                         '  bar = -> { puts  }',
-                         '  bar.call',
-                         'end'])
+    inspect_source(cop, <<-END.strip_indent)
+      def foo
+        bar = -> { puts  }
+        bar.call
+      end
+    END
     expect(cop.offenses).to be_empty
   end
 
   it 'does not register offense for nested definition inside instance_eval' do
-    inspect_source(cop, ['class Foo',
-                         '  def x(obj)',
-                         '    obj.instance_eval do',
-                         '      def y',
-                         '      end',
-                         '    end',
-                         '  end',
-                         'end'])
+    inspect_source(cop, <<-END.strip_indent)
+      class Foo
+        def x(obj)
+          obj.instance_eval do
+            def y
+            end
+          end
+        end
+      end
+    END
     expect(cop.offenses).to be_empty
   end
 
   it 'does not register offense for nested definition inside instance_exec' do
-    inspect_source(cop, ['class Foo',
-                         '  def x(obj)',
-                         '    obj.instance_exec do',
-                         '      def y',
-                         '      end',
-                         '    end',
-                         '  end',
-                         'end'])
+    inspect_source(cop, <<-END.strip_indent)
+      class Foo
+        def x(obj)
+          obj.instance_exec do
+            def y
+            end
+          end
+        end
+      end
+    END
     expect(cop.offenses).to be_empty
   end
 
   it 'does not register offense for definition of method on local var' do
-    inspect_source(cop, ['class Foo',
-                         '  def x(obj)',
-                         '    def obj.y',
-                         '    end',
-                         '  end',
-                         'end'])
+    inspect_source(cop, <<-END.strip_indent)
+      class Foo
+        def x(obj)
+          def obj.y
+          end
+        end
+      end
+    END
     expect(cop.offenses).to be_empty
   end
 
   it 'does not register offense for nested definition inside class_eval' do
-    inspect_source(cop, ['class Foo',
-                         '  def x(klass)',
-                         '    klass.class_eval do',
-                         '      def y',
-                         '      end',
-                         '    end',
-                         '  end',
-                         'end'])
+    inspect_source(cop, <<-END.strip_indent)
+      class Foo
+        def x(klass)
+          klass.class_eval do
+            def y
+            end
+          end
+        end
+      end
+    END
     expect(cop.offenses).to be_empty
   end
 
   it 'does not register offense for nested definition inside class_exec' do
-    inspect_source(cop, ['class Foo',
-                         '  def x(klass)',
-                         '    klass.class_exec do',
-                         '      def y',
-                         '      end',
-                         '    end',
-                         '  end',
-                         'end'])
+    inspect_source(cop, <<-END.strip_indent)
+      class Foo
+        def x(klass)
+          klass.class_exec do
+            def y
+            end
+          end
+        end
+      end
+    END
     expect(cop.offenses).to be_empty
   end
 
   it 'does not register offense for nested definition inside module_eval' do
-    inspect_source(cop, ['class Foo',
-                         '  def self.define(mod)',
-                         '    mod.module_eval do',
-                         '      def y',
-                         '      end',
-                         '    end',
-                         '  end',
-                         'end'])
+    inspect_source(cop, <<-END.strip_indent)
+      class Foo
+        def self.define(mod)
+          mod.module_eval do
+            def y
+            end
+          end
+        end
+      end
+    END
     expect(cop.offenses).to be_empty
   end
 
   it 'does not register offense for nested definition inside module_eval' do
-    inspect_source(cop, ['class Foo',
-                         '  def self.define(mod)',
-                         '    mod.module_exec do',
-                         '      def y',
-                         '      end',
-                         '    end',
-                         '  end',
-                         'end'])
+    inspect_source(cop, <<-END.strip_indent)
+      class Foo
+        def self.define(mod)
+          mod.module_exec do
+            def y
+            end
+          end
+        end
+      end
+    END
     expect(cop.offenses).to be_empty
   end
 
   it 'does not register offense for nested definition inside class shovel' do
-    inspect_source(cop, ['class Foo',
-                         '  def bar',
-                         '    class << self',
-                         '      def baz',
-                         '      end',
-                         '    end',
-                         '  end',
-                         'end'])
+    inspect_source(cop, <<-END.strip_indent)
+      class Foo
+        def bar
+          class << self
+            def baz
+            end
+          end
+        end
+      end
+    END
     expect(cop.offenses).to be_empty
   end
 
   it 'does not register offense for nested definition inside Class.new' do
     ['(S)', ''].each do |constructor_args|
-      inspect_source(cop, ['class Foo',
-                           '  def self.define',
-                           "    Class.new#{constructor_args} do",
-                           '      def y',
-                           '      end',
-                           '    end',
-                           '  end',
-                           'end'])
+      inspect_source(cop, <<-END.strip_indent)
+        class Foo
+          def self.define
+            Class.new#{constructor_args} do
+              def y
+              end
+            end
+          end
+        end
+      END
       expect(cop.offenses).to be_empty
     end
   end
 
   it 'does not register offense for nested definition inside Module.new' do
-    inspect_source(cop, ['class Foo',
-                         '  def self.define',
-                         '    Module.new do',
-                         '      def y',
-                         '      end',
-                         '    end',
-                         '  end',
-                         'end'])
+    inspect_source(cop, <<-END.strip_indent)
+      class Foo
+        def self.define
+          Module.new do
+            def y
+            end
+          end
+        end
+      end
+    END
     expect(cop.offenses).to be_empty
   end
 
   it 'does not register offense for nested definition inside Struct.new' do
     ['(:name)', ''].each do |constructor_args|
-      inspect_source(cop, ['class Foo',
-                           '  def self.define',
-                           "    Struct.new#{constructor_args} do",
-                           '      def y',
-                           '      end',
-                           '    end',
-                           '  end',
-                           'end'])
+      inspect_source(cop, <<-END.strip_indent)
+        class Foo
+          def self.define
+            Struct.new#{constructor_args} do
+              def y
+              end
+            end
+          end
+        end
+      END
       expect(cop.offenses).to be_empty
     end
   end

--- a/spec/rubocop/cop/lint/parentheses_as_grouped_expression_spec.rb
+++ b/spec/rubocop/cop/lint/parentheses_as_grouped_expression_spec.rb
@@ -31,9 +31,11 @@ describe RuboCop::Cop::Lint::ParenthesesAsGroupedExpression do
   end
 
   it 'accepts a chain of method calls' do
-    inspect_source(cop, ['a.b',
-                         'a.b 1',
-                         'a.b(1)'])
+    inspect_source(cop, <<-END.strip_indent)
+      a.b
+      a.b 1
+      a.b(1)
+    END
     expect(cop.offenses).to be_empty
   end
 
@@ -43,8 +45,10 @@ describe RuboCop::Cop::Lint::ParenthesesAsGroupedExpression do
   end
 
   it 'accepts an operator call with argument in parentheses' do
-    inspect_source(cop, ['a % (b + c)',
-                         'a.b = (c == d)'])
+    inspect_source(cop, <<-END.strip_indent)
+      a % (b + c)
+      a.b = (c == d)
+    END
     expect(cop.offenses).to be_empty
   end
 

--- a/spec/rubocop/cop/lint/require_parentheses_spec.rb
+++ b/spec/rubocop/cop/lint/require_parentheses_spec.rb
@@ -5,9 +5,11 @@ describe RuboCop::Cop::Lint::RequireParentheses do
 
   it 'registers an offense for missing parentheses around expression with ' \
      '&& operator' do
-    inspect_source(cop, ["if day.is? 'monday' && month == :jan",
-                         '  foo',
-                         'end'])
+    inspect_source(cop, <<-END.strip_indent)
+      if day.is? 'monday' && month == :jan
+        foo
+      end
+    END
     expect(cop.highlights).to eq(["day.is? 'monday' && month == :jan"])
     expect(cop.messages)
       .to eq(['Use parentheses in the method call to avoid confusion about ' \
@@ -27,34 +29,44 @@ describe RuboCop::Cop::Lint::RequireParentheses do
   end
 
   it 'accepts missing parentheses around expression with + operator' do
-    inspect_source(cop, ["if day_is? 'tuesday' + rest",
-                         'end'])
+    inspect_source(cop, <<-END.strip_indent)
+      if day_is? 'tuesday' + rest
+      end
+    END
     expect(cop.offenses).to be_empty
   end
 
   it 'accepts method calls without parentheses followed by keyword and/or' do
-    inspect_source(cop, ["if day.is? 'tuesday' and month == :jan",
-                         'end',
-                         "if day.is? 'tuesday' or month == :jan",
-                         'end'])
+    inspect_source(cop, <<-END.strip_indent)
+      if day.is? 'tuesday' and month == :jan
+      end
+      if day.is? 'tuesday' or month == :jan
+      end
+    END
     expect(cop.offenses).to be_empty
   end
 
   it 'accepts method calls that are all operations' do
-    inspect_source(cop, ['if current_level == max + 1',
-                         'end'])
+    inspect_source(cop, <<-END.strip_indent)
+      if current_level == max + 1
+      end
+    END
     expect(cop.offenses).to be_empty
   end
 
   it 'accepts condition that is not a call' do
-    inspect_source(cop, ['if @debug',
-                         'end'])
+    inspect_source(cop, <<-END.strip_indent)
+      if @debug
+      end
+    END
     expect(cop.offenses).to be_empty
   end
 
   it 'accepts parentheses around expression with boolean operator' do
-    inspect_source(cop, ["if day.is?('tuesday' && true == true)",
-                         'end'])
+    inspect_source(cop, <<-END.strip_indent)
+      if day.is?('tuesday' && true == true)
+      end
+    END
     expect(cop.offenses).to be_empty
   end
 

--- a/spec/rubocop/cop/lint/rescue_exception_spec.rb
+++ b/spec/rubocop/cop/lint/rescue_exception_spec.rb
@@ -4,118 +4,129 @@ describe RuboCop::Cop::Lint::RescueException do
   subject(:cop) { described_class.new }
 
   it 'registers an offense for rescue from Exception' do
-    inspect_source(cop,
-                   ['begin',
-                    '  something',
-                    'rescue Exception',
-                    '  #do nothing',
-                    'end'])
+    inspect_source(cop, <<-END.strip_indent)
+      begin
+        something
+      rescue Exception
+        #do nothing
+      end
+    END
     expect(cop.offenses.size).to eq(1)
   end
 
   it 'registers an offense for rescue with ::Exception' do
-    inspect_source(cop,
-                   ['begin',
-                    '  something',
-                    'rescue ::Exception',
-                    '  #do nothing',
-                    'end'])
+    inspect_source(cop, <<-END.strip_indent)
+      begin
+        something
+      rescue ::Exception
+        #do nothing
+      end
+    END
     expect(cop.offenses.size).to eq(1)
   end
 
   it 'registers an offense for rescue with StandardError, Exception' do
-    inspect_source(cop,
-                   ['begin',
-                    '  something',
-                    'rescue StandardError, Exception',
-                    '  #do nothing',
-                    'end'])
+    inspect_source(cop, <<-END.strip_indent)
+      begin
+        something
+      rescue StandardError, Exception
+        #do nothing
+      end
+    END
     expect(cop.offenses.size).to eq(1)
   end
 
   it 'registers an offense for rescue with Exception => e' do
-    inspect_source(cop,
-                   ['begin',
-                    '  something',
-                    'rescue Exception => e',
-                    '  #do nothing',
-                    'end'])
+    inspect_source(cop, <<-END.strip_indent)
+      begin
+        something
+      rescue Exception => e
+        #do nothing
+      end
+    END
     expect(cop.offenses.size).to eq(1)
   end
 
   it 'does not register an offense for rescue with no class' do
-    inspect_source(cop,
-                   ['begin',
-                    '  something',
-                    '  return',
-                    'rescue',
-                    '  file.close',
-                    'end'])
+    inspect_source(cop, <<-END.strip_indent)
+      begin
+        something
+        return
+      rescue
+        file.close
+      end
+    END
     expect(cop.offenses).to be_empty
   end
 
   it 'does not register an offense for rescue with no class and => e' do
-    inspect_source(cop,
-                   ['begin',
-                    '  something',
-                    '  return',
-                    'rescue => e',
-                    '  file.close',
-                    'end'])
+    inspect_source(cop, <<-END.strip_indent)
+      begin
+        something
+        return
+      rescue => e
+        file.close
+      end
+    END
     expect(cop.offenses).to be_empty
   end
 
   it 'does not register an offense for rescue with other class' do
-    inspect_source(cop,
-                   ['begin',
-                    '  something',
-                    '  return',
-                    'rescue ArgumentError => e',
-                    '  file.close',
-                    'end'])
+    inspect_source(cop, <<-END.strip_indent)
+      begin
+        something
+        return
+      rescue ArgumentError => e
+        file.close
+      end
+    END
     expect(cop.offenses).to be_empty
   end
 
   it 'does not register an offense for rescue with other classes' do
-    inspect_source(cop,
-                   ['begin',
-                    '  something',
-                    '  return',
-                    'rescue EOFError, ArgumentError => e',
-                    '  file.close',
-                    'end'])
+    inspect_source(cop, <<-END.strip_indent)
+      begin
+        something
+        return
+      rescue EOFError, ArgumentError => e
+        file.close
+      end
+    END
     expect(cop.offenses).to be_empty
   end
 
   it 'does not register an offense for rescue with a module prefix' do
-    inspect_source(cop,
-                   ['begin',
-                    '  something',
-                    '  return',
-                    'rescue Test::Exception => e',
-                    '  file.close',
-                    'end'])
+    inspect_source(cop, <<-END.strip_indent)
+      begin
+        something
+        return
+      rescue Test::Exception => e
+        file.close
+      end
+    END
     expect(cop.offenses).to be_empty
   end
 
   it 'does not crash when the splat operator is used in a rescue' do
-    inspect_source(cop,
-                   ['ERRORS = [Exception]',
-                    'begin',
-                    '  a = 3 / 0',
-                    'rescue *ERRORS',
-                    '  puts e',
-                    'end'])
+    inspect_source(cop, <<-END.strip_indent)
+      ERRORS = [Exception]
+      begin
+        a = 3 / 0
+      rescue *ERRORS
+        puts e
+      end
+    END
     expect(cop.offenses).to be_empty
   end
 
   it 'does not crash when the namespace of a rescued class is in a local ' \
      'variable' do
-    inspect_source(cop,
-                   ['adapter = current_adapter',
-                    'begin',
-                    'rescue adapter::ParseError',
-                    'end'])
+    inspect_source(cop, <<-END.strip_indent)
+      adapter = current_adapter
+      begin
+      rescue adapter::ParseError
+      end
+    END
     expect(cop.offenses).to be_empty
   end
 end

--- a/spec/rubocop/cop/lint/shadowed_exception_spec.rb
+++ b/spec/rubocop/cop/lint/shadowed_exception_spec.rb
@@ -13,142 +13,168 @@ describe RuboCop::Cop::Lint::ShadowedException do
 
   context 'single rescue' do
     it 'accepts an empty rescue' do
-      inspect_source(cop, ['begin',
-                           '  something',
-                           'rescue',
-                           '  handle_exception',
-                           'end'])
+      inspect_source(cop, <<-END.strip_indent)
+        begin
+          something
+        rescue
+          handle_exception
+        end
+      END
 
       expect(cop.offenses).to be_empty
     end
 
     it 'accepts rescuing a single exception' do
-      inspect_source(cop, ['begin',
-                           '  something',
-                           'rescue Exception',
-                           '  handle_exception',
-                           'end'])
+      inspect_source(cop, <<-END.strip_indent)
+        begin
+          something
+        rescue Exception
+          handle_exception
+        end
+      END
 
       expect(cop.offenses).to be_empty
     end
 
     it 'accepts rescuing a single custom exception' do
-      inspect_source(cop, ['begin',
-                           '  something',
-                           'rescue NonStandardException',
-                           '  handle_exception',
-                           'end'])
+      inspect_source(cop, <<-END.strip_indent)
+        begin
+          something
+        rescue NonStandardException
+          handle_exception
+        end
+      END
 
       expect(cop.offenses).to be_empty
     end
 
     it 'accepts rescuing a custom exception and a standard exception' do
-      inspect_source(cop, ['begin',
-                           '  something',
-                           'rescue Error, NonStandardException',
-                           '  handle_exception',
-                           'end'])
+      inspect_source(cop, <<-END.strip_indent)
+        begin
+          something
+        rescue Error, NonStandardException
+          handle_exception
+        end
+      END
 
       expect(cop.offenses).to be_empty
     end
 
     it 'accepts rescuing multiple custom exceptions' do
-      inspect_source(cop, ['begin',
-                           '  something',
-                           'rescue CustomError, NonStandardException',
-                           '  handle_exception',
-                           'end'])
+      inspect_source(cop, <<-END.strip_indent)
+        begin
+          something
+        rescue CustomError, NonStandardException
+          handle_exception
+        end
+      END
 
       expect(cop.offenses).to be_empty
     end
 
     it 'registers an offense rescuing exceptions that are ' \
       'ancestors of each other ' do
-      inspect_source(cop, ['def',
-                           '  something',
-                           'rescue StandardError, RuntimeError',
-                           '  handle_exception',
-                           'end'])
+      inspect_source(cop, <<-END.strip_indent)
+        def
+          something
+        rescue StandardError, RuntimeError
+          handle_exception
+        end
+      END
 
       expect(cop.messages).to eq(['Do not shadow rescued Exceptions.'])
     end
 
     it 'registers an offense rescuing Exception with any other error or ' \
        'exception' do
-      inspect_source(cop, ['begin',
-                           '  something',
-                           'rescue NonStandardError, Exception',
-                           '  handle_exception',
-                           'end'])
+      inspect_source(cop, <<-END.strip_indent)
+        begin
+          something
+        rescue NonStandardError, Exception
+          handle_exception
+        end
+      END
 
       expect(cop.messages).to eq(['Do not shadow rescued Exceptions.'])
     end
 
     it 'accepts rescuing a single exception that is assigned to a variable' do
-      inspect_source(cop, ['begin',
-                           '  something',
-                           'rescue Exception => e',
-                           '  handle_exception(e)',
-                           'end'])
+      inspect_source(cop, <<-END.strip_indent)
+        begin
+          something
+        rescue Exception => e
+          handle_exception(e)
+        end
+      END
 
       expect(cop.offenses).to be_empty
     end
 
     it 'accepts rescuing a single exception that has an ensure' do
-      inspect_source(cop, ['begin',
-                           '  something',
-                           'rescue Exception',
-                           '  handle_exception',
-                           'ensure',
-                           '  everything_is_ok',
-                           'end'])
+      inspect_source(cop, <<-END.strip_indent)
+        begin
+          something
+        rescue Exception
+          handle_exception
+        ensure
+          everything_is_ok
+        end
+      END
 
       expect(cop.offenses).to be_empty
     end
 
     it 'accepts rescuing a single exception that has an else' do
-      inspect_source(cop, ['begin',
-                           '  something',
-                           'rescue Exception',
-                           '  handle_exception',
-                           'else',
-                           '  handle_non_exception',
-                           'end'])
+      inspect_source(cop, <<-END.strip_indent)
+        begin
+          something
+        rescue Exception
+          handle_exception
+        else
+          handle_non_exception
+        end
+      END
 
       expect(cop.offenses).to be_empty
     end
 
     it 'accepts rescuing a multiple exceptions that are not ancestors that ' \
        'have an else' do
-      inspect_source(cop, ['begin',
-                           '  something',
-                           'rescue NoMethodError, ZeroDivisionError',
-                           '  handle_exception',
-                           'else',
-                           '  handle_non_exception',
-                           'end'])
+      inspect_source(cop, <<-END.strip_indent)
+        begin
+          something
+        rescue NoMethodError, ZeroDivisionError
+          handle_exception
+        else
+          handle_non_exception
+        end
+      END
 
       expect(cop.offenses).to be_empty
     end
 
     context 'when there are multiple levels of exceptions in the same rescue' do
       it 'registers an offense for two exceptions' do
-        inspect_source(cop, ['begin',
-                             '  something',
-                             'rescue StandardError, NameError',
-                             '  foo',
-                             'end'])
+        inspect_source(cop, <<-END.strip_indent)
+          begin
+            something
+          rescue StandardError, NameError
+            foo
+          end
+        END
 
         expect(cop.messages).to eq(['Do not shadow rescued Exceptions.'])
         expect(cop.highlights).to eq(['rescue StandardError, NameError'])
       end
 
       it 'registers an offense for more than two exceptions' do
-        inspect_source(cop, ['begin',
-                             '  something',
-                             'rescue StandardError, NameError, NoMethodError',
-                             '  foo',
-                             'end'])
+        inspect_source(cop, <<-END.strip_indent)
+          begin
+            something
+          rescue StandardError, NameError, NoMethodError
+            foo
+          end
+        END
 
         expect(cop.messages).to eq(['Do not shadow rescued Exceptions.'])
         expect(cop.highlights)
@@ -157,11 +183,13 @@ describe RuboCop::Cop::Lint::ShadowedException do
     end
 
     it 'registers an offense for the same exception multiple times' do
-      inspect_source(cop, ['begin',
-                           '  something',
-                           'rescue NameError, NameError',
-                           '  foo',
-                           'end'])
+      inspect_source(cop, <<-END.strip_indent)
+        begin
+          something
+        rescue NameError, NameError
+          foo
+        end
+      END
 
       expect(cop.messages).to eq(['Do not shadow rescued Exceptions.'])
       expect(cop.highlights)
@@ -169,42 +197,50 @@ describe RuboCop::Cop::Lint::ShadowedException do
     end
 
     it 'accepts splat arguments passed to rescue' do
-      inspect_source(cop, ['begin',
-                           '  a',
-                           'rescue *FOO',
-                           '  b',
-                           'end'])
+      inspect_source(cop, <<-END.strip_indent)
+        begin
+          a
+        rescue *FOO
+          b
+        end
+      END
 
       expect(cop.offenses).to be_empty
     end
 
     it 'accepts rescuing nil' do
-      inspect_source(cop, ['begin',
-                           '  a',
-                           'rescue nil',
-                           '  b',
-                           'end'])
+      inspect_source(cop, <<-END.strip_indent)
+        begin
+          a
+        rescue nil
+          b
+        end
+      END
 
       expect(cop.offenses).to be_empty
     end
 
     it 'accepts rescuing nil and another exception' do
-      inspect_source(cop, ['begin',
-                           '  a',
-                           'rescue nil, Exception',
-                           '  b',
-                           'end'])
+      inspect_source(cop, <<-END.strip_indent)
+        begin
+          a
+        rescue nil, Exception
+          b
+        end
+      END
 
       expect(cop.offenses).to be_empty
     end
 
     it 'registers an offense when rescuing nil multiple exceptions of ' \
        'different levels' do
-      inspect_source(cop, ['begin',
-                           '  a',
-                           'rescue nil, StandardError, Exception',
-                           '  b',
-                           'end'])
+      inspect_source(cop, <<-END.strip_indent)
+        begin
+          a
+        rescue nil, StandardError, Exception
+          b
+        end
+      END
 
       expect(cop.messages).to eq(['Do not shadow rescued Exceptions.'])
       expect(cop.highlights).to eq(['rescue nil, StandardError, Exception'])
@@ -214,13 +250,15 @@ describe RuboCop::Cop::Lint::ShadowedException do
   context 'multiple rescues' do
     it 'registers an offense when a higher level exception is rescued before' \
        ' a lower level exception' do
-      inspect_source(cop, ['begin',
-                           '  something',
-                           'rescue Exception',
-                           '  handle_exception',
-                           'rescue StandardError',
-                           '  handle_standard_error',
-                           'end'])
+      inspect_source(cop, <<-END.strip_indent)
+        begin
+          something
+        rescue Exception
+          handle_exception
+        rescue StandardError
+          handle_standard_error
+        end
+      END
 
       expect(cop.messages).to eq(['Do not shadow rescued Exceptions.'])
       expect(cop.highlights).to eq([['rescue Exception',
@@ -231,13 +269,15 @@ describe RuboCop::Cop::Lint::ShadowedException do
     it 'registers an offense when a higher level exception is rescued before ' \
        'a lower level exception when there are multiple exceptions ' \
        'rescued in a group' do
-      inspect_source(cop, ['begin',
-                           '  something',
-                           'rescue Exception',
-                           '  handle_exception',
-                           'rescue NoMethodError, ZeroDivisionError',
-                           '  handle_standard_error',
-                           'end'])
+      inspect_source(cop, <<-END.strip_indent)
+        begin
+          something
+        rescue Exception
+          handle_exception
+        rescue NoMethodError, ZeroDivisionError
+          handle_standard_error
+        end
+      END
 
       expect(cop.messages).to eq(['Do not shadow rescued Exceptions.'])
       expect(cop.highlights).to eq([['rescue Exception',
@@ -248,15 +288,17 @@ describe RuboCop::Cop::Lint::ShadowedException do
 
     it 'registers an offense rescuing out of order exceptions when there ' \
        'is an ensure' do
-      inspect_source(cop, ['begin',
-                           '  something',
-                           'rescue Exception',
-                           '  handle_exception',
-                           'rescue StandardError',
-                           '  handle_standard_error',
-                           'ensure',
-                           '  everything_is_ok',
-                           'end'])
+      inspect_source(cop, <<-END.strip_indent)
+        begin
+          something
+        rescue Exception
+          handle_exception
+        rescue StandardError
+          handle_standard_error
+        ensure
+          everything_is_ok
+        end
+      END
 
       expect(cop.messages).to eq(['Do not shadow rescued Exceptions.'])
       expect(cop.highlights).to eq([['rescue Exception',
@@ -265,112 +307,128 @@ describe RuboCop::Cop::Lint::ShadowedException do
     end
 
     it 'accepts rescuing exceptions in order of level' do
-      inspect_source(cop, ['begin',
-                           '  something',
-                           'rescue StandardError',
-                           '  handle_standard_error',
-                           'rescue Exception',
-                           '  handle_exception',
-                           'end'])
+      inspect_source(cop, <<-END.strip_indent)
+        begin
+          something
+        rescue StandardError
+          handle_standard_error
+        rescue Exception
+          handle_exception
+        end
+      END
 
       expect(cop.offenses).to be_empty
     end
 
     it 'accepts many (>= 7) rescue groups' do
-      inspect_source(cop, ['begin',
-                           '  something',
-                           'rescue StandardError',
-                           '  handle_error',
-                           'rescue ErrorA',
-                           '  handle_error',
-                           'rescue ErrorB',
-                           '  handle_error',
-                           'rescue ErrorC',
-                           '  handle_error',
-                           'rescue ErrorD',
-                           '  handle_error',
-                           'rescue ErrorE',
-                           '  handle_error',
-                           'rescue ErrorF',
-                           '  handle_error',
-                           'end'])
+      inspect_source(cop, <<-END.strip_indent)
+        begin
+          something
+        rescue StandardError
+          handle_error
+        rescue ErrorA
+          handle_error
+        rescue ErrorB
+          handle_error
+        rescue ErrorC
+          handle_error
+        rescue ErrorD
+          handle_error
+        rescue ErrorE
+          handle_error
+        rescue ErrorF
+          handle_error
+        end
+      END
 
       expect(cop.offenses).to be_empty
     end
 
     it 'accepts rescuing exceptions in order of level with multiple ' \
        'exceptions in a group' do
-      inspect_source(cop, ['begin',
-                           '  something',
-                           'rescue NoMethodError, ZeroDivisionError',
-                           '  handle_standard_error',
-                           'rescue Exception',
-                           '  handle_exception',
-                           'end'])
+      inspect_source(cop, <<-END.strip_indent)
+        begin
+          something
+        rescue NoMethodError, ZeroDivisionError
+          handle_standard_error
+        rescue Exception
+          handle_exception
+        end
+      END
 
       expect(cop.offenses).to be_empty
     end
 
     it 'accepts rescuing exceptions in order of level with multiple ' \
        'exceptions in a group with custom exceptions' do
-      inspect_source(cop, ['begin',
-                           '  something',
-                           'rescue NonStandardError, NoMethodError',
-                           '  handle_standard_error',
-                           'rescue Exception',
-                           '  handle_exception',
-                           'end'])
+      inspect_source(cop, <<-END.strip_indent)
+        begin
+          something
+        rescue NonStandardError, NoMethodError
+          handle_standard_error
+        rescue Exception
+          handle_exception
+        end
+      END
 
       expect(cop.offenses).to be_empty
     end
 
     it 'accepts rescuing custom exceptions in multiple rescue groups' do
-      inspect_source(cop, ['begin',
-                           '  something',
-                           'rescue NonStandardError, OtherError',
-                           '  handle_standard_error',
-                           'rescue CustomError',
-                           '  handle_exception',
-                           'end'])
+      inspect_source(cop, <<-END.strip_indent)
+        begin
+          something
+        rescue NonStandardError, OtherError
+          handle_standard_error
+        rescue CustomError
+          handle_exception
+        end
+      END
 
       expect(cop.offenses).to be_empty
     end
 
     context 'splat arguments' do
       it 'accepts splat arguments passed to multiple rescues' do
-        inspect_source(cop, ['begin',
-                             '  a',
-                             'rescue *FOO',
-                             '  b',
-                             'rescue *BAR',
-                             '  c',
-                             'end'])
+        inspect_source(cop, <<-END.strip_indent)
+          begin
+            a
+          rescue *FOO
+            b
+          rescue *BAR
+            c
+          end
+        END
 
         expect(cop.offenses).to be_empty
       end
 
       it 'registers an offense for splat arguments rescued after ' \
          'rescuing a known exception' do
-        inspect_source(cop, ['begin',
-                             '  a',
-                             'rescue StandardError',
-                             '  b',
-                             'rescue *BAR',
-                             '  c',
-                             'end'])
+        inspect_source(cop, <<-END.strip_indent)
+          begin
+            a
+          rescue StandardError
+            b
+          rescue *BAR
+            c
+          end
+        END
 
         expect(cop.offenses).to be_empty
       end
 
       it 'registers an offense for splat arguments rescued after ' \
          'rescuing Exception' do
-        inspect_source(cop, ['begin',
-                             '  a',
-                             'rescue Exception',
-                             '  b',
-                             'rescue *BAR',
-                             '  c',
-                             'end'])
+        inspect_source(cop, <<-END.strip_indent)
+          begin
+            a
+          rescue Exception
+            b
+          rescue *BAR
+            c
+          end
+        END
 
         expect(cop.messages).to eq(['Do not shadow rescued Exceptions.'])
         expect(cop.highlights).to eq([['rescue Exception',
@@ -381,100 +439,116 @@ describe RuboCop::Cop::Lint::ShadowedException do
 
     context 'exceptions from different ancestry chains' do
       it 'accepts rescuing exceptions in one order' do
-        inspect_source(cop, ['begin',
-                             '  a',
-                             'rescue ArgumentError',
-                             '  b',
-                             'rescue Interrupt',
-                             '  c',
-                             'end'])
+        inspect_source(cop, <<-END.strip_indent)
+          begin
+            a
+          rescue ArgumentError
+            b
+          rescue Interrupt
+            c
+          end
+        END
 
         expect(cop.offenses).to be_empty
       end
 
       it 'accepts rescuing exceptions in another order' do
-        inspect_source(cop, ['begin',
-                             '  a',
-                             'rescue Interrupt',
-                             '  b',
-                             'rescue ArgumentError',
-                             '  c',
-                             'end'])
+        inspect_source(cop, <<-END.strip_indent)
+          begin
+            a
+          rescue Interrupt
+            b
+          rescue ArgumentError
+            c
+          end
+        END
 
         expect(cop.offenses).to be_empty
       end
     end
 
     it 'accepts rescuing nil before another exception' do
-      inspect_source(cop, ['begin',
-                           '  a',
-                           'rescue nil',
-                           '  b',
-                           'rescue',
-                           '  c',
-                           'end'])
+      inspect_source(cop, <<-END.strip_indent)
+        begin
+          a
+        rescue nil
+          b
+        rescue
+          c
+        end
+      END
 
       expect(cop.offenses).to be_empty
     end
 
     it 'accepts rescuing nil after another exception' do
-      inspect_source(cop, ['begin',
-                           '  a',
-                           'rescue',
-                           '  b',
-                           'rescue nil',
-                           '  c',
-                           'end'])
+      inspect_source(cop, <<-END.strip_indent)
+        begin
+          a
+        rescue
+          b
+        rescue nil
+          c
+        end
+      END
 
       expect(cop.offenses).to be_empty
     end
 
     it 'accepts rescuing a known exception after an unknown exceptions' do
-      inspect_source(cop, ['begin',
-                           '  a',
-                           'rescue UnknownException',
-                           '  b',
-                           'rescue StandardError',
-                           '  c',
-                           'end'])
+      inspect_source(cop, <<-END.strip_indent)
+        begin
+          a
+        rescue UnknownException
+          b
+        rescue StandardError
+          c
+        end
+      END
 
       expect(cop.offenses).to be_empty
     end
 
     it 'accepts rescuing a known exception before an unknown exceptions' do
-      inspect_source(cop, ['begin',
-                           '  a',
-                           'rescue StandardError',
-                           '  b',
-                           'rescue UnknownException',
-                           '  c',
-                           'end'])
+      inspect_source(cop, <<-END.strip_indent)
+        begin
+          a
+        rescue StandardError
+          b
+        rescue UnknownException
+          c
+        end
+      END
 
       expect(cop.offenses).to be_empty
     end
 
     it 'accepts rescuing a known exception between unknown exceptions' do
-      inspect_source(cop, ['begin',
-                           '  a',
-                           'rescue UnknownException',
-                           '  b',
-                           'rescue StandardError',
-                           '  c',
-                           'rescue AnotherUnknownException',
-                           '  d',
-                           'end'])
+      inspect_source(cop, <<-END.strip_indent)
+        begin
+          a
+        rescue UnknownException
+          b
+        rescue StandardError
+          c
+        rescue AnotherUnknownException
+          d
+        end
+      END
 
       expect(cop.offenses).to be_empty
     end
 
     it 'registers an offense rescuing Exception before an unknown exceptions' do
-      inspect_source(cop, ['begin',
-                           '  a',
-                           'rescue Exception',
-                           '  b',
-                           'rescue UnknownException',
-                           '  c',
-                           'end'])
+      inspect_source(cop, <<-END.strip_indent)
+        begin
+          a
+        rescue Exception
+          b
+        rescue UnknownException
+          c
+        end
+      END
 
       expect(cop.messages).to eq(['Do not shadow rescued Exceptions.'])
       expect(cop.highlights).to eq([['rescue Exception',
@@ -483,27 +557,31 @@ describe RuboCop::Cop::Lint::ShadowedException do
     end
 
     it 'ignores expressions of non-const' do
-      inspect_source(cop, ['begin',
-                           '  a',
-                           'rescue foo',
-                           '  b',
-                           'rescue [bar]',
-                           '  c',
-                           'end'])
+      inspect_source(cop, <<-END.strip_indent)
+        begin
+          a
+        rescue foo
+          b
+        rescue [bar]
+          c
+        end
+      END
 
       expect(cop.offenses).to be_empty
     end
 
     context 'last rescue does not specify exception class' do
       let(:source) do
-        ['begin',
-         'rescue A, B',
-         '  do_something',
-         'rescue C',
-         '  do_something',
-         'rescue',
-         '  do_something',
-         'end']
+        <<-END.strip_indent
+          begin
+          rescue A, B
+            do_something
+          rescue C
+            do_something
+          rescue
+            do_something
+          end
+        END
       end
 
       it 'does not raise error' do

--- a/spec/rubocop/cop/lint/shadowing_outer_local_variable_spec.rb
+++ b/spec/rubocop/cop/lint/shadowing_outer_local_variable_spec.rb
@@ -6,14 +6,14 @@ describe RuboCop::Cop::Lint::ShadowingOuterLocalVariable do
   context 'when a block argument has same name ' \
           'as an outer scope variable' do
     let(:source) do
-      [
-        'def some_method',
-        '  foo = 1',
-        '  puts foo',
-        '  1.times do |foo|',
-        '  end',
-        'end'
-      ]
+      <<-END.strip_indent
+        def some_method
+          foo = 1
+          puts foo
+          1.times do |foo|
+          end
+        end
+      END
     end
 
     it 'registers an offense' do
@@ -30,14 +30,14 @@ describe RuboCop::Cop::Lint::ShadowingOuterLocalVariable do
   context 'when a splat block argument has same name ' \
           'as an outer scope variable' do
     let(:source) do
-      [
-        'def some_method',
-        '  foo = 1',
-        '  puts foo',
-        '  1.times do |*foo|',
-        '  end',
-        'end'
-      ]
+      <<-END.strip_indent
+        def some_method
+          foo = 1
+          puts foo
+          1.times do |*foo|
+          end
+        end
+      END
     end
 
     it 'registers an offense' do
@@ -54,16 +54,16 @@ describe RuboCop::Cop::Lint::ShadowingOuterLocalVariable do
   context 'when a block block argument has same name ' \
           'as an outer scope variable' do
     let(:source) do
-      [
-        'def some_method',
-        '  foo = 1',
-        '  puts foo',
-        '  proc_taking_block = proc do |&foo|',
-        '  end',
-        '  proc_taking_block.call do',
-        '  end',
-        'end'
-      ]
+      <<-END.strip_indent
+        def some_method
+          foo = 1
+          puts foo
+          proc_taking_block = proc do |&foo|
+          end
+          proc_taking_block.call do
+          end
+        end
+      END
     end
 
     it 'registers an offense' do
@@ -80,15 +80,15 @@ describe RuboCop::Cop::Lint::ShadowingOuterLocalVariable do
   context 'when a block local variable has same name ' \
           'as an outer scope variable' do
     let(:source) do
-      [
-        'def some_method',
-        '  foo = 1',
-        '  puts foo',
-        '  1.times do |i; foo|',
-        '    puts foo',
-        '  end',
-        'end'
-      ]
+      <<-END.strip_indent
+        def some_method
+          foo = 1
+          puts foo
+          1.times do |i; foo|
+            puts foo
+          end
+        end
+      END
     end
 
     it 'registers an offense' do
@@ -105,14 +105,14 @@ describe RuboCop::Cop::Lint::ShadowingOuterLocalVariable do
   context 'when a block argument has different name ' \
           'with outer scope variables' do
     let(:source) do
-      [
-        'def some_method',
-        '  foo = 1',
-        '  puts foo',
-        '  1.times do |bar|',
-        '  end',
-        'end'
-      ]
+      <<-END.strip_indent
+        def some_method
+          foo = 1
+          puts foo
+          1.times do |bar|
+          end
+        end
+      END
     end
 
     include_examples 'accepts'
@@ -121,15 +121,15 @@ describe RuboCop::Cop::Lint::ShadowingOuterLocalVariable do
 
   context 'when an outer scope variable is reassigned in a block' do
     let(:source) do
-      [
-        'def some_method',
-        '  foo = 1',
-        '  puts foo',
-        '  1.times do',
-        '    foo = 2',
-        '  end',
-        'end'
-      ]
+      <<-END.strip_indent
+        def some_method
+          foo = 1
+          puts foo
+          1.times do
+            foo = 2
+          end
+        end
+      END
     end
 
     include_examples 'accepts'
@@ -138,15 +138,15 @@ describe RuboCop::Cop::Lint::ShadowingOuterLocalVariable do
 
   context 'when an outer scope variable is referenced in a block' do
     let(:source) do
-      [
-        'def some_method',
-        '  foo = 1',
-        '  puts foo',
-        '  1.times do',
-        '    puts foo',
-        '  end',
-        'end'
-      ]
+      <<-END.strip_indent
+        def some_method
+          foo = 1
+          puts foo
+          1.times do
+            puts foo
+          end
+        end
+      END
     end
 
     include_examples 'accepts'
@@ -155,12 +155,12 @@ describe RuboCop::Cop::Lint::ShadowingOuterLocalVariable do
 
   context 'when multiple block arguments have same name "_"' do
     let(:source) do
-      [
-        'def some_method',
-        '  1.times do |_, foo, _|',
-        '  end',
-        'end'
-      ]
+      <<-END.strip_indent
+        def some_method
+          1.times do |_, foo, _|
+          end
+        end
+      END
     end
 
     include_examples 'accepts'
@@ -170,12 +170,12 @@ describe RuboCop::Cop::Lint::ShadowingOuterLocalVariable do
   context 'when multiple block arguments have ' \
           'a same name starts with "_"' do
     let(:source) do
-      [
-        'def some_method',
-        '  1.times do |_foo, bar, _foo|',
-        '  end',
-        'end'
-      ]
+      <<-END.strip_indent
+        def some_method
+          1.times do |_foo, bar, _foo|
+          end
+        end
+      END
     end
 
     include_examples 'accepts' unless RUBY_VERSION < '2.0'
@@ -185,14 +185,14 @@ describe RuboCop::Cop::Lint::ShadowingOuterLocalVariable do
   context 'when a block argument has same name "_" ' \
           'as outer scope variable "_"' do
     let(:source) do
-      [
-        'def some_method',
-        '  _ = 1',
-        '  puts _',
-        '  1.times do |_|',
-        '  end',
-        'end'
-      ]
+      <<-END.strip_indent
+        def some_method
+          _ = 1
+          puts _
+          1.times do |_|
+          end
+        end
+      END
     end
 
     include_examples 'accepts'
@@ -202,14 +202,14 @@ describe RuboCop::Cop::Lint::ShadowingOuterLocalVariable do
   context 'when a block argument has a same name starts with "_" ' \
           'as an outer scope variable' do
     let(:source) do
-      [
-        'def some_method',
-        '  _foo = 1',
-        '  puts _foo',
-        '  1.times do |_foo|',
-        '  end',
-        'end'
-      ]
+      <<-END.strip_indent
+        def some_method
+          _foo = 1
+          puts _foo
+          1.times do |_foo|
+          end
+        end
+      END
     end
 
     include_examples 'accepts'
@@ -219,14 +219,14 @@ describe RuboCop::Cop::Lint::ShadowingOuterLocalVariable do
   context 'when a method argument has same name ' \
           'as an outer scope variable' do
     let(:source) do
-      [
-        'class SomeClass',
-        '  foo = 1',
-        '  puts foo',
-        '  def some_method(foo)',
-        '  end',
-        'end'
-      ]
+      <<-END.strip_indent
+        class SomeClass
+          foo = 1
+          puts foo
+          def some_method(foo)
+          end
+        end
+      END
     end
 
     include_examples 'accepts'

--- a/spec/rubocop/cop/lint/unreachable_code_spec.rb
+++ b/spec/rubocop/cop/lint/unreachable_code_spec.rb
@@ -13,42 +13,47 @@ describe RuboCop::Cop::Lint::UnreachableCode do
     end
 
     it "accepts code with conditional #{t}" do
-      inspect_source(cop,
-                     ['foo = 5',
-                      "#{t} if test",
-                      'bar'])
+      inspect_source(cop, <<-END.strip_indent)
+        foo = 5
+        #{t} if test
+        bar
+      END
       expect(cop.offenses).to be_empty
     end
 
     it "accepts #{t} as the final expression" do
-      inspect_source(cop,
-                     ['foo = 5',
-                      "#{t} if test"])
+      inspect_source(cop, <<-END.strip_indent)
+        foo = 5
+        #{t} if test
+      END
       expect(cop.offenses).to be_empty
     end
   end
 
   described_class::FLOW_COMMANDS.each do |t|
     it "registers an offense for #{t} before other statements" do
-      inspect_source(cop,
-                     ['foo = 5',
-                      "#{t} something",
-                      'bar'])
+      inspect_source(cop, <<-END.strip_indent)
+        foo = 5
+        #{t} something
+        bar
+      END
       expect(cop.offenses.size).to eq(1)
     end
 
     it "accepts code with conditional #{t}" do
-      inspect_source(cop,
-                     ['foo = 5',
-                      "#{t} something if test",
-                      'bar'])
+      inspect_source(cop, <<-END.strip_indent)
+        foo = 5
+        #{t} something if test
+        bar
+      END
       expect(cop.offenses).to be_empty
     end
 
     it "accepts #{t} as the final expression" do
-      inspect_source(cop,
-                     ['foo = 5',
-                      "#{t} something if test"])
+      inspect_source(cop, <<-END.strip_indent)
+        foo = 5
+        #{t} something if test
+      END
       expect(cop.offenses).to be_empty
     end
   end

--- a/spec/rubocop/cop/lint/unused_method_argument_spec.rb
+++ b/spec/rubocop/cop/lint/unused_method_argument_spec.rb
@@ -352,30 +352,38 @@ describe RuboCop::Cop::Lint::UnusedMethodArgument, :config do
     let(:cop_config) { { 'IgnoreEmptyMethods' => true } }
 
     it 'accepts an empty method with a single unused parameter' do
-      inspect_source(cop, ['def method(arg)',
-                           'end'])
+      inspect_source(cop, <<-END.strip_indent)
+        def method(arg)
+        end
+      END
       expect(cop.offenses).to be_empty
     end
 
     it 'registers an offense for a non-empty method with a single unused ' \
         'parameter' do
-      inspect_source(cop, ['def method(arg)',
-                           '  1',
-                           'end'])
+      inspect_source(cop, <<-END.strip_indent)
+        def method(arg)
+          1
+        end
+      END
       expect(cop.offenses.size).to eq 1
     end
 
     it 'accepts an empty method with multiple unused parameters' do
-      inspect_source(cop, ['def method(a, b, *others)',
-                           'end'])
+      inspect_source(cop, <<-END.strip_indent)
+        def method(a, b, *others)
+        end
+      END
       expect(cop.offenses).to be_empty
     end
 
     it 'registers an offense for a non-empty method with multiple unused ' \
        'parameters' do
-      inspect_source(cop, ['def method(a, b, *others)',
-                           '  1',
-                           'end'])
+      inspect_source(cop, <<-END.strip_indent)
+        def method(a, b, *others)
+          1
+        end
+      END
       expect(cop.offenses.size).to eq 3
     end
   end

--- a/spec/rubocop/cop/lint/useless_access_modifier_spec.rb
+++ b/spec/rubocop/cop/lint/useless_access_modifier_spec.rb
@@ -6,17 +6,17 @@ describe RuboCop::Cop::Lint::UselessAccessModifier do
 
   context 'when an access modifier has no effect' do
     let(:source) do
-      [
-        'class SomeClass',
-        '  def some_method',
-        '    puts 10',
-        '  end',
-        '  private',
-        '  def self.some_method',
-        '    puts 10',
-        '  end',
-        'end'
-      ]
+      <<-END.strip_indent
+        class SomeClass
+          def some_method
+            puts 10
+          end
+          private
+          def self.some_method
+            puts 10
+          end
+        end
+      END
     end
 
     it 'registers an offense' do
@@ -31,14 +31,14 @@ describe RuboCop::Cop::Lint::UselessAccessModifier do
 
   context 'when an access modifier has no methods' do
     let(:source) do
-      [
-        'class SomeClass',
-        '  def some_method',
-        '    puts 10',
-        '  end',
-        '  protected',
-        'end'
-      ]
+      <<-END.strip_indent
+        class SomeClass
+          def some_method
+            puts 10
+          end
+          protected
+        end
+      END
     end
 
     it 'registers an offense' do
@@ -53,18 +53,18 @@ describe RuboCop::Cop::Lint::UselessAccessModifier do
 
   context 'when an access modifier is followed by attr_*' do
     let(:source) do
-      [
-        'class SomeClass',
-        '  protected',
-        '  attr_accessor :some_property',
-        '  public',
-        '  attr_reader :another_one',
-        '  private',
-        '  attr :yet_again, true',
-        '  protected',
-        '  attr_writer :just_for_good_measure',
-        'end'
-      ]
+      <<-END.strip_indent
+        class SomeClass
+          protected
+          attr_accessor :some_property
+          public
+          attr_reader :another_one
+          private
+          attr :yet_again, true
+          protected
+          attr_writer :just_for_good_measure
+        end
+      END
     end
 
     it 'does not register an offense' do
@@ -76,13 +76,13 @@ describe RuboCop::Cop::Lint::UselessAccessModifier do
   context 'when an access modifier is followed by a ' \
     'class method defined on constant' do
     let(:source) do
-      [
-        'class SomeClass',
-        '  protected',
-        '  def SomeClass.some_method',
-        '  end',
-        'end'
-      ]
+      <<-END.strip_indent
+        class SomeClass
+          protected
+          def SomeClass.some_method
+          end
+        end
+      END
     end
 
     it 'registers an offense' do
@@ -97,18 +97,18 @@ describe RuboCop::Cop::Lint::UselessAccessModifier do
 
   context 'when there are consecutive access modifiers' do
     let(:source) do
-      [
-        'class SomeClass',
-        ' private',
-        ' private',
-        '  def some_method',
-        '    puts 10',
-        '  end',
-        '  def some_other_method',
-        '    puts 10',
-        '  end',
-        'end'
-      ]
+      <<-END.strip_indent
+        class SomeClass
+         private
+         private
+          def some_method
+            puts 10
+          end
+          def some_other_method
+            puts 10
+          end
+        end
+      END
     end
 
     it 'registers an offense' do
@@ -123,14 +123,14 @@ describe RuboCop::Cop::Lint::UselessAccessModifier do
 
   context 'when passing method as symbol' do
     let(:source) do
-      [
-        'class SomeClass',
-        '  def some_method',
-        '    puts 10',
-        '  end',
-        '  private :some_method',
-        'end'
-      ]
+      <<-END.strip_indent
+        class SomeClass
+          def some_method
+            puts 10
+          end
+          private :some_method
+        end
+      END
     end
 
     it 'does not register an offense' do
@@ -141,11 +141,11 @@ describe RuboCop::Cop::Lint::UselessAccessModifier do
 
   context 'when class is empty save modifier' do
     let(:source) do
-      [
-        'class SomeClass',
-        '  private',
-        'end'
-      ]
+      <<-END.strip_indent
+        class SomeClass
+          private
+        end
+      END
     end
 
     it 'registers an offense' do
@@ -160,13 +160,13 @@ describe RuboCop::Cop::Lint::UselessAccessModifier do
 
   context 'when multiple class definitions in file but only one has offense' do
     let(:source) do
-      [
-        'class SomeClass',
-        '  private',
-        'end',
-        'class SomeOtherClass',
-        'end'
-      ]
+      <<-END.strip_indent
+        class SomeClass
+          private
+        end
+        class SomeOtherClass
+        end
+      END
     end
 
     it 'registers an offense' do
@@ -182,13 +182,13 @@ describe RuboCop::Cop::Lint::UselessAccessModifier do
   if RUBY_ENGINE == 'ruby' && RUBY_VERSION.start_with?('2.1')
     context 'ruby 2.1 style modifiers' do
       let(:source) do
-        [
-          'class SomeClass',
-          '  private def some_method',
-          '    puts 10',
-          '  end',
-          'end'
-        ]
+        <<-END.strip_indent
+          class SomeClass
+            private def some_method
+              puts 10
+            end
+          end
+        END
       end
 
       it 'does not register an offense' do
@@ -202,12 +202,12 @@ describe RuboCop::Cop::Lint::UselessAccessModifier do
     'modifier' do
     %w[CONSTANT some_var].each do |binding_name|
       let(:source) do
-        [
-          'class SomeClass',
-          '  private',
-          "  #{binding_name} = 1",
-          'end'
-        ]
+        <<-END.strip_indent
+          class SomeClass
+            private
+            #{binding_name} = 1
+          end
+        END
       end
 
       it 'registers an offense' do
@@ -219,14 +219,14 @@ describe RuboCop::Cop::Lint::UselessAccessModifier do
 
   context 'when a def is an argument to a method call' do
     let(:source) do
-      [
-        'class SomeClass',
-        '  private',
-        '  helper_method def some_method',
-        '    puts 10',
-        '  end',
-        'end'
-      ]
+      <<-END.strip_indent
+        class SomeClass
+          private
+          helper_method def some_method
+            puts 10
+          end
+        end
+      END
     end
 
     it 'does not register an offense' do
@@ -244,50 +244,54 @@ describe RuboCop::Cop::Lint::UselessAccessModifier do
       )
     end
     it 'is aware that this creates a new scope' do
-      src = ['class SomeClass',
-             '  concerning :FirstThing do',
-             '    def foo',
-             '    end',
-             '    private',
-             '',
-             '    def method',
-             '    end',
-             '  end',
-             '',
-             '  concerning :SecondThing do',
-             '    def omg',
-             '    end',
-             '    private',
-             '    def method',
-             '    end',
-             '  end',
-             ' end']
+      src = <<-END.strip_indent
+        class SomeClass
+          concerning :FirstThing do
+            def foo
+            end
+            private
+
+            def method
+            end
+          end
+
+          concerning :SecondThing do
+            def omg
+            end
+            private
+            def method
+            end
+          end
+         end
+      END
       inspect_source(cop, src)
       expect(cop.offenses).to be_empty
     end
 
     it 'still points out redundant uses within the block' do
-      src = ['class SomeClass',
-             '  concerning :FirstThing do',
-             '    def foo',
-             '    end',
-             '    private',
-             '',
-             '    def method',
-             '    end',
-             '  end',
-             '',
-             '  concerning :SecondThing do',
-             '    def omg',
-             '    end',
-             '    private',
-             '    def method',
-             '    end',
-             '    private',
-             '    def another_method',
-             '    end',
-             '  end',
-             ' end']
+      src = <<-END.strip_indent
+        class SomeClass
+          concerning :FirstThing do
+            def foo
+            end
+            private
+
+            def method
+            end
+          end
+
+          concerning :SecondThing do
+            def omg
+            end
+            private
+            def method
+            end
+            private
+            def another_method
+            end
+          end
+         end
+      END
       inspect_source(cop, src)
       expect(cop.offenses.size).to eq(1)
       expect(cop.offenses.first.line).to eq(17)
@@ -296,21 +300,23 @@ describe RuboCop::Cop::Lint::UselessAccessModifier do
 
   context 'when using ActiveSupport behavior when Rails is not eabled' do
     it 'reports offenses' do
-      src = ['module SomeModule',
-             '  extend ActiveSupport::Concern',
-             '  class_methods do',
-             '    def some_public_class_method',
-             '    end',
-             '    private',
-             '    def some_private_class_method',
-             '    end',
-             '  end',
-             '  def some_public_instance_method',
-             '  end',
-             '  private',
-             '  def some_private_instance_method',
-             '  end',
-             'end']
+      src = <<-END.strip_indent
+        module SomeModule
+          extend ActiveSupport::Concern
+          class_methods do
+            def some_public_class_method
+            end
+            private
+            def some_private_class_method
+            end
+          end
+          def some_public_instance_method
+          end
+          private
+          def some_private_instance_method
+          end
+        end
+      END
       inspect_source(cop, src)
       expect(cop.offenses.size).to eq(1)
     end
@@ -325,21 +331,23 @@ describe RuboCop::Cop::Lint::UselessAccessModifier do
       )
     end
     it 'is aware that this creates a new scope' do
-      src = ['module SomeModule',
-             '  extend ActiveSupport::Concern',
-             '  class_methods do',
-             '    def some_public_class_method',
-             '    end',
-             '    private',
-             '    def some_private_class_method',
-             '    end',
-             '  end',
-             '  def some_public_instance_method',
-             '  end',
-             '  private',
-             '  def some_private_instance_method',
-             '  end',
-             'end']
+      src = <<-END.strip_indent
+        module SomeModule
+          extend ActiveSupport::Concern
+          class_methods do
+            def some_public_class_method
+            end
+            private
+            def some_private_class_method
+            end
+          end
+          def some_public_instance_method
+          end
+          private
+          def some_private_instance_method
+          end
+        end
+      END
       inspect_source(cop, src)
       expect(cop.offenses).to be_empty
     end
@@ -354,21 +362,25 @@ describe RuboCop::Cop::Lint::UselessAccessModifier do
       )
     end
     it 'is aware that this creates a new method' do
-      src = ['class SomeClass',
-             '  private',
-             '  ',
-             '  delegate :foo, to: :bar',
-             'end']
+      src = <<-END.strip_indent
+        class SomeClass
+          private
+
+          delegate :foo, to: :bar
+        end
+      END
       inspect_source(cop, src)
       expect(cop.offenses).to be_empty
     end
 
     it 'still points out redundant uses within the module' do
-      src = ['class SomeClass',
-             '  delegate :foo, to: :bar',
-             '  ',
-             '  private',
-             'end']
+      src = <<-END.strip_indent
+        class SomeClass
+          delegate :foo, to: :bar
+
+          private
+        end
+      END
       inspect_source(cop, src)
       expect(cop.offenses.size).to eq(1)
       expect(cop.offenses.first.line).to eq(4)
@@ -377,31 +389,37 @@ describe RuboCop::Cop::Lint::UselessAccessModifier do
 
   shared_examples 'at the top of the body' do |keyword|
     it 'registers an offense for `public`' do
-      src = ["#{keyword} A",
-             '  public',
-             '  def method',
-             '  end',
-             'end']
+      src = <<-END.strip_indent
+        #{keyword} A
+          public
+          def method
+          end
+        end
+      END
       inspect_source(cop, src)
       expect(cop.offenses.size).to eq(1)
     end
 
     it "doesn't register an offense for `protected`" do
-      src = ["#{keyword} A",
-             '  protected',
-             '  def method',
-             '  end',
-             'end']
+      src = <<-END.strip_indent
+        #{keyword} A
+          protected
+          def method
+          end
+        end
+      END
       inspect_source(cop, src)
       expect(cop.offenses).to be_empty
     end
 
     it "doesn't register an offense for `private`" do
-      src = ["#{keyword} A",
-             '  private',
-             '  def method',
-             '  end',
-             'end']
+      src = <<-END.strip_indent
+        #{keyword} A
+          private
+          def method
+          end
+        end
+      END
       inspect_source(cop, src)
       expect(cop.offenses).to be_empty
     end
@@ -409,15 +427,17 @@ describe RuboCop::Cop::Lint::UselessAccessModifier do
 
   shared_examples 'repeated visibility modifiers' do |keyword, modifier|
     it "registers an offense when `#{modifier}` is repeated" do
-      src = ["#{keyword} A",
-             "  #{modifier == 'private' ? 'protected' : 'private'}",
-             '  def method1',
-             '  end',
-             "  #{modifier}",
-             "  #{modifier}",
-             '  def method2',
-             '  end',
-             'end']
+      src = <<-END.strip_indent
+        #{keyword} A
+          #{modifier == 'private' ? 'protected' : 'private'}
+          def method1
+          end
+          #{modifier}
+          #{modifier}
+          def method2
+          end
+        end
+      END
       inspect_source(cop, src)
       expect(cop.offenses.size).to eq(1)
     end
@@ -425,37 +445,43 @@ describe RuboCop::Cop::Lint::UselessAccessModifier do
 
   shared_examples 'non-repeated visibility modifiers' do |keyword|
     it 'registers an offense even when `public` is not repeated' do
-      src = ["#{keyword} A",
-             '  def method1',
-             '  end',
-             '  public',
-             '  def method2',
-             '  end',
-             'end']
+      src = <<-END.strip_indent
+        #{keyword} A
+          def method1
+          end
+          public
+          def method2
+          end
+        end
+      END
       inspect_source(cop, src)
       expect(cop.offenses.size).to eq(1)
     end
 
     it "doesn't register an offense when `protected` is not repeated" do
-      src = ["#{keyword} A",
-             '  def method1',
-             '  end',
-             '  protected',
-             '  def method2',
-             '  end',
-             'end']
+      src = <<-END.strip_indent
+        #{keyword} A
+          def method1
+          end
+          protected
+          def method2
+          end
+        end
+      END
       inspect_source(cop, src)
       expect(cop.offenses).to be_empty
     end
 
     it "doesn't register an offense when `private` is not repeated" do
-      src = ["#{keyword} A",
-             '  def method1',
-             '  end',
-             '  private',
-             '  def method2',
-             '  end',
-             'end']
+      src = <<-END.strip_indent
+        #{keyword} A
+          def method1
+          end
+          private
+          def method2
+          end
+        end
+      END
       inspect_source(cop, src)
       expect(cop.offenses).to be_empty
     end
@@ -463,13 +489,15 @@ describe RuboCop::Cop::Lint::UselessAccessModifier do
 
   shared_examples 'at the end of the body' do |keyword, modifier|
     it "registers an offense for trailing `#{modifier}`" do
-      src = ["#{keyword} A",
-             '  def method1',
-             '  end',
-             '  def method2',
-             '  end',
-             "  #{modifier}",
-             'end']
+      src = <<-END.strip_indent
+        #{keyword} A
+          def method1
+          end
+          def method2
+          end
+          #{modifier}
+        end
+      END
       inspect_source(cop, src)
       expect(cop.offenses.size).to eq(1)
     end
@@ -477,32 +505,36 @@ describe RuboCop::Cop::Lint::UselessAccessModifier do
 
   shared_examples 'nested in a begin..end block' do |keyword, modifier|
     it "still flags repeated `#{modifier}`" do
-      src = ["#{keyword} A",
-             "  #{modifier == 'private' ? 'protected' : 'private'}",
-             '  def blah',
-             '  end',
-             '  begin',
-             '    def method1',
-             '    end',
-             "    #{modifier}",
-             "    #{modifier}",
-             '    def method2',
-             '    end',
-             '  end',
-             'end']
+      src = <<-END.strip_indent
+        #{keyword} A
+          #{modifier == 'private' ? 'protected' : 'private'}
+          def blah
+          end
+          begin
+            def method1
+            end
+            #{modifier}
+            #{modifier}
+            def method2
+            end
+          end
+        end
+      END
       inspect_source(cop, src)
       expect(cop.offenses.size).to eq(1)
     end
 
     unless modifier == 'public'
       it "doesn't flag an access modifier from surrounding scope" do
-        src = ["#{keyword} A",
-               "  #{modifier}",
-               '  begin',
-               '    def method1',
-               '    end',
-               '  end',
-               'end']
+        src = <<-END.strip_indent
+          #{keyword} A
+            #{modifier}
+            begin
+              def method1
+              end
+            end
+          end
+        END
         inspect_source(cop, src)
         expect(cop.offenses).to be_empty
       end
@@ -512,15 +544,17 @@ describe RuboCop::Cop::Lint::UselessAccessModifier do
   shared_examples 'unused visibility modifiers' do |keyword|
     it 'registers an error when visibility is immediately changed ' \
        'without any intervening defs' do
-      src = ["#{keyword} A",
-             '  private',
-             '  def method1',
-             '  end',
-             '  public', # bad
-             '  private',
-             '  def method2',
-             '  end',
-             'end']
+      src = <<-END.strip_indent
+        #{keyword} A
+          private
+          def method1
+          end
+          public # bad
+          private
+          def method2
+          end
+        end
+      END
       inspect_source(cop, src)
       expect(cop.offenses.size).to eq(1)
     end
@@ -528,14 +562,16 @@ describe RuboCop::Cop::Lint::UselessAccessModifier do
 
   shared_examples 'access modifiers with argument' do |keyword|
     it "doesn't register an offense" do
-      src = ["#{keyword} A",
-             '  def method1',
-             '  end',
-             '  private :method1',
-             '  def method2',
-             '  end',
-             '  public :method2',
-             'end']
+      src = <<-END.strip_indent
+        #{keyword} A
+          def method1
+          end
+          private :method1
+          def method2
+          end
+          public :method2
+        end
+      END
       inspect_source(cop, src)
       expect(cop.offenses).to be_empty
     end
@@ -544,13 +580,15 @@ describe RuboCop::Cop::Lint::UselessAccessModifier do
   shared_examples 'conditionally defined method' do |keyword, modifier|
     %w[if unless].each do |conditional_type|
       it "doesn't register an offense for #{conditional_type}" do
-        src = ["#{keyword} A",
-               "  #{modifier}",
-               "  #{conditional_type} x",
-               '    def method1',
-               '    end',
-               '  end',
-               'end']
+        src = <<-END.strip_indent
+          #{keyword} A
+            #{modifier}
+            #{conditional_type} x
+              def method1
+              end
+            end
+          end
+        END
         inspect_source(cop, src)
         expect(cop.offenses).to be_empty
       end
@@ -576,21 +614,25 @@ describe RuboCop::Cop::Lint::UselessAccessModifier do
 
   shared_examples 'method defined with define_method' do |keyword, modifier|
     it "doesn't register an offense if a block is passed" do
-      src = ["#{keyword} A",
-             "  #{modifier}",
-             '  define_method(:method1) do',
-             '  end',
-             'end']
+      src = <<-END.strip_indent
+        #{keyword} A
+          #{modifier}
+          define_method(:method1) do
+          end
+        end
+      END
       inspect_source(cop, src)
       expect(cop.offenses).to be_empty
     end
 
     %w[lambda proc ->].each do |proc_type|
       it "doesn't register an offense if a #{proc_type} is passed" do
-        src = ["#{keyword} A",
-               "  #{modifier}",
-               "  define_method(:method1, #{proc_type} { })",
-               'end']
+        src = <<-END.strip_indent
+          #{keyword} A
+            #{modifier}
+            define_method(:method1, #{proc_type} { })
+          end
+        END
         inspect_source(cop, src)
         expect(cop.offenses).to be_empty
       end
@@ -600,64 +642,74 @@ describe RuboCop::Cop::Lint::UselessAccessModifier do
   shared_examples 'method defined on a singleton class' do |keyword, modifier|
     context 'inside a class' do
       it "doesn't register an offense if a method is defined" do
-        src = ["#{keyword} A",
-               '  class << self',
-               "    #{modifier}",
-               '    define_method(:method1) do',
-               '    end',
-               '  end',
-               'end']
+        src = <<-END.strip_indent
+          #{keyword} A
+            class << self
+              #{modifier}
+              define_method(:method1) do
+              end
+            end
+          end
+        END
         inspect_source(cop, src)
         expect(cop.offenses).to be_empty
       end
 
       it "doesn't register an offense if the modifier is the same as " \
         'outside the meta-class' do
-        src = ["#{keyword} A",
-               "  #{modifier}",
-               '  def method1',
-               '  end',
-               '  class << self',
-               "    #{modifier}",
-               '    def method2',
-               '    end',
-               '  end',
-               'end']
+        src = <<-END.strip_indent
+          #{keyword} A
+            #{modifier}
+            def method1
+            end
+            class << self
+              #{modifier}
+              def method2
+              end
+            end
+          end
+        END
         inspect_source(cop, src)
         expect(cop.offenses).to be_empty
       end
 
       it 'registers an offense if no method is defined' do
-        src = ["#{keyword} A",
-               '  class << self',
-               "    #{modifier}",
-               '  end',
-               'end']
+        src = <<-END.strip_indent
+          #{keyword} A
+            class << self
+              #{modifier}
+            end
+          end
+        END
         inspect_source(cop, src)
         expect(cop.offenses.size).to eq(1)
       end
 
       it 'registers an offense if no method is defined after the modifier' do
-        src = ["#{keyword} A",
-               '  class << self',
-               '    def method1',
-               '    end',
-               "    #{modifier}",
-               '  end',
-               'end']
+        src = <<-END.strip_indent
+          #{keyword} A
+            class << self
+              def method1
+              end
+              #{modifier}
+            end
+          end
+        END
         inspect_source(cop, src)
         expect(cop.offenses.size).to eq(1)
       end
 
       it 'registers an offense even if a non-singleton-class method is ' \
         'defined' do
-        src = ["#{keyword} A",
-               '  def method1',
-               '  end',
-               '  class << self',
-               "    #{modifier}",
-               '  end',
-               'end']
+        src = <<-END.strip_indent
+          #{keyword} A
+            def method1
+            end
+            class << self
+              #{modifier}
+            end
+          end
+        END
         inspect_source(cop, src)
         expect(cop.offenses.size).to eq(1)
       end
@@ -665,29 +717,35 @@ describe RuboCop::Cop::Lint::UselessAccessModifier do
 
     context 'outside a class' do
       it "doesn't register an offense if a method is defined" do
-        src = ['class << A',
-               "  #{modifier}",
-               '  define_method(:method1) do',
-               '  end',
-               'end']
+        src = <<-END.strip_indent
+          class << A
+            #{modifier}
+            define_method(:method1) do
+            end
+          end
+        END
         inspect_source(cop, src)
         expect(cop.offenses).to be_empty
       end
 
       it 'registers an offense if no method is defined' do
-        src = ['class << A',
-               "  #{modifier}",
-               'end']
+        src = <<-END.strip_indent
+          class << A
+            #{modifier}
+          end
+        END
         inspect_source(cop, src)
         expect(cop.offenses.size).to eq(1)
       end
 
       it 'registers an offense if no method is defined after the modifier' do
-        src = ['class << A',
-               '  def method1',
-               '  end',
-               "  #{modifier}",
-               'end']
+        src = <<-END.strip_indent
+          class << A
+            def method1
+            end
+            #{modifier}
+          end
+        END
         inspect_source(cop, src)
         expect(cop.offenses.size).to eq(1)
       end
@@ -696,19 +754,23 @@ describe RuboCop::Cop::Lint::UselessAccessModifier do
 
   shared_examples 'method defined using class_eval' do |modifier|
     it "doesn't register an offense if a method is defined" do
-      src = ['A.class_eval do',
-             "  #{modifier}",
-             '  define_method(:method1) do',
-             '  end',
-             'end']
+      src = <<-END.strip_indent
+        A.class_eval do
+          #{modifier}
+          define_method(:method1) do
+          end
+        end
+      END
       inspect_source(cop, src)
       expect(cop.offenses).to be_empty
     end
 
     it 'registers an offense if no method is defined' do
-      src = ['A.class_eval do',
-             "  #{modifier}",
-             'end']
+      src = <<-END.strip_indent
+        A.class_eval do
+          #{modifier}
+        end
+      END
       inspect_source(cop, src)
       expect(cop.offenses.size).to eq(1)
     end
@@ -716,25 +778,29 @@ describe RuboCop::Cop::Lint::UselessAccessModifier do
     context 'inside a class' do
       it 'registers an offense when a modifier is ouside the block and a ' \
         'method is defined only inside the block' do
-        src = ['class A',
-               "  #{modifier}",
-               '  A.class_eval do',
-               '    def method1',
-               '    end',
-               '  end',
-               'end']
+        src = <<-END.strip_indent
+          class A
+            #{modifier}
+            A.class_eval do
+              def method1
+              end
+            end
+          end
+        END
         inspect_source(cop, src)
         expect(cop.offenses.size).to eq(1)
       end
 
       it 'registers two offenses when a modifier is inside and outside the ' \
         ' and no method is defined' do
-        src = ['class A',
-               "  #{modifier}",
-               '  A.class_eval do',
-               "    #{modifier}",
-               '  end',
-               'end']
+        src = <<-END.strip_indent
+          class A
+            #{modifier}
+            A.class_eval do
+              #{modifier}
+            end
+          end
+        END
         inspect_source(cop, src)
         expect(cop.offenses.size).to eq(2)
       end
@@ -743,19 +809,23 @@ describe RuboCop::Cop::Lint::UselessAccessModifier do
 
   shared_examples 'def in new block' do |klass, modifier|
     it "doesn't register an offense if a method is defined in #{klass}.new" do
-      src = ["#{klass}.new do",
-             "  #{modifier}",
-             '  def foo',
-             '  end',
-             'end']
+      src = <<-END.strip_indent
+        #{klass}.new do
+          #{modifier}
+          def foo
+          end
+        end
+      END
       inspect_source(cop, src)
       expect(cop.offenses).to be_empty
     end
 
     it "registers an offense if no method is defined in #{klass}.new" do
-      src = ["#{klass}.new do",
-             "  #{modifier}",
-             'end']
+      src = <<-END.strip_indent
+        #{klass}.new do
+          #{modifier}
+        end
+      END
       inspect_source(cop, src)
       expect(cop.offenses.size).to eq(1)
     end
@@ -763,19 +833,23 @@ describe RuboCop::Cop::Lint::UselessAccessModifier do
 
   shared_examples 'method defined using instance_eval' do |modifier|
     it "doesn't register an offense if a method is defined" do
-      src = ['A.instance_eval do',
-             "  #{modifier}",
-             '  define_method(:method1) do',
-             '  end',
-             'end']
+      src = <<-END.strip_indent
+        A.instance_eval do
+          #{modifier}
+          define_method(:method1) do
+          end
+        end
+      END
       inspect_source(cop, src)
       expect(cop.offenses).to be_empty
     end
 
     it 'registers an offense if no method is defined' do
-      src = ['A.instance_eval do',
-             "  #{modifier}",
-             'end']
+      src = <<-END.strip_indent
+        A.instance_eval do
+          #{modifier}
+        end
+      END
       inspect_source(cop, src)
       expect(cop.offenses.size).to eq(1)
     end
@@ -783,25 +857,29 @@ describe RuboCop::Cop::Lint::UselessAccessModifier do
     context 'inside a class' do
       it 'registers an offense when a modifier is ouside the block and a ' \
         'method is defined only inside the block' do
-        src = ['class A',
-               "  #{modifier}",
-               '  self.instance_eval do',
-               '    def method1',
-               '    end',
-               '  end',
-               'end']
+        src = <<-END.strip_indent
+          class A
+            #{modifier}
+            self.instance_eval do
+              def method1
+              end
+            end
+          end
+        END
         inspect_source(cop, src)
         expect(cop.offenses.size).to eq(1)
       end
 
       it 'registers two offenses when a modifier is inside and outside the ' \
         ' and no method is defined' do
-        src = ['class A',
-               "  #{modifier}",
-               '  self.instance_eval do',
-               "    #{modifier}",
-               '  end',
-               'end']
+        src = <<-END.strip_indent
+          class A
+            #{modifier}
+            self.instance_eval do
+              #{modifier}
+            end
+          end
+        END
         inspect_source(cop, src)
         expect(cop.offenses.size).to eq(2)
       end
@@ -810,52 +888,60 @@ describe RuboCop::Cop::Lint::UselessAccessModifier do
 
   shared_examples 'nested modules' do |keyword, modifier|
     it "doesn't register an offense for nested #{keyword}s" do
-      src = ["#{keyword} A",
-             "  #{modifier}",
-             '  def method1',
-             '  end',
-             "  #{keyword} B",
-             '    def method2',
-             '    end',
-             "    #{modifier}",
-             '    def method3',
-             '    end',
-             '  end',
-             'end']
+      src = <<-END.strip_indent
+        #{keyword} A
+          #{modifier}
+          def method1
+          end
+          #{keyword} B
+            def method2
+            end
+            #{modifier}
+            def method3
+            end
+          end
+        end
+      END
       inspect_source(cop, src)
       expect(cop.offenses).to be_empty
     end
 
     context 'unused modifiers' do
       it "registers an offense with a nested #{keyword}" do
-        src = ["#{keyword} A",
-               "  #{modifier}",
-               "  #{keyword} B",
-               "    #{modifier}",
-               '  end',
-               'end']
+        src = <<-END.strip_indent
+          #{keyword} A
+            #{modifier}
+            #{keyword} B
+              #{modifier}
+            end
+          end
+        END
         inspect_source(cop, src)
         expect(cop.offenses.size).to eq(2)
       end
 
       it "registers an offense when outside a nested #{keyword}" do
-        src = ["#{keyword} A",
-               "  #{modifier}",
-               "  #{keyword} B",
-               '    def method1',
-               '    end',
-               '  end',
-               'end']
+        src = <<-END.strip_indent
+          #{keyword} A
+            #{modifier}
+            #{keyword} B
+              def method1
+              end
+            end
+          end
+        END
         inspect_source(cop, src)
         expect(cop.offenses.size).to eq(1)
       end
 
       it "registers an offense when inside a nested #{keyword}" do
-        src = ["#{keyword} A",
-               "  #{keyword} B",
-               "    #{modifier}",
-               '  end',
-               'end']
+        src = <<-END.strip_indent
+          #{keyword} A
+            #{keyword} B
+              #{modifier}
+            end
+          end
+        END
         inspect_source(cop, src)
         expect(cop.offenses.size).to eq(1)
       end

--- a/spec/rubocop/cop/lint/useless_assignment_spec.rb
+++ b/spec/rubocop/cop/lint/useless_assignment_spec.rb
@@ -5,17 +5,17 @@ describe RuboCop::Cop::Lint::UselessAssignment do
 
   context 'when a variable is assigned and unreferenced in a method' do
     let(:source) do
-      [
-        'class SomeClass',
-        '  foo = 1',
-        '  puts foo',
-        '  def some_method',
-        '    foo = 2',
-        '    bar = 3',
-        '    puts bar',
-        '  end',
-        'end'
-      ]
+      <<-END.strip_indent
+        class SomeClass
+          foo = 1
+          puts foo
+          def some_method
+            foo = 2
+            bar = 3
+            puts bar
+          end
+        end
+      END
     end
 
     it 'registers an offense' do
@@ -33,17 +33,17 @@ describe RuboCop::Cop::Lint::UselessAssignment do
   context 'when a variable is assigned and unreferenced ' \
           'in a singleton method defined with self keyword' do
     let(:source) do
-      [
-        'class SomeClass',
-        '  foo = 1',
-        '  puts foo',
-        '  def self.some_method',
-        '    foo = 2',
-        '    bar = 3',
-        '    puts bar',
-        '  end',
-        'end'
-      ]
+      <<-END.strip_indent
+        class SomeClass
+          foo = 1
+          puts foo
+          def self.some_method
+            foo = 2
+            bar = 3
+            puts bar
+          end
+        end
+      END
     end
 
     it 'registers an offense' do
@@ -61,18 +61,18 @@ describe RuboCop::Cop::Lint::UselessAssignment do
   context 'when a variable is assigned and unreferenced ' \
           'in a singleton method defined with variable name' do
     let(:source) do
-      [
-        '1.times do',
-        '  foo = 1',
-        '  puts foo',
-        '  instance = Object.new',
-        '  def instance.some_method',
-        '    foo = 2',
-        '    bar = 3',
-        '    puts bar',
-        '  end',
-        'end'
-      ]
+      <<-END.strip_indent
+        1.times do
+          foo = 1
+          puts foo
+          instance = Object.new
+          def instance.some_method
+            foo = 2
+            bar = 3
+            puts bar
+          end
+        end
+      END
     end
 
     it 'registers an offense' do
@@ -89,17 +89,17 @@ describe RuboCop::Cop::Lint::UselessAssignment do
 
   context 'when a variable is assigned and unreferenced in a class' do
     let(:source) do
-      [
-        '1.times do',
-        '  foo = 1',
-        '  puts foo',
-        '  class SomeClass',
-        '    foo = 2',
-        '    bar = 3',
-        '    puts bar',
-        '  end',
-        'end'
-      ]
+      <<-END.strip_indent
+        1.times do
+          foo = 1
+          puts foo
+          class SomeClass
+            foo = 2
+            bar = 3
+            puts bar
+          end
+        end
+      END
     end
 
     it 'registers an offense' do
@@ -117,18 +117,18 @@ describe RuboCop::Cop::Lint::UselessAssignment do
   context 'when a variable is assigned and unreferenced in a class ' \
           'subclassing another class stored in local variable' do
     let(:source) do
-      [
-        '1.times do',
-        '  foo = 1',
-        '  puts foo',
-        '  array_class = Array',
-        '  class SomeClass < array_class',
-        '    foo = 2',
-        '    bar = 3',
-        '    puts bar',
-        '  end',
-        'end'
-      ]
+      <<-END.strip_indent
+        1.times do
+          foo = 1
+          puts foo
+          array_class = Array
+          class SomeClass < array_class
+            foo = 2
+            bar = 3
+            puts bar
+          end
+        end
+      END
     end
 
     it 'registers an offense' do
@@ -146,18 +146,18 @@ describe RuboCop::Cop::Lint::UselessAssignment do
   context 'when a variable is assigned and unreferenced ' \
           'in a singleton class' do
     let(:source) do
-      [
-        '1.times do',
-        '  foo = 1',
-        '  puts foo',
-        '  instance = Object.new',
-        '  class << instance',
-        '    foo = 2',
-        '    bar = 3',
-        '    puts bar',
-        '  end',
-        'end'
-      ]
+      <<-END.strip_indent
+        1.times do
+          foo = 1
+          puts foo
+          instance = Object.new
+          class << instance
+            foo = 2
+            bar = 3
+            puts bar
+          end
+        end
+      END
     end
 
     it 'registers an offense' do
@@ -174,17 +174,17 @@ describe RuboCop::Cop::Lint::UselessAssignment do
 
   context 'when a variable is assigned and unreferenced in a module' do
     let(:source) do
-      [
-        '1.times do',
-        '  foo = 1',
-        '  puts foo',
-        '  module SomeModule',
-        '    foo = 2',
-        '    bar = 3',
-        '    puts bar',
-        '  end',
-        'end'
-      ]
+      <<-END.strip_indent
+        1.times do
+          foo = 1
+          puts foo
+          module SomeModule
+            foo = 2
+            bar = 3
+            puts bar
+          end
+        end
+      END
     end
 
     it 'registers an offense' do
@@ -201,11 +201,11 @@ describe RuboCop::Cop::Lint::UselessAssignment do
 
   context 'when a variable is assigned and unreferenced in top level' do
     let(:source) do
-      [
-        'foo = 1',
-        'bar = 2',
-        'puts bar'
-      ]
+      <<-END.strip_indent
+        foo = 1
+        bar = 2
+        puts bar
+      END
     end
 
     it 'registers an offense' do
@@ -240,14 +240,14 @@ describe RuboCop::Cop::Lint::UselessAssignment do
   context 'when a variable is assigned multiple times ' \
           'but unreferenced' do
     let(:source) do
-      [
-        'def some_method',
-        '  foo = 1',
-        '  bar = 2',
-        '  foo = 3',
-        '  puts bar',
-        'end'
-      ]
+      <<-END.strip_indent
+        def some_method
+          foo = 1
+          bar = 2
+          foo = 3
+          puts bar
+        end
+      END
     end
 
     it 'registers offenses for each assignment' do
@@ -269,13 +269,13 @@ describe RuboCop::Cop::Lint::UselessAssignment do
   context 'when a referenced variable is reassigned ' \
           'but not re-referenced' do
     let(:source) do
-      [
-        'def some_method',
-        '  foo = 1',
-        '  puts foo',
-        '  foo = 3',
-        'end'
-      ]
+      <<-END.strip_indent
+        def some_method
+          foo = 1
+          puts foo
+          foo = 3
+        end
+      END
     end
 
     it 'registers an offense for the non-re-referenced assignment' do
@@ -291,13 +291,13 @@ describe RuboCop::Cop::Lint::UselessAssignment do
   context 'when an unreferenced variable is reassigned ' \
           'and re-referenced' do
     let(:source) do
-      [
-        'def some_method',
-        '  foo = 1',
-        '  foo = 3',
-        '  puts foo',
-        'end'
-      ]
+      <<-END.strip_indent
+        def some_method
+          foo = 1
+          foo = 3
+          puts foo
+        end
+      END
     end
 
     it 'registers an offense for the unreferenced assignment' do
@@ -312,22 +312,22 @@ describe RuboCop::Cop::Lint::UselessAssignment do
 
   context 'when an unreferenced variable is reassigned in a block' do
     let(:source) do
-      [
-        'def const_name(node)',
-        '  const_names = []',
-        '  const_node = node',
-        '',
-        '  loop do',
-        '    namespace_node, name = *const_node',
-        '    const_names << name',
-        '    break unless namespace_node',
-        '    break if namespace_node.type == :cbase',
-        '    const_node = namespace_node',
-        '  end',
-        '',
-        "  const_names.reverse.join('::')",
-        'end'
-      ]
+      <<-END.strip_indent
+        def const_name(node)
+          const_names = []
+          const_node = node
+
+          loop do
+            namespace_node, name = *const_node
+            const_names << name
+            break unless namespace_node
+            break if namespace_node.type == :cbase
+            const_node = namespace_node
+          end
+
+          const_names.reverse.join('::')
+        end
+      END
     end
 
     include_examples 'accepts'
@@ -336,15 +336,15 @@ describe RuboCop::Cop::Lint::UselessAssignment do
 
   context 'when a referenced variable is reassigned in a block' do
     let(:source) do
-      [
-        'def some_method',
-        '  foo = 1',
-        '  puts foo',
-        '  1.times do',
-        '    foo = 2',
-        '  end',
-        'end'
-      ]
+      <<-END.strip_indent
+        def some_method
+          foo = 1
+          puts foo
+          1.times do
+            foo = 2
+          end
+        end
+      END
     end
 
     include_examples 'accepts'
@@ -353,10 +353,10 @@ describe RuboCop::Cop::Lint::UselessAssignment do
 
   context 'when a block local variable is declared but not assigned' do
     let(:source) do
-      [
-        '1.times do |i; foo|',
-        'end'
-      ]
+      <<-END.strip_indent
+        1.times do |i; foo|
+        end
+      END
     end
 
     include_examples 'accepts'
@@ -364,11 +364,11 @@ describe RuboCop::Cop::Lint::UselessAssignment do
 
   context 'when a block local variable is assigned and unreferenced' do
     let(:source) do
-      [
-        '1.times do |i; foo|',
-        '  foo = 2',
-        'end'
-      ]
+      <<-END.strip_indent
+        1.times do |i; foo|
+          foo = 2
+        end
+      END
     end
 
     it 'registers offenses for the assignment' do
@@ -383,13 +383,13 @@ describe RuboCop::Cop::Lint::UselessAssignment do
 
   context 'when a variable is assigned in loop body and unreferenced' do
     let(:source) do
-      [
-        'def some_method',
-        '  while true',
-        '    foo = 1',
-        '  end',
-        'end'
-      ]
+      <<-END.strip_indent
+        def some_method
+          while true
+            foo = 1
+          end
+        end
+      END
     end
 
     it 'registers an offense' do
@@ -407,19 +407,19 @@ describe RuboCop::Cop::Lint::UselessAssignment do
   context 'when a variable is reassigned at the end of loop body ' \
           'and would be referenced in next iteration' do
     let(:source) do
-      [
-        'def some_method',
-        '  total = 0',
-        '  foo = 0',
-        '',
-        '  while total < 100',
-        '    total += foo',
-        '    foo += 1',
-        '  end',
-        '',
-        '  total',
-        'end'
-      ]
+      <<-END.strip_indent
+        def some_method
+          total = 0
+          foo = 0
+
+          while total < 100
+            total += foo
+            foo += 1
+          end
+
+          total
+        end
+      END
     end
 
     include_examples 'accepts'
@@ -429,19 +429,19 @@ describe RuboCop::Cop::Lint::UselessAssignment do
   context 'when a variable is reassigned at the end of loop body ' \
           'and would be referenced in loop condition' do
     let(:source) do
-      [
-        'def some_method',
-        '  total = 0',
-        '  foo = 0',
-        '',
-        '  while foo < 100',
-        '    total += 1',
-        '    foo += 1',
-        '  end',
-        '',
-        '  total',
-        'end'
-      ]
+      <<-END.strip_indent
+        def some_method
+          total = 0
+          foo = 0
+
+          while foo < 100
+            total += 1
+            foo += 1
+          end
+
+          total
+        end
+      END
     end
 
     include_examples 'accepts'
@@ -450,15 +450,15 @@ describe RuboCop::Cop::Lint::UselessAssignment do
 
   context 'when a setter is invoked with operator assignment in loop body' do
     let(:source) do
-      [
-        'def some_method',
-        '  obj = {}',
-        '',
-        '  while obj[:count] < 100',
-        '    obj[:count] += 1',
-        '  end',
-        'end'
-      ]
+      <<-END.strip_indent
+        def some_method
+          obj = {}
+
+          while obj[:count] < 100
+            obj[:count] += 1
+          end
+        end
+      END
     end
 
     include_examples 'accepts'
@@ -468,19 +468,19 @@ describe RuboCop::Cop::Lint::UselessAssignment do
   context "when a variable is reassigned in loop body but won't " \
           'be referenced either next iteration or loop condition' do
     let(:source) do
-      [
-        'def some_method',
-        '  total = 0',
-        '  foo = 0',
-        '',
-        '  while total < 100',
-        '    total += 1',
-        '    foo += 1',
-        '  end',
-        '',
-        '  total',
-        'end'
-      ]
+      <<-END.strip_indent
+        def some_method
+          total = 0
+          foo = 0
+
+          while total < 100
+            total += 1
+            foo += 1
+          end
+
+          total
+        end
+      END
     end
 
     it 'registers an offense' do
@@ -498,15 +498,15 @@ describe RuboCop::Cop::Lint::UselessAssignment do
   context 'when a referenced variable is reassigned ' \
           'but not re-referenced in a method defined in loop' do
     let(:source) do
-      [
-        'while true',
-        '  def some_method',
-        '    foo = 1',
-        '    puts foo',
-        '    foo = 3',
-        '  end',
-        'end'
-      ]
+      <<-END.strip_indent
+        while true
+          def some_method
+            foo = 1
+            puts foo
+            foo = 3
+          end
+        end
+      END
     end
 
     it 'registers an offense' do
@@ -522,16 +522,16 @@ describe RuboCop::Cop::Lint::UselessAssignment do
   context 'when a variable that has same name as outer scope variable ' \
           'is not referenced in a method defined in loop' do
     let(:source) do
-      [
-        'foo = 1',
-        '',
-        'while foo < 100',
-        '  foo += 1',
-        '  def some_method',
-        '    foo = 1',
-        '  end',
-        'end'
-      ]
+      <<-END.strip_indent
+        foo = 1
+
+        while foo < 100
+          foo += 1
+          def some_method
+            foo = 1
+          end
+        end
+      END
     end
 
     it 'registers an offense' do
@@ -547,13 +547,13 @@ describe RuboCop::Cop::Lint::UselessAssignment do
   context 'when a variable is assigned in single branch if ' \
           'and unreferenced' do
     let(:source) do
-      [
-        'def some_method(flag)',
-        '  if flag',
-        '    foo = 1',
-        '  end',
-        'end'
-      ]
+      <<-END.strip_indent
+        def some_method(flag)
+          if flag
+            foo = 1
+          end
+        end
+      END
     end
 
     it 'registers an offense' do
@@ -571,16 +571,16 @@ describe RuboCop::Cop::Lint::UselessAssignment do
   context 'when a unreferenced variable is reassigned in same branch ' \
           'and referenced after the branching' do
     let(:source) do
-      [
-        'def some_method(flag)',
-        '  if flag',
-        '    foo = 1',
-        '    foo = 2',
-        '  end',
-        '',
-        '  foo',
-        'end'
-      ]
+      <<-END.strip_indent
+        def some_method(flag)
+          if flag
+            foo = 1
+            foo = 2
+          end
+
+          foo
+        end
+      END
     end
 
     it 'registers an offense for the unreferenced assignment' do
@@ -596,17 +596,17 @@ describe RuboCop::Cop::Lint::UselessAssignment do
   context 'when a variable is reassigned in single branch if ' \
           'and referenced after the branching' do
     let(:source) do
-      [
-        'def some_method(flag)',
-        '  foo = 1',
-        '',
-        '  if flag',
-        '    foo = 2',
-        '  end',
-        '',
-        '  foo',
-        'end'
-      ]
+      <<-END.strip_indent
+        def some_method(flag)
+          foo = 1
+
+          if flag
+            foo = 2
+          end
+
+          foo
+        end
+      END
     end
 
     include_examples 'accepts'
@@ -616,18 +616,18 @@ describe RuboCop::Cop::Lint::UselessAssignment do
   context 'when a variable is reassigned in a loop' do
     context 'while loop' do
       let(:source) do
-        [
-          'def while(param)',
-          '  ret = 1',
-          '',
-          '  while param != 10',
-          '    param += 2',
-          '    ret = param + 1',
-          '  end',
-          '',
-          '  ret',
-          'end'
-        ]
+        <<-END.strip_indent
+          def while(param)
+            ret = 1
+
+            while param != 10
+              param += 2
+              ret = param + 1
+            end
+
+            ret
+          end
+        END
       end
 
       include_examples 'accepts'
@@ -635,18 +635,18 @@ describe RuboCop::Cop::Lint::UselessAssignment do
 
     context 'post while loop' do
       let(:source) do
-        [
-          'def post_while(param)',
-          '  ret = 1',
-          '',
-          '  begin',
-          '    param += 2',
-          '    ret = param + 1',
-          '  end while param < 40',
-          '',
-          '  ret',
-          'end'
-        ]
+        <<-END.strip_indent
+          def post_while(param)
+            ret = 1
+
+            begin
+              param += 2
+              ret = param + 1
+            end while param < 40
+
+            ret
+          end
+        END
       end
 
       include_examples 'accepts'
@@ -654,18 +654,18 @@ describe RuboCop::Cop::Lint::UselessAssignment do
 
     context 'until loop' do
       let(:source) do
-        [
-          'def until(param)',
-          '  ret = 1',
-          '',
-          '  until param == 10',
-          '    param += 2',
-          '    ret = param + 1',
-          '  end',
-          '',
-          '  ret',
-          'end'
-        ]
+        <<-END.strip_indent
+          def until(param)
+            ret = 1
+
+            until param == 10
+              param += 2
+              ret = param + 1
+            end
+
+            ret
+          end
+        END
       end
 
       include_examples 'accepts'
@@ -673,18 +673,18 @@ describe RuboCop::Cop::Lint::UselessAssignment do
 
     context 'post until loop' do
       let(:source) do
-        [
-          'def post_until(param)',
-          '  ret = 1',
-          '',
-          '  begin',
-          '    param += 2',
-          '    ret = param + 1',
-          '  end until param == 10',
-          '',
-          '  ret',
-          'end'
-        ]
+        <<-END.strip_indent
+          def post_until(param)
+            ret = 1
+
+            begin
+              param += 2
+              ret = param + 1
+            end until param == 10
+
+            ret
+          end
+        END
       end
 
       include_examples 'accepts'
@@ -692,18 +692,18 @@ describe RuboCop::Cop::Lint::UselessAssignment do
 
     context 'for loop' do
       let(:source) do
-        [
-          'def for(param)',
-          '  ret = 1',
-          '',
-          '  for x in param...10',
-          '    param += x',
-          '    ret = param + 1',
-          '  end',
-          '',
-          '  ret',
-          'end'
-        ]
+        <<-END.strip_indent
+          def for(param)
+            ret = 1
+
+            for x in param...10
+              param += x
+              ret = param + 1
+            end
+
+            ret
+          end
+        END
       end
 
       include_examples 'accepts'
@@ -713,17 +713,17 @@ describe RuboCop::Cop::Lint::UselessAssignment do
   context 'when a variable is assigned in each branch of if ' \
           'and referenced after the branching' do
     let(:source) do
-      [
-        'def some_method(flag)',
-        '  if flag',
-        '    foo = 2',
-        '  else',
-        '    foo = 3',
-        '  end',
-        '',
-        '  foo',
-        'end'
-      ]
+      <<-END.strip_indent
+        def some_method(flag)
+          if flag
+            foo = 2
+          else
+            foo = 3
+          end
+
+          foo
+        end
+      END
     end
 
     include_examples 'accepts'
@@ -733,16 +733,16 @@ describe RuboCop::Cop::Lint::UselessAssignment do
   context 'when a variable is reassigned in single branch if ' \
           'and referenced in the branch' do
     let(:source) do
-      [
-        'def some_method(flag)',
-        '  foo = 1',
-        '',
-        '  if flag',
-        '    foo = 2',
-        '    puts foo',
-        '  end',
-        'end'
-      ]
+      <<-END.strip_indent
+        def some_method(flag)
+          foo = 1
+
+          if flag
+            foo = 2
+            puts foo
+          end
+        end
+      END
     end
 
     it 'registers an offense for the unreferenced assignment' do
@@ -758,16 +758,16 @@ describe RuboCop::Cop::Lint::UselessAssignment do
   context 'when a variable is assigned in each branch of if ' \
           'and referenced in the else branch' do
     let(:source) do
-      [
-        'def some_method(flag)',
-        '  if flag',
-        '    foo = 2',
-        '  else',
-        '    foo = 3',
-        '    puts foo',
-        '  end',
-        'end'
-      ]
+      <<-END.strip_indent
+        def some_method(flag)
+          if flag
+            foo = 2
+          else
+            foo = 3
+            puts foo
+          end
+        end
+      END
     end
 
     it 'registers an offense for the assignment in the if branch' do
@@ -783,18 +783,18 @@ describe RuboCop::Cop::Lint::UselessAssignment do
   context 'when a variable is reassigned and unreferenced in a if branch ' \
           'while the variable is referenced in the paired else branch ' do
     let(:source) do
-      [
-        'def some_method(flag)',
-        '  foo = 1',
-        '',
-        '  if flag',
-        '    puts foo',
-        '    foo = 2',
-        '  else',
-        '    puts foo',
-        '  end',
-        'end'
-      ]
+      <<-END.strip_indent
+        def some_method(flag)
+          foo = 1
+
+          if flag
+            puts foo
+            foo = 2
+          else
+            puts foo
+          end
+        end
+      END
     end
 
     it 'registers an offense for the reassignment in the if branch' do
@@ -810,13 +810,13 @@ describe RuboCop::Cop::Lint::UselessAssignment do
   context "when there's an unreferenced assignment in top level if branch " \
           'while the variable is referenced in the paired else branch' do
     let(:source) do
-      [
-        'if flag',
-        '  foo = 1',
-        'else',
-        '  puts foo',
-        'end'
-      ]
+      <<-END.strip_indent
+        if flag
+          foo = 1
+        else
+          puts foo
+        end
+      END
     end
 
     it 'registers an offense for the assignment in the if branch' do
@@ -832,18 +832,18 @@ describe RuboCop::Cop::Lint::UselessAssignment do
   context "when there's an unreferenced reassignment in a if branch " \
           'while the variable is referenced in the paired elsif branch' do
     let(:source) do
-      [
-        'def some_method(flag_a, flag_b)',
-        '  foo = 1',
-        '',
-        '  if flag_a',
-        '    puts foo',
-        '    foo = 2',
-        '  elsif flag_b',
-        '    puts foo',
-        '  end',
-        'end'
-      ]
+      <<-END.strip_indent
+        def some_method(flag_a, flag_b)
+          foo = 1
+
+          if flag_a
+            puts foo
+            foo = 2
+          elsif flag_b
+            puts foo
+          end
+        end
+      END
     end
 
     it 'registers an offense for the reassignment in the if branch' do
@@ -860,21 +860,21 @@ describe RuboCop::Cop::Lint::UselessAssignment do
           'while the variable is referenced in a case branch ' \
           'in the paired else branch' do
     let(:source) do
-      [
-        'def some_method(flag_a, flag_b)',
-        '  foo = 1',
-        '',
-        '  if flag_a',
-        '    puts foo',
-        '    foo = 2',
-        '  else',
-        '    case',
-        '    when flag_b',
-        '      puts foo',
-        '    end',
-        '  end',
-        'end'
-      ]
+      <<-END.strip_indent
+        def some_method(flag_a, flag_b)
+          foo = 1
+
+          if flag_a
+            puts foo
+            foo = 2
+          else
+            case
+            when flag_b
+              puts foo
+            end
+          end
+        end
+      END
     end
 
     it 'registers an offense for the reassignment in the if branch' do
@@ -890,17 +890,17 @@ describe RuboCop::Cop::Lint::UselessAssignment do
   context 'when an assignment in a if branch is referenced ' \
           'in another if branch' do
     let(:source) do
-      [
-        'def some_method(flag_a, flag_b)',
-        '  if flag_a',
-        '    foo = 1',
-        '  end',
-        '',
-        '  if flag_b',
-        '    puts foo',
-        '  end',
-        'end'
-      ]
+      <<-END.strip_indent
+        def some_method(flag_a, flag_b)
+          if flag_a
+            foo = 1
+          end
+
+          if flag_b
+            puts foo
+          end
+        end
+      END
     end
 
     include_examples 'accepts'
@@ -910,12 +910,12 @@ describe RuboCop::Cop::Lint::UselessAssignment do
           'that references the variable in its conditional clause' \
           'and referenced after the branching' do
     let(:source) do
-      [
-        'def some_method(flag)',
-        '  foo = 1 unless foo',
-        '  puts foo',
-        'end'
-      ]
+      <<-END.strip_indent
+        def some_method(flag)
+          foo = 1 unless foo
+          puts foo
+        end
+      END
     end
 
     include_examples 'accepts'
@@ -926,11 +926,11 @@ describe RuboCop::Cop::Lint::UselessAssignment do
           'that references the variable in its conditional clause' \
           'and unreferenced' do
     let(:source) do
-      [
-        'def some_method(flag)',
-        '  foo = 1 unless foo',
-        'end'
-      ]
+      <<-END.strip_indent
+        def some_method(flag)
+          foo = 1 unless foo
+        end
+      END
     end
 
     it 'registers an offense' do
@@ -946,12 +946,12 @@ describe RuboCop::Cop::Lint::UselessAssignment do
   context 'when a variable is assigned on each side of && ' \
           'and referenced after the &&' do
     let(:source) do
-      [
-        'def some_method',
-        '  (foo = do_something_returns_object_or_nil) && (foo = 1)',
-        '  foo',
-        'end'
-      ]
+      <<-END.strip_indent
+        def some_method
+          (foo = do_something_returns_object_or_nil) && (foo = 1)
+          foo
+        end
+      END
     end
 
     include_examples 'accepts'
@@ -961,13 +961,13 @@ describe RuboCop::Cop::Lint::UselessAssignment do
   context 'when a unreferenced variable is reassigned ' \
           'on the left side of && and referenced after the &&' do
     let(:source) do
-      [
-        'def some_method',
-        '  foo = 1',
-        '  (foo = do_something_returns_object_or_nil) && do_something',
-        '  foo',
-        'end'
-      ]
+      <<-END.strip_indent
+        def some_method
+          foo = 1
+          (foo = do_something_returns_object_or_nil) && do_something
+          foo
+        end
+      END
     end
 
     it 'registers an offense for the unreferenced assignment' do
@@ -983,13 +983,13 @@ describe RuboCop::Cop::Lint::UselessAssignment do
   context 'when a unreferenced variable is reassigned ' \
           'on the right side of && and referenced after the &&' do
     let(:source) do
-      [
-        'def some_method',
-        '  foo = 1',
-        '  do_something_returns_object_or_nil && foo = 2',
-        '  foo',
-        'end'
-      ]
+      <<-END.strip_indent
+        def some_method
+          foo = 1
+          do_something_returns_object_or_nil && foo = 2
+          foo
+        end
+      END
     end
 
     include_examples 'accepts'
@@ -999,13 +999,13 @@ describe RuboCop::Cop::Lint::UselessAssignment do
   context 'when a variable is reassigned ' \
           'while referencing itself in rhs and referenced' do
     let(:source) do
-      [
-        'def some_method',
-        '  foo = [1, 2]',
-        '  foo = foo.map { |i| i + 1 }',
-        '  puts foo',
-        'end'
-      ]
+      <<-END.strip_indent
+        def some_method
+          foo = [1, 2]
+          foo = foo.map { |i| i + 1 }
+          puts foo
+        end
+      END
     end
 
     include_examples 'accepts'
@@ -1015,13 +1015,13 @@ describe RuboCop::Cop::Lint::UselessAssignment do
   context 'when a variable is reassigned ' \
           'with binary operator assignment and referenced' do
     let(:source) do
-      [
-        'def some_method',
-        '  foo = 1',
-        '  foo += 1',
-        '  foo',
-        'end'
-      ]
+      <<-END.strip_indent
+        def some_method
+          foo = 1
+          foo += 1
+          foo
+        end
+      END
     end
 
     include_examples 'accepts'
@@ -1031,13 +1031,13 @@ describe RuboCop::Cop::Lint::UselessAssignment do
   context 'when a variable is reassigned ' \
           'with logical operator assignment and referenced' do
     let(:source) do
-      [
-        'def some_method',
-        '  foo = do_something_returns_object_or_nil',
-        '  foo ||= 1',
-        '  foo',
-        'end'
-      ]
+      <<-END.strip_indent
+        def some_method
+          foo = do_something_returns_object_or_nil
+          foo ||= 1
+          foo
+        end
+      END
     end
 
     include_examples 'accepts'
@@ -1048,13 +1048,13 @@ describe RuboCop::Cop::Lint::UselessAssignment do
            'assignment while assigning to itself in rhs ' \
            'then referenced' do
     let(:source) do
-      [
-        'def some_method',
-        '  foo = 1',
-        '  foo += foo = 2',
-        '  foo',
-        'end'
-      ]
+      <<-END.strip_indent
+        def some_method
+          foo = 1
+          foo += foo = 2
+          foo
+        end
+      END
     end
 
     it 'registers an offense for the assignment in rhs' do
@@ -1069,12 +1069,12 @@ describe RuboCop::Cop::Lint::UselessAssignment do
 
   context 'when a variable is assigned first with ||= and referenced' do
     let(:source) do
-      [
-        'def some_method',
-        '  foo ||= 1',
-        '  foo',
-        'end'
-      ]
+      <<-END.strip_indent
+        def some_method
+          foo ||= 1
+          foo
+        end
+      END
     end
 
     include_examples 'accepts'
@@ -1084,12 +1084,12 @@ describe RuboCop::Cop::Lint::UselessAssignment do
   context 'when a variable is assigned with ||= ' \
           'at the last expression of the scope' do
     let(:source) do
-      [
-        'def some_method',
-        '  foo = do_something_returns_object_or_nil',
-        '  foo ||= 1',
-        'end'
-      ]
+      <<-END.strip_indent
+        def some_method
+          foo = do_something_returns_object_or_nil
+          foo ||= 1
+        end
+      END
     end
 
     it 'registers an offense' do
@@ -1106,13 +1106,13 @@ describe RuboCop::Cop::Lint::UselessAssignment do
   context 'when a variable is assigned with ||= ' \
           'before the last expression of the scope' do
     let(:source) do
-      [
-        'def some_method',
-        '  foo = do_something_returns_object_or_nil',
-        '  foo ||= 1',
-        '  some_return_value',
-        'end'
-      ]
+      <<-END.strip_indent
+        def some_method
+          foo = do_something_returns_object_or_nil
+          foo ||= 1
+          some_return_value
+        end
+      END
     end
 
     it 'registers an offense' do
@@ -1128,12 +1128,12 @@ describe RuboCop::Cop::Lint::UselessAssignment do
   context 'when a variable is assigned with multiple assignment ' \
           'and unreferenced' do
     let(:source) do
-      [
-        'def some_method',
-        '  foo, bar = do_something',
-        '  puts foo',
-        'end'
-      ]
+      <<-END.strip_indent
+        def some_method
+          foo, bar = do_something
+          puts foo
+        end
+      END
     end
 
     it 'registers an offense' do
@@ -1154,13 +1154,13 @@ describe RuboCop::Cop::Lint::UselessAssignment do
   context 'when a variable is reassigned with multiple assignment ' \
           'while referencing itself in rhs and referenced' do
     let(:source) do
-      [
-        'def some_method',
-        '  foo = 1',
-        '  foo, bar = do_something(foo)',
-        '  puts foo, bar',
-        'end'
-      ]
+      <<-END.strip_indent
+        def some_method
+          foo = 1
+          foo, bar = do_something(foo)
+          puts foo, bar
+        end
+      END
     end
 
     include_examples 'accepts'
@@ -1170,12 +1170,12 @@ describe RuboCop::Cop::Lint::UselessAssignment do
   context 'when a variable is assigned in loop body ' \
           'and referenced in post while condition' do
     let(:source) do
-      [
-        'begin',
-        '  a = (a || 0) + 1',
-        '  puts a',
-        'end while a <= 2'
-      ]
+      <<-END.strip_indent
+        begin
+          a = (a || 0) + 1
+          puts a
+        end while a <= 2
+      END
     end
 
     include_examples 'accepts'
@@ -1185,12 +1185,12 @@ describe RuboCop::Cop::Lint::UselessAssignment do
   context 'when a variable is assigned in loop body ' \
           'and referenced in post until condition' do
     let(:source) do
-      [
-        'begin',
-        '  a = (a || 0) + 1',
-        '  puts a',
-        'end until a > 2'
-      ]
+      <<-END.strip_indent
+        begin
+          a = (a || 0) + 1
+          puts a
+        end until a > 2
+      END
     end
 
     include_examples 'accepts'
@@ -1200,14 +1200,14 @@ describe RuboCop::Cop::Lint::UselessAssignment do
   context 'when a variable is assigned ' \
           'in main body of begin with rescue but unreferenced' do
     let(:source) do
-      [
-        'begin',
-        '  do_something',
-        '  foo = true',
-        'rescue',
-        '  do_anything',
-        'end'
-      ]
+      <<-END.strip_indent
+        begin
+          do_something
+          foo = true
+        rescue
+          do_anything
+        end
+      END
     end
 
     it 'registers an offense' do
@@ -1225,20 +1225,20 @@ describe RuboCop::Cop::Lint::UselessAssignment do
   context 'when a variable is assigned in main body of begin, rescue ' \
           'and else then referenced after the begin' do
     let(:source) do
-      [
-        'begin',
-        '  do_something',
-        '  foo = :in_begin',
-        'rescue FirstError',
-        '  foo = :in_first_rescue',
-        'rescue SecondError',
-        '  foo = :in_second_rescue',
-        'else',
-        '  foo = :in_else',
-        'end',
-        '',
-        'puts foo'
-      ]
+      <<-END.strip_indent
+        begin
+          do_something
+          foo = :in_begin
+        rescue FirstError
+          foo = :in_first_rescue
+        rescue SecondError
+          foo = :in_second_rescue
+        else
+          foo = :in_else
+        end
+
+        puts foo
+      END
     end
 
     include_examples 'accepts'
@@ -1248,19 +1248,19 @@ describe RuboCop::Cop::Lint::UselessAssignment do
   context 'when a variable is reassigned multiple times ' \
           'in main body of begin then referenced after the begin' do
     let(:source) do
-      [
-        'begin',
-        '  status = :initial',
-        '  connect_sometimes_fails!',
-        '  status = :connected',
-        '  fetch_sometimes_fails!',
-        '  status = :fetched',
-        'rescue',
-        '  do_something',
-        'end',
-        '',
-        'puts status'
-      ]
+      <<-END.strip_indent
+        begin
+          status = :initial
+          connect_sometimes_fails!
+          status = :connected
+          fetch_sometimes_fails!
+          status = :fetched
+        rescue
+          do_something
+        end
+
+        puts status
+      END
     end
 
     include_examples 'accepts'
@@ -1270,17 +1270,17 @@ describe RuboCop::Cop::Lint::UselessAssignment do
   context 'when a variable is reassigned multiple times ' \
           'in main body of begin then referenced in rescue' do
     let(:source) do
-      [
-        'begin',
-        '  status = :initial',
-        '  connect_sometimes_fails!',
-        '  status = :connected',
-        '  fetch_sometimes_fails!',
-        '  status = :fetched',
-        'rescue',
-        '  puts status',
-        'end'
-      ]
+      <<-END.strip_indent
+        begin
+          status = :initial
+          connect_sometimes_fails!
+          status = :connected
+          fetch_sometimes_fails!
+          status = :fetched
+        rescue
+          puts status
+        end
+      END
     end
 
     include_examples 'accepts'
@@ -1290,17 +1290,17 @@ describe RuboCop::Cop::Lint::UselessAssignment do
   context 'when a variable is reassigned multiple times ' \
           'in main body of begin then referenced in ensure' do
     let(:source) do
-      [
-        'begin',
-        '  status = :initial',
-        '  connect_sometimes_fails!',
-        '  status = :connected',
-        '  fetch_sometimes_fails!',
-        '  status = :fetched',
-        'ensure',
-        '  puts status',
-        'end'
-      ]
+      <<-END.strip_indent
+        begin
+          status = :initial
+          connect_sometimes_fails!
+          status = :connected
+          fetch_sometimes_fails!
+          status = :fetched
+        ensure
+          puts status
+        end
+      END
     end
 
     include_examples 'accepts'
@@ -1310,18 +1310,18 @@ describe RuboCop::Cop::Lint::UselessAssignment do
   context 'when a variable is reassigned multiple times in rescue ' \
           'and referenced after the begin' do
     let(:source) do
-      [
-        'foo = false',
-        '',
-        'begin',
-        '  do_something',
-        'rescue',
-        '  foo = true',
-        '  foo = true',
-        'end',
-        '',
-        'puts foo'
-      ]
+      <<-END.strip_indent
+        foo = false
+
+        begin
+          do_something
+        rescue
+          foo = true
+          foo = true
+        end
+
+        puts foo
+      END
     end
 
     it 'registers an offense' do
@@ -1337,20 +1337,20 @@ describe RuboCop::Cop::Lint::UselessAssignment do
   context 'when a variable is reassigned multiple times ' \
           'in rescue with ensure then referenced after the begin' do
     let(:source) do
-      [
-        'foo = false',
-        '',
-        'begin',
-        '  do_something',
-        'rescue',
-        '  foo = true',
-        '  foo = true',
-        'ensure',
-        '  do_anything',
-        'end',
-        '',
-        'puts foo'
-      ]
+      <<-END.strip_indent
+        foo = false
+
+        begin
+          do_something
+        rescue
+          foo = true
+          foo = true
+        ensure
+          do_anything
+        end
+
+        puts foo
+      END
     end
 
     it 'registers an offense' do
@@ -1366,18 +1366,18 @@ describe RuboCop::Cop::Lint::UselessAssignment do
   context 'when a variable is reassigned multiple times ' \
           'in ensure with rescue then referenced after the begin' do
     let(:source) do
-      [
-        'begin',
-        '  do_something',
-        'rescue',
-        '  do_anything',
-        'ensure',
-        '  foo = true',
-        '  foo = true',
-        'end',
-        '',
-        'puts foo'
-      ]
+      <<-END.strip_indent
+        begin
+          do_something
+        rescue
+          do_anything
+        ensure
+          foo = true
+          foo = true
+        end
+
+        puts foo
+      END
     end
 
     it 'registers an offense' do
@@ -1393,17 +1393,17 @@ describe RuboCop::Cop::Lint::UselessAssignment do
   context 'when a variable is assigned at the end of rescue ' \
           'and would be referenced with retry' do
     let(:source) do
-      [
-        'retried = false',
-        '',
-        'begin',
-        '  do_something',
-        'rescue',
-        '  fail if retried',
-        '  retried = true',
-        '  retry',
-        'end'
-      ]
+      <<-END.strip_indent
+        retried = false
+
+        begin
+          do_something
+        rescue
+          fail if retried
+          retried = true
+          retry
+        end
+      END
     end
 
     include_examples 'accepts'
@@ -1413,16 +1413,16 @@ describe RuboCop::Cop::Lint::UselessAssignment do
   context 'when a variable is assigned with operator assignment ' \
           'in rescue and would be referenced with retry' do
     let(:source) do
-      [
-        'retry_count = 0',
-        '',
-        'begin',
-        '  do_something',
-        'rescue',
-        '  fail if (retry_count += 1) > 3',
-        '  retry',
-        'end'
-      ]
+      <<-END.strip_indent
+        retry_count = 0
+
+        begin
+          do_something
+        rescue
+          fail if (retry_count += 1) > 3
+          retry
+        end
+      END
     end
 
     include_examples 'accepts'
@@ -1433,22 +1433,22 @@ describe RuboCop::Cop::Lint::UselessAssignment do
           'in main body of begin, rescue and else ' \
           'and reassigned in ensure then referenced after the begin' do
     let(:source) do
-      [
-        'begin',
-        '  do_something',
-        '  foo = :in_begin',
-        'rescue FirstError',
-        '  foo = :in_first_rescue',
-        'rescue SecondError',
-        '  foo = :in_second_rescue',
-        'else',
-        '  foo = :in_else',
-        'ensure',
-        '  foo = :in_ensure',
-        'end',
-        '',
-        'puts foo'
-      ]
+      <<-END.strip_indent
+        begin
+          do_something
+          foo = :in_begin
+        rescue FirstError
+          foo = :in_first_rescue
+        rescue SecondError
+          foo = :in_second_rescue
+        else
+          foo = :in_else
+        ensure
+          foo = :in_ensure
+        end
+
+        puts foo
+      END
     end
 
     it 'registers offenses for each assignment before ensure' do
@@ -1465,14 +1465,14 @@ describe RuboCop::Cop::Lint::UselessAssignment do
   context 'when a rescued error variable is wrongly tried to be referenced ' \
           'in another rescue body' do
     let(:source) do
-      [
-        'begin',
-        '  do_something',
-        'rescue FirstError => error',
-        'rescue SecondError',
-        '  p error # => nil',
-        'end'
-      ]
+      <<-END.strip_indent
+        begin
+          do_something
+        rescue FirstError => error
+        rescue SecondError
+          p error # => nil
+        end
+      END
     end
 
     it 'registers an offense' do
@@ -1488,12 +1488,12 @@ describe RuboCop::Cop::Lint::UselessAssignment do
   context 'when a method argument is reassigned ' \
           'and zero arity super is called' do
     let(:source) do
-      [
-        'def some_method(foo)',
-        '  foo = 1',
-        '  super',
-        'end'
-      ]
+      <<-END.strip_indent
+        def some_method(foo)
+          foo = 1
+          super
+        end
+      END
     end
 
     include_examples 'accepts'
@@ -1503,12 +1503,12 @@ describe RuboCop::Cop::Lint::UselessAssignment do
   context 'when a local variable is unreferenced ' \
           'and zero arity super is called' do
     let(:source) do
-      [
-        'def some_method(bar)',
-        '  foo = 1',
-        '  super',
-        'end'
-      ]
+      <<-END.strip_indent
+        def some_method(bar)
+          foo = 1
+          super
+        end
+      END
     end
 
     it 'registers an offense' do
@@ -1526,12 +1526,12 @@ describe RuboCop::Cop::Lint::UselessAssignment do
   context 'when a method argument is reassigned ' \
           'but not passed to super' do
     let(:source) do
-      [
-        'def some_method(foo, bar)',
-        '  foo = 1',
-        '  super(bar)',
-        'end'
-      ]
+      <<-END.strip_indent
+        def some_method(foo, bar)
+          foo = 1
+          super(bar)
+        end
+      END
     end
 
     it 'registers an offense' do
@@ -1563,11 +1563,11 @@ describe RuboCop::Cop::Lint::UselessAssignment do
   context 'when a named capture is unreferenced ' \
           'in other than top level' do
     let(:source) do
-      [
-        'def some_method',
-        "  /(?<foo>\\w+)/ =~ 'FOO'",
-        'end'
-      ]
+      <<-END.strip_indent
+        def some_method
+          /(?<foo>\\w+)/ =~ 'FOO'
+        end
+      END
     end
 
     it 'registers an offense' do
@@ -1586,13 +1586,13 @@ describe RuboCop::Cop::Lint::UselessAssignment do
 
   context 'when a named capture is referenced' do
     let(:source) do
-      [
-        'def some_method',
-        "  /(?<foo>\w+)(?<bar>\s+)/ =~ 'FOO'",
-        '  puts foo',
-        '  puts bar',
-        'end'
-      ]
+      <<-END.strip_indent
+        def some_method
+          /(?<foo>\w+)(?<bar>\s+)/ =~ 'FOO'
+          puts foo
+          puts bar
+        end
+      END
     end
 
     include_examples 'accepts'
@@ -1602,13 +1602,13 @@ describe RuboCop::Cop::Lint::UselessAssignment do
   context 'when a variable is referenced ' \
           'in rhs of named capture expression' do
     let(:source) do
-      [
-        'def some_method',
-        "  foo = 'some string'",
-        '  /(?<foo>\w+)/ =~ foo',
-        '  puts foo',
-        'end'
-      ]
+      <<-END.strip_indent
+        def some_method
+          foo = 'some string'
+          /(?<foo>\w+)/ =~ foo
+          puts foo
+        end
+      END
     end
 
     include_examples 'accepts'
@@ -1617,14 +1617,14 @@ describe RuboCop::Cop::Lint::UselessAssignment do
   context 'when a variable is assigned in begin ' \
           'and referenced outside' do
     let(:source) do
-      [
-        'def some_method',
-        '  begin',
-        '    foo = 1',
-        '  end',
-        '  puts foo',
-        'end'
-      ]
+      <<-END.strip_indent
+        def some_method
+          begin
+            foo = 1
+          end
+          puts foo
+        end
+      END
     end
 
     include_examples 'accepts'
@@ -1634,14 +1634,14 @@ describe RuboCop::Cop::Lint::UselessAssignment do
   context 'when a variable is shadowed by a block argument ' \
           'and unreferenced' do
     let(:source) do
-      [
-        'def some_method',
-        '  foo = 1',
-        '  1.times do |foo|',
-        '    puts foo',
-        '  end',
-        'end'
-      ]
+      <<-END.strip_indent
+        def some_method
+          foo = 1
+          1.times do |foo|
+            puts foo
+          end
+        end
+      END
     end
 
     it 'registers an offense' do
@@ -1658,13 +1658,13 @@ describe RuboCop::Cop::Lint::UselessAssignment do
 
   context 'when a variable is not used and the name starts with _' do
     let(:source) do
-      [
-        'def some_method',
-        '  _foo = 1',
-        '  bar = 2',
-        '  puts bar',
-        'end'
-      ]
+      <<-END.strip_indent
+        def some_method
+          _foo = 1
+          bar = 2
+          puts bar
+        end
+      END
     end
 
     include_examples 'accepts'
@@ -1673,10 +1673,10 @@ describe RuboCop::Cop::Lint::UselessAssignment do
 
   context 'when a method argument is not used' do
     let(:source) do
-      [
-        'def some_method(arg)',
-        'end'
-      ]
+      <<-END.strip_indent
+        def some_method(arg)
+        end
+      END
     end
 
     include_examples 'accepts'
@@ -1685,10 +1685,10 @@ describe RuboCop::Cop::Lint::UselessAssignment do
 
   context 'when an optional method argument is not used' do
     let(:source) do
-      [
-        'def some_method(arg = nil)',
-        'end'
-      ]
+      <<-END.strip_indent
+        def some_method(arg = nil)
+        end
+      END
     end
 
     include_examples 'accepts'
@@ -1697,10 +1697,10 @@ describe RuboCop::Cop::Lint::UselessAssignment do
 
   context 'when a block method argument is not used' do
     let(:source) do
-      [
-        'def some_method(&block)',
-        'end'
-      ]
+      <<-END.strip_indent
+        def some_method(&block)
+        end
+      END
     end
 
     include_examples 'accepts'
@@ -1709,10 +1709,10 @@ describe RuboCop::Cop::Lint::UselessAssignment do
 
   context 'when a splat method argument is not used' do
     let(:source) do
-      [
-        'def some_method(*args)',
-        'end'
-      ]
+      <<-END.strip_indent
+        def some_method(*args)
+        end
+      END
     end
 
     include_examples 'accepts'
@@ -1721,10 +1721,10 @@ describe RuboCop::Cop::Lint::UselessAssignment do
 
   context 'when a optional keyword method argument is not used' do
     let(:source) do
-      [
-        'def some_method(name: value)',
-        'end'
-      ]
+      <<-END.strip_indent
+        def some_method(name: value)
+        end
+      END
     end
 
     include_examples 'accepts' unless RUBY_VERSION < '2.0'
@@ -1733,11 +1733,11 @@ describe RuboCop::Cop::Lint::UselessAssignment do
 
   context 'when a keyword splat method argument is used' do
     let(:source) do
-      [
-        'def some_method(name: value, **rest_keywords)',
-        '  p rest_keywords',
-        'end'
-      ]
+      <<-END.strip_indent
+        def some_method(name: value, **rest_keywords)
+          p rest_keywords
+        end
+      END
     end
 
     include_examples 'accepts' unless RUBY_VERSION < '2.0'
@@ -1746,10 +1746,10 @@ describe RuboCop::Cop::Lint::UselessAssignment do
 
   context 'when a keyword splat method argument is not used' do
     let(:source) do
-      [
-        'def some_method(name: value, **rest_keywords)',
-        'end'
-      ]
+      <<-END.strip_indent
+        def some_method(name: value, **rest_keywords)
+        end
+      END
     end
 
     include_examples 'accepts' unless RUBY_VERSION < '2.0'
@@ -1758,10 +1758,10 @@ describe RuboCop::Cop::Lint::UselessAssignment do
 
   context 'when an anonymous keyword splat method argument is defined' do
     let(:source) do
-      [
-        'def some_method(name: value, **)',
-        'end'
-      ]
+      <<-END.strip_indent
+        def some_method(name: value, **)
+        end
+      END
     end
 
     include_examples 'accepts' unless RUBY_VERSION < '2.0'
@@ -1770,10 +1770,10 @@ describe RuboCop::Cop::Lint::UselessAssignment do
 
   context 'when a block argument is not used' do
     let(:source) do
-      [
-        '1.times do |i|',
-        'end'
-      ]
+      <<-END.strip_indent
+        1.times do |i|
+        end
+      END
     end
 
     include_examples 'accepts'
@@ -1801,11 +1801,11 @@ describe RuboCop::Cop::Lint::UselessAssignment do
           'while being passed to a method taking block' do
     context 'and the variable is used' do
       let(:source) do
-        [
-          'some_method(foo = 1) do',
-          'end',
-          'puts foo'
-        ]
+        <<-END.strip_indent
+          some_method(foo = 1) do
+          end
+          puts foo
+        END
       end
 
       include_examples 'accepts'
@@ -1814,10 +1814,10 @@ describe RuboCop::Cop::Lint::UselessAssignment do
 
     context 'and the variable is not used' do
       let(:source) do
-        [
-          'some_method(foo = 1) do',
-          'end'
-        ]
+        <<-END.strip_indent
+          some_method(foo = 1) do
+          end
+        END
       end
 
       it 'registers an offense' do
@@ -1836,11 +1836,11 @@ describe RuboCop::Cop::Lint::UselessAssignment do
   context 'when a variable is assigned ' \
           'and passed to a method followed by method taking block' do
     let(:source) do
-      [
-        "pattern = '*.rb'",
-        'Dir.glob(pattern).map do |path|',
-        'end'
-      ]
+      <<-END.strip_indent
+        pattern = '*.rb'
+        Dir.glob(pattern).map do |path|
+        end
+      END
     end
 
     include_examples 'accepts'
@@ -1850,14 +1850,16 @@ describe RuboCop::Cop::Lint::UselessAssignment do
   # regression test, from problem in Locatable
   context 'when a variable is assigned in 2 identical if branches' do
     let(:source) do
-      ['def foo',
-       '  if bar',
-       '    foo = 1',
-       '  else',
-       '    foo = 1',
-       '  end',
-       '  foo.bar.baz',
-       'end']
+      <<-END.strip_indent
+        def foo
+          if bar
+            foo = 1
+          else
+            foo = 1
+          end
+          foo.bar.baz
+        end
+      END
     end
 
     it "doesn't think 1 of the 2 assignments is useless" do
@@ -1869,13 +1871,13 @@ describe RuboCop::Cop::Lint::UselessAssignment do
   describe 'similar name suggestion' do
     context "when there's a similar variable-like method invocation" do
       let(:source) do
-        [
-          'def some_method',
-          '  enviromnent = {}',
-          '  another_symbol',
-          '  puts environment',
-          'end'
-        ]
+        <<-END.strip_indent
+          def some_method
+            enviromnent = {}
+            another_symbol
+            puts environment
+          end
+        END
       end
 
       it 'suggests the method name' do
@@ -1890,14 +1892,14 @@ describe RuboCop::Cop::Lint::UselessAssignment do
 
     context "when there's a similar variable" do
       let(:source) do
-        [
-          'def some_method',
-          '  environment = nil',
-          '  another_symbol',
-          '  enviromnent = {}',
-          '  puts environment',
-          'end'
-        ]
+        <<-END.strip_indent
+          def some_method
+            environment = nil
+            another_symbol
+            enviromnent = {}
+            puts environment
+          end
+        END
       end
 
       it 'suggests the variable name' do
@@ -1912,13 +1914,13 @@ describe RuboCop::Cop::Lint::UselessAssignment do
 
     context 'when there are only less similar names' do
       let(:source) do
-        [
-          'def some_method',
-          '  enviromnent = {}',
-          '  another_symbol',
-          '  puts envelope',
-          'end'
-        ]
+        <<-END.strip_indent
+          def some_method
+            enviromnent = {}
+            another_symbol
+            puts envelope
+          end
+        END
       end
 
       it 'does not suggest any name' do
@@ -1931,13 +1933,13 @@ describe RuboCop::Cop::Lint::UselessAssignment do
 
     context "when there's a similar method invocation with explicit receiver" do
       let(:source) do
-        [
-          'def some_method',
-          '  enviromnent = {}',
-          '  another_symbol',
-          '  puts self.environment',
-          'end'
-        ]
+        <<-END.strip_indent
+          def some_method
+            enviromnent = {}
+            another_symbol
+            puts self.environment
+          end
+        END
       end
 
       it 'does not suggest any name' do
@@ -1950,13 +1952,13 @@ describe RuboCop::Cop::Lint::UselessAssignment do
 
     context "when there's a similar method invocation with arguments" do
       let(:source) do
-        [
-          'def some_method',
-          '  enviromnent = {}',
-          '  another_symbol',
-          '  puts environment(1)',
-          'end'
-        ]
+        <<-END.strip_indent
+          def some_method
+            enviromnent = {}
+            another_symbol
+            puts environment(1)
+          end
+        END
       end
 
       it 'does not suggest any name' do
@@ -1969,15 +1971,15 @@ describe RuboCop::Cop::Lint::UselessAssignment do
 
     context "when there's a similar name but it's in inner scope" do
       let(:source) do
-        [
-          'class SomeClass',
-          '  enviromnent = {}',
-          '',
-          '  def some_method(environment)',
-          '    puts environment',
-          '  end',
-          'end'
-        ]
+        <<-END.strip_indent
+          class SomeClass
+            enviromnent = {}
+
+            def some_method(environment)
+              puts environment
+            end
+          end
+        END
       end
 
       it 'does not suggest any name' do

--- a/spec/rubocop/cop/lint/useless_comparison_spec.rb
+++ b/spec/rubocop/cop/lint/useless_comparison_spec.rb
@@ -5,16 +5,18 @@ describe RuboCop::Cop::Lint::UselessComparison do
 
   described_class::OPS.each do |op|
     it "registers an offense for a simple comparison with #{op}" do
-      inspect_source(cop,
-                     ["5 #{op} 5",
-                      "a #{op} a"])
+      inspect_source(cop, <<-END.strip_indent)
+        5 #{op} 5
+        a #{op} a
+      END
       expect(cop.offenses.size).to eq(2)
     end
 
     it "registers an offense for a complex comparison with #{op}" do
-      inspect_source(cop,
-                     ["5 + 10 * 30 #{op} 5 + 10 * 30",
-                      "a.top(x) #{op} a.top(x)"])
+      inspect_source(cop, <<-END.strip_indent)
+        5 + 10 * 30 #{op} 5 + 10 * 30
+        a.top(x) #{op} a.top(x)
+      END
       expect(cop.offenses.size).to eq(2)
     end
   end

--- a/spec/rubocop/cop/lint/useless_else_without_rescue_spec.rb
+++ b/spec/rubocop/cop/lint/useless_else_without_rescue_spec.rb
@@ -9,13 +9,13 @@ describe RuboCop::Cop::Lint::UselessElseWithoutRescue do
 
   context 'with `else` without `rescue`' do
     let(:source) do
-      [
-        'begin',
-        '  do_something',
-        'else',
-        '  handle_unknown_errors',
-        'end'
-      ]
+      <<-END.strip_indent
+        begin
+          do_something
+        else
+          handle_unknown_errors
+        end
+      END
     end
 
     it 'registers an offense' do
@@ -28,15 +28,15 @@ describe RuboCop::Cop::Lint::UselessElseWithoutRescue do
 
   context 'with `else` with `rescue`' do
     let(:source) do
-      [
-        'begin',
-        '  do_something',
-        'rescue ArgumentError',
-        '  handle_argument_error',
-        'else',
-        '  handle_unknown_errors',
-        'end'
-      ]
+      <<-END.strip_indent
+        begin
+          do_something
+        rescue ArgumentError
+          handle_argument_error
+        else
+          handle_unknown_errors
+        end
+      END
     end
 
     it 'accepts' do

--- a/spec/rubocop/cop/lint/useless_setter_call_spec.rb
+++ b/spec/rubocop/cop/lint/useless_setter_call_spec.rb
@@ -5,11 +5,12 @@ describe RuboCop::Cop::Lint::UselessSetterCall do
 
   context 'with method ending with setter call on local object' do
     it 'registers an offense' do
-      inspect_source(cop,
-                     ['def test',
-                      '  top = Top.new',
-                      '  top.attr = 5',
-                      'end'])
+      inspect_source(cop, <<-END.strip_indent)
+        def test
+          top = Top.new
+          top.attr = 5
+        end
+      END
       expect(cop.offenses.size).to eq(1)
       expect(cop.messages)
         .to eq(['Useless setter call to local variable `top`.'])
@@ -18,22 +19,24 @@ describe RuboCop::Cop::Lint::UselessSetterCall do
 
   context 'with singleton method ending with setter call on local object' do
     it 'registers an offense' do
-      inspect_source(cop,
-                     ['def Top.test',
-                      '  top = Top.new',
-                      '  top.attr = 5',
-                      'end'])
+      inspect_source(cop, <<-END.strip_indent)
+        def Top.test
+          top = Top.new
+          top.attr = 5
+        end
+      END
       expect(cop.offenses.size).to eq(1)
     end
   end
 
   context 'with method ending with square bracket setter on local object' do
     it 'registers an offense' do
-      inspect_source(cop,
-                     ['def test',
-                      '  top = Top.new',
-                      '  top[:attr] = 5',
-                      'end'])
+      inspect_source(cop, <<-END.strip_indent)
+        def test
+          top = Top.new
+          top[:attr] = 5
+        end
+      END
       expect(cop.offenses.size).to eq(1)
       expect(cop.messages)
         .to eq(['Useless setter call to local variable `top`.'])
@@ -42,33 +45,36 @@ describe RuboCop::Cop::Lint::UselessSetterCall do
 
   context 'with method ending with ivar assignment' do
     it 'accepts' do
-      inspect_source(cop,
-                     ['def test',
-                      '  something',
-                      '  @top = 5',
-                      'end'])
+      inspect_source(cop, <<-END.strip_indent)
+        def test
+          something
+          @top = 5
+        end
+      END
       expect(cop.offenses).to be_empty
     end
   end
 
   context 'with method ending with setter call on ivar' do
     it 'accepts' do
-      inspect_source(cop,
-                     ['def test',
-                      '  something',
-                      '  @top.attr = 5',
-                      'end'])
+      inspect_source(cop, <<-END.strip_indent)
+        def test
+          something
+          @top.attr = 5
+        end
+      END
       expect(cop.offenses).to be_empty
     end
   end
 
   context 'with method ending with setter call on argument' do
     it 'accepts' do
-      inspect_source(cop,
-                     ['def test(some_arg)',
-                      '  unrelated_local_variable = Top.new',
-                      '  some_arg.attr = 5',
-                      'end'])
+      inspect_source(cop, <<-END.strip_indent)
+        def test(some_arg)
+          unrelated_local_variable = Top.new
+          some_arg.attr = 5
+        end
+      END
       expect(cop.offenses).to be_empty
     end
   end
@@ -76,14 +82,15 @@ describe RuboCop::Cop::Lint::UselessSetterCall do
   context 'when a lvar contains an object passed as argument ' \
           'at the end of the method' do
     it 'accepts the setter call on the lvar' do
-      inspect_source(cop,
-                     ['def test(some_arg)',
-                      '  @some_ivar = some_arg',
-                      '  @some_ivar.do_something',
-                      '  some_lvar = @some_ivar',
-                      '  some_lvar.do_something',
-                      '  some_lvar.attr = 5',
-                      'end'])
+      inspect_source(cop, <<-END.strip_indent)
+        def test(some_arg)
+          @some_ivar = some_arg
+          @some_ivar.do_something
+          some_lvar = @some_ivar
+          some_lvar.do_something
+          some_lvar.attr = 5
+        end
+      END
       expect(cop.offenses).to be_empty
     end
   end
@@ -91,11 +98,12 @@ describe RuboCop::Cop::Lint::UselessSetterCall do
   context 'when a lvar contains an object passed as argument ' \
           'by multiple-assignment at the end of the method' do
     it 'accepts the setter call on the lvar' do
-      inspect_source(cop,
-                     ['def test(some_arg)',
-                      '  _first, some_lvar, _third  = 1, some_arg, 3',
-                      '  some_lvar.attr = 5',
-                      'end'])
+      inspect_source(cop, <<-END.strip_indent)
+        def test(some_arg)
+          _first, some_lvar, _third  = 1, some_arg, 3
+          some_lvar.attr = 5
+        end
+      END
       expect(cop.offenses).to be_empty
     end
   end
@@ -103,11 +111,12 @@ describe RuboCop::Cop::Lint::UselessSetterCall do
   context 'when a lvar does not contain any object passed as argument ' \
           'with multiple-assignment at the end of the method' do
     it 'registers an offense' do
-      inspect_source(cop,
-                     ['def test(some_arg)',
-                      '  _first, some_lvar, _third  = do_something',
-                      '  some_lvar.attr = 5',
-                      'end'])
+      inspect_source(cop, <<-END.strip_indent)
+        def test(some_arg)
+          _first, some_lvar, _third  = do_something
+          some_lvar.attr = 5
+        end
+      END
       expect(cop.offenses.size).to eq(1)
     end
   end
@@ -115,12 +124,13 @@ describe RuboCop::Cop::Lint::UselessSetterCall do
   context 'when a lvar possibly contains an object passed as argument ' \
           'by logical-operator-assignment at the end of the method' do
     it 'accepts the setter call on the lvar' do
-      inspect_source(cop,
-                     ['def test(some_arg)',
-                      '  some_lvar = nil',
-                      '  some_lvar ||= some_arg',
-                      '  some_lvar.attr = 5',
-                      'end'])
+      inspect_source(cop, <<-END.strip_indent)
+        def test(some_arg)
+          some_lvar = nil
+          some_lvar ||= some_arg
+          some_lvar.attr = 5
+        end
+      END
       expect(cop.offenses).to be_empty
     end
   end
@@ -128,12 +138,13 @@ describe RuboCop::Cop::Lint::UselessSetterCall do
   context 'when a lvar does not contain any object passed as argument ' \
           'by binary-operator-assignment at the end of the method' do
     it 'registers an offense' do
-      inspect_source(cop,
-                     ['def test(some_arg)',
-                      '  some_lvar = some_arg',
-                      '  some_lvar += some_arg',
-                      '  some_lvar.attr = 5',
-                      'end'])
+      inspect_source(cop, <<-END.strip_indent)
+        def test(some_arg)
+          some_lvar = some_arg
+          some_lvar += some_arg
+          some_lvar.attr = 5
+        end
+      END
       expect(cop.offenses.size).to eq(1)
     end
   end
@@ -141,53 +152,58 @@ describe RuboCop::Cop::Lint::UselessSetterCall do
   context 'when a lvar declared as an argument ' \
           'is no longer the passed object at the end of the method' do
     it 'registers an offense for the setter call on the lvar' do
-      inspect_source(cop,
-                     ['def test(some_arg)',
-                      '  some_arg = Top.new',
-                      '  some_arg.attr = 5',
-                      'end'])
+      inspect_source(cop, <<-END.strip_indent)
+        def test(some_arg)
+          some_arg = Top.new
+          some_arg.attr = 5
+        end
+      END
       expect(cop.offenses.size).to eq(1)
     end
   end
 
   context 'when a lvar contains a local object instantiated with literal' do
     it 'registers an offense for the setter call on the lvar' do
-      inspect_source(cop,
-                     ['def test',
-                      '  some_arg = {}',
-                      '  some_arg[:attr] = 1',
-                      'end'])
+      inspect_source(cop, <<-END.strip_indent)
+        def test
+          some_arg = {}
+          some_arg[:attr] = 1
+        end
+      END
       expect(cop.offenses.size).to eq(1)
     end
   end
 
   context 'when a lvar contains a non-local object returned by a method' do
     it 'accepts' do
-      inspect_source(cop,
-                     ['def test',
-                      '  some_lvar = Foo.shared_object',
-                      '  some_lvar[:attr] = 1',
-                      'end'])
+      inspect_source(cop, <<-END.strip_indent)
+        def test
+          some_lvar = Foo.shared_object
+          some_lvar[:attr] = 1
+        end
+      END
       expect(cop.offenses).to be_empty
     end
   end
 
   it 'is not confused by operators ending with =' do
-    inspect_source(cop,
-                   ['def test',
-                    '  top.attr == 5',
-                    'end'])
+    inspect_source(cop, <<-END.strip_indent)
+      def test
+        top.attr == 5
+      end
+    END
     expect(cop.offenses).to be_empty
   end
 
   it 'handles exception assignments without exploding' do
-    inspect_source(cop,
-                   ['def foo(bar)',
-                    '  begin',
-                    '  rescue StandardError => _',
-                    '  end',
-                    '  bar[:baz] = true',
-                    'end'])
+    inspect_source(cop, <<-END.strip_indent)
+      def foo(bar)
+        begin
+        rescue StandardError => _
+        end
+        bar[:baz] = true
+      end
+    END
     expect(cop.offenses).to be_empty
   end
 end

--- a/spec/rubocop/cop/lint/void_spec.rb
+++ b/spec/rubocop/cop/lint/void_spec.rb
@@ -5,19 +5,21 @@ describe RuboCop::Cop::Lint::Void do
 
   described_class::OPS.each do |op|
     it "registers an offense for void op #{op} if not on last line" do
-      inspect_source(cop,
-                     ["a #{op} b",
-                      "a #{op} b",
-                      "a #{op} b"])
+      inspect_source(cop, <<-END.strip_indent)
+        a #{op} b
+        a #{op} b
+        a #{op} b
+      END
       expect(cop.offenses.size).to eq(2)
     end
   end
 
   described_class::OPS.each do |op|
     it "accepts void op #{op} if on last line" do
-      inspect_source(cop,
-                     ['something',
-                      "a #{op} b"])
+      inspect_source(cop, <<-END.strip_indent)
+        something
+        a #{op} b
+      END
       expect(cop.offenses).to be_empty
     end
   end
@@ -54,39 +56,44 @@ describe RuboCop::Cop::Lint::Void do
   end
 
   it 'registers an offense for void `defined?` if not on last line' do
-    inspect_source(cop,
-                   ['defined?(x)',
-                    'top'])
+    inspect_source(cop, <<-END.strip_indent)
+      defined?(x)
+      top
+    END
     expect(cop.offenses.size).to eq(1)
   end
 
   it 'handles explicit begin blocks' do
-    inspect_source(cop,
-                   ['begin',
-                    ' 1',
-                    ' 2',
-                    'end'])
+    inspect_source(cop, <<-END.strip_indent)
+      begin
+       1
+       2
+      end
+    END
     expect(cop.offenses.size).to eq(1)
   end
 
   it 'accepts short call syntax' do
-    inspect_source(cop,
-                   ['lambda.(a)',
-                    'top'])
+    inspect_source(cop, <<-END.strip_indent)
+      lambda.(a)
+      top
+    END
     expect(cop.offenses).to be_empty
   end
 
   it 'accepts backtick commands' do
-    inspect_source(cop,
-                   ['`touch x`',
-                    'nil'])
+    inspect_source(cop, <<-END.strip_indent)
+      `touch x`
+      nil
+    END
     expect(cop.offenses).to be_empty
   end
 
   it 'accepts percent-x commands' do
-    inspect_source(cop,
-                   ['%x(touch x)',
-                    'nil'])
+    inspect_source(cop, <<-END.strip_indent)
+      %x(touch x)
+      nil
+    END
     expect(cop.offenses).to be_empty
   end
 end

--- a/spec/rubocop/cop/metrics/abc_size_spec.rb
+++ b/spec/rubocop/cop/metrics/abc_size_spec.rb
@@ -7,15 +7,19 @@ describe RuboCop::Cop::Metrics::AbcSize, :config do
     let(:cop_config) { { 'Max' => 0 } }
 
     it 'accepts an empty method' do
-      inspect_source(cop, ['def method_name',
-                           'end'])
+      inspect_source(cop, <<-END.strip_indent)
+        def method_name
+        end
+      END
       expect(cop.offenses).to be_empty
     end
 
     it 'registers an offense for an if modifier' do
-      inspect_source(cop, ['def method_name',
-                           '  call_foo if some_condition', # 0 + 2*2 + 1*1
-                           'end'])
+      inspect_source(cop, <<-END.strip_indent)
+        def method_name
+          call_foo if some_condition # 0 + 2*2 + 1*1
+        end
+      END
       expect(cop.messages)
         .to eq(['Assignment Branch Condition size for method_name is too ' \
                 'high. [2.24/0]'])
@@ -24,9 +28,11 @@ describe RuboCop::Cop::Metrics::AbcSize, :config do
     end
 
     it 'registers an offense for an assignment of a local variable' do
-      inspect_source(cop, ['def method_name',
-                           '  x = 1',
-                           'end'])
+      inspect_source(cop, <<-END.strip_indent)
+        def method_name
+          x = 1
+        end
+      END
       expect(cop.messages)
         .to eq(['Assignment Branch Condition size for method_name is too ' \
                 'high. [1/0]'])
@@ -34,9 +40,11 @@ describe RuboCop::Cop::Metrics::AbcSize, :config do
     end
 
     it 'registers an offense for an assignment of an element' do
-      inspect_source(cop, ['def method_name',
-                           '  x[0] = 1',
-                           'end'])
+      inspect_source(cop, <<-END.strip_indent)
+        def method_name
+          x[0] = 1
+        end
+      END
       expect(cop.messages)
         .to eq(['Assignment Branch Condition size for method_name is too ' \
                 'high. [1.41/0]'])
@@ -45,14 +53,15 @@ describe RuboCop::Cop::Metrics::AbcSize, :config do
 
     it 'registers an offense for complex content including A, B, and C ' \
        'scores' do
-      inspect_source(cop,
-                     ['def method_name',
-                      '  my_options = Hash.new if 1 == 1 || 2 == 2', # 1, 3, 2
-                      '  my_options.each do |key, value|',           # 0, 1, 0
-                      '    p key',                                   # 0, 1, 0
-                      '    p value',                                 # 0, 1, 0
-                      '  end',
-                      'end'])
+      inspect_source(cop, <<-END.strip_indent)
+        def method_name
+          my_options = Hash.new if 1 == 1 || 2 == 2 # 1, 3, 2
+          my_options.each do |key, value|           # 0, 1, 0
+            p key                                   # 0, 1, 0
+            p value                                 # 0, 1, 0
+          end
+        end
+      END
       expect(cop.messages)
         .to eq(['Assignment Branch Condition size for method_name is too ' \
                 'high. [6.4/0]']) # sqrt(1*1 + 6*6 + 2*2) => 6.4
@@ -60,10 +69,11 @@ describe RuboCop::Cop::Metrics::AbcSize, :config do
 
     context 'target_ruby_version >= 2.3', :ruby23 do
       it 'treats safe navigation method calls like regular method calls' do
-        inspect_source(cop,
-                       ['def method_name',
-                        '  object&.do_something',
-                        'end'])
+        inspect_source(cop, <<-END.strip_indent)
+          def method_name
+            object&.do_something
+          end
+        END
         expect(cop.messages)
           .to eq(['Assignment Branch Condition size for method_name is too ' \
                   'high. [2/0]']) # sqrt(0 + 2*2 + 0) => 2
@@ -75,10 +85,12 @@ describe RuboCop::Cop::Metrics::AbcSize, :config do
     let(:cop_config) { { 'Max' => 2 } }
 
     it 'accepts two assignments' do
-      inspect_source(cop, ['def method_name',
-                           '  x = 1',
-                           '  y = 2',
-                           'end'])
+      inspect_source(cop, <<-END.strip_indent)
+        def method_name
+          x = 1
+          y = 2
+        end
+      END
       expect(cop.offenses).to be_empty
     end
   end
@@ -87,9 +99,11 @@ describe RuboCop::Cop::Metrics::AbcSize, :config do
     let(:cop_config) { { 'Max' => 1.8 } }
 
     it 'accepts a total score of 1.7' do
-      inspect_source(cop, ['def method_name',
-                           '  y = 1 if y == 1',
-                           'end'])
+      inspect_source(cop, <<-END.strip_indent)
+        def method_name
+          y = 1 if y == 1
+        end
+      END
       expect(cop.offenses).to be_empty
     end
   end

--- a/spec/rubocop/cop/metrics/block_length_spec.rb
+++ b/spec/rubocop/cop/metrics/block_length_spec.rb
@@ -5,11 +5,13 @@ describe RuboCop::Cop::Metrics::BlockLength, :config do
   let(:cop_config) { { 'Max' => 2, 'CountComments' => false } }
 
   it 'rejects a block with more than 5 lines' do
-    inspect_source(cop, ['something do',
-                         '  a = 1',
-                         '  a = 2',
-                         '  a = 3',
-                         'end'])
+    inspect_source(cop, <<-END.strip_indent)
+      something do
+        a = 1
+        a = 2
+        a = 3
+      end
+    END
     expect(cop.offenses.size).to eq(1)
     expect(cop.offenses.map(&:line).sort).to eq([1])
     expect(cop.config_to_allow_offenses).to eq('Max' => 3)
@@ -17,81 +19,97 @@ describe RuboCop::Cop::Metrics::BlockLength, :config do
   end
 
   it 'reports the correct beginning and end lines' do
-    inspect_source(cop, ['something do',
-                         '  a = 1',
-                         '  a = 2',
-                         '  a = 3',
-                         'end'])
+    inspect_source(cop, <<-END.strip_indent)
+      something do
+        a = 1
+        a = 2
+        a = 3
+      end
+    END
     offense = cop.offenses.first
     expect(offense.location.first_line).to eq(1)
     expect(offense.location.last_line).to eq(5)
   end
 
   it 'accepts a block with less than 3 lines' do
-    inspect_source(cop, ['something do',
-                         '  a = 1',
-                         '  a = 2',
-                         'end'])
+    inspect_source(cop, <<-END.strip_indent)
+      something do
+        a = 1
+        a = 2
+      end
+    END
     expect(cop.offenses).to be_empty
   end
 
   it 'does not count blank lines' do
-    inspect_source(cop, ['something do',
-                         '  a = 1',
-                         '',
-                         '',
-                         '  a = 4',
-                         'end'])
+    inspect_source(cop, <<-END.strip_indent)
+      something do
+        a = 1
+
+
+        a = 4
+      end
+    END
     expect(cop.offenses).to be_empty
   end
 
   it 'accepts a block with multiline receiver and less than 3 lines of body' do
-    inspect_source(cop, ['[',
-                         '  :a,',
-                         '  :b,',
-                         '  :c,',
-                         '].each do',
-                         '  a = 1',
-                         '  a = 2',
-                         'end'])
+    inspect_source(cop, <<-END.strip_indent)
+      [
+        :a,
+        :b,
+        :c,
+      ].each do
+        a = 1
+        a = 2
+      end
+    END
     expect(cop.offenses).to be_empty
   end
 
   it 'accepts empty blocks' do
-    inspect_source(cop, ['something do',
-                         'end'])
+    inspect_source(cop, <<-END.strip_indent)
+      something do
+      end
+    END
     expect(cop.offenses).to be_empty
   end
 
   it 'rejects brace blocks too' do
-    inspect_source(cop, ['something {',
-                         '  a = 1',
-                         '  a = 2',
-                         '  a = 3',
-                         '}'])
+    inspect_source(cop, <<-END.strip_indent)
+      something {
+        a = 1
+        a = 2
+        a = 3
+      }
+    END
     expect(cop.offenses.size).to eq(1)
   end
 
   it 'properly counts nested blocks' do
-    inspect_source(cop, ['something do',
-                         '  something do',
-                         '    a = 2',
-                         '    a = 3',
-                         '    a = 4',
-                         '    a = 5',
-                         '  end',
-                         'end'])
+    inspect_source(cop, <<-END.strip_indent)
+      something do
+        something do
+          a = 2
+          a = 3
+          a = 4
+          a = 5
+        end
+      end
+    END
     expect(cop.offenses.size).to eq(2)
     expect(cop.offenses.map(&:line).sort).to eq([1, 2])
   end
 
   it 'does not count commented lines by default' do
-    inspect_source(cop, ['something do',
-                         '  a = 1',
-                         '  #a = 2',
-                         '  #a = 3',
-                         '  a = 4',
-                         'end'])
+    inspect_source(cop, <<-END.strip_indent)
+      something do
+        a = 1
+        #a = 2
+        #a = 3
+        a = 4
+      end
+    END
     expect(cop.offenses).to be_empty
   end
 
@@ -99,11 +117,13 @@ describe RuboCop::Cop::Metrics::BlockLength, :config do
     before { cop_config['CountComments'] = true }
 
     it 'also counts commented lines' do
-      inspect_source(cop, ['something do',
-                           '  a = 1',
-                           '  #a = 2',
-                           '  a = 3',
-                           'end'])
+      inspect_source(cop, <<-END.strip_indent)
+        something do
+          a = 1
+          #a = 2
+          a = 3
+        end
+      END
       expect(cop.offenses.size).to eq(1)
       expect(cop.offenses.map(&:line).sort).to eq([1])
     end
@@ -113,20 +133,24 @@ describe RuboCop::Cop::Metrics::BlockLength, :config do
     before { cop_config['ExcludedMethods'] = ['foo'] }
 
     it 'still rejects other methods with long blocks' do
-      inspect_source(cop, ['something do',
-                           '  a = 1',
-                           '  a = 2',
-                           '  a = 3',
-                           'end'])
+      inspect_source(cop, <<-END.strip_indent)
+        something do
+          a = 1
+          a = 2
+          a = 3
+        end
+      END
       expect(cop.offenses).not_to be_empty
     end
 
     it 'accepts the foo method with a long block' do
-      inspect_source(cop, ['foo do',
-                           '  a = 1',
-                           '  a = 2',
-                           '  a = 3',
-                           'end'])
+      inspect_source(cop, <<-END.strip_indent)
+        foo do
+          a = 1
+          a = 2
+          a = 3
+        end
+      END
       expect(cop.offenses).to be_empty
     end
   end

--- a/spec/rubocop/cop/metrics/block_nesting_spec.rb
+++ b/spec/rubocop/cop/metrics/block_nesting_spec.rb
@@ -20,140 +20,164 @@ describe RuboCop::Cop::Metrics::BlockNesting, :config do
   end
 
   it 'accepts `Max` levels of nesting' do
-    inspect_source(cop, ['if a',
-                         '  if b',
-                         '    puts b',
-                         '  end',
-                         'end'])
+    inspect_source(cop, <<-END.strip_indent)
+      if a
+        if b
+          puts b
+        end
+      end
+    END
     expect(cop.offenses).to be_empty
   end
 
   context '`Max + 1` levels of `if` nesting' do
-    source = ['if a',
-              '  if b',
-              '    if c',
-              '      puts c',
-              '    end',
-              '  end',
-              'end']
+    source = <<-END.strip_indent
+      if a
+        if b
+          if c
+            puts c
+          end
+        end
+      end
+    END
     it_behaves_like 'too deep', source, [3]
   end
 
   context '`Max + 2` levels of `if` nesting' do
-    source = ['if a',
-              '  if b',
-              '    if c',
-              '      if d',
-              '        puts d',
-              '      end',
-              '    end',
-              '  end',
-              'end']
+    source = <<-END.strip_indent
+      if a
+        if b
+          if c
+            if d
+              puts d
+            end
+          end
+        end
+      end
+    END
     it_behaves_like 'too deep', source, [3], 4
   end
 
   context 'Multiple nested `ifs` at same level' do
-    source = ['if a',
-              '  if b',
-              '    if c',
-              '      puts c',
-              '    end',
-              '  end',
-              '  if d',
-              '    if e',
-              '      puts e',
-              '    end',
-              '  end',
-              'end']
+    source = <<-END.strip_indent
+      if a
+        if b
+          if c
+            puts c
+          end
+        end
+        if d
+          if e
+            puts e
+          end
+        end
+      end
+    END
     it_behaves_like 'too deep', source, [3, 8]
   end
 
   context 'nested `case`' do
-    source = ['if a',
-              '  if b',
-              '    case c',
-              '      when C',
-              '        puts C',
-              '    end',
-              '  end',
-              'end']
+    source = <<-END.strip_indent
+      if a
+        if b
+          case c
+            when C
+              puts C
+          end
+        end
+      end
+    END
     it_behaves_like 'too deep', source, [3]
   end
 
   context 'nested `while`' do
-    source = ['if a',
-              '  if b',
-              '    while c',
-              '      puts c',
-              '    end',
-              '  end',
-              'end']
+    source = <<-END.strip_indent
+      if a
+        if b
+          while c
+            puts c
+          end
+        end
+      end
+    END
     it_behaves_like 'too deep', source, [3]
   end
 
   context 'nested modifier `while`' do
-    source = ['if a',
-              '  if b',
-              '    begin',
-              '      puts c',
-              '    end while c',
-              '  end',
-              'end']
+    source = <<-END.strip_indent
+      if a
+        if b
+          begin
+            puts c
+          end while c
+        end
+      end
+    END
     it_behaves_like 'too deep', source, [3]
   end
 
   context 'nested `until`' do
-    source = ['if a',
-              '  if b',
-              '    until c',
-              '      puts c',
-              '    end',
-              '  end',
-              'end']
+    source = <<-END.strip_indent
+      if a
+        if b
+          until c
+            puts c
+          end
+        end
+      end
+    END
     it_behaves_like 'too deep', source, [3]
   end
 
   context 'nested modifier `until`' do
-    source = ['if a',
-              '  if b',
-              '    begin',
-              '      puts c',
-              '    end until c',
-              '  end',
-              'end']
+    source = <<-END.strip_indent
+      if a
+        if b
+          begin
+            puts c
+          end until c
+        end
+      end
+    END
     it_behaves_like 'too deep', source, [3]
   end
 
   context 'nested `for`' do
-    source = ['if a',
-              '  if b',
-              '    for c in [1,2] do',
-              '      puts c',
-              '    end',
-              '  end',
-              'end']
+    source = <<-END.strip_indent
+      if a
+        if b
+          for c in [1,2] do
+            puts c
+          end
+        end
+      end
+    END
     it_behaves_like 'too deep', source, [3]
   end
 
   context 'nested `rescue`' do
-    source = ['if a',
-              '  if b',
-              '    begin',
-              '      puts c',
-              '    rescue',
-              '      puts x',
-              '    end',
-              '  end',
-              'end']
+    source = <<-END.strip_indent
+      if a
+        if b
+          begin
+            puts c
+          rescue
+            puts x
+          end
+        end
+      end
+    END
     it_behaves_like 'too deep', source, [5]
   end
 
   it 'accepts if/elsif' do
-    inspect_source(cop, ['if a',
-                         'elsif b',
-                         'elsif c',
-                         'elsif d',
-                         'end'])
+    inspect_source(cop, <<-END.strip_indent)
+      if a
+      elsif b
+      elsif c
+      elsif d
+      end
+    END
     expect(cop.offenses).to be_empty
   end
 
@@ -161,22 +185,26 @@ describe RuboCop::Cop::Metrics::BlockNesting, :config do
     let(:cop_config) { { 'Max' => 2, 'CountBlocks' => false } }
 
     it 'accepts nested multiline blocks' do
-      inspect_source(cop, ['if a',
-                           '  if b',
-                           '    [1, 2].each do |c|',
-                           '      puts c',
-                           '    end',
-                           '  end',
-                           'end'])
+      inspect_source(cop, <<-END.strip_indent)
+        if a
+          if b
+            [1, 2].each do |c|
+              puts c
+            end
+          end
+        end
+      END
       expect(cop.offenses).to be_empty
     end
 
     it 'accepts nested inline blocks' do
-      inspect_source(cop, ['if a',
-                           '  if b',
-                           '    [1, 2].each { |c| puts c }',
-                           '  end',
-                           'end'])
+      inspect_source(cop, <<-END.strip_indent)
+        if a
+          if b
+            [1, 2].each { |c| puts c }
+          end
+        end
+      END
       expect(cop.offenses).to be_empty
     end
   end
@@ -185,22 +213,26 @@ describe RuboCop::Cop::Metrics::BlockNesting, :config do
     let(:cop_config) { { 'Max' => 2, 'CountBlocks' => true } }
 
     context 'nested multiline block' do
-      source = ['if a',
-                '  if b',
-                '    [1, 2].each do |c|',
-                '      puts c',
-                '    end',
-                '  end',
-                'end']
+      source = <<-END.strip_indent
+        if a
+          if b
+            [1, 2].each do |c|
+              puts c
+            end
+          end
+        end
+      END
       it_behaves_like 'too deep', source, [3]
     end
 
     context 'nested inline block' do
-      source = ['if a',
-                '  if b',
-                '    [1, 2].each { |c| puts c }',
-                '  end',
-                'end']
+      source = <<-END.strip_indent
+        if a
+          if b
+            [1, 2].each { |c| puts c }
+          end
+        end
+      END
       it_behaves_like 'too deep', source, [3]
     end
   end

--- a/spec/rubocop/cop/metrics/class_length_spec.rb
+++ b/spec/rubocop/cop/metrics/class_length_spec.rb
@@ -5,28 +5,32 @@ describe RuboCop::Cop::Metrics::ClassLength, :config do
   let(:cop_config) { { 'Max' => 5, 'CountComments' => false } }
 
   it 'rejects a class with more than 5 lines' do
-    inspect_source(cop, ['class Test',
-                         '  a = 1',
-                         '  a = 2',
-                         '  a = 3',
-                         '  a = 4',
-                         '  a = 5',
-                         '  a = 6',
-                         'end'])
+    inspect_source(cop, <<-END.strip_indent)
+      class Test
+        a = 1
+        a = 2
+        a = 3
+        a = 4
+        a = 5
+        a = 6
+      end
+    END
     expect(cop.offenses.size).to eq(1)
     expect(cop.messages).to eq(['Class has too many lines. [6/5]'])
     expect(cop.config_to_allow_offenses).to eq('Max' => 6)
   end
 
   it 'reports the correct beginning and end lines' do
-    inspect_source(cop, ['class Test',
-                         '  a = 1',
-                         '  a = 2',
-                         '  a = 3',
-                         '  a = 4',
-                         '  a = 5',
-                         '  a = 6',
-                         'end'])
+    inspect_source(cop, <<-END.strip_indent)
+      class Test
+        a = 1
+        a = 2
+        a = 3
+        a = 4
+        a = 5
+        a = 6
+      end
+    END
 
     offense = cop.offenses.first
     expect(offense.location.first_line).to eq(1)
@@ -34,94 +38,106 @@ describe RuboCop::Cop::Metrics::ClassLength, :config do
   end
 
   it 'accepts a class with 5 lines' do
-    inspect_source(cop, ['class Test',
-                         '  a = 1',
-                         '  a = 2',
-                         '  a = 3',
-                         '  a = 4',
-                         '  a = 5',
-                         'end'])
+    inspect_source(cop, <<-END.strip_indent)
+      class Test
+        a = 1
+        a = 2
+        a = 3
+        a = 4
+        a = 5
+      end
+    END
     expect(cop.offenses).to be_empty
   end
 
   it 'accepts a class with less than 5 lines' do
-    inspect_source(cop, ['class Test',
-                         '  a = 1',
-                         '  a = 2',
-                         '  a = 3',
-                         '  a = 4',
-                         'end'])
+    inspect_source(cop, <<-END.strip_indent)
+      class Test
+        a = 1
+        a = 2
+        a = 3
+        a = 4
+      end
+    END
     expect(cop.offenses).to be_empty
   end
 
   it 'does not count blank lines' do
-    inspect_source(cop, ['class Test',
-                         '  a = 1',
-                         '  a = 2',
-                         '  a = 3',
-                         '  a = 4',
-                         '',
-                         '',
-                         '  a = 7',
-                         'end'])
+    inspect_source(cop, <<-END.strip_indent)
+      class Test
+        a = 1
+        a = 2
+        a = 3
+        a = 4
+
+
+        a = 7
+      end
+    END
     expect(cop.offenses).to be_empty
   end
 
   it 'accepts empty classes' do
-    inspect_source(cop, ['class Test',
-                         'end'])
+    inspect_source(cop, <<-END.strip_indent)
+      class Test
+      end
+    END
     expect(cop.offenses).to be_empty
   end
 
   context 'when a class has inner classes' do
     it 'does not count lines of inner classes' do
-      inspect_source(cop, ['class NamespaceClass',
-                           '  class TestOne',
-                           '    a = 1',
-                           '    a = 2',
-                           '    a = 3',
-                           '    a = 4',
-                           '    a = 5',
-                           '  end',
-                           '  class TestTwo',
-                           '    a = 1',
-                           '    a = 2',
-                           '    a = 3',
-                           '    a = 4',
-                           '    a = 5',
-                           '  end',
-                           '  a = 1',
-                           '  a = 2',
-                           '  a = 3',
-                           '  a = 4',
-                           '  a = 5',
-                           'end'])
+      inspect_source(cop, <<-END.strip_indent)
+        class NamespaceClass
+          class TestOne
+            a = 1
+            a = 2
+            a = 3
+            a = 4
+            a = 5
+          end
+          class TestTwo
+            a = 1
+            a = 2
+            a = 3
+            a = 4
+            a = 5
+          end
+          a = 1
+          a = 2
+          a = 3
+          a = 4
+          a = 5
+        end
+      END
       expect(cop.offenses).to be_empty
     end
 
     it 'rejects a class with 6 lines that belong to the class directly' do
-      inspect_source(cop, ['class NamespaceClass',
-                           '  class TestOne',
-                           '    a = 1',
-                           '    a = 2',
-                           '    a = 3',
-                           '    a = 4',
-                           '    a = 5',
-                           '  end',
-                           '  class TestTwo',
-                           '    a = 1',
-                           '    a = 2',
-                           '    a = 3',
-                           '    a = 4',
-                           '    a = 5',
-                           '  end',
-                           '  a = 1',
-                           '  a = 2',
-                           '  a = 3',
-                           '  a = 4',
-                           '  a = 5',
-                           '  a = 6',
-                           'end'])
+      inspect_source(cop, <<-END.strip_indent)
+        class NamespaceClass
+          class TestOne
+            a = 1
+            a = 2
+            a = 3
+            a = 4
+            a = 5
+          end
+          class TestTwo
+            a = 1
+            a = 2
+            a = 3
+            a = 4
+            a = 5
+          end
+          a = 1
+          a = 2
+          a = 3
+          a = 4
+          a = 5
+          a = 6
+        end
+      END
       expect(cop.offenses.size).to eq(1)
     end
   end
@@ -130,14 +146,16 @@ describe RuboCop::Cop::Metrics::ClassLength, :config do
     before { cop_config['CountComments'] = true }
 
     it 'also counts commented lines' do
-      inspect_source(cop, ['class Test',
-                           '  a = 1',
-                           '  #a = 2',
-                           '  a = 3',
-                           '  #a = 4',
-                           '  a = 5',
-                           '  a = 6',
-                           'end'])
+      inspect_source(cop, <<-END.strip_indent)
+        class Test
+          a = 1
+          #a = 2
+          a = 3
+          #a = 4
+          a = 5
+          a = 6
+        end
+      END
       expect(cop.offenses.size).to eq(1)
     end
   end

--- a/spec/rubocop/cop/metrics/cyclomatic_complexity_spec.rb
+++ b/spec/rubocop/cop/metrics/cyclomatic_complexity_spec.rb
@@ -7,29 +7,34 @@ describe RuboCop::Cop::Metrics::CyclomaticComplexity, :config do
     let(:cop_config) { { 'Max' => 1 } }
 
     it 'accepts a method with no decision points' do
-      inspect_source(cop, ['def method_name',
-                           '  call_foo',
-                           'end'])
+      inspect_source(cop, <<-END.strip_indent)
+        def method_name
+          call_foo
+        end
+      END
       expect(cop.offenses).to be_empty
     end
 
     it 'accepts complex code outside of methods' do
-      inspect_source(cop,
-                     ['def method_name',
-                      '  call_foo',
-                      'end',
-                      '',
-                      'if first_condition then',
-                      '  call_foo if second_condition && third_condition',
-                      '  call_bar if fourth_condition || fifth_condition',
-                      'end'])
+      inspect_source(cop, <<-END.strip_indent)
+        def method_name
+          call_foo
+        end
+
+        if first_condition then
+          call_foo if second_condition && third_condition
+          call_bar if fourth_condition || fifth_condition
+        end
+      END
       expect(cop.offenses).to be_empty
     end
 
     it 'registers an offense for an if modifier' do
-      inspect_source(cop, ['def self.method_name',
-                           '  call_foo if some_condition',
-                           'end'])
+      inspect_source(cop, <<-END.strip_indent)
+        def self.method_name
+          call_foo if some_condition
+        end
+      END
       expect(cop.messages)
         .to eq(['Cyclomatic complexity for method_name is too high. [2/1]'])
       expect(cop.highlights).to eq(['def'])
@@ -37,142 +42,169 @@ describe RuboCop::Cop::Metrics::CyclomaticComplexity, :config do
     end
 
     it 'registers an offense for an unless modifier' do
-      inspect_source(cop, ['def method_name',
-                           '  call_foo unless some_condition',
-                           'end'])
+      inspect_source(cop, <<-END.strip_indent)
+        def method_name
+          call_foo unless some_condition
+        end
+      END
       expect(cop.messages)
         .to eq(['Cyclomatic complexity for method_name is too high. [2/1]'])
     end
 
     it 'registers an offense for an elsif block' do
-      inspect_source(cop, ['def method_name',
-                           '  if first_condition then',
-                           '    call_foo',
-                           '  elsif second_condition then',
-                           '    call_bar',
-                           '  else',
-                           '    call_bam',
-                           '  end',
-                           'end'])
+      inspect_source(cop, <<-END.strip_indent)
+        def method_name
+          if first_condition then
+            call_foo
+          elsif second_condition then
+            call_bar
+          else
+            call_bam
+          end
+        end
+      END
       expect(cop.messages)
         .to eq(['Cyclomatic complexity for method_name is too high. [3/1]'])
     end
 
     it 'registers an offense for a ternary operator' do
-      inspect_source(cop, ['def method_name',
-                           '  value = some_condition ? 1 : 2',
-                           'end'])
+      inspect_source(cop, <<-END.strip_indent)
+        def method_name
+          value = some_condition ? 1 : 2
+        end
+      END
       expect(cop.messages)
         .to eq(['Cyclomatic complexity for method_name is too high. [2/1]'])
     end
 
     it 'registers an offense for a while block' do
-      inspect_source(cop, ['def method_name',
-                           '  while some_condition do',
-                           '    call_foo',
-                           '  end',
-                           'end'])
+      inspect_source(cop, <<-END.strip_indent)
+        def method_name
+          while some_condition do
+            call_foo
+          end
+        end
+      END
       expect(cop.messages)
         .to eq(['Cyclomatic complexity for method_name is too high. [2/1]'])
     end
 
     it 'registers an offense for an until block' do
-      inspect_source(cop, ['def method_name',
-                           '  until some_condition do',
-                           '    call_foo',
-                           '  end',
-                           'end'])
+      inspect_source(cop, <<-END.strip_indent)
+        def method_name
+          until some_condition do
+            call_foo
+          end
+        end
+      END
       expect(cop.messages)
         .to eq(['Cyclomatic complexity for method_name is too high. [2/1]'])
     end
 
     it 'registers an offense for a for block' do
-      inspect_source(cop, ['def method_name',
-                           '  for i in 1..2 do',
-                           '    call_method',
-                           '  end',
-                           'end'])
+      inspect_source(cop, <<-END.strip_indent)
+        def method_name
+          for i in 1..2 do
+            call_method
+          end
+        end
+      END
       expect(cop.messages)
         .to eq(['Cyclomatic complexity for method_name is too high. [2/1]'])
     end
 
     it 'registers an offense for a rescue block' do
-      inspect_source(cop, ['def method_name',
-                           '  begin',
-                           '    call_foo',
-                           '  rescue Exception',
-                           '    call_bar',
-                           '  end',
-                           'end'])
+      inspect_source(cop, <<-END.strip_indent)
+        def method_name
+          begin
+            call_foo
+          rescue Exception
+            call_bar
+          end
+        end
+      END
       expect(cop.messages)
         .to eq(['Cyclomatic complexity for method_name is too high. [2/1]'])
     end
 
     it 'registers an offense for a case/when block' do
-      inspect_source(cop, ['def method_name',
-                           '  case value',
-                           '  when 1',
-                           '    call_foo',
-                           '  when 2',
-                           '    call_bar',
-                           '  end',
-                           'end'])
+      inspect_source(cop, <<-END.strip_indent)
+        def method_name
+          case value
+          when 1
+            call_foo
+          when 2
+            call_bar
+          end
+        end
+      END
       expect(cop.messages)
         .to eq(['Cyclomatic complexity for method_name is too high. [3/1]'])
     end
 
     it 'registers an offense for &&' do
-      inspect_source(cop, ['def method_name',
-                           '  call_foo && call_bar',
-                           'end'])
+      inspect_source(cop, <<-END.strip_indent)
+        def method_name
+          call_foo && call_bar
+        end
+      END
       expect(cop.messages)
         .to eq(['Cyclomatic complexity for method_name is too high. [2/1]'])
     end
 
     it 'registers an offense for and' do
-      inspect_source(cop, ['def method_name',
-                           '  call_foo and call_bar',
-                           'end'])
+      inspect_source(cop, <<-END.strip_indent)
+        def method_name
+          call_foo and call_bar
+        end
+      END
       expect(cop.messages)
         .to eq(['Cyclomatic complexity for method_name is too high. [2/1]'])
     end
 
     it 'registers an offense for ||' do
-      inspect_source(cop, ['def method_name',
-                           '  call_foo || call_bar',
-                           'end'])
+      inspect_source(cop, <<-END.strip_indent)
+        def method_name
+          call_foo || call_bar
+        end
+      END
       expect(cop.messages)
         .to eq(['Cyclomatic complexity for method_name is too high. [2/1]'])
     end
 
     it 'registers an offense for or' do
-      inspect_source(cop, ['def method_name',
-                           '  call_foo or call_bar',
-                           'end'])
+      inspect_source(cop, <<-END.strip_indent)
+        def method_name
+          call_foo or call_bar
+        end
+      END
       expect(cop.messages)
         .to eq(['Cyclomatic complexity for method_name is too high. [2/1]'])
     end
 
     it 'deals with nested if blocks containing && and ||' do
-      inspect_source(cop,
-                     ['def method_name',
-                      '  if first_condition then',
-                      '    call_foo if second_condition && third_condition',
-                      '    call_bar if fourth_condition || fifth_condition',
-                      '  end',
-                      'end'])
+      inspect_source(cop, <<-END.strip_indent)
+        def method_name
+          if first_condition then
+            call_foo if second_condition && third_condition
+            call_bar if fourth_condition || fifth_condition
+          end
+        end
+      END
       expect(cop.messages)
         .to eq(['Cyclomatic complexity for method_name is too high. [6/1]'])
     end
 
     it 'counts only a single method' do
-      inspect_source(cop, ['def method_name_1',
-                           '  call_foo if some_condition',
-                           'end',
-                           '',
-                           'def method_name_2',
-                           '  call_foo if some_condition',
-                           'end'])
+      inspect_source(cop, <<-END.strip_indent)
+        def method_name_1
+          call_foo if some_condition
+        end
+
+        def method_name_2
+          call_foo if some_condition
+        end
+      END
       expect(cop.messages)
         .to eq(['Cyclomatic complexity for method_name_1 is too high. [2/1]',
                 'Cyclomatic complexity for method_name_2 is too high. [2/1]'])
@@ -183,18 +215,20 @@ describe RuboCop::Cop::Metrics::CyclomaticComplexity, :config do
     let(:cop_config) { { 'Max' => 2 } }
 
     it 'counts stupid nested if and else blocks' do
-      inspect_source(cop, ['def method_name',
-                           '  if first_condition then',
-                           '    call_foo',
-                           '  else',
-                           '    if second_condition then',
-                           '      call_bar',
-                           '    else',
-                           '      call_bam if third_condition',
-                           '    end',
-                           '    call_baz if fourth_condition',
-                           '  end',
-                           'end'])
+      inspect_source(cop, <<-END.strip_indent)
+        def method_name
+          if first_condition then
+            call_foo
+          else
+            if second_condition then
+              call_bar
+            else
+              call_bam if third_condition
+            end
+            call_baz if fourth_condition
+          end
+        end
+      END
       expect(cop.messages)
         .to eq(['Cyclomatic complexity for method_name is too high. [5/2]'])
     end

--- a/spec/rubocop/cop/metrics/line_length_spec.rb
+++ b/spec/rubocop/cop/metrics/line_length_spec.rb
@@ -125,12 +125,14 @@ describe RuboCop::Cop::Metrics::LineLength, :config do
     end
 
     let(:source) do
-      ['class ExampleTest < TestCase',
-       "  test 'some really long test description which exceeds length' do",
-       '  end',
-       '  def test_some_other_long_test_description_which_exceeds_length',
-       '  end',
-       'end']
+      <<-END.strip_indent
+        class ExampleTest < TestCase
+          test 'some really long test description which exceeds length' do
+          end
+          def test_some_other_long_test_description_which_exceeds_length
+          end
+        end
+      END
     end
 
     it 'accepts long lines matching a pattern but not other long lines' do

--- a/spec/rubocop/cop/metrics/method_length_spec.rb
+++ b/spec/rubocop/cop/metrics/method_length_spec.rb
@@ -5,14 +5,16 @@ describe RuboCop::Cop::Metrics::MethodLength, :config do
   let(:cop_config) { { 'Max' => 5, 'CountComments' => false } }
 
   it 'rejects a method with more than 5 lines' do
-    inspect_source(cop, ['def m()',
-                         '  a = 1',
-                         '  a = 2',
-                         '  a = 3',
-                         '  a = 4',
-                         '  a = 5',
-                         '  a = 6',
-                         'end'])
+    inspect_source(cop, <<-END.strip_indent)
+      def m()
+        a = 1
+        a = 2
+        a = 3
+        a = 4
+        a = 5
+        a = 6
+      end
+    END
     expect(cop.offenses.size).to eq(1)
     expect(cop.offenses.map(&:line).sort).to eq([1])
     expect(cop.config_to_allow_offenses).to eq('Max' => 6)
@@ -20,137 +22,159 @@ describe RuboCop::Cop::Metrics::MethodLength, :config do
   end
 
   it 'reports the correct beginning and end lines' do
-    inspect_source(cop, ['def m()',
-                         '  a = 1',
-                         '  a = 2',
-                         '  a = 3',
-                         '  a = 4',
-                         '  a = 5',
-                         '  a = 6',
-                         'end'])
+    inspect_source(cop, <<-END.strip_indent)
+      def m()
+        a = 1
+        a = 2
+        a = 3
+        a = 4
+        a = 5
+        a = 6
+      end
+    END
     offense = cop.offenses.first
     expect(offense.location.first_line).to eq(1)
     expect(offense.location.last_line).to eq(8)
   end
 
   it 'accepts a method with less than 5 lines' do
-    inspect_source(cop, ['def m()',
-                         '  a = 1',
-                         '  a = 2',
-                         '  a = 3',
-                         '  a = 4',
-                         'end'])
+    inspect_source(cop, <<-END.strip_indent)
+      def m()
+        a = 1
+        a = 2
+        a = 3
+        a = 4
+      end
+    END
     expect(cop.offenses).to be_empty
   end
 
   it 'accepts a method with multiline arguments ' \
      'and less than 5 lines of body' do
-    inspect_source(cop, ['def m(x,',
-                         '      y,',
-                         '      z)',
-                         '  a = 1',
-                         '  a = 2',
-                         '  a = 3',
-                         '  a = 4',
-                         'end'])
+    inspect_source(cop, <<-END.strip_indent)
+      def m(x,
+            y,
+            z)
+        a = 1
+        a = 2
+        a = 3
+        a = 4
+      end
+    END
     expect(cop.offenses).to be_empty
   end
 
   it 'does not count blank lines' do
-    inspect_source(cop, ['def m()',
-                         '  a = 1',
-                         '  a = 2',
-                         '  a = 3',
-                         '  a = 4',
-                         '',
-                         '',
-                         '  a = 7',
-                         'end'])
+    inspect_source(cop, <<-END.strip_indent)
+      def m()
+        a = 1
+        a = 2
+        a = 3
+        a = 4
+
+
+        a = 7
+      end
+    END
     expect(cop.offenses).to be_empty
   end
 
   it 'accepts empty methods' do
-    inspect_source(cop, ['def m()',
-                         'end'])
+    inspect_source(cop, <<-END.strip_indent)
+      def m()
+      end
+    END
     expect(cop.offenses).to be_empty
   end
 
   it 'is not fooled by one-liner methods, syntax #1' do
-    inspect_source(cop, ['def one_line; 10 end',
-                         'def self.m()',
-                         '  a = 1',
-                         '  a = 2',
-                         '  a = 4',
-                         '  a = 5',
-                         '  a = 6',
-                         'end'])
+    inspect_source(cop, <<-END.strip_indent)
+      def one_line; 10 end
+      def self.m()
+        a = 1
+        a = 2
+        a = 4
+        a = 5
+        a = 6
+      end
+    END
     expect(cop.offenses).to be_empty
   end
 
   it 'is not fooled by one-liner methods, syntax #2' do
-    inspect_source(cop, ['def one_line(test) 10 end',
-                         'def self.m()',
-                         '  a = 1',
-                         '  a = 2',
-                         '  a = 4',
-                         '  a = 5',
-                         '  a = 6',
-                         'end'])
+    inspect_source(cop, <<-END.strip_indent)
+      def one_line(test) 10 end
+      def self.m()
+        a = 1
+        a = 2
+        a = 4
+        a = 5
+        a = 6
+      end
+    END
     expect(cop.offenses).to be_empty
   end
 
   it 'checks class methods, syntax #1' do
-    inspect_source(cop, ['def self.m()',
-                         '  a = 1',
-                         '  a = 2',
-                         '  a = 3',
-                         '  a = 4',
-                         '  a = 5',
-                         '  a = 6',
-                         'end'])
+    inspect_source(cop, <<-END.strip_indent)
+      def self.m()
+        a = 1
+        a = 2
+        a = 3
+        a = 4
+        a = 5
+        a = 6
+      end
+    END
     expect(cop.offenses.size).to eq(1)
     expect(cop.offenses.map(&:line).sort).to eq([1])
   end
 
   it 'checks class methods, syntax #2' do
-    inspect_source(cop, ['class K',
-                         '  class << self',
-                         '    def m()',
-                         '      a = 1',
-                         '      a = 2',
-                         '      a = 3',
-                         '      a = 4',
-                         '      a = 5',
-                         '      a = 6',
-                         '    end',
-                         '  end',
-                         'end'])
+    inspect_source(cop, <<-END.strip_indent)
+      class K
+        class << self
+          def m()
+            a = 1
+            a = 2
+            a = 3
+            a = 4
+            a = 5
+            a = 6
+          end
+        end
+      end
+    END
     expect(cop.offenses.size).to eq(1)
     expect(cop.offenses.map(&:line).sort).to eq([3])
   end
 
   it 'properly counts lines when method ends with block' do
-    inspect_source(cop, ['def m()',
-                         '  something do',
-                         '    a = 2',
-                         '    a = 3',
-                         '    a = 4',
-                         '    a = 5',
-                         '  end',
-                         'end'])
+    inspect_source(cop, <<-END.strip_indent)
+      def m()
+        something do
+          a = 2
+          a = 3
+          a = 4
+          a = 5
+        end
+      end
+    END
     expect(cop.offenses.size).to eq(1)
     expect(cop.offenses.map(&:line).sort).to eq([1])
   end
 
   it 'does not count commented lines by default' do
-    inspect_source(cop, ['def m()',
-                         '  a = 1',
-                         '  #a = 2',
-                         '  a = 3',
-                         '  #a = 4',
-                         '  a = 5',
-                         '  a = 6',
-                         'end'])
+    inspect_source(cop, <<-END.strip_indent)
+      def m()
+        a = 1
+        #a = 2
+        a = 3
+        #a = 4
+        a = 5
+        a = 6
+      end
+    END
     expect(cop.offenses).to be_empty
   end
 
@@ -158,14 +182,16 @@ describe RuboCop::Cop::Metrics::MethodLength, :config do
     before { cop_config['CountComments'] = true }
 
     it 'also counts commented lines' do
-      inspect_source(cop, ['def m()',
-                           '  a = 1',
-                           '  #a = 2',
-                           '  a = 3',
-                           '  #a = 4',
-                           '  a = 5',
-                           '  a = 6',
-                           'end'])
+      inspect_source(cop, <<-END.strip_indent)
+        def m()
+          a = 1
+          #a = 2
+          a = 3
+          #a = 4
+          a = 5
+          a = 6
+        end
+      END
       expect(cop.offenses.size).to eq(1)
       expect(cop.offenses.map(&:line).sort).to eq([1])
     end

--- a/spec/rubocop/cop/metrics/module_length_spec.rb
+++ b/spec/rubocop/cop/metrics/module_length_spec.rb
@@ -5,175 +5,195 @@ describe RuboCop::Cop::Metrics::ModuleLength, :config do
   let(:cop_config) { { 'Max' => 5, 'CountComments' => false } }
 
   it 'rejects a module with more than 5 lines' do
-    inspect_source(cop, ['module Test',
-                         '  a = 1',
-                         '  a = 2',
-                         '  a = 3',
-                         '  a = 4',
-                         '  a = 5',
-                         '  a = 6',
-                         'end'])
+    inspect_source(cop, <<-END.strip_indent)
+      module Test
+        a = 1
+        a = 2
+        a = 3
+        a = 4
+        a = 5
+        a = 6
+      end
+    END
     expect(cop.offenses.size).to eq(1)
     expect(cop.messages).to eq(['Module has too many lines. [6/5]'])
     expect(cop.config_to_allow_offenses).to eq('Max' => 6)
   end
 
   it 'reports the correct beginning and end lines' do
-    inspect_source(cop, ['module Test',
-                         '  a = 1',
-                         '  a = 2',
-                         '  a = 3',
-                         '  a = 4',
-                         '  a = 5',
-                         '  a = 6',
-                         'end'])
+    inspect_source(cop, <<-END.strip_indent)
+      module Test
+        a = 1
+        a = 2
+        a = 3
+        a = 4
+        a = 5
+        a = 6
+      end
+    END
     offense = cop.offenses.first
     expect(offense.location.first_line).to eq(1)
     expect(offense.location.last_line).to eq(8)
   end
 
   it 'accepts a module with 5 lines' do
-    inspect_source(cop, ['module Test',
-                         '  a = 1',
-                         '  a = 2',
-                         '  a = 3',
-                         '  a = 4',
-                         '  a = 5',
-                         'end'])
+    inspect_source(cop, <<-END.strip_indent)
+      module Test
+        a = 1
+        a = 2
+        a = 3
+        a = 4
+        a = 5
+      end
+    END
     expect(cop.offenses).to be_empty
   end
 
   it 'accepts a module with less than 5 lines' do
-    inspect_source(cop, ['module Test',
-                         '  a = 1',
-                         '  a = 2',
-                         '  a = 3',
-                         '  a = 4',
-                         'end'])
+    inspect_source(cop, <<-END.strip_indent)
+      module Test
+        a = 1
+        a = 2
+        a = 3
+        a = 4
+      end
+    END
     expect(cop.offenses).to be_empty
   end
 
   it 'does not count blank lines' do
-    inspect_source(cop, ['module Test',
-                         '  a = 1',
-                         '  a = 2',
-                         '  a = 3',
-                         '  a = 4',
-                         '',
-                         '',
-                         '  a = 7',
-                         'end'])
+    inspect_source(cop, <<-END.strip_indent)
+      module Test
+        a = 1
+        a = 2
+        a = 3
+        a = 4
+
+
+        a = 7
+      end
+    END
     expect(cop.offenses).to be_empty
   end
 
   it 'accepts empty modules' do
-    inspect_source(cop, ['module Test',
-                         'end'])
+    inspect_source(cop, <<-END.strip_indent)
+      module Test
+      end
+    END
     expect(cop.offenses).to be_empty
   end
 
   context 'when a module has inner modules' do
     it 'does not count lines of inner modules' do
-      inspect_source(cop, ['module NamespaceModule',
-                           '  module TestOne',
-                           '    a = 1',
-                           '    a = 2',
-                           '    a = 3',
-                           '    a = 4',
-                           '    a = 5',
-                           '  end',
-                           '  module TestTwo',
-                           '    a = 1',
-                           '    a = 2',
-                           '    a = 3',
-                           '    a = 4',
-                           '    a = 5',
-                           '  end',
-                           '  a = 1',
-                           '  a = 2',
-                           '  a = 3',
-                           '  a = 4',
-                           '  a = 5',
-                           'end'])
+      inspect_source(cop, <<-END.strip_indent)
+        module NamespaceModule
+          module TestOne
+            a = 1
+            a = 2
+            a = 3
+            a = 4
+            a = 5
+          end
+          module TestTwo
+            a = 1
+            a = 2
+            a = 3
+            a = 4
+            a = 5
+          end
+          a = 1
+          a = 2
+          a = 3
+          a = 4
+          a = 5
+        end
+      END
       expect(cop.offenses).to be_empty
     end
 
     it 'rejects a module with 6 lines that belong to the module directly' do
-      inspect_source(cop, ['module NamespaceModule',
-                           '  module TestOne',
-                           '    a = 1',
-                           '    a = 2',
-                           '    a = 3',
-                           '    a = 4',
-                           '    a = 5',
-                           '  end',
-                           '  module TestTwo',
-                           '    a = 1',
-                           '    a = 2',
-                           '    a = 3',
-                           '    a = 4',
-                           '    a = 5',
-                           '  end',
-                           '  a = 1',
-                           '  a = 2',
-                           '  a = 3',
-                           '  a = 4',
-                           '  a = 5',
-                           '  a = 6',
-                           'end'])
+      inspect_source(cop, <<-END.strip_indent)
+        module NamespaceModule
+          module TestOne
+            a = 1
+            a = 2
+            a = 3
+            a = 4
+            a = 5
+          end
+          module TestTwo
+            a = 1
+            a = 2
+            a = 3
+            a = 4
+            a = 5
+          end
+          a = 1
+          a = 2
+          a = 3
+          a = 4
+          a = 5
+          a = 6
+        end
+      END
       expect(cop.offenses.size).to eq(1)
     end
   end
 
   context 'when a module has inner classes' do
     it 'does not count lines of inner classes' do
-      inspect_source(cop, ['module NamespaceModule',
-                           '  class TestOne',
-                           '    a = 1',
-                           '    a = 2',
-                           '    a = 3',
-                           '    a = 4',
-                           '    a = 5',
-                           '  end',
-                           '  class TestTwo',
-                           '    a = 1',
-                           '    a = 2',
-                           '    a = 3',
-                           '    a = 4',
-                           '    a = 5',
-                           '  end',
-                           '  a = 1',
-                           '  a = 2',
-                           '  a = 3',
-                           '  a = 4',
-                           '  a = 5',
-                           'end'])
+      inspect_source(cop, <<-END.strip_indent)
+        module NamespaceModule
+          class TestOne
+            a = 1
+            a = 2
+            a = 3
+            a = 4
+            a = 5
+          end
+          class TestTwo
+            a = 1
+            a = 2
+            a = 3
+            a = 4
+            a = 5
+          end
+          a = 1
+          a = 2
+          a = 3
+          a = 4
+          a = 5
+        end
+      END
       expect(cop.offenses).to be_empty
     end
 
     it 'rejects a module with 6 lines that belong to the module directly' do
-      inspect_source(cop, ['module NamespaceModule',
-                           '  class TestOne',
-                           '    a = 1',
-                           '    a = 2',
-                           '    a = 3',
-                           '    a = 4',
-                           '    a = 5',
-                           '  end',
-                           '  class TestTwo',
-                           '    a = 1',
-                           '    a = 2',
-                           '    a = 3',
-                           '    a = 4',
-                           '    a = 5',
-                           '  end',
-                           '  a = 1',
-                           '  a = 2',
-                           '  a = 3',
-                           '  a = 4',
-                           '  a = 5',
-                           '  a = 6',
-                           'end'])
+      inspect_source(cop, <<-END.strip_indent)
+        module NamespaceModule
+          class TestOne
+            a = 1
+            a = 2
+            a = 3
+            a = 4
+            a = 5
+          end
+          class TestTwo
+            a = 1
+            a = 2
+            a = 3
+            a = 4
+            a = 5
+          end
+          a = 1
+          a = 2
+          a = 3
+          a = 4
+          a = 5
+          a = 6
+        end
+      END
       expect(cop.offenses.size).to eq(1)
     end
   end
@@ -182,14 +202,16 @@ describe RuboCop::Cop::Metrics::ModuleLength, :config do
     before { cop_config['CountComments'] = true }
 
     it 'also counts commented lines' do
-      inspect_source(cop, ['module Test',
-                           '  a = 1',
-                           '  #a = 2',
-                           '  a = 3',
-                           '  #a = 4',
-                           '  a = 5',
-                           '  a = 6',
-                           'end'])
+      inspect_source(cop, <<-END.strip_indent)
+        module Test
+          a = 1
+          #a = 2
+          a = 3
+          #a = 4
+          a = 5
+          a = 6
+        end
+      END
       expect(cop.offenses.size).to eq(1)
     end
   end

--- a/spec/rubocop/cop/metrics/parameter_lists_spec.rb
+++ b/spec/rubocop/cop/metrics/parameter_lists_spec.rb
@@ -10,8 +10,10 @@ describe RuboCop::Cop::Metrics::ParameterLists, :config do
   end
 
   it 'registers an offense for a method def with 5 parameters' do
-    inspect_source(cop, ['def meth(a, b, c, d, e)',
-                         'end'])
+    inspect_source(cop, <<-END.strip_indent)
+      def meth(a, b, c, d, e)
+      end
+    END
     expect(cop.offenses.size).to eq(1)
     expect(cop.messages).to eq(
       ['Avoid parameter lists longer than 4 parameters. [5/4]']
@@ -20,15 +22,19 @@ describe RuboCop::Cop::Metrics::ParameterLists, :config do
   end
 
   it 'accepts a method def with 4 parameters' do
-    inspect_source(cop, ['def meth(a, b, c, d)',
-                         'end'])
+    inspect_source(cop, <<-END.strip_indent)
+      def meth(a, b, c, d)
+      end
+    END
     expect(cop.offenses).to be_empty
   end
 
   context 'When CountKeywordArgs is true' do
     it 'counts keyword arguments as well' do
-      inspect_source(cop, ['def meth(a, b, c, d: 1, e: 2)',
-                           'end'])
+      inspect_source(cop, <<-END.strip_indent)
+        def meth(a, b, c, d: 1, e: 2)
+        end
+      END
       expect(cop.messages).to eq(
         ['Avoid parameter lists longer than 4 parameters. [5/4]']
       )
@@ -40,14 +46,18 @@ describe RuboCop::Cop::Metrics::ParameterLists, :config do
     before { cop_config['CountKeywordArgs'] = false }
 
     it 'does not count keyword arguments' do
-      inspect_source(cop, ['def meth(a, b, c, d: 1, e: 2)',
-                           'end'])
+      inspect_source(cop, <<-END.strip_indent)
+        def meth(a, b, c, d: 1, e: 2)
+        end
+      END
       expect(cop.offenses).to be_empty
     end
 
     it 'does not count keyword arguments without default values', ruby: 2.1 do
-      inspect_source(cop, ['def meth(a, b, c, d:, e:)',
-                           'end'])
+      inspect_source(cop, <<-END.strip_indent)
+        def meth(a, b, c, d:, e:)
+        end
+      END
       expect(cop.offenses).to be_empty
     end
   end

--- a/spec/rubocop/cop/offense_spec.rb
+++ b/spec/rubocop/cop/offense_spec.rb
@@ -135,10 +135,12 @@ describe RuboCop::Cop::Offense do
   context 'offenses that span multiple lines' do
     let(:location) do
       source_buffer = Parser::Source::Buffer.new('test', 1)
-      source_buffer.source = ['def foo',
-                              '  something',
-                              '  something_else',
-                              'end'].join("\n")
+      source_buffer.source = <<-END.strip_indent
+        def foo
+          something
+          something_else
+        end
+      END
       Parser::Source::Range.new(source_buffer, 0, source_buffer.source.length)
     end
 
@@ -156,10 +158,12 @@ describe RuboCop::Cop::Offense do
   context 'offenses that span part of a line' do
     let(:location) do
       source_buffer = Parser::Source::Buffer.new('test', 1)
-      source_buffer.source = ['def Foo',
-                              '  something',
-                              '  something_else',
-                              'end'].join("\n")
+      source_buffer.source = <<-END.strip_indent
+        def Foo
+          something
+          something_else
+        end
+      END
       Parser::Source::Range.new(source_buffer, 4, 7)
     end
 

--- a/spec/rubocop/cop/performance/case_when_splat_spec.rb
+++ b/spec/rubocop/cop/performance/case_when_splat_spec.rb
@@ -4,75 +4,87 @@ describe RuboCop::Cop::Performance::CaseWhenSplat do
   subject(:cop) { described_class.new }
 
   it 'allows case when without splat' do
-    inspect_source(cop, ['case foo',
-                         'when 1',
-                         '  bar',
-                         'else',
-                         '  baz',
-                         'end'])
+    inspect_source(cop, <<-END.strip_indent)
+      case foo
+      when 1
+        bar
+      else
+        baz
+      end
+    END
 
     expect(cop.messages).to be_empty
   end
 
   it 'allows splat on a variable in the last when condition' do
-    inspect_source(cop, ['case foo',
-                         'when 4',
-                         '  foobar',
-                         'when *cond',
-                         '  bar',
-                         'else',
-                         '  baz',
-                         'end'])
+    inspect_source(cop, <<-END.strip_indent)
+      case foo
+      when 4
+        foobar
+      when *cond
+        bar
+      else
+        baz
+      end
+    END
 
     expect(cop.messages).to be_empty
   end
 
   it 'allows multiple splat conditions on variables at the end' do
-    inspect_source(cop, ['case foo',
-                         'when 4',
-                         '  foobar',
-                         'when *cond1',
-                         '  bar',
-                         'when *cond2',
-                         '  doo',
-                         'else',
-                         '  baz',
-                         'end'])
+    inspect_source(cop, <<-END.strip_indent)
+      case foo
+      when 4
+        foobar
+      when *cond1
+        bar
+      when *cond2
+        doo
+      else
+        baz
+      end
+    END
 
     expect(cop.messages).to be_empty
   end
 
   it 'registers an offense for case when with a splat in the first condition' do
-    inspect_source(cop, ['case foo',
-                         'when *cond',
-                         '  bar',
-                         'when 4',
-                         '  foobar',
-                         'else',
-                         '  baz',
-                         'end'])
+    inspect_source(cop, <<-END.strip_indent)
+      case foo
+      when *cond
+        bar
+      when 4
+        foobar
+      else
+        baz
+      end
+    END
 
     expect(cop.messages).to eq([described_class::MSG])
     expect(cop.highlights).to eq(['when *cond'])
   end
 
   it 'registers an offense for case when with a splat without an else' do
-    inspect_source(cop, ['case foo',
-                         'when *baz',
-                         '  bar',
-                         'when 4',
-                         '  foobar',
-                         'end'])
+    inspect_source(cop, <<-END.strip_indent)
+      case foo
+      when *baz
+        bar
+      when 4
+        foobar
+      end
+    END
 
     expect(cop.messages).to eq([described_class::MSG])
     expect(cop.highlights).to eq(['when *baz'])
   end
 
   it 'registers an offense for splat conditions in when then' do
-    inspect_source(cop, ['case foo',
-                         'when *cond then bar',
-                         'when 4 then baz',
-                         'end'])
+    inspect_source(cop, <<-END.strip_indent)
+      case foo
+      when *cond then bar
+      when 4 then baz
+      end
+    END
 
     expect(cop.messages).to eq([described_class::MSG])
     expect(cop.highlights).to eq(['when *cond'])
@@ -80,110 +92,126 @@ describe RuboCop::Cop::Performance::CaseWhenSplat do
 
   it 'registers an offense for a single when with splat expansion followed ' \
      'by another value' do
-    inspect_source(cop, ['case foo',
-                         'when *Foo, Bar',
-                         '  nil',
-                         'end'])
+    inspect_source(cop, <<-END.strip_indent)
+      case foo
+      when *Foo, Bar
+        nil
+      end
+    END
     expect(cop.messages).to eq([described_class::MSG])
     expect(cop.highlights).to eq(['when *Foo'])
   end
 
   it 'registers an offense for multiple splat conditions at the beginning' do
-    inspect_source(cop, ['case foo',
-                         'when *cond1',
-                         '  bar',
-                         'when *cond2',
-                         '  doo',
-                         'when 4',
-                         '  foobar',
-                         'else',
-                         '  baz',
-                         'end'])
+    inspect_source(cop, <<-END.strip_indent)
+      case foo
+      when *cond1
+        bar
+      when *cond2
+        doo
+      when 4
+        foobar
+      else
+        baz
+      end
+    END
 
     expect(cop.messages).to eq([described_class::MSG, described_class::MSG])
     expect(cop.highlights).to eq(['when *cond1', 'when *cond2'])
   end
 
   it 'registers an offense for multiple out of order splat conditions' do
-    inspect_source(cop, ['case foo',
-                         'when *cond1',
-                         '  bar',
-                         'when 8',
-                         '  barfoo',
-                         'when *SOME_CONSTANT',
-                         '  doo',
-                         'when 4',
-                         '  foobar',
-                         'else',
-                         '  baz',
-                         'end'])
+    inspect_source(cop, <<-END.strip_indent)
+      case foo
+      when *cond1
+        bar
+      when 8
+        barfoo
+      when *SOME_CONSTANT
+        doo
+      when 4
+        foobar
+      else
+        baz
+      end
+    END
 
     expect(cop.messages).to eq([described_class::MSG, described_class::MSG])
     expect(cop.highlights).to eq(['when *cond1', 'when *SOME_CONSTANT'])
   end
 
   it 'registers an offense for splat condition that do not appear at the end' do
-    inspect_source(cop, ['case foo',
-                         'when *cond1',
-                         '  bar',
-                         'when 8',
-                         '  barfoo',
-                         'when *cond2',
-                         '  doo',
-                         'when 4',
-                         '  foobar',
-                         'when *cond3',
-                         '  doofoo',
-                         'else',
-                         '  baz',
-                         'end'])
+    inspect_source(cop, <<-END.strip_indent)
+      case foo
+      when *cond1
+        bar
+      when 8
+        barfoo
+      when *cond2
+        doo
+      when 4
+        foobar
+      when *cond3
+        doofoo
+      else
+        baz
+      end
+    END
 
     expect(cop.messages).to eq([described_class::MSG, described_class::MSG])
     expect(cop.highlights).to eq(['when *cond1', 'when *cond2'])
   end
 
   it 'allows splat expansion on an array literal' do
-    inspect_source(cop, ['case foo',
-                         'when *[1, 2]',
-                         '  bar',
-                         'when *[3, 4]',
-                         '  bar',
-                         'when 5',
-                         '  baz',
-                         'end'])
+    inspect_source(cop, <<-END.strip_indent)
+      case foo
+      when *[1, 2]
+        bar
+      when *[3, 4]
+        bar
+      when 5
+        baz
+      end
+    END
 
     expect(cop.offenses).to be_empty
   end
 
   it 'allows splat expansion on array literal as the last condition' do
-    inspect_source(cop, ['case foo',
-                         'when *[1, 2]',
-                         '  bar',
-                         'end'])
+    inspect_source(cop, <<-END.strip_indent)
+      case foo
+      when *[1, 2]
+        bar
+      end
+    END
 
     expect(cop.offenses).to be_empty
   end
 
   it 'registers an offense for a splat on a variable that proceeds a splat ' \
      'on an array literal as the last condition' do
-    inspect_source(cop, ['case foo',
-                         'when *cond',
-                         '  bar',
-                         'when *[1, 2]',
-                         '  baz',
-                         'end'])
+    inspect_source(cop, <<-END.strip_indent)
+      case foo
+      when *cond
+        bar
+      when *[1, 2]
+        baz
+      end
+    END
 
     expect(cop.messages).to eq([described_class::MSG])
     expect(cop.highlights).to eq(['when *cond'])
   end
 
   it 'registers an offense when splat is part of the condition' do
-    inspect_source(cop, ['case foo',
-                         'when cond1, *cond2',
-                         '  bar',
-                         'when cond3',
-                         '  baz',
-                         'end'])
+    inspect_source(cop, <<-END.strip_indent)
+      case foo
+      when cond1, *cond2
+        bar
+      when cond3
+        baz
+      end
+    END
 
     expect(cop.messages).to eq([described_class::MSG])
     expect(cop.highlights).to eq(['when cond1, *cond2'])
@@ -192,216 +220,264 @@ describe RuboCop::Cop::Performance::CaseWhenSplat do
   context 'autocorrect' do
     it 'corrects a single when with splat expansion followed by ' \
       'another value' do
-      source = ['case foo',
-                'when *Foo, Bar, Baz',
-                '  nil',
-                'end']
+      source = <<-END.strip_indent
+        case foo
+        when *Foo, Bar, Baz
+          nil
+        end
+      END
       new_source = autocorrect_source(cop, source)
-      expect(new_source).to eq(['case foo',
-                                'when Bar, Baz, *Foo',
-                                '  nil',
-                                'end'].join("\n"))
+      expect(new_source).to eq(<<-END.strip_indent)
+        case foo
+        when Bar, Baz, *Foo
+          nil
+        end
+      END
     end
 
     it 'corrects a when with splat expansion followed by another value ' \
       'when there are multiple whens' do
-      source = ['case foo',
-                'when *Foo, Bar',
-                '  nil',
-                'when FooBar',
-                '  1',
-                'end']
+      source = <<-END.strip_indent
+        case foo
+        when *Foo, Bar
+          nil
+        when FooBar
+          1
+        end
+      END
       new_source = autocorrect_source(cop, source)
-      expect(new_source).to eq(['case foo',
-                                'when FooBar',
-                                '  1',
-                                'when Bar, *Foo',
-                                '  nil',
-                                'end'].join("\n"))
+      expect(new_source).to eq(<<-END.strip_indent)
+        case foo
+        when FooBar
+          1
+        when Bar, *Foo
+          nil
+        end
+      END
     end
 
     it 'corrects a when with multiple out of order splat expansions ' \
       'followed by other values when there are multiple whens' do
-      source = ['case foo',
-                'when *Foo, Bar, *Baz, Qux',
-                '  nil',
-                'when FooBar',
-                '  1',
-                'end']
+      source = <<-END.strip_indent
+        case foo
+        when *Foo, Bar, *Baz, Qux
+          nil
+        when FooBar
+          1
+        end
+      END
       new_source = autocorrect_source(cop, source)
-      expect(new_source).to eq(['case foo',
-                                'when FooBar',
-                                '  1',
-                                'when Bar, Qux, *Foo, *Baz',
-                                '  nil',
-                                'end'].join("\n"))
+      expect(new_source).to eq(<<-END.strip_indent)
+        case foo
+        when FooBar
+          1
+        when Bar, Qux, *Foo, *Baz
+          nil
+        end
+      END
     end
 
     it 'moves a single splat condition to the end of the when conditions' do
-      new_source = autocorrect_source(cop, ['case foo',
-                                            'when *cond',
-                                            '  bar',
-                                            'when 3',
-                                            '  baz',
-                                            'end'])
+      new_source = autocorrect_source(cop, <<-END.strip_indent)
+        case foo
+        when *cond
+          bar
+        when 3
+          baz
+        end
+      END
 
-      expect(new_source).to eq(['case foo',
-                                'when 3',
-                                '  baz',
-                                'when *cond',
-                                '  bar',
-                                'end'].join("\n"))
+      expect(new_source).to eq(<<-END.strip_indent)
+        case foo
+        when 3
+          baz
+        when *cond
+          bar
+        end
+      END
     end
 
     it 'moves multiple splat condition to the end of the when conditions' do
-      new_source = autocorrect_source(cop, ['case foo',
-                                            'when *cond1',
-                                            '  bar',
-                                            'when *cond2',
-                                            '  foobar',
-                                            'when 5',
-                                            '  baz',
-                                            'end'])
+      new_source = autocorrect_source(cop, <<-END.strip_indent)
+        case foo
+        when *cond1
+          bar
+        when *cond2
+          foobar
+        when 5
+          baz
+        end
+      END
 
       # CaseWhenSplat requires multiple rounds of correction to avoid
       # "clobbering errors" from Source::Rewriter
       cop = described_class.new
       new_source = autocorrect_source(cop, new_source)
 
-      expect(new_source).to eq(['case foo',
-                                'when 5',
-                                '  baz',
-                                'when *cond1',
-                                '  bar',
-                                'when *cond2',
-                                '  foobar',
-                                'end'].join("\n"))
+      expect(new_source).to eq(<<-END.strip_indent)
+        case foo
+        when 5
+          baz
+        when *cond1
+          bar
+        when *cond2
+          foobar
+        end
+      END
     end
 
     it 'moves multiple out of order splat condition to the end ' \
        'of the when conditions' do
-      new_source = autocorrect_source(cop, ['case foo',
-                                            'when *cond1',
-                                            '  bar',
-                                            'when 3',
-                                            '  doo',
-                                            'when *cond2',
-                                            '  foobar',
-                                            'when 6',
-                                            '  baz',
-                                            'end'])
+      new_source = autocorrect_source(cop, <<-END.strip_indent)
+        case foo
+        when *cond1
+          bar
+        when 3
+          doo
+        when *cond2
+          foobar
+        when 6
+          baz
+        end
+      END
 
       # CaseWhenSplat requires multiple rounds of correction to avoid
       # "clobbering errors" from Source::Rewriter
       cop = described_class.new
       new_source = autocorrect_source(cop, new_source)
 
-      expect(new_source).to eq(['case foo',
-                                'when 3',
-                                '  doo',
-                                'when 6',
-                                '  baz',
-                                'when *cond1',
-                                '  bar',
-                                'when *cond2',
-                                '  foobar',
-                                'end'].join("\n"))
+      expect(new_source).to eq(<<-END.strip_indent)
+        case foo
+        when 3
+          doo
+        when 6
+          baz
+        when *cond1
+          bar
+        when *cond2
+          foobar
+        end
+      END
     end
 
     it 'corrects splat condition when using when then' do
-      new_source = autocorrect_source(cop, ['case foo',
-                                            'when *cond then bar',
-                                            'when 4 then baz',
-                                            'end'])
+      new_source = autocorrect_source(cop, <<-END.strip_indent)
+        case foo
+        when *cond then bar
+        when 4 then baz
+        end
+      END
 
-      expect(new_source).to eq(['case foo',
-                                'when 4 then baz',
-                                'when *cond then bar',
-                                'end'].join("\n"))
+      expect(new_source).to eq(<<-END.strip_indent)
+        case foo
+        when 4 then baz
+        when *cond then bar
+        end
+      END
     end
 
     it 'corrects nested case when statements' do
-      new_source = autocorrect_source(cop, ['def check',
-                                            '  case foo',
-                                            '  when *cond',
-                                            '    bar',
-                                            '  when 3',
-                                            '    baz',
-                                            '  end',
-                                            'end'])
+      new_source = autocorrect_source(cop, <<-END.strip_indent)
+        def check
+          case foo
+          when *cond
+            bar
+          when 3
+            baz
+          end
+        end
+      END
 
-      expect(new_source).to eq(['def check',
-                                '  case foo',
-                                '  when 3',
-                                '    baz',
-                                '  when *cond',
-                                '    bar',
-                                '  end',
-                                'end'].join("\n"))
+      expect(new_source).to eq(<<-END.strip_indent)
+        def check
+          case foo
+          when 3
+            baz
+          when *cond
+            bar
+          end
+        end
+      END
     end
 
     it 'corrects splat on a variable and leaves an array literal alone' do
-      new_source = autocorrect_source(cop, ['case foo',
-                                            'when *cond',
-                                            '  bar',
-                                            'when *[1, 2]',
-                                            '  baz',
-                                            'end'])
+      new_source = autocorrect_source(cop, <<-END.strip_indent)
+        case foo
+        when *cond
+          bar
+        when *[1, 2]
+          baz
+        end
+      END
 
-      expect(new_source).to eq(['case foo',
-                                'when *[1, 2]',
-                                '  baz',
-                                'when *cond',
-                                '  bar',
-                                'end'].join("\n"))
+      expect(new_source).to eq(<<-END.strip_indent)
+        case foo
+        when *[1, 2]
+          baz
+        when *cond
+          bar
+        end
+      END
     end
 
     it 'corrects a splat as part of the condition' do
-      new_source = autocorrect_source(cop, ['case foo',
-                                            'when cond1, *cond2',
-                                            '  bar',
-                                            'when cond3',
-                                            '  baz',
-                                            'end'])
+      new_source = autocorrect_source(cop, <<-END.strip_indent)
+        case foo
+        when cond1, *cond2
+          bar
+        when cond3
+          baz
+        end
+      END
 
-      expect(new_source).to eq(['case foo',
-                                'when cond3',
-                                '  baz',
-                                'when cond1, *cond2',
-                                '  bar',
-                                'end'].join("\n"))
+      expect(new_source).to eq(<<-END.strip_indent)
+        case foo
+        when cond3
+          baz
+        when cond1, *cond2
+          bar
+        end
+      END
     end
 
     it 'corrects an array followed by splat in the same condition' do
-      new_source = autocorrect_source(cop, ['case foo',
-                                            'when *[cond1, cond2], *cond3',
-                                            '  bar',
-                                            'when cond4',
-                                            '  baz',
-                                            'end'])
+      new_source = autocorrect_source(cop, <<-END.strip_indent)
+        case foo
+        when *[cond1, cond2], *cond3
+          bar
+        when cond4
+          baz
+        end
+      END
 
-      expect(new_source).to eq(['case foo',
-                                'when cond4',
-                                '  baz',
-                                'when *[cond1, cond2], *cond3',
-                                '  bar',
-                                'end'].join("\n"))
+      expect(new_source).to eq(<<-END.strip_indent)
+        case foo
+        when cond4
+          baz
+        when *[cond1, cond2], *cond3
+          bar
+        end
+      END
     end
 
     it 'corrects a splat followed by array in the same condition' do
-      new_source = autocorrect_source(cop, ['case foo',
-                                            'when *cond1, *[cond2, cond3]',
-                                            '  bar',
-                                            'when cond4',
-                                            '  baz',
-                                            'end'])
+      new_source = autocorrect_source(cop, <<-END.strip_indent)
+        case foo
+        when *cond1, *[cond2, cond3]
+          bar
+        when cond4
+          baz
+        end
+      END
 
-      expect(new_source).to eq(['case foo',
-                                'when cond4',
-                                '  baz',
-                                'when *cond1, *[cond2, cond3]',
-                                '  bar',
-                                'end'].join("\n"))
+      expect(new_source).to eq(<<-END.strip_indent)
+        case foo
+        when cond4
+          baz
+        when *cond1, *[cond2, cond3]
+          bar
+        end
+      END
     end
   end
 end

--- a/spec/rubocop/cop/performance/casecmp_spec.rb
+++ b/spec/rubocop/cop/performance/casecmp_spec.rb
@@ -101,14 +101,18 @@ describe RuboCop::Cop::Performance::Casecmp do
     end
 
     it "doesn't report an offense for variable == str.#{selector}" do
-      inspect_source(cop, ['var = "a"',
-                           "var == str.#{selector}"])
+      inspect_source(cop, <<-END.strip_indent)
+        var = "a"
+        var == str.#{selector}
+      END
       expect(cop.offenses).to be_empty
     end
 
     it "doesn't report an offense for str.#{selector} == variable" do
-      inspect_source(cop, ['var = "a"',
-                           "str.#{selector} == var"])
+      inspect_source(cop, <<-END.strip_indent)
+        var = "a"
+        str.#{selector} == var
+      END
       expect(cop.offenses).to be_empty
     end
 

--- a/spec/rubocop/cop/performance/compare_with_block_spec.rb
+++ b/spec/rubocop/cop/performance/compare_with_block_spec.rb
@@ -37,10 +37,12 @@ describe RuboCop::Cop::Performance::CompareWithBlock do
     end
 
     it "autocorrects array.#{method} do |a, b| a.foo <=> b.foo end" do
-      new_source = autocorrect_source(cop, ["array.#{method} do |a, b|",
-                                            '  a.foo <=> b.foo',
-                                            'end'])
-      expect(new_source).to eq "array.#{method}_by(&:foo)"
+      new_source = autocorrect_source(cop, <<-END.strip_indent)
+        array.#{method} do |a, b|
+          a.foo <=> b.foo
+        end
+      END
+      expect(new_source).to eq "array.#{method}_by(&:foo)\n"
     end
 
     it 'formats the error message correctly for ' \

--- a/spec/rubocop/cop/performance/count_spec.rb
+++ b/spec/rubocop/cop/performance/count_spec.rb
@@ -67,9 +67,11 @@ describe RuboCop::Cop::Performance::Count do
     end
 
     it "registers an offense for #{selector} with params instead of a block" do
-      inspect_source(cop, ['Data = Struct.new(:value)',
-                           'array = [Data.new(2), Data.new(3), Data.new(2)]',
-                           "puts array.#{selector}(&:value).count"].join("\n"))
+      inspect_source(cop, <<-END.strip_indent)
+        Data = Struct.new(:value)
+        array = [Data.new(2), Data.new(3), Data.new(2)]
+        puts array.#{selector}(&:value).count
+      END
 
       expect(cop.messages)
         .to eq(["Use `count` instead of `#{selector}...count`."])
@@ -86,11 +88,13 @@ describe RuboCop::Cop::Performance::Count do
 
     it "registers an offense for #{selector}(&:something).count " \
        'when called as an instance method on its own class' do
-      source = ['class A < Array',
-                '  def count(&block)',
-                "    #{selector}(&block).count",
-                '  end',
-                'end']
+      source = <<-END.strip_indent
+        class A < Array
+          def count(&block)
+            #{selector}(&block).count
+          end
+        end
+      END
       inspect_source(cop, source)
 
       expect(cop.messages)
@@ -177,25 +181,31 @@ describe RuboCop::Cop::Performance::Count do
   end
 
   it 'allows usage of count on an interstitial method called on select' do
-    inspect_source(cop, ['Data = Struct.new(:value)',
-                         'array = [Data.new(2), Data.new(3), Data.new(2)]',
-                         'puts array.select(&:value).uniq.count'].join("\n"))
+    inspect_source(cop, <<-END.strip_indent)
+      Data = Struct.new(:value)
+      array = [Data.new(2), Data.new(3), Data.new(2)]
+      puts array.select(&:value).uniq.count
+    END
 
     expect(cop.messages).to be_empty
   end
 
   it 'allows usage of count on an interstitial method with blocks ' \
      'called on select' do
-    inspect_source(cop, ['Data = Struct.new(:value)',
-                         'array = [Data.new(2), Data.new(3), Data.new(2)]',
-                         'array.select(&:value).uniq { |v| v > 2 }.count'])
+    inspect_source(cop, <<-END.strip_indent)
+      Data = Struct.new(:value)
+      array = [Data.new(2), Data.new(3), Data.new(2)]
+      array.select(&:value).uniq { |v| v > 2 }.count
+    END
 
     expect(cop.messages).to be_empty
   end
 
   it 'allows usage of size called on an assigned variable' do
-    inspect_source(cop, ['nodes = [1]',
-                         'nodes.size'].join("\n"))
+    inspect_source(cop, <<-END.strip_indent)
+      nodes = [1]
+      nodes.size
+    END
 
     expect(cop.messages).to be_empty
   end
@@ -241,16 +251,20 @@ describe RuboCop::Cop::Performance::Count do
       end
 
       it 'select...size when select has parameters' do
-        source = ['Data = Struct.new(:value)',
-                  'array = [Data.new(2), Data.new(3), Data.new(2)]',
-                  'puts array.select(&:value).size'].join("\n")
+        source = <<-END.strip_indent
+          Data = Struct.new(:value)
+          array = [Data.new(2), Data.new(3), Data.new(2)]
+          puts array.select(&:value).size
+        END
 
         new_source = autocorrect_source(cop, source)
 
         expect(new_source)
-          .to eq(['Data = Struct.new(:value)',
-                  'array = [Data.new(2), Data.new(3), Data.new(2)]',
-                  'puts array.count(&:value)'].join("\n"))
+          .to eq(<<-END.strip_indent)
+            Data = Struct.new(:value)
+            array = [Data.new(2), Data.new(3), Data.new(2)]
+            puts array.count(&:value)
+          END
       end
     end
 
@@ -283,9 +297,11 @@ describe RuboCop::Cop::Performance::Count do
       end
 
       it 'reject...size when select has parameters' do
-        source = ['Data = Struct.new(:value)',
-                  'array = [Data.new(2), Data.new(3), Data.new(2)]',
-                  'puts array.reject(&:value).size'].join("\n")
+        source = <<-END.strip_indent
+          Data = Struct.new(:value)
+          array = [Data.new(2), Data.new(3), Data.new(2)]
+          puts array.reject(&:value).size
+        END
 
         new_source = autocorrect_source(cop, source)
 

--- a/spec/rubocop/cop/performance/detect_spec.rb
+++ b/spec/rubocop/cop/performance/detect_spec.rb
@@ -44,17 +44,21 @@ describe RuboCop::Cop::Performance::Detect do
     end
 
     it "registers an offense when first is called on multiline #{method}" do
-      inspect_source(cop, ["[1, 2, 3].#{method} do |i|",
-                           '  i % 2 == 0',
-                           'end.first'])
+      inspect_source(cop, <<-END.strip_indent)
+        [1, 2, 3].#{method} do |i|
+          i % 2 == 0
+        end.first
+      END
 
       expect(cop.messages).to eq(["Use `detect` instead of `#{method}.first`."])
     end
 
     it "registers an offense when last is called on multiline #{method}" do
-      inspect_source(cop, ["[1, 2, 3].#{method} do |i|",
-                           '  i % 2 == 0',
-                           'end.last'])
+      inspect_source(cop, <<-END.strip_indent)
+        [1, 2, 3].#{method} do |i|
+          i % 2 == 0
+        end.last
+      END
 
       expect(cop.messages)
         .to eq(["Use `reverse.detect` instead of `#{method}.last`."])
@@ -159,47 +163,59 @@ describe RuboCop::Cop::Performance::Detect do
           end
 
           it "corrects #{method}.first to #{preferred_method} (multiline)" do
-            source = ["[1, 2, 3].#{method} do |i|",
-                      '  i % 2 == 0',
-                      'end.first']
+            source = <<-END.strip_indent
+              [1, 2, 3].#{method} do |i|
+                i % 2 == 0
+              end.first
+            END
             new_source = autocorrect_source(cop, source)
 
-            expect(new_source).to eq(["[1, 2, 3].#{preferred_method} do |i|",
-                                      '  i % 2 == 0',
-                                      'end'].join("\n"))
+            expect(new_source).to eq(<<-END.strip_indent)
+              [1, 2, 3].#{preferred_method} do |i|
+                i % 2 == 0
+              end
+            END
           end
 
           it "corrects #{method}.last to reverse.#{preferred_method} " \
              '(multiline)' do
-            source = ["[1, 2, 3].#{method} do |i|",
-                      '  i % 2 == 0',
-                      'end.last']
+            source = <<-END.strip_indent
+              [1, 2, 3].#{method} do |i|
+                i % 2 == 0
+              end.last
+            END
             new_source = autocorrect_source(cop, source)
 
             expect(new_source)
-              .to eq(["[1, 2, 3].reverse.#{preferred_method} do |i|",
-                      '  i % 2 == 0',
-                      'end'].join("\n"))
+              .to eq(<<-END.strip_indent)
+                [1, 2, 3].reverse.#{preferred_method} do |i|
+                  i % 2 == 0
+                end
+              END
           end
 
           it "corrects multiline #{method} to #{preferred_method} " \
              "with 'first' on the last line" do
-            source = ["[1, 2, 3].#{method} { true }",
-                      ".first['x']"]
+            source = <<-END.strip_indent
+              [1, 2, 3].#{method} { true }
+              .first['x']
+            END
             new_source = autocorrect_source(cop, source)
 
             expect(new_source)
-              .to eq("[1, 2, 3].#{preferred_method} { true }['x']")
+              .to eq("[1, 2, 3].#{preferred_method} { true }['x']\n")
           end
 
           it "corrects multiline #{method} to #{preferred_method} " \
              "with 'first' on the last line (short syntax)" do
-            source = ["[1, 2, 3].#{method}(&:blank?)",
-                      ".first['x']"]
+            source = <<-END.strip_indent
+              [1, 2, 3].#{method}(&:blank?)
+              .first['x']
+            END
             new_source = autocorrect_source(cop, source)
 
             expect(new_source)
-              .to eq("[1, 2, 3].#{preferred_method}(&:blank?)['x']")
+              .to eq("[1, 2, 3].#{preferred_method}(&:blank?)['x']\n")
           end
         end
       end

--- a/spec/rubocop/cop/performance/fixed_size_spec.rb
+++ b/spec/rubocop/cop/performance/fixed_size_spec.rb
@@ -80,8 +80,10 @@ describe RuboCop::Cop::Performance::FixedSize do
       end
 
       it "accepts calling #{method} on a variable " do
-        inspect_source(cop, ['foo = "abc"',
-                             "foo.#{method}"])
+        inspect_source(cop, <<-END.strip_indent)
+          foo = "abc"
+          foo.#{method}
+        END
 
         expect(cop.messages).to be_empty
       end
@@ -147,8 +149,10 @@ describe RuboCop::Cop::Performance::FixedSize do
       end
 
       it "accepts calling #{method} on array that is set to a variable" do
-        inspect_source(cop, ['foo = [1, 2, 3]',
-                             "foo.#{method}"])
+        inspect_source(cop, <<-END.strip_indent)
+          foo = [1, 2, 3]
+          foo.#{method}
+        END
 
         expect(cop.messages).to be_empty
       end
@@ -169,8 +173,10 @@ describe RuboCop::Cop::Performance::FixedSize do
       end
 
       it "accepts calling #{method} on a hash set to a variable" do
-        inspect_source(cop, ['foo = {a: 1, b: 2}',
-                             "foo.#{method}"])
+        inspect_source(cop, <<-END.strip_indent)
+          foo = {a: 1, b: 2}
+          foo.#{method}
+        END
 
         expect(cop.messages).to be_empty
       end

--- a/spec/rubocop/cop/performance/redundant_block_call_spec.rb
+++ b/spec/rubocop/cop/performance/redundant_block_call_spec.rb
@@ -4,134 +4,178 @@ describe RuboCop::Cop::Performance::RedundantBlockCall do
   subject(:cop) { described_class.new }
 
   it 'autocorrects block.call without arguments' do
-    new_source = autocorrect_source(cop, ['def method(&block)',
-                                          '  block.call',
-                                          'end'])
-    expect(new_source).to eq(['def method(&block)',
-                              '  yield',
-                              'end'].join("\n"))
+    new_source = autocorrect_source(cop, <<-END.strip_indent)
+      def method(&block)
+        block.call
+      end
+    END
+    expect(new_source).to eq(<<-END.strip_indent)
+      def method(&block)
+        yield
+      end
+    END
   end
 
   it 'autocorrects block.call with empty parentheses' do
-    new_source = autocorrect_source(cop, ['def method(&block)',
-                                          '  block.call()',
-                                          'end'])
-    expect(new_source).to eq(['def method(&block)',
-                              '  yield',
-                              'end'].join("\n"))
+    new_source = autocorrect_source(cop, <<-END.strip_indent)
+      def method(&block)
+        block.call()
+      end
+    END
+    expect(new_source).to eq(<<-END.strip_indent)
+      def method(&block)
+        yield
+      end
+    END
   end
 
   it 'autocorrects block.call with arguments' do
-    new_source = autocorrect_source(cop, ['def method(&block)',
-                                          '  block.call 1, 2',
-                                          'end'])
-    expect(new_source).to eq(['def method(&block)',
-                              '  yield 1, 2',
-                              'end'].join("\n"))
+    new_source = autocorrect_source(cop, <<-END.strip_indent)
+      def method(&block)
+        block.call 1, 2
+      end
+    END
+    expect(new_source).to eq(<<-END.strip_indent)
+      def method(&block)
+        yield 1, 2
+      end
+    END
   end
 
   it 'autocorrects multiple occurances of block.call with arguments' do
-    new_source = autocorrect_source(cop, ['def method(&block)',
-                                          '  block.call 1',
-                                          '  block.call 2',
-                                          'end'])
-    expect(new_source).to eq(['def method(&block)',
-                              '  yield 1',
-                              '  yield 2',
-                              'end'].join("\n"))
+    new_source = autocorrect_source(cop, <<-END.strip_indent)
+      def method(&block)
+        block.call 1
+        block.call 2
+      end
+    END
+    expect(new_source).to eq(<<-END.strip_indent)
+      def method(&block)
+        yield 1
+        yield 2
+      end
+    END
   end
 
   it 'autocorrects even when block arg has a different name' do
-    new_source = autocorrect_source(cop, ['def method(&func)',
-                                          '  func.call',
-                                          'end'])
-    expect(new_source).to eq(['def method(&func)',
-                              '  yield',
-                              'end'].join("\n"))
+    new_source = autocorrect_source(cop, <<-END.strip_indent)
+      def method(&func)
+        func.call
+      end
+    END
+    expect(new_source).to eq(<<-END.strip_indent)
+      def method(&func)
+        yield
+      end
+    END
   end
 
   it 'accepts a block that is not `call`ed' do
-    inspect_source(cop, ['def method(&block)',
-                         ' something.call',
-                         'end'])
+    inspect_source(cop, <<-END.strip_indent)
+      def method(&block)
+       something.call
+      end
+    END
     expect(cop.messages).to be_empty
   end
 
   it 'accepts an empty method body' do
-    inspect_source(cop, ['def method(&block)',
-                         'end'])
+    inspect_source(cop, <<-END.strip_indent)
+      def method(&block)
+      end
+    END
     expect(cop.messages).to be_empty
   end
 
   it 'accepts another block being passed as the only arg' do
-    inspect_source(cop, ['def method(&block)',
-                         '  block.call(&some_proc)',
-                         'end'])
+    inspect_source(cop, <<-END.strip_indent)
+      def method(&block)
+        block.call(&some_proc)
+      end
+    END
     expect(cop.messages).to be_empty
   end
 
   it 'accepts another block being passed along with other args' do
-    inspect_source(cop, ['def method(&block)',
-                         '  block.call(1, &some_proc)',
-                         'end'])
+    inspect_source(cop, <<-END.strip_indent)
+      def method(&block)
+        block.call(1, &some_proc)
+      end
+    END
     expect(cop.messages).to be_empty
   end
 
   it 'accepts another block arg in at least one occurance of block.call' do
-    inspect_source(cop, ['def method(&block)',
-                         '  block.call(1, &some_proc)',
-                         '  block.call(2)',
-                         'end'])
+    inspect_source(cop, <<-END.strip_indent)
+      def method(&block)
+        block.call(1, &some_proc)
+        block.call(2)
+      end
+    END
     expect(cop.messages).to be_empty
   end
 
   it 'accepts an optional block that is defaulted' do
-    inspect_source(cop, ['def method(&block)',
-                         '  block ||= ->(i) { puts i }',
-                         '  block.call(1)',
-                         'end'])
+    inspect_source(cop, <<-END.strip_indent)
+      def method(&block)
+        block ||= ->(i) { puts i }
+        block.call(1)
+      end
+    END
     expect(cop.messages).to be_empty
   end
 
   it 'accepts an optional block that is overridden' do
-    inspect_source(cop, ['def method(&block)',
-                         '  block = ->(i) { puts i }',
-                         '  block.call(1)',
-                         'end'])
+    inspect_source(cop, <<-END.strip_indent)
+      def method(&block)
+        block = ->(i) { puts i }
+        block.call(1)
+      end
+    END
     expect(cop.messages).to be_empty
   end
 
   it 'formats the error message for func.call(1) correctly' do
-    inspect_source(cop, ['def method(&func)',
-                         '  func.call(1)',
-                         'end'])
+    inspect_source(cop, <<-END.strip_indent)
+      def method(&func)
+        func.call(1)
+      end
+    END
     expect(cop.messages).to eq(['Use `yield` instead of `func.call`.'])
   end
 
   it 'autocorrects using parentheses when block.call uses parentheses' do
-    new_source = autocorrect_source(cop, ['def method(&block)',
-                                          '  block.call(a, b)',
-                                          'end'])
+    new_source = autocorrect_source(cop, <<-END.strip_indent)
+      def method(&block)
+        block.call(a, b)
+      end
+    END
 
-    expect(new_source).to eq(['def method(&block)',
-                              '  yield(a, b)',
-                              'end'].join("\n"))
+    expect(new_source).to eq(<<-END.strip_indent)
+      def method(&block)
+        yield(a, b)
+      end
+    END
   end
 
   it 'autocorrects when the result of the call is used in a scope that ' \
      'requires parentheses' do
-    source = ['def method(&block)',
-              '  each_with_object({}) do |(key, value), acc|',
-              '    acc.merge!(block.call(key) => rhs[value])',
-              '  end',
-              'end']
+    source = <<-END.strip_indent
+      def method(&block)
+        each_with_object({}) do |(key, value), acc|
+          acc.merge!(block.call(key) => rhs[value])
+        end
+      end
+    END
 
     new_source = autocorrect_source(cop, source)
 
-    expect(new_source).to eq(['def method(&block)',
-                              '  each_with_object({}) do |(key, value), acc|',
-                              '    acc.merge!(yield(key) => rhs[value])',
-                              '  end',
-                              'end'].join("\n"))
+    expect(new_source).to eq(<<-END.strip_indent)
+      def method(&block)
+        each_with_object({}) do |(key, value), acc|
+          acc.merge!(yield(key) => rhs[value])
+        end
+      end
+    END
   end
 end

--- a/spec/rubocop/cop/performance/redundant_match_spec.rb
+++ b/spec/rubocop/cop/performance/redundant_match_spec.rb
@@ -23,32 +23,44 @@ describe RuboCop::Cop::Performance::RedundantMatch do
   end
 
   it 'autocorrects .match in while condition' do
-    new_source = autocorrect_source(cop, ['while str.match(/regex/)',
-                                          '  do_something',
-                                          'end'])
-    expect(new_source).to eq(['while str =~ /regex/',
-                              '  do_something',
-                              'end'].join("\n"))
+    new_source = autocorrect_source(cop, <<-END.strip_indent)
+      while str.match(/regex/)
+        do_something
+      end
+    END
+    expect(new_source).to eq(<<-END.strip_indent)
+      while str =~ /regex/
+        do_something
+      end
+    END
   end
 
   it 'autocorrects .match in until condition' do
-    new_source = autocorrect_source(cop, ['until str.match(/regex/)',
-                                          '  do_something',
-                                          'end'])
-    expect(new_source).to eq(['until str =~ /regex/',
-                              '  do_something',
-                              'end'].join("\n"))
+    new_source = autocorrect_source(cop, <<-END.strip_indent)
+      until str.match(/regex/)
+        do_something
+      end
+    END
+    expect(new_source).to eq(<<-END.strip_indent)
+      until str =~ /regex/
+        do_something
+      end
+    END
   end
 
   it 'autocorrects .match in method body (but not tail position)' do
-    new_source = autocorrect_source(cop, ['def method(str)',
-                                          '  str.match(/regex/)',
-                                          '  true',
-                                          'end'])
-    expect(new_source).to eq(['def method(str)',
-                              '  str =~ /regex/',
-                              '  true',
-                              'end'].join("\n"))
+    new_source = autocorrect_source(cop, <<-END.strip_indent)
+      def method(str)
+        str.match(/regex/)
+        true
+      end
+    END
+    expect(new_source).to eq(<<-END.strip_indent)
+      def method(str)
+        str =~ /regex/
+        true
+      end
+    END
   end
 
   it 'does not autocorrect if .match has a string agrgument' do
@@ -58,33 +70,41 @@ describe RuboCop::Cop::Performance::RedundantMatch do
 
   it 'does not register an error when return value of .match is passed ' \
      'to another method' do
-    inspect_source(cop, ['def method(str)',
-                         ' something(str.match(/regex/))',
-                         'end'])
+    inspect_source(cop, <<-END.strip_indent)
+      def method(str)
+       something(str.match(/regex/))
+      end
+    END
     expect(cop.messages).to be_empty
   end
 
   it 'does not register an error when return value of .match is stored in an ' \
      'instance variable' do
-    inspect_source(cop, ['def method(str)',
-                         ' @var = str.match(/regex/)',
-                         ' true',
-                         'end'])
+    inspect_source(cop, <<-END.strip_indent)
+      def method(str)
+       @var = str.match(/regex/)
+       true
+      end
+    END
     expect(cop.messages).to be_empty
   end
 
   it 'does not register an error when return value of .match is returned from' \
      ' surrounding method' do
-    inspect_source(cop, ['def method(str)',
-                         ' str.match(/regex/)',
-                         'end'])
+    inspect_source(cop, <<-END.strip_indent)
+      def method(str)
+       str.match(/regex/)
+      end
+    END
     expect(cop.messages).to be_empty
   end
 
   it 'does not register an offense when match has a block' do
-    inspect_source(cop, ['/regex/.match(str) do |m|',
-                         '  something(m)',
-                         'end'])
+    inspect_source(cop, <<-END.strip_indent)
+      /regex/.match(str) do |m|
+        something(m)
+      end
+    END
     expect(cop.offenses).to be_empty
   end
 

--- a/spec/rubocop/cop/performance/redundant_sort_by_spec.rb
+++ b/spec/rubocop/cop/performance/redundant_sort_by_spec.rb
@@ -14,10 +14,12 @@ describe RuboCop::Cop::Performance::RedundantSortBy do
   end
 
   it 'autocorrects array.sort_by do |x| x end' do
-    new_source = autocorrect_source(cop, ['array.sort_by do |x|',
-                                          '  x',
-                                          'end'])
-    expect(new_source).to eq 'array.sort'
+    new_source = autocorrect_source(cop, <<-END.strip_indent)
+      array.sort_by do |x|
+        x
+      end
+    END
+    expect(new_source).to eq "array.sort\n"
   end
 
   it 'formats the error message correctly for array.sort_by { |x| x }' do

--- a/spec/rubocop/cop/performance/string_replacement_spec.rb
+++ b/spec/rubocop/cop/performance/string_replacement_spec.rb
@@ -18,23 +18,29 @@ describe RuboCop::Cop::Performance::StringReplacement do
       end
 
       it 'accepts the first param being a variable' do
-        inspect_source(cop, ['regex = /a/',
-                             "'abc'.#{method}(regex, '1')"])
+        inspect_source(cop, <<-END.strip_indent)
+          regex = /a/
+          'abc'.#{method}(regex, '1')
+        END
 
         expect(cop.messages).to be_empty
       end
 
       it 'accepts the second param being a variable' do
-        inspect_source(cop, ["replacement = 'e'",
-                             "'abc'.#{method}('abc', replacement)"])
+        inspect_source(cop, <<-END.strip_indent)
+          replacement = 'e'
+          'abc'.#{method}('abc', replacement)
+        END
 
         expect(cop.messages).to be_empty
       end
 
       it 'accepts the both params being a variables' do
-        inspect_source(cop, ['regex = /a/',
-                             "replacement = 'e'",
-                             "'abc'.#{method}(regex, replacement)"])
+        inspect_source(cop, <<-END.strip_indent)
+          regex = /a/
+          replacement = 'e'
+          'abc'.#{method}(regex, replacement)
+        END
 
         expect(cop.messages).to be_empty
       end
@@ -52,15 +58,19 @@ describe RuboCop::Cop::Performance::StringReplacement do
       end
 
       it 'accepts a pattern with string interpolation' do
-        inspect_source(cop, ["foo = 'a'",
-                             "'abc'.#{method}(\"\#{foo}\", '1')"])
+        inspect_source(cop, <<-END.strip_indent)
+          foo = 'a'
+          'abc'.#{method}(\"\#{foo}\", '1')
+        END
 
         expect(cop.messages).to be_empty
       end
 
       it 'accepts a replacement with string interpolation' do
-        inspect_source(cop, ["foo = '1'",
-                             "'abc'.#{method}('a', \"\#{foo}\")"])
+        inspect_source(cop, <<-END.strip_indent)
+          foo = '1'
+          'abc'.#{method}('a', \"\#{foo}\")
+        END
 
         expect(cop.messages).to be_empty
       end
@@ -256,22 +266,28 @@ describe RuboCop::Cop::Performance::StringReplacement do
     end
 
     it 'allows regex literal containing interpolations' do
-      inspect_source(cop, ["foo = 'a'",
-                           '"abc".gsub(/#{foo}/, "d")'])
+      inspect_source(cop, <<-'END'.strip_indent)
+        foo = 'a'
+        "abc".gsub(/#{foo}/, "d")
+      END
 
       expect(cop.messages).to be_empty
     end
 
     it 'allows regex constructor containing a string with interpolations' do
-      inspect_source(cop, ["foo = 'a'",
-                           '"abc".gsub(Regexp.new("#{foo}"), "d")'])
+      inspect_source(cop, <<-'END'.strip_indent)
+        foo = 'a'
+        "abc".gsub(Regexp.new("#{foo}"), "d")
+      END
 
       expect(cop.messages).to be_empty
     end
 
     it 'allows regex constructor containing regex with interpolations' do
-      inspect_source(cop, ["foo = 'a'",
-                           '"abc".gsub(Regexp.new(/#{foo}/), "d")'])
+      inspect_source(cop, <<-'END'.strip_indent)
+        foo = 'a'
+        "abc".gsub(Regexp.new(/#{foo}/), "d")
+      END
 
       expect(cop.messages).to be_empty
     end

--- a/spec/rubocop/cop/rails/blank_spec.rb
+++ b/spec/rubocop/cop/rails/blank_spec.rb
@@ -151,27 +151,33 @@ describe RuboCop::Cop::Rails::Blank, :config do
     end
 
     it 'accepts normal if present?' do
-      inspect_source(cop, ['if foo.present?',
-                           '  something',
-                           'end'])
+      inspect_source(cop, <<-END.strip_indent)
+        if foo.present?
+          something
+        end
+      END
 
       expect(cop.offenses).to be_empty
     end
 
     it 'accepts normal unless blank?' do
-      inspect_source(cop, ['unless foo.blank?',
-                           '  something',
-                           'end'])
+      inspect_source(cop, <<-END.strip_indent)
+        unless foo.blank?
+          something
+        end
+      END
 
       expect(cop.offenses).to be_empty
     end
 
     it 'accepts elsif present?' do
-      inspect_source(cop, ['if bar.present?',
-                           '  something',
-                           'elsif bar.present?',
-                           '  something_else',
-                           'end'])
+      inspect_source(cop, <<-END.strip_indent)
+        if bar.present?
+          something
+        elsif bar.present?
+          something_else
+        end
+      END
 
       expect(cop.offenses).to be_empty
     end
@@ -196,9 +202,11 @@ describe RuboCop::Cop::Rails::Blank, :config do
 
     context 'normal unless present?' do
       let(:source) do
-        ['unless foo.present?',
-         '  something',
-         'end']
+        <<-END.strip_indent
+          unless foo.present?
+            something
+          end
+        END
       end
 
       it 'registers an offense' do
@@ -212,19 +220,23 @@ describe RuboCop::Cop::Rails::Blank, :config do
       it 'auto-corrects' do
         new_source = autocorrect_source(cop, source)
 
-        expect(new_source).to eq(['if foo.blank?',
-                                  '  something',
-                                  'end'].join("\n"))
+        expect(new_source).to eq(<<-END.strip_indent)
+          if foo.blank?
+            something
+          end
+        END
       end
     end
 
     context 'unless present? with an else' do
       let(:source) do
-        ['unless foo.present?',
-         '  something',
-         'else',
-         '  something_else',
-         'end']
+        <<-END.strip_indent
+          unless foo.present?
+            something
+          else
+            something_else
+          end
+        END
       end
 
       it 'registers an offense' do
@@ -238,11 +250,13 @@ describe RuboCop::Cop::Rails::Blank, :config do
       it 'auto-corrects' do
         new_source = autocorrect_source(cop, source)
 
-        expect(new_source).to eq(['if foo.blank?',
-                                  '  something',
-                                  'else',
-                                  '  something_else',
-                                  'end'].join("\n"))
+        expect(new_source).to eq(<<-END.strip_indent)
+          if foo.blank?
+            something
+          else
+            something_else
+          end
+        END
       end
     end
   end

--- a/spec/rubocop/cop/rails/dynamic_find_by_spec.rb
+++ b/spec/rubocop/cop/rails/dynamic_find_by_spec.rb
@@ -74,23 +74,25 @@ describe RuboCop::Cop::Rails::DynamicFindBy, :config do
 
   context 'with dynamic find_by_*_and_*_and_* with newline' do
     let(:source) do
-      [
-        'User.find_by_name_and_email_and_token(',
-        '  name,',
-        '  email,',
-        '  token',
-        ')'
-      ]
+      <<-END.strip_indent
+        User.find_by_name_and_email_and_token(
+          name,
+          email,
+          token
+        )
+      END
     end
 
     include_examples(
       'register an offense and auto correct',
       'Use `find_by` instead of dynamic `find_by_name_and_email_and_token`.',
-      "User.find_by(\n" \
-      "  name: name,\n" \
-      "  email: email,\n" \
-      "  token: token\n" \
-      ')' \
+      <<-END.strip_indent
+        User.find_by(
+          name: name,
+          email: email,
+          token: token
+        )
+      END
     )
   end
 

--- a/spec/rubocop/cop/rails/enum_uniqueness_spec.rb
+++ b/spec/rubocop/cop/rails/enum_uniqueness_spec.rb
@@ -63,8 +63,10 @@ describe RuboCop::Cop::Rails::EnumUniqueness, :config do
 
   context 'when receiving a variable' do
     it 'does not register an offense' do
-      inspect_source(cop, ['var = { status: { active: 0, archived: 1 } }',
-                           'enum var'])
+      inspect_source(cop, <<-END.strip_indent)
+        var = { status: { active: 0, archived: 1 } }
+        enum var
+      END
 
       expect(cop.offenses).to be_empty
     end

--- a/spec/rubocop/cop/rails/http_positional_arguments_spec.rb
+++ b/spec/rubocop/cop/rails/http_positional_arguments_spec.rb
@@ -222,16 +222,15 @@ describe RuboCop::Cop::Rails::HttpPositionalArguments do
       expect(new_source).to eq(source)
     end
 
-    it 'auto-corrects http action when params is a lvar' do
-      source = [
-        'params = { id: 1 }',
-        'post user_attrs, params'
-      ]
+    it 'does not auto-correct when params is a lvar' do
+      source = <<-END.strip_indent
+        params = { id: 1 }
+        post user_attrs, params
+      END
       inspect_source(cop, source)
       expect(cop.offenses.size).to eq(0)
       new_source = autocorrect_source(cop, source)
-      expected = "params = { id: 1 }\npost user_attrs, params"
-      expect(new_source).to eq(expected)
+      expect(new_source).to eq(source)
     end
 
     it 'does not auto-correct http action when params is a method call' do
@@ -506,15 +505,17 @@ describe RuboCop::Cop::Rails::HttpPositionalArguments do
     end
 
     it 'auto-corrects http action when params is a lvar' do
-      source = [
-        'params = { id: 1 }',
-        'post user_attrs, params'
-      ]
+      source = <<-END.strip_indent
+        params = { id: 1 }
+        post user_attrs, params
+      END
       inspect_source(cop, source)
       expect(cop.offenses.size).to eq(1)
       new_source = autocorrect_source(cop, source)
-      expected = "params = { id: 1 }\npost user_attrs, params: params"
-      expect(new_source).to eq(expected)
+      expect(new_source).to eq(<<-END.strip_indent)
+        params = { id: 1 }
+        post user_attrs, params: params
+      END
     end
 
     it 'auto-corrects http action when params is a method call' do

--- a/spec/rubocop/cop/rails/not_null_column_spec.rb
+++ b/spec/rubocop/cop/rails/not_null_column_spec.rb
@@ -51,25 +51,27 @@ describe RuboCop::Cop::Rails::NotNullColumn, :config do
 
   context 'with change_column call' do
     let(:source) do
-      [
-        'add_column :users, :name, :string',
-        'User.update_all(name: "dummy")',
-        'change_column :users, :name, :string, null: false'
-      ]
+      <<-END.strip_indent
+        add_column :users, :name, :string
+        User.update_all(name: "dummy")
+        change_column :users, :name, :string, null: false
+      END
     end
     include_examples 'accepts'
   end
 
   context 'with create_table call' do
     let(:source) do
-      ['class CreateUsersTable < ActiveRecord::Migration',
-       '  def change',
-       '    create_table :users do |t|',
-       '      t.string :name, null: false',
-       '      t.timestamps null: false',
-       '    end',
-       '  end',
-       'end']
+      <<-END.strip_indent
+        class CreateUsersTable < ActiveRecord::Migration
+          def change
+            create_table :users do |t|
+              t.string :name, null: false
+              t.timestamps null: false
+            end
+          end
+        end
+      END
     end
     include_examples 'accepts'
   end

--- a/spec/rubocop/cop/rails/output_safety_spec.rb
+++ b/spec/rubocop/cop/rails/output_safety_spec.rb
@@ -5,8 +5,10 @@ describe RuboCop::Cop::Rails::OutputSafety do
 
   it 'registers an offense for html_safe methods with a receiver and no ' \
      'arguments' do
-    source = ['foo.html_safe',
-              '"foo".html_safe']
+    source = <<-END.strip_indent
+      foo.html_safe
+      "foo".html_safe
+    END
     inspect_source(cop, source)
     expect(cop.offenses.size).to eq(2)
   end
@@ -18,22 +20,28 @@ describe RuboCop::Cop::Rails::OutputSafety do
   end
 
   it 'accepts html_safe methods with arguments' do
-    source = ['foo.html_safe one',
-              '"foo".html_safe two']
+    source = <<-END.strip_indent
+      foo.html_safe one
+      "foo".html_safe two
+    END
     inspect_source(cop, source)
     expect(cop.offenses).to be_empty
   end
 
   it 'registers an offense for raw methods without a receiver' do
-    source = ['raw(foo)',
-              'raw "foo"']
+    source = <<-END.strip_indent
+      raw(foo)
+      raw "foo"
+    END
     inspect_source(cop, source)
     expect(cop.offenses.size).to eq(2)
   end
 
   it 'accepts raw methods with a receiver' do
-    source = ['foo.raw(foo)',
-              '"foo".raw "foo"']
+    source = <<-END.strip_indent
+      foo.raw(foo)
+      "foo".raw "foo"
+    END
     inspect_source(cop, source)
     expect(cop.offenses).to be_empty
   end
@@ -51,8 +59,10 @@ describe RuboCop::Cop::Rails::OutputSafety do
   end
 
   it 'accepts comments' do
-    source = ['# foo.html_safe',
-              '# raw foo']
+    source = <<-END.strip_indent
+      # foo.html_safe
+      # raw foo
+    END
     inspect_source(cop, source)
     expect(cop.offenses).to be_empty
   end

--- a/spec/rubocop/cop/rails/output_spec.rb
+++ b/spec/rubocop/cop/rails/output_spec.rb
@@ -4,18 +4,22 @@ describe RuboCop::Cop::Rails::Output do
   subject(:cop) { described_class.new }
 
   it 'records an offense for methods without a receiver' do
-    source = ['p "edmond dantes"',
-              'puts "sinbad"',
-              'print "abbe busoni"',
-              'pp "monte cristo"']
+    source = <<-END.strip_indent
+      p "edmond dantes"
+      puts "sinbad"
+      print "abbe busoni"
+      pp "monte cristo"
+    END
     inspect_source(cop, source)
     expect(cop.offenses.size).to eq(4)
   end
 
   it 'does not record an offense for methods with a receiver' do
-    source = ['obj.print',
-              'something.p',
-              'nothing.pp']
+    source = <<-END.strip_indent
+      obj.print
+      something.p
+      nothing.pp
+    END
     inspect_source(cop, source)
     expect(cop.offenses).to be_empty
   end
@@ -27,8 +31,10 @@ describe RuboCop::Cop::Rails::Output do
   end
 
   it 'does not record an offense for comments' do
-    source = ['# print "test"',
-              '# p']
+    source = <<-END.strip_indent
+      # print "test"
+      # p
+    END
     inspect_source(cop, source)
     expect(cop.offenses).to be_empty
   end

--- a/spec/rubocop/cop/rails/present_spec.rb
+++ b/spec/rubocop/cop/rails/present_spec.rb
@@ -145,17 +145,21 @@ describe RuboCop::Cop::Rails::Present, :config do
     end
 
     it 'accepts normal if blank?' do
-      inspect_source(cop, ['if foo.blank?',
-                           '  something',
-                           'end'])
+      inspect_source(cop, <<-END.strip_indent)
+        if foo.blank?
+          something
+        end
+      END
 
       expect(cop.offenses).to be_empty
     end
 
     it 'accepts normal unless present?' do
-      inspect_source(cop, ['unless foo.present?',
-                           '  something',
-                           'end'])
+      inspect_source(cop, <<-END.strip_indent)
+        unless foo.present?
+          something
+        end
+      END
 
       expect(cop.offenses).to be_empty
     end
@@ -181,9 +185,11 @@ describe RuboCop::Cop::Rails::Present, :config do
 
       context 'normal unless blank?' do
         let(:source) do
-          ['unless foo.blank?',
-           '  something',
-           'end']
+          <<-END.strip_indent
+            unless foo.blank?
+              something
+            end
+          END
         end
 
         it 'registers an offense' do
@@ -197,19 +203,23 @@ describe RuboCop::Cop::Rails::Present, :config do
         it 'auto-corrects' do
           new_source = autocorrect_source(cop, source)
 
-          expect(new_source).to eq(['if foo.present?',
-                                    '  something',
-                                    'end'].join("\n"))
+          expect(new_source).to eq(<<-END.strip_indent)
+            if foo.present?
+              something
+            end
+          END
         end
       end
 
       context 'unless blank? with an else' do
         let(:source) do
-          ['unless foo.blank?',
-           '  something',
-           'else',
-           '  something_else',
-           'end']
+          <<-END.strip_indent
+            unless foo.blank?
+              something
+            else
+              something_else
+            end
+          END
         end
 
         it 'registers an offense' do
@@ -223,11 +233,13 @@ describe RuboCop::Cop::Rails::Present, :config do
         it 'auto-corrects' do
           new_source = autocorrect_source(cop, source)
 
-          expect(new_source).to eq(['if foo.present?',
-                                    '  something',
-                                    'else',
-                                    '  something_else',
-                                    'end'].join("\n"))
+          expect(new_source).to eq(<<-END.strip_indent)
+            if foo.present?
+              something
+            else
+              something_else
+            end
+          END
         end
       end
     end

--- a/spec/rubocop/cop/rails/read_write_attribute_spec.rb
+++ b/spec/rubocop/cop/rails/read_write_attribute_spec.rb
@@ -66,13 +66,14 @@ describe RuboCop::Cop::Rails::ReadWriteAttribute do
           '(',
           "'test_' + postfix",
           ').to_sym',
-          ')'
+          ')',
+          ''
         ]
-        corrected_source = [
-          'self[:attr] = (',
-          "'test_' + postfix",
-          ').to_sym'
-        ].join("\n")
+        corrected_source = <<-END.strip_indent
+          self[:attr] = (
+          'test_' + postfix
+          ).to_sym
+        END
 
         expect(autocorrect_source(cop, source)).to eq(corrected_source)
       end
@@ -108,18 +109,18 @@ describe RuboCop::Cop::Rails::ReadWriteAttribute do
       end
 
       it 'autocorrects multiline' do
-        source = [
-          'res = read_attribute(',
-          '(',
-          "'test_' + postfix",
-          ').to_sym',
-          ')'
-        ]
-        corrected_source = [
-          'res = self[(',
-          "'test_' + postfix",
-          ').to_sym]'
-        ].join("\n")
+        source = <<-END.strip_indent
+          res = read_attribute(
+          (
+          'test_' + postfix
+          ).to_sym
+          )
+        END
+        corrected_source = <<-END.strip_indent
+          res = self[(
+          'test_' + postfix
+          ).to_sym]
+        END
 
         expect(autocorrect_source(cop, source)).to eq(corrected_source)
       end

--- a/spec/rubocop/cop/rails/relative_date_constant_spec.rb
+++ b/spec/rubocop/cop/rails/relative_date_constant_spec.rb
@@ -4,70 +4,80 @@ describe RuboCop::Cop::Rails::RelativeDateConstant do
   subject(:cop) { described_class.new }
 
   it 'registers an offense for ActiveSupport::Duration.since' do
-    inspect_source(cop,
-                   ['class SomeClass',
-                    '  EXPIRED_AT = 1.week.since',
-                    'end'])
+    inspect_source(cop, <<-END.strip_indent)
+      class SomeClass
+        EXPIRED_AT = 1.week.since
+      end
+    END
     expect(cop.offenses.size).to eq(1)
   end
 
   it 'accepts a method with arguments' do
-    inspect_source(cop,
-                   ['class SomeClass',
-                    '  EXPIRED_AT = 1.week.since(base)',
-                    'end'])
+    inspect_source(cop, <<-END.strip_indent)
+      class SomeClass
+        EXPIRED_AT = 1.week.since(base)
+      end
+    END
     expect(cop.offenses).to be_empty
   end
 
   it 'accepts a lambda' do
-    inspect_source(cop,
-                   ['class SomeClass',
-                    '  EXPIRED_AT = -> { 1.year.ago }',
-                    'end'])
+    inspect_source(cop, <<-END.strip_indent)
+      class SomeClass
+        EXPIRED_AT = -> { 1.year.ago }
+      end
+    END
     expect(cop.offenses).to be_empty
   end
 
   it 'accepts a proc' do
-    inspect_source(cop,
-                   ['class SomeClass',
-                    '  EXPIRED_AT = Proc.new { 1.year.ago }',
-                    'end'])
+    inspect_source(cop, <<-END.strip_indent)
+      class SomeClass
+        EXPIRED_AT = Proc.new { 1.year.ago }
+      end
+    END
     expect(cop.offenses).to be_empty
   end
 
   it 'registers an offense for relative date in ||=' do
-    inspect_source(cop,
-                   ['class SomeClass',
-                    '  EXPIRED_AT ||= 1.week.since',
-                    'end'])
+    inspect_source(cop, <<-END.strip_indent)
+      class SomeClass
+        EXPIRED_AT ||= 1.week.since
+      end
+    END
     expect(cop.offenses.size).to eq(1)
   end
 
   it 'registers an offense for exclusive end range' do
-    inspect_source(cop,
-                   ['class SomeClass',
-                    '  TRIAL_PERIOD = DateTime.current..1.day.since',
-                    'end'])
+    inspect_source(cop, <<-END.strip_indent)
+      class SomeClass
+        TRIAL_PERIOD = DateTime.current..1.day.since
+      end
+    END
     expect(cop.offenses.size).to eq(1)
   end
 
   it 'registers an offense for inclusive end range' do
-    inspect_source(cop,
-                   ['class SomeClass',
-                    '  TRIAL_PERIOD = DateTime.current...1.day.since',
-                    'end'])
+    inspect_source(cop, <<-END.strip_indent)
+      class SomeClass
+        TRIAL_PERIOD = DateTime.current...1.day.since
+      end
+    END
     expect(cop.offenses.size).to eq(1)
   end
 
   it 'autocorrects' do
-    new_source = autocorrect_source(cop,
-                                    ['class SomeClass',
-                                     '  EXPIRED_AT = 1.week.since',
-                                     'end'])
-    expect(new_source).to eq(['class SomeClass',
-                              '  def self.expired_at',
-                              '    1.week.since',
-                              '  end',
-                              'end'].join("\n"))
+    new_source = autocorrect_source(cop, <<-END.strip_indent)
+      class SomeClass
+        EXPIRED_AT = 1.week.since
+      end
+    END
+    expect(new_source).to eq(<<-END.strip_indent)
+      class SomeClass
+        def self.expired_at
+          1.week.since
+        end
+      end
+    END
   end
 end

--- a/spec/rubocop/cop/rails/save_bang_spec.rb
+++ b/spec/rubocop/cop/rails/save_bang_spec.rb
@@ -90,9 +90,11 @@ describe RuboCop::Cop::Rails::SaveBang do
     end
 
     it "when using #{method} with multiple conditional" do
-      inspect_source(cop, ["if true && object.active? && object.#{method}",
-                           '  something',
-                           'end'])
+      inspect_source(cop, <<-END.strip_indent)
+        if true && object.active? && object.#{method}
+          something
+        end
+      END
       if pass
         expect(cop.messages).to be_empty
       else

--- a/spec/rubocop/cop/rails/scope_args_spec.rb
+++ b/spec/rubocop/cop/rails/scope_args_spec.rb
@@ -41,9 +41,11 @@ describe RuboCop::Cop::Rails::ScopeArgs do
   end
 
   it 'accepts a lambda with a multiline block' do
-    inspect_source(cop, ['scope :active, (lambda do |active|',
-                         '                 where(active: active)',
-                         '               end)'])
+    inspect_source(cop, <<-END.strip_indent)
+      scope :active, (lambda do |active|
+                       where(active: active)
+                     end)
+    END
 
     expect(cop.offenses).to be_empty
   end

--- a/spec/rubocop/cop/style/access_modifier_indentation_spec.rb
+++ b/spec/rubocop/cop/style/access_modifier_indentation_spec.rb
@@ -14,13 +14,14 @@ describe RuboCop::Cop::Style::AccessModifierIndentation do
     let(:cop_config) { { 'EnforcedStyle' => 'indent' } }
 
     it 'registers an offense for misaligned private' do
-      inspect_source(cop,
-                     ['class Test',
-                      '',
-                      'private',
-                      '',
-                      '  def test; end',
-                      'end'])
+      inspect_source(cop, <<-END.strip_indent)
+        class Test
+
+        private
+
+          def test; end
+        end
+      END
       expect(cop.offenses.size).to eq(1)
       expect(cop.messages)
         .to eq(['Indent access modifiers like `private`.'])
@@ -28,13 +29,14 @@ describe RuboCop::Cop::Style::AccessModifierIndentation do
     end
 
     it 'registers an offense for misaligned private in module' do
-      inspect_source(cop,
-                     ['module Test',
-                      '',
-                      ' private',
-                      '',
-                      '  def test; end',
-                      'end'])
+      inspect_source(cop, <<-END.strip_indent)
+        module Test
+
+         private
+
+          def test; end
+        end
+      END
       expect(cop.offenses.size).to eq(1)
       expect(cop.messages).to eq(['Indent access modifiers like `private`.'])
       # Not aligned according to `indent` or `outdent` style:
@@ -42,13 +44,14 @@ describe RuboCop::Cop::Style::AccessModifierIndentation do
     end
 
     it 'registers an offense for misaligned module_function in module' do
-      inspect_source(cop,
-                     ['module Test',
-                      '',
-                      ' module_function',
-                      '',
-                      '  def test; end',
-                      'end'])
+      inspect_source(cop, <<-END.strip_indent)
+        module Test
+
+         module_function
+
+          def test; end
+        end
+      END
       expect(cop.offenses.size).to eq(1)
       expect(cop.messages)
         .to eq(['Indent access modifiers like `module_function`.'])
@@ -57,15 +60,16 @@ describe RuboCop::Cop::Style::AccessModifierIndentation do
     end
 
     it 'registers an offense for correct + opposite alignment' do
-      inspect_source(cop,
-                     ['module Test',
-                      '',
-                      '  public',
-                      '',
-                      'private',
-                      '',
-                      '  def test; end',
-                      'end'])
+      inspect_source(cop, <<-END.strip_indent)
+        module Test
+
+          public
+
+        private
+
+          def test; end
+        end
+      END
       expect(cop.offenses.size).to eq(1)
       expect(cop.messages).to eq(['Indent access modifiers like `private`.'])
       # No EnforcedStyle can allow both alignments:
@@ -73,15 +77,16 @@ describe RuboCop::Cop::Style::AccessModifierIndentation do
     end
 
     it 'registers an offense for opposite + correct alignment' do
-      inspect_source(cop,
-                     ['module Test',
-                      '',
-                      'public',
-                      '',
-                      '  private',
-                      '',
-                      '  def test; end',
-                      'end'])
+      inspect_source(cop, <<-END.strip_indent)
+        module Test
+
+        public
+
+          private
+
+          def test; end
+        end
+      END
       expect(cop.offenses.size).to eq(1)
       expect(cop.messages).to eq(['Indent access modifiers like `public`.'])
       # No EnforcedStyle can allow both alignments:
@@ -89,13 +94,14 @@ describe RuboCop::Cop::Style::AccessModifierIndentation do
     end
 
     it 'registers an offense for misaligned private in singleton class' do
-      inspect_source(cop,
-                     ['class << self',
-                      '',
-                      'private',
-                      '',
-                      '  def test; end',
-                      'end'])
+      inspect_source(cop, <<-END.strip_indent)
+        class << self
+
+        private
+
+          def test; end
+        end
+      END
       expect(cop.offenses.size).to eq(1)
       expect(cop.messages)
         .to eq(['Indent access modifiers like `private`.'])
@@ -103,13 +109,14 @@ describe RuboCop::Cop::Style::AccessModifierIndentation do
 
     it 'registers an offense for misaligned private in class ' \
        'defined with Class.new' do
-      inspect_source(cop,
-                     ['Test = Class.new do',
-                      '',
-                      'private',
-                      '',
-                      '  def test; end',
-                      'end'])
+      inspect_source(cop, <<-END.strip_indent)
+        Test = Class.new do
+
+        private
+
+          def test; end
+        end
+      END
       expect(cop.offenses.size).to eq(1)
       expect(cop.messages)
         .to eq(['Indent access modifiers like `private`.'])
@@ -117,131 +124,145 @@ describe RuboCop::Cop::Style::AccessModifierIndentation do
 
     it 'accepts misaligned private in blocks that are not recognized as ' \
        'class/module definitions' do
-      inspect_source(cop,
-                     ['Test = func do',
-                      '',
-                      'private',
-                      '',
-                      '  def test; end',
-                      'end'])
+      inspect_source(cop, <<-END.strip_indent)
+        Test = func do
+
+        private
+
+          def test; end
+        end
+      END
       expect(cop.offenses).to be_empty
     end
 
     it 'registers an offense for misaligned private in module ' \
        'defined with Module.new' do
-      inspect_source(cop,
-                     ['Test = Module.new do',
-                      '',
-                      'private',
-                      '',
-                      '  def test; end',
-                      'end'])
+      inspect_source(cop, <<-END.strip_indent)
+        Test = Module.new do
+
+        private
+
+          def test; end
+        end
+      END
       expect(cop.offenses.size).to eq(1)
       expect(cop.messages)
         .to eq(['Indent access modifiers like `private`.'])
     end
 
     it 'registers an offense for misaligned protected' do
-      inspect_source(cop,
-                     ['class Test',
-                      '',
-                      'protected',
-                      '',
-                      '  def test; end',
-                      'end'])
+      inspect_source(cop, <<-END.strip_indent)
+        class Test
+
+        protected
+
+          def test; end
+        end
+      END
       expect(cop.offenses.size).to eq(1)
       expect(cop.messages)
         .to eq(['Indent access modifiers like `protected`.'])
     end
 
     it 'accepts properly indented private' do
-      inspect_source(cop,
-                     ['class Test',
-                      '',
-                      '  private',
-                      '',
-                      '  def test; end',
-                      'end'])
+      inspect_source(cop, <<-END.strip_indent)
+        class Test
+
+          private
+
+          def test; end
+        end
+      END
       expect(cop.offenses).to be_empty
     end
 
     it 'accepts properly indented protected' do
-      inspect_source(cop,
-                     ['class Test',
-                      '',
-                      '  protected',
-                      '',
-                      '  def test; end',
-                      'end'])
+      inspect_source(cop, <<-END.strip_indent)
+        class Test
+
+          protected
+
+          def test; end
+        end
+      END
       expect(cop.offenses).to be_empty
     end
 
     it 'accepts an empty class' do
-      inspect_source(cop,
-                     ['class Test',
-                      'end'])
+      inspect_source(cop, <<-END.strip_indent)
+        class Test
+        end
+      END
       expect(cop.offenses).to be_empty
     end
 
     it 'accepts methods with a body' do
-      inspect_source(cop, ['module Test',
-                           '  def test',
-                           '    foo',
-                           '  end',
-                           'end'])
+      inspect_source(cop, <<-END.strip_indent)
+        module Test
+          def test
+            foo
+          end
+        end
+      END
       expect(cop.offenses).to be_empty
     end
 
     it 'handles properly nested classes' do
-      inspect_source(cop,
-                     ['class Test',
-                      '',
-                      '  class Nested',
-                      '',
-                      '  private',
-                      '',
-                      '    def a; end',
-                      '  end',
-                      '',
-                      '  protected',
-                      '',
-                      '  def test; end',
-                      'end'])
+      inspect_source(cop, <<-END.strip_indent)
+        class Test
+
+          class Nested
+
+          private
+
+            def a; end
+          end
+
+          protected
+
+          def test; end
+        end
+      END
       expect(cop.offenses.size).to eq(1)
       expect(cop.messages)
         .to eq(['Indent access modifiers like `private`.'])
     end
 
     it 'auto-corrects incorrectly indented access modifiers' do
-      corrected = autocorrect_source(cop, ['class Test',
-                                           '',
-                                           'public',
-                                           ' private',
-                                           '   protected',
-                                           '',
-                                           '  def test; end',
-                                           'end'])
-      expect(corrected).to eq(['class Test',
-                               '',
-                               '  public',
-                               '  private',
-                               '  protected',
-                               '',
-                               '  def test; end',
-                               'end'].join("\n"))
+      corrected = autocorrect_source(cop, <<-END.strip_indent)
+        class Test
+
+        public
+         private
+           protected
+
+          def test; end
+        end
+      END
+      expect(corrected).to eq(<<-END.strip_indent)
+        class Test
+
+          public
+          private
+          protected
+
+          def test; end
+        end
+      END
     end
 
     context 'when 4 spaces per indent level are used' do
       let(:indentation_width) { 4 }
 
       it 'accepts properly indented private' do
-        inspect_source(cop,
-                       ['class Test',
-                        '',
-                        '    private',
-                        '',
-                        '    def test; end',
-                        'end'])
+        inspect_source(cop, <<-END.strip_indent)
+          class Test
+
+              private
+
+              def test; end
+          end
+        END
         expect(cop.offenses).to be_empty
       end
     end
@@ -252,13 +273,14 @@ describe RuboCop::Cop::Style::AccessModifierIndentation do
       end
 
       it 'accepts properly indented private' do
-        inspect_source(cop,
-                       ['class Test',
-                        '',
-                        '    private',
-                        '',
-                        '  def test; end',
-                        'end'])
+        inspect_source(cop, <<-END.strip_indent)
+          class Test
+
+              private
+
+            def test; end
+          end
+        END
         expect(cop.offenses).to be_empty
       end
     end
@@ -269,177 +291,194 @@ describe RuboCop::Cop::Style::AccessModifierIndentation do
     let(:indent_msg) { 'Outdent access modifiers like `private`.' }
 
     it 'registers offense for private indented to method depth in a class' do
-      inspect_source(cop,
-                     ['class Test',
-                      '',
-                      '  private',
-                      '',
-                      '  def test; end',
-                      'end'])
+      inspect_source(cop, <<-END.strip_indent)
+        class Test
+
+          private
+
+          def test; end
+        end
+      END
       expect(cop.offenses.size).to eq(1)
       expect(cop.messages).to eq([indent_msg])
       expect(cop.config_to_allow_offenses).to eq('EnforcedStyle' => 'indent')
     end
 
     it 'registers offense for private indented to method depth in a module' do
-      inspect_source(cop,
-                     ['module Test',
-                      '',
-                      '  private',
-                      '',
-                      '  def test; end',
-                      'end'])
+      inspect_source(cop, <<-END.strip_indent)
+        module Test
+
+          private
+
+          def test; end
+        end
+      END
       expect(cop.offenses.size).to eq(1)
       expect(cop.messages).to eq([indent_msg])
     end
 
     it 'registers offense for module fn indented to method depth in a module' do
-      inspect_source(cop,
-                     ['module Test',
-                      '',
-                      '  module_function',
-                      '',
-                      '  def test; end',
-                      'end'])
+      inspect_source(cop, <<-END.strip_indent)
+        module Test
+
+          module_function
+
+          def test; end
+        end
+      END
       expect(cop.offenses.size).to eq(1)
     end
 
     it 'registers offense for private indented to method depth in singleton' \
        'class' do
-      inspect_source(cop,
-                     ['class << self',
-                      '',
-                      '  private',
-                      '',
-                      '  def test; end',
-                      'end'])
+      inspect_source(cop, <<-END.strip_indent)
+        class << self
+
+          private
+
+          def test; end
+        end
+      END
       expect(cop.offenses.size).to eq(1)
       expect(cop.messages).to eq([indent_msg])
     end
 
     it 'registers offense for private indented to method depth in class ' \
        'defined with Class.new' do
-      inspect_source(cop,
-                     ['Test = Class.new do',
-                      '',
-                      '  private',
-                      '',
-                      '  def test; end',
-                      'end'])
+      inspect_source(cop, <<-END.strip_indent)
+        Test = Class.new do
+
+          private
+
+          def test; end
+        end
+      END
       expect(cop.offenses.size).to eq(1)
       expect(cop.messages).to eq([indent_msg])
     end
 
     it 'registers offense for private indented to method depth in module ' \
        'defined with Module.new' do
-      inspect_source(cop,
-                     ['Test = Module.new do',
-                      '',
-                      '  private',
-                      '',
-                      '  def test; end',
-                      'end'])
+      inspect_source(cop, <<-END.strip_indent)
+        Test = Module.new do
+
+          private
+
+          def test; end
+        end
+      END
       expect(cop.offenses.size).to eq(1)
       expect(cop.messages).to eq([indent_msg])
     end
 
     it 'accepts private indented to the containing class indent level' do
-      inspect_source(cop,
-                     ['class Test',
-                      '',
-                      'private',
-                      '',
-                      '  def test; end',
-                      'end'])
+      inspect_source(cop, <<-END.strip_indent)
+        class Test
+
+        private
+
+          def test; end
+        end
+      END
       expect(cop.offenses).to be_empty
     end
 
     it 'accepts protected indented to the containing class indent level' do
-      inspect_source(cop,
-                     ['class Test',
-                      '',
-                      'protected',
-                      '',
-                      '  def test; end',
-                      'end'])
+      inspect_source(cop, <<-END.strip_indent)
+        class Test
+
+        protected
+
+          def test; end
+        end
+      END
       expect(cop.offenses).to be_empty
     end
 
     it 'handles properly nested classes' do
-      inspect_source(cop,
-                     ['class Test',
-                      '',
-                      '  class Nested',
-                      '',
-                      '    private',
-                      '',
-                      '    def a; end',
-                      '  end',
-                      '',
-                      'protected',
-                      '',
-                      '  def test; end',
-                      'end'])
+      inspect_source(cop, <<-END.strip_indent)
+        class Test
+
+          class Nested
+
+            private
+
+            def a; end
+          end
+
+        protected
+
+          def test; end
+        end
+      END
       expect(cop.offenses.size).to eq(1)
       expect(cop.messages).to eq([indent_msg])
     end
 
     it 'auto-corrects incorrectly indented access modifiers' do
-      corrected = autocorrect_source(cop, ['module M',
-                                           '  class Test',
-                                           '',
-                                           'public',
-                                           ' private',
-                                           '     protected',
-                                           '',
-                                           '    def test; end',
-                                           '  end',
-                                           'end'])
-      expect(corrected).to eq(['module M',
-                               '  class Test',
-                               '',
-                               '  public',
-                               '  private',
-                               '  protected',
-                               '',
-                               '    def test; end',
-                               '  end',
-                               'end'].join("\n"))
+      corrected = autocorrect_source(cop, <<-END.strip_indent)
+        module M
+          class Test
+
+        public
+         private
+             protected
+
+            def test; end
+          end
+        end
+      END
+      expect(corrected).to eq(<<-END.strip_indent)
+        module M
+          class Test
+
+          public
+          private
+          protected
+
+            def test; end
+          end
+        end
+      END
     end
 
     it 'auto-corrects private in complicated case' do
-      corrected = autocorrect_source(cop, ['class Hello',
-                                           '  def foo',
-                                           "    'hi'",
-                                           '  end',
-                                           '',
-                                           '  def bar',
-                                           '    Module.new do',
-                                           '',
-                                           '     private',
-                                           '',
-                                           '      def hi',
-                                           "        'bye'",
-                                           '      end',
-                                           '    end',
-                                           '  end',
-                                           'end'])
-      expect(corrected).to eq(['class Hello',
-                               '  def foo',
-                               "    'hi'",
-                               '  end',
-                               '',
-                               '  def bar',
-                               '    Module.new do',
-                               '',
-                               '    private',
-                               '',
-                               '      def hi',
-                               "        'bye'",
-                               '      end',
-                               '    end',
-                               '  end',
-                               'end'].join("\n"))
+      corrected = autocorrect_source(cop, <<-END.strip_indent)
+        class Hello
+          def foo
+            'hi'
+          end
+
+          def bar
+            Module.new do
+
+             private
+
+              def hi
+                'bye'
+              end
+            end
+          end
+        end
+      END
+      expect(corrected).to eq(<<-END.strip_indent)
+        class Hello
+          def foo
+            'hi'
+          end
+
+          def bar
+            Module.new do
+
+            private
+
+              def hi
+                'bye'
+              end
+            end
+          end
+        end
+      END
     end
   end
 end

--- a/spec/rubocop/cop/style/accessor_method_name_spec.rb
+++ b/spec/rubocop/cop/style/accessor_method_name_spec.rb
@@ -4,76 +4,96 @@ describe RuboCop::Cop::Style::AccessorMethodName do
   subject(:cop) { described_class.new }
 
   it 'registers an offense for method get_... with no args' do
-    inspect_source(cop, ['def get_attr',
-                         '  # ...',
-                         'end'])
+    inspect_source(cop, <<-END.strip_indent)
+      def get_attr
+        # ...
+      end
+    END
     expect(cop.offenses.size).to eq(1)
     expect(cop.highlights).to eq(['get_attr'])
   end
 
   it 'registers an offense for singleton method get_... with no args' do
-    inspect_source(cop, ['def self.get_attr',
-                         '  # ...',
-                         'end'])
+    inspect_source(cop, <<-END.strip_indent)
+      def self.get_attr
+        # ...
+      end
+    END
     expect(cop.offenses.size).to eq(1)
     expect(cop.highlights).to eq(['get_attr'])
   end
 
   it 'accepts method get_something with args' do
-    inspect_source(cop, ['def get_something(arg)',
-                         '  # ...',
-                         'end'])
+    inspect_source(cop, <<-END.strip_indent)
+      def get_something(arg)
+        # ...
+      end
+    END
     expect(cop.offenses).to be_empty
   end
 
   it 'accepts singleton method get_something with args' do
-    inspect_source(cop, ['def self.get_something(arg)',
-                         '  # ...',
-                         'end'])
+    inspect_source(cop, <<-END.strip_indent)
+      def self.get_something(arg)
+        # ...
+      end
+    END
     expect(cop.offenses).to be_empty
   end
 
   it 'registers an offense for method set_something with one arg' do
-    inspect_source(cop, ['def set_attr(arg)',
-                         '  # ...',
-                         'end'])
+    inspect_source(cop, <<-END.strip_indent)
+      def set_attr(arg)
+        # ...
+      end
+    END
     expect(cop.offenses.size).to eq(1)
     expect(cop.highlights).to eq(['set_attr'])
   end
 
   it 'registers an offense for singleton method set_... with one args' do
-    inspect_source(cop, ['def self.set_attr(arg)',
-                         '  # ...',
-                         'end'])
+    inspect_source(cop, <<-END.strip_indent)
+      def self.set_attr(arg)
+        # ...
+      end
+    END
     expect(cop.offenses.size).to eq(1)
     expect(cop.highlights).to eq(['set_attr'])
   end
 
   it 'accepts method set_something with no args' do
-    inspect_source(cop, ['def set_something',
-                         '  # ...',
-                         'end'])
+    inspect_source(cop, <<-END.strip_indent)
+      def set_something
+        # ...
+      end
+    END
     expect(cop.offenses).to be_empty
   end
 
   it 'accepts singleton method set_something with no args' do
-    inspect_source(cop, ['def self.set_something',
-                         '  # ...',
-                         'end'])
+    inspect_source(cop, <<-END.strip_indent)
+      def self.set_something
+        # ...
+      end
+    END
     expect(cop.offenses).to be_empty
   end
 
   it 'accepts method set_something with two args' do
-    inspect_source(cop, ['def set_something(arg1, arg2)',
-                         '  # ...',
-                         'end'])
+    inspect_source(cop, <<-END.strip_indent)
+      def set_something(arg1, arg2)
+        # ...
+      end
+    END
     expect(cop.offenses).to be_empty
   end
 
   it 'accepts singleton method set_something with two args' do
-    inspect_source(cop, ['def self.get_something(arg1, arg2)',
-                         '  # ...',
-                         'end'])
+    inspect_source(cop, <<-END.strip_indent)
+      def self.get_something(arg1, arg2)
+        # ...
+      end
+    END
     expect(cop.offenses).to be_empty
   end
 end

--- a/spec/rubocop/cop/style/alias_spec.rb
+++ b/spec/rubocop/cop/style/alias_spec.rb
@@ -41,13 +41,15 @@ describe RuboCop::Cop::Style::Alias, :config do
     end
 
     it 'does not register an offense for alias in an instance_eval block' do
-      inspect_source(cop, ['module M',
-                           '  def foo',
-                           '    instance_eval {',
-                           '      alias bar baz',
-                           '    }',
-                           '  end',
-                           'end'])
+      inspect_source(cop, <<-END.strip_indent)
+        module M
+          def foo
+            instance_eval {
+              alias bar baz
+            }
+          end
+        end
+      END
       expect(cop.offenses).to be_empty
     end
   end
@@ -85,77 +87,99 @@ describe RuboCop::Cop::Style::Alias, :config do
     end
 
     it 'registers an offense for alias_method in a class block' do
-      inspect_source(cop, ['class C',
-                           '  alias_method :ala, :bala',
-                           'end'])
+      inspect_source(cop, <<-END.strip_indent)
+        class C
+          alias_method :ala, :bala
+        end
+      END
       expect(cop.offenses.size).to eq(1)
       expect(cop.messages)
         .to eq(['Use `alias` instead of `alias_method` in a class body.'])
     end
 
     it 'autocorrects alias_method in a class block' do
-      corrected = autocorrect_source(cop, ['class C',
-                                           '  alias_method :ala, :bala',
-                                           'end'])
-      expect(corrected).to eq(['class C',
-                               '  alias ala bala',
-                               'end'].join("\n"))
+      corrected = autocorrect_source(cop, <<-END.strip_indent)
+        class C
+          alias_method :ala, :bala
+        end
+      END
+      expect(corrected).to eq(<<-END.strip_indent)
+        class C
+          alias ala bala
+        end
+      END
     end
 
     it 'registers an offense for alias_method in a module block' do
-      inspect_source(cop, ['module M',
-                           '  alias_method :ala, :bala',
-                           'end'])
+      inspect_source(cop, <<-END.strip_indent)
+        module M
+          alias_method :ala, :bala
+        end
+      END
       expect(cop.offenses.size).to eq(1)
       expect(cop.messages)
         .to eq(['Use `alias` instead of `alias_method` in a module body.'])
     end
 
     it 'autocorrects alias_method in a module block' do
-      corrected = autocorrect_source(cop, ['module M',
-                                           '  alias_method :ala, :bala',
-                                           'end'])
-      expect(corrected).to eq(['module M',
-                               '  alias ala bala',
-                               'end'].join("\n"))
+      corrected = autocorrect_source(cop, <<-END.strip_indent)
+        module M
+          alias_method :ala, :bala
+        end
+      END
+      expect(corrected).to eq(<<-END.strip_indent)
+        module M
+          alias ala bala
+        end
+      END
     end
 
     it 'does not register an offense for alias_method with explicit receiver' do
-      inspect_source(cop, ['class C',
-                           '  receiver.alias_method :ala, :bala',
-                           'end'])
+      inspect_source(cop, <<-END.strip_indent)
+        class C
+          receiver.alias_method :ala, :bala
+        end
+      END
       expect(cop.offenses).to be_empty
     end
 
     it 'does not register an offense for alias_method in a method def' do
-      inspect_source(cop, ['def method',
-                           '  alias_method :ala, :bala',
-                           'end'])
+      inspect_source(cop, <<-END.strip_indent)
+        def method
+          alias_method :ala, :bala
+        end
+      END
       expect(cop.offenses).to be_empty
     end
 
     it 'does not register an offense for alias_method in self.method def' do
-      inspect_source(cop, ['def self.method',
-                           '  alias_method :ala, :bala',
-                           'end'])
+      inspect_source(cop, <<-END.strip_indent)
+        def self.method
+          alias_method :ala, :bala
+        end
+      END
       expect(cop.offenses).to be_empty
     end
 
     it 'does not register an offense for alias_method in a block' do
-      inspect_source(cop, ['dsl_method do',
-                           '  alias_method :ala, :bala',
-                           'end'])
+      inspect_source(cop, <<-END.strip_indent)
+        dsl_method do
+          alias_method :ala, :bala
+        end
+      END
       expect(cop.offenses).to be_empty
     end
 
     it 'does not register an offense for alias in an instance_eval block' do
-      inspect_source(cop, ['module M',
-                           '  def foo',
-                           '    instance_eval {',
-                           '      alias bar baz',
-                           '    }',
-                           '  end',
-                           'end'])
+      inspect_source(cop, <<-END.strip_indent)
+        module M
+          def foo
+            instance_eval {
+              alias bar baz
+            }
+          end
+        end
+      END
       expect(cop.offenses).to be_empty
     end
   end

--- a/spec/rubocop/cop/style/align_array_spec.rb
+++ b/spec/rubocop/cop/style/align_array_spec.rb
@@ -4,12 +4,14 @@ describe RuboCop::Cop::Style::AlignArray do
   subject(:cop) { described_class.new }
 
   it 'registers an offense for misaligned array elements' do
-    inspect_source(cop, ['array = [',
-                         '  a,',
-                         '   b,',
-                         '  c,',
-                         '   d',
-                         ']'])
+    inspect_source(cop, <<-END.strip_indent)
+      array = [
+        a,
+         b,
+        c,
+         d
+      ]
+    END
     expect(cop.messages).to eq(['Align the elements of an array ' \
                                 'literal if they span more than ' \
                                 'one line.'] * 2)
@@ -17,12 +19,14 @@ describe RuboCop::Cop::Style::AlignArray do
   end
 
   it 'accepts aligned array keys' do
-    inspect_source(cop, ['array = [',
-                         '  a,',
-                         '  b,',
-                         '  c,',
-                         '  d',
-                         ']'])
+    inspect_source(cop, <<-END.strip_indent)
+      array = [
+        a,
+        b,
+        c,
+        d
+      ]
+    END
     expect(cop.offenses).to be_empty
   end
 
@@ -32,96 +36,118 @@ describe RuboCop::Cop::Style::AlignArray do
   end
 
   it 'accepts several elements per line' do
-    inspect_source(cop, ['array = [ a, b,',
-                         '          c, d ]'])
+    inspect_source(cop, <<-END.strip_indent)
+      array = [ a, b,
+                c, d ]
+    END
     expect(cop.offenses).to be_empty
   end
 
   it 'accepts aligned array with fullwidth characters' do
-    inspect_source(cop, ["puts 'Ｒｕｂｙ', [ a,",
-                         '                   b ]'])
+    inspect_source(cop, <<-END.strip_indent)
+      puts 'Ｒｕｂｙ', [ a,
+                         b ]
+    END
     expect(cop.offenses).to be_empty
   end
 
   it 'auto-corrects alignment' do
-    new_source = autocorrect_source(cop, ['array = [',
-                                          '  a,',
-                                          '   b,',
-                                          '  c,',
-                                          ' d',
-                                          ']'])
-    expect(new_source).to eq(['array = [',
-                              '  a,',
-                              '  b,',
-                              '  c,',
-                              '  d',
-                              ']'].join("\n"))
+    new_source = autocorrect_source(cop, <<-END.strip_indent)
+      array = [
+        a,
+         b,
+        c,
+       d
+      ]
+    END
+    expect(new_source).to eq(<<-END.strip_indent)
+      array = [
+        a,
+        b,
+        c,
+        d
+      ]
+    END
   end
 
   it 'does not auto-correct array within array with too much indentation' do
-    original_source = ['[:l1,',
-                       '  [:l2,',
-                       '',
-                       '    [:l3,',
-                       '     [:l4]]]]']
+    original_source = <<-END.strip_indent
+      [:l1,
+        [:l2,
+
+          [:l3,
+           [:l4]]]]
+    END
     new_source = autocorrect_source(cop, original_source)
-    expect(new_source).to eq(['[:l1,',
-                              ' [:l2,', # Corrected
-                              '',
-                              '   [:l3,', # Not corrected
-                              '    [:l4]]]]'].join("\n"))
+    expect(new_source).to eq(<<-END.strip_indent)
+      [:l1,
+       [:l2,
+
+         [:l3,
+          [:l4]]]]
+    END
   end
 
   it 'does not auto-correct array within array with too little indentation' do
-    original_source = ['[:l1,',
-                       '[:l2,',
-                       '',
-                       '  [:l3,',
-                       '   [:l4]]]]']
+    original_source = <<-END.strip_indent
+      [:l1,
+      [:l2,
+
+        [:l3,
+         [:l4]]]]
+    END
     new_source = autocorrect_source(cop, original_source)
-    expect(new_source).to eq(['[:l1,',
-                              ' [:l2,', # Corrected
-                              '',
-                              '   [:l3,', # Not corrected
-                              '    [:l4]]]]'].join("\n"))
+    expect(new_source).to eq(<<-END.strip_indent)
+      [:l1,
+       [:l2,
+
+         [:l3,
+          [:l4]]]]
+    END
   end
 
   it 'auto-corrects only elements that begin a line' do
-    original_source = ['array = [:bar, {',
-                       '         whiz: 2, bang: 3 }, option: 3]']
+    original_source = <<-END.strip_indent
+      array = [:bar, {
+               whiz: 2, bang: 3 }, option: 3]
+    END
     new_source = autocorrect_source(cop, original_source)
-    expect(new_source).to eq(original_source.join("\n"))
+    expect(new_source).to eq(original_source)
   end
 
   it 'does not indent heredoc strings in autocorrect' do
-    original_source = ['var = [',
-                       "       { :type => 'something',",
-                       '         :sql => <<EOF',
-                       'Select something',
-                       'from atable',
-                       'EOF',
-                       '       },',
-                       "      { :type => 'something',",
-                       '        :sql => <<EOF',
-                       'Select something',
-                       'from atable',
-                       'EOF',
-                       '      }',
-                       ']']
+    original_source = <<-END.strip_indent
+      var = [
+             { :type => 'something',
+               :sql => <<EOF
+      Select something
+      from atable
+      EOF
+             },
+            { :type => 'something',
+              :sql => <<EOF
+      Select something
+      from atable
+      EOF
+            }
+      ]
+    END
     new_source = autocorrect_source(cop, original_source)
-    expect(new_source).to eq(['var = [',
-                              "       { :type => 'something',",
-                              '         :sql => <<EOF',
-                              'Select something',
-                              'from atable',
-                              'EOF',
-                              '       },',
-                              "       { :type => 'something',",
-                              '         :sql => <<EOF',
-                              'Select something',
-                              'from atable',
-                              'EOF',
-                              '       }',
-                              ']'].join("\n"))
+    expect(new_source).to eq(<<-END.strip_indent)
+      var = [
+             { :type => 'something',
+               :sql => <<EOF
+      Select something
+      from atable
+      EOF
+             },
+             { :type => 'something',
+               :sql => <<EOF
+      Select something
+      from atable
+      EOF
+             }
+      ]
+    END
   end
 end

--- a/spec/rubocop/cop/style/align_hash_spec.rb
+++ b/spec/rubocop/cop/style/align_hash_spec.rb
@@ -10,23 +10,27 @@ describe RuboCop::Cop::Style::AlignHash, :config do
     end
 
     it 'accepts several pairs per line' do
-      inspect_source(cop, ['func(a: 1, bb: 2,',
-                           '     ccc: 3, dddd: 4)'])
+      inspect_source(cop, <<-END.strip_indent)
+        func(a: 1, bb: 2,
+             ccc: 3, dddd: 4)
+      END
       expect(cop.offenses).to be_empty
     end
 
     it "does not auto-correct pairs that don't start a line" do
-      source = ['render :json => {:a => messages,',
-                '                 :b => :json}, :status => 404',
-                'def example',
-                '  a(',
-                '    b: :c,',
-                '    d: e(',
-                '      f: g',
-                '    ), h: :i)',
-                'end']
+      source = <<-END.strip_indent
+        render :json => {:a => messages,
+                         :b => :json}, :status => 404
+        def example
+          a(
+            b: :c,
+            d: e(
+              f: g
+            ), h: :i)
+        end
+      END
       new_source = autocorrect_source(cop, source)
-      expect(new_source).to eq(source.join("\n"))
+      expect(new_source).to eq(source)
     end
   end
 
@@ -38,14 +42,18 @@ describe RuboCop::Cop::Style::AlignHash, :config do
     end
 
     it 'registers offense for misaligned keys in implicit hash' do
-      inspect_source(cop, ['func(a: 0,',
-                           '  b: 1)'])
+      inspect_source(cop, <<-END.strip_indent)
+        func(a: 0,
+          b: 1)
+      END
       expect(cop.offenses.size).to eq(1)
     end
 
     it 'registers offense for misaligned keys in explicit hash' do
-      inspect_source(cop, ['func({a: 0,',
-                           '  b: 1})'])
+      inspect_source(cop, <<-END.strip_indent)
+        func({a: 0,
+          b: 1})
+      END
       expect(cop.offenses.size).to eq(1)
     end
   end
@@ -58,14 +66,18 @@ describe RuboCop::Cop::Style::AlignHash, :config do
     end
 
     it 'accepts misaligned keys in implicit hash' do
-      inspect_source(cop, ['func(a: 0,',
-                           '  b: 1)'])
+      inspect_source(cop, <<-END.strip_indent)
+        func(a: 0,
+          b: 1)
+      END
       expect(cop.offenses).to be_empty
     end
 
     it 'accepts misaligned keys in explicit hash' do
-      inspect_source(cop, ['func({a: 0,',
-                           '  b: 1})'])
+      inspect_source(cop, <<-END.strip_indent)
+        func({a: 0,
+          b: 1})
+      END
       expect(cop.offenses).to be_empty
     end
   end
@@ -78,14 +90,18 @@ describe RuboCop::Cop::Style::AlignHash, :config do
     end
 
     it 'accepts misaligned keys in implicit hash' do
-      inspect_source(cop, ['func(a: 0,',
-                           '  b: 1)'])
+      inspect_source(cop, <<-END.strip_indent)
+        func(a: 0,
+          b: 1)
+      END
       expect(cop.offenses).to be_empty
     end
 
     it 'registers offense for misaligned keys in explicit hash' do
-      inspect_source(cop, ['func({a: 0,',
-                           '  b: 1})'])
+      inspect_source(cop, <<-END.strip_indent)
+        func({a: 0,
+          b: 1})
+      END
       expect(cop.offenses.size).to eq(1)
     end
   end
@@ -98,14 +114,18 @@ describe RuboCop::Cop::Style::AlignHash, :config do
     end
 
     it 'registers offense for misaligned keys in implicit hash' do
-      inspect_source(cop, ['func(a: 0,',
-                           '  b: 1)'])
+      inspect_source(cop, <<-END.strip_indent)
+        func(a: 0,
+          b: 1)
+      END
       expect(cop.offenses.size).to eq(1)
     end
 
     it 'accepts misaligned keys in explicit hash' do
-      inspect_source(cop, ['func({a: 0,',
-                           '  b: 1})'])
+      inspect_source(cop, <<-END.strip_indent)
+        func({a: 0,
+          b: 1})
+      END
       expect(cop.offenses).to be_empty
     end
   end
@@ -119,14 +139,16 @@ describe RuboCop::Cop::Style::AlignHash, :config do
 
   context 'with default configuration' do
     it 'registers an offense for misaligned hash keys' do
-      inspect_source(cop, ['hash1 = {',
-                           '  a: 0,',
-                           '   bb: 1',
-                           '}',
-                           'hash2 = {',
-                           "  'ccc' => 2,",
-                           " 'dddd'  =>  2",
-                           '}'])
+      inspect_source(cop, <<-END.strip_indent)
+        hash1 = {
+          a: 0,
+           bb: 1
+        }
+        hash2 = {
+          'ccc' => 2,
+         'dddd'  =>  2
+        }
+      END
       expect(cop.messages).to eq(['Align the elements of a hash ' \
                                   'literal if they span more than ' \
                                   'one line.'] * 2)
@@ -135,48 +157,60 @@ describe RuboCop::Cop::Style::AlignHash, :config do
     end
 
     it 'registers an offense for misaligned mixed multiline hash keys' do
-      inspect_source(cop, ['hash = { a: 1, b: 2,',
-                           '        c: 3 }'])
+      inspect_source(cop, <<-END.strip_indent)
+        hash = { a: 1, b: 2,
+                c: 3 }
+      END
       expect(cop.offenses.size).to eq(1)
     end
 
     it 'accepts aligned hash keys' do
-      inspect_source(cop, ['hash1 = {',
-                           '  a: 0,',
-                           '  bb: 1,',
-                           '}',
-                           'hash2 = {',
-                           "  'ccc' => 2,",
-                           "  'dddd'  =>  2",
-                           '}'])
+      inspect_source(cop, <<-END.strip_indent)
+        hash1 = {
+          a: 0,
+          bb: 1,
+        }
+        hash2 = {
+          'ccc' => 2,
+          'dddd'  =>  2
+        }
+      END
       expect(cop.offenses).to be_empty
     end
 
     it 'registers an offense for separator alignment' do
-      inspect_source(cop, ['hash = {',
-                           "    'a' => 0,",
-                           "  'bbb' => 1",
-                           '}'])
+      inspect_source(cop, <<-END.strip_indent)
+        hash = {
+            'a' => 0,
+          'bbb' => 1
+        }
+      END
       expect(cop.offenses.size).to eq(1)
       expect(cop.highlights).to eq(["'bbb' => 1"])
     end
 
     context 'with implicit hash as last argument' do
       it 'registers an offense for misaligned hash keys' do
-        inspect_source(cop, ['func(a: 0,',
-                             '  b: 1)'])
+        inspect_source(cop, <<-END.strip_indent)
+          func(a: 0,
+            b: 1)
+        END
         expect(cop.offenses.size).to eq(1)
       end
 
       it 'registers an offense for right alignment of keys' do
-        inspect_source(cop, ['func(a: 0,',
-                             '   bbb: 1)'])
+        inspect_source(cop, <<-END.strip_indent)
+          func(a: 0,
+             bbb: 1)
+        END
         expect(cop.offenses.size).to eq(1)
       end
 
       it 'accepts aligned hash keys' do
-        inspect_source(cop, ['func(a: 0,',
-                             '     b: 1)'])
+        inspect_source(cop, <<-END.strip_indent)
+          func(a: 0,
+               b: 1)
+        END
         expect(cop.offenses).to be_empty
       end
 
@@ -187,49 +221,65 @@ describe RuboCop::Cop::Style::AlignHash, :config do
     end
 
     it 'auto-corrects alignment' do
-      new_source = autocorrect_source(cop, ['hash1 = { a: 0,',
-                                            '     bb: 1,',
-                                            '           ccc: 2 }',
-                                            'hash2 = { :a   => 0,',
-                                            '     :bb  => 1,',
-                                            '          :ccc  =>2 }'])
-      expect(new_source).to eq(['hash1 = { a: 0,',
-                                '          bb: 1,',
-                                '          ccc: 2 }',
-                                'hash2 = { :a   => 0,',
-                                '          :bb  => 1,',
-                                # Separator and value are not corrected
-                                # in 'key' mode.
-                                '          :ccc  =>2 }'].join("\n"))
+      new_source = autocorrect_source(cop, <<-END.strip_indent)
+        hash1 = { a: 0,
+             bb: 1,
+                   ccc: 2 }
+        hash2 = { :a   => 0,
+             :bb  => 1,
+                  :ccc  =>2 }
+      END
+
+      # Separator and value are not corrected in 'key' mode.
+      expect(new_source).to eq(<<-END.strip_indent)
+        hash1 = { a: 0,
+                  bb: 1,
+                  ccc: 2 }
+        hash2 = { :a   => 0,
+                  :bb  => 1,
+                  :ccc  =>2 }
+      END
     end
 
     it 'auto-corrects alignment for mixed multiline hash keys' do
-      new_sources = autocorrect_source(cop, ['hash = { a: 1, b: 2,',
-                                             '        c: 3 }'])
-      expect(new_sources).to eq(['hash = { a: 1, b: 2,',
-                                 '         c: 3 }'].join("\n"))
+      new_sources = autocorrect_source(cop, <<-END.strip_indent)
+        hash = { a: 1, b: 2,
+                c: 3 }
+      END
+      expect(new_sources).to eq(<<-END.strip_indent)
+        hash = { a: 1, b: 2,
+                 c: 3 }
+      END
     end
 
     context 'ruby >= 2.0', :ruby20 do
       it 'auto-corrects alignment when using double splat ' \
          'in an explicit hash' do
-        new_source = autocorrect_source(cop, ["Hash(foo: 'bar',",
-                                              '       **extra_params',
-                                              ')'].join("\n"))
+        new_source = autocorrect_source(cop, <<-END.strip_indent)
+          Hash(foo: 'bar',
+                 **extra_params
+          )
+        END
 
-        expect(new_source).to eq(["Hash(foo: 'bar',",
-                                  '     **extra_params',
-                                  ')'].join("\n"))
+        expect(new_source).to eq(<<-END.strip_indent)
+          Hash(foo: 'bar',
+               **extra_params
+          )
+        END
       end
 
       it 'auto-corrects alignment when using double splat in braces' do
-        new_source = autocorrect_source(cop, ["{foo: 'bar',",
-                                              '       **extra_params',
-                                              '}'].join("\n"))
+        new_source = autocorrect_source(cop, <<-END.strip_indent)
+          {foo: 'bar',
+                 **extra_params
+          }
+        END
 
-        expect(new_source).to eq(["{foo: 'bar',",
-                                  ' **extra_params',
-                                  '}'].join("\n"))
+        expect(new_source).to eq(<<-END.strip_indent)
+          {foo: 'bar',
+           **extra_params
+          }
+        END
       end
     end
   end
@@ -247,14 +297,16 @@ describe RuboCop::Cop::Style::AlignHash, :config do
     include_examples 'not on separate lines'
 
     it 'accepts aligned hash keys and values' do
-      inspect_source(cop, ['hash1 = {',
-                           "  'a'   => 0,",
-                           "  'bbb' => 1",
-                           '}',
-                           'hash2 = {',
-                           '  a:   0,',
-                           '  bbb: 1',
-                           '}'])
+      inspect_source(cop, <<-END.strip_indent)
+        hash1 = {
+          'a'   => 0,
+          'bbb' => 1
+        }
+        hash2 = {
+          a:   0,
+          bbb: 1
+        }
+      END
       expect(cop.offenses).to be_empty
     end
 
@@ -264,66 +316,78 @@ describe RuboCop::Cop::Style::AlignHash, :config do
     end
 
     it 'accepts a multiline array of single line hashes' do
-      inspect_source(cop, ['def self.scenarios_order',
-                           '    [',
-                           '      { before:   %w( l k ) },',
-                           '      { ending:   %w( m l ) },',
-                           '      { starting: %w( m n ) },',
-                           '      { after:    %w( n o ) }',
-                           '    ]',
-                           '  end'])
+      inspect_source(cop, <<-END.strip_indent)
+        def self.scenarios_order
+            [
+              { before:   %w( l k ) },
+              { ending:   %w( m l ) },
+              { starting: %w( m n ) },
+              { after:    %w( n o ) }
+            ]
+          end
+      END
       expect(cop.offenses).to be_empty
     end
 
     it 'accepts hashes that use different separators' do
-      inspect_source(cop, ['hash = {',
-                           '  a: 1,',
-                           "  'bbb' => 2",
-                           '}'])
+      inspect_source(cop, <<-END.strip_indent)
+        hash = {
+          a: 1,
+          'bbb' => 2
+        }
+      END
       expect(cop.offenses).to be_empty
     end
 
     context 'ruby >= 2.0', :ruby20 do
       it 'accepts hashes that use different separators and double splats' do
-        inspect_source(cop, ['hash = {',
-                             '  a: 1,',
-                             "  'bbb' => 2,",
-                             '  **foo',
-                             '}'])
+        inspect_source(cop, <<-END.strip_indent)
+          hash = {
+            a: 1,
+            'bbb' => 2,
+            **foo
+          }
+        END
         expect(cop.offenses).to be_empty
       end
 
       it 'accepts hashes that use different separators and double splats' do
-        inspect_source(cop, ['hash = {',
-                             '  a: 1,',
-                             '  **kw',
-                             '}'])
+        inspect_source(cop, <<-END.strip_indent)
+          hash = {
+            a: 1,
+            **kw
+          }
+        END
         expect(cop.offenses).to be_empty
       end
     end
 
     it 'registers an offense for misaligned hash values' do
-      inspect_source(cop, ['hash1 = {',
-                           "  'a'   =>  0,",
-                           "  'bbb' => 1",
-                           '}',
-                           'hash2 = {',
-                           '  a:   0,',
-                           '  bbb:1',
-                           '}'])
+      inspect_source(cop, <<-END.strip_indent)
+        hash1 = {
+          'a'   =>  0,
+          'bbb' => 1
+        }
+        hash2 = {
+          a:   0,
+          bbb:1
+        }
+      END
       expect(cop.highlights).to eq(["'a'   =>  0",
                                     'bbb:1'])
     end
 
     it 'registers an offense for misaligned hash keys' do
-      inspect_source(cop, ['hash1 = {',
-                           "  'a'   =>  0,",
-                           " 'bbb'  =>  1",
-                           '}',
-                           'hash2 = {',
-                           '   a:  0,',
-                           '  bbb: 1',
-                           '}'])
+      inspect_source(cop, <<-END.strip_indent)
+        hash1 = {
+          'a'   =>  0,
+         'bbb'  =>  1
+        }
+        hash2 = {
+           a:  0,
+          bbb: 1
+        }
+      END
       expect(cop.highlights).to eq(["'a'   =>  0",
                                     "'bbb'  =>  1",
                                     'a:  0',
@@ -331,26 +395,32 @@ describe RuboCop::Cop::Style::AlignHash, :config do
     end
 
     it 'registers an offense for misaligned hash rockets' do
-      inspect_source(cop, ['hash = {',
-                           "  'a'   => 0,",
-                           "  'bbb'  => 1",
-                           '}'])
+      inspect_source(cop, <<-END.strip_indent)
+        hash = {
+          'a'   => 0,
+          'bbb'  => 1
+        }
+      END
       expect(cop.offenses.size).to eq(1)
     end
 
     it 'auto-corrects alignment' do
-      new_source = autocorrect_source(cop, ['hash1 = { a: 0,',
-                                            '     bb:   1,',
-                                            '           ccc: 2 }',
-                                            "hash2 = { 'a' => 0,",
-                                            "     'bb' =>   1,",
-                                            "           'ccc'  =>2 }"])
-      expect(new_source).to eq(['hash1 = { a:   0,',
-                                '          bb:  1,',
-                                '          ccc: 2 }',
-                                "hash2 = { 'a'   => 0,",
-                                "          'bb'  => 1,",
-                                "          'ccc' => 2 }"].join("\n"))
+      new_source = autocorrect_source(cop, <<-END.strip_indent)
+        hash1 = { a: 0,
+             bb:   1,
+                   ccc: 2 }
+        hash2 = { 'a' => 0,
+             'bb' =>   1,
+                   'ccc'  =>2 }
+      END
+      expect(new_source).to eq(<<-END.strip_indent)
+        hash1 = { a:   0,
+                  bb:  1,
+                  ccc: 2 }
+        hash2 = { 'a'   => 0,
+                  'bb'  => 1,
+                  'ccc' => 2 }
+      END
     end
   end
 
@@ -376,10 +446,12 @@ describe RuboCop::Cop::Style::AlignHash, :config do
       }
     end
     it 'fails' do
-      src = ['hash = {',
-             '  a: 0,',
-             '  bb: 1',
-             '}']
+      src = <<-END.strip_indent
+        hash = {
+          a: 0,
+          bb: 1
+        }
+      END
       expect { inspect_source(cop, src) }.to raise_error(RuntimeError)
     end
   end
@@ -393,14 +465,16 @@ describe RuboCop::Cop::Style::AlignHash, :config do
     end
 
     it 'accepts aligned hash keys' do
-      inspect_source(cop, ['hash1 = {',
-                           '    a: 0,',
-                           '  bbb: 1',
-                           '}',
-                           'hash2 = {',
-                           "    'a' => 0,",
-                           "  'bbb' => 1",
-                           '}'])
+      inspect_source(cop, <<-END.strip_indent)
+        hash1 = {
+            a: 0,
+          bbb: 1
+        }
+        hash2 = {
+            'a' => 0,
+          'bbb' => 1
+        }
+      END
       expect(cop.offenses).to be_empty
     end
 
@@ -410,26 +484,32 @@ describe RuboCop::Cop::Style::AlignHash, :config do
     end
 
     it 'registers an offense for misaligned hash values' do
-      inspect_source(cop, ['hash = {',
-                           "    'a' =>  0,",
-                           "  'bbb' => 1",
-                           '}'])
+      inspect_source(cop, <<-END.strip_indent)
+        hash = {
+            'a' =>  0,
+          'bbb' => 1
+        }
+      END
       expect(cop.offenses.size).to eq(1)
     end
 
     it 'registers an offense for misaligned hash rockets' do
-      inspect_source(cop, ['hash = {',
-                           "    'a'  => 0,",
-                           "  'bbb' =>  1",
-                           '}'])
+      inspect_source(cop, <<-END.strip_indent)
+        hash = {
+            'a'  => 0,
+          'bbb' =>  1
+        }
+      END
       expect(cop.offenses.size).to eq(1)
     end
 
     context 'ruby >= 2.0', :ruby20 do
       it 'accepts hashes with different separators' do
-        inspect_source(cop, ['{a: 1,',
-                             "  'b' => 2,",
-                             '   **params}'])
+        inspect_source(cop, <<-END.strip_indent)
+          {a: 1,
+            'b' => 2,
+             **params}
+        END
 
         expect(cop.offenses).to be_empty
       end
@@ -438,18 +518,22 @@ describe RuboCop::Cop::Style::AlignHash, :config do
     include_examples 'not on separate lines'
 
     it 'auto-corrects alignment' do
-      new_source = autocorrect_source(cop, ['hash1 = { a: 0,',
-                                            '     bb:    1,',
-                                            '           ccc: 2 }',
-                                            'hash2 = { a => 0,',
-                                            '     bb =>    1,',
-                                            '           ccc  =>2 }'])
-      expect(new_source).to eq(['hash1 = { a: 0,',
-                                '         bb: 1,',
-                                '        ccc: 2 }',
-                                'hash2 = { a => 0,',
-                                '         bb => 1,',
-                                '        ccc => 2 }'].join("\n"))
+      new_source = autocorrect_source(cop, <<-END.strip_indent)
+        hash1 = { a: 0,
+             bb:    1,
+                   ccc: 2 }
+        hash2 = { a => 0,
+             bb =>    1,
+                   ccc  =>2 }
+      END
+      expect(new_source).to eq(<<-END.strip_indent)
+        hash1 = { a: 0,
+                 bb: 1,
+                ccc: 2 }
+        hash2 = { a => 0,
+                 bb => 1,
+                ccc => 2 }
+      END
     end
 
     it "doesn't break code by moving long keys too far left" do
@@ -476,26 +560,30 @@ describe RuboCop::Cop::Style::AlignHash, :config do
     end
 
     it 'registers offenses for misaligned entries' do
-      inspect_source(cop, ['hash1 = {',
-                           '  a:   0,',
-                           '  bbb: 1',
-                           '}',
-                           'hash2 = {',
-                           "    'a' => 0,",
-                           "  'bbb' => 1",
-                           '}'])
+      inspect_source(cop, <<-END.strip_indent)
+        hash1 = {
+          a:   0,
+          bbb: 1
+        }
+        hash2 = {
+            'a' => 0,
+          'bbb' => 1
+        }
+      END
       expect(cop.highlights).to eq(['bbb: 1', "'bbb' => 1"])
     end
 
     it 'accepts aligned entries' do
-      inspect_source(cop, ['hash1 = {',
-                           '    a: 0,',
-                           '  bbb: 1',
-                           '}',
-                           'hash2 = {',
-                           "  'a' => 0,",
-                           "  'bbb' => 1",
-                           '}'])
+      inspect_source(cop, <<-END.strip_indent)
+        hash1 = {
+            a: 0,
+          bbb: 1
+        }
+        hash2 = {
+          'a' => 0,
+          'bbb' => 1
+        }
+      END
       expect(cop.offenses).to be_empty
     end
   end

--- a/spec/rubocop/cop/style/align_parameters_spec.rb
+++ b/spec/rubocop/cop/style/align_parameters_spec.rb
@@ -18,35 +18,45 @@ describe RuboCop::Cop::Style::AlignParameters do
     end
 
     it 'registers an offense for parameters with single indent' do
-      inspect_source(cop, ['function(a,',
-                           '  if b then c else d end)'])
+      inspect_source(cop, <<-END.strip_indent)
+        function(a,
+          if b then c else d end)
+      END
       expect(cop.offenses.size).to eq(1)
       expect(cop.highlights).to eq(['if b then c else d end'])
     end
 
     it 'registers an offense for parameters with double indent' do
-      inspect_source(cop, ['function(a,',
-                           '    if b then c else d end)'])
+      inspect_source(cop, <<-END.strip_indent)
+        function(a,
+            if b then c else d end)
+      END
       expect(cop.offenses.size).to eq(1)
     end
 
     it 'accepts multiline []= method call' do
-      inspect_source(cop, ['Test.config["something"] =',
-                           ' true'])
+      inspect_source(cop, <<-END.strip_indent)
+        Test.config["something"] =
+         true
+      END
       expect(cop.offenses).to be_empty
     end
 
     it 'accepts correctly aligned parameters' do
-      inspect_source(cop, ['function(a,',
-                           '         0, 1,',
-                           '         (x + y),',
-                           '         if b then c else d end)'])
+      inspect_source(cop, <<-END.strip_indent)
+        function(a,
+                 0, 1,
+                 (x + y),
+                 if b then c else d end)
+      END
       expect(cop.offenses).to be_empty
     end
 
     it 'accepts correctly aligned parameters with fullwidth characters' do
-      inspect_source(cop, ["f 'Ｒｕｂｙ', g(a,",
-                           '                b)'])
+      inspect_source(cop, <<-END.strip_indent)
+        f 'Ｒｕｂｙ', g(a,
+                        b)
+      END
       expect(cop.offenses).to be_empty
     end
 
@@ -56,19 +66,23 @@ describe RuboCop::Cop::Style::AlignParameters do
     end
 
     it "doesn't get confused by a symbol argument" do
-      inspect_source(cop, ['add_offense(index,',
-                           '            MSG % kind)'])
+      inspect_source(cop, <<-END.strip_indent)
+        add_offense(index,
+                    MSG % kind)
+      END
       expect(cop.offenses).to be_empty
     end
 
     it "doesn't get confused by splat operator" do
-      inspect_source(cop, ['func1(*a,',
-                           '      *b,',
-                           '      c)',
-                           'func2(a,',
-                           '     *b,',
-                           '      c)',
-                           'func3(*a)'])
+      inspect_source(cop, <<-END.strip_indent)
+        func1(*a,
+              *b,
+              c)
+        func2(a,
+             *b,
+              c)
+        func3(*a)
+      END
       expect(cop.offenses.map(&:to_s))
         .to eq(['C:  5:  6: Align the parameters of a method call if ' \
                 'they span more than one line.'])
@@ -76,8 +90,10 @@ describe RuboCop::Cop::Style::AlignParameters do
     end
 
     it "doesn't get confused by extra comma at the end" do
-      inspect_source(cop, ['func1(a,',
-                           '     b,)'])
+      inspect_source(cop, <<-END.strip_indent)
+        func1(a,
+             b,)
+      END
       expect(cop.offenses.map(&:to_s))
         .to eq(['C:  2:  6: Align the parameters of a method call if ' \
                 'they span more than one line.'])
@@ -85,20 +101,26 @@ describe RuboCop::Cop::Style::AlignParameters do
     end
 
     it 'can handle a correctly aligned string literal as first argument' do
-      inspect_source(cop, ['add_offense(x,',
-                           '            a)'])
+      inspect_source(cop, <<-END.strip_indent)
+        add_offense(x,
+                    a)
+      END
       expect(cop.offenses).to be_empty
     end
 
     it 'can handle a string literal as other argument' do
-      inspect_source(cop, ['add_offense(',
-                           '            "", a)'])
+      inspect_source(cop, <<-END.strip_indent)
+        add_offense(
+                    "", a)
+      END
       expect(cop.offenses).to be_empty
     end
 
     it "doesn't get confused by a line break inside a parameter" do
-      inspect_source(cop, ['read(path, { headers:    true,',
-                           '             converters: :numeric })'])
+      inspect_source(cop, <<-END.strip_indent)
+        read(path, { headers:    true,
+                     converters: :numeric })
+      END
       expect(cop.offenses).to be_empty
     end
 
@@ -113,34 +135,42 @@ describe RuboCop::Cop::Style::AlignParameters do
     end
 
     it 'accepts braceless hashes' do
-      inspect_source(cop, ['run(collection, :entry_name => label,',
-                           '                :paginator  => paginator)'])
+      inspect_source(cop, <<-END.strip_indent)
+        run(collection, :entry_name => label,
+                        :paginator  => paginator)
+      END
       expect(cop.offenses).to be_empty
     end
 
     it 'accepts the first parameter being on a new row' do
-      inspect_source(cop, ['  match(',
-                           '    a,',
-                           '    b',
-                           '  )'])
+      inspect_source(cop, <<-END.strip_margin('|'))
+        |  match(
+        |    a,
+        |    b
+        |  )
+      END
       expect(cop.offenses).to be_empty
     end
 
     it 'can handle heredoc strings' do
-      inspect_source(cop, ['class_eval(<<-EOS, __FILE__, __LINE__ + 1)',
-                           '            def run_#{name}_callbacks(*args)',
-                           '              a = 1',
-                           '              return value',
-                           '            end',
-                           '            EOS'])
+      inspect_source(cop, <<-'END'.strip_indent)
+        class_eval(<<-EOS, __FILE__, __LINE__ + 1)
+                    def run_#{name}_callbacks(*args)
+                      a = 1
+                      return value
+                    end
+                    EOS
+      END
       expect(cop.offenses).to be_empty
     end
 
     it 'can handle a method call within a method call' do
-      inspect_source(cop, ['a(a1,',
-                           '  b(b1,',
-                           '    b2),',
-                           '  a2)'])
+      inspect_source(cop, <<-END.strip_indent)
+        a(a1,
+          b(b1,
+            b2),
+          a2)
+      END
       expect(cop.offenses).to be_empty
     end
 
@@ -150,17 +180,21 @@ describe RuboCop::Cop::Style::AlignParameters do
     end
 
     it 'can handle do-end' do
-      inspect_source(cop, ['      run(lambda do |e|',
-                           "        w = e['warden']",
-                           '      end)'])
+      inspect_source(cop, <<-END.strip_margin('|'))
+        |      run(lambda do |e|
+        |        w = e['warden']
+        |      end)
+      END
       expect(cop.offenses).to be_empty
     end
 
     it 'can handle a call with a block inside another call' do
-      src = ['new(table_name,',
-             '    exec_query("info(\'#{row[\'name\']}\')").map { |col|',
-             "      col['name']",
-             '    })']
+      src = <<-'END'.strip_indent
+        new(table_name,
+            exec_query("info('#{row['name']}')").map { |col|
+              col['name']
+            })
+      END
       inspect_source(cop, src)
       expect(cop.offenses).to be_empty
     end
@@ -176,9 +210,11 @@ describe RuboCop::Cop::Style::AlignParameters do
     end
 
     it 'can handle a multiline hash as second parameter' do
-      inspect_source(cop, ['tag(:input, {',
-                           '  :value => value',
-                           '})'])
+      inspect_source(cop, <<-END.strip_indent)
+        tag(:input, {
+          :value => value
+        })
+      END
       expect(cop.offenses).to be_empty
     end
 
@@ -195,185 +231,233 @@ describe RuboCop::Cop::Style::AlignParameters do
 
     it "doesn't crash and burn when there are nested issues" do
       # regression test; see GH issue 2441
-      src = ['build(:house,',
-             '  :rooms => [',
-             '    build(:bedroom,',
-             '      :bed => build(:bed,',
-             '        :occupants => [],',
-             '        :size => "king"',
-             '      )',
-             '    )',
-             '  ]',
-             ')']
+      src = <<-END.strip_indent
+        build(:house,
+          :rooms => [
+            build(:bedroom,
+              :bed => build(:bed,
+                :occupants => [],
+                :size => "king"
+              )
+            )
+          ]
+        )
+      END
       expect { inspect_source(cop, src) }.not_to raise_error
     end
 
     context 'method definitions' do
       it 'registers an offense for parameters with single indent' do
-        inspect_source(cop, ['def method(a,',
-                             '  b)',
-                             'end'])
+        inspect_source(cop, <<-END.strip_indent)
+          def method(a,
+            b)
+          end
+        END
         expect(cop.offenses.size).to eq 1
         expect(cop.offenses.first.to_s).to match(/method definition/)
       end
 
       it 'registers an offense for parameters with double indent' do
-        inspect_source(cop, ['def method(a,',
-                             '    b)',
-                             'end'])
+        inspect_source(cop, <<-END.strip_indent)
+          def method(a,
+              b)
+          end
+        END
         expect(cop.offenses.size).to eq 1
       end
 
       it 'accepts parameter lists on a single line' do
-        inspect_source(cop, ['def method(a, b)',
-                             'end'])
+        inspect_source(cop, <<-END.strip_indent)
+          def method(a, b)
+          end
+        END
         expect(cop.offenses).to be_empty
       end
 
       it 'accepts proper indentation' do
-        inspect_source(cop, ['def method(a,',
-                             '           b)',
-                             'end'])
+        inspect_source(cop, <<-END.strip_indent)
+          def method(a,
+                     b)
+          end
+        END
         expect(cop.offenses).to be_empty
       end
 
       it 'accepts the first parameter being on a new row' do
-        inspect_source(cop, ['def method(',
-                             '  a,',
-                             '  b)',
-                             'end'])
+        inspect_source(cop, <<-END.strip_indent)
+          def method(
+            a,
+            b)
+          end
+        END
         expect(cop.offenses).to be_empty
       end
 
       it 'accepts a method definition without parameters' do
-        inspect_source(cop, ['def method',
-                             'end'])
+        inspect_source(cop, <<-END.strip_indent)
+          def method
+          end
+        END
         expect(cop.offenses).to be_empty
       end
 
       it "doesn't get confused by splat" do
-        inspect_source(cop, ['def func2(a,',
-                             '         *b,',
-                             '          c)',
-                             'end'])
+        inspect_source(cop, <<-END.strip_indent)
+          def func2(a,
+                   *b,
+                    c)
+          end
+        END
         expect(cop.offenses.size).to eq 1
         expect(cop.highlights).to eq(['*b'])
       end
 
       it 'auto-corrects alignment' do
-        new_source = autocorrect_source(cop, ['def method(a,',
-                                              '    b)',
-                                              'end'])
-        expect(new_source).to eq(['def method(a,',
-                                  '           b)',
-                                  'end'].join("\n"))
+        new_source = autocorrect_source(cop, <<-END.strip_indent)
+          def method(a,
+              b)
+          end
+        END
+        expect(new_source).to eq(<<-END.strip_indent)
+          def method(a,
+                     b)
+          end
+        END
       end
 
       context 'defining self.method' do
         it 'registers an offense for parameters with single indent' do
-          inspect_source(cop, ['def self.method(a,',
-                               '  b)',
-                               'end'])
+          inspect_source(cop, <<-END.strip_indent)
+            def self.method(a,
+              b)
+            end
+          END
           expect(cop.offenses.size).to eq 1
           expect(cop.offenses.first.to_s).to match(/method definition/)
         end
 
         it 'accepts proper indentation' do
-          inspect_source(cop, ['def self.method(a,',
-                               '                b)',
-                               'end'])
+          inspect_source(cop, <<-END.strip_indent)
+            def self.method(a,
+                            b)
+            end
+          END
           expect(cop.offenses).to be_empty
         end
 
         it 'auto-corrects alignment' do
-          new_source = autocorrect_source(cop, ['def self.method(a,',
-                                                '    b)',
-                                                'end'])
-          expect(new_source).to eq(['def self.method(a,',
-                                    '                b)',
-                                    'end'].join("\n"))
+          new_source = autocorrect_source(cop, <<-END.strip_indent)
+            def self.method(a,
+                b)
+            end
+          END
+          expect(new_source).to eq(<<-END.strip_indent)
+            def self.method(a,
+                            b)
+            end
+          END
         end
       end
     end
 
     context 'assigned methods' do
       it 'accepts the first parameter being on a new row' do
-        inspect_source(cop, [' assigned_value = match(',
-                             '   a,',
-                             '   b,',
-                             '   c',
-                             ' )'])
+        inspect_source(cop, <<-END.strip_margin('|'))
+          | assigned_value = match(
+          |   a,
+          |   b,
+          |   c
+          | )
+        END
         expect(cop.offenses).to be_empty
       end
 
       it 'accepts the first parameter being on method row' do
-        inspect_source(cop, [' assigned_value = match(a,',
-                             '                        b,',
-                             '                        c',
-                             '                  )'])
+        inspect_source(cop, <<-END.strip_margin('|'))
+          | assigned_value = match(a,
+          |                        b,
+          |                        c
+          |                  )
+        END
         expect(cop.offenses).to be_empty
       end
     end
 
     it 'auto-corrects alignment' do
-      new_source = autocorrect_source(cop, ['func(a,',
-                                            '       b,',
-                                            'c)'])
-      expect(new_source).to eq(['func(a,',
-                                '     b,',
-                                '     c)'].join("\n"))
+      new_source = autocorrect_source(cop, <<-END.strip_indent)
+        func(a,
+               b,
+        c)
+      END
+      expect(new_source).to eq(<<-END.strip_indent)
+        func(a,
+             b,
+             c)
+      END
     end
 
     it 'auto-corrects each line of a multi-line parameter to the right' do
       new_source =
-        autocorrect_source(cop,
-                           ['create :transaction, :closed,',
-                            '      account:          account,',
-                            '      open_price:       1.29,',
-                            '      close_price:      1.30'])
+        autocorrect_source(cop, <<-END.strip_indent)
+          create :transaction, :closed,
+                account:          account,
+                open_price:       1.29,
+                close_price:      1.30
+        END
       expect(new_source)
-        .to eq(['create :transaction, :closed,',
-                '       account:          account,',
-                '       open_price:       1.29,',
-                '       close_price:      1.30'].join("\n"))
+        .to eq(<<-END.strip_indent)
+          create :transaction, :closed,
+                 account:          account,
+                 open_price:       1.29,
+                 close_price:      1.30
+        END
     end
 
     it 'auto-corrects each line of a multi-line parameter to the left' do
       new_source =
-        autocorrect_source(cop,
-                           ['create :transaction, :closed,',
-                            '         account:          account,',
-                            '         open_price:       1.29,',
-                            '         close_price:      1.30'])
+        autocorrect_source(cop, <<-END.strip_indent)
+          create :transaction, :closed,
+                   account:          account,
+                   open_price:       1.29,
+                   close_price:      1.30
+        END
       expect(new_source)
-        .to eq(['create :transaction, :closed,',
-                '       account:          account,',
-                '       open_price:       1.29,',
-                '       close_price:      1.30'].join("\n"))
+        .to eq(<<-END.strip_indent)
+          create :transaction, :closed,
+                 account:          account,
+                 open_price:       1.29,
+                 close_price:      1.30
+        END
     end
 
     it 'auto-corrects only parameters that begin a line' do
-      original_source = ['foo(:bar, {',
-                         '    whiz: 2, bang: 3 }, option: 3)']
+      original_source = <<-END.strip_indent
+        foo(:bar, {
+            whiz: 2, bang: 3 }, option: 3)
+      END
       new_source = autocorrect_source(cop, original_source)
-      expect(new_source).to eq(original_source.join("\n"))
+      expect(new_source).to eq(original_source)
     end
 
     it 'does not crash in autocorrect on dynamic string in parameter value' do
-      src = ['class MyModel < ActiveRecord::Base',
-             '  has_many :other_models,',
-             '    class_name: "legacy_name",',
-             '    order: "#{legacy_name.table_name}.published DESC"',
-             '',
-             'end']
+      src = <<-'END'.strip_indent
+        class MyModel < ActiveRecord::Base
+          has_many :other_models,
+            class_name: "legacy_name",
+            order: "#{legacy_name.table_name}.published DESC"
+
+        end
+      END
       new_source = autocorrect_source(cop, src)
       expect(new_source)
-        .to eq ['class MyModel < ActiveRecord::Base',
-                '  has_many :other_models,',
-                '           class_name: "legacy_name",',
-                '           order: "#{legacy_name.table_name}.published DESC"',
-                '',
-                'end'].join("\n")
+        .to eq <<-'END'.strip_indent
+          class MyModel < ActiveRecord::Base
+            has_many :other_models,
+                     class_name: "legacy_name",
+                     order: "#{legacy_name.table_name}.published DESC"
+
+          end
+        END
     end
   end
 
@@ -385,120 +469,128 @@ describe RuboCop::Cop::Style::AlignParameters do
     end
 
     let(:correct_source) do
-      [
-        'create :transaction, :closed,',
-        '  account:     account,',
-        '  open_price:  1.29,',
-        '  close_price: 1.30'
-      ]
+      <<-END.strip_indent
+        create :transaction, :closed,
+          account:     account,
+          open_price:  1.29,
+          close_price: 1.30
+      END
     end
 
     it 'does not autocorrect correct source' do
       expect(autocorrect_source(cop, correct_source))
-        .to eq(correct_source.join("\n"))
+        .to eq(correct_source)
     end
 
     it 'autocorrects by outdenting when indented too far' do
-      original_source = [
-        'create :transaction, :closed,',
-        '       account:     account,',
-        '       open_price:  1.29,',
-        '       close_price: 1.30'
-      ]
+      original_source = <<-END.strip_indent
+        create :transaction, :closed,
+               account:     account,
+               open_price:  1.29,
+               close_price: 1.30
+      END
 
       expect(autocorrect_source(cop, original_source))
-        .to eq(correct_source.join("\n"))
+        .to eq(correct_source)
     end
 
     it 'autocorrects by indenting when not indented' do
-      original_source = [
-        'create :transaction, :closed,',
-        'account:     account,',
-        'open_price:  1.29,',
-        'close_price: 1.30'
-      ]
+      original_source = <<-END.strip_indent
+        create :transaction, :closed,
+        account:     account,
+        open_price:  1.29,
+        close_price: 1.30
+      END
 
       expect(autocorrect_source(cop, original_source))
-        .to eq(correct_source.join("\n"))
+        .to eq(correct_source)
     end
 
     it 'autocorrects when first line is indented' do
-      original_source = [
-        '  create :transaction, :closed,',
-        '  account:     account,',
-        '  open_price:  1.29,',
-        '  close_price: 1.30'
-      ]
+      original_source = <<-END.strip_margin('|')
+        |  create :transaction, :closed,
+        |  account:     account,
+        |  open_price:  1.29,
+        |  close_price: 1.30
+      END
 
-      correct_source = [
-        '  create :transaction, :closed,',
-        '    account:     account,',
-        '    open_price:  1.29,',
-        '    close_price: 1.30'
-      ]
+      correct_source = <<-END.strip_margin('|')
+        |  create :transaction, :closed,
+        |    account:     account,
+        |    open_price:  1.29,
+        |    close_price: 1.30
+      END
 
       expect(autocorrect_source(cop, original_source))
-        .to eq(correct_source.join("\n"))
+        .to eq(correct_source)
     end
 
     context 'multi-line method calls' do
       it 'can handle existing indentation from multi-line method calls' do
-        inspect_source(cop, [' something',
-                             '   .method_name(',
-                             '     a,',
-                             '     b,',
-                             '     c',
-                             '   )'])
+        inspect_source(cop, <<-END.strip_margin('|'))
+          | something
+          |   .method_name(
+          |     a,
+          |     b,
+          |     c
+          |   )
+        END
         expect(cop.offenses).to be_empty
       end
 
       it 'registers offenses for double indentation from relevant method' do
-        inspect_source(cop, [' something',
-                             '   .method_name(',
-                             '       a,',
-                             '       b,',
-                             '       c',
-                             '   )'])
+        inspect_source(cop, <<-END.strip_margin('|'))
+          | something
+          |   .method_name(
+          |       a,
+          |       b,
+          |       c
+          |   )
+        END
         expect(cop.offenses.size).to eq(3)
       end
 
       it 'does not err on method call without a method name' do
-        inspect_source(cop, [' something',
-                             '   .(',
-                             '     a,',
-                             '     b,',
-                             '     c',
-                             '   )'])
+        inspect_source(cop, <<-END.strip_margin('|'))
+          | something
+          |   .(
+          |     a,
+          |     b,
+          |     c
+          |   )
+        END
         expect(cop.offenses).to be_empty
       end
 
       it 'autocorrects relative to position of relevant method call' do
-        original_source = [
-          ' something',
-          '   .method_name(',
-          '       a,',
-          '          b,',
-          '            c',
-          '   )'
-        ]
-        correct_source = [
-          ' something',
-          '   .method_name(',
-          '     a,',
-          '     b,',
-          '     c',
-          '   )'
-        ]
+        original_source = <<-END.strip_margin('|')
+          | something
+          |   .method_name(
+          |       a,
+          |          b,
+          |            c
+          |   )
+        END
+        correct_source = <<-END.strip_margin('|')
+          | something
+          |   .method_name(
+          |     a,
+          |     b,
+          |     c
+          |   )
+        END
         expect(autocorrect_source(cop, original_source))
-          .to eq(correct_source.join("\n"))
+          .to eq(correct_source)
       end
     end
 
     context 'method definitions' do
       it 'registers an offense for parameters aligned to first param' do
-        inspect_source(cop, ['def method(a,',
-                             '           b)',
-                             'end'])
+        inspect_source(cop, <<-END.strip_indent)
+          def method(a,
+                     b)
+          end
+        END
         expect(cop.offenses.size).to eq 1
         expect(cop.messages)
           .to eq(['Use one level of indentation for parameters ' \
@@ -507,80 +599,104 @@ describe RuboCop::Cop::Style::AlignParameters do
       end
 
       it 'registers an offense for parameters with double indent' do
-        inspect_source(cop, ['def method(a,',
-                             '    b)',
-                             'end'])
+        inspect_source(cop, <<-END.strip_indent)
+          def method(a,
+              b)
+          end
+        END
         expect(cop.offenses.size).to eq 1
       end
 
       it 'accepts parameter lists on a single line' do
-        inspect_source(cop, ['def method(a, b)',
-                             'end'])
+        inspect_source(cop, <<-END.strip_indent)
+          def method(a, b)
+          end
+        END
         expect(cop.offenses).to be_empty
       end
 
       it 'accepts proper indentation' do
-        inspect_source(cop, ['def method(a,',
-                             '  b)',
-                             'end'])
+        inspect_source(cop, <<-END.strip_indent)
+          def method(a,
+            b)
+          end
+        END
         expect(cop.offenses).to be_empty
       end
 
       it 'accepts the first parameter being on a new row' do
-        inspect_source(cop, ['def method(',
-                             '  a,',
-                             '  b)',
-                             'end'])
+        inspect_source(cop, <<-END.strip_indent)
+          def method(
+            a,
+            b)
+          end
+        END
         expect(cop.offenses).to be_empty
       end
 
       it 'accepts a method definition without parameters' do
-        inspect_source(cop, ['def method',
-                             'end'])
+        inspect_source(cop, <<-END.strip_indent)
+          def method
+          end
+        END
         expect(cop.offenses).to be_empty
       end
 
       it "doesn't get confused by splat" do
-        inspect_source(cop, ['def func2(a,',
-                             '         *b,',
-                             '          c)',
-                             'end'])
+        inspect_source(cop, <<-END.strip_indent)
+          def func2(a,
+                   *b,
+                    c)
+          end
+        END
         expect(cop.offenses).not_to be_empty
         expect(cop.highlights).to include '*b'
       end
 
       it 'auto-corrects alignment' do
-        new_source = autocorrect_source(cop, ['def method(a,',
-                                              '    b)',
-                                              'end'])
-        expect(new_source).to eq(['def method(a,',
-                                  '  b)',
-                                  'end'].join("\n"))
+        new_source = autocorrect_source(cop, <<-END.strip_indent)
+          def method(a,
+              b)
+          end
+        END
+        expect(new_source).to eq(<<-END.strip_indent)
+          def method(a,
+            b)
+          end
+        END
       end
 
       context 'defining self.method' do
         it 'registers an offense for parameters aligned to first param' do
-          inspect_source(cop, ['def self.method(a,',
-                               '                b)',
-                               'end'])
+          inspect_source(cop, <<-END.strip_indent)
+            def self.method(a,
+                            b)
+            end
+          END
           expect(cop.offenses.size).to eq 1
           expect(cop.offenses.first.to_s).to match(/method definition/)
         end
 
         it 'accepts proper indentation' do
-          inspect_source(cop, ['def self.method(a,',
-                               '  b)',
-                               'end'])
+          inspect_source(cop, <<-END.strip_indent)
+            def self.method(a,
+              b)
+            end
+          END
           expect(cop.offenses).to be_empty
         end
 
         it 'auto-corrects alignment' do
-          new_source = autocorrect_source(cop, ['def self.method(a,',
-                                                '    b)',
-                                                'end'])
-          expect(new_source).to eq(['def self.method(a,',
-                                    '  b)',
-                                    'end'].join("\n"))
+          new_source = autocorrect_source(cop, <<-END.strip_indent)
+            def self.method(a,
+                b)
+            end
+          END
+          expect(new_source).to eq(<<-END.strip_indent)
+            def self.method(a,
+              b)
+            end
+          END
         end
       end
     end
@@ -590,37 +706,45 @@ describe RuboCop::Cop::Style::AlignParameters do
         let(:indentation_width) { 4 }
 
         it 'accepts the first parameter being on a new row' do
-          inspect_source(cop, [' assigned_value = match(',
-                               '     a,',
-                               '     b,',
-                               '     c',
-                               ' )'])
+          inspect_source(cop, <<-END.strip_margin('|'))
+            | assigned_value = match(
+            |     a,
+            |     b,
+            |     c
+            | )
+          END
           expect(cop.offenses).to be_empty
         end
 
         it 'accepts the first parameter being on method row' do
-          inspect_source(cop, [' assigned_value = match(a,',
-                               '     b,',
-                               '     c',
-                               ' )'])
+          inspect_source(cop, <<-END.strip_margin('|'))
+            | assigned_value = match(a,
+            |     b,
+            |     c
+            | )
+          END
           expect(cop.offenses).to be_empty
         end
 
         it 'autocorrects even when first argument is in wrong position' do
-          original_source = [' assigned_value = match(',
-                             '         a,',
-                             '            b,',
-                             '                    c',
-                             ' )']
+          original_source = <<-END.strip_margin('|')
+            | assigned_value = match(
+            |         a,
+            |            b,
+            |                    c
+            | )
+          END
 
-          correct_source = [' assigned_value = match(',
-                            '     a,',
-                            '     b,',
-                            '     c',
-                            ' )']
+          correct_source = <<-END.strip_margin('|')
+            | assigned_value = match(
+            |     a,
+            |     b,
+            |     c
+            | )
+          END
 
           expect(autocorrect_source(cop, original_source))
-            .to eq(correct_source.join("\n"))
+            .to eq(correct_source)
         end
       end
 
@@ -631,19 +755,23 @@ describe RuboCop::Cop::Style::AlignParameters do
         end
 
         it 'accepts the first parameter being on a new row' do
-          inspect_source(cop, [' assigned_value = match(',
-                               '     a,',
-                               '     b,',
-                               '     c',
-                               ' )'])
+          inspect_source(cop, <<-END.strip_margin('|'))
+            | assigned_value = match(
+            |     a,
+            |     b,
+            |     c
+            | )
+          END
           expect(cop.offenses).to be_empty
         end
 
         it 'accepts the first parameter being on method row' do
-          inspect_source(cop, [' assigned_value = match(a,',
-                               '     b,',
-                               '     c',
-                               ' )'])
+          inspect_source(cop, <<-END.strip_margin('|'))
+            | assigned_value = match(a,
+            |     b,
+            |     c
+            | )
+          END
           expect(cop.offenses).to be_empty
         end
       end

--- a/spec/rubocop/cop/style/and_or_spec.rb
+++ b/spec/rubocop/cop/style/and_or_spec.rb
@@ -95,19 +95,27 @@ describe RuboCop::Cop::Style::AndOr, :config do
     end
 
     it 'auto-corrects "or" with ||' do
-      new_source = autocorrect_source(cop, ['x = 12345',
-                                            'true or false'])
-      expect(new_source).to eq(['x = 12345',
-                                'true || false'].join("\n"))
+      new_source = autocorrect_source(cop, <<-END.strip_indent)
+        x = 12345
+        true or false
+      END
+      expect(new_source).to eq(<<-END.strip_indent)
+        x = 12345
+        true || false
+      END
     end
 
     it 'auto-corrects "or" with || inside def' do
-      new_source = autocorrect_source(cop, ['def z(a, b)',
-                                            '  return true if a or b',
-                                            'end'])
-      expect(new_source).to eq(['def z(a, b)',
-                                '  return true if a || b',
-                                'end'].join("\n"))
+      new_source = autocorrect_source(cop, <<-END.strip_indent)
+        def z(a, b)
+          return true if a or b
+        end
+      END
+      expect(new_source).to eq(<<-END.strip_indent)
+        def z(a, b)
+          return true if a || b
+        end
+      END
     end
 
     it 'autocorrects "or" with an assignment on the left' do
@@ -330,45 +338,57 @@ describe RuboCop::Cop::Style::AndOr, :config do
     context 'within a nested begin node' do
       # regression test; see GH issue 2531
       it 'autocorrects "and" with && and adds parens' do
-        new_source = autocorrect_source(cop, ['def x',
-                                              'end',
-                                              '',
-                                              'def y',
-                                              '  a = b and a.c',
-                                              'end'])
-        expect(new_source).to eq(['def x',
-                                  'end',
-                                  '',
-                                  'def y',
-                                  '  (a = b) && a.c',
-                                  'end'].join("\n"))
+        new_source = autocorrect_source(cop, <<-END.strip_indent)
+          def x
+          end
+
+          def y
+            a = b and a.c
+          end
+        END
+        expect(new_source).to eq(<<-END.strip_indent)
+          def x
+          end
+
+          def y
+            (a = b) && a.c
+          end
+        END
       end
     end
 
     context 'within a nested begin node with one child only' do
       # regression test; see GH issue 2531
       it 'autocorrects "and" with && and adds parens' do
-        new_source = autocorrect_source(cop, ['(def y',
-                                              '  a = b and a.c',
-                                              'end)'])
-        expect(new_source).to eq(['(def y',
-                                  '  (a = b) && a.c',
-                                  'end)'].join("\n"))
+        new_source = autocorrect_source(cop, <<-END.strip_indent)
+          (def y
+            a = b and a.c
+          end)
+        END
+        expect(new_source).to eq(<<-END.strip_indent)
+          (def y
+            (a = b) && a.c
+          end)
+        END
       end
     end
 
     context 'with a file which contains __FILE__' do
       let(:source) do
-        ["APP_ROOT = Pathname.new File.expand_path('../../', __FILE__)",
-         "system('bundle check') or system!('bundle install')"]
+        <<-END.strip_indent
+          APP_ROOT = Pathname.new File.expand_path('../../', __FILE__)
+          system('bundle check') or system!('bundle install')
+        END
       end
 
       # regression test; see GH issue 2609
       it 'autocorrects "or" with ||' do
         new_source = autocorrect_source(cop, source)
         expect(new_source).to eq(
-          ["APP_ROOT = Pathname.new File.expand_path('../../', __FILE__)",
-           "system('bundle check') || system!('bundle install')"].join("\n")
+          <<-END.strip_indent
+            APP_ROOT = Pathname.new File.expand_path('../../', __FILE__)
+            system('bundle check') || system!('bundle install')
+          END
         )
       end
     end

--- a/spec/rubocop/cop/style/ascii_comments_spec.rb
+++ b/spec/rubocop/cop/style/ascii_comments_spec.rb
@@ -4,9 +4,10 @@ describe RuboCop::Cop::Style::AsciiComments do
   subject(:cop) { described_class.new }
 
   it 'registers an offense for a comment with non-ascii chars' do
-    inspect_source(cop,
-                   ['# encoding: utf-8',
-                    '# 这是什么？'])
+    inspect_source(cop, <<-END.strip_indent)
+      # encoding: utf-8
+      # 这是什么？
+    END
     expect(cop.offenses.size).to eq(1)
     expect(cop.highlights).to eq(['这是什么？'])
     expect(cop.messages)
@@ -14,9 +15,10 @@ describe RuboCop::Cop::Style::AsciiComments do
   end
 
   it 'registers an offense for commentes with mixed chars' do
-    inspect_source(cop,
-                   ['# encoding: utf-8',
-                    '# foo ∂ bar'])
+    inspect_source(cop, <<-END.strip_indent)
+      # encoding: utf-8
+      # foo ∂ bar
+    END
     expect(cop.offenses.size).to eq(1)
     expect(cop.highlights).to eq(['∂'])
     expect(cop.messages)

--- a/spec/rubocop/cop/style/ascii_identifiers_spec.rb
+++ b/spec/rubocop/cop/style/ascii_identifiers_spec.rb
@@ -4,9 +4,10 @@ describe RuboCop::Cop::Style::AsciiIdentifiers do
   subject(:cop) { described_class.new }
 
   it 'registers an offense for a variable name with non-ascii chars' do
-    inspect_source(cop,
-                   ['# encoding: utf-8',
-                    'älg = 1'])
+    inspect_source(cop, <<-END.strip_indent)
+      # encoding: utf-8
+      älg = 1
+    END
     expect(cop.offenses.size).to eq(1)
     expect(cop.highlights).to eq(['ä'])
     expect(cop.messages)
@@ -14,9 +15,10 @@ describe RuboCop::Cop::Style::AsciiIdentifiers do
   end
 
   it 'registers an offense for a variable name with mixed chars' do
-    inspect_source(cop,
-                   ['# encoding: utf-8',
-                    'foo∂∂bar = baz'])
+    inspect_source(cop, <<-END.strip_indent)
+      # encoding: utf-8
+      foo∂∂bar = baz
+    END
     expect(cop.offenses.size).to eq(1)
     expect(cop.highlights).to eq(['∂∂'])
     expect(cop.messages)

--- a/spec/rubocop/cop/style/attr_spec.rb
+++ b/spec/rubocop/cop/style/attr_spec.rb
@@ -4,9 +4,11 @@ describe RuboCop::Cop::Style::Attr do
   subject(:cop) { described_class.new }
 
   it 'registers an offense attr' do
-    inspect_source(cop, ['class SomeClass',
-                         '  attr :name',
-                         'end'])
+    inspect_source(cop, <<-END.strip_indent)
+      class SomeClass
+        attr :name
+      end
+    END
     expect(cop.offenses.size).to eq(1)
   end
 

--- a/spec/rubocop/cop/style/bare_percent_literals_spec.rb
+++ b/spec/rubocop/cop/style/bare_percent_literals_spec.rb
@@ -35,9 +35,11 @@ describe RuboCop::Cop::Style::BarePercentLiterals, :config do
     end
 
     it 'accepts heredoc' do
-      inspect_source(cop, ['func <<END',
-                           'hi',
-                           'END'])
+      inspect_source(cop, <<-END.strip_indent)
+        func <<HEREDOC
+        hi
+        HEREDOC
+      END
       expect(cop.offenses).to be_empty
     end
   end

--- a/spec/rubocop/cop/style/block_comments_spec.rb
+++ b/spec/rubocop/cop/style/block_comments_spec.rb
@@ -4,10 +4,11 @@ describe RuboCop::Cop::Style::BlockComments do
   subject(:cop) { described_class.new }
 
   it 'registers an offense for block comments' do
-    inspect_source(cop,
-                   ['=begin',
-                    'comment',
-                    '=end'])
+    inspect_source(cop, <<-END.strip_indent)
+      =begin
+      comment
+      =end
+    END
     expect(cop.offenses.size).to eq(1)
   end
 
@@ -18,26 +19,34 @@ describe RuboCop::Cop::Style::BlockComments do
   end
 
   it 'auto-corrects a block comment into a regular comment' do
-    new_source = autocorrect_source(cop, ['=begin',
-                                          'comment line 1',
-                                          '',
-                                          'comment line 2',
-                                          '=end',
-                                          'def foo',
-                                          'end'])
-    expect(new_source).to eq(['# comment line 1',
-                              '#',
-                              '# comment line 2',
-                              'def foo',
-                              'end'].join("\n"))
+    new_source = autocorrect_source(cop, <<-END.strip_indent)
+      =begin
+      comment line 1
+
+      comment line 2
+      =end
+      def foo
+      end
+    END
+    expect(new_source).to eq(<<-END.strip_indent)
+      # comment line 1
+      #
+      # comment line 2
+      def foo
+      end
+    END
   end
 
   it 'auto-corrects an empty block comment by removing it' do
-    new_source = autocorrect_source(cop, ['=begin',
-                                          '=end',
-                                          'def foo',
-                                          'end'])
-    expect(new_source).to eq(['def foo',
-                              'end'].join("\n"))
+    new_source = autocorrect_source(cop, <<-END.strip_indent)
+      =begin
+      =end
+      def foo
+      end
+    END
+    expect(new_source).to eq(<<-END.strip_indent)
+      def foo
+      end
+    END
   end
 end

--- a/spec/rubocop/cop/style/block_delimiters_spec.rb
+++ b/spec/rubocop/cop/style/block_delimiters_spec.rb
@@ -16,15 +16,19 @@ describe RuboCop::Cop::Style::BlockDelimiters, :config do
     end
 
     it 'accepts a multi-line block with do-end' do
-      inspect_source(cop, ['each do |x|',
-                           'end'])
+      inspect_source(cop, <<-END.strip_indent)
+        each do |x|
+        end
+      END
       expect(cop.offenses).to be_empty
     end
 
     it 'accepts a multi-line block that needs braces to be valid ruby' do
-      inspect_source(cop, ['puts [1, 2, 3].map { |n|',
-                           '  n * n',
-                           '}, 1'])
+      inspect_source(cop, <<-END.strip_indent)
+        puts [1, 2, 3].map { |n|
+          n * n
+        }, 1
+      END
       expect(cop.messages).to be_empty
     end
   end
@@ -41,78 +45,96 @@ describe RuboCop::Cop::Style::BlockDelimiters, :config do
 
     it 'accepts a multi-line block with braces if the return value is ' \
        'assigned' do
-      inspect_source(cop, ['foo = map { |x|',
-                           '  x',
-                           '}'])
+      inspect_source(cop, <<-END.strip_indent)
+        foo = map { |x|
+          x
+        }
+      END
       expect(cop.offenses).to be_empty
     end
 
     it 'accepts a multi-line block with braces if it is the return value ' \
        'of its scope' do
-      inspect_source(cop, ['block do',
-                           '  map { |x|',
-                           '    x',
-                           '  }',
-                           'end'])
+      inspect_source(cop, <<-END.strip_indent)
+        block do
+          map { |x|
+            x
+          }
+        end
+      END
       expect(cop.offenses).to be_empty
     end
 
     it 'accepts a multi-line block with braces when passed to a method' do
-      inspect_source(cop, ['puts map { |x|',
-                           '  x',
-                           '}'])
+      inspect_source(cop, <<-END.strip_indent)
+        puts map { |x|
+          x
+        }
+      END
       expect(cop.offenses).to be_empty
     end
 
     it 'accepts a multi-line block with braces when chained' do
-      inspect_source(cop, ['map { |x|',
-                           '  x',
-                           '}.inspect'])
+      inspect_source(cop, <<-END.strip_indent)
+        map { |x|
+          x
+        }.inspect
+      END
       expect(cop.offenses).to be_empty
     end
 
     it 'accepts a multi-line block with braces when passed to a known ' \
        'functional method' do
-      inspect_source(cop, ['let(:foo) {',
-                           '  x',
-                           '}'])
+      inspect_source(cop, <<-END.strip_indent)
+        let(:foo) {
+          x
+        }
+      END
       expect(cop.offenses).to be_empty
     end
 
     it 'registers an offense for a multi-line block with braces if the ' \
        'return value is not used' do
-      inspect_source(cop, ['each { |x|',
-                           '  x',
-                           '}'])
+      inspect_source(cop, <<-END.strip_indent)
+        each { |x|
+          x
+        }
+      END
       expect(cop.messages)
         .to eq(['Prefer `do...end` over `{...}` for procedural blocks.'])
     end
 
     it 'registers an offense for a multi-line block with do-end if the ' \
        'return value is assigned' do
-      inspect_source(cop, ['foo = map do |x|',
-                           '  x',
-                           'end'])
+      inspect_source(cop, <<-END.strip_indent)
+        foo = map do |x|
+          x
+        end
+      END
       expect(cop.messages)
         .to eq(['Prefer `{...}` over `do...end` for functional blocks.'])
     end
 
     it 'registers an offense for a multi-line block with do-end if the ' \
        'return value is passed to a method' do
-      inspect_source(cop, ['puts (map do |x|',
-                           '  x',
-                           'end)'])
+      inspect_source(cop, <<-END.strip_indent)
+        puts (map do |x|
+          x
+        end)
+      END
       expect(cop.messages)
         .to eq(['Prefer `{...}` over `do...end` for functional blocks.'])
     end
 
     it 'accepts a multi-line block with do-end if it is the return value ' \
        'of its scope' do
-      inspect_source(cop, ['block do',
-                           '  map do |x|',
-                           '    x',
-                           '  end',
-                           'end'])
+      inspect_source(cop, <<-END.strip_indent)
+        block do
+          map do |x|
+            x
+          end
+        end
+      END
       expect(cop.messages).to be_empty
     end
 
@@ -148,17 +170,21 @@ describe RuboCop::Cop::Style::BlockDelimiters, :config do
 
     it 'accepts a multi-line functional block with do-end if it is ' \
        'a known procedural method' do
-      inspect_source(cop, ['foo = bar.tap do |x|',
-                           '  x.age = 3',
-                           'end'])
+      inspect_source(cop, <<-END.strip_indent)
+        foo = bar.tap do |x|
+          x.age = 3
+        end
+      END
       expect(cop.messages).to be_empty
     end
 
     it 'accepts a multi-line functional block with do-end if it is ' \
        'an ignored method' do
-      inspect_source(cop, ['foo = lambda do',
-                           '  puts 42',
-                           'end'])
+      inspect_source(cop, <<-END.strip_indent)
+        foo = lambda do
+          puts 42
+        end
+      END
       expect(cop.messages).to be_empty
     end
 
@@ -304,71 +330,83 @@ describe RuboCop::Cop::Style::BlockDelimiters, :config do
     end
 
     it 'does not auto-correct {} if do-end would change the meaning' do
-      src = ['foo :bar, :baz, qux: lambda { |a|',
-             '  bar a',
-             '}'].join("\n")
+      src = <<-END.strip_indent
+        foo :bar, :baz, qux: lambda { |a|
+          bar a
+        }
+      END
       new_source = autocorrect_source(cop, src)
       expect(new_source).to eq(src)
     end
 
     context 'when there are braces around a multi-line block' do
       it 'registers an offense in the simple case' do
-        inspect_source(cop, ['each { |x|',
-                             '}'])
+        inspect_source(cop, <<-END.strip_indent)
+          each { |x|
+          }
+        END
         expect(cop.messages)
           .to eq(['Avoid using `{...}` for multi-line blocks.'])
       end
 
       it 'accepts braces if do-end would change the meaning' do
-        src = ['scope :foo, lambda { |f|',
-               '  where(condition: "value")',
-               '}',
-               '',
-               'expect { something }.to raise_error(ErrorClass) { |error|',
-               '  # ...',
-               '}',
-               '',
-               'expect { x }.to change {',
-               '  Counter.count',
-               '}.from(0).to(1)',
-               '',
-               'cr.stubs client: mock {',
-               '  expects(:email_disabled=).with(true)',
-               '  expects :save',
-               '}']
+        src = <<-END.strip_indent
+          scope :foo, lambda { |f|
+            where(condition: "value")
+          }
+
+          expect { something }.to raise_error(ErrorClass) { |error|
+            # ...
+          }
+
+          expect { x }.to change {
+            Counter.count
+          }.from(0).to(1)
+
+          cr.stubs client: mock {
+            expects(:email_disabled=).with(true)
+            expects :save
+          }
+        END
         inspect_source(cop, src)
         expect(cop.offenses).to be_empty
       end
 
       it 'accepts a multi-line functional block with {} if it is ' \
          'an ignored method' do
-        inspect_source(cop, ['foo = proc {',
-                             '  puts 42',
-                             '}'])
+        inspect_source(cop, <<-END.strip_indent)
+          foo = proc {
+            puts 42
+          }
+        END
         expect(cop.messages).to be_empty
       end
 
       it 'registers an offense for braces if do-end would not change ' \
          'the meaning' do
-        src = ['scope :foo, (lambda { |f|',
-               '  where(condition: "value")',
-               '})',
-               '',
-               'expect { something }.to(raise_error(ErrorClass) { |error|',
-               '  # ...',
-               '})']
+        src = <<-END.strip_indent
+          scope :foo, (lambda { |f|
+            where(condition: "value")
+          })
+
+          expect { something }.to(raise_error(ErrorClass) { |error|
+            # ...
+          })
+        END
         inspect_source(cop, src)
         expect(cop.offenses.size).to eq(2)
       end
 
       it 'can handle special method names such as []= and done?' do
-        src = ['h2[k2] = Hash.new { |h3,k3|',
-               '  h3[k3] = 0',
-               '}',
-               '',
-               'x = done? list.reject { |e|',
-               '  e.nil?',
-               '}']
+        src = <<-END.strip_indent
+          h2[k2] = Hash.new { |h3,k3|
+            h3[k3] = 0
+          }
+
+          x = done? list.reject { |e|
+            e.nil?
+          }
+        END
         inspect_source(cop, src)
         expect(cop.messages)
           .to eq(['Avoid using `{...}` for multi-line blocks.'])
@@ -394,20 +432,26 @@ describe RuboCop::Cop::Style::BlockDelimiters, :config do
       end
 
       it 'auto-corrects adjacent curly braces correctly' do
-        source = ['(0..3).each { |a| a.times {',
-                  '  puts a',
-                  '}}']
+        source = <<-END.strip_indent
+          (0..3).each { |a| a.times {
+            puts a
+          }}
+        END
 
         new_source = autocorrect_source(cop, source)
-        expect(new_source).to eq(['(0..3).each do |a| a.times do',
-                                  '  puts a',
-                                  'end end'].join("\n"))
+        expect(new_source).to eq(<<-END.strip_indent)
+          (0..3).each do |a| a.times do
+            puts a
+          end end
+        END
       end
 
       it 'does not auto-correct {} if do-end would introduce a syntax error' do
-        src = ['my_method :arg1, arg2: proc {',
-               '  something',
-               '}, arg3: :another_value'].join("\n")
+        src = <<-END.strip_indent
+          my_method :arg1, arg2: proc {
+            something
+          }, arg3: :another_value
+        END
         new_source = autocorrect_source(cop, src)
         expect(new_source).to eq(src)
       end
@@ -425,39 +469,52 @@ describe RuboCop::Cop::Style::BlockDelimiters, :config do
     include_examples 'syntactic styles'
 
     it 'registers an offense for multi-line chained do-end blocks' do
-      inspect_source(cop, ['each do |x|',
-                           'end.map(&:to_s)'])
+      inspect_source(cop, <<-END.strip_indent)
+        each do |x|
+        end.map(&:to_s)
+      END
       expect(cop.messages).to eq(
         ['Prefer `{...}` over `do...end` for multi-line chained blocks.']
       )
     end
 
     it 'auto-corrects do-end for chained blocks' do
-      src = ['each do |x|',
-             'end.map(&:to_s)']
+      src = <<-END.strip_indent
+        each do |x|
+        end.map(&:to_s)
+      END
       new_source = autocorrect_source(cop, src)
-      expect(new_source).to eq("each { |x|\n}.map(&:to_s)")
+      expect(new_source).to eq(<<-END.strip_indent)
+        each { |x|
+        }.map(&:to_s)
+      END
     end
 
     it 'accepts a multi-line functional block with {} if it is ' \
        'an ignored method' do
-      inspect_source(cop, ['foo = proc {',
-                           '  puts 42',
-                           '}'])
+      inspect_source(cop, <<-END.strip_indent)
+        foo = proc {
+          puts 42
+        }
+      END
       expect(cop.messages).to be_empty
     end
 
     context 'when there are braces around a multi-line block' do
       it 'registers an offense in the simple case' do
-        inspect_source(cop, ['each { |x|',
-                             '}'])
+        inspect_source(cop, <<-END.strip_indent)
+          each { |x|
+          }
+        END
         expect(cop.messages)
           .to eq(['Prefer `do...end` for multi-line blocks without chaining.'])
       end
 
       it 'allows when the block is being chained' do
-        inspect_source(cop, ['each { |x|',
-                             '}.map(&:to_sym)'])
+        inspect_source(cop, <<-END.strip_indent)
+          each { |x|
+          }.map(&:to_sym)
+        END
         expect(cop.offenses).to be_empty
       end
     end

--- a/spec/rubocop/cop/style/block_end_newline_spec.rb
+++ b/spec/rubocop/cop/style/block_end_newline_spec.rb
@@ -10,48 +10,57 @@ describe RuboCop::Cop::Style::BlockEndNewline do
 
   it 'does not register an offense for multiline blocks with newlines before '\
      'the end' do
-    inspect_source(cop,
-                   ['test do',
-                    '  foo',
-                    'end'])
+    inspect_source(cop, <<-END.strip_indent)
+      test do
+        foo
+      end
+    END
     expect(cop.messages).to be_empty
   end
 
   it 'registers an offense when multiline block end is not on its own line' do
-    inspect_source(cop,
-                   ['test do',
-                    '  foo end'])
+    inspect_source(cop, <<-END.strip_indent)
+      test do
+        foo end
+    END
     expect(cop.messages)
       .to eq(['Expression at 2, 7 should be on its own line.'])
   end
 
   it 'registers an offense when multiline block } is not on its own line' do
-    inspect_source(cop,
-                   ['test {',
-                    '  foo }'])
+    inspect_source(cop, <<-END.strip_indent)
+      test {
+        foo }
+    END
     expect(cop.messages)
       .to eq(['Expression at 2, 7 should be on its own line.'])
   end
 
   it 'autocorrects a do/end block where the end is not on its own line' do
-    src = ['test do',
-           '  foo end']
+    src = <<-END.strip_indent
+      test do
+        foo end
+    END
 
     new_source = autocorrect_source(cop, src)
 
     expect(new_source).to eq(['test do',
                               '  foo ',
-                              'end'].join("\n"))
+                              'end',
+                              ''].join("\n"))
   end
 
   it 'autocorrects a {} block where the } is not on its own line' do
-    src = ['test {',
-           '  foo }']
+    src = <<-END.strip_indent
+      test {
+        foo }
+    END
 
     new_source = autocorrect_source(cop, src)
 
     expect(new_source).to eq(['test {',
                               '  foo ',
-                              '}'].join("\n"))
+                              '}',
+                              ''].join("\n"))
   end
 end

--- a/spec/rubocop/cop/style/braces_around_hash_parameters_spec.rb
+++ b/spec/rubocop/cop/style/braces_around_hash_parameters_spec.rb
@@ -144,15 +144,19 @@ describe RuboCop::Cop::Style::BracesAroundHashParameters, :config do
 
     context 'with a comment following the last key-value pair' do
       it 'corrects and leaves line breaks' do
-        src = ['r = opts.merge({',
-               '  p1: opts[:a],',
-               '  p2: (opts[:b] || opts[:c]) # a comment',
-               '})']
+        src = <<-END.strip_indent
+          r = opts.merge({
+            p1: opts[:a],
+            p2: (opts[:b] || opts[:c]) # a comment
+          })
+        END
         corrected = autocorrect_source(cop, src)
-        expect(corrected).to eq(['r = opts.merge(',
-                                 '  p1: opts[:a],',
-                                 '  p2: (opts[:b] || opts[:c]) # a comment',
-                                 ')'].join("\n"))
+        expect(corrected).to eq(<<-END.strip_indent)
+          r = opts.merge(
+            p1: opts[:a],
+            p2: (opts[:b] || opts[:c]) # a comment
+          )
+        END
       end
     end
 

--- a/spec/rubocop/cop/style/case_indentation_spec.rb
+++ b/spec/rubocop/cop/style/case_indentation_spec.rb
@@ -26,21 +26,25 @@ describe RuboCop::Cop::Style::CaseIndentation do
 
       context 'regarding assignment where the right hand side is a case' do
         let(:correct_source) do
-          ['output = case variable',
-           "         when 'value1'",
-           "  'output1'",
-           'else',
-           "  'output2'",
-           'end']
+          <<-END.strip_indent
+            output = case variable
+                     when 'value1'
+              'output1'
+            else
+              'output2'
+            end
+          END
         end
 
         let(:source) do
-          ['output = case variable',
-           "         when 'value1'",
-           "           'output1'",
-           '         else',
-           "           'output2'",
-           '         end']
+          <<-END.strip_indent
+            output = case variable
+                     when 'value1'
+                       'output1'
+                     else
+                       'output2'
+                     end
+          END
         end
 
         it 'accepts a correctly indented assignment' do
@@ -50,12 +54,14 @@ describe RuboCop::Cop::Style::CaseIndentation do
 
         context 'an assignment indented as end' do
           let(:source) do
-            ['output = case variable',
-             "when 'value1'",
-             "  'output1'",
-             'else',
-             "  'output2'",
-             'end']
+            <<-END.strip_indent
+              output = case variable
+              when 'value1'
+                'output1'
+              else
+                'output2'
+              end
+            END
           end
 
           it 'registers an offense' do
@@ -67,27 +73,31 @@ describe RuboCop::Cop::Style::CaseIndentation do
 
           it 'does auto-correction' do
             corrected = autocorrect_source(cop, source)
-            expect(corrected).to eq correct_source.join("\n")
+            expect(corrected).to eq correct_source
           end
         end
 
         context 'an assignment indented some other way' do
           let(:source) do
-            ['output = case variable',
-             "  when 'value1'",
-             "    'output1'",
-             '  else',
-             "    'output2'",
-             'end']
+            <<-END.strip_indent
+              output = case variable
+                when 'value1'
+                  'output1'
+                else
+                  'output2'
+              end
+            END
           end
 
           let(:correct_source) do
-            ['output = case variable',
-             "         when 'value1'",
-             "    'output1'",
-             '  else',
-             "    'output2'",
-             'end']
+            <<-END.strip_indent
+              output = case variable
+                       when 'value1'
+                  'output1'
+                else
+                  'output2'
+              end
+            END
           end
 
           it 'registers an offense' do
@@ -98,39 +108,43 @@ describe RuboCop::Cop::Style::CaseIndentation do
 
           it 'does auto-correction' do
             corrected = autocorrect_source(cop, source)
-            expect(corrected).to eq correct_source.join("\n")
+            expect(corrected).to eq correct_source
           end
         end
 
         context 'correct + opposite' do
           let(:source) do
-            ['output = case variable',
-             "         when 'value1'",
-             "           'output1'",
-             '         else',
-             "           'output2'",
-             '         end',
-             'output = case variable',
-             "when 'value1'",
-             "  'output1'",
-             'else',
-             "  'output2'",
-             'end']
+            <<-END.strip_indent
+              output = case variable
+                       when 'value1'
+                         'output1'
+                       else
+                         'output2'
+                       end
+              output = case variable
+              when 'value1'
+                'output1'
+              else
+                'output2'
+              end
+            END
           end
 
           let(:correct_source) do
-            ['output = case variable',
-             "         when 'value1'",
-             "           'output1'",
-             '         else',
-             "           'output2'",
-             '         end',
-             'output = case variable',
-             "         when 'value1'",
-             "  'output1'",
-             'else',
-             "  'output2'",
-             'end']
+            <<-END.strip_indent
+              output = case variable
+                       when 'value1'
+                         'output1'
+                       else
+                         'output2'
+                       end
+              output = case variable
+                       when 'value1'
+                'output1'
+              else
+                'output2'
+              end
+            END
           end
 
           it 'registers an offense' do
@@ -141,20 +155,22 @@ describe RuboCop::Cop::Style::CaseIndentation do
 
           it 'does auto-correction' do
             corrected = autocorrect_source(cop, source)
-            expect(corrected).to eq(correct_source.join("\n"))
+            expect(corrected).to eq(correct_source)
           end
         end
       end
 
       context "a when clause that's deeper than case" do
         let(:source) do
-          ['case a',
-           '    when 0 then return',
-           '    else',
-           '        case b',
-           '         when 1 then return',
-           '        end',
-           'end']
+          <<-END.strip_indent
+            case a
+                when 0 then return
+                else
+                    case b
+                     when 1 then return
+                    end
+            end
+          END
         end
 
         it 'registers an offense' do
@@ -164,76 +180,82 @@ describe RuboCop::Cop::Style::CaseIndentation do
 
         it 'does auto-correction' do
           corrected = autocorrect_source(cop, source)
-          expect(corrected).to eq(['case a',
-                                   'when 0 then return',
-                                   '    else',
-                                   '        case b',
-                                   '        when 1 then return',
-                                   '        end',
-                                   'end'].join("\n"))
+          expect(corrected).to eq(<<-END.strip_indent)
+            case a
+            when 0 then return
+                else
+                    case b
+                    when 1 then return
+                    end
+            end
+          END
         end
       end
 
       it "accepts a when clause that's equally indented with case" do
-        source = ['y = case a',
-                  '    when 0 then break',
-                  '    when 0 then return',
-                  '    else',
-                  '      z = case b',
-                  '          when 1 then return',
-                  '          when 1 then break',
-                  '          end',
-                  '    end',
-                  'case c',
-                  'when 2 then encoding',
-                  'end',
-                  '']
+        source = <<-END.strip_indent
+          y = case a
+              when 0 then break
+              when 0 then return
+              else
+                z = case b
+                    when 1 then return
+                    when 1 then break
+                    end
+              end
+          case c
+          when 2 then encoding
+          end
+        END
         inspect_source(cop, source)
         expect(cop.offenses).to be_empty
       end
 
       it "doesn't get confused by strings with case in them" do
-        source = ['a = "case"',
-                  'case x',
-                  'when 0',
-                  'end',
-                  '']
+        source = <<-END.strip_indent
+          a = "case"
+          case x
+          when 0
+          end
+        END
         inspect_source(cop, source)
         expect(cop.messages).to be_empty
       end
 
       it "doesn't get confused by symbols named case or when" do
-        source = ['KEYWORDS = { :case => true, :when => true }',
-                  'case type',
-                  'when 0',
-                  '  ParameterNode',
-                  'when 1',
-                  '  MethodCallNode',
-                  'end',
-                  '']
+        source = <<-END.strip_indent
+          KEYWORDS = { :case => true, :when => true }
+          case type
+          when 0
+            ParameterNode
+          when 1
+            MethodCallNode
+          end
+        END
         inspect_source(cop, source)
         expect(cop.messages).to be_empty
       end
 
       it 'accepts correctly indented whens in complex combinations' do
-        source = ['each {',
-                  '  case state',
-                  '  when 0',
-                  '    case name',
-                  '    when :a',
-                  '    end',
-                  '  when 1',
-                  '    loop {',
-                  '      case name',
-                  '      when :b',
-                  '      end',
-                  '    }',
-                  '  end',
-                  '}',
-                  'case s',
-                  'when Array',
-                  'end',
-                  '']
+        source = <<-END.strip_indent
+          each {
+            case state
+            when 0
+              case name
+              when :a
+              end
+            when 1
+              loop {
+                case name
+                when :b
+                end
+              }
+            end
+          }
+          case s
+          when Array
+          end
+        END
         inspect_source(cop, source)
         expect(cop.messages).to be_empty
       end
@@ -254,12 +276,14 @@ describe RuboCop::Cop::Style::CaseIndentation do
       end
 
       let(:correct_source) do
-        ['output = case variable',
-         "           when 'value1'",
-         "             'output1'",
-         '           else',
-         "             'output2'",
-         '         end']
+        <<-END.strip_indent
+          output = case variable
+                     when 'value1'
+                       'output1'
+                     else
+                       'output2'
+                   end
+        END
       end
 
       context 'regarding assignment where the right hand side is a case' do
@@ -270,21 +294,25 @@ describe RuboCop::Cop::Style::CaseIndentation do
 
         context 'an assignment indented some other way' do
           let(:source) do
-            ['output = case variable',
-             "         when 'value1'",
-             "           'output1'",
-             '         else',
-             "           'output2'",
-             '         end']
+            <<-END.strip_indent
+              output = case variable
+                       when 'value1'
+                         'output1'
+                       else
+                         'output2'
+                       end
+            END
           end
 
           let(:correct_source) do
-            ['output = case variable',
-             "           when 'value1'",
-             "           'output1'",
-             '         else',
-             "           'output2'",
-             '         end']
+            <<-END.strip_indent
+              output = case variable
+                         when 'value1'
+                         'output1'
+                       else
+                         'output2'
+                       end
+            END
           end
 
           it 'registers an offense' do
@@ -295,37 +323,40 @@ describe RuboCop::Cop::Style::CaseIndentation do
 
           it 'does auto-correction' do
             corrected = autocorrect_source(cop, source)
-            expect(corrected).to eq correct_source.join("\n")
+            expect(corrected).to eq correct_source
           end
         end
       end
 
       it "accepts a when clause that's 2 spaces deeper than case" do
-        source = ['case a',
-                  '  when 0 then return',
-                  '  else',
-                  '        case b',
-                  '          when 1 then return',
-                  '        end',
-                  'end']
+        source = <<-END.strip_indent
+          case a
+            when 0 then return
+            else
+                  case b
+                    when 1 then return
+                  end
+          end
+        END
         inspect_source(cop, source)
         expect(cop.offenses).to be_empty
       end
 
       context "a when clause that's equally indented with case" do
         let(:source) do
-          ['y = case a',
-           '    when 0 then break',
-           '    when 0 then return',
-           '      z = case b',
-           '          when 1 then return',
-           '          when 1 then break',
-           '          end',
-           '    end',
-           'case c',
-           'when 2 then encoding',
-           'end',
-           '']
+          <<-END.strip_indent
+            y = case a
+                when 0 then break
+                when 0 then return
+                  z = case b
+                      when 1 then return
+                      when 1 then break
+                      end
+                end
+            case c
+            when 2 then encoding
+            end
+          END
         end
 
         it 'registers an offense' do
@@ -336,18 +367,19 @@ describe RuboCop::Cop::Style::CaseIndentation do
 
         it 'does auto-correction' do
           corrected = autocorrect_source(cop, source)
-          expect(corrected).to eq(['y = case a',
-                                   '      when 0 then break',
-                                   '      when 0 then return',
-                                   '      z = case b',
-                                   '            when 1 then return',
-                                   '            when 1 then break',
-                                   '          end',
-                                   '    end',
-                                   'case c',
-                                   '  when 2 then encoding',
-                                   'end',
-                                   ''].join("\n"))
+          expect(corrected).to eq(<<-END.strip_indent)
+            y = case a
+                  when 0 then break
+                  when 0 then return
+                  z = case b
+                        when 1 then return
+                        when 1 then break
+                      end
+                end
+            case c
+              when 2 then encoding
+            end
+          END
         end
       end
 
@@ -361,12 +393,14 @@ describe RuboCop::Cop::Style::CaseIndentation do
         end
 
         let(:source) do
-          ['output = case variable',
-           "              when 'value1'",
-           "             'output1'",
-           '              else',
-           "             'output2'",
-           '         end']
+          <<-END.strip_indent
+            output = case variable
+                          when 'value1'
+                         'output1'
+                          else
+                         'output2'
+                     end
+          END
         end
 
         it 'respects cop-specific IndentationWidth' do
@@ -393,12 +427,14 @@ describe RuboCop::Cop::Style::CaseIndentation do
       end
 
       let(:correct_source) do
-        ['output = case variable',
-         "when 'value1'",
-         "  'output1'",
-         'else',
-         "  'output2'",
-         'end']
+        <<-END.strip_indent
+          output = case variable
+          when 'value1'
+            'output1'
+          else
+            'output2'
+          end
+        END
       end
 
       context 'regarding assignment where the right hand side is a case' do
@@ -409,21 +445,25 @@ describe RuboCop::Cop::Style::CaseIndentation do
 
         context 'an assignment indented some other way' do
           let(:source) do
-            ['output = case variable',
-             "  when 'value1'",
-             "    'output1'",
-             '  else',
-             "    'output2'",
-             'end']
+            <<-END.strip_indent
+              output = case variable
+                when 'value1'
+                  'output1'
+                else
+                  'output2'
+              end
+            END
           end
 
           let(:correct_source) do
-            ['output = case variable',
-             "when 'value1'",
-             "    'output1'",
-             '  else',
-             "    'output2'",
-             'end']
+            <<-END.strip_indent
+              output = case variable
+              when 'value1'
+                  'output1'
+                else
+                  'output2'
+              end
+            END
           end
 
           it 'registers an offense' do
@@ -433,7 +473,7 @@ describe RuboCop::Cop::Style::CaseIndentation do
 
           it 'does auto-correction' do
             corrected = autocorrect_source(cop, source)
-            expect(corrected).to eq correct_source.join("\n")
+            expect(corrected).to eq correct_source
           end
         end
       end
@@ -454,12 +494,14 @@ describe RuboCop::Cop::Style::CaseIndentation do
       end
 
       let(:correct_source) do
-        ['output = case variable',
-         "  when 'value1'",
-         "    'output1'",
-         '  else',
-         "    'output2'",
-         'end']
+        <<-END.strip_indent
+          output = case variable
+            when 'value1'
+              'output1'
+            else
+              'output2'
+          end
+        END
       end
 
       context 'regarding assignment where the right hand side is a case' do
@@ -470,21 +512,25 @@ describe RuboCop::Cop::Style::CaseIndentation do
 
         context 'an assignment indented as case' do
           let(:source) do
-            ['output = case variable',
-             "         when 'value1'",
-             "           'output1'",
-             '         else',
-             "           'output2'",
-             '         end']
+            <<-END.strip_indent
+              output = case variable
+                       when 'value1'
+                         'output1'
+                       else
+                         'output2'
+                       end
+            END
           end
 
           let(:correct_source) do
-            ['output = case variable',
-             "           when 'value1'",
-             "           'output1'",
-             '         else',
-             "           'output2'",
-             '         end']
+            <<-END.strip_indent
+              output = case variable
+                         when 'value1'
+                         'output1'
+                       else
+                         'output2'
+                       end
+            END
           end
 
           it 'registers an offense' do
@@ -497,27 +543,31 @@ describe RuboCop::Cop::Style::CaseIndentation do
 
           it 'does auto-correction' do
             corrected = autocorrect_source(cop, source)
-            expect(corrected).to eq correct_source.join("\n")
+            expect(corrected).to eq correct_source
           end
         end
 
         context 'an assignment indented some other way' do
           let(:source) do
-            ['output = case variable',
-             "       when 'value1'",
-             "         'output1'",
-             '       else',
-             "         'output2'",
-             '       end']
+            <<-END.strip_indent
+              output = case variable
+                     when 'value1'
+                       'output1'
+                     else
+                       'output2'
+                     end
+            END
           end
 
           let(:correct_source) do
-            ['output = case variable',
-             "         when 'value1'",
-             "         'output1'",
-             '       else',
-             "         'output2'",
-             '       end']
+            <<-END.strip_indent
+              output = case variable
+                       when 'value1'
+                       'output1'
+                     else
+                       'output2'
+                     end
+            END
           end
 
           it 'registers an offense' do
@@ -529,7 +579,7 @@ describe RuboCop::Cop::Style::CaseIndentation do
 
           it 'does auto-correction' do
             corrected = autocorrect_source(cop, source)
-            expect(corrected).to eq correct_source.join("\n")
+            expect(corrected).to eq correct_source
           end
         end
       end
@@ -539,8 +589,10 @@ describe RuboCop::Cop::Style::CaseIndentation do
   context 'when case is preceded by something else than whitespace' do
     let(:cop_config) { {} }
     let(:source) do
-      ['case test when something',
-       'end']
+      <<-END.strip_indent
+        case test when something
+        end
+      END
     end
 
     it 'registers an offense' do
@@ -550,7 +602,7 @@ describe RuboCop::Cop::Style::CaseIndentation do
 
     it "doesn't auto-correct" do
       expect(autocorrect_source(cop, source))
-        .to eq(source.join("\n"))
+        .to eq(source)
       expect(cop.offenses.map(&:corrected?)).to eq [false]
     end
   end

--- a/spec/rubocop/cop/style/class_and_module_camel_case_spec.rb
+++ b/spec/rubocop/cop/style/class_and_module_camel_case_spec.rb
@@ -4,32 +4,35 @@ describe RuboCop::Cop::Style::ClassAndModuleCamelCase do
   subject(:cop) { described_class.new }
 
   it 'registers an offense for underscore in class and module name' do
-    inspect_source(cop,
-                   ['class My_Class',
-                    'end',
-                    '',
-                    'module My_Module',
-                    'end'])
+    inspect_source(cop, <<-END.strip_indent)
+      class My_Class
+      end
+
+      module My_Module
+      end
+    END
     expect(cop.offenses.size).to eq(2)
   end
 
   it 'is not fooled by qualified names' do
-    inspect_source(cop,
-                   ['class Top::My_Class',
-                    'end',
-                    '',
-                    'module My_Module::Ala',
-                    'end'])
+    inspect_source(cop, <<-END.strip_indent)
+      class Top::My_Class
+      end
+
+      module My_Module::Ala
+      end
+    END
     expect(cop.offenses.size).to eq(2)
   end
 
   it 'accepts CamelCase names' do
-    inspect_source(cop,
-                   ['class MyClass',
-                    'end',
-                    '',
-                    'module Mine',
-                    'end'])
+    inspect_source(cop, <<-END.strip_indent)
+      class MyClass
+      end
+
+      module Mine
+      end
+    END
     expect(cop.offenses).to be_empty
   end
 end

--- a/spec/rubocop/cop/style/class_and_module_children_spec.rb
+++ b/spec/rubocop/cop/style/class_and_module_children_spec.rb
@@ -7,8 +7,10 @@ describe RuboCop::Cop::Style::ClassAndModuleChildren, :config do
     let(:cop_config) { { 'EnforcedStyle' => 'nested' } }
 
     it 'registers an offense for not nested classes' do
-      inspect_source(cop, ['class FooClass::BarClass',
-                           'end'])
+      inspect_source(cop, <<-END.strip_indent)
+        class FooClass::BarClass
+        end
+      END
 
       expect(cop.offenses.size).to eq 1
       expect(cop.messages).to eq [
@@ -18,8 +20,10 @@ describe RuboCop::Cop::Style::ClassAndModuleChildren, :config do
     end
 
     it 'registers an offense for not nested classes with explicit superclass' do
-      inspect_source(cop, ['class FooClass::BarClass < Super',
-                           'end'])
+      inspect_source(cop, <<-END.strip_indent)
+        class FooClass::BarClass < Super
+        end
+      END
 
       expect(cop.offenses.size).to eq 1
       expect(cop.messages).to eq [
@@ -29,8 +33,10 @@ describe RuboCop::Cop::Style::ClassAndModuleChildren, :config do
     end
 
     it 'registers an offense for not nested modules' do
-      inspect_source(cop, ['module FooModule::BarModule',
-                           'end'])
+      inspect_source(cop, <<-END.strip_indent)
+        module FooModule::BarModule
+        end
+      END
 
       expect(cop.offenses.size).to eq 1
       expect(cop.messages).to eq [
@@ -40,28 +46,30 @@ describe RuboCop::Cop::Style::ClassAndModuleChildren, :config do
     end
 
     it 'accepts nested children' do
-      inspect_source(cop,
-                     ['class FooClass',
-                      '  class BarClass',
-                      '  end',
-                      'end',
-                      '',
-                      'module FooModule',
-                      '  module BarModule',
-                      '  end',
-                      'end'])
+      inspect_source(cop, <<-END.strip_indent)
+        class FooClass
+          class BarClass
+          end
+        end
+
+        module FooModule
+          module BarModule
+          end
+        end
+      END
       expect(cop.offenses).to be_empty
     end
 
     it 'accepts :: in parent class on inheritance' do
-      inspect_source(cop,
-                     ['class FooClass',
-                      '  class BarClass',
-                      '  end',
-                      'end',
-                      '',
-                      'class BazClass < FooClass::BarClass',
-                      'end'])
+      inspect_source(cop, <<-END.strip_indent)
+        class FooClass
+          class BarClass
+          end
+        end
+
+        class BazClass < FooClass::BarClass
+        end
+      END
       expect(cop.offenses).to be_empty
     end
   end
@@ -70,11 +78,12 @@ describe RuboCop::Cop::Style::ClassAndModuleChildren, :config do
     let(:cop_config) { { 'EnforcedStyle' => 'compact' } }
 
     it 'registers a offense for classes with nested children' do
-      inspect_source(cop,
-                     ['class FooClass',
-                      '  class BarClass',
-                      '  end',
-                      'end'])
+      inspect_source(cop, <<-END.strip_indent)
+        class FooClass
+          class BarClass
+          end
+        end
+      END
       expect(cop.offenses.size).to eq 1
       expect(cop.messages).to eq [
         'Use compact module/class definition instead of nested style.'
@@ -83,11 +92,12 @@ describe RuboCop::Cop::Style::ClassAndModuleChildren, :config do
     end
 
     it 'registers a offense for modules with nested children' do
-      inspect_source(cop,
-                     ['module FooModule',
-                      '  module BarModule',
-                      '  end',
-                      'end'])
+      inspect_source(cop, <<-END.strip_indent)
+        module FooModule
+          module BarModule
+          end
+        end
+      END
       expect(cop.offenses.size).to eq 1
       expect(cop.messages).to eq [
         'Use compact module/class definition instead of nested style.'
@@ -96,48 +106,52 @@ describe RuboCop::Cop::Style::ClassAndModuleChildren, :config do
     end
 
     it 'accepts compact style for classes/modules' do
-      inspect_source(cop,
-                     ['class FooClass::BarClass',
-                      'end',
-                      '',
-                      'module FooClass::BarModule',
-                      'end'])
+      inspect_source(cop, <<-END.strip_indent)
+        class FooClass::BarClass
+        end
+
+        module FooClass::BarModule
+        end
+      END
       expect(cop.offenses).to be_empty
     end
 
     it 'accepts nesting for classes/modules with more than one child' do
-      inspect_source(cop,
-                     ['class FooClass',
-                      '  class BarClass',
-                      '  end',
-                      '  class BazClass',
-                      '  end',
-                      'end',
-                      '',
-                      'module FooModule',
-                      '  module BarModule',
-                      '  end',
-                      '  class BazModule',
-                      '  end',
-                      'end'])
+      inspect_source(cop, <<-END.strip_indent)
+        class FooClass
+          class BarClass
+          end
+          class BazClass
+          end
+        end
+
+        module FooModule
+          module BarModule
+          end
+          class BazModule
+          end
+        end
+      END
       expect(cop.offenses).to be_empty
     end
 
     it 'accepts class/module with single method' do
-      inspect_source(cop,
-                     ['class FooClass',
-                      '  def bar_method',
-                      '  end',
-                      'end'])
+      inspect_source(cop, <<-END.strip_indent)
+        class FooClass
+          def bar_method
+          end
+        end
+      END
       expect(cop.offenses).to be_empty
     end
 
     it 'accepts nesting for classes with an explicit superclass' do
-      inspect_source(cop,
-                     ['class FooClass < Super',
-                      '  class BarClass',
-                      '  end',
-                      'end'])
+      inspect_source(cop, <<-END.strip_indent)
+        class FooClass < Super
+          class BarClass
+          end
+        end
+      END
       expect(cop.offenses).to be_empty
     end
   end

--- a/spec/rubocop/cop/style/class_methods_spec.rb
+++ b/spec/rubocop/cop/style/class_methods_spec.rb
@@ -4,12 +4,13 @@ describe RuboCop::Cop::Style::ClassMethods do
   subject(:cop) { described_class.new }
 
   it 'registers an offense for methods using a class name' do
-    inspect_source(cop,
-                   ['class Test',
-                    '  def Test.some_method',
-                    '    do_something',
-                    '  end',
-                    'end'])
+    inspect_source(cop, <<-END.strip_indent)
+      class Test
+        def Test.some_method
+          do_something
+        end
+      end
+    END
     expect(cop.offenses.size).to eq(1)
     expect(cop.messages)
       .to eq(['Use `self.some_method` instead of `Test.some_method`.'])
@@ -17,12 +18,13 @@ describe RuboCop::Cop::Style::ClassMethods do
   end
 
   it 'registers an offense for methods using a module name' do
-    inspect_source(cop,
-                   ['module Test',
-                    '  def Test.some_method',
-                    '    do_something',
-                    '  end',
-                    'end'])
+    inspect_source(cop, <<-END.strip_indent)
+      module Test
+        def Test.some_method
+          do_something
+        end
+      end
+    END
     expect(cop.offenses.size).to eq(1)
     expect(cop.messages)
       .to eq(['Use `self.some_method` instead of `Test.some_method`.'])
@@ -30,47 +32,54 @@ describe RuboCop::Cop::Style::ClassMethods do
   end
 
   it 'does not register an offense for methods using self' do
-    inspect_source(cop,
-                   ['module Test',
-                    '  def self.some_method',
-                    '    do_something',
-                    '  end',
-                    'end'])
+    inspect_source(cop, <<-END.strip_indent)
+      module Test
+        def self.some_method
+          do_something
+        end
+      end
+    END
     expect(cop.offenses).to be_empty
   end
 
   it 'does not register an offense for other top-level singleton methods' do
-    inspect_source(cop,
-                   ['class Test',
-                    '  X = Something.new',
-                    '',
-                    '  def X.some_method',
-                    '    do_something',
-                    '  end',
-                    'end'])
+    inspect_source(cop, <<-END.strip_indent)
+      class Test
+        X = Something.new
+
+        def X.some_method
+          do_something
+        end
+      end
+    END
     expect(cop.offenses).to be_empty
   end
 
   it 'does not register an offense outside class/module bodies' do
-    inspect_source(cop,
-                   ['def Test.some_method',
-                    '  do_something',
-                    'end'])
+    inspect_source(cop, <<-END.strip_indent)
+      def Test.some_method
+        do_something
+      end
+    END
     expect(cop.offenses).to be_empty
   end
 
   it 'autocorrects class name to self' do
-    src = ['class Test',
-           '  def Test.some_method',
-           '    do_something',
-           '  end',
-           'end']
+    src = <<-END.strip_indent
+      class Test
+        def Test.some_method
+          do_something
+        end
+      end
+    END
 
-    correct_source = ['class Test',
-                      '  def self.some_method',
-                      '    do_something',
-                      '  end',
-                      'end'].join("\n")
+    correct_source = <<-END.strip_indent
+      class Test
+        def self.some_method
+          do_something
+        end
+      end
+    END
 
     new_source = autocorrect_source(cop, src)
     expect(new_source).to eq(correct_source)

--- a/spec/rubocop/cop/style/closing_parenthesis_indentation_spec.rb
+++ b/spec/rubocop/cop/style/closing_parenthesis_indentation_spec.rb
@@ -12,49 +12,65 @@ describe RuboCop::Cop::Style::ClosingParenthesisIndentation do
   context 'for method calls' do
     context 'with line break before 1st parameter' do
       it 'registers an offense for misaligned )' do
-        inspect_source(cop, ['some_method(',
-                             '  a',
-                             '  )'])
+        inspect_source(cop, <<-END.strip_indent)
+          some_method(
+            a
+            )
+        END
         expect(cop.messages)
           .to eq(['Indent `)` the same as the start of the line where `(` is.'])
         expect(cop.highlights).to eq([')'])
       end
 
       it 'autocorrects misaligned )' do
-        corrected = autocorrect_source(cop, ['some_method(',
-                                             '  a',
-                                             '  )'])
-        expect(corrected).to eq ['some_method(',
-                                 '  a',
-                                 ')'].join("\n")
+        corrected = autocorrect_source(cop, <<-END.strip_indent)
+          some_method(
+            a
+            )
+        END
+        expect(corrected).to eq <<-END.strip_indent
+          some_method(
+            a
+          )
+        END
       end
 
       it 'accepts a correctly aligned )' do
-        inspect_source(cop, ['some_method(',
-                             '  a',
-                             ')'])
+        inspect_source(cop, <<-END.strip_indent)
+          some_method(
+            a
+          )
+        END
         expect(cop.offenses).to be_empty
       end
     end
 
     context 'with no line break before 1st parameter' do
       it 'registers an offense for misaligned )' do
-        inspect_source(cop, ['some_method(a',
-                             ')'])
+        inspect_source(cop, <<-END.strip_indent)
+          some_method(a
+          )
+        END
         expect(cop.messages).to eq(['Align `)` with `(`.'])
         expect(cop.highlights).to eq([')'])
       end
 
       it 'autocorrects misaligned )' do
-        corrected = autocorrect_source(cop, ['some_method(a',
-                                             ')'])
-        expect(corrected).to eq ['some_method(a',
-                                 '           )'].join("\n")
+        corrected = autocorrect_source(cop, <<-END.strip_indent)
+          some_method(a
+          )
+        END
+        expect(corrected).to eq <<-END.strip_indent
+          some_method(a
+                     )
+        END
       end
 
       it 'accepts a correctly aligned )' do
-        inspect_source(cop, ['some_method(a',
-                             '           )'])
+        inspect_source(cop, <<-END.strip_indent)
+          some_method(a
+                     )
+        END
         expect(cop.offenses).to be_empty
       end
 
@@ -67,31 +83,37 @@ describe RuboCop::Cop::Style::ClosingParenthesisIndentation do
         let(:align_parameters_config) { 'with_fixed_indentation' }
 
         it 'accepts a correctly indented )' do
-          inspect_source(cop, ['some_method(a,',
-                               '  x: 1,',
-                               '  y: 2',
-                               ')',
-                               'b =',
-                               '  some_method(a,',
-                               '  )'])
+          inspect_source(cop, <<-END.strip_indent)
+            some_method(a,
+              x: 1,
+              y: 2
+            )
+            b =
+              some_method(a,
+              )
+          END
           expect(cop.offenses).to be_empty
         end
 
         it 'autocorrects misindented )' do
-          corrected = autocorrect_source(cop, ['some_method(a,',
-                                               '  x: 1,',
-                                               '  y: 2',
-                                               '           )',
-                                               'b =',
-                                               '  some_method(a,',
-                                               '             )'])
-          expect(corrected).to eq ['some_method(a,',
-                                   '  x: 1,',
-                                   '  y: 2',
-                                   ')',
-                                   'b =',
-                                   '  some_method(a,',
-                                   '  )'].join("\n")
+          corrected = autocorrect_source(cop, <<-END.strip_indent)
+            some_method(a,
+              x: 1,
+              y: 2
+                       )
+            b =
+              some_method(a,
+                         )
+          END
+          expect(corrected).to eq <<-END.strip_indent
+            some_method(a,
+              x: 1,
+              y: 2
+            )
+            b =
+              some_method(a,
+              )
+          END
         end
       end
     end
@@ -100,63 +122,81 @@ describe RuboCop::Cop::Style::ClosingParenthesisIndentation do
   context 'for method definitions' do
     context 'with line break before 1st parameter' do
       it 'registers an offense for misaligned )' do
-        inspect_source(cop, ['def some_method(',
-                             '  a',
-                             '  )',
-                             'end'])
+        inspect_source(cop, <<-END.strip_indent)
+          def some_method(
+            a
+            )
+          end
+        END
         expect(cop.messages)
           .to eq(['Indent `)` the same as the start of the line where `(` is.'])
         expect(cop.highlights).to eq([')'])
       end
 
       it 'autocorrects misaligned )' do
-        corrected = autocorrect_source(cop, ['def some_method(',
-                                             '  a',
-                                             '  )',
-                                             'end'])
-        expect(corrected).to eq ['def some_method(',
-                                 '  a',
-                                 ')',
-                                 'end'].join("\n")
+        corrected = autocorrect_source(cop, <<-END.strip_indent)
+          def some_method(
+            a
+            )
+          end
+        END
+        expect(corrected).to eq <<-END.strip_indent
+          def some_method(
+            a
+          )
+          end
+        END
       end
 
       it 'accepts a correctly aligned )' do
-        inspect_source(cop, ['def some_method(',
-                             '  a',
-                             ')',
-                             'end'])
+        inspect_source(cop, <<-END.strip_indent)
+          def some_method(
+            a
+          )
+          end
+        END
         expect(cop.offenses).to be_empty
       end
     end
 
     context 'with no line break before 1st parameter' do
       it 'registers an offense for misaligned )' do
-        inspect_source(cop, ['def some_method(a',
-                             ')',
-                             'end'])
+        inspect_source(cop, <<-END.strip_indent)
+          def some_method(a
+          )
+          end
+        END
         expect(cop.messages).to eq(['Align `)` with `(`.'])
         expect(cop.highlights).to eq([')'])
       end
 
       it 'autocorrects misaligned )' do
-        corrected = autocorrect_source(cop, ['def some_method(a',
-                                             ')',
-                                             'end'])
-        expect(corrected).to eq ['def some_method(a',
-                                 '               )',
-                                 'end'].join("\n")
+        corrected = autocorrect_source(cop, <<-END.strip_indent)
+          def some_method(a
+          )
+          end
+        END
+        expect(corrected).to eq <<-END.strip_indent
+          def some_method(a
+                         )
+          end
+        END
       end
 
       it 'accepts a correctly aligned )' do
-        inspect_source(cop, ['def some_method(a',
-                             '               )',
-                             'end'])
+        inspect_source(cop, <<-END.strip_indent)
+          def some_method(a
+                         )
+          end
+        END
         expect(cop.offenses).to be_empty
       end
 
       it 'accepts empty ()' do
-        inspect_source(cop, ['def some_method()',
-                             'end'])
+        inspect_source(cop, <<-END.strip_indent)
+          def some_method()
+          end
+        END
         expect(cop.offenses).to be_empty
       end
     end
@@ -165,65 +205,85 @@ describe RuboCop::Cop::Style::ClosingParenthesisIndentation do
   context 'for grouped expressions' do
     context 'with line break before 1st operand' do
       it 'registers an offense for misaligned )' do
-        inspect_source(cop, ['w = x * (',
-                             '  y + z',
-                             '  )'])
+        inspect_source(cop, <<-END.strip_indent)
+          w = x * (
+            y + z
+            )
+        END
         expect(cop.messages)
           .to eq(['Indent `)` the same as the start of the line where `(` is.'])
         expect(cop.highlights).to eq([')'])
       end
 
       it 'autocorrects misaligned )' do
-        corrected = autocorrect_source(cop, ['w = x * (',
-                                             '  y + z',
-                                             '  )'])
-        expect(corrected).to eq ['w = x * (',
-                                 '  y + z',
-                                 ')'].join("\n")
+        corrected = autocorrect_source(cop, <<-END.strip_indent)
+          w = x * (
+            y + z
+            )
+        END
+        expect(corrected).to eq <<-END.strip_indent
+          w = x * (
+            y + z
+          )
+        END
       end
 
       it 'accepts a correctly aligned )' do
-        inspect_source(cop, ['w = x * (',
-                             '  y + z',
-                             ')'])
+        inspect_source(cop, <<-END.strip_indent)
+          w = x * (
+            y + z
+          )
+        END
         expect(cop.offenses).to be_empty
       end
     end
 
     context 'with no line break before 1st operand' do
       it 'registers an offense for misaligned )' do
-        inspect_source(cop, ['w = x * (y + z',
-                             ')'])
+        inspect_source(cop, <<-END.strip_indent)
+          w = x * (y + z
+          )
+        END
         expect(cop.messages).to eq(['Align `)` with `(`.'])
         expect(cop.highlights).to eq([')'])
       end
 
       it 'autocorrects misaligned )' do
-        corrected = autocorrect_source(cop, ['w = x * (y + z',
-                                             '  )'])
-        expect(corrected).to eq ['w = x * (y + z',
-                                 '        )'].join("\n")
+        corrected = autocorrect_source(cop, <<-END.strip_indent)
+          w = x * (y + z
+            )
+        END
+        expect(corrected).to eq <<-END.strip_indent
+          w = x * (y + z
+                  )
+        END
       end
 
       it 'accepts a correctly aligned )' do
-        inspect_source(cop, ['w = x * (y + z',
-                             '        )'])
+        inspect_source(cop, <<-END.strip_indent)
+          w = x * (y + z
+                  )
+        END
         expect(cop.offenses).to be_empty
       end
 
       it 'accepts ) that does not begin its line' do
-        inspect_source(cop, ['w = x * (y + z +',
-                             '        a)'])
+        inspect_source(cop, <<-END.strip_indent)
+          w = x * (y + z +
+                  a)
+        END
         expect(cop.offenses).to be_empty
       end
     end
   end
 
   it 'accepts begin nodes that are not grouped expressions' do
-    inspect_source(cop, ['def a',
-                         '  x',
-                         '  y',
-                         'end'])
+    inspect_source(cop, <<-END.strip_indent)
+      def a
+        x
+        y
+      end
+    END
     expect(cop.offenses).to be_empty
   end
 end

--- a/spec/rubocop/cop/style/comment_annotation_spec.rb
+++ b/spec/rubocop/cop/style/comment_annotation_spec.rb
@@ -104,16 +104,19 @@ describe RuboCop::Cop::Style::CommentAnnotation, :config do
   end
 
   it 'accepts a keyword that is just the beginning of a sentence' do
-    inspect_source(cop,
-                   ["# Optimize if you want. I wouldn't recommend it.",
-                    '# Hack is a fun game.'])
+    inspect_source(cop, <<-END.strip_indent)
+      # Optimize if you want. I wouldn't recommend it.
+      # Hack is a fun game.
+    END
     expect(cop.offenses).to be_empty
   end
 
   it 'accepts a keyword that is somewhere in a sentence' do
-    src = ['# Example: There are three reviews, with ranks 1, 2, and 3. A new',
-           '# review is saved with rank 2. The two reviews that originally had',
-           '# ranks 2 and 3 will have their ranks increased to 3 and 4.']
+    src = <<-END.strip_indent
+      # Example: There are three reviews, with ranks 1, 2, and 3. A new
+      # review is saved with rank 2. The two reviews that originally had
+      # ranks 2 and 3 will have their ranks increased to 3 and 4.
+    END
     inspect_source(cop, src)
     expect(cop.offenses).to be_empty
   end

--- a/spec/rubocop/cop/style/comment_indentation_spec.rb
+++ b/spec/rubocop/cop/style/comment_indentation_spec.rb
@@ -20,12 +20,14 @@ describe RuboCop::Cop::Style::CommentIndentation do
     end
 
     it 'accepts a documentation comment' do
-      inspect_source(cop, ['=begin',
-                           'Doc comment',
-                           '=end',
-                           '  hello',
-                           ' #',
-                           'hi'])
+      inspect_source(cop, <<-END.strip_indent)
+        =begin
+        Doc comment
+        =end
+          hello
+         #
+        hi
+      END
       expect(cop.highlights).to eq(['#'])
     end
 
@@ -43,11 +45,13 @@ describe RuboCop::Cop::Style::CommentIndentation do
     end
 
     it 'registers an offense for each incorrectly indented comment' do
-      inspect_source(cop, ['# a',
-                           '  # b',
-                           '    # c',
-                           '# d',
-                           'def test; end'])
+      inspect_source(cop, <<-END.strip_indent)
+        # a
+          # b
+            # c
+        # d
+        def test; end
+      END
       expect(cop.messages)
         .to eq(['Incorrect indentation detected (column 0 instead of 2).',
                 'Incorrect indentation detected (column 2 instead of 4).',
@@ -56,50 +60,56 @@ describe RuboCop::Cop::Style::CommentIndentation do
   end
 
   it 'registers offenses before __END__ but not after' do
-    inspect_source(cop, [' #',
-                         '__END__',
-                         '  #'])
+    inspect_source(cop, <<-END.strip_indent)
+       #
+      __END__
+        #
+    END
     expect(cop.messages)
       .to eq(['Incorrect indentation detected (column 1 instead of 0).'])
   end
 
   context 'around program structure keywords' do
     it 'accepts correctly indented comments' do
-      inspect_source(cop, ['#',
-                           'def m',
-                           '  #',
-                           '  if a',
-                           '    #',
-                           '    b',
-                           '  # this is accepted',
-                           '  elsif aa',
-                           '    # this is accepted',
-                           '  else',
-                           '    #',
-                           '  end',
-                           '  #',
-                           '  case a',
-                           '  # this is accepted',
-                           '  when 0',
-                           '    #',
-                           '    b',
-                           '  end',
-                           '  # this is accepted',
-                           'rescue',
-                           '# this is accepted',
-                           'ensure',
-                           '  #',
-                           'end',
-                           '#'])
+      inspect_source(cop, <<-END.strip_indent)
+        #
+        def m
+          #
+          if a
+            #
+            b
+          # this is accepted
+          elsif aa
+            # this is accepted
+          else
+            #
+          end
+          #
+          case a
+          # this is accepted
+          when 0
+            #
+            b
+          end
+          # this is accepted
+        rescue
+        # this is accepted
+        ensure
+          #
+        end
+        #
+      END
       expect(cop.offenses).to eq([])
     end
 
     context 'with a blank line following the comment' do
       it 'accepts a correctly indented comment' do
-        inspect_source(cop, ['def m',
-                             '  # comment',
-                             '',
-                             'end'])
+        inspect_source(cop, <<-END.strip_indent)
+          def m
+            # comment
+
+          end
+        END
         expect(cop.offenses).to be_empty
       end
     end
@@ -107,79 +117,87 @@ describe RuboCop::Cop::Style::CommentIndentation do
 
   context 'near various kinds of brackets' do
     it 'accepts correctly indented comments' do
-      inspect_source(cop, ['#',
-                           'a = {',
-                           '  #',
-                           '  x: [',
-                           '    1',
-                           '    #',
-                           '  ],',
-                           '  #',
-                           '  y: func(',
-                           '    1',
-                           '    #',
-                           '  )',
-                           '  #',
-                           '}',
-                           '#'])
+      inspect_source(cop, <<-END.strip_indent)
+        #
+        a = {
+          #
+          x: [
+            1
+            #
+          ],
+          #
+          y: func(
+            1
+            #
+          )
+          #
+        }
+        #
+      END
       expect(cop.offenses).to eq([])
     end
 
     it 'is unaffected by closing bracket that does not begin a line' do
-      inspect_source(cop, ['#',
-                           'result = []'])
+      inspect_source(cop, <<-END.strip_indent)
+        #
+        result = []
+      END
       expect(cop.messages).to eq([])
     end
   end
 
   it 'auto-corrects' do
-    new_source = autocorrect_source(cop, [' # comment',
-                                          'hash1 = { a: 0,',
-                                          '     # comment',
-                                          '          bb: 1,',
-                                          '          ccc: 2 }',
-                                          '  if a',
-                                          '  #',
-                                          '    b',
-                                          '  # this is accepted',
-                                          '  elsif aa',
-                                          '    # so is this',
-                                          '  elsif bb',
-                                          '#',
-                                          '  else',
-                                          '   #',
-                                          '  end',
-                                          '  case a',
-                                          '  # this is accepted',
-                                          '  when 0',
-                                          '    # so is this',
-                                          '  when 1',
-                                          '     #',
-                                          '    b',
-                                          '  end'])
-    expect(new_source).to eq(['# comment',
-                              'hash1 = { a: 0,',
-                              '          # comment',
-                              '          bb: 1,',
-                              '          ccc: 2 }',
-                              '  if a',
-                              '    #',
-                              '    b',
-                              '  # this is accepted',
-                              '  elsif aa',
-                              '    # so is this',
-                              '  elsif bb',
-                              '  #',
-                              '  else',
-                              '    #',
-                              '  end',
-                              '  case a',
-                              '  # this is accepted',
-                              '  when 0',
-                              '    # so is this',
-                              '  when 1',
-                              '    #',
-                              '    b',
-                              '  end'].join("\n"))
+    new_source = autocorrect_source(cop, <<-END.strip_indent)
+       # comment
+      hash1 = { a: 0,
+           # comment
+                bb: 1,
+                ccc: 2 }
+        if a
+        #
+          b
+        # this is accepted
+        elsif aa
+          # so is this
+        elsif bb
+      #
+        else
+         #
+        end
+        case a
+        # this is accepted
+        when 0
+          # so is this
+        when 1
+           #
+          b
+        end
+    END
+    expect(new_source).to eq(<<-END.strip_indent)
+      # comment
+      hash1 = { a: 0,
+                # comment
+                bb: 1,
+                ccc: 2 }
+        if a
+          #
+          b
+        # this is accepted
+        elsif aa
+          # so is this
+        elsif bb
+        #
+        else
+          #
+        end
+        case a
+        # this is accepted
+        when 0
+          # so is this
+        when 1
+          #
+          b
+        end
+    END
   end
 end

--- a/spec/rubocop/cop/style/conditional_assignment_assign_in_condition_spec.rb
+++ b/spec/rubocop/cop/style/conditional_assignment_assign_in_condition_spec.rb
@@ -17,24 +17,28 @@ describe RuboCop::Cop::Style::ConditionalAssignment do
     end
 
     it 'registers an offense assigning any variable type to if else' do
-      source = ["#{variable} = if foo",
-                '                1',
-                '              else',
-                '                2',
-                '              end']
+      source = <<-END.strip_indent
+        #{variable} = if foo
+                        1
+                      else
+                        2
+                      end
+      END
       inspect_source(cop, source)
 
       expect(cop.messages).to eq([described_class::ASSIGN_TO_CONDITION_MSG])
     end
 
     it 'registers an offense assigning any variable type to if elsif else' do
-      source = ["#{variable} = if foo",
-                '                1',
-                '              elsif baz',
-                '                2',
-                '              else',
-                '                3',
-                '              end']
+      source = <<-END.strip_indent
+        #{variable} = if foo
+                        1
+                      elsif baz
+                        2
+                      else
+                        3
+                      end
+      END
       inspect_source(cop, source)
 
       expect(cop.messages).to eq([described_class::ASSIGN_TO_CONDITION_MSG])
@@ -42,11 +46,13 @@ describe RuboCop::Cop::Style::ConditionalAssignment do
 
     it 'registers an offense assigning any variable type to if else' \
       'with multiple assignment' do
-      source = ["#{variable}, #{variable} = if foo",
-                '                something',
-                '              else',
-                '                something_else',
-                '              end']
+      source = <<-END.strip_indent
+        #{variable}, #{variable} = if foo
+                        something
+                      else
+                        something_else
+                      end
+      END
       inspect_source(cop, source)
 
       expect(cop.messages).to eq([described_class::ASSIGN_TO_CONDITION_MSG])
@@ -54,88 +60,104 @@ describe RuboCop::Cop::Style::ConditionalAssignment do
 
     it 'allows assigning any variable type inside if else' \
       'with multiple assignment' do
-      source = ['if foo',
-                "  #{variable}, #{variable} = something",
-                'else',
-                "  #{variable}, #{variable} = something_else",
-                'end']
+      source = <<-END.strip_indent
+        if foo
+          #{variable}, #{variable} = something
+        else
+          #{variable}, #{variable} = something_else
+        end
+      END
       inspect_source(cop, source)
 
       expect(cop.messages).to be_empty
     end
 
     it 'allows assigning any variable type inside if else' do
-      source = ['if foo',
-                "  #{variable} = 1",
-                'else',
-                "  #{variable} = 2",
-                'end']
+      source = <<-END.strip_indent
+        if foo
+          #{variable} = 1
+        else
+          #{variable} = 2
+        end
+      END
       inspect_source(cop, source)
 
       expect(cop.offenses).to be_empty
     end
 
     it 'allows assignment to if without else' do
-      source = ["#{variable} = if foo",
-                '                1',
-                '              end']
+      source = <<-END.strip_indent
+        #{variable} = if foo
+                        1
+                      end
+      END
       inspect_source(cop, source)
 
       expect(cop.offenses).to be_empty
     end
 
     it 'registers an offense assigning any variable type to unless else' do
-      source = ["#{variable} = unless foo",
-                '                1',
-                '              else',
-                '                2',
-                '              end']
+      source = <<-END.strip_indent
+        #{variable} = unless foo
+                        1
+                      else
+                        2
+                      end
+      END
       inspect_source(cop, source)
 
       expect(cop.messages).to eq([described_class::ASSIGN_TO_CONDITION_MSG])
     end
 
     it 'allows assigning any variable type inside unless else' do
-      source = ['unless foo',
-                "  #{variable} = 1",
-                'else',
-                "  #{variable} = 2",
-                'end']
+      source = <<-END.strip_indent
+        unless foo
+          #{variable} = 1
+        else
+          #{variable} = 2
+        end
+      END
       inspect_source(cop, source)
 
       expect(cop.offenses).to be_empty
     end
 
     it 'registers an offense for assigning any variable type to case when' do
-      source = ["#{variable} = case foo",
-                '              when "a"',
-                '                1',
-                '              else',
-                '                2',
-                '              end']
+      source = <<-END.strip_indent
+        #{variable} = case foo
+                      when "a"
+                        1
+                      else
+                        2
+                      end
+      END
       inspect_source(cop, source)
 
       expect(cop.messages).to eq([described_class::ASSIGN_TO_CONDITION_MSG])
     end
 
     it 'allows assigning any variable type inside case when' do
-      source = ['case foo',
-                'when "a"',
-                "  #{variable} = 1",
-                'else',
-                "  #{variable} = 2",
-                'end']
+      source = <<-END.strip_indent
+        case foo
+        when "a"
+          #{variable} = 1
+        else
+          #{variable} = 2
+        end
+      END
       inspect_source(cop, source)
 
       expect(cop.offenses).to be_empty
     end
 
     it 'does not crash for rescue assignment' do
-      source = ['begin',
-                '  foo',
-                "rescue => #{variable}",
-                '  bar',
-                'end']
+      source = <<-END.strip_indent
+        begin
+          foo
+        rescue => #{variable}
+          bar
+        end
+      END
       inspect_source(cop, source)
 
       expect(cop.offenses).to be_empty
@@ -149,58 +171,70 @@ describe RuboCop::Cop::Style::ConditionalAssignment do
       end
 
       it 'corrects assigning any variable type to if elsif else' do
-        source = ["#{variable} = if foo",
-                  '                1',
-                  '              elsif baz',
-                  '                2',
-                  '              else',
-                  '                3',
-                  '              end']
+        source = <<-END.strip_indent
+          #{variable} = if foo
+                          1
+                        elsif baz
+                          2
+                        else
+                          3
+                        end
+        END
         new_source = autocorrect_source(cop, source)
 
-        expect(new_source).to eq(['if foo',
-                                  "  #{variable} = 1",
-                                  'elsif baz',
-                                  "  #{variable} = 2",
-                                  'else',
-                                  "  #{variable} = 3",
-                                  'end'].join("\n"))
+        expect(new_source).to eq(<<-END.strip_indent)
+          if foo
+            #{variable} = 1
+          elsif baz
+            #{variable} = 2
+          else
+            #{variable} = 3
+          end
+        END
       end
 
       it 'corrects assigning any variable type to unless else' do
-        source = ["#{variable} = unless foo",
-                  '                1',
-                  '              else',
-                  '                2',
-                  '              end']
+        source = <<-END.strip_indent
+          #{variable} = unless foo
+                          1
+                        else
+                          2
+                        end
+        END
         new_source = autocorrect_source(cop, source)
 
-        expect(new_source).to eq(['unless foo',
-                                  "  #{variable} = 1",
-                                  'else',
-                                  "  #{variable} = 2",
-                                  'end'].join("\n"))
+        expect(new_source).to eq(<<-END.strip_indent)
+          unless foo
+            #{variable} = 1
+          else
+            #{variable} = 2
+          end
+        END
       end
 
       it 'corrects assigning any variable type to case when' do
-        source = ["#{variable} = case foo",
-                  '              when "a"',
-                  '                1',
-                  '              when "b"',
-                  '                2',
-                  '              else',
-                  '                3',
-                  '              end']
+        source = <<-END.strip_indent
+          #{variable} = case foo
+                        when "a"
+                          1
+                        when "b"
+                          2
+                        else
+                          3
+                        end
+        END
         new_source = autocorrect_source(cop, source)
 
-        expect(new_source).to eq(['case foo',
-                                  'when "a"',
-                                  "  #{variable} = 1",
-                                  'when "b"',
-                                  "  #{variable} = 2",
-                                  'else',
-                                  "  #{variable} = 3",
-                                  'end'].join("\n"))
+        expect(new_source).to eq(<<-END.strip_indent)
+          case foo
+          when "a"
+            #{variable} = 1
+          when "b"
+            #{variable} = 2
+          else
+            #{variable} = 3
+          end
+        END
       end
     end
   end
@@ -213,43 +247,51 @@ describe RuboCop::Cop::Style::ConditionalAssignment do
     end
 
     it 'registers an offense any assignment to if else' do
-      source = ["bar #{assignment} if foo",
-                '                1',
-                '              else',
-                '                2',
-                '              end']
+      source = <<-END.strip_indent
+        bar #{assignment} if foo
+                        1
+                      else
+                        2
+                      end
+      END
       inspect_source(cop, source)
 
       expect(cop.messages).to eq([described_class::ASSIGN_TO_CONDITION_MSG])
     end
 
     it 'allows any assignment to if without else' do
-      source = ["bar #{assignment} if foo",
-                '                1',
-                '              end']
+      source = <<-END.strip_indent
+        bar #{assignment} if foo
+                        1
+                      end
+      END
       inspect_source(cop, source)
 
       expect(cop.offenses).to be_empty
     end
 
     it 'registers an offense for any assignment to unless else' do
-      source = ["bar #{assignment} unless foo",
-                '                1',
-                '              else',
-                '                2',
-                '              end']
+      source = <<-END.strip_indent
+        bar #{assignment} unless foo
+                        1
+                      else
+                        2
+                      end
+      END
       inspect_source(cop, source)
 
       expect(cop.messages).to eq([described_class::ASSIGN_TO_CONDITION_MSG])
     end
 
     it 'registers an offense any assignment to case when' do
-      source = ["bar #{assignment} case foo",
-                '              when "a"',
-                '                1',
-                '              else',
-                '                2',
-                '              end']
+      source = <<-END.strip_indent
+        bar #{assignment} case foo
+                      when "a"
+                        1
+                      else
+                        2
+                      end
+      END
       inspect_source(cop, source)
 
       expect(cop.messages).to eq([described_class::ASSIGN_TO_CONDITION_MSG])
@@ -264,63 +306,77 @@ describe RuboCop::Cop::Style::ConditionalAssignment do
       end
 
       it 'corrects any assignment to if else' do
-        source = ["bar #{assignment} if foo",
-                  '                1',
-                  '              else',
-                  '                2',
-                  '              end']
+        source = <<-END.strip_indent
+          bar #{assignment} if foo
+                          1
+                        else
+                          2
+                        end
+        END
         new_source = autocorrect_source(cop, source)
 
-        expect(new_source).to eq(['if foo',
-                                  "  bar #{assignment} 1",
-                                  'else',
-                                  "  bar #{assignment} 2",
-                                  'end'].join("\n"))
+        expect(new_source).to eq(<<-END.strip_indent)
+          if foo
+            bar #{assignment} 1
+          else
+            bar #{assignment} 2
+          end
+        END
       end
 
       it 'corrects any assignment to unless else' do
-        source = ["bar #{assignment} unless foo",
-                  '                1',
-                  '              else',
-                  '                2',
-                  '              end']
+        source = <<-END.strip_indent
+          bar #{assignment} unless foo
+                          1
+                        else
+                          2
+                        end
+        END
         new_source = autocorrect_source(cop, source)
 
-        expect(new_source).to eq(['unless foo',
-                                  "  bar #{assignment} 1",
-                                  'else',
-                                  "  bar #{assignment} 2",
-                                  'end'].join("\n"))
+        expect(new_source).to eq(<<-END.strip_indent)
+          unless foo
+            bar #{assignment} 1
+          else
+            bar #{assignment} 2
+          end
+        END
       end
 
       it 'corrects any assignment to case when' do
-        source = ["bar #{assignment} case foo",
-                  '              when "a"',
-                  '                1',
-                  '              else',
-                  '                2',
-                  '              end']
+        source = <<-END.strip_indent
+          bar #{assignment} case foo
+                        when "a"
+                          1
+                        else
+                          2
+                        end
+        END
         new_source = autocorrect_source(cop, source)
 
-        expect(new_source).to eq(['case foo',
-                                  'when "a"',
-                                  "  bar #{assignment} 1",
-                                  'else',
-                                  "  bar #{assignment} 2",
-                                  'end'].join("\n"))
+        expect(new_source).to eq(<<-END.strip_indent)
+          case foo
+          when "a"
+            bar #{assignment} 1
+          else
+            bar #{assignment} 2
+          end
+        END
       end
     end
   end
 
   shared_examples 'multiline all variable types' do |variable, expected|
     it 'assigning any variable type to a multiline if else' do
-      source = ["#{variable} = if foo",
-                '                something',
-                '                1',
-                '              else',
-                '                something_else',
-                '                2',
-                '              end']
+      source = <<-END.strip_indent
+        #{variable} = if foo
+                        something
+                        1
+                      else
+                        something_else
+                        2
+                      end
+      END
       inspect_source(cop, source)
 
       expect(cop.messages).to eq(expected)
@@ -328,58 +384,66 @@ describe RuboCop::Cop::Style::ConditionalAssignment do
 
     it 'assigning any variable type to an if else with multiline ' \
        'in one branch' do
-      source = ["#{variable} = if foo",
-                '                1',
-                '              else',
-                '                something_else',
-                '                2',
-                '              end']
+      source = <<-END.strip_indent
+        #{variable} = if foo
+                        1
+                      else
+                        something_else
+                        2
+                      end
+      END
       inspect_source(cop, source)
 
       expect(cop.messages).to eq(expected)
     end
 
     it 'assigning any variable type to a multiline if elsif else' do
-      source = ["#{variable} = if foo",
-                '                something',
-                '                1',
-                '              elsif',
-                '                something_other',
-                '                2',
-                '              elsif',
-                '                something_other_again',
-                '                3',
-                '              else',
-                '                something_else',
-                '                4',
-                '              end']
+      source = <<-END.strip_indent
+        #{variable} = if foo
+                        something
+                        1
+                      elsif
+                        something_other
+                        2
+                      elsif
+                        something_other_again
+                        3
+                      else
+                        something_else
+                        4
+                      end
+      END
       inspect_source(cop, source)
 
       expect(cop.messages).to eq(expected)
     end
 
     it 'assigning any variable type to a multiline unless else' do
-      source = ["#{variable} = unless foo",
-                '                something',
-                '                1',
-                '              else',
-                '                something_else',
-                '                2',
-                '              end']
+      source = <<-END.strip_indent
+        #{variable} = unless foo
+                        something
+                        1
+                      else
+                        something_else
+                        2
+                      end
+      END
       inspect_source(cop, source)
 
       expect(cop.messages).to eq(expected)
     end
 
     it 'assigning any variable type to a multiline case when' do
-      source = ["#{variable} = case foo",
-                '              when "a"',
-                '                something',
-                '                1',
-                '              else',
-                '                something_else',
-                '                2',
-                '              end']
+      source = <<-END.strip_indent
+        #{variable} = case foo
+                      when "a"
+                        something
+                        1
+                      else
+                        something_else
+                        2
+                      end
+      END
       inspect_source(cop, source)
 
       expect(cop.messages).to eq(expected)
@@ -388,40 +452,46 @@ describe RuboCop::Cop::Style::ConditionalAssignment do
 
   shared_examples 'multiline all assignment types' do |assignment, expected|
     it 'any assignment to a multiline if else' do
-      source = ["bar #{assignment} if foo",
-                '                something',
-                '                1',
-                '              else',
-                '                something_else',
-                '                2',
-                '              end']
+      source = <<-END.strip_indent
+        bar #{assignment} if foo
+                        something
+                        1
+                      else
+                        something_else
+                        2
+                      end
+      END
       inspect_source(cop, source)
 
       expect(cop.messages).to eq(expected)
     end
 
     it 'any assignment to a multiline unless else' do
-      source = ["bar #{assignment} unless foo",
-                '                something',
-                '                1',
-                '              else',
-                '                something_else',
-                '                2',
-                '              end']
+      source = <<-END.strip_indent
+        bar #{assignment} unless foo
+                        something
+                        1
+                      else
+                        something_else
+                        2
+                      end
+      END
       inspect_source(cop, source)
 
       expect(cop.messages).to eq(expected)
     end
 
     it 'any assignment to a multiline case when' do
-      source = ["bar #{assignment} case foo",
-                '              when "a"',
-                '                something',
-                '                1',
-                '              else',
-                '                something_else',
-                '                2',
-                '              end']
+      source = <<-END.strip_indent
+        bar #{assignment} case foo
+                      when "a"
+                        something
+                        1
+                      else
+                        something_else
+                        2
+                      end
+      END
       inspect_source(cop, source)
 
       expect(cop.messages).to eq(expected)
@@ -430,113 +500,137 @@ describe RuboCop::Cop::Style::ConditionalAssignment do
 
   shared_examples 'single line condition auto-correct' do
     it 'corrects assignment to an if else condition' do
-      source = ['bar = if foo',
-                '        1',
-                '      else',
-                '        2',
-                '      end']
+      source = <<-END.strip_indent
+        bar = if foo
+                1
+              else
+                2
+              end
+      END
       new_source = autocorrect_source(cop, source)
 
-      expect(new_source).to eq(['if foo',
-                                '  bar = 1',
-                                'else',
-                                '  bar = 2',
-                                'end'].join("\n"))
+      expect(new_source).to eq(<<-END.strip_indent)
+        if foo
+          bar = 1
+        else
+          bar = 2
+        end
+      END
     end
 
     it 'corrects assignment to an if elsif else condition' do
-      source = ['bar = if foo',
-                '        1',
-                '      elsif foobar',
-                '        2',
-                '      else',
-                '        3',
-                '      end']
+      source = <<-END.strip_indent
+        bar = if foo
+                1
+              elsif foobar
+                2
+              else
+                3
+              end
+      END
       new_source = autocorrect_source(cop, source)
 
-      expect(new_source).to eq(['if foo',
-                                '  bar = 1',
-                                'elsif foobar',
-                                '  bar = 2',
-                                'else',
-                                '  bar = 3',
-                                'end'].join("\n"))
+      expect(new_source).to eq(<<-END.strip_indent)
+        if foo
+          bar = 1
+        elsif foobar
+          bar = 2
+        else
+          bar = 3
+        end
+      END
     end
 
     it 'corrects assignment to an if elsif else with multiple elsifs' do
-      source = ['bar = if foo',
-                '        1',
-                '      elsif foobar',
-                '        2',
-                '      elsif baz',
-                '        3',
-                '      else',
-                '        4',
-                '      end']
+      source = <<-END.strip_indent
+        bar = if foo
+                1
+              elsif foobar
+                2
+              elsif baz
+                3
+              else
+                4
+              end
+      END
       new_source = autocorrect_source(cop, source)
 
-      expect(new_source).to eq(['if foo',
-                                '  bar = 1',
-                                'elsif foobar',
-                                '  bar = 2',
-                                'elsif baz',
-                                '  bar = 3',
-                                'else',
-                                '  bar = 4',
-                                'end'].join("\n"))
+      expect(new_source).to eq(<<-END.strip_indent)
+        if foo
+          bar = 1
+        elsif foobar
+          bar = 2
+        elsif baz
+          bar = 3
+        else
+          bar = 4
+        end
+      END
     end
 
     it 'corrects assignment to an unless else condition' do
-      source = ['bar = unless foo',
-                '        1',
-                '      else',
-                '        2',
-                '      end']
+      source = <<-END.strip_indent
+        bar = unless foo
+                1
+              else
+                2
+              end
+      END
       new_source = autocorrect_source(cop, source)
 
-      expect(new_source).to eq(['unless foo',
-                                '  bar = 1',
-                                'else',
-                                '  bar = 2',
-                                'end'].join("\n"))
+      expect(new_source).to eq(<<-END.strip_indent)
+        unless foo
+          bar = 1
+        else
+          bar = 2
+        end
+      END
     end
 
     it 'corrects assignment to a case when else condition' do
-      source = ['bar = case foo',
-                '      when foobar',
-                '        1',
-                '      else',
-                '        2',
-                '      end']
+      source = <<-END.strip_indent
+        bar = case foo
+              when foobar
+                1
+              else
+                2
+              end
+      END
       new_source = autocorrect_source(cop, source)
 
-      expect(new_source).to eq(['case foo',
-                                'when foobar',
-                                '  bar = 1',
-                                'else',
-                                '  bar = 2',
-                                'end'].join("\n"))
+      expect(new_source).to eq(<<-END.strip_indent)
+        case foo
+        when foobar
+          bar = 1
+        else
+          bar = 2
+        end
+      END
     end
 
     it 'corrects assignment to a case when else with multiple whens' do
-      source = ['bar = case foo',
-                '      when foobar',
-                '        1',
-                '      when baz',
-                '        2',
-                '      else',
-                '        3',
-                '      end']
+      source = <<-END.strip_indent
+        bar = case foo
+              when foobar
+                1
+              when baz
+                2
+              else
+                3
+              end
+      END
       new_source = autocorrect_source(cop, source)
 
-      expect(new_source).to eq(['case foo',
-                                'when foobar',
-                                '  bar = 1',
-                                'when baz',
-                                '  bar = 2',
-                                'else',
-                                '  bar = 3',
-                                'end'].join("\n"))
+      expect(new_source).to eq(<<-END.strip_indent)
+        case foo
+        when foobar
+          bar = 1
+        when baz
+          bar = 2
+        else
+          bar = 3
+        end
+      END
     end
 
     it 'corrects assignment to a ternary operator' do
@@ -640,30 +734,36 @@ describe RuboCop::Cop::Style::ConditionalAssignment do
     end
 
     it 'registers an offense for assignment using []=' do
-      source = ['foo[:a] = if bar?',
-                '            1',
-                '          else',
-                '            2',
-                '          end']
+      source = <<-END.strip_indent
+        foo[:a] = if bar?
+                    1
+                  else
+                    2
+                  end
+      END
       inspect_source(cop, source)
 
       expect(cop.messages).to eq([described_class::ASSIGN_TO_CONDITION_MSG])
     end
 
     it 'registers an offense for assignment to an if then else' do
-      source = ['bar = if foo then 1',
-                '      else 2',
-                '      end']
+      source = <<-END.strip_indent
+        bar = if foo then 1
+              else 2
+              end
+      END
       inspect_source(cop, source)
 
       expect(cop.messages).to eq([described_class::ASSIGN_TO_CONDITION_MSG])
     end
 
     it 'registers an offense for assignment to case when then else' do
-      source = ['baz = case foo',
-                '      when bar then 1',
-                '      else 2',
-                '      end']
+      source = <<-END.strip_indent
+        baz = case foo
+              when bar then 1
+              else 2
+              end
+      END
       inspect_source(cop, source)
 
       expect(cop.messages).to eq([described_class::ASSIGN_TO_CONDITION_MSG])
@@ -673,29 +773,37 @@ describe RuboCop::Cop::Style::ConditionalAssignment do
       it_behaves_like('single line condition auto-correct')
 
       it 'corrects assignment to an if then else' do
-        source = ['bar = if foo then 1',
-                  '      else 2',
-                  '      end']
+        source = <<-END.strip_indent
+          bar = if foo then 1
+                else 2
+                end
+        END
 
         new_source = autocorrect_source(cop, source)
 
-        expect(new_source).to eq(['if foo then bar = 1',
-                                  'else bar = 2',
-                                  'end'].join("\n"))
+        expect(new_source).to eq(<<-END.strip_indent)
+          if foo then bar = 1
+          else bar = 2
+          end
+        END
       end
 
       it 'corrects assignment to case when then else' do
-        source = ['baz = case foo',
-                  '      when bar then 1',
-                  '      else 2',
-                  '      end']
+        source = <<-END.strip_indent
+          baz = case foo
+                when bar then 1
+                else 2
+                end
+        END
 
         new_source = autocorrect_source(cop, source)
 
-        expect(new_source).to eq(['case foo',
-                                  'when bar then baz = 1',
-                                  'else baz = 2',
-                                  'end'].join("\n"))
+        expect(new_source).to eq(<<-END.strip_indent)
+          case foo
+          when bar then baz = 1
+          else baz = 2
+          end
+        END
       end
 
       it 'corrects assignment using a method that ends with an equal sign' do
@@ -706,33 +814,41 @@ describe RuboCop::Cop::Style::ConditionalAssignment do
       end
 
       it 'corrects assignment using []=' do
-        source = ['foo[:a] = if bar?',
-                  '            1',
-                  '          else',
-                  '            2',
-                  '          end']
+        source = <<-END.strip_indent
+          foo[:a] = if bar?
+                      1
+                    else
+                      2
+                    end
+        END
         new_source = autocorrect_source(cop, source)
 
-        expect(new_source).to eq(['if bar?',
-                                  '  foo[:a] = 1',
-                                  'else',
-                                  '  foo[:a] = 2',
-                                  'end'].join("\n"))
+        expect(new_source).to eq(<<-END.strip_indent)
+          if bar?
+            foo[:a] = 1
+          else
+            foo[:a] = 2
+          end
+        END
       end
 
       it 'corrects assignment to a namespaced constant' do
-        source = ['FOO::BAR = if baz?',
-                  '             1',
-                  '           else',
-                  '             2',
-                  '           end']
+        source = <<-END.strip_indent
+          FOO::BAR = if baz?
+                       1
+                     else
+                       2
+                     end
+        END
         new_source = autocorrect_source(cop, source)
 
-        expect(new_source).to eq(['if baz?',
-                                  '  FOO::BAR = 1',
-                                  'else',
-                                  '  FOO::BAR = 2',
-                                  'end'].join("\n"))
+        expect(new_source).to eq(<<-END.strip_indent)
+          if baz?
+            FOO::BAR = 1
+          else
+            FOO::BAR = 2
+          end
+        END
       end
     end
   end
@@ -848,145 +964,169 @@ describe RuboCop::Cop::Style::ConditionalAssignment do
     it_behaves_like('single line condition auto-correct')
 
     it 'corrects assignment to a multiline if else condition' do
-      source = ['bar = if foo',
-                '        something',
-                '        1',
-                '      else',
-                '        something_else',
-                '        2',
-                '      end']
+      source = <<-END.strip_indent
+        bar = if foo
+                something
+                1
+              else
+                something_else
+                2
+              end
+      END
       new_source = autocorrect_source(cop, source)
 
-      expect(new_source).to eq(['if foo',
-                                '  something',
-                                '  bar = 1',
-                                'else',
-                                '  something_else',
-                                '  bar = 2',
-                                'end'].join("\n"))
+      expect(new_source).to eq(<<-END.strip_indent)
+        if foo
+          something
+          bar = 1
+        else
+          something_else
+          bar = 2
+        end
+      END
     end
 
     it 'corrects assignment to a multiline if elsif else condition' do
-      source = ['bar = if foo',
-                '        something',
-                '        1',
-                '      elsif foobar',
-                '        something_elsif',
-                '        2',
-                '      else',
-                '        something_else',
-                '        3',
-                '      end']
+      source = <<-END.strip_indent
+        bar = if foo
+                something
+                1
+              elsif foobar
+                something_elsif
+                2
+              else
+                something_else
+                3
+              end
+      END
       new_source = autocorrect_source(cop, source)
 
-      expect(new_source).to eq(['if foo',
-                                '  something',
-                                '  bar = 1',
-                                'elsif foobar',
-                                '  something_elsif',
-                                '  bar = 2',
-                                'else',
-                                '  something_else',
-                                '  bar = 3',
-                                'end'].join("\n"))
+      expect(new_source).to eq(<<-END.strip_indent)
+        if foo
+          something
+          bar = 1
+        elsif foobar
+          something_elsif
+          bar = 2
+        else
+          something_else
+          bar = 3
+        end
+      END
     end
 
     it 'corrects assignment to an if elsif else with multiple elsifs' do
-      source = ['bar = if foo',
-                '        something',
-                '        1',
-                '      elsif foobar',
-                '        something_elsif1',
-                '        2',
-                '      elsif baz',
-                '        something_elsif2',
-                '        3',
-                '      else',
-                '        something_else',
-                '        4',
-                '      end']
+      source = <<-END.strip_indent
+        bar = if foo
+                something
+                1
+              elsif foobar
+                something_elsif1
+                2
+              elsif baz
+                something_elsif2
+                3
+              else
+                something_else
+                4
+              end
+      END
       new_source = autocorrect_source(cop, source)
 
-      expect(new_source).to eq(['if foo',
-                                '  something',
-                                '  bar = 1',
-                                'elsif foobar',
-                                '  something_elsif1',
-                                '  bar = 2',
-                                'elsif baz',
-                                '  something_elsif2',
-                                '  bar = 3',
-                                'else',
-                                '  something_else',
-                                '  bar = 4',
-                                'end'].join("\n"))
+      expect(new_source).to eq(<<-END.strip_indent)
+        if foo
+          something
+          bar = 1
+        elsif foobar
+          something_elsif1
+          bar = 2
+        elsif baz
+          something_elsif2
+          bar = 3
+        else
+          something_else
+          bar = 4
+        end
+      END
     end
 
     it 'corrects assignment to an unless else condition' do
-      source = ['bar = unless foo',
-                '        something',
-                '        1',
-                '      else',
-                '        something_else',
-                '        2',
-                '      end']
+      source = <<-END.strip_indent
+        bar = unless foo
+                something
+                1
+              else
+                something_else
+                2
+              end
+      END
       new_source = autocorrect_source(cop, source)
 
-      expect(new_source).to eq(['unless foo',
-                                '  something',
-                                '  bar = 1',
-                                'else',
-                                '  something_else',
-                                '  bar = 2',
-                                'end'].join("\n"))
+      expect(new_source).to eq(<<-END.strip_indent)
+        unless foo
+          something
+          bar = 1
+        else
+          something_else
+          bar = 2
+        end
+      END
     end
 
     it 'corrects assignment to a case when else condition' do
-      source = ['bar = case foo',
-                '      when foobar',
-                '        something',
-                '        1',
-                '      else',
-                '        something_else',
-                '        2',
-                '      end']
+      source = <<-END.strip_indent
+        bar = case foo
+              when foobar
+                something
+                1
+              else
+                something_else
+                2
+              end
+      END
       new_source = autocorrect_source(cop, source)
 
-      expect(new_source).to eq(['case foo',
-                                'when foobar',
-                                '  something',
-                                '  bar = 1',
-                                'else',
-                                '  something_else',
-                                '  bar = 2',
-                                'end'].join("\n"))
+      expect(new_source).to eq(<<-END.strip_indent)
+        case foo
+        when foobar
+          something
+          bar = 1
+        else
+          something_else
+          bar = 2
+        end
+      END
     end
 
     it 'corrects assignment to a case when else with multiple whens' do
-      source = ['bar = case foo',
-                '      when foobar',
-                '        something',
-                '        1',
-                '      when baz',
-                '        something_other',
-                '        2',
-                '      else',
-                '        something_else',
-                '        3',
-                '      end']
+      source = <<-END.strip_indent
+        bar = case foo
+              when foobar
+                something
+                1
+              when baz
+                something_other
+                2
+              else
+                something_else
+                3
+              end
+      END
       new_source = autocorrect_source(cop, source)
 
-      expect(new_source).to eq(['case foo',
-                                'when foobar',
-                                '  something',
-                                '  bar = 1',
-                                'when baz',
-                                '  something_other',
-                                '  bar = 2',
-                                'else',
-                                '  something_else',
-                                '  bar = 3',
-                                'end'].join("\n"))
+      expect(new_source).to eq(<<-END.strip_indent)
+        case foo
+        when foobar
+          something
+          bar = 1
+        when baz
+          something_other
+          bar = 2
+        else
+          something_else
+          bar = 3
+        end
+      END
     end
   end
 

--- a/spec/rubocop/cop/style/conditional_assignment_assign_to_condition_spec.rb
+++ b/spec/rubocop/cop/style/conditional_assignment_assign_to_condition_spec.rb
@@ -22,13 +22,15 @@ describe RuboCop::Cop::Style::ConditionalAssignment do
   end
 
   it 'counts array assignment when determining multiple assignment' do
-    source = ['if foo',
-              '  array[1] = 1',
-              '  a = 1',
-              'else',
-              '  array[1] = 2',
-              '  a = 2',
-              'end']
+    source = <<-END.strip_indent
+      if foo
+        array[1] = 1
+        a = 1
+      else
+        array[1] = 2
+        a = 2
+      end
+    END
 
     inspect_source(cop, source)
 
@@ -36,22 +38,26 @@ describe RuboCop::Cop::Style::ConditionalAssignment do
   end
 
   it 'allows method calls in conditionals' do
-    source = ['if line.is_a?(String)',
-              '  expect(actual[ix]).to eq(line)',
-              'else',
-              '  expect(actual[ix]).to match(line)',
-              'end']
+    source = <<-END.strip_indent
+      if line.is_a?(String)
+        expect(actual[ix]).to eq(line)
+      else
+        expect(actual[ix]).to match(line)
+      end
+    END
     inspect_source(cop, source)
 
     expect(cop.offenses).to be_empty
   end
 
   it 'allows if else without variable assignment' do
-    source = ['if foo',
-              '  1',
-              'else',
-              '  2',
-              'end']
+    source = <<-END.strip_indent
+      if foo
+        1
+      else
+        2
+      end
+    END
     inspect_source(cop, source)
 
     expect(cop.offenses).to be_empty
@@ -78,11 +84,13 @@ describe RuboCop::Cop::Style::ConditionalAssignment do
   end
 
   it 'allows modifier if inside of if else' do
-    source = ['if foo',
-              '  a unless b',
-              'else',
-              '  c unless d',
-              'end']
+    source = <<-END.strip_indent
+      if foo
+        a unless b
+      else
+        c unless d
+      end
+    END
 
     inspect_source(cop, source)
 
@@ -92,11 +100,13 @@ describe RuboCop::Cop::Style::ConditionalAssignment do
   it "doesn't crash when assignment statement uses chars which have " \
      'special meaning in a regex' do
     # regression test; see GH issue 2876
-    source = ['if condition',
-              "  default['key-with-dash'] << a",
-              'else',
-              "  default['key-with-dash'] << b",
-              'end']
+    source = <<-END.strip_indent
+      if condition
+        default['key-with-dash'] << a
+      else
+        default['key-with-dash'] << b
+      end
+    END
 
     inspect_source(cop, source)
 
@@ -105,11 +115,13 @@ describe RuboCop::Cop::Style::ConditionalAssignment do
 
   shared_examples 'comparison methods' do |method|
     it 'registers an offense for comparison methods in if else' do
-      source = ['if foo',
-                "  a #{method} b",
-                'else',
-                "  a #{method} d",
-                'end']
+      source = <<-END.strip_indent
+        if foo
+          a #{method} b
+        else
+          a #{method} d
+        end
+      END
 
       inspect_source(cop, source)
 
@@ -117,11 +129,13 @@ describe RuboCop::Cop::Style::ConditionalAssignment do
     end
 
     it 'registers an offense for comparison methods in unless else' do
-      source = ['unless foo',
-                "  a #{method} b",
-                'else',
-                "  a #{method} d",
-                'end']
+      source = <<-END.strip_indent
+        unless foo
+          a #{method} b
+        else
+          a #{method} d
+        end
+      END
 
       inspect_source(cop, source)
 
@@ -129,12 +143,14 @@ describe RuboCop::Cop::Style::ConditionalAssignment do
     end
 
     it 'registers an offense for comparison methods in case when' do
-      source = ['case foo',
-                'when bar',
-                "  a #{method} b",
-                'else',
-                "  a #{method} d",
-                'end']
+      source = <<-END.strip_indent
+        case foo
+        when bar
+          a #{method} b
+        else
+          a #{method} d
+        end
+      END
 
       inspect_source(cop, source)
 
@@ -150,35 +166,41 @@ describe RuboCop::Cop::Style::ConditionalAssignment do
 
   context 'empty branch' do
     it 'allows an empty if statement' do
-      source = ['if foo',
-                '  # comment',
-                'else',
-                '  do_something',
-                'end']
+      source = <<-END.strip_indent
+        if foo
+          # comment
+        else
+          do_something
+        end
+      END
       inspect_source(cop, source)
 
       expect(cop.offenses).to be_empty
     end
 
     it 'allows an empty elsif statement' do
-      source = ['if foo',
-                '  bar = 1',
-                'elsif baz',
-                '  # empty',
-                'else',
-                '  bar = 2',
-                'end']
+      source = <<-END.strip_indent
+        if foo
+          bar = 1
+        elsif baz
+          # empty
+        else
+          bar = 2
+        end
+      END
       inspect_source(cop, source)
 
       expect(cop.offenses).to be_empty
     end
 
     it 'allows if elsif without else' do
-      source = ['if foo',
-                "  bar = 'some string'",
-                'elsif bar',
-                "  bar = 'another string'",
-                'end']
+      source = <<-END.strip_indent
+        if foo
+          bar = 'some string'
+        elsif bar
+          bar = 'another string'
+        end
+      END
 
       inspect_source(cop, source)
 
@@ -186,56 +208,66 @@ describe RuboCop::Cop::Style::ConditionalAssignment do
     end
 
     it 'allows assignment in if without an else' do
-      source = ['if foo',
-                '  bar = 1',
-                'end']
+      source = <<-END.strip_indent
+        if foo
+          bar = 1
+        end
+      END
       inspect_source(cop, source)
 
       expect(cop.offenses).to be_empty
     end
 
     it 'allows assignment in unless without an else' do
-      source = ['unless foo',
-                '  bar = 1',
-                'end']
+      source = <<-END.strip_indent
+        unless foo
+          bar = 1
+        end
+      END
       inspect_source(cop, source)
 
       expect(cop.offenses).to be_empty
     end
 
     it 'allows assignment in case when without an else' do
-      source = ['case foo',
-                'when "a"',
-                '  bar = 1',
-                'when "b"',
-                '  bar = 2',
-                'end']
+      source = <<-END.strip_indent
+        case foo
+        when "a"
+          bar = 1
+        when "b"
+          bar = 2
+        end
+      END
       inspect_source(cop, source)
 
       expect(cop.offenses).to be_empty
     end
 
     it 'allows an empty when branch with an else' do
-      source = ['case foo',
-                'when "a"',
-                '  # empty',
-                'when "b"',
-                '  bar = 2',
-                'else',
-                '  bar = 3',
-                'end']
+      source = <<-END.strip_indent
+        case foo
+        when "a"
+          # empty
+        when "b"
+          bar = 2
+        else
+          bar = 3
+        end
+      END
       inspect_source(cop, source)
 
       expect(cop.messages).to be_empty
     end
 
     it 'allows case with an empty else' do
-      source = ['case foo',
-                'when "b"',
-                '  bar = 2',
-                'else',
-                '  # empty',
-                'end']
+      source = <<-END.strip_indent
+        case foo
+        when "b"
+          bar = 2
+        else
+          # empty
+        end
+      END
       inspect_source(cop, source)
 
       expect(cop.offenses).to be_empty
@@ -243,119 +275,139 @@ describe RuboCop::Cop::Style::ConditionalAssignment do
   end
 
   it 'allows assignment of different variables in if else' do
-    source = ['if foo',
-              '  bar = 1',
-              'else',
-              '  baz = 1',
-              'end']
+    source = <<-END.strip_indent
+      if foo
+        bar = 1
+      else
+        baz = 1
+      end
+    END
     inspect_source(cop, source)
 
     expect(cop.offenses).to be_empty
   end
 
   it 'allows method calls in if else' do
-    source = ['if foo',
-              '  bar',
-              'else',
-              '  baz',
-              'end']
+    source = <<-END.strip_indent
+      if foo
+        bar
+      else
+        baz
+      end
+    END
     inspect_source(cop, source)
 
     expect(cop.offenses).to be_empty
   end
 
   it 'allows if elsif else with the same assignment only in if else' do
-    source = ['if foo',
-              '  bar = 1',
-              'elsif foobar',
-              '  baz = 2',
-              'else',
-              '  bar = 1',
-              'end']
+    source = <<-END.strip_indent
+      if foo
+        bar = 1
+      elsif foobar
+        baz = 2
+      else
+        bar = 1
+      end
+    END
     inspect_source(cop, source)
 
     expect(cop.offenses).to be_empty
   end
 
   it 'allows if elsif else with the same assignment only in if elsif' do
-    source = ['if foo',
-              '  bar = 1',
-              'elsif foobar',
-              '  bar = 2',
-              'else',
-              '  baz = 1',
-              'end']
+    source = <<-END.strip_indent
+      if foo
+        bar = 1
+      elsif foobar
+        bar = 2
+      else
+        baz = 1
+      end
+    END
     inspect_source(cop, source)
 
     expect(cop.offenses).to be_empty
   end
 
   it 'allows if elsif else with the same assignment only in elsif else' do
-    source = ['if foo',
-              '  bar = 1',
-              'elsif foobar',
-              '  baz = 2',
-              'else',
-              '  baz = 1',
-              'end']
+    source = <<-END.strip_indent
+      if foo
+        bar = 1
+      elsif foobar
+        baz = 2
+      else
+        baz = 1
+      end
+    END
     inspect_source(cop, source)
 
     expect(cop.offenses).to be_empty
   end
 
   it 'allows assignment using different operators in if else' do
-    source = ['if foo',
-              '  bar = 1',
-              'else',
-              '  bar << 2',
-              'end']
+    source = <<-END.strip_indent
+      if foo
+        bar = 1
+      else
+        bar << 2
+      end
+    END
     inspect_source(cop, source)
 
     expect(cop.offenses).to be_empty
   end
 
   it 'allows assignment using different (method) operators in if..else' do
-    source = ['if foo',
-              '  bar[index] = 1',
-              'else',
-              '  bar << 2',
-              'end']
+    source = <<-END.strip_indent
+      if foo
+        bar[index] = 1
+      else
+        bar << 2
+      end
+    END
     inspect_source(cop, source)
 
     expect(cop.messages).to be_empty
   end
 
   it 'allows aref assignment with different indices in if..else' do
-    source = ['if foo',
-              '  bar[1] = 1',
-              'else',
-              '  bar[2] = 2',
-              'end']
+    source = <<-END.strip_indent
+      if foo
+        bar[1] = 1
+      else
+        bar[2] = 2
+      end
+    END
     inspect_source(cop, source)
 
     expect(cop.messages).to be_empty
   end
 
   it 'allows assignment using different operators in if elsif else' do
-    source = ['if foo',
-              '  bar = 1',
-              'elsif foobar',
-              '  bar += 2',
-              'else',
-              '  bar << 3',
-              'end']
+    source = <<-END.strip_indent
+      if foo
+        bar = 1
+      elsif foobar
+        bar += 2
+      else
+        bar << 3
+      end
+    END
     inspect_source(cop, source)
 
     expect(cop.offenses).to be_empty
   end
 
   it 'allows assignment of different variables in case when else' do
-    source = ['case foo',
-              'when "a"',
-              '  bar = 1',
-              'else',
-              '  baz = 2',
-              'end']
+    source = <<-END.strip_indent
+      case foo
+      when "a"
+        bar = 1
+      else
+        baz = 2
+      end
+    END
     inspect_source(cop, source)
 
     expect(cop.offenses).to be_empty
@@ -364,12 +416,14 @@ describe RuboCop::Cop::Style::ConditionalAssignment do
   context 'correction would exceed max line length' do
     it 'allows assignment to the same variable in if else if the correction ' \
        'would create a line longer than the configured LineLength' do
-      source = ['if foo',
-                "  #{'a' * 78}",
-                '  bar = 1',
-                'else',
-                '  bar = 2',
-                'end']
+      source = <<-END.strip_indent
+        if foo
+          #{'a' * 78}
+          bar = 1
+        else
+          bar = 2
+        end
+      END
 
       inspect_source(cop, source)
 
@@ -378,11 +432,13 @@ describe RuboCop::Cop::Style::ConditionalAssignment do
 
     it 'allows assignment to the same variable in if else if the correction ' \
        'would cause the condition to exceed the configured LineLength' do
-      source = ["if #{'a' * 78}",
-                '  bar = 1',
-                'else',
-                '  bar = 2',
-                'end']
+      source = <<-END.strip_indent
+        if #{'a' * 78}
+          bar = 1
+        else
+          bar = 2
+        end
+      END
 
       inspect_source(cop, source)
 
@@ -391,13 +447,15 @@ describe RuboCop::Cop::Style::ConditionalAssignment do
 
     it 'allows assignment to the same variable in case when else if the ' \
        'correction would create a line longer than the configured LineLength' do
-      source = ['case foo',
-                'when foobar',
-                "  #{'a' * 78}",
-                '  bar = 1',
-                'else',
-                '  bar = 2',
-                'end']
+      source = <<-END.strip_indent
+        case foo
+        when foobar
+          #{'a' * 78}
+          bar = 1
+        else
+          bar = 2
+        end
+      END
 
       inspect_source(cop, source)
 
@@ -413,46 +471,54 @@ describe RuboCop::Cop::Style::ConditionalAssignment do
     end
 
     it 'registers an offense assigning any variable type in if else' do
-      source = ['if foo',
-                "  #{variable} = 1",
-                'else',
-                "  #{variable} = 2",
-                'end']
+      source = <<-END.strip_indent
+        if foo
+          #{variable} = 1
+        else
+          #{variable} = 2
+        end
+      END
       inspect_source(cop, source)
 
       expect(cop.messages).to eq([described_class::MSG])
     end
 
     it 'registers an offense assigning any variable type in case when' do
-      source = ['case foo',
-                'when "a"',
-                "  #{variable} = 1",
-                'else',
-                "  #{variable} = 2",
-                'end']
+      source = <<-END.strip_indent
+        case foo
+        when "a"
+          #{variable} = 1
+        else
+          #{variable} = 2
+        end
+      END
       inspect_source(cop, source)
 
       expect(cop.messages).to eq([described_class::MSG])
     end
 
     it 'allows assignment to the return of if else' do
-      source = ["#{variable} = if foo",
-                '                1',
-                '              else',
-                '                2',
-                '              end']
+      source = <<-END.strip_indent
+        #{variable} = if foo
+                        1
+                      else
+                        2
+                      end
+      END
       inspect_source(cop, source)
 
       expect(cop.offenses).to be_empty
     end
 
     it 'allows assignment to the return of case when' do
-      source = ["#{variable} = case foo",
-                '              when bar',
-                '                1',
-                '              else',
-                '                2',
-                '              end']
+      source = <<-END.strip_indent
+        #{variable} = case foo
+                      when bar
+                        1
+                      else
+                        2
+                      end
+      END
       inspect_source(cop, source)
 
       expect(cop.offenses).to be_empty
@@ -497,11 +563,13 @@ describe RuboCop::Cop::Style::ConditionalAssignment do
 
         it "registers an offense for assignment using #{assignment} in " \
            'if else' do
-          source = ['if foo',
-                    "  #{name} #{assignment} 1",
-                    'else',
-                    "  #{name} #{assignment} 2",
-                    'end']
+          source = <<-END.strip_indent
+            if foo
+              #{name} #{assignment} 1
+            else
+              #{name} #{assignment} 2
+            end
+          END
           inspect_source(cop, source)
 
           expect(cop.messages).to eq([described_class::MSG])
@@ -509,31 +577,37 @@ describe RuboCop::Cop::Style::ConditionalAssignment do
 
         it "registers an offense for assignment using #{assignment} in "\
         ' case when' do
-          source = ['case foo',
-                    'when "a"',
-                    "  #{name} #{assignment} 1",
-                    'else',
-                    "  #{name} #{assignment} 2",
-                    'end']
+          source = <<-END.strip_indent
+            case foo
+            when "a"
+              #{name} #{assignment} 1
+            else
+              #{name} #{assignment} 2
+            end
+          END
           inspect_source(cop, source)
 
           expect(cop.messages).to eq([described_class::MSG])
         end
 
         it "autocorrects for assignment using #{assignment} in if else" do
-          source = ['if foo',
-                    "  #{name} #{assignment} 1",
-                    'else',
-                    "  #{name} #{assignment} 2",
-                    'end']
+          source = <<-END.strip_indent
+            if foo
+              #{name} #{assignment} 1
+            else
+              #{name} #{assignment} 2
+            end
+          END
           new_source = autocorrect_source(cop, source)
 
           indent = ' ' * "#{name} #{assignment} ".length
-          expect(new_source).to eq ["#{name} #{assignment} if foo",
-                                    '  1',
-                                    'else',
-                                    '  2',
-                                    "#{indent}end"].join("\n")
+          expect(new_source).to eq <<-END.strip_indent
+            #{name} #{assignment} if foo
+              1
+            else
+              2
+            #{indent}end
+          END
         end
       end
     end
@@ -562,28 +636,32 @@ describe RuboCop::Cop::Style::ConditionalAssignment do
   it_behaves_like('all assignment types', '-=')
 
   it 'registers an offense for assignment in if elsif else' do
-    source = ['if foo',
-              '  bar = 1',
-              'elsif baz',
-              '  bar = 2',
-              'else',
-              '  bar = 3',
-              'end']
+    source = <<-END.strip_indent
+      if foo
+        bar = 1
+      elsif baz
+        bar = 2
+      else
+        bar = 3
+      end
+    END
     inspect_source(cop, source)
 
     expect(cop.messages).to eq([described_class::MSG])
   end
 
   it 'registers an offense for assignment in if elsif elsif else' do
-    source = ['if foo',
-              '  bar = 1',
-              'elsif baz',
-              '  bar = 2',
-              'elsif foobar',
-              '  bar = 3',
-              'else',
-              '  bar = 4',
-              'end']
+    source = <<-END.strip_indent
+      if foo
+        bar = 1
+      elsif baz
+        bar = 2
+      elsif foobar
+        bar = 3
+      else
+        bar = 4
+      end
+    END
     inspect_source(cop, source)
 
     expect(cop.messages).to eq([described_class::MSG])
@@ -591,20 +669,22 @@ describe RuboCop::Cop::Style::ConditionalAssignment do
 
   it 'registers an offense for assignment in if else when the assignment ' \
     'spans multiple lines' do
-    source = ['if foo',
-              '  foo = {',
-              '    a: 1,',
-              '    b: 2,',
-              '    c: 2,',
-              '    d: 2,',
-              '    e: 2,',
-              '    f: 2,',
-              '    g: 2,',
-              '    h: 2',
-              '  }',
-              'else',
-              '  foo = { }',
-              'end']
+    source = <<-END.strip_indent
+      if foo
+        foo = {
+          a: 1,
+          b: 2,
+          c: 2,
+          d: 2,
+          e: 2,
+          f: 2,
+          g: 2,
+          h: 2
+        }
+      else
+        foo = { }
+      end
+    END
     inspect_source(cop, source)
 
     expect(cop.messages).to eq([described_class::MSG])
@@ -612,111 +692,125 @@ describe RuboCop::Cop::Style::ConditionalAssignment do
 
   it 'autocorrects assignment in if else when the assignment ' \
     'spans multiple lines' do
-    source = ['if foo',
-              '  foo = {',
-              '    a: 1,',
-              '    b: 2,',
-              '    c: 2,',
-              '    d: 2,',
-              '    e: 2,',
-              '    f: 2,',
-              '    g: 2,',
-              '    h: 2',
-              '  }',
-              'else',
-              '  foo = { }',
-              'end']
+    source = <<-END.strip_indent
+      if foo
+        foo = {
+          a: 1,
+          b: 2,
+          c: 2,
+          d: 2,
+          e: 2,
+          f: 2,
+          g: 2,
+          h: 2
+        }
+      else
+        foo = { }
+      end
+    END
     new_source = autocorrect_source(cop, source)
 
-    expect(new_source).to eq(['foo = if foo',
-                              '  {',
-                              '    a: 1,',
-                              '    b: 2,',
-                              '    c: 2,',
-                              '    d: 2,',
-                              '    e: 2,',
-                              '    f: 2,',
-                              '    g: 2,',
-                              '    h: 2',
-                              '  }',
-                              'else',
-                              '  { }',
-                              '      end'].join("\n"))
+    expect(new_source).to eq(<<-END.strip_indent)
+      foo = if foo
+        {
+          a: 1,
+          b: 2,
+          c: 2,
+          d: 2,
+          e: 2,
+          f: 2,
+          g: 2,
+          h: 2
+        }
+      else
+        { }
+            end
+    END
   end
 
   context 'assignment as the last statement' do
     it 'allows more than variable assignment in if else' do
-      source = ['if foo',
-                '  method_call',
-                '  bar = 1',
-                'else',
-                '  method_call',
-                '  bar = 2',
-                'end']
+      source = <<-END.strip_indent
+        if foo
+          method_call
+          bar = 1
+        else
+          method_call
+          bar = 2
+        end
+      END
       inspect_source(cop, source)
 
       expect(cop.offenses).to be_empty
     end
 
     it 'allows more than variable assignment in if elsif else' do
-      source = ['if foo',
-                '  method_call',
-                '  bar = 1',
-                'elsif foobar',
-                '  method_call',
-                '  bar = 2',
-                'else',
-                '  method_call',
-                '  bar = 3',
-                'end']
+      source = <<-END.strip_indent
+        if foo
+          method_call
+          bar = 1
+        elsif foobar
+          method_call
+          bar = 2
+        else
+          method_call
+          bar = 3
+        end
+      END
       inspect_source(cop, source)
 
       expect(cop.offenses).to be_empty
     end
 
     it 'allows multiple assignment in if else' do
-      source = ['if baz',
-                '  foo = 1',
-                '  bar = 1',
-                'else',
-                '  foo = 2',
-                '  bar = 2',
-                'end']
+      source = <<-END.strip_indent
+        if baz
+          foo = 1
+          bar = 1
+        else
+          foo = 2
+          bar = 2
+        end
+      END
       inspect_source(cop, source)
 
       expect(cop.offenses).to be_empty
     end
 
     it 'allows multiple assignment in if elsif else' do
-      source = ['if baz',
-                '  foo = 1',
-                '  bar = 1',
-                'elsif foobar',
-                '  foo = 2',
-                '  bar = 2',
-                'else',
-                '  foo = 3',
-                '  bar = 3',
-                'end']
+      source = <<-END.strip_indent
+        if baz
+          foo = 1
+          bar = 1
+        elsif foobar
+          foo = 2
+          bar = 2
+        else
+          foo = 3
+          bar = 3
+        end
+      END
       inspect_source(cop, source)
 
       expect(cop.offenses).to be_empty
     end
 
     it 'allows multiple assignment in if elsif elsif else' do
-      source = ['if baz',
-                '  foo = 1',
-                '  bar = 1',
-                'elsif foobar',
-                '  foo = 2',
-                '  bar = 2',
-                'elsif barfoo',
-                '  foo = 3',
-                '  bar = 3',
-                'else',
-                '  foo = 4',
-                '  bar = 4',
-                'end']
+      source = <<-END.strip_indent
+        if baz
+          foo = 1
+          bar = 1
+        elsif foobar
+          foo = 2
+          bar = 2
+        elsif barfoo
+          foo = 3
+          bar = 3
+        else
+          foo = 4
+          bar = 4
+        end
+      END
       inspect_source(cop, source)
 
       expect(cop.offenses).to be_empty
@@ -725,16 +819,18 @@ describe RuboCop::Cop::Style::ConditionalAssignment do
     it 'allows multiple assignment in if elsif else when the last ' \
        'assignment is the same and the earlier assignments do not appear in ' \
        'all branches' do
-      source = ['if baz',
-                '  foo = 1',
-                '  bar = 1',
-                'elsif foobar',
-                '  baz = 2',
-                '  bar = 2',
-                'else',
-                '  boo = 3',
-                '  bar = 3',
-                'end']
+      source = <<-END.strip_indent
+        if baz
+          foo = 1
+          bar = 1
+        elsif foobar
+          baz = 2
+          bar = 2
+        else
+          boo = 3
+          bar = 3
+        end
+      END
       inspect_source(cop, source)
 
       expect(cop.offenses).to be_empty
@@ -743,77 +839,87 @@ describe RuboCop::Cop::Style::ConditionalAssignment do
     it 'allows multiple assignment in case when else when the last ' \
        'assignment is the same and the earlier assignments do not appear ' \
        'in all branches' do
-      source = ['case foo',
-                'when foobar',
-                '  baz = 1',
-                '  bar = 1',
-                'when foobaz',
-                '  boo = 2',
-                '  bar = 2',
-                'else',
-                '  faz = 3',
-                '  bar = 3',
-                'end']
+      source = <<-END.strip_indent
+        case foo
+        when foobar
+          baz = 1
+          bar = 1
+        when foobaz
+          boo = 2
+          bar = 2
+        else
+          faz = 3
+          bar = 3
+        end
+      END
       inspect_source(cop, source)
 
       expect(cop.offenses).to be_empty
     end
 
     it 'allows out of order multiple assignment in if elsif else' do
-      source = ['if baz',
-                '  bar = 1',
-                '  foo = 1',
-                'elsif foobar',
-                '  foo = 2',
-                '  bar = 2',
-                'else',
-                '  foo = 3',
-                '  bar = 3',
-                'end']
+      source = <<-END.strip_indent
+        if baz
+          bar = 1
+          foo = 1
+        elsif foobar
+          foo = 2
+          bar = 2
+        else
+          foo = 3
+          bar = 3
+        end
+      END
       inspect_source(cop, source)
 
       expect(cop.offenses).to be_empty
     end
 
     it 'allows multiple assignment in unless else' do
-      source = ['unless baz',
-                '  foo = 1',
-                '  bar = 1',
-                'else',
-                '  foo = 2',
-                '  bar = 2',
-                'end']
+      source = <<-END.strip_indent
+        unless baz
+          foo = 1
+          bar = 1
+        else
+          foo = 2
+          bar = 2
+        end
+      END
       inspect_source(cop, source)
 
       expect(cop.offenses).to be_empty
     end
 
     it 'allows multiple assignments in case when with only one when' do
-      source = ['case foo',
-                'when foobar',
-                '  foo = 1',
-                '  bar = 1',
-                'else',
-                '  foo = 3',
-                '  bar = 3',
-                'end']
+      source = <<-END.strip_indent
+        case foo
+        when foobar
+          foo = 1
+          bar = 1
+        else
+          foo = 3
+          bar = 3
+        end
+      END
       inspect_source(cop, source)
 
       expect(cop.offenses).to be_empty
     end
 
     it 'allows multiple assignments in case when with multiple whens' do
-      source = ['case foo',
-                'when foobar',
-                '  foo = 1',
-                '  bar = 1',
-                'when foobaz',
-                '  foo = 2',
-                '  bar = 2',
-                'else',
-                '  foo = 3',
-                '  bar = 3',
-                'end']
+      source = <<-END.strip_indent
+        case foo
+        when foobar
+          foo = 1
+          bar = 1
+        when foobaz
+          foo = 2
+          bar = 2
+        else
+          foo = 3
+          bar = 3
+        end
+      END
       inspect_source(cop, source)
 
       expect(cop.offenses).to be_empty
@@ -821,19 +927,21 @@ describe RuboCop::Cop::Style::ConditionalAssignment do
 
     it 'allows multiple assignments in case when if there are uniq ' \
        'variables in the when branches' do
-      source = ['case foo',
-                'when foobar',
-                '  foo = 1',
-                '  baz = 1',
-                '  bar = 1',
-                'when foobaz',
-                '  foo = 2',
-                '  baz = 2',
-                '  bar = 2',
-                'else',
-                '  foo = 3',
-                '  bar = 3',
-                'end']
+      source = <<-END.strip_indent
+        case foo
+        when foobar
+          foo = 1
+          baz = 1
+          bar = 1
+        when foobaz
+          foo = 2
+          baz = 2
+          bar = 2
+        else
+          foo = 3
+          bar = 3
+        end
+      END
       inspect_source(cop, source)
 
       expect(cop.offenses).to be_empty
@@ -842,17 +950,19 @@ describe RuboCop::Cop::Style::ConditionalAssignment do
     it 'allows multiple assignment in case statements when the last ' \
        'assignment is the same and the earlier assignments do not appear in ' \
        'all branches' do
-      source = ['case foo',
-                'when foobar',
-                '  foo = 1',
-                '  bar = 1',
-                'when foobaz',
-                '  baz = 2',
-                '  bar = 2',
-                'else',
-                '  boo = 3',
-                '  bar = 3',
-                'end']
+      source = <<-END.strip_indent
+        case foo
+        when foobar
+          foo = 1
+          bar = 1
+        when foobaz
+          baz = 2
+          bar = 2
+        else
+          boo = 3
+          bar = 3
+        end
+      END
       inspect_source(cop, source)
 
       expect(cop.offenses).to be_empty
@@ -861,17 +971,19 @@ describe RuboCop::Cop::Style::ConditionalAssignment do
     it 'allows assignment in if elsif else with some branches only ' \
        'containing variable assignment and others containing more than ' \
        'variable assignment' do
-      source = ['if foo',
-                '  bar = 1',
-                'elsif foobar',
-                '  method_call',
-                '  bar = 2',
-                'elsif baz',
-                '  bar = 3',
-                'else',
-                '  method_call',
-                '  bar = 4',
-                'end']
+      source = <<-END.strip_indent
+        if foo
+          bar = 1
+        elsif foobar
+          method_call
+          bar = 2
+        elsif baz
+          bar = 3
+        else
+          method_call
+          bar = 4
+        end
+      END
       inspect_source(cop, source)
 
       expect(cop.offenses).to be_empty
@@ -879,13 +991,15 @@ describe RuboCop::Cop::Style::ConditionalAssignment do
 
     it 'allows variable assignment in unless else with more than ' \
        'variable assignment' do
-      source = ['unless foo',
-                '  method_call',
-                '  bar = 1',
-                'else',
-                '  method_call',
-                '  bar = 2',
-                'end']
+      source = <<-END.strip_indent
+        unless foo
+          method_call
+          bar = 1
+        else
+          method_call
+          bar = 2
+        end
+      END
       inspect_source(cop, source)
 
       expect(cop.offenses).to be_empty
@@ -893,14 +1007,16 @@ describe RuboCop::Cop::Style::ConditionalAssignment do
 
     it 'allows variable assignment in case when else with more than ' \
        'variable assignment' do
-      source = ['case foo',
-                'when foobar',
-                '  method_call',
-                '  bar = 1',
-                'else',
-                '  method_call',
-                '  bar = 2',
-                'end']
+      source = <<-END.strip_indent
+        case foo
+        when foobar
+          method_call
+          bar = 1
+        else
+          method_call
+          bar = 2
+        end
+      END
 
       inspect_source(cop, source)
 
@@ -909,48 +1025,54 @@ describe RuboCop::Cop::Style::ConditionalAssignment do
 
     context 'multiple assignment in only one branch' do
       it 'allows multiple assignment is in if' do
-        source = ['if foo',
-                  '  baz = 1',
-                  '  bar = 1',
-                  'elsif foobar',
-                  '  method_call',
-                  '  bar = 2',
-                  'else',
-                  '  other_method',
-                  '  bar = 3',
-                  'end']
+        source = <<-END.strip_indent
+          if foo
+            baz = 1
+            bar = 1
+          elsif foobar
+            method_call
+            bar = 2
+          else
+            other_method
+            bar = 3
+          end
+        END
         inspect_source(cop, source)
 
         expect(cop.offenses).to be_empty
       end
 
       it 'allows multiple assignment is in elsif' do
-        source = ['if foo',
-                  '  method_call',
-                  '  bar = 1',
-                  'elsif foobar',
-                  '  baz = 2',
-                  '  bar = 2',
-                  'else',
-                  '  other_method',
-                  '  bar = 3',
-                  'end']
+        source = <<-END.strip_indent
+          if foo
+            method_call
+            bar = 1
+          elsif foobar
+            baz = 2
+            bar = 2
+          else
+            other_method
+            bar = 3
+          end
+        END
         inspect_source(cop, source)
 
         expect(cop.offenses).to be_empty
       end
 
       it 'registers an offense when multiple assignment is in else' do
-        source = ['if foo',
-                  '  method_call',
-                  '  bar = 1',
-                  'elsif foobar',
-                  '  other_method',
-                  '  bar = 2',
-                  'else',
-                  '  baz = 3',
-                  '  bar = 3',
-                  'end']
+        source = <<-END.strip_indent
+          if foo
+            method_call
+            bar = 1
+          elsif foobar
+            other_method
+            bar = 2
+          else
+            baz = 3
+            bar = 3
+          end
+        END
         inspect_source(cop, source)
 
         expect(cop.offenses).to be_empty
@@ -959,56 +1081,66 @@ describe RuboCop::Cop::Style::ConditionalAssignment do
   end
 
   it 'registers an offense for assignment in if then else' do
-    source = ['if foo then bar = 1',
-              'else bar = 2',
-              'end']
+    source = <<-END.strip_indent
+      if foo then bar = 1
+      else bar = 2
+      end
+    END
     inspect_source(cop, source)
 
     expect(cop.messages).to eq([described_class::MSG])
   end
 
   it 'registers an offense for assignment in unless else' do
-    source = ['unless foo',
-              '  bar = 1',
-              'else',
-              '  bar = 2',
-              'end']
+    source = <<-END.strip_indent
+      unless foo
+        bar = 1
+      else
+        bar = 2
+      end
+    END
     inspect_source(cop, source)
 
     expect(cop.messages).to eq([described_class::MSG])
   end
 
   it 'registers an offense for assignment in case when then else' do
-    source = ['case foo',
-              'when bar then baz = 1',
-              'else baz = 2',
-              'end']
+    source = <<-END.strip_indent
+      case foo
+      when bar then baz = 1
+      else baz = 2
+      end
+    END
     inspect_source(cop, source)
 
     expect(cop.messages).to eq([described_class::MSG])
   end
 
   it 'registers an offense for assignment in case with when when else' do
-    source = ['case foo',
-              'when foobar',
-              '  bar = 1',
-              'when baz',
-              '  bar = 2',
-              'else',
-              '  bar = 3',
-              'end']
+    source = <<-END.strip_indent
+      case foo
+      when foobar
+        bar = 1
+      when baz
+        bar = 2
+      else
+        bar = 3
+      end
+    END
     inspect_source(cop, source)
 
     expect(cop.messages).to eq([described_class::MSG])
   end
 
   it 'allows different assignment types in case with when when else' do
-    source = ['case foo',
-              'when foobar',
-              '  bar = 1',
-              'else',
-              '  bar << 2',
-              'end']
+    source = <<-END.strip_indent
+      case foo
+      when foobar
+        bar = 1
+      else
+        bar << 2
+      end
+    END
     inspect_source(cop, source)
 
     expect(cop.offenses).to be_empty
@@ -1016,11 +1148,13 @@ describe RuboCop::Cop::Style::ConditionalAssignment do
 
   it 'allows assignment in multiple branches when it is ' \
      'wrapped in a modifier' do
-    source = ['if foo',
-              '  bar << 1',
-              'else',
-              '  bar << 2 if foobar',
-              'end']
+    source = <<-END.strip_indent
+      if foo
+        bar << 1
+      else
+        bar << 2 if foobar
+      end
+    END
     inspect_source(cop, source)
 
     expect(cop.offenses).to be_empty
@@ -1029,60 +1163,72 @@ describe RuboCop::Cop::Style::ConditionalAssignment do
   context 'auto-correct' do
     shared_examples 'comparison correction' do |method|
       it 'corrects comparison methods in if elsif else' do
-        source = ['if foo',
-                  "  a #{method} b",
-                  'elsif bar',
-                  "  a #{method} c",
-                  'else',
-                  "  a #{method} d",
-                  'end']
+        source = <<-END.strip_indent
+          if foo
+            a #{method} b
+          elsif bar
+            a #{method} c
+          else
+            a #{method} d
+          end
+        END
 
         new_source = autocorrect_source(cop, source)
 
         indent = ' ' * "a #{method} ".length
-        expect(new_source).to eq(["a #{method} if foo",
-                                  '  b',
-                                  'elsif bar',
-                                  '  c',
-                                  'else',
-                                  '  d',
-                                  "#{indent}end"].join("\n"))
+        expect(new_source).to eq(<<-END.strip_indent)
+          a #{method} if foo
+            b
+          elsif bar
+            c
+          else
+            d
+          #{indent}end
+        END
       end
 
       it 'corrects comparison methods in unless else' do
-        source = ['unless foo',
-                  "  a #{method} b",
-                  'else',
-                  "  a #{method} d",
-                  'end']
+        source = <<-END.strip_indent
+          unless foo
+            a #{method} b
+          else
+            a #{method} d
+          end
+        END
 
         new_source = autocorrect_source(cop, source)
 
         indent = ' ' * "a #{method} ".length
-        expect(new_source).to eq(["a #{method} unless foo",
-                                  '  b',
-                                  'else',
-                                  '  d',
-                                  "#{indent}end"].join("\n"))
+        expect(new_source).to eq(<<-END.strip_indent)
+          a #{method} unless foo
+            b
+          else
+            d
+          #{indent}end
+        END
       end
 
       it 'corrects comparison methods in case when' do
-        source = ['case foo',
-                  'when bar',
-                  "  a #{method} b",
-                  'else',
-                  "  a #{method} d",
-                  'end']
+        source = <<-END.strip_indent
+          case foo
+          when bar
+            a #{method} b
+          else
+            a #{method} d
+          end
+        END
 
         new_source = autocorrect_source(cop, source)
 
         indent = ' ' * "a #{method} ".length
-        expect(new_source).to eq(["a #{method} case foo",
-                                  'when bar',
-                                  '  b',
-                                  'else',
-                                  '  d',
-                                  "#{indent}end"].join("\n"))
+        expect(new_source).to eq(<<-END.strip_indent)
+          a #{method} case foo
+          when bar
+            b
+          else
+            d
+          #{indent}end
+        END
       end
     end
 
@@ -1120,94 +1266,114 @@ describe RuboCop::Cop::Style::ConditionalAssignment do
     end
 
     it 'corrects assignment in if else' do
-      source = ['if foo',
-                '  bar = 1',
-                'else',
-                '  bar = 2',
-                'end']
+      source = <<-END.strip_indent
+        if foo
+          bar = 1
+        else
+          bar = 2
+        end
+      END
 
       new_source = autocorrect_source(cop, source)
 
-      expect(new_source).to eq(['bar = if foo',
-                                '  1',
-                                'else',
-                                '  2',
-                                '      end'].join("\n"))
+      expect(new_source).to eq(<<-END.strip_indent)
+        bar = if foo
+          1
+        else
+          2
+              end
+      END
     end
 
     it 'corrects assignment in if elsif else' do
-      source = ['if foo',
-                '  bar = 1',
-                'elsif baz',
-                '  bar = 2',
-                'else',
-                '  bar = 3',
-                'end']
+      source = <<-END.strip_indent
+        if foo
+          bar = 1
+        elsif baz
+          bar = 2
+        else
+          bar = 3
+        end
+      END
 
       new_source = autocorrect_source(cop, source)
 
-      expect(new_source).to eq(['bar = if foo',
-                                '  1',
-                                'elsif baz',
-                                '  2',
-                                'else',
-                                '  3',
-                                '      end'].join("\n"))
+      expect(new_source).to eq(<<-END.strip_indent)
+        bar = if foo
+          1
+        elsif baz
+          2
+        else
+          3
+              end
+      END
     end
 
     shared_examples '2 character assignment types' do |asgn|
       it "corrects assignment using #{asgn} in if elsif else" do
-        source = ['if foo',
-                  "  bar #{asgn} 1",
-                  'elsif baz',
-                  "  bar #{asgn} 2",
-                  'else',
-                  "  bar #{asgn} 3",
-                  'end']
+        source = <<-END.strip_indent
+          if foo
+            bar #{asgn} 1
+          elsif baz
+            bar #{asgn} 2
+          else
+            bar #{asgn} 3
+          end
+        END
 
         new_source = autocorrect_source(cop, source)
 
-        expect(new_source).to eq(["bar #{asgn} if foo",
-                                  '  1',
-                                  'elsif baz',
-                                  '  2',
-                                  'else',
-                                  '  3',
-                                  '       end'].join("\n"))
+        expect(new_source).to eq(<<-END.strip_indent)
+          bar #{asgn} if foo
+            1
+          elsif baz
+            2
+          else
+            3
+                 end
+        END
       end
 
       it "corrects assignment using #{asgn} in case when else" do
-        source = ['case foo',
-                  'when bar',
-                  "  baz #{asgn} 1",
-                  'else',
-                  "  baz #{asgn} 2",
-                  'end']
+        source = <<-END.strip_indent
+          case foo
+          when bar
+            baz #{asgn} 1
+          else
+            baz #{asgn} 2
+          end
+        END
 
         new_source = autocorrect_source(cop, source)
 
-        expect(new_source).to eq(["baz #{asgn} case foo",
-                                  'when bar',
-                                  '  1',
-                                  'else',
-                                  '  2',
-                                  '       end'].join("\n"))
+        expect(new_source).to eq(<<-END.strip_indent)
+          baz #{asgn} case foo
+          when bar
+            1
+          else
+            2
+                 end
+        END
       end
 
       it "corrects assignment using #{asgn} in unless else" do
-        source = ['unless foo',
-                  "  bar #{asgn} 1",
-                  'else',
-                  "  bar #{asgn} 2",
-                  'end']
+        source = <<-END.strip_indent
+          unless foo
+            bar #{asgn} 1
+          else
+            bar #{asgn} 2
+          end
+        END
 
         new_source = autocorrect_source(cop, source)
 
-        expect(new_source).to eq(["bar #{asgn} unless foo",
-                                  '  1',
-                                  'else',
-                                  '  2',
-                                  '       end'].join("\n"))
+        expect(new_source).to eq(<<-END.strip_indent)
+          bar #{asgn} unless foo
+            1
+          else
+            2
+                 end
+        END
       end
     end
 
@@ -1217,57 +1383,69 @@ describe RuboCop::Cop::Style::ConditionalAssignment do
 
     shared_examples '3 character assignment types' do |asgn|
       it "corrects assignment using #{asgn} in if elsif else" do
-        source = ['if foo',
-                  "  bar #{asgn} 1",
-                  'elsif baz',
-                  "  bar #{asgn} 2",
-                  'else',
-                  "  bar #{asgn} 3",
-                  'end']
+        source = <<-END.strip_indent
+          if foo
+            bar #{asgn} 1
+          elsif baz
+            bar #{asgn} 2
+          else
+            bar #{asgn} 3
+          end
+        END
 
         new_source = autocorrect_source(cop, source)
 
-        expect(new_source).to eq(["bar #{asgn} if foo",
-                                  '  1',
-                                  'elsif baz',
-                                  '  2',
-                                  'else',
-                                  '  3',
-                                  '        end'].join("\n"))
+        expect(new_source).to eq(<<-END.strip_indent)
+          bar #{asgn} if foo
+            1
+          elsif baz
+            2
+          else
+            3
+                  end
+        END
       end
 
       it "corrects assignment using #{asgn} in case when else" do
-        source = ['case foo',
-                  'when bar',
-                  "  baz #{asgn} 1",
-                  'else',
-                  "  baz #{asgn} 2",
-                  'end']
+        source = <<-END.strip_indent
+          case foo
+          when bar
+            baz #{asgn} 1
+          else
+            baz #{asgn} 2
+          end
+        END
 
         new_source = autocorrect_source(cop, source)
 
-        expect(new_source).to eq(["baz #{asgn} case foo",
-                                  'when bar',
-                                  '  1',
-                                  'else',
-                                  '  2',
-                                  '        end'].join("\n"))
+        expect(new_source).to eq(<<-END.strip_indent)
+          baz #{asgn} case foo
+          when bar
+            1
+          else
+            2
+                  end
+        END
       end
 
       it "corrects assignment using #{asgn} in unless else" do
-        source = ['unless foo',
-                  "  bar #{asgn} 1",
-                  'else',
-                  "  bar #{asgn} 2",
-                  'end']
+        source = <<-END.strip_indent
+          unless foo
+            bar #{asgn} 1
+          else
+            bar #{asgn} 2
+          end
+        END
 
         new_source = autocorrect_source(cop, source)
 
-        expect(new_source).to eq(["bar #{asgn} unless foo",
-                                  '  1',
-                                  'else',
-                                  '  2',
-                                  '        end'].join("\n"))
+        expect(new_source).to eq(<<-END.strip_indent)
+          bar #{asgn} unless foo
+            1
+          else
+            2
+                  end
+        END
       end
     end
 
@@ -1275,230 +1453,280 @@ describe RuboCop::Cop::Style::ConditionalAssignment do
     it_behaves_like('3 character assignment types', '||=')
 
     it 'corrects assignment in if elsif else with multiple elsifs' do
-      source = ['if foo',
-                '  bar = 1',
-                'elsif baz',
-                '  bar = 2',
-                'elsif foobar',
-                '  bar = 3',
-                'else',
-                '  bar = 4',
-                'end']
+      source = <<-END.strip_indent
+        if foo
+          bar = 1
+        elsif baz
+          bar = 2
+        elsif foobar
+          bar = 3
+        else
+          bar = 4
+        end
+      END
 
       new_source = autocorrect_source(cop, source)
 
-      expect(new_source).to eq(['bar = if foo',
-                                '  1',
-                                'elsif baz',
-                                '  2',
-                                'elsif foobar',
-                                '  3',
-                                'else',
-                                '  4',
-                                '      end'].join("\n"))
+      expect(new_source).to eq(<<-END.strip_indent)
+        bar = if foo
+          1
+        elsif baz
+          2
+        elsif foobar
+          3
+        else
+          4
+              end
+      END
     end
 
     it 'corrects assignment in unless else' do
-      source = ['unless foo',
-                '  bar = 1',
-                'else',
-                '  bar = 2',
-                'end']
+      source = <<-END.strip_indent
+        unless foo
+          bar = 1
+        else
+          bar = 2
+        end
+      END
 
       new_source = autocorrect_source(cop, source)
 
-      expect(new_source).to eq(['bar = unless foo',
-                                '  1',
-                                'else',
-                                '  2',
-                                '      end'].join("\n"))
+      expect(new_source).to eq(<<-END.strip_indent)
+        bar = unless foo
+          1
+        else
+          2
+              end
+      END
     end
 
     it 'corrects assignment in case when else' do
-      source = ['case foo',
-                'when bar',
-                '  baz = 1',
-                'else',
-                '  baz = 2',
-                'end']
+      source = <<-END.strip_indent
+        case foo
+        when bar
+          baz = 1
+        else
+          baz = 2
+        end
+      END
 
       new_source = autocorrect_source(cop, source)
 
-      expect(new_source).to eq(['baz = case foo',
-                                'when bar',
-                                '  1',
-                                'else',
-                                '  2',
-                                '      end'].join("\n"))
+      expect(new_source).to eq(<<-END.strip_indent)
+        baz = case foo
+        when bar
+          1
+        else
+          2
+              end
+      END
     end
 
     it 'corrects assignment in case when else with multiple whens' do
-      source = ['case foo',
-                'when bar',
-                '  baz = 1',
-                'when foobar',
-                '  baz = 2',
-                'else',
-                '  baz = 3',
-                'end']
+      source = <<-END.strip_indent
+        case foo
+        when bar
+          baz = 1
+        when foobar
+          baz = 2
+        else
+          baz = 3
+        end
+      END
 
       new_source = autocorrect_source(cop, source)
 
-      expect(new_source).to eq(['baz = case foo',
-                                'when bar',
-                                '  1',
-                                'when foobar',
-                                '  2',
-                                'else',
-                                '  3',
-                                '      end'].join("\n"))
+      expect(new_source).to eq(<<-END.strip_indent)
+        baz = case foo
+        when bar
+          1
+        when foobar
+          2
+        else
+          3
+              end
+      END
     end
 
     context 'assignment from a method' do
       it 'corrects if else' do
-        source = ['if foo?(scope.node)',
-                  '  bar << foobar(var, all)',
-                  'else',
-                  '  bar << baz(var, all)',
-                  'end']
+        source = <<-END.strip_indent
+          if foo?(scope.node)
+            bar << foobar(var, all)
+          else
+            bar << baz(var, all)
+          end
+        END
 
         new_source = autocorrect_source(cop, source)
 
-        expect(new_source).to eq(['bar << if foo?(scope.node)',
-                                  '  foobar(var, all)',
-                                  'else',
-                                  '  baz(var, all)',
-                                  '       end'].join("\n"))
+        expect(new_source).to eq(<<-END.strip_indent)
+          bar << if foo?(scope.node)
+            foobar(var, all)
+          else
+            baz(var, all)
+                 end
+        END
       end
 
       it 'corrects unless else' do
-        source = ['unless foo?(scope.node)',
-                  '  bar << foobar(var, all)',
-                  'else',
-                  '  bar << baz(var, all)',
-                  'end']
+        source = <<-END.strip_indent
+          unless foo?(scope.node)
+            bar << foobar(var, all)
+          else
+            bar << baz(var, all)
+          end
+        END
 
         new_source = autocorrect_source(cop, source)
 
-        expect(new_source).to eq(['bar << unless foo?(scope.node)',
-                                  '  foobar(var, all)',
-                                  'else',
-                                  '  baz(var, all)',
-                                  '       end'].join("\n"))
+        expect(new_source).to eq(<<-END.strip_indent)
+          bar << unless foo?(scope.node)
+            foobar(var, all)
+          else
+            baz(var, all)
+                 end
+        END
       end
 
       it 'corrects case when' do
-        source = ['case foo',
-                  'when foobar',
-                  '  bar << foobar(var, all)',
-                  'else',
-                  '  bar << baz(var, all)',
-                  'end']
+        source = <<-END.strip_indent
+          case foo
+          when foobar
+            bar << foobar(var, all)
+          else
+            bar << baz(var, all)
+          end
+        END
 
         new_source = autocorrect_source(cop, source)
 
-        expect(new_source).to eq(['bar << case foo',
-                                  'when foobar',
-                                  '  foobar(var, all)',
-                                  'else',
-                                  '  baz(var, all)',
-                                  '       end'].join("\n"))
+        expect(new_source).to eq(<<-END.strip_indent)
+          bar << case foo
+          when foobar
+            foobar(var, all)
+          else
+            baz(var, all)
+                 end
+        END
       end
     end
 
     context 'then' do
       it 'corrects if then elsif then else' do
-        source = ['if cond then bar = 1',
-                  'elsif cond then bar = 2',
-                  'else bar = 3',
-                  'end']
+        source = <<-END.strip_indent
+          if cond then bar = 1
+          elsif cond then bar = 2
+          else bar = 3
+          end
+        END
 
         new_source = autocorrect_source(cop, source)
 
-        expect(new_source).to eq(['bar = if cond then 1',
-                                  'elsif cond then 2',
-                                  'else 3',
-                                  '      end'].join("\n"))
+        expect(new_source).to eq(<<-END.strip_indent)
+          bar = if cond then 1
+          elsif cond then 2
+          else 3
+                end
+        END
       end
 
       it 'corrects case when then else' do
-        source = ['case foo',
-                  'when baz then bar = 1',
-                  'else bar = 2',
-                  'end']
+        source = <<-END.strip_indent
+          case foo
+          when baz then bar = 1
+          else bar = 2
+          end
+        END
 
         new_source = autocorrect_source(cop, source)
 
-        expect(new_source).to eq(['bar = case foo',
-                                  'when baz then 1',
-                                  'else 2',
-                                  '      end'].join("\n"))
+        expect(new_source).to eq(<<-END.strip_indent)
+          bar = case foo
+          when baz then 1
+          else 2
+                end
+        END
       end
     end
 
     it 'preserves comments during correction in if else' do
-      source = ['if foo',
-                '  # comment in if',
-                '  bar = 1',
-                'else',
-                '  # comment in else',
-                '  bar = 2',
-                'end']
+      source = <<-END.strip_indent
+        if foo
+          # comment in if
+          bar = 1
+        else
+          # comment in else
+          bar = 2
+        end
+      END
 
       new_source = autocorrect_source(cop, source)
 
-      expect(new_source).to eq(['bar = if foo',
-                                '  # comment in if',
-                                '  1',
-                                'else',
-                                '  # comment in else',
-                                '  2',
-                                '      end'].join("\n"))
+      expect(new_source).to eq(<<-END.strip_indent)
+        bar = if foo
+          # comment in if
+          1
+        else
+          # comment in else
+          2
+              end
+      END
     end
 
     it 'preserves comments during correction in case when else' do
-      source = ['case foo',
-                'when foobar',
-                '  # comment in when',
-                '  bar = 1',
-                'else',
-                '  # comment in else',
-                '  bar = 2',
-                'end']
+      source = <<-END.strip_indent
+        case foo
+        when foobar
+          # comment in when
+          bar = 1
+        else
+          # comment in else
+          bar = 2
+        end
+      END
 
       new_source = autocorrect_source(cop, source)
 
-      expect(new_source).to eq(['bar = case foo',
-                                'when foobar',
-                                '  # comment in when',
-                                '  1',
-                                'else',
-                                '  # comment in else',
-                                '  2',
-                                '      end'].join("\n"))
+      expect(new_source).to eq(<<-END.strip_indent)
+        bar = case foo
+        when foobar
+          # comment in when
+          1
+        else
+          # comment in else
+          2
+              end
+      END
     end
 
     context 'aref assignment' do
       it 'corrects if..else' do
-        new_source = autocorrect_source(cop, ['if something',
-                                              '  array[1] = 1',
-                                              'else',
-                                              '  array[1] = 2',
-                                              'end'])
-        expect(new_source).to eq(['array[1] = if something',
-                                  '  1',
-                                  'else',
-                                  '  2',
-                                  '           end'].join("\n"))
+        new_source = autocorrect_source(cop, <<-END.strip_indent)
+          if something
+            array[1] = 1
+          else
+            array[1] = 2
+          end
+        END
+        expect(new_source).to eq(<<-END.strip_indent)
+          array[1] = if something
+            1
+          else
+            2
+                     end
+        END
       end
 
       context 'with different indices' do
         it "doesn't register an offense" do
-          inspect_source(cop, ['if something',
-                               '  array[1, 2] = 1',
-                               'else',
-                               '  array[1, 3] = 2',
-                               'end'])
+          inspect_source(cop, <<-END.strip_indent)
+            if something
+              array[1, 2] = 1
+            else
+              array[1, 3] = 2
+            end
+          END
           expect(cop.offenses).to be_empty
         end
       end
@@ -1506,25 +1734,31 @@ describe RuboCop::Cop::Style::ConditionalAssignment do
 
     context 'self.attribute= assignment' do
       it 'corrects if..else' do
-        new_source = autocorrect_source(cop, ['if something',
-                                              '  self.attribute = 1',
-                                              'else',
-                                              '  self.attribute = 2',
-                                              'end'])
-        expect(new_source).to eq(['self.attribute = if something',
-                                  '  1',
-                                  'else',
-                                  '  2',
-                                  '                 end'].join("\n"))
+        new_source = autocorrect_source(cop, <<-END.strip_indent)
+          if something
+            self.attribute = 1
+          else
+            self.attribute = 2
+          end
+        END
+        expect(new_source).to eq(<<-END.strip_indent)
+          self.attribute = if something
+            1
+          else
+            2
+                           end
+        END
       end
 
       context 'with different receivers' do
         it "doesn't register an offense" do
-          inspect_source(cop, ['if something',
-                               '  obj1.attribute = 1',
-                               'else',
-                               '  obj2.attribute = 2',
-                               'end'])
+          inspect_source(cop, <<-END.strip_indent)
+            if something
+              obj1.attribute = 1
+            else
+              obj2.attribute = 2
+            end
+          END
           expect(cop.offenses).to be_empty
         end
       end
@@ -1532,21 +1766,25 @@ describe RuboCop::Cop::Style::ConditionalAssignment do
 
     context 'multiple assignment' do
       it 'does not register an offense in if else' do
-        inspect_source(cop, ['if something',
-                             '  a, b = 1, 2',
-                             'else',
-                             '  a, b = 2, 1',
-                             'end'])
+        inspect_source(cop, <<-END.strip_indent)
+          if something
+            a, b = 1, 2
+          else
+            a, b = 2, 1
+          end
+        END
         expect(cop.offenses).to be_empty
       end
 
       it 'does not register an offense in case when' do
-        inspect_source(cop, ['case foo',
-                             'when bar',
-                             '  a, b = 1, 2',
-                             'else',
-                             '  a, b = 2, 1',
-                             'end'])
+        inspect_source(cop, <<-END.strip_indent)
+          case foo
+          when bar
+            a, b = 1, 2
+          else
+            a, b = 2, 1
+          end
+        END
         expect(cop.offenses).to be_empty
       end
     end
@@ -1575,13 +1813,15 @@ describe RuboCop::Cop::Style::ConditionalAssignment do
 
     context 'assignment as the last statement' do
       it 'registers an offense in if else with more than variable assignment' do
-        source = ['if foo',
-                  '  method_call',
-                  '  bar = 1',
-                  'else',
-                  '  method_call',
-                  '  bar = 2',
-                  'end']
+        source = <<-END.strip_indent
+          if foo
+            method_call
+            bar = 1
+          else
+            method_call
+            bar = 2
+          end
+        END
         inspect_source(cop, source)
 
         expect(cop.messages).to eq([described_class::MSG])
@@ -1589,124 +1829,140 @@ describe RuboCop::Cop::Style::ConditionalAssignment do
 
       it 'registers an offense in if elsif else with more than ' \
          'variable assignment' do
-        source = ['if foo',
-                  '  method_call',
-                  '  bar = 1',
-                  'elsif foobar',
-                  '  method_call',
-                  '  bar = 2',
-                  'else',
-                  '  method_call',
-                  '  bar = 3',
-                  'end']
+        source = <<-END.strip_indent
+          if foo
+            method_call
+            bar = 1
+          elsif foobar
+            method_call
+            bar = 2
+          else
+            method_call
+            bar = 3
+          end
+        END
         inspect_source(cop, source)
 
         expect(cop.messages).to eq([described_class::MSG])
       end
 
       it 'register an offense for multiple assignment in if else' do
-        source = ['if baz',
-                  '  foo = 1',
-                  '  bar = 1',
-                  'else',
-                  '  foo = 2',
-                  '  bar = 2',
-                  'end']
+        source = <<-END.strip_indent
+          if baz
+            foo = 1
+            bar = 1
+          else
+            foo = 2
+            bar = 2
+          end
+        END
         inspect_source(cop, source)
 
         expect(cop.messages).to eq([described_class::MSG])
       end
 
       it 'registers an offense for multiple assignment in if elsif else' do
-        source = ['if baz',
-                  '  foo = 1',
-                  '  bar = 1',
-                  'elsif foobar',
-                  '  foo = 2',
-                  '  bar = 2',
-                  'else',
-                  '  foo = 3',
-                  '  bar = 3',
-                  'end']
+        source = <<-END.strip_indent
+          if baz
+            foo = 1
+            bar = 1
+          elsif foobar
+            foo = 2
+            bar = 2
+          else
+            foo = 3
+            bar = 3
+          end
+        END
         inspect_source(cop, source)
 
         expect(cop.messages).to eq([described_class::MSG])
       end
 
       it 'allows multiple assignment in if elsif elsif else' do
-        source = ['if baz',
-                  '  foo = 1',
-                  '  bar = 1',
-                  'elsif foobar',
-                  '  foo = 2',
-                  '  bar = 2',
-                  'elsif barfoo',
-                  '  foo = 3',
-                  '  bar = 3',
-                  'else',
-                  '  foo = 4',
-                  '  bar = 4',
-                  'end']
+        source = <<-END.strip_indent
+          if baz
+            foo = 1
+            bar = 1
+          elsif foobar
+            foo = 2
+            bar = 2
+          elsif barfoo
+            foo = 3
+            bar = 3
+          else
+            foo = 4
+            bar = 4
+          end
+        END
         inspect_source(cop, source)
 
         expect(cop.messages).to eq([described_class::MSG])
       end
 
       it 'allows out of order multiple assignment in if elsif else' do
-        source = ['if baz',
-                  '  bar = 1',
-                  '  foo = 1',
-                  'elsif foobar',
-                  '  foo = 2',
-                  '  bar = 2',
-                  'else',
-                  '  foo = 3',
-                  '  bar = 3',
-                  'end']
+        source = <<-END.strip_indent
+          if baz
+            bar = 1
+            foo = 1
+          elsif foobar
+            foo = 2
+            bar = 2
+          else
+            foo = 3
+            bar = 3
+          end
+        END
         inspect_source(cop, source)
 
         expect(cop.offenses).to be_empty
       end
 
       it 'allows multiple assignment in unless else' do
-        source = ['unless baz',
-                  '  foo = 1',
-                  '  bar = 1',
-                  'else',
-                  '  foo = 2',
-                  '  bar = 2',
-                  'end']
+        source = <<-END.strip_indent
+          unless baz
+            foo = 1
+            bar = 1
+          else
+            foo = 2
+            bar = 2
+          end
+        END
         inspect_source(cop, source)
 
         expect(cop.messages).to eq([described_class::MSG])
       end
 
       it 'allows multiple assignments in case when with only one when' do
-        source = ['case foo',
-                  'when foobar',
-                  '  foo = 1',
-                  '  bar = 1',
-                  'else',
-                  '  foo = 3',
-                  '  bar = 3',
-                  'end']
+        source = <<-END.strip_indent
+          case foo
+          when foobar
+            foo = 1
+            bar = 1
+          else
+            foo = 3
+            bar = 3
+          end
+        END
         inspect_source(cop, source)
 
         expect(cop.messages).to eq([described_class::MSG])
       end
 
       it 'allows multiple assignments in case when with multiple whens' do
-        source = ['case foo',
-                  'when foobar',
-                  '  foo = 1',
-                  '  bar = 1',
-                  'when foobaz',
-                  '  foo = 2',
-                  '  bar = 2',
-                  'else',
-                  '  foo = 3',
-                  '  bar = 3',
-                  'end']
+        source = <<-END.strip_indent
+          case foo
+          when foobar
+            foo = 1
+            bar = 1
+          when foobaz
+            foo = 2
+            bar = 2
+          else
+            foo = 3
+            bar = 3
+          end
+        END
         inspect_source(cop, source)
 
         expect(cop.messages).to eq([described_class::MSG])
@@ -1715,17 +1971,19 @@ describe RuboCop::Cop::Style::ConditionalAssignment do
       it 'registers an offense in if elsif else with some branches only ' \
           'containing variable assignment and others containing more than ' \
           'variable assignment' do
-        source = ['if foo',
-                  '  bar = 1',
-                  'elsif foobar',
-                  '  method_call',
-                  '  bar = 2',
-                  'elsif baz',
-                  '  bar = 3',
-                  'else',
-                  '  method_call',
-                  '  bar = 4',
-                  'end']
+        source = <<-END.strip_indent
+          if foo
+            bar = 1
+          elsif foobar
+            method_call
+            bar = 2
+          elsif baz
+            bar = 3
+          else
+            method_call
+            bar = 4
+          end
+        END
         inspect_source(cop, source)
 
         expect(cop.messages).to eq([described_class::MSG])
@@ -1733,13 +1991,15 @@ describe RuboCop::Cop::Style::ConditionalAssignment do
 
       it 'registers an offense in unless else with more than ' \
          'variable assignment' do
-        source = ['unless foo',
-                  '  method_call',
-                  '  bar = 1',
-                  'else',
-                  '  method_call',
-                  '  bar = 2',
-                  'end']
+        source = <<-END.strip_indent
+          unless foo
+            method_call
+            bar = 1
+          else
+            method_call
+            bar = 2
+          end
+        END
         inspect_source(cop, source)
 
         expect(cop.messages).to eq([described_class::MSG])
@@ -1747,14 +2007,16 @@ describe RuboCop::Cop::Style::ConditionalAssignment do
 
       it 'registers an offense in case when else with more than ' \
          'variable assignment' do
-        source = ['case foo',
-                  'when foobar',
-                  '  method_call',
-                  '  bar = 1',
-                  'else',
-                  '  method_call',
-                  '  bar = 2',
-                  'end']
+        source = <<-END.strip_indent
+          case foo
+          when foobar
+            method_call
+            bar = 1
+          else
+            method_call
+            bar = 2
+          end
+        END
 
         inspect_source(cop, source)
 
@@ -1763,48 +2025,54 @@ describe RuboCop::Cop::Style::ConditionalAssignment do
 
       context 'multiple assignment in only one branch' do
         it 'registers an offense when multiple assignment is in if' do
-          source = ['if foo',
-                    '  baz = 1',
-                    '  bar = 1',
-                    'elsif foobar',
-                    '  method_call',
-                    '  bar = 2',
-                    'else',
-                    '  other_method',
-                    '  bar = 3',
-                    'end']
+          source = <<-END.strip_indent
+            if foo
+              baz = 1
+              bar = 1
+            elsif foobar
+              method_call
+              bar = 2
+            else
+              other_method
+              bar = 3
+            end
+          END
           inspect_source(cop, source)
 
           expect(cop.offenses.size).to eq(1)
         end
 
         it 'registers an offense when multiple assignment is in elsif' do
-          source = ['if foo',
-                    '  method_call',
-                    '  bar = 1',
-                    'elsif foobar',
-                    '  baz = 2',
-                    '  bar = 2',
-                    'else',
-                    '  other_method',
-                    '  bar = 3',
-                    'end']
+          source = <<-END.strip_indent
+            if foo
+              method_call
+              bar = 1
+            elsif foobar
+              baz = 2
+              bar = 2
+            else
+              other_method
+              bar = 3
+            end
+          END
           inspect_source(cop, source)
 
           expect(cop.offenses.size).to eq(1)
         end
 
         it 'registers an offense when multiple assignment is in else' do
-          source = ['if foo',
-                    '  method_call',
-                    '  bar = 1',
-                    'elsif foobar',
-                    '  other_method',
-                    '  bar = 2',
-                    'else',
-                    '  baz = 3',
-                    '  bar = 3',
-                    'end']
+          source = <<-END.strip_indent
+            if foo
+              method_call
+              bar = 1
+            elsif foobar
+              other_method
+              bar = 2
+            else
+              baz = 3
+              bar = 3
+            end
+          END
           inspect_source(cop, source)
 
           expect(cop.offenses.size).to eq(1)
@@ -1814,13 +2082,15 @@ describe RuboCop::Cop::Style::ConditionalAssignment do
 
     it 'allows assignment in multiple branches when it is ' \
        'wrapped in a modifier' do
-      source = ['if foo',
-                '  bar << 1',
-                '  bar << 2',
-                'else',
-                '  bar << 3',
-                '  bar << 4 if foobar',
-                'end']
+      source = <<-END.strip_indent
+        if foo
+          bar << 1
+          bar << 2
+        else
+          bar << 3
+          bar << 4 if foobar
+        end
+      END
       inspect_source(cop, source)
 
       expect(cop.offenses).to be_empty
@@ -1828,13 +2098,15 @@ describe RuboCop::Cop::Style::ConditionalAssignment do
 
     it 'registers an offense for multiple assignment when an earlier ' \
        'assignment is is protected by a modifier' do
-      source = ['if foo',
-                '  bar << 1',
-                '  bar << 2',
-                'else',
-                '  bar << 3 if foobar',
-                '  bar << 4',
-                'end']
+      source = <<-END.strip_indent
+        if foo
+          bar << 1
+          bar << 2
+        else
+          bar << 3 if foobar
+          bar << 4
+        end
+      END
       inspect_source(cop, source)
 
       expect(cop.messages).to eq([described_class::MSG])
@@ -1842,174 +2114,202 @@ describe RuboCop::Cop::Style::ConditionalAssignment do
 
     context 'auto-correct' do
       it 'corrects multiple assignment in if else' do
-        source = ['if foo',
-                  '  baz = 1',
-                  '  bar = 1',
-                  'else',
-                  '  baz = 3',
-                  '  bar = 3',
-                  'end']
+        source = <<-END.strip_indent
+          if foo
+            baz = 1
+            bar = 1
+          else
+            baz = 3
+            bar = 3
+          end
+        END
         new_source = autocorrect_source(cop, source)
 
-        expect(new_source).to eq(['bar = if foo',
-                                  '  baz = 1',
-                                  '  1',
-                                  'else',
-                                  '  baz = 3',
-                                  '  3',
-                                  '      end'].join("\n"))
+        expect(new_source).to eq(<<-END.strip_indent)
+          bar = if foo
+            baz = 1
+            1
+          else
+            baz = 3
+            3
+                end
+        END
       end
 
       it 'corrects multiple assignment in if elsif else' do
-        source = ['if foo',
-                  '  baz = 1',
-                  '  bar = 1',
-                  'elsif foobar',
-                  '  baz = 2',
-                  '  bar = 2',
-                  'else',
-                  '  baz = 3',
-                  '  bar = 3',
-                  'end']
+        source = <<-END.strip_indent
+          if foo
+            baz = 1
+            bar = 1
+          elsif foobar
+            baz = 2
+            bar = 2
+          else
+            baz = 3
+            bar = 3
+          end
+        END
         new_source = autocorrect_source(cop, source)
 
-        expect(new_source).to eq(['bar = if foo',
-                                  '  baz = 1',
-                                  '  1',
-                                  'elsif foobar',
-                                  '  baz = 2',
-                                  '  2',
-                                  'else',
-                                  '  baz = 3',
-                                  '  3',
-                                  '      end'].join("\n"))
+        expect(new_source).to eq(<<-END.strip_indent)
+          bar = if foo
+            baz = 1
+            1
+          elsif foobar
+            baz = 2
+            2
+          else
+            baz = 3
+            3
+                end
+        END
       end
 
       it 'corrects multiple assignment in if elsif else with multiple elsifs' do
-        source = ['if foo',
-                  '  baz = 1',
-                  '  bar = 1',
-                  'elsif foobar',
-                  '  baz = 2',
-                  '  bar = 2',
-                  'elsif foobaz',
-                  '  baz = 3',
-                  '  bar = 3',
-                  'else',
-                  '  baz = 4',
-                  '  bar = 4',
-                  'end']
+        source = <<-END.strip_indent
+          if foo
+            baz = 1
+            bar = 1
+          elsif foobar
+            baz = 2
+            bar = 2
+          elsif foobaz
+            baz = 3
+            bar = 3
+          else
+            baz = 4
+            bar = 4
+          end
+        END
         new_source = autocorrect_source(cop, source)
 
-        expect(new_source).to eq(['bar = if foo',
-                                  '  baz = 1',
-                                  '  1',
-                                  'elsif foobar',
-                                  '  baz = 2',
-                                  '  2',
-                                  'elsif foobaz',
-                                  '  baz = 3',
-                                  '  3',
-                                  'else',
-                                  '  baz = 4',
-                                  '  4',
-                                  '      end'].join("\n"))
+        expect(new_source).to eq(<<-END.strip_indent)
+          bar = if foo
+            baz = 1
+            1
+          elsif foobar
+            baz = 2
+            2
+          elsif foobaz
+            baz = 3
+            3
+          else
+            baz = 4
+            4
+                end
+        END
       end
 
       it 'corrects multiple assignment in case when' do
-        source = ['case foo',
-                  'when foobar',
-                  '  baz = 1',
-                  '  bar = 1',
-                  'else',
-                  '  baz = 2',
-                  '  bar = 2',
-                  'end']
+        source = <<-END.strip_indent
+          case foo
+          when foobar
+            baz = 1
+            bar = 1
+          else
+            baz = 2
+            bar = 2
+          end
+        END
         new_source = autocorrect_source(cop, source)
 
-        expect(new_source).to eq(['bar = case foo',
-                                  'when foobar',
-                                  '  baz = 1',
-                                  '  1',
-                                  'else',
-                                  '  baz = 2',
-                                  '  2',
-                                  '      end'].join("\n"))
+        expect(new_source).to eq(<<-END.strip_indent)
+          bar = case foo
+          when foobar
+            baz = 1
+            1
+          else
+            baz = 2
+            2
+                end
+        END
       end
 
       it 'corrects multiple assignment in case when with multiple whens' do
-        source = ['case foo',
-                  'when foobar',
-                  '  baz = 1',
-                  '  bar = 1',
-                  'when foobaz',
-                  '  baz = 2',
-                  '  bar = 2',
-                  'else',
-                  '  baz = 3',
-                  '  bar = 3',
-                  'end']
+        source = <<-END.strip_indent
+          case foo
+          when foobar
+            baz = 1
+            bar = 1
+          when foobaz
+            baz = 2
+            bar = 2
+          else
+            baz = 3
+            bar = 3
+          end
+        END
         new_source = autocorrect_source(cop, source)
 
-        expect(new_source).to eq(['bar = case foo',
-                                  'when foobar',
-                                  '  baz = 1',
-                                  '  1',
-                                  'when foobaz',
-                                  '  baz = 2',
-                                  '  2',
-                                  'else',
-                                  '  baz = 3',
-                                  '  3',
-                                  '      end'].join("\n"))
+        expect(new_source).to eq(<<-END.strip_indent)
+          bar = case foo
+          when foobar
+            baz = 1
+            1
+          when foobaz
+            baz = 2
+            2
+          else
+            baz = 3
+            3
+                end
+        END
       end
 
       it 'corrects multiple assignment in unless else' do
-        source = ['unless foo',
-                  '  baz = 1',
-                  '  bar = 1',
-                  'else',
-                  '  baz = 2',
-                  '  bar = 2',
-                  'end']
+        source = <<-END.strip_indent
+          unless foo
+            baz = 1
+            bar = 1
+          else
+            baz = 2
+            bar = 2
+          end
+        END
         new_source = autocorrect_source(cop, source)
 
-        expect(new_source).to eq(['bar = unless foo',
-                                  '  baz = 1',
-                                  '  1',
-                                  'else',
-                                  '  baz = 2',
-                                  '  2',
-                                  '      end'].join("\n"))
+        expect(new_source).to eq(<<-END.strip_indent)
+          bar = unless foo
+            baz = 1
+            1
+          else
+            baz = 2
+            2
+                end
+        END
       end
 
       it 'corrects assignment in an if statement that is nested ' \
         'in unless else' do
-        source = ['unless foo',
-                  '  if foobar',
-                  '    baz = 1',
-                  '  elsif qux',
-                  '    baz = 2',
-                  '  else',
-                  '    baz = 3',
-                  '  end',
-                  'else',
-                  '  baz = 4',
-                  'end']
+        source = <<-END.strip_indent
+          unless foo
+            if foobar
+              baz = 1
+            elsif qux
+              baz = 2
+            else
+              baz = 3
+            end
+          else
+            baz = 4
+          end
+        END
 
         new_source = autocorrect_source(cop, source)
 
-        expect(new_source).to eq(['unless foo',
-                                  '  baz = if foobar',
-                                  '    1',
-                                  '  elsif qux',
-                                  '    2',
-                                  '  else',
-                                  '    3',
-                                  '        end',
-                                  'else',
-                                  '  baz = 4',
-                                  'end'].join("\n"))
+        expect(new_source).to eq(<<-END.strip_indent)
+          unless foo
+            baz = if foobar
+              1
+            elsif qux
+              2
+            else
+              3
+                  end
+          else
+            baz = 4
+          end
+        END
       end
     end
   end
@@ -2033,61 +2333,73 @@ describe RuboCop::Cop::Style::ConditionalAssignment do
 
       context 'auto-correct' do
         it 'uses proper end alignment in if' do
-          source = ['if foo',
-                    '  a =  b',
-                    'elsif bar',
-                    '  a = c',
-                    'else',
-                    '  a = d',
-                    'end']
+          source = <<-END.strip_indent
+            if foo
+              a =  b
+            elsif bar
+              a = c
+            else
+              a = d
+            end
+          END
 
           new_source = autocorrect_source(cop, source)
 
-          expect(new_source).to eq(['a = if foo',
-                                    '  b',
-                                    'elsif bar',
-                                    '  c',
-                                    'else',
-                                    '  d',
-                                    'end'].join("\n"))
+          expect(new_source).to eq(<<-END.strip_indent)
+            a = if foo
+              b
+            elsif bar
+              c
+            else
+              d
+            end
+          END
         end
 
         it 'uses proper end alignment in unless' do
-          source = ['unless foo',
-                    '  a = b',
-                    'else',
-                    '  a = d',
-                    'end']
+          source = <<-END.strip_indent
+            unless foo
+              a = b
+            else
+              a = d
+            end
+          END
 
           new_source = autocorrect_source(cop, source)
 
-          expect(new_source).to eq(['a = unless foo',
-                                    '  b',
-                                    'else',
-                                    '  d',
-                                    'end'].join("\n"))
+          expect(new_source).to eq(<<-END.strip_indent)
+            a = unless foo
+              b
+            else
+              d
+            end
+          END
         end
 
         it 'uses proper end alignment in case' do
-          source = ['case foo',
-                    'when bar',
-                    '  a = b',
-                    'when baz',
-                    '  a = c',
-                    'else',
-                    '  a = d',
-                    'end']
+          source = <<-END.strip_indent
+            case foo
+            when bar
+              a = b
+            when baz
+              a = c
+            else
+              a = d
+            end
+          END
 
           new_source = autocorrect_source(cop, source)
 
-          expect(new_source).to eq(['a = case foo',
-                                    'when bar',
-                                    '  b',
-                                    'when baz',
-                                    '  c',
-                                    'else',
-                                    '  d',
-                                    'end'].join("\n"))
+          expect(new_source).to eq(<<-END.strip_indent)
+            a = case foo
+            when bar
+              b
+            when baz
+              c
+            else
+              d
+            end
+          END
         end
       end
     end

--- a/spec/rubocop/cop/style/constant_name_spec.rb
+++ b/spec/rubocop/cop/style/constant_name_spec.rb
@@ -40,10 +40,11 @@ describe RuboCop::Cop::Style::ConstantName do
   end
 
   it 'does not check names if rhs is a method call with block' do
-    inspect_source(cop,
-                   ['AnythingGoes = test do',
-                    '  do_something',
-                    'end'])
+    inspect_source(cop, <<-END.strip_indent)
+      AnythingGoes = test do
+        do_something
+      end
+    END
     expect(cop.offenses).to be_empty
   end
 
@@ -54,9 +55,10 @@ describe RuboCop::Cop::Style::ConstantName do
   end
 
   it 'checks qualified const names' do
-    inspect_source(cop,
-                   ['::AnythingGoes = 30',
-                    'a::Bar_foo = 10'])
+    inspect_source(cop, <<-END.strip_indent)
+      ::AnythingGoes = 30
+      a::Bar_foo = 10
+    END
     expect(cop.offenses.size).to eq(2)
   end
 end

--- a/spec/rubocop/cop/style/def_with_parentheses_spec.rb
+++ b/spec/rubocop/cop/style/def_with_parentheses_spec.rb
@@ -4,22 +4,28 @@ describe RuboCop::Cop::Style::DefWithParentheses do
   subject(:cop) { described_class.new }
 
   it 'reports an offense for def with empty parens' do
-    src = ['def func()',
-           'end']
+    src = <<-END.strip_indent
+      def func()
+      end
+    END
     inspect_source(cop, src)
     expect(cop.offenses.size).to eq(1)
   end
 
   it 'reports an offense for class def with empty parens' do
-    src = ['def Test.func()',
-           'end']
+    src = <<-END.strip_indent
+      def Test.func()
+      end
+    END
     inspect_source(cop, src)
     expect(cop.offenses.size).to eq(1)
   end
 
   it 'accepts def with arg and parens' do
-    src = ['def func(a)',
-           'end']
+    src = <<-END.strip_indent
+      def func(a)
+      end
+    END
     inspect_source(cop, src)
     expect(cop.offenses).to be_empty
   end
@@ -31,11 +37,15 @@ describe RuboCop::Cop::Style::DefWithParentheses do
   end
 
   it 'auto-removes unneeded parens' do
-    new_source = autocorrect_source(cop, ['def test();',
-                                          'something',
-                                          'end'])
-    expect(new_source).to eq(['def test;',
-                              'something',
-                              'end'].join("\n"))
+    new_source = autocorrect_source(cop, <<-END.strip_indent)
+      def test();
+      something
+      end
+    END
+    expect(new_source).to eq(<<-END.strip_indent)
+      def test;
+      something
+      end
+    END
   end
 end

--- a/spec/rubocop/cop/style/documentation_spec.rb
+++ b/spec/rubocop/cop/style/documentation_spec.rb
@@ -9,220 +9,241 @@ describe RuboCop::Cop::Style::Documentation do
   end
 
   it 'registers an offense for non-empty class' do
-    inspect_source(cop,
-                   ['class My_Class',
-                    '  def method',
-                    '  end',
-                    'end'])
+    inspect_source(cop, <<-END.strip_indent)
+      class My_Class
+        def method
+        end
+      end
+    END
     expect(cop.offenses.size).to eq(1)
   end
 
   it 'does not consider comment followed by empty line to be class ' \
      'documentation' do
-    inspect_source(cop,
-                   ['# Copyright 2014',
-                    '# Some company',
-                    '',
-                    'class My_Class',
-                    '  def method',
-                    '  end',
-                    'end'])
+    inspect_source(cop, <<-END.strip_indent)
+      # Copyright 2014
+      # Some company
+
+      class My_Class
+        def method
+        end
+      end
+    END
     expect(cop.offenses.size).to eq(1)
   end
 
   it 'registers an offense for non-namespace' do
-    inspect_source(cop,
-                   ['module My_Class',
-                    '  def method',
-                    '  end',
-                    'end'])
+    inspect_source(cop, <<-END.strip_indent)
+      module My_Class
+        def method
+        end
+      end
+    END
     expect(cop.offenses.size).to eq(1)
   end
 
   it 'registers an offense for empty module without documentation' do
     # Because why would you have an empty module? It requires some
     # explanation.
-    inspect_source(cop,
-                   ['module Test',
-                    'end'])
+    inspect_source(cop, <<-END.strip_indent)
+      module Test
+      end
+    END
     expect(cop.offenses.size).to eq(1)
   end
 
   it 'accepts non-empty class with documentation' do
-    inspect_source(cop,
-                   ['# class comment',
-                    'class My_Class',
-                    '  def method',
-                    '  end',
-                    'end'])
+    inspect_source(cop, <<-END.strip_indent)
+      # class comment
+      class My_Class
+        def method
+        end
+      end
+    END
     expect(cop.offenses).to be_empty
   end
 
   it 'registers an offense for non-empty class with annotation comment' do
-    inspect_source(cop,
-                   ['# OPTIMIZE: Make this faster.',
-                    'class My_Class',
-                    '  def method',
-                    '  end',
-                    'end'])
+    inspect_source(cop, <<-END.strip_indent)
+      # OPTIMIZE: Make this faster.
+      class My_Class
+        def method
+        end
+      end
+    END
     expect(cop.offenses.size).to eq(1)
   end
 
   it 'registers an offense for non-empty class with directive comment' do
-    inspect_source(cop,
-                   ['# rubocop:disable Style/For',
-                    'class My_Class',
-                    '  def method',
-                    '  end',
-                    'end'])
+    inspect_source(cop, <<-END.strip_indent)
+      # rubocop:disable Style/For
+      class My_Class
+        def method
+        end
+      end
+    END
     expect(cop.offenses.size).to eq(1)
   end
 
   it 'registers offense for non-empty class with frozen string comment' do
-    inspect_source(cop,
-                   ['# frozen_string_literal: true',
-                    'class My_Class',
-                    '  def method',
-                    '  end',
-                    'end'])
+    inspect_source(cop, <<-END.strip_indent)
+      # frozen_string_literal: true
+      class My_Class
+        def method
+        end
+      end
+    END
     expect(cop.offenses.size).to eq(1)
   end
 
   it 'registers an offense for non-empty class with encoding comment' do
-    inspect_source(cop,
-                   ['# encoding: ascii-8bit',
-                    'class My_Class',
-                    '  def method',
-                    '  end',
-                    'end'])
+    inspect_source(cop, <<-END.strip_indent)
+      # encoding: ascii-8bit
+      class My_Class
+        def method
+        end
+      end
+    END
     expect(cop.offenses.size).to eq(1)
   end
 
   it 'accepts non-empty class with annotation comment followed by other ' \
      'comment' do
-    inspect_source(cop,
-                   ['# OPTIMIZE: Make this faster.',
-                    '# Class comment.',
-                    'class My_Class',
-                    '  def method',
-                    '  end',
-                    'end'])
+    inspect_source(cop, <<-END.strip_indent)
+      # OPTIMIZE: Make this faster.
+      # Class comment.
+      class My_Class
+        def method
+        end
+      end
+    END
     expect(cop.offenses).to be_empty
   end
 
   it 'accepts non-empty class with comment that ends with an annotation' do
-    inspect_source(cop,
-                   ['# Does fooing.',
-                    '# FIXME: Not yet implemented.',
-                    'class Foo',
-                    '  def initialize',
-                    '  end',
-                    'end'])
+    inspect_source(cop, <<-END.strip_indent)
+      # Does fooing.
+      # FIXME: Not yet implemented.
+      class Foo
+        def initialize
+        end
+      end
+    END
     expect(cop.offenses).to be_empty
   end
 
   it 'accepts non-empty module with documentation' do
-    inspect_source(cop,
-                   ['# class comment',
-                    'module My_Class',
-                    '  def method',
-                    '  end',
-                    'end'])
+    inspect_source(cop, <<-END.strip_indent)
+      # class comment
+      module My_Class
+        def method
+        end
+      end
+    END
     expect(cop.offenses).to be_empty
   end
 
   it 'accepts empty class without documentation' do
-    inspect_source(cop,
-                   ['class My_Class',
-                    'end'])
+    inspect_source(cop, <<-END.strip_indent)
+      class My_Class
+      end
+    END
     expect(cop.offenses).to be_empty
   end
 
   it 'accepts namespace module without documentation' do
-    inspect_source(cop,
-                   ['module Test',
-                    '  class A; end',
-                    '  class B; end',
-                    'end'])
+    inspect_source(cop, <<-END.strip_indent)
+      module Test
+        class A; end
+        class B; end
+      end
+    END
     expect(cop.offenses).to be_empty
   end
 
   it 'accepts namespace class without documentation' do
-    inspect_source(cop,
-                   ['class Test',
-                    '  class A; end',
-                    '  class B; end',
-                    'end'])
+    inspect_source(cop, <<-END.strip_indent)
+      class Test
+        class A; end
+        class B; end
+      end
+    END
     expect(cop.offenses).to be_empty
   end
 
   it 'accepts namespace class which defines constants' do
-    inspect_source(cop,
-                   ['class Test',
-                    '  A = Class.new',
-                    '  B = Class.new(A)',
-                    '  C = Class.new { call_method }',
-                    '  D = 1',
-                    'end'])
+    inspect_source(cop, <<-END.strip_indent)
+      class Test
+        A = Class.new
+        B = Class.new(A)
+        C = Class.new { call_method }
+        D = 1
+      end
+    END
     expect(cop.offenses).to be_empty
   end
 
   it 'accepts namespace module which defines constants' do
-    inspect_source(cop,
-                   ['module Test',
-                    '  A = Class.new',
-                    '  B = Class.new(A)',
-                    '  C = Class.new { call_method }',
-                    '  D = 1',
-                    'end'])
+    inspect_source(cop, <<-END.strip_indent)
+      module Test
+        A = Class.new
+        B = Class.new(A)
+        C = Class.new { call_method }
+        D = 1
+      end
+    END
     expect(cop.offenses).to be_empty
   end
 
   it 'does not raise an error for an implicit match conditional' do
     expect do
-      inspect_source(cop,
-                     ['class Test',
-                      '  if //',
-                      '  end',
-                      'end'])
+      inspect_source(cop, <<-END.strip_indent)
+        class Test
+          if //
+          end
+        end
+      END
     end.not_to raise_error
   end
 
   it 'registers an offense if the comment line contains code' do
-    inspect_source(cop,
-                   ['module A # The A Module',
-                    '  class B',
-                    '    C = 1',
-                    '    def method',
-                    '    end',
-                    '  end',
-                    'end'])
+    inspect_source(cop, <<-END.strip_indent)
+      module A # The A Module
+        class B
+          C = 1
+          def method
+          end
+        end
+      end
+    END
     expect(cop.offenses.size).to eq 1
   end
 
   context 'sparse and trailing comments' do
     %w[class module].each do |keyword|
       it "ignores comments after #{keyword} node end" do
-        inspect_source(cop,
-                       ['module TestModule',
-                        '  # documentation comment',
-                        "  #{keyword} Test",
-                        '    def method',
-                        '    end',
-                        '  end # decorating comment',
-                        'end'])
+        inspect_source(cop, <<-END.strip_indent)
+          module TestModule
+            # documentation comment
+            #{keyword} Test
+              def method
+              end
+            end # decorating comment
+          end
+        END
         expect(cop.offenses).to be_empty
       end
 
       it "ignores sparse comments inside #{keyword} node" do
-        inspect_source(cop,
-                       ['module TestModule',
-                        "  #{keyword} Test",
-                        '    def method',
-                        '    end',
-                        '    # sparse comment',
-                        '  end',
-                        'end'])
+        inspect_source(cop, <<-END.strip_indent)
+          module TestModule
+            #{keyword} Test
+              def method
+              end
+              # sparse comment
+            end
+          end
+        END
         expect(cop.offenses.size).to eq(1)
       end
     end
@@ -231,37 +252,40 @@ describe RuboCop::Cop::Style::Documentation do
   context 'with # :nodoc:' do
     %w[class module].each do |keyword|
       it "accepts non-namespace #{keyword} without documentation" do
-        inspect_source(cop,
-                       ["#{keyword} Test #:nodoc:",
-                        '  def method',
-                        '  end',
-                        'end'])
+        inspect_source(cop, <<-END.strip_indent)
+          #{keyword} Test #:nodoc:
+            def method
+            end
+          end
+        END
         expect(cop.offenses).to be_empty
       end
 
       it "registers an offense for nested #{keyword} without documentation" do
-        inspect_source(cop,
-                       ['module TestModule #:nodoc:',
-                        '  TEST = 20',
-                        "  #{keyword} Test",
-                        '    def method',
-                        '    end',
-                        '  end',
-                        'end'])
+        inspect_source(cop, <<-END.strip_indent)
+          module TestModule #:nodoc:
+            TEST = 20
+            #{keyword} Test
+              def method
+              end
+            end
+          end
+        END
         expect(cop.offenses.size).to eq(1)
       end
 
       context 'with `all` modifier' do
         it "accepts nested #{keyword} without documentation" do
-          inspect_source(cop,
-                         ['module A #:nodoc: all',
-                          '  module B',
-                          '    TEST = 20',
-                          "    #{keyword} Test",
-                          '      TEST = 20',
-                          '    end',
-                          '  end',
-                          'end'])
+          inspect_source(cop, <<-END.strip_indent)
+            module A #:nodoc: all
+              module B
+                TEST = 20
+                #{keyword} Test
+                  TEST = 20
+                end
+              end
+            end
+          END
           expect(cop.offenses).to be_empty
         end
       end
@@ -269,37 +293,40 @@ describe RuboCop::Cop::Style::Documentation do
 
     context 'on a subclass' do
       it 'accepts non-namespace subclass without documentation' do
-        inspect_source(cop,
-                       ['class Test < Parent #:nodoc:',
-                        '  def method',
-                        '  end',
-                        'end'])
+        inspect_source(cop, <<-END.strip_indent)
+          class Test < Parent #:nodoc:
+            def method
+            end
+          end
+        END
         expect(cop.offenses).to be_empty
       end
 
       it 'registers an offense for nested subclass without documentation' do
-        inspect_source(cop,
-                       ['module TestModule #:nodoc:',
-                        '  TEST = 20',
-                        '  class Test < Parent',
-                        '    def method',
-                        '    end',
-                        '  end',
-                        'end'])
+        inspect_source(cop, <<-END.strip_indent)
+          module TestModule #:nodoc:
+            TEST = 20
+            class Test < Parent
+              def method
+              end
+            end
+          end
+        END
         expect(cop.offenses.size).to eq(1)
       end
 
       context 'with `all` modifier' do
         it 'accepts nested subclass without documentation' do
-          inspect_source(cop,
-                         ['module A #:nodoc: all',
-                          '  module B',
-                          '    TEST = 20',
-                          '    class Test < Parent',
-                          '      TEST = 20',
-                          '    end',
-                          '  end',
-                          'end'])
+          inspect_source(cop, <<-END.strip_indent)
+            module A #:nodoc: all
+              module B
+                TEST = 20
+                class Test < Parent
+                  TEST = 20
+                end
+              end
+            end
+          END
           expect(cop.offenses).to be_empty
         end
       end

--- a/spec/rubocop/cop/style/dot_position_spec.rb
+++ b/spec/rubocop/cop/style/dot_position_spec.rb
@@ -7,25 +7,31 @@ describe RuboCop::Cop::Style::DotPosition, :config do
     let(:cop_config) { { 'EnforcedStyle' => 'leading' } }
 
     it 'registers an offense for trailing dot in multi-line call' do
-      inspect_source(cop, ['something.',
-                           '  method_name'])
+      inspect_source(cop, <<-END.strip_indent)
+        something.
+          method_name
+      END
       expect(cop.offenses.size).to eq(1)
       expect(cop.highlights).to eq(['.'])
       expect(cop.config_to_allow_offenses).to eq('EnforcedStyle' => 'trailing')
     end
 
     it 'registers an offense for correct + opposite' do
-      inspect_source(cop, ['something',
-                           '  .method_name',
-                           'something.',
-                           '  method_name'])
+      inspect_source(cop, <<-END.strip_indent)
+        something
+          .method_name
+        something.
+          method_name
+      END
       expect(cop.offenses.size).to eq(1)
       expect(cop.config_to_allow_offenses).to eq('Enabled' => false)
     end
 
     it 'accepts leading do in multi-line method call' do
-      inspect_source(cop, ['something',
-                           '  .method_name'])
+      inspect_source(cop, <<-END.strip_indent)
+        something
+          .method_name
+      END
       expect(cop.offenses).to be_empty
     end
 
@@ -35,8 +41,10 @@ describe RuboCop::Cop::Style::DotPosition, :config do
     end
 
     it 'does not err on method call without a method name' do
-      inspect_source(cop, ['l.',
-                           '(1)'])
+      inspect_source(cop, <<-END.strip_indent)
+        l.
+        (1)
+      END
       expect(cop.offenses.size).to eq(1)
     end
 
@@ -46,44 +54,60 @@ describe RuboCop::Cop::Style::DotPosition, :config do
     end
 
     it 'auto-corrects trailing dot in multi-line call' do
-      new_source = autocorrect_source(cop, ['something.',
-                                            '  method_name'])
-      expect(new_source).to eq(['something',
-                                '  .method_name'].join("\n"))
+      new_source = autocorrect_source(cop, <<-END.strip_indent)
+        something.
+          method_name
+      END
+      expect(new_source).to eq(<<-END.strip_indent)
+        something
+          .method_name
+      END
     end
 
     it 'auto-corrects trailing dot in multi-line call without selector' do
-      new_source = autocorrect_source(cop, ['something.',
-                                            '  (1)'])
-      expect(new_source).to eq(['something',
-                                '  .(1)'].join("\n"))
+      new_source = autocorrect_source(cop, <<-END.strip_indent)
+        something.
+          (1)
+      END
+      expect(new_source).to eq(<<-END.strip_indent)
+        something
+          .(1)
+      END
     end
 
     it 'auto-corrects correct + opposite style' do
-      new_source = autocorrect_source(cop, ['something',
-                                            '  .method_name',
-                                            'something.',
-                                            '  method_name'])
-      expect(new_source).to eq(['something',
-                                '  .method_name',
-                                'something',
-                                '  .method_name'].join("\n"))
+      new_source = autocorrect_source(cop, <<-END.strip_indent)
+        something
+          .method_name
+        something.
+          method_name
+      END
+      expect(new_source).to eq(<<-END.strip_indent)
+        something
+          .method_name
+        something
+          .method_name
+      END
     end
 
     context 'when there is an intervening line comment' do
       it 'does not register offense' do
-        inspect_source(cop, ['something.',
-                             '# a comment here',
-                             '  method_name'])
+        inspect_source(cop, <<-END.strip_indent)
+          something.
+          # a comment here
+            method_name
+        END
         expect(cop.offenses).to be_empty
       end
     end
 
     context 'when there is an intervening blank line' do
       it 'does not register offense' do
-        inspect_source(cop, ['something.',
-                             '',
-                             '  method_name'])
+        inspect_source(cop, <<-END.strip_indent)
+          something.
+
+            method_name
+        END
         expect(cop.offenses).to be_empty
       end
     end
@@ -93,8 +117,10 @@ describe RuboCop::Cop::Style::DotPosition, :config do
     let(:cop_config) { { 'EnforcedStyle' => 'trailing' } }
 
     it 'registers an offense for leading dot in multi-line call' do
-      inspect_source(cop, ['something',
-                           '  .method_name'])
+      inspect_source(cop, <<-END.strip_indent)
+        something
+          .method_name
+      END
       expect(cop.messages)
         .to eq(['Place the . on the previous line, together with the method ' \
                 'call receiver.'])
@@ -103,8 +129,10 @@ describe RuboCop::Cop::Style::DotPosition, :config do
     end
 
     it 'accepts trailing dot in multi-line method call' do
-      inspect_source(cop, ['something.',
-                           '  method_name'])
+      inspect_source(cop, <<-END.strip_indent)
+        something.
+          method_name
+      END
       expect(cop.offenses).to be_empty
     end
 
@@ -114,8 +142,10 @@ describe RuboCop::Cop::Style::DotPosition, :config do
     end
 
     it 'does not err on method call without a method name' do
-      inspect_source(cop, ['l',
-                           '.(1)'])
+      inspect_source(cop, <<-END.strip_indent)
+        l
+        .(1)
+      END
       expect(cop.offenses.size).to eq(1)
     end
 
@@ -125,24 +155,34 @@ describe RuboCop::Cop::Style::DotPosition, :config do
     end
 
     it 'does not get confused by several lines of chained methods' do
-      inspect_source(cop, ['File.new(something).',
-                           'readlines.map.',
-                           'compact.join("\n")'])
+      inspect_source(cop, <<-END.strip_indent)
+        File.new(something).
+        readlines.map.
+        compact.join("\n")
+      END
       expect(cop.offenses).to be_empty
     end
 
     it 'auto-corrects leading dot in multi-line call' do
-      new_source = autocorrect_source(cop, ['something',
-                                            '  .method_name'])
-      expect(new_source).to eq(['something.',
-                                '  method_name'].join("\n"))
+      new_source = autocorrect_source(cop, <<-END.strip_indent)
+        something
+          .method_name
+      END
+      expect(new_source).to eq(<<-END.strip_indent)
+        something.
+          method_name
+      END
     end
 
     it 'auto-corrects leading dot in multi-line call without selector' do
-      new_source = autocorrect_source(cop, ['something',
-                                            '  .(1)'])
-      expect(new_source).to eq(['something.',
-                                '  (1)'].join("\n"))
+      new_source = autocorrect_source(cop, <<-END.strip_indent)
+        something
+          .(1)
+      END
+      expect(new_source).to eq(<<-END.strip_indent)
+        something.
+          (1)
+      END
     end
   end
 end

--- a/spec/rubocop/cop/style/each_for_simple_loop_spec.rb
+++ b/spec/rubocop/cop/style/each_for_simple_loop_spec.rb
@@ -21,16 +21,20 @@ describe RuboCop::Cop::Style::EachForSimpleLoop do
   end
 
   it 'registers offense for exclusive end range with do ... end syntax' do
-    inspect_source(cop, ['(0...10).each do',
-                         'end'])
+    inspect_source(cop, <<-END.strip_indent)
+      (0...10).each do
+      end
+    END
     expect(cop.offenses.size).to eq 1
     expect(cop.messages).to eq([OFFENSE_MSG])
     expect(cop.highlights).to eq(['(0...10).each'])
   end
 
   it 'registers an offense for range not starting with zero' do
-    inspect_source(cop, ['(3..7).each do',
-                         'end'])
+    inspect_source(cop, <<-END.strip_indent)
+      (3..7).each do
+      end
+    END
     expect(cop.offenses.size).to eq 1
     expect(cop.messages).to eq([OFFENSE_MSG])
     expect(cop.highlights).to eq(['(3..7).each'])
@@ -52,8 +56,10 @@ describe RuboCop::Cop::Style::EachForSimpleLoop do
   end
 
   it 'does not register offense for multiline block with parameters' do
-    inspect_source(cop, ['(0..10).each do |n|',
-                         'end'])
+    inspect_source(cop, <<-END.strip_indent)
+      (0..10).each do |n|
+      end
+    END
     expect(cop.offenses).to be_empty
   end
 
@@ -69,21 +75,36 @@ describe RuboCop::Cop::Style::EachForSimpleLoop do
     end
 
     it 'autocorrects the source with multiline block' do
-      corrected = autocorrect_source(cop, ['(0..10).each do',
-                                           'end'])
-      expect(corrected).to eq "11.times do\nend"
+      corrected = autocorrect_source(cop, <<-END.strip_indent)
+        (0..10).each do
+        end
+      END
+
+      expect(corrected).to eq <<-END.strip_indent
+        11.times do
+        end
+      END
     end
 
     it 'autocorrects the range not starting with zero' do
-      corrected = autocorrect_source(cop, ['(3..7).each do',
-                                           'end'])
-      expect(corrected).to eq "5.times do\nend"
+      corrected = autocorrect_source(cop, <<-END.strip_indent)
+        (3..7).each do
+        end
+      END
+
+      expect(corrected).to eq <<-END.strip_indent
+        5.times do
+        end
+      END
     end
 
     it 'does not autocorrect range not starting with zero and using param' do
-      corrected = autocorrect_source(cop, ['(3..7).each do |n|',
-                                           'end'])
-      expect(corrected).to eq "(3..7).each do |n|\nend"
+      source = <<-END.strip_indent
+        (3..7).each do |n|
+        end
+      END
+      corrected = autocorrect_source(cop, source)
+      expect(corrected).to eq(source)
     end
   end
 
@@ -94,21 +115,36 @@ describe RuboCop::Cop::Style::EachForSimpleLoop do
     end
 
     it 'autocorrects the source with multiline block' do
-      corrected = autocorrect_source(cop, ['(0...10).each do',
-                                           'end'])
-      expect(corrected).to eq "10.times do\nend"
+      corrected = autocorrect_source(cop, <<-END.strip_indent)
+        (0...10).each do
+        end
+      END
+
+      expect(corrected).to eq <<-END.strip_indent
+        10.times do
+        end
+      END
     end
 
     it 'autocorrects the range not starting with zero' do
-      corrected = autocorrect_source(cop, ['(3...7).each do',
-                                           'end'])
-      expect(corrected).to eq "4.times do\nend"
+      corrected = autocorrect_source(cop, <<-END.strip_indent)
+        (3...7).each do
+        end
+      END
+
+      expect(corrected).to eq <<-END.strip_indent
+        4.times do
+        end
+      END
     end
 
     it 'does not autocorrect range not starting with zero and using param' do
-      corrected = autocorrect_source(cop, ['(3...7).each do |n|',
-                                           'end'])
-      expect(corrected).to eq "(3...7).each do |n|\nend"
+      source = <<-END.strip_indent
+        (3...7).each do |n|
+        end
+      END
+      corrected = autocorrect_source(cop, source)
+      expect(corrected).to eq(source)
     end
   end
 end

--- a/spec/rubocop/cop/style/else_alignment_spec.rb
+++ b/spec/rubocop/cop/style/else_alignment_spec.rb
@@ -16,59 +16,65 @@ describe RuboCop::Cop::Style::ElseAlignment do
 
   context 'with if statement' do
     it 'registers an offense for misaligned else' do
-      inspect_source(cop,
-                     ['if cond',
-                      '  func1',
-                      ' else',
-                      ' func2',
-                      'end'])
+      inspect_source(cop, <<-END.strip_indent)
+        if cond
+          func1
+         else
+         func2
+        end
+      END
       expect(cop.messages).to eq(['Align `else` with `if`.'])
       expect(cop.highlights).to eq(['else'])
     end
 
     it 'registers an offense for misaligned elsif' do
-      inspect_source(cop,
-                     ['  if a1',
-                      '    b1',
-                      'elsif a2',
-                      '    b2',
-                      '  end'])
+      inspect_source(cop, <<-END.strip_indent)
+          if a1
+            b1
+        elsif a2
+            b2
+          end
+      END
       expect(cop.messages).to eq(['Align `elsif` with `if`.'])
       expect(cop.highlights).to eq(['elsif'])
     end
 
     it 'accepts indentation after else when if is on new line after ' \
        'assignment' do
-      inspect_source(cop,
-                     ['Rails.application.config.ideal_postcodes_key =',
-                      '  if Rails.env.production? || Rails.env.staging?',
-                      '    "AAAA-AAAA-AAAA-AAAA"',
-                      '  else',
-                      '    "BBBB-BBBB-BBBB-BBBB"',
-                      '  end'])
+      inspect_source(cop, <<-END.strip_indent)
+        Rails.application.config.ideal_postcodes_key =
+          if Rails.env.production? || Rails.env.staging?
+            "AAAA-AAAA-AAAA-AAAA"
+          else
+            "BBBB-BBBB-BBBB-BBBB"
+          end
+      END
       expect(cop.offenses).to be_empty
     end
 
     describe '#autocorrect' do
       it 'corrects bad alignment' do
-        corrected = autocorrect_source(cop,
-                                       ['  if a1',
-                                        '    b1',
-                                        '    elsif a2',
-                                        '    b2',
-                                        'else',
-                                        '    c',
-                                        '  end'])
+        corrected = autocorrect_source(cop, <<-END.strip_indent)
+            if a1
+              b1
+              elsif a2
+              b2
+          else
+              c
+            end
+        END
         expect(cop.messages).to eq(['Align `elsif` with `if`.',
                                     'Align `else` with `if`.'])
         expect(corrected)
-          .to eq ['  if a1',
-                  '    b1',
-                  '  elsif a2',
-                  '    b2',
-                  '  else',
-                  '    c',
-                  '  end'].join("\n")
+          .to eq <<-END.strip_margin('|')
+            |  if a1
+            |    b1
+            |  elsif a2
+            |    b2
+            |  else
+            |    c
+            |  end
+          END
       end
     end
 
@@ -78,14 +84,15 @@ describe RuboCop::Cop::Style::ElseAlignment do
     end
 
     it 'accepts a correctly aligned if/elsif/else/end' do
-      inspect_source(cop,
-                     ['if a1',
-                      '  b1',
-                      'elsif a2',
-                      '  b2',
-                      'else',
-                      '  c',
-                      'end'])
+      inspect_source(cop, <<-END.strip_indent)
+        if a1
+          b1
+        elsif a2
+          b2
+        else
+          c
+        end
+      END
       expect(cop.offenses).to be_empty
     end
 
@@ -93,14 +100,15 @@ describe RuboCop::Cop::Style::ElseAlignment do
       let(:bom) { "\xef\xbb\xbf" }
 
       it 'accepts a correctly aligned if/elsif/else/end' do
-        inspect_source(cop,
-                       ["#{bom}if a1",
-                        '  b1',
-                        'elsif a2',
-                        '  b2',
-                        'else',
-                        '  c',
-                        'end'])
+        inspect_source(cop, <<-END.strip_indent)
+          #{bom}if a1
+            b1
+          elsif a2
+            b2
+          else
+            c
+          end
+        END
         expect(cop.offenses).to be_empty
       end
     end
@@ -109,97 +117,106 @@ describe RuboCop::Cop::Style::ElseAlignment do
       context 'when alignment style is variable' do
         context 'and end is aligned with variable' do
           it 'accepts an if-else with end aligned with setter' do
-            inspect_source(cop,
-                           ['foo.bar = if baz',
-                            '  derp1',
-                            'else',
-                            '  derp2',
-                            'end'])
+            inspect_source(cop, <<-END.strip_indent)
+              foo.bar = if baz
+                derp1
+              else
+                derp2
+              end
+            END
             expect(cop.offenses).to be_empty
           end
 
           it 'accepts an if-elsif-else with end aligned with setter' do
-            inspect_source(cop,
-                           ['foo.bar = if baz',
-                            '  derp1',
-                            'elsif meh',
-                            '  derp2',
-                            'else',
-                            '  derp3',
-                            'end'])
+            inspect_source(cop, <<-END.strip_indent)
+              foo.bar = if baz
+                derp1
+              elsif meh
+                derp2
+              else
+                derp3
+              end
+            END
             expect(cop.offenses).to be_empty
           end
 
           it 'accepts an if with end aligned with element assignment' do
-            inspect_source(cop,
-                           ['foo[bar] = if baz',
-                            '  derp',
-                            'end'])
+            inspect_source(cop, <<-END.strip_indent)
+              foo[bar] = if baz
+                derp
+              end
+            END
             expect(cop.offenses).to be_empty
           end
 
           it 'accepts an if/else' do
-            inspect_source(cop,
-                           ['var = if a',
-                            '  0',
-                            'else',
-                            '  1',
-                            'end'])
+            inspect_source(cop, <<-END.strip_indent)
+              var = if a
+                0
+              else
+                1
+              end
+            END
             expect(cop.offenses).to be_empty
           end
 
           it 'accepts an if/else with chaining after the end' do
-            inspect_source(cop,
-                           ['var = if a',
-                            '  0',
-                            'else',
-                            '  1',
-                            'end.abc.join("")'])
+            inspect_source(cop, <<-END.strip_indent)
+              var = if a
+                0
+              else
+                1
+              end.abc.join("")
+            END
             expect(cop.offenses).to be_empty
           end
 
           it 'accepts an if/else with chaining with a block after the end' do
-            inspect_source(cop,
-                           ['var = if a',
-                            '  0',
-                            'else',
-                            '  1',
-                            'end.abc.tap {}'])
+            inspect_source(cop, <<-END.strip_indent)
+              var = if a
+                0
+              else
+                1
+              end.abc.tap {}
+            END
             expect(cop.offenses).to be_empty
           end
         end
 
         context 'and end is aligned with keyword' do
           it 'registers offenses for an if with setter' do
-            inspect_source(cop,
-                           ['foo.bar = if baz',
-                            '            derp1',
-                            '          elsif meh',
-                            '            derp2',
-                            '          else',
-                            '            derp3',
-                            '          end'])
+            inspect_source(cop, <<-END.strip_indent)
+              foo.bar = if baz
+                          derp1
+                        elsif meh
+                          derp2
+                        else
+                          derp3
+                        end
+            END
             expect(cop.messages).to eq(['Align `elsif` with `foo.bar`.',
                                         'Align `else` with `foo.bar`.'])
           end
 
           it 'registers an offense for an if with element assignment' do
-            inspect_source(cop,
-                           ['foo[bar] = if baz',
-                            '             derp1',
-                            '           else',
-                            '             derp2',
-                            '           end'])
+            inspect_source(cop, <<-END.strip_indent)
+              foo[bar] = if baz
+                           derp1
+                         else
+                           derp2
+                         end
+            END
             expect(cop.messages).to eq(['Align `else` with `foo[bar]`.'])
           end
 
           it 'registers an offense for an if' do
-            inspect_source(cop,
-                           ['var = if a',
-                            '        0',
-                            '      else',
-                            '        1',
-                            '      end'])
+            inspect_source(cop, <<-END.strip_indent)
+              var = if a
+                      0
+                    else
+                      1
+                    end
+            END
             expect(cop.messages).to eq(['Align `else` with `var`.'])
           end
         end
@@ -208,73 +225,82 @@ describe RuboCop::Cop::Style::ElseAlignment do
       shared_examples 'assignment and if with keyword alignment' do
         context 'and end is aligned with variable' do
           it 'registers an offense for an if' do
-            inspect_source(cop,
-                           ['var = if a',
-                            '  0',
-                            'elsif b',
-                            '  1',
-                            'end'])
+            inspect_source(cop, <<-END.strip_indent)
+              var = if a
+                0
+              elsif b
+                1
+              end
+            END
             expect(cop.messages).to eq(['Align `elsif` with `if`.'])
           end
 
           it 'autocorrects bad alignment' do
-            corrected = autocorrect_source(cop,
-                                           ['var = if a',
-                                            '  b1',
-                                            'else',
-                                            '  b2',
-                                            'end'])
-            expect(corrected).to eq ['var = if a',
-                                     '  b1',
-                                     '      else',
-                                     '  b2',
-                                     'end'].join("\n")
+            corrected = autocorrect_source(cop, <<-END.strip_indent)
+              var = if a
+                b1
+              else
+                b2
+              end
+            END
+            expect(corrected).to eq <<-END.strip_indent
+              var = if a
+                b1
+                    else
+                b2
+              end
+            END
           end
         end
 
         context 'and end is aligned with keyword' do
           it 'accepts an if in assignment' do
-            inspect_source(cop,
-                           ['var = if a',
-                            '        0',
-                            '      end'])
+            inspect_source(cop, <<-END.strip_indent)
+              var = if a
+                      0
+                    end
+            END
             expect(cop.offenses).to be_empty
           end
 
           it 'accepts an if/else in assignment' do
-            inspect_source(cop,
-                           ['var = if a',
-                            '        0',
-                            '      else',
-                            '        1',
-                            '      end'])
+            inspect_source(cop, <<-END.strip_indent)
+              var = if a
+                      0
+                    else
+                      1
+                    end
+            END
             expect(cop.offenses).to be_empty
           end
 
           it 'accepts an if/else in assignment on next line' do
-            inspect_source(cop,
-                           ['var =',
-                            '  if a',
-                            '    0',
-                            '  else',
-                            '    1',
-                            '  end'])
+            inspect_source(cop, <<-END.strip_indent)
+              var =
+                if a
+                  0
+                else
+                  1
+                end
+            END
             expect(cop.offenses).to be_empty
           end
 
           it 'accepts a while in assignment' do
-            inspect_source(cop,
-                           ['var = while a',
-                            '        b',
-                            '      end'])
+            inspect_source(cop, <<-END.strip_indent)
+              var = while a
+                      b
+                    end
+            END
             expect(cop.offenses).to be_empty
           end
 
           it 'accepts an until in assignment' do
-            inspect_source(cop,
-                           ['var = until a',
-                            '        b',
-                            '      end'])
+            inspect_source(cop, <<-END.strip_indent)
+              var = until a
+                      b
+                    end
+            END
             expect(cop.offenses).to be_empty
           end
         end
@@ -292,137 +318,149 @@ describe RuboCop::Cop::Style::ElseAlignment do
     it 'accepts an if/else branches with rescue clauses' do
       # Because of how the rescue clauses come out of Parser, these are
       # special and need to be tested.
-      inspect_source(cop,
-                     ['if a',
-                      '  a rescue nil',
-                      'else',
-                      '  a rescue nil',
-                      'end'])
+      inspect_source(cop, <<-END.strip_indent)
+        if a
+          a rescue nil
+        else
+          a rescue nil
+        end
+      END
       expect(cop.offenses).to be_empty
     end
   end
 
   context 'with unless' do
     it 'registers an offense for misaligned else' do
-      inspect_source(cop,
-                     ['unless cond',
-                      '   func1',
-                      ' else',
-                      '   func2',
-                      'end'])
+      inspect_source(cop, <<-END.strip_indent)
+        unless cond
+           func1
+         else
+           func2
+        end
+      END
       expect(cop.messages).to eq(['Align `else` with `unless`.'])
     end
 
     it 'accepts a correctly aligned else in an otherwise empty unless' do
-      inspect_source(cop,
-                     ['unless a',
-                      'else',
-                      'end'])
+      inspect_source(cop, <<-END.strip_indent)
+        unless a
+        else
+        end
+      END
       expect(cop.offenses).to be_empty
     end
 
     it 'accepts an empty unless' do
-      inspect_source(cop,
-                     ['unless a',
-                      'end'])
+      inspect_source(cop, <<-END.strip_indent)
+        unless a
+        end
+      END
       expect(cop.offenses).to be_empty
     end
   end
 
   context 'with case' do
     it 'registers an offense for misaligned else' do
-      inspect_source(cop,
-                     ['case a',
-                      'when b',
-                      '  c',
-                      'when d',
-                      '  e',
-                      ' else',
-                      '  f',
-                      'end'])
+      inspect_source(cop, <<-END.strip_indent)
+        case a
+        when b
+          c
+        when d
+          e
+         else
+          f
+        end
+      END
       expect(cop.messages).to eq(['Align `else` with `when`.'])
     end
 
     it 'accepts correctly aligned case/when/else' do
-      inspect_source(cop,
-                     ['case a',
-                      'when b',
-                      '  c',
-                      '  c',
-                      'when d',
-                      'else',
-                      '  f',
-                      'end'])
+      inspect_source(cop, <<-END.strip_indent)
+        case a
+        when b
+          c
+          c
+        when d
+        else
+          f
+        end
+      END
       expect(cop.offenses).to be_empty
     end
 
     it 'accepts case without else' do
-      inspect_source(cop,
-                     ['case superclass',
-                      'when /\A(#{NAMESPACEMATCH})(?:\s|\Z)/',
-                      '  $1',
-                      'when "self"',
-                      '  namespace.path',
-                      'end'])
+      inspect_source(cop, <<-'END'.strip_indent)
+        case superclass
+        when /\A(#{NAMESPACEMATCH})(?:\s|\Z)/
+          $1
+        when "self"
+          namespace.path
+        end
+      END
       expect(cop.offenses).to be_empty
     end
 
     it 'accepts else aligned with when but not with case' do
       # "Indent when as deep as case" is the job of another cop, and this is
       # one of the possible styles supported by configuration.
-      inspect_source(cop,
-                     ['case code_type',
-                      "  when 'ruby', 'sql', 'plain'",
-                      '    code_type',
-                      "  when 'erb'",
-                      "    'ruby; html-script: true'",
-                      '  when "html"',
-                      "    'xml'",
-                      '  else',
-                      "    'plain'",
-                      'end'])
+      inspect_source(cop, <<-END.strip_indent)
+        case code_type
+          when 'ruby', 'sql', 'plain'
+            code_type
+          when 'erb'
+            'ruby; html-script: true'
+          when "html"
+            'xml'
+          else
+            'plain'
+        end
+      END
       expect(cop.offenses).to be_empty
     end
   end
 
   context 'with def/defs' do
     it 'accepts an empty def body' do
-      inspect_source(cop,
-                     ['def test',
-                      'end'])
+      inspect_source(cop, <<-END.strip_indent)
+        def test
+        end
+      END
       expect(cop.offenses).to be_empty
     end
 
     it 'accepts an empty defs body' do
-      inspect_source(cop,
-                     ['def self.test',
-                      'end'])
+      inspect_source(cop, <<-END.strip_indent)
+        def self.test
+        end
+      END
       expect(cop.offenses).to be_empty
     end
 
     if RUBY_VERSION >= '2.1'
       context 'when modifier and def are on the same line' do
         it 'accepts a correctly aligned body' do
-          inspect_source(cop,
-                         ['private def test',
-                          '  something',
-                          'rescue',
-                          '  handling',
-                          'else',
-                          '  something_else',
-                          'end'])
+          inspect_source(cop, <<-END.strip_indent)
+            private def test
+              something
+            rescue
+              handling
+            else
+              something_else
+            end
+          END
           expect(cop.offenses).to be_empty
         end
 
         it 'registers an offense for else not aligned with private' do
-          inspect_source(cop,
-                         ['private def test',
-                          '          something',
-                          '        rescue',
-                          '          handling',
-                          '        else',
-                          '          something_else',
-                          '        end'])
+          inspect_source(cop, <<-END.strip_indent)
+            private def test
+                      something
+                    rescue
+                      handling
+                    else
+                      something_else
+                    end
+          END
           expect(cop.messages).to eq(['Align `else` with `private`.'])
         end
       end
@@ -431,93 +469,99 @@ describe RuboCop::Cop::Style::ElseAlignment do
 
   context 'with begin/rescue/else/ensure/end' do
     it 'registers an offense for misaligned else' do
-      inspect_source(cop,
-                     ['def my_func',
-                      "  puts 'do something outside block'",
-                      '  begin',
-                      "    puts 'do something error prone'",
-                      '  rescue SomeException, SomeOther => e',
-                      "    puts 'wrongly intended error handling'",
-                      '  rescue',
-                      "    puts 'wrongly intended error handling'",
-                      'else',
-                      "    puts 'wrongly intended normal case handling'",
-                      '  ensure',
-                      "    puts 'wrongly intended common handling'",
-                      '  end',
-                      'end'])
+      inspect_source(cop, <<-END.strip_indent)
+        def my_func
+          puts 'do something outside block'
+          begin
+            puts 'do something error prone'
+          rescue SomeException, SomeOther => e
+            puts 'wrongly intended error handling'
+          rescue
+            puts 'wrongly intended error handling'
+        else
+            puts 'wrongly intended normal case handling'
+          ensure
+            puts 'wrongly intended common handling'
+          end
+        end
+      END
       expect(cop.messages).to eq(['Align `else` with `begin`.'])
     end
 
     it 'accepts a correctly aligned else' do
-      inspect_source(cop,
-                     ['begin',
-                      "  raise StandardError.new('Fail') if rand(2).odd?",
-                      'rescue StandardError => error',
-                      '  $stderr.puts error.message',
-                      'else',
-                      "  $stdout.puts 'Lucky you!'",
-                      'end'])
+      inspect_source(cop, <<-END.strip_indent)
+        begin
+          raise StandardError.new('Fail') if rand(2).odd?
+        rescue StandardError => error
+          $stderr.puts error.message
+        else
+          $stdout.puts 'Lucky you!'
+        end
+      END
       expect(cop.offenses).to be_empty
     end
   end
 
   context 'with def/rescue/else/ensure/end' do
     it 'accepts a correctly aligned else' do
-      inspect_source(cop,
-                     ['def my_func(string)',
-                      '  puts string',
-                      'rescue => e',
-                      '  puts e',
-                      'else',
-                      '  puts e',
-                      'ensure',
-                      "  puts 'I love methods that print'",
-                      'end'])
+      inspect_source(cop, <<-END.strip_indent)
+        def my_func(string)
+          puts string
+        rescue => e
+          puts e
+        else
+          puts e
+        ensure
+          puts 'I love methods that print'
+        end
+      END
       expect(cop.offenses).to be_empty
     end
 
     it 'registers an offense for misaligned else' do
-      inspect_source(cop,
-                     ['def my_func(string)',
-                      '  puts string',
-                      'rescue => e',
-                      '  puts e',
-                      '  else',
-                      '  puts e',
-                      'ensure',
-                      "  puts 'I love methods that print'",
-                      'end'])
+      inspect_source(cop, <<-END.strip_indent)
+        def my_func(string)
+          puts string
+        rescue => e
+          puts e
+          else
+          puts e
+        ensure
+          puts 'I love methods that print'
+        end
+      END
       expect(cop.messages).to eq(['Align `else` with `def`.'])
     end
   end
 
   context 'with def/rescue/else/end' do
     it 'accepts a correctly aligned else' do
-      inspect_source(cop,
-                     ['def my_func',
-                      "  puts 'do something error prone'",
-                      'rescue SomeException',
-                      "  puts 'error handling'",
-                      'rescue',
-                      "  puts 'error handling'",
-                      'else',
-                      "  puts 'normal handling'",
-                      'end'])
+      inspect_source(cop, <<-END.strip_indent)
+        def my_func
+          puts 'do something error prone'
+        rescue SomeException
+          puts 'error handling'
+        rescue
+          puts 'error handling'
+        else
+          puts 'normal handling'
+        end
+      END
       expect(cop.messages).to be_empty
     end
 
     it 'registers an offense for misaligned else' do
-      inspect_source(cop,
-                     ['def my_func',
-                      "  puts 'do something error prone'",
-                      'rescue SomeException',
-                      "  puts 'error handling'",
-                      'rescue',
-                      "  puts 'error handling'",
-                      '  else',
-                      "  puts 'normal handling'",
-                      'end'])
+      inspect_source(cop, <<-END.strip_indent)
+        def my_func
+          puts 'do something error prone'
+        rescue SomeException
+          puts 'error handling'
+        rescue
+          puts 'error handling'
+          else
+          puts 'normal handling'
+        end
+      END
       expect(cop.messages).to eq(['Align `else` with `def`.'])
     end
   end

--- a/spec/rubocop/cop/style/empty_case_condition_spec.rb
+++ b/spec/rubocop/cop/style/empty_case_condition_spec.rb
@@ -10,10 +10,10 @@ describe RuboCop::Cop::Style::EmptyCaseCondition do
     end
 
     it 'correctly autocorrects' do
-      expect(autocorrect_source(cop, source)).to eq corrected_source.join("\n")
+      expect(autocorrect_source(cop, source)).to eq corrected_source
     end
 
-    let(:source_with_case) { source.map { |s| s.gsub(/case/, 'case :a') } }
+    let(:source_with_case) { source.sub(/case/, 'case :a') }
 
     it 'accepts the source with case' do
       inspect_source(cop, source_with_case)
@@ -24,23 +24,27 @@ describe RuboCop::Cop::Style::EmptyCaseCondition do
   context 'given a case statement with an empty case' do
     context 'with multiple when branches and an else' do
       let(:source) do
-        ['case',
-         'when 1 == 2',
-         '  foo',
-         'when 1 == 1',
-         '  bar',
-         'else',
-         '  baz',
-         'end']
+        <<-END.strip_indent
+          case
+          when 1 == 2
+            foo
+          when 1 == 1
+            bar
+          else
+            baz
+          end
+        END
       end
       let(:corrected_source) do
-        ['if 1 == 2',
-         '  foo',
-         'elsif 1 == 1',
-         '  bar',
-         'else',
-         '  baz',
-         'end']
+        <<-END.strip_indent
+          if 1 == 2
+            foo
+          elsif 1 == 1
+            bar
+          else
+            baz
+          end
+        END
       end
 
       it_behaves_like 'detect/correct empty case, accept non-empty case'
@@ -48,19 +52,23 @@ describe RuboCop::Cop::Style::EmptyCaseCondition do
 
     context 'with multiple when branches and no else' do
       let(:source) do
-        ['case',
-         'when 1 == 2',
-         '  foo',
-         'when 1 == 1',
-         '  bar',
-         'end']
+        <<-END.strip_indent
+          case
+          when 1 == 2
+            foo
+          when 1 == 1
+            bar
+          end
+        END
       end
       let(:corrected_source) do
-        ['if 1 == 2',
-         '  foo',
-         'elsif 1 == 1',
-         '  bar',
-         'end']
+        <<-END.strip_indent
+          if 1 == 2
+            foo
+          elsif 1 == 1
+            bar
+          end
+        END
       end
 
       it_behaves_like 'detect/correct empty case, accept non-empty case'
@@ -68,19 +76,23 @@ describe RuboCop::Cop::Style::EmptyCaseCondition do
 
     context 'with a single when branch and an else' do
       let(:source) do
-        ['case',
-         'when 1 == 2',
-         '  foo',
-         'else',
-         '  bar',
-         'end']
+        <<-END.strip_indent
+          case
+          when 1 == 2
+            foo
+          else
+            bar
+          end
+        END
       end
       let(:corrected_source) do
-        ['if 1 == 2',
-         '  foo',
-         'else',
-         '  bar',
-         'end']
+        <<-END.strip_indent
+          if 1 == 2
+            foo
+          else
+            bar
+          end
+        END
       end
 
       it_behaves_like 'detect/correct empty case, accept non-empty case'
@@ -88,15 +100,19 @@ describe RuboCop::Cop::Style::EmptyCaseCondition do
 
     context 'with a single when branch and no else' do
       let(:source) do
-        ['case',
-         'when 1 == 2',
-         '  foo',
-         'end']
+        <<-END.strip_indent
+          case
+          when 1 == 2
+            foo
+          end
+        END
       end
       let(:corrected_source) do
-        ['if 1 == 2',
-         '  foo',
-         'end']
+        <<-END.strip_indent
+          if 1 == 2
+            foo
+          end
+        END
       end
 
       it_behaves_like 'detect/correct empty case, accept non-empty case'
@@ -104,23 +120,27 @@ describe RuboCop::Cop::Style::EmptyCaseCondition do
 
     context 'with a when branch including comma-delimited alternatives' do
       let(:source) do
-        ['case',
-         'when false',
-         '  foo',
-         'when nil, false, 1',
-         '  bar',
-         'when false, 1',
-         '  baz',
-         'end']
+        <<-END.strip_indent
+          case
+          when false
+            foo
+          when nil, false, 1
+            bar
+          when false, 1
+            baz
+          end
+        END
       end
       let(:corrected_source) do
-        ['if false',
-         '  foo',
-         'elsif nil || false || 1',
-         '  bar',
-         'elsif false || 1',
-         '  baz',
-         'end']
+        <<-END.strip_indent
+          if false
+            foo
+          elsif nil || false || 1
+            bar
+          elsif false || 1
+            baz
+          end
+        END
       end
 
       it_behaves_like 'detect/correct empty case, accept non-empty case'
@@ -128,17 +148,21 @@ describe RuboCop::Cop::Style::EmptyCaseCondition do
 
     context 'with when branches using then' do
       let(:source) do
-        ['case',
-         'when false then foo',
-         'when nil, false, 1 then bar',
-         'when false, 1 then baz',
-         'end']
+        <<-END.strip_indent
+          case
+          when false then foo
+          when nil, false, 1 then bar
+          when false, 1 then baz
+          end
+        END
       end
       let(:corrected_source) do
-        ['if false then foo',
-         'elsif nil || false || 1 then bar',
-         'elsif false || 1 then baz',
-         'end']
+        <<-END.strip_indent
+          if false then foo
+          elsif nil || false || 1 then bar
+          elsif false || 1 then baz
+          end
+        END
       end
 
       it_behaves_like 'detect/correct empty case, accept non-empty case'

--- a/spec/rubocop/cop/style/empty_line_after_magic_comment_spec.rb
+++ b/spec/rubocop/cop/style/empty_line_after_magic_comment_spec.rb
@@ -5,32 +5,40 @@ describe RuboCop::Cop::Style::EmptyLineAfterMagicComment do
   subject(:cop) { described_class.new(config) }
 
   it 'registers an offense for code that immediately follows comment' do
-    inspect_source(cop, ['# frozen_string_literal: true',
-                         'class Foo; end'])
+    inspect_source(cop, <<-END.strip_indent)
+      # frozen_string_literal: true
+      class Foo; end
+    END
     expect(cop.offenses.size).to eq(1)
     expect(cop.messages).to eq(['Add an empty line after magic comments.'])
   end
 
   it 'registers an offense for documentation immediately following comment' do
-    inspect_source(cop, ['# frozen_string_literal: true',
-                         '# Documentation for Foo',
-                         'class Foo; end'])
+    inspect_source(cop, <<-END.strip_indent)
+      # frozen_string_literal: true
+      # Documentation for Foo
+      class Foo; end
+    END
     expect(cop.offenses.size).to eq(1)
     expect(cop.messages).to eq(['Add an empty line after magic comments.'])
   end
 
   it 'registers an offense when multiple magic comments without empty line' do
-    inspect_source(cop, ['# encoding: utf-8',
-                         '# frozen_string_literal: true',
-                         'class Foo; end'])
+    inspect_source(cop, <<-END.strip_indent)
+      # encoding: utf-8
+      # frozen_string_literal: true
+      class Foo; end
+    END
     expect(cop.offenses.size).to eq(1)
     expect(cop.messages).to eq(['Add an empty line after magic comments.'])
   end
 
   it 'accepts code that separates the comment from the code with a newline' do
-    inspect_source(cop, ['# frozen_string_literal: true',
-                         '',
-                         'class Foo; end'])
+    inspect_source(cop, <<-END.strip_indent)
+      # frozen_string_literal: true
+
+      class Foo; end
+    END
     expect(cop.offenses).to be_empty
   end
 
@@ -45,32 +53,44 @@ describe RuboCop::Cop::Style::EmptyLineAfterMagicComment do
   end
 
   it 'autocorrects by adding a newline' do
-    new_source = autocorrect_source(cop, ['# frozen_string_literal: true',
-                                          'class Foo; end'])
+    new_source = autocorrect_source(cop, <<-END.strip_indent)
+      # frozen_string_literal: true
+      class Foo; end
+    END
 
-    expect(new_source).to eq(["# frozen_string_literal: true\n",
-                              'class Foo; end'].join("\n"))
+    expect(new_source).to eq(<<-END.strip_indent)
+      # frozen_string_literal: true\n
+      class Foo; end
+    END
   end
 
   it 'autocorrects by adding a newline above the documentation' do
-    new_source = autocorrect_source(cop, ['# frozen_string_literal: true',
-                                          '# Documentation for Foo',
-                                          'class Foo; end'])
+    new_source = autocorrect_source(cop, <<-END.strip_indent)
+      # frozen_string_literal: true
+      # Documentation for Foo
+      class Foo; end
+    END
 
-    expect(new_source).to eq(['# frozen_string_literal: true',
-                              '',
-                              '# Documentation for Foo',
-                              'class Foo; end'].join("\n"))
+    expect(new_source).to eq(<<-END.strip_indent)
+      # frozen_string_literal: true
+
+      # Documentation for Foo
+      class Foo; end
+    END
   end
 
   it 'autocorrects by adding a newline above the documentation' do
-    new_source = autocorrect_source(cop, ['# frozen_string_literal: true',
-                                          '# Documentation for Foo',
-                                          'class Foo; end'])
+    new_source = autocorrect_source(cop, <<-END.strip_indent)
+      # frozen_string_literal: true
+      # Documentation for Foo
+      class Foo; end
+    END
 
-    expect(new_source).to eq(['# frozen_string_literal: true',
-                              '',
-                              '# Documentation for Foo',
-                              'class Foo; end'].join("\n"))
+    expect(new_source).to eq(<<-END.strip_indent)
+      # frozen_string_literal: true
+
+      # Documentation for Foo
+      class Foo; end
+    END
   end
 end

--- a/spec/rubocop/cop/style/empty_lines_around_access_modifier_spec.rb
+++ b/spec/rubocop/cop/style/empty_lines_around_access_modifier_spec.rb
@@ -5,128 +5,142 @@ describe RuboCop::Cop::Style::EmptyLinesAroundAccessModifier do
 
   %w[private protected public module_function].each do |access_modifier|
     it "requires blank line before #{access_modifier}" do
-      inspect_source(cop,
-                     ['class Test',
-                      '  something',
-                      "  #{access_modifier}",
-                      '',
-                      '  def test; end',
-                      'end'])
+      inspect_source(cop, <<-END.strip_indent)
+        class Test
+          something
+          #{access_modifier}
+
+          def test; end
+        end
+      END
       expect(cop.offenses.size).to eq(1)
       expect(cop.messages)
         .to eq(["Keep a blank line before and after `#{access_modifier}`."])
     end
 
     it "requires blank line after #{access_modifier}" do
-      inspect_source(cop,
-                     ['class Test',
-                      '  something',
-                      '',
-                      "  #{access_modifier}",
-                      '  def test; end',
-                      'end'])
+      inspect_source(cop, <<-END.strip_indent)
+        class Test
+          something
+
+          #{access_modifier}
+          def test; end
+        end
+      END
       expect(cop.offenses.size).to eq(1)
       expect(cop.messages)
         .to eq(["Keep a blank line before and after `#{access_modifier}`."])
     end
 
     it "ignores comment line before #{access_modifier}" do
-      inspect_source(cop,
-                     ['class Test',
-                      '  something',
-                      '',
-                      '  # This comment is fine',
-                      "  #{access_modifier}",
-                      '',
-                      '  def test; end',
-                      'end'])
+      inspect_source(cop, <<-END.strip_indent)
+        class Test
+          something
+
+          # This comment is fine
+          #{access_modifier}
+
+          def test; end
+        end
+      END
       expect(cop.offenses).to be_empty
     end
 
     it "ignores #{access_modifier} inside a method call" do
-      inspect_source(cop,
-                     ['class Test',
-                      '  def #{access_modifier}?',
-                      "    #{access_modifier}",
-                      '  end',
-                      'end'])
+      inspect_source(cop, <<-END.strip_indent)
+        class Test
+          def #{access_modifier}?
+            #{access_modifier}
+          end
+        end
+      END
       expect(cop.offenses).to be_empty
     end
 
     it "ignores #{access_modifier} deep inside a method call" do
-      inspect_source(cop,
-                     ['class Test',
-                      "  def #{access_modifier}?",
-                      '    if true',
-                      "      #{access_modifier}",
-                      '    end',
-                      '  end',
-                      'end'])
+      inspect_source(cop, <<-END.strip_indent)
+        class Test
+          def #{access_modifier}?
+            if true
+              #{access_modifier}
+            end
+          end
+        end
+      END
       expect(cop.offenses).to be_empty
     end
 
     it "ignores #{access_modifier} with a right-hand-side condition" do
-      inspect_source(cop,
-                     ['class Test',
-                      "  def #{access_modifier}?",
-                      "    #{access_modifier} if true",
-                      '  end',
-                      'end'])
+      inspect_source(cop, <<-END.strip_indent)
+        class Test
+          def #{access_modifier}?
+            #{access_modifier} if true
+          end
+        end
+      END
       expect(cop.offenses).to be_empty
     end
 
     it "autocorrects blank line before #{access_modifier}" do
-      corrected = autocorrect_source(cop,
-                                     ['class Test',
-                                      '  something',
-                                      "  #{access_modifier}",
-                                      '',
-                                      '  def test; end',
-                                      'end'])
-      expect(corrected).to eq(['class Test',
-                               '  something',
-                               '',
-                               "  #{access_modifier}",
-                               '',
-                               '  def test; end',
-                               'end'].join("\n"))
+      corrected = autocorrect_source(cop, <<-END.strip_indent)
+        class Test
+          something
+          #{access_modifier}
+
+          def test; end
+        end
+      END
+      expect(corrected).to eq(<<-END.strip_indent)
+        class Test
+          something
+
+          #{access_modifier}
+
+          def test; end
+        end
+      END
     end
 
     it 'autocorrects blank line after #{access_modifier}' do
-      corrected = autocorrect_source(cop,
-                                     ['class Test',
-                                      '  something',
-                                      '',
-                                      "  #{access_modifier}",
-                                      '  def test; end',
-                                      'end'])
-      expect(corrected).to eq(['class Test',
-                               '  something',
-                               '',
-                               "  #{access_modifier}",
-                               '',
-                               '  def test; end',
-                               'end'].join("\n"))
+      corrected = autocorrect_source(cop, <<-END.strip_indent)
+        class Test
+          something
+
+          #{access_modifier}
+          def test; end
+        end
+      END
+      expect(corrected).to eq(<<-END.strip_indent)
+        class Test
+          something
+
+          #{access_modifier}
+
+          def test; end
+        end
+      END
     end
 
     it 'accepts missing blank line when at the beginning of class/module' do
-      inspect_source(cop,
-                     ['class Test',
-                      "  #{access_modifier}",
-                      '',
-                      '  def test; end',
-                      'end'])
+      inspect_source(cop, <<-END.strip_indent)
+        class Test
+          #{access_modifier}
+
+          def test; end
+        end
+      END
       expect(cop.offenses).to be_empty
     end
 
     it "requires blank line after, but not before, #{access_modifier} " \
        'when at the beginning of class/module' do
-      inspect_source(cop,
-                     ['class Test',
-                      "  #{access_modifier}",
-                      '  def test',
-                      '  end',
-                      'end'])
+      inspect_source(cop, <<-END.strip_indent)
+        class Test
+          #{access_modifier}
+          def test
+          end
+        end
+      END
       expect(cop.offenses.size).to eq(1)
       expect(cop.messages)
         .to eq(["Keep a blank line after `#{access_modifier}`."])
@@ -135,32 +149,35 @@ describe RuboCop::Cop::Style::EmptyLinesAroundAccessModifier do
     context 'at the beginning of block' do
       context 'for blocks defined with do' do
         it 'accepts missing blank line' do
-          inspect_source(cop,
-                         ['included do',
-                          "  #{access_modifier}",
-                          '',
-                          '  def test; end',
-                          'end'])
+          inspect_source(cop, <<-END.strip_indent)
+            included do
+              #{access_modifier}
+
+              def test; end
+            end
+          END
           expect(cop.offenses).to be_empty
         end
 
         it 'accepts missing blank line with arguments' do
-          inspect_source(cop,
-                         ['included do |foo|',
-                          "  #{access_modifier}",
-                          '',
-                          '  def test; end',
-                          'end'])
+          inspect_source(cop, <<-END.strip_indent)
+            included do |foo|
+              #{access_modifier}
+
+              def test; end
+            end
+          END
           expect(cop.offenses).to be_empty
         end
 
         it "requires blank line after, but not before, #{access_modifier}" do
-          inspect_source(cop,
-                         ['included do',
-                          "  #{access_modifier}",
-                          '  def test',
-                          '  end',
-                          'end'])
+          inspect_source(cop, <<-END.strip_indent)
+            included do
+              #{access_modifier}
+              def test
+              end
+            end
+          END
           expect(cop.offenses.size).to eq(1)
           expect(cop.messages)
             .to eq(["Keep a blank line after `#{access_modifier}`."])
@@ -169,45 +186,49 @@ describe RuboCop::Cop::Style::EmptyLinesAroundAccessModifier do
 
       context 'for blocks defined with {}' do
         it 'accepts missing blank line' do
-          inspect_source(cop,
-                         ['included {',
-                          "  #{access_modifier}",
-                          '',
-                          '  def test; end',
-                          '}'])
+          inspect_source(cop, <<-END.strip_indent)
+            included {
+              #{access_modifier}
+
+              def test; end
+            }
+          END
           expect(cop.offenses).to be_empty
         end
 
         it 'accepts missing blank line with arguments' do
-          inspect_source(cop,
-                         ['included { |foo|',
-                          "  #{access_modifier}",
-                          '',
-                          '  def test; end',
-                          '}'])
+          inspect_source(cop, <<-END.strip_indent)
+            included { |foo|
+              #{access_modifier}
+
+              def test; end
+            }
+          END
           expect(cop.offenses).to be_empty
         end
       end
     end
 
     it 'accepts missing blank line when at the end of block' do
-      inspect_source(cop,
-                     ['class Test',
-                      '  def test; end',
-                      '',
-                      "  #{access_modifier}",
-                      'end'])
+      inspect_source(cop, <<-END.strip_indent)
+        class Test
+          def test; end
+
+          #{access_modifier}
+        end
+      END
       expect(cop.offenses).to be_empty
     end
 
     it 'recognizes blank lines with DOS style line endings' do
-      inspect_source(cop,
-                     ["class Test\r",
-                      "\r",
-                      "  #{access_modifier}\r",
-                      "\r",
-                      "  def test; end\r",
-                      "end\r"])
+      inspect_source(cop, <<-END.strip_indent)
+        class Test\r
+        \r
+          #{access_modifier}\r
+        \r
+          def test; end\r
+        end\r
+      END
       expect(cop.offenses).to be_empty
     end
   end

--- a/spec/rubocop/cop/style/empty_lines_around_block_body_spec.rb
+++ b/spec/rubocop/cop/style/empty_lines_around_block_body_spec.rb
@@ -47,10 +47,11 @@ describe RuboCop::Cop::Style::EmptyLinesAroundBlockBody, :config do
       end
 
       it 'is not fooled by single line blocks' do
-        inspect_source(cop,
-                       ["some_method #{open} do_something #{close}",
-                        '',
-                        'something_else'])
+        inspect_source(cop, <<-END.strip_indent)
+          some_method #{open} do_something #{close}
+
+          something_else
+        END
         expect(cop.offenses).to be_empty
       end
     end
@@ -88,9 +89,10 @@ describe RuboCop::Cop::Style::EmptyLinesAroundBlockBody, :config do
       end
 
       it 'is not fooled by single line blocks' do
-        inspect_source(cop,
-                       ["some_method #{open} do_something #{close}",
-                        'something_else'])
+        inspect_source(cop, <<-END.strip_indent)
+          some_method #{open} do_something #{close}
+          something_else
+        END
         expect(cop.offenses).to be_empty
       end
     end

--- a/spec/rubocop/cop/style/empty_lines_around_class_body_spec.rb
+++ b/spec/rubocop/cop/style/empty_lines_around_class_body_spec.rb
@@ -13,59 +13,69 @@ describe RuboCop::Cop::Style::EmptyLinesAroundClassBody, :config do
     let(:cop_config) { { 'EnforcedStyle' => 'no_empty_lines' } }
 
     it 'registers an offense for class body starting with a blank' do
-      inspect_source(cop,
-                     ['class SomeClass',
-                      '',
-                      '  do_something',
-                      'end'])
+      inspect_source(cop, <<-END.strip_indent)
+        class SomeClass
+
+          do_something
+        end
+      END
       expect(cop.messages)
         .to eq(['Extra empty line detected at class body beginning.'])
     end
 
     it 'autocorrects class body containing only a blank' do
-      corrected = autocorrect_source(cop,
-                                     ['class SomeClass',
-                                      '',
-                                      'end'])
-      expect(corrected).to eq ['class SomeClass',
-                               'end'].join("\n")
+      corrected = autocorrect_source(cop, <<-END.strip_indent)
+        class SomeClass
+
+        end
+      END
+      expect(corrected).to eq <<-END.strip_indent
+        class SomeClass
+        end
+      END
     end
 
     it 'registers an offense for class body ending with a blank' do
-      inspect_source(cop,
-                     ['class SomeClass',
-                      '  do_something',
-                      '',
-                      'end'])
+      inspect_source(cop, <<-END.strip_indent)
+        class SomeClass
+          do_something
+
+        end
+      END
       expect(cop.messages)
         .to eq(['Extra empty line detected at class body end.'])
     end
 
     it 'registers an offense for singleton class body starting with a blank' do
-      inspect_source(cop,
-                     ['class << self',
-                      '',
-                      '  do_something',
-                      'end'])
+      inspect_source(cop, <<-END.strip_indent)
+        class << self
+
+          do_something
+        end
+      END
       expect(cop.messages)
         .to eq(['Extra empty line detected at class body beginning.'])
     end
 
     it 'autocorrects singleton class body containing only a blank' do
-      corrected = autocorrect_source(cop,
-                                     ['class << self',
-                                      '',
-                                      'end'])
-      expect(corrected).to eq ['class << self',
-                               'end'].join("\n")
+      corrected = autocorrect_source(cop, <<-END.strip_indent)
+        class << self
+
+        end
+      END
+      expect(corrected).to eq <<-END.strip_indent
+        class << self
+        end
+      END
     end
 
     it 'registers an offense for singleton class body ending with a blank' do
-      inspect_source(cop,
-                     ['class << self',
-                      '  do_something',
-                      '',
-                      'end'])
+      inspect_source(cop, <<-END.strip_indent)
+        class << self
+          do_something
+
+        end
+      END
       expect(cop.messages)
         .to eq(['Extra empty line detected at class body end.'])
     end
@@ -76,10 +86,11 @@ describe RuboCop::Cop::Style::EmptyLinesAroundClassBody, :config do
 
     it 'registers an offense for class body not starting or ending with a ' \
        'blank' do
-      inspect_source(cop,
-                     ['class SomeClass',
-                      '  do_something',
-                      'end'])
+      inspect_source(cop, <<-END.strip_indent)
+        class SomeClass
+          do_something
+        end
+      END
       expect(cop.messages).to eq(['Empty line missing at class body beginning.',
                                   'Empty line missing at class body end.'])
     end
@@ -91,23 +102,27 @@ describe RuboCop::Cop::Style::EmptyLinesAroundClassBody, :config do
     end
 
     it 'autocorrects beginning and end' do
-      new_source = autocorrect_source(cop,
-                                      ['class SomeClass',
-                                       '  do_something',
-                                       'end'])
-      expect(new_source).to eq(['class SomeClass',
-                                '',
-                                '  do_something',
-                                '',
-                                'end'].join("\n"))
+      new_source = autocorrect_source(cop, <<-END.strip_indent)
+        class SomeClass
+          do_something
+        end
+      END
+      expect(new_source).to eq(<<-END.strip_indent)
+        class SomeClass
+
+          do_something
+
+        end
+      END
     end
 
     it 'registers an offense for singleton class body not starting or ending ' \
        'with a blank' do
-      inspect_source(cop,
-                     ['class << self',
-                      '  do_something',
-                      'end'])
+      inspect_source(cop, <<-END.strip_indent)
+        class << self
+          do_something
+        end
+      END
       expect(cop.messages).to eq(['Empty line missing at class body beginning.',
                                   'Empty line missing at class body end.'])
     end
@@ -119,15 +134,18 @@ describe RuboCop::Cop::Style::EmptyLinesAroundClassBody, :config do
     end
 
     it 'autocorrects beginning and end for `class << self`' do
-      new_source = autocorrect_source(cop,
-                                      ['class << self',
-                                       '  do_something',
-                                       'end'])
-      expect(new_source).to eq(['class << self',
-                                '',
-                                '  do_something',
-                                '',
-                                'end'].join("\n"))
+      new_source = autocorrect_source(cop, <<-END.strip_indent)
+        class << self
+          do_something
+        end
+      END
+      expect(new_source).to eq(<<-END.strip_indent)
+        class << self
+
+          do_something
+
+        end
+      END
     end
   end
 
@@ -136,151 +154,164 @@ describe RuboCop::Cop::Style::EmptyLinesAroundClassBody, :config do
 
     context 'when only child is class' do
       it 'requires no empty lines for namespace' do
-        inspect_source(cop,
-                       ['class Parent < Base',
-                        '  class Child',
-                        '',
-                        '    do_something',
-                        '',
-                        '  end',
-                        'end'])
+        inspect_source(cop, <<-END.strip_indent)
+          class Parent < Base
+            class Child
+
+              do_something
+
+            end
+          end
+        END
         expect(cop.messages).to eq([])
       end
 
       it 'registers offence for namespace body starting with a blank' do
-        inspect_source(cop,
-                       ['class Parent',
-                        '',
-                        '  class Child',
-                        '',
-                        '    do_something',
-                        '',
-                        '  end',
-                        'end'])
+        inspect_source(cop, <<-END.strip_indent)
+          class Parent
+
+            class Child
+
+              do_something
+
+            end
+          end
+        END
         expect(cop.messages).to eq([extra_begin])
       end
 
       it 'registers offence for namespace body ending with a blank' do
-        inspect_source(cop,
-                       ['class Parent',
-                        '  class Child',
-                        '',
-                        '    do_something',
-                        '',
-                        '  end',
-                        '',
-                        'end'])
+        inspect_source(cop, <<-END.strip_indent)
+          class Parent
+            class Child
+
+              do_something
+
+            end
+
+          end
+        END
         expect(cop.messages).to eq([extra_end])
       end
 
       it 'registers offences for namespaced class body not starting '\
           'with a blank' do
-        inspect_source(cop,
-                       ['class Parent',
-                        '  class Child',
-                        '    do_something',
-                        '',
-                        '  end',
-                        'end'])
+        inspect_source(cop, <<-END.strip_indent)
+          class Parent
+            class Child
+              do_something
+
+            end
+          end
+        END
         expect(cop.messages).to eq([missing_begin])
       end
 
       it 'registers offences for namespaced class body not ending '\
           'with a blank' do
-        inspect_source(cop,
-                       ['class Parent',
-                        '  class Child',
-                        '',
-                        '    do_something',
-                        '  end',
-                        'end'])
+        inspect_source(cop, <<-END.strip_indent)
+          class Parent
+            class Child
+
+              do_something
+            end
+          end
+        END
         expect(cop.messages).to eq([missing_end])
       end
 
       it 'autocorrects beginning and end' do
-        new_source = autocorrect_source(cop,
-                                        ['class Parent < Base',
-                                         '',
-                                         '  class Child',
-                                         '    do_something',
-                                         '  end',
-                                         '',
-                                         'end'])
-        expect(new_source).to eq(['class Parent < Base',
-                                  '  class Child',
-                                  '',
-                                  '    do_something',
-                                  '',
-                                  '  end',
-                                  'end'].join("\n"))
+        new_source = autocorrect_source(cop, <<-END.strip_indent)
+          class Parent < Base
+
+            class Child
+              do_something
+            end
+
+          end
+        END
+        expect(new_source).to eq(<<-END.strip_indent)
+          class Parent < Base
+            class Child
+
+              do_something
+
+            end
+          end
+        END
       end
     end
 
     context 'when only child is module' do
       it 'requires no empty lines for namespace' do
-        inspect_source(cop,
-                       ['class Parent',
-                        '  module Child',
-                        '    do_something',
-                        '  end',
-                        'end'])
+        inspect_source(cop, <<-END.strip_indent)
+          class Parent
+            module Child
+              do_something
+            end
+          end
+        END
         expect(cop.messages).to eq([])
       end
 
       it 'registers offence for namespace body starting with a blank' do
-        inspect_source(cop,
-                       ['class Parent',
-                        '',
-                        '  module Child',
-                        '    do_something',
-                        '  end',
-                        'end'])
+        inspect_source(cop, <<-END.strip_indent)
+          class Parent
+
+            module Child
+              do_something
+            end
+          end
+        END
         expect(cop.messages).to eq([extra_begin])
       end
 
       it 'registers offence for namespace body ending with a blank' do
-        inspect_source(cop,
-                       ['class Parent',
-                        '  module Child',
-                        '    do_something',
-                        '  end',
-                        '',
-                        'end'])
+        inspect_source(cop, <<-END.strip_indent)
+          class Parent
+            module Child
+              do_something
+            end
+
+          end
+        END
         expect(cop.messages).to eq([extra_end])
       end
     end
 
     context 'when has multiple child classes' do
       it 'requires empty lines for namespace' do
-        inspect_source(cop,
-                       ['class Parent',
-                        '',
-                        '  class Mom',
-                        '',
-                        '    do_something',
-                        '',
-                        '  end',
-                        '  class Dad',
-                        '',
-                        '  end',
-                        '',
-                        'end'])
+        inspect_source(cop, <<-END.strip_indent)
+          class Parent
+
+            class Mom
+
+              do_something
+
+            end
+            class Dad
+
+            end
+
+          end
+        END
         expect(cop.messages).to eq([])
       end
 
       it 'registers offences for namespace body starting '\
         'and ending without a blank' do
-        inspect_source(cop,
-                       ['class Parent',
-                        '  class Mom',
-                        '',
-                        '    do_something',
-                        '',
-                        '  end',
-                        '  class Dad',
-                        '',
-                        '  end',
-                        'end'])
+        inspect_source(cop, <<-END.strip_indent)
+          class Parent
+            class Mom
+
+              do_something
+
+            end
+            class Dad
+
+            end
+          end
+        END
         expect(cop.messages).to eq([missing_begin, missing_end])
       end
     end

--- a/spec/rubocop/cop/style/empty_lines_around_method_body_spec.rb
+++ b/spec/rubocop/cop/style/empty_lines_around_method_body_spec.rb
@@ -4,11 +4,12 @@ describe RuboCop::Cop::Style::EmptyLinesAroundMethodBody do
   subject(:cop) { described_class.new }
 
   it 'registers an offense for method body starting with a blank' do
-    inspect_source(cop,
-                   ['def some_method',
-                    '',
-                    '  do_something',
-                    'end'])
+    inspect_source(cop, <<-END.strip_indent)
+      def some_method
+
+        do_something
+      end
+    END
     expect(cop.messages)
       .to eq(['Extra empty line detected at method body beginning.'])
   end
@@ -27,62 +28,72 @@ describe RuboCop::Cop::Style::EmptyLinesAroundMethodBody do
   end
 
   it 'autocorrects method body starting with a blank' do
-    corrected = autocorrect_source(cop,
-                                   ['def some_method',
-                                    '',
-                                    '  do_something',
-                                    'end'])
-    expect(corrected).to eq ['def some_method',
-                             '  do_something',
-                             'end'].join("\n")
+    corrected = autocorrect_source(cop, <<-END.strip_indent)
+      def some_method
+
+        do_something
+      end
+    END
+    expect(corrected).to eq <<-END.strip_indent
+      def some_method
+        do_something
+      end
+    END
   end
 
   it 'registers an offense for class method body starting with a blank' do
-    inspect_source(cop,
-                   ['def Test.some_method',
-                    '',
-                    '  do_something',
-                    'end'])
+    inspect_source(cop, <<-END.strip_indent)
+      def Test.some_method
+
+        do_something
+      end
+    END
     expect(cop.messages)
       .to eq(['Extra empty line detected at method body beginning.'])
   end
 
   it 'autocorrects class method body starting with a blank' do
-    corrected = autocorrect_source(cop,
-                                   ['def Test.some_method',
-                                    '',
-                                    '  do_something',
-                                    'end'])
-    expect(corrected).to eq ['def Test.some_method',
-                             '  do_something',
-                             'end'].join("\n")
+    corrected = autocorrect_source(cop, <<-END.strip_indent)
+      def Test.some_method
+
+        do_something
+      end
+    END
+    expect(corrected).to eq <<-END.strip_indent
+      def Test.some_method
+        do_something
+      end
+    END
   end
 
   it 'registers an offense for method body ending with a blank' do
-    inspect_source(cop,
-                   ['def some_method',
-                    '  do_something',
-                    '',
-                    'end'])
+    inspect_source(cop, <<-END.strip_indent)
+      def some_method
+        do_something
+
+      end
+    END
     expect(cop.messages)
       .to eq(['Extra empty line detected at method body end.'])
   end
 
   it 'registers an offense for class method body ending with a blank' do
-    inspect_source(cop,
-                   ['def Test.some_method',
-                    '  do_something',
-                    '',
-                    'end'])
+    inspect_source(cop, <<-END.strip_indent)
+      def Test.some_method
+        do_something
+
+      end
+    END
     expect(cop.messages)
       .to eq(['Extra empty line detected at method body end.'])
   end
 
   it 'is not fooled by single line methods' do
-    inspect_source(cop,
-                   ['def some_method; do_something; end',
-                    '',
-                    'something_else'])
+    inspect_source(cop, <<-END.strip_indent)
+      def some_method; do_something; end
+
+      something_else
+    END
     expect(cop.offenses).to be_empty
   end
 end

--- a/spec/rubocop/cop/style/empty_lines_around_module_body_spec.rb
+++ b/spec/rubocop/cop/style/empty_lines_around_module_body_spec.rb
@@ -13,35 +13,40 @@ describe RuboCop::Cop::Style::EmptyLinesAroundModuleBody, :config do
     let(:cop_config) { { 'EnforcedStyle' => 'no_empty_lines' } }
 
     it 'registers an offense for module body starting with a blank' do
-      inspect_source(cop,
-                     ['module SomeModule',
-                      '',
-                      '  do_something',
-                      'end'])
+      inspect_source(cop, <<-END.strip_indent)
+        module SomeModule
+
+          do_something
+        end
+      END
       expect(cop.messages)
         .to eq(['Extra empty line detected at module body beginning.'])
     end
 
     it 'registers an offense for module body ending with a blank' do
-      inspect_source(cop,
-                     ['module SomeModule',
-                      '  do_something',
-                      '',
-                      'end'])
+      inspect_source(cop, <<-END.strip_indent)
+        module SomeModule
+          do_something
+
+        end
+      END
       expect(cop.messages)
         .to eq(['Extra empty line detected at module body end.'])
     end
 
     it 'autocorrects beginning and end' do
-      new_source = autocorrect_source(cop,
-                                      ['module SomeModule',
-                                       '',
-                                       '  do_something',
-                                       '',
-                                       'end'])
-      expect(new_source).to eq(['module SomeModule',
-                                '  do_something',
-                                'end'].join("\n"))
+      new_source = autocorrect_source(cop, <<-END.strip_indent)
+        module SomeModule
+
+          do_something
+
+        end
+      END
+      expect(new_source).to eq(<<-END.strip_indent)
+        module SomeModule
+          do_something
+        end
+      END
     end
   end
 
@@ -50,34 +55,39 @@ describe RuboCop::Cop::Style::EmptyLinesAroundModuleBody, :config do
 
     it 'registers an offense for module body not starting or ending with a ' \
        'blank' do
-      inspect_source(cop,
-                     ['module SomeModule',
-                      '  do_something',
-                      'end'])
+      inspect_source(cop, <<-END.strip_indent)
+        module SomeModule
+          do_something
+        end
+      END
       expect(cop.messages)
         .to eq(['Empty line missing at module body beginning.',
                 'Empty line missing at module body end.'])
     end
 
     it 'registers an offense for module body not ending with a blank' do
-      inspect_source(cop,
-                     ['module SomeModule',
-                      '',
-                      '  do_something',
-                      'end'])
+      inspect_source(cop, <<-END.strip_indent)
+        module SomeModule
+
+          do_something
+        end
+      END
       expect(cop.messages).to eq(['Empty line missing at module body end.'])
     end
 
     it 'autocorrects beginning and end' do
-      new_source = autocorrect_source(cop,
-                                      ['module SomeModule',
-                                       '  do_something',
-                                       'end'])
-      expect(new_source).to eq(['module SomeModule',
-                                '',
-                                '  do_something',
-                                '',
-                                'end'].join("\n"))
+      new_source = autocorrect_source(cop, <<-END.strip_indent)
+        module SomeModule
+          do_something
+        end
+      END
+      expect(new_source).to eq(<<-END.strip_indent)
+        module SomeModule
+
+          do_something
+
+        end
+      END
     end
 
     it 'ignores modules with an empty body' do
@@ -92,151 +102,164 @@ describe RuboCop::Cop::Style::EmptyLinesAroundModuleBody, :config do
 
     context 'when only child is class' do
       it 'requires no empty lines for namespace' do
-        inspect_source(cop,
-                       ['module Parent',
-                        '  module Child',
-                        '',
-                        '    do_something',
-                        '',
-                        '  end',
-                        'end'])
+        inspect_source(cop, <<-END.strip_indent)
+          module Parent
+            module Child
+
+              do_something
+
+            end
+          end
+        END
         expect(cop.messages).to eq([])
       end
 
       it 'registers offence for namespace body starting with a blank' do
-        inspect_source(cop,
-                       ['module Parent',
-                        '',
-                        '  module Child',
-                        '',
-                        '    do_something',
-                        '',
-                        '  end',
-                        'end'])
+        inspect_source(cop, <<-END.strip_indent)
+          module Parent
+
+            module Child
+
+              do_something
+
+            end
+          end
+        END
         expect(cop.messages).to eq([extra_begin])
       end
 
       it 'registers offence for namespace body ending with a blank' do
-        inspect_source(cop,
-                       ['module Parent',
-                        '  module Child',
-                        '',
-                        '    do_something',
-                        '',
-                        '  end',
-                        '',
-                        'end'])
+        inspect_source(cop, <<-END.strip_indent)
+          module Parent
+            module Child
+
+              do_something
+
+            end
+
+          end
+        END
         expect(cop.messages).to eq([extra_end])
       end
 
       it 'registers offences for namespaced module body not starting '\
           'with a blank' do
-        inspect_source(cop,
-                       ['module Parent',
-                        '  module Child',
-                        '    do_something',
-                        '',
-                        '  end',
-                        'end'])
+        inspect_source(cop, <<-END.strip_indent)
+          module Parent
+            module Child
+              do_something
+
+            end
+          end
+        END
         expect(cop.messages).to eq([missing_begin])
       end
 
       it 'registers offences for namespaced module body not ending '\
           'with a blank' do
-        inspect_source(cop,
-                       ['module Parent',
-                        '  module Child',
-                        '',
-                        '    do_something',
-                        '  end',
-                        'end'])
+        inspect_source(cop, <<-END.strip_indent)
+          module Parent
+            module Child
+
+              do_something
+            end
+          end
+        END
         expect(cop.messages).to eq([missing_end])
       end
 
       it 'autocorrects beginning and end' do
-        new_source = autocorrect_source(cop,
-                                        ['module Parent',
-                                         '',
-                                         '  module Child',
-                                         '    do_something',
-                                         '  end',
-                                         '',
-                                         'end'])
-        expect(new_source).to eq(['module Parent',
-                                  '  module Child',
-                                  '',
-                                  '    do_something',
-                                  '',
-                                  '  end',
-                                  'end'].join("\n"))
+        new_source = autocorrect_source(cop, <<-END.strip_indent)
+          module Parent
+
+            module Child
+              do_something
+            end
+
+          end
+        END
+        expect(new_source).to eq(<<-END.strip_indent)
+          module Parent
+            module Child
+
+              do_something
+
+            end
+          end
+        END
       end
     end
 
     context 'when only child is class' do
       it 'requires no empty lines for namespace' do
-        inspect_source(cop,
-                       ['module Parent',
-                        '  class SomeClass',
-                        '    do_something',
-                        '  end',
-                        'end'])
+        inspect_source(cop, <<-END.strip_indent)
+          module Parent
+            class SomeClass
+              do_something
+            end
+          end
+        END
         expect(cop.messages).to eq([])
       end
 
       it 'registers offence for namespace body starting with a blank' do
-        inspect_source(cop,
-                       ['module Parent',
-                        '',
-                        '  class SomeClass',
-                        '    do_something',
-                        '  end',
-                        'end'])
+        inspect_source(cop, <<-END.strip_indent)
+          module Parent
+
+            class SomeClass
+              do_something
+            end
+          end
+        END
         expect(cop.messages).to eq([extra_begin])
       end
 
       it 'registers offence for namespace body ending with a blank' do
-        inspect_source(cop,
-                       ['module Parent',
-                        '  class SomeClass',
-                        '    do_something',
-                        '  end',
-                        '',
-                        'end'])
+        inspect_source(cop, <<-END.strip_indent)
+          module Parent
+            class SomeClass
+              do_something
+            end
+
+          end
+        END
         expect(cop.messages).to eq([extra_end])
       end
     end
 
     context 'when has multiple child modules' do
       it 'requires empty lines for namespace' do
-        inspect_source(cop,
-                       ['module Parent',
-                        '',
-                        '  module Mom',
-                        '',
-                        '    do_something',
-                        '',
-                        '  end',
-                        '  module Dad',
-                        '',
-                        '  end',
-                        '',
-                        'end'])
+        inspect_source(cop, <<-END.strip_indent)
+          module Parent
+
+            module Mom
+
+              do_something
+
+            end
+            module Dad
+
+            end
+
+          end
+        END
         expect(cop.messages).to eq([])
       end
 
       it 'registers offences for namespace body starting '\
         'and ending without a blank' do
-        inspect_source(cop,
-                       ['module Parent',
-                        '  module Mom',
-                        '',
-                        '    do_something',
-                        '',
-                        '  end',
-                        '  module Dad',
-                        '',
-                        '  end',
-                        'end'])
+        inspect_source(cop, <<-END.strip_indent)
+          module Parent
+            module Mom
+
+              do_something
+
+            end
+            module Dad
+
+            end
+          end
+        END
         expect(cop.messages).to eq([missing_begin, missing_end])
       end
     end

--- a/spec/rubocop/cop/style/empty_lines_spec.rb
+++ b/spec/rubocop/cop/style/empty_lines_spec.rb
@@ -37,13 +37,15 @@ describe RuboCop::Cop::Style::EmptyLines do
   end
 
   it 'does not register an offense for heredocs with empty lines inside' do
-    inspect_source(cop, ['str = <<-TEXT',
-                         'line 1',
-                         '',
-                         '',
-                         'line 2',
-                         'TEXT',
-                         'puts str'])
+    inspect_source(cop, <<-END.strip_indent)
+      str = <<-TEXT
+      line 1
+
+
+      line 2
+      TEXT
+      puts str
+    END
     expect(cop.offenses).to be_empty
   end
 end

--- a/spec/rubocop/cop/style/empty_literal_spec.rb
+++ b/spec/rubocop/cop/style/empty_literal_spec.rb
@@ -85,13 +85,17 @@ describe RuboCop::Cop::Style::EmptyLiteral do
 
     it 'auto-corrects Hash.new to {} in various contexts' do
       new_source =
-        autocorrect_source(cop, ['test = Hash.new',
-                                 'Hash.new.merge("a" => 3)',
-                                 'yadayada.map { a }.reduce(Hash.new, :merge)'])
+        autocorrect_source(cop, <<-END.strip_indent)
+          test = Hash.new
+          Hash.new.merge("a" => 3)
+          yadayada.map { a }.reduce(Hash.new, :merge)
+        END
       expect(new_source)
-        .to eq(['test = {}',
-                '{}.merge("a" => 3)',
-                'yadayada.map { a }.reduce({}, :merge)'].join("\n"))
+        .to eq(<<-END.strip_indent)
+          test = {}
+          {}.merge("a" => 3)
+          yadayada.map { a }.reduce({}, :merge)
+        END
     end
 
     it 'auto-correct Hash.new to {} as the only parameter to a method' do
@@ -164,9 +168,11 @@ describe RuboCop::Cop::Style::EmptyLiteral do
       let(:ruby_version) { 2.3 }
 
       it 'does not register an offense for String.new' do
-        inspect_source(cop, ['# encoding: utf-8',
-                             '# frozen_string_literal: true',
-                             'test = String.new'])
+        inspect_source(cop, <<-END.strip_indent)
+          # encoding: utf-8
+          # frozen_string_literal: true
+          test = String.new
+        END
 
         expect(cop.offenses).to be_empty
       end

--- a/spec/rubocop/cop/style/encoding_spec.rb
+++ b/spec/rubocop/cop/style/encoding_spec.rb
@@ -27,8 +27,10 @@ describe RuboCop::Cop::Style::Encoding, :config do
 
     it 'registers an offense when encoding present but only ASCII ' \
        'characters' do
-      inspect_source(cop, ['# encoding: utf-8',
-                           'def foo() end'])
+      inspect_source(cop, <<-END.strip_indent)
+        # encoding: utf-8
+        def foo() end
+      END
 
       expect(cop.offenses.size).to eq(1)
       expect(cop.messages).to eq(
@@ -43,23 +45,29 @@ describe RuboCop::Cop::Style::Encoding, :config do
     end
 
     it 'accepts encoding on first line' do
-      inspect_source(cop, ['# encoding: utf-8',
-                           'def foo() \'ä\' end'])
+      inspect_source(cop, <<-END.strip_indent)
+        # encoding: utf-8
+        def foo() \'ä\' end
+      END
 
       expect(cop.offenses).to be_empty
     end
 
     it 'accepts encoding on second line when shebang present' do
-      inspect_source(cop, ['#!/usr/bin/env ruby',
-                           '# encoding: utf-8',
-                           'def foo() \'ä\' end'])
+      inspect_source(cop, <<-END.strip_indent)
+        #!/usr/bin/env ruby
+        # encoding: utf-8
+        def foo() \'ä\' end
+      END
 
       expect(cop.messages).to be_empty
     end
 
     it 'registers an offense when encoding is in the wrong place' do
-      inspect_source(cop, ['def foo() \'ä\' end',
-                           '# encoding: utf-8'])
+      inspect_source(cop, <<-END.strip_indent)
+        def foo() \'ä\' end
+        # encoding: utf-8
+      END
 
       expect(cop.offenses.size).to eq(1)
       expect(cop.messages).to eq(
@@ -68,31 +76,44 @@ describe RuboCop::Cop::Style::Encoding, :config do
     end
 
     it 'accepts encoding inserted by magic_encoding gem' do
-      inspect_source(cop, ['# -*- encoding : utf-8 -*-',
-                           'def foo() \'ä\' end'])
+      inspect_source(cop, <<-END.strip_indent)
+        # -*- encoding : utf-8 -*-
+        def foo() \'ä\' end
+      END
 
       expect(cop.messages).to be_empty
     end
 
     it 'accepts vim-style encoding comments' do
-      inspect_source(cop, ['# vim:filetype=ruby, fileencoding=utf-8',
-                           'def foo() \'ä\' end'])
+      inspect_source(cop, <<-END.strip_indent)
+        # vim:filetype=ruby, fileencoding=utf-8
+        def foo() \'ä\' end
+      END
       expect(cop.messages).to be_empty
     end
 
     context 'auto-correct' do
       it 'inserts an encoding comment on the first line when there are ' \
          'non ASCII characters in the file' do
-        new_source = autocorrect_source(cop, 'def foo() \'ä\' end')
+        new_source = autocorrect_source(cop, <<-END.strip_indent)
+          def foo() 'ä' end
+        END
 
-        expect(new_source).to eq(['# encoding: utf-8',
-                                  'def foo() \'ä\' end'].join("\n"))
+        expect(new_source).to eq(<<-END.strip_indent)
+          # encoding: utf-8
+          def foo() 'ä' end
+        END
       end
 
       it "removes encoding comment on first line when it's not needed" do
-        new_source = autocorrect_source(cop, "# encoding: utf-8\nblah")
+        new_source = autocorrect_source(cop, <<-END.strip_indent)
+          # encoding: utf-8
+          blah
+        END
 
-        expect(new_source).to eq('blah')
+        expect(new_source).to eq(<<-END.strip_indent)
+          blah
+        END
       end
     end
   end
@@ -118,23 +139,29 @@ describe RuboCop::Cop::Style::Encoding, :config do
     end
 
     it 'accepts encoding on first line' do
-      inspect_source(cop, ['# encoding: utf-8',
-                           'def foo() end'])
+      inspect_source(cop, <<-END.strip_indent)
+        # encoding: utf-8
+        def foo() end
+      END
 
       expect(cop.offenses).to be_empty
     end
 
     it 'accepts encoding on second line when shebang present' do
-      inspect_source(cop, ['#!/usr/bin/env ruby',
-                           '# encoding: utf-8',
-                           'def foo() end'])
+      inspect_source(cop, <<-END.strip_indent)
+        #!/usr/bin/env ruby
+        # encoding: utf-8
+        def foo() end
+      END
 
       expect(cop.messages).to be_empty
     end
 
     it 'books an offense when encoding is in the wrong place' do
-      inspect_source(cop, ['def foo() end',
-                           '# encoding: utf-8'])
+      inspect_source(cop, <<-END.strip_indent)
+        def foo() end
+        # encoding: utf-8
+      END
 
       expect(cop.offenses.size).to eq(1)
       expect(cop.messages).to eq(
@@ -143,15 +170,19 @@ describe RuboCop::Cop::Style::Encoding, :config do
     end
 
     it 'accepts encoding inserted by magic_encoding gem' do
-      inspect_source(cop, ['# -*- encoding : utf-8 -*-',
-                           'def foo() end'])
+      inspect_source(cop, <<-END.strip_indent)
+        # -*- encoding : utf-8 -*-
+        def foo() end
+      END
 
       expect(cop.messages).to be_empty
     end
 
     it 'accepts vim-style encoding comments' do
-      inspect_source(cop, ['# vim:filetype=ruby, fileencoding=utf-8',
-                           'def foo() end'])
+      inspect_source(cop, <<-END.strip_indent)
+        # vim:filetype=ruby, fileencoding=utf-8
+        def foo() end
+      END
       expect(cop.messages).to be_empty
     end
 
@@ -168,34 +199,46 @@ describe RuboCop::Cop::Style::Encoding, :config do
         it 'inserts an encoding comment on the first line and leaves ' \
            'the wrong encoding line when encoding is in the wrong place' do
           cop_config['AutoCorrectEncodingComment'] = '# encoding: utf-8'
-          new_source = autocorrect_source(cop, ['def foo() end',
-                                                '# encoding: utf-8'])
+          new_source = autocorrect_source(cop, <<-END.strip_indent)
+            def foo() end
+            # encoding: utf-8
+          END
 
-          expect(new_source).to eq(['# encoding: utf-8',
-                                    'def foo() end',
-                                    '# encoding: utf-8'].join("\n"))
+          expect(new_source).to eq(<<-END.strip_indent)
+            # encoding: utf-8
+            def foo() end
+            # encoding: utf-8
+          END
         end
 
         it 'inserts an encoding comment on the second line when the first ' \
            'line is a shebang' do
-          new_source = autocorrect_source(cop, ['#!/usr/bin/env ruby',
-                                                'def foo',
-                                                'end'])
+          new_source = autocorrect_source(cop, <<-END.strip_indent)
+            #!/usr/bin/env ruby
+            def foo
+            end
+          END
 
-          expect(new_source).to eq(['#!/usr/bin/env ruby',
-                                    '# encoding: utf-8',
-                                    'def foo',
-                                    'end'].join("\n"))
+          expect(new_source).to eq(<<-END.strip_indent)
+            #!/usr/bin/env ruby
+            # encoding: utf-8
+            def foo
+            end
+          END
         end
 
         it "doesn't infinite-loop when the first line is blank" do
-          new_source = autocorrect_source(cop, ['',
-                                                'module Toto',
-                                                'end'])
-          expect(new_source).to eq(['# encoding: utf-8',
-                                    '',
-                                    'module Toto',
-                                    'end'].join("\n"))
+          new_source = autocorrect_source(cop, <<-END.strip_indent)
+
+            module Toto
+            end
+          END
+          expect(new_source).to eq(<<-END.strip_indent)
+            # encoding: utf-8
+
+            module Toto
+            end
+          END
         end
       end
 
@@ -231,8 +274,10 @@ describe RuboCop::Cop::Style::Encoding, :config do
 
     it 'registers an offense when encoding present but only ASCII ' \
        'characters' do
-      inspect_source(cop, ['# encoding: utf-8',
-                           'def foo() end'])
+      inspect_source(cop, <<-END.strip_indent)
+        # encoding: utf-8
+        def foo() end
+      END
 
       expect(cop.offenses.size).to eq(1)
       expect(cop.messages).to eq(

--- a/spec/rubocop/cop/style/even_odd_spec.rb
+++ b/spec/rubocop/cop/style/even_odd_spec.rb
@@ -144,19 +144,19 @@ describe RuboCop::Cop::Style::EvenOdd do
   end
 
   it 'converts complex examples' do
-    corrected = autocorrect_source(cop, [
-                                     'if (y % 2) != 1',
-                                     '  method == :== ? :even : :odd',
-                                     'elsif x % 2 == 1',
-                                     '  method == :== ? :odd : :even',
-                                     'end'
-                                   ])
-    expect(corrected).to eq([
-      'if y.even?',
-      '  method == :== ? :even : :odd',
-      'elsif x.odd?',
-      '  method == :== ? :odd : :even',
-      'end'
-    ].join("\n"))
+    corrected = autocorrect_source(cop, <<-END.strip_indent)
+      if (y % 2) != 1
+        method == :== ? :even : :odd
+      elsif x % 2 == 1
+        method == :== ? :odd : :even
+      end
+    END
+    expect(corrected).to eq(<<-END.strip_indent)
+      if y.even?
+        method == :== ? :even : :odd
+      elsif x.odd?
+        method == :== ? :odd : :even
+      end
+    END
   end
 end

--- a/spec/rubocop/cop/style/extra_spacing_spec.rb
+++ b/spec/rubocop/cop/style/extra_spacing_spec.rb
@@ -7,42 +7,46 @@ describe RuboCop::Cop::Style::ExtraSpacing, :config do
     it 'registers an offense for alignment with token not preceded by space' do
       # The = and the ( are on the same column, but this is not for alignment,
       # it's just a mistake.
-      inspect_source(cop, ['website("example.org")',
-                           'name   = "Jill"'])
+      inspect_source(cop, <<-END.strip_indent)
+        website("example.org")
+        name   = "Jill"
+      END
       expect(cop.offenses.size).to eq(1)
     end
 
     it 'accepts aligned values of an implicit hash literal' do
-      source = ["register(street1:    '1 Market',",
-                "         street2:    '#200',",
-                "         :city =>    'Some Town',",
-                "         state:      'CA',",
-                "         postal_code:'99999-1111')"]
+      source = <<-END.strip_indent
+        register(street1:    '1 Market',
+                 street2:    '#200',
+                 :city =>    'Some Town',
+                 state:      'CA',
+                 postal_code:'99999-1111')
+      END
       inspect_source(cop, source)
       expect(cop.offenses).to be_empty
     end
 
     it 'accepts space between key and value in a hash with hash rockets' do
-      source = [
-        'ospf_h = {',
-        "  'ospfTest'    => {",
-        "    'foo'      => {",
-        "      area: '0.0.0.0', cost: 10, hello: 30, pass: true },",
-        "    'longname' => {",
-        "      area: '1.1.1.38', pass: false },",
-        "    'vlan101'  => {",
-        "      area: '2.2.2.101', cost: 5, hello: 20, pass: true }",
-        '  },',
-        "  'TestOspfInt' => {",
-        "    'x'               => {",
-        "      area: '0.0.0.19' },",
-        "    'vlan290'         => {",
-        "      area: '2.2.2.29', cost: 200, hello: 30, pass: true },",
-        "    'port-channel100' => {",
-        "      area: '3.2.2.29', cost: 25, hello: 50, pass: false }",
-        '  }',
-        '}'
-      ]
+      source = <<-END.strip_indent
+        ospf_h = {
+          'ospfTest'    => {
+            'foo'      => {
+              area: '0.0.0.0', cost: 10, hello: 30, pass: true },
+            'longname' => {
+              area: '1.1.1.38', pass: false },
+            'vlan101'  => {
+              area: '2.2.2.101', cost: 5, hello: 20, pass: true }
+          },
+          'TestOspfInt' => {
+            'x'               => {
+              area: '0.0.0.19' },
+            'vlan290'         => {
+              area: '2.2.2.29', cost: 200, hello: 30, pass: true },
+            'port-channel100' => {
+              area: '3.2.2.29', cost: 25, hello: 50, pass: false }
+          }
+        }
+      END
       inspect_source(cop, source)
       expect(cop.offenses).to be_empty
     end
@@ -54,11 +58,11 @@ describe RuboCop::Cop::Style::ExtraSpacing, :config do
       end
 
       it 'registers an offense for hashes with hash rockets' do
-        source = [
-          'let(:single_line_hash) {',
-          '  {"a"   => "1", "b" => "2"}',
-          '}'
-        ]
+        source = <<-END.strip_indent
+          let(:single_line_hash) {
+            {"a"   => "1", "b" => "2"}
+          }
+        END
 
         inspect_source(cop, source)
         expect(cop.offenses.size).to eq(1)
@@ -67,23 +71,29 @@ describe RuboCop::Cop::Style::ExtraSpacing, :config do
     end
 
     it 'can handle extra space before a float' do
-      source = ['{:a => "a",',
-                ' :b => [nil,  2.5]}']
+      source = <<-END.strip_indent
+        {:a => "a",
+         :b => [nil,  2.5]}
+      END
       inspect_source(cop, source)
       expect(cop.offenses.size).to eq(1)
     end
 
     it 'can handle unary plus in an argument list' do
-      source = ['assert_difference(MyModel.count, +2,',
-                '                  3,  +3,', # Extra spacing only here.
-                '                  4,+4)']
+      source = <<-END.strip_indent
+        assert_difference(MyModel.count, +2,
+                          3,  +3, # Extra spacing only here.
+                          4,+4)
+      END
       inspect_source(cop, source)
       expect(cop.offenses.map { |o| o.location.line }).to eq([2])
     end
 
     it 'gives the correct line' do
-      inspect_source(cop, ['class A   < String',
-                           'end'])
+      inspect_source(cop, <<-END.strip_indent)
+        class A   < String
+        end
+      END
       expect(cop.offenses.first.location.line).to eq(1)
     end
 
@@ -109,95 +119,108 @@ describe RuboCop::Cop::Style::ExtraSpacing, :config do
     end
 
     it 'registers an offense on class inheritance' do
-      inspect_source(cop, ['class A   < String',
-                           'end'])
+      inspect_source(cop, <<-END.strip_indent)
+        class A   < String
+        end
+      END
       expect(cop.offenses.size).to eq(1)
     end
 
     it 'auto-corrects a line indented with mixed whitespace' do
-      new_source = autocorrect_source(cop, ['website("example.org")',
-                                            'name    = "Jill"'])
-      expect(new_source).to eq(['website("example.org")',
-                                'name = "Jill"'].join("\n"))
+      new_source = autocorrect_source(cop, <<-END.strip_indent)
+        website("example.org")
+        name    = "Jill"
+      END
+      expect(new_source).to eq(<<-END.strip_indent)
+        website("example.org")
+        name = "Jill"
+      END
     end
 
     it 'auto-corrects the class inheritance' do
-      new_source = autocorrect_source(cop, ['class A   < String',
-                                            'end'])
-      expect(new_source).to eq(['class A < String',
-                                'end'].join("\n"))
+      new_source = autocorrect_source(cop, <<-END.strip_indent)
+        class A   < String
+        end
+      END
+      expect(new_source).to eq(<<-END.strip_indent)
+        class A < String
+        end
+      END
     end
   end
 
-  SOURCES = {
-    'lining up assignments' => [
-      'website = "example.org"',
-      'name    = "Jill"'
-    ],
+  sources = {
+    'lining up assignments' => <<-END.strip_indent,
+      website = "example.org"
+      name    = "Jill"
+    END
 
-    'lining up assignments with empty lines and comments in between' => [
-      'a   += 1',
-      '',
-      '# Comment',
-      'aa   = 2',
-      'bb   = 3',
-      '',
-      'a  ||= 1'
-    ],
+    'lining up assignments with empty lines and comments in between' =>
+    <<-END.strip_indent,
+      a   += 1
 
-    'aligning with the same character' => [
-      '      y, m = (year * 12 + (mon - 1) + n).divmod(12)',
-      '      m,   = (m + 1)                    .divmod(1)'
-    ],
+      # Comment
+      aa   = 2
+      bb   = 3
 
-    'lining up different kinds of assignments' => [
-      'type_name ||= value.class.name if value',
-      'type_name   = type_name.to_s   if type_name',
-      '',
-      'type_name  = value.class.name if     value',
-      'type_name += type_name.to_s   unless type_name',
-      '',
-      'a  += 1',
-      'aa -= 2'
-    ],
+      a  ||= 1
+    END
 
-    'aligning comments on non-adjacent lines' => [
-      %(include_examples 'aligned',   'var = until',  'test'),
-      '',
-      %(include_examples 'unaligned', "var = if",     'test')
-    ],
+    'aligning with the same character' => <<-END.strip_margin('|'),
+      |      y, m = (year * 12 + (mon - 1) + n).divmod(12)
+      |      m,   = (m + 1)                    .divmod(1)
+    END
 
-    'aligning = on lines where there are trailing comments' => [
-      'a_long_var_name = 100 # this is 100',
-      'short_name1     = 2',
-      '',
-      'clear',
-      '',
-      'short_name2     = 2',
-      'a_long_var_name = 100 # this is 100',
-      '',
-      'clear',
-      '',
-      'short_name3     = 2   # this is 2',
-      'a_long_var_name = 100 # this is 100'
-    ],
+    'lining up different kinds of assignments' => <<-END.strip_indent,
+      type_name ||= value.class.name if value
+      type_name   = type_name.to_s   if type_name
 
-    'aligning tokens with empty line between' => [
-      'unless nochdir',
-      '  Dir.chdir "/"    # Release old working directory.',
-      'end',
-      '',
-      'File.umask 0000    # Ensure sensible umask.'
-    ],
+      type_name  = value.class.name if     value
+      type_name += type_name.to_s   unless type_name
 
-    'aligning long assignment expressions that include line breaks' => [
-      'size_attribute_name    = FactoryGirl.create(:attribute,',
-      "                                            name:   'Size',",
-      '                                            values: %w{small large})',
-      'carrier_attribute_name = FactoryGirl.create(:attribute,',
-      "                                            name:   'Carrier',",
-      '                                            values: %w{verizon})'
-    ]
+      a  += 1
+      aa -= 2
+    END
+
+    'aligning comments on non-adjacent lines' => <<-END.strip_indent,
+      include_examples 'aligned',   'var = until',  'test'
+
+      include_examples 'unaligned', "var = if",     'test'
+    END
+
+    'aligning = on lines where there are trailing comments' =>
+    <<-END.strip_indent,
+      a_long_var_name = 100 # this is 100
+      short_name1     = 2
+
+      clear
+
+      short_name2     = 2
+      a_long_var_name = 100 # this is 100
+
+      clear
+
+      short_name3     = 2   # this is 2
+      a_long_var_name = 100 # this is 100
+    END
+
+    'aligning tokens with empty line between' => <<-END.strip_indent,
+      unless nochdir
+        Dir.chdir "/"    # Release old working directory.
+      end
+
+      File.umask 0000    # Ensure sensible umask.
+    END
+
+    'aligning long assignment expressions that include line breaks' =>
+    <<-END.strip_indent
+      size_attribute_name    = FactoryGirl.create(:attribute,
+                                                  name:   'Size',
+                                                  values: %w{small large})
+      carrier_attribute_name = FactoryGirl.create(:attribute,
+                                                  name:   'Carrier',
+                                                  values: %w{verizon})
+    END
   }.freeze
 
   context 'when AllowForAlignment is true' do
@@ -208,7 +231,7 @@ describe RuboCop::Cop::Style::ExtraSpacing, :config do
     include_examples 'common behavior'
 
     context 'with extra spacing for alignment purposes' do
-      SOURCES.each do |reason, src|
+      sources.each do |reason, src|
         context "such as #{reason}" do
           it 'allows it' do
             inspect_source(cop, src)
@@ -227,7 +250,7 @@ describe RuboCop::Cop::Style::ExtraSpacing, :config do
     include_examples 'common behavior'
 
     context 'with extra spacing for alignment purposes' do
-      SOURCES.each do |reason, src|
+      sources.each do |reason, src|
         context "such as #{reason}" do
           it 'registers offense(s)' do
             inspect_source(cop, src)
@@ -244,9 +267,11 @@ describe RuboCop::Cop::Style::ExtraSpacing, :config do
     end
 
     it 'registers an offense if consecutive assignments are not aligned' do
-      inspect_source(cop, ['a = 1',
-                           'bb = 2',
-                           'ccc = 3'])
+      inspect_source(cop, <<-END.strip_indent)
+        a = 1
+        bb = 2
+        ccc = 3
+      END
       expect(cop.offenses.size).to eq(3)
       expect(cop.messages).to eq(
         ['`=` is not aligned with the following assignment.',
@@ -256,101 +281,125 @@ describe RuboCop::Cop::Style::ExtraSpacing, :config do
     end
 
     it 'does not register an offense if assignments are separated by blanks' do
-      inspect_source(cop, ['a = 1',
-                           '',
-                           'bb = 2',
-                           '',
-                           'ccc = 3'])
+      inspect_source(cop, <<-END.strip_indent)
+        a = 1
+
+        bb = 2
+
+        ccc = 3
+      END
       expect(cop.offenses).to be_empty
     end
 
     it 'does not register an offense if assignments are aligned' do
-      inspect_source(cop, ['a   = 1',
-                           'bb  = 2',
-                           'ccc = 3'])
+      inspect_source(cop, <<-END.strip_indent)
+        a   = 1
+        bb  = 2
+        ccc = 3
+      END
       expect(cop.offenses).to be_empty
     end
 
     it 'aligns the first assignment with the following assignment' do
-      inspect_source(cop, ['# comment',
-                           'a   = 1',
-                           'bb  = 2'])
+      inspect_source(cop, <<-END.strip_indent)
+        # comment
+        a   = 1
+        bb  = 2
+      END
       expect(cop.offenses).to be_empty
     end
 
     it 'autocorrects consecutive assignments which are not aligned' do
-      new_source = autocorrect_source(cop, ['a = 1',
-                                            'bb = 2',
-                                            'ccc = 3',
-                                            '',
-                                            'abcde        = 1',
-                                            'a                 = 2',
-                                            'abc = 3'])
-      expect(new_source).to eq(['a   = 1',
-                                'bb  = 2',
-                                'ccc = 3',
-                                '',
-                                'abcde = 1',
-                                'a     = 2',
-                                'abc   = 3'].join("\n"))
+      new_source = autocorrect_source(cop, <<-END.strip_indent)
+        a = 1
+        bb = 2
+        ccc = 3
+
+        abcde        = 1
+        a                 = 2
+        abc = 3
+      END
+      expect(new_source).to eq(<<-END.strip_indent)
+        a   = 1
+        bb  = 2
+        ccc = 3
+
+        abcde = 1
+        a     = 2
+        abc   = 3
+      END
     end
 
     it 'autocorrects consecutive operator assignments which are not aligned' do
-      new_source = autocorrect_source(cop, ['a += 1',
-                                            'bb = 2',
-                                            'ccc <<= 3',
-                                            '',
-                                            'abcde        = 1',
-                                            'a                 *= 2',
-                                            'abc ||= 3'])
-      expect(new_source).to eq(['a    += 1',
-                                'bb    = 2',
-                                'ccc <<= 3',
-                                '',
-                                'abcde = 1',
-                                'a    *= 2',
-                                'abc ||= 3'].join("\n"))
+      new_source = autocorrect_source(cop, <<-END.strip_indent)
+        a += 1
+        bb = 2
+        ccc <<= 3
+
+        abcde        = 1
+        a                 *= 2
+        abc ||= 3
+      END
+      expect(new_source).to eq(<<-END.strip_indent)
+        a    += 1
+        bb    = 2
+        ccc <<= 3
+
+        abcde = 1
+        a    *= 2
+        abc ||= 3
+      END
     end
 
     it 'autocorrects consecutive aref assignments which are not aligned' do
-      new_source = autocorrect_source(cop, ['a[1] = 1',
-                                            'bb[2,3] = 2',
-                                            'ccc[:key] = 3',
-                                            '',
-                                            'abcde[0]        = 1',
-                                            'a                 = 2',
-                                            'abc += 3'])
-      expect(new_source).to eq(['a[1]      = 1',
-                                'bb[2,3]   = 2',
-                                'ccc[:key] = 3',
-                                '',
-                                'abcde[0] = 1',
-                                'a        = 2',
-                                'abc     += 3'].join("\n"))
+      new_source = autocorrect_source(cop, <<-END.strip_indent)
+        a[1] = 1
+        bb[2,3] = 2
+        ccc[:key] = 3
+
+        abcde[0]        = 1
+        a                 = 2
+        abc += 3
+      END
+      expect(new_source).to eq(<<-END.strip_indent)
+        a[1]      = 1
+        bb[2,3]   = 2
+        ccc[:key] = 3
+
+        abcde[0] = 1
+        a        = 2
+        abc     += 3
+      END
     end
 
     it 'autocorrects consecutive attribute assignments which are not aligned' do
-      new_source = autocorrect_source(cop, ['a.attr = 1',
-                                            'bb &&= 2',
-                                            'ccc.s = 3',
-                                            '',
-                                            'abcde.blah        = 1',
-                                            'a.attribute_name              = 2',
-                                            'abc[1] = 3'])
-      expect(new_source).to eq(['a.attr = 1',
-                                'bb   &&= 2',
-                                'ccc.s  = 3',
-                                '',
-                                'abcde.blah       = 1',
-                                'a.attribute_name = 2',
-                                'abc[1]           = 3'].join("\n"))
+      new_source = autocorrect_source(cop, <<-END.strip_indent)
+        a.attr = 1
+        bb &&= 2
+        ccc.s = 3
+
+        abcde.blah        = 1
+        a.attribute_name              = 2
+        abc[1] = 3
+      END
+      expect(new_source).to eq(<<-END.strip_indent)
+        a.attr = 1
+        bb   &&= 2
+        ccc.s  = 3
+
+        abcde.blah       = 1
+        a.attribute_name = 2
+        abc[1]           = 3
+      END
     end
 
     it 'does not register an offense when optarg equals is not aligned with ' \
        'assignment equals sign' do
-      inspect_source(cop, ['def method(arg = 1)',
-                           '  var = arg',
-                           'end'])
+      inspect_source(cop, <<-END.strip_indent)
+        def method(arg = 1)
+          var = arg
+        end
+      END
       expect(cop.offenses).to be_empty
     end
   end

--- a/spec/rubocop/cop/style/file_name_spec.rb
+++ b/spec/rubocop/cop/style/file_name_spec.rb
@@ -19,7 +19,7 @@ describe RuboCop::Cop::Style::FileName do
   end
 
   let(:includes) { [] }
-  let(:source) { ['print 1'] }
+  let(:source) { 'print 1' }
   let(:processed_source) { parse_source(source) }
 
   before do
@@ -86,7 +86,10 @@ describe RuboCop::Cop::Style::FileName do
 
   context 'with non-snake-case file names with a shebang' do
     let(:filename) { '/some/dir/test-case' }
-    let(:source) { ['#!/usr/bin/env ruby', 'print 1'] }
+    let(:source) { <<-END.strip_indent }
+      #!/usr/bin/env ruby
+      print 1
+    END
 
     it 'does not report an offense' do
       expect(cop.offenses).to be_empty
@@ -214,49 +217,49 @@ describe RuboCop::Cop::Style::FileName do
     end
 
     context 'on a file which defines a nested module' do
-      let(:source) do
-        ['module A',
-         '  module B',
-         '  end',
-         'end']
-      end
+      let(:source) { <<-END.strip_indent }
+        module A
+          module B
+          end
+        end
+      END
 
       include_examples 'matching module or class'
     end
 
     context 'on a file which defines a nested class' do
-      let(:source) do
-        ['module A',
-         '  class B',
-         '  end',
-         'end']
-      end
+      let(:source) { <<-END.strip_indent }
+        module A
+          class B
+          end
+        end
+      END
 
       include_examples 'matching module or class'
     end
 
     context 'on a file which uses Name::Spaced::Module syntax' do
-      let(:source) do
-        ['begin',
-         '  module A::B',
-         '  end',
-         'end']
-      end
+      let(:source) { <<-END.strip_indent }
+        begin
+          module A::B
+          end
+        end
+      END
 
       include_examples 'matching module or class'
     end
 
     context 'on a file which defines multiple classes' do
-      let(:source) do
-        ['class X',
-         'end',
-         'module M',
-         'end',
-         'class A',
-         '  class B',
-         '  end',
-         'end']
-      end
+      let(:source) { <<-END.strip_indent }
+        class X
+        end
+        module M
+        end
+        class A
+          class B
+          end
+        end
+      END
 
       include_examples 'matching module or class'
     end
@@ -296,16 +299,14 @@ describe RuboCop::Cop::Style::FileName do
 
     let(:filename) { '/lib/my/cli/admin_user.rb' }
 
-    let(:source) do
-      [
-        'module My',
-        '  module CLI',
-        '    class AdminUser',
-        '    end',
-        '  end',
-        'end'
-      ]
-    end
+    let(:source) { <<-END.strip_indent }
+      module My
+        module CLI
+          class AdminUser
+          end
+        end
+      end
+    END
 
     it 'does not register an offense' do
       expect(cop.offenses).to be_empty
@@ -323,14 +324,12 @@ describe RuboCop::Cop::Style::FileName do
 
     let(:filename) { '/lib/my/cli.rb' }
 
-    let(:source) do
-      [
-        'module My',
-        '  class CLI',
-        '  end',
-        'end'
-      ]
-    end
+    let(:source) { <<-END.strip_indent }
+      module My
+        class CLI
+        end
+      end
+    END
 
     it 'does not register an offense' do
       expect(cop.offenses).to be_empty
@@ -348,14 +347,12 @@ describe RuboCop::Cop::Style::FileName do
 
     let(:filename) { '/lib/my/http_server.rb' }
 
-    let(:source) do
-      [
-        'module My',
-        '  class HTTPServer',
-        '  end',
-        'end'
-      ]
-    end
+    let(:source) { <<-END.strip_indent }
+      module My
+        class HTTPServer
+        end
+      end
+    END
 
     it 'does not register an offense' do
       expect(cop.offenses).to be_empty

--- a/spec/rubocop/cop/style/first_array_element_line_break_spec.rb
+++ b/spec/rubocop/cop/style/first_array_element_line_break_spec.rb
@@ -5,8 +5,10 @@ describe RuboCop::Cop::Style::FirstArrayElementLineBreak do
 
   context 'elements listed on the first line' do
     let(:source) do
-      ['a = [:a,',
-       '     :b]']
+      <<-END.strip_indent
+        a = [:a,
+             :b]
+      END
     end
     it 'detects the offense' do
       inspect_source(cop, source)
@@ -20,14 +22,20 @@ describe RuboCop::Cop::Style::FirstArrayElementLineBreak do
       new_source = autocorrect_source(cop, source)
       # Alignment for the first element is set by IndentationWidth cop,
       # the rest of the elements should be aligned using the AlignArray cop.
-      expect(new_source).to eq("a = [\n:a,\n     :b]")
+      expect(new_source).to eq(<<-END.strip_indent)
+        a = [
+        :a,
+             :b]
+      END
     end
   end
 
   context 'word arrays' do
     let(:source) do
-      ['%w(a b',
-       '   c d)']
+      <<-END.strip_indent
+        %w(a b
+           c d)
+      END
     end
 
     it 'detects the offense' do
@@ -40,14 +48,20 @@ describe RuboCop::Cop::Style::FirstArrayElementLineBreak do
 
     it 'autocorrects the offense' do
       new_source = autocorrect_source(cop, source)
-      expect(new_source).to eq("%w(\na b\n   c d)")
+      expect(new_source).to eq(<<-END.strip_indent)
+        %w(
+        a b
+           c d)
+      END
     end
   end
 
   context 'array nested in a method call' do
     let(:source) do
-      ['method([:foo,',
-       '        :bar])']
+      <<-END.strip_indent
+        method([:foo,
+                :bar])
+      END
     end
 
     it 'detects the offense' do
@@ -61,26 +75,29 @@ describe RuboCop::Cop::Style::FirstArrayElementLineBreak do
     it 'autocorrects the offense' do
       new_source = autocorrect_source(cop, source)
 
-      expect(new_source).to eq(
-        "method([\n" \
-        ":foo,\n" \
-        '        :bar])'
-      )
+      expect(new_source).to eq(<<-END.strip_indent)
+        method([
+        :foo,
+                :bar])
+      END
     end
   end
 
   context 'masgn implicit arrays' do
     let(:source) do
-      ['a, b,',
-       'c = 1,',
-       '2, 3']
+      <<-END.strip_indent
+        a, b,
+        c = 1,
+        2, 3
+      END
     end
 
     let(:correct_source) do
       ['a, b,',
        'c = ',
        '1,',
-       '2, 3'].join("\n")
+       '2, 3',
+       ''].join("\n")
     end
 
     it 'detects the offense' do
@@ -100,16 +117,19 @@ describe RuboCop::Cop::Style::FirstArrayElementLineBreak do
 
   context 'send implicit arrays' do
     let(:source) do
-      ['a',
-       '.c = 1,',
-       '2, 3']
+      <<-END.strip_indent
+        a
+        .c = 1,
+        2, 3
+      END
     end
 
     let(:correct_source) do
       ['a',
        '.c = ',
        '1,',
-       '2, 3'].join("\n")
+       '2, 3',
+       ''].join("\n")
     end
 
     it 'detects the offense' do
@@ -130,10 +150,12 @@ describe RuboCop::Cop::Style::FirstArrayElementLineBreak do
   it 'ignores properly formatted implicit arrays' do
     inspect_source(
       cop,
-      ['a, b,',
-       'c =',
-       '1, 2,',
-       '3']
+      <<-END.strip_indent
+        a, b,
+        c =
+        1, 2,
+        3
+      END
     )
 
     expect(cop.offenses).to be_empty
@@ -142,9 +164,11 @@ describe RuboCop::Cop::Style::FirstArrayElementLineBreak do
   it 'ignores elements listed on a single line' do
     inspect_source(
       cop,
-      ['b = [',
-       '  :a,',
-       '  :b]']
+      <<-END.strip_indent
+        b = [
+          :a,
+          :b]
+      END
     )
 
     expect(cop.offenses).to be_empty

--- a/spec/rubocop/cop/style/first_hash_element_line_break_spec.rb
+++ b/spec/rubocop/cop/style/first_hash_element_line_break_spec.rb
@@ -5,8 +5,10 @@ describe RuboCop::Cop::Style::FirstHashElementLineBreak do
 
   context 'elements listed on the first line' do
     let(:source) do
-      ['a = { a: 1,',
-       '      b: 2}']
+      <<-END.strip_indent
+        a = { a: 1,
+              b: 2}
+      END
     end
 
     it 'detects the offense' do
@@ -20,18 +22,21 @@ describe RuboCop::Cop::Style::FirstHashElementLineBreak do
     it 'autocorrects the offense' do
       new_source = autocorrect_source(cop, source)
 
-      expect(new_source).to eq(
-        "a = { \n" \
-        "a: 1,\n" \
-        '      b: 2}'
-      )
+      expect(new_source).to eq([
+        'a = { ',
+        'a: 1,',
+        '      b: 2}',
+        ''
+      ].join("\n"))
     end
   end
 
   context 'hash nested in a method call' do
     let(:source) do
-      ['method({ foo: 1,',
-       '         bar: 2 })']
+      <<-END.strip_indent
+        method({ foo: 1,
+                 bar: 2 })
+      END
     end
 
     it 'detects the offense' do
@@ -45,20 +50,23 @@ describe RuboCop::Cop::Style::FirstHashElementLineBreak do
     it 'autocorrects the offense' do
       new_source = autocorrect_source(cop, source)
 
-      expect(new_source).to eq(
-        "method({ \n" \
-        "foo: 1,\n" \
-        '         bar: 2 })'
-      )
+      expect(new_source).to eq([
+        'method({ ',
+        'foo: 1,',
+        '         bar: 2 })',
+        ''
+      ].join("\n"))
     end
   end
 
   it 'ignores implicit hashes in method calls with parens' do
     inspect_source(
       cop,
-      ['method(',
-       '  foo: 1,',
-       '  bar: 2)']
+      <<-END.strip_indent
+        method(
+          foo: 1,
+          bar: 2)
+      END
     )
 
     expect(cop.offenses).to be_empty
@@ -67,8 +75,10 @@ describe RuboCop::Cop::Style::FirstHashElementLineBreak do
   it 'ignores implicit hashes in method calls without parens' do
     inspect_source(
       cop,
-      ['method foo: 1,',
-       ' bar:2']
+      <<-END.strip_indent
+        method foo: 1,
+         bar:2
+      END
     )
 
     expect(cop.offenses).to be_empty
@@ -78,8 +88,10 @@ describe RuboCop::Cop::Style::FirstHashElementLineBreak do
     # These are covered by Style/FirstMethodArgumentLineBreak
     inspect_source(
       cop,
-      ['method(foo: 1,',
-       '  bar: 2)']
+      <<-END.strip_indent
+        method(foo: 1,
+          bar: 2)
+      END
     )
 
     expect(cop.offenses).to be_empty
@@ -88,9 +100,11 @@ describe RuboCop::Cop::Style::FirstHashElementLineBreak do
   it 'ignores elements listed on a single line' do
     inspect_source(
       cop,
-      ['b = {',
-       '  a: 1,',
-       '  b: 2}']
+      <<-END.strip_indent
+        b = {
+          a: 1,
+          b: 2}
+      END
     )
 
     expect(cop.offenses).to be_empty

--- a/spec/rubocop/cop/style/first_method_argument_line_break_spec.rb
+++ b/spec/rubocop/cop/style/first_method_argument_line_break_spec.rb
@@ -5,8 +5,10 @@ describe RuboCop::Cop::Style::FirstMethodArgumentLineBreak do
 
   context 'args listed on the first line' do
     let(:source) do
-      ['foo(bar,',
-       '  baz)']
+      <<-END.strip_indent
+        foo(bar,
+          baz)
+      END
     end
 
     it 'detects the offense' do
@@ -20,18 +22,21 @@ describe RuboCop::Cop::Style::FirstMethodArgumentLineBreak do
     it 'autocorrects the offense' do
       new_source = autocorrect_source(cop, source)
 
-      expect(new_source).to eq(
-        "foo(\n" \
-        "bar,\n" \
-        '  baz)'
-      )
+      expect(new_source).to eq([
+        'foo(',
+        'bar,',
+        '  baz)',
+        ''
+      ].join("\n"))
     end
   end
 
   context 'hash arg spanning multiple lines' do
     let(:source) do
-      ['something(3, bar: 1,',
-       'baz: 2)']
+      <<-END.strip_indent
+        something(3, bar: 1,
+        baz: 2)
+      END
     end
 
     it 'detects the offense' do
@@ -45,18 +50,21 @@ describe RuboCop::Cop::Style::FirstMethodArgumentLineBreak do
     it 'autocorrects the offense' do
       new_source = autocorrect_source(cop, source)
 
-      expect(new_source).to eq(
-        "something(\n" \
-        "3, bar: 1,\n" \
-        'baz: 2)'
-      )
+      expect(new_source).to eq([
+        'something(',
+        '3, bar: 1,',
+        'baz: 2)',
+        ''
+      ].join("\n"))
     end
   end
 
   context 'hash arg without a line break before the first pair' do
     let(:source) do
-      ['something(bar: 1,',
-       'baz: 2)']
+      <<-END.strip_indent
+        something(bar: 1,
+        baz: 2)
+      END
     end
 
     it 'detects the offense' do
@@ -70,11 +78,12 @@ describe RuboCop::Cop::Style::FirstMethodArgumentLineBreak do
     it 'autocorrects the offense' do
       new_source = autocorrect_source(cop, source)
 
-      expect(new_source).to eq(
-        "something(\n" \
-        "bar: 1,\n" \
-        'baz: 2)'
-      )
+      expect(new_source).to eq([
+        'something(',
+        'bar: 1,',
+        'baz: 2)',
+        ''
+      ].join("\n"))
     end
   end
 
@@ -87,8 +96,10 @@ describe RuboCop::Cop::Style::FirstMethodArgumentLineBreak do
   it 'ignores arguments without parens' do
     inspect_source(
       cop,
-      ['foo bar,',
-       '  baz']
+      <<-END.strip_indent
+        foo bar,
+          baz
+      END
     )
 
     expect(cop.offenses).to be_empty

--- a/spec/rubocop/cop/style/first_method_parameter_line_break_spec.rb
+++ b/spec/rubocop/cop/style/first_method_parameter_line_break_spec.rb
@@ -5,10 +5,12 @@ describe RuboCop::Cop::Style::FirstMethodParameterLineBreak do
 
   context 'params listed on the first line' do
     let(:source) do
-      ['def foo(bar,',
-       '  baz)',
-       '  do_something',
-       'end']
+      <<-END.strip_indent
+        def foo(bar,
+          baz)
+          do_something
+        end
+      END
     end
 
     it 'detects the offense' do
@@ -22,22 +24,25 @@ describe RuboCop::Cop::Style::FirstMethodParameterLineBreak do
     it 'autocorrects the offense' do
       new_source = autocorrect_source(cop, source)
 
-      expect(new_source).to eq(
-        "def foo(\n" \
-        "bar,\n" \
-        "  baz)\n" \
-        "  do_something\n" \
-        'end'
-      )
+      expect(new_source).to eq([
+        'def foo(',
+        'bar,',
+        '  baz)',
+        '  do_something',
+        'end',
+        ''
+      ].join("\n"))
     end
   end
 
   context 'params on first line of singleton method' do
     let(:source) do
-      ['def self.foo(bar,',
-       '  baz)',
-       '  do_something',
-       'end']
+      <<-END.strip_indent
+        def self.foo(bar,
+          baz)
+          do_something
+        end
+      END
     end
 
     it 'detects the offense' do
@@ -51,22 +56,25 @@ describe RuboCop::Cop::Style::FirstMethodParameterLineBreak do
     it 'autocorrects the offense' do
       new_source = autocorrect_source(cop, source)
 
-      expect(new_source).to eq(
-        "def self.foo(\n" \
-        "bar,\n" \
-        "  baz)\n" \
-        "  do_something\n" \
-        'end'
-      )
+      expect(new_source).to eq([
+        'def self.foo(',
+        'bar,',
+        '  baz)',
+        '  do_something',
+        'end',
+        ''
+      ].join("\n"))
     end
   end
 
   it 'ignores params listed on a single line' do
     inspect_source(
       cop,
-      ['def foo(bar, baz, bing)',
-       '  do_something',
-       'end']
+      <<-END.strip_indent
+        def foo(bar, baz, bing)
+          do_something
+        end
+      END
     )
 
     expect(cop.offenses).to be_empty
@@ -75,10 +83,12 @@ describe RuboCop::Cop::Style::FirstMethodParameterLineBreak do
   it 'ignores params without parens' do
     inspect_source(
       cop,
-      ['def foo bar,',
-       '  baz',
-       '  do_something',
-       'end']
+      <<-END.strip_indent
+        def foo bar,
+          baz
+          do_something
+        end
+      END
     )
 
     expect(cop.offenses).to be_empty
@@ -96,9 +106,11 @@ describe RuboCop::Cop::Style::FirstMethodParameterLineBreak do
   it 'ignores methods without params' do
     inspect_source(
       cop,
-      ['def foo',
-       '  bing',
-       'end']
+      <<-END.strip_indent
+        def foo
+          bing
+        end
+      END
     )
 
     expect(cop.offenses).to be_empty
@@ -106,10 +118,12 @@ describe RuboCop::Cop::Style::FirstMethodParameterLineBreak do
 
   context 'params with default values' do
     let(:source) do
-      ['def foo(bar = [],',
-       '  baz = 2)',
-       '  do_something',
-       'end']
+      <<-END.strip_indent
+        def foo(bar = [],
+          baz = 2)
+          do_something
+        end
+      END
     end
 
     it 'detects the offense' do
@@ -123,13 +137,14 @@ describe RuboCop::Cop::Style::FirstMethodParameterLineBreak do
     it 'autocorrects the offense' do
       new_source = autocorrect_source(cop, source)
 
-      expect(new_source).to eq(
-        "def foo(\n" \
-        "bar = [],\n" \
-        "  baz = 2)\n" \
-        "  do_something\n" \
-        'end'
-      )
+      expect(new_source).to eq([
+        'def foo(',
+        'bar = [],',
+        '  baz = 2)',
+        '  do_something',
+        'end',
+        ''
+      ].join("\n"))
     end
   end
 end

--- a/spec/rubocop/cop/style/flip_flop_spec.rb
+++ b/spec/rubocop/cop/style/flip_flop_spec.rb
@@ -4,18 +4,20 @@ describe RuboCop::Cop::Style::FlipFlop do
   subject(:cop) { described_class.new }
 
   it 'registers an offense for inclusive flip flops' do
-    inspect_source(cop,
-                   ['DATA.each_line do |line|',
-                    'print line if (line =~ /begin/)..(line =~ /end/)',
-                    'end'])
+    inspect_source(cop, <<-END.strip_indent)
+      DATA.each_line do |line|
+      print line if (line =~ /begin/)..(line =~ /end/)
+      end
+    END
     expect(cop.offenses.size).to eq(1)
   end
 
   it 'registers an offense for exclusive flip flops' do
-    inspect_source(cop,
-                   ['DATA.each_line do |line|',
-                    'print line if (line =~ /begin/)...(line =~ /end/)',
-                    'end'])
+    inspect_source(cop, <<-END.strip_indent)
+      DATA.each_line do |line|
+      print line if (line =~ /begin/)...(line =~ /end/)
+      end
+    END
     expect(cop.offenses.size).to eq(1)
   end
 end

--- a/spec/rubocop/cop/style/for_spec.rb
+++ b/spec/rubocop/cop/style/for_spec.rb
@@ -7,38 +7,41 @@ describe RuboCop::Cop::Style::For, :config do
     let(:cop_config) { { 'EnforcedStyle' => 'each' } }
 
     it 'registers an offense for for' do
-      inspect_source(cop,
-                     ['def func',
-                      '  for n in [1, 2, 3] do',
-                      '    puts n',
-                      '  end',
-                      'end'])
+      inspect_source(cop, <<-END.strip_indent)
+        def func
+          for n in [1, 2, 3] do
+            puts n
+          end
+        end
+      END
       expect(cop.messages).to eq(['Prefer `each` over `for`.'])
       expect(cop.highlights).to eq(['for'])
       expect(cop.config_to_allow_offenses).to eq('EnforcedStyle' => 'for')
     end
 
     it 'registers an offense for opposite + correct style' do
-      inspect_source(cop,
-                     ['def func',
-                      '  for n in [1, 2, 3] do',
-                      '    puts n',
-                      '  end',
-                      '  [1, 2, 3].each do |n|',
-                      '    puts n',
-                      '  end',
-                      'end'])
+      inspect_source(cop, <<-END.strip_indent)
+        def func
+          for n in [1, 2, 3] do
+            puts n
+          end
+          [1, 2, 3].each do |n|
+            puts n
+          end
+        end
+      END
       expect(cop.messages).to eq(['Prefer `each` over `for`.'])
       expect(cop.config_to_allow_offenses).to eq('Enabled' => false)
     end
 
     it 'accepts multiline each' do
-      inspect_source(cop,
-                     ['def func',
-                      '  [1, 2, 3].each do |n|',
-                      '    puts n',
-                      '  end',
-                      'end'])
+      inspect_source(cop, <<-END.strip_indent)
+        def func
+          [1, 2, 3].each do |n|
+            puts n
+          end
+        end
+      END
       expect(cop.offenses).to be_empty
     end
 
@@ -57,46 +60,50 @@ describe RuboCop::Cop::Style::For, :config do
     let(:cop_config) { { 'EnforcedStyle' => 'for' } }
 
     it 'accepts for' do
-      inspect_source(cop,
-                     ['def func',
-                      '  for n in [1, 2, 3] do',
-                      '    puts n',
-                      '  end',
-                      'end'])
+      inspect_source(cop, <<-END.strip_indent)
+        def func
+          for n in [1, 2, 3] do
+            puts n
+          end
+        end
+      END
       expect(cop.offenses).to be_empty
     end
 
     it 'registers an offense for multiline each' do
-      inspect_source(cop,
-                     ['def func',
-                      '  [1, 2, 3].each do |n|',
-                      '    puts n',
-                      '  end',
-                      'end'])
+      inspect_source(cop, <<-END.strip_indent)
+        def func
+          [1, 2, 3].each do |n|
+            puts n
+          end
+        end
+      END
       expect(cop.messages).to eq(['Prefer `for` over `each`.'])
       expect(cop.highlights).to eq(['each'])
       expect(cop.config_to_allow_offenses).to eq('EnforcedStyle' => 'each')
     end
 
     it 'registers an offense for correct + opposite style' do
-      inspect_source(cop,
-                     ['def func',
-                      '  for n in [1, 2, 3] do',
-                      '    puts n',
-                      '  end',
-                      '  [1, 2, 3].each do |n|',
-                      '    puts n',
-                      '  end',
-                      'end'])
+      inspect_source(cop, <<-END.strip_indent)
+        def func
+          for n in [1, 2, 3] do
+            puts n
+          end
+          [1, 2, 3].each do |n|
+            puts n
+          end
+        end
+      END
       expect(cop.messages).to eq(['Prefer `for` over `each`.'])
       expect(cop.config_to_allow_offenses).to eq('Enabled' => false)
     end
 
     it 'accepts single line each' do
-      inspect_source(cop,
-                     ['def func',
-                      '  [1, 2, 3].each { |n| puts n }',
-                      'end'])
+      inspect_source(cop, <<-END.strip_indent)
+        def func
+          [1, 2, 3].each { |n| puts n }
+        end
+      END
       expect(cop.offenses).to be_empty
     end
   end

--- a/spec/rubocop/cop/style/frozen_string_literal_comment_spec.rb
+++ b/spec/rubocop/cop/style/frozen_string_literal_comment_spec.rb
@@ -22,15 +22,19 @@ describe RuboCop::Cop::Style::FrozenStringLiteralComment, :config do
     end
 
     it 'accepts a frozen string literal on the top line' do
-      inspect_source(cop, ['# frozen_string_literal: true',
-                           'puts 1'])
+      inspect_source(cop, <<-END.strip_indent)
+        # frozen_string_literal: true
+        puts 1
+      END
 
       expect(cop.offenses).to be_empty
     end
 
     it 'accepts a disabled frozen string literal on the top line' do
-      inspect_source(cop, ['# frozen_string_literal: false',
-                           'puts 1'])
+      inspect_source(cop, <<-END.strip_indent)
+        # frozen_string_literal: false
+        puts 1
+      END
 
       expect(cop.offenses).to be_empty
     end
@@ -45,59 +49,73 @@ describe RuboCop::Cop::Style::FrozenStringLiteralComment, :config do
 
     it 'registers an offense for not having a frozen string literal comment ' \
        'under a shebang' do
-      inspect_source(cop, ['#!/usr/bin/env ruby',
-                           'puts 1'])
+      inspect_source(cop, <<-END.strip_indent)
+        #!/usr/bin/env ruby
+        puts 1
+      END
 
       expect(cop.messages)
         .to eq(['Missing magic comment `# frozen_string_literal: true`.'])
     end
 
     it 'accepts a frozen string literal below a shebang comment' do
-      inspect_source(cop, ['#!/usr/bin/env ruby',
-                           '# frozen_string_literal: true',
-                           'puts 1'])
+      inspect_source(cop, <<-END.strip_indent)
+        #!/usr/bin/env ruby
+        # frozen_string_literal: true
+        puts 1
+      END
 
       expect(cop.offenses).to be_empty
     end
 
     it 'accepts a disabled frozen string literal below a shebang comment' do
-      inspect_source(cop, ['#!/usr/bin/env ruby',
-                           '# frozen_string_literal: false',
-                           'puts 1'])
+      inspect_source(cop, <<-END.strip_indent)
+        #!/usr/bin/env ruby
+        # frozen_string_literal: false
+        puts 1
+      END
 
       expect(cop.offenses).to be_empty
     end
 
     it 'registers an offense for not having a frozen string literal comment ' \
        'under an encoding comment' do
-      inspect_source(cop, ['# encoding: utf-8',
-                           'puts 1'])
+      inspect_source(cop, <<-END.strip_indent)
+        # encoding: utf-8
+        puts 1
+      END
 
       expect(cop.messages)
         .to eq(['Missing magic comment `# frozen_string_literal: true`.'])
     end
 
     it 'accepts a frozen string literal below an encoding comment' do
-      inspect_source(cop, ['# encoding: utf-8',
-                           '# frozen_string_literal: true',
-                           'puts 1'])
+      inspect_source(cop, <<-END.strip_indent)
+        # encoding: utf-8
+        # frozen_string_literal: true
+        puts 1
+      END
 
       expect(cop.offenses).to be_empty
     end
 
     it 'accepts a dsabled frozen string literal below an encoding comment' do
-      inspect_source(cop, ['# encoding: utf-8',
-                           '# frozen_string_literal: false',
-                           'puts 1'])
+      inspect_source(cop, <<-END.strip_indent)
+        # encoding: utf-8
+        # frozen_string_literal: false
+        puts 1
+      END
 
       expect(cop.offenses).to be_empty
     end
 
     it 'registers an offense for not having a frozen string literal comment ' \
        'under a shebang and an encoding comment' do
-      inspect_source(cop, ['#!/usr/bin/env ruby',
-                           '# encoding: utf-8',
-                           'puts 1'])
+      inspect_source(cop, <<-END.strip_indent)
+        #!/usr/bin/env ruby
+        # encoding: utf-8
+        puts 1
+      END
 
       expect(cop.messages)
         .to eq(['Missing magic comment `# frozen_string_literal: true`.'])
@@ -105,40 +123,48 @@ describe RuboCop::Cop::Style::FrozenStringLiteralComment, :config do
 
     it 'accepts a frozen string literal comment below shebang and encoding ' \
        'comments' do
-      inspect_source(cop, ['#!/usr/bin/env ruby',
-                           '# encoding: utf-8',
-                           '# frozen_string_literal: true',
-                           'puts 1'])
+      inspect_source(cop, <<-END.strip_indent)
+        #!/usr/bin/env ruby
+        # encoding: utf-8
+        # frozen_string_literal: true
+        puts 1
+      END
 
       expect(cop.offenses).to be_empty
     end
 
     it 'accepts a disabled frozen string literal comment below shebang and ' \
        'encoding comments' do
-      inspect_source(cop, ['#!/usr/bin/env ruby',
-                           '# encoding: utf-8',
-                           '# frozen_string_literal: false',
-                           'puts 1'])
+      inspect_source(cop, <<-END.strip_indent)
+        #!/usr/bin/env ruby
+        # encoding: utf-8
+        # frozen_string_literal: false
+        puts 1
+      END
 
       expect(cop.offenses).to be_empty
     end
 
     it 'accepts a frozen string literal comment below shebang above an ' \
        'encoding comments' do
-      inspect_source(cop, ['#!/usr/bin/env ruby',
-                           '# frozen_string_literal: true',
-                           '# encoding: utf-8',
-                           'puts 1'])
+      inspect_source(cop, <<-END.strip_indent)
+        #!/usr/bin/env ruby
+        # frozen_string_literal: true
+        # encoding: utf-8
+        puts 1
+      END
 
       expect(cop.offenses).to be_empty
     end
 
     it 'accepts a disabled frozen string literal comment below shebang above ' \
        'an encoding comments' do
-      inspect_source(cop, ['#!/usr/bin/env ruby',
-                           '# frozen_string_literal: false',
-                           '# encoding: utf-8',
-                           'puts 1'])
+      inspect_source(cop, <<-END.strip_indent)
+        #!/usr/bin/env ruby
+        # frozen_string_literal: false
+        # encoding: utf-8
+        puts 1
+      END
 
       expect(cop.offenses).to be_empty
     end
@@ -146,12 +172,12 @@ describe RuboCop::Cop::Style::FrozenStringLiteralComment, :config do
     it 'accepts an emacs style combined magic comment' do
       inspect_source(
         cop,
-        [
-          '#!/usr/bin/env ruby',
-          '# -*- encoding: UTF-8; frozen_string_literal: true -*-',
-          '# encoding: utf-8',
-          'puts 1'
-        ]
+        <<-END.strip_indent
+          #!/usr/bin/env ruby
+          # -*- encoding: UTF-8; frozen_string_literal: true -*-
+          # encoding: utf-8
+          puts 1
+        END
       )
 
       expect(cop.offenses).to be_empty
@@ -160,66 +186,90 @@ describe RuboCop::Cop::Style::FrozenStringLiteralComment, :config do
     context 'auto-correct' do
       it 'adds a frozen string literal comment to the first line if one is ' \
          'missing' do
-        new_source = autocorrect_source(cop, 'puts 1')
+        new_source = autocorrect_source(cop, <<-END.strip_indent)
+          puts 1
+        END
 
-        expect(new_source).to eq(['# frozen_string_literal: true',
-                                  'puts 1'].join("\n"))
+        expect(new_source).to eq(<<-END.strip_indent)
+          # frozen_string_literal: true
+          puts 1
+        END
       end
 
       it 'adds a frozen string literal comment after a shebang' do
-        new_source = autocorrect_source(cop, ['#!/usr/bin/env ruby',
-                                              'puts 1'])
+        new_source = autocorrect_source(cop, <<-END.strip_indent)
+          #!/usr/bin/env ruby
+          puts 1
+        END
 
-        expect(new_source).to eq(['#!/usr/bin/env ruby',
-                                  '# frozen_string_literal: true',
-                                  'puts 1'].join("\n"))
+        expect(new_source).to eq(<<-END.strip_indent)
+          #!/usr/bin/env ruby
+          # frozen_string_literal: true
+          puts 1
+        END
       end
 
       it 'adds a frozen string literal comment after an encoding comment' do
-        new_source = autocorrect_source(cop, ['# encoding: utf-8',
-                                              'puts 1'])
+        new_source = autocorrect_source(cop, <<-END.strip_indent)
+          # encoding: utf-8
+          puts 1
+        END
 
-        expect(new_source).to eq(['# encoding: utf-8',
-                                  '# frozen_string_literal: true',
-                                  'puts 1'].join("\n"))
+        expect(new_source).to eq(<<-END.strip_indent)
+          # encoding: utf-8
+          # frozen_string_literal: true
+          puts 1
+        END
       end
 
       it 'adds a frozen string literal comment after a shebang and encoding ' \
          'comment' do
-        new_source = autocorrect_source(cop, ['#!/usr/bin/env ruby',
-                                              '# encoding: utf-8',
-                                              'puts 1'])
+        new_source = autocorrect_source(cop, <<-END.strip_indent)
+          #!/usr/bin/env ruby
+          # encoding: utf-8
+          puts 1
+        END
 
-        expect(new_source).to eq(['#!/usr/bin/env ruby',
-                                  '# encoding: utf-8',
-                                  '# frozen_string_literal: true',
-                                  'puts 1'].join("\n"))
+        expect(new_source).to eq(<<-END.strip_indent)
+          #!/usr/bin/env ruby
+          # encoding: utf-8
+          # frozen_string_literal: true
+          puts 1
+        END
       end
 
       it 'adds a frozen string literal comment after a shebang and encoding ' \
          'comment when there is an empty line before the code' do
-        new_source = autocorrect_source(cop, ['#!/usr/bin/env ruby',
-                                              '# encoding: utf-8',
-                                              '',
-                                              'puts 1'])
+        new_source = autocorrect_source(cop, <<-END.strip_indent)
+          #!/usr/bin/env ruby
+          # encoding: utf-8
 
-        expect(new_source).to eq(['#!/usr/bin/env ruby',
-                                  '# encoding: utf-8',
-                                  '# frozen_string_literal: true',
-                                  '',
-                                  'puts 1'].join("\n"))
+          puts 1
+        END
+
+        expect(new_source).to eq(<<-END.strip_indent)
+          #!/usr/bin/env ruby
+          # encoding: utf-8
+          # frozen_string_literal: true
+
+          puts 1
+        END
       end
 
       it 'adds a frozen string literal comment after an encoding comment ' \
          'when there is an empty line before the code' do
-        new_source = autocorrect_source(cop, ['# encoding: utf-8',
-                                              '',
-                                              'puts 1'])
+        new_source = autocorrect_source(cop, <<-END.strip_indent)
+          # encoding: utf-8
 
-        expect(new_source).to eq(['# encoding: utf-8',
-                                  '# frozen_string_literal: true',
-                                  '',
-                                  'puts 1'].join("\n"))
+          puts 1
+        END
+
+        expect(new_source).to eq(<<-END.strip_indent)
+          # encoding: utf-8
+          # frozen_string_literal: true
+
+          puts 1
+        END
       end
     end
   end
@@ -252,15 +302,19 @@ describe RuboCop::Cop::Style::FrozenStringLiteralComment, :config do
           end
 
           it 'accepts calling freeze on a variable' do
-            inspect_source(cop, ['foo = "x"',
-                                 '  foo.freeze'])
+            inspect_source(cop, <<-END.strip_indent)
+              foo = "x"
+                foo.freeze
+            END
 
             expect(cop.offenses).to be_empty
           end
 
           it 'accepts calling shovel on a variable' do
-            inspect_source(cop, ['foo = "x"',
-                                 '  foo << "y"'])
+            inspect_source(cop, <<-END.strip_indent)
+              foo = "x"
+                foo << "y"
+            END
 
             expect(cop.offenses).to be_empty
           end
@@ -280,16 +334,20 @@ describe RuboCop::Cop::Style::FrozenStringLiteralComment, :config do
 
         it 'accepts freezing a string when there is a frozen string literal ' \
            'comment' do
-          inspect_source(cop, ['# frozen_string_literal: true',
-                               '"x".freeze'])
+          inspect_source(cop, <<-END.strip_indent)
+            # frozen_string_literal: true
+            "x".freeze
+          END
 
           expect(cop.offenses).to be_empty
         end
 
         it 'accepts shoveling into a string when there is a frozen string ' \
            'literal comment' do
-          inspect_source(cop, ['# frozen_string_literal: true',
-                               '"x" << "y"'])
+          inspect_source(cop, <<-END.strip_indent)
+            # frozen_string_literal: true
+            "x" << "y"
+          END
 
           expect(cop.offenses).to be_empty
         end
@@ -375,8 +433,10 @@ describe RuboCop::Cop::Style::FrozenStringLiteralComment, :config do
 
     it 'registers an offense for a frozen string literal comment ' \
       'on the top line' do
-      inspect_source(cop, ['# frozen_string_literal: true',
-                           'puts 1'])
+      inspect_source(cop, <<-END.strip_indent)
+        # frozen_string_literal: true
+        puts 1
+      END
 
       expect(cop.messages).to eq(['Unnecessary frozen string literal comment.'])
       expect(cop.highlights).to eq(['# frozen_string_literal: true'])
@@ -384,8 +444,10 @@ describe RuboCop::Cop::Style::FrozenStringLiteralComment, :config do
 
     it 'registers an offense for a disabled frozen string literal comment ' \
       'on the top line' do
-      inspect_source(cop, ['# frozen_string_literal: false',
-                           'puts 1'])
+      inspect_source(cop, <<-END.strip_indent)
+        # frozen_string_literal: false
+        puts 1
+      END
 
       expect(cop.messages).to eq(['Unnecessary frozen string literal comment.'])
       expect(cop.highlights).to eq(['# frozen_string_literal: false'])
@@ -399,17 +461,21 @@ describe RuboCop::Cop::Style::FrozenStringLiteralComment, :config do
 
     it 'accepts not having not having a frozen string literal comment ' \
       'under a shebang' do
-      inspect_source(cop, ['#!/usr/bin/env ruby',
-                           'puts 1'])
+      inspect_source(cop, <<-END.strip_indent)
+        #!/usr/bin/env ruby
+        puts 1
+      END
 
       expect(cop.offenses).to be_empty
     end
 
     it 'registers an offense for a frozen string literal comment ' \
       'below a shebang comment' do
-      inspect_source(cop, ['#!/usr/bin/env ruby',
-                           '# frozen_string_literal: true',
-                           'puts 1'])
+      inspect_source(cop, <<-END.strip_indent)
+        #!/usr/bin/env ruby
+        # frozen_string_literal: true
+        puts 1
+      END
 
       expect(cop.messages).to eq(['Unnecessary frozen string literal comment.'])
       expect(cop.highlights).to eq(['# frozen_string_literal: true'])
@@ -417,9 +483,11 @@ describe RuboCop::Cop::Style::FrozenStringLiteralComment, :config do
 
     it 'registers an offense for a disabled frozen string literal ' \
       'below a shebang comment' do
-      inspect_source(cop, ['#!/usr/bin/env ruby',
-                           '# frozen_string_literal: false',
-                           'puts 1'])
+      inspect_source(cop, <<-END.strip_indent)
+        #!/usr/bin/env ruby
+        # frozen_string_literal: false
+        puts 1
+      END
 
       expect(cop.messages).to eq(['Unnecessary frozen string literal comment.'])
       expect(cop.highlights).to eq(['# frozen_string_literal: false'])
@@ -427,17 +495,21 @@ describe RuboCop::Cop::Style::FrozenStringLiteralComment, :config do
 
     it 'allows not having a frozen string literal comment ' \
       'under an encoding comment' do
-      inspect_source(cop, ['# encoding: utf-8',
-                           'puts 1'])
+      inspect_source(cop, <<-END.strip_indent)
+        # encoding: utf-8
+        puts 1
+      END
 
       expect(cop.offenses).to be_empty
     end
 
     it 'registers an offense for a frozen string literal comment below ' \
       'an encoding comment' do
-      inspect_source(cop, ['# encoding: utf-8',
-                           '# frozen_string_literal: true',
-                           'puts 1'])
+      inspect_source(cop, <<-END.strip_indent)
+        # encoding: utf-8
+        # frozen_string_literal: true
+        puts 1
+      END
 
       expect(cop.messages).to eq(['Unnecessary frozen string literal comment.'])
       expect(cop.highlights).to eq(['# frozen_string_literal: true'])
@@ -445,9 +517,11 @@ describe RuboCop::Cop::Style::FrozenStringLiteralComment, :config do
 
     it 'registers an offense for a dsabled frozen string literal below ' \
       'an encoding comment' do
-      inspect_source(cop, ['# encoding: utf-8',
-                           '# frozen_string_literal: false',
-                           'puts 1'])
+      inspect_source(cop, <<-END.strip_indent)
+        # encoding: utf-8
+        # frozen_string_literal: false
+        puts 1
+      END
 
       expect(cop.messages).to eq(['Unnecessary frozen string literal comment.'])
       expect(cop.highlights).to eq(['# frozen_string_literal: false'])
@@ -455,19 +529,23 @@ describe RuboCop::Cop::Style::FrozenStringLiteralComment, :config do
 
     it 'allows not having a frozen string literal comment ' \
       'under a shebang and an encoding comment' do
-      inspect_source(cop, ['#!/usr/bin/env ruby',
-                           '# encoding: utf-8',
-                           'puts 1'])
+      inspect_source(cop, <<-END.strip_indent)
+        #!/usr/bin/env ruby
+        # encoding: utf-8
+        puts 1
+      END
 
       expect(cop.offenses).to be_empty
     end
 
     it 'registers an offense for a frozen string literal comment ' \
       'below shebang and encoding comments' do
-      inspect_source(cop, ['#!/usr/bin/env ruby',
-                           '# encoding: utf-8',
-                           '# frozen_string_literal: true',
-                           'puts 1'])
+      inspect_source(cop, <<-END.strip_indent)
+        #!/usr/bin/env ruby
+        # encoding: utf-8
+        # frozen_string_literal: true
+        puts 1
+      END
 
       expect(cop.messages).to eq(['Unnecessary frozen string literal comment.'])
       expect(cop.highlights).to eq(['# frozen_string_literal: true'])
@@ -475,10 +553,12 @@ describe RuboCop::Cop::Style::FrozenStringLiteralComment, :config do
 
     it 'registers an offense for a disabled frozen string literal comment ' \
       'below shebang and encoding comments' do
-      inspect_source(cop, ['#!/usr/bin/env ruby',
-                           '# encoding: utf-8',
-                           '# frozen_string_literal: false',
-                           'puts 1'])
+      inspect_source(cop, <<-END.strip_indent)
+        #!/usr/bin/env ruby
+        # encoding: utf-8
+        # frozen_string_literal: false
+        puts 1
+      END
 
       expect(cop.messages).to eq(['Unnecessary frozen string literal comment.'])
       expect(cop.highlights).to eq(['# frozen_string_literal: false'])
@@ -486,10 +566,12 @@ describe RuboCop::Cop::Style::FrozenStringLiteralComment, :config do
 
     it 'registers an offense for a frozen string literal comment ' \
       'below shebang above an encoding comments' do
-      inspect_source(cop, ['#!/usr/bin/env ruby',
-                           '# frozen_string_literal: true',
-                           '# encoding: utf-8',
-                           'puts 1'])
+      inspect_source(cop, <<-END.strip_indent)
+        #!/usr/bin/env ruby
+        # frozen_string_literal: true
+        # encoding: utf-8
+        puts 1
+      END
 
       expect(cop.messages).to eq(['Unnecessary frozen string literal comment.'])
       expect(cop.highlights).to eq(['# frozen_string_literal: true'])
@@ -497,10 +579,12 @@ describe RuboCop::Cop::Style::FrozenStringLiteralComment, :config do
 
     it 'registers an offense for a disabled frozen string literal comment ' \
       'below shebang above an encoding comments' do
-      inspect_source(cop, ['#!/usr/bin/env ruby',
-                           '# frozen_string_literal: false',
-                           '# encoding: utf-8',
-                           'puts 1'])
+      inspect_source(cop, <<-END.strip_indent)
+        #!/usr/bin/env ruby
+        # frozen_string_literal: false
+        # encoding: utf-8
+        puts 1
+      END
 
       expect(cop.messages).to eq(['Unnecessary frozen string literal comment.'])
       expect(cop.highlights).to eq(['# frozen_string_literal: false'])
@@ -508,101 +592,141 @@ describe RuboCop::Cop::Style::FrozenStringLiteralComment, :config do
 
     context 'auto-correct' do
       it 'removes the frozen string literal comment from the top line' do
-        new_source = autocorrect_source(cop, ['# frozen_string_literal: true',
-                                              'puts 1'])
+        new_source = autocorrect_source(cop, <<-END.strip_indent)
+          # frozen_string_literal: true
+          puts 1
+        END
 
-        expect(new_source).to eq('puts 1')
+        expect(new_source).to eq(<<-END.strip_indent)
+          puts 1
+        END
       end
 
       it 'removes a disabled frozen string literal comment on the top line' do
-        new_source = autocorrect_source(cop, ['# frozen_string_literal: false',
-                                              'puts 1'])
+        new_source = autocorrect_source(cop, <<-END.strip_indent)
+          # frozen_string_literal: false
+          puts 1
+        END
 
-        expect(new_source).to eq('puts 1')
+        expect(new_source).to eq(<<-END.strip_indent)
+          puts 1
+        END
       end
 
       it 'removes a frozen string literal comment below a shebang comment' do
-        new_source = autocorrect_source(cop, ['#!/usr/bin/env ruby',
-                                              '# frozen_string_literal: true',
-                                              'puts 1'])
+        new_source = autocorrect_source(cop, <<-END.strip_indent)
+          #!/usr/bin/env ruby
+          # frozen_string_literal: true
+          puts 1
+        END
 
-        expect(new_source).to eq(['#!/usr/bin/env ruby',
-                                  'puts 1'].join("\n"))
+        expect(new_source).to eq(<<-END.strip_indent)
+          #!/usr/bin/env ruby
+          puts 1
+        END
       end
 
       it 'removes a disabled frozen string literal below a shebang comment' do
-        new_source = autocorrect_source(cop, ['#!/usr/bin/env ruby',
-                                              '# frozen_string_literal: false',
-                                              'puts 1'])
+        new_source = autocorrect_source(cop, <<-END.strip_indent)
+          #!/usr/bin/env ruby
+          # frozen_string_literal: false
+          puts 1
+        END
 
-        expect(new_source).to eq(['#!/usr/bin/env ruby',
-                                  'puts 1'].join("\n"))
+        expect(new_source).to eq(<<-END.strip_indent)
+          #!/usr/bin/env ruby
+          puts 1
+        END
       end
 
       it 'removes a frozen string literal comment below an encoding comment' do
-        new_source = autocorrect_source(cop, ['# encoding: utf-8',
-                                              '# frozen_string_literal: true',
-                                              'puts 1'])
+        new_source = autocorrect_source(cop, <<-END.strip_indent)
+          # encoding: utf-8
+          # frozen_string_literal: true
+          puts 1
+        END
 
-        expect(new_source).to eq(['# encoding: utf-8',
-                                  'puts 1'].join("\n"))
+        expect(new_source).to eq(<<-END.strip_indent)
+          # encoding: utf-8
+          puts 1
+        END
       end
 
       it 'removes a dsabled frozen string literal below an encoding comment' do
-        new_source = autocorrect_source(cop, ['# encoding: utf-8',
-                                              '# frozen_string_literal: false',
-                                              'puts 1'])
+        new_source = autocorrect_source(cop, <<-END.strip_indent)
+          # encoding: utf-8
+          # frozen_string_literal: false
+          puts 1
+        END
 
-        expect(new_source).to eq(['# encoding: utf-8',
-                                  'puts 1'].join("\n"))
+        expect(new_source).to eq(<<-END.strip_indent)
+          # encoding: utf-8
+          puts 1
+        END
       end
 
       it 'removes a frozen string literal comment ' \
         'below shebang and encoding comments' do
-        new_source = autocorrect_source(cop, ['#!/usr/bin/env ruby',
-                                              '# encoding: utf-8',
-                                              '# frozen_string_literal: true',
-                                              'puts 1'])
+        new_source = autocorrect_source(cop, <<-END.strip_indent)
+          #!/usr/bin/env ruby
+          # encoding: utf-8
+          # frozen_string_literal: true
+          puts 1
+        END
 
-        expect(new_source).to eq(['#!/usr/bin/env ruby',
-                                  '# encoding: utf-8',
-                                  'puts 1'].join("\n"))
+        expect(new_source).to eq(<<-END.strip_indent)
+          #!/usr/bin/env ruby
+          # encoding: utf-8
+          puts 1
+        END
       end
 
       it 'removes a disabled frozen string literal comment from ' \
         'below shebang and encoding comments' do
-        new_source = autocorrect_source(cop, ['#!/usr/bin/env ruby',
-                                              '# encoding: utf-8',
-                                              '# frozen_string_literal: false',
-                                              'puts 1'])
+        new_source = autocorrect_source(cop, <<-END.strip_indent)
+          #!/usr/bin/env ruby
+          # encoding: utf-8
+          # frozen_string_literal: false
+          puts 1
+        END
 
-        expect(new_source).to eq(['#!/usr/bin/env ruby',
-                                  '# encoding: utf-8',
-                                  'puts 1'].join("\n"))
+        expect(new_source).to eq(<<-END.strip_indent)
+          #!/usr/bin/env ruby
+          # encoding: utf-8
+          puts 1
+        END
       end
 
       it 'removes a frozen string literal comment ' \
         'below shebang above an encoding comments' do
-        new_source = autocorrect_source(cop, ['#!/usr/bin/env ruby',
-                                              '# frozen_string_literal: true',
-                                              '# encoding: utf-8',
-                                              'puts 1'])
+        new_source = autocorrect_source(cop, <<-END.strip_indent)
+          #!/usr/bin/env ruby
+          # frozen_string_literal: true
+          # encoding: utf-8
+          puts 1
+        END
 
-        expect(new_source).to eq(['#!/usr/bin/env ruby',
-                                  '# encoding: utf-8',
-                                  'puts 1'].join("\n"))
+        expect(new_source).to eq(<<-END.strip_indent)
+          #!/usr/bin/env ruby
+          # encoding: utf-8
+          puts 1
+        END
       end
 
       it 'removes a disabled frozen string literal comment ' \
         'below shebang above an encoding comments' do
-        new_source = autocorrect_source(cop, ['#!/usr/bin/env ruby',
-                                              '# frozen_string_literal: false',
-                                              '# encoding: utf-8',
-                                              'puts 1'])
+        new_source = autocorrect_source(cop, <<-END.strip_indent)
+          #!/usr/bin/env ruby
+          # frozen_string_literal: false
+          # encoding: utf-8
+          puts 1
+        END
 
-        expect(new_source).to eq(['#!/usr/bin/env ruby',
-                                  '# encoding: utf-8',
-                                  'puts 1'].join("\n"))
+        expect(new_source).to eq(<<-END.strip_indent)
+          #!/usr/bin/env ruby
+          # encoding: utf-8
+          puts 1
+        END
       end
     end
   end

--- a/spec/rubocop/cop/style/guard_clause_spec.rb
+++ b/spec/rubocop/cop/style/guard_clause_spec.rb
@@ -6,18 +6,19 @@ describe RuboCop::Cop::Style::GuardClause, :config do
 
   shared_examples 'reports offense' do |body|
     it 'reports an offense if method body is if / unless without else' do
-      inspect_source(cop,
-                     ['def func',
-                      '  if something',
-                      "    #{body}",
-                      '  end',
-                      'end',
-                      '',
-                      'def func',
-                      '  unless something',
-                      "    #{body}",
-                      '  end',
-                      'end'])
+      inspect_source(cop, <<-END.strip_indent)
+        def func
+          if something
+            #{body}
+          end
+        end
+
+        def func
+          unless something
+            #{body}
+          end
+        end
+      END
       expect(cop.offenses.size).to eq(2)
       expect(cop.offenses.map(&:line).sort).to eq([2, 8])
       expect(cop.messages)
@@ -27,18 +28,19 @@ describe RuboCop::Cop::Style::GuardClause, :config do
     end
 
     it 'reports an offense if method body is if / unless without else' do
-      inspect_source(cop,
-                     ['def func',
-                      '  if something',
-                      "    #{body}",
-                      '  end',
-                      'end',
-                      '',
-                      'def func',
-                      '  unless something',
-                      "    #{body}",
-                      '  end',
-                      'end'])
+      inspect_source(cop, <<-END.strip_indent)
+        def func
+          if something
+            #{body}
+          end
+        end
+
+        def func
+          unless something
+            #{body}
+          end
+        end
+      END
       expect(cop.offenses.size).to eq(2)
       expect(cop.offenses.map(&:line).sort).to eq([2, 8])
       expect(cop.messages)
@@ -48,20 +50,21 @@ describe RuboCop::Cop::Style::GuardClause, :config do
     end
 
     it 'reports an offense if method body ends with if / unless without else' do
-      inspect_source(cop,
-                     ['def func',
-                      '  test',
-                      '  if something',
-                      "    #{body}",
-                      '  end',
-                      'end',
-                      '',
-                      'def func',
-                      '  test',
-                      '  unless something',
-                      "    #{body}",
-                      '  end',
-                      'end'])
+      inspect_source(cop, <<-END.strip_indent)
+        def func
+          test
+          if something
+            #{body}
+          end
+        end
+
+        def func
+          test
+          unless something
+            #{body}
+          end
+        end
+      END
       expect(cop.offenses.size).to eq(2)
       expect(cop.offenses.map(&:line).sort).to eq([3, 10])
       expect(cop.messages)
@@ -75,82 +78,87 @@ describe RuboCop::Cop::Style::GuardClause, :config do
   it_behaves_like('reports offense', '# TODO')
 
   it 'does not report an offense if body is if..elsif..end' do
-    inspect_source(cop,
-                   ['def func',
-                    '  if something',
-                    '    a',
-                    '  elsif something_else',
-                    '    b',
-                    '  end',
-                    'end'])
+    inspect_source(cop, <<-END.strip_indent)
+      def func
+        if something
+          a
+        elsif something_else
+          b
+        end
+      end
+    END
     expect(cop.offenses).to be_empty
   end
 
   it "doesn't report an offense if condition has multiple lines" do
-    inspect_source(cop,
-                   ['def func',
-                    '  if something &&',
-                    '       something_else',
-                    '    work',
-                    '  end',
-                    'end',
-                    '',
-                    'def func',
-                    '  unless something &&',
-                    '           something_else',
-                    '    work',
-                    '  end',
-                    'end'])
+    inspect_source(cop, <<-END.strip_indent)
+      def func
+        if something &&
+             something_else
+          work
+        end
+      end
+
+      def func
+        unless something &&
+                 something_else
+          work
+        end
+      end
+    END
     expect(cop.offenses).to be_empty
   end
 
   it 'accepts a method which body is if / unless with else' do
-    inspect_source(cop,
-                   ['def func',
-                    '  if something',
-                    '    work',
-                    '  else',
-                    '    test',
-                    '  end',
-                    'end',
-                    '',
-                    'def func',
-                    '  unless something',
-                    '    work',
-                    '  else',
-                    '    test',
-                    '  end',
-                    'end'])
+    inspect_source(cop, <<-END.strip_indent)
+      def func
+        if something
+          work
+        else
+          test
+        end
+      end
+
+      def func
+        unless something
+          work
+        else
+          test
+        end
+      end
+    END
     expect(cop.offenses).to be_empty
   end
 
   it 'accepts a method which body does not end with if / unless' do
-    inspect_source(cop,
-                   ['def func',
-                    '  if something',
-                    '    work',
-                    '  end',
-                    '  test',
-                    'end',
-                    '',
-                    'def func',
-                    '  unless something',
-                    '    work',
-                    '  end',
-                    '  test',
-                    'end'])
+    inspect_source(cop, <<-END.strip_indent)
+      def func
+        if something
+          work
+        end
+        test
+      end
+
+      def func
+        unless something
+          work
+        end
+        test
+      end
+    END
     expect(cop.offenses).to be_empty
   end
 
   it 'accepts a method whose body is a modifier if / unless' do
-    inspect_source(cop,
-                   ['def func',
-                    '  work if something',
-                    'end',
-                    '',
-                    'def func',
-                    '  work if something',
-                    'end'])
+    inspect_source(cop, <<-END.strip_indent)
+      def func
+        work if something
+      end
+
+      def func
+        work if something
+      end
+    END
     expect(cop.offenses).to be_empty
   end
 
@@ -160,18 +168,19 @@ describe RuboCop::Cop::Style::GuardClause, :config do
     end
 
     it 'reports an offense for if whose body has 1 line' do
-      inspect_source(cop,
-                     ['def func',
-                      '  if something',
-                      '    work',
-                      '  end',
-                      'end',
-                      '',
-                      'def func',
-                      '  unless something',
-                      '    work',
-                      '  end',
-                      'end'])
+      inspect_source(cop, <<-END.strip_indent)
+        def func
+          if something
+            work
+          end
+        end
+
+        def func
+          unless something
+            work
+          end
+        end
+      END
       expect(cop.offenses.size).to eq(2)
       expect(cop.offenses.map(&:line).sort).to eq([2, 8])
       expect(cop.messages)
@@ -187,22 +196,23 @@ describe RuboCop::Cop::Style::GuardClause, :config do
     end
 
     it 'accepts a method whose body has 3 lines' do
-      inspect_source(cop,
-                     ['def func',
-                      '  if something',
-                      '    work',
-                      '    work',
-                      '    work',
-                      '  end',
-                      'end',
-                      '',
-                      'def func',
-                      '  unless something',
-                      '    work',
-                      '    work',
-                      '    work',
-                      '  end',
-                      'end'])
+      inspect_source(cop, <<-END.strip_indent)
+        def func
+          if something
+            work
+            work
+            work
+          end
+        end
+
+        def func
+          unless something
+            work
+            work
+            work
+          end
+        end
+      END
       expect(cop.offenses).to be_empty
     end
   end
@@ -213,11 +223,13 @@ describe RuboCop::Cop::Style::GuardClause, :config do
     end
 
     it 'fails with an error' do
-      source = ['def func',
-                '  if something',
-                '    work',
-                '  end',
-                'end']
+      source = <<-END.strip_indent
+        def func
+          if something
+            work
+          end
+        end
+      END
 
       expect { inspect_source(cop, source) }
         .to raise_error('MinBodyLength needs to be a positive integer!')
@@ -226,56 +238,64 @@ describe RuboCop::Cop::Style::GuardClause, :config do
 
   shared_examples 'on if nodes which exit current scope' do |kw|
     it "registers an error with #{kw} in the if branch" do
-      inspect_source(cop, ['if something',
-                           "  #{kw}",
-                           'else',
-                           '  puts "hello"',
-                           'end'])
+      inspect_source(cop, <<-END.strip_indent)
+        if something
+          #{kw}
+        else
+          puts "hello"
+        end
+      END
       expect(cop.offenses.size).to eq(1)
       expect(cop.messages).to eq(['Use a guard clause instead of wrapping ' \
                                   'the code inside a conditional expression.'])
     end
 
     it "registers an error with #{kw} in the else branch" do
-      inspect_source(cop, ['if something',
-                           ' puts "hello"',
-                           'else',
-                           "  #{kw}",
-                           'end'])
+      inspect_source(cop, <<-END.strip_indent)
+        if something
+         puts "hello"
+        else
+          #{kw}
+        end
+      END
       expect(cop.offenses.size).to eq(1)
       expect(cop.messages).to eq(['Use a guard clause instead of wrapping ' \
                                   'the code inside a conditional expression.'])
     end
 
     it "doesn't register an error if condition has multiple lines" do
-      inspect_source(cop, ['if something &&',
-                           '     something_else',
-                           "  #{kw}",
-                           'else',
-                           '  puts "hello"',
-                           'end'])
+      inspect_source(cop, <<-END.strip_indent)
+        if something &&
+             something_else
+          #{kw}
+        else
+          puts "hello"
+        end
+      END
       expect(cop.offenses).to be_empty
     end
 
     it "does not report an offense if #{kw} is inside elsif" do
-      inspect_source(cop,
-                     ['if something',
-                      '  a',
-                      'elsif something_else',
-                      "  #{kw}",
-                      'end'])
+      inspect_source(cop, <<-END.strip_indent)
+        if something
+          a
+        elsif something_else
+          #{kw}
+        end
+      END
       expect(cop.offenses).to be_empty
     end
 
     it "does not report an offense if #{kw} is inside if..elsif..else..end" do
-      inspect_source(cop,
-                     ['if something',
-                      '  a',
-                      'elsif something_else',
-                      '  b',
-                      'else',
-                      "  #{kw}",
-                      'end'])
+      inspect_source(cop, <<-END.strip_indent)
+        if something
+          a
+        elsif something_else
+          b
+        else
+          #{kw}
+        end
+      END
       expect(cop.offenses).to be_empty
     end
 
@@ -307,24 +327,28 @@ describe RuboCop::Cop::Style::GuardClause, :config do
 
   context 'method in module' do
     it 'registers an offense for instance method' do
-      inspect_source(cop, ['module CopTest',
-                           '  def test',
-                           '    if something',
-                           '      work',
-                           '    end',
-                           '  end',
-                           'end'])
+      inspect_source(cop, <<-END.strip_indent)
+        module CopTest
+          def test
+            if something
+              work
+            end
+          end
+        end
+      END
       expect(cop.offenses.size).to eq(1)
     end
 
     it 'registers an offense for singleton methods' do
-      inspect_source(cop, ['module CopTest',
-                           '  def self.test',
-                           '    if something',
-                           '      work',
-                           '    end',
-                           '  end',
-                           'end'])
+      inspect_source(cop, <<-END.strip_indent)
+        module CopTest
+          def self.test
+            if something
+              work
+            end
+          end
+        end
+      END
       expect(cop.offenses.size).to eq(1)
     end
   end

--- a/spec/rubocop/cop/style/identical_conditional_branches_spec.rb
+++ b/spec/rubocop/cop/style/identical_conditional_branches_spec.rb
@@ -9,11 +9,13 @@ describe RuboCop::Cop::Style::IdenticalConditionalBranches do
 
   context 'on if..else with identical bodies' do
     let(:source) do
-      ['if something',
-       '  do_x',
-       'else',
-       '  do_x',
-       'end']
+      <<-END.strip_indent
+        if something
+          do_x
+        else
+          do_x
+        end
+      END
     end
 
     it 'registers an offense' do
@@ -27,13 +29,15 @@ describe RuboCop::Cop::Style::IdenticalConditionalBranches do
 
   context 'on if..else with identical trailing lines' do
     let(:source) do
-      ['if something',
-       '  method_call_here(1, 2, 3)',
-       '  do_x',
-       'else',
-       '  1 + 2 + 3',
-       '  do_x',
-       'end']
+      <<-END.strip_indent
+        if something
+          method_call_here(1, 2, 3)
+          do_x
+        else
+          1 + 2 + 3
+          do_x
+        end
+      END
     end
 
     it 'registers an offense' do
@@ -47,13 +51,15 @@ describe RuboCop::Cop::Style::IdenticalConditionalBranches do
 
   context 'on if..else with identical leading lines' do
     let(:source) do
-      ['if something',
-       '  do_x',
-       '  method_call_here(1, 2, 3)',
-       'else',
-       '  do_x',
-       '  1 + 2 + 3',
-       'end']
+      <<-END.strip_indent
+        if something
+          do_x
+          method_call_here(1, 2, 3)
+        else
+          do_x
+          1 + 2 + 3
+        end
+      END
     end
 
     it 'registers an offense' do
@@ -67,11 +73,13 @@ describe RuboCop::Cop::Style::IdenticalConditionalBranches do
 
   context 'on if..elsif with no else' do
     let(:source) do
-      ['if something',
-       '  do_x',
-       'elsif something_else',
-       '  do_x',
-       'end']
+      <<-END.strip_indent
+        if something
+          do_x
+        elsif something_else
+          do_x
+        end
+      END
     end
 
     it "doesn't register an offense" do
@@ -81,11 +89,13 @@ describe RuboCop::Cop::Style::IdenticalConditionalBranches do
 
   context 'on if..else with slightly different trailing lines' do
     let(:source) do
-      ['if something',
-       '  do_x(1)',
-       'else',
-       '  do_x(2)',
-       'end']
+      <<-END.strip_indent
+        if something
+          do_x(1)
+        else
+          do_x(2)
+        end
+      END
     end
 
     it "doesn't register an offense" do
@@ -95,14 +105,16 @@ describe RuboCop::Cop::Style::IdenticalConditionalBranches do
 
   context 'on case with identical bodies' do
     let(:source) do
-      ['case something',
-       'when :a',
-       '  do_x',
-       'when :b',
-       '  do_x',
-       'else',
-       '  do_x',
-       'end']
+      <<-END.strip_indent
+        case something
+        when :a
+          do_x
+        when :b
+          do_x
+        else
+          do_x
+        end
+      END
     end
 
     it 'registers an offense' do
@@ -118,13 +130,15 @@ describe RuboCop::Cop::Style::IdenticalConditionalBranches do
   # Regression: https://github.com/bbatsov/rubocop/issues/3868
   context 'when one of the case branches is empty' do
     let(:source) do
-      ['case value',
-       'when cond1',
-       'else',
-       '  if cond2',
-       '  else',
-       '  end',
-       'end']
+      <<-END.strip_indent
+        case value
+        when cond1
+        else
+          if cond2
+          else
+          end
+        end
+      END
     end
 
     it 'does not register an offense' do
@@ -134,17 +148,19 @@ describe RuboCop::Cop::Style::IdenticalConditionalBranches do
 
   context 'on case with identical trailing lines' do
     let(:source) do
-      ['case something',
-       'when :a',
-       '  x1',
-       '  do_x',
-       'when :b',
-       '  x2',
-       '  do_x',
-       'else',
-       '  x3',
-       '  do_x',
-       'end']
+      <<-END.strip_indent
+        case something
+        when :a
+          x1
+          do_x
+        when :b
+          x2
+          do_x
+        else
+          x3
+          do_x
+        end
+      END
     end
 
     it 'registers an offense' do
@@ -159,17 +175,19 @@ describe RuboCop::Cop::Style::IdenticalConditionalBranches do
 
   context 'on case with identical leading lines' do
     let(:source) do
-      ['case something',
-       'when :a',
-       '  do_x',
-       '  x1',
-       'when :b',
-       '  do_x',
-       '  x2',
-       'else',
-       '  do_x',
-       '  x3',
-       'end']
+      <<-END.strip_indent
+        case something
+        when :a
+          do_x
+          x1
+        when :b
+          do_x
+          x2
+        else
+          do_x
+          x3
+        end
+      END
     end
 
     it 'registers an offense' do
@@ -184,12 +202,14 @@ describe RuboCop::Cop::Style::IdenticalConditionalBranches do
 
   context 'on case without else' do
     let(:source) do
-      ['case something',
-       'when :a',
-       '  do_x',
-       'when :b',
-       '  do_x',
-       'end']
+      <<-END.strip_indent
+        case something
+        when :a
+          do_x
+        when :b
+          do_x
+        end
+      END
     end
 
     it "doesn't register an offense" do
@@ -199,15 +219,17 @@ describe RuboCop::Cop::Style::IdenticalConditionalBranches do
 
   context 'on case with empty when' do
     let(:source) do
-      ['case something',
-       'when :a',
-       '  do_x',
-       '  do_y',
-       'when :b',
-       'else',
-       '  do_x',
-       '  do_z',
-       'end']
+      <<-END.strip_indent
+        case something
+        when :a
+          do_x
+          do_y
+        when :b
+        else
+          do_x
+          do_z
+        end
+      END
     end
 
     it "doesn't register an offense" do

--- a/spec/rubocop/cop/style/if_inside_else_spec.rb
+++ b/spec/rubocop/cop/style/if_inside_else_spec.rb
@@ -4,13 +4,15 @@ describe RuboCop::Cop::Style::IfInsideElse do
   subject(:cop) { described_class.new }
 
   it 'catches an if node nested inside an else' do
-    inspect_source(cop, ['if a',
-                         '  blah',
-                         'else',
-                         '  if b',
-                         '    foo',
-                         '  end',
-                         'end'])
+    inspect_source(cop, <<-END.strip_indent)
+      if a
+        blah
+      else
+        if b
+          foo
+        end
+      end
+    END
     expect(cop.offenses.size).to eq(1)
     expect(cop.messages).to eq(
       ['Convert `if` nested inside `else` to `elsif`.']
@@ -19,15 +21,17 @@ describe RuboCop::Cop::Style::IfInsideElse do
   end
 
   it 'catches an if..else nested inside an else' do
-    inspect_source(cop, ['if a',
-                         '  blah',
-                         'else',
-                         '  if b',
-                         '    foo',
-                         '  else',
-                         '    bar',
-                         '  end',
-                         'end'])
+    inspect_source(cop, <<-END.strip_indent)
+      if a
+        blah
+      else
+        if b
+          foo
+        else
+          bar
+        end
+      end
+    END
     expect(cop.offenses.size).to eq(1)
     expect(cop.messages).to eq(
       ['Convert `if` nested inside `else` to `elsif`.']
@@ -36,11 +40,13 @@ describe RuboCop::Cop::Style::IfInsideElse do
   end
 
   it 'catches a modifier if nested inside an else' do
-    inspect_source(cop, ['if a',
-                         '  blah',
-                         'else',
-                         '  foo if b',
-                         'end'])
+    inspect_source(cop, <<-END.strip_indent)
+      if a
+        blah
+      else
+        foo if b
+      end
+    END
     expect(cop.offenses.size).to eq(1)
     expect(cop.messages).to eq(
       ['Convert `if` nested inside `else` to `elsif`.']
@@ -49,57 +55,67 @@ describe RuboCop::Cop::Style::IfInsideElse do
   end
 
   it "isn't offended if there is a statement following the if node" do
-    inspect_source(cop, ['if a',
-                         '  blah',
-                         'else',
-                         '  if b',
-                         '    foo',
-                         '  end',
-                         '  bar',
-                         'end'])
+    inspect_source(cop, <<-END.strip_indent)
+      if a
+        blah
+      else
+        if b
+          foo
+        end
+        bar
+      end
+    END
     expect(cop.offenses).to be_empty
   end
 
   it "isn't offended if there is a statement preceding the if node" do
-    inspect_source(cop, ['if a',
-                         '  blah',
-                         'else',
-                         '  bar',
-                         '  if b',
-                         '    foo',
-                         '  end',
-                         'end'])
+    inspect_source(cop, <<-END.strip_indent)
+      if a
+        blah
+      else
+        bar
+        if b
+          foo
+        end
+      end
+    END
     expect(cop.offenses).to be_empty
   end
 
   it "isn't offended by if..elsif..else" do
-    inspect_source(cop, ['if a',
-                         '  blah',
-                         'elsif b',
-                         '  blah',
-                         'else',
-                         '  blah',
-                         'end'])
+    inspect_source(cop, <<-END.strip_indent)
+      if a
+        blah
+      elsif b
+        blah
+      else
+        blah
+      end
+    END
     expect(cop.offenses).to be_empty
   end
 
   it 'ignores unless inside else' do
-    inspect_source(cop, ['if a',
-                         '  blah',
-                         'else',
-                         '  unless b',
-                         '    foo',
-                         '  end',
-                         'end'])
+    inspect_source(cop, <<-END.strip_indent)
+      if a
+        blah
+      else
+        unless b
+          foo
+        end
+      end
+    END
     expect(cop.offenses).to be_empty
   end
 
   it 'ignores if inside unless' do
-    inspect_source(cop, ['unless a',
-                         '  if b',
-                         '    foo',
-                         '  end',
-                         'end'])
+    inspect_source(cop, <<-END.strip_indent)
+      unless a
+        if b
+          foo
+        end
+      end
+    END
     expect(cop.offenses).to be_empty
   end
 
@@ -109,11 +125,13 @@ describe RuboCop::Cop::Style::IfInsideElse do
   end
 
   it 'ignores ternary inside if..else' do
-    inspect_source(cop, ['if a',
-                         '  blah',
-                         'else',
-                         '  a ? b : c',
-                         'end'])
+    inspect_source(cop, <<-END.strip_indent)
+      if a
+        blah
+      else
+        a ? b : c
+      end
+    END
     expect(cop.offenses).to be_empty
   end
 end

--- a/spec/rubocop/cop/style/if_unless_modifier_of_if_unless_spec.rb
+++ b/spec/rubocop/cop/style/if_unless_modifier_of_if_unless_spec.rb
@@ -25,9 +25,11 @@ describe RuboCop::Cop::Style::IfUnlessModifierOfIfUnless do
 
   context 'conditional with modifier' do
     let(:source) do
-      ['unless condition',
-       '  then_part',
-       'end if external_condition']
+      <<-END.strip_indent
+        unless condition
+          then_part
+        end if external_condition
+      END
     end
 
     it 'registers an offense' do
@@ -38,9 +40,11 @@ describe RuboCop::Cop::Style::IfUnlessModifierOfIfUnless do
 
   context 'conditional with modifier in body' do
     let(:source) do
-      ['if condition',
-       '  then_part if maybe?',
-       'end']
+      <<-END.strip_indent
+        if condition
+          then_part if maybe?
+        end
+      END
     end
 
     it 'accepts' do
@@ -51,11 +55,13 @@ describe RuboCop::Cop::Style::IfUnlessModifierOfIfUnless do
 
   context 'nested conditionals' do
     let(:source) do
-      ['if external_condition',
-       '  if condition',
-       '    then_part',
-       '  end',
-       'end']
+      <<-END.strip_indent
+        if external_condition
+          if condition
+            then_part
+          end
+        end
+      END
     end
 
     it 'accepts' do

--- a/spec/rubocop/cop/style/if_with_semicolon_spec.rb
+++ b/spec/rubocop/cop/style/if_with_semicolon_spec.rb
@@ -16,8 +16,10 @@ describe RuboCop::Cop::Style::IfWithSemicolon do
   end
 
   it 'can handle modifier conditionals' do
-    inspect_source(cop, ['class Hash',
-                         'end if RUBY_VERSION < "1.8.7"'])
+    inspect_source(cop, <<-END.strip_indent)
+      class Hash
+      end if RUBY_VERSION < "1.8.7"
+    END
     expect(cop.messages).to be_empty
   end
 end

--- a/spec/rubocop/cop/style/indent_array_spec.rb
+++ b/spec/rubocop/cop/style/indent_array_spec.rb
@@ -18,35 +18,42 @@ describe RuboCop::Cop::Style::IndentArray do
 
   context 'when array is operand' do
     it 'accepts correctly indented first element' do
-      inspect_source(cop,
-                     ['a << [',
-                      '  1',
-                      ']'])
+      inspect_source(cop, <<-END.strip_indent)
+        a << [
+          1
+        ]
+      END
       expect(cop.offenses).to be_empty
     end
 
     it 'registers an offense for incorrectly indented first element' do
-      inspect_source(cop,
-                     ['a << [',
-                      ' 1',
-                      ']'])
+      inspect_source(cop, <<-END.strip_indent)
+        a << [
+         1
+        ]
+      END
       expect(cop.highlights).to eq(['1'])
       expect(cop.config_to_allow_offenses).to eq('Enabled' => false)
     end
 
     it 'auto-corrects incorrectly indented first element' do
-      corrected = autocorrect_source(cop, ['a << [',
-                                           ' 1',
-                                           ']'])
-      expect(corrected).to eq ['a << [',
-                               '  1',
-                               ']'].join("\n")
+      corrected = autocorrect_source(cop, <<-END.strip_indent)
+        a << [
+         1
+        ]
+      END
+      expect(corrected).to eq <<-END.strip_indent
+        a << [
+          1
+        ]
+      END
     end
 
     it 'registers an offense for incorrectly indented ]' do
-      inspect_source(cop,
-                     ['a << [',
-                      '  ]'])
+      inspect_source(cop, <<-END.strip_indent)
+        a << [
+          ]
+      END
       expect(cop.highlights).to eq([']'])
       expect(cop.messages)
         .to eq(['Indent the right bracket the same as the start of the line ' \
@@ -58,18 +65,20 @@ describe RuboCop::Cop::Style::IndentArray do
       let(:cop_indent) { 4 }
 
       it 'accepts correctly indented first element' do
-        inspect_source(cop,
-                       ['a << [',
-                        '    1',
-                        ']'])
+        inspect_source(cop, <<-END.strip_indent)
+          a << [
+              1
+          ]
+        END
         expect(cop.offenses).to be_empty
       end
 
       it 'registers an offense for incorrectly indented first element' do
-        inspect_source(cop,
-                       ['a << [',
-                        '  1',
-                        ']'])
+        inspect_source(cop, <<-END.strip_indent)
+          a << [
+            1
+          ]
+        END
         expect(cop.highlights).to eq(['1'])
         expect(cop.config_to_allow_offenses).to eq('Enabled' => false)
       end
@@ -78,22 +87,24 @@ describe RuboCop::Cop::Style::IndentArray do
 
   context 'when array is argument to setter' do
     it 'accepts correctly indented first element' do
-      inspect_source(cop,
-                     ['   config.rack_cache = [',
-                      '     "rails:/",',
-                      '     "rails:/",',
-                      '     false',
-                      '   ]'])
+      inspect_source(cop, <<-END.strip_margin('|'))
+        |   config.rack_cache = [
+        |     "rails:/",
+        |     "rails:/",
+        |     false
+        |   ]
+      END
       expect(cop.offenses).to be_empty
     end
 
     it 'registers an offense for incorrectly indented first element' do
-      inspect_source(cop,
-                     ['   config.rack_cache = [',
-                      '   "rails:/",',
-                      '   "rails:/",',
-                      '   false',
-                      '   ]'])
+      inspect_source(cop, <<-END.strip_margin('|'))
+        |   config.rack_cache = [
+        |   "rails:/",
+        |   "rails:/",
+        |   false
+        |   ]
+      END
       expect(cop.highlights).to eq(['"rails:/"'])
       expect(cop.config_to_allow_offenses).to eq('Enabled' => false)
     end
@@ -101,11 +112,13 @@ describe RuboCop::Cop::Style::IndentArray do
 
   context 'when array is right hand side in assignment' do
     it 'registers an offense for incorrectly indented first element' do
-      inspect_source(cop, ['a = [',
-                           '    1,',
-                           '  2,',
-                           ' 3',
-                           ']'])
+      inspect_source(cop, <<-END.strip_indent)
+        a = [
+            1,
+          2,
+         3
+        ]
+      END
       expect(cop.messages)
         .to eq(['Use 2 spaces for indentation in an array, relative to the ' \
                 'start of the line where the left square bracket is.'])
@@ -114,38 +127,45 @@ describe RuboCop::Cop::Style::IndentArray do
     end
 
     it 'auto-corrects incorrectly indented first element' do
-      corrected = autocorrect_source(cop, ['a = [',
-                                           '    1,',
-                                           '  2,',
-                                           ' 3',
-                                           ']'])
-      expect(corrected).to eq ['a = [',
-                               '  1,',
-                               '  2,',
-                               ' 3',
-                               ']'].join("\n")
+      corrected = autocorrect_source(cop, <<-END.strip_indent)
+        a = [
+            1,
+          2,
+         3
+        ]
+      END
+      expect(corrected).to eq <<-END.strip_indent
+        a = [
+          1,
+          2,
+         3
+        ]
+      END
     end
 
     it 'accepts correctly indented first element' do
-      inspect_source(cop,
-                     ['a = [',
-                      '  1',
-                      ']'])
+      inspect_source(cop, <<-END.strip_indent)
+        a = [
+          1
+        ]
+      END
       expect(cop.offenses).to be_empty
     end
 
     it 'accepts several elements per line' do
-      inspect_source(cop,
-                     ['a = [',
-                      '  1, 2',
-                      ']'])
+      inspect_source(cop, <<-END.strip_indent)
+        a = [
+          1, 2
+        ]
+      END
       expect(cop.offenses).to be_empty
     end
 
     it 'accepts a first element on the same line as the left bracket' do
-      inspect_source(cop,
-                     ['a = [1,',
-                      '     2]'])
+      inspect_source(cop, <<-END.strip_indent)
+        a = [1,
+             2]
+      END
       expect(cop.offenses).to be_empty
     end
 
@@ -178,33 +198,32 @@ describe RuboCop::Cop::Style::IndentArray do
     context 'and arguments are surrounded by parentheses' do
       context 'and EnforcedStyle is special_inside_parentheses' do
         it 'accepts special indentation for first argument' do
-          inspect_source(cop,
-                         # Only the function calls are affected by
-                         # EnforcedStyle setting. Other indentation shall be
-                         # the same regardless of EnforcedStyle.
-                         ['h = [',
-                          '  1',
-                          ']',
-                          'func([',
-                          '       1',
-                          '     ])',
-                          'func(x, [',
-                          '       1',
-                          '     ])',
-                          'h = [1',
-                          ']',
-                          'func([1',
-                          '     ])',
-                          'func(x, [1',
-                          '     ])'])
+          inspect_source(cop, <<-END.strip_indent)
+            h = [
+              1
+            ]
+            func([
+                   1
+                 ])
+            func(x, [
+                   1
+                 ])
+            h = [1
+            ]
+            func([1
+                 ])
+            func(x, [1
+                 ])
+          END
           expect(cop.offenses).to be_empty
         end
 
         it "registers an offense for 'consistent' indentation" do
-          inspect_source(cop,
-                         ['func([',
-                          '  1',
-                          '])'])
+          inspect_source(cop, <<-END.strip_indent)
+            func([
+              1
+            ])
+          END
           expect(cop.messages)
             .to eq(['Use 2 spaces for indentation in an array, relative to ' \
                     'the first position after the preceding left parenthesis.',
@@ -215,10 +234,11 @@ describe RuboCop::Cop::Style::IndentArray do
         end
 
         it "registers an offense for 'align_brackets' indentation" do
-          inspect_source(cop,
-                         ['var = [',
-                          '        1',
-                          '      ]'])
+          inspect_source(cop, <<-END.strip_indent)
+            var = [
+                    1
+                  ]
+          END
           # since there are no parens, warning message is for 'consistent' style
           expect(cop.messages)
             .to eq(['Use 2 spaces for indentation in an array, relative to ' \
@@ -230,28 +250,34 @@ describe RuboCop::Cop::Style::IndentArray do
         end
 
         it 'auto-corrects incorrectly indented first element' do
-          corrected = autocorrect_source(cop, ['func([',
-                                               '  1',
-                                               '])'])
-          expect(corrected).to eq ['func([',
-                                   '       1',
-                                   '     ])'].join("\n")
+          corrected = autocorrect_source(cop, <<-END.strip_indent)
+            func([
+              1
+            ])
+          END
+          expect(corrected).to eq <<-END.strip_indent
+            func([
+                   1
+                 ])
+          END
         end
 
         it 'accepts special indentation for second argument' do
-          inspect_source(cop,
-                         ['body.should have_tag("input", [',
-                          '                       :name])'])
+          inspect_source(cop, <<-END.strip_indent)
+            body.should have_tag("input", [
+                                   :name])
+          END
           expect(cop.offenses).to be_empty
         end
 
         it 'accepts normal indentation for array within array' do
-          inspect_source(cop,
-                         ['puts(',
-                          '  [',
-                          '    [1, 2]',
-                          '  ]',
-                          ')'])
+          inspect_source(cop, <<-END.strip_indent)
+            puts(
+              [
+                [1, 2]
+              ]
+            )
+          END
           expect(cop.offenses).to be_empty
         end
       end
@@ -260,33 +286,32 @@ describe RuboCop::Cop::Style::IndentArray do
         let(:cop_config) { { 'EnforcedStyle' => 'consistent' } }
 
         it 'accepts normal indentation for first argument' do
-          inspect_source(cop,
-                         # Only the function calls are affected by
-                         # EnforcedStyle setting. Other indentation shall be
-                         # the same regardless of EnforcedStyle.
-                         ['h = [',
-                          '  1',
-                          ']',
-                          'func([',
-                          '  1',
-                          '])',
-                          'func(x, [',
-                          '  1',
-                          '])',
-                          'h = [1',
-                          ']',
-                          'func([1',
-                          '])',
-                          'func(x, [1',
-                          '])'])
+          inspect_source(cop, <<-END.strip_indent)
+            h = [
+              1
+            ]
+            func([
+              1
+            ])
+            func(x, [
+              1
+            ])
+            h = [1
+            ]
+            func([1
+            ])
+            func(x, [1
+            ])
+          END
           expect(cop.offenses).to be_empty
         end
 
         it 'registers an offense for incorrect indentation' do
-          inspect_source(cop,
-                         ['func([',
-                          '       1',
-                          '     ])'])
+          inspect_source(cop, <<-END.strip_indent)
+            func([
+                   1
+                 ])
+          END
           expect(cop.messages)
             .to eq(['Use 2 spaces for indentation in an array, relative to ' \
                     'the start of the line where the left square bracket is.',
@@ -298,9 +323,10 @@ describe RuboCop::Cop::Style::IndentArray do
         end
 
         it 'accepts normal indentation for second argument' do
-          inspect_source(cop,
-                         ['body.should have_tag("input", [',
-                          '  :name])'])
+          inspect_source(cop, <<-END.strip_indent)
+            body.should have_tag("input", [
+              :name])
+          END
           expect(cop.offenses).to be_empty
         end
       end
@@ -320,17 +346,19 @@ describe RuboCop::Cop::Style::IndentArray do
       end
 
       it 'accepts a correctly indented multi-line array with brackets' do
-        inspect_source(cop,
-                       ['func x, [',
-                        '  1, 2]'])
+        inspect_source(cop, <<-END.strip_indent)
+          func x, [
+            1, 2]
+        END
         expect(cop.offenses).to be_empty
       end
 
       it 'registers an offense for incorrectly indented multi-line array ' \
          'with brackets' do
-        inspect_source(cop,
-                       ['func x, [',
-                        '       1, 2]'])
+        inspect_source(cop, <<-END.strip_indent)
+          func x, [
+                 1, 2]
+        END
         expect(cop.messages)
           .to eq(['Use 2 spaces for indentation in an array, relative to the ' \
                   'start of the line where the left square bracket is.'])
@@ -344,25 +372,28 @@ describe RuboCop::Cop::Style::IndentArray do
     let(:cop_config) { { 'EnforcedStyle' => 'align_brackets' } }
 
     it 'accepts correctly indented first element' do
-      inspect_source(cop,
-                     ['a = [',
-                      '      1',
-                      '    ]'])
+      inspect_source(cop, <<-END.strip_indent)
+        a = [
+              1
+            ]
+      END
       expect(cop.offenses).to be_empty
     end
 
     it 'accepts several elements per line' do
-      inspect_source(cop,
-                     ['a = [',
-                      '      1, 2',
-                      '    ]'])
+      inspect_source(cop, <<-END.strip_indent)
+        a = [
+              1, 2
+            ]
+      END
       expect(cop.offenses).to be_empty
     end
 
     it 'accepts a first element on the same line as the left bracket' do
-      inspect_source(cop,
-                     ['a = [1,',
-                      '     2]'])
+      inspect_source(cop, <<-END.strip_indent)
+        a = [1,
+             2]
+      END
       expect(cop.offenses).to be_empty
     end
 
@@ -392,10 +423,11 @@ describe RuboCop::Cop::Style::IndentArray do
 
     context "when 'consistent' style is used" do
       it 'registers an offense for incorrect indentation' do
-        inspect_source(cop,
-                       ['func([',
-                        '  1',
-                        '])'])
+        inspect_source(cop, <<-END.strip_indent)
+          func([
+            1
+          ])
+        END
         expect(cop.messages)
           .to eq(['Use 2 spaces for indentation in an array, relative to the' \
                   ' position of the opening bracket.',
@@ -405,24 +437,29 @@ describe RuboCop::Cop::Style::IndentArray do
       end
 
       it 'auto-corrects incorrectly indented first element' do
-        corrected = autocorrect_source(cop, ['var = [',
-                                             '  1',
-                                             ']'])
-        expect(corrected).to eq ['var = [',
-                                 '        1',
-                                 '      ]'].join("\n")
+        corrected = autocorrect_source(cop, <<-END.strip_indent)
+          var = [
+            1
+          ]
+        END
+        expect(corrected).to eq <<-END.strip_indent
+          var = [
+                  1
+                ]
+        END
       end
     end
 
     context "when 'special_inside_parentheses' style is used" do
       it 'registers an offense for incorrect indentation' do
-        inspect_source(cop,
-                       ['var = [',
-                        '  1',
-                        ']',
-                        'func([',
-                        '       1',
-                        '     ])'])
+        inspect_source(cop, <<-END.strip_indent)
+          var = [
+            1
+          ]
+          func([
+                 1
+               ])
+        END
         expect(cop.messages)
           .to eq(['Use 2 spaces for indentation in an array, relative to the' \
                   ' position of the opening bracket.',
@@ -433,9 +470,10 @@ describe RuboCop::Cop::Style::IndentArray do
     end
 
     it 'registers an offense for incorrectly indented ]' do
-      inspect_source(cop,
-                     ['a << [',
-                      '  ]'])
+      inspect_source(cop, <<-END.strip_indent)
+        a << [
+          ]
+      END
       expect(cop.highlights).to eq([']'])
       expect(cop.messages)
         .to eq(['Indent the right bracket the same as the left bracket.'])
@@ -446,20 +484,25 @@ describe RuboCop::Cop::Style::IndentArray do
       let(:cop_indent) { 4 }
 
       it 'accepts correctly indented first element' do
-        inspect_source(cop,
-                       ['a = [',
-                        '        1',
-                        '    ]'])
+        inspect_source(cop, <<-END.strip_indent)
+          a = [
+                  1
+              ]
+        END
         expect(cop.offenses).to be_empty
       end
 
       it 'autocorrects indentation which does not match IndentationWidth' do
-        new_source = autocorrect_source(cop, ['a = [',
-                                              '      1',
-                                              '    ]'])
-        expect(new_source).to eq(['a = [',
-                                  '        1',
-                                  '    ]'].join("\n"))
+        new_source = autocorrect_source(cop, <<-END.strip_indent)
+          a = [
+                1
+              ]
+        END
+        expect(new_source).to eq(<<-END.strip_indent)
+          a = [
+                  1
+              ]
+        END
       end
     end
   end

--- a/spec/rubocop/cop/style/indent_assignment_spec.rb
+++ b/spec/rubocop/cop/style/indent_assignment_spec.rb
@@ -11,8 +11,10 @@ describe RuboCop::Cop::Style::IndentAssignment, :config do
   let(:cop_indent) { nil } # use indentation with from Style/IndentationWidth
 
   it 'registers an offense for incorrectly indented rhs' do
-    inspect_source(cop, ['a =',
-                         'if b ; end'])
+    inspect_source(cop, <<-END.strip_indent)
+      a =
+      if b ; end
+    END
 
     expect(cop.offenses.length).to eq(1)
     expect(cop.highlights).to eq(['if b ; end'])
@@ -20,31 +22,39 @@ describe RuboCop::Cop::Style::IndentAssignment, :config do
   end
 
   it 'allows assignments that do not start on a newline' do
-    inspect_source(cop, ['a = if b',
-                         '      foo',
-                         '    end'])
+    inspect_source(cop, <<-END.strip_indent)
+      a = if b
+            foo
+          end
+    END
 
     expect(cop.offenses).to be_empty
   end
 
   it 'allows a properly indented rhs' do
-    inspect_source(cop, ['a =',
-                         '  if b ; end'])
+    inspect_source(cop, <<-END.strip_indent)
+      a =
+        if b ; end
+    END
 
     expect(cop.offenses).to be_empty
   end
 
   it 'allows a properly indented rhs with fullwidth characters' do
-    inspect_source(cop, ["f 'Ｒｕｂｙ', a =",
-                         '                b'])
+    inspect_source(cop, <<-END.strip_indent)
+      f 'Ｒｕｂｙ', a =
+                      b
+    END
 
     expect(cop.offenses).to be_empty
   end
 
   it 'registers an offense for multi-lhs' do
-    inspect_source(cop, ['a,',
-                         'b =',
-                         'if b ; end'])
+    inspect_source(cop, <<-END.strip_indent)
+      a,
+      b =
+      if b ; end
+    END
 
     expect(cop.offenses.length).to eq(1)
     expect(cop.highlights).to eq(['if b ; end'])
@@ -52,42 +62,54 @@ describe RuboCop::Cop::Style::IndentAssignment, :config do
   end
 
   it 'ignores comparison operators' do
-    inspect_source(cop, ['a ===',
-                         'if b ; end'])
+    inspect_source(cop, <<-END.strip_indent)
+      a ===
+      if b ; end
+    END
 
     expect(cop.offenses).to be_empty
   end
 
   it 'auto-corrects indentation' do
     new_source = autocorrect_source(
-      cop, ['a =',
-            'if b ; end']
+      cop, <<-END.strip_indent
+        a =
+        if b ; end
+      END
     )
 
     expect(new_source)
-      .to eq(['a =',
-              '  if b ; end'].join("\n"))
+      .to eq(<<-END.strip_indent)
+        a =
+          if b ; end
+      END
   end
 
   context 'when indentation width is overridden for this cop only' do
     let(:cop_indent) { 7 }
 
     it 'allows a properly indented rhs' do
-      inspect_source(cop, ['a =',
-                           '       if b ; end'])
+      inspect_source(cop, <<-END.strip_indent)
+        a =
+               if b ; end
+      END
 
       expect(cop.offenses).to be_empty
     end
 
     it 'auto-corrects indentation' do
       new_source = autocorrect_source(
-        cop, ['a =',
-              '  if b ; end']
+        cop, <<-END.strip_indent
+          a =
+            if b ; end
+        END
       )
 
       expect(new_source)
-        .to eq(['a =',
-                '       if b ; end'].join("\n"))
+        .to eq(<<-END.strip_indent)
+          a =
+                 if b ; end
+        END
     end
   end
 end

--- a/spec/rubocop/cop/style/indent_hash_spec.rb
+++ b/spec/rubocop/cop/style/indent_hash_spec.rb
@@ -26,9 +26,10 @@ describe RuboCop::Cop::Style::IndentHash do
 
   shared_examples 'right brace' do
     it 'registers an offense for incorrectly indented }' do
-      inspect_source(cop,
-                     ['a << {',
-                      '  }'])
+      inspect_source(cop, <<-END.strip_indent)
+        a << {
+          }
+      END
       expect(cop.highlights).to eq(['}'])
       expect(cop.messages)
         .to eq(['Indent the right brace the same as the start of the line ' \
@@ -47,20 +48,22 @@ describe RuboCop::Cop::Style::IndentHash do
     end
 
     it 'accepts correctly indented first pair' do
-      inspect_source(cop,
-                     ['a << {',
-                      '    a: 1,',
-                      '  aaa: 222',
-                      '}'])
+      inspect_source(cop, <<-END.strip_indent)
+        a << {
+            a: 1,
+          aaa: 222
+        }
+      END
       expect(cop.offenses).to be_empty
     end
 
     it 'registers an offense for incorrectly indented first pair with :' do
-      inspect_source(cop,
-                     ['a << {',
-                      '       a: 1,',
-                      '     aaa: 222',
-                      '}'])
+      inspect_source(cop, <<-END.strip_indent)
+        a << {
+               a: 1,
+             aaa: 222
+        }
+      END
       expect(cop.highlights).to eq(['a: 1'])
       expect(cop.config_to_allow_offenses).to eq('Enabled' => false)
     end
@@ -78,20 +81,22 @@ describe RuboCop::Cop::Style::IndentHash do
     end
 
     it 'accepts correctly indented first pair' do
-      inspect_source(cop,
-                     ['a << {',
-                      "    'a' => 1,",
-                      "  'aaa' => 222",
-                      '}'])
+      inspect_source(cop, <<-END.strip_indent)
+        a << {
+            'a' => 1,
+          'aaa' => 222
+        }
+      END
       expect(cop.offenses).to be_empty
     end
 
     it 'registers an offense for incorrectly indented first pair with =>' do
-      inspect_source(cop,
-                     ['a << {',
-                      "   'a' => 1,",
-                      " 'aaa' => 222",
-                      '}'])
+      inspect_source(cop, <<-END.strip_indent)
+        a << {
+           'a' => 1,
+         'aaa' => 222
+        }
+      END
       expect(cop.highlights).to eq(["'a' => 1"])
       expect(cop.config_to_allow_offenses).to eq('Enabled' => false)
     end
@@ -101,29 +106,35 @@ describe RuboCop::Cop::Style::IndentHash do
 
   context 'when hash is operand' do
     it 'accepts correctly indented first pair' do
-      inspect_source(cop,
-                     ['a << {',
-                      '  a: 1',
-                      '}'])
+      inspect_source(cop, <<-END.strip_indent)
+        a << {
+          a: 1
+        }
+      END
       expect(cop.offenses).to be_empty
     end
 
     it 'registers an offense for incorrectly indented first pair' do
-      inspect_source(cop,
-                     ['a << {',
-                      ' a: 1',
-                      '}'])
+      inspect_source(cop, <<-END.strip_indent)
+        a << {
+         a: 1
+        }
+      END
       expect(cop.highlights).to eq(['a: 1'])
       expect(cop.config_to_allow_offenses).to eq('Enabled' => false)
     end
 
     it 'auto-corrects incorrectly indented first pair' do
-      corrected = autocorrect_source(cop, ['a << {',
-                                           ' a: 1',
-                                           '}'])
-      expect(corrected).to eq ['a << {',
-                               '  a: 1',
-                               '}'].join("\n")
+      corrected = autocorrect_source(cop, <<-END.strip_indent)
+        a << {
+         a: 1
+        }
+      END
+      expect(corrected).to eq <<-END.strip_indent
+        a << {
+          a: 1
+        }
+      END
     end
 
     include_examples 'right brace'
@@ -131,22 +142,24 @@ describe RuboCop::Cop::Style::IndentHash do
 
   context 'when hash is argument to setter' do
     it 'accepts correctly indented first pair' do
-      inspect_source(cop,
-                     ['   config.rack_cache = {',
-                      '     :metastore => "rails:/",',
-                      '     :entitystore => "rails:/",',
-                      '     :verbose => false',
-                      '   }'])
+      inspect_source(cop, <<-END.strip_margin('|'))
+        |   config.rack_cache = {
+        |     :metastore => "rails:/",
+        |     :entitystore => "rails:/",
+        |     :verbose => false
+        |   }
+      END
       expect(cop.offenses).to be_empty
     end
 
     it 'registers an offense for incorrectly indented first pair' do
-      inspect_source(cop,
-                     ['   config.rack_cache = {',
-                      '   :metastore => "rails:/",',
-                      '   :entitystore => "rails:/",',
-                      '   :verbose => false',
-                      '   }'])
+      inspect_source(cop, <<-END.strip_margin('|'))
+        |   config.rack_cache = {
+        |   :metastore => "rails:/",
+        |   :entitystore => "rails:/",
+        |   :verbose => false
+        |   }
+      END
       expect(cop.highlights).to eq([':metastore => "rails:/"'])
       expect(cop.config_to_allow_offenses).to eq('Enabled' => false)
     end
@@ -154,11 +167,13 @@ describe RuboCop::Cop::Style::IndentHash do
 
   context 'when hash is right hand side in assignment' do
     it 'registers an offense for incorrectly indented first pair' do
-      inspect_source(cop, ['a = {',
-                           '    a: 1,',
-                           '  b: 2,',
-                           ' c: 3',
-                           '}'])
+      inspect_source(cop, <<-END.strip_indent)
+        a = {
+            a: 1,
+          b: 2,
+         c: 3
+        }
+      END
       expect(cop.messages)
         .to eq(['Use 2 spaces for indentation in a hash, relative to the ' \
                 'start of the line where the left curly brace is.'])
@@ -167,38 +182,45 @@ describe RuboCop::Cop::Style::IndentHash do
     end
 
     it 'auto-corrects incorrectly indented first pair' do
-      corrected = autocorrect_source(cop, ['a = {',
-                                           '    a: 1,',
-                                           '  b: 2,',
-                                           ' c: 3',
-                                           '}'])
-      expect(corrected).to eq ['a = {',
-                               '  a: 1,',
-                               '  b: 2,',
-                               ' c: 3',
-                               '}'].join("\n")
+      corrected = autocorrect_source(cop, <<-END.strip_indent)
+        a = {
+            a: 1,
+          b: 2,
+         c: 3
+        }
+      END
+      expect(corrected).to eq <<-END.strip_indent
+        a = {
+          a: 1,
+          b: 2,
+         c: 3
+        }
+      END
     end
 
     it 'accepts correctly indented first pair' do
-      inspect_source(cop,
-                     ['a = {',
-                      '  a: 1',
-                      '}'])
+      inspect_source(cop, <<-END.strip_indent)
+        a = {
+          a: 1
+        }
+      END
       expect(cop.offenses).to be_empty
     end
 
     it 'accepts several pairs per line' do
-      inspect_source(cop,
-                     ['a = {',
-                      '  a: 1, b: 2',
-                      '}'])
+      inspect_source(cop, <<-END.strip_indent)
+        a = {
+          a: 1, b: 2
+        }
+      END
       expect(cop.offenses).to be_empty
     end
 
     it 'accepts a first pair on the same line as the left brace' do
-      inspect_source(cop,
-                     ['a = { "a" => 1,',
-                      '      "b" => 2 }'])
+      inspect_source(cop, <<-END.strip_indent)
+        a = { "a" => 1,
+              "b" => 2 }
+      END
       expect(cop.offenses).to be_empty
     end
 
@@ -218,23 +240,28 @@ describe RuboCop::Cop::Style::IndentHash do
       let(:cop_indent) { 3 }
 
       it 'auto-corrects incorrectly indented first pair' do
-        corrected = autocorrect_source(cop, ['a = {',
-                                             '    a: 1,',
-                                             '  b: 2,',
-                                             ' c: 3',
-                                             '}'])
-        expect(corrected).to eq ['a = {',
-                                 '   a: 1,',
-                                 '  b: 2,',
-                                 ' c: 3',
-                                 '}'].join("\n")
+        corrected = autocorrect_source(cop, <<-END.strip_indent)
+          a = {
+              a: 1,
+            b: 2,
+           c: 3
+          }
+        END
+        expect(corrected).to eq <<-END.strip_indent
+          a = {
+             a: 1,
+            b: 2,
+           c: 3
+          }
+        END
       end
 
       it 'accepts correctly indented first pair' do
-        inspect_source(cop,
-                       ['a = {',
-                        '   a: 1',
-                        '}'])
+        inspect_source(cop, <<-END.strip_indent)
+          a = {
+             a: 1
+          }
+        END
         expect(cop.offenses).to be_empty
       end
     end
@@ -244,33 +271,32 @@ describe RuboCop::Cop::Style::IndentHash do
     context 'and arguments are surrounded by parentheses' do
       context 'and EnforcedStyle is special_inside_parentheses' do
         it 'accepts special indentation for first argument' do
-          inspect_source(cop,
-                         # Only the function calls are affected by
-                         # EnforcedStyle setting. Other indentation shall be
-                         # the same regardless of EnforcedStyle.
-                         ['h = {',
-                          '  a: 1',
-                          '}',
-                          'func({',
-                          '       a: 1',
-                          '     })',
-                          'func(x, {',
-                          '       a: 1',
-                          '     })',
-                          'h = { a: 1',
-                          '}',
-                          'func({ a: 1',
-                          '     })',
-                          'func(x, { a: 1',
-                          '     })'])
+          inspect_source(cop, <<-END.strip_indent)
+            h = {
+              a: 1
+            }
+            func({
+                   a: 1
+                 })
+            func(x, {
+                   a: 1
+                 })
+            h = { a: 1
+            }
+            func({ a: 1
+                 })
+            func(x, { a: 1
+                 })
+          END
           expect(cop.offenses).to be_empty
         end
 
         it "registers an offense for 'consistent' indentation" do
-          inspect_source(cop,
-                         ['func({',
-                          '  a: 1',
-                          '})'])
+          inspect_source(cop, <<-END.strip_indent)
+            func({
+              a: 1
+            })
+          END
           expect(cop.messages)
             .to eq(['Use 2 spaces for indentation in a hash, relative to the' \
                     ' first position after the preceding left parenthesis.',
@@ -281,10 +307,11 @@ describe RuboCop::Cop::Style::IndentHash do
         end
 
         it "registers an offense for 'align_braces' indentation" do
-          inspect_source(cop,
-                         ['var = {',
-                          '        a: 1',
-                          '      }'])
+          inspect_source(cop, <<-END.strip_indent)
+            var = {
+                    a: 1
+                  }
+          END
           # since there are no parens, warning message is for 'consistent' style
           expect(cop.messages)
             .to eq(['Use 2 spaces for indentation in a hash, relative to the' \
@@ -296,28 +323,34 @@ describe RuboCop::Cop::Style::IndentHash do
         end
 
         it 'auto-corrects incorrectly indented first pair' do
-          corrected = autocorrect_source(cop, ['func({',
-                                               '  a: 1',
-                                               '})'])
-          expect(corrected).to eq ['func({',
-                                   '       a: 1',
-                                   '     })'].join("\n")
+          corrected = autocorrect_source(cop, <<-END.strip_indent)
+            func({
+              a: 1
+            })
+          END
+          expect(corrected).to eq <<-END.strip_indent
+            func({
+                   a: 1
+                 })
+          END
         end
 
         it 'accepts special indentation for second argument' do
-          inspect_source(cop,
-                         ['body.should have_tag("input", :attributes => {',
-                          '                       :name => /q\[(id_eq)\]/ })'])
+          inspect_source(cop, <<-'END'.strip_indent)
+            body.should have_tag("input", :attributes => {
+                                   :name => /q\[(id_eq)\]/ })
+          END
           expect(cop.offenses).to be_empty
         end
 
         it 'accepts normal indentation for hash within hash' do
-          inspect_source(cop,
-                         ['scope = scope.where(',
-                          '  klass.table_name => {',
-                          '    reflection.type => model.base_class.sti_name',
-                          '  }',
-                          ')'])
+          inspect_source(cop, <<-END.strip_indent)
+            scope = scope.where(
+              klass.table_name => {
+                reflection.type => model.base_class.sti_name
+              }
+            )
+          END
           expect(cop.offenses).to be_empty
         end
       end
@@ -326,33 +359,32 @@ describe RuboCop::Cop::Style::IndentHash do
         let(:cop_config) { { 'EnforcedStyle' => 'consistent' } }
 
         it 'accepts normal indentation for first argument' do
-          inspect_source(cop,
-                         # Only the function calls are affected by
-                         # EnforcedStyle setting. Other indentation shall be
-                         # the same regardless of EnforcedStyle.
-                         ['h = {',
-                          '  a: 1',
-                          '}',
-                          'func({',
-                          '  a: 1',
-                          '})',
-                          'func(x, {',
-                          '  a: 1',
-                          '})',
-                          'h = { a: 1',
-                          '}',
-                          'func({ a: 1',
-                          '})',
-                          'func(x, { a: 1',
-                          '})'])
+          inspect_source(cop, <<-END.strip_indent)
+            h = {
+              a: 1
+            }
+            func({
+              a: 1
+            })
+            func(x, {
+              a: 1
+            })
+            h = { a: 1
+            }
+            func({ a: 1
+            })
+            func(x, { a: 1
+            })
+          END
           expect(cop.offenses).to be_empty
         end
 
         it 'registers an offense for incorrect indentation' do
-          inspect_source(cop,
-                         ['func({',
-                          '       a: 1',
-                          '     })'])
+          inspect_source(cop, <<-END.strip_indent)
+            func({
+                   a: 1
+                 })
+          END
           expect(cop.messages)
             .to eq(['Use 2 spaces for indentation in a hash, relative to the' \
                     ' start of the line where the left curly brace is.',
@@ -364,9 +396,10 @@ describe RuboCop::Cop::Style::IndentHash do
         end
 
         it 'accepts normal indentation for second argument' do
-          inspect_source(cop,
-                         ['body.should have_tag("input", :attributes => {',
-                          '  :name => /q\[(id_eq)\]/ })'])
+          inspect_source(cop, <<-'END'.strip_indent)
+            body.should have_tag("input", :attributes => {
+              :name => /q\[(id_eq)\]/ })
+          END
           expect(cop.offenses).to be_empty
         end
       end
@@ -386,17 +419,19 @@ describe RuboCop::Cop::Style::IndentHash do
       end
 
       it 'accepts a correctly indented multi-line hash with braces' do
-        inspect_source(cop,
-                       ['func x, {',
-                        '  a: 1, b: 2 }'])
+        inspect_source(cop, <<-END.strip_indent)
+          func x, {
+            a: 1, b: 2 }
+        END
         expect(cop.offenses).to be_empty
       end
 
       it 'registers an offense for incorrectly indented multi-line hash ' \
          'with braces' do
-        inspect_source(cop,
-                       ['func x, {',
-                        '       a: 1, b: 2 }'])
+        inspect_source(cop, <<-END.strip_indent)
+          func x, {
+                 a: 1, b: 2 }
+        END
         expect(cop.messages)
           .to eq(['Use 2 spaces for indentation in a hash, relative to the ' \
                   'start of the line where the left curly brace is.'])
@@ -410,25 +445,28 @@ describe RuboCop::Cop::Style::IndentHash do
     let(:cop_config) { { 'EnforcedStyle' => 'align_braces' } }
 
     it 'accepts correctly indented first pair' do
-      inspect_source(cop,
-                     ['a = {',
-                      '      a: 1',
-                      '    }'])
+      inspect_source(cop, <<-END.strip_indent)
+        a = {
+              a: 1
+            }
+      END
       expect(cop.offenses).to be_empty
     end
 
     it 'accepts several pairs per line' do
-      inspect_source(cop,
-                     ['a = {',
-                      '      a: 1, b: 2',
-                      '    }'])
+      inspect_source(cop, <<-END.strip_indent)
+        a = {
+              a: 1, b: 2
+            }
+      END
       expect(cop.offenses).to be_empty
     end
 
     it 'accepts a first pair on the same line as the left brace' do
-      inspect_source(cop,
-                     ['a = { "a" => 1,',
-                      '      "b" => 2 }'])
+      inspect_source(cop, <<-END.strip_indent)
+        a = { "a" => 1,
+              "b" => 2 }
+      END
       expect(cop.offenses).to be_empty
     end
 
@@ -446,10 +484,11 @@ describe RuboCop::Cop::Style::IndentHash do
 
     context "when 'consistent' style is used" do
       it 'registers an offense for incorrect indentation' do
-        inspect_source(cop,
-                       ['func({',
-                        '  a: 1',
-                        '})'])
+        inspect_source(cop, <<-END.strip_indent)
+          func({
+            a: 1
+          })
+        END
         expect(cop.messages)
           .to eq(['Use 2 spaces for indentation in a hash, relative to the' \
                   ' position of the opening brace.',
@@ -459,24 +498,29 @@ describe RuboCop::Cop::Style::IndentHash do
       end
 
       it 'auto-corrects incorrectly indented first pair' do
-        corrected = autocorrect_source(cop, ['var = {',
-                                             '  a: 1',
-                                             '}'])
-        expect(corrected).to eq ['var = {',
-                                 '        a: 1',
-                                 '      }'].join("\n")
+        corrected = autocorrect_source(cop, <<-END.strip_indent)
+          var = {
+            a: 1
+          }
+        END
+        expect(corrected).to eq <<-END.strip_indent
+          var = {
+                  a: 1
+                }
+        END
       end
     end
 
     context "when 'special_inside_parentheses' style is used" do
       it 'registers an offense for incorrect indentation' do
-        inspect_source(cop,
-                       ['var = {',
-                        '  a: 1',
-                        '}',
-                        'func({',
-                        '       a: 1',
-                        '     })'])
+        inspect_source(cop, <<-END.strip_indent)
+          var = {
+            a: 1
+          }
+          func({
+                 a: 1
+               })
+        END
         expect(cop.messages)
           .to eq(['Use 2 spaces for indentation in a hash, relative to the' \
                   ' position of the opening brace.',
@@ -487,9 +531,10 @@ describe RuboCop::Cop::Style::IndentHash do
     end
 
     it 'registers an offense for incorrectly indented }' do
-      inspect_source(cop,
-                     ['a << {',
-                      '  }'])
+      inspect_source(cop, <<-END.strip_indent)
+        a << {
+          }
+      END
       expect(cop.highlights).to eq(['}'])
       expect(cop.messages)
         .to eq(['Indent the right brace the same as the left brace.'])

--- a/spec/rubocop/cop/style/indentation_consistency_spec.rb
+++ b/spec/rubocop/cop/style/indentation_consistency_spec.rb
@@ -7,56 +7,62 @@ describe RuboCop::Cop::Style::IndentationConsistency, :config do
 
   context 'with if statement' do
     it 'registers an offense for bad indentation in an if body' do
-      inspect_source(cop,
-                     ['if cond',
-                      ' func',
-                      '  func',
-                      'end'])
+      inspect_source(cop, <<-END.strip_indent)
+        if cond
+         func
+          func
+        end
+      END
       expect(cop.messages).to eq(['Inconsistent indentation detected.'])
     end
 
     it 'registers an offense for bad indentation in an else body' do
-      inspect_source(cop,
-                     ['if cond',
-                      '  func1',
-                      'else',
-                      ' func2',
-                      '  func2',
-                      'end'])
+      inspect_source(cop, <<-END.strip_indent)
+        if cond
+          func1
+        else
+         func2
+          func2
+        end
+      END
       expect(cop.messages).to eq(['Inconsistent indentation detected.'])
     end
 
     it 'registers an offense for bad indentation in an elsif body' do
-      inspect_source(cop,
-                     ['if a1',
-                      '  b1',
-                      'elsif a2',
-                      ' b2',
-                      'b3',
-                      'else',
-                      '  c',
-                      'end'])
+      inspect_source(cop, <<-END.strip_indent)
+        if a1
+          b1
+        elsif a2
+         b2
+        b3
+        else
+          c
+        end
+      END
       expect(cop.messages).to eq(['Inconsistent indentation detected.'])
     end
 
     it 'autocorrects bad indentation' do
-      corrected = autocorrect_source(cop,
-                                     ['if a1',
-                                      '   b1',
-                                      'elsif a2',
-                                      ' b2',
-                                      '  b3',
-                                      'else',
-                                      '    c',
-                                      'end'])
-      expect(corrected).to eq ['if a1',
-                               '   b1',
-                               'elsif a2',
-                               ' b2',
-                               ' b3',
-                               'else',
-                               '    c',
-                               'end'].join("\n")
+      corrected = autocorrect_source(cop, <<-END.strip_indent)
+        if a1
+           b1
+        elsif a2
+         b2
+          b3
+        else
+            c
+        end
+      END
+      expect(corrected).to eq <<-END.strip_indent
+        if a1
+           b1
+        elsif a2
+         b2
+         b3
+        else
+            c
+        end
+      END
     end
 
     it 'accepts a one line if statement' do
@@ -65,331 +71,362 @@ describe RuboCop::Cop::Style::IndentationConsistency, :config do
     end
 
     it 'accepts a correctly aligned if/elsif/else/end' do
-      inspect_source(cop,
-                     ['if a1',
-                      '  b1',
-                      'elsif a2',
-                      '  b2',
-                      'else',
-                      '  c',
-                      'end'])
+      inspect_source(cop, <<-END.strip_indent)
+        if a1
+          b1
+        elsif a2
+          b2
+        else
+          c
+        end
+      END
       expect(cop.offenses).to be_empty
     end
 
     it 'accepts if/elsif/else/end laid out as a table' do
-      inspect_source(cop,
-                     ['if    @io == $stdout then str << "$stdout"',
-                      'elsif @io == $stdin  then str << "$stdin"',
-                      'elsif @io == $stderr then str << "$stderr"',
-                      'else                      str << @io.class.to_s',
-                      'end'])
+      inspect_source(cop, <<-END.strip_indent)
+        if    @io == $stdout then str << "$stdout"
+        elsif @io == $stdin  then str << "$stdin"
+        elsif @io == $stderr then str << "$stderr"
+        else                      str << @io.class.to_s
+        end
+      END
       expect(cop.offenses).to be_empty
     end
 
     it 'accepts if/then/else/end laid out as another table' do
-      inspect_source(cop,
-                     ["if File.exist?('config.save')",
-                      'then ConfigTable.load',
-                      'else ConfigTable.new',
-                      'end'])
+      inspect_source(cop, <<-END.strip_indent)
+        if File.exist?('config.save')
+        then ConfigTable.load
+        else ConfigTable.new
+        end
+      END
       expect(cop.offenses).to be_empty
     end
 
     it 'accepts if/elsif/else/end with fullwidth characters' do
-      inspect_source(cop,
-                     ["p 'Ｒｕｂｙ', if a then b",
-                      '                        c',
-                      '              end'])
+      inspect_source(cop, <<-END.strip_indent)
+        p 'Ｒｕｂｙ', if a then b
+                                c
+                      end
+      END
       expect(cop.offenses).to be_empty
     end
 
     it 'accepts an empty if' do
-      inspect_source(cop,
-                     ['if a',
-                      'else',
-                      'end'])
+      inspect_source(cop, <<-END.strip_indent)
+        if a
+        else
+        end
+      END
       expect(cop.offenses).to be_empty
     end
 
     it 'accepts an if in assignment with end aligned with variable' do
-      inspect_source(cop,
-                     ['var = if a',
-                      '  0',
-                      'end',
-                      '@var = if a',
-                      '  0',
-                      'end',
-                      '$var = if a',
-                      '  0',
-                      'end',
-                      'var ||= if a',
-                      '  0',
-                      'end',
-                      'var &&= if a',
-                      '  0',
-                      'end',
-                      'var -= if a',
-                      '  0',
-                      'end',
-                      'VAR = if a',
-                      '  0',
-                      'end'])
+      inspect_source(cop, <<-END.strip_indent)
+        var = if a
+          0
+        end
+        @var = if a
+          0
+        end
+        $var = if a
+          0
+        end
+        var ||= if a
+          0
+        end
+        var &&= if a
+          0
+        end
+        var -= if a
+          0
+        end
+        VAR = if a
+          0
+        end
+      END
       expect(cop.offenses).to be_empty
     end
 
     it 'accepts an if/else in assignment with end aligned with variable' do
-      inspect_source(cop,
-                     ['var = if a',
-                      '  0',
-                      'else',
-                      '  1',
-                      'end'])
+      inspect_source(cop, <<-END.strip_indent)
+        var = if a
+          0
+        else
+          1
+        end
+      END
       expect(cop.offenses).to be_empty
     end
 
     it 'accepts an if/else in assignment with end aligned with variable ' \
        'and chaining after the end' do
-      inspect_source(cop,
-                     ['var = if a',
-                      '  0',
-                      'else',
-                      '  1',
-                      'end.abc.join("")'])
+      inspect_source(cop, <<-END.strip_indent)
+        var = if a
+          0
+        else
+          1
+        end.abc.join("")
+      END
       expect(cop.offenses).to be_empty
     end
 
     it 'accepts an if/else in assignment with end aligned with variable ' \
        'and chaining with a block after the end' do
-      inspect_source(cop,
-                     ['var = if a',
-                      '  0',
-                      'else',
-                      '  1',
-                      'end.abc.tap {}'])
+      inspect_source(cop, <<-END.strip_indent)
+        var = if a
+          0
+        else
+          1
+        end.abc.tap {}
+      END
       expect(cop.offenses).to be_empty
     end
 
     it 'accepts an if in assignment with end aligned with if' do
-      inspect_source(cop,
-                     ['var = if a',
-                      '        0',
-                      '      end'])
+      inspect_source(cop, <<-END.strip_indent)
+        var = if a
+                0
+              end
+      END
       expect(cop.offenses).to be_empty
     end
 
     it 'accepts an if/else in assignment with end aligned with if' do
-      inspect_source(cop,
-                     ['var = if a',
-                      '        0',
-                      '      else',
-                      '        1',
-                      '      end'])
+      inspect_source(cop, <<-END.strip_indent)
+        var = if a
+                0
+              else
+                1
+              end
+      END
       expect(cop.offenses).to be_empty
     end
 
     it 'accepts an if/else in assignment on next line with end aligned ' \
        'with if' do
-      inspect_source(cop,
-                     ['var =',
-                      '  if a',
-                      '    0',
-                      '  else',
-                      '    1',
-                      '  end'])
+      inspect_source(cop, <<-END.strip_indent)
+        var =
+          if a
+            0
+          else
+            1
+          end
+      END
       expect(cop.offenses).to be_empty
     end
 
     it 'accepts an if/else branches with rescue clauses' do
       # Because of how the rescue clauses come out of Parser, these are
       # special and need to be tested.
-      inspect_source(cop,
-                     ['if a',
-                      '  a rescue nil',
-                      'else',
-                      '  a rescue nil',
-                      'end'])
+      inspect_source(cop, <<-END.strip_indent)
+        if a
+          a rescue nil
+        else
+          a rescue nil
+        end
+      END
       expect(cop.offenses).to be_empty
     end
   end
 
   context 'with unless' do
     it 'registers an offense for bad indentation in an unless body' do
-      inspect_source(cop,
-                     ['unless cond',
-                      ' func',
-                      '  func',
-                      'end'])
+      inspect_source(cop, <<-END.strip_indent)
+        unless cond
+         func
+          func
+        end
+      END
       expect(cop.messages).to eq(['Inconsistent indentation detected.'])
     end
 
     it 'accepts an empty unless' do
-      inspect_source(cop,
-                     ['unless a',
-                      'else',
-                      'end'])
+      inspect_source(cop, <<-END.strip_indent)
+        unless a
+        else
+        end
+      END
       expect(cop.offenses).to be_empty
     end
   end
 
   context 'with case' do
     it 'registers an offense for bad indentation in a case/when body' do
-      inspect_source(cop,
-                     ['case a',
-                      'when b',
-                      ' c',
-                      '    d',
-                      'end'])
+      inspect_source(cop, <<-END.strip_indent)
+        case a
+        when b
+         c
+            d
+        end
+      END
       expect(cop.messages).to eq(['Inconsistent indentation detected.'])
     end
 
     it 'registers an offense for bad indentation in a case/else body' do
-      inspect_source(cop,
-                     ['case a',
-                      'when b',
-                      '  c',
-                      'when d',
-                      '  e',
-                      'else',
-                      '   f',
-                      '  g',
-                      'end'])
+      inspect_source(cop, <<-END.strip_indent)
+        case a
+        when b
+          c
+        when d
+          e
+        else
+           f
+          g
+        end
+      END
       expect(cop.messages).to eq(['Inconsistent indentation detected.'])
     end
 
     it 'accepts correctly indented case/when/else' do
-      inspect_source(cop,
-                     ['case a',
-                      'when b',
-                      '  c',
-                      '  c',
-                      'when d',
-                      'else',
-                      '  f',
-                      'end'])
+      inspect_source(cop, <<-END.strip_indent)
+        case a
+        when b
+          c
+          c
+        when d
+        else
+          f
+        end
+      END
       expect(cop.offenses).to be_empty
     end
 
     it 'accepts case/when/else laid out as a table' do
-      inspect_source(cop,
-                     ['case sexp.loc.keyword.source',
-                      "when 'if'     then cond, body, _else = *sexp",
-                      "when 'unless' then cond, _else, body = *sexp",
-                      'else               cond, body = *sexp',
-                      'end'])
+      inspect_source(cop, <<-END.strip_indent)
+        case sexp.loc.keyword.source
+        when 'if'     then cond, body, _else = *sexp
+        when 'unless' then cond, _else, body = *sexp
+        else               cond, body = *sexp
+        end
+      END
       expect(cop.offenses).to be_empty
     end
 
     it 'accepts case/when/else with then beginning a line' do
-      inspect_source(cop,
-                     ['case sexp.loc.keyword.source',
-                      "when 'if'",
-                      'then cond, body, _else = *sexp',
-                      'end'])
+      inspect_source(cop, <<-END.strip_indent)
+        case sexp.loc.keyword.source
+        when 'if'
+        then cond, body, _else = *sexp
+        end
+      END
       expect(cop.offenses).to be_empty
     end
 
     it 'accepts indented when/else plus indented body' do
       # "Indent when as deep as case" is the job of another cop.
-      inspect_source(cop,
-                     ['case code_type',
-                      "  when 'ruby', 'sql', 'plain'",
-                      '    code_type',
-                      "  when 'erb'",
-                      "    'ruby; html-script: true'",
-                      '  when "html"',
-                      "    'xml'",
-                      '  else',
-                      "    'plain'",
-                      'end'])
+      inspect_source(cop, <<-END.strip_indent)
+        case code_type
+          when 'ruby', 'sql', 'plain'
+            code_type
+          when 'erb'
+            'ruby; html-script: true'
+          when "html"
+            'xml'
+          else
+            'plain'
+        end
+      END
       expect(cop.offenses).to be_empty
     end
   end
 
   context 'with while/until' do
     it 'registers an offense for bad indentation in a while body' do
-      inspect_source(cop,
-                     ['while cond',
-                      ' func',
-                      '  func',
-                      'end'])
+      inspect_source(cop, <<-END.strip_indent)
+        while cond
+         func
+          func
+        end
+      END
       expect(cop.messages).to eq(['Inconsistent indentation detected.'])
     end
 
     it 'registers an offense for bad indentation in begin/end/while' do
-      inspect_source(cop,
-                     ['something = begin',
-                      ' func1',
-                      '   func2',
-                      'end while cond'])
+      inspect_source(cop, <<-END.strip_indent)
+        something = begin
+         func1
+           func2
+        end while cond
+      END
       expect(cop.messages).to eq(['Inconsistent indentation detected.'])
     end
 
     it 'registers an offense for bad indentation in an until body' do
-      inspect_source(cop,
-                     ['until cond',
-                      ' func',
-                      '  func',
-                      'end'])
+      inspect_source(cop, <<-END.strip_indent)
+        until cond
+         func
+          func
+        end
+      END
       expect(cop.messages).to eq(['Inconsistent indentation detected.'])
     end
 
     it 'accepts an empty while' do
-      inspect_source(cop,
-                     ['while a',
-                      'end'])
+      inspect_source(cop, <<-END.strip_indent)
+        while a
+        end
+      END
       expect(cop.offenses).to be_empty
     end
   end
 
   context 'with for' do
     it 'registers an offense for bad indentation in a for body' do
-      inspect_source(cop,
-                     ['for var in 1..10',
-                      ' func',
-                      'func',
-                      'end'])
+      inspect_source(cop, <<-END.strip_indent)
+        for var in 1..10
+         func
+        func
+        end
+      END
       expect(cop.messages).to eq(['Inconsistent indentation detected.'])
     end
 
     it 'accepts an empty for' do
-      inspect_source(cop,
-                     ['for var in 1..10',
-                      'end'])
+      inspect_source(cop, <<-END.strip_indent)
+        for var in 1..10
+        end
+      END
       expect(cop.offenses).to be_empty
     end
   end
 
   context 'with def/defs' do
     it 'registers an offense for bad indentation in a def body' do
-      inspect_source(cop,
-                     ['def test',
-                      '    func1',
-                      '     func2',
-                      'end'])
+      inspect_source(cop, <<-END.strip_indent)
+        def test
+            func1
+             func2
+        end
+      END
       expect(cop.messages)
         .to eq(['Inconsistent indentation detected.'])
     end
 
     it 'registers an offense for bad indentation in a defs body' do
-      inspect_source(cop,
-                     ['def self.test',
-                      '   func',
-                      '    func',
-                      'end'])
+      inspect_source(cop, <<-END.strip_indent)
+        def self.test
+           func
+            func
+        end
+      END
       expect(cop.messages).to eq(['Inconsistent indentation detected.'])
     end
 
     it 'accepts an empty def body' do
-      inspect_source(cop,
-                     ['def test',
-                      'end'])
+      inspect_source(cop, <<-END.strip_indent)
+        def test
+        end
+      END
       expect(cop.offenses).to be_empty
     end
 
     it 'accepts an empty defs body' do
-      inspect_source(cop,
-                     ['def self.test',
-                      'end'])
+      inspect_source(cop, <<-END.strip_indent)
+        def self.test
+        end
+      END
       expect(cop.offenses).to be_empty
     end
   end
@@ -399,101 +436,106 @@ describe RuboCop::Cop::Style::IndentationConsistency, :config do
       let(:cop_config) { { 'EnforcedStyle' => 'rails' } }
 
       it 'accepts different indentation in different visibility sections' do
-        inspect_source(cop,
-                       ['class Cat',
-                        '  def meow',
-                        "    puts('Meow!')",
-                        '  end',
-                        '',
-                        '  protected',
-                        '',
-                        '    def can_we_be_friends?(another_cat)',
-                        '      # some logic',
-                        '    end',
-                        '',
-                        '    def related_to?(another_cat)',
-                        '      # some logic',
-                        '    end',
-                        '',
-                        '  private',
-                        '',
+        inspect_source(cop, <<-END.strip_indent)
+          class Cat
+            def meow
+              puts('Meow!')
+            end
+
+            protected
+
+              def can_we_be_friends?(another_cat)
+                # some logic
+              end
+
+              def related_to?(another_cat)
+                # some logic
+              end
+
+            private
+
                         # Here we go back an indentation level again. This is a
                         # violation of the Rails style, but it's not for this
                         # cop to report. Style/IndentationWidth will handle it.
-                        '  def meow_at_3am?',
-                        '    rand < 0.8',
-                        '  end',
-                        '',
+            def meow_at_3am?
+              rand < 0.8
+            end
+
                         # As long as the indentation of this method is
                         # consistent with that of the last one, we're fine.
-                        '  def meow_at_4am?',
-                        '    rand < 0.8',
-                        '  end',
-                        'end'])
+            def meow_at_4am?
+              rand < 0.8
+            end
+          end
+        END
         expect(cop.offenses).to be_empty
       end
     end
 
     context 'with normal style configured' do
       it 'registers an offense for bad indentation in a class body' do
-        inspect_source(cop,
-                       ['class Test',
-                        '    def func1',
-                        '    end',
-                        '  def func2',
-                        '  end',
-                        'end'])
+        inspect_source(cop, <<-END.strip_indent)
+          class Test
+              def func1
+              end
+            def func2
+            end
+          end
+        END
         expect(cop.messages)
           .to eq(['Inconsistent indentation detected.'])
       end
 
       it 'accepts an empty class body' do
-        inspect_source(cop,
-                       ['class Test',
-                        'end'])
+        inspect_source(cop, <<-END.strip_indent)
+          class Test
+          end
+        END
         expect(cop.offenses).to be_empty
       end
 
       it 'accepts indented public, protected, and private' do
-        inspect_source(cop,
-                       ['class Test',
-                        '  public',
-                        '',
-                        '  def e',
-                        '  end',
-                        '',
-                        '  protected',
-                        '',
-                        '  def f',
-                        '  end',
-                        '',
-                        '  private',
-                        '',
-                        '  def g',
-                        '  end',
-                        'end'])
+        inspect_source(cop, <<-END.strip_indent)
+          class Test
+            public
+
+            def e
+            end
+
+            protected
+
+            def f
+            end
+
+            private
+
+            def g
+            end
+          end
+        END
         expect(cop.offenses).to be_empty
       end
 
       it 'registers an offense for bad indentation in def but not for ' \
          'outdented public, protected, and private' do
-        inspect_source(cop,
-                       ['class Test',
-                        'public',
-                        '',
-                        '  def e',
-                        '  end',
-                        '',
-                        'protected',
-                        '',
-                        '  def f',
-                        '  end',
-                        '',
-                        'private',
-                        '',
-                        ' def g',
-                        ' end',
-                        'end'])
+        inspect_source(cop, <<-END.strip_indent)
+          class Test
+          public
+
+            def e
+            end
+
+          protected
+
+            def f
+            end
+
+          private
+
+           def g
+           end
+          end
+        END
         expect(cop.messages).to eq(['Inconsistent indentation detected.'])
         expect(cop.highlights).to eq(["def g\n end"])
       end
@@ -502,88 +544,97 @@ describe RuboCop::Cop::Style::IndentationConsistency, :config do
 
   context 'with module' do
     it 'registers an offense for bad indentation in a module body' do
-      inspect_source(cop,
-                     ['module Test',
-                      '    def func1',
-                      '    end',
-                      '     def func2',
-                      '     end',
-                      'end'])
+      inspect_source(cop, <<-END.strip_indent)
+        module Test
+            def func1
+            end
+             def func2
+             end
+        end
+      END
       expect(cop.messages).to eq(['Inconsistent indentation detected.'])
     end
 
     it 'accepts an empty module body' do
-      inspect_source(cop,
-                     ['module Test',
-                      'end'])
+      inspect_source(cop, <<-END.strip_indent)
+        module Test
+        end
+      END
       expect(cop.offenses).to be_empty
     end
   end
 
   context 'with block' do
     it 'registers an offense for bad indentation in a do/end body' do
-      inspect_source(cop,
-                     ['a = func do',
-                      ' b',
-                      '  c',
-                      'end'])
+      inspect_source(cop, <<-END.strip_indent)
+        a = func do
+         b
+          c
+        end
+      END
       expect(cop.messages).to eq(['Inconsistent indentation detected.'])
     end
 
     it 'registers an offense for bad indentation in a {} body' do
-      inspect_source(cop,
-                     ['func {',
-                      '   b',
-                      '  c',
-                      '}'])
+      inspect_source(cop, <<-END.strip_indent)
+        func {
+           b
+          c
+        }
+      END
       expect(cop.messages).to eq(['Inconsistent indentation detected.'])
     end
 
     it 'accepts a correctly indented block body' do
-      inspect_source(cop,
-                     ['a = func do',
-                      '  b',
-                      '  c',
-                      'end'])
+      inspect_source(cop, <<-END.strip_indent)
+        a = func do
+          b
+          c
+        end
+      END
       expect(cop.offenses).to be_empty
     end
 
     it 'accepts an empty block body' do
-      inspect_source(cop,
-                     ['a = func do',
-                      'end'])
+      inspect_source(cop, <<-END.strip_indent)
+        a = func do
+        end
+      END
       expect(cop.offenses).to be_empty
     end
 
     it 'does not auto-correct an offense within another offense' do
-      corrected = autocorrect_source(cop,
-                                     ["require 'spec_helper'",
-                                      'describe ArticlesController do',
-                                      '  render_views',
-                                      '    describe "GET \'index\'" do',
-                                      '            it "returns success" do',
-                                      '            end',
-                                      '        describe "admin user" do',
-                                      '             before(:each) do',
-                                      '            end',
-                                      '        end',
-                                      '    end',
-                                      'end'])
+      corrected = autocorrect_source(cop, <<-END.strip_indent)
+        require 'spec_helper'
+        describe ArticlesController do
+          render_views
+            describe "GET \'index\'" do
+                    it "returns success" do
+                    end
+                describe "admin user" do
+                     before(:each) do
+                    end
+                end
+            end
+        end
+      END
       expect(cop.offenses.map(&:line)).to eq [4, 7] # Two offenses are found.
 
       # The offense on line 4 is corrected, affecting lines 4 to 11.
-      expect(corrected).to eq ["require 'spec_helper'",
-                               'describe ArticlesController do',
-                               '  render_views',
-                               "  describe \"GET 'index'\" do",
-                               '          it "returns success" do',
-                               '          end',
-                               '      describe "admin user" do',
-                               '           before(:each) do',
-                               '          end',
-                               '      end',
-                               '  end',
-                               'end'].join("\n")
+      expect(corrected).to eq <<-END.strip_indent
+        require 'spec_helper'
+        describe ArticlesController do
+          render_views
+          describe \"GET 'index'\" do
+                  it "returns success" do
+                  end
+              describe "admin user" do
+                   before(:each) do
+                  end
+              end
+          end
+        end
+      END
     end
   end
 end

--- a/spec/rubocop/cop/style/indentation_width_spec.rb
+++ b/spec/rubocop/cop/style/indentation_width_spec.rb
@@ -23,10 +23,12 @@ describe RuboCop::Cop::Style::IndentationWidth do
       let(:bom) { "\xef\xbb\xbf" }
 
       it 'accepts correctly indented method definition' do
-        inspect_source(cop, ["#{bom}class Test",
-                             '    def method',
-                             '    end',
-                             'end'])
+        inspect_source(cop, <<-END.strip_indent)
+          #{bom}class Test
+              def method
+              end
+          end
+        END
         expect(cop.offenses).to be_empty
       end
     end
@@ -40,29 +42,32 @@ describe RuboCop::Cop::Style::IndentationWidth do
       end
 
       it 'accepts unindented lines for those keywords' do
-        inspect_source(cop, ['module Foo',
-                             'class Test',
-                             '    if blah',
-                             '        if blah == Apple',
-                             'puts "sweet"',
-                             '        elsif blah == Lemon',
-                             'puts "sour"',
-                             '        elsif blah == popcorn',
-                             '            puts "salty"',
-                             '        end',
-                             '    end',
-                             'end',
-                             'end'])
+        inspect_source(cop, <<-END.strip_indent)
+          module Foo
+          class Test
+              if blah
+                  if blah == Apple
+          puts "sweet"
+                  elsif blah == Lemon
+          puts "sour"
+                  elsif blah == popcorn
+                      puts "salty"
+                  end
+              end
+          end
+          end
+        END
         expect(cop.offenses).to be_empty
       end
     end
 
     context 'with if statement' do
       it 'registers an offense for bad indentation of an if body' do
-        inspect_source(cop,
-                       ['if cond',
-                        ' func',
-                        'end'])
+        inspect_source(cop, <<-END.strip_indent)
+          if cond
+           func
+          end
+        END
         expect(cop.messages).to eq(['Use 4 (not 1) spaces for indentation.'])
         expect(cop.highlights).to eq([' '])
       end
@@ -70,24 +75,27 @@ describe RuboCop::Cop::Style::IndentationWidth do
 
     describe '#autocorrect' do
       it 'corrects bad indentation' do
-        corrected = autocorrect_source(cop,
-                                       ['if a1',
-                                        '   b1',
-                                        '   b1',
-                                        'elsif a2',
-                                        ' b2',
-                                        'else',
-                                        '    c',
-                                        'end'])
-        expect(corrected)
-          .to eq ['if a1',
-                  '    b1',
-                  '   b1', # Will be corrected by IndentationConsistency.
-                  'elsif a2',
-                  '    b2',
-                  'else',
-                  '    c',
-                  'end'].join("\n")
+        corrected = autocorrect_source(cop, <<-END.strip_indent)
+          if a1
+             b1
+             b1
+          elsif a2
+           b2
+          else
+              c
+          end
+        END
+        # The second `b1` will be corrected by IndentationConsistency.
+        expect(corrected).to eq <<-END.strip_indent
+          if a1
+              b1
+             b1
+          elsif a2
+              b2
+          else
+              c
+          end
+        END
       end
     end
   end
@@ -97,207 +105,221 @@ describe RuboCop::Cop::Style::IndentationWidth do
 
     context 'with if statement' do
       it 'registers an offense for bad indentation of an if body' do
-        inspect_source(cop,
-                       ['if cond',
-                        ' func',
-                        'end'])
+        inspect_source(cop, <<-END.strip_indent)
+          if cond
+           func
+          end
+        END
         expect(cop.messages).to eq(['Use 2 (not 1) spaces for indentation.'])
         expect(cop.highlights).to eq([' '])
       end
 
       it 'registers an offense for bad indentation of an else body' do
-        inspect_source(cop,
-                       ['if cond',
-                        '  func1',
-                        'else',
-                        ' func2',
-                        'end'])
+        inspect_source(cop, <<-END.strip_indent)
+          if cond
+            func1
+          else
+           func2
+          end
+        END
         expect(cop.messages).to eq(['Use 2 (not 1) spaces for indentation.'])
         expect(cop.highlights).to eq([' '])
       end
 
       it 'registers an offense for bad indentation of an elsif body' do
-        inspect_source(cop,
-                       ['if a1',
-                        '  b1',
-                        'elsif a2',
-                        ' b2',
-                        'else',
-                        '  c',
-                        'end'])
+        inspect_source(cop, <<-END.strip_indent)
+          if a1
+            b1
+          elsif a2
+           b2
+          else
+            c
+          end
+        END
         expect(cop.messages).to eq(['Use 2 (not 1) spaces for indentation.'])
       end
 
       it 'registers offense for bad indentation of ternary inside else' do
-        inspect_source(cop,
-                       ['if a',
-                        '  b',
-                        'else',
-                        '     x ? y : z',
-                        'end'])
+        inspect_source(cop, <<-END.strip_indent)
+          if a
+            b
+          else
+               x ? y : z
+          end
+        END
         expect(cop.messages)
           .to eq(['Use 2 (not 5) spaces for indentation.'])
         expect(cop.highlights).to eq(['     '])
       end
 
       it 'registers offense for bad indentation of modifier if in else' do
-        inspect_source(cop,
-                       ['if a',
-                        '  b',
-                        'else',
-                        '   x if y',
-                        'end'])
+        inspect_source(cop, <<-END.strip_indent)
+          if a
+            b
+          else
+             x if y
+          end
+        END
         expect(cop.messages)
           .to eq(['Use 2 (not 3) spaces for indentation.'])
       end
 
       it 'accepts indentation after if on new line after assignment' do
-        inspect_source(cop,
-                       ['Rails.application.config.ideal_postcodes_key =',
-                        '  if Rails.env.production? || Rails.env.staging?',
-                        '    "AAAA-AAAA-AAAA-AAAA"',
-                        '  end'])
+        inspect_source(cop, <<-END.strip_indent)
+          Rails.application.config.ideal_postcodes_key =
+            if Rails.env.production? || Rails.env.staging?
+              "AAAA-AAAA-AAAA-AAAA"
+            end
+        END
         expect(cop.offenses).to be_empty
       end
 
       it 'accepts `rescue` after an empty body' do
-        inspect_source(cop, ['begin',
-                             'rescue',
-                             '  handle_error',
-                             'end'])
+        inspect_source(cop, <<-END.strip_indent)
+          begin
+          rescue
+            handle_error
+          end
+        END
         expect(cop.offenses).to be_empty
       end
 
       it 'accepts `ensure` after an empty body' do
-        inspect_source(cop, ['begin',
-                             'ensure',
-                             '  something',
-                             'end'])
+        inspect_source(cop, <<-END.strip_indent)
+          begin
+          ensure
+            something
+          end
+        END
         expect(cop.offenses).to be_empty
       end
 
       describe '#autocorrect' do
         it 'corrects bad indentation' do
-          corrected = autocorrect_source(cop,
-                                         ['if a1',
-                                          '   b1',
-                                          '   b1',
-                                          'elsif a2',
-                                          ' b2',
-                                          'else',
-                                          '    c',
-                                          'end'])
-          expect(corrected)
-            .to eq ['if a1',
-                    '  b1',
-                    '   b1', # Will be corrected by IndentationConsistency.
-                    'elsif a2',
-                    '  b2',
-                    'else',
-                    '  c',
-                    'end'].join("\n")
+          corrected = autocorrect_source(cop, <<-END.strip_indent)
+            if a1
+               b1
+               b1
+            elsif a2
+             b2
+            else
+                c
+            end
+          END
+          # The second `b1` will be corrected by IndentationConsistency.
+          expect(corrected).to eq <<-END.strip_indent
+            if a1
+              b1
+               b1
+            elsif a2
+              b2
+            else
+              c
+            end
+          END
         end
 
         it 'does not correct in scopes that contain block comments' do
-          corrected = autocorrect_source(cop,
-                                         ['module Foo',
-                                          'class Bar',
-                                          '=begin',
-                                          'This is a nice long',
-                                          'comment',
-                                          'which spans a few lines',
-                                          '=end',
-                                          'def baz',
-                                          'do_something',
-                                          'end',
-                                          'end',
-                                          'end'])
-          expect(corrected).to eq ['module Foo',
-                                   # The class has a block comment within, so
-                                   # it's not corrected.
-                                   'class Bar',
-                                   '=begin',
-                                   'This is a nice long',
-                                   'comment',
-                                   'which spans a few lines',
-                                   '=end',
-                                   # The method has no block comment inside,
-                                   # but it's within a class that has a block
-                                   # comment, so it's not corrected either.
-                                   'def baz',
-                                   'do_something',
-                                   'end',
-                                   'end',
-                                   'end'].join("\n")
+          source = <<-END.strip_indent
+            module Foo
+            # The class has a block comment within, so it's not corrected.
+            class Bar
+            =begin
+            This is a nice long
+            comment
+            which spans a few lines
+            =end
+            # The method has no block comment inside,
+            # but it's within a class that has a block
+            # comment, so it's not corrected either.
+            def baz
+            do_something
+            end
+            end
+            end
+          END
+
+          expect(autocorrect_source(cop, source)).to eq source
         end
 
         it 'does not indent heredoc strings' do
-          corrected = autocorrect_source(cop,
-                                         ['module Foo',
-                                          'module Bar',
-                                          '  SOMETHING = <<GOO',
-                                          'text',
-                                          'more text',
-                                          'foo',
-                                          'GOO',
-                                          '  def baz',
-                                          '    do_something("#{x}")',
-                                          '  end',
-                                          'end',
-                                          'end'])
-          expect(corrected).to eq ['module Foo',
-                                   '  module Bar',
-                                   '    SOMETHING = <<GOO',
-                                   'text',
-                                   'more text',
-                                   'foo',
-                                   'GOO',
-                                   '    def baz',
-                                   '      do_something("#{x}")',
-                                   '    end',
-                                   '  end',
-                                   'end'].join("\n")
+          corrected = autocorrect_source(cop, <<-'END'.strip_indent)
+            module Foo
+            module Bar
+              SOMETHING = <<GOO
+            text
+            more text
+            foo
+            GOO
+              def baz
+                do_something("#{x}")
+              end
+            end
+            end
+          END
+          expect(corrected).to eq <<-'END'.strip_indent
+            module Foo
+              module Bar
+                SOMETHING = <<GOO
+            text
+            more text
+            foo
+            GOO
+                def baz
+                  do_something("#{x}")
+                end
+              end
+            end
+          END
         end
 
         it 'indents parenthesized expressions' do
-          src = ['var1 = nil',
-                 'array_list = []',
-                 'if var1.attr1 != 0 || array_list.select{ |w|',
-                 '                        (w.attr2 == var1.attr2)',
-                 '                 }.blank?',
-                 '  array_list << var1',
-                 'end']
+          src = <<-END.strip_indent
+            var1 = nil
+            array_list = []
+            if var1.attr1 != 0 || array_list.select{ |w|
+                                    (w.attr2 == var1.attr2)
+                             }.blank?
+              array_list << var1
+            end
+          END
           corrected = autocorrect_source(cop, src)
           expect(corrected)
-            .to eq ['var1 = nil',
-                    'array_list = []',
-                    'if var1.attr1 != 0 || array_list.select{ |w|',
-                    '                   (w.attr2 == var1.attr2)',
-                    '                 }.blank?',
-                    '  array_list << var1',
-                    'end'].join("\n")
+            .to eq <<-END.strip_indent
+              var1 = nil
+              array_list = []
+              if var1.attr1 != 0 || array_list.select{ |w|
+                                 (w.attr2 == var1.attr2)
+                               }.blank?
+                array_list << var1
+              end
+            END
         end
 
         it 'leaves rescue ; end unchanged' do
-          src = ['if variable',
-                 '  begin',
-                 '    do_something',
-                 '  rescue ; end # consume any exception',
-                 'end']
+          src = <<-END.strip_indent
+            if variable
+              begin
+                do_something
+              rescue ; end # consume any exception
+            end
+          END
           corrected = autocorrect_source(cop, src)
-          expect(corrected).to eq src.join("\n")
+          expect(corrected).to eq src
         end
 
         it 'leaves block unchanged if block end is not on its own line' do
-          src = ['a_function {',
-                 '  # a comment',
-                 '  result = AObject.find_by_attr(attr) if attr',
-                 '  result || AObject.make(',
-                 '      :attr => attr,',
-                 '      :attr2 => Other.get_value(),',
-                 '      :attr3 => Another.get_value()) }']
+          src = <<-END.strip_indent
+            a_function {
+              # a comment
+              result = AObject.find_by_attr(attr) if attr
+              result || AObject.make(
+                  :attr => attr,
+                  :attr2 => Other.get_value(),
+                  :attr3 => Another.get_value()) }
+          END
           corrected = autocorrect_source(cop, src)
-          expect(corrected).to eq src.join("\n")
+          expect(corrected).to eq src
         end
 
         it 'handles lines with only whitespace' do
@@ -321,55 +343,60 @@ describe RuboCop::Cop::Style::IndentationWidth do
       end
 
       it 'accepts a correctly aligned if/elsif/else/end' do
-        inspect_source(cop,
-                       ['if a1',
-                        '  b1',
-                        'elsif a2',
-                        '  b2',
-                        'else',
-                        '  c',
-                        'end'])
+        inspect_source(cop, <<-END.strip_indent)
+          if a1
+            b1
+          elsif a2
+            b2
+          else
+            c
+          end
+        END
         expect(cop.offenses).to be_empty
       end
 
       it 'accepts a correctly aligned if/elsif/else/end as a method argument' do
-        inspect_source(cop,
-                       ['foo(',
-                        '  if a1',
-                        '    b1',
-                        '  elsif a2',
-                        '    b2',
-                        '  else',
-                        '    c',
-                        '  end',
-                        ')'])
+        inspect_source(cop, <<-END.strip_indent)
+          foo(
+            if a1
+              b1
+            elsif a2
+              b2
+            else
+              c
+            end
+          )
+        END
         expect(cop.offenses).to be_empty
       end
 
       it 'accepts if/elsif/else/end laid out as a table' do
-        inspect_source(cop,
-                       ['if    @io == $stdout then str << "$stdout"',
-                        'elsif @io == $stdin  then str << "$stdin"',
-                        'elsif @io == $stderr then str << "$stderr"',
-                        'else                      str << @io.class.to_s',
-                        'end'])
+        inspect_source(cop, <<-END.strip_indent)
+          if    @io == $stdout then str << "$stdout"
+          elsif @io == $stdin  then str << "$stdin"
+          elsif @io == $stderr then str << "$stderr"
+          else                      str << @io.class.to_s
+          end
+        END
         expect(cop.offenses).to be_empty
       end
 
       it 'accepts if/then/else/end laid out as another table' do
-        inspect_source(cop,
-                       ["if File.exist?('config.save')",
-                        'then ConfigTable.load',
-                        'else ConfigTable.new',
-                        'end'])
+        inspect_source(cop, <<-END.strip_indent)
+          if File.exist?('config.save')
+          then ConfigTable.load
+          else ConfigTable.new
+          end
+        END
         expect(cop.offenses).to be_empty
       end
 
       it 'accepts an empty if' do
-        inspect_source(cop,
-                       ['if a',
-                        'else',
-                        'end'])
+        inspect_source(cop, <<-END.strip_indent)
+          if a
+          else
+          end
+        END
         expect(cop.offenses).to be_empty
       end
 
@@ -377,120 +404,131 @@ describe RuboCop::Cop::Style::IndentationWidth do
         context 'when alignment style is variable' do
           context 'and end is aligned with variable' do
             it 'accepts an if with end aligned with setter' do
-              inspect_source(cop,
-                             ['foo.bar = if baz',
-                              '  derp',
-                              'end'])
+              inspect_source(cop, <<-END.strip_indent)
+                foo.bar = if baz
+                  derp
+                end
+              END
               expect(cop.offenses).to be_empty
             end
 
             it 'accepts an if with end aligned with element assignment' do
-              inspect_source(cop,
-                             ['foo[bar] = if baz',
-                              '  derp',
-                              'end'])
+              inspect_source(cop, <<-END.strip_indent)
+                foo[bar] = if baz
+                  derp
+                end
+              END
               expect(cop.offenses).to be_empty
             end
 
             it 'accepts an if with end aligned with variable' do
-              inspect_source(cop,
-                             ['var = if a',
-                              '  0',
-                              'end',
-                              '@var = if a',
-                              '  0',
-                              'end',
-                              '$var = if a',
-                              '  0',
-                              'end',
-                              'var ||= if a',
-                              '  0',
-                              'end',
-                              'var &&= if a',
-                              '  0',
-                              'end',
-                              'var -= if a',
-                              '  0',
-                              'end',
-                              'VAR = if a',
-                              '  0',
-                              'end'])
+              inspect_source(cop, <<-END.strip_indent)
+                var = if a
+                  0
+                end
+                @var = if a
+                  0
+                end
+                $var = if a
+                  0
+                end
+                var ||= if a
+                  0
+                end
+                var &&= if a
+                  0
+                end
+                var -= if a
+                  0
+                end
+                VAR = if a
+                  0
+                end
+              END
               expect(cop.offenses).to be_empty
             end
 
             it 'accepts an if/else' do
-              inspect_source(cop,
-                             ['var = if a',
-                              '  0',
-                              'else',
-                              '  1',
-                              'end'])
+              inspect_source(cop, <<-END.strip_indent)
+                var = if a
+                  0
+                else
+                  1
+                end
+              END
               expect(cop.offenses).to be_empty
             end
 
             it 'accepts an if/else with chaining after the end' do
-              inspect_source(cop,
-                             ['var = if a',
-                              '  0',
-                              'else',
-                              '  1',
-                              'end.abc.join("")'])
+              inspect_source(cop, <<-END.strip_indent)
+                var = if a
+                  0
+                else
+                  1
+                end.abc.join("")
+              END
               expect(cop.offenses).to be_empty
             end
 
             it 'accepts an if/else with chaining with a block after the end' do
-              inspect_source(cop,
-                             ['var = if a',
-                              '  0',
-                              'else',
-                              '  1',
-                              'end.abc.tap {}'])
+              inspect_source(cop, <<-END.strip_indent)
+                var = if a
+                  0
+                else
+                  1
+                end.abc.tap {}
+              END
               expect(cop.offenses).to be_empty
             end
           end
 
           context 'and end is aligned with keyword' do
             it 'registers an offense for an if with setter' do
-              inspect_source(cop,
-                             ['foo.bar = if baz',
-                              '            derp',
-                              '          end'])
+              inspect_source(cop, <<-END.strip_indent)
+                foo.bar = if baz
+                            derp
+                          end
+              END
               expect(cop.messages)
                 .to eq(['Use 2 (not 12) spaces for indentation.'])
             end
 
             it 'registers an offense for an if with element assignment' do
-              inspect_source(cop,
-                             ['foo[bar] = if baz',
-                              '             derp',
-                              '           end'])
+              inspect_source(cop, <<-END.strip_indent)
+                foo[bar] = if baz
+                             derp
+                           end
+              END
               expect(cop.messages)
                 .to eq(['Use 2 (not 13) spaces for indentation.'])
             end
 
             it 'registers an offense for an if' do
-              inspect_source(cop,
-                             ['var = if a',
-                              '        0',
-                              '      end'])
+              inspect_source(cop, <<-END.strip_indent)
+                var = if a
+                        0
+                      end
+              END
               expect(cop.messages)
                 .to eq(['Use 2 (not 8) spaces for indentation.'])
             end
 
             it 'registers an offense for a while' do
-              inspect_source(cop,
-                             ['var = while a',
-                              '        b',
-                              '      end'])
+              inspect_source(cop, <<-END.strip_indent)
+                var = while a
+                        b
+                      end
+              END
               expect(cop.messages)
                 .to eq(['Use 2 (not 8) spaces for indentation.'])
             end
 
             it 'registers an offense for an until' do
-              inspect_source(cop,
-                             ['var = until a',
-                              '        b',
-                              '      end'])
+              inspect_source(cop, <<-END.strip_indent)
+                var = until a
+                        b
+                      end
+              END
               expect(cop.messages)
                 .to eq(['Use 2 (not 8) spaces for indentation.'])
             end
@@ -498,28 +536,31 @@ describe RuboCop::Cop::Style::IndentationWidth do
 
           context 'and end is aligned randomly' do
             it 'registers an offense for an if' do
-              inspect_source(cop,
-                             ['var = if a',
-                              '          0',
-                              '      end'])
+              inspect_source(cop, <<-END.strip_indent)
+                var = if a
+                          0
+                      end
+              END
               expect(cop.messages)
                 .to eq(['Use 2 (not 10) spaces for indentation.'])
             end
 
             it 'registers an offense for a while' do
-              inspect_source(cop,
-                             ['var = while a',
-                              '          b',
-                              '      end'])
+              inspect_source(cop, <<-END.strip_indent)
+                var = while a
+                          b
+                      end
+              END
               expect(cop.messages)
                 .to eq(['Use 2 (not 10) spaces for indentation.'])
             end
 
             it 'registers an offense for an until' do
-              inspect_source(cop,
-                             ['var = until a',
-                              '          b',
-                              '      end'])
+              inspect_source(cop, <<-END.strip_indent)
+                var = until a
+                          b
+                      end
+              END
               expect(cop.messages)
                 .to eq(['Use 2 (not 10) spaces for indentation.'])
             end
@@ -529,85 +570,96 @@ describe RuboCop::Cop::Style::IndentationWidth do
         shared_examples 'assignment and if with keyword alignment' do
           context 'and end is aligned with variable' do
             it 'registers an offense for an if' do
-              inspect_source(cop,
-                             ['var = if a',
-                              '  0',
-                              'end'])
+              inspect_source(cop, <<-END.strip_indent)
+                var = if a
+                  0
+                end
+              END
               expect(cop.messages)
                 .to eq(['Use 2 (not -4) spaces for indentation.'])
             end
 
             it 'registers an offense for a while' do
-              inspect_source(cop,
-                             ['var = while a',
-                              '  b',
-                              'end'])
+              inspect_source(cop, <<-END.strip_indent)
+                var = while a
+                  b
+                end
+              END
               expect(cop.messages)
                 .to eq(['Use 2 (not -4) spaces for indentation.'])
             end
 
             it 'autocorrects bad indentation' do
-              corrected = autocorrect_source(cop,
-                                             ['var = if a',
-                                              '  b',
-                                              'end',
-                                              '',
-                                              'var = while a',
-                                              '  b',
-                                              'end'])
-              expect(corrected).to eq ['var = if a',
-                                       '        b',
-                                       'end', # Not this cop's job to fix end.
-                                       '',
-                                       'var = while a',
-                                       '        b',
-                                       'end'].join("\n")
+              corrected = autocorrect_source(cop, <<-END.strip_indent)
+                var = if a
+                  b
+                end
+
+                var = while a
+                  b
+                end
+              END
+              # Not this cop's job to fix the `end`.
+              expect(corrected).to eq <<-END.strip_indent
+                var = if a
+                        b
+                end
+
+                var = while a
+                        b
+                end
+              END
             end
           end
 
           context 'and end is aligned with keyword' do
             it 'accepts an if in assignment' do
-              inspect_source(cop,
-                             ['var = if a',
-                              '        0',
-                              '      end'])
+              inspect_source(cop, <<-END.strip_indent)
+                var = if a
+                        0
+                      end
+              END
               expect(cop.offenses).to be_empty
             end
 
             it 'accepts an if/else in assignment' do
-              inspect_source(cop,
-                             ['var = if a',
-                              '        0',
-                              '      else',
-                              '        1',
-                              '      end'])
+              inspect_source(cop, <<-END.strip_indent)
+                var = if a
+                        0
+                      else
+                        1
+                      end
+              END
               expect(cop.offenses).to be_empty
             end
 
             it 'accepts an if/else in assignment on next line' do
-              inspect_source(cop,
-                             ['var =',
-                              '  if a',
-                              '    0',
-                              '  else',
-                              '    1',
-                              '  end'])
+              inspect_source(cop, <<-END.strip_indent)
+                var =
+                  if a
+                    0
+                  else
+                    1
+                  end
+              END
               expect(cop.offenses).to be_empty
             end
 
             it 'accepts a while in assignment' do
-              inspect_source(cop,
-                             ['var = while a',
-                              '        b',
-                              '      end'])
+              inspect_source(cop, <<-END.strip_indent)
+                var = while a
+                        b
+                      end
+              END
               expect(cop.offenses).to be_empty
             end
 
             it 'accepts an until in assignment' do
-              inspect_source(cop,
-                             ['var = until a',
-                              '        b',
-                              '      end'])
+              inspect_source(cop, <<-END.strip_indent)
+                var = until a
+                        b
+                      end
+              END
               expect(cop.offenses).to be_empty
             end
           end
@@ -625,167 +677,183 @@ describe RuboCop::Cop::Style::IndentationWidth do
       it 'accepts an if/else branches with rescue clauses' do
         # Because of how the rescue clauses come out of Parser, these are
         # special and need to be tested.
-        inspect_source(cop,
-                       ['if a',
-                        '  a rescue nil',
-                        'else',
-                        '  a rescue nil',
-                        'end'])
+        inspect_source(cop, <<-END.strip_indent)
+          if a
+            a rescue nil
+          else
+            a rescue nil
+          end
+        END
         expect(cop.offenses).to be_empty
       end
     end
 
     context 'with unless' do
       it 'registers an offense for bad indentation of an unless body' do
-        inspect_source(cop,
-                       ['unless cond',
-                        ' func',
-                        'end'])
+        inspect_source(cop, <<-END.strip_indent)
+          unless cond
+           func
+          end
+        END
         expect(cop.messages).to eq(['Use 2 (not 1) spaces for indentation.'])
       end
 
       it 'accepts an empty unless' do
-        inspect_source(cop,
-                       ['unless a',
-                        'else',
-                        'end'])
+        inspect_source(cop, <<-END.strip_indent)
+          unless a
+          else
+          end
+        END
         expect(cop.offenses).to be_empty
       end
     end
 
     context 'with case' do
       it 'registers an offense for bad indentation in a case/when body' do
-        inspect_source(cop,
-                       ['case a',
-                        'when b',
-                        ' c',
-                        'end'])
+        inspect_source(cop, <<-END.strip_indent)
+          case a
+          when b
+           c
+          end
+        END
         expect(cop.messages).to eq(['Use 2 (not 1) spaces for indentation.'])
       end
 
       it 'registers an offense for bad indentation in a case/else body' do
-        inspect_source(cop,
-                       ['case a',
-                        'when b',
-                        '  c',
-                        'when d',
-                        '  e',
-                        'else',
-                        '   f',
-                        'end'])
+        inspect_source(cop, <<-END.strip_indent)
+          case a
+          when b
+            c
+          when d
+            e
+          else
+             f
+          end
+        END
         expect(cop.messages).to eq(['Use 2 (not 3) spaces for indentation.'])
       end
 
       it 'accepts correctly indented case/when/else' do
-        inspect_source(cop,
-                       ['case a',
-                        'when b',
-                        '  c',
-                        '  c',
-                        'when d',
-                        'else',
-                        '  f',
-                        'end'])
+        inspect_source(cop, <<-END.strip_indent)
+          case a
+          when b
+            c
+            c
+          when d
+          else
+            f
+          end
+        END
         expect(cop.offenses).to be_empty
       end
 
       it 'accepts aligned values in when clause' do
-        inspect_source(cop,
-                       ['case superclass',
-                        'when /\A(#{NAMESPACEMATCH})(?:\s|\Z)/,',
-                        '     /\A(Struct|OStruct)\.new/,',
-                        '     /\ADelegateClass\((.+?)\)\s*\Z/,',
-                        '     /\A(#{NAMESPACEMATCH})\(/',
-                        '  $1',
-                        'when "self"',
-                        '  namespace.path',
-                        'end'])
+        inspect_source(cop, <<-'END'.strip_indent)
+          case superclass
+          when /\A(#{NAMESPACEMATCH})(?:\s|\Z)/,
+               /\A(Struct|OStruct)\.new/,
+               /\ADelegateClass\((.+?)\)\s*\Z/,
+               /\A(#{NAMESPACEMATCH})\(/
+            $1
+          when "self"
+            namespace.path
+          end
+        END
         expect(cop.offenses).to be_empty
       end
 
       it 'accepts case/when/else laid out as a table' do
-        inspect_source(cop,
-                       ['case sexp.loc.keyword.source',
-                        "when 'if'     then cond, body, _else = *sexp",
-                        "when 'unless' then cond, _else, body = *sexp",
-                        'else               cond, body = *sexp',
-                        'end'])
+        inspect_source(cop, <<-END.strip_indent)
+          case sexp.loc.keyword.source
+          when 'if'     then cond, body, _else = *sexp
+          when 'unless' then cond, _else, body = *sexp
+          else               cond, body = *sexp
+          end
+        END
         expect(cop.offenses).to be_empty
       end
 
       it 'accepts case/when/else with then beginning a line' do
-        inspect_source(cop,
-                       ['case sexp.loc.keyword.source',
-                        "when 'if'",
-                        'then cond, body, _else = *sexp',
-                        'end'])
+        inspect_source(cop, <<-END.strip_indent)
+          case sexp.loc.keyword.source
+          when 'if'
+          then cond, body, _else = *sexp
+          end
+        END
         expect(cop.offenses).to be_empty
       end
 
       it 'accepts indented when/else plus indented body' do
         # "Indent when as deep as case" is the job of another cop.
-        inspect_source(cop,
-                       ['case code_type',
-                        "  when 'ruby', 'sql', 'plain'",
-                        '    code_type',
-                        "  when 'erb'",
-                        "    'ruby; html-script: true'",
-                        '  when "html"',
-                        "    'xml'",
-                        '  else',
-                        "    'plain'",
-                        'end'])
+        inspect_source(cop, <<-END.strip_indent)
+          case code_type
+            when 'ruby', 'sql', 'plain'
+              code_type
+            when 'erb'
+              'ruby; html-script: true'
+            when "html"
+              'xml'
+            else
+              'plain'
+          end
+        END
         expect(cop.offenses).to be_empty
       end
     end
 
     context 'with while/until' do
       it 'registers an offense for bad indentation of a while body' do
-        inspect_source(cop,
-                       ['while cond',
-                        ' func',
-                        'end'])
+        inspect_source(cop, <<-END.strip_indent)
+          while cond
+           func
+          end
+        END
         expect(cop.messages).to eq(['Use 2 (not 1) spaces for indentation.'])
       end
 
       it 'registers an offense for bad indentation of begin/end/while' do
-        inspect_source(cop,
-                       ['something = begin',
-                        ' func1',
-                        '   func2',
-                        'end while cond'])
+        inspect_source(cop, <<-END.strip_indent)
+          something = begin
+           func1
+             func2
+          end while cond
+        END
         expect(cop.messages).to eq(['Use 2 (not 1) spaces for indentation.'])
       end
 
       it 'registers an offense for bad indentation of an until body' do
-        inspect_source(cop,
-                       ['until cond',
-                        ' func',
-                        'end'])
+        inspect_source(cop, <<-END.strip_indent)
+          until cond
+           func
+          end
+        END
         expect(cop.messages).to eq(['Use 2 (not 1) spaces for indentation.'])
       end
 
       it 'accepts an empty while' do
-        inspect_source(cop,
-                       ['while a',
-                        'end'])
+        inspect_source(cop, <<-END.strip_indent)
+          while a
+          end
+        END
         expect(cop.offenses).to be_empty
       end
     end
 
     context 'with for' do
       it 'registers an offense for bad indentation of a for body' do
-        inspect_source(cop,
-                       ['for var in 1..10',
-                        ' func',
-                        'end'])
+        inspect_source(cop, <<-END.strip_indent)
+          for var in 1..10
+           func
+          end
+        END
         expect(cop.messages).to eq(['Use 2 (not 1) spaces for indentation.'])
       end
 
       it 'accepts an empty for' do
-        inspect_source(cop,
-                       ['for var in 1..10',
-                        'end'])
+        inspect_source(cop, <<-END.strip_indent)
+          for var in 1..10
+          end
+        END
         expect(cop.offenses).to be_empty
       end
     end
@@ -793,40 +861,45 @@ describe RuboCop::Cop::Style::IndentationWidth do
     context 'with def/defs' do
       shared_examples 'without modifier on the same line' do
         it 'registers an offense for bad indentation of a def body' do
-          inspect_source(cop,
-                         ['def test',
-                          '    func1',
-                          '     func2', # No offense registered for this.
-                          'end'])
+          inspect_source(cop, <<-END.strip_indent)
+            def test
+                func1
+                 func2 # No offense registered for this.
+            end
+          END
           expect(cop.messages).to eq(['Use 2 (not 4) spaces for indentation.'])
         end
 
         it 'registers an offense for bad indentation of a defs body' do
-          inspect_source(cop,
-                         ['def self.test',
-                          '   func',
-                          'end'])
+          inspect_source(cop, <<-END.strip_indent)
+            def self.test
+               func
+            end
+          END
           expect(cop.messages).to eq(['Use 2 (not 3) spaces for indentation.'])
         end
 
         it 'accepts an empty def body' do
-          inspect_source(cop,
-                         ['def test',
-                          'end'])
+          inspect_source(cop, <<-END.strip_indent)
+            def test
+            end
+          END
           expect(cop.offenses).to be_empty
         end
 
         it 'accepts an empty defs body' do
-          inspect_source(cop,
-                         ['def self.test',
-                          'end'])
+          inspect_source(cop, <<-END.strip_indent)
+            def self.test
+            end
+          END
           expect(cop.offenses).to be_empty
         end
 
         it 'with an assignment' do
-          inspect_source(cop,
-                         ['something = def self.foo',
-                          'end'])
+          inspect_source(cop, <<-END.strip_indent)
+            something = def self.foo
+            end
+          END
           expect(cop.offenses).to be_empty
         end
       end
@@ -841,27 +914,30 @@ describe RuboCop::Cop::Style::IndentationWidth do
         if RUBY_VERSION >= '2.1'
           context 'when modifier and def are on the same line' do
             it 'accepts a correctly aligned body' do
-              inspect_source(cop,
-                             ['foo def test',
-                              '  something',
-                              'end'])
+              inspect_source(cop, <<-END.strip_indent)
+                foo def test
+                  something
+                end
+              END
               expect(cop.offenses).to be_empty
             end
 
             it 'registers an offense for bad indentation of a def body' do
-              inspect_source(cop,
-                             ['foo def test',
-                              '      something',
-                              '    end'])
+              inspect_source(cop, <<-END.strip_indent)
+                foo def test
+                      something
+                    end
+              END
               expect(cop.messages)
                 .to eq(['Use 2 (not 6) spaces for indentation.'])
             end
 
             it 'registers an offense for bad indentation of a defs body' do
-              inspect_source(cop,
-                             ['foo def self.test',
-                              '      something',
-                              '    end'])
+              inspect_source(cop, <<-END.strip_indent)
+                foo def self.test
+                      something
+                    end
+              END
               expect(cop.messages)
                 .to eq(['Use 2 (not 6) spaces for indentation.'])
             end
@@ -879,27 +955,30 @@ describe RuboCop::Cop::Style::IndentationWidth do
         if RUBY_VERSION >= '2.1'
           context 'when modifier and def are on the same line' do
             it 'accepts a correctly aligned body' do
-              inspect_source(cop,
-                             ['foo def test',
-                              '      something',
-                              'end'])
+              inspect_source(cop, <<-END.strip_indent)
+                foo def test
+                      something
+                end
+              END
               expect(cop.offenses).to be_empty
             end
 
             it 'registers an offense for bad indentation of a def body' do
-              inspect_source(cop,
-                             ['foo def test',
-                              '  something',
-                              '    end'])
+              inspect_source(cop, <<-END.strip_indent)
+                foo def test
+                  something
+                    end
+              END
               expect(cop.messages)
                 .to eq(['Use 2 (not -2) spaces for indentation.'])
             end
 
             it 'registers an offense for bad indentation of a defs body' do
-              inspect_source(cop,
-                             ['foo def self.test',
-                              '  something',
-                              '    end'])
+              inspect_source(cop, <<-END.strip_indent)
+                foo def self.test
+                  something
+                    end
+              END
               expect(cop.messages)
                 .to eq(['Use 2 (not -2) spaces for indentation.'])
             end
@@ -910,40 +989,43 @@ describe RuboCop::Cop::Style::IndentationWidth do
 
     context 'with class' do
       it 'registers an offense for bad indentation of a class body' do
-        inspect_source(cop,
-                       ['class Test',
-                        '    def func',
-                        '    end',
-                        'end'])
+        inspect_source(cop, <<-END.strip_indent)
+          class Test
+              def func
+              end
+          end
+        END
         expect(cop.messages).to eq(['Use 2 (not 4) spaces for indentation.'])
       end
 
       it 'accepts an empty class body' do
-        inspect_source(cop,
-                       ['class Test',
-                        'end'])
+        inspect_source(cop, <<-END.strip_indent)
+          class Test
+          end
+        END
         expect(cop.offenses).to be_empty
       end
 
       context 'when consistency style is normal' do
         it 'accepts indented public, protected, and private' do
-          inspect_source(cop,
-                         ['class Test',
-                          '  public',
-                          '',
-                          '  def e',
-                          '  end',
-                          '',
-                          '  protected',
-                          '',
-                          '  def f',
-                          '  end',
-                          '',
-                          '  private',
-                          '',
-                          '  def g',
-                          '  end',
-                          'end'])
+          inspect_source(cop, <<-END.strip_indent)
+            class Test
+              public
+
+              def e
+              end
+
+              protected
+
+              def f
+              end
+
+              private
+
+              def g
+              end
+            end
+          END
           expect(cop.offenses).to be_empty
         end
       end
@@ -952,23 +1034,24 @@ describe RuboCop::Cop::Style::IndentationWidth do
         let(:consistency_config) { { 'EnforcedStyle' => 'rails' } }
 
         it 'registers an offense for normal non-rails indentation' do
-          inspect_source(cop,
-                         ['class Test',
-                          '  public',
-                          '',
-                          '  def e',
-                          '  end',
-                          '',
-                          '  protected',
-                          '',
-                          '  def f',
-                          '  end',
-                          '',
-                          '  private',
-                          '',
-                          '  def g',
-                          '  end',
-                          'end'])
+          inspect_source(cop, <<-END.strip_indent)
+            class Test
+              public
+
+              def e
+              end
+
+              protected
+
+              def f
+              end
+
+              private
+
+              def g
+              end
+            end
+          END
           expect(cop.messages)
             .to eq(['Use 2 (not 0) spaces for rails indentation.'] * 2)
           expect(cop.offenses.map(&:line)).to eq([9, 14])
@@ -979,18 +1062,20 @@ describe RuboCop::Cop::Style::IndentationWidth do
     context 'with module' do
       context 'when consistency style is normal' do
         it 'registers an offense for bad indentation of a module body' do
-          inspect_source(cop,
-                         ['module Test',
-                          '    def func',
-                          '    end',
-                          'end'])
+          inspect_source(cop, <<-END.strip_indent)
+            module Test
+                def func
+                end
+            end
+          END
           expect(cop.messages).to eq(['Use 2 (not 4) spaces for indentation.'])
         end
 
         it 'accepts an empty module body' do
-          inspect_source(cop,
-                         ['module Test',
-                          'end'])
+          inspect_source(cop, <<-END.strip_indent)
+            module Test
+            end
+          END
           expect(cop.offenses).to be_empty
         end
       end
@@ -999,26 +1084,28 @@ describe RuboCop::Cop::Style::IndentationWidth do
         let(:consistency_config) { { 'EnforcedStyle' => 'rails' } }
 
         it 'registers an offense for bad indentation of a module body' do
-          inspect_source(cop,
-                         ['module Test',
-                          '   def func1',
-                          '   end',
-                          '  private',
-                          ' def func2',
-                          ' end',
-                          'end'])
+          inspect_source(cop, <<-END.strip_indent)
+            module Test
+               def func1
+               end
+              private
+             def func2
+             end
+            end
+          END
           expect(cop.messages)
             .to eq(['Use 2 (not 3) spaces for indentation.',
                     'Use 2 (not -1) spaces for rails indentation.'])
         end
 
         it 'accepts normal non-rails indentation of module functions' do
-          inspect_source(cop,
-                         ['module Test',
-                          '  module_function',
-                          '  def func',
-                          '  end',
-                          'end'])
+          inspect_source(cop, <<-END.strip_indent)
+            module Test
+              module_function
+              def func
+              end
+            end
+          END
           expect(cop.offenses).to be_empty
         end
       end
@@ -1026,21 +1113,22 @@ describe RuboCop::Cop::Style::IndentationWidth do
 
     context 'with begin/rescue/else/ensure/end' do
       it 'registers an offense for bad indentation of bodies' do
-        inspect_source(cop,
-                       ['def my_func',
-                        "  puts 'do something outside block'",
-                        '  begin',
-                        "  puts 'do something error prone'",
-                        '  rescue SomeException, SomeOther => e',
-                        "   puts 'wrongly intended error handling'",
-                        '  rescue',
-                        "   puts 'wrongly intended error handling'",
-                        '  else',
-                        "     puts 'wrongly intended normal case handling'",
-                        '  ensure',
-                        "      puts 'wrongly intended common handling'",
-                        '  end',
-                        'end'])
+        inspect_source(cop, <<-END.strip_indent)
+          def my_func
+            puts 'do something outside block'
+            begin
+            puts 'do something error prone'
+            rescue SomeException, SomeOther => e
+             puts 'wrongly intended error handling'
+            rescue
+             puts 'wrongly intended error handling'
+            else
+               puts 'wrongly intended normal case handling'
+            ensure
+                puts 'wrongly intended common handling'
+            end
+          end
+        END
         expect(cop.messages).to eq(['Use 2 (not 0) spaces for indentation.',
                                     'Use 2 (not 1) spaces for indentation.',
                                     'Use 2 (not 1) spaces for indentation.',
@@ -1051,27 +1139,29 @@ describe RuboCop::Cop::Style::IndentationWidth do
 
     context 'with def/rescue/end' do
       it 'registers an offense for bad indentation of bodies' do
-        inspect_source(cop,
-                       ['def my_func',
-                        "  puts 'do something error prone'",
-                        'rescue SomeException',
-                        " puts 'wrongly intended error handling'",
-                        'rescue',
-                        " puts 'wrongly intended error handling'",
-                        'end'])
+        inspect_source(cop, <<-END.strip_indent)
+          def my_func
+            puts 'do something error prone'
+          rescue SomeException
+           puts 'wrongly intended error handling'
+          rescue
+           puts 'wrongly intended error handling'
+          end
+        END
         expect(cop.messages).to eq(['Use 2 (not 1) spaces for indentation.',
                                     'Use 2 (not 1) spaces for indentation.'])
       end
 
       it 'registers an offense for bad indent of defs bodies with a modifier' do
-        inspect_source(cop,
-                       ['foo def self.my_func',
-                        "  puts 'do something error prone'",
-                        'rescue SomeException',
-                        " puts 'wrongly intended error handling'",
-                        'rescue',
-                        " puts 'wrongly intended error handling'",
-                        'end'])
+        inspect_source(cop, <<-END.strip_indent)
+          foo def self.my_func
+            puts 'do something error prone'
+          rescue SomeException
+           puts 'wrongly intended error handling'
+          rescue
+           puts 'wrongly intended error handling'
+          end
+        END
         expect(cop.messages).to eq(['Use 2 (not 1) spaces for indentation.',
                                     'Use 2 (not 1) spaces for indentation.'])
       end
@@ -1082,61 +1172,67 @@ describe RuboCop::Cop::Style::IndentationWidth do
         let(:consistency_config) { { 'EnforcedStyle' => 'rails' } }
 
         it 'registers an offense for bad indentation in a do/end body' do
-          inspect_source(cop,
-                         ['concern :Authenticatable do',
-                          '  def foo',
-                          '    puts "foo"',
-                          '  end',
-                          '',
-                          '  private',
-                          '',
-                          '  def bar',
-                          '    puts "bar"',
-                          '  end',
-                          'end'])
+          inspect_source(cop, <<-END.strip_indent)
+            concern :Authenticatable do
+              def foo
+                puts "foo"
+              end
+
+              private
+
+              def bar
+                puts "bar"
+              end
+            end
+          END
           expect(cop.messages)
             .to eq(['Use 2 (not 0) spaces for rails indentation.'])
         end
       end
 
       it 'registers an offense for bad indentation of a do/end body' do
-        inspect_source(cop,
-                       ['a = func do',
-                        ' b',
-                        'end'])
+        inspect_source(cop, <<-END.strip_indent)
+          a = func do
+           b
+          end
+        END
         expect(cop.messages).to eq(['Use 2 (not 1) spaces for indentation.'])
       end
 
       it 'registers an offense for bad indentation of a {} body' do
-        inspect_source(cop,
-                       ['func {',
-                        '   b',
-                        '}'])
+        inspect_source(cop, <<-END.strip_indent)
+          func {
+             b
+          }
+        END
         expect(cop.messages).to eq(['Use 2 (not 3) spaces for indentation.'])
       end
 
       it 'accepts a correctly indented block body' do
-        inspect_source(cop,
-                       ['a = func do',
-                        '  b',
-                        'end'])
+        inspect_source(cop, <<-END.strip_indent)
+          a = func do
+            b
+          end
+        END
         expect(cop.offenses).to be_empty
       end
 
       it 'accepts an empty block body' do
-        inspect_source(cop,
-                       ['a = func do',
-                        'end'])
+        inspect_source(cop, <<-END.strip_indent)
+          a = func do
+          end
+        END
         expect(cop.offenses).to be_empty
       end
 
       # The cop uses the block end/} as the base for indentation, so if it's not
       # on its own line, all bets are off.
       it 'accepts badly indented code if block end is not on separate line' do
-        inspect_source(cop,
-                       ['foo {',
-                        'def baz',
-                        'end }'])
+        inspect_source(cop, <<-END.strip_indent)
+          foo {
+          def baz
+          end }
+        END
         expect(cop.offenses).to be_empty
       end
     end

--- a/spec/rubocop/cop/style/initial_indentation_spec.rb
+++ b/spec/rubocop/cop/style/initial_indentation_spec.rb
@@ -4,14 +4,18 @@ describe RuboCop::Cop::Style::InitialIndentation do
   subject(:cop) { described_class.new }
 
   it 'registers an offense for indented method definition ' do
-    inspect_source(cop, ['  def f',
-                         '  end'])
+    inspect_source(cop, <<-END.strip_margin('|'))
+      |  def f
+      |  end
+    END
     expect(cop.messages).to eq(['Indentation of first line in file detected.'])
   end
 
   it 'accepts unindented method definition' do
-    inspect_source(cop, ['def f',
-                         'end'])
+    inspect_source(cop, <<-END.strip_indent)
+      def f
+      end
+    END
     expect(cop.offenses).to be_empty
   end
 
@@ -41,28 +45,40 @@ describe RuboCop::Cop::Style::InitialIndentation do
   end
 
   it 'registers an offense for indented assignment disregarding comment' do
-    inspect_source(cop, [' # comment',
-                         ' x = 1'])
+    inspect_source(cop, <<-END.strip_margin('|'))
+      | # comment
+      | x = 1
+    END
     expect(cop.highlights).to eq(['x'])
   end
 
   it 'accepts unindented comment + assignment' do
-    inspect_source(cop, ['# comment',
-                         'x = 1'])
+    inspect_source(cop, <<-END.strip_indent)
+      # comment
+      x = 1
+    END
     expect(cop.offenses).to be_empty
   end
 
   it 'auto-corrects indented method definition' do
-    corrected = autocorrect_source(cop, ['  def f',
-                                         '  end'])
-    expect(corrected).to eq ['def f',
-                             '  end'].join("\n")
+    corrected = autocorrect_source(cop, <<-END.strip_margin('|'))
+      |  def f
+      |  end
+    END
+    expect(corrected).to eq <<-END.strip_indent
+      def f
+        end
+    END
   end
 
   it 'auto-corrects indented assignment but not comment' do
-    corrected = autocorrect_source(cop, ['  # comment',
-                                         '  x = 1'])
-    expect(corrected).to eq ['  # comment',
-                             'x = 1'].join("\n")
+    corrected = autocorrect_source(cop, <<-END.strip_margin('|'))
+      |  # comment
+      |  x = 1
+    END
+    expect(corrected).to eq <<-END.strip_indent
+        # comment
+      x = 1
+    END
   end
 end

--- a/spec/rubocop/cop/style/inverse_methods_spec.rb
+++ b/spec/rubocop/cop/style/inverse_methods_spec.rb
@@ -158,10 +158,12 @@ describe RuboCop::Cop::Style::InverseMethods do
 
       it 'registers an offense for a multiline method call where the last ' \
         'method is inverted' do
-        inspect_source(cop, ["foo.#{method} do |e|",
-                             '  something',
-                             '  !e.bar',
-                             'end'])
+        inspect_source(cop, <<-END.strip_indent)
+          foo.#{method} do |e|
+            something
+            !e.bar
+          end
+        END
 
         expect(cop.messages)
           .to eq(["Use `#{inverse}` instead of inverting `#{method}`."])
@@ -175,11 +177,13 @@ describe RuboCop::Cop::Style::InverseMethods do
       end
 
       it 'registers an offense for a multiline inverted equality block' do
-        inspect_source(cop, ["foo.#{method} do |e|",
-                             '  something',
-                             '  something_else',
-                             '  e != 2',
-                             'end'])
+        inspect_source(cop, <<-END.strip_indent)
+          foo.#{method} do |e|
+            something
+            something_else
+            e != 2
+          end
+        END
 
         expect(cop.messages)
           .to eq(["Use `#{inverse}` instead of inverting `#{method}`."])
@@ -205,27 +209,35 @@ describe RuboCop::Cop::Style::InverseMethods do
       end
 
       it 'corrects an inverted do end method call' do
-        new_source = autocorrect_source(cop, ["foo.#{method} do |e|",
-                                              '  !e.bar',
-                                              'end'])
+        new_source = autocorrect_source(cop, <<-END.strip_indent)
+          foo.#{method} do |e|
+            !e.bar
+          end
+        END
 
-        expect(new_source).to eq(["foo.#{inverse} do |e|",
-                                  '  e.bar',
-                                  'end'].join("\n"))
+        expect(new_source).to eq(<<-END.strip_indent)
+          foo.#{inverse} do |e|
+            e.bar
+          end
+        END
       end
 
       it 'corrects a multiline method call where the last method is inverted' do
-        new_source = autocorrect_source(cop, ["foo.#{method} do |e|",
-                                              '  something',
-                                              '  something_else',
-                                              '  !e.bar',
-                                              'end'])
+        new_source = autocorrect_source(cop, <<-END.strip_indent)
+          foo.#{method} do |e|
+            something
+            something_else
+            !e.bar
+          end
+        END
 
-        expect(new_source).to eq(["foo.#{inverse} do |e|",
-                                  '  something',
-                                  '  something_else',
-                                  '  e.bar',
-                                  'end'].join("\n"))
+        expect(new_source).to eq(<<-END.strip_indent)
+          foo.#{inverse} do |e|
+            something
+            something_else
+            e.bar
+          end
+        END
       end
 
       it 'corrects an offense for an inverted equality block' do
@@ -235,17 +247,21 @@ describe RuboCop::Cop::Style::InverseMethods do
       end
 
       it 'corrects an offense for a multiline inverted equality block' do
-        new_source = autocorrect_source(cop, ["foo.#{method} do |e|",
-                                              '  something',
-                                              '  something_else',
-                                              '  e != 2',
-                                              'end'])
+        new_source = autocorrect_source(cop, <<-END.strip_indent)
+          foo.#{method} do |e|
+            something
+            something_else
+            e != 2
+          end
+        END
 
-        expect(new_source).to eq(["foo.#{inverse} do |e|",
-                                  '  something',
-                                  '  something_else',
-                                  '  e == 2',
-                                  'end'].join("\n"))
+        expect(new_source).to eq(<<-END.strip_indent)
+          foo.#{inverse} do |e|
+            something
+            something_else
+            e == 2
+          end
+        END
       end
     end
   end

--- a/spec/rubocop/cop/style/lambda_call_spec.rb
+++ b/spec/rubocop/cop/style/lambda_call_spec.rb
@@ -14,9 +14,10 @@ describe RuboCop::Cop::Style::LambdaCall, :config do
     end
 
     it 'registers an offense for correct + opposite' do
-      inspect_source(cop,
-                     ['x.call(a, b)',
-                      'x.(a, b)'])
+      inspect_source(cop, <<-END.strip_indent)
+        x.call(a, b)
+        x.(a, b)
+      END
       expect(cop.offenses.size).to eq(1)
       expect(cop.config_to_allow_offenses).to eq('Enabled' => false)
     end
@@ -43,9 +44,10 @@ describe RuboCop::Cop::Style::LambdaCall, :config do
     end
 
     it 'registers an offense for opposite + correct' do
-      inspect_source(cop,
-                     ['x.call(a, b)',
-                      'x.(a, b)'])
+      inspect_source(cop, <<-END.strip_indent)
+        x.call(a, b)
+        x.(a, b)
+      END
       expect(cop.offenses.size).to eq(1)
       expect(cop.config_to_allow_offenses).to eq('Enabled' => false)
     end

--- a/spec/rubocop/cop/style/lambda_spec.rb
+++ b/spec/rubocop/cop/style/lambda_spec.rb
@@ -22,7 +22,7 @@ describe RuboCop::Cop::Style::Lambda, :config do
 
   shared_examples 'does not auto-correct' do
     it 'does not autocorrect' do
-      expect(autocorrect_source(cop, source)).to eq(source.join("\n"))
+      expect(autocorrect_source(cop, source)).to eq(source)
       expect(cop.offenses.map(&:corrected?)).to eq [false]
     end
   end
@@ -51,30 +51,38 @@ describe RuboCop::Cop::Style::Lambda, :config do
     context 'with a multiline lambda literal' do
       context 'with arguments' do
         let(:source) do
-          ['f = ->(x) do',
-           '  x',
-           'end']
+          <<-END.strip_indent
+            f = ->(x) do
+              x
+            end
+          END
         end
 
         it_behaves_like 'registers an offense',
                         'Use the `lambda` method for all lambdas.'
-        it_behaves_like 'auto-correct', ['f = lambda do |x|',
-                                         '  x',
-                                         'end'].join("\n")
+        it_behaves_like 'auto-correct', <<-END.strip_indent
+          f = lambda do |x|
+            x
+          end
+        END
       end
 
       context 'without arguments' do
         let(:source) do
-          ['f = -> do',
-           '  x',
-           'end']
+          <<-END.strip_indent
+            f = -> do
+              x
+            end
+          END
         end
 
         it_behaves_like 'registers an offense',
                         'Use the `lambda` method for all lambdas.'
-        it_behaves_like 'auto-correct', ['f = lambda do',
-                                         '  x',
-                                         'end'].join("\n")
+        it_behaves_like 'auto-correct', <<-END.strip_indent
+          f = lambda do
+            x
+          end
+        END
       end
     end
   end
@@ -105,32 +113,40 @@ describe RuboCop::Cop::Style::Lambda, :config do
     context 'with a multiline lambda method call' do
       context 'with arguments' do
         let(:source) do
-          ['f = lambda do |x|',
-           '  x',
-           'end']
+          <<-END.strip_indent
+            f = lambda do |x|
+              x
+            end
+          END
         end
 
         it_behaves_like 'registers an offense',
                         'Use the `-> { ... }` lambda literal syntax for ' \
                         'all lambdas.'
-        it_behaves_like 'auto-correct', ['f = ->(x) do',
-                                         '  x',
-                                         'end'].join("\n")
+        it_behaves_like 'auto-correct', <<-END.strip_indent
+          f = ->(x) do
+            x
+          end
+        END
       end
 
       context 'without arguments' do
         let(:source) do
-          ['f = lambda do',
-           '  x',
-           'end']
+          <<-END.strip_indent
+            f = lambda do
+              x
+            end
+          END
         end
 
         it_behaves_like 'registers an offense',
                         'Use the `-> { ... }` lambda literal syntax for ' \
                         'all lambdas.'
-        it_behaves_like 'auto-correct', ['f = -> do',
-                                         '  x',
-                                         'end'].join("\n")
+        it_behaves_like 'auto-correct', <<-END.strip_indent
+          f = -> do
+            x
+          end
+        END
       end
     end
   end
@@ -160,17 +176,21 @@ describe RuboCop::Cop::Style::Lambda, :config do
 
     context 'with a multiline lambda method call' do
       it 'does not register an offense' do
-        inspect_source(cop, ['l = lambda do |x|',
-                             '  x',
-                             'end'])
+        inspect_source(cop, <<-END.strip_indent)
+          l = lambda do |x|
+            x
+          end
+        END
         expect(cop.offenses).to be_empty
       end
     end
 
     context 'with a single line lambda literal' do
       it 'does not register an offense' do
-        inspect_source(cop, ['lambda = ->(x) { x }',
-                             'lambda.(1)'])
+        inspect_source(cop, <<-END.strip_indent)
+          lambda = ->(x) { x }
+          lambda.(1)
+        END
         expect(cop.offenses).to be_empty
       end
     end
@@ -178,30 +198,38 @@ describe RuboCop::Cop::Style::Lambda, :config do
     context 'with a multiline lambda literal' do
       context 'with arguments' do
         let(:source) do
-          ['f = ->(x) do',
-           '  x',
-           'end']
+          <<-END.strip_indent
+            f = ->(x) do
+              x
+            end
+          END
         end
 
         it_behaves_like 'registers an offense',
                         'Use the `lambda` method for multiline lambdas.'
-        it_behaves_like 'auto-correct', ['f = lambda do |x|',
-                                         '  x',
-                                         'end'].join("\n")
+        it_behaves_like 'auto-correct', <<-END.strip_indent
+          f = lambda do |x|
+            x
+          end
+        END
       end
 
       context 'without arguments' do
         let(:source) do
-          ['f = -> do',
-           '  x',
-           'end']
+          <<-END.strip_indent
+            f = -> do
+              x
+            end
+          END
         end
 
         it_behaves_like 'registers an offense',
                         'Use the `lambda` method for multiline lambdas.'
-        it_behaves_like 'auto-correct', ['f = lambda do',
-                                         '  x',
-                                         'end'].join("\n")
+        it_behaves_like 'auto-correct', <<-END.strip_indent
+          f = lambda do
+            x
+          end
+        END
       end
     end
 
@@ -213,117 +241,153 @@ describe RuboCop::Cop::Style::Lambda, :config do
       # Tests correction of an issue resulting in `lambdado` syntax errors.
       context 'without any spacing' do
         let(:source) do
-          ['->(x)do',
-           '  x',
-           'end']
+          <<-END.strip_indent
+            ->(x)do
+              x
+            end
+          END
         end
 
-        it_behaves_like 'auto-correct', ['lambda do |x|',
-                                         '  x',
-                                         'end'].join("\n")
+        it_behaves_like 'auto-correct', <<-END.strip_indent
+          lambda do |x|
+            x
+          end
+        END
       end
 
       context 'without spacing after arguments' do
         let(:source) do
-          ['-> (x)do',
-           '  x',
-           'end']
+          <<-END.strip_indent
+            -> (x)do
+              x
+            end
+          END
         end
 
-        it_behaves_like 'auto-correct', ['lambda do |x|',
-                                         '  x',
-                                         'end'].join("\n")
+        it_behaves_like 'auto-correct', <<-END.strip_indent
+          lambda do |x|
+            x
+          end
+        END
       end
 
       context 'without spacing before arguments' do
         let(:source) do
-          ['->(x) do',
-           '  x',
-           'end']
+          <<-END.strip_indent
+            ->(x) do
+              x
+            end
+          END
         end
 
-        it_behaves_like 'auto-correct', ['lambda do |x|',
-                                         '  x',
-                                         'end'].join("\n")
+        it_behaves_like 'auto-correct', <<-END.strip_indent
+          lambda do |x|
+            x
+          end
+        END
       end
 
       context 'with a multiline lambda literal' do
         context 'with empty arguments' do
           let(:source) do
-            ['->()do',
-             '  x',
-             'end']
+            <<-END.strip_indent
+              ->()do
+                x
+              end
+            END
           end
 
-          it_behaves_like 'auto-correct', ['lambda do',
-                                           '  x',
-                                           'end'].join("\n")
+          it_behaves_like 'auto-correct', <<-END.strip_indent
+            lambda do
+              x
+            end
+          END
         end
 
         context 'with no arguments and bad spacing' do
           let(:source) do
-            ['-> ()do',
-             '  x',
-             'end']
+            <<-END.strip_indent
+              -> ()do
+                x
+              end
+            END
           end
 
-          it_behaves_like 'auto-correct', ['lambda do',
-                                           '  x',
-                                           'end'].join("\n")
+          it_behaves_like 'auto-correct', <<-END.strip_indent
+            lambda do
+              x
+            end
+          END
         end
 
         context 'with no arguments and no spacing' do
           let(:source) do
-            ['->do',
-             '  x',
-             'end']
+            <<-END.strip_indent
+              ->do
+                x
+              end
+            END
           end
 
-          it_behaves_like 'auto-correct', ['lambda do',
-                                           '  x',
-                                           'end'].join("\n")
+          it_behaves_like 'auto-correct', <<-END.strip_indent
+            lambda do
+              x
+            end
+          END
         end
 
         context 'without parentheses' do
           let(:source) do
-            ['-> hello do',
-             '  puts hello',
-             'end']
+            <<-END.strip_indent
+              -> hello do
+                puts hello
+              end
+            END
           end
 
           it_behaves_like 'registers an offense',
                           'Use the `lambda` method for multiline lambdas.'
-          it_behaves_like 'auto-correct', ['lambda do |hello|',
-                                           '  puts hello',
-                                           'end'].join("\n")
+          it_behaves_like 'auto-correct', <<-END.strip_indent
+            lambda do |hello|
+              puts hello
+            end
+          END
         end
 
         context 'with no parentheses and bad spacing' do
           let(:source) do
-            ['->   hello  do',
-             '  puts hello',
-             'end']
+            <<-END.strip_indent
+              ->   hello  do
+                puts hello
+              end
+            END
           end
 
           it_behaves_like 'registers an offense',
                           'Use the `lambda` method for multiline lambdas.'
-          it_behaves_like 'auto-correct', ['lambda do |hello|',
-                                           '  puts hello',
-                                           'end'].join("\n")
+          it_behaves_like 'auto-correct', <<-END.strip_indent
+            lambda do |hello|
+              puts hello
+            end
+          END
         end
 
         context 'with no parentheses and many args' do
           let(:source) do
-            ['->   hello, user  do',
-             '  puts hello',
-             'end']
+            <<-END.strip_indent
+              ->   hello, user  do
+                puts hello
+              end
+            END
           end
 
           it_behaves_like 'registers an offense',
                           'Use the `lambda` method for multiline lambdas.'
-          it_behaves_like 'auto-correct', ['lambda do |hello, user|',
-                                           '  puts hello',
-                                           'end'].join("\n")
+          it_behaves_like 'auto-correct', <<-END.strip_indent
+            lambda do |hello, user|
+              puts hello
+            end
+          END
         end
       end
     end
@@ -337,9 +401,11 @@ describe RuboCop::Cop::Style::Lambda, :config do
 
     context 'with a multiline lambda literal as an argument' do
       let(:source) do
-        ['has_many :kittens, -> do',
-         '  where(cats: Cat.young.where_values_hash)',
-         'end, source: cats']
+        <<-END.strip_indent
+          has_many :kittens, -> do
+            where(cats: Cat.young.where_values_hash)
+          end, source: cats
+        END
       end
 
       it_behaves_like 'registers an offense',
@@ -349,9 +415,11 @@ describe RuboCop::Cop::Style::Lambda, :config do
 
     context 'with a multiline lambda literal as a keyword argument' do
       let(:source) do
-        ['has_many opt: -> do',
-         '  where(cats: Cat.young.where_values_hash)',
-         'end']
+        <<-END.strip_indent
+          has_many opt: -> do
+            where(cats: Cat.young.where_values_hash)
+          end
+        END
       end
 
       it_behaves_like 'registers an offense',

--- a/spec/rubocop/cop/style/leading_comment_space_spec.rb
+++ b/spec/rubocop/cop/style/leading_comment_space_spec.rb
@@ -29,15 +29,18 @@ describe RuboCop::Cop::Style::LeadingCommentSpace do
   end
 
   it 'does not register an offense for #! on first line' do
-    inspect_source(cop,
-                   ['#!/usr/bin/ruby',
-                    'test'])
+    inspect_source(cop, <<-END.strip_indent)
+      #!/usr/bin/ruby
+      test
+    END
     expect(cop.offenses).to be_empty
   end
 
   it 'registers an offense for #! after the first line' do
-    inspect_source(cop, ['test',
-                         '#!/usr/bin/ruby'])
+    inspect_source(cop, <<-END.strip_indent)
+      test
+      #!/usr/bin/ruby
+    END
     expect(cop.offenses.size).to eq(1)
   end
 
@@ -78,10 +81,11 @@ describe RuboCop::Cop::Style::LeadingCommentSpace do
   end
 
   it 'accepts rdoc syntax' do
-    inspect_source(cop,
-                   ['#++',
-                    '#--',
-                    '#:nodoc:'])
+    inspect_source(cop, <<-END.strip_indent)
+      #++
+      #--
+      #:nodoc:
+    END
 
     expect(cop.offenses).to be_empty
   end
@@ -97,9 +101,11 @@ describe RuboCop::Cop::Style::LeadingCommentSpace do
   end
 
   it 'accepts =begin/=end comments' do
-    inspect_source(cop, ['=begin',
-                         '#blahblah',
-                         '=end'])
+    inspect_source(cop, <<-END.strip_indent)
+      =begin
+      #blahblah
+      =end
+    END
     expect(cop.offenses).to be_empty
   end
 end

--- a/spec/rubocop/cop/style/method_call_with_args_parentheses_spec.rb
+++ b/spec/rubocop/cop/style/method_call_with_args_parentheses_spec.rb
@@ -93,11 +93,11 @@ describe RuboCop::Cop::Style::MethodCallWithArgsParentheses, :config do
 
     context 'in a class body' do
       it 'does not register an offense' do
-        inspect_source(cop, [
-          'class Foo',
-          '  bar :baz',
-          'end'
-        ].join("\n"))
+        inspect_source(cop, <<-END.strip_indent)
+          class Foo
+            bar :baz
+          end
+        END
 
         expect(cop.offenses).to be_empty
       end
@@ -105,11 +105,11 @@ describe RuboCop::Cop::Style::MethodCallWithArgsParentheses, :config do
 
     context 'in a module body' do
       it 'does not register an offense' do
-        inspect_source(cop, [
-          'module Foo',
-          '  bar :baz',
-          'end'
-        ].join("\n"))
+        inspect_source(cop, <<-END.strip_indent)
+          module Foo
+            bar :baz
+          end
+        END
 
         expect(cop.offenses).to be_empty
       end

--- a/spec/rubocop/cop/style/method_call_without_args_parentheses_spec.rb
+++ b/spec/rubocop/cop/style/method_call_without_args_parentheses_spec.rb
@@ -51,12 +51,14 @@ describe RuboCop::Cop::Style::MethodCallWithoutArgsParentheses do
     end
 
     it 'accepts parens in complex assignment' do
-      inspect_source(cop, ['test = begin',
-                           '  case a',
-                           '  when b',
-                           '    c = test() if d',
-                           '  end',
-                           'end'])
+      inspect_source(cop, <<-END.strip_indent)
+        test = begin
+          case a
+          when b
+            c = test() if d
+          end
+        end
+      END
       expect(cop.offenses).to be_empty
     end
   end
@@ -84,13 +86,17 @@ describe RuboCop::Cop::Style::MethodCallWithoutArgsParentheses do
   # These will be offenses for the EmptyLiteral cop. The autocorrect loop will
   # handle that.
   it 'auto-corrects calls that could be empty literals' do
-    original = ['Hash.new()',
-                'Array.new()',
-                'String.new()']
+    original = <<-END.strip_indent
+      Hash.new()
+      Array.new()
+      String.new()
+    END
     new_source = autocorrect_source(cop, original)
-    expect(new_source).to eq(['Hash.new',
-                              'Array.new',
-                              'String.new'].join("\n"))
+    expect(new_source).to eq(<<-END.strip_indent)
+      Hash.new
+      Array.new
+      String.new
+    END
   end
 
   context 'method call as argument' do

--- a/spec/rubocop/cop/style/method_called_on_do_end_block_spec.rb
+++ b/spec/rubocop/cop/style/method_called_on_do_end_block_spec.rb
@@ -5,26 +5,32 @@ describe RuboCop::Cop::Style::MethodCalledOnDoEndBlock do
 
   context 'with a multi-line do..end block' do
     it 'registers an offense for a chained call' do
-      inspect_source(cop, ['a do',
-                           '  b',
-                           'end.c'])
+      inspect_source(cop, <<-END.strip_indent)
+        a do
+          b
+        end.c
+      END
       expect(cop.offenses.size).to eq(1)
       expect(cop.highlights).to eq(['end.c'])
     end
 
     it 'accepts it if there is no chained call' do
-      inspect_source(cop, ['a do',
-                           '  b',
-                           'end'])
+      inspect_source(cop, <<-END.strip_indent)
+        a do
+          b
+        end
+      END
       expect(cop.offenses).to be_empty
     end
 
     it 'accepts a chained block' do
-      inspect_source(cop, ['a do',
-                           '  b',
-                           'end.c do',
-                           '  d',
-                           'end'])
+      inspect_source(cop, <<-END.strip_indent)
+        a do
+          b
+        end.c do
+          d
+        end
+      END
       expect(cop.offenses).to be_empty
     end
   end
@@ -44,9 +50,11 @@ describe RuboCop::Cop::Style::MethodCalledOnDoEndBlock do
 
   context 'with a {} block' do
     it 'accepts a multi-line block with a chained call' do
-      inspect_source(cop, ['a {',
-                           '  b',
-                           '}.c'])
+      inspect_source(cop, <<-END.strip_indent)
+        a {
+          b
+        }.c
+      END
       expect(cop.offenses).to be_empty
     end
 

--- a/spec/rubocop/cop/style/method_def_parentheses_spec.rb
+++ b/spec/rubocop/cop/style/method_def_parentheses_spec.rb
@@ -7,8 +7,10 @@ describe RuboCop::Cop::Style::MethodDefParentheses, :config do
     let(:cop_config) { { 'EnforcedStyle' => 'require_parentheses' } }
 
     it 'reports an offense for def with parameters but no parens' do
-      src = ['def func a, b',
-             'end']
+      src = <<-END.strip_indent
+        def func a, b
+        end
+      END
       inspect_source(cop, src)
       expect(cop.offenses.size).to eq(1)
       expect(cop.config_to_allow_offenses).to eq('EnforcedStyle' =>
@@ -16,25 +18,31 @@ describe RuboCop::Cop::Style::MethodDefParentheses, :config do
     end
 
     it 'reports an offense for correct + opposite' do
-      src = ['def func(a, b)',
-             'end',
-             'def func a, b',
-             'end']
+      src = <<-END.strip_indent
+        def func(a, b)
+        end
+        def func a, b
+        end
+      END
       inspect_source(cop, src)
       expect(cop.offenses.size).to eq(1)
       expect(cop.config_to_allow_offenses).to eq('Enabled' => false)
     end
 
     it 'reports an offense for class def with parameters but no parens' do
-      src = ['def Test.func a, b',
-             'end']
+      src = <<-END.strip_indent
+        def Test.func a, b
+        end
+      END
       inspect_source(cop, src)
       expect(cop.offenses.size).to eq(1)
     end
 
     it 'accepts def with no args and no parens' do
-      src = ['def func',
-             'end']
+      src = <<-END.strip_indent
+        def func
+        end
+      END
       inspect_source(cop, src)
       expect(cop.offenses).to be_empty
     end
@@ -50,10 +58,17 @@ describe RuboCop::Cop::Style::MethodDefParentheses, :config do
     end
 
     it 'auto-adds required parens to argument lists on multiple lines' do
-      new_source = autocorrect_source(cop, ['def test one,', 'two', 'end'])
-      expect(new_source).to eq(['def test(one,',
-                                'two)',
-                                'end'].join("\n"))
+      new_source = autocorrect_source(cop, <<-END.strip_indent)
+        def test one,
+        two
+        end
+      END
+
+      expect(new_source).to eq(<<-END.strip_indent)
+        def test(one,
+        two)
+        end
+      END
     end
   end
 
@@ -61,8 +76,10 @@ describe RuboCop::Cop::Style::MethodDefParentheses, :config do
     # common to require_no_parentheses and
     # require_no_parentheses_except_multiline
     it 'reports an offense for def with parameters with parens' do
-      src = ['def func(a, b)',
-             'end']
+      src = <<-END.strip_indent
+        def func(a, b)
+        end
+      END
       inspect_source(cop, src)
       expect(cop.offenses.size).to eq(1)
       expect(cop.config_to_allow_offenses).to eq('EnforcedStyle' =>
@@ -70,46 +87,58 @@ describe RuboCop::Cop::Style::MethodDefParentheses, :config do
     end
 
     it 'accepts a def with parameters but no parens' do
-      src = ['def func a, b',
-             'end']
+      src = <<-END.strip_indent
+        def func a, b
+        end
+      END
       inspect_source(cop, src)
       expect(cop.offenses).to be_empty
     end
 
     it 'reports an offense for opposite + correct' do
-      src = ['def func(a, b)',
-             'end',
-             'def func a, b',
-             'end']
+      src = <<-END.strip_indent
+        def func(a, b)
+        end
+        def func a, b
+        end
+      END
       inspect_source(cop, src)
       expect(cop.offenses.size).to eq(1)
       expect(cop.config_to_allow_offenses).to eq('Enabled' => false)
     end
 
     it 'reports an offense for class def with parameters with parens' do
-      src = ['def Test.func(a, b)',
-             'end']
+      src = <<-END.strip_indent
+        def Test.func(a, b)
+        end
+      END
       inspect_source(cop, src)
       expect(cop.offenses.size).to eq(1)
     end
 
     it 'accepts a class def with parameters with parens' do
-      src = ['def Test.func a, b',
-             'end']
+      src = <<-END.strip_indent
+        def Test.func a, b
+        end
+      END
       inspect_source(cop, src)
       expect(cop.offenses).to be_empty
     end
 
     it 'reports an offense for def with no args and parens' do
-      src = ['def func()',
-             'end']
+      src = <<-END.strip_indent
+        def func()
+        end
+      END
       inspect_source(cop, src)
       expect(cop.offenses.size).to eq(1)
     end
 
     it 'accepts def with no args and no parens' do
-      src = ['def func',
-             'end']
+      src = <<-END.strip_indent
+        def func
+        end
+      END
       inspect_source(cop, src)
       expect(cop.offenses).to be_empty
     end
@@ -142,22 +171,31 @@ describe RuboCop::Cop::Style::MethodDefParentheses, :config do
 
     context 'when args span multiple lines' do
       it 'reports an offense for correct + opposite' do
-        src = ['def func(a,',
-               '         b)',
-               'end',
-               'def func a,',
-               '         b',
-               'end']
+        src = <<-END.strip_indent
+          def func(a,
+                   b)
+          end
+          def func a,
+                   b
+          end
+        END
         inspect_source(cop, src)
         expect(cop.offenses.size).to eq(1)
         expect(cop.config_to_allow_offenses).to eq('Enabled' => false)
       end
 
       it 'auto-adds required parens to argument lists on multiple lines' do
-        new_source = autocorrect_source(cop, ['def test one,', 'two', 'end'])
-        expect(new_source).to eq(['def test(one,',
-                                  'two)',
-                                  'end'].join("\n"))
+        new_source = autocorrect_source(cop, <<-END.strip_indent)
+          def test one,
+          two
+          end
+        END
+
+        expect(new_source).to eq(<<-END.strip_indent)
+          def test(one,
+          two)
+          end
+        END
       end
     end
   end

--- a/spec/rubocop/cop/style/method_missing_spec.rb
+++ b/spec/rubocop/cop/style/method_missing_spec.rb
@@ -30,10 +30,11 @@ describe RuboCop::Cop::Style::MethodMissing do
       'fall back on `super`.'
     end
 
-    it_behaves_like 'code with offense',
-                    ['class Test',
-                     '  def method_missing; end',
-                     'end'].join("\n")
+    it_behaves_like 'code with offense', <<-END.strip_indent
+      class Test
+        def method_missing; end
+      end
+    END
   end
 
   describe 'when not implementing #respond_to_missing?' do
@@ -41,12 +42,13 @@ describe RuboCop::Cop::Style::MethodMissing do
       'When using `method_missing`, define `respond_to_missing?`.'
     end
 
-    it_behaves_like 'code with offense',
-                    ['class Test',
-                     '  def method_missing',
-                     '    super',
-                     '  end',
-                     'end'].join("\n")
+    it_behaves_like 'code with offense', <<-END.strip_indent
+      class Test
+        def method_missing
+          super
+        end
+      end
+    END
   end
 
   describe 'when not calling #super' do
@@ -54,32 +56,35 @@ describe RuboCop::Cop::Style::MethodMissing do
       'When using `method_missing`, fall back on `super`.'
     end
 
-    it_behaves_like 'code with offense',
-                    ['class Test',
-                     '  def respond_to_missing?; end',
-                     '  def method_missing; end',
-                     'end'].join("\n")
+    it_behaves_like 'code with offense', <<-END.strip_indent
+      class Test
+        def respond_to_missing?; end
+        def method_missing; end
+      end
+    END
   end
 
   describe 'when implementing #respond_to_missing? and calling #super' do
     context 'when implemented as instance methods' do
-      it_behaves_like 'code without offense',
-                      ['class Test',
-                       '  def respond_to_missing?; end',
-                       '  def method_missing',
-                       '    super',
-                       '  end',
-                       'end'].join("\n")
+      it_behaves_like 'code without offense', <<-END.strip_indent
+        class Test
+          def respond_to_missing?; end
+          def method_missing
+            super
+          end
+        end
+      END
     end
 
     context 'when implemented as class methods' do
-      it_behaves_like 'code without offense',
-                      ['class Test',
-                       '  def self.respond_to_missing?; end',
-                       '  def self.method_missing',
-                       '    super',
-                       '  end',
-                       'end'].join("\n")
+      it_behaves_like 'code without offense', <<-END.strip_indent
+        class Test
+          def self.respond_to_missing?; end
+          def self.method_missing
+            super
+          end
+        end
+      END
     end
 
     context 'when implemented with different scopes' do
@@ -87,13 +92,14 @@ describe RuboCop::Cop::Style::MethodMissing do
         'When using `method_missing`, define `respond_to_missing?`.'
       end
 
-      it_behaves_like 'code with offense',
-                      ['class Test',
-                       '  def respond_to_missing?; end',
-                       '  def self.method_missing',
-                       '    super',
-                       '  end',
-                       'end'].join("\n")
+      it_behaves_like 'code with offense', <<-END.strip_indent
+        class Test
+          def respond_to_missing?; end
+          def self.method_missing
+            super
+          end
+        end
+      END
     end
   end
 end

--- a/spec/rubocop/cop/style/method_name_spec.rb
+++ b/spec/rubocop/cop/style/method_name_spec.rb
@@ -5,27 +5,33 @@ describe RuboCop::Cop::Style::MethodName, :config do
 
   shared_examples 'never accepted' do
     it 'registers an offense for mixed snake case and camel case' do
-      inspect_source(cop, ['def visit_Arel_Nodes_SelectStatement',
-                           'end'])
+      inspect_source(cop, <<-END.strip_indent)
+        def visit_Arel_Nodes_SelectStatement
+        end
+      END
       expect(cop.offenses.size).to eq(1)
       expect(cop.highlights).to eq(['visit_Arel_Nodes_SelectStatement'])
     end
 
     it 'registers an offense for capitalized camel case' do
-      inspect_source(cop, ['class MyClass',
-                           '  def MyMethod',
-                           '  end',
-                           'end'])
+      inspect_source(cop, <<-END.strip_indent)
+        class MyClass
+          def MyMethod
+          end
+        end
+      END
       expect(cop.offenses.size).to eq(1)
       expect(cop.highlights).to eq(['MyMethod'])
     end
 
     it 'registers an offense for singleton upper case method without ' \
        'corresponding class' do
-      inspect_source(cop, ['module Sequel',
-                           '  def self.Model(source)',
-                           '  end',
-                           'end'])
+      inspect_source(cop, <<-END.strip_indent)
+        module Sequel
+          def self.Model(source)
+          end
+        end
+      END
       expect(cop.highlights).to eq(['Model'])
     end
   end
@@ -37,38 +43,44 @@ describe RuboCop::Cop::Style::MethodName, :config do
     end
 
     it 'accepts operator definitions' do
-      inspect_source(cop, ['def +(other)',
-                           '  # ...',
-                           'end'])
+      inspect_source(cop, <<-END.strip_indent)
+        def +(other)
+          # ...
+        end
+      END
       expect(cop.offenses).to be_empty
     end
 
     %w[class module].each do |kind|
       it "accepts class emitter method in a #{kind}" do
-        inspect_source(cop, ["#{kind} Sequel",
-                             '  def self.Model(source)',
-                             '  end',
-                             '',
-                             '  class Model',
-                             '  end',
-                             'end'])
+        inspect_source(cop, <<-END.strip_indent)
+          #{kind} Sequel
+            def self.Model(source)
+            end
+
+            class Model
+            end
+          end
+        END
         expect(cop.offenses).to be_empty
       end
 
       it "accepts class emitter method in a #{kind}, even when it is " \
          'defined inside another method' do
-        inspect_source(cop, ['module DPN',
-                             '  module Flow',
-                             '    module BaseFlow',
-                             '      class Start',
-                             '      end',
-                             '      def self.included(base)',
-                             '        def base.Start(aws_env, *args)',
-                             '        end',
-                             '      end',
-                             '    end',
-                             '  end',
-                             'end'])
+        inspect_source(cop, <<-END.strip_indent)
+          module DPN
+            module Flow
+              module BaseFlow
+                class Start
+                end
+                def self.included(base)
+                  def base.Start(aws_env, *args)
+                  end
+                end
+              end
+            end
+          end
+        END
         expect(cop.offenses).to be_empty
       end
     end
@@ -78,9 +90,11 @@ describe RuboCop::Cop::Style::MethodName, :config do
     let(:cop_config) { { 'EnforcedStyle' => 'snake_case' } }
 
     it 'registers an offense for camel case in instance method name' do
-      inspect_source(cop, ['def myMethod',
-                           '  # ...',
-                           'end'])
+      inspect_source(cop, <<-END.strip_indent)
+        def myMethod
+          # ...
+        end
+      END
       expect(cop.offenses.size).to eq(1)
       expect(cop.highlights).to eq(['myMethod'])
       expect(cop.config_to_allow_offenses).to eq('EnforcedStyle' =>
@@ -88,33 +102,41 @@ describe RuboCop::Cop::Style::MethodName, :config do
     end
 
     it 'registers an offense for opposite + correct' do
-      inspect_source(cop, ['def my_method',
-                           'end',
-                           'def myMethod',
-                           'end'])
+      inspect_source(cop, <<-END.strip_indent)
+        def my_method
+        end
+        def myMethod
+        end
+      END
       expect(cop.highlights).to eq(['myMethod'])
       expect(cop.config_to_allow_offenses).to eq('Enabled' => false)
     end
 
     it 'registers an offense for camel case in singleton method name' do
-      inspect_source(cop, ['def self.myMethod',
-                           '  # ...',
-                           'end'])
+      inspect_source(cop, <<-END.strip_indent)
+        def self.myMethod
+          # ...
+        end
+      END
       expect(cop.offenses.size).to eq(1)
       expect(cop.highlights).to eq(['myMethod'])
     end
 
     it 'accepts snake case in names' do
-      inspect_source(cop, ['def my_method',
-                           'end'])
+      inspect_source(cop, <<-END.strip_indent)
+        def my_method
+        end
+      END
       expect(cop.offenses).to be_empty
     end
 
     it 'registers an offense for singleton camelCase method within class' do
-      inspect_source(cop, ['class Sequel',
-                           '  def self.fooBar',
-                           '  end',
-                           'end'])
+      inspect_source(cop, <<-END.strip_indent)
+        class Sequel
+          def self.fooBar
+          end
+        end
+      END
       expect(cop.highlights).to eq(['fooBar'])
     end
 
@@ -126,22 +148,28 @@ describe RuboCop::Cop::Style::MethodName, :config do
     let(:cop_config) { { 'EnforcedStyle' => 'camelCase' } }
 
     it 'accepts camel case in instance method name' do
-      inspect_source(cop, ['def myMethod',
-                           '  # ...',
-                           'end'])
+      inspect_source(cop, <<-END.strip_indent)
+        def myMethod
+          # ...
+        end
+      END
       expect(cop.offenses).to be_empty
     end
 
     it 'accepts camel case in singleton method name' do
-      inspect_source(cop, ['def self.myMethod',
-                           '  # ...',
-                           'end'])
+      inspect_source(cop, <<-END.strip_indent)
+        def self.myMethod
+          # ...
+        end
+      END
       expect(cop.offenses).to be_empty
     end
 
     it 'registers an offense for snake case in names' do
-      inspect_source(cop, ['def my_method',
-                           'end'])
+      inspect_source(cop, <<-END.strip_indent)
+        def my_method
+        end
+      END
       expect(cop.offenses.size).to eq(1)
       expect(cop.highlights).to eq(['my_method'])
       expect(cop.config_to_allow_offenses).to eq('EnforcedStyle' =>
@@ -149,19 +177,23 @@ describe RuboCop::Cop::Style::MethodName, :config do
     end
 
     it 'registers an offense for correct + opposite' do
-      inspect_source(cop, ['def my_method',
-                           'end',
-                           'def myMethod',
-                           'end'])
+      inspect_source(cop, <<-END.strip_indent)
+        def my_method
+        end
+        def myMethod
+        end
+      END
       expect(cop.highlights).to eq(['my_method'])
       expect(cop.config_to_allow_offenses).to eq('Enabled' => false)
     end
 
     it 'registers an offense for singleton snake_case method within class' do
-      inspect_source(cop, ['class Sequel',
-                           '  def self.foo_bar',
-                           '  end',
-                           'end'])
+      inspect_source(cop, <<-END.strip_indent)
+        class Sequel
+          def self.foo_bar
+          end
+        end
+      END
       expect(cop.highlights).to eq(['foo_bar'])
     end
 

--- a/spec/rubocop/cop/style/mixin_grouping_spec.rb
+++ b/spec/rubocop/cop/style/mixin_grouping_spec.rb
@@ -45,18 +45,20 @@ describe RuboCop::Cop::Style::MixinGrouping, :config do
       let(:message) { 'Put `include` mixins in separate statements.' }
 
       context 'with several mixins in one call' do
-        it_behaves_like 'code with offense',
-                        ['class Foo',
-                         '  include Bar, Qux',
-                         'end'].join("\n")
+        it_behaves_like 'code with offense', <<-END.strip_indent
+          class Foo
+            include Bar, Qux
+          end
+        END
       end
 
       context 'with several mixins in separate calls' do
-        it_behaves_like 'code without offense',
-                        ['class Foo',
-                         '  include Bar',
-                         '  include Qux',
-                         'end'].join("\n")
+        it_behaves_like 'code without offense', <<-END.strip_indent
+          class Foo
+            include Bar
+            include Qux
+          end
+        END
       end
 
       context 'when include call is an argument to another method' do
@@ -69,18 +71,20 @@ describe RuboCop::Cop::Style::MixinGrouping, :config do
       let(:message) { 'Put `extend` mixins in separate statements.' }
 
       context 'with several mixins in one call' do
-        it_behaves_like 'code with offense',
-                        ['class Foo',
-                         '  extend Bar, Qux',
-                         'end'].join("\n")
+        it_behaves_like 'code with offense', <<-END.strip_indent
+          class Foo
+            extend Bar, Qux
+          end
+        END
       end
 
       context 'with several mixins in separate calls' do
-        it_behaves_like 'code without offense',
-                        ['class Foo',
-                         '  extend Bar',
-                         '  extend Qux',
-                         'end'].join("\n")
+        it_behaves_like 'code without offense', <<-END.strip_indent
+          class Foo
+            extend Bar
+            extend Qux
+          end
+        END
       end
     end
 
@@ -88,18 +92,20 @@ describe RuboCop::Cop::Style::MixinGrouping, :config do
       let(:message) { 'Put `prepend` mixins in separate statements.' }
 
       context 'with several mixins in one call' do
-        it_behaves_like 'code with offense',
-                        ['class Foo',
-                         '  prepend Bar, Qux',
-                         'end'].join("\n")
+        it_behaves_like 'code with offense', <<-END.strip_indent
+          class Foo
+            prepend Bar, Qux
+          end
+        END
       end
 
       context 'with several mixins in separate calls' do
-        it_behaves_like 'code without offense',
-                        ['class Foo',
-                         '  prepend Bar',
-                         '  prepend Qux',
-                         'end'].join("\n")
+        it_behaves_like 'code without offense', <<-END.strip_indent
+          class Foo
+            prepend Bar
+            prepend Qux
+          end
+        END
       end
     end
 
@@ -107,20 +113,22 @@ describe RuboCop::Cop::Style::MixinGrouping, :config do
       context 'with some calls having several mixins' do
         let(:message) { 'Put `include` mixins in separate statements.' }
 
-        it_behaves_like 'code with offense',
-                        ['class Foo',
-                         '  include Bar, Baz',
-                         '  extend Qux',
-                         'end'].join("\n")
+        it_behaves_like 'code with offense', <<-END.strip_indent
+          class Foo
+            include Bar, Baz
+            extend Qux
+          end
+        END
       end
 
       context 'with all calls having one mixin' do
-        it_behaves_like 'code without offense',
-                        ['class Foo',
-                         '  include Bar',
-                         '  prepend Baz',
-                         '  extend Baz',
-                         'end'].join("\n")
+        it_behaves_like 'code without offense', <<-END.strip_indent
+          class Foo
+            include Bar
+            prepend Baz
+            extend Baz
+          end
+        END
       end
     end
   end
@@ -133,25 +141,28 @@ describe RuboCop::Cop::Style::MixinGrouping, :config do
         let(:offenses) { 3 }
         let(:message) { 'Put `include` mixins in a single statement.' }
 
-        it_behaves_like 'code with offense',
-                        ['class Foo',
-                         '  include Bar',
-                         '  include Baz',
-                         '  include Qux',
-                         'end'].join("\n")
+        it_behaves_like 'code with offense', <<-END.strip_indent
+          class Foo
+            include Bar
+            include Baz
+            include Qux
+          end
+        END
       end
 
       context 'with several mixins in separate calls' do
-        it_behaves_like 'code without offense',
-                        ['class Foo',
-                         '  include Bar, Qux',
-                         'end'].join("\n")
+        it_behaves_like 'code without offense', <<-END.strip_indent
+          class Foo
+            include Bar, Qux
+          end
+        END
       end
 
       context 'when include has an explicit receiver' do
-        it_behaves_like 'code without offense',
-                        ['config.include Foo',
-                         'config.include Bar'].join("\n")
+        it_behaves_like 'code without offense', <<-END.strip_indent
+          config.include Foo
+          config.include Bar
+        END
       end
     end
 
@@ -160,18 +171,20 @@ describe RuboCop::Cop::Style::MixinGrouping, :config do
         let(:offenses) { 2 }
         let(:message) { 'Put `extend` mixins in a single statement.' }
 
-        it_behaves_like 'code with offense',
-                        ['class Foo',
-                         '  extend Bar',
-                         '  extend Baz',
-                         'end'].join("\n")
+        it_behaves_like 'code with offense', <<-END.strip_indent
+          class Foo
+            extend Bar
+            extend Baz
+          end
+        END
       end
 
       context 'with several mixins in separate calls' do
-        it_behaves_like 'code without offense',
-                        ['class Foo',
-                         '  extend Bar, Qux',
-                         'end'].join("\n")
+        it_behaves_like 'code without offense', <<-END.strip_indent
+          class Foo
+            extend Bar, Qux
+          end
+        END
       end
     end
 
@@ -180,18 +193,20 @@ describe RuboCop::Cop::Style::MixinGrouping, :config do
         let(:offenses) { 2 }
         let(:message) { 'Put `prepend` mixins in a single statement.' }
 
-        it_behaves_like 'code with offense',
-                        ['class Foo',
-                         '  prepend Bar',
-                         '  prepend Baz',
-                         'end'].join("\n")
+        it_behaves_like 'code with offense', <<-END.strip_indent
+          class Foo
+            prepend Bar
+            prepend Baz
+          end
+        END
       end
 
       context 'with several mixins in separate calls' do
-        it_behaves_like 'code without offense',
-                        ['class Foo',
-                         '  prepend Bar, Qux',
-                         'end'].join("\n")
+        it_behaves_like 'code without offense', <<-END.strip_indent
+          class Foo
+            prepend Bar, Qux
+          end
+        END
       end
     end
 
@@ -200,21 +215,23 @@ describe RuboCop::Cop::Style::MixinGrouping, :config do
         let(:offenses) { 2 }
         let(:message) { 'Put `include` mixins in a single statement.' }
 
-        it_behaves_like 'code with offense',
-                        ['class Foo',
-                         '  include Bar',
-                         '  include Baz',
-                         '  extend Baz',
-                         'end'].join("\n")
+        it_behaves_like 'code with offense', <<-END.strip_indent
+          class Foo
+            include Bar
+            include Baz
+            extend Baz
+          end
+        END
       end
 
       context 'with all different mixin methods' do
-        it_behaves_like 'code without offense',
-                        ['class Foo',
-                         '  include Bar',
-                         '  prepend Baz',
-                         '  extend Baz',
-                         'end'].join("\n")
+        it_behaves_like 'code without offense', <<-END.strip_indent
+          class Foo
+            include Bar
+            prepend Baz
+            extend Baz
+          end
+        END
       end
     end
   end

--- a/spec/rubocop/cop/style/module_function_spec.rb
+++ b/spec/rubocop/cop/style/module_function_spec.rb
@@ -7,20 +7,22 @@ describe RuboCop::Cop::Style::ModuleFunction, :config do
     let(:cop_config) { { 'EnforcedStyle' => 'module_function' } }
 
     it 'registers an offense for `extend self` in a module' do
-      inspect_source(cop,
-                     ['module Test',
-                      '  extend self',
-                      '  def test; end',
-                      'end'])
+      inspect_source(cop, <<-END.strip_indent)
+        module Test
+          extend self
+          def test; end
+        end
+      END
       expect(cop.messages).to eq([described_class::MODULE_FUNCTION_MSG])
       expect(cop.highlights).to eq(['extend self'])
     end
 
     it 'accepts `extend self` in a class' do
-      inspect_source(cop,
-                     ['class Test',
-                      '  extend self',
-                      'end'])
+      inspect_source(cop, <<-END.strip_indent)
+        class Test
+          extend self
+        end
+      END
       expect(cop.offenses).to be_empty
     end
   end
@@ -29,21 +31,23 @@ describe RuboCop::Cop::Style::ModuleFunction, :config do
     let(:cop_config) { { 'EnforcedStyle' => 'extend_self' } }
 
     it 'registers an offense for `module_function` without an argument' do
-      inspect_source(cop,
-                     ['module Test',
-                      '  module_function',
-                      '  def test; end',
-                      'end'])
+      inspect_source(cop, <<-END.strip_indent)
+        module Test
+          module_function
+          def test; end
+        end
+      END
       expect(cop.messages).to eq([described_class::EXTEND_SELF_MSG])
       expect(cop.highlights).to eq(['module_function'])
     end
 
     it 'accepts module_function with an argument' do
-      inspect_source(cop,
-                     ['module Test',
-                      '  def test; end',
-                      '  module_function :test',
-                      'end'])
+      inspect_source(cop, <<-END.strip_indent)
+        module Test
+          def test; end
+          module_function :test
+        end
+      END
       expect(cop.offenses).to be_empty
     end
   end

--- a/spec/rubocop/cop/style/multiline_array_brace_layout_spec.rb
+++ b/spec/rubocop/cop/style/multiline_array_brace_layout_spec.rb
@@ -5,8 +5,10 @@ describe RuboCop::Cop::Style::MultilineArrayBraceLayout, :config do
   let(:cop_config) { { 'EnforcedStyle' => 'symmetrical' } }
 
   it 'ignores implicit arrays' do
-    inspect_source(cop, ['foo = a,',
-                         'b'])
+    inspect_source(cop, <<-END.strip_indent)
+      foo = a,
+      b
+    END
 
     expect(cop.offenses).to be_empty
   end

--- a/spec/rubocop/cop/style/multiline_assignment_layout_spec.rb
+++ b/spec/rubocop/cop/style/multiline_assignment_layout_spec.rb
@@ -15,8 +15,10 @@ describe RuboCop::Cop::Style::MultilineAssignmentLayout, :config do
     let(:enforced_style) { 'new_line' }
 
     it 'registers an offense when the rhs is on the same line' do
-      inspect_source(cop, ['blarg = if true',
-                           'end'])
+      inspect_source(cop, <<-END.strip_indent)
+        blarg = if true
+        end
+      END
 
       expect(cop.offenses.size).to eq(1)
       expect(cop.offenses.first.line).to eq(1)
@@ -25,15 +27,23 @@ describe RuboCop::Cop::Style::MultilineAssignmentLayout, :config do
     end
 
     it 'auto-corrects offenses' do
-      new_source = autocorrect_source(cop, ['blarg = if true',
-                                            'end'])
+      new_source = autocorrect_source(cop, <<-END.strip_indent)
+        blarg = if true
+        end
+      END
 
-      expect(new_source).to eq("blarg =\n if true\nend")
+      expect(new_source).to eq(<<-END.strip_indent)
+        blarg =
+         if true
+        end
+      END
     end
 
     it 'ignores arrays' do
-      inspect_source(cop, ['a, b = 4,',
-                           '5'])
+      inspect_source(cop, <<-END.strip_indent)
+        a, b = 4,
+        5
+      END
 
       expect(cop.offenses).to be_empty
     end
@@ -42,8 +52,10 @@ describe RuboCop::Cop::Style::MultilineAssignmentLayout, :config do
       let(:supported_types) { %w[array] }
 
       it 'allows supported types to be configured' do
-        inspect_source(cop, ['a, b = 4,',
-                             '5'])
+        inspect_source(cop, <<-END.strip_indent)
+          a, b = 4,
+          5
+        END
 
         expect(cop.offenses.size).to eq(1)
         expect(cop.offenses.first.line).to eq(1)
@@ -53,17 +65,21 @@ describe RuboCop::Cop::Style::MultilineAssignmentLayout, :config do
     end
 
     it 'allows multi-line assignments on separate lines' do
-      inspect_source(cop, ['blarg=',
-                           'if true',
-                           'end'])
+      inspect_source(cop, <<-END.strip_indent)
+        blarg=
+        if true
+        end
+      END
 
       expect(cop.offenses).to be_empty
     end
 
     it 'registers an offense for masgn with multi-line lhs' do
-      inspect_source(cop, ['a,',
-                           'b = if foo',
-                           'end'])
+      inspect_source(cop, <<-END.strip_indent)
+        a,
+        b = if foo
+        end
+      END
 
       expect(cop.offenses.size).to eq(1)
       expect(cop.offenses.first.line).to eq(1)
@@ -76,9 +92,11 @@ describe RuboCop::Cop::Style::MultilineAssignmentLayout, :config do
     let(:enforced_style) { 'same_line' }
 
     it 'registers an offense when the rhs is a different line' do
-      inspect_source(cop, ['blarg =',
-                           'if true',
-                           'end'])
+      inspect_source(cop, <<-END.strip_indent)
+        blarg =
+        if true
+        end
+      END
 
       expect(cop.offenses.size).to eq(1)
       expect(cop.offenses.first.line).to eq(1)
@@ -87,17 +105,24 @@ describe RuboCop::Cop::Style::MultilineAssignmentLayout, :config do
     end
 
     it 'auto-corrects offenses' do
-      new_source = autocorrect_source(cop, ['blarg =',
-                                            'if true',
-                                            'end'])
+      new_source = autocorrect_source(cop, <<-END.strip_indent)
+        blarg =
+        if true
+        end
+      END
 
-      expect(new_source).to eq("blarg = if true\nend")
+      expect(new_source).to eq(<<-END.strip_indent)
+        blarg = if true
+        end
+      END
     end
 
     it 'ignores arrays' do
-      inspect_source(cop, ['a, b =',
-                           '4,',
-                           '5'])
+      inspect_source(cop, <<-END.strip_indent)
+        a, b =
+        4,
+        5
+      END
 
       expect(cop.offenses).to be_empty
     end
@@ -106,9 +131,11 @@ describe RuboCop::Cop::Style::MultilineAssignmentLayout, :config do
       let(:supported_types) { %w[array] }
 
       it 'allows supported types to be configured' do
-        inspect_source(cop, ['a, b =',
-                             '4,',
-                             '5'])
+        inspect_source(cop, <<-END.strip_indent)
+          a, b =
+          4,
+          5
+        END
 
         expect(cop.offenses.size).to eq(1)
         expect(cop.offenses.first.line).to eq(1)
@@ -118,17 +145,21 @@ describe RuboCop::Cop::Style::MultilineAssignmentLayout, :config do
     end
 
     it 'allows multi-line assignments on the same line' do
-      inspect_source(cop, ['blarg= if true',
-                           'end'])
+      inspect_source(cop, <<-END.strip_indent)
+        blarg= if true
+        end
+      END
 
       expect(cop.offenses).to be_empty
     end
 
     it 'registers an offense for masgn with multi-line lhs' do
-      inspect_source(cop, ['a,',
-                           'b =',
-                           'if foo',
-                           'end'])
+      inspect_source(cop, <<-END.strip_indent)
+        a,
+        b =
+        if foo
+        end
+      END
 
       expect(cop.offenses.size).to eq(1)
       expect(cop.offenses.first.line).to eq(1)

--- a/spec/rubocop/cop/style/multiline_block_chain_spec.rb
+++ b/spec/rubocop/cop/style/multiline_block_chain_spec.rb
@@ -5,42 +5,50 @@ describe RuboCop::Cop::Style::MultilineBlockChain do
 
   context 'with multi-line block chaining' do
     it 'registers an offense for a simple case' do
-      inspect_source(cop, ['a do',
-                           '  b',
-                           'end.c do',
-                           '  d',
-                           'end'])
+      inspect_source(cop, <<-END.strip_indent)
+        a do
+          b
+        end.c do
+          d
+        end
+      END
       expect(cop.offenses.size).to eq(1)
       expect(cop.highlights).to eq(['end.c'])
     end
 
     it 'registers an offense for a slightly more complicated case' do
-      inspect_source(cop, ['a do',
-                           '  b',
-                           'end.c1.c2 do',
-                           '  d',
-                           'end'])
+      inspect_source(cop, <<-END.strip_indent)
+        a do
+          b
+        end.c1.c2 do
+          d
+        end
+      END
       expect(cop.offenses.size).to eq(1)
       expect(cop.highlights).to eq(['end.c1.c2'])
     end
 
     it 'registers two offenses for a chain of three blocks' do
-      inspect_source(cop, ['a do',
-                           '  b',
-                           'end.c do',
-                           '  d',
-                           'end.e do',
-                           '  f',
-                           'end'])
+      inspect_source(cop, <<-END.strip_indent)
+        a do
+          b
+        end.c do
+          d
+        end.e do
+          f
+        end
+      END
       expect(cop.offenses.size).to eq(2)
       expect(cop.highlights).to eq(['end.c', 'end.e'])
     end
 
     it 'registers an offense for a chain where the second block is ' \
        'single-line' do
-      inspect_source(cop, ['Thread.list.find_all { |t|',
-                           '  t.alive?',
-                           '}.map { |thread| thread.object_id }'])
+      inspect_source(cop, <<-END.strip_indent)
+        Thread.list.find_all { |t|
+          t.alive?
+        }.map { |thread| thread.object_id }
+      END
       expect(cop.offenses.size).to eq(1)
       expect(cop.highlights).to eq(['}.map'])
     end
@@ -55,22 +63,28 @@ describe RuboCop::Cop::Style::MultilineBlockChain do
   end
 
   it 'accepts a chain of blocks spanning one line' do
-    inspect_source(cop, ['a { b }.c { d }',
-                         'w do x end.y do z end'])
+    inspect_source(cop, <<-END.strip_indent)
+      a { b }.c { d }
+      w do x end.y do z end
+    END
     expect(cop.offenses).to be_empty
   end
 
   it 'accepts a multi-line block chained with calls on one line' do
-    inspect_source(cop, ['a do',
-                         '  b',
-                         'end.c.d'])
+    inspect_source(cop, <<-END.strip_indent)
+      a do
+        b
+      end.c.d
+    END
     expect(cop.offenses).to be_empty
   end
 
   it 'accepts a chain of calls followed by a multi-line block' do
-    inspect_source(cop, ['a1.a2.a3 do',
-                         '  b',
-                         'end'])
+    inspect_source(cop, <<-END.strip_indent)
+      a1.a2.a3 do
+        b
+      end
+    END
     expect(cop.offenses).to be_empty
   end
 end

--- a/spec/rubocop/cop/style/multiline_block_layout_spec.rb
+++ b/spec/rubocop/cop/style/multiline_block_layout_spec.rb
@@ -4,33 +4,37 @@ describe RuboCop::Cop::Style::MultilineBlockLayout do
   subject(:cop) { described_class.new }
 
   it 'registers an offense for missing newline in do/end block w/o params' do
-    inspect_source(cop,
-                   ['test do foo',
-                    'end'])
+    inspect_source(cop, <<-END.strip_indent)
+      test do foo
+      end
+    END
     expect(cop.messages)
       .to eq(['Block body expression is on the same line as the block start.'])
   end
 
   it 'registers an offense for missing newline in {} block w/o params' do
-    inspect_source(cop,
-                   ['test { foo',
-                    '}'])
+    inspect_source(cop, <<-END.strip_indent)
+      test { foo
+      }
+    END
     expect(cop.messages)
       .to eq(['Block body expression is on the same line as the block start.'])
   end
 
   it 'registers an offense for missing newline in do/end block with params' do
-    inspect_source(cop,
-                   ['test do |x| foo',
-                    'end'])
+    inspect_source(cop, <<-END.strip_indent)
+      test do |x| foo
+      end
+    END
     expect(cop.messages)
       .to eq(['Block body expression is on the same line as the block start.'])
   end
 
   it 'registers an offense for missing newline in {} block with params' do
-    inspect_source(cop,
-                   ['test { |x| foo',
-                    '}'])
+    inspect_source(cop, <<-END.strip_indent)
+      test { |x| foo
+      }
+    END
     expect(cop.messages)
       .to eq(['Block body expression is on the same line as the block start.'])
   end
@@ -46,176 +50,212 @@ describe RuboCop::Cop::Style::MultilineBlockLayout do
   end
 
   it 'does not register offenses when there is a newline for do/end block' do
-    inspect_source(cop,
-                   ['test do',
-                    '  foo',
-                    'end'])
+    inspect_source(cop, <<-END.strip_indent)
+      test do
+        foo
+      end
+    END
     expect(cop.offenses).to be_empty
   end
 
   it 'does not error out when the block is empty' do
-    inspect_source(cop,
-                   ['test do |x|',
-                    'end'])
+    inspect_source(cop, <<-END.strip_indent)
+      test do |x|
+      end
+    END
     expect(cop.offenses).to be_empty
   end
 
   it 'does not register offenses when there is a newline for {} block' do
-    inspect_source(cop,
-                   ['test {',
-                    '  foo',
-                    '}'])
+    inspect_source(cop, <<-END.strip_indent)
+      test {
+        foo
+      }
+    END
     expect(cop.offenses).to be_empty
   end
 
   it 'registers offenses for lambdas as expected' do
-    inspect_source(cop,
-                   ['-> (x) do foo',
-                    '  bar',
-                    'end'])
+    inspect_source(cop, <<-END.strip_indent)
+      -> (x) do foo
+        bar
+      end
+    END
     expect(cop.messages)
       .to eq(['Block body expression is on the same line as the block start.'])
   end
 
   it 'registers offenses for new lambda literal syntax as expected' do
-    inspect_source(cop,
-                   ['-> x do foo',
-                    '  bar',
-                    'end'])
+    inspect_source(cop, <<-END.strip_indent)
+      -> x do foo
+        bar
+      end
+    END
     expect(cop.messages)
       .to eq(['Block body expression is on the same line as the block start.'])
   end
 
   it 'registers an offense for line-break before arguments' do
-    inspect_source(cop,
-                   ['test do',
-                    '  |x| play_with(x)',
-                    'end'])
+    inspect_source(cop, <<-END.strip_indent)
+      test do
+        |x| play_with(x)
+      end
+    END
     expect(cop.messages)
       .to eq(['Block argument expression is not on the same line as the ' \
               'block start.'])
   end
 
   it 'registers an offense for line-break before arguments with empty block' do
-    inspect_source(cop,
-                   ['test do',
-                    '  |x|',
-                    'end'])
+    inspect_source(cop, <<-END.strip_indent)
+      test do
+        |x|
+      end
+    END
     expect(cop.messages)
       .to eq(['Block argument expression is not on the same line as the ' \
               'block start.'])
   end
 
   it 'registers an offense for line-break within arguments' do
-    inspect_source(cop,
-                   ['test do |x,',
-                    '  y|',
-                    'end'])
+    inspect_source(cop, <<-END.strip_indent)
+      test do |x,
+        y|
+      end
+    END
     expect(cop.messages)
       .to eq(['Block argument expression is not on the same line as the ' \
               'block start.'])
   end
 
   it 'auto-corrects a do/end block with params that is missing newlines' do
-    src = ['test do |foo| bar',
-           'end']
+    src = <<-END.strip_indent
+      test do |foo| bar
+      end
+    END
 
     new_source = autocorrect_source(cop, src)
 
     expect(new_source).to eq(['test do |foo| ',
                               '  bar',
-                              'end'].join("\n"))
+                              'end',
+                              ''].join("\n"))
   end
 
   it 'auto-corrects a do/end block with a mult-line body' do
-    src = ['test do |foo| bar',
-           '  test',
-           'end']
+    src = <<-END.strip_indent
+      test do |foo| bar
+        test
+      end
+    END
 
     new_source = autocorrect_source(cop, src)
 
     expect(new_source).to eq(['test do |foo| ',
                               '  bar',
                               '  test',
-                              'end'].join("\n"))
+                              'end',
+                              ''].join("\n"))
   end
 
   it 'auto-corrects a {} block with params that is missing newlines' do
-    src = ['test { |foo| bar',
-           '}']
+    src = <<-END.strip_indent
+      test { |foo| bar
+      }
+    END
 
     new_source = autocorrect_source(cop, src)
 
     expect(new_source).to eq(['test { |foo| ',
                               '  bar',
-                              '}'].join("\n"))
+                              '}',
+                              ''].join("\n"))
   end
 
   it 'autocorrects in more complex case with lambda and assignment, and '\
      'aligns the next line two spaces out from the start of the block' do
-    src = ['x = -> (y) { foo',
-           '  bar',
-           '}']
+    src = <<-END.strip_indent
+      x = -> (y) { foo
+        bar
+      }
+    END
 
     new_source = autocorrect_source(cop, src)
 
     expect(new_source).to eq(['x = -> (y) { ',
                               '      foo',
                               '  bar',
-                              '}'].join("\n"))
+                              '}',
+                              ''].join("\n"))
   end
 
   it 'auto-corrects a line-break before arguments' do
-    new_source = autocorrect_source(cop,
-                                    ['test do',
-                                     '  |x| play_with(x)',
-                                     'end'])
+    new_source = autocorrect_source(cop, <<-END.strip_indent)
+      test do
+        |x| play_with(x)
+      end
+    END
 
-    expect(new_source).to eq(['test do |x|',
-                              '  play_with(x)',
-                              'end'].join("\n"))
+    expect(new_source).to eq(<<-END.strip_indent)
+      test do |x|
+        play_with(x)
+      end
+    END
   end
 
   it 'auto-corrects a line-break before arguments with empty block' do
-    new_source = autocorrect_source(cop,
-                                    ['test do',
-                                     '  |x|',
-                                     'end'])
+    new_source = autocorrect_source(cop, <<-END.strip_indent)
+      test do
+        |x|
+      end
+    END
 
-    expect(new_source).to eq(['test do |x|',
-                              'end'].join("\n"))
+    expect(new_source).to eq(<<-END.strip_indent)
+      test do |x|
+      end
+    END
   end
 
   it 'auto-corrects a line-break within arguments' do
-    new_source = autocorrect_source(cop,
-                                    ['test do |x,',
-                                     '  y| play_with(x, y)',
-                                     'end'])
-    expect(new_source).to eq(['test do |x, y|',
-                              '  play_with(x, y)',
-                              'end'].join("\n"))
+    new_source = autocorrect_source(cop, <<-END.strip_indent)
+      test do |x,
+        y| play_with(x, y)
+      end
+    END
+    expect(new_source).to eq(<<-END.strip_indent)
+      test do |x, y|
+        play_with(x, y)
+      end
+    END
   end
 
   it 'auto-corrects a line break within destructured arguments' do
-    new_source = autocorrect_source(cop,
-                                    ['test do |(x,',
-                                     '  y)| play_with(x, y)',
-                                     'end'])
-    expect(new_source).to eq(['test do |(x, y)|',
-                              '  play_with(x, y)',
-                              'end'].join("\n"))
+    new_source = autocorrect_source(cop, <<-END.strip_indent)
+      test do |(x,
+        y)| play_with(x, y)
+      end
+    END
+    expect(new_source).to eq(<<-END.strip_indent)
+      test do |(x, y)|
+        play_with(x, y)
+      end
+    END
   end
 
   it "doesn't move end keyword in a way which causes infinite loop " \
      'in combination with Style/BlockEndNewLine' do
-    new_source = autocorrect_source(cop, ['def f',
-                                          '  X.map do |(a,',
-                                          '  b)|',
-                                          '  end',
-                                          'end'])
-    expect(new_source).to eq(['def f',
-                              '  X.map do |(a, b)|',
-                              '  end',
-                              'end'].join("\n"))
+    new_source = autocorrect_source(cop, <<-END.strip_indent)
+      def f
+        X.map do |(a,
+        b)|
+        end
+      end
+    END
+    expect(new_source).to eq(<<-END.strip_indent)
+      def f
+        X.map do |(a, b)|
+        end
+      end
+    END
   end
 end

--- a/spec/rubocop/cop/style/multiline_hash_brace_layout_spec.rb
+++ b/spec/rubocop/cop/style/multiline_hash_brace_layout_spec.rb
@@ -5,8 +5,10 @@ describe RuboCop::Cop::Style::MultilineHashBraceLayout, :config do
   let(:cop_config) { { 'EnforcedStyle' => 'symmetrical' } }
 
   it 'ignores implicit hashes' do
-    inspect_source(cop, ['foo(a: 1,',
-                         'b: 2)'])
+    inspect_source(cop, <<-END.strip_indent)
+      foo(a: 1,
+      b: 2)
+    END
 
     expect(cop.offenses).to be_empty
   end

--- a/spec/rubocop/cop/style/multiline_if_then_spec.rb
+++ b/spec/rubocop/cop/style/multiline_if_then_spec.rb
@@ -6,9 +6,11 @@ describe RuboCop::Cop::Style::MultilineIfThen do
   # if
 
   it 'does not get confused by empty elsif branch' do
-    inspect_source(cop, ['if cond',
-                         'elsif cond',
-                         'end'])
+    inspect_source(cop, <<-END.strip_indent)
+      if cond
+      elsif cond
+      end
+    END
     expect(cop.offenses).to be_empty
   end
 
@@ -30,73 +32,85 @@ describe RuboCop::Cop::Style::MultilineIfThen do
   end
 
   it 'registers an offense for then in multiline elsif' do
-    inspect_source(cop, ['if cond1',
-                         '  a',
-                         'elsif cond2 then',
-                         '  b',
-                         'end'])
+    inspect_source(cop, <<-END.strip_indent)
+      if cond1
+        a
+      elsif cond2 then
+        b
+      end
+    END
     expect(cop.offenses.map(&:line)).to eq([3])
     expect(cop.highlights).to eq(['then'])
     expect(cop.messages).to eq(['Do not use `then` for multi-line `elsif`.'])
   end
 
   it 'accepts multiline if without then' do
-    inspect_source(cop, ['if cond',
-                         'end'])
+    inspect_source(cop, <<-END.strip_indent)
+      if cond
+      end
+    END
     expect(cop.offenses).to be_empty
   end
 
   it 'accepts table style if/then/elsif/ends' do
-    inspect_source(cop,
-                   ['if    @io == $stdout then str << "$stdout"',
-                    'elsif @io == $stdin  then str << "$stdin"',
-                    'elsif @io == $stderr then str << "$stderr"',
-                    'else                      str << @io.class.to_s',
-                    'end'])
+    inspect_source(cop, <<-END.strip_indent)
+      if    @io == $stdout then str << "$stdout"
+      elsif @io == $stdin  then str << "$stdin"
+      elsif @io == $stderr then str << "$stderr"
+      else                      str << @io.class.to_s
+      end
+    END
     expect(cop.offenses).to be_empty
   end
 
   it 'does not get confused by a then in a when' do
-    inspect_source(cop,
-                   ['if a',
-                    '  case b',
-                    '  when c then',
-                    '  end',
-                    'end'])
+    inspect_source(cop, <<-END.strip_indent)
+      if a
+        case b
+        when c then
+        end
+      end
+    END
     expect(cop.offenses).to be_empty
   end
 
   it 'does not get confused by a commented-out then' do
-    inspect_source(cop,
-                   ['if a # then',
-                    '  b',
-                    'end',
-                    'if c # then',
-                    'end'])
+    inspect_source(cop, <<-END.strip_indent)
+      if a # then
+        b
+      end
+      if c # then
+      end
+    END
     expect(cop.offenses).to be_empty
   end
 
   it 'does not raise an error for an implicit match if' do
     expect do
-      inspect_source(cop,
-                     ['if //',
-                      'end'])
+      inspect_source(cop, <<-END.strip_indent)
+        if //
+        end
+      END
     end.not_to raise_error
   end
 
   # unless
 
   it 'registers an offense for then in multiline unless' do
-    inspect_source(cop, ['unless cond then',
-                         'end'])
+    inspect_source(cop, <<-END.strip_indent)
+      unless cond then
+      end
+    END
     expect(cop.messages).to eq(
       ['Do not use `then` for multi-line `unless`.']
     )
   end
 
   it 'accepts multiline unless without then' do
-    inspect_source(cop, ['unless cond',
-                         'end'])
+    inspect_source(cop, <<-END.strip_indent)
+      unless cond
+      end
+    END
     expect(cop.offenses).to be_empty
   end
 
@@ -106,27 +120,33 @@ describe RuboCop::Cop::Style::MultilineIfThen do
   end
 
   it 'does not get confused by a nested postfix unless' do
-    inspect_source(cop,
-                   ['if two',
-                    '  puts 1',
-                    'end unless two'])
+    inspect_source(cop, <<-END.strip_indent)
+      if two
+        puts 1
+      end unless two
+    END
     expect(cop.offenses).to be_empty
   end
 
   it 'does not raise an error for an implicit match unless' do
     expect do
-      inspect_source(cop,
-                     ['unless //',
-                      'end'])
+      inspect_source(cop, <<-END.strip_indent)
+        unless //
+        end
+      END
     end.not_to raise_error
   end
 
   it 'auto-corrects the usage of "then" in multiline if' do
-    new_source = autocorrect_source(cop, ['if cond then',
-                                          '  something',
-                                          'end'])
-    expect(new_source).to eq(['if cond',
-                              '  something',
-                              'end'].join("\n"))
+    new_source = autocorrect_source(cop, <<-END.strip_indent)
+      if cond then
+        something
+      end
+    END
+    expect(new_source).to eq(<<-END.strip_indent)
+      if cond
+        something
+      end
+    END
   end
 end

--- a/spec/rubocop/cop/style/multiline_memoization_spec.rb
+++ b/spec/rubocop/cop/style/multiline_memoization_spec.rb
@@ -34,47 +34,52 @@ describe RuboCop::Cop::Style::MultilineMemoization, :config do
       it_behaves_like 'code without offense',
                       'foo ||= bar'
 
-      it_behaves_like 'code without offense',
-                      ['foo ||=',
-                       '  bar'].join("\n")
+      it_behaves_like 'code without offense', <<-END.strip_indent
+        foo ||=
+          bar
+      END
     end
 
     context 'with a multiline memoization' do
       context 'without a `begin` and `end` block' do
         context 'when there is another block on the first line' do
-          it_behaves_like 'code without offense',
-                          ['foo ||= bar.each do |b|',
-                           '  b.baz',
-                           '  bb.ax',
-                           'end'].join("\n")
+          it_behaves_like 'code without offense', <<-END.strip_indent
+            foo ||= bar.each do |b|
+              b.baz
+              bb.ax
+            end
+          END
         end
 
         context 'when there is another block on the following line' do
-          it_behaves_like 'code without offense',
-                          ['foo ||=',
-                           '  bar.each do |b|',
-                           '    b.baz',
-                           '    b.bax',
-                           '  end'].join("\n")
+          it_behaves_like 'code without offense', <<-END.strip_indent
+            foo ||=
+              bar.each do |b|
+                b.baz
+                b.bax
+              end
+          END
         end
 
         context 'when there is a conditional on the first line' do
-          it_behaves_like 'code without offense',
-                          ['foo ||= if bar',
-                           '          baz',
-                           '        else',
-                           '          bax',
-                           '        end'].join("\n")
+          it_behaves_like 'code without offense', <<-END.strip_indent
+            foo ||= if bar
+                      baz
+                    else
+                      bax
+                    end
+          END
         end
 
         context 'when there is a conditional on the following line' do
-          it_behaves_like 'code without offense',
-                          ['foo ||=',
-                           '  if bar',
-                           '    baz',
-                           '  else',
-                           '    bax',
-                           '  end'].join("\n")
+          it_behaves_like 'code without offense', <<-END.strip_indent
+            foo ||=
+              if bar
+                baz
+              else
+                bax
+              end
+          END
         end
       end
     end
@@ -88,44 +93,54 @@ describe RuboCop::Cop::Style::MultilineMemoization, :config do
       context 'without a `begin` and `end` block' do
         context 'when the expression is wrapped in parentheses' do
           it_behaves_like 'code with offense',
-                          ['foo ||= (',
-                           '  bar',
-                           '  baz',
-                           ')'].join("\n"),
-                          ['foo ||= begin',
-                           '  bar',
-                           '  baz',
-                           'end'].join("\n")
+                          <<-END.strip_indent,
+                            foo ||= (
+                              bar
+                              baz
+                            )
+                          END
+                          <<-END.strip_indent
+                            foo ||= begin
+                              bar
+                              baz
+                            end
+                          END
 
           it_behaves_like 'code with offense',
-                          ['foo ||=',
-                           '  (',
-                           '    bar',
-                           '    baz',
-                           '  )'].join("\n"),
-                          ['foo ||=',
-                           '  begin',
-                           '    bar',
-                           '    baz',
-                           '  end'].join("\n")
+                          <<-END.strip_indent,
+                            foo ||=
+                              (
+                                bar
+                                baz
+                              )
+                          END
+                          <<-END.strip_indent
+                            foo ||=
+                              begin
+                                bar
+                                baz
+                              end
+                          END
         end
       end
 
       context 'with a `begin` and `end` block on the first line' do
-        it_behaves_like 'code without offense',
-                        ['foo ||= begin',
-                         '  bar',
-                         '  baz',
-                         'end'].join("\n")
+        it_behaves_like 'code without offense', <<-END.strip_indent
+          foo ||= begin
+            bar
+            baz
+          end
+        END
       end
 
       context 'with a `begin` and `end` block on the following line' do
-        it_behaves_like 'code without offense',
-                        ['foo ||=',
-                         '  begin',
-                         '  bar',
-                         '  baz',
-                         'end'].join("\n")
+        it_behaves_like 'code without offense', <<-END.strip_indent
+          foo ||=
+            begin
+            bar
+            baz
+          end
+        END
       end
     end
   end
@@ -139,44 +154,54 @@ describe RuboCop::Cop::Style::MultilineMemoization, :config do
         context 'when the expression is wrapped in' \
                 ' `begin` and `end` keywords' do
           it_behaves_like 'code with offense',
-                          ['foo ||= begin',
-                           '  bar',
-                           '  baz',
-                           'end'].join("\n"),
-                          ['foo ||= (',
-                           '  bar',
-                           '  baz',
-                           ')'].join("\n")
+                          <<-END.strip_indent,
+                            foo ||= begin
+                              bar
+                              baz
+                            end
+                          END
+                          <<-END.strip_indent
+                            foo ||= (
+                              bar
+                              baz
+                            )
+                          END
 
           it_behaves_like 'code with offense',
-                          ['foo ||=',
-                           '  begin',
-                           '    bar',
-                           '    baz',
-                           '  end'].join("\n"),
-                          ['foo ||=',
-                           '  (',
-                           '    bar',
-                           '    baz',
-                           '  )'].join("\n")
+                          <<-END.strip_indent,
+                            foo ||=
+                              begin
+                                bar
+                                baz
+                              end
+                          END
+                          <<-END.strip_indent
+                            foo ||=
+                              (
+                                bar
+                                baz
+                              )
+                          END
         end
       end
 
       context 'with parentheses on the first line' do
-        it_behaves_like 'code without offense',
-                        ['foo ||= (',
-                         '  bar',
-                         '  baz',
-                         ')'].join("\n")
+        it_behaves_like 'code without offense', <<-END.strip_indent
+          foo ||= (
+            bar
+            baz
+          )
+        END
       end
 
       context 'with parentheses block on the following line' do
-        it_behaves_like 'code without offense',
-                        ['foo ||=',
-                         '  (',
-                         '  bar',
-                         '  baz',
-                         ')'].join("\n")
+        it_behaves_like 'code without offense', <<-END.strip_indent
+          foo ||=
+            (
+            bar
+            baz
+          )
+        END
       end
     end
   end

--- a/spec/rubocop/cop/style/multiline_method_call_brace_layout_spec.rb
+++ b/spec/rubocop/cop/style/multiline_method_call_brace_layout_spec.rb
@@ -5,8 +5,10 @@ describe RuboCop::Cop::Style::MultilineMethodCallBraceLayout, :config do
   let(:cop_config) { { 'EnforcedStyle' => 'symmetrical' } }
 
   it 'ignores implicit calls' do
-    inspect_source(cop, ['foo 1,',
-                         '2'])
+    inspect_source(cop, <<-END.strip_indent)
+      foo 1,
+      2
+    END
 
     expect(cop.offenses).to be_empty
   end
@@ -30,8 +32,10 @@ describe RuboCop::Cop::Style::MultilineMethodCallBraceLayout, :config do
   end
 
   it 'ignores calls with a multiline empty brace ' do
-    inspect_source(cop, ['puts(',
-                         ')'])
+    inspect_source(cop, <<-END.strip_indent)
+      puts(
+      )
+    END
 
     expect(cop.offenses).to be_empty
   end
@@ -55,15 +59,19 @@ describe RuboCop::Cop::Style::MultilineMethodCallBraceLayout, :config do
     end
 
     it 'ignores single-line calls with multi-line receiver' do
-      inspect_source(cop, ['[',
-                           '].join(" ")'])
+      inspect_source(cop, <<-END.strip_indent)
+        [
+        ].join(" ")
+      END
       expect(cop.offenses).to be_empty
     end
 
     it 'ignores single-line calls with multi-line receiver with leading dot' do
-      inspect_source(cop, ['[',
-                           ']',
-                           '.join(" ")'])
+      inspect_source(cop, <<-END.strip_indent)
+        [
+        ]
+        .join(" ")
+      END
       expect(cop.offenses).to be_empty
     end
   end

--- a/spec/rubocop/cop/style/multiline_method_call_indentation_spec.rb
+++ b/spec/rubocop/cop/style/multiline_method_call_indentation_spec.rb
@@ -16,103 +16,115 @@ describe RuboCop::Cop::Style::MultilineMethodCallIndentation do
 
   shared_examples 'common' do
     it 'accepts indented methods in LHS of []= assignment' do
-      inspect_source(cop,
-                     ['a',
-                      '  .b[c] = 0'])
+      inspect_source(cop, <<-END.strip_indent)
+        a
+          .b[c] = 0
+      END
       expect(cop.offenses).to be_empty
     end
 
     it 'accepts indented methods inside and outside a block' do
-      inspect_source(cop,
-                     ['a = b.map do |c|',
-                      '  c',
-                      '    .b',
-                      '    .d do',
-                      '      x',
-                      '        .y',
-                      '    end',
-                      'end'])
+      inspect_source(cop, <<-END.strip_indent)
+        a = b.map do |c|
+          c
+            .b
+            .d do
+              x
+                .y
+            end
+        end
+      END
       expect(cop.messages).to be_empty
     end
 
     it 'accepts indentation relative to first receiver' do
-      inspect_source(cop,
-                     ['node',
-                      '  .children.map { |n| string_source(n) }.compact',
-                      '  .any? { |s| preferred.any? { |d| s.include?(d) } }'])
+      inspect_source(cop, <<-END.strip_indent)
+        node
+          .children.map { |n| string_source(n) }.compact
+          .any? { |s| preferred.any? { |d| s.include?(d) } }
+      END
       expect(cop.offenses).to be_empty
     end
 
     it 'accepts indented methods in ordinary statement' do
-      inspect_source(cop,
-                     ['a.',
-                      '  b'])
+      inspect_source(cop, <<-END.strip_indent)
+        a.
+          b
+      END
       expect(cop.messages).to be_empty
     end
 
     it 'accepts no extra indentation of third line' do
-      inspect_source(cop,
-                     ['   a.',
-                      '     b.',
-                      '     c'])
+      inspect_source(cop, <<-END.strip_margin('|'))
+        |   a.
+        |     b.
+        |     c
+      END
       expect(cop.offenses).to be_empty
     end
 
     it 'accepts indented methods in for body' do
-      inspect_source(cop,
-                     ['for x in a',
-                      '  something.',
-                      '    something_else',
-                      'end'])
+      inspect_source(cop, <<-END.strip_indent)
+        for x in a
+          something.
+            something_else
+        end
+      END
       expect(cop.highlights).to be_empty
     end
 
     it 'accepts alignment inside a grouped expression' do
-      inspect_source(cop,
-                     ['(a.',
-                      ' b)'])
+      inspect_source(cop, <<-END.strip_indent)
+        (a.
+         b)
+      END
       expect(cop.messages).to be_empty
     end
 
     it 'accepts an expression where the first method spans multiple lines' do
-      inspect_source(cop,
-                     ['subject.each do |item|',
-                      '  result = resolve(locale) and return result',
-                      'end.a'])
+      inspect_source(cop, <<-END.strip_indent)
+        subject.each do |item|
+          result = resolve(locale) and return result
+        end.a
+      END
       expect(cop.messages).to be_empty
     end
 
     it 'accepts any indentation of parameters to #[]' do
-      inspect_source(cop,
-                     ['payment = Models::IncomingPayments[',
-                      "        id:      input['incoming-payment-id'],",
-                      '           user_id: @user[:id]]'])
+      inspect_source(cop, <<-END.strip_indent)
+        payment = Models::IncomingPayments[
+                id:      input['incoming-payment-id'],
+                   user_id: @user[:id]]
+      END
       expect(cop.messages).to be_empty
     end
 
     it "doesn't fail on unary operators" do
-      inspect_source(cop,
-                     ['def foo',
-                      '  !0',
-                      '  .nil?',
-                      'end'])
+      inspect_source(cop, <<-END.strip_indent)
+        def foo
+          !0
+          .nil?
+        end
+      END
       expect(cop.offenses.size).to eq(1)
     end
   end
 
   shared_examples 'common for aligned and indented' do
     it 'accepts even indentation of consecutive lines in typical RSpec code' do
-      inspect_source(cop,
-                     ['expect { Foo.new }.',
-                      '  to change { Bar.count }.',
-                      '  from(1).to(2)'])
+      inspect_source(cop, <<-END.strip_indent)
+        expect { Foo.new }.
+          to change { Bar.count }.
+          from(1).to(2)
+      END
       expect(cop.messages).to be_empty
     end
 
     it 'registers an offense for no indentation of second line' do
-      inspect_source(cop,
-                     ['a.',
-                      'b'])
+      inspect_source(cop, <<-END.strip_indent)
+        a.
+        b
+      END
       expect(cop.messages)
         .to eq(['Use 2 (not 0) spaces for indenting an expression spanning ' \
                 'multiple lines.'])
@@ -120,11 +132,12 @@ describe RuboCop::Cop::Style::MultilineMethodCallIndentation do
     end
 
     it 'registers an offense for 3 spaces indentation of second line' do
-      inspect_source(cop,
-                     ['a.',
-                      '   b',
-                      'c.',
-                      '   d'])
+      inspect_source(cop, <<-END.strip_indent)
+        a.
+           b
+        c.
+           d
+      END
       expect(cop.messages)
         .to eq(['Use 2 (not 3) spaces for indenting an expression spanning ' \
                 'multiple lines.'] * 2)
@@ -132,10 +145,11 @@ describe RuboCop::Cop::Style::MultilineMethodCallIndentation do
     end
 
     it 'registers an offense for extra indentation of third line' do
-      inspect_source(cop,
-                     ['   a.',
-                      '     b.',
-                      '       c'])
+      inspect_source(cop, <<-END.strip_margin('|'))
+        |   a.
+        |     b.
+        |       c
+      END
       expect(cop.messages)
         .to eq(['Use 2 (not 4) spaces for indenting an expression spanning ' \
                 'multiple lines.'])
@@ -144,11 +158,12 @@ describe RuboCop::Cop::Style::MultilineMethodCallIndentation do
 
     it 'registers an offense for the emacs ruby-mode 1.1 indentation of an ' \
        'expression in an array' do
-      inspect_source(cop,
-                     ['  [',
-                      '   a.',
-                      '   b',
-                      '  ]'])
+      inspect_source(cop, <<-END.strip_margin('|'))
+        |  [
+        |   a.
+        |   b
+        |  ]
+      END
       expect(cop.messages)
         .to eq(['Use 2 (not 0) spaces for indenting an expression spanning ' \
                 'multiple lines.'])
@@ -157,28 +172,31 @@ describe RuboCop::Cop::Style::MultilineMethodCallIndentation do
 
     it 'registers an offense for extra indentation of 3rd line in typical ' \
        'RSpec code' do
-      inspect_source(cop,
-                     ['expect { Foo.new }.',
-                      '  to change { Bar.count }.',
-                      '      from(1).to(2)'])
+      inspect_source(cop, <<-END.strip_indent)
+        expect { Foo.new }.
+          to change { Bar.count }.
+              from(1).to(2)
+      END
       expect(cop.messages).to eq(['Use 2 (not 6) spaces for indenting an ' \
                                   'expression spanning multiple lines.'])
       expect(cop.highlights).to eq(['from'])
     end
 
     it 'registers an offense for proc call without a selector' do
-      inspect_source(cop,
-                     ['a',
-                      ' .(args)'])
+      inspect_source(cop, <<-END.strip_indent)
+        a
+         .(args)
+      END
       expect(cop.messages).to eq(['Use 2 (not 1) spaces for indenting an ' \
                                   'expression spanning multiple lines.'])
       expect(cop.highlights).to eq(['.('])
     end
 
     it 'registers an offense for one space indentation of second line' do
-      inspect_source(cop,
-                     ['a',
-                      ' .b'])
+      inspect_source(cop, <<-END.strip_indent)
+        a
+         .b
+      END
       expect(cop.messages).to eq(['Use 2 (not 1) spaces for indenting an ' \
                                   'expression spanning multiple lines.'])
       expect(cop.highlights).to eq(['.b'])
@@ -195,30 +213,36 @@ describe RuboCop::Cop::Style::MultilineMethodCallIndentation do
     # a chain of calls, and that first dot does not begin its line.
     context 'for semantic alignment' do
       it 'accepts method being aligned with method' do
-        inspect_source(cop,
-                       ['User.all.first',
-                        '    .age.to_s'])
+        inspect_source(cop, <<-END.strip_indent)
+          User.all.first
+              .age.to_s
+        END
         expect(cop.offenses).to be_empty
       end
 
       it 'accepts method being aligned with method in assignment' do
-        inspect_source(cop,
-                       ['age = User.all.first',
-                        '          .age.to_s'])
+        inspect_source(cop, <<-END.strip_indent)
+          age = User.all.first
+                    .age.to_s
+        END
         expect(cop.offenses).to be_empty
       end
 
       it 'accepts aligned method even when an aref is in the chain' do
-        inspect_source(cop, ["foo = '123'.a",
-                             '           .b[1]',
-                             '           .c'])
+        inspect_source(cop, <<-END.strip_indent)
+          foo = '123'.a
+                     .b[1]
+                     .c
+        END
         expect(cop.offenses).to be_empty
       end
 
       it 'accepts aligned method even when an aref is first in the chain' do
-        inspect_source(cop, ["foo = '123'[1].a",
-                             '              .b',
-                             '              .c'])
+        inspect_source(cop, <<-END.strip_indent)
+          foo = '123'[1].a
+                        .b
+                        .c
+        END
         expect(cop.offenses).to be_empty
       end
 
@@ -228,95 +252,110 @@ describe RuboCop::Cop::Style::MultilineMethodCallIndentation do
       end
 
       it 'accepts aligned method with blocks in operation assignment' do
-        inspect_source(cop,
-                       ['@comment_lines ||=',
-                        '  src.comments',
-                        '     .select { |c| begins_its_line?(c) }',
-                        '     .map { |c| c.loc.line }'])
+        inspect_source(cop, <<-END.strip_indent)
+          @comment_lines ||=
+            src.comments
+               .select { |c| begins_its_line?(c) }
+               .map { |c| c.loc.line }
+        END
         expect(cop.offenses).to be_empty
       end
 
       it 'accepts 3 aligned methods' do
-        inspect_source(cop,
-                       ["a_class.new(severity, location, 'message', 'CopName')",
-                        '       .severity',
-                        '       .level'])
+        inspect_source(cop, <<-END.strip_indent)
+          a_class.new(severity, location, 'message', 'CopName')
+                 .severity
+                 .level
+        END
         expect(cop.offenses).to be_empty
       end
 
       it 'registers an offense for unaligned methods' do
-        inspect_source(cop,
-                       ['User.a',
-                        '  .b',
-                        ' .c'])
+        inspect_source(cop, <<-END.strip_indent)
+          User.a
+            .b
+           .c
+        END
         expect(cop.messages).to eq(['Align `.b` with `.a` on line 1.',
                                     'Align `.c` with `.a` on line 1.'])
         expect(cop.highlights).to eq(['.b', '.c'])
       end
 
       it 'registers an offense for unaligned method in block body' do
-        inspect_source(cop,
-                       ['a do',
-                        '  b.c',
-                        '    .d',
-                        'end'])
+        inspect_source(cop, <<-END.strip_indent)
+          a do
+            b.c
+              .d
+          end
+        END
         expect(cop.messages).to eq(['Align `.d` with `.c` on line 2.'])
         expect(cop.highlights).to eq(['.d'])
       end
 
       it 'auto-corrects' do
-        new_source = autocorrect_source(cop, ['User.all.first',
-                                              '  .age.to_s'])
-        expect(new_source).to eq(['User.all.first',
-                                  '    .age.to_s'].join("\n"))
+        new_source = autocorrect_source(cop, <<-END.strip_indent)
+          User.all.first
+            .age.to_s
+        END
+        expect(new_source).to eq(<<-END.strip_indent)
+          User.all.first
+              .age.to_s
+        END
       end
     end
 
     it 'accepts correctly aligned methods in operands' do
-      inspect_source(cop, ['1 + a',
-                           '    .b',
-                           '    .c + d.',
-                           '         e'])
+      inspect_source(cop, <<-END.strip_indent)
+        1 + a
+            .b
+            .c + d.
+                 e
+      END
       expect(cop.offenses).to be_empty
     end
 
     it 'accepts correctly aligned methods in assignment' do
-      inspect_source(cop, ['def investigate(processed_source)',
-                           '  @modifier = processed_source',
-                           '              .tokens',
-                           '              .select { |t| t.type == :k }',
-                           '              .map(&:pos)',
-                           'end'])
+      inspect_source(cop, <<-END.strip_indent)
+        def investigate(processed_source)
+          @modifier = processed_source
+                      .tokens
+                      .select { |t| t.type == :k }
+                      .map(&:pos)
+        end
+      END
       expect(cop.offenses).to be_empty
     end
 
     it 'accepts aligned methods in if + assignment' do
-      inspect_source(cop,
-                     ['KeyMap = Hash.new do |map, key|',
-                      '  value = if key.respond_to?(:to_str)',
-                      '    key',
-                      '  else',
-                      "    key.to_s.split('_').",
-                      '      each { |w| w.capitalize! }.',
-                      "      join('-')",
-                      '  end',
-                      '  keymap_mutex.synchronize { map[key] = value }',
-                      'end'])
+      inspect_source(cop, <<-END.strip_indent)
+        KeyMap = Hash.new do |map, key|
+          value = if key.respond_to?(:to_str)
+            key
+          else
+            key.to_s.split('_').
+              each { |w| w.capitalize! }.
+              join('-')
+          end
+          keymap_mutex.synchronize { map[key] = value }
+        end
+      END
       expect(cop.offenses).to be_empty
     end
 
     it 'accepts indented method when there is nothing to align with' do
-      inspect_source(cop,
-                     ["expect { custom_formatter_class('NonExistentClass') }",
-                      '  .to raise_error(NameError)'])
+      inspect_source(cop, <<-END.strip_indent)
+        expect { custom_formatter_class('NonExistentClass') }
+          .to raise_error(NameError)
+      END
       expect(cop.offenses).to be_empty
     end
 
     it 'registers an offense for one space indentation of third line' do
-      inspect_source(cop,
-                     ['a',
-                      '  .b',
-                      ' .c'])
+      inspect_source(cop, <<-END.strip_indent)
+        a
+          .b
+         .c
+      END
       expect(cop.messages)
         .to eq(['Use 2 (not 1) spaces for indenting an expression spanning ' \
                 'multiple lines.'])
@@ -324,50 +363,54 @@ describe RuboCop::Cop::Style::MultilineMethodCallIndentation do
     end
 
     it 'accepts indented and aligned methods in binary operation' do
-      inspect_source(cop,
-                     ['a.',
-                      '  b + c',   # b is indented relative to a
-                      '      .d']) # .d is aligned with c
+      # b is indented relative to a
+      # .d is aligned with c
+      inspect_source(cop, <<-END.strip_indent)
+        a.
+          b + c
+              .d
+      END
       expect(cop.offenses).to be_empty
     end
 
     it 'accepts aligned methods in if condition' do
-      inspect_source(cop,
-                     ['if a.',
-                      '   b',
-                      '  something',
-                      'end'])
+      inspect_source(cop, <<-END.strip_indent)
+        if a.
+           b
+          something
+        end
+      END
       expect(cop.messages).to be_empty
     end
 
     it 'accepts aligned methods in a begin..end block' do
-      inspect_source(cop,
-                     ['@dependencies ||= begin',
-                      '  DEFAULT_DEPENDENCIES',
-                      '    .reject { |e| e }',
-                      '    .map { |e| e }',
-                      'end'])
+      inspect_source(cop, <<-END.strip_indent)
+        @dependencies ||= begin
+          DEFAULT_DEPENDENCIES
+            .reject { |e| e }
+            .map { |e| e }
+        end
+      END
       expect(cop.messages).to be_empty
     end
 
     it 'registers an offense for misaligned methods in if condition' do
-      inspect_source(cop,
-                     ['if a.',
-                      '    b',
-                      '  something',
-                      'end'])
+      inspect_source(cop, <<-END.strip_indent)
+        if a.
+            b
+          something
+        end
+      END
       expect(cop.messages).to eq(['Align `b` with `a.` on line 1.'])
       expect(cop.highlights).to eq(['b'])
       expect(cop.config_to_allow_offenses).to eq('Enabled' => false)
     end
 
     it 'falls back to indentation in complicated cases' do
-      inspect_source(cop,
-                     # There are two method call chains here. The last one is
-                     # an argument to the first, and they both start on the
-                     # same line.
-                     ['expect(RuboCop::ConfigLoader).to receive(:file).once',
-                      "    .with('dir')"])
+      inspect_source(cop, <<-END.strip_indent)
+        expect(RuboCop::ConfigLoader).to receive(:file).once
+            .with('dir')
+      END
       expect(cop.messages)
         .to eq(['Use 2 (not 4) spaces for indenting an expression spanning ' \
                 'multiple lines.'])
@@ -383,120 +426,139 @@ describe RuboCop::Cop::Style::MultilineMethodCallIndentation do
     end
 
     it 'does not check binary operations when string wrapped with +' do
-      inspect_source(cop,
-                     ["flash[:error] = 'Here is a string ' +",
-                      "                'That spans' <<",
-                      "  'multiple lines'"])
+      inspect_source(cop, <<-END.strip_indent)
+        flash[:error] = 'Here is a string ' +
+                        'That spans' <<
+          'multiple lines'
+      END
       expect(cop.offenses).to be_empty
     end
 
     it 'registers an offense for misaligned method in []= call' do
-      inspect_source(cop,
-                     ['flash[:error] = here_is_a_string.',
-                      '                that_spans.',
-                      '   multiple_lines'])
+      inspect_source(cop, <<-END.strip_indent)
+        flash[:error] = here_is_a_string.
+                        that_spans.
+           multiple_lines
+      END
       expect(cop.messages)
         .to eq(['Align `multiple_lines` with `here_is_a_string.` on line 1.'])
       expect(cop.highlights).to eq(['multiple_lines'])
     end
 
     it 'registers an offense for misaligned methods in unless condition' do
-      inspect_source(cop,
-                     ['unless a',
-                      '.b',
-                      '  something',
-                      'end'])
+      inspect_source(cop, <<-END.strip_indent)
+        unless a
+        .b
+          something
+        end
+      END
       expect(cop.messages).to eq(['Align `.b` with `a` on line 1.'])
       expect(cop.highlights).to eq(['.b'])
       expect(cop.config_to_allow_offenses).to eq('Enabled' => false)
     end
 
     it 'registers an offense for misaligned methods in while condition' do
-      inspect_source(cop,
-                     ['while a.',
-                      '    b',
-                      '  something',
-                      'end'])
+      inspect_source(cop, <<-END.strip_indent)
+        while a.
+            b
+          something
+        end
+      END
       expect(cop.messages).to eq(['Align `b` with `a.` on line 1.'])
       expect(cop.highlights).to eq(['b'])
     end
 
     it 'registers an offense for misaligned methods in until condition' do
-      inspect_source(cop,
-                     ['until a.',
-                      '    b',
-                      '  something',
-                      'end'])
+      inspect_source(cop, <<-END.strip_indent)
+        until a.
+            b
+          something
+        end
+      END
       expect(cop.messages).to eq(['Align `b` with `a.` on line 1.'])
       expect(cop.highlights).to eq(['b'])
     end
 
     it 'accepts aligned method in return' do
-      inspect_source(cop,
-                     ['def a',
-                      '  return b.',
-                      '         c',
-                      'end'])
+      inspect_source(cop, <<-END.strip_indent)
+        def a
+          return b.
+                 c
+        end
+      END
       expect(cop.offenses).to be_empty
     end
 
     it 'accepts aligned method in assignment + block + assignment' do
-      inspect_source(cop,
-                     ['a = b do',
-                      '  c.d = e.',
-                      '        f',
-                      'end'])
+      inspect_source(cop, <<-END.strip_indent)
+        a = b do
+          c.d = e.
+                f
+        end
+      END
       expect(cop.offenses).to be_empty
     end
 
     it 'accepts aligned methods in assignment' do
-      inspect_source(cop,
-                     ['formatted_int = int_part',
-                      '                .to_s',
-                      '                .reverse',
-                      "                .gsub(/...(?=.)/, '\&_')"])
+      inspect_source(cop, <<-END.strip_indent)
+        formatted_int = int_part
+                        .to_s
+                        .reverse
+                        .gsub(/...(?=.)/, '\&_')
+      END
       expect(cop.messages).to be_empty
     end
 
     it 'registers an offense for misaligned methods in local variable ' \
        'assignment' do
-      inspect_source(cop, ['a = b.c.',
-                           ' d'])
+      inspect_source(cop, <<-END.strip_indent)
+        a = b.c.
+         d
+      END
       expect(cop.messages).to eq(['Align `d` with `b.c.` on line 1.'])
       expect(cop.highlights).to eq(['d'])
     end
 
     it 'accepts aligned methods in constant assignment' do
-      inspect_source(cop, ['A = b',
-                           '    .c'])
+      inspect_source(cop, <<-END.strip_indent)
+        A = b
+            .c
+      END
       expect(cop.offenses).to be_empty
     end
 
     it 'accepts aligned methods in operator assignment' do
-      inspect_source(cop, ['a +=',
-                           '  b',
-                           '  .c'])
+      inspect_source(cop, <<-END.strip_indent)
+        a +=
+          b
+          .c
+      END
       expect(cop.offenses).to be_empty
     end
 
     it 'registers an offense for unaligned methods in assignment' do
-      inspect_source(cop,
-                     ['bar = Foo',
-                      '  .a',
-                      '      .b(c)'])
+      inspect_source(cop, <<-END.strip_indent)
+        bar = Foo
+          .a
+              .b(c)
+      END
       expect(cop.messages).to eq(['Align `.a` with `Foo` on line 1.'])
       expect(cop.highlights).to eq(['.a'])
     end
 
     it 'auto-corrects' do
-      new_source = autocorrect_source(cop, ['until a.',
-                                            '    b',
-                                            '  something',
-                                            'end'])
-      expect(new_source).to eq(['until a.',
-                                '      b',
-                                '  something',
-                                'end'].join("\n"))
+      new_source = autocorrect_source(cop, <<-END.strip_indent)
+        until a.
+            b
+          something
+        end
+      END
+      expect(new_source).to eq(<<-END.strip_indent)
+        until a.
+              b
+          something
+        end
+      END
     end
   end
 
@@ -506,10 +568,11 @@ describe RuboCop::Cop::Style::MultilineMethodCallIndentation do
     # indented style, it doesn't come into play.
     context 'for possible semantic alignment' do
       it 'accepts indented methods' do
-        inspect_source(cop,
-                       ['User.a',
-                        '  .c',
-                        '  .b'])
+        inspect_source(cop, <<-END.strip_indent)
+          User.a
+            .c
+            .b
+        END
         expect(cop.messages).to be_empty
         expect(cop.highlights).to be_empty
         expect(cop.offenses).to be_empty
@@ -524,30 +587,35 @@ describe RuboCop::Cop::Style::MultilineMethodCallIndentation do
     include_examples 'both indented* styles'
 
     it 'accepts correctly indented methods in operation' do
-      inspect_source(cop, ['        1 + a',
-                           '              .b',
-                           '              .c'])
+      inspect_source(cop, <<-END.strip_margin('|'))
+        |        1 + a
+        |              .b
+        |              .c
+      END
       expect(cop.highlights).to be_empty
       expect(cop.offenses).to be_empty
     end
 
     it 'accepts indentation of consecutive lines in typical RSpec code' do
-      inspect_source(cop,
-                     ['expect { Foo.new }.',
-                      '  to change { Bar.count }.',
-                      '       from(1).to(2)'])
+      inspect_source(cop, <<-END.strip_indent)
+        expect { Foo.new }.
+          to change { Bar.count }.
+               from(1).to(2)
+      END
       expect(cop.messages).to be_empty
 
-      inspect_source(cop,
-                     ['expect { Foo.new }.to change { Bar.count }',
-                      '                        .from(1).to(2)'])
+      inspect_source(cop, <<-END.strip_indent)
+        expect { Foo.new }.to change { Bar.count }
+                                .from(1).to(2)
+      END
       expect(cop.messages).to be_empty
     end
 
     it 'registers an offense for no indentation of second line' do
-      inspect_source(cop,
-                     ['a.',
-                      'b'])
+      inspect_source(cop, <<-END.strip_indent)
+        a.
+        b
+      END
       expect(cop.messages)
         .to eq(['Indent `b` 2 spaces more than `a` on line 1.'])
       expect(cop.highlights).to eq(['b'])
@@ -555,39 +623,43 @@ describe RuboCop::Cop::Style::MultilineMethodCallIndentation do
 
     it 'registers an offense for extra indentation of 3rd line in typical ' \
        'RSpec code' do
-      inspect_source(cop,
-                     ['expect { Foo.new }.',
-                      '  to change { Bar.count }.',
-                      '      from(1).to(2)'])
+      inspect_source(cop, <<-END.strip_indent)
+        expect { Foo.new }.
+          to change { Bar.count }.
+              from(1).to(2)
+      END
       expect(cop.messages).to eq(['Indent `from` 2 spaces more than `change ' \
                                   '{ Bar.count }` on line 2.'])
       expect(cop.highlights).to eq(['from'])
     end
 
     it 'registers an offense for proc call without a selector' do
-      inspect_source(cop,
-                     ['a',
-                      ' .(args)'])
+      inspect_source(cop, <<-END.strip_indent)
+        a
+         .(args)
+      END
       expect(cop.messages).to eq(['Indent `.(` 2 spaces more than `a` on ' \
                                   'line 1.'])
       expect(cop.highlights).to eq(['.('])
     end
 
     it 'registers an offense for one space indentation of second line' do
-      inspect_source(cop,
-                     ['a',
-                      ' .b'])
+      inspect_source(cop, <<-END.strip_indent)
+        a
+         .b
+      END
       expect(cop.messages).to eq(['Indent `.b` 2 spaces more than `a` on ' \
                                   'line 1.'])
       expect(cop.highlights).to eq(['.b'])
     end
 
     it 'registers an offense for 3 spaces indentation of second line' do
-      inspect_source(cop,
-                     ['a.',
-                      '   b',
-                      'c.',
-                      '   d'])
+      inspect_source(cop, <<-END.strip_indent)
+        a.
+           b
+        c.
+           d
+      END
       expect(cop.messages)
         .to eq(['Indent `b` 2 spaces more than `a` on line 1.',
                 'Indent `d` 2 spaces more than `c` on line 3.'])
@@ -595,10 +667,11 @@ describe RuboCop::Cop::Style::MultilineMethodCallIndentation do
     end
 
     it 'registers an offense for extra indentation of third line' do
-      inspect_source(cop,
-                     ['   a.',
-                      '     b.',
-                      '       c'])
+      inspect_source(cop, <<-END.strip_margin('|'))
+        |   a.
+        |     b.
+        |       c
+      END
       expect(cop.messages)
         .to eq(['Indent `c` 2 spaces more than `a` on line 1.'])
       expect(cop.highlights).to eq(['c'])
@@ -606,25 +679,30 @@ describe RuboCop::Cop::Style::MultilineMethodCallIndentation do
 
     it 'registers an offense for the emacs ruby-mode 1.1 indentation of an ' \
        'expression in an array' do
-      inspect_source(cop,
-                     ['  [',
-                      '   a.',
-                      '   b',
-                      '  ]'])
+      inspect_source(cop, <<-END.strip_margin('|'))
+        |  [
+        |   a.
+        |   b
+        |  ]
+      END
       expect(cop.messages)
         .to eq(['Indent `b` 2 spaces more than `a` on line 2.'])
       expect(cop.highlights).to eq(['b'])
     end
 
     it 'auto-corrects' do
-      new_source = autocorrect_source(cop, ['until a.',
-                                            '      b',
-                                            '  something',
-                                            'end'])
-      expect(new_source).to eq(['until a.',
-                                '        b',
-                                '  something',
-                                'end'].join("\n"))
+      new_source = autocorrect_source(cop, <<-END.strip_indent)
+        until a.
+              b
+          something
+        end
+      END
+      expect(new_source).to eq(<<-END.strip_indent)
+        until a.
+                b
+          something
+        end
+      END
     end
   end
 
@@ -636,38 +714,43 @@ describe RuboCop::Cop::Style::MultilineMethodCallIndentation do
     include_examples 'both indented* styles'
 
     it 'accepts correctly indented methods in operation' do
-      inspect_source(cop, ['        1 + a',
-                           '          .b',
-                           '          .c'])
+      inspect_source(cop, <<-END.strip_margin('|'))
+        |        1 + a
+        |          .b
+        |          .c
+      END
       expect(cop.offenses).to be_empty
       expect(cop.highlights).to be_empty
     end
 
     it 'registers an offense for one space indentation of third line' do
-      inspect_source(cop,
-                     ['a',
-                      '  .b',
-                      ' .c'])
+      inspect_source(cop, <<-END.strip_indent)
+        a
+          .b
+         .c
+      END
       expect(cop.messages).to eq(['Use 2 (not 1) spaces for indenting an ' \
                                   'expression spanning multiple lines.'])
       expect(cop.highlights).to eq(['.c'])
     end
 
     it 'accepts indented methods in if condition' do
-      inspect_source(cop,
-                     ['if a.',
-                      '    b',
-                      '  something',
-                      'end'])
+      inspect_source(cop, <<-END.strip_indent)
+        if a.
+            b
+          something
+        end
+      END
       expect(cop.messages).to be_empty
     end
 
     it 'registers an offense for aligned methods in if condition' do
-      inspect_source(cop,
-                     ['if a.',
-                      '   b',
-                      '  something',
-                      'end'])
+      inspect_source(cop, <<-END.strip_indent)
+        if a.
+           b
+          something
+        end
+      END
       expect(cop.messages).to eq(['Use 4 (not 3) spaces for indenting a ' \
                                   'condition in an `if` statement spanning ' \
                                   'multiple lines.'])
@@ -676,27 +759,30 @@ describe RuboCop::Cop::Style::MultilineMethodCallIndentation do
     end
 
     it 'accepts normal indentation of method parameters' do
-      inspect_source(cop,
-                     ['Parser::Source::Range.new(expr.source_buffer,',
-                      '                          begin_pos,',
-                      '                          begin_pos + line.length)'])
+      inspect_source(cop, <<-END.strip_indent)
+        Parser::Source::Range.new(expr.source_buffer,
+                                  begin_pos,
+                                  begin_pos + line.length)
+      END
       expect(cop.messages).to be_empty
     end
 
     it 'accepts any indentation of method parameters' do
-      inspect_source(cop,
-                     ['a(b.',
-                      '    c',
-                      '.d)'])
+      inspect_source(cop, <<-END.strip_indent)
+        a(b.
+            c
+        .d)
+      END
       expect(cop.messages).to be_empty
     end
 
     it 'accepts normal indentation inside grouped expression' do
-      inspect_source(cop,
-                     ['arg_array.size == a.size && (',
-                      '  arg_array == a ||',
-                      '  arg_array.map(&:children) == a.map(&:children)',
-                      ')'])
+      inspect_source(cop, <<-END.strip_indent)
+        arg_array.size == a.size && (
+          arg_array == a ||
+          arg_array.map(&:children) == a.map(&:children)
+        )
+      END
       expect(cop.messages).to be_empty
     end
 
@@ -707,21 +793,23 @@ describe RuboCop::Cop::Style::MultilineMethodCallIndentation do
       %w[an until]
     ].each do |article, keyword|
       it "accepts double indentation of #{keyword} condition" do
-        inspect_source(cop,
-                       ["#{keyword} receiver.",
-                        '    nil? &&',
-                        '    !args.empty?',
-                        'end'])
+        inspect_source(cop, <<-END.strip_indent)
+          #{keyword} receiver.
+              nil? &&
+              !args.empty?
+          end
+        END
         expect(cop.messages).to be_empty
       end
 
       it "registers an offense for a 2 space indentation of #{keyword} " \
          'condition' do
-        inspect_source(cop,
-                       ["#{keyword} receiver",
-                        '  .nil? &&',
-                        '  !args.empty?',
-                        'end'])
+        inspect_source(cop, <<-END.strip_indent)
+          #{keyword} receiver
+            .nil? &&
+            !args.empty?
+          end
+        END
         expect(cop.highlights).to eq(['.nil?'])
         expect(cop.messages).to eq(['Use 4 (not 2) spaces for indenting a ' \
                                     "condition in #{article} `#{keyword}` " \
@@ -729,30 +817,33 @@ describe RuboCop::Cop::Style::MultilineMethodCallIndentation do
       end
 
       it "accepts indented methods in #{keyword} body" do
-        inspect_source(cop,
-                       ["#{keyword} a",
-                        '  something.',
-                        '    something_else',
-                        'end'])
+        inspect_source(cop, <<-END.strip_indent)
+          #{keyword} a
+            something.
+              something_else
+          end
+        END
         expect(cop.highlights).to be_empty
       end
     end
 
     %w[unless if].each do |keyword|
       it "accepts special indentation of return #{keyword} condition" do
-        inspect_source(cop,
-                       ["return #{keyword} receiver.nil? &&",
-                        '    !args.empty? &&',
-                        '    BLACKLIST.include?(method_name)'])
+        inspect_source(cop, <<-END.strip_indent)
+          return #{keyword} receiver.nil? &&
+              !args.empty? &&
+              BLACKLIST.include?(method_name)
+        END
         expect(cop.messages).to be_empty
       end
     end
 
     it 'registers an offense for wrong indentation of for expression' do
-      inspect_source(cop,
-                     ['for n in a.',
-                      '  b',
-                      'end'])
+      inspect_source(cop, <<-END.strip_indent)
+        for n in a.
+          b
+        end
+      END
       expect(cop.messages).to eq(['Use 4 (not 2) spaces for indenting a ' \
                                   'collection in a `for` statement spanning ' \
                                   'multiple lines.'])
@@ -760,30 +851,33 @@ describe RuboCop::Cop::Style::MultilineMethodCallIndentation do
     end
 
     it 'accepts special indentation of for expression' do
-      inspect_source(cop,
-                     ['for n in a.',
-                      '    b',
-                      'end'])
+      inspect_source(cop, <<-END.strip_indent)
+        for n in a.
+            b
+        end
+      END
       expect(cop.messages).to be_empty
     end
 
     it 'accepts indentation of assignment' do
-      inspect_source(cop,
-                     ['formatted_int = int_part',
-                      '  .abs',
-                      '  .to_s',
-                      '  .reverse',
-                      "  .gsub(/...(?=.)/, '\&_')",
-                      '  .reverse'])
+      inspect_source(cop, <<-END.strip_indent)
+        formatted_int = int_part
+          .abs
+          .to_s
+          .reverse
+          .gsub(/...(?=.)/, '\&_')
+          .reverse
+      END
       expect(cop.messages).to be_empty
     end
 
     it 'registers an offense for correct + unrecognized style' do
-      inspect_source(cop,
-                     ['a.',
-                      '  b',
-                      'c.',
-                      '    d'])
+      inspect_source(cop, <<-END.strip_indent)
+        a.
+          b
+        c.
+            d
+      END
       expect(cop.messages).to eq(['Use 2 (not 4) spaces for indenting an ' \
                                   'expression spanning multiple lines.'])
       expect(cop.highlights).to eq(%w[d])
@@ -791,60 +885,70 @@ describe RuboCop::Cop::Style::MultilineMethodCallIndentation do
     end
 
     it 'registers an offense for aligned operators in assignment' do
-      inspect_source(cop,
-                     ['formatted_int = int_part',
-                      '                .abs',
-                      '                .reverse'])
+      inspect_source(cop, <<-END.strip_indent)
+        formatted_int = int_part
+                        .abs
+                        .reverse
+      END
       expect(cop.messages).to eq(['Use 2 (not 16) spaces for indenting an ' \
                                   'expression in an assignment spanning ' \
                                   'multiple lines.'] * 2)
     end
 
     it 'auto-corrects' do
-      new_source = autocorrect_source(cop, ['until a.',
-                                            '      b',
-                                            '  something',
-                                            'end'])
-      expect(new_source).to eq(['until a.',
-                                '    b',
-                                '  something',
-                                'end'].join("\n"))
+      new_source = autocorrect_source(cop, <<-END.strip_indent)
+        until a.
+              b
+          something
+        end
+      END
+      expect(new_source).to eq(<<-END.strip_indent)
+        until a.
+            b
+          something
+        end
+      END
     end
 
     context 'when indentation width is overridden for this cop' do
       let(:cop_indent) { 7 }
 
       it 'accepts indented methods' do
-        inspect_source(cop,
-                       ['User.a',
-                        '       .c',
-                        '       .b'])
+        inspect_source(cop, <<-END.strip_indent)
+          User.a
+                 .c
+                 .b
+        END
         expect(cop.offenses).to be_empty
       end
 
       it 'accepts correctly indented methods in operation' do
-        inspect_source(cop, ['        1 + a',
-                             '               .b',
-                             '               .c'])
+        inspect_source(cop, <<-END.strip_margin('|'))
+          |        1 + a
+          |               .b
+          |               .c
+        END
         expect(cop.offenses).to be_empty
         expect(cop.highlights).to be_empty
       end
 
       it 'accepts indented methods in if condition' do
-        inspect_source(cop,
-                       ['if a.',
-                        '         b',
-                        '  something',
-                        'end'])
+        inspect_source(cop, <<-END.strip_indent)
+          if a.
+                   b
+            something
+          end
+        END
         expect(cop.messages).to be_empty
       end
 
       it 'accepts indentation of assignment' do
-        inspect_source(cop,
-                       ['formatted_int = int_part',
-                        '       .abs',
-                        '       .to_s',
-                        '       .reverse'])
+        inspect_source(cop, <<-END.strip_indent)
+          formatted_int = int_part
+                 .abs
+                 .to_s
+                 .reverse
+        END
         expect(cop.messages).to be_empty
       end
 
@@ -859,21 +963,23 @@ describe RuboCop::Cop::Style::MultilineMethodCallIndentation do
           # normal code indentation is 2 spaces, and we have configured
           # multiline method indentation to 7 spaces
           # so in this case, 9 spaces are required
-          inspect_source(cop,
-                         ["#{keyword} receiver.",
-                          '         nil? &&',
-                          '         !args.empty?',
-                          'end'])
+          inspect_source(cop, <<-END.strip_indent)
+            #{keyword} receiver.
+                     nil? &&
+                     !args.empty?
+            end
+          END
           expect(cop.messages).to be_empty
         end
 
         it "registers an offense for a 4 space indentation of #{keyword} " \
            'condition' do
-          inspect_source(cop,
-                         ["#{keyword} receiver",
-                          '    .nil? &&',
-                          '    !args.empty?',
-                          'end'])
+          inspect_source(cop, <<-END.strip_indent)
+            #{keyword} receiver
+                .nil? &&
+                !args.empty?
+            end
+          END
           expect(cop.highlights).to eq(['.nil?'])
           expect(cop.messages).to eq(['Use 9 (not 4) spaces for indenting a ' \
                                       "condition in #{article} `#{keyword}` " \
@@ -881,11 +987,12 @@ describe RuboCop::Cop::Style::MultilineMethodCallIndentation do
         end
 
         it "accepts indented methods in #{keyword} body" do
-          inspect_source(cop,
-                         ["#{keyword} a",
-                          '  something.',
-                          '         something_else',
-                          'end'])
+          inspect_source(cop, <<-END.strip_indent)
+            #{keyword} a
+              something.
+                     something_else
+            end
+          END
           expect(cop.highlights).to be_empty
         end
       end

--- a/spec/rubocop/cop/style/multiline_method_definition_brace_layout_spec.rb
+++ b/spec/rubocop/cop/style/multiline_method_definition_brace_layout_spec.rb
@@ -5,23 +5,29 @@ describe RuboCop::Cop::Style::MultilineMethodDefinitionBraceLayout, :config do
   let(:cop_config) { { 'EnforcedStyle' => 'symmetrical' } }
 
   it 'ignores implicit defs' do
-    inspect_source(cop, ['def foo a: 1,',
-                         'b: 2',
-                         'end'])
+    inspect_source(cop, <<-END.strip_indent)
+      def foo a: 1,
+      b: 2
+      end
+    END
 
     expect(cop.offenses).to be_empty
   end
 
   it 'ignores single-line defs' do
-    inspect_source(cop, ['def foo(a,b)',
-                         'end'])
+    inspect_source(cop, <<-END.strip_indent)
+      def foo(a,b)
+      end
+    END
 
     expect(cop.offenses).to be_empty
   end
 
   it 'ignores defs without params' do
-    inspect_source(cop, ['def foo',
-                         'end'])
+    inspect_source(cop, <<-END.strip_indent)
+      def foo
+      end
+    END
 
     expect(cop.offenses).to be_empty
   end

--- a/spec/rubocop/cop/style/multiline_operation_indentation_spec.rb
+++ b/spec/rubocop/cop/style/multiline_operation_indentation_spec.rb
@@ -16,78 +16,85 @@ describe RuboCop::Cop::Style::MultilineOperationIndentation do
 
   shared_examples 'common' do
     it 'accepts indented operands in ordinary statement' do
-      inspect_source(cop,
-                     ['a +',
-                      '  b'])
+      inspect_source(cop, <<-END.strip_indent)
+        a +
+          b
+      END
       expect(cop.messages).to be_empty
     end
 
     it 'accepts indented operands inside and outside a block' do
-      inspect_source(cop,
-                     ['a = b.map do |c|',
-                      '  c +',
-                      '    b +',
-                      '    d do',
-                      '      x +',
-                      '        y',
-                      '    end',
-                      'end'])
+      inspect_source(cop, <<-END.strip_indent)
+        a = b.map do |c|
+          c +
+            b +
+            d do
+              x +
+                y
+            end
+        end
+      END
       expect(cop.messages).to be_empty
     end
 
     it 'registers an offense for no indentation of second line' do
-      inspect_source(cop,
-                     ['a +',
-                      'b'])
+      inspect_source(cop, <<-END.strip_indent)
+        a +
+        b
+      END
       expect(cop.messages).to eq(['Use 2 (not 0) spaces for indenting an ' \
                                   'expression spanning multiple lines.'])
       expect(cop.highlights).to eq(['b'])
     end
 
     it 'registers an offense for one space indentation of second line' do
-      inspect_source(cop,
-                     ['a +',
-                      ' b'])
+      inspect_source(cop, <<-END.strip_indent)
+        a +
+         b
+      END
       expect(cop.messages).to eq(['Use 2 (not 1) spaces for indenting an ' \
                                   'expression spanning multiple lines.'])
       expect(cop.highlights).to eq(['b'])
     end
 
     it 'does not check method calls' do
-      inspect_source(cop,
-                     ['a',
-                      ' .(args)',
-                      '',
-                      'Foo',
-                      '.a',
-                      '  .b',
-                      '',
-                      'Foo',
-                      '.a',
-                      '  .b(c)',
-                      '',
-                      'expect { Foo.new }.',
-                      '  to change { Bar.count }.',
-                      '      from(1).to(2)'])
+      inspect_source(cop, <<-END.strip_indent)
+        a
+         .(args)
+
+        Foo
+        .a
+          .b
+
+        Foo
+        .a
+          .b(c)
+
+        expect { Foo.new }.
+          to change { Bar.count }.
+              from(1).to(2)
+      END
       expect(cop.offenses).to be_empty
     end
 
     it 'registers an offense for three spaces indentation of second line' do
-      inspect_source(cop,
-                     ['a ||',
-                      '   b',
-                      'c and',
-                      '   d'])
+      inspect_source(cop, <<-END.strip_indent)
+        a ||
+           b
+        c and
+           d
+      END
       expect(cop.messages).to eq(['Use 2 (not 3) spaces for indenting an ' \
                                   'expression spanning multiple lines.'] * 2)
       expect(cop.highlights).to eq(%w[b d])
     end
 
     it 'registers an offense for extra indentation of third line' do
-      inspect_source(cop,
-                     ['   a ||',
-                      '     b ||',
-                      '       c'])
+      inspect_source(cop, <<-END.strip_margin('|'))
+        |   a ||
+        |     b ||
+        |       c
+      END
       expect(cop.messages).to eq(['Use 2 (not 4) spaces for indenting an ' \
                                   'expression spanning multiple lines.'])
       expect(cop.highlights).to eq(['c'])
@@ -95,93 +102,106 @@ describe RuboCop::Cop::Style::MultilineOperationIndentation do
 
     it 'registers an offense for the emacs ruby-mode 1.1 indentation of an ' \
        'expression in an array' do
-      inspect_source(cop,
-                     ['  [',
-                      '   a +',
-                      '   b',
-                      '  ]'])
+      inspect_source(cop, <<-END.strip_margin('|'))
+        |  [
+        |   a +
+        |   b
+        |  ]
+      END
       expect(cop.messages).to eq(['Use 2 (not 0) spaces for indenting an ' \
                                   'expression spanning multiple lines.'])
       expect(cop.highlights).to eq(['b'])
     end
 
     it 'accepts indented operands in an array' do
-      inspect_source(cop, ['    dm[i][j] = [',
-                           '      dm[i-1][j-1] +',
-                           '        (this[j-1] == that[i-1] ? 0 : sub),',
-                           '      dm[i][j-1] + ins,',
-                           '      dm[i-1][j] + del',
-                           '    ].min'])
+      inspect_source(cop, <<-END.strip_margin('|'))
+        |    dm[i][j] = [
+        |      dm[i-1][j-1] +
+        |        (this[j-1] == that[i-1] ? 0 : sub),
+        |      dm[i][j-1] + ins,
+        |      dm[i-1][j] + del
+        |    ].min
+      END
       expect(cop.offenses).to be_empty
     end
 
     it 'accepts two spaces indentation in assignment of local variable' do
-      inspect_source(cop,
-                     ['a =',
-                      "  'foo' +",
-                      "  'bar'"])
+      inspect_source(cop, <<-END.strip_indent)
+        a =
+          'foo' +
+          'bar'
+      END
       expect(cop.messages).to be_empty
     end
 
     it 'accepts two spaces indentation in assignment of array element' do
-      inspect_source(cop,
-                     ["a['test'] =",
-                      "  'foo' +",
-                      "  'bar'"])
+      inspect_source(cop, <<-END.strip_indent)
+        a['test'] =
+          'foo' +
+          'bar'
+      END
       expect(cop.messages).to be_empty
     end
 
     it 'accepts two spaces indentation of second line' do
-      inspect_source(cop,
-                     ['   a ||',
-                      '     b'])
+      inspect_source(cop, <<-END.strip_margin('|'))
+        |   a ||
+        |     b
+      END
       expect(cop.messages).to be_empty
     end
 
     it 'accepts no extra indentation of third line' do
-      inspect_source(cop,
-                     ['   a &&',
-                      '     b &&',
-                      '     c'])
+      inspect_source(cop, <<-END.strip_margin('|'))
+        |   a &&
+        |     b &&
+        |     c
+      END
       expect(cop.messages).to be_empty
     end
 
     it 'accepts indented operands in for body' do
-      inspect_source(cop,
-                     ['for x in a',
-                      '  something &&',
-                      '    something_else',
-                      'end'])
+      inspect_source(cop, <<-END.strip_indent)
+        for x in a
+          something &&
+            something_else
+        end
+      END
       expect(cop.highlights).to be_empty
     end
 
     it 'accepts alignment inside a grouped expression' do
-      inspect_source(cop,
-                     ['(a +',
-                      ' b)'])
+      inspect_source(cop, <<-END.strip_indent)
+        (a +
+         b)
+      END
       expect(cop.messages).to be_empty
     end
 
     it 'accepts an expression where the first operand spans multiple lines' do
-      inspect_source(cop,
-                     ['subject.each do |item|',
-                      '  result = resolve(locale) and return result',
-                      'end and nil'])
+      inspect_source(cop, <<-END.strip_indent)
+        subject.each do |item|
+          result = resolve(locale) and return result
+        end and nil
+      END
       expect(cop.messages).to be_empty
     end
 
     it 'accepts any indentation of parameters to #[]' do
-      inspect_source(cop,
-                     ['payment = Models::IncomingPayments[',
-                      "        id:      input['incoming-payment-id'],",
-                      '           user_id: @user[:id]]'])
+      inspect_source(cop, <<-END.strip_indent)
+        payment = Models::IncomingPayments[
+                id:      input['incoming-payment-id'],
+                   user_id: @user[:id]]
+      END
       expect(cop.messages).to be_empty
     end
 
     it 'registers an offense for an unindented multiline operation that is ' \
        'the left operand in another operation' do
-      inspect_source(cop, ['a +',
-                           'b < 3'])
+      inspect_source(cop, <<-END.strip_indent)
+        a +
+        b < 3
+      END
       expect(cop.messages).to eq(['Use 2 (not 0) spaces for indenting an ' \
                                   'expression spanning multiple lines.'])
       expect(cop.highlights).to eq(['b'])
@@ -194,20 +214,22 @@ describe RuboCop::Cop::Style::MultilineOperationIndentation do
     include_examples 'common'
 
     it 'accepts aligned operands in if condition' do
-      inspect_source(cop,
-                     ['if a +',
-                      '   b',
-                      '  something',
-                      'end'])
+      inspect_source(cop, <<-END.strip_indent)
+        if a +
+           b
+          something
+        end
+      END
       expect(cop.messages).to be_empty
     end
 
     it 'registers an offense for indented operands in if condition' do
-      inspect_source(cop,
-                     ['if a +',
-                      '    b',
-                      '  something',
-                      'end'])
+      inspect_source(cop, <<-END.strip_indent)
+        if a +
+            b
+          something
+        end
+      END
       expect(cop.messages).to eq(['Align the operands of a condition in an ' \
                                   '`if` statement spanning multiple lines.'])
       expect(cop.highlights).to eq(['b'])
@@ -223,24 +245,27 @@ describe RuboCop::Cop::Style::MultilineOperationIndentation do
     end
 
     it 'accepts indented operands inside block + assignment' do
-      inspect_source(cop, ['a = b.map do |c|',
-                           '  c +',
-                           '    d',
-                           'end',
-                           '',
-                           'requires_interpolation = node.children.any? do |s|',
-                           '  s.type == :dstr ||',
-                           '    s.loc.expression.source =~ REGEXP',
-                           'end'])
+      inspect_source(cop, <<-END.strip_indent)
+        a = b.map do |c|
+          c +
+            d
+        end
+
+        requires_interpolation = node.children.any? do |s|
+          s.type == :dstr ||
+            s.loc.expression.source =~ REGEXP
+        end
+      END
       expect(cop.offenses).to be_empty
     end
 
     it 'registers an offense for indented second part of string' do
-      inspect_source(cop,
-                     ['it "should convert " +',
-                      '  "a to " +',
-                      '  "b" do',
-                      'end'])
+      inspect_source(cop, <<-END.strip_indent)
+        it "should convert " +
+          "a to " +
+          "b" do
+        end
+      END
       expect(cop.messages).to eq(['Align the operands of an expression ' \
                                   'spanning multiple lines.'] * 2)
       expect(cop.highlights).to eq(['"a to "', '"b"'])
@@ -248,9 +273,10 @@ describe RuboCop::Cop::Style::MultilineOperationIndentation do
     end
 
     it 'registers an offense for indented operand in second argument' do
-      inspect_source(cop,
-                     ['puts a, 1 +',
-                      '  2'])
+      inspect_source(cop, <<-END.strip_indent)
+        puts a, 1 +
+          2
+      END
       expect(cop.messages)
         .to eq(['Align the operands of an expression spanning multiple lines.'])
       expect(cop.highlights).to eq(['2'])
@@ -271,21 +297,23 @@ describe RuboCop::Cop::Style::MultilineOperationIndentation do
     end
 
     it 'registers an offense for misaligned string operand when plus is used' do
-      inspect_source(cop,
-                     ["Error = 'Here is a string ' +",
-                      "        'That spans' <<",
-                      "  'multiple lines'"])
+      inspect_source(cop, <<-END.strip_indent)
+        Error = 'Here is a string ' +
+                'That spans' <<
+          'multiple lines'
+      END
       expect(cop.messages).to eq(['Align the operands of an expression in an ' \
                                   'assignment spanning multiple lines.'])
       expect(cop.highlights).to eq(["'multiple lines'"])
     end
 
     it 'registers an offense for misaligned operands in unless condition' do
-      inspect_source(cop,
-                     ['unless a +',
-                      '  b',
-                      '  something',
-                      'end'])
+      inspect_source(cop, <<-END.strip_indent)
+        unless a +
+          b
+          something
+        end
+      END
       expect(cop.messages).to eq(['Align the operands of a condition in an ' \
                                   '`unless` statement spanning multiple ' \
                                   'lines.'])
@@ -301,11 +329,12 @@ describe RuboCop::Cop::Style::MultilineOperationIndentation do
     ].each do |article, keyword|
       it "registers an offense for misaligned operands in #{keyword} " \
          'condition' do
-        inspect_source(cop,
-                       ["#{keyword} a or",
-                        '    b',
-                        '  something',
-                        'end'])
+        inspect_source(cop, <<-END.strip_indent)
+          #{keyword} a or
+              b
+            something
+          end
+        END
         expect(cop.messages).to eq(['Align the operands of a condition in ' \
                                     "#{article} `#{keyword}` statement " \
                                     'spanning multiple lines.'])
@@ -316,39 +345,46 @@ describe RuboCop::Cop::Style::MultilineOperationIndentation do
     end
 
     it 'accepts aligned operands in assignment' do
-      inspect_source(cop,
-                     ['a = b +',
-                      '    c +',
-                      '    d'])
+      inspect_source(cop, <<-END.strip_indent)
+        a = b +
+            c +
+            d
+      END
       expect(cop.offenses).to be_empty
     end
 
     it 'accepts aligned or:ed operands in assignment' do
-      inspect_source(cop,
-                     ["tmp_dir = ENV['TMPDIR'] || ENV['TMP'] || ENV['TEMP'] ||",
-                      "          Etc.systmpdir || '/tmp'"])
+      inspect_source(cop, <<-END.strip_indent)
+        tmp_dir = ENV['TMPDIR'] || ENV['TMP'] || ENV['TEMP'] ||
+                  Etc.systmpdir || '/tmp'
+      END
       expect(cop.messages).to be_empty
     end
 
     it 'registers an offense for unaligned operands in op-assignment' do
-      inspect_source(cop,
-                     ['bar *= Foo +',
-                      '  a +',
-                      '       b(c)'])
+      inspect_source(cop, <<-END.strip_indent)
+        bar *= Foo +
+          a +
+               b(c)
+      END
       expect(cop.messages).to eq(['Align the operands of an expression in an ' \
                                   'assignment spanning multiple lines.'])
       expect(cop.highlights).to eq(['a'])
     end
 
     it 'auto-corrects' do
-      new_source = autocorrect_source(cop, ['until a +',
-                                            '    b',
-                                            '  something',
-                                            'end'])
-      expect(new_source).to eq(['until a +',
-                                '      b',
-                                '  something',
-                                'end'].join("\n"))
+      new_source = autocorrect_source(cop, <<-END.strip_indent)
+        until a +
+            b
+          something
+        end
+      END
+      expect(new_source).to eq(<<-END.strip_indent)
+        until a +
+              b
+          something
+        end
+      END
     end
   end
 
@@ -358,20 +394,22 @@ describe RuboCop::Cop::Style::MultilineOperationIndentation do
     include_examples 'common'
 
     it 'accepts indented operands in if condition' do
-      inspect_source(cop,
-                     ['if a +',
-                      '    b',
-                      '  something',
-                      'end'])
+      inspect_source(cop, <<-END.strip_indent)
+        if a +
+            b
+          something
+        end
+      END
       expect(cop.messages).to be_empty
     end
 
     it 'registers an offense for aligned operands in if condition' do
-      inspect_source(cop,
-                     ['if a +',
-                      '   b',
-                      '  something',
-                      'end'])
+      inspect_source(cop, <<-END.strip_indent)
+        if a +
+           b
+          something
+        end
+      END
       expect(cop.messages).to eq(['Use 4 (not 3) spaces for indenting a ' \
                                   'condition in an `if` statement spanning ' \
                                   'multiple lines.'])
@@ -387,27 +425,30 @@ describe RuboCop::Cop::Style::MultilineOperationIndentation do
     end
 
     it 'accepts normal indentation of method parameters' do
-      inspect_source(cop,
-                     ['Parser::Source::Range.new(expr.source_buffer,',
-                      '                          begin_pos,',
-                      '                          begin_pos + line.length)'])
+      inspect_source(cop, <<-END.strip_indent)
+        Parser::Source::Range.new(expr.source_buffer,
+                                  begin_pos,
+                                  begin_pos + line.length)
+      END
       expect(cop.messages).to be_empty
     end
 
     it 'accepts any indentation of method parameters' do
-      inspect_source(cop,
-                     ['a(b +',
-                      '    c +',
-                      'd)'])
+      inspect_source(cop, <<-END.strip_indent)
+        a(b +
+            c +
+        d)
+      END
       expect(cop.messages).to be_empty
     end
 
     it 'accepts normal indentation inside grouped expression' do
-      inspect_source(cop,
-                     ['arg_array.size == a.size && (',
-                      '  arg_array == a ||',
-                      '  arg_array.map(&:children) == a.map(&:children)',
-                      ')'])
+      inspect_source(cop, <<-END.strip_indent)
+        arg_array.size == a.size && (
+          arg_array == a ||
+          arg_array.map(&:children) == a.map(&:children)
+        )
+      END
       expect(cop.offenses).to be_empty
     end
 
@@ -427,24 +468,26 @@ describe RuboCop::Cop::Style::MultilineOperationIndentation do
       %w[an until]
     ].each do |article, keyword|
       it "accepts double indentation of #{keyword} condition" do
-        inspect_source(cop,
-                       ["#{keyword} receiver.nil? &&",
-                        '    !args.empty? &&',
-                        '    BLACKLIST.include?(method_name)',
-                        'end',
-                        "#{keyword} receiver.",
-                        '    nil?',
-                        'end'])
+        inspect_source(cop, <<-END.strip_indent)
+          #{keyword} receiver.nil? &&
+              !args.empty? &&
+              BLACKLIST.include?(method_name)
+          end
+          #{keyword} receiver.
+              nil?
+          end
+        END
         expect(cop.messages).to be_empty
       end
 
       it "registers an offense for a 2 space indentation of #{keyword} " \
          'condition' do
-        inspect_source(cop,
-                       ["#{keyword} receiver.nil? &&",
-                        '  !args.empty? &&',
-                        '  BLACKLIST.include?(method_name)',
-                        'end'])
+        inspect_source(cop, <<-END.strip_indent)
+          #{keyword} receiver.nil? &&
+            !args.empty? &&
+            BLACKLIST.include?(method_name)
+          end
+        END
         expect(cop.highlights).to eq(['!args.empty?',
                                       'BLACKLIST.include?(method_name)'])
         expect(cop.messages).to eq(['Use 4 (not 2) spaces for indenting a ' \
@@ -453,30 +496,33 @@ describe RuboCop::Cop::Style::MultilineOperationIndentation do
       end
 
       it "accepts indented operands in #{keyword} body" do
-        inspect_source(cop,
-                       ["#{keyword} a",
-                        '  something &&',
-                        '    something_else',
-                        'end'])
+        inspect_source(cop, <<-END.strip_indent)
+          #{keyword} a
+            something &&
+              something_else
+          end
+        END
         expect(cop.highlights).to be_empty
       end
     end
 
     %w[unless if].each do |keyword|
       it "accepts special indentation of return #{keyword} condition" do
-        inspect_source(cop,
-                       ["return #{keyword} receiver.nil? &&",
-                        '    !args.empty? &&',
-                        '    BLACKLIST.include?(method_name)'])
+        inspect_source(cop, <<-END.strip_indent)
+          return #{keyword} receiver.nil? &&
+              !args.empty? &&
+              BLACKLIST.include?(method_name)
+        END
         expect(cop.messages).to be_empty
       end
     end
 
     it 'registers an offense for wrong indentation of for expression' do
-      inspect_source(cop,
-                     ['for n in a +',
-                      '  b',
-                      'end'])
+      inspect_source(cop, <<-END.strip_indent)
+        for n in a +
+          b
+        end
+      END
       expect(cop.messages).to eq(['Use 4 (not 2) spaces for indenting a ' \
                                   'collection in a `for` statement spanning ' \
                                   'multiple lines.'])
@@ -484,27 +530,30 @@ describe RuboCop::Cop::Style::MultilineOperationIndentation do
     end
 
     it 'accepts special indentation of for expression' do
-      inspect_source(cop,
-                     ['for n in a +',
-                      '    b',
-                      'end'])
+      inspect_source(cop, <<-END.strip_indent)
+        for n in a +
+            b
+        end
+      END
       expect(cop.messages).to be_empty
     end
 
     it 'accepts indentation of assignment' do
-      inspect_source(cop,
-                     ['a = b +',
-                      '  c +',
-                      '  d'])
+      inspect_source(cop, <<-END.strip_indent)
+        a = b +
+          c +
+          d
+      END
       expect(cop.messages).to be_empty
     end
 
     it 'registers an offense for correct + unrecognized style' do
-      inspect_source(cop,
-                     ['a ||',
-                      '  b',
-                      'c and',
-                      '    d'])
+      inspect_source(cop, <<-END.strip_indent)
+        a ||
+          b
+        c and
+            d
+      END
       expect(cop.messages).to eq(['Use 2 (not 4) spaces for indenting an ' \
                                   'expression spanning multiple lines.'])
       expect(cop.highlights).to eq(%w[d])
@@ -512,35 +561,41 @@ describe RuboCop::Cop::Style::MultilineOperationIndentation do
     end
 
     it 'registers an offense for aligned operators in assignment' do
-      inspect_source(cop,
-                     ['a = b +',
-                      '    c +',
-                      '    d'])
+      inspect_source(cop, <<-END.strip_indent)
+        a = b +
+            c +
+            d
+      END
       expect(cop.messages).to eq(['Use 2 (not 4) spaces for indenting an ' \
                                   'expression in an assignment spanning ' \
                                   'multiple lines.'] * 2)
     end
 
     it 'auto-corrects' do
-      new_source = autocorrect_source(cop, ['until a +',
-                                            '      b',
-                                            '  something',
-                                            'end'])
-      expect(new_source).to eq(['until a +',
-                                '    b',
-                                '  something',
-                                'end'].join("\n"))
+      new_source = autocorrect_source(cop, <<-END.strip_indent)
+        until a +
+              b
+          something
+        end
+      END
+      expect(new_source).to eq(<<-END.strip_indent)
+        until a +
+            b
+          something
+        end
+      END
     end
 
     context 'when indentation width is overridden for this cop' do
       let(:cop_indent) { 6 }
 
       it 'accepts indented operands in if condition' do
-        inspect_source(cop,
-                       ['if a +',
-                        '        b',
-                        '  something',
-                        'end'])
+        inspect_source(cop, <<-END.strip_indent)
+          if a +
+                  b
+            something
+          end
+        END
         expect(cop.messages).to be_empty
       end
 
@@ -555,24 +610,26 @@ describe RuboCop::Cop::Style::MultilineOperationIndentation do
           # normal code indentation is 2 spaces, and we have configured
           # multiline method indentation to 6 spaces
           # so in this case, 8 spaces are required
-          inspect_source(cop,
-                         ["#{keyword} receiver.nil? &&",
-                          '        !args.empty? &&',
-                          '        BLACKLIST.include?(method_name)',
-                          'end',
-                          "#{keyword} receiver.",
-                          '        nil?',
-                          'end'])
+          inspect_source(cop, <<-END.strip_indent)
+            #{keyword} receiver.nil? &&
+                    !args.empty? &&
+                    BLACKLIST.include?(method_name)
+            end
+            #{keyword} receiver.
+                    nil?
+            end
+          END
           expect(cop.messages).to be_empty
         end
 
         it "registers an offense for a 4 space indentation of #{keyword} " \
            'condition' do
-          inspect_source(cop,
-                         ["#{keyword} receiver.nil? &&",
-                          '    !args.empty? &&',
-                          '    BLACKLIST.include?(method_name)',
-                          'end'])
+          inspect_source(cop, <<-END.strip_indent)
+            #{keyword} receiver.nil? &&
+                !args.empty? &&
+                BLACKLIST.include?(method_name)
+            end
+          END
           expect(cop.highlights).to eq(['!args.empty?',
                                         'BLACKLIST.include?(method_name)'])
           expect(cop.messages).to eq(['Use 8 (not 4) spaces for indenting a ' \
@@ -581,24 +638,29 @@ describe RuboCop::Cop::Style::MultilineOperationIndentation do
         end
 
         it "accepts indented operands in #{keyword} body" do
-          inspect_source(cop,
-                         ["#{keyword} a",
-                          '  something &&',
-                          '        something_else',
-                          'end'])
+          inspect_source(cop, <<-END.strip_indent)
+            #{keyword} a
+              something &&
+                    something_else
+            end
+          END
           expect(cop.highlights).to be_empty
         end
       end
 
       it 'auto-corrects' do
-        new_source = autocorrect_source(cop, ['until a +',
-                                              '      b',
-                                              '  something',
-                                              'end'])
-        expect(new_source).to eq(['until a +',
-                                  '        b',
-                                  '  something',
-                                  'end'].join("\n"))
+        new_source = autocorrect_source(cop, <<-END.strip_indent)
+          until a +
+                b
+            something
+          end
+        END
+        expect(new_source).to eq(<<-END.strip_indent)
+          until a +
+                  b
+            something
+          end
+        END
       end
     end
   end

--- a/spec/rubocop/cop/style/multiline_ternary_operator_spec.rb
+++ b/spec/rubocop/cop/style/multiline_ternary_operator_spec.rb
@@ -5,22 +5,28 @@ describe RuboCop::Cop::Style::MultilineTernaryOperator do
 
   it 'registers offense when the if branch and the else branch are ' \
      'on a separate line from the condition' do
-    inspect_source(cop, ['a = cond ?',
-                         '  b : c'])
+    inspect_source(cop, <<-END.strip_indent)
+      a = cond ?
+        b : c
+    END
     expect(cop.offenses.size).to eq(1)
   end
 
   it 'registers an offense when the false branch is on a separate line' do
-    inspect_source(cop, ['a = cond ? b :',
-                         '    c'].join("\n"))
+    inspect_source(cop, <<-END.strip_indent)
+      a = cond ? b :
+          c
+    END
 
     expect(cop.offenses.size).to eq(1)
   end
 
   it 'registers an offense when everything is on a separate line' do
-    inspect_source(cop, ['a = cond ?',
-                         '    b :',
-                         '    c'])
+    inspect_source(cop, <<-END.strip_indent)
+      a = cond ?
+          b :
+          c
+    END
 
     expect(cop.offenses.size).to eq(1)
   end

--- a/spec/rubocop/cop/style/negated_if_spec.rb
+++ b/spec/rubocop/cop/style/negated_if_spec.rb
@@ -13,11 +13,12 @@ describe RuboCop::Cop::Style::NegatedIf do
 
   describe 'with “both” style' do
     it 'registers an offense for if with exclamation point condition' do
-      inspect_source(cop,
-                     ['if !a_condition',
-                      '  some_method',
-                      'end',
-                      'some_method if !a_condition'])
+      inspect_source(cop, <<-END.strip_indent)
+        if !a_condition
+          some_method
+        end
+        some_method if !a_condition
+      END
       expect(cop.messages).to eq(
         ['Favor `unless` over `if` for negative ' \
          'conditions.'] * 2
@@ -25,21 +26,23 @@ describe RuboCop::Cop::Style::NegatedIf do
     end
 
     it 'registers an offense for unless with exclamation point condition' do
-      inspect_source(cop,
-                     ['unless !a_condition',
-                      '  some_method',
-                      'end',
-                      'some_method unless !a_condition'])
+      inspect_source(cop, <<-END.strip_indent)
+        unless !a_condition
+          some_method
+        end
+        some_method unless !a_condition
+      END
       expect(cop.messages).to eq(['Favor `if` over `unless` for negative ' \
                                   'conditions.'] * 2)
     end
 
     it 'registers an offense for if with "not" condition' do
-      inspect_source(cop,
-                     ['if not a_condition',
-                      '  some_method',
-                      'end',
-                      'some_method if not a_condition'])
+      inspect_source(cop, <<-END.strip_indent)
+        if not a_condition
+          some_method
+        end
+        some_method if not a_condition
+      END
       expect(cop.messages).to eq(
         ['Favor `unless` over `if` for negative ' \
          'conditions.'] * 2
@@ -48,50 +51,54 @@ describe RuboCop::Cop::Style::NegatedIf do
     end
 
     it 'accepts an if/else with negative condition' do
-      inspect_source(cop,
-                     ['if !a_condition',
-                      '  some_method',
-                      'else',
-                      '  something_else',
-                      'end',
-                      'if not a_condition',
-                      '  some_method',
-                      'elsif other_condition',
-                      '  something_else',
-                      'end'])
+      inspect_source(cop, <<-END.strip_indent)
+        if !a_condition
+          some_method
+        else
+          something_else
+        end
+        if not a_condition
+          some_method
+        elsif other_condition
+          something_else
+        end
+      END
       expect(cop.offenses).to be_empty
     end
 
     it 'accepts an if where only part of the condition is negated' do
-      inspect_source(cop,
-                     ['if !condition && another_condition',
-                      '  some_method',
-                      'end',
-                      'if not condition or another_condition',
-                      '  some_method',
-                      'end',
-                      'some_method if not condition or another_condition'])
+      inspect_source(cop, <<-END.strip_indent)
+        if !condition && another_condition
+          some_method
+        end
+        if not condition or another_condition
+          some_method
+        end
+        some_method if not condition or another_condition
+      END
       expect(cop.offenses).to be_empty
     end
 
     it 'accepts an if where the condition is doubly negated' do
-      inspect_source(cop,
-                     ['if !!condition',
-                      '  some_method',
-                      'end',
-                      'some_method if !!condition'])
+      inspect_source(cop, <<-END.strip_indent)
+        if !!condition
+          some_method
+        end
+        some_method if !!condition
+      END
       expect(cop.offenses).to be_empty
     end
 
     it 'is not confused by negated elsif' do
-      inspect_source(cop,
-                     ['if test.is_a?(String)',
-                      '  3',
-                      'elsif test.is_a?(Array)',
-                      '  2',
-                      'elsif !test.nil?',
-                      '  1',
-                      'end'])
+      inspect_source(cop, <<-END.strip_indent)
+        if test.is_a?(String)
+          3
+        elsif test.is_a?(Array)
+          2
+        elsif !test.nil?
+          1
+        end
+      END
 
       expect(cop.offenses).to be_empty
     end
@@ -118,14 +125,15 @@ describe RuboCop::Cop::Style::NegatedIf do
     end
 
     it 'autocorrects for prefix' do
-      corrected = autocorrect_source(cop,
-                                     ['if !foo',
-                                      'end'])
+      corrected = autocorrect_source(cop, <<-END.strip_indent)
+        if !foo
+        end
+      END
 
-      expect(corrected).to eq [
-        'unless foo',
-        'end'
-      ].join("\n")
+      expect(corrected).to eq <<-END.strip_indent
+        unless foo
+        end
+      END
     end
   end
 
@@ -142,9 +150,10 @@ describe RuboCop::Cop::Style::NegatedIf do
     end
 
     it 'registers an offence for prefix' do
-      inspect_source(cop,
-                     ['if !foo',
-                      'end'])
+      inspect_source(cop, <<-END.strip_indent)
+        if !foo
+        end
+      END
 
       expect(cop.messages).to eq(
         ['Favor `unless` over `if` for negative conditions.']
@@ -158,14 +167,15 @@ describe RuboCop::Cop::Style::NegatedIf do
     end
 
     it 'autocorrects for prefix' do
-      corrected = autocorrect_source(cop,
-                                     ['if !foo',
-                                      'end'])
+      corrected = autocorrect_source(cop, <<-END.strip_indent)
+        if !foo
+        end
+      END
 
-      expect(corrected).to eq [
-        'unless foo',
-        'end'
-      ].join("\n")
+      expect(corrected).to eq <<-END.strip_indent
+        unless foo
+        end
+      END
     end
   end
 
@@ -190,9 +200,10 @@ describe RuboCop::Cop::Style::NegatedIf do
     end
 
     it 'does not register an offence for prefix' do
-      inspect_source(cop,
-                     ['if !foo',
-                      'end'])
+      inspect_source(cop, <<-END.strip_indent)
+        if !foo
+        end
+      END
 
       expect(cop.offenses).to be_empty
     end
@@ -215,16 +226,18 @@ describe RuboCop::Cop::Style::NegatedIf do
   end
 
   it 'does not blow up for empty if condition' do
-    inspect_source(cop,
-                   ['if ()',
-                    'end'])
+    inspect_source(cop, <<-END.strip_indent)
+      if ()
+      end
+    END
     expect(cop.offenses).to be_empty
   end
 
   it 'does not blow up for empty unless condition' do
-    inspect_source(cop,
-                   ['unless ()',
-                    'end'])
+    inspect_source(cop, <<-END.strip_indent)
+      unless ()
+      end
+    END
     expect(cop.offenses).to be_empty
   end
 end

--- a/spec/rubocop/cop/style/negated_while_spec.rb
+++ b/spec/rubocop/cop/style/negated_while_spec.rb
@@ -4,32 +4,35 @@ describe RuboCop::Cop::Style::NegatedWhile do
   subject(:cop) { described_class.new }
 
   it 'registers an offense for while with exclamation point condition' do
-    inspect_source(cop,
-                   ['while !a_condition',
-                    '  some_method',
-                    'end',
-                    'some_method while !a_condition'])
+    inspect_source(cop, <<-END.strip_indent)
+      while !a_condition
+        some_method
+      end
+      some_method while !a_condition
+    END
     expect(cop.messages).to eq(
       ['Favor `until` over `while` for negative conditions.'] * 2
     )
   end
 
   it 'registers an offense for until with exclamation point condition' do
-    inspect_source(cop,
-                   ['until !a_condition',
-                    '  some_method',
-                    'end',
-                    'some_method until !a_condition'])
+    inspect_source(cop, <<-END.strip_indent)
+      until !a_condition
+        some_method
+      end
+      some_method until !a_condition
+    END
     expect(cop.messages)
       .to eq(['Favor `while` over `until` for negative conditions.'] * 2)
   end
 
   it 'registers an offense for while with "not" condition' do
-    inspect_source(cop,
-                   ['while (not a_condition)',
-                    '  some_method',
-                    'end',
-                    'some_method while not a_condition'])
+    inspect_source(cop, <<-END.strip_indent)
+      while (not a_condition)
+        some_method
+      end
+      some_method while not a_condition
+    END
     expect(cop.messages).to eq(
       ['Favor `until` over `while` for negative conditions.'] * 2
     )
@@ -37,31 +40,37 @@ describe RuboCop::Cop::Style::NegatedWhile do
   end
 
   it 'accepts a while where only part of the condition is negated' do
-    inspect_source(cop,
-                   ['while !a_condition && another_condition',
-                    '  some_method',
-                    'end',
-                    'while not a_condition or another_condition',
-                    '  some_method',
-                    'end',
-                    'some_method while not a_condition or other_cond'])
+    inspect_source(cop, <<-END.strip_indent)
+      while !a_condition && another_condition
+        some_method
+      end
+      while not a_condition or another_condition
+        some_method
+      end
+      some_method while not a_condition or other_cond
+    END
     expect(cop.messages).to be_empty
   end
 
   it 'accepts a while where the condition is doubly negated' do
-    inspect_source(cop,
-                   ['while !!a_condition',
-                    '  some_method',
-                    'end',
-                    'some_method while !!a_condition'])
+    inspect_source(cop, <<-END.strip_indent)
+      while !!a_condition
+        some_method
+      end
+      some_method while !!a_condition
+    END
     expect(cop.messages).to be_empty
   end
 
   it 'autocorrects by replacing while not with until' do
-    corrected = autocorrect_source(cop, ['something while !x.even?',
-                                         'something while(!x.even?)'])
-    expect(corrected).to eq ['something until x.even?',
-                             'something until(x.even?)'].join("\n")
+    corrected = autocorrect_source(cop, <<-END.strip_indent)
+      something while !x.even?
+      something while(!x.even?)
+    END
+    expect(corrected).to eq <<-END.strip_indent
+      something until x.even?
+      something until(x.even?)
+    END
   end
 
   it 'autocorrects by replacing until not with while' do
@@ -70,16 +79,18 @@ describe RuboCop::Cop::Style::NegatedWhile do
   end
 
   it 'does not blow up for empty while condition' do
-    inspect_source(cop,
-                   ['while ()',
-                    'end'])
+    inspect_source(cop, <<-END.strip_indent)
+      while ()
+      end
+    END
     expect(cop.offenses).to be_empty
   end
 
   it 'does not blow up for empty until condition' do
-    inspect_source(cop,
-                   ['until ()',
-                    'end'])
+    inspect_source(cop, <<-END.strip_indent)
+      until ()
+      end
+    END
     expect(cop.offenses).to be_empty
   end
 end

--- a/spec/rubocop/cop/style/nested_ternary_operator_spec.rb
+++ b/spec/rubocop/cop/style/nested_ternary_operator_spec.rb
@@ -9,11 +9,13 @@ describe RuboCop::Cop::Style::NestedTernaryOperator do
   end
 
   it 'accepts a non-nested ternary operator within an if' do
-    inspect_source(cop, ['a = if x',
-                         '  cond ? b : c',
-                         'else',
-                         '  d',
-                         'end'])
+    inspect_source(cop, <<-END.strip_indent)
+      a = if x
+        cond ? b : c
+      else
+        d
+      end
+    END
     expect(cop.offenses).to be_empty
   end
 end

--- a/spec/rubocop/cop/style/next_spec.rb
+++ b/spec/rubocop/cop/style/next_spec.rb
@@ -8,198 +8,238 @@ describe RuboCop::Cop::Style::Next, :config do
     let(:opposite) { condition == 'if' ? 'unless' : 'if' }
 
     it "registers an offense for #{condition} inside of downto" do
-      inspect_source(cop, ['3.downto(1) do',
-                           "  #{condition} o == 1",
-                           '    puts o',
-                           '  end',
-                           'end'])
+      inspect_source(cop, <<-END.strip_indent)
+        3.downto(1) do
+          #{condition} o == 1
+            puts o
+          end
+        end
+      END
 
       expect(cop.messages).to eq(['Use `next` to skip iteration.'])
       expect(cop.highlights).to eq(["#{condition} o == 1"])
     end
 
     it "autocorrects #{condition} inside of downto" do
-      new_source = autocorrect_source(cop, ['3.downto(1) do',
-                                            "  #{condition} o == 1",
-                                            '    puts o',
-                                            '  end',
-                                            'end'])
-      expect(new_source).to eq(['3.downto(1) do',
-                                "  next #{opposite} o == 1",
-                                '  puts o',
-                                'end'].join("\n"))
+      new_source = autocorrect_source(cop, <<-END.strip_indent)
+        3.downto(1) do
+          #{condition} o == 1
+            puts o
+          end
+        end
+      END
+      expect(new_source).to eq(<<-END.strip_indent)
+        3.downto(1) do
+          next #{opposite} o == 1
+          puts o
+        end
+      END
     end
 
     it "registers an offense for #{condition} inside of each" do
-      inspect_source(cop, ['[].each do |o|',
-                           "  #{condition} o == 1",
-                           '    puts o',
-                           '  end',
-                           'end'])
+      inspect_source(cop, <<-END.strip_indent)
+        [].each do |o|
+          #{condition} o == 1
+            puts o
+          end
+        end
+      END
 
       expect(cop.messages).to eq(['Use `next` to skip iteration.'])
       expect(cop.highlights).to eq(["#{condition} o == 1"])
     end
 
     it "autocorrects #{condition} inside of each" do
-      new_source = autocorrect_source(cop, ['[].each do |o|',
-                                            "  #{condition} o == 1",
-                                            '    puts o',
-                                            '  end',
-                                            'end'])
-      expect(new_source).to eq(['[].each do |o|',
-                                "  next #{opposite} o == 1",
-                                '  puts o',
-                                'end'].join("\n"))
+      new_source = autocorrect_source(cop, <<-END.strip_indent)
+        [].each do |o|
+          #{condition} o == 1
+            puts o
+          end
+        end
+      END
+      expect(new_source).to eq(<<-END.strip_indent)
+        [].each do |o|
+          next #{opposite} o == 1
+          puts o
+        end
+      END
     end
 
     it "registers an offense for #{condition} inside of each_with_object" do
-      inspect_source(cop, ['[].each_with_object({}) do |o, a|',
-                           "  #{condition} o == 1",
-                           '    a[o] = {}',
-                           '  end',
-                           'end'])
+      inspect_source(cop, <<-END.strip_indent)
+        [].each_with_object({}) do |o, a|
+          #{condition} o == 1
+            a[o] = {}
+          end
+        end
+      END
 
       expect(cop.messages).to eq(['Use `next` to skip iteration.'])
       expect(cop.highlights).to eq(["#{condition} o == 1"])
     end
 
     it "registers an offense for #{condition} inside of for" do
-      inspect_source(cop, ['for o in 1..3 do',
-                           "  #{condition} o == 1",
-                           '    puts o',
-                           '  end',
-                           'end'])
+      inspect_source(cop, <<-END.strip_indent)
+        for o in 1..3 do
+          #{condition} o == 1
+            puts o
+          end
+        end
+      END
 
       expect(cop.messages).to eq(['Use `next` to skip iteration.'])
       expect(cop.highlights).to eq(["#{condition} o == 1"])
     end
 
     it "autocorrects #{condition} inside of for" do
-      new_source = autocorrect_source(cop, ['for o in 1..3 do',
-                                            "  #{condition} o == 1",
-                                            '    puts o',
-                                            '  end',
-                                            'end'])
-      expect(new_source).to eq(['for o in 1..3 do',
-                                "  next #{opposite} o == 1",
-                                '  puts o',
-                                'end'].join("\n"))
+      new_source = autocorrect_source(cop, <<-END.strip_indent)
+        for o in 1..3 do
+          #{condition} o == 1
+            puts o
+          end
+        end
+      END
+      expect(new_source).to eq(<<-END.strip_indent)
+        for o in 1..3 do
+          next #{opposite} o == 1
+          puts o
+        end
+      END
     end
 
     it "registers an offense for #{condition} inside of loop" do
-      inspect_source(cop, ['loop do',
-                           "  #{condition} o == 1",
-                           '    puts o',
-                           '  end',
-                           'end'])
+      inspect_source(cop, <<-END.strip_indent)
+        loop do
+          #{condition} o == 1
+            puts o
+          end
+        end
+      END
 
       expect(cop.messages).to eq(['Use `next` to skip iteration.'])
       expect(cop.highlights).to eq(["#{condition} o == 1"])
     end
 
     it "registers an offense for #{condition} inside of map" do
-      inspect_source(cop, ['loop do',
-                           '  {}.map do |k, v|',
-                           "    #{condition} v == 1",
-                           '      puts k',
-                           '    end',
-                           '  end',
-                           'end'])
+      inspect_source(cop, <<-END.strip_indent)
+        loop do
+          {}.map do |k, v|
+            #{condition} v == 1
+              puts k
+            end
+          end
+        end
+      END
 
       expect(cop.messages).to eq(['Use `next` to skip iteration.'])
       expect(cop.highlights).to eq(["#{condition} v == 1"])
     end
 
     it "registers an offense for #{condition} inside of times" do
-      inspect_source(cop, ['loop do',
-                           '  3.times do |o|',
-                           "    #{condition} o == 1",
-                           '      puts o',
-                           '    end',
-                           '  end',
-                           'end'])
+      inspect_source(cop, <<-END.strip_indent)
+        loop do
+          3.times do |o|
+            #{condition} o == 1
+              puts o
+            end
+          end
+        end
+      END
 
       expect(cop.messages).to eq(['Use `next` to skip iteration.'])
       expect(cop.highlights).to eq(["#{condition} o == 1"])
     end
 
     it "registers an offense for #{condition} inside of collect" do
-      inspect_source(cop, ['[].collect do |o|',
-                           "  #{condition} o == 1",
-                           '    true',
-                           '  end',
-                           'end'])
+      inspect_source(cop, <<-END.strip_indent)
+        [].collect do |o|
+          #{condition} o == 1
+            true
+          end
+        end
+      END
 
       expect(cop.messages).to eq(['Use `next` to skip iteration.'])
       expect(cop.highlights).to eq(["#{condition} o == 1"])
     end
 
     it "registers an offense for #{condition} inside of select" do
-      inspect_source(cop, ['[].select do |o|',
-                           "  #{condition} o == 1",
-                           '    true',
-                           '  end',
-                           'end'])
+      inspect_source(cop, <<-END.strip_indent)
+        [].select do |o|
+          #{condition} o == 1
+            true
+          end
+        end
+      END
 
       expect(cop.messages).to eq(['Use `next` to skip iteration.'])
       expect(cop.highlights).to eq(["#{condition} o == 1"])
     end
 
     it "registers an offense for #{condition} inside of select!" do
-      inspect_source(cop, ['[].select! do |o|',
-                           "  #{condition} o == 1",
-                           '    true',
-                           '  end',
-                           'end'])
+      inspect_source(cop, <<-END.strip_indent)
+        [].select! do |o|
+          #{condition} o == 1
+            true
+          end
+        end
+      END
 
       expect(cop.messages).to eq(['Use `next` to skip iteration.'])
       expect(cop.highlights).to eq(["#{condition} o == 1"])
     end
 
     it "registers an offense for #{condition} inside of reject" do
-      inspect_source(cop, ['[].reject do |o|',
-                           "  #{condition} o == 1",
-                           '    true',
-                           '  end',
-                           'end'])
+      inspect_source(cop, <<-END.strip_indent)
+        [].reject do |o|
+          #{condition} o == 1
+            true
+          end
+        end
+      END
 
       expect(cop.messages).to eq(['Use `next` to skip iteration.'])
       expect(cop.highlights).to eq(["#{condition} o == 1"])
     end
 
     it "registers an offense for #{condition} inside of reject!" do
-      inspect_source(cop, ['[].reject! do |o|',
-                           "  #{condition} o == 1",
-                           '    true',
-                           '  end',
-                           'end'])
+      inspect_source(cop, <<-END.strip_indent)
+        [].reject! do |o|
+          #{condition} o == 1
+            true
+          end
+        end
+      END
 
       expect(cop.messages).to eq(['Use `next` to skip iteration.'])
       expect(cop.highlights).to eq(["#{condition} o == 1"])
     end
 
     it "registers an offense for #{condition} inside of nested iterators" do
-      inspect_source(cop, ['loop do',
-                           '  until false',
-                           "    #{condition} o == 1",
-                           '      puts o',
-                           '    end',
-                           '  end',
-                           'end'])
+      inspect_source(cop, <<-END.strip_indent)
+        loop do
+          until false
+            #{condition} o == 1
+              puts o
+            end
+          end
+        end
+      END
 
       expect(cop.messages).to eq(['Use `next` to skip iteration.'])
       expect(cop.highlights).to eq(["#{condition} o == 1"])
     end
 
     it "registers an offense for #{condition} inside of nested iterators" do
-      inspect_source(cop, ['loop do',
-                           '  while true',
-                           "    #{condition} o == 1",
-                           '      puts o',
-                           '    end',
-                           '  end',
-                           'end'])
+      inspect_source(cop, <<-END.strip_indent)
+        loop do
+          while true
+            #{condition} o == 1
+              puts o
+            end
+          end
+        end
+      END
 
       expect(cop.messages).to eq(['Use `next` to skip iteration.'])
       expect(cop.highlights).to eq(["#{condition} o == 1"])
@@ -207,83 +247,97 @@ describe RuboCop::Cop::Style::Next, :config do
 
     it 'registers an offense for a condition at the end of an iterator ' \
        'when there is more in the iterator than the condition' do
-      inspect_source(cop, ['[].each do |o|',
-                           '  puts o',
-                           "  #{condition} o == 1",
-                           '    puts o',
-                           '  end',
-                           'end'])
+      inspect_source(cop, <<-END.strip_indent)
+        [].each do |o|
+          puts o
+          #{condition} o == 1
+            puts o
+          end
+        end
+      END
 
       expect(cop.messages).to eq(['Use `next` to skip iteration.'])
       expect(cop.highlights).to eq(["#{condition} o == 1"])
     end
 
     it 'allows loops with conditional break' do
-      inspect_source(cop, ['loop do',
-                           "  puts ''",
-                           "  break #{condition} o == 1",
-                           'end'])
+      inspect_source(cop, <<-END.strip_indent)
+        loop do
+          puts ''
+          break #{condition} o == 1
+        end
+      END
 
       expect(cop.offenses).to be_empty
     end
 
     it 'allows loops with conditional return' do
-      inspect_source(cop, ['loop do',
-                           "  puts ''",
-                           "  return #{condition} o == 1",
-                           'end'])
+      inspect_source(cop, <<-END.strip_indent)
+        loop do
+          puts ''
+          return #{condition} o == 1
+        end
+      END
 
       expect(cop.offenses).to be_empty
     end
 
     it "allows loops with #{condition} being the entire body with else" do
-      inspect_source(cop, ['[].each do |o|',
-                           "  #{condition} o == 1",
-                           '    puts o',
-                           '  else',
-                           "    puts 'no'",
-                           '  end',
-                           'end'])
+      inspect_source(cop, <<-END.strip_indent)
+        [].each do |o|
+          #{condition} o == 1
+            puts o
+          else
+            puts 'no'
+          end
+        end
+      END
 
       expect(cop.offenses).to be_empty
     end
 
     it "allows loops with #{condition} with else, nested in another " \
        'condition' do
-      inspect_source(cop, ['[].each do |o|',
-                           '  if foo',
-                           "    #{condition} o == 1",
-                           '      puts o',
-                           '    else',
-                           "      puts 'no'",
-                           '    end',
-                           '  end',
-                           'end'])
+      inspect_source(cop, <<-END.strip_indent)
+        [].each do |o|
+          if foo
+            #{condition} o == 1
+              puts o
+            else
+              puts 'no'
+            end
+          end
+        end
+      END
 
       expect(cop.offenses).to be_empty
     end
 
     it "allows loops with #{condition} with else at the end" do
-      inspect_source(cop, ['[].each do |o|',
-                           '  puts o',
-                           "  #{condition} o == 1",
-                           '    puts o',
-                           '  else',
-                           "    puts 'no'",
-                           '  end',
-                           'end'])
+      inspect_source(cop, <<-END.strip_indent)
+        [].each do |o|
+          puts o
+          #{condition} o == 1
+            puts o
+          else
+            puts 'no'
+          end
+        end
+      END
 
       expect(cop.offenses).to be_empty
     end
 
     it "reports an offense for #{condition} whose body has 3 lines" do
-      inspect_source(cop, ['arr.each do |e|',
-                           "  #{condition} something",
-                           '    work',
-                           '    work',
-                           '    work',
-                           '  end',
-                           'end'])
+      inspect_source(cop, <<-END.strip_indent)
+        arr.each do |e|
+          #{condition} something
+            work
+            work
+            work
+          end
+        end
+      END
 
       expect(cop.offenses.size).to eq(1)
       expect(cop.highlights).to eq(["#{condition} something"])
@@ -295,9 +349,11 @@ describe RuboCop::Cop::Style::Next, :config do
       end
 
       it "allows modifier #{condition}" do
-        inspect_source(cop, ['[].each do |o|',
-                             "  puts o #{condition} o == 1",
-                             'end'])
+        inspect_source(cop, <<-END.strip_indent)
+          [].each do |o|
+            puts o #{condition} o == 1
+          end
+        END
 
         expect(cop.offenses).to be_empty
       end
@@ -309,9 +365,11 @@ describe RuboCop::Cop::Style::Next, :config do
       end
       let(:opposite) { condition == 'if' ? 'unless' : 'if' }
       let(:source) do
-        ['[].each do |o|',
-         "  puts o #{condition} o == 1 # comment",
-         'end']
+        <<-END.strip_indent
+          [].each do |o|
+            puts o #{condition} o == 1 # comment
+          end
+        END
       end
 
       it "registers an offense for modifier #{condition}" do
@@ -323,10 +381,12 @@ describe RuboCop::Cop::Style::Next, :config do
 
       it "auto-corrects modifier #{condition}" do
         corrected = autocorrect_source(cop, source)
-        expect(corrected).to eq(['[].each do |o|',
-                                 "  next #{opposite} o == 1",
-                                 '  puts o # comment',
-                                 'end'].join("\n"))
+        expect(corrected).to eq(<<-END.strip_indent)
+          [].each do |o|
+            next #{opposite} o == 1
+            puts o # comment
+          end
+        END
       end
     end
   end
@@ -351,80 +411,98 @@ describe RuboCop::Cop::Style::Next, :config do
   end
 
   it 'handles `then` when autocorrecting' do
-    new_source = autocorrect_source(cop, ['loop do',
-                                          '  if test then',
-                                          '    something',
-                                          '  end',
-                                          'end'])
-    expect(new_source).to eq(['loop do',
-                              '  next unless test',
-                              '  something',
-                              'end'].join("\n"))
+    new_source = autocorrect_source(cop, <<-END.strip_indent)
+      loop do
+        if test then
+          something
+        end
+      end
+    END
+    expect(new_source).to eq(<<-END.strip_indent)
+      loop do
+        next unless test
+        something
+      end
+    END
   end
 
   it "doesn't reindent heredoc bodies when autocorrecting" do
-    new_source = autocorrect_source(cop, ['loop do',
-                                          '  if test',
-                                          '    str = <<-BLAH',
-                                          '  this is a heredoc',
-                                          '   nice eh?',
-                                          '    BLAH',
-                                          '    something',
-                                          '  end',
-                                          'end'])
-    expect(new_source).to eq(['loop do',
-                              '  next unless test',
-                              '  str = <<-BLAH',
-                              '  this is a heredoc',
-                              '   nice eh?',
-                              '  BLAH',
-                              '  something',
-                              'end'].join("\n"))
+    new_source = autocorrect_source(cop, <<-END.strip_indent)
+      loop do
+        if test
+          str = <<-BLAH
+        this is a heredoc
+         nice eh?
+          BLAH
+          something
+        end
+      end
+    END
+    expect(new_source).to eq(<<-END.strip_indent)
+      loop do
+        next unless test
+        str = <<-BLAH
+        this is a heredoc
+         nice eh?
+        BLAH
+        something
+      end
+    END
   end
 
   it 'handles nested autocorrections' do
-    new_source = autocorrect_source(cop, ['loop do',
-                                          '  if test',
-                                          '    loop do',
-                                          '      if test',
-                                          '        something',
-                                          '      end',
-                                          '    end',
-                                          '  end',
-                                          'end'])
-    expect(new_source).to eq(['loop do',
-                              '  next unless test',
-                              '  loop do',
-                              '    next unless test',
-                              '    something',
-                              '  end',
-                              'end'].join("\n"))
+    new_source = autocorrect_source(cop, <<-END.strip_indent)
+      loop do
+        if test
+          loop do
+            if test
+              something
+            end
+          end
+        end
+      end
+    END
+    expect(new_source).to eq(<<-END.strip_indent)
+      loop do
+        next unless test
+        loop do
+          next unless test
+          something
+        end
+      end
+    END
   end
 
   it_behaves_like 'iterators', 'if'
   it_behaves_like 'iterators', 'unless'
 
   it 'allows empty blocks' do
-    inspect_source(cop, ['[].each do',
-                         'end',
-                         '[].each { }'])
+    inspect_source(cop, <<-END.strip_indent)
+      [].each do
+      end
+      [].each { }
+    END
 
     expect(cop.offenses).to be_empty
   end
 
   it 'allows loops with conditions at the end with ternary op' do
-    inspect_source(cop, ['[].each do |o|',
-                         '  o == x ? y : z',
-                         'end'])
+    inspect_source(cop, <<-END.strip_indent)
+      [].each do |o|
+        o == x ? y : z
+      end
+    END
 
     expect(cop.offenses).to be_empty
   end
 
   it 'allows super nodes' do
     # https://github.com/bbatsov/rubocop/issues/1115
-    inspect_source(cop, ['def foo',
-                         '  super(a, a) { a }',
-                         'end'])
+    inspect_source(cop, <<-END.strip_indent)
+      def foo
+        super(a, a) { a }
+      end
+    END
 
     expect(cop.offenses).to be_empty
   end
@@ -448,17 +526,21 @@ describe RuboCop::Cop::Style::Next, :config do
   end
 
   it 'does not crash with an empty body branch' do
-    inspect_source(cop, ['loop do',
-                         '  if true',
-                         '  end',
-                         'end'])
+    inspect_source(cop, <<-END.strip_indent)
+      loop do
+        if true
+        end
+      end
+    END
     expect(cop.offenses).to be_empty
   end
 
   it 'does not crash with empty brackets' do
-    inspect_source(cop, ['loop do',
-                         '  ()',
-                         'end'])
+    inspect_source(cop, <<-END.strip_indent)
+      loop do
+        ()
+      end
+    END
     expect(cop.offenses).to be_empty
   end
 
@@ -468,11 +550,13 @@ describe RuboCop::Cop::Style::Next, :config do
     end
 
     it 'accepts if whose body has 1 line' do
-      inspect_source(cop, ['arr.each do |e|',
-                           '  if something',
-                           '    work',
-                           '  end',
-                           'end'])
+      inspect_source(cop, <<-END.strip_indent)
+        arr.each do |e|
+          if something
+            work
+          end
+        end
+      END
 
       expect(cop.offenses).to be_empty
     end
@@ -484,11 +568,13 @@ describe RuboCop::Cop::Style::Next, :config do
     end
 
     it 'fails with an error' do
-      source = ['loop do',
-                '  if o == 1',
-                '    puts o',
-                '  end',
-                'end']
+      source = <<-END.strip_indent
+        loop do
+          if o == 1
+            puts o
+          end
+        end
+      END
 
       expect { inspect_source(cop, source) }
         .to raise_error('MinBodyLength needs to be a positive integer!')

--- a/spec/rubocop/cop/style/non_nil_check_spec.rb
+++ b/spec/rubocop/cop/style/non_nil_check_spec.rb
@@ -34,32 +34,40 @@ describe RuboCop::Cop::Style::NonNilCheck, :config do
     end
 
     it 'does not register an offense if only expression in predicate' do
-      inspect_source(cop, ['def signed_in?',
-                           '  !current_user.nil?',
-                           'end'])
+      inspect_source(cop, <<-END.strip_indent)
+        def signed_in?
+          !current_user.nil?
+        end
+      END
       expect(cop.offenses).to be_empty
     end
 
     it 'does not register an offense if only expression in class predicate' do
-      inspect_source(cop, ['def Test.signed_in?',
-                           '  current_user != nil',
-                           'end'])
+      inspect_source(cop, <<-END.strip_indent)
+        def Test.signed_in?
+          current_user != nil
+        end
+      END
       expect(cop.offenses).to be_empty
     end
 
     it 'does not register an offense if last expression in predicate' do
-      inspect_source(cop, ['def signed_in?',
-                           '  something',
-                           '  current_user != nil',
-                           'end'])
+      inspect_source(cop, <<-END.strip_indent)
+        def signed_in?
+          something
+          current_user != nil
+        end
+      END
       expect(cop.offenses).to be_empty
     end
 
     it 'does not register an offense if last expression in class predicate' do
-      inspect_source(cop, ['def Test.signed_in?',
-                           '  something',
-                           '  current_user != nil',
-                           'end'])
+      inspect_source(cop, <<-END.strip_indent)
+        def Test.signed_in?
+          something
+          current_user != nil
+        end
+      END
       expect(cop.offenses).to be_empty
     end
 

--- a/spec/rubocop/cop/style/numeric_literal_prefix_spec.rb
+++ b/spec/rubocop/cop/style/numeric_literal_prefix_spec.rb
@@ -12,16 +12,20 @@ describe RuboCop::Cop::Style::NumericLiteralPrefix, :config do
       end
 
       it 'registers an offense for prefixes `0` and `0O`' do
-        inspect_source(cop, ['a = 01234',
-                             'b(0O1234)'])
+        inspect_source(cop, <<-END.strip_indent)
+          a = 01234
+          b(0O1234)
+        END
         expect(cop.offenses.size).to eq(2)
         expect(cop.messages.uniq).to eq(['Use 0o for octal literals.'])
         expect(cop.highlights).to eq(%w[01234 0O1234])
       end
 
       it 'does not register offense for lowercase prefix' do
-        inspect_source(cop, ['a = 0o101',
-                             'b = 0o567'])
+        inspect_source(cop, <<-END.strip_indent)
+          a = 0o101
+          b = 0o567
+        END
         expect(cop.messages).to be_empty
       end
 
@@ -44,8 +48,10 @@ describe RuboCop::Cop::Style::NumericLiteralPrefix, :config do
       end
 
       it 'registers an offense for prefix `0O` and `0o`' do
-        inspect_source(cop, ['a = 0O1234',
-                             'b(0o1234)'])
+        inspect_source(cop, <<-END.strip_indent)
+          a = 0O1234
+          b(0o1234)
+        END
         expect(cop.offenses.size).to eq(2)
         expect(cop.messages.uniq).to eq(['Use 0 for octal literals.'])
         expect(cop.highlights).to eq(%w[0O1234 0o1234])
@@ -57,9 +63,15 @@ describe RuboCop::Cop::Style::NumericLiteralPrefix, :config do
       end
 
       it 'autocorrects an octal literal starting with 0O or 0o' do
-        corrected = autocorrect_source(cop, ['a = 0O1234',
-                                             'b(0o1234)'])
-        expect(corrected).to eq "a = 01234\nb(01234)"
+        corrected = autocorrect_source(cop, <<-END.strip_indent)
+          a = 0O1234
+          b(0o1234)
+        END
+
+        expect(corrected).to eq <<-END.strip_indent
+          a = 01234
+          b(01234)
+        END
       end
 
       it 'does not autocorrect an octal literal starting with 0' do
@@ -71,8 +83,10 @@ describe RuboCop::Cop::Style::NumericLiteralPrefix, :config do
 
   context 'hex literals' do
     it 'registers an offense for uppercase prefix' do
-      inspect_source(cop, ['a = 0X1AC',
-                           'b(0XABC)'])
+      inspect_source(cop, <<-END.strip_indent)
+        a = 0X1AC
+        b(0XABC)
+      END
       expect(cop.offenses.size).to eq(2)
       expect(cop.messages.uniq).to eq(['Use 0x for hexadecimal literals.'])
       expect(cop.highlights).to eq(%w[0X1AC 0XABC])
@@ -91,8 +105,10 @@ describe RuboCop::Cop::Style::NumericLiteralPrefix, :config do
 
   context 'binary literals' do
     it 'registers an offense for uppercase prefix' do
-      inspect_source(cop, ['a = 0B10101',
-                           'b(0B111)'])
+      inspect_source(cop, <<-END.strip_indent)
+        a = 0B10101
+        b(0B111)
+      END
       expect(cop.offenses.size).to eq(2)
       expect(cop.messages.uniq).to eq(['Use 0b for binary literals.'])
       expect(cop.highlights).to eq(%w[0B10101 0B111])
@@ -111,8 +127,10 @@ describe RuboCop::Cop::Style::NumericLiteralPrefix, :config do
 
   context 'decimal literals' do
     it 'registers an offense for prefixes' do
-      inspect_source(cop, ['a = 0d1234',
-                           'b(0D1234)'])
+      inspect_source(cop, <<-END.strip_indent)
+        a = 0d1234
+        b(0D1234)
+      END
       expect(cop.offenses.size).to eq(2)
       expect(cop.messages.uniq)
         .to eq(['Do not use prefixes for decimal literals.'])

--- a/spec/rubocop/cop/style/numeric_literals_spec.rb
+++ b/spec/rubocop/cop/style/numeric_literals_spec.rb
@@ -17,21 +17,27 @@ describe RuboCop::Cop::Style::NumericLiterals, :config do
   end
 
   it 'accepts integers with less than three places at the end' do
-    inspect_source(cop, ['a = 123_456_789_00',
-                         'b = 819_2'])
+    inspect_source(cop, <<-END.strip_indent)
+      a = 123_456_789_00
+      b = 819_2
+    END
     expect(cop.offenses).to be_empty
   end
 
   it 'registers an offense for an integer with misplaced underscore' do
-    inspect_source(cop, ['a = 123_456_78_90_00',
-                         'b = 1_8192'])
+    inspect_source(cop, <<-END.strip_indent)
+      a = 123_456_78_90_00
+      b = 1_8192
+    END
     expect(cop.offenses.size).to eq(2)
     expect(cop.config_to_allow_offenses).to eq('Enabled' => false)
   end
 
   it 'accepts long numbers with underscore' do
-    inspect_source(cop, ['a = 123_456',
-                         'b = 123_456.55'])
+    inspect_source(cop, <<-END.strip_indent)
+      a = 123_456
+      b = 123_456.55
+    END
     expect(cop.messages).to be_empty
   end
 
@@ -46,15 +52,19 @@ describe RuboCop::Cop::Style::NumericLiterals, :config do
   end
 
   it 'accepts short numbers without underscore' do
-    inspect_source(cop, ['a = 123',
-                         'b = 123.456'])
+    inspect_source(cop, <<-END.strip_indent)
+      a = 123
+      b = 123.456
+    END
     expect(cop.messages).to be_empty
   end
 
   it 'ignores non-decimal literals' do
-    inspect_source(cop, ['a = 0b1010101010101',
-                         'b = 01717171717171',
-                         'c = 0xab11111111bb'])
+    inspect_source(cop, <<-END.strip_indent)
+      a = 0b1010101010101
+      b = 01717171717171
+      c = 0xab11111111bb
+    END
     expect(cop.offenses).to be_empty
   end
 
@@ -92,8 +102,10 @@ describe RuboCop::Cop::Style::NumericLiterals, :config do
     end
 
     it 'registers an offense for an integer with misplaced underscore' do
-      inspect_source(cop, ['a = 123_456_78_90_00',
-                           'b = 81_92'])
+      inspect_source(cop, <<-END.strip_indent)
+        a = 123_456_78_90_00
+        b = 81_92
+      END
       expect(cop.offenses.size).to eq(2)
       expect(cop.config_to_allow_offenses).to eq('Enabled' => false)
     end

--- a/spec/rubocop/cop/style/op_method_spec.rb
+++ b/spec/rubocop/cop/style/op_method_spec.rb
@@ -5,10 +5,11 @@ describe RuboCop::Cop::Style::OpMethod do
 
   %i[+ eql? equal?].each do |op|
     it "registers an offense for #{op} with arg not named other" do
-      inspect_source(cop,
-                     ["def #{op}(another)",
-                      '  another',
-                      'end'])
+      inspect_source(cop, <<-END.strip_indent)
+        def #{op}(another)
+          another
+        end
+      END
       expect(cop.offenses.size).to eq(1)
       expect(cop.messages)
         .to eq(["When defining the `#{op}` operator, " \
@@ -17,63 +18,70 @@ describe RuboCop::Cop::Style::OpMethod do
   end
 
   it 'works properly even if the argument not surrounded with braces' do
-    inspect_source(cop,
-                   ['def + another',
-                    '  another',
-                    'end'])
+    inspect_source(cop, <<-END.strip_indent)
+      def + another
+        another
+      end
+    END
     expect(cop.offenses.size).to eq(1)
     expect(cop.messages)
       .to eq(['When defining the `+` operator, name its argument `other`.'])
   end
 
   it 'does not register an offense for arg named other' do
-    inspect_source(cop,
-                   ['def +(other)',
-                    '  other',
-                    'end'])
+    inspect_source(cop, <<-END.strip_indent)
+      def +(other)
+        other
+      end
+    END
     expect(cop.offenses).to be_empty
   end
 
   it 'does not register an offense for arg named _other' do
-    inspect_source(cop,
-                   ['def <=>(_other)',
-                    '  0',
-                    'end'])
+    inspect_source(cop, <<-END.strip_indent)
+      def <=>(_other)
+        0
+      end
+    END
     expect(cop.offenses).to be_empty
   end
 
   it 'does not register an offense for []' do
-    inspect_source(cop,
-                   ['def [](index)',
-                    '  other',
-                    'end'])
+    inspect_source(cop, <<-END.strip_indent)
+      def [](index)
+        other
+      end
+    END
     expect(cop.offenses).to be_empty
   end
 
   it 'does not register an offense for []=' do
-    inspect_source(cop,
-                   ['def []=(index, value)',
-                    '  other',
-                    'end'])
+    inspect_source(cop, <<-END.strip_indent)
+      def []=(index, value)
+        other
+      end
+    END
     expect(cop.offenses).to be_empty
   end
 
   it 'does not register an offense for <<' do
-    inspect_source(cop,
-                   ['def <<(cop)',
-                    '  other',
-                    'end'])
+    inspect_source(cop, <<-END.strip_indent)
+      def <<(cop)
+        other
+      end
+    END
     expect(cop.offenses).to be_empty
   end
 
   it 'does not register an offense for non binary operators' do
-    inspect_source(cop,
-                   ['def -@; end',
+    inspect_source(cop, <<-END.strip_indent)
+      def -@; end
                     # This + is not a unary operator. It can only be
                     # called with dot notation.
-                    'def +; end',
-                    'def *(a, b); end', # Quite strange, but legal ruby.
-                    'def `(cmd); end'])
+      def +; end
+      def *(a, b); end # Quite strange, but legal ruby.
+      def `(cmd); end
+    END
     expect(cop.offenses).to be_empty
   end
 end

--- a/spec/rubocop/cop/style/option_hash_spec.rb
+++ b/spec/rubocop/cop/style/option_hash_spec.rb
@@ -5,11 +5,11 @@ describe RuboCop::Cop::Style::OptionHash, :config do
   let(:cop_config) { { 'SuspiciousParamNames' => ['options'] } }
 
   let(:source) do
-    [
-      'def some_method(options = {})',
-      '  puts some_arg',
-      'end'
-    ]
+    <<-END.strip_indent
+      def some_method(options = {})
+        puts some_arg
+      end
+    END
   end
 
   it 'registers an offense' do
@@ -22,12 +22,12 @@ describe RuboCop::Cop::Style::OptionHash, :config do
 
   context 'when the last argument is an options hash named something else' do
     let(:source) do
-      [
-        'def steep(flavor, duration, config={})',
-        '  mug = config.fetch(:mug)',
-        '  prep(flavor, duration, mug)',
-        'end'
-      ]
+      <<-END.strip_indent
+        def steep(flavor, duration, config={})
+          mug = config.fetch(:mug)
+          prep(flavor, duration, mug)
+        end
+      END
     end
 
     it 'does not register an offense' do
@@ -53,12 +53,12 @@ describe RuboCop::Cop::Style::OptionHash, :config do
     end
 
     let(:source) do
-      [
-        'def meditate',
-        '  puts true',
-        '  puts true',
-        'end'
-      ]
+      <<-END.strip_indent
+        def meditate
+          puts true
+          puts true
+        end
+      END
     end
 
     it 'does not register an offense' do
@@ -72,11 +72,11 @@ describe RuboCop::Cop::Style::OptionHash, :config do
     end
 
     let(:source) do
-      [
-        'def cook(instructions, ingredients = { hot: [], cold: [] })',
-        '  prep(ingredients)',
-        'end'
-      ]
+      <<-END.strip_indent
+        def cook(instructions, ingredients = { hot: [], cold: [] })
+          prep(ingredients)
+        end
+      END
     end
 
     it 'does not register an offense' do

--- a/spec/rubocop/cop/style/optional_arguments_spec.rb
+++ b/spec/rubocop/cop/style/optional_arguments_spec.rb
@@ -5,8 +5,10 @@ describe RuboCop::Cop::Style::OptionalArguments do
 
   it 'registers an offense when an optional argument is followed by a ' \
      'required argument' do
-    inspect_source(cop, ['def foo(a = 1, b)',
-                         'end'])
+    inspect_source(cop, <<-END.strip_indent)
+      def foo(a = 1, b)
+      end
+    END
 
     expect(cop.messages)
       .to eq([described_class::MSG])
@@ -15,51 +17,65 @@ describe RuboCop::Cop::Style::OptionalArguments do
 
   it 'registers an offense for each optional argument when multiple ' \
      'optional arguments are followed by a required argument' do
-    inspect_source(cop, ['def foo(a = 1, b = 2, c)',
-                         'end'])
+    inspect_source(cop, <<-END.strip_indent)
+      def foo(a = 1, b = 2, c)
+      end
+    END
 
     expect(cop.messages).to eq([described_class::MSG, described_class::MSG])
     expect(cop.highlights).to eq(['a = 1', 'b = 2'])
   end
 
   it 'allows methods without arguments' do
-    inspect_source(cop, ['def foo',
-                         'end'])
+    inspect_source(cop, <<-END.strip_indent)
+      def foo
+      end
+    END
 
     expect(cop.messages).to be_empty
   end
 
   it 'allows methods with only one required argument' do
-    inspect_source(cop, ['def foo(a)',
-                         'end'])
+    inspect_source(cop, <<-END.strip_indent)
+      def foo(a)
+      end
+    END
 
     expect(cop.messages).to be_empty
   end
 
   it 'allows methods with only required arguments' do
-    inspect_source(cop, ['def foo(a, b, c)',
-                         'end'])
+    inspect_source(cop, <<-END.strip_indent)
+      def foo(a, b, c)
+      end
+    END
 
     expect(cop.messages).to be_empty
   end
 
   it 'allows methods with only one optional argument' do
-    inspect_source(cop, ['def foo(a = 1)',
-                         'end'])
+    inspect_source(cop, <<-END.strip_indent)
+      def foo(a = 1)
+      end
+    END
 
     expect(cop.messages).to be_empty
   end
 
   it 'allows methods with only optional arguments' do
-    inspect_source(cop, ['def foo(a = 1, b = 2, c = 3)',
-                         'end'])
+    inspect_source(cop, <<-END.strip_indent)
+      def foo(a = 1, b = 2, c = 3)
+      end
+    END
 
     expect(cop.messages).to be_empty
   end
 
   it 'allows methods with multiple optional arguments at the end' do
-    inspect_source(cop, ['def foo(a, b = 2, c = 3)',
-                         'end'])
+    inspect_source(cop, <<-END.strip_indent)
+      def foo(a, b = 2, c = 3)
+      end
+    END
 
     expect(cop.messages).to be_empty
   end
@@ -67,8 +83,10 @@ describe RuboCop::Cop::Style::OptionalArguments do
   context 'named params' do
     context 'with default values', :ruby20 do
       it 'allows optional arguments before an optional named argument' do
-        inspect_source(cop, ['def foo(a = 1, b: 2)',
-                             'end'])
+        inspect_source(cop, <<-END.strip_indent)
+          def foo(a = 1, b: 2)
+          end
+        END
 
         expect(cop.messages).to be_empty
       end
@@ -77,24 +95,30 @@ describe RuboCop::Cop::Style::OptionalArguments do
     context 'required params', :ruby21 do
       it 'registers an offense for optional arguments that come before ' \
          'required arguments where there are name arguments' do
-        inspect_source(cop, ['def foo(a = 1, b, c:, d: 4)',
-                             'end'])
+        inspect_source(cop, <<-END.strip_indent)
+          def foo(a = 1, b, c:, d: 4)
+          end
+        END
 
         expect(cop.messages).to eq([described_class::MSG])
         expect(cop.highlights).to eq(['a = 1'])
       end
 
       it 'allows optional arguments before required named arguments' do
-        inspect_source(cop, ['def foo(a = 1, b:)',
-                             'end'])
+        inspect_source(cop, <<-END.strip_indent)
+          def foo(a = 1, b:)
+          end
+        END
 
         expect(cop.messages).to be_empty
       end
 
       it 'allows optional arguments to come before a mix of required and ' \
          'optional named argument' do
-        inspect_source(cop, ['def foo(a = 1, b:, c: 3)',
-                             'end'])
+        inspect_source(cop, <<-END.strip_indent)
+          def foo(a = 1, b:, c: 3)
+          end
+        END
 
         expect(cop.messages).to be_empty
       end

--- a/spec/rubocop/cop/style/parentheses_around_condition_spec.rb
+++ b/spec/rubocop/cop/style/parentheses_around_condition_spec.rb
@@ -5,19 +5,21 @@ describe RuboCop::Cop::Style::ParenthesesAroundCondition, :config do
   let(:cop_config) { { 'AllowSafeAssignment' => true } }
 
   it 'registers an offense for parentheses around condition' do
-    inspect_source(cop, ['if (x > 10)',
-                         'elsif (x < 3)',
-                         'end',
-                         'unless (x > 10)',
-                         'end',
-                         'while (x > 10)',
-                         'end',
-                         'until (x > 10)',
-                         'end',
-                         'x += 1 if (x < 10)',
-                         'x += 1 unless (x < 10)',
-                         'x += 1 until (x < 10)',
-                         'x += 1 while (x < 10)'])
+    inspect_source(cop, <<-END.strip_indent)
+      if (x > 10)
+      elsif (x < 3)
+      end
+      unless (x > 10)
+      end
+      while (x > 10)
+      end
+      until (x > 10)
+      end
+      x += 1 if (x < 10)
+      x += 1 unless (x < 10)
+      x += 1 until (x < 10)
+      x += 1 while (x < 10)
+    END
     expect(cop.offenses.size).to eq(9)
     expect(cop.messages.first)
       .to eq("Don't use parentheses around the condition of an `if`.")
@@ -26,53 +28,61 @@ describe RuboCop::Cop::Style::ParenthesesAroundCondition, :config do
   end
 
   it 'accepts parentheses if there is no space between the keyword and (.' do
-    inspect_source(cop, ['if(x > 5) then something end',
-                         'do_something until(x > 5)'])
+    inspect_source(cop, <<-END.strip_indent)
+      if(x > 5) then something end
+      do_something until(x > 5)
+    END
     expect(cop.offenses).to be_empty
   end
 
   it 'auto-corrects parentheses around condition' do
-    corrected = autocorrect_source(cop, ['if (x > 10)',
-                                         'elsif (x < 3)',
-                                         'end',
-                                         'unless (x > 10)',
-                                         'end',
-                                         'while (x > 10)',
-                                         'end',
-                                         'until (x > 10)',
-                                         'end',
-                                         'x += 1 if (x < 10)',
-                                         'x += 1 unless (x < 10)',
-                                         'x += 1 while (x < 10)',
-                                         'x += 1 until (x < 10)'])
-    expect(corrected).to eq ['if x > 10',
-                             'elsif x < 3',
-                             'end',
-                             'unless x > 10',
-                             'end',
-                             'while x > 10',
-                             'end',
-                             'until x > 10',
-                             'end',
-                             'x += 1 if x < 10',
-                             'x += 1 unless x < 10',
-                             'x += 1 while x < 10',
-                             'x += 1 until x < 10'].join("\n")
+    corrected = autocorrect_source(cop, <<-END.strip_indent)
+      if (x > 10)
+      elsif (x < 3)
+      end
+      unless (x > 10)
+      end
+      while (x > 10)
+      end
+      until (x > 10)
+      end
+      x += 1 if (x < 10)
+      x += 1 unless (x < 10)
+      x += 1 while (x < 10)
+      x += 1 until (x < 10)
+    END
+    expect(corrected).to eq <<-END.strip_indent
+      if x > 10
+      elsif x < 3
+      end
+      unless x > 10
+      end
+      while x > 10
+      end
+      until x > 10
+      end
+      x += 1 if x < 10
+      x += 1 unless x < 10
+      x += 1 while x < 10
+      x += 1 until x < 10
+    END
   end
 
   it 'accepts condition without parentheses' do
-    inspect_source(cop, ['if x > 10',
-                         'end',
-                         'unless x > 10',
-                         'end',
-                         'while x > 10',
-                         'end',
-                         'until x > 10',
-                         'end',
-                         'x += 1 if x < 10',
-                         'x += 1 unless x < 10',
-                         'x += 1 while x < 10',
-                         'x += 1 until x < 10'])
+    inspect_source(cop, <<-END.strip_indent)
+      if x > 10
+      end
+      unless x > 10
+      end
+      while x > 10
+      end
+      until x > 10
+      end
+      x += 1 if x < 10
+      x += 1 unless x < 10
+      x += 1 while x < 10
+      x += 1 until x < 10
+    END
     expect(cop.offenses).to be_empty
   end
 
@@ -87,15 +97,19 @@ describe RuboCop::Cop::Style::ParenthesesAroundCondition, :config do
   end
 
   it 'is not confused by unbalanced parentheses' do
-    inspect_source(cop, ['if (a + b).c()',
-                         'end'])
+    inspect_source(cop, <<-END.strip_indent)
+      if (a + b).c()
+      end
+    END
     expect(cop.offenses).to be_empty
   end
 
   %w[rescue if unless while until].each do |op|
     it "allows parens if the condition node is a modifier #{op} op" do
-      inspect_source(cop, ["if (something #{op} top)",
-                           'end'])
+      inspect_source(cop, <<-END.strip_indent)
+        if (something #{op} top)
+        end
+      END
       expect(cop.offenses).to be_empty
     end
   end
@@ -106,38 +120,43 @@ describe RuboCop::Cop::Style::ParenthesesAroundCondition, :config do
   end
 
   it 'does not blow up for empty if condition' do
-    inspect_source(cop,
-                   ['if ()',
-                    'end'])
+    inspect_source(cop, <<-END.strip_indent)
+      if ()
+      end
+    END
     expect(cop.offenses).to be_empty
   end
 
   it 'does not blow up for empty unless condition' do
-    inspect_source(cop,
-                   ['unless ()',
-                    'end'])
+    inspect_source(cop, <<-END.strip_indent)
+      unless ()
+      end
+    END
     expect(cop.offenses).to be_empty
   end
 
   context 'safe assignment is allowed' do
     it 'accepts variable assignment in condition surrounded with parentheses' do
-      inspect_source(cop,
-                     ['if (test = 10)',
-                      'end'])
+      inspect_source(cop, <<-END.strip_indent)
+        if (test = 10)
+        end
+      END
       expect(cop.offenses).to be_empty
     end
 
     it 'accepts element assignment in condition surrounded with parentheses' do
-      inspect_source(cop,
-                     ['if (test[0] = 10)',
-                      'end'])
+      inspect_source(cop, <<-END.strip_indent)
+        if (test[0] = 10)
+        end
+      END
       expect(cop.offenses).to be_empty
     end
 
     it 'accepts setter in condition surrounded with parentheses' do
-      inspect_source(cop,
-                     ['if (self.test = 10)',
-                      'end'])
+      inspect_source(cop, <<-END.strip_indent)
+        if (self.test = 10)
+        end
+      END
       expect(cop.offenses).to be_empty
     end
   end
@@ -147,17 +166,19 @@ describe RuboCop::Cop::Style::ParenthesesAroundCondition, :config do
 
     it 'does not accept variable assignment in condition surrounded with ' \
        'parentheses' do
-      inspect_source(cop,
-                     ['if (test = 10)',
-                      'end'])
+      inspect_source(cop, <<-END.strip_indent)
+        if (test = 10)
+        end
+      END
       expect(cop.offenses.size).to eq(1)
     end
 
     it 'does not accept element assignment in condition surrounded with ' \
        'parentheses' do
-      inspect_source(cop,
-                     ['if (test[0] = 10)',
-                      'end'])
+      inspect_source(cop, <<-END.strip_indent)
+        if (test[0] = 10)
+        end
+      END
       expect(cop.offenses.size).to eq(1)
     end
   end

--- a/spec/rubocop/cop/style/percent_literal_delimiters_spec.rb
+++ b/spec/rubocop/cop/style/percent_literal_delimiters_spec.rb
@@ -273,20 +273,24 @@ describe RuboCop::Cop::Style::PercentLiteralDelimiters, :config do
     end
 
     it 'fixes a string array in a scope' do
-      new_source = autocorrect_source(cop, ['module Foo',
-                                            '   class Bar',
-                                            '     def baz',
-                                            '       %(one two)',
-                                            '     end',
-                                            '   end',
-                                            ' end'])
-      expect(new_source).to eq(['module Foo',
-                                '   class Bar',
-                                '     def baz',
-                                '       %[one two]',
-                                '     end',
-                                '   end',
-                                ' end'].join("\n"))
+      new_source = autocorrect_source(cop, <<-END.strip_indent)
+        module Foo
+           class Bar
+             def baz
+               %(one two)
+             end
+           end
+         end
+      END
+      expect(new_source).to eq(<<-END.strip_indent)
+        module Foo
+           class Bar
+             def baz
+               %[one two]
+             end
+           end
+         end
+      END
     end
 
     it 'fixes a regular expression' do
@@ -314,43 +318,50 @@ describe RuboCop::Cop::Style::PercentLiteralDelimiters, :config do
     end
 
     it 'preserves line breaks when fixing a multiline array' do
-      new_source = autocorrect_source(cop, ['%w(', 'some', 'words', ')'])
-      expect(new_source).to eq(['%w[',
-                                'some',
-                                'words',
-                                ']'].join("\n"))
+      new_source = autocorrect_source(cop, <<-END.strip_indent)
+        %w(
+        some
+        words
+        )
+      END
+      expect(new_source).to eq(<<-END.strip_indent)
+        %w[
+        some
+        words
+        ]
+      END
     end
 
     it 'preserves indentation when correcting a multiline array' do
-      original_source = [
-        '  array = %w(',
-        '    first',
-        '    second',
-        '  )'
-      ]
-      corrected_source = [
-        '  array = %w[',
-        '    first',
-        '    second',
-        '  ]'
-      ].join("\n")
+      original_source = <<-END.strip_margin('|')
+        |  array = %w(
+        |    first
+        |    second
+        |  )
+      END
+      corrected_source = <<-END.strip_margin('|')
+        |  array = %w[
+        |    first
+        |    second
+        |  ]
+      END
       new_source = autocorrect_source(cop, original_source)
       expect(new_source).to eq(corrected_source)
     end
 
     it 'preserves irregular indentation when correcting a multiline array' do
-      original_source = [
-        '  array = %w(',
-        '    first',
-        '  second',
-        ')'
-      ]
-      corrected_source = [
-        '  array = %w[',
-        '    first',
-        '  second',
-        ']'
-      ].join("\n")
+      original_source = <<-END.strip_indent
+          array = %w(
+            first
+          second
+        )
+      END
+      corrected_source = <<-END.strip_indent
+          array = %w[
+            first
+          second
+        ]
+      END
       new_source = autocorrect_source(cop, original_source)
       expect(new_source).to eq(corrected_source)
     end

--- a/spec/rubocop/cop/style/predicate_name_spec.rb
+++ b/spec/rubocop/cop/style/predicate_name_spec.rb
@@ -11,9 +11,11 @@ describe RuboCop::Cop::Style::PredicateName, :config do
 
     %w[has is].each do |prefix|
       it 'registers an offense when method name starts with known prefix' do
-        inspect_source(cop, ["def #{prefix}_attr",
-                             '  # ...',
-                             'end'])
+        inspect_source(cop, <<-END.strip_indent)
+          def #{prefix}_attr
+            # ...
+          end
+        END
         expect(cop.offenses.size).to eq(1)
         expect(cop.messages).to eq(["Rename `#{prefix}_attr` to `attr?`."])
         expect(cop.highlights).to eq(["#{prefix}_attr"])
@@ -21,9 +23,11 @@ describe RuboCop::Cop::Style::PredicateName, :config do
     end
 
     it 'accepts method name that starts with unknown prefix' do
-      inspect_source(cop, ['def have_attr',
-                           '  # ...',
-                           'end'])
+      inspect_source(cop, <<-END.strip_indent)
+        def have_attr
+          # ...
+        end
+      END
       expect(cop.offenses).to be_empty
     end
   end
@@ -35,9 +39,11 @@ describe RuboCop::Cop::Style::PredicateName, :config do
 
     %w[has is].each do |prefix|
       it 'registers an offense when method name starts with known prefix' do
-        inspect_source(cop, ["def #{prefix}_attr",
-                             '  # ...',
-                             'end'])
+        inspect_source(cop, <<-END.strip_indent)
+          def #{prefix}_attr
+            # ...
+          end
+        END
         expect(cop.offenses.size).to eq(1)
         expect(cop.messages)
           .to eq(["Rename `#{prefix}_attr` to `#{prefix}_attr?`."])
@@ -46,9 +52,11 @@ describe RuboCop::Cop::Style::PredicateName, :config do
     end
 
     it 'accepts method name that starts with unknown prefix' do
-      inspect_source(cop, ['def have_attr',
-                           '  # ...',
-                           'end'])
+      inspect_source(cop, <<-END.strip_indent)
+        def have_attr
+          # ...
+        end
+      END
       expect(cop.offenses).to be_empty
     end
   end
@@ -60,9 +68,11 @@ describe RuboCop::Cop::Style::PredicateName, :config do
     end
 
     it 'accepts method name which is in whitelist' do
-      inspect_source(cop, ['def is_a?',
-                           '  # ...',
-                           'end'])
+      inspect_source(cop, <<-END.strip_indent)
+        def is_a?
+          # ...
+        end
+      END
       expect(cop.offenses).to be_empty
     end
   end

--- a/spec/rubocop/cop/style/raise_args_spec.rb
+++ b/spec/rubocop/cop/style/raise_args_spec.rb
@@ -22,11 +22,13 @@ describe RuboCop::Cop::Style::RaiseArgs, :config do
 
     context 'with correct + opposite' do
       it 'reports an offense' do
-        inspect_source(cop, ['if a',
-                             '  raise RuntimeError, msg',
-                             'else',
-                             '  raise Ex.new(msg)',
-                             'end'])
+        inspect_source(cop, <<-END.strip_indent)
+          if a
+            raise RuntimeError, msg
+          else
+            raise Ex.new(msg)
+          end
+        END
         expect(cop.offenses.size).to eq(1)
         expect(cop.messages)
           .to eq(['Provide an exception object as an argument to `raise`.'])
@@ -34,16 +36,20 @@ describe RuboCop::Cop::Style::RaiseArgs, :config do
       end
 
       it 'auto-corrects to compact style' do
-        new_source = autocorrect_source(cop, ['if a',
-                                              '  raise RuntimeError, msg',
-                                              'else',
-                                              '  raise Ex.new(msg)',
-                                              'end'])
-        expect(new_source).to eq(['if a',
-                                  '  raise RuntimeError.new(msg)',
-                                  'else',
-                                  '  raise Ex.new(msg)',
-                                  'end'].join("\n"))
+        new_source = autocorrect_source(cop, <<-END.strip_indent)
+          if a
+            raise RuntimeError, msg
+          else
+            raise Ex.new(msg)
+          end
+        END
+        expect(new_source).to eq(<<-END.strip_indent)
+          if a
+            raise RuntimeError.new(msg)
+          else
+            raise Ex.new(msg)
+          end
+        END
       end
     end
 
@@ -112,26 +118,32 @@ describe RuboCop::Cop::Style::RaiseArgs, :config do
 
     context 'with opposite + correct' do
       it 'reports an offense for opposite + correct' do
-        inspect_source(cop, ['if a',
-                             '  raise RuntimeError, msg',
-                             'else',
-                             '  raise Ex.new(msg)',
-                             'end'])
+        inspect_source(cop, <<-END.strip_indent)
+          if a
+            raise RuntimeError, msg
+          else
+            raise Ex.new(msg)
+          end
+        END
         expect(cop.offenses.size).to eq(1)
         expect(cop.config_to_allow_offenses).to eq('Enabled' => false)
       end
 
       it 'auto-corrects to exploded style' do
-        new_source = autocorrect_source(cop, ['if a',
-                                              '  raise RuntimeError, msg',
-                                              'else',
-                                              '  raise Ex.new(msg)',
-                                              'end'])
-        expect(new_source).to eq(['if a',
-                                  '  raise RuntimeError, msg',
-                                  'else',
-                                  '  raise Ex, msg',
-                                  'end'].join("\n"))
+        new_source = autocorrect_source(cop, <<-END.strip_indent)
+          if a
+            raise RuntimeError, msg
+          else
+            raise Ex.new(msg)
+          end
+        END
+        expect(new_source).to eq(<<-END.strip_indent)
+          if a
+            raise RuntimeError, msg
+          else
+            raise Ex, msg
+          end
+        END
       end
     end
 

--- a/spec/rubocop/cop/style/redundant_begin_spec.rb
+++ b/spec/rubocop/cop/style/redundant_begin_spec.rb
@@ -10,65 +10,75 @@ describe RuboCop::Cop::Style::RedundantBegin do
   end
 
   it 'reports an offense for def with redundant begin block' do
-    src = ['def func',
-           '  begin',
-           '    ala',
-           '  rescue => e',
-           '    bala',
-           '  end',
-           'end']
+    src = <<-END.strip_indent
+      def func
+        begin
+          ala
+        rescue => e
+          bala
+        end
+      end
+    END
     inspect_source(cop, src)
     expect(cop.offenses.size).to eq(1)
   end
 
   it 'reports an offense for defs with redundant begin block' do
-    src = ['def Test.func',
-           '  begin',
-           '    ala',
-           '  rescue => e',
-           '    bala',
-           '  end',
-           'end']
+    src = <<-END.strip_indent
+      def Test.func
+        begin
+          ala
+        rescue => e
+          bala
+        end
+      end
+    END
     inspect_source(cop, src)
     expect(cop.offenses.size).to eq(1)
   end
 
   it 'accepts a def with required begin block' do
-    src = ['def func',
-           '  begin',
-           '    ala',
-           '  rescue => e',
-           '    bala',
-           '  end',
-           '  something',
-           'end']
+    src = <<-END.strip_indent
+      def func
+        begin
+          ala
+        rescue => e
+          bala
+        end
+        something
+      end
+    END
     inspect_source(cop, src)
     expect(cop.offenses).to be_empty
   end
 
   it 'accepts a defs with required begin block' do
-    src = ['def Test.func',
-           '  begin',
-           '    ala',
-           '  rescue => e',
-           '    bala',
-           '  end',
-           '  something',
-           'end']
+    src = <<-END.strip_indent
+      def Test.func
+        begin
+          ala
+        rescue => e
+          bala
+        end
+        something
+      end
+    END
     inspect_source(cop, src)
     expect(cop.offenses).to be_empty
   end
 
   it 'auto-corrects source separated by newlines ' \
      'by removing redundant begin blocks' do
-    src = ['  def func',
-           '    begin',
-           '      foo',
-           '      bar',
-           '    rescue',
-           '      baz',
-           '    end',
-           '  end'].join("\n")
+    src = <<-END.strip_margin('|')
+      |  def func
+      |    begin
+      |      foo
+      |      bar
+      |    rescue
+      |      baz
+      |    end
+      |  end
+    END
     result_src = ['  def func',
                   '    ',
                   '      foo',
@@ -76,7 +86,8 @@ describe RuboCop::Cop::Style::RedundantBegin do
                   '    rescue',
                   '      baz',
                   '    ',
-                  '  end'].join("\n")
+                  '  end',
+                  ''].join("\n")
     new_source = autocorrect_source(cop, src)
     expect(new_source).to eq(result_src)
   end
@@ -90,20 +101,22 @@ describe RuboCop::Cop::Style::RedundantBegin do
   end
 
   it "doesn't modify spacing when auto-correcting" do
-    src = ['def method',
-           '  begin',
-           '    BlockA do |strategy|',
-           '      foo',
-           '    end',
-           '',
-           '    BlockB do |portfolio|',
-           '      foo',
-           '    end',
-           '',
-           '  rescue => e # some problem',
-           '    bar',
-           '  end',
-           'end']
+    src = <<-END.strip_indent
+      def method
+        begin
+          BlockA do |strategy|
+            foo
+          end
+
+          BlockB do |portfolio|
+            foo
+          end
+
+        rescue => e # some problem
+          bar
+        end
+      end
+    END
 
     result_src = ['def method',
                   '  ',
@@ -118,24 +131,29 @@ describe RuboCop::Cop::Style::RedundantBegin do
                   '  rescue => e # some problem',
                   '    bar',
                   '  ',
-                  'end'].join("\n")
+                  'end',
+                  ''].join("\n")
     new_source = autocorrect_source(cop, src)
     expect(new_source).to eq(result_src)
   end
 
   it 'auto-corrects when there are trailing comments' do
-    src = ['def method',
-           '  begin # comment 1',
-           '    do_some_stuff',
-           '  rescue # comment 2',
-           '  end # comment 3',
-           'end']
-    result_src = ['def method',
-                  '   # comment 1',
-                  '    do_some_stuff',
-                  '  rescue # comment 2',
-                  '   # comment 3',
-                  'end'].join("\n")
+    src = <<-END.strip_indent
+      def method
+        begin # comment 1
+          do_some_stuff
+        rescue # comment 2
+        end # comment 3
+      end
+    END
+    result_src = <<-END.strip_indent
+      def method
+         # comment 1
+          do_some_stuff
+        rescue # comment 2
+         # comment 3
+      end
+    END
     new_source = autocorrect_source(cop, src)
     expect(new_source).to eq(result_src)
   end

--- a/spec/rubocop/cop/style/redundant_parentheses_spec.rb
+++ b/spec/rubocop/cop/style/redundant_parentheses_spec.rb
@@ -239,18 +239,22 @@ describe RuboCop::Cop::Style::RedundantParentheses do
   end
 
   it 'accepts parentheses around the error passed to rescue' do
-    inspect_source(cop, ['begin',
-                         '  some_method',
-                         'rescue(StandardError)',
-                         'end'])
+    inspect_source(cop, <<-END.strip_indent)
+      begin
+        some_method
+      rescue(StandardError)
+      end
+    END
     expect(cop.offenses).to be_empty
   end
 
   it 'accepts parentheses around a constant passed to when' do
-    source = ['case foo',
-              'when(Const)',
-              '  bar',
-              'end']
+    source = <<-END.strip_indent
+      case foo
+      when(Const)
+        bar
+      end
+    END
 
     inspect_source(cop, source)
 

--- a/spec/rubocop/cop/style/redundant_return_spec.rb
+++ b/spec/rubocop/cop/style/redundant_return_spec.rb
@@ -5,78 +5,96 @@ describe RuboCop::Cop::Style::RedundantReturn, :config do
   let(:cop_config) { { 'AllowMultipleReturnValues' => false } }
 
   it 'reports an offense for def with only a return' do
-    src = ['def func',
-           '  return something',
-           'end']
+    src = <<-END.strip_indent
+      def func
+        return something
+      end
+    END
     inspect_source(cop, src)
     expect(cop.offenses.size).to eq(1)
   end
 
   it 'reports an offense for defs with only a return' do
-    src = ['def Test.func',
-           '  return something',
-           'end']
+    src = <<-END.strip_indent
+      def Test.func
+        return something
+      end
+    END
     inspect_source(cop, src)
     expect(cop.offenses.size).to eq(1)
   end
 
   it 'reports an offense for def ending with return' do
-    src = ['def func',
-           '  one',
-           '  two',
-           '  return something',
-           'end']
+    src = <<-END.strip_indent
+      def func
+        one
+        two
+        return something
+      end
+    END
     inspect_source(cop, src)
     expect(cop.offenses.size).to eq(1)
   end
 
   it 'reports an offense for defs ending with return' do
-    src = ['def self.func',
-           '  one',
-           '  two',
-           '  return something',
-           'end']
+    src = <<-END.strip_indent
+      def self.func
+        one
+        two
+        return something
+      end
+    END
     inspect_source(cop, src)
     expect(cop.offenses.size).to eq(1)
   end
 
   it 'accepts return in a non-final position' do
-    src = ['def func',
-           '  return something if something_else',
-           'end']
+    src = <<-END.strip_indent
+      def func
+        return something if something_else
+      end
+    END
     inspect_source(cop, src)
     expect(cop.offenses).to be_empty
   end
 
   it 'does not blow up on empty method body' do
-    src = ['def func',
-           'end']
+    src = <<-END.strip_indent
+      def func
+      end
+    END
     inspect_source(cop, src)
     expect(cop.offenses).to be_empty
   end
 
   it 'does not blow up on empty if body' do
-    src = ['def func',
-           '  if x',
-           '  elsif y',
-           '  else',
-           '  end',
-           'end']
+    src = <<-END.strip_indent
+      def func
+        if x
+        elsif y
+        else
+        end
+      end
+    END
     inspect_source(cop, src)
     expect(cop.offenses).to be_empty
   end
 
   it 'auto-corrects by removing redundant returns' do
-    src = ['def func',
-           '  one',
-           '  two',
-           '  return something',
-           'end'].join("\n")
-    result_src = ['def func',
-                  '  one',
-                  '  two',
-                  '  something',
-                  'end'].join("\n")
+    src = <<-END.strip_indent
+      def func
+        one
+        two
+        return something
+      end
+    END
+    result_src = <<-END.strip_indent
+      def func
+        one
+        two
+        something
+      end
+    END
     new_source = autocorrect_source(cop, src)
     expect(new_source).to eq(result_src)
   end
@@ -84,12 +102,14 @@ describe RuboCop::Cop::Style::RedundantReturn, :config do
   context 'when return has no arguments' do
     shared_examples 'common behavior' do |ret|
       let(:src) do
-        ['def func',
-         '  one',
-         '  two',
-         "  #{ret}",
-         '  # comment',
-         'end']
+        <<-END.strip_indent
+          def func
+            one
+            two
+            #{ret}
+            # comment
+          end
+        END
       end
 
       it "registers an offense for #{ret}" do
@@ -99,12 +119,14 @@ describe RuboCop::Cop::Style::RedundantReturn, :config do
 
       it "auto-corrects by replacing #{ret} with nil" do
         new_source = autocorrect_source(cop, src)
-        expect(new_source).to eq(['def func',
-                                  '  one',
-                                  '  two',
-                                  '  nil',
-                                  '  # comment',
-                                  'end'].join("\n"))
+        expect(new_source).to eq(<<-END.strip_indent)
+          def func
+            one
+            two
+            nil
+            # comment
+          end
+        END
       end
     end
 
@@ -114,70 +136,93 @@ describe RuboCop::Cop::Style::RedundantReturn, :config do
 
   context 'when multi-value returns are not allowed' do
     it 'reports an offense for def with only a return' do
-      src = ['def func',
-             '  return something, test',
-             'end']
+      src = <<-END.strip_indent
+        def func
+          return something, test
+        end
+      END
       inspect_source(cop, src)
       expect(cop.offenses.size).to eq(1)
     end
 
     it 'reports an offense for defs with only a return' do
-      src = ['def Test.func',
-             '  return something, test',
-             'end']
+      src = <<-END.strip_indent
+        def Test.func
+          return something, test
+        end
+      END
       inspect_source(cop, src)
       expect(cop.offenses.size).to eq(1)
     end
 
     it 'reports an offense for def ending with return' do
-      src = ['def func',
-             '  one',
-             '  two',
-             '  return something, test',
-             'end']
+      src = <<-END.strip_indent
+        def func
+          one
+          two
+          return something, test
+        end
+      END
       inspect_source(cop, src)
       expect(cop.offenses.size).to eq(1)
     end
 
     it 'reports an offense for defs ending with return' do
-      src = ['def self.func',
-             '  one',
-             '  two',
-             '  return something, test',
-             'end']
+      src = <<-END.strip_indent
+        def self.func
+          one
+          two
+          return something, test
+        end
+      END
       inspect_source(cop, src)
       expect(cop.offenses.size).to eq(1)
     end
 
     it 'auto-corrects by making implicit arrays explicit' do
-      src = ['def func',
-             '  return  1, 2',
-             'end'].join("\n")
-      result_src = ['def func',
-                    '  [1, 2]', # Just 1, 2 is not valid Ruby.
-                    'end'].join("\n")
+      src = <<-END.strip_indent
+        def func
+          return  1, 2
+        end
+      END
+      # Just 1, 2 is not valid Ruby.
+      result_src = <<-END.strip_indent
+        def func
+          [1, 2]
+        end
+      END
       new_source = autocorrect_source(cop, src)
       expect(new_source).to eq(result_src)
     end
 
     it 'auto-corrects removes return when using an explicit hash' do
-      src = ['def func',
-             '  return {:a => 1, :b => 2}',
-             'end'].join("\n")
-      result_src = ['def func',
-                    '  {:a => 1, :b => 2}', # :a => 1, :b => 2 is not valid Ruby
-                    'end'].join("\n")
+      src = <<-END.strip_indent
+        def func
+          return {:a => 1, :b => 2}
+        end
+      END
+      # :a => 1, :b => 2 is not valid Ruby
+      result_src = <<-END.strip_indent
+        def func
+          {:a => 1, :b => 2}
+        end
+      END
       new_source = autocorrect_source(cop, src)
       expect(new_source).to eq(result_src)
     end
 
     it 'auto-corrects by making an implicit hash explicit' do
-      src = ['def func',
-             '  return :a => 1, :b => 2',
-             'end'].join("\n")
-      result_src = ['def func',
-                    '  {:a => 1, :b => 2}', # :a => 1, :b => 2 is not valid Ruby
-                    'end'].join("\n")
+      src = <<-END.strip_indent
+        def func
+          return :a => 1, :b => 2
+        end
+      END
+      # :a => 1, :b => 2 is not valid Ruby
+      result_src = <<-END.strip_indent
+        def func
+          {:a => 1, :b => 2}
+        end
+      END
       new_source = autocorrect_source(cop, src)
       expect(new_source).to eq(result_src)
     end
@@ -187,45 +232,55 @@ describe RuboCop::Cop::Style::RedundantReturn, :config do
     let(:cop_config) { { 'AllowMultipleReturnValues' => true } }
 
     it 'accepts def with only a return' do
-      src = ['def func',
-             '  return something, test',
-             'end']
+      src = <<-END.strip_indent
+        def func
+          return something, test
+        end
+      END
       inspect_source(cop, src)
       expect(cop.offenses).to be_empty
     end
 
     it 'accepts defs with only a return' do
-      src = ['def Test.func',
-             '  return something, test',
-             'end']
+      src = <<-END.strip_indent
+        def Test.func
+          return something, test
+        end
+      END
       inspect_source(cop, src)
       expect(cop.offenses).to be_empty
     end
 
     it 'accepts def ending with return' do
-      src = ['def func',
-             '  one',
-             '  two',
-             '  return something, test',
-             'end']
+      src = <<-END.strip_indent
+        def func
+          one
+          two
+          return something, test
+        end
+      END
       inspect_source(cop, src)
       expect(cop.offenses).to be_empty
     end
 
     it 'accepts defs ending with return' do
-      src = ['def self.func',
-             '  one',
-             '  two',
-             '  return something, test',
-             'end']
+      src = <<-END.strip_indent
+        def self.func
+          one
+          two
+          return something, test
+        end
+      END
       inspect_source(cop, src)
       expect(cop.offenses).to be_empty
     end
 
     it 'does not auto-correct' do
-      src = ['def func',
-             '  return  1, 2',
-             'end'].join("\n")
+      src = <<-END.strip_indent
+        def func
+          return  1, 2
+        end
+      END
       new_source = autocorrect_source(cop, src)
       expect(new_source).to eq(src)
     end
@@ -233,15 +288,17 @@ describe RuboCop::Cop::Style::RedundantReturn, :config do
 
   context 'when return is inside an if-branch' do
     let(:src) do
-      ['def func',
-       '  if x',
-       '    return 1',
-       '  elsif y',
-       '    return 2',
-       '  else',
-       '    return 3',
-       '  end',
-       'end']
+      <<-END.strip_indent
+        def func
+          if x
+            return 1
+          elsif y
+            return 2
+          else
+            return 3
+          end
+        end
+      END
     end
 
     it 'registers an offense' do
@@ -251,29 +308,33 @@ describe RuboCop::Cop::Style::RedundantReturn, :config do
 
     it 'auto-corrects' do
       corrected = autocorrect_source(cop, src)
-      expect(corrected).to eq ['def func',
-                               '  if x',
-                               '    1',
-                               '  elsif y',
-                               '    2',
-                               '  else',
-                               '    3',
-                               '  end',
-                               'end'].join("\n")
+      expect(corrected).to eq <<-END.strip_indent
+        def func
+          if x
+            1
+          elsif y
+            2
+          else
+            3
+          end
+        end
+      END
     end
   end
 
   context 'when return is inside a when-branch' do
     let(:src) do
-      ['def func',
-       '  case x',
-       '  when y then return 1',
-       '  when z then return 2',
-       '  when q',
-       '  else',
-       '    return 3',
-       '  end',
-       'end']
+      <<-END.strip_indent
+        def func
+          case x
+          when y then return 1
+          when z then return 2
+          when q
+          else
+            return 3
+          end
+        end
+      END
     end
 
     it 'registers an offense' do
@@ -283,28 +344,32 @@ describe RuboCop::Cop::Style::RedundantReturn, :config do
 
     it 'auto-corrects' do
       corrected = autocorrect_source(cop, src)
-      expect(corrected).to eq ['def func',
-                               '  case x',
-                               '  when y then 1',
-                               '  when z then 2',
-                               '  when q',
-                               '  else',
-                               '    3',
-                               '  end',
-                               'end'].join("\n")
+      expect(corrected).to eq <<-END.strip_indent
+        def func
+          case x
+          when y then 1
+          when z then 2
+          when q
+          else
+            3
+          end
+        end
+      END
     end
   end
 
   context 'when case nodes are empty' do
     let(:src) do
-      ['def func',
-       '  case x',
-       '  when y then 1',
-       '  when z # do nothing',
-       '  else',
-       '    3',
-       '  end',
-       'end']
+      <<-END.strip_indent
+        def func
+          case x
+          when y then 1
+          when z # do nothing
+          else
+            3
+          end
+        end
+      END
     end
 
     it 'accepts empty when nodes' do

--- a/spec/rubocop/cop/style/redundant_self_spec.rb
+++ b/spec/rubocop/cop/style/redundant_self_spec.rb
@@ -58,97 +58,111 @@ describe RuboCop::Cop::Style::RedundantSelf do
   end
 
   it 'accepts a self receiver for methods named like ruby keywords' do
-    src = ['a = self.class',
-           'self.for(deps, [], true)',
-           'self.and(other)',
-           'self.or(other)',
-           'self.alias',
-           'self.begin',
-           'self.break',
-           'self.case',
-           'self.def',
-           'self.defined?',
-           'self.do',
-           'self.else',
-           'self.elsif',
-           'self.end',
-           'self.ensure',
-           'self.false',
-           'self.if',
-           'self.in',
-           'self.module',
-           'self.next',
-           'self.nil',
-           'self.not',
-           'self.redo',
-           'self.rescue',
-           'self.retry',
-           'self.return',
-           'self.self',
-           'self.super',
-           'self.then',
-           'self.true',
-           'self.undef',
-           'self.unless',
-           'self.until',
-           'self.when',
-           'self.while',
-           'self.yield']
+    src = <<-END.strip_indent
+      a = self.class
+      self.for(deps, [], true)
+      self.and(other)
+      self.or(other)
+      self.alias
+      self.begin
+      self.break
+      self.case
+      self.def
+      self.defined?
+      self.do
+      self.else
+      self.elsif
+      self.end
+      self.ensure
+      self.false
+      self.if
+      self.in
+      self.module
+      self.next
+      self.nil
+      self.not
+      self.redo
+      self.rescue
+      self.retry
+      self.return
+      self.self
+      self.super
+      self.then
+      self.true
+      self.undef
+      self.unless
+      self.until
+      self.when
+      self.while
+      self.yield
+    END
     inspect_source(cop, src)
     expect(cop.offenses).to be_empty
   end
 
   describe 'instance methods' do
     it 'accepts a self receiver used to distinguish from blockarg' do
-      src = ['def requested_specs(&groups)',
-             '  some_method(self.groups)',
-             'end']
+      src = <<-END.strip_indent
+        def requested_specs(&groups)
+          some_method(self.groups)
+        end
+      END
       inspect_source(cop, src)
       expect(cop.offenses).to be_empty
     end
 
     it 'accepts a self receiver used to distinguish from argument' do
-      src = ['def requested_specs(groups)',
-             '  some_method(self.groups)',
-             'end']
+      src = <<-END.strip_indent
+        def requested_specs(groups)
+          some_method(self.groups)
+        end
+      END
       inspect_source(cop, src)
       expect(cop.offenses).to be_empty
     end
 
     it 'accepts a self receiver used to distinguish from optional argument' do
-      src = ['def requested_specs(final = true)',
-             '  something if self.final != final',
-             'end']
+      src = <<-END.strip_indent
+        def requested_specs(final = true)
+          something if self.final != final
+        end
+      END
       inspect_source(cop, src)
       expect(cop.offenses).to be_empty
     end
 
     it 'accepts a self receiver used to distinguish from local variable' do
-      src = ['def requested_specs',
-             '  @requested_specs ||= begin',
-             '    groups = self.groups - Bundler.settings.without',
-             '    groups.map! { |g| g.to_sym }',
-             '    specs_for(groups)',
-             '  end',
-             'end']
+      src = <<-END.strip_indent
+        def requested_specs
+          @requested_specs ||= begin
+            groups = self.groups - Bundler.settings.without
+            groups.map! { |g| g.to_sym }
+            specs_for(groups)
+          end
+        end
+      END
       inspect_source(cop, src)
       expect(cop.offenses).to be_empty
     end
 
     it 'accepts a self receiver used to distinguish from an argument' do
-      src = ['def foo(bar)',
-             '  puts bar, self.bar',
-             'end']
+      src = <<-END.strip_indent
+        def foo(bar)
+          puts bar, self.bar
+        end
+      END
       inspect_source(cop, src)
       expect(cop.offenses).to be_empty
     end
 
     it 'accepts a self receiver used to distinguish from an argument' \
       ' when an inner method is defined' do
-      src = ['def foo(bar)',
-             '  def inner_method(); end',
-             '  puts bar, self.bar',
-             'end']
+      src = <<-END.strip_indent
+        def foo(bar)
+          def inner_method(); end
+          puts bar, self.bar
+        end
+      END
       inspect_source(cop, src)
       expect(cop.offenses).to be_empty
     end
@@ -156,37 +170,45 @@ describe RuboCop::Cop::Style::RedundantSelf do
 
   describe 'class methods' do
     it 'accepts a self receiver used to distinguish from blockarg' do
-      src = ['def self.requested_specs(&groups)',
-             '  some_method(self.groups)',
-             'end']
+      src = <<-END.strip_indent
+        def self.requested_specs(&groups)
+          some_method(self.groups)
+        end
+      END
       inspect_source(cop, src)
       expect(cop.offenses).to be_empty
     end
 
     it 'accepts a self receiver used to distinguish from argument' do
-      src = ['def self.requested_specs(groups)',
-             '  some_method(self.groups)',
-             'end']
+      src = <<-END.strip_indent
+        def self.requested_specs(groups)
+          some_method(self.groups)
+        end
+      END
       inspect_source(cop, src)
       expect(cop.offenses).to be_empty
     end
 
     it 'accepts a self receiver used to distinguish from optional argument' do
-      src = ['def self.requested_specs(final = true)',
-             '  something if self.final != final',
-             'end']
+      src = <<-END.strip_indent
+        def self.requested_specs(final = true)
+          something if self.final != final
+        end
+      END
       inspect_source(cop, src)
       expect(cop.offenses).to be_empty
     end
 
     it 'accepts a self receiver used to distinguish from local variable' do
-      src = ['def self.requested_specs',
-             '  @requested_specs ||= begin',
-             '    groups = self.groups - Bundler.settings.without',
-             '    groups.map! { |g| g.to_sym }',
-             '    specs_for(groups)',
-             '  end',
-             'end']
+      src = <<-END.strip_indent
+        def self.requested_specs
+          @requested_specs ||= begin
+            groups = self.groups - Bundler.settings.without
+            groups.map! { |g| g.to_sym }
+            specs_for(groups)
+          end
+        end
+      END
       inspect_source(cop, src)
       expect(cop.offenses).to be_empty
     end

--- a/spec/rubocop/cop/style/rescue_ensure_alignment_spec.rb
+++ b/spec/rubocop/cop/style/rescue_ensure_alignment_spec.rb
@@ -6,51 +6,61 @@ describe RuboCop::Cop::Style::RescueEnsureAlignment do
   shared_examples 'common behavior' do |keyword|
     context 'bad alignment' do
       it 'registers an offense when used with begin' do
-        inspect_source(cop, ['begin',
-                             '  something',
-                             "    #{keyword}",
-                             '    error',
-                             'end'])
+        inspect_source(cop, <<-END.strip_indent)
+          begin
+            something
+              #{keyword}
+              error
+          end
+        END
         expect(cop.messages).to eq(["`#{keyword}` at 3, 4 is not aligned with" \
                                     ' `end` at 5, 0.'])
       end
 
       it 'registers an offense when used with def' do
-        inspect_source(cop, ['def test',
-                             '  something',
-                             "    #{keyword}",
-                             '    error',
-                             'end'])
+        inspect_source(cop, <<-END.strip_indent)
+          def test
+            something
+              #{keyword}
+              error
+          end
+        END
         expect(cop.messages).to eq(["`#{keyword}` at 3, 4 is not aligned with" \
                                     ' `end` at 5, 0.'])
       end
 
       it 'registers an offense when used with defs' do
-        inspect_source(cop, ['def Test.test',
-                             '  something',
-                             "    #{keyword}",
-                             '    error',
-                             'end'])
+        inspect_source(cop, <<-END.strip_indent)
+          def Test.test
+            something
+              #{keyword}
+              error
+          end
+        END
         expect(cop.messages).to eq(["`#{keyword}` at 3, 4 is not aligned with" \
                                     ' `end` at 5, 0.'])
       end
 
       it 'registers an offense when used with class' do
-        inspect_source(cop, ['class C',
-                             '  something',
-                             "    #{keyword}",
-                             '    error',
-                             'end'])
+        inspect_source(cop, <<-END.strip_indent)
+          class C
+            something
+              #{keyword}
+              error
+          end
+        END
         expect(cop.messages).to eq(["`#{keyword}` at 3, 4 is not aligned with" \
                                     ' `end` at 5, 0.'])
       end
 
       it 'registers an offense when used with module' do
-        inspect_source(cop, ['module M',
-                             '  something',
-                             "    #{keyword}",
-                             '    error',
-                             'end'])
+        inspect_source(cop, <<-END.strip_indent)
+          module M
+            something
+              #{keyword}
+              error
+          end
+        END
         expect(cop.messages).to eq(["`#{keyword}` at 3, 4 is not aligned with" \
                                     ' `end` at 5, 0.'])
       end
@@ -62,16 +72,20 @@ describe RuboCop::Cop::Style::RescueEnsureAlignment do
       end
 
       it 'auto-corrects' do
-        corrected = autocorrect_source(cop, ['begin',
-                                             '  something',
-                                             "    #{keyword}",
-                                             '    error',
-                                             'end'])
-        expect(corrected).to eq ['begin',
-                                 '  something',
-                                 keyword,
-                                 '    error',
-                                 'end'].join("\n")
+        corrected = autocorrect_source(cop, <<-END.strip_indent)
+          begin
+            something
+              #{keyword}
+              error
+          end
+        END
+        expect(corrected).to eq(<<-END.strip_indent)
+          begin
+            something
+          #{keyword}
+              error
+          end
+        END
       end
     end
 
@@ -108,11 +122,13 @@ describe RuboCop::Cop::Style::RescueEnsureAlignment do
     subject(:cop) { described_class.new(config) }
 
     it 'processes excluded files with issue' do
-      inspect_source_file(cop, ['begin',
-                                '  foo',
-                                'rescue',
-                                '  bar',
-                                'end'])
+      inspect_source_file(cop, <<-END.strip_indent)
+        begin
+          foo
+        rescue
+          bar
+        end
+      END
 
       expect(cop.messages).to be_empty
     end

--- a/spec/rubocop/cop/style/rescue_modifier_spec.rb
+++ b/spec/rubocop/cop/style/rescue_modifier_spec.rb
@@ -33,12 +33,13 @@ describe RuboCop::Cop::Style::RescueModifier do
   end
 
   it 'handles modifier rescue in normal rescue' do
-    inspect_source(cop,
-                   ['begin',
-                    '  test rescue modifier_handle',
-                    'rescue',
-                    '  normal_handle',
-                    'end'])
+    inspect_source(cop, <<-END.strip_indent)
+      begin
+        test rescue modifier_handle
+      rescue
+        normal_handle
+      end
+    END
 
     expect(cop.offenses.size).to eq(1)
     expect(cop.offenses.first.line).to eq(2)
@@ -46,68 +47,74 @@ describe RuboCop::Cop::Style::RescueModifier do
   end
 
   it 'handles modifier rescue in a method' do
-    inspect_source(cop,
-                   ['def a_method',
-                    '  test rescue nil',
-                    'end'])
+    inspect_source(cop, <<-END.strip_indent)
+      def a_method
+        test rescue nil
+      end
+    END
     expect(cop.offenses.size).to eq(1)
     expect(cop.offenses.first.line).to eq(2)
   end
 
   it 'does not register an offense for normal rescue' do
-    inspect_source(cop,
-                   ['begin',
-                    '  test',
-                    'rescue',
-                    '  handle',
-                    'end'])
+    inspect_source(cop, <<-END.strip_indent)
+      begin
+        test
+      rescue
+        handle
+      end
+    END
     expect(cop.offenses).to be_empty
   end
 
   it 'does not register an offense for normal rescue with ensure' do
-    inspect_source(cop,
-                   ['begin',
-                    '  test',
-                    'rescue',
-                    '  handle',
-                    'ensure',
-                    '  cleanup',
-                    'end'])
+    inspect_source(cop, <<-END.strip_indent)
+      begin
+        test
+      rescue
+        handle
+      ensure
+        cleanup
+      end
+    END
     expect(cop.offenses).to be_empty
   end
 
   it 'does not register an offense for nested normal rescue' do
-    inspect_source(cop,
-                   ['begin',
-                    '  begin',
-                    '    test',
-                    '  rescue',
-                    '    handle_inner',
-                    '  end',
-                    'rescue',
-                    '  handle_outer',
-                    'end'])
+    inspect_source(cop, <<-END.strip_indent)
+      begin
+        begin
+          test
+        rescue
+          handle_inner
+        end
+      rescue
+        handle_outer
+      end
+    END
     expect(cop.offenses).to be_empty
   end
 
   context 'when an instance method has implicit begin' do
     it 'accepts normal rescue' do
-      inspect_source(cop,
-                     ['def some_method',
-                      '  test',
-                      'rescue',
-                      '  handle',
-                      'end'])
+      inspect_source(cop, <<-END.strip_indent)
+        def some_method
+          test
+        rescue
+          handle
+        end
+      END
       expect(cop.offenses).to be_empty
     end
 
     it 'handles modifier rescue in body of implicit begin' do
-      inspect_source(cop,
-                     ['def some_method',
-                      '  test rescue modifier_handle',
-                      'rescue',
-                      '  normal_handle',
-                      'end'])
+      inspect_source(cop, <<-END.strip_indent)
+        def some_method
+          test rescue modifier_handle
+        rescue
+          normal_handle
+        end
+      END
       expect(cop.offenses.size).to eq(1)
       expect(cop.offenses.first.line).to eq(2)
       expect(cop.highlights).to eq(['test rescue modifier_handle'])
@@ -116,22 +123,24 @@ describe RuboCop::Cop::Style::RescueModifier do
 
   context 'when a singleton method has implicit begin' do
     it 'accepts normal rescue' do
-      inspect_source(cop,
-                     ['def self.some_method',
-                      '  test',
-                      'rescue',
-                      '  handle',
-                      'end'])
+      inspect_source(cop, <<-END.strip_indent)
+        def self.some_method
+          test
+        rescue
+          handle
+        end
+      END
       expect(cop.offenses).to be_empty
     end
 
     it 'handles modifier rescue in body of implicit begin' do
-      inspect_source(cop,
-                     ['def self.some_method',
-                      '  test rescue modifier_handle',
-                      'rescue',
-                      '  normal_handle',
-                      'end'])
+      inspect_source(cop, <<-END.strip_indent)
+        def self.some_method
+          test rescue modifier_handle
+        rescue
+          normal_handle
+        end
+      END
       expect(cop.offenses.size).to eq(1)
       expect(cop.offenses.first.line).to eq(2)
       expect(cop.highlights).to eq(['test rescue modifier_handle'])
@@ -140,74 +149,94 @@ describe RuboCop::Cop::Style::RescueModifier do
 
   context 'autocorrect' do
     it 'corrects basic rescue modifier' do
-      new_source = autocorrect_source(cop, 'foo rescue bar')
+      new_source = autocorrect_source(cop, <<-END.strip_indent)
+        foo rescue bar
+      END
 
-      expect(new_source).to eq(['begin',
-                                '  foo',
-                                'rescue',
-                                '  bar',
-                                'end'].join("\n"))
+      expect(new_source).to eq(<<-END.strip_indent)
+        begin
+          foo
+        rescue
+          bar
+        end
+      END
     end
 
     it 'corrects complex rescue modifier' do
-      new_source = autocorrect_source(cop, 'foo || bar rescue bar')
+      new_source = autocorrect_source(cop, <<-END.strip_indent)
+        foo || bar rescue bar
+      END
 
-      expect(new_source).to eq(['begin',
-                                '  foo || bar',
-                                'rescue',
-                                '  bar',
-                                'end'].join("\n"))
+      expect(new_source).to eq(<<-END.strip_indent)
+        begin
+          foo || bar
+        rescue
+          bar
+        end
+      END
     end
 
     it 'corrects rescue modifier nested inside of def' do
-      source = ['def foo',
-                '  test rescue modifier_handle',
-                'end'].join("\n")
+      source = <<-END.strip_indent
+        def foo
+          test rescue modifier_handle
+        end
+      END
       new_source = autocorrect_source(cop, source)
 
-      expect(new_source).to eq(['def foo',
-                                '  begin',
-                                '    test',
-                                '  rescue',
-                                '    modifier_handle',
-                                '  end',
-                                'end'].join("\n"))
+      expect(new_source).to eq(<<-END.strip_indent)
+        def foo
+          begin
+            test
+          rescue
+            modifier_handle
+          end
+        end
+      END
     end
 
     it 'corrects nested rescue modifier' do
-      source = ['begin',
-                '  test rescue modifier_handle',
-                'rescue',
-                '  normal_handle',
-                'end'].join("\n")
+      source = <<-END.strip_indent
+        begin
+          test rescue modifier_handle
+        rescue
+          normal_handle
+        end
+      END
       new_source = autocorrect_source(cop, source)
 
-      expect(new_source).to eq(['begin',
-                                '  begin',
-                                '    test',
-                                '  rescue',
-                                '    modifier_handle',
-                                '  end',
-                                'rescue',
-                                '  normal_handle',
-                                'end'].join("\n"))
+      expect(new_source).to eq(<<-END.strip_indent)
+        begin
+          begin
+            test
+          rescue
+            modifier_handle
+          end
+        rescue
+          normal_handle
+        end
+      END
     end
 
     it 'corrects doubled rescue modifiers' do
-      source = 'blah rescue 1 rescue 2'
-      new_source = autocorrect_source(cop, source)
+      new_source = autocorrect_source(cop, <<-END.strip_indent)
+        blah rescue 1 rescue 2
+      END
+
       # Another round of autocorrection is needed
       new_source = autocorrect_source(described_class.new(config), new_source)
 
-      expect(new_source).to eq(['begin',
-                                '  begin',
-                                '    blah',
-                                '  rescue',
-                                '    1',
-                                '  end',
-                                'rescue',
-                                '  2',
-                                'end'].join("\n"))
+      expect(new_source).to eq(<<-END.strip_indent)
+        begin
+          begin
+            blah
+          rescue
+            1
+          end
+        rescue
+          2
+        end
+      END
     end
   end
 

--- a/spec/rubocop/cop/style/safe_navigation_spec.rb
+++ b/spec/rubocop/cop/style/safe_navigation_spec.rb
@@ -39,11 +39,13 @@ describe RuboCop::Cop::Style::SafeNavigation, :config do
 
     it 'allows object checks in the condition of an elsif statement ' \
       'and a method call on that object in the body' do
-      inspect_source(cop, ['if foo',
-                           '  something',
-                           'elsif bar',
-                           '  bar.baz',
-                           'end'])
+      inspect_source(cop, <<-END.strip_indent)
+        if foo
+          something
+        elsif bar
+          bar.baz
+        end
+      END
 
       expect(cop.offenses).to be_empty
     end
@@ -185,47 +187,57 @@ describe RuboCop::Cop::Style::SafeNavigation, :config do
       context 'if expression' do
         it 'registers an offense for a single method call inside of a check ' \
           'for the object' do
-          inspect_source(cop, ["if #{variable}",
-                               "  #{variable}.bar",
-                               'end'])
+          inspect_source(cop, <<-END.strip_indent)
+            if #{variable}
+              #{variable}.bar
+            end
+          END
 
           expect(cop.messages).to eq([described_class::MSG])
         end
 
         it 'registers an offense for a single method call inside of a ' \
           'non-nil check for the object' do
-          inspect_source(cop, ["if !#{variable}.nil?",
-                               "  #{variable}.bar",
-                               'end'])
+          inspect_source(cop, <<-END.strip_indent)
+            if !#{variable}.nil?
+              #{variable}.bar
+            end
+          END
 
           expect(cop.messages).to eq([described_class::MSG])
         end
 
         it 'registers an offense for a single method call inside of an ' \
           'unless nil check for the object' do
-          inspect_source(cop, ["unless #{variable}.nil?",
-                               "  #{variable}.bar",
-                               'end'])
+          inspect_source(cop, <<-END.strip_indent)
+            unless #{variable}.nil?
+              #{variable}.bar
+            end
+          END
 
           expect(cop.messages).to eq([described_class::MSG])
         end
 
         it 'registers an offense for a single method call inside of an ' \
           'unless negative check for the object' do
-          inspect_source(cop, ["unless !#{variable}",
-                               "  #{variable}.bar",
-                               'end'])
+          inspect_source(cop, <<-END.strip_indent)
+            unless !#{variable}
+              #{variable}.bar
+            end
+          END
 
           expect(cop.messages).to eq([described_class::MSG])
         end
 
         it 'accepts a single method call inside of a check for the object ' \
            'with an else' do
-          inspect_source(cop, ["if #{variable}",
-                               "  #{variable}.bar",
-                               'else',
-                               '  something',
-                               'end'])
+          inspect_source(cop, <<-END.strip_indent)
+            if #{variable}
+              #{variable}.bar
+            else
+              something
+            end
+          END
 
           expect(cop.offenses).to be_empty
         end
@@ -308,9 +320,11 @@ describe RuboCop::Cop::Style::SafeNavigation, :config do
 
           it 'registers an offense for a check for the object followed by a ' \
             'method call in the condition for an if expression' do
-            inspect_source(cop, ["if #{variable} && #{variable}.bar",
-                                 '  something',
-                                 'end'])
+            inspect_source(cop, <<-END.strip_indent)
+              if #{variable} && #{variable}.bar
+                something
+              end
+            END
 
             expect(cop.messages).to eq([described_class::MSG])
           end
@@ -381,9 +395,11 @@ describe RuboCop::Cop::Style::SafeNavigation, :config do
 
           it 'registers an offense for a check for the object followed by a ' \
             'method call in the condition for an if expression' do
-            inspect_source(cop, ["if #{variable} && #{variable}.bar",
-                                 '  something',
-                                 'end'])
+            inspect_source(cop, <<-END.strip_indent)
+              if #{variable} && #{variable}.bar
+                something
+              end
+            END
 
             expect(cop.offenses).to be_empty
           end
@@ -649,154 +665,186 @@ describe RuboCop::Cop::Style::SafeNavigation, :config do
 
         context 'if expression' do
           it 'corrects a single method call inside of a check for the object' do
-            new_source = autocorrect_source(cop, ["if #{variable}",
-                                                  "  #{variable}.bar",
-                                                  'end'])
+            new_source = autocorrect_source(cop, <<-END.strip_indent)
+              if #{variable}
+                #{variable}.bar
+              end
+            END
 
-            expect(new_source).to eq("#{variable}&.bar")
+            expect(new_source).to eq("#{variable}&.bar\n")
           end
 
           it 'corrects a single method call with params inside of a check ' \
             'for the object' do
-            new_source = autocorrect_source(cop, ["if #{variable}",
-                                                  "  #{variable}.bar(baz)",
-                                                  'end'])
+            new_source = autocorrect_source(cop, <<-END.strip_indent)
+              if #{variable}
+                #{variable}.bar(baz)
+              end
+            END
 
-            expect(new_source).to eq("#{variable}&.bar(baz)")
+            expect(new_source).to eq("#{variable}&.bar(baz)\n")
           end
 
           it 'corrects a single method call with a block inside of a check ' \
             'for the object' do
-            source = ["if #{variable}",
-                      "  #{variable}.bar { |e| e.qux }",
-                      'end']
+            source = <<-END.strip_indent
+              if #{variable}
+                #{variable}.bar { |e| e.qux }
+              end
+            END
             new_source = autocorrect_source(cop, source)
 
-            expect(new_source).to eq("#{variable}&.bar { |e| e.qux }")
+            expect(new_source).to eq("#{variable}&.bar { |e| e.qux }\n")
           end
 
           it 'corrects a single method call with params and a block inside ' \
             'of a check for the object' do
-            source = ["if #{variable}",
-                      "  #{variable}.bar(baz) { |e| e.qux }",
-                      'end']
+            source = <<-END.strip_indent
+              if #{variable}
+                #{variable}.bar(baz) { |e| e.qux }
+              end
+            END
             new_source = autocorrect_source(cop, source)
 
-            expect(new_source).to eq("#{variable}&.bar(baz) { |e| e.qux }")
+            expect(new_source).to eq("#{variable}&.bar(baz) { |e| e.qux }\n")
           end
 
           it 'corrects a single method call inside of a non-nil check for ' \
             'the object' do
-            new_source = autocorrect_source(cop, ["if !#{variable}.nil?",
-                                                  "  #{variable}.bar",
-                                                  'end'])
+            new_source = autocorrect_source(cop, <<-END.strip_indent)
+              if !#{variable}.nil?
+                #{variable}.bar
+              end
+            END
 
-            expect(new_source).to eq("#{variable}&.bar")
+            expect(new_source).to eq("#{variable}&.bar\n")
           end
 
           it 'corrects a single method call with params inside of a non-nil ' \
             'check for the object' do
-            new_source = autocorrect_source(cop, ["if !#{variable}.nil?",
-                                                  "  #{variable}.bar(baz)",
-                                                  'end'])
+            new_source = autocorrect_source(cop, <<-END.strip_indent)
+              if !#{variable}.nil?
+                #{variable}.bar(baz)
+              end
+            END
 
-            expect(new_source).to eq("#{variable}&.bar(baz)")
+            expect(new_source).to eq("#{variable}&.bar(baz)\n")
           end
 
           it 'corrects a single method call with a block inside of a non-nil ' \
             'check for the object' do
-            source = ["if !#{variable}.nil?",
-                      "  #{variable}.bar { |e| e.qux }",
-                      'end']
+            source = <<-END.strip_indent
+              if !#{variable}.nil?
+                #{variable}.bar { |e| e.qux }
+              end
+            END
             new_source = autocorrect_source(cop, source)
 
-            expect(new_source).to eq("#{variable}&.bar { |e| e.qux }")
+            expect(new_source).to eq("#{variable}&.bar { |e| e.qux }\n")
           end
 
           it 'corrects a single method call with params and a block inside ' \
             'of a non-nil check for the object' do
-            source = ["if !#{variable}.nil?",
-                      "  #{variable}.bar(baz) { |e| e.qux }",
-                      'end']
+            source = <<-END.strip_indent
+              if !#{variable}.nil?
+                #{variable}.bar(baz) { |e| e.qux }
+              end
+            END
             new_source = autocorrect_source(cop, source)
 
-            expect(new_source).to eq("#{variable}&.bar(baz) { |e| e.qux }")
+            expect(new_source).to eq("#{variable}&.bar(baz) { |e| e.qux }\n")
           end
 
           it 'corrects a single method call inside of an unless nil check ' \
             'for the object' do
-            new_source = autocorrect_source(cop, ["unless #{variable}.nil?",
-                                                  "  #{variable}.bar",
-                                                  'end'])
+            new_source = autocorrect_source(cop, <<-END.strip_indent)
+              unless #{variable}.nil?
+                #{variable}.bar
+              end
+            END
 
-            expect(new_source).to eq("#{variable}&.bar")
+            expect(new_source).to eq("#{variable}&.bar\n")
           end
 
           it 'corrects a single method call with params inside of an unless ' \
             'nil check for the object' do
-            new_source = autocorrect_source(cop, ["unless #{variable}.nil?",
-                                                  "  #{variable}.bar(baz)",
-                                                  'end'])
+            new_source = autocorrect_source(cop, <<-END.strip_indent)
+              unless #{variable}.nil?
+                #{variable}.bar(baz)
+              end
+            END
 
-            expect(new_source).to eq("#{variable}&.bar(baz)")
+            expect(new_source).to eq("#{variable}&.bar(baz)\n")
           end
 
           it 'corrects a single method call with a block inside of an unless ' \
             'nil check for the object' do
-            source = ["unless #{variable}.nil?",
-                      "  #{variable}.bar { |e| e.qux }",
-                      'end']
+            source = <<-END.strip_indent
+              unless #{variable}.nil?
+                #{variable}.bar { |e| e.qux }
+              end
+            END
             new_source = autocorrect_source(cop, source)
 
-            expect(new_source).to eq("#{variable}&.bar { |e| e.qux }")
+            expect(new_source).to eq("#{variable}&.bar { |e| e.qux }\n")
           end
 
           it 'corrects a single method call with params and a block inside ' \
             'of an unless nil check for the object' do
-            source = ["unless #{variable}.nil?",
-                      "  #{variable}.bar(baz) { |e| e.qux }",
-                      'end']
+            source = <<-END.strip_indent
+              unless #{variable}.nil?
+                #{variable}.bar(baz) { |e| e.qux }
+              end
+            END
             new_source = autocorrect_source(cop, source)
 
-            expect(new_source).to eq("#{variable}&.bar(baz) { |e| e.qux }")
+            expect(new_source).to eq("#{variable}&.bar(baz) { |e| e.qux }\n")
           end
 
           it 'corrects a single method call inside of an unless negative ' \
             'check for the object' do
-            new_source = autocorrect_source(cop, ["unless !#{variable}",
-                                                  "  #{variable}.bar",
-                                                  'end'])
+            new_source = autocorrect_source(cop, <<-END.strip_indent)
+              unless !#{variable}
+                #{variable}.bar
+              end
+            END
 
-            expect(new_source).to eq("#{variable}&.bar")
+            expect(new_source).to eq("#{variable}&.bar\n")
           end
 
           it 'corrects a single method call with params inside of an unless ' \
             'negative check for the object' do
-            new_source = autocorrect_source(cop, ["unless !#{variable}",
-                                                  "  #{variable}.bar(baz)",
-                                                  'end'])
+            new_source = autocorrect_source(cop, <<-END.strip_indent)
+              unless !#{variable}
+                #{variable}.bar(baz)
+              end
+            END
 
-            expect(new_source).to eq("#{variable}&.bar(baz)")
+            expect(new_source).to eq("#{variable}&.bar(baz)\n")
           end
 
           it 'corrects a single method call with a block inside of an unless ' \
             'negative check for the object' do
-            source = ["unless !#{variable}",
-                      "  #{variable}.bar { |e| e.qux }",
-                      'end']
+            source = <<-END.strip_indent
+              unless !#{variable}
+                #{variable}.bar { |e| e.qux }
+              end
+            END
             new_source = autocorrect_source(cop, source)
 
-            expect(new_source).to eq("#{variable}&.bar { |e| e.qux }")
+            expect(new_source).to eq("#{variable}&.bar { |e| e.qux }\n")
           end
 
           it 'corrects a single method call with params and a block inside ' \
             'of an unless negative check for the object' do
-            source = ["unless !#{variable}",
-                      "  #{variable}.bar(baz) { |e| e.qux }",
-                      'end']
+            source = <<-END.strip_indent
+              unless !#{variable}
+                #{variable}.bar(baz) { |e| e.qux }
+              end
+            END
             new_source = autocorrect_source(cop, source)
 
-            expect(new_source).to eq("#{variable}&.bar(baz) { |e| e.qux }")
+            expect(new_source).to eq("#{variable}&.bar(baz) { |e| e.qux }\n")
           end
         end
 

--- a/spec/rubocop/cop/style/semicolon_spec.rb
+++ b/spec/rubocop/cop/style/semicolon_spec.rb
@@ -35,29 +35,32 @@ describe RuboCop::Cop::Style::Semicolon, :config do
   end
 
   it 'accepts one line method definitions' do
-    inspect_source(cop,
-                   ['def foo1; x(3) end',
-                    'def initialize(*_); end',
-                    'def foo2() x(3); end',
-                    'def foo3; x(3); end'])
+    inspect_source(cop, <<-END.strip_indent)
+      def foo1; x(3) end
+      def initialize(*_); end
+      def foo2() x(3); end
+      def foo3; x(3); end
+    END
     expect(cop.offenses).to be_empty
   end
 
   it 'accepts one line empty class definitions' do
-    inspect_source(cop,
-                   ['# Prefer a single-line format for class ...',
-                    'class Foo < Exception; end',
-                    '',
-                    'class Bar; end'])
+    inspect_source(cop, <<-END.strip_indent)
+      # Prefer a single-line format for class ...
+      class Foo < Exception; end
+
+      class Bar; end
+    END
     expect(cop.offenses).to be_empty
   end
 
   it 'accepts one line empty method definitions' do
-    inspect_source(cop,
-                   ['# One exception to the rule are empty-body methods',
-                    'def no_op; end',
-                    '',
-                    'def foo; end'])
+    inspect_source(cop, <<-END.strip_indent)
+      # One exception to the rule are empty-body methods
+      def no_op; end
+
+      def foo; end
+    END
     expect(cop.offenses).to be_empty
   end
 
@@ -74,9 +77,10 @@ describe RuboCop::Cop::Style::Semicolon, :config do
   end
 
   it 'accept semicolons inside strings' do
-    inspect_source(cop,
-                   ['string = ";',
-                    'multi-line string"'])
+    inspect_source(cop, <<-END.strip_indent)
+      string = ";
+      multi-line string"
+    END
     expect(cop.offenses).to be_empty
   end
 
@@ -87,18 +91,21 @@ describe RuboCop::Cop::Style::Semicolon, :config do
 
   it 'auto-corrects semicolons when syntactically possible' do
     corrected =
-      autocorrect_source(cop,
-                         ['module Foo; end;',
-                          'puts "this is a test";',
-                          'puts "this is a test"; puts "So is this"',
-                          'def foo(a) x(1); y(2); z(3); end',
-                          ';puts 1'])
+      autocorrect_source(cop, <<-END.strip_indent)
+        module Foo; end;
+        puts "this is a test";
+        puts "this is a test"; puts "So is this"
+        def foo(a) x(1); y(2); z(3); end
+        ;puts 1
+      END
     expect(corrected)
-      .to eq(['module Foo; end',
-              'puts "this is a test"',
-              'puts "this is a test"; puts "So is this"',
-              'def foo(a) x(1); y(2); z(3); end',
-              'puts 1'].join("\n"))
+      .to eq(<<-END.strip_indent)
+        module Foo; end
+        puts "this is a test"
+        puts "this is a test"; puts "So is this"
+        def foo(a) x(1); y(2); z(3); end
+        puts 1
+      END
   end
 
   context 'when AllowAsExpressionSeparator is true' do

--- a/spec/rubocop/cop/style/signal_exception_spec.rb
+++ b/spec/rubocop/cop/style/signal_exception_spec.rb
@@ -7,126 +7,137 @@ describe RuboCop::Cop::Style::SignalException, :config do
     let(:cop_config) { { 'EnforcedStyle' => 'semantic' } }
 
     it 'registers an offense for raise in begin section' do
-      inspect_source(cop,
-                     ['begin',
-                      '  raise',
-                      'rescue Exception',
-                      '  #do nothing',
-                      'end'])
+      inspect_source(cop, <<-END.strip_indent)
+        begin
+          raise
+        rescue Exception
+          #do nothing
+        end
+      END
       expect(cop.offenses.size).to eq(1)
       expect(cop.messages)
         .to eq(['Use `fail` instead of `raise` to signal exceptions.'])
     end
 
     it 'registers an offense for raise in def body' do
-      inspect_source(cop,
-                     ['def test',
-                      '  raise',
-                      'rescue Exception',
-                      '  #do nothing',
-                      'end'])
+      inspect_source(cop, <<-END.strip_indent)
+        def test
+          raise
+        rescue Exception
+          #do nothing
+        end
+      END
       expect(cop.offenses.size).to eq(1)
       expect(cop.messages)
         .to eq(['Use `fail` instead of `raise` to signal exceptions.'])
     end
 
     it 'registers an offense for fail in rescue section' do
-      inspect_source(cop,
-                     ['begin',
-                      '  fail',
-                      'rescue Exception',
-                      '  fail',
-                      'end'])
+      inspect_source(cop, <<-END.strip_indent)
+        begin
+          fail
+        rescue Exception
+          fail
+        end
+      END
       expect(cop.offenses.size).to eq(1)
       expect(cop.messages)
         .to eq(['Use `raise` instead of `fail` to rethrow exceptions.'])
     end
 
     it 'accepts raise in rescue section' do
-      inspect_source(cop,
-                     ['begin',
-                      '  fail',
-                      'rescue Exception',
-                      '  raise RuntimeError',
-                      'end'])
+      inspect_source(cop, <<-END.strip_indent)
+        begin
+          fail
+        rescue Exception
+          raise RuntimeError
+        end
+      END
       expect(cop.offenses).to be_empty
     end
 
     it 'accepts raise in def with multiple rescues' do
-      inspect_source(cop,
-                     ['def test',
-                      '  fail',
-                      'rescue StandardError',
-                      '  # handle error',
-                      'rescue Exception',
-                      '  raise',
-                      'end'])
+      inspect_source(cop, <<-END.strip_indent)
+        def test
+          fail
+        rescue StandardError
+          # handle error
+        rescue Exception
+          raise
+        end
+      END
       expect(cop.offenses).to be_empty
     end
 
     it 'registers an offense for fail in def rescue section' do
-      inspect_source(cop,
-                     ['def test',
-                      '  fail',
-                      'rescue Exception',
-                      '  fail',
-                      'end'])
+      inspect_source(cop, <<-END.strip_indent)
+        def test
+          fail
+        rescue Exception
+          fail
+        end
+      END
       expect(cop.offenses.size).to eq(1)
       expect(cop.messages)
         .to eq(['Use `raise` instead of `fail` to rethrow exceptions.'])
     end
 
     it 'registers an offense for fail in second rescue' do
-      inspect_source(cop,
-                     ['def test',
-                      '  fail',
-                      'rescue StandardError',
-                      '  # handle error',
-                      'rescue Exception',
-                      '  fail',
-                      'end'])
+      inspect_source(cop, <<-END.strip_indent)
+        def test
+          fail
+        rescue StandardError
+          # handle error
+        rescue Exception
+          fail
+        end
+      END
       expect(cop.offenses.size).to eq(1)
     end
 
     it 'registers only offense for one raise that should be fail' do
       # This is a special case that has caused double reporting.
-      inspect_source(cop,
-                     ['map do',
-                      "  raise 'I'",
-                      'end.flatten.compact'])
+      inspect_source(cop, <<-END.strip_indent)
+        map do
+          raise 'I'
+        end.flatten.compact
+      END
       expect(cop.offenses.size).to eq(1)
       expect(cop.messages)
         .to eq(['Use `fail` instead of `raise` to signal exceptions.'])
     end
 
     it 'accepts raise in def rescue section' do
-      inspect_source(cop,
-                     ['def test',
-                      '  fail',
-                      'rescue Exception',
-                      '  raise',
-                      'end'])
+      inspect_source(cop, <<-END.strip_indent)
+        def test
+          fail
+        rescue Exception
+          raise
+        end
+      END
       expect(cop.offenses).to be_empty
     end
 
     it 'accepts `raise` and `fail` with explicit receiver' do
-      inspect_source(cop,
-                     ['def test',
-                      '  test.raise',
-                      'rescue Exception',
-                      '  test.fail',
-                      'end'])
+      inspect_source(cop, <<-END.strip_indent)
+        def test
+          test.raise
+        rescue Exception
+          test.fail
+        end
+      END
       expect(cop.offenses).to be_empty
     end
 
     it 'registers an offense for `raise` and `fail` with `Kernel` as ' \
        'explicit receiver' do
-      inspect_source(cop,
-                     ['def test',
-                      '  Kernel.raise',
-                      'rescue Exception',
-                      '  Kernel.fail',
-                      'end'])
+      inspect_source(cop, <<-END.strip_indent)
+        def test
+          Kernel.raise
+        rescue Exception
+          Kernel.fail
+        end
+      END
       expect(cop.offenses.size).to eq(2)
       expect(cop.messages)
         .to eq(['Use `fail` instead of `raise` to signal exceptions.',
@@ -134,38 +145,41 @@ describe RuboCop::Cop::Style::SignalException, :config do
     end
 
     it 'registers an offense for raise not in a begin/rescue/end' do
-      inspect_source(cop,
-                     ["case cop_config['EnforcedStyle']",
-                      "when 'single_quotes' then true",
-                      "when 'double_quotes' then false",
-                      "else raise 'Unknown StringLiterals style'",
-                      'end'])
+      inspect_source(cop, <<-END.strip_indent)
+        case cop_config['EnforcedStyle']
+        when 'single_quotes' then true
+        when 'double_quotes' then false
+        else raise 'Unknown StringLiterals style'
+        end
+      END
       expect(cop.offenses.size).to eq(1)
       expect(cop.messages)
         .to eq(['Use `fail` instead of `raise` to signal exceptions.'])
     end
 
     it 'registers one offense for each raise' do
-      inspect_source(cop,
-                     ['cop.stub(:on_def) { raise RuntimeError }',
-                      'cop.stub(:on_def) { raise RuntimeError }'])
+      inspect_source(cop, <<-END.strip_indent)
+        cop.stub(:on_def) { raise RuntimeError }
+        cop.stub(:on_def) { raise RuntimeError }
+      END
       expect(cop.offenses.size).to eq(2)
       expect(cop.messages)
         .to eq(['Use `fail` instead of `raise` to signal exceptions.'] * 2)
     end
 
     it 'is not confused by nested begin/rescue' do
-      inspect_source(cop,
-                     ['begin',
-                      '  raise',
-                      '  begin',
-                      '    raise',
-                      '  rescue',
-                      '    fail',
-                      '  end',
-                      'rescue Exception',
-                      '  #do nothing',
-                      'end'])
+      inspect_source(cop, <<-END.strip_indent)
+        begin
+          raise
+          begin
+            raise
+          rescue
+            fail
+          end
+        rescue Exception
+          #do nothing
+        end
+      END
       expect(cop.offenses.size).to eq(3)
       expect(cop.messages)
         .to eq(['Use `fail` instead of `raise` to signal exceptions.'] * 2 +
@@ -173,31 +187,37 @@ describe RuboCop::Cop::Style::SignalException, :config do
     end
 
     it 'auto-corrects raise to fail when appropriate' do
-      new_source = autocorrect_source(cop,
-                                      ['begin',
-                                       '  raise',
-                                       'rescue Exception',
-                                       '  raise',
-                                       'end'])
-      expect(new_source).to eq(['begin',
-                                '  fail',
-                                'rescue Exception',
-                                '  raise',
-                                'end'].join("\n"))
+      new_source = autocorrect_source(cop, <<-END.strip_indent)
+        begin
+          raise
+        rescue Exception
+          raise
+        end
+      END
+      expect(new_source).to eq(<<-END.strip_indent)
+        begin
+          fail
+        rescue Exception
+          raise
+        end
+      END
     end
 
     it 'auto-corrects fail to raise when appropriate' do
-      new_source = autocorrect_source(cop,
-                                      ['begin',
-                                       '  fail',
-                                       'rescue Exception',
-                                       '  fail',
-                                       'end'])
-      expect(new_source).to eq(['begin',
-                                '  fail',
-                                'rescue Exception',
-                                '  raise',
-                                'end'].join("\n"))
+      new_source = autocorrect_source(cop, <<-END.strip_indent)
+        begin
+          fail
+        rescue Exception
+          fail
+        end
+      END
+      expect(new_source).to eq(<<-END.strip_indent)
+        begin
+          fail
+        rescue Exception
+          raise
+        end
+      END
     end
   end
 
@@ -205,62 +225,67 @@ describe RuboCop::Cop::Style::SignalException, :config do
     let(:cop_config) { { 'EnforcedStyle' => 'only_raise' } }
 
     it 'registers an offense for fail in begin section' do
-      inspect_source(cop,
-                     ['begin',
-                      '  fail',
-                      'rescue Exception',
-                      '  #do nothing',
-                      'end'])
+      inspect_source(cop, <<-END.strip_indent)
+        begin
+          fail
+        rescue Exception
+          #do nothing
+        end
+      END
       expect(cop.offenses.size).to eq(1)
       expect(cop.messages)
         .to eq(['Always use `raise` to signal exceptions.'])
     end
 
     it 'registers an offense for fail in def body' do
-      inspect_source(cop,
-                     ['def test',
-                      '  fail',
-                      'rescue Exception',
-                      '  #do nothing',
-                      'end'])
+      inspect_source(cop, <<-END.strip_indent)
+        def test
+          fail
+        rescue Exception
+          #do nothing
+        end
+      END
       expect(cop.offenses.size).to eq(1)
       expect(cop.messages)
         .to eq(['Always use `raise` to signal exceptions.'])
     end
 
     it 'registers an offense for fail in rescue section' do
-      inspect_source(cop,
-                     ['begin',
-                      '  raise',
-                      'rescue Exception',
-                      '  fail',
-                      'end'])
+      inspect_source(cop, <<-END.strip_indent)
+        begin
+          raise
+        rescue Exception
+          fail
+        end
+      END
       expect(cop.offenses.size).to eq(1)
       expect(cop.messages)
         .to eq(['Always use `raise` to signal exceptions.'])
     end
 
     it 'accepts `fail` if a custom `fail` instance method is defined' do
-      inspect_source(cop,
-                     ['class A',
-                      '  def fail(arg)',
-                      '  end',
-                      '  def other_method',
-                      '    fail "message"',
-                      '  end',
-                      'end'])
+      inspect_source(cop, <<-END.strip_indent)
+        class A
+          def fail(arg)
+          end
+          def other_method
+            fail "message"
+          end
+        end
+      END
       expect(cop.offenses).to be_empty
     end
 
     it 'accepts `fail` if a custom `fail` singleton method is defined' do
-      inspect_source(cop,
-                     ['class A',
-                      '  def self.fail(arg)',
-                      '  end',
-                      '  def self.other_method',
-                      '    fail "message"',
-                      '  end',
-                      'end'])
+      inspect_source(cop, <<-END.strip_indent)
+        class A
+          def self.fail(arg)
+          end
+          def self.other_method
+            fail "message"
+          end
+        end
+      END
       expect(cop.offenses).to be_empty
     end
 
@@ -277,17 +302,20 @@ describe RuboCop::Cop::Style::SignalException, :config do
     end
 
     it 'auto-corrects fail to raise always' do
-      new_source = autocorrect_source(cop,
-                                      ['begin',
-                                       '  fail',
-                                       'rescue Exception',
-                                       '  fail',
-                                       'end'])
-      expect(new_source).to eq(['begin',
-                                '  raise',
-                                'rescue Exception',
-                                '  raise',
-                                'end'].join("\n"))
+      new_source = autocorrect_source(cop, <<-END.strip_indent)
+        begin
+          fail
+        rescue Exception
+          fail
+        end
+      END
+      expect(new_source).to eq(<<-END.strip_indent)
+        begin
+          raise
+        rescue Exception
+          raise
+        end
+      END
     end
   end
 
@@ -295,36 +323,39 @@ describe RuboCop::Cop::Style::SignalException, :config do
     let(:cop_config) { { 'EnforcedStyle' => 'only_fail' } }
 
     it 'registers an offense for raise in begin section' do
-      inspect_source(cop,
-                     ['begin',
-                      '  raise',
-                      'rescue Exception',
-                      '  #do nothing',
-                      'end'])
+      inspect_source(cop, <<-END.strip_indent)
+        begin
+          raise
+        rescue Exception
+          #do nothing
+        end
+      END
       expect(cop.offenses.size).to eq(1)
       expect(cop.messages)
         .to eq(['Always use `fail` to signal exceptions.'])
     end
 
     it 'registers an offense for raise in def body' do
-      inspect_source(cop,
-                     ['def test',
-                      '  raise',
-                      'rescue Exception',
-                      '  #do nothing',
-                      'end'])
+      inspect_source(cop, <<-END.strip_indent)
+        def test
+          raise
+        rescue Exception
+          #do nothing
+        end
+      END
       expect(cop.offenses.size).to eq(1)
       expect(cop.messages)
         .to eq(['Always use `fail` to signal exceptions.'])
     end
 
     it 'registers an offense for raise in rescue section' do
-      inspect_source(cop,
-                     ['begin',
-                      '  fail',
-                      'rescue Exception',
-                      '  raise',
-                      'end'])
+      inspect_source(cop, <<-END.strip_indent)
+        begin
+          fail
+        rescue Exception
+          raise
+        end
+      END
       expect(cop.offenses.size).to eq(1)
       expect(cop.messages)
         .to eq(['Always use `fail` to signal exceptions.'])
@@ -343,17 +374,20 @@ describe RuboCop::Cop::Style::SignalException, :config do
     end
 
     it 'auto-corrects raise to fail always' do
-      new_source = autocorrect_source(cop,
-                                      ['begin',
-                                       '  raise',
-                                       'rescue Exception',
-                                       '  raise',
-                                       'end'])
-      expect(new_source).to eq(['begin',
-                                '  fail',
-                                'rescue Exception',
-                                '  fail',
-                                'end'].join("\n"))
+      new_source = autocorrect_source(cop, <<-END.strip_indent)
+        begin
+          raise
+        rescue Exception
+          raise
+        end
+      END
+      expect(new_source).to eq(<<-END.strip_indent)
+        begin
+          fail
+        rescue Exception
+          fail
+        end
+      END
     end
   end
 end

--- a/spec/rubocop/cop/style/single_line_block_params_spec.rb
+++ b/spec/rubocop/cop/style/single_line_block_params_spec.rb
@@ -9,16 +9,17 @@ describe RuboCop::Cop::Style::SingleLineBlockParams, :config do
   end
 
   it 'finds wrong argument names in calls with different syntax' do
-    inspect_source(cop,
-                   ['def m',
-                    '  [0, 1].reduce { |c, d| c + d }',
-                    '  [0, 1].reduce{ |c, d| c + d }',
-                    '  [0, 1].reduce(5) { |c, d| c + d }',
-                    '  [0, 1].reduce(5){ |c, d| c + d }',
-                    '  [0, 1].reduce (5) { |c, d| c + d }',
-                    '  [0, 1].reduce(5) { |c, d| c + d }',
-                    '  ala.test { |x, z| bala }',
-                    'end'])
+    inspect_source(cop, <<-END.strip_indent)
+      def m
+        [0, 1].reduce { |c, d| c + d }
+        [0, 1].reduce{ |c, d| c + d }
+        [0, 1].reduce(5) { |c, d| c + d }
+        [0, 1].reduce(5){ |c, d| c + d }
+        [0, 1].reduce (5) { |c, d| c + d }
+        [0, 1].reduce(5) { |c, d| c + d }
+        ala.test { |x, z| bala }
+      end
+    END
     expect(cop.offenses.size).to eq(7)
     expect(cop.offenses.map(&:line).sort).to eq((2..8).to_a)
     expect(cop.messages.first)
@@ -26,16 +27,17 @@ describe RuboCop::Cop::Style::SingleLineBlockParams, :config do
   end
 
   it 'allows calls with proper argument names' do
-    inspect_source(cop,
-                   ['def m',
-                    '  [0, 1].reduce { |a, e| a + e }',
-                    '  [0, 1].reduce{ |a, e| a + e }',
-                    '  [0, 1].reduce(5) { |a, e| a + e }',
-                    '  [0, 1].reduce(5){ |a, e| a + e }',
-                    '  [0, 1].reduce (5) { |a, e| a + e }',
-                    '  [0, 1].reduce(5) { |a, e| a + e }',
-                    '  ala.test { |x, y| bala }',
-                    'end'])
+    inspect_source(cop, <<-END.strip_indent)
+      def m
+        [0, 1].reduce { |a, e| a + e }
+        [0, 1].reduce{ |a, e| a + e }
+        [0, 1].reduce(5) { |a, e| a + e }
+        [0, 1].reduce(5){ |a, e| a + e }
+        [0, 1].reduce (5) { |a, e| a + e }
+        [0, 1].reduce(5) { |a, e| a + e }
+        ala.test { |x, y| bala }
+      end
+    END
     expect(cop.offenses).to be_empty
   end
 
@@ -52,36 +54,40 @@ describe RuboCop::Cop::Style::SingleLineBlockParams, :config do
   end
 
   it 'ignores do..end blocks' do
-    inspect_source(cop,
-                   ['def m',
-                    '  [0, 1].reduce do |c, d|',
-                    '    c + d',
-                    '  end',
-                    'end'])
+    inspect_source(cop, <<-END.strip_indent)
+      def m
+        [0, 1].reduce do |c, d|
+          c + d
+        end
+      end
+    END
     expect(cop.offenses).to be_empty
   end
 
   it 'ignores :reduce symbols' do
-    inspect_source(cop,
-                   ['def m',
-                    '  call_method(:reduce) { |a, b| a + b}',
-                    'end'])
+    inspect_source(cop, <<-END.strip_indent)
+      def m
+        call_method(:reduce) { |a, b| a + b}
+      end
+    END
     expect(cop.offenses).to be_empty
   end
 
   it 'does not report when destructuring is used' do
-    inspect_source(cop,
-                   ['def m',
-                    '  test.reduce { |a, (id, _)| a + id}',
-                    'end'])
+    inspect_source(cop, <<-END.strip_indent)
+      def m
+        test.reduce { |a, (id, _)| a + id}
+      end
+    END
     expect(cop.offenses).to be_empty
   end
 
   it 'does not report if no block arguments are present' do
-    inspect_source(cop,
-                   ['def m',
-                    '  test.reduce { true }',
-                    'end'])
+    inspect_source(cop, <<-END.strip_indent)
+      def m
+        test.reduce { true }
+      end
+    END
     expect(cop.offenses).to be_empty
   end
 end

--- a/spec/rubocop/cop/style/single_line_methods_spec.rb
+++ b/spec/rubocop/cop/style/single_line_methods_spec.rb
@@ -9,10 +9,11 @@ describe RuboCop::Cop::Style::SingleLineMethods do
   let(:cop_config) { { 'AllowIfMethodIsEmpty' => true } }
 
   it 'registers an offense for a single-line method' do
-    inspect_source(cop,
-                   ['def some_method; body end',
-                    'def link_to(name, url); {:name => name}; end',
-                    'def @table.columns; super; end'])
+    inspect_source(cop, <<-END.strip_indent)
+      def some_method; body end
+      def link_to(name, url); {:name => name}; end
+      def @table.columns; super; end
+    END
     expect(cop.messages).to eq(
       ['Avoid single-line method definitions.'] * 3
     )
@@ -22,9 +23,11 @@ describe RuboCop::Cop::Style::SingleLineMethods do
     let(:cop_config) { { 'AllowIfMethodIsEmpty' => false } }
 
     it 'registers an offense for an empty method' do
-      inspect_source(cop, ['def no_op; end',
-                           'def self.resource_class=(klass); end',
-                           'def @table.columns; end'])
+      inspect_source(cop, <<-END.strip_indent)
+        def no_op; end
+        def self.resource_class=(klass); end
+        def @table.columns; end
+      END
       expect(cop.offenses.size).to eq(3)
     end
 
@@ -39,23 +42,29 @@ describe RuboCop::Cop::Style::SingleLineMethods do
     let(:cop_config) { { 'AllowIfMethodIsEmpty' => true } }
 
     it 'accepts a single-line empty method' do
-      inspect_source(cop, ['def no_op; end',
-                           'def self.resource_class=(klass); end',
-                           'def @table.columns; end'])
+      inspect_source(cop, <<-END.strip_indent)
+        def no_op; end
+        def self.resource_class=(klass); end
+        def @table.columns; end
+      END
       expect(cop.offenses).to be_empty
     end
   end
 
   it 'accepts a multi-line method' do
-    inspect_source(cop, ['def some_method',
-                         '  body',
-                         'end'])
+    inspect_source(cop, <<-END.strip_indent)
+      def some_method
+        body
+      end
+    END
     expect(cop.offenses).to be_empty
   end
 
   it 'does not crash on an method with a capitalized name' do
-    inspect_source(cop, ['def NoSnakeCase',
-                         'end'])
+    inspect_source(cop, <<-END.strip_indent)
+      def NoSnakeCase
+      end
+    END
     expect(cop.offenses).to be_empty
   end
 

--- a/spec/rubocop/cop/style/space_after_colon_spec.rb
+++ b/spec/rubocop/cop/style/space_after_colon_spec.rb
@@ -30,9 +30,11 @@ describe RuboCop::Cop::Style::SpaceAfterColon do
   end
 
   it 'accepts if' do
-    inspect_source(cop, ['x = if w',
-                         '      a',
-                         '    end'])
+    inspect_source(cop, <<-END.strip_indent)
+      x = if w
+            a
+          end
+    END
     expect(cop.messages).to be_empty
   end
 
@@ -42,21 +44,27 @@ describe RuboCop::Cop::Style::SpaceAfterColon do
   end
 
   it 'accepts required keyword arguments' do
-    inspect_source(cop, ['def f(x:, y:)',
-                         'end'])
+    inspect_source(cop, <<-END.strip_indent)
+      def f(x:, y:)
+      end
+    END
     expect(cop.messages).to be_empty
   end
 
   if RUBY_VERSION >= '2.1'
     it 'accepts colons denoting required keyword argument' do
-      inspect_source(cop, ['def initialize(table:, nodes:)',
-                           'end'])
+      inspect_source(cop, <<-END.strip_indent)
+        def initialize(table:, nodes:)
+        end
+      END
       expect(cop.messages).to be_empty
     end
 
     it 'registers an offence if an keyword optional argument has no space' do
-      inspect_source(cop, ['def m(var:1, other_var: 2)',
-                           'end'])
+      inspect_source(cop, <<-END.strip_indent)
+        def m(var:1, other_var: 2)
+        end
+      END
       expect(cop.messages).to eq(['Space missing after colon.'])
     end
   end

--- a/spec/rubocop/cop/style/space_after_method_name_spec.rb
+++ b/spec/rubocop/cop/style/space_after_method_name_spec.rb
@@ -4,65 +4,75 @@ describe RuboCop::Cop::Style::SpaceAfterMethodName do
   subject(:cop) { described_class.new }
 
   it 'registers an offense for def with space before the parenthesis' do
-    inspect_source(cop,
-                   ['def func (x)',
-                    '  a',
-                    'end'])
+    inspect_source(cop, <<-END.strip_indent)
+      def func (x)
+        a
+      end
+    END
     expect(cop.offenses.size).to eq(1)
   end
 
   it 'registers an offense for defs with space before the parenthesis' do
-    inspect_source(cop,
-                   ['def self.func (x)',
-                    '  a',
-                    'end'])
+    inspect_source(cop, <<-END.strip_indent)
+      def self.func (x)
+        a
+      end
+    END
     expect(cop.offenses.size).to eq(1)
   end
 
   it 'accepts a def without arguments' do
-    inspect_source(cop,
-                   ['def func',
-                    '  a',
-                    'end'])
+    inspect_source(cop, <<-END.strip_indent)
+      def func
+        a
+      end
+    END
     expect(cop.offenses).to be_empty
   end
 
   it 'accepts a defs without arguments' do
-    inspect_source(cop,
-                   ['def self.func',
-                    '  a',
-                    'end'])
+    inspect_source(cop, <<-END.strip_indent)
+      def self.func
+        a
+      end
+    END
     expect(cop.offenses).to be_empty
   end
 
   it 'accepts a def with arguments but no parentheses' do
-    inspect_source(cop,
-                   ['def func x',
-                    '  a',
-                    'end'])
+    inspect_source(cop, <<-END.strip_indent)
+      def func x
+        a
+      end
+    END
     expect(cop.offenses).to be_empty
   end
 
   it 'accepts a defs with arguments but no parentheses' do
-    inspect_source(cop,
-                   ['def self.func x',
-                    '  a',
-                    'end'])
+    inspect_source(cop, <<-END.strip_indent)
+      def self.func x
+        a
+      end
+    END
     expect(cop.offenses).to be_empty
   end
 
   it 'auto-corrects unwanted space' do
-    new_source = autocorrect_source(cop, ['def func (x)',
-                                          '  a',
-                                          'end',
-                                          'def self.func (x)',
-                                          '  a',
-                                          'end'])
-    expect(new_source).to eq(['def func(x)',
-                              '  a',
-                              'end',
-                              'def self.func(x)',
-                              '  a',
-                              'end'].join("\n"))
+    new_source = autocorrect_source(cop, <<-END.strip_indent)
+      def func (x)
+        a
+      end
+      def self.func (x)
+        a
+      end
+    END
+    expect(new_source).to eq(<<-END.strip_indent)
+      def func(x)
+        a
+      end
+      def self.func(x)
+        a
+      end
+    END
   end
 end

--- a/spec/rubocop/cop/style/space_around_block_parameters_spec.rb
+++ b/spec/rubocop/cop/style/space_around_block_parameters_spec.rb
@@ -56,9 +56,11 @@ describe RuboCop::Cop::Style::SpaceAroundBlockParameters, :config do
     end
 
     it 'accepts line break after closing pipe' do
-      inspect_source(cop, ['{}.each do |x, y|',
-                           '  puts x',
-                           'end'])
+      inspect_source(cop, <<-END.strip_indent)
+        {}.each do |x, y|
+          puts x
+        end
+      END
       expect(cop.offenses).to be_empty
     end
 
@@ -145,9 +147,11 @@ describe RuboCop::Cop::Style::SpaceAroundBlockParameters, :config do
     end
 
     it 'accepts line break after closing pipe' do
-      inspect_source(cop, ['{}.each do | x, y |',
-                           '  puts x',
-                           'end'])
+      inspect_source(cop, <<-END.strip_indent)
+        {}.each do | x, y |
+          puts x
+        end
+      END
       expect(cop.offenses).to be_empty
     end
 

--- a/spec/rubocop/cop/style/space_around_equals_in_parameter_default_spec.rb
+++ b/spec/rubocop/cop/style/space_around_equals_in_parameter_default_spec.rb
@@ -7,8 +7,10 @@ describe RuboCop::Cop::Style::SpaceAroundEqualsInParameterDefault, :config do
     let(:cop_config) { { 'EnforcedStyle' => 'space' } }
 
     it 'registers an offense for default value assignment without space' do
-      inspect_source(cop, ['def f(x, y=0, z= 1)',
-                           'end'])
+      inspect_source(cop, <<-END.strip_indent)
+        def f(x, y=0, z= 1)
+        end
+      END
       expect(cop.messages)
         .to eq(['Surrounding space missing in default value assignment.'] * 2)
       expect(cop.highlights).to eq(['=', '= '])
@@ -16,21 +18,27 @@ describe RuboCop::Cop::Style::SpaceAroundEqualsInParameterDefault, :config do
     end
 
     it 'registers an offense for assignment empty string without space' do
-      inspect_source(cop, ['def f(x, y="", z=1)',
-                           'end'])
+      inspect_source(cop, <<-END.strip_indent)
+        def f(x, y="", z=1)
+        end
+      END
       expect(cop.offenses.size).to eq(2)
       expect(cop.config_to_allow_offenses).to eq('EnforcedStyle' => 'no_space')
     end
 
     it 'registers an offense for assignment of empty list without space' do
-      inspect_source(cop, ['def f(x, y=[])',
-                           'end'])
+      inspect_source(cop, <<-END.strip_indent)
+        def f(x, y=[])
+        end
+      END
       expect(cop.offenses.size).to eq(1)
     end
 
     it 'accepts default value assignment with space' do
-      inspect_source(cop, ['def f(x, y = 0, z = {})',
-                           'end'])
+      inspect_source(cop, <<-END.strip_indent)
+        def f(x, y = 0, z = {})
+        end
+      END
       expect(cop.messages).to be_empty
     end
 
@@ -40,15 +48,22 @@ describe RuboCop::Cop::Style::SpaceAroundEqualsInParameterDefault, :config do
     end
 
     it 'accepts default value assignment with spaces and unary + operator' do
-      inspect_source(cop, ['def f(x, y = +1, z = {})',
-                           'end'])
+      inspect_source(cop, <<-END.strip_indent)
+        def f(x, y = +1, z = {})
+        end
+      END
       expect(cop.messages).to be_empty
     end
 
     it 'auto-corrects missing space for arguments with unary operators' do
-      new_source = autocorrect_source(cop, ['def f(x=-1, y= 0, z =+1)', 'end'])
-      expect(new_source).to eq(['def f(x = -1, y = 0, z = +1)',
-                                'end'].join("\n"))
+      new_source = autocorrect_source(cop, <<-END.strip_indent)
+        def f(x=-1, y= 0, z =+1)
+        end
+      END
+      expect(new_source).to eq(<<-END.strip_indent)
+        def f(x = -1, y = 0, z = +1)
+        end
+      END
     end
   end
 
@@ -56,8 +71,10 @@ describe RuboCop::Cop::Style::SpaceAroundEqualsInParameterDefault, :config do
     let(:cop_config) { { 'EnforcedStyle' => 'no_space' } }
 
     it 'registers an offense for default value assignment with space' do
-      inspect_source(cop, ['def f(x, y = 0, z =1, w= 2)',
-                           'end'])
+      inspect_source(cop, <<-END.strip_indent)
+        def f(x, y = 0, z =1, w= 2)
+        end
+      END
       expect(cop.messages)
         .to eq(['Surrounding space detected in default value assignment.'] * 3)
       expect(cop.highlights).to eq([' = ', ' =', '= '])
@@ -65,29 +82,39 @@ describe RuboCop::Cop::Style::SpaceAroundEqualsInParameterDefault, :config do
     end
 
     it 'registers an offense for assignment empty string with space' do
-      inspect_source(cop, ['def f(x, y = "", z = 1)',
-                           'end'])
+      inspect_source(cop, <<-END.strip_indent)
+        def f(x, y = "", z = 1)
+        end
+      END
       expect(cop.offenses.size).to eq(2)
       expect(cop.config_to_allow_offenses).to eq('EnforcedStyle' => 'space')
     end
 
     it 'registers an offense for assignment of empty list with space' do
-      inspect_source(cop, ['def f(x, y = [])',
-                           'end'])
+      inspect_source(cop, <<-END.strip_indent)
+        def f(x, y = [])
+        end
+      END
       expect(cop.offenses.size).to eq(1)
     end
 
     it 'accepts default value assignment without space' do
-      inspect_source(cop, ['def f(x, y=0, z={})',
-                           'end'])
+      inspect_source(cop, <<-END.strip_indent)
+        def f(x, y=0, z={})
+        end
+      END
       expect(cop.messages).to be_empty
     end
 
     it 'auto-corrects unwanted space' do
-      new_source = autocorrect_source(cop, ['def f(x, y = 0, z= 1, w= 2)',
-                                            'end'])
-      expect(new_source).to eq(['def f(x, y=0, z=1, w=2)',
-                                'end'].join("\n"))
+      new_source = autocorrect_source(cop, <<-END.strip_indent)
+        def f(x, y = 0, z= 1, w= 2)
+        end
+      END
+      expect(new_source).to eq(<<-END.strip_indent)
+        def f(x, y=0, z=1, w=2)
+        end
+      END
     end
   end
 end

--- a/spec/rubocop/cop/style/space_around_operators_spec.rb
+++ b/spec/rubocop/cop/style/space_around_operators_spec.rb
@@ -49,30 +49,32 @@ describe RuboCop::Cop::Style::SpaceAroundOperators do
   end
 
   it 'accepts exclamation point definition' do
-    inspect_source(cop, ['  def !',
-                         '    !__getobj__',
-                         '  end'])
+    inspect_source(cop, <<-END.strip_margin('|'))
+      |  def !
+      |    !__getobj__
+      |  end
+    END
     expect(cop.offenses).to be_empty
     expect(cop.messages).to be_empty
   end
 
   it 'accepts a unary' do
-    inspect_source(cop,
-                   ['  def bm(label_width = 0, *labels, &blk)',
-                    '    benchmark(CAPTION, label_width, FORMAT,',
-                    '              *labels, &blk)',
-                    '  end',
-                    '',
-                    '  def each &block',
-                    '    +11',
-                    '  end',
-                    '',
-                    '  def self.search *args',
-                    '  end',
-                    '',
-                    '  def each *args',
-                    '  end',
-                    ''])
+    inspect_source(cop, <<-END.strip_indent)
+        def bm(label_width = 0, *labels, &blk)
+          benchmark(CAPTION, label_width, FORMAT,
+                    *labels, &blk)
+        end
+
+        def each &block
+          +11
+        end
+
+        def self.search *args
+        end
+
+        def each *args
+        end
+    END
     expect(cop.messages).to be_empty
   end
 
@@ -82,15 +84,18 @@ describe RuboCop::Cop::Style::SpaceAroundOperators do
   end
 
   it 'accepts def of operator' do
-    inspect_source(cop, ['def +(other); end',
-                         'def self.===(other); end'])
+    inspect_source(cop, <<-END.strip_indent)
+      def +(other); end
+      def self.===(other); end
+    END
     expect(cop.messages).to be_empty
   end
 
   it 'accepts an operator at the end of a line' do
-    inspect_source(cop,
-                   ["['Favor unless over if for negative ' +",
-                    " 'conditions.'] * 2"])
+    inspect_source(cop, <<-END.strip_indent)
+      ['Favor unless over if for negative ' +
+       'conditions.'] * 2
+    END
     expect(cop.messages).to eq([])
   end
 
@@ -100,11 +105,12 @@ describe RuboCop::Cop::Style::SpaceAroundOperators do
   end
 
   it 'accepts an assignment by `for` statement' do
-    inspect_source(cop,
-                   ['for a in [] do; end',
-                    'for A in [] do; end',
-                    'for @a in [] do; end',
-                    'for @@a in [] do; end'])
+    inspect_source(cop, <<-END.strip_indent)
+      for a in [] do; end
+      for A in [] do; end
+      for @a in [] do; end
+      for @@a in [] do; end
+    END
     expect(cop.offenses).to be_empty
   end
 
@@ -114,16 +120,19 @@ describe RuboCop::Cop::Style::SpaceAroundOperators do
   end
 
   it 'accepts operators with spaces' do
-    inspect_source(cop,
-                   ['x += a + b - c * d / e % f ^ g | h & i || j',
-                    'y -= k && l'])
+    inspect_source(cop, <<-END.strip_indent)
+      x += a + b - c * d / e % f ^ g | h & i || j
+      y -= k && l
+    END
     expect(cop.messages).to eq([])
   end
 
   it "accepts some operators that are exceptions & don't need spaces" do
-    inspect_source(cop, ['(1..3)',
-                         'ActionController::Base',
-                         'each { |s, t| }'])
+    inspect_source(cop, <<-END.strip_indent)
+      (1..3)
+      ActionController::Base
+      each { |s, t| }
+    END
     expect(cop.messages).to eq([])
   end
 
@@ -146,10 +155,14 @@ describe RuboCop::Cop::Style::SpaceAroundOperators do
   end
 
   it 'auto-corrects unwanted space around **' do
-    new_source = autocorrect_source(cop, ['x = a * b ** 2',
-                                          'y = a * b** 2'])
-    expect(new_source).to eq(['x = a * b**2',
-                              'y = a * b**2'].join("\n"))
+    new_source = autocorrect_source(cop, <<-END.strip_indent)
+      x = a * b ** 2
+      y = a * b** 2
+    END
+    expect(new_source).to eq(<<-END.strip_indent)
+      x = a * b**2
+      y = a * b**2
+    END
   end
 
   it 'accepts exponent operator without spaces' do
@@ -158,11 +171,13 @@ describe RuboCop::Cop::Style::SpaceAroundOperators do
   end
 
   it 'accepts unary operators without space' do
-    inspect_source(cop, ['[].map(&:size)',
-                         'a.(b)',
-                         '-3',
-                         'arr.collect { |e| -e }',
-                         'x = +2'])
+    inspect_source(cop, <<-END.strip_indent)
+      [].map(&:size)
+      a.(b)
+      -3
+      arr.collect { |e| -e }
+      x = +2
+    END
     expect(cop.messages).to eq([])
   end
 
@@ -184,23 +199,28 @@ describe RuboCop::Cop::Style::SpaceAroundOperators do
   it 'accepts argument default values without space' do
     # These are handled by SpaceAroundEqualsInParameterDefault,
     # so SpaceAroundOperators leaves them alone.
-    inspect_source(cop,
-                   ['def init(name=nil)',
-                    'end'])
+    inspect_source(cop, <<-END.strip_indent)
+      def init(name=nil)
+      end
+    END
     expect(cop.messages).to be_empty
   end
 
   it 'accepts the construct class <<self with no space after <<' do
-    inspect_source(cop, ['class <<self',
-                         'end'])
+    inspect_source(cop, <<-END.strip_indent)
+      class <<self
+      end
+    END
     expect(cop.messages).to be_empty
   end
 
   describe 'missing space around operators' do
     shared_examples 'modifier with missing space' do |keyword|
       it "registers an offense in presence of modifier #{keyword} statement" do
-        src = ["a=1 #{keyword} condition",
-               'c=2']
+        src = <<-END.strip_indent
+          a=1 #{keyword} condition
+          c=2
+        END
         inspect_source(cop, src)
         expect(cop.offenses.map(&:line)).to eq([1, 2])
         expect(cop.messages).to eq(
@@ -208,8 +228,10 @@ describe RuboCop::Cop::Style::SpaceAroundOperators do
         )
 
         new_source = autocorrect_source(cop, src)
-        expect(new_source)
-          .to eq(src.map { |line| line.sub('=', ' = ') }.join("\n"))
+        expect(new_source).to eq(<<-END.strip_indent)
+          a = 1 #{keyword} condition
+          c = 2
+        END
       end
     end
 
@@ -292,9 +314,10 @@ describe RuboCop::Cop::Style::SpaceAroundOperators do
     end
 
     it 'registers an offense for operators without spaces' do
-      inspect_source(cop,
-                     ['x+= a+b-c*d/e%f^g|h&i||j',
-                      'y -=k&&l'])
+      inspect_source(cop, <<-END.strip_indent)
+        x+= a+b-c*d/e%f^g|h&i||j
+        y -=k&&l
+      END
       expect(cop.messages)
         .to eq(['Surrounding space missing for operator `+=`.',
                 'Surrounding space missing for operator `+`.',
@@ -311,10 +334,14 @@ describe RuboCop::Cop::Style::SpaceAroundOperators do
     end
 
     it 'auto-corrects missing space' do
-      new_source = autocorrect_source(cop, ['x+= a+b-c*d/e%f^g|h&i||j',
-                                            'y -=k&&l'])
-      expect(new_source).to eq(['x += a + b - c * d / e % f ^ g | h & i || j',
-                                'y -= k && l'].join("\n"))
+      new_source = autocorrect_source(cop, <<-END.strip_indent)
+        x+= a+b-c*d/e%f^g|h&i||j
+        y -=k&&l
+      END
+      expect(new_source).to eq(<<-END.strip_indent)
+        x += a + b - c * d / e % f ^ g | h & i || j
+        y -= k && l
+      END
     end
 
     it 'registers an offense for a setter call without spaces' do
@@ -348,10 +375,12 @@ describe RuboCop::Cop::Style::SpaceAroundOperators do
 
     context 'when a hash literal is on multiple lines' do
       before do
-        inspect_source(cop, ['{',
-                             '  1=>2,',
-                             '  a: b',
-                             '}'])
+        inspect_source(cop, <<-END.strip_indent)
+          {
+            1=>2,
+            a: b
+          }
+        END
       end
 
       context 'and Style/AlignHash:EnforcedHashRocketStyle is key' do
@@ -373,24 +402,28 @@ describe RuboCop::Cop::Style::SpaceAroundOperators do
     end
 
     it 'registers an offense for match operators without space' do
-      inspect_source(cop, ['x=~/abc/',
-                           'y !~/abc/'])
+      inspect_source(cop, <<-END.strip_indent)
+        x=~/abc/
+        y !~/abc/
+      END
       expect(cop.messages)
         .to eq(['Surrounding space missing for operator `=~`.',
                 'Surrounding space missing for operator `!~`.'])
     end
 
     it 'registers an offense for various assignments without space' do
-      inspect_source(cop, ['x||=0',
-                           'y&&=0',
-                           'z*=2',
-                           '@a=0',
-                           '@@a=0',
-                           'a,b=0',
-                           'A=0',
-                           'x[3]=0',
-                           '$A=0',
-                           'A||=0'])
+      inspect_source(cop, <<-END.strip_indent)
+        x||=0
+        y&&=0
+        z*=2
+        @a=0
+        @@a=0
+        a,b=0
+        A=0
+        x[3]=0
+        $A=0
+        A||=0
+      END
       expect(cop.messages)
         .to eq(['Surrounding space missing for operator `||=`.',
                 'Surrounding space missing for operator `&&=`.',
@@ -419,33 +452,43 @@ describe RuboCop::Cop::Style::SpaceAroundOperators do
     end
 
     it 'registers an offense for inheritance < without space' do
-      inspect_source(cop, ['class ShowSourceTestClass<ShowSourceTestSuperClass',
-                           'end'])
+      inspect_source(cop, <<-END.strip_indent)
+        class ShowSourceTestClass<ShowSourceTestSuperClass
+        end
+      END
       expect(cop.messages)
         .to eq(['Surrounding space missing for operator `<`.'])
     end
 
     it 'registers an offense for hash rocket without space at rescue' do
-      inspect_source(cop, ['begin',
-                           'rescue Exception=>e',
-                           'end'])
+      inspect_source(cop, <<-END.strip_indent)
+        begin
+        rescue Exception=>e
+        end
+      END
       expect(cop.messages)
         .to eq(['Surrounding space missing for operator `=>`.'])
     end
 
     it "doesn't eat a newline when auto-correcting" do
-      new_source = autocorrect_source(cop, ["'Here is a'+",
-                                            "'joined string'+",
-                                            "'across three lines'"])
-      expect(new_source).to eq(["'Here is a' +",
-                                "'joined string' +",
-                                "'across three lines'"].join("\n"))
+      new_source = autocorrect_source(cop, <<-END.strip_indent)
+        'Here is a'+
+        'joined string'+
+        'across three lines'
+      END
+      expect(new_source).to eq(<<-END.strip_indent)
+        'Here is a' +
+        'joined string' +
+        'across three lines'
+      END
     end
 
     it "doesn't register an offense for operators with newline on right" do
-      inspect_source(cop, ["'Here is a' +",
-                           "'joined string' +",
-                           "'across three lines'"])
+      inspect_source(cop, <<-END.strip_indent)
+        'Here is a' +
+        'joined string' +
+        'across three lines'
+      END
       expect(cop.offenses).to be_empty
     end
   end
@@ -453,8 +496,10 @@ describe RuboCop::Cop::Style::SpaceAroundOperators do
   describe 'extra space around operators' do
     shared_examples 'modifier with extra space' do |keyword|
       it "registers an offense in presence of modifier #{keyword} statement" do
-        src = ["a =  1 #{keyword} condition",
-               'c =   2']
+        src = <<-END.strip_indent
+          a =  1 #{keyword} condition
+          c =   2
+        END
         inspect_source(cop, src)
         expect(cop.offenses.map(&:line)).to eq([1, 2])
         expect(cop.messages).to eq(
@@ -462,15 +507,19 @@ describe RuboCop::Cop::Style::SpaceAroundOperators do
         )
 
         new_source = autocorrect_source(cop, src)
-        expect(new_source)
-          .to eq(src.map { |line| line.sub(/\s*=\s*/, ' = ') }.join("\n"))
+        expect(new_source).to eq(<<-END.strip_indent)
+          a = 1 #{keyword} condition
+          c = 2
+        END
       end
     end
 
     it 'registers an offense for assignment with many spaces on either side' do
-      inspect_source(cop, ['x   = 0',
-                           'y +=   0',
-                           'z[0]  =  0'])
+      inspect_source(cop, <<-END.strip_indent)
+        x   = 0
+        y +=   0
+        z[0]  =  0
+      END
       expect(cop.messages)
         .to eq(['Operator `=` should be surrounded by a single space.',
                 'Operator `+=` should be surrounded by a single space.',
@@ -478,10 +527,16 @@ describe RuboCop::Cop::Style::SpaceAroundOperators do
     end
 
     it 'auto-corrects assignment with too many spaces on either side' do
-      new_source = autocorrect_source(cop, ['x  = 0',
-                                            'y =   0',
-                                            'z  =   0'])
-      expect(new_source).to eq(['x = 0', 'y = 0', 'z = 0'].join("\n"))
+      new_source = autocorrect_source(cop, <<-END.strip_indent)
+        x  = 0
+        y =   0
+        z  =   0
+      END
+      expect(new_source).to eq(<<-END.strip_indent)
+        x = 0
+        y = 0
+        z = 0
+      END
     end
 
     it 'registers an offense for ternary operator with too many spaces' do
@@ -503,9 +558,11 @@ describe RuboCop::Cop::Style::SpaceAroundOperators do
     it_behaves_like 'modifier with extra space', 'until'
 
     it 'registers an offense for binary operators that could be unary' do
-      inspect_source(cop, ['a -  3',
-                           'x &   0xff',
-                           'z +  0'])
+      inspect_source(cop, <<-END.strip_indent)
+        a -  3
+        x &   0xff
+        z +  0
+      END
       expect(cop.messages).to eq(
         ['Operator `-` should be surrounded by a single space.',
          'Operator `&` should be surrounded by a single space.',
@@ -514,10 +571,16 @@ describe RuboCop::Cop::Style::SpaceAroundOperators do
     end
 
     it 'auto-corrects missing space in binary operators that could be unary' do
-      new_source = autocorrect_source(cop, ['a -  3',
-                                            'x &   0xff',
-                                            'z +  0'])
-      expect(new_source).to eq(['a - 3', 'x & 0xff', 'z + 0'].join("\n"))
+      new_source = autocorrect_source(cop, <<-END.strip_indent)
+        a -  3
+        x &   0xff
+        z +  0
+      END
+      expect(new_source).to eq(<<-END.strip_indent)
+        a - 3
+        x & 0xff
+        z + 0
+      END
     end
 
     it 'registers an offense for arguments to a method' do
@@ -533,9 +596,10 @@ describe RuboCop::Cop::Style::SpaceAroundOperators do
     end
 
     it 'registers an offense for operators with too many spaces' do
-      inspect_source(cop,
-                     ['x +=  a  + b -  c  * d /  e  % f  ^ g   | h &  i  ||  j',
-                      'y  -=  k   &&        l'])
+      inspect_source(cop, <<-END.strip_indent)
+        x +=  a  + b -  c  * d /  e  % f  ^ g   | h &  i  ||  j
+        y  -=  k   &&        l
+      END
       expect(cop.messages)
         .to eq(['Operator `+=` should be surrounded by a single space.',
                 'Operator `+` should be surrounded by a single space.',
@@ -554,11 +618,15 @@ describe RuboCop::Cop::Style::SpaceAroundOperators do
     it 'auto-corrects missing space' do
       new_source = autocorrect_source(
         cop,
-        ['x +=  a  + b -  c  * d /  e  % f  ^ g   | h &  i  ||  j',
-         'y  -=  k   &&        l']
+        <<-END.strip_indent
+          x +=  a  + b -  c  * d /  e  % f  ^ g   | h &  i  ||  j
+          y  -=  k   &&        l
+        END
       )
-      expect(new_source).to eq(['x += a + b - c * d / e % f ^ g | h & i || j',
-                                'y -= k && l'].join("\n"))
+      expect(new_source).to eq(<<-END.strip_indent)
+        x += a + b - c * d / e % f ^ g | h & i || j
+        y -= k && l
+      END
     end
 
     it 'registers an offense for a setter call with too many spaces' do
@@ -577,9 +645,11 @@ describe RuboCop::Cop::Style::SpaceAroundOperators do
 
     it 'registers an offense for a hash rocket with an extra space' \
       'on multiple line' do
-      inspect_source(cop, ['{',
-                           '  1 =>  2',
-                           '}'])
+      inspect_source(cop, <<-END.strip_indent)
+        {
+          1 =>  2
+        }
+      END
       expect(cop.messages).to eq(
         ['Operator `=>` should be surrounded by a single space.']
       )
@@ -587,10 +657,12 @@ describe RuboCop::Cop::Style::SpaceAroundOperators do
 
     it 'accepts for a hash rocket with an extra space for alignment' \
       'on multiple line' do
-      inspect_source(cop, ['{',
-                           '  1 =>  2,',
-                           '  11 => 3',
-                           '}'])
+      inspect_source(cop, <<-END.strip_indent)
+        {
+          1 =>  2,
+          11 => 3
+        }
+      END
       expect(cop.offenses).to be_empty
     end
 
@@ -598,10 +670,12 @@ describe RuboCop::Cop::Style::SpaceAroundOperators do
       let(:allow_for_alignment) { false }
 
       it 'accepts an extra space' do
-        inspect_source(cop, ['{',
-                             '  1 =>  2,',
-                             '  11 => 3',
-                             '}'])
+        inspect_source(cop, <<-END.strip_indent)
+          {
+            1 =>  2,
+            11 => 3
+          }
+        END
         expect(cop.messages).to eq(
           ['Operator `=>` should be surrounded by a single space.']
         )
@@ -609,25 +683,29 @@ describe RuboCop::Cop::Style::SpaceAroundOperators do
     end
 
     it 'registers an offense for match operators with too many spaces' do
-      inspect_source(cop, ['x  =~ /abc/',
-                           'y !~   /abc/'])
+      inspect_source(cop, <<-END.strip_indent)
+        x  =~ /abc/
+        y !~   /abc/
+      END
       expect(cop.messages)
         .to eq(['Operator `=~` should be surrounded by a single space.',
                 'Operator `!~` should be surrounded by a single space.'])
     end
 
     it 'registers an offense for various assignments with too many spaces' do
-      inspect_source(cop, ['x ||=  0',
-                           'y  &&=  0',
-                           'z  *=   2',
-                           '@a   = 0',
-                           '@@a   = 0',
-                           'a,b    =   0',
-                           'A  = 0',
-                           'x[3]   = 0',
-                           '$A    =   0',
-                           'A  ||=  0',
-                           'A  +=    0'])
+      inspect_source(cop, <<-END.strip_indent)
+        x ||=  0
+        y  &&=  0
+        z  *=   2
+        @a   = 0
+        @@a   = 0
+        a,b    =   0
+        A  = 0
+        x[3]   = 0
+        $A    =   0
+        A  ||=  0
+        A  +=    0
+      END
       expect(cop.messages)
         .to eq(['Operator `||=` should be surrounded by a single space.',
                 'Operator `&&=` should be surrounded by a single space.',
@@ -658,17 +736,20 @@ describe RuboCop::Cop::Style::SpaceAroundOperators do
     end
 
     it 'registers an offense for inheritance < with too many spaces' do
-      inspect_source(cop,
-                     ['class ShowSourceTestClass  <  ShowSourceTestSuperClass',
-                      'end'])
+      inspect_source(cop, <<-END.strip_indent)
+        class ShowSourceTestClass  <  ShowSourceTestSuperClass
+        end
+      END
       expect(cop.messages)
         .to eq(['Operator `<` should be surrounded by a single space.'])
     end
 
     it 'registers an offense for hash rocket with too many spaces at rescue' do
-      inspect_source(cop, ['begin',
-                           'rescue Exception   =>      e',
-                           'end'])
+      inspect_source(cop, <<-END.strip_indent)
+        begin
+        rescue Exception   =>      e
+        end
+      END
       expect(cop.messages)
         .to eq(['Operator `=>` should be surrounded by a single space.'])
     end

--- a/spec/rubocop/cop/style/space_before_block_braces_spec.rb
+++ b/spec/rubocop/cop/style/space_before_block_braces_spec.rb
@@ -19,18 +19,21 @@ describe RuboCop::Cop::Style::SpaceBeforeBlockBraces, :config do
     end
 
     it 'registers an offense for opposite + correct style' do
-      inspect_source(cop,
-                     ['each{ puts }',
-                      'each { puts }'])
+      inspect_source(cop, <<-END.strip_indent)
+        each{ puts }
+        each { puts }
+      END
       expect(cop.messages).to eq(['Space missing to the left of {.'])
       expect(cop.config_to_allow_offenses).to eq('Enabled' => false)
     end
 
     it 'registers an offense for multiline block where left brace has no ' \
        'outer space' do
-      inspect_source(cop, ['foo.map{ |a|',
-                           '  a.bar.to_s',
-                           '}'])
+      inspect_source(cop, <<-END.strip_indent)
+        foo.map{ |a|
+          a.bar.to_s
+        }
+      END
       expect(cop.messages).to eq(['Space missing to the left of {.'])
       expect(cop.highlights).to eq(['{'])
       expect(cop.config_to_allow_offenses).to eq('EnforcedStyle' => 'no_space')
@@ -53,9 +56,10 @@ describe RuboCop::Cop::Style::SpaceBeforeBlockBraces, :config do
     end
 
     it 'registers an offense for correct + opposite style' do
-      inspect_source(cop,
-                     ['each{ puts }',
-                      'each { puts }'])
+      inspect_source(cop, <<-END.strip_indent)
+        each{ puts }
+        each { puts }
+      END
       expect(cop.messages).to eq(['Space detected to the left of {.'])
       expect(cop.config_to_allow_offenses).to eq('Enabled' => false)
     end

--- a/spec/rubocop/cop/style/space_before_comment_spec.rb
+++ b/spec/rubocop/cop/style/space_before_comment_spec.rb
@@ -19,9 +19,11 @@ describe RuboCop::Cop::Style::SpaceBeforeComment do
   end
 
   it 'accepts a doc comment' do
-    inspect_source(cop, ['=begin',
-                         'Doc comment',
-                         '=end'])
+    inspect_source(cop, <<-END.strip_indent)
+      =begin
+      Doc comment
+      =end
+    END
     expect(cop.offenses).to be_empty
   end
 

--- a/spec/rubocop/cop/style/space_before_first_arg_spec.rb
+++ b/spec/rubocop/cop/style/space_before_first_arg_spec.rb
@@ -7,8 +7,10 @@ describe RuboCop::Cop::Style::SpaceBeforeFirstArg, :config do
   context 'for method calls without parentheses' do
     it 'registers an offense for method call with two spaces before the ' \
        'first arg' do
-      inspect_source(cop, ['something  x',
-                           'a.something  y, z'])
+      inspect_source(cop, <<-END.strip_indent)
+        something  x
+        a.something  y, z
+      END
       expect(cop.messages)
         .to eq(['Put one space between the method name and the first ' \
                 'argument.'] * 2)
@@ -16,43 +18,57 @@ describe RuboCop::Cop::Style::SpaceBeforeFirstArg, :config do
     end
 
     it 'auto-corrects extra space' do
-      new_source = autocorrect_source(cop, ['something  x',
-                                            'a.something   y, z'])
-      expect(new_source).to eq(['something x',
-                                'a.something y, z'].join("\n"))
+      new_source = autocorrect_source(cop, <<-END.strip_indent)
+        something  x
+        a.something   y, z
+      END
+      expect(new_source).to eq(<<-END.strip_indent)
+        something x
+        a.something y, z
+      END
     end
 
     it 'accepts a method call with one space before the first arg' do
-      inspect_source(cop, ['something x',
-                           'a.something y, z'])
+      inspect_source(cop, <<-END.strip_indent)
+        something x
+        a.something y, z
+      END
       expect(cop.offenses).to be_empty
     end
 
     it 'accepts + operator' do
-      inspect_source(cop, ['something +',
-                           '  x'])
+      inspect_source(cop, <<-END.strip_indent)
+        something +
+          x
+      END
       expect(cop.offenses).to be_empty
     end
 
     it 'accepts setter call' do
-      inspect_source(cop, ['something.x =',
-                           '  y'])
+      inspect_source(cop, <<-END.strip_indent)
+        something.x =
+          y
+      END
       expect(cop.offenses).to be_empty
     end
 
     it 'accepts multiple space containing line break' do
-      inspect_source(cop, ['something \\',
-                           '  x'])
+      inspect_source(cop, <<-END.strip_indent)
+        something \\
+          x
+      END
       expect(cop.offenses).to be_empty
     end
 
     context 'when AllowForAlignment is true' do
       it 'accepts method calls with aligned first arguments' do
-        inspect_source(cop, ['form.inline_input   :full_name,     as: :string',
-                             'form.disabled_input :password,      as: :passwd',
-                             'form.masked_input   :zip_code,      as: :string',
-                             'form.masked_input   :email_address, as: :email',
-                             'form.masked_input   :phone_number,  as: :tel'])
+        inspect_source(cop, <<-END.strip_indent)
+          form.inline_input   :full_name,     as: :string
+          form.disabled_input :password,      as: :passwd
+          form.masked_input   :zip_code,      as: :string
+          form.masked_input   :email_address, as: :email
+          form.masked_input   :phone_number,  as: :tel
+        END
         expect(cop.offenses).to be_empty
       end
     end
@@ -61,11 +77,13 @@ describe RuboCop::Cop::Style::SpaceBeforeFirstArg, :config do
       let(:cop_config) { { 'AllowForAlignment' => false } }
 
       it 'does not accept method calls with aligned first arguments' do
-        inspect_source(cop, ['form.inline_input   :full_name,     as: :string',
-                             'form.disabled_input :password,      as: :passwd',
-                             'form.masked_input   :zip_code,      as: :string',
-                             'form.masked_input   :email_address, as: :email',
-                             'form.masked_input   :phone_number,  as: :tel'])
+        inspect_source(cop, <<-END.strip_indent)
+          form.inline_input   :full_name,     as: :string
+          form.disabled_input :password,      as: :passwd
+          form.masked_input   :zip_code,      as: :string
+          form.masked_input   :email_address, as: :email
+          form.masked_input   :phone_number,  as: :tel
+        END
         expect(cop.offenses.size).to eq(4)
       end
     end
@@ -73,8 +91,10 @@ describe RuboCop::Cop::Style::SpaceBeforeFirstArg, :config do
 
   context 'for method calls with parentheses' do
     it 'accepts a method call without space' do
-      inspect_source(cop, ['something(x)',
-                           'a.something(y, z)'])
+      inspect_source(cop, <<-END.strip_indent)
+        something(x)
+        a.something(y, z)
+      END
       expect(cop.offenses).to be_empty
     end
 

--- a/spec/rubocop/cop/style/space_in_lambda_literal_spec.rb
+++ b/spec/rubocop/cop/style/space_in_lambda_literal_spec.rb
@@ -17,10 +17,12 @@ describe RuboCop::Cop::Style::SpaceInLambdaLiteral, :config do
     end
 
     it 'does not register an offense for multi-line lambdas' do
-      inspect_source(cop, ['l = lambda do |a, b|',
-                           '  tmp = a * 7',
-                           '  tmp * b / 50',
-                           'end'])
+      inspect_source(cop, <<-END.strip_indent)
+        l = lambda do |a, b|
+          tmp = a * 7
+          tmp * b / 50
+        end
+      END
       expect(cop.offenses).to be_empty
     end
 
@@ -83,10 +85,12 @@ describe RuboCop::Cop::Style::SpaceInLambdaLiteral, :config do
     end
 
     it 'does not register an offense for multi-line lambdas' do
-      inspect_source(cop, ['l = lambda do |a, b|',
-                           '  tmp = a * 7',
-                           '  tmp * b / 50',
-                           'end'])
+      inspect_source(cop, <<-END.strip_indent)
+        l = lambda do |a, b|
+          tmp = a * 7
+          tmp * b / 50
+        end
+      END
       expect(cop.offenses).to be_empty
     end
 

--- a/spec/rubocop/cop/style/space_inside_array_percent_literal_spec.rb
+++ b/spec/rubocop/cop/style/space_inside_array_percent_literal_spec.rb
@@ -48,28 +48,34 @@ describe RuboCop::Cop::Style::SpaceInsideArrayPercentLiteral do
         end
 
         it 'accepts multi-line literals' do
-          inspect_source(cop, ["%#{type}(",
-                               '  a',
-                               '  b',
-                               '  c',
-                               ')'])
+          inspect_source(cop, <<-END.strip_indent)
+            %#{type}(
+              a
+              b
+              c
+            )
+          END
           expect(cop.messages).to be_empty
         end
 
         it 'accepts multi-line literals within a method' do
-          inspect_source(cop, ['def foo',
-                               "  %#{type}(",
-                               '    a',
-                               '    b',
-                               '    c',
-                               '  )',
-                               'end'])
+          inspect_source(cop, <<-END.strip_indent)
+            def foo
+              %#{type}(
+                a
+                b
+                c
+              )
+            end
+          END
           expect(cop.messages).to be_empty
         end
 
         it 'accepts newlines and additional following alignment spaces' do
-          inspect_source(cop, ["%#{type}(a b",
-                               '   c)'])
+          inspect_source(cop, <<-END.strip_indent)
+            %#{type}(a b
+               c)
+          END
           expect(cop.messages).to be_empty
         end
       end

--- a/spec/rubocop/cop/style/space_inside_block_braces_spec.rb
+++ b/spec/rubocop/cop/style/space_inside_block_braces_spec.rb
@@ -26,20 +26,26 @@ describe RuboCop::Cop::Style::SpaceInsideBlockBraces, :config do
     end
 
     it 'accepts multiline braces with content' do
-      inspect_source(cop, ['each { %(',
-                           ') }'])
+      inspect_source(cop, <<-END.strip_indent)
+        each { %(
+        ) }
+      END
       expect(cop.offenses).to be_empty
     end
 
     it 'accepts empty braces with comment and line break inside' do
-      inspect_source(cop, ['  each { # Comment',
-                           '  }'])
+      inspect_source(cop, <<-END.strip_margin('|'))
+        |  each { # Comment
+        |  }
+      END
       expect(cop.offenses).to be_empty
     end
 
     it 'registers an offense for empty braces with line break inside' do
-      inspect_source(cop, ['  each {',
-                           '  }'])
+      inspect_source(cop, <<-END.strip_margin('|'))
+        |  each {
+        |  }
+      END
       expect(cop.messages).to eq(['Space inside empty braces detected.'])
       expect(cop.highlights).to eq(["\n  "])
     end
@@ -120,9 +126,11 @@ describe RuboCop::Cop::Style::SpaceInsideBlockBraces, :config do
   end
 
   it 'registers offenses for both braces without inner space' do
-    inspect_source(cop, ['a {}',
-                         'b { }',
-                         'each {puts}'])
+    inspect_source(cop, <<-END.strip_indent)
+      a {}
+      b { }
+      each {puts}
+    END
     expect(cop.messages).to eq(['Space inside empty braces detected.',
                                 'Space missing inside {.',
                                 'Space missing inside }.'])
@@ -157,16 +165,20 @@ describe RuboCop::Cop::Style::SpaceInsideBlockBraces, :config do
 
     context 'for multi-line blocks' do
       it 'accepts left brace with inner space' do
-        inspect_source(cop, ['each { |x|',
-                             'puts',
-                             '}'])
+        inspect_source(cop, <<-END.strip_indent)
+          each { |x|
+          puts
+          }
+        END
         expect(cop.offenses).to be_empty
       end
 
       it 'registers an offense for left brace without inner space' do
-        inspect_source(cop, ['each {|x|',
-                             'puts',
-                             '}'])
+        inspect_source(cop, <<-END.strip_indent)
+          each {|x|
+          puts
+          }
+        END
         expect(cop.messages).to eq(['Space between { and | missing.'])
         expect(cop.highlights).to eq(['{|'])
         expect(cop.config_to_allow_offenses).to eq('Enabled' => false)
@@ -209,13 +221,17 @@ describe RuboCop::Cop::Style::SpaceInsideBlockBraces, :config do
       end
 
       it 'does auto-correction for multi-line blocks' do
-        old_source = ['each {|x|',
-                      '  puts',
-                      '}']
+        old_source = <<-END.strip_indent
+          each {|x|
+            puts
+          }
+        END
         new_source = autocorrect_source(cop, old_source)
-        expect(new_source).to eq(['each { |x|',
-                                  '  puts',
-                                  '}'].join("\n"))
+        expect(new_source).to eq(<<-END.strip_indent)
+          each { |x|
+            puts
+          }
+        END
       end
     end
 

--- a/spec/rubocop/cop/style/space_inside_brackets_spec.rb
+++ b/spec/rubocop/cop/style/space_inside_brackets_spec.rb
@@ -4,8 +4,10 @@ describe RuboCop::Cop::Style::SpaceInsideBrackets do
   subject(:cop) { described_class.new }
 
   it 'registers an offense for an array literal with spaces inside' do
-    inspect_source(cop, ['a = [1, 2 ]',
-                         'b = [ 1, 2]'])
+    inspect_source(cop, <<-END.strip_indent)
+      a = [1, 2 ]
+      b = [ 1, 2]
+    END
     expect(cop.messages).to eq(
       ['Space inside square brackets detected.',
        'Space inside square brackets detected.']
@@ -13,8 +15,10 @@ describe RuboCop::Cop::Style::SpaceInsideBrackets do
   end
 
   it 'registers an offense for Hash#[] with symbol key and spaces inside' do
-    inspect_source(cop, ['a[ :key]',
-                         'b[:key ]'])
+    inspect_source(cop, <<-END.strip_indent)
+      a[ :key]
+      b[:key ]
+    END
     expect(cop.messages).to eq(
       ['Space inside square brackets detected.',
        'Space inside square brackets detected.']
@@ -22,8 +26,10 @@ describe RuboCop::Cop::Style::SpaceInsideBrackets do
   end
 
   it 'registers an offense for Hash#[] with string key and spaces inside' do
-    inspect_source(cop, ['a[\'key\' ]',
-                         'b[ \'key\']'])
+    inspect_source(cop, <<-END.strip_indent)
+      a[\'key\' ]
+      b[ \'key\']
+    END
     expect(cop.messages).to eq(
       ['Space inside square brackets detected.',
        'Space inside square brackets detected.']
@@ -31,28 +37,36 @@ describe RuboCop::Cop::Style::SpaceInsideBrackets do
   end
 
   it 'accepts space inside strings within square brackets' do
-    inspect_source(cop, ["['Encoding:',",
-                         " '  Enabled: false']"])
+    inspect_source(cop, <<-END.strip_indent)
+      ['Encoding:',
+       '  Enabled: false']
+    END
     expect(cop.messages).to be_empty
   end
 
   it 'accepts space inside square brackets if on its own row' do
-    inspect_source(cop, ['a = [',
-                         '     1, 2',
-                         '    ]'])
+    inspect_source(cop, <<-END.strip_indent)
+      a = [
+           1, 2
+          ]
+    END
     expect(cop.messages).to be_empty
   end
 
   it 'accepts space inside square brackets if with comment' do
-    inspect_source(cop, ['a = [ # Comment',
-                         '     1, 2',
-                         '    ]'])
+    inspect_source(cop, <<-END.strip_indent)
+      a = [ # Comment
+           1, 2
+          ]
+    END
     expect(cop.messages).to be_empty
   end
 
   it 'accepts square brackets as method name' do
-    inspect_source(cop, ['def Vector.[](*array)',
-                         'end'])
+    inspect_source(cop, <<-END.strip_indent)
+      def Vector.[](*array)
+      end
+    END
     expect(cop.messages).to be_empty
   end
 
@@ -69,17 +83,21 @@ describe RuboCop::Cop::Style::SpaceInsideBrackets do
   end
 
   it 'auto-corrects unwanted space' do
-    new_source = autocorrect_source(cop, ['a = [1, 2 ]',
-                                          'b = [ 1, 2]',
-                                          'c[ :key]',
-                                          'd[:key ]',
-                                          'e["key" ]',
-                                          'f[ "key"]'])
-    expect(new_source).to eq(['a = [1, 2]',
-                              'b = [1, 2]',
-                              'c[:key]',
-                              'd[:key]',
-                              'e["key"]',
-                              'f["key"]'].join("\n"))
+    new_source = autocorrect_source(cop, <<-END.strip_indent)
+      a = [1, 2 ]
+      b = [ 1, 2]
+      c[ :key]
+      d[:key ]
+      e["key" ]
+      f[ "key"]
+    END
+    expect(new_source).to eq(<<-END.strip_indent)
+      a = [1, 2]
+      b = [1, 2]
+      c[:key]
+      d[:key]
+      e["key"]
+      f["key"]
+    END
   end
 end

--- a/spec/rubocop/cop/style/space_inside_hash_literal_braces_spec.rb
+++ b/spec/rubocop/cop/style/space_inside_hash_literal_braces_spec.rb
@@ -47,9 +47,10 @@ describe RuboCop::Cop::Style::SpaceInsideHashLiteralBraces, :config do
   end
 
   it 'registers an offense for hashes with no spaces if so configured' do
-    inspect_source(cop,
-                   ['h = {a: 1, b: 2}',
-                    'h = {a => 1}'])
+    inspect_source(cop, <<-END.strip_indent)
+      h = {a: 1, b: 2}
+      h = {a => 1}
+    END
     expect(cop.messages).to eq(['Space inside { missing.',
                                 'Space inside } missing.',
                                 'Space inside { missing.',
@@ -66,10 +67,14 @@ describe RuboCop::Cop::Style::SpaceInsideHashLiteralBraces, :config do
   end
 
   it 'auto-corrects missing space' do
-    new_source = autocorrect_source(cop, ['h = {a: 1, b: 2}',
-                                          'h = {a => 1 }'])
-    expect(new_source).to eq(['h = { a: 1, b: 2 }',
-                              'h = { a => 1 }'].join("\n"))
+    new_source = autocorrect_source(cop, <<-END.strip_indent)
+      h = {a: 1, b: 2}
+      h = {a => 1 }
+    END
+    expect(new_source).to eq(<<-END.strip_indent)
+      h = { a: 1, b: 2 }
+      h = { a => 1 }
+    END
   end
 
   context 'when EnforcedStyle is no_space' do
@@ -92,34 +97,41 @@ describe RuboCop::Cop::Style::SpaceInsideHashLiteralBraces, :config do
     end
 
     it 'auto-corrects unwanted space' do
-      new_source = autocorrect_source(cop, ['h = { a: 1, b: 2 }',
-                                            'h = {a => 1 }'])
-      expect(new_source).to eq(['h = {a: 1, b: 2}',
-                                'h = {a => 1}'].join("\n"))
+      new_source = autocorrect_source(cop, <<-END.strip_indent)
+        h = { a: 1, b: 2 }
+        h = {a => 1 }
+      END
+      expect(new_source).to eq(<<-END.strip_indent)
+        h = {a: 1, b: 2}
+        h = {a => 1}
+      END
     end
 
     it 'accepts hashes with no spaces' do
-      inspect_source(cop,
-                     ['h = {a: 1, b: 2}',
-                      'h = {a => 1}'])
+      inspect_source(cop, <<-END.strip_indent)
+        h = {a: 1, b: 2}
+        h = {a => 1}
+      END
       expect(cop.offenses).to be_empty
     end
 
     it 'accepts multiline hash' do
-      inspect_source(cop,
-                     ['h = {',
-                      '      a: 1,',
-                      '      b: 2,',
-                      '}'])
+      inspect_source(cop, <<-END.strip_indent)
+        h = {
+              a: 1,
+              b: 2,
+        }
+      END
       expect(cop.offenses).to be_empty
     end
 
     it 'accepts multiline hash with comment' do
-      inspect_source(cop,
-                     ['h = { # Comment',
-                      '      a: 1,',
-                      '      b: 2,',
-                      '}'])
+      inspect_source(cop, <<-END.strip_indent)
+        h = { # Comment
+              a: 1,
+              b: 2,
+        }
+      END
       expect(cop.offenses).to be_empty
     end
   end
@@ -147,49 +159,61 @@ describe RuboCop::Cop::Style::SpaceInsideHashLiteralBraces, :config do
     end
 
     it 'auto-corrects hashes with no space' do
-      new_source = autocorrect_source(cop, ['h = {a: 1, b: 2}',
-                                            'h = {a => 1 }'])
-      expect(new_source).to eq(['h = { a: 1, b: 2 }',
-                                'h = { a => 1 }'].join("\n"))
+      new_source = autocorrect_source(cop, <<-END.strip_indent)
+        h = {a: 1, b: 2}
+        h = {a => 1 }
+      END
+      expect(new_source).to eq(<<-END.strip_indent)
+        h = { a: 1, b: 2 }
+        h = { a => 1 }
+      END
     end
 
     it 'auto-corrects nested hashes with spaces' do
-      new_source = autocorrect_source(cop, ['h = { a: { a: 1, b: 2 } }',
-                                            'h = {a => method { 1 } }'])
-      expect(new_source).to eq(['h = { a: { a: 1, b: 2 }}',
-                                'h = { a => method { 1 }}'].join("\n"))
+      new_source = autocorrect_source(cop, <<-END.strip_indent)
+        h = { a: { a: 1, b: 2 } }
+        h = {a => method { 1 } }
+      END
+      expect(new_source).to eq(<<-END.strip_indent)
+        h = { a: { a: 1, b: 2 }}
+        h = { a => method { 1 }}
+      END
     end
 
     it 'registers offenses for hashes with no spaces' do
-      inspect_source(cop,
-                     ['h = {a: 1, b: 2}',
-                      'h = {a => 1}'])
+      inspect_source(cop, <<-END.strip_indent)
+        h = {a: 1, b: 2}
+        h = {a => 1}
+      END
       expect(cop.offenses.size).to eq 4
     end
 
     it 'accepts multiline hash' do
-      inspect_source(cop,
-                     ['h = {',
-                      '      a: 1,',
-                      '      b: 2,',
-                      '}'])
+      inspect_source(cop, <<-END.strip_indent)
+        h = {
+              a: 1,
+              b: 2,
+        }
+      END
       expect(cop.offenses).to be_empty
     end
 
     it 'accepts multiline hash with comment' do
-      inspect_source(cop,
-                     ['h = { # Comment',
-                      '      a: 1,',
-                      '      b: 2,',
-                      '}'])
+      inspect_source(cop, <<-END.strip_indent)
+        h = { # Comment
+              a: 1,
+              b: 2,
+        }
+      END
       expect(cop.offenses).to be_empty
     end
   end
 
   it 'accepts hashes with spaces by default' do
-    inspect_source(cop,
-                   ['h = { a: 1, b: 2 }',
-                    'h = { a => 1 }'])
+    inspect_source(cop, <<-END.strip_indent)
+      h = { a: 1, b: 2 }
+      h = { a => 1 }
+    END
     expect(cop.offenses).to be_empty
   end
 

--- a/spec/rubocop/cop/style/space_inside_parens_spec.rb
+++ b/spec/rubocop/cop/style/space_inside_parens_spec.rb
@@ -4,15 +4,18 @@ describe RuboCop::Cop::Style::SpaceInsideParens do
   subject(:cop) { described_class.new }
 
   it 'registers an offense for spaces inside parens' do
-    inspect_source(cop, ['f( 3)',
-                         'g = (a + 3 )'])
+    inspect_source(cop, <<-END.strip_indent)
+      f( 3)
+      g = (a + 3 )
+    END
     expect(cop.messages).to eq(['Space inside parentheses detected.'] * 2)
   end
 
   it 'accepts parentheses in block parameter list' do
-    inspect_source(cop,
-                   ['list.inject(Tms.new) { |sum, (label, item)|',
-                    '}'])
+    inspect_source(cop, <<-END.strip_indent)
+      list.inject(Tms.new) { |sum, (label, item)|
+      }
+    END
     expect(cop.messages).to be_empty
   end
 
@@ -22,21 +25,29 @@ describe RuboCop::Cop::Style::SpaceInsideParens do
   end
 
   it 'accepts parentheses with line break' do
-    inspect_source(cop, ['f(',
-                         '  1)'])
+    inspect_source(cop, <<-END.strip_indent)
+      f(
+        1)
+    END
     expect(cop.messages).to be_empty
   end
 
   it 'accepts parentheses with comment and line break' do
-    inspect_source(cop, ['f( # Comment',
-                         '  1)'])
+    inspect_source(cop, <<-END.strip_indent)
+      f( # Comment
+        1)
+    END
     expect(cop.messages).to be_empty
   end
 
   it 'auto-corrects unwanted space' do
-    new_source = autocorrect_source(cop, ['f( 3)',
-                                          'g = ( a + 3 )'])
-    expect(new_source).to eq(['f(3)',
-                              'g = (a + 3)'].join("\n"))
+    new_source = autocorrect_source(cop, <<-END.strip_indent)
+      f( 3)
+      g = ( a + 3 )
+    END
+    expect(new_source).to eq(<<-END.strip_indent)
+      f(3)
+      g = (a + 3)
+    END
   end
 end

--- a/spec/rubocop/cop/style/space_inside_percent_literal_delimiters_spec.rb
+++ b/spec/rubocop/cop/style/space_inside_percent_literal_delimiters_spec.rb
@@ -55,28 +55,34 @@ describe RuboCop::Cop::Style::SpaceInsidePercentLiteralDelimiters do
         end
 
         it 'accepts multi-line literals' do
-          inspect_source(cop, ["%#{type}(",
-                               '  a',
-                               '  b',
-                               '  c',
-                               ')'])
+          inspect_source(cop, <<-END.strip_indent)
+            %#{type}(
+              a
+              b
+              c
+            )
+          END
           expect(cop.messages).to be_empty
         end
 
         it 'accepts multi-line literals within a method' do
-          inspect_source(cop, ['def foo',
-                               "  %#{type}(",
-                               '    a',
-                               '    b',
-                               '    c',
-                               '  )',
-                               'end'])
+          inspect_source(cop, <<-END.strip_indent)
+            def foo
+              %#{type}(
+                a
+                b
+                c
+              )
+            end
+          END
           expect(cop.messages).to be_empty
         end
 
         it 'accepts newlines and additional following alignment spaces' do
-          inspect_source(cop, ["%#{type}(a b",
-                               '   c)'])
+          inspect_source(cop, <<-END.strip_indent)
+            %#{type}(a b
+               c)
+          END
           expect(cop.messages).to be_empty
         end
 

--- a/spec/rubocop/cop/style/space_inside_range_literal_spec.rb
+++ b/spec/rubocop/cop/style/space_inside_range_literal_spec.rb
@@ -4,10 +4,11 @@ describe RuboCop::Cop::Style::SpaceInsideRangeLiteral do
   subject(:cop) { described_class.new }
 
   it 'registers an offense for space inside .. literal' do
-    inspect_source(cop,
-                   ['1 .. 2',
-                    '1.. 2',
-                    '1 ..2'])
+    inspect_source(cop, <<-END.strip_indent)
+      1 .. 2
+      1.. 2
+      1 ..2
+    END
     expect(cop.offenses.size).to eq(3)
     expect(cop.messages)
       .to eq(['Space inside range literal.'] * 3)
@@ -19,10 +20,11 @@ describe RuboCop::Cop::Style::SpaceInsideRangeLiteral do
   end
 
   it 'registers an offense for space inside ... literal' do
-    inspect_source(cop,
-                   ['1 ... 2',
-                    '1... 2',
-                    '1 ...2'])
+    inspect_source(cop, <<-END.strip_indent)
+      1 ... 2
+      1... 2
+      1 ...2
+    END
     expect(cop.offenses.size).to eq(3)
     expect(cop.messages)
       .to eq(['Space inside range literal.'] * 3)
@@ -39,14 +41,18 @@ describe RuboCop::Cop::Style::SpaceInsideRangeLiteral do
   end
 
   it 'accepts multiline range literal with no space in it' do
-    inspect_source(cop, ['x = 0..',
-                         '    10'])
+    inspect_source(cop, <<-END.strip_indent)
+      x = 0..
+          10
+    END
     expect(cop.offenses).to be_empty
   end
 
   it 'registers an offense in multiline range literal with space in it' do
-    inspect_source(cop, ['x = 0 ..',
-                         '    10'])
+    inspect_source(cop, <<-END.strip_indent)
+      x = 0 ..
+          10
+    END
     expect(cop.offenses.size).to eq(1)
   end
 

--- a/spec/rubocop/cop/style/struct_inheritance_spec.rb
+++ b/spec/rubocop/cop/style/struct_inheritance_spec.rb
@@ -4,30 +4,34 @@ describe RuboCop::Cop::Style::StructInheritance do
   subject(:cop) { described_class.new }
 
   it 'registers an offense when extending instance of Struct' do
-    inspect_source(cop,
-                   ['class Person < Struct.new(:first_name, :last_name)',
-                    'end'])
+    inspect_source(cop, <<-END.strip_indent)
+      class Person < Struct.new(:first_name, :last_name)
+      end
+    END
     expect(cop.offenses.size).to eq(1)
   end
 
   it 'registers an offense when extending instance of Struct with do ... end' do
-    inspect_source(cop,
-                   ['class Person < Struct.new(:first_name, :last_name) do end',
-                    'end'])
+    inspect_source(cop, <<-END.strip_indent)
+      class Person < Struct.new(:first_name, :last_name) do end
+      end
+    END
     expect(cop.offenses.size).to eq(1)
   end
 
   it 'accepts plain class' do
-    inspect_source(cop,
-                   ['class Person',
-                    'end'])
+    inspect_source(cop, <<-END.strip_indent)
+      class Person
+      end
+    END
     expect(cop.offenses).to be_empty
   end
 
   it 'accepts extending DelegateClass' do
-    inspect_source(cop,
-                   ['class Person < DelegateClass(Animal)',
-                    'end'])
+    inspect_source(cop, <<-END.strip_indent)
+      class Person < DelegateClass(Animal)
+      end
+    END
     expect(cop.offenses).to be_empty
   end
 

--- a/spec/rubocop/cop/style/symbol_proc_spec.rb
+++ b/spec/rubocop/cop/style/symbol_proc_spec.rb
@@ -154,13 +154,17 @@ describe RuboCop::Cop::Style::SymbolProc, :config do
   end
 
   it 'auto-corrects correctly when args have a trailing comma' do
-    corrected = autocorrect_source(cop, ['mail(',
-                                         "  to: 'foo',",
-                                         "  subject: 'bar',",
-                                         ') { |format| format.text }'])
-    expect(corrected).to eq(['mail(',
-                             "  to: 'foo',",
-                             "  subject: 'bar', &:text",
-                             ')'].join("\n"))
+    corrected = autocorrect_source(cop, <<-END.strip_indent)
+      mail(
+        to: 'foo',
+        subject: 'bar',
+      ) { |format| format.text }
+    END
+    expect(corrected).to eq(<<-END.strip_indent)
+      mail(
+        to: 'foo',
+        subject: 'bar', &:text
+      )
+    END
   end
 end

--- a/spec/rubocop/cop/style/tab_spec.rb
+++ b/spec/rubocop/cop/style/tab_spec.rb
@@ -19,9 +19,11 @@ describe RuboCop::Cop::Style::Tab do
   end
 
   it 'registers offenses before __END__ but not after' do
-    inspect_source(cop, ["\tx = 0",
-                         '__END__',
-                         "\tx = 0"])
+    inspect_source(cop, <<-END.strip_indent)
+      \tx = 0
+      __END__
+      \tx = 0
+    END
     expect(cop.messages).to eq(['Tab detected.'])
   end
 

--- a/spec/rubocop/cop/style/trailing_comma_in_arguments_spec.rb
+++ b/spec/rubocop/cop/style/trailing_comma_in_arguments_spec.rb
@@ -38,8 +38,10 @@ describe RuboCop::Cop::Style::TrailingCommaInArguments, :config do
     end
 
     it 'accepts chained single-line method calls' do
-      inspect_source(cop, ['target',
-                           '  .some_method(a)'])
+      inspect_source(cop, <<-END.strip_indent)
+        target
+          .some_method(a)
+      END
       expect(cop.offenses).to be_empty
     end
 
@@ -80,45 +82,55 @@ describe RuboCop::Cop::Style::TrailingCommaInArguments, :config do
 
       it 'registers an offense for trailing comma in a method call with ' \
          'hash parameters at the end' do
-        inspect_source(cop, ['some_method(',
-                             '              a,',
-                             '              b,',
-                             '              c: 0,',
-                             '              d: 1,)'])
+        inspect_source(cop, <<-END.strip_indent)
+          some_method(
+                        a,
+                        b,
+                        c: 0,
+                        d: 1,)
+        END
         expect(cop.highlights).to eq([','])
       end
 
       it 'accepts a method call with ' \
          'hash parameters at the end and no trailing comma' do
-        inspect_source(cop, ['some_method(a,',
-                             '            b,',
-                             '            c: 0,',
-                             '            d: 1',
-                             '           )'])
+        inspect_source(cop, <<-END.strip_indent)
+          some_method(a,
+                      b,
+                      c: 0,
+                      d: 1
+                     )
+        END
         expect(cop.offenses).to be_empty
       end
 
       it 'accepts comma inside a heredoc parameter at the end' do
-        inspect_source(cop, ['route(help: {',
-                             "  'auth' => <<-HELP.chomp",
-                             ',',
-                             'HELP',
-                             '})'])
+        inspect_source(cop, <<-END.strip_indent)
+          route(help: {
+            'auth' => <<-HELP.chomp
+          ,
+          HELP
+          })
+        END
         expect(cop.offenses).to be_empty
       end
 
       it 'auto-corrects unwanted comma in a method call with hash parameters' \
          ' at the end' do
-        new_source = autocorrect_source(cop, ['some_method(',
-                                              '              a,',
-                                              '              b,',
-                                              '              c: 0,',
-                                              '              d: 1,)'])
-        expect(new_source).to eq(['some_method(',
-                                  '              a,',
-                                  '              b,',
-                                  '              c: 0,',
-                                  '              d: 1)'].join("\n"))
+        new_source = autocorrect_source(cop, <<-END.strip_indent)
+          some_method(
+                        a,
+                        b,
+                        c: 0,
+                        d: 1,)
+        END
+        expect(new_source).to eq(<<-END.strip_indent)
+          some_method(
+                        a,
+                        b,
+                        c: 0,
+                        d: 1)
+        END
       end
     end
 
@@ -128,20 +140,24 @@ describe RuboCop::Cop::Style::TrailingCommaInArguments, :config do
       context 'when closing bracket is on same line as last value' do
         it 'accepts a method call with Hash as last parameter split on ' \
            'multiple lines' do
-          inspect_source(cop, ['some_method(a: "b",',
-                               '            c: "d")'])
+          inspect_source(cop, <<-END.strip_indent)
+            some_method(a: "b",
+                        c: "d")
+          END
           expect(cop.offenses).to be_empty
         end
       end
 
       it 'registers an offense for no trailing comma in a method call with' \
          ' hash parameters at the end' do
-        inspect_source(cop, ['some_method(',
-                             '              a,',
-                             '              b,',
-                             '              c: 0,',
-                             '              d: 1',
-                             '           )'])
+        inspect_source(cop, <<-END.strip_indent)
+          some_method(
+                        a,
+                        b,
+                        c: 0,
+                        d: 1
+                     )
+        END
         expect(cop.messages)
           .to eq(['Put a comma after the last parameter of a multiline ' \
                   'method call.'])
@@ -149,71 +165,89 @@ describe RuboCop::Cop::Style::TrailingCommaInArguments, :config do
       end
 
       it 'accepts a method call with two parameters on the same line' do
-        inspect_source(cop, ['some_method(a, b',
-                             '           )'])
+        inspect_source(cop, <<-END.strip_indent)
+          some_method(a, b
+                     )
+        END
         expect(cop.offenses).to be_empty
       end
 
       it 'accepts trailing comma in a method call with hash' \
          ' parameters at the end' do
-        inspect_source(cop, ['some_method(',
-                             '              a,',
-                             '              b,',
-                             '              c: 0,',
-                             '              d: 1,',
-                             '           )'])
+        inspect_source(cop, <<-END.strip_indent)
+          some_method(
+                        a,
+                        b,
+                        c: 0,
+                        d: 1,
+                     )
+        END
         expect(cop.offenses).to be_empty
       end
 
       it 'accepts no trailing comma in a method call with a multiline' \
          ' braceless hash at the end with more than one parameter on a line' do
-        inspect_source(cop, ['some_method(',
-                             '              a,',
-                             '              b: 0,',
-                             '              c: 0, d: 1',
-                             '           )'])
+        inspect_source(cop, <<-END.strip_indent)
+          some_method(
+                        a,
+                        b: 0,
+                        c: 0, d: 1
+                     )
+        END
         expect(cop.offenses).to be_empty
       end
 
       it 'accepts a trailing comma in a method call with single ' \
          'line hashes' do
-        inspect_source(cop, ['some_method(',
-                             ' { a: 0, b: 1 },',
-                             ' { a: 1, b: 0 },',
-                             ')'])
+        inspect_source(cop, <<-END.strip_indent)
+          some_method(
+           { a: 0, b: 1 },
+           { a: 1, b: 0 },
+          )
+        END
 
         expect(cop.offenses).to be_empty
       end
 
       it 'accepts an empty hash being passed as a method argument' do
         inspect_source(cop, 'Foo.new({})')
-        inspect_source(cop, ['Foo.new({',
-                             '         })'])
-        inspect_source(cop, ['Foo.new([',
-                             '         ])'])
+        inspect_source(cop, <<-END.strip_indent)
+          Foo.new({
+                   })
+        END
+        inspect_source(cop, <<-END.strip_indent)
+          Foo.new([
+                   ])
+        END
         expect(cop.offenses).to be_empty
       end
 
       it 'auto-corrects missing comma in a method call with hash parameters' \
          ' at the end' do
-        new_source = autocorrect_source(cop, ['some_method(',
-                                              '              a,',
-                                              '              b,',
-                                              '              c: 0,',
-                                              '              d: 1',
-                                              '           )'])
-        expect(new_source).to eq(['some_method(',
-                                  '              a,',
-                                  '              b,',
-                                  '              c: 0,',
-                                  '              d: 1,',
-                                  '           )'].join("\n"))
+        new_source = autocorrect_source(cop, <<-END.strip_indent)
+          some_method(
+                        a,
+                        b,
+                        c: 0,
+                        d: 1
+                     )
+        END
+        expect(new_source).to eq(<<-END.strip_indent)
+          some_method(
+                        a,
+                        b,
+                        c: 0,
+                        d: 1,
+                     )
+        END
       end
 
       it 'accepts a multiline call with a single argument and trailing comma' do
-        inspect_source(cop, ['method(',
-                             '  1,',
-                             ')'])
+        inspect_source(cop, <<-END.strip_indent)
+          method(
+            1,
+          )
+        END
         expect(cop.offenses).to be_empty
       end
     end
@@ -224,8 +258,10 @@ describe RuboCop::Cop::Style::TrailingCommaInArguments, :config do
       context 'when closing bracket is on same line as last value' do
         it 'registers an offense for a method call, with a Hash as the ' \
            'last parameter, split on multiple lines' do
-          inspect_source(cop, ['some_method(a: "b",',
-                               '            c: "d")'])
+          inspect_source(cop, <<-END.strip_indent)
+            some_method(a: "b",
+                        c: "d")
+          END
           expect(cop.messages)
             .to eq(['Put a comma after the last parameter of a ' \
                     'multiline method call.'])
@@ -234,12 +270,14 @@ describe RuboCop::Cop::Style::TrailingCommaInArguments, :config do
 
       it 'registers an offense for no trailing comma in a method call with' \
          ' hash parameters at the end' do
-        inspect_source(cop, ['some_method(',
-                             '              a,',
-                             '              b,',
-                             '              c: 0,',
-                             '              d: 1',
-                             '           )'])
+        inspect_source(cop, <<-END.strip_indent)
+          some_method(
+                        a,
+                        b,
+                        c: 0,
+                        d: 1
+                     )
+        END
         expect(cop.messages)
           .to eq(['Put a comma after the last parameter of a multiline ' \
                   'method call.'])
@@ -248,8 +286,10 @@ describe RuboCop::Cop::Style::TrailingCommaInArguments, :config do
 
       it 'registers an offense for no trailing comma in a method call with' \
           'two parameters on the same line' do
-        inspect_source(cop, ['some_method(a, b',
-                             '           )'])
+        inspect_source(cop, <<-END.strip_indent)
+          some_method(a, b
+                     )
+        END
         expect(cop.messages)
           .to eq(['Put a comma after the last parameter of a multiline ' \
                   'method call.'])
@@ -257,30 +297,36 @@ describe RuboCop::Cop::Style::TrailingCommaInArguments, :config do
 
       it 'accepts trailing comma in a method call with hash' \
          ' parameters at the end' do
-        inspect_source(cop, ['some_method(',
-                             '              a,',
-                             '              b,',
-                             '              c: 0,',
-                             '              d: 1,',
-                             '           )'])
+        inspect_source(cop, <<-END.strip_indent)
+          some_method(
+                        a,
+                        b,
+                        c: 0,
+                        d: 1,
+                     )
+        END
         expect(cop.offenses).to be_empty
       end
 
       it 'accepts a trailing comma in a method call with ' \
          'a single hash parameter' do
-        inspect_source(cop, ['some_method(',
-                             '              a: 0,',
-                             '              b: 1,',
-                             '           )'])
+        inspect_source(cop, <<-END.strip_indent)
+          some_method(
+                        a: 0,
+                        b: 1,
+                     )
+        END
         expect(cop.offenses).to be_empty
       end
 
       it 'accepts a trailing comma in a method call with single ' \
          'line hashes' do
-        inspect_source(cop, ['some_method(',
-                             ' { a: 0, b: 1 },',
-                             ' { a: 1, b: 0 },',
-                             ')'])
+        inspect_source(cop, <<-END.strip_indent)
+          some_method(
+           { a: 0, b: 1 },
+           { a: 1, b: 0 },
+          )
+        END
 
         expect(cop.offenses).to be_empty
       end
@@ -288,54 +334,66 @@ describe RuboCop::Cop::Style::TrailingCommaInArguments, :config do
       # this is a sad parse error
       it 'accepts no trailing comma in a method call with a block' \
          ' parameter at the end' do
-        inspect_source(cop, ['some_method(',
-                             '              a,',
-                             '              b,',
-                             '              c: 0,',
-                             '              d: 1,',
-                             '              &block',
-                             '           )'])
+        inspect_source(cop, <<-END.strip_indent)
+          some_method(
+                        a,
+                        b,
+                        c: 0,
+                        d: 1,
+                        &block
+                     )
+        END
         expect(cop.offenses).to be_empty
       end
 
       it 'accepts missing comma after a heredoc' do
         # A heredoc that's the last item in a literal or parameter list can not
         # have a trailing comma. It's a syntax error.
-        inspect_source(cop, ['route(1, <<-HELP.chomp',
-                             '...',
-                             'HELP',
-                             ')'])
+        inspect_source(cop, <<-END.strip_indent)
+          route(1, <<-HELP.chomp
+          ...
+          HELP
+          )
+        END
         expect(cop.offenses).to be_empty
       end
 
       it 'auto-corrects missing comma in a method call with hash parameters' \
          ' at the end' do
-        new_source = autocorrect_source(cop, ['some_method(',
-                                              '              a,',
-                                              '              b,',
-                                              '              c: 0,',
-                                              '              d: 1',
-                                              '           )'])
-        expect(new_source).to eq(['some_method(',
-                                  '              a,',
-                                  '              b,',
-                                  '              c: 0,',
-                                  '              d: 1,',
-                                  '           )'].join("\n"))
+        new_source = autocorrect_source(cop, <<-END.strip_indent)
+          some_method(
+                        a,
+                        b,
+                        c: 0,
+                        d: 1
+                     )
+        END
+        expect(new_source).to eq(<<-END.strip_indent)
+          some_method(
+                        a,
+                        b,
+                        c: 0,
+                        d: 1,
+                     )
+        END
       end
 
       it 'accepts a multiline call with a single argument and trailing comma' do
-        inspect_source(cop, ['method(',
-                             '  1,',
-                             ')'])
+        inspect_source(cop, <<-END.strip_indent)
+          method(
+            1,
+          )
+        END
         expect(cop.offenses).to be_empty
       end
 
       it 'accepts a multiline call with arguments on a single line and' \
          ' trailing comma' do
-        inspect_source(cop, ['method(',
-                             '  1, 2,',
-                             ')'])
+        inspect_source(cop, <<-END.strip_indent)
+          method(
+            1, 2,
+          )
+        END
         expect(cop.offenses).to be_empty
       end
     end

--- a/spec/rubocop/cop/style/trailing_comma_in_literal_spec.rb
+++ b/spec/rubocop/cop/style/trailing_comma_in_literal_spec.rb
@@ -35,10 +35,12 @@ describe RuboCop::Cop::Style::TrailingCommaInLiteral, :config do
 
     it 'accepts rescue clause' do
       # The list of rescued classes is an array.
-      inspect_source(cop, ['begin',
-                           '  do_something',
-                           'rescue RuntimeError',
-                           'end'])
+      inspect_source(cop, <<-END.strip_indent)
+        begin
+          do_something
+        rescue RuntimeError
+        end
+      END
       expect(cop.offenses).to be_empty
     end
 
@@ -93,44 +95,54 @@ describe RuboCop::Cop::Style::TrailingCommaInLiteral, :config do
       let(:cop_config) { { 'EnforcedStyleForMultiline' => 'no_comma' } }
 
       it 'registers an offense for trailing comma in an Array literal' do
-        inspect_source(cop, ['VALUES = [',
-                             '           1001,',
-                             '           2020,',
-                             '           3333,',
-                             '         ]'])
+        inspect_source(cop, <<-END.strip_indent)
+          VALUES = [
+                     1001,
+                     2020,
+                     3333,
+                   ]
+        END
         expect(cop.highlights).to eq([','])
       end
 
       it 'registers an offense for trailing comma in a Hash literal' do
-        inspect_source(cop, ['MAP = { a: 1001,',
-                             '        b: 2020,',
-                             '        c: 3333,',
-                             '      }'])
+        inspect_source(cop, <<-END.strip_indent)
+          MAP = { a: 1001,
+                  b: 2020,
+                  c: 3333,
+                }
+        END
         expect(cop.highlights).to eq([','])
       end
 
       it 'accepts an Array literal with no trailing comma' do
-        inspect_source(cop, ['VALUES = [ 1001,',
-                             '           2020,',
-                             '           3333 ]'])
+        inspect_source(cop, <<-END.strip_indent)
+          VALUES = [ 1001,
+                     2020,
+                     3333 ]
+        END
         expect(cop.offenses).to be_empty
       end
 
       it 'accepts a Hash literal with no trailing comma' do
-        inspect_source(cop, ['MAP = {',
-                             '        a: 1001,',
-                             '        b: 2020,',
-                             '        c: 3333',
-                             '      }'])
+        inspect_source(cop, <<-END.strip_indent)
+          MAP = {
+                  a: 1001,
+                  b: 2020,
+                  c: 3333
+                }
+        END
         expect(cop.offenses).to be_empty
       end
 
       it 'accepts comma inside a heredoc parameters at the end' do
-        inspect_source(cop, ['route(help: {',
-                             "  'auth' => <<-HELP.chomp",
-                             ',',
-                             'HELP',
-                             '})'])
+        inspect_source(cop, <<-END.strip_indent)
+          route(help: {
+            'auth' => <<-HELP.chomp
+          ,
+          HELP
+          })
+        END
         expect(cop.offenses).to be_empty
       end
 
@@ -143,27 +155,35 @@ describe RuboCop::Cop::Style::TrailingCommaInLiteral, :config do
       end
 
       it 'auto-corrects unwanted comma in an Array literal' do
-        new_source = autocorrect_source(cop, ['VALUES = [',
-                                              '           1001,',
-                                              '           2020,',
-                                              '           3333,',
-                                              '         ]'])
-        expect(new_source).to eq(['VALUES = [',
-                                  '           1001,',
-                                  '           2020,',
-                                  '           3333',
-                                  '         ]'].join("\n"))
+        new_source = autocorrect_source(cop, <<-END.strip_indent)
+          VALUES = [
+                     1001,
+                     2020,
+                     3333,
+                   ]
+        END
+        expect(new_source).to eq(<<-END.strip_indent)
+          VALUES = [
+                     1001,
+                     2020,
+                     3333
+                   ]
+        END
       end
 
       it 'auto-corrects unwanted comma in a Hash literal' do
-        new_source = autocorrect_source(cop, ['MAP = { a: 1001,',
-                                              '        b: 2020,',
-                                              '        c: 3333,',
-                                              '      }'])
-        expect(new_source).to eq(['MAP = { a: 1001,',
-                                  '        b: 2020,',
-                                  '        c: 3333',
-                                  '      }'].join("\n"))
+        new_source = autocorrect_source(cop, <<-END.strip_indent)
+          MAP = { a: 1001,
+                  b: 2020,
+                  c: 3333,
+                }
+        END
+        expect(new_source).to eq(<<-END.strip_indent)
+          MAP = { a: 1001,
+                  b: 2020,
+                  c: 3333
+                }
+        END
       end
     end
 
@@ -172,141 +192,177 @@ describe RuboCop::Cop::Style::TrailingCommaInLiteral, :config do
 
       context 'when closing bracket is on same line as last value' do
         it 'accepts Array literal with no trailing comma' do
-          inspect_source(cop, ['VALUES = [',
-                               '           1001,',
-                               '           2020,',
-                               '           3333]'])
+          inspect_source(cop, <<-END.strip_indent)
+            VALUES = [
+                       1001,
+                       2020,
+                       3333]
+          END
           expect(cop.offenses).to be_empty
         end
 
         it 'accepts a Hash literal with no trailing comma' do
-          inspect_source(cop, ['VALUES = {',
-                               '           a: "b",',
-                               '           c: "d",',
-                               '           e: "f"}'])
+          inspect_source(cop, <<-END.strip_indent)
+            VALUES = {
+                       a: "b",
+                       c: "d",
+                       e: "f"}
+          END
           expect(cop.offenses).to be_empty
         end
       end
 
       it 'accepts Array literal with two of the values on the same line' do
-        inspect_source(cop, ['VALUES = [',
-                             '           1001, 2020,',
-                             '           3333',
-                             '         ]'])
+        inspect_source(cop, <<-END.strip_indent)
+          VALUES = [
+                     1001, 2020,
+                     3333
+                   ]
+        END
         expect(cop.offenses).to be_empty
       end
 
       it 'registers an offense for an Array literal with two of the values ' \
          'on the same line and a trailing comma' do
-        inspect_source(cop, ['VALUES = [',
-                             '           1001, 2020,',
-                             '           3333,',
-                             '         ]'])
+        inspect_source(cop, <<-END.strip_indent)
+          VALUES = [
+                     1001, 2020,
+                     3333,
+                   ]
+        END
         expect(cop.messages)
           .to eq(['Avoid comma after the last item of an array, unless each ' \
                   'item is on its own line.'])
       end
 
       it 'registers an offense for no trailing comma in a Hash literal' do
-        inspect_source(cop, ['MAP = { a: 1001,',
-                             '        b: 2020,',
-                             '        c: 3333',
-                             '}'])
+        inspect_source(cop, <<-END.strip_indent)
+          MAP = { a: 1001,
+                  b: 2020,
+                  c: 3333
+          }
+        END
         expect(cop.messages)
           .to eq(['Put a comma after the last item of a multiline hash.'])
         expect(cop.highlights).to eq(['c: 3333'])
       end
 
       it 'registers an offense for trailing comma in a comment in Hash' do
-        inspect_source(cop, ['MAP = { a: 1001,',
-                             '        b: 2020,',
-                             '        c: 3333 # ,',
-                             '}'])
+        inspect_source(cop, <<-END.strip_indent)
+          MAP = { a: 1001,
+                  b: 2020,
+                  c: 3333 # ,
+          }
+        END
         expect(cop.messages)
           .to eq(['Put a comma after the last item of a multiline hash.'])
         expect(cop.highlights).to eq(['c: 3333'])
       end
 
       it 'accepts trailing comma in an Array literal' do
-        inspect_source(cop, ['VALUES = [1001,',
-                             '          2020,',
-                             '          3333,',
-                             '         ]'])
+        inspect_source(cop, <<-END.strip_indent)
+          VALUES = [1001,
+                    2020,
+                    3333,
+                   ]
+        END
         expect(cop.offenses).to be_empty
       end
 
       it 'accepts trailing comma in a Hash literal' do
-        inspect_source(cop, ['MAP = {',
-                             '        a: 1001,',
-                             '        b: 2020,',
-                             '        c: 3333,',
-                             '      }'])
+        inspect_source(cop, <<-END.strip_indent)
+          MAP = {
+                  a: 1001,
+                  b: 2020,
+                  c: 3333,
+                }
+        END
         expect(cop.offenses).to be_empty
       end
 
       it 'accepts a multiline word array' do
-        inspect_source(cop, ['ingredients = %w(',
-                             '  sausage',
-                             '  anchovies',
-                             '  olives',
-                             ')'])
+        inspect_source(cop, <<-END.strip_indent)
+          ingredients = %w(
+            sausage
+            anchovies
+            olives
+          )
+        END
         expect(cop.offenses).to be_empty
       end
 
       it 'accepts missing comma after a heredoc' do
         # A heredoc that's the last item in a literal or parameter list can not
         # have a trailing comma. It's a syntax error.
-        inspect_source(cop, ['route(help: {',
-                             "  'auth' => <<-HELP.chomp",
-                             '...',
-                             'HELP',
-                             '})'])
+        inspect_source(cop, <<-END.strip_indent)
+          route(help: {
+            'auth' => <<-HELP.chomp
+          ...
+          HELP
+          })
+        END
         expect(cop.offenses).to be_empty
       end
 
       it 'accepts an empty hash being passed as a method argument' do
         inspect_source(cop, 'Foo.new({})')
-        inspect_source(cop, ['Foo.new({',
-                             '         })'])
-        inspect_source(cop, ['Foo.new([',
-                             '         ])'])
+        inspect_source(cop, <<-END.strip_indent)
+          Foo.new({
+                   })
+        END
+        inspect_source(cop, <<-END.strip_indent)
+          Foo.new([
+                   ])
+        END
         expect(cop.offenses).to be_empty
       end
 
       it 'auto-corrects an Array literal with two of the values on the same' \
          ' line and a trailing comma' do
-        new_source = autocorrect_source(cop, ['VALUES = [',
-                                              '           1001, 2020,',
-                                              '           3333',
-                                              '         ]'])
-        expect(new_source).to eq(['VALUES = [',
-                                  '           1001, 2020,',
-                                  '           3333',
-                                  '         ]'].join("\n"))
+        new_source = autocorrect_source(cop, <<-END.strip_indent)
+          VALUES = [
+                     1001, 2020,
+                     3333
+                   ]
+        END
+        expect(new_source).to eq(<<-END.strip_indent)
+          VALUES = [
+                     1001, 2020,
+                     3333
+                   ]
+        END
       end
 
       it 'auto-corrects missing comma in a Hash literal' do
-        new_source = autocorrect_source(cop, ['MAP = { a: 1001,',
-                                              '        b: 2020,',
-                                              '        c: 3333',
-                                              '}'])
-        expect(new_source).to eq(['MAP = { a: 1001,',
-                                  '        b: 2020,',
-                                  '        c: 3333,',
-                                  '}'].join("\n"))
+        new_source = autocorrect_source(cop, <<-END.strip_indent)
+          MAP = { a: 1001,
+                  b: 2020,
+                  c: 3333
+          }
+        END
+        expect(new_source).to eq(<<-END.strip_indent)
+          MAP = { a: 1001,
+                  b: 2020,
+                  c: 3333,
+          }
+        END
       end
 
       it 'accepts a multiline array with a single item and trailing comma' do
-        inspect_source(cop, ['foo = [',
-                             '  1,',
-                             ']'])
+        inspect_source(cop, <<-END.strip_indent)
+          foo = [
+            1,
+          ]
+        END
         expect(cop.offenses).to be_empty
       end
 
       it 'accepts a multiline hash with a single pair and trailing comma' do
-        inspect_source(cop, ['bar = {',
-                             '  a: 123,',
-                             '}'])
+        inspect_source(cop, <<-END.strip_indent)
+          bar = {
+            a: 123,
+          }
+        END
         expect(cop.offenses).to be_empty
       end
     end
@@ -316,148 +372,186 @@ describe RuboCop::Cop::Style::TrailingCommaInLiteral, :config do
 
       context 'when closing bracket is on same line as last value' do
         it 'registers an offense for an Array literal with no trailing comma' do
-          inspect_source(cop, ['VALUES = [',
-                               '           1001,',
-                               '           2020,',
-                               '           3333]'])
+          inspect_source(cop, <<-END.strip_indent)
+            VALUES = [
+                       1001,
+                       2020,
+                       3333]
+          END
           expect(cop.messages)
             .to eq(['Put a comma after the last item of a multiline array.'])
         end
 
         it 'registers an offense for a Hash literal with no trailing comma' do
-          inspect_source(cop, ['VALUES = {',
-                               '           a: "b",',
-                               '           b: "c",',
-                               '           d: "e"}'])
+          inspect_source(cop, <<-END.strip_indent)
+            VALUES = {
+                       a: "b",
+                       b: "c",
+                       d: "e"}
+          END
           expect(cop.messages)
             .to eq(['Put a comma after the last item of a multiline hash.'])
         end
 
         it 'auto-corrects a missing comma in a Hash literal' do
-          new_source = autocorrect_source(cop, ['MAP = { a: 1001,',
-                                                '        b: 2020,',
-                                                '        c: 3333}'])
-          expect(new_source).to eq(['MAP = { a: 1001,',
-                                    '        b: 2020,',
-                                    '        c: 3333,}'].join("\n"))
+          new_source = autocorrect_source(cop, <<-END.strip_indent)
+            MAP = { a: 1001,
+                    b: 2020,
+                    c: 3333}
+          END
+          expect(new_source).to eq(<<-END.strip_indent)
+            MAP = { a: 1001,
+                    b: 2020,
+                    c: 3333,}
+          END
         end
       end
 
       it 'accepts Array literal with two of the values on the same line' do
-        inspect_source(cop, ['VALUES = [',
-                             '           1001, 2020,',
-                             '           3333,',
-                             '         ]'])
+        inspect_source(cop, <<-END.strip_indent)
+          VALUES = [
+                     1001, 2020,
+                     3333,
+                   ]
+        END
         expect(cop.offenses).to be_empty
       end
 
       it 'registers an offense for an Array literal with two of the values ' \
          'on the same line and no trailing comma' do
-        inspect_source(cop, ['VALUES = [',
-                             '           1001, 2020,',
-                             '           3333',
-                             '         ]'])
+        inspect_source(cop, <<-END.strip_indent)
+          VALUES = [
+                     1001, 2020,
+                     3333
+                   ]
+        END
         expect(cop.messages)
           .to eq(['Put a comma after the last item of a multiline array.'])
       end
 
       it 'registers an offense for no trailing comma in a Hash literal' do
-        inspect_source(cop, ['MAP = { a: 1001,',
-                             '        b: 2020,',
-                             '        c: 3333',
-                             '}'])
+        inspect_source(cop, <<-END.strip_indent)
+          MAP = { a: 1001,
+                  b: 2020,
+                  c: 3333
+          }
+        END
         expect(cop.messages)
           .to eq(['Put a comma after the last item of a multiline hash.'])
         expect(cop.highlights).to eq(['c: 3333'])
       end
 
       it 'accepts trailing comma in an Array literal' do
-        inspect_source(cop, ['VALUES = [1001,',
-                             '          2020,',
-                             '          3333,',
-                             '         ]'])
+        inspect_source(cop, <<-END.strip_indent)
+          VALUES = [1001,
+                    2020,
+                    3333,
+                   ]
+        END
         expect(cop.offenses).to be_empty
       end
 
       it 'accepts trailing comma in a Hash literal' do
-        inspect_source(cop, ['MAP = {',
-                             '        a: 1001,',
-                             '        b: 2020,',
-                             '        c: 3333,',
-                             '      }'])
+        inspect_source(cop, <<-END.strip_indent)
+          MAP = {
+                  a: 1001,
+                  b: 2020,
+                  c: 3333,
+                }
+        END
         expect(cop.offenses).to be_empty
       end
 
       it 'accepts a multiline word array' do
-        inspect_source(cop, ['ingredients = %w(',
-                             '  sausage',
-                             '  anchovies',
-                             '  olives',
-                             ')'])
+        inspect_source(cop, <<-END.strip_indent)
+          ingredients = %w(
+            sausage
+            anchovies
+            olives
+          )
+        END
         expect(cop.offenses).to be_empty
       end
 
       it 'accepts missing comma after a heredoc' do
         # A heredoc that's the last item in a literal or parameter list can not
         # have a trailing comma. It's a syntax error.
-        inspect_source(cop, ['route(help: {',
-                             "  'auth' => <<-HELP.chomp",
-                             '...',
-                             'HELP',
-                             '})'])
+        inspect_source(cop, <<-END.strip_indent)
+          route(help: {
+            'auth' => <<-HELP.chomp
+          ...
+          HELP
+          })
+        END
         expect(cop.offenses).to be_empty
       end
 
       it 'auto-corrects an Array literal with two of the values on the same' \
          ' line and a trailing comma' do
-        new_source = autocorrect_source(cop, ['VALUES = [',
-                                              '           1001, 2020,',
-                                              '           3333',
-                                              '         ]'])
-        expect(new_source).to eq(['VALUES = [',
-                                  '           1001, 2020,',
-                                  '           3333,',
-                                  '         ]'].join("\n"))
+        new_source = autocorrect_source(cop, <<-END.strip_indent)
+          VALUES = [
+                     1001, 2020,
+                     3333
+                   ]
+        END
+        expect(new_source).to eq(<<-END.strip_indent)
+          VALUES = [
+                     1001, 2020,
+                     3333,
+                   ]
+        END
       end
 
       it 'auto-corrects missing comma in a Hash literal' do
-        new_source = autocorrect_source(cop, ['MAP = { a: 1001,',
-                                              '        b: 2020,',
-                                              '        c: 3333',
-                                              '}'])
-        expect(new_source).to eq(['MAP = { a: 1001,',
-                                  '        b: 2020,',
-                                  '        c: 3333,',
-                                  '}'].join("\n"))
+        new_source = autocorrect_source(cop, <<-END.strip_indent)
+          MAP = { a: 1001,
+                  b: 2020,
+                  c: 3333
+          }
+        END
+        expect(new_source).to eq(<<-END.strip_indent)
+          MAP = { a: 1001,
+                  b: 2020,
+                  c: 3333,
+          }
+        END
       end
 
       it 'accepts a multiline array with a single item and trailing comma' do
-        inspect_source(cop, ['foo = [',
-                             '  1,',
-                             ']'])
+        inspect_source(cop, <<-END.strip_indent)
+          foo = [
+            1,
+          ]
+        END
         expect(cop.offenses).to be_empty
       end
 
       it 'accepts a multiline hash with a single pair and trailing comma' do
-        inspect_source(cop, ['bar = {',
-                             '  a: 123,',
-                             '}'])
+        inspect_source(cop, <<-END.strip_indent)
+          bar = {
+            a: 123,
+          }
+        END
         expect(cop.offenses).to be_empty
       end
 
       it 'accepts a multiline array with items on a single line and' \
          'trailing comma' do
-        inspect_source(cop, ['foo = [',
-                             '  1, 2,',
-                             ']'])
+        inspect_source(cop, <<-END.strip_indent)
+          foo = [
+            1, 2,
+          ]
+        END
         expect(cop.offenses).to be_empty
       end
 
       it 'accepts a multiline hash with pairs on a single line and' \
          'trailing comma' do
-        inspect_source(cop, ['bar = {',
-                             '  a: 1001, b: 2020,',
-                             '}'])
+        inspect_source(cop, <<-END.strip_indent)
+          bar = {
+            a: 1001, b: 2020,
+          }
+        END
         expect(cop.offenses).to be_empty
       end
     end

--- a/spec/rubocop/cop/style/trivial_accessors_spec.rb
+++ b/spec/rubocop/cop/style/trivial_accessors_spec.rb
@@ -5,15 +5,19 @@ describe RuboCop::Cop::Style::TrivialAccessors, :config do
   let(:cop_config) { {} }
 
   let(:trivial_reader) do
-    ['def foo',
-     '  @foo',
-     'end']
+    <<-END.strip_indent
+      def foo
+        @foo
+      end
+    END
   end
 
   let(:trivial_writer) do
-    ['def foo=(val)',
-     '  @foo = val',
-     'end']
+    <<-END.strip_indent
+      def foo=(val)
+        @foo = val
+      end
+    END
   end
 
   it 'registers an offense on instance reader' do
@@ -39,30 +43,38 @@ describe RuboCop::Cop::Style::TrivialAccessors, :config do
   end
 
   it 'registers an offense on class reader' do
-    inspect_source(cop, ['def self.foo',
-                         '  @foo',
-                         'end'])
+    inspect_source(cop, <<-END.strip_indent)
+      def self.foo
+        @foo
+      end
+    END
     expect(cop.offenses.size).to eq(1)
   end
 
   it 'registers an offense on class writer' do
-    inspect_source(cop, ['def self.foo(val)',
-                         '  @foo = val',
-                         'end'])
+    inspect_source(cop, <<-END.strip_indent)
+      def self.foo(val)
+        @foo = val
+      end
+    END
     expect(cop.offenses.size).to eq(1)
   end
 
   it 'registers an offense on reader with braces' do
-    inspect_source(cop, ['def foo()',
-                         '  @foo',
-                         'end'])
+    inspect_source(cop, <<-END.strip_indent)
+      def foo()
+        @foo
+      end
+    END
     expect(cop.offenses.size).to eq(1)
   end
 
   it 'registers an offense on writer without braces' do
-    inspect_source(cop, ['def foo= val',
-                         '  @foo = val',
-                         'end'])
+    inspect_source(cop, <<-END.strip_indent)
+      def foo= val
+        @foo = val
+      end
+    END
     expect(cop.offenses.size).to eq(1)
   end
 
@@ -77,170 +89,186 @@ describe RuboCop::Cop::Style::TrivialAccessors, :config do
   end
 
   it 'register an offense on DSL-style trivial writer' do
-    inspect_source(cop,
-                   ['def foo(val)',
-                    ' @foo = val',
-                    'end'])
+    inspect_source(cop, <<-END.strip_indent)
+      def foo(val)
+       @foo = val
+      end
+    END
     expect(cop.offenses.size).to eq(1)
   end
 
   it 'accepts non-trivial reader' do
-    inspect_source(cop,
-                   ['def test',
-                    '  some_function_call',
-                    '  @test',
-                    'end'])
+    inspect_source(cop, <<-END.strip_indent)
+      def test
+        some_function_call
+        @test
+      end
+    END
     expect(cop.offenses).to be_empty
   end
 
   it 'accepts non-trivial writer' do
-    inspect_source(cop,
-                   ['def test(val)',
-                    '  some_function_call(val)',
-                    '  @test = val',
-                    '  log(val)',
-                    'end'])
+    inspect_source(cop, <<-END.strip_indent)
+      def test(val)
+        some_function_call(val)
+        @test = val
+        log(val)
+      end
+    END
     expect(cop.offenses).to be_empty
   end
 
   it 'accepts splats' do
-    inspect_source(cop,
-                   ['def splatomatic(*values)',
-                    '  @splatomatic = values',
-                    'end'])
+    inspect_source(cop, <<-END.strip_indent)
+      def splatomatic(*values)
+        @splatomatic = values
+      end
+    END
     expect(cop.offenses).to be_empty
   end
 
   it 'accepts blocks' do
-    inspect_source(cop,
-                   ['def something(&block)',
-                    '  @b = block',
-                    'end'])
+    inspect_source(cop, <<-END.strip_indent)
+      def something(&block)
+        @b = block
+      end
+    END
     expect(cop.offenses).to be_empty
   end
 
   it 'accepts expressions within reader' do
-    inspect_source(cop,
-                   ['def bar',
-                    '  @bar + foo',
-                    'end'])
+    inspect_source(cop, <<-END.strip_indent)
+      def bar
+        @bar + foo
+      end
+    END
     expect(cop.offenses).to be_empty
   end
 
   it 'accepts expressions within writer' do
-    inspect_source(cop,
-                   ['def bar(val)',
-                    '  @bar = val + foo',
-                    'end'])
+    inspect_source(cop, <<-END.strip_indent)
+      def bar(val)
+        @bar = val + foo
+      end
+    END
     expect(cop.offenses).to be_empty
   end
 
   it 'accepts an initialize method looking like a writer' do
-    inspect_source(cop,
-                   [' def initialize(value)',
-                    '   @top = value',
-                    ' end'])
+    inspect_source(cop, <<-END.strip_margin('|'))
+      | def initialize(value)
+      |   @top = value
+      | end
+    END
     expect(cop.offenses).to be_empty
   end
 
   it 'accepts reader with different ivar name' do
-    inspect_source(cop,
-                   ['def foo',
-                    '  @fo',
-                    'end'])
+    inspect_source(cop, <<-END.strip_indent)
+      def foo
+        @fo
+      end
+    END
     expect(cop.offenses).to be_empty
   end
 
   it 'accepts writer with different ivar name' do
-    inspect_source(cop,
-                   ['def foo(val)',
-                    '  @fo = val',
-                    'end'])
+    inspect_source(cop, <<-END.strip_indent)
+      def foo(val)
+        @fo = val
+      end
+    END
     expect(cop.offenses).to be_empty
   end
 
   it 'accepts writer in a module' do
-    inspect_source(cop,
-                   ['module Foo',
-                    '  def bar=(bar)',
-                    '    @bar = bar',
-                    '  end',
-                    'end'])
+    inspect_source(cop, <<-END.strip_indent)
+      module Foo
+        def bar=(bar)
+          @bar = bar
+        end
+      end
+    END
 
     expect(cop.offenses).to be_empty
   end
 
   it 'accepts writer nested within a module' do
-    inspect_source(cop,
-                   ['module Foo',
-                    '  begin',
-                    '    if RUBY_VERSION > "2.0"',
-                    '      def bar=(bar)',
-                    '        @bar = bar',
-                    '      end',
-                    '    end',
-                    '  end',
-                    'end'])
+    inspect_source(cop, <<-END.strip_indent)
+      module Foo
+        begin
+          if RUBY_VERSION > "2.0"
+            def bar=(bar)
+              @bar = bar
+            end
+          end
+        end
+      end
+    END
 
     expect(cop.offenses).to be_empty
   end
 
   it 'accepts reader nested within a module' do
-    inspect_source(cop,
-                   ['module Foo',
-                    '  begin',
-                    '    if RUBY_VERSION > "2.0"',
-                    '      def bar',
-                    '        @bar',
-                    '      end',
-                    '    end',
-                    '  end',
-                    'end'])
+    inspect_source(cop, <<-END.strip_indent)
+      module Foo
+        begin
+          if RUBY_VERSION > "2.0"
+            def bar
+              @bar
+            end
+          end
+        end
+      end
+    END
 
     expect(cop.offenses).to be_empty
   end
 
   it 'accepts writer nested within an instance_eval call' do
-    inspect_source(cop,
-                   ['something.instance_eval do',
-                    '  begin',
-                    '    if RUBY_VERSION > "2.0"',
-                    '      def bar=(bar)',
-                    '        @bar = bar',
-                    '      end',
-                    '    end',
-                    '  end',
-                    'end'])
+    inspect_source(cop, <<-END.strip_indent)
+      something.instance_eval do
+        begin
+          if RUBY_VERSION > "2.0"
+            def bar=(bar)
+              @bar = bar
+            end
+          end
+        end
+      end
+    END
 
     expect(cop.offenses).to be_empty
   end
 
   it 'accepts reader nested within an instance_eval calll' do
-    inspect_source(cop,
-                   ['something.instance_eval do',
-                    '  begin',
-                    '    if RUBY_VERSION > "2.0"',
-                    '      def bar',
-                    '        @bar',
-                    '      end',
-                    '    end',
-                    '  end',
-                    'end'])
+    inspect_source(cop, <<-END.strip_indent)
+      something.instance_eval do
+        begin
+          if RUBY_VERSION > "2.0"
+            def bar
+              @bar
+            end
+          end
+        end
+      end
+    END
 
     expect(cop.offenses).to be_empty
   end
 
   it 'flags a reader inside a class, inside an instance_eval call' do
-    inspect_source(cop,
-                   ['something.instance_eval do',
-                    '  class << @blah',
-                    '    begin',
-                    '      def bar',
-                    '        @bar',
-                    '      end',
-                    '    end',
-                    '  end',
-                    'end'])
+    inspect_source(cop, <<-END.strip_indent)
+      something.instance_eval do
+        class << @blah
+          begin
+            def bar
+              @bar
+            end
+          end
+        end
+      end
+    END
 
     expect(cop.offenses.size).to eq(1)
     expect(cop.messages).to eq(
@@ -251,16 +279,20 @@ describe RuboCop::Cop::Style::TrivialAccessors, :config do
     let(:cop_config) { { 'ExactNameMatch' => false } }
 
     it 'registers an offense when names mismatch in writer' do
-      inspect_source(cop, ['def foo(val)',
-                           '  @f = val',
-                           'end'])
+      inspect_source(cop, <<-END.strip_indent)
+        def foo(val)
+          @f = val
+        end
+      END
       expect(cop.offenses.size).to eq(1)
     end
 
     it 'registers an offense when names mismatch in reader' do
-      inspect_source(cop, ['def foo',
-                           '  @f',
-                           'end'])
+      inspect_source(cop, <<-END.strip_indent)
+        def foo
+          @f
+        end
+      END
       expect(cop.offenses.size).to eq(1)
     end
   end
@@ -269,10 +301,11 @@ describe RuboCop::Cop::Style::TrivialAccessors, :config do
     let(:cop_config) { { 'AllowPredicates' => false } }
 
     it 'does not accept predicate-like reader' do
-      inspect_source(cop,
-                     ['def foo?',
-                      '  @foo',
-                      'end'])
+      inspect_source(cop, <<-END.strip_indent)
+        def foo?
+          @foo
+        end
+      END
       expect(cop.offenses.size).to eq(1)
     end
   end
@@ -281,10 +314,11 @@ describe RuboCop::Cop::Style::TrivialAccessors, :config do
     let(:cop_config) { { 'AllowPredicates' => true } }
 
     it 'accepts predicate-like reader' do
-      inspect_source(cop,
-                     ['def foo?',
-                      '  @foo',
-                      'end'])
+      inspect_source(cop, <<-END.strip_indent)
+        def foo?
+          @foo
+        end
+      END
       expect(cop.offenses).to be_empty
     end
   end
@@ -293,18 +327,20 @@ describe RuboCop::Cop::Style::TrivialAccessors, :config do
     let(:cop_config) { { 'Whitelist' => ['to_foo', 'bar='] } }
 
     it 'accepts whitelisted reader' do
-      inspect_source(cop,
-                     [' def to_foo',
-                      '   @foo',
-                      ' end'])
+      inspect_source(cop, <<-END.strip_margin('|'))
+        | def to_foo
+        |   @foo
+        | end
+      END
       expect(cop.offenses).to be_empty
     end
 
     it 'accepts whitelisted writer' do
-      inspect_source(cop,
-                     [' def bar=(bar)',
-                      '   @bar = bar',
-                      ' end'])
+      inspect_source(cop, <<-END.strip_margin('|'))
+        | def bar=(bar)
+        |   @bar = bar
+        | end
+      END
       expect(cop.offenses).to be_empty
     end
 
@@ -315,10 +351,11 @@ describe RuboCop::Cop::Style::TrivialAccessors, :config do
       end
 
       it 'accepts whitelisted predicate' do
-        inspect_source(cop,
-                       [' def foo?',
-                        '   @foo',
-                        ' end'])
+        inspect_source(cop, <<-END.strip_margin('|'))
+          | def foo?
+          |   @foo
+          | end
+        END
         expect(cop.offenses).to be_empty
       end
     end
@@ -328,10 +365,11 @@ describe RuboCop::Cop::Style::TrivialAccessors, :config do
     let(:cop_config) { { 'AllowDSLWriters' => true } }
 
     it 'accepts DSL-style writer' do
-      inspect_source(cop,
-                     ['def foo(val)',
-                      ' @foo = val',
-                      'end'])
+      inspect_source(cop, <<-END.strip_indent)
+        def foo(val)
+         @foo = val
+        end
+      END
       expect(cop.offenses).to be_empty
     end
   end
@@ -340,18 +378,20 @@ describe RuboCop::Cop::Style::TrivialAccessors, :config do
     let(:cop_config) { { 'IgnoreClassMethods' => true } }
 
     it 'accepts class reader' do
-      inspect_source(cop,
-                     ['def self.foo',
-                      '  @foo',
-                      'end'])
+      inspect_source(cop, <<-END.strip_indent)
+        def self.foo
+          @foo
+        end
+      END
       expect(cop.offenses).to be_empty
     end
 
     it 'accepts class writer' do
-      inspect_source(cop,
-                     ['def self.foo(val)',
-                      '  @foo = val',
-                      'end'])
+      inspect_source(cop, <<-END.strip_indent)
+        def self.foo(val)
+          @foo = val
+        end
+      END
       expect(cop.offenses).to be_empty
     end
   end
@@ -360,7 +400,7 @@ describe RuboCop::Cop::Style::TrivialAccessors, :config do
     context 'trivial reader' do
       let(:source) { trivial_reader }
 
-      let(:corrected_source) { 'attr_reader :foo' }
+      let(:corrected_source) { "attr_reader :foo\n" }
 
       it 'autocorrects' do
         expect(autocorrect_source(cop, source)).to eq(corrected_source)
@@ -371,14 +411,15 @@ describe RuboCop::Cop::Style::TrivialAccessors, :config do
       let(:cop_config) { { 'ExactNameMatch' => false } }
 
       let(:source) do
-        ['def foo',
-         '  @bar',
-         'end']
+        <<-END.strip_indent
+          def foo
+            @bar
+          end
+        END
       end
 
       it 'does not autocorrect' do
-        expect(autocorrect_source(cop, source))
-          .to eq(source.join("\n"))
+        expect(autocorrect_source(cop, source)).to eq(source)
         expect(cop.offenses.map(&:corrected?)).to eq [false]
       end
     end
@@ -386,13 +427,15 @@ describe RuboCop::Cop::Style::TrivialAccessors, :config do
     context 'predicate reader, with AllowPredicates: false' do
       let(:cop_config) { { 'AllowPredicates' => false } }
       let(:source) do
-        ['def foo?',
-         '  @foo',
-         'end']
+        <<-END.strip_indent
+          def foo?
+            @foo
+          end
+        END
       end
 
       it 'does not autocorrect' do
-        expect(autocorrect_source(cop, source)).to eq(source.join("\n"))
+        expect(autocorrect_source(cop, source)).to eq(source)
         expect(cop.offenses.map(&:corrected?)).to eq [false]
       end
     end
@@ -400,7 +443,7 @@ describe RuboCop::Cop::Style::TrivialAccessors, :config do
     context 'trivial writer' do
       let(:source) { trivial_writer }
 
-      let(:corrected_source) { 'attr_writer :foo' }
+      let(:corrected_source) { "attr_writer :foo\n" }
 
       it 'autocorrects' do
         expect(autocorrect_source(cop, source)).to eq(corrected_source)
@@ -409,75 +452,83 @@ describe RuboCop::Cop::Style::TrivialAccessors, :config do
 
     context 'matching DSL-style writer' do
       let(:source) do
-        ['def foo(f)',
-         '  @foo=f',
-         'end']
+        <<-END.strip_indent
+          def foo(f)
+            @foo=f
+          end
+        END
       end
 
       it 'does not autocorrect' do
-        expect(autocorrect_source(cop, source))
-          .to eq(source.join("\n"))
+        expect(autocorrect_source(cop, source)).to eq(source)
         expect(cop.offenses.map(&:corrected?)).to eq [false]
       end
     end
 
     context 'explicit receiver writer' do
       let(:source) do
-        ['def derp.foo=(f)',
-         '  @foo=f',
-         'end']
+        <<-END.strip_indent
+          def derp.foo=(f)
+            @foo=f
+          end
+        END
       end
 
       it 'does not autocorrect' do
-        expect(autocorrect_source(cop, source))
-          .to eq(source.join("\n"))
+        expect(autocorrect_source(cop, source)).to eq(source)
         expect(cop.offenses.map(&:corrected?)).to eq [false]
       end
     end
 
     context 'class receiver reader' do
       let(:source) do
-        ['class Foo',
-         '  def self.foo',
-         '    @foo',
-         '  end',
-         'end']
+        <<-END.strip_indent
+          class Foo
+            def self.foo
+              @foo
+            end
+          end
+        END
       end
 
       let(:corrected_source) do
-        ['class Foo',
-         '  class << self',
-         '    attr_reader :foo',
-         '  end',
-         'end']
+        <<-END.strip_indent
+          class Foo
+            class << self
+              attr_reader :foo
+            end
+          end
+        END
       end
 
       it 'autocorrects with class-level attr_reader' do
-        expect(autocorrect_source(cop, source))
-          .to eq(corrected_source.join("\n"))
+        expect(autocorrect_source(cop, source)).to eq(corrected_source)
       end
     end
 
     context 'class receiver writer' do
       let(:source) do
-        ['class Foo',
-         '  def self.foo=(f)',
-         '    @foo = f',
-         '  end',
-         'end']
+        <<-END.strip_indent
+          class Foo
+            def self.foo=(f)
+              @foo = f
+            end
+          end
+        END
       end
 
       let(:corrected_source) do
-        ['class Foo',
-         '  class << self',
-         '    attr_writer :foo',
-         '  end',
-         'end']
+        <<-END.strip_indent
+          class Foo
+            class << self
+              attr_writer :foo
+            end
+          end
+        END
       end
 
       it 'autocorrects with class-level attr_writer' do
-        expect(autocorrect_source(cop, source))
-          .to eq(corrected_source.join("\n"))
+        expect(autocorrect_source(cop, source)).to eq(corrected_source)
       end
     end
   end

--- a/spec/rubocop/cop/style/unless_else_spec.rb
+++ b/spec/rubocop/cop/style/unless_else_spec.rb
@@ -5,11 +5,13 @@ describe RuboCop::Cop::Style::UnlessElse do
 
   context 'unless with else' do
     let(:source) do
-      ['unless x # negative 1',
-       '  a = 1 # negative 2',
-       'else # positive 1',
-       '  a = 0 # positive 2',
-       'end']
+      <<-END.strip_indent
+        unless x # negative 1
+          a = 1 # negative 2
+        else # positive 1
+          a = 0 # positive 2
+        end
+      END
     end
 
     it 'registers an offense' do
@@ -19,27 +21,31 @@ describe RuboCop::Cop::Style::UnlessElse do
 
     it 'auto-corrects' do
       corrected = autocorrect_source(cop, source)
-      expect(corrected).to eq(['if x # positive 1',
-                               '  a = 0 # positive 2',
-                               'else # negative 1',
-                               '  a = 1 # negative 2',
-                               'end'].join("\n"))
+      expect(corrected).to eq(<<-END.strip_indent)
+        if x # positive 1
+          a = 0 # positive 2
+        else # negative 1
+          a = 1 # negative 2
+        end
+      END
     end
   end
 
   context 'unless with nested if-else' do
     let(:source) do
-      ['unless(x)',
-       '  if(y == 0)',
-       '    a = 0',
-       '  elsif(z == 0)',
-       '    a = 1',
-       '  else',
-       '    a = 2',
-       '  end',
-       'else',
-       '  a = 3',
-       'end']
+      <<-END.strip_indent
+        unless(x)
+          if(y == 0)
+            a = 0
+          elsif(z == 0)
+            a = 1
+          else
+            a = 2
+          end
+        else
+          a = 3
+        end
+      END
     end
 
     it 'registers an offense' do
@@ -49,25 +55,29 @@ describe RuboCop::Cop::Style::UnlessElse do
 
     it 'auto-corrects' do
       corrected = autocorrect_source(cop, source)
-      expect(corrected).to eq(['if(x)',
-                               '  a = 3',
-                               'else',
-                               '  if(y == 0)',
-                               '    a = 0',
-                               '  elsif(z == 0)',
-                               '    a = 1',
-                               '  else',
-                               '    a = 2',
-                               '  end',
-                               'end'].join("\n"))
+      expect(corrected).to eq(<<-END.strip_indent)
+        if(x)
+          a = 3
+        else
+          if(y == 0)
+            a = 0
+          elsif(z == 0)
+            a = 1
+          else
+            a = 2
+          end
+        end
+      END
     end
   end
 
   context 'unless without else' do
     it 'does not register an offense' do
-      inspect_source(cop, ['unless x',
-                           '  a = 1',
-                           'end'])
+      inspect_source(cop, <<-END.strip_indent)
+        unless x
+          a = 1
+        end
+      END
       expect(cop.offenses).to be_empty
     end
   end

--- a/spec/rubocop/cop/style/unneeded_capital_w_spec.rb
+++ b/spec/rubocop/cop/style/unneeded_capital_w_spec.rb
@@ -24,22 +24,24 @@ describe RuboCop::Cop::Style::UnneededCapitalW do
   end
 
   it 'registers no offense for %W with special characters' do
-    source = ['def dangerous_characters',
-              '  %W(\000) +',
-              '  %W(\001) +',
-              '  %W(\027) +',
-              '  %W(\002) +',
-              '  %W(\003) +',
-              '  %W(\004) +',
-              '  %W(\005) +',
-              '  %W(\006) +',
-              '  %W(\007) +',
-              '  %W(\00) +',
-              '  %W(\a)',
-              '  %W(\s)',
-              '  %W(\n)',
-              '  %W(\!)',
-              'end']
+    source = <<-'END'.strip_indent
+      def dangerous_characters
+        %W(\000) +
+        %W(\001) +
+        %W(\027) +
+        %W(\002) +
+        %W(\003) +
+        %W(\004) +
+        %W(\005) +
+        %W(\006) +
+        %W(\007) +
+        %W(\00) +
+        %W(\a)
+        %W(\s)
+        %W(\n)
+        %W(\!)
+      end
+    END
     inspect_source(cop, source)
     expect(cop.offenses).to be_empty
   end

--- a/spec/rubocop/cop/style/variable_name_spec.rb
+++ b/spec/rubocop/cop/style/variable_name_spec.rb
@@ -37,8 +37,10 @@ describe RuboCop::Cop::Style::VariableName, :config do
     end
 
     it 'registers an offense for correct + opposite' do
-      inspect_source(cop, ['my_local = 1',
-                           'myLocal = 1'])
+      inspect_source(cop, <<-END.strip_indent)
+        my_local = 1
+        myLocal = 1
+      END
       expect(cop.highlights).to eq(['myLocal'])
       expect(cop.config_to_allow_offenses).to eq('Enabled' => false)
     end
@@ -82,8 +84,10 @@ describe RuboCop::Cop::Style::VariableName, :config do
     end
 
     it 'registers an offense for opposite + correct' do
-      inspect_source(cop, ['my_local = 1',
-                           'myLocal = 1'])
+      inspect_source(cop, <<-END.strip_indent)
+        my_local = 1
+        myLocal = 1
+      END
       expect(cop.highlights).to eq(['my_local'])
       expect(cop.config_to_allow_offenses).to eq('Enabled' => false)
     end

--- a/spec/rubocop/cop/style/when_then_spec.rb
+++ b/spec/rubocop/cop/style/when_then_spec.rb
@@ -4,46 +4,58 @@ describe RuboCop::Cop::Style::WhenThen do
   subject(:cop) { described_class.new }
 
   it 'registers an offense for when x;' do
-    inspect_source(cop, ['case a',
-                         'when b; c',
-                         'end'])
+    inspect_source(cop, <<-END.strip_indent)
+      case a
+      when b; c
+      end
+    END
     expect(cop.offenses.size).to eq(1)
   end
 
   it 'accepts when x then' do
-    inspect_source(cop, ['case a',
-                         'when b then c',
-                         'end'])
+    inspect_source(cop, <<-END.strip_indent)
+      case a
+      when b then c
+      end
+    END
     expect(cop.offenses).to be_empty
   end
 
   it 'accepts ; separating statements in the body of when' do
-    inspect_source(cop, ['case a',
-                         'when b then c; d',
-                         'end',
-                         '',
-                         'case e',
-                         'when f',
-                         '  g; h',
-                         'end'])
+    inspect_source(cop, <<-END.strip_indent)
+      case a
+      when b then c; d
+      end
+
+      case e
+      when f
+        g; h
+      end
+    END
     expect(cop.offenses).to be_empty
   end
 
   it 'auto-corrects "when x;" with "when x then"' do
-    new_source = autocorrect_source(cop, ['case a',
-                                          'when b; c',
-                                          'end'])
-    expect(new_source).to eq(['case a',
-                              'when b then c',
-                              'end'].join("\n"))
+    new_source = autocorrect_source(cop, <<-END.strip_indent)
+      case a
+      when b; c
+      end
+    END
+    expect(new_source).to eq(<<-END.strip_indent)
+      case a
+      when b then c
+      end
+    END
   end
 
   # Regression: https://github.com/bbatsov/rubocop/issues/3868
   context 'when inspecting a case statement with an empty branch' do
     it 'does not register an offense' do
-      inspect_source(cop, ['case value',
-                           'when cond1',
-                           'end'])
+      inspect_source(cop, <<-END.strip_indent)
+        case value
+        when cond1
+        end
+      END
 
       expect(cop.offenses).to be_empty
     end

--- a/spec/rubocop/cop/style/while_until_do_spec.rb
+++ b/spec/rubocop/cop/style/while_until_do_spec.rb
@@ -4,14 +4,18 @@ describe RuboCop::Cop::Style::WhileUntilDo do
   subject(:cop) { described_class.new }
 
   it 'registers an offense for do in multiline while' do
-    inspect_source(cop, ['while cond do',
-                         'end'])
+    inspect_source(cop, <<-END.strip_indent)
+      while cond do
+      end
+    END
     expect(cop.offenses.size).to eq(1)
   end
 
   it 'registers an offense for do in multiline until' do
-    inspect_source(cop, ['until cond do',
-                         'end'])
+    inspect_source(cop, <<-END.strip_indent)
+      until cond do
+      end
+    END
     expect(cop.offenses.size).to eq(1)
   end
 
@@ -26,28 +30,40 @@ describe RuboCop::Cop::Style::WhileUntilDo do
   end
 
   it 'accepts multi-line while without do' do
-    inspect_source(cop, ['while cond',
-                         'end'])
+    inspect_source(cop, <<-END.strip_indent)
+      while cond
+      end
+    END
     expect(cop.offenses).to be_empty
   end
 
   it 'accepts multi-line until without do' do
-    inspect_source(cop, ['until cond',
-                         'end'])
+    inspect_source(cop, <<-END.strip_indent)
+      until cond
+      end
+    END
     expect(cop.offenses).to be_empty
   end
 
   it 'auto-corrects the usage of "do" in multiline while' do
-    new_source = autocorrect_source(cop, ['while cond do',
-                                          'end'])
-    expect(new_source).to eq(['while cond',
-                              'end'].join("\n"))
+    new_source = autocorrect_source(cop, <<-END.strip_indent)
+      while cond do
+      end
+    END
+    expect(new_source).to eq(<<-END.strip_indent)
+      while cond
+      end
+    END
   end
 
   it 'auto-corrects the usage of "do" in multiline until' do
-    new_source = autocorrect_source(cop, ['until cond do',
-                                          'end'])
-    expect(new_source).to eq(['until cond',
-                              'end'].join("\n"))
+    new_source = autocorrect_source(cop, <<-END.strip_indent)
+      until cond do
+      end
+    END
+    expect(new_source).to eq(<<-END.strip_indent)
+      until cond
+      end
+    END
   end
 end

--- a/spec/rubocop/cop/style/while_until_modifier_spec.rb
+++ b/spec/rubocop/cop/style/while_until_modifier_spec.rb
@@ -36,18 +36,22 @@ describe RuboCop::Cop::Style::WhileUntilModifier do
   end
 
   it 'accepts oneline while when condition has local variable assignment' do
-    inspect_source(cop, ['lines = %w{first second third}',
-                         'while (line = lines.shift)',
-                         '  puts line',
-                         'end'])
+    inspect_source(cop, <<-END.strip_indent)
+      lines = %w{first second third}
+      while (line = lines.shift)
+        puts line
+      end
+    END
     expect(cop.offenses).to be_empty
   end
 
   context 'oneline while when assignment is in body' do
     let(:source) do
-      ['while true',
-       '  x = 0',
-       'end']
+      <<-END.strip_indent
+        while true
+          x = 0
+        end
+      END
     end
 
     it 'registers an offense' do
@@ -57,7 +61,7 @@ describe RuboCop::Cop::Style::WhileUntilModifier do
 
     it 'does auto-correction' do
       corrected = autocorrect_source(cop, source)
-      expect(corrected).to eq 'x = 0 while true'
+      expect(corrected).to eq "x = 0 while true\n"
     end
   end
 
@@ -97,9 +101,10 @@ describe RuboCop::Cop::Style::WhileUntilModifier do
   # Regression: https://github.com/bbatsov/rubocop/issues/4006
   context 'when the modifier condition is multiline' do
     it 'registers an offense' do
-      inspect_source(cop,
-                     ['foo while bar ||',
-                      '  baz'].join("\n"))
+      inspect_source(cop, <<-END.strip_indent)
+        foo while bar ||
+          baz
+      END
       expect(cop.offenses.size).to eq(1)
     end
   end

--- a/spec/rubocop/cop/style/word_array_spec.rb
+++ b/spec/rubocop/cop/style/word_array_spec.rb
@@ -94,23 +94,25 @@ describe RuboCop::Cop::Style::WordArray, :config do
     end
 
     it 'does not register an offense for an array with comments in it' do
-      inspect_source(cop,
-                     ['[',
-                      '"foo", # comment here',
-                      '"bar", # this thing was done because of a bug',
-                      '"baz" # do not delete this line',
-                      ']'])
+      inspect_source(cop, <<-END.strip_indent)
+        [
+        "foo", # comment here
+        "bar", # this thing was done because of a bug
+        "baz" # do not delete this line
+        ]
+      END
 
       expect(cop.offenses).to be_empty
     end
 
     it 'registers an offense for an array with comments outside of it' do
-      inspect_source(cop,
-                     ['[',
-                      '"foo",',
-                      '"bar",',
-                      '"baz"',
-                      '] # test'])
+      inspect_source(cop, <<-END.strip_indent)
+        [
+        "foo",
+        "bar",
+        "baz"
+        ] # test
+      END
 
       expect(cop.offenses.size).to eq(1)
     end
@@ -134,9 +136,10 @@ describe RuboCop::Cop::Style::WordArray, :config do
     end
 
     it 'detects right value of MinSize to use for --auto-gen-config' do
-      inspect_source(cop,
-                     ["['one', 'two', 'three']",
-                      '%w(a b c d)'])
+      inspect_source(cop, <<-END.strip_indent)
+        ['one', 'two', 'three']
+        %w(a b c d)
+      END
       expect(cop.offenses.size).to eq(1)
       expect(cop.messages).to eq(['Use `%w` or `%W` for an array of words.'])
       expect(cop.config_to_allow_offenses).to eq('EnforcedStyle' => 'percent',
@@ -144,9 +147,10 @@ describe RuboCop::Cop::Style::WordArray, :config do
     end
 
     it 'detects when the cop must be disabled to avoid offenses' do
-      inspect_source(cop,
-                     ["['one', 'two', 'three']",
-                      '%w(a b)'])
+      inspect_source(cop, <<-END.strip_indent)
+        ['one', 'two', 'three']
+        %w(a b)
+      END
       expect(cop.offenses.size).to eq(1)
       expect(cop.messages).to eq(['Use `%w` or `%W` for an array of words.'])
       expect(cop.config_to_allow_offenses).to eq('Enabled' => false)
@@ -206,13 +210,15 @@ describe RuboCop::Cop::Style::WordArray, :config do
 
     it "doesn't fail on strings which are not valid UTF-8" do
       # Regression test, see GH issue 2671
-      inspect_source(cop, ['["\xC0",',
-                           ' "\xC2\x4a",',
-                           ' "\xC2\xC2",',
-                           ' "\x4a\x82",',
-                           ' "\x82\x82",',
-                           ' "\xe1\x82\x4a",',
-                           ']'])
+      inspect_source(cop, <<-'END'.strip_indent)
+        ["\xC0",
+         "\xC2\x4a",
+         "\xC2\xC2",
+         "\x4a\x82",
+         "\x82\x82",
+         "\xe1\x82\x4a",
+        ]
+      END
       # Currently, this cop completely ignores strings with invalid encoding
       # If it could handle them and still report an offense when appropriate,
       # that would be even better

--- a/spec/rubocop/formatter/base_formatter_spec.rb
+++ b/spec/rubocop/formatter/base_formatter_spec.rb
@@ -46,17 +46,16 @@ module RuboCop
 
           it 'is called in the proper sequence' do
             run
-            expect(output).to eq([
-              'started',
-              'file_started',
-              'file_finished',
-              'file_started',
-              'file_finished',
-              'file_started',
-              'file_finished',
-              'finished',
-              ''
-            ].join("\n"))
+            expect(output).to eq(<<-END.strip_indent)
+              started
+              file_started
+              file_finished
+              file_started
+              file_finished
+              file_started
+              file_finished
+              finished
+            END
           end
         end
 

--- a/spec/rubocop/formatter/clang_style_formatter_spec.rb
+++ b/spec/rubocop/formatter/clang_style_formatter_spec.rb
@@ -19,13 +19,14 @@ module RuboCop
                           'message 2')
 
           formatter.report_file('test', cop.offenses)
-          expect(output.string).to eq ['test:1:1: C: message 1',
-                                       'aa',
-                                       '^^',
-                                       'test:11:1: C: message 2',
-                                       'ak',
-                                       '^^',
-                                       ''].join("\n")
+          expect(output.string).to eq <<-END.strip_indent
+            test:1:1: C: message 1
+            aa
+            ^^
+            test:11:1: C: message 2
+            ak
+            ^^
+          END
         end
 
         context 'when the source line is blank' do
@@ -41,19 +42,22 @@ module RuboCop
                             'message 2')
 
             formatter.report_file('test', cop.offenses)
-            expect(output.string).to eq ['test:1:1: C: message 1',
-                                         'test:2:1: C: message 2',
-                                         'yaba',
-                                         '^^^^',
-                                         ''].join("\n")
+            expect(output.string).to eq <<-END.strip_indent
+              test:1:1: C: message 1
+              test:2:1: C: message 2
+              yaba
+              ^^^^
+            END
           end
         end
 
         context 'when the offending source spans multiple lines' do
           it 'displays the first line with ellipses' do
-            source = ['do_something([this,',
-                      '              is,',
-                      '              target])'].join($RS)
+            source = <<-END.strip_indent
+              do_something([this,
+                            is,
+                            target])
+            END
 
             source_buffer = Parser::Source::Buffer.new('test', 1)
             source_buffer.source = source
@@ -67,10 +71,11 @@ module RuboCop
 
             formatter.report_file('test', cop.offenses)
             expect(output.string)
-              .to eq ['test:1:14: C: message 1',
-                      "do_something([this, #{described_class::ELLIPSES}",
-                      '             ^^^^^^',
-                      ''].join("\n")
+              .to eq <<-END.strip_indent
+                test:1:14: C: message 1
+                do_something([this, #{described_class::ELLIPSES}
+                             ^^^^^^
+              END
           end
         end
 

--- a/spec/rubocop/formatter/disabled_config_formatter_spec.rb
+++ b/spec/rubocop/formatter/disabled_config_formatter_spec.rb
@@ -6,52 +6,78 @@ module RuboCop
       include FileHelper
 
       subject(:formatter) { described_class.new(output) }
+
       let(:output) do
-        o = StringIO.new
-        def o.path
+        io = StringIO.new
+
+        def io.path
           '.rubocop_todo.yml'
         end
-        o
+
+        io
       end
+
       let(:offenses) do
         [RuboCop::Cop::Offense.new(:convention, location, 'message', 'Cop1'),
          RuboCop::Cop::Offense.new(:convention, location, 'message', 'Cop2')]
       end
+
       let(:location) { OpenStruct.new(line: 1, column: 5) }
 
-      before do
-        $stderr = StringIO.new
+      let(:heading) do
+        format(described_class::HEADING, expected_heading_command) + "\n"
+      end
+
+      let(:expected_heading_command) do
+        'rubocop --auto-gen-config'
+      end
+
+      around do |example|
+        original_stdout = $stdout
+        original_stderr = $stderr
+
         $stdout = StringIO.new
+        $stderr = StringIO.new
+
+        example.run
+
+        $stdout = original_stdout
+        $stderr = original_stderr
+      end
+
+      before do
         # Avoid intermittent failure when another test set ConfigLoader options
         ConfigLoader.clear_options
       end
-      after do
-        $stderr = STDERR
-        $stdout = STDOUT
-      end
 
-      describe '#finished' do
-        it 'displays YAML configuration disabling all cops with offenses' do
+      context 'when any offenses are detected' do
+        before do
+          formatter.started(['test_a.rb', 'test_b.rb'])
           formatter.file_started('test_a.rb', {})
           formatter.file_finished('test_a.rb', offenses)
           formatter.file_started('test_b.rb', {})
           formatter.file_finished('test_b.rb', [offenses.first])
           formatter.finished(['test_a.rb', 'test_b.rb'])
-          expect(output.string).to eq(format(described_class::HEADING,
-                                             'rubocop --auto-gen-config') +
-                                      ['',
-                                       '',
-                                       '# Offense count: 2',
-                                       'Cop1:',
-                                       '  Exclude:',
-                                       "    - 'test_a.rb'",
-                                       "    - 'test_b.rb'",
-                                       '',
-                                       '# Offense count: 1',
-                                       'Cop2:',
-                                       '  Exclude:',
-                                       "    - 'test_a.rb'",
-                                       ''].join("\n"))
+        end
+
+        let(:expected_rubocop_todo) do
+          [heading,
+           '# Offense count: 2',
+           'Cop1:',
+           '  Exclude:',
+           "    - 'test_a.rb'",
+           "    - 'test_b.rb'",
+           '',
+           '# Offense count: 1',
+           'Cop2:',
+           '  Exclude:',
+           "    - 'test_a.rb'",
+           ''].join("\n")
+        end
+
+        it 'displays YAML configuration disabling all cops with offenses' do
+          expect(output.string).to eq(expected_rubocop_todo)
+
           expect($stdout.string)
             .to eq(['Created .rubocop_todo.yml.',
                     'Run `rubocop --config .rubocop_todo.yml`, or ' \
@@ -59,110 +85,160 @@ module RuboCop
                     'file.',
                     ''].join("\n"))
         end
+      end
 
-        it 'merges in excludes from .rubocop.yml' do
+      context "when there's .rubocop.yml" do
+        before do
           create_file('.rubocop.yml', ['Cop1:',
                                        '  Exclude:',
                                        '    - Gemfile',
                                        'Cop2:',
                                        '  Exclude:',
                                        '    - "**/*.blah"'])
+
+        end
+
+        before do
+          formatter.started(['test_a.rb', 'test_b.rb'])
           formatter.file_started('test_a.rb', {})
           formatter.file_finished('test_a.rb', offenses)
           formatter.file_started('test_b.rb', {})
           formatter.file_finished('test_b.rb', [offenses.first])
           formatter.finished(['test_a.rb', 'test_b.rb'])
-          expect(output.string).to eq(format(described_class::HEADING,
-                                             'rubocop --auto-gen-config') +
-                                      ['',
-                                       '',
-                                       '# Offense count: 2',
-                                       'Cop1:',
-                                       '  Exclude:',
-                                       "    - 'Gemfile'",
-                                       "    - 'test_a.rb'",
-                                       "    - 'test_b.rb'",
-                                       '',
-                                       '# Offense count: 1',
-                                       'Cop2:',
-                                       '  Exclude:',
-                                       "    - '**/*.blah'",
-                                       "    - 'test_a.rb'",
-                                       ''].join("\n"))
         end
 
-        it 'displays a file exclusion list up to a maximum of 15 offenses' do
-          exclusion_list = []
-          file_list = []
-
-          15.times do |index|
-            file_name = format('test_%02d.rb', index)
-            formatter.file_started(file_name, {})
-            formatter.file_finished(file_name, offenses)
-            file_list << file_name
-            exclusion_list << "    - '#{file_name}'"
-          end
-
-          file_list << 'test.rb'
-          formatter.file_started('test.rb', {})
-          formatter.file_finished('test.rb', [offenses.first])
-          formatter.finished(file_list)
-          expect(output.string).to eq(format(described_class::HEADING,
-                                             'rubocop --auto-gen-config') +
-                                      ['',
-                                       '',
-                                       '# Offense count: 16',
-                                       'Cop1:',
-                                       '  Enabled: false',
-                                       '',
-                                       '# Offense count: 15',
-                                       'Cop2:',
-                                       '  Exclude:',
-                                       exclusion_list,
-                                       ''].flatten.join("\n"))
+        let(:expected_rubocop_todo) do
+          [heading,
+           '# Offense count: 2',
+           'Cop1:',
+           '  Exclude:',
+           "    - 'Gemfile'",
+           "    - 'test_a.rb'",
+           "    - 'test_b.rb'",
+           '',
+           '# Offense count: 1',
+           'Cop2:',
+           '  Exclude:',
+           "    - '**/*.blah'",
+           "    - 'test_a.rb'",
+           ''].join("\n")
         end
 
-        it 'creates a .rubocop_todo.yml even if RuboCop does not inspect ' \
-           'any files' do
-          formatter.finished([])
-          expect(output.string).to eq(format(described_class::HEADING,
-                                             'rubocop --auto-gen-config') +
-                                      "\n")
+        it 'merges in excludes from .rubocop.yml' do
+          expect(output.string).to eq(expected_rubocop_todo)
         end
+      end
 
-        context 'when exclude_limit option is passed into constructor' do
-          let(:formatter) { described_class.new(output, exclude_limit: 5) }
+      context 'when exclude_limit option is omitted' do
+        before do
+          formatter.started(filenames)
 
-          it 'respects the exclusion list limit' do
-            exclusion_list = []
-            file_list = []
+          filenames.each do |filename|
+            formatter.file_started(filename, {})
 
-            15.times do |index|
-              file_name = format('test_%02d.rb', index)
-              formatter.file_started(file_name, {})
-              formatter.file_finished(file_name, offenses)
-              file_list << file_name
-              exclusion_list << "    - '#{file_name}'"
+            if filename == filenames.last
+              formatter.file_finished(filename, [offenses.first])
+            else
+              formatter.file_finished(filename, offenses)
             end
-
-            file_list << 'test.rb'
-            formatter.file_started('test.rb', {})
-            formatter.file_finished('test.rb', [offenses.first])
-            formatter.finished(file_list)
-            expect(output.string).to eq(format(described_class::HEADING,
-                                               'rubocop --auto-gen-config ' \
-                                               '--exclude-limit 5') +
-                                        ['',
-                                         '',
-                                         '# Offense count: 16',
-                                         'Cop1:',
-                                         '  Enabled: false',
-                                         '',
-                                         '# Offense count: 15',
-                                         'Cop2:',
-                                         '  Enabled: false',
-                                         ''].flatten.join("\n"))
           end
+
+          formatter.finished(filenames)
+        end
+
+        let(:filenames) do
+          16.times.map { |index| format('test_%02d.rb', index + 1) }
+        end
+
+        let(:expected_rubocop_todo) do
+          [heading,
+           '# Offense count: 16',
+           'Cop1:',
+           '  Enabled: false',
+           '',
+           '# Offense count: 15',
+           'Cop2:',
+           '  Exclude:',
+           "    - 'test_01.rb'",
+           "    - 'test_02.rb'",
+           "    - 'test_03.rb'",
+           "    - 'test_04.rb'",
+           "    - 'test_05.rb'",
+           "    - 'test_06.rb'",
+           "    - 'test_07.rb'",
+           "    - 'test_08.rb'",
+           "    - 'test_09.rb'",
+           "    - 'test_10.rb'",
+           "    - 'test_11.rb'",
+           "    - 'test_12.rb'",
+           "    - 'test_13.rb'",
+           "    - 'test_14.rb'",
+           "    - 'test_15.rb'",
+           ''].join("\n")
+        end
+
+        it 'disables the cop with 15 offending files' do
+          expect(output.string).to eq(expected_rubocop_todo)
+        end
+      end
+
+      context 'when exclude_limit option is passed' do
+        let(:formatter) { described_class.new(output, exclude_limit: 5) }
+
+        before do
+          formatter.started(filenames)
+
+          filenames.each do |filename|
+            formatter.file_started(filename, {})
+
+            if filename == filenames.last
+              formatter.file_finished(filename, [offenses.first])
+            else
+              formatter.file_finished(filename, offenses)
+            end
+          end
+
+          formatter.finished(filenames)
+        end
+
+        let(:filenames) do
+          6.times.map { |index| format('test_%02d.rb', index + 1) }
+        end
+
+        let(:expected_heading_command) do
+          'rubocop --auto-gen-config --exclude-limit 5'
+        end
+
+        let(:expected_rubocop_todo) do
+          [heading,
+           '# Offense count: 6',
+           'Cop1:',
+           '  Enabled: false',
+           '',
+           '# Offense count: 5',
+           'Cop2:',
+           '  Exclude:',
+           "    - 'test_01.rb'",
+           "    - 'test_02.rb'",
+           "    - 'test_03.rb'",
+           "    - 'test_04.rb'",
+           "    - 'test_05.rb'",
+           ''].join("\n")
+        end
+
+        it 'respects the file exclusion list limit' do
+          expect(output.string).to eq(expected_rubocop_todo)
+        end
+      end
+
+      context 'when no files are inspected' do
+        before do
+          formatter.started([])
+          formatter.finished([])
+        end
+
+        it 'creates a .rubocop_todo.yml even in such case' do
+          expect(output.string).to eq(heading)
         end
       end
     end

--- a/spec/rubocop/formatter/disabled_config_formatter_spec.rb
+++ b/spec/rubocop/formatter/disabled_config_formatter_spec.rb
@@ -89,13 +89,14 @@ module RuboCop
 
       context "when there's .rubocop.yml" do
         before do
-          create_file('.rubocop.yml', ['Cop1:',
-                                       '  Exclude:',
-                                       '    - Gemfile',
-                                       'Cop2:',
-                                       '  Exclude:',
-                                       '    - "**/*.blah"'])
-
+          create_file('.rubocop.yml', <<-END.strip_indent)
+            Cop1:
+              Exclude:
+                - Gemfile
+            Cop2:
+              Exclude:
+                - "**/*.blah"
+          END
         end
 
         before do
@@ -147,7 +148,7 @@ module RuboCop
         end
 
         let(:filenames) do
-          16.times.map { |index| format('test_%02d.rb', index + 1) }
+          Array.new(16) { |index| format('test_%02d.rb', index + 1) }
         end
 
         let(:expected_rubocop_todo) do
@@ -202,7 +203,7 @@ module RuboCop
         end
 
         let(:filenames) do
-          6.times.map { |index| format('test_%02d.rb', index + 1) }
+          Array.new(6) { |index| format('test_%02d.rb', index + 1) }
         end
 
         let(:expected_heading_command) do

--- a/spec/rubocop/formatter/disabled_lines_formatter_spec.rb
+++ b/spec/rubocop/formatter/disabled_lines_formatter_spec.rb
@@ -69,12 +69,13 @@ module RuboCop
           it 'lists disabled cops by file' do
             formatter.finished(files)
             expect(output.string)
-              .to eq(['',
-                      'Cops disabled line ranges:',
-                      '',
-                      'lib/rubocop.rb:1..1: LineLength',
-                      'lib/rubocop.rb:1..Infinity: ClassLength',
-                      ''].join("\n"))
+              .to eq(<<-END.strip_indent)
+
+                Cops disabled line ranges:
+
+                lib/rubocop.rb:1..1: LineLength
+                lib/rubocop.rb:1..Infinity: ClassLength
+              END
           end
         end
       end

--- a/spec/rubocop/formatter/emacs_style_formatter_spec.rb
+++ b/spec/rubocop/formatter/emacs_style_formatter_spec.rb
@@ -20,9 +20,10 @@ module RuboCop
                           'message 2')
 
           formatter.file_finished('test', cop.offenses)
-          expect(output.string).to eq ['test:1:1: C: message 1',
-                                       'test:3:6: C: message 2',
-                                       ''].join("\n")
+          expect(output.string).to eq <<-END.strip_indent
+            test:1:1: C: message 1
+            test:3:6: C: message 2
+          END
         end
 
         context 'when the offense is automatically corrected' do

--- a/spec/rubocop/formatter/offense_count_formatter_spec.rb
+++ b/spec/rubocop/formatter/offense_count_formatter_spec.rb
@@ -57,14 +57,15 @@ module RuboCop
 
           it 'sorts by offense count first and then by cop name' do
             formatter.finished(files)
-            expect(output.string).to eq(['',
-                                         '2  CopC',
-                                         '1  CopA',
-                                         '1  CopB',
-                                         '--',
-                                         '4  Total',
-                                         '',
-                                         ''].join("\n"))
+            expect(output.string).to eq(<<-END.strip_indent)
+
+              2  CopC
+              1  CopA
+              1  CopB
+              --
+              4  Total
+
+            END
           end
         end
       end

--- a/spec/rubocop/formatter/progress_formatter_spec.rb
+++ b/spec/rubocop/formatter/progress_formatter_spec.rb
@@ -145,19 +145,19 @@ module RuboCop
 
         it 'reports all detected offenses for all failed files' do
           formatter.finished(files)
-          expect(output.string).to include([
-            'Offenses:',
-            '',
-            'lib/rubocop.rb:2:3: C: foo',
-            'This is line 2.',
-            '  ^',
-            'bin/rubocop:5:2: E: bar',
-            'This is line 5.',
-            ' ^',
-            'bin/rubocop:6:1: C: foo',
-            'This is line 6.',
-            '^'
-          ].join("\n"))
+          expect(output.string).to include(<<-END.strip_indent)
+            Offenses:
+
+            lib/rubocop.rb:2:3: C: foo
+            This is line 2.
+              ^
+            bin/rubocop:5:2: E: bar
+            This is line 5.
+             ^
+            bin/rubocop:6:1: C: foo
+            This is line 6.
+            ^
+          END
         end
       end
 

--- a/spec/rubocop/formatter/simple_text_formatter_spec.rb
+++ b/spec/rubocop/formatter/simple_text_formatter_spec.rb
@@ -74,66 +74,60 @@ module RuboCop
         context 'when no files inspected' do
           it 'handles pluralization correctly' do
             formatter.report_summary(0, 0, 0)
-            expect(output.string).to eq(
-              ['',
-               '0 files inspected, no offenses detected',
-               ''].join("\n")
-            )
+            expect(output.string).to eq(<<-END.strip_indent)
+
+              0 files inspected, no offenses detected
+            END
           end
         end
 
         context 'when a file inspected and no offenses detected' do
           it 'handles pluralization correctly' do
             formatter.report_summary(1, 0, 0)
-            expect(output.string).to eq(
-              ['',
-               '1 file inspected, no offenses detected',
-               ''].join("\n")
-            )
+            expect(output.string).to eq(<<-END.strip_indent)
+
+              1 file inspected, no offenses detected
+            END
           end
         end
 
         context 'when a offense detected' do
           it 'handles pluralization correctly' do
             formatter.report_summary(1, 1, 0)
-            expect(output.string).to eq(
-              ['',
-               '1 file inspected, 1 offense detected',
-               ''].join("\n")
-            )
+            expect(output.string).to eq(<<-END.strip_indent)
+
+              1 file inspected, 1 offense detected
+            END
           end
         end
 
         context 'when 2 offenses detected' do
           it 'handles pluralization correctly' do
             formatter.report_summary(2, 2, 0)
-            expect(output.string).to eq(
-              ['',
-               '2 files inspected, 2 offenses detected',
-               ''].join("\n")
-            )
+            expect(output.string).to eq(<<-END.strip_indent)
+
+              2 files inspected, 2 offenses detected
+            END
           end
         end
 
         context 'when an offense is corrected' do
           it 'prints about correction' do
             formatter.report_summary(1, 1, 1)
-            expect(output.string).to eq(
-              ['',
-               '1 file inspected, 1 offense detected, 1 offense corrected',
-               ''].join("\n")
-            )
+            expect(output.string).to eq(<<-END.strip_indent)
+
+              1 file inspected, 1 offense detected, 1 offense corrected
+            END
           end
         end
 
         context 'when 2 offenses are corrected' do
           it 'handles pluralization correctly' do
             formatter.report_summary(1, 1, 2)
-            expect(output.string).to eq(
-              ['',
-               '1 file inspected, 1 offense detected, 2 offenses corrected',
-               ''].join("\n")
-            )
+            expect(output.string).to eq(<<-END.strip_indent)
+
+              1 file inspected, 1 offense detected, 2 offenses corrected
+            END
           end
         end
       end

--- a/spec/rubocop/formatter/worst_offenders_formatter_spec.rb
+++ b/spec/rubocop/formatter/worst_offenders_formatter_spec.rb
@@ -25,14 +25,15 @@ module RuboCop
 
           it 'sorts by offense count first and then by cop name' do
             formatter.finished(files)
-            expect(output.string).to eq(['',
-                                         '4  bin/rubocop',
-                                         '3  spec/spec_helper.rb',
-                                         '2  lib/rubocop.rb',
-                                         '--',
-                                         '9  Total',
-                                         '',
-                                         ''].join("\n"))
+            expect(output.string).to eq(<<-END.strip_indent)
+
+              4  bin/rubocop
+              3  spec/spec_helper.rb
+              2  lib/rubocop.rb
+              --
+              9  Total
+
+            END
           end
         end
       end

--- a/spec/rubocop/options_spec.rb
+++ b/spec/rubocop/options_spec.rb
@@ -146,8 +146,8 @@ describe RuboCop::Options, :isolated_environment do
       end
 
       it 'mentions all incompatible options when more than two are used' do
-        msg = ['Incompatible cli options: [:version, :verbose_version,',
-               ' :show_cops]'].join
+        msg = 'Incompatible cli options: [:version, :verbose_version,' \
+              ' :show_cops]'
         expect { options.parse %w[-vV --show-cops] }
           .to raise_error(ArgumentError, msg)
       end

--- a/spec/rubocop/rake_task_spec.rb
+++ b/spec/rubocop/rake_task_spec.rb
@@ -109,8 +109,10 @@ describe RuboCop::RakeTask do
 
     it 'uses the default formatter from .rubocop.yml if no formatter ' \
        'option is given', :isolated_environment do
-      create_file('.rubocop.yml', ['AllCops:',
-                                   '  DefaultFormatter: offenses'])
+      create_file('.rubocop.yml', <<-END.strip_indent)
+        AllCops:
+          DefaultFormatter: offenses
+      END
       create_file('test.rb', '$:')
 
       described_class.new do |task|
@@ -119,11 +121,14 @@ describe RuboCop::RakeTask do
 
       expect { Rake::Task['rubocop'].execute }.to raise_error(SystemExit)
 
-      expect($stdout.string.strip).to eq(['Running RuboCop...',
-                                          '',
-                                          '1  Style/SpecialGlobalVars',
-                                          '--',
-                                          '1  Total'].join("\n"))
+      expect($stdout.string).to eq(<<-END.strip_indent)
+        Running RuboCop...
+
+        1  Style/SpecialGlobalVars
+        --
+        1  Total
+
+      END
       expect($stderr.string.strip).to eq 'RuboCop failed!'
     end
 

--- a/spec/rubocop/result_cache_spec.rb
+++ b/spec/rubocop/result_cache_spec.rb
@@ -25,8 +25,10 @@ describe RuboCop::ResultCache, :isolated_environment do
   end
 
   before do
-    create_file('example.rb', ['# Hello',
-                               'x = 1'])
+    create_file('example.rb', <<-END.strip_indent)
+      # Hello
+      x = 1
+    END
     allow(config_store).to receive(:for).with('example.rb')
       .and_return(RuboCop::Config.new)
   end

--- a/spec/rubocop/runner_spec.rb
+++ b/spec/rubocop/runner_spec.rb
@@ -82,8 +82,10 @@ describe RuboCop::Runner, :isolated_environment do
     context 'if -s/--stdin is used with an offense' do
       before do
         # Make Style/EndOfLine give same output regardless of platform.
-        create_file('.rubocop.yml', ['Style/EndOfLine:',
-                                     '  EnforcedStyle: lf'])
+        create_file('.rubocop.yml', <<-END.strip_indent)
+          Style/EndOfLine:
+            EnforcedStyle: lf
+        END
       end
 
       let(:options) do

--- a/spec/rubocop/target_finder_spec.rb
+++ b/spec/rubocop/target_finder_spec.rb
@@ -121,18 +121,18 @@ describe RuboCop::TargetFinder, :isolated_environment do
     context 'when some paths are specified in the configuration Exclude ' \
             'and they are explicitly passed as arguments' do
       before do
-        create_file('.rubocop.yml', [
-                      'AllCops:',
-                      '  Exclude:',
-                      '    - dir1/ruby1.rb',
-                      "    - 'dir2/*'"
-                    ])
+        create_file('.rubocop.yml', <<-END.strip_indent)
+          AllCops:
+            Exclude:
+              - dir1/ruby1.rb
+              - 'dir2/*'
+        END
 
-        create_file('dir1/.rubocop.yml', [
-                      'AllCops:',
-                      '  Exclude:',
-                      '    - executable'
-                    ])
+        create_file('dir1/.rubocop.yml', <<-END.strip_indent)
+          AllCops:
+            Exclude:
+              - executable
+        END
       end
 
       let(:args) do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -11,6 +11,8 @@ require 'rubocop'
 
 require 'webmock/rspec'
 
+require 'powerpack/string/strip_margin'
+
 # Require supporting files exposed for testing.
 require 'rubocop/rspec/support'
 

--- a/spec/support/empty_lines_around_body_shared_examples.rb
+++ b/spec/support/empty_lines_around_body_shared_examples.rb
@@ -6,20 +6,23 @@ shared_examples_for 'empty_lines_around_class_or_module_body' do |type|
 
     context 'when first child is method' do
       it "requires blank line at the beginning and ending of #{type} body" do
-        inspect_source(cop,
-                       ["#{type} SomeObject",
-                        '',
-                        '  def do_something; end',
-                        '',
-                        'end'])
+        inspect_source(cop, <<-END.strip_indent)
+          #{type} SomeObject
+
+            def do_something; end
+
+          end
+        END
         expect(cop.messages).to eq([])
       end
 
       context 'source without blank lines' do
         let(:source) do
-          ["#{type} SomeObject",
-           '  def do_something; end',
-           'end']
+          <<-END.strip_indent
+            #{type} SomeObject
+              def do_something; end
+            end
+          END
         end
 
         it "registers an offense for #{type} not beginning "\
@@ -30,76 +33,87 @@ shared_examples_for 'empty_lines_around_class_or_module_body' do |type|
 
         it 'autocorrects the offenses' do
           new_source = autocorrect_source(cop, source)
-          expect(new_source).to eq(["#{type} SomeObject",
-                                    '',
-                                    '  def do_something; end',
-                                    '',
-                                    'end'].join("\n"))
+          expect(new_source).to eq(<<-END.strip_indent)
+            #{type} SomeObject
+
+              def do_something; end
+
+            end
+          END
         end
       end
 
       context "when #{type} has a namespace" do
         it 'requires no empty lines for namespace but '\
           "requires blank line at the beginning and ending of #{type} body" do
-          inspect_source(cop,
-                         ["#{type} Parent",
-                          "  #{type} SomeObject",
-                          '',
-                          '    def do_something',
-                          '    end',
-                          '',
-                          '  end',
-                          'end'])
+          inspect_source(cop, <<-END.strip_indent)
+            #{type} Parent
+              #{type} SomeObject
+
+                def do_something
+                end
+
+              end
+            end
+          END
           expect(cop.messages).to eq([])
         end
 
         context 'source without blank lines' do
           let(:source) do
-            ["#{type} Parent",
-             "  #{type} SomeObject",
-             '    def do_something',
-             '    end',
-             '  end',
-             'end']
+            <<-END.strip_indent
+              #{type} Parent
+                #{type} SomeObject
+                  def do_something
+                  end
+                end
+              end
+            END
           end
 
           it 'autocorrects the offenses' do
             new_source = autocorrect_source(cop, source)
-            expect(new_source).to eq(["#{type} Parent",
-                                      "  #{type} SomeObject",
-                                      '',
-                                      '    def do_something',
-                                      '    end',
-                                      '',
-                                      '  end',
-                                      'end'].join("\n"))
+            expect(new_source).to eq(<<-END.strip_indent)
+              #{type} Parent
+                #{type} SomeObject
+
+                  def do_something
+                  end
+
+                end
+              end
+            END
           end
         end
 
         context 'source with blank lines' do
           let(:source) do
-            ["#{type} Parent",
-             '',
-             "  #{type} SomeObject",
-             '',
-             '    def do_something',
-             '    end',
-             '',
-             '  end',
-             '',
-             'end']
+            <<-END.strip_indent
+              #{type} Parent
+
+                #{type} SomeObject
+
+                  def do_something
+                  end
+
+                end
+
+              end
+            END
           end
 
           it 'autocorrects the offenses' do
             new_source = autocorrect_source(cop, source)
-            expect(new_source).to eq(["#{type} Parent",
-                                      "  #{type} SomeObject",
-                                      '',
-                                      '    def do_something',
-                                      '    end',
-                                      '',
-                                      '  end',
-                                      'end'].join("\n"))
+            expect(new_source).to eq(<<-END.strip_indent)
+              #{type} Parent
+                #{type} SomeObject
+
+                  def do_something
+                  end
+
+                end
+              end
+            END
           end
         end
       end
@@ -109,22 +123,25 @@ shared_examples_for 'empty_lines_around_class_or_module_body' do |type|
       it "does not require blank line at the beginning of #{type} body "\
         'but requires blank line before first def definition '\
         "and requires blank line at the end of #{type} body" do
-        inspect_source(cop,
-                       ["#{type} SomeObject",
-                        '  include Something',
-                        '',
-                        '  def do_something; end',
-                        '',
-                        'end'])
+        inspect_source(cop, <<-END.strip_indent)
+          #{type} SomeObject
+            include Something
+
+            def do_something; end
+
+          end
+        END
         expect(cop.messages).to eq([])
       end
 
       context 'source without blank lines' do
         let(:source) do
-          ["#{type} SomeObject",
-           '  include Something',
-           '  def do_something; end',
-           'end']
+          <<-END.strip_indent
+            #{type} SomeObject
+              include Something
+              def do_something; end
+            end
+          END
         end
 
         it "registers an offense for #{type} not ending with a blank line" do
@@ -134,23 +151,27 @@ shared_examples_for 'empty_lines_around_class_or_module_body' do |type|
 
         it 'autocorrects the offenses' do
           new_source = autocorrect_source(cop, source)
-          expect(new_source).to eq(["#{type} SomeObject",
-                                    '  include Something',
-                                    '',
-                                    '  def do_something; end',
-                                    '',
-                                    'end'].join("\n"))
+          expect(new_source).to eq(<<-END.strip_indent)
+            #{type} SomeObject
+              include Something
+
+              def do_something; end
+
+            end
+          END
         end
       end
 
       context 'source with blank lines' do
         let(:source) do
-          ["#{type} SomeObject",
-           '',
-           '  include Something',
-           '  def do_something; end',
-           '',
-           'end']
+          <<-END.strip_indent
+            #{type} SomeObject
+
+              include Something
+              def do_something; end
+
+            end
+          END
         end
 
         it "registers an offense for #{type} beginning with a blank line" do
@@ -160,24 +181,28 @@ shared_examples_for 'empty_lines_around_class_or_module_body' do |type|
 
         it 'autocorrects the offenses' do
           new_source = autocorrect_source(cop, source)
-          expect(new_source).to eq(["#{type} SomeObject",
-                                    '  include Something',
-                                    '',
-                                    '  def do_something; end',
-                                    '',
-                                    'end'].join("\n"))
+          expect(new_source).to eq(<<-END.strip_indent)
+            #{type} SomeObject
+              include Something
+
+              def do_something; end
+
+            end
+          END
         end
       end
 
       context 'source with comment before method definition' do
         let(:source) do
-          ["#{type} SomeObject",
-           '',
-           '  include Something',
-           '  # Comment',
-           '  def do_something; end',
-           '',
-           'end']
+          <<-END.strip_indent
+            #{type} SomeObject
+
+              include Something
+              # Comment
+              def do_something; end
+
+            end
+          END
         end
 
         it "registers an offense for #{type} beginning with a blank line" do
@@ -187,13 +212,15 @@ shared_examples_for 'empty_lines_around_class_or_module_body' do |type|
 
         it 'autocorrects the offenses' do
           new_source = autocorrect_source(cop, source)
-          expect(new_source).to eq(["#{type} SomeObject",
-                                    '  include Something',
-                                    '',
-                                    '  # Comment',
-                                    '  def do_something; end',
-                                    '',
-                                    'end'].join("\n"))
+          expect(new_source).to eq(<<-END.strip_indent)
+            #{type} SomeObject
+              include Something
+
+              # Comment
+              def do_something; end
+
+            end
+          END
         end
       end
 
@@ -201,96 +228,109 @@ shared_examples_for 'empty_lines_around_class_or_module_body' do |type|
         it 'requires no empty lines for namespace '\
           "and does not require blank line at the beginning of #{type} body "\
           "but requires blank line at the end of #{type} body" do
-          inspect_source(cop,
-                         ["#{type} Parent",
-                          "  #{type} SomeObject",
-                          '    include Something',
-                          '',
-                          '    def do_something',
-                          '    end',
-                          '',
-                          '  end',
-                          'end'])
+          inspect_source(cop, <<-END.strip_indent)
+            #{type} Parent
+              #{type} SomeObject
+                include Something
+
+                def do_something
+                end
+
+              end
+            end
+          END
           expect(cop.messages).to eq([])
         end
 
         context 'source without blank lines' do
           let(:source) do
-            ["#{type} Parent",
-             "  #{type} SomeObject",
-             '    include Something',
-             '    def do_something',
-             '    end',
-             '  end',
-             'end']
+            <<-END.strip_indent
+              #{type} Parent
+                #{type} SomeObject
+                  include Something
+                  def do_something
+                  end
+                end
+              end
+            END
           end
 
           it 'autocorrects the offenses' do
             new_source = autocorrect_source(cop, source)
-            expect(new_source).to eq(["#{type} Parent",
-                                      "  #{type} SomeObject",
-                                      '    include Something',
-                                      '',
-                                      '    def do_something',
-                                      '    end',
-                                      '',
-                                      '  end',
-                                      'end'].join("\n"))
+            expect(new_source).to eq(<<-END.strip_indent)
+              #{type} Parent
+                #{type} SomeObject
+                  include Something
+
+                  def do_something
+                  end
+
+                end
+              end
+            END
           end
         end
 
         context 'source with blank lines' do
           let(:source) do
-            ["#{type} Parent",
-             '',
-             "  #{type} SomeObject",
-             '',
-             '    include Something',
-             '',
-             '    def do_something',
-             '    end',
-             '',
-             '  end',
-             '',
-             'end']
+            <<-END.strip_indent
+              #{type} Parent
+
+                #{type} SomeObject
+
+                  include Something
+
+                  def do_something
+                  end
+
+                end
+
+              end
+            END
           end
 
           it 'autocorrects the offenses' do
             new_source = autocorrect_source(cop, source)
-            expect(new_source).to eq(["#{type} Parent",
-                                      "  #{type} SomeObject",
-                                      '    include Something',
-                                      '',
-                                      '    def do_something',
-                                      '    end',
-                                      '',
-                                      '  end',
-                                      'end'].join("\n"))
+            expect(new_source).to eq(<<-END.strip_indent)
+              #{type} Parent
+                #{type} SomeObject
+                  include Something
+
+                  def do_something
+                  end
+
+                end
+              end
+            END
           end
         end
 
         context 'source with constants' do
           let(:source) do
-            ["#{type} Parent",
-             "  #{type} SomeObject",
-             '    URL = %q(http://example.com)',
-             '    def do_something',
-             '    end',
-             '  end',
-             'end']
+            <<-END.strip_indent
+              #{type} Parent
+                #{type} SomeObject
+                  URL = %q(http://example.com)
+                  def do_something
+                  end
+                end
+              end
+            END
           end
 
           it 'autocorrects the offenses' do
             new_source = autocorrect_source(cop, source)
-            expect(new_source).to eq(["#{type} Parent",
-                                      "  #{type} SomeObject",
-                                      '    URL = %q(http://example.com)',
-                                      '',
-                                      '    def do_something',
-                                      '    end',
-                                      '',
-                                      '  end',
-                                      'end'].join("\n"))
+            expect(new_source).to eq(<<-END.strip_indent)
+              #{type} Parent
+                #{type} SomeObject
+                  URL = %q(http://example.com)
+
+                  def do_something
+                  end
+
+                end
+              end
+            END
           end
         end
       end
@@ -298,54 +338,61 @@ shared_examples_for 'empty_lines_around_class_or_module_body' do |type|
 
     context 'when namespace has multiple children' do
       it 'requires empty lines for namespace' do
-        inspect_source(cop,
-                       ["#{type} Parent",
-                        '',
-                        "  #{type} Mom",
-                        '',
-                        '    def do_something',
-                        '    end',
-                        '',
-                        '  end',
-                        "  #{type} Dad",
-                        '',
-                        '  end',
-                        '',
-                        'end'])
+        inspect_source(cop, <<-END.strip_indent)
+          #{type} Parent
+
+            #{type} Mom
+
+              def do_something
+              end
+
+            end
+            #{type} Dad
+
+            end
+
+          end
+        END
         expect(cop.messages).to eq([])
       end
     end
 
     context "#{type} with only constants" do
       let(:source) do
-        ["#{type} Parent",
-         "  #{type} SomeObject",
-         '    URL = %q(http://example.com)',
-         '    WSDL = %q(http://example.com/wsdl)',
-         '  end',
-         'end']
+        <<-END.strip_indent
+          #{type} Parent
+            #{type} SomeObject
+              URL = %q(http://example.com)
+              WSDL = %q(http://example.com/wsdl)
+            end
+          end
+        END
       end
 
       it 'autocorrects the offenses' do
         new_source = autocorrect_source(cop, source)
-        expect(new_source).to eq(["#{type} Parent",
-                                  "  #{type} SomeObject",
-                                  '    URL = %q(http://example.com)',
-                                  '    WSDL = %q(http://example.com/wsdl)',
-                                  '',
-                                  '  end',
-                                  'end'].join("\n"))
+        expect(new_source).to eq(<<-END.strip_indent)
+          #{type} Parent
+            #{type} SomeObject
+              URL = %q(http://example.com)
+              WSDL = %q(http://example.com/wsdl)
+
+            end
+          end
+        END
       end
     end
 
     context "#{type} with constant and child #{type}" do
       let(:source) do
-        ["#{type} Parent",
-         '  URL = %q(http://example.com)',
-         "  #{type} SomeObject",
-         '    def do_something; end',
-         '  end',
-         'end']
+        <<-END.strip_indent
+          #{type} Parent
+            URL = %q(http://example.com)
+            #{type} SomeObject
+              def do_something; end
+            end
+          end
+        END
       end
 
       it 'registers offenses' do
@@ -358,25 +405,29 @@ shared_examples_for 'empty_lines_around_class_or_module_body' do |type|
 
       it 'autocorrects the offenses' do
         new_source = autocorrect_source(cop, source)
-        expect(new_source).to eq(["#{type} Parent",
-                                  '  URL = %q(http://example.com)',
-                                  '',
-                                  "  #{type} SomeObject",
-                                  '',
-                                  '    def do_something; end',
-                                  '',
-                                  '  end',
-                                  '',
-                                  'end'].join("\n"))
+        expect(new_source).to eq(<<-END.strip_indent)
+          #{type} Parent
+            URL = %q(http://example.com)
+
+            #{type} SomeObject
+
+              def do_something; end
+
+            end
+
+          end
+        END
       end
     end
 
     context "#{type} with empty body" do
       context 'with empty line' do
         let(:source) do
-          ["#{type} SomeObject",
-           '',
-           'end']
+          <<-END.strip_indent
+            #{type} SomeObject
+
+            end
+          END
         end
 
         it 'does NOT register offenses' do
@@ -387,8 +438,10 @@ shared_examples_for 'empty_lines_around_class_or_module_body' do |type|
 
       context 'without empty line' do
         let(:source) do
-          ["#{type} SomeObject",
-           'end']
+          <<-END.strip_indent
+            #{type} SomeObject
+            end
+          END
         end
 
         it 'does NOT register offenses' do

--- a/spec/support/statement_modifier_helper.rb
+++ b/spec/support/statement_modifier_helper.rb
@@ -2,15 +2,19 @@
 
 module StatementModifierHelper
   def check_empty(cop, keyword)
-    inspect_source(cop, ["#{keyword} cond",
-                         'end'])
+    inspect_source(cop, <<-END.strip_indent)
+      #{keyword} cond
+      end
+    END
     expect(cop.offenses).to be_empty
   end
 
   def check_really_short(cop, keyword)
-    inspect_source(cop, ["#{keyword} a",
-                         '  b',
-                         'end'])
+    inspect_source(cop, <<-END.strip_indent)
+      #{keyword} a
+        b
+      end
+    END
     expect(cop.messages).to eq(
       ["Favor modifier `#{keyword}` usage when having a single-line body."]
     )
@@ -18,11 +22,12 @@ module StatementModifierHelper
   end
 
   def autocorrect_really_short(cop, keyword)
-    corrected = autocorrect_source(cop,
-                                   ["#{keyword} a",
-                                    '  b',
-                                    'end'])
-    expect(corrected).to eq "b #{keyword} a"
+    corrected = autocorrect_source(cop, <<-END.strip_indent)
+      #{keyword} a
+        b
+      end
+    END
+    expect(corrected).to eq "b #{keyword} a\n"
   end
 
   def check_too_long(cop, keyword)
@@ -31,20 +36,22 @@ module StatementModifierHelper
     body = 'b' * 37
     expect("  #{body} #{keyword} #{condition}".length).to eq(81)
 
-    inspect_source(cop,
-                   ["  #{keyword} #{condition}",
-                    "    #{body}",
-                    '  end'])
+    inspect_source(cop, <<-END.strip_margin('|'))
+      |  #{keyword} #{condition}
+      |    #{body}
+      |  end
+    END
 
     expect(cop.offenses).to be_empty
   end
 
   def check_short_multiline(cop, keyword)
-    inspect_source(cop,
-                   ["#{keyword} ENV['COVERAGE']",
-                    "  require 'simplecov'",
-                    '  SimpleCov.start',
-                    'end'])
+    inspect_source(cop, <<-END.strip_indent)
+      #{keyword} ENV['COVERAGE']
+        require 'simplecov'
+        SimpleCov.start
+      end
+    END
     expect(cop.messages).to be_empty
   end
 end


### PR DESCRIPTION
Sorry for this jumbo PR but this has been concerned me for years 😬

Historically, we've been used both heredoc and the array-of-lines styles for example sources in specs, but the array-of-lines style is actually hard to read. It's usable only when there're trailing whitespaces in the example source.

Here are some examples of this conversion:

Standard
--------

The following source:

```ruby
source = [
  'def some_method',
  '  body',
  'end'
]
END
```

... should be converted to:

```ruby
source = <<-END.strip_indent
  def some_method
    body
  end
END
```

With indentations
-----------------

The following source:

```ruby
source = [
  '  def some_method',
  '    body',
  '  end'
]
END
```

... should be converted to:

```ruby
source = <<-END.strip_margin('|')
  |  def some_method
  |    body
  |  end
END
```

With trailing whitespaces
-------------------------

The following source does _not_ need to be converted:

```ruby
source = [
  'def some_method',
  '  body ',
  'end'
]
END
```

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Used the same coding conventions as the rest of the project.
* [ ] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [ ] Added tests.
* [ ] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] All tests are passing.
* [x] The new code doesn't generate RuboCop offenses.
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [ ] Updated cop documentation with `rake generate_cops_documentation` (required only when you've added a new cop or changed the configuration/documentation of an existing cop).

[1]: http://chris.beams.io/posts/git-commit/