### PR TITLE
Fix typo in Style/Next documentation

### DIFF
--- a/lib/rubocop/cop/style/next.rb
+++ b/lib/rubocop/cop/style/next.rb
@@ -8,7 +8,7 @@ module RuboCop
       # @example
       #   # bad
       #   [1, 2].each do |a|
-      #     if a == 1 do
+      #     if a == 1
       #       puts a
       #     end
       #   end

--- a/manual/cops_lint.md
+++ b/manual/cops_lint.md
@@ -276,7 +276,7 @@ end
 
 Enabled by default | Supports autocorrection
 --- | ---
-Enabled | Yes
+Enabled | No
 
 This cop checks for calls to debugger or pry.
 

--- a/manual/cops_rails.md
+++ b/manual/cops_rails.md
@@ -523,7 +523,9 @@ Enabled by default | Supports autocorrection
 Enabled | No
 
 This cop checks for the use of output safety calls like html_safe and
-raw. These methods do not escape content. They simply return a `SafeBuffer` containing the content as is. Instead, use `safe_join` to escape content and ensure its safety. 
+raw. These methods do not escape content. They simply return a
+SafeBuffer containing the content as is. Instead, use safe_join
+to escape content and ensure its safety.
 
 ### Example
 

--- a/manual/cops_style.md
+++ b/manual/cops_style.md
@@ -1165,24 +1165,12 @@ Enabled by default | Supports autocorrection
 --- | ---
 Enabled | No
 
-Use a consistent style for format string tokens.
+Use a consistent style for named format string tokens.
 
 ### Example
 
 ```ruby
-EnforcedStyle: unnamed
-
-# bad
-
-format('%<greeting>s', greeting: 'Hello')
-format('%{greeting}', greeting: 'Hello')
-
-# good
-
-format('%s', 'Hello')
-```
-```ruby
-EnforcedStyle: named
+EnforcedStyle: annotated
 
 # bad
 
@@ -1210,8 +1198,8 @@ format('%{greeting}', greeting: 'Hello')
 
 Attribute | Value
 --- | ---
-EnforcedStyle | unnamed
-SupportedStyles | unnamed, named, template
+EnforcedStyle | annotated
+SupportedStyles | annotated, template
 
 ## Style/FrozenStringLiteralComment
 
@@ -2412,7 +2400,7 @@ Use `next` to skip iteration instead of a condition at the end.
 ```ruby
 # bad
 [1, 2].each do |a|
-  if a == 1 do
+  if a == 1
     puts a
   end
 end


### PR DESCRIPTION
`if cond do` is incorrect as ruby code, `do` is unnecessary.

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Used the same coding conventions as the rest of the project.
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [ ] Added tests.
* [ ] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] All tests are passing.
* [x] The new code doesn't generate RuboCop offenses.
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Updated cop documentation with `rake generate_cops_documentation` (required only when you've added a new cop or changed the configuration/documentation of an existing cop).

[1]: http://chris.beams.io/posts/git-commit/
