### PR TITLE
Added some missing examples in Layout cops documentation

### DIFF
--- a/lib/rubocop/cop/layout/access_modifier_indentation.rb
+++ b/lib/rubocop/cop/layout/access_modifier_indentation.rb
@@ -5,6 +5,35 @@ module RuboCop
     module Layout
       # Modifiers should be indented as deep as method definitions, or as deep
       # as the class/module keyword, depending on configuration.
+      #
+      # @example
+      #   # EnforcedStyle: indent (default)
+      #
+      #   # bad
+      #   class Plumbus
+      #   private
+      #     def smooth; end
+      #   end
+      #
+      #   # good
+      #   class Plumbus
+      #     private
+      #     def smooth; end
+      #   end
+      #
+      #   # EnforcedStyle: outdent
+      #
+      #   # bad
+      #   class Plumbus
+      #     private
+      #     def smooth; end
+      #   end
+      #
+      #   # good
+      #   class Plumbus
+      #   private
+      #     def smooth; end
+      #   end
       class AccessModifierIndentation < Cop
         include AutocorrectAlignment
         include ConfigurableEnforcedStyle

--- a/lib/rubocop/cop/layout/align_array.rb
+++ b/lib/rubocop/cop/layout/align_array.rb
@@ -5,6 +5,21 @@ module RuboCop
     module Layout
       # Here we check if the elements of a multi-line array literal are
       # aligned.
+      #
+      # @example
+      #   # bad
+      #   a = [1, 2, 3
+      #     4, 5, 6]
+      #   array = ['run',
+      #        'forrest',
+      #        'run']
+      #
+      #   # good
+      #   a = [1, 2, 3
+      #        4, 5, 6]
+      #   a = ['run',
+      #        'forrest',
+      #        'run']
       class AlignArray < Cop
         include AutocorrectAlignment
 

--- a/lib/rubocop/cop/layout/case_indentation.rb
+++ b/lib/rubocop/cop/layout/case_indentation.rb
@@ -7,6 +7,69 @@ module RuboCop
       # are indented in relation to its *case* or *end* keyword.
       #
       # It will register a separate offense for each misaligned *when*.
+      #
+      # @example
+      #   # If Layout/EndAlignment is set to keyword style (default)
+      #   # *case* and *end* should always be aligned to same depth,
+      #   # and therefore *when* should always be aligned to both -
+      #   # regardless of configuration.
+      #
+      #   # bad for all styles
+      #   case n
+      #     when 0
+      #       x * 2
+      #     else
+      #       y / 3
+      #   end
+      #
+      #   # good for all styles
+      #   case n
+      #   when 0
+      #     x * 2
+      #   else
+      #     y / 3
+      #   end
+      #
+      # @example
+      #   # if EndAlignment is set to other style such as
+      #   # start_of_line (as shown below), then *when* alignment
+      #   # configuration does have an effect.
+      #
+      #   # EnforcedStyle: case (default)
+      #
+      #   # bad
+      #   a = case n
+      #   when 0
+      #     x * 2
+      #   else
+      #     y / 3
+      #   end
+      #
+      #   # good
+      #   a = case n
+      #       when 0
+      #         x * 2
+      #       else
+      #         y / 3
+      #   end
+      #
+      #   # EnforcedStyle: end
+      #
+      #   # bad
+      #   a = case n
+      #       when 0
+      #         x * 2
+      #       else
+      #         y / 3
+      #   end
+      #
+      #   # good
+      #   a = case n
+      #   when 0
+      #     x * 2
+      #   else
+      #     y / 3
+      #   end
       class CaseIndentation < Cop
         include AutocorrectAlignment
         include ConfigurableEnforcedStyle

--- a/manual/cops_layout.md
+++ b/manual/cops_layout.md
@@ -9,6 +9,38 @@ Enabled | Yes
 Modifiers should be indented as deep as method definitions, or as deep
 as the class/module keyword, depending on configuration.
 
+### Example
+
+```ruby
+# EnforcedStyle: indent (default)
+
+# bad
+class Plumbus
+private
+  def smooth; end
+end
+
+# good
+class Plumbus
+  private
+  def smooth; end
+end
+
+# EnforcedStyle: outdent
+
+# bad
+class Plumbus
+  private
+  def smooth; end
+end
+
+# good
+class Plumbus
+private
+  def smooth; end
+end
+```
+
 ### Important attributes
 
 Attribute | Value
@@ -29,6 +61,24 @@ Enabled | Yes
 
 Here we check if the elements of a multi-line array literal are
 aligned.
+
+### Example
+
+```ruby
+# bad
+a = [1, 2, 3
+  4, 5, 6]
+array = ['run',
+     'forrest',
+     'run']
+
+# good
+a = [1, 2, 3
+     4, 5, 6]
+a = ['run',
+     'forrest',
+     'run']
+```
 
 ### References
 
@@ -237,6 +287,72 @@ This cop checks how the *when*s of a *case* expression
 are indented in relation to its *case* or *end* keyword.
 
 It will register a separate offense for each misaligned *when*.
+
+### Example
+
+```ruby
+# If Layout/EndAlignment is set to keyword style (default)
+# *case* and *end* should always be aligned to same depth,
+# and therefore *when* should always be aligned to both -
+# regardless of configuration.
+
+# bad for all styles
+case n
+  when 0
+    x * 2
+  else
+    y / 3
+end
+
+# good for all styles
+case n
+when 0
+  x * 2
+else
+  y / 3
+end
+```
+```ruby
+# if EndAlignment is set to other style such as
+# start_of_line (as shown below), then *when* alignment
+# configuration does have an effect.
+
+# EnforcedStyle: case (default)
+
+# bad
+a = case n
+when 0
+  x * 2
+else
+  y / 3
+end
+
+# good
+a = case n
+    when 0
+      x * 2
+    else
+      y / 3
+end
+
+# EnforcedStyle: end
+
+# bad
+a = case n
+    when 0
+      x * 2
+    else
+      y / 3
+end
+
+# good
+a = case n
+when 0
+  x * 2
+else
+  y / 3
+end
+```
 
 ### Important attributes
 


### PR DESCRIPTION
Hi.
This is my first pull request.
A few cops were missing examples in their documentation. This commit adds the
missing examples for some `Style` cops. Additionally, it attempts to be consistent
with the formatting in the documentation.

See also: #3808

After running `rake generate_cops_documentation`, it seems like some unrelated changes were added to the markdown file, can you help me fix this? (if needed)
Also, some tests didn't pass when running `rake spec`:


Finished in 1 minute 15.16 seconds (files took 13.11 seconds to load)
15848 examples, 2 failures, 4 pending

Failed examples:

rspec ./spec/rubocop/cop/style/string_literals_spec.rb:172 # RuboCop::Cop::Style::StringLiterals configured with single quotes preferred autocorrects words with non-ascii chars
rspec ./spec/rubocop/cli/cli_options_spec.rb:129 # RuboCop::CLI --only when one cop is given accepts cop names from plugins


-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Used the same coding conventions as the rest of the project.
* [ ] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [ ] Added tests.
* [x] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [ ] All tests are passing.
* [x] The new code doesn't generate RuboCop offenses.
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Updated cop documentation with `rake generate_cops_documentation` (required only when you've added a new cop or changed the configuration/documentation of an existing cop).

[1]: http://chris.beams.io/posts/git-commit/
