### PR TITLE
[Fix #3969] Multiline method call alignment for arguments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@
 * [#4250](https://github.com/bbatsov/rubocop/issues/4250): Improve a bit the Ruby code detection config. ([@bbatsov][])
 * [#4268](https://github.com/bbatsov/rubocop/issues/4268): Handle end-of-line comments when autocorrecting Style/EmptyLinesAroundAccessModifier. ([@vergenzt][])
 * [#4275](https://github.com/bbatsov/rubocop/issues/4275): Prevent `Style/MethodCallWithArgsParentheses` from blowing up on `yield`. ([@drenmi][])
+* [#3969](https://github.com/bbatsov/rubocop/issues/3969): Handle multiline method call alignment for arguments to methods. ([@jonas054][])
 
 ## 0.48.1 (2017-04-03)
 

--- a/lib/rubocop/cop/layout/multiline_method_call_indentation.rb
+++ b/lib/rubocop/cop/layout/multiline_method_call_indentation.rb
@@ -188,7 +188,7 @@ module RuboCop
         end
 
         def semantic_alignment_node(node)
-          return if argument_in_method_call(node)
+          return if argument_in_method_call(node, :with_parentheses)
 
           # descend to root of method chain
           node = node.receiver while node.receiver

--- a/lib/rubocop/cop/layout/multiline_operation_indentation.rb
+++ b/lib/rubocop/cop/layout/multiline_operation_indentation.rb
@@ -67,9 +67,10 @@ module RuboCop
             return true if begins_its_line?(assignment_rhs.source_range)
           end
 
-          given_style == :aligned && (kw_node_with_special_indentation(node) ||
-                                      assignment_node ||
-                                      argument_in_method_call(node))
+          given_style == :aligned &&
+            (kw_node_with_special_indentation(node) ||
+             assignment_node ||
+             argument_in_method_call(node, :with_or_without_parentheses))
         end
 
         def message(node, lhs, rhs)

--- a/lib/rubocop/cop/mixin/multiline_expression_indentation.rb
+++ b/lib/rubocop/cop/mixin/multiline_expression_indentation.rb
@@ -105,7 +105,7 @@ module RuboCop
         end
       end
 
-      def argument_in_method_call(node)
+      def argument_in_method_call(node, kind)
         node.each_ancestor(:send, :block).find do |a|
           # If the node is inside a block, it makes no difference if that block
           # is an argument in a method call. It doesn't count.
@@ -113,7 +113,11 @@ module RuboCop
 
           next if a.setter_method?
 
-          a.arguments.any? { |arg| within_node?(node, arg) }
+          a.arguments.any? do |arg|
+            within_node?(node, arg) && (kind == :with_or_without_parentheses ||
+                                        kind == :with_parentheses &&
+                                        parentheses?(node.parent))
+          end
         end
       end
 

--- a/spec/rubocop/cop/layout/multiline_method_call_indentation_spec.rb
+++ b/spec/rubocop/cop/layout/multiline_method_call_indentation_spec.rb
@@ -220,6 +220,21 @@ describe RuboCop::Cop::Layout::MultilineMethodCallIndentation do
         expect(cop.offenses).to be_empty
       end
 
+      it 'accepts method being aligned with method that is an argument' do
+        inspect_source(cop,
+                       ['authorize scope.includes(:user)',
+                        '               .order(:name)'])
+        expect(cop.offenses).to be_empty
+      end
+
+      it 'accepts method being aligned with method that is an argument in ' \
+         'assignment' do
+        inspect_source(cop,
+                       ['user = authorize scope.includes(:user)',
+                        '                      .order(:name)'])
+        expect(cop.offenses).to be_empty
+      end
+
       it 'accepts method being aligned with method in assignment' do
         inspect_source(cop, <<-END.strip_indent)
           age = User.all.first
@@ -404,17 +419,6 @@ describe RuboCop::Cop::Layout::MultilineMethodCallIndentation do
       expect(cop.messages).to eq(['Align `b` with `a.` on line 1.'])
       expect(cop.highlights).to eq(['b'])
       expect(cop.config_to_allow_offenses).to eq('Enabled' => false)
-    end
-
-    it 'falls back to indentation in complicated cases' do
-      inspect_source(cop, <<-END.strip_indent)
-        expect(RuboCop::ConfigLoader).to receive(:file).once
-            .with('dir')
-      END
-      expect(cop.messages)
-        .to eq(['Use 2 (not 4) spaces for indenting an expression spanning ' \
-                'multiple lines.'])
-      expect(cop.highlights).to eq(['.with'])
     end
 
     it 'does not check binary operations when string wrapped with backslash' do

--- a/spec/rubocop/result_cache_spec.rb
+++ b/spec/rubocop/result_cache_spec.rb
@@ -30,7 +30,7 @@ describe RuboCop::ResultCache, :isolated_environment do
       x = 1
     END
     allow(config_store).to receive(:for).with('example.rb')
-      .and_return(RuboCop::Config.new)
+                                        .and_return(RuboCop::Config.new)
   end
 
   describe 'cached result that was saved with no command line option' do

--- a/tasks/cops_documentation.rake
+++ b/tasks/cops_documentation.rake
@@ -54,7 +54,7 @@ task generate_cops_documentation: :yard do
   def code_example(ruby_code)
     content = "```ruby\n".dup
     content << ruby_code.text.gsub('@good', '# good')
-               .gsub('@bad', '# bad').strip
+                        .gsub('@bad', '# bad').strip
     content << "\n```\n"
     content
   end


### PR DESCRIPTION
Handle the case when a multiline method call is itself an argument in another method call with no parentheses around the argument list.

For multiline *operations* we don't want this special handling, so we make it behave as it currently does.