### PR TITLE
Prevent Layout/SpaceAroundBlockParameters from breaking on lambda

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@
 * [#4419](https://github.com/bbatsov/rubocop/issues/4419): Handle combination `AllCops: DisabledByDefault: true` and `Rails: Enabled: true`. ([@jonas054][])
 * [#4422](https://github.com/bbatsov/rubocop/issues/4422): Fix missing space in message for `Style/MultipleComparison`. ([@timrogers][])
 * [#4420](https://github.com/bbatsov/rubocop/issues/4420): Ensure `Style/EmptyMethod` honours indentation when auto-correcting. ([@drenmi][])
+* [#4441](https://github.com/bbatsov/rubocop/pull/4441): Prevent `Layout/SpaceAroundBlockParameters` from breaking on lambda. ([@pocke][])
+
 
 ### Changes
 

--- a/lib/rubocop/cop/layout/space_around_block_parameters.rb
+++ b/lib/rubocop/cop/layout/space_around_block_parameters.rb
@@ -7,11 +7,27 @@ module RuboCop
       #
       # @example
       #
+      #   # EnforcedStyleInsidePipes: no_space (default)
+      #
       #   # bad
       #   {}.each { | x,  y |puts x }
+      #   ->( x,  y ) { puts x }
       #
       #   # good
       #   {}.each { |x, y| puts x }
+      #   ->(x, y) { puts x }
+      #
+      # @example
+      #
+      #   # EnforcedStyleInsidePipes: space
+      #
+      #   # bad
+      #   {}.each { |x,  y| puts x }
+      #   ->(x,  y) { puts x }
+      #
+      #   # good
+      #   {}.each { | x, y | puts x }
+      #   ->( x, y ) { puts x }
       class SpaceAroundBlockParameters < Cop
         include ConfigurableEnforcedStyle
 
@@ -22,6 +38,7 @@ module RuboCop
 
           opening_pipe = args.loc.begin
           closing_pipe = args.loc.end
+          return if opening_pipe.nil? || closing_pipe.nil?
 
           check_inside_pipes(args.children, opening_pipe, closing_pipe)
 

--- a/manual/cops_layout.md
+++ b/manual/cops_layout.md
@@ -1840,11 +1840,26 @@ Checks the spacing inside and after block parameters pipes.
 ### Example
 
 ```ruby
+# EnforcedStyleInsidePipes: no_space (default)
+
 # bad
 {}.each { | x,  y |puts x }
+->( x,  y ) { puts x }
 
 # good
 {}.each { |x, y| puts x }
+->(x, y) { puts x }
+```
+```ruby
+# EnforcedStyleInsidePipes: space
+
+# bad
+{}.each { |x,  y| puts x }
+->(x,  y) { puts x }
+
+# good
+{}.each { | x, y | puts x }
+->( x, y ) { puts x }
 ```
 
 ### Important attributes


### PR DESCRIPTION
`Layout/SpaceAroundKeyword` cop crashes on lambda literal that does not have parens.

```ruby
-> a { puts a }
```

```bash
$ rubocop --debug
An error occurred while Layout/SpaceAroundBlockParameters cop was inspecting /tmp/tmp.OXikUmBqDF/test.rb:1:0.

1 error occurred:
An error occurred while Layout/SpaceAroundBlockParameters cop was inspecting /tmp/tmp.OXikUmBqDF/test.rb:1:0.
Errors are usually caused by RuboCop bugs.
Please, report your problems to RuboCop's issue tracker.
Mention the following information in the issue report:
0.49.0 (using Parser 2.4.0.0, running on ruby 2.4.1 x86_64-linux)
For /tmp/tmp.OXikUmBqDF: configuration from /home/pocke/.gem/ruby/2.4.0/gems/rubocop-0.49.0/config/default.yml
Inheriting configuration from /home/pocke/.gem/ruby/2.4.0/gems/rubocop-0.49.0/config/enabled.yml
Inheriting configuration from /home/pocke/.gem/ruby/2.4.0/gems/rubocop-0.49.0/config/disabled.yml
Inspecting 1 file
Scanning /tmp/tmp.OXikUmBqDF/test.rb
undefined method `end_pos' for nil:NilClass
/home/pocke/.gem/ruby/2.4.0/gems/rubocop-0.49.0/lib/rubocop/cop/layout/space_around_block_parameters.rb:54:in `check_no_space_style_inside_pipes'
/home/pocke/.gem/ruby/2.4.0/gems/rubocop-0.49.0/lib/rubocop/cop/layout/space_around_block_parameters.rb:44:in `check_inside_pipes'
/home/pocke/.gem/ruby/2.4.0/gems/rubocop-0.49.0/lib/rubocop/cop/layout/space_around_block_parameters.rb:26:in `on_block'
/home/pocke/.gem/ruby/2.4.0/gems/rubocop-0.49.0/lib/rubocop/cop/commissioner.rb:44:in `block (2 levels) in on_block'
/home/pocke/.gem/ruby/2.4.0/gems/rubocop-0.49.0/lib/rubocop/cop/commissioner.rb:106:in `with_cop_error_handling'
/home/pocke/.gem/ruby/2.4.0/gems/rubocop-0.49.0/lib/rubocop/cop/commissioner.rb:43:in `block in on_block'
/home/pocke/.gem/ruby/2.4.0/gems/rubocop-0.49.0/lib/rubocop/cop/commissioner.rb:42:in `each'
/home/pocke/.gem/ruby/2.4.0/gems/rubocop-0.49.0/lib/rubocop/cop/commissioner.rb:42:in `on_block'
/home/pocke/.gem/ruby/2.4.0/gems/rubocop-0.49.0/lib/rubocop/ast/traversal.rb:12:in `walk'
/home/pocke/.gem/ruby/2.4.0/gems/rubocop-0.49.0/lib/rubocop/cop/commissioner.rb:60:in `investigate'
/home/pocke/.gem/ruby/2.4.0/gems/rubocop-0.49.0/lib/rubocop/cop/team.rb:112:in `investigate'
/home/pocke/.gem/ruby/2.4.0/gems/rubocop-0.49.0/lib/rubocop/cop/team.rb:100:in `offenses'
/home/pocke/.gem/ruby/2.4.0/gems/rubocop-0.49.0/lib/rubocop/cop/team.rb:42:in `inspect_file'
/home/pocke/.gem/ruby/2.4.0/gems/rubocop-0.49.0/lib/rubocop/runner.rb:258:in `inspect_file'
/home/pocke/.gem/ruby/2.4.0/gems/rubocop-0.49.0/lib/rubocop/runner.rb:205:in `block in do_inspection_loop'
/home/pocke/.gem/ruby/2.4.0/gems/rubocop-0.49.0/lib/rubocop/runner.rb:237:in `block in iterate_until_no_changes'
/home/pocke/.gem/ruby/2.4.0/gems/rubocop-0.49.0/lib/rubocop/runner.rb:230:in `loop'
/home/pocke/.gem/ruby/2.4.0/gems/rubocop-0.49.0/lib/rubocop/runner.rb:230:in `iterate_until_no_changes'
/home/pocke/.gem/ruby/2.4.0/gems/rubocop-0.49.0/lib/rubocop/runner.rb:201:in `do_inspection_loop'
/home/pocke/.gem/ruby/2.4.0/gems/rubocop-0.49.0/lib/rubocop/runner.rb:111:in `block in file_offenses'
/home/pocke/.gem/ruby/2.4.0/gems/rubocop-0.49.0/lib/rubocop/runner.rb:121:in `file_offense_cache'
/home/pocke/.gem/ruby/2.4.0/gems/rubocop-0.49.0/lib/rubocop/runner.rb:109:in `file_offenses'
/home/pocke/.gem/ruby/2.4.0/gems/rubocop-0.49.0/lib/rubocop/runner.rb:100:in `process_file'
/home/pocke/.gem/ruby/2.4.0/gems/rubocop-0.49.0/lib/rubocop/runner.rb:78:in `block in each_inspected_file'
/home/pocke/.gem/ruby/2.4.0/gems/rubocop-0.49.0/lib/rubocop/runner.rb:75:in `each'
/home/pocke/.gem/ruby/2.4.0/gems/rubocop-0.49.0/lib/rubocop/runner.rb:75:in `reduce'
/home/pocke/.gem/ruby/2.4.0/gems/rubocop-0.49.0/lib/rubocop/runner.rb:75:in `each_inspected_file'
/home/pocke/.gem/ruby/2.4.0/gems/rubocop-0.49.0/lib/rubocop/runner.rb:67:in `inspect_files'
/home/pocke/.gem/ruby/2.4.0/gems/rubocop-0.49.0/lib/rubocop/runner.rb:39:in `run'
/home/pocke/.gem/ruby/2.4.0/gems/rubocop-0.49.0/lib/rubocop/cli.rb:82:in `execute_runner'
/home/pocke/.gem/ruby/2.4.0/gems/rubocop-0.49.0/lib/rubocop/cli.rb:28:in `run'
/home/pocke/.gem/ruby/2.4.0/gems/rubocop-0.49.0/bin/rubocop:13:in `block in <top (required)>'
/usr/lib/ruby/2.4.0/benchmark.rb:308:in `realtime'
/home/pocke/.gem/ruby/2.4.0/gems/rubocop-0.49.0/bin/rubocop:12:in `<top (required)>'
/home/pocke/.gem/ruby/2.4.0/bin/rubocop:22:in `load'
/home/pocke/.gem/ruby/2.4.0/bin/rubocop:22:in `<main>'
C

Offenses:

test.rb:1:1: C: Layout/SpaceInLambdaLiteral: Do not use spaces between -> and opening brace in lambda literals
-> a { puts a }
^^^^^^^^^^^^^^^
test.rb:1:4: C: Style/StabbyLambdaParentheses: Wrap stabby lambda arguments with parentheses.
-> a { puts a }
   ^

1 file inspected, 2 offenses detected
Finished in 0.07601038400025573 seconds
```

This change fixes the problem, and adds specs for lambda literals.



-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Used the same coding conventions as the rest of the project.
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] All tests are passing.
* [x] The new code doesn't generate RuboCop offenses.
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Updated cop documentation with `rake generate_cops_documentation` (required only when you've added a new cop or changed the configuration/documentation of an existing cop).

[1]: http://chris.beams.io/posts/git-commit/
