### PR TITLE
Do not register an offense for FileUtils.touch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,6 +50,7 @@
 * [#4366](https://github.com/bbatsov/rubocop/issues/4366): Prevent `Performance/RedundantMerge` from blowing up on double splat arguments. ([@drenmi][])
 * [#4352](https://github.com/bbatsov/rubocop/issues/4352): Fix the auto-correct of `Style/AndOr` when Enumerable accessors (`[]`) are used. ([@rrosenblum][])
 * [#4394](https://github.com/bbatsov/rubocop/issues/4394): [Fix #4394] Prevent some cops from breaking on safe navigation operator. ([@drenmi][])
+* Prevent `Rails/SkipsModelValidations` from registering an offense for `FileUtils.touch`. ([@rrosenblum][])
 
 ## 0.48.1 (2017-04-03)
 

--- a/lib/rubocop/cop/rails/skips_model_validations.rb
+++ b/lib/rubocop/cop/rails/skips_model_validations.rb
@@ -22,6 +22,7 @@ module RuboCop
       #
       #   # good
       #   user.update_attributes(website: 'example.com')
+      #   FileUtils.touch('file')
       class SkipsModelValidations < Cop
         MSG = 'Avoid using `%s` because it skips validations.'.freeze
 
@@ -36,6 +37,10 @@ module RuboCop
                                     update_columns
                                     update_counters].freeze
 
+        def_node_matcher :good_touch?, <<-PATTERN
+          (send (const nil :FileUtils) :touch ...)
+        PATTERN
+
         def on_send(node)
           return unless blacklist.include?(node.method_name.to_s)
 
@@ -44,6 +49,8 @@ module RuboCop
           if METHODS_WITH_ARGUMENTS.include?(method_name.to_s) && args.empty?
             return
           end
+
+          return if good_touch?(node)
 
           add_offense(node, :selector)
         end

--- a/manual/cops_rails.md
+++ b/manual/cops_rails.md
@@ -1039,6 +1039,7 @@ Post.update_counters 5, comment_count: -1, action_count: 1
 
 # good
 user.update_attributes(website: 'example.com')
+FileUtils.touch('file')
 ```
 
 ### Important attributes

--- a/spec/rubocop/cop/rails/skips_model_validations_spec.rb
+++ b/spec/rubocop/cop/rails/skips_model_validations_spec.rb
@@ -30,6 +30,10 @@ describe RuboCop::Cop::Rails::SkipsModelValidations, :config do
           .to eq([format(msg, method_name)])
       end
     end
+
+    it 'accepts FileUtils.touch' do
+      expect_no_offenses("FileUtils.touch('file')")
+    end
   end
 
   context 'with methods that require at least an argument' do


### PR DESCRIPTION
I found that `Rails/SkipsModelValidations` was registering a false positive for `FileUtils.touch('file')`.