### PR TITLE
Enable Style/Encoding by default

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -10,10 +10,6 @@ AllCops:
     - 'tmp/**/*'
   TargetRubyVersion: 2.0
 
-Style/Encoding:
-  EnforcedStyle: never
-  Enabled: true
-
 Style/FrozenStringLiteralComment:
   EnforcedStyle: always
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 * [#4443](https://github.com/bbatsov/rubocop/pull/4443): Prevent `Style/YodaCondition` from breaking `not LITERAL`. ([@pocke][])
 
+### Changes
+
+* [#4444](https://github.com/bbatsov/rubocop/pull/4444): Make `Style/Encoding` cop enabled by default. ([@deivid-rodriguez][])
+
 ## 0.49.1 (2017-05-29)
 
 ### Bug fixes

--- a/config/disabled.yml
+++ b/config/disabled.yml
@@ -59,11 +59,6 @@ Style/DocumentationMethod:
     - 'spec/**/*'
     - 'test/**/*'
 
-Style/Encoding:
-  Description: 'Use UTF-8 as the source file encoding.'
-  StyleGuide: '#utf-8'
-  Enabled: false
-
 Style/ImplicitRuntimeError:
   Description: >-
                  Use `raise` or `fail` with an explicit exception class and

--- a/config/enabled.yml
+++ b/config/enabled.yml
@@ -514,6 +514,11 @@ Style/EndBlock:
   StyleGuide: '#no-END-blocks'
   Enabled: true
 
+Style/Encoding:
+  Description: 'Use UTF-8 as the source file encoding.'
+  StyleGuide: '#utf-8'
+  Enabled: true
+
 Style/EvenOdd:
   Description: 'Favor the use of Integer#even? && Integer#odd?'
   StyleGuide: '#predicate-methods'

--- a/manual/cops_style.md
+++ b/manual/cops_style.md
@@ -1021,7 +1021,7 @@ SupportedStyles | compact, expanded
 
 Enabled by default | Supports autocorrection
 --- | ---
-Disabled | Yes
+Enabled | Yes
 
 This cop checks whether the source file has a utf-8 encoding
 comment or not.

--- a/spec/isolated_environment_spec.rb
+++ b/spec/isolated_environment_spec.rb
@@ -12,7 +12,7 @@ describe 'isolated environment', :isolated_environment do
   # rspec.
   it 'is not affected by a config file above the work directory' do
     create_file('../.rubocop.yml', ['inherit_from: missing_file.yml'])
-    create_file('ex.rb', ['# encoding: utf-8'])
+    create_file('ex.rb', ['# frozen_string_literal: true'])
     # A return value of 0 means that the erroneous config file was not read.
     expect(cli.run([])).to eq(0)
   end

--- a/spec/rubocop/cli/cli_auto_gen_config_spec.rb
+++ b/spec/rubocop/cli/cli_auto_gen_config_spec.rb
@@ -88,7 +88,7 @@ describe RuboCop::CLI, :isolated_environment do
                                   'y ',
                                   'puts x'])
       create_file('example2.rb', <<-END.strip_indent)
-        # encoding: utf-8
+        # frozen_string_literal: true
 
         \tx = 0
         puts x
@@ -193,7 +193,7 @@ describe RuboCop::CLI, :isolated_environment do
                                   '#' * 85,
                                   'y ',
                                   'puts x'])
