### PR TITLE
Remove trailing space from offense message when `ExtraDetails` is true

### DIFF
--- a/lib/rubocop/cop/message_annotator.rb
+++ b/lib/rubocop/cop/message_annotator.rb
@@ -49,7 +49,7 @@ module RuboCop
       # @return [String] annotated message
       def annotate(message, name)
         message = "#{name}: #{message}" if display_cop_names?
-        message += " #{details}" if extra_details?
+        message += " #{details}" if extra_details? && details
         if display_style_guide?
           links = urls.join(', ')
           message = "#{message} (#{links})"

--- a/spec/rubocop/cli/cli_options_spec.rb
+++ b/spec/rubocop/cli/cli_options_spec.rb
@@ -515,7 +515,7 @@ describe RuboCop::CLI, :isolated_environment do
                       'example1.rb'])).to eq(1)
       expect($stdout.string)
         .to eq(["#{file}:1:8: W: Unnecessary disabling of " \
-                '`Style/NumericLiterals`. ',
+                '`Style/NumericLiterals`.',
                 "#{file}:1:41: C: Trailing " \
                 'whitespace detected. Trailing space is just sloppy.',
                 ''].join("\n"))


### PR DESCRIPTION
Currently, if `ExtraDetails` option is true, a space is added to offense message.

For example:

`test.rb`

```ruby
foo()
```

`.rubocop.yml`

```yaml
AllCops:
  ExtraDetails: true
```

```bash
$ rubocop
Inspecting 1 file
C

Offenses:

test.rb:1:4: C: Do not use parentheses for method calls with no arguments. # This line has a trailing space!
foo()
   ^

1 file inspected, 1 offense detected
```

This change fixes the problem.


-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Used the same coding conventions as the rest of the project.
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [ ] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] All tests are passing.
* [x] The new code doesn't generate RuboCop offenses.
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Updated cop documentation with `rake generate_cops_documentation` (required only when you've added a new cop or changed the configuration/documentation of an existing cop).

[1]: http://chris.beams.io/posts/git-commit/
