### PR TITLE
Refactor `Lint/Syntax` cop

### DIFF
--- a/config/enabled.yml
+++ b/config/enabled.yml
@@ -1326,6 +1326,10 @@ Lint/StringConversionInInterpolation:
   StyleGuide: '#no-to-s'
   Enabled: true
 
+Lint/Syntax:
+  Description: 'Checks syntax error'
+  Enabled: true
+
 Lint/UnderscorePrefixedVariableName:
   Description: 'Do not use prefix `_` for a variable that is used.'
   Enabled: true

--- a/lib/rubocop/config.rb
+++ b/lib/rubocop/config.rb
@@ -227,6 +227,7 @@ module RuboCop
       check_target_ruby
       validate_parameter_names(valid_cop_names)
       validate_enforced_styles(valid_cop_names)
+      validate_syntax_cop(valid_cop_names)
       reject_mutually_exclusive_defaults
     end
 
@@ -317,18 +318,21 @@ module RuboCop
 
     def warn_about_unrecognized_cops(invalid_cop_names)
       invalid_cop_names.each do |name|
-        if name == 'Syntax'
-          raise ValidationError,
-                "configuration for Syntax cop found in #{loaded_path}\n" \
-                'This cop cannot be configured.'
-        end
-
         # There could be a custom cop with this name. If so, don't warn
         next if Cop::Cop.registry.contains_cop_matching?([name])
 
         warn Rainbow("Warning: unrecognized cop #{name} found in " \
                      "#{loaded_path}").yellow
       end
+    end
+
+    def validate_syntax_cop(valid_cop_names)
+      return unless valid_cop_names.include?('Lint/Syntax') ||
+                    valid_cop_names.include?('Syntax')
+
+      raise ValidationError,
+            "configuration for Syntax cop found in #{loaded_path}\n" \
+            'This cop cannot be configured.'
     end
 
     def validate_section_presence(name)

--- a/lib/rubocop/cop/lint/syntax.rb
+++ b/lib/rubocop/cop/lint/syntax.rb
@@ -5,50 +5,47 @@ module RuboCop
     module Lint
       # This is actually not a cop and inspects nothing. It just provides
       # methods to repack Parser's diagnostics/errors into RuboCop's offenses.
-      module Syntax
+      class Syntax < Cop
         PseudoSourceRange = Struct.new(:line, :column, :source_line, :begin_pos,
                                        :end_pos)
 
-        COP_NAME = 'Syntax'.freeze
         ERROR_SOURCE_RANGE = PseudoSourceRange.new(1, 0, '', 0, 1).freeze
 
-        def self.offenses_from_processed_source(processed_source)
-          offenses = []
+        def self.offenses_from_processed_source(processed_source,
+                                                config, options)
+          cop = new(config, options)
 
           if processed_source.parser_error
-            offenses << offense_from_error(processed_source.parser_error)
+            cop.add_offense_from_error(processed_source.parser_error)
           end
 
           processed_source.diagnostics.each do |diagnostic|
-            offenses << offense_from_diagnostic(diagnostic,
-                                                processed_source.ruby_version)
+            cop.add_offense_from_diagnostic(diagnostic,
+                                            processed_source.ruby_version)
           end
 
-          offenses
+          cop.offenses
         end
 
-        def self.offense_from_diagnostic(diagnostic, ruby_version)
-          Offense.new(
-            diagnostic.level,
-            diagnostic.location,
+        def add_offense_from_diagnostic(diagnostic, ruby_version)
+          message =
             "#{diagnostic.message}\n(Using Ruby #{ruby_version} parser; " \
-            'configure using `TargetRubyVersion` parameter, under `AllCops`)',
-            COP_NAME
-          )
+            'configure using `TargetRubyVersion` parameter, under `AllCops`)'
+          add_offense(nil, diagnostic.location, message, diagnostic.level)
         end
 
-        def self.offense_from_error(error)
+        def add_offense_from_error(error)
           message = beautify_message(error.message)
-          Offense.new(:fatal, ERROR_SOURCE_RANGE, message, COP_NAME)
+          add_offense(nil, ERROR_SOURCE_RANGE, message, :fatal)
         end
 
