### PR TITLE
Remove described_class::MSG usage in specs

### DIFF
--- a/spec/rubocop/cop/layout/indent_assignment_spec.rb
+++ b/spec/rubocop/cop/layout/indent_assignment_spec.rb
@@ -10,6 +10,10 @@ describe RuboCop::Cop::Layout::IndentAssignment, :config do
   end
   let(:cop_indent) { nil } # use indentation with from Layout/IndentationWidth
 
+  let(:message) do
+    'Indent the first line of the right-hand-side of a multi-line assignment.'
+  end
+
   it 'registers an offense for incorrectly indented rhs' do
     inspect_source(cop, <<-END.strip_indent)
       a =
@@ -18,7 +22,7 @@ describe RuboCop::Cop::Layout::IndentAssignment, :config do
 
     expect(cop.offenses.length).to eq(1)
     expect(cop.highlights).to eq(['if b ; end'])
-    expect(cop.message).to eq(described_class::MSG)
+    expect(cop.message).to eq(message)
   end
 
   it 'allows assignments that do not start on a newline' do
@@ -52,7 +56,7 @@ describe RuboCop::Cop::Layout::IndentAssignment, :config do
 
     expect(cop.offenses.length).to eq(1)
     expect(cop.highlights).to eq(['if b ; end'])
-    expect(cop.message).to eq(described_class::MSG)
+    expect(cop.message).to eq(message)
   end
 
   it 'ignores comparison operators' do

--- a/spec/rubocop/cop/layout/space_inside_array_percent_literal_spec.rb
+++ b/spec/rubocop/cop/layout/space_inside_array_percent_literal_spec.rb
@@ -3,6 +3,10 @@
 describe RuboCop::Cop::Layout::SpaceInsideArrayPercentLiteral do
   subject(:cop) { described_class.new }
 
+  let(:message) do
+    'Use only a single space inside array percent literal.'
+  end
+
   %w[i I w W].each do |type|
     [%w[{ }], %w[( )], %w([ ]), %w[! !]].each do |(ldelim, rdelim)|
       context "for #{type} type and #{[ldelim, rdelim]} delimiters" do
@@ -19,7 +23,7 @@ describe RuboCop::Cop::Layout::SpaceInsideArrayPercentLiteral do
           inspect_source(cop, source)
           expect(cop.offenses.size).to eq(1)
           expect(cop.highlights).to eq(['   '])
-          expect(cop.messages).to eq([described_class::MSG])
+          expect(cop.messages).to eq([message])
           expect_corrected(source, code_example('1 2'))
         end
 

--- a/spec/rubocop/cop/layout/space_inside_percent_literal_delimiters_spec.rb
+++ b/spec/rubocop/cop/layout/space_inside_percent_literal_delimiters_spec.rb
@@ -3,6 +3,10 @@
 describe RuboCop::Cop::Layout::SpaceInsidePercentLiteralDelimiters do
   subject(:cop) { described_class.new }
 
+  let(:message) do
+    'Do not use spaces inside percent literal delimiters.'
+  end
+
   %w[i I w W x].each do |type|
     [%w[{ }], %w[( )], %w([ ]), %w[! !]].each do |(ldelim, rdelim)|
       context "for #{type} type and #{[ldelim, rdelim]} delimiters" do
@@ -18,7 +22,7 @@ describe RuboCop::Cop::Layout::SpaceInsidePercentLiteralDelimiters do
           source = code_example(' 1 2  ')
           inspect_source(cop, source)
           expect(cop.offenses.size).to eq(2)
-          expect(cop.messages.uniq).to eq([described_class::MSG])
+          expect(cop.messages.uniq).to eq([message])
           expect(cop.highlights).to eq([' ', '  '])
           expect_corrected(source, code_example('1 2'))
         end

--- a/spec/rubocop/cop/lint/ambiguous_block_association_spec.rb
+++ b/spec/rubocop/cop/lint/ambiguous_block_association_spec.rb
@@ -4,7 +4,10 @@ require 'spec_helper'
 
 describe RuboCop::Cop::Lint::AmbiguousBlockAssociation do
   subject(:cop) { described_class.new }
-  subject(:error_message) { described_class::MSG }
+  let(:error_message) do
+    'Parenthesize the param `%s` to make sure that the block will be ' \
+      'associated with the `%s` method call.'
+  end
 
   before { inspect_source(cop, source) }
 

--- a/spec/rubocop/cop/lint/empty_expression_spec.rb
+++ b/spec/rubocop/cop/lint/empty_expression_spec.rb
@@ -28,7 +28,7 @@ describe RuboCop::Cop::Lint::EmptyExpression, :config do
     end
   end
 
