### PR TITLE
Refactor more specs to use expect_offense

### DIFF
--- a/spec/rubocop/cop/layout/end_of_line_spec.rb
+++ b/spec/rubocop/cop/layout/end_of_line_spec.rb
@@ -157,9 +157,10 @@ describe RuboCop::Cop::Layout::EndOfLine, :config do
 
     context 'and source is a string' do
       it 'registers an offense' do
-        inspect_source(cop, "x=0\r")
-
-        expect(cop.messages).to eq(['Carriage return character detected.'])
+        expect_offense(<<-RUBY.strip_indent)
+          x=0\r
+          ^^^ Carriage return character detected.
+        RUBY
       end
     end
   end

--- a/spec/rubocop/cop/layout/indentation_width_spec.rb
+++ b/spec/rubocop/cop/layout/indentation_width_spec.rb
@@ -61,13 +61,12 @@ describe RuboCop::Cop::Layout::IndentationWidth do
 
     context 'with if statement' do
       it 'registers an offense for bad indentation of an if body' do
-        inspect_source(cop, <<-END.strip_indent)
+        expect_offense(<<-RUBY.strip_indent)
           if cond
            func
+          ^ Use 4 (not 1) spaces for indentation.
           end
-        END
-        expect(cop.messages).to eq(['Use 4 (not 1) spaces for indentation.'])
-        expect(cop.highlights).to eq([' '])
+        RUBY
       end
     end
 
@@ -103,25 +102,23 @@ describe RuboCop::Cop::Layout::IndentationWidth do
 
     context 'with if statement' do
       it 'registers an offense for bad indentation of an if body' do
-        inspect_source(cop, <<-END.strip_indent)
+        expect_offense(<<-RUBY.strip_indent)
           if cond
            func
+          ^ Use 2 (not 1) spaces for indentation.
           end
-        END
-        expect(cop.messages).to eq(['Use 2 (not 1) spaces for indentation.'])
-        expect(cop.highlights).to eq([' '])
+        RUBY
       end
 
       it 'registers an offense for bad indentation of an else body' do
-        inspect_source(cop, <<-END.strip_indent)
+        expect_offense(<<-RUBY.strip_indent)
           if cond
             func1
           else
            func2
+          ^ Use 2 (not 1) spaces for indentation.
           end
-        END
-        expect(cop.messages).to eq(['Use 2 (not 1) spaces for indentation.'])
-        expect(cop.highlights).to eq([' '])
+        RUBY
       end
 
       it 'registers an offense for bad indentation of an elsif body' do
@@ -138,16 +135,14 @@ describe RuboCop::Cop::Layout::IndentationWidth do
       end
 
       it 'registers offense for bad indentation of ternary inside else' do
-        inspect_source(cop, <<-END.strip_indent)
+        expect_offense(<<-RUBY.strip_indent)
           if a
             b
           else
                x ? y : z
+          ^^^^^ Use 2 (not 5) spaces for indentation.
           end
-        END
-        expect(cop.messages)
-          .to eq(['Use 2 (not 5) spaces for indentation.'])
-        expect(cop.highlights).to eq(['     '])
+        RUBY
       end
 
       it 'registers offense for bad indentation of modifier if in else' do

--- a/spec/rubocop/cop/layout/space_around_block_parameters_spec.rb
+++ b/spec/rubocop/cop/layout/space_around_block_parameters_spec.rb
@@ -32,22 +32,24 @@ describe RuboCop::Cop::Layout::SpaceAroundBlockParameters, :config do
     end
 
     it 'registers an offense for space before first parameter' do
-      inspect_source(cop, '{}.each { | x| puts x }')
-      expect(cop.messages)
-        .to eq(['Space before first block parameter detected.'])
-      expect(cop.highlights).to eq([' '])
+      expect_offense(<<-RUBY.strip_indent)
+        {}.each { | x| puts x }
+                   ^ Space before first block parameter detected.
+      RUBY
     end
 
     it 'registers an offense for space after last parameter' do
-      inspect_source(cop, '{}.each { |x, y  | puts x }')
-      expect(cop.messages).to eq(['Space after last block parameter detected.'])
-      expect(cop.highlights).to eq(['  '])
+      expect_offense(<<-RUBY.strip_indent)
+        {}.each { |x, y  | puts x }
+                       ^^ Space after last block parameter detected.
+      RUBY
     end
 
     it 'registers an offense for no space after closing pipe' do
-      inspect_source(cop, '{}.each { |x, y|puts x }')
-      expect(cop.messages).to eq(['Space after closing `|` missing.'])
-      expect(cop.highlights).to eq(['|'])
+      expect_offense(<<-RUBY.strip_indent)
+        {}.each { |x, y|puts x }
+                       ^ Space after closing `|` missing.
+      RUBY
     end
 
     it 'accepts line break after closing pipe' do
@@ -59,18 +61,18 @@ describe RuboCop::Cop::Layout::SpaceAroundBlockParameters, :config do
     end
 
     it 'registers an offense for multiple spaces before parameter' do
-      inspect_source(cop, '{}.each { |x,   y| puts x }')
-      expect(cop.messages)
-        .to eq(['Extra space before block parameter detected.'])
-      expect(cop.highlights).to eq(['  '])
+      expect_offense(<<-RUBY.strip_indent)
+        {}.each { |x,   y| puts x }
+                     ^^ Extra space before block parameter detected.
+      RUBY
     end
 
     context 'trailing comma' do
       it 'registers an offense for space after the last comma' do
-        inspect_source(cop, '{}.each { |x, | puts x }')
-        expect(cop.messages)
-          .to eq(['Space after last block parameter detected.'])
-        expect(cop.highlights).to eq([' '])
+        expect_offense(<<-RUBY.strip_indent)
+          {}.each { |x, | puts x }
+                       ^ Space after last block parameter detected.
+        RUBY
       end
 
       it 'accepts no space after the last comma' do
@@ -104,36 +106,38 @@ describe RuboCop::Cop::Layout::SpaceAroundBlockParameters, :config do
     end
 
     it 'registers an offense for no space before first parameter' do
-      inspect_source(cop, '{}.each { |x | puts x }')
-      expect(cop.messages)
-        .to eq(['Space before first block parameter missing.'])
-      expect(cop.highlights).to eq(['x'])
+      expect_offense(<<-RUBY.strip_indent)
+        {}.each { |x | puts x }
+                   ^ Space before first block parameter missing.
+      RUBY
     end
 
     it 'registers an offense for no space after last parameter' do
-      inspect_source(cop, '{}.each { | x, y| puts x }')
-      expect(cop.messages).to eq(['Space after last block parameter missing.'])
-      expect(cop.highlights).to eq(['y'])
+      expect_offense(<<-RUBY.strip_indent)
+        {}.each { | x, y| puts x }
+                       ^ Space after last block parameter missing.
+      RUBY
     end
 
     it 'registers an offense for extra space before first parameter' do
-      inspect_source(cop, '{}.each { |  x | puts x }')
-      expect(cop.messages)
-        .to eq(['Extra space before first block parameter detected.'])
-      expect(cop.highlights).to eq([' '])
+      expect_offense(<<-RUBY.strip_indent)
+        {}.each { |  x | puts x }
+                   ^ Extra space before first block parameter detected.
+      RUBY
     end
 
     it 'registers an offense for multiple spaces after last parameter' do
-      inspect_source(cop, '{}.each { | x, y   | puts x }')
-      expect(cop.messages)
-        .to eq(['Extra space after last block parameter detected.'])
-      expect(cop.highlights).to eq(['  '])
+      expect_offense(<<-RUBY.strip_indent)
+        {}.each { | x, y   | puts x }
+                         ^^ Extra space after last block parameter detected.
+      RUBY
     end
 
     it 'registers an offense for no space after closing pipe' do
-      inspect_source(cop, '{}.each { | x, y |puts x }')
-      expect(cop.messages).to eq(['Space after closing `|` missing.'])
-      expect(cop.highlights).to eq(['|'])
+      expect_offense(<<-RUBY.strip_indent)
+        {}.each { | x, y |puts x }
+                         ^ Space after closing `|` missing.
+      RUBY
     end
 
     it 'accepts line break after closing pipe' do
@@ -145,10 +149,10 @@ describe RuboCop::Cop::Layout::SpaceAroundBlockParameters, :config do
     end
 
     it 'registers an offense for multiple spaces before parameter' do
-      inspect_source(cop, '{}.each { | x,   y | puts x }')
-      expect(cop.messages)
-        .to eq(['Extra space before block parameter detected.'])
-      expect(cop.highlights).to eq(['  '])
+      expect_offense(<<-RUBY.strip_indent)
+        {}.each { | x,   y | puts x }
+                      ^^ Extra space before block parameter detected.
+      RUBY
     end
 
     context 'trailing comma' do
@@ -157,10 +161,10 @@ describe RuboCop::Cop::Layout::SpaceAroundBlockParameters, :config do
       end
 
       it 'registers an offense for no space after the last comma' do
-        inspect_source(cop, '{}.each { | x,| puts x }')
-        expect(cop.messages)
-          .to eq(['Space after last block parameter missing.'])
-        expect(cop.highlights).to eq(['x'])
+        expect_offense(<<-RUBY.strip_indent)
+          {}.each { | x,| puts x }
+                      ^ Space after last block parameter missing.
+        RUBY
       end
     end
 

--- a/spec/rubocop/cop/layout/space_around_equals_in_parameter_default_spec.rb
+++ b/spec/rubocop/cop/layout/space_around_equals_in_parameter_default_spec.rb
@@ -27,11 +27,11 @@ describe RuboCop::Cop::Layout::SpaceAroundEqualsInParameterDefault, :config do
     end
 
     it 'registers an offense for assignment of empty list without space' do
-      inspect_source(cop, <<-END.strip_indent)
+      expect_offense(<<-RUBY.strip_indent)
         def f(x, y=[])
+                  ^ Surrounding space missing in default value assignment.
         end
-      END
-      expect(cop.offenses.size).to eq(1)
+      RUBY
     end
 
     it 'accepts default value assignment with space' do
@@ -91,11 +91,11 @@ describe RuboCop::Cop::Layout::SpaceAroundEqualsInParameterDefault, :config do
     end
 
     it 'registers an offense for assignment of empty list with space' do
-      inspect_source(cop, <<-END.strip_indent)
+      expect_offense(<<-RUBY.strip_indent)
         def f(x, y = [])
+                  ^^^ Surrounding space detected in default value assignment.
         end
-      END
-      expect(cop.offenses.size).to eq(1)
+      RUBY
     end
 
     it 'accepts default value assignment without space' do

--- a/spec/rubocop/cop/layout/space_around_operators_spec.rb
+++ b/spec/rubocop/cop/layout/space_around_operators_spec.rb
@@ -42,10 +42,10 @@ describe RuboCop::Cop::Layout::SpaceAroundOperators do
   end
 
   it 'accepts exclamation point negation' do
-    inspect_source(cop, 'x = !a&&!b')
-    expect(cop.messages).to eq(
-      ['Surrounding space missing for operator `&&`.']
-    )
+    expect_offense(<<-RUBY.strip_indent)
+      x = !a&&!b
+            ^^ Surrounding space missing for operator `&&`.
+    RUBY
   end
 
   it 'accepts exclamation point definition' do
@@ -145,10 +145,10 @@ describe RuboCop::Cop::Layout::SpaceAroundOperators do
   end
 
   it 'registers an offenses for exponent operator with spaces' do
-    inspect_source(cop, 'x = a * b ** 2')
-    expect(cop.messages).to eq(
-      ['Space around operator `**` detected.']
-    )
+    expect_offense(<<-RUBY.strip_indent)
+      x = a * b ** 2
+                ^^ Space around operator `**` detected.
+    RUBY
   end
 
   it 'auto-corrects unwanted space around **' do
@@ -232,11 +232,14 @@ describe RuboCop::Cop::Layout::SpaceAroundOperators do
     end
 
     it 'registers an offense for assignment without space on both sides' do
-      inspect_source(cop, ['x=0', 'y+= 0', 'z[0] =0'])
-      expect(cop.messages)
-        .to eq(['Surrounding space missing for operator `=`.',
-                'Surrounding space missing for operator `+=`.',
-                'Surrounding space missing for operator `=`.'])
+      expect_offense(<<-RUBY.strip_indent)
+        x=0
+         ^ Surrounding space missing for operator `=`.
+        y+= 0
+         ^^ Surrounding space missing for operator `+=`.
+        z[0] =0
+             ^ Surrounding space missing for operator `=`.
+      RUBY
     end
 
     it 'auto-corrects assignment without space on both sides' do
@@ -246,30 +249,27 @@ describe RuboCop::Cop::Layout::SpaceAroundOperators do
 
     context 'ternary operators' do
       it 'registers an offense for operators with no spaces' do
-        inspect_source(cop, 'x == 0?1:2')
-
-        expect(cop.messages).to eq(
-          ['Surrounding space missing for operator `?`.',
-           'Surrounding space missing for operator `:`.']
-        )
+        expect_offense(<<-RUBY.strip_indent)
+          x == 0?1:2
+                  ^ Surrounding space missing for operator `:`.
+                ^ Surrounding space missing for operator `?`.
+        RUBY
       end
 
       it 'registers an offense for operators with just a trailing space' do
-        inspect_source(cop, 'x == 0? 1: 2')
-
-        expect(cop.messages).to eq(
-          ['Surrounding space missing for operator `?`.',
-           'Surrounding space missing for operator `:`.']
-        )
+        expect_offense(<<-RUBY.strip_indent)
+          x == 0? 1: 2
+                   ^ Surrounding space missing for operator `:`.
+                ^ Surrounding space missing for operator `?`.
+        RUBY
       end
 
       it 'registers an offense for operators with just a leading space' do
-        inspect_source(cop, 'x == 0 ?1 :2')
-
-        expect(cop.messages).to eq(
-          ['Surrounding space missing for operator `?`.',
-           'Surrounding space missing for operator `:`.']
-        )
+        expect_offense(<<-RUBY.strip_indent)
+          x == 0 ?1 :2
+                    ^ Surrounding space missing for operator `:`.
+                 ^ Surrounding space missing for operator `?`.
+        RUBY
       end
 
       it 'auto-corrects a ternary operator without space' do
@@ -284,12 +284,14 @@ describe RuboCop::Cop::Layout::SpaceAroundOperators do
     it_behaves_like 'modifier with missing space', 'until'
 
     it 'registers an offense for binary operators that could be unary' do
-      inspect_source(cop, ['a-3', 'x&0xff', 'z+0'])
-      expect(cop.messages).to eq(
-        ['Surrounding space missing for operator `-`.',
-         'Surrounding space missing for operator `&`.',
-         'Surrounding space missing for operator `+`.']
-      )
+      expect_offense(<<-RUBY.strip_indent)
+        a-3
+         ^ Surrounding space missing for operator `-`.
+        x&0xff
+         ^ Surrounding space missing for operator `&`.
+        z+0
+         ^ Surrounding space missing for operator `+`.
+      RUBY
     end
 
     it 'auto-corrects missing space in binary operators that could be unary' do
@@ -298,10 +300,10 @@ describe RuboCop::Cop::Layout::SpaceAroundOperators do
     end
 
     it 'registers an offense for arguments to a method' do
-      inspect_source(cop, 'puts 1+2')
-      expect(cop.messages).to eq(
-        ['Surrounding space missing for operator `+`.']
-      )
+      expect_offense(<<-RUBY.strip_indent)
+        puts 1+2
+              ^ Surrounding space missing for operator `+`.
+      RUBY
     end
 
     it 'auto-corrects missing space in arguments to a method' do
@@ -340,10 +342,10 @@ describe RuboCop::Cop::Layout::SpaceAroundOperators do
     end
 
     it 'registers an offense for a setter call without spaces' do
-      inspect_source(cop, 'x.y=2')
-      expect(cop.messages).to eq(
-        ['Surrounding space missing for operator `=`.']
-      )
+      expect_offense(<<-RUBY.strip_indent)
+        x.y=2
+           ^ Surrounding space missing for operator `=`.
+      RUBY
     end
 
     context 'when a hash literal is on a single line' do
@@ -431,17 +433,21 @@ describe RuboCop::Cop::Layout::SpaceAroundOperators do
     end
 
     it 'registers an offense for equality operators without space' do
-      inspect_source(cop, ['x==0', 'y!=0', 'Hash===z'])
-      expect(cop.messages)
-        .to eq(['Surrounding space missing for operator `==`.',
-                'Surrounding space missing for operator `!=`.',
-                'Surrounding space missing for operator `===`.'])
+      expect_offense(<<-RUBY.strip_indent)
+        x==0
+         ^^ Surrounding space missing for operator `==`.
+        y!=0
+         ^^ Surrounding space missing for operator `!=`.
+        Hash===z
+            ^^^ Surrounding space missing for operator `===`.
+      RUBY
     end
 
     it 'registers an offense for - without space with negative lhs operand' do
-      inspect_source(cop, '-1-arg')
-      expect(cop.messages)
-        .to eq(['Surrounding space missing for operator `-`.'])
+      expect_offense(<<-RUBY.strip_indent)
+        -1-arg
+          ^ Surrounding space missing for operator `-`.
+      RUBY
     end
 
     it 'registers an offense for inheritance < without space' do
@@ -529,11 +535,11 @@ describe RuboCop::Cop::Layout::SpaceAroundOperators do
     end
 
     it 'registers an offense for ternary operator with too many spaces' do
-      inspect_source(cop, 'x == 0  ? 1 :  2')
-      expect(cop.messages).to eq(
-        ['Operator `?` should be surrounded by a single space.',
-         'Operator `:` should be surrounded by a single space.']
-      )
+      expect_offense(<<-RUBY.strip_indent)
+        x == 0  ? 1 :  2
+                    ^ Operator `:` should be surrounded by a single space.
+                ^ Operator `?` should be surrounded by a single space.
+      RUBY
     end
 
     it 'auto-corrects a ternary operator too many spaces' do
@@ -571,10 +577,10 @@ describe RuboCop::Cop::Layout::SpaceAroundOperators do
     end
 
     it 'registers an offense for arguments to a method' do
-      inspect_source(cop, 'puts 1 +  2')
-      expect(cop.messages).to eq(
-        ['Operator `+` should be surrounded by a single space.']
-      )
+      expect_offense(<<-RUBY.strip_indent)
+        puts 1 +  2
+               ^ Operator `+` should be surrounded by a single space.
+      RUBY
     end
 
     it 'auto-corrects missing space in arguments to a method' do
@@ -625,17 +631,17 @@ describe RuboCop::Cop::Layout::SpaceAroundOperators do
     end
 
     it 'registers an offense for a setter call with too many spaces' do
-      inspect_source(cop, 'x.y  =  2')
-      expect(cop.messages).to eq(
-        ['Operator `=` should be surrounded by a single space.']
-      )
+      expect_offense(<<-RUBY.strip_indent)
+        x.y  =  2
+             ^ Operator `=` should be surrounded by a single space.
+      RUBY
     end
 
     it 'registers an offense for a hash rocket with too many spaces' do
-      inspect_source(cop, '{ 1  =>   2, a: b }')
-      expect(cop.messages).to eq(
-        ['Operator `=>` should be surrounded by a single space.']
-      )
+      expect_offense(<<-RUBY.strip_indent)
+        { 1  =>   2, a: b }
+             ^^ Operator `=>` should be surrounded by a single space.
+      RUBY
     end
 
     it 'registers an offense for a hash rocket with an extra space' \
@@ -712,11 +718,14 @@ describe RuboCop::Cop::Layout::SpaceAroundOperators do
     end
 
     it 'registers an offense for equality operators with too many spaces' do
-      inspect_source(cop, ['x  ==  0', 'y   != 0', 'Hash   ===   z'])
-      expect(cop.messages)
-        .to eq(['Operator `==` should be surrounded by a single space.',
-                'Operator `!=` should be surrounded by a single space.',
-                'Operator `===` should be surrounded by a single space.'])
+      expect_offense(<<-RUBY.strip_indent)
+        x  ==  0
+           ^^ Operator `==` should be surrounded by a single space.
+        y   != 0
+            ^^ Operator `!=` should be surrounded by a single space.
+        Hash   ===   z
+               ^^^ Operator `===` should be surrounded by a single space.
+      RUBY
     end
 
     it 'registers an offense for - with too many spaces with ' \

--- a/spec/rubocop/cop/layout/space_before_comment_spec.rb
+++ b/spec/rubocop/cop/layout/space_before_comment_spec.rb
@@ -4,8 +4,10 @@ describe RuboCop::Cop::Layout::SpaceBeforeComment do
   subject(:cop) { described_class.new }
 
   it 'registers an offense for missing space before an EOL comment' do
-    inspect_source(cop, 'a += 1# increment')
-    expect(cop.highlights).to eq(['# increment'])
+    expect_offense(<<-RUBY.strip_indent)
+      a += 1# increment
+            ^^^^^^^^^^^ Put a space before an end-of-line comment.
+    RUBY
   end
 
   it 'accepts an EOL comment with a preceding space' do

--- a/spec/rubocop/cop/layout/space_before_first_arg_spec.rb
+++ b/spec/rubocop/cop/layout/space_before_first_arg_spec.rb
@@ -94,14 +94,17 @@ describe RuboCop::Cop::Layout::SpaceBeforeFirstArg, :config do
       let(:cop_config) { { 'AllowForAlignment' => false } }
 
       it 'does not accept method calls with aligned first arguments' do
-        inspect_source(cop, <<-END.strip_indent)
+        expect_offense(<<-RUBY.strip_indent)
           form.inline_input   :full_name,     as: :string
+                           ^^^ Put one space between the method name and the first argument.
           form.disabled_input :password,      as: :passwd
           form.masked_input   :zip_code,      as: :string
+                           ^^^ Put one space between the method name and the first argument.
           form.masked_input   :email_address, as: :email
+                           ^^^ Put one space between the method name and the first argument.
           form.masked_input   :phone_number,  as: :tel
-        END
-        expect(cop.offenses.size).to eq(4)
+                           ^^^ Put one space between the method name and the first argument.
+        RUBY
       end
     end
   end

--- a/spec/rubocop/cop/layout/space_in_lambda_literal_spec.rb
+++ b/spec/rubocop/cop/layout/space_in_lambda_literal_spec.rb
@@ -7,8 +7,10 @@ describe RuboCop::Cop::Layout::SpaceInLambdaLiteral, :config do
     let(:cop_config) { { 'EnforcedStyle' => 'require_space' } }
 
     it 'registers an offense for no space between -> and (' do
-      inspect_source(cop, 'a = ->(b, c) { b + c }')
-      expect(cop.offenses.size).to eq(1)
+      expect_offense(<<-RUBY.strip_indent)
+        a = ->(b, c) { b + c }
+            ^^^^^^^^^^^^^^^^^^ Use a space between `->` and opening brace in lambda literals
+      RUBY
     end
 
     it 'does not register an offense for a space between -> and (' do
@@ -29,18 +31,25 @@ describe RuboCop::Cop::Layout::SpaceInLambdaLiteral, :config do
     end
 
     it 'registers an offense for no space in the inner nested lambda' do
-      inspect_source(cop, 'a = -> (b = ->(c) {}, d) { b + d }')
-      expect(cop.offenses.size).to eq(1)
+      expect_offense(<<-RUBY.strip_indent)
+        a = -> (b = ->(c) {}, d) { b + d }
+                    ^^^^^^^^ Use a space between `->` and opening brace in lambda literals
+      RUBY
     end
 
     it 'registers an offense for no space in the outer nested lambda' do
-      inspect_source(cop, 'a = ->(b = -> (c) {}, d) { b + d }')
-      expect(cop.offenses.size).to eq(1)
+      expect_offense(<<-RUBY.strip_indent)
+        a = ->(b = -> (c) {}, d) { b + d }
+            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Use a space between `->` and opening brace in lambda literals
+      RUBY
     end
 
     it 'registers an offense for no space in both lambdas when nested' do
-      inspect_source(cop, 'a = ->(b = ->(c) {}, d) { b + d }')
-      expect(cop.offenses.size).to eq(2)
+      expect_offense(<<-RUBY.strip_indent)
+        a = ->(b = ->(c) {}, d) { b + d }
+                   ^^^^^^^^ Use a space between `->` and opening brace in lambda literals
+            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Use a space between `->` and opening brace in lambda literals
+      RUBY
     end
 
     it 'autocorrects an offense for no space between -> and (' do
@@ -72,8 +81,10 @@ describe RuboCop::Cop::Layout::SpaceInLambdaLiteral, :config do
     let(:cop_config) { { 'EnforcedStyle' => 'require_no_space' } }
 
     it 'registers an offense for a space between -> and (' do
-      inspect_source(cop, 'a = -> (b, c) { b + c }')
-      expect(cop.offenses.size).to eq(1)
+      expect_offense(<<-RUBY.strip_indent)
+        a = -> (b, c) { b + c }
+            ^^^^^^^^^^^^^^^^^^^ Do not use spaces between `->` and opening brace in lambda literals
+      RUBY
     end
 
     it 'does not register an offense for no space between -> and (' do
@@ -94,23 +105,32 @@ describe RuboCop::Cop::Layout::SpaceInLambdaLiteral, :config do
     end
 
     it 'registers an offense for spaces between -> and (' do
-      inspect_source(cop, 'a = ->   (b, c) { b + c }')
-      expect(cop.offenses.size).to eq(1)
+      expect_offense(<<-RUBY.strip_indent)
+        a = ->   (b, c) { b + c }
+            ^^^^^^^^^^^^^^^^^^^^^ Do not use spaces between `->` and opening brace in lambda literals
+      RUBY
     end
 
     it 'registers an offense for a space in the inner nested lambda' do
-      inspect_source(cop, 'a = ->(b = -> (c) {}, d) { b + d }')
-      expect(cop.offenses.size).to eq(1)
+      expect_offense(<<-RUBY.strip_indent)
+        a = ->(b = -> (c) {}, d) { b + d }
+                   ^^^^^^^^^ Do not use spaces between `->` and opening brace in lambda literals
+      RUBY
     end
 
     it 'registers an offense for a space in the outer nested lambda' do
-      inspect_source(cop, 'a = -> (b = ->(c) {}, d) { b + d }')
-      expect(cop.offenses.size).to eq(1)
+      expect_offense(<<-RUBY.strip_indent)
+        a = -> (b = ->(c) {}, d) { b + d }
+            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Do not use spaces between `->` and opening brace in lambda literals
+      RUBY
     end
 
     it 'registers two offenses for a space in both lambdas when nested' do
-      inspect_source(cop, 'a = -> (b = -> (c) {}, d) { b + d }')
-      expect(cop.offenses.size).to eq(2)
+      expect_offense(<<-RUBY.strip_indent)
+        a = -> (b = -> (c) {}, d) { b + d }
+                    ^^^^^^^^^ Do not use spaces between `->` and opening brace in lambda literals
+            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Do not use spaces between `->` and opening brace in lambda literals
+      RUBY
     end
 
     it 'autocorrects an offense for a space between -> and (' do

--- a/spec/rubocop/cop/layout/space_inside_block_braces_spec.rb
+++ b/spec/rubocop/cop/layout/space_inside_block_braces_spec.rb
@@ -48,9 +48,10 @@ describe RuboCop::Cop::Layout::SpaceInsideBlockBraces, :config do
     end
 
     it 'registers an offense for empty braces with space inside' do
-      inspect_source(cop, 'each { }')
-      expect(cop.messages).to eq(['Space inside empty braces detected.'])
-      expect(cop.highlights).to eq([' '])
+      expect_offense(<<-RUBY.strip_indent)
+        each { }
+              ^ Space inside empty braces detected.
+      RUBY
     end
 
     it 'auto-corrects unwanted space' do
@@ -77,9 +78,10 @@ describe RuboCop::Cop::Layout::SpaceInsideBlockBraces, :config do
     end
 
     it 'registers an offense for empty braces with no space inside' do
-      inspect_source(cop, 'each {}')
-      expect(cop.messages).to eq(['Space missing inside empty braces.'])
-      expect(cop.highlights).to eq(['{}'])
+      expect_offense(<<-RUBY.strip_indent)
+        each {}
+             ^^ Space missing inside empty braces.
+      RUBY
     end
 
     it 'auto-corrects missing space' do

--- a/spec/rubocop/cop/layout/space_inside_brackets_spec.rb
+++ b/spec/rubocop/cop/layout/space_inside_brackets_spec.rb
@@ -70,10 +70,10 @@ describe RuboCop::Cop::Layout::SpaceInsideBrackets do
   end
 
   it 'only reports a single space once' do
-    inspect_source(cop, '[ ]')
-    expect(cop.messages).to eq(
-      ['Space inside square brackets detected.']
-    )
+    expect_offense(<<-RUBY.strip_indent)
+      [ ]
+       ^ Space inside square brackets detected.
+    RUBY
   end
 
   it 'auto-corrects unwanted space' do

--- a/spec/rubocop/cop/layout/space_inside_hash_literal_braces_spec.rb
+++ b/spec/rubocop/cop/layout/space_inside_hash_literal_braces_spec.rb
@@ -13,10 +13,10 @@ describe RuboCop::Cop::Layout::SpaceInsideHashLiteralBraces, :config do
     end
 
     it 'registers an offense for empty braces with space inside' do
-      inspect_source(cop, 'h = { }')
-      expect(cop.messages)
-        .to eq(['Space inside empty hash literal braces detected.'])
-      expect(cop.highlights).to eq([' '])
+      expect_offense(<<-RUBY.strip_indent)
+        h = { }
+             ^ Space inside empty hash literal braces detected.
+      RUBY
     end
 
     it 'auto-corrects unwanted space' do
@@ -34,10 +34,10 @@ describe RuboCop::Cop::Layout::SpaceInsideHashLiteralBraces, :config do
     end
 
     it 'registers an offense for empty braces with no space inside' do
-      inspect_source(cop, 'h = {}')
-      expect(cop.messages)
-        .to eq(['Space inside empty hash literal braces missing.'])
-      expect(cop.highlights).to eq(['{'])
+      expect_offense(<<-RUBY.strip_indent)
+        h = {}
+            ^ Space inside empty hash literal braces missing.
+      RUBY
     end
 
     it 'auto-corrects missing space' do
@@ -143,9 +143,10 @@ describe RuboCop::Cop::Layout::SpaceInsideHashLiteralBraces, :config do
     end
 
     it 'registers an offense for nested hashes with spaces' do
-      inspect_source(cop, 'h = { a: { a: 1, b: 2 } }')
-      expect(cop.offenses.size).to eq 1
-      expect(cop.messages).to eq(['Space inside } detected.'])
+      expect_offense(<<-RUBY.strip_indent)
+        h = { a: { a: 1, b: 2 } }
+                               ^ Space inside } detected.
+      RUBY
     end
 
     it 'registers an offense for opposite + correct' do
@@ -178,11 +179,14 @@ describe RuboCop::Cop::Layout::SpaceInsideHashLiteralBraces, :config do
     end
 
     it 'registers offenses for hashes with no spaces' do
-      inspect_source(cop, <<-END.strip_indent)
+      expect_offense(<<-RUBY.strip_indent)
         h = {a: 1, b: 2}
