### PR TITLE
Fix example for Style/PercentLiteralDelimiters cop

### DIFF
--- a/lib/rubocop/cop/style/percent_literal_delimiters.rb
+++ b/lib/rubocop/cop/style/percent_literal_delimiters.rb
@@ -12,8 +12,8 @@ module RuboCop
       # @example
       #   # Style/PercentLiteralDelimiters:
       #   #   PreferredDelimiters:
-      #   #     default: []
-      #   #     %i:      ()
+      #   #     default: '[]'
+      #   #     '%i':    '()'
       #
       #   # good
       #   %w[alpha beta] + %i(gamma delta)

--- a/manual/cops_style.md
+++ b/manual/cops_style.md
@@ -2785,8 +2785,8 @@ default.
 ```ruby
 # Style/PercentLiteralDelimiters:
 #   PreferredDelimiters:
-#     default: []
-#     %i:      ()
+#     default: '[]'
+#     '%i':    '()'
 
 # good
 %w[alpha beta] + %i(gamma delta)


### PR DESCRIPTION
Current example for Style/PercentLiteralDelimiters cop seems to be broken.
Actual Rubocop [config](https://github.com/bbatsov/rubocop/blob/master/config/default.yml#L1045) places keys and values with single quotes.

As I can see `[]` should be placed in quotes too whereas `()` can be specified without quotes.

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [ ] Used the same coding conventions as the rest of the project.
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [ ] Squashed related commits together.
* [ ] Added tests.
* [ ] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] All tests are passing.
* [x] The new code doesn't generate RuboCop offenses.
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Updated cop documentation with `rake generate_cops_documentation` (required only when you've added a new cop or changed the configuration/documentation of an existing cop).

[1]: http://chris.beams.io/posts/git-commit/
