### PR TITLE
Save lint cache in '.rubocop' directory

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 ### Changes
 
 * [#4444](https://github.com/bbatsov/rubocop/pull/4444): Make `Style/Encoding` cop enabled by default. ([@deivid-rodriguez][])
+* [#4456](https://github.com/bbatsov/rubocop/pull/4456): Save remote config file cache to under the `.rubocop` directory. ([@unasuke][])
 
 ## 0.49.1 (2017-05-29)
 
@@ -2823,3 +2824,4 @@
 [@yhirano55]: https://github.com/yhirano55
 [@hoshinotsuyoshi]: https://github.com/hoshinotsuyoshi
 [@timrogers]: https://github.com/timrogers
+[@unasuke]: https://github.com/unasuke

--- a/lib/rubocop/remote_config.rb
+++ b/lib/rubocop/remote_config.rb
@@ -11,6 +11,8 @@ module RuboCop
     def initialize(url, base_dir)
       @uri = URI.parse(url)
       @base_dir = base_dir
+      @cache_dir = File.join(@base_dir, '.rubocop')
+      Dir.mkdir(@cache_dir) unless Dir.exist?(@cache_dir)
     end
 
     def file
@@ -53,7 +55,7 @@ module RuboCop
     end
 
     def cache_path
-      File.expand_path(".rubocop-#{cache_name_from_uri}", @base_dir)
+      File.expand_path(File.join(@cache_dir, cache_name_from_uri), @base_dir)
     end
 
     def cache_path_exists?

--- a/spec/rubocop/config_loader_spec.rb
+++ b/spec/rubocop/config_loader_spec.rb
@@ -475,8 +475,10 @@ describe RuboCop::ConfigLoader do
     end
 
     context 'when a file inherits from a url' do
-      let(:file_path) { '.rubocop.yml' }
-      let(:cache_file) { '.rubocop-http---example-com-rubocop-yml' }
+      let(:file_path)  { '.rubocop.yml' }
+      let(:cache_dir)  { '.rubocop' }
+      let(:cache_name) { 'http---example-com-rubocop-yml' }
+      let(:cache_file) { File.join(cache_dir, cache_name) }
 
       before do
         stub_request(:get, /example.com/)

--- a/spec/rubocop/remote_config_spec.rb
+++ b/spec/rubocop/remote_config_spec.rb
@@ -5,8 +5,9 @@ describe RuboCop::RemoteConfig do
 
   let(:remote_config_url) { 'http://example.com/rubocop.yml' }
   let(:base_dir) { '.' }
-  let(:cached_file_name) { '.rubocop-http---example-com-rubocop-yml' }
-  let(:cached_file_path) { File.expand_path(cached_file_name, base_dir) }
+  let(:cache_dir) { File.join(base_dir, '.rubocop') }
+  let(:cached_file_name) { 'http---example-com-rubocop-yml' }
+  let(:cached_file_path) { File.expand_path(cached_file_name, cache_dir) }
 
   subject(:remote_config) do
     described_class.new(remote_config_url, base_dir).file


### PR DESCRIPTION
When I using remote lint file in inherit_from,
currently, save cache in project root directory.
But its behavior makes project root directory dirty when setting
multiple remote lint files to inherit_from because many cache file
saved in (usually) project root dir.

This pull-req makes save cache under the `.rubocop` directory.
I can get keep clean directory to just set `.rubocop`
to `.gitignore`

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Used the same coding conventions as the rest of the project.
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] All tests are passing.
* [x] The new code doesn't generate RuboCop offenses.
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [ ] Updated cop documentation with `rake generate_cops_documentation` (required only when you've added a new cop or changed the configuration/documentation of an existing cop).

[1]: http://chris.beams.io/posts/git-commit/
