### PR TITLE
Fix typo in Style/IdenticalConditionalBranches documentation

### DIFF
--- a/lib/rubocop/cop/style/identical_conditional_branches.rb
+++ b/lib/rubocop/cop/style/identical_conditional_branches.rb
@@ -42,7 +42,7 @@ module RuboCop
       #   end
       #
       #   @bad
-      #   switch foo
+      #   case foo
       #   when 1
       #     do_x
       #   when 2
@@ -52,7 +52,7 @@ module RuboCop
       #   end
       #
       #   @good
-      #   switch foo
+      #   case foo
       #   when 1
       #     do_x
       #     do_y

--- a/manual/cops_style.md
+++ b/manual/cops_style.md
@@ -1383,7 +1383,7 @@ else
 end
 
 # bad
-switch foo
+case foo
 when 1
   do_x
 when 2
@@ -1393,7 +1393,7 @@ else
 end
 
 # good
-switch foo
+case foo
 when 1
   do_x
   do_y


### PR DESCRIPTION
I found and fixed a small typo in Style/IdenticalConditionalBranches documentation.

Also modified `manual/cops_style.md` by running `rake  generate_cops_documentation`.

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Used the same coding conventions as the rest of the project.
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together
* [ ] Added tests.
* Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] All tests are passing.
* [x] The new code doesn't generate RuboCop offenses.
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Updated cop documentation with `rake generate_cops_documentation` (required only when you've added a new cop or changed the configuration/documentation of an existing cop).

[1]: http://chris.beams.io/posts/git-commit/
