### PR TITLE
[Fix #4331] Added ability to configure Severity for AllCops

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@
 * [#4320](https://github.com/bbatsov/rubocop/pull/4320): Update `Rails/OutputSafety` to disallow wrapping `raw` or `html_safe` with `safe_join`. ([@klesse413][])
 * [#4336](https://github.com/bbatsov/rubocop/issues/4336): Store `rubocop_cache` in safer directories. ([@jonas054][])
 * [#4361](https://github.com/bbatsov/rubocop/pull/4361): Use relative path for offense message in `Lint/DuplicateMethods`. ([@pocke][])
+* [#4331](https://github.com/bbatsov/rubocop/issues/4331): Added ability to configure `Severity` for `AllCops` ([@ipepe][])
 
 ### Bug fixes
 

--- a/lib/rubocop/config.rb
+++ b/lib/rubocop/config.rb
@@ -116,6 +116,9 @@ module RuboCop
         qualified_cop_name = Cop::Cop.qualified_cop_name(cop, loaded_path)
         cop_options = self[qualified_cop_name] || {}
         cop_options['Enabled'] = enable_cop?(qualified_cop_name, cop_options)
+        if (severity = for_all_cops['Severity']) && !cop_options['Severity']
+          cop_options['Severity'] = severity
+        end
         h[cop] = cop_options
       end
       @hash = hash

--- a/manual/configuration.md
+++ b/manual/configuration.md
@@ -246,6 +246,17 @@ to. The level is `warning` for `Lint` and `convention` for all the others.
 Cops can customize their severity level. Allowed params are `refactor`,
 `convention`, `warning`, `error` and `fatal`.
 
+You can also override Severity in all Cops like:
+```yaml
+AllCops:
+  Severity: error
+```
+
+If you specify Severity in particular Cop cofiguration, it will take over 
+Severity value from AllCops config. So basically Severity from most important 
+to least looks like this: explicit value for particular Cop from `.rubocop.yml`,
+AllCops value from `.rubocop.yml`, internal value and default value.
+
 There is one exception from the general rule above and that is `Lint/Syntax`, a
 special cop that checks for syntax errors before the other cops are invoked. It
 can not be disabled and its severity (`fatal`) can not be changed in

--- a/spec/rubocop/config_spec.rb
+++ b/spec/rubocop/config_spec.rb
@@ -497,6 +497,56 @@ describe RuboCop::Config do
     end
   end
 
+  context 'whether the cop inherits Severity from AllCops' do
+    def cop_severity_level(cop_class)
+      configuration.for_cop(cop_class)['Severity']
+    end
+
+    context 'when AllCops define Severity as fatal' do
+      context 'and tested Cop does not define its own Severity' do
+        let(:hash) do
+          {
+            'AllCops' => { 'Severity' => 'fatal' },
+            'Layout/TrailingWhitespace' => { 'Enabled' => true }
+          }
+        end
+        it 'successfully inherits Severity' do
+          cop_class = RuboCop::Cop::Layout::TrailingWhitespace
+          expect(cop_severity_level(cop_class)).to be 'fatal'
+        end
+      end
+      context 'and tested Cop does define its own Severity' do
+        let(:hash) do
+          {
+            'AllCops' => { 'Severity' => 'fatal' },
+            'Layout/TrailingWhitespace' => {
+              'Enabled' => true,
+              'Severity' => 'error'
+            }
+          }
+        end
+        it 'successfully inherits Severity' do
+          cop_class = RuboCop::Cop::Layout::TrailingWhitespace
+          expect(cop_severity_level(cop_class)).to be 'error'
+        end
+      end
+      context 'and tested Cop does define its own Severity' do
+        let(:hash) do
+          {
+            'AllCops' => {},
+            'Layout/TrailingWhitespace' => {
+              'Enabled' => true
+            }
+          }
+        end
+        it 'successfully inherits Severity' do
+          cop_class = RuboCop::Cop::Layout::TrailingWhitespace
+          expect(cop_severity_level(cop_class)).to be nil
+        end
+      end
+    end
+  end
+
   context 'whether the cop is enabled' do
     def cop_enabled(cop_class)
       configuration.for_cop(cop_class).fetch('Enabled')


### PR DESCRIPTION
**I added global severity configuration in AllCops config. You can specify all cops for warning, error or whatever You want in just one place. It does not break any current configurations of rubocop. PR for #4331 **

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Used the same coding conventions as the rest of the project.
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [ ] All tests are passing.
* [x] The new code doesn't generate RuboCop offenses.
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [ ] Updated cop documentation with `rake generate_cops_documentation` (required only when you've added a new cop or changed the configuration/documentation of an existing cop).

[1]: http://chris.beams.io/posts/git-commit/
