### PR TITLE
Update specs to use `expect_offense`

### DIFF
--- a/spec/rubocop/cop/layout/block_end_newline_spec.rb
+++ b/spec/rubocop/cop/layout/block_end_newline_spec.rb
@@ -19,21 +19,19 @@ describe RuboCop::Cop::Layout::BlockEndNewline do
   end
 
   it 'registers an offense when multiline block end is not on its own line' do
-    inspect_source(cop, <<-END.strip_indent)
+    expect_offense(<<-END.strip_indent)
       test do
         foo end
+            ^^^ Expression at 2, 7 should be on its own line.
     END
-    expect(cop.messages)
-      .to eq(['Expression at 2, 7 should be on its own line.'])
   end
 
   it 'registers an offense when multiline block } is not on its own line' do
-    inspect_source(cop, <<-END.strip_indent)
+    expect_offense(<<-END.strip_indent)
       test {
         foo }
+            ^ Expression at 2, 7 should be on its own line.
     END
-    expect(cop.messages)
-      .to eq(['Expression at 2, 7 should be on its own line.'])
   end
 
   it 'autocorrects a do/end block where the end is not on its own line' do

--- a/spec/rubocop/cop/layout/comment_indentation_spec.rb
+++ b/spec/rubocop/cop/layout/comment_indentation_spec.rb
@@ -43,28 +43,26 @@ describe RuboCop::Cop::Layout::CommentIndentation do
     end
 
     it 'registers an offense for each incorrectly indented comment' do
-      inspect_source(cop, <<-END.strip_indent)
+      expect_offense(<<-END.strip_indent)
         # a
+        ^^^ Incorrect indentation detected (column 0 instead of 2).
           # b
+          ^^^ Incorrect indentation detected (column 2 instead of 4).
             # c
+            ^^^ Incorrect indentation detected (column 4 instead of 0).
         # d
         def test; end
       END
-      expect(cop.messages)
-        .to eq(['Incorrect indentation detected (column 0 instead of 2).',
-                'Incorrect indentation detected (column 2 instead of 4).',
-                'Incorrect indentation detected (column 4 instead of 0).'])
     end
   end
 
   it 'registers offenses before __END__ but not after' do
-    inspect_source(cop, <<-END.strip_indent)
+    expect_offense(<<-END.strip_indent)
        #
+       ^ Incorrect indentation detected (column 1 instead of 0).
       __END__
         #
     END
-    expect(cop.messages)
-      .to eq(['Incorrect indentation detected (column 1 instead of 0).'])
   end
 
   context 'around program structure keywords' do

--- a/spec/rubocop/cop/layout/else_alignment_spec.rb
+++ b/spec/rubocop/cop/layout/else_alignment_spec.rb
@@ -175,39 +175,39 @@ describe RuboCop::Cop::Layout::ElseAlignment do
 
         context 'and end is aligned with keyword' do
           it 'registers offenses for an if with setter' do
-            inspect_source(cop, <<-END.strip_indent)
+            expect_offense(<<-END.strip_indent)
               foo.bar = if baz
                           derp1
                         elsif meh
+                        ^^^^^ Align `elsif` with `foo.bar`.
                           derp2
                         else
+                        ^^^^ Align `else` with `foo.bar`.
                           derp3
                         end
             END
-            expect(cop.messages).to eq(['Align `elsif` with `foo.bar`.',
-                                        'Align `else` with `foo.bar`.'])
           end
 
           it 'registers an offense for an if with element assignment' do
-            inspect_source(cop, <<-END.strip_indent)
+            expect_offense(<<-END.strip_indent)
               foo[bar] = if baz
                            derp1
                          else
+                         ^^^^ Align `else` with `foo[bar]`.
                            derp2
                          end
             END
-            expect(cop.messages).to eq(['Align `else` with `foo[bar]`.'])
           end
 
           it 'registers an offense for an if' do
-            inspect_source(cop, <<-END.strip_indent)
+            expect_offense(<<-END.strip_indent)
               var = if a
                       0
                     else
+                    ^^^^ Align `else` with `var`.
                       1
                     end
             END
-            expect(cop.messages).to eq(['Align `else` with `var`.'])
           end
         end
       end
@@ -215,14 +215,14 @@ describe RuboCop::Cop::Layout::ElseAlignment do
       shared_examples 'assignment and if with keyword alignment' do
         context 'and end is aligned with variable' do
           it 'registers an offense for an if' do
-            inspect_source(cop, <<-END.strip_indent)
+            expect_offense(<<-END.strip_indent)
               var = if a
                 0
               elsif b
+              ^^^^^ Align `elsif` with `if`.
                 1
               end
             END
-            expect(cop.messages).to eq(['Align `elsif` with `if`.'])
           end
 
           it 'autocorrects bad alignment' do
@@ -315,14 +315,14 @@ describe RuboCop::Cop::Layout::ElseAlignment do
 
   context 'with unless' do
     it 'registers an offense for misaligned else' do
-      inspect_source(cop, <<-END.strip_indent)
+      expect_offense(<<-END.strip_indent)
         unless cond
            func1
          else
+         ^^^^ Align `else` with `unless`.
            func2
         end
       END
-      expect(cop.messages).to eq(['Align `else` with `unless`.'])
     end
 
     it 'accepts a correctly aligned else in an otherwise empty unless' do
@@ -343,17 +343,17 @@ describe RuboCop::Cop::Layout::ElseAlignment do
 
   context 'with case' do
     it 'registers an offense for misaligned else' do
-      inspect_source(cop, <<-END.strip_indent)
+      expect_offense(<<-END.strip_indent)
         case a
         when b
           c
         when d
           e
          else
+         ^^^^ Align `else` with `when`.
           f
         end
       END
-      expect(cop.messages).to eq(['Align `else` with `when`.'])
     end
 
     it 'accepts correctly aligned case/when/else' do
@@ -428,16 +428,16 @@ describe RuboCop::Cop::Layout::ElseAlignment do
         end
 
         it 'registers an offense for else not aligned with private' do
-          inspect_source(cop, <<-END.strip_indent)
+          expect_offense(<<-END.strip_indent)
             private def test
                       something
                     rescue
                       handling
                     else
+                    ^^^^ Align `else` with `private`.
                       something_else
                     end
           END
-          expect(cop.messages).to eq(['Align `else` with `private`.'])
         end
       end
     end
@@ -445,7 +445,7 @@ describe RuboCop::Cop::Layout::ElseAlignment do
 
   context 'with begin/rescue/else/ensure/end' do
     it 'registers an offense for misaligned else' do
-      inspect_source(cop, <<-END.strip_indent)
+      expect_offense(<<-END.strip_indent)
         def my_func
           puts 'do something outside block'
           begin
@@ -455,13 +455,13 @@ describe RuboCop::Cop::Layout::ElseAlignment do
           rescue
             puts 'wrongly intended error handling'
         else
+        ^^^^ Align `else` with `begin`.
             puts 'wrongly intended normal case handling'
           ensure
             puts 'wrongly intended common handling'
           end
         end
       END
-      expect(cop.messages).to eq(['Align `else` with `begin`.'])
     end
 
     it 'accepts a correctly aligned else' do
@@ -493,18 +493,18 @@ describe RuboCop::Cop::Layout::ElseAlignment do
     end
 
     it 'registers an offense for misaligned else' do
-      inspect_source(cop, <<-END.strip_indent)
+      expect_offense(<<-END.strip_indent)
         def my_func(string)
           puts string
         rescue => e
           puts e
           else
+          ^^^^ Align `else` with `def`.
           puts e
         ensure
           puts 'I love methods that print'
         end
       END
-      expect(cop.messages).to eq(['Align `else` with `def`.'])
     end
   end
 
@@ -525,7 +525,7 @@ describe RuboCop::Cop::Layout::ElseAlignment do
     end
 
     it 'registers an offense for misaligned else' do
-      inspect_source(cop, <<-END.strip_indent)
+      expect_offense(<<-END.strip_indent)
         def my_func
           puts 'do something error prone'
         rescue SomeException
@@ -533,10 +533,10 @@ describe RuboCop::Cop::Layout::ElseAlignment do
         rescue
           puts 'error handling'
           else
+          ^^^^ Align `else` with `def`.
           puts 'normal handling'
         end
       END
-      expect(cop.messages).to eq(['Align `else` with `def`.'])
     end
   end
 end

--- a/spec/rubocop/cop/layout/empty_lines_around_module_body_spec.rb
+++ b/spec/rubocop/cop/layout/empty_lines_around_module_body_spec.rb
@@ -66,13 +66,13 @@ describe RuboCop::Cop::Layout::EmptyLinesAroundModuleBody, :config do
     end
 
     it 'registers an offense for module body not ending with a blank' do
-      inspect_source(cop, <<-END.strip_indent)
+      expect_offense(<<-END.strip_indent)
         module SomeModule
 
           do_something
         end
+        ^ Empty line missing at module body end.
       END
-      expect(cop.messages).to eq(['Empty line missing at module body end.'])
     end
 
     it 'autocorrects beginning and end' do

--- a/spec/rubocop/cop/layout/indentation_consistency_spec.rb
+++ b/spec/rubocop/cop/layout/indentation_consistency_spec.rb
@@ -7,39 +7,39 @@ describe RuboCop::Cop::Layout::IndentationConsistency, :config do
 
   context 'with if statement' do
     it 'registers an offense for bad indentation in an if body' do
-      inspect_source(cop, <<-END.strip_indent)
+      expect_offense(<<-END.strip_indent)
         if cond
          func
           func
+          ^^^^ Inconsistent indentation detected.
         end
       END
-      expect(cop.messages).to eq(['Inconsistent indentation detected.'])
     end
 
     it 'registers an offense for bad indentation in an else body' do
-      inspect_source(cop, <<-END.strip_indent)
+      expect_offense(<<-END.strip_indent)
         if cond
           func1
         else
          func2
           func2
+          ^^^^^ Inconsistent indentation detected.
         end
       END
-      expect(cop.messages).to eq(['Inconsistent indentation detected.'])
     end
 
     it 'registers an offense for bad indentation in an elsif body' do
-      inspect_source(cop, <<-END.strip_indent)
+      expect_offense(<<-END.strip_indent)
         if a1
           b1
         elsif a2
          b2
         b3
+        ^^ Inconsistent indentation detected.
         else
           c
         end
       END
-      expect(cop.messages).to eq(['Inconsistent indentation detected.'])
     end
 
     it 'autocorrects bad indentation' do
@@ -222,13 +222,13 @@ describe RuboCop::Cop::Layout::IndentationConsistency, :config do
 
   context 'with unless' do
     it 'registers an offense for bad indentation in an unless body' do
-      inspect_source(cop, <<-END.strip_indent)
+      expect_offense(<<-END.strip_indent)
         unless cond
          func
           func
+          ^^^^ Inconsistent indentation detected.
         end
       END
-      expect(cop.messages).to eq(['Inconsistent indentation detected.'])
     end
 
     it 'accepts an empty unless' do
@@ -242,18 +242,18 @@ describe RuboCop::Cop::Layout::IndentationConsistency, :config do
 
   context 'with case' do
     it 'registers an offense for bad indentation in a case/when body' do
-      inspect_source(cop, <<-END.strip_indent)
+      expect_offense(<<-END.strip_indent)
         case a
         when b
          c
             d
+            ^ Inconsistent indentation detected.
         end
       END
-      expect(cop.messages).to eq(['Inconsistent indentation detected.'])
     end
 
     it 'registers an offense for bad indentation in a case/else body' do
-      inspect_source(cop, <<-END.strip_indent)
+      expect_offense(<<-END.strip_indent)
         case a
         when b
           c
@@ -262,9 +262,9 @@ describe RuboCop::Cop::Layout::IndentationConsistency, :config do
         else
            f
           g
+          ^ Inconsistent indentation detected.
         end
       END
-      expect(cop.messages).to eq(['Inconsistent indentation detected.'])
     end
 
     it 'accepts correctly indented case/when/else' do
@@ -318,33 +318,33 @@ describe RuboCop::Cop::Layout::IndentationConsistency, :config do
 
   context 'with while/until' do
     it 'registers an offense for bad indentation in a while body' do
-      inspect_source(cop, <<-END.strip_indent)
+      expect_offense(<<-END.strip_indent)
         while cond
          func
           func
