### PR TITLE
Rewrite specs to use `expect_no_offenses`

### DIFF
--- a/spec/rubocop/cop/layout/access_modifier_indentation_spec.rb
+++ b/spec/rubocop/cop/layout/access_modifier_indentation_spec.rb
@@ -165,7 +165,7 @@ describe RuboCop::Cop::Layout::AccessModifierIndentation do
     end
 
     it 'accepts properly indented private' do
-      inspect_source(cop, <<-END.strip_indent)
+      expect_no_offenses(<<-END.strip_indent)
         class Test
 
           private
@@ -173,11 +173,10 @@ describe RuboCop::Cop::Layout::AccessModifierIndentation do
           def test; end
         end
       END
-      expect(cop.offenses).to be_empty
     end
 
     it 'accepts properly indented protected' do
-      inspect_source(cop, <<-END.strip_indent)
+      expect_no_offenses(<<-END.strip_indent)
         class Test
 
           protected
@@ -185,26 +184,23 @@ describe RuboCop::Cop::Layout::AccessModifierIndentation do
           def test; end
         end
       END
-      expect(cop.offenses).to be_empty
     end
 
     it 'accepts an empty class' do
-      inspect_source(cop, <<-END.strip_indent)
+      expect_no_offenses(<<-END.strip_indent)
         class Test
         end
       END
-      expect(cop.offenses).to be_empty
     end
 
     it 'accepts methods with a body' do
-      inspect_source(cop, <<-END.strip_indent)
+      expect_no_offenses(<<-END.strip_indent)
         module Test
           def test
             foo
           end
         end
       END
-      expect(cop.offenses).to be_empty
     end
 
     it 'handles properly nested classes' do
@@ -255,7 +251,7 @@ describe RuboCop::Cop::Layout::AccessModifierIndentation do
       let(:indentation_width) { 4 }
 
       it 'accepts properly indented private' do
-        inspect_source(cop, <<-END.strip_indent)
+        expect_no_offenses(<<-END.strip_indent)
           class Test
 
               private
@@ -263,7 +259,6 @@ describe RuboCop::Cop::Layout::AccessModifierIndentation do
               def test; end
           end
         END
-        expect(cop.offenses).to be_empty
       end
     end
 
@@ -273,7 +268,7 @@ describe RuboCop::Cop::Layout::AccessModifierIndentation do
       end
 
       it 'accepts properly indented private' do
-        inspect_source(cop, <<-END.strip_indent)
+        expect_no_offenses(<<-END.strip_indent)
           class Test
 
               private
@@ -281,7 +276,6 @@ describe RuboCop::Cop::Layout::AccessModifierIndentation do
             def test; end
           end
         END
-        expect(cop.offenses).to be_empty
       end
     end
   end
@@ -372,7 +366,7 @@ describe RuboCop::Cop::Layout::AccessModifierIndentation do
     end
 
     it 'accepts private indented to the containing class indent level' do
-      inspect_source(cop, <<-END.strip_indent)
+      expect_no_offenses(<<-END.strip_indent)
         class Test
 
         private
@@ -380,11 +374,10 @@ describe RuboCop::Cop::Layout::AccessModifierIndentation do
           def test; end
         end
       END
-      expect(cop.offenses).to be_empty
     end
 
     it 'accepts protected indented to the containing class indent level' do
-      inspect_source(cop, <<-END.strip_indent)
+      expect_no_offenses(<<-END.strip_indent)
         class Test
 
         protected
@@ -392,7 +385,6 @@ describe RuboCop::Cop::Layout::AccessModifierIndentation do
           def test; end
         end
       END
-      expect(cop.offenses).to be_empty
     end
 
     it 'handles properly nested classes' do

--- a/spec/rubocop/cop/layout/align_array_spec.rb
+++ b/spec/rubocop/cop/layout/align_array_spec.rb
@@ -19,7 +19,7 @@ describe RuboCop::Cop::Layout::AlignArray do
   end
 
   it 'accepts aligned array keys' do
-    inspect_source(cop, <<-END.strip_indent)
+    expect_no_offenses(<<-END.strip_indent)
       array = [
         a,
         b,
@@ -27,7 +27,6 @@ describe RuboCop::Cop::Layout::AlignArray do
         d
       ]
     END
-    expect(cop.offenses).to be_empty
   end
 
   it 'accepts single line array' do
@@ -35,19 +34,17 @@ describe RuboCop::Cop::Layout::AlignArray do
   end
 
   it 'accepts several elements per line' do
-    inspect_source(cop, <<-END.strip_indent)
+    expect_no_offenses(<<-END.strip_indent)
       array = [ a, b,
                 c, d ]
     END
-    expect(cop.offenses).to be_empty
   end
 
   it 'accepts aligned array with fullwidth characters' do
-    inspect_source(cop, <<-END.strip_indent)
+    expect_no_offenses(<<-END.strip_indent)
       puts 'Ｒｕｂｙ', [ a,
                          b ]
     END
-    expect(cop.offenses).to be_empty
   end
 
   it 'auto-corrects alignment' do

--- a/spec/rubocop/cop/layout/align_array_spec.rb
+++ b/spec/rubocop/cop/layout/align_array_spec.rb
@@ -31,8 +31,7 @@ describe RuboCop::Cop::Layout::AlignArray do
   end
 
   it 'accepts single line array' do
-    inspect_source(cop, 'array = [ a, b ]')
-    expect(cop.offenses).to be_empty
+    expect_no_offenses('array = [ a, b ]')
   end
 
   it 'accepts several elements per line' do

--- a/spec/rubocop/cop/layout/align_hash_spec.rb
+++ b/spec/rubocop/cop/layout/align_hash_spec.rb
@@ -5,8 +5,7 @@ describe RuboCop::Cop::Layout::AlignHash, :config do
 
   shared_examples 'not on separate lines' do
     it 'accepts single line hash' do
-      inspect_source(cop, 'func(a: 0, bb: 1)')
-      expect(cop.offenses).to be_empty
+      expect_no_offenses('func(a: 0, bb: 1)')
     end
 
     it 'accepts several pairs per line' do
@@ -215,8 +214,7 @@ describe RuboCop::Cop::Layout::AlignHash, :config do
       end
 
       it 'accepts an empty hash' do
-        inspect_source(cop, 'h = {}')
-        expect(cop.offenses).to be_empty
+        expect_no_offenses('h = {}')
       end
     end
 
@@ -311,8 +309,7 @@ describe RuboCop::Cop::Layout::AlignHash, :config do
     end
 
     it 'accepts an empty hash' do
-      inspect_source(cop, 'h = {}')
-      expect(cop.offenses).to be_empty
+      expect_no_offenses('h = {}')
     end
 
     it 'accepts a multiline array of single line hashes' do
@@ -433,8 +430,7 @@ describe RuboCop::Cop::Layout::AlignHash, :config do
     end
 
     it 'accepts a single method argument entry with colon' do
-      inspect_source(cop, 'merge(parent: nil)')
-      expect(cop.offenses).to be_empty
+      expect_no_offenses('merge(parent: nil)')
     end
   end
 
@@ -479,8 +475,7 @@ describe RuboCop::Cop::Layout::AlignHash, :config do
     end
 
     it 'accepts an empty hash' do
-      inspect_source(cop, 'h = {}')
-      expect(cop.offenses).to be_empty
+      expect_no_offenses('h = {}')
     end
 
     it 'registers an offense for misaligned hash values' do

--- a/spec/rubocop/cop/layout/align_hash_spec.rb
+++ b/spec/rubocop/cop/layout/align_hash_spec.rb
@@ -9,11 +9,10 @@ describe RuboCop::Cop::Layout::AlignHash, :config do
     end
 
     it 'accepts several pairs per line' do
-      inspect_source(cop, <<-END.strip_indent)
+      expect_no_offenses(<<-END.strip_indent)
         func(a: 1, bb: 2,
              ccc: 3, dddd: 4)
       END
-      expect(cop.offenses).to be_empty
     end
 
     it "does not auto-correct pairs that don't start a line" do
@@ -65,19 +64,17 @@ describe RuboCop::Cop::Layout::AlignHash, :config do
     end
 
     it 'accepts misaligned keys in implicit hash' do
-      inspect_source(cop, <<-END.strip_indent)
+      expect_no_offenses(<<-END.strip_indent)
         func(a: 0,
           b: 1)
       END
-      expect(cop.offenses).to be_empty
     end
 
     it 'accepts misaligned keys in explicit hash' do
-      inspect_source(cop, <<-END.strip_indent)
+      expect_no_offenses(<<-END.strip_indent)
         func({a: 0,
           b: 1})
       END
-      expect(cop.offenses).to be_empty
     end
   end
 
@@ -89,11 +86,10 @@ describe RuboCop::Cop::Layout::AlignHash, :config do
     end
 
     it 'accepts misaligned keys in implicit hash' do
-      inspect_source(cop, <<-END.strip_indent)
+      expect_no_offenses(<<-END.strip_indent)
         func(a: 0,
           b: 1)
       END
-      expect(cop.offenses).to be_empty
     end
 
     it 'registers offense for misaligned keys in explicit hash' do
@@ -121,11 +117,10 @@ describe RuboCop::Cop::Layout::AlignHash, :config do
     end
 
     it 'accepts misaligned keys in explicit hash' do
-      inspect_source(cop, <<-END.strip_indent)
+      expect_no_offenses(<<-END.strip_indent)
         func({a: 0,
           b: 1})
       END
-      expect(cop.offenses).to be_empty
     end
   end
 
@@ -164,7 +159,7 @@ describe RuboCop::Cop::Layout::AlignHash, :config do
     end
 
     it 'accepts aligned hash keys' do
-      inspect_source(cop, <<-END.strip_indent)
+      expect_no_offenses(<<-END.strip_indent)
         hash1 = {
           a: 0,
           bb: 1,
@@ -174,7 +169,6 @@ describe RuboCop::Cop::Layout::AlignHash, :config do
           'dddd'  =>  2
         }
       END
-      expect(cop.offenses).to be_empty
     end
 
     it 'registers an offense for separator alignment' do
@@ -206,11 +200,10 @@ describe RuboCop::Cop::Layout::AlignHash, :config do
       end
 
       it 'accepts aligned hash keys' do
-        inspect_source(cop, <<-END.strip_indent)
+        expect_no_offenses(<<-END.strip_indent)
           func(a: 0,
                b: 1)
         END
-        expect(cop.offenses).to be_empty
       end
 
       it 'accepts an empty hash' do
@@ -295,7 +288,7 @@ describe RuboCop::Cop::Layout::AlignHash, :config do
     include_examples 'not on separate lines'
 
     it 'accepts aligned hash keys and values' do
-      inspect_source(cop, <<-END.strip_indent)
+      expect_no_offenses(<<-END.strip_indent)
         hash1 = {
           'a'   => 0,
           'bbb' => 1
@@ -305,7 +298,6 @@ describe RuboCop::Cop::Layout::AlignHash, :config do
           bbb: 1
         }
       END
-      expect(cop.offenses).to be_empty
     end
 
     it 'accepts an empty hash' do
@@ -313,7 +305,7 @@ describe RuboCop::Cop::Layout::AlignHash, :config do
     end
 
     it 'accepts a multiline array of single line hashes' do
-      inspect_source(cop, <<-END.strip_indent)
+      expect_no_offenses(<<-END.strip_indent)
         def self.scenarios_order
             [
               { before:   %w( l k ) },
@@ -323,39 +315,35 @@ describe RuboCop::Cop::Layout::AlignHash, :config do
             ]
           end
       END
-      expect(cop.offenses).to be_empty
     end
 
     it 'accepts hashes that use different separators' do
-      inspect_source(cop, <<-END.strip_indent)
+      expect_no_offenses(<<-END.strip_indent)
         hash = {
           a: 1,
           'bbb' => 2
         }
       END
-      expect(cop.offenses).to be_empty
     end
 
     context 'ruby >= 2.0', :ruby20 do
       it 'accepts hashes that use different separators and double splats' do
-        inspect_source(cop, <<-END.strip_indent)
+        expect_no_offenses(<<-END.strip_indent)
           hash = {
             a: 1,
             'bbb' => 2,
             **foo
           }
         END
-        expect(cop.offenses).to be_empty
       end
 
       it 'accepts hashes that use different separators and double splats' do
-        inspect_source(cop, <<-END.strip_indent)
+        expect_no_offenses(<<-END.strip_indent)
           hash = {
             a: 1,
             **kw
           }
         END
-        expect(cop.offenses).to be_empty
       end
     end
 
@@ -461,7 +449,7 @@ describe RuboCop::Cop::Layout::AlignHash, :config do
     end
 
     it 'accepts aligned hash keys' do
-      inspect_source(cop, <<-END.strip_indent)
+      expect_no_offenses(<<-END.strip_indent)
         hash1 = {
             a: 0,
           bbb: 1
@@ -471,7 +459,6 @@ describe RuboCop::Cop::Layout::AlignHash, :config do
           'bbb' => 1
         }
       END
-      expect(cop.offenses).to be_empty
     end
 
     it 'accepts an empty hash' do
@@ -500,13 +487,11 @@ describe RuboCop::Cop::Layout::AlignHash, :config do
 
     context 'ruby >= 2.0', :ruby20 do
       it 'accepts hashes with different separators' do
-        inspect_source(cop, <<-END.strip_indent)
+        expect_no_offenses(<<-END.strip_indent)
           {a: 1,
             'b' => 2,
              **params}
         END
-
-        expect(cop.offenses).to be_empty
       end
     end
 
@@ -569,7 +554,7 @@ describe RuboCop::Cop::Layout::AlignHash, :config do
     end
 
     it 'accepts aligned entries' do
-      inspect_source(cop, <<-END.strip_indent)
+      expect_no_offenses(<<-END.strip_indent)
         hash1 = {
             a: 0,
           bbb: 1
@@ -579,7 +564,6 @@ describe RuboCop::Cop::Layout::AlignHash, :config do
           'bbb' => 1
         }
       END
-      expect(cop.offenses).to be_empty
     end
   end
 end

--- a/spec/rubocop/cop/layout/align_parameters_spec.rb
+++ b/spec/rubocop/cop/layout/align_parameters_spec.rb
@@ -35,29 +35,26 @@ describe RuboCop::Cop::Layout::AlignParameters do
     end
 
     it 'accepts multiline []= method call' do
-      inspect_source(cop, <<-END.strip_indent)
+      expect_no_offenses(<<-END.strip_indent)
         Test.config["something"] =
          true
       END
-      expect(cop.offenses).to be_empty
     end
 
     it 'accepts correctly aligned parameters' do
-      inspect_source(cop, <<-END.strip_indent)
+      expect_no_offenses(<<-END.strip_indent)
         function(a,
                  0, 1,
                  (x + y),
                  if b then c else d end)
       END
-      expect(cop.offenses).to be_empty
     end
 
     it 'accepts correctly aligned parameters with fullwidth characters' do
-      inspect_source(cop, <<-END.strip_indent)
+      expect_no_offenses(<<-END.strip_indent)
         f 'Ｒｕｂｙ', g(a,
                         b)
       END
-      expect(cop.offenses).to be_empty
     end
 
     it 'accepts calls that only span one line' do
@@ -65,11 +62,10 @@ describe RuboCop::Cop::Layout::AlignParameters do
     end
 
     it "doesn't get confused by a symbol argument" do
-      inspect_source(cop, <<-END.strip_indent)
+      expect_no_offenses(<<-END.strip_indent)
         add_offense(index,
                     MSG % kind)
       END
-      expect(cop.offenses).to be_empty
     end
 
     it "doesn't get confused by splat operator" do
@@ -100,27 +96,24 @@ describe RuboCop::Cop::Layout::AlignParameters do
     end
 
     it 'can handle a correctly aligned string literal as first argument' do
-      inspect_source(cop, <<-END.strip_indent)
+      expect_no_offenses(<<-END.strip_indent)
         add_offense(x,
                     a)
       END
-      expect(cop.offenses).to be_empty
     end
 
     it 'can handle a string literal as other argument' do
-      inspect_source(cop, <<-END.strip_indent)
+      expect_no_offenses(<<-END.strip_indent)
         add_offense(
                     "", a)
       END
-      expect(cop.offenses).to be_empty
     end
 
     it "doesn't get confused by a line break inside a parameter" do
-      inspect_source(cop, <<-END.strip_indent)
+      expect_no_offenses(<<-END.strip_indent)
         read(path, { headers:    true,
                      converters: :numeric })
       END
-      expect(cop.offenses).to be_empty
     end
 
     it "doesn't get confused by symbols with embedded expressions" do
@@ -132,11 +125,10 @@ describe RuboCop::Cop::Layout::AlignParameters do
     end
 
     it 'accepts braceless hashes' do
-      inspect_source(cop, <<-END.strip_indent)
+      expect_no_offenses(<<-END.strip_indent)
         run(collection, :entry_name => label,
                         :paginator  => paginator)
       END
-      expect(cop.offenses).to be_empty
     end
 
     it 'accepts the first parameter being on a new row' do
@@ -150,7 +142,7 @@ describe RuboCop::Cop::Layout::AlignParameters do
     end
 
     it 'can handle heredoc strings' do
-      inspect_source(cop, <<-'END'.strip_indent)
+      expect_no_offenses(<<-'END'.strip_indent)
         class_eval(<<-EOS, __FILE__, __LINE__ + 1)
                     def run_#{name}_callbacks(*args)
                       a = 1
@@ -158,17 +150,15 @@ describe RuboCop::Cop::Layout::AlignParameters do
                     end
                     EOS
       END
-      expect(cop.offenses).to be_empty
     end
 
     it 'can handle a method call within a method call' do
-      inspect_source(cop, <<-END.strip_indent)
+      expect_no_offenses(<<-END.strip_indent)
         a(a1,
           b(b1,
             b2),
           a2)
       END
-      expect(cop.offenses).to be_empty
     end
 
     it 'can handle a call embedded in a string' do
@@ -204,12 +194,11 @@ describe RuboCop::Cop::Layout::AlignParameters do
     end
 
     it 'can handle a multiline hash as second parameter' do
-      inspect_source(cop, <<-END.strip_indent)
+      expect_no_offenses(<<-END.strip_indent)
         tag(:input, {
           :value => value
         })
       END
-      expect(cop.offenses).to be_empty
     end
 
     it 'can handle method calls without parentheses' do
@@ -260,38 +249,34 @@ describe RuboCop::Cop::Layout::AlignParameters do
       end
 
       it 'accepts parameter lists on a single line' do
-        inspect_source(cop, <<-END.strip_indent)
+        expect_no_offenses(<<-END.strip_indent)
           def method(a, b)
           end
         END
-        expect(cop.offenses).to be_empty
       end
 
       it 'accepts proper indentation' do
-        inspect_source(cop, <<-END.strip_indent)
+        expect_no_offenses(<<-END.strip_indent)
           def method(a,
                      b)
           end
         END
-        expect(cop.offenses).to be_empty
       end
 
       it 'accepts the first parameter being on a new row' do
-        inspect_source(cop, <<-END.strip_indent)
+        expect_no_offenses(<<-END.strip_indent)
           def method(
             a,
             b)
           end
         END
-        expect(cop.offenses).to be_empty
       end
 
       it 'accepts a method definition without parameters' do
-        inspect_source(cop, <<-END.strip_indent)
+        expect_no_offenses(<<-END.strip_indent)
           def method
           end
         END
-        expect(cop.offenses).to be_empty
       end
 
       it "doesn't get confused by splat" do
@@ -330,12 +315,11 @@ describe RuboCop::Cop::Layout::AlignParameters do
         end
 
         it 'accepts proper indentation' do
-          inspect_source(cop, <<-END.strip_indent)
+          expect_no_offenses(<<-END.strip_indent)
             def self.method(a,
                             b)
             end
           END
-          expect(cop.offenses).to be_empty
         end
 
         it 'auto-corrects alignment' do
@@ -601,38 +585,34 @@ describe RuboCop::Cop::Layout::AlignParameters do
       end
 
       it 'accepts parameter lists on a single line' do
-        inspect_source(cop, <<-END.strip_indent)
+        expect_no_offenses(<<-END.strip_indent)
           def method(a, b)
           end
         END
-        expect(cop.offenses).to be_empty
       end
 
       it 'accepts proper indentation' do
-        inspect_source(cop, <<-END.strip_indent)
+        expect_no_offenses(<<-END.strip_indent)
           def method(a,
             b)
           end
         END
-        expect(cop.offenses).to be_empty
       end
 
       it 'accepts the first parameter being on a new row' do
-        inspect_source(cop, <<-END.strip_indent)
+        expect_no_offenses(<<-END.strip_indent)
           def method(
             a,
             b)
           end
         END
-        expect(cop.offenses).to be_empty
       end
 
       it 'accepts a method definition without parameters' do
-        inspect_source(cop, <<-END.strip_indent)
+        expect_no_offenses(<<-END.strip_indent)
           def method
           end
         END
-        expect(cop.offenses).to be_empty
       end
 
       it "doesn't get confused by splat" do
@@ -671,12 +651,11 @@ describe RuboCop::Cop::Layout::AlignParameters do
         end
 
         it 'accepts proper indentation' do
-          inspect_source(cop, <<-END.strip_indent)
+          expect_no_offenses(<<-END.strip_indent)
             def self.method(a,
               b)
             end
           END
-          expect(cop.offenses).to be_empty
         end
 
         it 'auto-corrects alignment' do

--- a/spec/rubocop/cop/layout/align_parameters_spec.rb
+++ b/spec/rubocop/cop/layout/align_parameters_spec.rb
@@ -61,8 +61,7 @@ describe RuboCop::Cop::Layout::AlignParameters do
     end
 
     it 'accepts calls that only span one line' do
-      inspect_source(cop, 'find(path, s, @special[sexp[0]])')
-      expect(cop.offenses).to be_empty
+      expect_no_offenses('find(path, s, @special[sexp[0]])')
     end
 
     it "doesn't get confused by a symbol argument" do
@@ -125,13 +124,11 @@ describe RuboCop::Cop::Layout::AlignParameters do
     end
 
     it "doesn't get confused by symbols with embedded expressions" do
-      inspect_source(cop, 'send(:"#{name}_comments_path")')
-      expect(cop.offenses).to be_empty
+      expect_no_offenses('send(:"#{name}_comments_path")')
     end
 
     it "doesn't get confused by regexen with embedded expressions" do
-      inspect_source(cop, 'a(/#{name}/)')
-      expect(cop.offenses).to be_empty
+      expect_no_offenses('a(/#{name}/)')
     end
 
     it 'accepts braceless hashes' do
@@ -175,8 +172,7 @@ describe RuboCop::Cop::Layout::AlignParameters do
     end
 
     it 'can handle a call embedded in a string' do
-      inspect_source(cop, 'model("#{index(name)}", child)')
-      expect(cop.offenses).to be_empty
+      expect_no_offenses('model("#{index(name)}", child)')
     end
 
     it 'can handle do-end' do
@@ -200,13 +196,11 @@ describe RuboCop::Cop::Layout::AlignParameters do
     end
 
     it 'can handle a ternary condition with a block reference' do
-      inspect_source(cop, 'cond ? a : func(&b)')
-      expect(cop.offenses).to be_empty
+      expect_no_offenses('cond ? a : func(&b)')
     end
 
     it 'can handle parentheses used with no parameters' do
-      inspect_source(cop, 'func()')
-      expect(cop.offenses).to be_empty
+      expect_no_offenses('func()')
     end
 
     it 'can handle a multiline hash as second parameter' do
@@ -219,8 +213,7 @@ describe RuboCop::Cop::Layout::AlignParameters do
     end
 
     it 'can handle method calls without parentheses' do
-      inspect_source(cop, 'a(b c, d)')
-      expect(cop.offenses).to be_empty
+      expect_no_offenses('a(b c, d)')
     end
 
     it 'can handle other method calls without parentheses' do

--- a/spec/rubocop/cop/layout/closing_parenthesis_indentation_spec.rb
+++ b/spec/rubocop/cop/layout/closing_parenthesis_indentation_spec.rb
@@ -75,8 +75,7 @@ describe RuboCop::Cop::Layout::ClosingParenthesisIndentation do
       end
 
       it 'accepts empty ()' do
-        inspect_source(cop, 'some_method()')
-        expect(cop.offenses).to be_empty
+        expect_no_offenses('some_method()')
       end
 
       context 'with fixed indentation of parameters' do

--- a/spec/rubocop/cop/layout/closing_parenthesis_indentation_spec.rb
+++ b/spec/rubocop/cop/layout/closing_parenthesis_indentation_spec.rb
@@ -36,12 +36,11 @@ describe RuboCop::Cop::Layout::ClosingParenthesisIndentation do
       end
 
       it 'accepts a correctly aligned )' do
-        inspect_source(cop, <<-END.strip_indent)
+        expect_no_offenses(<<-END.strip_indent)
           some_method(
             a
           )
         END
-        expect(cop.offenses).to be_empty
       end
     end
 
@@ -67,11 +66,10 @@ describe RuboCop::Cop::Layout::ClosingParenthesisIndentation do
       end
 
       it 'accepts a correctly aligned )' do
-        inspect_source(cop, <<-END.strip_indent)
+        expect_no_offenses(<<-END.strip_indent)
           some_method(a
                      )
         END
-        expect(cop.offenses).to be_empty
       end
 
       it 'accepts empty ()' do
@@ -82,7 +80,7 @@ describe RuboCop::Cop::Layout::ClosingParenthesisIndentation do
         let(:align_parameters_config) { 'with_fixed_indentation' }
 
         it 'accepts a correctly indented )' do
-          inspect_source(cop, <<-END.strip_indent)
+          expect_no_offenses(<<-END.strip_indent)
             some_method(a,
               x: 1,
               y: 2
@@ -91,7 +89,6 @@ describe RuboCop::Cop::Layout::ClosingParenthesisIndentation do
               some_method(a,
               )
           END
-          expect(cop.offenses).to be_empty
         end
 
         it 'autocorrects misindented )' do
@@ -148,13 +145,12 @@ describe RuboCop::Cop::Layout::ClosingParenthesisIndentation do
       end
 
       it 'accepts a correctly aligned )' do
-        inspect_source(cop, <<-END.strip_indent)
+        expect_no_offenses(<<-END.strip_indent)
           def some_method(
             a
           )
           end
         END
-        expect(cop.offenses).to be_empty
       end
     end
 
@@ -183,20 +179,18 @@ describe RuboCop::Cop::Layout::ClosingParenthesisIndentation do
       end
 
       it 'accepts a correctly aligned )' do
-        inspect_source(cop, <<-END.strip_indent)
+        expect_no_offenses(<<-END.strip_indent)
           def some_method(a
                          )
           end
         END
-        expect(cop.offenses).to be_empty
       end
 
       it 'accepts empty ()' do
-        inspect_source(cop, <<-END.strip_indent)
+        expect_no_offenses(<<-END.strip_indent)
           def some_method()
           end
         END
-        expect(cop.offenses).to be_empty
       end
     end
   end
@@ -228,12 +222,11 @@ describe RuboCop::Cop::Layout::ClosingParenthesisIndentation do
       end
 
       it 'accepts a correctly aligned )' do
-        inspect_source(cop, <<-END.strip_indent)
+        expect_no_offenses(<<-END.strip_indent)
           w = x * (
             y + z
           )
         END
-        expect(cop.offenses).to be_empty
       end
     end
 
@@ -259,30 +252,27 @@ describe RuboCop::Cop::Layout::ClosingParenthesisIndentation do
       end
 
       it 'accepts a correctly aligned )' do
-        inspect_source(cop, <<-END.strip_indent)
+        expect_no_offenses(<<-END.strip_indent)
           w = x * (y + z
                   )
         END
-        expect(cop.offenses).to be_empty
       end
 
       it 'accepts ) that does not begin its line' do
-        inspect_source(cop, <<-END.strip_indent)
+        expect_no_offenses(<<-END.strip_indent)
           w = x * (y + z +
                   a)
         END
-        expect(cop.offenses).to be_empty
       end
     end
   end
 
   it 'accepts begin nodes that are not grouped expressions' do
-    inspect_source(cop, <<-END.strip_indent)
+    expect_no_offenses(<<-END.strip_indent)
       def a
         x
         y
       end
     END
-    expect(cop.offenses).to be_empty
   end
 end

--- a/spec/rubocop/cop/layout/comment_indentation_spec.rb
+++ b/spec/rubocop/cop/layout/comment_indentation_spec.rb
@@ -102,13 +102,12 @@ describe RuboCop::Cop::Layout::CommentIndentation do
 
     context 'with a blank line following the comment' do
       it 'accepts a correctly indented comment' do
-        inspect_source(cop, <<-END.strip_indent)
+        expect_no_offenses(<<-END.strip_indent)
           def m
             # comment
 
           end
         END
-        expect(cop.offenses).to be_empty
       end
     end
   end

--- a/spec/rubocop/cop/layout/comment_indentation_spec.rb
+++ b/spec/rubocop/cop/layout/comment_indentation_spec.rb
@@ -10,13 +10,11 @@ describe RuboCop::Cop::Layout::CommentIndentation do
 
   context 'on outer level' do
     it 'accepts a correctly indented comment' do
-      inspect_source(cop, '# comment')
-      expect(cop.offenses).to be_empty
+      expect_no_offenses('# comment')
     end
 
     it 'accepts a comment that follows code' do
-      inspect_source(cop, 'hello # comment')
-      expect(cop.offenses).to be_empty
+      expect_no_offenses('hello # comment')
     end
 
     it 'accepts a documentation comment' do

--- a/spec/rubocop/cop/layout/dot_position_spec.rb
+++ b/spec/rubocop/cop/layout/dot_position_spec.rb
@@ -28,11 +28,10 @@ describe RuboCop::Cop::Layout::DotPosition, :config do
     end
 
     it 'accepts leading do in multi-line method call' do
-      inspect_source(cop, <<-END.strip_indent)
+      expect_no_offenses(<<-END.strip_indent)
         something
           .method_name
       END
-      expect(cop.offenses).to be_empty
     end
 
     it 'does not err on method call with no dots' do
@@ -90,23 +89,21 @@ describe RuboCop::Cop::Layout::DotPosition, :config do
 
     context 'when there is an intervening line comment' do
       it 'does not register offense' do
-        inspect_source(cop, <<-END.strip_indent)
+        expect_no_offenses(<<-END.strip_indent)
           something.
           # a comment here
             method_name
         END
-        expect(cop.offenses).to be_empty
       end
     end
 
     context 'when there is an intervening blank line' do
       it 'does not register offense' do
-        inspect_source(cop, <<-END.strip_indent)
+        expect_no_offenses(<<-END.strip_indent)
           something.
 
             method_name
         END
-        expect(cop.offenses).to be_empty
       end
     end
   end
@@ -127,11 +124,10 @@ describe RuboCop::Cop::Layout::DotPosition, :config do
     end
 
     it 'accepts trailing dot in multi-line method call' do
-      inspect_source(cop, <<-END.strip_indent)
+      expect_no_offenses(<<-END.strip_indent)
         something.
           method_name
       END
-      expect(cop.offenses).to be_empty
     end
 
     it 'does not err on method call with no dots' do
@@ -151,12 +147,11 @@ describe RuboCop::Cop::Layout::DotPosition, :config do
     end
 
     it 'does not get confused by several lines of chained methods' do
-      inspect_source(cop, <<-END.strip_indent)
+      expect_no_offenses(<<-END.strip_indent)
         File.new(something).
         readlines.map.
         compact.join("\n")
       END
-      expect(cop.offenses).to be_empty
     end
 
     it 'auto-corrects leading dot in multi-line call' do

--- a/spec/rubocop/cop/layout/dot_position_spec.rb
+++ b/spec/rubocop/cop/layout/dot_position_spec.rb
@@ -36,8 +36,7 @@ describe RuboCop::Cop::Layout::DotPosition, :config do
     end
 
     it 'does not err on method call with no dots' do
-      inspect_source(cop, 'puts something')
-      expect(cop.offenses).to be_empty
+      expect_no_offenses('puts something')
     end
 
     it 'does not err on method call without a method name' do
@@ -49,8 +48,7 @@ describe RuboCop::Cop::Layout::DotPosition, :config do
     end
 
     it 'does not err on method call on same line' do
-      inspect_source(cop, 'something.method_name')
-      expect(cop.offenses).to be_empty
+      expect_no_offenses('something.method_name')
     end
 
     it 'auto-corrects trailing dot in multi-line call' do
@@ -137,8 +135,7 @@ describe RuboCop::Cop::Layout::DotPosition, :config do
     end
 
     it 'does not err on method call with no dots' do
-      inspect_source(cop, 'puts something')
-      expect(cop.offenses).to be_empty
+      expect_no_offenses('puts something')
     end
 
     it 'does not err on method call without a method name' do
@@ -150,8 +147,7 @@ describe RuboCop::Cop::Layout::DotPosition, :config do
     end
 
     it 'does not err on method call on same line' do
-      inspect_source(cop, 'something.method_name')
-      expect(cop.offenses).to be_empty
+      expect_no_offenses('something.method_name')
     end
 
     it 'does not get confused by several lines of chained methods' do

--- a/spec/rubocop/cop/layout/else_alignment_spec.rb
+++ b/spec/rubocop/cop/layout/else_alignment_spec.rb
@@ -10,8 +10,7 @@ describe RuboCop::Cop::Layout::ElseAlignment do
   end
 
   it 'accepts a ternary if' do
-    inspect_source(cop, 'cond ? func1 : func2')
-    expect(cop.offenses).to be_empty
+    expect_no_offenses('cond ? func1 : func2')
   end
 
   context 'with if statement' do
@@ -79,8 +78,7 @@ describe RuboCop::Cop::Layout::ElseAlignment do
     end
 
     it 'accepts a one line if statement' do
-      inspect_source(cop, 'if cond then func1 else func2 end')
-      expect(cop.offenses).to be_empty
+      expect_no_offenses('if cond then func1 else func2 end')
     end
 
     it 'accepts a correctly aligned if/elsif/else/end' do

--- a/spec/rubocop/cop/layout/else_alignment_spec.rb
+++ b/spec/rubocop/cop/layout/else_alignment_spec.rb
@@ -82,7 +82,7 @@ describe RuboCop::Cop::Layout::ElseAlignment do
     end
 
     it 'accepts a correctly aligned if/elsif/else/end' do
-      inspect_source(cop, <<-END.strip_indent)
+      expect_no_offenses(<<-END.strip_indent)
         if a1
           b1
         elsif a2
@@ -91,14 +91,13 @@ describe RuboCop::Cop::Layout::ElseAlignment do
           c
         end
       END
-      expect(cop.offenses).to be_empty
     end
 
     context 'for a file with byte order mark' do
       let(:bom) { "\xef\xbb\xbf" }
 
       it 'accepts a correctly aligned if/elsif/else/end' do
-        inspect_source(cop, <<-END.strip_indent)
+        expect_no_offenses(<<-END.strip_indent)
           #{bom}if a1
             b1
           elsif a2
@@ -107,7 +106,6 @@ describe RuboCop::Cop::Layout::ElseAlignment do
             c
           end
         END
-        expect(cop.offenses).to be_empty
       end
     end
 
@@ -115,18 +113,17 @@ describe RuboCop::Cop::Layout::ElseAlignment do
       context 'when alignment style is variable' do
         context 'and end is aligned with variable' do
           it 'accepts an if-else with end aligned with setter' do
-            inspect_source(cop, <<-END.strip_indent)
+            expect_no_offenses(<<-END.strip_indent)
               foo.bar = if baz
                 derp1
               else
                 derp2
               end
             END
-            expect(cop.offenses).to be_empty
           end
 
           it 'accepts an if-elsif-else with end aligned with setter' do
-            inspect_source(cop, <<-END.strip_indent)
+            expect_no_offenses(<<-END.strip_indent)
               foo.bar = if baz
                 derp1
               elsif meh
@@ -135,49 +132,44 @@ describe RuboCop::Cop::Layout::ElseAlignment do
                 derp3
               end
             END
-            expect(cop.offenses).to be_empty
           end
 
           it 'accepts an if with end aligned with element assignment' do
-            inspect_source(cop, <<-END.strip_indent)
+            expect_no_offenses(<<-END.strip_indent)
               foo[bar] = if baz
                 derp
               end
             END
-            expect(cop.offenses).to be_empty
           end
 
           it 'accepts an if/else' do
-            inspect_source(cop, <<-END.strip_indent)
+            expect_no_offenses(<<-END.strip_indent)
               var = if a
                 0
               else
                 1
               end
             END
-            expect(cop.offenses).to be_empty
           end
 
           it 'accepts an if/else with chaining after the end' do
-            inspect_source(cop, <<-END.strip_indent)
+            expect_no_offenses(<<-END.strip_indent)
               var = if a
                 0
               else
                 1
               end.abc.join("")
             END
-            expect(cop.offenses).to be_empty
           end
 
           it 'accepts an if/else with chaining with a block after the end' do
-            inspect_source(cop, <<-END.strip_indent)
+            expect_no_offenses(<<-END.strip_indent)
               var = if a
                 0
               else
                 1
               end.abc.tap {}
             END
-            expect(cop.offenses).to be_empty
           end
         end
 
@@ -253,27 +245,25 @@ describe RuboCop::Cop::Layout::ElseAlignment do
 
         context 'and end is aligned with keyword' do
           it 'accepts an if in assignment' do
-            inspect_source(cop, <<-END.strip_indent)
+            expect_no_offenses(<<-END.strip_indent)
               var = if a
                       0
                     end
             END
-            expect(cop.offenses).to be_empty
           end
 
           it 'accepts an if/else in assignment' do
-            inspect_source(cop, <<-END.strip_indent)
+            expect_no_offenses(<<-END.strip_indent)
               var = if a
                       0
                     else
                       1
                     end
             END
-            expect(cop.offenses).to be_empty
           end
 
           it 'accepts an if/else in assignment on next line' do
-            inspect_source(cop, <<-END.strip_indent)
+            expect_no_offenses(<<-END.strip_indent)
               var =
                 if a
                   0
@@ -281,25 +271,22 @@ describe RuboCop::Cop::Layout::ElseAlignment do
                   1
                 end
             END
-            expect(cop.offenses).to be_empty
           end
 
           it 'accepts a while in assignment' do
-            inspect_source(cop, <<-END.strip_indent)
+            expect_no_offenses(<<-END.strip_indent)
               var = while a
                       b
                     end
             END
-            expect(cop.offenses).to be_empty
           end
 
           it 'accepts an until in assignment' do
-            inspect_source(cop, <<-END.strip_indent)
+            expect_no_offenses(<<-END.strip_indent)
               var = until a
                       b
                     end
             END
-            expect(cop.offenses).to be_empty
           end
         end
       end
@@ -316,14 +303,13 @@ describe RuboCop::Cop::Layout::ElseAlignment do
     it 'accepts an if/else branches with rescue clauses' do
       # Because of how the rescue clauses come out of Parser, these are
       # special and need to be tested.
-      inspect_source(cop, <<-END.strip_indent)
+      expect_no_offenses(<<-END.strip_indent)
         if a
           a rescue nil
         else
           a rescue nil
         end
       END
-      expect(cop.offenses).to be_empty
     end
   end
 
@@ -340,20 +326,18 @@ describe RuboCop::Cop::Layout::ElseAlignment do
     end
 
     it 'accepts a correctly aligned else in an otherwise empty unless' do
-      inspect_source(cop, <<-END.strip_indent)
+      expect_no_offenses(<<-END.strip_indent)
         unless a
         else
         end
       END
-      expect(cop.offenses).to be_empty
     end
 
     it 'accepts an empty unless' do
-      inspect_source(cop, <<-END.strip_indent)
+      expect_no_offenses(<<-END.strip_indent)
         unless a
         end
       END
-      expect(cop.offenses).to be_empty
     end
   end
 
@@ -373,7 +357,7 @@ describe RuboCop::Cop::Layout::ElseAlignment do
     end
 
     it 'accepts correctly aligned case/when/else' do
-      inspect_source(cop, <<-END.strip_indent)
+      expect_no_offenses(<<-END.strip_indent)
         case a
         when b
           c
@@ -383,11 +367,10 @@ describe RuboCop::Cop::Layout::ElseAlignment do
           f
         end
       END
-      expect(cop.offenses).to be_empty
     end
 
     it 'accepts case without else' do
-      inspect_source(cop, <<-'END'.strip_indent)
+      expect_no_offenses(<<-'END'.strip_indent)
         case superclass
         when /\A(#{NAMESPACEMATCH})(?:\s|\Z)/
           $1
@@ -395,13 +378,12 @@ describe RuboCop::Cop::Layout::ElseAlignment do
           namespace.path
         end
       END
-      expect(cop.offenses).to be_empty
     end
 
     it 'accepts else aligned with when but not with case' do
       # "Indent when as deep as case" is the job of another cop, and this is
       # one of the possible styles supported by configuration.
-      inspect_source(cop, <<-END.strip_indent)
+      expect_no_offenses(<<-END.strip_indent)
         case code_type
           when 'ruby', 'sql', 'plain'
             code_type
@@ -413,31 +395,28 @@ describe RuboCop::Cop::Layout::ElseAlignment do
             'plain'
         end
       END
-      expect(cop.offenses).to be_empty
     end
   end
 
   context 'with def/defs' do
     it 'accepts an empty def body' do
-      inspect_source(cop, <<-END.strip_indent)
+      expect_no_offenses(<<-END.strip_indent)
         def test
         end
       END
-      expect(cop.offenses).to be_empty
     end
 
     it 'accepts an empty defs body' do
-      inspect_source(cop, <<-END.strip_indent)
+      expect_no_offenses(<<-END.strip_indent)
         def self.test
         end
       END
-      expect(cop.offenses).to be_empty
     end
 
     if RUBY_VERSION >= '2.1'
       context 'when modifier and def are on the same line' do
         it 'accepts a correctly aligned body' do
-          inspect_source(cop, <<-END.strip_indent)
+          expect_no_offenses(<<-END.strip_indent)
             private def test
               something
             rescue
@@ -446,7 +425,6 @@ describe RuboCop::Cop::Layout::ElseAlignment do
               something_else
             end
           END
-          expect(cop.offenses).to be_empty
         end
 
         it 'registers an offense for else not aligned with private' do
@@ -487,7 +465,7 @@ describe RuboCop::Cop::Layout::ElseAlignment do
     end
 
     it 'accepts a correctly aligned else' do
-      inspect_source(cop, <<-END.strip_indent)
+      expect_no_offenses(<<-END.strip_indent)
         begin
           raise StandardError.new('Fail') if rand(2).odd?
         rescue StandardError => error
@@ -496,13 +474,12 @@ describe RuboCop::Cop::Layout::ElseAlignment do
           $stdout.puts 'Lucky you!'
         end
       END
-      expect(cop.offenses).to be_empty
     end
   end
 
   context 'with def/rescue/else/ensure/end' do
     it 'accepts a correctly aligned else' do
-      inspect_source(cop, <<-END.strip_indent)
+      expect_no_offenses(<<-END.strip_indent)
         def my_func(string)
           puts string
         rescue => e
@@ -513,7 +490,6 @@ describe RuboCop::Cop::Layout::ElseAlignment do
           puts 'I love methods that print'
         end
       END
-      expect(cop.offenses).to be_empty
     end
 
     it 'registers an offense for misaligned else' do

--- a/spec/rubocop/cop/layout/empty_line_after_magic_comment_spec.rb
+++ b/spec/rubocop/cop/layout/empty_line_after_magic_comment_spec.rb
@@ -34,12 +34,11 @@ describe RuboCop::Cop::Layout::EmptyLineAfterMagicComment do
   end
 
   it 'accepts code that separates the comment from the code with a newline' do
-    inspect_source(cop, <<-END.strip_indent)
+    expect_no_offenses(<<-END.strip_indent)
       # frozen_string_literal: true
 
       class Foo; end
     END
-    expect(cop.offenses).to be_empty
   end
 
   it 'accepts an empty source file' do

--- a/spec/rubocop/cop/layout/empty_line_after_magic_comment_spec.rb
+++ b/spec/rubocop/cop/layout/empty_line_after_magic_comment_spec.rb
@@ -43,13 +43,11 @@ describe RuboCop::Cop::Layout::EmptyLineAfterMagicComment do
   end
 
   it 'accepts an empty source file' do
-    inspect_source(cop, '')
-    expect(cop.offenses).to be_empty
+    expect_no_offenses('')
   end
 
   it 'accepts a source file with only a magic comment' do
-    inspect_source(cop, '# frozen_string_literal: true')
-    expect(cop.offenses).to be_empty
+    expect_no_offenses('# frozen_string_literal: true')
   end
 
   it 'autocorrects by adding a newline' do

--- a/spec/rubocop/cop/layout/empty_lines_around_access_modifier_spec.rb
+++ b/spec/rubocop/cop/layout/empty_lines_around_access_modifier_spec.rb
@@ -142,14 +142,13 @@ describe RuboCop::Cop::Layout::EmptyLinesAroundAccessModifier do
     end
 
     it 'accepts missing blank line when at the beginning of class/module' do
-      inspect_source(cop, <<-END.strip_indent)
+      expect_no_offenses(<<-END.strip_indent)
         class Test
           #{access_modifier}
 
           def test; end
         end
       END
-      expect(cop.offenses).to be_empty
     end
 
     it "requires blank line after, but not before, #{access_modifier} " \
@@ -169,25 +168,23 @@ describe RuboCop::Cop::Layout::EmptyLinesAroundAccessModifier do
     context 'at the beginning of block' do
       context 'for blocks defined with do' do
         it 'accepts missing blank line' do
-          inspect_source(cop, <<-END.strip_indent)
+          expect_no_offenses(<<-END.strip_indent)
             included do
               #{access_modifier}
 
               def test; end
             end
           END
-          expect(cop.offenses).to be_empty
         end
 
         it 'accepts missing blank line with arguments' do
-          inspect_source(cop, <<-END.strip_indent)
+          expect_no_offenses(<<-END.strip_indent)
             included do |foo|
               #{access_modifier}
 
               def test; end
             end
           END
-          expect(cop.offenses).to be_empty
         end
 
         it "requires blank line after, but not before, #{access_modifier}" do
@@ -206,42 +203,39 @@ describe RuboCop::Cop::Layout::EmptyLinesAroundAccessModifier do
 
       context 'for blocks defined with {}' do
         it 'accepts missing blank line' do
-          inspect_source(cop, <<-END.strip_indent)
+          expect_no_offenses(<<-END.strip_indent)
             included {
               #{access_modifier}
 
               def test; end
             }
           END
-          expect(cop.offenses).to be_empty
         end
 
         it 'accepts missing blank line with arguments' do
-          inspect_source(cop, <<-END.strip_indent)
+          expect_no_offenses(<<-END.strip_indent)
             included { |foo|
               #{access_modifier}
 
               def test; end
             }
           END
-          expect(cop.offenses).to be_empty
         end
       end
     end
 
     it 'accepts missing blank line when at the end of block' do
-      inspect_source(cop, <<-END.strip_indent)
+      expect_no_offenses(<<-END.strip_indent)
         class Test
           def test; end
 
           #{access_modifier}
         end
       END
-      expect(cop.offenses).to be_empty
     end
 
     it 'recognizes blank lines with DOS style line endings' do
-      inspect_source(cop, <<-END.strip_indent)
+      expect_no_offenses(<<-END.strip_indent)
         class Test\r
         \r
           #{access_modifier}\r
@@ -249,7 +243,6 @@ describe RuboCop::Cop::Layout::EmptyLinesAroundAccessModifier do
           def test; end\r
         end\r
       END
-      expect(cop.offenses).to be_empty
     end
   end
 end

--- a/spec/rubocop/cop/layout/empty_lines_around_block_body_spec.rb
+++ b/spec/rubocop/cop/layout/empty_lines_around_block_body_spec.rb
@@ -47,12 +47,11 @@ describe RuboCop::Cop::Layout::EmptyLinesAroundBlockBody, :config do
       end
 
       it 'is not fooled by single line blocks' do
-        inspect_source(cop, <<-END.strip_indent)
+        expect_no_offenses(<<-END.strip_indent)
           some_method #{open} do_something #{close}
 
           something_else
         END
-        expect(cop.offenses).to be_empty
       end
     end
 
@@ -89,11 +88,10 @@ describe RuboCop::Cop::Layout::EmptyLinesAroundBlockBody, :config do
       end
 
       it 'is not fooled by single line blocks' do
-        inspect_source(cop, <<-END.strip_indent)
+        expect_no_offenses(<<-END.strip_indent)
           some_method #{open} do_something #{close}
           something_else
         END
-        expect(cop.offenses).to be_empty
       end
     end
   end

--- a/spec/rubocop/cop/layout/empty_lines_around_method_body_spec.rb
+++ b/spec/rubocop/cop/layout/empty_lines_around_method_body_spec.rb
@@ -89,11 +89,10 @@ describe RuboCop::Cop::Layout::EmptyLinesAroundMethodBody do
   end
 
   it 'is not fooled by single line methods' do
-    inspect_source(cop, <<-END.strip_indent)
+    expect_no_offenses(<<-END.strip_indent)
       def some_method; do_something; end
 
       something_else
     END
-    expect(cop.offenses).to be_empty
   end
 end

--- a/spec/rubocop/cop/layout/empty_lines_spec.rb
+++ b/spec/rubocop/cop/layout/empty_lines_spec.rb
@@ -16,9 +16,7 @@ describe RuboCop::Cop::Layout::EmptyLines do
   end
 
   it 'works when there are no tokens' do
-    inspect_source(cop,
-                   '#comment')
-    expect(cop.offenses).to be_empty
+    expect_no_offenses('#comment')
   end
 
   it 'handles comments' do

--- a/spec/rubocop/cop/layout/empty_lines_spec.rb
+++ b/spec/rubocop/cop/layout/empty_lines_spec.rb
@@ -35,7 +35,7 @@ describe RuboCop::Cop::Layout::EmptyLines do
   end
 
   it 'does not register an offense for heredocs with empty lines inside' do
-    inspect_source(cop, <<-END.strip_indent)
+    expect_no_offenses(<<-END.strip_indent)
       str = <<-TEXT
       line 1
 
@@ -44,6 +44,5 @@ describe RuboCop::Cop::Layout::EmptyLines do
       TEXT
       puts str
     END
-    expect(cop.offenses).to be_empty
   end
 end

--- a/spec/rubocop/cop/layout/extra_spacing_spec.rb
+++ b/spec/rubocop/cop/layout/extra_spacing_spec.rb
@@ -103,13 +103,11 @@ describe RuboCop::Cop::Layout::ExtraSpacing, :config do
     end
 
     it 'ignores whitespace at the beginning of the line' do
-      inspect_source(cop, '  m = "hello"')
-      expect(cop.offenses).to be_empty
+      expect_no_offenses('  m = "hello"')
     end
 
     it 'ignores whitespace inside a string' do
-      inspect_source(cop, 'm = "hello   this"')
-      expect(cop.offenses).to be_empty
+      expect_no_offenses('m = "hello   this"')
     end
 
     it 'ignores trailing whitespace' do

--- a/spec/rubocop/cop/layout/extra_spacing_spec.rb
+++ b/spec/rubocop/cop/layout/extra_spacing_spec.rb
@@ -279,32 +279,29 @@ describe RuboCop::Cop::Layout::ExtraSpacing, :config do
     end
 
     it 'does not register an offense if assignments are separated by blanks' do
-      inspect_source(cop, <<-END.strip_indent)
+      expect_no_offenses(<<-END.strip_indent)
         a = 1
 
         bb = 2
 
         ccc = 3
       END
-      expect(cop.offenses).to be_empty
     end
 
     it 'does not register an offense if assignments are aligned' do
-      inspect_source(cop, <<-END.strip_indent)
+      expect_no_offenses(<<-END.strip_indent)
         a   = 1
         bb  = 2
         ccc = 3
       END
-      expect(cop.offenses).to be_empty
     end
 
     it 'aligns the first assignment with the following assignment' do
-      inspect_source(cop, <<-END.strip_indent)
+      expect_no_offenses(<<-END.strip_indent)
         # comment
         a   = 1
         bb  = 2
       END
-      expect(cop.offenses).to be_empty
     end
 
     it 'autocorrects consecutive assignments which are not aligned' do

--- a/spec/rubocop/cop/layout/first_array_element_line_break_spec.rb
+++ b/spec/rubocop/cop/layout/first_array_element_line_break_spec.rb
@@ -148,29 +148,19 @@ describe RuboCop::Cop::Layout::FirstArrayElementLineBreak do
   end
 
   it 'ignores properly formatted implicit arrays' do
-    inspect_source(
-      cop,
-      <<-END.strip_indent
-        a, b,
-        c =
-        1, 2,
-        3
-      END
-    )
-
-    expect(cop.offenses).to be_empty
+    expect_no_offenses(<<-END.strip_indent)
+      a, b,
+      c =
+      1, 2,
+      3
+    END
   end
 
   it 'ignores elements listed on a single line' do
-    inspect_source(
-      cop,
-      <<-END.strip_indent
-        b = [
-          :a,
-          :b]
-      END
-    )
-
-    expect(cop.offenses).to be_empty
+    expect_no_offenses(<<-END.strip_indent)
+      b = [
+        :a,
+        :b]
+    END
   end
 end

--- a/spec/rubocop/cop/layout/first_hash_element_line_break_spec.rb
+++ b/spec/rubocop/cop/layout/first_hash_element_line_break_spec.rb
@@ -60,53 +60,33 @@ describe RuboCop::Cop::Layout::FirstHashElementLineBreak do
   end
 
   it 'ignores implicit hashes in method calls with parens' do
-    inspect_source(
-      cop,
-      <<-END.strip_indent
-        method(
-          foo: 1,
-          bar: 2)
-      END
-    )
-
-    expect(cop.offenses).to be_empty
+    expect_no_offenses(<<-END.strip_indent)
+      method(
+        foo: 1,
+        bar: 2)
+    END
   end
 
   it 'ignores implicit hashes in method calls without parens' do
-    inspect_source(
-      cop,
-      <<-END.strip_indent
-        method foo: 1,
-         bar:2
-      END
-    )
-
-    expect(cop.offenses).to be_empty
+    expect_no_offenses(<<-END.strip_indent)
+      method foo: 1,
+       bar:2
+    END
   end
 
   it 'ignores implicit hashes in method calls that are improperly formatted' do
     # These are covered by Style/FirstMethodArgumentLineBreak
-    inspect_source(
-      cop,
-      <<-END.strip_indent
-        method(foo: 1,
-          bar: 2)
-      END
-    )
-
-    expect(cop.offenses).to be_empty
+    expect_no_offenses(<<-END.strip_indent)
+      method(foo: 1,
+        bar: 2)
+    END
   end
 
   it 'ignores elements listed on a single line' do
-    inspect_source(
-      cop,
-      <<-END.strip_indent
-        b = {
-          a: 1,
-          b: 2}
-      END
-    )
-
-    expect(cop.offenses).to be_empty
+    expect_no_offenses(<<-END.strip_indent)
+      b = {
+        a: 1,
+        b: 2}
+    END
   end
 end

--- a/spec/rubocop/cop/layout/first_method_argument_line_break_spec.rb
+++ b/spec/rubocop/cop/layout/first_method_argument_line_break_spec.rb
@@ -88,9 +88,7 @@ describe RuboCop::Cop::Layout::FirstMethodArgumentLineBreak do
   end
 
   it 'ignores arguments listed on a single line' do
-    inspect_source(cop, 'foo(bar, baz, bing)')
-
-    expect(cop.offenses).to be_empty
+    expect_no_offenses('foo(bar, baz, bing)')
   end
 
   it 'ignores arguments without parens' do
@@ -106,8 +104,6 @@ describe RuboCop::Cop::Layout::FirstMethodArgumentLineBreak do
   end
 
   it 'ignores methods without arguments' do
-    inspect_source(cop, 'foo')
-
-    expect(cop.offenses).to be_empty
+    expect_no_offenses('foo')
   end
 end

--- a/spec/rubocop/cop/layout/first_method_argument_line_break_spec.rb
+++ b/spec/rubocop/cop/layout/first_method_argument_line_break_spec.rb
@@ -92,15 +92,10 @@ describe RuboCop::Cop::Layout::FirstMethodArgumentLineBreak do
   end
 
   it 'ignores arguments without parens' do
-    inspect_source(
-      cop,
-      <<-END.strip_indent
-        foo bar,
-          baz
-      END
-    )
-
-    expect(cop.offenses).to be_empty
+    expect_no_offenses(<<-END.strip_indent)
+      foo bar,
+        baz
+    END
   end
 
   it 'ignores methods without arguments' do

--- a/spec/rubocop/cop/layout/first_method_parameter_line_break_spec.rb
+++ b/spec/rubocop/cop/layout/first_method_parameter_line_break_spec.rb
@@ -95,12 +95,7 @@ describe RuboCop::Cop::Layout::FirstMethodParameterLineBreak do
   end
 
   it 'ignores single-line methods' do
-    inspect_source(
-      cop,
-      'def foo(bar, baz) ; bing ; end'
-    )
-
-    expect(cop.offenses).to be_empty
+    expect_no_offenses('def foo(bar, baz) ; bing ; end')
   end
 
   it 'ignores methods without params' do

--- a/spec/rubocop/cop/layout/first_method_parameter_line_break_spec.rb
+++ b/spec/rubocop/cop/layout/first_method_parameter_line_break_spec.rb
@@ -68,30 +68,20 @@ describe RuboCop::Cop::Layout::FirstMethodParameterLineBreak do
   end
 
   it 'ignores params listed on a single line' do
-    inspect_source(
-      cop,
-      <<-END.strip_indent
+    expect_no_offenses(<<-END.strip_indent)
         def foo(bar, baz, bing)
           do_something
         end
       END
-    )
-
-    expect(cop.offenses).to be_empty
   end
 
   it 'ignores params without parens' do
-    inspect_source(
-      cop,
-      <<-END.strip_indent
+    expect_no_offenses(<<-END.strip_indent)
         def foo bar,
           baz
           do_something
         end
       END
-    )
-
-    expect(cop.offenses).to be_empty
   end
 
   it 'ignores single-line methods' do
@@ -99,16 +89,11 @@ describe RuboCop::Cop::Layout::FirstMethodParameterLineBreak do
   end
 
   it 'ignores methods without params' do
-    inspect_source(
-      cop,
-      <<-END.strip_indent
+    expect_no_offenses(<<-END.strip_indent)
         def foo
           bing
         end
       END
-    )
-
-    expect(cop.offenses).to be_empty
   end
 
   context 'params with default values' do

--- a/spec/rubocop/cop/layout/first_parameter_indentation_spec.rb
+++ b/spec/rubocop/cop/layout/first_parameter_indentation_spec.rb
@@ -93,12 +93,11 @@ describe RuboCop::Cop::Layout::FirstParameterIndentation do
 
         context 'with line break' do
           it 'accepts a correctly indented first parameter' do
-            inspect_source(cop, <<-END.strip_indent)
+            expect_no_offenses(<<-END.strip_indent)
               x =
                 run(
                   :foo)
             END
-            expect(cop.offenses).to be_empty
           end
 
           it 'registers an offense for an under-indented first parameter' do
@@ -113,22 +112,20 @@ describe RuboCop::Cop::Layout::FirstParameterIndentation do
       end
 
       it 'accepts a first parameter that is not preceded by a line break' do
-        inspect_source(cop, <<-END.strip_indent)
+        expect_no_offenses(<<-END.strip_indent)
           run :foo,
               bar: 3
         END
-        expect(cop.offenses).to be_empty
       end
 
       context 'when the receiver contains a line break' do
         it 'accepts a correctly indented first parameter' do
-          inspect_source(cop, <<-END.strip_indent)
+          expect_no_offenses(<<-END.strip_indent)
             puts x.
               merge(
                 b: 2
               )
           END
-          expect(cop.offenses).to be_empty
         end
 
         it 'registers an offense for an over-indented first parameter' do
@@ -158,14 +155,13 @@ describe RuboCop::Cop::Layout::FirstParameterIndentation do
 
         context 'when preceded by a comment line' do
           it 'accepts a correctly indented first parameter' do
-            inspect_source(cop, <<-END.strip_indent)
+            expect_no_offenses(<<-END.strip_indent)
               puts x.
                 merge( # EOL comment
                   # comment
                   b: 2
                 )
             END
-            expect(cop.offenses).to be_empty
           end
 
           it 'registers an offense for an under-indented first parameter' do
@@ -185,29 +181,26 @@ describe RuboCop::Cop::Layout::FirstParameterIndentation do
       end
 
       it 'accepts method calls with no parameters' do
-        inspect_source(cop, <<-END.strip_indent)
+        expect_no_offenses(<<-END.strip_indent)
           run()
           run_again
         END
-        expect(cop.offenses).to be_empty
       end
 
       it 'accepts operator calls' do
-        inspect_source(cop, <<-END.strip_indent)
+        expect_no_offenses(<<-END.strip_indent)
           params = default_cfg.keys - %w(Description) -
                    cfg.keys
         END
-        expect(cop.offenses).to be_empty
       end
 
       it 'does not view []= as an outer method call' do
-        inspect_source(cop, <<-END.strip_indent)
+        expect_no_offenses(<<-END.strip_indent)
           @subject_results[subject] = original.update(
             mutation_results: (dup << mutation_result),
             tests:            test_result.tests
           )
         END
-        expect(cop.offenses).to be_empty
       end
 
       it 'does not view chained call as an outer method call' do
@@ -269,13 +262,12 @@ describe RuboCop::Cop::Layout::FirstParameterIndentation do
       end
 
       it 'accepts a correctly indented first parameter' do
-        inspect_source(cop, <<-END.strip_indent)
+        expect_no_offenses(<<-END.strip_indent)
           run(
               :foo,
               bar: 3
           )
         END
-        expect(cop.offenses).to be_empty
       end
 
       it 'auto-corrects an over-indented first parameter' do
@@ -314,11 +306,10 @@ describe RuboCop::Cop::Layout::FirstParameterIndentation do
 
       context 'without outer parentheses' do
         it 'accepts a first parameter with special indentation' do
-          inspect_source(cop, <<-END.strip_indent)
+          expect_no_offenses(<<-END.strip_indent)
             run :foo, defaults.merge(
                         bar: 3)
           END
-          expect(cop.offenses).to be_empty
         end
       end
 
@@ -367,7 +358,7 @@ describe RuboCop::Cop::Layout::FirstParameterIndentation do
         end
 
         it 'accepts a correctly indented first parameter in interpolation' do
-          inspect_source(cop, <<-'END'.strip_indent)
+          expect_no_offenses(<<-'END'.strip_indent)
             puts %(
               <p>
                 #{Array(
@@ -376,7 +367,6 @@ describe RuboCop::Cop::Layout::FirstParameterIndentation do
               </p>
             )
           END
-          expect(cop.offenses).to be_empty
         end
 
         it 'accepts a correctly indented first parameter with fullwidth ' \
@@ -391,11 +381,10 @@ describe RuboCop::Cop::Layout::FirstParameterIndentation do
 
       context 'without outer parentheses' do
         it 'accepts a first parameter with consistent style indentation' do
-          inspect_source(cop, <<-END.strip_indent)
+          expect_no_offenses(<<-END.strip_indent)
             run :foo, defaults.merge(
               bar: 3)
           END
-          expect(cop.offenses).to be_empty
         end
       end
 

--- a/spec/rubocop/cop/layout/indent_array_spec.rb
+++ b/spec/rubocop/cop/layout/indent_array_spec.rb
@@ -170,27 +170,19 @@ describe RuboCop::Cop::Layout::IndentArray do
     end
 
     it 'accepts single line array' do
-      inspect_source(cop,
-                     'a = [1, 2]')
-      expect(cop.offenses).to be_empty
+      expect_no_offenses('a = [1, 2]')
     end
 
     it 'accepts an empty array' do
-      inspect_source(cop,
-                     'a = []')
-      expect(cop.offenses).to be_empty
+      expect_no_offenses('a = []')
     end
 
     it 'accepts multi-assignments with brackets' do
-      inspect_source(cop,
-                     'a, b = [b, a]')
-      expect(cop.offenses).to be_empty
+      expect_no_offenses('a, b = [b, a]')
     end
 
     it 'accepts multi-assignments with no brackets' do
-      inspect_source(cop,
-                     'a, b = b, a')
-      expect(cop.offenses).to be_empty
+      expect_no_offenses('a, b = b, a')
     end
   end
 
@@ -334,15 +326,11 @@ describe RuboCop::Cop::Layout::IndentArray do
 
     context 'and argument are not surrounded by parentheses' do
       it 'accepts bracketless array' do
-        inspect_source(cop,
-                       'func 1, 2')
-        expect(cop.offenses).to be_empty
+        expect_no_offenses('func 1, 2')
       end
 
       it 'accepts single line array with brackets' do
-        inspect_source(cop,
-                       'func x, [1, 2]')
-        expect(cop.offenses).to be_empty
+        expect_no_offenses('func x, [1, 2]')
       end
 
       it 'accepts a correctly indented multi-line array with brackets' do
@@ -398,27 +386,19 @@ describe RuboCop::Cop::Layout::IndentArray do
     end
 
     it 'accepts single line array' do
-      inspect_source(cop,
-                     'a = [1, 2]')
-      expect(cop.offenses).to be_empty
+      expect_no_offenses('a = [1, 2]')
     end
 
     it 'accepts an empty array' do
-      inspect_source(cop,
-                     'a = []')
-      expect(cop.offenses).to be_empty
+      expect_no_offenses('a = []')
     end
 
     it 'accepts multi-assignments with brackets' do
-      inspect_source(cop,
-                     'a, b = [b, a]')
-      expect(cop.offenses).to be_empty
+      expect_no_offenses('a, b = [b, a]')
     end
 
     it 'accepts multi-assignments with no brackets' do
-      inspect_source(cop,
-                     'a, b = b, a')
-      expect(cop.offenses).to be_empty
+      expect_no_offenses('a, b = b, a')
     end
 
     context "when 'consistent' style is used" do

--- a/spec/rubocop/cop/layout/indent_array_spec.rb
+++ b/spec/rubocop/cop/layout/indent_array_spec.rb
@@ -18,12 +18,11 @@ describe RuboCop::Cop::Layout::IndentArray do
 
   context 'when array is operand' do
     it 'accepts correctly indented first element' do
-      inspect_source(cop, <<-END.strip_indent)
+      expect_no_offenses(<<-END.strip_indent)
         a << [
           1
         ]
       END
-      expect(cop.offenses).to be_empty
     end
 
     it 'registers an offense for incorrectly indented first element' do
@@ -65,12 +64,11 @@ describe RuboCop::Cop::Layout::IndentArray do
       let(:cop_indent) { 4 }
 
       it 'accepts correctly indented first element' do
-        inspect_source(cop, <<-END.strip_indent)
+        expect_no_offenses(<<-END.strip_indent)
           a << [
               1
           ]
         END
-        expect(cop.offenses).to be_empty
       end
 
       it 'registers an offense for incorrectly indented first element' do
@@ -144,29 +142,26 @@ describe RuboCop::Cop::Layout::IndentArray do
     end
 
     it 'accepts correctly indented first element' do
-      inspect_source(cop, <<-END.strip_indent)
+      expect_no_offenses(<<-END.strip_indent)
         a = [
           1
         ]
       END
-      expect(cop.offenses).to be_empty
     end
 
     it 'accepts several elements per line' do
-      inspect_source(cop, <<-END.strip_indent)
+      expect_no_offenses(<<-END.strip_indent)
         a = [
           1, 2
         ]
       END
-      expect(cop.offenses).to be_empty
     end
 
     it 'accepts a first element on the same line as the left bracket' do
-      inspect_source(cop, <<-END.strip_indent)
+      expect_no_offenses(<<-END.strip_indent)
         a = [1,
              2]
       END
-      expect(cop.offenses).to be_empty
     end
 
     it 'accepts single line array' do
@@ -190,7 +185,7 @@ describe RuboCop::Cop::Layout::IndentArray do
     context 'and arguments are surrounded by parentheses' do
       context 'and EnforcedStyle is special_inside_parentheses' do
         it 'accepts special indentation for first argument' do
-          inspect_source(cop, <<-END.strip_indent)
+          expect_no_offenses(<<-END.strip_indent)
             h = [
               1
             ]
@@ -207,7 +202,6 @@ describe RuboCop::Cop::Layout::IndentArray do
             func(x, [1
                  ])
           END
-          expect(cop.offenses).to be_empty
         end
 
         it "registers an offense for 'consistent' indentation" do
@@ -255,22 +249,20 @@ describe RuboCop::Cop::Layout::IndentArray do
         end
 
         it 'accepts special indentation for second argument' do
-          inspect_source(cop, <<-END.strip_indent)
+          expect_no_offenses(<<-END.strip_indent)
             body.should have_tag("input", [
                                    :name])
           END
-          expect(cop.offenses).to be_empty
         end
 
         it 'accepts normal indentation for array within array' do
-          inspect_source(cop, <<-END.strip_indent)
+          expect_no_offenses(<<-END.strip_indent)
             puts(
               [
                 [1, 2]
               ]
             )
           END
-          expect(cop.offenses).to be_empty
         end
       end
 
@@ -278,7 +270,7 @@ describe RuboCop::Cop::Layout::IndentArray do
         let(:cop_config) { { 'EnforcedStyle' => 'consistent' } }
 
         it 'accepts normal indentation for first argument' do
-          inspect_source(cop, <<-END.strip_indent)
+          expect_no_offenses(<<-END.strip_indent)
             h = [
               1
             ]
@@ -295,7 +287,6 @@ describe RuboCop::Cop::Layout::IndentArray do
             func(x, [1
             ])
           END
-          expect(cop.offenses).to be_empty
         end
 
         it 'registers an offense for incorrect indentation' do
@@ -315,11 +306,10 @@ describe RuboCop::Cop::Layout::IndentArray do
         end
 
         it 'accepts normal indentation for second argument' do
-          inspect_source(cop, <<-END.strip_indent)
+          expect_no_offenses(<<-END.strip_indent)
             body.should have_tag("input", [
               :name])
           END
-          expect(cop.offenses).to be_empty
         end
       end
     end
@@ -334,11 +324,10 @@ describe RuboCop::Cop::Layout::IndentArray do
       end
 
       it 'accepts a correctly indented multi-line array with brackets' do
-        inspect_source(cop, <<-END.strip_indent)
+        expect_no_offenses(<<-END.strip_indent)
           func x, [
             1, 2]
         END
-        expect(cop.offenses).to be_empty
       end
 
       it 'registers an offense for incorrectly indented multi-line array ' \
@@ -360,29 +349,26 @@ describe RuboCop::Cop::Layout::IndentArray do
     let(:cop_config) { { 'EnforcedStyle' => 'align_brackets' } }
 
     it 'accepts correctly indented first element' do
-      inspect_source(cop, <<-END.strip_indent)
+      expect_no_offenses(<<-END.strip_indent)
         a = [
               1
             ]
       END
-      expect(cop.offenses).to be_empty
     end
 
     it 'accepts several elements per line' do
-      inspect_source(cop, <<-END.strip_indent)
+      expect_no_offenses(<<-END.strip_indent)
         a = [
               1, 2
             ]
       END
-      expect(cop.offenses).to be_empty
     end
 
     it 'accepts a first element on the same line as the left bracket' do
-      inspect_source(cop, <<-END.strip_indent)
+      expect_no_offenses(<<-END.strip_indent)
         a = [1,
              2]
       END
-      expect(cop.offenses).to be_empty
     end
 
     it 'accepts single line array' do
@@ -464,12 +450,11 @@ describe RuboCop::Cop::Layout::IndentArray do
       let(:cop_indent) { 4 }
 
       it 'accepts correctly indented first element' do
-        inspect_source(cop, <<-END.strip_indent)
+        expect_no_offenses(<<-END.strip_indent)
           a = [
                   1
               ]
         END
-        expect(cop.offenses).to be_empty
       end
 
       it 'autocorrects indentation which does not match IndentationWidth' do

--- a/spec/rubocop/cop/layout/indent_assignment_spec.rb
+++ b/spec/rubocop/cop/layout/indent_assignment_spec.rb
@@ -22,31 +22,25 @@ describe RuboCop::Cop::Layout::IndentAssignment, :config do
   end
 
   it 'allows assignments that do not start on a newline' do
-    inspect_source(cop, <<-END.strip_indent)
+    expect_no_offenses(<<-END.strip_indent)
       a = if b
             foo
           end
     END
-
-    expect(cop.offenses).to be_empty
   end
 
   it 'allows a properly indented rhs' do
-    inspect_source(cop, <<-END.strip_indent)
+    expect_no_offenses(<<-END.strip_indent)
       a =
         if b ; end
     END
-
-    expect(cop.offenses).to be_empty
   end
 
   it 'allows a properly indented rhs with fullwidth characters' do
-    inspect_source(cop, <<-END.strip_indent)
+    expect_no_offenses(<<-END.strip_indent)
       f 'Ｒｕｂｙ', a =
                       b
     END
-
-    expect(cop.offenses).to be_empty
   end
 
   it 'registers an offense for multi-lhs' do
@@ -62,12 +56,10 @@ describe RuboCop::Cop::Layout::IndentAssignment, :config do
   end
 
   it 'ignores comparison operators' do
-    inspect_source(cop, <<-END.strip_indent)
+    expect_no_offenses(<<-END.strip_indent)
       a ===
       if b ; end
     END
-
-    expect(cop.offenses).to be_empty
   end
 
   it 'auto-corrects indentation' do
@@ -89,12 +81,10 @@ describe RuboCop::Cop::Layout::IndentAssignment, :config do
     let(:cop_indent) { 7 }
 
     it 'allows a properly indented rhs' do
-      inspect_source(cop, <<-END.strip_indent)
+      expect_no_offenses(<<-END.strip_indent)
         a =
                if b ; end
       END
-
-      expect(cop.offenses).to be_empty
     end
 
     it 'auto-corrects indentation' do

--- a/spec/rubocop/cop/layout/indent_hash_spec.rb
+++ b/spec/rubocop/cop/layout/indent_hash_spec.rb
@@ -48,13 +48,12 @@ describe RuboCop::Cop::Layout::IndentHash do
     end
 
     it 'accepts correctly indented first pair' do
-      inspect_source(cop, <<-END.strip_indent)
+      expect_no_offenses(<<-END.strip_indent)
         a << {
             a: 1,
           aaa: 222
         }
       END
-      expect(cop.offenses).to be_empty
     end
 
     it 'registers an offense for incorrectly indented first pair with :' do
@@ -81,13 +80,12 @@ describe RuboCop::Cop::Layout::IndentHash do
     end
 
     it 'accepts correctly indented first pair' do
-      inspect_source(cop, <<-END.strip_indent)
+      expect_no_offenses(<<-END.strip_indent)
         a << {
             'a' => 1,
           'aaa' => 222
         }
       END
-      expect(cop.offenses).to be_empty
     end
 
     it 'registers an offense for incorrectly indented first pair with =>' do
@@ -106,12 +104,11 @@ describe RuboCop::Cop::Layout::IndentHash do
 
   context 'when hash is operand' do
     it 'accepts correctly indented first pair' do
-      inspect_source(cop, <<-END.strip_indent)
+      expect_no_offenses(<<-END.strip_indent)
         a << {
           a: 1
         }
       END
-      expect(cop.offenses).to be_empty
     end
 
     it 'registers an offense for incorrectly indented first pair' do
@@ -199,29 +196,26 @@ describe RuboCop::Cop::Layout::IndentHash do
     end
 
     it 'accepts correctly indented first pair' do
-      inspect_source(cop, <<-END.strip_indent)
+      expect_no_offenses(<<-END.strip_indent)
         a = {
           a: 1
         }
       END
-      expect(cop.offenses).to be_empty
     end
 
     it 'accepts several pairs per line' do
-      inspect_source(cop, <<-END.strip_indent)
+      expect_no_offenses(<<-END.strip_indent)
         a = {
           a: 1, b: 2
         }
       END
-      expect(cop.offenses).to be_empty
     end
 
     it 'accepts a first pair on the same line as the left brace' do
-      inspect_source(cop, <<-END.strip_indent)
+      expect_no_offenses(<<-END.strip_indent)
         a = { "a" => 1,
               "b" => 2 }
       END
-      expect(cop.offenses).to be_empty
     end
 
     it 'accepts single line hash' do
@@ -253,12 +247,11 @@ describe RuboCop::Cop::Layout::IndentHash do
       end
 
       it 'accepts correctly indented first pair' do
-        inspect_source(cop, <<-END.strip_indent)
+        expect_no_offenses(<<-END.strip_indent)
           a = {
              a: 1
           }
         END
-        expect(cop.offenses).to be_empty
       end
     end
   end
@@ -267,7 +260,7 @@ describe RuboCop::Cop::Layout::IndentHash do
     context 'and arguments are surrounded by parentheses' do
       context 'and EnforcedStyle is special_inside_parentheses' do
         it 'accepts special indentation for first argument' do
-          inspect_source(cop, <<-END.strip_indent)
+          expect_no_offenses(<<-END.strip_indent)
             h = {
               a: 1
             }
@@ -284,7 +277,6 @@ describe RuboCop::Cop::Layout::IndentHash do
             func(x, { a: 1
                  })
           END
-          expect(cop.offenses).to be_empty
         end
 
         it "registers an offense for 'consistent' indentation" do
@@ -332,22 +324,20 @@ describe RuboCop::Cop::Layout::IndentHash do
         end
 
         it 'accepts special indentation for second argument' do
-          inspect_source(cop, <<-'END'.strip_indent)
+          expect_no_offenses(<<-'END'.strip_indent)
             body.should have_tag("input", :attributes => {
                                    :name => /q\[(id_eq)\]/ })
           END
-          expect(cop.offenses).to be_empty
         end
 
         it 'accepts normal indentation for hash within hash' do
-          inspect_source(cop, <<-END.strip_indent)
+          expect_no_offenses(<<-END.strip_indent)
             scope = scope.where(
               klass.table_name => {
                 reflection.type => model.base_class.sti_name
               }
             )
           END
-          expect(cop.offenses).to be_empty
         end
       end
 
@@ -355,7 +345,7 @@ describe RuboCop::Cop::Layout::IndentHash do
         let(:cop_config) { { 'EnforcedStyle' => 'consistent' } }
 
         it 'accepts normal indentation for first argument' do
-          inspect_source(cop, <<-END.strip_indent)
+          expect_no_offenses(<<-END.strip_indent)
             h = {
               a: 1
             }
@@ -372,7 +362,6 @@ describe RuboCop::Cop::Layout::IndentHash do
             func(x, { a: 1
             })
           END
-          expect(cop.offenses).to be_empty
         end
 
         it 'registers an offense for incorrect indentation' do
@@ -392,11 +381,10 @@ describe RuboCop::Cop::Layout::IndentHash do
         end
 
         it 'accepts normal indentation for second argument' do
-          inspect_source(cop, <<-'END'.strip_indent)
+          expect_no_offenses(<<-'END'.strip_indent)
             body.should have_tag("input", :attributes => {
               :name => /q\[(id_eq)\]/ })
           END
-          expect(cop.offenses).to be_empty
         end
       end
     end
@@ -411,11 +399,10 @@ describe RuboCop::Cop::Layout::IndentHash do
       end
 
       it 'accepts a correctly indented multi-line hash with braces' do
-        inspect_source(cop, <<-END.strip_indent)
+        expect_no_offenses(<<-END.strip_indent)
           func x, {
             a: 1, b: 2 }
         END
-        expect(cop.offenses).to be_empty
       end
 
       it 'registers an offense for incorrectly indented multi-line hash ' \
@@ -437,29 +424,26 @@ describe RuboCop::Cop::Layout::IndentHash do
     let(:cop_config) { { 'EnforcedStyle' => 'align_braces' } }
 
     it 'accepts correctly indented first pair' do
-      inspect_source(cop, <<-END.strip_indent)
+      expect_no_offenses(<<-END.strip_indent)
         a = {
               a: 1
             }
       END
-      expect(cop.offenses).to be_empty
     end
 
     it 'accepts several pairs per line' do
-      inspect_source(cop, <<-END.strip_indent)
+      expect_no_offenses(<<-END.strip_indent)
         a = {
               a: 1, b: 2
             }
       END
-      expect(cop.offenses).to be_empty
     end
 
     it 'accepts a first pair on the same line as the left brace' do
-      inspect_source(cop, <<-END.strip_indent)
+      expect_no_offenses(<<-END.strip_indent)
         a = { "a" => 1,
               "b" => 2 }
       END
-      expect(cop.offenses).to be_empty
     end
 
     it 'accepts single line hash' do

--- a/spec/rubocop/cop/layout/indent_hash_spec.rb
+++ b/spec/rubocop/cop/layout/indent_hash_spec.rb
@@ -225,15 +225,11 @@ describe RuboCop::Cop::Layout::IndentHash do
     end
 
     it 'accepts single line hash' do
-      inspect_source(cop,
-                     'a = { a: 1, b: 2 }')
-      expect(cop.offenses).to be_empty
+      expect_no_offenses('a = { a: 1, b: 2 }')
     end
 
     it 'accepts an empty hash' do
-      inspect_source(cop,
-                     'a = {}')
-      expect(cop.offenses).to be_empty
+      expect_no_offenses('a = {}')
     end
 
     context 'when indentation width is overridden for this cop' do
@@ -407,15 +403,11 @@ describe RuboCop::Cop::Layout::IndentHash do
 
     context 'and argument are not surrounded by parentheses' do
       it 'accepts braceless hash' do
-        inspect_source(cop,
-                       'func a: 1, b: 2')
-        expect(cop.offenses).to be_empty
+        expect_no_offenses('func a: 1, b: 2')
       end
 
       it 'accepts single line hash with braces' do
-        inspect_source(cop,
-                       'func x, { a: 1, b: 2 }')
-        expect(cop.offenses).to be_empty
+        expect_no_offenses('func x, { a: 1, b: 2 }')
       end
 
       it 'accepts a correctly indented multi-line hash with braces' do
@@ -471,15 +463,11 @@ describe RuboCop::Cop::Layout::IndentHash do
     end
 
     it 'accepts single line hash' do
-      inspect_source(cop,
-                     'a = { a: 1, b: 2 }')
-      expect(cop.offenses).to be_empty
+      expect_no_offenses('a = { a: 1, b: 2 }')
     end
 
     it 'accepts an empty hash' do
-      inspect_source(cop,
-                     'a = {}')
-      expect(cop.offenses).to be_empty
+      expect_no_offenses('a = {}')
     end
 
     context "when 'consistent' style is used" do

--- a/spec/rubocop/cop/layout/indentation_consistency_spec.rb
+++ b/spec/rubocop/cop/layout/indentation_consistency_spec.rb
@@ -66,8 +66,7 @@ describe RuboCop::Cop::Layout::IndentationConsistency, :config do
     end
 
     it 'accepts a one line if statement' do
-      inspect_source(cop, 'if cond then func1 else func2 end')
-      expect(cop.offenses).to be_empty
+      expect_no_offenses('if cond then func1 else func2 end')
     end
 
     it 'accepts a correctly aligned if/elsif/else/end' do

--- a/spec/rubocop/cop/layout/indentation_consistency_spec.rb
+++ b/spec/rubocop/cop/layout/indentation_consistency_spec.rb
@@ -70,7 +70,7 @@ describe RuboCop::Cop::Layout::IndentationConsistency, :config do
     end
 
     it 'accepts a correctly aligned if/elsif/else/end' do
-      inspect_source(cop, <<-END.strip_indent)
+      expect_no_offenses(<<-END.strip_indent)
         if a1
           b1
         elsif a2
@@ -79,50 +79,45 @@ describe RuboCop::Cop::Layout::IndentationConsistency, :config do
           c
         end
       END
-      expect(cop.offenses).to be_empty
     end
 
     it 'accepts if/elsif/else/end laid out as a table' do
-      inspect_source(cop, <<-END.strip_indent)
+      expect_no_offenses(<<-END.strip_indent)
         if    @io == $stdout then str << "$stdout"
         elsif @io == $stdin  then str << "$stdin"
         elsif @io == $stderr then str << "$stderr"
         else                      str << @io.class.to_s
         end
       END
-      expect(cop.offenses).to be_empty
     end
 
     it 'accepts if/then/else/end laid out as another table' do
-      inspect_source(cop, <<-END.strip_indent)
+      expect_no_offenses(<<-END.strip_indent)
         if File.exist?('config.save')
         then ConfigTable.load
         else ConfigTable.new
         end
       END
-      expect(cop.offenses).to be_empty
     end
 
     it 'accepts if/elsif/else/end with fullwidth characters' do
-      inspect_source(cop, <<-END.strip_indent)
+      expect_no_offenses(<<-END.strip_indent)
         p 'Ｒｕｂｙ', if a then b
                                 c
                       end
       END
-      expect(cop.offenses).to be_empty
     end
 
     it 'accepts an empty if' do
-      inspect_source(cop, <<-END.strip_indent)
+      expect_no_offenses(<<-END.strip_indent)
         if a
         else
         end
       END
-      expect(cop.offenses).to be_empty
     end
 
     it 'accepts an if in assignment with end aligned with variable' do
-      inspect_source(cop, <<-END.strip_indent)
+      expect_no_offenses(<<-END.strip_indent)
         var = if a
           0
         end
@@ -145,18 +140,16 @@ describe RuboCop::Cop::Layout::IndentationConsistency, :config do
           0
         end
       END
-      expect(cop.offenses).to be_empty
     end
 
     it 'accepts an if/else in assignment with end aligned with variable' do
-      inspect_source(cop, <<-END.strip_indent)
+      expect_no_offenses(<<-END.strip_indent)
         var = if a
           0
         else
           1
         end
       END
-      expect(cop.offenses).to be_empty
     end
 
     it 'accepts an if/else in assignment with end aligned with variable ' \
@@ -184,23 +177,21 @@ describe RuboCop::Cop::Layout::IndentationConsistency, :config do
     end
 
     it 'accepts an if in assignment with end aligned with if' do
-      inspect_source(cop, <<-END.strip_indent)
+      expect_no_offenses(<<-END.strip_indent)
         var = if a
                 0
               end
       END
-      expect(cop.offenses).to be_empty
     end
 
     it 'accepts an if/else in assignment with end aligned with if' do
-      inspect_source(cop, <<-END.strip_indent)
+      expect_no_offenses(<<-END.strip_indent)
         var = if a
                 0
               else
                 1
               end
       END
-      expect(cop.offenses).to be_empty
     end
 
     it 'accepts an if/else in assignment on next line with end aligned ' \
@@ -219,14 +210,13 @@ describe RuboCop::Cop::Layout::IndentationConsistency, :config do
     it 'accepts an if/else branches with rescue clauses' do
       # Because of how the rescue clauses come out of Parser, these are
       # special and need to be tested.
-      inspect_source(cop, <<-END.strip_indent)
+      expect_no_offenses(<<-END.strip_indent)
         if a
           a rescue nil
         else
           a rescue nil
         end
       END
-      expect(cop.offenses).to be_empty
     end
   end
 
@@ -242,12 +232,11 @@ describe RuboCop::Cop::Layout::IndentationConsistency, :config do
     end
 
     it 'accepts an empty unless' do
-      inspect_source(cop, <<-END.strip_indent)
+      expect_no_offenses(<<-END.strip_indent)
         unless a
         else
         end
       END
-      expect(cop.offenses).to be_empty
     end
   end
 
@@ -279,7 +268,7 @@ describe RuboCop::Cop::Layout::IndentationConsistency, :config do
     end
 
     it 'accepts correctly indented case/when/else' do
-      inspect_source(cop, <<-END.strip_indent)
+      expect_no_offenses(<<-END.strip_indent)
         case a
         when b
           c
@@ -289,33 +278,30 @@ describe RuboCop::Cop::Layout::IndentationConsistency, :config do
           f
         end
       END
-      expect(cop.offenses).to be_empty
     end
 
     it 'accepts case/when/else laid out as a table' do
-      inspect_source(cop, <<-END.strip_indent)
+      expect_no_offenses(<<-END.strip_indent)
         case sexp.loc.keyword.source
         when 'if'     then cond, body, _else = *sexp
         when 'unless' then cond, _else, body = *sexp
         else               cond, body = *sexp
         end
       END
-      expect(cop.offenses).to be_empty
     end
 
     it 'accepts case/when/else with then beginning a line' do
-      inspect_source(cop, <<-END.strip_indent)
+      expect_no_offenses(<<-END.strip_indent)
         case sexp.loc.keyword.source
         when 'if'
         then cond, body, _else = *sexp
         end
       END
-      expect(cop.offenses).to be_empty
     end
 
     it 'accepts indented when/else plus indented body' do
       # "Indent when as deep as case" is the job of another cop.
-      inspect_source(cop, <<-END.strip_indent)
+      expect_no_offenses(<<-END.strip_indent)
         case code_type
           when 'ruby', 'sql', 'plain'
             code_type
@@ -327,7 +313,6 @@ describe RuboCop::Cop::Layout::IndentationConsistency, :config do
             'plain'
         end
       END
-      expect(cop.offenses).to be_empty
     end
   end
 
@@ -363,11 +348,10 @@ describe RuboCop::Cop::Layout::IndentationConsistency, :config do
     end
 
     it 'accepts an empty while' do
-      inspect_source(cop, <<-END.strip_indent)
+      expect_no_offenses(<<-END.strip_indent)
         while a
         end
       END
-      expect(cop.offenses).to be_empty
     end
   end
 
@@ -383,11 +367,10 @@ describe RuboCop::Cop::Layout::IndentationConsistency, :config do
     end
 
     it 'accepts an empty for' do
-      inspect_source(cop, <<-END.strip_indent)
+      expect_no_offenses(<<-END.strip_indent)
         for var in 1..10
         end
       END
-      expect(cop.offenses).to be_empty
     end
   end
 
@@ -414,19 +397,17 @@ describe RuboCop::Cop::Layout::IndentationConsistency, :config do
     end
 
     it 'accepts an empty def body' do
-      inspect_source(cop, <<-END.strip_indent)
+      expect_no_offenses(<<-END.strip_indent)
         def test
         end
       END
-      expect(cop.offenses).to be_empty
     end
 
     it 'accepts an empty defs body' do
-      inspect_source(cop, <<-END.strip_indent)
+      expect_no_offenses(<<-END.strip_indent)
         def self.test
         end
       END
-      expect(cop.offenses).to be_empty
     end
   end
 
@@ -435,7 +416,7 @@ describe RuboCop::Cop::Layout::IndentationConsistency, :config do
       let(:cop_config) { { 'EnforcedStyle' => 'rails' } }
 
       it 'accepts different indentation in different visibility sections' do
-        inspect_source(cop, <<-END.strip_indent)
+        expect_no_offenses(<<-END.strip_indent)
           class Cat
             def meow
               puts('Meow!')
@@ -467,7 +448,6 @@ describe RuboCop::Cop::Layout::IndentationConsistency, :config do
             end
           end
         END
-        expect(cop.offenses).to be_empty
       end
     end
 
@@ -486,15 +466,14 @@ describe RuboCop::Cop::Layout::IndentationConsistency, :config do
       end
 
       it 'accepts an empty class body' do
-        inspect_source(cop, <<-END.strip_indent)
+        expect_no_offenses(<<-END.strip_indent)
           class Test
           end
         END
-        expect(cop.offenses).to be_empty
       end
 
       it 'accepts indented public, protected, and private' do
-        inspect_source(cop, <<-END.strip_indent)
+        expect_no_offenses(<<-END.strip_indent)
           class Test
             public
 
@@ -512,7 +491,6 @@ describe RuboCop::Cop::Layout::IndentationConsistency, :config do
             end
           end
         END
-        expect(cop.offenses).to be_empty
       end
 
       it 'registers an offense for bad indentation in def but not for ' \
@@ -555,11 +533,10 @@ describe RuboCop::Cop::Layout::IndentationConsistency, :config do
     end
 
     it 'accepts an empty module body' do
-      inspect_source(cop, <<-END.strip_indent)
+      expect_no_offenses(<<-END.strip_indent)
         module Test
         end
       END
-      expect(cop.offenses).to be_empty
     end
   end
 
@@ -585,21 +562,19 @@ describe RuboCop::Cop::Layout::IndentationConsistency, :config do
     end
 
     it 'accepts a correctly indented block body' do
-      inspect_source(cop, <<-END.strip_indent)
+      expect_no_offenses(<<-END.strip_indent)
         a = func do
           b
           c
         end
       END
-      expect(cop.offenses).to be_empty
     end
 
     it 'accepts an empty block body' do
-      inspect_source(cop, <<-END.strip_indent)
+      expect_no_offenses(<<-END.strip_indent)
         a = func do
         end
       END
-      expect(cop.offenses).to be_empty
     end
 
     it 'does not auto-correct an offense within another offense' do

--- a/spec/rubocop/cop/layout/indentation_width_spec.rb
+++ b/spec/rubocop/cop/layout/indentation_width_spec.rb
@@ -23,13 +23,12 @@ describe RuboCop::Cop::Layout::IndentationWidth do
       let(:bom) { "\xef\xbb\xbf" }
 
       it 'accepts correctly indented method definition' do
-        inspect_source(cop, <<-END.strip_indent)
+        expect_no_offenses(<<-END.strip_indent)
           #{bom}class Test
               def method
               end
           end
         END
-        expect(cop.offenses).to be_empty
       end
     end
 
@@ -42,7 +41,7 @@ describe RuboCop::Cop::Layout::IndentationWidth do
       end
 
       it 'accepts unindented lines for those keywords' do
-        inspect_source(cop, <<-END.strip_indent)
+        expect_no_offenses(<<-END.strip_indent)
           module Foo
           class Test
               if blah
@@ -57,7 +56,6 @@ describe RuboCop::Cop::Layout::IndentationWidth do
           end
           end
         END
-        expect(cop.offenses).to be_empty
       end
     end
 
@@ -165,33 +163,30 @@ describe RuboCop::Cop::Layout::IndentationWidth do
       end
 
       it 'accepts indentation after if on new line after assignment' do
-        inspect_source(cop, <<-END.strip_indent)
+        expect_no_offenses(<<-END.strip_indent)
           Rails.application.config.ideal_postcodes_key =
             if Rails.env.production? || Rails.env.staging?
               "AAAA-AAAA-AAAA-AAAA"
             end
         END
-        expect(cop.offenses).to be_empty
       end
 
       it 'accepts `rescue` after an empty body' do
-        inspect_source(cop, <<-END.strip_indent)
+        expect_no_offenses(<<-END.strip_indent)
           begin
           rescue
             handle_error
           end
         END
-        expect(cop.offenses).to be_empty
       end
 
       it 'accepts `ensure` after an empty body' do
-        inspect_source(cop, <<-END.strip_indent)
+        expect_no_offenses(<<-END.strip_indent)
           begin
           ensure
             something
           end
         END
-        expect(cop.offenses).to be_empty
       end
 
       describe '#autocorrect' do
@@ -342,7 +337,7 @@ describe RuboCop::Cop::Layout::IndentationWidth do
       end
 
       it 'accepts a correctly aligned if/elsif/else/end' do
-        inspect_source(cop, <<-END.strip_indent)
+        expect_no_offenses(<<-END.strip_indent)
           if a1
             b1
           elsif a2
@@ -351,11 +346,10 @@ describe RuboCop::Cop::Layout::IndentationWidth do
             c
           end
         END
-        expect(cop.offenses).to be_empty
       end
 
       it 'accepts a correctly aligned if/elsif/else/end as a method argument' do
-        inspect_source(cop, <<-END.strip_indent)
+        expect_no_offenses(<<-END.strip_indent)
           foo(
             if a1
               b1
@@ -366,62 +360,56 @@ describe RuboCop::Cop::Layout::IndentationWidth do
             end
           )
         END
-        expect(cop.offenses).to be_empty
       end
 
       it 'accepts if/elsif/else/end laid out as a table' do
-        inspect_source(cop, <<-END.strip_indent)
+        expect_no_offenses(<<-END.strip_indent)
           if    @io == $stdout then str << "$stdout"
           elsif @io == $stdin  then str << "$stdin"
           elsif @io == $stderr then str << "$stderr"
           else                      str << @io.class.to_s
           end
         END
-        expect(cop.offenses).to be_empty
       end
 
       it 'accepts if/then/else/end laid out as another table' do
-        inspect_source(cop, <<-END.strip_indent)
+        expect_no_offenses(<<-END.strip_indent)
           if File.exist?('config.save')
           then ConfigTable.load
           else ConfigTable.new
           end
         END
-        expect(cop.offenses).to be_empty
       end
 
       it 'accepts an empty if' do
-        inspect_source(cop, <<-END.strip_indent)
+        expect_no_offenses(<<-END.strip_indent)
           if a
           else
           end
         END
-        expect(cop.offenses).to be_empty
       end
 
       context 'with assignment' do
         context 'when alignment style is variable' do
           context 'and end is aligned with variable' do
             it 'accepts an if with end aligned with setter' do
-              inspect_source(cop, <<-END.strip_indent)
+              expect_no_offenses(<<-END.strip_indent)
                 foo.bar = if baz
                   derp
                 end
               END
-              expect(cop.offenses).to be_empty
             end
 
             it 'accepts an if with end aligned with element assignment' do
-              inspect_source(cop, <<-END.strip_indent)
+              expect_no_offenses(<<-END.strip_indent)
                 foo[bar] = if baz
                   derp
                 end
               END
-              expect(cop.offenses).to be_empty
             end
 
             it 'accepts an if with end aligned with variable' do
-              inspect_source(cop, <<-END.strip_indent)
+              expect_no_offenses(<<-END.strip_indent)
                 var = if a
                   0
                 end
@@ -444,40 +432,36 @@ describe RuboCop::Cop::Layout::IndentationWidth do
                   0
                 end
               END
-              expect(cop.offenses).to be_empty
             end
 
             it 'accepts an if/else' do
-              inspect_source(cop, <<-END.strip_indent)
+              expect_no_offenses(<<-END.strip_indent)
                 var = if a
                   0
                 else
                   1
                 end
               END
-              expect(cop.offenses).to be_empty
             end
 
             it 'accepts an if/else with chaining after the end' do
-              inspect_source(cop, <<-END.strip_indent)
+              expect_no_offenses(<<-END.strip_indent)
                 var = if a
                   0
                 else
                   1
                 end.abc.join("")
               END
-              expect(cop.offenses).to be_empty
             end
 
             it 'accepts an if/else with chaining with a block after the end' do
-              inspect_source(cop, <<-END.strip_indent)
+              expect_no_offenses(<<-END.strip_indent)
                 var = if a
                   0
                 else
                   1
                 end.abc.tap {}
               END
-              expect(cop.offenses).to be_empty
             end
           end
 
@@ -613,27 +597,25 @@ describe RuboCop::Cop::Layout::IndentationWidth do
 
           context 'and end is aligned with keyword' do
             it 'accepts an if in assignment' do
-              inspect_source(cop, <<-END.strip_indent)
+              expect_no_offenses(<<-END.strip_indent)
                 var = if a
                         0
                       end
               END
-              expect(cop.offenses).to be_empty
             end
 
             it 'accepts an if/else in assignment' do
-              inspect_source(cop, <<-END.strip_indent)
+              expect_no_offenses(<<-END.strip_indent)
                 var = if a
                         0
                       else
                         1
                       end
               END
-              expect(cop.offenses).to be_empty
             end
 
             it 'accepts an if/else in assignment on next line' do
-              inspect_source(cop, <<-END.strip_indent)
+              expect_no_offenses(<<-END.strip_indent)
                 var =
                   if a
                     0
@@ -641,25 +623,22 @@ describe RuboCop::Cop::Layout::IndentationWidth do
                     1
                   end
               END
-              expect(cop.offenses).to be_empty
             end
 
             it 'accepts a while in assignment' do
-              inspect_source(cop, <<-END.strip_indent)
+              expect_no_offenses(<<-END.strip_indent)
                 var = while a
                         b
                       end
               END
-              expect(cop.offenses).to be_empty
             end
 
             it 'accepts an until in assignment' do
-              inspect_source(cop, <<-END.strip_indent)
+              expect_no_offenses(<<-END.strip_indent)
                 var = until a
                         b
                       end
               END
-              expect(cop.offenses).to be_empty
             end
           end
         end
@@ -676,14 +655,13 @@ describe RuboCop::Cop::Layout::IndentationWidth do
       it 'accepts an if/else branches with rescue clauses' do
         # Because of how the rescue clauses come out of Parser, these are
         # special and need to be tested.
-        inspect_source(cop, <<-END.strip_indent)
+        expect_no_offenses(<<-END.strip_indent)
           if a
             a rescue nil
           else
             a rescue nil
           end
         END
-        expect(cop.offenses).to be_empty
       end
     end
 
@@ -698,12 +676,11 @@ describe RuboCop::Cop::Layout::IndentationWidth do
       end
 
       it 'accepts an empty unless' do
-        inspect_source(cop, <<-END.strip_indent)
+        expect_no_offenses(<<-END.strip_indent)
           unless a
           else
           end
         END
-        expect(cop.offenses).to be_empty
       end
     end
 
@@ -733,7 +710,7 @@ describe RuboCop::Cop::Layout::IndentationWidth do
       end
 
       it 'accepts correctly indented case/when/else' do
-        inspect_source(cop, <<-END.strip_indent)
+        expect_no_offenses(<<-END.strip_indent)
           case a
           when b
             c
@@ -743,11 +720,10 @@ describe RuboCop::Cop::Layout::IndentationWidth do
             f
           end
         END
-        expect(cop.offenses).to be_empty
       end
 
       it 'accepts aligned values in when clause' do
-        inspect_source(cop, <<-'END'.strip_indent)
+        expect_no_offenses(<<-'END'.strip_indent)
           case superclass
           when /\A(#{NAMESPACEMATCH})(?:\s|\Z)/,
                /\A(Struct|OStruct)\.new/,
@@ -758,33 +734,30 @@ describe RuboCop::Cop::Layout::IndentationWidth do
             namespace.path
           end
         END
-        expect(cop.offenses).to be_empty
       end
 
       it 'accepts case/when/else laid out as a table' do
-        inspect_source(cop, <<-END.strip_indent)
+        expect_no_offenses(<<-END.strip_indent)
           case sexp.loc.keyword.source
           when 'if'     then cond, body, _else = *sexp
           when 'unless' then cond, _else, body = *sexp
           else               cond, body = *sexp
           end
         END
-        expect(cop.offenses).to be_empty
       end
 
       it 'accepts case/when/else with then beginning a line' do
-        inspect_source(cop, <<-END.strip_indent)
+        expect_no_offenses(<<-END.strip_indent)
           case sexp.loc.keyword.source
           when 'if'
           then cond, body, _else = *sexp
           end
         END
-        expect(cop.offenses).to be_empty
       end
 
       it 'accepts indented when/else plus indented body' do
         # "Indent when as deep as case" is the job of another cop.
-        inspect_source(cop, <<-END.strip_indent)
+        expect_no_offenses(<<-END.strip_indent)
           case code_type
             when 'ruby', 'sql', 'plain'
               code_type
@@ -796,7 +769,6 @@ describe RuboCop::Cop::Layout::IndentationWidth do
               'plain'
           end
         END
-        expect(cop.offenses).to be_empty
       end
     end
 
@@ -830,11 +802,10 @@ describe RuboCop::Cop::Layout::IndentationWidth do
       end
 
       it 'accepts an empty while' do
-        inspect_source(cop, <<-END.strip_indent)
+        expect_no_offenses(<<-END.strip_indent)
           while a
           end
         END
-        expect(cop.offenses).to be_empty
       end
     end
 
@@ -849,11 +820,10 @@ describe RuboCop::Cop::Layout::IndentationWidth do
       end
 
       it 'accepts an empty for' do
-        inspect_source(cop, <<-END.strip_indent)
+        expect_no_offenses(<<-END.strip_indent)
           for var in 1..10
           end
         END
-        expect(cop.offenses).to be_empty
       end
     end
 
@@ -879,27 +849,24 @@ describe RuboCop::Cop::Layout::IndentationWidth do
         end
 
         it 'accepts an empty def body' do
-          inspect_source(cop, <<-END.strip_indent)
+          expect_no_offenses(<<-END.strip_indent)
             def test
             end
           END
-          expect(cop.offenses).to be_empty
         end
 
         it 'accepts an empty defs body' do
-          inspect_source(cop, <<-END.strip_indent)
+          expect_no_offenses(<<-END.strip_indent)
             def self.test
             end
           END
-          expect(cop.offenses).to be_empty
         end
 
         it 'with an assignment' do
-          inspect_source(cop, <<-END.strip_indent)
+          expect_no_offenses(<<-END.strip_indent)
             something = def self.foo
             end
           END
-          expect(cop.offenses).to be_empty
         end
       end
 
@@ -913,12 +880,11 @@ describe RuboCop::Cop::Layout::IndentationWidth do
         if RUBY_VERSION >= '2.1'
           context 'when modifier and def are on the same line' do
             it 'accepts a correctly aligned body' do
-              inspect_source(cop, <<-END.strip_indent)
+              expect_no_offenses(<<-END.strip_indent)
                 foo def test
                   something
                 end
               END
-              expect(cop.offenses).to be_empty
             end
 
             it 'registers an offense for bad indentation of a def body' do
@@ -954,12 +920,11 @@ describe RuboCop::Cop::Layout::IndentationWidth do
         if RUBY_VERSION >= '2.1'
           context 'when modifier and def are on the same line' do
             it 'accepts a correctly aligned body' do
-              inspect_source(cop, <<-END.strip_indent)
+              expect_no_offenses(<<-END.strip_indent)
                 foo def test
                       something
                 end
               END
-              expect(cop.offenses).to be_empty
             end
 
             it 'registers an offense for bad indentation of a def body' do
@@ -998,16 +963,15 @@ describe RuboCop::Cop::Layout::IndentationWidth do
       end
 
       it 'accepts an empty class body' do
-        inspect_source(cop, <<-END.strip_indent)
+        expect_no_offenses(<<-END.strip_indent)
           class Test
           end
         END
-        expect(cop.offenses).to be_empty
       end
 
       context 'when consistency style is normal' do
         it 'accepts indented public, protected, and private' do
-          inspect_source(cop, <<-END.strip_indent)
+          expect_no_offenses(<<-END.strip_indent)
             class Test
               public
 
@@ -1025,7 +989,6 @@ describe RuboCop::Cop::Layout::IndentationWidth do
               end
             end
           END
-          expect(cop.offenses).to be_empty
         end
       end
 
@@ -1071,11 +1034,10 @@ describe RuboCop::Cop::Layout::IndentationWidth do
         end
 
         it 'accepts an empty module body' do
-          inspect_source(cop, <<-END.strip_indent)
+          expect_no_offenses(<<-END.strip_indent)
             module Test
             end
           END
-          expect(cop.offenses).to be_empty
         end
       end
 
@@ -1098,14 +1060,13 @@ describe RuboCop::Cop::Layout::IndentationWidth do
         end
 
         it 'accepts normal non-rails indentation of module functions' do
-          inspect_source(cop, <<-END.strip_indent)
+          expect_no_offenses(<<-END.strip_indent)
             module Test
               module_function
               def func
               end
             end
           END
-          expect(cop.offenses).to be_empty
         end
       end
     end
@@ -1208,31 +1169,28 @@ describe RuboCop::Cop::Layout::IndentationWidth do
       end
 
       it 'accepts a correctly indented block body' do
-        inspect_source(cop, <<-END.strip_indent)
+        expect_no_offenses(<<-END.strip_indent)
           a = func do
             b
           end
         END
-        expect(cop.offenses).to be_empty
       end
 
       it 'accepts an empty block body' do
-        inspect_source(cop, <<-END.strip_indent)
+        expect_no_offenses(<<-END.strip_indent)
           a = func do
           end
         END
-        expect(cop.offenses).to be_empty
       end
 
       # The cop uses the block end/} as the base for indentation, so if it's not
       # on its own line, all bets are off.
       it 'accepts badly indented code if block end is not on separate line' do
-        inspect_source(cop, <<-END.strip_indent)
+        expect_no_offenses(<<-END.strip_indent)
           foo {
           def baz
           end }
         END
-        expect(cop.offenses).to be_empty
       end
     end
   end

--- a/spec/rubocop/cop/layout/indentation_width_spec.rb
+++ b/spec/rubocop/cop/layout/indentation_width_spec.rb
@@ -338,8 +338,7 @@ describe RuboCop::Cop::Layout::IndentationWidth do
       end
 
       it 'accepts a one line if statement' do
-        inspect_source(cop, 'if cond then func1 else func2 end')
-        expect(cop.offenses).to be_empty
+        expect_no_offenses('if cond then func1 else func2 end')
       end
 
       it 'accepts a correctly aligned if/elsif/else/end' do

--- a/spec/rubocop/cop/layout/initial_indentation_spec.rb
+++ b/spec/rubocop/cop/layout/initial_indentation_spec.rb
@@ -40,8 +40,7 @@ describe RuboCop::Cop::Layout::InitialIndentation do
   end
 
   it 'accepts empty file' do
-    inspect_source(cop, '')
-    expect(cop.offenses).to be_empty
+    expect_no_offenses('')
   end
 
   it 'registers an offense for indented assignment disregarding comment' do

--- a/spec/rubocop/cop/layout/initial_indentation_spec.rb
+++ b/spec/rubocop/cop/layout/initial_indentation_spec.rb
@@ -12,11 +12,10 @@ describe RuboCop::Cop::Layout::InitialIndentation do
   end
 
   it 'accepts unindented method definition' do
-    inspect_source(cop, <<-END.strip_indent)
+    expect_no_offenses(<<-END.strip_indent)
       def f
       end
     END
-    expect(cop.offenses).to be_empty
   end
 
   context 'for a file with byte order mark' do
@@ -52,11 +51,10 @@ describe RuboCop::Cop::Layout::InitialIndentation do
   end
 
   it 'accepts unindented comment + assignment' do
-    inspect_source(cop, <<-END.strip_indent)
+    expect_no_offenses(<<-END.strip_indent)
       # comment
       x = 1
     END
-    expect(cop.offenses).to be_empty
   end
 
   it 'auto-corrects indented method definition' do

--- a/spec/rubocop/cop/layout/leading_comment_space_spec.rb
+++ b/spec/rubocop/cop/layout/leading_comment_space_spec.rb
@@ -25,11 +25,10 @@ describe RuboCop::Cop::Layout::LeadingCommentSpace do
   end
 
   it 'does not register an offense for #! on first line' do
-    inspect_source(cop, <<-END.strip_indent)
+    expect_no_offenses(<<-END.strip_indent)
       #!/usr/bin/ruby
       test
     END
-    expect(cop.offenses).to be_empty
   end
 
   it 'registers an offense for #! after the first line' do
@@ -77,13 +76,11 @@ describe RuboCop::Cop::Layout::LeadingCommentSpace do
   end
 
   it 'accepts rdoc syntax' do
-    inspect_source(cop, <<-END.strip_indent)
+    expect_no_offenses(<<-END.strip_indent)
       #++
       #--
       #:nodoc:
     END
-
-    expect(cop.offenses).to be_empty
   end
 
   it 'accepts sprockets directives' do
@@ -96,11 +93,10 @@ describe RuboCop::Cop::Layout::LeadingCommentSpace do
   end
 
   it 'accepts =begin/=end comments' do
-    inspect_source(cop, <<-END.strip_indent)
+    expect_no_offenses(<<-END.strip_indent)
       =begin
       #blahblah
       =end
     END
-    expect(cop.offenses).to be_empty
   end
 end

--- a/spec/rubocop/cop/layout/leading_comment_space_spec.rb
+++ b/spec/rubocop/cop/layout/leading_comment_space_spec.rb
@@ -9,23 +9,19 @@ describe RuboCop::Cop::Layout::LeadingCommentSpace do
   end
 
   it 'does not register an offense for # followed by no text' do
-    inspect_source(cop, '#')
-    expect(cop.offenses).to be_empty
+    expect_no_offenses('#')
   end
 
   it 'does not register an offense for more than one space' do
-    inspect_source(cop, '#   heavily indented')
-    expect(cop.offenses).to be_empty
+    expect_no_offenses('#   heavily indented')
   end
 
   it 'does not register an offense for more than one #' do
-    inspect_source(cop, '###### heavily indented')
-    expect(cop.offenses).to be_empty
+    expect_no_offenses('###### heavily indented')
   end
 
   it 'does not register an offense for only #s' do
-    inspect_source(cop, '######')
-    expect(cop.offenses).to be_empty
+    expect_no_offenses('######')
   end
 
   it 'does not register an offense for #! on first line' do
@@ -91,8 +87,7 @@ describe RuboCop::Cop::Layout::LeadingCommentSpace do
   end
 
   it 'accepts sprockets directives' do
-    inspect_source(cop, '#= require_tree .')
-    expect(cop.offenses).to be_empty
+    expect_no_offenses('#= require_tree .')
   end
 
   it 'auto-corrects missing space' do

--- a/spec/rubocop/cop/layout/multiline_array_brace_layout_spec.rb
+++ b/spec/rubocop/cop/layout/multiline_array_brace_layout_spec.rb
@@ -14,15 +14,11 @@ describe RuboCop::Cop::Layout::MultilineArrayBraceLayout, :config do
   end
 
   it 'ignores single-line arrays' do
-    inspect_source(cop, '[a, b, c]')
-
-    expect(cop.offenses).to be_empty
+    expect_no_offenses('[a, b, c]')
   end
 
   it 'ignores empty arrays' do
-    inspect_source(cop, '[]')
-
-    expect(cop.offenses).to be_empty
+    expect_no_offenses('[]')
   end
 
   include_examples 'multiline literal brace layout' do

--- a/spec/rubocop/cop/layout/multiline_array_brace_layout_spec.rb
+++ b/spec/rubocop/cop/layout/multiline_array_brace_layout_spec.rb
@@ -5,12 +5,10 @@ describe RuboCop::Cop::Layout::MultilineArrayBraceLayout, :config do
   let(:cop_config) { { 'EnforcedStyle' => 'symmetrical' } }
 
   it 'ignores implicit arrays' do
-    inspect_source(cop, <<-END.strip_indent)
+    expect_no_offenses(<<-END.strip_indent)
       foo = a,
       b
     END
-
-    expect(cop.offenses).to be_empty
   end
 
   it 'ignores single-line arrays' do

--- a/spec/rubocop/cop/layout/multiline_assignment_layout_spec.rb
+++ b/spec/rubocop/cop/layout/multiline_assignment_layout_spec.rb
@@ -40,12 +40,10 @@ describe RuboCop::Cop::Layout::MultilineAssignmentLayout, :config do
     end
 
     it 'ignores arrays' do
-      inspect_source(cop, <<-END.strip_indent)
+      expect_no_offenses(<<-END.strip_indent)
         a, b = 4,
         5
       END
-
-      expect(cop.offenses).to be_empty
     end
 
     context 'configured supported types' do
@@ -65,13 +63,11 @@ describe RuboCop::Cop::Layout::MultilineAssignmentLayout, :config do
     end
 
     it 'allows multi-line assignments on separate lines' do
-      inspect_source(cop, <<-END.strip_indent)
+      expect_no_offenses(<<-END.strip_indent)
         blarg=
         if true
         end
       END
-
-      expect(cop.offenses).to be_empty
     end
 
     it 'registers an offense for masgn with multi-line lhs' do
@@ -118,13 +114,11 @@ describe RuboCop::Cop::Layout::MultilineAssignmentLayout, :config do
     end
 
     it 'ignores arrays' do
-      inspect_source(cop, <<-END.strip_indent)
+      expect_no_offenses(<<-END.strip_indent)
         a, b =
         4,
         5
       END
-
-      expect(cop.offenses).to be_empty
     end
 
     context 'configured supported types' do
@@ -145,12 +139,10 @@ describe RuboCop::Cop::Layout::MultilineAssignmentLayout, :config do
     end
 
     it 'allows multi-line assignments on the same line' do
-      inspect_source(cop, <<-END.strip_indent)
+      expect_no_offenses(<<-END.strip_indent)
         blarg= if true
         end
       END
-
-      expect(cop.offenses).to be_empty
     end
 
     it 'registers an offense for masgn with multi-line lhs' do

--- a/spec/rubocop/cop/layout/multiline_block_layout_spec.rb
+++ b/spec/rubocop/cop/layout/multiline_block_layout_spec.rb
@@ -48,29 +48,26 @@ describe RuboCop::Cop::Layout::MultilineBlockLayout do
   end
 
   it 'does not register offenses when there is a newline for do/end block' do
-    inspect_source(cop, <<-END.strip_indent)
+    expect_no_offenses(<<-END.strip_indent)
       test do
         foo
       end
     END
-    expect(cop.offenses).to be_empty
   end
 
   it 'does not error out when the block is empty' do
-    inspect_source(cop, <<-END.strip_indent)
+    expect_no_offenses(<<-END.strip_indent)
       test do |x|
       end
     END
-    expect(cop.offenses).to be_empty
   end
 
   it 'does not register offenses when there is a newline for {} block' do
-    inspect_source(cop, <<-END.strip_indent)
+    expect_no_offenses(<<-END.strip_indent)
       test {
         foo
       }
     END
-    expect(cop.offenses).to be_empty
   end
 
   it 'registers offenses for lambdas as expected' do

--- a/spec/rubocop/cop/layout/multiline_block_layout_spec.rb
+++ b/spec/rubocop/cop/layout/multiline_block_layout_spec.rb
@@ -40,13 +40,11 @@ describe RuboCop::Cop::Layout::MultilineBlockLayout do
   end
 
   it 'does not register an offense for one-line do/end blocks' do
-    inspect_source(cop, 'test do foo end')
-    expect(cop.offenses).to be_empty
+    expect_no_offenses('test do foo end')
   end
 
   it 'does not register an offense for one-line {} blocks' do
-    inspect_source(cop, 'test { foo }')
-    expect(cop.offenses).to be_empty
+    expect_no_offenses('test { foo }')
   end
 
   it 'does not register offenses when there is a newline for do/end block' do

--- a/spec/rubocop/cop/layout/multiline_hash_brace_layout_spec.rb
+++ b/spec/rubocop/cop/layout/multiline_hash_brace_layout_spec.rb
@@ -14,15 +14,11 @@ describe RuboCop::Cop::Layout::MultilineHashBraceLayout, :config do
   end
 
   it 'ignores single-line hashes' do
-    inspect_source(cop, '{a: 1, b: 2}')
-
-    expect(cop.offenses).to be_empty
+    expect_no_offenses('{a: 1, b: 2}')
   end
 
   it 'ignores empty hashes' do
-    inspect_source(cop, '{}')
-
-    expect(cop.offenses).to be_empty
+    expect_no_offenses('{}')
   end
 
   include_examples 'multiline literal brace layout' do

--- a/spec/rubocop/cop/layout/multiline_hash_brace_layout_spec.rb
+++ b/spec/rubocop/cop/layout/multiline_hash_brace_layout_spec.rb
@@ -5,12 +5,10 @@ describe RuboCop::Cop::Layout::MultilineHashBraceLayout, :config do
   let(:cop_config) { { 'EnforcedStyle' => 'symmetrical' } }
 
   it 'ignores implicit hashes' do
-    inspect_source(cop, <<-END.strip_indent)
+    expect_no_offenses(<<-END.strip_indent)
       foo(a: 1,
       b: 2)
     END
-
-    expect(cop.offenses).to be_empty
   end
 
   it 'ignores single-line hashes' do

--- a/spec/rubocop/cop/layout/multiline_method_call_brace_layout_spec.rb
+++ b/spec/rubocop/cop/layout/multiline_method_call_brace_layout_spec.rb
@@ -5,12 +5,10 @@ describe RuboCop::Cop::Layout::MultilineMethodCallBraceLayout, :config do
   let(:cop_config) { { 'EnforcedStyle' => 'symmetrical' } }
 
   it 'ignores implicit calls' do
-    inspect_source(cop, <<-END.strip_indent)
+    expect_no_offenses(<<-END.strip_indent)
       foo 1,
       2
     END
-
-    expect(cop.offenses).to be_empty
   end
 
   it 'ignores single-line calls' do
@@ -26,12 +24,10 @@ describe RuboCop::Cop::Layout::MultilineMethodCallBraceLayout, :config do
   end
 
   it 'ignores calls with a multiline empty brace ' do
-    inspect_source(cop, <<-END.strip_indent)
+    expect_no_offenses(<<-END.strip_indent)
       puts(
       )
     END
-
-    expect(cop.offenses).to be_empty
   end
 
   include_examples 'multiline literal brace layout' do
@@ -52,20 +48,18 @@ describe RuboCop::Cop::Layout::MultilineMethodCallBraceLayout, :config do
     end
 
     it 'ignores single-line calls with multi-line receiver' do
-      inspect_source(cop, <<-END.strip_indent)
+      expect_no_offenses(<<-END.strip_indent)
         [
         ].join(" ")
       END
-      expect(cop.offenses).to be_empty
     end
 
     it 'ignores single-line calls with multi-line receiver with leading dot' do
-      inspect_source(cop, <<-END.strip_indent)
+      expect_no_offenses(<<-END.strip_indent)
         [
         ]
         .join(" ")
       END
-      expect(cop.offenses).to be_empty
     end
   end
 end

--- a/spec/rubocop/cop/layout/multiline_method_call_brace_layout_spec.rb
+++ b/spec/rubocop/cop/layout/multiline_method_call_brace_layout_spec.rb
@@ -14,21 +14,15 @@ describe RuboCop::Cop::Layout::MultilineMethodCallBraceLayout, :config do
   end
 
   it 'ignores single-line calls' do
-    inspect_source(cop, 'foo(1,2)')
-
-    expect(cop.offenses).to be_empty
+    expect_no_offenses('foo(1,2)')
   end
 
   it 'ignores calls without arguments' do
-    inspect_source(cop, 'puts')
-
-    expect(cop.offenses).to be_empty
+    expect_no_offenses('puts')
   end
 
   it 'ignores calls with an empty brace' do
-    inspect_source(cop, 'puts()')
-
-    expect(cop.offenses).to be_empty
+    expect_no_offenses('puts()')
   end
 
   it 'ignores calls with a multiline empty brace ' do
@@ -54,8 +48,7 @@ describe RuboCop::Cop::Layout::MultilineMethodCallBraceLayout, :config do
     let(:cop_config) { { 'EnforcedStyle' => 'new_line' } }
 
     it 'still ignores single-line calls' do
-      inspect_source(cop, 'puts("Hello world!")')
-      expect(cop.offenses).to be_empty
+      expect_no_offenses('puts("Hello world!")')
     end
 
     it 'ignores single-line calls with multi-line receiver' do

--- a/spec/rubocop/cop/layout/multiline_method_call_indentation_spec.rb
+++ b/spec/rubocop/cop/layout/multiline_method_call_indentation_spec.rb
@@ -262,8 +262,7 @@ describe RuboCop::Cop::Layout::MultilineMethodCallIndentation do
       end
 
       it "doesn't fail on a chain of aref calls" do
-        inspect_source(cop, 'a[1][2][3]')
-        expect(cop.offenses).to be_empty
+        expect_no_offenses('a[1][2][3]')
       end
 
       it 'accepts aligned method with blocks in operation assignment' do

--- a/spec/rubocop/cop/layout/multiline_method_call_indentation_spec.rb
+++ b/spec/rubocop/cop/layout/multiline_method_call_indentation_spec.rb
@@ -16,11 +16,10 @@ describe RuboCop::Cop::Layout::MultilineMethodCallIndentation do
 
   shared_examples 'common' do
     it 'accepts indented methods in LHS of []= assignment' do
-      inspect_source(cop, <<-END.strip_indent)
+      expect_no_offenses(<<-END.strip_indent)
         a
           .b[c] = 0
       END
-      expect(cop.offenses).to be_empty
     end
 
     it 'accepts indented methods inside and outside a block' do
@@ -38,12 +37,11 @@ describe RuboCop::Cop::Layout::MultilineMethodCallIndentation do
     end
 
     it 'accepts indentation relative to first receiver' do
-      inspect_source(cop, <<-END.strip_indent)
+      expect_no_offenses(<<-END.strip_indent)
         node
           .children.map { |n| string_source(n) }.compact
           .any? { |s| preferred.any? { |d| s.include?(d) } }
       END
-      expect(cop.offenses).to be_empty
     end
 
     it 'accepts indented methods in ordinary statement' do
@@ -213,11 +211,10 @@ describe RuboCop::Cop::Layout::MultilineMethodCallIndentation do
     # a chain of calls, and that first dot does not begin its line.
     context 'for semantic alignment' do
       it 'accepts method being aligned with method' do
-        inspect_source(cop, <<-END.strip_indent)
+        expect_no_offenses(<<-END.strip_indent)
           User.all.first
               .age.to_s
         END
-        expect(cop.offenses).to be_empty
       end
 
       it 'accepts method being aligned with method that is an argument' do
@@ -236,29 +233,26 @@ describe RuboCop::Cop::Layout::MultilineMethodCallIndentation do
       end
 
       it 'accepts method being aligned with method in assignment' do
-        inspect_source(cop, <<-END.strip_indent)
+        expect_no_offenses(<<-END.strip_indent)
           age = User.all.first
                     .age.to_s
         END
-        expect(cop.offenses).to be_empty
       end
 
       it 'accepts aligned method even when an aref is in the chain' do
-        inspect_source(cop, <<-END.strip_indent)
+        expect_no_offenses(<<-END.strip_indent)
           foo = '123'.a
                      .b[1]
                      .c
         END
-        expect(cop.offenses).to be_empty
       end
 
       it 'accepts aligned method even when an aref is first in the chain' do
-        inspect_source(cop, <<-END.strip_indent)
+        expect_no_offenses(<<-END.strip_indent)
           foo = '123'[1].a
                         .b
                         .c
         END
-        expect(cop.offenses).to be_empty
       end
 
       it "doesn't fail on a chain of aref calls" do
@@ -266,22 +260,20 @@ describe RuboCop::Cop::Layout::MultilineMethodCallIndentation do
       end
 
       it 'accepts aligned method with blocks in operation assignment' do
-        inspect_source(cop, <<-END.strip_indent)
+        expect_no_offenses(<<-END.strip_indent)
           @comment_lines ||=
             src.comments
                .select { |c| begins_its_line?(c) }
                .map { |c| c.loc.line }
         END
-        expect(cop.offenses).to be_empty
       end
 
       it 'accepts 3 aligned methods' do
-        inspect_source(cop, <<-END.strip_indent)
+        expect_no_offenses(<<-END.strip_indent)
           a_class.new(severity, location, 'message', 'CopName')
                  .severity
                  .level
         END
-        expect(cop.offenses).to be_empty
       end
 
       it 'registers an offense for unaligned methods' do
@@ -319,17 +311,16 @@ describe RuboCop::Cop::Layout::MultilineMethodCallIndentation do
     end
 
     it 'accepts correctly aligned methods in operands' do
-      inspect_source(cop, <<-END.strip_indent)
+      expect_no_offenses(<<-END.strip_indent)
         1 + a
             .b
             .c + d.
                  e
       END
-      expect(cop.offenses).to be_empty
     end
 
     it 'accepts correctly aligned methods in assignment' do
-      inspect_source(cop, <<-END.strip_indent)
+      expect_no_offenses(<<-END.strip_indent)
         def investigate(processed_source)
           @modifier = processed_source
                       .tokens
@@ -337,11 +328,10 @@ describe RuboCop::Cop::Layout::MultilineMethodCallIndentation do
                       .map(&:pos)
         end
       END
-      expect(cop.offenses).to be_empty
     end
 
     it 'accepts aligned methods in if + assignment' do
-      inspect_source(cop, <<-END.strip_indent)
+      expect_no_offenses(<<-END.strip_indent)
         KeyMap = Hash.new do |map, key|
           value = if key.respond_to?(:to_str)
             key
@@ -353,15 +343,13 @@ describe RuboCop::Cop::Layout::MultilineMethodCallIndentation do
           keymap_mutex.synchronize { map[key] = value }
         end
       END
-      expect(cop.offenses).to be_empty
     end
 
     it 'accepts indented method when there is nothing to align with' do
-      inspect_source(cop, <<-END.strip_indent)
+      expect_no_offenses(<<-END.strip_indent)
         expect { custom_formatter_class('NonExistentClass') }
           .to raise_error(NameError)
       END
-      expect(cop.offenses).to be_empty
     end
 
     it 'registers an offense for one space indentation of third line' do
@@ -379,12 +367,11 @@ describe RuboCop::Cop::Layout::MultilineMethodCallIndentation do
     it 'accepts indented and aligned methods in binary operation' do
       # b is indented relative to a
       # .d is aligned with c
-      inspect_source(cop, <<-END.strip_indent)
+      expect_no_offenses(<<-END.strip_indent)
         a.
           b + c
               .d
       END
-      expect(cop.offenses).to be_empty
     end
 
     it 'accepts aligned methods in if condition' do
@@ -429,12 +416,11 @@ describe RuboCop::Cop::Layout::MultilineMethodCallIndentation do
     end
 
     it 'does not check binary operations when string wrapped with +' do
-      inspect_source(cop, <<-END.strip_indent)
+      expect_no_offenses(<<-END.strip_indent)
         flash[:error] = 'Here is a string ' +
                         'That spans' <<
           'multiple lines'
       END
-      expect(cop.offenses).to be_empty
     end
 
     it 'registers an offense for misaligned method in []= call' do
@@ -483,23 +469,21 @@ describe RuboCop::Cop::Layout::MultilineMethodCallIndentation do
     end
 
     it 'accepts aligned method in return' do
-      inspect_source(cop, <<-END.strip_indent)
+      expect_no_offenses(<<-END.strip_indent)
         def a
           return b.
                  c
         end
       END
-      expect(cop.offenses).to be_empty
     end
 
     it 'accepts aligned method in assignment + block + assignment' do
-      inspect_source(cop, <<-END.strip_indent)
+      expect_no_offenses(<<-END.strip_indent)
         a = b do
           c.d = e.
                 f
         end
       END
-      expect(cop.offenses).to be_empty
     end
 
     it 'accepts aligned methods in assignment' do
@@ -523,20 +507,18 @@ describe RuboCop::Cop::Layout::MultilineMethodCallIndentation do
     end
 
     it 'accepts aligned methods in constant assignment' do
-      inspect_source(cop, <<-END.strip_indent)
+      expect_no_offenses(<<-END.strip_indent)
         A = b
             .c
       END
-      expect(cop.offenses).to be_empty
     end
 
     it 'accepts aligned methods in operator assignment' do
-      inspect_source(cop, <<-END.strip_indent)
+      expect_no_offenses(<<-END.strip_indent)
         a +=
           b
           .c
       END
-      expect(cop.offenses).to be_empty
     end
 
     it 'registers an offense for unaligned methods in assignment' do
@@ -917,12 +899,11 @@ describe RuboCop::Cop::Layout::MultilineMethodCallIndentation do
       let(:cop_indent) { 7 }
 
       it 'accepts indented methods' do
-        inspect_source(cop, <<-END.strip_indent)
+        expect_no_offenses(<<-END.strip_indent)
           User.a
                  .c
                  .b
         END
-        expect(cop.offenses).to be_empty
       end
 
       it 'accepts correctly indented methods in operation' do

--- a/spec/rubocop/cop/layout/multiline_method_definition_brace_layout_spec.rb
+++ b/spec/rubocop/cop/layout/multiline_method_definition_brace_layout_spec.rb
@@ -5,31 +5,25 @@ describe RuboCop::Cop::Layout::MultilineMethodDefinitionBraceLayout, :config do
   let(:cop_config) { { 'EnforcedStyle' => 'symmetrical' } }
 
   it 'ignores implicit defs' do
-    inspect_source(cop, <<-END.strip_indent)
+    expect_no_offenses(<<-END.strip_indent)
       def foo a: 1,
       b: 2
       end
     END
-
-    expect(cop.offenses).to be_empty
   end
 
   it 'ignores single-line defs' do
-    inspect_source(cop, <<-END.strip_indent)
+    expect_no_offenses(<<-END.strip_indent)
       def foo(a,b)
       end
     END
-
-    expect(cop.offenses).to be_empty
   end
 
   it 'ignores defs without params' do
-    inspect_source(cop, <<-END.strip_indent)
+    expect_no_offenses(<<-END.strip_indent)
       def foo
       end
     END
-
-    expect(cop.offenses).to be_empty
   end
 
   include_examples 'multiline literal brace layout' do

--- a/spec/rubocop/cop/layout/multiline_operation_indentation_spec.rb
+++ b/spec/rubocop/cop/layout/multiline_operation_indentation_spec.rb
@@ -58,7 +58,7 @@ describe RuboCop::Cop::Layout::MultilineOperationIndentation do
     end
 
     it 'does not check method calls' do
-      inspect_source(cop, <<-END.strip_indent)
+      expect_no_offenses(<<-END.strip_indent)
         a
          .(args)
 
@@ -74,7 +74,6 @@ describe RuboCop::Cop::Layout::MultilineOperationIndentation do
           to change { Bar.count }.
               from(1).to(2)
       END
-      expect(cop.offenses).to be_empty
     end
 
     it 'registers an offense for three spaces indentation of second line' do
@@ -245,7 +244,7 @@ describe RuboCop::Cop::Layout::MultilineOperationIndentation do
     end
 
     it 'accepts indented operands inside block + assignment' do
-      inspect_source(cop, <<-END.strip_indent)
+      expect_no_offenses(<<-END.strip_indent)
         a = b.map do |c|
           c +
             d
@@ -256,7 +255,6 @@ describe RuboCop::Cop::Layout::MultilineOperationIndentation do
             s.loc.expression.source =~ REGEXP
         end
       END
-      expect(cop.offenses).to be_empty
     end
 
     it 'registers an offense for indented second part of string' do
@@ -345,12 +343,11 @@ describe RuboCop::Cop::Layout::MultilineOperationIndentation do
     end
 
     it 'accepts aligned operands in assignment' do
-      inspect_source(cop, <<-END.strip_indent)
+      expect_no_offenses(<<-END.strip_indent)
         a = b +
             c +
             d
       END
-      expect(cop.offenses).to be_empty
     end
 
     it 'accepts aligned or:ed operands in assignment' do
@@ -443,13 +440,12 @@ describe RuboCop::Cop::Layout::MultilineOperationIndentation do
     end
 
     it 'accepts normal indentation inside grouped expression' do
-      inspect_source(cop, <<-END.strip_indent)
+      expect_no_offenses(<<-END.strip_indent)
         arg_array.size == a.size && (
           arg_array == a ||
           arg_array.map(&:children) == a.map(&:children)
         )
       END
-      expect(cop.offenses).to be_empty
     end
 
     it 'registers an offense for aligned code on LHS of equality operator' do

--- a/spec/rubocop/cop/layout/space_after_method_name_spec.rb
+++ b/spec/rubocop/cop/layout/space_after_method_name_spec.rb
@@ -22,39 +22,35 @@ describe RuboCop::Cop::Layout::SpaceAfterMethodName do
   end
 
   it 'accepts a def without arguments' do
-    inspect_source(cop, <<-END.strip_indent)
+    expect_no_offenses(<<-END.strip_indent)
       def func
         a
       end
     END
-    expect(cop.offenses).to be_empty
   end
 
   it 'accepts a defs without arguments' do
-    inspect_source(cop, <<-END.strip_indent)
+    expect_no_offenses(<<-END.strip_indent)
       def self.func
         a
       end
     END
-    expect(cop.offenses).to be_empty
   end
 
   it 'accepts a def with arguments but no parentheses' do
-    inspect_source(cop, <<-END.strip_indent)
+    expect_no_offenses(<<-END.strip_indent)
       def func x
         a
       end
     END
-    expect(cop.offenses).to be_empty
   end
 
   it 'accepts a defs with arguments but no parentheses' do
-    inspect_source(cop, <<-END.strip_indent)
+    expect_no_offenses(<<-END.strip_indent)
       def self.func x
         a
       end
     END
-    expect(cop.offenses).to be_empty
   end
 
   it 'auto-corrects unwanted space' do

--- a/spec/rubocop/cop/layout/space_after_not_spec.rb
+++ b/spec/rubocop/cop/layout/space_after_not_spec.rb
@@ -12,15 +12,11 @@ describe RuboCop::Cop::Layout::SpaceAfterNot do
   end
 
   it 'accepts no space after !' do
-    inspect_source(cop, '!something')
-
-    expect(cop.offenses).to be_empty
+    expect_no_offenses('!something')
   end
 
   it 'accepts space after not keyword' do
-    inspect_source(cop, 'not something')
-
-    expect(cop.offenses).to be_empty
+    expect_no_offenses('not something')
   end
 
   it 'reports an offense for space after ! with the negated receiver ' \

--- a/spec/rubocop/cop/layout/space_around_block_parameters_spec.rb
+++ b/spec/rubocop/cop/layout/space_around_block_parameters_spec.rb
@@ -51,12 +51,11 @@ describe RuboCop::Cop::Layout::SpaceAroundBlockParameters, :config do
     end
 
     it 'accepts line break after closing pipe' do
-      inspect_source(cop, <<-END.strip_indent)
+      expect_no_offenses(<<-END.strip_indent)
         {}.each do |x, y|
           puts x
         end
       END
-      expect(cop.offenses).to be_empty
     end
 
     it 'registers an offense for multiple spaces before parameter' do
@@ -138,12 +137,11 @@ describe RuboCop::Cop::Layout::SpaceAroundBlockParameters, :config do
     end
 
     it 'accepts line break after closing pipe' do
-      inspect_source(cop, <<-END.strip_indent)
+      expect_no_offenses(<<-END.strip_indent)
         {}.each do | x, y |
           puts x
         end
       END
-      expect(cop.offenses).to be_empty
     end
 
     it 'registers an offense for multiple spaces before parameter' do

--- a/spec/rubocop/cop/layout/space_around_block_parameters_spec.rb
+++ b/spec/rubocop/cop/layout/space_around_block_parameters_spec.rb
@@ -5,13 +5,11 @@ describe RuboCop::Cop::Layout::SpaceAroundBlockParameters, :config do
 
   shared_examples 'common behavior' do
     it 'accepts an empty block' do
-      inspect_source(cop, '{}.each {}')
-      expect(cop.offenses).to be_empty
+      expect_no_offenses('{}.each {}')
     end
 
     it 'skips lambda without args' do
-      inspect_source(cop, '->() { puts "a" }')
-      expect(cop.offenses).to be_empty
+      expect_no_offenses('->() { puts "a" }')
     end
   end
 
@@ -21,19 +19,16 @@ describe RuboCop::Cop::Layout::SpaceAroundBlockParameters, :config do
     include_examples 'common behavior'
 
     it 'accepts a block with spaces in the right places' do
-      inspect_source(cop, '{}.each { |x, y| puts x }')
-      expect(cop.offenses).to be_empty
+      expect_no_offenses('{}.each { |x, y| puts x }')
     end
 
     it 'accepts a block with parameters but no body' do
-      inspect_source(cop, '{}.each { |x, y| }')
-      expect(cop.offenses).to be_empty
+      expect_no_offenses('{}.each { |x, y| }')
     end
 
     it 'accepts a block parameter without preceding space' do
       # This is checked by Layout/SpaceAfterComma.
-      inspect_source(cop, '{}.each { |x,y| puts x }')
-      expect(cop.offenses).to be_empty
+      expect_no_offenses('{}.each { |x,y| puts x }')
     end
 
     it 'registers an offense for space before first parameter' do
@@ -80,8 +75,7 @@ describe RuboCop::Cop::Layout::SpaceAroundBlockParameters, :config do
       end
 
       it 'accepts no space after the last comma' do
-        inspect_source(cop, '{}.each { |x,| puts x }')
-        expect(cop.offenses).to be_empty
+        expect_no_offenses('{}.each { |x,| puts x }')
       end
     end
 
@@ -98,19 +92,16 @@ describe RuboCop::Cop::Layout::SpaceAroundBlockParameters, :config do
     include_examples 'common behavior'
 
     it 'accepts a block with spaces in the right places' do
-      inspect_source(cop, '{}.each { | x, y | puts x }')
-      expect(cop.offenses).to be_empty
+      expect_no_offenses('{}.each { | x, y | puts x }')
     end
 
     it 'accepts a block with parameters but no body' do
-      inspect_source(cop, '{}.each { | x, y | }')
-      expect(cop.offenses).to be_empty
+      expect_no_offenses('{}.each { | x, y | }')
     end
 
     it 'accepts a block parameter without preceding space' do
       # This is checked by Layout/SpaceAfterComma.
-      inspect_source(cop, '{}.each { | x,y | puts x }')
-      expect(cop.offenses).to be_empty
+      expect_no_offenses('{}.each { | x,y | puts x }')
     end
 
     it 'registers an offense for no space before first parameter' do
@@ -164,8 +155,7 @@ describe RuboCop::Cop::Layout::SpaceAroundBlockParameters, :config do
 
     context 'trailing comma' do
       it 'accepts space after the last comma' do
-        inspect_source(cop, '{}.each { | x, | puts x }')
-        expect(cop.offenses).to be_empty
+        expect_no_offenses('{}.each { | x, | puts x }')
       end
 
       it 'registers an offense for no space after the last comma' do

--- a/spec/rubocop/cop/layout/space_around_operators_spec.rb
+++ b/spec/rubocop/cop/layout/space_around_operators_spec.rb
@@ -104,13 +104,12 @@ describe RuboCop::Cop::Layout::SpaceAroundOperators do
   end
 
   it 'accepts an assignment by `for` statement' do
-    inspect_source(cop, <<-END.strip_indent)
+    expect_no_offenses(<<-END.strip_indent)
       for a in [] do; end
       for A in [] do; end
       for @a in [] do; end
       for @@a in [] do; end
     END
-    expect(cop.offenses).to be_empty
   end
 
   it 'accepts an operator called with method syntax' do
@@ -481,12 +480,11 @@ describe RuboCop::Cop::Layout::SpaceAroundOperators do
     end
 
     it "doesn't register an offense for operators with newline on right" do
-      inspect_source(cop, <<-END.strip_indent)
+      expect_no_offenses(<<-END.strip_indent)
         'Here is a' +
         'joined string' +
         'across three lines'
       END
-      expect(cop.offenses).to be_empty
     end
   end
 

--- a/spec/rubocop/cop/layout/space_around_operators_spec.rb
+++ b/spec/rubocop/cop/layout/space_around_operators_spec.rb
@@ -100,8 +100,7 @@ describe RuboCop::Cop::Layout::SpaceAroundOperators do
   end
 
   it 'accepts an assignment with spaces' do
-    inspect_source(cop, 'x = 0')
-    expect(cop.offenses).to be_empty
+    expect_no_offenses('x = 0')
   end
 
   it 'accepts an assignment by `for` statement' do
@@ -115,8 +114,7 @@ describe RuboCop::Cop::Layout::SpaceAroundOperators do
   end
 
   it 'accepts an operator called with method syntax' do
-    inspect_source(cop, 'Date.today.+(1).to_s')
-    expect(cop.offenses).to be_empty
+    expect_no_offenses('Date.today.+(1).to_s')
   end
 
   it 'accepts operators with spaces' do
@@ -166,8 +164,7 @@ describe RuboCop::Cop::Layout::SpaceAroundOperators do
   end
 
   it 'accepts exponent operator without spaces' do
-    inspect_source(cop, 'x = a * b**2')
-    expect(cop.offenses).to be_empty
+    expect_no_offenses('x = a * b**2')
   end
 
   it 'accepts unary operators without space' do

--- a/spec/rubocop/cop/layout/space_before_comment_spec.rb
+++ b/spec/rubocop/cop/layout/space_before_comment_spec.rb
@@ -9,13 +9,11 @@ describe RuboCop::Cop::Layout::SpaceBeforeComment do
   end
 
   it 'accepts an EOL comment with a preceding space' do
-    inspect_source(cop, 'a += 1 # increment')
-    expect(cop.offenses).to be_empty
+    expect_no_offenses('a += 1 # increment')
   end
 
   it 'accepts a comment that begins a line' do
-    inspect_source(cop, '# comment')
-    expect(cop.offenses).to be_empty
+    expect_no_offenses('# comment')
   end
 
   it 'accepts a doc comment' do

--- a/spec/rubocop/cop/layout/space_before_comment_spec.rb
+++ b/spec/rubocop/cop/layout/space_before_comment_spec.rb
@@ -17,12 +17,11 @@ describe RuboCop::Cop::Layout::SpaceBeforeComment do
   end
 
   it 'accepts a doc comment' do
-    inspect_source(cop, <<-END.strip_indent)
+    expect_no_offenses(<<-END.strip_indent)
       =begin
       Doc comment
       =end
     END
-    expect(cop.offenses).to be_empty
   end
 
   it 'auto-corrects missing space' do

--- a/spec/rubocop/cop/layout/space_before_first_arg_spec.rb
+++ b/spec/rubocop/cop/layout/space_before_first_arg_spec.rb
@@ -51,47 +51,42 @@ describe RuboCop::Cop::Layout::SpaceBeforeFirstArg, :config do
     end
 
     it 'accepts a method call with one space before the first arg' do
-      inspect_source(cop, <<-END.strip_indent)
+      expect_no_offenses(<<-END.strip_indent)
         something x
         a.something y, z
       END
-      expect(cop.offenses).to be_empty
     end
 
     it 'accepts + operator' do
-      inspect_source(cop, <<-END.strip_indent)
+      expect_no_offenses(<<-END.strip_indent)
         something +
           x
       END
-      expect(cop.offenses).to be_empty
     end
 
     it 'accepts setter call' do
-      inspect_source(cop, <<-END.strip_indent)
+      expect_no_offenses(<<-END.strip_indent)
         something.x =
           y
       END
-      expect(cop.offenses).to be_empty
     end
 
     it 'accepts multiple space containing line break' do
-      inspect_source(cop, <<-END.strip_indent)
+      expect_no_offenses(<<-END.strip_indent)
         something \\
           x
       END
-      expect(cop.offenses).to be_empty
     end
 
     context 'when AllowForAlignment is true' do
       it 'accepts method calls with aligned first arguments' do
-        inspect_source(cop, <<-END.strip_indent)
+        expect_no_offenses(<<-END.strip_indent)
           form.inline_input   :full_name,     as: :string
           form.disabled_input :password,      as: :passwd
           form.masked_input   :zip_code,      as: :string
           form.masked_input   :email_address, as: :email
           form.masked_input   :phone_number,  as: :tel
         END
-        expect(cop.offenses).to be_empty
       end
     end
 
@@ -113,11 +108,10 @@ describe RuboCop::Cop::Layout::SpaceBeforeFirstArg, :config do
 
   context 'for method calls with parentheses' do
     it 'accepts a method call without space' do
-      inspect_source(cop, <<-END.strip_indent)
+      expect_no_offenses(<<-END.strip_indent)
         something(x)
         a.something(y, z)
       END
-      expect(cop.offenses).to be_empty
     end
 
     it 'accepts a method call with space after the left parenthesis' do

--- a/spec/rubocop/cop/layout/space_before_first_arg_spec.rb
+++ b/spec/rubocop/cop/layout/space_before_first_arg_spec.rb
@@ -121,8 +121,7 @@ describe RuboCop::Cop::Layout::SpaceBeforeFirstArg, :config do
     end
 
     it 'accepts a method call with space after the left parenthesis' do
-      inspect_source(cop, 'something(  x  )')
-      expect(cop.offenses).to be_empty
+      expect_no_offenses('something(  x  )')
     end
   end
 end

--- a/spec/rubocop/cop/layout/space_in_lambda_literal_spec.rb
+++ b/spec/rubocop/cop/layout/space_in_lambda_literal_spec.rb
@@ -16,13 +16,12 @@ describe RuboCop::Cop::Layout::SpaceInLambdaLiteral, :config do
     end
 
     it 'does not register an offense for multi-line lambdas' do
-      inspect_source(cop, <<-END.strip_indent)
+      expect_no_offenses(<<-END.strip_indent)
         l = lambda do |a, b|
           tmp = a * 7
           tmp * b / 50
         end
       END
-      expect(cop.offenses).to be_empty
     end
 
     it 'does not register an offense for no space between -> and {' do
@@ -82,13 +81,12 @@ describe RuboCop::Cop::Layout::SpaceInLambdaLiteral, :config do
     end
 
     it 'does not register an offense for multi-line lambdas' do
-      inspect_source(cop, <<-END.strip_indent)
+      expect_no_offenses(<<-END.strip_indent)
         l = lambda do |a, b|
           tmp = a * 7
           tmp * b / 50
         end
       END
-      expect(cop.offenses).to be_empty
     end
 
     it 'does not register an offense for a space between -> and {' do

--- a/spec/rubocop/cop/layout/space_in_lambda_literal_spec.rb
+++ b/spec/rubocop/cop/layout/space_in_lambda_literal_spec.rb
@@ -12,8 +12,7 @@ describe RuboCop::Cop::Layout::SpaceInLambdaLiteral, :config do
     end
 
     it 'does not register an offense for a space between -> and (' do
-      inspect_source(cop, 'a = -> (b, c) { b + c }')
-      expect(cop.offenses).to be_empty
+      expect_no_offenses('a = -> (b, c) { b + c }')
     end
 
     it 'does not register an offense for multi-line lambdas' do
@@ -27,8 +26,7 @@ describe RuboCop::Cop::Layout::SpaceInLambdaLiteral, :config do
     end
 
     it 'does not register an offense for no space between -> and {' do
-      inspect_source(cop, 'a = ->{ b + c }')
-      expect(cop.offenses).to be_empty
+      expect_no_offenses('a = ->{ b + c }')
     end
 
     it 'registers an offense for no space in the inner nested lambda' do
@@ -80,8 +78,7 @@ describe RuboCop::Cop::Layout::SpaceInLambdaLiteral, :config do
     end
 
     it 'does not register an offense for no space between -> and (' do
-      inspect_source(cop, 'a = ->(b, c) { b + c }')
-      expect(cop.offenses).to be_empty
+      expect_no_offenses('a = ->(b, c) { b + c }')
     end
 
     it 'does not register an offense for multi-line lambdas' do
@@ -95,8 +92,7 @@ describe RuboCop::Cop::Layout::SpaceInLambdaLiteral, :config do
     end
 
     it 'does not register an offense for a space between -> and {' do
-      inspect_source(cop, 'a = -> { b + c }')
-      expect(cop.offenses).to be_empty
+      expect_no_offenses('a = -> { b + c }')
     end
 
     it 'registers an offense for spaces between -> and (' do

--- a/spec/rubocop/cop/layout/space_inside_block_braces_spec.rb
+++ b/spec/rubocop/cop/layout/space_inside_block_braces_spec.rb
@@ -16,13 +16,11 @@ describe RuboCop::Cop::Layout::SpaceInsideBlockBraces, :config do
     let(:cop_config) { { 'EnforcedStyleForEmptyBraces' => 'no_space' } }
 
     it 'accepts empty braces with no space inside' do
-      inspect_source(cop, 'each {}')
-      expect(cop.offenses).to be_empty
+      expect_no_offenses('each {}')
     end
 
     it 'accepts braces with something inside' do
-      inspect_source(cop, 'each { "f" }')
-      expect(cop.offenses).to be_empty
+      expect_no_offenses('each { "f" }')
     end
 
     it 'accepts multiline braces with content' do
@@ -76,8 +74,7 @@ describe RuboCop::Cop::Layout::SpaceInsideBlockBraces, :config do
     let(:cop_config) { { 'EnforcedStyleForEmptyBraces' => 'space' } }
 
     it 'accepts empty braces with space inside' do
-      inspect_source(cop, 'each { }')
-      expect(cop.offenses).to be_empty
+      expect_no_offenses('each { }')
     end
 
     it 'registers an offense for empty braces with no space inside' do
@@ -102,13 +99,11 @@ describe RuboCop::Cop::Layout::SpaceInsideBlockBraces, :config do
   end
 
   it 'accepts braces surrounded by spaces' do
-    inspect_source(cop, 'each { puts }')
-    expect(cop.offenses).to be_empty
+    expect_no_offenses('each { puts }')
   end
 
   it 'accepts left brace without outer space' do
-    inspect_source(cop, 'each{ puts }')
-    expect(cop.offenses).to be_empty
+    expect_no_offenses('each{ puts }')
   end
 
   it 'registers an offense for left brace without inner space' do
@@ -151,8 +146,7 @@ describe RuboCop::Cop::Layout::SpaceInsideBlockBraces, :config do
   context 'with passed in parameters' do
     context 'for single-line blocks' do
       it 'accepts left brace with inner space' do
-        inspect_source(cop, 'each { |x| puts }')
-        expect(cop.offenses).to be_empty
+        expect_no_offenses('each { |x| puts }')
       end
 
       it 'registers an offense for left brace without inner space' do
@@ -200,8 +194,7 @@ describe RuboCop::Cop::Layout::SpaceInsideBlockBraces, :config do
     end
 
     it 'accepts new lambda syntax' do
-      inspect_source(cop, '->(x) { x }')
-      expect(cop.offenses).to be_empty
+      expect_no_offenses('->(x) { x }')
     end
 
     it 'auto-corrects missing space' do
@@ -252,8 +245,7 @@ describe RuboCop::Cop::Layout::SpaceInsideBlockBraces, :config do
       end
 
       it 'accepts new lambda syntax' do
-        inspect_source(cop, '->(x) { x }')
-        expect(cop.offenses).to be_empty
+        expect_no_offenses('->(x) { x }')
       end
 
       it 'auto-corrects unwanted space' do
@@ -262,8 +254,7 @@ describe RuboCop::Cop::Layout::SpaceInsideBlockBraces, :config do
       end
 
       it 'accepts left brace without inner space' do
-        inspect_source(cop, 'each {|x| puts }')
-        expect(cop.offenses).to be_empty
+        expect_no_offenses('each {|x| puts }')
       end
     end
   end
@@ -278,8 +269,7 @@ describe RuboCop::Cop::Layout::SpaceInsideBlockBraces, :config do
     end
 
     it 'accepts braces without spaces inside' do
-      inspect_source(cop, 'each {puts}')
-      expect(cop.offenses).to be_empty
+      expect_no_offenses('each {puts}')
     end
 
     it 'registers an offense for left brace with inner space' do
@@ -306,8 +296,7 @@ describe RuboCop::Cop::Layout::SpaceInsideBlockBraces, :config do
     end
 
     it 'accepts left brace without outer space' do
-      inspect_source(cop, 'each{puts}')
-      expect(cop.offenses).to be_empty
+      expect_no_offenses('each{puts}')
     end
 
     it 'auto-corrects unwanted space' do
@@ -331,8 +320,7 @@ describe RuboCop::Cop::Layout::SpaceInsideBlockBraces, :config do
         end
 
         it 'accepts new lambda syntax' do
-          inspect_source(cop, '->(x) {x}')
-          expect(cop.offenses).to be_empty
+          expect_no_offenses('->(x) {x}')
         end
 
         it 'auto-corrects missing space' do
@@ -358,8 +346,7 @@ describe RuboCop::Cop::Layout::SpaceInsideBlockBraces, :config do
         end
 
         it 'accepts new lambda syntax' do
-          inspect_source(cop, '->(x) {x}')
-          expect(cop.offenses).to be_empty
+          expect_no_offenses('->(x) {x}')
         end
 
         it 'auto-corrects unwanted space' do

--- a/spec/rubocop/cop/layout/space_inside_block_braces_spec.rb
+++ b/spec/rubocop/cop/layout/space_inside_block_braces_spec.rb
@@ -24,11 +24,10 @@ describe RuboCop::Cop::Layout::SpaceInsideBlockBraces, :config do
     end
 
     it 'accepts multiline braces with content' do
-      inspect_source(cop, <<-END.strip_indent)
+      expect_no_offenses(<<-END.strip_indent)
         each { %(
         ) }
       END
-      expect(cop.offenses).to be_empty
     end
 
     it 'accepts empty braces with comment and line break inside' do
@@ -159,12 +158,11 @@ describe RuboCop::Cop::Layout::SpaceInsideBlockBraces, :config do
 
     context 'for multi-line blocks' do
       it 'accepts left brace with inner space' do
-        inspect_source(cop, <<-END.strip_indent)
+        expect_no_offenses(<<-END.strip_indent)
           each { |x|
           puts
           }
         END
-        expect(cop.offenses).to be_empty
       end
 
       it 'registers an offense for left brace without inner space' do

--- a/spec/rubocop/cop/layout/space_inside_hash_literal_braces_spec.rb
+++ b/spec/rubocop/cop/layout/space_inside_hash_literal_braces_spec.rb
@@ -108,31 +108,28 @@ describe RuboCop::Cop::Layout::SpaceInsideHashLiteralBraces, :config do
     end
 
     it 'accepts hashes with no spaces' do
-      inspect_source(cop, <<-END.strip_indent)
+      expect_no_offenses(<<-END.strip_indent)
         h = {a: 1, b: 2}
         h = {a => 1}
       END
-      expect(cop.offenses).to be_empty
     end
 
     it 'accepts multiline hash' do
-      inspect_source(cop, <<-END.strip_indent)
+      expect_no_offenses(<<-END.strip_indent)
         h = {
               a: 1,
               b: 2,
         }
       END
-      expect(cop.offenses).to be_empty
     end
 
     it 'accepts multiline hash with comment' do
-      inspect_source(cop, <<-END.strip_indent)
+      expect_no_offenses(<<-END.strip_indent)
         h = { # Comment
               a: 1,
               b: 2,
         }
       END
-      expect(cop.offenses).to be_empty
     end
   end
 
@@ -189,32 +186,29 @@ describe RuboCop::Cop::Layout::SpaceInsideHashLiteralBraces, :config do
     end
 
     it 'accepts multiline hash' do
-      inspect_source(cop, <<-END.strip_indent)
+      expect_no_offenses(<<-END.strip_indent)
         h = {
               a: 1,
               b: 2,
         }
       END
-      expect(cop.offenses).to be_empty
     end
 
     it 'accepts multiline hash with comment' do
-      inspect_source(cop, <<-END.strip_indent)
+      expect_no_offenses(<<-END.strip_indent)
         h = { # Comment
               a: 1,
               b: 2,
         }
       END
-      expect(cop.offenses).to be_empty
     end
   end
 
   it 'accepts hashes with spaces by default' do
-    inspect_source(cop, <<-END.strip_indent)
+    expect_no_offenses(<<-END.strip_indent)
       h = { a: 1, b: 2 }
       h = { a => 1 }
     END
-    expect(cop.offenses).to be_empty
   end
 
   it 'accepts hash literals with no braces' do

--- a/spec/rubocop/cop/layout/space_inside_hash_literal_braces_spec.rb
+++ b/spec/rubocop/cop/layout/space_inside_hash_literal_braces_spec.rb
@@ -218,30 +218,26 @@ describe RuboCop::Cop::Layout::SpaceInsideHashLiteralBraces, :config do
   end
 
   it 'accepts hash literals with no braces' do
-    inspect_source(cop, 'x(a: b.c)')
-    expect(cop.offenses).to be_empty
+    expect_no_offenses('x(a: b.c)')
   end
 
   it 'can handle interpolation in a braceless hash literal' do
     # A tricky special case where the closing brace of the
     # interpolation risks getting confused for a hash literal brace.
-    inspect_source(cop, 'f(get: "#{x}")')
-    expect(cop.offenses).to be_empty
+    expect_no_offenses('f(get: "#{x}")')
   end
 
   context 'on Hash[{ x: 1 } => [1]]' do
     # regression test; see GH issue 2436
     it 'does not register an offense' do
-      inspect_source(cop, 'Hash[{ x: 1 } => [1]]')
-      expect(cop.offenses).to be_empty
+      expect_no_offenses('Hash[{ x: 1 } => [1]]')
     end
   end
 
   context 'on { key: "{" }' do
     # regression test; see GH issue 3958
     it 'does not register an offense' do
-      inspect_source(cop, '{ key: "{" }')
-      expect(cop.offenses).to be_empty
+      expect_no_offenses('{ key: "{" }')
     end
   end
 end

--- a/spec/rubocop/cop/layout/space_inside_range_literal_spec.rb
+++ b/spec/rubocop/cop/layout/space_inside_range_literal_spec.rb
@@ -15,8 +15,7 @@ describe RuboCop::Cop::Layout::SpaceInsideRangeLiteral do
   end
 
   it 'accepts no space inside .. literal' do
-    inspect_source(cop, '1..2')
-    expect(cop.offenses).to be_empty
+    expect_no_offenses('1..2')
   end
 
   it 'registers an offense for space inside ... literal' do
@@ -31,13 +30,11 @@ describe RuboCop::Cop::Layout::SpaceInsideRangeLiteral do
   end
 
   it 'accepts no space inside ... literal' do
-    inspect_source(cop, '1...2')
-    expect(cop.offenses).to be_empty
+    expect_no_offenses('1...2')
   end
 
   it 'accepts complex range literal with space in it' do
-    inspect_source(cop, '0...(line - 1)')
-    expect(cop.offenses).to be_empty
+    expect_no_offenses('0...(line - 1)')
   end
 
   it 'accepts multiline range literal with no space in it' do

--- a/spec/rubocop/cop/layout/space_inside_range_literal_spec.rb
+++ b/spec/rubocop/cop/layout/space_inside_range_literal_spec.rb
@@ -38,11 +38,10 @@ describe RuboCop::Cop::Layout::SpaceInsideRangeLiteral do
   end
 
   it 'accepts multiline range literal with no space in it' do
-    inspect_source(cop, <<-END.strip_indent)
+    expect_no_offenses(<<-END.strip_indent)
       x = 0..
           10
     END
-    expect(cop.offenses).to be_empty
   end
 
   it 'registers an offense in multiline range literal with space in it' do

--- a/spec/rubocop/cop/layout/tab_spec.rb
+++ b/spec/rubocop/cop/layout/tab_spec.rb
@@ -28,18 +28,15 @@ describe RuboCop::Cop::Layout::Tab do
   end
 
   it 'accepts a line with tab in a string' do
-    inspect_source(cop, "(x = \"\t\")")
-    expect(cop.offenses).to be_empty
+    expect_no_offenses("(x = \"\t\")")
   end
 
   it 'accepts a line which begins with tab in a string' do
-    inspect_source(cop, "x = '\n\thello'")
-    expect(cop.offenses).to be_empty
+    expect_no_offenses("x = '\n\thello'")
   end
 
   it 'accepts a line which begins with tab in a heredoc' do
-    inspect_source(cop, "x = <<HELLO\n\thello\nHELLO")
-    expect(cop.offenses).to be_empty
+    expect_no_offenses("x = <<HELLO\n\thello\nHELLO")
   end
 
   it 'auto-corrects a line indented with tab' do

--- a/spec/rubocop/cop/layout/trailing_blank_lines_spec.rb
+++ b/spec/rubocop/cop/layout/trailing_blank_lines_spec.rb
@@ -12,8 +12,7 @@ describe RuboCop::Cop::Layout::TrailingBlankLines, :config do
     end
 
     it 'accepts an empty file' do
-      inspect_source(cop, '')
-      expect(cop.offenses).to be_empty
+      expect_no_offenses('')
     end
 
     it 'accepts final blank lines if they come after __END__' do

--- a/spec/rubocop/cop/lint/assignment_in_condition_spec.rb
+++ b/spec/rubocop/cop/lint/assignment_in_condition_spec.rb
@@ -69,11 +69,10 @@ describe RuboCop::Cop::Lint::AssignmentInCondition, :config do
   end
 
   it 'accepts == in condition' do
-    inspect_source(cop, <<-END.strip_indent)
+    expect_no_offenses(<<-END.strip_indent)
       if test == 10
       end
     END
-    expect(cop.offenses).to be_empty
   end
 
   it 'registers an offense for assignment after == in condition' do
@@ -111,36 +110,32 @@ describe RuboCop::Cop::Lint::AssignmentInCondition, :config do
   end
 
   it 'does not blow up for empty if condition' do
-    inspect_source(cop, <<-END.strip_indent)
+    expect_no_offenses(<<-END.strip_indent)
       if ()
       end
     END
-    expect(cop.offenses).to be_empty
   end
 
   it 'does not blow up for empty unless condition' do
-    inspect_source(cop, <<-END.strip_indent)
+    expect_no_offenses(<<-END.strip_indent)
       unless ()
       end
     END
-    expect(cop.offenses).to be_empty
   end
 
   context 'safe assignment is allowed' do
     it 'accepts = in condition surrounded with braces' do
-      inspect_source(cop, <<-END.strip_indent)
+      expect_no_offenses(<<-END.strip_indent)
         if (test = 10)
         end
       END
-      expect(cop.offenses).to be_empty
     end
 
     it 'accepts []= in condition surrounded with braces' do
-      inspect_source(cop, <<-END.strip_indent)
+      expect_no_offenses(<<-END.strip_indent)
         if (test[0] = 10)
         end
       END
-      expect(cop.offenses).to be_empty
     end
   end
 

--- a/spec/rubocop/cop/lint/assignment_in_condition_spec.rb
+++ b/spec/rubocop/cop/lint/assignment_in_condition_spec.rb
@@ -85,21 +85,15 @@ describe RuboCop::Cop::Lint::AssignmentInCondition, :config do
   end
 
   it 'accepts = in a block that is called in a condition' do
-    inspect_source(cop,
-                   'return 1 if any_errors? { o = inspect(file) }')
-    expect(cop.offenses).to be_empty
+    expect_no_offenses('return 1 if any_errors? { o = inspect(file) }')
   end
 
   it 'accepts = in a block followed by method call' do
-    inspect_source(cop,
-                   'return 1 if any_errors? { o = file }.present?')
-    expect(cop.offenses).to be_empty
+    expect_no_offenses('return 1 if any_errors? { o = file }.present?')
   end
 
   it 'accepts ||= in condition' do
-    inspect_source(cop,
-                   'raise StandardError unless foo ||= bar')
-    expect(cop.offenses).to be_empty
+    expect_no_offenses('raise StandardError unless foo ||= bar')
   end
 
   it 'registers an offense for assignment after ||= in condition' do

--- a/spec/rubocop/cop/lint/block_alignment_spec.rb
+++ b/spec/rubocop/cop/lint/block_alignment_spec.rb
@@ -62,23 +62,21 @@ describe RuboCop::Cop::Lint::BlockAlignment, :config do
 
   context 'when the block is a logical operand' do
     it 'accepts a correctly aligned block end' do
-      inspect_source(cop, <<-END.strip_indent)
+      expect_no_offenses(<<-END.strip_indent)
         (value.is_a? Array) && value.all? do |subvalue|
           type_check_value(subvalue, array_type)
         end
         a || b do
         end
       END
-      expect(cop.offenses).to be_empty
     end
   end
 
   it 'accepts end aligned with a variable' do
-    inspect_source(cop, <<-END.strip_indent)
+    expect_no_offenses(<<-END.strip_indent)
       variable = test do |ala|
       end
     END
-    expect(cop.offenses).to be_empty
   end
 
   context 'when there is an assignment chain' do
@@ -93,11 +91,10 @@ describe RuboCop::Cop::Lint::BlockAlignment, :config do
     end
 
     it 'accepts end aligned with the first variable' do
-      inspect_source(cop, <<-END.strip_indent)
+      expect_no_offenses(<<-END.strip_indent)
         a = b = c = test do |ala|
         end
       END
-      expect(cop.offenses).to be_empty
     end
 
     it 'auto-corrects alignment to the first variable' do
@@ -115,12 +112,11 @@ describe RuboCop::Cop::Lint::BlockAlignment, :config do
 
   context 'and the block is an operand' do
     it 'accepts end aligned with a variable' do
-      inspect_source(cop, <<-END.strip_indent)
+      expect_no_offenses(<<-END.strip_indent)
         b = 1 + preceding_line.reduce(0) do |a, e|
           a + e.length + newline_length
         end + 1
       END
-      expect(cop.offenses).to be_empty
     end
   end
 
@@ -136,13 +132,12 @@ describe RuboCop::Cop::Lint::BlockAlignment, :config do
 
   context 'when the block is defined on the next line' do
     it 'accepts end aligned with the block expression' do
-      inspect_source(cop, <<-END.strip_indent)
+      expect_no_offenses(<<-END.strip_indent)
         variable =
           a_long_method_that_dont_fit_on_the_line do |v|
             v.foo
           end
       END
-      expect(cop.offenses).to be_empty
     end
 
     it 'registers an offenses for mismatched end alignment' do
@@ -337,11 +332,10 @@ describe RuboCop::Cop::Lint::BlockAlignment, :config do
   end
 
   it 'accepts end aligned with an instance variable' do
-    inspect_source(cop, <<-END.strip_indent)
+    expect_no_offenses(<<-END.strip_indent)
       @variable = test do |ala|
       end
     END
-    expect(cop.offenses).to be_empty
   end
 
   it 'registers an offense for mismatched block end with' \
@@ -356,11 +350,10 @@ describe RuboCop::Cop::Lint::BlockAlignment, :config do
   end
 
   it 'accepts end aligned with a class variable' do
-    inspect_source(cop, <<-END.strip_indent)
+    expect_no_offenses(<<-END.strip_indent)
       @@variable = test do |ala|
       end
     END
-    expect(cop.offenses).to be_empty
   end
 
   it 'registers an offense for mismatched block end with a class variable' do
@@ -374,11 +367,10 @@ describe RuboCop::Cop::Lint::BlockAlignment, :config do
   end
 
   it 'accepts end aligned with a global variable' do
-    inspect_source(cop, <<-END.strip_indent)
+    expect_no_offenses(<<-END.strip_indent)
       $variable = test do |ala|
       end
     END
-    expect(cop.offenses).to be_empty
   end
 
   it 'registers an offense for mismatched block end with a global variable' do
@@ -392,11 +384,10 @@ describe RuboCop::Cop::Lint::BlockAlignment, :config do
   end
 
   it 'accepts end aligned with a constant' do
-    inspect_source(cop, <<-END.strip_indent)
+    expect_no_offenses(<<-END.strip_indent)
       CONSTANT = test do |ala|
       end
     END
-    expect(cop.offenses).to be_empty
   end
 
   it 'registers an offense for mismatched block end with a constant' do
@@ -410,12 +401,11 @@ describe RuboCop::Cop::Lint::BlockAlignment, :config do
   end
 
   it 'accepts end aligned with a method call' do
-    inspect_source(cop, <<-END.strip_indent)
+    expect_no_offenses(<<-END.strip_indent)
       parser.children << lambda do |token|
         token << 1
       end
     END
-    expect(cop.offenses).to be_empty
   end
 
   it 'registers an offense for mismatched block end with a method call' do
@@ -430,12 +420,11 @@ describe RuboCop::Cop::Lint::BlockAlignment, :config do
   end
 
   it 'accepts end aligned with a method call with arguments' do
-    inspect_source(cop, <<-END.strip_indent)
+    expect_no_offenses(<<-END.strip_indent)
       @h[:f] = f.each_pair.map do |f, v|
         v = 1
       end
     END
-    expect(cop.offenses).to be_empty
   end
 
   it 'registers an offense for mismatched end with a method call' \
@@ -455,12 +444,11 @@ describe RuboCop::Cop::Lint::BlockAlignment, :config do
   end
 
   it 'accepts end aligned with the block when the block is a method argument' do
-    inspect_source(cop, <<-END.strip_indent)
+    expect_no_offenses(<<-END.strip_indent)
       expect(arr.all? do |o|
                o.valid?
              end)
     END
-    expect(cop.offenses).to be_empty
   end
 
   it 'registers an offense for mismatched end not aligned with the block' \
@@ -476,12 +464,11 @@ describe RuboCop::Cop::Lint::BlockAlignment, :config do
   end
 
   it 'accepts end aligned with an op-asgn (+=, -=)' do
-    inspect_source(cop, <<-END.strip_indent)
+    expect_no_offenses(<<-END.strip_indent)
       rb += files.select do |file|
         file << something
       end
     END
-    expect(cop.offenses).to be_empty
   end
 
   it 'registers an offense for mismatched block end with an op-asgn (+=, -=)' do
@@ -495,11 +482,10 @@ describe RuboCop::Cop::Lint::BlockAlignment, :config do
   end
 
   it 'accepts end aligned with an and-asgn (&&=)' do
-    inspect_source(cop, <<-END.strip_indent)
+    expect_no_offenses(<<-END.strip_indent)
       variable &&= test do |ala|
       end
     END
-    expect(cop.offenses).to be_empty
   end
 
   it 'registers an offense for mismatched block end with an and-asgn (&&=)' do
@@ -513,11 +499,10 @@ describe RuboCop::Cop::Lint::BlockAlignment, :config do
   end
 
   it 'accepts end aligned with an or-asgn (||=)' do
-    inspect_source(cop, <<-END.strip_indent)
+    expect_no_offenses(<<-END.strip_indent)
       variable ||= test do |ala|
       end
     END
-    expect(cop.offenses).to be_empty
   end
 
   it 'registers an offense for mismatched block end with an or-asgn (||=)' do
@@ -531,21 +516,19 @@ describe RuboCop::Cop::Lint::BlockAlignment, :config do
   end
 
   it 'accepts end aligned with a mass assignment' do
-    inspect_source(cop, <<-END.strip_indent)
+    expect_no_offenses(<<-END.strip_indent)
       var1, var2 = lambda do |test|
         [1, 2]
       end
     END
-    expect(cop.offenses).to be_empty
   end
 
   it 'accepts end aligned with a call chain left hand side' do
-    inspect_source(cop, <<-END.strip_indent)
+    expect_no_offenses(<<-END.strip_indent)
       parser.diagnostics.consumer = lambda do |diagnostic|
         diagnostics << diagnostic
       end
     END
-    expect(cop.offenses).to be_empty
   end
 
   it 'registers an offense for mismatched block end with a mass assignment' do
@@ -572,14 +555,13 @@ describe RuboCop::Cop::Lint::BlockAlignment, :config do
 
   context 'on a splatted method call' do
     it 'aligns end with the splat operator' do
-      inspect_source(cop, <<-END.strip_indent)
+      expect_no_offenses(<<-END.strip_indent)
         def get_gems_by_name
           @gems ||= Hash[*get_latest_gems.map { |gem|
                            [gem.name, gem, gem.full_name, gem]
                          }.flatten]
         end
       END
-      expect(cop.offenses).to be_empty
     end
 
     it 'autocorrects' do
@@ -605,14 +587,13 @@ describe RuboCop::Cop::Lint::BlockAlignment, :config do
 
   context 'on a bit-flipped method call' do
     it 'aligns end with the ~ operator' do
-      inspect_source(cop, <<-END.strip_indent)
+      expect_no_offenses(<<-END.strip_indent)
         def abc
           @abc ||= A[~xyz { |x|
                        x
                      }.flatten]
         end
       END
-      expect(cop.offenses).to be_empty
     end
 
     it 'autocorrects' do
@@ -638,14 +619,13 @@ describe RuboCop::Cop::Lint::BlockAlignment, :config do
 
   context 'on a logically negated method call' do
     it 'aligns end with the ! operator' do
-      inspect_source(cop, <<-END.strip_indent)
+      expect_no_offenses(<<-END.strip_indent)
         def abc
           @abc ||= A[!xyz { |x|
                        x
                      }.flatten]
         end
       END
-      expect(cop.offenses).to be_empty
     end
 
     it 'autocorrects' do
@@ -671,14 +651,13 @@ describe RuboCop::Cop::Lint::BlockAlignment, :config do
 
   context 'on an arithmetically negated method call' do
     it 'aligns end with the - operator' do
-      inspect_source(cop, <<-END.strip_indent)
+      expect_no_offenses(<<-END.strip_indent)
         def abc
           @abc ||= A[-xyz { |x|
                        x
                      }.flatten]
         end
       END
-      expect(cop.offenses).to be_empty
     end
 
     it 'autocorrects' do

--- a/spec/rubocop/cop/lint/block_alignment_spec.rb
+++ b/spec/rubocop/cop/lint/block_alignment_spec.rb
@@ -451,9 +451,7 @@ describe RuboCop::Cop::Lint::BlockAlignment, :config do
   end
 
   it 'does not raise an error for nested block in a method call' do
-    inspect_source(cop,
-                   'expect(arr.all? { |o| o.valid? })')
-    expect(cop.offenses).to be_empty
+    expect_no_offenses('expect(arr.all? { |o| o.valid? })')
   end
 
   it 'accepts end aligned with the block when the block is a method argument' do

--- a/spec/rubocop/cop/lint/condition_position_spec.rb
+++ b/spec/rubocop/cop/lint/condition_position_spec.rb
@@ -43,7 +43,6 @@ describe RuboCop::Cop::Lint::ConditionPosition do
   end
 
   it 'handles ternary ops' do
-    inspect_source(cop, 'x ? a : b')
-    expect(cop.offenses).to be_empty
+    expect_no_offenses('x ? a : b')
   end
 end

--- a/spec/rubocop/cop/lint/condition_position_spec.rb
+++ b/spec/rubocop/cop/lint/condition_position_spec.rb
@@ -13,20 +13,18 @@ describe RuboCop::Cop::Lint::ConditionPosition do
     end
 
     it 'accepts condition on the same line' do
-      inspect_source(cop, <<-END.strip_indent)
+      expect_no_offenses(<<-END.strip_indent)
         #{keyword} x == 10
          bala
         end
       END
-      expect(cop.offenses).to be_empty
     end
 
     it 'accepts condition on a different line for modifiers' do
-      inspect_source(cop, <<-END.strip_indent)
+      expect_no_offenses(<<-END.strip_indent)
         do_something #{keyword}
           something && something_else
       END
-      expect(cop.offenses).to be_empty
     end
   end
 

--- a/spec/rubocop/cop/lint/duplicate_methods_spec.rb
+++ b/spec/rubocop/cop/lint/duplicate_methods_spec.rb
@@ -323,7 +323,7 @@ describe RuboCop::Cop::Lint::DuplicateMethods do
   end
 
   it 'ignores Class.new blocks which are assigned to local variables' do
-    inspect_source(cop, <<-END.strip_indent)
+    expect_no_offenses(<<-END.strip_indent)
       a = Class.new do
         def foo
         end
@@ -333,6 +333,5 @@ describe RuboCop::Cop::Lint::DuplicateMethods do
         end
       end
     END
-    expect(cop.offenses).to be_empty
   end
 end

--- a/spec/rubocop/cop/lint/each_with_object_argument_spec.rb
+++ b/spec/rubocop/cop/lint/each_with_object_argument_spec.rb
@@ -21,19 +21,15 @@ describe RuboCop::Cop::Lint::EachWithObjectArgument do
   end
 
   it 'accepts a variable argument' do
-    inspect_source(cop, 'collection.each_with_object(x) { |e, a| a.add(e) }')
-    expect(cop.offenses).to be_empty
+    expect_no_offenses('collection.each_with_object(x) { |e, a| a.add(e) }')
   end
 
   it 'accepts two arguments' do
     # Two arguments would indicate that this is not Enumerable#each_with_object.
-    inspect_source(cop, 'collection.each_with_object(1, 2) { |e, a| a.add(e) }')
-    expect(cop.offenses).to be_empty
+    expect_no_offenses('collection.each_with_object(1, 2) { |e, a| a.add(e) }')
   end
 
   it 'accepts a string argument' do
-    inspect_source(cop,
-                   "collection.each_with_object('') { |e, a| a << e.to_s }")
-    expect(cop.offenses).to be_empty
+    expect_no_offenses("collection.each_with_object('') { |e, a| a << e.to_s }")
   end
 end

--- a/spec/rubocop/cop/lint/else_layout_spec.rb
+++ b/spec/rubocop/cop/lint/else_layout_spec.rb
@@ -52,12 +52,10 @@ describe RuboCop::Cop::Lint::ElseLayout do
   end
 
   it 'handles ternary ops' do
-    inspect_source(cop, 'x ? a : b')
-    expect(cop.offenses).to be_empty
+    expect_no_offenses('x ? a : b')
   end
 
   it 'handles modifier forms' do
-    inspect_source(cop, 'x if something')
-    expect(cop.offenses).to be_empty
+    expect_no_offenses('x if something')
   end
 end

--- a/spec/rubocop/cop/lint/else_layout_spec.rb
+++ b/spec/rubocop/cop/lint/else_layout_spec.rb
@@ -16,7 +16,7 @@ describe RuboCop::Cop::Lint::ElseLayout do
   end
 
   it 'accepts proper else' do
-    inspect_source(cop, <<-END.strip_indent)
+    expect_no_offenses(<<-END.strip_indent)
       if something
         test
       else
@@ -24,17 +24,15 @@ describe RuboCop::Cop::Lint::ElseLayout do
         test
       end
     END
-    expect(cop.offenses).to be_empty
   end
 
   it 'accepts single-expr else regardless of layout' do
-    inspect_source(cop, <<-END.strip_indent)
+    expect_no_offenses(<<-END.strip_indent)
       if something
         test
       else bala
       end
     END
-    expect(cop.offenses).to be_empty
   end
 
   it 'can handle elsifs' do

--- a/spec/rubocop/cop/lint/empty_ensure_spec.rb
+++ b/spec/rubocop/cop/lint/empty_ensure_spec.rb
@@ -29,7 +29,7 @@ describe RuboCop::Cop::Lint::EmptyEnsure do
   end
 
   it 'does not register an offense for non-empty ensure' do
-    inspect_source(cop, <<-END.strip_indent)
+    expect_no_offenses(<<-END.strip_indent)
       begin
         something
         return
@@ -37,6 +37,5 @@ describe RuboCop::Cop::Lint::EmptyEnsure do
         file.close
       end
     END
-    expect(cop.offenses).to be_empty
   end
 end

--- a/spec/rubocop/cop/lint/empty_interpolation_spec.rb
+++ b/spec/rubocop/cop/lint/empty_interpolation_spec.rb
@@ -16,8 +16,7 @@ describe RuboCop::Cop::Lint::EmptyInterpolation do
   end
 
   it 'accepts non-empty interpolation' do
-    inspect_source(cop, '"this is #{top} silly"')
-    expect(cop.offenses).to be_empty
+    expect_no_offenses('"this is #{top} silly"')
   end
 
   it 'autocorrects empty interpolation' do

--- a/spec/rubocop/cop/lint/end_alignment_spec.rb
+++ b/spec/rubocop/cop/lint/end_alignment_spec.rb
@@ -41,13 +41,11 @@ describe RuboCop::Cop::Lint::EndAlignment, :config do
   include_examples 'aligned', 'puts 1; case',   'a when b', '        end'
 
   it 'can handle ternary if' do
-    inspect_source(cop, 'a = cond ? x : y')
-    expect(cop.offenses).to be_empty
+    expect_no_offenses('a = cond ? x : y')
   end
 
   it 'can handle modifier if' do
-    inspect_source(cop, 'a = x if cond')
-    expect(cop.offenses).to be_empty
+    expect_no_offenses('a = x if cond')
   end
 
   context 'when EnforcedStyleAlignWith is start_of_line' do

--- a/spec/rubocop/cop/lint/ensure_return_spec.rb
+++ b/spec/rubocop/cop/lint/ensure_return_spec.rb
@@ -16,7 +16,7 @@ describe RuboCop::Cop::Lint::EnsureReturn do
   end
 
   it 'does not register an offense for return outside ensure' do
-    inspect_source(cop, <<-END.strip_indent)
+    expect_no_offenses(<<-END.strip_indent)
       begin
         something
         return
@@ -24,7 +24,6 @@ describe RuboCop::Cop::Lint::EnsureReturn do
         file.close
       end
     END
-    expect(cop.offenses).to be_empty
   end
 
   it 'does not check when ensure block has no body' do

--- a/spec/rubocop/cop/lint/format_parameter_mismatch_spec.rb
+++ b/spec/rubocop/cop/lint/format_parameter_mismatch_spec.rb
@@ -240,11 +240,10 @@ describe RuboCop::Cop::Lint::FormatParameterMismatch do
   context 'on format with %{} interpolations' do
     context 'and 1 argument' do
       it 'does not register an offense' do
-        inspect_source(cop, <<-END.strip_indent)
+        expect_no_offenses(<<-END.strip_indent)
           params = { y: '2015', m: '01', d: '01' }
           puts format('%{y}-%{m}-%{d}', params)
         END
-        expect(cop.offenses).to be_empty
       end
     end
 
@@ -263,11 +262,10 @@ describe RuboCop::Cop::Lint::FormatParameterMismatch do
   context 'on format with %<> interpolations' do
     context 'and 1 argument' do
       it 'does not register an offense' do
-        inspect_source(cop, <<-END.strip_indent)
+        expect_no_offenses(<<-END.strip_indent)
           params = { y: '2015', m: '01', d: '01' }
           puts format('%<y>d-%<m>d-%<d>d', params)
         END
-        expect(cop.offenses).to be_empty
       end
     end
 

--- a/spec/rubocop/cop/lint/format_parameter_mismatch_spec.rb
+++ b/spec/rubocop/cop/lint/format_parameter_mismatch_spec.rb
@@ -78,18 +78,15 @@ describe RuboCop::Cop::Lint::FormatParameterMismatch do
   end
 
   it 'does not register an offense when arguments and fields match' do
-    inspect_source(cop, 'format("%s %d %i", 1, 2, 3)')
-    expect(cop.offenses).to be_empty
+    expect_no_offenses('format("%s %d %i", 1, 2, 3)')
   end
 
   it 'correctly ignores double percent' do
-    inspect_source(cop, "format('%s %s %% %s %%%% %%%%%%', 1, 2, 3)")
-    expect(cop.offenses).to be_empty
+    expect_no_offenses("format('%s %s %% %s %%%% %%%%%%', 1, 2, 3)")
   end
 
   it 'constants do not register offenses' do
-    inspect_source(cop, 'format(A_CONST, 1, 2, 3)')
-    expect(cop.offenses).to be_empty
+    expect_no_offenses('format(A_CONST, 1, 2, 3)')
   end
 
   it 'registers offense with sprintf' do
@@ -102,9 +99,7 @@ describe RuboCop::Cop::Lint::FormatParameterMismatch do
   end
 
   it 'correctly parses different sprintf formats' do
-    inspect_source(cop,
-                   'sprintf("%020x%+g:% g %%%#20.8x %#.0e", 1, 2, 3, 4, 5)')
-    expect(cop.offenses).to be_empty
+    expect_no_offenses('sprintf("%020x%+g:% g %%%#20.8x %#.0e", 1, 2, 3, 4, 5)')
   end
 
   it 'registers an offense for String#%' do
@@ -117,13 +112,11 @@ describe RuboCop::Cop::Lint::FormatParameterMismatch do
   end
 
   it 'does not register offense for `String#%` when arguments, fields match' do
-    inspect_source(cop, '"%s %s" % [1, 2]')
-    expect(cop.offenses).to be_empty
+    expect_no_offenses('"%s %s" % [1, 2]')
   end
 
   it 'does not register an offense when single argument is a hash' do
-    inspect_source(cop, 'puts "%s" % {"a" => 1}')
-    expect(cop.offenses).to be_empty
+    expect_no_offenses('puts "%s" % {"a" => 1}')
   end
 
   it 'does not register an offense when single argument is not an array' do
@@ -167,42 +160,36 @@ describe RuboCop::Cop::Lint::FormatParameterMismatch do
     context 'and a single variable argument is passed' do
       it 'does not register an offense' do
         # the variable could evaluate to an array
-        inspect_source(cop, 'puts "%s %s" % var')
-        expect(cop.offenses).to be_empty
+        expect_no_offenses('puts "%s %s" % var')
       end
     end
 
     context 'and a single send node is passed' do
       it 'does not register an offense' do
-        inspect_source(cop, 'puts "%s %s" % ("ab".chars)')
-        expect(cop.offenses).to be_empty
+        expect_no_offenses('puts "%s %s" % ("ab".chars)')
       end
     end
   end
 
   context 'when format is not a string literal' do
     it 'does not register an offense' do
-      inspect_source(cop, 'puts str % [1, 2]')
-      expect(cop.offenses).to be_empty
+      expect_no_offenses('puts str % [1, 2]')
     end
   end
 
   # Regression: https://github.com/bbatsov/rubocop/issues/3869
   context 'when passed an empty array' do
     it 'does not register an offense' do
-      inspect_source(cop, "'%' % []")
-      expect(cop.offenses).to be_empty
+      expect_no_offenses("'%' % []")
     end
   end
 
   it 'ignores percent right next to format string' do
-    inspect_source(cop, 'format("%0.1f%% percent", 22.5)')
-    expect(cop.offenses).to be_empty
+    expect_no_offenses('format("%0.1f%% percent", 22.5)')
   end
 
   it 'accepts an extra argument for dynamic width' do
-    inspect_source(cop, 'format("%*d", max_width, id)')
-    expect(cop.offenses).to be_empty
+    expect_no_offenses('format("%*d", max_width, id)')
   end
 
   it 'registers an offense if extra argument for dynamic width not given' do
@@ -213,13 +200,11 @@ describe RuboCop::Cop::Lint::FormatParameterMismatch do
   end
 
   it 'accepts an extra arg for dynamic width with other preceding flags' do
-    inspect_source(cop, 'format("%0*x", max_width, id)')
-    expect(cop.offenses).to be_empty
+    expect_no_offenses('format("%0*x", max_width, id)')
   end
 
   it 'accepts an extra arg for dynamic width with other following flags' do
-    inspect_source(cop, 'format("%*0x", max_width, id)')
-    expect(cop.offenses).to be_empty
+    expect_no_offenses('format("%*0x", max_width, id)')
   end
 
   it 'does not register an offense argument is the result of a message send' do
@@ -231,13 +216,11 @@ describe RuboCop::Cop::Lint::FormatParameterMismatch do
   end
 
   it 'does not register an offense when using named parameters' do
-    inspect_source(cop, '"foo %{bar} baz" % { bar: 42 }')
-    expect(cop.offenses).to be_empty
+    expect_no_offenses('"foo %{bar} baz" % { bar: 42 }')
   end
 
   it 'identifies correctly digits for spacing in format' do
-    inspect_source(cop, '"duration: %10.fms" % 42')
-    expect(cop.offenses).to be_empty
+    expect_no_offenses('"duration: %10.fms" % 42')
   end
 
   it 'finds faults even when the string looks like a HEREDOC' do
@@ -247,13 +230,11 @@ describe RuboCop::Cop::Lint::FormatParameterMismatch do
   end
 
   it 'does not register an offense for sprintf with splat argument' do
-    inspect_source(cop, 'sprintf("%d%d", *test)')
-    expect(cop.offenses).to be_empty
+    expect_no_offenses('sprintf("%d%d", *test)')
   end
 
   it 'does not register an offense for format with splat argument' do
-    inspect_source(cop, 'format("%d%d", *test)')
-    expect(cop.offenses).to be_empty
+    expect_no_offenses('format("%d%d", *test)')
   end
 
   context 'on format with %{} interpolations' do

--- a/spec/rubocop/cop/lint/handle_exceptions_spec.rb
+++ b/spec/rubocop/cop/lint/handle_exceptions_spec.rb
@@ -17,7 +17,7 @@ describe RuboCop::Cop::Lint::HandleExceptions do
   end
 
   it 'does not register an offense for rescue with body' do
-    inspect_source(cop, <<-END.strip_indent)
+    expect_no_offenses(<<-END.strip_indent)
       begin
         something
         return
@@ -25,6 +25,5 @@ describe RuboCop::Cop::Lint::HandleExceptions do
         file.close
       end
     END
-    expect(cop.offenses).to be_empty
   end
 end

--- a/spec/rubocop/cop/lint/literal_in_condition_spec.rb
+++ b/spec/rubocop/cop/lint/literal_in_condition_spec.rb
@@ -134,21 +134,19 @@ describe RuboCop::Cop::Lint::LiteralInCondition do
   end
 
   it 'accepts array literal in case, if it has non-literal elements' do
-    inspect_source(cop, <<-END.strip_indent)
+    expect_no_offenses(<<-END.strip_indent)
       case [1, 2, x]
       when [1, 2, 5] then top
       end
     END
-    expect(cop.offenses).to be_empty
   end
 
   it 'accepts array literal in case, if it has nested non-literal element' do
-    inspect_source(cop, <<-END.strip_indent)
+    expect_no_offenses(<<-END.strip_indent)
       case [1, 2, [x, 1]]
       when [1, 2, 5] then top
       end
     END
-    expect(cop.offenses).to be_empty
   end
 
   it 'registers an offense for case with a primitive array condition' do
@@ -161,11 +159,10 @@ describe RuboCop::Cop::Lint::LiteralInCondition do
   end
 
   it 'accepts dstr literal in case' do
-    inspect_source(cop, <<-'END'.strip_indent)
+    expect_no_offenses(<<-'END'.strip_indent)
       case "#{x}"
       when [1, 2, 5] then top
       end
     END
-    expect(cop.offenses).to be_empty
   end
 end

--- a/spec/rubocop/cop/lint/literal_in_interpolation_spec.rb
+++ b/spec/rubocop/cop/lint/literal_in_interpolation_spec.rb
@@ -4,23 +4,19 @@ describe RuboCop::Cop::Lint::LiteralInInterpolation do
   subject(:cop) { described_class.new }
 
   it 'accepts empty interpolation' do
-    inspect_source(cop, '"this is #{a} silly"')
-    expect(cop.offenses).to be_empty
+    expect_no_offenses('"this is #{a} silly"')
   end
 
   it 'accepts interpolation of xstr' do
-    inspect_source(cop, '"this is #{`a`} silly"')
-    expect(cop.offenses).to be_empty
+    expect_no_offenses('"this is #{`a`} silly"')
   end
 
   it 'accepts interpolation of irange where endpoints are not literals' do
-    inspect_source(cop, '"this is an irange: #{var1..var2}"')
-    expect(cop.offenses).to be_empty
+    expect_no_offenses('"this is an irange: #{var1..var2}"')
   end
 
   it 'accepts interpolation of erange where endpoints are not literals' do
-    inspect_source(cop, '"this is an erange: #{var1...var2}"')
-    expect(cop.offenses).to be_empty
+    expect_no_offenses('"this is an erange: #{var1...var2}"')
   end
 
   shared_examples 'literal interpolation' do |literal, expected = literal|

--- a/spec/rubocop/cop/lint/loop_spec.rb
+++ b/spec/rubocop/cop/lint/loop_spec.rb
@@ -14,12 +14,10 @@ describe RuboCop::Cop::Lint::Loop do
   end
 
   it 'accepts normal while' do
-    inspect_source(cop, 'while test; one; two; end')
-    expect(cop.offenses).to be_empty
+    expect_no_offenses('while test; one; two; end')
   end
 
   it 'accepts normal until' do
-    inspect_source(cop, 'until test; one; two; end')
-    expect(cop.offenses).to be_empty
+    expect_no_offenses('until test; one; two; end')
   end
 end

--- a/spec/rubocop/cop/lint/multiple_compare_spec.rb
+++ b/spec/rubocop/cop/lint/multiple_compare_spec.rb
@@ -31,7 +31,6 @@ describe RuboCop::Cop::Lint::MultipleCompare do
   end
 
   it 'accepts to use one compare operator' do
-    inspect_source(cop, 'x < 1')
-    expect(cop.offenses).to be_empty
+    expect_no_offenses('x < 1')
   end
 end

--- a/spec/rubocop/cop/lint/nested_method_definition_spec.rb
+++ b/spec/rubocop/cop/lint/nested_method_definition_spec.rb
@@ -43,17 +43,16 @@ describe RuboCop::Cop::Lint::NestedMethodDefinition do
   end
 
   it 'does not register an offense for a lambda definition inside method' do
-    inspect_source(cop, <<-END.strip_indent)
+    expect_no_offenses(<<-END.strip_indent)
       def foo
         bar = -> { puts  }
         bar.call
       end
     END
-    expect(cop.offenses).to be_empty
   end
 
   it 'does not register offense for nested definition inside instance_eval' do
-    inspect_source(cop, <<-END.strip_indent)
+    expect_no_offenses(<<-END.strip_indent)
       class Foo
         def x(obj)
           obj.instance_eval do
@@ -63,11 +62,10 @@ describe RuboCop::Cop::Lint::NestedMethodDefinition do
         end
       end
     END
-    expect(cop.offenses).to be_empty
   end
 
   it 'does not register offense for nested definition inside instance_exec' do
-    inspect_source(cop, <<-END.strip_indent)
+    expect_no_offenses(<<-END.strip_indent)
       class Foo
         def x(obj)
           obj.instance_exec do
@@ -77,11 +75,10 @@ describe RuboCop::Cop::Lint::NestedMethodDefinition do
         end
       end
     END
-    expect(cop.offenses).to be_empty
   end
 
   it 'does not register offense for definition of method on local var' do
-    inspect_source(cop, <<-END.strip_indent)
+    expect_no_offenses(<<-END.strip_indent)
       class Foo
         def x(obj)
           def obj.y
@@ -89,11 +86,10 @@ describe RuboCop::Cop::Lint::NestedMethodDefinition do
         end
       end
     END
-    expect(cop.offenses).to be_empty
   end
 
   it 'does not register offense for nested definition inside class_eval' do
-    inspect_source(cop, <<-END.strip_indent)
+    expect_no_offenses(<<-END.strip_indent)
       class Foo
         def x(klass)
           klass.class_eval do
@@ -103,11 +99,10 @@ describe RuboCop::Cop::Lint::NestedMethodDefinition do
         end
       end
     END
-    expect(cop.offenses).to be_empty
   end
 
   it 'does not register offense for nested definition inside class_exec' do
-    inspect_source(cop, <<-END.strip_indent)
+    expect_no_offenses(<<-END.strip_indent)
       class Foo
         def x(klass)
           klass.class_exec do
@@ -117,11 +112,10 @@ describe RuboCop::Cop::Lint::NestedMethodDefinition do
         end
       end
     END
-    expect(cop.offenses).to be_empty
   end
 
   it 'does not register offense for nested definition inside module_eval' do
-    inspect_source(cop, <<-END.strip_indent)
+    expect_no_offenses(<<-END.strip_indent)
       class Foo
         def self.define(mod)
           mod.module_eval do
@@ -131,11 +125,10 @@ describe RuboCop::Cop::Lint::NestedMethodDefinition do
         end
       end
     END
-    expect(cop.offenses).to be_empty
   end
 
   it 'does not register offense for nested definition inside module_eval' do
-    inspect_source(cop, <<-END.strip_indent)
+    expect_no_offenses(<<-END.strip_indent)
       class Foo
         def self.define(mod)
           mod.module_exec do
@@ -145,11 +138,10 @@ describe RuboCop::Cop::Lint::NestedMethodDefinition do
         end
       end
     END
-    expect(cop.offenses).to be_empty
   end
 
   it 'does not register offense for nested definition inside class shovel' do
-    inspect_source(cop, <<-END.strip_indent)
+    expect_no_offenses(<<-END.strip_indent)
       class Foo
         def bar
           class << self
@@ -159,7 +151,6 @@ describe RuboCop::Cop::Lint::NestedMethodDefinition do
         end
       end
     END
-    expect(cop.offenses).to be_empty
   end
 
   it 'does not register offense for nested definition inside Class.new' do
@@ -179,7 +170,7 @@ describe RuboCop::Cop::Lint::NestedMethodDefinition do
   end
 
   it 'does not register offense for nested definition inside Module.new' do
-    inspect_source(cop, <<-END.strip_indent)
+    expect_no_offenses(<<-END.strip_indent)
       class Foo
         def self.define
           Module.new do
@@ -189,7 +180,6 @@ describe RuboCop::Cop::Lint::NestedMethodDefinition do
         end
       end
     END
-    expect(cop.offenses).to be_empty
   end
 
   it 'does not register offense for nested definition inside Struct.new' do

--- a/spec/rubocop/cop/lint/parentheses_as_grouped_expression_spec.rb
+++ b/spec/rubocop/cop/lint/parentheses_as_grouped_expression_spec.rb
@@ -29,12 +29,11 @@ describe RuboCop::Cop::Lint::ParenthesesAsGroupedExpression do
   end
 
   it 'accepts a chain of method calls' do
-    inspect_source(cop, <<-END.strip_indent)
+    expect_no_offenses(<<-END.strip_indent)
       a.b
       a.b 1
       a.b(1)
     END
-    expect(cop.offenses).to be_empty
   end
 
   it 'accepts method with parens as arg to method without' do
@@ -42,11 +41,10 @@ describe RuboCop::Cop::Lint::ParenthesesAsGroupedExpression do
   end
 
   it 'accepts an operator call with argument in parentheses' do
-    inspect_source(cop, <<-END.strip_indent)
+    expect_no_offenses(<<-END.strip_indent)
       a % (b + c)
       a.b = (c == d)
     END
-    expect(cop.offenses).to be_empty
   end
 
   it 'accepts a space inside opening paren followed by left paren' do

--- a/spec/rubocop/cop/lint/parentheses_as_grouped_expression_spec.rb
+++ b/spec/rubocop/cop/lint/parentheses_as_grouped_expression_spec.rb
@@ -21,13 +21,11 @@ describe RuboCop::Cop::Lint::ParenthesesAsGroupedExpression do
   end
 
   it 'accepts a method call without arguments' do
-    inspect_source(cop, 'func')
-    expect(cop.offenses).to be_empty
+    expect_no_offenses('func')
   end
 
   it 'accepts a method call with arguments but no parentheses' do
-    inspect_source(cop, 'puts x')
-    expect(cop.offenses).to be_empty
+    expect_no_offenses('puts x')
   end
 
   it 'accepts a chain of method calls' do
@@ -40,8 +38,7 @@ describe RuboCop::Cop::Lint::ParenthesesAsGroupedExpression do
   end
 
   it 'accepts method with parens as arg to method without' do
-    inspect_source(cop, 'a b(c)')
-    expect(cop.offenses).to be_empty
+    expect_no_offenses('a b(c)')
   end
 
   it 'accepts an operator call with argument in parentheses' do
@@ -53,13 +50,11 @@ describe RuboCop::Cop::Lint::ParenthesesAsGroupedExpression do
   end
 
   it 'accepts a space inside opening paren followed by left paren' do
-    inspect_source(cop, 'a( (b) )')
-    expect(cop.offenses).to be_empty
+    expect_no_offenses('a( (b) )')
   end
 
   it "doesn't register an offense for a call with multiple arguments" do
     # there is no ambiguity here
-    inspect_source(cop, 'assert_equal (0..1.9), acceleration.domain')
-    expect(cop.offenses).to be_empty
+    expect_no_offenses('assert_equal (0..1.9), acceleration.domain')
   end
 end

--- a/spec/rubocop/cop/lint/percent_string_array_spec.rb
+++ b/spec/rubocop/cop/lint/percent_string_array_spec.rb
@@ -74,9 +74,7 @@ describe RuboCop::Cop::Lint::PercentStringArray do
     end
 
     it 'accepts if tokens contain invalid byte sequence only' do
-      inspect_source(cop, '%W(\255)')
-
-      expect(cop.offenses).to be_empty
+      expect_no_offenses('%W(\255)')
     end
   end
 end

--- a/spec/rubocop/cop/lint/require_parentheses_spec.rb
+++ b/spec/rubocop/cop/lint/require_parentheses_spec.rb
@@ -71,22 +71,18 @@ describe RuboCop::Cop::Lint::RequireParentheses do
   end
 
   it 'accepts method call with parentheses in ternary' do
-    inspect_source(cop, "wd.include?('tuesday' && true == true) ? a : b")
-    expect(cop.offenses).to be_empty
+    expect_no_offenses("wd.include?('tuesday' && true == true) ? a : b")
   end
 
   it 'accepts missing parentheses when method is not a predicate' do
-    inspect_source(cop, "weekdays.foo 'tuesday' && true == true")
-    expect(cop.offenses).to be_empty
+    expect_no_offenses("weekdays.foo 'tuesday' && true == true")
   end
 
   it 'accepts calls to methods that are setters' do
-    inspect_source(cop, 's.version = @version || ">= 1.8.5"')
-    expect(cop.offenses).to be_empty
+    expect_no_offenses('s.version = @version || ">= 1.8.5"')
   end
 
   it 'accepts calls to methods that are operators' do
-    inspect_source(cop, 'a[b || c]')
-    expect(cop.offenses).to be_empty
+    expect_no_offenses('a[b || c]')
   end
 end

--- a/spec/rubocop/cop/lint/require_parentheses_spec.rb
+++ b/spec/rubocop/cop/lint/require_parentheses_spec.rb
@@ -29,45 +29,40 @@ describe RuboCop::Cop::Lint::RequireParentheses do
   end
 
   it 'accepts missing parentheses around expression with + operator' do
-    inspect_source(cop, <<-END.strip_indent)
+    expect_no_offenses(<<-END.strip_indent)
       if day_is? 'tuesday' + rest
       end
     END
-    expect(cop.offenses).to be_empty
   end
 
   it 'accepts method calls without parentheses followed by keyword and/or' do
-    inspect_source(cop, <<-END.strip_indent)
+    expect_no_offenses(<<-END.strip_indent)
       if day.is? 'tuesday' and month == :jan
       end
       if day.is? 'tuesday' or month == :jan
       end
     END
-    expect(cop.offenses).to be_empty
   end
 
   it 'accepts method calls that are all operations' do
-    inspect_source(cop, <<-END.strip_indent)
+    expect_no_offenses(<<-END.strip_indent)
       if current_level == max + 1
       end
     END
-    expect(cop.offenses).to be_empty
   end
 
   it 'accepts condition that is not a call' do
-    inspect_source(cop, <<-END.strip_indent)
+    expect_no_offenses(<<-END.strip_indent)
       if @debug
       end
     END
-    expect(cop.offenses).to be_empty
   end
 
   it 'accepts parentheses around expression with boolean operator' do
-    inspect_source(cop, <<-END.strip_indent)
+    expect_no_offenses(<<-END.strip_indent)
       if day.is?('tuesday' && true == true)
       end
     END
-    expect(cop.offenses).to be_empty
   end
 
   it 'accepts method call with parentheses in ternary' do

--- a/spec/rubocop/cop/lint/rescue_exception_spec.rb
+++ b/spec/rubocop/cop/lint/rescue_exception_spec.rb
@@ -48,7 +48,7 @@ describe RuboCop::Cop::Lint::RescueException do
   end
 
   it 'does not register an offense for rescue with no class' do
-    inspect_source(cop, <<-END.strip_indent)
+    expect_no_offenses(<<-END.strip_indent)
       begin
         something
         return
@@ -56,11 +56,10 @@ describe RuboCop::Cop::Lint::RescueException do
         file.close
       end
     END
-    expect(cop.offenses).to be_empty
   end
 
   it 'does not register an offense for rescue with no class and => e' do
-    inspect_source(cop, <<-END.strip_indent)
+    expect_no_offenses(<<-END.strip_indent)
       begin
         something
         return
@@ -68,11 +67,10 @@ describe RuboCop::Cop::Lint::RescueException do
         file.close
       end
     END
-    expect(cop.offenses).to be_empty
   end
 
   it 'does not register an offense for rescue with other class' do
-    inspect_source(cop, <<-END.strip_indent)
+    expect_no_offenses(<<-END.strip_indent)
       begin
         something
         return
@@ -80,11 +78,10 @@ describe RuboCop::Cop::Lint::RescueException do
         file.close
       end
     END
-    expect(cop.offenses).to be_empty
   end
 
   it 'does not register an offense for rescue with other classes' do
-    inspect_source(cop, <<-END.strip_indent)
+    expect_no_offenses(<<-END.strip_indent)
       begin
         something
         return
@@ -92,11 +89,10 @@ describe RuboCop::Cop::Lint::RescueException do
         file.close
       end
     END
-    expect(cop.offenses).to be_empty
   end
 
   it 'does not register an offense for rescue with a module prefix' do
-    inspect_source(cop, <<-END.strip_indent)
+    expect_no_offenses(<<-END.strip_indent)
       begin
         something
         return
@@ -104,11 +100,10 @@ describe RuboCop::Cop::Lint::RescueException do
         file.close
       end
     END
-    expect(cop.offenses).to be_empty
   end
 
   it 'does not crash when the splat operator is used in a rescue' do
-    inspect_source(cop, <<-END.strip_indent)
+    expect_no_offenses(<<-END.strip_indent)
       ERRORS = [Exception]
       begin
         a = 3 / 0
@@ -116,7 +111,6 @@ describe RuboCop::Cop::Lint::RescueException do
         puts e
       end
     END
-    expect(cop.offenses).to be_empty
   end
 
   it 'does not crash when the namespace of a rescued class is in a local ' \

--- a/spec/rubocop/cop/lint/shadowed_exception_spec.rb
+++ b/spec/rubocop/cop/lint/shadowed_exception_spec.rb
@@ -11,63 +11,53 @@ describe RuboCop::Cop::Lint::ShadowedException do
 
   context 'single rescue' do
     it 'accepts an empty rescue' do
-      inspect_source(cop, <<-END.strip_indent)
+      expect_no_offenses(<<-END.strip_indent)
         begin
           something
         rescue
           handle_exception
         end
       END
-
-      expect(cop.offenses).to be_empty
     end
 
     it 'accepts rescuing a single exception' do
-      inspect_source(cop, <<-END.strip_indent)
+      expect_no_offenses(<<-END.strip_indent)
         begin
           something
         rescue Exception
           handle_exception
         end
       END
-
-      expect(cop.offenses).to be_empty
     end
 
     it 'accepts rescuing a single custom exception' do
-      inspect_source(cop, <<-END.strip_indent)
+      expect_no_offenses(<<-END.strip_indent)
         begin
           something
         rescue NonStandardException
           handle_exception
         end
       END
-
-      expect(cop.offenses).to be_empty
     end
 
     it 'accepts rescuing a custom exception and a standard exception' do
-      inspect_source(cop, <<-END.strip_indent)
+      expect_no_offenses(<<-END.strip_indent)
         begin
           something
         rescue Error, NonStandardException
           handle_exception
         end
       END
-
-      expect(cop.offenses).to be_empty
     end
 
     it 'accepts rescuing multiple custom exceptions' do
-      inspect_source(cop, <<-END.strip_indent)
+      expect_no_offenses(<<-END.strip_indent)
         begin
           something
         rescue CustomError, NonStandardException
           handle_exception
         end
       END
-
-      expect(cop.offenses).to be_empty
     end
 
     it 'registers an offense rescuing exceptions that are ' \
@@ -97,19 +87,17 @@ describe RuboCop::Cop::Lint::ShadowedException do
     end
 
     it 'accepts rescuing a single exception that is assigned to a variable' do
-      inspect_source(cop, <<-END.strip_indent)
+      expect_no_offenses(<<-END.strip_indent)
         begin
           something
         rescue Exception => e
           handle_exception(e)
         end
       END
-
-      expect(cop.offenses).to be_empty
     end
 
     it 'accepts rescuing a single exception that has an ensure' do
-      inspect_source(cop, <<-END.strip_indent)
+      expect_no_offenses(<<-END.strip_indent)
         begin
           something
         rescue Exception
@@ -118,12 +106,10 @@ describe RuboCop::Cop::Lint::ShadowedException do
           everything_is_ok
         end
       END
-
-      expect(cop.offenses).to be_empty
     end
 
     it 'accepts rescuing a single exception that has an else' do
-      inspect_source(cop, <<-END.strip_indent)
+      expect_no_offenses(<<-END.strip_indent)
         begin
           something
         rescue Exception
@@ -132,8 +118,6 @@ describe RuboCop::Cop::Lint::ShadowedException do
           handle_non_exception
         end
       END
-
-      expect(cop.offenses).to be_empty
     end
 
     it 'accepts rescuing a multiple exceptions that are not ancestors that ' \
@@ -195,39 +179,33 @@ describe RuboCop::Cop::Lint::ShadowedException do
     end
 
     it 'accepts splat arguments passed to rescue' do
-      inspect_source(cop, <<-END.strip_indent)
+      expect_no_offenses(<<-END.strip_indent)
         begin
           a
         rescue *FOO
           b
         end
       END
-
-      expect(cop.offenses).to be_empty
     end
 
     it 'accepts rescuing nil' do
-      inspect_source(cop, <<-END.strip_indent)
+      expect_no_offenses(<<-END.strip_indent)
         begin
           a
         rescue nil
           b
         end
       END
-
-      expect(cop.offenses).to be_empty
     end
 
     it 'accepts rescuing nil and another exception' do
-      inspect_source(cop, <<-END.strip_indent)
+      expect_no_offenses(<<-END.strip_indent)
         begin
           a
         rescue nil, Exception
           b
         end
       END
-
-      expect(cop.offenses).to be_empty
     end
 
     it 'registers an offense when rescuing nil multiple exceptions of ' \
@@ -305,7 +283,7 @@ describe RuboCop::Cop::Lint::ShadowedException do
     end
 
     it 'accepts rescuing exceptions in order of level' do
-      inspect_source(cop, <<-END.strip_indent)
+      expect_no_offenses(<<-END.strip_indent)
         begin
           something
         rescue StandardError
@@ -314,12 +292,10 @@ describe RuboCop::Cop::Lint::ShadowedException do
           handle_exception
         end
       END
-
-      expect(cop.offenses).to be_empty
     end
 
     it 'accepts many (>= 7) rescue groups' do
-      inspect_source(cop, <<-END.strip_indent)
+      expect_no_offenses(<<-END.strip_indent)
         begin
           something
         rescue StandardError
@@ -338,8 +314,6 @@ describe RuboCop::Cop::Lint::ShadowedException do
           handle_error
         end
       END
-
-      expect(cop.offenses).to be_empty
     end
 
     it 'accepts rescuing exceptions in order of level with multiple ' \
@@ -373,7 +347,7 @@ describe RuboCop::Cop::Lint::ShadowedException do
     end
 
     it 'accepts rescuing custom exceptions in multiple rescue groups' do
-      inspect_source(cop, <<-END.strip_indent)
+      expect_no_offenses(<<-END.strip_indent)
         begin
           something
         rescue NonStandardError, OtherError
@@ -382,13 +356,11 @@ describe RuboCop::Cop::Lint::ShadowedException do
           handle_exception
         end
       END
-
-      expect(cop.offenses).to be_empty
     end
 
     context 'splat arguments' do
       it 'accepts splat arguments passed to multiple rescues' do
-        inspect_source(cop, <<-END.strip_indent)
+        expect_no_offenses(<<-END.strip_indent)
           begin
             a
           rescue *FOO
@@ -397,8 +369,6 @@ describe RuboCop::Cop::Lint::ShadowedException do
             c
           end
         END
-
-        expect(cop.offenses).to be_empty
       end
 
       it 'registers an offense for splat arguments rescued after ' \
@@ -437,7 +407,7 @@ describe RuboCop::Cop::Lint::ShadowedException do
 
     context 'exceptions from different ancestry chains' do
       it 'accepts rescuing exceptions in one order' do
-        inspect_source(cop, <<-END.strip_indent)
+        expect_no_offenses(<<-END.strip_indent)
           begin
             a
           rescue ArgumentError
@@ -446,12 +416,10 @@ describe RuboCop::Cop::Lint::ShadowedException do
             c
           end
         END
-
-        expect(cop.offenses).to be_empty
       end
 
       it 'accepts rescuing exceptions in another order' do
-        inspect_source(cop, <<-END.strip_indent)
+        expect_no_offenses(<<-END.strip_indent)
           begin
             a
           rescue Interrupt
@@ -460,13 +428,11 @@ describe RuboCop::Cop::Lint::ShadowedException do
             c
           end
         END
-
-        expect(cop.offenses).to be_empty
       end
     end
 
     it 'accepts rescuing nil before another exception' do
-      inspect_source(cop, <<-END.strip_indent)
+      expect_no_offenses(<<-END.strip_indent)
         begin
           a
         rescue nil
@@ -475,12 +441,10 @@ describe RuboCop::Cop::Lint::ShadowedException do
           c
         end
       END
-
-      expect(cop.offenses).to be_empty
     end
 
     it 'accepts rescuing nil after another exception' do
-      inspect_source(cop, <<-END.strip_indent)
+      expect_no_offenses(<<-END.strip_indent)
         begin
           a
         rescue
@@ -489,12 +453,10 @@ describe RuboCop::Cop::Lint::ShadowedException do
           c
         end
       END
-
-      expect(cop.offenses).to be_empty
     end
 
     it 'accepts rescuing a known exception after an unknown exceptions' do
-      inspect_source(cop, <<-END.strip_indent)
+      expect_no_offenses(<<-END.strip_indent)
         begin
           a
         rescue UnknownException
@@ -503,12 +465,10 @@ describe RuboCop::Cop::Lint::ShadowedException do
           c
         end
       END
-
-      expect(cop.offenses).to be_empty
     end
 
     it 'accepts rescuing a known exception before an unknown exceptions' do
-      inspect_source(cop, <<-END.strip_indent)
+      expect_no_offenses(<<-END.strip_indent)
         begin
           a
         rescue StandardError
@@ -517,12 +477,10 @@ describe RuboCop::Cop::Lint::ShadowedException do
           c
         end
       END
-
-      expect(cop.offenses).to be_empty
     end
 
     it 'accepts rescuing a known exception between unknown exceptions' do
-      inspect_source(cop, <<-END.strip_indent)
+      expect_no_offenses(<<-END.strip_indent)
         begin
           a
         rescue UnknownException
@@ -533,8 +491,6 @@ describe RuboCop::Cop::Lint::ShadowedException do
           d
         end
       END
-
-      expect(cop.offenses).to be_empty
     end
 
     it 'registers an offense rescuing Exception before an unknown exceptions' do
@@ -555,7 +511,7 @@ describe RuboCop::Cop::Lint::ShadowedException do
     end
 
     it 'ignores expressions of non-const' do
-      inspect_source(cop, <<-END.strip_indent)
+      expect_no_offenses(<<-END.strip_indent)
         begin
           a
         rescue foo
@@ -564,8 +520,6 @@ describe RuboCop::Cop::Lint::ShadowedException do
           c
         end
       END
-
-      expect(cop.offenses).to be_empty
     end
 
     context 'last rescue does not specify exception class' do

--- a/spec/rubocop/cop/lint/shadowed_exception_spec.rb
+++ b/spec/rubocop/cop/lint/shadowed_exception_spec.rb
@@ -5,9 +5,7 @@ describe RuboCop::Cop::Lint::ShadowedException do
 
   context 'modifier rescue' do
     it 'accepts rescue in its modifier form' do
-      inspect_source(cop, 'foo rescue nil')
-
-      expect(cop.offenses).to be_empty
+      expect_no_offenses('foo rescue nil')
     end
   end
 

--- a/spec/rubocop/cop/lint/string_conversion_in_interpolation_spec.rb
+++ b/spec/rubocop/cop/lint/string_conversion_in_interpolation_spec.rb
@@ -16,13 +16,11 @@ describe RuboCop::Cop::Lint::StringConversionInInterpolation do
   end
 
   it 'accepts #to_s with arguments in an interpolation' do
-    inspect_source(cop, '"this is a #{result.to_s(8)}"')
-    expect(cop.offenses).to be_empty
+    expect_no_offenses('"this is a #{result.to_s(8)}"')
   end
 
   it 'accepts interpolation without #to_s' do
-    inspect_source(cop, '"this is the #{result}"')
-    expect(cop.offenses).to be_empty
+    expect_no_offenses('"this is the #{result}"')
   end
 
   it 'does not explode on implicit receiver' do
@@ -33,8 +31,7 @@ describe RuboCop::Cop::Lint::StringConversionInInterpolation do
   end
 
   it 'does not explode on empty interpolation' do
-    inspect_source(cop, '"this is #{} silly"')
-    expect(cop.offenses).to be_empty
+    expect_no_offenses('"this is #{} silly"')
   end
 
   it 'autocorrects by removing the redundant to_s' do

--- a/spec/rubocop/cop/lint/unneeded_splat_expansion_spec.rb
+++ b/spec/rubocop/cop/lint/unneeded_splat_expansion_spec.rb
@@ -26,12 +26,10 @@ describe RuboCop::Cop::Lint::UnneededSplatExpansion do
   end
 
   it 'accepts expanding a variable as a method parameter' do
-    inspect_source(cop, <<-END.strip_indent)
+    expect_no_offenses(<<-END.strip_indent)
       foo = [1, 2, 3]
       array.push(*foo)
     END
-
-    expect(cop.offenses).to be_empty
   end
 
   shared_examples 'splat literal assignment' do |literal|
@@ -124,26 +122,22 @@ describe RuboCop::Cop::Lint::UnneededSplatExpansion do
     end
 
     it 'allows an array that is assigned to a variable' do
-      inspect_source(cop, <<-END.strip_indent)
+      expect_no_offenses(<<-END.strip_indent)
         baz = [1, 2, 3]
         case foo
         when *baz
           bar
         end
       END
-
-      expect(cop.offenses).to be_empty
     end
 
     it 'allows an array using a constructor' do
-      inspect_source(cop, <<-END.strip_indent)
+      expect_no_offenses(<<-END.strip_indent)
         case foo
         when *Array.new(3) { 42 }
           bar
         end
       END
-
-      expect(cop.offenses).to be_empty
     end
   end
 
@@ -161,7 +155,7 @@ describe RuboCop::Cop::Lint::UnneededSplatExpansion do
   end
 
   it 'allows expansions of an array that is assigned to a variable in rescue' do
-    inspect_source(cop, <<-END.strip_indent)
+    expect_no_offenses(<<-END.strip_indent)
       ERRORS = [FirstError, SecondError]
       begin
         foo
@@ -169,20 +163,16 @@ describe RuboCop::Cop::Lint::UnneededSplatExpansion do
         bar
       end
     END
-
-    expect(cop.offenses).to be_empty
   end
 
   it 'allows an array using a constructor' do
-    inspect_source(cop, <<-END.strip_indent)
+    expect_no_offenses(<<-END.strip_indent)
       begin
         foo
       rescue *Array.new(3) { 42 }
         bad_example
       end
     END
-
-    expect(cop.offenses).to be_empty
   end
 
   it 'registers an offense for the expansion of an array literal' \

--- a/spec/rubocop/cop/lint/unneeded_splat_expansion_spec.rb
+++ b/spec/rubocop/cop/lint/unneeded_splat_expansion_spec.rb
@@ -6,33 +6,23 @@ describe RuboCop::Cop::Lint::UnneededSplatExpansion do
   let(:array_param_message) { 'Pass array contents as separate arguments.' }
 
   it 'allows assigning to a splat' do
-    inspect_source(cop, '*, rhs = *node')
-
-    expect(cop.offenses).to be_empty
+    expect_no_offenses('*, rhs = *node')
   end
 
   it 'allows assigning to a splat variable' do
-    inspect_source(cop, 'lhs, *args = *node')
-
-    expect(cop.offenses).to be_empty
+    expect_no_offenses('lhs, *args = *node')
   end
 
   it 'allows assigning a variable to a splat expansion of a variable' do
-    inspect_source(cop, 'a = *b')
-
-    expect(cop.offenses).to be_empty
+    expect_no_offenses('a = *b')
   end
 
   it 'allows assigning to an expanded range' do
-    inspect_source(cop, 'a = *1..10')
-
-    expect(cop.offenses).to be_empty
+    expect_no_offenses('a = *1..10')
   end
 
   it 'allows splat expansion inside of an array' do
-    inspect_source(cop, 'a = [10, 11, *1..9]')
-
-    expect(cop.offenses).to be_empty
+    expect_no_offenses('a = [10, 11, *1..9]')
   end
 
   it 'accepts expanding a variable as a method parameter' do
@@ -204,9 +194,7 @@ describe RuboCop::Cop::Lint::UnneededSplatExpansion do
   end
 
   it 'allows expanding a method call on an array literal' do
-    inspect_source(cop, '[1, 2, *[3, 4, 5].map(&:to_s), 6, 7]')
-
-    expect(cop.offenses).to be_empty
+    expect_no_offenses('[1, 2, *[3, 4, 5].map(&:to_s), 6, 7]')
   end
 
   context 'autocorrect' do

--- a/spec/rubocop/cop/lint/unused_block_argument_spec.rb
+++ b/spec/rubocop/cop/lint/unused_block_argument_spec.rb
@@ -348,8 +348,7 @@ describe RuboCop::Cop::Lint::UnusedBlockArgument, :config do
     let(:cop_config) { { 'IgnoreEmptyBlocks' => true } }
 
     it 'accepts an empty block with a single unused parameter' do
-      inspect_source(cop, '->(arg) { }')
-      expect(cop.offenses).to be_empty
+      expect_no_offenses('->(arg) { }')
     end
 
     it 'registers an offense for a non-empty block with an unused parameter' do
@@ -358,8 +357,7 @@ describe RuboCop::Cop::Lint::UnusedBlockArgument, :config do
     end
 
     it 'accepts an empty block with multiple unused parameters' do
-      inspect_source(cop, '->(arg1, arg2, *others) { }')
-      expect(cop.offenses).to be_empty
+      expect_no_offenses('->(arg1, arg2, *others) { }')
     end
 
     it 'registers an offense for a non-empty block with multiple unused args' do

--- a/spec/rubocop/cop/lint/unused_method_argument_spec.rb
+++ b/spec/rubocop/cop/lint/unused_method_argument_spec.rb
@@ -352,11 +352,10 @@ describe RuboCop::Cop::Lint::UnusedMethodArgument, :config do
     let(:cop_config) { { 'IgnoreEmptyMethods' => true } }
 
     it 'accepts an empty method with a single unused parameter' do
-      inspect_source(cop, <<-END.strip_indent)
+      expect_no_offenses(<<-END.strip_indent)
         def method(arg)
         end
       END
-      expect(cop.offenses).to be_empty
     end
 
     it 'registers an offense for a non-empty method with a single unused ' \
@@ -370,11 +369,10 @@ describe RuboCop::Cop::Lint::UnusedMethodArgument, :config do
     end
 
     it 'accepts an empty method with multiple unused parameters' do
-      inspect_source(cop, <<-END.strip_indent)
+      expect_no_offenses(<<-END.strip_indent)
         def method(a, b, *others)
         end
       END
-      expect(cop.offenses).to be_empty
     end
 
     it 'registers an offense for a non-empty method with multiple unused ' \

--- a/spec/rubocop/cop/lint/useless_setter_call_spec.rb
+++ b/spec/rubocop/cop/lint/useless_setter_call_spec.rb
@@ -45,44 +45,41 @@ describe RuboCop::Cop::Lint::UselessSetterCall do
 
   context 'with method ending with ivar assignment' do
     it 'accepts' do
-      inspect_source(cop, <<-END.strip_indent)
+      expect_no_offenses(<<-END.strip_indent)
         def test
           something
           @top = 5
         end
       END
-      expect(cop.offenses).to be_empty
     end
   end
 
   context 'with method ending with setter call on ivar' do
     it 'accepts' do
-      inspect_source(cop, <<-END.strip_indent)
+      expect_no_offenses(<<-END.strip_indent)
         def test
           something
           @top.attr = 5
         end
       END
-      expect(cop.offenses).to be_empty
     end
   end
 
   context 'with method ending with setter call on argument' do
     it 'accepts' do
-      inspect_source(cop, <<-END.strip_indent)
+      expect_no_offenses(<<-END.strip_indent)
         def test(some_arg)
           unrelated_local_variable = Top.new
           some_arg.attr = 5
         end
       END
-      expect(cop.offenses).to be_empty
     end
   end
 
   context 'when a lvar contains an object passed as argument ' \
           'at the end of the method' do
     it 'accepts the setter call on the lvar' do
-      inspect_source(cop, <<-END.strip_indent)
+      expect_no_offenses(<<-END.strip_indent)
         def test(some_arg)
           @some_ivar = some_arg
           @some_ivar.do_something
@@ -91,20 +88,18 @@ describe RuboCop::Cop::Lint::UselessSetterCall do
           some_lvar.attr = 5
         end
       END
-      expect(cop.offenses).to be_empty
     end
   end
 
   context 'when a lvar contains an object passed as argument ' \
           'by multiple-assignment at the end of the method' do
     it 'accepts the setter call on the lvar' do
-      inspect_source(cop, <<-END.strip_indent)
+      expect_no_offenses(<<-END.strip_indent)
         def test(some_arg)
           _first, some_lvar, _third  = 1, some_arg, 3
           some_lvar.attr = 5
         end
       END
-      expect(cop.offenses).to be_empty
     end
   end
 
@@ -124,14 +119,13 @@ describe RuboCop::Cop::Lint::UselessSetterCall do
   context 'when a lvar possibly contains an object passed as argument ' \
           'by logical-operator-assignment at the end of the method' do
     it 'accepts the setter call on the lvar' do
-      inspect_source(cop, <<-END.strip_indent)
+      expect_no_offenses(<<-END.strip_indent)
         def test(some_arg)
           some_lvar = nil
           some_lvar ||= some_arg
           some_lvar.attr = 5
         end
       END
-      expect(cop.offenses).to be_empty
     end
   end
 
@@ -176,27 +170,25 @@ describe RuboCop::Cop::Lint::UselessSetterCall do
 
   context 'when a lvar contains a non-local object returned by a method' do
     it 'accepts' do
-      inspect_source(cop, <<-END.strip_indent)
+      expect_no_offenses(<<-END.strip_indent)
         def test
           some_lvar = Foo.shared_object
           some_lvar[:attr] = 1
         end
       END
-      expect(cop.offenses).to be_empty
     end
   end
 
   it 'is not confused by operators ending with =' do
-    inspect_source(cop, <<-END.strip_indent)
+    expect_no_offenses(<<-END.strip_indent)
       def test
         top.attr == 5
       end
     END
-    expect(cop.offenses).to be_empty
   end
 
   it 'handles exception assignments without exploding' do
-    inspect_source(cop, <<-END.strip_indent)
+    expect_no_offenses(<<-END.strip_indent)
       def foo(bar)
         begin
         rescue StandardError => _
@@ -204,6 +196,5 @@ describe RuboCop::Cop::Lint::UselessSetterCall do
         bar[:baz] = true
       end
     END
-    expect(cop.offenses).to be_empty
   end
 end

--- a/spec/rubocop/cop/lint/void_spec.rb
+++ b/spec/rubocop/cop/lint/void_spec.rb
@@ -74,26 +74,23 @@ describe RuboCop::Cop::Lint::Void do
   end
 
   it 'accepts short call syntax' do
-    inspect_source(cop, <<-END.strip_indent)
+    expect_no_offenses(<<-END.strip_indent)
       lambda.(a)
       top
     END
-    expect(cop.offenses).to be_empty
   end
 
   it 'accepts backtick commands' do
-    inspect_source(cop, <<-END.strip_indent)
+    expect_no_offenses(<<-END.strip_indent)
       `touch x`
       nil
     END
-    expect(cop.offenses).to be_empty
   end
 
   it 'accepts percent-x commands' do
-    inspect_source(cop, <<-END.strip_indent)
+    expect_no_offenses(<<-END.strip_indent)
       %x(touch x)
       nil
     END
-    expect(cop.offenses).to be_empty
   end
 end

--- a/spec/rubocop/cop/metrics/abc_size_spec.rb
+++ b/spec/rubocop/cop/metrics/abc_size_spec.rb
@@ -7,11 +7,10 @@ describe RuboCop::Cop::Metrics::AbcSize, :config do
     let(:cop_config) { { 'Max' => 0 } }
 
     it 'accepts an empty method' do
-      inspect_source(cop, <<-END.strip_indent)
+      expect_no_offenses(<<-END.strip_indent)
         def method_name
         end
       END
-      expect(cop.offenses).to be_empty
     end
 
     it 'registers an offense for an if modifier' do
@@ -85,13 +84,12 @@ describe RuboCop::Cop::Metrics::AbcSize, :config do
     let(:cop_config) { { 'Max' => 2 } }
 
     it 'accepts two assignments' do
-      inspect_source(cop, <<-END.strip_indent)
+      expect_no_offenses(<<-END.strip_indent)
         def method_name
           x = 1
           y = 2
         end
       END
-      expect(cop.offenses).to be_empty
     end
   end
 
@@ -99,12 +97,11 @@ describe RuboCop::Cop::Metrics::AbcSize, :config do
     let(:cop_config) { { 'Max' => 1.8 } }
 
     it 'accepts a total score of 1.7' do
-      inspect_source(cop, <<-END.strip_indent)
+      expect_no_offenses(<<-END.strip_indent)
         def method_name
           y = 1 if y == 1
         end
       END
-      expect(cop.offenses).to be_empty
     end
   end
 

--- a/spec/rubocop/cop/metrics/block_length_spec.rb
+++ b/spec/rubocop/cop/metrics/block_length_spec.rb
@@ -32,17 +32,16 @@ describe RuboCop::Cop::Metrics::BlockLength, :config do
   end
 
   it 'accepts a block with less than 3 lines' do
-    inspect_source(cop, <<-END.strip_indent)
+    expect_no_offenses(<<-END.strip_indent)
       something do
         a = 1
         a = 2
       end
     END
-    expect(cop.offenses).to be_empty
   end
 
   it 'does not count blank lines' do
-    inspect_source(cop, <<-END.strip_indent)
+    expect_no_offenses(<<-END.strip_indent)
       something do
         a = 1
 
@@ -50,11 +49,10 @@ describe RuboCop::Cop::Metrics::BlockLength, :config do
         a = 4
       end
     END
-    expect(cop.offenses).to be_empty
   end
 
   it 'accepts a block with multiline receiver and less than 3 lines of body' do
-    inspect_source(cop, <<-END.strip_indent)
+    expect_no_offenses(<<-END.strip_indent)
       [
         :a,
         :b,
@@ -64,15 +62,13 @@ describe RuboCop::Cop::Metrics::BlockLength, :config do
         a = 2
       end
     END
-    expect(cop.offenses).to be_empty
   end
 
   it 'accepts empty blocks' do
-    inspect_source(cop, <<-END.strip_indent)
+    expect_no_offenses(<<-END.strip_indent)
       something do
       end
     END
-    expect(cop.offenses).to be_empty
   end
 
   it 'rejects brace blocks too' do
@@ -102,7 +98,7 @@ describe RuboCop::Cop::Metrics::BlockLength, :config do
   end
 
   it 'does not count commented lines by default' do
-    inspect_source(cop, <<-END.strip_indent)
+    expect_no_offenses(<<-END.strip_indent)
       something do
         a = 1
         #a = 2
@@ -110,7 +106,6 @@ describe RuboCop::Cop::Metrics::BlockLength, :config do
         a = 4
       end
     END
-    expect(cop.offenses).to be_empty
   end
 
   context 'when CountComments is enabled' do
@@ -144,14 +139,13 @@ describe RuboCop::Cop::Metrics::BlockLength, :config do
     end
 
     it 'accepts the foo method with a long block' do
-      inspect_source(cop, <<-END.strip_indent)
+      expect_no_offenses(<<-END.strip_indent)
         foo do
           a = 1
           a = 2
           a = 3
         end
       END
-      expect(cop.offenses).to be_empty
     end
   end
 end

--- a/spec/rubocop/cop/metrics/block_nesting_spec.rb
+++ b/spec/rubocop/cop/metrics/block_nesting_spec.rb
@@ -20,14 +20,13 @@ describe RuboCop::Cop::Metrics::BlockNesting, :config do
   end
 
   it 'accepts `Max` levels of nesting' do
-    inspect_source(cop, <<-END.strip_indent)
+    expect_no_offenses(<<-END.strip_indent)
       if a
         if b
           puts b
         end
       end
     END
-    expect(cop.offenses).to be_empty
   end
 
   context '`Max + 1` levels of `if` nesting' do
@@ -171,21 +170,20 @@ describe RuboCop::Cop::Metrics::BlockNesting, :config do
   end
 
   it 'accepts if/elsif' do
-    inspect_source(cop, <<-END.strip_indent)
+    expect_no_offenses(<<-END.strip_indent)
       if a
       elsif b
       elsif c
       elsif d
       end
     END
-    expect(cop.offenses).to be_empty
   end
 
   context 'when CountBlocks is false' do
     let(:cop_config) { { 'Max' => 2, 'CountBlocks' => false } }
 
     it 'accepts nested multiline blocks' do
-      inspect_source(cop, <<-END.strip_indent)
+      expect_no_offenses(<<-END.strip_indent)
         if a
           if b
             [1, 2].each do |c|
@@ -194,18 +192,16 @@ describe RuboCop::Cop::Metrics::BlockNesting, :config do
           end
         end
       END
-      expect(cop.offenses).to be_empty
     end
 
     it 'accepts nested inline blocks' do
-      inspect_source(cop, <<-END.strip_indent)
+      expect_no_offenses(<<-END.strip_indent)
         if a
           if b
             [1, 2].each { |c| puts c }
           end
         end
       END
-      expect(cop.offenses).to be_empty
     end
   end
 

--- a/spec/rubocop/cop/metrics/class_length_spec.rb
+++ b/spec/rubocop/cop/metrics/class_length_spec.rb
@@ -38,7 +38,7 @@ describe RuboCop::Cop::Metrics::ClassLength, :config do
   end
 
   it 'accepts a class with 5 lines' do
-    inspect_source(cop, <<-END.strip_indent)
+    expect_no_offenses(<<-END.strip_indent)
       class Test
         a = 1
         a = 2
@@ -47,11 +47,10 @@ describe RuboCop::Cop::Metrics::ClassLength, :config do
         a = 5
       end
     END
-    expect(cop.offenses).to be_empty
   end
 
   it 'accepts a class with less than 5 lines' do
-    inspect_source(cop, <<-END.strip_indent)
+    expect_no_offenses(<<-END.strip_indent)
       class Test
         a = 1
         a = 2
@@ -59,11 +58,10 @@ describe RuboCop::Cop::Metrics::ClassLength, :config do
         a = 4
       end
     END
-    expect(cop.offenses).to be_empty
   end
 
   it 'does not count blank lines' do
-    inspect_source(cop, <<-END.strip_indent)
+    expect_no_offenses(<<-END.strip_indent)
       class Test
         a = 1
         a = 2
@@ -74,20 +72,18 @@ describe RuboCop::Cop::Metrics::ClassLength, :config do
         a = 7
       end
     END
-    expect(cop.offenses).to be_empty
   end
 
   it 'accepts empty classes' do
-    inspect_source(cop, <<-END.strip_indent)
+    expect_no_offenses(<<-END.strip_indent)
       class Test
       end
     END
-    expect(cop.offenses).to be_empty
   end
 
   context 'when a class has inner classes' do
     it 'does not count lines of inner classes' do
-      inspect_source(cop, <<-END.strip_indent)
+      expect_no_offenses(<<-END.strip_indent)
         class NamespaceClass
           class TestOne
             a = 1
@@ -110,7 +106,6 @@ describe RuboCop::Cop::Metrics::ClassLength, :config do
           a = 5
         end
       END
-      expect(cop.offenses).to be_empty
     end
 
     it 'rejects a class with 6 lines that belong to the class directly' do

--- a/spec/rubocop/cop/metrics/cyclomatic_complexity_spec.rb
+++ b/spec/rubocop/cop/metrics/cyclomatic_complexity_spec.rb
@@ -7,16 +7,15 @@ describe RuboCop::Cop::Metrics::CyclomaticComplexity, :config do
     let(:cop_config) { { 'Max' => 1 } }
 
     it 'accepts a method with no decision points' do
-      inspect_source(cop, <<-END.strip_indent)
+      expect_no_offenses(<<-END.strip_indent)
         def method_name
           call_foo
         end
       END
-      expect(cop.offenses).to be_empty
     end
 
     it 'accepts complex code outside of methods' do
-      inspect_source(cop, <<-END.strip_indent)
+      expect_no_offenses(<<-END.strip_indent)
         def method_name
           call_foo
         end
@@ -26,7 +25,6 @@ describe RuboCop::Cop::Metrics::CyclomaticComplexity, :config do
           call_bar if fourth_condition || fifth_condition
         end
       END
-      expect(cop.offenses).to be_empty
     end
 
     it 'registers an offense for an if modifier' do

--- a/spec/rubocop/cop/metrics/method_length_spec.rb
+++ b/spec/rubocop/cop/metrics/method_length_spec.rb
@@ -38,7 +38,7 @@ describe RuboCop::Cop::Metrics::MethodLength, :config do
   end
 
   it 'accepts a method with less than 5 lines' do
-    inspect_source(cop, <<-END.strip_indent)
+    expect_no_offenses(<<-END.strip_indent)
       def m()
         a = 1
         a = 2
@@ -46,7 +46,6 @@ describe RuboCop::Cop::Metrics::MethodLength, :config do
         a = 4
       end
     END
-    expect(cop.offenses).to be_empty
   end
 
   it 'accepts a method with multiline arguments ' \
@@ -65,7 +64,7 @@ describe RuboCop::Cop::Metrics::MethodLength, :config do
   end
 
   it 'does not count blank lines' do
-    inspect_source(cop, <<-END.strip_indent)
+    expect_no_offenses(<<-END.strip_indent)
       def m()
         a = 1
         a = 2
@@ -76,19 +75,17 @@ describe RuboCop::Cop::Metrics::MethodLength, :config do
         a = 7
       end
     END
-    expect(cop.offenses).to be_empty
   end
 
   it 'accepts empty methods' do
-    inspect_source(cop, <<-END.strip_indent)
+    expect_no_offenses(<<-END.strip_indent)
       def m()
       end
     END
-    expect(cop.offenses).to be_empty
   end
 
   it 'is not fooled by one-liner methods, syntax #1' do
-    inspect_source(cop, <<-END.strip_indent)
+    expect_no_offenses(<<-END.strip_indent)
       def one_line; 10 end
       def self.m()
         a = 1
@@ -98,11 +95,10 @@ describe RuboCop::Cop::Metrics::MethodLength, :config do
         a = 6
       end
     END
-    expect(cop.offenses).to be_empty
   end
 
   it 'is not fooled by one-liner methods, syntax #2' do
-    inspect_source(cop, <<-END.strip_indent)
+    expect_no_offenses(<<-END.strip_indent)
       def one_line(test) 10 end
       def self.m()
         a = 1
@@ -112,7 +108,6 @@ describe RuboCop::Cop::Metrics::MethodLength, :config do
         a = 6
       end
     END
-    expect(cop.offenses).to be_empty
   end
 
   it 'checks class methods, syntax #1' do
@@ -165,7 +160,7 @@ describe RuboCop::Cop::Metrics::MethodLength, :config do
   end
 
   it 'does not count commented lines by default' do
-    inspect_source(cop, <<-END.strip_indent)
+    expect_no_offenses(<<-END.strip_indent)
       def m()
         a = 1
         #a = 2
@@ -175,7 +170,6 @@ describe RuboCop::Cop::Metrics::MethodLength, :config do
         a = 6
       end
     END
-    expect(cop.offenses).to be_empty
   end
 
   context 'when CountComments is enabled' do

--- a/spec/rubocop/cop/metrics/module_length_spec.rb
+++ b/spec/rubocop/cop/metrics/module_length_spec.rb
@@ -37,7 +37,7 @@ describe RuboCop::Cop::Metrics::ModuleLength, :config do
   end
 
   it 'accepts a module with 5 lines' do
-    inspect_source(cop, <<-END.strip_indent)
+    expect_no_offenses(<<-END.strip_indent)
       module Test
         a = 1
         a = 2
@@ -46,11 +46,10 @@ describe RuboCop::Cop::Metrics::ModuleLength, :config do
         a = 5
       end
     END
-    expect(cop.offenses).to be_empty
   end
 
   it 'accepts a module with less than 5 lines' do
-    inspect_source(cop, <<-END.strip_indent)
+    expect_no_offenses(<<-END.strip_indent)
       module Test
         a = 1
         a = 2
@@ -58,11 +57,10 @@ describe RuboCop::Cop::Metrics::ModuleLength, :config do
         a = 4
       end
     END
-    expect(cop.offenses).to be_empty
   end
 
   it 'does not count blank lines' do
-    inspect_source(cop, <<-END.strip_indent)
+    expect_no_offenses(<<-END.strip_indent)
       module Test
         a = 1
         a = 2
@@ -73,20 +71,18 @@ describe RuboCop::Cop::Metrics::ModuleLength, :config do
         a = 7
       end
     END
-    expect(cop.offenses).to be_empty
   end
 
   it 'accepts empty modules' do
-    inspect_source(cop, <<-END.strip_indent)
+    expect_no_offenses(<<-END.strip_indent)
       module Test
       end
     END
-    expect(cop.offenses).to be_empty
   end
 
   context 'when a module has inner modules' do
     it 'does not count lines of inner modules' do
-      inspect_source(cop, <<-END.strip_indent)
+      expect_no_offenses(<<-END.strip_indent)
         module NamespaceModule
           module TestOne
             a = 1
@@ -109,7 +105,6 @@ describe RuboCop::Cop::Metrics::ModuleLength, :config do
           a = 5
         end
       END
-      expect(cop.offenses).to be_empty
     end
 
     it 'rejects a module with 6 lines that belong to the module directly' do
@@ -143,7 +138,7 @@ describe RuboCop::Cop::Metrics::ModuleLength, :config do
 
   context 'when a module has inner classes' do
     it 'does not count lines of inner classes' do
-      inspect_source(cop, <<-END.strip_indent)
+      expect_no_offenses(<<-END.strip_indent)
         module NamespaceModule
           class TestOne
             a = 1
@@ -166,7 +161,6 @@ describe RuboCop::Cop::Metrics::ModuleLength, :config do
           a = 5
         end
       END
-      expect(cop.offenses).to be_empty
     end
 
     it 'rejects a module with 6 lines that belong to the module directly' do

--- a/spec/rubocop/cop/metrics/parameter_lists_spec.rb
+++ b/spec/rubocop/cop/metrics/parameter_lists_spec.rb
@@ -22,11 +22,10 @@ describe RuboCop::Cop::Metrics::ParameterLists, :config do
   end
 
   it 'accepts a method def with 4 parameters' do
-    inspect_source(cop, <<-END.strip_indent)
+    expect_no_offenses(<<-END.strip_indent)
       def meth(a, b, c, d)
       end
     END
-    expect(cop.offenses).to be_empty
   end
 
   context 'When CountKeywordArgs is true' do
@@ -46,11 +45,10 @@ describe RuboCop::Cop::Metrics::ParameterLists, :config do
     before { cop_config['CountKeywordArgs'] = false }
 
     it 'does not count keyword arguments' do
-      inspect_source(cop, <<-END.strip_indent)
+      expect_no_offenses(<<-END.strip_indent)
         def meth(a, b, c, d: 1, e: 2)
         end
       END
-      expect(cop.offenses).to be_empty
     end
 
     it 'does not count keyword arguments without default values', ruby: 2.1 do

--- a/spec/rubocop/cop/metrics/perceived_complexity_spec.rb
+++ b/spec/rubocop/cop/metrics/perceived_complexity_spec.rb
@@ -7,16 +7,15 @@ describe RuboCop::Cop::Metrics::PerceivedComplexity, :config do
     let(:cop_config) { { 'Max' => 1 } }
 
     it 'accepts a method with no decision points' do
-      inspect_source(cop, <<-END.strip_indent)
+      expect_no_offenses(<<-END.strip_indent)
         def method_name
           call_foo
         end
       END
-      expect(cop.offenses).to be_empty
     end
 
     it 'accepts complex code outside of methods' do
-      inspect_source(cop, <<-END.strip_indent)
+      expect_no_offenses(<<-END.strip_indent)
         def method_name
           call_foo
         end
@@ -26,7 +25,6 @@ describe RuboCop::Cop::Metrics::PerceivedComplexity, :config do
           call_bar if fourth_condition || fifth_condition
         end
       END
-      expect(cop.offenses).to be_empty
     end
 
     it 'registers an offense for an if modifier' do

--- a/spec/rubocop/cop/performance/case_when_splat_spec.rb
+++ b/spec/rubocop/cop/performance/case_when_splat_spec.rb
@@ -163,7 +163,7 @@ describe RuboCop::Cop::Performance::CaseWhenSplat do
   end
 
   it 'allows splat expansion on an array literal' do
-    inspect_source(cop, <<-END.strip_indent)
+    expect_no_offenses(<<-END.strip_indent)
       case foo
       when *[1, 2]
         bar
@@ -173,19 +173,15 @@ describe RuboCop::Cop::Performance::CaseWhenSplat do
         baz
       end
     END
-
-    expect(cop.offenses).to be_empty
   end
 
   it 'allows splat expansion on array literal as the last condition' do
-    inspect_source(cop, <<-END.strip_indent)
+    expect_no_offenses(<<-END.strip_indent)
       case foo
       when *[1, 2]
         bar
       end
     END
-
-    expect(cop.offenses).to be_empty
   end
 
   it 'registers an offense for a splat on a variable that proceeds a splat ' \

--- a/spec/rubocop/cop/performance/end_with_spec.rb
+++ b/spec/rubocop/cop/performance/end_with_spec.rb
@@ -74,7 +74,6 @@ describe RuboCop::Cop::Performance::EndWith do
   include_examples('different match methods', '.match')
 
   it 'allows match without a receiver' do
-    inspect_source(cop, 'expect(subject.spin).to match(/\n\z/)')
-    expect(cop.offenses).to be_empty
+    expect_no_offenses('expect(subject.spin).to match(/\n\z/)')
   end
 end

--- a/spec/rubocop/cop/performance/redundant_match_spec.rb
+++ b/spec/rubocop/cop/performance/redundant_match_spec.rb
@@ -100,12 +100,11 @@ describe RuboCop::Cop::Performance::RedundantMatch do
   end
 
   it 'does not register an offense when match has a block' do
-    inspect_source(cop, <<-END.strip_indent)
+    expect_no_offenses(<<-END.strip_indent)
       /regex/.match(str) do |m|
         something(m)
       end
     END
-    expect(cop.offenses).to be_empty
   end
 
   it 'does not register an error when there is no receiver to the match call' do

--- a/spec/rubocop/cop/performance/redundant_merge_spec.rb
+++ b/spec/rubocop/cop/performance/redundant_merge_spec.rb
@@ -225,11 +225,10 @@ describe RuboCop::Cop::Performance::RedundantMerge, :config do
   end
 
   it "doesn't register an error when return value is used" do
-    inspect_source(cop, <<-END.strip_indent)
+    expect_no_offenses(<<-END.strip_indent)
       variable = hash.merge!(a: 1)
       puts variable
     END
-    expect(cop.offenses).to be_empty
   end
 
   it 'formats the error message correctly for hash.merge!(a: 1)' do
@@ -245,11 +244,10 @@ describe RuboCop::Cop::Performance::RedundantMerge, :config do
     end
 
     it "doesn't register errors for multi-value hash merges" do
-      inspect_source(cop, <<-END.strip_indent)
+      expect_no_offenses(<<-END.strip_indent)
         hash = {}
         hash.merge!(a: 1, b: 2)
       END
-      expect(cop.offenses).to be_empty
     end
   end
 end

--- a/spec/rubocop/cop/performance/size_spec.rb
+++ b/spec/rubocop/cop/performance/size_spec.rb
@@ -55,15 +55,11 @@ describe RuboCop::Cop::Performance::Size do
     end
 
     it 'does not register an offense when calling count with a to_proc block' do
-      inspect_source(cop, '[1, 2, 3].count(&:nil?)')
-
-      expect(cop.offenses).to be_empty
+      expect_no_offenses('[1, 2, 3].count(&:nil?)')
     end
 
     it 'does not register an offense when calling count with an argument' do
-      inspect_source(cop, '[1, 2, 3].count(1)')
-
-      expect(cop.offenses).to be_empty
+      expect_no_offenses('[1, 2, 3].count(1)')
     end
 
     it 'corrects count to size' do
@@ -123,15 +119,11 @@ describe RuboCop::Cop::Performance::Size do
     end
 
     it 'does not register an offense when calling count with a to_proc block' do
-      inspect_source(cop, '{a: 1, b: 2, c: 3}.count(&:nil?)')
-
-      expect(cop.offenses).to be_empty
+      expect_no_offenses('{a: 1, b: 2, c: 3}.count(&:nil?)')
     end
 
     it 'does not register an offense when calling count with an argument' do
-      inspect_source(cop, '{a: 1, b: 2, c: 3}.count(1)')
-
-      expect(cop.offenses).to be_empty
+      expect_no_offenses('{a: 1, b: 2, c: 3}.count(1)')
     end
 
     it 'corrects count to size' do

--- a/spec/rubocop/cop/performance/start_with_spec.rb
+++ b/spec/rubocop/cop/performance/start_with_spec.rb
@@ -65,7 +65,6 @@ describe RuboCop::Cop::Performance::StartWith do
   include_examples('different match methods', '.match')
 
   it 'allows match without a receiver' do
-    inspect_source(cop, 'expect(subject.spin).to match(/\A\n/)')
-    expect(cop.offenses).to be_empty
+    expect_no_offenses('expect(subject.spin).to match(/\A\n/)')
   end
 end

--- a/spec/rubocop/cop/rails/blank_spec.rb
+++ b/spec/rubocop/cop/rails/blank_spec.rb
@@ -137,35 +137,29 @@ describe RuboCop::Cop::Rails::Blank, :config do
     end
 
     it 'accepts normal if present?' do
-      inspect_source(cop, <<-END.strip_indent)
+      expect_no_offenses(<<-END.strip_indent)
         if foo.present?
           something
         end
       END
-
-      expect(cop.offenses).to be_empty
     end
 
     it 'accepts normal unless blank?' do
-      inspect_source(cop, <<-END.strip_indent)
+      expect_no_offenses(<<-END.strip_indent)
         unless foo.blank?
           something
         end
       END
-
-      expect(cop.offenses).to be_empty
     end
 
     it 'accepts elsif present?' do
-      inspect_source(cop, <<-END.strip_indent)
+      expect_no_offenses(<<-END.strip_indent)
         if bar.present?
           something
         elsif bar.present?
           something_else
         end
       END
-
-      expect(cop.offenses).to be_empty
     end
 
     context 'modifier unless' do

--- a/spec/rubocop/cop/rails/blank_spec.rb
+++ b/spec/rubocop/cop/rails/blank_spec.rb
@@ -24,34 +24,24 @@ describe RuboCop::Cop::Rails::Blank, :config do
     end
 
     it 'accepts checking nil?' do
-      inspect_source(cop, 'foo.nil?')
-
-      expect(cop.offenses).to be_empty
+      expect_no_offenses('foo.nil?')
     end
 
     it 'accepts checking empty?' do
-      inspect_source(cop, 'foo.empty?')
-
-      expect(cop.offenses).to be_empty
+      expect_no_offenses('foo.empty?')
     end
 
     it 'accepts checking nil? || empty? on different objects' do
-      inspect_source(cop, 'foo.nil? || bar.empty?')
-
-      expect(cop.offenses).to be_empty
+      expect_no_offenses('foo.nil? || bar.empty?')
     end
 
     # Bug: https://github.com/bbatsov/rubocop/issues/4171
     it 'does not break when RHS of `or` is a naked falsiness check' do
-      inspect_source(cop, 'foo.empty? || bar')
-
-      expect(cop.offenses).to be_empty
+      expect_no_offenses('foo.empty? || bar')
     end
 
     it 'does not break when LHS of `or` is a naked falsiness check' do
-      inspect_source(cop, 'bar || foo.empty?')
-
-      expect(cop.offenses).to be_empty
+      expect_no_offenses('bar || foo.empty?')
     end
 
     context 'nil or empty' do
@@ -139,15 +129,11 @@ describe RuboCop::Cop::Rails::Blank, :config do
     end
 
     it 'accepts modifier if present?' do
-      inspect_source(cop, 'something if foo.present?')
-
-      expect(cop.offenses).to be_empty
+      expect_no_offenses('something if foo.present?')
     end
 
     it 'accepts modifier unless blank?' do
-      inspect_source(cop, 'something unless foo.blank?')
-
-      expect(cop.offenses).to be_empty
+      expect_no_offenses('something unless foo.blank?')
     end
 
     it 'accepts normal if present?' do
@@ -269,9 +255,7 @@ describe RuboCop::Cop::Rails::Blank, :config do
     end
 
     it 'accepts checking nil? || empty?' do
-      inspect_source(cop, 'foo.nil? || foo.empty?')
-
-      expect(cop.offenses).to be_empty
+      expect_no_offenses('foo.nil? || foo.empty?')
     end
   end
 
@@ -283,9 +267,7 @@ describe RuboCop::Cop::Rails::Blank, :config do
     end
 
     it 'accepts !present?' do
-      inspect_source(cop, '!foo.present?')
-
-      expect(cop.offenses).to be_empty
+      expect_no_offenses('!foo.present?')
     end
   end
 
@@ -297,9 +279,7 @@ describe RuboCop::Cop::Rails::Blank, :config do
     end
 
     it 'accepts unless present?' do
-      inspect_source(cop, 'something unless foo.present?')
-
-      expect(cop.offenses).to be_empty
+      expect_no_offenses('something unless foo.present?')
     end
   end
 end

--- a/spec/rubocop/cop/rails/date_spec.rb
+++ b/spec/rubocop/cop/rails/date_spec.rb
@@ -42,15 +42,13 @@ describe RuboCop::Cop::Rails::Date, :config do
 
     context 'when a zone is provided' do
       it 'does not register an offense' do
-        inspect_source(cop, 'date.to_time(:utc)')
-        expect(cop.offenses).to be_empty
+        expect_no_offenses('date.to_time(:utc)')
       end
     end
 
     context 'when a string literal with timezone' do
       it 'does not register an offense' do
-        inspect_source(cop, '"2016-07-12 14:36:31 +0100".to_time(:utc)')
-        expect(cop.offenses).to be_empty
+        expect_no_offenses('"2016-07-12 14:36:31 +0100".to_time(:utc)')
       end
     end
 
@@ -62,8 +60,7 @@ describe RuboCop::Cop::Rails::Date, :config do
     end
 
     it 'does not blow up in the presence of a single constant to inspect' do
-      inspect_source(cop, 'A')
-      expect(cop.offenses).to be_empty
+      expect_no_offenses('A')
     end
 
     RuboCop::Cop::Rails::TimeZone::ACCEPTED_METHODS.each do |a_method|
@@ -97,8 +94,7 @@ describe RuboCop::Cop::Rails::Date, :config do
     end
 
     it 'accepts #to_time_in_current_zone' do
-      inspect_source(cop, 'date.to_time_in_current_zone')
-      expect(cop.offenses).to be_empty
+      expect_no_offenses('date.to_time_in_current_zone')
     end
   end
 end

--- a/spec/rubocop/cop/rails/delegate_spec.rb
+++ b/spec/rubocop/cop/rails/delegate_spec.rb
@@ -46,70 +46,63 @@ describe RuboCop::Cop::Rails::Delegate do
   end
 
   it 'ignores class methods' do
-    inspect_source(cop, <<-END.strip_indent)
+    expect_no_offenses(<<-END.strip_indent)
       def self.fox
         new.fox
       end
     END
-    expect(cop.offenses).to be_empty
   end
 
   it 'ignores non trivial delegate' do
-    inspect_source(cop, <<-END.strip_indent)
+    expect_no_offenses(<<-END.strip_indent)
       def fox
         bar.foo.fox
       end
     END
-    expect(cop.offenses).to be_empty
   end
 
   it 'ignores trivial delegate with mismatched arguments' do
-    inspect_source(cop, <<-END.strip_indent)
+    expect_no_offenses(<<-END.strip_indent)
       def fox(baz)
         bar.fox(foo)
       end
     END
-    expect(cop.offenses).to be_empty
   end
 
   it 'ignores trivial delegate with optional argument with a default value' do
-    inspect_source(cop, <<-END.strip_indent)
+    expect_no_offenses(<<-END.strip_indent)
       def fox(foo = nil)
         bar.fox(foo || 5)
       end
     END
-    expect(cop.offenses).to be_empty
   end
 
   it 'ignores trivial delegate with mismatched number of arguments' do
-    inspect_source(cop, <<-END.strip_indent)
+    expect_no_offenses(<<-END.strip_indent)
       def fox(a, baz)
         bar.fox(a)
       end
     END
-    expect(cop.offenses).to be_empty
   end
 
   it 'ignores trivial delegate with other prefix' do
-    inspect_source(cop, <<-END.strip_indent)
+    expect_no_offenses(<<-END.strip_indent)
       def fox_foo
         bar.foo
       end
     END
-    expect(cop.offenses).to be_empty
   end
 
   it 'ignores methods with arguments' do
-    inspect_source(cop, <<-END.strip_indent)
+    expect_no_offenses(<<-END.strip_indent)
       def fox(bar)
         bar.fox
       end
     END
-    expect(cop.offenses).to be_empty
   end
 
   it 'ignores private delegations' do
-    inspect_source(cop, <<-END.strip_indent)
+    expect_no_offenses(<<-END.strip_indent)
         private def fox # leading spaces are on purpose
           bar.fox
         end
@@ -120,11 +113,10 @@ describe RuboCop::Cop::Rails::Delegate do
           bar.fox
         end
     END
-    expect(cop.offenses).to be_empty
   end
 
   it 'ignores protected delegations' do
-    inspect_source(cop, <<-END.strip_indent)
+    expect_no_offenses(<<-END.strip_indent)
         protected def fox # leading spaces are on purpose
           bar.fox
         end
@@ -135,26 +127,23 @@ describe RuboCop::Cop::Rails::Delegate do
           bar.fox
         end
     END
-    expect(cop.offenses).to be_empty
   end
 
   it 'ignores delegation with assignment' do
-    inspect_source(cop, <<-END.strip_indent)
+    expect_no_offenses(<<-END.strip_indent)
       def new
         @bar = Foo.new
       end
     END
-    expect(cop.offenses).to be_empty
   end
 
   it 'ignores delegation to constant' do
-    inspect_source(cop, <<-END.strip_indent)
+    expect_no_offenses(<<-END.strip_indent)
       FOO = []
       def size
         FOO.size
       end
     END
-    expect(cop.offenses).to be_empty
   end
 
   describe '#autocorrect' do

--- a/spec/rubocop/cop/rails/dynamic_find_by_spec.rb
+++ b/spec/rubocop/cop/rails/dynamic_find_by_spec.rb
@@ -129,8 +129,7 @@ describe RuboCop::Cop::Rails::DynamicFindBy, :config do
   end
 
   it 'accepts' do
-    inspect_source(cop, 'User.find_by(name: name)')
-    expect(cop.offenses).to be_empty
+    expect_no_offenses('User.find_by(name: name)')
   end
 
   it 'accepts method in whitelist' do

--- a/spec/rubocop/cop/rails/enum_uniqueness_spec.rb
+++ b/spec/rubocop/cop/rails/enum_uniqueness_spec.rb
@@ -59,12 +59,10 @@ describe RuboCop::Cop::Rails::EnumUniqueness, :config do
 
   context 'when receiving a variable' do
     it 'does not register an offense' do
-      inspect_source(cop, <<-END.strip_indent)
+      expect_no_offenses(<<-END.strip_indent)
         var = { status: { active: 0, archived: 1 } }
         enum var
       END
-
-      expect(cop.offenses).to be_empty
     end
   end
 

--- a/spec/rubocop/cop/rails/enum_uniqueness_spec.rb
+++ b/spec/rubocop/cop/rails/enum_uniqueness_spec.rb
@@ -25,9 +25,7 @@ describe RuboCop::Cop::Rails::EnumUniqueness, :config do
 
     context 'with no duplicated enum values' do
       it 'does not register an offense for unique enum values' do
-        inspect_source(cop, 'enum status: [:active, :archived]')
-
-        expect(cop.offenses).to be_empty
+        expect_no_offenses('enum status: [:active, :archived]')
       end
     end
   end
@@ -54,9 +52,7 @@ describe RuboCop::Cop::Rails::EnumUniqueness, :config do
 
     context 'with no duplicated enum values' do
       it 'does not register an offense' do
-        inspect_source(cop, 'enum status: { active: 0, pending: 1 }')
-
-        expect(cop.offenses).to be_empty
+        expect_no_offenses('enum status: { active: 0, pending: 1 }')
       end
     end
   end
@@ -75,25 +71,19 @@ describe RuboCop::Cop::Rails::EnumUniqueness, :config do
   context 'when receiving a hash without literal values' do
     context 'when value is a variable' do
       it 'does not register an offense' do
-        inspect_source(cop, 'enum status: statuses')
-
-        expect(cop.offenses).to be_empty
+        expect_no_offenses('enum status: statuses')
       end
     end
 
     context 'when value is a method chain' do
       it 'does not register an offense' do
-        inspect_source(cop, 'enum status: User.statuses.keys')
-
-        expect(cop.offenses).to be_empty
+        expect_no_offenses('enum status: User.statuses.keys')
       end
     end
 
     context 'when value is a constant' do
       it 'does not register an offense' do
-        inspect_source(cop, 'enum status: STATUSES')
-
-        expect(cop.offenses).to be_empty
+        expect_no_offenses('enum status: STATUSES')
       end
     end
   end

--- a/spec/rubocop/cop/rails/exit_spec.rb
+++ b/spec/rubocop/cop/rails/exit_spec.rb
@@ -17,9 +17,7 @@ describe RuboCop::Cop::Rails::Exit, :config do
 
   context 'exit calls on objects' do
     it 'does not register an offense for an explicit exit call on an object' do
-      inspect_source(cop,
-                     'Object.new.exit')
-      expect(cop.offenses).to be_empty
+      expect_no_offenses('Object.new.exit')
     end
 
     it 'does not register an offense for an explicit exit call '\
@@ -30,9 +28,7 @@ describe RuboCop::Cop::Rails::Exit, :config do
     end
 
     it 'does not register an offense for an explicit exit! call on an object' do
-      inspect_source(cop,
-                     'Object.new.exit!(0)')
-      expect(cop.offenses).to be_empty
+      expect_no_offenses('Object.new.exit!(0)')
     end
   end
 
@@ -44,9 +40,7 @@ describe RuboCop::Cop::Rails::Exit, :config do
     end
 
     it 'ignores exit calls with unexpected number of parameters' do
-      inspect_source(cop,
-                     'exit(1, 2)')
-      expect(cop.offenses).to be_empty
+      expect_no_offenses('exit(1, 2)')
     end
   end
 

--- a/spec/rubocop/cop/rails/present_spec.rb
+++ b/spec/rubocop/cop/rails/present_spec.rb
@@ -133,23 +133,19 @@ describe RuboCop::Cop::Rails::Present, :config do
     end
 
     it 'accepts normal if blank?' do
-      inspect_source(cop, <<-END.strip_indent)
+      expect_no_offenses(<<-END.strip_indent)
         if foo.blank?
           something
         end
       END
-
-      expect(cop.offenses).to be_empty
     end
 
     it 'accepts normal unless present?' do
-      inspect_source(cop, <<-END.strip_indent)
+      expect_no_offenses(<<-END.strip_indent)
         unless foo.present?
           something
         end
       END
-
-      expect(cop.offenses).to be_empty
     end
 
     context 'unless blank?' do

--- a/spec/rubocop/cop/rails/present_spec.rb
+++ b/spec/rubocop/cop/rails/present_spec.rb
@@ -26,27 +26,19 @@ describe RuboCop::Cop::Rails::Present, :config do
     end
 
     it 'accepts checking nil?' do
-      inspect_source(cop, 'foo.nil?')
-
-      expect(cop.offenses).to be_empty
+      expect_no_offenses('foo.nil?')
     end
 
     it 'accepts checking empty?' do
-      inspect_source(cop, 'foo.empty?')
-
-      expect(cop.offenses).to be_empty
+      expect_no_offenses('foo.empty?')
     end
 
     it 'accepts checking nil? || empty? on different objects' do
-      inspect_source(cop, 'foo.nil? || bar.empty?')
-
-      expect(cop.offenses).to be_empty
+      expect_no_offenses('foo.nil? || bar.empty?')
     end
 
     it 'accepts checking existance && not empty? on different objects' do
-      inspect_source(cop, 'foo && !bar.empty?')
-
-      expect(cop.offenses).to be_empty
+      expect_no_offenses('foo && !bar.empty?')
     end
 
     it_behaves_like :offense, 'foo && !foo.empty?',
@@ -133,15 +125,11 @@ describe RuboCop::Cop::Rails::Present, :config do
     end
 
     it 'accepts modifier if blank?' do
-      inspect_source(cop, 'something if foo.blank?')
-
-      expect(cop.offenses).to be_empty
+      expect_no_offenses('something if foo.blank?')
     end
 
     it 'accepts modifier unless present?' do
-      inspect_source(cop, 'something unless foo.present?')
-
-      expect(cop.offenses).to be_empty
+      expect_no_offenses('something unless foo.present?')
     end
 
     it 'accepts normal if blank?' do
@@ -253,9 +241,7 @@ describe RuboCop::Cop::Rails::Present, :config do
     end
 
     it 'accepts checking nil? || empty?' do
-      inspect_source(cop, 'foo.nil? || foo.empty?')
-
-      expect(cop.offenses).to be_empty
+      expect_no_offenses('foo.nil? || foo.empty?')
     end
   end
 
@@ -267,9 +253,7 @@ describe RuboCop::Cop::Rails::Present, :config do
     end
 
     it 'accepts !...blank?' do
-      inspect_source(cop, '!foo.blank?')
-
-      expect(cop.offenses).to be_empty
+      expect_no_offenses('!foo.blank?')
     end
   end
 
@@ -281,9 +265,7 @@ describe RuboCop::Cop::Rails::Present, :config do
     end
 
     it 'accepts unless blank?' do
-      inspect_source(cop, 'something unless foo.blank?')
-
-      expect(cop.offenses).to be_empty
+      expect_no_offenses('something unless foo.blank?')
     end
   end
 end

--- a/spec/rubocop/cop/rails/read_write_attribute_spec.rb
+++ b/spec/rubocop/cop/rails/read_write_attribute_spec.rb
@@ -11,8 +11,7 @@ describe RuboCop::Cop::Rails::ReadWriteAttribute do
     end
 
     it 'registers no offense with explicit receiver' do
-      inspect_source(cop, 'res = object.read_attribute(:test)')
-      expect(cop.offenses).to be_empty
+      expect_no_offenses('res = object.read_attribute(:test)')
     end
   end
 
@@ -24,8 +23,7 @@ describe RuboCop::Cop::Rails::ReadWriteAttribute do
     end
 
     it 'registers no offense with explicit receiver' do
-      inspect_source(cop, 'object.write_attribute(:test, val)')
-      expect(cop.offenses).to be_empty
+      expect_no_offenses('object.write_attribute(:test, val)')
     end
   end
 

--- a/spec/rubocop/cop/rails/relative_date_constant_spec.rb
+++ b/spec/rubocop/cop/rails/relative_date_constant_spec.rb
@@ -13,30 +13,27 @@ describe RuboCop::Cop::Rails::RelativeDateConstant do
   end
 
   it 'accepts a method with arguments' do
-    inspect_source(cop, <<-END.strip_indent)
+    expect_no_offenses(<<-END.strip_indent)
       class SomeClass
         EXPIRED_AT = 1.week.since(base)
       end
     END
-    expect(cop.offenses).to be_empty
   end
 
   it 'accepts a lambda' do
-    inspect_source(cop, <<-END.strip_indent)
+    expect_no_offenses(<<-END.strip_indent)
       class SomeClass
         EXPIRED_AT = -> { 1.year.ago }
       end
     END
-    expect(cop.offenses).to be_empty
   end
 
   it 'accepts a proc' do
-    inspect_source(cop, <<-END.strip_indent)
+    expect_no_offenses(<<-END.strip_indent)
       class SomeClass
         EXPIRED_AT = Proc.new { 1.year.ago }
       end
     END
-    expect(cop.offenses).to be_empty
   end
 
   it 'registers an offense for relative date in ||=' do

--- a/spec/rubocop/cop/rails/safe_navigation_spec.rb
+++ b/spec/rubocop/cop/rails/safe_navigation_spec.rb
@@ -71,9 +71,7 @@ describe RuboCop::Cop::Rails::SafeNavigation, :config do
                          'foo.try!(baz, bar)'].join("\n")
 
         it 'accepts usages of try! without receiver' do
-          inspect_source(cop, 'try!(:something)')
-
-          expect(cop.offenses).to be_empty
+          expect_no_offenses('try!(:something)')
         end
       end
 

--- a/spec/rubocop/cop/rails/scope_args_spec.rb
+++ b/spec/rubocop/cop/rails/scope_args_spec.rb
@@ -10,34 +10,27 @@ describe RuboCop::Cop::Rails::ScopeArgs do
   end
 
   it 'accepts a non send argument' do
-    inspect_source(cop, 'scope :active, "adsf"')
-
-    expect(cop.offenses).to be_empty
+    expect_no_offenses('scope :active, "adsf"')
   end
 
   it 'accepts a stabby lambda' do
-    inspect_source(cop, 'scope :active, -> { where(active: true) }')
-
-    expect(cop.offenses).to be_empty
+    expect_no_offenses('scope :active, -> { where(active: true) }')
   end
 
   it 'accepts a stabby lambda with arguments' do
-    inspect_source(cop, 'scope :active, ->(active) { where(active: active) }')
-
-    expect(cop.offenses).to be_empty
+    expect_no_offenses(
+      'scope :active, ->(active) { where(active: active) }'
+    )
   end
 
   it 'accepts a lambda' do
-    inspect_source(cop, 'scope :active, lambda { where(active: true) }')
-
-    expect(cop.offenses).to be_empty
+    expect_no_offenses('scope :active, lambda { where(active: true) }')
   end
 
   it 'accepts a lambda with a block argument' do
-    inspect_source(cop,
-                   'scope :active, lambda { |active| where(active: active) }')
-
-    expect(cop.offenses).to be_empty
+    expect_no_offenses(
+      'scope :active, lambda { |active| where(active: active) }'
+    )
   end
 
   it 'accepts a lambda with a multiline block' do
@@ -51,8 +44,6 @@ describe RuboCop::Cop::Rails::ScopeArgs do
   end
 
   it 'accepts a proc' do
-    inspect_source(cop, 'scope :active, proc { where(active: true) }')
-
-    expect(cop.offenses).to be_empty
+    expect_no_offenses('scope :active, proc { where(active: true) }')
   end
 end

--- a/spec/rubocop/cop/rails/scope_args_spec.rb
+++ b/spec/rubocop/cop/rails/scope_args_spec.rb
@@ -34,13 +34,11 @@ describe RuboCop::Cop::Rails::ScopeArgs do
   end
 
   it 'accepts a lambda with a multiline block' do
-    inspect_source(cop, <<-END.strip_indent)
+    expect_no_offenses(<<-END.strip_indent)
       scope :active, (lambda do |active|
                        where(active: active)
                      end)
     END
-
-    expect(cop.offenses).to be_empty
   end
 
   it 'accepts a proc' do

--- a/spec/rubocop/cop/rails/time_zone_spec.rb
+++ b/spec/rubocop/cop/rails/time_zone_spec.rb
@@ -122,96 +122,77 @@ describe RuboCop::Cop::Rails::TimeZone, :config do
     end
 
     it 'accepts Time.zone.now' do
-      inspect_source(cop, 'Time.zone.now')
-      expect(cop.offenses).to be_empty
+      expect_no_offenses('Time.zone.now')
     end
 
     it 'accepts Time.zone.today' do
-      inspect_source(cop, 'Time.zone.today')
-      expect(cop.offenses).to be_empty
+      expect_no_offenses('Time.zone.today')
     end
 
     it 'accepts Time.zone.local' do
-      inspect_source(cop, 'Time.zone.local(2012, 6, 10, 12, 00)')
-      expect(cop.offenses).to be_empty
+      expect_no_offenses('Time.zone.local(2012, 6, 10, 12, 00)')
     end
 
     it 'accepts Time.zone.parse' do
-      inspect_source(cop, 'Time.zone.parse("2012-03-02 16:05:37")')
-      expect(cop.offenses).to be_empty
+      expect_no_offenses('Time.zone.parse("2012-03-02 16:05:37")')
     end
 
     it 'accepts Time.zone.at' do
-      inspect_source(cop, 'Time.zone.at(ts)')
-      expect(cop.offenses).to be_empty
+      expect_no_offenses('Time.zone.at(ts)')
     end
 
     it 'accepts Time.strptime' do
-      inspect_source(cop, 'Time.strptime(datetime, format).in_time_zone')
-      expect(cop.offenses).to be_empty
+      expect_no_offenses('Time.strptime(datetime, format).in_time_zone')
     end
 
     it 'accepts Time.zone.strftime' do
-      inspect_source(
-        cop,
+      expect_no_offenses(
         'Time.zone.strftime(time_string, "%Y-%m-%dT%H:%M:%S%z")'
       )
-      expect(cop.offenses).to be_empty
     end
 
     it 'accepts Time.zone.parse.localtime' do
-      inspect_source(cop, "Time.zone.parse('12:00').localtime")
-      expect(cop.offenses).to be_empty
+      expect_no_offenses("Time.zone.parse('12:00').localtime")
     end
 
     it 'accepts Time.zone.parse.localtime(offset)' do
-      inspect_source(cop, "Time.zone.parse('12:00').localtime('+03:00')")
-      expect(cop.offenses).to be_empty
+      expect_no_offenses("Time.zone.parse('12:00').localtime('+03:00')")
     end
 
     it 'accepts Time.zone_default.now' do
-      inspect_source(cop, 'Time.zone_default.now')
-      expect(cop.offenses).to be_empty
+      expect_no_offenses('Time.zone_default.now')
     end
 
     it 'accepts Time.zone_default.today' do
-      inspect_source(cop, 'Time.zone_default.today')
-      expect(cop.offenses).to be_empty
+      expect_no_offenses('Time.zone_default.today')
     end
 
     it 'accepts Time.zone_default.local' do
-      inspect_source(cop, 'Time.zone_default.local(2012, 6, 10, 12, 00)')
-      expect(cop.offenses).to be_empty
+      expect_no_offenses('Time.zone_default.local(2012, 6, 10, 12, 00)')
     end
 
     it 'accepts Time.find_zone(time_zone).now' do
-      inspect_source(cop, "Time.find_zone('EST').now")
-      expect(cop.offenses).to be_empty
+      expect_no_offenses("Time.find_zone('EST').now")
     end
 
     it 'accepts Time.find_zone(time_zone).today' do
-      inspect_source(cop, "Time.find_zone('EST').today")
-      expect(cop.offenses).to be_empty
+      expect_no_offenses("Time.find_zone('EST').today")
     end
 
     it 'accepts Time.find_zone(time_zone).local' do
-      inspect_source(cop, "Time.find_zone('EST').local(2012, 6, 10, 12, 00)")
-      expect(cop.offenses).to be_empty
+      expect_no_offenses("Time.find_zone('EST').local(2012, 6, 10, 12, 00)")
     end
 
     it 'accepts Time.find_zone!(time_zone).now' do
-      inspect_source(cop, "Time.find_zone!('EST').now")
-      expect(cop.offenses).to be_empty
+      expect_no_offenses("Time.find_zone!('EST').now")
     end
 
     it 'accepts Time.find_zone!(time_zone).today' do
-      inspect_source(cop, "Time.find_zone!('EST').today")
-      expect(cop.offenses).to be_empty
+      expect_no_offenses("Time.find_zone!('EST').today")
     end
 
     it 'accepts Time.find_zone!(time_zone).local' do
-      inspect_source(cop, "Time.find_zone!('EST').local(2012, 6, 10, 12, 00)")
-      expect(cop.offenses).to be_empty
+      expect_no_offenses("Time.find_zone!('EST').local(2012, 6, 10, 12, 00)")
     end
 
     described_class::DANGEROUS_METHODS.each do |a_method|
@@ -281,21 +262,17 @@ describe RuboCop::Cop::Rails::TimeZone, :config do
     end
 
     it 'accepts Time.strftime.in_time_zone' do
-      inspect_source(
-        cop,
+      expect_no_offenses(
         'Time.strftime(time_string, "%Y-%m-%dT%H:%M:%S%z").in_time_zone'
       )
-      expect(cop.offenses).to be_empty
     end
 
     it 'accepts Time.parse.localtime(offset)' do
-      inspect_source(cop, "Time.parse('12:00').localtime('+03:00')")
-      expect(cop.offenses).to be_empty
+      expect_no_offenses("Time.parse('12:00').localtime('+03:00')")
     end
 
     it 'does not blow up in the presence of a single constant to inspect' do
-      inspect_source(cop, 'A')
-      expect(cop.offenses).to be_empty
+      expect_no_offenses('A')
     end
   end
 end

--- a/spec/rubocop/cop/rails/validation_spec.rb
+++ b/spec/rubocop/cop/rails/validation_spec.rb
@@ -29,8 +29,7 @@ describe RuboCop::Cop::Rails::Validation do
   end
 
   it 'accepts new style validations' do
-    inspect_source(cop, 'validates :name')
-    expect(cop.offenses).to be_empty
+    expect_no_offenses('validates :name')
   end
 
   it 'autocorrect validates_length_of' do

--- a/spec/rubocop/cop/style/accessor_method_name_spec.rb
+++ b/spec/rubocop/cop/style/accessor_method_name_spec.rb
@@ -24,21 +24,19 @@ describe RuboCop::Cop::Style::AccessorMethodName do
   end
 
   it 'accepts method get_something with args' do
-    inspect_source(cop, <<-END.strip_indent)
+    expect_no_offenses(<<-END.strip_indent)
       def get_something(arg)
         # ...
       end
     END
-    expect(cop.offenses).to be_empty
   end
 
   it 'accepts singleton method get_something with args' do
-    inspect_source(cop, <<-END.strip_indent)
+    expect_no_offenses(<<-END.strip_indent)
       def self.get_something(arg)
         # ...
       end
     END
-    expect(cop.offenses).to be_empty
   end
 
   it 'registers an offense for method set_something with one arg' do
@@ -62,38 +60,34 @@ describe RuboCop::Cop::Style::AccessorMethodName do
   end
 
   it 'accepts method set_something with no args' do
-    inspect_source(cop, <<-END.strip_indent)
+    expect_no_offenses(<<-END.strip_indent)
       def set_something
         # ...
       end
     END
-    expect(cop.offenses).to be_empty
   end
 
   it 'accepts singleton method set_something with no args' do
-    inspect_source(cop, <<-END.strip_indent)
+    expect_no_offenses(<<-END.strip_indent)
       def self.set_something
         # ...
       end
     END
-    expect(cop.offenses).to be_empty
   end
 
   it 'accepts method set_something with two args' do
-    inspect_source(cop, <<-END.strip_indent)
+    expect_no_offenses(<<-END.strip_indent)
       def set_something(arg1, arg2)
         # ...
       end
     END
-    expect(cop.offenses).to be_empty
   end
 
   it 'accepts singleton method set_something with two args' do
-    inspect_source(cop, <<-END.strip_indent)
+    expect_no_offenses(<<-END.strip_indent)
       def self.get_something(arg1, arg2)
         # ...
       end
     END
-    expect(cop.offenses).to be_empty
   end
 end

--- a/spec/rubocop/cop/style/alias_spec.rb
+++ b/spec/rubocop/cop/style/alias_spec.rb
@@ -39,7 +39,7 @@ describe RuboCop::Cop::Style::Alias, :config do
     end
 
     it 'does not register an offense for alias in an instance_eval block' do
-      inspect_source(cop, <<-END.strip_indent)
+      expect_no_offenses(<<-END.strip_indent)
         module M
           def foo
             instance_eval {
@@ -48,7 +48,6 @@ describe RuboCop::Cop::Style::Alias, :config do
           end
         end
       END
-      expect(cop.offenses).to be_empty
     end
   end
 
@@ -132,43 +131,39 @@ describe RuboCop::Cop::Style::Alias, :config do
     end
 
     it 'does not register an offense for alias_method with explicit receiver' do
-      inspect_source(cop, <<-END.strip_indent)
+      expect_no_offenses(<<-END.strip_indent)
         class C
           receiver.alias_method :ala, :bala
         end
       END
-      expect(cop.offenses).to be_empty
     end
 
     it 'does not register an offense for alias_method in a method def' do
-      inspect_source(cop, <<-END.strip_indent)
+      expect_no_offenses(<<-END.strip_indent)
         def method
           alias_method :ala, :bala
         end
       END
-      expect(cop.offenses).to be_empty
     end
 
     it 'does not register an offense for alias_method in self.method def' do
-      inspect_source(cop, <<-END.strip_indent)
+      expect_no_offenses(<<-END.strip_indent)
         def self.method
           alias_method :ala, :bala
         end
       END
-      expect(cop.offenses).to be_empty
     end
 
     it 'does not register an offense for alias_method in a block' do
-      inspect_source(cop, <<-END.strip_indent)
+      expect_no_offenses(<<-END.strip_indent)
         dsl_method do
           alias_method :ala, :bala
         end
       END
-      expect(cop.offenses).to be_empty
     end
 
     it 'does not register an offense for alias in an instance_eval block' do
-      inspect_source(cop, <<-END.strip_indent)
+      expect_no_offenses(<<-END.strip_indent)
         module M
           def foo
             instance_eval {
@@ -177,7 +172,6 @@ describe RuboCop::Cop::Style::Alias, :config do
           end
         end
       END
-      expect(cop.offenses).to be_empty
     end
   end
 end

--- a/spec/rubocop/cop/style/alias_spec.rb
+++ b/spec/rubocop/cop/style/alias_spec.rb
@@ -31,13 +31,11 @@ describe RuboCop::Cop::Style::Alias, :config do
     end
 
     it 'does not register an offense for alias_method' do
-      inspect_source(cop, 'alias_method :ala, :bala')
-      expect(cop.offenses).to be_empty
+      expect_no_offenses('alias_method :ala, :bala')
     end
 
     it 'does not register an offense for alias with gvars' do
-      inspect_source(cop, 'alias $ala $bala')
-      expect(cop.offenses).to be_empty
+      expect_no_offenses('alias $ala $bala')
     end
 
     it 'does not register an offense for alias in an instance_eval block' do
@@ -70,8 +68,7 @@ describe RuboCop::Cop::Style::Alias, :config do
     end
 
     it 'does not register an offense for alias with bareword args' do
-      inspect_source(cop, 'alias ala bala')
-      expect(cop.offenses).to be_empty
+      expect_no_offenses('alias ala bala')
     end
 
     it 'registers an offense for alias_method at the top level' do

--- a/spec/rubocop/cop/style/and_or_spec.rb
+++ b/spec/rubocop/cop/style/and_or_spec.rb
@@ -80,13 +80,11 @@ describe RuboCop::Cop::Style::AndOr, :config do
     end
 
     it 'accepts ||' do
-      inspect_source(cop, 'test if a || b')
-      expect(cop.offenses).to be_empty
+      expect_no_offenses('test if a || b')
     end
 
     it 'accepts &&' do
-      inspect_source(cop, 'test if a && b')
-      expect(cop.offenses).to be_empty
+      expect_no_offenses('test if a && b')
     end
 
     it 'auto-corrects "and" with &&' do

--- a/spec/rubocop/cop/style/array_join_spec.rb
+++ b/spec/rubocop/cop/style/array_join_spec.rb
@@ -31,9 +31,7 @@ describe RuboCop::Cop::Style::ArrayJoin do
   end
 
   it 'does not register an offense for numbers' do
-    inspect_source(cop,
-                   '%w(one two three) * 4')
-    expect(cop.offenses).to be_empty
+    expect_no_offenses('%w(one two three) * 4')
   end
 
   it 'does not register an offense for ambiguous cases' do

--- a/spec/rubocop/cop/style/ascii_comments_spec.rb
+++ b/spec/rubocop/cop/style/ascii_comments_spec.rb
@@ -26,7 +26,6 @@ describe RuboCop::Cop::Style::AsciiComments do
   end
 
   it 'accepts comments with only ascii chars' do
-    inspect_source(cop, '# AZaz1@$%~,;*_`|')
-    expect(cop.offenses).to be_empty
+    expect_no_offenses('# AZaz1@$%~,;*_`|')
   end
 end

--- a/spec/rubocop/cop/style/ascii_identifiers_spec.rb
+++ b/spec/rubocop/cop/style/ascii_identifiers_spec.rb
@@ -26,9 +26,7 @@ describe RuboCop::Cop::Style::AsciiIdentifiers do
   end
 
   it 'accepts identifiers with only ascii chars' do
-    inspect_source(cop,
-                   'x.empty?')
-    expect(cop.offenses).to be_empty
+    expect_no_offenses('x.empty?')
   end
 
   it 'does not get confused by a byte order mark' do
@@ -40,8 +38,6 @@ describe RuboCop::Cop::Style::AsciiIdentifiers do
   end
 
   it 'does not get confused by an empty file' do
-    inspect_source(cop,
-                   '')
-    expect(cop.offenses).to be_empty
+    expect_no_offenses('')
   end
 end

--- a/spec/rubocop/cop/style/attr_spec.rb
+++ b/spec/rubocop/cop/style/attr_spec.rb
@@ -13,13 +13,11 @@ describe RuboCop::Cop::Style::Attr do
   end
 
   it 'accepts attr when it does not take arguments' do
-    inspect_source(cop, 'func(attr)')
-    expect(cop.offenses).to be_empty
+    expect_no_offenses('func(attr)')
   end
 
   it 'accepts attr when it has a receiver' do
-    inspect_source(cop, 'x.attr arg')
-    expect(cop.offenses).to be_empty
+    expect_no_offenses('x.attr arg')
   end
 
   context 'auto-corrects' do

--- a/spec/rubocop/cop/style/auto_resource_cleanup_spec.rb
+++ b/spec/rubocop/cop/style/auto_resource_cleanup_spec.rb
@@ -10,14 +10,10 @@ describe RuboCop::Cop::Style::AutoResourceCleanup do
   end
 
   it 'does not register an offense for File.open with block' do
-    inspect_source(cop, 'File.open("file") { |f| something }')
-
-    expect(cop.offenses).to be_empty
+    expect_no_offenses('File.open("file") { |f| something }')
   end
 
   it 'does not register an offense for File.open with block-pass' do
-    inspect_source(cop, 'File.open("file", &:read)')
-
-    expect(cop.offenses).to be_empty
+    expect_no_offenses('File.open("file", &:read)')
   end
 end

--- a/spec/rubocop/cop/style/bare_percent_literals_spec.rb
+++ b/spec/rubocop/cop/style/bare_percent_literals_spec.rb
@@ -29,12 +29,11 @@ describe RuboCop::Cop::Style::BarePercentLiterals, :config do
     end
 
     it 'accepts heredoc' do
-      inspect_source(cop, <<-END.strip_indent)
+      expect_no_offenses(<<-END.strip_indent)
         func <<HEREDOC
         hi
         HEREDOC
       END
-      expect(cop.offenses).to be_empty
     end
   end
 

--- a/spec/rubocop/cop/style/bare_percent_literals_spec.rb
+++ b/spec/rubocop/cop/style/bare_percent_literals_spec.rb
@@ -5,33 +5,27 @@ describe RuboCop::Cop::Style::BarePercentLiterals, :config do
 
   shared_examples 'accepts other delimiters' do
     it 'accepts __FILE__' do
-      inspect_source(cop, '__FILE__')
-      expect(cop.offenses).to be_empty
+      expect_no_offenses('__FILE__')
     end
 
     it 'accepts regular expressions' do
-      inspect_source(cop, '/%Q?/')
-      expect(cop.offenses).to be_empty
+      expect_no_offenses('/%Q?/')
     end
 
     it 'accepts ""' do
-      inspect_source(cop, '""')
-      expect(cop.offenses).to be_empty
+      expect_no_offenses('""')
     end
 
     it 'accepts "" string with interpolation' do
-      inspect_source(cop, '"#{file}hi"')
-      expect(cop.offenses).to be_empty
+      expect_no_offenses('"#{file}hi"')
     end
 
     it "accepts ''" do
-      inspect_source(cop, "'hi'")
-      expect(cop.offenses).to be_empty
+      expect_no_offenses("'hi'")
     end
 
     it 'accepts %q' do
-      inspect_source(cop, '%q(hi)')
-      expect(cop.offenses).to be_empty
+      expect_no_offenses('%q(hi)')
     end
 
     it 'accepts heredoc' do
@@ -60,8 +54,7 @@ describe RuboCop::Cop::Style::BarePercentLiterals, :config do
       end
 
       it 'accepts %Q()' do
-        inspect_source(cop, '%Q(hi)')
-        expect(cop.offenses).to be_empty
+        expect_no_offenses('%Q(hi)')
       end
 
       include_examples 'accepts other delimiters'
@@ -79,8 +72,7 @@ describe RuboCop::Cop::Style::BarePercentLiterals, :config do
       end
 
       it 'accepts %Q()' do
-        inspect_source(cop, '%Q(#{x})')
-        expect(cop.offenses).to be_empty
+        expect_no_offenses('%Q(#{x})')
       end
 
       include_examples 'accepts other delimiters'
@@ -103,8 +95,7 @@ describe RuboCop::Cop::Style::BarePercentLiterals, :config do
       end
 
       it 'accepts %()' do
-        inspect_source(cop, '%(hi)')
-        expect(cop.offenses).to be_empty
+        expect_no_offenses('%(hi)')
       end
 
       include_examples 'accepts other delimiters'
@@ -122,8 +113,7 @@ describe RuboCop::Cop::Style::BarePercentLiterals, :config do
       end
 
       it 'accepts %()' do
-        inspect_source(cop, '%(#{x})')
-        expect(cop.offenses).to be_empty
+        expect_no_offenses('%(#{x})')
       end
 
       include_examples 'accepts other delimiters'

--- a/spec/rubocop/cop/style/block_comments_spec.rb
+++ b/spec/rubocop/cop/style/block_comments_spec.rb
@@ -13,9 +13,7 @@ describe RuboCop::Cop::Style::BlockComments do
   end
 
   it 'accepts regular comments' do
-    inspect_source(cop,
-                   '# comment')
-    expect(cop.offenses).to be_empty
+    expect_no_offenses('# comment')
   end
 
   it 'auto-corrects a block comment into a regular comment' do

--- a/spec/rubocop/cop/style/block_delimiters_spec.rb
+++ b/spec/rubocop/cop/style/block_delimiters_spec.rb
@@ -11,8 +11,7 @@ describe RuboCop::Cop::Style::BlockDelimiters, :config do
     end
 
     it 'accepts a single line block with braces' do
-      inspect_source(cop, 'each { |x| }')
-      expect(cop.offenses).to be_empty
+      expect_no_offenses('each { |x| }')
     end
 
     it 'accepts a multi-line block with do-end' do

--- a/spec/rubocop/cop/style/block_delimiters_spec.rb
+++ b/spec/rubocop/cop/style/block_delimiters_spec.rb
@@ -15,11 +15,10 @@ describe RuboCop::Cop::Style::BlockDelimiters, :config do
     end
 
     it 'accepts a multi-line block with do-end' do
-      inspect_source(cop, <<-END.strip_indent)
+      expect_no_offenses(<<-END.strip_indent)
         each do |x|
         end
       END
-      expect(cop.offenses).to be_empty
     end
 
     it 'accepts a multi-line block that needs braces to be valid ruby' do
@@ -65,21 +64,19 @@ describe RuboCop::Cop::Style::BlockDelimiters, :config do
     end
 
     it 'accepts a multi-line block with braces when passed to a method' do
-      inspect_source(cop, <<-END.strip_indent)
+      expect_no_offenses(<<-END.strip_indent)
         puts map { |x|
           x
         }
       END
-      expect(cop.offenses).to be_empty
     end
 
     it 'accepts a multi-line block with braces when chained' do
-      inspect_source(cop, <<-END.strip_indent)
+      expect_no_offenses(<<-END.strip_indent)
         map { |x|
           x
         }.inspect
       END
-      expect(cop.offenses).to be_empty
     end
 
     it 'accepts a multi-line block with braces when passed to a known ' \
@@ -510,11 +507,10 @@ describe RuboCop::Cop::Style::BlockDelimiters, :config do
       end
 
       it 'allows when the block is being chained' do
-        inspect_source(cop, <<-END.strip_indent)
+        expect_no_offenses(<<-END.strip_indent)
           each { |x|
           }.map(&:to_sym)
         END
-        expect(cop.offenses).to be_empty
       end
     end
   end

--- a/spec/rubocop/cop/style/braces_around_hash_parameters_spec.rb
+++ b/spec/rubocop/cop/style/braces_around_hash_parameters_spec.rb
@@ -214,8 +214,7 @@ describe RuboCop::Cop::Style::BracesAroundHashParameters, :config do
       include_examples 'no_braces and context_dependent non-offenses'
 
       it 'accepts two hash parameters with braces' do
-        inspect_source(cop, 'where({ x: 1 }, { y: 2 })')
-        expect(cop.offenses).to be_empty
+        expect_no_offenses('where({ x: 1 }, { y: 2 })')
       end
     end
 

--- a/spec/rubocop/cop/style/character_literal_spec.rb
+++ b/spec/rubocop/cop/style/character_literal_spec.rb
@@ -14,13 +14,11 @@ describe RuboCop::Cop::Style::CharacterLiteral do
   end
 
   it 'accepts literals like ?\C-\M-d' do
-    inspect_source(cop, 'x = ?\C-\M-d')
-    expect(cop.offenses).to be_empty
+    expect_no_offenses('x = ?\C-\M-d')
   end
 
   it 'accepts ? in a %w literal' do
-    inspect_source(cop, '%w{? A}')
-    expect(cop.offenses).to be_empty
+    expect_no_offenses('%w{? A}')
   end
 
   it "auto-corrects ?x to 'x'" do

--- a/spec/rubocop/cop/style/class_and_module_camel_case_spec.rb
+++ b/spec/rubocop/cop/style/class_and_module_camel_case_spec.rb
@@ -26,13 +26,12 @@ describe RuboCop::Cop::Style::ClassAndModuleCamelCase do
   end
 
   it 'accepts CamelCase names' do
-    inspect_source(cop, <<-END.strip_indent)
+    expect_no_offenses(<<-END.strip_indent)
       class MyClass
       end
 
       module Mine
       end
     END
-    expect(cop.offenses).to be_empty
   end
 end

--- a/spec/rubocop/cop/style/class_and_module_children_spec.rb
+++ b/spec/rubocop/cop/style/class_and_module_children_spec.rb
@@ -46,7 +46,7 @@ describe RuboCop::Cop::Style::ClassAndModuleChildren, :config do
     end
 
     it 'accepts nested children' do
-      inspect_source(cop, <<-END.strip_indent)
+      expect_no_offenses(<<-END.strip_indent)
         class FooClass
           class BarClass
           end
@@ -57,11 +57,10 @@ describe RuboCop::Cop::Style::ClassAndModuleChildren, :config do
           end
         end
       END
-      expect(cop.offenses).to be_empty
     end
 
     it 'accepts :: in parent class on inheritance' do
-      inspect_source(cop, <<-END.strip_indent)
+      expect_no_offenses(<<-END.strip_indent)
         class FooClass
           class BarClass
           end
@@ -70,7 +69,6 @@ describe RuboCop::Cop::Style::ClassAndModuleChildren, :config do
         class BazClass < FooClass::BarClass
         end
       END
-      expect(cop.offenses).to be_empty
     end
   end
 
@@ -106,18 +104,17 @@ describe RuboCop::Cop::Style::ClassAndModuleChildren, :config do
     end
 
     it 'accepts compact style for classes/modules' do
-      inspect_source(cop, <<-END.strip_indent)
+      expect_no_offenses(<<-END.strip_indent)
         class FooClass::BarClass
         end
 
         module FooClass::BarModule
         end
       END
-      expect(cop.offenses).to be_empty
     end
 
     it 'accepts nesting for classes/modules with more than one child' do
-      inspect_source(cop, <<-END.strip_indent)
+      expect_no_offenses(<<-END.strip_indent)
         class FooClass
           class BarClass
           end
@@ -132,27 +129,24 @@ describe RuboCop::Cop::Style::ClassAndModuleChildren, :config do
           end
         end
       END
-      expect(cop.offenses).to be_empty
     end
 
     it 'accepts class/module with single method' do
-      inspect_source(cop, <<-END.strip_indent)
+      expect_no_offenses(<<-END.strip_indent)
         class FooClass
           def bar_method
           end
         end
       END
-      expect(cop.offenses).to be_empty
     end
 
     it 'accepts nesting for classes with an explicit superclass' do
-      inspect_source(cop, <<-END.strip_indent)
+      expect_no_offenses(<<-END.strip_indent)
         class FooClass < Super
           class BarClass
           end
         end
       END
-      expect(cop.offenses).to be_empty
     end
   end
 end

--- a/spec/rubocop/cop/style/class_methods_spec.rb
+++ b/spec/rubocop/cop/style/class_methods_spec.rb
@@ -32,18 +32,17 @@ describe RuboCop::Cop::Style::ClassMethods do
   end
 
   it 'does not register an offense for methods using self' do
-    inspect_source(cop, <<-END.strip_indent)
+    expect_no_offenses(<<-END.strip_indent)
       module Test
         def self.some_method
           do_something
         end
       end
     END
-    expect(cop.offenses).to be_empty
   end
 
   it 'does not register an offense for other top-level singleton methods' do
-    inspect_source(cop, <<-END.strip_indent)
+    expect_no_offenses(<<-END.strip_indent)
       class Test
         X = Something.new
 
@@ -52,16 +51,14 @@ describe RuboCop::Cop::Style::ClassMethods do
         end
       end
     END
-    expect(cop.offenses).to be_empty
   end
 
   it 'does not register an offense outside class/module bodies' do
-    inspect_source(cop, <<-END.strip_indent)
+    expect_no_offenses(<<-END.strip_indent)
       def Test.some_method
         do_something
       end
     END
-    expect(cop.offenses).to be_empty
   end
 
   it 'autocorrects class name to self' do

--- a/spec/rubocop/cop/style/class_vars_spec.rb
+++ b/spec/rubocop/cop/style/class_vars_spec.rb
@@ -11,7 +11,6 @@ describe RuboCop::Cop::Style::ClassVars do
   end
 
   it 'does not register an offense for class variable usage' do
-    inspect_source(cop, '@@test.test(20)')
-    expect(cop.offenses).to be_empty
+    expect_no_offenses('@@test.test(20)')
   end
 end

--- a/spec/rubocop/cop/style/colon_method_call_spec.rb
+++ b/spec/rubocop/cop/style/colon_method_call_spec.rb
@@ -24,28 +24,23 @@ describe RuboCop::Cop::Style::ColonMethodCall do
   end
 
   it 'does not register an offense for constant access' do
-    inspect_source(cop, 'Tip::Top::SOME_CONST')
-    expect(cop.offenses).to be_empty
+    expect_no_offenses('Tip::Top::SOME_CONST')
   end
 
   it 'does not register an offense for nested class' do
-    inspect_source(cop, 'Tip::Top.some_method')
-    expect(cop.offenses).to be_empty
+    expect_no_offenses('Tip::Top.some_method')
   end
 
   it 'does not register an offense for op methods' do
-    inspect_source(cop, 'Tip::Top.some_method[3]')
-    expect(cop.offenses).to be_empty
+    expect_no_offenses('Tip::Top.some_method[3]')
   end
 
   it 'does not register an offense when for constructor methods' do
-    inspect_source(cop, 'Tip::Top(some_arg)')
-    expect(cop.offenses).to be_empty
+    expect_no_offenses('Tip::Top(some_arg)')
   end
 
   it 'does not register an offense for Java static types' do
-    inspect_source(cop, 'Java::int')
-    expect(cop.offenses).to be_empty
+    expect_no_offenses('Java::int')
   end
 
   it 'auto-corrects "::" with "."' do

--- a/spec/rubocop/cop/style/comment_annotation_spec.rb
+++ b/spec/rubocop/cop/style/comment_annotation_spec.rb
@@ -101,11 +101,10 @@ describe RuboCop::Cop::Style::CommentAnnotation, :config do
   end
 
   it 'accepts a keyword that is just the beginning of a sentence' do
-    inspect_source(cop, <<-END.strip_indent)
+    expect_no_offenses(<<-END.strip_indent)
       # Optimize if you want. I wouldn't recommend it.
       # Hack is a fun game.
     END
-    expect(cop.offenses).to be_empty
   end
 
   it 'accepts a keyword that is somewhere in a sentence' do

--- a/spec/rubocop/cop/style/comment_annotation_spec.rb
+++ b/spec/rubocop/cop/style/comment_annotation_spec.rb
@@ -89,18 +89,15 @@ describe RuboCop::Cop::Style::CommentAnnotation, :config do
   end
 
   it 'accepts upper case keyword with colon, space and note' do
-    inspect_source(cop, '# REVIEW: not sure about this')
-    expect(cop.offenses).to be_empty
+    expect_no_offenses('# REVIEW: not sure about this')
   end
 
   it 'accepts upper case keyword alone' do
-    inspect_source(cop, '# OPTIMIZE')
-    expect(cop.offenses).to be_empty
+    expect_no_offenses('# OPTIMIZE')
   end
 
   it 'accepts a comment that is obviously a code example' do
-    inspect_source(cop, '# Todo.destroy(1)')
-    expect(cop.offenses).to be_empty
+    expect_no_offenses('# Todo.destroy(1)')
   end
 
   it 'accepts a keyword that is just the beginning of a sentence' do
@@ -127,8 +124,7 @@ describe RuboCop::Cop::Style::CommentAnnotation, :config do
     end
 
     it 'accepts the word without colon' do
-      inspect_source(cop, '# TODO make better')
-      expect(cop.offenses).to be_empty
+      expect_no_offenses('# TODO make better')
     end
   end
 end

--- a/spec/rubocop/cop/style/conditional_assignment_assign_in_condition_spec.rb
+++ b/spec/rubocop/cop/style/conditional_assignment_assign_in_condition_spec.rb
@@ -721,9 +721,7 @@ describe RuboCop::Cop::Style::ConditionalAssignment do
     it_behaves_like('multiline all assignment types', '<<', [])
 
     it 'allows a method call in the subject of a ternary operator' do
-      inspect_source(cop, 'bar << foo? ? 1 : 2')
-
-      expect(cop.offenses).to be_empty
+      expect_no_offenses('bar << foo? ? 1 : 2')
     end
 
     it 'registers an offense for assignment using a method that ends with ' \
@@ -1151,9 +1149,7 @@ describe RuboCop::Cop::Style::ConditionalAssignment do
     end
 
     it 'allows assigning any variable type to ternary' do
-      inspect_source(cop, 'bar = foo? ? 1 : 2')
-
-      expect(cop.offenses).to be_empty
+      expect_no_offenses('bar = foo? ? 1 : 2')
     end
   end
 end

--- a/spec/rubocop/cop/style/conditional_assignment_assign_to_condition_spec.rb
+++ b/spec/rubocop/cop/style/conditional_assignment_assign_to_condition_spec.rb
@@ -78,9 +78,7 @@ describe RuboCop::Cop::Style::ConditionalAssignment do
   end
 
   it 'allows modifier if' do
-    inspect_source(cop, 'return if a == 1')
-
-    expect(cop.offenses).to be_empty
+    expect_no_offenses('return if a == 1')
   end
 
   it 'allows modifier if inside of if else' do

--- a/spec/rubocop/cop/style/conditional_assignment_assign_to_condition_spec.rb
+++ b/spec/rubocop/cop/style/conditional_assignment_assign_to_condition_spec.rb
@@ -1718,14 +1718,13 @@ describe RuboCop::Cop::Style::ConditionalAssignment do
 
       context 'with different indices' do
         it "doesn't register an offense" do
-          inspect_source(cop, <<-END.strip_indent)
+          expect_no_offenses(<<-END.strip_indent)
             if something
               array[1, 2] = 1
             else
               array[1, 3] = 2
             end
           END
-          expect(cop.offenses).to be_empty
         end
       end
     end
@@ -1750,32 +1749,30 @@ describe RuboCop::Cop::Style::ConditionalAssignment do
 
       context 'with different receivers' do
         it "doesn't register an offense" do
-          inspect_source(cop, <<-END.strip_indent)
+          expect_no_offenses(<<-END.strip_indent)
             if something
               obj1.attribute = 1
             else
               obj2.attribute = 2
             end
           END
-          expect(cop.offenses).to be_empty
         end
       end
     end
 
     context 'multiple assignment' do
       it 'does not register an offense in if else' do
-        inspect_source(cop, <<-END.strip_indent)
+        expect_no_offenses(<<-END.strip_indent)
           if something
             a, b = 1, 2
           else
             a, b = 2, 1
           end
         END
-        expect(cop.offenses).to be_empty
       end
 
       it 'does not register an offense in case when' do
-        inspect_source(cop, <<-END.strip_indent)
+        expect_no_offenses(<<-END.strip_indent)
           case foo
           when bar
             a, b = 1, 2
@@ -1783,7 +1780,6 @@ describe RuboCop::Cop::Style::ConditionalAssignment do
             a, b = 2, 1
           end
         END
-        expect(cop.offenses).to be_empty
       end
     end
   end

--- a/spec/rubocop/cop/style/constant_name_spec.rb
+++ b/spec/rubocop/cop/style/constant_name_spec.rb
@@ -34,12 +34,11 @@ describe RuboCop::Cop::Style::ConstantName do
   end
 
   it 'does not check names if rhs is a method call with block' do
-    inspect_source(cop, <<-END.strip_indent)
+    expect_no_offenses(<<-END.strip_indent)
       AnythingGoes = test do
         do_something
       end
     END
-    expect(cop.offenses).to be_empty
   end
 
   it 'does not check if rhs is another constant' do

--- a/spec/rubocop/cop/style/constant_name_spec.rb
+++ b/spec/rubocop/cop/style/constant_name_spec.rb
@@ -22,21 +22,15 @@ describe RuboCop::Cop::Style::ConstantName do
   end
 
   it 'allows screaming snake case in const name' do
-    inspect_source(cop,
-                   'TOP_TEST = 5')
-    expect(cop.offenses).to be_empty
+    expect_no_offenses('TOP_TEST = 5')
   end
 
   it 'allows screaming snake case in multiple const assignment' do
-    inspect_source(cop,
-                   'TOP_TEST, TEST_2 = 5, 6')
-    expect(cop.offenses).to be_empty
+    expect_no_offenses('TOP_TEST, TEST_2 = 5, 6')
   end
 
   it 'does not check names if rhs is a method call' do
-    inspect_source(cop,
-                   'AnythingGoes = test')
-    expect(cop.offenses).to be_empty
+    expect_no_offenses('AnythingGoes = test')
   end
 
   it 'does not check names if rhs is a method call with block' do
@@ -49,9 +43,7 @@ describe RuboCop::Cop::Style::ConstantName do
   end
 
   it 'does not check if rhs is another constant' do
-    inspect_source(cop,
-                   'Parser::CurrentRuby = Parser::Ruby20')
-    expect(cop.offenses).to be_empty
+    expect_no_offenses('Parser::CurrentRuby = Parser::Ruby20')
   end
 
   it 'checks qualified const names' do

--- a/spec/rubocop/cop/style/documentation_spec.rb
+++ b/spec/rubocop/cop/style/documentation_spec.rb
@@ -53,14 +53,13 @@ describe RuboCop::Cop::Style::Documentation do
   end
 
   it 'accepts non-empty class with documentation' do
-    inspect_source(cop, <<-END.strip_indent)
+    expect_no_offenses(<<-END.strip_indent)
       # class comment
       class My_Class
         def method
         end
       end
     END
-    expect(cop.offenses).to be_empty
   end
 
   it 'registers an offense for non-empty class with annotation comment' do
@@ -121,7 +120,7 @@ describe RuboCop::Cop::Style::Documentation do
   end
 
   it 'accepts non-empty class with comment that ends with an annotation' do
-    inspect_source(cop, <<-END.strip_indent)
+    expect_no_offenses(<<-END.strip_indent)
       # Does fooing.
       # FIXME: Not yet implemented.
       class Foo
@@ -129,50 +128,45 @@ describe RuboCop::Cop::Style::Documentation do
         end
       end
     END
-    expect(cop.offenses).to be_empty
   end
 
   it 'accepts non-empty module with documentation' do
-    inspect_source(cop, <<-END.strip_indent)
+    expect_no_offenses(<<-END.strip_indent)
       # class comment
       module My_Class
         def method
         end
       end
     END
-    expect(cop.offenses).to be_empty
   end
 
   it 'accepts empty class without documentation' do
-    inspect_source(cop, <<-END.strip_indent)
+    expect_no_offenses(<<-END.strip_indent)
       class My_Class
       end
     END
-    expect(cop.offenses).to be_empty
   end
 
   it 'accepts namespace module without documentation' do
-    inspect_source(cop, <<-END.strip_indent)
+    expect_no_offenses(<<-END.strip_indent)
       module Test
         class A; end
         class B; end
       end
     END
-    expect(cop.offenses).to be_empty
   end
 
   it 'accepts namespace class without documentation' do
-    inspect_source(cop, <<-END.strip_indent)
+    expect_no_offenses(<<-END.strip_indent)
       class Test
         class A; end
         class B; end
       end
     END
-    expect(cop.offenses).to be_empty
   end
 
   it 'accepts namespace class which defines constants' do
-    inspect_source(cop, <<-END.strip_indent)
+    expect_no_offenses(<<-END.strip_indent)
       class Test
         A = Class.new
         B = Class.new(A)
@@ -180,11 +174,10 @@ describe RuboCop::Cop::Style::Documentation do
         D = 1
       end
     END
-    expect(cop.offenses).to be_empty
   end
 
   it 'accepts namespace module which defines constants' do
-    inspect_source(cop, <<-END.strip_indent)
+    expect_no_offenses(<<-END.strip_indent)
       module Test
         A = Class.new
         B = Class.new(A)
@@ -192,7 +185,6 @@ describe RuboCop::Cop::Style::Documentation do
         D = 1
       end
     END
-    expect(cop.offenses).to be_empty
   end
 
   it 'does not raise an error for an implicit match conditional' do
@@ -293,13 +285,12 @@ describe RuboCop::Cop::Style::Documentation do
 
     context 'on a subclass' do
       it 'accepts non-namespace subclass without documentation' do
-        inspect_source(cop, <<-END.strip_indent)
+        expect_no_offenses(<<-END.strip_indent)
           class Test < Parent #:nodoc:
             def method
             end
           end
         END
-        expect(cop.offenses).to be_empty
       end
 
       it 'registers an offense for nested subclass without documentation' do
@@ -317,7 +308,7 @@ describe RuboCop::Cop::Style::Documentation do
 
       context 'with `all` modifier' do
         it 'accepts nested subclass without documentation' do
-          inspect_source(cop, <<-END.strip_indent)
+          expect_no_offenses(<<-END.strip_indent)
             module A #:nodoc: all
               module B
                 TEST = 20
@@ -327,7 +318,6 @@ describe RuboCop::Cop::Style::Documentation do
               end
             end
           END
-          expect(cop.offenses).to be_empty
         end
       end
     end

--- a/spec/rubocop/cop/style/double_negation_spec.rb
+++ b/spec/rubocop/cop/style/double_negation_spec.rb
@@ -9,12 +9,10 @@ describe RuboCop::Cop::Style::DoubleNegation do
   end
 
   it 'does not register an offense for !' do
-    inspect_source(cop, '!test.something')
-    expect(cop.offenses).to be_empty
+    expect_no_offenses('!test.something')
   end
 
   it 'does not register an offense for not not' do
-    inspect_source(cop, 'not not test.something')
-    expect(cop.offenses).to be_empty
+    expect_no_offenses('not not test.something')
   end
 end

--- a/spec/rubocop/cop/style/each_for_simple_loop_spec.rb
+++ b/spec/rubocop/cop/style/each_for_simple_loop_spec.rb
@@ -53,11 +53,10 @@ describe RuboCop::Cop::Style::EachForSimpleLoop do
   end
 
   it 'does not register offense for multiline block with parameters' do
-    inspect_source(cop, <<-END.strip_indent)
+    expect_no_offenses(<<-END.strip_indent)
       (0..10).each do |n|
       end
     END
-    expect(cop.offenses).to be_empty
   end
 
   it 'does not register offense for character range' do

--- a/spec/rubocop/cop/style/each_for_simple_loop_spec.rb
+++ b/spec/rubocop/cop/style/each_for_simple_loop_spec.rb
@@ -41,18 +41,15 @@ describe RuboCop::Cop::Style::EachForSimpleLoop do
   end
 
   it 'does not register offense if range startpoint is not constant' do
-    inspect_source(cop, '(a..10).each {}')
-    expect(cop.offenses).to be_empty
+    expect_no_offenses('(a..10).each {}')
   end
 
   it 'does not register offense if range endpoint is not constant' do
-    inspect_source(cop, '(0..b).each {}')
-    expect(cop.offenses).to be_empty
+    expect_no_offenses('(0..b).each {}')
   end
 
   it 'does not register offense for inline block with parameters' do
-    inspect_source(cop, '(0..10).each { |n| puts n }')
-    expect(cop.offenses).to be_empty
+    expect_no_offenses('(0..10).each { |n| puts n }')
   end
 
   it 'does not register offense for multiline block with parameters' do
@@ -64,8 +61,7 @@ describe RuboCop::Cop::Style::EachForSimpleLoop do
   end
 
   it 'does not register offense for character range' do
-    inspect_source(cop, "('a'..'b').each {}")
-    expect(cop.offenses).to be_empty
+    expect_no_offenses("('a'..'b').each {}")
   end
 
   context 'when using an inclusive range' do

--- a/spec/rubocop/cop/style/each_with_object_spec.rb
+++ b/spec/rubocop/cop/style/each_with_object_spec.rb
@@ -50,7 +50,7 @@ describe RuboCop::Cop::Style::EachWithObject do
   end
 
   it 'ignores inject and reduce with passed in, but not returned hash' do
-    inspect_source(cop, <<-END.strip_indent)
+    expect_no_offenses(<<-END.strip_indent)
       [].inject({}) do |a, e|
         a + e
       end
@@ -59,21 +59,19 @@ describe RuboCop::Cop::Style::EachWithObject do
         my_method e, a
       end
     END
-    expect(cop.offenses).to be_empty
   end
 
   it 'ignores inject and reduce with empty body' do
-    inspect_source(cop, <<-END.strip_indent)
+    expect_no_offenses(<<-END.strip_indent)
       [].inject({}) do |a, e|
       end
 
       [].reduce({}) { |a, e| }
     END
-    expect(cop.offenses).to be_empty
   end
 
   it 'ignores inject and reduce with condition as body' do
-    inspect_source(cop, <<-END.strip_indent)
+    expect_no_offenses(<<-END.strip_indent)
       [].inject({}) do |a, e|
         a = e if e
       end
@@ -88,7 +86,6 @@ describe RuboCop::Cop::Style::EachWithObject do
         a = e ? e : 2
       end
     END
-    expect(cop.offenses).to be_empty
   end
 
   it 'ignores inject and reduce passed in symbol' do
@@ -101,13 +98,12 @@ describe RuboCop::Cop::Style::EachWithObject do
   end
 
   it 'ignores inject/reduce with assignment to accumulator param in block' do
-    inspect_source(cop, <<-END.strip_indent)
+    expect_no_offenses(<<-END.strip_indent)
       r = [1, 2, 3].reduce({}) do |memo, item|
         memo += item > 2 ? item : 0
         memo
       end
     END
-    expect(cop.offenses).to be_empty
   end
 
   context 'when a simple literal is passed as initial value' do

--- a/spec/rubocop/cop/style/each_with_object_spec.rb
+++ b/spec/rubocop/cop/style/each_with_object_spec.rb
@@ -97,8 +97,7 @@ describe RuboCop::Cop::Style::EachWithObject do
   end
 
   it 'does not blow up for reduce with no arguments' do
-    inspect_source(cop, '[1, 2, 3].inject { |a, e| a + e }')
-    expect(cop.offenses).to be_empty
+    expect_no_offenses('[1, 2, 3].inject { |a, e| a + e }')
   end
 
   it 'ignores inject/reduce with assignment to accumulator param in block' do
@@ -113,8 +112,7 @@ describe RuboCop::Cop::Style::EachWithObject do
 
   context 'when a simple literal is passed as initial value' do
     it 'ignores inject/reduce' do
-      inspect_source(cop, 'array.reduce(0) { |a, e| a }')
-      expect(cop.offenses).to be_empty
+      expect_no_offenses('array.reduce(0) { |a, e| a }')
     end
   end
 end

--- a/spec/rubocop/cop/style/empty_literal_spec.rb
+++ b/spec/rubocop/cop/style/empty_literal_spec.rb
@@ -163,13 +163,11 @@ describe RuboCop::Cop::Style::EmptyLiteral do
       let(:ruby_version) { 2.3 }
 
       it 'does not register an offense for String.new' do
-        inspect_source(cop, <<-END.strip_indent)
+        expect_no_offenses(<<-END.strip_indent)
           # encoding: utf-8
           # frozen_string_literal: true
           test = String.new
         END
-
-        expect(cop.offenses).to be_empty
       end
     end
   end

--- a/spec/rubocop/cop/style/empty_literal_spec.rb
+++ b/spec/rubocop/cop/style/empty_literal_spec.rb
@@ -19,8 +19,7 @@ describe RuboCop::Cop::Style::EmptyLiteral do
     end
 
     it 'does not register an offense for Array.new(3)' do
-      inspect_source(cop, 'test = Array.new(3)')
-      expect(cop.offenses).to be_empty
+      expect_no_offenses('test = Array.new(3)')
     end
 
     it 'auto-corrects Array.new to []' do
@@ -63,13 +62,11 @@ describe RuboCop::Cop::Style::EmptyLiteral do
     end
 
     it 'does not register an offense for Hash.new(3)' do
-      inspect_source(cop, 'test = Hash.new(3)')
-      expect(cop.offenses).to be_empty
+      expect_no_offenses('test = Hash.new(3)')
     end
 
     it 'does not register an offense for Hash.new { block }' do
-      inspect_source(cop, 'test = Hash.new { block }')
-      expect(cop.offenses).to be_empty
+      expect_no_offenses('test = Hash.new { block }')
     end
 
     it 'auto-corrects Hash.new to {}' do
@@ -129,9 +126,7 @@ describe RuboCop::Cop::Style::EmptyLiteral do
     end
 
     it 'does not register an offense for String.new("top")' do
-      inspect_source(cop, 'test = String.new("top")')
-
-      expect(cop.offenses).to be_empty
+      expect_no_offenses('test = String.new("top")')
     end
 
     it 'auto-corrects String.new to empty string literal' do

--- a/spec/rubocop/cop/style/encoding_spec.rb
+++ b/spec/rubocop/cop/style/encoding_spec.rb
@@ -43,12 +43,10 @@ describe RuboCop::Cop::Style::Encoding, :config do
     end
 
     it 'accepts encoding on first line' do
-      inspect_source(cop, <<-END.strip_indent)
+      expect_no_offenses(<<-END.strip_indent)
         # encoding: utf-8
         def foo() \'ä\' end
       END
-
-      expect(cop.offenses).to be_empty
     end
 
     it 'accepts encoding on second line when shebang present' do
@@ -135,12 +133,10 @@ describe RuboCop::Cop::Style::Encoding, :config do
     end
 
     it 'accepts encoding on first line' do
-      inspect_source(cop, <<-END.strip_indent)
+      expect_no_offenses(<<-END.strip_indent)
         # encoding: utf-8
         def foo() end
       END
-
-      expect(cop.offenses).to be_empty
     end
 
     it 'accepts encoding on second line when shebang present' do

--- a/spec/rubocop/cop/style/encoding_spec.rb
+++ b/spec/rubocop/cop/style/encoding_spec.rb
@@ -39,9 +39,7 @@ describe RuboCop::Cop::Style::Encoding, :config do
     end
 
     it 'accepts an empty file' do
-      inspect_source(cop, '')
-
-      expect(cop.offenses).to be_empty
+      expect_no_offenses('')
     end
 
     it 'accepts encoding on first line' do
@@ -133,9 +131,7 @@ describe RuboCop::Cop::Style::Encoding, :config do
     end
 
     it 'accepts an empty file' do
-      inspect_source(cop, '')
-
-      expect(cop.offenses).to be_empty
+      expect_no_offenses('')
     end
 
     it 'accepts encoding on first line' do

--- a/spec/rubocop/cop/style/even_odd_spec.rb
+++ b/spec/rubocop/cop/style/even_odd_spec.rb
@@ -64,13 +64,11 @@ describe RuboCop::Cop::Style::EvenOdd do
   end
 
   it 'accepts x % 3 == 0' do
-    inspect_source(cop, 'x % 3 == 0')
-    expect(cop.offenses).to be_empty
+    expect_no_offenses('x % 3 == 0')
   end
 
   it 'accepts x % 3 != 0' do
-    inspect_source(cop, 'x % 3 != 0')
-    expect(cop.offenses).to be_empty
+    expect_no_offenses('x % 3 != 0')
   end
 
   it 'converts x % 2 == 0 to #even?' do

--- a/spec/rubocop/cop/style/for_spec.rb
+++ b/spec/rubocop/cop/style/for_spec.rb
@@ -46,13 +46,11 @@ describe RuboCop::Cop::Style::For, :config do
     end
 
     it 'accepts :for' do
-      inspect_source(cop, '[:for, :ala, :bala]')
-      expect(cop.offenses).to be_empty
+      expect_no_offenses('[:for, :ala, :bala]')
     end
 
     it 'accepts def for' do
-      inspect_source(cop, 'def for; end')
-      expect(cop.offenses).to be_empty
+      expect_no_offenses('def for; end')
     end
   end
 

--- a/spec/rubocop/cop/style/for_spec.rb
+++ b/spec/rubocop/cop/style/for_spec.rb
@@ -35,14 +35,13 @@ describe RuboCop::Cop::Style::For, :config do
     end
 
     it 'accepts multiline each' do
-      inspect_source(cop, <<-END.strip_indent)
+      expect_no_offenses(<<-END.strip_indent)
         def func
           [1, 2, 3].each do |n|
             puts n
           end
         end
       END
-      expect(cop.offenses).to be_empty
     end
 
     it 'accepts :for' do
@@ -58,14 +57,13 @@ describe RuboCop::Cop::Style::For, :config do
     let(:cop_config) { { 'EnforcedStyle' => 'for' } }
 
     it 'accepts for' do
-      inspect_source(cop, <<-END.strip_indent)
+      expect_no_offenses(<<-END.strip_indent)
         def func
           for n in [1, 2, 3] do
             puts n
           end
         end
       END
-      expect(cop.offenses).to be_empty
     end
 
     it 'registers an offense for multiline each' do
@@ -97,12 +95,11 @@ describe RuboCop::Cop::Style::For, :config do
     end
 
     it 'accepts single line each' do
-      inspect_source(cop, <<-END.strip_indent)
+      expect_no_offenses(<<-END.strip_indent)
         def func
           [1, 2, 3].each { |n| puts n }
         end
       END
-      expect(cop.offenses).to be_empty
     end
   end
 end

--- a/spec/rubocop/cop/style/format_string_spec.rb
+++ b/spec/rubocop/cop/style/format_string_spec.rb
@@ -22,9 +22,7 @@ describe RuboCop::Cop::Style::FormatString, :config do
     end
 
     it 'does not register an offense for numbers' do
-      inspect_source(cop,
-                     'puts 10 % 4')
-      expect(cop.offenses).to be_empty
+      expect_no_offenses('puts 10 % 4')
     end
 
     it 'does not register an offense for ambiguous cases' do
@@ -90,9 +88,7 @@ describe RuboCop::Cop::Style::FormatString, :config do
     end
 
     it 'does not register an offense for numbers' do
-      inspect_source(cop,
-                     'puts 10 % 4')
-      expect(cop.offenses).to be_empty
+      expect_no_offenses('puts 10 % 4')
     end
 
     it 'does not register an offense for ambiguous cases' do
@@ -158,33 +154,23 @@ describe RuboCop::Cop::Style::FormatString, :config do
     end
 
     it 'accepts format with 1 argument' do
-      inspect_source(cop,
-                     'format :xml')
-      expect(cop.offenses).to be_empty
+      expect_no_offenses('format :xml')
     end
 
     it 'accepts sprintf with 1 argument' do
-      inspect_source(cop,
-                     'sprintf :xml')
-      expect(cop.offenses).to be_empty
+      expect_no_offenses('sprintf :xml')
     end
 
     it 'accepts format without arguments' do
-      inspect_source(cop,
-                     'format')
-      expect(cop.offenses).to be_empty
+      expect_no_offenses('format')
     end
 
     it 'accepts sprintf without arguments' do
-      inspect_source(cop,
-                     'sprintf')
-      expect(cop.offenses).to be_empty
+      expect_no_offenses('sprintf')
     end
 
     it 'accepts String#%' do
-      inspect_source(cop,
-                     'puts "%d" % 10')
-      expect(cop.offenses).to be_empty
+      expect_no_offenses('puts "%d" % 10')
     end
   end
 end

--- a/spec/rubocop/cop/style/frozen_string_literal_comment_spec.rb
+++ b/spec/rubocop/cop/style/frozen_string_literal_comment_spec.rb
@@ -10,15 +10,11 @@ describe RuboCop::Cop::Style::FrozenStringLiteralComment, :config do
     end
 
     it 'accepts an empty source' do
-      inspect_source(cop, '')
-
-      expect(cop.offenses).to be_empty
+      expect_no_offenses('')
     end
 
     it 'accepts a source with no tokens' do
-      inspect_source(cop, ' ')
-
-      expect(cop.offenses).to be_empty
+      expect_no_offenses(' ')
     end
 
     it 'accepts a frozen string literal on the top line' do
@@ -281,24 +277,18 @@ describe RuboCop::Cop::Style::FrozenStringLiteralComment, :config do
     end
 
     it 'accepts an empty source' do
-      inspect_source(cop, '')
-
-      expect(cop.offenses).to be_empty
+      expect_no_offenses('')
     end
 
     if RUBY_VERSION >= '2.3.0'
       context 'ruby >= 2.3' do
         context 'no frozen string literal comment' do
           it 'accepts not modifing a string' do
-            inspect_source(cop, 'puts "x"')
-
-            expect(cop.offenses).to be_empty
+            expect_no_offenses('puts "x"')
           end
 
           it 'accepts calling + on a string' do
-            inspect_source(cop, '"x" + "y"')
-
-            expect(cop.offenses).to be_empty
+            expect_no_offenses('"x" + "y"')
           end
 
           it 'accepts calling freeze on a variable' do
@@ -320,15 +310,11 @@ describe RuboCop::Cop::Style::FrozenStringLiteralComment, :config do
           end
 
           it 'accepts freezing a string' do
-            inspect_source(cop, '"x".freeze')
-
-            expect(cop.offenses).to be_empty
+            expect_no_offenses('"x".freeze')
           end
 
           it 'accepts when << is called on a string literal' do
-            inspect_source(cop, '"x" << "y"')
-
-            expect(cop.offenses).to be_empty
+            expect_no_offenses('"x" << "y"')
           end
         end
 
@@ -357,27 +343,19 @@ describe RuboCop::Cop::Style::FrozenStringLiteralComment, :config do
     context 'ruby < 2.3' do
       context 'target_ruby_version < 2.3', :ruby19 do
         it 'accepts freezing a string' do
-          inspect_source(cop, '"x".freeze')
-
-          expect(cop.offenses).to be_empty
+          expect_no_offenses('"x".freeze')
         end
 
         it 'accepts calling << on a string' do
-          inspect_source(cop, '"x" << "y"')
-
-          expect(cop.offenses).to be_empty
+          expect_no_offenses('"x" << "y"')
         end
 
         it 'accepts freezing a string with interpolation' do
-          inspect_source(cop, '"#{foo}bar".freeze')
-
-          expect(cop.offenses).to be_empty
+          expect_no_offenses('"#{foo}bar".freeze')
         end
 
         it 'accepts calling << on a string with interpolation' do
-          inspect_source(cop, '"#{foo}bar" << "baz"')
-
-          expect(cop.offenses).to be_empty
+          expect_no_offenses('"#{foo}bar" << "baz"')
         end
       end
 
@@ -420,15 +398,11 @@ describe RuboCop::Cop::Style::FrozenStringLiteralComment, :config do
     end
 
     it 'accepts an empty source' do
-      inspect_source(cop, '')
-
-      expect(cop.offenses).to be_empty
+      expect_no_offenses('')
     end
 
     it 'accepts a source with no tokens' do
-      inspect_source(cop, ' ')
-
-      expect(cop.offenses).to be_empty
+      expect_no_offenses(' ')
     end
 
     it 'registers an offense for a frozen string literal comment ' \
@@ -454,9 +428,7 @@ describe RuboCop::Cop::Style::FrozenStringLiteralComment, :config do
     end
 
     it 'accepts not having a frozen string literal comment on the top line' do
-      inspect_source(cop, 'puts 1')
-
-      expect(cop.offenses).to be_empty
+      expect_no_offenses('puts 1')
     end
 
     it 'accepts not having not having a frozen string literal comment ' \

--- a/spec/rubocop/cop/style/frozen_string_literal_comment_spec.rb
+++ b/spec/rubocop/cop/style/frozen_string_literal_comment_spec.rb
@@ -18,21 +18,17 @@ describe RuboCop::Cop::Style::FrozenStringLiteralComment, :config do
     end
 
     it 'accepts a frozen string literal on the top line' do
-      inspect_source(cop, <<-END.strip_indent)
+      expect_no_offenses(<<-END.strip_indent)
         # frozen_string_literal: true
         puts 1
       END
-
-      expect(cop.offenses).to be_empty
     end
 
     it 'accepts a disabled frozen string literal on the top line' do
-      inspect_source(cop, <<-END.strip_indent)
+      expect_no_offenses(<<-END.strip_indent)
         # frozen_string_literal: false
         puts 1
       END
-
-      expect(cop.offenses).to be_empty
     end
 
     it 'registers an offense for not having a frozen string literal comment ' \
@@ -55,23 +51,19 @@ describe RuboCop::Cop::Style::FrozenStringLiteralComment, :config do
     end
 
     it 'accepts a frozen string literal below a shebang comment' do
-      inspect_source(cop, <<-END.strip_indent)
+      expect_no_offenses(<<-END.strip_indent)
         #!/usr/bin/env ruby
         # frozen_string_literal: true
         puts 1
       END
-
-      expect(cop.offenses).to be_empty
     end
 
     it 'accepts a disabled frozen string literal below a shebang comment' do
-      inspect_source(cop, <<-END.strip_indent)
+      expect_no_offenses(<<-END.strip_indent)
         #!/usr/bin/env ruby
         # frozen_string_literal: false
         puts 1
       END
-
-      expect(cop.offenses).to be_empty
     end
 
     it 'registers an offense for not having a frozen string literal comment ' \
@@ -86,23 +78,19 @@ describe RuboCop::Cop::Style::FrozenStringLiteralComment, :config do
     end
 
     it 'accepts a frozen string literal below an encoding comment' do
-      inspect_source(cop, <<-END.strip_indent)
+      expect_no_offenses(<<-END.strip_indent)
         # encoding: utf-8
         # frozen_string_literal: true
         puts 1
       END
-
-      expect(cop.offenses).to be_empty
     end
 
     it 'accepts a dsabled frozen string literal below an encoding comment' do
-      inspect_source(cop, <<-END.strip_indent)
+      expect_no_offenses(<<-END.strip_indent)
         # encoding: utf-8
         # frozen_string_literal: false
         puts 1
       END
-
-      expect(cop.offenses).to be_empty
     end
 
     it 'registers an offense for not having a frozen string literal comment ' \
@@ -166,17 +154,12 @@ describe RuboCop::Cop::Style::FrozenStringLiteralComment, :config do
     end
 
     it 'accepts an emacs style combined magic comment' do
-      inspect_source(
-        cop,
-        <<-END.strip_indent
+      expect_no_offenses(<<-END.strip_indent)
           #!/usr/bin/env ruby
           # -*- encoding: UTF-8; frozen_string_literal: true -*-
           # encoding: utf-8
           puts 1
         END
-      )
-
-      expect(cop.offenses).to be_empty
     end
 
     context 'auto-correct' do
@@ -292,21 +275,17 @@ describe RuboCop::Cop::Style::FrozenStringLiteralComment, :config do
           end
 
           it 'accepts calling freeze on a variable' do
-            inspect_source(cop, <<-END.strip_indent)
+            expect_no_offenses(<<-END.strip_indent)
               foo = "x"
                 foo.freeze
             END
-
-            expect(cop.offenses).to be_empty
           end
 
           it 'accepts calling shovel on a variable' do
-            inspect_source(cop, <<-END.strip_indent)
+            expect_no_offenses(<<-END.strip_indent)
               foo = "x"
                 foo << "y"
             END
-
-            expect(cop.offenses).to be_empty
           end
 
           it 'accepts freezing a string' do

--- a/spec/rubocop/cop/style/global_vars_spec.rb
+++ b/spec/rubocop/cop/style/global_vars_spec.rb
@@ -14,8 +14,7 @@ describe RuboCop::Cop::Style::GlobalVars, :config do
   end
 
   it 'allows user whitelisted variables' do
-    inspect_source(cop, 'puts $allowed')
-    expect(cop.offenses).to be_empty
+    expect_no_offenses('puts $allowed')
   end
 
   described_class::BUILT_IN_VARS.each do |var|
@@ -26,7 +25,6 @@ describe RuboCop::Cop::Style::GlobalVars, :config do
   end
 
   it 'does not register an offense for backrefs like $1' do
-    inspect_source(cop, 'puts $1')
-    expect(cop.offenses).to be_empty
+    expect_no_offenses('puts $1')
   end
 end

--- a/spec/rubocop/cop/style/guard_clause_spec.rb
+++ b/spec/rubocop/cop/style/guard_clause_spec.rb
@@ -78,7 +78,7 @@ describe RuboCop::Cop::Style::GuardClause, :config do
   it_behaves_like('reports offense', '# TODO')
 
   it 'does not report an offense if body is if..elsif..end' do
-    inspect_source(cop, <<-END.strip_indent)
+    expect_no_offenses(<<-END.strip_indent)
       def func
         if something
           a
@@ -87,11 +87,10 @@ describe RuboCop::Cop::Style::GuardClause, :config do
         end
       end
     END
-    expect(cop.offenses).to be_empty
   end
 
   it "doesn't report an offense if condition has multiple lines" do
-    inspect_source(cop, <<-END.strip_indent)
+    expect_no_offenses(<<-END.strip_indent)
       def func
         if something &&
              something_else
@@ -106,11 +105,10 @@ describe RuboCop::Cop::Style::GuardClause, :config do
         end
       end
     END
-    expect(cop.offenses).to be_empty
   end
 
   it 'accepts a method which body is if / unless with else' do
-    inspect_source(cop, <<-END.strip_indent)
+    expect_no_offenses(<<-END.strip_indent)
       def func
         if something
           work
@@ -127,11 +125,10 @@ describe RuboCop::Cop::Style::GuardClause, :config do
         end
       end
     END
-    expect(cop.offenses).to be_empty
   end
 
   it 'accepts a method which body does not end with if / unless' do
-    inspect_source(cop, <<-END.strip_indent)
+    expect_no_offenses(<<-END.strip_indent)
       def func
         if something
           work
@@ -146,11 +143,10 @@ describe RuboCop::Cop::Style::GuardClause, :config do
         test
       end
     END
-    expect(cop.offenses).to be_empty
   end
 
   it 'accepts a method whose body is a modifier if / unless' do
-    inspect_source(cop, <<-END.strip_indent)
+    expect_no_offenses(<<-END.strip_indent)
       def func
         work if something
       end
@@ -159,7 +155,6 @@ describe RuboCop::Cop::Style::GuardClause, :config do
         work if something
       end
     END
-    expect(cop.offenses).to be_empty
   end
 
   context 'MinBodyLength: 1' do
@@ -196,7 +191,7 @@ describe RuboCop::Cop::Style::GuardClause, :config do
     end
 
     it 'accepts a method whose body has 3 lines' do
-      inspect_source(cop, <<-END.strip_indent)
+      expect_no_offenses(<<-END.strip_indent)
         def func
           if something
             work
@@ -213,7 +208,6 @@ describe RuboCop::Cop::Style::GuardClause, :config do
           end
         end
       END
-      expect(cop.offenses).to be_empty
     end
   end
 
@@ -264,7 +258,7 @@ describe RuboCop::Cop::Style::GuardClause, :config do
     end
 
     it "doesn't register an error if condition has multiple lines" do
-      inspect_source(cop, <<-END.strip_indent)
+      expect_no_offenses(<<-END.strip_indent)
         if something &&
              something_else
           #{kw}
@@ -272,7 +266,6 @@ describe RuboCop::Cop::Style::GuardClause, :config do
           puts "hello"
         end
       END
-      expect(cop.offenses).to be_empty
     end
 
     it "does not report an offense if #{kw} is inside elsif" do

--- a/spec/rubocop/cop/style/if_inside_else_spec.rb
+++ b/spec/rubocop/cop/style/if_inside_else_spec.rb
@@ -120,8 +120,7 @@ describe RuboCop::Cop::Style::IfInsideElse do
   end
 
   it 'ignores nested ternary expressions' do
-    inspect_source(cop, 'a ? b : c ? d : e')
-    expect(cop.offenses).to be_empty
+    expect_no_offenses('a ? b : c ? d : e')
   end
 
   it 'ignores ternary inside if..else' do

--- a/spec/rubocop/cop/style/if_inside_else_spec.rb
+++ b/spec/rubocop/cop/style/if_inside_else_spec.rb
@@ -55,7 +55,7 @@ describe RuboCop::Cop::Style::IfInsideElse do
   end
 
   it "isn't offended if there is a statement following the if node" do
-    inspect_source(cop, <<-END.strip_indent)
+    expect_no_offenses(<<-END.strip_indent)
       if a
         blah
       else
@@ -65,11 +65,10 @@ describe RuboCop::Cop::Style::IfInsideElse do
         bar
       end
     END
-    expect(cop.offenses).to be_empty
   end
 
   it "isn't offended if there is a statement preceding the if node" do
-    inspect_source(cop, <<-END.strip_indent)
+    expect_no_offenses(<<-END.strip_indent)
       if a
         blah
       else
@@ -79,11 +78,10 @@ describe RuboCop::Cop::Style::IfInsideElse do
         end
       end
     END
-    expect(cop.offenses).to be_empty
   end
 
   it "isn't offended by if..elsif..else" do
-    inspect_source(cop, <<-END.strip_indent)
+    expect_no_offenses(<<-END.strip_indent)
       if a
         blah
       elsif b
@@ -92,11 +90,10 @@ describe RuboCop::Cop::Style::IfInsideElse do
         blah
       end
     END
-    expect(cop.offenses).to be_empty
   end
 
   it 'ignores unless inside else' do
-    inspect_source(cop, <<-END.strip_indent)
+    expect_no_offenses(<<-END.strip_indent)
       if a
         blah
       else
@@ -105,18 +102,16 @@ describe RuboCop::Cop::Style::IfInsideElse do
         end
       end
     END
-    expect(cop.offenses).to be_empty
   end
 
   it 'ignores if inside unless' do
-    inspect_source(cop, <<-END.strip_indent)
+    expect_no_offenses(<<-END.strip_indent)
       unless a
         if b
           foo
         end
       end
     END
-    expect(cop.offenses).to be_empty
   end
 
   it 'ignores nested ternary expressions' do
@@ -124,13 +119,12 @@ describe RuboCop::Cop::Style::IfInsideElse do
   end
 
   it 'ignores ternary inside if..else' do
-    inspect_source(cop, <<-END.strip_indent)
+    expect_no_offenses(<<-END.strip_indent)
       if a
         blah
       else
         a ? b : c
       end
     END
-    expect(cop.offenses).to be_empty
   end
 end

--- a/spec/rubocop/cop/style/if_unless_modifier_spec.rb
+++ b/spec/rubocop/cop/style/if_unless_modifier_spec.rb
@@ -175,12 +175,11 @@ describe RuboCop::Cop::Style::IfUnlessModifier do
   end
 
   it 'accepts code with EOL comment since user might want to keep it' do
-    inspect_source(cop, <<-END.strip_indent)
+    expect_no_offenses(<<-END.strip_indent)
       unless a
         b # A comment
       end
     END
-    expect(cop.offenses).to be_empty
   end
 
   it 'accepts if-else-end' do
@@ -196,14 +195,13 @@ describe RuboCop::Cop::Style::IfUnlessModifier do
   end
 
   it 'accepts if/elsif' do
-    inspect_source(cop, <<-END.strip_indent)
+    expect_no_offenses(<<-END.strip_indent)
       if test
         something
       elsif test2
         something_else
       end
     END
-    expect(cop.offenses).to be_empty
   end
 
   context 'with implicit match conditional' do

--- a/spec/rubocop/cop/style/infinite_loop_spec.rb
+++ b/spec/rubocop/cop/style/infinite_loop_spec.rb
@@ -31,9 +31,7 @@ describe RuboCop::Cop::Style::InfiniteLoop do
   end
 
   it 'accepts Kernel#loop' do
-    inspect_source(cop,
-                   'loop { break if something }')
-    expect(cop.offenses).to be_empty
+    expect_no_offenses('loop { break if something }')
   end
 
   shared_examples_for 'auto-corrector' do |keyword, lit|

--- a/spec/rubocop/cop/style/inline_comment_spec.rb
+++ b/spec/rubocop/cop/style/inline_comment_spec.rb
@@ -12,8 +12,6 @@ describe RuboCop::Cop::Style::InlineComment do
   end
 
   it 'does not register an offense for a standalone comment' do
-    inspect_source(cop, '# A standalone comment')
-
-    expect(cop.offenses).to be_empty
+    expect_no_offenses('# A standalone comment')
   end
 end

--- a/spec/rubocop/cop/style/inverse_methods_spec.rb
+++ b/spec/rubocop/cop/style/inverse_methods_spec.rb
@@ -39,9 +39,7 @@ describe RuboCop::Cop::Style::InverseMethods do
   end
 
   it 'allows a method call without a not' do
-    inspect_source(cop, 'foo.none?')
-
-    expect(cop.offenses).to be_empty
+    expect_no_offenses('foo.none?')
   end
 
   context 'auto-correct' do

--- a/spec/rubocop/cop/style/lambda_call_spec.rb
+++ b/spec/rubocop/cop/style/lambda_call_spec.rb
@@ -23,8 +23,7 @@ describe RuboCop::Cop::Style::LambdaCall, :config do
     end
 
     it 'accepts x.call()' do
-      inspect_source(cop, 'x.call(a, b)')
-      expect(cop.offenses).to be_empty
+      expect_no_offenses('x.call(a, b)')
     end
 
     it 'auto-corrects x.() to x.call()' do
@@ -53,13 +52,11 @@ describe RuboCop::Cop::Style::LambdaCall, :config do
     end
 
     it 'accepts x.()' do
-      inspect_source(cop, 'x.(a, b)')
-      expect(cop.offenses).to be_empty
+      expect_no_offenses('x.(a, b)')
     end
 
     it 'accepts a call without receiver' do
-      inspect_source(cop, 'call(a, b)')
-      expect(cop.offenses).to be_empty
+      expect_no_offenses('call(a, b)')
     end
 
     it 'auto-corrects x.call() to x.()' do

--- a/spec/rubocop/cop/style/lambda_spec.rb
+++ b/spec/rubocop/cop/style/lambda_spec.rb
@@ -176,22 +176,20 @@ describe RuboCop::Cop::Style::Lambda, :config do
 
     context 'with a multiline lambda method call' do
       it 'does not register an offense' do
-        inspect_source(cop, <<-END.strip_indent)
+        expect_no_offenses(<<-END.strip_indent)
           l = lambda do |x|
             x
           end
         END
-        expect(cop.offenses).to be_empty
       end
     end
 
     context 'with a single line lambda literal' do
       it 'does not register an offense' do
-        inspect_source(cop, <<-END.strip_indent)
+        expect_no_offenses(<<-END.strip_indent)
           lambda = ->(x) { x }
           lambda.(1)
         END
-        expect(cop.offenses).to be_empty
       end
     end
 

--- a/spec/rubocop/cop/style/lambda_spec.rb
+++ b/spec/rubocop/cop/style/lambda_spec.rb
@@ -394,8 +394,7 @@ describe RuboCop::Cop::Style::Lambda, :config do
 
     context 'when calling a lambda method without a block' do
       it 'does not register an offense' do
-        inspect_source(cop, 'l = lambda.test')
-        expect(cop.offenses).to be_empty
+        expect_no_offenses('l = lambda.test')
       end
     end
 

--- a/spec/rubocop/cop/style/line_end_concatenation_spec.rb
+++ b/spec/rubocop/cop/style/line_end_concatenation_spec.rb
@@ -68,9 +68,7 @@ describe RuboCop::Cop::Style::LineEndConcatenation do
   end
 
   it 'accepts string concat on the same line' do
-    inspect_source(cop,
-                   'top = "test" + "top"')
-    expect(cop.offenses).to be_empty
+    expect_no_offenses('top = "test" + "top"')
   end
 
   it 'accepts string concat with a return value of method on a string' do

--- a/spec/rubocop/cop/style/method_call_with_args_parentheses_spec.rb
+++ b/spec/rubocop/cop/style/method_call_with_args_parentheses_spec.rb
@@ -89,25 +89,21 @@ describe RuboCop::Cop::Style::MethodCallWithArgsParentheses, :config do
 
     context 'in a class body' do
       it 'does not register an offense' do
-        inspect_source(cop, <<-END.strip_indent)
+        expect_no_offenses(<<-END.strip_indent)
           class Foo
             bar :baz
           end
         END
-
-        expect(cop.offenses).to be_empty
       end
     end
 
     context 'in a module body' do
       it 'does not register an offense' do
-        inspect_source(cop, <<-END.strip_indent)
+        expect_no_offenses(<<-END.strip_indent)
           module Foo
             bar :baz
           end
         END
-
-        expect(cop.offenses).to be_empty
       end
     end
   end

--- a/spec/rubocop/cop/style/method_call_with_args_parentheses_spec.rb
+++ b/spec/rubocop/cop/style/method_call_with_args_parentheses_spec.rb
@@ -7,13 +7,11 @@ describe RuboCop::Cop::Style::MethodCallWithArgsParentheses, :config do
   end
 
   it 'accepts no parens in method call without args' do
-    inspect_source(cop, 'top.test')
-    expect(cop.offenses).to be_empty
+    expect_no_offenses('top.test')
   end
 
   it 'accepts parens in method call with args' do
-    inspect_source(cop, 'top.test(a, b)')
-    expect(cop.offenses).to be_empty
+    expect_no_offenses('top.test(a, b)')
   end
 
   it 'register an offense for method call without parens' do
@@ -37,18 +35,15 @@ describe RuboCop::Cop::Style::MethodCallWithArgsParentheses, :config do
   end
 
   it 'register no offense for superclass call without args' do
-    inspect_source(cop, 'super')
-    expect(cop.offenses).to be_empty
+    expect_no_offenses('super')
   end
 
   it 'register no offense for yield without args' do
-    inspect_source(cop, 'yield')
-    expect(cop.offenses).to be_empty
+    expect_no_offenses('yield')
   end
 
   it 'register no offense for superclass call with parens' do
-    inspect_source(cop, 'super(a)')
-    expect(cop.offenses).to be_empty
+    expect_no_offenses('super(a)')
   end
 
   it 'register an offense for yield without parens' do
@@ -57,18 +52,15 @@ describe RuboCop::Cop::Style::MethodCallWithArgsParentheses, :config do
   end
 
   it 'accepts no parens for operators' do
-    inspect_source(cop, 'top.test + a')
-    expect(cop.offenses).to be_empty
+    expect_no_offenses('top.test + a')
   end
 
   it 'accepts no parens for setter methods' do
-    inspect_source(cop, 'top.test = a')
-    expect(cop.offenses).to be_empty
+    expect_no_offenses('top.test = a')
   end
 
   it 'accepts no parens for unary operators' do
-    inspect_source(cop, '!test')
-    expect(cop.offenses).to be_empty
+    expect_no_offenses('!test')
   end
 
   it 'auto-corrects call by adding needed braces' do
@@ -87,8 +79,7 @@ describe RuboCop::Cop::Style::MethodCallWithArgsParentheses, :config do
   end
 
   it 'ignores method listed in IgnoredMethods' do
-    inspect_source(cop, 'puts :test')
-    expect(cop.offenses).to be_empty
+    expect_no_offenses('puts :test')
   end
 
   context 'when inspecting macro methods' do

--- a/spec/rubocop/cop/style/method_call_without_args_parentheses_spec.rb
+++ b/spec/rubocop/cop/style/method_call_without_args_parentheses_spec.rb
@@ -43,7 +43,7 @@ describe RuboCop::Cop::Style::MethodCallWithoutArgsParentheses do
     end
 
     it 'accepts parens in complex assignment' do
-      inspect_source(cop, <<-END.strip_indent)
+      expect_no_offenses(<<-END.strip_indent)
         test = begin
           case a
           when b
@@ -51,7 +51,6 @@ describe RuboCop::Cop::Style::MethodCallWithoutArgsParentheses do
           end
         end
       END
-      expect(cop.offenses).to be_empty
     end
   end
 

--- a/spec/rubocop/cop/style/method_call_without_args_parentheses_spec.rb
+++ b/spec/rubocop/cop/style/method_call_without_args_parentheses_spec.rb
@@ -9,45 +9,37 @@ describe RuboCop::Cop::Style::MethodCallWithoutArgsParentheses do
   end
 
   it 'accepts parentheses for methods starting with an upcase letter' do
-    inspect_source(cop, 'Test()')
-    expect(cop.offenses).to be_empty
+    expect_no_offenses('Test()')
   end
 
   it 'accepts no parens in method call without args' do
-    inspect_source(cop, 'top.test')
-    expect(cop.offenses).to be_empty
+    expect_no_offenses('top.test')
   end
 
   it 'accepts parens in method call with args' do
-    inspect_source(cop, 'top.test(a)')
-    expect(cop.offenses).to be_empty
+    expect_no_offenses('top.test(a)')
   end
 
   it 'accepts special lambda call syntax' do
     # Style/LambdaCall checks for this syntax
-    inspect_source(cop, 'thing.()')
-    expect(cop.offenses).to be_empty
+    expect_no_offenses('thing.()')
   end
 
   it 'accepts parens after not' do
-    inspect_source(cop, 'not(something)')
-    expect(cop.offenses).to be_empty
+    expect_no_offenses('not(something)')
   end
 
   context 'assignment to a variable with the same name' do
     it 'accepts parens in local variable assignment ' do
-      inspect_source(cop, 'test = test()')
-      expect(cop.offenses).to be_empty
+      expect_no_offenses('test = test()')
     end
 
     it 'accepts parens in shorthand assignment' do
-      inspect_source(cop, 'test ||= test()')
-      expect(cop.offenses).to be_empty
+      expect_no_offenses('test ||= test()')
     end
 
     it 'accepts parens in parallel assignment' do
-      inspect_source(cop, 'one, test = 1, test()')
-      expect(cop.offenses).to be_empty
+      expect_no_offenses('one, test = 1, test()')
     end
 
     it 'accepts parens in complex assignment' do
@@ -101,8 +93,7 @@ describe RuboCop::Cop::Style::MethodCallWithoutArgsParentheses do
 
   context 'method call as argument' do
     it 'accepts without parens' do
-      inspect_source(cop, '_a = c(d.e)')
-      expect(cop.offenses).to be_empty
+      expect_no_offenses('_a = c(d.e)')
     end
 
     it 'registers an offense with empty parens' do

--- a/spec/rubocop/cop/style/method_name_spec.rb
+++ b/spec/rubocop/cop/style/method_name_spec.rb
@@ -42,12 +42,11 @@ describe RuboCop::Cop::Style::MethodName, :config do
     end
 
     it 'accepts operator definitions' do
-      inspect_source(cop, <<-END.strip_indent)
+      expect_no_offenses(<<-END.strip_indent)
         def +(other)
           # ...
         end
       END
-      expect(cop.offenses).to be_empty
     end
 
     %w[class module].each do |kind|
@@ -122,11 +121,10 @@ describe RuboCop::Cop::Style::MethodName, :config do
     end
 
     it 'accepts snake case in names' do
-      inspect_source(cop, <<-END.strip_indent)
+      expect_no_offenses(<<-END.strip_indent)
         def my_method
         end
       END
-      expect(cop.offenses).to be_empty
     end
 
     it 'registers an offense for singleton camelCase method within class' do
@@ -147,21 +145,19 @@ describe RuboCop::Cop::Style::MethodName, :config do
     let(:cop_config) { { 'EnforcedStyle' => 'camelCase' } }
 
     it 'accepts camel case in instance method name' do
-      inspect_source(cop, <<-END.strip_indent)
+      expect_no_offenses(<<-END.strip_indent)
         def myMethod
           # ...
         end
       END
-      expect(cop.offenses).to be_empty
     end
 
     it 'accepts camel case in singleton method name' do
-      inspect_source(cop, <<-END.strip_indent)
+      expect_no_offenses(<<-END.strip_indent)
         def self.myMethod
           # ...
         end
       END
-      expect(cop.offenses).to be_empty
     end
 
     it 'registers an offense for snake case in names' do

--- a/spec/rubocop/cop/style/method_name_spec.rb
+++ b/spec/rubocop/cop/style/method_name_spec.rb
@@ -38,8 +38,7 @@ describe RuboCop::Cop::Style::MethodName, :config do
 
   shared_examples 'always accepted' do
     it 'accepts one line methods' do
-      inspect_source(cop, "def body; '' end")
-      expect(cop.offenses).to be_empty
+      expect_no_offenses("def body; '' end")
     end
 
     it 'accepts operator definitions' do

--- a/spec/rubocop/cop/style/module_function_spec.rb
+++ b/spec/rubocop/cop/style/module_function_spec.rb
@@ -18,12 +18,11 @@ describe RuboCop::Cop::Style::ModuleFunction, :config do
     end
 
     it 'accepts `extend self` in a class' do
-      inspect_source(cop, <<-END.strip_indent)
+      expect_no_offenses(<<-END.strip_indent)
         class Test
           extend self
         end
       END
-      expect(cop.offenses).to be_empty
     end
   end
 
@@ -42,13 +41,12 @@ describe RuboCop::Cop::Style::ModuleFunction, :config do
     end
 
     it 'accepts module_function with an argument' do
-      inspect_source(cop, <<-END.strip_indent)
+      expect_no_offenses(<<-END.strip_indent)
         module Test
           def test; end
           module_function :test
         end
       END
-      expect(cop.offenses).to be_empty
     end
   end
 end

--- a/spec/rubocop/cop/style/multiline_block_chain_spec.rb
+++ b/spec/rubocop/cop/style/multiline_block_chain_spec.rb
@@ -63,28 +63,25 @@ describe RuboCop::Cop::Style::MultilineBlockChain do
   end
 
   it 'accepts a chain of blocks spanning one line' do
-    inspect_source(cop, <<-END.strip_indent)
+    expect_no_offenses(<<-END.strip_indent)
       a { b }.c { d }
       w do x end.y do z end
     END
-    expect(cop.offenses).to be_empty
   end
 
   it 'accepts a multi-line block chained with calls on one line' do
-    inspect_source(cop, <<-END.strip_indent)
+    expect_no_offenses(<<-END.strip_indent)
       a do
         b
       end.c.d
     END
-    expect(cop.offenses).to be_empty
   end
 
   it 'accepts a chain of calls followed by a multi-line block' do
-    inspect_source(cop, <<-END.strip_indent)
+    expect_no_offenses(<<-END.strip_indent)
       a1.a2.a3 do
         b
       end
     END
-    expect(cop.offenses).to be_empty
   end
 end

--- a/spec/rubocop/cop/style/multiline_if_then_spec.rb
+++ b/spec/rubocop/cop/style/multiline_if_then_spec.rb
@@ -6,12 +6,11 @@ describe RuboCop::Cop::Style::MultilineIfThen do
   # if
 
   it 'does not get confused by empty elsif branch' do
-    inspect_source(cop, <<-END.strip_indent)
+    expect_no_offenses(<<-END.strip_indent)
       if cond
       elsif cond
       end
     END
-    expect(cop.offenses).to be_empty
   end
 
   it 'registers an offense for then in multiline if' do
@@ -45,44 +44,40 @@ describe RuboCop::Cop::Style::MultilineIfThen do
   end
 
   it 'accepts multiline if without then' do
-    inspect_source(cop, <<-END.strip_indent)
+    expect_no_offenses(<<-END.strip_indent)
       if cond
       end
     END
-    expect(cop.offenses).to be_empty
   end
 
   it 'accepts table style if/then/elsif/ends' do
-    inspect_source(cop, <<-END.strip_indent)
+    expect_no_offenses(<<-END.strip_indent)
       if    @io == $stdout then str << "$stdout"
       elsif @io == $stdin  then str << "$stdin"
       elsif @io == $stderr then str << "$stderr"
       else                      str << @io.class.to_s
       end
     END
-    expect(cop.offenses).to be_empty
   end
 
   it 'does not get confused by a then in a when' do
-    inspect_source(cop, <<-END.strip_indent)
+    expect_no_offenses(<<-END.strip_indent)
       if a
         case b
         when c then
         end
       end
     END
-    expect(cop.offenses).to be_empty
   end
 
   it 'does not get confused by a commented-out then' do
-    inspect_source(cop, <<-END.strip_indent)
+    expect_no_offenses(<<-END.strip_indent)
       if a # then
         b
       end
       if c # then
       end
     END
-    expect(cop.offenses).to be_empty
   end
 
   it 'does not raise an error for an implicit match if' do
@@ -107,11 +102,10 @@ describe RuboCop::Cop::Style::MultilineIfThen do
   end
 
   it 'accepts multiline unless without then' do
-    inspect_source(cop, <<-END.strip_indent)
+    expect_no_offenses(<<-END.strip_indent)
       unless cond
       end
     END
-    expect(cop.offenses).to be_empty
   end
 
   it 'does not get confused by a postfix unless' do
@@ -119,12 +113,11 @@ describe RuboCop::Cop::Style::MultilineIfThen do
   end
 
   it 'does not get confused by a nested postfix unless' do
-    inspect_source(cop, <<-END.strip_indent)
+    expect_no_offenses(<<-END.strip_indent)
       if two
         puts 1
       end unless two
     END
-    expect(cop.offenses).to be_empty
   end
 
   it 'does not raise an error for an implicit match unless' do

--- a/spec/rubocop/cop/style/multiline_if_then_spec.rb
+++ b/spec/rubocop/cop/style/multiline_if_then_spec.rb
@@ -115,8 +115,7 @@ describe RuboCop::Cop::Style::MultilineIfThen do
   end
 
   it 'does not get confused by a postfix unless' do
-    inspect_source(cop, 'two unless one')
-    expect(cop.offenses).to be_empty
+    expect_no_offenses('two unless one')
   end
 
   it 'does not get confused by a nested postfix unless' do

--- a/spec/rubocop/cop/style/multiline_ternary_operator_spec.rb
+++ b/spec/rubocop/cop/style/multiline_ternary_operator_spec.rb
@@ -32,7 +32,6 @@ describe RuboCop::Cop::Style::MultilineTernaryOperator do
   end
 
   it 'accepts a single line ternary operator expression' do
-    inspect_source(cop, 'a = cond ? b : c')
-    expect(cop.offenses).to be_empty
+    expect_no_offenses('a = cond ? b : c')
   end
 end

--- a/spec/rubocop/cop/style/mutable_constant_spec.rb
+++ b/spec/rubocop/cop/style/mutable_constant_spec.rb
@@ -59,19 +59,16 @@ describe RuboCop::Cop::Style::MutableConstant do
   it_behaves_like :immutable_objects, ':sym'
 
   it 'allows method call assignments' do
-    inspect_source(cop, 'TOP_TEST = Something.new')
-    expect(cop.offenses).to be_empty
+    expect_no_offenses('TOP_TEST = Something.new')
   end
 
   context 'when performing a splat assignment' do
     it 'allows an immutable value' do
-      inspect_source(cop, 'FOO = *(1...10)')
-      expect(cop.offenses).to be_empty
+      expect_no_offenses('FOO = *(1...10)')
     end
 
     it 'allows a frozen array value' do
-      inspect_source(cop, 'FOO = *[1...10].freeze')
-      expect(cop.offenses).to be_empty
+      expect_no_offenses('FOO = *[1...10].freeze')
     end
 
     it 'registers an offense for a mutable value' do

--- a/spec/rubocop/cop/style/negated_if_spec.rb
+++ b/spec/rubocop/cop/style/negated_if_spec.rb
@@ -51,7 +51,7 @@ describe RuboCop::Cop::Style::NegatedIf do
     end
 
     it 'accepts an if/else with negative condition' do
-      inspect_source(cop, <<-END.strip_indent)
+      expect_no_offenses(<<-END.strip_indent)
         if !a_condition
           some_method
         else
@@ -63,11 +63,10 @@ describe RuboCop::Cop::Style::NegatedIf do
           something_else
         end
       END
-      expect(cop.offenses).to be_empty
     end
 
     it 'accepts an if where only part of the condition is negated' do
-      inspect_source(cop, <<-END.strip_indent)
+      expect_no_offenses(<<-END.strip_indent)
         if !condition && another_condition
           some_method
         end
@@ -76,21 +75,19 @@ describe RuboCop::Cop::Style::NegatedIf do
         end
         some_method if not condition or another_condition
       END
-      expect(cop.offenses).to be_empty
     end
 
     it 'accepts an if where the condition is doubly negated' do
-      inspect_source(cop, <<-END.strip_indent)
+      expect_no_offenses(<<-END.strip_indent)
         if !!condition
           some_method
         end
         some_method if !!condition
       END
-      expect(cop.offenses).to be_empty
     end
 
     it 'is not confused by negated elsif' do
-      inspect_source(cop, <<-END.strip_indent)
+      expect_no_offenses(<<-END.strip_indent)
         if test.is_a?(String)
           3
         elsif test.is_a?(Array)
@@ -99,8 +96,6 @@ describe RuboCop::Cop::Style::NegatedIf do
           1
         end
       END
-
-      expect(cop.offenses).to be_empty
     end
 
     it 'autocorrects for postfix' do
@@ -198,12 +193,10 @@ describe RuboCop::Cop::Style::NegatedIf do
     end
 
     it 'does not register an offence for prefix' do
-      inspect_source(cop, <<-END.strip_indent)
+      expect_no_offenses(<<-END.strip_indent)
         if !foo
         end
       END
-
-      expect(cop.offenses).to be_empty
     end
 
     it 'autocorrects for postfix' do
@@ -222,18 +215,16 @@ describe RuboCop::Cop::Style::NegatedIf do
   end
 
   it 'does not blow up for empty if condition' do
-    inspect_source(cop, <<-END.strip_indent)
+    expect_no_offenses(<<-END.strip_indent)
       if ()
       end
     END
-    expect(cop.offenses).to be_empty
   end
 
   it 'does not blow up for empty unless condition' do
-    inspect_source(cop, <<-END.strip_indent)
+    expect_no_offenses(<<-END.strip_indent)
       unless ()
       end
     END
-    expect(cop.offenses).to be_empty
   end
 end

--- a/spec/rubocop/cop/style/negated_if_spec.rb
+++ b/spec/rubocop/cop/style/negated_if_spec.rb
@@ -161,9 +161,7 @@ describe RuboCop::Cop::Style::NegatedIf do
     end
 
     it 'does not register an offence for postfix' do
-      inspect_source(cop, 'foo if !bar')
-
-      expect(cop.offenses).to be_empty
+      expect_no_offenses('foo if !bar')
     end
 
     it 'autocorrects for prefix' do
@@ -216,13 +214,11 @@ describe RuboCop::Cop::Style::NegatedIf do
   end
 
   it 'does not blow up for ternary ops' do
-    inspect_source(cop, 'a ? b : c')
-    expect(cop.offenses).to be_empty
+    expect_no_offenses('a ? b : c')
   end
 
   it 'does not blow up on a negated ternary operator' do
-    inspect_source(cop, '!foo.empty? ? :bar : :baz')
-    expect(cop.offenses).to be_empty
+    expect_no_offenses('!foo.empty? ? :bar : :baz')
   end
 
   it 'does not blow up for empty if condition' do

--- a/spec/rubocop/cop/style/negated_while_spec.rb
+++ b/spec/rubocop/cop/style/negated_while_spec.rb
@@ -79,18 +79,16 @@ describe RuboCop::Cop::Style::NegatedWhile do
   end
 
   it 'does not blow up for empty while condition' do
-    inspect_source(cop, <<-END.strip_indent)
+    expect_no_offenses(<<-END.strip_indent)
       while ()
       end
     END
-    expect(cop.offenses).to be_empty
   end
 
   it 'does not blow up for empty until condition' do
-    inspect_source(cop, <<-END.strip_indent)
+    expect_no_offenses(<<-END.strip_indent)
       until ()
       end
     END
-    expect(cop.offenses).to be_empty
   end
 end

--- a/spec/rubocop/cop/style/nested_ternary_operator_spec.rb
+++ b/spec/rubocop/cop/style/nested_ternary_operator_spec.rb
@@ -9,13 +9,12 @@ describe RuboCop::Cop::Style::NestedTernaryOperator do
   end
 
   it 'accepts a non-nested ternary operator within an if' do
-    inspect_source(cop, <<-END.strip_indent)
+    expect_no_offenses(<<-END.strip_indent)
       a = if x
         cond ? b : c
       else
         d
       end
     END
-    expect(cop.offenses).to be_empty
   end
 end

--- a/spec/rubocop/cop/style/next_spec.rb
+++ b/spec/rubocop/cop/style/next_spec.rb
@@ -508,21 +508,15 @@ describe RuboCop::Cop::Style::Next, :config do
   end
 
   it 'does not blow up on empty body until block' do
-    inspect_source(cop, 'until sup; end')
-
-    expect(cop.offenses).to be_empty
+    expect_no_offenses('until sup; end')
   end
 
   it 'does not blow up on empty body while block' do
-    inspect_source(cop, 'while sup; end')
-
-    expect(cop.offenses).to be_empty
+    expect_no_offenses('while sup; end')
   end
 
   it 'does not blow up on empty body for block' do
-    inspect_source(cop, 'for x in y; end')
-
-    expect(cop.offenses).to be_empty
+    expect_no_offenses('for x in y; end')
   end
 
   it 'does not crash with an empty body branch' do

--- a/spec/rubocop/cop/style/next_spec.rb
+++ b/spec/rubocop/cop/style/next_spec.rb
@@ -261,25 +261,21 @@ describe RuboCop::Cop::Style::Next, :config do
     end
 
     it 'allows loops with conditional break' do
-      inspect_source(cop, <<-END.strip_indent)
+      expect_no_offenses(<<-END.strip_indent)
         loop do
           puts ''
           break #{condition} o == 1
         end
       END
-
-      expect(cop.offenses).to be_empty
     end
 
     it 'allows loops with conditional return' do
-      inspect_source(cop, <<-END.strip_indent)
+      expect_no_offenses(<<-END.strip_indent)
         loop do
           puts ''
           return #{condition} o == 1
         end
       END
-
-      expect(cop.offenses).to be_empty
     end
 
     it "allows loops with #{condition} being the entire body with else" do
@@ -477,34 +473,28 @@ describe RuboCop::Cop::Style::Next, :config do
   it_behaves_like 'iterators', 'unless'
 
   it 'allows empty blocks' do
-    inspect_source(cop, <<-END.strip_indent)
+    expect_no_offenses(<<-END.strip_indent)
       [].each do
       end
       [].each { }
     END
-
-    expect(cop.offenses).to be_empty
   end
 
   it 'allows loops with conditions at the end with ternary op' do
-    inspect_source(cop, <<-END.strip_indent)
+    expect_no_offenses(<<-END.strip_indent)
       [].each do |o|
         o == x ? y : z
       end
     END
-
-    expect(cop.offenses).to be_empty
   end
 
   it 'allows super nodes' do
     # https://github.com/bbatsov/rubocop/issues/1115
-    inspect_source(cop, <<-END.strip_indent)
+    expect_no_offenses(<<-END.strip_indent)
       def foo
         super(a, a) { a }
       end
     END
-
-    expect(cop.offenses).to be_empty
   end
 
   it 'does not blow up on empty body until block' do
@@ -520,22 +510,20 @@ describe RuboCop::Cop::Style::Next, :config do
   end
 
   it 'does not crash with an empty body branch' do
-    inspect_source(cop, <<-END.strip_indent)
+    expect_no_offenses(<<-END.strip_indent)
       loop do
         if true
         end
       end
     END
-    expect(cop.offenses).to be_empty
   end
 
   it 'does not crash with empty brackets' do
-    inspect_source(cop, <<-END.strip_indent)
+    expect_no_offenses(<<-END.strip_indent)
       loop do
         ()
       end
     END
-    expect(cop.offenses).to be_empty
   end
 
   context 'MinBodyLength: 3' do
@@ -544,15 +532,13 @@ describe RuboCop::Cop::Style::Next, :config do
     end
 
     it 'accepts if whose body has 1 line' do
-      inspect_source(cop, <<-END.strip_indent)
+      expect_no_offenses(<<-END.strip_indent)
         arr.each do |e|
           if something
             work
           end
         end
       END
-
-      expect(cop.offenses).to be_empty
     end
   end
 

--- a/spec/rubocop/cop/style/non_nil_check_spec.rb
+++ b/spec/rubocop/cop/style/non_nil_check_spec.rb
@@ -31,41 +31,37 @@ describe RuboCop::Cop::Style::NonNilCheck, :config do
     end
 
     it 'does not register an offense if only expression in predicate' do
-      inspect_source(cop, <<-END.strip_indent)
+      expect_no_offenses(<<-END.strip_indent)
         def signed_in?
           !current_user.nil?
         end
       END
-      expect(cop.offenses).to be_empty
     end
 
     it 'does not register an offense if only expression in class predicate' do
-      inspect_source(cop, <<-END.strip_indent)
+      expect_no_offenses(<<-END.strip_indent)
         def Test.signed_in?
           current_user != nil
         end
       END
-      expect(cop.offenses).to be_empty
     end
 
     it 'does not register an offense if last expression in predicate' do
-      inspect_source(cop, <<-END.strip_indent)
+      expect_no_offenses(<<-END.strip_indent)
         def signed_in?
           something
           current_user != nil
         end
       END
-      expect(cop.offenses).to be_empty
     end
 
     it 'does not register an offense if last expression in class predicate' do
-      inspect_source(cop, <<-END.strip_indent)
+      expect_no_offenses(<<-END.strip_indent)
         def Test.signed_in?
           something
           current_user != nil
         end
       END
-      expect(cop.offenses).to be_empty
     end
 
     it 'autocorrects by changing `!= nil` to `!x.nil?`' do

--- a/spec/rubocop/cop/style/non_nil_check_spec.rb
+++ b/spec/rubocop/cop/style/non_nil_check_spec.rb
@@ -19,18 +19,15 @@ describe RuboCop::Cop::Style::NonNilCheck, :config do
     end
 
     it 'does not register an offense for != 0' do
-      inspect_source(cop, 'x != 0')
-      expect(cop.offenses).to be_empty
+      expect_no_offenses('x != 0')
     end
 
     it 'does not register an offense for !x.nil?' do
-      inspect_source(cop, '!x.nil?')
-      expect(cop.offenses).to be_empty
+      expect_no_offenses('!x.nil?')
     end
 
     it 'does not register an offense for not x.nil?' do
-      inspect_source(cop, 'not x.nil?')
-      expect(cop.offenses).to be_empty
+      expect_no_offenses('not x.nil?')
     end
 
     it 'does not register an offense if only expression in predicate' do
@@ -120,13 +117,11 @@ describe RuboCop::Cop::Style::NonNilCheck, :config do
     end
 
     it 'does not register an offense for `x.nil?`' do
-      inspect_source(cop, 'x.nil?')
-      expect(cop.offenses).to be_empty
+      expect_no_offenses('x.nil?')
     end
 
     it 'does not register an offense for `!x`' do
-      inspect_source(cop, '!x')
-      expect(cop.offenses).to be_empty
+      expect_no_offenses('!x')
     end
 
     it 'registers an offense for `not x.nil?`' do
@@ -136,8 +131,7 @@ describe RuboCop::Cop::Style::NonNilCheck, :config do
     end
 
     it 'does not blow up with ternary operators' do
-      inspect_source(cop, 'my_var.nil? ? 1 : 0')
-      expect(cop.offenses).to be_empty
+      expect_no_offenses('my_var.nil? ? 1 : 0')
     end
 
     it 'autocorrects by changing unless x.nil? to if x' do

--- a/spec/rubocop/cop/style/not_spec.rb
+++ b/spec/rubocop/cop/style/not_spec.rb
@@ -9,8 +9,7 @@ describe RuboCop::Cop::Style::Not, :config do
   end
 
   it 'does not register an offense for !' do
-    inspect_source(cop, '!test')
-    expect(cop.offenses).to be_empty
+    expect_no_offenses('!test')
   end
 
   it 'auto-corrects "not" with !' do

--- a/spec/rubocop/cop/style/numeric_literals_spec.rb
+++ b/spec/rubocop/cop/style/numeric_literals_spec.rb
@@ -17,11 +17,10 @@ describe RuboCop::Cop::Style::NumericLiterals, :config do
   end
 
   it 'accepts integers with less than three places at the end' do
-    inspect_source(cop, <<-END.strip_indent)
+    expect_no_offenses(<<-END.strip_indent)
       a = 123_456_789_00
       b = 819_2
     END
-    expect(cop.offenses).to be_empty
   end
 
   it 'registers an offense for an integer with misplaced underscore' do
@@ -60,12 +59,11 @@ describe RuboCop::Cop::Style::NumericLiterals, :config do
   end
 
   it 'ignores non-decimal literals' do
-    inspect_source(cop, <<-END.strip_indent)
+    expect_no_offenses(<<-END.strip_indent)
       a = 0b1010101010101
       b = 01717171717171
       c = 0xab11111111bb
     END
-    expect(cop.offenses).to be_empty
   end
 
   it 'autocorrects a long integer offense' do

--- a/spec/rubocop/cop/style/op_method_spec.rb
+++ b/spec/rubocop/cop/style/op_method_spec.rb
@@ -29,52 +29,47 @@ describe RuboCop::Cop::Style::OpMethod do
   end
 
   it 'does not register an offense for arg named other' do
-    inspect_source(cop, <<-END.strip_indent)
+    expect_no_offenses(<<-END.strip_indent)
       def +(other)
         other
       end
     END
-    expect(cop.offenses).to be_empty
   end
 
   it 'does not register an offense for arg named _other' do
-    inspect_source(cop, <<-END.strip_indent)
+    expect_no_offenses(<<-END.strip_indent)
       def <=>(_other)
         0
       end
     END
-    expect(cop.offenses).to be_empty
   end
 
   it 'does not register an offense for []' do
-    inspect_source(cop, <<-END.strip_indent)
+    expect_no_offenses(<<-END.strip_indent)
       def [](index)
         other
       end
     END
-    expect(cop.offenses).to be_empty
   end
 
   it 'does not register an offense for []=' do
-    inspect_source(cop, <<-END.strip_indent)
+    expect_no_offenses(<<-END.strip_indent)
       def []=(index, value)
         other
       end
     END
-    expect(cop.offenses).to be_empty
   end
 
   it 'does not register an offense for <<' do
-    inspect_source(cop, <<-END.strip_indent)
+    expect_no_offenses(<<-END.strip_indent)
       def <<(cop)
         other
       end
     END
-    expect(cop.offenses).to be_empty
   end
 
   it 'does not register an offense for non binary operators' do
-    inspect_source(cop, <<-END.strip_indent)
+    expect_no_offenses(<<-END.strip_indent)
       def -@; end
                     # This + is not a unary operator. It can only be
                     # called with dot notation.
@@ -82,6 +77,5 @@ describe RuboCop::Cop::Style::OpMethod do
       def *(a, b); end # Quite strange, but legal ruby.
       def `(cmd); end
     END
-    expect(cop.offenses).to be_empty
   end
 end

--- a/spec/rubocop/cop/style/parentheses_around_condition_spec.rb
+++ b/spec/rubocop/cop/style/parentheses_around_condition_spec.rb
@@ -28,11 +28,10 @@ describe RuboCop::Cop::Style::ParenthesesAroundCondition, :config do
   end
 
   it 'accepts parentheses if there is no space between the keyword and (.' do
-    inspect_source(cop, <<-END.strip_indent)
+    expect_no_offenses(<<-END.strip_indent)
       if(x > 5) then something end
       do_something until(x > 5)
     END
-    expect(cop.offenses).to be_empty
   end
 
   it 'auto-corrects parentheses around condition' do
@@ -69,7 +68,7 @@ describe RuboCop::Cop::Style::ParenthesesAroundCondition, :config do
   end
 
   it 'accepts condition without parentheses' do
-    inspect_source(cop, <<-END.strip_indent)
+    expect_no_offenses(<<-END.strip_indent)
       if x > 10
       end
       unless x > 10
@@ -83,7 +82,6 @@ describe RuboCop::Cop::Style::ParenthesesAroundCondition, :config do
       x += 1 while x < 10
       x += 1 until x < 10
     END
-    expect(cop.offenses).to be_empty
   end
 
   it 'accepts parentheses around condition in a ternary' do
@@ -95,11 +93,10 @@ describe RuboCop::Cop::Style::ParenthesesAroundCondition, :config do
   end
 
   it 'is not confused by unbalanced parentheses' do
-    inspect_source(cop, <<-END.strip_indent)
+    expect_no_offenses(<<-END.strip_indent)
       if (a + b).c()
       end
     END
-    expect(cop.offenses).to be_empty
   end
 
   %w[rescue if unless while until].each do |op|
@@ -118,44 +115,39 @@ describe RuboCop::Cop::Style::ParenthesesAroundCondition, :config do
   end
 
   it 'does not blow up for empty if condition' do
-    inspect_source(cop, <<-END.strip_indent)
+    expect_no_offenses(<<-END.strip_indent)
       if ()
       end
     END
-    expect(cop.offenses).to be_empty
   end
 
   it 'does not blow up for empty unless condition' do
-    inspect_source(cop, <<-END.strip_indent)
+    expect_no_offenses(<<-END.strip_indent)
       unless ()
       end
     END
-    expect(cop.offenses).to be_empty
   end
 
   context 'safe assignment is allowed' do
     it 'accepts variable assignment in condition surrounded with parentheses' do
-      inspect_source(cop, <<-END.strip_indent)
+      expect_no_offenses(<<-END.strip_indent)
         if (test = 10)
         end
       END
-      expect(cop.offenses).to be_empty
     end
 
     it 'accepts element assignment in condition surrounded with parentheses' do
-      inspect_source(cop, <<-END.strip_indent)
+      expect_no_offenses(<<-END.strip_indent)
         if (test[0] = 10)
         end
       END
-      expect(cop.offenses).to be_empty
     end
 
     it 'accepts setter in condition surrounded with parentheses' do
-      inspect_source(cop, <<-END.strip_indent)
+      expect_no_offenses(<<-END.strip_indent)
         if (self.test = 10)
         end
       END
-      expect(cop.offenses).to be_empty
     end
   end
 

--- a/spec/rubocop/cop/style/parentheses_around_condition_spec.rb
+++ b/spec/rubocop/cop/style/parentheses_around_condition_spec.rb
@@ -87,13 +87,11 @@ describe RuboCop::Cop::Style::ParenthesesAroundCondition, :config do
   end
 
   it 'accepts parentheses around condition in a ternary' do
-    inspect_source(cop, '(a == 0) ? b : a')
-    expect(cop.offenses).to be_empty
+    expect_no_offenses('(a == 0) ? b : a')
   end
 
   it 'is not confused by leading parentheses in subexpression' do
-    inspect_source(cop, '(a > b) && other ? one : two')
-    expect(cop.offenses).to be_empty
+    expect_no_offenses('(a > b) && other ? one : two')
   end
 
   it 'is not confused by unbalanced parentheses' do

--- a/spec/rubocop/cop/style/percent_literal_delimiters_spec.rb
+++ b/spec/rubocop/cop/style/percent_literal_delimiters_spec.rb
@@ -18,13 +18,11 @@ describe RuboCop::Cop::Style::PercentLiteralDelimiters, :config do
     end
 
     it 'allows all preferred delimiters to be set with one key' do
-      inspect_source(cop, '%w[string] + %i[string]')
-      expect(cop.offenses).to be_empty
+      expect_no_offenses('%w[string] + %i[string]')
     end
 
     it 'allows individual preferred delimiters to override `default`' do
-      inspect_source(cop, '%w[string] + [%(string)]')
-      expect(cop.offenses).to be_empty
+      expect_no_offenses('%w[string] + [%(string)]')
     end
   end
 
@@ -38,8 +36,7 @@ describe RuboCop::Cop::Style::PercentLiteralDelimiters, :config do
 
   context '`%` interpolated string' do
     it 'does not register an offense for preferred delimiters' do
-      inspect_source(cop, '%[string]')
-      expect(cop.offenses).to be_empty
+      expect_no_offenses('%[string]')
     end
 
     it 'registers an offense for other delimiters' do
@@ -64,8 +61,7 @@ describe RuboCop::Cop::Style::PercentLiteralDelimiters, :config do
 
   context '`%q` string' do
     it 'does not register an offense for preferred delimiters' do
-      inspect_source(cop, '%q[string]')
-      expect(cop.offenses).to be_empty
+      expect_no_offenses('%q[string]')
     end
 
     it 'registers an offense for other delimiters' do
@@ -84,8 +80,7 @@ describe RuboCop::Cop::Style::PercentLiteralDelimiters, :config do
 
   context '`%Q` interpolated string' do
     it 'does not register an offense for preferred delimiters' do
-      inspect_source(cop, '%Q[string]')
-      expect(cop.offenses).to be_empty
+      expect_no_offenses('%Q[string]')
     end
 
     it 'registers an offense for other delimiters' do
@@ -110,8 +105,7 @@ describe RuboCop::Cop::Style::PercentLiteralDelimiters, :config do
 
   context '`%w` string array' do
     it 'does not register an offense for preferred delimiters' do
-      inspect_source(cop, '%w[some words]')
-      expect(cop.offenses).to be_empty
+      expect_no_offenses('%w[some words]')
     end
 
     it 'registers an offense for other delimiters' do
@@ -130,8 +124,7 @@ describe RuboCop::Cop::Style::PercentLiteralDelimiters, :config do
 
   context '`%W` interpolated string array' do
     it 'does not register an offense for preferred delimiters' do
-      inspect_source(cop, '%W[some words]')
-      expect(cop.offenses).to be_empty
+      expect_no_offenses('%W[some words]')
     end
 
     it 'registers an offense for other delimiters' do
@@ -156,8 +149,7 @@ describe RuboCop::Cop::Style::PercentLiteralDelimiters, :config do
 
   context '`%r` interpolated regular expression' do
     it 'does not register an offense for preferred delimiters' do
-      inspect_source(cop, '%r[regexp]')
-      expect(cop.offenses).to be_empty
+      expect_no_offenses('%r[regexp]')
     end
 
     it 'registers an offense for other delimiters' do
@@ -182,8 +174,7 @@ describe RuboCop::Cop::Style::PercentLiteralDelimiters, :config do
 
   context '`%i` symbol array' do
     it 'does not register an offense for preferred delimiters' do
-      inspect_source(cop, '%i[some symbols]')
-      expect(cop.offenses).to be_empty
+      expect_no_offenses('%i[some symbols]')
     end
 
     it 'registers an offense for other delimiters' do
@@ -196,8 +187,7 @@ describe RuboCop::Cop::Style::PercentLiteralDelimiters, :config do
 
   context '`%I` interpolated symbol array' do
     it 'does not register an offense for preferred delimiters' do
-      inspect_source(cop, '%I[some words]')
-      expect(cop.offenses).to be_empty
+      expect_no_offenses('%I[some words]')
     end
 
     it 'registers an offense for other delimiters' do
@@ -218,8 +208,7 @@ describe RuboCop::Cop::Style::PercentLiteralDelimiters, :config do
 
   context '`%s` symbol' do
     it 'does not register an offense for preferred delimiters' do
-      inspect_source(cop, '%s[symbol]')
-      expect(cop.offenses).to be_empty
+      expect_no_offenses('%s[symbol]')
     end
 
     it 'registers an offense for other delimiters' do
@@ -232,8 +221,7 @@ describe RuboCop::Cop::Style::PercentLiteralDelimiters, :config do
 
   context '`%x` interpolated system call' do
     it 'does not register an offense for preferred delimiters' do
-      inspect_source(cop, '%x[command]')
-      expect(cop.offenses).to be_empty
+      expect_no_offenses('%x[command]')
     end
 
     it 'registers an offense for other delimiters' do

--- a/spec/rubocop/cop/style/percent_q_literals_spec.rb
+++ b/spec/rubocop/cop/style/percent_q_literals_spec.rb
@@ -5,26 +5,22 @@ describe RuboCop::Cop::Style::PercentQLiterals, :config do
 
   shared_examples 'accepts quote characters' do
     it 'accepts single quotes' do
-      inspect_source(cop, "'hi'")
-      expect(cop.offenses).to be_empty
+      expect_no_offenses("'hi'")
     end
 
     it 'accepts double quotes' do
-      inspect_source(cop, '"hi"')
-      expect(cop.offenses).to be_empty
+      expect_no_offenses('"hi"')
     end
   end
 
   shared_examples 'accepts any q string with backslash t' do
     context 'with special characters' do
       it 'accepts %q' do
-        inspect_source(cop, '%q(\t)')
-        expect(cop.offenses).to be_empty
+        expect_no_offenses('%q(\t)')
       end
 
       it 'accepts %Q' do
-        inspect_source(cop, '%Q(\t)')
-        expect(cop.offenses).to be_empty
+        expect_no_offenses('%Q(\t)')
       end
     end
   end
@@ -34,8 +30,7 @@ describe RuboCop::Cop::Style::PercentQLiterals, :config do
 
     context 'without interpolation' do
       it 'accepts %q' do
-        inspect_source(cop, '%q(hi)')
-        expect(cop.offenses).to be_empty
+        expect_no_offenses('%q(hi)')
       end
 
       it 'registers offense for %Q' do
@@ -56,14 +51,12 @@ describe RuboCop::Cop::Style::PercentQLiterals, :config do
 
     context 'with interpolation' do
       it 'accepts %Q' do
-        inspect_source(cop, '%Q(#{1 + 2})')
-        expect(cop.offenses).to be_empty
+        expect_no_offenses('%Q(#{1 + 2})')
       end
 
       it 'accepts %q' do
         # This is most probably a mistake, but not this cop's responsibility.
-        inspect_source(cop, '%q(#{1 + 2})')
-        expect(cop.offenses).to be_empty
+        expect_no_offenses('%q(#{1 + 2})')
       end
 
       include_examples 'accepts quote characters'
@@ -81,8 +74,7 @@ describe RuboCop::Cop::Style::PercentQLiterals, :config do
       end
 
       it 'accepts %Q' do
-        inspect_source(cop, '%Q(hi)')
-        expect(cop.offenses).to be_empty
+        expect_no_offenses('%Q(hi)')
       end
 
       it 'auto-corrects' do
@@ -96,16 +88,14 @@ describe RuboCop::Cop::Style::PercentQLiterals, :config do
 
     context 'with interpolation' do
       it 'accepts %Q' do
-        inspect_source(cop, '%Q(#{1 + 2})')
-        expect(cop.offenses).to be_empty
+        expect_no_offenses('%Q(#{1 + 2})')
       end
 
       it 'accepts %q' do
         # It's strange if interpolation syntax appears inside a static string,
         # but we can't be sure if it's a mistake or not. Changing it to %Q
         # would alter semantics, so we leave it as it is.
-        inspect_source(cop, '%q(#{1 + 2})')
-        expect(cop.offenses).to be_empty
+        expect_no_offenses('%q(#{1 + 2})')
       end
 
       it 'does not auto-correct' do

--- a/spec/rubocop/cop/style/predicate_name_spec.rb
+++ b/spec/rubocop/cop/style/predicate_name_spec.rb
@@ -23,12 +23,11 @@ describe RuboCop::Cop::Style::PredicateName, :config do
     end
 
     it 'accepts method name that starts with unknown prefix' do
-      inspect_source(cop, <<-END.strip_indent)
+      expect_no_offenses(<<-END.strip_indent)
         def have_attr
           # ...
         end
       END
-      expect(cop.offenses).to be_empty
     end
   end
 
@@ -52,12 +51,11 @@ describe RuboCop::Cop::Style::PredicateName, :config do
     end
 
     it 'accepts method name that starts with unknown prefix' do
-      inspect_source(cop, <<-END.strip_indent)
+      expect_no_offenses(<<-END.strip_indent)
         def have_attr
           # ...
         end
       END
-      expect(cop.offenses).to be_empty
     end
   end
 
@@ -68,12 +66,11 @@ describe RuboCop::Cop::Style::PredicateName, :config do
     end
 
     it 'accepts method name which is in whitelist' do
-      inspect_source(cop, <<-END.strip_indent)
+      expect_no_offenses(<<-END.strip_indent)
         def is_a?
           # ...
         end
       END
-      expect(cop.offenses).to be_empty
     end
   end
 end

--- a/spec/rubocop/cop/style/preferred_hash_methods_spec.rb
+++ b/spec/rubocop/cop/style/preferred_hash_methods_spec.rb
@@ -15,9 +15,7 @@ describe RuboCop::Cop::Style::PreferredHashMethods, :config do
     end
 
     it 'accepts has_key? with no args' do
-      inspect_source(cop,
-                     'o.has_key?')
-      expect(cop.offenses).to be_empty
+      expect_no_offenses('o.has_key?')
     end
 
     it 'registers an offense for has_value? with one arg' do
@@ -29,9 +27,7 @@ describe RuboCop::Cop::Style::PreferredHashMethods, :config do
     end
 
     it 'accepts has_value? with no args' do
-      inspect_source(cop,
-                     'o.has_value?')
-      expect(cop.offenses).to be_empty
+      expect_no_offenses('o.has_value?')
     end
 
     it 'auto-corrects has_key? with key?' do
@@ -57,9 +53,7 @@ describe RuboCop::Cop::Style::PreferredHashMethods, :config do
     end
 
     it 'accepts key? with no args' do
-      inspect_source(cop,
-                     'o.key?')
-      expect(cop.offenses).to be_empty
+      expect_no_offenses('o.key?')
     end
 
     it 'registers an offense for value? with one arg' do
@@ -71,9 +65,7 @@ describe RuboCop::Cop::Style::PreferredHashMethods, :config do
     end
 
     it 'accepts value? with no args' do
-      inspect_source(cop,
-                     'o.value?')
-      expect(cop.offenses).to be_empty
+      expect_no_offenses('o.value?')
     end
 
     it 'auto-corrects key? with has_key?' do

--- a/spec/rubocop/cop/style/proc_spec.rb
+++ b/spec/rubocop/cop/style/proc_spec.rb
@@ -9,13 +9,11 @@ describe RuboCop::Cop::Style::Proc do
   end
 
   it 'accepts the proc method' do
-    inspect_source(cop, 'f = proc { |x| puts x }')
-    expect(cop.offenses).to be_empty
+    expect_no_offenses('f = proc { |x| puts x }')
   end
 
   it 'accepts the Proc.new call outside of block' do
-    inspect_source(cop, 'p = Proc.new')
-    expect(cop.offenses).to be_empty
+    expect_no_offenses('p = Proc.new')
   end
 
   it 'auto-corrects Proc.new to proc' do

--- a/spec/rubocop/cop/style/raise_args_spec.rb
+++ b/spec/rubocop/cop/style/raise_args_spec.rb
@@ -67,13 +67,11 @@ describe RuboCop::Cop::Style::RaiseArgs, :config do
     end
 
     it 'accepts a raise with msg argument' do
-      inspect_source(cop, 'raise msg')
-      expect(cop.offenses).to be_empty
+      expect_no_offenses('raise msg')
     end
 
     it 'accepts a raise with an exception argument' do
-      inspect_source(cop, 'raise Ex.new(msg)')
-      expect(cop.offenses).to be_empty
+      expect_no_offenses('raise Ex.new(msg)')
     end
   end
 
@@ -148,33 +146,27 @@ describe RuboCop::Cop::Style::RaiseArgs, :config do
     end
 
     it 'accepts exception constructor with more than 1 argument' do
-      inspect_source(cop, 'raise MyCustomError.new(a1, a2, a3)')
-      expect(cop.offenses).to be_empty
+      expect_no_offenses('raise MyCustomError.new(a1, a2, a3)')
     end
 
     it 'accepts exception constructor with keyword arguments' do
-      inspect_source(cop, 'raise MyKwArgError.new(a: 1, b: 2)')
-      expect(cop.offenses).to be_empty
+      expect_no_offenses('raise MyKwArgError.new(a: 1, b: 2)')
     end
 
     it 'accepts a raise with splatted arguments' do
-      inspect_source(cop, 'raise MyCustomError.new(*args)')
-      expect(cop.offenses).to be_empty
+      expect_no_offenses('raise MyCustomError.new(*args)')
     end
 
     it 'accepts a raise with 3 args' do
-      inspect_source(cop, 'raise RuntimeError, msg, caller')
-      expect(cop.offenses).to be_empty
+      expect_no_offenses('raise RuntimeError, msg, caller')
     end
 
     it 'accepts a raise with 2 args' do
-      inspect_source(cop, 'raise RuntimeError, msg')
-      expect(cop.offenses).to be_empty
+      expect_no_offenses('raise RuntimeError, msg')
     end
 
     it 'accepts a raise with msg argument' do
-      inspect_source(cop, 'raise msg')
-      expect(cop.offenses).to be_empty
+      expect_no_offenses('raise msg')
     end
   end
 end

--- a/spec/rubocop/cop/style/redundant_freeze_spec.rb
+++ b/spec/rubocop/cop/style/redundant_freeze_spec.rb
@@ -39,8 +39,7 @@ describe RuboCop::Cop::Style::RedundantFreeze do
   it_behaves_like :mutable_objects, '"top#{1 + 2}"'
 
   it 'allows .freeze on  method call' do
-    inspect_source(cop, 'TOP_TEST = Something.new.freeze')
-    expect(cop.offenses).to be_empty
+    expect_no_offenses('TOP_TEST = Something.new.freeze')
   end
 
   context 'when the receiver is a frozen string literal' do

--- a/spec/rubocop/cop/style/redundant_parentheses_spec.rb
+++ b/spec/rubocop/cop/style/redundant_parentheses_spec.rb
@@ -230,13 +230,12 @@ describe RuboCop::Cop::Style::RedundantParentheses do
   end
 
   it 'accepts parentheses around the error passed to rescue' do
-    inspect_source(cop, <<-END.strip_indent)
+    expect_no_offenses(<<-END.strip_indent)
       begin
         some_method
       rescue(StandardError)
       end
     END
-    expect(cop.offenses).to be_empty
   end
 
   it 'accepts parentheses around a constant passed to when' do

--- a/spec/rubocop/cop/style/redundant_parentheses_spec.rb
+++ b/spec/rubocop/cop/style/redundant_parentheses_spec.rb
@@ -173,28 +173,23 @@ describe RuboCop::Cop::Style::RedundantParentheses do
   end
 
   it 'accepts parentheses inside an irange' do
-    inspect_source(cop, '(a)..(b)')
-    expect(cop.offenses).to be_empty
+    expect_no_offenses('(a)..(b)')
   end
 
   it 'accepts parentheses inside an erange' do
-    inspect_source(cop, '(a)...(b)')
-    expect(cop.offenses).to be_empty
+    expect_no_offenses('(a)...(b)')
   end
 
   it 'accepts parentheses around an irange' do
-    inspect_source(cop, '(a..b)')
-    expect(cop.offenses).to be_empty
+    expect_no_offenses('(a..b)')
   end
 
   it 'accepts parentheses around an erange' do
-    inspect_source(cop, '(a...b)')
-    expect(cop.offenses).to be_empty
+    expect_no_offenses('(a...b)')
   end
 
   it 'accepts parentheses around operator keywords' do
-    inspect_source(cop, '(1 and 2) and (3 or 4)')
-    expect(cop.offenses).to be_empty
+    expect_no_offenses('(1 and 2) and (3 or 4)')
   end
 
   it 'registers an offense when there is space around the parentheses' do
@@ -203,19 +198,16 @@ describe RuboCop::Cop::Style::RedundantParentheses do
   end
 
   it 'accepts parentheses when they touch the preceding keyword' do
-    inspect_source(cop, 'if x; y else(1) end')
-    expect(cop.offenses).to be_empty
+    expect_no_offenses('if x; y else(1) end')
   end
 
   it 'accepts parentheses when they touch the following keyword' do
-    inspect_source(cop, 'if x; y else (1)end')
-    expect(cop.offenses).to be_empty
+    expect_no_offenses('if x; y else (1)end')
   end
 
   context 'when a hash literal is the first argument in a method call' do
     it 'accepts parentheses if the argument list is not parenthesized ' do
-      inspect_source(cop, 'x ({ y: 1 }), z')
-      expect(cop.offenses).to be_empty
+      expect_no_offenses('x ({ y: 1 }), z')
     end
 
     it 'registers an offense if the argument list is parenthesized ' do
@@ -233,8 +225,7 @@ describe RuboCop::Cop::Style::RedundantParentheses do
 
   context 'when a non-parenthesized call has an arg and a block' do
     it 'accepts parens around the arg' do
-      inspect_source(cop, 'method (:arg) { blah }')
-      expect(cop.offenses).to be_empty
+      expect_no_offenses('method (:arg) { blah }')
     end
   end
 

--- a/spec/rubocop/cop/style/regexp_literal_spec.rb
+++ b/spec/rubocop/cop/style/regexp_literal_spec.rb
@@ -19,8 +19,7 @@ describe RuboCop::Cop::Style::RegexpLiteral, :config do
     let(:cop_config) { { 'EnforcedStyle' => 'slashes' } }
 
     it 'ignores the slashes that do not belong // regex' do
-      inspect_source(cop, 'x =~ /\s{#{x[/\s+/].length}}/')
-      expect(cop.offenses).to be_empty
+      expect_no_offenses('x =~ /\s{#{x[/\s+/].length}}/')
     end
   end
 

--- a/spec/rubocop/cop/style/rescue_modifier_spec.rb
+++ b/spec/rubocop/cop/style/rescue_modifier_spec.rb
@@ -57,18 +57,17 @@ describe RuboCop::Cop::Style::RescueModifier do
   end
 
   it 'does not register an offense for normal rescue' do
-    inspect_source(cop, <<-END.strip_indent)
+    expect_no_offenses(<<-END.strip_indent)
       begin
         test
       rescue
         handle
       end
     END
-    expect(cop.offenses).to be_empty
   end
 
   it 'does not register an offense for normal rescue with ensure' do
-    inspect_source(cop, <<-END.strip_indent)
+    expect_no_offenses(<<-END.strip_indent)
       begin
         test
       rescue
@@ -77,11 +76,10 @@ describe RuboCop::Cop::Style::RescueModifier do
         cleanup
       end
     END
-    expect(cop.offenses).to be_empty
   end
 
   it 'does not register an offense for nested normal rescue' do
-    inspect_source(cop, <<-END.strip_indent)
+    expect_no_offenses(<<-END.strip_indent)
       begin
         begin
           test
@@ -92,19 +90,17 @@ describe RuboCop::Cop::Style::RescueModifier do
         handle_outer
       end
     END
-    expect(cop.offenses).to be_empty
   end
 
   context 'when an instance method has implicit begin' do
     it 'accepts normal rescue' do
-      inspect_source(cop, <<-END.strip_indent)
+      expect_no_offenses(<<-END.strip_indent)
         def some_method
           test
         rescue
           handle
         end
       END
-      expect(cop.offenses).to be_empty
     end
 
     it 'handles modifier rescue in body of implicit begin' do
@@ -123,14 +119,13 @@ describe RuboCop::Cop::Style::RescueModifier do
 
   context 'when a singleton method has implicit begin' do
     it 'accepts normal rescue' do
-      inspect_source(cop, <<-END.strip_indent)
+      expect_no_offenses(<<-END.strip_indent)
         def self.some_method
           test
         rescue
           handle
         end
       END
-      expect(cop.offenses).to be_empty
     end
 
     it 'handles modifier rescue in body of implicit begin' do

--- a/spec/rubocop/cop/style/safe_navigation_spec.rb
+++ b/spec/rubocop/cop/style/safe_navigation_spec.rb
@@ -6,21 +6,15 @@ describe RuboCop::Cop::Style::SafeNavigation, :config do
 
   context 'target_ruby_version > 2.3', :ruby23 do
     it 'allows calls to methods not safeguarded by respond_to' do
-      inspect_source(cop, 'foo.bar')
-
-      expect(cop.offenses).to be_empty
+      expect_no_offenses('foo.bar')
     end
 
     it 'allows calls using safe navigation' do
-      inspect_source(cop, 'foo&.bar')
-
-      expect(cop.offenses).to be_empty
+      expect_no_offenses('foo&.bar')
     end
 
     it 'allows calls on nil' do
-      inspect_source(cop, 'nil&.bar')
-
-      expect(cop.offenses).to be_empty
+      expect_no_offenses('nil&.bar')
     end
 
     it 'allows method calls that nil responds to safe guarded by ' \
@@ -472,9 +466,7 @@ describe RuboCop::Cop::Style::SafeNavigation, :config do
 
     context 'respond_to?' do
       it 'allows method calls safeguarded by a respond_to check' do
-        inspect_source(cop, 'foo.bar if foo.respond_to?(:bar)')
-
-        expect(cop.offenses).to be_empty
+        expect_no_offenses('foo.bar if foo.respond_to?(:bar)')
       end
 
       it 'allows method calls safeguarded by a respond_to check to a ' \
@@ -947,9 +939,7 @@ describe RuboCop::Cop::Style::SafeNavigation, :config do
 
   context 'target_ruby_version < 2.3', :ruby19 do
     it 'allows a method call safeguarded by a check for the variable' do
-      inspect_source(cop, 'foo.bar if foo')
-
-      expect(cop.offenses).to be_empty
+      expect_no_offenses('foo.bar if foo')
     end
   end
 end

--- a/spec/rubocop/cop/style/semicolon_spec.rb
+++ b/spec/rubocop/cop/style/semicolon_spec.rb
@@ -31,33 +31,30 @@ describe RuboCop::Cop::Style::Semicolon, :config do
   end
 
   it 'accepts one line method definitions' do
-    inspect_source(cop, <<-END.strip_indent)
+    expect_no_offenses(<<-END.strip_indent)
       def foo1; x(3) end
       def initialize(*_); end
       def foo2() x(3); end
       def foo3; x(3); end
     END
-    expect(cop.offenses).to be_empty
   end
 
   it 'accepts one line empty class definitions' do
-    inspect_source(cop, <<-END.strip_indent)
+    expect_no_offenses(<<-END.strip_indent)
       # Prefer a single-line format for class ...
       class Foo < Exception; end
 
       class Bar; end
     END
-    expect(cop.offenses).to be_empty
   end
 
   it 'accepts one line empty method definitions' do
-    inspect_source(cop, <<-END.strip_indent)
+    expect_no_offenses(<<-END.strip_indent)
       # One exception to the rule are empty-body methods
       def no_op; end
 
       def foo; end
     END
-    expect(cop.offenses).to be_empty
   end
 
   it 'accepts one line empty module definitions' do
@@ -71,11 +68,10 @@ describe RuboCop::Cop::Style::Semicolon, :config do
   end
 
   it 'accept semicolons inside strings' do
-    inspect_source(cop, <<-END.strip_indent)
+    expect_no_offenses(<<-END.strip_indent)
       string = ";
       multi-line string"
     END
-    expect(cop.offenses).to be_empty
   end
 
   it 'registers an offense for a semicolon at the beginning of a line' do

--- a/spec/rubocop/cop/style/semicolon_spec.rb
+++ b/spec/rubocop/cop/style/semicolon_spec.rb
@@ -23,15 +23,11 @@ describe RuboCop::Cop::Style::Semicolon, :config do
   end
 
   it 'accepts semicolon before end if so configured' do
-    inspect_source(cop,
-                   'def foo(a) z(3); end')
-    expect(cop.offenses).to be_empty
+    expect_no_offenses('def foo(a) z(3); end')
   end
 
   it 'accepts semicolon after params if so configured' do
-    inspect_source(cop,
-                   'def foo(a); z(3) end')
-    expect(cop.offenses).to be_empty
+    expect_no_offenses('def foo(a); z(3) end')
   end
 
   it 'accepts one line method definitions' do
@@ -65,9 +61,7 @@ describe RuboCop::Cop::Style::Semicolon, :config do
   end
 
   it 'accepts one line empty module definitions' do
-    inspect_source(cop,
-                   'module Foo; end')
-    expect(cop.offenses).to be_empty
+    expect_no_offenses('module Foo; end')
   end
 
   it 'registers an offense for semicolon at the end no matter what' do
@@ -112,15 +106,11 @@ describe RuboCop::Cop::Style::Semicolon, :config do
     let(:cop_config) { { 'AllowAsExpressionSeparator' => true } }
 
     it 'accepts several expressions' do
-      inspect_source(cop,
-                     'puts "this is a test"; puts "So is this"')
-      expect(cop.offenses).to be_empty
+      expect_no_offenses('puts "this is a test"; puts "So is this"')
     end
 
     it 'accepts one line method with two statements' do
-      inspect_source(cop,
-                     'def foo(a) x(1); y(2); z(3); end')
-      expect(cop.offenses).to be_empty
+      expect_no_offenses('def foo(a) x(1); y(2); z(3); end')
     end
   end
 end

--- a/spec/rubocop/cop/style/send_spec.rb
+++ b/spec/rubocop/cop/style/send_spec.rb
@@ -11,8 +11,7 @@ describe RuboCop::Cop::Style::Send do
       end
 
       it 'does not register an offense for an invocation without args' do
-        inspect_source(cop, 'Object.send')
-        expect(cop.offenses).to be_empty
+        expect_no_offenses('Object.send')
       end
     end
 
@@ -23,8 +22,7 @@ describe RuboCop::Cop::Style::Send do
       end
 
       it 'does not register an offense for an invocation without args' do
-        inspect_source(cop, 'send')
-        expect(cop.offenses).to be_empty
+        expect_no_offenses('send')
       end
     end
   end

--- a/spec/rubocop/cop/style/signal_exception_spec.rb
+++ b/spec/rubocop/cop/style/signal_exception_spec.rb
@@ -46,18 +46,17 @@ describe RuboCop::Cop::Style::SignalException, :config do
     end
 
     it 'accepts raise in rescue section' do
-      inspect_source(cop, <<-END.strip_indent)
+      expect_no_offenses(<<-END.strip_indent)
         begin
           fail
         rescue Exception
           raise RuntimeError
         end
       END
-      expect(cop.offenses).to be_empty
     end
 
     it 'accepts raise in def with multiple rescues' do
-      inspect_source(cop, <<-END.strip_indent)
+      expect_no_offenses(<<-END.strip_indent)
         def test
           fail
         rescue StandardError
@@ -66,7 +65,6 @@ describe RuboCop::Cop::Style::SignalException, :config do
           raise
         end
       END
-      expect(cop.offenses).to be_empty
     end
 
     it 'registers an offense for fail in def rescue section' do
@@ -108,25 +106,23 @@ describe RuboCop::Cop::Style::SignalException, :config do
     end
 
     it 'accepts raise in def rescue section' do
-      inspect_source(cop, <<-END.strip_indent)
+      expect_no_offenses(<<-END.strip_indent)
         def test
           fail
         rescue Exception
           raise
         end
       END
-      expect(cop.offenses).to be_empty
     end
 
     it 'accepts `raise` and `fail` with explicit receiver' do
-      inspect_source(cop, <<-END.strip_indent)
+      expect_no_offenses(<<-END.strip_indent)
         def test
           test.raise
         rescue Exception
           test.fail
         end
       END
-      expect(cop.offenses).to be_empty
     end
 
     it 'registers an offense for `raise` and `fail` with `Kernel` as ' \
@@ -264,7 +260,7 @@ describe RuboCop::Cop::Style::SignalException, :config do
     end
 
     it 'accepts `fail` if a custom `fail` instance method is defined' do
-      inspect_source(cop, <<-END.strip_indent)
+      expect_no_offenses(<<-END.strip_indent)
         class A
           def fail(arg)
           end
@@ -273,11 +269,10 @@ describe RuboCop::Cop::Style::SignalException, :config do
           end
         end
       END
-      expect(cop.offenses).to be_empty
     end
 
     it 'accepts `fail` if a custom `fail` singleton method is defined' do
-      inspect_source(cop, <<-END.strip_indent)
+      expect_no_offenses(<<-END.strip_indent)
         class A
           def self.fail(arg)
           end
@@ -286,7 +281,6 @@ describe RuboCop::Cop::Style::SignalException, :config do
           end
         end
       END
-      expect(cop.offenses).to be_empty
     end
 
     it 'accepts `fail` with explicit receiver' do

--- a/spec/rubocop/cop/style/signal_exception_spec.rb
+++ b/spec/rubocop/cop/style/signal_exception_spec.rb
@@ -290,8 +290,7 @@ describe RuboCop::Cop::Style::SignalException, :config do
     end
 
     it 'accepts `fail` with explicit receiver' do
-      inspect_source(cop, 'test.fail')
-      expect(cop.offenses).to be_empty
+      expect_no_offenses('test.fail')
     end
 
     it 'registers an offense for `fail` with `Kernel` as explicit receiver' do
@@ -362,8 +361,7 @@ describe RuboCop::Cop::Style::SignalException, :config do
     end
 
     it 'accepts `raise` with explicit receiver' do
-      inspect_source(cop, 'test.raise')
-      expect(cop.offenses).to be_empty
+      expect_no_offenses('test.raise')
     end
 
     it 'registers an offense for `raise` with `Kernel` as explicit receiver' do

--- a/spec/rubocop/cop/style/single_line_block_params_spec.rb
+++ b/spec/rubocop/cop/style/single_line_block_params_spec.rb
@@ -42,9 +42,7 @@ describe RuboCop::Cop::Style::SingleLineBlockParams, :config do
   end
 
   it 'allows an unused parameter to have a leading underscore' do
-    inspect_source(cop,
-                   'File.foreach(filename).reduce(0) { |a, _e| a + 1 }')
-    expect(cop.offenses).to be_empty
+    expect_no_offenses('File.foreach(filename).reduce(0) { |a, _e| a + 1 }')
   end
 
   it 'finds incorrectly named parameters with leading underscores' do

--- a/spec/rubocop/cop/style/single_line_block_params_spec.rb
+++ b/spec/rubocop/cop/style/single_line_block_params_spec.rb
@@ -27,7 +27,7 @@ describe RuboCop::Cop::Style::SingleLineBlockParams, :config do
   end
 
   it 'allows calls with proper argument names' do
-    inspect_source(cop, <<-END.strip_indent)
+    expect_no_offenses(<<-END.strip_indent)
       def m
         [0, 1].reduce { |a, e| a + e }
         [0, 1].reduce{ |a, e| a + e }
@@ -38,7 +38,6 @@ describe RuboCop::Cop::Style::SingleLineBlockParams, :config do
         ala.test { |x, y| bala }
       end
     END
-    expect(cop.offenses).to be_empty
   end
 
   it 'allows an unused parameter to have a leading underscore' do
@@ -52,40 +51,36 @@ describe RuboCop::Cop::Style::SingleLineBlockParams, :config do
   end
 
   it 'ignores do..end blocks' do
-    inspect_source(cop, <<-END.strip_indent)
+    expect_no_offenses(<<-END.strip_indent)
       def m
         [0, 1].reduce do |c, d|
           c + d
         end
       end
     END
-    expect(cop.offenses).to be_empty
   end
 
   it 'ignores :reduce symbols' do
-    inspect_source(cop, <<-END.strip_indent)
+    expect_no_offenses(<<-END.strip_indent)
       def m
         call_method(:reduce) { |a, b| a + b}
       end
     END
-    expect(cop.offenses).to be_empty
   end
 
   it 'does not report when destructuring is used' do
-    inspect_source(cop, <<-END.strip_indent)
+    expect_no_offenses(<<-END.strip_indent)
       def m
         test.reduce { |a, (id, _)| a + id}
       end
     END
-    expect(cop.offenses).to be_empty
   end
 
   it 'does not report if no block arguments are present' do
-    inspect_source(cop, <<-END.strip_indent)
+    expect_no_offenses(<<-END.strip_indent)
       def m
         test.reduce { true }
       end
     END
-    expect(cop.offenses).to be_empty
   end
 end

--- a/spec/rubocop/cop/style/single_line_methods_spec.rb
+++ b/spec/rubocop/cop/style/single_line_methods_spec.rb
@@ -42,30 +42,27 @@ describe RuboCop::Cop::Style::SingleLineMethods do
     let(:cop_config) { { 'AllowIfMethodIsEmpty' => true } }
 
     it 'accepts a single-line empty method' do
-      inspect_source(cop, <<-END.strip_indent)
+      expect_no_offenses(<<-END.strip_indent)
         def no_op; end
         def self.resource_class=(klass); end
         def @table.columns; end
       END
-      expect(cop.offenses).to be_empty
     end
   end
 
   it 'accepts a multi-line method' do
-    inspect_source(cop, <<-END.strip_indent)
+    expect_no_offenses(<<-END.strip_indent)
       def some_method
         body
       end
     END
-    expect(cop.offenses).to be_empty
   end
 
   it 'does not crash on an method with a capitalized name' do
-    inspect_source(cop, <<-END.strip_indent)
+    expect_no_offenses(<<-END.strip_indent)
       def NoSnakeCase
       end
     END
-    expect(cop.offenses).to be_empty
   end
 
   it 'auto-corrects def with semicolon after method name' do

--- a/spec/rubocop/cop/style/special_global_vars_spec.rb
+++ b/spec/rubocop/cop/style/special_global_vars_spec.rb
@@ -43,8 +43,7 @@ describe RuboCop::Cop::Style::SpecialGlobalVars, :config do
     end
 
     it 'does not register an offense for backrefs like $1' do
-      inspect_source(cop, 'puts $1')
-      expect(cop.offenses).to be_empty
+      expect_no_offenses('puts $1')
     end
 
     it 'auto-corrects $: to $LOAD_PATH' do
@@ -116,8 +115,7 @@ describe RuboCop::Cop::Style::SpecialGlobalVars, :config do
     end
 
     it 'does not register an offense for backrefs like $1' do
-      inspect_source(cop, 'puts $1')
-      expect(cop.offenses).to be_empty
+      expect_no_offenses('puts $1')
     end
 
     it 'auto-corrects $LOAD_PATH to $:' do

--- a/spec/rubocop/cop/style/stabby_lambda_parentheses_spec.rb
+++ b/spec/rubocop/cop/style/stabby_lambda_parentheses_spec.rb
@@ -5,18 +5,15 @@ describe RuboCop::Cop::Style::StabbyLambdaParentheses, :config do
 
   shared_examples 'common' do
     it 'does not check the old lambda syntax' do
-      inspect_source(cop, 'lambda(&:nil?)')
-      expect(cop.offenses).to be_empty
+      expect_no_offenses('lambda(&:nil?)')
     end
 
     it 'does not check a stabby lambda without arguments' do
-      inspect_source(cop, '-> { true }')
-      expect(cop.offenses).to be_empty
+      expect_no_offenses('-> { true }')
     end
 
     it 'does not check a method call named lambda' do
-      inspect_source(cop, 'o.lambda')
-      expect(cop.offenses).to be_empty
+      expect_no_offenses('o.lambda')
     end
   end
 
@@ -33,8 +30,7 @@ describe RuboCop::Cop::Style::StabbyLambdaParentheses, :config do
     end
 
     it 'does not register an offense for a stabby lambda with parentheses' do
-      inspect_source(cop, '->(a,b,c) { a + b + c }')
-      expect(cop.offenses).to be_empty
+      expect_no_offenses('->(a,b,c) { a + b + c }')
     end
 
     it 'autocorrects when a stabby lambda has no parentheses' do

--- a/spec/rubocop/cop/style/string_literals_spec.rb
+++ b/spec/rubocop/cop/style/string_literals_spec.rb
@@ -32,23 +32,19 @@ describe RuboCop::Cop::Style::StringLiterals, :config do
     end
 
     it 'accepts single quotes' do
-      inspect_source(cop, "a = 'x'")
-      expect(cop.offenses).to be_empty
+      expect_no_offenses("a = 'x'")
     end
 
     it 'accepts single quotes in interpolation' do
-      inspect_source(cop, %q("hello#{hash['there']}"))
-      expect(cop.offenses).to be_empty
+      expect_no_offenses(%q("hello#{hash['there']}"))
     end
 
     it 'accepts %q and %Q quotes' do
-      inspect_source(cop, 'a = %q(x) + %Q[x]')
-      expect(cop.offenses).to be_empty
+      expect_no_offenses('a = %q(x) + %Q[x]')
     end
 
     it 'accepts % quotes' do
-      inspect_source(cop, 'a = %(x)')
-      expect(cop.offenses).to be_empty
+      expect_no_offenses('a = %(x)')
     end
 
     it 'accepts heredocs' do
@@ -61,8 +57,7 @@ describe RuboCop::Cop::Style::StringLiterals, :config do
     end
 
     it 'accepts double quotes when new line is used' do
-      inspect_source(cop, '"\n"')
-      expect(cop.offenses).to be_empty
+      expect_no_offenses('"\n"')
     end
 
     it 'accepts double quotes when interpolating & quotes in multiple lines' do
@@ -72,38 +67,31 @@ describe RuboCop::Cop::Style::StringLiterals, :config do
     end
 
     it 'accepts double quotes when single quotes are used' do
-      inspect_source(cop, '"\'"')
-      expect(cop.offenses).to be_empty
+      expect_no_offenses('"\'"')
     end
 
     it 'accepts double quotes when interpolating an instance variable' do
-      inspect_source(cop, '"#@test"')
-      expect(cop.offenses).to be_empty
+      expect_no_offenses('"#@test"')
     end
 
     it 'accepts double quotes when interpolating a global variable' do
-      inspect_source(cop, '"#$test"')
-      expect(cop.offenses).to be_empty
+      expect_no_offenses('"#$test"')
     end
 
     it 'accepts double quotes when interpolating a class variable' do
-      inspect_source(cop, '"#@@test"')
-      expect(cop.offenses).to be_empty
+      expect_no_offenses('"#@@test"')
     end
 
     it 'accepts double quotes when control characters are used' do
-      inspect_source(cop, '"\e"')
-      expect(cop.offenses).to be_empty
+      expect_no_offenses('"\e"')
     end
 
     it 'accepts double quotes when unicode control sequence is used' do
-      inspect_source(cop, '"Espa\u00f1a"')
-      expect(cop.offenses).to be_empty
+      expect_no_offenses('"Espa\u00f1a"')
     end
 
     it 'accepts double quotes at the start of regexp literals' do
-      inspect_source(cop, 's = /"((?:[^\\"]|\\.)*)"/')
-      expect(cop.offenses).to be_empty
+      expect_no_offenses('s = /"((?:[^\\"]|\\.)*)"/')
     end
 
     it 'accepts double quotes with some other special symbols' do
@@ -116,13 +104,11 @@ describe RuboCop::Cop::Style::StringLiterals, :config do
     end
 
     it 'accepts " in a %w' do
-      inspect_source(cop, '%w(")')
-      expect(cop.offenses).to be_empty
+      expect_no_offenses('%w(")')
     end
 
     it 'accepts \\\\\n in a string' do # this would be: "\\\n"
-      inspect_source(cop, '"foo \\\\\n bar"')
-      expect(cop.offenses).to be_empty
+      expect_no_offenses('"foo \\\\\n bar"')
     end
 
     it 'accepts double quotes in interpolation' do
@@ -213,23 +199,19 @@ describe RuboCop::Cop::Style::StringLiterals, :config do
     end
 
     it 'accepts double quotes' do
-      inspect_source(cop, 'a = "x"')
-      expect(cop.offenses).to be_empty
+      expect_no_offenses('a = "x"')
     end
 
     it 'accepts single quotes in interpolation' do
-      inspect_source(cop, %q("hello#{hash['there']}"))
-      expect(cop.offenses).to be_empty
+      expect_no_offenses(%q("hello#{hash['there']}"))
     end
 
     it 'accepts %q and %Q quotes' do
-      inspect_source(cop, 'a = %q(x) + %Q[x]')
-      expect(cop.offenses).to be_empty
+      expect_no_offenses('a = %q(x) + %Q[x]')
     end
 
     it 'accepts % quotes' do
-      inspect_source(cop, 'a = %(x)')
-      expect(cop.offenses).to be_empty
+      expect_no_offenses('a = %(x)')
     end
 
     it 'accepts heredocs' do
@@ -255,13 +237,11 @@ describe RuboCop::Cop::Style::StringLiterals, :config do
     end
 
     it 'accepts single quotes at the start of regexp literals' do
-      inspect_source(cop, "s = /'((?:[^\\']|\\.)*)'/")
-      expect(cop.offenses).to be_empty
+      expect_no_offenses("s = /'((?:[^\\']|\\.)*)'/")
     end
 
     it "accepts ' in a %w" do
-      inspect_source(cop, "%w(')")
-      expect(cop.offenses).to be_empty
+      expect_no_offenses("%w(')")
     end
 
     it 'can handle a built-in constant parsed as string' do

--- a/spec/rubocop/cop/style/struct_inheritance_spec.rb
+++ b/spec/rubocop/cop/style/struct_inheritance_spec.rb
@@ -36,7 +36,6 @@ describe RuboCop::Cop::Style::StructInheritance do
   end
 
   it 'accepts assignment to Struct.new' do
-    inspect_source(cop, 'Person = Struct.new(:first_name, :last_name)')
-    expect(cop.offenses).to be_empty
+    expect_no_offenses('Person = Struct.new(:first_name, :last_name)')
   end
 end

--- a/spec/rubocop/cop/style/struct_inheritance_spec.rb
+++ b/spec/rubocop/cop/style/struct_inheritance_spec.rb
@@ -20,19 +20,17 @@ describe RuboCop::Cop::Style::StructInheritance do
   end
 
   it 'accepts plain class' do
-    inspect_source(cop, <<-END.strip_indent)
+    expect_no_offenses(<<-END.strip_indent)
       class Person
       end
     END
-    expect(cop.offenses).to be_empty
   end
 
   it 'accepts extending DelegateClass' do
-    inspect_source(cop, <<-END.strip_indent)
+    expect_no_offenses(<<-END.strip_indent)
       class Person < DelegateClass(Animal)
       end
     END
-    expect(cop.offenses).to be_empty
   end
 
   it 'accepts assignment to Struct.new' do

--- a/spec/rubocop/cop/style/symbol_array_spec.rb
+++ b/spec/rubocop/cop/style/symbol_array_spec.rb
@@ -53,23 +53,19 @@ describe RuboCop::Cop::Style::SymbolArray, :config do
     end
 
     it 'does not register an offense for array with non-syms' do
-      inspect_source(cop, '[:one, :two, "three"]')
-      expect(cop.offenses).to be_empty
+      expect_no_offenses('[:one, :two, "three"]')
     end
 
     it 'does not register an offense for array starting with %i' do
-      inspect_source(cop, '%i(one two three)')
-      expect(cop.offenses).to be_empty
+      expect_no_offenses('%i(one two three)')
     end
 
     it 'does not register an offense for array with one element' do
-      inspect_source(cop, '[:three]')
-      expect(cop.offenses).to be_empty
+      expect_no_offenses('[:three]')
     end
 
     it 'does not register an offense if symbol contains whitespace' do
-      inspect_source(cop, '[:one, :two, :"space here"]')
-      expect(cop.offenses).to be_empty
+      expect_no_offenses('[:one, :two, :"space here"]')
     end
 
     it 'detects right value for MinSize to use for --auto-gen-config' do
@@ -96,8 +92,7 @@ describe RuboCop::Cop::Style::SymbolArray, :config do
 
     context 'Ruby 1.9', :ruby19 do
       it 'accepts arrays of smybols' do
-        inspect_source(cop, '[:one, :two, :three]')
-        expect(cop.offenses).to be_empty
+        expect_no_offenses('[:one, :two, :three]')
       end
     end
 
@@ -124,8 +119,7 @@ describe RuboCop::Cop::Style::SymbolArray, :config do
     let(:cop_config) { { 'EnforcedStyle' => 'brackets', 'MinSize' => 0 } }
 
     it 'does not register an offense for arrays of symbols' do
-      inspect_source(cop, '[:one, :two, :three]')
-      expect(cop.offenses).to be_empty
+      expect_no_offenses('[:one, :two, :three]')
     end
 
     it 'registers an offense for array starting with %i' do

--- a/spec/rubocop/cop/style/symbol_proc_spec.rb
+++ b/spec/rubocop/cop/style/symbol_proc_spec.rb
@@ -22,69 +22,47 @@ describe RuboCop::Cop::Style::SymbolProc, :config do
   end
 
   it 'accepts block with more than 1 arguments' do
-    inspect_source(cop, 'something { |x, y| x.method }')
-
-    expect(cop.offenses).to be_empty
+    expect_no_offenses('something { |x, y| x.method }')
   end
 
   it 'accepts lambda with 1 argument' do
-    inspect_source(cop, '->(x) { x.method }')
-
-    expect(cop.offenses).to be_empty
+    expect_no_offenses('->(x) { x.method }')
   end
 
   it 'accepts proc with 1 argument' do
-    inspect_source(cop, 'proc { |x| x.method }')
-
-    expect(cop.offenses).to be_empty
+    expect_no_offenses('proc { |x| x.method }')
   end
 
   it 'accepts Proc.new with 1 argument' do
-    inspect_source(cop, 'Proc.new { |x| x.method }')
-
-    expect(cop.offenses).to be_empty
+    expect_no_offenses('Proc.new { |x| x.method }')
   end
 
   it 'accepts ignored method' do
-    inspect_source(cop, 'respond_to { |format| format.xml }')
-
-    expect(cop.offenses).to be_empty
+    expect_no_offenses('respond_to { |format| format.xml }')
   end
 
   it 'accepts block with no arguments' do
-    inspect_source(cop, 'something { x.method }')
-
-    expect(cop.offenses).to be_empty
+    expect_no_offenses('something { x.method }')
   end
 
   it 'accepts empty block body' do
-    inspect_source(cop, 'something { |x| }')
-
-    expect(cop.offenses).to be_empty
+    expect_no_offenses('something { |x| }')
   end
 
   it 'accepts block with more than 1 expression in body' do
-    inspect_source(cop, 'something { |x| x.method; something_else }')
-
-    expect(cop.offenses).to be_empty
+    expect_no_offenses('something { |x| x.method; something_else }')
   end
 
   it 'accepts block when method in body is not called on block arg' do
-    inspect_source(cop, 'something { |x| y.method }')
-
-    expect(cop.offenses).to be_empty
+    expect_no_offenses('something { |x| y.method }')
   end
 
   it 'accepts block with a block argument ' do
-    inspect_source(cop, 'something { |&x| x.call }')
-
-    expect(cop.offenses).to be_empty
+    expect_no_offenses('something { |&x| x.call }')
   end
 
   it 'accepts block with splat params' do
-    inspect_source(cop, 'something { |*x| x.first }')
-
-    expect(cop.offenses).to be_empty
+    expect_no_offenses('something { |*x| x.first }')
   end
 
   context 'when the method has arguments' do

--- a/spec/rubocop/cop/style/trailing_comma_in_arguments_spec.rb
+++ b/spec/rubocop/cop/style/trailing_comma_in_arguments_spec.rb
@@ -36,11 +36,10 @@ describe RuboCop::Cop::Style::TrailingCommaInArguments, :config do
     end
 
     it 'accepts chained single-line method calls' do
-      inspect_source(cop, <<-END.strip_indent)
+      expect_no_offenses(<<-END.strip_indent)
         target
           .some_method(a)
       END
-      expect(cop.offenses).to be_empty
     end
 
     it 'auto-corrects unwanted comma in a method call' do
@@ -103,14 +102,13 @@ describe RuboCop::Cop::Style::TrailingCommaInArguments, :config do
       end
 
       it 'accepts comma inside a heredoc parameter at the end' do
-        inspect_source(cop, <<-END.strip_indent)
+        expect_no_offenses(<<-END.strip_indent)
           route(help: {
             'auth' => <<-HELP.chomp
           ,
           HELP
           })
         END
-        expect(cop.offenses).to be_empty
       end
 
       it 'auto-corrects unwanted comma in a method call with hash parameters' \
@@ -163,11 +161,10 @@ describe RuboCop::Cop::Style::TrailingCommaInArguments, :config do
       end
 
       it 'accepts a method call with two parameters on the same line' do
-        inspect_source(cop, <<-END.strip_indent)
+        expect_no_offenses(<<-END.strip_indent)
           some_method(a, b
                      )
         END
-        expect(cop.offenses).to be_empty
       end
 
       it 'accepts trailing comma in a method call with hash' \
@@ -241,12 +238,11 @@ describe RuboCop::Cop::Style::TrailingCommaInArguments, :config do
       end
 
       it 'accepts a multiline call with a single argument and trailing comma' do
-        inspect_source(cop, <<-END.strip_indent)
+        expect_no_offenses(<<-END.strip_indent)
           method(
             1,
           )
         END
-        expect(cop.offenses).to be_empty
       end
     end
 
@@ -347,13 +343,12 @@ describe RuboCop::Cop::Style::TrailingCommaInArguments, :config do
       it 'accepts missing comma after a heredoc' do
         # A heredoc that's the last item in a literal or parameter list can not
         # have a trailing comma. It's a syntax error.
-        inspect_source(cop, <<-END.strip_indent)
+        expect_no_offenses(<<-END.strip_indent)
           route(1, <<-HELP.chomp
           ...
           HELP
           )
         END
-        expect(cop.offenses).to be_empty
       end
 
       it 'auto-corrects missing comma in a method call with hash parameters' \
@@ -377,12 +372,11 @@ describe RuboCop::Cop::Style::TrailingCommaInArguments, :config do
       end
 
       it 'accepts a multiline call with a single argument and trailing comma' do
-        inspect_source(cop, <<-END.strip_indent)
+        expect_no_offenses(<<-END.strip_indent)
           method(
             1,
           )
         END
-        expect(cop.offenses).to be_empty
       end
 
       it 'accepts a multiline call with arguments on a single line and' \

--- a/spec/rubocop/cop/style/trailing_comma_in_arguments_spec.rb
+++ b/spec/rubocop/cop/style/trailing_comma_in_arguments_spec.rb
@@ -22,8 +22,7 @@ describe RuboCop::Cop::Style::TrailingCommaInArguments, :config do
     end
 
     it 'accepts method call without trailing comma' do
-      inspect_source(cop, 'some_method(a, b, c)')
-      expect(cop.offenses).to be_empty
+      expect_no_offenses('some_method(a, b, c)')
     end
 
     it 'accepts method call without trailing comma with single element hash' \
@@ -33,8 +32,7 @@ describe RuboCop::Cop::Style::TrailingCommaInArguments, :config do
     end
 
     it 'accepts method call without parameters' do
-      inspect_source(cop, 'some_method')
-      expect(cop.offenses).to be_empty
+      expect_no_offenses('some_method')
     end
 
     it 'accepts chained single-line method calls' do

--- a/spec/rubocop/cop/style/trailing_comma_in_literal_spec.rb
+++ b/spec/rubocop/cop/style/trailing_comma_in_literal_spec.rb
@@ -32,13 +32,12 @@ describe RuboCop::Cop::Style::TrailingCommaInLiteral, :config do
 
     it 'accepts rescue clause' do
       # The list of rescued classes is an array.
-      inspect_source(cop, <<-END.strip_indent)
+      expect_no_offenses(<<-END.strip_indent)
         begin
           do_something
         rescue RuntimeError
         end
       END
-      expect(cop.offenses).to be_empty
     end
 
     it 'accepts Hash literal without trailing comma' do
@@ -110,34 +109,31 @@ describe RuboCop::Cop::Style::TrailingCommaInLiteral, :config do
       end
 
       it 'accepts an Array literal with no trailing comma' do
-        inspect_source(cop, <<-END.strip_indent)
+        expect_no_offenses(<<-END.strip_indent)
           VALUES = [ 1001,
                      2020,
                      3333 ]
         END
-        expect(cop.offenses).to be_empty
       end
 
       it 'accepts a Hash literal with no trailing comma' do
-        inspect_source(cop, <<-END.strip_indent)
+        expect_no_offenses(<<-END.strip_indent)
           MAP = {
                   a: 1001,
                   b: 2020,
                   c: 3333
                 }
         END
-        expect(cop.offenses).to be_empty
       end
 
       it 'accepts comma inside a heredoc parameters at the end' do
-        inspect_source(cop, <<-END.strip_indent)
+        expect_no_offenses(<<-END.strip_indent)
           route(help: {
             'auth' => <<-HELP.chomp
           ,
           HELP
           })
         END
-        expect(cop.offenses).to be_empty
       end
 
       it 'accepts comma in comment after last value item' do
@@ -186,34 +182,31 @@ describe RuboCop::Cop::Style::TrailingCommaInLiteral, :config do
 
       context 'when closing bracket is on same line as last value' do
         it 'accepts Array literal with no trailing comma' do
-          inspect_source(cop, <<-END.strip_indent)
+          expect_no_offenses(<<-END.strip_indent)
             VALUES = [
                        1001,
                        2020,
                        3333]
           END
-          expect(cop.offenses).to be_empty
         end
 
         it 'accepts a Hash literal with no trailing comma' do
-          inspect_source(cop, <<-END.strip_indent)
+          expect_no_offenses(<<-END.strip_indent)
             VALUES = {
                        a: "b",
                        c: "d",
                        e: "f"}
           END
-          expect(cop.offenses).to be_empty
         end
       end
 
       it 'accepts Array literal with two of the values on the same line' do
-        inspect_source(cop, <<-END.strip_indent)
+        expect_no_offenses(<<-END.strip_indent)
           VALUES = [
                      1001, 2020,
                      3333
                    ]
         END
-        expect(cop.offenses).to be_empty
       end
 
       it 'registers an offense for an Array literal with two of the values ' \
@@ -254,48 +247,44 @@ describe RuboCop::Cop::Style::TrailingCommaInLiteral, :config do
       end
 
       it 'accepts trailing comma in an Array literal' do
-        inspect_source(cop, <<-END.strip_indent)
+        expect_no_offenses(<<-END.strip_indent)
           VALUES = [1001,
                     2020,
                     3333,
                    ]
         END
-        expect(cop.offenses).to be_empty
       end
 
       it 'accepts trailing comma in a Hash literal' do
-        inspect_source(cop, <<-END.strip_indent)
+        expect_no_offenses(<<-END.strip_indent)
           MAP = {
                   a: 1001,
                   b: 2020,
                   c: 3333,
                 }
         END
-        expect(cop.offenses).to be_empty
       end
 
       it 'accepts a multiline word array' do
-        inspect_source(cop, <<-END.strip_indent)
+        expect_no_offenses(<<-END.strip_indent)
           ingredients = %w(
             sausage
             anchovies
             olives
           )
         END
-        expect(cop.offenses).to be_empty
       end
 
       it 'accepts missing comma after a heredoc' do
         # A heredoc that's the last item in a literal or parameter list can not
         # have a trailing comma. It's a syntax error.
-        inspect_source(cop, <<-END.strip_indent)
+        expect_no_offenses(<<-END.strip_indent)
           route(help: {
             'auth' => <<-HELP.chomp
           ...
           HELP
           })
         END
-        expect(cop.offenses).to be_empty
       end
 
       it 'accepts an empty hash being passed as a method argument' do
@@ -343,21 +332,19 @@ describe RuboCop::Cop::Style::TrailingCommaInLiteral, :config do
       end
 
       it 'accepts a multiline array with a single item and trailing comma' do
-        inspect_source(cop, <<-END.strip_indent)
+        expect_no_offenses(<<-END.strip_indent)
           foo = [
             1,
           ]
         END
-        expect(cop.offenses).to be_empty
       end
 
       it 'accepts a multiline hash with a single pair and trailing comma' do
-        inspect_source(cop, <<-END.strip_indent)
+        expect_no_offenses(<<-END.strip_indent)
           bar = {
             a: 123,
           }
         END
-        expect(cop.offenses).to be_empty
       end
     end
 
@@ -402,13 +389,12 @@ describe RuboCop::Cop::Style::TrailingCommaInLiteral, :config do
       end
 
       it 'accepts Array literal with two of the values on the same line' do
-        inspect_source(cop, <<-END.strip_indent)
+        expect_no_offenses(<<-END.strip_indent)
           VALUES = [
                      1001, 2020,
                      3333,
                    ]
         END
-        expect(cop.offenses).to be_empty
       end
 
       it 'registers an offense for an Array literal with two of the values ' \
@@ -436,48 +422,44 @@ describe RuboCop::Cop::Style::TrailingCommaInLiteral, :config do
       end
 
       it 'accepts trailing comma in an Array literal' do
-        inspect_source(cop, <<-END.strip_indent)
+        expect_no_offenses(<<-END.strip_indent)
           VALUES = [1001,
                     2020,
                     3333,
                    ]
         END
-        expect(cop.offenses).to be_empty
       end
 
       it 'accepts trailing comma in a Hash literal' do
-        inspect_source(cop, <<-END.strip_indent)
+        expect_no_offenses(<<-END.strip_indent)
           MAP = {
                   a: 1001,
                   b: 2020,
                   c: 3333,
                 }
         END
-        expect(cop.offenses).to be_empty
       end
 
       it 'accepts a multiline word array' do
-        inspect_source(cop, <<-END.strip_indent)
+        expect_no_offenses(<<-END.strip_indent)
           ingredients = %w(
             sausage
             anchovies
             olives
           )
         END
-        expect(cop.offenses).to be_empty
       end
 
       it 'accepts missing comma after a heredoc' do
         # A heredoc that's the last item in a literal or parameter list can not
         # have a trailing comma. It's a syntax error.
-        inspect_source(cop, <<-END.strip_indent)
+        expect_no_offenses(<<-END.strip_indent)
           route(help: {
             'auth' => <<-HELP.chomp
           ...
           HELP
           })
         END
-        expect(cop.offenses).to be_empty
       end
 
       it 'auto-corrects an Array literal with two of the values on the same' \
@@ -512,21 +494,19 @@ describe RuboCop::Cop::Style::TrailingCommaInLiteral, :config do
       end
 
       it 'accepts a multiline array with a single item and trailing comma' do
-        inspect_source(cop, <<-END.strip_indent)
+        expect_no_offenses(<<-END.strip_indent)
           foo = [
             1,
           ]
         END
-        expect(cop.offenses).to be_empty
       end
 
       it 'accepts a multiline hash with a single pair and trailing comma' do
-        inspect_source(cop, <<-END.strip_indent)
+        expect_no_offenses(<<-END.strip_indent)
           bar = {
             a: 123,
           }
         END
-        expect(cop.offenses).to be_empty
       end
 
       it 'accepts a multiline array with items on a single line and' \

--- a/spec/rubocop/cop/style/trailing_comma_in_literal_spec.rb
+++ b/spec/rubocop/cop/style/trailing_comma_in_literal_spec.rb
@@ -19,18 +19,15 @@ describe RuboCop::Cop::Style::TrailingCommaInLiteral, :config do
     end
 
     it 'accepts Array literal without trailing comma' do
-      inspect_source(cop, 'VALUES = [1001, 2020, 3333]')
-      expect(cop.offenses).to be_empty
+      expect_no_offenses('VALUES = [1001, 2020, 3333]')
     end
 
     it 'accepts single element Array literal without trailing comma' do
-      inspect_source(cop, 'VALUES = [1001]')
-      expect(cop.offenses).to be_empty
+      expect_no_offenses('VALUES = [1001]')
     end
 
     it 'accepts empty Array literal' do
-      inspect_source(cop, 'VALUES = []')
-      expect(cop.offenses).to be_empty
+      expect_no_offenses('VALUES = []')
     end
 
     it 'accepts rescue clause' do
@@ -45,18 +42,15 @@ describe RuboCop::Cop::Style::TrailingCommaInLiteral, :config do
     end
 
     it 'accepts Hash literal without trailing comma' do
-      inspect_source(cop, 'MAP = { a: 1001, b: 2020, c: 3333 }')
-      expect(cop.offenses).to be_empty
+      expect_no_offenses('MAP = { a: 1001, b: 2020, c: 3333 }')
     end
 
     it 'accepts single element Hash literal without trailing comma' do
-      inspect_source(cop, 'MAP = { a: 10001 }')
-      expect(cop.offenses).to be_empty
+      expect_no_offenses('MAP = { a: 10001 }')
     end
 
     it 'accepts empty Hash literal' do
-      inspect_source(cop, 'MAP = {}')
-      expect(cop.offenses).to be_empty
+      expect_no_offenses('MAP = {}')
     end
 
     it 'auto-corrects unwanted comma in an Array literal' do

--- a/spec/rubocop/cop/style/trivial_accessors_spec.rb
+++ b/spec/rubocop/cop/style/trivial_accessors_spec.rb
@@ -98,60 +98,54 @@ describe RuboCop::Cop::Style::TrivialAccessors, :config do
   end
 
   it 'accepts non-trivial reader' do
-    inspect_source(cop, <<-END.strip_indent)
+    expect_no_offenses(<<-END.strip_indent)
       def test
         some_function_call
         @test
       end
     END
-    expect(cop.offenses).to be_empty
   end
 
   it 'accepts non-trivial writer' do
-    inspect_source(cop, <<-END.strip_indent)
+    expect_no_offenses(<<-END.strip_indent)
       def test(val)
         some_function_call(val)
         @test = val
         log(val)
       end
     END
-    expect(cop.offenses).to be_empty
   end
 
   it 'accepts splats' do
-    inspect_source(cop, <<-END.strip_indent)
+    expect_no_offenses(<<-END.strip_indent)
       def splatomatic(*values)
         @splatomatic = values
       end
     END
-    expect(cop.offenses).to be_empty
   end
 
   it 'accepts blocks' do
-    inspect_source(cop, <<-END.strip_indent)
+    expect_no_offenses(<<-END.strip_indent)
       def something(&block)
         @b = block
       end
     END
-    expect(cop.offenses).to be_empty
   end
 
   it 'accepts expressions within reader' do
-    inspect_source(cop, <<-END.strip_indent)
+    expect_no_offenses(<<-END.strip_indent)
       def bar
         @bar + foo
       end
     END
-    expect(cop.offenses).to be_empty
   end
 
   it 'accepts expressions within writer' do
-    inspect_source(cop, <<-END.strip_indent)
+    expect_no_offenses(<<-END.strip_indent)
       def bar(val)
         @bar = val + foo
       end
     END
-    expect(cop.offenses).to be_empty
   end
 
   it 'accepts an initialize method looking like a writer' do
@@ -164,37 +158,33 @@ describe RuboCop::Cop::Style::TrivialAccessors, :config do
   end
 
   it 'accepts reader with different ivar name' do
-    inspect_source(cop, <<-END.strip_indent)
+    expect_no_offenses(<<-END.strip_indent)
       def foo
         @fo
       end
     END
-    expect(cop.offenses).to be_empty
   end
 
   it 'accepts writer with different ivar name' do
-    inspect_source(cop, <<-END.strip_indent)
+    expect_no_offenses(<<-END.strip_indent)
       def foo(val)
         @fo = val
       end
     END
-    expect(cop.offenses).to be_empty
   end
 
   it 'accepts writer in a module' do
-    inspect_source(cop, <<-END.strip_indent)
+    expect_no_offenses(<<-END.strip_indent)
       module Foo
         def bar=(bar)
           @bar = bar
         end
       end
     END
-
-    expect(cop.offenses).to be_empty
   end
 
   it 'accepts writer nested within a module' do
-    inspect_source(cop, <<-END.strip_indent)
+    expect_no_offenses(<<-END.strip_indent)
       module Foo
         begin
           if RUBY_VERSION > "2.0"
@@ -205,12 +195,10 @@ describe RuboCop::Cop::Style::TrivialAccessors, :config do
         end
       end
     END
-
-    expect(cop.offenses).to be_empty
   end
 
   it 'accepts reader nested within a module' do
-    inspect_source(cop, <<-END.strip_indent)
+    expect_no_offenses(<<-END.strip_indent)
       module Foo
         begin
           if RUBY_VERSION > "2.0"
@@ -221,12 +209,10 @@ describe RuboCop::Cop::Style::TrivialAccessors, :config do
         end
       end
     END
-
-    expect(cop.offenses).to be_empty
   end
 
   it 'accepts writer nested within an instance_eval call' do
-    inspect_source(cop, <<-END.strip_indent)
+    expect_no_offenses(<<-END.strip_indent)
       something.instance_eval do
         begin
           if RUBY_VERSION > "2.0"
@@ -237,12 +223,10 @@ describe RuboCop::Cop::Style::TrivialAccessors, :config do
         end
       end
     END
-
-    expect(cop.offenses).to be_empty
   end
 
   it 'accepts reader nested within an instance_eval calll' do
-    inspect_source(cop, <<-END.strip_indent)
+    expect_no_offenses(<<-END.strip_indent)
       something.instance_eval do
         begin
           if RUBY_VERSION > "2.0"
@@ -253,8 +237,6 @@ describe RuboCop::Cop::Style::TrivialAccessors, :config do
         end
       end
     END
-
-    expect(cop.offenses).to be_empty
   end
 
   it 'flags a reader inside a class, inside an instance_eval call' do
@@ -314,12 +296,11 @@ describe RuboCop::Cop::Style::TrivialAccessors, :config do
     let(:cop_config) { { 'AllowPredicates' => true } }
 
     it 'accepts predicate-like reader' do
-      inspect_source(cop, <<-END.strip_indent)
+      expect_no_offenses(<<-END.strip_indent)
         def foo?
           @foo
         end
       END
-      expect(cop.offenses).to be_empty
     end
   end
 
@@ -365,12 +346,11 @@ describe RuboCop::Cop::Style::TrivialAccessors, :config do
     let(:cop_config) { { 'AllowDSLWriters' => true } }
 
     it 'accepts DSL-style writer' do
-      inspect_source(cop, <<-END.strip_indent)
+      expect_no_offenses(<<-END.strip_indent)
         def foo(val)
          @foo = val
         end
       END
-      expect(cop.offenses).to be_empty
     end
   end
 
@@ -378,21 +358,19 @@ describe RuboCop::Cop::Style::TrivialAccessors, :config do
     let(:cop_config) { { 'IgnoreClassMethods' => true } }
 
     it 'accepts class reader' do
-      inspect_source(cop, <<-END.strip_indent)
+      expect_no_offenses(<<-END.strip_indent)
         def self.foo
           @foo
         end
       END
-      expect(cop.offenses).to be_empty
     end
 
     it 'accepts class writer' do
-      inspect_source(cop, <<-END.strip_indent)
+      expect_no_offenses(<<-END.strip_indent)
         def self.foo(val)
           @foo = val
         end
       END
-      expect(cop.offenses).to be_empty
     end
   end
 

--- a/spec/rubocop/cop/style/unless_else_spec.rb
+++ b/spec/rubocop/cop/style/unless_else_spec.rb
@@ -73,12 +73,11 @@ describe RuboCop::Cop::Style::UnlessElse do
 
   context 'unless without else' do
     it 'does not register an offense' do
-      inspect_source(cop, <<-END.strip_indent)
+      expect_no_offenses(<<-END.strip_indent)
         unless x
           a = 1
         end
       END
-      expect(cop.offenses).to be_empty
     end
   end
 end

--- a/spec/rubocop/cop/style/unneeded_capital_w_spec.rb
+++ b/spec/rubocop/cop/style/unneeded_capital_w_spec.rb
@@ -4,13 +4,11 @@ describe RuboCop::Cop::Style::UnneededCapitalW do
   subject(:cop) { described_class.new }
 
   it 'registers no offense for normal arrays of strings' do
-    inspect_source(cop, '["one", "two", "three"]')
-    expect(cop.offenses).to be_empty
+    expect_no_offenses('["one", "two", "three"]')
   end
 
   it 'registers no offense for normal arrays of strings with interpolation' do
-    inspect_source(cop, '["one", "two", "th#{?r}ee"]')
-    expect(cop.offenses).to be_empty
+    expect_no_offenses('["one", "two", "th#{?r}ee"]')
   end
 
   it 'registers an offense for misused %W' do
@@ -19,8 +17,7 @@ describe RuboCop::Cop::Style::UnneededCapitalW do
   end
 
   it 'registers no offense for %W with interpolation' do
-    inspect_source(cop, '%W(c#{?a}t dog)')
-    expect(cop.offenses).to be_empty
+    expect_no_offenses('%W(c#{?a}t dog)')
   end
 
   it 'registers no offense for %W with special characters' do
@@ -47,38 +44,31 @@ describe RuboCop::Cop::Style::UnneededCapitalW do
   end
 
   it 'registers no offense for %w without interpolation' do
-    inspect_source(cop, '%w(cat dog)')
-    expect(cop.offenses).to be_empty
+    expect_no_offenses('%w(cat dog)')
   end
 
   it 'registers no offense for %w with interpolation-like syntax' do
-    inspect_source(cop, '%w(c#{?a}t dog)')
-    expect(cop.offenses).to be_empty
+    expect_no_offenses('%w(c#{?a}t dog)')
   end
 
   it 'registers no offense for arrays with character constants' do
-    inspect_source(cop, '["one", ?\n]')
-    expect(cop.offenses).to be_empty
+    expect_no_offenses('["one", ?\n]')
   end
 
   it 'does not register an offense for array of non-words' do
-    inspect_source(cop, '["one space", "two", "three"]')
-    expect(cop.offenses).to be_empty
+    expect_no_offenses('["one space", "two", "three"]')
   end
 
   it 'does not register an offense for array containing non-string' do
-    inspect_source(cop, '["one", "two", 3]')
-    expect(cop.offenses).to be_empty
+    expect_no_offenses('["one", "two", 3]')
   end
 
   it 'does not register an offense for array with one element' do
-    inspect_source(cop, '["three"]')
-    expect(cop.offenses).to be_empty
+    expect_no_offenses('["three"]')
   end
 
   it 'does not register an offense for array with empty strings' do
-    inspect_source(cop, '["", "two", "three"]')
-    expect(cop.offenses).to be_empty
+    expect_no_offenses('["", "two", "three"]')
   end
 
   it 'auto-corrects an array of words' do

--- a/spec/rubocop/cop/style/unneeded_interpolation_spec.rb
+++ b/spec/rubocop/cop/style/unneeded_interpolation_spec.rb
@@ -100,28 +100,23 @@ describe RuboCop::Cop::Style::UnneededInterpolation do
   end
 
   it 'accepts strings with characters before the interpolation' do
-    inspect_source(cop, '"this is #{@sparta}"')
-    expect(cop.offenses).to be_empty
+    expect_no_offenses('"this is #{@sparta}"')
   end
 
   it 'accepts strings with characters after the interpolation' do
-    inspect_source(cop, '"#{@sparta} this is"')
-    expect(cop.offenses).to be_empty
+    expect_no_offenses('"#{@sparta} this is"')
   end
 
   it 'accepts strings implicitly concatenated with a later string' do
-    inspect_source(cop, %q("#{sparta}" ' this is'))
-    expect(cop.offenses).to be_empty
+    expect_no_offenses(%q("#{sparta}" ' this is'))
   end
 
   it 'accepts strings implicitly concatenated with an earlier string' do
-    inspect_source(cop, %q('this is ' "#{sparta}"))
-    expect(cop.offenses).to be_empty
+    expect_no_offenses(%q('this is ' "#{sparta}"))
   end
 
   it 'accepts strings that are part of a %W()' do
-    inspect_source(cop, '%W(#{@var} foo)')
-    expect(cop.offenses).to be_empty
+    expect_no_offenses('%W(#{@var} foo)')
   end
 
   it 'autocorrects "#{1 + 1; 2 + 2}"' do

--- a/spec/rubocop/cop/style/variable_interpolation_spec.rb
+++ b/spec/rubocop/cop/style/variable_interpolation_spec.rb
@@ -71,9 +71,7 @@ describe RuboCop::Cop::Style::VariableInterpolation do
   end
 
   it 'does not register an offense for variables in expressions' do
-    inspect_source(cop,
-                   'puts "this is a #{@test} #{@@t} #{$t} #{$1} #{$+}"')
-    expect(cop.offenses).to be_empty
+    expect_no_offenses('puts "this is a #{@test} #{@@t} #{$t} #{$1} #{$+}"')
   end
 
   it 'autocorrects by adding the missing {}' do

--- a/spec/rubocop/cop/style/variable_name_spec.rb
+++ b/spec/rubocop/cop/style/variable_name_spec.rb
@@ -5,23 +5,19 @@ describe RuboCop::Cop::Style::VariableName, :config do
 
   shared_examples 'always accepted' do
     it 'accepts screaming snake case globals' do
-      inspect_source(cop, '$MY_GLOBAL = 0')
-      expect(cop.offenses).to be_empty
+      expect_no_offenses('$MY_GLOBAL = 0')
     end
 
     it 'accepts screaming snake case constants' do
-      inspect_source(cop, 'MY_CONSTANT = 0')
-      expect(cop.offenses).to be_empty
+      expect_no_offenses('MY_CONSTANT = 0')
     end
 
     it 'accepts assigning to camel case constant' do
-      inspect_source(cop, 'Paren = Struct.new :left, :right, :kind')
-      expect(cop.offenses).to be_empty
+      expect_no_offenses('Paren = Struct.new :left, :right, :kind')
     end
 
     it 'accepts assignment with indexing of self' do
-      inspect_source(cop, 'self[:a] = b')
-      expect(cop.offenses).to be_empty
+      expect_no_offenses('self[:a] = b')
     end
   end
 
@@ -93,18 +89,15 @@ describe RuboCop::Cop::Style::VariableName, :config do
     end
 
     it 'accepts camel case in local variable name' do
-      inspect_source(cop, 'myLocal = 1')
-      expect(cop.offenses).to be_empty
+      expect_no_offenses('myLocal = 1')
     end
 
     it 'accepts camel case in instance variable name' do
-      inspect_source(cop, '@myAttribute = 3')
-      expect(cop.offenses).to be_empty
+      expect_no_offenses('@myAttribute = 3')
     end
 
     it 'accepts camel case in class variable name' do
-      inspect_source(cop, '@@myAttr = 2')
-      expect(cop.offenses).to be_empty
+      expect_no_offenses('@@myAttr = 2')
     end
 
     it 'registers an offense for snake case in method parameter' do
@@ -114,8 +107,7 @@ describe RuboCop::Cop::Style::VariableName, :config do
     end
 
     it 'accepts camel case local variables marked as unused' do
-      inspect_source(cop, '_myLocal = 1')
-      expect(cop.offenses).to be_empty
+      expect_no_offenses('_myLocal = 1')
     end
 
     include_examples 'always accepted'

--- a/spec/rubocop/cop/style/when_then_spec.rb
+++ b/spec/rubocop/cop/style/when_then_spec.rb
@@ -13,16 +13,15 @@ describe RuboCop::Cop::Style::WhenThen do
   end
 
   it 'accepts when x then' do
-    inspect_source(cop, <<-END.strip_indent)
+    expect_no_offenses(<<-END.strip_indent)
       case a
       when b then c
       end
     END
-    expect(cop.offenses).to be_empty
   end
 
   it 'accepts ; separating statements in the body of when' do
-    inspect_source(cop, <<-END.strip_indent)
+    expect_no_offenses(<<-END.strip_indent)
       case a
       when b then c; d
       end
@@ -32,7 +31,6 @@ describe RuboCop::Cop::Style::WhenThen do
         g; h
       end
     END
-    expect(cop.offenses).to be_empty
   end
 
   it 'auto-corrects "when x;" with "when x then"' do
@@ -51,13 +49,11 @@ describe RuboCop::Cop::Style::WhenThen do
   # Regression: https://github.com/bbatsov/rubocop/issues/3868
   context 'when inspecting a case statement with an empty branch' do
     it 'does not register an offense' do
-      inspect_source(cop, <<-END.strip_indent)
+      expect_no_offenses(<<-END.strip_indent)
         case value
         when cond1
         end
       END
-
-      expect(cop.offenses).to be_empty
     end
   end
 end

--- a/spec/rubocop/cop/style/while_until_do_spec.rb
+++ b/spec/rubocop/cop/style/while_until_do_spec.rb
@@ -20,13 +20,11 @@ describe RuboCop::Cop::Style::WhileUntilDo do
   end
 
   it 'accepts do in single-line while' do
-    inspect_source(cop, 'while cond do something end')
-    expect(cop.offenses).to be_empty
+    expect_no_offenses('while cond do something end')
   end
 
   it 'accepts do in single-line until' do
-    inspect_source(cop, 'until cond do something end')
-    expect(cop.offenses).to be_empty
+    expect_no_offenses('until cond do something end')
   end
 
   it 'accepts multi-line while without do' do

--- a/spec/rubocop/cop/style/while_until_do_spec.rb
+++ b/spec/rubocop/cop/style/while_until_do_spec.rb
@@ -28,19 +28,17 @@ describe RuboCop::Cop::Style::WhileUntilDo do
   end
 
   it 'accepts multi-line while without do' do
-    inspect_source(cop, <<-END.strip_indent)
+    expect_no_offenses(<<-END.strip_indent)
       while cond
       end
     END
-    expect(cop.offenses).to be_empty
   end
 
   it 'accepts multi-line until without do' do
-    inspect_source(cop, <<-END.strip_indent)
+    expect_no_offenses(<<-END.strip_indent)
       until cond
       end
     END
-    expect(cop.offenses).to be_empty
   end
 
   it 'auto-corrects the usage of "do" in multiline while' do

--- a/spec/rubocop/cop/style/while_until_modifier_spec.rb
+++ b/spec/rubocop/cop/style/while_until_modifier_spec.rb
@@ -89,13 +89,11 @@ describe RuboCop::Cop::Style::WhileUntilModifier do
   end
 
   it 'accepts modifier while' do
-    inspect_source(cop, 'ala while bala')
-    expect(cop.offenses).to be_empty
+    expect_no_offenses('ala while bala')
   end
 
   it 'accepts modifier until' do
-    inspect_source(cop, 'ala until bala')
-    expect(cop.offenses).to be_empty
+    expect_no_offenses('ala until bala')
   end
 
   # Regression: https://github.com/bbatsov/rubocop/issues/4006

--- a/spec/rubocop/cop/style/while_until_modifier_spec.rb
+++ b/spec/rubocop/cop/style/while_until_modifier_spec.rb
@@ -36,13 +36,12 @@ describe RuboCop::Cop::Style::WhileUntilModifier do
   end
 
   it 'accepts oneline while when condition has local variable assignment' do
-    inspect_source(cop, <<-END.strip_indent)
+    expect_no_offenses(<<-END.strip_indent)
       lines = %w{first second third}
       while (line = lines.shift)
         puts line
       end
     END
-    expect(cop.offenses).to be_empty
   end
 
   context 'oneline while when assignment is in body' do

--- a/spec/rubocop/cop/style/word_array_spec.rb
+++ b/spec/rubocop/cop/style/word_array_spec.rb
@@ -63,28 +63,23 @@ describe RuboCop::Cop::Style::WordArray, :config do
     end
 
     it 'does not register an offense for array of non-words' do
-      inspect_source(cop, '["one space", "two", "three"]')
-      expect(cop.offenses).to be_empty
+      expect_no_offenses('["one space", "two", "three"]')
     end
 
     it 'does not register an offense for array containing non-string' do
-      inspect_source(cop, '["one", "two", 3]')
-      expect(cop.offenses).to be_empty
+      expect_no_offenses('["one", "two", 3]')
     end
 
     it 'does not register an offense for array starting with %w' do
-      inspect_source(cop, '%w(one two three)')
-      expect(cop.offenses).to be_empty
+      expect_no_offenses('%w(one two three)')
     end
 
     it 'does not register an offense for array with one element' do
-      inspect_source(cop, '["three"]')
-      expect(cop.offenses).to be_empty
+      expect_no_offenses('["three"]')
     end
 
     it 'does not register an offense for array with empty strings' do
-      inspect_source(cop, '["", "two", "three"]')
-      expect(cop.offenses).to be_empty
+      expect_no_offenses('["", "two", "three"]')
     end
 
     it 'does not register offense for array with allowed number of strings' do
@@ -179,13 +174,11 @@ describe RuboCop::Cop::Style::WordArray, :config do
     end
 
     it 'does not register an offense for arrays of single quoted strings' do
-      inspect_source(cop, "['one', 'two', 'three']")
-      expect(cop.offenses).to be_empty
+      expect_no_offenses("['one', 'two', 'three']")
     end
 
     it 'does not register an offense for arrays of double quoted strings' do
-      inspect_source(cop, '["one", "two", "three"]')
-      expect(cop.offenses).to be_empty
+      expect_no_offenses('["one", "two", "three"]')
     end
 
     it 'registers an offense for a %w() array' do

--- a/spec/rubocop/cop/style/word_array_spec.rb
+++ b/spec/rubocop/cop/style/word_array_spec.rb
@@ -89,15 +89,13 @@ describe RuboCop::Cop::Style::WordArray, :config do
     end
 
     it 'does not register an offense for an array with comments in it' do
-      inspect_source(cop, <<-END.strip_indent)
+      expect_no_offenses(<<-END.strip_indent)
         [
         "foo", # comment here
         "bar", # this thing was done because of a bug
         "baz" # do not delete this line
         ]
       END
-
-      expect(cop.offenses).to be_empty
     end
 
     it 'registers an offense for an array with comments outside of it' do
@@ -203,7 +201,7 @@ describe RuboCop::Cop::Style::WordArray, :config do
 
     it "doesn't fail on strings which are not valid UTF-8" do
       # Regression test, see GH issue 2671
-      inspect_source(cop, <<-'END'.strip_indent)
+      expect_no_offenses(<<-'END'.strip_indent)
         ["\xC0",
          "\xC2\x4a",
          "\xC2\xC2",
@@ -212,10 +210,6 @@ describe RuboCop::Cop::Style::WordArray, :config do
          "\xe1\x82\x4a",
         ]
       END
-      # Currently, this cop completely ignores strings with invalid encoding
-      # If it could handle them and still report an offense when appropriate,
-      # that would be even better
-      expect(cop.offenses).to be_empty
     end
   end
 


### PR DESCRIPTION
Followup after #4337!

Simple bulk rewrite to start! Using `expect_no_offenses`. Kills 1,488 LoC :smile:

---

I did the rewrite for the single line expectations with this script:

```ruby
require 'rubocop'

include RuboCop::AST::Sexp

class Rewritter
  extend RuboCop::NodePattern::Macros

  def_node_search(:match, <<-PATTERN)
    (block
      (send nil :it str)
      args
      $(begin
        (send nil :inspect_source (send nil :cop) $str)
        (send
          (send nil :expect
            (send
              (send nil :cop) :offenses)) :to
          (send nil :be_empty))))
  PATTERN

  def initialize(path)
    @path     = path
    @source   = RuboCop::ProcessedSource.from_file(path.to_s, 2.4)
    @rewriter = Parser::Source::Rewriter.new(source.buffer)
  end

  def match?
    match(source.ast).any?
  end

  def rewrite
    return unless match?

    count = 0

    match(source.ast) do |*args|
      count += 1
      rewrite_one(*args)
    end

    rewritten = rewriter.process

    puts "Rewrote #{count} entries for #{path}"

    path.write(rewritten)
  end

  private

  attr_reader :source, :rewriter, :path

  def rewrite_one(spec_body, example_source)
    rewriter.replace(
      spec_body.loc.expression,
      "expect_no_offenses(#{example_source.source})"
    )
  end
end

Pathname.glob('spec/rubocop/cop/**/*.rb').each do |path|
  Rewritter.new(path).rewrite
end
```

---

I rewrote the multiline examples with this script:

```ruby
require 'rubocop'

include RuboCop::AST::Sexp

class Rewritter
  extend RuboCop::NodePattern::Macros

  def_node_search(:match, <<-PATTERN)
    (block
      (send nil :it str)
      args
      $(begin
        $(send nil :inspect_source $(send nil :cop)
        (send $dstr :strip_indent))
        $(send
          (send nil :expect
            (send
              (send nil :cop) :offenses)) :to
          (send nil :be_empty))))
  PATTERN

  def initialize(path)
    @path     = path
    @source   = RuboCop::ProcessedSource.from_file(path.to_s, 2.4)
    @rewriter = Parser::Source::Rewriter.new(source.buffer)
  end

  def match?
    match(source.ast).any?
  end

  def rewrite
    return unless match?

    count = 0

    match(source.ast) do |*args|
      count += 1
      rewrite_one(*args)
    end

    rewritten = rewriter.process

    puts "Rewrote #{count} entries for #{path}"

    path.write(rewritten)
  end

  private

  attr_reader :source, :rewriter, :path

  def rewrite_one(body, inspect_call,
                  spec_cop, example_source, expectation)

    heredoc_start = example_source.loc.expression.source
    replacement = [
      "expect_no_offenses(#{heredoc_start}.strip_indent)",
      example_source.loc.heredoc_body.source.chomp,
      example_source.loc.heredoc_end.source
    ].join("\n")

    rewriter.replace(body.loc.expression, replacement)
  end
end

Pathname.glob('spec/rubocop/cop/**/*.rb').each do |path|
  Rewritter.new(path).rewrite
end
```

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Used the same coding conventions as the rest of the project.
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] All tests are passing.
* [x] The new code doesn't generate RuboCop offenses.
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Updated cop documentation with `rake generate_cops_documentation` (required only when you've added a new cop or changed the configuration/documentation of an existing cop).

[1]: http://chris.beams.io/posts/git-commit/
