### PR TITLE
Update Rails/OutputSafety to disallow safe_concat

### DIFF
--- a/lib/rubocop/cop/rails/output_safety.rb
+++ b/lib/rubocop/cop/rails/output_safety.rb
@@ -3,42 +3,78 @@
 module RuboCop
   module Cop
     module Rails
-      # This cop checks for the use of output safety calls like html_safe and
-      # raw. These methods do not escape content. They simply return a
-      # SafeBuffer containing the content as is. Instead, use safe_join
-      # to escape content and ensure its safety.
+      # This cop checks for the use of output safety calls like html_safe,
+      # raw, and safe_concat. These methods do not escape content. They
+      # simply return a SafeBuffer containing the content as is. Instead,
+      # use safe_join to join content and escape it and concat to
+      # concatenate content and escape it, ensuring its safety.
       #
       # @example
+      #   user_content = "<b>hi</b>"
+      #
       #   # bad
-      #   "<p>#{text}</p>".html_safe
+      #   "<p>#{user_content}</p>".html_safe
+      #   => ActiveSupport::SafeBuffer
+      #   "<p><b>hi</b></p>"
       #
       #   # good
-      #   content_tag(:p, text)
+      #   content_tag(:p, user_content)
+      #   => ActiveSupport::SafeBuffer
+      #   "<p>&lt;b&gt;hi&lt;/b&gt;</p>"
       #
       #   # bad
       #   out = ""
-      #   out << content_tag(:li, "one")
-      #   out << content_tag(:li, "two")
+      #   out << "<li>#{user_content}</li>"
+      #   out << "<li>#{user_content}</li>"
       #   out.html_safe
+      #   => ActiveSupport::SafeBuffer
+      #   "<li><b>hi</b></li><li><b>hi</b></li>"
       #
       #   # good
       #   out = []
-      #   out << content_tag(:li, "one")
-      #   out << content_tag(:li, "two")
+      #   out << content_tag(:li, user_content)
+      #   out << content_tag(:li, user_content)
       #   safe_join(out)
+      #   => ActiveSupport::SafeBuffer
+      #   "<li>&lt;b&gt;hi&lt;/b&gt;</li><li>&lt;b&gt;hi&lt;/b&gt;</li>"
       #
       #   # bad
-      #   (person.login + " " + content_tag(:span, person.email)).html_safe
+      #   out = "<h1>trusted content</h1>".html_safe
+      #   out.safe_concat(user_content)
+      #   => ActiveSupport::SafeBuffer
+      #   "<h1>trusted_content</h1><b>hi</b>"
       #
       #   # good
-      #   safe_join([person.login, " ", content_tag(:span, person.email)])
+      #   out = "<h1>trusted content</h1>".html_safe
+      #   out.concat(user_content)
+      #   => ActiveSupport::SafeBuffer
+      #   "<h1>trusted_content</h1>&lt;b&gt;hi&lt;/b&gt;"
+      #
+      #   # safe, though maybe not good style
+      #   out = "trusted content"
+      #   result = out.concat(user_content)
+      #   => String "trusted content<b>hi</b>"
+      #   # because when rendered in ERB the String will be escaped:
+      #   <%= result %>
+      #   => trusted content&lt;b&gt;hi&lt;/b&gt;
+      #
+      #   # bad
+      #   (user_content + " " + content_tag(:span, user_content)).html_safe
+      #   => ActiveSupport::SafeBuffer
+      #   "<b>hi</b> <span><b>hi</b></span>"
+      #
+      #   # good
+      #   safe_join([user_content, " ", content_tag(:span, user_content)])
+      #   => ActiveSupport::SafeBuffer
+      #   "&lt;b&gt;hi&lt;/b&gt; <span>&lt;b&gt;hi&lt;/b&gt;</span>"
       #
       class OutputSafety < Cop
         MSG = 'Tagging a string as html safe may be a security risk.'.freeze
 
         def on_send(node)
           return unless looks_like_rails_html_safe?(node) ||
