### PR TITLE
Fix generate_cops_documentation warnings

### DIFF
--- a/lib/rubocop/cop/message_annotator.rb
+++ b/lib/rubocop/cop/message_annotator.rb
@@ -28,14 +28,14 @@ module RuboCop
       # @option cop_config [String] :Reference Full reference URL
       # @option cop_config [String] :Details
       #
-      # @param [Hash, nil] optional options
-      # @option option [Boolean] :display_style_guide
+      # @param [Hash, nil] options optional
+      # @option options [Boolean] :display_style_guide
       #   Include style guide and reference URLs
-      # @option option [Boolean] :extra_details
+      # @option options [Boolean] :extra_details
       #   Include cop specific details
-      # @option option [Boolean] :debug
+      # @option options [Boolean] :debug
       #   Include debug output
-      # @option option [Boolean] :display_cop_names
+      # @option options [Boolean] :display_cop_names
       #   Include cop name
       def initialize(config, cop_config, options)
         @config = config

--- a/lib/rubocop/cop/style/copyright.rb
+++ b/lib/rubocop/cop/style/copyright.rb
@@ -8,8 +8,8 @@ module RuboCop
       # The default regexp for an acceptable copyright notice can be found in
       # config/default.yml.  The default can be changed as follows:
       #
-      # Style/Copyright:
-      #   Notice: '^Copyright (\(c\) )?2\d{3} Acme Inc'
+      #     Style/Copyright:
+      #       Notice: '^Copyright (\(c\) )?2\d{3} Acme Inc'
       #
       # This regex string is treated as an unanchored regex.  For each file
       # that RuboCop scans, a comment that matches this regex must be found or

--- a/lib/rubocop/cop/style/hash_syntax.rb
+++ b/lib/rubocop/cop/style/hash_syntax.rb
@@ -12,7 +12,7 @@ module RuboCop
       #
       # The supported styles are:
       #
-      # * ruby19 - forces use of the 1.9 syntax (e.g. {a: 1}) when hashes have
+      # * ruby19 - forces use of the 1.9 syntax (e.g. `{a: 1}`) when hashes have
       #   all symbols for keys
       # * hash_rockets - forces use of hash rockets for all hashes
       # * no_mixed_keys - simply checks for hashes with mixed syntaxes

--- a/lib/rubocop/node_pattern.rb
+++ b/lib/rubocop/node_pattern.rb
@@ -23,55 +23,55 @@ module RuboCop
   #
   # ## Pattern string format examples
   #
-  #    ':sym'              # matches a literal symbol
-  #    '1'                 # matches a literal integer
-  #    'nil'               # matches a literal nil
-  #    'send'              # matches (send ...)
-  #    '(send)'            # matches (send)
-  #    '(send ...)'        # matches (send ...)
-  #    '(op-asgn)'         # node types with hyphenated names also work
-  #    '{send class}'      # matches (send ...) or (class ...)
-  #    '({send class})'    # matches (send) or (class)
-  #    '(send const)'      # matches (send (const ...))
-  #    '(send _ :new)'     # matches (send <anything> :new)
-  #    '(send $_ :new)'    # as above, but whatever matches the $_ is captured
-  #    '(send $_ $_)'      # you can use as many captures as you want
-  #    '(send !const ...)' # ! negates the next part of the pattern
-  #    '$(send const ...)' # arbitrary matching can be performed on a capture
-  #    '(send _recv _msg)' # wildcards can be named (for readability)
-  #    '(send ... :new)'   # you can specifically match against the last child
-  #                        # (this only works for the very last)
-  #    '(send $...)'       # capture all the children as an array
-  #    '(send $... int)'   # capture all children but the last as an array
-  #    '(send _x :+ _x)'   # unification is performed on named wildcards
-  #                        # (like Prolog variables...)
-  #                        # (#== is used to see if values unify)
-  #    '(int odd?)'        # words which end with a ? are predicate methods,
-  #                        # are are called on the target to see if it matches
-  #                        # any Ruby method which the matched object supports
-  #                        # can be used
-  #                        # if a truthy value is returned, the match succeeds
-  #    '(int [!1 !2])'     # [] contains multiple patterns, ALL of which must
-  #                        # match in that position
-  #                        # in other words, while {} is pattern union (logical
-  #                        # OR), [] is intersection (logical AND)
-  #    '(send %1 _)'       # % stands for a parameter which must be supplied to
-  #                        # #match at matching time
-  #                        # it will be compared to the corresponding value in
-  #                        # the AST using #==
-  #                        # a bare '%' is the same as '%1'
-  #                        # the number of extra parameters passed to #match
-  #                        # must equal the highest % value in the pattern
-  #                        # for consistency, %0 is the 'root node' which is
-  #                        # passed as the 1st argument to #match, where the
-  #                        # matching process starts
-  #    '^^send'            # each ^ ascends one level in the AST
-  #                        # so this matches against the grandparent node
-  #    '#method'           # we call this a 'funcall'; it calls a method in the
-  #                        # context where a pattern-matching method is defined
-  #                        # if that returns a truthy value, the match succeeds
-  #    'equal?(%1)'        # predicates can be given 1 or more extra args
-  #    '#method(%0, 1)'    # funcalls can also be given 1 or more extra args
+  #     ':sym'              # matches a literal symbol
+  #     '1'                 # matches a literal integer
+  #     'nil'               # matches a literal nil
+  #     'send'              # matches (send ...)
+  #     '(send)'            # matches (send)
+  #     '(send ...)'        # matches (send ...)
+  #     '(op-asgn)'         # node types with hyphenated names also work
+  #     '{send class}'      # matches (send ...) or (class ...)
+  #     '({send class})'    # matches (send) or (class)
+  #     '(send const)'      # matches (send (const ...))
+  #     '(send _ :new)'     # matches (send <anything> :new)
+  #     '(send $_ :new)'    # as above, but whatever matches the $_ is captured
+  #     '(send $_ $_)'      # you can use as many captures as you want
+  #     '(send !const ...)' # ! negates the next part of the pattern
+  #     '$(send const ...)' # arbitrary matching can be performed on a capture
+  #     '(send _recv _msg)' # wildcards can be named (for readability)
+  #     '(send ... :new)'   # you can specifically match against the last child
+  #                         # (this only works for the very last)
+  #     '(send $...)'       # capture all the children as an array
+  #     '(send $... int)'   # capture all children but the last as an array
+  #     '(send _x :+ _x)'   # unification is performed on named wildcards
+  #                         # (like Prolog variables...)
+  #                         # (#== is used to see if values unify)
+  #     '(int odd?)'        # words which end with a ? are predicate methods,
+  #                         # are are called on the target to see if it matches
+  #                         # any Ruby method which the matched object supports
+  #                         # can be used
+  #                         # if a truthy value is returned, the match succeeds
+  #     '(int [!1 !2])'     # [] contains multiple patterns, ALL of which must
+  #                         # match in that position
+  #                         # in other words, while {} is pattern union (logical
+  #                         # OR), [] is intersection (logical AND)
+  #     '(send %1 _)'       # % stands for a parameter which must be supplied to
+  #                         # #match at matching time
+  #                         # it will be compared to the corresponding value in
+  #                         # the AST using #==
+  #                         # a bare '%' is the same as '%1'
+  #                         # the number of extra parameters passed to #match
+  #                         # must equal the highest % value in the pattern
+  #                         # for consistency, %0 is the 'root node' which is
+  #                         # passed as the 1st argument to #match, where the
+  #                         # matching process starts
+  #     '^^send'            # each ^ ascends one level in the AST
+  #                         # so this matches against the grandparent node
+  #     '#method'           # we call this a 'funcall'; it calls a method in the
+  #                         # context where a pattern-matching method is defined
+  #                         # if that returns a truthy value, the match succeeds
+  #     'equal?(%1)'        # predicates can be given 1 or more extra args
+  #     '#method(%0, 1)'    # funcalls can also be given 1 or more extra args
   #
   # You can nest arbitrarily deep:
   #