-        def self.beautify_message(message)
+        private
+
+        def beautify_message(message)
           message = message.capitalize
           message << '.' unless message.end_with?('.')
           message
         end
-
-        private_class_method :beautify_message
       end
     end
   end

--- a/lib/rubocop/cop/team.rb
+++ b/lib/rubocop/cop/team.rb
@@ -36,7 +36,9 @@ module RuboCop
       def inspect_file(processed_source)
         # If we got any syntax errors, return only the syntax offenses.
         unless processed_source.valid_syntax?
-          return Lint::Syntax.offenses_from_processed_source(processed_source)
+          return Lint::Syntax.offenses_from_processed_source(
+            processed_source, @config, @options
+          )
         end
 
         offenses(processed_source)

--- a/lib/rubocop/formatter/disabled_config_formatter.rb
+++ b/lib/rubocop/formatter/disabled_config_formatter.rb
@@ -50,7 +50,7 @@ module RuboCop
         output.puts HEADING % command
 
         # Syntax isn't a real cop and it can't be disabled.
-        @cops_with_offenses.delete('Syntax')
+        @cops_with_offenses.delete('Lint/Syntax')
 
         output_offenses
 

--- a/manual/cops.md
+++ b/manual/cops.md
@@ -209,6 +209,7 @@ In the following section you find all available cops:
 * [Lint/ShadowedException](cops_lint.md#lintshadowedexception)
 * [Lint/ShadowingOuterLocalVariable](cops_lint.md#lintshadowingouterlocalvariable)
 * [Lint/StringConversionInInterpolation](cops_lint.md#lintstringconversionininterpolation)
+* [Lint/Syntax](cops_lint.md#lintsyntax)
 * [Lint/UnderscorePrefixedVariableName](cops_lint.md#lintunderscoreprefixedvariablename)
 * [Lint/UnifiedInteger](cops_lint.md#lintunifiedinteger)
 * [Lint/UnneededDisable](cops_lint.md#lintunneededdisable)

--- a/manual/cops_lint.md
+++ b/manual/cops_lint.md
@@ -1619,6 +1619,15 @@ which is redundant.
 
 * [https://github.com/bbatsov/ruby-style-guide#no-to-s](https://github.com/bbatsov/ruby-style-guide#no-to-s)
 
+## Lint/Syntax
+
+Enabled by default | Supports autocorrection
+--- | ---
+Enabled | No
+
+This is actually not a cop and inspects nothing. It just provides
+methods to repack Parser's diagnostics/errors into RuboCop's offenses.
+
 ## Lint/UnderscorePrefixedVariableName
 
 Enabled by default | Supports autocorrection


### PR DESCRIPTION
Why
=====

1. Apply MessageAnnotator to the cop.
2. Add the cop to the documentation.

First, currently MessageAnnotator is not enabled in `Lint/Syntax` cop.

For example:

```bash
$ rubocop --display-cop-names
Inspecting 1 file
E

Offenses:

test.rb:2:1: E: unexpected token $end
(Using Ruby 2.1 parser; configure using TargetRubyVersion parameter, under AllCops)

1 file inspected, 1 offense detected
```

`--display-cop-names` option is specified in the above example, but cop name is not displayed.

Second, `Lint/Syntax` cop does not exist in the documentation. Because the cop does not exist in `RuboCop::Cop::Cop.all`.

Purpose of the pull-request is solving the above problems.

What
=======

- Inherit `RuboCop::Cop::Cop` to `Lint/Syntax`.

We'll be able to use `add_offense` method in `Lint/Syntax` cop by the inheritance. In the method, MessageAnnotator is used. So the first problem is solved.

And by the inheritance, `Cop.all` will include `Lint/Syntax` cop. So the second problem is solved also.


-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Used the same coding conventions as the rest of the project.
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [ ] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] All tests are passing.
* [x] The new code doesn't generate RuboCop offenses.
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Updated cop documentation with `rake generate_cops_documentation` (required only when you've added a new cop or changed the configuration/documentation of an existing cop).

[1]: http://chris.beams.io/posts/git-commit/
