### PR TITLE
Check slow hash accessing in `Array#sort` by `Performance/CompareWithBlock` cop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 * Add auto-correct support to `Style/MixinGrouping`. ([@rrosenblum][])
 * [#4236](https://github.com/bbatsov/rubocop/issues/4236): Add new `Rails/ApplicationJob` and `Rails/ApplicationRecord` cops. ([@tjwp][])
 * [#4078](https://github.com/bbatsov/rubocop/pull/4078): Add new `Performance/Caller` cop. ([@alpaca-tc][])
+* [#4314](https://github.com/bbatsov/rubocop/pull/4314): Check slow hash accessing in `Array#sort` by `Performance/CompareWithBlock`. ([@pocke][])
 
 ### Changes
 

--- a/manual/cops_performance.md
+++ b/manual/cops_performance.md
@@ -123,6 +123,7 @@ This cop also checks `max` and `min` methods.
 array.sort { |a, b| a.foo <=> b.foo }
 array.max { |a, b| a.foo <=> b.foo }
 array.min { |a, b| a.foo <=> b.foo }
+array.sort { |a, b| a[:foo] <=> b[:foo] }
 
 # good
 array.sort_by(&:foo)
@@ -132,6 +133,7 @@ array.sort_by do |var|
 end
 array.max_by(&:foo)
 array.min_by(&:foo)
+array.sort_by { |a| a[:foo] }
 ```
 
 ## Performance/Count


### PR DESCRIPTION


Currently, `Performance/CompareWithBlock` cop accepts the following code.

```ruby
array.sort { |a, b| a[:foo] <=> b[:foo] }
```

But the code has same issue as `a.foo <=> b.foo`.
So, by this change, the cop registers an offense for this code.

Benchmark
========

```ruby
require 'benchmark'

array10000 = 10000.times.map do |i|
  {value: i}
end.shuffle

array100 = 100.times.map do |i|
  {value: i}
end.shuffle

array10 = 10.times.map do |i|
  {value: i}
end.shuffle

Benchmark.bm(15) do |x|
  x.report('sort_by 10000'){500.times{array10000.sort_by{|a| a[:value]}}}
  x.report('sort    10000'){500.times{array10000.sort{|a, b| a[:value] <=> b[:value]}}}

  x.report('sort_by 100'){50000.times{array100.sort_by{|a| a[:value]}}}
  x.report('sort    100'){50000.times{array100.sort{|a, b| a[:value] <=> b[:value]}}}

  x.report('sort_by 10'){500000.times{array10.sort_by{|a| a[:value]}}}
  x.report('sort    10'){500000.times{array10.sort{|a, b| a[:value] <=> b[:value]}}}
end
```

```bash
$ ruby test.rb
                      user     system      total        real
sort_by 10000     2.470000   0.000000   2.470000 (  2.480009)
sort    10000     4.790000   0.010000   4.800000 (  4.797943)
sort_by 100       1.140000   0.000000   1.140000 (  1.146861)
sort    100       1.910000   0.000000   1.910000 (  1.910717)
sort_by 10        0.880000   0.000000   0.880000 (  0.871086)
sort    10        1.000000   0.000000   1.000000 (  1.002856)
```



-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Used the same coding conventions as the rest of the project.
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] All tests are passing.
* [x] The new code doesn't generate RuboCop offenses.
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Updated cop documentation with `rake generate_cops_documentation` (required only when you've added a new cop or changed the configuration/documentation of an existing cop).

[1]: http://chris.beams.io/posts/git-commit/