-                        looks_like_rails_raw?(node)
+                        looks_like_rails_raw?(node) ||
+                        looks_like_rails_safe_concat?(node)
 
           add_offense(node, :selector)
         end
@@ -51,6 +87,10 @@ module RuboCop
 
         def looks_like_rails_raw?(node)
           node.command?(:raw) && node.arguments.one?
+        end
+
+        def looks_like_rails_safe_concat?(node)
+          node.method?(:safe_concat) && node.arguments.one?
         end
       end
     end

--- a/manual/cops_rails.md
+++ b/manual/cops_rails.md
@@ -522,37 +522,63 @@ Enabled by default | Supports autocorrection
 --- | ---
 Enabled | No
 
-This cop checks for the use of output safety calls like html_safe and
-raw. These methods do not escape content. They simply return a
-SafeBuffer containing the content as is. Instead, use safe_join
-to escape content and ensure its safety.
+This cop checks for the use of output safety calls like html_safe,
+raw, and safe_concat. These methods do not escape content. They simply return a
+SafeBuffer containing the content as is. Instead, use safe_join to join content
+and escape it and concat to concatenate content and escape it, ensuring its safety.
 
 ### Example
 
 ```ruby
+user_content = "<b>hi</b>"
+
 # bad
-"<p>#{text}</p>".html_safe
+"<p>#{user_content}</p>".html_safe
+=> ActiveSupport::SafeBuffer "<p><b>hi</b></p>"
 
 # good
-content_tag(:p, text)
+content_tag(:p, user_content)
+=> ActiveSupport::SafeBuffer "<p>&lt;b&gt;hi&lt;/b&gt;</p>"
 
 # bad
 out = ""
-out << content_tag(:li, "one")
-out << content_tag(:li, "two")
+out << "<li>#{user_content}</li>"
+out << "<li>#{user_content}</li>"
 out.html_safe
+=> ActiveSupport::SafeBuffer "<li><b>hi</b></li><li><b>hi</b></li>"
 
 # good
 out = []
-out << content_tag(:li, "one")
-out << content_tag(:li, "two")
+out << content_tag(:li, user_content)
+out << content_tag(:li, user_content)
 safe_join(out)
+=> ActiveSupport::SafeBuffer "<li>&lt;b&gt;hi&lt;/b&gt;</li><li>&lt;b&gt;hi&lt;/b&gt;</li>"
 
 # bad
-(person.login + " " + content_tag(:span, person.email)).html_safe
+out = "<h1>trusted content</h1>".html_safe
+out.safe_concat(user_content)
+=> ActiveSupport::SafeBuffer "<h1>trusted_content</h1><b>hi</b>"
 
 # good
-safe_join([person.login, " ", content_tag(:span, person.email)])
+out = "<h1>trusted content</h1>".html_safe
+out.concat(user_content)
+=> ActiveSupport::SafeBuffer "<h1>trusted_content</h1>&lt;b&gt;hi&lt;/b&gt;"
+
+# safe, though maybe not good style
+out = "trusted content"
+result = out.concat(user_content)
+=> String "trusted content<b>hi</b>"
+# because when rendered in ERB the String will be escaped:
+<%= result %>
+=> trusted content&lt;b&gt;hi&lt;/b&gt;
+
+# bad
+(user_content + " " + content_tag(:span, user_content)).html_safe
+=> ActiveSupport::SafeBuffer "<b>hi</b> <span><b>hi</b></span>"
+
+# good
+safe_join([user_content, " ", content_tag(:span, user_content)])
+=> ActiveSupport::SafeBuffer "&lt;b&gt;hi&lt;/b&gt; <span>&lt;b&gt;hi&lt;/b&gt;</span>"
 ```
 
 ## Rails/PluralizationGrammar

--- a/spec/rubocop/cop/rails/output_safety_spec.rb
+++ b/spec/rubocop/cop/rails/output_safety_spec.rb
@@ -3,6 +3,14 @@
 describe RuboCop::Cop::Rails::OutputSafety do
   subject(:cop) { described_class.new }
 