+          ^^^^ Inconsistent indentation detected.
         end
       END
-      expect(cop.messages).to eq(['Inconsistent indentation detected.'])
     end
 
     it 'registers an offense for bad indentation in begin/end/while' do
-      inspect_source(cop, <<-END.strip_indent)
+      expect_offense(<<-END.strip_indent)
         something = begin
          func1
            func2
+           ^^^^^ Inconsistent indentation detected.
         end while cond
       END
-      expect(cop.messages).to eq(['Inconsistent indentation detected.'])
     end
 
     it 'registers an offense for bad indentation in an until body' do
-      inspect_source(cop, <<-END.strip_indent)
+      expect_offense(<<-END.strip_indent)
         until cond
          func
           func
+          ^^^^ Inconsistent indentation detected.
         end
       END
-      expect(cop.messages).to eq(['Inconsistent indentation detected.'])
     end
 
     it 'accepts an empty while' do
@@ -357,13 +357,13 @@ describe RuboCop::Cop::Layout::IndentationConsistency, :config do
 
   context 'with for' do
     it 'registers an offense for bad indentation in a for body' do
-      inspect_source(cop, <<-END.strip_indent)
+      expect_offense(<<-END.strip_indent)
         for var in 1..10
          func
         func
+        ^^^^ Inconsistent indentation detected.
         end
       END
-      expect(cop.messages).to eq(['Inconsistent indentation detected.'])
     end
 
     it 'accepts an empty for' do
@@ -376,24 +376,23 @@ describe RuboCop::Cop::Layout::IndentationConsistency, :config do
 
   context 'with def/defs' do
     it 'registers an offense for bad indentation in a def body' do
-      inspect_source(cop, <<-END.strip_indent)
+      expect_offense(<<-END.strip_indent)
         def test
             func1
              func2
+             ^^^^^ Inconsistent indentation detected.
         end
       END
-      expect(cop.messages)
-        .to eq(['Inconsistent indentation detected.'])
     end
 
     it 'registers an offense for bad indentation in a defs body' do
-      inspect_source(cop, <<-END.strip_indent)
+      expect_offense(<<-END.strip_indent)
         def self.test
            func
             func
+            ^^^^ Inconsistent indentation detected.
         end
       END
-      expect(cop.messages).to eq(['Inconsistent indentation detected.'])
     end
 
     it 'accepts an empty def body' do
@@ -542,23 +541,23 @@ describe RuboCop::Cop::Layout::IndentationConsistency, :config do
 
   context 'with block' do
     it 'registers an offense for bad indentation in a do/end body' do
-      inspect_source(cop, <<-END.strip_indent)
+      expect_offense(<<-END.strip_indent)
         a = func do
          b
           c
+          ^ Inconsistent indentation detected.
         end
       END
-      expect(cop.messages).to eq(['Inconsistent indentation detected.'])
     end
 
     it 'registers an offense for bad indentation in a {} body' do
-      inspect_source(cop, <<-END.strip_indent)
+      expect_offense(<<-END.strip_indent)
         func {
            b
           c
+          ^ Inconsistent indentation detected.
         }
       END
-      expect(cop.messages).to eq(['Inconsistent indentation detected.'])
     end
 
     it 'accepts a correctly indented block body' do

--- a/spec/rubocop/cop/layout/indentation_width_spec.rb
+++ b/spec/rubocop/cop/layout/indentation_width_spec.rb
@@ -125,16 +125,16 @@ describe RuboCop::Cop::Layout::IndentationWidth do
       end
 
       it 'registers an offense for bad indentation of an elsif body' do
-        inspect_source(cop, <<-END.strip_indent)
+        expect_offense(<<-END.strip_indent)
           if a1
             b1
           elsif a2
            b2
+          ^ Use 2 (not 1) spaces for indentation.
           else
             c
           end
         END
-        expect(cop.messages).to eq(['Use 2 (not 1) spaces for indentation.'])
       end
 
       it 'registers offense for bad indentation of ternary inside else' do
@@ -151,15 +151,14 @@ describe RuboCop::Cop::Layout::IndentationWidth do
       end
 
       it 'registers offense for bad indentation of modifier if in else' do
-        inspect_source(cop, <<-END.strip_indent)
+        expect_offense(<<-END.strip_indent)
           if a
             b
           else
              x if y
+          ^^^ Use 2 (not 3) spaces for indentation.
           end
         END
-        expect(cop.messages)
-          .to eq(['Use 2 (not 3) spaces for indentation.'])
       end
 
       it 'accepts indentation after if on new line after assignment' do
@@ -467,85 +466,77 @@ describe RuboCop::Cop::Layout::IndentationWidth do
 
           context 'and end is aligned with keyword' do
             it 'registers an offense for an if with setter' do
-              inspect_source(cop, <<-END.strip_indent)
+              expect_offense(<<-END.strip_indent)
                 foo.bar = if baz
                             derp
+                ^^^^^^^^^^^^ Use 2 (not 12) spaces for indentation.
                           end
               END
-              expect(cop.messages)
-                .to eq(['Use 2 (not 12) spaces for indentation.'])
             end
 
             it 'registers an offense for an if with element assignment' do
-              inspect_source(cop, <<-END.strip_indent)
+              expect_offense(<<-END.strip_indent)
                 foo[bar] = if baz
                              derp
+                ^^^^^^^^^^^^^ Use 2 (not 13) spaces for indentation.
                            end
               END
-              expect(cop.messages)
-                .to eq(['Use 2 (not 13) spaces for indentation.'])
             end
 
             it 'registers an offense for an if' do
-              inspect_source(cop, <<-END.strip_indent)
+              expect_offense(<<-END.strip_indent)
                 var = if a
                         0
+                ^^^^^^^^ Use 2 (not 8) spaces for indentation.
                       end
               END
-              expect(cop.messages)
-                .to eq(['Use 2 (not 8) spaces for indentation.'])
             end
 
             it 'registers an offense for a while' do
-              inspect_source(cop, <<-END.strip_indent)
+              expect_offense(<<-END.strip_indent)
                 var = while a
                         b
+                ^^^^^^^^ Use 2 (not 8) spaces for indentation.
                       end
               END
-              expect(cop.messages)
-                .to eq(['Use 2 (not 8) spaces for indentation.'])
             end
 
             it 'registers an offense for an until' do
-              inspect_source(cop, <<-END.strip_indent)
+              expect_offense(<<-END.strip_indent)
                 var = until a
                         b
+                ^^^^^^^^ Use 2 (not 8) spaces for indentation.
                       end
               END
-              expect(cop.messages)
-                .to eq(['Use 2 (not 8) spaces for indentation.'])
             end
           end
 
           context 'and end is aligned randomly' do
             it 'registers an offense for an if' do
-              inspect_source(cop, <<-END.strip_indent)
+              expect_offense(<<-END.strip_indent)
                 var = if a
                           0
+                ^^^^^^^^^^ Use 2 (not 10) spaces for indentation.
                       end
               END
-              expect(cop.messages)
-                .to eq(['Use 2 (not 10) spaces for indentation.'])
             end
 
             it 'registers an offense for a while' do
-              inspect_source(cop, <<-END.strip_indent)
+              expect_offense(<<-END.strip_indent)
                 var = while a
                           b
+                ^^^^^^^^^^ Use 2 (not 10) spaces for indentation.
                       end
               END
-              expect(cop.messages)
-                .to eq(['Use 2 (not 10) spaces for indentation.'])
             end
 
             it 'registers an offense for an until' do
-              inspect_source(cop, <<-END.strip_indent)
+              expect_offense(<<-END.strip_indent)
                 var = until a
                           b
+                ^^^^^^^^^^ Use 2 (not 10) spaces for indentation.
                       end
               END
-              expect(cop.messages)
-                .to eq(['Use 2 (not 10) spaces for indentation.'])
             end
           end
         end
@@ -667,12 +658,12 @@ describe RuboCop::Cop::Layout::IndentationWidth do
 
     context 'with unless' do
       it 'registers an offense for bad indentation of an unless body' do
-        inspect_source(cop, <<-END.strip_indent)
+        expect_offense(<<-END.strip_indent)
           unless cond
            func
+          ^ Use 2 (not 1) spaces for indentation.
           end
         END
-        expect(cop.messages).to eq(['Use 2 (not 1) spaces for indentation.'])
       end
 
       it 'accepts an empty unless' do
@@ -686,17 +677,17 @@ describe RuboCop::Cop::Layout::IndentationWidth do
 
     context 'with case' do
       it 'registers an offense for bad indentation in a case/when body' do
-        inspect_source(cop, <<-END.strip_indent)
+        expect_offense(<<-END.strip_indent)
           case a
           when b
            c
+          ^ Use 2 (not 1) spaces for indentation.
           end
         END
-        expect(cop.messages).to eq(['Use 2 (not 1) spaces for indentation.'])
       end
 
       it 'registers an offense for bad indentation in a case/else body' do
-        inspect_source(cop, <<-END.strip_indent)
+        expect_offense(<<-END.strip_indent)
           case a
           when b
             c
@@ -704,9 +695,9 @@ describe RuboCop::Cop::Layout::IndentationWidth do
             e
           else
              f
+          ^^^ Use 2 (not 3) spaces for indentation.
           end
         END
-        expect(cop.messages).to eq(['Use 2 (not 3) spaces for indentation.'])
       end
 
       it 'accepts correctly indented case/when/else' do
@@ -774,31 +765,31 @@ describe RuboCop::Cop::Layout::IndentationWidth do
 
     context 'with while/until' do
       it 'registers an offense for bad indentation of a while body' do
-        inspect_source(cop, <<-END.strip_indent)
+        expect_offense(<<-END.strip_indent)
           while cond
            func
+          ^ Use 2 (not 1) spaces for indentation.
           end
         END
-        expect(cop.messages).to eq(['Use 2 (not 1) spaces for indentation.'])
       end
 
       it 'registers an offense for bad indentation of begin/end/while' do
-        inspect_source(cop, <<-END.strip_indent)
+        expect_offense(<<-END.strip_indent)
           something = begin
            func1
+          ^ Use 2 (not 1) spaces for indentation.
              func2
           end while cond
         END
-        expect(cop.messages).to eq(['Use 2 (not 1) spaces for indentation.'])
       end
 
       it 'registers an offense for bad indentation of an until body' do
-        inspect_source(cop, <<-END.strip_indent)
+        expect_offense(<<-END.strip_indent)
           until cond
            func
+          ^ Use 2 (not 1) spaces for indentation.
           end
         END
-        expect(cop.messages).to eq(['Use 2 (not 1) spaces for indentation.'])
       end
 
       it 'accepts an empty while' do
@@ -811,12 +802,12 @@ describe RuboCop::Cop::Layout::IndentationWidth do
 
     context 'with for' do
       it 'registers an offense for bad indentation of a for body' do
-        inspect_source(cop, <<-END.strip_indent)
+        expect_offense(<<-END.strip_indent)
           for var in 1..10
            func
+          ^ Use 2 (not 1) spaces for indentation.
           end
         END
-        expect(cop.messages).to eq(['Use 2 (not 1) spaces for indentation.'])
       end
 
       it 'accepts an empty for' do
@@ -888,23 +879,21 @@ describe RuboCop::Cop::Layout::IndentationWidth do
             end
 
             it 'registers an offense for bad indentation of a def body' do
-              inspect_source(cop, <<-END.strip_indent)
+              expect_offense(<<-END.strip_indent)
                 foo def test
                       something
+                ^^^^^^ Use 2 (not 6) spaces for indentation.
                     end
               END
-              expect(cop.messages)
-                .to eq(['Use 2 (not 6) spaces for indentation.'])
             end
 
             it 'registers an offense for bad indentation of a defs body' do
-              inspect_source(cop, <<-END.strip_indent)
+              expect_offense(<<-END.strip_indent)
                 foo def self.test
                       something
+                ^^^^^^ Use 2 (not 6) spaces for indentation.
                     end
               END
-              expect(cop.messages)
-                .to eq(['Use 2 (not 6) spaces for indentation.'])
             end
           end
         end
@@ -928,23 +917,21 @@ describe RuboCop::Cop::Layout::IndentationWidth do
             end
 
             it 'registers an offense for bad indentation of a def body' do
