### PR TITLE
[Fix #4327] Prevent `Layout/SpaceInsidePercentLiteralDelimiters` from registering offenses on execute-strings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,7 @@
 * [#4310](https://github.com/bbatsov/rubocop/pull/4310): Treat paths containing invalid byte sequences as non-matches. ([@mclark][])
 * [#4339](https://github.com/bbatsov/rubocop/pull/4339): Fix false positive in `Security/Eval` cop for multiline string lietral. ([@pocke][])
 * [#4339](https://github.com/bbatsov/rubocop/pull/4339): Fix false negative in `Security/Eval` cop for `Binding#eval`. ([@pocke][])
+* [#4327](https://github.com/bbatsov/rubocop/issues/4327): Prevent `Layout/SpaceInsidePercentLiteralDelimiters` from registering offenses on execute-strings. ([@drenmi][])
 
 ## 0.48.1 (2017-04-03)
 

--- a/lib/rubocop/cop/layout/space_inside_percent_literal_delimiters.rb
+++ b/lib/rubocop/cop/layout/space_inside_percent_literal_delimiters.rb
@@ -7,13 +7,14 @@ module RuboCop
       # %i/%w/%x literals.
       #
       # @example
-      #   @good
+      #
+      #   # good
       #   %i(foo bar baz)
       #
-      #   @bad
+      #   # bad
       #   %w( foo bar baz )
       #
-      #   @bad
+      #   # bad
       #   %x(  ls -l )
       class SpaceInsidePercentLiteralDelimiters < Cop
         include MatchRange
@@ -27,11 +28,11 @@ module RuboCop
           process(node, '%i', '%I', '%w', '%W')
         end
 
-        def on_percent_literal(node)
-          add_offenses_for_unnecessary_spaces(node)
+        def on_xstr(node)
+          process(node, '%x')
         end
 
-        def on_xstr(node)
+        def on_percent_literal(node)
           add_offenses_for_unnecessary_spaces(node)
         end
 

--- a/spec/rubocop/cop/layout/space_inside_percent_literal_delimiters_spec.rb
+++ b/spec/rubocop/cop/layout/space_inside_percent_literal_delimiters_spec.rb
@@ -100,4 +100,10 @@ describe RuboCop::Cop::Layout::SpaceInsidePercentLiteralDelimiters do
       expect(cop.messages).to be_empty
     end
   end
+
+  it 'accepts execute-string literals' do
+    inspect_source(cop, '` curl `')
+
+    expect(cop.messages).to be_empty
+  end
 end


### PR DESCRIPTION
This cop would register offenses on execute-strings, e.g.:

```ruby
result = ` curl `
```

despite its name indicating that it only operates on percent literals.

This was caused by the `#on_xstr` not invoking `#process` (which checks that the node is a percent literal), but instead directly registering an offense.

This change fixes that.

-----------------

Before submitting the PR make sure the following are checked:

* [X] Wrote [good commit messages][1].
* [X] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [X] Used the same coding conventions as the rest of the project.
* [X] Feature branch is up-to-date with `master` (if not - rebase it).
* [X] Squashed related commits together.
* [X] Added tests.
* [X] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [X] All tests are passing.
* [X] The new code doesn't generate RuboCop offenses.
* [X] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [X] Updated cop documentation with `rake generate_cops_documentation` (required only when you've added a new cop or changed the configuration/documentation of an existing cop).

[1]: http://chris.beams.io/posts/git-commit/
