### PR TITLE
Add link to new namespacing style-guide section

### DIFF
--- a/config/enabled.yml
+++ b/config/enabled.yml
@@ -419,6 +419,7 @@ Style/ClassAndModuleCamelCase:
 
 Style/ClassAndModuleChildren:
   Description: 'Checks style of children classes and modules.'
+  StyleGuide: '#namespace-definition'
   Enabled: true
 
 Style/ClassCheck:


### PR DESCRIPTION
This PR is a follow-up to #4383

The documentation patch was moved to https://github.com/bbatsov/ruby-style-guide/pull/657, and now that it's been merged there, this PR adds a Rubocop style guide link to it.

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [x] ~Commit message starts with `[Fix #issue-number]` (if the related issue exists).~
* [x] Used the same coding conventions as the rest of the project.
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] ~Added tests.~
* [x] ~Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).~
* [x] All tests are passing.
* [x] The new code doesn't generate RuboCop offenses.
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] ~Updated cop documentation with `rake generate_cops_documentation` (required only when you've added a new cop or changed the configuration/documentation of an existing cop).~

[1]: http://chris.beams.io/posts/git-commit/
