### PR TITLE
Require a space before first argument of a method call

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,11 +2,9 @@
 
 ## master (unreleased)
 
-### New features
-* [#4265](https://github.com/bbatsov/rubocop/pull/4265): Require a space before first argument of a method call. ([@cjlarose][])
-
 ### Bug fixes
 
+* [#4265](https://github.com/bbatsov/rubocop/pull/4265): Require a space before first argument of a method call in `Style/SpaceBeforeFirstArg` cop. ([@cjlarose][])
 * [#4237](https://github.com/bbatsov/rubocop/pull/4237): Fix false positive in `Lint/AmbiguousBlockAssociation` cop for lambdas. ([@smakagon][])
 * [#4242](https://github.com/bbatsov/rubocop/issues/4242): Add `Capfile` to the list of known Ruby filenames. ([@bbatsov][])
 * [#4240](https://github.com/bbatsov/rubocop/issues/4240): Handle `||=` in `Rails/RelativeDateConstant`. ([@bbatsov][])

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2738,3 +2738,4 @@
 [@dpostorivo]: https://github.com/dpostorivo
 [@konto-andrzeja]: https://github.com/konto-andrzeja
 [@sadovnik]: https://github.com/sadovnik
+[@cjlarose]: https://github.com/cjlarose

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## master (unreleased)
 
+### New features
+* [#4265](https://github.com/bbatsov/rubocop/pull/4265): Require a space before first argument of a method call. ([@cjlarose][])
+
 ### Bug fixes
 
 * [#4237](https://github.com/bbatsov/rubocop/pull/4237): Fix false positive in `Lint/AmbiguousBlockAssociation` cop for lambdas. ([@smakagon][])

--- a/lib/rubocop/cop/style/space_before_first_arg.rb
+++ b/lib/rubocop/cop/style/space_before_first_arg.rb
@@ -18,6 +18,7 @@ module RuboCop
       #   @good
       #   something x
       #   something y, z
+      #   something 'hello'
       #
       class SpaceBeforeFirstArg < Cop
         include PrecedingFollowingAlignment
@@ -34,7 +35,7 @@ module RuboCop
           space = range_between(first_arg_with_space.begin_pos,
                                 first_arg.begin_pos)
 
-          add_offense(space, space) if space.length > 1
+          add_offense(space, space) if space.length != 1
         end
 
         def autocorrect(range)

--- a/lib/rubocop/cop/style/space_before_first_arg.rb
+++ b/lib/rubocop/cop/style/space_before_first_arg.rb
@@ -14,6 +14,7 @@ module RuboCop
       #   @bad
       #   something  x
       #   something   y, z
+      #   something'hello'
       #
       #   @good
       #   something x

--- a/manual/cops_style.md
+++ b/manual/cops_style.md
@@ -986,7 +986,7 @@ module Foo
   end
 end
 
-# Documenation
+# Documentation
 def foo.bar
   puts baz
 end
@@ -2292,7 +2292,7 @@ Enabled by default | Supports autocorrection
 --- | ---
 Enabled | No
 
-Checks for if and unless statements used as modifers of other if or
+Checks for if and unless statements used as modifiers of other if or
 unless statements.
 
 ### Example
@@ -4318,24 +4318,24 @@ default.
 ```ruby
 # Style/PercentLiteralDelimiters:
 #   PreferredDelimiters:
-#     default: ()
-#     %i:      []
+#     default: []
+#     %i:      ()
 
 # good
-%w(alpha beta) + %i[gamma delta]
+%w[alpha beta] + %i(gamma delta)
 
 # bad
-%W[alpha #{beta}]
+%W(alpha #{beta})
 
 # bad
-%I[alpha beta]
+%I(alpha beta)
 ```
 
 ### Important attributes
 
 Attribute | Value
 --- | ---
-PreferredDelimiters | {"default"=>"()", "%r"=>"{}"}
+PreferredDelimiters | {"default"=>"()", "%i"=>"[]", "%I"=>"[]", "%r"=>"{}", "%w"=>"[]", "%W"=>"[]"}
 
 ### References
 
@@ -5182,10 +5182,12 @@ config parameter is true.
 # bad
 something  x
 something   y, z
+something'hello'
 
 # good
 something x
 something y, z
+something 'hello'
 ```
 
 ### Important attributes
@@ -5640,7 +5642,7 @@ Enabled | Yes
 This cop checks for the presence of parentheses around ternary
 conditions. It is configurable to enforce inclusion or omission of
 parentheses using `EnforcedStyle`. Omission is only enforced when
-removing the parentheses won't cause a different behaviour.
+removing the parentheses won't cause a different behavior.
 
 ### Example
 

--- a/spec/rubocop/cop/style/space_before_first_arg_spec.rb
+++ b/spec/rubocop/cop/style/space_before_first_arg_spec.rb
@@ -28,6 +28,28 @@ describe RuboCop::Cop::Style::SpaceBeforeFirstArg, :config do
       END
     end
 
+    it 'registers an offense for method call with no spaces before the '\
+       'first arg' do
+      inspect_source(cop, <<-END.strip_indent)
+        something'hello'
+        a.something'hello world'
+      END
+      expect(cop.messages)
+        .to eq(['Put one space between the method name and the first ' \
+                'argument.'] * 2)
+    end
+
+    it 'auto-corrects missing space' do
+      new_source = autocorrect_source(cop, <<-END.strip_indent)
+        something'hello'
+        a.something'hello world'
+      END
+      expect(new_source).to eq(<<-END.strip_indent)
+        something 'hello'
+        a.something 'hello world'
+      END
+    end
+
     it 'accepts a method call with one space before the first arg' do
       inspect_source(cop, <<-END.strip_indent)
         something x


### PR DESCRIPTION
The Ruby parser appears to be completely fine with something like

```ruby
puts'hello'
```

The cop `Style/SpaceBeforeFirstArg` claims to check that "exactly one space is used between a method name and the first argument for method calls without parentheses", but does not account for source code that has zero spaces between the method name and the first argument.

-----------------

Before submitting the PR make sure the following are checked:

* [X] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [X] Used the same coding conventions as the rest of the project.
* [X] Feature branch is up-to-date with `master` (if not - rebase it).
* [X] Squashed related commits together.
* [X] Added tests.
* [X] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [ ] All tests are passing.
* [X] The new code doesn't generate RuboCop offenses.
* [X] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [X] Updated cop documentation with `rake generate_cops_documentation` (required only when you've added a new cop or changed the configuration/documentation of an existing cop).

[1]: http://chris.beams.io/posts/git-commit/
