### PR TITLE
[Fix #4275] Prevent `Style/MethodCallWithArgsParentheses` from blowing up on `yield`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@
 * [#4249](https://github.com/bbatsov/rubocop/issues/4249): Handle multiple assignment in `Rails/RelativeDateConstant`. ([@bbatsov][])
 * [#4250](https://github.com/bbatsov/rubocop/issues/4250): Improve a bit the Ruby code detection config. ([@bbatsov][])
 * [#4268](https://github.com/bbatsov/rubocop/issues/4268): Handle end-of-line comments when autocorrecting Style/EmptyLinesAroundAccessModifier. ([@vergenzt][])
+* [#4275](https://github.com/bbatsov/rubocop/issues/4275): Prevent `Style/MethodCallWithArgsParentheses` from blowing up on `yield`. ([@drenmi][])
 
 ## 0.48.1 (2017-04-03)
 

--- a/lib/rubocop/cop/style/method_call_with_args_parentheses.rb
+++ b/lib/rubocop/cop/style/method_call_with_args_parentheses.rb
@@ -93,7 +93,8 @@ module RuboCop
 
         def args_begin(node)
           loc = node.loc
-          selector = node.super_type? ? loc.keyword : loc.selector
+          selector =
+            node.super_type? || node.yield_type? ? loc.keyword : loc.selector
           selector.end.resize(1)
         end
 

--- a/spec/rubocop/cop/style/method_call_with_args_parentheses_spec.rb
+++ b/spec/rubocop/cop/style/method_call_with_args_parentheses_spec.rb
@@ -81,6 +81,11 @@ describe RuboCop::Cop::Style::MethodCallWithArgsParentheses, :config do
     expect(new_source).to eq('super(a)')
   end
 
+  it 'auto-corrects superclass call by adding needed braces' do
+    new_source = autocorrect_source(cop, 'yield a')
+    expect(new_source).to eq('yield(a)')
+  end
+
   it 'ignores method listed in IgnoredMethods' do
     inspect_source(cop, 'puts :test')
     expect(cop.offenses).to be_empty


### PR DESCRIPTION
When attempting to auto-correct a `yield` with arguments, this cop would blow up. This change fixes that.

-----------------

Before submitting the PR make sure the following are checked:

* [X] Wrote [good commit messages][1].
* [X] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [X] Used the same coding conventions as the rest of the project.
* [X] Feature branch is up-to-date with `master` (if not - rebase it).
* [X] Squashed related commits together.
* [X] Added tests.
* [X] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [X] All tests are passing.
* [X] The new code doesn't generate RuboCop offenses.
* [X] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [ ] Updated cop documentation with `rake generate_cops_documentation` (required only when you've added a new cop or changed the configuration/documentation of an existing cop).

[1]: http://chris.beams.io/posts/git-commit/
