### PR TITLE
Add SendNode#comparison_method? predicate

### DIFF
--- a/lib/rubocop/ast/node/send_node.rb
+++ b/lib/rubocop/ast/node/send_node.rb
@@ -103,6 +103,13 @@ module RuboCop
         RuboCop::Cop::Util::OPERATOR_METHODS.include?(method_name)
       end
 
+      # Checks whether the invoked method is a comparison method.
+      #
+      # @return [Boolean] whether the involed method is a comparison
+      def comparison_method?
+        COMPARISON_OPERATORS.include?(method_name)
+      end
+
       # Checks whether the method call uses a dot to connect the receiver and
       # the method name.
       #

--- a/spec/rubocop/ast/send_node_spec.rb
+++ b/spec/rubocop/ast/send_node_spec.rb
@@ -399,6 +399,20 @@ describe RuboCop::AST::SendNode do
     end
   end
 
+  describe '#comparison_method?' do
+    context 'with a comparison method' do
+      let(:source) { 'foo.bar <=> :baz' }
+
+      it { expect(send_node.comparison_method?).to be_truthy }
+    end
+
+    context 'with a regular method' do
+      let(:source) { 'foo.bar(:baz)' }
+
+      it { expect(send_node.comparison_method?).to be_falsey }
+    end
+  end
+
   describe '#dot?' do
     context 'with a dot' do
       let(:source) { 'foo.+ 1' }


### PR DESCRIPTION
This change adds a method, `#comparison_method?` to `SendNode`, for easily checking if a `send` node is any of the comparison operators.

-----------------

Before submitting the PR make sure the following are checked:

* [X] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [X] Used the same coding conventions as the rest of the project.
* [X] Feature branch is up-to-date with `master` (if not - rebase it).
* [X] Squashed related commits together.
* [X] Added tests.
* [ ] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [X] All tests are passing.
* [X] The new code doesn't generate RuboCop offenses.
* [X] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [ ] Updated cop documentation with `rake generate_cops_documentation` (required only when you've added a new cop or changed the configuration/documentation of an existing cop).

[1]: http://chris.beams.io/posts/git-commit/
