### PR TITLE
Add EnforcePrefix option to Rails/Delegate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 ### Changes
 
 * [#4444](https://github.com/bbatsov/rubocop/pull/4444): Make `Style/Encoding` cop enabled by default. ([@deivid-rodriguez][])
+* [#4452](https://github.com/bbatsov/rubocop/pull/4452): Add option to `Rails/Delegate` for enforcing the prefixed method name case. ([@klesse413][])
 
 ## 0.49.1 (2017-05-29)
 

--- a/config/default.yml
+++ b/config/default.yml
@@ -1447,6 +1447,12 @@ Rails/Date:
     - strict
     - flexible
 
+Rails/Delegate:
+  # When set to true, using the target object as a prefix of the
+  # method name without using the `delegate` method will be a
+  # violation. When set to false, this case is legal.
+  EnforceForPrefixed: true
+
 Rails/DynamicFindBy:
   Whitelist:
     - find_by_sql

--- a/manual/cops_rails.md
+++ b/manual/cops_rails.md
@@ -198,8 +198,13 @@ Enabled by default | Supports autocorrection
 --- | ---
 Enabled | Yes
 
-This cop looks for delegations, that could have been created
-automatically with delegate method.
+This cop looks for delegations that could have been created
+automatically with the `delegate` method.
+
+The `EnforceForPrefixed` option (defaulted to `true`) means that
+using the target object as a prefix of the method name
+without using the `delegate` method will be a violation.
+When set to `false`, this case is legal.
 
 ### Example
 
@@ -212,6 +217,13 @@ end
 # good
 delegate :bar, to: :foo
 
+# good
+private
+def bar
+  foo.bar
+end
+
+# EnforceForPrefixed: true
 # bad
 def foo_bar
   foo.bar
@@ -219,13 +231,22 @@ end
 
 # good
 delegate :bar, to: :foo, prefix: true
-
+  
+# EnforceForPrefixed: false
 # good
-private
-def bar
+def foo_bar
   foo.bar
 end
+
+# good
+delegate :bar, to: :foo, prefix: true
 ```
+
+### Important attributes
+
+Attribute | Value
+--- | ---
+EnforceForPrefixed | true
 
 ## Rails/DelegateAllowBlank
 

--- a/spec/rubocop/cop/rails/delegate_spec.rb
+++ b/spec/rubocop/cop/rails/delegate_spec.rb
@@ -1,7 +1,13 @@
 # frozen_string_literal: true
 
 describe RuboCop::Cop::Rails::Delegate do
-  subject(:cop) { described_class.new }
+  subject(:cop) { described_class.new(config) }
+  let(:cop_config) { { 'EnforceForPrefixed' => true } }
+  let(:config) do
+    merged = RuboCop::ConfigLoader
+             .default_configuration['Rails/Delegate'].merge(cop_config)
+    RuboCop::Config.new('Rails/Delegate' => merged)
+  end
 
   it 'finds trivial delegate' do
     expect_offense(<<-RUBY.strip_indent)
@@ -131,6 +137,20 @@ describe RuboCop::Cop::Rails::Delegate do
     END
   end
 
+  context 'with EnforceForPrefixed: false' do
+    let(:cop_config) do
+      { 'EnforceForPrefixed' => false }
+    end
+
+    it 'ignores trivial delegate with prefix' do
+      expect_no_offenses(<<-RUBY.strip_indent)
+        def bar_foo
+          bar.foo
+        end
+      RUBY
+    end
+  end
+
   describe '#autocorrect' do
     context 'trivial delegation' do
       let(:source) do
@@ -169,6 +189,16 @@ describe RuboCop::Cop::Rails::Delegate do
 
       it 'autocorrects' do
         expect(autocorrect_source(cop, source)).to eq(corrected_source)
+      end
+
+      context 'with EnforceForPrefixed: false' do
+        let(:cop_config) do
+          { 'EnforceForPrefixed' => false }
+        end
+
+        it 'does not autocorrect' do
+          expect(autocorrect_source(cop, source)).to eq(source)
+        end
       end
     end
   end


### PR DESCRIPTION
Hi! I'm proposing a change to the Rails/Delegate cop that adds an option (EnforcePrefix) to give users the ability to choose whether or not to enforce the `prefix: true` case when delegating.

At Betterment, we prefer to use

```ruby
def foo_bar
  foo.bar
end
```

over

```ruby
delegate :bar, to: :foo, prefix: true
```

because the second way makes it difficult to find where a method is defined (a search of the codebase would come up empty). I've defaulted the EnforcePrefix option to true, leaving current functionality as is, but this way the option is there to turn it off for projects that prefer to.

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Used the same coding conventions as the rest of the project.
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] All tests are passing.
* [x] The new code doesn't generate RuboCop offenses.
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Updated cop documentation with `rake generate_cops_documentation` (required only when you've added a new cop or changed the configuration/documentation of an existing cop).

[1]: http://chris.beams.io/posts/git-commit/
