### PR TITLE
Fix false positive/negative in Security/Eval cop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,8 @@
 * [#4304](https://github.com/bbatsov/rubocop/pull/4304): Allow enabling whole departments when `DisabledByDefault` is `true`. ([@jonas054][])
 * [#4264](https://github.com/bbatsov/rubocop/issues/4264): Prevent `Rails/SaveBang` from blowing up when using the assigned variable in a hash. ([@drenmi][])
 * [#4310](https://github.com/bbatsov/rubocop/pull/4310): Treat paths containing invalid byte sequences as non-matches. ([@mclark][])
+* [#4339](https://github.com/bbatsov/rubocop/pull/4339): Fix false positive in `Security/Eval` cop for multiline string lietral. ([@pocke][])
+* [#4339](https://github.com/bbatsov/rubocop/pull/4339): Fix false negative in `Security/Eval` cop for `Binding#eval`. ([@pocke][])
 
 ## 0.48.1 (2017-04-03)
 

--- a/lib/rubocop/cop/security/eval.rb
+++ b/lib/rubocop/cop/security/eval.rb
@@ -3,20 +3,26 @@
 module RuboCop
   module Cop
     module Security
-      # This cop checks for the use of *Kernel#eval*.
+      # This cop checks for the use of `Kernel#eval` and `Binding#eval`.
       #
       # @example
       #
       #   # bad
       #
       #   eval(something)
+      #   binding.eval(something)
       class Eval < Cop
         MSG = 'The use of `eval` is a serious security risk.'.freeze
 
-        def_node_matcher :eval?, '(send nil :eval $!str ...)'
+        def_node_matcher :eval?, <<-END
+          (send {nil (send nil :binding)} :eval $!str ...)
+        END
 
         def on_send(node)
-          eval?(node) { add_offense(node, :selector) }
+          eval?(node) do |code|
+            return if code.dstr_type? && code.recursive_literal?
+            add_offense(node, :selector)
+          end
         end
       end
     end

--- a/manual/cops_security.md
+++ b/manual/cops_security.md
@@ -6,7 +6,7 @@ Enabled by default | Supports autocorrection
 --- | ---
 Enabled | No
 
-This cop checks for the use of *Kernel#eval*.
+This cop checks for the use of `Kernel#eval` and `Binding#eval`.
 
 ### Example
 
@@ -14,6 +14,7 @@ This cop checks for the use of *Kernel#eval*.
 # bad
 
 eval(something)
+binding.eval(something)
 ```
 
 ## Security/JSONLoad

--- a/spec/rubocop/cop/security/eval_spec.rb
+++ b/spec/rubocop/cop/security/eval_spec.rb
@@ -15,23 +15,48 @@ describe RuboCop::Cop::Security::Eval do
     expect(cop.highlights).to eq(['eval'])
   end
 
-  it 'does not register an offense for eval as variable' do
+  it 'registers an offense `Binding#eval`' do
+    inspect_source(cop, 'binding.eval something')
+    expect(cop.offenses.size).to eq(1)
+    expect(cop.highlights).to eq(['eval'])
+  end
+
+  it 'registers an offense for eval with string that has an interpolation' do
+    inspect_source(cop, 'eval "something#{foo}"')
+    expect(cop.offenses.size).to eq(1)
+    expect(cop.highlights).to eq(['eval'])
+  end
+
+  it 'accepts eval as variable' do
     inspect_source(cop, 'eval = something')
     expect(cop.offenses).to be_empty
   end
 
-  it 'does not register an offense for eval as method' do
+  it 'accepts eval as method' do
     inspect_source(cop, 'something.eval')
     expect(cop.offenses).to be_empty
   end
 
-  it 'does not register an offense for eval on a literal string' do
+  it 'accepts eval on a literal string' do
     inspect_source(cop, 'eval("puts 1")')
     expect(cop.offenses).to be_empty
   end
 
-  it 'does not register an offense for eval with no arguments' do
+  it 'accepts eval with no arguments' do
     inspect_source(cop, 'eval')
+    expect(cop.offenses).to be_empty
+  end
+
+  it 'accepts eval with a multiline string' do
+    inspect_source(cop, <<-END)
+      eval "something
+      something2"
+    END
+    expect(cop.offenses).to be_empty
+  end
+
+  it 'accepts eval with a string that is interpolated a literal' do
+    inspect_source(cop, 'eval "something#{2}"')
     expect(cop.offenses).to be_empty
   end
 
@@ -48,7 +73,7 @@ describe RuboCop::Cop::Security::Eval do
       expect(cop.highlights).to eq(['eval'])
     end
 
-    it 'does not register an offense for eval on a literal string' do
+    it 'accepts eval on a literal string' do
       inspect_source(cop, 'eval("puts 1", binding, "test.rb", 1)')
       expect(cop.offenses).to be_empty
     end


### PR DESCRIPTION
Changes
=========

- Add an offense for `binding.eval(something)`
- Not add an offense for `dstr` if it doesn't have a string interpolation

```ruby
 # bad
binding.eval(something)
eval <<-END
  #{foo}
END

 # good
eval <<-END
  foo
  bar
END
```



-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Used the same coding conventions as the rest of the project.
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] All tests are passing.
* [x] The new code doesn't generate RuboCop offenses.
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Updated cop documentation with `rake generate_cops_documentation` (required only when you've added a new cop or changed the configuration/documentation of an existing cop).

[1]: http://chris.beams.io/posts/git-commit/
