### PR TITLE
Improve performance of Layout/TrailingWhitespace

### DIFF
--- a/lib/rubocop/cop/layout/trailing_whitespace.rb
+++ b/lib/rubocop/cop/layout/trailing_whitespace.rb
@@ -9,7 +9,7 @@ module RuboCop
 
         def investigate(processed_source)
           processed_source.lines.each_with_index do |line, index|
-            next unless line =~ /.*[ \t]+$/
+            next unless line.end_with?(' ', "\t")
 
             range = source_range(processed_source.buffer,
                                  index + 1,


### PR DESCRIPTION
The `Layout/TrailingWhitespace` cop will be faster around 11%.

Profiling
=========

```ruby
require 'benchmark'

def rubocop_dev
  # `dev` is applied this change.
  system('rubocop _0.48.1.dev_ --cache false --only Layout/TrailingWhitespace > /dev/null')
end

def rubocop_master
  system('rubocop _0.48.1.master_ --cache false --only Layout/TrailingWhitespace > /dev/null')
end

n = 10

Benchmark.bm(16) do |x|
  x.report('dev'){   n.times{rubocop_dev}}
  x.report('master'){n.times{rubocop_master}}
end
```

```
 # In rubocop repository
$ ruby bench.rb
                       user     system      total        real
dev                0.000000   0.000000  98.100000 ( 98.152543)
master             0.000000   0.000000 110.270000 (110.310969)
```



-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Used the same coding conventions as the rest of the project.
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [ ] Added tests.
* [ ] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] All tests are passing.
* [x] The new code doesn't generate RuboCop offenses.
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Updated cop documentation with `rake generate_cops_documentation` (required only when you've added a new cop or changed the configuration/documentation of an existing cop).

[1]: http://chris.beams.io/posts/git-commit/