+  it 'registers an offense for safe_concat methods' do
+    source = <<-END.strip_indent
+      foo.safe_concat('bar')
+    END
+    inspect_source(cop, source)
+    expect(cop.offenses.size).to eq(1)
+  end
+
   it 'registers an offense for html_safe methods with a receiver and no ' \
      'arguments' do
     source = <<-END.strip_indent
@@ -65,6 +73,13 @@ describe RuboCop::Cop::Rails::OutputSafety do
     END
     inspect_source(cop, source)
     expect(cop.offenses).to be_empty
+  end
+
+  it 'does not accept safe_concat methods when wrapped in a safe_join' do
+    source = 'safe_join([i18n_text.safe_concat(i18n_text),
+              i18n_text.safe_concat(i18n_mode_additional_markup(key))])'
+    inspect_source(cop, source)
+    expect(cop.offenses.size).to eq(2)
   end
 
   it 'does not accept raw methods when wrapped in a safe_join' do


### PR DESCRIPTION
Hi again! This is a follow-up PR from https://github.com/bbatsov/rubocop/pull/4320 (thanks for the speedy review!).

At Betterment, we built a custom cop to use alongside `Rails/OutputSafety` to disallow usage of `safe_concat`. Given that this custom cop is really an extension of `Rails/OutputSafety`, we'd love to integrate its behavior into the mainline `Rails/OutputSafety` cop.

## Proposed Change

I would like to propose changing the behavior of the `Rails/OutputSafety` cop to disallow usage of `safe_concat` in addition to disallowing usage of `raw` and `html_safe`. `safe_concat` should only be used when the cop is explicitly disabled.

## Why

In summary, `safe_concat` is an act of blessing content as "safe" as is, without escaping it, in a sense providing the same behavior as `raw` and `html_safe`.

I'm proposing this change because `safe_concat` is a means to bless content as "safe" by returning a `SafeBuffer` containing the content as is. This mirrors the functionality of `raw` and `html_safe`, which the `Rails/OutputSafety` cop tells us to avoid. To demonstrate how `raw` works:

```ruby
[1] pry(main)> include ActionView::Helpers::TextHelper
=> Object
[2] pry(main)> raw_markup = raw("<p>hi</p>")
=> "<p>hi</p>"
[3] pry(main)> raw_markup.class
=> ActiveSupport::SafeBuffer
```

If we use `safe_concat` to concatenate a string here, the string we concatenate to the `SafeBuffer` is not escaped. Rather, it is just marked "safe" by returning a `SafeBuffer` containing the original content concatenated with the new content, like so:

```ruby
[4] pry(main)> result = raw_markup.safe_concat("<p>bye</p>")
=> "<p>hi</p><p>bye</p>"
[5] pry(main)> result.class
=> ActiveSupport::SafeBuffer
```

Alternatively, if we use `concat` to concatenate the content to the `SafeBuffer`, the new content is escaped and a `SafeBuffer` is returned containing the full content, like so:

```ruby
[6] pry(main)> result = raw_markup.concat("<p>bye</p>")
=> "<p>hi</p><p>bye</p>&lt;p&gt;bye&lt;/p&gt;"
[7] pry(main)> result.class
=> ActiveSupport::SafeBuffer
```

Therefore, if the `Rails/OutputSafety` cop tells us that we should not use `raw` or `html_safe` without explicitly disabling it (and to prefer to use `safe_join` for joining), the cop should also tell us that we should not use `safe_concat` without explicitly disabling it (and to prefer to use `concat` for concatenating).

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Used the same coding conventions as the rest of the project.
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [ ] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] All tests are passing.
* [x] The new code doesn't generate RuboCop offenses.
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Updated cop documentation with `rake generate_cops_documentation` (required only when you've added a new cop or changed the configuration/documentation of an existing cop).

[1]: http://chris.beams.io/posts/git-commit/
