### PR TITLE
[Fix #4371] Prevent `Style/MethodName` from complaining about unary o…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,7 @@
 * [#4339](https://github.com/bbatsov/rubocop/pull/4339): Fix false positive in `Security/Eval` cop for multiline string lietral. ([@pocke][])
 * [#4339](https://github.com/bbatsov/rubocop/pull/4339): Fix false negative in `Security/Eval` cop for `Binding#eval`. ([@pocke][])
 * [#4327](https://github.com/bbatsov/rubocop/issues/4327): Prevent `Layout/SpaceInsidePercentLiteralDelimiters` from registering offenses on execute-strings. ([@drenmi][])
+* [#4371](https://github.com/bbatsov/rubocop/issues/4371): Prevent `Style/MethodName` from complaining about unary operator definitions. ([@drenmi][])
 
 ## 0.48.1 (2017-04-03)
 

--- a/lib/rubocop/cop/style/method_name.rb
+++ b/lib/rubocop/cop/style/method_name.rb
@@ -11,16 +11,22 @@ module RuboCop
 
         def on_def(node)
           name, = *node
-          check_name(node, name, node.loc.name)
+          check_name(node, sanitize_name(name), node.loc.name)
         end
 
         def on_defs(node)
           _object, name, = *node
-          check_name(node, name, node.loc.name)
+          check_name(node, sanitize_name(name), node.loc.name)
         end
+
+        private
 
         def message(style)
           format('Use %s for method names.', style)
+        end
+
+        def sanitize_name(name)
+          name.to_s.delete('@').to_sym
         end
       end
     end

--- a/spec/rubocop/cop/style/method_name_spec.rb
+++ b/spec/rubocop/cop/style/method_name_spec.rb
@@ -49,6 +49,16 @@ describe RuboCop::Cop::Style::MethodName, :config do
       END
     end
 
+    it 'accepts unary operator definitions' do
+      expect_no_offenses(<<-END.strip_indent)
+        def ~@; end
+      END
+
+      expect_no_offenses(<<-END.strip_indent)
+        def !@; end
+      END
+    end
+
     %w[class module].each do |kind|
       it "accepts class emitter method in a #{kind}" do
         inspect_source(cop, <<-END.strip_indent)


### PR DESCRIPTION
This cop would complain of not using the configured method naming scheme when defining unary operators, e.g.:

```
def ~@
  # ...
end
```

This was happening because we internally check the method name against our list of known operators, but the cop was passing the trailing `@` as well, causing in a lookup miss.

This change fixes that.

-----------------

Before submitting the PR make sure the following are checked:

* [X] Wrote [good commit messages][1].
* [X] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [X] Used the same coding conventions as the rest of the project.
* [X] Feature branch is up-to-date with `master` (if not - rebase it).
* [X] Squashed related commits together.
* [X] Added tests.
* [X] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [X] All tests are passing.
* [X] The new code doesn't generate RuboCop offenses.
* [X] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [ ] Updated cop documentation with `rake generate_cops_documentation` (required only when you've added a new cop or changed the configuration/documentation of an existing cop).

[1]: http://chris.beams.io/posts/git-commit/
