### PR TITLE
add a message about the Style/DeprecatedHashMethods renaming

### DIFF
--- a/lib/rubocop/config.rb
+++ b/lib/rubocop/config.rb
@@ -49,7 +49,10 @@ module RuboCop
         'The `Style/MethodCallParentheses` cop has been renamed to ' \
           '`Style/MethodCallWithoutArgsParentheses`.',
       'Lint/Eval' =>
-        'The `Lint/Eval` cop has been renamed to `Security/Eval`.'
+        'The `Lint/Eval` cop has been renamed to `Security/Eval`.',
+      'Style/DeprecatedHashMethods' =>
+        'The `Style/DeprecatedHashMethods` cop has been renamed to ' \
+          '`Style/PreferredHashMethods`.'
     }.freeze
 
     OBSOLETE_PARAMETERS = [


### PR DESCRIPTION
There was previously no message about the renaming of
Style/DeprecatedHashMethods to Style/PreferredHashMethods, just a
message that the cop didn't exist anymore, so I had to google to find
out the new name.

I added an entry to the OBSOLETE_COPS hash so that a message telling you
the new name is shown.

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Used the same coding conventions as the rest of the project.
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] All tests are passing.
* [x] The new code doesn't generate RuboCop offenses.
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Updated cop documentation with `rake generate_cops_documentation` (required only when you've added a new cop or changed the configuration/documentation of an existing cop).

[1]: http://chris.beams.io/posts/git-commit/
