### PR TITLE
Remove unused test setup

### DIFF
--- a/spec/rubocop/cop/lint/empty_expression_spec.rb
+++ b/spec/rubocop/cop/lint/empty_expression_spec.rb
@@ -28,14 +28,6 @@ describe RuboCop::Cop::Lint::EmptyExpression, :config do
     end
   end
 
-  shared_examples 'code without offense' do |code|
-    let(:source) { code }
-
-    it 'does not register an offense' do
-      expect(cop.offenses).to be_empty
-    end
-  end
-
   let(:message) { described_class::MSG }
 
   context 'when used as a standalone expression' do

--- a/spec/rubocop/cop/lint/float_out_of_range_spec.rb
+++ b/spec/rubocop/cop/lint/float_out_of_range_spec.rb
@@ -3,28 +3,16 @@
 describe RuboCop::Cop::Lint::FloatOutOfRange do
   subject(:cop) { described_class.new }
 
-  context 'on 0.0' do
-    let(:source) { '0.0' }
-
-    it "doesn't register an offense" do
-      expect(cop.offenses).to be_empty
-    end
+  it 'does not register an offense for 0.0' do
+    expect_no_offenses('0.0')
   end
 
-  context 'on tiny little itty bitty floats' do
-    let(:source) { '1.1e-100' }
-
-    it "doesn't register an offense" do
-      expect(cop.offenses).to be_empty
-    end
+  it 'does not register an offense for tiny little itty bitty floats' do
+    expect_no_offenses('1.1e-100')
   end
 
-  context 'on respectably sized floats' do
-    let(:source) { '55.7e89' }
-
-    it "doesn't register an offense" do
-      expect(cop.offenses).to be_empty
-    end
+  it 'does not register an offense for respectably sized floats' do
+    expect_no_offenses('55.7e89')
   end
 
   context 'on whopping big floats which tip the scales' do

--- a/spec/rubocop/cop/lint/ineffective_access_modifier_spec.rb
+++ b/spec/rubocop/cop/lint/ineffective_access_modifier_spec.rb
@@ -4,18 +4,6 @@ describe RuboCop::Cop::Lint::IneffectiveAccessModifier do
   subject(:cop) { described_class.new }
 
   context 'when `private` is applied to a class method' do
-    let(:source) do
-      <<-END.strip_indent
-        class C
-          private
-
-          def self.method
-            puts "hi"
-          end
-        end
-      END
-    end
-
     it 'registers an offense' do
       expect_offense(<<-RUBY.strip_indent)
         class C
@@ -31,18 +19,6 @@ describe RuboCop::Cop::Lint::IneffectiveAccessModifier do
   end
 
   context 'when `protected` is applied to a class method' do
-    let(:source) do
-      <<-END.strip_indent
-        class C
-          protected
-
-          def self.method
-            puts "hi"
-          end
-        end
-      END
-    end
-
     it 'registers an offense' do
       expect_offense(<<-RUBY.strip_indent)
         class C
@@ -58,8 +34,8 @@ describe RuboCop::Cop::Lint::IneffectiveAccessModifier do
   end
 
   context 'when `private_class_method` is used' do
-    let(:source) do
-      <<-END.strip_indent
+    it "doesn't register an offense" do
+      expect_no_offenses(<<-END.strip_indent)
         class C
           private
 
@@ -71,15 +47,11 @@ describe RuboCop::Cop::Lint::IneffectiveAccessModifier do
         end
       END
     end
-
-    it "doesn't register an offense" do
-      expect(cop.offenses).to be_empty
-    end
   end
 
   context 'when a `class << self` block is used' do
-    let(:source) do
-      <<-END.strip_indent
+    it "doesn't register an offense" do
+      expect_no_offenses(<<-END.strip_indent)
         class C
           private
 
@@ -91,29 +63,9 @@ describe RuboCop::Cop::Lint::IneffectiveAccessModifier do
         end
       END
     end
-
-    it "doesn't register an offense" do
-      expect(cop.offenses).to be_empty
-    end
   end
 
   context 'when there is an intervening instance method' do
-    let(:source) do
-      <<-END.strip_indent
-        class C
-
-          private
-
-          def instance_method
-          end
-
-          def self.method
-            puts "hi"
-          end
-        end
-      END
-    end
-
     it 'still registers an offense' do
       expect_offense(<<-RUBY.strip_indent)
         class C

--- a/spec/rubocop/cop/lint/useless_access_modifier_spec.rb
+++ b/spec/rubocop/cop/lint/useless_access_modifier_spec.rb
@@ -201,15 +201,6 @@ describe RuboCop::Cop::Lint::UselessAccessModifier do
   context 'when only a constant or local variable is defined after the ' \
     'modifier' do
     %w[CONSTANT some_var].each do |binding_name|
