### PR TITLE
Use relative path for offense message in `Lint/DuplicateMethods`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@
 * [#4278](https://github.com/bbatsov/rubocop/pull/4278): Move all cops dealing with whitespace into a new department called `Layout`. ([@jonas054][])
 * [#4320](https://github.com/bbatsov/rubocop/pull/4320): Update `Rails/OutputSafety` to disallow wrapping `raw` or `html_safe` with `safe_join`. ([@klesse413][])
 * [#4336](https://github.com/bbatsov/rubocop/issues/4336): Store `rubocop_cache` in safer directories. ([@jonas054][])
+* [#4361](https://github.com/bbatsov/rubocop/pull/4361): Use relative path for offense message in `Lint/DuplicateMethods`. ([@pocke][])
 
 ### Bug fixes
 

--- a/lib/rubocop/cop/lint/duplicate_methods.rb
+++ b/lib/rubocop/cop/lint/duplicate_methods.rb
@@ -143,7 +143,8 @@ module RuboCop
 
         def source_location(node)
           range = node.location.expression
-          "#{range.source_buffer.name}:#{range.line}"
+          path = smart_path(range.source_buffer.name)
+          "#{path}:#{range.line}"
         end
       end
     end

--- a/lib/rubocop/formatter/simple_text_formatter.rb
+++ b/lib/rubocop/formatter/simple_text_formatter.rb
@@ -64,17 +64,6 @@ module RuboCop
         @total_correction_count += offenses.count(&:corrected?)
       end
 
-      def smart_path(path)
-        # Ideally, we calculate this relative to the project root.
-        base_dir = Dir.pwd
-
-        if path.start_with? base_dir
-          relative_path(path, base_dir)
-        else
-          path
-        end
-      end
-
       def colored_severity_code(offense)
         color = COLOR_FOR_SEVERITY[offense.severity.name]
         colorize(offense.severity.code, color)

--- a/lib/rubocop/path_util.rb
+++ b/lib/rubocop/path_util.rb
@@ -14,6 +14,17 @@ module RuboCop
       path_name.relative_path_from(Pathname.new(base_dir)).to_s
     end
 
+    def smart_path(path)
+      # Ideally, we calculate this relative to the project root.
+      base_dir = Dir.pwd
+
+      if path.start_with? base_dir
+        relative_path(path, base_dir)
+      else
+        path
+      end
+    end
+
     def match_path?(pattern, path)
       case pattern
       when String

--- a/spec/rubocop/cop/lint/duplicate_methods_spec.rb
+++ b/spec/rubocop/cop/lint/duplicate_methods_spec.rb
@@ -334,4 +334,40 @@ describe RuboCop::Cop::Lint::DuplicateMethods do
       end
     END
   end
+
+  context 'when path is in the project root' do
+    before do
+      allow(Dir).to receive(:pwd).and_return('/path/to/project/root')
+      allow_any_instance_of(Parser::Source::Buffer).to receive(:name)
+        .and_return('/path/to/project/root/lib/foo.rb')
+    end
+
+    it 'adds a message with relative path' do
+      expect_offense(<<-END.strip_indent)
+        def something
+        end
+        def something
+        ^^^ Method `Object#something` is defined at both lib/foo.rb:1 and lib/foo.rb:3.
+        end
+      END
+    end
+  end
+
+  context 'when path is not in the project root' do
+    before do
+      allow(Dir).to receive(:pwd).and_return('/path/to/project/root')
+      allow_any_instance_of(Parser::Source::Buffer).to receive(:name)
+        .and_return('/no/project/root/foo.rb')
+    end
+
+    it 'adds a message with absolute path' do
+      expect_offense(<<-END.strip_indent)
+        def something
+        end
+        def something
+        ^^^ Method `Object#something` is defined at both /no/project/root/foo.rb:1 and /no/project/root/foo.rb:3.
+        end
+      END
+    end
+  end
 end


### PR DESCRIPTION
Currently `Lint/DuplicateMethods` cop messages have absolute paths.

```bash
$ rubocop test.rb --only Lint/DuplicateMethods
Inspecting 1 file
W

Offenses:

test.rb:3:1: W: Method Object#foo is defined at both /home/pocke/ghq/github.com/bbatsov/rubocop/test.rb:1 and /home/pocke/ghq/github.com/bbatsov/rubocop/test.rb:3.
def foo
^^^

1 file inspected, 1 offense detected
```

I think Absolute path is unnecessarily long.
And we use relative path for a location of an offense(e.g. `test.rb:3:1`).
So, I think we should use relative path for this message also.

By this change, the absolute path is replaced with relative path.

For example:

```bash
$ rubocop test.rb --only Lint/DuplicateMethods
Inspecting 1 file
W

Offenses:

test.rb:3:1: W: Method Object#foo is defined at both test.rb:1 and test.rb:3.
def foo
^^^

1 file inspected, 1 offense detected
```

What do you think?


-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Used the same coding conventions as the rest of the project.
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [ ] Added tests.
* [x] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] All tests are passing.
* [x] The new code doesn't generate RuboCop offenses.
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [ ] Updated cop documentation with `rake generate_cops_documentation` (required only when you've added a new cop or changed the configuration/documentation of an existing cop).

[1]: http://chris.beams.io/posts/git-commit/