-              inspect_source(cop, <<-END.strip_indent)
+              expect_offense(<<-END.strip_indent)
                 foo def test
                   something
+                  ^^ Use 2 (not -2) spaces for indentation.
                     end
               END
-              expect(cop.messages)
-                .to eq(['Use 2 (not -2) spaces for indentation.'])
             end
 
             it 'registers an offense for bad indentation of a defs body' do
-              inspect_source(cop, <<-END.strip_indent)
+              expect_offense(<<-END.strip_indent)
                 foo def self.test
                   something
+                  ^^ Use 2 (not -2) spaces for indentation.
                     end
               END
-              expect(cop.messages)
-                .to eq(['Use 2 (not -2) spaces for indentation.'])
             end
           end
         end
@@ -953,13 +940,13 @@ describe RuboCop::Cop::Layout::IndentationWidth do
 
     context 'with class' do
       it 'registers an offense for bad indentation of a class body' do
-        inspect_source(cop, <<-END.strip_indent)
+        expect_offense(<<-END.strip_indent)
           class Test
               def func
+          ^^^^ Use 2 (not 4) spaces for indentation.
               end
           end
         END
-        expect(cop.messages).to eq(['Use 2 (not 4) spaces for indentation.'])
       end
 
       it 'accepts an empty class body' do
@@ -1024,13 +1011,13 @@ describe RuboCop::Cop::Layout::IndentationWidth do
     context 'with module' do
       context 'when consistency style is normal' do
         it 'registers an offense for bad indentation of a module body' do
-          inspect_source(cop, <<-END.strip_indent)
+          expect_offense(<<-END.strip_indent)
             module Test
                 def func
+            ^^^^ Use 2 (not 4) spaces for indentation.
                 end
             end
           END
-          expect(cop.messages).to eq(['Use 2 (not 4) spaces for indentation.'])
         end
 
         it 'accepts an empty module body' do
@@ -1045,18 +1032,17 @@ describe RuboCop::Cop::Layout::IndentationWidth do
         let(:consistency_config) { { 'EnforcedStyle' => 'rails' } }
 
         it 'registers an offense for bad indentation of a module body' do
-          inspect_source(cop, <<-END.strip_indent)
+          expect_offense(<<-END.strip_indent)
             module Test
                def func1
+            ^^^ Use 2 (not 3) spaces for indentation.
                end
               private
              def func2
+             ^ Use 2 (not -1) spaces for rails indentation.
              end
             end
           END
-          expect(cop.messages)
-            .to eq(['Use 2 (not 3) spaces for indentation.',
-                    'Use 2 (not -1) spaces for rails indentation.'])
         end
 
         it 'accepts normal non-rails indentation of module functions' do
@@ -1099,31 +1085,31 @@ describe RuboCop::Cop::Layout::IndentationWidth do
 
     context 'with def/rescue/end' do
       it 'registers an offense for bad indentation of bodies' do
-        inspect_source(cop, <<-END.strip_indent)
+        expect_offense(<<-END.strip_indent)
           def my_func
             puts 'do something error prone'
           rescue SomeException
            puts 'wrongly intended error handling'
+          ^ Use 2 (not 1) spaces for indentation.
           rescue
            puts 'wrongly intended error handling'
+          ^ Use 2 (not 1) spaces for indentation.
           end
         END
-        expect(cop.messages).to eq(['Use 2 (not 1) spaces for indentation.',
-                                    'Use 2 (not 1) spaces for indentation.'])
       end
 
       it 'registers an offense for bad indent of defs bodies with a modifier' do
-        inspect_source(cop, <<-END.strip_indent)
+        expect_offense(<<-END.strip_indent)
           foo def self.my_func
             puts 'do something error prone'
           rescue SomeException
            puts 'wrongly intended error handling'
+          ^ Use 2 (not 1) spaces for indentation.
           rescue
            puts 'wrongly intended error handling'
+          ^ Use 2 (not 1) spaces for indentation.
           end
         END
-        expect(cop.messages).to eq(['Use 2 (not 1) spaces for indentation.',
-                                    'Use 2 (not 1) spaces for indentation.'])
       end
     end
 
@@ -1151,21 +1137,21 @@ describe RuboCop::Cop::Layout::IndentationWidth do
       end
 
       it 'registers an offense for bad indentation of a do/end body' do
-        inspect_source(cop, <<-END.strip_indent)
+        expect_offense(<<-END.strip_indent)
           a = func do
            b
+          ^ Use 2 (not 1) spaces for indentation.
           end
         END
-        expect(cop.messages).to eq(['Use 2 (not 1) spaces for indentation.'])
       end
 
       it 'registers an offense for bad indentation of a {} body' do
-        inspect_source(cop, <<-END.strip_indent)
+        expect_offense(<<-END.strip_indent)
           func {
              b
+          ^^^ Use 2 (not 3) spaces for indentation.
           }
         END
-        expect(cop.messages).to eq(['Use 2 (not 3) spaces for indentation.'])
       end
 
       it 'accepts a correctly indented block body' do

--- a/spec/rubocop/cop/layout/multiline_block_layout_spec.rb
+++ b/spec/rubocop/cop/layout/multiline_block_layout_spec.rb
@@ -4,39 +4,35 @@ describe RuboCop::Cop::Layout::MultilineBlockLayout do
   subject(:cop) { described_class.new }
 
   it 'registers an offense for missing newline in do/end block w/o params' do
-    inspect_source(cop, <<-END.strip_indent)
+    expect_offense(<<-END.strip_indent)
       test do foo
+              ^^^ Block body expression is on the same line as the block start.
       end
     END
-    expect(cop.messages)
-      .to eq(['Block body expression is on the same line as the block start.'])
   end
 
   it 'registers an offense for missing newline in {} block w/o params' do
-    inspect_source(cop, <<-END.strip_indent)
+    expect_offense(<<-END.strip_indent)
       test { foo
+             ^^^ Block body expression is on the same line as the block start.
       }
     END
-    expect(cop.messages)
-      .to eq(['Block body expression is on the same line as the block start.'])
   end
 
   it 'registers an offense for missing newline in do/end block with params' do
-    inspect_source(cop, <<-END.strip_indent)
+    expect_offense(<<-END.strip_indent)
       test do |x| foo
+                  ^^^ Block body expression is on the same line as the block start.
       end
     END
-    expect(cop.messages)
-      .to eq(['Block body expression is on the same line as the block start.'])
   end
 
   it 'registers an offense for missing newline in {} block with params' do
-    inspect_source(cop, <<-END.strip_indent)
+    expect_offense(<<-END.strip_indent)
       test { |x| foo
+                 ^^^ Block body expression is on the same line as the block start.
       }
     END
-    expect(cop.messages)
-      .to eq(['Block body expression is on the same line as the block start.'])
   end
 
   it 'does not register an offense for one-line do/end blocks' do
@@ -91,25 +87,21 @@ describe RuboCop::Cop::Layout::MultilineBlockLayout do
   end
 
   it 'registers an offense for line-break before arguments' do
-    inspect_source(cop, <<-END.strip_indent)
+    expect_offense(<<-END.strip_indent)
       test do
         |x| play_with(x)
+        ^^^ Block argument expression is not on the same line as the block start.
       end
     END
-    expect(cop.messages)
-      .to eq(['Block argument expression is not on the same line as the ' \
-              'block start.'])
   end
 
   it 'registers an offense for line-break before arguments with empty block' do
-    inspect_source(cop, <<-END.strip_indent)
+    expect_offense(<<-END.strip_indent)
       test do
         |x|
+        ^^^ Block argument expression is not on the same line as the block start.
       end
     END
-    expect(cop.messages)
-      .to eq(['Block argument expression is not on the same line as the ' \
-              'block start.'])
   end
 
   it 'registers an offense for line-break within arguments' do

--- a/spec/rubocop/cop/layout/multiline_method_call_indentation_spec.rb
+++ b/spec/rubocop/cop/layout/multiline_method_call_indentation_spec.rb
@@ -870,14 +870,16 @@ describe RuboCop::Cop::Layout::MultilineMethodCallIndentation do
     end
 
     it 'registers an offense for aligned operators in assignment' do
-      inspect_source(cop, <<-END.strip_indent)
+      msg = 'Use %d (not %d) spaces for indenting an expression ' \
+              'in an assignment spanning multiple lines.'
+
+      expect_offense(<<-END.strip_indent)
         formatted_int = int_part
                         .abs
+                        ^^^^ #{format(msg, 2, 16)}
                         .reverse
+                        ^^^^^^^^ #{format(msg, 2, 16)}
       END
-      expect(cop.messages).to eq(['Use 2 (not 16) spaces for indenting an ' \
-                                  'expression in an assignment spanning ' \
-                                  'multiple lines.'] * 2)
     end
 
     it 'auto-corrects' do

--- a/spec/rubocop/cop/layout/multiline_operation_indentation_spec.rb
+++ b/spec/rubocop/cop/layout/multiline_operation_indentation_spec.rb
@@ -557,14 +557,15 @@ describe RuboCop::Cop::Layout::MultilineOperationIndentation do
     end
 
     it 'registers an offense for aligned operators in assignment' do
-      inspect_source(cop, <<-END.strip_indent)
+      msg = 'Use %d (not %d) spaces for indenting an expression in ' \
+              'an assignment spanning multiple lines.'
+      expect_offense(<<-END.strip_indent)
         a = b +
             c +
+            ^ #{format(msg, 2, 4)}
             d
+            ^ #{format(msg, 2, 4)}
       END
-      expect(cop.messages).to eq(['Use 2 (not 4) spaces for indenting an ' \
-                                  'expression in an assignment spanning ' \
-                                  'multiple lines.'] * 2)
     end
 
     it 'auto-corrects' do

--- a/spec/rubocop/cop/layout/space_after_colon_spec.rb
+++ b/spec/rubocop/cop/layout/space_after_colon_spec.rb
@@ -61,11 +61,11 @@ describe RuboCop::Cop::Layout::SpaceAfterColon do
     end
 
     it 'registers an offence if an keyword optional argument has no space' do
-      inspect_source(cop, <<-END.strip_indent)
+      expect_offense(<<-END.strip_indent)
         def m(var:1, other_var: 2)
+                 ^ Space missing after colon.
         end
       END
-      expect(cop.messages).to eq(['Space missing after colon.'])
     end
   end
 

--- a/spec/rubocop/cop/layout/space_after_semicolon_spec.rb
+++ b/spec/rubocop/cop/layout/space_after_semicolon_spec.rb
@@ -8,10 +8,10 @@ describe RuboCop::Cop::Layout::SpaceAfterSemicolon do
   let(:brace_config) { {} }
 
   it 'registers an offense for semicolon without space after it' do
-    inspect_source(cop, 'x = 1;y = 2')
-    expect(cop.messages).to eq(
-      ['Space missing after semicolon.']
-    )
+    expect_offense(<<-RUBY.strip_indent)
+      x = 1;y = 2
+           ^ Space missing after semicolon.
+    RUBY
   end
 
   it 'does not crash if semicolon is the last character of the file' do

--- a/spec/rubocop/cop/layout/space_around_operators_spec.rb
+++ b/spec/rubocop/cop/layout/space_around_operators_spec.rb
@@ -310,23 +310,22 @@ describe RuboCop::Cop::Layout::SpaceAroundOperators do
     end
 
     it 'registers an offense for operators without spaces' do
-      inspect_source(cop, <<-END.strip_indent)
+      expect_offense(<<-END.strip_indent)
         x+= a+b-c*d/e%f^g|h&i||j
+         ^^ Surrounding space missing for operator `+=`.
+             ^ Surrounding space missing for operator `+`.
+               ^ Surrounding space missing for operator `-`.
+                 ^ Surrounding space missing for operator `*`.
+                   ^ Surrounding space missing for operator `/`.
+                     ^ Surrounding space missing for operator `%`.
+                       ^ Surrounding space missing for operator `^`.
+                         ^ Surrounding space missing for operator `|`.
+                           ^ Surrounding space missing for operator `&`.
+                             ^^ Surrounding space missing for operator `||`.
         y -=k&&l
+          ^^ Surrounding space missing for operator `-=`.
+             ^^ Surrounding space missing for operator `&&`.
       END
