### PR TITLE
Remove bang method from comparison method list

### DIFF
--- a/lib/rubocop/ast/node.rb
+++ b/lib/rubocop/ast/node.rb
@@ -21,7 +21,7 @@ module RuboCop
     class Node < Parser::AST::Node # rubocop:disable Metrics/ClassLength
       include RuboCop::AST::Sexp
 
-      COMPARISON_OPERATORS = %i[! == === != <= >= > < <=>].freeze
+      COMPARISON_OPERATORS = %i[== === != <= >= > < <=>].freeze
 
       TRUTHY_LITERALS = %i[str dstr xstr int float sym dsym array
                            hash regexp true irange erange complex
@@ -368,7 +368,7 @@ module RuboCop
           case type
           when :send
             receiver, method_name, *args = *self
-            COMPARISON_OPERATORS.include?(method_name) &&
+            [*COMPARISON_OPERATORS, :!].include?(method_name) &&
               receiver.send(recursive_kind) &&
               args.all?(&recursive_kind)
           when :begin, :pair, *OPERATOR_KEYWORDS, *COMPOSITE_LITERALS

--- a/lib/rubocop/cop/style/yoda_condition.rb
+++ b/lib/rubocop/cop/style/yoda_condition.rb
@@ -29,8 +29,6 @@ module RuboCop
           '>' => '<',
           '>=' => '<='
         }.freeze
-        COMPARISON_OPERATORS = RuboCop::AST::Node::COMPARISON_OPERATORS
-                               .reject { |op| op == :! }.freeze
 
         def on_send(node)
           return unless yoda_condition?(node)
@@ -41,13 +39,9 @@ module RuboCop
         private
 
         def yoda_condition?(node)
-          return false unless comparison_operator?(node)
+          return false unless node.comparison_method?
 
           node.receiver.literal? && !node.arguments.first.literal?
-        end
-
-        def comparison_operator?(node)
-          COMPARISON_OPERATORS.include?(node.method_name)
         end
 
         def register_offense(node)

--- a/spec/rubocop/ast/send_node_spec.rb
+++ b/spec/rubocop/ast/send_node_spec.rb
@@ -420,6 +420,12 @@ describe RuboCop::AST::SendNode do
 
       it { expect(send_node.comparison_method?).to be_falsey }
     end
+
+    context 'with a negation method' do
+      let(:source) { '!foo' }
+
+      it { expect(send_node.comparison_method?).to be_falsey }
+    end
   end
 
   describe '#assignment_method?' do


### PR DESCRIPTION
The bang method `#!` was added together with the comparison methods in `Node::COMPARISON_OPERATORS`. This caused `SendNode#comparison_method?` to be truthy for negation methods, which in turn led to the need for hard-coded special cases in cops. (`YodaCondition` and `RedundantCondition`).

This change removes `#!` from the constant, since it is in fact not a comparison method, adds a test case to `SendNode#comparison_method?` and simplifies `YodaCondition` based on this.

-----------------

Before submitting the PR make sure the following are checked:

* [X] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [X] Used the same coding conventions as the rest of the project.
* [X] Feature branch is up-to-date with `master` (if not - rebase it).
* [X] Squashed related commits together.
* [X] Added tests.
* [ ] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [X] All tests are passing.
* [X] The new code doesn't generate RuboCop offenses.
* [X] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [ ] Updated cop documentation with `rake generate_cops_documentation` (required only when you've added a new cop or changed the configuration/documentation of an existing cop).

[1]: http://chris.beams.io/posts/git-commit/
