### PR TITLE
Prevent `Style/YodaCondition` from breaking `not LITERAL`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## master (unreleased)
 
+### Bug fixes
+
+* [#4443](https://github.com/bbatsov/rubocop/pull/4443): Prevent `Style/YodaCondition` from breaking `not LITERAL`. ([@pocke][])
+
 ## 0.49.1 (2017-05-29)
 
 ### Bug fixes

--- a/lib/rubocop/cop/style/yoda_condition.rb
+++ b/lib/rubocop/cop/style/yoda_condition.rb
@@ -29,6 +29,8 @@ module RuboCop
           '>' => '<',
           '>=' => '<='
         }.freeze
+        COMPARISON_OPERATORS = RuboCop::AST::Node::COMPARISON_OPERATORS
+                               .reject { |op| op == :! }.freeze
 
         def on_send(node)
           return unless yoda_condition?(node)
@@ -45,7 +47,7 @@ module RuboCop
         end
 
         def comparison_operator?(node)
-          RuboCop::AST::Node::COMPARISON_OPERATORS.include?(node.method_name)
+          COMPARISON_OPERATORS.include?(node.method_name)
         end
 
         def register_offense(node)

--- a/spec/rubocop/cop/style/yoda_condition_spec.rb
+++ b/spec/rubocop/cop/style/yoda_condition_spec.rb
@@ -49,6 +49,8 @@ describe RuboCop::Cop::Style::YodaCondition do
   it_behaves_like 'accepts', '(first_line - second_line) > 0'
   it_behaves_like 'accepts', '5 == 6'
   it_behaves_like 'accepts', '[1, 2, 3] <=> [4, 5, 6]'
+  it_behaves_like 'accepts', '!true'
+  it_behaves_like 'accepts', 'not true'
 
   it_behaves_like 'offense', '"foo" == bar'
   it_behaves_like 'offense', 'nil == bar'


### PR DESCRIPTION
For example

```ruby
!true
not true
!1
!'foo'
```

`Style/YodaCondition` cop crashes on the above cases.


-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Used the same coding conventions as the rest of the project.
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] All tests are passing.
* [x] The new code doesn't generate RuboCop offenses.
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Updated cop documentation with `rake generate_cops_documentation` (required only when you've added a new cop or changed the configuration/documentation of an existing cop).

[1]: http://chris.beams.io/posts/git-commit/
