### PR TITLE
Improve performance of `Node#node_parts` method

### DIFF
--- a/lib/rubocop/ast/node/and_node.rb
+++ b/lib/rubocop/ast/node/and_node.rb
@@ -30,7 +30,7 @@ module RuboCop
       #
       # @return [Array<Node>] the different parts of the `and` predicate
       def node_parts
-        [*self]
+        to_a
       end
     end
   end

--- a/lib/rubocop/ast/node/case_node.rb
+++ b/lib/rubocop/ast/node/case_node.rb
@@ -57,7 +57,7 @@ module RuboCop
       #
       # @return [Array<Node>] the different parts of the `case` statement
       def node_parts
-        [*self]
+        to_a
       end
     end
   end

--- a/lib/rubocop/ast/node/ensure_node.rb
+++ b/lib/rubocop/ast/node/ensure_node.rb
@@ -18,7 +18,7 @@ module RuboCop
       #
       # @return [Array<Node>] the different parts of the `ensure` statement
       def node_parts
-        [*self]
+        to_a
       end
     end
   end

--- a/lib/rubocop/ast/node/for_node.rb
+++ b/lib/rubocop/ast/node/for_node.rb
@@ -46,7 +46,7 @@ module RuboCop
       #
       # @return [Array<Node>] the different parts of the `until` statement
       def node_parts
-        [*self]
+        to_a
       end
     end
   end

--- a/lib/rubocop/ast/node/or_node.rb
+++ b/lib/rubocop/ast/node/or_node.rb
@@ -30,7 +30,7 @@ module RuboCop
       #
       # @return [Array<Node>] the different parts of the `or` predicate
       def node_parts
-        [*self]
+        to_a
       end
     end
   end

--- a/lib/rubocop/ast/node/pair_node.rb
+++ b/lib/rubocop/ast/node/pair_node.rb
@@ -57,7 +57,7 @@ module RuboCop
       #
       # @return [Array<Node>] the different parts of the `pair`
       def node_parts
-        [*self]
+        to_a
       end
     end
   end

--- a/lib/rubocop/ast/node/resbody_node.rb
+++ b/lib/rubocop/ast/node/resbody_node.rb
@@ -18,7 +18,7 @@ module RuboCop
       #
       # @return [Array<Node>] the different parts of the `resbody` statement
       def node_parts
-        [*self]
+        to_a
       end
     end
   end

--- a/lib/rubocop/ast/node/send_node.rb
+++ b/lib/rubocop/ast/node/send_node.rb
@@ -181,7 +181,7 @@ module RuboCop
       #
       # @return [Array] the different parts of the `send` node
       def node_parts
-        [*self]
+        to_a
       end
 
       private

--- a/lib/rubocop/ast/node/until_node.rb
+++ b/lib/rubocop/ast/node/until_node.rb
@@ -36,7 +36,7 @@ module RuboCop
       #
       # @return [Array<Node>] the different parts of the `until` statement
       def node_parts
-        [*self]
+        to_a
       end
     end
   end

--- a/lib/rubocop/ast/node/when_node.rb
+++ b/lib/rubocop/ast/node/when_node.rb
@@ -54,7 +54,7 @@ module RuboCop
       #
       # @return [Array<Node>] the different parts of the `until` statement
       def node_parts
-        [*self]
+        to_a
       end
     end
   end

--- a/lib/rubocop/ast/node/while_node.rb
+++ b/lib/rubocop/ast/node/while_node.rb
@@ -36,7 +36,7 @@ module RuboCop
       #
       # @return [Array<Node>] the different parts of the `while` statement
       def node_parts
-        [*self]
+        to_a
       end
     end
   end


### PR DESCRIPTION

`rubocop` command will be faster around 3%.


Profiling
=========

```
==================================
  Mode: cpu(1000)
  Samples: 11760 (0.01% miss rate)
  GC: 838 (7.13%)
==================================
     TOTAL    (pct)     SAMPLES    (pct)     FRAME
      1015   (8.6%)        1015   (8.6%)     block (2 levels) in <class:Node>
      1435  (12.2%)         727   (6.2%)     Parser::Lexer#advance
       597   (5.1%)         597   (5.1%)     RuboCop::AST::SendNode#node_parts
.............................
```

`SendNode#node_parts` method accounts for 5% of the CPU time.

How to fix
========

`[*x]` equals `x.to_a`, but `x.to_a` is faster than `[*x]`.
So, I replaced `[*x]` with `x.to_a`.

Benchmark
=========

Micro benchmark
-----------

```ruby
require 'benchmark'
require 'parser/current'

node = Parser::CurrentRuby.parse('foo.bart(baz)')

raise unless [*node] == node.to_a

Benchmark.bm(15) do |x|
  x.report('[*node]'){  10000000.times{[*node]}}
  x.report('node.to_a'){10000000.times{node.to_a}}
end
```

```bash
$ ruby test.rb
                      user     system      total        real
[*node]           1.300000   0.000000   1.300000 (  1.293447)
node.to_a         0.310000   0.000000   0.310000 (  0.312420)
```

Benchmark with command execution
-------

```ruby
 # bench.rb
require 'benchmark'

 # origin/master (5778e5f1be8510bf302c7cfbf1ae0841aede252d)
def run_master
  system('rubocop _0.48.1.master_ --cache false --force-default-config > /dev/null')
end

 # This pull-request's branch
def run_improvement
  system('rubocop _0.48.1.improvement_ --cache false --force-default-config > /dev/null')
end

Benchmark.bm(15) do |x|
  x.report('master'){     5.times{run_master}}
  x.report('improvement'){5.times{run_improvement}}
end
```

```bash
$ cd path/to/rubocop/
$ ruby /path/to/bench.rb
                      user     system      total        real
master            0.000000   0.000000 195.480000 (195.510623)
improvement       0.000000   0.000000 189.820000 (189.841417)
```




-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Used the same coding conventions as the rest of the project.
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [ ] Added tests.
* [ ] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] All tests are passing.
* [x] The new code doesn't generate RuboCop offenses.
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Updated cop documentation with `rake generate_cops_documentation` (required only when you've added a new cop or changed the configuration/documentation of an existing cop).

[1]: http://chris.beams.io/posts/git-commit/
