### PR TITLE
Suppress `warning: URI.regexp is obsolete`

### DIFF
--- a/spec/rubocop/ast/node_spec.rb
+++ b/spec/rubocop/ast/node_spec.rb
@@ -350,7 +350,7 @@ describe RuboCop::AST::Node do
       end
 
       context 'with no interpolation' do
-        let(:src) { URI.regexp.inspect }
+        let(:src) { URI::Parser.new.regexp.inspect }
         it 'returns true' do
           expect(node).to be_pure
         end


### PR DESCRIPTION
This PR suppresses the following warning.

```sh
% ruby -v
ruby 2.4.1p111 (2017-03-22 revision 58053) [x86_64-darwin13]
% bundle exec rspec -w spec/rubocop/ast/node_spec.rb
/Users/koic/.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/parser-2.4.0.0/lib/parser/lexer.rb:10922: warning: assigned but unused variable - te
stEof
Run options:
  include {:focus=>true}
  exclude {:broken=>#<Proc:./spec/spec_helper.rb:34>}

All examples were filtered out; ignoring {:focus=>true}

Randomized with seed 55088
..................................../Users/koic/src/github.com/bbatsov/rubocop/spec/rubocop/ast/node_spec.rb:353:in `block (5 levels) in <top (
required)>': warning: URI.regexp is obsolete
..........................

Finished in 0.09529 seconds (files took 1.02 seconds to load)
62 examples, 0 failures
```

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Used the same coding conventions as the rest of the project.
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [ ] Squashed related commits together.
* [ ] Added tests.
* [ ] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] All tests are passing.
* [x] The new code doesn't generate RuboCop offenses.
* [ ] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [ ] Updated cop documentation with `rake generate_cops_documentation` (required only when you've added a new cop or changed the configuration/documentation of an existing cop).

[1]: http://chris.beams.io/posts/git-commit/
