### PR TITLE
Add new `InternalAffairs/NodeTypePredicate` cop

### DIFF
--- a/lib/rubocop/cop/internal_affairs.rb
+++ b/lib/rubocop/cop/internal_affairs.rb
@@ -1,3 +1,4 @@
 # frozen_string_literal: true
 
+require 'rubocop/cop/internal_affairs/node_type_predicate'
 require 'rubocop/cop/internal_affairs/useless_message_assertion'

--- a/lib/rubocop/cop/internal_affairs/node_type_predicate.rb
+++ b/lib/rubocop/cop/internal_affairs/node_type_predicate.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+module RuboCop
+  module Cop
+    module InternalAffairs
+      # Checks that node types are checked using the predicate helpers.
+      #
+      # @example
+      #
+      #   # bad
+      #   node.type == :send
+      #
+      #   # good
+      #   node.send_type?
+      #
+      class NodeTypePredicate < Cop
+        MSG = 'Use `#%s_type?` to check node type.'.freeze
+
+        def_node_search :node_type_check, <<-PATTERN
+          (send (send _ :type) :== (sym $_))
+        PATTERN
+
+        def on_send(node)
+          node_type_check(node) do |node_type|
+            return unless Parser::Meta::NODE_TYPES.include?(node_type)
+
+            add_offense(node, :expression, format(MSG, node_type))
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/rubocop/cop/lint/format_parameter_mismatch.rb
+++ b/lib/rubocop/cop/lint/format_parameter_mismatch.rb
@@ -136,7 +136,7 @@ module RuboCop
         def arguments_count(args)
           if args.empty?
             0
-          elsif args.last.type == :splat
+          elsif args.last.splat_type?
             -(args.count - 1)
           else
             args.count

--- a/lib/rubocop/cop/rails/file_path.rb
+++ b/lib/rubocop/cop/rails/file_path.rb
@@ -57,7 +57,7 @@ module RuboCop
         end
 
         def string_with_slash?(node)
-          node.type == :str && node.source =~ %r{/}
+          node.str_type? && node.source =~ %r{/}
         end
 
         def register_offense(node)

--- a/lib/rubocop/cop/rails/http_positional_arguments.rb
+++ b/lib/rubocop/cop/rails/http_positional_arguments.rb
@@ -56,11 +56,11 @@ module RuboCop
         end
 
         def special_keyword_arg?(node)
-          KEYWORD_ARGS.include?(node.children.first) if node.type == :sym
+          KEYWORD_ARGS.include?(node.children.first) if node.sym_type?
         end
 
         def format_arg?(node)
-          node.children.first == :format if node.type == :sym
+          node.children.first == :format if node.sym_type?
         end
 
         def convert_hash_data(data, type)

--- a/lib/rubocop/cop/style/ternary_parentheses.rb
+++ b/lib/rubocop/cop/style/ternary_parentheses.rb
@@ -99,7 +99,7 @@ module RuboCop
         # If the condition is parenthesized we recurse and check for any
         # complex expressions within it.
         def complex_condition?(condition)
-          if condition.type == :begin
+          if condition.begin_type?
             condition.to_a.any? { |x| complex_condition?(x) }
           else
             non_complex_type?(condition) ? false : true

--- a/spec/rubocop/cop/internal_affairs/node_type_predicate_spec.rb
+++ b/spec/rubocop/cop/internal_affairs/node_type_predicate_spec.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+describe RuboCop::Cop::InternalAffairs::NodeTypePredicate do
+  subject(:cop) { described_class.new }
+
+  it 'registers an offense for a comparison node type check' do
+    expect_offense(<<-RUBY, 'example_cop.rb')
+      node.type == :send
+      ^^^^^^^^^^^^^^^^^^ Use `#send_type?` to check node type.
+    RUBY
+  end
+
+  it 'does not register an offense for a predicate node type check' do
+    expect_no_offenses(<<-RUBY, 'example_spec.rb')
+      node.send_type?
+    RUBY
+  end
+end


### PR DESCRIPTION
This change adds a new RuboCop internal cop for enforcing the use of the node type predicates, e.g.:

```
# bad
node.type == :send

# good
node.send_type?
```

I opted not to add auto-correct at this point, as we only had a handful of offenses, and I would like to focus my time elsewhere. 🙂 It should be straight-forward for anyone who feels compelled to add it.

-----------------

Before submitting the PR make sure the following are checked:

* [X] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [X] Used the same coding conventions as the rest of the project.
* [X] Feature branch is up-to-date with `master` (if not - rebase it).
* [X] Squashed related commits together.
* [X] Added tests.
* [ ] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [X] All tests are passing.
* [X] The new code doesn't generate RuboCop offenses.
* [X] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [ ] Updated cop documentation with `rake generate_cops_documentation` (required only when you've added a new cop or changed the configuration/documentation of an existing cop).

[1]: http://chris.beams.io/posts/git-commit/
