### PR TITLE
Add missing examples in Layout cops documentation

### DIFF
--- a/lib/rubocop/cop/layout/dot_position.rb
+++ b/lib/rubocop/cop/layout/dot_position.rb
@@ -4,6 +4,15 @@ module RuboCop
   module Cop
     module Layout
       # This cop checks the . position in multi-line method calls.
+      #
+      # @example
+      #   # bad
+      #   something.
+      #     mehod
+      #
+      #   # good
+      #   something
+      #     .method
       class DotPosition < Cop
         include ConfigurableEnforcedStyle
 

--- a/lib/rubocop/cop/layout/else_alignment.rb
+++ b/lib/rubocop/cop/layout/else_alignment.rb
@@ -7,6 +7,28 @@ module RuboCop
       # be aligned with an if/unless/while/until/begin/def keyword, but there
       # are special cases when they should follow the same rules as the
       # alignment of end.
+      #
+      # @example
+      #   # bad
+      #   if something
+      #     code
+      #  else
+      #     code
+      #   end
+      #
+      #   # bad
+      #   if something
+      #     code
+      #  elsif something
+      #     code
+      #   end
+      #
+      #   # good
+      #   if something
+      #     code
+      #   else
+      #     code
+      #   end
       class ElseAlignment < Cop
         include EndKeywordAlignment
         include AutocorrectAlignment

--- a/lib/rubocop/cop/layout/multiline_operation_indentation.rb
+++ b/lib/rubocop/cop/layout/multiline_operation_indentation.rb
@@ -12,6 +12,12 @@ module RuboCop
       #   b
       #     something
       #   end
+      #
+      #   # good
+      #   if a +
+      #      b
+      #     something
+      #   end
       class MultilineOperationIndentation < Cop
         include ConfigurableEnforcedStyle
         include AutocorrectAlignment

--- a/lib/rubocop/cop/layout/space_after_colon.rb
+++ b/lib/rubocop/cop/layout/space_after_colon.rb
@@ -6,6 +6,13 @@ module RuboCop
       # Checks for colon (:) not followed by some kind of space.
       # N.B. this cop does not handle spaces after a ternary operator, which are
       # instead handled by Layout/SpaceAroundOperators.
+      #
+      # @example
+      #   # bad
+      #   def f(a:, b:2); {a:3}; end
+      #
+      #   # good
+      #   def f(a:, b: 2); {a: 3}; end
       class SpaceAfterColon < Cop
         MSG = 'Space missing after colon.'.freeze
 

--- a/lib/rubocop/cop/layout/space_after_comma.rb
+++ b/lib/rubocop/cop/layout/space_after_comma.rb
@@ -4,6 +4,15 @@ module RuboCop
   module Cop
     module Layout
       # Checks for comma (,) not followed by some kind of space.
+      #
+      # @exmple
+      #   # bad
+      #   1,2
+      #   { foo:bar,}
+      #
+      #   # good
+      #   1, 2
+      #   { foo:bar, }
       class SpaceAfterComma < Cop
         include SpaceAfterPunctuation
 

--- a/lib/rubocop/cop/layout/space_before_block_braces.rb
+++ b/lib/rubocop/cop/layout/space_before_block_braces.rb
@@ -5,6 +5,17 @@ module RuboCop
     module Layout
       # Checks that block braces have or don't have a space before the opening
       # brace depending on configuration.
+      #
+      # @example
+      #   # bad
+      #   foo.map{ |a|
+      #     a.bar.to_s
+      #   }
+      #
+      #   # good
+      #   foo.map { |a|
+      #     a.bar.to_s
+      #   }
       class SpaceBeforeBlockBraces < Cop
         include ConfigurableEnforcedStyle
 

--- a/lib/rubocop/cop/layout/space_before_comment.rb
+++ b/lib/rubocop/cop/layout/space_before_comment.rb
@@ -5,6 +5,13 @@ module RuboCop
     module Layout
       # This cop checks for missing space between a token and a comment on the
       # same line.