-      expect(cop.messages)
-        .to eq(['Surrounding space missing for operator `+=`.',
-                'Surrounding space missing for operator `+`.',
-                'Surrounding space missing for operator `-`.',
-                'Surrounding space missing for operator `*`.',
-                'Surrounding space missing for operator `/`.',
-                'Surrounding space missing for operator `%`.',
-                'Surrounding space missing for operator `^`.',
-                'Surrounding space missing for operator `|`.',
-                'Surrounding space missing for operator `&`.',
-                'Surrounding space missing for operator `||`.',
-                'Surrounding space missing for operator `-=`.',
-                'Surrounding space missing for operator `&&`.'])
     end
 
     it 'auto-corrects missing space' do
@@ -398,39 +397,37 @@ describe RuboCop::Cop::Layout::SpaceAroundOperators do
     end
 
     it 'registers an offense for match operators without space' do
-      inspect_source(cop, <<-END.strip_indent)
+      expect_offense(<<-END.strip_indent)
         x=~/abc/
+         ^^ Surrounding space missing for operator `=~`.
         y !~/abc/
+          ^^ Surrounding space missing for operator `!~`.
       END
-      expect(cop.messages)
-        .to eq(['Surrounding space missing for operator `=~`.',
-                'Surrounding space missing for operator `!~`.'])
     end
 
     it 'registers an offense for various assignments without space' do
-      inspect_source(cop, <<-END.strip_indent)
+      expect_offense(<<-END.strip_indent)
         x||=0
+         ^^^ Surrounding space missing for operator `||=`.
         y&&=0
+         ^^^ Surrounding space missing for operator `&&=`.
         z*=2
+         ^^ Surrounding space missing for operator `*=`.
         @a=0
+          ^ Surrounding space missing for operator `=`.
         @@a=0
+           ^ Surrounding space missing for operator `=`.
         a,b=0
+           ^ Surrounding space missing for operator `=`.
         A=0
+         ^ Surrounding space missing for operator `=`.
         x[3]=0
+            ^ Surrounding space missing for operator `=`.
         $A=0
+          ^ Surrounding space missing for operator `=`.
         A||=0
+         ^^^ Surrounding space missing for operator `||=`.
       END
-      expect(cop.messages)
-        .to eq(['Surrounding space missing for operator `||=`.',
-                'Surrounding space missing for operator `&&=`.',
-                'Surrounding space missing for operator `*=`.',
-                'Surrounding space missing for operator `=`.',
-                'Surrounding space missing for operator `=`.',
-                'Surrounding space missing for operator `=`.',
-                'Surrounding space missing for operator `=`.',
-                'Surrounding space missing for operator `=`.',
-                'Surrounding space missing for operator `=`.',
-                'Surrounding space missing for operator `||=`.'])
     end
 
     it 'registers an offense for equality operators without space' do
@@ -448,22 +445,20 @@ describe RuboCop::Cop::Layout::SpaceAroundOperators do
     end
 
     it 'registers an offense for inheritance < without space' do
-      inspect_source(cop, <<-END.strip_indent)
+      expect_offense(<<-END.strip_indent)
         class ShowSourceTestClass<ShowSourceTestSuperClass
+                                 ^ Surrounding space missing for operator `<`.
         end
       END
-      expect(cop.messages)
-        .to eq(['Surrounding space missing for operator `<`.'])
     end
 
     it 'registers an offense for hash rocket without space at rescue' do
-      inspect_source(cop, <<-END.strip_indent)
+      expect_offense(<<-END.strip_indent)
         begin
         rescue Exception=>e
+                        ^^ Surrounding space missing for operator `=>`.
         end
       END
-      expect(cop.messages)
-        .to eq(['Surrounding space missing for operator `=>`.'])
     end
 
     it "doesn't eat a newline when auto-correcting" do
@@ -510,15 +505,14 @@ describe RuboCop::Cop::Layout::SpaceAroundOperators do
     end
 
     it 'registers an offense for assignment with many spaces on either side' do
-      inspect_source(cop, <<-END.strip_indent)
+      expect_offense(<<-END.strip_indent)
         x   = 0
+            ^ Operator `=` should be surrounded by a single space.
         y +=   0
+          ^^ Operator `+=` should be surrounded by a single space.
         z[0]  =  0
+              ^ Operator `=` should be surrounded by a single space.
       END
-      expect(cop.messages)
-        .to eq(['Operator `=` should be surrounded by a single space.',
-                'Operator `+=` should be surrounded by a single space.',
-                'Operator `=` should be surrounded by a single space.'])
     end
 
     it 'auto-corrects assignment with too many spaces on either side' do
@@ -553,16 +547,14 @@ describe RuboCop::Cop::Layout::SpaceAroundOperators do
     it_behaves_like 'modifier with extra space', 'until'
 
     it 'registers an offense for binary operators that could be unary' do
-      inspect_source(cop, <<-END.strip_indent)
+      expect_offense(<<-END.strip_indent)
         a -  3
+          ^ Operator `-` should be surrounded by a single space.
         x &   0xff
+          ^ Operator `&` should be surrounded by a single space.
         z +  0
+          ^ Operator `+` should be surrounded by a single space.
       END
-      expect(cop.messages).to eq(
-        ['Operator `-` should be surrounded by a single space.',
-         'Operator `&` should be surrounded by a single space.',
-         'Operator `+` should be surrounded by a single space.']
-      )
     end
 
     it 'auto-corrects missing space in binary operators that could be unary' do
@@ -591,23 +583,31 @@ describe RuboCop::Cop::Layout::SpaceAroundOperators do
     end
 
     it 'registers an offense for operators with too many spaces' do
-      inspect_source(cop, <<-END.strip_indent)
-        x +=  a  + b -  c  * d /  e  % f  ^ g   | h &  i  ||  j
+      expect_offense(<<-END.strip_indent)
+        x +=  a
+          ^^ Operator `+=` should be surrounded by a single space.
+        a  + b
+           ^ Operator `+` should be surrounded by a single space.
+        b  -  c
+           ^ Operator `-` should be surrounded by a single space.
+        c  * d
+           ^ Operator `*` should be surrounded by a single space.
+        d  /  e
+           ^ Operator `/` should be surrounded by a single space.
+        e  % f
+           ^ Operator `%` should be surrounded by a single space.
+        f  ^ g
+           ^ Operator `^` should be surrounded by a single space.
+        g  | h
+           ^ Operator `|` should be surrounded by a single space.
+        h  &  i
+           ^ Operator `&` should be surrounded by a single space.
+        i  ||  j
+           ^^ Operator `||` should be surrounded by a single space.
         y  -=  k   &&        l
+           ^^ Operator `-=` should be surrounded by a single space.
+                   ^^ Operator `&&` should be surrounded by a single space.
       END
-      expect(cop.messages)
-        .to eq(['Operator `+=` should be surrounded by a single space.',
-                'Operator `+` should be surrounded by a single space.',
-                'Operator `-` should be surrounded by a single space.',
-                'Operator `*` should be surrounded by a single space.',
-                'Operator `/` should be surrounded by a single space.',
-                'Operator `%` should be surrounded by a single space.',
-                'Operator `^` should be surrounded by a single space.',
-                'Operator `|` should be surrounded by a single space.',
-                'Operator `&` should be surrounded by a single space.',
-                'Operator `||` should be surrounded by a single space.',
-                'Operator `-=` should be surrounded by a single space.',
-                'Operator `&&` should be surrounded by a single space.'])
     end
 
     it 'auto-corrects missing space' do
@@ -665,54 +665,50 @@ describe RuboCop::Cop::Layout::SpaceAroundOperators do
       let(:allow_for_alignment) { false }
 
       it 'accepts an extra space' do
-        inspect_source(cop, <<-END.strip_indent)
+        expect_offense(<<-END.strip_indent)
           {
             1 =>  2,
+              ^^ Operator `=>` should be surrounded by a single space.
             11 => 3
           }
         END
-        expect(cop.messages).to eq(
-          ['Operator `=>` should be surrounded by a single space.']
-        )
       end
     end
 
     it 'registers an offense for match operators with too many spaces' do
-      inspect_source(cop, <<-END.strip_indent)
+      expect_offense(<<-END.strip_indent)
         x  =~ /abc/
+           ^^ Operator `=~` should be surrounded by a single space.
         y !~   /abc/
+          ^^ Operator `!~` should be surrounded by a single space.
       END
-      expect(cop.messages)
-        .to eq(['Operator `=~` should be surrounded by a single space.',
-                'Operator `!~` should be surrounded by a single space.'])
     end
 
     it 'registers an offense for various assignments with too many spaces' do
-      inspect_source(cop, <<-END.strip_indent)
+      expect_offense(<<-END.strip_indent)
         x ||=  0
+          ^^^ Operator `||=` should be surrounded by a single space.
         y  &&=  0
+           ^^^ Operator `&&=` should be surrounded by a single space.
         z  *=   2
+           ^^ Operator `*=` should be surrounded by a single space.
         @a   = 0
+             ^ Operator `=` should be surrounded by a single space.
         @@a   = 0
+              ^ Operator `=` should be surrounded by a single space.
         a,b    =   0
+               ^ Operator `=` should be surrounded by a single space.
         A  = 0
+           ^ Operator `=` should be surrounded by a single space.
         x[3]   = 0
+               ^ Operator `=` should be surrounded by a single space.
         $A    =   0
+              ^ Operator `=` should be surrounded by a single space.
         A  ||=  0
+           ^^^ Operator `||=` should be surrounded by a single space.
         A  +=    0
+           ^^ Operator `+=` should be surrounded by a single space.
       END
-      expect(cop.messages)
-        .to eq(['Operator `||=` should be surrounded by a single space.',
-                'Operator `&&=` should be surrounded by a single space.',
-                'Operator `*=` should be surrounded by a single space.',
-                'Operator `=` should be surrounded by a single space.',
-                'Operator `=` should be surrounded by a single space.',
-                'Operator `=` should be surrounded by a single space.',
-                'Operator `=` should be surrounded by a single space.',
-                'Operator `=` should be surrounded by a single space.',
-                'Operator `=` should be surrounded by a single space.',
-                'Operator `||=` should be surrounded by a single space.',
-                'Operator `+=` should be surrounded by a single space.'])
     end
 
     it 'registers an offense for equality operators with too many spaces' do
@@ -731,22 +727,20 @@ describe RuboCop::Cop::Layout::SpaceAroundOperators do
     end
 
     it 'registers an offense for inheritance < with too many spaces' do
-      inspect_source(cop, <<-END.strip_indent)
-        class ShowSourceTestClass  <  ShowSourceTestSuperClass
+      expect_offense(<<-END.strip_indent)
+        class Foo  <  Bar
+                   ^ Operator `<` should be surrounded by a single space.
         end
       END
-      expect(cop.messages)
-        .to eq(['Operator `<` should be surrounded by a single space.'])
     end
 
     it 'registers an offense for hash rocket with too many spaces at rescue' do
-      inspect_source(cop, <<-END.strip_indent)
+      expect_offense(<<-END.strip_indent)
         begin
         rescue Exception   =>      e
+                           ^^ Operator `=>` should be surrounded by a single space.
         end
       END
-      expect(cop.messages)
-        .to eq(['Operator `=>` should be surrounded by a single space.'])
     end
   end
 end

--- a/spec/rubocop/cop/layout/space_before_comma_spec.rb
+++ b/spec/rubocop/cop/layout/space_before_comma_spec.rb
@@ -4,24 +4,24 @@ describe RuboCop::Cop::Layout::SpaceBeforeComma do
   subject(:cop) { described_class.new }
 
   it 'registers an offense for block argument with space before comma' do
-    inspect_source(cop, 'each { |s , t| }')
-    expect(cop.messages).to eq(
-      ['Space found before comma.']
-    )
+    expect_offense(<<-RUBY.strip_indent)
+      each { |s , t| }
+               ^ Space found before comma.
+    RUBY
   end
 
   it 'registers an offense for array index with space before comma' do
-    inspect_source(cop, 'formats[0 , 1]')
-    expect(cop.messages).to eq(
-      ['Space found before comma.']
-    )
+    expect_offense(<<-RUBY.strip_indent)
+      formats[0 , 1]
+               ^ Space found before comma.
+    RUBY
   end
 
   it 'registers an offense for method call arg with space before comma' do
