### PR TITLE
[Fix #4352] Fix auto-correct of AndOr with Enumerable accessors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,7 @@
 * [#4327](https://github.com/bbatsov/rubocop/issues/4327): Prevent `Layout/SpaceInsidePercentLiteralDelimiters` from registering offenses on execute-strings. ([@drenmi][])
 * [#4371](https://github.com/bbatsov/rubocop/issues/4371): Prevent `Style/MethodName` from complaining about unary operator definitions. ([@drenmi][])
 * [#4366](https://github.com/bbatsov/rubocop/issues/4366): Prevent `Performance/RedundantMerge` from blowing up on double splat arguments. ([@drenmi][])
+* [#4352](https://github.com/bbatsov/rubocop/issues/4352): Fix the auto-correct of `Style/AndOr` when Enumerable accessors (`[]`) are used. ([@rrosenblum][])
 
 ## 0.48.1 (2017-04-03)
 

--- a/lib/rubocop/cop/style/and_or.rb
+++ b/lib/rubocop/cop/style/and_or.rb
@@ -108,7 +108,7 @@ module RuboCop
         end
 
         def correctable_send?(node)
-          !node.parenthesized? && node.arguments?
+          !node.parenthesized? && !node.method?(:[]) && node.arguments?
         end
 
         def whitespace_before_arg(node)

--- a/spec/rubocop/cop/style/and_or_spec.rb
+++ b/spec/rubocop/cop/style/and_or_spec.rb
@@ -136,6 +136,12 @@ describe RuboCop::Cop::Style::AndOr, :config do
       expect(new_source).to eq('(x = a + b) && (return x)')
     end
 
+    it 'autocorrects "and" with an Enumerable accessor on either side' do
+      src = 'foo[:bar] and foo[:baz]'
+      new_source = autocorrect_source(cop, src)
+      expect(new_source).to eq('foo[:bar] && foo[:baz]')
+    end
+
     it 'warns on short-circuit (and)' do
       expect_offense(<<-RUBY.strip_indent)
         x = a + b and return x


### PR DESCRIPTION
This fixes #4352 