### PR TITLE
Fix typo for Runner#check_for_unneeded_disables?

### DIFF
--- a/lib/rubocop/runner.rb
+++ b/lib/rubocop/runner.rb
@@ -126,7 +126,7 @@ module RuboCop
     end
 
     def add_unneeded_disables(file, offenses, source)
-      if check_for_unneded_disables?(source)
+      if check_for_unneeded_disables?(source)
         config = @config_store.for(file)
         if config.for_cop(Cop::Lint::UnneededDisable).fetch('Enabled')
           cop = Cop::Lint::UnneededDisable.new(config, @options)
@@ -142,7 +142,7 @@ module RuboCop
       offenses.sort.reject(&:disabled?).freeze
     end
 
-    def check_for_unneded_disables?(source)
+    def check_for_unneeded_disables?(source)
       !source.disabled_line_ranges.empty? && !filtered_run?
     end
 


### PR DESCRIPTION
Fixed typo in Runner class method.

-----------------

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Used the same coding conventions as the rest of the project.
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [ ] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] All tests are passing.
* [x] The new code doesn't generate RuboCop offenses.
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Updated cop documentation with `rake generate_cops_documentation` (required only when you've added a new cop or changed the configuration/documentation of an existing cop).

[1]: http://chris.beams.io/posts/git-commit/