-    inspect_source(cop, 'a(1 , 2)')
-    expect(cop.messages).to eq(
-      ['Space found before comma.']
-    )
+    expect_offense(<<-RUBY.strip_indent)
+      a(1 , 2)
+         ^ Space found before comma.
+    RUBY
   end
 
   it 'does not register an offense for no spaces before comma' do

--- a/spec/rubocop/cop/layout/space_before_semicolon_spec.rb
+++ b/spec/rubocop/cop/layout/space_before_semicolon_spec.rb
@@ -8,10 +8,10 @@ describe RuboCop::Cop::Layout::SpaceBeforeSemicolon do
   let(:brace_config) { {} }
 
   it 'registers an offense for space before semicolon' do
-    inspect_source(cop, 'x = 1 ; y = 2')
-    expect(cop.messages).to eq(
-      ['Space found before semicolon.']
-    )
+    expect_offense(<<-RUBY.strip_indent)
+      x = 1 ; y = 2
+           ^ Space found before semicolon.
+    RUBY
   end
 
   it 'does not register an offense for no space before semicolons' do

--- a/spec/rubocop/cop/layout/space_inside_brackets_spec.rb
+++ b/spec/rubocop/cop/layout/space_inside_brackets_spec.rb
@@ -4,36 +4,30 @@ describe RuboCop::Cop::Layout::SpaceInsideBrackets do
   subject(:cop) { described_class.new }
 
   it 'registers an offense for an array literal with spaces inside' do
-    inspect_source(cop, <<-END.strip_indent)
+    expect_offense(<<-END.strip_indent)
       a = [1, 2 ]
+               ^ Space inside square brackets detected.
       b = [ 1, 2]
+           ^ Space inside square brackets detected.
     END
-    expect(cop.messages).to eq(
-      ['Space inside square brackets detected.',
-       'Space inside square brackets detected.']
-    )
   end
 
   it 'registers an offense for Hash#[] with symbol key and spaces inside' do
-    inspect_source(cop, <<-END.strip_indent)
+    expect_offense(<<-END.strip_indent)
       a[ :key]
+        ^ Space inside square brackets detected.
       b[:key ]
+            ^ Space inside square brackets detected.
     END
-    expect(cop.messages).to eq(
-      ['Space inside square brackets detected.',
-       'Space inside square brackets detected.']
-    )
   end
 
   it 'registers an offense for Hash#[] with string key and spaces inside' do