-      let(:source) do
-        <<-END.strip_indent
-          class SomeClass
-            private
-            #{binding_name} = 1
-          end
-        END
-      end
-
       it 'registers an offense' do
         expect_offense(<<-RUBY.strip_indent)
           class SomeClass
@@ -562,23 +553,6 @@ describe RuboCop::Cop::Lint::UselessAccessModifier do
       END
       inspect_source(cop, src)
       expect(cop.offenses.size).to eq(1)
-    end
-  end
-
-  shared_examples 'access modifiers with argument' do |keyword|
-    it "doesn't register an offense" do
-      src = <<-END.strip_indent
-        #{keyword} A
-          def method1
-          end
-          private :method1
-          def method2
-          end
-          public :method2
-        end
-      END
-      inspect_source(cop, src)
-      expect(cop.offenses).to be_empty
     end
   end
 

--- a/spec/rubocop/cop/rails/file_path_spec.rb
+++ b/spec/rubocop/cop/rails/file_path_spec.rb
@@ -13,8 +13,6 @@ describe RuboCop::Cop::Rails::FilePath do
   end
 
   context 'when using File.join with Rails.root' do
-    let(:source) { "File.join(Rails.root, 'app', 'models')" }
-
     it 'registers an offense' do
       expect_offense(<<-RUBY.strip_indent)
         File.join(Rails.root, 'app', 'models')
@@ -24,8 +22,6 @@ describe RuboCop::Cop::Rails::FilePath do
   end
 
   context 'when using Rails.root.join with slash separated path string' do
-    let(:source) { "Rails.root.join('app/models/goober')" }
-
     it 'registers an offense' do
       expect_offense(<<-RUBY.strip_indent)
         Rails.root.join('app/models/goober')
@@ -35,8 +31,6 @@ describe RuboCop::Cop::Rails::FilePath do
   end
 
   context 'when using Rails.root called by double quoted string' do
-    let(:source) { '"#{Rails.root}/app/models/goober"' }
-
     it 'registers an offense' do
       expect_offense(<<-'RUBY'.strip_indent)
         "#{Rails.root}/app/models/goober"
@@ -46,8 +40,6 @@ describe RuboCop::Cop::Rails::FilePath do
   end
 
   context 'Rails.root is used as a method argument' do
-    let(:source) { 'foo(bar(File.join(Rails.root, "app", "models")))' }
-
     it 'registers an offense once' do
       expect_offense(<<-RUBY.strip_indent)
         foo(bar(File.join(Rails.root, "app", "models")))
@@ -57,8 +49,6 @@ describe RuboCop::Cop::Rails::FilePath do
   end
 
   context 'Rails.root.join used as an argument' do
-    let(:source) { 'foo(Rails.root.join(\'app/models\'))' }
-
     it 'registers an offense once' do
       expect_offense(<<-RUBY.strip_indent)
         foo(Rails.root.join('app/models'))

--- a/spec/rubocop/cop/rails/not_null_column_spec.rb
+++ b/spec/rubocop/cop/rails/not_null_column_spec.rb
@@ -6,7 +6,6 @@ describe RuboCop::Cop::Rails::NotNullColumn, :config do
 
   context 'with add_column call' do
     context 'with null: false' do
-      let(:source) { 'add_column :users, :name, :string, null: false' }
       it 'reports an offense' do
         expect_offense(<<-RUBY.strip_indent)
           add_column :users, :name, :string, null: false
@@ -23,9 +22,6 @@ describe RuboCop::Cop::Rails::NotNullColumn, :config do
     end
 
     context 'with null: false and default: nil' do
-      let(:source) do
-        'add_column :users, :name, :string, null: false, default: nil'
-      end
       it 'reports an offense' do
         expect_offense(<<-RUBY.strip_indent)
           add_column :users, :name, :string, null: false, default: nil
@@ -74,7 +70,6 @@ describe RuboCop::Cop::Rails::NotNullColumn, :config do
 
   context 'with add_reference call' do
     context 'with null: false' do
-      let(:source) { 'add_reference :products, :category, null: false' }
       it 'reports an offense' do
         expect_offense(<<-RUBY.strip_indent)
           add_reference :products, :category, null: false

--- a/spec/rubocop/cop/style/identical_conditional_branches_spec.rb
+++ b/spec/rubocop/cop/style/identical_conditional_branches_spec.rb
@@ -4,16 +4,6 @@ describe RuboCop::Cop::Style::IdenticalConditionalBranches do
   subject(:cop) { described_class.new }
 
   context 'on if..else with identical bodies' do
-    let(:source) do
-      <<-END.strip_indent
-        if something
-          do_x
-        else
-          do_x
-        end
-      END
-    end
-
     it 'registers an offense' do
       expect_offense(<<-RUBY.strip_indent)
         if something