-  let(:message) { described_class::MSG }
+  let(:message) { 'Avoid empty expressions.' }
 
   context 'when used as a standalone expression' do
     it_behaves_like 'code with offense',

--- a/spec/rubocop/cop/lint/empty_when_spec.rb
+++ b/spec/rubocop/cop/lint/empty_when_spec.rb
@@ -36,7 +36,7 @@ describe RuboCop::Cop::Lint::EmptyWhen, :config do
     end
   end
 
-  let(:message) { described_class::MSG }
+  let(:message) { 'Avoid `when` branches without a body.' }
 
   context 'when a `when` body is missing' do
     it_behaves_like 'code with offense', <<-END.strip_indent

--- a/spec/rubocop/cop/lint/percent_string_array_spec.rb
+++ b/spec/rubocop/cop/lint/percent_string_array_spec.rb
@@ -3,10 +3,15 @@
 describe RuboCop::Cop::Lint::PercentStringArray do
   subject(:cop) { described_class.new }
 
+  let(:message) do
+    "Within `%w`/`%W`, quotes and ',' are unnecessary and may be " \
+      'unwanted in the resulting strings.'
+  end
+
   def expect_offense(source)
     inspect_source(cop, source)
 
-    expect(cop.offenses.map(&:message)).to eq([described_class::MSG])
+    expect(cop.offenses.map(&:message)).to eq([message])
     expect(cop.highlights).to eq([source])
   end
 

--- a/spec/rubocop/cop/lint/percent_symbol_array_spec.rb
+++ b/spec/rubocop/cop/lint/percent_symbol_array_spec.rb
@@ -3,10 +3,15 @@
 describe RuboCop::Cop::Lint::PercentSymbolArray do
   subject(:cop) { described_class.new }
 
+  let(:message) do
+    "Within `%i`/`%I`, ':' and ',' are unnecessary and may be " \
+      'unwanted in the resulting symbols.'
+  end
+
   def expect_offense(source)
     inspect_source(cop, source)
 
-    expect(cop.offenses.map(&:message)).to eq([described_class::MSG])
+    expect(cop.offenses.map(&:message)).to eq([message])
     expect(cop.highlights).to eq([source])
   end
 

--- a/spec/rubocop/cop/performance/case_when_splat_spec.rb
+++ b/spec/rubocop/cop/performance/case_when_splat_spec.rb
@@ -3,6 +3,11 @@
 describe RuboCop::Cop::Performance::CaseWhenSplat do
   subject(:cop) { described_class.new }
 
+  let(:message) do
+    'Place `when` conditions with a splat at ' \
+      'the end of the `when` branches.'
+  end
+
   it 'allows case when without splat' do
     expect_no_offenses(<<-RUBY.strip_indent)
       case foo
@@ -86,7 +91,7 @@ describe RuboCop::Cop::Performance::CaseWhenSplat do
         nil
       end
     END
-    expect(cop.messages).to eq([described_class::MSG])
+    expect(cop.messages).to eq([message])
     expect(cop.highlights).to eq(['when *Foo'])
   end
 
@@ -180,7 +185,7 @@ describe RuboCop::Cop::Performance::CaseWhenSplat do
       end
     END
 
-    expect(cop.messages).to eq([described_class::MSG])
+    expect(cop.messages).to eq([message])
     expect(cop.highlights).to eq(['when *cond'])
   end
 

--- a/spec/rubocop/cop/performance/fixed_size_spec.rb
+++ b/spec/rubocop/cop/performance/fixed_size_spec.rb
@@ -3,38 +3,42 @@
 describe RuboCop::Cop::Performance::FixedSize do
   subject(:cop) { described_class.new }
 
+  let(:message) do
+    'Do not compute the size of statically sized objects.'
+  end
+
   shared_examples :common_functionality do |method|
     context 'strings' do
       it "registers an offense when calling #{method} on a single quoted " \
          'string' do
         inspect_source(cop, "'a'.#{method}")
 
-        expect(cop.messages).to eq([described_class::MSG])
+        expect(cop.messages).to eq([message])
       end
 
       it "registers an offense when calling #{method} on a double quoted " \
          'string' do
         inspect_source(cop, "\"a\".#{method}")
 
-        expect(cop.messages).to eq([described_class::MSG])
+        expect(cop.messages).to eq([message])
       end
 
       it "registers an offense when calling #{method} on a %q string" do
         inspect_source(cop, "%q(a).#{method}")
 
-        expect(cop.messages).to eq([described_class::MSG])
+        expect(cop.messages).to eq([message])
       end
 
       it "registers an offense when calling #{method} on a %Q string" do
         inspect_source(cop, "%Q(a).#{method}")
 
