### PR TITLE
[Fix #4264] Prevent `Rails/SaveBang` from blowing up when using assigned variable in a hash

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@
 * [#4275](https://github.com/bbatsov/rubocop/issues/4275): Prevent `Style/MethodCallWithArgsParentheses` from blowing up on `yield`. ([@drenmi][])
 * [#3969](https://github.com/bbatsov/rubocop/issues/3969): Handle multiline method call alignment for arguments to methods. ([@jonas054][])
 * [#4304](https://github.com/bbatsov/rubocop/pull/4304): Allow enabling whole departments when `DisabledByDefault` is `true`. ([@jonas054][])
+* [#4264](https://github.com/bbatsov/rubocop/issues/4264): Prevent `Rails/SaveBang` from blowing up when using the assigned variable in a hash. ([@drenmi][])
 
 ## 0.48.1 (2017-04-03)
 

--- a/lib/rubocop/cop/rails/save_bang.rb
+++ b/lib/rubocop/cop/rails/save_bang.rb
@@ -107,9 +107,14 @@ module RuboCop
 
         def persisted_referenced?(assignment)
           return unless assignment.referenced?
+
           assignment.variable.references.any? do |reference|
-            reference.node.parent.method?(:persisted?)
+            call_to_persisted?(reference.node.parent)
           end
+        end
+
+        def call_to_persisted?(node)
+          node.send_type? && node.method?(:persisted?)
         end
 
         def check_used_in_conditional(node)
@@ -130,7 +135,7 @@ module RuboCop
         end
 
         def last_call_of_method?(node)
-          node.parent && node.parent.children.count == node.sibling_index + 1
+          node.parent && node.parent.children.size == node.sibling_index + 1
         end
 
         # Ignore simple assignment or if condition

--- a/spec/rubocop/cop/rails/save_bang_spec.rb
+++ b/spec/rubocop/cop/rails/save_bang_spec.rb
@@ -129,6 +129,19 @@ describe RuboCop::Cop::Rails::SaveBang do
       inspect_source(cop, ['def foo', "object.#{method}", 'end'])
       expect(cop.messages).to be_empty
     end
+
+    # Bug: https://github.com/bbatsov/rubocop/issues/4264
+    it 'when using the assigned variable as value in a hash' do
+      inspect_source(cop, ['def foo',
+                           "  foo = Foo.#{method}",
+                           '  render json: foo',
+                           'end'])
+      if pass
+        expect(cop.offenses).to be_empty
+      else
+        expect(cop.offenses.size).to eq(1)
+      end
+    end
   end
 
   described_class::MODIFY_PERSIST_METHODS.each do |method|


### PR DESCRIPTION
This cop would raise an exception when the assigned variable was used as a value in a hash, e.g.:

```ruby
foo = Foo.create

render json: foo
```

This change fixes that.

-----------------

Before submitting the PR make sure the following are checked:

* [X] Wrote [good commit messages][1].
* [X] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [X] Used the same coding conventions as the rest of the project.
* [X] Feature branch is up-to-date with `master` (if not - rebase it).
* [X] Squashed related commits together.
* [X] Added tests.
* [X] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [X] All tests are passing.
* [X] The new code doesn't generate RuboCop offenses.
* [X] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [ ] Updated cop documentation with `rake generate_cops_documentation` (required only when you've added a new cop or changed the configuration/documentation of an existing cop).

[1]: http://chris.beams.io/posts/git-commit/
