### PR TITLE
[Fix #117] Add --parallel option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## master (unreleased)
 
+### New features
+
+* [#117](https://github.com/bbatsov/rubocop/issues/117): Add `--parallel` option for running RuboCop in multiple processes or threads. ([@jonas054][])
+
 ### Changes
 
 * [#4262](https://github.com/bbatsov/rubocop/pull/4262): Add new `MinSize` configuration to `Style/SymbolArray`, consistent with the same configuration in `Style/WordArray`. ([@scottmatthewman][])

--- a/lib/rubocop/cli.rb
+++ b/lib/rubocop/cli.rb
@@ -21,6 +21,7 @@ module RuboCop
     # @return [Integer] UNIX exit code
     def run(args = ARGV)
       @options, paths = Options.new.parse(args)
+      validate_options_vs_config
       act_on_options
       apply_default_formatter
 
@@ -46,6 +47,15 @@ module RuboCop
     end
 
     private
+
+    def validate_options_vs_config
+      if @options[:parallel] &&
+         !@config_store.for(Dir.pwd).for_all_cops['UseCache']
+        raise ArgumentError, '-P/--parallel uses caching to speed up ' \
+                             'execution, so combining with AllCops: ' \
+                             'UseCache: false is not allowed.'
+      end
+    end
 
     def act_on_options
       handle_exiting_options

--- a/lib/rubocop/result_cache.rb
+++ b/lib/rubocop/result_cache.rb
@@ -9,7 +9,7 @@ module RuboCop
   # Provides functionality for caching rubocop runs.
   class ResultCache
     NON_CHANGING = %i[color format formatters out debug fail_level
-                      cache fail_fast stdin].freeze
+                      cache fail_fast stdin parallel].freeze
 
     # Remove old files so that the cache doesn't grow too big. When the
     # threshold MaxFilesInCache has been exceeded, the oldest 50% of all the

--- a/manual/basic_usage.md
+++ b/manual/basic_usage.md
@@ -79,6 +79,7 @@ Command flag              | Description
 `--fail-level`            | Minimum [severity](#severity) for exit with error code. Full severity name or upper case initial can be given. Normally, auto-corrected offenses are ignored. Use `A` or `autocorrect` if you'd like them to trigger failure.
 `-s/--stdin`              | Pipe source from STDIN. This is useful for editor integration.
 `--[no-]color`            | Force color output on or off.
+`--parallel`              | Use available CPUs to execute inspection in parallel.
 
 Default command-line options are loaded from `.rubocop` and `RUBOCOP_OPTS` and are combined with command-line options that are explicitly passed to `rubocop`.
 Thus, the options have the following order of precedence (from highest to lowest):

--- a/rubocop.gemspec
+++ b/rubocop.gemspec
@@ -30,6 +30,7 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency('powerpack', '~> 0.1')
   s.add_runtime_dependency('ruby-progressbar', '~> 1.7')
   s.add_runtime_dependency('unicode-display_width', '~> 1.0', '>= 1.0.1')
+  s.add_runtime_dependency('parallel', '~> 1.10')
 
   s.add_development_dependency('bundler', '~> 1.3')
 end

--- a/spec/rubocop/options_spec.rb
+++ b/spec/rubocop/options_spec.rb
@@ -93,6 +93,8 @@ describe RuboCop::Options, :isolated_environment do
                   --[no-]color                 Force color output on or off.
               -v, --version                    Display version.
               -V, --verbose-version            Display verbose version.
+              -P, --parallel                   Use available CPUs to execute inspection in
+                                               parallel.
               -s, --stdin FILE                 Pipe source from STDIN, using FILE in offense
                                                reports. This is useful for editor integration.
         END
@@ -150,6 +152,25 @@ describe RuboCop::Options, :isolated_environment do
               ' :show_cops]'
         expect { options.parse %w[-vV --show-cops] }
           .to raise_error(ArgumentError, msg)
+      end
+    end
+
+    describe '--parallel' do
+      context 'combined with --cache false' do
+        it 'fails with an error message' do
+          msg = ['-P/--parallel uses caching to speed up execution, so ',
+                 'combining with --cache false is not allowed.'].join
+          expect { options.parse %w[--parallel --cache false] }
+            .to raise_error(ArgumentError, msg)
+        end
+      end
+
+      context 'combined with --auto-correct' do
+        it 'fails with an error message' do
+          msg = '-P/--parallel can not be combined with --auto-correct.'
+          expect { options.parse %w[--parallel --auto-correct] }
+            .to raise_error(ArgumentError, msg)
+        end
       end
     end
 


### PR DESCRIPTION
Another stab at an old problem.

This change tries to solve the tricky parallel execution problem by spawning off a number of processes/threads to do file inspection, sharing the work between them, without collecting any output. When all processes are finished, the original process runs the full inspection again, taking advantage of result caching.

There's not a lot of specs added for parallel execution. I've run on RuboCop's own source with `--force-default-config` to see that I get the same offenses with and without `-P`.

With MRI there seems to be a speed gain of around 3 times when running on an 8 core machine. With JRuby and Rubinius, it's about 2 times.

@bbatsov said in #3794

> I think we also have some cops that depend on the order other cops are executed

With the solution proposed here, this would not matter. Files are inspected in parallel, but cops are being run in sequence on a given file.

> and a few cops that work on all processed files that were added afterwards - I'll have to double check this.

I have looked but have not found any evidence for tricky cops like that, and I have no memory of them being added. Let's hope I'm right about that, because otherwise I don't think there's any easy way to parallelize the execution.