### PR TITLE
Add auto-correct to MixinGrouping

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### New features
 
 * [#117](https://github.com/bbatsov/rubocop/issues/117): Add `--parallel` option for running RuboCop in multiple processes or threads. ([@jonas054][])
+* Add auto-correct support to `Style/MixinGrouping`. ([@rrosenblum][])
 
 ### Changes
 

--- a/lib/rubocop/cop/style/mixin_grouping.rb
+++ b/lib/rubocop/cop/style/mixin_grouping.rb
@@ -46,6 +46,21 @@ module RuboCop
           check(node)
         end
 
+        def autocorrect(node)
+          if separated_style?
+            range = node.loc.expression
+            correction = separate_mixins(node)
+          else
+            mixins = sibling_mixins(node)
+            mixins.unshift(node)
+
+            range = node.loc.expression.join(mixins.last.loc.expression)
+            correction = group_mixins(node, mixins)
+          end
+
+          ->(corrector) { corrector.replace(range, correction) }
+        end
+
         private
 
         def check(send_node)
@@ -57,7 +72,7 @@ module RuboCop
         end
 
         def check_grouped_style(send_node)
-          return unless sibling_mixins?(send_node)
+          return if sibling_mixins(send_node).empty?
 
           add_offense(send_node, :expression)
         end
@@ -68,11 +83,11 @@ module RuboCop
           add_offense(send_node, :expression)
         end
 
-        def sibling_mixins?(send_node)
+        def sibling_mixins(send_node)
           siblings = send_node.parent.each_child_node(:send)
                               .reject { |sibling| sibling == send_node }
 
-          siblings.any? do |sibling_node|
+          siblings.select do |sibling_node|
             sibling_node.method_name == send_node.method_name
           end
         end
@@ -90,6 +105,29 @@ module RuboCop
 
         def separated_style?
           style == :separated
+        end
+
+        def separate_mixins(node)
+          _receiver, mixin, *args = *node
+          args.reverse!
+          first_mixin = String.new("#{mixin} #{args.first.source}")
+
+          args[1..-1].inject(first_mixin) do |replacement, arg|
+            replacement << "\n#{indent(node)}#{mixin} #{arg.source}"
+          end
+        end
+
+        def group_mixins(node, mixins)
+          _receiver, mixin, *_args = *node
+          all_mixin_arguments = mixins.reverse.flat_map do |m|
+            m.arguments.map(&:source)
+          end
+
+          "#{mixin} #{all_mixin_arguments.join(', ')}"
+        end
+
+        def indent(node)
+          ' ' * node.loc.column
         end
       end
     end

--- a/manual/cops_style.md
+++ b/manual/cops_style.md
@@ -3075,7 +3075,7 @@ SupportedStyles | if, case, both
 
 Enabled by default | Supports autocorrection
 --- | ---
-Enabled | No
+Enabled | Yes
 
 This cop checks for grouping of mixins in `class` and `module` bodies.
 By default it enforces mixins to be placed in separate declarations,

--- a/spec/rubocop/cop/style/mixin_grouping_spec.rb
+++ b/spec/rubocop/cop/style/mixin_grouping_spec.rb
@@ -45,14 +45,17 @@ describe RuboCop::Cop::Style::MixinGrouping, :config do
       let(:message) { 'Put `include` mixins in separate statements.' }
 
       context 'with several mixins in one call' do
-        it_behaves_like 'code with offense', <<-END.strip_indent
-          class Foo
-            include Bar, Qux
-          end
-        END
+        it_behaves_like 'code with offense',
+                        ['class Foo',
+                         '  include Bar, Qux',
+                         'end'].join("\n"),
+                        ['class Foo',
+                         '  include Qux',
+                         '  include Bar',
+                         'end'].join("\n")
       end
 
-      context 'with several mixins in separate calls' do
+      context 'with single mixins in separate calls' do
         it_behaves_like 'code without offense', <<-END.strip_indent
           class Foo
             include Bar
@@ -65,20 +68,36 @@ describe RuboCop::Cop::Style::MixinGrouping, :config do
         it_behaves_like 'code without offense',
                         'expect(foo).to include(bar, baz)'
       end
+
+      context 'with several mixins in seperate calls' do
+        it_behaves_like 'code with offense',
+                        ['class Foo',
+                         '  include Bar, Baz',
+                         '  include Qux',
+                         'end'].join("\n"),
+                        ['class Foo',
+                         '  include Baz',
+                         '  include Bar',
+                         '  include Qux',
+                         'end'].join("\n")
+      end
     end
 
     context 'when using `extend`' do
       let(:message) { 'Put `extend` mixins in separate statements.' }
 
       context 'with several mixins in one call' do
-        it_behaves_like 'code with offense', <<-END.strip_indent
-          class Foo
-            extend Bar, Qux
-          end
-        END
+        it_behaves_like 'code with offense',
+                        ['class Foo',
+                         '  extend Bar, Qux',
+                         'end'].join("\n"),
+                        ['class Foo',
+                         '  extend Qux',
+                         '  extend Bar',
+                         'end'].join("\n")
       end
 
-      context 'with several mixins in separate calls' do
+      context 'with single mixins in separate calls' do
         it_behaves_like 'code without offense', <<-END.strip_indent
           class Foo
             extend Bar
@@ -92,14 +111,17 @@ describe RuboCop::Cop::Style::MixinGrouping, :config do
       let(:message) { 'Put `prepend` mixins in separate statements.' }
 
       context 'with several mixins in one call' do
-        it_behaves_like 'code with offense', <<-END.strip_indent
-          class Foo
-            prepend Bar, Qux
-          end
-        END
+        it_behaves_like 'code with offense',
+                        ['class Foo',
+                         '  prepend Bar, Qux',
+                         'end'].join("\n"),
+                        ['class Foo',
+                         '  prepend Qux',
+                         '  prepend Bar',
+                         'end'].join("\n")
       end
 
-      context 'with several mixins in separate calls' do
+      context 'with single mixins in separate calls' do
         it_behaves_like 'code without offense', <<-END.strip_indent
           class Foo
             prepend Bar
@@ -113,12 +135,16 @@ describe RuboCop::Cop::Style::MixinGrouping, :config do
       context 'with some calls having several mixins' do
         let(:message) { 'Put `include` mixins in separate statements.' }
 
-        it_behaves_like 'code with offense', <<-END.strip_indent
-          class Foo
-            include Bar, Baz
-            extend Qux
-          end
-        END
+        it_behaves_like 'code with offense',
+                        ['class Foo',
+                         '  include Bar, Baz',
+                         '  extend Qux',
+                         'end'].join("\n"),
+                        ['class Foo',
+                         '  include Baz',
+                         '  include Bar',
+                         '  extend Qux',
+                         'end'].join("\n")
       end
 
       context 'with all calls having one mixin' do
@@ -137,20 +163,22 @@ describe RuboCop::Cop::Style::MixinGrouping, :config do
     let(:cop_config) { { 'EnforcedStyle' => 'grouped' } }
 
     context 'when using include' do
-      context 'with several mixins in one call' do
+      context 'with single mixins in separate calls' do
         let(:offenses) { 3 }
         let(:message) { 'Put `include` mixins in a single statement.' }
 
-        it_behaves_like 'code with offense', <<-END.strip_indent
-          class Foo
-            include Bar
-            include Baz
-            include Qux
-          end
-        END
+        it_behaves_like 'code with offense',
+                        ['class Foo',
+                         '  include Bar',
+                         '  include Baz',
+                         '  include Qux',
+                         'end'].join("\n"),
+                        ['class Foo',
+                         '  include Qux, Baz, Bar',
+                         'end'].join("\n")
       end
 
-      context 'with several mixins in separate calls' do
+      context 'with several mixins in one call' do
         it_behaves_like 'code without offense', <<-END.strip_indent
           class Foo
             include Bar, Qux
@@ -164,22 +192,39 @@ describe RuboCop::Cop::Style::MixinGrouping, :config do
           config.include Bar
         END
       end
+
+      context 'with several mixins in seperate calls' do
+        let(:offenses) { 3 }
+        let(:message) { 'Put `include` mixins in a single statement.' }
+
+        it_behaves_like 'code with offense',
+                        ['class Foo',
+                         '  include Bar, Baz',
+                         '  include FooBar, FooBaz',
+                         '  include Qux, FooBarBaz',
+                         'end'].join("\n"),
+                        ['class Foo',
+                         '  include Qux, FooBarBaz, FooBar, FooBaz, Bar, Baz',
+                         'end'].join("\n")
+      end
     end
 
     context 'when using `extend`' do
-      context 'with several mixins in one call' do
+      context 'with single mixins in seperate calls' do
         let(:offenses) { 2 }
         let(:message) { 'Put `extend` mixins in a single statement.' }
 
-        it_behaves_like 'code with offense', <<-END.strip_indent
-          class Foo
-            extend Bar
-            extend Baz
-          end
-        END
+        it_behaves_like 'code with offense',
+                        ['class Foo',
+                         '  extend Bar',
+                         '  extend Baz',
+                         'end'].join("\n"),
+                        ['class Foo',
+                         '  extend Baz, Bar',
+                         'end'].join("\n")
       end
 
-      context 'with several mixins in separate calls' do
+      context 'with several mixins in one call' do
         it_behaves_like 'code without offense', <<-END.strip_indent
           class Foo
             extend Bar, Qux
@@ -189,19 +234,21 @@ describe RuboCop::Cop::Style::MixinGrouping, :config do
     end
 
     context 'when using `prepend`' do
-      context 'with several mixins in one call' do
+      context 'with single mixins in separate calls' do
         let(:offenses) { 2 }
         let(:message) { 'Put `prepend` mixins in a single statement.' }
 
-        it_behaves_like 'code with offense', <<-END.strip_indent
-          class Foo
-            prepend Bar
-            prepend Baz
-          end
-        END
+        it_behaves_like 'code with offense',
+                        ['class Foo',
+                         '  prepend Bar',
+                         '  prepend Baz',
+                         'end'].join("\n"),
+                        ['class Foo',
+                         '  prepend Baz, Bar',
+                         'end'].join("\n")
       end
 
-      context 'with several mixins in separate calls' do
+      context 'with several mixins in one call' do
         it_behaves_like 'code without offense', <<-END.strip_indent
           class Foo
             prepend Bar, Qux
@@ -215,13 +262,16 @@ describe RuboCop::Cop::Style::MixinGrouping, :config do
         let(:offenses) { 2 }
         let(:message) { 'Put `include` mixins in a single statement.' }
 
-        it_behaves_like 'code with offense', <<-END.strip_indent
-          class Foo
-            include Bar
-            include Baz
-            extend Baz
-          end
-        END
+        it_behaves_like 'code with offense',
+                        ['class Foo',
+                         '  include Bar',
+                         '  include Baz',
+                         '  extend Baz',
+                         'end'].join("\n"),
+                        ['class Foo',
+                         '  include Baz, Bar',
+                         '  extend Baz',
+                         'end'].join("\n")
       end
 
       context 'with all different mixin methods' do


### PR DESCRIPTION
I noticed that `Style/MixinGrouping` didn't support auto-correct so I decided to add it. So far I have the auto-correct of `separated` working, and I am trying to see if it will be feasible to add auto-correct for the `grouped` style.