### PR TITLE
Rewrite Security cop specs to use expect_offense

### DIFF
--- a/spec/rubocop/cop/security/eval_spec.rb
+++ b/spec/rubocop/cop/security/eval_spec.rb
@@ -32,36 +32,30 @@ describe RuboCop::Cop::Security::Eval do
   end
 
   it 'accepts eval as variable' do
-    inspect_source(cop, 'eval = something')
-    expect(cop.offenses).to be_empty
+    expect_no_offenses('eval = something')
   end
 
   it 'accepts eval as method' do
-    inspect_source(cop, 'something.eval')
-    expect(cop.offenses).to be_empty
+    expect_no_offenses('something.eval')
   end
 
   it 'accepts eval on a literal string' do
-    inspect_source(cop, 'eval("puts 1")')
-    expect(cop.offenses).to be_empty
+    expect_no_offenses('eval("puts 1")')
   end
 
   it 'accepts eval with no arguments' do
-    inspect_source(cop, 'eval')
-    expect(cop.offenses).to be_empty
+    expect_no_offenses('eval')
   end
 
   it 'accepts eval with a multiline string' do
-    inspect_source(cop, <<-END)
+    expect_no_offenses(<<-END.strip_indent)
       eval "something
       something2"
     END
-    expect(cop.offenses).to be_empty
   end
 
   it 'accepts eval with a string that is interpolated a literal' do
-    inspect_source(cop, 'eval "something#{2}"')
-    expect(cop.offenses).to be_empty
+    expect_no_offenses('eval "something#{2}"')
   end
 
   context 'with an explicit binding, filename, and line number' do
@@ -80,8 +74,9 @@ describe RuboCop::Cop::Security::Eval do
     end
 
     it 'accepts eval on a literal string' do
-      inspect_source(cop, 'eval("puts 1", binding, "test.rb", 1)')
-      expect(cop.offenses).to be_empty
+      expect_no_offenses(<<-RUBY.strip_indent)
+        eval("puts 1", binding, "test.rb", 1)
+      RUBY
     end
   end
 end

--- a/spec/rubocop/cop/security/json_load_spec.rb
+++ b/spec/rubocop/cop/security/json_load_spec.rb
@@ -3,66 +3,42 @@
 describe RuboCop::Cop::Security::JSONLoad, :config do
   subject(:cop) { described_class.new(config) }
 
-  before do
-    inspect_source(cop, source)
+  it 'registers an offense for JSON.load' do
+    expect_offense(<<-RUBY.strip_indent)
+      JSON.load(arg)
+           ^^^^ Prefer `JSON.parse` over `JSON.load`.
+      ::JSON.load(arg)
+             ^^^^ Prefer `JSON.parse` over `JSON.load`.
+    RUBY
   end
 
-  shared_examples 'code with offense' do |code, message, expected|
-    context "when checking #{code}" do
-      let(:source) { code }
-
-      it 'registers an offense' do
-        expect(cop.offenses.size).to eq(1)
-        expect(cop.offenses.first.message).to eq(message)
-      end
-
-      it 'auto-corrects' do
-        expect(autocorrect_source(cop, code)).to eq expected
-      end
-    end
+  it 'registers an offense for JSON.restore' do
+    expect_offense(<<-RUBY.strip_indent)
+      JSON.restore(arg)
+           ^^^^^^^ Prefer `JSON.parse` over `JSON.restore`.
+      ::JSON.restore(arg)
+             ^^^^^^^ Prefer `JSON.parse` over `JSON.restore`.
+    RUBY
   end
 
-  shared_examples 'code without offense' do |code|
-    context "when checking #{code}" do
-      let(:source) { code }
-
-      it 'does not register any offense' do
-        expect(cop.offenses).to be_empty
-      end
-    end
+  it 'does not register an offense for JSON under another namespace' do
+    expect_no_offenses(<<-RUBY.strip_indent)
+      SomeModule::JSON.load(arg)
+      SomeModule::JSON.restore(arg)
+    RUBY
   end
 
-  shared_examples 'accepted method' do |method|
-    include_examples 'code without offense',
-                     "JSON.#{method}(arg)"
-
-    include_examples 'code without offense',
-                     "::JSON.#{method}(arg)"
-
-    include_examples 'code without offense',
-                     "Module::JSON.#{method}(arg)"
+  it 'allows JSON.parse' do
+    expect_no_offenses(<<-RUBY.strip_indent)
+      JSON.parse(arg)
+      ::JSON.parse(arg)
+    RUBY
   end
 
-  shared_examples 'offensive method' do |method|
-    include_examples 'code with offense',
-                     "JSON.#{method}(arg)",
-                     "Prefer `JSON.parse` over `JSON.#{method}`.",
-                     'JSON.parse(arg)'
-
-    include_examples 'code with offense',
-                     "::JSON.#{method}(arg)",
-                     "Prefer `JSON.parse` over `JSON.#{method}`.",
-                     '::JSON.parse(arg)'
-
-    include_examples 'code without offense',
-                     "Module::JSON.#{method}(arg)"
+  it 'allows JSON.dump' do
+    expect_no_offenses(<<-RUBY.strip_indent)
+      JSON.dump(arg)
+      ::JSON.dump(arg)
+    RUBY
   end
-
-  include_examples 'accepted method', :parse
-
-  include_examples 'accepted method', :dump
-
-  include_examples 'offensive method', :load
-
-  include_examples 'offensive method', :restore
 end


### PR DESCRIPTION
Unlike previous PRs (#4362, #4357, #4356, #4353) I did these changes manually. I wanted to see how quickly I could manually update remaining specs. Took a few minutes per file in this case since I had to unravel some shared contexts.

As a side note, seems like there should be some simple abstraction (and equivalent shared examples) for registering offenses for a single top level method. All of these specs were basically the same.

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Used the same coding conventions as the rest of the project.
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] All tests are passing.
* [x] The new code doesn't generate RuboCop offenses.
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Updated cop documentation with `rake generate_cops_documentation` (required only when you've added a new cop or changed the configuration/documentation of an existing cop).

[1]: http://chris.beams.io/posts/git-commit/