+      #
+      # @example
+      #   # bad
+      #   1 + 1# this operation does ...
+      #
+      #   # good
+      #   1 + 1 # this operation does ...
       class SpaceBeforeComment < Cop
         MSG = 'Put a space before an end-of-line comment.'.freeze
 

--- a/lib/rubocop/cop/layout/space_before_semicolon.rb
+++ b/lib/rubocop/cop/layout/space_before_semicolon.rb
@@ -4,6 +4,13 @@ module RuboCop
   module Cop
     module Layout
       # Checks for semicolon (;) preceded by space.
+      #
+      # @example
+      #   # bad
+      #   x = 1 ; y = 2
+      #
+      #   # good
+      #   x = 1; y = 2
       class SpaceBeforeSemicolon < Cop
         include SpaceBeforePunctuation
 

--- a/manual/cops_layout.md
+++ b/manual/cops_layout.md
@@ -414,6 +414,18 @@ Enabled | Yes
 
 This cop checks the . position in multi-line method calls.
 
+### Example
+
+```ruby
+# bad
+something.
+  mehod
+
+# good
+something
+  .method
+```
+
 ### Important attributes
 
 Attribute | Value
@@ -435,6 +447,32 @@ This cops checks the alignment of else keywords. Normally they should
 be aligned with an if/unless/while/until/begin/def keyword, but there
 are special cases when they should follow the same rules as the
 alignment of end.
+
+ else
+    code
+  end
+
+  # bad
+  if something
+    code
+ elsif something
+    code
+  end
+
+  # good
+  if something
+    code
+  else
+    code
+  end
+
+### Example
+
+```ruby
+# bad
+if something
+  code
+```
 
 ## Layout/EmptyLineAfterMagicComment
 
@@ -1710,6 +1748,12 @@ if a +
 b
   something
 end
+
+# good
+if a +
+   b
+  something
+end
 ```
 
 ### Important attributes
@@ -1756,6 +1800,16 @@ Enabled | Yes
 Checks for colon (:) not followed by some kind of space.
 N.B. this cop does not handle spaces after a ternary operator, which are
 instead handled by Layout/SpaceAroundOperators.
+
+### Example
+
+```ruby
+# bad
+def f(a:, b:2); {a:3}; end
+
+# good
+def f(a:, b: 2); {a: 3}; end
+```
 
 ### References
 
@@ -1947,6 +2001,20 @@ Enabled | Yes
 Checks that block braces have or don't have a space before the opening
 brace depending on configuration.
 
+### Example
+
+```ruby
+# bad
+foo.map{ |a|
+  a.bar.to_s
+}
+
+# good
+foo.map { |a|
+  a.bar.to_s
+}
+```
+
 ### Important attributes
 
 Attribute | Value
@@ -1970,6 +2038,16 @@ Enabled | Yes
 
 This cop checks for missing space between a token and a comment on the
 same line.
+
+### Example
+
+```ruby
+# bad
+1 + 1# this operation does ...
+
+# good
+1 + 1 # this operation does ...
+```
 
 ## Layout/SpaceBeforeFirstArg
 
@@ -2011,6 +2089,16 @@ Enabled by default | Supports autocorrection
 Enabled | Yes
 
 Checks for semicolon (;) preceded by space.
+
+### Example
+
+```ruby
+# bad
+x = 1 ; y = 2
+
+# good
+x = 1; y = 2
+```
 
 ## Layout/SpaceInLambdaLiteral
 

--- a/manual/cops_rails.md
+++ b/manual/cops_rails.md
@@ -231,7 +231,7 @@ end
 
 # good
 delegate :bar, to: :foo, prefix: true
-  
+
 # EnforceForPrefixed: false
 # good
 def foo_bar


### PR DESCRIPTION
Few missing examples in cop documentation. This commit adds the some missing example `layout` cops.

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Used the same coding conventions as the rest of the project.
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [ ] Added tests.
* [x] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] All tests are passing.
* [x] The new code doesn't generate RuboCop offenses.
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Updated cop documentation with `rake generate_cops_documentation` (required only when you've added a new cop or changed the configuration/documentation of an existing cop).

[1]: http://chris.beams.io/posts/git-commit/
