### PR TITLE
Fix false negative in `Lint/Void` with initialize and setter methods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 * [#4443](https://github.com/bbatsov/rubocop/pull/4443): Prevent `Style/YodaCondition` from breaking `not LITERAL`. ([@pocke][])
 * [#4434](https://github.com/bbatsov/rubocop/issues/4434): Prevent bad auto-correct in `Style/Alias` for non-literal arguments. ([@drenmi][])
 * [#4451](https://github.com/bbatsov/rubocop/issues/4451): Make `Style/AndOr` cop aware of comparison methods. ([@drenmi][])
+* [#4457](https://github.com/bbatsov/rubocop/pull/4457): Fix false negative in `Lint/Void` with initialize and setter methods. ([@pocke][])
 
 ### Changes
 

--- a/manual/cops_lint.md
+++ b/manual/cops_lint.md
@@ -2099,7 +2099,7 @@ end
 ```ruby
 # bad
 
-def some_method
+def some_method(some_var)
   some_var
   do_something
 end
@@ -2115,7 +2115,7 @@ end
 ```ruby
 # good
 
-def some_method
+def some_method(some_var)
   do_something
   some_var
 end

--- a/spec/rubocop/cop/lint/void_spec.rb
+++ b/spec/rubocop/cop/lint/void_spec.rb
@@ -5,21 +5,21 @@ describe RuboCop::Cop::Lint::Void do
 
   described_class::OPS.each do |op|
     it "registers an offense for void op #{op} if not on last line" do
-      inspect_source(cop, <<-END.strip_indent)
+      inspect_source(cop, <<-RUBY.strip_indent)
         a #{op} b
         a #{op} b
         a #{op} b
-      END
+      RUBY
       expect(cop.offenses.size).to eq(2)
     end
   end
 
   described_class::OPS.each do |op|
     it "accepts void op #{op} if on last line" do
-      inspect_source(cop, <<-END.strip_indent)
+      inspect_source(cop, <<-RUBY.strip_indent)
         something
         a #{op} b
-      END
+      RUBY
       expect(cop.offenses).to be_empty
     end
   end
@@ -31,7 +31,7 @@ describe RuboCop::Cop::Lint::Void do
     end
   end
 
-  %w[var @var @@var VAR].each do |var|
+  %w[var @var @@var VAR $var].each do |var|
     it "registers an offense for void var #{var} if not on last line" do
       inspect_source(cop,
                      ["#{var} = 5",
@@ -65,6 +65,38 @@ describe RuboCop::Cop::Lint::Void do
     RUBY
   end
 
+  it 'registers an offense for void literal in a method definition' do
+    expect_offense(<<-RUBY.strip_indent)
+      def something
+        42
+        ^^ Literal `42` used in void context.
+        42
+      end
+    RUBY
+  end
+
+  it 'registers two offenses for void literals in an initialize method' do
+    expect_offense(<<-RUBY.strip_indent)
+      def initialize
+        42
+        ^^ Literal `42` used in void context.
+        42
+        ^^ Literal `42` used in void context.
+      end
+    RUBY
+  end
+
+  it 'registers two offenses for void literals in a setter method' do
+    expect_offense(<<-RUBY.strip_indent)
+      def foo=(rhs)
+        42
+        ^^ Literal `42` used in void context.
+        42
+        ^^ Literal `42` used in void context.
+      end
+    RUBY
+  end
+
   it 'handles explicit begin blocks' do
     expect_offense(<<-RUBY.strip_indent)
       begin
@@ -76,23 +108,23 @@ describe RuboCop::Cop::Lint::Void do
   end
 
   it 'accepts short call syntax' do
-    expect_no_offenses(<<-END.strip_indent)
+    expect_no_offenses(<<-RUBY.strip_indent)
       lambda.(a)
       top
-    END
+    RUBY
   end
 
   it 'accepts backtick commands' do
-    expect_no_offenses(<<-END.strip_indent)
+    expect_no_offenses(<<-RUBY.strip_indent)
       `touch x`
       nil
-    END
+    RUBY
   end
 
   it 'accepts percent-x commands' do
-    expect_no_offenses(<<-END.strip_indent)
+    expect_no_offenses(<<-RUBY.strip_indent)
       %x(touch x)
       nil
-    END
+    RUBY
   end
 end


### PR DESCRIPTION
In `initialize` and setter methods, returned value is ignored(See #4153).

```ruby
def initialize
  42 # This value is ignored.
end
```

However, `Lint/Void` cop doesn't add an offense for the above code.

This change makes to add an offense for the code.


-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Used the same coding conventions as the rest of the project.
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] All tests are passing.
* [x] The new code doesn't generate RuboCop offenses.
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Updated cop documentation with `rake generate_cops_documentation` (required only when you've added a new cop or changed the configuration/documentation of an existing cop).

[1]: http://chris.beams.io/posts/git-commit/
