### PR TITLE
[Fix #4336] Store rubocop_cache in safer directories

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@
 * [#3400](https://github.com/bbatsov/rubocop/issues/3400): Remove auto-correct support from Lint/Debugger. ([@ilansh][])
 * [#4278](https://github.com/bbatsov/rubocop/pull/4278): Move all cops dealing with whitespace into a new department called `Layout`. ([@jonas054][])
 * [#4320](https://github.com/bbatsov/rubocop/pull/4320): Update `Rails/OutputSafety` to disallow wrapping `raw` or `html_safe` with `safe_join`. ([@klesse413][])
+* [#4336](https://github.com/bbatsov/rubocop/issues/4336): Store `rubocop_cache` in safer directories. ([@jonas054][])
 
 ### Bug fixes
 

--- a/config/default.yml
+++ b/config/default.yml
@@ -95,18 +95,17 @@ AllCops:
   # Threshold for how many files can be stored in the result cache before some
   # of the files are automatically removed.
   MaxFilesInCache: 20000
-  # The cache will be stored in "rubocop_cache" under this directory. The name
-  # "/tmp" is special and will be converted to the system temporary directory,
-  # which is "/tmp" on Unix-like systems, but could be something else on other
-  # systems.
-  CacheRootDirectory: /tmp
-  # The default cache root directory is /tmp, which on most systems is
-  # writable by any system user. This means that it is possible for a
-  # malicious user to anticipate the location of Rubocop's cache directory,
-  # and create a symlink in its place that could cause Rubocop to overwrite
-  # unintended files, or read malicious input. If you are certain that your
-  # cache location is secure from this kind of attack, and wish to use a
-  # symlinked cache location, set this value to "true".
+  # The cache will be stored in "rubocop_cache" under this directory. If
+  # CacheRootDirectory is ~ (nil), which it is by default, the root will be
+  # taken from the environment variable `$XDG_CACHE_HOME` if it is set, or if
+  # `$XDG_CACHE_HOME` is not set, it will be `$HOME/.cache/`.
+  CacheRootDirectory: ~
+  # It is possible for a malicious user to know the location of RuboCop's cache
+  # directory by looking at CacheRootDirectory, and create a symlink in its
+  # place that could cause RuboCop to overwrite unintended files, or read
+  # malicious input. If you are certain that your cache location is secure from
+  # this kind of attack, and wish to use a symlinked cache location, set this
+  # value to "true".
   AllowSymlinksInCacheRootDirectory: false
   # What MRI version of the Ruby interpreter is the inspected code intended to
   # run on? (If there is more than one, set this to the lowest version.)

--- a/lib/rubocop/result_cache.rb
+++ b/lib/rubocop/result_cache.rb
@@ -2,7 +2,6 @@
 
 require 'digest/md5'
 require 'find'
-require 'tmpdir'
 require 'etc'
 
 module RuboCop
@@ -63,11 +62,13 @@ module RuboCop
 
     def self.cache_root(config_store)
       root = config_store.for('.').for_all_cops['CacheRootDirectory']
-      if root == '/tmp'
-        tmpdir = File.realpath(Dir.tmpdir)
-        # Include user ID in the path to make sure the user has write access.
-        root = File.join(tmpdir, Process.uid.to_s)
-      end
+      root ||= if ENV.key?('XDG_CACHE_HOME')
+                 # Include user ID in the path to make sure the user has write
+                 # access.
+                 File.join(ENV['XDG_CACHE_HOME'], Process.uid.to_s)
+               else
+                 File.join(ENV['HOME'], '.cache')
+               end
       File.join(root, 'rubocop_cache')
     end
 

--- a/manual/caching.md
+++ b/manual/caching.md
@@ -30,14 +30,15 @@ overrides the setting.
 
 ### Cache Path
 
-By default, the cache is stored in a subdirectory of the temporary
-directory, `/tmp/rubocop_cache/` on Unix-like systems. The
-configuration parameter `AllCops: CacheRootDirectory` can be used to
-set it to a different path. One reason to use this option could be
-that there's a network disk where users on different machines want to
-have a common RuboCop cache. Another could be that a Continuous
-Integration system allows directories, but not a temporary directory,
-to be saved between runs.
+By default, the cache is stored in either
+`$XDG_CACHE_HOME/rubocop_cache` if `$XDG_CACHE_HOME` is set, or in
+`$HOME/.cache/rubocop_cache/` if it's not.  The configuration parameter
+`AllCops: CacheRootDirectory` can be used to set the root to a
+different path. One reason to use this option could be that there's a
+network disk where users on different machines want to have a common
+RuboCop cache. Another could be that a Continuous Integration system
+allows directories, but not a temporary directory, to be saved between
+runs.
 
 ### Cache Pruning
 


### PR DESCRIPTION
A malicious person could pre-create directories and set write access on them so that their contents could be tampered with when RuboCop has written cache files there.

We follow the recommendations of https://standards.freedesktop.org/basedir-spec/basedir-spec-latest.html to avoid these problems.

A functional difference is now is that the support for translating `CacheRootDirectory: /tmp` to the system temporary directory is removed. The default `CacheRootDirectory` is `nil` (~ in YAML), which normally means `$HOME/.cache`, so no reason to encourage the use of `/tmp`.