-        expect(cop.messages).to eq([described_class::MSG])
+        expect(cop.messages).to eq([message])
       end
 
       it "registers an offense when calling #{method} on a % string" do
         inspect_source(cop, "%(a).#{method}")
 
-        expect(cop.messages).to eq([described_class::MSG])
+        expect(cop.messages).to eq([message])
       end
 
       it "accepts calling #{method} on a double quoted string that " \
@@ -93,13 +97,13 @@ describe RuboCop::Cop::Performance::FixedSize do
       it "registers an offense when calling #{method} on a symbol" do
         inspect_source(cop, ":foo.#{method}")
 
-        expect(cop.messages).to eq([described_class::MSG])
+        expect(cop.messages).to eq([message])
       end
 
       it "registers an offense when calling #{method} on a quoted symbol" do
         inspect_source(cop, ":'foo-bar'.#{method}")
 
-        expect(cop.messages).to eq([described_class::MSG])
+        expect(cop.messages).to eq([message])
       end
 
       it "accepts calling #{method} on an interpolated quoted symbol" do
@@ -111,7 +115,7 @@ describe RuboCop::Cop::Performance::FixedSize do
       it "registers an offense when calling #{method} on %s" do
         inspect_source(cop, "%s(foo-bar).#{method}")
 
-        expect(cop.messages).to eq([described_class::MSG])
+        expect(cop.messages).to eq([message])
       end
 
       it "accepts calling #{method} on a symbol that is assigned " \
@@ -126,19 +130,19 @@ describe RuboCop::Cop::Performance::FixedSize do
       it "registers an offense when calling #{method} on an array using []" do
         inspect_source(cop, "[1, 2, foo].#{method}")
 
-        expect(cop.messages).to eq([described_class::MSG])
+        expect(cop.messages).to eq([message])
       end
 
       it "registers an offense when calling #{method} on an array using %w" do
         inspect_source(cop, "%w(1, 2, foo).#{method}")
 
-        expect(cop.messages).to eq([described_class::MSG])
+        expect(cop.messages).to eq([message])
       end
 
       it "registers an offense when calling #{method} on an array using %W" do
         inspect_source(cop, "%W(1, 2, foo).#{method}")
 
-        expect(cop.messages).to eq([described_class::MSG])
+        expect(cop.messages).to eq([message])
       end
 
       it "accepts calling #{method} on an array using [] that contains " \
@@ -169,7 +173,7 @@ describe RuboCop::Cop::Performance::FixedSize do
       it "registers an offense when calling #{method} on a hash using {}" do
         inspect_source(cop, "{a: 1, b: 2}.#{method}")
 
-        expect(cop.messages).to eq([described_class::MSG])
+        expect(cop.messages).to eq([message])
       end
 
       it "accepts calling #{method} on a hash set to a variable" do
@@ -218,7 +222,7 @@ describe RuboCop::Cop::Performance::FixedSize do
     it 'registers an offense when calling count with a string' do
       inspect_source(cop, "#{variable}.count('o')")
 
-      expect(cop.messages).to eq([described_class::MSG])
+      expect(cop.messages).to eq([message])
     end
 
     it 'accepts calling count with a block' do

--- a/spec/rubocop/cop/rails/application_job_spec.rb
+++ b/spec/rubocop/cop/rails/application_job_spec.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 describe RuboCop::Cop::Rails::ApplicationJob do
-  let(:msgs) { [described_class::MSG] }
+  let(:msgs) { ['Jobs should subclass `ApplicationJob`.'] }
 
   context 'rails 4', :rails4, :config do
     subject(:cop) { described_class.new(config) }

--- a/spec/rubocop/cop/rails/application_record_spec.rb
+++ b/spec/rubocop/cop/rails/application_record_spec.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 describe RuboCop::Cop::Rails::ApplicationRecord do
-  let(:msgs) { [described_class::MSG] }
+  let(:msgs) { ['Models should subclass `ApplicationRecord`.'] }
 
   context 'rails 4', :rails4, :config do
     subject(:cop) { described_class.new(config) }

--- a/spec/rubocop/cop/style/conditional_assignment_assign_to_condition_spec.rb
+++ b/spec/rubocop/cop/style/conditional_assignment_assign_to_condition_spec.rb
@@ -21,6 +21,11 @@ describe RuboCop::Cop::Style::ConditionalAssignment do
                         })
   end
 
+  let(:message) do
+    'Use the return of the conditional ' \
+    'for variable assignment and comparison.'
+  end
+
   it 'counts array assignment when determining multiple assignment' do
     expect_no_offenses(<<-RUBY.strip_indent)
       if foo