+                       ^ Space inside } missing.
+            ^ Space inside { missing.
         h = {a => 1}
-      END
-      expect(cop.offenses.size).to eq 4
+                   ^ Space inside } missing.
+            ^ Space inside { missing.
+      RUBY
     end
 
     it 'accepts multiline hash' do

--- a/spec/rubocop/cop/layout/tab_spec.rb
+++ b/spec/rubocop/cop/layout/tab_spec.rb
@@ -4,18 +4,24 @@ describe RuboCop::Cop::Layout::Tab do
   subject(:cop) { described_class.new }
 
   it 'registers an offense for a line indented with tab' do
-    inspect_source(cop, "\tx = 0")
-    expect(cop.offenses.size).to eq(1)
+    expect_offense(<<-RUBY.strip_indent)
+      	x = 0
+      ^ Tab detected.
+    RUBY
   end
 
   it 'registers an offense for a line indented with multiple tabs' do
-    inspect_source(cop, "\t\t\tx = 0")
-    expect(cop.offenses.size).to eq(1)
+    expect_offense(<<-RUBY.strip_indent)
+      			x = 0
+      ^^^ Tab detected.
+    RUBY
   end
 
   it 'registers an offense for a line indented with mixed whitespace' do
-    inspect_source(cop, " \tx = 0")
-    expect(cop.offenses.size).to eq(1)
+    expect_offense(<<-RUBY.strip_indent)
+       	x = 0
+       ^ Tab detected.
+    RUBY
   end
 
   it 'registers offenses before __END__ but not after' do

--- a/spec/rubocop/cop/lint/assignment_in_condition_spec.rb
+++ b/spec/rubocop/cop/lint/assignment_in_condition_spec.rb
@@ -5,67 +5,67 @@ describe RuboCop::Cop::Lint::AssignmentInCondition, :config do
   let(:cop_config) { { 'AllowSafeAssignment' => true } }
 
   it 'registers an offense for lvar assignment in condition' do
-    inspect_source(cop, <<-END.strip_indent)
+    expect_offense(<<-RUBY.strip_indent)
       if test = 10
+              ^ Assignment in condition - you probably meant to use `==`.
       end
-    END
-    expect(cop.offenses.size).to eq(1)
+    RUBY
   end
 
   it 'registers an offense for lvar assignment in while condition' do
-    inspect_source(cop, <<-END.strip_indent)
+    expect_offense(<<-RUBY.strip_indent)
       while test = 10
+                 ^ Assignment in condition - you probably meant to use `==`.
       end
-    END
-    expect(cop.offenses.size).to eq(1)
+    RUBY
   end
 
   it 'registers an offense for lvar assignment in until condition' do
-    inspect_source(cop, <<-END.strip_indent)
+    expect_offense(<<-RUBY.strip_indent)
       until test = 10
+                 ^ Assignment in condition - you probably meant to use `==`.
       end
-    END
-    expect(cop.offenses.size).to eq(1)
+    RUBY
   end
 
   it 'registers an offense for ivar assignment in condition' do
-    inspect_source(cop, <<-END.strip_indent)
+    expect_offense(<<-RUBY.strip_indent)
       if @test = 10
+               ^ Assignment in condition - you probably meant to use `==`.
       end
-    END
-    expect(cop.offenses.size).to eq(1)
+    RUBY
   end
 
   it 'registers an offense for clvar assignment in condition' do
-    inspect_source(cop, <<-END.strip_indent)
+    expect_offense(<<-RUBY.strip_indent)
       if @@test = 10
+                ^ Assignment in condition - you probably meant to use `==`.
       end
-    END
-    expect(cop.offenses.size).to eq(1)
+    RUBY
   end
 
   it 'registers an offense for gvar assignment in condition' do
-    inspect_source(cop, <<-END.strip_indent)
+    expect_offense(<<-RUBY.strip_indent)
       if $test = 10
+               ^ Assignment in condition - you probably meant to use `==`.
       end
-    END
-    expect(cop.offenses.size).to eq(1)
+    RUBY
   end
 
   it 'registers an offense for constant assignment in condition' do
-    inspect_source(cop, <<-END.strip_indent)
+    expect_offense(<<-RUBY.strip_indent)
       if TEST = 10
+              ^ Assignment in condition - you probably meant to use `==`.
       end
-    END
-    expect(cop.offenses.size).to eq(1)
+    RUBY
   end
 
   it 'registers an offense for collection element assignment in condition' do
-    inspect_source(cop, <<-END.strip_indent)
+    expect_offense(<<-RUBY.strip_indent)
       if a[3] = 10
+              ^ Assignment in condition - you probably meant to use `==`.
       end
-    END
-    expect(cop.offenses.size).to eq(1)
+    RUBY
   end
 
   it 'accepts == in condition' do
@@ -76,11 +76,11 @@ describe RuboCop::Cop::Lint::AssignmentInCondition, :config do
   end
 
   it 'registers an offense for assignment after == in condition' do
-    inspect_source(cop, <<-END.strip_indent)
+    expect_offense(<<-RUBY.strip_indent)
       if test == 10 || foobar = 1
+                              ^ Assignment in condition - you probably meant to use `==`.
       end
-    END
-    expect(cop.offenses.size).to eq(1)
+    RUBY
   end
 
   it 'accepts = in a block that is called in a condition' do
@@ -96,17 +96,18 @@ describe RuboCop::Cop::Lint::AssignmentInCondition, :config do
   end
 
   it 'registers an offense for assignment after ||= in condition' do
-    inspect_source(cop,
-                   'raise StandardError unless (foo ||= bar) || a = b')
-    expect(cop.offenses.size).to eq(1)
+    expect_offense(<<-RUBY.strip_indent)
+      raise StandardError unless (foo ||= bar) || a = b
+                                                    ^ Assignment in condition - you probably meant to use `==`.
+    RUBY
   end
 
   it 'registers an offense for assignment methods' do
-    inspect_source(cop, <<-END.strip_indent)
+    expect_offense(<<-RUBY.strip_indent)
       if test.method = 10
+                     ^ Assignment in condition - you probably meant to use `==`.
       end
-    END
-    expect(cop.offenses.size).to eq(1)
+    RUBY
   end
 
   it 'does not blow up for empty if condition' do
@@ -143,19 +144,19 @@ describe RuboCop::Cop::Lint::AssignmentInCondition, :config do
     let(:cop_config) { { 'AllowSafeAssignment' => false } }
 
     it 'does not accept = in condition surrounded with braces' do
-      inspect_source(cop, <<-END.strip_indent)
+      expect_offense(<<-RUBY.strip_indent)
         if (test = 10)
+                 ^ Assignment in condition - you probably meant to use `==`.
         end
-      END
-      expect(cop.offenses.size).to eq(1)
+      RUBY
     end
 
     it 'does not accept []= in condition surrounded with braces' do
-      inspect_source(cop, <<-END.strip_indent)
+      expect_offense(<<-RUBY.strip_indent)
         if (test[0] = 10)
+                    ^ Assignment in condition - you probably meant to use `==`.
         end
-      END
-      expect(cop.offenses.size).to eq(1)
+      RUBY
     end
   end
 end

--- a/spec/rubocop/cop/lint/block_alignment_spec.rb
+++ b/spec/rubocop/cop/lint/block_alignment_spec.rb
@@ -521,13 +521,14 @@ describe RuboCop::Cop::Lint::BlockAlignment, :config do
 
   context 'when multiple similar-looking blocks have misaligned ends' do
     it 'registers an offense for each of them' do
-      inspect_source(cop, <<-END.strip_indent)
+      expect_offense(<<-RUBY.strip_indent)
         a = test do
          end
+         ^^^ `end` at 2, 1 is not aligned with `a = test do` at 1, 0.
         b = test do
          end
-      END
-      expect(cop.offenses.size).to eq 2
+         ^^^ `end` at 4, 1 is not aligned with `b = test do` at 3, 0.
+      RUBY
     end
   end
 

--- a/spec/rubocop/cop/lint/condition_position_spec.rb
+++ b/spec/rubocop/cop/lint/condition_position_spec.rb
@@ -5,11 +5,12 @@ describe RuboCop::Cop::Lint::ConditionPosition do
 
   %w[if unless while until].each do |keyword|
     it 'registers an offense for condition on the next line' do
-      inspect_source(cop,
-                     [keyword,
-                      'x == 10',
-                      'end'])
-      expect(cop.offenses.size).to eq(1)
+      expect_offense(<<-RUBY.strip_indent)
+        #{keyword}
+        x == 10
+        ^^^^^^^ Place the condition on the same line as `#{keyword}`.
+        end
+      RUBY
     end
 
     it 'accepts condition on the same line' do
@@ -29,15 +30,15 @@ describe RuboCop::Cop::Lint::ConditionPosition do
   end
 
   it 'registers an offense for elsif condition on the next line' do
-    inspect_source(cop, <<-END.strip_indent)
+    expect_offense(<<-RUBY.strip_indent)
       if something
         test
       elsif
         something
+        ^^^^^^^^^ Place the condition on the same line as `elsif`.
         test
       end
-    END
-    expect(cop.offenses.size).to eq(1)
+    RUBY
   end
 
   it 'handles ternary ops' do

--- a/spec/rubocop/cop/lint/debugger_spec.rb
+++ b/spec/rubocop/cop/lint/debugger_spec.rb
@@ -34,13 +34,12 @@ describe RuboCop::Cop::Lint::Debugger, :config do
   end
 
   it 'reports an offense for a Pry.rescue call' do
-    inspect_source(cop, <<-END.strip_indent)
+    expect_offense(<<-RUBY.strip_indent)
       def method
         Pry.rescue { puts 1 }
+        ^^^^^^^^^^ Remove debugger entry point `Pry.rescue`.
       end
-    END
-    expect(cop.offenses.size).to eq(1)
-    expect(cop.messages).to eq(['Remove debugger entry point `Pry.rescue`.'])
+    RUBY
   end
 
   context 'target_ruby_version >= 2.4', :ruby24 do

--- a/spec/rubocop/cop/lint/deprecated_class_methods_spec.rb
+++ b/spec/rubocop/cop/lint/deprecated_class_methods_spec.rb
@@ -4,17 +4,17 @@ describe RuboCop::Cop::Lint::DeprecatedClassMethods do
   subject(:cop) { described_class.new }
 
   it 'registers an offense for File.exists?' do
-    inspect_source(cop, 'File.exists?(o)')
-    expect(cop.offenses.size).to eq(1)
-    expect(cop.messages)
-      .to eq(['`File.exists?` is deprecated in favor of `File.exist?`.'])
+    expect_offense(<<-RUBY.strip_indent)
+      File.exists?(o)
+           ^^^^^^^ `File.exists?` is deprecated in favor of `File.exist?`.
+    RUBY
   end
 
   it 'registers an offense for ::File.exists?' do
-    inspect_source(cop, '::File.exists?(o)')
-    expect(cop.offenses.size).to eq(1)
-    expect(cop.messages)
-      .to eq(['`File.exists?` is deprecated in favor of `File.exist?`.'])
+    expect_offense(<<-RUBY.strip_indent)
+      ::File.exists?(o)
+             ^^^^^^^ `File.exists?` is deprecated in favor of `File.exist?`.
+    RUBY
   end
 
   it 'does not register an offense for File.exist?' do
@@ -23,10 +23,10 @@ describe RuboCop::Cop::Lint::DeprecatedClassMethods do
   end
 
   it 'registers an offense for Dir.exists?' do
-    inspect_source(cop, 'Dir.exists?(o)')
-    expect(cop.offenses.size).to eq(1)
-    expect(cop.messages)
-      .to eq(['`Dir.exists?` is deprecated in favor of `Dir.exist?`.'])
+    expect_offense(<<-RUBY.strip_indent)
+      Dir.exists?(o)
+          ^^^^^^^ `Dir.exists?` is deprecated in favor of `Dir.exist?`.
+    RUBY
   end
 
   it 'auto-corrects File.exists? with File.exist?' do

--- a/spec/rubocop/cop/lint/duplicate_case_condition_spec.rb
+++ b/spec/rubocop/cop/lint/duplicate_case_condition_spec.rb
@@ -4,69 +4,71 @@ describe RuboCop::Cop::Lint::DuplicateCaseCondition do
   subject(:cop) { described_class.new }
 
   it 'registers an offense for repeated case conditionals' do
-    inspect_source(cop, <<-END.strip_indent)
+    expect_offense(<<-RUBY.strip_indent)
       case x
       when false
         first_method
       when true
         second_method
       when false
+           ^^^^^ Duplicate `when` condition detected.
         third_method
       end
-    END
-    expect(cop.offenses.size).to eq(1)
+    RUBY
   end
 
   it 'registers an offense for subsequent repeated case conditionals' do
-    inspect_source(cop, <<-END.strip_indent)
+    expect_offense(<<-RUBY.strip_indent)
       case x
       when false
         first_method
       when false
+           ^^^^^ Duplicate `when` condition detected.
         second_method
       end
-    END
-    expect(cop.offenses.size).to eq(1)
+    RUBY
   end
 
   it 'registers multiple offenses for multiple repeated case conditionals' do
-    inspect_source(cop, <<-END.strip_indent)
+    expect_offense(<<-RUBY.strip_indent)
       case x
       when false
         first_method
       when true
         second_method
       when false
+           ^^^^^ Duplicate `when` condition detected.
         third_method
       when true
+           ^^^^ Duplicate `when` condition detected.
         fourth_method
       end
-    END
-    expect(cop.offenses.size).to eq(2)
+    RUBY
   end
 
   it 'registers multiple offenses for repeated multi-value condtionals' do
-    inspect_source(cop, <<-END.strip_indent)
+    expect_offense(<<-RUBY.strip_indent)
       case x
       when a, b
         first_method
       when b, a
+              ^ Duplicate `when` condition detected.
+           ^ Duplicate `when` condition detected.
         second_method
       end
-    END
-    expect(cop.offenses.size).to eq(2)
+    RUBY
   end
 
   it 'registers an offense for repeated logical operator when expressions' do
-    inspect_source(cop, <<-END.strip_indent)
+    expect_offense(<<-RUBY.strip_indent)
       case x
       when a && b
         first_method
       when a && b
+           ^^^^^^ Duplicate `when` condition detected.
         second_method
       end
-    END
-    expect(cop.offenses.size).to eq(1)
+    RUBY
   end
 
   it 'accepts trivial case expressions' do

--- a/spec/rubocop/cop/lint/each_with_object_argument_spec.rb
+++ b/spec/rubocop/cop/lint/each_with_object_argument_spec.rb
@@ -11,14 +11,17 @@ describe RuboCop::Cop::Lint::EachWithObjectArgument do
   end
 
   it 'registers an offense for float argument' do
-    inspect_source(cop, 'collection.each_with_object(0.1) { |e, a| a + e }')
-    expect(cop.offenses.size).to eq(1)
+    expect_offense(<<-RUBY.strip_indent)
+      collection.each_with_object(0.1) { |e, a| a + e }
+      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ The argument to each_with_object can not be immutable.
+    RUBY
   end
 
   it 'registers an offense for bignum argument' do
-    inspect_source(cop,
-                   'c.each_with_object(100000000000000000000) { |e, o| o + e }')
-    expect(cop.offenses.size).to eq(1)
+    expect_offense(<<-RUBY.strip_indent)
+      c.each_with_object(100000000000000000000) { |e, o| o + e }
+      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ The argument to each_with_object can not be immutable.
+    RUBY
   end
 
   it 'accepts a variable argument' do

--- a/spec/rubocop/cop/lint/else_layout_spec.rb
+++ b/spec/rubocop/cop/lint/else_layout_spec.rb
@@ -4,15 +4,15 @@ describe RuboCop::Cop::Lint::ElseLayout do
   subject(:cop) { described_class.new }
 
   it 'registers an offense for expr on same line as else' do
-    inspect_source(cop, <<-END.strip_indent)
+    expect_offense(<<-RUBY.strip_indent)
       if something
         test
       else ala
+           ^^^ Odd `else` layout detected. Did you mean to use `elsif`?
         something
         test
       end
-    END
-    expect(cop.offenses.size).to eq(1)
+    RUBY
   end
 
   it 'accepts proper else' do
@@ -36,17 +36,17 @@ describe RuboCop::Cop::Lint::ElseLayout do
   end
 
   it 'can handle elsifs' do
-    inspect_source(cop, <<-END.strip_indent)
+    expect_offense(<<-RUBY.strip_indent)
       if something
         test
       elsif something
         bala
       else ala
+           ^^^ Odd `else` layout detected. Did you mean to use `elsif`?
         something
         test
       end
-    END
-    expect(cop.offenses.size).to eq(1)
+    RUBY
   end
 
   it 'handles ternary ops' do

--- a/spec/rubocop/cop/lint/empty_ensure_spec.rb
+++ b/spec/rubocop/cop/lint/empty_ensure_spec.rb
@@ -4,13 +4,13 @@ describe RuboCop::Cop::Lint::EmptyEnsure do
   subject(:cop) { described_class.new }
 
   it 'registers an offense for empty ensure' do
-    inspect_source(cop, <<-END.strip_indent)
+    expect_offense(<<-RUBY.strip_indent)
       begin
         something
       ensure
+      ^^^^^^ Empty `ensure` block detected.
       end
-    END
-    expect(cop.offenses.size).to eq(1)
+    RUBY
   end
 
   it 'autocorrects for empty ensure' do

--- a/spec/rubocop/cop/lint/empty_interpolation_spec.rb
+++ b/spec/rubocop/cop/lint/empty_interpolation_spec.rb
@@ -4,15 +4,17 @@ describe RuboCop::Cop::Lint::EmptyInterpolation do
   subject(:cop) { described_class.new }
 
   it 'registers an offense for #{} in interpolation' do
-    inspect_source(cop, '"this is the #{}"')
-    expect(cop.offenses.size).to eq(1)
-    expect(cop.highlights).to eq(['#{}'])
+    expect_offense(<<-'RUBY'.strip_indent)
+      "this is the #{}"
+                   ^^^ Empty interpolation detected.
+    RUBY
   end
 
   it 'registers an offense for #{ } in interpolation' do
-    inspect_source(cop, '"this is the #{ }"')
-    expect(cop.offenses.size).to eq(1)
-    expect(cop.highlights).to eq(['#{ }'])
+    expect_offense(<<-'RUBY'.strip_indent)
+      "this is the #{ }"
+                   ^^^^ Empty interpolation detected.
+    RUBY
   end
 
   it 'accepts non-empty interpolation' do

--- a/spec/rubocop/cop/lint/ensure_return_spec.rb
+++ b/spec/rubocop/cop/lint/ensure_return_spec.rb
@@ -4,15 +4,15 @@ describe RuboCop::Cop::Lint::EnsureReturn do
   subject(:cop) { described_class.new }
 
   it 'registers an offense for return in ensure' do
-    inspect_source(cop, <<-END.strip_indent)
+    expect_offense(<<-RUBY.strip_indent)
       begin
         something
       ensure
         file.close
         return
+        ^^^^^^ Do not return from an `ensure` block.
       end
-    END
-    expect(cop.offenses.size).to eq(1)
+    RUBY
   end
 
   it 'does not register an offense for return outside ensure' do

--- a/spec/rubocop/cop/lint/float_out_of_range_spec.rb
+++ b/spec/rubocop/cop/lint/float_out_of_range_spec.rb
@@ -3,10 +3,6 @@
 describe RuboCop::Cop::Lint::FloatOutOfRange do
   subject(:cop) { described_class.new }
 
-  before do
-    inspect_source(cop, source)
-  end
-
   context 'on 0.0' do
     let(:source) { '0.0' }
 
@@ -35,8 +31,10 @@ describe RuboCop::Cop::Lint::FloatOutOfRange do
     let(:source) { '9.9999e999' }
 
     it 'registers an offense' do
-      expect(cop.offenses.size).to eq(1)
-      expect(cop.messages).to eq(['Float out of range.'])
+      expect_offense(<<-RUBY.strip_indent)
+        9.9999e999
+        ^^^^^^^^^^ Float out of range.
+      RUBY
     end
   end
 
@@ -44,8 +42,10 @@ describe RuboCop::Cop::Lint::FloatOutOfRange do
     let(:source) { '1.0e-400' }
 
     it 'registers an offense' do
-      expect(cop.offenses.size).to eq(1)
-      expect(cop.messages).to eq(['Float out of range.'])
+      expect_offense(<<-RUBY.strip_indent)
+        1.0e-400
+        ^^^^^^^^ Float out of range.
+      RUBY
     end
   end
 end

--- a/spec/rubocop/cop/lint/handle_exceptions_spec.rb
+++ b/spec/rubocop/cop/lint/handle_exceptions_spec.rb
@@ -4,16 +4,14 @@ describe RuboCop::Cop::Lint::HandleExceptions do
   subject(:cop) { described_class.new }
 
   it 'registers an offense for empty rescue block' do
-    inspect_source(cop, <<-END.strip_indent)
+    expect_offense(<<-RUBY.strip_indent)
       begin
         something
       rescue
+      ^^^^^^ Do not suppress exceptions.
         #do nothing
       end
-    END
-    expect(cop.offenses.size).to eq(1)
-    expect(cop.messages)
-      .to eq(['Do not suppress exceptions.'])
+    RUBY
   end
 
   it 'does not register an offense for rescue with body' do

--- a/spec/rubocop/cop/lint/ineffective_access_modifier_spec.rb
+++ b/spec/rubocop/cop/lint/ineffective_access_modifier_spec.rb
@@ -3,10 +3,6 @@
 describe RuboCop::Cop::Lint::IneffectiveAccessModifier do
   subject(:cop) { described_class.new }
 
-  before do
-    inspect_source(cop, source)
-  end
-
   context 'when `private` is applied to a class method' do
     let(:source) do
       <<-END.strip_indent
@@ -21,13 +17,16 @@ describe RuboCop::Cop::Lint::IneffectiveAccessModifier do
     end
 
     it 'registers an offense' do
-      expect(cop.offenses.size).to eq(1)
-      expect(cop.messages).to eq(
-        ['`private` (on line 2) does not make singleton methods private. ' \
-         'Use `private_class_method` or `private` inside a `class << self` ' \
-         'block instead.']
-      )
-      expect(cop.highlights).to eq(['def'])
+      expect_offense(<<-RUBY.strip_indent)
+        class C
+          private
+
+          def self.method
+          ^^^ `private` (on line 2) does not make singleton methods private. Use `private_class_method` or `private` inside a `class << self` block instead.
+            puts "hi"
+          end
+        end
+      RUBY
     end
   end
 
@@ -45,12 +44,16 @@ describe RuboCop::Cop::Lint::IneffectiveAccessModifier do
     end
 
     it 'registers an offense' do
-      expect(cop.offenses.size).to eq(1)
-      expect(cop.messages).to eq(
-        ['`protected` (on line 2) does not make singleton methods protected. ' \
-         'Use `protected` inside a `class << self` block instead.']
-      )
-      expect(cop.highlights).to eq(['def'])
+      expect_offense(<<-RUBY.strip_indent)
+        class C
+          protected
+
+          def self.method
+          ^^^ `protected` (on line 2) does not make singleton methods protected. Use `protected` inside a `class << self` block instead.
+            puts "hi"
+          end
+        end
+      RUBY
     end
   end
 
@@ -112,13 +115,20 @@ describe RuboCop::Cop::Lint::IneffectiveAccessModifier do
     end
 
     it 'still registers an offense' do
-      expect(cop.offenses.size).to eq(1)
-      expect(cop.messages).to eq(
-        ['`private` (on line 3) does not make singleton methods private. ' \
-         'Use `private_class_method` or `private` inside a `class << self` ' \
-         'block instead.']
-      )
-      expect(cop.highlights).to eq(['def'])
+      expect_offense(<<-RUBY.strip_indent)
+        class C
+
+          private
+
+          def instance_method
+          end
+
+          def self.method
+          ^^^ `private` (on line 3) does not make singleton methods private. Use `private_class_method` or `private` inside a `class << self` block instead.
+            puts "hi"
+          end
+        end
+      RUBY
     end
   end
 end

--- a/spec/rubocop/cop/lint/literal_in_condition_spec.rb
+++ b/spec/rubocop/cop/lint/literal_in_condition_spec.rb
@@ -150,12 +150,12 @@ describe RuboCop::Cop::Lint::LiteralInCondition do
   end
 
   it 'registers an offense for case with a primitive array condition' do
-    inspect_source(cop, <<-END.strip_indent)
+    expect_offense(<<-RUBY.strip_indent)
       case [1, 2, [3, 4]]
+           ^^^^^^^^^^^^^^ Literal `[1, 2, [3, 4]]` appeared in a condition.
       when [1, 2, 5] then top
       end
-    END
-    expect(cop.offenses.size).to eq(1)
+    RUBY
   end
 
   it 'accepts dstr literal in case' do

--- a/spec/rubocop/cop/lint/loop_spec.rb
+++ b/spec/rubocop/cop/lint/loop_spec.rb
@@ -4,13 +4,17 @@ describe RuboCop::Cop::Lint::Loop do
   subject(:cop) { described_class.new }
 
   it 'registers an offense for begin/end/while' do
-    inspect_source(cop, 'begin something; top; end while test')
-    expect(cop.offenses.size).to eq(1)
+    expect_offense(<<-RUBY.strip_indent)
+      begin something; top; end while test
+                                ^^^^^ Use `Kernel#loop` with `break` rather than `begin/end/until`(or `while`).
+    RUBY
   end
 
   it 'registers an offense for begin/end/until' do
-    inspect_source(cop, 'begin something; top; end until test')
-    expect(cop.offenses.size).to eq(1)
+    expect_offense(<<-RUBY.strip_indent)
+      begin something; top; end until test
+                                ^^^^^ Use `Kernel#loop` with `break` rather than `begin/end/until`(or `while`).
+    RUBY
   end
 
   it 'accepts normal while' do

--- a/spec/rubocop/cop/lint/nested_method_definition_spec.rb
+++ b/spec/rubocop/cop/lint/nested_method_definition_spec.rb
@@ -4,8 +4,10 @@ describe RuboCop::Cop::Lint::NestedMethodDefinition do
   subject(:cop) { described_class.new }
 
   it 'registers an offense for a nested method definition' do
-    inspect_source(cop, 'def x; def y; end; end')
-    expect(cop.offenses.size).to eq(1)
+    expect_offense(<<-RUBY.strip_indent)
+      def x; def y; end; end
+             ^^^^^^^^^^ Method definitions must not be nested. Use `lambda` instead.
+    RUBY
   end
 
   it 'registers an offense for a nested singleton method definition' do
@@ -22,12 +24,12 @@ describe RuboCop::Cop::Lint::NestedMethodDefinition do
   end
 
   it 'registers an offense for a nested method definition inside lambda' do
-    inspect_source(cop, <<-END.strip_indent)
+    expect_offense(<<-RUBY.strip_indent)
       def foo
         bar = -> { def baz; puts; end }
+                   ^^^^^^^^^^^^^^^^^^ Method definitions must not be nested. Use `lambda` instead.
       end
-    END
-    expect(cop.offenses.size).to eq(1)
+    RUBY
   end
 
   it 'registers an offense for a nested class method definition' do

--- a/spec/rubocop/cop/lint/parentheses_as_grouped_expression_spec.rb
+++ b/spec/rubocop/cop/lint/parentheses_as_grouped_expression_spec.rb
@@ -16,8 +16,10 @@ describe RuboCop::Cop::Lint::ParenthesesAsGroupedExpression do
   end
 
   it 'registers an offense for math expression' do
-    inspect_source(cop, 'puts (2 + 3) * 4')
-    expect(cop.offenses.size).to eq(1)
+    expect_offense(<<-RUBY.strip_indent)
+      puts (2 + 3) * 4
+          ^ `(...)` interpreted as grouped expression.
+    RUBY
   end
 
   it 'accepts a method call without arguments' do

--- a/spec/rubocop/cop/lint/rescue_exception_spec.rb
+++ b/spec/rubocop/cop/lint/rescue_exception_spec.rb
@@ -4,47 +4,47 @@ describe RuboCop::Cop::Lint::RescueException do
   subject(:cop) { described_class.new }
 
   it 'registers an offense for rescue from Exception' do
-    inspect_source(cop, <<-END.strip_indent)
+    expect_offense(<<-RUBY.strip_indent)
       begin
         something
       rescue Exception
+      ^^^^^^^^^^^^^^^^ Avoid rescuing the `Exception` class. Perhaps you meant to rescue `StandardError`?
         #do nothing
       end
-    END
-    expect(cop.offenses.size).to eq(1)
+    RUBY
   end
 
   it 'registers an offense for rescue with ::Exception' do
-    inspect_source(cop, <<-END.strip_indent)
+    expect_offense(<<-RUBY.strip_indent)
       begin
         something
       rescue ::Exception
+      ^^^^^^^^^^^^^^^^^^ Avoid rescuing the `Exception` class. Perhaps you meant to rescue `StandardError`?
         #do nothing
       end
-    END
-    expect(cop.offenses.size).to eq(1)
+    RUBY
   end
 
   it 'registers an offense for rescue with StandardError, Exception' do
-    inspect_source(cop, <<-END.strip_indent)
+    expect_offense(<<-RUBY.strip_indent)
       begin
         something
       rescue StandardError, Exception
+      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Avoid rescuing the `Exception` class. Perhaps you meant to rescue `StandardError`?
         #do nothing
       end
-    END
-    expect(cop.offenses.size).to eq(1)
+    RUBY
   end
 
   it 'registers an offense for rescue with Exception => e' do
-    inspect_source(cop, <<-END.strip_indent)
+    expect_offense(<<-RUBY.strip_indent)
       begin
         something
       rescue Exception => e
+      ^^^^^^^^^^^^^^^^^^^^^ Avoid rescuing the `Exception` class. Perhaps you meant to rescue `StandardError`?
         #do nothing
       end
-    END
-    expect(cop.offenses.size).to eq(1)
+    RUBY
   end
 
   it 'does not register an offense for rescue with no class' do

--- a/spec/rubocop/cop/lint/shadowed_exception_spec.rb
+++ b/spec/rubocop/cop/lint/shadowed_exception_spec.rb
@@ -137,45 +137,37 @@ describe RuboCop::Cop::Lint::ShadowedException do
 
     context 'when there are multiple levels of exceptions in the same rescue' do
       it 'registers an offense for two exceptions' do
-        inspect_source(cop, <<-END.strip_indent)
+        expect_offense(<<-RUBY.strip_indent)
           begin
             something
           rescue StandardError, NameError
+          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Do not shadow rescued Exceptions.
             foo
           end
-        END
-
-        expect(cop.messages).to eq(['Do not shadow rescued Exceptions.'])
-        expect(cop.highlights).to eq(['rescue StandardError, NameError'])
+        RUBY
       end
 
       it 'registers an offense for more than two exceptions' do
-        inspect_source(cop, <<-END.strip_indent)
+        expect_offense(<<-RUBY.strip_indent)
           begin
             something
           rescue StandardError, NameError, NoMethodError
+          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Do not shadow rescued Exceptions.
             foo
           end
-        END
-
-        expect(cop.messages).to eq(['Do not shadow rescued Exceptions.'])
-        expect(cop.highlights)
-          .to eq(['rescue StandardError, NameError, NoMethodError'])
+        RUBY
       end
     end
 
     it 'registers an offense for the same exception multiple times' do
-      inspect_source(cop, <<-END.strip_indent)
+      expect_offense(<<-RUBY.strip_indent)
         begin
           something
         rescue NameError, NameError
+        ^^^^^^^^^^^^^^^^^^^^^^^^^^^ Do not shadow rescued Exceptions.
           foo
         end
-      END
-
-      expect(cop.messages).to eq(['Do not shadow rescued Exceptions.'])
-      expect(cop.highlights)
-        .to eq(['rescue NameError, NameError'])
+      RUBY
     end
 
     it 'accepts splat arguments passed to rescue' do

--- a/spec/rubocop/cop/lint/string_conversion_in_interpolation_spec.rb
+++ b/spec/rubocop/cop/lint/string_conversion_in_interpolation_spec.rb
@@ -4,15 +4,17 @@ describe RuboCop::Cop::Lint::StringConversionInInterpolation do
   subject(:cop) { described_class.new }
 
   it 'registers an offense for #to_s in interpolation' do
-    inspect_source(cop, '"this is the #{result.to_s}"')
-    expect(cop.offenses.size).to eq(1)
-    expect(cop.messages)
-      .to eq(['Redundant use of `Object#to_s` in interpolation.'])
+    expect_offense(<<-'RUBY'.strip_indent)
+      "this is the #{result.to_s}"
+                            ^^^^ Redundant use of `Object#to_s` in interpolation.
+    RUBY
   end
 
   it 'detects #to_s in an interpolation with several expressions' do
-    inspect_source(cop, '"this is the #{top; result.to_s}"')
-    expect(cop.offenses.size).to eq(1)
+    expect_offense(<<-'RUBY'.strip_indent)
+      "this is the #{top; result.to_s}"
+                                 ^^^^ Redundant use of `Object#to_s` in interpolation.
+    RUBY
   end
 
   it 'accepts #to_s with arguments in an interpolation' do
@@ -24,10 +26,10 @@ describe RuboCop::Cop::Lint::StringConversionInInterpolation do
   end
 
   it 'does not explode on implicit receiver' do
-    inspect_source(cop, '"#{to_s}"')
-    expect(cop.offenses.size).to eq(1)
-    expect(cop.messages)
-      .to eq(['Use `self` instead of `Object#to_s` in interpolation.'])
+    expect_offense(<<-'RUBY'.strip_indent)
+      "#{to_s}"
+         ^^^^ Use `self` instead of `Object#to_s` in interpolation.
+    RUBY
   end
 
   it 'does not explode on empty interpolation' do

--- a/spec/rubocop/cop/lint/unneeded_splat_expansion_spec.rb
+++ b/spec/rubocop/cop/lint/unneeded_splat_expansion_spec.rb
@@ -77,48 +77,42 @@ describe RuboCop::Cop::Lint::UnneededSplatExpansion do
 
   context 'assignment to splat expansion' do
     it 'registers an offense for an array using a constructor' do
-      inspect_source(cop, 'a = *Array.new(3) { 42 }')
-
-      expect(cop.messages).to eq([message])
-      expect(cop.highlights).to eq(['*Array.new(3) { 42 }'])
+      expect_offense(<<-RUBY.strip_indent)
+        a = *Array.new(3) { 42 }
+            ^^^^^^^^^^^^^^^^^^^^ Unnecessary splat expansion.
+      RUBY
     end
   end
 
   context 'expanding an array literal in a when condition' do
     it 'registers an offense for an array using []' do
-      inspect_source(cop, <<-END.strip_indent)
+      expect_offense(<<-RUBY.strip_indent)
         case foo
         when *[first, second]
+             ^^^^^^^^^^^^^^^^ Unnecessary splat expansion.
           bar
         end
-      END
-
-      expect(cop.messages).to eq([message])
-      expect(cop.highlights).to eq(['*[first, second]'])
+      RUBY
     end
 
     it 'registers an offense for an array using %w' do
-      inspect_source(cop, <<-END.strip_indent)
+      expect_offense(<<-RUBY.strip_indent)
         case foo
         when *%w(first second)
+             ^^^^^^^^^^^^^^^^^ Unnecessary splat expansion.
           bar
         end
-      END
-
-      expect(cop.messages).to eq([message])
-      expect(cop.highlights).to eq(['*%w(first second)'])
+      RUBY
     end
 
     it 'registers an offense for an array using %W' do
-      inspect_source(cop, <<-'END'.strip_indent)
+      expect_offense(<<-'RUBY'.strip_indent)
         case foo
         when *%W(#{first} second)
+             ^^^^^^^^^^^^^^^^^^^^ Unnecessary splat expansion.
           bar
         end
-      END
-
-      expect(cop.messages).to eq([message])
-      expect(cop.highlights).to eq(['*%W(#{first} second)'])
+      RUBY
     end
 
     it 'allows an array that is assigned to a variable' do
@@ -142,16 +136,14 @@ describe RuboCop::Cop::Lint::UnneededSplatExpansion do
   end
 
   it 'registers an offense for an array literal being expanded in a rescue' do
-    inspect_source(cop, <<-END.strip_indent)
+    expect_offense(<<-RUBY.strip_indent)
       begin
         foo
       rescue *[First, Second]
+             ^^^^^^^^^^^^^^^^ Unnecessary splat expansion.
         bar
       end
-    END
-
-    expect(cop.messages).to eq([message])
-    expect(cop.highlights).to eq(['*[First, Second]'])
+    RUBY
   end
 
   it 'allows expansions of an array that is assigned to a variable in rescue' do
@@ -366,17 +358,17 @@ describe RuboCop::Cop::Lint::UnneededSplatExpansion do
 
       context 'splat expansion of method parameters' do
         it 'registers an offense for an array literal %i' do
-          inspect_source(cop, 'array.push(*%i(first second))')
-
-          expect(cop.messages).to eq([array_param_message])
-          expect(cop.highlights).to eq(['*%i(first second)'])
+          expect_offense(<<-RUBY.strip_indent)
+            array.push(*%i(first second))
+                       ^^^^^^^^^^^^^^^^^ Pass array contents as separate arguments.
+          RUBY
         end
 
         it 'registers an offense for an array literal %I' do
-          inspect_source(cop, 'array.push(*%I(#{first} second))')
-
-          expect(cop.messages).to eq([array_param_message])
-          expect(cop.highlights).to eq(['*%I(#{first} second)'])
+          expect_offense(<<-'RUBY'.strip_indent)
+            array.push(*%I(#{first} second))
+                       ^^^^^^^^^^^^^^^^^^^^ Pass array contents as separate arguments.
+          RUBY
         end
       end
 

--- a/spec/rubocop/cop/lint/unused_block_argument_spec.rb
+++ b/spec/rubocop/cop/lint/unused_block_argument_spec.rb
@@ -352,8 +352,10 @@ describe RuboCop::Cop::Lint::UnusedBlockArgument, :config do
     end
 
     it 'registers an offense for a non-empty block with an unused parameter' do
-      inspect_source(cop, '->(arg) { 1 }')
-      expect(cop.offenses.size).to eq 1
+      expect_offense(<<-RUBY.strip_indent)
+        ->(arg) { 1 }
+           ^^^ Unused block argument - `arg`. If it's necessary, use `_` or `_arg` as an argument name to indicate that it won't be used. Also consider using a proc without arguments instead of a lambda if you want it to accept any arguments but don't care about them.
+      RUBY
     end
 
     it 'accepts an empty block with multiple unused parameters' do
@@ -361,8 +363,12 @@ describe RuboCop::Cop::Lint::UnusedBlockArgument, :config do
     end
 
     it 'registers an offense for a non-empty block with multiple unused args' do
-      inspect_source(cop, '->(arg1, arg2, *others) { 1 }')
-      expect(cop.offenses.size).to eq 3
+      expect_offense(<<-RUBY.strip_indent)
+        ->(arg1, arg2, *others) { 1 }
+                        ^^^^^^ Unused block argument - `others`. If it's necessary, use `_` or `_others` as an argument name to indicate that it won't be used. Also consider using a proc without arguments instead of a lambda if you want it to accept any arguments but don't care about them.
+                 ^^^^ Unused block argument - `arg2`. If it's necessary, use `_` or `_arg2` as an argument name to indicate that it won't be used. Also consider using a proc without arguments instead of a lambda if you want it to accept any arguments but don't care about them.
+           ^^^^ Unused block argument - `arg1`. If it's necessary, use `_` or `_arg1` as an argument name to indicate that it won't be used. Also consider using a proc without arguments instead of a lambda if you want it to accept any arguments but don't care about them.
+      RUBY
     end
   end
 end

--- a/spec/rubocop/cop/lint/useless_access_modifier_spec.rb
+++ b/spec/rubocop/cop/lint/useless_access_modifier_spec.rb
@@ -211,8 +211,13 @@ describe RuboCop::Cop::Lint::UselessAccessModifier do
       end
 
       it 'registers an offense' do
-        inspect_source(cop, source)
-        expect(cop.offenses.size).to eq(1)
+        expect_offense(<<-RUBY.strip_indent)
+          class SomeClass
+            private
+            ^^^^^^^ Useless `private` access modifier.
+            #{binding_name} = 1
+          end
+        RUBY
       end
     end
   end

--- a/spec/rubocop/cop/lint/useless_comparison_spec.rb
+++ b/spec/rubocop/cop/lint/useless_comparison_spec.rb
@@ -22,7 +22,9 @@ describe RuboCop::Cop::Lint::UselessComparison do
   end
 
   it 'works with lambda.()' do
-    inspect_source(cop, 'a.(x) > a.(x)')
-    expect(cop.offenses.size).to eq(1)
+    expect_offense(<<-RUBY.strip_indent)
+      a.(x) > a.(x)
+            ^ Comparison of something with itself detected.
+    RUBY
   end
 end

--- a/spec/rubocop/cop/lint/useless_setter_call_spec.rb
+++ b/spec/rubocop/cop/lint/useless_setter_call_spec.rb
@@ -5,41 +5,37 @@ describe RuboCop::Cop::Lint::UselessSetterCall do
 
   context 'with method ending with setter call on local object' do
     it 'registers an offense' do
-      inspect_source(cop, <<-END.strip_indent)
+      expect_offense(<<-RUBY.strip_indent)
         def test
           top = Top.new
           top.attr = 5
+          ^^^ Useless setter call to local variable `top`.
         end
-      END
-      expect(cop.offenses.size).to eq(1)
-      expect(cop.messages)
-        .to eq(['Useless setter call to local variable `top`.'])
+      RUBY
     end
   end
 
   context 'with singleton method ending with setter call on local object' do
     it 'registers an offense' do
-      inspect_source(cop, <<-END.strip_indent)
+      expect_offense(<<-RUBY.strip_indent)
         def Top.test
           top = Top.new
           top.attr = 5
+          ^^^ Useless setter call to local variable `top`.
         end
-      END
-      expect(cop.offenses.size).to eq(1)
+      RUBY
     end
   end
 
   context 'with method ending with square bracket setter on local object' do
     it 'registers an offense' do
-      inspect_source(cop, <<-END.strip_indent)
+      expect_offense(<<-RUBY.strip_indent)
         def test
           top = Top.new
           top[:attr] = 5
+          ^^^ Useless setter call to local variable `top`.
         end
-      END
-      expect(cop.offenses.size).to eq(1)
-      expect(cop.messages)
-        .to eq(['Useless setter call to local variable `top`.'])
+      RUBY
     end
   end
 
@@ -106,13 +102,13 @@ describe RuboCop::Cop::Lint::UselessSetterCall do
   context 'when a lvar does not contain any object passed as argument ' \
           'with multiple-assignment at the end of the method' do
     it 'registers an offense' do
-      inspect_source(cop, <<-END.strip_indent)
+      expect_offense(<<-RUBY.strip_indent)
         def test(some_arg)
           _first, some_lvar, _third  = do_something
           some_lvar.attr = 5
+          ^^^^^^^^^ Useless setter call to local variable `some_lvar`.
         end
-      END
-      expect(cop.offenses.size).to eq(1)
+      RUBY
     end
   end
 
@@ -132,39 +128,39 @@ describe RuboCop::Cop::Lint::UselessSetterCall do
   context 'when a lvar does not contain any object passed as argument ' \
           'by binary-operator-assignment at the end of the method' do
     it 'registers an offense' do
-      inspect_source(cop, <<-END.strip_indent)
+      expect_offense(<<-RUBY.strip_indent)
         def test(some_arg)
           some_lvar = some_arg
           some_lvar += some_arg
           some_lvar.attr = 5
+          ^^^^^^^^^ Useless setter call to local variable `some_lvar`.
         end
-      END
-      expect(cop.offenses.size).to eq(1)
+      RUBY
     end
   end
 
   context 'when a lvar declared as an argument ' \
           'is no longer the passed object at the end of the method' do
     it 'registers an offense for the setter call on the lvar' do
-      inspect_source(cop, <<-END.strip_indent)
+      expect_offense(<<-RUBY.strip_indent)
         def test(some_arg)
           some_arg = Top.new
           some_arg.attr = 5
+          ^^^^^^^^ Useless setter call to local variable `some_arg`.
         end
-      END
-      expect(cop.offenses.size).to eq(1)
+      RUBY
     end
   end
 
   context 'when a lvar contains a local object instantiated with literal' do
     it 'registers an offense for the setter call on the lvar' do
-      inspect_source(cop, <<-END.strip_indent)
+      expect_offense(<<-RUBY.strip_indent)
         def test
           some_arg = {}
           some_arg[:attr] = 1
+          ^^^^^^^^ Useless setter call to local variable `some_arg`.
         end
-      END
-      expect(cop.offenses.size).to eq(1)
+      RUBY
     end
   end
 

--- a/spec/rubocop/cop/lint/void_spec.rb
+++ b/spec/rubocop/cop/lint/void_spec.rb
@@ -51,26 +51,28 @@ describe RuboCop::Cop::Lint::Void do
   end
 
   it 'registers an offense for void `self` if not on last line' do
-    inspect_source(cop, 'self; top')
-    expect(cop.offenses.size).to eq(1)
+    expect_offense(<<-RUBY.strip_indent)
+      self; top
+      ^^^^ `self` used in void context.
+    RUBY
   end
 
   it 'registers an offense for void `defined?` if not on last line' do
-    inspect_source(cop, <<-END.strip_indent)
+    expect_offense(<<-RUBY.strip_indent)
       defined?(x)
+      ^^^^^^^^^^^ `defined?(x)` used in void context.
       top
-    END
-    expect(cop.offenses.size).to eq(1)
+    RUBY
   end
 
   it 'handles explicit begin blocks' do
-    inspect_source(cop, <<-END.strip_indent)
+    expect_offense(<<-RUBY.strip_indent)
       begin
        1
+       ^ Literal `1` used in void context.
        2
       end
-    END
-    expect(cop.offenses.size).to eq(1)
+    RUBY
   end
 
   it 'accepts short call syntax' do

--- a/spec/rubocop/cop/metrics/parameter_lists_spec.rb
+++ b/spec/rubocop/cop/metrics/parameter_lists_spec.rb
@@ -30,14 +30,11 @@ describe RuboCop::Cop::Metrics::ParameterLists, :config do
 
   context 'When CountKeywordArgs is true' do
     it 'counts keyword arguments as well' do
-      inspect_source(cop, <<-END.strip_indent)
+      expect_offense(<<-RUBY.strip_indent)
         def meth(a, b, c, d: 1, e: 2)
+                ^^^^^^^^^^^^^^^^^^^^^ Avoid parameter lists longer than 4 parameters. [5/4]
         end
-      END
-      expect(cop.messages).to eq(
-        ['Avoid parameter lists longer than 4 parameters. [5/4]']
-      )
-      expect(cop.offenses.size).to eq(1)
+      RUBY
     end
   end
 

--- a/spec/rubocop/cop/performance/caller_spec.rb
+++ b/spec/rubocop/cop/performance/caller_spec.rb
@@ -15,32 +15,44 @@ describe RuboCop::Cop::Performance::Caller do
   end
 
   it 'registers an offense when :first is called on caller' do
-    inspect_source(cop, 'caller.first')
-    expect(cop.offenses.size).to eq(1)
+    expect_offense(<<-RUBY.strip_indent)
+      caller.first
+             ^^^^^ Use `caller(n..n)` instead of `caller[n]`.
+    RUBY
   end
 
   it 'registers an offense when :first is called on caller with 1' do
-    inspect_source(cop, 'caller(1).first')
-    expect(cop.offenses.size).to eq(1)
+    expect_offense(<<-RUBY.strip_indent)
+      caller(1).first
+                ^^^^^ Use `caller(n..n)` instead of `caller[n]`.
+    RUBY
   end
 
   it 'registers an offense when :first is called on caller with 2' do
-    inspect_source(cop, 'caller(2).first')
-    expect(cop.offenses.size).to eq(1)
+    expect_offense(<<-RUBY.strip_indent)
+      caller(2).first
+                ^^^^^ Use `caller(n..n)` instead of `caller[n]`.
+    RUBY
   end
 
   it 'registers an offense when :[] is called on caller' do
-    inspect_source(cop, 'caller[1]')
-    expect(cop.offenses.size).to eq(1)
+    expect_offense(<<-RUBY.strip_indent)
+      caller[1]
+            ^^^ Use `caller(n..n)` instead of `caller[n]`.
+    RUBY
   end
 
   it 'registers an offense when :[] is called on caller with 1' do
-    inspect_source(cop, 'caller(1)[1]')
-    expect(cop.offenses.size).to eq(1)
+    expect_offense(<<-RUBY.strip_indent)
+      caller(1)[1]
+               ^^^ Use `caller(n..n)` instead of `caller[n]`.
+    RUBY
   end
 
   it 'registers an offense when :[] is called on caller with 2' do
-    inspect_source(cop, 'caller(2)[1]')
-    expect(cop.offenses.size).to eq(1)
+    expect_offense(<<-RUBY.strip_indent)
+      caller(2)[1]
+               ^^^ Use `caller(n..n)` instead of `caller[n]`.
+    RUBY
   end
 end

--- a/spec/rubocop/cop/performance/case_when_splat_spec.rb
+++ b/spec/rubocop/cop/performance/case_when_splat_spec.rb
@@ -49,45 +49,39 @@ describe RuboCop::Cop::Performance::CaseWhenSplat do
   end
 
   it 'registers an offense for case when with a splat in the first condition' do
-    inspect_source(cop, <<-END.strip_indent)
+    expect_offense(<<-RUBY.strip_indent)
       case foo
       when *cond
+      ^^^^^^^^^^ Place `when` conditions with a splat at the end of the `when` branches.
         bar
       when 4
         foobar
       else
         baz
       end
-    END
-
-    expect(cop.messages).to eq([described_class::MSG])
-    expect(cop.highlights).to eq(['when *cond'])
+    RUBY
   end
 
   it 'registers an offense for case when with a splat without an else' do
-    inspect_source(cop, <<-END.strip_indent)
+    expect_offense(<<-RUBY.strip_indent)
       case foo
       when *baz
+      ^^^^^^^^^ Place `when` conditions with a splat at the end of the `when` branches.
         bar
       when 4
         foobar
       end
-    END
-
-    expect(cop.messages).to eq([described_class::MSG])
-    expect(cop.highlights).to eq(['when *baz'])
+    RUBY
   end
 
   it 'registers an offense for splat conditions in when then' do
-    inspect_source(cop, <<-END.strip_indent)
+    expect_offense(<<-RUBY.strip_indent)
       case foo
       when *cond then bar
+      ^^^^^^^^^^ Place `when` conditions with a splat at the end of the `when` branches.
       when 4 then baz
       end
-    END
-
-    expect(cop.messages).to eq([described_class::MSG])
-    expect(cop.highlights).to eq(['when *cond'])
+    RUBY
   end
 
   it 'registers an offense for a single when with splat expansion followed ' \
@@ -103,51 +97,51 @@ describe RuboCop::Cop::Performance::CaseWhenSplat do
   end
 
   it 'registers an offense for multiple splat conditions at the beginning' do
-    inspect_source(cop, <<-END.strip_indent)
+    expect_offense(<<-RUBY.strip_indent)
       case foo
       when *cond1
+      ^^^^^^^^^^^ Place `when` conditions with a splat at the end of the `when` branches.
         bar
       when *cond2
+      ^^^^^^^^^^^ Place `when` conditions with a splat at the end of the `when` branches.
         doo
       when 4
         foobar
       else
         baz
       end
-    END
-
-    expect(cop.messages).to eq([described_class::MSG, described_class::MSG])
-    expect(cop.highlights).to eq(['when *cond1', 'when *cond2'])
+    RUBY
   end
 
   it 'registers an offense for multiple out of order splat conditions' do
-    inspect_source(cop, <<-END.strip_indent)
+    expect_offense(<<-RUBY.strip_indent)
       case foo
       when *cond1
+      ^^^^^^^^^^^ Place `when` conditions with a splat at the end of the `when` branches.
         bar
       when 8
         barfoo
       when *SOME_CONSTANT
+      ^^^^^^^^^^^^^^^^^^^ Place `when` conditions with a splat at the end of the `when` branches.
         doo
       when 4
         foobar
       else
         baz
       end
-    END
-
-    expect(cop.messages).to eq([described_class::MSG, described_class::MSG])
-    expect(cop.highlights).to eq(['when *cond1', 'when *SOME_CONSTANT'])
+    RUBY
   end
 
   it 'registers an offense for splat condition that do not appear at the end' do
-    inspect_source(cop, <<-END.strip_indent)
+    expect_offense(<<-RUBY.strip_indent)
       case foo
       when *cond1
+      ^^^^^^^^^^^ Place `when` conditions with a splat at the end of the `when` branches.
         bar
       when 8
         barfoo
       when *cond2
+      ^^^^^^^^^^^ Place `when` conditions with a splat at the end of the `when` branches.
         doo
       when 4
         foobar
@@ -156,10 +150,7 @@ describe RuboCop::Cop::Performance::CaseWhenSplat do
       else
         baz
       end
-    END
-
-    expect(cop.messages).to eq([described_class::MSG, described_class::MSG])
-    expect(cop.highlights).to eq(['when *cond1', 'when *cond2'])
+    RUBY
   end
 
   it 'allows splat expansion on an array literal' do
@@ -200,17 +191,15 @@ describe RuboCop::Cop::Performance::CaseWhenSplat do
   end
 
   it 'registers an offense when splat is part of the condition' do
-    inspect_source(cop, <<-END.strip_indent)
+    expect_offense(<<-RUBY.strip_indent)
       case foo
       when cond1, *cond2
+      ^^^^^^^^^^^^^^^^^^ Place `when` conditions with a splat at the end of the `when` branches.
         bar
       when cond3
         baz
       end
-    END
-
-    expect(cop.messages).to eq([described_class::MSG])
-    expect(cop.highlights).to eq(['when cond1, *cond2'])
+    RUBY
   end
 
   context 'autocorrect' do

--- a/spec/rubocop/cop/performance/hash_each_methods_spec.rb
+++ b/spec/rubocop/cop/performance/hash_each_methods_spec.rb
@@ -4,31 +4,31 @@ describe RuboCop::Cop::Performance::HashEachMethods do
   subject(:cop) { described_class.new }
 
   it 'registers an offense for Hash#keys.each' do
-    inspect_source(cop, 'hash.keys.each { |k| p k }')
-    expect(cop.offenses.size).to eq(1)
-    expect(cop.messages)
-      .to eq(['Use `each_key` instead of `keys.each`.'])
+    expect_offense(<<-RUBY.strip_indent)
+      hash.keys.each { |k| p k }
+           ^^^^^^^^^ Use `each_key` instead of `keys.each`.
+    RUBY
   end
 
   it 'registers an offense for Hash#values.each' do
-    inspect_source(cop, 'hash.values.each { |v| p v }')
-    expect(cop.offenses.size).to eq(1)
-    expect(cop.messages)
-      .to eq(['Use `each_value` instead of `values.each`.'])
+    expect_offense(<<-RUBY.strip_indent)
+      hash.values.each { |v| p v }
+           ^^^^^^^^^^^ Use `each_value` instead of `values.each`.
+    RUBY
   end
 
   it 'registers an offense for Hash#each with unused value' do
-    inspect_source(cop, 'hash.each { |k, _v| p k }')
-    expect(cop.offenses.size).to eq(1)
-    expect(cop.messages)
-      .to eq(['Use `each_key` instead of `each`.'])
+    expect_offense(<<-RUBY.strip_indent)
+      hash.each { |k, _v| p k }
+      ^^^^^^^^^ Use `each_key` instead of `each`.
+    RUBY
   end
 
   it 'registers an offense for Hash#each with unused key' do
-    inspect_source(cop, 'hash.each { |_k, v| p v }')
-    expect(cop.offenses.size).to eq(1)
-    expect(cop.messages)
-      .to eq(['Use `each_value` instead of `each`.'])
+    expect_offense(<<-RUBY.strip_indent)
+      hash.each { |_k, v| p v }
+      ^^^^^^^^^ Use `each_value` instead of `each`.
+    RUBY
   end
 
   it 'does not register an offense for Hash#each_key' do

--- a/spec/rubocop/cop/performance/string_replacement_spec.rb
+++ b/spec/rubocop/cop/performance/string_replacement_spec.rb
@@ -133,9 +133,10 @@ describe RuboCop::Cop::Performance::StringReplacement do
   describe 'deterministic regex' do
     describe 'regex literal' do
       it 'registers an offense when using space' do
-        inspect_source(cop, %('abc'.gsub(/ /, '')))
-
-        expect(cop.messages).to eq(['Use `delete` instead of `gsub`.'])
+        expect_offense(<<-RUBY.strip_indent)
+          'abc'.gsub(/ /, '')
+                ^^^^^^^^^^^^^ Use `delete` instead of `gsub`.
+        RUBY
       end
 
       %w[a b c ' " % ! = < > # & ; : ` ~ 1 2 3 - _ , \r \\\\ \y \u1234
@@ -165,29 +166,33 @@ describe RuboCop::Cop::Performance::StringReplacement do
       end
 
       it 'registers an offense when using %r notation' do
-        inspect_source(cop, %('/abc'.gsub(%r{a}, 'd')))
-
-        expect(cop.messages).to eq(['Use `tr` instead of `gsub`.'])
+        expect_offense(<<-RUBY.strip_indent)
+          '/abc'.gsub(%r{a}, 'd')
+                 ^^^^^^^^^^^^^^^^ Use `tr` instead of `gsub`.
+        RUBY
       end
     end
 
     describe 'regex constructor' do
       it 'registers an offense when only using word characters' do
-        inspect_source(cop, "'abc'.gsub(Regexp.new('b'), '2')")
-
-        expect(cop.messages).to eq(['Use `tr` instead of `gsub`.'])
+        expect_offense(<<-RUBY.strip_indent)
+          'abc'.gsub(Regexp.new('b'), '2')
+                ^^^^^^^^^^^^^^^^^^^^^^^^^^ Use `tr` instead of `gsub`.
+        RUBY
       end
 
       it 'registers an offense when regex is built from regex' do
-        inspect_source(cop, "'abc'.gsub(Regexp.new(/b/), '2')")
-
-        expect(cop.messages).to eq(['Use `tr` instead of `gsub`.'])
+        expect_offense(<<-RUBY.strip_indent)
+          'abc'.gsub(Regexp.new(/b/), '2')
+                ^^^^^^^^^^^^^^^^^^^^^^^^^^ Use `tr` instead of `gsub`.
+        RUBY
       end
 
       it 'registers an offense when using compile' do
-        inspect_source(cop, "'123'.gsub(Regexp.compile('1'), 'a')")
-
-        expect(cop.messages).to eq(['Use `tr` instead of `gsub`.'])
+        expect_offense(<<-RUBY.strip_indent)
+          '123'.gsub(Regexp.compile('1'), 'a')
+                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Use `tr` instead of `gsub`.
+        RUBY
       end
     end
   end
@@ -317,10 +322,10 @@ describe RuboCop::Cop::Performance::StringReplacement do
   end
 
   it 'registers an offense for gsub! when deleting one characters' do
-    inspect_source(cop, "'abc'.gsub!('a', '')")
-
-    expect(cop.messages).to eq(['Use `delete!` instead of `gsub!`.'])
-    expect(cop.highlights).to eq(["gsub!('a', '')"])
+    expect_offense(<<-RUBY.strip_indent)
+      'abc'.gsub!('a', '')
+            ^^^^^^^^^^^^^^ Use `delete!` instead of `gsub!`.
+    RUBY
   end
 
   it 'registers an offense when using escape characters in the replacement' do

--- a/spec/rubocop/cop/rails/active_support_aliases_spec.rb
+++ b/spec/rubocop/cop/rails/active_support_aliases_spec.rb
@@ -8,10 +8,10 @@ describe RuboCop::Cop::Rails::ActiveSupportAliases do
   describe 'String' do
     describe '#starts_with?' do
       it 'is registered as an offence' do
-        inspect_source(cop, "'some_string'.starts_with?('prefix')")
-        expect(cop.offenses.size).to eq(1)
-        expect(cop.messages)
-          .to eq(['Use `start_with?` instead of `starts_with?`.'])
+        expect_offense(<<-RUBY.strip_indent)
+          'some_string'.starts_with?('prefix')
+          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Use `start_with?` instead of `starts_with?`.
+        RUBY
       end
 
       it 'is autocorrected' do
@@ -31,10 +31,10 @@ describe RuboCop::Cop::Rails::ActiveSupportAliases do
 
     describe '#ends_with?' do
       it 'it is registered as an offense' do
-        inspect_source(cop, "'some_string'.ends_with?('prefix')")
-        expect(cop.offenses.size).to eq(1)
-        expect(cop.messages)
-          .to eq(['Use `end_with?` instead of `ends_with?`.'])
+        expect_offense(<<-RUBY.strip_indent)
+          'some_string'.ends_with?('prefix')
+          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Use `end_with?` instead of `ends_with?`.
+        RUBY
       end
 
       it 'is autocorrected' do
@@ -56,10 +56,10 @@ describe RuboCop::Cop::Rails::ActiveSupportAliases do
   describe 'Array' do
     describe '#append' do
       it 'is registered as an offence' do
-        inspect_source(cop, "[1, 'a', 3].append('element')")
-        expect(cop.offenses.size).to eq(1)
-        expect(cop.messages)
-          .to eq(['Use `<<` instead of `append`.'])
+        expect_offense(<<-RUBY.strip_indent)
+          [1, 'a', 3].append('element')
+          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Use `<<` instead of `append`.
+        RUBY
       end
 
       it 'is not autocorrected' do
@@ -78,10 +78,10 @@ describe RuboCop::Cop::Rails::ActiveSupportAliases do
 
     describe '#prepend' do
       it 'is registered as an offence' do
-        inspect_source(cop, "[1, 'a', 3].prepend('element')")
-        expect(cop.offenses.size).to eq(1)
-        expect(cop.messages)
-          .to eq(['Use `unshift` instead of `prepend`.'])
+        expect_offense(<<-RUBY.strip_indent)
+          [1, 'a', 3].prepend('element')
+          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Use `unshift` instead of `prepend`.
+        RUBY
       end
 
       it 'is autocorrected' do

--- a/spec/rubocop/cop/rails/blank_spec.rb
+++ b/spec/rubocop/cop/rails/blank_spec.rb
@@ -166,11 +166,10 @@ describe RuboCop::Cop::Rails::Blank, :config do
       let(:source) { 'something unless foo.present?' }
 
       it 'registers an offense' do
-        inspect_source(cop, source)
-
-        expect(cop.messages)
-          .to eq(['Use `if foo.blank?` instead of `unless foo.present?`.'])
-        expect(cop.highlights).to eq(['unless foo.present?'])
+        expect_offense(<<-RUBY.strip_indent)
+          something unless foo.present?
+                    ^^^^^^^^^^^^^^^^^^^ Use `if foo.blank?` instead of `unless foo.present?`.
+        RUBY
       end
 
       it 'auto-corrects' do
@@ -190,11 +189,12 @@ describe RuboCop::Cop::Rails::Blank, :config do
       end
 
       it 'registers an offense' do
-        inspect_source(cop, source)
-
-        expect(cop.messages)
-          .to eq(['Use `if foo.blank?` instead of `unless foo.present?`.'])
-        expect(cop.highlights).to eq(['unless foo.present?'])
+        expect_offense(<<-RUBY.strip_indent)
+          unless foo.present?
+          ^^^^^^^^^^^^^^^^^^^ Use `if foo.blank?` instead of `unless foo.present?`.
+            something
+          end
+        RUBY
       end
 
       it 'auto-corrects' do
@@ -220,11 +220,14 @@ describe RuboCop::Cop::Rails::Blank, :config do
       end
 
       it 'registers an offense' do
-        inspect_source(cop, source)
-
-        expect(cop.messages)
-          .to eq(['Use `if foo.blank?` instead of `unless foo.present?`.'])
-        expect(cop.highlights).to eq(['unless foo.present?'])
+        expect_offense(<<-RUBY.strip_indent)
+          unless foo.present?
+          ^^^^^^^^^^^^^^^^^^^ Use `if foo.blank?` instead of `unless foo.present?`.
+            something
+          else
+            something_else
+          end
+        RUBY
       end
 
       it 'auto-corrects' do

--- a/spec/rubocop/cop/rails/date_spec.rb
+++ b/spec/rubocop/cop/rails/date_spec.rb
@@ -54,8 +54,10 @@ describe RuboCop::Cop::Rails::Date, :config do
 
     context 'when a string literal without timezone' do
       it 'registers an offense' do
-        inspect_source(cop, '"2016-07-12 14:36:31".to_time(:utc)')
-        expect(cop.offenses.size).to eq(1)
+        expect_offense(<<-RUBY.strip_indent)
+          "2016-07-12 14:36:31".to_time(:utc)
+                                ^^^^^^^ Do not use `to_time` on Date objects, because they know nothing about the time zone in use.
+        RUBY
       end
     end
 
@@ -82,8 +84,10 @@ describe RuboCop::Cop::Rails::Date, :config do
     end
 
     it 'registers an offense for Date.today' do
-      inspect_source(cop, 'Date.today')
-      expect(cop.offenses.size).to eq(1)
+      expect_offense(<<-RUBY.strip_indent)
+        Date.today
+             ^^^^^ Do not use `Date.today` without zone. Use `Time.zone.today` instead.
+      RUBY
     end
 
     RuboCop::Cop::Rails::TimeZone::ACCEPTED_METHODS.each do |a_method|

--- a/spec/rubocop/cop/rails/delegate_spec.rb
+++ b/spec/rubocop/cop/rails/delegate_spec.rb
@@ -4,45 +4,30 @@ describe RuboCop::Cop::Rails::Delegate do
   subject(:cop) { described_class.new }
 
   it 'finds trivial delegate' do
-    inspect_source(cop, <<-END.strip_indent)
+    expect_offense(<<-RUBY.strip_indent)
       def foo
+      ^^^ Use `delegate` to define delegations.
         bar.foo
       end
-    END
-    expect(cop.offenses.size).to eq(1)
-    expect(cop.offenses
-            .map(&:line).sort).to eq([1])
-    expect(cop.messages)
-      .to eq(['Use `delegate` to define delegations.'])
-    expect(cop.highlights).to eq(['def'])
+    RUBY
   end
 
   it 'finds trivial delegate with arguments' do
-    inspect_source(cop, <<-END.strip_indent)
+    expect_offense(<<-RUBY.strip_indent)
       def foo(baz)
+      ^^^ Use `delegate` to define delegations.
         bar.foo(baz)
       end
-    END
-    expect(cop.offenses.size).to eq(1)
-    expect(cop.offenses
-            .map(&:line).sort).to eq([1])
-    expect(cop.messages)
-      .to eq(['Use `delegate` to define delegations.'])
-    expect(cop.highlights).to eq(['def'])
+    RUBY
   end
 
   it 'finds trivial delegate with prefix' do
-    inspect_source(cop, <<-END.strip_indent)
+    expect_offense(<<-RUBY.strip_indent)
       def bar_foo
+      ^^^ Use `delegate` to define delegations.
         bar.foo
       end
-    END
-    expect(cop.offenses.size).to eq(1)
-    expect(cop.offenses
-            .map(&:line).sort).to eq([1])
-    expect(cop.messages)
-      .to eq(['Use `delegate` to define delegations.'])
-    expect(cop.highlights).to eq(['def'])
+    RUBY
   end
 
   it 'ignores class methods' do

--- a/spec/rubocop/cop/rails/enum_uniqueness_spec.rb
+++ b/spec/rubocop/cop/rails/enum_uniqueness_spec.rb
@@ -16,10 +16,11 @@ describe RuboCop::Cop::Rails::EnumUniqueness, :config do
 
     context 'with several duplicated enum values' do
       it 'registers two offenses' do
-        inspect_source(cop,
-                       'enum status: [:active, :archived, :active, :active]')
-
-        expect(cop.offenses.size).to eq(2)
+        expect_offense(<<-RUBY.strip_indent)
+          enum status: [:active, :archived, :active, :active]
+                                                     ^^^^^^^ Duplicate value `:active` found in `status` enum declaration.
+                                            ^^^^^^^ Duplicate value `:active` found in `status` enum declaration.
+        RUBY
       end
     end
 
@@ -43,10 +44,11 @@ describe RuboCop::Cop::Rails::EnumUniqueness, :config do
 
     context 'with several duplicated enum values' do
       it 'registers two offenses' do
-        inspect_source(cop,
-                       'enum status: { active: 0, pending: 0, archived: 0 }')
-
-        expect(cop.offenses.size).to eq(2)
+        expect_offense(<<-RUBY.strip_indent)
+          enum status: { active: 0, pending: 0, archived: 0 }
+                                                          ^ Duplicate value `0` found in `status` enum declaration.
+                                             ^ Duplicate value `0` found in `status` enum declaration.
+        RUBY
       end
     end
 

--- a/spec/rubocop/cop/rails/exit_spec.rb
+++ b/spec/rubocop/cop/rails/exit_spec.rb
@@ -36,9 +36,10 @@ describe RuboCop::Cop::Rails::Exit, :config do
 
   context 'with arguments' do
     it 'registers an offense for an exit(0) call with no receiver' do
-      inspect_source(cop,
-                     'exit(0)')
-      expect(cop.offenses.size).to eq(1)
+      expect_offense(<<-RUBY.strip_indent)
+        exit(0)
+        ^^^^ Do not use `exit` in Rails applications.
+      RUBY
     end
 
     it 'ignores exit calls with unexpected number of parameters' do

--- a/spec/rubocop/cop/rails/file_path_spec.rb
+++ b/spec/rubocop/cop/rails/file_path_spec.rb
@@ -16,8 +16,10 @@ describe RuboCop::Cop::Rails::FilePath do
     let(:source) { "File.join(Rails.root, 'app', 'models')" }
 
     it 'registers an offense' do
-      inspect_source(cop, source)
-      expect(cop.offenses.size).to eq(1)
+      expect_offense(<<-RUBY.strip_indent)
+        File.join(Rails.root, 'app', 'models')
+        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Please use `Rails.root.join('path', 'to')` instead.
+      RUBY
     end
   end
 
@@ -25,8 +27,10 @@ describe RuboCop::Cop::Rails::FilePath do
     let(:source) { "Rails.root.join('app/models/goober')" }
 
     it 'registers an offense' do
-      inspect_source(cop, source)
-      expect(cop.offenses.size).to eq(1)
+      expect_offense(<<-RUBY.strip_indent)
+        Rails.root.join('app/models/goober')
+        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Please use `Rails.root.join('path', 'to')` instead.
+      RUBY
     end
   end
 
@@ -34,8 +38,10 @@ describe RuboCop::Cop::Rails::FilePath do
     let(:source) { '"#{Rails.root}/app/models/goober"' }
 
     it 'registers an offense' do
-      inspect_source(cop, source)
-      expect(cop.offenses.size).to eq(1)
+      expect_offense(<<-'RUBY'.strip_indent)
+        "#{Rails.root}/app/models/goober"
+        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Please use `Rails.root.join('path', 'to')` instead.
+      RUBY
     end
   end
 
@@ -43,8 +49,10 @@ describe RuboCop::Cop::Rails::FilePath do
     let(:source) { 'foo(bar(File.join(Rails.root, "app", "models")))' }
 
     it 'registers an offense once' do
-      inspect_source(cop, source)
-      expect(cop.offenses.size).to eq(1)
+      expect_offense(<<-RUBY.strip_indent)
+        foo(bar(File.join(Rails.root, "app", "models")))
+                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Please use `Rails.root.join('path', 'to')` instead.
+      RUBY
     end
   end
 
@@ -52,8 +60,10 @@ describe RuboCop::Cop::Rails::FilePath do
     let(:source) { 'foo(Rails.root.join(\'app/models\'))' }
 
     it 'registers an offense once' do
-      inspect_source(cop, source)
-      expect(cop.offenses.size).to eq(1)
+      expect_offense(<<-RUBY.strip_indent)
+        foo(Rails.root.join('app/models'))
+            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Please use `Rails.root.join('path', 'to')` instead.
+      RUBY
     end
   end
 

--- a/spec/rubocop/cop/rails/has_and_belongs_to_many_spec.rb
+++ b/spec/rubocop/cop/rails/has_and_belongs_to_many_spec.rb
@@ -4,8 +4,9 @@ describe RuboCop::Cop::Rails::HasAndBelongsToMany do
   subject(:cop) { described_class.new }
 
   it 'registers an offense for has_and_belongs_to_many' do
-    inspect_source(cop,
-                   'has_and_belongs_to_many :groups')
-    expect(cop.offenses.size).to eq(1)
+    expect_offense(<<-RUBY.strip_indent)
+      has_and_belongs_to_many :groups
+      ^^^^^^^^^^^^^^^^^^^^^^^ Prefer `has_many :through` to `has_and_belongs_to_many`.
+    RUBY
   end
 end

--- a/spec/rubocop/cop/rails/http_positional_arguments_spec.rb
+++ b/spec/rubocop/cop/rails/http_positional_arguments_spec.rb
@@ -315,8 +315,10 @@ describe RuboCop::Cop::Rails::HttpPositionalArguments do
       end
 
       it 'registers an offense' do
-        inspect_source(cop, source)
-        expect(cop.offenses.size).to eq(1)
+        expect_offense(<<-RUBY.strip_indent)
+          get :new, user_id: @user.id
+          ^^^ Use keyword arguments instead of positional arguments for http call: `get`.
+        RUBY
       end
 
       it 'autocorrects offense' do
@@ -360,8 +362,16 @@ describe RuboCop::Cop::Rails::HttpPositionalArguments do
       end
 
       it 'registers an offense' do
-        inspect_source(cop, source)
-        expect(cop.offenses.size).to eq(1)
+        expect_offense(<<-RUBY.strip_indent)
+          patch :update,
+          ^^^^^ Use keyword arguments instead of positional arguments for http call: `patch`.
+                    id: @user.id,
+                    ac: {
+                      article_id: @article1.id,
+                      profile_id: @profile1.id,
+                      content: 'Some Text'
+                    }
+        RUBY
       end
 
       it 'autocorrects offense' do
@@ -394,8 +404,16 @@ describe RuboCop::Cop::Rails::HttpPositionalArguments do
       end
 
       it 'registers an offense' do
-        inspect_source(cop, source)
-        expect(cop.offenses.size).to eq(1)
+        expect_offense(<<-RUBY.strip_indent)
+          post :create,
+          ^^^^ Use keyword arguments instead of positional arguments for http call: `post`.
+                    id: @user.id,
+                    ac: {
+                      article_id: @article1.id,
+                      profile_id: @profile1.id,
+                      content: 'Some Text'
+                    }
+        RUBY
       end
 
       it 'autocorrects offense' do

--- a/spec/rubocop/cop/rails/not_null_column_spec.rb
+++ b/spec/rubocop/cop/rails/not_null_column_spec.rb
@@ -4,18 +4,14 @@ describe RuboCop::Cop::Rails::NotNullColumn, :config do
   subject(:cop) { described_class.new(config) }
   let(:cop_config) { { 'Include' => nil } }
 
-  before do
-    inspect_source(cop, source)
-  end
-
   context 'with add_column call' do
     context 'with null: false' do
       let(:source) { 'add_column :users, :name, :string, null: false' }
       it 'reports an offense' do
-        expect(cop.offenses.size).to eq(1)
-        expect(cop.messages).to eq(
-          ['Do not add a NOT NULL column without a default value.']
-        )
+        expect_offense(<<-RUBY.strip_indent)
+          add_column :users, :name, :string, null: false
+                                             ^^^^^^^^^^^ Do not add a NOT NULL column without a default value.
+        RUBY
       end
     end
 
@@ -31,10 +27,10 @@ describe RuboCop::Cop::Rails::NotNullColumn, :config do
         'add_column :users, :name, :string, null: false, default: nil'
       end
       it 'reports an offense' do
-        expect(cop.offenses.size).to eq(1)
-        expect(cop.messages).to eq(
-          ['Do not add a NOT NULL column without a default value.']
-        )
+        expect_offense(<<-RUBY.strip_indent)
+          add_column :users, :name, :string, null: false, default: nil
+                                             ^^^^^^^^^^^ Do not add a NOT NULL column without a default value.
+        RUBY
       end
     end
 
@@ -80,10 +76,10 @@ describe RuboCop::Cop::Rails::NotNullColumn, :config do
     context 'with null: false' do
       let(:source) { 'add_reference :products, :category, null: false' }
       it 'reports an offense' do
-        expect(cop.offenses.size).to eq(1)
-        expect(cop.messages).to eq(
-          ['Do not add a NOT NULL column without a default value.']
-        )
+        expect_offense(<<-RUBY.strip_indent)
+          add_reference :products, :category, null: false
+                                              ^^^^^^^^^^^ Do not add a NOT NULL column without a default value.
+        RUBY
       end
     end
 

--- a/spec/rubocop/cop/rails/present_spec.rb
+++ b/spec/rubocop/cop/rails/present_spec.rb
@@ -153,11 +153,10 @@ describe RuboCop::Cop::Rails::Present, :config do
         let(:source) { 'something unless foo.blank?' }
 
         it 'registers an offense' do
-          inspect_source(cop, source)
-
-          expect(cop.messages)
-            .to eq(['Use `if foo.present?` instead of `unless foo.blank?`.'])
-          expect(cop.highlights).to eq(['unless foo.blank?'])
+          expect_offense(<<-RUBY.strip_indent)
+            something unless foo.blank?
+                      ^^^^^^^^^^^^^^^^^ Use `if foo.present?` instead of `unless foo.blank?`.
+          RUBY
         end
 
         it 'auto-corrects' do
@@ -177,11 +176,12 @@ describe RuboCop::Cop::Rails::Present, :config do
         end
 
         it 'registers an offense' do
-          inspect_source(cop, source)
-
-          expect(cop.messages)
-            .to eq(['Use `if foo.present?` instead of `unless foo.blank?`.'])
-          expect(cop.highlights).to eq(['unless foo.blank?'])
+          expect_offense(<<-RUBY.strip_indent)
+            unless foo.blank?
+            ^^^^^^^^^^^^^^^^^ Use `if foo.present?` instead of `unless foo.blank?`.
+              something
+            end
+          RUBY
         end
 
         it 'auto-corrects' do
@@ -207,11 +207,14 @@ describe RuboCop::Cop::Rails::Present, :config do
         end
 
         it 'registers an offense' do
-          inspect_source(cop, source)
-
-          expect(cop.messages)
-            .to eq(['Use `if foo.present?` instead of `unless foo.blank?`.'])
-          expect(cop.highlights).to eq(['unless foo.blank?'])
+          expect_offense(<<-RUBY.strip_indent)
+            unless foo.blank?
+            ^^^^^^^^^^^^^^^^^ Use `if foo.present?` instead of `unless foo.blank?`.
+              something
+            else
+              something_else
+            end
+          RUBY
         end
 
         it 'auto-corrects' do

--- a/spec/rubocop/cop/rails/read_write_attribute_spec.rb
+++ b/spec/rubocop/cop/rails/read_write_attribute_spec.rb
@@ -5,9 +5,10 @@ describe RuboCop::Cop::Rails::ReadWriteAttribute do
 
   context 'read_attribute' do
     it 'registers an offense' do
-      inspect_source(cop, 'res = read_attribute(:test)')
-      expect(cop.offenses.size).to eq(1)
-      expect(cop.highlights).to eq(['read_attribute'])
+      expect_offense(<<-RUBY.strip_indent)
+        res = read_attribute(:test)
+              ^^^^^^^^^^^^^^ Prefer `self[:attr]` over `read_attribute(:attr)`.
+      RUBY
     end
 
     it 'registers no offense with explicit receiver' do
@@ -17,9 +18,10 @@ describe RuboCop::Cop::Rails::ReadWriteAttribute do
 
   context 'write_attribute' do
     it 'registers an offense' do
-      inspect_source(cop, 'write_attribute(:test, val)')
-      expect(cop.offenses.size).to eq(1)
-      expect(cop.highlights).to eq(['write_attribute'])
+      expect_offense(<<-RUBY.strip_indent)
+        write_attribute(:test, val)
+        ^^^^^^^^^^^^^^^ Prefer `self[:attr] = val` over `write_attribute(:attr, val)`.
+      RUBY
     end
 
     it 'registers no offense with explicit receiver' do

--- a/spec/rubocop/cop/rails/relative_date_constant_spec.rb
+++ b/spec/rubocop/cop/rails/relative_date_constant_spec.rb
@@ -4,12 +4,12 @@ describe RuboCop::Cop::Rails::RelativeDateConstant do
   subject(:cop) { described_class.new }
 
   it 'registers an offense for ActiveSupport::Duration.since' do
-    inspect_source(cop, <<-END.strip_indent)
+    expect_offense(<<-RUBY.strip_indent)
       class SomeClass
         EXPIRED_AT = 1.week.since
+        ^^^^^^^^^^^^^^^^^^^^^^^^^ Do not assign since to constants as it will be evaluated only once.
       end
-    END
-    expect(cop.offenses.size).to eq(1)
+    RUBY
   end
 
   it 'accepts a method with arguments' do
@@ -37,39 +37,39 @@ describe RuboCop::Cop::Rails::RelativeDateConstant do
   end
 
   it 'registers an offense for relative date in ||=' do
-    inspect_source(cop, <<-END.strip_indent)
+    expect_offense(<<-RUBY.strip_indent)
       class SomeClass
         EXPIRED_AT ||= 1.week.since
+        ^^^^^^^^^^^^^^^^^^^^^^^^^^^ Do not assign since to constants as it will be evaluated only once.
       end
-    END
-    expect(cop.offenses.size).to eq(1)
+    RUBY
   end
 
   it 'registers an offense for relative date in multiple assignment' do
-    inspect_source(cop, <<-END.strip_indent)
+    expect_offense(<<-RUBY.strip_indent)
       class SomeClass
         START, A, x = 2.weeks.ago, 1.week.since, 5
+                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Do not assign ago to constants as it will be evaluated only once.
       end
-    END
-    expect(cop.offenses.size).to eq(1)
+    RUBY
   end
 
   it 'registers an offense for exclusive end range' do
-    inspect_source(cop, <<-END.strip_indent)
+    expect_offense(<<-RUBY.strip_indent)
       class SomeClass
         TRIAL_PERIOD = DateTime.current..1.day.since
+        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Do not assign since to constants as it will be evaluated only once.
       end
-    END
-    expect(cop.offenses.size).to eq(1)
+    RUBY
   end
 
   it 'registers an offense for inclusive end range' do
-    inspect_source(cop, <<-END.strip_indent)
+    expect_offense(<<-RUBY.strip_indent)
       class SomeClass
         TRIAL_PERIOD = DateTime.current...1.day.since
+        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Do not assign since to constants as it will be evaluated only once.
       end
-    END
-    expect(cop.offenses.size).to eq(1)
+    RUBY
   end
 
   it 'autocorrects' do

--- a/spec/rubocop/cop/rails/scope_args_spec.rb
+++ b/spec/rubocop/cop/rails/scope_args_spec.rb
@@ -4,9 +4,10 @@ describe RuboCop::Cop::Rails::ScopeArgs do
   subject(:cop) { described_class.new }
 
   it 'registers an offense a scope with a method arg' do
-    inspect_source(cop, 'scope :active, where(active: true)')
-
-    expect(cop.offenses.size).to eq(1)
+    expect_offense(<<-RUBY.strip_indent)
+      scope :active, where(active: true)
+                     ^^^^^^^^^^^^^^^^^^^ Use `lambda`/`proc` instead of a plain method call.
+    RUBY
   end
 
   it 'accepts a non send argument' do

--- a/spec/rubocop/cop/rails/skips_model_validations_spec.rb
+++ b/spec/rubocop/cop/rails/skips_model_validations_spec.rb
@@ -69,10 +69,10 @@ describe RuboCop::Cop::Rails::SkipsModelValidations, :config do
     end
 
     it 'registers an offense for `update_attribute`' do
-      inspect_source(cop, 'user.update_attribute(\'website\': \'example.com\')')
-      expect(cop.offenses.size).to eq(1)
-      expect(cop.messages)
-        .to eq([format(msg, 'update_attribute')])
+      expect_offense(<<-RUBY.strip_indent)
+        user.update_attribute('website': 'example.com')
+             ^^^^^^^^^^^^^^^^ Avoid using `update_attribute` because it skips validations.
+      RUBY
     end
   end
 end

--- a/spec/rubocop/cop/rails/time_zone_spec.rb
+++ b/spec/rubocop/cop/rails/time_zone_spec.rb
@@ -63,62 +63,73 @@ describe RuboCop::Cop::Rails::TimeZone, :config do
     end
 
     it 'registers an offense for Time.parse' do
-      inspect_source(cop, 'Time.parse("2012-03-02 16:05:37")')
-      expect(cop.offenses.size).to eq(1)
+      expect_offense(<<-RUBY.strip_indent)
+        Time.parse("2012-03-02 16:05:37")
+             ^^^^^ Do not use `Time.parse` without zone. Use `Time.zone.parse` instead.
+      RUBY
     end
 
     it 'registers an offense for Time.strftime' do
-      inspect_source(cop, 'Time.strftime(time_string, "%Y-%m-%dT%H:%M:%S%z")')
-      expect(cop.offenses.size).to eq(1)
+      expect_offense(<<-RUBY.strip_indent)
+        Time.strftime(time_string, "%Y-%m-%dT%H:%M:%S%z")
+             ^^^^^^^^ Do not use `Time.strftime` without zone. Use `Time.zone.strftime` instead.
+      RUBY
     end
 
     it 'registers an offense for Time.strftime.in_time_zone' do
-      inspect_source(
-        cop,
-        'Time.strftime(time_string, "%Y-%m-%dT%H:%M:%S%z").in_time_zone'
-      )
-      expect(cop.offenses.size).to eq(1)
+      expect_offense(<<-RUBY.strip_indent)
+        Time.strftime(time_string, "%Y-%m-%dT%H:%M:%S%z").in_time_zone
+             ^^^^^^^^ Do not use `Time.strftime` without zone. Use `Time.zone.strftime` instead.
+      RUBY
     end
 
     it 'registers an offense for Time.strftime with nested Time.zone' do
-      inspect_source(
-        cop,
-        'Time.strftime(Time.zone.now.to_s, "%Y-%m-%dT%H:%M:%S%z")'
-      )
-      expect(cop.offenses.size).to eq(1)
+      expect_offense(<<-RUBY.strip_indent)
+        Time.strftime(Time.zone.now.to_s, "%Y-%m-%dT%H:%M:%S%z")
+             ^^^^^^^^ Do not use `Time.strftime` without zone. Use `Time.zone.strftime` instead.
+      RUBY
     end
 
     it 'registers an offense for Time.zone.strftime with nested Time.now' do
-      inspect_source(
-        cop,
-        'Time.zone.strftime(Time.now.to_s, "%Y-%m-%dT%H:%M:%S%z")'
-      )
-      expect(cop.offenses.size).to eq(1)
+      expect_offense(<<-RUBY.strip_indent)
+        Time.zone.strftime(Time.now.to_s, "%Y-%m-%dT%H:%M:%S%z")
+                                ^^^ Do not use `Time.now.strftime` without zone. Use `Time.zone.now.strftime` instead.
+      RUBY
     end
 
     it 'registers an offense for Time.at' do
-      inspect_source(cop, 'Time.at(ts)')
-      expect(cop.offenses.size).to eq(1)
+      expect_offense(<<-RUBY.strip_indent)
+        Time.at(ts)
+             ^^ Do not use `Time.at` without zone. Use `Time.zone.at` instead.
+      RUBY
     end
 
     it 'registers an offense for Time.at.in_time_zone' do
-      inspect_source(cop, 'Time.at(ts).in_time_zone')
-      expect(cop.offenses.size).to eq(1)
+      expect_offense(<<-RUBY.strip_indent)
+        Time.at(ts).in_time_zone
+             ^^ Do not use `Time.at` without zone. Use `Time.zone.at` instead.
+      RUBY
     end
 
     it 'registers an offense for Time.parse.localtime(offset)' do
-      inspect_source(cop, "Time.parse('12:00').localtime('+03:00')")
-      expect(cop.offenses.size).to eq(1)
+      expect_offense(<<-RUBY.strip_indent)
+        Time.parse('12:00').localtime('+03:00')
+             ^^^^^ Do not use `Time.parse` without zone. Use `Time.zone.parse` instead.
+      RUBY
     end
 
     it 'registers an offense for Time.parse.localtime' do
-      inspect_source(cop, "Time.parse('12:00').localtime")
-      expect(cop.offenses.size).to eq(1)
+      expect_offense(<<-RUBY.strip_indent)
+        Time.parse('12:00').localtime
+             ^^^^^ Do not use `Time.parse` without zone. Use `Time.zone.parse` instead.
+      RUBY
     end
 
     it 'registers an offense for Time.parse in return' do
-      inspect_source(cop, 'return Foo, Time.parse("2012-03-02 16:05:37")')
-      expect(cop.offenses.size).to eq(1)
+      expect_offense(<<-RUBY.strip_indent)
+        return Foo, Time.parse("2012-03-02 16:05:37")
+                         ^^^^^ Do not use `Time.parse` without zone. Use `Time.zone.parse` instead.
+      RUBY
     end
 
     it 'accepts Time.zone.now' do

--- a/spec/rubocop/cop/security/eval_spec.rb
+++ b/spec/rubocop/cop/security/eval_spec.rb
@@ -4,27 +4,31 @@ describe RuboCop::Cop::Security::Eval do
   subject(:cop) { described_class.new }
 
   it 'registers an offense for eval as function' do
-    inspect_source(cop, 'eval(something)')
-    expect(cop.offenses.size).to eq(1)
-    expect(cop.highlights) .to eq(['eval'])
+    expect_offense(<<-RUBY.strip_indent)
+      eval(something)
+      ^^^^ The use of `eval` is a serious security risk.
+    RUBY
   end
 
   it 'registers an offense for eval as command' do
-    inspect_source(cop, 'eval something')
-    expect(cop.offenses.size).to eq(1)
-    expect(cop.highlights).to eq(['eval'])
+    expect_offense(<<-RUBY.strip_indent)
+      eval something
+      ^^^^ The use of `eval` is a serious security risk.
+    RUBY
   end
 
   it 'registers an offense `Binding#eval`' do
-    inspect_source(cop, 'binding.eval something')
-    expect(cop.offenses.size).to eq(1)
-    expect(cop.highlights).to eq(['eval'])
+    expect_offense(<<-RUBY.strip_indent)
+      binding.eval something
+              ^^^^ The use of `eval` is a serious security risk.
+    RUBY
   end
 
   it 'registers an offense for eval with string that has an interpolation' do
-    inspect_source(cop, 'eval "something#{foo}"')
-    expect(cop.offenses.size).to eq(1)
-    expect(cop.highlights).to eq(['eval'])
+    expect_offense(<<-'RUBY'.strip_indent)
+      eval "something#{foo}"
+      ^^^^ The use of `eval` is a serious security risk.
+    RUBY
   end
 
   it 'accepts eval as variable' do
@@ -62,15 +66,17 @@ describe RuboCop::Cop::Security::Eval do
 
   context 'with an explicit binding, filename, and line number' do
     it 'registers an offense for eval as function' do
-      inspect_source(cop, 'eval(something, binding, "test.rb", 1)')
-      expect(cop.offenses.size).to eq(1)
-      expect(cop.highlights) .to eq(['eval'])
+      expect_offense(<<-RUBY.strip_indent)
+        eval(something, binding, "test.rb", 1)
+        ^^^^ The use of `eval` is a serious security risk.
+      RUBY
     end
 
     it 'registers an offense for eval as command' do
-      inspect_source(cop, 'eval something, binding, "test.rb", 1')
-      expect(cop.offenses.size).to eq(1)
-      expect(cop.highlights).to eq(['eval'])
+      expect_offense(<<-RUBY.strip_indent)
+        eval something, binding, "test.rb", 1
+        ^^^^ The use of `eval` is a serious security risk.
+      RUBY
     end
 
     it 'accepts eval on a literal string' do

--- a/spec/rubocop/cop/style/identical_conditional_branches_spec.rb
+++ b/spec/rubocop/cop/style/identical_conditional_branches_spec.rb
@@ -3,10 +3,6 @@
 describe RuboCop::Cop::Style::IdenticalConditionalBranches do
   subject(:cop) { described_class.new }
 
-  before do
-    inspect_source(cop, source)
-  end
-
   context 'on if..else with identical bodies' do
     let(:source) do
       <<-END.strip_indent
@@ -19,11 +15,15 @@ describe RuboCop::Cop::Style::IdenticalConditionalBranches do
     end
 
     it 'registers an offense' do
-      expect(cop.offenses.size).to eq(2)
-      expect(cop.messages).to eq([
-                                   'Move `do_x` out of the conditional.',
-                                   'Move `do_x` out of the conditional.'
-                                 ])
+      expect_offense(<<-RUBY.strip_indent)
+        if something
+          do_x
+          ^^^^ Move `do_x` out of the conditional.
+        else
+          do_x
+          ^^^^ Move `do_x` out of the conditional.
+        end
+      RUBY
     end
   end
 
@@ -41,11 +41,17 @@ describe RuboCop::Cop::Style::IdenticalConditionalBranches do
     end
 
     it 'registers an offense' do
-      expect(cop.offenses.size).to eq(2)
-      expect(cop.messages).to eq([
-                                   'Move `do_x` out of the conditional.',
-                                   'Move `do_x` out of the conditional.'
-                                 ])
+      expect_offense(<<-RUBY.strip_indent)
+        if something
+          method_call_here(1, 2, 3)
+          do_x
+          ^^^^ Move `do_x` out of the conditional.
+        else
+          1 + 2 + 3
+          do_x
+          ^^^^ Move `do_x` out of the conditional.
+        end
+      RUBY
     end
   end
 
@@ -63,11 +69,17 @@ describe RuboCop::Cop::Style::IdenticalConditionalBranches do
     end
 
     it 'registers an offense' do
-      expect(cop.offenses.size).to eq(2)
-      expect(cop.messages).to eq([
-                                   'Move `do_x` out of the conditional.',
-                                   'Move `do_x` out of the conditional.'
-                                 ])
+      expect_offense(<<-RUBY.strip_indent)
+        if something
+          do_x
+          ^^^^ Move `do_x` out of the conditional.
+          method_call_here(1, 2, 3)
+        else
+          do_x
+          ^^^^ Move `do_x` out of the conditional.
+          1 + 2 + 3
+        end
+      RUBY
     end
   end
 
@@ -118,12 +130,19 @@ describe RuboCop::Cop::Style::IdenticalConditionalBranches do
     end
 
     it 'registers an offense' do
-      expect(cop.offenses.size).to eq(3)
-      expect(cop.messages).to eq([
-                                   'Move `do_x` out of the conditional.',
-                                   'Move `do_x` out of the conditional.',
-                                   'Move `do_x` out of the conditional.'
-                                 ])
+      expect_offense(<<-RUBY.strip_indent)
+        case something
+        when :a
+          do_x
+          ^^^^ Move `do_x` out of the conditional.
+        when :b
+          do_x
+          ^^^^ Move `do_x` out of the conditional.
+        else
+          do_x
+          ^^^^ Move `do_x` out of the conditional.
+        end
+      RUBY
     end
   end
 
@@ -164,12 +183,22 @@ describe RuboCop::Cop::Style::IdenticalConditionalBranches do
     end
 
     it 'registers an offense' do
-      expect(cop.offenses.size).to eq(3)
-      expect(cop.messages).to eq([
-                                   'Move `do_x` out of the conditional.',
-                                   'Move `do_x` out of the conditional.',
-                                   'Move `do_x` out of the conditional.'
-                                 ])
+      expect_offense(<<-RUBY.strip_indent)
+        case something
+        when :a
+          x1
+          do_x
+          ^^^^ Move `do_x` out of the conditional.
+        when :b
+          x2
+          do_x
+          ^^^^ Move `do_x` out of the conditional.
+        else
+          x3
+          do_x
+          ^^^^ Move `do_x` out of the conditional.
+        end
+      RUBY
     end
   end
 
@@ -191,12 +220,22 @@ describe RuboCop::Cop::Style::IdenticalConditionalBranches do
     end
 
     it 'registers an offense' do
-      expect(cop.offenses.size).to eq(3)
-      expect(cop.messages).to eq([
-                                   'Move `do_x` out of the conditional.',
-                                   'Move `do_x` out of the conditional.',
-                                   'Move `do_x` out of the conditional.'
-                                 ])
+      expect_offense(<<-RUBY.strip_indent)
+        case something
+        when :a
+          do_x
+          ^^^^ Move `do_x` out of the conditional.
+          x1
+        when :b
+          do_x
+          ^^^^ Move `do_x` out of the conditional.
+          x2
+        else
+          do_x
+          ^^^^ Move `do_x` out of the conditional.
+          x3
+        end
+      RUBY
     end
   end
 

--- a/spec/rubocop/cop/style/if_inside_else_spec.rb
+++ b/spec/rubocop/cop/style/if_inside_else_spec.rb
@@ -4,54 +4,42 @@ describe RuboCop::Cop::Style::IfInsideElse do
   subject(:cop) { described_class.new }
 
   it 'catches an if node nested inside an else' do
-    inspect_source(cop, <<-END.strip_indent)
+    expect_offense(<<-RUBY.strip_indent)
       if a
         blah
       else
         if b
+        ^^ Convert `if` nested inside `else` to `elsif`.
           foo
         end
       end
-    END
-    expect(cop.offenses.size).to eq(1)
-    expect(cop.messages).to eq(
-      ['Convert `if` nested inside `else` to `elsif`.']
-    )
-    expect(cop.highlights).to eq(['if'])
+    RUBY
   end
 
   it 'catches an if..else nested inside an else' do
-    inspect_source(cop, <<-END.strip_indent)
+    expect_offense(<<-RUBY.strip_indent)
       if a
         blah
       else
         if b
+        ^^ Convert `if` nested inside `else` to `elsif`.
           foo
         else
           bar
         end
       end
-    END
-    expect(cop.offenses.size).to eq(1)
-    expect(cop.messages).to eq(
-      ['Convert `if` nested inside `else` to `elsif`.']
-    )
-    expect(cop.highlights).to eq(['if'])
+    RUBY
   end
 
   it 'catches a modifier if nested inside an else' do
-    inspect_source(cop, <<-END.strip_indent)
+    expect_offense(<<-RUBY.strip_indent)
       if a
         blah
       else
         foo if b
+            ^^ Convert `if` nested inside `else` to `elsif`.
       end
-    END
-    expect(cop.offenses.size).to eq(1)
-    expect(cop.messages).to eq(
-      ['Convert `if` nested inside `else` to `elsif`.']
-    )
-    expect(cop.highlights).to eq(['if'])
+    RUBY
   end
 
   it "isn't offended if there is a statement following the if node" do

--- a/spec/rubocop/cop/style/if_unless_modifier_of_if_unless_spec.rb
+++ b/spec/rubocop/cop/style/if_unless_modifier_of_if_unless_spec.rb
@@ -18,8 +18,10 @@ describe RuboCop::Cop::Style::IfUnlessModifierOfIfUnless do
     end
 
     it 'registers an offense' do
-      inspect_source(cop, source)
-      expect(cop.offenses.size).to eq(1)
+      expect_offense(<<-RUBY.strip_indent)
+        condition ? then_part : else_part unless external_condition
+                                          ^^^^^^ Avoid modifier `unless` after another conditional.
+      RUBY
     end
   end
 
@@ -33,8 +35,12 @@ describe RuboCop::Cop::Style::IfUnlessModifierOfIfUnless do
     end
 
     it 'registers an offense' do
-      inspect_source(cop, source)
-      expect(cop.offenses.size).to eq(1)
+      expect_offense(<<-RUBY.strip_indent)
+        unless condition
+          then_part
+        end if external_condition
+            ^^ Avoid modifier `if` after another conditional.
+      RUBY
     end
   end
 

--- a/spec/rubocop/cop/style/if_unless_modifier_spec.rb
+++ b/spec/rubocop/cop/style/if_unless_modifier_spec.rb
@@ -67,12 +67,12 @@ describe RuboCop::Cop::Style::IfUnlessModifier do
     end
 
     it 'registers an offense' do
-      inspect_source(cop, source)
-      expect(cop.messages).to eq(
-        ['Favor modifier `if` usage when having a single-line' \
-         ' body. Another good alternative is the usage of control flow' \
-         ' `&&`/`||`.']
-      )
+      expect_offense(<<-RUBY.strip_indent)
+        if a # comment
+        ^^ Favor modifier `if` usage when having a single-line body. Another good alternative is the usage of control flow `&&`/`||`.
+          b
+        end
+      RUBY
     end
 
     it 'does auto-correction and preserves comment' do
@@ -120,8 +120,22 @@ describe RuboCop::Cop::Style::IfUnlessModifier do
     end
 
     it 'registers an offense' do
-      inspect_source(cop, source)
-      expect(cop.offenses.size).to eq(1)
+      expect_offense(<<-RUBY.strip_indent)
+        if x
+          y
+        elsif x1
+          y1
+        else
+          z
+        end
+        n = a ? 0 : 1
+        m = 3 if m0
+
+        if a
+        ^^ Favor modifier `if` usage when having a single-line body. Another good alternative is the usage of control flow `&&`/`||`.
+          b
+        end
+      RUBY
     end
 
     it 'does auto-correction' do
@@ -160,12 +174,12 @@ describe RuboCop::Cop::Style::IfUnlessModifier do
     end
 
     it 'registers an offense' do
-      inspect_source(cop, source)
-      expect(cop.messages).to eq(
-        ['Favor modifier `unless` usage when having a single-line' \
-         ' body. Another good alternative is the usage of control flow' \
-         ' `&&`/`||`.']
-      )
+      expect_offense(<<-RUBY.strip_indent)
+        unless a
+        ^^^^^^ Favor modifier `unless` usage when having a single-line body. Another good alternative is the usage of control flow `&&`/`||`.
+          b
+        end
+      RUBY
     end
 
     it 'does auto-correction' do

--- a/spec/rubocop/cop/style/if_with_semicolon_spec.rb
+++ b/spec/rubocop/cop/style/if_with_semicolon_spec.rb
@@ -4,10 +4,10 @@ describe RuboCop::Cop::Style::IfWithSemicolon do
   subject(:cop) { described_class.new }
 
   it 'registers an offense for one line if/;/end' do
-    inspect_source(cop, 'if cond; run else dont end')
-    expect(cop.messages).to eq(
-      ['Do not use if x; Use the ternary operator instead.']
-    )
+    expect_offense(<<-RUBY.strip_indent)
+      if cond; run else dont end
+      ^^^^^^^^^^^^^^^^^^^^^^^^^^ Do not use if x; Use the ternary operator instead.
+    RUBY
   end
 
   it 'accepts one line if/then/end' do

--- a/spec/rubocop/cop/style/inline_comment_spec.rb
+++ b/spec/rubocop/cop/style/inline_comment_spec.rb
@@ -4,11 +4,10 @@ describe RuboCop::Cop::Style::InlineComment do
   subject(:cop) { described_class.new }
 
   it 'registers an offense for a trailing inline comment' do
-    inspect_source(cop, 'two = 1 + 1 # A trailing inline comment')
-
-    expect(cop.offenses.size).to eq(1)
-    expect(cop.messages).to eq(['Avoid trailing inline comments.'])
-    expect(cop.highlights).to eq(['# A trailing inline comment'])
+    expect_offense(<<-RUBY.strip_indent)
+      two = 1 + 1 # A trailing inline comment
+                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^ Avoid trailing inline comments.
+    RUBY
   end
 
   it 'does not register an offense for a standalone comment' do

--- a/spec/rubocop/cop/style/inverse_methods_spec.rb
+++ b/spec/rubocop/cop/style/inverse_methods_spec.rb
@@ -25,17 +25,17 @@ describe RuboCop::Cop::Style::InverseMethods do
   subject(:cop) { described_class.new(config) }
 
   it 'registers an offense for calling !.none? with a symbol proc' do
-    inspect_source(cop, '!foo.none?(&:even?)')
-
-    expect(cop.messages).to eq(['Use `any?` instead of inverting `none?`.'])
-    expect(cop.highlights).to eq(['!foo.none?(&:even?)'])
+    expect_offense(<<-RUBY.strip_indent)
+      !foo.none?(&:even?)
+      ^^^^^^^^^^^^^^^^^^^ Use `any?` instead of inverting `none?`.
+    RUBY
   end
 
   it 'registers an offense for calling !.none? with a block' do
-    inspect_source(cop, '!foo.none? { |f| f.even? }')
-
-    expect(cop.messages).to eq(['Use `any?` instead of inverting `none?`.'])
-    expect(cop.highlights).to eq(['!foo.none? { |f| f.even? }'])
+    expect_offense(<<-RUBY.strip_indent)
+      !foo.none? { |f| f.even? }
+      ^^^^^^^^^^^^^^^^^^^^^^^^^^ Use `any?` instead of inverting `none?`.
+    RUBY
   end
 
   it 'allows a method call without a not' do
@@ -168,10 +168,10 @@ describe RuboCop::Cop::Style::InverseMethods do
       end
 
       it 'registers an offense for an inverted equality block' do
-        inspect_source(cop, "foo.#{method} { |e| e != 2 }")
-
-        expect(cop.messages)
-          .to eq(["Use `#{inverse}` instead of inverting `#{method}`."])
+        expect_offense(<<-RUBY.strip_indent)
+          foo.select { |e| e != 2 }
+          ^^^^^^^^^^^^^^^^^^^^^^^^^ Use `reject` instead of inverting `select`.
+        RUBY
       end
 
       it 'registers an offense for a multiline inverted equality block' do

--- a/spec/rubocop/cop/style/line_end_concatenation_spec.rb
+++ b/spec/rubocop/cop/style/line_end_concatenation_spec.rb
@@ -4,57 +4,64 @@ describe RuboCop::Cop::Style::LineEndConcatenation do
   subject(:cop) { described_class.new }
 
   it 'registers an offense for string concat at line end' do
-    inspect_source(cop,
-                   ['top = "test" +',
-                    '"top"'])
-    expect(cop.offenses.size).to eq(1)
-    expect(cop.highlights).to eq(['+'])
+    expect_offense(<<-RUBY.strip_indent)
+      top = "test" +
+                   ^ Use `\\` instead of `+` or `<<` to concatenate those strings.
+      "top"
+    RUBY
   end
 
   it 'registers an offense for string concat with << at line end' do
-    inspect_source(cop,
-                   ['top = "test" <<',
-                    '"top"'])
-    expect(cop.offenses.size).to eq(1)
-    expect(cop.highlights).to eq(['<<'])
+    expect_offense(<<-RUBY.strip_indent)
+      top = "test" <<
+                   ^^ Use `\\` instead of `+` or `<<` to concatenate those strings.
+      "top"
+    RUBY
   end
 
   it 'registers an offense for string concat with << and \ at line ends' do
-    inspect_source(cop,
-                   ['top = "test " \\',
-                    '"foo" <<',
-                    '"bar"'])
-    expect(cop.offenses.size).to eq(1)
+    expect_offense(<<-RUBY.strip_indent)
+      top = "test " \\
+      "foo" <<
+            ^^ Use `\\` instead of `+` or `<<` to concatenate those strings.
+      "bar"
+    RUBY
   end
 
   it 'registers an offense for dynamic string concat at line end' do
-    inspect_source(cop,
-                   ['top = "test#{x}" +',
-                    '"top"'])
-    expect(cop.offenses.size).to eq(1)
+    expect_offense(<<-'RUBY'.strip_indent)
+      top = "test#{x}" +
+                       ^ Use `\` instead of `+` or `<<` to concatenate those strings.
+      "top"
+    RUBY
   end
 
   it 'registers an offense for dynamic string concat with << at line end' do
-    inspect_source(cop,
-                   ['top = "test#{x}" <<',
-                    '"top"'])
-    expect(cop.offenses.size).to eq(1)
+    expect_offense(<<-'RUBY'.strip_indent)
+      top = "test#{x}" <<
+                       ^^ Use `\` instead of `+` or `<<` to concatenate those strings.
+      "top"
+    RUBY
   end
 
   it 'registers multiple offenses when there are chained << methods' do
-    inspect_source(cop,
-                   ['top = "test#{x}" <<',
-                    '"top" <<',
-                    '"ubertop"'])
-    expect(cop.offenses.size).to eq(2)
+    expect_offense(<<-'RUBY'.strip_indent)
+      top = "test#{x}" <<
+                       ^^ Use `\` instead of `+` or `<<` to concatenate those strings.
+      "top" <<
+            ^^ Use `\` instead of `+` or `<<` to concatenate those strings.
+      "ubertop"
+    RUBY
   end
 
   it 'registers multiple offenses when there are chained concatenations' do
-    inspect_source(cop,
-                   ['top = "test#{x}" +',
-                    '"top" +',
-                    '"foo"'])
-    expect(cop.offenses.size).to eq(2)
+    expect_offense(<<-'RUBY'.strip_indent)
+      top = "test#{x}" +
+                       ^ Use `\` instead of `+` or `<<` to concatenate those strings.
+      "top" +
+            ^ Use `\` instead of `+` or `<<` to concatenate those strings.
+      "foo"
+    RUBY
   end
 
   it 'registers multiple offenses when there are chained concatenations' \
@@ -132,13 +139,14 @@ describe RuboCop::Cop::Style::LineEndConcatenation do
 
   it 'registers offenses only for the appropriate lines in chained concats' do
     # only the last concatenation is an offense
-    inspect_source(cop,
-                   ['top = "test#{x}" + # comment',
-                    '"foo" +',
-                    '%(bar) +',
-                    '"baz" +',
-                    '"qux"'])
-    expect(cop.offenses.size).to eq(1)
+    expect_offense(<<-'RUBY'.strip_indent)
+      top = "test#{x}" + # comment
+      "foo" +
+      %(bar) +
+      "baz" +
+            ^ Use `\` instead of `+` or `<<` to concatenate those strings.
+      "qux"
+    RUBY
   end
 
   it 'autocorrects in the simple case by replacing + with \\' do

--- a/spec/rubocop/cop/style/method_call_with_args_parentheses_spec.rb
+++ b/spec/rubocop/cop/style/method_call_with_args_parentheses_spec.rb
@@ -15,23 +15,31 @@ describe RuboCop::Cop::Style::MethodCallWithArgsParentheses, :config do
   end
 
   it 'register an offense for method call without parens' do
-    inspect_source(cop, 'top.test a, b')
-    expect(cop.offenses.size).to eq(1)
+    expect_offense(<<-RUBY.strip_indent)
+      top.test a, b
+          ^^^^ Use parentheses for method calls with arguments.
+    RUBY
   end
 
   it 'register an offense for non-reciever method call without parens' do
-    inspect_source(cop, 'test a, b')
-    expect(cop.offenses.size).to eq(1)
+    expect_offense(<<-RUBY.strip_indent)
+      test a, b
+      ^^^^ Use parentheses for method calls with arguments.
+    RUBY
   end
 
   it 'register an offense for methods starting with a capital without parens' do
-    inspect_source(cop, 'Test a, b')
-    expect(cop.offenses.size).to eq(1)
+    expect_offense(<<-RUBY.strip_indent)
+      Test a, b
+      ^^^^ Use parentheses for method calls with arguments.
+    RUBY
   end
 
   it 'register an offense for superclass call without parens' do
-    inspect_source(cop, 'super a')
-    expect(cop.offenses.size).to eq(1)
+    expect_offense(<<-RUBY.strip_indent)
+      super a
+      ^^^^^ Use parentheses for method calls with arguments.
+    RUBY
   end
 
   it 'register no offense for superclass call without args' do
@@ -47,8 +55,10 @@ describe RuboCop::Cop::Style::MethodCallWithArgsParentheses, :config do
   end
 
   it 'register an offense for yield without parens' do
-    inspect_source(cop, 'yield a')
-    expect(cop.offenses.size).to eq(1)
+    expect_offense(<<-RUBY.strip_indent)
+      yield a
+      ^^^^^ Use parentheses for method calls with arguments.
+    RUBY
   end
 
   it 'accepts no parens for operators' do

--- a/spec/rubocop/cop/style/method_call_without_args_parentheses_spec.rb
+++ b/spec/rubocop/cop/style/method_call_without_args_parentheses_spec.rb
@@ -4,8 +4,10 @@ describe RuboCop::Cop::Style::MethodCallWithoutArgsParentheses do
   subject(:cop) { described_class.new }
 
   it 'registers an offense for parens in method call without args' do
-    inspect_source(cop, 'top.test()')
-    expect(cop.offenses.size).to eq(1)
+    expect_offense(<<-RUBY.strip_indent)
+      top.test()
+              ^ Do not use parentheses for method calls with no arguments.
+    RUBY
   end
 
   it 'accepts parentheses for methods starting with an upcase letter' do
@@ -55,18 +57,24 @@ describe RuboCop::Cop::Style::MethodCallWithoutArgsParentheses do
   end
 
   it 'registers an offense for `obj.method ||= func()`' do
-    inspect_source(cop, 'obj.method ||= func()')
-    expect(cop.offenses.size).to eq 1
+    expect_offense(<<-RUBY.strip_indent)
+      obj.method ||= func()
+                         ^ Do not use parentheses for method calls with no arguments.
+    RUBY
   end
 
   it 'registers an offense for `obj.method &&= func()`' do
-    inspect_source(cop, 'obj.method &&= func()')
-    expect(cop.offenses.size).to eq 1
+    expect_offense(<<-RUBY.strip_indent)
+      obj.method &&= func()
+                         ^ Do not use parentheses for method calls with no arguments.
+    RUBY
   end
 
   it 'registers an offense for `obj.method += func()`' do
-    inspect_source(cop, 'obj.method += func()')
-    expect(cop.offenses.size).to eq 1
+    expect_offense(<<-RUBY.strip_indent)
+      obj.method += func()
+                        ^ Do not use parentheses for method calls with no arguments.
+    RUBY
   end
 
   it 'auto-corrects by removing unneeded braces' do
@@ -96,13 +104,17 @@ describe RuboCop::Cop::Style::MethodCallWithoutArgsParentheses do
     end
 
     it 'registers an offense with empty parens' do
-      inspect_source(cop, '_a = c(d())')
-      expect(cop.offenses.size).to eq 1
+      expect_offense(<<-RUBY.strip_indent)
+        _a = c(d())
+                ^ Do not use parentheses for method calls with no arguments.
+      RUBY
     end
 
     it 'registers an empty parens offense for multiple assignment' do
-      inspect_source(cop, '_a, _b, _c = d(e())')
-      expect(cop.offenses.size).to eq 1
+      expect_offense(<<-RUBY.strip_indent)
+        _a, _b, _c = d(e())
+                        ^ Do not use parentheses for method calls with no arguments.
+      RUBY
     end
   end
 end

--- a/spec/rubocop/cop/style/method_name_spec.rb
+++ b/spec/rubocop/cop/style/method_name_spec.rb
@@ -111,13 +111,12 @@ describe RuboCop::Cop::Style::MethodName, :config do
     end
 
     it 'registers an offense for camel case in singleton method name' do
-      inspect_source(cop, <<-END.strip_indent)
+      expect_offense(<<-RUBY.strip_indent)
         def self.myMethod
+                 ^^^^^^^^ Use snake_case for method names.
           # ...
         end
-      END
-      expect(cop.offenses.size).to eq(1)
-      expect(cop.highlights).to eq(['myMethod'])
+      RUBY
     end
 
     it 'accepts snake case in names' do
@@ -128,13 +127,13 @@ describe RuboCop::Cop::Style::MethodName, :config do
     end
 
     it 'registers an offense for singleton camelCase method within class' do
-      inspect_source(cop, <<-END.strip_indent)
+      expect_offense(<<-RUBY.strip_indent)
         class Sequel
           def self.fooBar
+                   ^^^^^^ Use snake_case for method names.
           end
         end
-      END
-      expect(cop.highlights).to eq(['fooBar'])
+      RUBY
     end
 
     include_examples 'never accepted'
@@ -183,13 +182,13 @@ describe RuboCop::Cop::Style::MethodName, :config do
     end
 
     it 'registers an offense for singleton snake_case method within class' do
-      inspect_source(cop, <<-END.strip_indent)
+      expect_offense(<<-RUBY.strip_indent)
         class Sequel
           def self.foo_bar
+                   ^^^^^^^ Use camelCase for method names.
           end
         end
-      END
-      expect(cop.highlights).to eq(['foo_bar'])
+      RUBY
     end
 
     include_examples 'always accepted'

--- a/spec/rubocop/cop/style/missing_else_spec.rb
+++ b/spec/rubocop/cop/style/missing_else_spec.rb
@@ -37,9 +37,10 @@ describe RuboCop::Cop::Style::MissingElse do
 
       context 'with no else-clause' do
         it 'registers an offense' do
-          inspect_source(cop, 'if cond; foo end')
-          expect(cop.messages)
-            .to eq(['`if` condition requires an `else`-clause.'])
+          expect_offense(<<-RUBY.strip_indent)
+            if cond; foo end
+            ^^^^^^^^^^^^^^^^ `if` condition requires an `else`-clause.
+          RUBY
         end
       end
     end
@@ -98,9 +99,10 @@ describe RuboCop::Cop::Style::MissingElse do
 
       context 'with no else-clause' do
         it 'registers an offense' do
-          inspect_source(cop, 'case v; when a; foo; when b; bar; end')
-          expect(cop.messages)
-            .to eq(['`case` condition requires an `else`-clause.'])
+          expect_offense(<<-RUBY.strip_indent)
+            case v; when a; foo; when b; bar; end
+            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ `case` condition requires an `else`-clause.
+          RUBY
         end
       end
     end
@@ -140,9 +142,10 @@ describe RuboCop::Cop::Style::MissingElse do
 
       context 'with no else-clause' do
         it 'registers an offense' do
-          inspect_source(cop, 'if cond; foo end')
-          expect(cop.messages)
-            .to eq(['`if` condition requires an `else`-clause.'])
+          expect_offense(<<-RUBY.strip_indent)
+            if cond; foo end
+            ^^^^^^^^^^^^^^^^ `if` condition requires an `else`-clause.
+          RUBY
         end
       end
     end
@@ -171,9 +174,10 @@ describe RuboCop::Cop::Style::MissingElse do
 
       context 'with no else-clause' do
         it 'registers an offense' do
-          inspect_source(cop, 'unless cond; foo end')
-          expect(cop.messages)
-            .to eq(['`if` condition requires an `else`-clause.'])
+          expect_offense(<<-RUBY.strip_indent)
+            unless cond; foo end
+            ^^^^^^^^^^^^^^^^^^^^ `if` condition requires an `else`-clause.
+          RUBY
         end
       end
     end
@@ -202,9 +206,10 @@ describe RuboCop::Cop::Style::MissingElse do
 
       context 'with no else-clause' do
         it 'registers an offense' do
-          inspect_source(cop, 'case v; when a; foo; when b; bar; end')
-          expect(cop.messages)
-            .to eq(['`case` condition requires an `else`-clause.'])
+          expect_offense(<<-RUBY.strip_indent)
+            case v; when a; foo; when b; bar; end
+            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ `case` condition requires an `else`-clause.
+          RUBY
         end
       end
     end
@@ -257,8 +262,10 @@ describe RuboCop::Cop::Style::MissingElse do
         end
 
         it 'highlights' do
-          inspect_source(cop, 'if cond; foo end')
-          expect(cop.highlights).to eq(['if cond; foo end'])
+          expect_offense(<<-RUBY.strip_indent)
+            if cond; foo end
+            ^^^^^^^^^^^^^^^^ `if` condition requires an `else`-clause with `nil` in it.
+          RUBY
         end
       end
     end
@@ -368,9 +375,10 @@ describe RuboCop::Cop::Style::MissingElse do
 
       context 'with no else-clause' do
         it 'registers an offense' do
-          inspect_source(cop, 'if cond; foo end')
-          expect(cop.messages)
-            .to eq(['`if` condition requires an empty `else`-clause.'])
+          expect_offense(<<-RUBY.strip_indent)
+            if cond; foo end
+            ^^^^^^^^^^^^^^^^ `if` condition requires an empty `else`-clause.
+          RUBY
         end
       end
     end
@@ -399,9 +407,10 @@ describe RuboCop::Cop::Style::MissingElse do
 
       context 'with no else-clause' do
         it 'registers an offense' do
-          inspect_source(cop, 'unless cond; foo end')
-          expect(cop.messages)
-            .to eq(['`if` condition requires an empty `else`-clause.'])
+          expect_offense(<<-RUBY.strip_indent)
+            unless cond; foo end
+            ^^^^^^^^^^^^^^^^^^^^ `if` condition requires an empty `else`-clause.
+          RUBY
         end
       end
     end
@@ -430,9 +439,10 @@ describe RuboCop::Cop::Style::MissingElse do
 
       context 'with no else-clause' do
         it 'registers an offense' do
-          inspect_source(cop, 'case v; when a; foo; when b; bar; end')
-          expect(cop.messages)
-            .to eq(['`case` condition requires an empty `else`-clause.'])
+          expect_offense(<<-RUBY.strip_indent)
+            case v; when a; foo; when b; bar; end
+            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ `case` condition requires an empty `else`-clause.
+          RUBY
         end
       end
     end
@@ -478,9 +488,10 @@ describe RuboCop::Cop::Style::MissingElse do
 
       context 'with no else-clause' do
         it 'registers an offense' do
-          inspect_source(cop, 'if cond; foo end')
-          expect(cop.messages)
-            .to eq(['`if` condition requires an empty `else`-clause.'])
+          expect_offense(<<-RUBY.strip_indent)
+            if cond; foo end
+            ^^^^^^^^^^^^^^^^ `if` condition requires an empty `else`-clause.
+          RUBY
         end
       end
     end
@@ -509,9 +520,10 @@ describe RuboCop::Cop::Style::MissingElse do
 
       context 'with no else-clause' do
         it 'registers an offense' do
-          inspect_source(cop, 'unless cond; foo end')
-          expect(cop.messages)
-            .to eq(['`if` condition requires an empty `else`-clause.'])
+          expect_offense(<<-RUBY.strip_indent)
+            unless cond; foo end
+            ^^^^^^^^^^^^^^^^^^^^ `if` condition requires an empty `else`-clause.
+          RUBY
         end
       end
     end
@@ -647,9 +659,10 @@ describe RuboCop::Cop::Style::MissingElse do
 
       context 'with no else-clause' do
         it 'registers an offense' do
-          inspect_source(cop, 'case v; when a; foo; when b; bar; end')
-          expect(cop.messages)
-            .to eq(['`case` condition requires an empty `else`-clause.'])
+          expect_offense(<<-RUBY.strip_indent)
+            case v; when a; foo; when b; bar; end
+            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ `case` condition requires an empty `else`-clause.
+          RUBY
         end
       end
     end

--- a/spec/rubocop/cop/style/module_function_spec.rb
+++ b/spec/rubocop/cop/style/module_function_spec.rb
@@ -7,14 +7,13 @@ describe RuboCop::Cop::Style::ModuleFunction, :config do
     let(:cop_config) { { 'EnforcedStyle' => 'module_function' } }
 
     it 'registers an offense for `extend self` in a module' do
-      inspect_source(cop, <<-END.strip_indent)
+      expect_offense(<<-RUBY.strip_indent)
         module Test
           extend self
+          ^^^^^^^^^^^ Use `module_function` instead of `extend self`.
           def test; end
         end
-      END
-      expect(cop.messages).to eq([described_class::MODULE_FUNCTION_MSG])
-      expect(cop.highlights).to eq(['extend self'])
+      RUBY
     end
 
     it 'accepts `extend self` in a class' do
@@ -30,14 +29,13 @@ describe RuboCop::Cop::Style::ModuleFunction, :config do
     let(:cop_config) { { 'EnforcedStyle' => 'extend_self' } }
 
     it 'registers an offense for `module_function` without an argument' do
-      inspect_source(cop, <<-END.strip_indent)
+      expect_offense(<<-RUBY.strip_indent)
         module Test
           module_function
+          ^^^^^^^^^^^^^^^ Use `extend self` instead of `module_function`.
           def test; end
         end
-      END
-      expect(cop.messages).to eq([described_class::EXTEND_SELF_MSG])
-      expect(cop.highlights).to eq(['module_function'])
+      RUBY
     end
 
     it 'accepts module_function with an argument' do

--- a/spec/rubocop/cop/style/multiline_block_chain_spec.rb
+++ b/spec/rubocop/cop/style/multiline_block_chain_spec.rb
@@ -5,41 +5,39 @@ describe RuboCop::Cop::Style::MultilineBlockChain do
 
   context 'with multi-line block chaining' do
     it 'registers an offense for a simple case' do
-      inspect_source(cop, <<-END.strip_indent)
+      expect_offense(<<-RUBY.strip_indent)
         a do
           b
         end.c do
+        ^^^^^ Avoid multi-line chains of blocks.
           d
         end
-      END
-      expect(cop.offenses.size).to eq(1)
-      expect(cop.highlights).to eq(['end.c'])
+      RUBY
     end
 
     it 'registers an offense for a slightly more complicated case' do
-      inspect_source(cop, <<-END.strip_indent)
+      expect_offense(<<-RUBY.strip_indent)
         a do
           b
         end.c1.c2 do
+        ^^^^^^^^^ Avoid multi-line chains of blocks.
           d
         end
-      END
-      expect(cop.offenses.size).to eq(1)
-      expect(cop.highlights).to eq(['end.c1.c2'])
+      RUBY
     end
 
     it 'registers two offenses for a chain of three blocks' do
-      inspect_source(cop, <<-END.strip_indent)
+      expect_offense(<<-RUBY.strip_indent)
         a do
           b
         end.c do
+        ^^^^^ Avoid multi-line chains of blocks.
           d
         end.e do
+        ^^^^^ Avoid multi-line chains of blocks.
           f
         end
-      END
-      expect(cop.offenses.size).to eq(2)
-      expect(cop.highlights).to eq(['end.c', 'end.e'])
+      RUBY
     end
 
     it 'registers an offense for a chain where the second block is ' \

--- a/spec/rubocop/cop/style/multiline_if_then_spec.rb
+++ b/spec/rubocop/cop/style/multiline_if_then_spec.rb
@@ -31,16 +31,14 @@ describe RuboCop::Cop::Style::MultilineIfThen do
   end
 
   it 'registers an offense for then in multiline elsif' do
-    inspect_source(cop, <<-END.strip_indent)
+    expect_offense(<<-RUBY.strip_indent)
       if cond1
         a
       elsif cond2 then
+                  ^^^^ Do not use `then` for multi-line `elsif`.
         b
       end
-    END
-    expect(cop.offenses.map(&:line)).to eq([3])
-    expect(cop.highlights).to eq(['then'])
-    expect(cop.messages).to eq(['Do not use `then` for multi-line `elsif`.'])
+    RUBY
   end
 
   it 'accepts multiline if without then' do

--- a/spec/rubocop/cop/style/negated_if_spec.rb
+++ b/spec/rubocop/cop/style/negated_if_spec.rb
@@ -185,11 +185,10 @@ describe RuboCop::Cop::Style::NegatedIf do
     end
 
     it 'registers an offence for postfix' do
-      inspect_source(cop, 'foo if !bar')
-
-      expect(cop.messages).to eq(
-        ['Favor `unless` over `if` for negative conditions.']
-      )
+      expect_offense(<<-RUBY.strip_indent)
+        foo if !bar
+        ^^^^^^^^^^^ Favor `unless` over `if` for negative conditions.
+      RUBY
     end
 
     it 'does not register an offence for prefix' do

--- a/spec/rubocop/cop/style/nested_modifier_spec.rb
+++ b/spec/rubocop/cop/style/nested_modifier_spec.rb
@@ -81,8 +81,9 @@ describe RuboCop::Cop::Style::NestedModifier do
   end
 
   it 'registers one offense for more than two modifiers' do
-    inspect_source(cop, 'something until a while b unless c if d')
-    expect(cop.messages).to eq(['Avoid using nested modifiers.'])
-    expect(cop.highlights).to eq(['unless'])
+    expect_offense(<<-RUBY.strip_indent)
+      something until a while b unless c if d
+                                ^^^^^^ Avoid using nested modifiers.
+    RUBY
   end
 end

--- a/spec/rubocop/cop/style/nested_parenthesized_calls_spec.rb
+++ b/spec/rubocop/cop/style/nested_parenthesized_calls_spec.rb
@@ -3,10 +3,6 @@
 describe RuboCop::Cop::Style::NestedParenthesizedCalls do
   subject(:cop) { described_class.new }
 
-  before do
-    inspect_source(cop, source)
-  end
-
   context 'on a non-parenthesized method call' do
     let(:source) { 'puts 1, 2' }
 
@@ -36,11 +32,10 @@ describe RuboCop::Cop::Style::NestedParenthesizedCalls do
       let(:source) { 'puts(compute something)' }
 
       it 'registers an offense' do
-        expect(cop.offenses.size).to eq(1)
-        expect(cop.messages).to eq(
-          ['Add parentheses to nested method call `compute something`.']
-        )
-        expect(cop.highlights).to eq(['compute something'])
+        expect_offense(<<-RUBY.strip_indent)
+          puts(compute something)
+               ^^^^^^^^^^^^^^^^^ Add parentheses to nested method call `compute something`.
+        RUBY
       end
 
       it 'auto-corrects by adding parentheses' do
@@ -53,11 +48,10 @@ describe RuboCop::Cop::Style::NestedParenthesizedCalls do
       let(:source) { 'puts(compute first, second)' }
 
       it 'registers an offense' do
-        expect(cop.offenses.size).to eq(1)
-        expect(cop.messages).to eq(
-          ['Add parentheses to nested method call `compute first, second`.']
-        )
-        expect(cop.highlights).to eq(['compute first, second'])
+        expect_offense(<<-RUBY.strip_indent)
+          puts(compute first, second)
+               ^^^^^^^^^^^^^^^^^^^^^ Add parentheses to nested method call `compute first, second`.
+        RUBY
       end
 
       it 'auto-corrects by adding parentheses' do

--- a/spec/rubocop/cop/style/nested_ternary_operator_spec.rb
+++ b/spec/rubocop/cop/style/nested_ternary_operator_spec.rb
@@ -4,8 +4,10 @@ describe RuboCop::Cop::Style::NestedTernaryOperator do
   subject(:cop) { described_class.new }
 
   it 'registers an offense for a nested ternary operator expression' do
-    inspect_source(cop, 'a ? (b ? b1 : b2) : a2')
-    expect(cop.offenses.size).to eq(1)
+    expect_offense(<<-RUBY.strip_indent)
+      a ? (b ? b1 : b2) : a2
+           ^^^^^^^^^^^ Ternary operators must not be nested. Prefer `if` or `else` constructs instead.
+    RUBY
   end
 
   it 'accepts a non-nested ternary operator within an if' do

--- a/spec/rubocop/cop/style/nil_comparison_spec.rb
+++ b/spec/rubocop/cop/style/nil_comparison_spec.rb
@@ -4,15 +4,17 @@ describe RuboCop::Cop::Style::NilComparison do
   subject(:cop) { described_class.new }
 
   it 'registers an offense for == nil' do
-    inspect_source(cop, 'x == nil')
-    expect(cop.offenses.size).to eq(1)
-    expect(cop.highlights).to eq(['=='])
+    expect_offense(<<-RUBY.strip_indent)
+      x == nil
+        ^^ Prefer the use of the `nil?` predicate.
+    RUBY
   end
 
   it 'registers an offense for === nil' do
-    inspect_source(cop, 'x === nil')
-    expect(cop.offenses.size).to eq(1)
-    expect(cop.highlights).to eq(['==='])
+    expect_offense(<<-RUBY.strip_indent)
+      x === nil
+        ^^^ Prefer the use of the `nil?` predicate.
+    RUBY
   end
 
   it 'autocorrects by replacing == nil with .nil?' do

--- a/spec/rubocop/cop/style/non_nil_check_spec.rb
+++ b/spec/rubocop/cop/style/non_nil_check_spec.rb
@@ -11,11 +11,10 @@ describe RuboCop::Cop::Style::NonNilCheck, :config do
     end
 
     it 'registers an offense for != nil' do
-      inspect_source(cop, 'x != nil')
-      expect(cop.offenses.size).to eq(1)
-      expect(cop.highlights).to eq(['!='])
-      expect(cop.messages)
-        .to eq(['Prefer `!expression.nil?` over `expression != nil`.'])
+      expect_offense(<<-RUBY.strip_indent)
+        x != nil
+          ^^ Prefer `!expression.nil?` over `expression != nil`.
+      RUBY
     end
 
     it 'does not register an offense for != 0' do
@@ -98,18 +97,17 @@ describe RuboCop::Cop::Style::NonNilCheck, :config do
     end
 
     it 'registers an offense for `!x.nil?`' do
-      inspect_source(cop, '!x.nil?')
-      expect(cop.offenses.size).to eq(1)
-      expect(cop.messages)
-        .to eq(['Explicit non-nil checks are usually redundant.'])
-      expect(cop.highlights).to eq(['!x.nil?'])
+      expect_offense(<<-RUBY.strip_indent)
+        !x.nil?
+        ^^^^^^^ Explicit non-nil checks are usually redundant.
+      RUBY
     end
 
     it 'registers an offense for unless x.nil?' do
-      inspect_source(cop, 'puts b unless x.nil?')
-      expect(cop.messages)
-        .to eq(['Explicit non-nil checks are usually redundant.'])
-      expect(cop.highlights).to eq(['x.nil?'])
+      expect_offense(<<-RUBY.strip_indent)
+        puts b unless x.nil?
+                      ^^^^^^ Explicit non-nil checks are usually redundant.
+      RUBY
     end
 
     it 'does not register an offense for `x.nil?`' do
@@ -121,9 +119,10 @@ describe RuboCop::Cop::Style::NonNilCheck, :config do
     end
 
     it 'registers an offense for `not x.nil?`' do
-      inspect_source(cop, 'not x.nil?')
-      expect(cop.offenses.size).to eq(1)
-      expect(cop.highlights).to eq(['not x.nil?'])
+      expect_offense(<<-RUBY.strip_indent)
+        not x.nil?
+        ^^^^^^^^^^ Explicit non-nil checks are usually redundant.
+      RUBY
     end
 
     it 'does not blow up with ternary operators' do

--- a/spec/rubocop/cop/style/not_spec.rb
+++ b/spec/rubocop/cop/style/not_spec.rb
@@ -4,8 +4,10 @@ describe RuboCop::Cop::Style::Not, :config do
   subject(:cop) { described_class.new(config) }
 
   it 'registers an offense for not' do
-    inspect_source(cop, 'not test')
-    expect(cop.offenses.size).to eq(1)
+    expect_offense(<<-RUBY.strip_indent)
+      not test
+      ^^^ Use `!` instead of `not`.
+    RUBY
   end
 
   it 'does not register an offense for !' do

--- a/spec/rubocop/cop/style/op_method_spec.rb
+++ b/spec/rubocop/cop/style/op_method_spec.rb
@@ -18,14 +18,12 @@ describe RuboCop::Cop::Style::OpMethod do
   end
 
   it 'works properly even if the argument not surrounded with braces' do
-    inspect_source(cop, <<-END.strip_indent)
+    expect_offense(<<-RUBY.strip_indent)
       def + another
+            ^^^^^^^ When defining the `+` operator, name its argument `other`.
         another
       end
-    END
-    expect(cop.offenses.size).to eq(1)
-    expect(cop.messages)
-      .to eq(['When defining the `+` operator, name its argument `other`.'])
+    RUBY
   end
 
   it 'does not register an offense for arg named other' do

--- a/spec/rubocop/cop/style/parallel_assignment_spec.rb
+++ b/spec/rubocop/cop/style/parallel_assignment_spec.rb
@@ -98,15 +98,17 @@ describe RuboCop::Cop::Style::ParallelAssignment, :config do
   it_behaves_like('allowed', 'self.a, self.b = b, a')
 
   it 'highlights the entire expression' do
-    inspect_source(cop, 'a, b = 1, 2')
-
-    expect(cop.highlights).to eq(['a, b = 1, 2'])
+    expect_offense(<<-RUBY.strip_indent)
+      a, b = 1, 2
+      ^^^^^^^^^^^ Do not use parallel assignment.
+    RUBY
   end
 
   it 'does not highlight the modifier statement' do
-    inspect_source(cop, 'a, b = 1, 2 if true')
-
-    expect(cop.highlights).to eq(['a, b = 1, 2'])
+    expect_offense(<<-RUBY.strip_indent)
+      a, b = 1, 2 if true
+      ^^^^^^^^^^^ Do not use parallel assignment.
+    RUBY
   end
 
   describe 'autocorrect' do

--- a/spec/rubocop/cop/style/parentheses_around_condition_spec.rb
+++ b/spec/rubocop/cop/style/parentheses_around_condition_spec.rb
@@ -110,8 +110,10 @@ describe RuboCop::Cop::Style::ParenthesesAroundCondition, :config do
   end
 
   it 'does not blow up when the condition is a ternary op' do
-    inspect_source(cop, 'x if (a ? b : c)')
-    expect(cop.offenses.size).to eq(1)
+    expect_offense(<<-RUBY.strip_indent)
+      x if (a ? b : c)
+           ^^^^^^^^^^^ Don't use parentheses around the condition of an `if`.
+    RUBY
   end
 
   it 'does not blow up for empty if condition' do

--- a/spec/rubocop/cop/style/percent_literal_delimiters_spec.rb
+++ b/spec/rubocop/cop/style/percent_literal_delimiters_spec.rb
@@ -40,10 +40,10 @@ describe RuboCop::Cop::Style::PercentLiteralDelimiters, :config do
     end
 
     it 'registers an offense for other delimiters' do
-      inspect_source(cop, '%(string)')
-      expect(cop.messages).to eq(
-        ['`%`-literals should be delimited by `[` and `]`.']
-      )
+      expect_offense(<<-RUBY.strip_indent)
+        %(string)
+        ^^^^^^^^^ `%`-literals should be delimited by `[` and `]`.
+      RUBY
     end
 
     it 'does not register an offense for other delimiters ' \
@@ -65,10 +65,10 @@ describe RuboCop::Cop::Style::PercentLiteralDelimiters, :config do
     end
 
     it 'registers an offense for other delimiters' do
-      inspect_source(cop, '%q(string)')
-      expect(cop.messages).to eq(
-        ['`%q`-literals should be delimited by `[` and `]`.']
-      )
+      expect_offense(<<-RUBY.strip_indent)
+        %q(string)
+        ^^^^^^^^^^ `%q`-literals should be delimited by `[` and `]`.
+      RUBY
     end
 
     it 'does not register an offense for other delimiters ' \
@@ -84,10 +84,10 @@ describe RuboCop::Cop::Style::PercentLiteralDelimiters, :config do
     end
 
     it 'registers an offense for other delimiters' do
-      inspect_source(cop, '%Q(string)')
-      expect(cop.messages).to eq(
-        ['`%Q`-literals should be delimited by `[` and `]`.']
-      )
+      expect_offense(<<-RUBY.strip_indent)
+        %Q(string)
+        ^^^^^^^^^^ `%Q`-literals should be delimited by `[` and `]`.
+      RUBY
     end
 
     it 'does not register an offense for other delimiters ' \
@@ -109,10 +109,10 @@ describe RuboCop::Cop::Style::PercentLiteralDelimiters, :config do
     end
 
     it 'registers an offense for other delimiters' do
-      inspect_source(cop, '%w(some words)')
-      expect(cop.messages).to eq(
-        ['`%w`-literals should be delimited by `[` and `]`.']
-      )
+      expect_offense(<<-RUBY.strip_indent)
+        %w(some words)
+        ^^^^^^^^^^^^^^ `%w`-literals should be delimited by `[` and `]`.
+      RUBY
     end
 
     it 'does not register an offense for other delimiters ' \
@@ -128,10 +128,10 @@ describe RuboCop::Cop::Style::PercentLiteralDelimiters, :config do
     end
 
     it 'registers an offense for other delimiters' do
-      inspect_source(cop, '%W(some words)')
-      expect(cop.messages).to eq(
-        ['`%W`-literals should be delimited by `[` and `]`.']
-      )
+      expect_offense(<<-RUBY.strip_indent)
+        %W(some words)
+        ^^^^^^^^^^^^^^ `%W`-literals should be delimited by `[` and `]`.
+      RUBY
     end
 
     it 'does not register an offense for other delimiters ' \
@@ -153,10 +153,10 @@ describe RuboCop::Cop::Style::PercentLiteralDelimiters, :config do
     end
 
     it 'registers an offense for other delimiters' do
-      inspect_source(cop, '%r(regexp)')
-      expect(cop.messages).to eq(
-        ['`%r`-literals should be delimited by `[` and `]`.']
-      )
+      expect_offense(<<-RUBY.strip_indent)
+        %r(regexp)
+        ^^^^^^^^^^ `%r`-literals should be delimited by `[` and `]`.
+      RUBY
     end
 
     it 'does not register an offense for other delimiters ' \
@@ -178,10 +178,10 @@ describe RuboCop::Cop::Style::PercentLiteralDelimiters, :config do
     end
 
     it 'registers an offense for other delimiters' do
-      inspect_source(cop, '%i(some symbols)')
-      expect(cop.messages).to eq(
-        ['`%i`-literals should be delimited by `[` and `]`.']
-      )
+      expect_offense(<<-RUBY.strip_indent)
+        %i(some symbols)
+        ^^^^^^^^^^^^^^^^ `%i`-literals should be delimited by `[` and `]`.
+      RUBY
     end
   end
 
@@ -191,10 +191,10 @@ describe RuboCop::Cop::Style::PercentLiteralDelimiters, :config do
     end
 
     it 'registers an offense for other delimiters' do
-      inspect_source(cop, '%I(some words)')
-      expect(cop.messages).to eq(
-        ['`%I`-literals should be delimited by `[` and `]`.']
-      )
+      expect_offense(<<-RUBY.strip_indent)
+        %I(some words)
+        ^^^^^^^^^^^^^^ `%I`-literals should be delimited by `[` and `]`.
+      RUBY
     end
 
     it 'registers an offense for other delimiters ' \
@@ -212,10 +212,10 @@ describe RuboCop::Cop::Style::PercentLiteralDelimiters, :config do
     end
 
     it 'registers an offense for other delimiters' do
-      inspect_source(cop, '%s(symbol)')
-      expect(cop.messages).to eq(
-        ['`%s`-literals should be delimited by `[` and `]`.']
-      )
+      expect_offense(<<-RUBY.strip_indent)
+        %s(symbol)
+        ^^^^^^^^^^ `%s`-literals should be delimited by `[` and `]`.
+      RUBY
     end
   end
 
@@ -225,10 +225,10 @@ describe RuboCop::Cop::Style::PercentLiteralDelimiters, :config do
     end
 
     it 'registers an offense for other delimiters' do
-      inspect_source(cop, '%x(command)')
-      expect(cop.messages).to eq(
-        ['`%x`-literals should be delimited by `[` and `]`.']
-      )
+      expect_offense(<<-RUBY.strip_indent)
+        %x(command)
+        ^^^^^^^^^^^ `%x`-literals should be delimited by `[` and `]`.
+      RUBY
     end
 
     it 'does not register an offense for other delimiters ' \

--- a/spec/rubocop/cop/style/percent_q_literals_spec.rb
+++ b/spec/rubocop/cop/style/percent_q_literals_spec.rb
@@ -34,10 +34,10 @@ describe RuboCop::Cop::Style::PercentQLiterals, :config do
       end
 
       it 'registers offense for %Q' do
-        inspect_source(cop, '%Q(hi)')
-        expect(cop.messages)
-          .to eq(['Do not use `%Q` unless interpolation is needed.  Use `%q`.'])
-        expect(cop.highlights).to eq(['%Q('])
+        expect_offense(<<-RUBY.strip_indent)
+          %Q(hi)
+          ^^^ Do not use `%Q` unless interpolation is needed.  Use `%q`.
+        RUBY
       end
 
       it 'auto-corrects' do
@@ -68,9 +68,10 @@ describe RuboCop::Cop::Style::PercentQLiterals, :config do
 
     context 'without interpolation' do
       it 'registers offense for %q' do
-        inspect_source(cop, '%q(hi)')
-        expect(cop.messages).to eq(['Use `%Q` instead of `%q`.'])
-        expect(cop.highlights).to eq(['%q('])
+        expect_offense(<<-RUBY.strip_indent)
+          %q(hi)
+          ^^^ Use `%Q` instead of `%q`.
+        RUBY
       end
 
       it 'accepts %Q' do

--- a/spec/rubocop/cop/style/perl_backrefs_spec.rb
+++ b/spec/rubocop/cop/style/perl_backrefs_spec.rb
@@ -4,8 +4,10 @@ describe RuboCop::Cop::Style::PerlBackrefs do
   subject(:cop) { described_class.new }
 
   it 'registers an offense for $1' do
-    inspect_source(cop, 'puts $1')
-    expect(cop.offenses.size).to eq(1)
+    expect_offense(<<-RUBY.strip_indent)
+      puts $1
+           ^^ Avoid the use of Perl-style backrefs.
+    RUBY
   end
 
   it 'auto-corrects $1 to Regexp.last_match[1]' do

--- a/spec/rubocop/cop/style/preferred_hash_methods_spec.rb
+++ b/spec/rubocop/cop/style/preferred_hash_methods_spec.rb
@@ -7,11 +7,10 @@ describe RuboCop::Cop::Style::PreferredHashMethods, :config do
     let(:cop_config) { { 'EnforcedStyle' => 'short' } }
 
     it 'registers an offense for has_key? with one arg' do
-      inspect_source(cop,
-                     'o.has_key?(o)')
-      expect(cop.offenses.size).to eq(1)
-      expect(cop.messages)
-        .to eq(['Use `Hash#key?` instead of `Hash#has_key?`.'])
+      expect_offense(<<-RUBY.strip_indent)
+        o.has_key?(o)
+          ^^^^^^^^ Use `Hash#key?` instead of `Hash#has_key?`.
+      RUBY
     end
 
     it 'accepts has_key? with no args' do
@@ -19,11 +18,10 @@ describe RuboCop::Cop::Style::PreferredHashMethods, :config do
     end
 
     it 'registers an offense for has_value? with one arg' do
-      inspect_source(cop,
-                     'o.has_value?(o)')
-      expect(cop.offenses.size).to eq(1)
-      expect(cop.messages)
-        .to eq(['Use `Hash#value?` instead of `Hash#has_value?`.'])
+      expect_offense(<<-RUBY.strip_indent)
+        o.has_value?(o)
+          ^^^^^^^^^^ Use `Hash#value?` instead of `Hash#has_value?`.
+      RUBY
     end
 
     it 'accepts has_value? with no args' do
@@ -45,11 +43,10 @@ describe RuboCop::Cop::Style::PreferredHashMethods, :config do
     let(:cop_config) { { 'EnforcedStyle' => 'verbose' } }
 
     it 'registers an offense for key? with one arg' do
-      inspect_source(cop,
-                     'o.key?(o)')
-      expect(cop.offenses.size).to eq(1)
-      expect(cop.messages)
-        .to eq(['Use `Hash#has_key?` instead of `Hash#key?`.'])
+      expect_offense(<<-RUBY.strip_indent)
+        o.key?(o)
+          ^^^^ Use `Hash#has_key?` instead of `Hash#key?`.
+      RUBY
     end
 
     it 'accepts key? with no args' do
@@ -57,11 +54,10 @@ describe RuboCop::Cop::Style::PreferredHashMethods, :config do
     end
 
     it 'registers an offense for value? with one arg' do
-      inspect_source(cop,
-                     'o.value?(o)')
-      expect(cop.offenses.size).to eq(1)
-      expect(cop.messages)
-        .to eq(['Use `Hash#has_value?` instead of `Hash#value?`.'])
+      expect_offense(<<-RUBY.strip_indent)
+        o.value?(o)
+          ^^^^^^ Use `Hash#has_value?` instead of `Hash#value?`.
+      RUBY
     end
 
     it 'accepts value? with no args' do

--- a/spec/rubocop/cop/style/proc_spec.rb
+++ b/spec/rubocop/cop/style/proc_spec.rb
@@ -4,8 +4,10 @@ describe RuboCop::Cop::Style::Proc do
   subject(:cop) { described_class.new }
 
   it 'registers an offense for a Proc.new call' do
-    inspect_source(cop, 'f = Proc.new { |x| puts x }')
-    expect(cop.offenses.size).to eq(1)
+    expect_offense(<<-RUBY.strip_indent)
+      f = Proc.new { |x| puts x }
+          ^^^^^^^^ Use `proc` instead of `Proc.new`.
+    RUBY
   end
 
   it 'accepts the proc method' do

--- a/spec/rubocop/cop/style/raise_args_spec.rb
+++ b/spec/rubocop/cop/style/raise_args_spec.rb
@@ -55,8 +55,10 @@ describe RuboCop::Cop::Style::RaiseArgs, :config do
 
     context 'with a raise with 3 args' do
       it 'reports an offense' do
-        inspect_source(cop, 'raise RuntimeError, msg, caller')
-        expect(cop.offenses.size).to eq(1)
+        expect_offense(<<-RUBY.strip_indent)
+          raise RuntimeError, msg, caller
+          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Provide an exception object as an argument to `raise`.
+        RUBY
       end
 
       it 'auto-corrects to compact style' do

--- a/spec/rubocop/cop/style/redundant_parentheses_spec.rb
+++ b/spec/rubocop/cop/style/redundant_parentheses_spec.rb
@@ -193,8 +193,10 @@ describe RuboCop::Cop::Style::RedundantParentheses do
   end
 
   it 'registers an offense when there is space around the parentheses' do
-    inspect_source(cop, 'if x; y else (1) end')
-    expect(cop.offenses.size).to eq 1
+    expect_offense(<<-RUBY.strip_indent)
+      if x; y else (1) end
+                   ^^^ Don't use parentheses around a literal.
+    RUBY
   end
 
   it 'accepts parentheses when they touch the preceding keyword' do
@@ -211,15 +213,19 @@ describe RuboCop::Cop::Style::RedundantParentheses do
     end
 
     it 'registers an offense if the argument list is parenthesized ' do
-      inspect_source(cop, 'x(({ y: 1 }), z)')
-      expect(cop.offenses.size).to eq 1
+      expect_offense(<<-RUBY.strip_indent)
+        x(({ y: 1 }), z)
+          ^^^^^^^^^^ Don't use parentheses around a literal.
+      RUBY
     end
   end
 
   context 'when a hash literal is the second argument in a method call' do
     it 'registers an offense' do
-      inspect_source(cop, 'x ({ y: 1 }), ({ y: 1 })')
-      expect(cop.offenses.size).to eq 1
+      expect_offense(<<-RUBY.strip_indent)
+        x ({ y: 1 }), ({ y: 1 })
+                      ^^^^^^^^^^ Don't use parentheses around a literal.
+      RUBY
     end
   end
 

--- a/spec/rubocop/cop/style/redundant_return_spec.rb
+++ b/spec/rubocop/cop/style/redundant_return_spec.rb
@@ -302,8 +302,20 @@ describe RuboCop::Cop::Style::RedundantReturn, :config do
     end
 
     it 'registers an offense' do
-      inspect_source(cop, src)
-      expect(cop.offenses.size).to eq 3
+      expect_offense(<<-RUBY.strip_indent)
+        def func
+          if x
+            return 1
+            ^^^^^^ Redundant `return` detected.
+          elsif y
+            return 2
+            ^^^^^^ Redundant `return` detected.
+          else
+            return 3
+            ^^^^^^ Redundant `return` detected.
+          end
+        end
+      RUBY
     end
 
     it 'auto-corrects' do
@@ -338,8 +350,20 @@ describe RuboCop::Cop::Style::RedundantReturn, :config do
     end
 
     it 'registers an offense' do
-      inspect_source(cop, src)
-      expect(cop.offenses.size).to eq 3
+      expect_offense(<<-RUBY.strip_indent)
+        def func
+          case x
+          when y then return 1
+                      ^^^^^^ Redundant `return` detected.
+          when z then return 2
+                      ^^^^^^ Redundant `return` detected.
+          when q
+          else
+            return 3
+            ^^^^^^ Redundant `return` detected.
+          end
+        end
+      RUBY
     end
 
     it 'auto-corrects' do

--- a/spec/rubocop/cop/style/regexp_literal_spec.rb
+++ b/spec/rubocop/cop/style/regexp_literal_spec.rb
@@ -27,8 +27,10 @@ describe RuboCop::Cop::Style::RegexpLiteral, :config do
     let(:cop_config) { { 'EnforcedStyle' => 'slashes' } }
 
     it 'registers an offense' do
-      inspect_source(cop, '%r_ls_')
-      expect(cop.messages).to eq(['Use `//` around regular expression.'])
+      expect_offense(<<-RUBY.strip_indent)
+        %r_ls_
+        ^^^^^^ Use `//` around regular expression.
+      RUBY
     end
   end
 
@@ -60,8 +62,10 @@ describe RuboCop::Cop::Style::RegexpLiteral, :config do
       let(:source) { 'foo = /home\//' }
 
       it 'registers an offense' do
-        inspect_source(cop, source)
-        expect(cop.messages).to eq(['Use `%r` around regular expression.'])
+        expect_offense(<<-'RUBY'.strip_indent)
+          foo = /home\//
+                ^^^^^^^^ Use `%r` around regular expression.
+        RUBY
       end
 
       it 'cannot auto-correct' do
@@ -125,8 +129,10 @@ describe RuboCop::Cop::Style::RegexpLiteral, :config do
       let(:source) { 'foo = %r{a}' }
 
       it 'registers an offense' do
-        inspect_source(cop, source)
-        expect(cop.messages).to eq(['Use `//` around regular expression.'])
+        expect_offense(<<-RUBY.strip_indent)
+          foo = %r{a}
+                ^^^^^ Use `//` around regular expression.
+        RUBY
       end
 
       it 'auto-corrects' do
@@ -147,8 +153,10 @@ describe RuboCop::Cop::Style::RegexpLiteral, :config do
         before { cop_config['AllowInnerSlashes'] = true }
 
         it 'registers an offense' do
-          inspect_source(cop, source)
-          expect(cop.messages).to eq(['Use `//` around regular expression.'])
+          expect_offense(<<-RUBY.strip_indent)
+            foo = %r{home/}
+                  ^^^^^^^^^ Use `//` around regular expression.
+          RUBY
         end
 
         it 'cannot auto-correct' do
@@ -213,8 +221,10 @@ describe RuboCop::Cop::Style::RegexpLiteral, :config do
       let(:source) { 'foo = /a/' }
 
       it 'registers an offense' do
-        inspect_source(cop, source)
-        expect(cop.messages).to eq(['Use `%r` around regular expression.'])
+        expect_offense(<<-RUBY.strip_indent)
+          foo = /a/
+                ^^^ Use `%r` around regular expression.
+        RUBY
       end
 
       it 'auto-corrects' do
@@ -227,8 +237,10 @@ describe RuboCop::Cop::Style::RegexpLiteral, :config do
       let(:source) { 'foo = /home\//' }
 
       it 'registers an offense' do
-        inspect_source(cop, source)
-        expect(cop.messages).to eq(['Use `%r` around regular expression.'])
+        expect_offense(<<-'RUBY'.strip_indent)
+          foo = /home\//
+                ^^^^^^^^ Use `%r` around regular expression.
+        RUBY
       end
 
       it 'cannot auto-correct' do
@@ -338,8 +350,10 @@ describe RuboCop::Cop::Style::RegexpLiteral, :config do
       let(:source) { 'foo = /home\//' }
 
       it 'registers an offense' do
-        inspect_source(cop, source)
-        expect(cop.messages).to eq(['Use `%r` around regular expression.'])
+        expect_offense(<<-'RUBY'.strip_indent)
+          foo = /home\//
+                ^^^^^^^^ Use `%r` around regular expression.
+        RUBY
       end
 
       it 'cannot auto-correct' do
@@ -399,8 +413,10 @@ describe RuboCop::Cop::Style::RegexpLiteral, :config do
       let(:source) { 'foo = %r{a}' }
 
       it 'registers an offense' do
-        inspect_source(cop, source)
-        expect(cop.messages).to eq(['Use `//` around regular expression.'])
+        expect_offense(<<-RUBY.strip_indent)
+          foo = %r{a}
+                ^^^^^ Use `//` around regular expression.
+        RUBY
       end
 
       it 'auto-corrects' do
@@ -421,8 +437,10 @@ describe RuboCop::Cop::Style::RegexpLiteral, :config do
         before { cop_config['AllowInnerSlashes'] = true }
 
         it 'registers an offense' do
-          inspect_source(cop, source)
-          expect(cop.messages).to eq(['Use `//` around regular expression.'])
+          expect_offense(<<-RUBY.strip_indent)
+            foo = %r{home/}
+                  ^^^^^^^^^ Use `//` around regular expression.
+          RUBY
         end
 
         it 'cannot auto-correct' do

--- a/spec/rubocop/cop/style/rescue_modifier_spec.rb
+++ b/spec/rubocop/cop/style/rescue_modifier_spec.rb
@@ -10,26 +10,24 @@ describe RuboCop::Cop::Style::RescueModifier do
   subject(:cop) { described_class.new(config) }
 
   it 'registers an offense for modifier rescue' do
-    inspect_source(cop, 'method rescue handle')
-
-    expect(cop.messages)
-      .to eq(['Avoid using `rescue` in its modifier form.'])
-    expect(cop.highlights).to eq(['method rescue handle'])
+    expect_offense(<<-RUBY.strip_indent)
+      method rescue handle
+      ^^^^^^^^^^^^^^^^^^^^ Avoid using `rescue` in its modifier form.
+    RUBY
   end
 
   it 'registers an offense for modifier rescue around parallel assignment' do
-    inspect_source(cop, 'a, b = 1, 2 rescue nil')
-
-    expect(cop.messages)
-      .to eq(['Avoid using `rescue` in its modifier form.'])
+    expect_offense(<<-RUBY.strip_indent)
+      a, b = 1, 2 rescue nil
+      ^^^^^^^^^^^^^^^^^^^^^^ Avoid using `rescue` in its modifier form.
+    RUBY
   end
 
   it 'handles more complex expression with modifier rescue' do
-    inspect_source(cop, 'method1 or method2 rescue handle')
-
-    expect(cop.messages)
-      .to eq(['Avoid using `rescue` in its modifier form.'])
-    expect(cop.highlights).to eq(['method1 or method2 rescue handle'])
+    expect_offense(<<-RUBY.strip_indent)
+      method1 or method2 rescue handle
+      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Avoid using `rescue` in its modifier form.
+    RUBY
   end
 
   it 'handles modifier rescue in normal rescue' do

--- a/spec/rubocop/cop/style/semicolon_spec.rb
+++ b/spec/rubocop/cop/style/semicolon_spec.rb
@@ -5,21 +5,24 @@ describe RuboCop::Cop::Style::Semicolon, :config do
   let(:cop_config) { { 'AllowAsExpressionSeparator' => false } }
 
   it 'registers an offense for a single expression' do
-    inspect_source(cop,
-                   'puts "this is a test";')
-    expect(cop.offenses.size).to eq(1)
+    expect_offense(<<-RUBY.strip_indent)
+      puts "this is a test";
+                           ^ Do not use semicolons to terminate expressions.
+    RUBY
   end
 
   it 'registers an offense for several expressions' do
-    inspect_source(cop,
-                   'puts "this is a test"; puts "So is this"')
-    expect(cop.offenses.size).to eq(1)
+    expect_offense(<<-RUBY.strip_indent)
+      puts "this is a test"; puts "So is this"
+                           ^ Do not use semicolons to terminate expressions.
+    RUBY
   end
 
   it 'registers an offense for one line method with two statements' do
-    inspect_source(cop,
-                   'def foo(a) x(1); y(2); z(3); end')
-    expect(cop.offenses.size).to eq(1)
+    expect_offense(<<-RUBY.strip_indent)
+      def foo(a) x(1); y(2); z(3); end
+                     ^ Do not use semicolons to terminate expressions.
+    RUBY
   end
 
   it 'accepts semicolon before end if so configured' do
@@ -62,9 +65,10 @@ describe RuboCop::Cop::Style::Semicolon, :config do
   end
 
   it 'registers an offense for semicolon at the end no matter what' do
-    inspect_source(cop,
-                   'module Foo; end;')
-    expect(cop.offenses.size).to eq(1)
+    expect_offense(<<-RUBY.strip_indent)
+      module Foo; end;
+                     ^ Do not use semicolons to terminate expressions.
+    RUBY
   end
 
   it 'accept semicolons inside strings' do
@@ -75,8 +79,10 @@ describe RuboCop::Cop::Style::Semicolon, :config do
   end
 
   it 'registers an offense for a semicolon at the beginning of a line' do
-    inspect_source(cop, '; puts 1')
-    expect(cop.offenses.size).to eq(1)
+    expect_offense(<<-RUBY.strip_indent)
+      ; puts 1
+      ^ Do not use semicolons to terminate expressions.
+    RUBY
   end
 
   it 'auto-corrects semicolons when syntactically possible' do

--- a/spec/rubocop/cop/style/send_spec.rb
+++ b/spec/rubocop/cop/style/send_spec.rb
@@ -6,8 +6,10 @@ describe RuboCop::Cop::Style::Send do
   context 'with send' do
     context 'and with a receiver' do
       it 'registers an offense for an invocation with args' do
-        inspect_source(cop, 'Object.send(:inspect)')
-        expect(cop.offenses.size).to eq(1)
+        expect_offense(<<-RUBY.strip_indent)
+          Object.send(:inspect)
+                 ^^^^ Prefer `Object#__send__` or `Object#public_send` to `send`.
+        RUBY
       end
 
       it 'does not register an offense for an invocation without args' do
@@ -17,8 +19,10 @@ describe RuboCop::Cop::Style::Send do
 
     context 'and without a receiver' do
       it 'registers an offense for an invocation with args' do
-        inspect_source(cop, 'send(:inspect)')
-        expect(cop.offenses.size).to eq(1)
+        expect_offense(<<-RUBY.strip_indent)
+          send(:inspect)
+          ^^^^ Prefer `Object#__send__` or `Object#public_send` to `send`.
+        RUBY
       end
 
       it 'does not register an offense for an invocation without args' do

--- a/spec/rubocop/cop/style/signal_exception_spec.rb
+++ b/spec/rubocop/cop/style/signal_exception_spec.rb
@@ -7,42 +7,36 @@ describe RuboCop::Cop::Style::SignalException, :config do
     let(:cop_config) { { 'EnforcedStyle' => 'semantic' } }
 
     it 'registers an offense for raise in begin section' do
-      inspect_source(cop, <<-END.strip_indent)
+      expect_offense(<<-RUBY.strip_indent)
         begin
           raise
+          ^^^^^ Use `fail` instead of `raise` to signal exceptions.
         rescue Exception
           #do nothing
         end
-      END
-      expect(cop.offenses.size).to eq(1)
-      expect(cop.messages)
-        .to eq(['Use `fail` instead of `raise` to signal exceptions.'])
+      RUBY
     end
 
     it 'registers an offense for raise in def body' do
-      inspect_source(cop, <<-END.strip_indent)
+      expect_offense(<<-RUBY.strip_indent)
         def test
           raise
+          ^^^^^ Use `fail` instead of `raise` to signal exceptions.
         rescue Exception
           #do nothing
         end
-      END
-      expect(cop.offenses.size).to eq(1)
-      expect(cop.messages)
-        .to eq(['Use `fail` instead of `raise` to signal exceptions.'])
+      RUBY
     end
 
     it 'registers an offense for fail in rescue section' do
-      inspect_source(cop, <<-END.strip_indent)
+      expect_offense(<<-RUBY.strip_indent)
         begin
           fail
         rescue Exception
           fail
+          ^^^^ Use `raise` instead of `fail` to rethrow exceptions.
         end
-      END
-      expect(cop.offenses.size).to eq(1)
-      expect(cop.messages)
-        .to eq(['Use `raise` instead of `fail` to rethrow exceptions.'])
+      RUBY
     end
 
     it 'accepts raise in rescue section' do
@@ -68,41 +62,37 @@ describe RuboCop::Cop::Style::SignalException, :config do
     end
 
     it 'registers an offense for fail in def rescue section' do
-      inspect_source(cop, <<-END.strip_indent)
+      expect_offense(<<-RUBY.strip_indent)
         def test
           fail
         rescue Exception
           fail
+          ^^^^ Use `raise` instead of `fail` to rethrow exceptions.
         end
-      END
-      expect(cop.offenses.size).to eq(1)
-      expect(cop.messages)
-        .to eq(['Use `raise` instead of `fail` to rethrow exceptions.'])
+      RUBY
     end
 
     it 'registers an offense for fail in second rescue' do
-      inspect_source(cop, <<-END.strip_indent)
+      expect_offense(<<-RUBY.strip_indent)
         def test
           fail
         rescue StandardError
           # handle error
         rescue Exception
           fail
+          ^^^^ Use `raise` instead of `fail` to rethrow exceptions.
         end
-      END
-      expect(cop.offenses.size).to eq(1)
+      RUBY
     end
 
     it 'registers only offense for one raise that should be fail' do
       # This is a special case that has caused double reporting.
-      inspect_source(cop, <<-END.strip_indent)
+      expect_offense(<<-RUBY.strip_indent)
         map do
           raise 'I'
+          ^^^^^ Use `fail` instead of `raise` to signal exceptions.
         end.flatten.compact
-      END
-      expect(cop.offenses.size).to eq(1)
-      expect(cop.messages)
-        .to eq(['Use `fail` instead of `raise` to signal exceptions.'])
+      RUBY
     end
 
     it 'accepts raise in def rescue section' do
@@ -141,16 +131,14 @@ describe RuboCop::Cop::Style::SignalException, :config do
     end
 
     it 'registers an offense for raise not in a begin/rescue/end' do
-      inspect_source(cop, <<-END.strip_indent)
+      expect_offense(<<-RUBY.strip_indent)
         case cop_config['EnforcedStyle']
         when 'single_quotes' then true
         when 'double_quotes' then false
         else raise 'Unknown StringLiterals style'
+             ^^^^^ Use `fail` instead of `raise` to signal exceptions.
         end
-      END
-      expect(cop.offenses.size).to eq(1)
-      expect(cop.messages)
-        .to eq(['Use `fail` instead of `raise` to signal exceptions.'])
+      RUBY
     end
 
     it 'registers one offense for each raise' do
@@ -221,42 +209,36 @@ describe RuboCop::Cop::Style::SignalException, :config do
     let(:cop_config) { { 'EnforcedStyle' => 'only_raise' } }
 
     it 'registers an offense for fail in begin section' do
-      inspect_source(cop, <<-END.strip_indent)
+      expect_offense(<<-RUBY.strip_indent)
         begin
           fail
+          ^^^^ Always use `raise` to signal exceptions.
         rescue Exception
           #do nothing
         end
-      END
-      expect(cop.offenses.size).to eq(1)
-      expect(cop.messages)
-        .to eq(['Always use `raise` to signal exceptions.'])
+      RUBY
     end
 
     it 'registers an offense for fail in def body' do
-      inspect_source(cop, <<-END.strip_indent)
+      expect_offense(<<-RUBY.strip_indent)
         def test
           fail
+          ^^^^ Always use `raise` to signal exceptions.
         rescue Exception
           #do nothing
         end
-      END
-      expect(cop.offenses.size).to eq(1)
-      expect(cop.messages)
-        .to eq(['Always use `raise` to signal exceptions.'])
+      RUBY
     end
 
     it 'registers an offense for fail in rescue section' do
-      inspect_source(cop, <<-END.strip_indent)
+      expect_offense(<<-RUBY.strip_indent)
         begin
           raise
         rescue Exception
           fail
+          ^^^^ Always use `raise` to signal exceptions.
         end
-      END
-      expect(cop.offenses.size).to eq(1)
-      expect(cop.messages)
-        .to eq(['Always use `raise` to signal exceptions.'])
+      RUBY
     end
 
     it 'accepts `fail` if a custom `fail` instance method is defined' do
@@ -288,10 +270,10 @@ describe RuboCop::Cop::Style::SignalException, :config do
     end
 
     it 'registers an offense for `fail` with `Kernel` as explicit receiver' do
-      inspect_source(cop, 'Kernel.fail')
-      expect(cop.offenses.size).to eq(1)
-      expect(cop.messages)
-        .to eq(['Always use `raise` to signal exceptions.'])
+      expect_offense(<<-RUBY.strip_indent)
+        Kernel.fail
+               ^^^^ Always use `raise` to signal exceptions.
+      RUBY
     end
 
     it 'auto-corrects fail to raise always' do
@@ -316,42 +298,36 @@ describe RuboCop::Cop::Style::SignalException, :config do
     let(:cop_config) { { 'EnforcedStyle' => 'only_fail' } }
 
     it 'registers an offense for raise in begin section' do
-      inspect_source(cop, <<-END.strip_indent)
+      expect_offense(<<-RUBY.strip_indent)
         begin
           raise
+          ^^^^^ Always use `fail` to signal exceptions.
         rescue Exception
           #do nothing
         end
-      END
-      expect(cop.offenses.size).to eq(1)
-      expect(cop.messages)
-        .to eq(['Always use `fail` to signal exceptions.'])
+      RUBY
     end
 
     it 'registers an offense for raise in def body' do
-      inspect_source(cop, <<-END.strip_indent)
+      expect_offense(<<-RUBY.strip_indent)
         def test
           raise
+          ^^^^^ Always use `fail` to signal exceptions.
         rescue Exception
           #do nothing
         end
-      END
-      expect(cop.offenses.size).to eq(1)
-      expect(cop.messages)
-        .to eq(['Always use `fail` to signal exceptions.'])
+      RUBY
     end
 
     it 'registers an offense for raise in rescue section' do
-      inspect_source(cop, <<-END.strip_indent)
+      expect_offense(<<-RUBY.strip_indent)
         begin
           fail
         rescue Exception
           raise
+          ^^^^^ Always use `fail` to signal exceptions.
         end
-      END
-      expect(cop.offenses.size).to eq(1)
-      expect(cop.messages)
-        .to eq(['Always use `fail` to signal exceptions.'])
+      RUBY
     end
 
     it 'accepts `raise` with explicit receiver' do
@@ -359,10 +335,10 @@ describe RuboCop::Cop::Style::SignalException, :config do
     end
 
     it 'registers an offense for `raise` with `Kernel` as explicit receiver' do
-      inspect_source(cop, 'Kernel.raise')
-      expect(cop.offenses.size).to eq(1)
-      expect(cop.messages)
-        .to eq(['Always use `fail` to signal exceptions.'])
+      expect_offense(<<-RUBY.strip_indent)
+        Kernel.raise
+               ^^^^^ Always use `fail` to signal exceptions.
+      RUBY
     end
 
     it 'auto-corrects raise to fail always' do

--- a/spec/rubocop/cop/style/single_line_block_params_spec.rb
+++ b/spec/rubocop/cop/style/single_line_block_params_spec.rb
@@ -45,9 +45,10 @@ describe RuboCop::Cop::Style::SingleLineBlockParams, :config do
   end
 
   it 'finds incorrectly named parameters with leading underscores' do
-    inspect_source(cop,
-                   'File.foreach(filename).reduce(0) { |_x, _y| }')
-    expect(cop.messages).to eq(['Name `reduce` block params `|a, e|`.'])
+    expect_offense(<<-RUBY.strip_indent)
+      File.foreach(filename).reduce(0) { |_x, _y| }
+                                         ^^^^^^^^ Name `reduce` block params `|a, e|`.
+    RUBY
   end
 
   it 'ignores do..end blocks' do

--- a/spec/rubocop/cop/style/single_line_methods_spec.rb
+++ b/spec/rubocop/cop/style/single_line_methods_spec.rb
@@ -23,12 +23,14 @@ describe RuboCop::Cop::Style::SingleLineMethods do
     let(:cop_config) { { 'AllowIfMethodIsEmpty' => false } }
 
     it 'registers an offense for an empty method' do
-      inspect_source(cop, <<-END.strip_indent)
+      expect_offense(<<-RUBY.strip_indent)
         def no_op; end
+        ^^^^^^^^^^^^^^ Avoid single-line method definitions.
         def self.resource_class=(klass); end
+        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Avoid single-line method definitions.
         def @table.columns; end
-      END
-      expect(cop.offenses.size).to eq(3)
+        ^^^^^^^^^^^^^^^^^^^^^^^ Avoid single-line method definitions.
+      RUBY
     end
 
     it 'auto-corrects an empty method' do

--- a/spec/rubocop/cop/style/special_global_vars_spec.rb
+++ b/spec/rubocop/cop/style/special_global_vars_spec.rb
@@ -7,39 +7,38 @@ describe RuboCop::Cop::Style::SpecialGlobalVars, :config do
     let(:cop_config) { { 'EnforcedStyle' => 'use_english_names' } }
 
     it 'registers an offense for $:' do
-      inspect_source(cop, 'puts $:')
-      expect(cop.offenses.size).to eq(1)
-      expect(cop.messages)
-        .to eq(['Prefer `$LOAD_PATH` over `$:`.'])
+      expect_offense(<<-RUBY.strip_indent)
+        puts $:
+             ^^ Prefer `$LOAD_PATH` over `$:`.
+      RUBY
     end
 
     it 'registers an offense for $"' do
-      inspect_source(cop, 'puts $"')
-      expect(cop.offenses.size).to eq(1)
-      expect(cop.messages)
-        .to eq(['Prefer `$LOADED_FEATURES` over `$"`.'])
+      expect_offense(<<-RUBY.strip_indent)
+        puts $"
+             ^^ Prefer `$LOADED_FEATURES` over `$"`.
+      RUBY
     end
 
     it 'registers an offense for $0' do
-      inspect_source(cop, 'puts $0')
-      expect(cop.offenses.size).to eq(1)
-      expect(cop.messages)
-        .to eq(['Prefer `$PROGRAM_NAME` over `$0`.'])
+      expect_offense(<<-RUBY.strip_indent)
+        puts $0
+             ^^ Prefer `$PROGRAM_NAME` over `$0`.
+      RUBY
     end
 
     it 'registers an offense for $$' do
-      inspect_source(cop, 'puts $$')
-      expect(cop.offenses.size).to eq(1)
-      expect(cop.messages)
-        .to eq(['Prefer `$PROCESS_ID` or `$PID` from the stdlib \'English\' ' \
-                'module (don\'t forget to require it) over `$$`.'])
+      expect_offense(<<-RUBY.strip_indent)
+        puts $$
+             ^^ Prefer `$PROCESS_ID` or `$PID` from the stdlib 'English' module (don't forget to require it) over `$$`.
+      RUBY
     end
 
     it 'is clear about variables from the English library vs those not' do
-      inspect_source(cop, 'puts $*')
-      expect(cop.messages)
-        .to eq(['Prefer `$ARGV` from the stdlib \'English\' module ' \
-                '(don\'t forget to require it), or `ARGV` over `$*`.'])
+      expect_offense(<<-RUBY.strip_indent)
+        puts $*
+             ^^ Prefer `$ARGV` from the stdlib 'English' module (don't forget to require it), or `ARGV` over `$*`.
+      RUBY
     end
 
     it 'does not register an offense for backrefs like $1' do
@@ -83,35 +82,38 @@ describe RuboCop::Cop::Style::SpecialGlobalVars, :config do
     let(:cop_config) { { 'EnforcedStyle' => 'use_perl_names' } }
 
     it 'registers an offense for $LOAD_PATH' do
-      inspect_source(cop, 'puts $LOAD_PATH')
-      expect(cop.offenses.size).to eq(1)
-      expect(cop.messages).to eq(['Prefer `$:` over `$LOAD_PATH`.'])
+      expect_offense(<<-RUBY.strip_indent)
+        puts $LOAD_PATH
+             ^^^^^^^^^^ Prefer `$:` over `$LOAD_PATH`.
+      RUBY
     end
 
     it 'registers an offense for $LOADED_FEATURES' do
-      inspect_source(cop, 'puts $LOADED_FEATURES')
-      expect(cop.offenses.size).to eq(1)
-      expect(cop.messages).to eq(['Prefer `$"` over `$LOADED_FEATURES`.'])
+      expect_offense(<<-RUBY.strip_indent)
+        puts $LOADED_FEATURES
+             ^^^^^^^^^^^^^^^^ Prefer `$"` over `$LOADED_FEATURES`.
+      RUBY
     end
 
     it 'registers an offense for $PROGRAM_NAME' do
-      inspect_source(cop, 'puts $PROGRAM_NAME')
-      expect(cop.offenses.size).to eq(1)
-      expect(cop.messages).to eq(['Prefer `$0` over `$PROGRAM_NAME`.'])
+      expect_offense(<<-RUBY.strip_indent)
+        puts $PROGRAM_NAME
+             ^^^^^^^^^^^^^ Prefer `$0` over `$PROGRAM_NAME`.
+      RUBY
     end
 
     it 'registers an offense for $PID' do
-      inspect_source(cop, 'puts $PID')
-      expect(cop.offenses.size).to eq(1)
-      expect(cop.messages)
-        .to eq(['Prefer `$$` over `$PID`.'])
+      expect_offense(<<-RUBY.strip_indent)
+        puts $PID
+             ^^^^ Prefer `$$` over `$PID`.
+      RUBY
     end
 
     it 'registers an offense for $PROCESS_ID' do
-      inspect_source(cop, 'puts $PROCESS_ID')
-      expect(cop.offenses.size).to eq(1)
-      expect(cop.messages)
-        .to eq(['Prefer `$$` over `$PROCESS_ID`.'])
+      expect_offense(<<-RUBY.strip_indent)
+        puts $PROCESS_ID
+             ^^^^^^^^^^^ Prefer `$$` over `$PROCESS_ID`.
+      RUBY
     end
 
     it 'does not register an offense for backrefs like $1' do

--- a/spec/rubocop/cop/style/stabby_lambda_parentheses_spec.rb
+++ b/spec/rubocop/cop/style/stabby_lambda_parentheses_spec.rb
@@ -23,10 +23,10 @@ describe RuboCop::Cop::Style::StabbyLambdaParentheses, :config do
     it_behaves_like 'common'
 
     it 'registers an offense for a stabby lambda without parentheses' do
-      inspect_source(cop, '->a,b,c { a + b + c }')
-      expect(cop.offenses.size).to eq(1)
-      expect(cop.messages)
-        .to eq(['Wrap stabby lambda arguments with parentheses.'])
+      expect_offense(<<-RUBY.strip_indent)
+        ->a,b,c { a + b + c }
+          ^^^^^ Wrap stabby lambda arguments with parentheses.
+      RUBY
     end
 
     it 'does not register an offense for a stabby lambda with parentheses' do
@@ -45,10 +45,10 @@ describe RuboCop::Cop::Style::StabbyLambdaParentheses, :config do
     it_behaves_like 'common'
 
     it 'registers an offense for a stabby lambda with parentheses' do
-      inspect_source(cop, '->(a,b,c) { a + b + c }')
-      expect(cop.offenses.size).to eq(1)
-      expect(cop.messages)
-        .to eq(['Do not wrap stabby lambda arguments with parentheses.'])
+      expect_offense(<<-RUBY.strip_indent)
+        ->(a,b,c) { a + b + c }
+          ^^^^^^^ Do not wrap stabby lambda arguments with parentheses.
+      RUBY
     end
 
     it 'autocorrects when a stabby lambda does not parentheses' do

--- a/spec/rubocop/cop/style/string_literals_spec.rb
+++ b/spec/rubocop/cop/style/string_literals_spec.rb
@@ -143,16 +143,17 @@ describe RuboCop::Cop::Style::StringLiterals, :config do
     end
 
     it 'registers an offense for "\""' do
-      inspect_source(cop, '"\\""')
-      expect(cop.offenses.size).to eq(1)
-      expect(cop.messages).to eq(['Prefer single-quoted strings when you ' \
-                                  "don't need string interpolation or " \
-                                  'special symbols.'])
+      expect_offense(<<-'RUBY'.strip_indent)
+        "\""
+        ^^^^ Prefer single-quoted strings when you don't need string interpolation or special symbols.
+      RUBY
     end
 
     it 'registers an offense for words with non-ascii chars' do
-      inspect_source(cop, '"España"')
-      expect(cop.offenses.size).to eq(1)
+      expect_offense(<<-RUBY.strip_indent)
+        "España"
+        ^^^^^^^^ Prefer single-quoted strings when you don't need string interpolation or special symbols.
+      RUBY
     end
 
     it 'autocorrects words with non-ascii chars' do

--- a/spec/rubocop/cop/style/struct_inheritance_spec.rb
+++ b/spec/rubocop/cop/style/struct_inheritance_spec.rb
@@ -4,19 +4,19 @@ describe RuboCop::Cop::Style::StructInheritance do
   subject(:cop) { described_class.new }
 
   it 'registers an offense when extending instance of Struct' do
-    inspect_source(cop, <<-END.strip_indent)
+    expect_offense(<<-RUBY.strip_indent)
       class Person < Struct.new(:first_name, :last_name)
+                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Don't extend an instance initialized by `Struct.new`.
       end
-    END
-    expect(cop.offenses.size).to eq(1)
+    RUBY
   end
 
   it 'registers an offense when extending instance of Struct with do ... end' do
-    inspect_source(cop, <<-END.strip_indent)
+    expect_offense(<<-RUBY.strip_indent)
       class Person < Struct.new(:first_name, :last_name) do end
+                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Don't extend an instance initialized by `Struct.new`.
       end
-    END
-    expect(cop.offenses.size).to eq(1)
+    RUBY
   end
 
   it 'accepts plain class' do

--- a/spec/rubocop/cop/style/symbol_array_spec.rb
+++ b/spec/rubocop/cop/style/symbol_array_spec.rb
@@ -123,9 +123,10 @@ describe RuboCop::Cop::Style::SymbolArray, :config do
     end
 
     it 'registers an offense for array starting with %i' do
-      inspect_source(cop, '%i(one two three)')
-      expect(cop.offenses.size).to eq(1)
-      expect(cop.messages).to eq(['Use `[]` for an array of symbols.'])
+      expect_offense(<<-RUBY.strip_indent)
+        %i(one two three)
+        ^^^^^^^^^^^^^^^^^ Use `[]` for an array of symbols.
+      RUBY
     end
 
     it 'autocorrects an array starting with %i' do

--- a/spec/rubocop/cop/style/symbol_literal_spec.rb
+++ b/spec/rubocop/cop/style/symbol_literal_spec.rb
@@ -4,8 +4,10 @@ describe RuboCop::Cop::Style::SymbolLiteral do
   subject(:cop) { described_class.new }
 
   it 'registers an offense for word-line symbols using string syntax' do
-    inspect_source(cop, 'x = { :"test" => 0 }')
-    expect(cop.offenses.size).to eq(1)
+    expect_offense(<<-RUBY.strip_indent)
+      x = { :"test" => 0 }
+            ^^^^^^^ Do not use strings for word-like symbol literals.
+    RUBY
   end
 
   it 'accepts string syntax when symbols have whitespaces in them' do

--- a/spec/rubocop/cop/style/symbol_proc_spec.rb
+++ b/spec/rubocop/cop/style/symbol_proc_spec.rb
@@ -15,10 +15,10 @@ describe RuboCop::Cop::Style::SymbolProc, :config do
   end
 
   it 'registers an offense for a block when method in body is unary -/=' do
-    inspect_source(cop, 'something.map { |x| -x }')
-    expect(cop.offenses.size).to eq(1)
-    expect(cop.messages)
-      .to eq(['Pass `&:-@` as an argument to `map` instead of a block.'])
+    expect_offense(<<-RUBY.strip_indent)
+      something.map { |x| -x }
+                    ^^^^^^^^^^ Pass `&:-@` as an argument to `map` instead of a block.
+    RUBY
   end
 
   it 'accepts block with more than 1 arguments' do
@@ -69,9 +69,10 @@ describe RuboCop::Cop::Style::SymbolProc, :config do
     let(:source) { 'method(one, 2) { |x| x.test }' }
 
     it 'registers an offense' do
-      inspect_source(cop, source)
-      expect(cop.messages)
-        .to eq(['Pass `&:test` as an argument to `method` instead of a block.'])
+      expect_offense(<<-RUBY.strip_indent)
+        method(one, 2) { |x| x.test }
+                       ^^^^^^^^^^^^^^ Pass `&:test` as an argument to `method` instead of a block.
+      RUBY
     end
 
     it 'auto-corrects' do
@@ -105,9 +106,10 @@ describe RuboCop::Cop::Style::SymbolProc, :config do
     let(:source) { 'super(one, two) { |x| x.test }' }
 
     it 'registers an offense' do
-      inspect_source(cop, source)
-      expect(cop.messages)
-        .to eq(['Pass `&:test` as an argument to `super` instead of a block.'])
+      expect_offense(<<-RUBY.strip_indent)
+        super(one, two) { |x| x.test }
+                        ^^^^^^^^^^^^^^ Pass `&:test` as an argument to `super` instead of a block.
+      RUBY
     end
 
     it 'auto-corrects' do
@@ -120,9 +122,10 @@ describe RuboCop::Cop::Style::SymbolProc, :config do
     let(:source) { 'super { |x| x.test }' }
 
     it 'registers an offense' do
-      inspect_source(cop, source)
-      expect(cop.messages)
-        .to eq(['Pass `&:test` as an argument to `super` instead of a block.'])
+      expect_offense(<<-RUBY.strip_indent)
+        super { |x| x.test }
+              ^^^^^^^^^^^^^^ Pass `&:test` as an argument to `super` instead of a block.
+      RUBY
     end
 
     it 'auto-corrects' do

--- a/spec/rubocop/cop/style/trailing_comma_in_literal_spec.rb
+++ b/spec/rubocop/cop/style/trailing_comma_in_literal_spec.rb
@@ -88,24 +88,24 @@ describe RuboCop::Cop::Style::TrailingCommaInLiteral, :config do
       let(:cop_config) { { 'EnforcedStyleForMultiline' => 'no_comma' } }
 
       it 'registers an offense for trailing comma in an Array literal' do
-        inspect_source(cop, <<-END.strip_indent)
+        expect_offense(<<-RUBY.strip_indent)
           VALUES = [
                      1001,
                      2020,
                      3333,
+                         ^ Avoid comma after the last item of an array.
                    ]
-        END
-        expect(cop.highlights).to eq([','])
+        RUBY
       end
 
       it 'registers an offense for trailing comma in a Hash literal' do
-        inspect_source(cop, <<-END.strip_indent)
+        expect_offense(<<-RUBY.strip_indent)
           MAP = { a: 1001,
                   b: 2020,
                   c: 3333,
+                         ^ Avoid comma after the last item of a hash.
                 }
-        END
-        expect(cop.highlights).to eq([','])
+        RUBY
       end
 
       it 'accepts an Array literal with no trailing comma' do
@@ -223,27 +223,23 @@ describe RuboCop::Cop::Style::TrailingCommaInLiteral, :config do
       end
 
       it 'registers an offense for no trailing comma in a Hash literal' do
-        inspect_source(cop, <<-END.strip_indent)
+        expect_offense(<<-RUBY.strip_indent)
           MAP = { a: 1001,
                   b: 2020,
                   c: 3333
+                  ^^^^^^^ Put a comma after the last item of a multiline hash.
           }
-        END
-        expect(cop.messages)
-          .to eq(['Put a comma after the last item of a multiline hash.'])
-        expect(cop.highlights).to eq(['c: 3333'])
+        RUBY
       end
 
       it 'registers an offense for trailing comma in a comment in Hash' do
-        inspect_source(cop, <<-END.strip_indent)
+        expect_offense(<<-RUBY.strip_indent)
           MAP = { a: 1001,
                   b: 2020,
                   c: 3333 # ,
+                  ^^^^^^^ Put a comma after the last item of a multiline hash.
           }
-        END
-        expect(cop.messages)
-          .to eq(['Put a comma after the last item of a multiline hash.'])
-        expect(cop.highlights).to eq(['c: 3333'])
+        RUBY
       end
 
       it 'accepts trailing comma in an Array literal' do
@@ -408,15 +404,13 @@ describe RuboCop::Cop::Style::TrailingCommaInLiteral, :config do
       end
 
       it 'registers an offense for no trailing comma in a Hash literal' do
-        inspect_source(cop, <<-END.strip_indent)
+        expect_offense(<<-RUBY.strip_indent)
           MAP = { a: 1001,
                   b: 2020,
                   c: 3333
+                  ^^^^^^^ Put a comma after the last item of a multiline hash.
           }
-        END
-        expect(cop.messages)
-          .to eq(['Put a comma after the last item of a multiline hash.'])
-        expect(cop.highlights).to eq(['c: 3333'])
+        RUBY
       end
 
       it 'accepts trailing comma in an Array literal' do

--- a/spec/rubocop/cop/style/trivial_accessors_spec.rb
+++ b/spec/rubocop/cop/style/trivial_accessors_spec.rb
@@ -21,13 +21,21 @@ describe RuboCop::Cop::Style::TrivialAccessors, :config do
   end
 
   it 'registers an offense on instance reader' do
-    inspect_source(cop, trivial_reader)
-    expect(cop.offenses.size).to eq(1)
+    expect_offense(<<-RUBY.strip_indent)
+      def foo
+      ^^^ Use `attr_reader` to define trivial reader methods.
+        @foo
+      end
+    RUBY
   end
 
   it 'registers an offense on instance writer' do
-    inspect_source(cop, trivial_writer)
-    expect(cop.offenses.size).to eq(1)
+    expect_offense(<<-RUBY.strip_indent)
+      def foo=(val)
+      ^^^ Use `attr_writer` to define trivial writer methods.
+        @foo = val
+      end
+    RUBY
   end
 
   it 'show correct message on reader' do
@@ -43,58 +51,62 @@ describe RuboCop::Cop::Style::TrivialAccessors, :config do
   end
 
   it 'registers an offense on class reader' do
-    inspect_source(cop, <<-END.strip_indent)
+    expect_offense(<<-RUBY.strip_indent)
       def self.foo
+      ^^^ Use `attr_reader` to define trivial reader methods.
         @foo
       end
-    END
-    expect(cop.offenses.size).to eq(1)
+    RUBY
   end
 
   it 'registers an offense on class writer' do
-    inspect_source(cop, <<-END.strip_indent)
+    expect_offense(<<-RUBY.strip_indent)
       def self.foo(val)
+      ^^^ Use `attr_writer` to define trivial writer methods.
         @foo = val
       end
-    END
-    expect(cop.offenses.size).to eq(1)
+    RUBY
   end
 
   it 'registers an offense on reader with braces' do
-    inspect_source(cop, <<-END.strip_indent)
+    expect_offense(<<-RUBY.strip_indent)
       def foo()
+      ^^^ Use `attr_reader` to define trivial reader methods.
         @foo
       end
-    END
-    expect(cop.offenses.size).to eq(1)
+    RUBY
   end
 
   it 'registers an offense on writer without braces' do
-    inspect_source(cop, <<-END.strip_indent)
+    expect_offense(<<-RUBY.strip_indent)
       def foo= val
+      ^^^ Use `attr_writer` to define trivial writer methods.
         @foo = val
       end
-    END
-    expect(cop.offenses.size).to eq(1)
+    RUBY
   end
 
   it 'registers an offense on one-liner reader' do
-    inspect_source(cop, 'def foo; @foo; end')
-    expect(cop.offenses.size).to eq(1)
+    expect_offense(<<-RUBY.strip_indent)
+      def foo; @foo; end
+      ^^^ Use `attr_reader` to define trivial reader methods.
+    RUBY
   end
 
   it 'registers an offense on one-liner writer' do
-    inspect_source(cop, 'def foo(val); @foo=val; end')
-    expect(cop.offenses.size).to eq(1)
+    expect_offense(<<-RUBY.strip_indent)
+      def foo(val); @foo=val; end
+      ^^^ Use `attr_writer` to define trivial writer methods.
+    RUBY
   end
 
   it 'register an offense on DSL-style trivial writer' do
-    inspect_source(cop, <<-END.strip_indent)
+    expect_offense(<<-RUBY.strip_indent)
       def foo(val)
+      ^^^ Use `attr_writer` to define trivial writer methods.
        @foo = val
       end
-    END
-    expect(cop.offenses.size).to eq(1)
+    RUBY
   end
 
   it 'accepts non-trivial reader' do
@@ -240,42 +252,38 @@ describe RuboCop::Cop::Style::TrivialAccessors, :config do
   end
 
   it 'flags a reader inside a class, inside an instance_eval call' do
-    inspect_source(cop, <<-END.strip_indent)
+    expect_offense(<<-RUBY.strip_indent)
       something.instance_eval do
         class << @blah
           begin
             def bar
+            ^^^ Use `attr_reader` to define trivial reader methods.
               @bar
             end
           end
         end
       end
-    END
-
-    expect(cop.offenses.size).to eq(1)
-    expect(cop.messages).to eq(
-      ['Use `attr_reader` to define trivial reader methods.']
-    )
+    RUBY
   end
   context 'exact name match disabled' do
     let(:cop_config) { { 'ExactNameMatch' => false } }
 
     it 'registers an offense when names mismatch in writer' do
-      inspect_source(cop, <<-END.strip_indent)
+      expect_offense(<<-RUBY.strip_indent)
         def foo(val)
+        ^^^ Use `attr_writer` to define trivial writer methods.
           @f = val
         end
-      END
-      expect(cop.offenses.size).to eq(1)
+      RUBY
     end
 
     it 'registers an offense when names mismatch in reader' do
-      inspect_source(cop, <<-END.strip_indent)
+      expect_offense(<<-RUBY.strip_indent)
         def foo
+        ^^^ Use `attr_reader` to define trivial reader methods.
           @f
         end
-      END
-      expect(cop.offenses.size).to eq(1)
+      RUBY
     end
   end
 
@@ -283,12 +291,12 @@ describe RuboCop::Cop::Style::TrivialAccessors, :config do
     let(:cop_config) { { 'AllowPredicates' => false } }
 
     it 'does not accept predicate-like reader' do
-      inspect_source(cop, <<-END.strip_indent)
+      expect_offense(<<-RUBY.strip_indent)
         def foo?
+        ^^^ Use `attr_reader` to define trivial reader methods.
           @foo
         end
-      END
-      expect(cop.offenses.size).to eq(1)
+      RUBY
     end
   end
 

--- a/spec/rubocop/cop/style/unneeded_capital_w_spec.rb
+++ b/spec/rubocop/cop/style/unneeded_capital_w_spec.rb
@@ -12,8 +12,10 @@ describe RuboCop::Cop::Style::UnneededCapitalW do
   end
 
   it 'registers an offense for misused %W' do
-    inspect_source(cop, '%W(cat dog)')
-    expect(cop.offenses.size).to eq(1)
+    expect_offense(<<-RUBY.strip_indent)
+      %W(cat dog)
+      ^^^^^^^^^^^ Do not use `%W` unless interpolation is needed. If not, use `%w`.
+    RUBY
   end
 
   it 'registers no offense for %W with interpolation' do

--- a/spec/rubocop/cop/style/unneeded_interpolation_spec.rb
+++ b/spec/rubocop/cop/style/unneeded_interpolation_spec.rb
@@ -4,99 +4,115 @@ describe RuboCop::Cop::Style::UnneededInterpolation do
   subject(:cop) { described_class.new }
 
   it 'registers an offense for "#{1 + 1}"' do
-    inspect_source(cop, '"#{1 + 1}"')
-    expect(cop.offenses.size).to eq(1)
-    expect(cop.highlights).to eq(['"#{1 + 1}"'])
+    expect_offense(<<-'RUBY'.strip_indent)
+      "#{1 + 1}"
+      ^^^^^^^^^^ Prefer `to_s` over string interpolation.
+    RUBY
   end
 
   it 'registers an offense for "%|#{1 + 1}|"' do
-    inspect_source(cop, '%|#{1 + 1}|')
-    expect(cop.offenses.size).to eq(1)
-    expect(cop.highlights).to eq(['%|#{1 + 1}|'])
+    expect_offense(<<-'RUBY'.strip_indent)
+      %|#{1 + 1}|
+      ^^^^^^^^^^^ Prefer `to_s` over string interpolation.
+    RUBY
   end
 
   it 'registers an offense for "%Q(#{1 + 1})"' do
-    inspect_source(cop, '%Q(#{1 + 1})')
-    expect(cop.offenses.size).to eq(1)
-    expect(cop.highlights).to eq(['%Q(#{1 + 1})'])
+    expect_offense(<<-'RUBY'.strip_indent)
+      %Q(#{1 + 1})
+      ^^^^^^^^^^^^ Prefer `to_s` over string interpolation.
+    RUBY
   end
 
   it 'registers an offense for "#{1 + 1; 2 + 2}"' do
-    inspect_source(cop, '"#{1 + 1; 2 + 2}"')
-    expect(cop.offenses.size).to eq(1)
-    expect(cop.highlights).to eq(['"#{1 + 1; 2 + 2}"'])
+    expect_offense(<<-'RUBY'.strip_indent)
+      "#{1 + 1; 2 + 2}"
+      ^^^^^^^^^^^^^^^^^ Prefer `to_s` over string interpolation.
+    RUBY
   end
 
   it 'registers an offense for "#{@var}"' do
-    inspect_source(cop, '"#{@var}"')
-    expect(cop.offenses.size).to eq(1)
-    expect(cop.highlights).to eq(['"#{@var}"'])
+    expect_offense(<<-'RUBY'.strip_indent)
+      "#{@var}"
+      ^^^^^^^^^ Prefer `to_s` over string interpolation.
+    RUBY
   end
 
   it 'registers an offense for "#@var"' do
-    inspect_source(cop, '"#@var"')
-    expect(cop.offenses.size).to eq(1)
-    expect(cop.highlights).to eq(['"#@var"'])
+    expect_offense(<<-'RUBY'.strip_indent)
+      "#@var"
+      ^^^^^^^ Prefer `to_s` over string interpolation.
+    RUBY
   end
 
   it 'registers an offense for "#{@@var}"' do
-    inspect_source(cop, '"#{@@var}"')
-    expect(cop.offenses.size).to eq(1)
-    expect(cop.highlights).to eq(['"#{@@var}"'])
+    expect_offense(<<-'RUBY'.strip_indent)
+      "#{@@var}"
+      ^^^^^^^^^^ Prefer `to_s` over string interpolation.
+    RUBY
   end
 
   it 'registers an offense for "#@@var"' do
-    inspect_source(cop, '"#@@var"')
-    expect(cop.offenses.size).to eq(1)
-    expect(cop.highlights).to eq(['"#@@var"'])
+    expect_offense(<<-'RUBY'.strip_indent)
+      "#@@var"
+      ^^^^^^^^ Prefer `to_s` over string interpolation.
+    RUBY
   end
 
   it 'registers an offense for "#{$var}"' do
-    inspect_source(cop, '"#{$var}"')
-    expect(cop.offenses.size).to eq(1)
-    expect(cop.highlights).to eq(['"#{$var}"'])
+    expect_offense(<<-'RUBY'.strip_indent)
+      "#{$var}"
+      ^^^^^^^^^ Prefer `to_s` over string interpolation.
+    RUBY
   end
 
   it 'registers an offense for "#$var"' do
-    inspect_source(cop, '"#$var"')
-    expect(cop.offenses.size).to eq(1)
-    expect(cop.highlights).to eq(['"#$var"'])
+    expect_offense(<<-'RUBY'.strip_indent)
+      "#$var"
+      ^^^^^^^ Prefer `to_s` over string interpolation.
+    RUBY
   end
 
   it 'registers an offense for "#{$1}"' do
-    inspect_source(cop, '"#{$1}"')
-    expect(cop.offenses.size).to eq(1)
-    expect(cop.highlights).to eq(['"#{$1}"'])
+    expect_offense(<<-'RUBY'.strip_indent)
+      "#{$1}"
+      ^^^^^^^ Prefer `to_s` over string interpolation.
+    RUBY
   end
 
   it 'registers an offense for "#$1"' do
-    inspect_source(cop, '"#$1"')
-    expect(cop.offenses.size).to eq(1)
-    expect(cop.highlights).to eq(['"#$1"'])
+    expect_offense(<<-'RUBY'.strip_indent)
+      "#$1"
+      ^^^^^ Prefer `to_s` over string interpolation.
+    RUBY
   end
 
   it 'registers an offense for "#{$+}"' do
-    inspect_source(cop, '"#{$+}"')
-    expect(cop.offenses.size).to eq(1)
-    expect(cop.highlights).to eq(['"#{$+}"'])
+    expect_offense(<<-'RUBY'.strip_indent)
+      "#{$+}"
+      ^^^^^^^ Prefer `to_s` over string interpolation.
+    RUBY
   end
 
   it 'registers an offense for "#$+"' do
-    inspect_source(cop, '"#$+"')
-    expect(cop.offenses.size).to eq(1)
-    expect(cop.highlights).to eq(['"#$+"'])
+    expect_offense(<<-'RUBY'.strip_indent)
+      "#$+"
+      ^^^^^ Prefer `to_s` over string interpolation.
+    RUBY
   end
 
   it 'registers an offense for "#{var}"' do
-    inspect_source(cop, 'var = 1; "#{var}"')
-    expect(cop.offenses.size).to eq(1)
-    expect(cop.highlights).to eq(['"#{var}"'])
+    expect_offense(<<-'RUBY'.strip_indent)
+      var = 1; "#{var}"
+               ^^^^^^^^ Prefer `to_s` over string interpolation.
+    RUBY
   end
 
   it 'registers an offense for ["#{@var}"]' do
-    inspect_source(cop, '["#{@var}", \'foo\']')
-    expect(cop.offenses.size).to eq(1)
-    expect(cop.highlights).to eq(['"#{@var}"'])
+    expect_offense(<<-'RUBY'.strip_indent)
+      ["#{@var}", 'foo']
+       ^^^^^^^^^ Prefer `to_s` over string interpolation.
+    RUBY
   end
 
   it 'accepts strings with characters before the interpolation' do

--- a/spec/rubocop/cop/style/unneeded_percent_q_spec.rb
+++ b/spec/rubocop/cop/style/unneeded_percent_q_spec.rb
@@ -5,24 +5,24 @@ describe RuboCop::Cop::Style::UnneededPercentQ do
 
   context 'with %q strings' do
     it 'registers an offense for only single quotes' do
-      inspect_source(cop, "%q('hi')")
-
-      expect(cop.messages).to eq(['Use `%q` only for strings that contain ' \
-                                  'both single quotes and double quotes.'])
+      expect_offense(<<-RUBY.strip_indent)
+        %q('hi')
+        ^^^^^^^^ Use `%q` only for strings that contain both single quotes and double quotes.
+      RUBY
     end
 
     it 'registers an offense for only double quotes' do
-      inspect_source(cop, '%q("hi")')
-
-      expect(cop.messages).to eq(['Use `%q` only for strings that contain ' \
-                                  'both single quotes and double quotes.'])
+      expect_offense(<<-RUBY.strip_indent)
+        %q("hi")
+        ^^^^^^^^ Use `%q` only for strings that contain both single quotes and double quotes.
+      RUBY
     end
 
     it 'registers an offense for no quotes' do
-      inspect_source(cop, '%q(hi)')
-
-      expect(cop.messages).to eq(['Use `%q` only for strings that contain ' \
-                                  'both single quotes and double quotes.'])
+      expect_offense(<<-RUBY.strip_indent)
+        %q(hi)
+        ^^^^^^ Use `%q` only for strings that contain both single quotes and double quotes.
+      RUBY
     end
 
     it 'accepts a string with single quotes and double quotes' do
@@ -78,30 +78,24 @@ describe RuboCop::Cop::Style::UnneededPercentQ do
 
   context 'with %Q strings' do
     it 'registers an offense for static string without quotes' do
-      inspect_source(cop, '%Q(hi)')
-
-      expect(cop.messages).to eq(['Use `%Q` only for strings that contain ' \
-                                  'both single quotes and double quotes, or ' \
-                                  'for dynamic strings that contain double ' \
-                                  'quotes.'])
+      expect_offense(<<-RUBY.strip_indent)
+        %Q(hi)
+        ^^^^^^ Use `%Q` only for strings that contain both single quotes and double quotes, or for dynamic strings that contain double quotes.
+      RUBY
     end
 
     it 'registers an offense for static string with only double quotes' do
-      inspect_source(cop, '%Q("hi")')
-
-      expect(cop.messages).to eq(['Use `%Q` only for strings that contain ' \
-                                  'both single quotes and double quotes, or ' \
-                                  'for dynamic strings that contain double ' \
-                                  'quotes.'])
+      expect_offense(<<-RUBY.strip_indent)
+        %Q("hi")
+        ^^^^^^^^ Use `%Q` only for strings that contain both single quotes and double quotes, or for dynamic strings that contain double quotes.
+      RUBY
     end
 
     it 'registers an offense for dynamic string without quotes' do
-      inspect_source(cop, "%Q(hi\#{4})")
-
-      expect(cop.messages).to eq(['Use `%Q` only for strings that contain ' \
-                                  'both single quotes and double quotes, or ' \
-                                  'for dynamic strings that contain double ' \
-                                  'quotes.'])
+      expect_offense(<<-'RUBY'.strip_indent)
+        %Q(hi#{4})
+        ^^^^^^^^^^ Use `%Q` only for strings that contain both single quotes and double quotes, or for dynamic strings that contain double quotes.
+      RUBY
     end
 
     it 'accepts a string with single quotes and double quotes' do

--- a/spec/rubocop/cop/style/variable_interpolation_spec.rb
+++ b/spec/rubocop/cop/style/variable_interpolation_spec.rb
@@ -4,70 +4,52 @@ describe RuboCop::Cop::Style::VariableInterpolation do
   subject(:cop) { described_class.new }
 
   it 'registers an offense for interpolated global variables in string' do
-    inspect_source(cop,
-                   'puts "this is a #$test"')
-    expect(cop.offenses.size).to eq(1)
-    expect(cop.highlights).to eq(['$test'])
-    expect(cop.messages)
-      .to eq(['Replace interpolated variable `$test`' \
-              ' with expression `#{$test}`.'])
+    expect_offense(<<-'RUBY'.strip_indent)
+      puts "this is a #$test"
+                       ^^^^^ Replace interpolated variable `$test` with expression `#{$test}`.
+    RUBY
   end
 
   it 'registers an offense for interpolated global variables in regexp' do
-    inspect_source(cop,
-                   'puts /this is a #$test/')
-    expect(cop.offenses.size).to eq(1)
-    expect(cop.highlights).to eq(['$test'])
-    expect(cop.messages)
-      .to eq(['Replace interpolated variable `$test`' \
-              ' with expression `#{$test}`.'])
+    expect_offense(<<-'RUBY'.strip_indent)
+      puts /this is a #$test/
+                       ^^^^^ Replace interpolated variable `$test` with expression `#{$test}`.
+    RUBY
   end
 
   it 'registers an offense for interpolated global variables in backticks' do
-    inspect_source(cop,
-                   'puts `this is a #$test`')
-    expect(cop.offenses.size).to eq(1)
-    expect(cop.highlights).to eq(['$test'])
-    expect(cop.messages)
-      .to eq(['Replace interpolated variable `$test`' \
-              ' with expression `#{$test}`.'])
+    expect_offense(<<-'RUBY'.strip_indent)
+      puts `this is a #$test`
+                       ^^^^^ Replace interpolated variable `$test` with expression `#{$test}`.
+    RUBY
   end
 
   it 'registers an offense for interpolated regexp nth back references' do
-    inspect_source(cop,
-                   'puts "this is a #$1"')
-    expect(cop.offenses.size).to eq(1)
-    expect(cop.highlights).to eq(['$1'])
-    expect(cop.messages)
-      .to eq(['Replace interpolated variable `$1` with expression `#{$1}`.'])
+    expect_offense(<<-'RUBY'.strip_indent)
+      puts "this is a #$1"
+                       ^^ Replace interpolated variable `$1` with expression `#{$1}`.
+    RUBY
   end
 
   it 'registers an offense for interpolated regexp back references' do
-    inspect_source(cop,
-                   'puts "this is a #$+"')
-    expect(cop.offenses.size).to eq(1)
-    expect(cop.highlights).to eq(['$+'])
-    expect(cop.messages)
-      .to eq(['Replace interpolated variable `$+` with expression `#{$+}`.'])
+    expect_offense(<<-'RUBY'.strip_indent)
+      puts "this is a #$+"
+                       ^^ Replace interpolated variable `$+` with expression `#{$+}`.
+    RUBY
   end
 
   it 'registers an offense for interpolated instance variables' do
-    inspect_source(cop,
-                   'puts "this is a #@test"')
-    expect(cop.offenses.size).to eq(1)
-    expect(cop.highlights).to eq(['@test'])
-    expect(cop.messages)
-      .to eq(['Replace interpolated variable `@test`' \
-              ' with expression `#{@test}`.'])
+    expect_offense(<<-'RUBY'.strip_indent)
+      puts "this is a #@test"
+                       ^^^^^ Replace interpolated variable `@test` with expression `#{@test}`.
+    RUBY
   end
 
   it 'registers an offense for interpolated class variables' do
-    inspect_source(cop,
-                   'puts "this is a #@@t"')
-    expect(cop.offenses.size).to eq(1)
-    expect(cop.highlights).to eq(['@@t'])
-    expect(cop.messages)
-      .to eq(['Replace interpolated variable `@@t` with expression `#{@@t}`.'])
+    expect_offense(<<-'RUBY'.strip_indent)
+      puts "this is a #@@t"
+                       ^^^ Replace interpolated variable `@@t` with expression `#{@@t}`.
+    RUBY
   end
 
   it 'does not register an offense for variables in expressions' do

--- a/spec/rubocop/cop/style/variable_name_spec.rb
+++ b/spec/rubocop/cop/style/variable_name_spec.rb
@@ -42,27 +42,31 @@ describe RuboCop::Cop::Style::VariableName, :config do
     end
 
     it 'registers an offense for camel case in instance variable name' do
-      inspect_source(cop, '@myAttribute = 3')
-      expect(cop.offenses.size).to eq(1)
-      expect(cop.highlights).to eq(['@myAttribute'])
+      expect_offense(<<-RUBY.strip_indent)
+        @myAttribute = 3
+        ^^^^^^^^^^^^ Use snake_case for variable names.
+      RUBY
     end
 
     it 'registers an offense for camel case in class variable name' do
-      inspect_source(cop, '@@myAttr = 2')
-      expect(cop.offenses.size).to eq(1)
-      expect(cop.highlights).to eq(['@@myAttr'])
+      expect_offense(<<-RUBY.strip_indent)
+        @@myAttr = 2
+        ^^^^^^^^ Use snake_case for variable names.
+      RUBY
     end
 
     it 'registers an offense for camel case in method parameter' do
-      inspect_source(cop, 'def method(funnyArg); end')
-      expect(cop.offenses.size).to eq(1)
-      expect(cop.highlights).to eq(['funnyArg'])
+      expect_offense(<<-RUBY.strip_indent)
+        def method(funnyArg); end
+                   ^^^^^^^^ Use snake_case for variable names.
+      RUBY
     end
 
     it 'registers an offense for camel case local variables marked as unused' do
-      inspect_source(cop, '_myLocal = 1')
-      expect(cop.offenses.size).to eq(1)
-      expect(cop.highlights).to eq(['_myLocal'])
+      expect_offense(<<-RUBY.strip_indent)
+        _myLocal = 1
+        ^^^^^^^^ Use snake_case for variable names.
+      RUBY
     end
 
     include_examples 'always accepted'
@@ -101,9 +105,10 @@ describe RuboCop::Cop::Style::VariableName, :config do
     end
 
     it 'registers an offense for snake case in method parameter' do
-      inspect_source(cop, 'def method(funny_arg); end')
-      expect(cop.offenses.size).to eq(1)
-      expect(cop.highlights).to eq(['funny_arg'])
+      expect_offense(<<-RUBY.strip_indent)
+        def method(funny_arg); end
+                   ^^^^^^^^^ Use camelCase for variable names.
+      RUBY
     end
 
     it 'accepts camel case local variables marked as unused' do

--- a/spec/rubocop/cop/style/variable_number_spec.rb
+++ b/spec/rubocop/cop/style/variable_number_spec.rb
@@ -52,9 +52,10 @@ describe RuboCop::Cop::Style::VariableNumber, :config do
     it_behaves_like :accepts, 'snake_case', '@__foo__'
 
     it 'registers an offense for normal case numbering in method parameter' do
-      inspect_source(cop, 'def method(arg1); end')
-      expect(cop.offenses.size).to eq(1)
-      expect(cop.highlights).to eq(['arg1'])
+      expect_offense(<<-RUBY.strip_indent)
+        def method(arg1); end
+                   ^^^^ Use snake_case for variable numbers.
+      RUBY
     end
 
     it 'registers an offense for normal case numbering in method camel case
@@ -94,9 +95,10 @@ describe RuboCop::Cop::Style::VariableNumber, :config do
     it_behaves_like :accepts, 'normalcase', '@__foo__'
 
     it 'registers an offense for snake case numbering in method parameter' do
-      inspect_source(cop, 'def method(arg_1); end')
-      expect(cop.offenses.size).to eq(1)
-      expect(cop.highlights).to eq(['arg_1'])
+      expect_offense(<<-RUBY.strip_indent)
+        def method(arg_1); end
+                   ^^^^^ Use normalcase for variable numbers.
+      RUBY
     end
 
     it 'registers an offense for snake case numbering in method camel case
@@ -133,15 +135,17 @@ describe RuboCop::Cop::Style::VariableNumber, :config do
     it_behaves_like :accepts, 'non_integer', '@__foo__'
 
     it 'registers an offense for snake case numbering in method parameter' do
-      inspect_source(cop, 'def method(arg_1); end')
-      expect(cop.offenses.size).to eq(1)
-      expect(cop.highlights).to eq(['arg_1'])
+      expect_offense(<<-RUBY.strip_indent)
+        def method(arg_1); end
+                   ^^^^^ Use non_integer for variable numbers.
+      RUBY
     end
 
     it 'registers an offense for normal case numbering in method parameter' do
-      inspect_source(cop, 'def method(arg1); end')
-      expect(cop.offenses.size).to eq(1)
-      expect(cop.highlights).to eq(['arg1'])
+      expect_offense(<<-RUBY.strip_indent)
+        def method(arg1); end
+                   ^^^^ Use non_integer for variable numbers.
+      RUBY
     end
 
     it 'registers an offense for snake case numbering in method camel case

--- a/spec/rubocop/cop/style/when_then_spec.rb
+++ b/spec/rubocop/cop/style/when_then_spec.rb
@@ -4,12 +4,12 @@ describe RuboCop::Cop::Style::WhenThen do
   subject(:cop) { described_class.new }
 
   it 'registers an offense for when x;' do
-    inspect_source(cop, <<-END.strip_indent)
+    expect_offense(<<-RUBY.strip_indent)
       case a
       when b; c
+            ^ Do not use `when x;`. Use `when x then` instead.
       end
-    END
-    expect(cop.offenses.size).to eq(1)
+    RUBY
   end
 
   it 'accepts when x then' do

--- a/spec/rubocop/cop/style/while_until_do_spec.rb
+++ b/spec/rubocop/cop/style/while_until_do_spec.rb
@@ -4,19 +4,19 @@ describe RuboCop::Cop::Style::WhileUntilDo do
   subject(:cop) { described_class.new }
 
   it 'registers an offense for do in multiline while' do
-    inspect_source(cop, <<-END.strip_indent)
+    expect_offense(<<-RUBY.strip_indent)
       while cond do
+                 ^^ Do not use `do` with multi-line `while`.
       end
-    END
-    expect(cop.offenses.size).to eq(1)
+    RUBY
   end
 
   it 'registers an offense for do in multiline until' do
-    inspect_source(cop, <<-END.strip_indent)
+    expect_offense(<<-RUBY.strip_indent)
       until cond do
+                 ^^ Do not use `do` with multi-line `until`.
       end
-    END
-    expect(cop.offenses.size).to eq(1)
+    RUBY
   end
 
   it 'accepts do in single-line while' do

--- a/spec/rubocop/cop/style/while_until_modifier_spec.rb
+++ b/spec/rubocop/cop/style/while_until_modifier_spec.rb
@@ -54,8 +54,12 @@ describe RuboCop::Cop::Style::WhileUntilModifier do
     end
 
     it 'registers an offense' do
-      inspect_source(cop, source)
-      expect(cop.offenses.size).to eq(1)
+      expect_offense(<<-RUBY.strip_indent)
+        while true
+        ^^^^^ Favor modifier `while` usage when having a single-line body.
+          x = 0
+        end
+      RUBY
     end
 
     it 'does auto-correction' do
@@ -98,11 +102,11 @@ describe RuboCop::Cop::Style::WhileUntilModifier do
   # Regression: https://github.com/bbatsov/rubocop/issues/4006
   context 'when the modifier condition is multiline' do
     it 'registers an offense' do
-      inspect_source(cop, <<-END.strip_indent)
+      expect_offense(<<-RUBY.strip_indent)
         foo while bar ||
+            ^^^^^ Favor modifier `while` usage when having a single-line body.
           baz
-      END
-      expect(cop.offenses.size).to eq(1)
+      RUBY
     end
   end
 

--- a/spec/rubocop/cop/style/word_array_spec.rb
+++ b/spec/rubocop/cop/style/word_array_spec.rb
@@ -33,18 +33,24 @@ describe RuboCop::Cop::Style::WordArray, :config do
     end
 
     it 'registers an offense for arrays of double quoted strings' do
-      inspect_source(cop, '["one", "two", "three"]')
-      expect(cop.offenses.size).to eq(1)
+      expect_offense(<<-RUBY.strip_indent)
+        ["one", "two", "three"]
+        ^^^^^^^^^^^^^^^^^^^^^^^ Use `%w` or `%W` for an array of words.
+      RUBY
     end
 
     it 'registers an offense for arrays of unicode word characters' do
-      inspect_source(cop, '["ВУЗ", "вуз", "中文网"]')
-      expect(cop.offenses.size).to eq(1)
+      expect_offense(<<-RUBY.strip_indent)
+        ["ВУЗ", "вуз", "中文网"]
+        ^^^^^^^^^^^^^^^^^^^^^ Use `%w` or `%W` for an array of words.
+      RUBY
     end
 
     it 'registers an offense for arrays with character constants' do
-      inspect_source(cop, '["one", ?\n]')
-      expect(cop.offenses.size).to eq(1)
+      expect_offense(<<-'RUBY'.strip_indent)
+        ["one", ?\n]
+        ^^^^^^^^^^^^ Use `%w` or `%W` for an array of words.
+      RUBY
     end
 
     it 'registers an offense for strings with embedded newlines and tabs' do
@@ -53,8 +59,10 @@ describe RuboCop::Cop::Style::WordArray, :config do
     end
 
     it 'registers an offense for strings with newline and tab escapes' do
-      inspect_source(cop, %(["one\\n", "hi\\tthere"]))
-      expect(cop.offenses.size).to eq(1)
+      expect_offense(<<-'RUBY'.strip_indent)
+        ["one\n", "hi\tthere"]
+        ^^^^^^^^^^^^^^^^^^^^^^ Use `%w` or `%W` for an array of words.
+      RUBY
     end
 
     it 'uses %W when autocorrecting strings with newlines and tabs' do
@@ -180,8 +188,10 @@ describe RuboCop::Cop::Style::WordArray, :config do
     end
 
     it 'registers an offense for a %w() array' do
-      inspect_source(cop, '%w(one two three)')
-      expect(cop.offenses.size).to eq(1)
+      expect_offense(<<-RUBY.strip_indent)
+        %w(one two three)
+        ^^^^^^^^^^^^^^^^^ Use `[]` for an array of words.
+      RUBY
     end
 
     it 'auto-corrects a %w() array' do
@@ -217,8 +227,10 @@ describe RuboCop::Cop::Style::WordArray, :config do
     let(:cop_config) { { 'MinSize' => 0, 'WordRegex' => /\A[\w@.]+\z/ } }
 
     it 'registers an offense for arrays of email addresses' do
-      inspect_source(cop, "['a@example.com', 'b@example.com']")
-      expect(cop.offenses.size).to eq(1)
+      expect_offense(<<-RUBY.strip_indent)
+        ['a@example.com', 'b@example.com']
+        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Use `%w` or `%W` for an array of words.
+      RUBY
     end
 
     it 'auto-corrects an array of email addresses' do


### PR DESCRIPTION
This change focuses on replacing the specs matching the following:

 - `expect(cop.messages).to eq(Array<String>)`
 - `expect(cop.highlights).to eq(Array<String>)`
 - `expect(cop.offenses.size).to eq(Integer)`

as well as patterns I enumerated in #4357

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Used the same coding conventions as the rest of the project.
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] All tests are passing.
* [x] The new code doesn't generate RuboCop offenses.
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Updated cop documentation with `rake generate_cops_documentation` (required only when you've added a new cop or changed the configuration/documentation of an existing cop).

[1]: http://chris.beams.io/posts/git-commit/
