### PR TITLE
[Fix #4451] Make `Style/AndOr` cop aware of comparison methods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 
 * [#4443](https://github.com/bbatsov/rubocop/pull/4443): Prevent `Style/YodaCondition` from breaking `not LITERAL`. ([@pocke][])
 * [#4434](https://github.com/bbatsov/rubocop/issues/4434): Prevent bad auto-correct in `Style/Alias` for non-literal arguments. ([@drenmi][])
+* [#4451](https://github.com/bbatsov/rubocop/issues/4451): Make `Style/AndOr` cop aware of comparison methods. ([@drenmi][])
 
 ### Changes
 

--- a/lib/rubocop/cop/style/and_or.rb
+++ b/lib/rubocop/cop/style/and_or.rb
@@ -3,60 +3,72 @@
 module RuboCop
   module Cop
     module Style
-      # This cop checks for uses of *and* and *or*.
+      # This cop checks for uses of `and` and `or`, and suggests using `&&` and
+      # `|| instead`. It can be configured to check only in conditions, or in
+      # all contexts.
+      #
+      # @example
+      #
+      #   # EnforcedStyle: always (default)
+      #
+      #   # good
+      #   foo.save && return
+      #   if foo && bar
+      #
+      #   # bad
+      #   foo.save and return
+      #   if foo and bar
+      #
+      # @example
+      #
+      #   # EnforcedStyle: conditionals
+      #
+      #   # good
+      #   foo.save && return
+      #   foo.save and return
+      #   if foo && bar
+      #
+      #   # bad
+      #   if foo and bar
       class AndOr < Cop
         include ConfigurableEnforcedStyle
 
         MSG = 'Use `%s` instead of `%s`.'.freeze
 
-        OPS = { 'and' => '&&', 'or' => '||' }.freeze
-
         def on_and(node)
-          process_logical_op(node) if style == :always
+          process_logical_operator(node) if style == :always
         end
-
-        def on_or(node)
-          process_logical_op(node) if style == :always
-        end
+        alias on_or on_and
 
         def on_if(node)
           on_conditionals(node) if style == :conditionals
         end
-
-        def on_while(node)
-          on_conditionals(node) if style == :conditionals
-        end
-
-        def on_while_post(node)
-          on_conditionals(node) if style == :conditionals
-        end
-
-        def on_until(node)
-          on_conditionals(node) if style == :conditionals
-        end
-
-        def on_until_post(node)
-          on_conditionals(node) if style == :conditionals
-        end
+        alias on_while      on_if
+        alias on_while_post on_if
+        alias on_until      on_if
+        alias on_until_post on_if
 
         private
 
         def on_conditionals(node)
           node.condition.each_node(*LOGICAL_OPERATOR_NODES) do |logical_node|
-            process_logical_op(logical_node)
+            process_logical_operator(logical_node)
           end
         end
 
-        def process_logical_op(node)
+        def process_logical_operator(node)
           return if node.logical_operator?
 
-          add_offense(node, :operator,
-                      format(MSG, node.alternate_operator, node.operator))
+          add_offense(node, :operator)
+        end
+
+        def message(node)
+          format(MSG, node.alternate_operator, node.operator)
         end
 
         def autocorrect(node)
           lambda do |corrector|
-            [*node].each do |expr|
+            node.each_child_node do |expr|
               if expr.send_type?
                 correct_send(expr, corrector)
               elsif expr.return_type?
@@ -73,15 +85,17 @@ module RuboCop
         def correct_send(node, corrector)
           return correct_not(node, node.receiver, corrector) if node.method?(:!)
           return correct_setter(node, corrector) if node.setter_method?
+          return correct_other(node, corrector) if node.comparison_method?
+
           return unless correctable_send?(node)
 
-          corrector.replace(whitespace_before_arg(node), '('.freeze)
-          corrector.insert_after(node.last_argument.source_range, ')'.freeze)
+          corrector.replace(whitespace_before_arg(node), '(')
+          corrector.insert_after(node.last_argument.source_range, ')')
         end
 
         def correct_setter(node, corrector)
-          corrector.insert_before(node.receiver.source_range, '('.freeze)
-          corrector.insert_after(node.last_argument.source_range, ')'.freeze)
+          corrector.insert_before(node.receiver.source_range, '(')
+          corrector.insert_after(node.last_argument.source_range, ')')
         end
 
         # ! is a special case:
@@ -108,7 +122,7 @@ module RuboCop
         end
 
         def correctable_send?(node)
-          !node.parenthesized? && !node.method?(:[]) && node.arguments?
+          !node.parenthesized? && node.arguments? && !node.method?(:[])
         end
 
         def whitespace_before_arg(node)

--- a/manual/cops_style.md
+++ b/manual/cops_style.md
@@ -77,7 +77,34 @@ Enabled by default | Supports autocorrection
 --- | ---
 Enabled | Yes
 
-This cop checks for uses of *and* and *or*.
+This cop checks for uses of `and` and `or`, and suggests using `&&` and
+`|| instead`. It can be configured to check only in conditions, or in
+all contexts.
+
+### Example
+
+```ruby
+# EnforcedStyle: always (default)
+
+# good
+foo.save && return
+if foo && bar
+
+# bad
+foo.save and return
+if foo and bar
+```
+```ruby
+# EnforcedStyle: conditionals
+
+# good
+foo.save && return
+foo.save and return
+if foo && bar
+
+# bad
+if foo and bar
+```
 
 ### Important attributes
 

--- a/spec/rubocop/cop/style/and_or_spec.rb
+++ b/spec/rubocop/cop/style/and_or_spec.rb
@@ -373,6 +373,18 @@ describe RuboCop::Cop::Style::AndOr, :config do
       end
     end
 
+    context 'when left hand side is a comparison method' do
+      # Regression: https://github.com/bbatsov/rubocop/issues/4451
+      it 'autocorrects "and" with && and adds parens' do
+        new_source = autocorrect_source(cop, <<-END.strip_indent)
+          foo == bar and baz
+        END
+        expect(new_source).to eq(<<-END.strip_indent)
+          (foo == bar) && baz
+        END
+      end
+    end
+
     context 'within a nested begin node with one child only' do
       # regression test; see GH issue 2531
       it 'autocorrects "and" with && and adds parens' do


### PR DESCRIPTION
This cop would behave badly when a comparison method was chained with an `and` or an `or`. E.g.:

```
foo==1 or bar
```

would autocorrect to:

```
foo == () || bar
```

This change fixes that, and adds documentation to the cop.

-----------------

Before submitting the PR make sure the following are checked:

* [X] Wrote [good commit messages][1].
* [X] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [X] Used the same coding conventions as the rest of the project.
* [X] Feature branch is up-to-date with `master` (if not - rebase it).
* [X] Squashed related commits together.
* [X] Added tests.
* [X] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [X] All tests are passing.
* [X] The new code doesn't generate RuboCop offenses.
* [X] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [X] Updated cop documentation with `rake generate_cops_documentation` (required only when you've added a new cop or changed the configuration/documentation of an existing cop).

[1]: http://chris.beams.io/posts/git-commit/
