### PR TITLE
Make `Style/HeredocDelimiters` aware of "naked" heredocs

### DIFF
--- a/lib/rubocop/cop/style/heredoc_delimiters.rb
+++ b/lib/rubocop/cop/style/heredoc_delimiters.rb
@@ -20,6 +20,7 @@ module RuboCop
       #   END
       class HeredocDelimiters < Cop
         MSG = 'Use meaningful heredoc delimiters.'.freeze
+        OPENING_DELIMITER = /<<[~-]?'?(\w+)'?\b/
 
         def on_str(node)
           return unless heredoc?(node) && !meaningful_delimiters?(node)
@@ -40,7 +41,7 @@ module RuboCop
         end
 
         def delimiters(node)
-          node.source[3..-1].delete("'")
+          node.source.match(OPENING_DELIMITER).captures.first
         end
 
         def blacklisted_delimiters

--- a/spec/rubocop/cop/style/heredoc_delimiters_spec.rb
+++ b/spec/rubocop/cop/style/heredoc_delimiters_spec.rb
@@ -67,4 +67,75 @@ describe RuboCop::Cop::Style::HeredocDelimiters, :config do
       RUBY
     end
   end
+
+  context 'with a naked heredoc', :ruby23 do
+    it 'registers an offense with a non-meaningful delimiter' do
+      expect_offense(<<-RUBY.strip_indent)
+        <<END
+          foo
+        END
+        ^^^ Use meaningful heredoc delimiters.
+      RUBY
+    end
+
+    it 'does not register an offense with a meaningful delimiter' do
+      expect_no_offenses(<<-RUBY.strip_indent)
+        <<SQL
+          foo
+        SQL
+      RUBY
+    end
+  end
+
+  context 'when the delimiter contains non-letter characters' do
+    it 'does not register an offense when delimiter contains an underscore' do
+      expect_no_offenses(<<-RUBY.strip_indent)
+        <<-SQL_CODE
+          foo
+        SQL_CODE
+      RUBY
+    end
+
+    it 'does not register an offense when delimiter contains a number' do
+      expect_no_offenses(<<-RUBY.strip_indent)
+        <<-BASE64
+          foo
+        BASE64
+      RUBY
+    end
+  end
+
+  context 'with multiple heredocs starting on the same line' do
+    it 'registers an offense with a leading non-meaningful delimiter' do
+      expect_offense(<<-RUBY.strip_indent)
+        foo(<<-END, <<-SQL)
+          foo
+        END
+        ^^^ Use meaningful heredoc delimiters.
+          bar
+        SQL
+      RUBY
+    end
+
+    it 'registers an offense with a trailing non-meaningful delimiter' do
+      expect_offense(<<-RUBY.strip_indent)
+        foo(<<-SQL, <<-END)
+          foo
+        SQL
+          bar
+        END
+        ^^^ Use meaningful heredoc delimiters.
+      RUBY
+    end
+
+    it 'does not register an offense with meaningful delimiters' do
+      expect_no_offenses(<<-RUBY.strip_indent)
+        foo(<<-SQL, <<-JS)
+          foo
+        SQL
+          bar
+        JS
+      RUBY
+    end
+  end
 end


### PR DESCRIPTION
I realized I forgot about one of the heredoc notations. This cop would not register offenses for "naked" heredocs with bad delimiters, e.g.:

```
<<END
  foo
END
```

This change fixes that, and also improves test coverage for the cop to include tests for multiple heredocs starting on the same line.

Since the cop is not released yet, I omitted the `CHANGELOG` entry.

-----------------

Before submitting the PR make sure the following are checked:

* [X] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [X] Used the same coding conventions as the rest of the project.
* [X] Feature branch is up-to-date with `master` (if not - rebase it).
* [X] Squashed related commits together.
* [X] Added tests.
* [ ] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [X] All tests are passing.
* [X] The new code doesn't generate RuboCop offenses.
* [X] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [ ] Updated cop documentation with `rake generate_cops_documentation` (required only when you've added a new cop or changed the configuration/documentation of an existing cop).

[1]: http://chris.beams.io/posts/git-commit/
