### PR TITLE
Add autocorrect to `Style/FormatString` cop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 * [#3438](https://github.com/bbatsov/rubocop/issues/3438): Add new `Style/FormatStringToken` cop. ([@backus][])
 * [#4342](https://github.com/bbatsov/rubocop/pull/4342): Add new `Lint/ScriptPermission` cop. ([@yhirano55][])
 * [#4403](https://github.com/bbatsov/rubocop/pull/4403): Add public API `Cop.autocorrect_incompatible_with` for specifying other cops that should not autocorrect together. ([@backus][])
+* [#4354](https://github.com/bbatsov/rubocop/pull/4354): Add autocorrect to `Style/FormatString`. ([@hoshinotsuyoshi][])
 
 ### Changes
 
@@ -2781,3 +2782,4 @@
 [@klesse413]: https://github.com/klesse413
 [@gprado]: https://github.com/gprado
 [@yhirano55]: https://github.com/yhirano55
+[@hoshinotsuyoshi]: https://github.com/hoshinotsuyoshi

--- a/manual/cops_style.md
+++ b/manual/cops_style.md
@@ -1138,7 +1138,7 @@ SupportedStyles | for, each
 
 Enabled by default | Supports autocorrection
 --- | ---
-Enabled | No
+Enabled | Yes
 
 This cop enforces the use of a single string formatting utility.
 Valid options include Kernel#format, Kernel#sprintf and String#%.

--- a/spec/rubocop/cop/style/format_string_spec.rb
+++ b/spec/rubocop/cop/style/format_string_spec.rb
@@ -47,6 +47,26 @@ describe RuboCop::Cop::Style::FormatString, :config do
         ^^^^^^ Favor `sprintf` over `format`.
       RUBY
     end
+
+    it 'auto-corrects format' do
+      corrected = autocorrect_source(cop, 'format(something, a, b)')
+      expect(corrected).to eq 'sprintf(something, a, b)'
+    end
+
+    it 'auto-corrects String#%' do
+      corrected = autocorrect_source(cop, 'puts "%d" % 10')
+      expect(corrected).to eq 'puts sprintf("%d", 10)'
+    end
+
+    it 'auto-corrects String#% with an array argument' do
+      corrected = autocorrect_source(cop, 'puts x % [10, 11]')
+      expect(corrected).to eq 'puts sprintf(x, 10, 11)'
+    end
+
+    it 'auto-corrects String#% with a hash argument' do
+      corrected = autocorrect_source(cop, 'puts x % { a: 10, b: 11 }')
+      expect(corrected).to eq 'puts sprintf(x, a: 10, b: 11)'
+    end
   end
 
   context 'when enforced style is format' do
@@ -101,6 +121,26 @@ describe RuboCop::Cop::Style::FormatString, :config do
         ^^^^^^^ Favor `format` over `sprintf`.
       RUBY
     end
+
+    it 'auto-corrects sprintf' do
+      corrected = autocorrect_source(cop, 'sprintf(something, a, b)')
+      expect(corrected).to eq 'format(something, a, b)'
+    end
+
+    it 'auto-corrects String#%' do
+      corrected = autocorrect_source(cop, 'puts "%d" % 10')
+      expect(corrected).to eq 'puts format("%d", 10)'
+    end
+
+    it 'auto-corrects String#% with an array argument' do
+      corrected = autocorrect_source(cop, 'puts x % [10, 11]')
+      expect(corrected).to eq 'puts format(x, 10, 11)'
+    end
+
+    it 'auto-corrects String#% with a hash argument' do
+      corrected = autocorrect_source(cop, 'puts x % { a: 10, b: 11 }')
+      expect(corrected).to eq 'puts format(x, a: 10, b: 11)'
+    end
   end
 
   context 'when enforced style is percent' do
@@ -145,6 +185,36 @@ describe RuboCop::Cop::Style::FormatString, :config do
 
     it 'accepts String#%' do
       expect_no_offenses('puts "%d" % 10')
+    end
+
+    it 'auto-corrects format with 2 arguments' do
+      corrected = autocorrect_source(cop, 'format(something, a)')
+      expect(corrected).to eq 'something % a'
+    end
+
+    it 'auto-corrects format with 3 arguments' do
+      corrected = autocorrect_source(cop, 'format(something, a, b)')
+      expect(corrected).to eq 'something % [a, b]'
+    end
+
+    it 'auto-corrects format with a hash argument' do
+      corrected = autocorrect_source(cop, 'format(something, a: 10, b: 11)')
+      expect(corrected).to eq 'something % { a: 10, b: 11 }'
+    end
+
+    it 'auto-corrects sprintf with 2 arguments' do
+      corrected = autocorrect_source(cop, 'sprintf(something, a)')
+      expect(corrected).to eq 'something % a'
+    end
+
+    it 'auto-corrects sprintf with 3 arguments' do
+      corrected = autocorrect_source(cop, 'sprintf(something, a, b)')
+      expect(corrected).to eq 'something % [a, b]'
+    end
+
+    it 'auto-corrects sprintf with a hash argument' do
+      corrected = autocorrect_source(cop, 'sprintf(something, a: 10, b: 11)')
+      expect(corrected).to eq 'something % { a: 10, b: 11 }'
     end
   end
 end


### PR DESCRIPTION
Add autocorrect to `Style/FormatString` cop.

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Used the same coding conventions as the rest of the project.
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] All tests are passing.
* [x] The new code doesn't generate RuboCop offenses.
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Updated cop documentation with `rake generate_cops_documentation` (required only when you've added a new cop or changed the configuration/documentation of an existing cop).

[1]: http://chris.beams.io/posts/git-commit/
