### PR TITLE
Support multiple rubocop:disable comments per line

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 
 * [#4262](https://github.com/bbatsov/rubocop/pull/4262): Add new `MinSize` configuration to `Style/SymbolArray`, consistent with the same configuration in `Style/WordArray`. ([@scottmatthewman][])
 * [#4278](https://github.com/bbatsov/rubocop/pull/4278): Move all cops dealing with whitespace into a new department called `Layout`. ([@jonas054][])
+* [#4282](https://github.com/bbatsov/rubocop/pull/4282): Support multiple `# rubocop:disable <cops...>` comments per line. ([@vergenzt][])
 
 ### Bug fixes
 

--- a/lib/rubocop/comment_config.rb
+++ b/lib/rubocop/comment_config.rb
@@ -107,18 +107,14 @@ module RuboCop
       return if processed_source.comments.nil?
 
       processed_source.comments.each do |comment|
-        directive = directive_parts(comment)
-        next unless directive
-
-        yield comment, *directive
+        comment.text.scan(COMMENT_DIRECTIVE_REGEXP) do |match_captures|
+          yield comment, *directive_parts(match_captures)
+        end
       end
     end
 
-    def directive_parts(comment)
-      match = comment.text.match(COMMENT_DIRECTIVE_REGEXP)
-      return unless match
-
-      switch, cops_string = match.captures
+    def directive_parts(match_captures)
+      switch, cops_string = match_captures
 
       cop_names =
         cops_string == 'all' ? all_cop_names : cops_string.split(/,\s*/)

--- a/spec/rubocop/comment_config_spec.rb
+++ b/spec/rubocop/comment_config_spec.rb
@@ -54,7 +54,21 @@ describe RuboCop::CommentConfig do
         '[1, 2, 3, 4].map { |e| [e, e] }.flatten(1)',
         '# rubocop:enable FlatMap',
         '# rubocop:disable RSpec/Example',
-        '# rubocop:disable Custom2/Number9'                  # 48
+        '# rubocop:disable Custom2/Number9',                 # 48
+        "puts 'multiple disables' # rubocop:disable Test/Something" \
+        ' # rubocop:disable Test/SomethingElse',             # 49
+        "puts 'multiple disables'" \
+        ' # rubocop:disable Test/Thing1, Test/Thing2' \
+        ' # rubocop:disable Test/Thing3,Test/Thing4',        # 50
+        "puts 'multiple disables with comments'" \
+        ' # rubocop:disable Test/Thing1,Test/Thing2 with comment' \
+        ' # rubocop:disable Test/Thing3, Test/Thing4 another comment', # 51
+        '',
+        "puts 'disabled then enabled' # rubocop:disable Test/Cop" \
+        ' # rubocop:enable Test/Cop',                        # 53
+        '',
+        "puts 'enabled then disabled' # rubocop:enable Test/Cop" \
+        ' # rubocop:disable Test/Cop'                        # 55
       ]
     end
 
@@ -160,6 +174,29 @@ describe RuboCop::CommentConfig do
 
     it 'supports disabling cops with numbers in their name' do
       expect(disabled_lines_of_cop('Custom2/Number9')).to include(48)
+    end
+
+    it 'supports multiple disable statements in a single line' do
+      expect(disabled_lines_of_cop('Test/Something')).to include(49)
+      expect(disabled_lines_of_cop('Test/SomethingElse')).to include(49)
+      expect(disabled_lines_of_cop('Test/Thing1')).to include(50)
+      expect(disabled_lines_of_cop('Test/Thing2')).to include(50)
+      expect(disabled_lines_of_cop('Test/Thing3')).to include(50)
+      expect(disabled_lines_of_cop('Test/Thing4')).to include(50)
+    end
+
+    it 'supports multiple commented disable statements in a single line' do
+      expect(disabled_lines_of_cop('Test/Thing1')).to include(51)
+      expect(disabled_lines_of_cop('Test/Thing2')).to include(51)
+      expect(disabled_lines_of_cop('Test/Thing3')).to include(51)
+      expect(disabled_lines_of_cop('Test/Thing4')).to include(51)
+    end
+
+    context 'when a cop is enabled and disabled on the same line' do
+      it 'disables the cop' do
+        expect(disabled_lines_of_cop('Test/Cop')).to include(53)
+        expect(disabled_lines_of_cop('Test/Cop')).to include(55)
+      end
     end
   end
 end


### PR DESCRIPTION
Supporting this would make implementing #4127 much easier because the code wouldn't ever have to _add_ cops to an existing `rubocop:disable` comment--it could always simply append `# rubocop:disable <cop>`.

What do you think?

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Used the same coding conventions as the rest of the project.
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] All tests are passing.
* [x] The new code doesn't generate RuboCop offenses.
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Updated cop documentation with `rake generate_cops_documentation` (required only when you've added a new cop or changed the configuration/documentation of an existing cop).

[1]: http://chris.beams.io/posts/git-commit/
