### PR TITLE
Treat files containing invalid byte sequences as non-matches

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@
 * [#3969](https://github.com/bbatsov/rubocop/issues/3969): Handle multiline method call alignment for arguments to methods. ([@jonas054][])
 * [#4304](https://github.com/bbatsov/rubocop/pull/4304): Allow enabling whole departments when `DisabledByDefault` is `true`. ([@jonas054][])
 * [#4264](https://github.com/bbatsov/rubocop/issues/4264): Prevent `Rails/SaveBang` from blowing up when using the assigned variable in a hash. ([@drenmi][])
+* [#4310](https://github.com/bbatsov/rubocop/pull/4310): Treat paths containing invalid byte sequences as non-matches. ([@mclark][])
 
 ## 0.48.1 (2017-04-03)
 
@@ -2759,3 +2760,4 @@
 [@cjlarose]: https://github.com/cjlarose
 [@alpaca-tc]: https://github.com/alpaca-tc
 [@ilansh]: https://github.com/ilansh
+[@mclark]: https://github.com/mclark

--- a/lib/rubocop/path_util.rb
+++ b/lib/rubocop/path_util.rb
@@ -19,7 +19,12 @@ module RuboCop
       when String
         File.fnmatch?(pattern, path, File::FNM_PATHNAME)
       when Regexp
-        path =~ pattern
+        begin
+          path =~ pattern
+        rescue ArgumentError => e
+          return false if e.message.start_with?('invalid byte sequence')
+          raise e
+        end
       end
     end
 

--- a/spec/rubocop/path_util_spec.rb
+++ b/spec/rubocop/path_util_spec.rb
@@ -80,5 +80,9 @@ describe RuboCop::PathUtil do
       expect(described_class.match_path?(/^d.*e$/, 'dir/file')).to be_truthy
       expect(described_class.match_path?(/^d.*e$/, 'dir/filez')).to be_falsey
     end
+
+    it 'does not match invalid UTF-8 paths' do
+      expect(described_class.match_path?(/^d.*$/, "dir/file\xBF")).to be_falsey
+    end
   end
 end


### PR DESCRIPTION
If a file path contains a non-UTF8 character and we are matching
against a regular expression, an ArgumentError is thrown,
failing the entire operation. Since it is not even a valid byte
sequence for the encoding, we can assume it is not a match and
return false instead.

With this change, if there are paths on the file system that are not
valid UTF-8 we will just treat them as **not** matching the
regular expression and continue processing instead of failing
with an exception.

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [x] Used the same coding conventions as the rest of the project.
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] All tests are passing.
* [x] The new code doesn't generate RuboCop offenses.
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.