@@ -28,18 +18,6 @@ describe RuboCop::Cop::Style::IdenticalConditionalBranches do
   end
 
   context 'on if..else with identical trailing lines' do
-    let(:source) do
-      <<-END.strip_indent
-        if something
-          method_call_here(1, 2, 3)
-          do_x
-        else
-          1 + 2 + 3
-          do_x
-        end
-      END
-    end
-
     it 'registers an offense' do
       expect_offense(<<-RUBY.strip_indent)
         if something
@@ -56,18 +34,6 @@ describe RuboCop::Cop::Style::IdenticalConditionalBranches do
   end
 
   context 'on if..else with identical leading lines' do
-    let(:source) do
-      <<-END.strip_indent
-        if something
-          do_x
-          method_call_here(1, 2, 3)
-        else
-          do_x
-          1 + 2 + 3
-        end
-      END
-    end
-
     it 'registers an offense' do
       expect_offense(<<-RUBY.strip_indent)
         if something
@@ -84,8 +50,8 @@ describe RuboCop::Cop::Style::IdenticalConditionalBranches do
   end
 
   context 'on if..elsif with no else' do
-    let(:source) do
-      <<-END.strip_indent
+    it "doesn't register an offense" do
+      expect_no_offenses(<<-END.strip_indent)
         if something
           do_x
         elsif something_else
@@ -93,15 +59,11 @@ describe RuboCop::Cop::Style::IdenticalConditionalBranches do
         end
       END
     end
-
-    it "doesn't register an offense" do
-      expect(cop.offenses).to be_empty
-    end
   end
 
   context 'on if..else with slightly different trailing lines' do
-    let(:source) do
-      <<-END.strip_indent
+    it "doesn't register an offense" do
+      expect_no_offenses(<<-END.strip_indent)
         if something
           do_x(1)
         else
@@ -109,26 +71,9 @@ describe RuboCop::Cop::Style::IdenticalConditionalBranches do
         end
       END
     end
-
-    it "doesn't register an offense" do
-      expect(cop.offenses).to be_empty
-    end
   end
 
   context 'on case with identical bodies' do
-    let(:source) do
-      <<-END.strip_indent
-        case something
-        when :a
-          do_x
-        when :b
-          do_x
-        else
-          do_x
-        end
-      END
-    end
-
     it 'registers an offense' do
       expect_offense(<<-RUBY.strip_indent)
         case something
@@ -148,8 +93,8 @@ describe RuboCop::Cop::Style::IdenticalConditionalBranches do
 
   # Regression: https://github.com/bbatsov/rubocop/issues/3868
   context 'when one of the case branches is empty' do
-    let(:source) do
-      <<-END.strip_indent
+    it 'does not register an offense' do
+      expect_no_offenses(<<-END.strip_indent)
         case value
         when cond1
         else
@@ -159,29 +104,9 @@ describe RuboCop::Cop::Style::IdenticalConditionalBranches do
         end
       END
     end
-
-    it 'does not register an offense' do
-      expect(cop.offenses).to be_empty
-    end
   end
 
   context 'on case with identical trailing lines' do
-    let(:source) do
-      <<-END.strip_indent
-        case something
-        when :a
-          x1
-          do_x
-        when :b
-          x2
-          do_x
-        else
-          x3
-          do_x
-        end
-      END
-    end
-
     it 'registers an offense' do
       expect_offense(<<-RUBY.strip_indent)
         case something
@@ -203,22 +128,6 @@ describe RuboCop::Cop::Style::IdenticalConditionalBranches do
   end
 
   context 'on case with identical leading lines' do
-    let(:source) do
-      <<-END.strip_indent
-        case something
-        when :a
-          do_x
-          x1
-        when :b
-          do_x
-          x2
-        else
-          do_x
-          x3
-        end
-      END
-    end
-
     it 'registers an offense' do
       expect_offense(<<-RUBY.strip_indent)
         case something
@@ -252,13 +161,20 @@ describe RuboCop::Cop::Style::IdenticalConditionalBranches do
     end
 
     it "doesn't register an offense" do
-      expect(cop.offenses).to be_empty
+      expect_no_offenses(<<-END.strip_indent)
+        case something
+        when :a
+          do_x
+        when :b
+          do_x
+        end
+      END
     end
   end
 
   context 'on case with empty when' do
-    let(:source) do
-      <<-END.strip_indent
+    it "doesn't register an offense" do
+      expect_no_offenses(<<-END.strip_indent)
         case something
         when :a
           do_x
@@ -269,10 +185,6 @@ describe RuboCop::Cop::Style::IdenticalConditionalBranches do
           do_z
         end
       END
-    end
-
-    it "doesn't register an offense" do
-      expect(cop.offenses).to be_empty
     end
   end
 end

