### PR TITLE
[Fix #4402] Add Cop.autocorrect_incompatible_with

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 * [#4314](https://github.com/bbatsov/rubocop/pull/4314): Check slow hash accessing in `Array#sort` by `Performance/CompareWithBlock`. ([@pocke][])
 * [#3438](https://github.com/bbatsov/rubocop/issues/3438): Add new `Style/FormatStringToken` cop. ([@backus][])
 * [#4342](https://github.com/bbatsov/rubocop/pull/4342): Add new `Lint/ScriptPermission` cop. ([@yhirano55][])
+* [#4403](https://github.com/bbatsov/rubocop/pull/4403): Add public API `Cop.autocorrect_incompatible_with` for specifying other cops that should not autocorrect together. ([@backus][])
 
 ### Changes
 

--- a/lib/rubocop/cop/cop.rb
+++ b/lib/rubocop/cop/cop.rb
@@ -81,6 +81,16 @@ module RuboCop
           given_names.include?(department.to_s)
       end
 
+      # List of cops that should not try to autocorrect at the same
+      # time as this cop
+      #
+      # @return [Array<RuboCop::Cop::Cop>]
+      #
+      # @api public
+      def self.autocorrect_incompatible_with
+        []
+      end
+
       def initialize(config = nil, options = nil)
         @config = config || Config.new
         @options = options || { debug: false }

--- a/lib/rubocop/cop/layout/multiline_hash_brace_layout.rb
+++ b/lib/rubocop/cop/layout/multiline_hash_brace_layout.rb
@@ -72,6 +72,10 @@ module RuboCop
         ALWAYS_SAME_LINE_MESSAGE = 'Closing hash brace must be on the same ' \
           'line as the last hash element.'.freeze
 
+        def self.autocorrect_incompatible_with
+          [Style::BracesAroundHashParameters]
+        end
+
         def on_hash(node)
           check_brace_layout(node)
         end

--- a/lib/rubocop/cop/layout/space_around_operators.rb
+++ b/lib/rubocop/cop/layout/space_around_operators.rb
@@ -10,6 +10,10 @@ module RuboCop
 
         IRREGULAR_METHODS = %i[[] ! []=].freeze
 
+        def self.autocorrect_incompatible_with
+          [Style::SelfAssignment]
+        end
+
         def on_pair(node)
           return unless node.hash_rocket?
 

--- a/lib/rubocop/cop/layout/space_before_block_braces.rb
+++ b/lib/rubocop/cop/layout/space_before_block_braces.rb
@@ -8,6 +8,10 @@ module RuboCop
       class SpaceBeforeBlockBraces < Cop
         include ConfigurableEnforcedStyle
 
+        def self.autocorrect_incompatible_with
+          [Style::SymbolProc]
+        end
+
         def on_block(node)
           return if node.keywords?
 

--- a/lib/rubocop/cop/style/line_end_concatenation.rb
+++ b/lib/rubocop/cop/style/line_end_concatenation.rb
@@ -29,6 +29,10 @@ module RuboCop
                                             tLBRACK2].freeze
         QUOTE_DELIMITERS = %w[' "].freeze
 
+        def self.autocorrect_incompatible_with
+          [Style::UnneededInterpolation]
+        end
+
         def investigate(processed_source)
           processed_source.tokens.each_index do |index|
             check_token_set(index)

--- a/lib/rubocop/cop/style/self_assignment.rb
+++ b/lib/rubocop/cop/style/self_assignment.rb
@@ -16,6 +16,10 @@ module RuboCop
         MSG = 'Use self-assignment shorthand `%s=`.'.freeze
         OPS = %i[+ - * ** / | &].freeze
 
+        def self.autocorrect_incompatible_with
+          [Layout::SpaceAroundOperators]
+        end
+
         def on_lvasgn(node)
           check(node, :lvar)
         end

--- a/lib/rubocop/cop/style/symbol_proc.rb
+++ b/lib/rubocop/cop/style/symbol_proc.rb
@@ -23,6 +23,10 @@ module RuboCop
             $(send lvar $_))
         PATTERN
 
+        def self.autocorrect_incompatible_with
+          [Layout::SpaceBeforeBlockBraces]
+        end
+
         def on_block(node)
           symbol_proc?(node) do |send_or_super, block_args, block_body, method|
             block_method_name = resolve_block_method_name(send_or_super)

--- a/lib/rubocop/cop/style/unneeded_interpolation.rb
+++ b/lib/rubocop/cop/style/unneeded_interpolation.rb
@@ -20,6 +20,10 @@ module RuboCop
 
         MSG = 'Prefer `to_s` over string interpolation.'.freeze
 
+        def self.autocorrect_incompatible_with
+          [Style::LineEndConcatenation]
+        end
+
         def on_dstr(node)
           add_offense(node, :expression, MSG) if single_interpolation?(node)
         end

--- a/lib/rubocop/cop/team.rb
+++ b/lib/rubocop/cop/team.rb
@@ -4,18 +4,6 @@ module RuboCop
   module Cop
     # FIXME
     class Team
-      # If these cops try to autocorrect the same file at the same time,
-      # bad things are liable to happen
-      INCOMPATIBLE_COPS = {
-        Style::SymbolProc => [Layout::SpaceBeforeBlockBraces],
-        Layout::SpaceBeforeBlockBraces => [Style::SymbolProc],
-        Style::LineEndConcatenation => [Style::UnneededInterpolation],
-        Style::UnneededInterpolation => [Style::LineEndConcatenation],
-        Style::SelfAssignment => [Layout::SpaceAroundOperators],
-        Layout::SpaceAroundOperators => [Style::SelfAssignment],
-        Style::BracesAroundHashParameters => [Layout::MultilineHashBraceLayout]
-      }.freeze
-
       DEFAULT_OPTIONS = {
         auto_correct: false,
         debug: false
@@ -135,8 +123,7 @@ module RuboCop
           next if cop.corrections.empty?
           next if skip.include?(cop.class)
           corrector.corrections.concat(cop.corrections)
-          incompatible = INCOMPATIBLE_COPS[cop.class]
-          skip.merge(incompatible) if incompatible
+          skip.merge(cop.class.autocorrect_incompatible_with)
         end
 
         if !corrector.corrections.empty?

--- a/spec/rubocop/cop/team_spec.rb
+++ b/spec/rubocop/cop/team_spec.rb
@@ -12,7 +12,7 @@ describe RuboCop::Cop::Team do
     RuboCop::ConfigLoader.default_configuration = nil
   end
 
-  describe 'INCOMPATIBLE_COPS' do
+  context 'when incompatible cops are correcting together' do
     include FileHelper
 
     let(:options) { { formatters: [], auto_correct: true } }


### PR DESCRIPTION
With this change, cops can now specify which cops their autocorrect
functionality is incompatible with. This makes it easier for third
party cops to specify cops they are not compatible with and have that
incompatibility be respected during correction. Autocorrect mapping
is not resolved on boot so this should play well with third party
extensions like rubocop-rspec.

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Used the same coding conventions as the rest of the project.
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] All tests are passing.
* [x] The new code doesn't generate RuboCop offenses.
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Updated cop documentation with `rake generate_cops_documentation` (required only when you've added a new cop or changed the configuration/documentation of an existing cop).

[1]: http://chris.beams.io/posts/git-commit/
