### PR TITLE
[Fix #4157] Modify offense message for `Style/RedundantReturn` cop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,7 @@
 * [#4550](https://github.com/bbatsov/rubocop/pull/4550): Mark `RuboCop::CLI#run` as a public API. ([@yujinakayama][])
 * [#4551](https://github.com/bbatsov/rubocop/pull/4551): Make `Performance/Caller` aware of `caller_locations`. ([@pocke][])
 * Rename `Style/HeredocDelimiters` to `Style/HeredocDelimiterNaming`. ([@drenmi][])
+* [#4157](https://github.com/bbatsov/rubocop/issues/4157): Enhance offense message for `Style/RedudantReturn` cop. ([@gohdaniel15][])
 
 ## 0.49.1 (2017-05-29)
 
@@ -2853,3 +2854,4 @@
 [@daniloisr]: https://github.com/daniloisr
 [@promisedlandt]: https://github.com/promisedlandt
 [@oboxodo]: https://github.com/oboxodo
+[@gohdaniel15]: https://github.com/gohdaniel15

--- a/lib/rubocop/cop/style/redundant_return.rb
+++ b/lib/rubocop/cop/style/redundant_return.rb
@@ -22,6 +22,8 @@ module RuboCop
       # or a case expression with a default branch.
       class RedundantReturn < Cop
         MSG = 'Redundant `return` detected.'.freeze
+        MULTI_RETURN_MSG = 'Redundant `return` detected.' \
+        ' To return multiple values, use an array.'.freeze
 
         def on_def(node)
           return unless node.body
@@ -113,6 +115,17 @@ module RuboCop
           return unless last_expr && last_expr.return_type?
 
           check_return_node(last_expr)
+        end
+
+        def allow_multiple_return_values?
+          cop_config['AllowMultipleReturnValues'] || false
+        end
+
+        def message(node)
+          return MULTI_RETURN_MSG if !allow_multiple_return_values? &&
+                                     node.children.size > 1
+
+          MSG
         end
       end
     end

--- a/spec/rubocop/cop/style/redundant_return_spec.rb
+++ b/spec/rubocop/cop/style/redundant_return_spec.rb
@@ -173,6 +173,15 @@ describe RuboCop::Cop::Style::RedundantReturn, :config do
       expect(cop.offenses.size).to eq(1)
     end
 
+    it 'registers a helpful message for defs with multiple returns' do
+      expect_offense(<<-RUBY.strip_indent)
+        def func
+          return something, test
+          ^^^^^^ Redundant `return` detected. To return multiple values, use an array.
+        end
+      RUBY
+    end
+
     it 'auto-corrects by making implicit arrays explicit' do
       src = <<-RUBY.strip_indent
         def func


### PR DESCRIPTION
This cop would produce the following offense message:
```
app/controllers/redacted_controller.rb:264:5: C: Redundant return detected.
    return a, b
    ^^^^^^
```

This PR modifies that message to be more helpful to less experienced programmers. 
```
app/controllers/redacted_controller.rb:264:5: C: Redundant return detected. To return multiple values, use an array.
    return a, b
    ^^^^^^
```

-----------------

Before submitting the PR make sure the following are checked:

* [X] Wrote [good commit messages][1].
* [X] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [X] Used the same coding conventions as the rest of the project.
* [X] Feature branch is up-to-date with `master` (if not - rebase it).
* [X] Squashed related commits together.
* [X] Added tests.
* [X] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [X] All tests are passing.
* [X] The new code doesn't generate RuboCop offenses.
* [X] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [X] Updated cop documentation with `rake generate_cops_documentation` (required only when you've added a new cop or changed the configuration/documentation of an existing cop).

[1]: http://chris.beams.io/posts/git-commit/
