### PR TITLE
Refactor specs to use `expect_no_offenses`

### DIFF
--- a/spec/rubocop/cop/bundler/duplicated_gem_spec.rb
+++ b/spec/rubocop/cop/bundler/duplicated_gem_spec.rb
@@ -5,15 +5,12 @@ describe RuboCop::Cop::Bundler::DuplicatedGem, :config do
   subject(:cop) { described_class.new(config) }
 
   context 'when investigating Ruby files' do
-    let(:source) { <<-END }
-      # cop will not read these contents
-      gem('rubocop')
-      gem('rubocop')
-    END
-
     it 'does not register any offenses' do
-      inspect_source_file(cop, source)
-      expect(cop.offenses).to be_empty
+      expect_no_offenses(<<-RUBY.strip_indent)
+        # cop will not read these contents
+        gem('rubocop')
+        gem('rubocop')
+      RUBY
     end
   end
 
@@ -31,14 +28,11 @@ describe RuboCop::Cop::Bundler::DuplicatedGem, :config do
     end
 
     context 'and no duplicate gems are present' do
-      let(:source) { <<-GEM }
-        gem 'rubocop'
-        gem 'flog'
-      GEM
-
       it 'does not register any offenses' do
-        inspect_gemfile(cop, source)
-        expect(cop.offenses).to be_empty
+        expect_no_offenses(<<-RUBY.strip_indent, 'Gemfile')
+          gem 'rubocop'
+          gem 'flog'
+        RUBY
       end
     end
 

--- a/spec/rubocop/cop/bundler/ordered_gems_spec.rb
+++ b/spec/rubocop/cop/bundler/ordered_gems_spec.rb
@@ -85,13 +85,8 @@ describe RuboCop::Cop::Bundler::OrderedGems, :config do
   end
 
   context 'When the gemfile is empty' do
-    let(:source) { <<-END.strip_indent }
-      # Gemfile
-    END
-
     it 'does not register any offenses' do
-      inspect_source(cop, source)
-      expect(cop.offenses.size).to eq(0)
+      expect_no_offenses('# Gemfile')
     end
   end
 

--- a/spec/rubocop/cop/layout/align_parameters_spec.rb
+++ b/spec/rubocop/cop/layout/align_parameters_spec.rb
@@ -126,10 +126,10 @@ describe RuboCop::Cop::Layout::AlignParameters do
 
     it 'accepts the first parameter being on a new row' do
       expect_no_offenses(<<-RUBY.strip_indent)
-          match(
-            a,
-            b
-          )
+        match(
+          a,
+          b
+        )
       RUBY
     end
 
@@ -159,21 +159,19 @@ describe RuboCop::Cop::Layout::AlignParameters do
 
     it 'can handle do-end' do
       expect_no_offenses(<<-RUBY.strip_indent)
-              run(lambda do |e|
-                w = e['warden']
-              end)
+        run(lambda do |e|
+          w = e['warden']
+        end)
       RUBY
     end
 
     it 'can handle a call with a block inside another call' do
-      src = <<-'END'.strip_indent
+      expect_no_offenses(<<-'RUBY'.strip_indent)
         new(table_name,
             exec_query("info('#{row['name']}')").map { |col|
               col['name']
             })
-      END
-      inspect_source(cop, src)
-      expect(cop.offenses).to be_empty
+      RUBY
     end
 
     it 'can handle a ternary condition with a block reference' do
@@ -197,9 +195,9 @@ describe RuboCop::Cop::Layout::AlignParameters do
     end
 
     it 'can handle other method calls without parentheses' do
-      src = 'chars(Unicode.apply_mapping @wrapped_string, :uppercase)'
-      inspect_source(cop, src)
-      expect(cop.offenses).to be_empty
+      expect_no_offenses(<<-RUBY.strip_indent)
+        chars(Unicode.apply_mapping @wrapped_string, :uppercase)
+      RUBY
     end
 
     it "doesn't crash and burn when there are nested issues" do

--- a/spec/rubocop/cop/layout/case_indentation_spec.rb
+++ b/spec/rubocop/cop/layout/case_indentation_spec.rb
@@ -194,7 +194,7 @@ describe RuboCop::Cop::Layout::CaseIndentation do
       end
 
       it "accepts a when clause that's equally indented with case" do
-        source = <<-END.strip_indent
+        expect_no_offenses(<<-RUBY.strip_indent)
           y = case a
               when 0 then break
               when 0 then return
@@ -207,24 +207,20 @@ describe RuboCop::Cop::Layout::CaseIndentation do
           case c
           when 2 then encoding
           end
-        END
-        inspect_source(cop, source)
-        expect(cop.offenses).to be_empty
+        RUBY
       end
 
       it "doesn't get confused by strings with case in them" do
-        source = <<-END.strip_indent
+        expect_no_offenses(<<-RUBY.strip_indent)
           a = "case"
           case x
           when 0
           end
-        END
-        inspect_source(cop, source)
-        expect(cop.messages).to be_empty
+        RUBY
       end
 
       it "doesn't get confused by symbols named case or when" do
-        source = <<-END.strip_indent
+        expect_no_offenses(<<-RUBY.strip_indent)
           KEYWORDS = { :case => true, :when => true }
           case type
           when 0
@@ -232,13 +228,11 @@ describe RuboCop::Cop::Layout::CaseIndentation do
           when 1
             MethodCallNode
           end
-        END
-        inspect_source(cop, source)
-        expect(cop.messages).to be_empty
+        RUBY
       end
 
       it 'accepts correctly indented whens in complex combinations' do
