### PR TITLE
Add InternalAffairs/UselessMessageAssertion

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,6 +1,7 @@
 # This is the configuration used to check the rubocop source code.
 
 inherit_from: .rubocop_todo.yml
+require: rubocop/cop/internal_affairs
 
 AllCops:
   Exclude:

--- a/lib/rubocop/cop/internal_affairs.rb
+++ b/lib/rubocop/cop/internal_affairs.rb
@@ -1,0 +1,3 @@
+# frozen_string_literal: true
+
+require 'rubocop/cop/internal_affairs/useless_message_assertion'

--- a/lib/rubocop/cop/internal_affairs/useless_message_assertion.rb
+++ b/lib/rubocop/cop/internal_affairs/useless_message_assertion.rb
@@ -1,0 +1,52 @@
+# frozen_string_literal: true
+
+module RuboCop
+  module Cop
+    module InternalAffairs
+      # Checks that cops are not tested using `described_class::MSG`.
+      #
+      # @example
+      #
+      #     # bad
+      #     expect(cop.messages).to eq([described_class::MSG])
+      #
+      #     # good
+      #     expect(cop.messages).to eq(['Do not write bad code like that.'])
+      #
+      class UselessMessageAssertion < Cop
+        MSG = 'Do not specify cop behavior using `described_class::MSG`.'.freeze
+
+        def_node_search :described_class_msg, <<-PATTERN
+          (const (send nil :described_class) :MSG)
+        PATTERN
+
+        def_node_matcher :rspec_expectation_on_msg?, <<-PATTERN
+          (send (send nil :expect #contains_described_class_msg?) :to ...)
+        PATTERN
+
+        def investigate(_processed_source)
+          assertions_using_described_class_msg.each do |node|
+            add_offense(node, :expression)
+          end
+        end
+
+        private
+
+        def contains_described_class_msg?(node)
+          described_class_msg(node).any?
+        end
+
+        def assertions_using_described_class_msg
+          described_class_msg(processed_source.ast).reject do |node|
+            node.ancestors.any?(&method(:rspec_expectation_on_msg?))
+          end
+        end
+
+        # Only process spec files
+        def relevant_file?(file)
+          file.end_with?('_spec.rb')
+        end
+      end
+    end
+  end
+end

--- a/spec/project_spec.rb
+++ b/spec/project_spec.rb
@@ -1,7 +1,14 @@
 # frozen_string_literal: true
 
 describe 'RuboCop Project' do
-  let(:cop_names) { RuboCop::Cop::Cop.all.map(&:cop_name) }
+  let(:cop_names) do
+    RuboCop::Cop::Cop
+      .registry
+      .without_department(:Test)
+      .without_department(:InternalAffairs)
+      .cops
+      .map(&:cop_name)
+  end
 
   shared_context 'configuration file' do |config_path|
     subject(:config) { RuboCop::ConfigLoader.load_file(config_path) }

--- a/spec/rubocop/cop/internal_affairs/useless_message_assertion_spec.rb
+++ b/spec/rubocop/cop/internal_affairs/useless_message_assertion_spec.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+describe RuboCop::Cop::InternalAffairs::UselessMessageAssertion do
+  subject(:cop) { described_class.new }
+
+  it 'registers an offense for specs that assert using the MSG' do
+    expect_offense(<<-RUBY, 'example_spec.rb')
+      it 'uses described_class::MSG to specify the expected message' do
+        inspect_source(cop, 'foo')
+        expect(cop.messages).to eq([described_class::MSG])
+                                    ^^^^^^^^^^^^^^^^^^^^ Do not specify cop behavior using `described_class::MSG`.
+      end
+    RUBY
+  end
+
+  it 'registers an offense for described_class::MSG in let' do
+    expect_offense(<<-RUBY, 'example_spec.rb')
+      let(:msg) { described_class::MSG }
+                  ^^^^^^^^^^^^^^^^^^^^ Do not specify cop behavior using `described_class::MSG`.
+    RUBY
+  end
+
+  it 'does not register an offense for an assertion about the message' do
+    expect_no_offenses(<<-RUBY, 'example_spec.rb')
+      it 'has a good message' do
+        expect(described_class::MSG).to eq('Good message.')
+      end
+    RUBY
+  end
+end

--- a/spec/rubocop/cop/style/yoda_condition_spec.rb
+++ b/spec/rubocop/cop/style/yoda_condition_spec.rb
@@ -4,7 +4,7 @@ require 'spec_helper'
 
 describe RuboCop::Cop::Style::YodaCondition do
   subject(:cop) { described_class.new }
-  subject(:error_message) { described_class::MSG }
+  let(:error_message) { 'Reverse the order of the operands `%s`.' }
 
   # needed because of usage of safe navigation operator
   let(:ruby_version) { 2.3 }

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -8,6 +8,7 @@ Rainbow.enabled = false
 require 'support/coverage'
 
 require 'rubocop'
+require 'rubocop/cop/internal_affairs'
 
 require 'webmock/rspec'
 


### PR DESCRIPTION
The internal affairs namespace is for cops that check RuboCop's own
codebase. These are not required by default for end users.

I haven't included an entry in any of the configuration files because I'm not sure if it makes sense for `InternalAffairs`. They aren't public cops and they shouldn't have configuration since this codebase shouldn't have more than one stance on any particular internal affairs cop.

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Used the same coding conventions as the rest of the project.
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] All tests are passing.
* [x] The new code doesn't generate RuboCop offenses.
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Updated cop documentation with `rake generate_cops_documentation` (required only when you've added a new cop or changed the configuration/documentation of an existing cop).

[1]: http://chris.beams.io/posts/git-commit/
