### PR TITLE
[Fix #4268] Handle comments when correcting Style/EmptyLinesAroundAccessModifier

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@
 * [#4241](https://github.com/bbatsov/rubocop/issues/4241): Prevent `Rails/Blank` and `Rails/Present` from breaking when there is no explicit receiver. ([@rrosenblum][])
 * [#4249](https://github.com/bbatsov/rubocop/issues/4249): Handle multiple assignment in `Rails/RelativeDateConstant`. ([@bbatsov][])
 * [#4250](https://github.com/bbatsov/rubocop/issues/4250): Improve a bit the Ruby code detection config. ([@bbatsov][])
+* [#4268](https://github.com/bbatsov/rubocop/issues/4268): Handle end-of-line comments when autocorrecting Style/EmptyLinesAroundAccessModifier. ([@vergenzt][])
 
 ## 0.48.1 (2017-04-03)
 

--- a/lib/rubocop/cop/style/empty_lines_around_access_modifier.rb
+++ b/lib/rubocop/cop/style/empty_lines_around_access_modifier.rb
@@ -23,7 +23,7 @@ module RuboCop
             send_line = node.loc.line
             previous_line = processed_source[send_line - 2]
             next_line = processed_source[send_line]
-            line = line_range(node)
+            line = range_by_whole_lines(node.source_range)
 
             unless previous_line_empty?(previous_line)
               corrector.insert_before(line, "\n")
@@ -36,11 +36,6 @@ module RuboCop
         end
 
         private
-
-        def line_range(node)
-          range_between(node.source_range.begin_pos - node.loc.column,
-                        node.source_range.end_pos)
-        end
 
         def previous_line_ignoring_comments(processed_source, send_line)
           processed_source[0..send_line - 2].reverse.find do |line|

--- a/lib/rubocop/cop/util.rb
+++ b/lib/rubocop/cop/util.rb
@@ -152,6 +152,22 @@ module RuboCop
         Parser::Source::Range.new(buffer, begin_pos, end_pos)
       end
 
+      def range_by_whole_lines(range, include_final_newline: false)
+        buffer = @processed_source.buffer
+
+        begin_pos = range.begin_pos
+        begin_offset = range.column
+        begin_of_first_line = begin_pos - begin_offset
+
+        last_line = buffer.source_line(range.last_line)
+        end_pos = range.end_pos
+        end_offset = last_line.length - range.last_column
+        end_offset += 1 if include_final_newline
+        end_of_last_line = end_pos + end_offset
+
+        Parser::Source::Range.new(buffer, begin_of_first_line, end_of_last_line)
+      end
+
       def move_pos(src, pos, step, condition, regexp)
         offset = step == -1 ? -1 : 0
         pos += step while condition && src[pos + offset] =~ regexp

--- a/spec/rubocop/cop/style/empty_lines_around_access_modifier_spec.rb
+++ b/spec/rubocop/cop/style/empty_lines_around_access_modifier_spec.rb
@@ -121,6 +121,26 @@ describe RuboCop::Cop::Style::EmptyLinesAroundAccessModifier do
       END
     end
 
+    it 'autocorrects blank line after #{access_modifier} with comment' do
+      corrected = autocorrect_source(cop, <<-END.strip_indent)
+        class Test
+          something
+
+          #{access_modifier} # let's modify the rest
+          def test; end
+        end
+      END
+      expect(corrected).to eq(<<-END.strip_indent)
+        class Test
+          something
+
+          #{access_modifier} # let's modify the rest
+
+          def test; end
+        end
+      END
+    end
+
     it 'accepts missing blank line when at the beginning of class/module' do
       inspect_source(cop, <<-END.strip_indent)
         class Test

--- a/spec/rubocop/cop/util_spec.rb
+++ b/spec/rubocop/cop/util_spec.rb
@@ -99,6 +99,107 @@ describe RuboCop::Cop::Util do
     end
   end
 
+  describe 'source indicated by #range_by_whole_lines' do
+    let(:source) { <<-END.strip_indent }
+      puts 'example'
+      puts 'another example'
+
+      something_else
+    END
+    let(:processed_source) { parse_source(source) }
+
+    # `input_source` defined in contexts
+    let(:begin_pos) { source.index(input_source) }
+    let(:end_pos) { begin_pos + input_source.length }
+    let(:input_range) do
+      Parser::Source::Range.new(processed_source.buffer, begin_pos, end_pos)
+    end
+
+    let(:include_final_newline) { false }
+    let(:output_range) do
+      obj = TestUtil.new
+      obj.instance_exec(processed_source) { |src| @processed_source = src }
+      obj.send(:range_by_whole_lines,
+               input_range,
+               include_final_newline: include_final_newline)
+    end
+    subject do
+      r = output_range
+      processed_source.buffer.source[r.begin_pos...r.end_pos]
+    end
+
+    shared_examples 'final newline behavior' do
+      context 'without include_final_newline' do
+        let(:include_final_newline) { false }
+        it { is_expected.to eq(expected) }
+      end
+
+      context 'with include_final_newline' do
+        let(:include_final_newline) { true }
+        it { is_expected.to eq(expected + "\n") }
+      end
+    end
+
+    context 'when part of a single line is selected' do
+      let(:input_source) { "'example'" }
+      let(:expected) { "puts 'example'" }
+      include_examples 'final newline behavior'
+    end
+
+    context 'with a whole line except newline selected' do
+      let(:input_source) { "puts 'example'" }
+      let(:expected) { "puts 'example'" }
+      include_examples 'final newline behavior'
+    end
+
+    context 'with a whole line plus beginning of next line' do
+      let(:input_source) { "puts 'example'\n" }
+      let(:expected) { "puts 'example'\nputs 'another example'" }
+      include_examples 'final newline behavior'
+    end
+
+    context 'with end of one line' do
+      let(:begin_pos) { 14 }
+      let(:end_pos) { 14 }
+      let(:expected) { "puts 'example'" }
+      include_examples 'final newline behavior'
+    end
+
+    context 'with beginning of one line' do
+      let(:begin_pos) { 15 }
+      let(:end_pos) { 15 }
+      let(:expected) { "puts 'another example'" }
+      include_examples 'final newline behavior'
+    end
+
+    context 'with parts of two lines' do
+      let(:input_source) { "'example'\nputs 'another" }
+      let(:expected) { "puts 'example'\nputs 'another example'" }
+      include_examples 'final newline behavior'
+    end
+
+    context 'with parts of four lines' do
+      let(:input_source) { "'example'\nputs 'another example'\n\nso" }
+      let(:expected) { source.chomp }
+      include_examples 'final newline behavior'
+    end
+
+    context "when source doesn't end with a newline" do
+      let(:source) { "example\nwith\nno\nnewline_at_end" }
+      let(:input_source) { 'line_at_e' }
+
+      context 'without include_final_newline' do
+        let(:include_final_newline) { false }
+        it { is_expected.to eq('newline_at_end') }
+      end
+
+      context 'with include_final_newline' do
+        let(:include_final_newline) { true }
+        it { is_expected.to eq('newline_at_end') }
+      end
+    end
+  end
+
   describe '#to_symbol_literal' do
     [
       ['foo', ':foo'],


### PR DESCRIPTION
Previously the autocorrect implementation inserted a newline at the end of the access modifier _node_ instead of at the end of the line. This fixes that.

Fixes #4268.

-----------------

Before submitting the PR make sure the following are checked:

* [X] Wrote [good commit messages][1].
* [X] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [X] Used the same coding conventions as the rest of the project.
* [X] Feature branch is up-to-date with `master` (if not - rebase it).
* [X] Squashed related commits together.
* [X] Added tests.
* [X] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [X] All tests are passing.
* [X] The new code doesn't generate RuboCop offenses.
* [X] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [X] Updated cop documentation with `rake generate_cops_documentation` (required only when you've added a new cop or changed the configuration/documentation of an existing cop).

[1]: http://chris.beams.io/posts/git-commit/