-    inspect_source(cop, <<-END.strip_indent)
+    expect_offense(<<-END.strip_indent)
       a[\'key\' ]
+             ^ Space inside square brackets detected.
       b[ \'key\']
+        ^ Space inside square brackets detected.
     END
-    expect(cop.messages).to eq(
-      ['Space inside square brackets detected.',
-       'Space inside square brackets detected.']
-    )
   end
 
   it 'accepts space inside strings within square brackets' do

--- a/spec/rubocop/cop/layout/space_inside_parens_spec.rb
+++ b/spec/rubocop/cop/layout/space_inside_parens_spec.rb
@@ -4,11 +4,12 @@ describe RuboCop::Cop::Layout::SpaceInsideParens do
   subject(:cop) { described_class.new }
 
   it 'registers an offense for spaces inside parens' do
-    inspect_source(cop, <<-END.strip_indent)
+    expect_offense(<<-END.strip_indent)
       f( 3)
+        ^ Space inside parentheses detected.
       g = (a + 3 )
+                ^ Space inside parentheses detected.
     END
-    expect(cop.messages).to eq(['Space inside parentheses detected.'] * 2)
   end
 
   it 'accepts parentheses in block parameter list' do

--- a/spec/rubocop/cop/layout/tab_spec.rb
+++ b/spec/rubocop/cop/layout/tab_spec.rb
@@ -19,12 +19,12 @@ describe RuboCop::Cop::Layout::Tab do
   end
 
   it 'registers offenses before __END__ but not after' do
-    inspect_source(cop, <<-END.strip_indent)
+    expect_offense(<<-END.strip_indent)
       \tx = 0
+      ^ Tab detected.
       __END__
       \tx = 0
     END
-    expect(cop.messages).to eq(['Tab detected.'])
   end
 
   it 'accepts a line with tab in a string' do

--- a/spec/rubocop/cop/lint/block_alignment_spec.rb
+++ b/spec/rubocop/cop/lint/block_alignment_spec.rb
@@ -8,12 +8,11 @@ describe RuboCop::Cop::Lint::BlockAlignment, :config do
 
   context 'when the block has no arguments' do
     it 'registers an offense for mismatched block end' do
-      inspect_source(cop, <<-END.strip_indent)
+      expect_offense(<<-END.strip_indent)
         test do
           end
+          ^^^ `end` at 2, 2 is not aligned with `test do` at 1, 0.
       END
-      expect(cop.messages)
-        .to eq(['`end` at 2, 2 is not aligned with `test do` at 1, 0.'])
     end
 
     it 'auto-corrects alignment' do
@@ -31,12 +30,11 @@ describe RuboCop::Cop::Lint::BlockAlignment, :config do
 
   context 'when the block has arguments' do
     it 'registers an offense for mismatched block end' do
-      inspect_source(cop, <<-END.strip_indent)
+      expect_offense(<<-END.strip_indent)
         test do |ala|
           end
+          ^^^ `end` at 2, 2 is not aligned with `test do |ala|` at 1, 0.
       END
-      expect(cop.messages)
-        .to eq(['`end` at 2, 2 is not aligned with `test do |ala|` at 1, 0.'])
     end
 
     it 'auto-corrects alignment' do
@@ -81,13 +79,11 @@ describe RuboCop::Cop::Lint::BlockAlignment, :config do
 
   context 'when there is an assignment chain' do
     it 'registers an offense for an end aligned with the 2nd variable' do
-      inspect_source(cop, <<-END.strip_indent)
+      expect_offense(<<-END.strip_indent)
         a = b = c = test do |ala|
             end
+            ^^^ `end` at 2, 4 is not aligned with `a = b = c = test do |ala|` at 1, 0.
       END
-      expect(cop.messages)
-        .to eq(['`end` at 2, 4 is not aligned with' \
-                ' `a = b = c = test do |ala|` at 1, 0.'])
     end
 
     it 'accepts end aligned with the first variable' do
@@ -121,13 +117,11 @@ describe RuboCop::Cop::Lint::BlockAlignment, :config do
   end
 
   it 'registers an offense for mismatched block end with a variable' do
-    inspect_source(cop, <<-END.strip_indent)
+    expect_offense(<<-END.strip_indent)
       variable = test do |ala|
         end
+        ^^^ `end` at 2, 2 is not aligned with `variable = test do |ala|` at 1, 0.
     END
-    expect(cop.messages)
-      .to eq(['`end` at 2, 2 is not aligned with `variable = test do |ala|`' \
-              ' at 1, 0.'])
   end
 
   context 'when the block is defined on the next line' do
@@ -141,15 +135,13 @@ describe RuboCop::Cop::Lint::BlockAlignment, :config do
     end
 
     it 'registers an offenses for mismatched end alignment' do
-      inspect_source(cop, <<-END.strip_indent)
+      expect_offense(<<-END.strip_indent)
         variable =
           a_long_method_that_dont_fit_on_the_line do |v|
             v.foo
         end
+        ^^^ `end` at 4, 0 is not aligned with `a_long_method_that_dont_fit_on_the_line do |v|` at 2, 2.
       END
-      expect(cop.messages)
-        .to eq(['`end` at 4, 0 is not aligned with' \
-                ' `a_long_method_that_dont_fit_on_the_line do |v|` at 2, 2.'])
     end
 
     it 'auto-corrects alignment' do
@@ -357,13 +349,11 @@ describe RuboCop::Cop::Lint::BlockAlignment, :config do
   end
 
   it 'registers an offense for mismatched block end with a class variable' do
-    inspect_source(cop, <<-END.strip_indent)
+    expect_offense(<<-END.strip_indent)
       @@variable = test do |ala|
         end
+        ^^^ `end` at 2, 2 is not aligned with `@@variable = test do |ala|` at 1, 0.
     END
-    expect(cop.messages)
-      .to eq(['`end` at 2, 2 is not aligned with `@@variable = test do |ala|`' \
-              ' at 1, 0.'])
   end
 
   it 'accepts end aligned with a global variable' do
@@ -374,13 +364,11 @@ describe RuboCop::Cop::Lint::BlockAlignment, :config do
   end
 
   it 'registers an offense for mismatched block end with a global variable' do
-    inspect_source(cop, <<-END.strip_indent)
+    expect_offense(<<-END.strip_indent)
       $variable = test do |ala|
         end
+        ^^^ `end` at 2, 2 is not aligned with `$variable = test do |ala|` at 1, 0.
     END
-    expect(cop.messages)
-      .to eq(['`end` at 2, 2 is not aligned with `$variable = test do |ala|`' \
-              ' at 1, 0.'])
   end
 
   it 'accepts end aligned with a constant' do
@@ -391,13 +379,11 @@ describe RuboCop::Cop::Lint::BlockAlignment, :config do
   end
 
   it 'registers an offense for mismatched block end with a constant' do
-    inspect_source(cop, <<-END.strip_indent)
+    expect_offense(<<-END.strip_indent)
       Module::CONSTANT = test do |ala|
         end
+        ^^^ `end` at 2, 2 is not aligned with `Module::CONSTANT = test do |ala|` at 1, 0.
     END
-    expect(cop.messages)
-      .to eq(['`end` at 2, 2 is not aligned with' \
-              ' `Module::CONSTANT = test do |ala|` at 1, 0.'])
   end
 
   it 'accepts end aligned with a method call' do
@@ -409,14 +395,12 @@ describe RuboCop::Cop::Lint::BlockAlignment, :config do
   end
 
   it 'registers an offense for mismatched block end with a method call' do
-    inspect_source(cop, <<-END.strip_indent)
+    expect_offense(<<-END.strip_indent)
       parser.children << lambda do |token|
         token << 1
         end
+        ^^^ `end` at 3, 2 is not aligned with `parser.children << lambda do |token|` at 1, 0.
     END
-    expect(cop.messages)
-      .to eq(['`end` at 3, 2 is not aligned with' \
-              ' `parser.children << lambda do |token|` at 1, 0.'])
   end
 
   it 'accepts end aligned with a method call with arguments' do
@@ -472,13 +456,12 @@ describe RuboCop::Cop::Lint::BlockAlignment, :config do
   end
 
   it 'registers an offense for mismatched block end with an op-asgn (+=, -=)' do
-    inspect_source(cop, <<-END.strip_indent)
+    expect_offense(<<-END.strip_indent)
       rb += files.select do |file|
         file << something
         end
+        ^^^ `end` at 3, 2 is not aligned with `rb` at 1, 0.
     END
-    expect(cop.messages)
-      .to eq(['`end` at 3, 2 is not aligned with `rb` at 1, 0.'])
   end
 
   it 'accepts end aligned with an and-asgn (&&=)' do
@@ -489,13 +472,11 @@ describe RuboCop::Cop::Lint::BlockAlignment, :config do
   end
 
   it 'registers an offense for mismatched block end with an and-asgn (&&=)' do
-    inspect_source(cop, <<-END.strip_indent)
+    expect_offense(<<-END.strip_indent)
       variable &&= test do |ala|
         end
+        ^^^ `end` at 2, 2 is not aligned with `variable &&= test do |ala|` at 1, 0.
     END
-    expect(cop.messages)
-      .to eq(['`end` at 2, 2 is not aligned with `variable &&= test do |ala|`' \
-              ' at 1, 0.'])
   end
 
   it 'accepts end aligned with an or-asgn (||=)' do
@@ -506,13 +487,11 @@ describe RuboCop::Cop::Lint::BlockAlignment, :config do
   end
 
   it 'registers an offense for mismatched block end with an or-asgn (||=)' do
-    inspect_source(cop, <<-END.strip_indent)
+    expect_offense(<<-END.strip_indent)
       variable ||= test do |ala|
         end
+        ^^^ `end` at 2, 2 is not aligned with `variable ||= test do |ala|` at 1, 0.
     END
-    expect(cop.messages)
-      .to eq(['`end` at 2, 2 is not aligned with `variable ||= test do |ala|`' \
-              ' at 1, 0.'])
   end
 
   it 'accepts end aligned with a mass assignment' do
@@ -532,13 +511,12 @@ describe RuboCop::Cop::Lint::BlockAlignment, :config do
   end
 
   it 'registers an offense for mismatched block end with a mass assignment' do
-    inspect_source(cop, <<-END.strip_indent)
+    expect_offense(<<-END.strip_indent)
       var1, var2 = lambda do |test|
         [1, 2]
         end
+        ^^^ `end` at 3, 2 is not aligned with `var1, var2` at 1, 0.
     END
-    expect(cop.messages)
-      .to eq(['`end` at 3, 2 is not aligned with `var1, var2` at 1, 0.'])
   end
 
   context 'when multiple similar-looking blocks have misaligned ends' do
@@ -683,12 +661,11 @@ describe RuboCop::Cop::Lint::BlockAlignment, :config do
 
   context 'when the block is terminated by }' do
     it 'mentions } (not end) in the message' do
-      inspect_source(cop, <<-END.strip_indent)
+      expect_offense(<<-END.strip_indent)
         test {
           }
+          ^ `}` at 2, 2 is not aligned with `test {` at 1, 0.
       END
-      expect(cop.messages)
-        .to eq(['`}` at 2, 2 is not aligned with `test {` at 1, 0.'])
     end
   end
 

--- a/spec/rubocop/cop/lint/each_with_object_argument_spec.rb
+++ b/spec/rubocop/cop/lint/each_with_object_argument_spec.rb
@@ -4,9 +4,10 @@ describe RuboCop::Cop::Lint::EachWithObjectArgument do
   subject(:cop) { described_class.new }
 
   it 'registers an offense for fixnum argument' do
-    inspect_source(cop, 'collection.each_with_object(0) { |e, a| a + e }')
-    expect(cop.messages)
-      .to eq(['The argument to each_with_object can not be immutable.'])
+    expect_offense(<<-RUBY.strip_indent)
+      collection.each_with_object(0) { |e, a| a + e }
+      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ The argument to each_with_object can not be immutable.
+    RUBY
   end
 
   it 'registers an offense for float argument' do

--- a/spec/rubocop/cop/lint/format_parameter_mismatch_spec.rb
+++ b/spec/rubocop/cop/lint/format_parameter_mismatch_spec.rb
@@ -249,12 +249,11 @@ describe RuboCop::Cop::Lint::FormatParameterMismatch do
 
     context 'and multiple arguments' do
       it 'registers an offense' do
-        inspect_source(cop, <<-END.strip_indent)
+        expect_offense(<<-END.strip_indent)
           params = { y: '2015', m: '01', d: '01' }
           puts format('%{y}-%{m}-%{d}', 2015, 1, 1)
+               ^^^^^^ Number of arguments (3) to `format` doesn't match the number of fields (1).
         END
-        expect(cop.messages).to eq(['Number of arguments (3) to `format` ' \
-                                    "doesn't match the number of fields (1)."])
       end
     end
   end
@@ -271,12 +270,11 @@ describe RuboCop::Cop::Lint::FormatParameterMismatch do
 
     context 'and multiple arguments' do
       it 'registers an offense' do
-        inspect_source(cop, <<-END.strip_indent)
+        expect_offense(<<-END.strip_indent)
           params = { y: '2015', m: '01', d: '01' }
           puts format('%<y>d-%<m>d-%<d>d', 2015, 1, 1)
+               ^^^^^^ Number of arguments (3) to `format` doesn't match the number of fields (1).
         END
-        expect(cop.messages).to eq(['Number of arguments (3) to `format` ' \
-                                    "doesn't match the number of fields (1)."])
       end
     end
   end

--- a/spec/rubocop/cop/metrics/abc_size_spec.rb
+++ b/spec/rubocop/cop/metrics/abc_size_spec.rb
@@ -68,14 +68,12 @@ describe RuboCop::Cop::Metrics::AbcSize, :config do
 
     context 'target_ruby_version >= 2.3', :ruby23 do
       it 'treats safe navigation method calls like regular method calls' do
-        inspect_source(cop, <<-END.strip_indent)
+        expect_offense(<<-END.strip_indent) # sqrt(0 + 2*2 + 0) => 2
           def method_name
+          ^^^ Assignment Branch Condition size for method_name is too high. [2/0]
             object&.do_something
           end
         END
-        expect(cop.messages)
-          .to eq(['Assignment Branch Condition size for method_name is too ' \
-                  'high. [2/0]']) # sqrt(0 + 2*2 + 0) => 2
       end
     end
   end

--- a/spec/rubocop/cop/metrics/cyclomatic_complexity_spec.rb
+++ b/spec/rubocop/cop/metrics/cyclomatic_complexity_spec.rb
@@ -40,18 +40,18 @@ describe RuboCop::Cop::Metrics::CyclomaticComplexity, :config do
     end
 
     it 'registers an offense for an unless modifier' do
-      inspect_source(cop, <<-END.strip_indent)
+      expect_offense(<<-END.strip_indent)
         def method_name
+        ^^^ Cyclomatic complexity for method_name is too high. [2/1]
           call_foo unless some_condition
         end
       END
-      expect(cop.messages)
-        .to eq(['Cyclomatic complexity for method_name is too high. [2/1]'])
     end
 
     it 'registers an offense for an elsif block' do
-      inspect_source(cop, <<-END.strip_indent)
+      expect_offense(<<-END.strip_indent)
         def method_name
+        ^^^ Cyclomatic complexity for method_name is too high. [3/1]
           if first_condition then
             call_foo
           elsif second_condition then
@@ -61,59 +61,54 @@ describe RuboCop::Cop::Metrics::CyclomaticComplexity, :config do
           end
         end
       END
-      expect(cop.messages)
-        .to eq(['Cyclomatic complexity for method_name is too high. [3/1]'])
     end
 
     it 'registers an offense for a ternary operator' do
-      inspect_source(cop, <<-END.strip_indent)
+      expect_offense(<<-END.strip_indent)
         def method_name
+        ^^^ Cyclomatic complexity for method_name is too high. [2/1]
           value = some_condition ? 1 : 2
         end
       END
-      expect(cop.messages)
-        .to eq(['Cyclomatic complexity for method_name is too high. [2/1]'])
     end
 
     it 'registers an offense for a while block' do
-      inspect_source(cop, <<-END.strip_indent)
+      expect_offense(<<-END.strip_indent)
         def method_name
+        ^^^ Cyclomatic complexity for method_name is too high. [2/1]
           while some_condition do
             call_foo
           end
         end
       END
-      expect(cop.messages)
-        .to eq(['Cyclomatic complexity for method_name is too high. [2/1]'])
     end
 
     it 'registers an offense for an until block' do
-      inspect_source(cop, <<-END.strip_indent)
+      expect_offense(<<-END.strip_indent)
         def method_name
+        ^^^ Cyclomatic complexity for method_name is too high. [2/1]
           until some_condition do
             call_foo
           end
         end
       END
-      expect(cop.messages)
-        .to eq(['Cyclomatic complexity for method_name is too high. [2/1]'])
     end
 
     it 'registers an offense for a for block' do
-      inspect_source(cop, <<-END.strip_indent)
+      expect_offense(<<-END.strip_indent)
         def method_name
+        ^^^ Cyclomatic complexity for method_name is too high. [2/1]
           for i in 1..2 do
             call_method
           end
         end
       END
-      expect(cop.messages)
-        .to eq(['Cyclomatic complexity for method_name is too high. [2/1]'])
     end
 
     it 'registers an offense for a rescue block' do
-      inspect_source(cop, <<-END.strip_indent)
+      expect_offense(<<-END.strip_indent)
         def method_name
+        ^^^ Cyclomatic complexity for method_name is too high. [2/1]
           begin
             call_foo
           rescue Exception
@@ -121,13 +116,12 @@ describe RuboCop::Cop::Metrics::CyclomaticComplexity, :config do
           end
         end
       END
-      expect(cop.messages)
-        .to eq(['Cyclomatic complexity for method_name is too high. [2/1]'])
     end
 
     it 'registers an offense for a case/when block' do
-      inspect_source(cop, <<-END.strip_indent)
+      expect_offense(<<-END.strip_indent)
         def method_name
+        ^^^ Cyclomatic complexity for method_name is too high. [3/1]
           case value
           when 1
             call_foo
@@ -136,76 +130,68 @@ describe RuboCop::Cop::Metrics::CyclomaticComplexity, :config do
           end
         end
       END
-      expect(cop.messages)
-        .to eq(['Cyclomatic complexity for method_name is too high. [3/1]'])
     end
 
     it 'registers an offense for &&' do
-      inspect_source(cop, <<-END.strip_indent)
+      expect_offense(<<-END.strip_indent)
         def method_name
+        ^^^ Cyclomatic complexity for method_name is too high. [2/1]
           call_foo && call_bar
         end
       END
-      expect(cop.messages)
-        .to eq(['Cyclomatic complexity for method_name is too high. [2/1]'])
     end
 
     it 'registers an offense for and' do
-      inspect_source(cop, <<-END.strip_indent)
+      expect_offense(<<-END.strip_indent)
         def method_name
+        ^^^ Cyclomatic complexity for method_name is too high. [2/1]
           call_foo and call_bar
         end
       END
-      expect(cop.messages)
-        .to eq(['Cyclomatic complexity for method_name is too high. [2/1]'])
     end
 
     it 'registers an offense for ||' do
-      inspect_source(cop, <<-END.strip_indent)
+      expect_offense(<<-END.strip_indent)
         def method_name
+        ^^^ Cyclomatic complexity for method_name is too high. [2/1]
           call_foo || call_bar
         end
       END
-      expect(cop.messages)
-        .to eq(['Cyclomatic complexity for method_name is too high. [2/1]'])
     end
 
     it 'registers an offense for or' do
-      inspect_source(cop, <<-END.strip_indent)
+      expect_offense(<<-END.strip_indent)
         def method_name
+        ^^^ Cyclomatic complexity for method_name is too high. [2/1]
           call_foo or call_bar
         end
       END
-      expect(cop.messages)
-        .to eq(['Cyclomatic complexity for method_name is too high. [2/1]'])
     end
 
     it 'deals with nested if blocks containing && and ||' do
-      inspect_source(cop, <<-END.strip_indent)
+      expect_offense(<<-END.strip_indent)
         def method_name
+        ^^^ Cyclomatic complexity for method_name is too high. [6/1]
           if first_condition then
             call_foo if second_condition && third_condition
             call_bar if fourth_condition || fifth_condition
           end
         end
       END
-      expect(cop.messages)
-        .to eq(['Cyclomatic complexity for method_name is too high. [6/1]'])
     end
 
     it 'counts only a single method' do
-      inspect_source(cop, <<-END.strip_indent)
+      expect_offense(<<-END.strip_indent)
         def method_name_1
+        ^^^ Cyclomatic complexity for method_name_1 is too high. [2/1]
           call_foo if some_condition
         end
 
         def method_name_2
+        ^^^ Cyclomatic complexity for method_name_2 is too high. [2/1]
           call_foo if some_condition
         end
       END
-      expect(cop.messages)
-        .to eq(['Cyclomatic complexity for method_name_1 is too high. [2/1]',
-                'Cyclomatic complexity for method_name_2 is too high. [2/1]'])
     end
   end
 
@@ -213,8 +199,9 @@ describe RuboCop::Cop::Metrics::CyclomaticComplexity, :config do
     let(:cop_config) { { 'Max' => 2 } }
 
     it 'counts stupid nested if and else blocks' do
-      inspect_source(cop, <<-END.strip_indent)
+      expect_offense(<<-END.strip_indent)
         def method_name
+        ^^^ Cyclomatic complexity for method_name is too high. [5/2]
           if first_condition then
             call_foo
           else
@@ -227,8 +214,6 @@ describe RuboCop::Cop::Metrics::CyclomaticComplexity, :config do
           end
         end
       END
-      expect(cop.messages)
-        .to eq(['Cyclomatic complexity for method_name is too high. [5/2]'])
     end
   end
 end

--- a/spec/rubocop/cop/metrics/perceived_complexity_spec.rb
+++ b/spec/rubocop/cop/metrics/perceived_complexity_spec.rb
@@ -40,18 +40,18 @@ describe RuboCop::Cop::Metrics::PerceivedComplexity, :config do
     end
 
     it 'registers an offense for an unless modifier' do
-      inspect_source(cop, <<-END.strip_indent)
+      expect_offense(<<-END.strip_indent)
         def method_name
+        ^^^ Perceived complexity for method_name is too high. [2/1]
           call_foo unless some_condition
         end
       END
-      expect(cop.messages)
-        .to eq(['Perceived complexity for method_name is too high. [2/1]'])
     end
 
     it 'registers an offense for elsif and else blocks' do
-      inspect_source(cop, <<-END.strip_indent)
+      expect_offense(<<-END.strip_indent)
         def method_name
+        ^^^ Perceived complexity for method_name is too high. [4/1]
           if first_condition then
             call_foo
           elsif second_condition then
@@ -61,59 +61,54 @@ describe RuboCop::Cop::Metrics::PerceivedComplexity, :config do
           end
         end
       END
-      expect(cop.messages)
-        .to eq(['Perceived complexity for method_name is too high. [4/1]'])
     end
 
     it 'registers an offense for a ternary operator' do
-      inspect_source(cop, <<-END.strip_indent)
+      expect_offense(<<-END.strip_indent)
         def method_name
+        ^^^ Perceived complexity for method_name is too high. [2/1]
           value = some_condition ? 1 : 2
         end
       END
-      expect(cop.messages)
-        .to eq(['Perceived complexity for method_name is too high. [2/1]'])
     end
 
     it 'registers an offense for a while block' do
-      inspect_source(cop, <<-END.strip_indent)
+      expect_offense(<<-END.strip_indent)
         def method_name
+        ^^^ Perceived complexity for method_name is too high. [2/1]
           while some_condition do
             call_foo
           end
         end
       END
-      expect(cop.messages)
-        .to eq(['Perceived complexity for method_name is too high. [2/1]'])
     end
 
     it 'registers an offense for an until block' do
-      inspect_source(cop, <<-END.strip_indent)
+      expect_offense(<<-END.strip_indent)
         def method_name
+        ^^^ Perceived complexity for method_name is too high. [2/1]
           until some_condition do
             call_foo
           end
         end
       END
-      expect(cop.messages)
-        .to eq(['Perceived complexity for method_name is too high. [2/1]'])
     end
 
     it 'registers an offense for a for block' do
-      inspect_source(cop, <<-END.strip_indent)
+      expect_offense(<<-END.strip_indent)
         def method_name
+        ^^^ Perceived complexity for method_name is too high. [2/1]
           for i in 1..2 do
             call_method
           end
         end
       END
-      expect(cop.messages)
-        .to eq(['Perceived complexity for method_name is too high. [2/1]'])
     end
 
     it 'registers an offense for a rescue block' do
-      inspect_source(cop, <<-END.strip_indent)
+      expect_offense(<<-END.strip_indent)
         def method_name
+        ^^^ Perceived complexity for method_name is too high. [2/1]
           begin
             call_foo
           rescue Exception
@@ -121,13 +116,12 @@ describe RuboCop::Cop::Metrics::PerceivedComplexity, :config do
           end
         end
       END
-      expect(cop.messages)
-        .to eq(['Perceived complexity for method_name is too high. [2/1]'])
     end
 
     it 'registers an offense for a case/when block' do
-      inspect_source(cop, <<-END.strip_indent)
+      expect_offense(<<-END.strip_indent)
         def method_name
+        ^^^ Perceived complexity for method_name is too high. [3/1]
           case value
           when 1 then call_foo_1
           when 2 then call_foo_2
@@ -136,10 +130,6 @@ describe RuboCop::Cop::Metrics::PerceivedComplexity, :config do
           end
         end
       END
-      # The `case` node plus the first `when` score one complexity point
-      # together. The other `when` nodes get 0.2 complexity points.
-      expect(cop.messages)
-        .to eq(['Perceived complexity for method_name is too high. [3/1]'])
     end
 
     it 'registers an offense for a case/when block without an expression ' \
@@ -161,71 +151,65 @@ describe RuboCop::Cop::Metrics::PerceivedComplexity, :config do
     end
 
     it 'registers an offense for &&' do
-      inspect_source(cop, <<-END.strip_indent)
+      expect_offense(<<-END.strip_indent)
         def method_name
+        ^^^ Perceived complexity for method_name is too high. [2/1]
           call_foo && call_bar
         end
       END
-      expect(cop.messages)
-        .to eq(['Perceived complexity for method_name is too high. [2/1]'])
     end
 
     it 'registers an offense for and' do
-      inspect_source(cop, <<-END.strip_indent)
+      expect_offense(<<-END.strip_indent)
         def method_name
+        ^^^ Perceived complexity for method_name is too high. [2/1]
           call_foo and call_bar
         end
       END
-      expect(cop.messages)
-        .to eq(['Perceived complexity for method_name is too high. [2/1]'])
     end
 
     it 'registers an offense for ||' do
-      inspect_source(cop, <<-END.strip_indent)
+      expect_offense(<<-END.strip_indent)
         def method_name
+        ^^^ Perceived complexity for method_name is too high. [2/1]
           call_foo || call_bar
         end
       END
-      expect(cop.messages)
-        .to eq(['Perceived complexity for method_name is too high. [2/1]'])
     end
 
     it 'registers an offense for or' do
-      inspect_source(cop, <<-END.strip_indent)
+      expect_offense(<<-END.strip_indent)
         def method_name
+        ^^^ Perceived complexity for method_name is too high. [2/1]
           call_foo or call_bar
         end
       END
-      expect(cop.messages)
-        .to eq(['Perceived complexity for method_name is too high. [2/1]'])
     end
 
     it 'deals with nested if blocks containing && and ||' do
-      inspect_source(cop, <<-END.strip_indent)
+      expect_offense(<<-END.strip_indent)
         def method_name
+        ^^^ Perceived complexity for method_name is too high. [6/1]
           if first_condition then
             call_foo if second_condition && third_condition
             call_bar if fourth_condition || fifth_condition
           end
         end
       END
-      expect(cop.messages)
-        .to eq(['Perceived complexity for method_name is too high. [6/1]'])
     end
 
     it 'counts only a single method' do
-      inspect_source(cop, <<-END.strip_indent)
+      expect_offense(<<-END.strip_indent)
         def method_name_1
+        ^^^ Perceived complexity for method_name_1 is too high. [2/1]
           call_foo if some_condition
         end
 
         def method_name_2
+        ^^^ Perceived complexity for method_name_2 is too high. [2/1]
           call_foo if some_condition
         end
       END
-      expect(cop.messages)
-        .to eq(['Perceived complexity for method_name_1 is too high. [2/1]',
-                'Perceived complexity for method_name_2 is too high. [2/1]'])
     end
   end
 
@@ -233,8 +217,9 @@ describe RuboCop::Cop::Metrics::PerceivedComplexity, :config do
     let(:cop_config) { { 'Max' => 2 } }
 
     it 'counts stupid nested if and else blocks' do
-      inspect_source(cop, <<-END.strip_indent)
+      expect_offense(<<-END.strip_indent)
         def method_name                   # 1
+        ^^^ Perceived complexity for method_name is too high. [7/2]
           if first_condition then         # 2
             call_foo
           else                            # 3
@@ -247,8 +232,6 @@ describe RuboCop::Cop::Metrics::PerceivedComplexity, :config do
           end
         end
       END
-      expect(cop.messages)
-        .to eq(['Perceived complexity for method_name is too high. [7/2]'])
     end
   end
 end

--- a/spec/rubocop/cop/performance/lstrip_rstrip_spec.rb
+++ b/spec/rubocop/cop/performance/lstrip_rstrip_spec.rb
@@ -14,7 +14,9 @@ describe RuboCop::Cop::Performance::LstripRstrip do
   end
 
   it 'formats the error message correctly for str.lstrip.rstrip' do
-    inspect_source(cop, 'str.lstrip.rstrip')
-    expect(cop.messages).to eq(['Use `strip` instead of `lstrip.rstrip`.'])
+    expect_offense(<<-RUBY.strip_indent)
+      str.lstrip.rstrip
+          ^^^^^^^^^^^^^ Use `strip` instead of `lstrip.rstrip`.
+    RUBY
   end
 end

--- a/spec/rubocop/cop/performance/range_include_spec.rb
+++ b/spec/rubocop/cop/performance/range_include_spec.rb
@@ -24,9 +24,9 @@ describe RuboCop::Cop::Performance::RangeInclude do
   end
 
   it 'formats the error message correctly for (a..b).include? 1' do
-    inspect_source(cop, '(a..b).include? 1')
-    expect(cop.messages).to eq(
-      ['Use `Range#cover?` instead of `Range#include?`.']
-    )
+    expect_offense(<<-RUBY.strip_indent)
+      (a..b).include? 1
+             ^^^^^^^^ Use `Range#cover?` instead of `Range#include?`.
+    RUBY
   end
 end

--- a/spec/rubocop/cop/performance/redundant_block_call_spec.rb
+++ b/spec/rubocop/cop/performance/redundant_block_call_spec.rb
@@ -136,12 +136,12 @@ describe RuboCop::Cop::Performance::RedundantBlockCall do
   end
 
   it 'formats the error message for func.call(1) correctly' do
-    inspect_source(cop, <<-END.strip_indent)
+    expect_offense(<<-END.strip_indent)
       def method(&func)
         func.call(1)
+        ^^^^^^^^^^^^ Use `yield` instead of `func.call`.
       end
     END
-    expect(cop.messages).to eq(['Use `yield` instead of `func.call`.'])
   end
 
   it 'autocorrects using parentheses when block.call uses parentheses' do

--- a/spec/rubocop/cop/performance/redundant_match_spec.rb
+++ b/spec/rubocop/cop/performance/redundant_match_spec.rb
@@ -113,8 +113,9 @@ describe RuboCop::Cop::Performance::RedundantMatch do
   end
 
   it 'formats error message correctly for something if str.match(/regex/)' do
-    inspect_source(cop, 'something if str.match(/regex/)')
-    expect(cop.messages).to eq(['Use `=~` in places where the `MatchData` ' \
-                                'returned by `#match` will not be used.'])
+    expect_offense(<<-RUBY.strip_indent)
+      something if str.match(/regex/)
+                   ^^^^^^^^^^^^^^^^^^ Use `=~` in places where the `MatchData` returned by `#match` will not be used.
+    RUBY
   end
 end

--- a/spec/rubocop/cop/performance/redundant_merge_spec.rb
+++ b/spec/rubocop/cop/performance/redundant_merge_spec.rb
@@ -232,10 +232,10 @@ describe RuboCop::Cop::Performance::RedundantMerge, :config do
   end
 
   it 'formats the error message correctly for hash.merge!(a: 1)' do
-    inspect_source(cop, 'hash.merge!(a: 1)')
-    expect(cop.messages).to eq(
-      ['Use `hash[:a] = 1` instead of `hash.merge!(a: 1)`.']
-    )
+    expect_offense(<<-RUBY.strip_indent)
+      hash.merge!(a: 1)
+      ^^^^^^^^^^^^^^^^^ Use `hash[:a] = 1` instead of `hash.merge!(a: 1)`.
+    RUBY
   end
 
   context 'with MaxKeyValuePairs of 1' do

--- a/spec/rubocop/cop/performance/redundant_sort_by_spec.rb
+++ b/spec/rubocop/cop/performance/redundant_sort_by_spec.rb
@@ -23,7 +23,9 @@ describe RuboCop::Cop::Performance::RedundantSortBy do
   end
 
   it 'formats the error message correctly for array.sort_by { |x| x }' do
-    inspect_source(cop, 'array.sort_by { |x| x }')
-    expect(cop.messages).to eq(['Use `sort` instead of `sort_by { |x| x }`.'])
+    expect_offense(<<-RUBY.strip_indent)
+      array.sort_by { |x| x }
+            ^^^^^^^^^^^^^^^^^ Use `sort` instead of `sort_by { |x| x }`.
+    RUBY
   end
 end

--- a/spec/rubocop/cop/performance/reverse_each_spec.rb
+++ b/spec/rubocop/cop/performance/reverse_each_spec.rb
@@ -4,10 +4,10 @@ describe RuboCop::Cop::Performance::ReverseEach do
   subject(:cop) { described_class.new }
 
   it 'registers an offense when each is called on reverse' do
-    inspect_source(cop, '[1, 2, 3].reverse.each { |e| puts e }')
-
-    expect(cop.messages)
-      .to eq(['Use `reverse_each` instead of `reverse.each`.'])
+    expect_offense(<<-RUBY.strip_indent)
+      [1, 2, 3].reverse.each { |e| puts e }
+                ^^^^^^^^^^^^ Use `reverse_each` instead of `reverse.each`.
+    RUBY
   end
 
   it 'does not register an offense when reverse is used without each' do

--- a/spec/rubocop/cop/performance/size_spec.rb
+++ b/spec/rubocop/cop/performance/size_spec.rb
@@ -19,21 +19,24 @@ describe RuboCop::Cop::Performance::Size do
 
   describe 'on array' do
     it 'registers an offense when calling count' do
-      inspect_source(cop, '[1, 2, 3].count')
-
-      expect(cop.messages).to eq(['Use `size` instead of `count`.'])
+      expect_offense(<<-RUBY.strip_indent)
+        [1, 2, 3].count
+                  ^^^^^ Use `size` instead of `count`.
+      RUBY
     end
 
     it 'registers an offense when calling count on to_a' do
-      inspect_source(cop, '(1..3).to_a.count')
-
-      expect(cop.messages).to eq(['Use `size` instead of `count`.'])
+      expect_offense(<<-RUBY.strip_indent)
+        (1..3).to_a.count
+                    ^^^^^ Use `size` instead of `count`.
+      RUBY
     end
 
     it 'registers an offense when calling count on Array[]' do
-      inspect_source(cop, 'Array[*1..5].count')
-
-      expect(cop.messages).to eq(['Use `size` instead of `count`.'])
+      expect_offense(<<-RUBY.strip_indent)
+        Array[*1..5].count
+                     ^^^^^ Use `size` instead of `count`.
+      RUBY
     end
 
     it 'does not register an offense when calling size' do
@@ -83,21 +86,24 @@ describe RuboCop::Cop::Performance::Size do
 
   describe 'on hash' do
     it 'registers an offense when calling count' do
-      inspect_source(cop, '{a: 1, b: 2, c: 3}.count')
-
-      expect(cop.messages).to eq(['Use `size` instead of `count`.'])
+      expect_offense(<<-RUBY.strip_indent)
+        {a: 1, b: 2, c: 3}.count
+                           ^^^^^ Use `size` instead of `count`.
+      RUBY
     end
 
     it 'registers an offense when calling count on to_h' do
-      inspect_source(cop, '[[:foo, :bar], [1, 2]].to_h.count')
-
-      expect(cop.messages).to eq(['Use `size` instead of `count`.'])
+      expect_offense(<<-RUBY.strip_indent)
+        [[:foo, :bar], [1, 2]].to_h.count
+                                    ^^^^^ Use `size` instead of `count`.
+      RUBY
     end
 
     it 'registers an offense when calling count on Hash[]' do
-      inspect_source(cop, "Hash[*('a'..'z')].count")
-
-      expect(cop.messages).to eq(['Use `size` instead of `count`.'])
+      expect_offense(<<-RUBY.strip_indent)
+        Hash[*('a'..'z')].count
+                          ^^^^^ Use `size` instead of `count`.
+      RUBY
     end
 
     it 'does not register an offense when calling size' do

--- a/spec/rubocop/cop/rails/exit_spec.rb
+++ b/spec/rubocop/cop/rails/exit_spec.rb
@@ -4,15 +4,17 @@ describe RuboCop::Cop::Rails::Exit, :config do
   subject(:cop) { described_class.new }
 
   it 'registers an offense for an exit call with no receiver' do
-    inspect_source(cop,
-                   'exit')
-    expect(cop.messages).to eq([RuboCop::Cop::Rails::Exit::MSG])
+    expect_offense(<<-RUBY.strip_indent)
+      exit
+      ^^^^ Do not use `exit` in Rails applications.
+    RUBY
   end
 
   it 'registers an offense for an exit! call with no receiver' do
-    inspect_source(cop,
-                   'exit!')
-    expect(cop.messages).to eq([RuboCop::Cop::Rails::Exit::MSG])
+    expect_offense(<<-RUBY.strip_indent)
+      exit!
+      ^^^^^ Do not use `exit` in Rails applications.
+    RUBY
   end
 
   context 'exit calls on objects' do
@@ -46,15 +48,17 @@ describe RuboCop::Cop::Rails::Exit, :config do
 
   context 'explicit calls' do
     it 'does register an offense for explicit Kernel.exit calls' do
-      inspect_source(cop,
-                     'Kernel.exit')
-      expect(cop.messages).to eq([RuboCop::Cop::Rails::Exit::MSG])
+      expect_offense(<<-RUBY.strip_indent)
+        Kernel.exit
+               ^^^^ Do not use `exit` in Rails applications.
+      RUBY
     end
 
     it 'does register an offense for explicit Process.exit calls' do
-      inspect_source(cop,
-                     'Process.exit')
-      expect(cop.messages).to eq([RuboCop::Cop::Rails::Exit::MSG])
+      expect_offense(<<-RUBY.strip_indent)
+        Process.exit
+                ^^^^ Do not use `exit` in Rails applications.
+      RUBY
     end
   end
 end

--- a/spec/rubocop/cop/style/block_delimiters_spec.rb
+++ b/spec/rubocop/cop/style/block_delimiters_spec.rb
@@ -185,9 +185,10 @@ describe RuboCop::Cop::Style::BlockDelimiters, :config do
     end
 
     it 'registers an offense for a single line procedural block' do
-      inspect_source(cop, 'each { |x| puts x }')
-      expect(cop.messages)
-        .to eq(['Prefer `do...end` over `{...}` for procedural blocks.'])
+      expect_offense(<<-RUBY.strip_indent)
+        each { |x| puts x }
+             ^ Prefer `do...end` over `{...}` for procedural blocks.
+      RUBY
     end
 
     it 'accepts a single line block with do-end if it is procedural' do
@@ -337,12 +338,11 @@ describe RuboCop::Cop::Style::BlockDelimiters, :config do
 
     context 'when there are braces around a multi-line block' do
       it 'registers an offense in the simple case' do
-        inspect_source(cop, <<-END.strip_indent)
+        expect_offense(<<-END.strip_indent)
           each { |x|
+               ^ Avoid using `{...}` for multi-line blocks.
           }
         END
-        expect(cop.messages)
-          .to eq(['Avoid using `{...}` for multi-line blocks.'])
       end
 
       it 'accepts braces if do-end would change the meaning' do
@@ -465,13 +465,11 @@ describe RuboCop::Cop::Style::BlockDelimiters, :config do
     include_examples 'syntactic styles'
 
     it 'registers an offense for multi-line chained do-end blocks' do
-      inspect_source(cop, <<-END.strip_indent)
+      expect_offense(<<-END.strip_indent)
         each do |x|
+             ^^ Prefer `{...}` over `do...end` for multi-line chained blocks.
         end.map(&:to_s)
       END
-      expect(cop.messages).to eq(
-        ['Prefer `{...}` over `do...end` for multi-line chained blocks.']
-      )
     end
 
     it 'auto-corrects do-end for chained blocks' do
@@ -498,12 +496,11 @@ describe RuboCop::Cop::Style::BlockDelimiters, :config do
 
     context 'when there are braces around a multi-line block' do
       it 'registers an offense in the simple case' do
-        inspect_source(cop, <<-END.strip_indent)
+        expect_offense(<<-END.strip_indent)
           each { |x|
+               ^ Prefer `do...end` for multi-line blocks without chaining.
           }
         END
-        expect(cop.messages)
-          .to eq(['Prefer `do...end` for multi-line blocks without chaining.'])
       end
 
       it 'allows when the block is being chained' do

--- a/spec/rubocop/cop/style/command_literal_spec.rb
+++ b/spec/rubocop/cop/style/command_literal_spec.rb
@@ -19,8 +19,10 @@ describe RuboCop::Cop::Style::CommandLiteral, :config do
     let(:cop_config) { { 'EnforcedStyle' => 'backticks' } }
 
     it 'registers an offense' do
-      inspect_source(cop, '%x$ls$')
-      expect(cop.messages).to eq(['Use backticks around command string.'])
+      expect_offense(<<-RUBY.strip_indent)
+        %x$ls$
+        ^^^^^^ Use backticks around command string.
+      RUBY
     end
   end
 

--- a/spec/rubocop/cop/style/multiline_if_then_spec.rb
+++ b/spec/rubocop/cop/style/multiline_if_then_spec.rb
@@ -92,13 +92,11 @@ describe RuboCop::Cop::Style::MultilineIfThen do
   # unless
 
   it 'registers an offense for then in multiline unless' do
-    inspect_source(cop, <<-END.strip_indent)
+    expect_offense(<<-END.strip_indent)
       unless cond then
+                  ^^^^ Do not use `then` for multi-line `unless`.
       end
     END
-    expect(cop.messages).to eq(
-      ['Do not use `then` for multi-line `unless`.']
-    )
   end
 
   it 'accepts multiline unless without then' do

--- a/spec/rubocop/cop/style/single_line_methods_spec.rb
+++ b/spec/rubocop/cop/style/single_line_methods_spec.rb
@@ -9,14 +9,14 @@ describe RuboCop::Cop::Style::SingleLineMethods do
   let(:cop_config) { { 'AllowIfMethodIsEmpty' => true } }
 
   it 'registers an offense for a single-line method' do
-    inspect_source(cop, <<-END.strip_indent)
+    expect_offense(<<-END.strip_indent)
       def some_method; body end
+      ^^^^^^^^^^^^^^^^^^^^^^^^^ Avoid single-line method definitions.
       def link_to(name, url); {:name => name}; end
+      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Avoid single-line method definitions.
       def @table.columns; super; end
+      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Avoid single-line method definitions.
     END
-    expect(cop.messages).to eq(
-      ['Avoid single-line method definitions.'] * 3
-    )
   end
 
   context 'when AllowIfMethodIsEmpty is disabled' do

--- a/spec/rubocop/cop/style/trailing_comma_in_literal_spec.rb
+++ b/spec/rubocop/cop/style/trailing_comma_in_literal_spec.rb
@@ -353,25 +353,23 @@ describe RuboCop::Cop::Style::TrailingCommaInLiteral, :config do
 
       context 'when closing bracket is on same line as last value' do
         it 'registers an offense for an Array literal with no trailing comma' do
-          inspect_source(cop, <<-END.strip_indent)
+          expect_offense(<<-END.strip_indent)
             VALUES = [
                        1001,
                        2020,
                        3333]
+                       ^^^^ Put a comma after the last item of a multiline array.
           END
-          expect(cop.messages)
-            .to eq(['Put a comma after the last item of a multiline array.'])
         end
 
         it 'registers an offense for a Hash literal with no trailing comma' do
-          inspect_source(cop, <<-END.strip_indent)
+          expect_offense(<<-END.strip_indent)
             VALUES = {
                        a: "b",
                        b: "c",
                        d: "e"}
+                       ^^^^^^ Put a comma after the last item of a multiline hash.
           END
-          expect(cop.messages)
-            .to eq(['Put a comma after the last item of a multiline hash.'])
         end
 
         it 'auto-corrects a missing comma in a Hash literal' do


### PR DESCRIPTION
Replaces specs which only call `inspect_source` and then assert something about `cop.messages`.

I used another script to do this rewrite but it will not be as useful for future reference. Basically, I temporarily overrode `inspect_source` in the spec support to do a `Marshal.dump` of the cop with offenses plus `RSpec.current_example` to a file. I then used this data in a separate static script (using `Parser`'s rewriter tools) to replace specs that only contained an `inspect_source` followed by a `cop.messages` assertions matching this pattern:

```
(send
  (send nil :expect
    (send
      (send nil :cop) :messages)) :to
  (send nil {:eq :eql} ...))
```

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Used the same coding conventions as the rest of the project.
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] All tests are passing.
* [x] The new code doesn't generate RuboCop offenses.
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Updated cop documentation with `rake generate_cops_documentation` (required only when you've added a new cop or changed the configuration/documentation of an existing cop).

[1]: http://chris.beams.io/posts/git-commit/
