### PR TITLE
Add autocorrect support to Style/ConstantName

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@
 * [#3400](https://github.com/bbatsov/rubocop/issues/3400): Remove auto-correct support from Lint/Debugger. ([@ilansh][])
 * [#4278](https://github.com/bbatsov/rubocop/pull/4278): Move all cops dealing with whitespace into a new department called `Layout`. ([@jonas054][])
 * [#4320](https://github.com/bbatsov/rubocop/pull/4320): Update `Rails/OutputSafety` to disallow wrapping `raw` or `html_safe` with `safe_join`. ([@klesse413][])
+* [#4349](https://github.com/bbatsov/rubocop/pull/4349): Add Autocorrect support to `Style/ConstantName`. ([@bardec][])
 
 ### Bug fixes
 
@@ -2769,3 +2770,4 @@
 [@ilansh]: https://github.com/ilansh
 [@mclark]: https://github.com/mclark
 [@klesse413]: https://github.com/klesse413
+[@bardec]: https://github.com/bardec

--- a/lib/rubocop/cop/style/constant_name.rb
+++ b/lib/rubocop/cop/style/constant_name.rb
@@ -11,6 +11,7 @@ module RuboCop
       class ConstantName < Cop
         MSG = 'Use SCREAMING_SNAKE_CASE for constants.'.freeze
         SNAKE_CASE = /^[\dA-Z_]+$/
+        CAMEL_CASE_BREAKS = /(?<=[a-z])(?=[A-Z])/
 
         def on_casgn(node)
           _scope, const_name, value = *node
@@ -22,6 +23,27 @@ module RuboCop
           return if value && %i[send block const].include?(value.type)
 
           add_offense(node, :name) if const_name !~ SNAKE_CASE
+        end
+
+        private
+
+        def autocorrect(node)
+          _scope, const_name, value = *node
+
+          new_const_name = snake_const(const_name)
+
+          lambda do |corrector|
+            corrector.replace(node.source_range,
+                              "#{new_const_name} = #{value.source}")
+          end
+        end
+
+        def snake_const(const_name)
+          const_name
+            .to_s
+            .split(CAMEL_CASE_BREAKS)
+            .join('_')
+            .upcase
         end
       end
     end

--- a/manual/cops_style.md
+++ b/manual/cops_style.md
@@ -606,7 +606,7 @@ IncludeTernaryExpressions | true
 
 Enabled by default | Supports autocorrection
 --- | ---
-Enabled | No
+Enabled | Yes
 
 This cop checks whether constant names are written using
 SCREAMING_SNAKE_CASE.

--- a/spec/rubocop/cop/style/constant_name_spec.rb
+++ b/spec/rubocop/cop/style/constant_name_spec.rb
@@ -61,4 +61,14 @@ describe RuboCop::Cop::Style::ConstantName do
     END
     expect(cop.offenses.size).to eq(2)
   end
+
+  it 'auto-corrects camel case to screaming snake case' do
+    new_source = autocorrect_source(cop, 'ConstantName = 5')
+    expect(new_source).to eq 'CONSTANT_NAME = 5'
+  end
+
+  it 'correctly auto-corrects camel cased initialisms' do
+    new_source = autocorrect_source(cop, 'ConstantCSV = 5')
+    expect(new_source).to eq 'CONSTANT_CSV = 5'
+  end
 end


### PR DESCRIPTION
Autocorrect support is something that is likely wanted and easy to support for CamelCased constant naming fixes.
In order to support initialisms (FBI, CSV, etc.) used in many constant namings it will do the following:

```
ConstantCSV -> CONSTANT_CSV
ConstantValue -> CONSTANT_VALUE
```

Let me know if this was already suggested at some point and not wanted. Seemed like something I wanted on a company project, so I figured I'd do it real quick :) 

Love this project!
-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Used the same coding conventions as the rest of the project.
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] All tests are passing.
* [x] The new code doesn't generate RuboCop offenses.
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Updated cop documentation with `rake generate_cops_documentation` (required only when you've added a new cop or changed the configuration/documentation of an existing cop).

[1]: http://chris.beams.io/posts/git-commit/
