### PR TITLE
Rewrite more specs to use expect_no_offenses

### DIFF
--- a/spec/rubocop/cop/bundler/ordered_gems_spec.rb
+++ b/spec/rubocop/cop/bundler/ordered_gems_spec.rb
@@ -15,14 +15,11 @@ describe RuboCop::Cop::Bundler::OrderedGems, :config do
   subject(:cop) { described_class.new(config) }
 
   context 'When gems are alphabetically sorted' do
-    let(:source) { <<-END.strip_indent }
-      gem 'rspec'
-      gem 'rubocop'
-    END
-
     it 'does not register any offenses' do
-      inspect_source(cop, source)
-      expect(cop.offenses).to be_empty
+      expect_no_offenses(<<-RUBY.strip_indent)
+        gem 'rspec'
+        gem 'rubocop'
+      RUBY
     end
   end
 
@@ -50,17 +47,14 @@ describe RuboCop::Cop::Bundler::OrderedGems, :config do
   end
 
   context 'When each individual group of line is sorted' do
-    let(:source) { <<-END.strip_indent }
-      gem 'rspec'
-      gem 'rubocop'
-
-      gem 'hello'
-      gem 'world'
-    END
-
     it 'does not register any offenses' do
-      inspect_source(cop, source)
-      expect(cop.offenses).to be_empty
+      expect_no_offenses(<<-RUBY.strip_indent)
+        gem 'rspec'
+        gem 'rubocop'
+
+        gem 'hello'
+        gem 'world'
+      RUBY
     end
   end
 
@@ -167,8 +161,13 @@ describe RuboCop::Cop::Bundler::OrderedGems, :config do
       let(:treat_comments_as_group_separators) { true }
 
       it 'accepts' do
-        inspect_source(cop, source)
-        expect(cop.offenses).to be_empty
+        expect_no_offenses(<<-RUBY.strip_indent)
+          # For code quality
+          gem 'rubocop'
+          # For
+          # test
+          gem 'rspec'
+        RUBY
       end
     end
 
@@ -224,26 +223,20 @@ describe RuboCop::Cop::Bundler::OrderedGems, :config do
   end
 
   context 'When gems are asciibetically sorted' do
-    let(:source) { <<-END.strip_indent }
-      gem 'paper_trail'
-      gem 'paperclip'
-    END
-
     it 'does not register an offense' do
-      inspect_source(cop, source)
-      expect(cop.offenses).to be_empty
+      expect_no_offenses(<<-RUBY.strip_indent)
+        gem 'paper_trail'
+        gem 'paperclip'
+      RUBY
     end
   end
 
   context 'When a gem that starts with a capital letter is sorted' do
-    let(:source) { <<-END.strip_indent }
-      gem 'a'
-      gem 'Z'
-    END
-
     it 'does not register an offense' do
-      inspect_source(cop, source)
-      expect(cop.offenses).to be_empty
+      expect_no_offenses(<<-RUBY.strip_indent)
+        gem 'a'
+        gem 'Z'
+      RUBY
     end
   end
 

--- a/spec/rubocop/cop/layout/align_parameters_spec.rb
+++ b/spec/rubocop/cop/layout/align_parameters_spec.rb
@@ -125,13 +125,12 @@ describe RuboCop::Cop::Layout::AlignParameters do
     end
 
     it 'accepts the first parameter being on a new row' do
-      inspect_source(cop, <<-END.strip_margin('|'))
-        |  match(
-        |    a,
-        |    b
-        |  )
-      END
-      expect(cop.offenses).to be_empty
+      expect_no_offenses(<<-RUBY.strip_indent)
+          match(
+            a,
+            b
+          )
+      RUBY
     end
 
     it 'can handle heredoc strings' do
@@ -159,12 +158,11 @@ describe RuboCop::Cop::Layout::AlignParameters do
     end
 
     it 'can handle do-end' do
-      inspect_source(cop, <<-END.strip_margin('|'))
-        |      run(lambda do |e|
-        |        w = e['warden']
-        |      end)
-      END
-      expect(cop.offenses).to be_empty
+      expect_no_offenses(<<-RUBY.strip_indent)
+              run(lambda do |e|
+                w = e['warden']
+              end)
+      RUBY
     end
 
     it 'can handle a call with a block inside another call' do
@@ -329,24 +327,22 @@ describe RuboCop::Cop::Layout::AlignParameters do
 
     context 'assigned methods' do
       it 'accepts the first parameter being on a new row' do
-        inspect_source(cop, <<-END.strip_margin('|'))
-          | assigned_value = match(
-          |   a,
-          |   b,
-          |   c
-          | )
-        END
-        expect(cop.offenses).to be_empty
+        expect_no_offenses(<<-RUBY.strip_indent)
+           assigned_value = match(
+             a,
+             b,
+             c
+           )
+        RUBY
       end
 
       it 'accepts the first parameter being on method row' do
-        inspect_source(cop, <<-END.strip_margin('|'))
-          | assigned_value = match(a,
-          |                        b,
-          |                        c
-          |                  )
-        END
-        expect(cop.offenses).to be_empty
+        expect_no_offenses(<<-RUBY.strip_indent)
+           assigned_value = match(a,
+                                  b,
+                                  c
+                            )
+        RUBY
       end
     end
 
@@ -494,15 +490,14 @@ describe RuboCop::Cop::Layout::AlignParameters do
 
     context 'multi-line method calls' do
       it 'can handle existing indentation from multi-line method calls' do
-        inspect_source(cop, <<-END.strip_margin('|'))
-          | something
-          |   .method_name(
-          |     a,
-          |     b,
-          |     c
-          |   )
-        END
-        expect(cop.offenses).to be_empty
+        expect_no_offenses(<<-RUBY.strip_indent)
+           something
+             .method_name(
+               a,
+               b,
+               c
+             )
+        RUBY
       end
 
       it 'registers offenses for double indentation from relevant method' do
@@ -520,15 +515,14 @@ describe RuboCop::Cop::Layout::AlignParameters do
       end
 
       it 'does not err on method call without a method name' do
-        inspect_source(cop, <<-END.strip_margin('|'))
-          | something
-          |   .(
-          |     a,
-          |     b,
-          |     c
-          |   )
-        END
-        expect(cop.offenses).to be_empty
+        expect_no_offenses(<<-RUBY.strip_indent)
+           something
+             .(
+               a,
+               b,
+               c
+             )
+        RUBY
       end
 
       it 'autocorrects relative to position of relevant method call' do
@@ -665,24 +659,22 @@ describe RuboCop::Cop::Layout::AlignParameters do
         let(:indentation_width) { 4 }
 
         it 'accepts the first parameter being on a new row' do
-          inspect_source(cop, <<-END.strip_margin('|'))
-            | assigned_value = match(
-            |     a,
-            |     b,
-            |     c
-            | )
-          END
-          expect(cop.offenses).to be_empty
+          expect_no_offenses(<<-RUBY.strip_indent)
+             assigned_value = match(
+                 a,
+                 b,
+                 c
+             )
+          RUBY
         end
 
         it 'accepts the first parameter being on method row' do
-          inspect_source(cop, <<-END.strip_margin('|'))
-            | assigned_value = match(a,
-            |     b,
-            |     c
-            | )
-          END
-          expect(cop.offenses).to be_empty
+          expect_no_offenses(<<-RUBY.strip_indent)
+             assigned_value = match(a,
+                 b,
+                 c
+             )
+          RUBY
         end
 
         it 'autocorrects even when first argument is in wrong position' do
@@ -714,24 +706,22 @@ describe RuboCop::Cop::Layout::AlignParameters do
         end
 
         it 'accepts the first parameter being on a new row' do
-          inspect_source(cop, <<-END.strip_margin('|'))
-            | assigned_value = match(
-            |     a,
-            |     b,
-            |     c
-            | )
-          END
-          expect(cop.offenses).to be_empty
+          expect_no_offenses(<<-RUBY.strip_indent)
+             assigned_value = match(
+                 a,
+                 b,
+                 c
+             )
+          RUBY
         end
 
         it 'accepts the first parameter being on method row' do
-          inspect_source(cop, <<-END.strip_margin('|'))
-            | assigned_value = match(a,
-            |     b,
-            |     c
-            | )
-          END
-          expect(cop.offenses).to be_empty
+          expect_no_offenses(<<-RUBY.strip_indent)
+             assigned_value = match(a,
+                 b,
+                 c
+             )
+          RUBY
         end
       end
     end

--- a/spec/rubocop/cop/layout/block_end_newline_spec.rb
+++ b/spec/rubocop/cop/layout/block_end_newline_spec.rb
@@ -4,8 +4,7 @@ describe RuboCop::Cop::Layout::BlockEndNewline do
   subject(:cop) { described_class.new }
 
   it 'does not register an offense for a one-liner' do
-    inspect_source(cop, 'test do foo end')
-    expect(cop.messages).to be_empty
+    expect_no_offenses('test do foo end')
   end
 
   it 'does not register an offense for multiline blocks with newlines before '\

--- a/spec/rubocop/cop/layout/case_indentation_spec.rb
+++ b/spec/rubocop/cop/layout/case_indentation_spec.rb
@@ -16,11 +16,8 @@ describe RuboCop::Cop::Layout::CaseIndentation do
       end
 
       context 'with everything on a single line' do
-        let(:source) { 'case foo; when :bar then 1; else 0; end' }
-
         it 'does not register an offense' do
-          inspect_source(cop, source)
-          expect(cop.offenses).to be_empty
+          expect_no_offenses('case foo; when :bar then 1; else 0; end')
         end
       end
 
@@ -36,20 +33,15 @@ describe RuboCop::Cop::Layout::CaseIndentation do
           END
         end
 
-        let(:source) do
-          <<-END.strip_indent
+        it 'accepts a correctly indented assignment' do
+          expect_no_offenses(<<-RUBY.strip_indent)
             output = case variable
                      when 'value1'
                        'output1'
                      else
                        'output2'
                      end
-          END
-        end
-
-        it 'accepts a correctly indented assignment' do
-          inspect_source(cop, source)
-          expect(cop.offenses).to be_empty
+          RUBY
         end
 
         context 'an assignment indented as end' do
@@ -276,29 +268,21 @@ describe RuboCop::Cop::Layout::CaseIndentation do
       end
 
       context 'with everything on a single line' do
-        let(:source) { 'case foo; when :bar then 1; else 0; end' }
-
         it 'does not register an offense' do
-          inspect_source(cop, source)
-          expect(cop.offenses).to be_empty
+          expect_no_offenses('case foo; when :bar then 1; else 0; end')
         end
-      end
-
-      let(:correct_source) do
-        <<-END.strip_indent
-          output = case variable
-                     when 'value1'
-                       'output1'
-                     else
-                       'output2'
-                   end
-        END
       end
 
       context 'regarding assignment where the right hand side is a case' do
         it 'accepts a correctly indented assignment' do
-          inspect_source(cop, correct_source)
-          expect(cop.offenses).to be_empty
+          expect_no_offenses(<<-RUBY.strip_indent)
+            output = case variable
+                       when 'value1'
+                         'output1'
+                       else
+                         'output2'
+                     end
+          RUBY
         end
 
         context 'an assignment indented some other way' do
@@ -422,20 +406,15 @@ describe RuboCop::Cop::Layout::CaseIndentation do
           }
         end
 
-        let(:source) do
-          <<-END.strip_indent
+        it 'respects cop-specific IndentationWidth' do
+          expect_no_offenses(<<-RUBY.strip_indent)
             output = case variable
                           when 'value1'
                          'output1'
                           else
                          'output2'
                      end
-          END
-        end
-
-        it 'respects cop-specific IndentationWidth' do
-          inspect_source(cop, source)
-          expect(cop.offenses).to be_empty
+          RUBY
         end
       end
     end
@@ -448,29 +427,21 @@ describe RuboCop::Cop::Layout::CaseIndentation do
       end
 
       context 'with everything on a single line' do
-        let(:source) { 'case foo; when :bar then 1; else 0; end' }
-
         it 'does not register an offense' do
-          inspect_source(cop, source)
-          expect(cop.offenses).to be_empty
+          expect_no_offenses('case foo; when :bar then 1; else 0; end')
         end
-      end
-
-      let(:correct_source) do
-        <<-END.strip_indent
-          output = case variable
-          when 'value1'
-            'output1'
-          else
-            'output2'
-          end
-        END
       end
 
       context 'regarding assignment where the right hand side is a case' do
         it 'accepts a correctly indented assignment' do
-          inspect_source(cop, correct_source)
-          expect(cop.offenses).to be_empty
+          expect_no_offenses(<<-RUBY.strip_indent)
+            output = case variable
+            when 'value1'
+              'output1'
+            else
+              'output2'
+            end
+          RUBY
         end
 
         context 'an assignment indented some other way' do
@@ -522,29 +493,21 @@ describe RuboCop::Cop::Layout::CaseIndentation do
       end
 
       context 'with everything on a single line' do
-        let(:source) { 'case foo; when :bar then 1; else 0; end' }
-
         it 'does not register an offense' do
-          inspect_source(cop, source)
-          expect(cop.offenses).to be_empty
+          expect_no_offenses('case foo; when :bar then 1; else 0; end')
         end
-      end
-
-      let(:correct_source) do
-        <<-END.strip_indent
-          output = case variable
-            when 'value1'
-              'output1'
-            else
-              'output2'
-          end
-        END
       end
 
       context 'regarding assignment where the right hand side is a case' do
         it 'accepts a correctly indented assignment' do
-          inspect_source(cop, correct_source)
-          expect(cop.offenses).to be_empty
+          expect_no_offenses(<<-RUBY.strip_indent)
+            output = case variable
+              when 'value1'
+                'output1'
+              else
+                'output2'
+            end
+          RUBY
         end
 
         context 'an assignment indented as case' do

--- a/spec/rubocop/cop/layout/else_alignment_spec.rb
+++ b/spec/rubocop/cop/layout/else_alignment_spec.rb
@@ -508,7 +508,7 @@ describe RuboCop::Cop::Layout::ElseAlignment do
 
   context 'with def/rescue/else/end' do
     it 'accepts a correctly aligned else' do
-      inspect_source(cop, <<-END.strip_indent)
+      expect_no_offenses(<<-RUBY.strip_indent)
         def my_func
           puts 'do something error prone'
         rescue SomeException
@@ -518,8 +518,7 @@ describe RuboCop::Cop::Layout::ElseAlignment do
         else
           puts 'normal handling'
         end
-      END
-      expect(cop.messages).to be_empty
+      RUBY
     end
 
     it 'registers an offense for misaligned else' do

--- a/spec/rubocop/cop/layout/empty_lines_spec.rb
+++ b/spec/rubocop/cop/layout/empty_lines_spec.rb
@@ -20,18 +20,22 @@ describe RuboCop::Cop::Layout::EmptyLines do
   end
 
   it 'handles comments' do
-    inspect_source(cop,
-                   ['test', '', '#comment', 'top'])
-    expect(cop.offenses).to be_empty
+    expect_no_offenses(<<-RUBY.strip_indent)
+      test
+
+      #comment
+      top
+    RUBY
   end
 
   it 'does not register an offense for empty lines in a string' do
