### PR TITLE
[Fix #4283] `Style/EmptyCaseCondition` autocorrect bugfix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@
 * [#4241](https://github.com/bbatsov/rubocop/issues/4241): Prevent `Rails/Blank` and `Rails/Present` from breaking when there is no explicit receiver. ([@rrosenblum][])
 * [#4249](https://github.com/bbatsov/rubocop/issues/4249): Handle multiple assignment in `Rails/RelativeDateConstant`. ([@bbatsov][])
 * [#4250](https://github.com/bbatsov/rubocop/issues/4250): Improve a bit the Ruby code detection config. ([@bbatsov][])
+* [#4283](https://github.com/bbatsov/rubocop/issues/4283): Fix `Style/EmptyCaseCondition` autocorrect bug - when first `when` branch includes comma-delimited alternatives. ([@ilansh][])
 * [#4268](https://github.com/bbatsov/rubocop/issues/4268): Handle end-of-line comments when autocorrecting Style/EmptyLinesAroundAccessModifier. ([@vergenzt][])
 * [#4275](https://github.com/bbatsov/rubocop/issues/4275): Prevent `Style/MethodCallWithArgsParentheses` from blowing up on `yield`. ([@drenmi][])
 * [#3969](https://github.com/bbatsov/rubocop/issues/3969): Handle multiline method call alignment for arguments to methods. ([@jonas054][])
@@ -2755,3 +2756,4 @@
 [@sadovnik]: https://github.com/sadovnik
 [@cjlarose]: https://github.com/cjlarose
 [@alpaca-tc]: https://github.com/alpaca-tc
+[@ilansh]: https://github.com/ilansh

--- a/lib/rubocop/cop/style/empty_case_condition.rb
+++ b/lib/rubocop/cop/style/empty_case_condition.rb
@@ -57,11 +57,11 @@ module RuboCop
         end
 
         def correct_case_when(corrector, case_node, when_nodes)
-          case_range = case_node.loc.keyword.join(when_nodes.shift.loc.keyword)
+          case_range = case_node.loc.keyword.join(when_nodes.first.loc.keyword)
 
           corrector.replace(case_range, 'if')
 
-          when_nodes.each do |when_node|
+          when_nodes[1..-1].each do |when_node|
             corrector.replace(when_node.loc.keyword, 'elsif')
           end
         end

--- a/spec/rubocop/cop/style/empty_case_condition_spec.rb
+++ b/spec/rubocop/cop/style/empty_case_condition_spec.rb
@@ -167,5 +167,29 @@ describe RuboCop::Cop::Style::EmptyCaseCondition do
 
       it_behaves_like 'detect/correct empty case, accept non-empty case'
     end
+
+    context 'with first when branch including comma-delimited alternatives' do
+      let(:source) do
+        <<-END.strip_indent
+          case
+          when my.foo?, my.bar?
+            something
+          when my.baz?
+            something_else
+          end
+        END
+      end
+      let(:corrected_source) do
+        <<-END.strip_indent
+          if my.foo? || my.bar?
+            something
+          elsif my.baz?
+            something_else
+          end
+        END
+      end
+
+      it_behaves_like 'detect/correct empty case, accept non-empty case'
+    end
   end
 end


### PR DESCRIPTION
When first `when` condition of an empty case included comma-delimited
alternatives, autocorrect did not replace the comma with `||`.
This commit fixes the issue.

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Used the same coding conventions as the rest of the project.
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] All tests are passing.
* [x] The new code doesn't generate RuboCop offenses.
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [ ] Updated cop documentation with `rake generate_cops_documentation` (required only when you've added a new cop or changed the configuration/documentation of an existing cop).

[1]: http://chris.beams.io/posts/git-commit/
