### PR TITLE
[Fix #4420] Ensure `Style/EmptyMethod` honours indentation when auto-correcting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 * [#4414](https://github.com/bbatsov/rubocop/issues/4414): Handle pseudo-assignments in `for` loops in `Style/ConditionalAssignment`. ([@bbatsov][])
 * [#4419](https://github.com/bbatsov/rubocop/issues/4419): Handle combination `AllCops: DisabledByDefault: true` and `Rails: Enabled: true`. ([@jonas054][])
 * [#4422](https://github.com/bbatsov/rubocop/issues/4422): Fix missing space in message for `Style/MultipleComparison`. ([@timrogers][])
+* [#4420](https://github.com/bbatsov/rubocop/issues/4420): Ensure `Style/EmptyMethod` honours indentation when auto-correcting. ([@drenmi][])
 
 ## 0.49.0 (2017-05-24)
 

--- a/lib/rubocop/cop/style/empty_method.rb
+++ b/lib/rubocop/cop/style/empty_method.rb
@@ -75,9 +75,10 @@ module RuboCop
         def corrected(node)
           method_name, args, _body, scope = method_def_node_parts(node)
 
-          arguments = args.source unless args.children.empty?
-          joint = compact_style? ? '; ' : "\n"
-          scope = scope ? 'self.' : ''
+          arguments = !args.children.empty? ? args.source : ''
+          indent    = ' ' * node.loc.column
+          joint     = compact_style? ? '; ' : "\n#{indent}"
+          scope     = scope ? 'self.' : ''
 
           ["def #{scope}#{method_name}#{arguments}", 'end'].join(joint)
         end

--- a/spec/rubocop/cop/style/empty_method_spec.rb
+++ b/spec/rubocop/cop/style/empty_method_spec.rb
@@ -182,5 +182,16 @@ describe RuboCop::Cop::Style::EmptyMethod, :config do
                        '  # bar',
                        'end']
     end
+
+    context 'when method is nested in class scope' do
+      it_behaves_like 'code with offense',
+                      ['class Foo',
+                       '  def bar; end',
+                       'end'].join("\n"),
+                      ['class Foo',
+                       '  def bar',
+                       '  end',
+                       'end'].join("\n")
+    end
   end
 end


### PR DESCRIPTION
This cop would ignore indentation when auto-correcting compact style into expanded style, resulting in indentation problems like:

```
class Foo
  def bar
end
end
```

This change fixes that.

-----------------

Before submitting the PR make sure the following are checked:

* [X] Wrote [good commit messages][1].
* [X] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [X] Used the same coding conventions as the rest of the project.
* [X] Feature branch is up-to-date with `master` (if not - rebase it).
* [X] Squashed related commits together.
* [X] Added tests.
* [X] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [X] All tests are passing.
* [X] The new code doesn't generate RuboCop offenses.
* [X] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [ ] Updated cop documentation with `rake generate_cops_documentation` (required only when you've added a new cop or changed the configuration/documentation of an existing cop).

[1]: http://chris.beams.io/posts/git-commit/