-    inspect_source(cop, 'result = "test
+    expect_no_offenses(<<-RUBY.strip_indent)
+      result = "test
 
 
 
-                                  string"')
-    expect(cop.offenses).to be_empty
+                                        string"
+    RUBY
   end
 
   it 'does not register an offense for heredocs with empty lines inside' do

--- a/spec/rubocop/cop/layout/first_parameter_indentation_spec.rb
+++ b/spec/rubocop/cop/layout/first_parameter_indentation_spec.rb
@@ -410,11 +410,10 @@ describe RuboCop::Cop::Layout::FirstParameterIndentation do
       end
 
       it 'accepts first parameter indented relative to previous line' do
-        inspect_source(cop, <<-END.strip_margin('|'))
-          |  @diagnostics.process(Diagnostic.new(
-          |    :error, :token, { :token => name }, location))
-        END
-        expect(cop.offenses).to be_empty
+        expect_no_offenses(<<-RUBY.strip_indent)
+            @diagnostics.process(Diagnostic.new(
+              :error, :token, { :token => name }, location))
+        RUBY
       end
 
       it 'auto-corrects an over-indented first parameter' do

--- a/spec/rubocop/cop/layout/indent_array_spec.rb
+++ b/spec/rubocop/cop/layout/indent_array_spec.rb
@@ -85,14 +85,13 @@ describe RuboCop::Cop::Layout::IndentArray do
 
   context 'when array is argument to setter' do
     it 'accepts correctly indented first element' do
-      inspect_source(cop, <<-END.strip_margin('|'))
-        |   config.rack_cache = [
-        |     "rails:/",
-        |     "rails:/",
-        |     false
-        |   ]
-      END
-      expect(cop.offenses).to be_empty
+      expect_no_offenses(<<-RUBY.strip_indent)
+           config.rack_cache = [
+             "rails:/",
+             "rails:/",
+             false
+           ]
+      RUBY
     end
 
     it 'registers an offense for incorrectly indented first element' do

--- a/spec/rubocop/cop/layout/indent_hash_spec.rb
+++ b/spec/rubocop/cop/layout/indent_hash_spec.rb
@@ -139,14 +139,13 @@ describe RuboCop::Cop::Layout::IndentHash do
 
   context 'when hash is argument to setter' do
     it 'accepts correctly indented first pair' do
-      inspect_source(cop, <<-END.strip_margin('|'))
-        |   config.rack_cache = {
-        |     :metastore => "rails:/",
-        |     :entitystore => "rails:/",
-        |     :verbose => false
-        |   }
-      END
-      expect(cop.offenses).to be_empty
+      expect_no_offenses(<<-RUBY.strip_indent)
+           config.rack_cache = {
+             :metastore => "rails:/",
+             :entitystore => "rails:/",
+             :verbose => false
+           }
+      RUBY
     end
 
     it 'registers an offense for incorrectly indented first pair' do

--- a/spec/rubocop/cop/layout/initial_indentation_spec.rb
+++ b/spec/rubocop/cop/layout/initial_indentation_spec.rb
@@ -19,11 +19,8 @@ describe RuboCop::Cop::Layout::InitialIndentation do
   end
 
   context 'for a file with byte order mark' do
-    let(:bom) { "\xef\xbb\xbf" }
-
     it 'accepts unindented method call' do
-      inspect_source(cop, bom + 'puts 1')
-      expect(cop.offenses).to be_empty
+      expect_no_offenses('﻿puts 1')
     end
 
     it 'registers an offense for indented method call' do

--- a/spec/rubocop/cop/layout/multiline_method_call_indentation_spec.rb
+++ b/spec/rubocop/cop/layout/multiline_method_call_indentation_spec.rb
@@ -218,10 +218,10 @@ describe RuboCop::Cop::Layout::MultilineMethodCallIndentation do
       end
 
       it 'accepts method being aligned with method that is an argument' do
-        inspect_source(cop,
-                       ['authorize scope.includes(:user)',
-                        '               .order(:name)'])
-        expect(cop.offenses).to be_empty
+        expect_no_offenses(<<-RUBY.strip_indent)
+          authorize scope.includes(:user)
+                         .order(:name)
+        RUBY
       end
 
       it 'accepts method being aligned with method that is an argument in ' \
@@ -401,11 +401,11 @@ describe RuboCop::Cop::Layout::MultilineMethodCallIndentation do
     end
 
     it 'does not check binary operations when string wrapped with backslash' do
-      inspect_source(cop,
-                     ["flash[:error] = 'Here is a string ' \\",
-                      "                'That spans' <<",
-                      "  'multiple lines'"])
-      expect(cop.offenses).to be_empty
+      expect_no_offenses(<<-RUBY.strip_indent)
+        flash[:error] = 'Here is a string ' \
+                        'That spans' <<
+          'multiple lines'
+      RUBY
     end
 
     it 'does not check binary operations when string wrapped with +' do

--- a/spec/rubocop/cop/layout/multiline_method_call_indentation_spec.rb
+++ b/spec/rubocop/cop/layout/multiline_method_call_indentation_spec.rb
@@ -370,24 +370,22 @@ describe RuboCop::Cop::Layout::MultilineMethodCallIndentation do
     end
 
     it 'accepts aligned methods in if condition' do
-      inspect_source(cop, <<-END.strip_indent)
+      expect_no_offenses(<<-RUBY.strip_indent)
         if a.
            b
           something
         end
-      END
-      expect(cop.messages).to be_empty
+      RUBY
     end
 
     it 'accepts aligned methods in a begin..end block' do
-      inspect_source(cop, <<-END.strip_indent)
+      expect_no_offenses(<<-RUBY.strip_indent)
         @dependencies ||= begin
           DEFAULT_DEPENDENCIES
             .reject { |e| e }
             .map { |e| e }
         end
-      END
-      expect(cop.messages).to be_empty
+      RUBY
     end
 
     it 'registers an offense for misaligned methods in if condition' do
@@ -478,13 +476,12 @@ describe RuboCop::Cop::Layout::MultilineMethodCallIndentation do
     end
 
     it 'accepts aligned methods in assignment' do
-      inspect_source(cop, <<-END.strip_indent)
+      expect_no_offenses(<<-RUBY.strip_indent)
         formatted_int = int_part
                         .to_s
                         .reverse
-                        .gsub(/...(?=.)/, '\&_')
-      END
-      expect(cop.messages).to be_empty
+                        .gsub(/...(?=.)/, '&_')
+      RUBY
     end
 
     it 'registers an offense for misaligned methods in local variable ' \
@@ -572,18 +569,10 @@ describe RuboCop::Cop::Layout::MultilineMethodCallIndentation do
     end
 
     it 'accepts indentation of consecutive lines in typical RSpec code' do
-      inspect_source(cop, <<-END.strip_indent)
-        expect { Foo.new }.
-          to change { Bar.count }.
-               from(1).to(2)
-      END
-      expect(cop.messages).to be_empty
-
-      inspect_source(cop, <<-END.strip_indent)
+      expect_no_offenses(<<-RUBY.strip_indent)
         expect { Foo.new }.to change { Bar.count }
                                 .from(1).to(2)
-      END
-      expect(cop.messages).to be_empty
+      RUBY
     end
 
     it 'registers an offense for no indentation of second line' do
@@ -698,13 +687,12 @@ describe RuboCop::Cop::Layout::MultilineMethodCallIndentation do
     end
 
     it 'accepts indented methods in if condition' do
-      inspect_source(cop, <<-END.strip_indent)
+      expect_no_offenses(<<-RUBY.strip_indent)
         if a.
             b
           something
         end
-      END
-      expect(cop.messages).to be_empty
+      RUBY
     end
 
     it 'registers an offense for aligned methods in if condition' do
@@ -722,31 +710,28 @@ describe RuboCop::Cop::Layout::MultilineMethodCallIndentation do
     end
 
     it 'accepts normal indentation of method parameters' do
-      inspect_source(cop, <<-END.strip_indent)
+      expect_no_offenses(<<-RUBY.strip_indent)
         Parser::Source::Range.new(expr.source_buffer,
                                   begin_pos,
                                   begin_pos + line.length)
-      END
-      expect(cop.messages).to be_empty
+      RUBY
     end
 
     it 'accepts any indentation of method parameters' do
-      inspect_source(cop, <<-END.strip_indent)
+      expect_no_offenses(<<-RUBY.strip_indent)
         a(b.
             c
         .d)
-      END
-      expect(cop.messages).to be_empty
+      RUBY
     end
 
     it 'accepts normal indentation inside grouped expression' do
-      inspect_source(cop, <<-END.strip_indent)
+      expect_no_offenses(<<-RUBY.strip_indent)
         arg_array.size == a.size && (
           arg_array == a ||
           arg_array.map(&:children) == a.map(&:children)
         )
-      END
-      expect(cop.messages).to be_empty
+      RUBY
     end
 
     [
@@ -811,24 +796,22 @@ describe RuboCop::Cop::Layout::MultilineMethodCallIndentation do
     end
 
     it 'accepts special indentation of for expression' do
-      inspect_source(cop, <<-END.strip_indent)
+      expect_no_offenses(<<-RUBY.strip_indent)
         for n in a.
             b
         end
-      END
-      expect(cop.messages).to be_empty
+      RUBY
     end
 
     it 'accepts indentation of assignment' do
-      inspect_source(cop, <<-END.strip_indent)
+      expect_no_offenses(<<-RUBY.strip_indent)
         formatted_int = int_part
           .abs
           .to_s
           .reverse
-          .gsub(/...(?=.)/, '\&_')
+          .gsub(/...(?=.)/, '&_')
           .reverse
-      END
-      expect(cop.messages).to be_empty
+      RUBY
     end
 
     it 'registers an offense for correct + unrecognized style' do
@@ -894,23 +877,21 @@ describe RuboCop::Cop::Layout::MultilineMethodCallIndentation do
       end
 
       it 'accepts indented methods in if condition' do
-        inspect_source(cop, <<-END.strip_indent)
+        expect_no_offenses(<<-RUBY.strip_indent)
           if a.
                    b
             something
           end
-        END
-        expect(cop.messages).to be_empty
+        RUBY
       end
 
       it 'accepts indentation of assignment' do
-        inspect_source(cop, <<-END.strip_indent)
+        expect_no_offenses(<<-RUBY.strip_indent)
           formatted_int = int_part
                  .abs
                  .to_s
                  .reverse
-        END
-        expect(cop.messages).to be_empty
+        RUBY
       end
 
       [

--- a/spec/rubocop/cop/layout/multiline_operation_indentation_spec.rb
+++ b/spec/rubocop/cop/layout/multiline_operation_indentation_spec.rb
@@ -213,13 +213,12 @@ describe RuboCop::Cop::Layout::MultilineOperationIndentation do
     include_examples 'common'
 
     it 'accepts aligned operands in if condition' do
-      inspect_source(cop, <<-END.strip_indent)
+      expect_no_offenses(<<-RUBY.strip_indent)
         if a +
            b
           something
         end
-      END
-      expect(cop.messages).to be_empty
+      RUBY
     end
 
     it 'registers an offense for indented operands in if condition' do
@@ -349,11 +348,10 @@ describe RuboCop::Cop::Layout::MultilineOperationIndentation do
     end
 
     it 'accepts aligned or:ed operands in assignment' do
-      inspect_source(cop, <<-END.strip_indent)
+      expect_no_offenses(<<-RUBY.strip_indent)
         tmp_dir = ENV['TMPDIR'] || ENV['TMP'] || ENV['TEMP'] ||
                   Etc.systmpdir || '/tmp'
-      END
-      expect(cop.messages).to be_empty
+      RUBY
     end
 
     it 'registers an offense for unaligned operands in op-assignment' do
@@ -387,13 +385,12 @@ describe RuboCop::Cop::Layout::MultilineOperationIndentation do
     include_examples 'common'
 
     it 'accepts indented operands in if condition' do
-      inspect_source(cop, <<-END.strip_indent)
+      expect_no_offenses(<<-RUBY.strip_indent)
         if a +
             b
           something
         end
-      END
-      expect(cop.messages).to be_empty
+      RUBY
     end
 
     it 'registers an offense for aligned operands in if condition' do
@@ -411,28 +408,26 @@ describe RuboCop::Cop::Layout::MultilineOperationIndentation do
     end
 
     it 'accepts the indentation of a broken string' do
-      inspect_source(cop,
-                     ["MSG = 'Use 2 (not %d) spaces for indenting a ' \\",
-                      "      'broken line.'"])
-      expect(cop.messages).to be_empty
+      expect_no_offenses(<<-RUBY.strip_indent)
+        MSG = 'Use 2 (not %d) spaces for indenting a ' \
+              'broken line.'
+      RUBY
     end
 
     it 'accepts normal indentation of method parameters' do
-      inspect_source(cop, <<-END.strip_indent)
+      expect_no_offenses(<<-RUBY.strip_indent)
         Parser::Source::Range.new(expr.source_buffer,
                                   begin_pos,
                                   begin_pos + line.length)
-      END
-      expect(cop.messages).to be_empty
+      RUBY
     end
 
     it 'accepts any indentation of method parameters' do
-      inspect_source(cop, <<-END.strip_indent)
+      expect_no_offenses(<<-RUBY.strip_indent)
         a(b +
             c +
         d)
-      END
-      expect(cop.messages).to be_empty
+      RUBY
     end
 
     it 'accepts normal indentation inside grouped expression' do
@@ -520,21 +515,19 @@ describe RuboCop::Cop::Layout::MultilineOperationIndentation do
     end
 
     it 'accepts special indentation of for expression' do
-      inspect_source(cop, <<-END.strip_indent)
+      expect_no_offenses(<<-RUBY.strip_indent)
         for n in a +
             b
         end
-      END
-      expect(cop.messages).to be_empty
+      RUBY
     end
 
     it 'accepts indentation of assignment' do
-      inspect_source(cop, <<-END.strip_indent)
+      expect_no_offenses(<<-RUBY.strip_indent)
         a = b +
           c +
           d
-      END
-      expect(cop.messages).to be_empty
+      RUBY
     end
 
     it 'registers an offense for correct + unrecognized style' do
@@ -581,13 +574,12 @@ describe RuboCop::Cop::Layout::MultilineOperationIndentation do
       let(:cop_indent) { 6 }
 
       it 'accepts indented operands in if condition' do
-        inspect_source(cop, <<-END.strip_indent)
+        expect_no_offenses(<<-RUBY.strip_indent)
           if a +
                   b
             something
           end
-        END
-        expect(cop.messages).to be_empty
+        RUBY
       end
 
       [

--- a/spec/rubocop/cop/layout/multiline_operation_indentation_spec.rb
+++ b/spec/rubocop/cop/layout/multiline_operation_indentation_spec.rb
@@ -235,11 +235,12 @@ describe RuboCop::Cop::Layout::MultilineOperationIndentation do
     end
 
     it 'accepts indented code on LHS of equality operator' do
-      inspect_source(cop, ['def config_to_allow_offenses',
-                           '  a +',
-                           '    b == c ',
-                           'end'])
-      expect(cop.offenses).to be_empty
+      expect_no_offenses(<<-RUBY.strip_indent)
+        def config_to_allow_offenses
+          a +
+            b == c
+        end
+      RUBY
     end
 
     it 'accepts indented operands inside block + assignment' do

--- a/spec/rubocop/cop/layout/rescue_ensure_alignment_spec.rb
+++ b/spec/rubocop/cop/layout/rescue_ensure_alignment_spec.rb
@@ -103,8 +103,7 @@ describe RuboCop::Cop::Layout::RescueEnsureAlignment do
     it_behaves_like 'common behavior', 'rescue'
 
     it 'accepts the modifier form' do
-      inspect_source(cop, 'test rescue nil')
-      expect(cop.messages).to be_empty
+      expect_no_offenses('test rescue nil')
     end
   end
 

--- a/spec/rubocop/cop/layout/space_after_colon_spec.rb
+++ b/spec/rubocop/cop/layout/space_after_colon_spec.rb
@@ -11,54 +11,46 @@ describe RuboCop::Cop::Layout::SpaceAfterColon do
   end
 
   it 'accepts colons in symbols' do
-    inspect_source(cop, 'x = :a')
-    expect(cop.messages).to be_empty
+    expect_no_offenses('x = :a')
   end
 
   it 'accepts colon in ternary followed by space' do
-    inspect_source(cop, 'x = w ? a : b')
-    expect(cop.messages).to be_empty
+    expect_no_offenses('x = w ? a : b')
   end
 
   it 'accepts hashes with a space after colons' do
-    inspect_source(cop, '{a: 3}')
-    expect(cop.messages).to be_empty
+    expect_no_offenses('{a: 3}')
   end
 
   it 'accepts hash rockets' do
-    inspect_source(cop, 'x = {"a"=>1}')
-    expect(cop.messages).to be_empty
+    expect_no_offenses('x = {"a"=>1}')
   end
 
   it 'accepts if' do
-    inspect_source(cop, <<-END.strip_indent)
+    expect_no_offenses(<<-RUBY.strip_indent)
       x = if w
             a
           end
-    END
-    expect(cop.messages).to be_empty
+    RUBY
   end
 
   it 'accepts colons in strings' do
-    inspect_source(cop, "str << ':'")
-    expect(cop.messages).to be_empty
+    expect_no_offenses("str << ':'")
   end
 
   it 'accepts required keyword arguments' do
-    inspect_source(cop, <<-END.strip_indent)
+    expect_no_offenses(<<-RUBY.strip_indent)
       def f(x:, y:)
       end
-    END
-    expect(cop.messages).to be_empty
+    RUBY
   end
 
   if RUBY_VERSION >= '2.1'
     it 'accepts colons denoting required keyword argument' do
-      inspect_source(cop, <<-END.strip_indent)
+      expect_no_offenses(<<-RUBY.strip_indent)
         def initialize(table:, nodes:)
         end
-      END
-      expect(cop.messages).to be_empty
+      RUBY
     end
 
     it 'registers an offence if an keyword optional argument has no space' do

--- a/spec/rubocop/cop/layout/space_after_comma_spec.rb
+++ b/spec/rubocop/cop/layout/space_after_comma_spec.rb
@@ -78,8 +78,7 @@ describe RuboCop::Cop::Layout::SpaceAfterComma do
       it_behaves_like 'common behavior'
 
       it 'accepts no space between a comma and a closing brace' do
-        inspect_source(cop, '{foo:bar,}')
-        expect(cop.messages).to be_empty
+        expect_no_offenses('{foo:bar,}')
       end
     end
   end

--- a/spec/rubocop/cop/layout/space_after_semicolon_spec.rb
+++ b/spec/rubocop/cop/layout/space_after_semicolon_spec.rb
@@ -15,8 +15,7 @@ describe RuboCop::Cop::Layout::SpaceAfterSemicolon do
   end
 
   it 'does not crash if semicolon is the last character of the file' do
-    inspect_source(cop, 'x = 1;')
-    expect(cop.messages).to be_empty
+    expect_no_offenses('x = 1;')
   end
 
   it 'auto-corrects missing space' do
@@ -54,8 +53,7 @@ describe RuboCop::Cop::Layout::SpaceAfterSemicolon do
       it_behaves_like 'common behavior'
 
       it 'accepts no space between a semicolon and a closing brace' do
-        inspect_source(cop, 'test { ;}')
-        expect(cop.messages).to be_empty
+        expect_no_offenses('test { ;}')
       end
     end
   end

--- a/spec/rubocop/cop/layout/space_around_equals_in_parameter_default_spec.rb
+++ b/spec/rubocop/cop/layout/space_around_equals_in_parameter_default_spec.rb
@@ -35,11 +35,10 @@ describe RuboCop::Cop::Layout::SpaceAroundEqualsInParameterDefault, :config do
     end
 
     it 'accepts default value assignment with space' do
-      inspect_source(cop, <<-END.strip_indent)
+      expect_no_offenses(<<-RUBY.strip_indent)
         def f(x, y = 0, z = {})
         end
-      END
-      expect(cop.messages).to be_empty
+      RUBY
     end
 
     it 'auto-corrects missing space' do
@@ -48,11 +47,10 @@ describe RuboCop::Cop::Layout::SpaceAroundEqualsInParameterDefault, :config do
     end
 
     it 'accepts default value assignment with spaces and unary + operator' do
-      inspect_source(cop, <<-END.strip_indent)
+      expect_no_offenses(<<-RUBY.strip_indent)
         def f(x, y = +1, z = {})
         end
-      END
-      expect(cop.messages).to be_empty
+      RUBY
     end
 
     it 'auto-corrects missing space for arguments with unary operators' do
@@ -99,11 +97,10 @@ describe RuboCop::Cop::Layout::SpaceAroundEqualsInParameterDefault, :config do
     end
 
     it 'accepts default value assignment without space' do
-      inspect_source(cop, <<-END.strip_indent)
+      expect_no_offenses(<<-RUBY.strip_indent)
         def f(x, y=0, z={})
         end
-      END
-      expect(cop.messages).to be_empty
+      RUBY
     end
 
     it 'auto-corrects unwanted space' do

--- a/spec/rubocop/cop/layout/space_around_operators_spec.rb
+++ b/spec/rubocop/cop/layout/space_around_operators_spec.rb
@@ -15,18 +15,15 @@ describe RuboCop::Cop::Layout::SpaceAroundOperators do
   let(:allow_for_alignment) { true }
 
   it 'accepts operator surrounded by tabs' do
-    inspect_source(cop, "a\t+\tb")
-    expect(cop.messages).to be_empty
+    expect_no_offenses("a\t+\tb")
   end
 
   it 'accepts operator symbols' do
-    inspect_source(cop, 'func(:-)')
-    expect(cop.messages).to be_empty
+    expect_no_offenses('func(:-)')
   end
 
   it 'accepts ranges' do
-    inspect_source(cop, 'a, b = (1..2), (1...3)')
-    expect(cop.messages).to be_empty
+    expect_no_offenses('a, b = (1..2), (1...3)')
   end
 
   it 'accepts scope operator' do
@@ -59,36 +56,33 @@ describe RuboCop::Cop::Layout::SpaceAroundOperators do
   end
 
   it 'accepts a unary' do
-    inspect_source(cop, <<-END.strip_indent)
-        def bm(label_width = 0, *labels, &blk)
-          benchmark(CAPTION, label_width, FORMAT,
-                    *labels, &blk)
-        end
+    expect_no_offenses(<<-RUBY.strip_indent)
+      def bm(label_width = 0, *labels, &blk)
+        benchmark(CAPTION, label_width, FORMAT,
+                  *labels, &blk)
+      end
 
-        def each &block
-          +11
-        end
+      def each &block
+        +11
+      end
 
-        def self.search *args
-        end
+      def self.search *args
+      end
 
-        def each *args
-        end
-    END
-    expect(cop.messages).to be_empty
+      def each *args
+      end
+    RUBY
   end
 
   it 'accepts splat operator' do
-    inspect_source(cop, 'return *list if options')
-    expect(cop.messages).to be_empty
+    expect_no_offenses('return *list if options')
   end
 
   it 'accepts def of operator' do
-    inspect_source(cop, <<-END.strip_indent)
+    expect_no_offenses(<<-RUBY.strip_indent)
       def +(other); end
       def self.===(other); end
-    END
-    expect(cop.messages).to be_empty
+    RUBY
   end
 
   it 'accepts an operator at the end of a line' do
@@ -195,19 +189,17 @@ describe RuboCop::Cop::Layout::SpaceAroundOperators do
   it 'accepts argument default values without space' do
     # These are handled by SpaceAroundEqualsInParameterDefault,
     # so SpaceAroundOperators leaves them alone.
-    inspect_source(cop, <<-END.strip_indent)
+    expect_no_offenses(<<-RUBY.strip_indent)
       def init(name=nil)
       end
-    END
-    expect(cop.messages).to be_empty
+    RUBY
   end
 
   it 'accepts the construct class <<self with no space after <<' do
-    inspect_source(cop, <<-END.strip_indent)
+    expect_no_offenses(<<-RUBY.strip_indent)
       class <<self
       end
-    END
-    expect(cop.messages).to be_empty
+    RUBY
   end
 
   describe 'missing space around operators' do

--- a/spec/rubocop/cop/layout/space_before_comma_spec.rb
+++ b/spec/rubocop/cop/layout/space_before_comma_spec.rb
@@ -25,8 +25,7 @@ describe RuboCop::Cop::Layout::SpaceBeforeComma do
   end
 
   it 'does not register an offense for no spaces before comma' do
-    inspect_source(cop, 'a(1, 2)')
-    expect(cop.messages).to be_empty
+    expect_no_offenses('a(1, 2)')
   end
 
   it 'auto-corrects space before comma' do

--- a/spec/rubocop/cop/layout/space_before_semicolon_spec.rb
+++ b/spec/rubocop/cop/layout/space_before_semicolon_spec.rb
@@ -15,8 +15,7 @@ describe RuboCop::Cop::Layout::SpaceBeforeSemicolon do
   end
 
   it 'does not register an offense for no space before semicolons' do
-    inspect_source(cop, 'x = 1; y = 2')
-    expect(cop.messages).to be_empty
+    expect_no_offenses('x = 1; y = 2')
   end
 
   it 'auto-corrects space before semicolon' do
@@ -45,8 +44,7 @@ describe RuboCop::Cop::Layout::SpaceBeforeSemicolon do
       it_behaves_like 'common behavior'
 
       it 'accepts a space between an opening brace and a semicolon' do
-        inspect_source(cop, 'test { ; }')
-        expect(cop.messages).to be_empty
+        expect_no_offenses('test { ; }')
       end
     end
 

--- a/spec/rubocop/cop/layout/space_inside_array_percent_literal_spec.rb
+++ b/spec/rubocop/cop/layout/space_inside_array_percent_literal_spec.rb
@@ -83,7 +83,6 @@ describe RuboCop::Cop::Layout::SpaceInsideArrayPercentLiteral do
   end
 
   it 'accepts non array percent literals' do
-    inspect_source(cop, '%q( a  b c )')
-    expect(cop.messages).to be_empty
+    expect_no_offenses('%q( a  b c )')
   end
 end

--- a/spec/rubocop/cop/layout/space_inside_block_braces_spec.rb
+++ b/spec/rubocop/cop/layout/space_inside_block_braces_spec.rb
@@ -31,11 +31,10 @@ describe RuboCop::Cop::Layout::SpaceInsideBlockBraces, :config do
     end
 
     it 'accepts empty braces with comment and line break inside' do
-      inspect_source(cop, <<-END.strip_margin('|'))
-        |  each { # Comment
-        |  }
-      END
-      expect(cop.offenses).to be_empty
+      expect_no_offenses(<<-RUBY.strip_indent)
+          each { # Comment
+          }
+      RUBY
     end
 
     it 'registers an offense for empty braces with line break inside' do

--- a/spec/rubocop/cop/layout/space_inside_brackets_spec.rb
+++ b/spec/rubocop/cop/layout/space_inside_brackets_spec.rb
@@ -31,42 +31,37 @@ describe RuboCop::Cop::Layout::SpaceInsideBrackets do
   end
 
   it 'accepts space inside strings within square brackets' do
-    inspect_source(cop, <<-END.strip_indent)
+    expect_no_offenses(<<-RUBY.strip_indent)
       ['Encoding:',
        '  Enabled: false']
-    END
-    expect(cop.messages).to be_empty
+    RUBY
   end
 
   it 'accepts space inside square brackets if on its own row' do
-    inspect_source(cop, <<-END.strip_indent)
+    expect_no_offenses(<<-RUBY.strip_indent)
       a = [
            1, 2
           ]
-    END
-    expect(cop.messages).to be_empty
+    RUBY
   end
 
   it 'accepts space inside square brackets if with comment' do
-    inspect_source(cop, <<-END.strip_indent)
+    expect_no_offenses(<<-RUBY.strip_indent)
       a = [ # Comment
            1, 2
           ]
-    END
-    expect(cop.messages).to be_empty
+    RUBY
   end
 
   it 'accepts square brackets as method name' do
-    inspect_source(cop, <<-END.strip_indent)
+    expect_no_offenses(<<-RUBY.strip_indent)
       def Vector.[](*array)
       end
-    END
-    expect(cop.messages).to be_empty
+    RUBY
   end
 
   it 'accepts square brackets called with method call syntax' do
-    inspect_source(cop, 'subject.[](0)')
-    expect(cop.messages).to be_empty
+    expect_no_offenses('subject.[](0)')
   end
 
   it 'only reports a single space once' do

--- a/spec/rubocop/cop/layout/space_inside_hash_literal_braces_spec.rb
+++ b/spec/rubocop/cop/layout/space_inside_hash_literal_braces_spec.rb
@@ -8,8 +8,7 @@ describe RuboCop::Cop::Layout::SpaceInsideHashLiteralBraces, :config do
     let(:cop_config) { { 'EnforcedStyleForEmptyBraces' => 'no_space' } }
 
     it 'accepts empty braces with no space inside' do
-      inspect_source(cop, 'h = {}')
-      expect(cop.messages).to be_empty
+      expect_no_offenses('h = {}')
     end
 
     it 'registers an offense for empty braces with space inside' do
@@ -29,8 +28,7 @@ describe RuboCop::Cop::Layout::SpaceInsideHashLiteralBraces, :config do
     let(:cop_config) { { 'EnforcedStyleForEmptyBraces' => 'space' } }
 
     it 'accepts empty braces with space inside' do
-      inspect_source(cop, 'h = { }')
-      expect(cop.messages).to be_empty
+      expect_no_offenses('h = { }')
     end
 
     it 'registers an offense for empty braces with no space inside' do

--- a/spec/rubocop/cop/layout/space_inside_parens_spec.rb
+++ b/spec/rubocop/cop/layout/space_inside_parens_spec.rb
@@ -13,32 +13,28 @@ describe RuboCop::Cop::Layout::SpaceInsideParens do
   end
 
   it 'accepts parentheses in block parameter list' do
-    inspect_source(cop, <<-END.strip_indent)
+    expect_no_offenses(<<-RUBY.strip_indent)
       list.inject(Tms.new) { |sum, (label, item)|
       }
-    END
-    expect(cop.messages).to be_empty
+    RUBY
   end
 
   it 'accepts parentheses with no spaces' do
-    inspect_source(cop, 'split("\n")')
-    expect(cop.messages).to be_empty
+    expect_no_offenses('split("\\n")')
   end
 
   it 'accepts parentheses with line break' do
-    inspect_source(cop, <<-END.strip_indent)
+    expect_no_offenses(<<-RUBY.strip_indent)
       f(
         1)
-    END
-    expect(cop.messages).to be_empty
+    RUBY
   end
 
   it 'accepts parentheses with comment and line break' do
-    inspect_source(cop, <<-END.strip_indent)
+    expect_no_offenses(<<-RUBY.strip_indent)
       f( # Comment
         1)
-    END
-    expect(cop.messages).to be_empty
+    RUBY
   end
 
   it 'auto-corrects unwanted space' do

--- a/spec/rubocop/cop/layout/space_inside_percent_literal_delimiters_spec.rb
+++ b/spec/rubocop/cop/layout/space_inside_percent_literal_delimiters_spec.rb
@@ -102,8 +102,6 @@ describe RuboCop::Cop::Layout::SpaceInsidePercentLiteralDelimiters do
   end
 
   it 'accepts execute-string literals' do
-    inspect_source(cop, '` curl `')
-
-    expect(cop.messages).to be_empty
+    expect_no_offenses('` curl `')
   end
 end

--- a/spec/rubocop/cop/layout/space_inside_string_interpolation_spec.rb
+++ b/spec/rubocop/cop/layout/space_inside_string_interpolation_spec.rb
@@ -55,8 +55,10 @@ describe RuboCop::Cop::Layout::SpaceInsideStringInterpolation, :config do
       end
 
       it 'does not register an offense for excess literal spacing' do
-        inspect_source(cop, source)
-        expect(cop.messages).to be_empty
+        expect_no_offenses(<<-'RUBY'.strip_indent)
+          "Variable is    #{var}      "
+          "  Variable is  #{var}"
+        RUBY
       end
 
       it 'does not correct valid string interpolations' do
@@ -66,8 +68,7 @@ describe RuboCop::Cop::Layout::SpaceInsideStringInterpolation, :config do
     end
 
     it 'accepts empty interpolation' do
-      inspect_source(cop, '"#{}"')
-      expect(cop.messages).to be_empty
+      expect_no_offenses("\"\#{}\"")
     end
   end
 
@@ -98,8 +99,10 @@ describe RuboCop::Cop::Layout::SpaceInsideStringInterpolation, :config do
       end
 
       it 'does not register an offense for excess literal spacing' do
-        inspect_source(cop, source)
-        expect(cop.messages).to be_empty
+        expect_no_offenses(<<-'RUBY'.strip_indent)
+          "Variable is    #{ var }      "
+          "  Variable is  #{ var }"
+        RUBY
       end
 
       it 'does not correct valid string interpolations' do
@@ -109,8 +112,7 @@ describe RuboCop::Cop::Layout::SpaceInsideStringInterpolation, :config do
     end
 
     it 'accepts empty interpolation' do
-      inspect_source(cop, '"#{}"')
-      expect(cop.messages).to be_empty
+      expect_no_offenses("\"\#{}\"")
     end
   end
 end

--- a/spec/rubocop/cop/lint/block_alignment_spec.rb
+++ b/spec/rubocop/cop/lint/block_alignment_spec.rb
@@ -51,11 +51,10 @@ describe RuboCop::Cop::Lint::BlockAlignment, :config do
   end
 
   it 'accepts a block end that does not begin its line' do
-    inspect_source(cop, <<-END.strip_margin('|'))
-      |  scope :bar, lambda { joins(:baz)
-      |                       .distinct }
-    END
-    expect(cop.offenses).to be_empty
+    expect_no_offenses(<<-RUBY.strip_indent)
+        scope :bar, lambda { joins(:baz)
+                             .distinct }
+    RUBY
   end
 
   context 'when the block is a logical operand' do

--- a/spec/rubocop/cop/lint/deprecated_class_methods_spec.rb
+++ b/spec/rubocop/cop/lint/deprecated_class_methods_spec.rb
@@ -18,8 +18,7 @@ describe RuboCop::Cop::Lint::DeprecatedClassMethods do
   end
 
   it 'does not register an offense for File.exist?' do
-    inspect_source(cop, 'File.exist?(o)')
-    expect(cop.messages).to be_empty
+    expect_no_offenses('File.exist?(o)')
   end
 
   it 'registers an offense for Dir.exists?' do

--- a/spec/rubocop/cop/lint/duplicate_case_condition_spec.rb
+++ b/spec/rubocop/cop/lint/duplicate_case_condition_spec.rb
@@ -72,29 +72,27 @@ describe RuboCop::Cop::Lint::DuplicateCaseCondition do
   end
 
   it 'accepts trivial case expressions' do
-    inspect_source(cop, <<-END.strip_indent)
+    expect_no_offenses(<<-RUBY.strip_indent)
       case x
       when false
         first_method
       end
-    END
-    expect(cop.messages).to be_empty
+    RUBY
   end
 
   it 'accepts non-redundant case expressions' do
-    inspect_source(cop, <<-END.strip_indent)
+    expect_no_offenses(<<-RUBY.strip_indent)
       case x
       when false
         first_method
       when true
         second_method
       end
-    END
-    expect(cop.messages).to be_empty
+    RUBY
   end
 
   it 'accepts non-redundant case expressions with an else expression' do
-    inspect_source(cop, <<-END.strip_indent)
+    expect_no_offenses(<<-RUBY.strip_indent)
       case x
       when false
         method_name
@@ -103,19 +101,17 @@ describe RuboCop::Cop::Lint::DuplicateCaseCondition do
       else
         third_method
       end
-    END
-    expect(cop.messages).to be_empty
+    RUBY
   end
 
   it 'accepts similar but not equivalent && expressions' do
-    inspect_source(cop, <<-END.strip_indent)
+    expect_no_offenses(<<-RUBY.strip_indent)
       case x
       when something && another && other
         first_method
       when something && another
         second_method
       end
-    END
-    expect(cop.messages).to be_empty
+    RUBY
   end
 end

--- a/spec/rubocop/cop/lint/duplicated_key_spec.rb
+++ b/spec/rubocop/cop/lint/duplicated_key_spec.rb
@@ -43,13 +43,10 @@ describe RuboCop::Cop::Lint::DuplicatedKey do
   end
 
   context 'When there is no duplicated key in the hash' do
-    let(:source) do
-      "hash = { ['one', 'two'] => ['hello, bye'], ['two'] => ['yes, no'] }"
-    end
-
     it 'does not register an offense' do
-      inspect_source(cop, source)
-      expect(cop.offenses).to be_empty
+      expect_no_offenses(<<-RUBY.strip_indent)
+        hash = { ['one', 'two'] => ['hello, bye'], ['two'] => ['yes, no'] }
+      RUBY
     end
   end
 

--- a/spec/rubocop/cop/lint/format_parameter_mismatch_spec.rb
+++ b/spec/rubocop/cop/lint/format_parameter_mismatch_spec.rb
@@ -120,30 +120,12 @@ describe RuboCop::Cop::Lint::FormatParameterMismatch do
   end
 
   it 'does not register an offense when single argument is not an array' do
-    inspect_source(cop, 'puts "%s" % 42')
-    expect(cop.offenses).to be_empty
-
-    inspect_source(cop, 'puts "%s" % "1"')
-    expect(cop.offenses).to be_empty
-
-    inspect_source(cop, 'puts "%s" % 1.2')
-    expect(cop.offenses).to be_empty
-
-    inspect_source(cop, 'puts "%s" % :a')
-    expect(cop.offenses).to be_empty
-
-    inspect_source(cop, 'puts "%s" % CONST')
-    expect(cop.offenses).to be_empty
+    expect_no_offenses('puts "%s" % CONST')
   end
 
   context 'when splat argument is present' do
     it 'does not register an offense when args count is less than expected' do
-      inspect_source(cop, '"%s, %s, %s" % [1, *arr]')
-      expect(cop.offenses).to be_empty
-      inspect_source(cop, 'format("%s, %s, %s", 1, *arr)')
-      expect(cop.offenses).to be_empty
-      inspect_source(cop, 'sprintf("%s, %s, %s", 1, *arr)')
-      expect(cop.offenses).to be_empty
+      expect_no_offenses('sprintf("%s, %s, %s", 1, *arr)')
     end
 
     it 'does register an offense when args count is more than expected' do
@@ -208,11 +190,7 @@ describe RuboCop::Cop::Lint::FormatParameterMismatch do
   end
 
   it 'does not register an offense argument is the result of a message send' do
-    inspect_source(cop, '"%s" % "a b c".gsub(" ", "_")')
-    expect(cop.offenses).to be_empty
-
-    inspect_source(cop, 'format("%s", "a b c".gsub(" ", "_"))')
-    expect(cop.offenses).to be_empty
+    expect_no_offenses('format("%s", "a b c".gsub(" ", "_"))')
   end
 
   it 'does not register an offense when using named parameters' do

--- a/spec/rubocop/cop/lint/next_without_accumulator_spec.rb
+++ b/spec/rubocop/cop/lint/next_without_accumulator_spec.rb
@@ -58,13 +58,21 @@ describe RuboCop::Cop::Lint::NextWithoutAccumulator do
 
   context 'given an unrelated block' do
     it 'accepts a bare next' do
-      inspect_source(cop, code_without_accumulator(:foo))
-      expect(cop.offenses).to be_empty
+      expect_no_offenses(<<-RUBY.strip_indent)
+              (1..4).foo(0) do |acc, i|
+                next if i.odd?
+                acc + i
+              end
+      RUBY
     end
 
     it 'accepts next with a value' do
-      inspect_source(cop, code_with_accumulator(:foo))
-      expect(cop.offenses).to be_empty
+      expect_no_offenses(<<-RUBY.strip_indent)
+              (1..4).foo(0) do |acc, i|
+                next acc if i.odd?
+                acc + i
+              end
+      RUBY
     end
   end
 end

--- a/spec/rubocop/cop/lint/shadowed_exception_spec.rb
+++ b/spec/rubocop/cop/lint/shadowed_exception_spec.rb
@@ -533,8 +533,16 @@ describe RuboCop::Cop::Lint::ShadowedException do
       end
 
       it 'highlights range ending at rescue keyword' do
-        inspect_source(cop, source)
-        expect(cop.offenses).to be_empty
+        expect_no_offenses(<<-RUBY.strip_indent)
+          begin
+          rescue A, B
+            do_something
+          rescue C
+            do_something
+          rescue
+            do_something
+          end
+        RUBY
       end
     end
   end

--- a/spec/rubocop/cop/lint/useless_access_modifier_spec.rb
+++ b/spec/rubocop/cop/lint/useless_access_modifier_spec.rb
@@ -52,8 +52,8 @@ describe RuboCop::Cop::Lint::UselessAccessModifier do
   end
 
   context 'when an access modifier is followed by attr_*' do
-    let(:source) do
-      <<-END.strip_indent
+    it 'does not register an offense' do
+      expect_no_offenses(<<-RUBY.strip_indent)
         class SomeClass
           protected
           attr_accessor :some_property
@@ -64,12 +64,7 @@ describe RuboCop::Cop::Lint::UselessAccessModifier do
           protected
           attr_writer :just_for_good_measure
         end
-      END
-    end
-
-    it 'does not register an offense' do
-      inspect_source(cop, source)
-      expect(cop.offenses).to be_empty
+      RUBY
     end
   end
 
@@ -122,20 +117,15 @@ describe RuboCop::Cop::Lint::UselessAccessModifier do
   end
 
   context 'when passing method as symbol' do
-    let(:source) do
-      <<-END.strip_indent
+    it 'does not register an offense' do
+      expect_no_offenses(<<-RUBY.strip_indent)
         class SomeClass
           def some_method
             puts 10
           end
           private :some_method
         end
-      END
-    end
-
-    it 'does not register an offense' do
-      inspect_source(cop, source)
-      expect(cop.offenses).to be_empty
+      RUBY
     end
   end
 

--- a/spec/rubocop/cop/lint/useless_assignment_spec.rb
+++ b/spec/rubocop/cop/lint/useless_assignment_spec.rb
@@ -1849,8 +1849,8 @@ describe RuboCop::Cop::Lint::UselessAssignment do
 
   # regression test, from problem in Locatable
   context 'when a variable is assigned in 2 identical if branches' do
-    let(:source) do
-      <<-END.strip_indent
+    it "doesn't think 1 of the 2 assignments is useless" do
+      expect_no_offenses(<<-RUBY.strip_indent)
         def foo
           if bar
             foo = 1
@@ -1859,12 +1859,7 @@ describe RuboCop::Cop::Lint::UselessAssignment do
           end
           foo.bar.baz
         end
-      END
-    end
-
-    it "doesn't think 1 of the 2 assignments is useless" do
-      inspect_source(cop, source)
-      expect(cop.offenses).to be_empty
+      RUBY
     end
   end
 

--- a/spec/rubocop/cop/performance/caller_spec.rb
+++ b/spec/rubocop/cop/performance/caller_spec.rb
@@ -4,14 +4,11 @@ describe RuboCop::Cop::Performance::Caller do
   subject(:cop) { described_class.new }
 
   it "doesn't register an offense when caller is called" do
-    inspect_source(cop, 'caller')
-    expect(cop.messages).to be_empty
+    expect_no_offenses('caller')
   end
 
   it "doesn't register an offense when caller with arguments is called" do
-    inspect_source(cop, 'caller(1..1).first')
-    inspect_source(cop, 'caller(1, 1).first')
-    expect(cop.messages).to be_empty
+    expect_no_offenses('caller(1, 1).first')
   end
 
   it 'registers an offense when :first is called on caller' do

--- a/spec/rubocop/cop/performance/case_when_splat_spec.rb
+++ b/spec/rubocop/cop/performance/case_when_splat_spec.rb
@@ -4,20 +4,18 @@ describe RuboCop::Cop::Performance::CaseWhenSplat do
   subject(:cop) { described_class.new }
 
   it 'allows case when without splat' do
-    inspect_source(cop, <<-END.strip_indent)
+    expect_no_offenses(<<-RUBY.strip_indent)
       case foo
       when 1
         bar
       else
         baz
       end
-    END
-
-    expect(cop.messages).to be_empty
+    RUBY
   end
 
   it 'allows splat on a variable in the last when condition' do
-    inspect_source(cop, <<-END.strip_indent)
+    expect_no_offenses(<<-RUBY.strip_indent)
       case foo
       when 4
         foobar
@@ -26,13 +24,11 @@ describe RuboCop::Cop::Performance::CaseWhenSplat do
       else
         baz
       end
-    END
-
-    expect(cop.messages).to be_empty
+    RUBY
   end
 
   it 'allows multiple splat conditions on variables at the end' do
-    inspect_source(cop, <<-END.strip_indent)
+    expect_no_offenses(<<-RUBY.strip_indent)
       case foo
       when 4
         foobar
@@ -43,9 +39,7 @@ describe RuboCop::Cop::Performance::CaseWhenSplat do
       else
         baz
       end
-    END
-
-    expect(cop.messages).to be_empty
+    RUBY
   end
 
   it 'registers an offense for case when with a splat in the first condition' do

--- a/spec/rubocop/cop/performance/count_spec.rb
+++ b/spec/rubocop/cop/performance/count_spec.rb
@@ -137,9 +137,7 @@ describe RuboCop::Cop::Performance::Count do
 
   context 'ActiveRecord select' do
     it 'allows usage of select with a string' do
-      inspect_source(cop, "Model.select('field AS field_one').count")
-
-      expect(cop.messages).to be_empty
+      expect_no_offenses("Model.select('field AS field_one').count")
     end
 
     it 'allows usage of select with multiple strings' do
@@ -150,44 +148,32 @@ describe RuboCop::Cop::Performance::Count do
     end
 
     it 'allows usage of select with a symbol' do
-      inspect_source(cop, 'Model.select(:field).count')
-
-      expect(cop.messages).to be_empty
+      expect_no_offenses('Model.select(:field).count')
     end
 
     it 'allows usage of select with multiple symbols' do
-      inspect_source(cop, 'Model.select(:field, :other_field).count')
-
-      expect(cop.messages).to be_empty
+      expect_no_offenses('Model.select(:field, :other_field).count')
     end
   end
 
   it 'allows usage of another method with size' do
-    inspect_source(cop, '[1, 2, 3].map { |e| e + 1 }.size')
-
-    expect(cop.messages).to be_empty
+    expect_no_offenses('[1, 2, 3].map { |e| e + 1 }.size')
   end
 
   it 'allows usage of size on an array' do
-    inspect_source(cop, '[1, 2, 3].size')
-
-    expect(cop.messages).to be_empty
+    expect_no_offenses('[1, 2, 3].size')
   end
 
   it 'allows usage of count on an array' do
-    inspect_source(cop, '[1, 2, 3].count')
-
-    expect(cop.messages).to be_empty
+    expect_no_offenses('[1, 2, 3].count')
   end
 
   it 'allows usage of count on an interstitial method called on select' do
-    inspect_source(cop, <<-END.strip_indent)
+    expect_no_offenses(<<-RUBY.strip_indent)
       Data = Struct.new(:value)
       array = [Data.new(2), Data.new(3), Data.new(2)]
       puts array.select(&:value).uniq.count
-    END
-
-    expect(cop.messages).to be_empty
+    RUBY
   end
 
   it 'allows usage of count on an interstitial method with blocks ' \
@@ -202,18 +188,14 @@ describe RuboCop::Cop::Performance::Count do
   end
 
   it 'allows usage of size called on an assigned variable' do
-    inspect_source(cop, <<-END.strip_indent)
+    expect_no_offenses(<<-RUBY.strip_indent)
       nodes = [1]
       nodes.size
-    END
-
-    expect(cop.messages).to be_empty
+    RUBY
   end
 
   it 'allows usage of methods called on size' do
-    inspect_source(cop, 'shorter.size.to_f')
-
-    expect(cop.messages).to be_empty
+    expect_no_offenses('shorter.size.to_f')
   end
 
   context 'properly parses non related code' do

--- a/spec/rubocop/cop/performance/detect_spec.rb
+++ b/spec/rubocop/cop/performance/detect_spec.rb
@@ -114,9 +114,7 @@ describe RuboCop::Cop::Performance::Detect do
   end
 
   it 'does not register an offense when detect is used' do
-    inspect_source(cop, '[1, 2, 3].detect { |i| i % 2 == 0 }')
-
-    expect(cop.messages).to be_empty
+    expect_no_offenses('[1, 2, 3].detect { |i| i % 2 == 0 }')
   end
 
   context 'autocorrect' do

--- a/spec/rubocop/cop/performance/double_start_end_with_spec.rb
+++ b/spec/rubocop/cop/performance/double_start_end_with_spec.rb
@@ -37,21 +37,15 @@ describe RuboCop::Cop::Performance::DoubleStartEndWith do
         end
 
         context 'one of the parameters of the second call is not pure' do
-          let(:source) { 'x.start_with?(a, "b") || x.start_with?(C, d)' }
-
           it "doesn't register an offense" do
-            inspect_source(cop, source)
-            expect(cop.offenses).to be_empty
+            expect_no_offenses('x.start_with?(a, "b") || x.start_with?(C, d)')
           end
         end
       end
 
       context 'with different receivers' do
-        let(:source) { 'x.start_with?("a") || y.start_with?("b")' }
-
         it "doesn't register an offense" do
-          inspect_source(cop, source)
-          expect(cop.offenses).to be_empty
+          expect_no_offenses('x.start_with?("a") || y.start_with?("b")')
         end
       end
     end
@@ -81,49 +75,34 @@ describe RuboCop::Cop::Performance::DoubleStartEndWith do
         end
 
         context 'one of the parameters of the second call is not pure' do
-          let(:source) { 'x.end_with?(a, "b") || x.end_with?(C, d)' }
-
           it "doesn't register an offense" do
-            inspect_source(cop, source)
-            expect(cop.offenses).to be_empty
+            expect_no_offenses('x.end_with?(a, "b") || x.end_with?(C, d)')
           end
         end
       end
 
       context 'with different receivers' do
-        let(:source) { 'x.end_with?("a") || y.end_with?("b")' }
-
         it "doesn't register an offense" do
-          inspect_source(cop, source)
-          expect(cop.offenses).to be_empty
+          expect_no_offenses('x.end_with?("a") || y.end_with?("b")')
         end
       end
     end
 
     context 'a .start_with? and .end_with? call with the same receiver' do
-      let(:source) { 'x.start_with?("a") || x.end_with?("b")' }
-
       it "doesn't register an offense" do
-        inspect_source(cop, source)
-        expect(cop.offenses).to be_empty
+        expect_no_offenses('x.start_with?("a") || x.end_with?("b")')
       end
     end
 
     context 'two #starts_with? calls' do
-      let(:source) { 'x.starts_with?(a, b) || x.starts_with?("c", D)' }
-
       it "doesn't register an offense" do
-        inspect_source(cop, source)
-        expect(cop.offenses).to be_empty
+        expect_no_offenses('x.starts_with?(a, b) || x.starts_with?("c", D)')
       end
     end
 
     context 'two #ends_with? calls' do
-      let(:source) { 'x.ends_with?(a, b) || x.ends_with?("c", D)' }
-
       it "doesn't register an offense" do
-        inspect_source(cop, source)
-        expect(cop.offenses).to be_empty
+        expect_no_offenses('x.ends_with?(a, b) || x.ends_with?("c", D)')
       end
     end
   end
@@ -210,21 +189,17 @@ describe RuboCop::Cop::Performance::DoubleStartEndWith do
         end
 
         context 'one of the parameters of the second call is not pure' do
-          let(:source) { 'x.starts_with?(a, "b") || x.starts_with?(C, d)' }
-
           it "doesn't register an offense" do
-            inspect_source(cop, source)
-            expect(cop.offenses).to be_empty
+            expect_no_offenses(<<-RUBY.strip_indent)
+              x.starts_with?(a, "b") || x.starts_with?(C, d)
+            RUBY
           end
         end
       end
 
       context 'with different receivers' do
-        let(:source) { 'x.starts_with?("a") || y.starts_with?("b")' }
-
         it "doesn't register an offense" do
-          inspect_source(cop, source)
-          expect(cop.offenses).to be_empty
+          expect_no_offenses('x.starts_with?("a") || y.starts_with?("b")')
         end
       end
     end
@@ -254,21 +229,15 @@ describe RuboCop::Cop::Performance::DoubleStartEndWith do
         end
 
         context 'one of the parameters of the second call is not pure' do
-          let(:source) { 'x.ends_with?(a, "b") || x.ends_with?(C, d)' }
-
           it "doesn't register an offense" do
-            inspect_source(cop, source)
-            expect(cop.offenses).to be_empty
+            expect_no_offenses('x.ends_with?(a, "b") || x.ends_with?(C, d)')
           end
         end
       end
 
       context 'with different receivers' do
-        let(:source) { 'x.ends_with?("a") || y.ends_with?("b")' }
-
         it "doesn't register an offense" do
-          inspect_source(cop, source)
-          expect(cop.offenses).to be_empty
+          expect_no_offenses('x.ends_with?("a") || y.ends_with?("b")')
         end
       end
     end

--- a/spec/rubocop/cop/performance/hash_each_methods_spec.rb
+++ b/spec/rubocop/cop/performance/hash_each_methods_spec.rb
@@ -32,23 +32,19 @@ describe RuboCop::Cop::Performance::HashEachMethods do
   end
 
   it 'does not register an offense for Hash#each_key' do
-    inspect_source(cop, 'hash.each_key { |k| p k }')
-    expect(cop.messages).to be_empty
+    expect_no_offenses('hash.each_key { |k| p k }')
   end
 
   it 'does not register an offense for Hash#each_value' do
-    inspect_source(cop, 'hash.each_value { |v| p v }')
-    expect(cop.messages).to be_empty
+    expect_no_offenses('hash.each_value { |v| p v }')
   end
 
   it 'does not register an offense for Hash#each if both key/value are used' do
-    inspect_source(cop, 'hash.each { |k, v| p "#{k}_#{v}" }')
-    expect(cop.messages).to be_empty
+    expect_no_offenses("hash.each { |k, v| p \"\#{k}_\#{v}\" }")
   end
 
   it 'does not register an offense for Hash#each if block takes only one arg' do
-    inspect_source(cop, 'hash.each { |kv| p kv }')
-    expect(cop.messages).to be_empty
+    expect_no_offenses('hash.each { |kv| p kv }')
   end
 
   it 'auto-corrects Hash#keys.each with Hash#each_key' do

--- a/spec/rubocop/cop/performance/redundant_block_call_spec.rb
+++ b/spec/rubocop/cop/performance/redundant_block_call_spec.rb
@@ -71,68 +71,61 @@ describe RuboCop::Cop::Performance::RedundantBlockCall do
   end
 
   it 'accepts a block that is not `call`ed' do
-    inspect_source(cop, <<-END.strip_indent)
+    expect_no_offenses(<<-RUBY.strip_indent)
       def method(&block)
        something.call
       end
-    END
-    expect(cop.messages).to be_empty
+    RUBY
   end
 
   it 'accepts an empty method body' do
-    inspect_source(cop, <<-END.strip_indent)
+    expect_no_offenses(<<-RUBY.strip_indent)
       def method(&block)
       end
-    END
-    expect(cop.messages).to be_empty
+    RUBY
   end
 
   it 'accepts another block being passed as the only arg' do
-    inspect_source(cop, <<-END.strip_indent)
+    expect_no_offenses(<<-RUBY.strip_indent)
       def method(&block)
         block.call(&some_proc)
       end
-    END
-    expect(cop.messages).to be_empty
+    RUBY
   end
 
   it 'accepts another block being passed along with other args' do
-    inspect_source(cop, <<-END.strip_indent)
+    expect_no_offenses(<<-RUBY.strip_indent)
       def method(&block)
         block.call(1, &some_proc)
       end
-    END
-    expect(cop.messages).to be_empty
+    RUBY
   end
 
   it 'accepts another block arg in at least one occurance of block.call' do
-    inspect_source(cop, <<-END.strip_indent)
+    expect_no_offenses(<<-RUBY.strip_indent)
       def method(&block)
         block.call(1, &some_proc)
         block.call(2)
       end
-    END
-    expect(cop.messages).to be_empty
+    RUBY
   end
 
   it 'accepts an optional block that is defaulted' do
-    inspect_source(cop, <<-END.strip_indent)
+    expect_no_offenses(<<-RUBY.strip_indent)
       def method(&block)
         block ||= ->(i) { puts i }
         block.call(1)
       end
-    END
-    expect(cop.messages).to be_empty
+    RUBY
   end
 
   it 'accepts an optional block that is overridden' do
-    inspect_source(cop, <<-END.strip_indent)
+    expect_no_offenses(<<-RUBY.strip_indent)
       def method(&block)
         block = ->(i) { puts i }
         block.call(1)
       end
-    END
-    expect(cop.messages).to be_empty
+    RUBY
   end
 
   it 'formats the error message for func.call(1) correctly' do

--- a/spec/rubocop/cop/performance/redundant_match_spec.rb
+++ b/spec/rubocop/cop/performance/redundant_match_spec.rb
@@ -108,8 +108,7 @@ describe RuboCop::Cop::Performance::RedundantMatch do
   end
 
   it 'does not register an error when there is no receiver to the match call' do
-    inspect_source(cop, 'match("bar")')
-    expect(cop.messages).to be_empty
+    expect_no_offenses('match("bar")')
   end
 
   it 'formats error message correctly for something if str.match(/regex/)' do

--- a/spec/rubocop/cop/performance/reverse_each_spec.rb
+++ b/spec/rubocop/cop/performance/reverse_each_spec.rb
@@ -11,15 +11,11 @@ describe RuboCop::Cop::Performance::ReverseEach do
   end
 
   it 'does not register an offense when reverse is used without each' do
-    inspect_source(cop, '[1, 2, 3].reverse')
-
-    expect(cop.messages).to be_empty
+    expect_no_offenses('[1, 2, 3].reverse')
   end
 
   it 'does not register an offense when each is used without reverse' do
-    inspect_source(cop, '[1, 2, 3].each { |e| puts e }')
-
-    expect(cop.messages).to be_empty
+    expect_no_offenses('[1, 2, 3].each { |e| puts e }')
   end
 
   context 'autocorrect' do

--- a/spec/rubocop/cop/performance/size_spec.rb
+++ b/spec/rubocop/cop/performance/size_spec.rb
@@ -40,21 +40,15 @@ describe RuboCop::Cop::Performance::Size do
     end
 
     it 'does not register an offense when calling size' do
-      inspect_source(cop, '[1, 2, 3].size')
-
-      expect(cop.messages).to be_empty
+      expect_no_offenses('[1, 2, 3].size')
     end
 
     it 'does not register an offense when calling another method' do
-      inspect_source(cop, '[1, 2, 3].each')
-
-      expect(cop.messages).to be_empty
+      expect_no_offenses('[1, 2, 3].each')
     end
 
     it 'does not register an offense when calling count with a block' do
-      inspect_source(cop, '[1, 2, 3].count { |e| e > 3 }')
-
-      expect(cop.messages).to be_empty
+      expect_no_offenses('[1, 2, 3].count { |e| e > 3 }')
     end
 
     it 'does not register an offense when calling count with a to_proc block' do
@@ -107,21 +101,15 @@ describe RuboCop::Cop::Performance::Size do
     end
 
     it 'does not register an offense when calling size' do
-      inspect_source(cop, '{a: 1, b: 2, c: 3}.size')
-
-      expect(cop.messages).to be_empty
+      expect_no_offenses('{a: 1, b: 2, c: 3}.size')
     end
 
     it 'does not register an offense when calling another method' do
-      inspect_source(cop, '{a: 1, b: 2, c: 3}.each')
-
-      expect(cop.messages).to be_empty
+      expect_no_offenses('{a: 1, b: 2, c: 3}.each')
     end
 
     it 'does not register an offense when calling count with a block' do
-      inspect_source(cop, '{a: 1, b: 2, c: 3}.count { |e| e > 3 }')
-
-      expect(cop.messages).to be_empty
+      expect_no_offenses('{a: 1, b: 2, c: 3}.count { |e| e > 3 }')
     end
 
     it 'does not register an offense when calling count with a to_proc block' do

--- a/spec/rubocop/cop/performance/string_replacement_spec.rb
+++ b/spec/rubocop/cop/performance/string_replacement_spec.rb
@@ -4,9 +4,7 @@ describe RuboCop::Cop::Performance::StringReplacement do
   subject(:cop) { described_class.new }
 
   it 'accepts methods other than gsub' do
-    inspect_source(cop, "'abc'.insert(2, 'a')")
-
-    expect(cop.messages).to be_empty
+    expect_no_offenses("'abc'.insert(2, 'a')")
   end
 
   shared_examples 'accepts' do |method|
@@ -199,102 +197,72 @@ describe RuboCop::Cop::Performance::StringReplacement do
 
   describe 'non deterministic regex' do
     it 'allows regex containing a +' do
-      inspect_source(cop, %('abc'.gsub(/a+/, 'def')))
-
-      expect(cop.messages).to be_empty
+      expect_no_offenses("'abc'.gsub(/a+/, 'def')")
     end
 
     it 'allows regex containing a *' do
-      inspect_source(cop, %('abc'.gsub(/a*/, 'def')))
-
-      expect(cop.messages).to be_empty
+      expect_no_offenses("'abc'.gsub(/a*/, 'def')")
     end
 
     it 'allows regex containing a ^' do
-      inspect_source(cop, %('abc'.gsub(/^/, '')))
-
-      expect(cop.messages).to be_empty
+      expect_no_offenses("'abc'.gsub(/^/, '')")
     end
 
     it 'allows regex containing a $' do
-      inspect_source(cop, %('abc'.gsub(/$/, '')))
-
-      expect(cop.messages).to be_empty
+      expect_no_offenses("'abc'.gsub(/$/, '')")
     end
 
     it 'allows regex containing a ?' do
-      inspect_source(cop, %('abc'.gsub(/a?/, 'def')))
-
-      expect(cop.messages).to be_empty
+      expect_no_offenses("'abc'.gsub(/a?/, 'def')")
     end
 
     it 'allows regex containing a .' do
-      inspect_source(cop, %('abc'.gsub(/./, 'a')))
-
-      expect(cop.messages).to be_empty
+      expect_no_offenses("'abc'.gsub(/./, 'a')")
     end
 
     it 'allows regex containing a |' do
-      inspect_source(cop, %('abc'.gsub(/a|b/, 'd')))
-
-      expect(cop.messages).to be_empty
+      expect_no_offenses("'abc'.gsub(/a|b/, 'd')")
     end
 
     it 'allows regex containing ()' do
-      inspect_source(cop, %('abc'.gsub(/(ab)/, 'd')))
-
-      expect(cop.messages).to be_empty
+      expect_no_offenses("'abc'.gsub(/(ab)/, 'd')")
     end
 
     it 'allows regex containing escaped ()' do
-      inspect_source(cop, %('(abc)'.gsub(/\(ab\)/, 'd')))
-
-      expect(cop.messages).to be_empty
+      expect_no_offenses("'(abc)'.gsub(/(ab)/, 'd')")
     end
 
     it 'allows regex containing {}' do
-      inspect_source(cop, %('abc'.gsub(/a{3,}/, 'd')))
-
-      expect(cop.messages).to be_empty
+      expect_no_offenses("'abc'.gsub(/a{3,}/, 'd')")
     end
 
     it 'allows regex containing []' do
-      inspect_source(cop, %('abc'.gsub(/[a-z]/, 'd')))
-
-      expect(cop.messages).to be_empty
+      expect_no_offenses("'abc'.gsub(/[a-z]/, 'd')")
     end
 
     it 'allows regex containing a backslash' do
-      inspect_source(cop, '"abc".gsub(/\s/, "d")')
-
-      expect(cop.messages).to be_empty
+      expect_no_offenses('"abc".gsub(/\\s/, "d")')
     end
 
     it 'allows regex literal containing interpolations' do
-      inspect_source(cop, <<-'END'.strip_indent)
+      expect_no_offenses(<<-'RUBY'.strip_indent)
         foo = 'a'
         "abc".gsub(/#{foo}/, "d")
-      END
-
-      expect(cop.messages).to be_empty
+      RUBY
     end
 
     it 'allows regex constructor containing a string with interpolations' do
-      inspect_source(cop, <<-'END'.strip_indent)
+      expect_no_offenses(<<-'RUBY'.strip_indent)
         foo = 'a'
         "abc".gsub(Regexp.new("#{foo}"), "d")
-      END
-
-      expect(cop.messages).to be_empty
+      RUBY
     end
 
     it 'allows regex constructor containing regex with interpolations' do
-      inspect_source(cop, <<-'END'.strip_indent)
+      expect_no_offenses(<<-'RUBY'.strip_indent)
         foo = 'a'
         "abc".gsub(Regexp.new(/#{foo}/), "d")
-      END
-
-      expect(cop.messages).to be_empty
+      RUBY
     end
   end
 

--- a/spec/rubocop/cop/rails/delegate_allow_blank_spec.rb
+++ b/spec/rubocop/cop/rails/delegate_allow_blank_spec.rb
@@ -11,15 +11,11 @@ describe RuboCop::Cop::Rails::DelegateAllowBlank do
   end
 
   it 'does not register an offense when using allow_nil' do
-    inspect_source(cop, 'delegate :foo, to: :bar, allow_nil: true')
-
-    expect(cop.messages).to be_empty
+    expect_no_offenses('delegate :foo, to: :bar, allow_nil: true')
   end
 
   it 'does not register an offense when no extra options given' do
-    inspect_source(cop, 'delegate :foo, to: :bar')
-
-    expect(cop.messages).to be_empty
+    expect_no_offenses('delegate :foo, to: :bar')
   end
 
   it 'autocorrects allow_blank to allow_nil' do

--- a/spec/rubocop/cop/rails/file_path_spec.rb
+++ b/spec/rubocop/cop/rails/file_path_spec.rb
@@ -4,11 +4,8 @@ describe RuboCop::Cop::Rails::FilePath do
   subject(:cop) { described_class.new }
 
   context 'when using Rails.root.join with some path strings' do
-    let(:source) { "Rails.root.join('app', 'models', 'user.rb')" }
-
     it 'does not registers an offense' do
-      inspect_source(cop, source)
-      expect(cop.offenses).to be_empty
+      expect_no_offenses("Rails.root.join('app', 'models', 'user.rb')")
     end
   end
 

--- a/spec/rubocop/cop/rails/find_by_spec.rb
+++ b/spec/rubocop/cop/rails/find_by_spec.rb
@@ -16,9 +16,7 @@ describe RuboCop::Cop::Rails::FindBy do
   it_behaves_like('registers_offense', 'take')
 
   it 'does not register an offense when using find_by' do
-    inspect_source(cop, 'User.find_by(id: x)')
-
-    expect(cop.messages).to be_empty
+    expect_no_offenses('User.find_by(id: x)')
   end
 
   it 'autocorrects where.take to find_by' do

--- a/spec/rubocop/cop/rails/find_each_spec.rb
+++ b/spec/rubocop/cop/rails/find_each_spec.rb
@@ -35,9 +35,7 @@ describe RuboCop::Cop::Rails::FindEach do
   it_behaves_like('register_offense', 'where.not(name: name)')
 
   it 'does not register an offense when using find_by' do
-    inspect_source(cop, 'User.all.find_each { |u| u.x }')
-
-    expect(cop.messages).to be_empty
+    expect_no_offenses('User.all.find_each { |u| u.x }')
   end
 
   it 'auto-corrects each to find_each' do

--- a/spec/rubocop/cop/rails/http_positional_arguments_spec.rb
+++ b/spec/rubocop/cop/rails/http_positional_arguments_spec.rb
@@ -29,13 +29,10 @@ describe RuboCop::Cop::Rails::HttpPositionalArguments do
     end
 
     describe 'when using process' do
-      let(:source) do
-        'process :new, method: :get, params: { user_id: @user.id }'
-      end
-
       it 'does not register an offense' do
-        inspect_source(cop, source)
-        expect(cop.messages).to be_empty
+        expect_no_offenses(<<-RUBY.strip_indent)
+          process :new, method: :get, params: { user_id: @user.id }
+        RUBY
       end
     end
 
@@ -277,13 +274,10 @@ describe RuboCop::Cop::Rails::HttpPositionalArguments do
     end
 
     describe 'when using process' do
-      let(:source) do
-        'process :new, method: :get, params: { user_id: @user.id }'
-      end
-
       it 'does not register an offense' do
-        inspect_source(cop, source)
-        expect(cop.messages).to be_empty
+        expect_no_offenses(<<-RUBY.strip_indent)
+          process :new, method: :get, params: { user_id: @user.id }
+        RUBY
       end
     end
 

--- a/spec/rubocop/cop/rails/save_bang_spec.rb
+++ b/spec/rubocop/cop/rails/save_bang_spec.rb
@@ -174,8 +174,6 @@ describe RuboCop::Cop::Rails::SaveBang do
   end
 
   it 'properly ignores lvasign without right hand side' do
-    inspect_source(cop, 'variable += 1')
-
-    expect(cop.messages).to be_empty
+    expect_no_offenses('variable += 1')
   end
 end

--- a/spec/rubocop/cop/security/eval_spec.rb
+++ b/spec/rubocop/cop/security/eval_spec.rb
@@ -48,13 +48,10 @@ describe RuboCop::Cop::Security::Eval do
   end
 
   it 'accepts eval with a multiline string' do
-    expect_no_offenses(<<-END.strip_indent)
-      eval "something
-      something2"
-    END
+    expect_no_offenses('eval "something\nsomething2"')
   end
 
-  it 'accepts eval with a string that is interpolated a literal' do
+  it 'accepts eval with a string that interpolates a literal' do
     expect_no_offenses('eval "something#{2}"')
   end
 
@@ -74,9 +71,7 @@ describe RuboCop::Cop::Security::Eval do
     end
 
     it 'accepts eval on a literal string' do
-      expect_no_offenses(<<-RUBY.strip_indent)
-        eval("puts 1", binding, "test.rb", 1)
-      RUBY
+      expect_no_offenses('eval("puts 1", binding, "test.rb", 1)')
     end
   end
 end

--- a/spec/rubocop/cop/style/array_join_spec.rb
+++ b/spec/rubocop/cop/style/array_join_spec.rb
@@ -36,12 +36,6 @@ describe RuboCop::Cop::Style::ArrayJoin do
   end
 
   it 'does not register an offense for ambiguous cases' do
-    inspect_source(cop,
-                   'test * ", "')
-    expect(cop.offenses).to be_empty
-
-    inspect_source(cop,
-                   '%w(one two three) * test')
-    expect(cop.offenses).to be_empty
+    expect_no_offenses('%w(one two three) * test')
   end
 end

--- a/spec/rubocop/cop/style/block_delimiters_spec.rb
+++ b/spec/rubocop/cop/style/block_delimiters_spec.rb
@@ -135,33 +135,27 @@ describe RuboCop::Cop::Style::BlockDelimiters, :config do
     end
 
     it 'accepts a single line block with {} if used in an if statement' do
-      inspect_source(cop, 'return if any? { |x| x }')
-      expect(cop.messages).to be_empty
+      expect_no_offenses('return if any? { |x| x }')
     end
 
     it 'accepts a single line block with {} if used in a logical or' do
-      inspect_source(cop, 'any? { |c| c } || foo')
-      expect(cop.messages).to be_empty
+      expect_no_offenses('any? { |c| c } || foo')
     end
 
     it 'accepts a single line block with {} if used in a logical and' do
-      inspect_source(cop, 'any? { |c| c } && foo')
-      expect(cop.messages).to be_empty
+      expect_no_offenses('any? { |c| c } && foo')
     end
 
     it 'accepts a single line block with {} if used in an array' do
-      inspect_source(cop, '[detect { true }, other]')
-      expect(cop.messages).to be_empty
+      expect_no_offenses('[detect { true }, other]')
     end
 
     it 'accepts a single line block with {} if used in an irange' do
-      inspect_source(cop, 'detect { true }..other')
-      expect(cop.messages).to be_empty
+      expect_no_offenses('detect { true }..other')
     end
 
     it 'accepts a single line block with {} if used in an erange' do
-      inspect_source(cop, 'detect { true }...other')
-      expect(cop.messages).to be_empty
+      expect_no_offenses('detect { true }...other')
     end
 
     it 'accepts a multi-line functional block with do-end if it is ' \
@@ -192,8 +186,7 @@ describe RuboCop::Cop::Style::BlockDelimiters, :config do
     end
 
     it 'accepts a single line block with do-end if it is procedural' do
-      inspect_source(cop, 'each do |x| puts x; end')
-      expect(cop.messages).to be_empty
+      expect_no_offenses('each do |x| puts x; end')
     end
 
     context 'with a procedural block' do

--- a/spec/rubocop/cop/style/empty_else_spec.rb
+++ b/spec/rubocop/cop/style/empty_else_spec.rb
@@ -83,22 +83,19 @@ describe RuboCop::Cop::Style::EmptyElse do
 
       context 'with an else-clause containing only the literal nil' do
         it "doesn't register an offense" do
-          inspect_source(cop, 'if a; foo elsif b; bar else nil end')
-          expect(cop.messages).to be_empty
+          expect_no_offenses('if a; foo elsif b; bar else nil end')
         end
       end
 
       context 'with an else-clause with side-effects' do
         it "doesn't register an offense" do
-          inspect_source(cop, 'if cond; foo else bar; nil end')
-          expect(cop.messages).to be_empty
+          expect_no_offenses('if cond; foo else bar; nil end')
         end
       end
 
       context 'with no else-clause' do
         it "doesn't register an offense" do
-          inspect_source(cop, 'if cond; foo end')
-          expect(cop.messages).to be_empty
+          expect_no_offenses('if cond; foo end')
         end
       end
     end
@@ -114,22 +111,19 @@ describe RuboCop::Cop::Style::EmptyElse do
 
       context 'with an else-clause containing only the literal nil' do
         it "doesn't register an offense" do
-          inspect_source(cop, 'unless cond; foo else nil end')
-          expect(cop.messages).to be_empty
+          expect_no_offenses('unless cond; foo else nil end')
         end
       end
 
       context 'with an else-clause with side-effects' do
         it "doesn't register an offense" do
-          inspect_source(cop, 'unless cond; foo else bar; nil end')
-          expect(cop.messages).to be_empty
+          expect_no_offenses('unless cond; foo else bar; nil end')
         end
       end
 
       context 'with no else-clause' do
         it "doesn't register an offense" do
-          inspect_source(cop, 'unless cond; foo end')
-          expect(cop.messages).to be_empty
+          expect_no_offenses('unless cond; foo end')
         end
       end
     end
@@ -145,22 +139,19 @@ describe RuboCop::Cop::Style::EmptyElse do
 
       context 'with an else-clause containing only the literal nil' do
         it "doesn't register an offense" do
-          inspect_source(cop, 'case v; when a; foo; when b; bar; else nil end')
-          expect(cop.messages).to be_empty
+          expect_no_offenses('case v; when a; foo; when b; bar; else nil end')
         end
       end
 
       context 'with an else-clause with side-effects' do
         it "doesn't register an offense" do
-          inspect_source(cop, 'case v; when a; foo; else b; nil end')
-          expect(cop.messages).to be_empty
+          expect_no_offenses('case v; when a; foo; else b; nil end')
         end
       end
 
       context 'with no else-clause' do
         it "doesn't register an offense" do
-          inspect_source(cop, 'case v; when a; foo; when b; bar; end')
-          expect(cop.messages).to be_empty
+          expect_no_offenses('case v; when a; foo; when b; bar; end')
         end
       end
     end
@@ -178,8 +169,7 @@ describe RuboCop::Cop::Style::EmptyElse do
     context 'given an if-statement' do
       context 'with a completely empty else-clause' do
         it "doesn't register an offense" do
-          inspect_source(cop, 'if a; foo else end')
-          expect(cop.messages).to be_empty
+          expect_no_offenses('if a; foo else end')
         end
       end
 
@@ -252,15 +242,13 @@ describe RuboCop::Cop::Style::EmptyElse do
 
       context 'with an else-clause with side-effects' do
         it "doesn't register an offense" do
-          inspect_source(cop, 'if cond; foo else bar; nil end')
-          expect(cop.messages).to be_empty
+          expect_no_offenses('if cond; foo else bar; nil end')
         end
       end
 
       context 'with no else-clause' do
         it "doesn't register an offense" do
-          inspect_source(cop, 'if cond; foo end')
-          expect(cop.messages).to be_empty
+          expect_no_offenses('if cond; foo end')
         end
       end
     end
@@ -268,8 +256,7 @@ describe RuboCop::Cop::Style::EmptyElse do
     context 'given an unless-statement' do
       context 'with a completely empty else-clause' do
         it "doesn't register an offense" do
-          inspect_source(cop, 'unless cond; foo else end')
-          expect(cop.messages).to be_empty
+          expect_no_offenses('unless cond; foo else end')
         end
       end
 
@@ -283,15 +270,13 @@ describe RuboCop::Cop::Style::EmptyElse do
 
       context 'with an else-clause with side-effects' do
         it "doesn't register an offense" do
-          inspect_source(cop, 'unless cond; foo else bar; nil end')
-          expect(cop.messages).to be_empty
+          expect_no_offenses('unless cond; foo else bar; nil end')
         end
       end
 
       context 'with no else-clause' do
         it "doesn't register an offense" do
-          inspect_source(cop, 'unless cond; foo end')
-          expect(cop.messages).to be_empty
+          expect_no_offenses('unless cond; foo end')
         end
       end
     end
@@ -299,8 +284,7 @@ describe RuboCop::Cop::Style::EmptyElse do
     context 'given a case statement' do
       context 'with a completely empty else-clause' do
         it "doesn't register an offense" do
-          inspect_source(cop, 'case v; when a; foo else end')
-          expect(cop.messages).to be_empty
+          expect_no_offenses('case v; when a; foo else end')
         end
       end
 
@@ -341,15 +325,13 @@ describe RuboCop::Cop::Style::EmptyElse do
 
       context 'with an else-clause with side-effects' do
         it "doesn't register an offense" do
-          inspect_source(cop, 'case v; when a; foo; else b; nil end')
-          expect(cop.messages).to be_empty
+          expect_no_offenses('case v; when a; foo; else b; nil end')
         end
       end
 
       context 'with no else-clause' do
         it "doesn't register an offense" do
-          inspect_source(cop, 'case v; when a; foo; when b; bar; end')
-          expect(cop.messages).to be_empty
+          expect_no_offenses('case v; when a; foo; when b; bar; end')
         end
       end
     end
@@ -393,15 +375,13 @@ describe RuboCop::Cop::Style::EmptyElse do
 
       context 'with an else-clause with side-effects' do
         it "doesn't register an offense" do
-          inspect_source(cop, 'if cond; foo else bar; nil end')
-          expect(cop.messages).to be_empty
+          expect_no_offenses('if cond; foo else bar; nil end')
         end
       end
 
       context 'with no else-clause' do
         it "doesn't register an offense" do
-          inspect_source(cop, 'if cond; foo end')
-          expect(cop.messages).to be_empty
+          expect_no_offenses('if cond; foo end')
         end
       end
     end
@@ -425,15 +405,13 @@ describe RuboCop::Cop::Style::EmptyElse do
 
       context 'with an else-clause with side-effects' do
         it "doesn't register an offense" do
-          inspect_source(cop, 'unless cond; foo else bar; nil end')
-          expect(cop.messages).to be_empty
+          expect_no_offenses('unless cond; foo else bar; nil end')
         end
       end
 
       context 'with no else-clause' do
         it "doesn't register an offense" do
-          inspect_source(cop, 'unless cond; foo end')
-          expect(cop.messages).to be_empty
+          expect_no_offenses('unless cond; foo end')
         end
       end
     end
@@ -457,15 +435,13 @@ describe RuboCop::Cop::Style::EmptyElse do
 
       context 'with an else-clause with side-effects' do
         it "doesn't register an offense" do
-          inspect_source(cop, 'case v; when a; foo; else b; nil end')
-          expect(cop.messages).to be_empty
+          expect_no_offenses('case v; when a; foo; else b; nil end')
         end
       end
 
       context 'with no else-clause' do
         it "doesn't register an offense" do
-          inspect_source(cop, 'case v; when a; foo; when b; bar; end')
-          expect(cop.messages).to be_empty
+          expect_no_offenses('case v; when a; foo; when b; bar; end')
         end
       end
     end

--- a/spec/rubocop/cop/style/encoding_spec.rb
+++ b/spec/rubocop/cop/style/encoding_spec.rb
@@ -50,13 +50,11 @@ describe RuboCop::Cop::Style::Encoding, :config do
     end
 
     it 'accepts encoding on second line when shebang present' do
-      inspect_source(cop, <<-END.strip_indent)
+      expect_no_offenses(<<-RUBY.strip_indent)
         #!/usr/bin/env ruby
         # encoding: utf-8
-        def foo() \'ä\' end
-      END
-
-      expect(cop.messages).to be_empty
+        def foo() 'ä' end
+      RUBY
     end
 
     it 'registers an offense when encoding is in the wrong place' do
@@ -68,20 +66,17 @@ describe RuboCop::Cop::Style::Encoding, :config do
     end
 
     it 'accepts encoding inserted by magic_encoding gem' do
-      inspect_source(cop, <<-END.strip_indent)
+      expect_no_offenses(<<-RUBY.strip_indent)
         # -*- encoding : utf-8 -*-
-        def foo() \'ä\' end
-      END
-
-      expect(cop.messages).to be_empty
+        def foo() 'ä' end
+      RUBY
     end
 
     it 'accepts vim-style encoding comments' do
-      inspect_source(cop, <<-END.strip_indent)
+      expect_no_offenses(<<-RUBY.strip_indent)
         # vim:filetype=ruby, fileencoding=utf-8
-        def foo() \'ä\' end
-      END
-      expect(cop.messages).to be_empty
+        def foo() 'ä' end
+      RUBY
     end
 
     context 'auto-correct' do
@@ -134,13 +129,11 @@ describe RuboCop::Cop::Style::Encoding, :config do
     end
 
     it 'accepts encoding on second line when shebang present' do
-      inspect_source(cop, <<-END.strip_indent)
+      expect_no_offenses(<<-RUBY.strip_indent)
         #!/usr/bin/env ruby
         # encoding: utf-8
         def foo() end
-      END
-
-      expect(cop.messages).to be_empty
+      RUBY
     end
 
     it 'books an offense when encoding is in the wrong place' do
@@ -152,20 +145,17 @@ describe RuboCop::Cop::Style::Encoding, :config do
     end
 
     it 'accepts encoding inserted by magic_encoding gem' do
-      inspect_source(cop, <<-END.strip_indent)
+      expect_no_offenses(<<-RUBY.strip_indent)
         # -*- encoding : utf-8 -*-
         def foo() end
-      END
-
-      expect(cop.messages).to be_empty
+      RUBY
     end
 
     it 'accepts vim-style encoding comments' do
-      inspect_source(cop, <<-END.strip_indent)
+      expect_no_offenses(<<-RUBY.strip_indent)
         # vim:filetype=ruby, fileencoding=utf-8
         def foo() end
-      END
-      expect(cop.messages).to be_empty
+      RUBY
     end
 
     context 'auto-correct' do

--- a/spec/rubocop/cop/style/format_string_spec.rb
+++ b/spec/rubocop/cop/style/format_string_spec.rb
@@ -24,13 +24,7 @@ describe RuboCop::Cop::Style::FormatString, :config do
     end
 
     it 'does not register an offense for ambiguous cases' do
-      inspect_source(cop,
-                     'puts x % 4')
-      expect(cop.offenses).to be_empty
-
-      inspect_source(cop,
-                     'puts x % Y')
-      expect(cop.offenses).to be_empty
+      expect_no_offenses('puts x % Y')
     end
 
     it 'works if the first operand contains embedded expressions' do
@@ -84,13 +78,7 @@ describe RuboCop::Cop::Style::FormatString, :config do
     end
 
     it 'does not register an offense for ambiguous cases' do
-      inspect_source(cop,
-                     'puts x % 4')
-      expect(cop.offenses).to be_empty
-
-      inspect_source(cop,
-                     'puts x % Y')
-      expect(cop.offenses).to be_empty
+      expect_no_offenses('puts x % Y')
     end
 
     it 'works if the first operand contains embedded expressions' do

--- a/spec/rubocop/cop/style/hash_syntax_spec.rb
+++ b/spec/rubocop/cop/style/hash_syntax_spec.rb
@@ -47,19 +47,16 @@ describe RuboCop::Cop::Style::HashSyntax, :config do
       end
 
       it 'accepts hash rockets when keys have different types' do
-        inspect_source(cop, 'x = { :a => 0, "b" => 1 }')
-        expect(cop.messages).to be_empty
+        expect_no_offenses('x = { :a => 0, "b" => 1 }')
       end
 
       it 'accepts an empty hash' do
-        inspect_source(cop, '{}')
-        expect(cop.messages).to be_empty
+        expect_no_offenses('{}')
       end
 
       context 'ruby < 2.2', :ruby21 do
         it 'accepts hash rockets when symbol keys have string in them' do
-          inspect_source(cop, 'x = { :"string" => 0 }')
-          expect(cop.messages).to be_empty
+          expect_no_offenses('x = { :"string" => 0 }')
         end
       end
 
@@ -96,24 +93,20 @@ describe RuboCop::Cop::Style::HashSyntax, :config do
         end
 
         it 'accepts hash rockets when symbols end with ?' do
-          inspect_source(cop, 'x = { :a? => 0 }')
-          expect(cop.messages).to be_empty
+          expect_no_offenses('x = { :a? => 0 }')
         end
 
         it 'accepts hash rockets when symbols end with !' do
-          inspect_source(cop, 'x = { :a! => 0 }')
-          expect(cop.messages).to be_empty
+          expect_no_offenses('x = { :a! => 0 }')
         end
       end
 
       it 'accepts hash rockets when symbol keys end with =' do
-        inspect_source(cop, 'x = { :a= => 0 }')
-        expect(cop.messages).to be_empty
+        expect_no_offenses('x = { :a= => 0 }')
       end
 
       it 'accepts hash rockets when symbol characters are not supported' do
-        inspect_source(cop, 'x = { :[] => 0 }')
-        expect(cop.messages).to be_empty
+        expect_no_offenses('x = { :[] => 0 }')
       end
 
       it 'registers offense when keys start with an uppercase letter' do
@@ -124,13 +117,11 @@ describe RuboCop::Cop::Style::HashSyntax, :config do
       end
 
       it 'accepts new syntax in a hash literal' do
-        inspect_source(cop, 'x = { a: 0, b: 1 }')
-        expect(cop.messages).to be_empty
+        expect_no_offenses('x = { a: 0, b: 1 }')
       end
 
       it 'accepts new syntax in method calls' do
-        inspect_source(cop, 'func(3, a: 0)')
-        expect(cop.messages).to be_empty
+        expect_no_offenses('func(3, a: 0)')
       end
 
       it 'auto-corrects old to new style' do
@@ -177,8 +168,7 @@ describe RuboCop::Cop::Style::HashSyntax, :config do
       end
 
       it 'accepts ruby19 syntax when no elements have symbol values' do
-        inspect_source(cop, 'x = { a: 1, b: 2 }')
-        expect(cop.messages).to be_empty
+        expect_no_offenses('x = { a: 1, b: 2 }')
       end
 
       it 'accepts ruby19 syntax when no elements have symbol values ' \
@@ -188,13 +178,11 @@ describe RuboCop::Cop::Style::HashSyntax, :config do
       end
 
       it 'accepts new syntax in method calls' do
-        inspect_source(cop, 'func(3, a: 0)')
-        expect(cop.messages).to be_empty
+        expect_no_offenses('func(3, a: 0)')
       end
 
       it 'accepts an empty hash' do
-        inspect_source(cop, '{}')
-        expect(cop.messages).to be_empty
+        expect_no_offenses('{}')
       end
 
       it 'registers an offense when any element uses a symbol for the value' do
@@ -282,18 +270,15 @@ describe RuboCop::Cop::Style::HashSyntax, :config do
     end
 
     it 'accepts hash rockets in a hash literal' do
-      inspect_source(cop, 'x = { :a => 0, :b => 1 }')
-      expect(cop.messages).to be_empty
+      expect_no_offenses('x = { :a => 0, :b => 1 }')
     end
 
     it 'accepts hash rockets in method calls' do
-      inspect_source(cop, 'func(3, :a => 0)')
-      expect(cop.messages).to be_empty
+      expect_no_offenses('func(3, :a => 0)')
     end
 
     it 'accepts an empty hash' do
-      inspect_source(cop, '{}')
-      expect(cop.messages).to be_empty
+      expect_no_offenses('{}')
     end
 
     it 'auto-corrects new style to hash rockets' do
@@ -311,8 +296,7 @@ describe RuboCop::Cop::Style::HashSyntax, :config do
       end
 
       it 'does not register an offense when there is a symbol value' do
-        inspect_source(cop, '{ :a => :b, :c => :d }')
-        expect(cop.messages).to be_empty
+        expect_no_offenses('{ :a => :b, :c => :d }')
       end
     end
   end
@@ -327,8 +311,7 @@ describe RuboCop::Cop::Style::HashSyntax, :config do
       end
 
       it 'accepts new syntax in a hash literal' do
-        inspect_source(cop, 'x = { a: 0, b: 1 }')
-        expect(cop.messages).to be_empty
+        expect_no_offenses('x = { a: 0, b: 1 }')
       end
 
       it 'registers offense for hash rocket syntax when new is possible' do
@@ -345,8 +328,7 @@ describe RuboCop::Cop::Style::HashSyntax, :config do
       end
 
       it 'accepts new syntax in method calls' do
-        inspect_source(cop, 'func(3, a: 0)')
-        expect(cop.messages).to be_empty
+        expect_no_offenses('func(3, a: 0)')
       end
 
       it 'registers an offense for hash rockets in method calls' do
@@ -357,13 +339,11 @@ describe RuboCop::Cop::Style::HashSyntax, :config do
       end
 
       it 'accepts hash rockets when keys have different types' do
-        inspect_source(cop, 'x = { :a => 0, "b" => 1 }')
-        expect(cop.messages).to be_empty
+        expect_no_offenses('x = { :a => 0, "b" => 1 }')
       end
 
       it 'accepts an empty hash' do
-        inspect_source(cop, '{}')
-        expect(cop.messages).to be_empty
+        expect_no_offenses('{}')
       end
 
       it 'registers an offense when keys have different types and styles' do
@@ -374,8 +354,7 @@ describe RuboCop::Cop::Style::HashSyntax, :config do
 
       context 'ruby < 2.2', :ruby21 do
         it 'accepts hash rockets when keys have whitespaces in them' do
-          inspect_source(cop, 'x = { :"t o" => 0, :b => 1 }')
-          expect(cop.messages).to be_empty
+          expect_no_offenses('x = { :"t o" => 0, :b => 1 }')
         end
 
         it 'registers an offense when keys have whitespaces and mix styles' do
@@ -385,8 +364,7 @@ describe RuboCop::Cop::Style::HashSyntax, :config do
         end
 
         it 'accepts hash rockets when keys have special symbols in them' do
-          inspect_source(cop, 'x = { :"\tab" => 1, :b => 1 }')
-          expect(cop.messages).to be_empty
+          expect_no_offenses('x = { :"\\tab" => 1, :b => 1 }')
         end
 
         it 'registers an offense when keys have special symbols and '\
@@ -397,8 +375,7 @@ describe RuboCop::Cop::Style::HashSyntax, :config do
         end
 
         it 'accepts hash rockets when keys start with a digit' do
-          inspect_source(cop, 'x = { :"1" => 1, :b => 1 }')
-          expect(cop.messages).to be_empty
+          expect_no_offenses('x = { :"1" => 1, :b => 1 }')
         end
 
         it 'registers an offense when keys start with a digit and mix styles' do
@@ -478,8 +455,7 @@ describe RuboCop::Cop::Style::HashSyntax, :config do
       end
 
       it 'accepts new syntax in a hash literal' do
-        inspect_source(cop, 'x = { a: 0, b: 1 }')
-        expect(cop.messages).to be_empty
+        expect_no_offenses('x = { a: 0, b: 1 }')
       end
 
       it 'registers offense for hash rocket syntax when new is possible' do
@@ -496,8 +472,7 @@ describe RuboCop::Cop::Style::HashSyntax, :config do
       end
 
       it 'accepts new syntax in method calls' do
-        inspect_source(cop, 'func(3, a: 0)')
-        expect(cop.messages).to be_empty
+        expect_no_offenses('func(3, a: 0)')
       end
 
       it 'registers an offense for hash rockets in method calls' do
@@ -508,13 +483,11 @@ describe RuboCop::Cop::Style::HashSyntax, :config do
       end
 
       it 'accepts hash rockets when keys have different types' do
-        inspect_source(cop, 'x = { :a => 0, "b" => 1 }')
-        expect(cop.messages).to be_empty
+        expect_no_offenses('x = { :a => 0, "b" => 1 }')
       end
 
       it 'accepts an empty hash' do
-        inspect_source(cop, '{}')
-        expect(cop.messages).to be_empty
+        expect_no_offenses('{}')
       end
 
       it 'registers an offense when keys have different types and styles' do
@@ -525,8 +498,7 @@ describe RuboCop::Cop::Style::HashSyntax, :config do
 
       context 'ruby < 2.2', :ruby21 do
         it 'accepts hash rockets when keys have whitespaces in them' do
-          inspect_source(cop, 'x = { :"t o" => 0, :b => 1 }')
-          expect(cop.messages).to be_empty
+          expect_no_offenses('x = { :"t o" => 0, :b => 1 }')
         end
 
         it 'registers an offense when keys have whitespaces and mix styles' do
@@ -536,8 +508,7 @@ describe RuboCop::Cop::Style::HashSyntax, :config do
         end
 
         it 'accepts hash rockets when keys have special symbols in them' do
-          inspect_source(cop, 'x = { :"\tab" => 1, :b => 1 }')
-          expect(cop.messages).to be_empty
+          expect_no_offenses('x = { :"\\tab" => 1, :b => 1 }')
         end
 
         it 'registers an offense when keys have special symbols and ' \
@@ -548,8 +519,7 @@ describe RuboCop::Cop::Style::HashSyntax, :config do
         end
 
         it 'accepts hash rockets when keys start with a digit' do
-          inspect_source(cop, 'x = { :"1" => 1, :b => 1 }')
-          expect(cop.messages).to be_empty
+          expect_no_offenses('x = { :"1" => 1, :b => 1 }')
         end
 
         it 'registers an offense when keys start with a digit and mix styles' do
@@ -603,13 +573,11 @@ describe RuboCop::Cop::Style::HashSyntax, :config do
     end
 
     it 'accepts new syntax in a hash literal' do
-      inspect_source(cop, 'x = { a: 0, b: 1 }')
-      expect(cop.messages).to be_empty
+      expect_no_offenses('x = { a: 0, b: 1 }')
     end
 
     it 'accepts the hash rocket syntax when new is possible' do
-      inspect_source(cop, 'x = { :a => 0 }')
-      expect(cop.messages).to be_empty
+      expect_no_offenses('x = { :a => 0 }')
     end
 
     it 'registers an offense for mixed syntax when new is possible' do
@@ -619,23 +587,19 @@ describe RuboCop::Cop::Style::HashSyntax, :config do
     end
 
     it 'accepts new syntax in method calls' do
-      inspect_source(cop, 'func(3, a: 0)')
-      expect(cop.messages).to be_empty
+      expect_no_offenses('func(3, a: 0)')
     end
 
     it 'accepts hash rockets in method calls' do
-      inspect_source(cop, 'func(3, :a => 0)')
-      expect(cop.messages).to be_empty
+      expect_no_offenses('func(3, :a => 0)')
     end
 
     it 'accepts hash rockets when keys have different types' do
-      inspect_source(cop, 'x = { :a => 0, "b" => 1 }')
-      expect(cop.messages).to be_empty
+      expect_no_offenses('x = { :a => 0, "b" => 1 }')
     end
 
     it 'accepts an empty hash' do
-      inspect_source(cop, '{}')
-      expect(cop.messages).to be_empty
+      expect_no_offenses('{}')
     end
 
     it 'registers an offense when keys have different types and styles' do
@@ -645,8 +609,7 @@ describe RuboCop::Cop::Style::HashSyntax, :config do
     end
 
     it 'accepts hash rockets when keys have whitespaces in them' do
-      inspect_source(cop, 'x = { :"t o" => 0, :b => 1 }')
-      expect(cop.messages).to be_empty
+      expect_no_offenses('x = { :"t o" => 0, :b => 1 }')
     end
 
     it 'registers an offense when keys have whitespaces and mix styles' do
@@ -656,8 +619,7 @@ describe RuboCop::Cop::Style::HashSyntax, :config do
     end
 
     it 'accepts hash rockets when keys have special symbols in them' do
-      inspect_source(cop, 'x = { :"\tab" => 1, :b => 1 }')
-      expect(cop.messages).to be_empty
+      expect_no_offenses('x = { :"\\tab" => 1, :b => 1 }')
     end
 
     it 'registers an offense when keys have special symbols and '\
@@ -668,8 +630,7 @@ describe RuboCop::Cop::Style::HashSyntax, :config do
     end
 
     it 'accepts hash rockets when keys start with a digit' do
-      inspect_source(cop, 'x = { :"1" => 1, :b => 1 }')
-      expect(cop.messages).to be_empty
+      expect_no_offenses('x = { :"1" => 1, :b => 1 }')
     end
 
     it 'registers an offense when keys start with a digit and mix styles' do

--- a/spec/rubocop/cop/style/if_unless_modifier_spec.rb
+++ b/spec/rubocop/cop/style/if_unless_modifier_spec.rb
@@ -197,10 +197,9 @@ describe RuboCop::Cop::Style::IfUnlessModifier do
   end
 
   it 'accepts if-else-end' do
-    inspect_source(cop,
-                   'if args.last.is_a? Hash then args.pop else ' \
-                   'Hash.new end')
-    expect(cop.messages).to be_empty
+    expect_no_offenses(<<-RUBY.strip_indent)
+      if args.last.is_a? Hash then args.pop else Hash.new end
+    RUBY
   end
 
   it 'accepts an empty condition' do
@@ -276,12 +275,11 @@ describe RuboCop::Cop::Style::IfUnlessModifier do
   end
 
   it 'accepts if-end followed by a chained call' do
-    inspect_source(cop, <<-END.strip_indent)
+    expect_no_offenses(<<-RUBY.strip_indent)
       if test
         something
       end.inspect
-    END
-    expect(cop.messages).to be_empty
+    RUBY
   end
 
   it "doesn't break if-end when used as RHS of local var assignment" do
@@ -330,12 +328,11 @@ describe RuboCop::Cop::Style::IfUnlessModifier do
   end
 
   it 'accepts if-end when used as LHS of binary arithmetic' do
-    inspect_source(cop, <<-END.strip_indent)
+    expect_no_offenses(<<-RUBY.strip_indent)
       if test
         1
       end + 2
-    END
-    expect(cop.messages).to be_empty
+    RUBY
   end
 
   context 'if-end is argument to a parenthesized method call' do

--- a/spec/rubocop/cop/style/if_unless_modifier_spec.rb
+++ b/spec/rubocop/cop/style/if_unless_modifier_spec.rb
@@ -42,17 +42,12 @@ describe RuboCop::Cop::Style::IfUnlessModifier do
     end
 
     context 'and has two statements separated by semicolon' do
-      let(:source) do
-        <<-END.strip_indent
+      it 'accepts' do
+        expect_no_offenses(<<-RUBY.strip_indent)
           if condition
             do_this; do_that
           end
-        END
-      end
-
-      it 'accepts' do
-        inspect_source(cop, source)
-        expect(cop.offenses).to be_empty
+        RUBY
       end
     end
   end
@@ -82,8 +77,8 @@ describe RuboCop::Cop::Style::IfUnlessModifier do
   end
 
   context 'multiline if that fits on one line with comment near end' do
-    let(:source) do
-      <<-END.strip_indent
+    it 'accepts' do
+      expect_no_offenses(<<-RUBY.strip_indent)
         if a
           b
         end # comment
@@ -91,12 +86,7 @@ describe RuboCop::Cop::Style::IfUnlessModifier do
           b
           # comment
         end
-      END
-    end
-
-    it 'accepts' do
-      inspect_source(cop, source)
-      expect(cop.offenses).to be_empty
+      RUBY
     end
   end
 
@@ -358,32 +348,22 @@ describe RuboCop::Cop::Style::IfUnlessModifier do
   end
 
   context 'if-end with conditional as body' do
-    let(:source) do
-      <<-END.strip_indent
+    it 'accepts' do
+      expect_no_offenses(<<-RUBY.strip_indent)
         if condition
           foo ? "bar" : "baz"
         end
-      END
-    end
-
-    it 'accepts' do
-      inspect_source(cop, source)
-      expect(cop.offenses).to be_empty
+      RUBY
     end
   end
 
   context 'unless-end with conditional as body' do
-    let(:source) do
-      <<-END.strip_indent
+    it 'accepts' do
+      expect_no_offenses(<<-RUBY.strip_indent)
         unless condition
           foo ? "bar" : "baz"
         end
-      END
-    end
-
-    it 'accepts' do
-      inspect_source(cop, source)
-      expect(cop.offenses).to be_empty
+      RUBY
     end
   end
 end

--- a/spec/rubocop/cop/style/if_with_semicolon_spec.rb
+++ b/spec/rubocop/cop/style/if_with_semicolon_spec.rb
@@ -11,15 +11,13 @@ describe RuboCop::Cop::Style::IfWithSemicolon do
   end
 
   it 'accepts one line if/then/end' do
-    inspect_source(cop, 'if cond then run else dont end')
-    expect(cop.messages).to be_empty
+    expect_no_offenses('if cond then run else dont end')
   end
 
   it 'can handle modifier conditionals' do
-    inspect_source(cop, <<-END.strip_indent)
+    expect_no_offenses(<<-RUBY.strip_indent)
       class Hash
       end if RUBY_VERSION < "1.8.7"
-    END
-    expect(cop.messages).to be_empty
+    RUBY
   end
 end

--- a/spec/rubocop/cop/style/line_end_concatenation_spec.rb
+++ b/spec/rubocop/cop/style/line_end_concatenation_spec.rb
@@ -79,23 +79,16 @@ describe RuboCop::Cop::Style::LineEndConcatenation do
   end
 
   it 'accepts string concat with a return value of method on a string' do
-    inspect_source(cop,
-                   [
-                     # What we want here is 'content   ', not '
-                     # content content content '.
-                     'content_and_three_spaces = "content" +',
-                     '  " " * 3',
-                     # Method call with dot on a string literal.
-                     "a_thing = 'a ' +",
-                     "  'gniht'.reverse",
-                     # Formatting operator.
-                     "output = 'value: ' +",
-                     "  '%d' % value",
-                     # Index operator.
-                     "'letter: ' +",
-                     "  'abcdefghij'[ix]"
-                   ])
-    expect(cop.offenses).to be_empty
+    expect_no_offenses(<<-RUBY.strip_indent)
+      content_and_three_spaces = "content" +
+        " " * 3
+      a_thing = 'a ' +
+        'gniht'.reverse
+      output = 'value: ' +
+        '%d' % value
+      'letter: ' +
+        'abcdefghij'[ix]
+    RUBY
   end
 
   it 'accepts string concat with a return value of method on an interpolated ' \
@@ -109,32 +102,32 @@ describe RuboCop::Cop::Style::LineEndConcatenation do
   end
 
   it 'accepts string concat at line end when followed by comment' do
-    inspect_source(cop,
-                   ['top = "test" + # something',
-                    '"top"'])
-    expect(cop.offenses).to be_empty
+    expect_no_offenses(<<-RUBY.strip_indent)
+      top = "test" + # something
+      "top"
+    RUBY
   end
 
   it 'accepts string concat at line end when followed by a comment line' do
-    inspect_source(cop,
-                   ['top = "test" +',
-                    '# something',
-                    '"top"'])
-    expect(cop.offenses).to be_empty
+    expect_no_offenses(<<-RUBY.strip_indent)
+      top = "test" +
+      # something
+      "top"
+    RUBY
   end
 
   it 'accepts string concat at line end when % literals are involved' do
-    inspect_source(cop,
-                   ['top = %(test) +',
-                    '"top"'])
-    expect(cop.offenses).to be_empty
+    expect_no_offenses(<<-RUBY.strip_indent)
+      top = %(test) +
+      "top"
+    RUBY
   end
 
   it 'accepts string concat at line end for special strings like __FILE__' do
-    inspect_source(cop,
-                   ['top = __FILE__ +',
-                    '"top"'])
-    expect(cop.offenses).to be_empty
+    expect_no_offenses(<<-RUBY.strip_indent)
+      top = __FILE__ +
+      "top"
+    RUBY
   end
 
   it 'registers offenses only for the appropriate lines in chained concats' do

--- a/spec/rubocop/cop/style/missing_else_spec.rb
+++ b/spec/rubocop/cop/style/missing_else_spec.rb
@@ -16,22 +16,19 @@ describe RuboCop::Cop::Style::MissingElse do
     context 'given an if-statement' do
       context 'with a completely empty else-clause' do
         it "doesn't register an offense" do
-          inspect_source(cop, 'if a; foo else end')
-          expect(cop.messages).to be_empty
+          expect_no_offenses('if a; foo else end')
         end
       end
 
       context 'with an else-clause containing only the literal nil' do
         it "doesn't register an offense" do
-          inspect_source(cop, 'if a; foo elsif b; bar else nil end')
-          expect(cop.messages).to be_empty
+          expect_no_offenses('if a; foo elsif b; bar else nil end')
         end
       end
 
       context 'with an else-clause with side-effects' do
         it "doesn't register an offense" do
-          inspect_source(cop, 'if cond; foo else bar; nil end')
-          expect(cop.messages).to be_empty
+          expect_no_offenses('if cond; foo else bar; nil end')
         end
       end
 
@@ -48,29 +45,25 @@ describe RuboCop::Cop::Style::MissingElse do
     context 'given an unless-statement' do
       context 'with a completely empty else-clause' do
         it "doesn't register an offense" do
-          inspect_source(cop, 'unless cond; foo else end')
-          expect(cop.messages).to be_empty
+          expect_no_offenses('unless cond; foo else end')
         end
       end
 
       context 'with an else-clause containing only the literal nil' do
         it "doesn't register an offense" do
-          inspect_source(cop, 'unless cond; foo else nil end')
-          expect(cop.messages).to be_empty
+          expect_no_offenses('unless cond; foo else nil end')
         end
       end
 
       context 'with an else-clause with side-effects' do
         it "doesn't register an offense" do
-          inspect_source(cop, 'unless cond; foo else bar; nil end')
-          expect(cop.messages).to be_empty
+          expect_no_offenses('unless cond; foo else bar; nil end')
         end
       end
 
       context 'with no else-clause' do
         it "doesn't register an offense" do
-          inspect_source(cop, 'unless cond; foo end')
-          expect(cop.messages).to be_empty
+          expect_no_offenses('unless cond; foo end')
         end
       end
     end
@@ -78,22 +71,19 @@ describe RuboCop::Cop::Style::MissingElse do
     context 'given a case statement' do
       context 'with a completely empty else-clause' do
         it "doesn't register an offense" do
-          inspect_source(cop, 'case v; when a; foo else end')
-          expect(cop.messages).to be_empty
+          expect_no_offenses('case v; when a; foo else end')
         end
       end
 
       context 'with an else-clause containing only the literal nil' do
         it "doesn't register an offense" do
-          inspect_source(cop, 'case v; when a; foo; when b; bar; else nil end')
-          expect(cop.messages).to be_empty
+          expect_no_offenses('case v; when a; foo; when b; bar; else nil end')
         end
       end
 
       context 'with an else-clause with side-effects' do
         it "doesn't register an offense" do
-          inspect_source(cop, 'case v; when a; foo; else b; nil end')
-          expect(cop.messages).to be_empty
+          expect_no_offenses('case v; when a; foo; else b; nil end')
         end
       end
 
@@ -121,22 +111,19 @@ describe RuboCop::Cop::Style::MissingElse do
     context 'given an if-statement' do
       context 'with a completely empty else-clause' do
         it "doesn't register an offense" do
-          inspect_source(cop, 'if a; foo else end')
-          expect(cop.messages).to be_empty
+          expect_no_offenses('if a; foo else end')
         end
       end
 
       context 'with an else-clause containing only the literal nil' do
         it "doesn't register an offense" do
-          inspect_source(cop, 'if a; foo elsif b; bar else nil end')
-          expect(cop.messages).to be_empty
+          expect_no_offenses('if a; foo elsif b; bar else nil end')
         end
       end
 
       context 'with an else-clause with side-effects' do
         it "doesn't register an offense" do
-          inspect_source(cop, 'if cond; foo else bar; nil end')
-          expect(cop.messages).to be_empty
+          expect_no_offenses('if cond; foo else bar; nil end')
         end
       end
 
@@ -153,22 +140,19 @@ describe RuboCop::Cop::Style::MissingElse do
     context 'given an unless-statement' do
       context 'with a completely empty else-clause' do
         it "doesn't register an offense" do
-          inspect_source(cop, 'unless cond; foo else end')
-          expect(cop.messages).to be_empty
+          expect_no_offenses('unless cond; foo else end')
         end
       end
 
       context 'with an else-clause containing only the literal nil' do
         it "doesn't register an offense" do
-          inspect_source(cop, 'unless cond; foo else nil end')
-          expect(cop.messages).to be_empty
+          expect_no_offenses('unless cond; foo else nil end')
         end
       end
 
       context 'with an else-clause with side-effects' do
         it "doesn't register an offense" do
-          inspect_source(cop, 'unless cond; foo else bar; nil end')
-          expect(cop.messages).to be_empty
+          expect_no_offenses('unless cond; foo else bar; nil end')
         end
       end
 
@@ -185,22 +169,19 @@ describe RuboCop::Cop::Style::MissingElse do
     context 'given a case statement' do
       context 'with a completely empty else-clause' do
         it "doesn't register an offense" do
-          inspect_source(cop, 'case v; when a; foo else end')
-          expect(cop.messages).to be_empty
+          expect_no_offenses('case v; when a; foo else end')
         end
       end
 
       context 'with an else-clause containing only the literal nil' do
         it "doesn't register an offense" do
-          inspect_source(cop, 'case v; when a; foo; when b; bar; else nil end')
-          expect(cop.messages).to be_empty
+          expect_no_offenses('case v; when a; foo; when b; bar; else nil end')
         end
       end
 
       context 'with an else-clause with side-effects' do
         it "doesn't register an offense" do
-          inspect_source(cop, 'case v; when a; foo; else b; nil end')
-          expect(cop.messages).to be_empty
+          expect_no_offenses('case v; when a; foo; else b; nil end')
         end
       end
 
@@ -234,22 +215,19 @@ describe RuboCop::Cop::Style::MissingElse do
     context 'given an if-statement' do
       context 'with a completely empty else-clause' do
         it "doesn't register an offense" do
-          inspect_source(cop, 'if a; foo else end')
-          expect(cop.messages).to be_empty
+          expect_no_offenses('if a; foo else end')
         end
       end
 
       context 'with an else-clause containing only the literal nil' do
         it "doesn't register an offense" do
-          inspect_source(cop, 'if a; foo elsif b; bar else nil end')
-          expect(cop.messages).to be_empty
+          expect_no_offenses('if a; foo elsif b; bar else nil end')
         end
       end
 
       context 'with an else-clause with side-effects' do
         it "doesn't register an offense" do
-          inspect_source(cop, 'if cond; foo else bar; nil end')
-          expect(cop.messages).to be_empty
+          expect_no_offenses('if cond; foo else bar; nil end')
         end
       end
 
@@ -273,22 +251,19 @@ describe RuboCop::Cop::Style::MissingElse do
     context 'given an unless-statement' do
       context 'with a completely empty else-clause' do
         it "doesn't register an offense" do
-          inspect_source(cop, 'unless cond; foo else end')
-          expect(cop.messages).to be_empty
+          expect_no_offenses('unless cond; foo else end')
         end
       end
 
       context 'with an else-clause containing only the literal nil' do
         it "doesn't register an offense" do
-          inspect_source(cop, 'unless cond; foo else nil end')
-          expect(cop.messages).to be_empty
+          expect_no_offenses('unless cond; foo else nil end')
         end
       end
 
       context 'with an else-clause with side-effects' do
         it "doesn't register an offense" do
-          inspect_source(cop, 'unless cond; foo else bar; nil end')
-          expect(cop.messages).to be_empty
+          expect_no_offenses('unless cond; foo else bar; nil end')
         end
       end
 
@@ -305,22 +280,19 @@ describe RuboCop::Cop::Style::MissingElse do
     context 'given a case statement' do
       context 'with a completely empty else-clause' do
         it "doesn't register an offense" do
-          inspect_source(cop, 'case v; when a; foo else end')
-          expect(cop.messages).to be_empty
+          expect_no_offenses('case v; when a; foo else end')
         end
       end
 
       context 'with an else-clause containing only the literal nil' do
         it "doesn't register an offense" do
-          inspect_source(cop, 'case v; when a; foo; when b; bar; else nil end')
-          expect(cop.messages).to be_empty
+          expect_no_offenses('case v; when a; foo; when b; bar; else nil end')
         end
       end
 
       context 'with an else-clause with side-effects' do
         it "doesn't register an offense" do
-          inspect_source(cop, 'case v; when a; foo; else b; nil end')
-          expect(cop.messages).to be_empty
+          expect_no_offenses('case v; when a; foo; else b; nil end')
         end
       end
 
@@ -354,22 +326,19 @@ describe RuboCop::Cop::Style::MissingElse do
     context 'given an if-statement' do
       context 'with a completely empty else-clause' do
         it "doesn't register an offense" do
-          inspect_source(cop, 'if a; foo else end')
-          expect(cop.messages).to be_empty
+          expect_no_offenses('if a; foo else end')
         end
       end
 
       context 'with an else-clause containing only the literal nil' do
         it "doesn't register an offense" do
-          inspect_source(cop, 'if a; foo elsif b; bar else nil end')
-          expect(cop.messages).to be_empty
+          expect_no_offenses('if a; foo elsif b; bar else nil end')
         end
       end
 
       context 'with an else-clause with side-effects' do
         it "doesn't register an offense" do
-          inspect_source(cop, 'if cond; foo else bar; nil end')
-          expect(cop.messages).to be_empty
+          expect_no_offenses('if cond; foo else bar; nil end')
         end
       end
 
@@ -386,22 +355,19 @@ describe RuboCop::Cop::Style::MissingElse do
     context 'given an unless-statement' do
       context 'with a completely empty else-clause' do
         it "doesn't register an offense" do
-          inspect_source(cop, 'unless cond; foo else end')
-          expect(cop.messages).to be_empty
+          expect_no_offenses('unless cond; foo else end')
         end
       end
 
       context 'with an else-clause containing only the literal nil' do
         it "doesn't register an offense" do
-          inspect_source(cop, 'unless cond; foo else nil end')
-          expect(cop.messages).to be_empty
+          expect_no_offenses('unless cond; foo else nil end')
         end
       end
 
       context 'with an else-clause with side-effects' do
         it "doesn't register an offense" do
-          inspect_source(cop, 'unless cond; foo else bar; nil end')
-          expect(cop.messages).to be_empty
+          expect_no_offenses('unless cond; foo else bar; nil end')
         end
       end
 
@@ -418,22 +384,19 @@ describe RuboCop::Cop::Style::MissingElse do
     context 'given a case statement' do
       context 'with a completely empty else-clause' do
         it "doesn't register an offense" do
-          inspect_source(cop, 'case v; when a; foo else end')
-          expect(cop.messages).to be_empty
+          expect_no_offenses('case v; when a; foo else end')
         end
       end
 
       context 'with an else-clause containing only the literal nil' do
         it "doesn't register an offense" do
-          inspect_source(cop, 'case v; when a; foo; when b; bar; else nil end')
-          expect(cop.messages).to be_empty
+          expect_no_offenses('case v; when a; foo; when b; bar; else nil end')
         end
       end
 
       context 'with an else-clause with side-effects' do
         it "doesn't register an offense" do
-          inspect_source(cop, 'case v; when a; foo; else b; nil end')
-          expect(cop.messages).to be_empty
+          expect_no_offenses('case v; when a; foo; else b; nil end')
         end
       end
 
@@ -467,22 +430,19 @@ describe RuboCop::Cop::Style::MissingElse do
     context 'given an if-statement' do
       context 'with a completely empty else-clause' do
         it "doesn't register an offense" do
-          inspect_source(cop, 'if a; foo else end')
-          expect(cop.messages).to be_empty
+          expect_no_offenses('if a; foo else end')
         end
       end
 
       context 'with an else-clause containing only the literal nil' do
         it "doesn't register an offense" do
-          inspect_source(cop, 'if a; foo elsif b; bar else nil end')
-          expect(cop.messages).to be_empty
+          expect_no_offenses('if a; foo elsif b; bar else nil end')
         end
       end
 
       context 'with an else-clause with side-effects' do
         it "doesn't register an offense" do
-          inspect_source(cop, 'if cond; foo else bar; nil end')
-          expect(cop.messages).to be_empty
+          expect_no_offenses('if cond; foo else bar; nil end')
         end
       end
 
@@ -499,22 +459,19 @@ describe RuboCop::Cop::Style::MissingElse do
     context 'given an unless-statement' do
       context 'with a completely empty else-clause' do
         it "doesn't register an offense" do
-          inspect_source(cop, 'unless cond; foo else end')
-          expect(cop.messages).to be_empty
+          expect_no_offenses('unless cond; foo else end')
         end
       end
 
       context 'with an else-clause containing only the literal nil' do
         it "doesn't register an offense" do
-          inspect_source(cop, 'unless cond; foo else nil end')
-          expect(cop.messages).to be_empty
+          expect_no_offenses('unless cond; foo else nil end')
         end
       end
 
       context 'with an else-clause with side-effects' do
         it "doesn't register an offense" do
-          inspect_source(cop, 'unless cond; foo else bar; nil end')
-          expect(cop.messages).to be_empty
+          expect_no_offenses('unless cond; foo else bar; nil end')
         end
       end
 
@@ -531,29 +488,25 @@ describe RuboCop::Cop::Style::MissingElse do
     context 'given a case statement' do
       context 'with a completely empty else-clause' do
         it "doesn't register an offense" do
-          inspect_source(cop, 'case v; when a; foo else end')
-          expect(cop.messages).to be_empty
+          expect_no_offenses('case v; when a; foo else end')
         end
       end
 
       context 'with an else-clause containing only the literal nil' do
         it "doesn't register an offense" do
-          inspect_source(cop, 'case v; when a; foo; when b; bar; else nil end')
-          expect(cop.messages).to be_empty
+          expect_no_offenses('case v; when a; foo; when b; bar; else nil end')
         end
       end
 
       context 'with an else-clause with side-effects' do
         it "doesn't register an offense" do
-          inspect_source(cop, 'case v; when a; foo; else b; nil end')
-          expect(cop.messages).to be_empty
+          expect_no_offenses('case v; when a; foo; else b; nil end')
         end
       end
 
       context 'with no else-clause' do
         it "doesn't register an offense" do
-          inspect_source(cop, 'case v; when a; foo; when b; bar; end')
-          expect(cop.messages).to be_empty
+          expect_no_offenses('case v; when a; foo; when b; bar; end')
         end
       end
     end
@@ -578,29 +531,25 @@ describe RuboCop::Cop::Style::MissingElse do
     context 'given an if-statement' do
       context 'with a completely empty else-clause' do
         it "doesn't register an offense" do
-          inspect_source(cop, 'if a; foo else end')
-          expect(cop.messages).to be_empty
+          expect_no_offenses('if a; foo else end')
         end
       end
 
       context 'with an else-clause containing only the literal nil' do
         it "doesn't register an offense" do
-          inspect_source(cop, 'if a; foo elsif b; bar else nil end')
-          expect(cop.messages).to be_empty
+          expect_no_offenses('if a; foo elsif b; bar else nil end')
         end
       end
 
       context 'with an else-clause with side-effects' do
         it "doesn't register an offense" do
-          inspect_source(cop, 'if cond; foo else bar; nil end')
-          expect(cop.messages).to be_empty
+          expect_no_offenses('if cond; foo else bar; nil end')
         end
       end
 
       context 'with no else-clause' do
         it "doesn't register an offense" do
-          inspect_source(cop, 'if cond; foo end')
-          expect(cop.messages).to be_empty
+          expect_no_offenses('if cond; foo end')
         end
       end
     end
@@ -608,29 +557,25 @@ describe RuboCop::Cop::Style::MissingElse do
     context 'given an unless-statement' do
       context 'with a completely empty else-clause' do
         it "doesn't register an offense" do
-          inspect_source(cop, 'unless cond; foo else end')
-          expect(cop.messages).to be_empty
+          expect_no_offenses('unless cond; foo else end')
         end
       end
 
       context 'with an else-clause containing only the literal nil' do
         it "doesn't register an offense" do
-          inspect_source(cop, 'unless cond; foo else nil end')
-          expect(cop.messages).to be_empty
+          expect_no_offenses('unless cond; foo else nil end')
         end
       end
 
       context 'with an else-clause with side-effects' do
         it "doesn't register an offense" do
-          inspect_source(cop, 'unless cond; foo else bar; nil end')
-          expect(cop.messages).to be_empty
+          expect_no_offenses('unless cond; foo else bar; nil end')
         end
       end
 
       context 'with no else-clause' do
         it "doesn't register an offense" do
-          inspect_source(cop, 'unless cond; foo end')
-          expect(cop.messages).to be_empty
+          expect_no_offenses('unless cond; foo end')
         end
       end
     end
@@ -638,22 +583,19 @@ describe RuboCop::Cop::Style::MissingElse do
     context 'given a case statement' do
       context 'with a completely empty else-clause' do
         it "doesn't register an offense" do
-          inspect_source(cop, 'case v; when a; foo else end')
-          expect(cop.messages).to be_empty
+          expect_no_offenses('case v; when a; foo else end')
         end
       end
 
       context 'with an else-clause containing only the literal nil' do
         it "doesn't register an offense" do
-          inspect_source(cop, 'case v; when a; foo; when b; bar; else nil end')
-          expect(cop.messages).to be_empty
+          expect_no_offenses('case v; when a; foo; when b; bar; else nil end')
         end
       end
 
       context 'with an else-clause with side-effects' do
         it "doesn't register an offense" do
-          inspect_source(cop, 'case v; when a; foo; else b; nil end')
-          expect(cop.messages).to be_empty
+          expect_no_offenses('case v; when a; foo; else b; nil end')
         end
       end
 

--- a/spec/rubocop/cop/style/multiline_block_chain_spec.rb
+++ b/spec/rubocop/cop/style/multiline_block_chain_spec.rb
@@ -52,11 +52,11 @@ describe RuboCop::Cop::Style::MultilineBlockChain do
     end
 
     it 'accepts a chain where the first block is single-line' do
-      inspect_source(cop,
-                     ['Thread.list.find_all { |t| t.alive? }.map { |t| ',
-                      '  t.object_id',
-                      '}'])
-      expect(cop.offenses).to be_empty
+      expect_no_offenses(<<-RUBY.strip_indent)
+        Thread.list.find_all { |t| t.alive? }.map { |t|
+          t.object_id
+        }
+      RUBY
     end
   end
 

--- a/spec/rubocop/cop/style/negated_while_spec.rb
+++ b/spec/rubocop/cop/style/negated_while_spec.rb
@@ -40,7 +40,7 @@ describe RuboCop::Cop::Style::NegatedWhile do
   end
 
   it 'accepts a while where only part of the condition is negated' do
-    inspect_source(cop, <<-END.strip_indent)
+    expect_no_offenses(<<-RUBY.strip_indent)
       while !a_condition && another_condition
         some_method
       end
@@ -48,18 +48,16 @@ describe RuboCop::Cop::Style::NegatedWhile do
         some_method
       end
       some_method while not a_condition or other_cond
-    END
-    expect(cop.messages).to be_empty
+    RUBY
   end
 
   it 'accepts a while where the condition is doubly negated' do
-    inspect_source(cop, <<-END.strip_indent)
+    expect_no_offenses(<<-RUBY.strip_indent)
       while !!a_condition
         some_method
       end
       some_method while !!a_condition
-    END
-    expect(cop.messages).to be_empty
+    RUBY
   end
 
   it 'autocorrects by replacing while not with until' do

--- a/spec/rubocop/cop/style/numeric_literal_prefix_spec.rb
+++ b/spec/rubocop/cop/style/numeric_literal_prefix_spec.rb
@@ -22,11 +22,10 @@ describe RuboCop::Cop::Style::NumericLiteralPrefix, :config do
       end
 
       it 'does not register offense for lowercase prefix' do
-        inspect_source(cop, <<-END.strip_indent)
+        expect_no_offenses(<<-RUBY.strip_indent)
           a = 0o101
           b = 0o567
-        END
-        expect(cop.messages).to be_empty
+        RUBY
       end
 
       it 'autocorrects an octal literal starting with 0' do
@@ -58,8 +57,7 @@ describe RuboCop::Cop::Style::NumericLiteralPrefix, :config do
       end
 
       it 'does not register offense for prefix `0`' do
-        inspect_source(cop, 'b = 0567')
-        expect(cop.messages).to be_empty
+        expect_no_offenses('b = 0567')
       end
 
       it 'autocorrects an octal literal starting with 0O or 0o' do
@@ -93,8 +91,7 @@ describe RuboCop::Cop::Style::NumericLiteralPrefix, :config do
     end
 
     it 'does not register offense for lowercase prefix' do
-      inspect_source(cop, 'a = 0x101')
-      expect(cop.messages).to be_empty
+      expect_no_offenses('a = 0x101')
     end
 
     it 'autocorrects literals with uppercase prefix' do
@@ -115,8 +112,7 @@ describe RuboCop::Cop::Style::NumericLiteralPrefix, :config do
     end
 
     it 'does not register offense for lowercase prefix' do
-      inspect_source(cop, 'a = 0b101')
-      expect(cop.messages).to be_empty
+      expect_no_offenses('a = 0b101')
     end
 
     it 'autocorrects literals with uppercase prefix' do
@@ -138,8 +134,7 @@ describe RuboCop::Cop::Style::NumericLiteralPrefix, :config do
     end
 
     it 'does not register offense for no prefix' do
-      inspect_source(cop, 'a = 101')
-      expect(cop.messages).to be_empty
+      expect_no_offenses('a = 101')
     end
 
     it 'autocorrects literals with prefix' do

--- a/spec/rubocop/cop/style/numeric_literals_spec.rb
+++ b/spec/rubocop/cop/style/numeric_literals_spec.rb
@@ -33,29 +33,25 @@ describe RuboCop::Cop::Style::NumericLiterals, :config do
   end
 
   it 'accepts long numbers with underscore' do
-    inspect_source(cop, <<-END.strip_indent)
+    expect_no_offenses(<<-RUBY.strip_indent)
       a = 123_456
       b = 123_456.55
-    END
-    expect(cop.messages).to be_empty
+    RUBY
   end
 
   it 'accepts a short integer without underscore' do
-    inspect_source(cop, 'a = 123')
-    expect(cop.messages).to be_empty
+    expect_no_offenses('a = 123')
   end
 
   it 'does not count a leading minus sign as a digit' do
-    inspect_source(cop, 'a = -1230')
-    expect(cop.messages).to be_empty
+    expect_no_offenses('a = -1230')
   end
 
   it 'accepts short numbers without underscore' do
-    inspect_source(cop, <<-END.strip_indent)
+    expect_no_offenses(<<-RUBY.strip_indent)
       a = 123
       b = 123.456
-    END
-    expect(cop.messages).to be_empty
+    RUBY
   end
 
   it 'ignores non-decimal literals' do

--- a/spec/rubocop/cop/style/option_hash_spec.rb
+++ b/spec/rubocop/cop/style/option_hash_spec.rb
@@ -31,8 +31,12 @@ describe RuboCop::Cop::Style::OptionHash, :config do
     end
 
     it 'does not register an offense' do
-      inspect_source(cop, source)
-      expect(cop.offenses).to be_empty
+      expect_no_offenses(<<-RUBY.strip_indent)
+        def steep(flavor, duration, config={})
+          mug = config.fetch(:mug)
+          prep(flavor, duration, mug)
+        end
+      RUBY
     end
 
     it 'registers an offense when in SuspiciousParamNames list' do

--- a/spec/rubocop/cop/style/optional_arguments_spec.rb
+++ b/spec/rubocop/cop/style/optional_arguments_spec.rb
@@ -27,68 +27,54 @@ describe RuboCop::Cop::Style::OptionalArguments do
   end
 
   it 'allows methods without arguments' do
-    inspect_source(cop, <<-END.strip_indent)
+    expect_no_offenses(<<-RUBY.strip_indent)
       def foo
       end
-    END
-
-    expect(cop.messages).to be_empty
+    RUBY
   end
 
   it 'allows methods with only one required argument' do
-    inspect_source(cop, <<-END.strip_indent)
+    expect_no_offenses(<<-RUBY.strip_indent)
       def foo(a)
       end
-    END
-
-    expect(cop.messages).to be_empty
+    RUBY
   end
 
   it 'allows methods with only required arguments' do
-    inspect_source(cop, <<-END.strip_indent)
+    expect_no_offenses(<<-RUBY.strip_indent)
       def foo(a, b, c)
       end
-    END
-
-    expect(cop.messages).to be_empty
+    RUBY
   end
 
   it 'allows methods with only one optional argument' do
-    inspect_source(cop, <<-END.strip_indent)
+    expect_no_offenses(<<-RUBY.strip_indent)
       def foo(a = 1)
       end
-    END
-
-    expect(cop.messages).to be_empty
+    RUBY
   end
 
   it 'allows methods with only optional arguments' do
-    inspect_source(cop, <<-END.strip_indent)
+    expect_no_offenses(<<-RUBY.strip_indent)
       def foo(a = 1, b = 2, c = 3)
       end
-    END
-
-    expect(cop.messages).to be_empty
+    RUBY
   end
 
   it 'allows methods with multiple optional arguments at the end' do
-    inspect_source(cop, <<-END.strip_indent)
+    expect_no_offenses(<<-RUBY.strip_indent)
       def foo(a, b = 2, c = 3)
       end
-    END
-
-    expect(cop.messages).to be_empty
+    RUBY
   end
 
   context 'named params' do
     context 'with default values', :ruby20 do
       it 'allows optional arguments before an optional named argument' do
-        inspect_source(cop, <<-END.strip_indent)
+        expect_no_offenses(<<-RUBY.strip_indent)
           def foo(a = 1, b: 2)
           end
-        END
-
-        expect(cop.messages).to be_empty
+        RUBY
       end
     end
 
@@ -105,12 +91,10 @@ describe RuboCop::Cop::Style::OptionalArguments do
       end
 
       it 'allows optional arguments before required named arguments' do
-        inspect_source(cop, <<-END.strip_indent)
+        expect_no_offenses(<<-RUBY.strip_indent)
           def foo(a = 1, b:)
           end
-        END
-
-        expect(cop.messages).to be_empty
+        RUBY
       end
 
       it 'allows optional arguments to come before a mix of required and ' \

--- a/spec/rubocop/cop/style/redundant_return_spec.rb
+++ b/spec/rubocop/cop/style/redundant_return_spec.rb
@@ -383,8 +383,8 @@ describe RuboCop::Cop::Style::RedundantReturn, :config do
   end
 
   context 'when case nodes are empty' do
-    let(:src) do
-      <<-END.strip_indent
+    it 'accepts empty when nodes' do
+      expect_no_offenses(<<-RUBY.strip_indent)
         def func
           case x
           when y then 1
@@ -393,12 +393,7 @@ describe RuboCop::Cop::Style::RedundantReturn, :config do
             3
           end
         end
-      END
-    end
-
-    it 'accepts empty when nodes' do
-      inspect_source(cop, src)
-      expect(cop.offenses).to be_empty
+      RUBY
     end
   end
 end

--- a/spec/rubocop/cop/style/symbol_literal_spec.rb
+++ b/spec/rubocop/cop/style/symbol_literal_spec.rb
@@ -11,18 +11,15 @@ describe RuboCop::Cop::Style::SymbolLiteral do
   end
 
   it 'accepts string syntax when symbols have whitespaces in them' do
-    inspect_source(cop, 'x = { :"t o" => 0 }')
-    expect(cop.messages).to be_empty
+    expect_no_offenses('x = { :"t o" => 0 }')
   end
 
   it 'accepts string syntax when symbols have special chars in them' do
-    inspect_source(cop, 'x = { :"\tab" => 1 }')
-    expect(cop.messages).to be_empty
+    expect_no_offenses('x = { :"\\tab" => 1 }')
   end
 
   it 'accepts string syntax when symbol start with a digit' do
-    inspect_source(cop, 'x = { :"1" => 1 }')
-    expect(cop.messages).to be_empty
+    expect_no_offenses('x = { :"1" => 1 }')
   end
 
   it 'auto-corrects by removing quotes' do

--- a/spec/rubocop/cop/style/trailing_comma_in_arguments_spec.rb
+++ b/spec/rubocop/cop/style/trailing_comma_in_arguments_spec.rb
@@ -205,16 +205,10 @@ describe RuboCop::Cop::Style::TrailingCommaInArguments, :config do
       end
 
       it 'accepts an empty hash being passed as a method argument' do
-        inspect_source(cop, 'Foo.new({})')
-        inspect_source(cop, <<-END.strip_indent)
-          Foo.new({
-                   })
-        END
-        inspect_source(cop, <<-END.strip_indent)
+        expect_no_offenses(<<-RUBY.strip_indent)
           Foo.new([
                    ])
-        END
-        expect(cop.offenses).to be_empty
+        RUBY
       end
 
       it 'auto-corrects missing comma in a method call with hash parameters' \

--- a/spec/rubocop/cop/style/trailing_comma_in_literal_spec.rb
+++ b/spec/rubocop/cop/style/trailing_comma_in_literal_spec.rb
@@ -137,11 +137,12 @@ describe RuboCop::Cop::Style::TrailingCommaInLiteral, :config do
       end
 
       it 'accepts comma in comment after last value item' do
-        inspect_source(cop, ['{ ',
-                             "  foo: 'foo',",
-                             "  bar: 'bar'.delete(',')#,",
-                             '}'])
-        expect(cop.offenses).to be_empty
+        expect_no_offenses(<<-RUBY.strip_indent)
+          {
+            foo: 'foo',
+            bar: 'bar'.delete(',')#,
+          }
+        RUBY
       end
 
       it 'auto-corrects unwanted comma in an Array literal' do
@@ -284,16 +285,10 @@ describe RuboCop::Cop::Style::TrailingCommaInLiteral, :config do
       end
 
       it 'accepts an empty hash being passed as a method argument' do
-        inspect_source(cop, 'Foo.new({})')
-        inspect_source(cop, <<-END.strip_indent)
-          Foo.new({
-                   })
-        END
-        inspect_source(cop, <<-END.strip_indent)
+        expect_no_offenses(<<-RUBY.strip_indent)
           Foo.new([
                    ])
-        END
-        expect(cop.offenses).to be_empty
+        RUBY
       end
 
       it 'auto-corrects an Array literal with two of the values on the same' \

--- a/spec/rubocop/cop/style/trivial_accessors_spec.rb
+++ b/spec/rubocop/cop/style/trivial_accessors_spec.rb
@@ -161,12 +161,11 @@ describe RuboCop::Cop::Style::TrivialAccessors, :config do
   end
 
   it 'accepts an initialize method looking like a writer' do
-    inspect_source(cop, <<-END.strip_margin('|'))
-      | def initialize(value)
-      |   @top = value
-      | end
-    END
-    expect(cop.offenses).to be_empty
+    expect_no_offenses(<<-RUBY.strip_indent)
+       def initialize(value)
+         @top = value
+       end
+    RUBY
   end
 
   it 'accepts reader with different ivar name' do
@@ -316,21 +315,19 @@ describe RuboCop::Cop::Style::TrivialAccessors, :config do
     let(:cop_config) { { 'Whitelist' => ['to_foo', 'bar='] } }
 
     it 'accepts whitelisted reader' do
-      inspect_source(cop, <<-END.strip_margin('|'))
-        | def to_foo
-        |   @foo
-        | end
-      END
-      expect(cop.offenses).to be_empty
+      expect_no_offenses(<<-RUBY.strip_indent)
+         def to_foo
+           @foo
+         end
+      RUBY
     end
 
     it 'accepts whitelisted writer' do
-      inspect_source(cop, <<-END.strip_margin('|'))
-        | def bar=(bar)
-        |   @bar = bar
-        | end
-      END
-      expect(cop.offenses).to be_empty
+      expect_no_offenses(<<-RUBY.strip_indent)
+         def bar=(bar)
+           @bar = bar
+         end
+      RUBY
     end
 
     context 'with AllowPredicates: false' do
@@ -340,12 +337,11 @@ describe RuboCop::Cop::Style::TrivialAccessors, :config do
       end
 
       it 'accepts whitelisted predicate' do
-        inspect_source(cop, <<-END.strip_margin('|'))
-          | def foo?
-          |   @foo
-          | end
-        END
-        expect(cop.offenses).to be_empty
+        expect_no_offenses(<<-RUBY.strip_indent)
+           def foo?
+             @foo
+           end
+        RUBY
       end
     end
   end

--- a/spec/rubocop/cop/style/unneeded_percent_q_spec.rb
+++ b/spec/rubocop/cop/style/unneeded_percent_q_spec.rb
@@ -26,9 +26,7 @@ describe RuboCop::Cop::Style::UnneededPercentQ do
     end
 
     it 'accepts a string with single quotes and double quotes' do
-      inspect_source(cop, %q(%q('"hi"')))
-
-      expect(cop.messages).to be_empty
+      expect_no_offenses("%q('\"hi\"')")
     end
 
     it 'registers an offfense for a string containing escaped backslashes' do
@@ -38,21 +36,15 @@ describe RuboCop::Cop::Style::UnneededPercentQ do
     end
 
     it 'accepts a string with escaped non-backslash characters' do
-      inspect_source(cop, "%q(\\'foo\\')")
-
-      expect(cop.messages).to be_empty
+      expect_no_offenses("%q(\\'foo\\')")
     end
 
     it 'accepts a string with escaped backslash and non-backslash characters' do
-      inspect_source(cop, "%q(\\\\ \\'foo\\' \\\\)") # This is \\ \'foo\' \\
-
-      expect(cop.messages).to be_empty
+      expect_no_offenses("%q(\\\\ \\'foo\\' \\\\)")
     end
 
     it 'accepts regular expressions starting with %q' do
-      inspect_source(cop, '/%q?/')
-
-      expect(cop.messages).to be_empty
+      expect_no_offenses('/%q?/')
     end
 
     context 'auto-correct' do
@@ -99,33 +91,23 @@ describe RuboCop::Cop::Style::UnneededPercentQ do
     end
 
     it 'accepts a string with single quotes and double quotes' do
-      inspect_source(cop, %q(%Q('"hi"')))
-
-      expect(cop.messages).to be_empty
+      expect_no_offenses("%Q('\"hi\"')")
     end
 
     it 'accepts a string with double quotes and an escaped special character' do
-      inspect_source(cop, '%Q("\\thi")')
-
-      expect(cop.messages).to be_empty
+      expect_no_offenses('%Q("\\thi")')
     end
 
     it 'accepts a string with double quotes and an escaped normal character' do
-      inspect_source(cop, '%Q("\\!thi")')
-
-      expect(cop.messages).to be_empty
+      expect_no_offenses('%Q("\\!thi")')
     end
 
     it 'accepts a dynamic %Q string with double quotes' do
-      inspect_source(cop, '%Q("hi#{4}")')
-
-      expect(cop.messages).to be_empty
+      expect_no_offenses("%Q(\"hi\#{4}\")")
     end
 
     it 'accepts regular expressions starting with %Q' do
-      inspect_source(cop, '/%Q?/')
-
-      expect(cop.messages).to be_empty
+      expect_no_offenses('/%Q?/')
     end
 
     context 'auto-correct' do
@@ -186,8 +168,6 @@ describe RuboCop::Cop::Style::UnneededPercentQ do
   end
 
   it 'accepts %q containing string interpolation' do
-    inspect_source(cop, %(%q(foo \#{'bar'} baz)))
-
-    expect(cop.messages).to be_empty
+    expect_no_offenses("%q(foo \#{'bar'} baz)")
   end
 end

--- a/spec/rubocop/cop/style/unneeded_percent_q_spec.rb
+++ b/spec/rubocop/cop/style/unneeded_percent_q_spec.rb
@@ -132,11 +132,12 @@ describe RuboCop::Cop::Style::UnneededPercentQ do
   end
 
   it 'accepts a heredoc string that contains %q' do
-    inspect_source(cop, ['  s = <<END',
-                         "%q('hi') # line 1",
-                         '%q("hi")',
-                         'END'])
-    expect(cop.offenses).to be_empty
+    expect_no_offenses(<<-RUBY.strip_indent)
+        s = <<END
+      %q('hi') # line 1
+      %q("hi")
+      END
+    RUBY
   end
 
   it 'accepts %q at the beginning of a double quoted string ' \


### PR DESCRIPTION
This bulk update rewrites specs that match the following formats:

```ruby
it '...' do
  inspect_source(cop, ...)
  expect(cop.offenses).to be_empty
end
```

```ruby
it '...' do
  inspect_source(cop, ...)
  expect(cop.messages).to be_empty
end
```