### PR TITLE
Allow enabling departments when DisabledByDefault is true

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@
 * [#4268](https://github.com/bbatsov/rubocop/issues/4268): Handle end-of-line comments when autocorrecting Style/EmptyLinesAroundAccessModifier. ([@vergenzt][])
 * [#4275](https://github.com/bbatsov/rubocop/issues/4275): Prevent `Style/MethodCallWithArgsParentheses` from blowing up on `yield`. ([@drenmi][])
 * [#3969](https://github.com/bbatsov/rubocop/issues/3969): Handle multiline method call alignment for arguments to methods. ([@jonas054][])
+* [#4304](https://github.com/bbatsov/rubocop/pull/4304): Allow enabling whole departments when `DisabledByDefault` is `true`. ([@jonas054][])
 
 ## 0.48.1 (2017-04-03)
 

--- a/spec/rubocop/config_loader_spec.rb
+++ b/spec/rubocop/config_loader_spec.rb
@@ -539,6 +539,32 @@ describe RuboCop::ConfigLoader do
           cop_class = RuboCop::Cop::Layout::TrailingWhitespace
           expect(cop_enabled?(cop_class)).to be false
         end
+
+        context 'and a department is enabled' do
+          let(:config) do
+            <<-END.strip_indent
+              AllCops:
+                DisabledByDefault: true
+              Style:
+                Enabled: true
+            END
+          end
+
+          it 'enables cops in that department' do
+            cop_class = RuboCop::Cop::Style::Alias
+            expect(cop_enabled?(cop_class)).to be true
+          end
+
+          it 'disables cops in other departments' do
+            cop_class = RuboCop::Cop::Layout::AlignHash
+            expect(cop_enabled?(cop_class)).to be false
+          end
+
+          it 'keeps cops that are disabled in default configuration disabled' do
+            cop_class = RuboCop::Cop::Style::AutoResourceCleanup
+            expect(cop_enabled?(cop_class)).to be false
+          end
+        end
       end
 
       context 'when EnabledByDefault is true' do


### PR DESCRIPTION
When `DisabledByDefault` is `true`, only cops explicitly enabled in user configuration are run. This should work for departments too.