@@ -61,7 +66,7 @@ describe RuboCop::Cop::Style::ConditionalAssignment do
     source = 'foo? ? bar = "a" : bar = "b"'
     inspect_source(cop, source)
 
-    expect(cop.messages).to eq([described_class::MSG])
+    expect(cop.messages).to eq([message])
   end
 
   it 'allows modifier if' do
@@ -106,7 +111,7 @@ describe RuboCop::Cop::Style::ConditionalAssignment do
 
       inspect_source(cop, source)
 
-      expect(cop.messages).to eq([described_class::MSG])
+      expect(cop.messages).to eq([message])
     end
 
     it 'registers an offense for comparison methods in unless else' do
@@ -120,7 +125,7 @@ describe RuboCop::Cop::Style::ConditionalAssignment do
 
       inspect_source(cop, source)
 
-      expect(cop.messages).to eq([described_class::MSG])
+      expect(cop.messages).to eq([message])
     end
 
     it 'registers an offense for comparison methods in case when' do
@@ -135,7 +140,7 @@ describe RuboCop::Cop::Style::ConditionalAssignment do
 
       inspect_source(cop, source)
 
-      expect(cop.messages).to eq([described_class::MSG])
+      expect(cop.messages).to eq([message])
     end
   end
 
@@ -393,7 +398,7 @@ describe RuboCop::Cop::Style::ConditionalAssignment do
     it 'registers an offense assigning any variable type in ternary' do
       inspect_source(cop, "foo? ? #{variable} = 1 : #{variable} = 2")
 
-      expect(cop.messages).to eq([described_class::MSG])
+      expect(cop.messages).to eq([message])
     end
 
     it 'registers an offense assigning any variable type in if else' do
@@ -406,7 +411,7 @@ describe RuboCop::Cop::Style::ConditionalAssignment do
       END
       inspect_source(cop, source)
 
-      expect(cop.messages).to eq([described_class::MSG])
+      expect(cop.messages).to eq([message])
     end
 
     it 'registers an offense assigning any variable type in case when' do
@@ -420,7 +425,7 @@ describe RuboCop::Cop::Style::ConditionalAssignment do
       END
       inspect_source(cop, source)
 
-      expect(cop.messages).to eq([described_class::MSG])
+      expect(cop.messages).to eq([message])
     end
 
     it 'allows assignment to the return of if else' do
@@ -477,7 +482,7 @@ describe RuboCop::Cop::Style::ConditionalAssignment do
           source = "foo? ? #{name} #{assignment} 1 : #{name} #{assignment} 2"
           inspect_source(cop, source)
 
-          expect(cop.messages).to eq([described_class::MSG])
+          expect(cop.messages).to eq([message])
         end
 
         it "allows assignment using #{assignment} to ternary" do
@@ -498,7 +503,7 @@ describe RuboCop::Cop::Style::ConditionalAssignment do
           END
           inspect_source(cop, source)
 
-          expect(cop.messages).to eq([described_class::MSG])
+          expect(cop.messages).to eq([message])
         end
 
         it "registers an offense for assignment using #{assignment} in "\
@@ -513,7 +518,7 @@ describe RuboCop::Cop::Style::ConditionalAssignment do
           END
           inspect_source(cop, source)
 
-          expect(cop.messages).to eq([described_class::MSG])
+          expect(cop.messages).to eq([message])
         end
 
         it "autocorrects for assignment using #{assignment} in if else" do
@@ -573,7 +578,7 @@ describe RuboCop::Cop::Style::ConditionalAssignment do
     END
     inspect_source(cop, source)
 
-    expect(cop.messages).to eq([described_class::MSG])
+    expect(cop.messages).to eq([message])
   end
 
   it 'registers an offense for assignment in if elsif elsif else' do
@@ -590,7 +595,7 @@ describe RuboCop::Cop::Style::ConditionalAssignment do
     END
     inspect_source(cop, source)
 
-    expect(cop.messages).to eq([described_class::MSG])
+    expect(cop.messages).to eq([message])
   end
 
   it 'registers an offense for assignment in if else when the assignment ' \
@@ -613,7 +618,7 @@ describe RuboCop::Cop::Style::ConditionalAssignment do
     END
     inspect_source(cop, source)
 
-    expect(cop.messages).to eq([described_class::MSG])
+    expect(cop.messages).to eq([message])
   end
 
   it 'autocorrects assignment in if else when the assignment ' \
@@ -978,7 +983,7 @@ describe RuboCop::Cop::Style::ConditionalAssignment do
     END
     inspect_source(cop, source)
 
-    expect(cop.messages).to eq([described_class::MSG])
+    expect(cop.messages).to eq([message])
   end
 
   it 'registers an offense for assignment in unless else' do
