### PR TITLE
More expect_offense bulk updates

### DIFF
--- a/spec/rubocop/cop/bundler/ordered_gems_spec.rb
+++ b/spec/rubocop/cop/bundler/ordered_gems_spec.rb
@@ -8,6 +8,10 @@ describe RuboCop::Cop::Bundler::OrderedGems, :config do
     }
   end
   let(:treat_comments_as_group_separators) { false }
+  let(:message) do
+    'Gems should be sorted in an alphabetical order within their ' \
+      'section of the Gemfile. Gem `%s` should appear before `%s`.'
+  end
   subject(:cop) { described_class.new(config) }
 
   context 'When gems are alphabetically sorted' do
@@ -29,21 +33,11 @@ describe RuboCop::Cop::Bundler::OrderedGems, :config do
     END
 
     it 'registers an offense' do
-      inspect_source(cop, source)
-      expect(cop.offenses.size).to eq(1)
-    end
-
-    it 'has the correct offense message' do
-      inspect_source(cop, source)
-      expect(cop.messages)
-        .to eq(['Gems should be sorted in an alphabetical ' \
-                'order within their section of the Gemfile. ' \
-                'Gem `rspec` should appear before `rubocop`.'])
-    end
-
-    it 'highlights the second gem' do
-      inspect_source(cop, source)
-      expect(cop.highlights).to eq(["gem 'rspec'"])
+      expect_offense(<<-RUBY.strip_indent)
+        gem 'rubocop'
+        gem 'rspec'
+        ^^^^^^^^^^^ #{format(message, 'rspec', 'rubocop')}
+      RUBY
     end
 
     it 'autocorrects' do
@@ -78,8 +72,12 @@ describe RuboCop::Cop::Bundler::OrderedGems, :config do
     END
 
     it 'registers an offense' do
-      inspect_source(cop, source)
-      expect(cop.offenses.size).to eq(1)
+      expect_offense(<<-RUBY.strip_indent)
+        gem 'rubocop',
+            '0.1.1'
+        gem 'rspec'
+        ^^^^^^^^^^^ #{format(message, 'rspec', 'rubocop')}
+      RUBY
     end
 
     it 'autocorrects' do
@@ -119,8 +117,23 @@ describe RuboCop::Cop::Bundler::OrderedGems, :config do
     END
 
     it 'registers some offenses' do
-      inspect_source(cop, source)
-      expect(cop.offenses).not_to be_empty
+      expect_offense(<<-RUBY.strip_indent)
+        gem "d"
+        gem "b"
+        ^^^^^^^ #{format(message, 'b', 'd')}
+        gem "e"
+        gem "a"
+        ^^^^^^^ #{format(message, 'a', 'e')}
+        gem "c"
+
+        gem "h"
+        gem "g"
+        ^^^^^^^ #{format(message, 'g', 'h')}
+        gem "j"
+        gem "f"
+        ^^^^^^^ #{format(message, 'f', 'j')}
+        gem "i"
+      RUBY
     end
 
     it 'autocorrects' do
@@ -161,21 +174,14 @@ describe RuboCop::Cop::Bundler::OrderedGems, :config do
 
     context 'with TreatCommentsAsGroupSeparators: false' do
       it 'registers an offense' do
-        inspect_source(cop, source)
-        expect(cop.offenses.size).to eq(1)
-      end
-
-      it 'has the correct offense message' do
-        inspect_source(cop, source)
-        expect(cop.messages)
-          .to eq(['Gems should be sorted in an alphabetical ' \
-                  'order within their section of the Gemfile. ' \
-                  'Gem `rspec` should appear before `rubocop`.'])
-      end
-
-      it 'highlights the second gem' do
-        inspect_source(cop, source)
-        expect(cop.highlights).to eq(["gem 'rspec'"])
+        expect_offense(<<-RUBY.strip_indent)
+          # For code quality
+          gem 'rubocop'
+          # For
+          # test
+          gem 'rspec'
+          ^^^^^^^^^^^ #{format(message, 'rspec', 'rubocop')}
+        RUBY
       end
 
       it 'autocorrects' do
@@ -199,8 +205,12 @@ describe RuboCop::Cop::Bundler::OrderedGems, :config do
     END
 
     it 'registers an offense' do
-      inspect_source(cop, source)
-      expect(cop.offenses.size).to eq(1)
+      expect_offense(<<-RUBY.strip_indent)
+        gem 'rubocop' # For code quality
+        gem 'pry'
+        ^^^^^^^^^ #{format(message, 'pry', 'rubocop')}
+        gem 'rspec'   # For test
+      RUBY
     end
 
     it 'autocorrects' do
@@ -244,8 +254,11 @@ describe RuboCop::Cop::Bundler::OrderedGems, :config do
     END
 
     it 'registers an offense' do
-      inspect_source(cop, source)
-      expect(cop.offenses.size).to eq(1)
+      expect_offense(<<-RUBY.strip_indent)
+        gem 'Z'
+        gem 'a'
+        ^^^^^^^ #{format(message, 'a', 'Z')}
+      RUBY
     end
 
     it 'autocorrects' do

--- a/spec/rubocop/cop/layout/access_modifier_indentation_spec.rb
+++ b/spec/rubocop/cop/layout/access_modifier_indentation_spec.rb
@@ -94,17 +94,15 @@ describe RuboCop::Cop::Layout::AccessModifierIndentation do
     end
 
     it 'registers an offense for misaligned private in singleton class' do
-      inspect_source(cop, <<-END.strip_indent)
+      expect_offense(<<-RUBY.strip_indent)
         class << self
 
         private
+        ^^^^^^^ Indent access modifiers like `private`.
 
           def test; end
         end
-      END
-      expect(cop.offenses.size).to eq(1)
-      expect(cop.messages)
-        .to eq(['Indent access modifiers like `private`.'])
+      RUBY
     end
 
     it 'registers an offense for misaligned private in class ' \
@@ -151,17 +149,15 @@ describe RuboCop::Cop::Layout::AccessModifierIndentation do
     end
 
     it 'registers an offense for misaligned protected' do
-      inspect_source(cop, <<-END.strip_indent)
+      expect_offense(<<-RUBY.strip_indent)
         class Test
 
         protected
+        ^^^^^^^^^ Indent access modifiers like `protected`.
 
           def test; end
         end
-      END
-      expect(cop.offenses.size).to eq(1)
-      expect(cop.messages)
-        .to eq(['Indent access modifiers like `protected`.'])
+      RUBY
     end
 
     it 'accepts properly indented private' do
@@ -204,12 +200,13 @@ describe RuboCop::Cop::Layout::AccessModifierIndentation do
     end
 
     it 'handles properly nested classes' do
-      inspect_source(cop, <<-END.strip_indent)
+      expect_offense(<<-RUBY.strip_indent)
         class Test
 
           class Nested
 
           private
+          ^^^^^^^ Indent access modifiers like `private`.
 
             def a; end
           end
@@ -218,10 +215,7 @@ describe RuboCop::Cop::Layout::AccessModifierIndentation do
 
           def test; end
         end
-      END
-      expect(cop.offenses.size).to eq(1)
-      expect(cop.messages)
-        .to eq(['Indent access modifiers like `private`.'])
+      RUBY
     end
 
     it 'auto-corrects incorrectly indented access modifiers' do
@@ -299,28 +293,27 @@ describe RuboCop::Cop::Layout::AccessModifierIndentation do
     end
 
     it 'registers offense for private indented to method depth in a module' do
-      inspect_source(cop, <<-END.strip_indent)
+      expect_offense(<<-RUBY.strip_indent)
         module Test
 
           private
+          ^^^^^^^ Outdent access modifiers like `private`.
 
           def test; end
         end
-      END
-      expect(cop.offenses.size).to eq(1)
-      expect(cop.messages).to eq([indent_msg])
+      RUBY
     end
 
     it 'registers offense for module fn indented to method depth in a module' do
-      inspect_source(cop, <<-END.strip_indent)
+      expect_offense(<<-RUBY.strip_indent)
         module Test
 
           module_function
+          ^^^^^^^^^^^^^^^ Outdent access modifiers like `module_function`.
 
           def test; end
         end
-      END
-      expect(cop.offenses.size).to eq(1)
+      RUBY
     end
 
     it 'registers offense for private indented to method depth in singleton' \
@@ -388,12 +381,13 @@ describe RuboCop::Cop::Layout::AccessModifierIndentation do
     end
 
     it 'handles properly nested classes' do
-      inspect_source(cop, <<-END.strip_indent)
+      expect_offense(<<-RUBY.strip_indent)
         class Test
 
           class Nested
 
             private
+            ^^^^^^^ Outdent access modifiers like `private`.
 
             def a; end
           end
@@ -402,9 +396,7 @@ describe RuboCop::Cop::Layout::AccessModifierIndentation do
 
           def test; end
         end
-      END
-      expect(cop.offenses.size).to eq(1)
-      expect(cop.messages).to eq([indent_msg])
+      RUBY
     end
 
     it 'auto-corrects incorrectly indented access modifiers' do

--- a/spec/rubocop/cop/layout/align_array_spec.rb
+++ b/spec/rubocop/cop/layout/align_array_spec.rb
@@ -4,18 +4,16 @@ describe RuboCop::Cop::Layout::AlignArray do
   subject(:cop) { described_class.new }
 
   it 'registers an offense for misaligned array elements' do
-    inspect_source(cop, <<-END.strip_indent)
+    expect_offense(<<-RUBY.strip_indent)
       array = [
         a,
          b,
+         ^ Align the elements of an array literal if they span more than one line.
         c,
          d
+         ^ Align the elements of an array literal if they span more than one line.
       ]
-    END
-    expect(cop.messages).to eq(['Align the elements of an array ' \
-                                'literal if they span more than ' \
-                                'one line.'] * 2)
-    expect(cop.highlights).to eq(%w[b d])
+    RUBY
   end
 
   it 'accepts aligned array keys' do

--- a/spec/rubocop/cop/layout/align_hash_spec.rb
+++ b/spec/rubocop/cop/layout/align_hash_spec.rb
@@ -40,19 +40,19 @@ describe RuboCop::Cop::Layout::AlignHash, :config do
     end
 
     it 'registers offense for misaligned keys in implicit hash' do
-      inspect_source(cop, <<-END.strip_indent)
+      expect_offense(<<-RUBY.strip_indent)
         func(a: 0,
           b: 1)
-      END
-      expect(cop.offenses.size).to eq(1)
+          ^^^^ Align the elements of a hash literal if they span more than one line.
+      RUBY
     end
 
     it 'registers offense for misaligned keys in explicit hash' do
-      inspect_source(cop, <<-END.strip_indent)
+      expect_offense(<<-RUBY.strip_indent)
         func({a: 0,
           b: 1})
-      END
-      expect(cop.offenses.size).to eq(1)
+          ^^^^ Align the elements of a hash literal if they span more than one line.
+      RUBY
     end
   end
 
@@ -93,11 +93,11 @@ describe RuboCop::Cop::Layout::AlignHash, :config do
     end
 
     it 'registers offense for misaligned keys in explicit hash' do
-      inspect_source(cop, <<-END.strip_indent)
+      expect_offense(<<-RUBY.strip_indent)
         func({a: 0,
           b: 1})
-      END
-      expect(cop.offenses.size).to eq(1)
+          ^^^^ Align the elements of a hash literal if they span more than one line.
+      RUBY
     end
   end
 
@@ -109,11 +109,11 @@ describe RuboCop::Cop::Layout::AlignHash, :config do
     end
 
     it 'registers offense for misaligned keys in implicit hash' do
-      inspect_source(cop, <<-END.strip_indent)
+      expect_offense(<<-RUBY.strip_indent)
         func(a: 0,
           b: 1)
-      END
-      expect(cop.offenses.size).to eq(1)
+          ^^^^ Align the elements of a hash literal if they span more than one line.
+      RUBY
     end
 
     it 'accepts misaligned keys in explicit hash' do
@@ -133,29 +133,26 @@ describe RuboCop::Cop::Layout::AlignHash, :config do
 
   context 'with default configuration' do
     it 'registers an offense for misaligned hash keys' do
-      inspect_source(cop, <<-END.strip_indent)
+      expect_offense(<<-RUBY.strip_indent)
         hash1 = {
           a: 0,
            bb: 1
+           ^^^^^ Align the elements of a hash literal if they span more than one line.
         }
         hash2 = {
           'ccc' => 2,
          'dddd'  =>  2
+         ^^^^^^^^^^^^^ Align the elements of a hash literal if they span more than one line.
         }
-      END
-      expect(cop.messages).to eq(['Align the elements of a hash ' \
-                                  'literal if they span more than ' \
-                                  'one line.'] * 2)
-      expect(cop.highlights).to eq(['bb: 1',
-                                    "'dddd'  =>  2"])
+      RUBY
     end
 
     it 'registers an offense for misaligned mixed multiline hash keys' do
-      inspect_source(cop, <<-END.strip_indent)
+      expect_offense(<<-RUBY.strip_indent)
         hash = { a: 1, b: 2,
                 c: 3 }
-      END
-      expect(cop.offenses.size).to eq(1)
+                ^^^^ Align the elements of a hash literal if they span more than one line.
+      RUBY
     end
 
     it 'accepts aligned hash keys' do
@@ -172,31 +169,30 @@ describe RuboCop::Cop::Layout::AlignHash, :config do
     end
 
     it 'registers an offense for separator alignment' do
-      inspect_source(cop, <<-END.strip_indent)
+      expect_offense(<<-RUBY.strip_indent)
         hash = {
             'a' => 0,
           'bbb' => 1
+          ^^^^^^^^^^ Align the elements of a hash literal if they span more than one line.
         }
-      END
-      expect(cop.offenses.size).to eq(1)
-      expect(cop.highlights).to eq(["'bbb' => 1"])
+      RUBY
     end
 
     context 'with implicit hash as last argument' do
       it 'registers an offense for misaligned hash keys' do
-        inspect_source(cop, <<-END.strip_indent)
+        expect_offense(<<-RUBY.strip_indent)
           func(a: 0,
             b: 1)
-        END
-        expect(cop.offenses.size).to eq(1)
+            ^^^^ Align the elements of a hash literal if they span more than one line.
+        RUBY
       end
 
       it 'registers an offense for right alignment of keys' do
-        inspect_source(cop, <<-END.strip_indent)
+        expect_offense(<<-RUBY.strip_indent)
           func(a: 0,
              bbb: 1)
-        END
-        expect(cop.offenses.size).to eq(1)
+             ^^^^^^ Align the elements of a hash literal if they span more than one line.
+        RUBY
       end
 
       it 'accepts aligned hash keys' do
@@ -348,45 +344,45 @@ describe RuboCop::Cop::Layout::AlignHash, :config do
     end
 
     it 'registers an offense for misaligned hash values' do
-      inspect_source(cop, <<-END.strip_indent)
+      expect_offense(<<-RUBY.strip_indent)
         hash1 = {
           'a'   =>  0,
+          ^^^^^^^^^^^ Align the elements of a hash literal if they span more than one line.
           'bbb' => 1
         }
         hash2 = {
           a:   0,
           bbb:1
+          ^^^^^ Align the elements of a hash literal if they span more than one line.
         }
-      END
-      expect(cop.highlights).to eq(["'a'   =>  0",
-                                    'bbb:1'])
+      RUBY
     end
 
     it 'registers an offense for misaligned hash keys' do
-      inspect_source(cop, <<-END.strip_indent)
+      expect_offense(<<-RUBY.strip_indent)
         hash1 = {
           'a'   =>  0,
+          ^^^^^^^^^^^ Align the elements of a hash literal if they span more than one line.
          'bbb'  =>  1
+         ^^^^^^^^^^^^ Align the elements of a hash literal if they span more than one line.
         }
         hash2 = {
            a:  0,
+           ^^^^^ Align the elements of a hash literal if they span more than one line.
           bbb: 1
+          ^^^^^^ Align the elements of a hash literal if they span more than one line.
         }
-      END
-      expect(cop.highlights).to eq(["'a'   =>  0",
-                                    "'bbb'  =>  1",
-                                    'a:  0',
-                                    'bbb: 1'])
+      RUBY
     end
 
     it 'registers an offense for misaligned hash rockets' do
-      inspect_source(cop, <<-END.strip_indent)
+      expect_offense(<<-RUBY.strip_indent)
         hash = {
           'a'   => 0,
           'bbb'  => 1
+          ^^^^^^^^^^^ Align the elements of a hash literal if they span more than one line.
         }
-      END
-      expect(cop.offenses.size).to eq(1)
+      RUBY
     end
 
     it 'auto-corrects alignment' do
@@ -466,23 +462,23 @@ describe RuboCop::Cop::Layout::AlignHash, :config do
     end
 
     it 'registers an offense for misaligned hash values' do
-      inspect_source(cop, <<-END.strip_indent)
+      expect_offense(<<-RUBY.strip_indent)
         hash = {
             'a' =>  0,
           'bbb' => 1
+          ^^^^^^^^^^ Align the elements of a hash literal if they span more than one line.
         }
-      END
-      expect(cop.offenses.size).to eq(1)
+      RUBY
     end
 
     it 'registers an offense for misaligned hash rockets' do
-      inspect_source(cop, <<-END.strip_indent)
+      expect_offense(<<-RUBY.strip_indent)
         hash = {
             'a'  => 0,
           'bbb' =>  1
+          ^^^^^^^^^^^ Align the elements of a hash literal if they span more than one line.
         }
-      END
-      expect(cop.offenses.size).to eq(1)
+      RUBY
     end
 
     context 'ruby >= 2.0', :ruby20 do
@@ -540,17 +536,18 @@ describe RuboCop::Cop::Layout::AlignHash, :config do
     end
 
     it 'registers offenses for misaligned entries' do
-      inspect_source(cop, <<-END.strip_indent)
+      expect_offense(<<-RUBY.strip_indent)
         hash1 = {
           a:   0,
           bbb: 1
+          ^^^^^^ Align the elements of a hash literal if they span more than one line.
         }
         hash2 = {
             'a' => 0,
           'bbb' => 1
+          ^^^^^^^^^^ Align the elements of a hash literal if they span more than one line.
         }
-      END
-      expect(cop.highlights).to eq(['bbb: 1', "'bbb' => 1"])
+      RUBY
     end
 
     it 'accepts aligned entries' do

--- a/spec/rubocop/cop/layout/align_parameters_spec.rb
+++ b/spec/rubocop/cop/layout/align_parameters_spec.rb
@@ -18,20 +18,19 @@ describe RuboCop::Cop::Layout::AlignParameters do
     end
 
     it 'registers an offense for parameters with single indent' do
-      inspect_source(cop, <<-END.strip_indent)
+      expect_offense(<<-RUBY.strip_indent)
         function(a,
           if b then c else d end)
-      END
-      expect(cop.offenses.size).to eq(1)
-      expect(cop.highlights).to eq(['if b then c else d end'])
+          ^^^^^^^^^^^^^^^^^^^^^^ Align the parameters of a method call if they span more than one line.
+      RUBY
     end
 
     it 'registers an offense for parameters with double indent' do
-      inspect_source(cop, <<-END.strip_indent)
+      expect_offense(<<-RUBY.strip_indent)
         function(a,
             if b then c else d end)
-      END
-      expect(cop.offenses.size).to eq(1)
+            ^^^^^^^^^^^^^^^^^^^^^^ Align the parameters of a method call if they span more than one line.
+      RUBY
     end
 
     it 'accepts multiline []= method call' do