-        source = <<-END.strip_indent
+        expect_no_offenses(<<-RUBY.strip_indent)
           each {
             case state
             when 0
@@ -256,9 +250,7 @@ describe RuboCop::Cop::Layout::CaseIndentation do
           case s
           when Array
           end
-        END
-        inspect_source(cop, source)
-        expect(cop.messages).to be_empty
+        RUBY
       end
     end
 
@@ -328,7 +320,7 @@ describe RuboCop::Cop::Layout::CaseIndentation do
       end
 
       it "accepts a when clause that's 2 spaces deeper than case" do
-        source = <<-END.strip_indent
+        expect_no_offenses(<<-RUBY.strip_indent)
           case a
             when 0 then return
             else
@@ -336,9 +328,7 @@ describe RuboCop::Cop::Layout::CaseIndentation do
                     when 1 then return
                   end
           end
-        END
-        inspect_source(cop, source)
-        expect(cop.offenses).to be_empty
+        RUBY
       end
 
       context "a when clause that's equally indented with case" do

--- a/spec/rubocop/cop/layout/comment_indentation_spec.rb
+++ b/spec/rubocop/cop/layout/comment_indentation_spec.rb
@@ -68,7 +68,7 @@ describe RuboCop::Cop::Layout::CommentIndentation do
 
   context 'around program structure keywords' do
     it 'accepts correctly indented comments' do
-      inspect_source(cop, <<-END.strip_indent)
+      expect_no_offenses(<<-RUBY.strip_indent)
         #
         def m
           #
@@ -95,8 +95,7 @@ describe RuboCop::Cop::Layout::CommentIndentation do
           #
         end
         #
-      END
-      expect(cop.offenses).to eq([])
+      RUBY
     end
 
     context 'with a blank line following the comment' do
@@ -113,7 +112,7 @@ describe RuboCop::Cop::Layout::CommentIndentation do
 
   context 'near various kinds of brackets' do
     it 'accepts correctly indented comments' do
-      inspect_source(cop, <<-END.strip_indent)
+      expect_no_offenses(<<-RUBY.strip_indent)
         #
         a = {
           #
@@ -129,8 +128,7 @@ describe RuboCop::Cop::Layout::CommentIndentation do
           #
         }
         #
-      END
-      expect(cop.offenses).to eq([])
+      RUBY
     end
 
     it 'is unaffected by closing bracket that does not begin a line' do

--- a/spec/rubocop/cop/layout/empty_line_between_defs_spec.rb
+++ b/spec/rubocop/cop/layout/empty_line_between_defs_spec.rb
@@ -71,7 +71,7 @@ describe RuboCop::Cop::Layout::EmptyLineBetweenDefs, :config do
 
   context 'conditional method definitions' do
     it 'accepts defs inside a conditional without blank lines in between' do
-      source = <<-END.strip_indent
+      expect_no_offenses(<<-RUBY.strip_indent)
         if condition
           def foo
             true
@@ -81,9 +81,7 @@ describe RuboCop::Cop::Layout::EmptyLineBetweenDefs, :config do
             false
           end
         end
-      END
-      inspect_source(cop, source)
-      expect(cop.offenses).to be_empty
+      RUBY
     end
 
     it 'registers an offense for consecutive defs inside a conditional' do
@@ -199,41 +197,35 @@ describe RuboCop::Cop::Layout::EmptyLineBetweenDefs, :config do
   # Only one def, so rule about empty line *between* defs does not
   # apply.
   it 'accepts a def that follows a line with code' do
-    source = <<-END.strip_indent
+    expect_no_offenses(<<-RUBY.strip_indent)
       x = 0
       def m
       end
-    END
-    inspect_source(cop, source)
-    expect(cop.offenses).to be_empty
+    RUBY
   end
 
   # Only one def, so rule about empty line *between* defs does not
   # apply.
   it 'accepts a def that follows code and a comment' do
-    source = <<-END.strip_indent
+    expect_no_offenses(<<-RUBY.strip_indent)
       x = 0
       # 123
       def m
       end
-    END
-    inspect_source(cop, source)
-    expect(cop.offenses).to be_empty
+    RUBY
   end
 
   it 'accepts the first def without leading empty line in a class' do
-    source = <<-END.strip_indent
+    expect_no_offenses(<<-RUBY.strip_indent)
       class K
         def m
         end
       end
-    END
-    inspect_source(cop, source)
-    expect(cop.offenses).to be_empty
+    RUBY
   end
 
   it 'accepts a def that follows an empty line and then a comment' do
-    source = <<-END.strip_indent
+    expect_no_offenses(<<-RUBY.strip_indent)
       class A
         # calculates value
         def m
@@ -244,35 +236,29 @@ describe RuboCop::Cop::Layout::EmptyLineBetweenDefs, :config do
         def n
         end
       end
-    END
-    inspect_source(cop, source)
-    expect(cop.offenses).to be_empty
+    RUBY
   end
 
   it 'accepts a def that is the first of a module' do
-    source = <<-END.strip_indent
+    expect_no_offenses(<<-RUBY.strip_indent)
       module Util
         public
         #
         def html_escape(s)
         end
       end
-    END
-    inspect_source(cop, source)
-    expect(cop.messages).to be_empty
+    RUBY
   end
 
   it 'accepts a nested def' do
-    source = <<-END.strip_indent
+    expect_no_offenses(<<-RUBY.strip_indent)
       def mock_model(*attributes)
         Class.new do
           def initialize(attrs)
           end
         end
       end
-    END
-    inspect_source(cop, source)
-    expect(cop.messages).to be_empty
+    RUBY
   end
 
   it 'registers an offense for adjacent one-liners by default' do
@@ -312,7 +298,7 @@ describe RuboCop::Cop::Layout::EmptyLineBetweenDefs, :config do
   end
 
   it 'treats lines with whitespaces as blank' do
-    source = <<-END.strip_indent
+    expect_no_offenses(<<-RUBY.strip_indent)
       class J
         def n
         end
@@ -320,9 +306,7 @@ describe RuboCop::Cop::Layout::EmptyLineBetweenDefs, :config do
         def o
         end
       end
-    END
-    inspect_source(cop, source)
-    expect(cop.offenses).to be_empty
+    RUBY
   end
 
   it "doesn't allow more than the required number of newlines" do
@@ -344,12 +328,10 @@ describe RuboCop::Cop::Layout::EmptyLineBetweenDefs, :config do
     let(:cop_config) { { 'AllowAdjacentOneLineDefs' => true } }
 
     it 'accepts adjacent one-liners' do
-      source = <<-END.strip_indent
+      expect_no_offenses(<<-RUBY.strip_indent)
         def a; end
         def b; end
-      END
-      inspect_source(cop, source)
-      expect(cop.offenses).to be_empty
+      RUBY
     end
 
     it 'registers an offense for adjacent defs if some are multi-line' do
@@ -369,26 +351,22 @@ describe RuboCop::Cop::Layout::EmptyLineBetweenDefs, :config do
     let(:cop_config) { { 'NumberOfEmptyLines' => [0, 1] } }
 
     it 'finds no offense for no empty line' do
-      source = <<-END.strip_indent
+      expect_no_offenses(<<-RUBY.strip_indent)
         def n
         end
         def o
         end
-      END
-      inspect_source(cop, source)
-      expect(cop.offenses).to be_empty
+      RUBY
     end
 
     it 'finds no offense for one empty line' do
-      source = <<-END.strip_indent
+      expect_no_offenses(<<-RUBY.strip_indent)
         def n
         end
 
         def o
          end
-      END
-      inspect_source(cop, source)
-      expect(cop.offenses).to be_empty
+      RUBY
     end
 
     it 'finds an  offense for two empty lines' do

--- a/spec/rubocop/cop/layout/empty_lines_around_class_body_spec.rb
+++ b/spec/rubocop/cop/layout/empty_lines_around_class_body_spec.rb
@@ -154,7 +154,7 @@ describe RuboCop::Cop::Layout::EmptyLinesAroundClassBody, :config do
 
     context 'when only child is class' do
       it 'requires no empty lines for namespace' do
-        inspect_source(cop, <<-END.strip_indent)
+        expect_no_offenses(<<-RUBY.strip_indent)
           class Parent < Base
             class Child
 
@@ -162,8 +162,7 @@ describe RuboCop::Cop::Layout::EmptyLinesAroundClassBody, :config do
 
             end
           end
-        END
-        expect(cop.messages).to eq([])
+        RUBY
       end
 
       it 'registers offence for namespace body starting with a blank' do
@@ -244,14 +243,13 @@ describe RuboCop::Cop::Layout::EmptyLinesAroundClassBody, :config do
 
     context 'when only child is module' do
       it 'requires no empty lines for namespace' do
-        inspect_source(cop, <<-END.strip_indent)
+        expect_no_offenses(<<-RUBY.strip_indent)
           class Parent
             module Child
               do_something
             end
           end
-        END
-        expect(cop.messages).to eq([])
+        RUBY
       end
 
       it 'registers offence for namespace body starting with a blank' do
@@ -281,7 +279,7 @@ describe RuboCop::Cop::Layout::EmptyLinesAroundClassBody, :config do
 
     context 'when has multiple child classes' do
       it 'requires empty lines for namespace' do
-        inspect_source(cop, <<-END.strip_indent)
+        expect_no_offenses(<<-RUBY.strip_indent)
           class Parent
 
             class Mom
@@ -294,8 +292,7 @@ describe RuboCop::Cop::Layout::EmptyLinesAroundClassBody, :config do
             end
 
           end
-        END
-        expect(cop.messages).to eq([])
+        RUBY
       end
 
       it 'registers offences for namespace body starting '\

--- a/spec/rubocop/cop/layout/empty_lines_around_method_body_spec.rb
+++ b/spec/rubocop/cop/layout/empty_lines_around_method_body_spec.rb
@@ -19,12 +19,12 @@ describe RuboCop::Cop::Layout::EmptyLinesAroundMethodBody do
   # two cops registering offense for the line with only spaces would cause
   # havoc in auto-correction.
   it 'accepts method body starting with a line with spaces' do
-    inspect_source(cop,
-                   ['def some_method',
-                    '  ',
-                    '  do_something',
-                    'end'])
-    expect(cop.offenses).to be_empty
+    expect_no_offenses([
+                         'def some_method',
+                         '  ',
+                         '  do_something',
+                         'end'
+                       ])
   end
 
   it 'autocorrects method body starting with a blank' do

--- a/spec/rubocop/cop/layout/empty_lines_around_module_body_spec.rb
+++ b/spec/rubocop/cop/layout/empty_lines_around_module_body_spec.rb
@@ -102,7 +102,7 @@ describe RuboCop::Cop::Layout::EmptyLinesAroundModuleBody, :config do
 
     context 'when only child is class' do
       it 'requires no empty lines for namespace' do
-        inspect_source(cop, <<-END.strip_indent)
+        expect_no_offenses(<<-RUBY.strip_indent)
           module Parent
             module Child
 
@@ -110,8 +110,7 @@ describe RuboCop::Cop::Layout::EmptyLinesAroundModuleBody, :config do
 
             end
           end
-        END
-        expect(cop.messages).to eq([])
+        RUBY
       end
 
       it 'registers offence for namespace body starting with a blank' do
@@ -192,14 +191,13 @@ describe RuboCop::Cop::Layout::EmptyLinesAroundModuleBody, :config do
 
     context 'when only child is class' do
       it 'requires no empty lines for namespace' do
-        inspect_source(cop, <<-END.strip_indent)
+        expect_no_offenses(<<-RUBY.strip_indent)
           module Parent
             class SomeClass
               do_something
             end
           end
-        END
-        expect(cop.messages).to eq([])
+        RUBY
       end
 
       it 'registers offence for namespace body starting with a blank' do
@@ -229,7 +227,7 @@ describe RuboCop::Cop::Layout::EmptyLinesAroundModuleBody, :config do
 
     context 'when has multiple child modules' do
       it 'requires empty lines for namespace' do
-        inspect_source(cop, <<-END.strip_indent)
+        expect_no_offenses(<<-RUBY.strip_indent)
           module Parent
 
             module Mom
@@ -242,8 +240,7 @@ describe RuboCop::Cop::Layout::EmptyLinesAroundModuleBody, :config do
             end
 
           end
-        END
-        expect(cop.messages).to eq([])
+        RUBY
       end
 
       it 'registers offences for namespace body starting '\

--- a/spec/rubocop/cop/layout/leading_comment_space_spec.rb
+++ b/spec/rubocop/cop/layout/leading_comment_space_spec.rb
@@ -43,11 +43,10 @@ describe RuboCop::Cop::Layout::LeadingCommentSpace do
 
   context 'file named config.ru' do
     it 'does not register an offense for #\ on first line' do
-      inspect_source(cop,
-                     ['#\ -w -p 8765',
-                      'test'],
-                     '/some/dir/config.ru')
-      expect(cop.offenses).to be_empty
+      expect_no_offenses(<<-RUBY.strip_indent)
+        #\ -w -p 8765
+        test
+      RUBY
     end
 
     it 'registers an offense for #\ after the first line' do

--- a/spec/rubocop/cop/layout/rescue_ensure_alignment_spec.rb
+++ b/spec/rubocop/cop/layout/rescue_ensure_alignment_spec.rb
@@ -121,15 +121,13 @@ describe RuboCop::Cop::Layout::RescueEnsureAlignment do
     subject(:cop) { described_class.new(config) }
 
     it 'processes excluded files with issue' do
-      inspect_source_file(cop, <<-END.strip_indent)
+      expect_no_offenses(<<-RUBY.strip_indent)
         begin
           foo
         rescue
           bar
         end
-      END
-
-      expect(cop.messages).to be_empty
+      RUBY
     end
   end
 end

--- a/spec/rubocop/cop/layout/space_around_operators_spec.rb
+++ b/spec/rubocop/cop/layout/space_around_operators_spec.rb
@@ -27,15 +27,11 @@ describe RuboCop::Cop::Layout::SpaceAroundOperators do
   end
 
   it 'accepts scope operator' do
-    source = '@io.class == Zlib::GzipWriter'
-    inspect_source(cop, source)
-    expect(cop.messages).to be_empty
+    expect_no_offenses('@io.class == Zlib::GzipWriter')
   end
 
   it 'accepts ::Kernel::raise' do
-    source = '::Kernel::raise IllegalBlockError.new'
-    inspect_source(cop, source)
-    expect(cop.messages).to be_empty
+    expect_no_offenses('::Kernel::raise IllegalBlockError.new')
   end
 
   it 'accepts exclamation point negation' do
@@ -46,13 +42,11 @@ describe RuboCop::Cop::Layout::SpaceAroundOperators do
   end
 
   it 'accepts exclamation point definition' do
-    inspect_source(cop, <<-END.strip_margin('|'))
-      |  def !
-      |    !__getobj__
-      |  end
-    END
-    expect(cop.offenses).to be_empty
-    expect(cop.messages).to be_empty
+    expect_no_offenses(<<-RUBY.strip_indent)
+      def !
+        !__getobj__
+      end
+    RUBY
   end
 
   it 'accepts a unary' do
@@ -86,11 +80,10 @@ describe RuboCop::Cop::Layout::SpaceAroundOperators do
   end
 
   it 'accepts an operator at the end of a line' do
-    inspect_source(cop, <<-END.strip_indent)
+    expect_no_offenses(<<-RUBY.strip_indent)
       ['Favor unless over if for negative ' +
        'conditions.'] * 2
-    END
-    expect(cop.messages).to eq([])
+    RUBY
   end
 
   it 'accepts an assignment with spaces' do
@@ -111,31 +104,32 @@ describe RuboCop::Cop::Layout::SpaceAroundOperators do
   end
 
   it 'accepts operators with spaces' do
-    inspect_source(cop, <<-END.strip_indent)
+    expect_no_offenses(<<-RUBY.strip_indent)
       x += a + b - c * d / e % f ^ g | h & i || j
       y -= k && l
-    END
-    expect(cop.messages).to eq([])
+    RUBY
   end
 
   it "accepts some operators that are exceptions & don't need spaces" do
-    inspect_source(cop, <<-END.strip_indent)
+    expect_no_offenses(<<-RUBY.strip_indent)
       (1..3)
       ActionController::Base
       each { |s, t| }
-    END
-    expect(cop.messages).to eq([])
+    RUBY
   end
 
   it 'accepts an assignment followed by newline' do
-    inspect_source(cop, ['x =', '0'])
-    expect(cop.offenses).to be_empty
+    expect_no_offenses(<<-RUBY.strip_indent)
+      x =
+      0
+    RUBY
   end
 
   it 'accepts an operator at the beginning of a line' do
-    inspect_source(cop, ['a = b \\',
-                         '    && c'])
-    expect(cop.offenses).to be_empty
+    expect_no_offenses(<<-'RUBY'.strip_indent)
+      a = b \
+          && c
+    RUBY
   end
 
   it 'registers an offenses for exponent operator with spaces' do
@@ -161,29 +155,25 @@ describe RuboCop::Cop::Layout::SpaceAroundOperators do
   end
 
   it 'accepts unary operators without space' do
-    inspect_source(cop, <<-END.strip_indent)
+    expect_no_offenses(<<-RUBY.strip_indent)
       [].map(&:size)
       a.(b)
       -3
       arr.collect { |e| -e }
       x = +2
-    END
-    expect(cop.messages).to eq([])
+    RUBY
   end
 
   it 'accepts [arg] without space' do
-    inspect_source(cop, 'files[2]')
-    expect(cop.messages).to eq([])
+    expect_no_offenses('files[2]')
   end
 
   it 'accepts [] without space' do
-    inspect_source(cop, 'files[]')
-    expect(cop.messages).to eq([])
+    expect_no_offenses('files[]')
   end
 
   it 'accepts []= without space' do
-    inspect_source(cop, 'files[:key], files[:another] = method')
-    expect(cop.messages).to eq([])
+    expect_no_offenses('files[:key], files[:another] = method')
   end
 
   it 'accepts argument default values without space' do
@@ -385,7 +375,12 @@ describe RuboCop::Cop::Layout::SpaceAroundOperators do
         let(:hash_style) { 'table' }
 
         it "doesn't register an offense for a hash rocket without spaces" do
-          expect(cop.offenses).to be_empty
+          expect_no_offenses(<<-RUBY.strip_indent)
+            {
+              1=>2,
+              a: b
+            }
+          RUBY
         end
       end
     end

--- a/spec/rubocop/cop/layout/space_before_block_braces_spec.rb
+++ b/spec/rubocop/cop/layout/space_before_block_braces_spec.rb
@@ -6,9 +6,7 @@ describe RuboCop::Cop::Layout::SpaceBeforeBlockBraces, :config do
 
   context 'when EnforcedStyle is space' do
     it 'accepts braces surrounded by spaces' do
-      inspect_source(cop, 'each { puts }')
-      expect(cop.messages).to be_empty
-      expect(cop.highlights).to be_empty
+      expect_no_offenses('each { puts }')
     end
 
     it 'registers an offense for left brace without outer space' do
@@ -70,9 +68,7 @@ describe RuboCop::Cop::Layout::SpaceBeforeBlockBraces, :config do
     end
 
     it 'accepts left brace without outer space' do
-      inspect_source(cop, 'each{ puts }')
-      expect(cop.messages).to be_empty
-      expect(cop.highlights).to be_empty
+      expect_no_offenses('each{ puts }')
     end
   end
 end

--- a/spec/rubocop/cop/layout/space_inside_block_braces_spec.rb
+++ b/spec/rubocop/cop/layout/space_inside_block_braces_spec.rb
@@ -32,8 +32,8 @@ describe RuboCop::Cop::Layout::SpaceInsideBlockBraces, :config do
 
     it 'accepts empty braces with comment and line break inside' do
       expect_no_offenses(<<-RUBY.strip_indent)
-          each { # Comment
-          }
+        each { # Comment
+        }
       RUBY
     end
 
@@ -306,9 +306,7 @@ describe RuboCop::Cop::Layout::SpaceInsideBlockBraces, :config do
     context 'with passed in parameters' do
       context 'and space before block parameters allowed' do
         it 'accepts left brace with inner space' do
-          inspect_source(cop, 'each { |x| puts}')
-          expect(cop.messages).to eq([])
-          expect(cop.highlights).to eq([])
+          expect_no_offenses('each { |x| puts}')
         end
 
         it 'registers an offense for left brace without inner space' do

--- a/spec/rubocop/cop/layout/space_inside_percent_literal_delimiters_spec.rb
+++ b/spec/rubocop/cop/layout/space_inside_percent_literal_delimiters_spec.rb
@@ -95,10 +95,11 @@ describe RuboCop::Cop::Layout::SpaceInsidePercentLiteralDelimiters do
   end
 
   it 'accepts other percent literals' do
-    %w[q r s].each do |type|
-      inspect_source(cop, "%#{type}( a  b c )")
-      expect(cop.messages).to be_empty
-    end
+    expect_no_offenses(<<-RUBY)
+      %q( a  b c )
+      %r( a  b c )
+      %s( a  b c )
+    RUBY
   end
 
   it 'accepts execute-string literals' do

--- a/spec/rubocop/cop/layout/trailing_blank_lines_spec.rb
+++ b/spec/rubocop/cop/layout/trailing_blank_lines_spec.rb
@@ -7,8 +7,7 @@ describe RuboCop::Cop::Layout::TrailingBlankLines, :config do
     let(:cop_config) { { 'EnforcedStyle' => 'final_newline' } }
 
     it 'accepts final newline' do
-      inspect_source(cop, ['x = 0', ''])
-      expect(cop.offenses).to be_empty
+      expect_no_offenses("x = 0\n")
     end
 
     it 'accepts an empty file' do
@@ -16,13 +15,20 @@ describe RuboCop::Cop::Layout::TrailingBlankLines, :config do
     end
 
     it 'accepts final blank lines if they come after __END__' do
-      inspect_source(cop, ['x = 0', '', '__END__', '', ''])
-      expect(cop.offenses).to be_empty
+      expect_no_offenses(<<-RUBY.strip_indent)
+        x = 0
+
+        __END__
+
+      RUBY
     end
 
     it 'accepts final blank lines if they come after __END__ in empty file' do
-      inspect_source(cop, ['__END__', '', '', ''])
-      expect(cop.offenses).to be_empty
+      expect_no_offenses(<<-RUBY.strip_indent)
+        __END__
+
+
+      RUBY
     end
 
     it 'registers an offense for multiple trailing blank lines' do
@@ -95,8 +101,7 @@ describe RuboCop::Cop::Layout::TrailingBlankLines, :config do
     end
 
     it 'accepts final blank line' do
-      inspect_source(cop, ['x = 0', '', ''])
-      expect(cop.offenses).to be_empty
+      expect_no_offenses("x = 0\n\n")
     end
 
     it 'auto-corrects unwanted blank lines' do

--- a/spec/rubocop/cop/layout/trailing_whitespace_spec.rb
+++ b/spec/rubocop/cop/layout/trailing_whitespace_spec.rb
@@ -63,9 +63,7 @@ describe RuboCop::Cop::Layout::TrailingWhitespace do
   end
 
   it 'accepts a line without trailing whitespace' do
-    inspect_source(cop, ['x = 0',
-                         ''])
-    expect(cop.offenses).to be_empty
+    expect_no_offenses('x = 0')
   end
 
   it 'auto-corrects unwanted space' do

--- a/spec/rubocop/cop/lint/ambiguous_operator_spec.rb
+++ b/spec/rubocop/cop/lint/ambiguous_operator_spec.rb
@@ -3,10 +3,6 @@
 describe RuboCop::Cop::Lint::AmbiguousOperator do
   subject(:cop) { described_class.new }
 
-  before do
-    inspect_source(cop, source)
-  end
-
   context 'with a splat operator in the first argument' do
     context 'without parentheses' do
       context 'without whitespaces on the right of the operator' do
@@ -18,6 +14,7 @@ describe RuboCop::Cop::Lint::AmbiguousOperator do
         end
 
         it 'registers an offense' do
+          inspect_source(cop, source)
           expect(cop.offenses.size).to eq(1)
           expect(cop.offenses.first.message).to eq(
             'Ambiguous splat operator. ' \
@@ -31,29 +28,21 @@ describe RuboCop::Cop::Lint::AmbiguousOperator do
       end
 
       context 'with a whitespace on the right of the operator' do
-        let(:source) do
-          <<-END.strip_indent
+        it 'accepts' do
+          expect_no_offenses(<<-RUBY.strip_indent)
             array = [1, 2, 3]
             puts * array
-          END
-        end
-
-        it 'accepts' do
-          expect(cop.offenses).to be_empty
+          RUBY
         end
       end
     end
 
     context 'with parentheses' do
-      let(:source) do
-        <<-END.strip_indent
+      it 'accepts' do
+        expect_no_offenses(<<-RUBY.strip_indent)
           array = [1, 2, 3]
           puts(*array)
-        END
-      end
-
-      it 'accepts' do
-        expect(cop.offenses).to be_empty
+        RUBY
       end
     end
   end
@@ -69,6 +58,7 @@ describe RuboCop::Cop::Lint::AmbiguousOperator do
         end
 
         it 'registers an offense' do
+          inspect_source(cop, source)
           expect(cop.offenses.size).to eq(1)
           expect(cop.offenses.first.message).to eq(
             'Ambiguous block operator. ' \
@@ -82,29 +72,21 @@ describe RuboCop::Cop::Lint::AmbiguousOperator do
       end
 
       context 'with a whitespace on the right of the operator' do
-        let(:source) do
-          <<-END.strip_indent
+        it 'accepts' do
+          expect_no_offenses(<<-RUBY.strip_indent)
             process = proc { do_something }
             2.times & process
-          END
-        end
-
-        it 'accepts' do
-          expect(cop.offenses).to be_empty
+          RUBY
         end
       end
     end
 
     context 'with parentheses' do
-      let(:source) do
-        <<-END.strip_indent
+      it 'accepts' do
+        expect_no_offenses(<<-RUBY.strip_indent)
           process = proc { do_something }
           2.times(&process)
-        END
-      end
-
-      it 'accepts' do
-        expect(cop.offenses).to be_empty
+        RUBY
       end
     end
   end

--- a/spec/rubocop/cop/lint/ambiguous_regexp_literal_spec.rb
+++ b/spec/rubocop/cop/lint/ambiguous_regexp_literal_spec.rb
@@ -3,15 +3,12 @@
 describe RuboCop::Cop::Lint::AmbiguousRegexpLiteral do
   subject(:cop) { described_class.new }
 
-  before do
-    inspect_source(cop, source)
-  end
-
   context 'with a regexp literal in the first argument' do
     context 'without parentheses' do
       let(:source) { 'p /pattern/' }
 
       it 'registers an offense' do
+        inspect_source(cop, source)
         expect(cop.offenses.size).to eq(1)
         expect(cop.offenses.first.message).to eq(
           'Ambiguous regexp literal. Parenthesize the method arguments ' \
@@ -23,10 +20,8 @@ describe RuboCop::Cop::Lint::AmbiguousRegexpLiteral do
     end
 
     context 'with parentheses' do
-      let(:source) { 'p(/pattern/)' }
-
       it 'accepts' do
-        expect(cop.offenses).to be_empty
+        expect_no_offenses('p(/pattern/)')
       end
     end
   end

--- a/spec/rubocop/cop/lint/block_alignment_spec.rb
+++ b/spec/rubocop/cop/lint/block_alignment_spec.rb
@@ -52,8 +52,8 @@ describe RuboCop::Cop::Lint::BlockAlignment, :config do
 
   it 'accepts a block end that does not begin its line' do
     expect_no_offenses(<<-RUBY.strip_indent)
-        scope :bar, lambda { joins(:baz)
-                             .distinct }
+      scope :bar, lambda { joins(:baz)
+                           .distinct }
     RUBY
   end
 
@@ -167,21 +167,19 @@ describe RuboCop::Cop::Lint::BlockAlignment, :config do
   context 'when the method part is a call chain that spans several lines' do
     # Example from issue 346 of bbatsov/rubocop on github:
     it 'accepts pretty alignment style' do
-      src = [
-        'def foo(bar)',
-        '  bar.get_stuffs',
-        '      .reject do |stuff| ',
-        '        stuff.with_a_very_long_expression_that_doesnt_fit_the_line',
-        '      end.select do |stuff|',
-        '        stuff.another_very_long_expression_that_doesnt_fit_the_line',
-        '      end',
-        '      .select do |stuff|',
-        '        stuff.another_very_long_expression_that_doesnt_fit_the_line',
-        '      end',
-        'end'
-      ]
-      inspect_source(cop, src)
-      expect(cop.offenses).to be_empty
+      expect_no_offenses(<<-RUBY.strip_indent)
+        def foo(bar)
+          bar.get_stuffs
+              .reject do |stuff|
+                stuff.with_a_very_long_expression_that_doesnt_fit_the_line
+              end.select do |stuff|
+                stuff.another_very_long_expression_that_doesnt_fit_the_line
+              end
+              .select do |stuff|
+                stuff.another_very_long_expression_that_doesnt_fit_the_line
+              end
+        end
+      RUBY
     end
 
     it 'registers offenses for misaligned ends' do
@@ -210,24 +208,22 @@ describe RuboCop::Cop::Lint::BlockAlignment, :config do
 
     # Example from issue 393 of bbatsov/rubocop on github:
     it 'accepts end indented as the start of the block' do
-      src = <<-END.strip_indent
-        my_object.chaining_this_very_long_method(with_a_parameter)
-            .and_one_with_a_block do
-          do_something
-        end
- # Other variant:
-        my_object.chaining_this_very_long_method(
-            with_a_parameter).and_one_with_a_block do
-          do_something
-        end
-      END
-      inspect_source(cop, src)
-      expect(cop.offenses).to be_empty
+      expect_no_offenses(<<-RUBY.strip_indent)
+               my_object.chaining_this_very_long_method(with_a_parameter)
+                   .and_one_with_a_block do
+                 do_something
+               end
+        # Other variant:
+               my_object.chaining_this_very_long_method(
+                   with_a_parameter).and_one_with_a_block do
+                 do_something
+               end
+      RUBY
     end
 
     # Example from issue 447 of bbatsov/rubocop on github:
     it 'accepts two kinds of end alignment' do
-      src = <<-END.strip_indent
+      expect_no_offenses(<<-RUBY.strip_indent)
         # Aligned with start of line where do is:
         params = default_options.merge(options)
                   .delete_if { |k, v| v.nil? }
@@ -240,9 +236,7 @@ describe RuboCop::Cop::Lint::BlockAlignment, :config do
                   .each_with_object({}) do |(k, v), new_hash|
                     new_hash[k.to_s] = v.to_s
         end
-      END
-      inspect_source(cop, src)
-      expect(cop.offenses).to be_empty
+      RUBY
     end
 
     it 'auto-corrects misaligned ends with the start of the expression' do
@@ -281,14 +275,12 @@ describe RuboCop::Cop::Lint::BlockAlignment, :config do
 
   context 'when variables of a mass assignment spans several lines' do
     it 'accepts end aligned with the variables' do
-      src = <<-END.strip_indent
+      expect_no_offenses(<<-RUBY.strip_indent)
         e,
         f = [5, 6].map do |i|
           i - 5
         end
-      END
-      inspect_source(cop, src)
-      expect(cop.offenses).to be_empty
+      RUBY
     end
 
     it 'registers an offense for end aligned with the block' do
@@ -675,14 +667,12 @@ describe RuboCop::Cop::Lint::BlockAlignment, :config do
     end
 
     it 'allows when start_of_line aligned' do
-      src = <<-END.strip_indent
+      expect_no_offenses(<<-RUBY.strip_indent)
         foo.bar
           .each do
             baz
         end
-      END
-      inspect_source(cop, src)
-      expect(cop.messages).to be_empty
+      RUBY
     end
 
     it 'errors when do aligned' do
@@ -723,14 +713,12 @@ describe RuboCop::Cop::Lint::BlockAlignment, :config do
     end
 
     it 'allows when do aligned' do
-      src = <<-END.strip_indent
+      expect_no_offenses(<<-RUBY.strip_indent)
         foo.bar
           .each do
             baz
           end
-      END
-      inspect_source(cop, src)
-      expect(cop.messages).to be_empty
+      RUBY
     end
 
     it 'errors when start_of_line aligned' do

--- a/spec/rubocop/cop/lint/circular_argument_reference_spec.rb
+++ b/spec/rubocop/cop/lint/circular_argument_reference_spec.rb
@@ -35,7 +35,11 @@ describe RuboCop::Cop::Lint::CircularArgumentReference do
       end
 
       it 'does not register an offense' do
-        expect(cop.offenses).to be_empty
+        expect_no_offenses(<<-RUBY.strip_indent)
+          def omg_wow(msg)
+            puts msg
+          end
+        RUBY
       end
     end
 
@@ -49,7 +53,11 @@ describe RuboCop::Cop::Lint::CircularArgumentReference do
       end
 
       it 'does not register an offense' do
-        expect(cop.offenses).to be_empty
+        expect_no_offenses(<<-RUBY.strip_indent)
+          def omg_wow(msg = self.msg)
+            puts msg
+          end
+        RUBY
       end
     end
   end
@@ -87,7 +95,11 @@ describe RuboCop::Cop::Lint::CircularArgumentReference do
         end
 
         it 'does not register an offense' do
-          expect(cop.offenses).to be_empty
+          expect_no_offenses(<<-RUBY.strip_indent)
+            def some_method(some_arg: nil)
+              puts some_arg
+            end
+          RUBY
         end
       end
 
@@ -100,7 +112,11 @@ describe RuboCop::Cop::Lint::CircularArgumentReference do
           END
         end
         it 'does not register an offense' do
-          expect(cop.offenses).to be_empty
+          expect_no_offenses(<<-RUBY.strip_indent)
+            def some_method(some_arg: some_method)
+              puts some_arg
+            end
+          RUBY
         end
       end
 
@@ -131,7 +147,11 @@ describe RuboCop::Cop::Lint::CircularArgumentReference do
         end
 
         it 'does not register an offense' do
-          expect(cop.offenses).to be_empty
+          expect_no_offenses(<<-RUBY.strip_indent)
+            def puts_value(value: self.class.value, smile: self.smile)
+              puts value
+            end
+          RUBY
         end
       end
 
@@ -146,7 +166,11 @@ describe RuboCop::Cop::Lint::CircularArgumentReference do
         end
 
         it 'does not register an offense' do
-          expect(cop.offenses).to be_empty
+          expect_no_offenses(<<-RUBY.strip_indent)
+            def puts_length(length: mystring.length)
+              puts length
+            end
+          RUBY
         end
       end
 

--- a/spec/rubocop/cop/lint/duplicate_methods_spec.rb
+++ b/spec/rubocop/cop/lint/duplicate_methods_spec.rb
@@ -310,16 +310,16 @@ describe RuboCop::Cop::Lint::DuplicateMethods do
   end
 
   it 'ignores method definitions in RSpec `describe` blocks' do
-    inspect_source(cop,
-                   ['describe "something" do',
-                    '  def some_method',
-                    '    implement 1',
-                    '  end',
-                    '  def some_method',
-                    '    implement 2',
-                    '  end',
-                    'end'], 'test.rb')
-    expect(cop.offenses).to be_empty
+    expect_no_offenses(<<-RUBY.strip_indent)
+      describe "something" do
+        def some_method
+          implement 1
+        end
+        def some_method
+          implement 2
+        end
+      end
+    RUBY
   end
 
   it 'ignores Class.new blocks which are assigned to local variables' do

--- a/spec/rubocop/cop/lint/end_in_method_spec.rb
+++ b/spec/rubocop/cop/lint/end_in_method_spec.rb
@@ -24,8 +24,6 @@ describe RuboCop::Cop::Lint::EndInMethod do
   end
 
   it 'accepts END outside of def(s)' do
-    src = 'END { something }'
-    inspect_source(cop, src)
-    expect(cop.offenses).to be_empty
+    expect_no_offenses('END { something }')
   end
 end

--- a/spec/rubocop/cop/lint/implicit_string_concatenation_spec.rb
+++ b/spec/rubocop/cop/lint/implicit_string_concatenation_spec.rb
@@ -3,15 +3,9 @@
 describe RuboCop::Cop::Lint::ImplicitStringConcatenation do
   subject(:cop) { described_class.new }
 
-  before do
-    inspect_source(cop, source)
-  end
-
   context 'on a single string literal' do
-    let(:source) { 'abc' }
-
     it 'does not register an offense' do
-      expect(cop.offenses).to be_empty
+      expect_no_offenses('abc')
     end
   end
 
@@ -19,6 +13,7 @@ describe RuboCop::Cop::Lint::ImplicitStringConcatenation do
     let(:source) { 'class A; "abc" "def"; end' }
 
     it 'registers an offense' do
+      inspect_source(cop, source)
       expect(cop.offenses.size).to eq(1)
       expect(cop.messages).to eq(['Combine "abc" and "def" into a single ' \
                                   'string literal, rather than using ' \
@@ -28,10 +23,13 @@ describe RuboCop::Cop::Lint::ImplicitStringConcatenation do
   end
 
   context 'on adjacent string literals on different lines' do
-    let(:source) { "array = [\n  'abc'\\\n  'def'\n]" }
-
     it 'does not register an offense' do
-      expect(cop.offenses).to be_empty
+      expect_no_offenses(<<-'RUBY'.strip_indent)
+        array = [
+          'abc'\
+          'def'
+        ]
+      RUBY
     end
   end
 
@@ -39,6 +37,7 @@ describe RuboCop::Cop::Lint::ImplicitStringConcatenation do
     let(:source) { "def method; 'ab\nc' 'de\nf'; end" }
 
     it 'registers an offense' do
+      inspect_source(cop, source)
       expect(cop.offenses.size).to eq(1)
       expect(cop.messages).to eq(['Combine "ab\nc" and "de\nf" into a ' \
                                   'single string literal, rather than using ' \
@@ -48,10 +47,8 @@ describe RuboCop::Cop::Lint::ImplicitStringConcatenation do
   end
 
   context 'on a string with interpolations' do
-    let(:source) { 'array = ["abc#{something}def#{something_else}"]' }
-
     it 'does register an offense' do
-      expect(cop.offenses).to be_empty
+      expect_no_offenses("array = [\"abc\#{something}def\#{something_else}\"]")
     end
   end
 
@@ -59,6 +56,7 @@ describe RuboCop::Cop::Lint::ImplicitStringConcatenation do
     let(:source) { 'array = ["abc" "def"]' }
 
     it 'notes that the strings could be separated by a comma instead' do
+      inspect_source(cop, source)
       expect(cop.offenses.size).to eq(1)
       expect(cop.messages).to eq(['Combine "abc" and "def" into a single ' \
                                   'string literal, rather than using ' \
@@ -73,6 +71,7 @@ describe RuboCop::Cop::Lint::ImplicitStringConcatenation do
     let(:source) { 'method("abc" "def")' }
 
     it 'notes that the strings could be separated by a comma instead' do
+      inspect_source(cop, source)
       expect(cop.offenses.size).to eq(1)
       expect(cop.messages).to eq(['Combine "abc" and "def" into a single ' \
                                   'string literal, rather than using ' \

--- a/spec/rubocop/cop/lint/nested_method_definition_spec.rb
+++ b/spec/rubocop/cop/lint/nested_method_definition_spec.rb
@@ -156,19 +156,25 @@ describe RuboCop::Cop::Lint::NestedMethodDefinition do
   end
 
   it 'does not register offense for nested definition inside Class.new' do
-    ['(S)', ''].each do |constructor_args|
-      inspect_source(cop, <<-END.strip_indent)
-        class Foo
-          def self.define
-            Class.new#{constructor_args} do
-              def y
-              end
+    expect_no_offenses(<<-RUBY.strip_indent)
+      class Foo
+        def self.define
+          Class.new(S) do
+            def y
             end
           end
         end
-      END
-      expect(cop.offenses).to be_empty
-    end
+      end
+
+      class Foo
+        def self.define
+          Class.new do
+            def y
+            end
+          end
+        end
+      end
+    RUBY
   end
 
   it 'does not register offense for nested definition inside Module.new' do
@@ -185,18 +191,24 @@ describe RuboCop::Cop::Lint::NestedMethodDefinition do
   end
 
   it 'does not register offense for nested definition inside Struct.new' do
-    ['(:name)', ''].each do |constructor_args|
-      inspect_source(cop, <<-END.strip_indent)
-        class Foo
-          def self.define
-            Struct.new#{constructor_args} do
-              def y
-              end
+    expect_no_offenses(<<-RUBY.strip_indent)
+      class Foo
+        def self.define
+          Struct.new(:name) do
+            def y
             end
           end
         end
-      END
-      expect(cop.offenses).to be_empty
-    end
+      end
+
+      class Foo
+        def self.define
+          Struct.new do
+            def y
+            end
+          end
+        end
+      end
+    RUBY
   end
 end

--- a/spec/rubocop/cop/lint/underscore_prefixed_variable_name_spec.rb
+++ b/spec/rubocop/cop/lint/underscore_prefixed_variable_name_spec.rb
@@ -3,10 +3,6 @@
 describe RuboCop::Cop::Lint::UnderscorePrefixedVariableName do
   subject(:cop) { described_class.new }
 
-  before do
-    inspect_source(cop, source)
-  end
-
   context 'when an underscore-prefixed variable is used' do
     let(:source) { <<-END }
       def some_method
@@ -16,6 +12,7 @@ describe RuboCop::Cop::Lint::UnderscorePrefixedVariableName do
     END
 
     it 'registers an offense' do
+      inspect_source(cop, source)
       expect(cop.offenses.size).to eq(1)
       expect(cop.offenses.first.message)
         .to eq('Do not use prefix `_` for a variable that is used.')
@@ -26,28 +23,24 @@ describe RuboCop::Cop::Lint::UnderscorePrefixedVariableName do
   end
 
   context 'when non-underscore-prefixed variable is used' do
-    let(:source) { <<-END }
-      def some_method
-        foo = 1
-        puts foo
-      end
-    END
-
     it 'accepts' do
-      expect(cop.offenses).to be_empty
+      expect_no_offenses(<<-RUBY.strip_indent)
+        def some_method
+          foo = 1
+          puts foo
+        end
+      RUBY
     end
   end
 
   context 'when an underscore-prefixed variable is reassigned' do
-    let(:source) { <<-END }
-      def some_method
-        _foo = 1
-        _foo = 2
-      end
-    END
-
     it 'accepts' do
-      expect(cop.offenses).to be_empty
+      expect_no_offenses(<<-RUBY.strip_indent)
+        def some_method
+          _foo = 1
+          _foo = 2
+        end
+      RUBY
     end
   end
 
@@ -59,6 +52,7 @@ describe RuboCop::Cop::Lint::UnderscorePrefixedVariableName do
     END
 
     it 'registers an offense' do
+      inspect_source(cop, source)
       expect(cop.offenses.size).to eq(1)
       expect(cop.offenses.first.line).to eq(1)
       expect(cop.highlights).to eq(['_foo'])
@@ -73,6 +67,7 @@ describe RuboCop::Cop::Lint::UnderscorePrefixedVariableName do
     END
 
     it 'registers an offense' do
+      inspect_source(cop, source)
       expect(cop.offenses.size).to eq(1)
       expect(cop.offenses.first.line).to eq(1)
       expect(cop.highlights).to eq(['_foo'])
@@ -86,6 +81,7 @@ describe RuboCop::Cop::Lint::UnderscorePrefixedVariableName do
     END
 
     it 'registers an offense' do
+      inspect_source(cop, source)
       expect(cop.offenses.size).to eq(1)
       expect(cop.offenses.first.line).to eq(1)
       expect(cop.highlights).to eq(['_foo'])
@@ -93,15 +89,13 @@ describe RuboCop::Cop::Lint::UnderscorePrefixedVariableName do
   end
 
   context 'when an underscore-prefixed variable is captured by a block' do
-    let(:source) { <<-END }
-      _foo = 1
-      1.times do
-        _foo = 2
-      end
-    END
-
     it 'accepts' do
-      expect(cop.offenses).to be_empty
+      expect_no_offenses(<<-RUBY.strip_indent)
+        _foo = 1
+        1.times do
+          _foo = 2
+        end
+      RUBY
     end
   end
 
@@ -112,6 +106,7 @@ describe RuboCop::Cop::Lint::UnderscorePrefixedVariableName do
     END
 
     it 'registers an offense' do
+      inspect_source(cop, source)
       expect(cop.offenses.size).to eq(1)
       expect(cop.offenses.first.line).to eq(1)
       expect(cop.highlights).to eq(['/(?<_foo>\\w+)/'])
@@ -128,6 +123,7 @@ describe RuboCop::Cop::Lint::UnderscorePrefixedVariableName do
         END
 
         it 'accepts' do
+          inspect_source(cop, source)
           expect(cop.offenses).to be_empty
         end
       end
@@ -141,6 +137,7 @@ describe RuboCop::Cop::Lint::UnderscorePrefixedVariableName do
         END
 
         it 'registers an offense' do
+          inspect_source(cop, source)
           expect(cop.offenses.size).to eq(1)
           expect(cop.offenses.first.line).to eq(1)
           expect(cop.highlights).to eq(['_'])
@@ -157,6 +154,7 @@ describe RuboCop::Cop::Lint::UnderscorePrefixedVariableName do
         END
 
         it 'accepts' do
+          inspect_source(cop, source)
           expect(cop.offenses).to be_empty
         end
       end
@@ -169,6 +167,7 @@ describe RuboCop::Cop::Lint::UnderscorePrefixedVariableName do
         END
 
         it 'registers an offense' do
+          inspect_source(cop, source)
           expect(cop.offenses.size).to eq(1)
           expect(cop.offenses.first.line).to eq(1)
           expect(cop.highlights).to eq(['_'])

--- a/spec/rubocop/cop/lint/unused_block_argument_spec.rb
+++ b/spec/rubocop/cop/lint/unused_block_argument_spec.rb
@@ -156,7 +156,11 @@ describe RuboCop::Cop::Lint::UnusedBlockArgument, :config do
       END
 
       it 'accepts' do
-        expect(cop.offenses).to be_empty
+        expect_no_offenses(<<-RUBY.strip_indent)
+          1.times do |_index|
+            puts 'foo'
+          end
+        RUBY
       end
     end
 
@@ -182,7 +186,11 @@ describe RuboCop::Cop::Lint::UnusedBlockArgument, :config do
           let(:cop_config) { { 'AllowUnusedKeywordArguments' => true } }
 
           it 'does not care' do
-            expect(cop.offenses).to be_empty
+            expect_no_offenses(<<-RUBY.strip_indent)
+              define_method(:foo) do |bar: 'default'|
+                puts 'bar'
+              end
+            RUBY
           end
         end
       end
@@ -207,7 +215,11 @@ describe RuboCop::Cop::Lint::UnusedBlockArgument, :config do
           let(:cop_config) { { 'AllowUnusedKeywordArguments' => true } }
 
           it 'does not care' do
-            expect(cop.offenses).to be_empty
+            expect_no_offenses(<<-RUBY.strip_indent)
+              foo(:foo) do |bar: 'default'|
+                puts 'bar'
+              end
+            RUBY
           end
         end
       end
@@ -220,7 +232,10 @@ describe RuboCop::Cop::Lint::UnusedBlockArgument, :config do
       END
 
       it 'does not care' do
-        expect(cop.offenses).to be_empty
+        expect_no_offenses(<<-RUBY.strip_indent)
+          def some_method(foo)
+          end
+        RUBY
       end
     end
 
@@ -232,7 +247,11 @@ describe RuboCop::Cop::Lint::UnusedBlockArgument, :config do
       END
 
       it 'does not care' do
-        expect(cop.offenses).to be_empty
+        expect_no_offenses(<<-RUBY.strip_indent)
+          1.times do
+            foo = 1
+          end
+        RUBY
       end
     end
 
@@ -244,7 +263,11 @@ describe RuboCop::Cop::Lint::UnusedBlockArgument, :config do
       END
 
       it 'accepts all arguments' do
-        expect(cop.offenses).to be_empty
+        expect_no_offenses(<<-RUBY.strip_indent)
+          test do |key, value|
+            puts something(binding)
+          end
+        RUBY
       end
 
       context 'inside a method definition' do
@@ -297,7 +320,7 @@ describe RuboCop::Cop::Lint::UnusedBlockArgument, :config do
         let(:cop_config) { { 'IgnoreEmptyBlocks' => true } }
 
         it 'does not register an offense' do
-          expect(cop.offenses).to be_empty
+          expect_no_offenses('        super { |bar| }')
         end
       end
     end

--- a/spec/rubocop/cop/lint/unused_method_argument_spec.rb
+++ b/spec/rubocop/cop/lint/unused_method_argument_spec.rb
@@ -84,7 +84,11 @@ describe RuboCop::Cop::Lint::UnusedMethodArgument, :config do
         let(:cop_config) { { 'AllowUnusedKeywordArguments' => true } }
 
         it 'does not care' do
-          expect(cop.offenses).to be_empty
+          expect_no_offenses(<<-RUBY.strip_indent)
+            def self.some_method(foo, bar: 1)
+              puts foo
+            end
+          RUBY
         end
       end
     end
@@ -109,7 +113,10 @@ describe RuboCop::Cop::Lint::UnusedMethodArgument, :config do
       END
 
       it 'accepts' do
-        expect(cop.offenses).to be_empty
+        expect_no_offenses(<<-RUBY.strip_indent)
+          def some_method(_foo)
+          end
+        RUBY
       end
     end
 
@@ -121,7 +128,11 @@ describe RuboCop::Cop::Lint::UnusedMethodArgument, :config do
       END
 
       it 'accepts' do
-        expect(cop.offenses).to be_empty
+        expect_no_offenses(<<-RUBY.strip_indent)
+          def some_method(foo)
+            puts foo
+          end
+        RUBY
       end
     end
 
@@ -133,7 +144,11 @@ describe RuboCop::Cop::Lint::UnusedMethodArgument, :config do
       END
 
       it 'does not care' do
-        expect(cop.offenses).to be_empty
+        expect_no_offenses(<<-RUBY.strip_indent)
+          def some_method
+            foo = 1
+          end
+        RUBY
       end
     end
 
@@ -144,7 +159,10 @@ describe RuboCop::Cop::Lint::UnusedMethodArgument, :config do
       END
 
       it 'does not care' do
-        expect(cop.offenses).to be_empty
+        expect_no_offenses(<<-RUBY.strip_indent)
+          1.times do |foo|
+          end
+        RUBY
       end
     end
 
@@ -187,7 +205,11 @@ describe RuboCop::Cop::Lint::UnusedMethodArgument, :config do
       END
 
       it 'accepts all arguments' do
-        expect(cop.offenses).to be_empty
+        expect_no_offenses(<<-RUBY.strip_indent)
+          def some_method(foo, bar)
+            do_something binding
+          end
+        RUBY
       end
 
       context 'inside another method definition' do

--- a/spec/rubocop/cop/lint/useless_access_modifier_spec.rb
+++ b/spec/rubocop/cop/lint/useless_access_modifier_spec.rb
@@ -204,20 +204,15 @@ describe RuboCop::Cop::Lint::UselessAccessModifier do
   end
 
   context 'when a def is an argument to a method call' do
-    let(:source) do
-      <<-END.strip_indent
+    it 'does not register an offense' do
+      expect_no_offenses(<<-RUBY.strip_indent)
         class SomeClass
           private
           helper_method def some_method
             puts 10
           end
         end
-      END
-    end
-
-    it 'does not register an offense' do
-      inspect_source(cop, source)
-      expect(cop.offenses).to be_empty
+      RUBY
     end
   end
 
@@ -230,7 +225,7 @@ describe RuboCop::Cop::Lint::UselessAccessModifier do
       )
     end
     it 'is aware that this creates a new scope' do
-      src = <<-END.strip_indent
+      expect_no_offenses(<<-RUBY.strip_indent)
         class SomeClass
           concerning :FirstThing do
             def foo
@@ -249,9 +244,7 @@ describe RuboCop::Cop::Lint::UselessAccessModifier do
             end
           end
          end
-      END
-      inspect_source(cop, src)
-      expect(cop.offenses).to be_empty
+      RUBY
     end
 
     it 'still points out redundant uses within the block' do
@@ -317,7 +310,7 @@ describe RuboCop::Cop::Lint::UselessAccessModifier do
       )
     end
     it 'is aware that this creates a new scope' do
-      src = <<-END.strip_indent
+      expect_no_offenses(<<-RUBY.strip_indent)
         module SomeModule
           extend ActiveSupport::Concern
           class_methods do
@@ -333,9 +326,7 @@ describe RuboCop::Cop::Lint::UselessAccessModifier do
           def some_private_instance_method
           end
         end
-      END
-      inspect_source(cop, src)
-      expect(cop.offenses).to be_empty
+      RUBY
     end
   end
 
@@ -348,15 +339,13 @@ describe RuboCop::Cop::Lint::UselessAccessModifier do
       )
     end
     it 'is aware that this creates a new method' do
-      src = <<-END.strip_indent
+      expect_no_offenses(<<-RUBY.strip_indent)
         class SomeClass
           private
 
           delegate :foo, to: :bar
         end
-      END
-      inspect_source(cop, src)
-      expect(cop.offenses).to be_empty
+      RUBY
     end
 
     it 'still points out redundant uses within the module' do

--- a/spec/rubocop/cop/lint/useless_else_without_rescue_spec.rb
+++ b/spec/rubocop/cop/lint/useless_else_without_rescue_spec.rb
@@ -40,7 +40,15 @@ describe RuboCop::Cop::Lint::UselessElseWithoutRescue do
     end
 
     it 'accepts' do
-      expect(cop.offenses).to be_empty
+      expect_no_offenses(<<-RUBY.strip_indent)
+        begin
+          do_something
+        rescue ArgumentError
+          handle_argument_error
+        else
+          handle_unknown_errors
+        end
+      RUBY
     end
   end
 end

--- a/spec/rubocop/cop/performance/count_spec.rb
+++ b/spec/rubocop/cop/performance/count_spec.rb
@@ -141,10 +141,9 @@ describe RuboCop::Cop::Performance::Count do
     end
 
     it 'allows usage of select with multiple strings' do
-      source = "Model.select('field AS field_one', 'other AS field_two').count"
-      inspect_source(cop, source)
-
-      expect(cop.messages).to be_empty
+      expect_no_offenses(<<-RUBY.strip_indent)
+        Model.select('field AS field_one', 'other AS field_two').count
+      RUBY
     end
 
     it 'allows usage of select with a symbol' do

--- a/spec/rubocop/cop/rails/active_support_aliases_spec.rb
+++ b/spec/rubocop/cop/rails/active_support_aliases_spec.rb
@@ -24,8 +24,7 @@ describe RuboCop::Cop::Rails::ActiveSupportAliases do
 
     describe '#start_with?' do
       it 'is not registered as an offense' do
-        inspect_source(cop, "'some_string'.start_with?('prefix')")
-        expect(cop.offenses.size).to eq(0)
+        expect_no_offenses("'some_string'.start_with?('prefix')")
       end
     end
 
@@ -47,8 +46,7 @@ describe RuboCop::Cop::Rails::ActiveSupportAliases do
 
     describe '#end_with?' do
       it 'is not registered as an offense' do
-        inspect_source(cop, "'some_string'.end_with?('prefix')")
-        expect(cop.offenses.size).to eq(0)
+        expect_no_offenses("'some_string'.end_with?('prefix')")
       end
     end
   end
@@ -71,8 +69,7 @@ describe RuboCop::Cop::Rails::ActiveSupportAliases do
 
     describe '#<<' do
       it 'is not registered as an offense' do
-        inspect_source(cop, "[1, 'a', 3] << 'element'")
-        expect(cop.offenses.size).to eq(0)
+        expect_no_offenses("[1, 'a', 3] << 'element'")
       end
     end
 
@@ -94,8 +91,7 @@ describe RuboCop::Cop::Rails::ActiveSupportAliases do
 
     describe '#unshift' do
       it 'is not registered as an offense' do
-        inspect_source(cop, "[1, 'a', 3].unshift('element')")
-        expect(cop.offenses.size).to eq(0)
+        expect_no_offenses("[1, 'a', 3].unshift('element')")
       end
     end
   end

--- a/spec/rubocop/cop/rails/application_job_spec.rb
+++ b/spec/rubocop/cop/rails/application_job_spec.rb
@@ -7,57 +7,53 @@ describe RuboCop::Cop::Rails::ApplicationJob do
     subject(:cop) { described_class.new(config) }
 
     it 'allows ApplicationJob to be defined' do
-      source = "class ApplicationJob < ActiveJob::Base\nend"
-      inspect_source(cop, source)
-      expect(cop.offenses).to be_empty
+      expect_no_offenses(<<-RUBY.strip_indent)
+        class ApplicationJob < ActiveJob::Base
+        end
+      RUBY
     end
 
     it 'allows jobs that subclass ActiveJob::Base' do
-      source = "class MyJob < ActiveJob::Base\nend"
-      inspect_source(cop, source)
-      expect(cop.offenses).to be_empty
+      expect_no_offenses(<<-RUBY.strip_indent)
+        class MyJob < ActiveJob::Base
+        end
+      RUBY
     end
 
     it 'allows a single-line class definitions' do
-      source = 'class MyJob < ActiveJob::Base; end'
-      inspect_source(cop, source)
-      expect(cop.offenses).to be_empty
+      expect_no_offenses('class MyJob < ActiveJob::Base; end')
     end
 
     it 'allows namespaced jobs that subclass ActiveJob::Base' do
-      source = "module Nested\n  class MyJob < ActiveJob::Base\n  end\nend"
-      inspect_source(cop, source)
-      expect(cop.offenses).to be_empty
+      expect_no_offenses(<<-RUBY.strip_indent)
+        module Nested
+          class MyJob < ActiveJob::Base
+          end
+        end
+      RUBY
     end
 
     it 'allows jobs defined using nested constants' do
-      source = "class Nested::MyJob < ActiveJob::Base\nend"
-      inspect_source(cop, source)
-      expect(cop.offenses).to be_empty
+      expect_no_offenses(<<-RUBY.strip_indent)
+        class Nested::MyJob < ActiveJob::Base
+        end
+      RUBY
     end
 
     it 'allows jobs defined using Class.new' do
-      source = 'MyJob = Class.new(ActiveJob::Base)'
-      inspect_source(cop, source)
-      expect(cop.offenses).to be_empty
+      expect_no_offenses('MyJob = Class.new(ActiveJob::Base)')
     end
 
     it 'allows nested jobs defined using Class.new' do
-      source = 'Nested::MyJob = Class.new(ActiveJob::Base)'
-      inspect_source(cop, source)
-      expect(cop.offenses).to be_empty
+      expect_no_offenses('Nested::MyJob = Class.new(ActiveJob::Base)')
     end
 
     it 'allows anonymous jobs' do
-      source = 'Class.new(ActiveJob::Base) {}'
-      inspect_source(cop, source)
-      expect(cop.offenses).to be_empty
+      expect_no_offenses('Class.new(ActiveJob::Base) {}')
     end
 
     it 'allows ApplicationJob defined using Class.new' do
-      source = 'ApplicationJob = Class.new(ActiveJob::Base)'
-      inspect_source(cop, source)
-      expect(cop.offenses).to be_empty
+      expect_no_offenses('ApplicationJob = Class.new(ActiveJob::Base)')
     end
   end
 
@@ -65,9 +61,10 @@ describe RuboCop::Cop::Rails::ApplicationJob do
     subject(:cop) { described_class.new }
 
     it 'allows ApplicationJob to be defined' do
-      source = "class ApplicationJob < ActiveJob::Base\nend"
-      inspect_source(cop, source)
-      expect(cop.offenses).to be_empty
+      expect_no_offenses(<<-RUBY.strip_indent)
+        class ApplicationJob < ActiveJob::Base
+        end
+      RUBY
     end
 
     it 'corrects jobs that subclass ActiveJob::Base' do
@@ -134,9 +131,7 @@ describe RuboCop::Cop::Rails::ApplicationJob do
     end
 
     it 'allows ApplicationJob defined using Class.new' do
-      source = 'ApplicationJob = Class.new(ActiveJob::Base)'
-      inspect_source(cop, source)
-      expect(cop.offenses).to be_empty
+      expect_no_offenses('ApplicationJob = Class.new(ActiveJob::Base)')
     end
   end
 end

--- a/spec/rubocop/cop/rails/application_record_spec.rb
+++ b/spec/rubocop/cop/rails/application_record_spec.rb
@@ -7,57 +7,53 @@ describe RuboCop::Cop::Rails::ApplicationRecord do
     subject(:cop) { described_class.new(config) }
 
     it 'allows ApplicationRecord to be defined' do
-      source = "class ApplicationRecord < ActiveRecord::Base\nend"
-      inspect_source(cop, source)
-      expect(cop.offenses).to be_empty
+      expect_no_offenses(<<-RUBY.strip_indent)
+        class ApplicationRecord < ActiveRecord::Base
+        end
+      RUBY
     end
 
     it 'allows models that subclass ActiveRecord::Base' do
-      source = "class MyModel < ActiveRecord::Base\nend"
-      inspect_source(cop, source)
-      expect(cop.offenses).to be_empty
+      expect_no_offenses(<<-RUBY.strip_indent)
+        class MyModel < ActiveRecord::Base
+        end
+      RUBY
     end
 
     it 'allows a single-line class definitions' do
-      source = 'class MyModel < ActiveRecord::Base; end'
-      inspect_source(cop, source)
-      expect(cop.offenses).to be_empty
+      expect_no_offenses('class MyModel < ActiveRecord::Base; end')
     end
 
     it 'allows namespaced models that subclass ActiveRecord::Base' do
-      source = "module Nested\n  class MyModel < ActiveRecord::Base\n  end\nend"
-      inspect_source(cop, source)
-      expect(cop.offenses).to be_empty
+      expect_no_offenses(<<-RUBY.strip_indent)
+        module Nested
+          class MyModel < ActiveRecord::Base
+          end
+        end
+      RUBY
     end
 
     it 'allows models defined using nested constants' do
-      source = "class Nested::MyModel < ActiveRecord::Base\nend"
-      inspect_source(cop, source)
-      expect(cop.offenses).to be_empty
+      expect_no_offenses(<<-RUBY.strip_indent)
+        class Nested::MyModel < ActiveRecord::Base
+        end
+      RUBY
     end
 
     it 'allows models defined using Class.new' do
-      source = 'MyModel = Class.new(ActiveRecord::Base)'
-      inspect_source(cop, source)
-      expect(cop.offenses).to be_empty
+      expect_no_offenses('MyModel = Class.new(ActiveRecord::Base)')
     end
 
     it 'allows nested models defined using Class.new' do
-      source = 'Nested::MyModel = Class.new(ActiveRecord::Base)'
-      inspect_source(cop, source)
-      expect(cop.offenses).to be_empty
+      expect_no_offenses('Nested::MyModel = Class.new(ActiveRecord::Base)')
     end
 
     it 'allows anonymous models' do
-      source = 'Class.new(ActiveRecord::Base) {}'
-      inspect_source(cop, source)
-      expect(cop.offenses).to be_empty
+      expect_no_offenses('Class.new(ActiveRecord::Base) {}')
     end
 
     it 'allows ApplicationRecord defined using Class.new' do
-      source = 'ApplicationRecord = Class.new(ActiveRecord::Base)'
-      inspect_source(cop, source)
-      expect(cop.offenses).to be_empty
+      expect_no_offenses('ApplicationRecord = Class.new(ActiveRecord::Base)')
     end
   end
 
@@ -65,9 +61,10 @@ describe RuboCop::Cop::Rails::ApplicationRecord do
     subject(:cop) { described_class.new }
 
     it 'allows ApplicationRecord to be defined' do
-      source = "class ApplicationRecord < ActiveRecord::Base\nend"
-      inspect_source(cop, source)
-      expect(cop.offenses).to be_empty
+      expect_no_offenses(<<-RUBY.strip_indent)
+        class ApplicationRecord < ActiveRecord::Base
+        end
+      RUBY
     end
 
     it 'corrects models that subclass ActiveRecord::Base' do
@@ -134,9 +131,7 @@ describe RuboCop::Cop::Rails::ApplicationRecord do
     end
 
     it 'allows ApplicationRecord defined using Class.new' do
-      source = 'ApplicationRecord = Class.new(ActiveRecord::Base)'
-      inspect_source(cop, source)
-      expect(cop.offenses).to be_empty
+      expect_no_offenses('ApplicationRecord = Class.new(ActiveRecord::Base)')
     end
   end
 end

--- a/spec/rubocop/cop/rails/dynamic_find_by_spec.rb
+++ b/spec/rubocop/cop/rails/dynamic_find_by_spec.rb
@@ -133,8 +133,8 @@ describe RuboCop::Cop::Rails::DynamicFindBy, :config do
   end
 
   it 'accepts method in whitelist' do
-    source = 'User.find_by_sql(["select * from users where name = ?", name])'
-    inspect_source(cop, source)
-    expect(cop.offenses).to be_empty
+    expect_no_offenses(<<-RUBY.strip_indent)
+      User.find_by_sql(["select * from users where name = ?", name])
+    RUBY
   end
 end

--- a/spec/rubocop/cop/rails/file_path_spec.rb
+++ b/spec/rubocop/cop/rails/file_path_spec.rb
@@ -55,11 +55,10 @@ describe RuboCop::Cop::Rails::FilePath do
   end
 
   context 'Rails.root.join with a non-string argument including "/"' do
-    let(:source) { 'Rails.root.join("tmp", "data", index/3, "data.csv")' }
-
     it 'does not register an offense' do
-      inspect_source(cop, source)
-      expect(cop.offenses).to be_empty
+      expect_no_offenses(<<-RUBY.strip_indent)
+        Rails.root.join("tmp", "data", index/3, "data.csv")
+      RUBY
     end
   end
 end

--- a/spec/rubocop/cop/rails/http_positional_arguments_spec.rb
+++ b/spec/rubocop/cop/rails/http_positional_arguments_spec.rb
@@ -5,27 +5,19 @@ describe RuboCop::Cop::Rails::HttpPositionalArguments do
     subject(:cop) { described_class.new(config) }
 
     it 'does not register an offense for post method' do
-      source = 'post :create, user_id: @user.id'
-      inspect_source(cop, source)
-      expect(cop.offenses.size).to eq(0)
+      expect_no_offenses('post :create, user_id: @user.id')
     end
 
     it 'does not register an offense for patch method' do
-      source = 'patch :update, user_id: @user.id'
-      inspect_source(cop, source)
-      expect(cop.offenses.size).to eq(0)
+      expect_no_offenses('patch :update, user_id: @user.id')
     end
 
     it 'does not register an offense for delete method' do
-      source = 'delete :destroy, id: @user.id'
-      inspect_source(cop, source)
-      expect(cop.offenses.size).to eq(0)
+      expect_no_offenses('delete :destroy, id: @user.id')
     end
 
     it 'accepts for not HTTP method' do
-      source = 'puts :create, user_id: @user.id'
-      inspect_source(cop, source)
-      expect(cop.offenses).to be_empty
+      expect_no_offenses('puts :create, user_id: @user.id')
     end
 
     describe 'when using process' do
@@ -60,8 +52,7 @@ describe RuboCop::Cop::Rails::HttpPositionalArguments do
       end
 
       it 'does not register an offense' do
-        inspect_source(cop, source)
-        expect(cop.offenses.size).to eq(0)
+        expect_no_offenses('get :new, user_id: @user.id')
       end
 
       it 'does not auto-correct' do
@@ -70,13 +61,8 @@ describe RuboCop::Cop::Rails::HttpPositionalArguments do
       end
 
       describe 'no params' do
-        let(:source) do
-          'get :new'
-        end
-
         it 'does not register an offense' do
-          inspect_source(cop, source)
-          expect(cop.offenses.size).to eq(0)
+          expect_no_offenses('get :new')
         end
       end
     end
@@ -95,8 +81,15 @@ describe RuboCop::Cop::Rails::HttpPositionalArguments do
       end
 
       it 'does not register an offense' do
-        inspect_source(cop, source)
-        expect(cop.offenses.size).to eq(0)
+        expect_no_offenses(<<-RUBY.strip_indent)
+          patch :update,
+                    id: @user.id,
+                    ac: {
+                      article_id: @article1.id,
+                      profile_id: @profile1.id,
+                      content: 'Some Text'
+                    }
+        RUBY
       end
 
       it 'does not auto-correct' do
@@ -119,8 +112,15 @@ describe RuboCop::Cop::Rails::HttpPositionalArguments do
       end
 
       it 'does not register an offense' do
-        inspect_source(cop, source)
-        expect(cop.offenses.size).to eq(0)
+        expect_no_offenses(<<-RUBY.strip_indent)
+          post :create,
+                    id: @user.id,
+                    ac: {
+                      article_id: @article1.id,
+                      profile_id: @profile1.id,
+                      content: 'Some Text'
+                    }
+        RUBY
       end
 
       it 'does not auto-correct' do
@@ -162,9 +162,11 @@ describe RuboCop::Cop::Rails::HttpPositionalArguments do
     end
 
     it 'does not register when post is found' do
-      source = "if post.stint_title.present? \n true\n end"
-      inspect_source(cop, source)
-      expect(cop.offenses.size).to eq(0)
+      expect_no_offenses(<<-RUBY.strip_indent)
+        if post.stint_title.present?
+         true
+         end
+      RUBY
     end
 
     it 'does not remove quotes when single quoted' do
@@ -268,9 +270,7 @@ describe RuboCop::Cop::Rails::HttpPositionalArguments do
     end
 
     it 'accepts for not HTTP method' do
-      source = 'puts :create, user_id: @user.id'
-      inspect_source(cop, source)
-      expect(cop.offenses).to be_empty
+      expect_no_offenses('puts :create, user_id: @user.id')
     end
 
     describe 'when using process' do
@@ -321,13 +321,8 @@ describe RuboCop::Cop::Rails::HttpPositionalArguments do
       end
 
       describe 'no params' do
-        let(:source) do
-          'get :new'
-        end
-
         it 'does not register an offense' do
-          inspect_source(cop, source)
-          expect(cop.offenses.size).to eq(0)
+          expect_no_offenses('get :new')
         end
       end
     end
@@ -452,9 +447,11 @@ describe RuboCop::Cop::Rails::HttpPositionalArguments do
     end
 
     it 'does not register when post is found' do
-      source = "if post.stint_title.present? \n true\n end"
-      inspect_source(cop, source)
-      expect(cop.offenses.size).to eq(0)
+      expect_no_offenses(<<-RUBY.strip_indent)
+        if post.stint_title.present?
+         true
+         end
+      RUBY
     end
 
     it 'does not remove quotes when single quoted' do

--- a/spec/rubocop/cop/rails/output_safety_spec.rb
+++ b/spec/rubocop/cop/rails/output_safety_spec.rb
@@ -22,18 +22,14 @@ describe RuboCop::Cop::Rails::OutputSafety do
   end
 
   it 'accepts html_safe methods without a receiver' do
-    source = 'html_safe'
-    inspect_source(cop, source)
-    expect(cop.offenses).to be_empty
+    expect_no_offenses('html_safe')
   end
 
   it 'accepts html_safe methods with arguments' do
-    source = <<-END.strip_indent
+    expect_no_offenses(<<-RUBY.strip_indent)
       foo.html_safe one
       "foo".html_safe two
-    END
-    inspect_source(cop, source)
-    expect(cop.offenses).to be_empty
+    RUBY
   end
 
   it 'registers an offense for raw methods without a receiver' do
@@ -46,33 +42,25 @@ describe RuboCop::Cop::Rails::OutputSafety do
   end
 
   it 'accepts raw methods with a receiver' do
-    source = <<-END.strip_indent
+    expect_no_offenses(<<-RUBY.strip_indent)
       foo.raw(foo)
       "foo".raw "foo"
-    END
-    inspect_source(cop, source)
-    expect(cop.offenses).to be_empty
+    RUBY
   end
 
   it 'accepts raw methods without arguments' do
-    source = 'raw'
-    inspect_source(cop, source)
-    expect(cop.offenses).to be_empty
+    expect_no_offenses('raw')
   end
 
   it 'accepts raw methods with more than one arguments' do
-    source = 'raw one, two'
-    inspect_source(cop, source)
-    expect(cop.offenses).to be_empty
+    expect_no_offenses('raw one, two')
   end
 
   it 'accepts comments' do
-    source = <<-END.strip_indent
+    expect_no_offenses(<<-RUBY.strip_indent)
       # foo.html_safe
       # raw foo
-    END
-    inspect_source(cop, source)
-    expect(cop.offenses).to be_empty
+    RUBY
   end
 
   it 'does not accept safe_concat methods when wrapped in a safe_join' do

--- a/spec/rubocop/cop/rails/output_spec.rb
+++ b/spec/rubocop/cop/rails/output_spec.rb
@@ -15,27 +15,25 @@ describe RuboCop::Cop::Rails::Output do
   end
 
   it 'does not record an offense for methods with a receiver' do
-    source = <<-END.strip_indent
+    expect_no_offenses(<<-RUBY.strip_indent)
       obj.print
       something.p
       nothing.pp
-    END
-    inspect_source(cop, source)
-    expect(cop.offenses).to be_empty
+    RUBY
   end
 
   it 'does not record an offense for methods without arguments' do
-    source = %w[print pp puts]
-    inspect_source(cop, source)
-    expect(cop.offenses).to be_empty
+    expect_no_offenses(<<-RUBY.strip_indent)
+      print
+      pp
+      puts
+    RUBY
   end
 
   it 'does not record an offense for comments' do
-    source = <<-END.strip_indent
+    expect_no_offenses(<<-RUBY.strip_indent)
       # print "test"
       # p
-    END
-    inspect_source(cop, source)
-    expect(cop.offenses).to be_empty
+    RUBY
   end
 end

--- a/spec/rubocop/cop/style/ascii_identifiers_spec.rb
+++ b/spec/rubocop/cop/style/ascii_identifiers_spec.rb
@@ -24,11 +24,10 @@ describe RuboCop::Cop::Style::AsciiIdentifiers do
   end
 
   it 'does not get confused by a byte order mark' do
-    bom = "\xef\xbb\xbf"
-    inspect_source(cop,
-                   [bom + '# encoding: utf-8',
-                    "puts 'foo'"])
-    expect(cop.offenses).to be_empty
+    expect_no_offenses(<<-RUBY.strip_indent)
+      ﻿# encoding: utf-8
+      puts 'foo'
+    RUBY
   end
 
   it 'does not get confused by an empty file' do

--- a/spec/rubocop/cop/style/braces_around_hash_parameters_spec.rb
+++ b/spec/rubocop/cop/style/braces_around_hash_parameters_spec.rb
@@ -256,16 +256,18 @@ describe RuboCop::Cop::Style::BracesAroundHashParameters, :config do
       after { expect(cop.offenses).to be_empty }
 
       it 'accepts one hash parameter with braces' do
-        inspect_source(cop, 'where({ x: 1 })')
+        expect_no_offenses('where({ x: 1 })')
       end
 
       it 'accepts multiple hash parameters with braces' do
-        inspect_source(cop, 'where({ x: 1 }, { y: 2 })')
+        expect_no_offenses('where({ x: 1 }, { y: 2 })')
       end
 
       it 'accepts one hash parameter with braces and whitespace' do
-        inspect_source(cop, ["where( \t    {  x: 1 ",
-                             '  }   )'])
+        expect_no_offenses(<<-RUBY.strip_indent)
+          where( 	    {  x: 1
+            }   )
+        RUBY
       end
     end
 

--- a/spec/rubocop/cop/style/command_literal_spec.rb
+++ b/spec/rubocop/cop/style/command_literal_spec.rb
@@ -42,10 +42,11 @@ describe RuboCop::Cop::Style::CommandLiteral, :config do
     let(:cop_config) { { 'EnforcedStyle' => 'backticks' } }
 
     it 'is ignored' do
-      inspect_source(cop, ['<<`COMMAND`',
-                           '  ls',
-                           'COMMAND'])
-      expect(cop.offenses).to be_empty
+      expect_no_offenses(<<-RUBY.strip_indent)
+        <<`COMMAND`
+          ls
+        COMMAND
+      RUBY
     end
   end
 
@@ -53,11 +54,8 @@ describe RuboCop::Cop::Style::CommandLiteral, :config do
     let(:cop_config) { { 'EnforcedStyle' => 'backticks' } }
 
     describe 'a single-line ` string without backticks' do
-      let(:source) { 'foo = `ls`' }
-
       it 'is accepted' do
-        inspect_source(cop, source)
-        expect(cop.offenses).to be_empty
+        expect_no_offenses('foo = `ls`')
       end
     end
 
@@ -80,23 +78,19 @@ describe RuboCop::Cop::Style::CommandLiteral, :config do
         before { cop_config['AllowInnerBackticks'] = true }
 
         it 'is accepted' do
-          inspect_source(cop, source)
-          expect(cop.offenses).to be_empty
+          expect_no_offenses('foo = `echo \\`ls\\``')
         end
       end
     end
 
     describe 'a multi-line ` string without backticks' do
-      let(:source) do
-        ['foo = `',
-         '  ls',
-         '  ls -l',
-         '`']
-      end
-
       it 'is accepted' do
-        inspect_source(cop, source)
-        expect(cop.offenses).to be_empty
+        expect_no_offenses(<<-RUBY.strip_indent)
+          foo = `
+            ls
+            ls -l
+          `
+        RUBY
       end
     end
 
@@ -127,8 +121,12 @@ describe RuboCop::Cop::Style::CommandLiteral, :config do
         before { cop_config['AllowInnerBackticks'] = true }
 
         it 'is accepted' do
-          inspect_source(cop, source)
-          expect(cop.offenses).to be_empty
+          expect_no_offenses(<<-'RUBY'.strip_indent)
+            foo = `
+              echo \`ls\`
+              echo \`ls -l\`
+            `
+          RUBY
         end
       end
     end
@@ -153,8 +151,7 @@ describe RuboCop::Cop::Style::CommandLiteral, :config do
       let(:source) { 'foo = %x(echo `ls`)' }
 
       it 'is accepted' do
-        inspect_source(cop, source)
-        expect(cop.offenses).to be_empty
+        expect_no_offenses('foo = %x(echo `ls`)')
       end
 
       describe 'when configured to allow inner backticks' do
@@ -207,8 +204,12 @@ describe RuboCop::Cop::Style::CommandLiteral, :config do
       end
 
       it 'is accepted' do
-        inspect_source(cop, source)
-        expect(cop.offenses).to be_empty
+        expect_no_offenses(<<-RUBY.strip_indent)
+          foo = %x(
+            echo `ls`
+            echo `ls -l`
+          )
+        RUBY
       end
 
       describe 'when configured to allow inner backticks' do
@@ -316,48 +317,36 @@ describe RuboCop::Cop::Style::CommandLiteral, :config do
     end
 
     describe 'a single-line %x string without backticks' do
-      let(:source) { 'foo = %x(ls)' }
-
       it 'is accepted' do
-        inspect_source(cop, source)
-        expect(cop.offenses).to be_empty
+        expect_no_offenses('foo = %x(ls)')
       end
     end
 
     describe 'a single-line %x string with backticks' do
-      let(:source) { 'foo = %x(echo `ls`)' }
-
       it 'is accepted' do
-        inspect_source(cop, source)
-        expect(cop.offenses).to be_empty
+        expect_no_offenses('foo = %x(echo `ls`)')
       end
     end
 
     describe 'a multi-line %x string without backticks' do
-      let(:source) do
-        ['foo = %x(',
-         '  ls',
-         '  ls -l',
-         ')']
-      end
-
       it 'is accepted' do
-        inspect_source(cop, source)
-        expect(cop.offenses).to be_empty
+        expect_no_offenses(<<-RUBY.strip_indent)
+          foo = %x(
+            ls
+            ls -l
+          )
+        RUBY
       end
     end
 
     describe 'a multi-line %x string with backticks' do
-      let(:source) do
-        ['foo = %x(',
-         '  echo `ls`',
-         '  echo `ls -l`',
-         ')']
-      end
-
       it 'is accepted' do
-        inspect_source(cop, source)
-        expect(cop.offenses).to be_empty
+        expect_no_offenses(<<-RUBY.strip_indent)
+          foo = %x(
+            echo `ls`
+            echo `ls -l`
+          )
+        RUBY
       end
     end
   end
@@ -366,11 +355,8 @@ describe RuboCop::Cop::Style::CommandLiteral, :config do
     let(:cop_config) { { 'EnforcedStyle' => 'mixed' } }
 
     describe 'a single-line ` string without backticks' do
-      let(:source) { 'foo = `ls`' }
-
       it 'is accepted' do
-        inspect_source(cop, source)
-        expect(cop.offenses).to be_empty
+        expect_no_offenses('foo = `ls`')
       end
     end
 
@@ -393,8 +379,7 @@ describe RuboCop::Cop::Style::CommandLiteral, :config do
         before { cop_config['AllowInnerBackticks'] = true }
 
         it 'is accepted' do
-          inspect_source(cop, source)
-          expect(cop.offenses).to be_empty
+          expect_no_offenses('foo = `echo \\`ls\\``')
         end
       end
     end
@@ -467,8 +452,7 @@ describe RuboCop::Cop::Style::CommandLiteral, :config do
       let(:source) { 'foo = %x(echo `ls`)' }
 
       it 'is accepted' do
-        inspect_source(cop, source)
-        expect(cop.offenses).to be_empty
+        expect_no_offenses('foo = %x(echo `ls`)')
       end
 
       describe 'when configured to allow inner backticks' do
@@ -489,30 +473,24 @@ describe RuboCop::Cop::Style::CommandLiteral, :config do
     end
 
     describe 'a multi-line %x string without backticks' do
-      let(:source) do
-        ['foo = %x(',
-         '  ls',
-         '  ls -l',
-         ')']
-      end
-
       it 'is accepted' do
-        inspect_source(cop, source)
-        expect(cop.offenses).to be_empty
+        expect_no_offenses(<<-RUBY.strip_indent)
+          foo = %x(
+            ls
+            ls -l
+          )
+        RUBY
       end
     end
 
     describe 'a multi-line %x string with backticks' do
-      let(:source) do
-        ['foo = %x(',
-         '  echo `ls`',
-         '  echo `ls -l`',
-         ')']
-      end
-
       it 'is accepted' do
-        inspect_source(cop, source)
-        expect(cop.offenses).to be_empty
+        expect_no_offenses(<<-RUBY.strip_indent)
+          foo = %x(
+            echo `ls`
+            echo `ls -l`
+          )
+        RUBY
       end
     end
   end

--- a/spec/rubocop/cop/style/comment_annotation_spec.rb
+++ b/spec/rubocop/cop/style/comment_annotation_spec.rb
@@ -113,13 +113,11 @@ describe RuboCop::Cop::Style::CommentAnnotation, :config do
   end
 
   it 'accepts a keyword that is somewhere in a sentence' do
-    src = <<-END.strip_indent
+    expect_no_offenses(<<-RUBY.strip_indent)
       # Example: There are three reviews, with ranks 1, 2, and 3. A new
       # review is saved with rank 2. The two reviews that originally had
       # ranks 2 and 3 will have their ranks increased to 3 and 4.
-    END
-    inspect_source(cop, src)
-    expect(cop.offenses).to be_empty
+    RUBY
   end
 
   context 'when a keyword is not in the configuration' do

--- a/spec/rubocop/cop/style/conditional_assignment_assign_to_condition_spec.rb
+++ b/spec/rubocop/cop/style/conditional_assignment_assign_to_condition_spec.rb
@@ -22,7 +22,7 @@ describe RuboCop::Cop::Style::ConditionalAssignment do
   end
 
   it 'counts array assignment when determining multiple assignment' do
-    source = <<-END.strip_indent
+    expect_no_offenses(<<-RUBY.strip_indent)
       if foo
         array[1] = 1
         a = 1
@@ -30,44 +30,31 @@ describe RuboCop::Cop::Style::ConditionalAssignment do
         array[1] = 2
         a = 2
       end
-    END
-
-    inspect_source(cop, source)
-
-    expect(cop.offenses).to be_empty
+    RUBY
   end
 
   it 'allows method calls in conditionals' do
-    source = <<-END.strip_indent
+    expect_no_offenses(<<-RUBY.strip_indent)
       if line.is_a?(String)
         expect(actual[ix]).to eq(line)
       else
         expect(actual[ix]).to match(line)
       end
-    END
-    inspect_source(cop, source)
-
-    expect(cop.offenses).to be_empty
+    RUBY
   end
 
   it 'allows if else without variable assignment' do
-    source = <<-END.strip_indent
+    expect_no_offenses(<<-RUBY.strip_indent)
       if foo
         1
       else
         2
       end
-    END
-    inspect_source(cop, source)
-
-    expect(cop.offenses).to be_empty
+    RUBY
   end
 
   it 'allows assignment to the result of a ternary operation' do
-    source = 'bar = foo? ? "a" : "b"'
-    inspect_source(cop, source)
-
-    expect(cop.offenses).to be_empty
+    expect_no_offenses('bar = foo? ? "a" : "b"')
   end
 
   it 'registers an offense for assignment in ternary operation' do
@@ -82,17 +69,13 @@ describe RuboCop::Cop::Style::ConditionalAssignment do
   end
 
   it 'allows modifier if inside of if else' do
-    source = <<-END.strip_indent
+    expect_no_offenses(<<-RUBY.strip_indent)
       if foo
         a unless b
       else
         c unless d
       end
-    END
-
-    inspect_source(cop, source)
-
-    expect(cop.offenses).to be_empty
+    RUBY
   end
 
   it "doesn't crash when assignment statement uses chars which have " \
@@ -164,20 +147,17 @@ describe RuboCop::Cop::Style::ConditionalAssignment do
 
   context 'empty branch' do
     it 'allows an empty if statement' do
-      source = <<-END.strip_indent
+      expect_no_offenses(<<-RUBY.strip_indent)
         if foo
           # comment
         else
           do_something
         end
-      END
-      inspect_source(cop, source)
-
-      expect(cop.offenses).to be_empty
+      RUBY
     end
 
     it 'allows an empty elsif statement' do
-      source = <<-END.strip_indent
+      expect_no_offenses(<<-RUBY.strip_indent)
         if foo
           bar = 1
         elsif baz
@@ -185,64 +165,48 @@ describe RuboCop::Cop::Style::ConditionalAssignment do
         else
           bar = 2
         end
-      END
-      inspect_source(cop, source)
-
-      expect(cop.offenses).to be_empty
+      RUBY
     end
 
     it 'allows if elsif without else' do
-      source = <<-END.strip_indent
+      expect_no_offenses(<<-RUBY.strip_indent)
         if foo
           bar = 'some string'
         elsif bar
           bar = 'another string'
         end
-      END
-
-      inspect_source(cop, source)
-
-      expect(cop.offenses).to be_empty
+      RUBY
     end
 
     it 'allows assignment in if without an else' do
-      source = <<-END.strip_indent
+      expect_no_offenses(<<-RUBY.strip_indent)
         if foo
           bar = 1
         end
-      END
-      inspect_source(cop, source)
-
-      expect(cop.offenses).to be_empty
+      RUBY
     end
 
     it 'allows assignment in unless without an else' do
-      source = <<-END.strip_indent
+      expect_no_offenses(<<-RUBY.strip_indent)
         unless foo
           bar = 1
         end
-      END
-      inspect_source(cop, source)
-
-      expect(cop.offenses).to be_empty
+      RUBY
     end
 
     it 'allows assignment in case when without an else' do
-      source = <<-END.strip_indent
+      expect_no_offenses(<<-RUBY.strip_indent)
         case foo
         when "a"
           bar = 1
         when "b"
           bar = 2
         end
-      END
-      inspect_source(cop, source)
-
-      expect(cop.offenses).to be_empty
+      RUBY
     end
 
     it 'allows an empty when branch with an else' do
-      source = <<-END.strip_indent
+      expect_no_offenses(<<-RUBY.strip_indent)
         case foo
         when "a"
           # empty
@@ -251,55 +215,43 @@ describe RuboCop::Cop::Style::ConditionalAssignment do
         else
           bar = 3
         end
-      END
-      inspect_source(cop, source)
-
-      expect(cop.messages).to be_empty
+      RUBY
     end
 
     it 'allows case with an empty else' do
-      source = <<-END.strip_indent
+      expect_no_offenses(<<-RUBY.strip_indent)
         case foo
         when "b"
           bar = 2
         else
           # empty
         end
-      END
-      inspect_source(cop, source)
-
-      expect(cop.offenses).to be_empty
+      RUBY
     end
   end
 
   it 'allows assignment of different variables in if else' do
-    source = <<-END.strip_indent
+    expect_no_offenses(<<-RUBY.strip_indent)
       if foo
         bar = 1
       else
         baz = 1
       end
-    END
-    inspect_source(cop, source)
-
-    expect(cop.offenses).to be_empty
+    RUBY
   end
 
   it 'allows method calls in if else' do
-    source = <<-END.strip_indent
+    expect_no_offenses(<<-RUBY.strip_indent)
       if foo
         bar
       else
         baz
       end
-    END
-    inspect_source(cop, source)
-
-    expect(cop.offenses).to be_empty
+    RUBY
   end
 
   it 'allows if elsif else with the same assignment only in if else' do
-    source = <<-END.strip_indent
+    expect_no_offenses(<<-RUBY.strip_indent)
       if foo
         bar = 1
       elsif foobar
@@ -307,14 +259,11 @@ describe RuboCop::Cop::Style::ConditionalAssignment do
       else
         bar = 1
       end
-    END
-    inspect_source(cop, source)
-
-    expect(cop.offenses).to be_empty
+    RUBY
   end
 
   it 'allows if elsif else with the same assignment only in if elsif' do
-    source = <<-END.strip_indent
+    expect_no_offenses(<<-RUBY.strip_indent)
       if foo
         bar = 1
       elsif foobar
@@ -322,14 +271,11 @@ describe RuboCop::Cop::Style::ConditionalAssignment do
       else
         baz = 1
       end
-    END
-    inspect_source(cop, source)
-
-    expect(cop.offenses).to be_empty
+    RUBY
   end
 
   it 'allows if elsif else with the same assignment only in elsif else' do
-    source = <<-END.strip_indent
+    expect_no_offenses(<<-RUBY.strip_indent)
       if foo
         bar = 1
       elsif foobar
@@ -337,53 +283,41 @@ describe RuboCop::Cop::Style::ConditionalAssignment do
       else
         baz = 1
       end
-    END
-    inspect_source(cop, source)
-
-    expect(cop.offenses).to be_empty
+    RUBY
   end
 
   it 'allows assignment using different operators in if else' do
-    source = <<-END.strip_indent
+    expect_no_offenses(<<-RUBY.strip_indent)
       if foo
         bar = 1
       else
         bar << 2
       end
-    END
-    inspect_source(cop, source)
-
-    expect(cop.offenses).to be_empty
+    RUBY
   end
 
   it 'allows assignment using different (method) operators in if..else' do
-    source = <<-END.strip_indent
+    expect_no_offenses(<<-RUBY.strip_indent)
       if foo
         bar[index] = 1
       else
         bar << 2
       end
-    END
-    inspect_source(cop, source)
-
-    expect(cop.messages).to be_empty
+    RUBY
   end
 
   it 'allows aref assignment with different indices in if..else' do
-    source = <<-END.strip_indent
+    expect_no_offenses(<<-RUBY.strip_indent)
       if foo
         bar[1] = 1
       else
         bar[2] = 2
       end
-    END
-    inspect_source(cop, source)
-
-    expect(cop.messages).to be_empty
+    RUBY
   end
 
   it 'allows assignment using different operators in if elsif else' do
-    source = <<-END.strip_indent
+    expect_no_offenses(<<-RUBY.strip_indent)
       if foo
         bar = 1
       elsif foobar
@@ -391,24 +325,18 @@ describe RuboCop::Cop::Style::ConditionalAssignment do
       else
         bar << 3
       end
-    END
-    inspect_source(cop, source)
-
-    expect(cop.offenses).to be_empty
+    RUBY
   end
 
   it 'allows assignment of different variables in case when else' do
-    source = <<-END.strip_indent
+    expect_no_offenses(<<-RUBY.strip_indent)
       case foo
       when "a"
         bar = 1
       else
         baz = 2
       end
-    END
-    inspect_source(cop, source)
-
-    expect(cop.offenses).to be_empty
+    RUBY
   end
 
   context 'correction would exceed max line length' do
@@ -728,7 +656,7 @@ describe RuboCop::Cop::Style::ConditionalAssignment do
 
   context 'assignment as the last statement' do
     it 'allows more than variable assignment in if else' do
-      source = <<-END.strip_indent
+      expect_no_offenses(<<-RUBY.strip_indent)
         if foo
           method_call
           bar = 1
@@ -736,14 +664,11 @@ describe RuboCop::Cop::Style::ConditionalAssignment do
           method_call
           bar = 2
         end
-      END
-      inspect_source(cop, source)
-
-      expect(cop.offenses).to be_empty
+      RUBY
     end
 
     it 'allows more than variable assignment in if elsif else' do
-      source = <<-END.strip_indent
+      expect_no_offenses(<<-RUBY.strip_indent)
         if foo
           method_call
           bar = 1
@@ -754,14 +679,11 @@ describe RuboCop::Cop::Style::ConditionalAssignment do
           method_call
           bar = 3
         end
-      END
-      inspect_source(cop, source)
-
-      expect(cop.offenses).to be_empty
+      RUBY
     end
 
     it 'allows multiple assignment in if else' do
-      source = <<-END.strip_indent
+      expect_no_offenses(<<-RUBY.strip_indent)
         if baz
           foo = 1
           bar = 1
@@ -769,14 +691,11 @@ describe RuboCop::Cop::Style::ConditionalAssignment do
           foo = 2
           bar = 2
         end
-      END
-      inspect_source(cop, source)
-
-      expect(cop.offenses).to be_empty
+      RUBY
     end
 
     it 'allows multiple assignment in if elsif else' do
-      source = <<-END.strip_indent
+      expect_no_offenses(<<-RUBY.strip_indent)
         if baz
           foo = 1
           bar = 1
@@ -787,14 +706,11 @@ describe RuboCop::Cop::Style::ConditionalAssignment do
           foo = 3
           bar = 3
         end
-      END
-      inspect_source(cop, source)
-
-      expect(cop.offenses).to be_empty
+      RUBY
     end
 
     it 'allows multiple assignment in if elsif elsif else' do
-      source = <<-END.strip_indent
+      expect_no_offenses(<<-RUBY.strip_indent)
         if baz
           foo = 1
           bar = 1
@@ -808,10 +724,7 @@ describe RuboCop::Cop::Style::ConditionalAssignment do
           foo = 4
           bar = 4
         end
-      END
-      inspect_source(cop, source)
-
-      expect(cop.offenses).to be_empty
+      RUBY
     end
 
     it 'allows multiple assignment in if elsif else when the last ' \
@@ -856,7 +769,7 @@ describe RuboCop::Cop::Style::ConditionalAssignment do
     end
 
     it 'allows out of order multiple assignment in if elsif else' do
-      source = <<-END.strip_indent
+      expect_no_offenses(<<-RUBY.strip_indent)
         if baz
           bar = 1
           foo = 1
@@ -867,14 +780,11 @@ describe RuboCop::Cop::Style::ConditionalAssignment do
           foo = 3
           bar = 3
         end
-      END
-      inspect_source(cop, source)
-
-      expect(cop.offenses).to be_empty
+      RUBY
     end
 
     it 'allows multiple assignment in unless else' do
-      source = <<-END.strip_indent
+      expect_no_offenses(<<-RUBY.strip_indent)
         unless baz
           foo = 1
           bar = 1
@@ -882,14 +792,11 @@ describe RuboCop::Cop::Style::ConditionalAssignment do
           foo = 2
           bar = 2
         end
-      END
-      inspect_source(cop, source)
-
-      expect(cop.offenses).to be_empty
+      RUBY
     end
 
     it 'allows multiple assignments in case when with only one when' do
-      source = <<-END.strip_indent
+      expect_no_offenses(<<-RUBY.strip_indent)
         case foo
         when foobar
           foo = 1
@@ -898,14 +805,11 @@ describe RuboCop::Cop::Style::ConditionalAssignment do
           foo = 3
           bar = 3
         end
-      END
-      inspect_source(cop, source)
-
-      expect(cop.offenses).to be_empty
+      RUBY
     end
 
     it 'allows multiple assignments in case when with multiple whens' do
-      source = <<-END.strip_indent
+      expect_no_offenses(<<-RUBY.strip_indent)
         case foo
         when foobar
           foo = 1
@@ -917,10 +821,7 @@ describe RuboCop::Cop::Style::ConditionalAssignment do
           foo = 3
           bar = 3
         end
-      END
-      inspect_source(cop, source)
-
-      expect(cop.offenses).to be_empty
+      RUBY
     end
 
     it 'allows multiple assignments in case when if there are uniq ' \
@@ -1023,7 +924,7 @@ describe RuboCop::Cop::Style::ConditionalAssignment do
 
     context 'multiple assignment in only one branch' do
       it 'allows multiple assignment is in if' do
-        source = <<-END.strip_indent
+        expect_no_offenses(<<-RUBY.strip_indent)
           if foo
             baz = 1
             bar = 1
@@ -1034,14 +935,11 @@ describe RuboCop::Cop::Style::ConditionalAssignment do
             other_method
             bar = 3
           end
-        END
-        inspect_source(cop, source)
-
-        expect(cop.offenses).to be_empty
+        RUBY
       end
 
       it 'allows multiple assignment is in elsif' do
-        source = <<-END.strip_indent
+        expect_no_offenses(<<-RUBY.strip_indent)
           if foo
             method_call
             bar = 1
@@ -1052,14 +950,11 @@ describe RuboCop::Cop::Style::ConditionalAssignment do
             other_method
             bar = 3
           end
-        END
-        inspect_source(cop, source)
-
-        expect(cop.offenses).to be_empty
+        RUBY
       end
 
       it 'registers an offense when multiple assignment is in else' do
-        source = <<-END.strip_indent
+        expect_no_offenses(<<-RUBY.strip_indent)
           if foo
             method_call
             bar = 1
@@ -1070,10 +965,7 @@ describe RuboCop::Cop::Style::ConditionalAssignment do
             baz = 3
             bar = 3
           end
-        END
-        inspect_source(cop, source)
-
-        expect(cop.offenses).to be_empty
+        RUBY
       end
     end
   end
@@ -1131,17 +1023,14 @@ describe RuboCop::Cop::Style::ConditionalAssignment do
   end
 
   it 'allows different assignment types in case with when when else' do
-    source = <<-END.strip_indent
+    expect_no_offenses(<<-RUBY.strip_indent)
       case foo
       when foobar
         bar = 1
       else
         bar << 2
       end
-    END
-    inspect_source(cop, source)
-
-    expect(cop.offenses).to be_empty
+    RUBY
   end
 
   it 'allows assignment in multiple branches when it is ' \
@@ -1895,7 +1784,7 @@ describe RuboCop::Cop::Style::ConditionalAssignment do
       end
 
       it 'allows out of order multiple assignment in if elsif else' do
-        source = <<-END.strip_indent
+        expect_no_offenses(<<-RUBY.strip_indent)
           if baz
             bar = 1
             foo = 1
@@ -1906,10 +1795,7 @@ describe RuboCop::Cop::Style::ConditionalAssignment do
             foo = 3
             bar = 3
           end
-        END
-        inspect_source(cop, source)
-
-        expect(cop.offenses).to be_empty
+        RUBY
       end
 
       it 'allows multiple assignment in unless else' do
@@ -2420,10 +2306,7 @@ describe RuboCop::Cop::Style::ConditionalAssignment do
     end
 
     it 'allows assignment in ternary operation' do
-      source = 'foo? ? bar = "a" : bar = "b"'
-      inspect_source(cop, source)
-
-      expect(cop.offenses).to be_empty
+      expect_no_offenses('foo? ? bar = "a" : bar = "b"')
     end
   end
 end

--- a/spec/rubocop/cop/style/def_with_parentheses_spec.rb
+++ b/spec/rubocop/cop/style/def_with_parentheses_spec.rb
@@ -22,18 +22,14 @@ describe RuboCop::Cop::Style::DefWithParentheses do
   end
 
   it 'accepts def with arg and parens' do
-    src = <<-END.strip_indent
+    expect_no_offenses(<<-RUBY.strip_indent)
       def func(a)
       end
-    END
-    inspect_source(cop, src)
-    expect(cop.offenses).to be_empty
+    RUBY
   end
 
   it 'accepts empty parentheses in one liners' do
-    src = "def to_s() join '/' end"
-    inspect_source(cop, src)
-    expect(cop.offenses).to be_empty
+    expect_no_offenses("def to_s() join '/' end")
   end
 
   it 'auto-removes unneeded parens' do

--- a/spec/rubocop/cop/style/each_with_object_spec.rb
+++ b/spec/rubocop/cop/style/each_with_object_spec.rb
@@ -85,8 +85,7 @@ describe RuboCop::Cop::Style::EachWithObject do
   end
 
   it 'ignores inject and reduce passed in symbol' do
-    inspect_source(cop, '[].inject(:+)', '[].reduce(:+)')
-    expect(cop.offenses).to be_empty
+    expect_no_offenses('[].inject(:+)')
   end
 
   it 'does not blow up for reduce with no arguments' do

--- a/spec/rubocop/cop/style/empty_literal_spec.rb
+++ b/spec/rubocop/cop/style/empty_literal_spec.rb
@@ -34,15 +34,11 @@ describe RuboCop::Cop::Style::EmptyLiteral do
     end
 
     it 'does not registers an offense Array.new with block' do
-      source = 'test = Array.new { 1 }'
-      inspect_source(cop, source)
-      expect(cop.offenses).to be_empty
+      expect_no_offenses('test = Array.new { 1 }')
     end
 
     it 'does not register Array.new with block in other block' do
-      source = 'puts { Array.new { 1 } }'
-      inspect_source(cop, source)
-      expect(cop.offenses).to be_empty
+      expect_no_offenses('puts { Array.new { 1 } }')
     end
   end
 

--- a/spec/rubocop/cop/style/format_string_token_spec.rb
+++ b/spec/rubocop/cop/style/format_string_token_spec.rb
@@ -84,8 +84,7 @@ describe RuboCop::Cop::Style::FormatStringToken, :config do
   end
 
   it 'ignores xstr' do
-    inspect_source(cop, '`echo "%s %<annotated>s %{template}"`')
-    expect(cop.offenses).to eql([])
+    expect_no_offenses('`echo "%s %<annotated>s %{template}"`')
   end
 
   it 'handles dstrs' do
@@ -94,8 +93,7 @@ describe RuboCop::Cop::Style::FormatStringToken, :config do
   end
 
   it 'handles __FILE__' do
-    inspect_source(cop, '__FILE__')
-    expect(cop.offenses).to eql([])
+    expect_no_offenses('__FILE__')
   end
 
   it_behaves_like 'enforced styles for format string tokens', 'A'

--- a/spec/rubocop/cop/style/if_unless_modifier_of_if_unless_spec.rb
+++ b/spec/rubocop/cop/style/if_unless_modifier_of_if_unless_spec.rb
@@ -33,34 +33,24 @@ describe RuboCop::Cop::Style::IfUnlessModifierOfIfUnless do
   end
 
   context 'conditional with modifier in body' do
-    let(:source) do
-      <<-END.strip_indent
+    it 'accepts' do
+      expect_no_offenses(<<-RUBY.strip_indent)
         if condition
           then_part if maybe?
         end
-      END
-    end
-
-    it 'accepts' do
-      inspect_source(cop, source)
-      expect(cop.offenses).to be_empty
+      RUBY
     end
   end
 
   context 'nested conditionals' do
-    let(:source) do
-      <<-END.strip_indent
+    it 'accepts' do
+      expect_no_offenses(<<-RUBY.strip_indent)
         if external_condition
           if condition
             then_part
           end
         end
-      END
-    end
-
-    it 'accepts' do
-      inspect_source(cop, source)
-      expect(cop.offenses).to be_empty
+      RUBY
     end
   end
 end

--- a/spec/rubocop/cop/style/method_def_parentheses_spec.rb
+++ b/spec/rubocop/cop/style/method_def_parentheses_spec.rb
@@ -39,12 +39,10 @@ describe RuboCop::Cop::Style::MethodDefParentheses, :config do
     end
 
     it 'accepts def with no args and no parens' do
-      src = <<-END.strip_indent
+      expect_no_offenses(<<-RUBY.strip_indent)
         def func
         end
-      END
-      inspect_source(cop, src)
-      expect(cop.offenses).to be_empty
+      RUBY
     end
 
     it 'auto-adds required parens for a def' do

--- a/spec/rubocop/cop/style/option_hash_spec.rb
+++ b/spec/rubocop/cop/style/option_hash_spec.rb
@@ -52,39 +52,23 @@ describe RuboCop::Cop::Style::OptionHash, :config do
   end
 
   context 'when there are no arguments' do
-    before do
-      inspect_source(cop, source)
-    end
-
-    let(:source) do
-      <<-END.strip_indent
+    it 'does not register an offense' do
+      expect_no_offenses(<<-RUBY.strip_indent)
         def meditate
           puts true
           puts true
         end
-      END
-    end
-
-    it 'does not register an offense' do
-      expect(cop.offenses).to be_empty
+      RUBY
     end
   end
 
   context 'when the last argument is a non-options-hash optional hash' do
-    before do
-      inspect_source(cop, source)
-    end
-
-    let(:source) do
-      <<-END.strip_indent
+    it 'does not register an offense' do
+      expect_no_offenses(<<-RUBY.strip_indent)
         def cook(instructions, ingredients = { hot: [], cold: [] })
           prep(ingredients)
         end
-      END
-    end
-
-    it 'does not register an offense' do
-      expect(cop.offenses).to be_empty
+      RUBY
     end
   end
 end

--- a/spec/rubocop/cop/style/redundant_begin_spec.rb
+++ b/spec/rubocop/cop/style/redundant_begin_spec.rb
@@ -38,7 +38,7 @@ describe RuboCop::Cop::Style::RedundantBegin do
   end
 
   it 'accepts a def with required begin block' do
-    src = <<-END.strip_indent
+    expect_no_offenses(<<-RUBY.strip_indent)
       def func
         begin
           ala
@@ -47,13 +47,11 @@ describe RuboCop::Cop::Style::RedundantBegin do
         end
         something
       end
-    END
-    inspect_source(cop, src)
-    expect(cop.offenses).to be_empty
+    RUBY
   end
 
   it 'accepts a defs with required begin block' do
-    src = <<-END.strip_indent
+    expect_no_offenses(<<-RUBY.strip_indent)
       def Test.func
         begin
           ala
@@ -62,9 +60,7 @@ describe RuboCop::Cop::Style::RedundantBegin do
         end
         something
       end
-    END
-    inspect_source(cop, src)
-    expect(cop.offenses).to be_empty
+    RUBY
   end
 
   it 'auto-corrects source separated by newlines ' \

--- a/spec/rubocop/cop/style/redundant_parentheses_spec.rb
+++ b/spec/rubocop/cop/style/redundant_parentheses_spec.rb
@@ -245,15 +245,11 @@ describe RuboCop::Cop::Style::RedundantParentheses do
   end
 
   it 'accepts parentheses around a constant passed to when' do
-    source = <<-END.strip_indent
+    expect_no_offenses(<<-RUBY.strip_indent)
       case foo
       when(Const)
         bar
       end
-    END
-
-    inspect_source(cop, source)
-
-    expect(cop.offenses).to be_empty
+    RUBY
   end
 end

--- a/spec/rubocop/cop/style/redundant_return_spec.rb
+++ b/spec/rubocop/cop/style/redundant_return_spec.rb
@@ -49,35 +49,29 @@ describe RuboCop::Cop::Style::RedundantReturn, :config do
   end
 
   it 'accepts return in a non-final position' do
-    src = <<-END.strip_indent
+    expect_no_offenses(<<-RUBY.strip_indent)
       def func
         return something if something_else
       end
-    END
-    inspect_source(cop, src)
-    expect(cop.offenses).to be_empty
+    RUBY
   end
 
   it 'does not blow up on empty method body' do
-    src = <<-END.strip_indent
+    expect_no_offenses(<<-RUBY.strip_indent)
       def func
       end
-    END
-    inspect_source(cop, src)
-    expect(cop.offenses).to be_empty
+    RUBY
   end
 
   it 'does not blow up on empty if body' do
-    src = <<-END.strip_indent
+    expect_no_offenses(<<-RUBY.strip_indent)
       def func
         if x
         elsif y
         else
         end
       end
-    END
-    inspect_source(cop, src)
-    expect(cop.offenses).to be_empty
+    RUBY
   end
 
   it 'auto-corrects by removing redundant returns' do
@@ -232,47 +226,39 @@ describe RuboCop::Cop::Style::RedundantReturn, :config do
     let(:cop_config) { { 'AllowMultipleReturnValues' => true } }
 
     it 'accepts def with only a return' do
-      src = <<-END.strip_indent
+      expect_no_offenses(<<-RUBY.strip_indent)
         def func
           return something, test
         end
-      END
-      inspect_source(cop, src)
-      expect(cop.offenses).to be_empty
+      RUBY
     end
 
     it 'accepts defs with only a return' do
-      src = <<-END.strip_indent
+      expect_no_offenses(<<-RUBY.strip_indent)
         def Test.func
           return something, test
         end
-      END
-      inspect_source(cop, src)
-      expect(cop.offenses).to be_empty
+      RUBY
     end
 
     it 'accepts def ending with return' do
-      src = <<-END.strip_indent
+      expect_no_offenses(<<-RUBY.strip_indent)
         def func
           one
           two
           return something, test
         end
-      END
-      inspect_source(cop, src)
-      expect(cop.offenses).to be_empty
+      RUBY
     end
 
     it 'accepts defs ending with return' do
-      src = <<-END.strip_indent
+      expect_no_offenses(<<-RUBY.strip_indent)
         def self.func
           one
           two
           return something, test
         end
-      END
-      inspect_source(cop, src)
-      expect(cop.offenses).to be_empty
+      RUBY
     end
 
     it 'does not auto-correct' do

--- a/spec/rubocop/cop/style/redundant_self_spec.rb
+++ b/spec/rubocop/cop/style/redundant_self_spec.rb
@@ -10,55 +10,39 @@ describe RuboCop::Cop::Style::RedundantSelf do
   end
 
   it 'does not report an offense when receiver and lvalue have the same name' do
-    src = 'a = self.a'
-    inspect_source(cop, src)
-    expect(cop.offenses).to be_empty
+    expect_no_offenses('a = self.a')
   end
 
   it 'accepts a self receiver on an lvalue of an assignment' do
-    src = 'self.a = b'
-    inspect_source(cop, src)
-    expect(cop.offenses).to be_empty
+    expect_no_offenses('self.a = b')
   end
 
   it 'accepts a self receiver on an lvalue of a parallel assignment' do
-    src = 'a, self.b = c, d'
-    inspect_source(cop, src)
-    expect(cop.offenses).to be_empty
+    expect_no_offenses('a, self.b = c, d')
   end
 
   it 'accepts a self receiver on an lvalue of an or-assignment' do
-    src = 'self.logger ||= Rails.logger'
-    inspect_source(cop, src)
-    expect(cop.offenses).to be_empty
+    expect_no_offenses('self.logger ||= Rails.logger')
   end
 
   it 'accepts a self receiver on an lvalue of an and-assignment' do
-    src = 'self.flag &&= value'
-    inspect_source(cop, src)
-    expect(cop.offenses).to be_empty
+    expect_no_offenses('self.flag &&= value')
   end
 
   it 'accepts a self receiver on an lvalue of a plus-assignment' do
-    src = 'self.sum += 10'
-    inspect_source(cop, src)
-    expect(cop.offenses).to be_empty
+    expect_no_offenses('self.sum += 10')
   end
 
   it 'accepts a self receiver with the square bracket operator' do
-    src = 'self[a]'
-    inspect_source(cop, src)
-    expect(cop.offenses).to be_empty
+    expect_no_offenses('self[a]')
   end
 
   it 'accepts a self receiver with the double less-than operator' do
-    src = 'self << a'
-    inspect_source(cop, src)
-    expect(cop.offenses).to be_empty
+    expect_no_offenses('self << a')
   end
 
   it 'accepts a self receiver for methods named like ruby keywords' do
-    src = <<-END.strip_indent
+    expect_no_offenses(<<-RUBY.strip_indent)
       a = self.class
       self.for(deps, [], true)
       self.and(other)
@@ -95,44 +79,36 @@ describe RuboCop::Cop::Style::RedundantSelf do
       self.when
       self.while
       self.yield
-    END
-    inspect_source(cop, src)
-    expect(cop.offenses).to be_empty
+    RUBY
   end
 
   describe 'instance methods' do
     it 'accepts a self receiver used to distinguish from blockarg' do
-      src = <<-END.strip_indent
+      expect_no_offenses(<<-RUBY.strip_indent)
         def requested_specs(&groups)
           some_method(self.groups)
         end
-      END
-      inspect_source(cop, src)
-      expect(cop.offenses).to be_empty
+      RUBY
     end
 
     it 'accepts a self receiver used to distinguish from argument' do
-      src = <<-END.strip_indent
+      expect_no_offenses(<<-RUBY.strip_indent)
         def requested_specs(groups)
           some_method(self.groups)
         end
-      END
-      inspect_source(cop, src)
-      expect(cop.offenses).to be_empty
+      RUBY
     end
 
     it 'accepts a self receiver used to distinguish from optional argument' do
-      src = <<-END.strip_indent
+      expect_no_offenses(<<-RUBY.strip_indent)
         def requested_specs(final = true)
           something if self.final != final
         end
-      END
-      inspect_source(cop, src)
-      expect(cop.offenses).to be_empty
+      RUBY
     end
 
     it 'accepts a self receiver used to distinguish from local variable' do
-      src = <<-END.strip_indent
+      expect_no_offenses(<<-RUBY.strip_indent)
         def requested_specs
           @requested_specs ||= begin
             groups = self.groups - Bundler.settings.without
@@ -140,19 +116,15 @@ describe RuboCop::Cop::Style::RedundantSelf do
             specs_for(groups)
           end
         end
-      END
-      inspect_source(cop, src)
-      expect(cop.offenses).to be_empty
+      RUBY
     end
 
     it 'accepts a self receiver used to distinguish from an argument' do
-      src = <<-END.strip_indent
+      expect_no_offenses(<<-RUBY.strip_indent)
         def foo(bar)
           puts bar, self.bar
         end
-      END
-      inspect_source(cop, src)
-      expect(cop.offenses).to be_empty
+      RUBY
     end
 
     it 'accepts a self receiver used to distinguish from an argument' \
@@ -170,37 +142,31 @@ describe RuboCop::Cop::Style::RedundantSelf do
 
   describe 'class methods' do
     it 'accepts a self receiver used to distinguish from blockarg' do
-      src = <<-END.strip_indent
+      expect_no_offenses(<<-RUBY.strip_indent)
         def self.requested_specs(&groups)
           some_method(self.groups)
         end
-      END
-      inspect_source(cop, src)
-      expect(cop.offenses).to be_empty
+      RUBY
     end
 
     it 'accepts a self receiver used to distinguish from argument' do
-      src = <<-END.strip_indent
+      expect_no_offenses(<<-RUBY.strip_indent)
         def self.requested_specs(groups)
           some_method(self.groups)
         end
-      END
-      inspect_source(cop, src)
-      expect(cop.offenses).to be_empty
+      RUBY
     end
 
     it 'accepts a self receiver used to distinguish from optional argument' do
-      src = <<-END.strip_indent
+      expect_no_offenses(<<-RUBY.strip_indent)
         def self.requested_specs(final = true)
           something if self.final != final
         end
-      END
-      inspect_source(cop, src)
-      expect(cop.offenses).to be_empty
+      RUBY
     end
 
     it 'accepts a self receiver used to distinguish from local variable' do
-      src = <<-END.strip_indent
+      expect_no_offenses(<<-RUBY.strip_indent)
         def self.requested_specs
           @requested_specs ||= begin
             groups = self.groups - Bundler.settings.without
@@ -208,22 +174,16 @@ describe RuboCop::Cop::Style::RedundantSelf do
             specs_for(groups)
           end
         end
-      END
-      inspect_source(cop, src)
-      expect(cop.offenses).to be_empty
+      RUBY
     end
   end
 
   it 'accepts a self receiver used to distinguish from constant' do
-    src = 'self.Foo'
-    inspect_source(cop, src)
-    expect(cop.offenses).to be_empty
+    expect_no_offenses('self.Foo')
   end
 
   it 'accepts a self receiver of .()' do
-    src = 'self.()'
-    inspect_source(cop, src)
-    expect(cop.offenses).to be_empty
+    expect_no_offenses('self.()')
   end
 
   it 'reports an offence a self receiver of .call' do

--- a/spec/rubocop/cop/style/regexp_literal_spec.rb
+++ b/spec/rubocop/cop/style/regexp_literal_spec.rb
@@ -50,11 +50,8 @@ describe RuboCop::Cop::Style::RegexpLiteral, :config do
     let(:cop_config) { { 'EnforcedStyle' => 'slashes' } }
 
     describe 'a single-line `//` regex without slashes' do
-      let(:source) { 'foo = /a/' }
-
       it 'is accepted' do
-        inspect_source(cop, source)
-        expect(cop.offenses).to be_empty
+        expect_no_offenses('foo = /a/')
       end
     end
 
@@ -77,23 +74,19 @@ describe RuboCop::Cop::Style::RegexpLiteral, :config do
         before { cop_config['AllowInnerSlashes'] = true }
 
         it 'is accepted' do
-          inspect_source(cop, source)
-          expect(cop.offenses).to be_empty
+          expect_no_offenses('foo = /home\\//')
         end
       end
     end
 
     describe 'a multi-line `//` regex without slashes' do
-      let(:source) do
-        ['foo = /',
-         '  foo',
-         '  bar',
-         '/x']
-      end
-
       it 'is accepted' do
-        inspect_source(cop, source)
-        expect(cop.offenses).to be_empty
+        expect_no_offenses(<<-RUBY.strip_indent)
+          foo = /
+            foo
+            bar
+          /x
+        RUBY
       end
     end
 
@@ -119,8 +112,12 @@ describe RuboCop::Cop::Style::RegexpLiteral, :config do
         before { cop_config['AllowInnerSlashes'] = true }
 
         it 'is accepted' do
-          inspect_source(cop, source)
-          expect(cop.offenses).to be_empty
+          expect_no_offenses(<<-'RUBY'.strip_indent)
+            foo = /
+              https?:\/\/
+              example\.com
+            /x
+          RUBY
         end
       end
     end
@@ -145,8 +142,7 @@ describe RuboCop::Cop::Style::RegexpLiteral, :config do
       let(:source) { 'foo = %r{home/}' }
 
       it 'is accepted' do
-        inspect_source(cop, source)
-        expect(cop.offenses).to be_empty
+        expect_no_offenses('foo = %r{home/}')
       end
 
       describe 'when configured to allow inner slashes' do
@@ -194,8 +190,12 @@ describe RuboCop::Cop::Style::RegexpLiteral, :config do
       end
 
       it 'is accepted' do
-        inspect_source(cop, source)
-        expect(cop.offenses).to be_empty
+        expect_no_offenses(<<-RUBY.strip_indent)
+          foo = %r{
+            https?://
+            example\.com
+          }x
+        RUBY
       end
 
       describe 'when configured to allow inner slashes' do
@@ -288,48 +288,36 @@ describe RuboCop::Cop::Style::RegexpLiteral, :config do
     end
 
     describe 'a single-line %r regex without slashes' do
-      let(:source) { 'foo = %r{a}' }
-
       it 'is accepted' do
-        inspect_source(cop, source)
-        expect(cop.offenses).to be_empty
+        expect_no_offenses('foo = %r{a}')
       end
     end
 
     describe 'a single-line %r regex with slashes' do
-      let(:source) { 'foo = %r{home/}' }
-
       it 'is accepted' do
-        inspect_source(cop, source)
-        expect(cop.offenses).to be_empty
+        expect_no_offenses('foo = %r{home/}')
       end
     end
 
     describe 'a multi-line %r regex without slashes' do
-      let(:source) do
-        ['foo = %r{',
-         '  foo',
-         '  bar',
-         '}x']
-      end
-
       it 'is accepted' do
-        inspect_source(cop, source)
-        expect(cop.offenses).to be_empty
+        expect_no_offenses(<<-RUBY.strip_indent)
+          foo = %r{
+            foo
+            bar
+          }x
+        RUBY
       end
     end
 
     describe 'a multi-line %r regex with slashes' do
-      let(:source) do
-        ['foo = %r{',
-         '  https?://',
-         '  example\.com',
-         '}x']
-      end
-
       it 'is accepted' do
-        inspect_source(cop, source)
-        expect(cop.offenses).to be_empty
+        expect_no_offenses(<<-RUBY.strip_indent)
+          foo = %r{
+            https?://
+            example\.com
+          }x
+        RUBY
       end
     end
   end
@@ -338,11 +326,8 @@ describe RuboCop::Cop::Style::RegexpLiteral, :config do
     let(:cop_config) { { 'EnforcedStyle' => 'mixed' } }
 
     describe 'a single-line `//` regex without slashes' do
-      let(:source) { 'foo = /a/' }
-
       it 'is accepted' do
-        inspect_source(cop, source)
-        expect(cop.offenses).to be_empty
+        expect_no_offenses('foo = /a/')
       end
     end
 
@@ -365,8 +350,7 @@ describe RuboCop::Cop::Style::RegexpLiteral, :config do
         before { cop_config['AllowInnerSlashes'] = true }
 
         it 'is accepted' do
-          inspect_source(cop, source)
-          expect(cop.offenses).to be_empty
+          expect_no_offenses('foo = /home\\//')
         end
       end
     end
@@ -429,8 +413,7 @@ describe RuboCop::Cop::Style::RegexpLiteral, :config do
       let(:source) { 'foo = %r{home/}' }
 
       it 'is accepted' do
-        inspect_source(cop, source)
-        expect(cop.offenses).to be_empty
+        expect_no_offenses('foo = %r{home/}')
       end
 
       describe 'when configured to allow inner slashes' do
@@ -451,30 +434,24 @@ describe RuboCop::Cop::Style::RegexpLiteral, :config do
     end
 
     describe 'a multi-line %r regex without slashes' do
-      let(:source) do
-        ['foo = %r{',
-         '  foo',
-         '  bar',
-         '}x']
-      end
-
       it 'is accepted' do
-        inspect_source(cop, source)
-        expect(cop.offenses).to be_empty
+        expect_no_offenses(<<-RUBY.strip_indent)
+          foo = %r{
+            foo
+            bar
+          }x
+        RUBY
       end
     end
 
     describe 'a multi-line %r regex with slashes' do
-      let(:source) do
-        ['foo = %r{',
-         '  https?://',
-         '  example\.com',
-         '}x']
-      end
-
       it 'is accepted' do
-        inspect_source(cop, source)
-        expect(cop.offenses).to be_empty
+        expect_no_offenses(<<-RUBY.strip_indent)
+          foo = %r{
+            https?://
+            example\.com
+          }x
+        RUBY
       end
     end
   end

--- a/spec/rubocop/cop/style/rescue_modifier_spec.rb
+++ b/spec/rubocop/cop/style/rescue_modifier_spec.rb
@@ -243,9 +243,7 @@ describe RuboCop::Cop::Style::RescueModifier do
     subject(:cop) { described_class.new(config) }
 
     it 'processes excluded files with issue' do
-      inspect_source_file(cop, 'foo rescue bar')
-
-      expect(cop.messages).to be_empty
+      expect_no_offenses('foo rescue bar')
     end
   end
 end

--- a/spec/rubocop/cop/style/send_spec.rb
+++ b/spec/rubocop/cop/style/send_spec.rb
@@ -36,21 +36,21 @@ describe RuboCop::Cop::Style::Send do
 
     context 'and with a receiver' do
       it 'does not register an offense for an invocation with args' do
-        inspect_source(cop, 'Object.__send__(:inspect)')
+        expect_no_offenses('Object.__send__(:inspect)')
       end
 
       it 'does not register an offense for an invocation without args' do
-        inspect_source(cop, 'Object.__send__')
+        expect_no_offenses('Object.__send__')
       end
     end
 
     context 'and without a receiver' do
       it 'does not register an offense for an invocation with args' do
-        inspect_source(cop, '__send__(:inspect)')
+        expect_no_offenses('__send__(:inspect)')
       end
 
       it 'does not register an offense for an invocation without args' do
-        inspect_source(cop, '__send__')
+        expect_no_offenses('__send__')
       end
     end
   end
@@ -60,21 +60,21 @@ describe RuboCop::Cop::Style::Send do
 
     context 'and with a receiver' do
       it 'does not register an offense for an invocation with args' do
-        inspect_source(cop, 'Object.public_send(:inspect)')
+        expect_no_offenses('Object.public_send(:inspect)')
       end
 
       it 'does not register an offense for an invocation without args' do
-        inspect_source(cop, 'Object.public_send')
+        expect_no_offenses('Object.public_send')
       end
     end
 
     context 'and without a receiver' do
       it 'does not register an offense for an invocation with args' do
-        inspect_source(cop, 'public_send(:inspect)')
+        expect_no_offenses('public_send(:inspect)')
       end
 
       it 'does not register an offense for an invocation without args' do
-        inspect_source(cop, 'public_send')
+        expect_no_offenses('public_send')
       end
     end
   end

--- a/spec/rubocop/cop/style/string_literals_in_interpolation_spec.rb
+++ b/spec/rubocop/cop/style/string_literals_in_interpolation_spec.rb
@@ -24,39 +24,35 @@ describe RuboCop::Cop::Style::StringLiteralsInInterpolation, :config do
     end
 
     it 'accepts double quotes on a static string' do
-      src = '"A"'
-      inspect_source(cop, src)
-      expect(cop.offenses).to be_empty
+      expect_no_offenses('"A"')
     end
 
     it 'accepts double quotes on a broken static string' do
-      src = ['"A" \\',
-             '  "B"']
-      inspect_source(cop, src)
-      expect(cop.offenses).to be_empty
+      expect_no_offenses(<<-RUBY.strip_indent)
+        "A" \
+          "B"
+      RUBY
     end
 
     it 'accepts double quotes on static strings within a method' do
-      src = ['def m',
-             '  puts "A"',
-             '  puts "B"',
-             'end']
-      inspect_source(cop, src)
-      expect(cop.offenses).to be_empty
+      expect_no_offenses(<<-RUBY.strip_indent)
+        def m
+          puts "A"
+          puts "B"
+        end
+      RUBY
     end
 
     it 'can handle a built-in constant parsed as string' do
       # Parser will produce str nodes for constants such as __FILE__.
-      src = ['if __FILE__ == $PROGRAM_NAME',
-             'end']
-      inspect_source(cop, src)
-      expect(cop.offenses).to be_empty
+      expect_no_offenses(<<-RUBY.strip_indent)
+        if __FILE__ == $PROGRAM_NAME
+        end
+      RUBY
     end
 
     it 'can handle character literals' do
-      src = 'a = ?/'
-      inspect_source(cop, src)
-      expect(cop.offenses).to be_empty
+      expect_no_offenses('a = ?/')
     end
 
     it 'auto-corrects " with \'' do

--- a/spec/rubocop/cop/style/string_literals_spec.rb
+++ b/spec/rubocop/cop/style/string_literals_spec.rb
@@ -48,12 +48,11 @@ describe RuboCop::Cop::Style::StringLiterals, :config do
     end
 
     it 'accepts heredocs' do
-      inspect_source(cop,
-                     ['execute <<-SQL',
-                      '  SELECT name from users',
-                      'SQL'])
-
-      expect(cop.offenses).to be_empty
+      expect_no_offenses(<<-RUBY.strip_indent)
+        execute <<-SQL
+          SELECT name from users
+        SQL
+      RUBY
     end
 
     it 'accepts double quotes when new line is used' do
@@ -61,9 +60,9 @@ describe RuboCop::Cop::Style::StringLiterals, :config do
     end
 
     it 'accepts double quotes when interpolating & quotes in multiple lines' do
-      inspect_source(cop, '"#{encode_severity}:' \
-                          '#{sprintf(\'%3d\', line_number)}: #{m}"')
-      expect(cop.offenses).to be_empty
+      expect_no_offenses(<<-'RUBY'.strip_indent)
+        "#{encode_severity}:#{sprintf('%3d', line_number)}: #{m}"
+      RUBY
     end
 
     it 'accepts double quotes when single quotes are used' do
@@ -97,10 +96,10 @@ describe RuboCop::Cop::Style::StringLiterals, :config do
     it 'accepts double quotes with some other special symbols' do
       # "Substitutions in double-quoted strings"
       # http://www.ruby-doc.org/docs/ProgrammingRuby/html/language.html
-      src = ['g = "\xf9"',
-             'copyright = "\u00A9"']
-      inspect_source(cop, src)
-      expect(cop.offenses).to be_empty
+      expect_no_offenses(<<-'RUBY'.strip_indent)
+        g = "\xf9"
+        copyright = "\u00A9"
+      RUBY
     end
 
     it 'accepts " in a %w' do
@@ -112,9 +111,7 @@ describe RuboCop::Cop::Style::StringLiterals, :config do
     end
 
     it 'accepts double quotes in interpolation' do
-      src = '"#{"A"}"'
-      inspect_source(cop, src)
-      expect(cop.offenses).to be_empty
+      expect_no_offenses("\"\#{\"A\"}\"")
     end
 
     it 'detects unneeded double quotes within concatenated string' do
@@ -125,16 +122,14 @@ describe RuboCop::Cop::Style::StringLiterals, :config do
 
     it 'can handle a built-in constant parsed as string' do
       # Parser will produce str nodes for constants such as __FILE__.
-      src = ['if __FILE__ == $PROGRAM_NAME',
-             'end']
-      inspect_source(cop, src)
-      expect(cop.offenses).to be_empty
+      expect_no_offenses(<<-RUBY.strip_indent)
+        if __FILE__ == $PROGRAM_NAME
+        end
+      RUBY
     end
 
     it 'can handle character literals' do
-      src = 'a = ?/'
-      inspect_source(cop, src)
-      expect(cop.offenses).to be_empty
+      expect_no_offenses('a = ?/')
     end
 
     it 'auto-corrects " with \'' do
@@ -216,20 +211,19 @@ describe RuboCop::Cop::Style::StringLiterals, :config do
     end
 
     it 'accepts heredocs' do
-      inspect_source(cop,
-                     ['execute <<-SQL',
-                      '  SELECT name from users',
-                      'SQL'])
-
-      expect(cop.offenses).to be_empty
+      expect_no_offenses(<<-RUBY.strip_indent)
+        execute <<-SQL
+          SELECT name from users
+        SQL
+      RUBY
     end
 
     it 'accepts single quotes when they are needed' do
-      src = ["a = '\\n'",
-             "b = '\"'",
-             "c = '\#{x}'"]
-      inspect_source(cop, src)
-      expect(cop.offenses).to be_empty
+      expect_no_offenses(<<-'RUBY'.strip_indent)
+        a = '\n'
+        b = '"'
+        c = '#{x}'
+      RUBY
     end
 
     it 'flags single quotes with plain # (not #@var or #{interpolation}' do
@@ -247,10 +241,10 @@ describe RuboCop::Cop::Style::StringLiterals, :config do
 
     it 'can handle a built-in constant parsed as string' do
       # Parser will produce str nodes for constants such as __FILE__.
-      src = ['if __FILE__ == $PROGRAM_NAME',
-             'end']
-      inspect_source(cop, src)
-      expect(cop.offenses).to be_empty
+      expect_no_offenses(<<-RUBY.strip_indent)
+        if __FILE__ == $PROGRAM_NAME
+        end
+      RUBY
     end
 
     it "auto-corrects ' with \"" do
@@ -290,9 +284,10 @@ describe RuboCop::Cop::Style::StringLiterals, :config do
       end
 
       it 'accepts continued strings using all single quotes' do
-        inspect_source(cop, ["'abc' \\",
-                             "'def'"])
-        expect(cop.offenses).to be_empty
+        expect_no_offenses(<<-RUBY.strip_indent)
+          'abc' \
+          'def'
+        RUBY
       end
 
       it 'registers an offense for mixed quote styles in a continued string' do
@@ -314,35 +309,40 @@ describe RuboCop::Cop::Style::StringLiterals, :config do
       end
 
       it "doesn't register offense for double quotes with interpolation" do
-        inspect_source(cop, ['"abc" \\',
-                             '"def#{1}"'])
-        expect(cop.offenses).to be_empty
+        expect_no_offenses(<<-'RUBY'.strip_indent)
+          "abc" \
+          "def#{1}"
+        RUBY
       end
 
       it "doesn't register offense for double quotes with embedded single" do
-        inspect_source(cop, ['"abc\'" \\',
-                             '"def"'])
-        expect(cop.offenses).to be_empty
+        expect_no_offenses(<<-RUBY.strip_indent)
+          "abc'" \
+          "def"
+        RUBY
       end
 
       it 'accepts for double quotes with an escaped special character' do
-        inspect_source(cop, ['"abc\\t" \\',
-                             '"def"'])
-        expect(cop.offenses).to be_empty
+        expect_no_offenses(<<-'RUBY'.strip_indent)
+          "abc\t" \
+          "def"
+        RUBY
       end
 
       it 'accepts for double quotes with an escaped normal character' do
-        inspect_source(cop, ['"abc\\!" \\',
-                             '"def"'])
-        expect(cop.offenses).to be_empty
+        expect_no_offenses(<<-'RUBY'.strip_indent)
+          "abc\!" \
+          "def"
+        RUBY
       end
 
       it "doesn't choke on heredocs with inconsistent indentation" do
-        inspect_source(cop, ['<<-QUERY_STRING',
-                             '  DEFINE',
-                             '    BLAH',
-                             'QUERY_STRING'])
-        expect(cop.offenses).to be_empty
+        expect_no_offenses(<<-RUBY.strip_indent)
+          <<-QUERY_STRING
+            DEFINE
+              BLAH
+          QUERY_STRING
+        RUBY
       end
     end
 
@@ -355,9 +355,10 @@ describe RuboCop::Cop::Style::StringLiterals, :config do
       end
 
       it 'accepts continued strings using all double quotes' do
-        inspect_source(cop, ['"abc" \\',
-                             '"def"'])
-        expect(cop.offenses).to be_empty
+        expect_no_offenses(<<-RUBY.strip_indent)
+          "abc" \
+          "def"
+        RUBY
       end
 
       it 'registers an offense for mixed quote styles in a continued string' do
@@ -379,9 +380,10 @@ describe RuboCop::Cop::Style::StringLiterals, :config do
       end
 
       it "doesn't register offense for single quotes with embedded double" do
-        inspect_source(cop, ["'abc\"' \\",
-                             "'def'"])
-        expect(cop.offenses).to be_empty
+        expect_no_offenses(<<-RUBY.strip_indent)
+          'abc"' \
+          'def'
+        RUBY
       end
     end
   end

--- a/spec/rubocop/cop/style/unneeded_capital_w_spec.rb
+++ b/spec/rubocop/cop/style/unneeded_capital_w_spec.rb
@@ -23,7 +23,7 @@ describe RuboCop::Cop::Style::UnneededCapitalW do
   end
 
   it 'registers no offense for %W with special characters' do
-    source = <<-'END'.strip_indent
+    expect_no_offenses(<<-'RUBY'.strip_indent)
       def dangerous_characters
         %W(\000) +
         %W(\001) +
@@ -40,9 +40,7 @@ describe RuboCop::Cop::Style::UnneededCapitalW do
         %W(\n)
         %W(\!)
       end
-    END
-    inspect_source(cop, source)
-    expect(cop.offenses).to be_empty
+    RUBY
   end
 
   it 'registers no offense for %w without interpolation' do

--- a/spec/rubocop/cop/style/word_array_spec.rb
+++ b/spec/rubocop/cop/style/word_array_spec.rb
@@ -92,8 +92,7 @@ describe RuboCop::Cop::Style::WordArray, :config do
 
     it 'does not register offense for array with allowed number of strings' do
       cop_config['MinSize'] = 4
-      inspect_source(cop, '["one", "two", "three"]')
-      expect(cop.offenses).to be_empty
+      expect_no_offenses('["one", "two", "three"]')
     end
 
     it 'does not register an offense for an array with comments in it' do


### PR DESCRIPTION
More changes to use `expect_no_offenses`. With this PR there is officially more usage of `expect_offense` and `expect_no_offenses` than `inspect_source` usage!

```
$ ag --stats-only 'inspect_source'
1556 matches
240 files contained matches
1012 files searched
4726233 bytes searched
0.021424 seconds
```

```
$ ag --stats-only '(?:expect_offenses|expect_no_offenses)'
1925 matches
276 files contained matches
1012 files searched
4726233 bytes searched
0.021768 seconds
```
