### PR TITLE
[Fix #4434] Prevent bad auto-correct in `Style/Alias` for non-literal arguments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Bug fixes
 
 * [#4443](https://github.com/bbatsov/rubocop/pull/4443): Prevent `Style/YodaCondition` from breaking `not LITERAL`. ([@pocke][])
+* [#4434](https://github.com/bbatsov/rubocop/issues/4434): Prevent bad auto-correct in `Style/Alias` for non-literal arguments. ([@drenmi][])
 
 ### Changes
 

--- a/lib/rubocop/cop/style/alias.rb
+++ b/lib/rubocop/cop/style/alias.rb
@@ -3,10 +3,30 @@
 module RuboCop
   module Cop
     module Style
-      # This cop finds uses of `alias` where `alias_method` would be more
-      # appropriate (or is simply preferred due to configuration), and vice
-      # versa.
-      # It also finds uses of `alias :symbol` rather than `alias bareword`.
+      # This cop enforces the use of either `#alias` or `#alias_method`
+      # depending on configuration.
+      # It also flags uses of `alias :symbol` rather than `alias bareword`.
+      #
+      # @example
+      #
+      #   # EnforcedStyle: prefer_alias
+      #
+      #   # good
+      #   alias bar foo
+      #
+      #   # bad
+      #   alias_method :bar, :foo
+      #   alias :bar :foo
+      #
+      # @example
+      #
+      #   # EnforcedStyle: prefer_alias_method
+      #
+      #   # good
+      #   alias_method :bar, :foo
+      #
+      #   # bad
+      #   alias bar foo
       class Alias < Cop
         include ConfigurableEnforcedStyle
 
@@ -16,34 +36,31 @@ module RuboCop
 
         def on_send(node)
           return unless node.command?(:alias_method)
-          return if style == :prefer_alias_method
-          return if scope_type(node) == :dynamic
+          return unless style == :prefer_alias && alias_keyword_possible?(node)
 
           msg = format(MSG_ALIAS_METHOD, lexical_scope_type(node))
           add_offense(node, :selector, msg)
         end
 
         def on_alias(node)
-          # alias_method can't be used with global variables
-          return if node.each_child_node(:gvar).any?
-          # alias_method can't be used in instance_eval blocks
-          scope_type = scope_type(node)
-          return if scope_type == :instance_eval
+          return unless alias_method_possible?(node)
 
-          if scope_type == :dynamic || style == :prefer_alias_method
+          if scope_type(node) == :dynamic || style == :prefer_alias_method
             add_offense(node, :keyword, MSG_ALIAS)
           elsif node.children.none? { |arg| bareword?(arg) }
             add_offense_for_args(node)
           end
         end
 
-        def add_offense_for_args(node)
-          existing_args  = node.children.map(&:source).join(' ')
-          preferred_args = node.children.map { |a| a.source[1..-1] }.join(' ')
-          arg_ranges     = node.children.map(&:source_range)
-          msg            = format(MSG_SYMBOL_ARGS, preferred_args,
-                                  existing_args)
-          add_offense(node, arg_ranges.reduce(&:join), msg)
+        private
+
+        def alias_keyword_possible?(node)
+          scope_type(node) != :dynamic && node.arguments.all?(&:sym_type?)
+        end
+
+        def alias_method_possible?(node)
+          scope_type(node) != :instance_eval &&
+            node.children.none?(&:gvar_type?)
         end
 
         def autocorrect(node)
@@ -56,7 +73,14 @@ module RuboCop
           end
         end
 
-        private
+        def add_offense_for_args(node)
+          existing_args  = node.children.map(&:source).join(' ')
+          preferred_args = node.children.map { |a| a.source[1..-1] }.join(' ')
+          arg_ranges     = node.children.map(&:source_range)
+          msg            = format(MSG_SYMBOL_ARGS, preferred_args,
+                                  existing_args)
+          add_offense(node, arg_ranges.reduce(&:join), msg)
+        end
 
         # In this expression, will `self` be the same as the innermost enclosing
         # class or module block (:lexical)? Or will it be something else

--- a/manual/cops_style.md
+++ b/manual/cops_style.md
@@ -34,10 +34,31 @@ Enabled by default | Supports autocorrection
 --- | ---
 Enabled | Yes
 
-This cop finds uses of `alias` where `alias_method` would be more
-appropriate (or is simply preferred due to configuration), and vice
-versa.
-It also finds uses of `alias :symbol` rather than `alias bareword`.
+This cop enforces the use of either `#alias` or `#alias_method`
+depending on configuration.
+It also flags uses of `alias :symbol` rather than `alias bareword`.
+
+### Example
+
+```ruby
+# EnforcedStyle: prefer_alias
+
+# good
+alias bar foo
+
+# bad
+alias_method :bar, :foo
+alias :bar :foo
+```
+```ruby
+# EnforcedStyle: prefer_alias_method
+
+# good
+alias_method :bar, :foo
+
+# bad
+alias bar foo
+```
 
 ### Important attributes
 

--- a/spec/rubocop/cop/style/alias_spec.rb
+++ b/spec/rubocop/cop/style/alias_spec.rb
@@ -158,6 +158,20 @@ describe RuboCop::Cop::Style::Alias, :config do
       END
     end
 
+    it 'does not register an offense for alias_method with non-literal '\
+       'argument' do
+      expect_no_offenses(<<-END.strip_indent)
+        alias_method :bar, FOO
+      END
+    end
+
+    it 'does not register an offense for alias_method with non-literal ' \
+       'argument' do
+      expect_no_offenses(<<-END.strip_indent)
+        alias_method :baz, foo.bar
+      END
+    end
+
     it 'does not register an offense for alias in an instance_eval block' do
       expect_no_offenses(<<-END.strip_indent)
         module M


### PR DESCRIPTION
This cop would have a bad auto-correct when configured style is `prefer_alias`, and the originating `#alias_method` has a non-literal argument, e.g.:

```
class Foo
  alias_method :foo, BAR
end
```

This change fixes that, and also adds some examples to the documentation.

-----------------

Before submitting the PR make sure the following are checked:

* [X] Wrote [good commit messages][1].
* [X] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [X] Used the same coding conventions as the rest of the project.
* [X] Feature branch is up-to-date with `master` (if not - rebase it).
* [X] Squashed related commits together.
* [X] Added tests.
* [X] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [X] All tests are passing.
* [X] The new code doesn't generate RuboCop offenses.
* [X] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [ ] Updated cop documentation with `rake generate_cops_documentation` (required only when you've added a new cop or changed the configuration/documentation of an existing cop).

[1]: http://chris.beams.io/posts/git-commit/