@@ -991,7 +996,7 @@ describe RuboCop::Cop::Style::ConditionalAssignment do
     END
     inspect_source(cop, source)
 
-    expect(cop.messages).to eq([described_class::MSG])
+    expect(cop.messages).to eq([message])
   end
 
   it 'registers an offense for assignment in case when then else' do
@@ -1003,7 +1008,7 @@ describe RuboCop::Cop::Style::ConditionalAssignment do
     END
     inspect_source(cop, source)
 
-    expect(cop.messages).to eq([described_class::MSG])
+    expect(cop.messages).to eq([message])
   end
 
   it 'registers an offense for assignment in case with when when else' do
@@ -1019,7 +1024,7 @@ describe RuboCop::Cop::Style::ConditionalAssignment do
     END
     inspect_source(cop, source)
 
-    expect(cop.messages).to eq([described_class::MSG])
+    expect(cop.messages).to eq([message])
   end
 
   it 'allows different assignment types in case with when when else' do
@@ -1707,7 +1712,7 @@ describe RuboCop::Cop::Style::ConditionalAssignment do
         END
         inspect_source(cop, source)
 
-        expect(cop.messages).to eq([described_class::MSG])
+        expect(cop.messages).to eq([message])
       end
 
       it 'registers an offense in if elsif else with more than ' \
@@ -1726,7 +1731,7 @@ describe RuboCop::Cop::Style::ConditionalAssignment do
         END
         inspect_source(cop, source)
 
-        expect(cop.messages).to eq([described_class::MSG])
+        expect(cop.messages).to eq([message])
       end
 
       it 'register an offense for multiple assignment in if else' do
@@ -1741,7 +1746,7 @@ describe RuboCop::Cop::Style::ConditionalAssignment do
         END
         inspect_source(cop, source)
 
-        expect(cop.messages).to eq([described_class::MSG])
+        expect(cop.messages).to eq([message])
       end
 
       it 'registers an offense for multiple assignment in if elsif else' do
@@ -1759,7 +1764,7 @@ describe RuboCop::Cop::Style::ConditionalAssignment do
         END
         inspect_source(cop, source)
 
-        expect(cop.messages).to eq([described_class::MSG])
+        expect(cop.messages).to eq([message])
       end
 
       it 'allows multiple assignment in if elsif elsif else' do
@@ -1780,7 +1785,7 @@ describe RuboCop::Cop::Style::ConditionalAssignment do
         END
         inspect_source(cop, source)
 
-        expect(cop.messages).to eq([described_class::MSG])
+        expect(cop.messages).to eq([message])
       end
 
       it 'allows out of order multiple assignment in if elsif else' do
@@ -1810,7 +1815,7 @@ describe RuboCop::Cop::Style::ConditionalAssignment do
         END
         inspect_source(cop, source)
 
-        expect(cop.messages).to eq([described_class::MSG])
+        expect(cop.messages).to eq([message])
       end
 
       it 'allows multiple assignments in case when with only one when' do
@@ -1826,7 +1831,7 @@ describe RuboCop::Cop::Style::ConditionalAssignment do
         END
         inspect_source(cop, source)
 
-        expect(cop.messages).to eq([described_class::MSG])
+        expect(cop.messages).to eq([message])
       end
 
       it 'allows multiple assignments in case when with multiple whens' do
@@ -1845,7 +1850,7 @@ describe RuboCop::Cop::Style::ConditionalAssignment do
         END
         inspect_source(cop, source)
 
-        expect(cop.messages).to eq([described_class::MSG])
+        expect(cop.messages).to eq([message])
       end
 
       it 'registers an offense in if elsif else with some branches only ' \
@@ -1866,7 +1871,7 @@ describe RuboCop::Cop::Style::ConditionalAssignment do
         END
         inspect_source(cop, source)
 
-        expect(cop.messages).to eq([described_class::MSG])
+        expect(cop.messages).to eq([message])
       end
 
       it 'registers an offense in unless else with more than ' \
@@ -1882,7 +1887,7 @@ describe RuboCop::Cop::Style::ConditionalAssignment do
         END
         inspect_source(cop, source)
 
-        expect(cop.messages).to eq([described_class::MSG])
+        expect(cop.messages).to eq([message])
       end
 
       it 'registers an offense in case when else with more than ' \
@@ -1900,7 +1905,7 @@ describe RuboCop::Cop::Style::ConditionalAssignment do
 
         inspect_source(cop, source)
 
-        expect(cop.messages).to eq([described_class::MSG])
+        expect(cop.messages).to eq([message])
       end
 
       context 'multiple assignment in only one branch' do
@@ -1989,7 +1994,7 @@ describe RuboCop::Cop::Style::ConditionalAssignment do
       END
       inspect_source(cop, source)
 