--- a/manual/cops_style.md
+++ b/manual/cops_style.md
@@ -629,8 +629,8 @@ Check that a copyright notice was given in each source file.
 The default regexp for an acceptable copyright notice can be found in
 config/default.yml.  The default can be changed as follows:
 
-Style/Copyright:
-  Notice: '^Copyright (\(c\) )?2\d{3} Acme Inc'
+    Style/Copyright:
+      Notice: '^Copyright (\(c\) )?2\d{3} Acme Inc'
 
 This regex string is treated as an unanchored regex.  For each file
 that RuboCop scans, a comment that matches this regex must be found or
@@ -1269,7 +1269,7 @@ A separate offense is registered for each problematic pair.
 
 The supported styles are:
 
-* ruby19 - forces use of the 1.9 syntax (e.g. {a: 1}) when hashes have
+* ruby19 - forces use of the 1.9 syntax (e.g. `{a: 1}`) when hashes have
   all symbols for keys
 * hash_rockets - forces use of hash rockets for all hashes
 * no_mixed_keys - simply checks for hashes with mixed syntaxes


### PR DESCRIPTION
When I execute `bundle exec rake generate_cops_documentation`, the following warnings are shown.

```
[warn]: @param tag has unknown parameter name: optional
    in file `lib/rubocop/cop/message_annotator.rb' near line 40
[warn]: In file `lib/rubocop/node_pattern.rb':37: Cannot resolve link to send from text:
        ...{sendclass}...
[warn]: In file `lib/rubocop/node_pattern.rb':37: Cannot resolve link to send from text:
        ...{sendclass}...
[warn]: In file `lib/rubocop/cop/style/copyright.rb':12: Cannot resolve link to 3 from text:
        ...{3}...
[warn]: In file `lib/rubocop/cop/style/hash_syntax.rb':16: Cannot resolve link to a: from text:
        ...{a: 1}...
```

I fixed the warnings.
And I also improved documents as follows.

![message_annotator](https://cloud.githubusercontent.com/assets/3458295/25306919/a5d5a074-27d2-11e7-82b7-4a6ff29b2447.png)

![style_hash_syntax](https://cloud.githubusercontent.com/assets/3458295/25306923/b5111bd6-27d2-11e7-91f7-8585ab794f67.png)

![style_copy_right](https://cloud.githubusercontent.com/assets/3458295/25306925/ba7ace5a-27d2-11e7-859c-5fa75a784c78.png)

![note_pattern](https://cloud.githubusercontent.com/assets/3458295/25306928/c0e029f2-27d2-11e7-84ed-d423ad804ff8.png)

![mkdocs_style_copy_right](https://cloud.githubusercontent.com/assets/3458295/25306940/fe40655a-27d2-11e7-884e-6786752fba18.png)

![mkdocs_style_hash_syntax](https://cloud.githubusercontent.com/assets/3458295/25306941/037bbd76-27d3-11e7-8e22-e931be7d531c.png)


-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [-] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Used the same coding conventions as the rest of the project.
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [-] Added tests.
* [-] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] All tests are passing.
* [x] The new code doesn't generate RuboCop offenses.
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Updated cop documentation with `rake generate_cops_documentation` (required only when you've added a new cop or changed the configuration/documentation of an existing cop).

[1]: http://chris.beams.io/posts/git-commit/