-      create_file('example2.rb', ['# encoding: utf-8',
+      create_file('example2.rb', ['# frozen_string_literal: true',
                                   '',
                                   '#' * 85,
                                   "\tx = 0",
@@ -272,13 +272,13 @@ describe RuboCop::CLI, :isolated_environment do
 
     it 'does not generate configuration for the Syntax cop' do
       create_file('example1.rb', <<-END.strip_indent)
-        # encoding: utf-8
+        # frozen_string_literal: true
 
         x = <  # Syntax error
         puts x
       END
       create_file('example2.rb', <<-END.strip_indent)
-        # encoding: utf-8
+        # frozen_string_literal: true
 
         \tx = 0
         puts x
@@ -376,7 +376,7 @@ describe RuboCop::CLI, :isolated_environment do
                                   'y ',
                                   'puts x'])
       create_file('example2.rb', <<-END.strip_indent)
-        # encoding: utf-8
+        # frozen_string_literal: true
 
         \tx = 0
         puts x

--- a/spec/rubocop/cli/cli_autocorrect_spec.rb
+++ b/spec/rubocop/cli/cli_autocorrect_spec.rb
@@ -1088,14 +1088,14 @@ describe RuboCop::CLI, :isolated_environment do
 
   it 'can correct TrailingBlankLines and TrailingWhitespace offenses' do
     create_file('example.rb',
-                ['# encoding: utf-8',
+                ['# frozen_string_literal: true',
                  '',
                  '  ',
                  '',
                  ''])
     expect(cli.run(%w[--auto-correct --format emacs])).to eq(0)
     expect(IO.read('example.rb')).to eq(<<-END.strip_indent)
-      # encoding: utf-8
+      # frozen_string_literal: true
     END
     expect($stdout.string)
       .to eq(["#{abs('example.rb')}:2:1: C: [Corrected] 3 trailing " \

--- a/spec/rubocop/cli/cli_options_spec.rb
+++ b/spec/rubocop/cli/cli_options_spec.rb
@@ -787,7 +787,7 @@ describe RuboCop::CLI, :isolated_environment do
                                       'y ',
                                       'puts x'])
           create_file('example2.rb', <<-END.strip_indent)
-            # encoding: utf-8
+            # frozen_string_literal: true
 
             \tx
             def a
@@ -822,8 +822,8 @@ describe RuboCop::CLI, :isolated_environment do
                     ' ^',
                     'example2.rb:1:1: C: Incorrect indentation detected' \
                     ' (column 0 instead of 1).',
-                    '# encoding: utf-8',
-                    '^^^^^^^^^^^^^^^^^',
+                    '# frozen_string_literal: true',
+                    '^^^^^^^^^^^^^^^^^^^^^^^^^^^^^',
                     'example2.rb:3:1: C: Tab detected.',
                     "\tx",
                     '^',
@@ -863,13 +863,13 @@ describe RuboCop::CLI, :isolated_environment do
 
       context 'when emacs format is specified' do
         it 'outputs with emacs format' do
-          create_file('example1.rb', ['# encoding: utf-8',
+          create_file('example1.rb', ['# frozen_string_literal: true',
                                       '',
                                       'x= 0 ',
                                       'y ',
                                       'puts x'])
           create_file('example2.rb', <<-END.strip_indent)
-            # encoding: utf-8
+            # frozen_string_literal: true
 
             \tx = 0
             puts x

--- a/spec/rubocop/formatter/base_formatter_spec.rb
+++ b/spec/rubocop/formatter/base_formatter_spec.rb
@@ -15,7 +15,7 @@ module RuboCop
 
           create_file('4_offenses.rb', ['puts x ', 'test;', 'top;', '#' * 90])
 
-          create_file('no_offense.rb', '# encoding: utf-8')
+          create_file('no_offense.rb', '# frozen_string_literal: true')
 
           allow(SimpleTextFormatter).to receive(:new).and_return(formatter)
           $stdout = StringIO.new

--- a/spec/rubocop/runner_spec.rb
+++ b/spec/rubocop/runner_spec.rb
@@ -21,7 +21,7 @@ describe RuboCop::Runner, :isolated_environment do
     subject(:runner) { described_class.new(options, RuboCop::ConfigStore.new) }
     context 'if there are no offenses in inspected files' do
       let(:source) { <<-END.strip_indent }
-        # coding: utf-8
+        # frozen_string_literal: true
 
         def valid_code; end
       END
@@ -33,7 +33,7 @@ describe RuboCop::Runner, :isolated_environment do
 
     context 'if there is an offense in an inspected file' do
       let(:source) { <<-END.strip_indent }
-        # coding: utf-8
+        # frozen_string_literal: true
 
         def INVALID_CODE; end
       END
@@ -92,7 +92,7 @@ describe RuboCop::Runner, :isolated_environment do
         {
           formatters: [['progress', formatter_output_path]],
           stdin: <<-END.strip_indent
-            # coding: utf-8
+            # frozen_string_literal: true
 
             def INVALID_CODE; end
           END
@@ -146,7 +146,7 @@ describe RuboCop::Runner, :isolated_environment do
 
     context 'if there is an offense in an inspected file' do
       let(:source) { <<-END.strip_indent }
-        # coding: utf-8
+        # frozen_string_literal: true
         class Klass
         end
       END


### PR DESCRIPTION
This cop was made a disabled by default cop back when Ruby 1.9 was still
supported and there was no `never` enforced style. This is not the case
any more, so we can start making sure that projects do not include
unnecessary encoding magic comments by default.

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Used the same coding conventions as the rest of the project.
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [ ] Added tests.
* [x] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] All tests are passing.
* [x] The new code doesn't generate RuboCop offenses.
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Updated cop documentation with `rake generate_cops_documentation` (required only when you've added a new cop or changed the configuration/documentation of an existing cop).

[1]: http://chris.beams.io/posts/git-commit/