-      expect(cop.messages).to eq([described_class::MSG])
+      expect(cop.messages).to eq([message])
     end
 
     context 'auto-correct' do

--- a/spec/rubocop/cop/style/documentation_method_spec.rb
+++ b/spec/rubocop/cop/style/documentation_method_spec.rb
@@ -39,7 +39,7 @@ describe RuboCop::Cop::Style::DocumentationMethod, :config do
     )
   end
 
-  let(:message) { described_class::MSG }
+  let(:message) { 'Missing method documentation comment.' }
 
   context 'when declaring methods outside a class' do
     context 'without documentation comment' do

--- a/spec/rubocop/cop/style/empty_case_condition_spec.rb
+++ b/spec/rubocop/cop/style/empty_case_condition_spec.rb
@@ -3,10 +3,14 @@
 describe RuboCop::Cop::Style::EmptyCaseCondition do
   subject(:cop) { described_class.new }
 
+  let(:message) do
+    'Do not use empty `case` condition, instead use an `if` expression.'
+  end
+
   shared_examples 'detect/correct empty case, accept non-empty case' do
     it 'registers an offense' do
       inspect_source(cop, source)
-      expect(cop.messages).to eq [described_class::MSG]
+      expect(cop.messages).to eq [message]
     end
 
     it 'correctly autocorrects' do

--- a/spec/rubocop/cop/style/multiline_memoization_spec.rb
+++ b/spec/rubocop/cop/style/multiline_memoization_spec.rb
@@ -2,7 +2,7 @@
 
 describe RuboCop::Cop::Style::MultilineMemoization, :config do
   subject(:cop) { described_class.new(config) }
-  let(:message) { described_class::MSG }
+  let(:message) { 'Wrap multiline memoization blocks in `begin` and `end`.' }
 
   before do
     inspect_source(cop, source)

--- a/spec/rubocop/cop/style/optional_arguments_spec.rb
+++ b/spec/rubocop/cop/style/optional_arguments_spec.rb
@@ -3,6 +3,10 @@
 describe RuboCop::Cop::Style::OptionalArguments do
   subject(:cop) { described_class.new }
 
+  let(:message) do
+    'Optional arguments should appear at the end of the argument list.'
+  end
+
   it 'registers an offense when an optional argument is followed by a ' \
      'required argument' do
     inspect_source(cop, <<-END.strip_indent)
@@ -10,8 +14,7 @@ describe RuboCop::Cop::Style::OptionalArguments do
       end
     END
 
-    expect(cop.messages)
-      .to eq([described_class::MSG])
+    expect(cop.messages).to eq([message])
     expect(cop.highlights).to eq(['a = 1'])
   end
 
@@ -22,7 +25,7 @@ describe RuboCop::Cop::Style::OptionalArguments do
       end
     END
 
-    expect(cop.messages).to eq([described_class::MSG, described_class::MSG])
+    expect(cop.messages).to eq([message, message])
     expect(cop.highlights).to eq(['a = 1', 'b = 2'])
   end
 
@@ -86,7 +89,7 @@ describe RuboCop::Cop::Style::OptionalArguments do
           end
         END
 
-        expect(cop.messages).to eq([described_class::MSG])
+        expect(cop.messages).to eq([message])
         expect(cop.highlights).to eq(['a = 1'])
       end
 

--- a/spec/rubocop/cop/style/safe_navigation_spec.rb
+++ b/spec/rubocop/cop/style/safe_navigation_spec.rb
@@ -4,6 +4,11 @@ describe RuboCop::Cop::Style::SafeNavigation, :config do
   subject(:cop) { described_class.new(config) }
   let(:cop_config) { { 'ConvertCodeThatCanStartToReturnNil' => false } }
 
+  let(:message) do
+    'Use safe navigation (`&.`) instead of checking if an object ' \
+      'exists before calling the method.'
+  end
+
   context 'target_ruby_version > 2.3', :ruby23 do
     it 'allows calls to methods not safeguarded by respond_to' do
       expect_no_offenses('foo.bar')
@@ -50,28 +55,28 @@ describe RuboCop::Cop::Style::SafeNavigation, :config do
           'safeguarded by a check for the accessed variable' do
           inspect_source(cop, "#{variable}[1].bar if #{variable}[1]")
 
-          expect(cop.messages).to eq([described_class::MSG])
+          expect(cop.messages).to eq([message])
         end
 
         it 'registers an offense for a method call safeguarded with a check ' \
           'for the object' do
           inspect_source(cop, "#{variable}.bar if #{variable}")
 