--- a/spec/rubocop/cop/style/if_unless_modifier_of_if_unless_spec.rb
+++ b/spec/rubocop/cop/style/if_unless_modifier_of_if_unless_spec.rb
@@ -13,10 +13,6 @@ describe RuboCop::Cop::Style::IfUnlessModifierOfIfUnless do
   end
 
   context 'ternary with modifier' do
-    let(:source) do
-      'condition ? then_part : else_part unless external_condition'
-    end
-
     it 'registers an offense' do
       expect_offense(<<-RUBY.strip_indent)
         condition ? then_part : else_part unless external_condition
@@ -26,14 +22,6 @@ describe RuboCop::Cop::Style::IfUnlessModifierOfIfUnless do
   end
 
   context 'conditional with modifier' do
-    let(:source) do
-      <<-END.strip_indent
-        unless condition
-          then_part
-        end if external_condition
-      END
-    end
-
     it 'registers an offense' do
       expect_offense(<<-RUBY.strip_indent)
         unless condition

--- a/spec/rubocop/cop/style/nested_parenthesized_calls_spec.rb
+++ b/spec/rubocop/cop/style/nested_parenthesized_calls_spec.rb
@@ -4,26 +4,20 @@ describe RuboCop::Cop::Style::NestedParenthesizedCalls do
   subject(:cop) { described_class.new }
 
   context 'on a non-parenthesized method call' do
-    let(:source) { 'puts 1, 2' }
-
     it "doesn't register an offense" do
-      expect(cop.offenses).to be_empty
+      expect_no_offenses('puts 1, 2')
     end
   end
 
   context 'on a method call with no arguments' do
-    let(:source) { 'puts' }
-
     it "doesn't register an offense" do
-      expect(cop.offenses).to be_empty
+      expect_no_offenses('puts')
     end
   end
 
   context 'on a nested, parenthesized method call' do
-    let(:source) { 'puts(compute(something))' }
-
     it "doesn't register an offense" do
-      expect(cop.offenses).to be_empty
+      expect_no_offenses('puts(compute(something))')
     end
   end
 
@@ -45,8 +39,6 @@ describe RuboCop::Cop::Style::NestedParenthesizedCalls do
     end
 
     context 'with multiple arguments to the nested call' do
-      let(:source) { 'puts(compute first, second)' }
-
       it 'registers an offense' do
         expect_offense(<<-RUBY.strip_indent)
           puts(compute first, second)
@@ -62,42 +54,32 @@ describe RuboCop::Cop::Style::NestedParenthesizedCalls do
   end
 
   context 'on a call with no arguments, nested in a parenthesized one' do
-    let(:source) { 'puts(compute)' }
-
     it "doesn't register an offense" do
-      expect(cop.offenses).to be_empty
+      expect_no_offenses('puts(compute)')
     end
   end
 
   context 'on an aref, nested in a parenthesized method call' do
-    let(:source) { 'method(obj[1])' }
-
     it "doesn't register an offense" do
-      expect(cop.offenses).to be_empty
+      expect_no_offenses('method(obj[1])')
     end
   end
 
   context 'on a deeply nested argument' do
-    let(:source) { 'method(block_taker { another_method 1 })' }
-
     it "doesn't register an offense" do
-      expect(cop.offenses).to be_empty
+      expect_no_offenses('method(block_taker { another_method 1 })')
     end
   end
 
   context 'on an RSpec matcher' do
-    let(:source) { 'expect(obj).to(be true)' }
-
     it "doesn't register an offense" do
-      expect(cop.offenses).to be_empty
+      expect_no_offenses('expect(obj).to(be true)')
     end
   end
 
   context 'on a call to a setter method' do
-    let(:source) { 'expect(object1.attr = 1).to eq 1' }
-
     it "doesn't register an offense" do
-      expect(cop.offenses).to be_empty
+      expect_no_offenses('expect(object1.attr = 1).to eq 1')
     end
   end
 end

--- a/spec/rubocop/cop/util_spec.rb
+++ b/spec/rubocop/cop/util_spec.rb
@@ -115,7 +115,6 @@ describe RuboCop::Cop::Util do
       Parser::Source::Range.new(processed_source.buffer, begin_pos, end_pos)
     end
 
-    let(:include_final_newline) { false }
     let(:output_range) do
       obj = TestUtil.new
       obj.instance_exec(processed_source) { |src| @processed_source = src }


### PR DESCRIPTION
Removes useless RSpec `let`s and various other shared setup using a new tool I've been working on called [rspectre](https://github.com/dgollahon/rspectre)!

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Used the same coding conventions as the rest of the project.
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] All tests are passing.
* [x] The new code doesn't generate RuboCop offenses.
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Updated cop documentation with `rake generate_cops_documentation` (required only when you've added a new cop or changed the configuration/documentation of an existing cop).

[1]: http://chris.beams.io/posts/git-commit/
