### PR TITLE
Prevent `Style/WordArray` from breaking on strings that aren't valid UTF-8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 * [#4419](https://github.com/bbatsov/rubocop/issues/4419): Handle combination `AllCops: DisabledByDefault: true` and `Rails: Enabled: true`. ([@jonas054][])
 * [#4422](https://github.com/bbatsov/rubocop/issues/4422): Fix missing space in message for `Style/MultipleComparison`. ([@timrogers][])
 * [#4420](https://github.com/bbatsov/rubocop/issues/4420): Ensure `Style/EmptyMethod` honours indentation when auto-correcting. ([@drenmi][])
+* [#4442](https://github.com/bbatsov/rubocop/pull/4442): Prevent `Style/WordArray` from breaking on strings that aren't valid UTF-8. ([@pocke][])
 
 ### Changes
 

--- a/lib/rubocop/cop/style/word_array.rb
+++ b/lib/rubocop/cop/style/word_array.rb
@@ -93,7 +93,8 @@ module RuboCop
         def complex_content?(strings)
           strings.any? do |s|
             string = s.str_content
-            !string.valid_encoding? || string !~ word_regex || string =~ / /
+            !string.dup.force_encoding(::Encoding::UTF_8).valid_encoding? ||
+              string !~ word_regex || string =~ / /
           end
         end
 

--- a/spec/rubocop/cop/style/word_array_spec.rb
+++ b/spec/rubocop/cop/style/word_array_spec.rb
@@ -220,6 +220,20 @@ describe RuboCop::Cop::Style::WordArray, :config do
         ]
       END
     end
+
+    it "doesn't fail on strings which are not valid UTF-8" \
+       'and encoding: binary is specified' do
+      expect_no_offenses(<<-'END'.strip_indent)
+        # -*- encoding: binary -*-
+        ["\xC0",
+         "\xC2\x4a",
+         "\xC2\xC2",
+         "\x4a\x82",
+         "\x82\x82",
+         "\xe1\x82\x4a",
+        ]
+      END
+    end
   end
 
   context 'with a custom WordRegex configuration' do


### PR DESCRIPTION


`Style/WordArray` cop crashes on strings that aren't valid UTF-8, and encoding: binary is specified.

For example

```ruby
# -*- encoding: binary -*-
["\xC0",
 "\xC2\x4a",
 "\xC2\xC2",
 "\x4a\x82",
 "\x82\x82",
 "\xe1\x82\x4a",
]
```

```bash
$ rubocop -Dd --only WordArray
For /tmp/tmp.GDijgfYoeb: configuration from /home/pocke/.gem/ruby/2.4.0/gems/rubocop-0.49.0/config/default.yml
Inheriting configuration from /home/pocke/.gem/ruby/2.4.0/gems/rubocop-0.49.0/config/enabled.yml
Inheriting configuration from /home/pocke/.gem/ruby/2.4.0/gems/rubocop-0.49.0/config/disabled.yml
Inspecting 1 file
Scanning /tmp/tmp.GDijgfYoeb/test.rb
"\xC0"
true
incompatible encoding regexp match (UTF-8 regexp with ASCII-8BIT string)
/home/pocke/.gem/ruby/2.4.0/gems/rubocop-0.49.0/lib/rubocop/cop/style/word_array.rb:99:in `=~'
/home/pocke/.gem/ruby/2.4.0/gems/rubocop-0.49.0/lib/rubocop/cop/style/word_array.rb:99:in `!~'
/home/pocke/.gem/ruby/2.4.0/gems/rubocop-0.49.0/lib/rubocop/cop/style/word_array.rb:99:in `block in complex_content?'
/home/pocke/.gem/ruby/2.4.0/gems/rubocop-0.49.0/lib/rubocop/cop/style/word_array.rb:94:in `any?'
/home/pocke/.gem/ruby/2.4.0/gems/rubocop-0.49.0/lib/rubocop/cop/style/word_array.rb:94:in `complex_content?'
/home/pocke/.gem/ruby/2.4.0/gems/rubocop-0.49.0/lib/rubocop/cop/style/word_array.rb:67:in `check_bracketed_array'
/home/pocke/.gem/ruby/2.4.0/gems/rubocop-0.49.0/lib/rubocop/cop/style/word_array.rb:50:in `on_array'
/home/pocke/.gem/ruby/2.4.0/gems/rubocop-0.49.0/lib/rubocop/cop/commissioner.rb:44:in `block (2 levels) in on_array'
/home/pocke/.gem/ruby/2.4.0/gems/rubocop-0.49.0/lib/rubocop/cop/commissioner.rb:106:in `with_cop_error_handling'
/home/pocke/.gem/ruby/2.4.0/gems/rubocop-0.49.0/lib/rubocop/cop/commissioner.rb:43:in `block in on_array'
/home/pocke/.gem/ruby/2.4.0/gems/rubocop-0.49.0/lib/rubocop/cop/commissioner.rb:42:in `each'
/home/pocke/.gem/ruby/2.4.0/gems/rubocop-0.49.0/lib/rubocop/cop/commissioner.rb:42:in `on_array'
/home/pocke/.gem/ruby/2.4.0/gems/rubocop-0.49.0/lib/rubocop/ast/traversal.rb:12:in `walk'
/home/pocke/.gem/ruby/2.4.0/gems/rubocop-0.49.0/lib/rubocop/cop/commissioner.rb:60:in `investigate'
/home/pocke/.gem/ruby/2.4.0/gems/rubocop-0.49.0/lib/rubocop/cop/team.rb:112:in `investigate'
/home/pocke/.gem/ruby/2.4.0/gems/rubocop-0.49.0/lib/rubocop/cop/team.rb:100:in `offenses'
/home/pocke/.gem/ruby/2.4.0/gems/rubocop-0.49.0/lib/rubocop/cop/team.rb:42:in `inspect_file'
/home/pocke/.gem/ruby/2.4.0/gems/rubocop-0.49.0/lib/rubocop/runner.rb:258:in `inspect_file'
/home/pocke/.gem/ruby/2.4.0/gems/rubocop-0.49.0/lib/rubocop/runner.rb:205:in `block in do_inspection_loop'
/home/pocke/.gem/ruby/2.4.0/gems/rubocop-0.49.0/lib/rubocop/runner.rb:237:in `block in iterate_until_no_changes'
/home/pocke/.gem/ruby/2.4.0/gems/rubocop-0.49.0/lib/rubocop/runner.rb:230:in `loop'
/home/pocke/.gem/ruby/2.4.0/gems/rubocop-0.49.0/lib/rubocop/runner.rb:230:in `iterate_until_no_changes'
/home/pocke/.gem/ruby/2.4.0/gems/rubocop-0.49.0/lib/rubocop/runner.rb:201:in `do_inspection_loop'
/home/pocke/.gem/ruby/2.4.0/gems/rubocop-0.49.0/lib/rubocop/runner.rb:111:in `block in file_offenses'
/home/pocke/.gem/ruby/2.4.0/gems/rubocop-0.49.0/lib/rubocop/runner.rb:121:in `file_offense_cache'
/home/pocke/.gem/ruby/2.4.0/gems/rubocop-0.49.0/lib/rubocop/runner.rb:109:in `file_offenses'
/home/pocke/.gem/ruby/2.4.0/gems/rubocop-0.49.0/lib/rubocop/runner.rb:100:in `process_file'
/home/pocke/.gem/ruby/2.4.0/gems/rubocop-0.49.0/lib/rubocop/runner.rb:78:in `block in each_inspected_file'
/home/pocke/.gem/ruby/2.4.0/gems/rubocop-0.49.0/lib/rubocop/runner.rb:75:in `each'
/home/pocke/.gem/ruby/2.4.0/gems/rubocop-0.49.0/lib/rubocop/runner.rb:75:in `reduce'
/home/pocke/.gem/ruby/2.4.0/gems/rubocop-0.49.0/lib/rubocop/runner.rb:75:in `each_inspected_file'
/home/pocke/.gem/ruby/2.4.0/gems/rubocop-0.49.0/lib/rubocop/runner.rb:67:in `inspect_files'
/home/pocke/.gem/ruby/2.4.0/gems/rubocop-0.49.0/lib/rubocop/runner.rb:39:in `run'
/home/pocke/.gem/ruby/2.4.0/gems/rubocop-0.49.0/lib/rubocop/cli.rb:82:in `execute_runner'
/home/pocke/.gem/ruby/2.4.0/gems/rubocop-0.49.0/lib/rubocop/cli.rb:28:in `run'
/home/pocke/.gem/ruby/2.4.0/gems/rubocop-0.49.0/bin/rubocop:13:in `block in <top (required)>'
/usr/lib/ruby/2.4.0/benchmark.rb:308:in `realtime'
/home/pocke/.gem/ruby/2.4.0/gems/rubocop-0.49.0/bin/rubocop:12:in `<top (required)>'
/home/pocke/.gem/ruby/2.4.0/bin/rubocop:22:in `load'
/home/pocke/.gem/ruby/2.4.0/bin/rubocop:22:in `<main>'
.

1 file inspected, no offenses detected
Finished in 0.08389679500032798 seconds
```

The cause is `str_content`'s Encoding is ASCII-8BIT if `encoding: binary` is specified.



-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Used the same coding conventions as the rest of the project.
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] All tests are passing.
* [x] The new code doesn't generate RuboCop offenses.
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Updated cop documentation with `rake generate_cops_documentation` (required only when you've added a new cop or changed the configuration/documentation of an existing cop).

[1]: http://chris.beams.io/posts/git-commit/
