### PR TITLE
[Fix #4366] Prevent `Performance/RedundantMerge` from blowing up on double splat argument

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,7 @@
 * [#4339](https://github.com/bbatsov/rubocop/pull/4339): Fix false positive in `Security/Eval` cop for multiline string lietral. ([@pocke][])
 * [#4339](https://github.com/bbatsov/rubocop/pull/4339): Fix false negative in `Security/Eval` cop for `Binding#eval`. ([@pocke][])
 * [#4327](https://github.com/bbatsov/rubocop/issues/4327): Prevent `Layout/SpaceInsidePercentLiteralDelimiters` from registering offenses on execute-strings. ([@drenmi][])
+* [#4366](https://github.com/bbatsov/rubocop/issues/4366): Prevent `Performance/RedundantMerge` from blowing up on double splat arguments. ([@drenmi][])
 
 ## 0.48.1 (2017-04-03)
 

--- a/lib/rubocop/cop/performance/redundant_merge.rb
+++ b/lib/rubocop/cop/performance/redundant_merge.rb
@@ -21,6 +21,8 @@ module RuboCop
 
         def on_send(node)
           each_redundant_merge(node) do |receiver, pairs|
+            return if pairs.any?(&:kwsplat_type?)
+
             assignments = to_assignments(receiver, pairs).join('; ')
             message = format(MSG, assignments, node.source)
             add_offense(node, :expression, message)

--- a/spec/rubocop/cop/performance/redundant_merge_spec.rb
+++ b/spec/rubocop/cop/performance/redundant_merge_spec.rb
@@ -45,6 +45,14 @@ describe RuboCop::Cop::Performance::RedundantMerge, :config do
     end
   end
 
+  context 'when any argument is a double splat' do
+    it 'does not register an offense' do
+      expect_no_offenses(<<-RUBY.strip_indent)
+        foo.merge!(baz: qux, **bar)
+      RUBY
+    end
+  end
+
   context 'when internal to each_with_object' do
     it 'autocorrects when the receiver is the object being built' do
       source = <<-END.strip_indent


### PR DESCRIPTION
This cop would raise an error when encountering a double splat argument:

```
foo.merge!(**bar)
```

This change fixes that.

-----------------

Before submitting the PR make sure the following are checked:

* [X] Wrote [good commit messages][1].
* [X] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [X] Used the same coding conventions as the rest of the project.
* [X] Feature branch is up-to-date with `master` (if not - rebase it).
* [X] Squashed related commits together.
* [X] Added tests.
* [X] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [X] All tests are passing.
* [X] The new code doesn't generate RuboCop offenses.
* [X] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [ ] Updated cop documentation with `rake generate_cops_documentation` (required only when you've added a new cop or changed the configuration/documentation of an existing cop).

[1]: http://chris.beams.io/posts/git-commit/
