### PR TITLE
[Fix #4407] Prevent `Performance/RegexpMatch` from blowing up on `match` without arguments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,8 +4,9 @@
 
 ### Bug fixes
 
-[#4411](https://github.com/bbatsov/rubocop/issues/4411): Handle properly safe navigation in `Style/YodaCondition`. ([@bbatsov])
-Handle properly class variables and global variables in `Style/YodaCondition`. ([@bbatsov])
+* [#4411](https://github.com/bbatsov/rubocop/issues/4411): Handle properly safe navigation in `Style/YodaCondition`. ([@bbatsov][])
+* Handle properly class variables and global variables in `Style/YodaCondition`. ([@bbatsov][])
+* [#4407](https://github.com/bbatsov/rubocop/issues/4407): Prevent `Performance/RegexpMatch` from blowing up on `match` without arguments. ([@pocke][])
 
 ## 0.49.0 (2017-05-24)
 

--- a/lib/rubocop/cop/performance/regexp_match.rb
+++ b/lib/rubocop/cop/performance/regexp_match.rb
@@ -69,7 +69,7 @@ module RuboCop
         def_node_matcher :match_method?, <<-PATTERN
           {
             (send _recv :match _)
-            (send _recv :match _ (:int ...))
+            (send _recv :match _ (int ...))
           }
         PATTERN
 

--- a/spec/rubocop/cop/performance/regexp_match_spec.rb
+++ b/spec/rubocop/cop/performance/regexp_match_spec.rb
@@ -307,5 +307,9 @@ describe RuboCop::Cop::Performance::RegexpMatch, :config do
         do_something
       end
     END
+
+    include_examples :accepts, '`match` without arguments', <<-END
+      code if match
+    END
   end
 end


### PR DESCRIPTION
See #4407 

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Used the same coding conventions as the rest of the project.
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] All tests are passing.
* [x] The new code doesn't generate RuboCop offenses.
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [ ] Updated cop documentation with `rake generate_cops_documentation` (required only when you've added a new cop or changed the configuration/documentation of an existing cop).

[1]: http://chris.beams.io/posts/git-commit/