-          expect(cop.messages).to eq([described_class::MSG])
+          expect(cop.messages).to eq([message])
         end
 
         it 'registers an offense for a method call with params safeguarded ' \
           'with a check for the object' do
           inspect_source(cop, "#{variable}.bar(baz) if #{variable}")
 
-          expect(cop.messages).to eq([described_class::MSG])
+          expect(cop.messages).to eq([message])
         end
 
         it 'registers an offense for a method call with a block safeguarded ' \
           'with a check for the object' do
           inspect_source(cop, "#{variable}.bar { |e| e.qux } if #{variable}")
 
-          expect(cop.messages).to eq([described_class::MSG])
+          expect(cop.messages).to eq([message])
         end
 
         it 'registers an offense for a method call with params and a block ' \
@@ -79,21 +84,21 @@ describe RuboCop::Cop::Style::SafeNavigation, :config do
           inspect_source(cop,
                          "#{variable}.bar(baz) { |e| e.qux } if #{variable}")
 
-          expect(cop.messages).to eq([described_class::MSG])
+          expect(cop.messages).to eq([message])
         end
 
         it 'registers an offense for a method call safeguarded with a ' \
           'negative check for the object' do
           inspect_source(cop, "#{variable}.bar unless !#{variable}")
 
-          expect(cop.messages).to eq([described_class::MSG])
+          expect(cop.messages).to eq([message])
         end
 
         it 'registers an offense for a method call with params safeguarded ' \
           'with a negative check for the object' do
           inspect_source(cop, "#{variable}.bar(baz) unless !#{variable}")
 
-          expect(cop.messages).to eq([described_class::MSG])
+          expect(cop.messages).to eq([message])
         end
 
         it 'registers an offense for a method call with a block safeguarded ' \
@@ -101,7 +106,7 @@ describe RuboCop::Cop::Style::SafeNavigation, :config do
           inspect_source(cop,
                          "#{variable}.bar { |e| e.qux } unless !#{variable}")
 
-          expect(cop.messages).to eq([described_class::MSG])
+          expect(cop.messages).to eq([message])
         end
 
         it 'registers an offense for a method call with params and a block ' \
@@ -110,21 +115,21 @@ describe RuboCop::Cop::Style::SafeNavigation, :config do
 
           inspect_source(cop, source)
 
-          expect(cop.messages).to eq([described_class::MSG])
+          expect(cop.messages).to eq([message])
         end
 
         it 'registers an offense for a method call safeguarded with a nil ' \
           'check for the object' do
           inspect_source(cop, "#{variable}.bar unless #{variable}.nil?")
 
-          expect(cop.messages).to eq([described_class::MSG])
+          expect(cop.messages).to eq([message])
         end
 
         it 'registers an offense for a method call with params safeguarded ' \
           'with a nil check for the object' do
           inspect_source(cop, "#{variable}.bar(baz) unless #{variable}.nil?")
 
-          expect(cop.messages).to eq([described_class::MSG])
+          expect(cop.messages).to eq([message])
         end
 
         it 'registers an offense for a method call with a block safeguarded ' \
@@ -133,7 +138,7 @@ describe RuboCop::Cop::Style::SafeNavigation, :config do
 
           inspect_source(cop, source)
 
-          expect(cop.messages).to eq([described_class::MSG])
+          expect(cop.messages).to eq([message])
         end
 
         it 'registers an offense for a method call with params and a block ' \
@@ -142,21 +147,21 @@ describe RuboCop::Cop::Style::SafeNavigation, :config do
 
           inspect_source(cop, source)
 
-          expect(cop.messages).to eq([described_class::MSG])
+          expect(cop.messages).to eq([message])
         end
 
         it 'registers an offense for a method call safeguarded with a ' \
           'negative nil check for the object' do
           inspect_source(cop, "#{variable}.bar if !#{variable}.nil?")
 
-          expect(cop.messages).to eq([described_class::MSG])
+          expect(cop.messages).to eq([message])
         end
 
         it 'registers an offense for a method call with params safeguarded ' \
           'with a negative nil check for the object' do
           inspect_source(cop, "#{variable}.bar(baz) if !#{variable}.nil?")
 
-          expect(cop.messages).to eq([described_class::MSG])
+          expect(cop.messages).to eq([message])
         end
 
         it 'registers an offense for a method call with a block safeguarded ' \
@@ -165,7 +170,7 @@ describe RuboCop::Cop::Style::SafeNavigation, :config do
 
           inspect_source(cop, source)
 
-          expect(cop.messages).to eq([described_class::MSG])
+          expect(cop.messages).to eq([message])
         end
 
         it 'registers an offense for a method call with params and a block ' \
@@ -174,7 +179,7 @@ describe RuboCop::Cop::Style::SafeNavigation, :config do
 
           inspect_source(cop, source)
 
