### PR TITLE
Suppress `warning: too many arguments for format string`

### DIFF
--- a/lib/rubocop/cop/style/optional_arguments.rb
+++ b/lib/rubocop/cop/style/optional_arguments.rb
@@ -26,8 +26,7 @@ module RuboCop
           arguments = *arguments
 
           each_misplaced_optional_arg(arguments) do |argument|
-            arg, = *argument
-            add_offense(argument, :expression, format(MSG, arg))
+            add_offense(argument, :expression)
           end
         end
 


### PR DESCRIPTION
`Style/OptionalArguments` cop has a warning of MRI.

```bash
$ RUBYOPT=-w bundle exec rspec spec/rubocop/cop/style/optional_arguments_spec.rb
/home/pocke/.gem/ruby/2.4.0/gems/parser-2.4.0.0/lib/parser/lexer.rb:10922: warning: assigned but unused variable - testEof
/home/pocke/.gem/ruby/2.4.0/gems/parallel-1.11.2/lib/parallel.rb:222: warning: shadowing outer local variable - args
/home/pocke/.gem/ruby/2.4.0/gems/parallel-1.11.2/lib/parallel.rb:227: warning: shadowing outer local variable - args
Run options:
  include {:focus=>true}
  exclude {:broken=>#<Proc:./spec/spec_helper.rb:39>}

All examples were filtered out; ignoring {:focus=>true}

Randomized with seed 20102

RuboCop::Cop::Style::OptionalArguments
/home/pocke/ghq/github.com/bbatsov/rubocop/lib/rubocop/cop/style/optional_arguments.rb:30: warning: too many arguments for format string
  registers an offense when an optional argument is followed by a required argument
  allows methods with only optional arguments
  allows methods with only one required argument
  allows methods with only required arguments
  allows methods with multiple optional arguments at the end
  allows methods with only one optional argument
  allows methods without arguments
/home/pocke/ghq/github.com/bbatsov/rubocop/lib/rubocop/cop/style/optional_arguments.rb:30: warning: too many arguments for format string
/home/pocke/ghq/github.com/bbatsov/rubocop/lib/rubocop/cop/style/optional_arguments.rb:30: warning: too many arguments for format string
  registers an offense for each optional argument when multiple optional arguments are followed by a required argument
  named params
    with default values
      allows optional arguments before an optional named argument
    required params
/home/pocke/ghq/github.com/bbatsov/rubocop/lib/rubocop/cop/style/optional_arguments.rb:30: warning: too many arguments for format string
      registers an offense for optional arguments that come before required arguments where there are name arguments
      allows optional arguments before required named arguments
      allows optional arguments to come before a mix of required and optional named argument

Finished in 0.10693 seconds (files took 0.69272 seconds to load)
12 examples, 0 failures

Randomized with seed 20102
```

This change suppresses the warning.



-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Used the same coding conventions as the rest of the project.
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [ ] Added tests.
* [ ] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] All tests are passing.
* [x] The new code doesn't generate RuboCop offenses.
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [ ] Updated cop documentation with `rake generate_cops_documentation` (required only when you've added a new cop or changed the configuration/documentation of an existing cop).

[1]: http://chris.beams.io/posts/git-commit/
