### PR TITLE
Fix autocorrect with parenthesis on same line

### DIFF
--- a/spec/rubocop/cop/style/multiline_memoization_spec.rb
+++ b/spec/rubocop/cop/style/multiline_memoization_spec.rb
@@ -121,6 +121,18 @@ describe RuboCop::Cop::Style::MultilineMemoization, :config do
                                 baz
                               end
                           END
+
+          it_behaves_like 'code with offense',
+                          <<-END.strip_indent,
+                            foo ||= (bar ||
+                                     baz)
+                          END
+                          <<-END.strip_indent
+                            foo ||= begin
+                                    bar ||
+                                     baz
+                                    end
+                          END
         end
       end
 


### PR DESCRIPTION
Basic fix to add a new line.  I was not sure how to get the alignment correct as I wanted to run Style/MultilineMethodCallIndentation autocorrect afterwards but I wasn't sure of the best way to do this.