### PR TITLE
Update Rails/OutputSafety to disallow wrapping safe_join

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 
 * [#4262](https://github.com/bbatsov/rubocop/pull/4262): Add new `MinSize` configuration to `Style/SymbolArray`, consistent with the same configuration in `Style/WordArray`. ([@scottmatthewman][])
 * [#4278](https://github.com/bbatsov/rubocop/pull/4278): Move all cops dealing with whitespace into a new department called `Layout`. ([@jonas054][])
+* [#4320](https://github.com/bbatsov/rubocop/pull/4320): Update `Rails/OutputSafety` to disallow wrapping `raw` or `html_safe` with `safe_join`. ([@klesse413][])
 
 ### Bug fixes
 
@@ -2762,3 +2763,4 @@
 [@alpaca-tc]: https://github.com/alpaca-tc
 [@ilansh]: https://github.com/ilansh
 [@mclark]: https://github.com/mclark
+[@klesse413]: https://github.com/klesse413

--- a/manual/cops_rails.md
+++ b/manual/cops_rails.md
@@ -523,7 +523,7 @@ Enabled by default | Supports autocorrection
 Enabled | No
 
 This cop checks for the use of output safety calls like html_safe and
-raw.
+raw. These methods do not escape content. They simply return a `SafeBuffer` containing the content as is. Instead, use `safe_join` to escape content and ensure its safety. 
 
 ### Example
 
@@ -545,6 +545,12 @@ out = []
 out << content_tag(:li, "one")
 out << content_tag(:li, "two")
 safe_join(out)
+
+# bad
+(person.login + " " + content_tag(:span, person.email)).html_safe
+
+# good
+safe_join([person.login, " ", content_tag(:span, person.email)])
 ```
 
 ## Rails/PluralizationGrammar

--- a/spec/rubocop/cop/rails/output_safety_spec.rb
+++ b/spec/rubocop/cop/rails/output_safety_spec.rb
@@ -67,31 +67,31 @@ describe RuboCop::Cop::Rails::OutputSafety do
     expect(cop.offenses).to be_empty
   end
 
-  it 'accepts raw methods when wrapped in a safe_join' do
+  it 'does not accept raw methods when wrapped in a safe_join' do
     source = 'safe_join([raw(i18n_text),
               raw(i18n_mode_additional_markup(key))])'
     inspect_source(cop, source)
-    expect(cop.offenses).to be_empty
+    expect(cop.offenses.size).to eq(2)
   end
 
-  it 'accepts html_safe methods when wrapped in a safe_join' do
+  it 'does not accept html_safe methods when wrapped in a safe_join' do
     source = 'safe_join([i18n_text.html_safe,
               i18n_mode_additional_markup(key).html_safe])'
     inspect_source(cop, source)
-    expect(cop.offenses).to be_empty
+    expect(cop.offenses.size).to eq(2)
   end
 
-  it 'accepts raw methods when wrapped in safe_join when not at the root' do
+  it 'does not accept html_safe methods wrapped in safe_join not at root' do
     source = 'foo(safe_join([i18n_text.html_safe,
               i18n_mode_additional_markup(key).html_safe]))'
     inspect_source(cop, source)
-    expect(cop.offenses).to be_empty
+    expect(cop.offenses.size).to eq(2)
   end
 
-  it 'accepts raw methods when wrapped in a safe_join when not at the root' do
+  it 'does not accept raw methods wrapped in a safe_join not at root' do
     source = 'foo(safe_join([raw(i18n_text),
               raw(i18n_mode_additional_markup(key))]))'
     inspect_source(cop, source)
-    expect(cop.offenses).to be_empty
+    expect(cop.offenses.size).to eq(2)
   end
 end


### PR DESCRIPTION
At Betterment, we built custom cops to prevent usage of `raw` and `html_safe` without review, but we'd love to get on the mainline version now that there is a built-in `Rails/OutputSafety` cop. However, we can't switch unless this cop can provide the guarantees that we need. Hopefully our learnings are valuable to the community.

## Proposed Change

I would like to propose changing the behavior of the `Rails/OutputSafety` cop. The change is to no longer allow usage of `raw` and `html_safe` when they are wrapped in `safe_join`. Instead, `raw` and `html_safe` should only be used when the cop is explicitly disabled. This change essentially reverts the `Rails/OutputSafety` cop back to its original functionality.

## Background

When it was first introduced, the `Rails/OutputSafety` cop only allowed the usage of `raw` or `html_safe` if the cop was explicitly disabled.

For reference, here is a link to that original PR: https://github.com/bbatsov/rubocop/pull/3135 In that PR, @josh explained:

> In instances .html_safe were is necessary, we use an inline # rubocop:disable Rails/OutputSafety comment after security review.

A few months after the introduction of this cop, an issue was opened here: https://github.com/bbatsov/rubocop/issues/3676 which was addressed by this PR: https://github.com/bbatsov/rubocop/pull/3682. The change is to allow usage of `raw` or `html_safe` when the usages are wrapped in `safe_join`.

## Why

In summary, `safe_join` is not a declaration about the safety of the buffers it joins, and it shouldn't be used by rubocop to impute that.

I'm proposing this change because usage of `safe_join` to combine buffers that have already been declared "safe" by using `raw` or `html_safe` to return a `SafeBuffer` does not add any additional "safety" to the buffer. Calling `raw` or `html_safe` essentially blesses a buffer as safe by returning a `SafeBuffer` containing the content, like so:

```ruby
[1] pry(main)> include ActionView::Helpers::OutputSafetyHelper
=> Object
[2] pry(main)> result = "<p>hi</p>".html_safe
=> "<p>hi</p>"
[3] pry(main)> result.class
=> ActiveSupport::SafeBuffer
[4] pry(main)> result = raw("<p>hi</p>")
=> "<p>hi</p>"
[5] pry(main)> result.class
=> ActiveSupport::SafeBuffer
```

Rather than bless content as already "safe", `safe_join` actually escapes the content, like so:

```ruby
[6] pry(main)> safe_join(["<p>hi</p>", "<p>bye</p>"])
=> "&lt;p&gt;hi&lt;/p&gt;&lt;p&gt;bye&lt;/p&gt;"
```

However, when passed content that has already been blessed as safe (because it's a `SafeBuffer`), `safe_join` does not escape the content, like so:

```ruby
[7] pry(main)> safe_join([raw("<p>hi</p>"), "<p>bye</p>".html_safe])
=> "<p>hi</p><p>bye</p>"
```

Therefore, if the `Rails/OutputSafety` cop tells us that we should not use `raw` or `html_safe` without explicitly disabling it, we should still hold to the standard of needing to explicitly disable it when usages are wrapped in `safe_join`, since `safe_join` does not provide any additional safety.

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Used the same coding conventions as the rest of the project.
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] All tests are passing.
* [x] The new code doesn't generate RuboCop offenses.
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Updated cop documentation with `rake generate_cops_documentation` (required only when you've added a new cop or changed the configuration/documentation of an existing cop).

[1]: http://chris.beams.io/posts/git-commit/