@@ -69,30 +68,24 @@ describe RuboCop::Cop::Layout::AlignParameters do
     end
 
     it "doesn't get confused by splat operator" do
-      inspect_source(cop, <<-END.strip_indent)
+      expect_offense(<<-RUBY.strip_indent)
         func1(*a,
               *b,
               c)
         func2(a,
              *b,
+             ^^ Align the parameters of a method call if they span more than one line.
               c)
         func3(*a)
-      END
-      expect(cop.offenses.map(&:to_s))
-        .to eq(['C:  5:  6: Align the parameters of a method call if ' \
-                'they span more than one line.'])
-      expect(cop.highlights).to eq(['*b'])
+      RUBY
     end
 
     it "doesn't get confused by extra comma at the end" do
-      inspect_source(cop, <<-END.strip_indent)
+      expect_offense(<<-RUBY.strip_indent)
         func1(a,
              b,)
-      END
-      expect(cop.offenses.map(&:to_s))
-        .to eq(['C:  2:  6: Align the parameters of a method call if ' \
-                'they span more than one line.'])
-      expect(cop.highlights).to eq(['b'])
+             ^ Align the parameters of a method call if they span more than one line.
+      RUBY
     end
 
     it 'can handle a correctly aligned string literal as first argument' do
@@ -230,22 +223,21 @@ describe RuboCop::Cop::Layout::AlignParameters do
 
     context 'method definitions' do
       it 'registers an offense for parameters with single indent' do
-        inspect_source(cop, <<-END.strip_indent)
+        expect_offense(<<-RUBY.strip_indent)
           def method(a,
             b)
+            ^ Align the parameters of a method definition if they span more than one line.
           end
-        END
-        expect(cop.offenses.size).to eq 1
-        expect(cop.offenses.first.to_s).to match(/method definition/)
+        RUBY
       end
 
       it 'registers an offense for parameters with double indent' do
-        inspect_source(cop, <<-END.strip_indent)
+        expect_offense(<<-RUBY.strip_indent)
           def method(a,
               b)
+              ^ Align the parameters of a method definition if they span more than one line.
           end
-        END
-        expect(cop.offenses.size).to eq 1
+        RUBY
       end
 
       it 'accepts parameter lists on a single line' do
@@ -280,14 +272,13 @@ describe RuboCop::Cop::Layout::AlignParameters do
       end
 
       it "doesn't get confused by splat" do
-        inspect_source(cop, <<-END.strip_indent)
+        expect_offense(<<-RUBY.strip_indent)
           def func2(a,
                    *b,
+                   ^^ Align the parameters of a method definition if they span more than one line.
                     c)
           end
-        END
-        expect(cop.offenses.size).to eq 1
-        expect(cop.highlights).to eq(['*b'])
+        RUBY
       end
 
       it 'auto-corrects alignment' do
@@ -305,13 +296,12 @@ describe RuboCop::Cop::Layout::AlignParameters do
 
       context 'defining self.method' do
         it 'registers an offense for parameters with single indent' do
-          inspect_source(cop, <<-END.strip_indent)
+          expect_offense(<<-RUBY.strip_indent)
             def self.method(a,
               b)
+              ^ Align the parameters of a method definition if they span more than one line.
             end
-          END
-          expect(cop.offenses.size).to eq 1
-          expect(cop.offenses.first.to_s).to match(/method definition/)
+          RUBY
         end
 
         it 'accepts proper indentation' do
@@ -516,15 +506,17 @@ describe RuboCop::Cop::Layout::AlignParameters do
       end
 
       it 'registers offenses for double indentation from relevant method' do
-        inspect_source(cop, <<-END.strip_margin('|'))
-          | something
-          |   .method_name(
-          |       a,
-          |       b,
-          |       c
-          |   )
-        END
-        expect(cop.offenses.size).to eq(3)
+        expect_offense(<<-RUBY.strip_indent)
+           something
+             .method_name(
+                 a,
+                 ^ Use one level of indentation for parameters following the first line of a multi-line method call.
+                 b,
+                 ^ Use one level of indentation for parameters following the first line of a multi-line method call.
+                 c
+                 ^ Use one level of indentation for parameters following the first line of a multi-line method call.
+             )
+        RUBY
       end
 
       it 'does not err on method call without a method name' do
@@ -563,25 +555,21 @@ describe RuboCop::Cop::Layout::AlignParameters do
 
     context 'method definitions' do
       it 'registers an offense for parameters aligned to first param' do
-        inspect_source(cop, <<-END.strip_indent)
+        expect_offense(<<-RUBY.strip_indent)
           def method(a,
                      b)
+                     ^ Use one level of indentation for parameters following the first line of a multi-line method definition.
           end
-        END
-        expect(cop.offenses.size).to eq 1
-        expect(cop.messages)
-          .to eq(['Use one level of indentation for parameters ' \
-                  'following the first line of a multi-line method ' \
-                  'definition.'])
+        RUBY
       end
 
       it 'registers an offense for parameters with double indent' do
-        inspect_source(cop, <<-END.strip_indent)
+        expect_offense(<<-RUBY.strip_indent)
           def method(a,
               b)
+              ^ Use one level of indentation for parameters following the first line of a multi-line method definition.
           end
-        END
-        expect(cop.offenses.size).to eq 1
+        RUBY
       end
 
       it 'accepts parameter lists on a single line' do
@@ -616,14 +604,14 @@ describe RuboCop::Cop::Layout::AlignParameters do
       end
 
       it "doesn't get confused by splat" do
-        inspect_source(cop, <<-END.strip_indent)
+        expect_offense(<<-RUBY.strip_indent)
           def func2(a,
                    *b,
+                   ^^ Use one level of indentation for parameters following the first line of a multi-line method definition.
                     c)
+                    ^ Use one level of indentation for parameters following the first line of a multi-line method definition.
           end
-        END
-        expect(cop.offenses).not_to be_empty
-        expect(cop.highlights).to include '*b'
+        RUBY
       end
 
       it 'auto-corrects alignment' do
@@ -641,13 +629,12 @@ describe RuboCop::Cop::Layout::AlignParameters do
 
       context 'defining self.method' do
         it 'registers an offense for parameters aligned to first param' do
-          inspect_source(cop, <<-END.strip_indent)
+          expect_offense(<<-RUBY.strip_indent)
             def self.method(a,
                             b)
+                            ^ Use one level of indentation for parameters following the first line of a multi-line method definition.
             end
-          END
-          expect(cop.offenses.size).to eq 1
-          expect(cop.offenses.first.to_s).to match(/method definition/)
+          RUBY
         end
 
         it 'accepts proper indentation' do

--- a/spec/rubocop/cop/layout/case_indentation_spec.rb
+++ b/spec/rubocop/cop/layout/case_indentation_spec.rb
@@ -174,8 +174,17 @@ describe RuboCop::Cop::Layout::CaseIndentation do
         end
 
         it 'registers an offense' do
-          inspect_source(cop, source)
-          expect(cop.messages).to eq(['Indent `when` as deep as `case`.'] * 2)
+          expect_offense(<<-RUBY.strip_indent)
+            case a
+                when 0 then return
+                ^^^^ Indent `when` as deep as `case`.
+                else
+                    case b
+                     when 1 then return
+                     ^^^^ Indent `when` as deep as `case`.
+                    end
+            end
+          RUBY
         end
 
         it 'does auto-correction' do
@@ -316,9 +325,15 @@ describe RuboCop::Cop::Layout::CaseIndentation do
           end
 
           it 'registers an offense' do
-            inspect_source(cop, source)
-            expect(cop.messages)
-              .to eq(['Indent `when` one step more than `case`.'])
+            expect_offense(<<-RUBY.strip_indent)
+              output = case variable
+                       when 'value1'
+                       ^^^^ Indent `when` one step more than `case`.
+                         'output1'
+                       else
+                         'output2'
+                       end
+            RUBY
           end
 
           it 'does auto-correction' do
@@ -360,9 +375,24 @@ describe RuboCop::Cop::Layout::CaseIndentation do
         end
 
         it 'registers an offense' do
-          inspect_source(cop, source)
-          expect(cop.messages)
-            .to eq(['Indent `when` one step more than `case`.'] * 5)
+          expect_offense(<<-RUBY.strip_indent)
+            y = case a
+                when 0 then break
+                ^^^^ Indent `when` one step more than `case`.
+                when 0 then return
+                ^^^^ Indent `when` one step more than `case`.
+                  z = case b
+                      when 1 then return
+                      ^^^^ Indent `when` one step more than `case`.
+                      when 1 then break
+                      ^^^^ Indent `when` one step more than `case`.
+                      end
+                end
+            case c
+            when 2 then encoding
+            ^^^^ Indent `when` one step more than `case`.
+            end
+          RUBY
         end
 
         it 'does auto-correction' do
@@ -467,8 +497,15 @@ describe RuboCop::Cop::Layout::CaseIndentation do
           end
 
           it 'registers an offense' do
-            inspect_source(cop, source)
-            expect(cop.messages).to eq(['Indent `when` as deep as `end`.'])
+            expect_offense(<<-RUBY.strip_indent)
+              output = case variable
+                when 'value1'
+                ^^^^ Indent `when` as deep as `end`.
+                  'output1'
+                else
+                  'output2'
+              end
+            RUBY
           end
 
           it 'does auto-correction' do
@@ -596,8 +633,11 @@ describe RuboCop::Cop::Layout::CaseIndentation do
     end
 
     it 'registers an offense' do
-      inspect_source(cop, source)
-      expect(cop.offenses.size).to eq(1)
+      expect_offense(<<-RUBY.strip_indent)
+        case test when something
+                  ^^^^ Indent `when` as deep as `case`.
+        end
+      RUBY
     end
 
     it "doesn't auto-correct" do

--- a/spec/rubocop/cop/layout/closing_parenthesis_indentation_spec.rb
+++ b/spec/rubocop/cop/layout/closing_parenthesis_indentation_spec.rb
@@ -12,14 +12,12 @@ describe RuboCop::Cop::Layout::ClosingParenthesisIndentation do
   context 'for method calls' do
     context 'with line break before 1st parameter' do
       it 'registers an offense for misaligned )' do
-        inspect_source(cop, <<-END.strip_indent)
+        expect_offense(<<-RUBY.strip_indent)
           some_method(
             a
             )
-        END
-        expect(cop.messages)
-          .to eq(['Indent `)` the same as the start of the line where `(` is.'])
-        expect(cop.highlights).to eq([')'])
+            ^ Indent `)` the same as the start of the line where `(` is.
+        RUBY
       end
 
       it 'autocorrects misaligned )' do
@@ -46,12 +44,11 @@ describe RuboCop::Cop::Layout::ClosingParenthesisIndentation do
 
     context 'with no line break before 1st parameter' do
       it 'registers an offense for misaligned )' do
-        inspect_source(cop, <<-END.strip_indent)
+        expect_offense(<<-RUBY.strip_indent)
           some_method(a
           )
-        END
-        expect(cop.messages).to eq(['Align `)` with `(`.'])
-        expect(cop.highlights).to eq([')'])
+          ^ Align `)` with `(`.
+        RUBY
       end
 
       it 'autocorrects misaligned )' do
@@ -118,15 +115,13 @@ describe RuboCop::Cop::Layout::ClosingParenthesisIndentation do
   context 'for method definitions' do
     context 'with line break before 1st parameter' do
       it 'registers an offense for misaligned )' do
-        inspect_source(cop, <<-END.strip_indent)
+        expect_offense(<<-RUBY.strip_indent)
           def some_method(
             a
             )
+            ^ Indent `)` the same as the start of the line where `(` is.
           end
-        END
-        expect(cop.messages)
-          .to eq(['Indent `)` the same as the start of the line where `(` is.'])
-        expect(cop.highlights).to eq([')'])
+        RUBY
       end
 
       it 'autocorrects misaligned )' do
@@ -156,13 +151,12 @@ describe RuboCop::Cop::Layout::ClosingParenthesisIndentation do
 
     context 'with no line break before 1st parameter' do
       it 'registers an offense for misaligned )' do
-        inspect_source(cop, <<-END.strip_indent)
+        expect_offense(<<-RUBY.strip_indent)
           def some_method(a
           )
+          ^ Align `)` with `(`.
           end
-        END
-        expect(cop.messages).to eq(['Align `)` with `(`.'])
-        expect(cop.highlights).to eq([')'])
+        RUBY
       end
 
       it 'autocorrects misaligned )' do
@@ -198,14 +192,12 @@ describe RuboCop::Cop::Layout::ClosingParenthesisIndentation do
   context 'for grouped expressions' do
     context 'with line break before 1st operand' do
       it 'registers an offense for misaligned )' do
-        inspect_source(cop, <<-END.strip_indent)
+        expect_offense(<<-RUBY.strip_indent)
           w = x * (
             y + z
             )
-        END
-        expect(cop.messages)
-          .to eq(['Indent `)` the same as the start of the line where `(` is.'])
-        expect(cop.highlights).to eq([')'])
+            ^ Indent `)` the same as the start of the line where `(` is.
+        RUBY
       end
 
       it 'autocorrects misaligned )' do
@@ -232,12 +224,11 @@ describe RuboCop::Cop::Layout::ClosingParenthesisIndentation do
 
     context 'with no line break before 1st operand' do
       it 'registers an offense for misaligned )' do
-        inspect_source(cop, <<-END.strip_indent)
+        expect_offense(<<-RUBY.strip_indent)
           w = x * (y + z
           )
-        END
-        expect(cop.messages).to eq(['Align `)` with `(`.'])
-        expect(cop.highlights).to eq([')'])
+          ^ Align `)` with `(`.
+        RUBY
       end
 
       it 'autocorrects misaligned )' do

--- a/spec/rubocop/cop/layout/comment_indentation_spec.rb
+++ b/spec/rubocop/cop/layout/comment_indentation_spec.rb
@@ -18,28 +18,29 @@ describe RuboCop::Cop::Layout::CommentIndentation do
     end
 
     it 'accepts a documentation comment' do
-      inspect_source(cop, <<-END.strip_indent)
+      expect_offense(<<-RUBY.strip_indent)
         =begin
         Doc comment
         =end
           hello
          #
+         ^ Incorrect indentation detected (column 1 instead of 0).
         hi
-      END
-      expect(cop.highlights).to eq(['#'])
+      RUBY
     end
 
     it 'registers an offense for an incorrectly indented (1) comment' do
-      inspect_source(cop, ' # comment')
-      expect(cop.messages)
-        .to eq(['Incorrect indentation detected (column 1 instead of 0).'])
-      expect(cop.highlights).to eq(['# comment'])
+      expect_offense(<<-RUBY.strip_margin('|'))
+        | # comment
+        | ^^^^^^^^^ Incorrect indentation detected (column 1 instead of 0).
+      RUBY
     end
 
     it 'registers an offense for an incorrectly indented (2) comment' do
-      inspect_source(cop, '  # comment')
-      expect(cop.messages)
-        .to eq(['Incorrect indentation detected (column 2 instead of 0).'])
+      expect_offense(<<-RUBY.strip_margin('|'))
+        |  # comment
+        |  ^^^^^^^^^ Incorrect indentation detected (column 2 instead of 0).
+      RUBY
     end
 
     it 'registers an offense for each incorrectly indented comment' do
@@ -133,11 +134,10 @@ describe RuboCop::Cop::Layout::CommentIndentation do
     end
 
     it 'is unaffected by closing bracket that does not begin a line' do
-      inspect_source(cop, <<-END.strip_indent)
+      expect_no_offenses(<<-RUBY.strip_indent)
         #
         result = []
-      END
-      expect(cop.messages).to eq([])
+      RUBY
     end
   end
 

--- a/spec/rubocop/cop/layout/dot_position_spec.rb
+++ b/spec/rubocop/cop/layout/dot_position_spec.rb
@@ -39,11 +39,11 @@ describe RuboCop::Cop::Layout::DotPosition, :config do
     end
 
     it 'does not err on method call without a method name' do
-      inspect_source(cop, <<-END.strip_indent)
+      expect_offense(<<-RUBY.strip_indent)
         l.
+         ^ Place the . on the next line, together with the method name.
         (1)
-      END
-      expect(cop.offenses.size).to eq(1)
+      RUBY
     end
 
     it 'does not err on method call on same line' do
@@ -135,11 +135,11 @@ describe RuboCop::Cop::Layout::DotPosition, :config do
     end
 
     it 'does not err on method call without a method name' do
-      inspect_source(cop, <<-END.strip_indent)
+      expect_offense(<<-RUBY.strip_indent)
         l
         .(1)
-      END
-      expect(cop.offenses.size).to eq(1)
+        ^ Place the . on the previous line, together with the method call receiver.
+      RUBY
     end
 
     it 'does not err on method call on same line' do

--- a/spec/rubocop/cop/layout/else_alignment_spec.rb
+++ b/spec/rubocop/cop/layout/else_alignment_spec.rb
@@ -15,27 +15,25 @@ describe RuboCop::Cop::Layout::ElseAlignment do
 
   context 'with if statement' do
     it 'registers an offense for misaligned else' do
-      inspect_source(cop, <<-END.strip_indent)
+      expect_offense(<<-RUBY.strip_indent)
         if cond
           func1
          else
+         ^^^^ Align `else` with `if`.
          func2
         end
-      END
-      expect(cop.messages).to eq(['Align `else` with `if`.'])
-      expect(cop.highlights).to eq(['else'])
+      RUBY
     end
 
     it 'registers an offense for misaligned elsif' do
-      inspect_source(cop, <<-END.strip_indent)
+      expect_offense(<<-RUBY.strip_indent)
           if a1
             b1
         elsif a2
+        ^^^^^ Align `elsif` with `if`.
             b2
           end
-      END
-      expect(cop.messages).to eq(['Align `elsif` with `if`.'])
-      expect(cop.highlights).to eq(['elsif'])
+      RUBY
     end
 
     it 'accepts indentation after else when if is on new line after ' \

--- a/spec/rubocop/cop/layout/empty_line_after_magic_comment_spec.rb
+++ b/spec/rubocop/cop/layout/empty_line_after_magic_comment_spec.rb
@@ -5,32 +5,29 @@ describe RuboCop::Cop::Layout::EmptyLineAfterMagicComment do
   subject(:cop) { described_class.new(config) }
 
   it 'registers an offense for code that immediately follows comment' do
-    inspect_source(cop, <<-END.strip_indent)
+    expect_offense(<<-RUBY.strip_indent)
       # frozen_string_literal: true
       class Foo; end
-    END
-    expect(cop.offenses.size).to eq(1)
-    expect(cop.messages).to eq(['Add an empty line after magic comments.'])
+      ^ Add an empty line after magic comments.
+    RUBY
   end
 
   it 'registers an offense for documentation immediately following comment' do
-    inspect_source(cop, <<-END.strip_indent)
+    expect_offense(<<-RUBY.strip_indent)
       # frozen_string_literal: true
       # Documentation for Foo
+      ^ Add an empty line after magic comments.
       class Foo; end
-    END
-    expect(cop.offenses.size).to eq(1)
-    expect(cop.messages).to eq(['Add an empty line after magic comments.'])
+    RUBY
   end
 
   it 'registers an offense when multiple magic comments without empty line' do
