### PR TITLE
Improve performance of `MessageAnnotator`

### DIFF
--- a/lib/rubocop/cop/message_annotator.rb
+++ b/lib/rubocop/cop/message_annotator.rb
@@ -15,6 +15,12 @@ module RuboCop
     class MessageAnnotator
       attr_reader :options, :config, :cop_config
 
+      @style_guide_urls = {}
+
+      class << self
+        attr_reader :style_guide_urls
+      end
+
       # @param config [RuboCop::Config] Check configs for all cops
       #   @note Message Annotator specifically checks the
       #     following config options for_all_cops
@@ -67,16 +73,20 @@ module RuboCop
         url = cop_config['StyleGuide']
         return nil if url.nil? || url.empty?
 
-        base_url = config.for_all_cops['StyleGuideBaseURL']
-        return url if base_url.nil? || base_url.empty?
-
-        URI.join(base_url, url).to_s
+        self.class.style_guide_urls[url] ||= begin
+          base_url = config.for_all_cops['StyleGuideBaseURL']
+          if base_url.nil? || base_url.empty?
+            url
+          else
+            URI.join(base_url, url).to_s
+          end
+        end
       end
 
       def display_style_guide?
-        !urls.empty? &&
-          (options[:display_style_guide] ||
-            config.for_all_cops['DisplayStyleGuide'])
+        (options[:display_style_guide] ||
+         config.for_all_cops['DisplayStyleGuide']) &&
+          !urls.empty?
       end
 
       def reference_url


### PR DESCRIPTION
`MessageAnnotator` has performance issues.

`URI.join` is slow. Because it parses an URI.

This PR improves `display_style_guide?` and `style_guide_url` methods that use `URI.join`.
By this change, `rubocop` command will be faster around 3~6%.

`display_style_guide?`
=======

Until now this method call `style_guide_url` method always.
For that reason, it parses a URI always, so, it has a performance issue.

This PR reduces parsing. This PR reduces parsing. It will parse only when "display style guide" is true.

`style_guide_url`
========

This PR introduces a cache for style guide URLs.

Benchmarking
======

I benchmarked in https://github.com/ruby/spec . This project is large, and has many offenses.
This change will make it faster only when offenses exist.

- with `--display-style-guide` option
  - It will be faster around 6%
- without `--display-style-guide` option
  - It will be faster around 3%

Code
----

`bench.rb`

```ruby
require 'benchmark'

def rubocop_dev
  system 'rubocop _0.48.1.dev_ --cache false --force-default-config > /dev/null 2>&1'
end

def rubocop_master
  system 'rubocop _0.48.1.master_ --cache false --force-default-config > /dev/null 2>&1'
end

def rubocop_dev_guide
  system 'rubocop _0.48.1.dev_ --cache false --force-default-config --display-style-guide > /dev/null 2>&1'
end

def rubocop_master_guide
  system 'rubocop _0.48.1.master_ --cache false --force-default-config --display-style-guide > /dev/null 2>&1'
end

n = 2

Benchmark.bm(16) do |x|
  x.report('dev'){   n.times{rubocop_dev}}
  x.report('master'){n.times{rubocop_master}}

  x.report('dev with guide URL'){   n.times{rubocop_dev_guide}}
  x.report('master with guide URL'){n.times{rubocop_master_guide}}
end
```

Result
-----

```bash
$ cd path/to/github.com/ruby/spec
$ ruby bench.rb
                       user     system      total        real
dev                0.000000   0.000000 164.870000 (164.901375)
master             0.000000   0.000000 170.630000 (170.631897)
dev with guide URL  0.000000   0.000000 165.250000 (165.264880)
master with guide URL  0.000000   0.000000 176.240000 (176.239310)
```

**Replace this text with a summary of the changes in your PR.
The more detailed you are, the better.**

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Used the same coding conventions as the rest of the project.
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [ ] Added tests.
* [ ] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] All tests are passing.
* [x] The new code doesn't generate RuboCop offenses.
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Updated cop documentation with `rake generate_cops_documentation` (required only when you've added a new cop or changed the configuration/documentation of an existing cop).

[1]: http://chris.beams.io/posts/git-commit/
