### PR TITLE
Add SendNode#assignment_method? predicate

### DIFF
--- a/lib/rubocop/ast/node/send_node.rb
+++ b/lib/rubocop/ast/node/send_node.rb
@@ -103,6 +103,13 @@ module RuboCop
         RuboCop::Cop::Util::OPERATOR_METHODS.include?(method_name)
       end
 
+      # Checks whether the invoked method is a comparison method.
+      #
+      # @return [Boolean] whether the involed method is a comparison
+      def comparison_method?
+        COMPARISON_OPERATORS.include?(method_name)
+      end
+
       # Checks whether the method call uses a dot to connect the receiver and
       # the method name.
       #

--- a/lib/rubocop/ast/node/send_node.rb
+++ b/lib/rubocop/ast/node/send_node.rb
@@ -110,6 +110,13 @@ module RuboCop
         COMPARISON_OPERATORS.include?(method_name)
       end
 
+      # Checks whether the invoked method is an assignment method.
+      #
+      # @return [Boolean] whether the invoked method is an assignment.
+      def assignment_method?
+        !comparison_method? && method_name.to_s.end_with?('=')
+      end
+
       # Checks whether the method call uses a dot to connect the receiver and
       # the method name.
       #

--- a/lib/rubocop/cop/style/braces_around_hash_parameters.rb
+++ b/lib/rubocop/cop/style/braces_around_hash_parameters.rb
@@ -45,7 +45,7 @@ module RuboCop
         MSG = '%s curly braces around a hash parameter.'.freeze
 
         def on_send(node)
-          return if node.asgn_method_call? || node.operator_method?
+          return if node.assignment_method? || node.operator_method?
 
           return unless node.arguments? && node.last_argument.hash_type? &&
                         !node.last_argument.empty?

--- a/lib/rubocop/cop/style/parallel_assignment.rb
+++ b/lib/rubocop/cop/style/parallel_assignment.rb
@@ -151,7 +151,7 @@ module RuboCop
 
           def dependency?(lhs, rhs)
             uses_var?(rhs, var_name(lhs)) ||
-              lhs.asgn_method_call? && accesses?(rhs, lhs)
+              lhs.send_type? && lhs.assignment_method? && accesses?(rhs, lhs)
           end
 
           # `lhs` is an assignment method call like `obj.attr=` or `ary[idx]=`.
@@ -169,7 +169,7 @@ module RuboCop
         end
 
         def modifier_statement?(node)
-          node && %i(if while until).include?(node.type) && node.modifier_form?
+          node && %i[if while until].include?(node.type) && node.modifier_form?
         end
 
         # An internal class for correcting parallel assignment

--- a/spec/rubocop/ast/send_node_spec.rb
+++ b/spec/rubocop/ast/send_node_spec.rb
@@ -413,6 +413,32 @@ describe RuboCop::AST::SendNode do
     end
   end
 
+  describe '#assignment_method?' do
+    context 'with an assignment method' do
+      let(:source) { 'foo.bar = :baz' }
+
+      it { expect(send_node.assignment_method?).to be_truthy }
+    end
+
+    context 'with a bracket assignment method' do
+      let(:source) { 'foo.bar[:baz] = :qux' }
+
+      it { expect(send_node.assignment_method?).to be_truthy }
+    end
+
+    context 'with a comparison method' do
+      let(:source) { 'foo.bar == :qux' }
+
+      it { expect(send_node.assignment_method?).to be_falsey }
+    end
+
+    context 'with a regular method' do
+      let(:source) { 'foo.bar(:baz)' }
+
+      it { expect(send_node.assignment_method?).to be_falsey }
+    end
+  end
+
   describe '#dot?' do
     context 'with a dot' do
       let(:source) { 'foo.+ 1' }

--- a/spec/rubocop/ast/send_node_spec.rb
+++ b/spec/rubocop/ast/send_node_spec.rb
@@ -399,6 +399,20 @@ describe RuboCop::AST::SendNode do
     end
   end
 
+  describe '#comparison_method?' do
+    context 'with a comparison method' do
+      let(:source) { 'foo.bar <=> :baz' }
+
+      it { expect(send_node.comparison_method?).to be_truthy }
+    end
+
+    context 'with a regular method' do
+      let(:source) { 'foo.bar(:baz)' }
+
+      it { expect(send_node.comparison_method?).to be_falsey }
+    end
+  end
+
   describe '#dot?' do
     context 'with a dot' do
       let(:source) { 'foo.+ 1' }


### PR DESCRIPTION
This change adds a method, `#assignment_method?` to `SendNode`, for easily checking if a method call is an assignment. (Hopefully `Node#asgn_method_call?` can soon be removed.)

It also uses the node extension methods to clean up `Style/ParallelAssignment`.

**Note: this is based on #4317.**

-----------------

Before submitting the PR make sure the following are checked:

* [X] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [X] Used the same coding conventions as the rest of the project.
* [X] Feature branch is up-to-date with `master` (if not - rebase it).
* [X] Squashed related commits together.
* [X] Added tests.
* [ ] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [X] All tests are passing.
* [X] The new code doesn't generate RuboCop offenses.
* [X] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [ ] Updated cop documentation with `rake generate_cops_documentation` (required only when you've added a new cop or changed the configuration/documentation of an existing cop).

[1]: http://chris.beams.io/posts/git-commit/
