### PR TITLE
Unify the name of GitHub [ci skip]

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -24,13 +24,13 @@ $ rubocop -V
 
 ## Pull requests
 
-* Read [how to properly contribute to open source projects on Github][2].
+* Read [how to properly contribute to open source projects on GitHub][2].
 * Fork the project.
 * Use a topic/feature branch to easily amend a pull request later, if necessary.
 * Write [good commit messages][3].
 * Use the same coding conventions as the rest of the project.
 * Commit and push until you are happy with your contribution.
-* If your change has a corresponding open Github issue, prefix the commit message with `[Fix #github-issue-number]`.
+* If your change has a corresponding open GitHub issue, prefix the commit message with `[Fix #github-issue-number]`.
 * Make sure to add tests for it. This is important so I don't break it
   in a future version unintentionally.
 * Add an entry to the [Changelog](CHANGELOG.md) accordingly. See [changelog entry format](#changelog-entry-format).

--- a/README.md
+++ b/README.md
@@ -172,7 +172,7 @@ Support us with a monthly donation and help us continue our activities. [[Become
 
 ### Open Collective Sponsors
 
-Become a sponsor and get your logo on our README on Github with a link to your site. [[Become a sponsor](https://opencollective.com/rubocop#sponsor)]
+Become a sponsor and get your logo on our README on GitHub with a link to your site. [[Become a sponsor](https://opencollective.com/rubocop#sponsor)]
 
 <a href="https://opencollective.com/rubocop/sponsor/0/website" target="_blank"><img src="https://opencollective.com/rubocop/sponsor/0/avatar.svg"></a>
 <a href="https://opencollective.com/rubocop/sponsor/1/website" target="_blank"><img src="https://opencollective.com/rubocop/sponsor/1/avatar.svg"></a>


### PR DESCRIPTION
As far as I know, I think that "GitHub" become more precise name. This PR unifies the name in that way.