-          expect(cop.messages).to eq([described_class::MSG])
+          expect(cop.messages).to eq([message])
         end
       end
 
@@ -187,7 +192,7 @@ describe RuboCop::Cop::Style::SafeNavigation, :config do
             end
           END
 
-          expect(cop.messages).to eq([described_class::MSG])
+          expect(cop.messages).to eq([message])
         end
 
         it 'registers an offense for a single method call inside of a ' \
@@ -198,7 +203,7 @@ describe RuboCop::Cop::Style::SafeNavigation, :config do
             end
           END
 
-          expect(cop.messages).to eq([described_class::MSG])
+          expect(cop.messages).to eq([message])
         end
 
         it 'registers an offense for a single method call inside of an ' \
@@ -209,7 +214,7 @@ describe RuboCop::Cop::Style::SafeNavigation, :config do
             end
           END
 
-          expect(cop.messages).to eq([described_class::MSG])
+          expect(cop.messages).to eq([message])
         end
 
         it 'registers an offense for a single method call inside of an ' \
@@ -220,7 +225,7 @@ describe RuboCop::Cop::Style::SafeNavigation, :config do
             end
           END
 
-          expect(cop.messages).to eq([described_class::MSG])
+          expect(cop.messages).to eq([message])
         end
 
         it 'accepts a single method call inside of a check for the object ' \
@@ -254,14 +259,14 @@ describe RuboCop::Cop::Style::SafeNavigation, :config do
             'method call' do
             inspect_source(cop, "!#{variable}.nil? && #{variable}.bar")
 
-            expect(cop.messages).to eq([described_class::MSG])
+            expect(cop.messages).to eq([message])
           end
 
           it 'registers an offense for a non-nil object check followed by a ' \
             'method call with params' do
             inspect_source(cop, "!#{variable}.nil? && #{variable}.bar(baz)")
 
-            expect(cop.messages).to eq([described_class::MSG])
+            expect(cop.messages).to eq([message])
           end
 
           it 'registers an offense for a non-nil object check followed by a ' \
@@ -270,7 +275,7 @@ describe RuboCop::Cop::Style::SafeNavigation, :config do
 
             inspect_source(cop, source)
 
-            expect(cop.messages).to eq([described_class::MSG])
+            expect(cop.messages).to eq([message])
           end
 
           it 'registers an offense for a non-nil object check followed by a ' \
@@ -279,28 +284,28 @@ describe RuboCop::Cop::Style::SafeNavigation, :config do
 
             inspect_source(cop, source)
 
-            expect(cop.messages).to eq([described_class::MSG])
+            expect(cop.messages).to eq([message])
           end
 
           it 'registers an offense for an object check followed by a ' \
             'method call' do
             inspect_source(cop, "#{variable} && #{variable}.bar")
 
-            expect(cop.messages).to eq([described_class::MSG])
+            expect(cop.messages).to eq([message])
           end
 
           it 'registers an offense for an object check followed by a ' \
             'method call with params' do
             inspect_source(cop, "#{variable} && #{variable}.bar(baz)")
 
-            expect(cop.messages).to eq([described_class::MSG])
+            expect(cop.messages).to eq([message])
           end
 
           it 'registers an offense for an object check followed by a ' \
             'method call with a block' do
             inspect_source(cop, "#{variable} && #{variable}.bar { |e| e.qux }")
 
-            expect(cop.messages).to eq([described_class::MSG])
+            expect(cop.messages).to eq([message])
           end
 
           it 'registers an offense for an object check followed by a ' \
@@ -309,7 +314,7 @@ describe RuboCop::Cop::Style::SafeNavigation, :config do
 
             inspect_source(cop, source)
 
-            expect(cop.messages).to eq([described_class::MSG])
+            expect(cop.messages).to eq([message])
           end
 
           it 'registers an offense for a check for the object followed by a ' \
@@ -320,7 +325,7 @@ describe RuboCop::Cop::Style::SafeNavigation, :config do
               end
             END
 
-            expect(cop.messages).to eq([described_class::MSG])
+            expect(cop.messages).to eq([message])
           end
         end
 


### PR DESCRIPTION
Some cop specs use `described_class::MSG` in their assertions which
does not make a lot of sense. Altering the actual message does not
fail the tests in almost all of these cases. We should either:

1. Not assert the message and assert number of offenses
2. Hardcode the asserted message in the specs

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Used the same coding conventions as the rest of the project.
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] All tests are passing.
* [x] The new code doesn't generate RuboCop offenses.
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Updated cop documentation with `rake generate_cops_documentation` (required only when you've added a new cop or changed the configuration/documentation of an existing cop).

[1]: http://chris.beams.io/posts/git-commit/
