### PR TITLE
[Fix #4394] Prevent some cops from breaking on safe navigation operator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,7 @@
 * [#4371](https://github.com/bbatsov/rubocop/issues/4371): Prevent `Style/MethodName` from complaining about unary operator definitions. ([@drenmi][])
 * [#4366](https://github.com/bbatsov/rubocop/issues/4366): Prevent `Performance/RedundantMerge` from blowing up on double splat arguments. ([@drenmi][])
 * [#4352](https://github.com/bbatsov/rubocop/issues/4352): Fix the auto-correct of `Style/AndOr` when Enumerable accessors (`[]`) are used. ([@rrosenblum][])
+* [#4394](https://github.com/bbatsov/rubocop/issues/4394): [Fix #4394] Prevent some cops from breaking on safe navigation operator. ([@drenmi][])
 
 ## 0.48.1 (2017-04-03)
 

--- a/lib/rubocop/ast/builder.rb
+++ b/lib/rubocop/ast/builder.rb
@@ -27,7 +27,7 @@ module RuboCop
         OrNode           => [:or],
         PairNode         => [:pair],
         ResbodyNode      => [:resbody],
-        SendNode         => [:send],
+        SendNode         => %i[csend send],
         SuperNode        => %i[super zsuper],
         UntilNode        => %i[until until_post],
         WhenNode         => [:when],

--- a/spec/rubocop/ast/send_node_spec.rb
+++ b/spec/rubocop/ast/send_node_spec.rb
@@ -4,9 +4,18 @@ describe RuboCop::AST::SendNode do
   let(:send_node) { parse_source(source).ast }
 
   describe '.new' do
-    let(:source) { 'foo.bar(:baz)' }
+    context 'with a regular method send' do
+      let(:source) { 'foo.bar(:baz)' }
 
-    it { expect(send_node).to be_a(described_class) }
+      it { expect(send_node).to be_a(described_class) }
+    end
+
+    context 'with a safe navigation method send' do
+      let(:ruby_version) { 2.3 }
+      let(:source) { 'foo&.bar(:baz)' }
+
+      it { expect(send_node).to be_a(described_class) }
+    end
   end
 
   describe '#receiver' do

--- a/spec/rubocop/cop/style/for_spec.rb
+++ b/spec/rubocop/cop/style/for_spec.rb
@@ -101,5 +101,17 @@ describe RuboCop::Cop::Style::For, :config do
         end
       END
     end
+
+    context 'when using safe navigation operator' do
+      let(:ruby_version) { 2.3 }
+
+      it 'does not break' do
+        expect_no_offenses(<<-END.strip_indent)
+          def func
+            [1, 2, 3]&.each { |n| puts n }
+          end
+        END
+      end
+    end
   end
 end

--- a/spec/rubocop/cop/style/lambda_spec.rb
+++ b/spec/rubocop/cop/style/lambda_spec.rb
@@ -424,4 +424,16 @@ describe RuboCop::Cop::Style::Lambda, :config do
       it_behaves_like 'does not auto-correct'
     end
   end
+
+  context 'when using safe navigation operator' do
+    let(:ruby_version) { 2.3 }
+
+    it 'does not break' do
+      expect_no_offenses(<<-END.strip_indent)
+        foo&.bar do |_|
+          baz
+        end
+      END
+    end
+  end
 end


### PR DESCRIPTION
Some cops, e.g. `Style/For` and `Style/Lambda` would break when encountering a safe navigation operator.

This change fixes that by granting the powers of the `SendNode` extension to `csend` nodes.

-----------------

Before submitting the PR make sure the following are checked:

* [X] Wrote [good commit messages][1].
* [X] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [X] Used the same coding conventions as the rest of the project.
* [X] Feature branch is up-to-date with `master` (if not - rebase it).
* [X] Squashed related commits together.
* [X] Added tests.
* [X] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [X] All tests are passing.
* [X] The new code doesn't generate RuboCop offenses.
* [X] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [ ] Updated cop documentation with `rake generate_cops_documentation` (required only when you've added a new cop or changed the configuration/documentation of an existing cop).

[1]: http://chris.beams.io/posts/git-commit/