-    inspect_source(cop, <<-END.strip_indent)
+    expect_offense(<<-RUBY.strip_indent)
       # encoding: utf-8
       # frozen_string_literal: true
       class Foo; end
-    END
-    expect(cop.offenses.size).to eq(1)
-    expect(cop.messages).to eq(['Add an empty line after magic comments.'])
+      ^ Add an empty line after magic comments.
+    RUBY
   end
 
   it 'accepts code that separates the comment from the code with a newline' do
@@ -57,21 +54,6 @@ describe RuboCop::Cop::Layout::EmptyLineAfterMagicComment do
 
     expect(new_source).to eq(<<-END.strip_indent)
       # frozen_string_literal: true\n
-      class Foo; end
-    END
-  end
-
-  it 'autocorrects by adding a newline above the documentation' do
-    new_source = autocorrect_source(cop, <<-END.strip_indent)
-      # frozen_string_literal: true
-      # Documentation for Foo
-      class Foo; end
-    END
-
-    expect(new_source).to eq(<<-END.strip_indent)
-      # frozen_string_literal: true
-
-      # Documentation for Foo
       class Foo; end
     END
   end

--- a/spec/rubocop/cop/layout/empty_line_between_defs_spec.rb
+++ b/spec/rubocop/cop/layout/empty_line_between_defs_spec.rb
@@ -40,8 +40,17 @@ describe RuboCop::Cop::Layout::EmptyLineBetweenDefs, :config do
     end
 
     it 'registers an offense' do
-      inspect_source(cop, source)
-      expect(cop.offenses.size).to eq(1)
+      expect_offense(<<-RUBY.strip_indent)
+        class J
+          def n
+          end # n-related
+          # checks something o-related
+          # and more
+          def o
+          ^^^ Use empty lines between method definitions.
+          end
+        end
+      RUBY
     end
 
     it 'auto-corrects' do
@@ -113,8 +122,17 @@ describe RuboCop::Cop::Layout::EmptyLineBetweenDefs, :config do
       end
 
       it 'registers an offense for missing blank line between methods' do
-        inspect_source(cop, offending_source)
-        expect(cop.offenses.size).to eq(1)
+        expect_offense(<<-RUBY.strip_indent)
+          class Test
+            def self.foo
+              true
+            end
+            def self.bar
+            ^^^ Use empty lines between method definitions.
+              true
+            end
+          end
+        RUBY
       end
 
       it 'autocorrects it' do
@@ -148,8 +166,17 @@ describe RuboCop::Cop::Layout::EmptyLineBetweenDefs, :config do
       end
 
       it 'registers an offense for missing blank line between methods' do
-        inspect_source(cop, offending_source)
-        expect(cop.offenses.size).to eq(1)
+        expect_offense(<<-RUBY.strip_indent)
+          class Test
+            def foo
+              true
+            end
+            def self.bar
+            ^^^ Use empty lines between method definitions.
+              true
+            end
+          end
+        RUBY
       end
 
       it 'autocorrects it' do

--- a/spec/rubocop/cop/layout/first_parameter_indentation_spec.rb
+++ b/spec/rubocop/cop/layout/first_parameter_indentation_spec.rb
@@ -294,13 +294,11 @@ describe RuboCop::Cop::Layout::FirstParameterIndentation do
     context 'for method calls within method calls' do
       context 'with outer parentheses' do
         it 'registers an offense for an over-indented first parameter' do
-          inspect_source(cop, <<-END.strip_indent)
+          expect_offense(<<-RUBY.strip_indent)
             run(:foo, defaults.merge(
                                     bar: 3))
-          END
-          expect(cop.messages).to eq(['Indent the first parameter one step ' \
-                                      'more than `defaults.merge(`.'])
-          expect(cop.highlights).to eq(['bar: 3'])
+                                    ^^^^^^ Indent the first parameter one step more than `defaults.merge(`.
+          RUBY
         end
       end
 
@@ -336,25 +334,20 @@ describe RuboCop::Cop::Layout::FirstParameterIndentation do
     context 'for method calls within method calls' do
       context 'with outer parentheses' do
         it 'registers an offense for an over-indented first parameter' do
-          inspect_source(cop, <<-END.strip_indent)
+          expect_offense(<<-RUBY.strip_indent)
             run(:foo, defaults.merge(
                                     bar: 3))
-          END
-          expect(cop.messages).to eq(['Indent the first parameter one step ' \
-                                      'more than `defaults.merge(`.'])
-          expect(cop.highlights).to eq(['bar: 3'])
+                                    ^^^^^^ Indent the first parameter one step more than `defaults.merge(`.
+          RUBY
         end
 
         it 'registers an offense for an under-indented first parameter' do
-          inspect_source(cop, <<-END.strip_indent)
+          expect_offense(<<-RUBY.strip_indent)
             run(:foo, defaults.
                       merge(
               bar: 3))
-          END
-          expect(cop.messages).to eq(['Indent the first parameter one step ' \
-                                      'more than the start of the ' \
-                                      'previous line.'])
-          expect(cop.highlights).to eq(['bar: 3'])
+              ^^^^^^ Indent the first parameter one step more than the start of the previous line.
+          RUBY
         end
 
         it 'accepts a correctly indented first parameter in interpolation' do
@@ -409,14 +402,11 @@ describe RuboCop::Cop::Layout::FirstParameterIndentation do
 
     context 'for method calls within method calls' do
       it 'registers an offense for an over-indented first parameter' do
-        inspect_source(cop, <<-END.strip_indent)
+        expect_offense(<<-RUBY.strip_indent)
           run(:foo, defaults.merge(
                       bar: 3))
-        END
-        expect(cop.messages).to eq(['Indent the first parameter one step ' \
-                                    'more than the start of the ' \
-                                    'previous line.'])
-        expect(cop.highlights).to eq(['bar: 3'])
+                      ^^^^^^ Indent the first parameter one step more than the start of the previous line.
+        RUBY
       end
 
       it 'accepts first parameter indented relative to previous line' do

--- a/spec/rubocop/cop/layout/indentation_consistency_spec.rb
+++ b/spec/rubocop/cop/layout/indentation_consistency_spec.rb
@@ -452,16 +452,15 @@ describe RuboCop::Cop::Layout::IndentationConsistency, :config do
 
     context 'with normal style configured' do
       it 'registers an offense for bad indentation in a class body' do
-        inspect_source(cop, <<-END.strip_indent)
+        expect_offense(<<-RUBY.strip_indent)
           class Test
               def func1
               end
             def func2
+            ^^^^^^^^^ Inconsistent indentation detected.
             end
           end
-        END
-        expect(cop.messages)
-          .to eq(['Inconsistent indentation detected.'])
+        RUBY
       end
 
       it 'accepts an empty class body' do
@@ -520,15 +519,15 @@ describe RuboCop::Cop::Layout::IndentationConsistency, :config do
 
   context 'with module' do
     it 'registers an offense for bad indentation in a module body' do
-      inspect_source(cop, <<-END.strip_indent)
+      expect_offense(<<-RUBY.strip_indent)
         module Test
             def func1
             end
              def func2
+             ^^^^^^^^^ Inconsistent indentation detected.
              end
         end
-      END
-      expect(cop.messages).to eq(['Inconsistent indentation detected.'])
+      RUBY
     end
 
     it 'accepts an empty module body' do

--- a/spec/rubocop/cop/layout/initial_indentation_spec.rb
+++ b/spec/rubocop/cop/layout/initial_indentation_spec.rb
@@ -4,11 +4,11 @@ describe RuboCop::Cop::Layout::InitialIndentation do
   subject(:cop) { described_class.new }
 
   it 'registers an offense for indented method definition ' do
-    inspect_source(cop, <<-END.strip_margin('|'))
+    expect_offense(<<-RUBY.strip_margin('|'))
       |  def f
+      |  ^^^ Indentation of first line in file detected.
       |  end
-    END
-    expect(cop.messages).to eq(['Indentation of first line in file detected.'])
+    RUBY
   end
 
   it 'accepts unindented method definition' do
@@ -27,14 +27,18 @@ describe RuboCop::Cop::Layout::InitialIndentation do
     end
 
     it 'registers an offense for indented method call' do
-      inspect_source(cop, bom + '  puts 1')
-      expect(cop.offenses.size).to eq(1)
+      expect_offense(<<-RUBY.strip_indent)
+        ﻿  puts 1
+           ^^^^ Indentation of first line in file detected.
+      RUBY
     end
 
     it 'registers an offense for indented method call after comment' do
-      inspect_source(cop, [bom + '# comment',
-                           '  puts 1'])
-      expect(cop.offenses.size).to eq(1)
+      expect_offense(<<-RUBY.strip_indent)
+        ﻿# comment
+          puts 1
+          ^^^^ Indentation of first line in file detected.
+      RUBY
     end
   end
 
@@ -43,11 +47,11 @@ describe RuboCop::Cop::Layout::InitialIndentation do
   end
 
   it 'registers an offense for indented assignment disregarding comment' do
-    inspect_source(cop, <<-END.strip_margin('|'))
-      | # comment
-      | x = 1
-    END
-    expect(cop.highlights).to eq(['x'])
+    expect_offense(<<-RUBY.strip_margin('|'))
+      |   # comment
+      |   x = 1
+      |   ^ Indentation of first line in file detected.
+    RUBY
   end
 
   it 'accepts unindented comment + assignment' do

--- a/spec/rubocop/cop/layout/leading_comment_space_spec.rb
+++ b/spec/rubocop/cop/layout/leading_comment_space_spec.rb
@@ -4,8 +4,10 @@ describe RuboCop::Cop::Layout::LeadingCommentSpace do
   subject(:cop) { described_class.new }
 
   it 'registers an offense for comment without leading space' do
-    inspect_source(cop, '#missing space')
-    expect(cop.offenses.size).to eq(1)
+    expect_offense(<<-RUBY.strip_indent)
+      #missing space
+      ^^^^^^^^^^^^^^ Missing space after #.
+    RUBY
   end
 
   it 'does not register an offense for # followed by no text' do
@@ -32,11 +34,11 @@ describe RuboCop::Cop::Layout::LeadingCommentSpace do
   end
 
   it 'registers an offense for #! after the first line' do
-    inspect_source(cop, <<-END.strip_indent)
+    expect_offense(<<-RUBY.strip_indent)
       test
       #!/usr/bin/ruby
-    END
-    expect(cop.offenses.size).to eq(1)
+      ^^^^^^^^^^^^^^^ Missing space after #.
+    RUBY
   end
 
   context 'file named config.ru' do

--- a/spec/rubocop/cop/layout/multiline_block_layout_spec.rb
+++ b/spec/rubocop/cop/layout/multiline_block_layout_spec.rb
@@ -67,23 +67,21 @@ describe RuboCop::Cop::Layout::MultilineBlockLayout do
   end
 
   it 'registers offenses for lambdas as expected' do
-    inspect_source(cop, <<-END.strip_indent)
+    expect_offense(<<-RUBY.strip_indent)
       -> (x) do foo
+                ^^^ Block body expression is on the same line as the block start.
         bar
       end
-    END
-    expect(cop.messages)
-      .to eq(['Block body expression is on the same line as the block start.'])
+    RUBY
   end
 
   it 'registers offenses for new lambda literal syntax as expected' do
-    inspect_source(cop, <<-END.strip_indent)
+    expect_offense(<<-RUBY.strip_indent)
       -> x do foo
+              ^^^ Block body expression is on the same line as the block start.
         bar
       end
-    END
-    expect(cop.messages)
-      .to eq(['Block body expression is on the same line as the block start.'])
+    RUBY
   end
 
   it 'registers an offense for line-break before arguments' do
@@ -105,14 +103,12 @@ describe RuboCop::Cop::Layout::MultilineBlockLayout do
   end
 
   it 'registers an offense for line-break within arguments' do
-    inspect_source(cop, <<-END.strip_indent)
+    expect_offense(<<-RUBY.strip_indent)
       test do |x,
+              ^^^ Block argument expression is not on the same line as the block start.
         y|
       end
-    END
-    expect(cop.messages)
-      .to eq(['Block argument expression is not on the same line as the ' \
-              'block start.'])
+    RUBY
   end
 
   it 'auto-corrects a do/end block with params that is missing newlines' do

--- a/spec/rubocop/cop/layout/multiline_method_call_indentation_spec.rb
+++ b/spec/rubocop/cop/layout/multiline_method_call_indentation_spec.rb
@@ -277,25 +277,23 @@ describe RuboCop::Cop::Layout::MultilineMethodCallIndentation do
       end
 
       it 'registers an offense for unaligned methods' do
-        inspect_source(cop, <<-END.strip_indent)
+        expect_offense(<<-RUBY.strip_indent)
           User.a
             .b
+            ^^ Align `.b` with `.a` on line 1.
            .c
-        END
-        expect(cop.messages).to eq(['Align `.b` with `.a` on line 1.',
-                                    'Align `.c` with `.a` on line 1.'])
-        expect(cop.highlights).to eq(['.b', '.c'])
+           ^^ Align `.c` with `.a` on line 1.
+        RUBY
       end
 
       it 'registers an offense for unaligned method in block body' do
-        inspect_source(cop, <<-END.strip_indent)
+        expect_offense(<<-RUBY.strip_indent)
           a do
             b.c
               .d
+              ^^ Align `.d` with `.c` on line 2.
           end
-        END
-        expect(cop.messages).to eq(['Align `.d` with `.c` on line 2.'])
-        expect(cop.highlights).to eq(['.d'])
+        RUBY
       end
 
       it 'auto-corrects' do
@@ -353,15 +351,12 @@ describe RuboCop::Cop::Layout::MultilineMethodCallIndentation do
     end
 
     it 'registers an offense for one space indentation of third line' do
-      inspect_source(cop, <<-END.strip_indent)
+      expect_offense(<<-RUBY.strip_indent)
         a
           .b
          .c
-      END
-      expect(cop.messages)
-        .to eq(['Use 2 (not 1) spaces for indenting an expression spanning ' \
-                'multiple lines.'])
-      expect(cop.highlights).to eq(['.c'])
+         ^^ Use 2 (not 1) spaces for indenting an expression spanning multiple lines.
+      RUBY
     end
 
     it 'accepts indented and aligned methods in binary operation' do
@@ -424,14 +419,12 @@ describe RuboCop::Cop::Layout::MultilineMethodCallIndentation do
     end
 
     it 'registers an offense for misaligned method in []= call' do
-      inspect_source(cop, <<-END.strip_indent)
+      expect_offense(<<-RUBY.strip_indent)
         flash[:error] = here_is_a_string.
                         that_spans.
            multiple_lines
-      END
-      expect(cop.messages)
-        .to eq(['Align `multiple_lines` with `here_is_a_string.` on line 1.'])
-      expect(cop.highlights).to eq(['multiple_lines'])
+           ^^^^^^^^^^^^^^ Align `multiple_lines` with `here_is_a_string.` on line 1.
+      RUBY
     end
 
     it 'registers an offense for misaligned methods in unless condition' do
@@ -447,25 +440,23 @@ describe RuboCop::Cop::Layout::MultilineMethodCallIndentation do
     end
 
     it 'registers an offense for misaligned methods in while condition' do
-      inspect_source(cop, <<-END.strip_indent)
+      expect_offense(<<-RUBY.strip_indent)
         while a.
             b
+            ^ Align `b` with `a.` on line 1.
           something
         end
-      END
-      expect(cop.messages).to eq(['Align `b` with `a.` on line 1.'])
-      expect(cop.highlights).to eq(['b'])
+      RUBY
     end
 
     it 'registers an offense for misaligned methods in until condition' do
-      inspect_source(cop, <<-END.strip_indent)
+      expect_offense(<<-RUBY.strip_indent)
         until a.
             b
+            ^ Align `b` with `a.` on line 1.
           something
         end
-      END
-      expect(cop.messages).to eq(['Align `b` with `a.` on line 1.'])
-      expect(cop.highlights).to eq(['b'])
+      RUBY
     end
 
     it 'accepts aligned method in return' do
@@ -522,13 +513,12 @@ describe RuboCop::Cop::Layout::MultilineMethodCallIndentation do
     end
 
     it 'registers an offense for unaligned methods in assignment' do
-      inspect_source(cop, <<-END.strip_indent)
+      expect_offense(<<-RUBY.strip_indent)
         bar = Foo
           .a
+          ^^ Align `.a` with `Foo` on line 1.
               .b(c)
-      END
-      expect(cop.messages).to eq(['Align `.a` with `Foo` on line 1.'])
-      expect(cop.highlights).to eq(['.a'])
+      RUBY
     end
 
     it 'auto-corrects' do
@@ -597,13 +587,11 @@ describe RuboCop::Cop::Layout::MultilineMethodCallIndentation do
     end
 
     it 'registers an offense for no indentation of second line' do
-      inspect_source(cop, <<-END.strip_indent)
+      expect_offense(<<-RUBY.strip_indent)
         a.
         b
-      END
-      expect(cop.messages)
-        .to eq(['Indent `b` 2 spaces more than `a` on line 1.'])
-      expect(cop.highlights).to eq(['b'])
+        ^ Indent `b` 2 spaces more than `a` on line 1.
+      RUBY
     end
 
     it 'registers an offense for extra indentation of 3rd line in typical ' \
@@ -619,47 +607,39 @@ describe RuboCop::Cop::Layout::MultilineMethodCallIndentation do
     end
 
     it 'registers an offense for proc call without a selector' do
-      inspect_source(cop, <<-END.strip_indent)
+      expect_offense(<<-RUBY.strip_indent)
         a
          .(args)
-      END
-      expect(cop.messages).to eq(['Indent `.(` 2 spaces more than `a` on ' \
-                                  'line 1.'])
-      expect(cop.highlights).to eq(['.('])
+         ^^ Indent `.(` 2 spaces more than `a` on line 1.
+      RUBY
     end
 
     it 'registers an offense for one space indentation of second line' do
-      inspect_source(cop, <<-END.strip_indent)
+      expect_offense(<<-RUBY.strip_indent)
         a
          .b
-      END
-      expect(cop.messages).to eq(['Indent `.b` 2 spaces more than `a` on ' \
-                                  'line 1.'])
-      expect(cop.highlights).to eq(['.b'])
+         ^^ Indent `.b` 2 spaces more than `a` on line 1.
+      RUBY
     end
 
     it 'registers an offense for 3 spaces indentation of second line' do
-      inspect_source(cop, <<-END.strip_indent)
+      expect_offense(<<-RUBY.strip_indent)
         a.
            b
+           ^ Indent `b` 2 spaces more than `a` on line 1.
         c.
            d
-      END
-      expect(cop.messages)
-        .to eq(['Indent `b` 2 spaces more than `a` on line 1.',
-                'Indent `d` 2 spaces more than `c` on line 3.'])
-      expect(cop.highlights).to eq(%w[b d])
+           ^ Indent `d` 2 spaces more than `c` on line 3.
+      RUBY
     end
 
     it 'registers an offense for extra indentation of third line' do
-      inspect_source(cop, <<-END.strip_margin('|'))
-        |   a.
-        |     b.
-        |       c
-      END
-      expect(cop.messages)
-        .to eq(['Indent `c` 2 spaces more than `a` on line 1.'])
-      expect(cop.highlights).to eq(['c'])
+      expect_offense(<<-RUBY.strip_indent)
+           a.
+             b.
+               c
+               ^ Indent `c` 2 spaces more than `a` on line 1.
+      RUBY
     end
 
     it 'registers an offense for the emacs ruby-mode 1.1 indentation of an ' \
