### PR TITLE
Add .ruby-version and vendor/bundle to the gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,6 +23,12 @@ pkg
 # etags
 TAGS
 
+# Ruby version management file
+.ruby-version
+
+# Common gem install location
+vendor/bundle
+
 # Have editor/IDE/OS specific files you need to ignore? Consider using a global gitignore:
 #
 # * Create a file at ~/.gitignore


### PR DESCRIPTION
Not sure what others think of this. I like having these in the gitignore so that they won't show up in `git status`. It also helps when using [ag](https://github.com/ggreer/the_silver_searcher) because ag ignores whatever is in your gitignore.