### PR TITLE
[Fix #3400] cancel `Lint/Debugger` autocorrect due to buggy implementation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 ### Changes
 
 * [#4262](https://github.com/bbatsov/rubocop/pull/4262): Add new `MinSize` configuration to `Style/SymbolArray`, consistent with the same configuration in `Style/WordArray`. ([@scottmatthewman][])
+* [#3400](https://github.com/bbatsov/rubocop/issues/3400): Remove auto-correct support from Lint/Debugger. ([@ilansh][])
 * [#4278](https://github.com/bbatsov/rubocop/pull/4278): Move all cops dealing with whitespace into a new department called `Layout`. ([@jonas054][])
 
 ### Bug fixes

--- a/lib/rubocop/cop/lint/debugger.rb
+++ b/lib/rubocop/cop/lint/debugger.rb
@@ -63,21 +63,6 @@ module RuboCop
           format(MSG, node.source)
         end
 
-        def autocorrect(node)
-          lambda do |corrector|
-            if pry_rescue?(node)
-              block = node.parent
-              body  = block.children[2] # (block <send> <parameters> <body>)
-              corrector.replace(block.source_range, body.source)
-            else
-              range = node.source_range
-              range = range_with_surrounding_space(range, :left, false)
-              range = range_with_surrounding_space(range, :right, true)
-              corrector.remove(range)
-            end
-          end
-        end
-
         def binding_irb?(node)
           target_ruby_version >= 2.4 && binding_irb_call?(node)
         end

--- a/lib/rubocop/rspec/shared_examples.rb
+++ b/lib/rubocop/rspec/shared_examples.rb
@@ -82,14 +82,6 @@ shared_examples_for 'debugger' do |name, src|
       .to eq(src.map { |s| "Remove debugger entry point `#{s}`." })
     expect(cop.highlights).to eq(src)
   end
-
-  it "can autocorrect a #{name} call" do
-    lines = src.is_a?(String) ? src : src.join("\n")
-    new_source = autocorrect_source(cop, ['def a',
-                                          "  #{lines}",
-                                          'end'].join("\n"))
-    expect(new_source).to eq("def a\nend")
-  end
 end
 
 shared_examples_for 'non-debugger' do |name, src|

--- a/spec/rubocop/cop/lint/debugger_spec.rb
+++ b/spec/rubocop/cop/lint/debugger_spec.rb
@@ -43,19 +43,6 @@ describe RuboCop::Cop::Lint::Debugger, :config do
     expect(cop.messages).to eq(['Remove debugger entry point `Pry.rescue`.'])
   end
 
-  it 'can autocorrect Pry.rescue' do
-    new_source = autocorrect_source(cop, <<-END.strip_indent)
-      def method
-        Pry.rescue { puts 1 }
-      end
-    END
-    expect(new_source).to eq(<<-END.strip_indent)
-      def method
-        puts 1
-      end
-    END
-  end
-
   context 'target_ruby_version >= 2.4', :ruby24 do
     include_examples 'debugger', 'irb binding', 'binding.irb'
 


### PR DESCRIPTION
It was decided to cancel autocorrection for this cop (see discussion in issue)
because it is too copmlex to implement correctly, and probably not worth the effort.

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Used the same coding conventions as the rest of the project.
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [ ] Added tests.
* [x] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] All tests are passing.
* [x] The new code doesn't generate RuboCop offenses.
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [ ] Updated cop documentation with `rake generate_cops_documentation` (required only when you've added a new cop or changed the configuration/documentation of an existing cop).

[1]: http://chris.beams.io/posts/git-commit/
