### PR TITLE
Display 'Running parallel inspection' only with --debug

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,10 @@
 * [#4422](https://github.com/bbatsov/rubocop/issues/4422): Fix missing space in message for `Style/MultipleComparison`. ([@timrogers][])
 * [#4420](https://github.com/bbatsov/rubocop/issues/4420): Ensure `Style/EmptyMethod` honours indentation when auto-correcting. ([@drenmi][])
 
+### Changes
+
+* [#4436](https://github.com/bbatsov/rubocop/pull/4436): Display 'Running parallel inspection' only with --debug. ([@pocke][])
+
 ## 0.49.0 (2017-05-24)
 
 ### New features

--- a/lib/rubocop/runner.rb
+++ b/lib/rubocop/runner.rb
@@ -49,7 +49,7 @@ module RuboCop
     # Warms up the RuboCop cache by forking a suitable number of rubocop
     # instances that each inspects its alotted group of files.
     def warm_cache(target_files)
-      puts 'Running parallel inspection'
+      puts 'Running parallel inspection' if @options[:debug]
       Parallel.each(target_files, &method(:file_offenses))
     end
 

--- a/spec/rubocop/cli/cli_options_spec.rb
+++ b/spec/rubocop/cli/cli_options_spec.rb
@@ -34,9 +34,14 @@ describe RuboCop::CLI, :isolated_environment do
       end
 
       context 'on Unix-like systems' do
-        it 'prints a message' do
-          cli.run ['--parallel']
+        it 'prints a message if --debug is specified' do
+          cli.run ['--parallel', '--debug']
           expect($stdout.string).to match(/Running parallel inspection/)
+        end
+
+        it 'does not print a message if --debug is not specified' do
+          cli.run ['--parallel']
+          expect($stdout.string).not_to match(/Running parallel inspection/)
         end
       end
     end


### PR DESCRIPTION
In parallel mode, `--format` option may not be work well.

For example

```bash
$ rubocop --parallel --format json | jq .
parse error: Invalid numeric literal at line 1, column 8
```

Because RuboCop prints a message if `--parallel` is received.

This change fixes the problem by removing the message if `--debug` is not received.


WDYT? cc: @jonas054 

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Used the same coding conventions as the rest of the project.
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [ ] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] All tests are passing.
* [x] The new code doesn't generate RuboCop offenses.
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [ ] Updated cop documentation with `rake generate_cops_documentation` (required only when you've added a new cop or changed the configuration/documentation of an existing cop).

[1]: http://chris.beams.io/posts/git-commit/
