### PR TITLE
Fix typo in manual/coms.md

### DIFF
--- a/manual/cops.md
+++ b/manual/cops.md
@@ -59,7 +59,7 @@ associated with potential security issues.
 ### Rails
 
 Rails cops are specific to the Ruby on Rails framework. Unlike all other cop
-types they are not used by default, and you have to request them explicity:
+types they are not used by default, and you have to request them explicitly:
 
 ```sh
 $ rubocop -R


### PR DESCRIPTION
I found and fixed typo in manual/cops.md.
(`explicity` to `explicitly`)

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Used the same coding conventions as the rest of the project.
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [ ] Added tests.
* [ ] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] All tests are passing.
* [x] The new code doesn't generate RuboCop offenses.
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [ ] Updated cop documentation with `rake generate_cops_documentation` (required only when you've added a new cop or changed the configuration/documentation of an existing cop).

[1]: http://chris.beams.io/posts/git-commit/
