### PR TITLE
Support EnforcedStyleForEmptyBraces for SpaceBeforeBlockBraces cop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### New features
 
+* [#4464](https://github.com/bbatsov/rubocop/pull/4464): Add `EnforcedStyleForEmptyBraces` parameter to `Layout/SpaceBeforeBlockBraces` cop. ([@palkan][])
 * [#4453](https://github.com/bbatsov/rubocop/pull/4453): New cop `Style/RedundantConditional` checks for conditionals that return true/false. ([@petehamilton][])
 * [#4448](https://github.com/bbatsov/rubocop/pull/4448): Add new `TapFormatter`. ([@cyberdelia][])
 * Add new `Style/HeredocDelimiters` cop. ([@drenmi][])

--- a/config/default.yml
+++ b/config/default.yml
@@ -490,6 +490,9 @@ Layout/SpaceBeforeBlockBraces:
   SupportedStyles:
     - space
     - no_space
+  SupportedStylesForEmptyBraces:
+    - space
+    - no_space
 
 Layout/SpaceBeforeFirstArg:
   # When `true`, allows most uses of extra spacing if the intent is to align

--- a/manual/cops_layout.md
+++ b/manual/cops_layout.md
@@ -2062,6 +2062,7 @@ Attribute | Value
 --- | ---
 EnforcedStyle | space
 SupportedStyles | space, no_space
+SupportedStylesForEmptyBraces | space, no_space
 
 ## Layout/SpaceBeforeComma
 

--- a/spec/rubocop/cop/layout/space_before_block_braces_spec.rb
+++ b/spec/rubocop/cop/layout/space_before_block_braces_spec.rb
@@ -71,4 +71,65 @@ describe RuboCop::Cop::Layout::SpaceBeforeBlockBraces, :config do
       expect_no_offenses('each{ puts }')
     end
   end
+
+  context 'with space before empty braces not allowed' do
+    let(:cop_config) do
+      {
+        'EnforcedStyle' => 'space',
+        'EnforcedStyleForEmptyBraces' => 'no_space'
+      }
+    end
+
+    it 'accepts empty braces without outer space' do
+      expect_no_offenses('->{}')
+    end
+
+    it 'registers an offense for empty braces' do
+      inspect_source('-> {}')
+      expect(cop.messages).to eq(['Space detected to the left of {.'])
+      expect(cop.highlights).to eq([' '])
+      expect(cop.config_to_allow_offenses)
+        .to eq('EnforcedStyleForEmptyBraces' => 'space')
+    end
+
+    it 'auto-corrects unwanted space' do
+      new_source = autocorrect_source('-> {}')
+      expect(new_source).to eq('->{}')
+    end
+  end
+
+  context 'with space before empty braces allowed' do
+    let(:cop_config) do
+      {
+        'EnforcedStyle' => 'no_space',
+        'EnforcedStyleForEmptyBraces' => 'space'
+      }
+    end
+
+    it 'accepts empty braces with outer space' do
+      expect_no_offenses('-> {}')
+    end
+
+    it 'registers an offense for empty braces' do
+      inspect_source('->{}')
+      expect(cop.messages).to eq(['Space missing to the left of {.'])
+      expect(cop.highlights).to eq(['{'])
+      expect(cop.config_to_allow_offenses)
+        .to eq('EnforcedStyleForEmptyBraces' => 'no_space')
+    end
+
+    it 'auto-corrects missing space' do
+      new_source = autocorrect_source('->{}')
+      expect(new_source).to eq('-> {}')
+    end
+  end
+
+  context 'with invalid value for EnforcedStyleForEmptyBraces' do
+    let(:cop_config) { { 'EnforcedStyleForEmptyBraces' => 'unknown' } }
+
+    it 'fails with an error' do
+      expect { inspect_source('each {}') }
+        .to raise_error('Unknown EnforcedStyleForEmptyBraces selected!')
+    end
+  end
 end


### PR DESCRIPTION
I've started to integrate Rubocop into Puma development (https://github.com/puma/puma/pull/1325) and found out that `SpaceBeforeBlockBraces` cannot handle empty braces differently (like, for example, `SpaceInsideBlockBraces` does). 

There is a lot of code like this:

```ruby
# I don't want this one to be an offense
conf = Rack::Handler::Puma.config(->{}, @options)
```

Although for non-empty blocks there is always a space before the block.

This PR adds `EnforcedStyleForEmptyBraces` configuration parameter for `Layout/SpaceBeforeBlockBraces`cop to allow handle empty braces differently.