@@ -709,14 +689,12 @@ describe RuboCop::Cop::Layout::MultilineMethodCallIndentation do
     end
 
     it 'registers an offense for one space indentation of third line' do
-      inspect_source(cop, <<-END.strip_indent)
+      expect_offense(<<-RUBY.strip_indent)
         a
           .b
          .c
-      END
-      expect(cop.messages).to eq(['Use 2 (not 1) spaces for indenting an ' \
-                                  'expression spanning multiple lines.'])
-      expect(cop.highlights).to eq(['.c'])
+         ^^ Use 2 (not 1) spaces for indenting an expression spanning multiple lines.
+      RUBY
     end
 
     it 'accepts indented methods in if condition' do
@@ -824,15 +802,12 @@ describe RuboCop::Cop::Layout::MultilineMethodCallIndentation do
     end
 
     it 'registers an offense for wrong indentation of for expression' do
-      inspect_source(cop, <<-END.strip_indent)
+      expect_offense(<<-RUBY.strip_indent)
         for n in a.
           b
+          ^ Use 4 (not 2) spaces for indenting a collection in a `for` statement spanning multiple lines.
         end
-      END
-      expect(cop.messages).to eq(['Use 4 (not 2) spaces for indenting a ' \
-                                  'collection in a `for` statement spanning ' \
-                                  'multiple lines.'])
-      expect(cop.highlights).to eq(['b'])
+      RUBY
     end
 
     it 'accepts special indentation of for expression' do

--- a/spec/rubocop/cop/layout/multiline_operation_indentation_spec.rb
+++ b/spec/rubocop/cop/layout/multiline_operation_indentation_spec.rb
@@ -295,14 +295,12 @@ describe RuboCop::Cop::Layout::MultilineOperationIndentation do
     end
 
     it 'registers an offense for misaligned string operand when plus is used' do
-      inspect_source(cop, <<-END.strip_indent)
+      expect_offense(<<-RUBY.strip_indent)
         Error = 'Here is a string ' +
                 'That spans' <<
           'multiple lines'
-      END
-      expect(cop.messages).to eq(['Align the operands of an expression in an ' \
-                                  'assignment spanning multiple lines.'])
-      expect(cop.highlights).to eq(["'multiple lines'"])
+          ^^^^^^^^^^^^^^^^ Align the operands of an expression in an assignment spanning multiple lines.
+      RUBY
     end
 
     it 'registers an offense for misaligned operands in unless condition' do
@@ -359,14 +357,12 @@ describe RuboCop::Cop::Layout::MultilineOperationIndentation do
     end
 
     it 'registers an offense for unaligned operands in op-assignment' do
-      inspect_source(cop, <<-END.strip_indent)
+      expect_offense(<<-RUBY.strip_indent)
         bar *= Foo +
           a +
+          ^ Align the operands of an expression in an assignment spanning multiple lines.
                b(c)
-      END
-      expect(cop.messages).to eq(['Align the operands of an expression in an ' \
-                                  'assignment spanning multiple lines.'])
-      expect(cop.highlights).to eq(['a'])
+      RUBY
     end
 
     it 'auto-corrects' do
@@ -449,12 +445,13 @@ describe RuboCop::Cop::Layout::MultilineOperationIndentation do
     end
 
     it 'registers an offense for aligned code on LHS of equality operator' do
