### PR TITLE
Make Style/AutoResourceCleanup examples equivalent

### DIFF
--- a/manual/cops_style.md
+++ b/manual/cops_style.md
@@ -139,7 +139,7 @@ resource cleanup.
 f = File.open('file')
 
 # good
-f = File.open('file') do
+File.open('file') do |f|
   ...
 end
 ```


### PR DESCRIPTION
In the bad example, `f` is the `File` object, so in the good example it should be the same.
(Prior to this commit, `f` in the good example is the return value of the block passed to `File.open`.)

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Used the same coding conventions as the rest of the project.
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] All tests are passing.
* [x] The new code doesn't generate RuboCop offenses.
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Updated cop documentation with `rake generate_cops_documentation` (required only when you've added a new cop or changed the configuration/documentation of an existing cop).

[1]: http://chris.beams.io/posts/git-commit/
