### PR TITLE
[Fix #4418] Fix the check for the longest line when the longest line is the assignment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 * [#4434](https://github.com/bbatsov/rubocop/issues/4434): Prevent bad auto-correct in `Style/Alias` for non-literal arguments. ([@drenmi][])
 * [#4451](https://github.com/bbatsov/rubocop/issues/4451): Make `Style/AndOr` cop aware of comparison methods. ([@drenmi][])
 * [#4457](https://github.com/bbatsov/rubocop/pull/4457): Fix false negative in `Lint/Void` with initialize and setter methods. ([@pocke][])
+* [#4418](https://github.com/bbatsov/rubocop/issues/4418): Register an offense in `Style/ConditionalAssignment` when the assignment line is the longest line, and it does not exceed the max line length. ([@rrosenblum][])
 
 ### Changes
 

--- a/lib/rubocop/cop/style/conditional_assignment.rb
+++ b/lib/rubocop/cop/style/conditional_assignment.rb
@@ -380,36 +380,20 @@ module RuboCop
 
           assignment = lhs(tail(branches[0]))
 
-          longest_rhs_exceeds_line_limit?(branches, assignment) ||
-            longest_line_exceeds_line_limit?(node, assignment)
-        end
-
-        def longest_rhs_exceeds_line_limit?(branches, assignment)
-          longest_rhs_full_length(branches, assignment) > max_line_length
+          longest_line_exceeds_line_limit?(node, assignment)
         end
 
         def longest_line_exceeds_line_limit?(node, assignment)
           longest_line(node, assignment).length > max_line_length
         end
 
-        def longest_rhs_full_length(branches, assignment)
-          longest_rhs(branches) + indentation_width + assignment.length
-        end
-
         def longest_line(node, assignment)
-          assignment_regex = /#{Regexp.escape(assignment).gsub(' ', '\s*')}/
+          assignment_regex = /\s*#{Regexp.escape(assignment).gsub('\ ', '\s*')}/
           lines = node.source.lines.map do |line|
             line.chomp.sub(assignment_regex, '')
           end
           longest_line = lines.max_by(&:length)
-          longest_line + assignment
-        end
-
-        def longest_rhs(branches)
-          line_lengths = branches.flat_map do |branch|
-            branch.children.last.source.split("\n").map(&:length)
-          end
-          line_lengths.max
+          assignment + longest_line
         end
 
         def line_length_cop_enabled?

--- a/spec/rubocop/cop/style/conditional_assignment_assign_to_condition_spec.rb
+++ b/spec/rubocop/cop/style/conditional_assignment_assign_to_condition_spec.rb
@@ -344,6 +344,21 @@ describe RuboCop::Cop::Style::ConditionalAssignment do
     RUBY
   end
 
+  it 'registers an offense in an if else if the assignment is already ' \
+    'at the line length limit' do
+    source = <<-RUBY.strip_indent
+      if foo
+        bar = #{'a' * 72}
+      else
+        bar = #{'b' * 72}
+      end
+    RUBY
+
+    inspect_source(cop, source)
+
+    expect(cop.messages).to eq([message])
+  end
+
   context 'correction would exceed max line length' do
     it 'allows assignment to the same variable in if else if the correction ' \
        'would create a line longer than the configured LineLength' do


### PR DESCRIPTION
This fixes #4418. It appears that the check for the longest line had some issues. The regex pattern was replacing a space with `\s*`, but the space was already escaped so we wound up with `\\s*` which would not match properly. We also weren't accounting for trailing white space on the left of the assignment. 

Using @bunufi's example
```ruby
def do_this_do_that(field, value, filter)
  if filter
    @i_do_not_believe_in_unicorns << { field => value }
  else
    @i_do_not_believe_in_unicorns << { field => 'i drink bear' }
  end
end
```

The longest line + assignment was being computed as `"    @i_do_not_believe_in_unicorns << { field => 'i drink bear' }@i_do_not_believe_in_unicorns << "`. This change will prevent double counting the assignment portion.

The check for `longest_rhs_exceeds_line_limit` seems redundant because of the check for `longest_line_exceeds_line_limit?`.