### PR TITLE
Add missing space in `RuboCop::Cop::Style::MultipleComparison::MSG`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 * [#4407](https://github.com/bbatsov/rubocop/issues/4407): Prevent `Performance/RegexpMatch` from blowing up on `match` without arguments. ([@pocke][])
 * [#4414](https://github.com/bbatsov/rubocop/issues/4414): Handle pseudo-assignments in `for` loops in `Style/ConditionalAssignment`. ([@bbatsov][])
 * [#4419](https://github.com/bbatsov/rubocop/issues/4419): Handle combination `AllCops: DisabledByDefault: true` and `Rails: Enabled: true`. ([@jonas054][])
+* [#4422](https://github.com/bbatsov/rubocop/issues/4422): Fix missing space in message for `Style/MultipleComparison`. ([@timrogers][])
 
 ## 0.49.0 (2017-05-24)
 
@@ -2800,3 +2801,4 @@
 [@gprado]: https://github.com/gprado
 [@yhirano55]: https://github.com/yhirano55
 [@hoshinotsuyoshi]: https://github.com/hoshinotsuyoshi
+[@timrogers]: https://github.com/timrogers

--- a/lib/rubocop/cop/style/multiple_comparison.rb
+++ b/lib/rubocop/cop/style/multiple_comparison.rb
@@ -15,7 +15,7 @@ module RuboCop
       #   a = 'a'
       #   foo if ['a', 'b', 'c'].include?(a)
       class MultipleComparison < Cop
-        MSG = 'Avoid comparing a variable with multiple items' \
+        MSG = 'Avoid comparing a variable with multiple items ' \
           'in a conditional, use `Array#include?` instead.'.freeze
 
         def on_if(node)


### PR DESCRIPTION
The message currently reads:

```
Avoid comparing a variable with multiple itemsin a conditional, use Array#include? instead.
```

But it will now read:

```
Avoid comparing a variable with multiple items in a conditional, use Array#include? instead.
```

Fixes #4422.