-      inspect_source(cop, ['def config_to_allow_offenses',
-                           '  a +',
-                           '  b == c ',
-                           'end'])
-      expect(cop.messages).to eq(['Use 2 (not 0) spaces for indenting an ' \
-                                  'expression spanning multiple lines.'])
+      expect_offense(<<-RUBY.strip_indent)
+        def config_to_allow_offenses
+          a +
+          b == c
+          ^ Use 2 (not 0) spaces for indenting an expression spanning multiple lines.
+        end
+      RUBY
     end
 
     [
@@ -514,15 +511,12 @@ describe RuboCop::Cop::Layout::MultilineOperationIndentation do
     end
 
     it 'registers an offense for wrong indentation of for expression' do
-      inspect_source(cop, <<-END.strip_indent)
+      expect_offense(<<-RUBY.strip_indent)
         for n in a +
           b
+          ^ Use 4 (not 2) spaces for indenting a collection in a `for` statement spanning multiple lines.
         end
-      END
-      expect(cop.messages).to eq(['Use 4 (not 2) spaces for indenting a ' \
-                                  'collection in a `for` statement spanning ' \
-                                  'multiple lines.'])
-      expect(cop.highlights).to eq(['b'])
+      RUBY
     end
 
     it 'accepts special indentation of for expression' do

--- a/spec/rubocop/cop/layout/space_after_colon_spec.rb
+++ b/spec/rubocop/cop/layout/space_after_colon_spec.rb
@@ -4,9 +4,10 @@ describe RuboCop::Cop::Layout::SpaceAfterColon do
   subject(:cop) { described_class.new }
 
   it 'registers an offense for colon without space after it' do
-    inspect_source(cop, '{a:3}')
-    expect(cop.messages).to eq(['Space missing after colon.'])
-    expect(cop.highlights).to eq([':'])
+    expect_offense(<<-RUBY.strip_indent)
+      {a:3}
+        ^ Space missing after colon.
+    RUBY
   end
 
   it 'accepts colons in symbols' do

--- a/spec/rubocop/cop/layout/space_after_method_name_spec.rb
+++ b/spec/rubocop/cop/layout/space_after_method_name_spec.rb
@@ -4,21 +4,21 @@ describe RuboCop::Cop::Layout::SpaceAfterMethodName do
   subject(:cop) { described_class.new }
 
   it 'registers an offense for def with space before the parenthesis' do
-    inspect_source(cop, <<-END.strip_indent)
+    expect_offense(<<-RUBY.strip_indent)
       def func (x)
+              ^ Do not put a space between a method name and the opening parenthesis.
         a
       end
-    END
-    expect(cop.offenses.size).to eq(1)
+    RUBY
   end
 
   it 'registers an offense for defs with space before the parenthesis' do
-    inspect_source(cop, <<-END.strip_indent)
+    expect_offense(<<-RUBY.strip_indent)
       def self.func (x)
+                   ^ Do not put a space between a method name and the opening parenthesis.
         a
       end
-    END
-    expect(cop.offenses.size).to eq(1)
+    RUBY
   end
 
   it 'accepts a def without arguments' do

--- a/spec/rubocop/cop/layout/space_after_not_spec.rb
+++ b/spec/rubocop/cop/layout/space_after_not_spec.rb
@@ -4,11 +4,10 @@ describe RuboCop::Cop::Layout::SpaceAfterNot do
   subject(:cop) { described_class.new }
 
   it 'reports an offense for space after !' do
-    inspect_source(cop, '! something')
-
-    expect(cop.messages)
-      .to eq(['Do not leave space between `!` and its argument.'])
-    expect(cop.highlights).to eq(['! something'])
+    expect_offense(<<-RUBY.strip_indent)
+      ! something
+      ^^^^^^^^^^^ Do not leave space between `!` and its argument.
+    RUBY
   end
 
   it 'accepts no space after !' do

--- a/spec/rubocop/cop/style/accessor_method_name_spec.rb
+++ b/spec/rubocop/cop/style/accessor_method_name_spec.rb
@@ -4,23 +4,21 @@ describe RuboCop::Cop::Style::AccessorMethodName do
   subject(:cop) { described_class.new }
 
   it 'registers an offense for method get_... with no args' do
-    inspect_source(cop, <<-END.strip_indent)
+    expect_offense(<<-RUBY.strip_indent)
       def get_attr
+          ^^^^^^^^ Do not prefix reader method names with `get_`.
         # ...
       end
-    END
-    expect(cop.offenses.size).to eq(1)
-    expect(cop.highlights).to eq(['get_attr'])
+    RUBY
   end
 
   it 'registers an offense for singleton method get_... with no args' do
-    inspect_source(cop, <<-END.strip_indent)
+    expect_offense(<<-RUBY.strip_indent)
       def self.get_attr
+               ^^^^^^^^ Do not prefix reader method names with `get_`.
         # ...
       end
-    END
-    expect(cop.offenses.size).to eq(1)
-    expect(cop.highlights).to eq(['get_attr'])
+    RUBY
   end
 
   it 'accepts method get_something with args' do
@@ -40,23 +38,21 @@ describe RuboCop::Cop::Style::AccessorMethodName do
   end
 
   it 'registers an offense for method set_something with one arg' do
-    inspect_source(cop, <<-END.strip_indent)
+    expect_offense(<<-RUBY.strip_indent)
       def set_attr(arg)
+          ^^^^^^^^ Do not prefix writer method names with `set_`.
         # ...
       end
-    END
-    expect(cop.offenses.size).to eq(1)
-    expect(cop.highlights).to eq(['set_attr'])
+    RUBY
   end
 
   it 'registers an offense for singleton method set_... with one args' do
-    inspect_source(cop, <<-END.strip_indent)
+    expect_offense(<<-RUBY.strip_indent)
       def self.set_attr(arg)
+               ^^^^^^^^ Do not prefix writer method names with `set_`.
         # ...
       end
-    END
-    expect(cop.offenses.size).to eq(1)
-    expect(cop.highlights).to eq(['set_attr'])
+    RUBY
   end
 
   it 'accepts method set_something with no args' do

--- a/spec/rubocop/cop/style/alias_spec.rb
+++ b/spec/rubocop/cop/style/alias_spec.rb
@@ -7,10 +7,10 @@ describe RuboCop::Cop::Style::Alias, :config do
     let(:cop_config) { { 'EnforcedStyle' => 'prefer_alias_method' } }
 
     it 'registers an offense for alias with symbol args' do
-      inspect_source(cop, 'alias :ala :bala')
-      expect(cop.offenses.size).to eq(1)
-      expect(cop.messages)
-        .to eq(['Use `alias_method` instead of `alias`.'])
+      expect_offense(<<-RUBY.strip_indent)
+        alias :ala :bala
+        ^^^^^ Use `alias_method` instead of `alias`.
+      RUBY
     end
 
     it 'autocorrects alias with symbol args' do
@@ -19,10 +19,10 @@ describe RuboCop::Cop::Style::Alias, :config do
     end
 
     it 'registers an offense for alias with bareword args' do
-      inspect_source(cop, 'alias ala bala')
-      expect(cop.offenses.size).to eq(1)
-      expect(cop.messages)
-        .to eq(['Use `alias_method` instead of `alias`.'])
+      expect_offense(<<-RUBY.strip_indent)
+        alias ala bala
+        ^^^^^ Use `alias_method` instead of `alias`.
+      RUBY
     end
 
     it 'autocorrects alias with bareword args' do
@@ -55,10 +55,10 @@ describe RuboCop::Cop::Style::Alias, :config do
     let(:cop_config) { { 'EnforcedStyle' => 'prefer_alias' } }
 
     it 'registers an offense for alias with symbol args' do
-      inspect_source(cop, 'alias :ala :bala')
-      expect(cop.offenses.size).to eq(1)
-      expect(cop.messages)
-        .to eq(['Use `alias ala bala` instead of `alias :ala :bala`.'])
+      expect_offense(<<-RUBY.strip_indent)
+        alias :ala :bala
+              ^^^^^^^^^^ Use `alias ala bala` instead of `alias :ala :bala`.
+      RUBY
     end
 
     it 'autocorrects alias with symbol args' do
@@ -71,10 +71,10 @@ describe RuboCop::Cop::Style::Alias, :config do
     end
 
     it 'registers an offense for alias_method at the top level' do
-      inspect_source(cop, 'alias_method :ala, :bala')
-      expect(cop.offenses.size).to eq(1)
-      expect(cop.messages)
-        .to eq(['Use `alias` instead of `alias_method` at the top level.'])
+      expect_offense(<<-RUBY.strip_indent)
+        alias_method :ala, :bala
+        ^^^^^^^^^^^^ Use `alias` instead of `alias_method` at the top level.
+      RUBY
     end
 
     it 'autocorrects alias_method at the top level' do
@@ -83,14 +83,12 @@ describe RuboCop::Cop::Style::Alias, :config do
     end
 
     it 'registers an offense for alias_method in a class block' do
-      inspect_source(cop, <<-END.strip_indent)
+      expect_offense(<<-RUBY.strip_indent)
         class C
           alias_method :ala, :bala
+          ^^^^^^^^^^^^ Use `alias` instead of `alias_method` in a class body.
         end
-      END
-      expect(cop.offenses.size).to eq(1)
-      expect(cop.messages)
-        .to eq(['Use `alias` instead of `alias_method` in a class body.'])
+      RUBY
     end
 
     it 'autocorrects alias_method in a class block' do
@@ -107,14 +105,12 @@ describe RuboCop::Cop::Style::Alias, :config do
     end
 
     it 'registers an offense for alias_method in a module block' do
-      inspect_source(cop, <<-END.strip_indent)
+      expect_offense(<<-RUBY.strip_indent)
         module M
           alias_method :ala, :bala
+          ^^^^^^^^^^^^ Use `alias` instead of `alias_method` in a module body.
         end
-      END
-      expect(cop.offenses.size).to eq(1)
-      expect(cop.messages)
-        .to eq(['Use `alias` instead of `alias_method` in a module body.'])
+      RUBY
     end
 
     it 'autocorrects alias_method in a module block' do

--- a/spec/rubocop/cop/style/and_or_spec.rb
+++ b/spec/rubocop/cop/style/and_or_spec.rb
@@ -68,15 +68,17 @@ describe RuboCop::Cop::Style::AndOr, :config do
     let(:cop_config) { cop_config }
 
     it 'registers an offense for "or"' do
-      inspect_source(cop, 'test if a or b')
-      expect(cop.offenses.size).to eq(1)
-      expect(cop.messages).to eq(['Use `||` instead of `or`.'])
+      expect_offense(<<-RUBY.strip_indent)
+        test if a or b
+                  ^^ Use `||` instead of `or`.
+      RUBY
     end
 
     it 'registers an offense for "and"' do
-      inspect_source(cop, 'test if a and b')
-      expect(cop.offenses.size).to eq(1)
-      expect(cop.messages).to eq(['Use `&&` instead of `and`.'])
+      expect_offense(<<-RUBY.strip_indent)
+        test if a and b
+                  ^^^ Use `&&` instead of `and`.
+      RUBY
     end
 
     it 'accepts ||' do
@@ -135,51 +137,59 @@ describe RuboCop::Cop::Style::AndOr, :config do
     end
 
     it 'warns on short-circuit (and)' do
-      inspect_source(cop, 'x = a + b and return x')
-      expect(cop.offenses.size).to eq(1)
-      expect(cop.messages).to eq(['Use `&&` instead of `and`.'])
+      expect_offense(<<-RUBY.strip_indent)
+        x = a + b and return x
+                  ^^^ Use `&&` instead of `and`.
+      RUBY
     end
 
     it 'also warns on non short-circuit (and)' do
-      inspect_source(cop, 'x = a + b if a and b')
-      expect(cop.offenses.size).to eq(1)
-      expect(cop.messages).to eq(['Use `&&` instead of `and`.'])
+      expect_offense(<<-RUBY.strip_indent)
+        x = a + b if a and b
+                       ^^^ Use `&&` instead of `and`.
+      RUBY
     end
 
     it 'also warns on non short-circuit (and) (unless)' do
-      inspect_source(cop, 'x = a + b unless a and b')
-      expect(cop.offenses.size).to eq(1)
-      expect(cop.messages).to eq(['Use `&&` instead of `and`.'])
+      expect_offense(<<-RUBY.strip_indent)
+        x = a + b unless a and b
+                           ^^^ Use `&&` instead of `and`.
+      RUBY
     end
 
     it 'warns on short-circuit (or)' do
-      inspect_source(cop, 'x = a + b or return x')
-      expect(cop.offenses.size).to eq(1)
-      expect(cop.messages).to eq(['Use `||` instead of `or`.'])
+      expect_offense(<<-RUBY.strip_indent)
+        x = a + b or return x
+                  ^^ Use `||` instead of `or`.
+      RUBY
     end
 
     it 'also warns on non short-circuit (or)' do
-      inspect_source(cop, 'x = a + b if a or b')
-      expect(cop.offenses.size).to eq(1)
-      expect(cop.messages).to eq(['Use `||` instead of `or`.'])
+      expect_offense(<<-RUBY.strip_indent)
+        x = a + b if a or b
+                       ^^ Use `||` instead of `or`.
+      RUBY
     end
 
     it 'also warns on non short-circuit (or) (unless)' do
-      inspect_source(cop, 'x = a + b unless a or b')
-      expect(cop.offenses.size).to eq(1)
-      expect(cop.messages).to eq(['Use `||` instead of `or`.'])
+      expect_offense(<<-RUBY.strip_indent)
+        x = a + b unless a or b
+                           ^^ Use `||` instead of `or`.
+      RUBY
     end
 
     it 'also warns on while (or)' do
-      inspect_source(cop, 'x = a + b while a or b')
-      expect(cop.offenses.size).to eq(1)
-      expect(cop.messages).to eq(['Use `||` instead of `or`.'])
+      expect_offense(<<-RUBY.strip_indent)
+        x = a + b while a or b
+                          ^^ Use `||` instead of `or`.
+      RUBY
     end
 
     it 'also warns on until (or)' do
-      inspect_source(cop, 'x = a + b until a or b')
-      expect(cop.offenses.size).to eq(1)
-      expect(cop.messages).to eq(['Use `||` instead of `or`.'])
+      expect_offense(<<-RUBY.strip_indent)
+        x = a + b until a or b
+                          ^^ Use `||` instead of `or`.
+      RUBY
     end
 
     it 'auto-corrects "or" with || in method calls' do
@@ -328,8 +338,10 @@ describe RuboCop::Cop::Style::AndOr, :config do
     context 'with !variable on left' do
       it "doesn't crash and burn" do
         # regression test; see GH issue 2482
-        inspect_source(cop, '!var or var.empty?')
-        expect(cop.offenses.size).to eq(1)
+        expect_offense(<<-RUBY.strip_indent)
+          !var or var.empty?
+               ^^ Use `||` instead of `or`.
+        RUBY
       end
     end
 

--- a/spec/rubocop/cop/style/array_join_spec.rb
+++ b/spec/rubocop/cop/style/array_join_spec.rb
@@ -4,9 +4,10 @@ describe RuboCop::Cop::Style::ArrayJoin do
   subject(:cop) { described_class.new }
 
   it 'registers an offense for an array followed by string' do
-    inspect_source(cop,
-                   '%w(one two three) * ", "')
-    expect(cop.offenses.size).to eq(1)
+    expect_offense(<<-RUBY.strip_indent)
+      %w(one two three) * ", "
+                        ^ Favor `Array#join` over `Array#*`.
+    RUBY
   end
 
   it "autocorrects '*' to 'join' when there are spaces" do

--- a/spec/rubocop/cop/style/ascii_comments_spec.rb
+++ b/spec/rubocop/cop/style/ascii_comments_spec.rb
@@ -4,25 +4,19 @@ describe RuboCop::Cop::Style::AsciiComments do
   subject(:cop) { described_class.new }
 
   it 'registers an offense for a comment with non-ascii chars' do
-    inspect_source(cop, <<-END.strip_indent)
+    expect_offense(<<-RUBY.strip_indent)
       # encoding: utf-8
       # 这是什么？
-    END
-    expect(cop.offenses.size).to eq(1)
-    expect(cop.highlights).to eq(['这是什么？'])
-    expect(cop.messages)
-      .to eq(['Use only ascii symbols in comments.'])
+        ^^^^^ Use only ascii symbols in comments.
+    RUBY
   end
 
   it 'registers an offense for commentes with mixed chars' do
-    inspect_source(cop, <<-END.strip_indent)
+    expect_offense(<<-RUBY.strip_indent)
       # encoding: utf-8
       # foo ∂ bar
-    END
-    expect(cop.offenses.size).to eq(1)
-    expect(cop.highlights).to eq(['∂'])
-    expect(cop.messages)
-      .to eq(['Use only ascii symbols in comments.'])
+            ^ Use only ascii symbols in comments.
+    RUBY
   end
 
   it 'accepts comments with only ascii chars' do

--- a/spec/rubocop/cop/style/ascii_identifiers_spec.rb
+++ b/spec/rubocop/cop/style/ascii_identifiers_spec.rb
@@ -4,25 +4,19 @@ describe RuboCop::Cop::Style::AsciiIdentifiers do
   subject(:cop) { described_class.new }
 
   it 'registers an offense for a variable name with non-ascii chars' do
-    inspect_source(cop, <<-END.strip_indent)
+    expect_offense(<<-RUBY.strip_indent)
       # encoding: utf-8
       älg = 1
-    END
-    expect(cop.offenses.size).to eq(1)
-    expect(cop.highlights).to eq(['ä'])
-    expect(cop.messages)
-      .to eq(['Use only ascii symbols in identifiers.'])
+      ^ Use only ascii symbols in identifiers.
+    RUBY
   end
 
   it 'registers an offense for a variable name with mixed chars' do
-    inspect_source(cop, <<-END.strip_indent)
+    expect_offense(<<-RUBY.strip_indent)
       # encoding: utf-8
       foo∂∂bar = baz
-    END
-    expect(cop.offenses.size).to eq(1)
-    expect(cop.highlights).to eq(['∂∂'])
-    expect(cop.messages)
-      .to eq(['Use only ascii symbols in identifiers.'])
+         ^^ Use only ascii symbols in identifiers.
+    RUBY
   end
 
   it 'accepts identifiers with only ascii chars' do

--- a/spec/rubocop/cop/style/attr_spec.rb
+++ b/spec/rubocop/cop/style/attr_spec.rb
@@ -4,12 +4,12 @@ describe RuboCop::Cop::Style::Attr do
   subject(:cop) { described_class.new }
 
   it 'registers an offense attr' do
-    inspect_source(cop, <<-END.strip_indent)
+    expect_offense(<<-RUBY.strip_indent)
       class SomeClass
         attr :name
+        ^^^^ Do not use `attr`. Use `attr_reader` instead.
       end
-    END
-    expect(cop.offenses.size).to eq(1)
+    RUBY
   end
 
   it 'accepts attr when it does not take arguments' do

--- a/spec/rubocop/cop/style/auto_resource_cleanup_spec.rb
+++ b/spec/rubocop/cop/style/auto_resource_cleanup_spec.rb
@@ -4,9 +4,10 @@ describe RuboCop::Cop::Style::AutoResourceCleanup do
   subject(:cop) { described_class.new }
 
   it 'registers an offense for File.open without block' do
-    inspect_source(cop, 'File.open("filename")')
-    expect(cop.offenses.size).to eq(1)
-    expect(cop.messages).to eq(['Use the block version of `File.open`.'])
+    expect_offense(<<-RUBY.strip_indent)
+      File.open("filename")
+      ^^^^^^^^^^^^^^^^^^^^^ Use the block version of `File.open`.
+    RUBY
   end
 
   it 'does not register an offense for File.open with block' do

--- a/spec/rubocop/cop/style/bare_percent_literals_spec.rb
+++ b/spec/rubocop/cop/style/bare_percent_literals_spec.rb
@@ -42,9 +42,10 @@ describe RuboCop::Cop::Style::BarePercentLiterals, :config do
 
     context 'and strings are static' do
       it 'registers an offense for %()' do
-        inspect_source(cop, '%(hi)')
-        expect(cop.messages).to eq(['Use `%Q` instead of `%`.'])
-        expect(cop.highlights).to eq(['%('])
+        expect_offense(<<-RUBY.strip_indent)
+          %(hi)
+          ^^ Use `%Q` instead of `%`.
+        RUBY
       end
 
       it 'auto-corrects' do
@@ -61,8 +62,10 @@ describe RuboCop::Cop::Style::BarePercentLiterals, :config do
 
     context 'and strings are dynamic' do
       it 'registers an offense for %()' do
-        inspect_source(cop, '%(#{x})')
-        expect(cop.messages).to eq(['Use `%Q` instead of `%`.'])
+        expect_offense(<<-'RUBY'.strip_indent)
+          %(#{x})
+          ^^ Use `%Q` instead of `%`.
+        RUBY
       end
 
       it 'auto-corrects' do
@@ -83,9 +86,10 @@ describe RuboCop::Cop::Style::BarePercentLiterals, :config do
 
     context 'and strings are static' do
       it 'registers an offense for %Q()' do
-        inspect_source(cop, '%Q(hi)')
-        expect(cop.messages).to eq(['Use `%` instead of `%Q`.'])
-        expect(cop.highlights).to eq(['%Q('])
+        expect_offense(<<-RUBY.strip_indent)
+          %Q(hi)
+          ^^^ Use `%` instead of `%Q`.
+        RUBY
       end
 
       it 'auto-corrects' do
@@ -102,8 +106,10 @@ describe RuboCop::Cop::Style::BarePercentLiterals, :config do
 
     context 'and strings are dynamic' do
       it 'registers an offense for %Q()' do
-        inspect_source(cop, '%Q(#{x})')
-        expect(cop.messages).to eq(['Use `%` instead of `%Q`.'])
+        expect_offense(<<-'RUBY'.strip_indent)
+          %Q(#{x})
+          ^^^ Use `%` instead of `%Q`.
+        RUBY
       end
 
       it 'auto-corrects' do

--- a/spec/rubocop/cop/style/block_comments_spec.rb
+++ b/spec/rubocop/cop/style/block_comments_spec.rb
@@ -4,12 +4,12 @@ describe RuboCop::Cop::Style::BlockComments do
   subject(:cop) { described_class.new }
 
   it 'registers an offense for block comments' do
-    inspect_source(cop, <<-END.strip_indent)
+    expect_offense(<<-RUBY.strip_indent)
       =begin
+      ^^^^^^ Do not use block comments.
       comment
       =end
-    END
-    expect(cop.offenses.size).to eq(1)
+    RUBY
   end
 
   it 'accepts regular comments' do

--- a/spec/rubocop/cop/style/braces_around_hash_parameters_spec.rb
+++ b/spec/rubocop/cop/style/braces_around_hash_parameters_spec.rb
@@ -186,8 +186,10 @@ describe RuboCop::Cop::Style::BracesAroundHashParameters, :config do
       end
 
       it 'registers an offense for two hash parameters with braces' do
-        inspect_source(cop, 'where({ x: 1 }, { y: 2 })')
-        expect(cop.highlights).to eq(['{ y: 2 }'])
+        expect_offense(<<-RUBY.strip_indent)
+          where({ x: 1 }, { y: 2 })
+                          ^^^^^^^^ Redundant curly braces around a hash parameter.
+        RUBY
       end
     end
 
@@ -274,8 +276,10 @@ describe RuboCop::Cop::Style::BracesAroundHashParameters, :config do
       end
 
       it 'registers an offense for one hash parameter without braces' do
-        inspect_source(cop, 'where(x: "y")')
-        expect(cop.highlights).to eq(['x: "y"'])
+        expect_offense(<<-RUBY.strip_indent)
+          where(x: "y")
+                ^^^^^^ Missing curly braces around a hash parameter.
+        RUBY
       end
 
       it 'registers an offense for one hash parameter with multiple keys and ' \

--- a/spec/rubocop/cop/style/case_equality_spec.rb
+++ b/spec/rubocop/cop/style/case_equality_spec.rb
@@ -4,8 +4,9 @@ describe RuboCop::Cop::Style::CaseEquality do
   subject(:cop) { described_class.new }
 
   it 'registers an offense for ===' do
-    inspect_source(cop, 'Array === var')
-    expect(cop.offenses.size).to eq(1)
-    expect(cop.highlights).to eq(['==='])
+    expect_offense(<<-RUBY.strip_indent)
+      Array === var
+            ^^^ Avoid the use of the case equality operator `===`.
+    RUBY
   end
 end

--- a/spec/rubocop/cop/style/character_literal_spec.rb
+++ b/spec/rubocop/cop/style/character_literal_spec.rb
@@ -4,13 +4,17 @@ describe RuboCop::Cop::Style::CharacterLiteral do
   subject(:cop) { described_class.new }
 
   it 'registers an offense for character literals' do
-    inspect_source(cop, 'x = ?x')
-    expect(cop.offenses.size).to eq(1)
+    expect_offense(<<-RUBY.strip_indent)
+      x = ?x
+          ^^ Do not use the character literal - use string literal instead.
+    RUBY
   end
 
   it 'registers an offense for literals like \n' do
-    inspect_source(cop, 'x = ?\n')
-    expect(cop.offenses.size).to eq(1)
+    expect_offense(<<-'RUBY'.strip_indent)
+      x = ?\n
+          ^^^ Do not use the character literal - use string literal instead.
+    RUBY
   end
 
   it 'accepts literals like ?\C-\M-d' do

--- a/spec/rubocop/cop/style/class_and_module_camel_case_spec.rb
+++ b/spec/rubocop/cop/style/class_and_module_camel_case_spec.rb
@@ -4,25 +4,27 @@ describe RuboCop::Cop::Style::ClassAndModuleCamelCase do
   subject(:cop) { described_class.new }
 
   it 'registers an offense for underscore in class and module name' do
-    inspect_source(cop, <<-END.strip_indent)
+    expect_offense(<<-RUBY.strip_indent)
       class My_Class
+            ^^^^^^^^ Use CamelCase for classes and modules.
       end
 
       module My_Module
+             ^^^^^^^^^ Use CamelCase for classes and modules.
       end
-    END
-    expect(cop.offenses.size).to eq(2)
+    RUBY
   end
 
   it 'is not fooled by qualified names' do
-    inspect_source(cop, <<-END.strip_indent)
+    expect_offense(<<-RUBY.strip_indent)
       class Top::My_Class
+            ^^^^^^^^^^^^^ Use CamelCase for classes and modules.
       end
 
       module My_Module::Ala
+             ^^^^^^^^^^^^^^ Use CamelCase for classes and modules.
       end
-    END
-    expect(cop.offenses.size).to eq(2)
+    RUBY
   end
 
   it 'accepts CamelCase names' do

--- a/spec/rubocop/cop/style/class_and_module_children_spec.rb
+++ b/spec/rubocop/cop/style/class_and_module_children_spec.rb
@@ -7,42 +7,27 @@ describe RuboCop::Cop::Style::ClassAndModuleChildren, :config do
     let(:cop_config) { { 'EnforcedStyle' => 'nested' } }
 
     it 'registers an offense for not nested classes' do
-      inspect_source(cop, <<-END.strip_indent)
+      expect_offense(<<-RUBY.strip_indent)
         class FooClass::BarClass
+              ^^^^^^^^^^^^^^^^^^ Use nested module/class definitions instead of compact style.
         end
-      END
-
-      expect(cop.offenses.size).to eq 1
-      expect(cop.messages).to eq [
-        'Use nested module/class definitions instead of compact style.'
-      ]
-      expect(cop.highlights).to eq ['FooClass::BarClass']
+      RUBY
     end
 
     it 'registers an offense for not nested classes with explicit superclass' do
-      inspect_source(cop, <<-END.strip_indent)
+      expect_offense(<<-RUBY.strip_indent)
         class FooClass::BarClass < Super
+              ^^^^^^^^^^^^^^^^^^ Use nested module/class definitions instead of compact style.
         end
-      END
-
-      expect(cop.offenses.size).to eq 1
-      expect(cop.messages).to eq [
-        'Use nested module/class definitions instead of compact style.'
-      ]
-      expect(cop.highlights).to eq ['FooClass::BarClass']
+      RUBY
     end
 
     it 'registers an offense for not nested modules' do
-      inspect_source(cop, <<-END.strip_indent)
+      expect_offense(<<-RUBY.strip_indent)
         module FooModule::BarModule
+               ^^^^^^^^^^^^^^^^^^^^ Use nested module/class definitions instead of compact style.
         end
-      END
-
-      expect(cop.offenses.size).to eq 1
-      expect(cop.messages).to eq [
-        'Use nested module/class definitions instead of compact style.'
-      ]
-      expect(cop.highlights).to eq ['FooModule::BarModule']
+      RUBY
     end
 
     it 'accepts nested children' do
@@ -76,31 +61,23 @@ describe RuboCop::Cop::Style::ClassAndModuleChildren, :config do
     let(:cop_config) { { 'EnforcedStyle' => 'compact' } }
 
     it 'registers a offense for classes with nested children' do
-      inspect_source(cop, <<-END.strip_indent)
+      expect_offense(<<-RUBY.strip_indent)
         class FooClass
+              ^^^^^^^^ Use compact module/class definition instead of nested style.
           class BarClass
           end
         end
-      END
-      expect(cop.offenses.size).to eq 1
-      expect(cop.messages).to eq [
-        'Use compact module/class definition instead of nested style.'
-      ]
-      expect(cop.highlights).to eq ['FooClass']
+      RUBY
     end
 
     it 'registers a offense for modules with nested children' do
-      inspect_source(cop, <<-END.strip_indent)
+      expect_offense(<<-RUBY.strip_indent)
         module FooModule
+               ^^^^^^^^^ Use compact module/class definition instead of nested style.
           module BarModule
           end
         end
-      END
-      expect(cop.offenses.size).to eq 1
-      expect(cop.messages).to eq [
-        'Use compact module/class definition instead of nested style.'
-      ]
-      expect(cop.highlights).to eq ['FooModule']
+      RUBY
     end
 
     it 'accepts compact style for classes/modules' do

--- a/spec/rubocop/cop/style/class_check_spec.rb
+++ b/spec/rubocop/cop/style/class_check_spec.rb
@@ -7,11 +7,10 @@ describe RuboCop::Cop::Style::ClassCheck, :config do
     let(:cop_config) { { 'EnforcedStyle' => 'is_a?' } }
 
     it 'registers an offense for kind_of?' do
-      inspect_source(cop, 'x.kind_of? y')
-      expect(cop.offenses.size).to eq(1)
-      expect(cop.highlights).to eq(['kind_of?'])
-      expect(cop.messages)
-        .to eq(['Prefer `Object#is_a?` over `Object#kind_of?`.'])
+      expect_offense(<<-RUBY.strip_indent)
+        x.kind_of? y
+          ^^^^^^^^ Prefer `Object#is_a?` over `Object#kind_of?`.
+      RUBY
     end
 
     it 'auto-corrects kind_of? to is_a?' do
@@ -24,11 +23,10 @@ describe RuboCop::Cop::Style::ClassCheck, :config do
     let(:cop_config) { { 'EnforcedStyle' => 'kind_of?' } }
 
     it 'registers an offense for is_a?' do
-      inspect_source(cop, 'x.is_a? y')
-      expect(cop.offenses.size).to eq(1)
-      expect(cop.highlights).to eq(['is_a?'])
-      expect(cop.messages)
-        .to eq(['Prefer `Object#kind_of?` over `Object#is_a?`.'])
+      expect_offense(<<-RUBY.strip_indent)
+        x.is_a? y
+          ^^^^^ Prefer `Object#kind_of?` over `Object#is_a?`.
+      RUBY
     end
 
     it 'auto-corrects is_a? to kind_of?' do

--- a/spec/rubocop/cop/style/class_methods_spec.rb
+++ b/spec/rubocop/cop/style/class_methods_spec.rb
@@ -4,31 +4,25 @@ describe RuboCop::Cop::Style::ClassMethods do
   subject(:cop) { described_class.new }
 
   it 'registers an offense for methods using a class name' do
-    inspect_source(cop, <<-END.strip_indent)
+    expect_offense(<<-RUBY.strip_indent)
       class Test
         def Test.some_method
+            ^^^^ Use `self.some_method` instead of `Test.some_method`.
           do_something
         end
       end
-    END
-    expect(cop.offenses.size).to eq(1)
-    expect(cop.messages)
-      .to eq(['Use `self.some_method` instead of `Test.some_method`.'])
-    expect(cop.highlights).to eq(['Test'])
+    RUBY
   end
 
   it 'registers an offense for methods using a module name' do
-    inspect_source(cop, <<-END.strip_indent)
+    expect_offense(<<-RUBY.strip_indent)
       module Test
         def Test.some_method
+            ^^^^ Use `self.some_method` instead of `Test.some_method`.
           do_something
         end
       end
-    END
-    expect(cop.offenses.size).to eq(1)
-    expect(cop.messages)
-      .to eq(['Use `self.some_method` instead of `Test.some_method`.'])
-    expect(cop.highlights).to eq(['Test'])
+    RUBY
   end
 
   it 'does not register an offense for methods using self' do

--- a/spec/rubocop/cop/style/class_vars_spec.rb
+++ b/spec/rubocop/cop/style/class_vars_spec.rb
@@ -4,10 +4,10 @@ describe RuboCop::Cop::Style::ClassVars do
   subject(:cop) { described_class.new }
 
   it 'registers an offense for class variable declaration' do
-    inspect_source(cop, 'class TestClass; @@test = 10; end')
-    expect(cop.offenses.size).to eq(1)
-    expect(cop.messages)
-      .to eq(['Replace class var @@test with a class instance var.'])
+    expect_offense(<<-RUBY.strip_indent)
+      class TestClass; @@test = 10; end
+                       ^^^^^^ Replace class var @@test with a class instance var.
+    RUBY
   end
 
   it 'does not register an offense for class variable usage' do

--- a/spec/rubocop/cop/style/colon_method_call_spec.rb
+++ b/spec/rubocop/cop/style/colon_method_call_spec.rb
@@ -4,23 +4,31 @@ describe RuboCop::Cop::Style::ColonMethodCall do
   subject(:cop) { described_class.new }
 
   it 'registers an offense for instance method call' do
-    inspect_source(cop, 'test::method_name')
-    expect(cop.offenses.size).to eq(1)
+    expect_offense(<<-RUBY.strip_indent)
+      test::method_name
+          ^^ Do not use `::` for method calls.
+    RUBY
   end
 
   it 'registers an offense for instance method call with arg' do
-    inspect_source(cop, 'test::method_name(arg)')
-    expect(cop.offenses.size).to eq(1)
+    expect_offense(<<-RUBY.strip_indent)
+      test::method_name(arg)
+          ^^ Do not use `::` for method calls.
+    RUBY
   end
 
   it 'registers an offense for class method call' do
-    inspect_source(cop, 'Class::method_name')
-    expect(cop.offenses.size).to eq(1)
+    expect_offense(<<-RUBY.strip_indent)
+      Class::method_name
+           ^^ Do not use `::` for method calls.
+    RUBY
   end
 
   it 'registers an offense for class method call with arg' do
-    inspect_source(cop, 'Class::method_name(arg, arg2)')
-    expect(cop.offenses.size).to eq(1)
+    expect_offense(<<-RUBY.strip_indent)
+      Class::method_name(arg, arg2)
+           ^^ Do not use `::` for method calls.
+    RUBY
   end
 
   it 'does not register an offense for constant access' do

--- a/spec/rubocop/cop/style/command_literal_spec.rb
+++ b/spec/rubocop/cop/style/command_literal_spec.rb
@@ -65,8 +65,10 @@ describe RuboCop::Cop::Style::CommandLiteral, :config do
       let(:source) { 'foo = `echo \`ls\``' }
 
       it 'registers an offense' do
-        inspect_source(cop, source)
-        expect(cop.messages).to eq(['Use `%x` around command string.'])
+        expect_offense(<<-'RUBY'.strip_indent)
+          foo = `echo \`ls\``
+                ^^^^^^^^^^^^^ Use `%x` around command string.
+        RUBY
       end
 
       it 'cannot auto-correct' do
@@ -107,8 +109,13 @@ describe RuboCop::Cop::Style::CommandLiteral, :config do
       end
 
       it 'registers an offense' do
-        inspect_source(cop, source)
-        expect(cop.messages).to eq(['Use `%x` around command string.'])
+        expect_offense(<<-'RUBY'.strip_indent)
+          foo = `
+                ^ Use `%x` around command string.
+            echo \`ls\`
+            echo \`ls -l\`
+          `
+        RUBY
       end
 
       it 'cannot auto-correct' do
@@ -130,8 +137,10 @@ describe RuboCop::Cop::Style::CommandLiteral, :config do
       let(:source) { 'foo = %x(ls)' }
 
       it 'registers an offense' do
-        inspect_source(cop, source)
-        expect(cop.messages).to eq(['Use backticks around command string.'])
+        expect_offense(<<-RUBY.strip_indent)
+          foo = %x(ls)
+                ^^^^^^ Use backticks around command string.
+        RUBY
       end
 
       it 'auto-corrects' do
@@ -152,8 +161,10 @@ describe RuboCop::Cop::Style::CommandLiteral, :config do
         before { cop_config['AllowInnerBackticks'] = true }
 
         it 'registers an offense' do
-          inspect_source(cop, source)
-          expect(cop.messages).to eq(['Use backticks around command string.'])
+          expect_offense(<<-RUBY.strip_indent)
+            foo = %x(echo `ls`)
+                  ^^^^^^^^^^^^^ Use backticks around command string.
+          RUBY
         end
 
         it 'cannot auto-correct' do
@@ -172,8 +183,13 @@ describe RuboCop::Cop::Style::CommandLiteral, :config do
       end
 
       it 'registers an offense' do
-        inspect_source(cop, source)
-        expect(cop.messages).to eq(['Use backticks around command string.'])
+        expect_offense(<<-RUBY.strip_indent)
+          foo = %x(
+                ^^^ Use backticks around command string.
+            ls
+            ls -l
+          )
+        RUBY
       end
 
       it 'auto-corrects' do
@@ -199,8 +215,13 @@ describe RuboCop::Cop::Style::CommandLiteral, :config do
         before { cop_config['AllowInnerBackticks'] = true }
 
         it 'registers an offense' do
-          inspect_source(cop, source)
-          expect(cop.messages).to eq(['Use backticks around command string.'])
+          expect_offense(<<-RUBY.strip_indent)
+            foo = %x(
+                  ^^^ Use backticks around command string.
+              echo `ls`
+              echo `ls -l`
+            )
+          RUBY
         end
 
         it 'cannot auto-correct' do
@@ -218,8 +239,10 @@ describe RuboCop::Cop::Style::CommandLiteral, :config do
       let(:source) { 'foo = `ls`' }
 
       it 'registers an offense' do
-        inspect_source(cop, source)
-        expect(cop.messages).to eq(['Use `%x` around command string.'])
+        expect_offense(<<-RUBY.strip_indent)
+          foo = `ls`
+                ^^^^ Use `%x` around command string.
+        RUBY
       end
 
       it 'auto-corrects' do
@@ -232,8 +255,10 @@ describe RuboCop::Cop::Style::CommandLiteral, :config do
       let(:source) { 'foo = `echo \`ls\``' }
 
       it 'registers an offense' do
-        inspect_source(cop, source)
-        expect(cop.messages).to eq(['Use `%x` around command string.'])
+        expect_offense(<<-'RUBY'.strip_indent)
+          foo = `echo \`ls\``
+                ^^^^^^^^^^^^^ Use `%x` around command string.
+        RUBY
       end
 
       it 'cannot auto-correct' do
@@ -251,8 +276,13 @@ describe RuboCop::Cop::Style::CommandLiteral, :config do
       end
 
       it 'registers an offense' do
-        inspect_source(cop, source)
-        expect(cop.messages).to eq(['Use `%x` around command string.'])
+        expect_offense(<<-'RUBY'.strip_indent)
+          foo = `
+                ^ Use `%x` around command string.
+            ls
+            ls -l
+          `
+        RUBY
       end
 
       it 'auto-corrects' do
@@ -270,8 +300,13 @@ describe RuboCop::Cop::Style::CommandLiteral, :config do
       end
 
       it 'registers an offense' do
-        inspect_source(cop, source)
-        expect(cop.messages).to eq(['Use `%x` around command string.'])
+        expect_offense(<<-'RUBY'.strip_indent)
+          foo = `
+                ^ Use `%x` around command string.
+            echo \`ls\`
+            echo \`ls -l\`
+          `
+        RUBY
       end
 
       it 'cannot auto-correct' do
@@ -343,8 +378,10 @@ describe RuboCop::Cop::Style::CommandLiteral, :config do
       let(:source) { 'foo = `echo \`ls\``' }
 
       it 'registers an offense' do
-        inspect_source(cop, source)
-        expect(cop.messages).to eq(['Use `%x` around command string.'])
+        expect_offense(<<-'RUBY'.strip_indent)
+          foo = `echo \`ls\``
+                ^^^^^^^^^^^^^ Use `%x` around command string.
+        RUBY
       end
 
       it 'cannot auto-correct' do
@@ -371,8 +408,13 @@ describe RuboCop::Cop::Style::CommandLiteral, :config do
       end
 
       it 'registers an offense' do
-        inspect_source(cop, source)
-        expect(cop.messages).to eq(['Use `%x` around command string.'])
+        expect_offense(<<-RUBY.strip_indent)
+          foo = `
+                ^ Use `%x` around command string.
+            ls
+            ls -l
+          `
+        RUBY
       end
 
       it 'auto-corrects' do
@@ -390,8 +432,13 @@ describe RuboCop::Cop::Style::CommandLiteral, :config do
       end
 
       it 'registers an offense' do
-        inspect_source(cop, source)
-        expect(cop.messages).to eq(['Use `%x` around command string.'])
+        expect_offense(<<-'RUBY'.strip_indent)
+          foo = `
+                ^ Use `%x` around command string.
+            echo \`ls\`
+            echo \`ls -l\`
+          `
+        RUBY
       end
 
       it 'cannot auto-correct' do
@@ -404,8 +451,10 @@ describe RuboCop::Cop::Style::CommandLiteral, :config do
       let(:source) { 'foo = %x(ls)' }
 
       it 'registers an offense' do
-        inspect_source(cop, source)
-        expect(cop.messages).to eq(['Use backticks around command string.'])
+        expect_offense(<<-RUBY.strip_indent)
+          foo = %x(ls)
+                ^^^^^^ Use backticks around command string.
+        RUBY
       end
 
       it 'auto-corrects' do
@@ -426,8 +475,10 @@ describe RuboCop::Cop::Style::CommandLiteral, :config do
         before { cop_config['AllowInnerBackticks'] = true }
 
         it 'registers an offense' do
-          inspect_source(cop, source)
-          expect(cop.messages).to eq(['Use backticks around command string.'])
+          expect_offense(<<-RUBY.strip_indent)
+            foo = %x(echo `ls`)
+                  ^^^^^^^^^^^^^ Use backticks around command string.
+          RUBY
         end
 
         it 'cannot auto-correct' do

--- a/spec/rubocop/cop/style/comment_annotation_spec.rb
+++ b/spec/rubocop/cop/style/comment_annotation_spec.rb
@@ -8,9 +8,10 @@ describe RuboCop::Cop::Style::CommentAnnotation, :config do
 
   context 'missing colon' do
     it 'registers an offense' do
-      inspect_source(cop, '# TODO make better')
-      expect(cop.messages).to eq([format(described_class::MSG, 'TODO')])
-      expect(cop.highlights).to eq(['TODO '])
+      expect_offense(<<-RUBY.strip_indent)
+        # TODO make better
+          ^^^^^ Annotation keywords like `TODO` should be all upper case, followed by a colon, and a space, then a note describing the problem.
+      RUBY
     end
 
     it 'autocorrects' do
@@ -23,9 +24,10 @@ describe RuboCop::Cop::Style::CommentAnnotation, :config do
     let(:cop_config) { { 'Keywords' => %w[ISSUE] } }
 
     it 'registers an offense for a missing colon after the word' do
-      inspect_source(cop, '# ISSUE wrong order')
-      expect(cop.messages).to eq([format(described_class::MSG, 'ISSUE')])
-      expect(cop.highlights).to eq(['ISSUE '])
+      expect_offense(<<-RUBY.strip_indent)
+        # ISSUE wrong order
+          ^^^^^^ Annotation keywords like `ISSUE` should be all upper case, followed by a colon, and a space, then a note describing the problem.
+      RUBY
     end
 
     it 'autocorrects a missing colon after keyword' do
@@ -36,9 +38,10 @@ describe RuboCop::Cop::Style::CommentAnnotation, :config do
 
   context 'missing space after colon' do
     it 'registers an offense' do
-      inspect_source(cop, '# TODO:make better')
-      expect(cop.messages).to eq([format(described_class::MSG, 'TODO')])
-      expect(cop.highlights).to eq(['TODO:'])
+      expect_offense(<<-RUBY.strip_indent)
+        # TODO:make better
+          ^^^^^ Annotation keywords like `TODO` should be all upper case, followed by a colon, and a space, then a note describing the problem.
+      RUBY
     end
 
     it 'autocorrects' do
@@ -49,9 +52,10 @@ describe RuboCop::Cop::Style::CommentAnnotation, :config do
 
   context 'lower case keyword' do
     it 'registers an offense' do
-      inspect_source(cop, '# fixme: does not work')
-      expect(cop.messages).to eq([format(described_class::MSG, 'fixme')])
-      expect(cop.highlights).to eq(['fixme: '])
+      expect_offense(<<-RUBY.strip_indent)
+        # fixme: does not work
+          ^^^^^^^ Annotation keywords like `fixme` should be all upper case, followed by a colon, and a space, then a note describing the problem.
+      RUBY
     end
 
     it 'autocorrects' do
@@ -62,9 +66,10 @@ describe RuboCop::Cop::Style::CommentAnnotation, :config do
 
   context 'capitalized keyword' do
     it 'registers an offense' do
-      inspect_source(cop, '# Optimize: does not work')
-      expect(cop.messages).to eq([format(described_class::MSG, 'Optimize')])
-      expect(cop.highlights).to eq(['Optimize: '])
+      expect_offense(<<-RUBY.strip_indent)
+        # Optimize: does not work
+          ^^^^^^^^^^ Annotation keywords like `Optimize` should be all upper case, followed by a colon, and a space, then a note describing the problem.
+      RUBY
     end
 
     it 'autocorrects' do
@@ -75,10 +80,10 @@ describe RuboCop::Cop::Style::CommentAnnotation, :config do
 
   context 'upper case keyword with colon by no note' do
     it 'registers an offense' do
-      inspect_source(cop, '# HACK:')
-      expect(cop.messages)
-        .to eq(['Annotation comment, with keyword `HACK`, is missing a note.'])
-      expect(cop.highlights).to eq(['HACK:'])
+      expect_offense(<<-RUBY.strip_indent)
+        # HACK:
+          ^^^^^ Annotation comment, with keyword `HACK`, is missing a note.
+      RUBY
     end
 
     it 'does not autocorrects' do

--- a/spec/rubocop/cop/style/constant_name_spec.rb
+++ b/spec/rubocop/cop/style/constant_name_spec.rb
@@ -4,21 +4,25 @@ describe RuboCop::Cop::Style::ConstantName do
   subject(:cop) { described_class.new }
 
   it 'registers an offense for camel case in const name' do
-    inspect_source(cop,
-                   'TopCase = 5')
-    expect(cop.offenses.size).to eq(1)
+    expect_offense(<<-RUBY.strip_indent)
+      TopCase = 5
+      ^^^^^^^ Use SCREAMING_SNAKE_CASE for constants.
+    RUBY
   end
 
   it 'registers offenses for camel case in multiple const assignment' do
-    inspect_source(cop,
-                   'TopCase, Test2, TEST_3 = 5, 6, 7')
-    expect(cop.offenses.size).to eq(2)
+    expect_offense(<<-RUBY.strip_indent)
+      TopCase, Test2, TEST_3 = 5, 6, 7
+      ^^^^^^^ Use SCREAMING_SNAKE_CASE for constants.
+               ^^^^^ Use SCREAMING_SNAKE_CASE for constants.
+    RUBY
   end
 
   it 'registers an offense for snake case in const name' do
-    inspect_source(cop,
-                   'TOP_test = 5')
-    expect(cop.offenses.size).to eq(1)
+    expect_offense(<<-RUBY.strip_indent)
+      TOP_test = 5
+      ^^^^^^^^ Use SCREAMING_SNAKE_CASE for constants.
+    RUBY
   end
 
   it 'allows screaming snake case in const name' do
@@ -46,10 +50,11 @@ describe RuboCop::Cop::Style::ConstantName do
   end
 
   it 'checks qualified const names' do
-    inspect_source(cop, <<-END.strip_indent)
+    expect_offense(<<-RUBY.strip_indent)
       ::AnythingGoes = 30
+        ^^^^^^^^^^^^ Use SCREAMING_SNAKE_CASE for constants.
       a::Bar_foo = 10
-    END
-    expect(cop.offenses.size).to eq(2)
+         ^^^^^^^ Use SCREAMING_SNAKE_CASE for constants.
+    RUBY
   end
 end

--- a/spec/rubocop/cop/style/documentation_spec.rb
+++ b/spec/rubocop/cop/style/documentation_spec.rb
@@ -9,13 +9,13 @@ describe RuboCop::Cop::Style::Documentation do
   end
 
   it 'registers an offense for non-empty class' do
-    inspect_source(cop, <<-END.strip_indent)
+    expect_offense(<<-RUBY.strip_indent)
       class My_Class
+      ^^^^^ Missing top-level class documentation comment.
         def method
         end
       end
-    END
-    expect(cop.offenses.size).to eq(1)
+    RUBY
   end
 
   it 'does not consider comment followed by empty line to be class ' \
@@ -33,23 +33,23 @@ describe RuboCop::Cop::Style::Documentation do
   end
 
   it 'registers an offense for non-namespace' do
-    inspect_source(cop, <<-END.strip_indent)
+    expect_offense(<<-RUBY.strip_indent)
       module My_Class
+      ^^^^^^ Missing top-level module documentation comment.
         def method
         end
       end
-    END
-    expect(cop.offenses.size).to eq(1)
+    RUBY
   end
 
   it 'registers an offense for empty module without documentation' do
     # Because why would you have an empty module? It requires some
     # explanation.
-    inspect_source(cop, <<-END.strip_indent)
+    expect_offense(<<-RUBY.strip_indent)
       module Test
+      ^^^^^^ Missing top-level module documentation comment.
       end
-    END
-    expect(cop.offenses.size).to eq(1)
+    RUBY
   end
 
   it 'accepts non-empty class with documentation' do
@@ -63,47 +63,47 @@ describe RuboCop::Cop::Style::Documentation do
   end
 
   it 'registers an offense for non-empty class with annotation comment' do
-    inspect_source(cop, <<-END.strip_indent)
+    expect_offense(<<-RUBY.strip_indent)
       # OPTIMIZE: Make this faster.
       class My_Class
+      ^^^^^ Missing top-level class documentation comment.
         def method
         end
       end
-    END
-    expect(cop.offenses.size).to eq(1)
+    RUBY
   end
 
   it 'registers an offense for non-empty class with directive comment' do
-    inspect_source(cop, <<-END.strip_indent)
+    expect_offense(<<-RUBY.strip_indent)
       # rubocop:disable Style/For
       class My_Class
+      ^^^^^ Missing top-level class documentation comment.
         def method
         end
       end
-    END
-    expect(cop.offenses.size).to eq(1)
+    RUBY
   end
 
   it 'registers offense for non-empty class with frozen string comment' do
-    inspect_source(cop, <<-END.strip_indent)
+    expect_offense(<<-RUBY.strip_indent)
       # frozen_string_literal: true
       class My_Class
+      ^^^^^ Missing top-level class documentation comment.
         def method
         end
       end
-    END
-    expect(cop.offenses.size).to eq(1)
+    RUBY
   end
 
   it 'registers an offense for non-empty class with encoding comment' do
-    inspect_source(cop, <<-END.strip_indent)
+    expect_offense(<<-RUBY.strip_indent)
       # encoding: ascii-8bit
       class My_Class
+      ^^^^^ Missing top-level class documentation comment.
         def method
         end
       end
-    END
-    expect(cop.offenses.size).to eq(1)
+    RUBY
   end
 
   it 'accepts non-empty class with annotation comment followed by other ' \
@@ -199,16 +199,16 @@ describe RuboCop::Cop::Style::Documentation do
   end
 
   it 'registers an offense if the comment line contains code' do
-    inspect_source(cop, <<-END.strip_indent)
+    expect_offense(<<-RUBY.strip_indent)
       module A # The A Module
         class B
+        ^^^^^ Missing top-level class documentation comment.
           C = 1
           def method
           end
         end
       end
-    END
-    expect(cop.offenses.size).to eq 1
+    RUBY
   end
 
   context 'sparse and trailing comments' do
@@ -294,16 +294,16 @@ describe RuboCop::Cop::Style::Documentation do
       end
 
       it 'registers an offense for nested subclass without documentation' do
-        inspect_source(cop, <<-END.strip_indent)
+        expect_offense(<<-RUBY.strip_indent)
           module TestModule #:nodoc:
             TEST = 20
             class Test < Parent
+            ^^^^^ Missing top-level class documentation comment.
               def method
               end
             end
           end
-        END
-        expect(cop.offenses.size).to eq(1)
+        RUBY
       end
 
       context 'with `all` modifier' do

--- a/spec/rubocop/cop/style/double_negation_spec.rb
+++ b/spec/rubocop/cop/style/double_negation_spec.rb
@@ -4,8 +4,10 @@ describe RuboCop::Cop::Style::DoubleNegation do
   subject(:cop) { described_class.new }
 
   it 'registers an offense for !!' do
-    inspect_source(cop, '!!test.something')
-    expect(cop.offenses.size).to eq(1)
+    expect_offense(<<-RUBY.strip_indent)
+      !!test.something
+      ^ Avoid the use of double negation (`!!`).
+    RUBY
   end
 
   it 'does not register an offense for !' do

--- a/spec/rubocop/cop/style/each_for_simple_loop_spec.rb
+++ b/spec/rubocop/cop/style/each_for_simple_loop_spec.rb
@@ -7,37 +7,33 @@ describe RuboCop::Cop::Style::EachForSimpleLoop do
                 'which iterates a fixed number of times.'.freeze
 
   it 'registers offense for inclusive end range' do
-    inspect_source(cop, '(0..10).each {}')
-    expect(cop.offenses.size).to eq 1
-    expect(cop.messages).to eq([OFFENSE_MSG])
-    expect(cop.highlights).to eq(['(0..10).each'])
+    expect_offense(<<-RUBY.strip_indent)
+      (0..10).each {}
+      ^^^^^^^^^^^^ Use `Integer#times` for a simple loop which iterates a fixed number of times.
+    RUBY
   end
 
   it 'registers offense for exclusive end range' do
-    inspect_source(cop, '(0...10).each {}')
-    expect(cop.offenses.size).to eq 1
-    expect(cop.messages).to eq([OFFENSE_MSG])
-    expect(cop.highlights).to eq(['(0...10).each'])
+    expect_offense(<<-RUBY.strip_indent)
+      (0...10).each {}
+      ^^^^^^^^^^^^^ Use `Integer#times` for a simple loop which iterates a fixed number of times.
+    RUBY
   end
 
   it 'registers offense for exclusive end range with do ... end syntax' do
-    inspect_source(cop, <<-END.strip_indent)
+    expect_offense(<<-RUBY.strip_indent)
       (0...10).each do
+      ^^^^^^^^^^^^^ Use `Integer#times` for a simple loop which iterates a fixed number of times.
       end
-    END
-    expect(cop.offenses.size).to eq 1
-    expect(cop.messages).to eq([OFFENSE_MSG])
-    expect(cop.highlights).to eq(['(0...10).each'])
+    RUBY
   end
 
   it 'registers an offense for range not starting with zero' do
-    inspect_source(cop, <<-END.strip_indent)
+    expect_offense(<<-RUBY.strip_indent)
       (3..7).each do
+      ^^^^^^^^^^^ Use `Integer#times` for a simple loop which iterates a fixed number of times.
       end
-    END
-    expect(cop.offenses.size).to eq 1
-    expect(cop.messages).to eq([OFFENSE_MSG])
-    expect(cop.highlights).to eq(['(3..7).each'])
+    RUBY
   end
 
   it 'does not register offense if range startpoint is not constant' do

--- a/spec/rubocop/cop/style/each_with_object_spec.rb
+++ b/spec/rubocop/cop/style/each_with_object_spec.rb
@@ -4,21 +4,17 @@ describe RuboCop::Cop::Style::EachWithObject do
   subject(:cop) { described_class.new }
 
   it 'finds inject and reduce with passed in and returned hash' do
-    inspect_source(cop, <<-END.strip_indent)
+    expect_offense(<<-RUBY.strip_indent)
       [].inject({}) { |a, e| a }
+         ^^^^^^ Use `each_with_object` instead of `inject`.
 
       [].reduce({}) do |a, e|
+         ^^^^^^ Use `each_with_object` instead of `reduce`.
         a[e] = 1
         a[e] = 1
         a
       end
-    END
-    expect(cop.offenses.size).to eq(2)
-    expect(cop.offenses.map(&:line).sort).to eq([1, 3])
-    expect(cop.messages)
-      .to eq(['Use `each_with_object` instead of `inject`.',
-              'Use `each_with_object` instead of `reduce`.'])
-    expect(cop.highlights).to eq(%w[inject reduce])
+    RUBY
   end
 
   it 'correctly autocorrects' do

--- a/spec/rubocop/cop/style/empty_literal_spec.rb
+++ b/spec/rubocop/cop/style/empty_literal_spec.rb
@@ -5,17 +5,17 @@ describe RuboCop::Cop::Style::EmptyLiteral do
 
   describe 'Empty Array' do
     it 'registers an offense for Array.new()' do
-      inspect_source(cop, 'test = Array.new()')
-      expect(cop.offenses.size).to eq(1)
-      expect(cop.messages)
-        .to eq(['Use array literal `[]` instead of `Array.new`.'])
+      expect_offense(<<-RUBY.strip_indent)
+        test = Array.new()
+               ^^^^^^^^^^^ Use array literal `[]` instead of `Array.new`.
+      RUBY
     end
 
     it 'registers an offense for Array.new' do
-      inspect_source(cop, 'test = Array.new')
-      expect(cop.offenses.size).to eq(1)
-      expect(cop.messages)
-        .to eq(['Use array literal `[]` instead of `Array.new`.'])
+      expect_offense(<<-RUBY.strip_indent)
+        test = Array.new
+               ^^^^^^^^^ Use array literal `[]` instead of `Array.new`.
+      RUBY
     end
 
     it 'does not register an offense for Array.new(3)' do
@@ -48,17 +48,17 @@ describe RuboCop::Cop::Style::EmptyLiteral do
 
   describe 'Empty Hash' do
     it 'registers an offense for Hash.new()' do
-      inspect_source(cop, 'test = Hash.new()')
-      expect(cop.offenses.size).to eq(1)
-      expect(cop.messages)
-        .to eq(['Use hash literal `{}` instead of `Hash.new`.'])
+      expect_offense(<<-RUBY.strip_indent)
+        test = Hash.new()
+               ^^^^^^^^^^ Use hash literal `{}` instead of `Hash.new`.
+      RUBY
     end
 
     it 'registers an offense for Hash.new' do
-      inspect_source(cop, 'test = Hash.new')
-      expect(cop.offenses.size).to eq(1)
-      expect(cop.messages)
-        .to eq(['Use hash literal `{}` instead of `Hash.new`.'])
+      expect_offense(<<-RUBY.strip_indent)
+        test = Hash.new
+               ^^^^^^^^ Use hash literal `{}` instead of `Hash.new`.
+      RUBY
     end
 
     it 'does not register an offense for Hash.new(3)' do
@@ -110,19 +110,17 @@ describe RuboCop::Cop::Style::EmptyLiteral do
 
   describe 'Empty String' do
     it 'registers an offense for String.new()' do
-      inspect_source(cop, 'test = String.new()')
-
-      expect(cop.offenses.size).to eq(1)
-      expect(cop.messages)
-        .to eq(["Use string literal `''` instead of `String.new`."])
+      expect_offense(<<-RUBY.strip_indent)
+        test = String.new()
+               ^^^^^^^^^^^^ Use string literal `''` instead of `String.new`.
+      RUBY
     end
 
     it 'registers an offense for String.new' do
-      inspect_source(cop, 'test = String.new')
-
-      expect(cop.offenses.size).to eq(1)
-      expect(cop.messages)
-        .to eq(["Use string literal `''` instead of `String.new`."])
+      expect_offense(<<-RUBY.strip_indent)
+        test = String.new
+               ^^^^^^^^^^ Use string literal `''` instead of `String.new`.
+      RUBY
     end
 
     it 'does not register an offense for String.new("top")' do
@@ -146,11 +144,10 @@ describe RuboCop::Cop::Style::EmptyLiteral do
       subject(:cop) { described_class.new(config) }
 
       it 'registers an offense for String.new' do
-        inspect_source(cop, 'test = String.new')
-
-        expect(cop.offenses.size).to eq(1)
-        expect(cop.messages)
-          .to eq(['Use string literal `""` instead of `String.new`.'])
+        expect_offense(<<-RUBY.strip_indent)
+          test = String.new
+                 ^^^^^^^^^^ Use string literal `""` instead of `String.new`.
+        RUBY
       end
 
       it 'auto-corrects String.new to a double-quoted empty string literal' do

--- a/spec/rubocop/cop/style/encoding_spec.rb
+++ b/spec/rubocop/cop/style/encoding_spec.rb
@@ -60,15 +60,11 @@ describe RuboCop::Cop::Style::Encoding, :config do
     end
 
     it 'registers an offense when encoding is in the wrong place' do
-      inspect_source(cop, <<-END.strip_indent)
-        def foo() \'ä\' end
+      expect_offense(<<-RUBY.strip_indent)
+        def foo() 'ä' end
+        ^^^^^^^^^^^^^^^^^ Missing utf-8 encoding comment.
         # encoding: utf-8
-      END
-
-      expect(cop.offenses.size).to eq(1)
-      expect(cop.messages).to eq(
-        ['Missing utf-8 encoding comment.']
-      )
+      RUBY
     end
 
     it 'accepts encoding inserted by magic_encoding gem' do
@@ -120,12 +116,10 @@ describe RuboCop::Cop::Style::Encoding, :config do
     end
 
     it 'registers an offense when no encoding present' do
-      inspect_source(cop, 'def foo() end')
-
-      expect(cop.offenses.size).to eq(1)
-      expect(cop.messages).to eq(
-        ['Missing utf-8 encoding comment.']
-      )
+      expect_offense(<<-RUBY.strip_indent)
+        def foo() end
+        ^^^^^^^^^^^^^ Missing utf-8 encoding comment.
+      RUBY
     end
 
     it 'accepts an empty file' do
@@ -150,15 +144,11 @@ describe RuboCop::Cop::Style::Encoding, :config do
     end
 
     it 'books an offense when encoding is in the wrong place' do
-      inspect_source(cop, <<-END.strip_indent)
+      expect_offense(<<-RUBY.strip_indent)
         def foo() end
+        ^^^^^^^^^^^^^ Missing utf-8 encoding comment.
         # encoding: utf-8
-      END
-
-      expect(cop.offenses.size).to eq(1)
-      expect(cop.messages).to eq(
-        ['Missing utf-8 encoding comment.']
-      )
+      RUBY
     end
 
     it 'accepts encoding inserted by magic_encoding gem' do

--- a/spec/rubocop/cop/style/even_odd_spec.rb
+++ b/spec/rubocop/cop/style/even_odd_spec.rb
@@ -4,63 +4,73 @@ describe RuboCop::Cop::Style::EvenOdd do
   subject(:cop) { described_class.new }
 
   it 'registers an offense for x % 2 == 0' do
-    inspect_source(cop, 'x % 2 == 0')
-    expect(cop.offenses.size).to eq(1)
-    expect(cop.messages).to eq(['Replace with `Integer#even?`.'])
+    expect_offense(<<-RUBY.strip_indent)
+      x % 2 == 0
+      ^^^^^^^^^^ Replace with `Integer#even?`.
+    RUBY
   end
 
   it 'registers an offense for x % 2 != 0' do
-    inspect_source(cop, 'x % 2 != 0')
-    expect(cop.offenses.size).to eq(1)
-    expect(cop.messages).to eq(['Replace with `Integer#odd?`.'])
+    expect_offense(<<-RUBY.strip_indent)
+      x % 2 != 0
+      ^^^^^^^^^^ Replace with `Integer#odd?`.
+    RUBY
   end
 
   it 'registers an offense for (x % 2) == 0' do
-    inspect_source(cop, '(x % 2) == 0')
-    expect(cop.offenses.size).to eq(1)
-    expect(cop.messages).to eq(['Replace with `Integer#even?`.'])
+    expect_offense(<<-RUBY.strip_indent)
+      (x % 2) == 0
+      ^^^^^^^^^^^^ Replace with `Integer#even?`.
+    RUBY
   end
 
   it 'registers an offense for (x % 2) != 0' do
-    inspect_source(cop, '(x % 2) != 0')
-    expect(cop.offenses.size).to eq(1)
-    expect(cop.messages).to eq(['Replace with `Integer#odd?`.'])
+    expect_offense(<<-RUBY.strip_indent)
+      (x % 2) != 0
+      ^^^^^^^^^^^^ Replace with `Integer#odd?`.
+    RUBY
   end
 
   it 'registers an offense for x % 2 == 1' do
-    inspect_source(cop, 'x % 2 == 1')
-    expect(cop.offenses.size).to eq(1)
-    expect(cop.messages).to eq(['Replace with `Integer#odd?`.'])
+    expect_offense(<<-RUBY.strip_indent)
+      x % 2 == 1
+      ^^^^^^^^^^ Replace with `Integer#odd?`.
+    RUBY
   end
 
   it 'registers an offense for x % 2 != 1' do
-    inspect_source(cop, 'x % 2 != 1')
-    expect(cop.offenses.size).to eq(1)
-    expect(cop.messages).to eq(['Replace with `Integer#even?`.'])
+    expect_offense(<<-RUBY.strip_indent)
+      x % 2 != 1
+      ^^^^^^^^^^ Replace with `Integer#even?`.
+    RUBY
   end
 
   it 'registers an offense for (x % 2) == 1' do
-    inspect_source(cop, '(x % 2) == 1')
-    expect(cop.offenses.size).to eq(1)
-    expect(cop.messages).to eq(['Replace with `Integer#odd?`.'])
+    expect_offense(<<-RUBY.strip_indent)
+      (x % 2) == 1
+      ^^^^^^^^^^^^ Replace with `Integer#odd?`.
+    RUBY
   end
 
   it 'registers an offense for (x % 2) != 1' do
-    inspect_source(cop, '(x % 2) != 1')
-    expect(cop.offenses.size).to eq(1)
-    expect(cop.messages).to eq(['Replace with `Integer#even?`.'])
+    expect_offense(<<-RUBY.strip_indent)
+      (x % 2) != 1
+      ^^^^^^^^^^^^ Replace with `Integer#even?`.
+    RUBY
   end
 
   it 'registers an offense for (x.y % 2) != 1' do
-    inspect_source(cop, '(x.y % 2) != 1')
-    expect(cop.offenses.size).to eq(1)
-    expect(cop.messages).to eq(['Replace with `Integer#even?`.'])
+    expect_offense(<<-RUBY.strip_indent)
+      (x.y % 2) != 1
+      ^^^^^^^^^^^^^^ Replace with `Integer#even?`.
+    RUBY
   end
 
   it 'registers an offense for (x(y) % 2) != 1' do
-    inspect_source(cop, '(x(y) % 2) != 1')
-    expect(cop.offenses.size).to eq(1)
-    expect(cop.messages).to eq(['Replace with `Integer#even?`.'])
+    expect_offense(<<-RUBY.strip_indent)
+      (x(y) % 2) != 1
+      ^^^^^^^^^^^^^^^ Replace with `Integer#even?`.
+    RUBY
   end
 
   it 'accepts x % 3 == 0' do

--- a/spec/rubocop/cop/style/flip_flop_spec.rb
+++ b/spec/rubocop/cop/style/flip_flop_spec.rb
@@ -4,20 +4,20 @@ describe RuboCop::Cop::Style::FlipFlop do
   subject(:cop) { described_class.new }
 
   it 'registers an offense for inclusive flip flops' do
-    inspect_source(cop, <<-END.strip_indent)
+    expect_offense(<<-RUBY.strip_indent)
       DATA.each_line do |line|
       print line if (line =~ /begin/)..(line =~ /end/)
+                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Avoid the use of flip flop operators.
       end
-    END
-    expect(cop.offenses.size).to eq(1)
+    RUBY
   end
 
   it 'registers an offense for exclusive flip flops' do
-    inspect_source(cop, <<-END.strip_indent)
+    expect_offense(<<-RUBY.strip_indent)
       DATA.each_line do |line|
       print line if (line =~ /begin/)...(line =~ /end/)
+                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Avoid the use of flip flop operators.
       end
-    END
-    expect(cop.offenses.size).to eq(1)
+    RUBY
   end
 end

--- a/spec/rubocop/cop/style/format_string_spec.rb
+++ b/spec/rubocop/cop/style/format_string_spec.rb
@@ -6,19 +6,17 @@ describe RuboCop::Cop::Style::FormatString, :config do
   context 'when enforced style is sprintf' do
     let(:cop_config) { { 'EnforcedStyle' => 'sprintf' } }
     it 'registers an offense for a string followed by something' do
-      inspect_source(cop,
-                     'puts "%d" % 10')
-      expect(cop.offenses.size).to eq(1)
-      expect(cop.messages)
-        .to eq(['Favor `sprintf` over `String#%`.'])
+      expect_offense(<<-RUBY.strip_indent)
+        puts "%d" % 10
+                  ^ Favor `sprintf` over `String#%`.
+      RUBY
     end
 
     it 'registers an offense for something followed by an array' do
-      inspect_source(cop,
-                     'puts x % [10, 11]')
-      expect(cop.offenses.size).to eq(1)
-      expect(cop.messages)
-        .to eq(['Favor `sprintf` over `String#%`.'])
+      expect_offense(<<-RUBY.strip_indent)
+        puts x % [10, 11]
+               ^ Favor `sprintf` over `String#%`.
+      RUBY
     end
 
     it 'does not register an offense for numbers' do
@@ -36,27 +34,24 @@ describe RuboCop::Cop::Style::FormatString, :config do
     end
 
     it 'works if the first operand contains embedded expressions' do
-      inspect_source(cop,
-                     'puts "#{x * 5} %d #{@test}" % 10')
-      expect(cop.offenses.size).to eq(1)
-      expect(cop.messages)
-        .to eq(['Favor `sprintf` over `String#%`.'])
+      expect_offense(<<-'RUBY'.strip_indent)
+        puts "#{x * 5} %d #{@test}" % 10
+                                    ^ Favor `sprintf` over `String#%`.
+      RUBY
     end
 
     it 'registers an offense for format' do
-      inspect_source(cop,
-                     'format(something, a, b)')
-      expect(cop.offenses.size).to eq(1)
-      expect(cop.messages)
-        .to eq(['Favor `sprintf` over `format`.'])
+      expect_offense(<<-RUBY.strip_indent)
+        format(something, a, b)
+        ^^^^^^ Favor `sprintf` over `format`.
+      RUBY
     end
 
     it 'registers an offense for format with 2 arguments' do
-      inspect_source(cop,
-                     'format("%X", 123)')
-      expect(cop.offenses.size).to eq(1)
-      expect(cop.messages)
-        .to eq(['Favor `sprintf` over `format`.'])
+      expect_offense(<<-RUBY.strip_indent)
+        format("%X", 123)
+        ^^^^^^ Favor `sprintf` over `format`.
+      RUBY
     end
   end
 
@@ -64,27 +59,24 @@ describe RuboCop::Cop::Style::FormatString, :config do
     let(:cop_config) { { 'EnforcedStyle' => 'format' } }
 
     it 'registers an offense for a string followed by something' do
-      inspect_source(cop,
-                     'puts "%d" % 10')
-      expect(cop.offenses.size).to eq(1)
-      expect(cop.messages)
-        .to eq(['Favor `format` over `String#%`.'])
+      expect_offense(<<-RUBY.strip_indent)
+        puts "%d" % 10
+                  ^ Favor `format` over `String#%`.
+      RUBY
     end
 
     it 'registers an offense for something followed by an array' do
-      inspect_source(cop,
-                     'puts x % [10, 11]')
-      expect(cop.offenses.size).to eq(1)
-      expect(cop.messages)
-        .to eq(['Favor `format` over `String#%`.'])
+      expect_offense(<<-RUBY.strip_indent)
+        puts x % [10, 11]
+               ^ Favor `format` over `String#%`.
+      RUBY
     end
 
     it 'registers an offense for something followed by a hash' do
-      inspect_source(cop,
-                     'puts x % { a: 10, b: 11 }')
-      expect(cop.offenses.size).to eq(1)
-      expect(cop.messages)
-        .to eq(['Favor `format` over `String#%`.'])
+      expect_offense(<<-RUBY.strip_indent)
+        puts x % { a: 10, b: 11 }
+               ^ Favor `format` over `String#%`.
+      RUBY
     end
 
     it 'does not register an offense for numbers' do
@@ -102,27 +94,24 @@ describe RuboCop::Cop::Style::FormatString, :config do
     end
 
     it 'works if the first operand contains embedded expressions' do
-      inspect_source(cop,
-                     'puts "#{x * 5} %d #{@test}" % 10')
-      expect(cop.offenses.size).to eq(1)
-      expect(cop.messages)
-        .to eq(['Favor `format` over `String#%`.'])
+      expect_offense(<<-'RUBY'.strip_indent)
+        puts "#{x * 5} %d #{@test}" % 10
+                                    ^ Favor `format` over `String#%`.
+      RUBY
     end
 
     it 'registers an offense for sprintf' do
-      inspect_source(cop,
-                     'sprintf(something, a, b)')
-      expect(cop.offenses.size).to eq(1)
-      expect(cop.messages)
-        .to eq(['Favor `format` over `sprintf`.'])
+      expect_offense(<<-RUBY.strip_indent)
+        sprintf(something, a, b)
+        ^^^^^^^ Favor `format` over `sprintf`.
+      RUBY
     end
 
     it 'registers an offense for sprintf with 2 arguments' do
-      inspect_source(cop,
-                     "sprintf('%020d', 123)")
-      expect(cop.offenses.size).to eq(1)
-      expect(cop.messages)
-        .to eq(['Favor `format` over `sprintf`.'])
+      expect_offense(<<-RUBY.strip_indent)
+        sprintf('%020d', 123)
+        ^^^^^^^ Favor `format` over `sprintf`.
+      RUBY
     end
   end
 
@@ -130,27 +119,24 @@ describe RuboCop::Cop::Style::FormatString, :config do
     let(:cop_config) { { 'EnforcedStyle' => 'percent' } }
 
     it 'registers an offense for format' do
-      inspect_source(cop,
-                     'format(something, a, b)')
-      expect(cop.offenses.size).to eq(1)
-      expect(cop.messages)
-        .to eq(['Favor `String#%` over `format`.'])
+      expect_offense(<<-RUBY.strip_indent)
+        format(something, a, b)
+        ^^^^^^ Favor `String#%` over `format`.
+      RUBY
     end
 
     it 'registers an offense for sprintf' do
-      inspect_source(cop,
-                     'sprintf(something, a, b)')
-      expect(cop.offenses.size).to eq(1)
-      expect(cop.messages)
-        .to eq(['Favor `String#%` over `sprintf`.'])
+      expect_offense(<<-RUBY.strip_indent)
+        sprintf(something, a, b)
+        ^^^^^^^ Favor `String#%` over `sprintf`.
+      RUBY
     end
 
     it 'registers an offense for sprintf with 3 arguments' do
-      inspect_source(cop,
-                     'format("%d %04x", 123, 123)')
-      expect(cop.offenses.size).to eq(1)
-      expect(cop.messages)
-        .to eq(['Favor `String#%` over `format`.'])
+      expect_offense(<<-RUBY.strip_indent)
+        format("%d %04x", 123, 123)
+        ^^^^^^ Favor `String#%` over `format`.
+      RUBY
     end
 
     it 'accepts format with 1 argument' do

--- a/spec/rubocop/cop/style/frozen_string_literal_comment_spec.rb
+++ b/spec/rubocop/cop/style/frozen_string_literal_comment_spec.rb
@@ -340,31 +340,31 @@ describe RuboCop::Cop::Style::FrozenStringLiteralComment, :config do
 
       context 'target_ruby_version 2.3+', :ruby23 do
         it 'accepts freezing a string' do
-          inspect_source(cop, '"x".freeze')
-
-          expect(cop.messages)
-            .to eq(['Missing magic comment `# frozen_string_literal: true`.'])
+          expect_offense(<<-RUBY.strip_indent)
+            "x".freeze
+            ^ Missing magic comment `# frozen_string_literal: true`.
+          RUBY
         end
 
         it 'accepts calling << on a string' do
-          inspect_source(cop, '"x" << "y"')
-
-          expect(cop.messages)
-            .to eq(['Missing magic comment `# frozen_string_literal: true`.'])
+          expect_offense(<<-RUBY.strip_indent)
+            "x" << "y"
+            ^ Missing magic comment `# frozen_string_literal: true`.
+          RUBY
         end
 
         it 'accepts freezing a string with interpolation' do
-          inspect_source(cop, '"#{foo}bar".freeze')
-
-          expect(cop.messages)
-            .to eq(['Missing magic comment `# frozen_string_literal: true`.'])
+          expect_offense(<<-'RUBY'.strip_indent)
+            "#{foo}bar".freeze
+            ^ Missing magic comment `# frozen_string_literal: true`.
+          RUBY
         end
 
         it 'accepts calling << on a string with interpolation' do
-          inspect_source(cop, '"#{foo}bar" << "baz"')
-
-          expect(cop.messages)
-            .to eq(['Missing magic comment `# frozen_string_literal: true`.'])
+          expect_offense(<<-'RUBY'.strip_indent)
+            "#{foo}bar" << "baz"
+            ^ Missing magic comment `# frozen_string_literal: true`.
+          RUBY
         end
       end
     end

--- a/spec/rubocop/cop/style/global_vars_spec.rb
+++ b/spec/rubocop/cop/style/global_vars_spec.rb
@@ -9,8 +9,10 @@ describe RuboCop::Cop::Style::GlobalVars, :config do
   let(:cop_config) { cop_config }
 
   it 'registers an offense for $custom' do
-    inspect_source(cop, 'puts $custom')
-    expect(cop.offenses.size).to eq(1)
+    expect_offense(<<-RUBY.strip_indent)
+      puts $custom
+           ^^^^^^^ Do not introduce global variables.
+    RUBY
   end
 
   it 'allows user whitelisted variables' do

--- a/spec/rubocop/cop/style/guard_clause_spec.rb
+++ b/spec/rubocop/cop/style/guard_clause_spec.rb
@@ -163,25 +163,21 @@ describe RuboCop::Cop::Style::GuardClause, :config do
     end
 
     it 'reports an offense for if whose body has 1 line' do
-      inspect_source(cop, <<-END.strip_indent)
+      expect_offense(<<-RUBY.strip_indent)
         def func
           if something
+          ^^ Use a guard clause instead of wrapping the code inside a conditional expression.
             work
           end
         end
 
         def func
           unless something
+          ^^^^^^ Use a guard clause instead of wrapping the code inside a conditional expression.
             work
           end
         end
-      END
-      expect(cop.offenses.size).to eq(2)
-      expect(cop.offenses.map(&:line).sort).to eq([2, 8])
-      expect(cop.messages)
-        .to eq(['Use a guard clause instead of wrapping ' \
-                'the code inside a conditional expression.'] * 2)
-      expect(cop.highlights).to eq(%w[if unless])
+      RUBY
     end
   end
 
@@ -320,29 +316,29 @@ describe RuboCop::Cop::Style::GuardClause, :config do
 
   context 'method in module' do
     it 'registers an offense for instance method' do
-      inspect_source(cop, <<-END.strip_indent)
+      expect_offense(<<-RUBY.strip_indent)
         module CopTest
           def test
             if something
+            ^^ Use a guard clause instead of wrapping the code inside a conditional expression.
               work
             end
           end
         end
-      END
-      expect(cop.offenses.size).to eq(1)
+      RUBY
     end
 
     it 'registers an offense for singleton methods' do
-      inspect_source(cop, <<-END.strip_indent)
+      expect_offense(<<-RUBY.strip_indent)
         module CopTest
           def self.test
             if something
+            ^^ Use a guard clause instead of wrapping the code inside a conditional expression.
               work
             end
           end
         end
-      END
-      expect(cop.offenses.size).to eq(1)
+      RUBY
     end
   end
 end

--- a/spec/rubocop/cop/style/hash_syntax_spec.rb
+++ b/spec/rubocop/cop/style/hash_syntax_spec.rb
@@ -40,8 +40,10 @@ describe RuboCop::Cop::Style::HashSyntax, :config do
       end
 
       it 'registers an offense for hash rockets in method calls' do
-        inspect_source(cop, 'func(3, :a => 0)')
-        expect(cop.messages).to eq(['Use the new Ruby 1.9 hash syntax.'])
+        expect_offense(<<-RUBY.strip_indent)
+          func(3, :a => 0)
+                  ^^^^^ Use the new Ruby 1.9 hash syntax.
+        RUBY
       end
 
       it 'accepts hash rockets when keys have different types' do
@@ -63,20 +65,26 @@ describe RuboCop::Cop::Style::HashSyntax, :config do
 
       context 'ruby >= 2.2', :ruby22 do
         it 'registers an offense when symbol keys have strings in them' do
-          inspect_source(cop, 'x = { :"string" => 0 }')
-          expect(cop.messages).to eq(['Use the new Ruby 1.9 hash syntax.'])
+          expect_offense(<<-RUBY.strip_indent)
+            x = { :"string" => 0 }
+                  ^^^^^^^^^^^^ Use the new Ruby 1.9 hash syntax.
+          RUBY
         end
       end
 
       context 'if PreferHashRocketsForNonAlnumEndingSymbols is false' do
         it 'registers an offense for hash rockets when symbols end with ?' do
-          inspect_source(cop, 'x = { :a? => 0 }')
-          expect(cop.messages).to eq(['Use the new Ruby 1.9 hash syntax.'])
+          expect_offense(<<-RUBY.strip_indent)
+            x = { :a? => 0 }
+                  ^^^^^^ Use the new Ruby 1.9 hash syntax.
+          RUBY
         end
 
         it 'registers an offense for hash rockets when symbols end with !' do
-          inspect_source(cop, 'x = { :a! => 0 }')
-          expect(cop.messages).to eq(['Use the new Ruby 1.9 hash syntax.'])
+          expect_offense(<<-RUBY.strip_indent)
+            x = { :a! => 0 }
+                  ^^^^^^ Use the new Ruby 1.9 hash syntax.
+          RUBY
         end
       end
 
@@ -109,8 +117,10 @@ describe RuboCop::Cop::Style::HashSyntax, :config do
       end
 
       it 'registers offense when keys start with an uppercase letter' do
-        inspect_source(cop, 'x = { :A => 0 }')
-        expect(cop.messages).to eq(['Use the new Ruby 1.9 hash syntax.'])
+        expect_offense(<<-RUBY.strip_indent)
+          x = { :A => 0 }
+                ^^^^^ Use the new Ruby 1.9 hash syntax.
+        RUBY
       end
 
       it 'accepts new syntax in a hash literal' do
@@ -188,9 +198,11 @@ describe RuboCop::Cop::Style::HashSyntax, :config do
       end
 
       it 'registers an offense when any element uses a symbol for the value' do
-        inspect_source(cop, 'x = { a: 1, b: :c }')
-        expect(cop.messages)
-          .to eq(['Use hash rockets syntax.', 'Use hash rockets syntax.'])
+        expect_offense(<<-RUBY.strip_indent)
+          x = { a: 1, b: :c }
+                ^^ Use hash rockets syntax.
+                      ^^ Use hash rockets syntax.
+        RUBY
       end
 
       it 'registers an offense when any element has a symbol value ' \
@@ -208,9 +220,12 @@ describe RuboCop::Cop::Style::HashSyntax, :config do
       end
 
       it 'registers an offense for hashes with elements on multiple lines' do
-        inspect_source(cop, "x = { a: :b,\n c: :d }")
-        expect(cop.messages)
-          .to eq(['Use hash rockets syntax.', 'Use hash rockets syntax.'])
+        expect_offense(<<-RUBY.strip_indent)
+          x = { a: :b,
+                ^^ Use hash rockets syntax.
+           c: :d }
+           ^^ Use hash rockets syntax.
+        RUBY
       end
 
       it 'auto-corrects to ruby19 style when there are no symbol values' do
@@ -260,8 +275,10 @@ describe RuboCop::Cop::Style::HashSyntax, :config do
     end
 
     it 'registers an offense for 1.9 style in method calls' do
-      inspect_source(cop, 'func(3, a: 0)')
-      expect(cop.messages).to eq(['Use hash rockets syntax.'])
+      expect_offense(<<-RUBY.strip_indent)
+        func(3, a: 0)
+                ^^ Use hash rockets syntax.
+      RUBY
     end
 
     it 'accepts hash rockets in a hash literal' do
@@ -333,8 +350,10 @@ describe RuboCop::Cop::Style::HashSyntax, :config do
       end
 
       it 'registers an offense for hash rockets in method calls' do
-        inspect_source(cop, 'func(3, :a => 0)')
-        expect(cop.messages).to eq(['Use the new Ruby 1.9 hash syntax.'])
+        expect_offense(<<-RUBY.strip_indent)
+          func(3, :a => 0)
+                  ^^^^^ Use the new Ruby 1.9 hash syntax.
+        RUBY
       end
 
       it 'accepts hash rockets when keys have different types' do
@@ -391,18 +410,24 @@ describe RuboCop::Cop::Style::HashSyntax, :config do
 
       context 'ruby >= 2.2', :ruby22 do
         it 'registers an offense when keys have whitespaces in them' do
-          inspect_source(cop, 'x = { :"t o" => 0 }')
-          expect(cop.messages).to eq(['Use the new Ruby 1.9 hash syntax.'])
+          expect_offense(<<-RUBY.strip_indent)
+            x = { :"t o" => 0 }
+                  ^^^^^^^^^ Use the new Ruby 1.9 hash syntax.
+          RUBY
         end
 
         it 'registers an offense when keys have special symbols in them' do
-          inspect_source(cop, 'x = { :"\tab" => 1 }')
-          expect(cop.messages).to eq(['Use the new Ruby 1.9 hash syntax.'])
+          expect_offense(<<-'RUBY'.strip_indent)
+            x = { :"\tab" => 1 }
+                  ^^^^^^^^^^ Use the new Ruby 1.9 hash syntax.
+          RUBY
         end
 
         it 'registers an offense when keys start with a digit' do
-          inspect_source(cop, 'x = { :"1" => 1 }')
-          expect(cop.messages).to eq(['Use the new Ruby 1.9 hash syntax.'])
+          expect_offense(<<-RUBY.strip_indent)
+            x = { :"1" => 1 }
+                  ^^^^^^^ Use the new Ruby 1.9 hash syntax.
+          RUBY
         end
       end
 
@@ -427,9 +452,11 @@ describe RuboCop::Cop::Style::HashSyntax, :config do
       end
 
       it 'registers an offense when any element uses a symbol for the value' do
-        inspect_source(cop, 'x = { a: 1, b: :c }')
-        expect(cop.messages)
-          .to eq(['Use hash rockets syntax.', 'Use hash rockets syntax.'])
+        expect_offense(<<-RUBY.strip_indent)
+          x = { a: 1, b: :c }
+                ^^ Use hash rockets syntax.
+                      ^^ Use hash rockets syntax.
+        RUBY
       end
 
       it 'registers an offense when any element has a symbol value ' \
@@ -474,8 +501,10 @@ describe RuboCop::Cop::Style::HashSyntax, :config do
       end
 
       it 'registers an offense for hash rockets in method calls' do
-        inspect_source(cop, 'func(3, :a => 0)')
-        expect(cop.messages).to eq(['Use the new Ruby 1.9 hash syntax.'])
+        expect_offense(<<-RUBY.strip_indent)
+          func(3, :a => 0)
+                  ^^^^^ Use the new Ruby 1.9 hash syntax.
+        RUBY
       end
 
       it 'accepts hash rockets when keys have different types' do
@@ -532,18 +561,24 @@ describe RuboCop::Cop::Style::HashSyntax, :config do
 
       context 'ruby >= 2.2', :ruby22 do
         it 'registers an offense when keys have whitespaces in them' do
-          inspect_source(cop, 'x = { :"t o" => 0 }')
-          expect(cop.messages).to eq(['Use the new Ruby 1.9 hash syntax.'])
+          expect_offense(<<-RUBY.strip_indent)
+            x = { :"t o" => 0 }
+                  ^^^^^^^^^ Use the new Ruby 1.9 hash syntax.
+          RUBY
         end
 
         it 'registers an offense when keys have special symbols in them' do
-          inspect_source(cop, 'x = { :"\tab" => 1 }')
-          expect(cop.messages).to eq(['Use the new Ruby 1.9 hash syntax.'])
+          expect_offense(<<-'RUBY'.strip_indent)
+            x = { :"\tab" => 1 }
+                  ^^^^^^^^^^ Use the new Ruby 1.9 hash syntax.
+          RUBY
         end
 
         it 'registers an offense when keys start with a digit' do
-          inspect_source(cop, 'x = { :"1" => 1 }')
-          expect(cop.messages).to eq(['Use the new Ruby 1.9 hash syntax.'])
+          expect_offense(<<-RUBY.strip_indent)
+            x = { :"1" => 1 }
+                  ^^^^^^^ Use the new Ruby 1.9 hash syntax.
+          RUBY
         end
       end
 


### PR DESCRIPTION
Followup similar to #4356, #4353, #4337.

This is a bulk edit that checks if an example contains only nodes matching the following patterns:

```
(send nil :inspect_source (send nil :cop), $_)
```

```
(send
  (send nil :expect {
    (send (send nil :cop) :messages)
    (send (send (send nil :cop) :offenses) :map (block-pass (sym :to_s)))
  }) :to (send nil :eq ...))
```

```
(send
  (send nil :expect
    (send {
      (send (send nil :cop) :messages)
      (send (send (send nil :cop) :offenses) :map (block-pass (sym :to_s)))
    } :size)) :to (send nil :eq ...))
```

```
(send
  (send nil :expect
    (send
      (send nil :cop) :highlights)) :to {
      (send nil :eq #array_of_strings?)
      (send nil :eq #array_of_lvar?)
      (send nil :include str)
      (send nil :match regexp)
    })
```

```
(send
  (send nil :expect
    (send
      (send
        (send
          (send nil :cop) :offenses) :first) {:message :to_s})) :to {
            (send nil :eq #array_of_strings?)
            (send nil :eq #array_of_lvar?)
            (send nil :include str)
            (send nil :match regexp)
          })
```

```
(send
  (send nil :expect
    (send
      (send
        (send nil :cop) :offenses) :size)) :to
  (send nil :eq (int positive?)))
```

```
(send
  (send nil :expect {
    (send (send (send nil :cop) :offenses) :map (block-pass (sym :line)))
    (send (send (send (send nil :cop) :offenses) :map (block-pass (sym :line))) :sort)
  }) :to (send nil :eq array))
```

```
(send
  (send nil :expect
    (send
      (send nil :cop) :offenses)) :not_to
  (send nil :be_empty))
```

If a spec only contains nodes matching these patterns then it can be replaced by `expect_offense`. This still isn't everything (I don't know if I will ever "finish" this bulk update) but it makes an even bigger dent.

This change actually increases the lines of code a bit. Basically,  there is a bit more duplication of the code inspected code and the offense messages. I think this is fine though. We are basically trading in a small amount of increased duplication in exchange for way better tests and more readable code.

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Used the same coding conventions as the rest of the project.
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] All tests are passing.
* [x] The new code doesn't generate RuboCop offenses.
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Updated cop documentation with `rake generate_cops_documentation` (required only when you've added a new cop or changed the configuration/documentation of an existing cop).

[1]: http://chris.beams.io/posts/git-commit/
