### PR TITLE
Add new `InternalAffairs/RedundantMessageArgument` cop

### DIFF
--- a/lib/rubocop/cop/internal_affairs.rb
+++ b/lib/rubocop/cop/internal_affairs.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
 
 require 'rubocop/cop/internal_affairs/node_type_predicate'
+require 'rubocop/cop/internal_affairs/redundant_message_argument'
 require 'rubocop/cop/internal_affairs/useless_message_assertion'

--- a/lib/rubocop/cop/internal_affairs/redundant_message_argument.rb
+++ b/lib/rubocop/cop/internal_affairs/redundant_message_argument.rb
@@ -1,0 +1,38 @@
+# frozen_string_literal: true
+
+module RuboCop
+  module Cop
+    module InternalAffairs
+      # Checks for redundant message arguments to `#add_offense`. This method
+      # will automatically use `#message` or `MSG` (in that order of priority)
+      # if they are defined.
+      #
+      # @example
+      #
+      #   # bad
+      #   add_offense(node, :expression, MSG)
+      #   add_offense(node, :expression, message)
+      #   add_offense(node, :expression, message(node))
+      #
+      #   # good
+      #   add_offense(node, :expression)
+      #   add_offense(node, :expression, CUSTOM_MSG)
+      #   add_offense(node, :expression, message(other_node))
+      #
+      class RedundantMessageArgument < Cop
+        MSG = 'Redundant message argument to `#add_offense`.'.freeze
+
+        def_node_search :node_type_check, <<-PATTERN
+          (send nil :add_offense _offender _
+            {(const nil :MSG) (send nil :message) (send nil :message _offender)})
+        PATTERN
+
+        def on_send(node)
+          node_type_check(node) do |offense_node|
+            add_offense(offense_node.last_argument, :expression)
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/rubocop/cop/layout/space_inside_array_percent_literal.rb
+++ b/lib/rubocop/cop/layout/space_inside_array_percent_literal.rb
@@ -26,7 +26,7 @@ module RuboCop
 
         def on_percent_literal(node)
           each_unnecessary_space_match(node) do |range|
-            add_offense(node, range, MSG)
+            add_offense(node, range)
           end
         end
 

--- a/lib/rubocop/cop/layout/space_inside_percent_literal_delimiters.rb
+++ b/lib/rubocop/cop/layout/space_inside_percent_literal_delimiters.rb
@@ -50,7 +50,7 @@ module RuboCop
           return unless node.single_line?
 
           regex_matches(node) do |match_range|
-            add_offense(node, match_range, MSG)
+            add_offense(node, match_range)
           end
         end
 

--- a/lib/rubocop/cop/layout/tab.rb
+++ b/lib/rubocop/cop/layout/tab.rb
@@ -22,7 +22,7 @@ module RuboCop
                                  index + 1,
                                  (spaces.length)...(match.end(0)))
 
-            add_offense(range, range, MSG)
+            add_offense(range, range)
           end
         end
 

--- a/lib/rubocop/cop/lint/duplicate_case_condition.rb
+++ b/lib/rubocop/cop/lint/duplicate_case_condition.rb
@@ -34,7 +34,7 @@ module RuboCop
           case_node.when_branches.each_with_object([]) do |when_node, previous|
             when_node.each_condition do |condition|
               if repeated_condition?(previous, condition)
-                add_offense(condition, :expression, MSG)
+                add_offense(condition, :expression)
               end
             end
 

--- a/lib/rubocop/cop/lint/empty_expression.rb
+++ b/lib/rubocop/cop/lint/empty_expression.rb
@@ -28,7 +28,7 @@ module RuboCop
         def on_begin(node)
           return unless empty_expression?(node)
 
-          add_offense(node, node.source_range, MSG)
+          add_offense(node, node.source_range)
         end
 
         private

--- a/lib/rubocop/cop/lint/empty_when.rb
+++ b/lib/rubocop/cop/lint/empty_when.rb
@@ -29,7 +29,7 @@ module RuboCop
           node.each_when do |when_node|
             next if when_node.body
 
-            add_offense(when_node, when_node.source_range, MSG)
+            add_offense(when_node, when_node.source_range)
           end
         end
       end

--- a/lib/rubocop/cop/lint/float_out_of_range.rb
+++ b/lib/rubocop/cop/lint/float_out_of_range.rb
@@ -23,11 +23,11 @@ module RuboCop
 
         def on_float(node)
           value, = *node
-          if value.infinite?
-            add_offense(node, :expression, MSG)
-          elsif value.zero? && node.source =~ /[1-9]/
-            add_offense(node, :expression, MSG)
-          end
+
+          return unless value.infinite? ||
+                        value.zero? && node.source =~ /[1-9]/
+
+          add_offense(node, :expression)
         end
       end
     end

--- a/lib/rubocop/cop/lint/percent_string_array.rb
+++ b/lib/rubocop/cop/lint/percent_string_array.rb
@@ -37,7 +37,7 @@ module RuboCop
         def on_percent_literal(node)
           return unless contains_quotes_or_commas?(node)
 
-          add_offense(node, :expression, MSG)
+          add_offense(node, :expression)
         end
 
         private

--- a/lib/rubocop/cop/lint/percent_symbol_array.rb
+++ b/lib/rubocop/cop/lint/percent_symbol_array.rb
@@ -33,7 +33,7 @@ module RuboCop
         def on_percent_literal(node)
           return unless contains_colons_or_commas?(node)
 
-          add_offense(node, :expression, MSG)
+          add_offense(node, :expression)
         end
 
         private

--- a/lib/rubocop/cop/rails/delegate.rb
+++ b/lib/rubocop/cop/rails/delegate.rb
@@ -50,7 +50,7 @@ module RuboCop
           method_name, args, body = *node
           return unless trivial_delegate?(method_name, args, body)
           return if private_or_protected_delegation(node)
-          add_offense(node, :keyword, MSG)
+          add_offense(node, :keyword)
         end
 
         private

--- a/lib/rubocop/cop/rails/file_path.rb
+++ b/lib/rubocop/cop/rails/file_path.rb
@@ -65,8 +65,7 @@ module RuboCop
 
           add_offense(
             node,
-            source_range(processed_source.buffer, node.loc.line, line_range),
-            MSG
+            source_range(processed_source.buffer, node.loc.line, line_range)
           )
         end
       end

--- a/lib/rubocop/cop/rails/find_each.rb
+++ b/lib/rubocop/cop/rails/find_each.rb
@@ -24,7 +24,7 @@ module RuboCop
           return unless SCOPE_METHODS.include?(node.receiver.method_name)
           return if method_chain(node).any? { |m| ignored_by_find_each?(m) }
 
-          add_offense(node, node.loc.selector, MSG)
+          add_offense(node, node.loc.selector)
         end
 
         def autocorrect(node)

--- a/lib/rubocop/cop/rails/request_referer.rb
+++ b/lib/rubocop/cop/rails/request_referer.rb
@@ -33,7 +33,7 @@ module RuboCop
           referer?(node) do
             return unless node.method?(wrong_method_name)
 
-            add_offense(node.source_range, node.source_range, message)
+            add_offense(node.source_range, node.source_range)
           end
         end
 
@@ -43,7 +43,7 @@ module RuboCop
 
         private
 
-        def message
+        def message(_node)
           format(MSG, style, wrong_method_name)
         end
 

--- a/lib/rubocop/cop/style/copyright.rb
+++ b/lib/rubocop/cop/style/copyright.rb
@@ -16,13 +16,20 @@ module RuboCop
       # an offense is reported.
       #
       class Copyright < Cop
+        MSG = 'Include a copyright notice matching /%s/ before ' \
+              'any code.'.freeze
         AUTOCORRECT_EMPTY_WARNING = 'An AutocorrectNotice must be defined in' \
                                     'your RuboCop config'.freeze
 
-        def message
-          "Include a copyright notice matching /#{notice}/" \
-          'before any code.'
+        def investigate(processed_source)
+          return if notice.empty?
+          return if notice_found?(processed_source)
+          range = source_range(processed_source.buffer, 1, 0)
+          add_offense(insert_notice_before(processed_source),
+                      range, MSG % notice)
         end
+
+        private
 
         def notice
           cop_config['Notice']
@@ -30,13 +37,6 @@ module RuboCop
 
         def autocorrect_notice
           cop_config['AutocorrectNotice']
-        end
-
-        def investigate(processed_source)
-          return if notice.empty?
-          return if notice_found?(processed_source)
-          range = source_range(processed_source.buffer, 1, 0)
-          add_offense(insert_notice_before(processed_source), range, message)
         end
 
         def insert_notice_before(processed_source)

--- a/lib/rubocop/cop/style/documentation_method.rb
+++ b/lib/rubocop/cop/style/documentation_method.rb
@@ -68,7 +68,7 @@ module RuboCop
           return if non_public?(node) && !require_for_non_public_methods?
           return if documentation_comment?(node)
 
-          add_offense(node, :expression, MSG)
+          add_offense(node, :expression)
         end
 
         def require_for_non_public_methods?

--- a/lib/rubocop/cop/style/empty_case_condition.rb
+++ b/lib/rubocop/cop/style/empty_case_condition.rb
@@ -42,7 +42,7 @@ module RuboCop
         def on_case(case_node)
           return if case_node.condition
 
-          add_offense(case_node, :keyword, MSG)
+          add_offense(case_node, :keyword)
         end
 
         private

--- a/lib/rubocop/cop/style/empty_else.rb
+++ b/lib/rubocop/cop/style/empty_else.rb
@@ -101,13 +101,13 @@ module RuboCop
         def empty_check(node)
           return unless node.else? && !node.else_branch
 
-          add_offense(node, :else, MSG)
+          add_offense(node, :else)
         end
 
         def nil_check(node)
           return unless node.else_branch && node.else_branch.nil_type?
 
-          add_offense(node, :else, MSG)
+          add_offense(node, :else)
         end
 
         def autocorrect(node)

--- a/lib/rubocop/cop/style/empty_method.rb
+++ b/lib/rubocop/cop/style/empty_method.rb
@@ -57,7 +57,7 @@ module RuboCop
           return if compact_style? && compact?(node)
           return if expanded_style? && expanded?(node)
 
-          add_offense(node, node.source_range, message)
+          add_offense(node, node.source_range)
         end
 
         private
@@ -68,7 +68,7 @@ module RuboCop
           end
         end
 
-        def message
+        def message(_node)
           compact_style? ? MSG_COMPACT : MSG_EXPANDED
         end
 

--- a/lib/rubocop/cop/style/frozen_string_literal_comment.rb
+++ b/lib/rubocop/cop/style/frozen_string_literal_comment.rb
@@ -79,7 +79,7 @@ module RuboCop
           last_special_comment = last_special_comment(processed_source)
           range = source_range(processed_source.buffer, 0, 0)
 
-          add_offense(last_special_comment, range, MSG)
+          add_offense(last_special_comment, range)
         end
 
         def unnecessary_comment_offense(processed_source)

--- a/lib/rubocop/cop/style/if_with_semicolon.rb
+++ b/lib/rubocop/cop/style/if_with_semicolon.rb
@@ -12,7 +12,7 @@ module RuboCop
         def on_normal_if_unless(node)
           beginning = node.loc.begin
           return unless beginning && beginning.is?(';')
-          add_offense(node, :expression, MSG)
+          add_offense(node, :expression)
         end
       end
     end

--- a/lib/rubocop/cop/style/multiline_memoization.rb
+++ b/lib/rubocop/cop/style/multiline_memoization.rb
@@ -46,7 +46,7 @@ module RuboCop
 
           return unless bad_rhs?(rhs)
 
-          add_offense(rhs, node.source_range, MSG)
+          add_offense(rhs, node.source_range)
         end
 
         private

--- a/lib/rubocop/cop/style/option_hash.rb
+++ b/lib/rubocop/cop/style/option_hash.rb
@@ -32,7 +32,7 @@ module RuboCop
           return unless default_value.hash_type? && default_value.pairs.empty?
           return unless suspicious_name?(arg)
 
-          add_offense(last_arg, :expression, MSG)
+          add_offense(last_arg, :expression)
         end
 
         def validate_config

--- a/lib/rubocop/cop/style/percent_q_literals.rb
+++ b/lib/rubocop/cop/style/percent_q_literals.rb
@@ -25,7 +25,7 @@ module RuboCop
           # i.e., if the string would become dynamic or has special characters.
           return if node.children != parse(corrected(node.source)).ast.children
 
-          add_offense(node, :begin, message)
+          add_offense(node, :begin)
         end
 
         def correct_literal_style?(node)
@@ -33,7 +33,7 @@ module RuboCop
             style == :upper_case_q && type(node) == '%Q'
         end
 
-        def message
+        def message(_node)
           style == :lower_case_q ? LOWER_CASE_Q_MSG : UPPER_CASE_Q_MSG
         end
 

--- a/lib/rubocop/cop/style/struct_inheritance.rb
+++ b/lib/rubocop/cop/style/struct_inheritance.rb
@@ -19,7 +19,7 @@ module RuboCop
           _name, superclass, _body = *node
           return unless struct_constructor?(superclass)
 
-          add_offense(node, superclass.source_range, MSG)
+          add_offense(node, superclass.source_range)
         end
 
         def_node_matcher :struct_constructor?, <<-PATTERN

--- a/lib/rubocop/cop/style/ternary_parentheses.rb
+++ b/lib/rubocop/cop/style/ternary_parentheses.rb
@@ -61,7 +61,7 @@ module RuboCop
         def on_if(node)
           return unless node.ternary? && !infinite_loop? && offense?(node)
 
-          add_offense(node, node.source_range, message(node))
+          add_offense(node, node.source_range)
         end
 
         private

--- a/lib/rubocop/cop/style/unneeded_interpolation.rb
+++ b/lib/rubocop/cop/style/unneeded_interpolation.rb
@@ -25,7 +25,7 @@ module RuboCop
         end
 
         def on_dstr(node)
-          add_offense(node, :expression, MSG) if single_interpolation?(node)
+          add_offense(node, :expression) if single_interpolation?(node)
         end
 
         private

--- a/spec/rubocop/cop/internal_affairs/redundant_message_argument_spec.rb
+++ b/spec/rubocop/cop/internal_affairs/redundant_message_argument_spec.rb
@@ -1,0 +1,39 @@
+# frozen_string_literal: true
+
+describe RuboCop::Cop::InternalAffairs::RedundantMessageArgument do
+  subject(:cop) { described_class.new }
+
+  it 'registers an offense when `MSG` is passed' do
+    expect_offense(<<-RUBY, 'example_cop.rb')
+      add_offense(node, :expression, MSG)
+                                     ^^^ Redundant message argument to `#add_offense`.
+    RUBY
+  end
+
+  it 'does not register an offense when formatted `MSG` is passed' do
+    expect_no_offenses(<<-RUBY, 'example_cop.rb')
+      add_offense(node, :expression, MSG % foo)
+    RUBY
+  end
+
+  it 'registers an offense when `#message` is passed' do
+    expect_offense(<<-RUBY, 'example_cop.rb')
+      add_offense(node, :expression, message)
+                                     ^^^^^^^ Redundant message argument to `#add_offense`.
+    RUBY
+  end
+
+  it 'registers an offense when `#message` with offending node is passed' do
+    expect_offense(<<-RUBY, 'example_cop.rb')
+      add_offense(node, :expression, message(node))
+                                     ^^^^^^^^^^^^^ Redundant message argument to `#add_offense`.
+    RUBY
+  end
+
+  it 'does not register an offense when `#message` with another node ' \
+     ' is passed' do
+    expect_no_offenses(<<-RUBY, 'example_cop.rb')
+      add_offense(node, :expression, message(other_node))
+    RUBY
+  end
+end

--- a/spec/rubocop/cop/style/copyright_spec.rb
+++ b/spec/rubocop/cop/style/copyright_spec.rb
@@ -12,7 +12,6 @@ end
 def expect_copyright_offense(cop, source)
   inspect_source(cop, source)
   expect(cop.offenses.size).to eq(1)
-  expect(cop.messages[0]).to eq(cop.message)
 end
 
 describe RuboCop::Cop::Style::Copyright, :config do


### PR DESCRIPTION
This change adds another internal affairs cop, that checks for redundant message arguments to `#add_offense`. This method will use `#message` or `MSG` (in that order of priority) as defaults if no argument is given.

-----------------

Before submitting the PR make sure the following are checked:

* [X] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [X] Used the same coding conventions as the rest of the project.
* [X] Feature branch is up-to-date with `master` (if not - rebase it).
* [X] Squashed related commits together.
* [X] Added tests.
* [ ] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [X] All tests are passing.
* [X] The new code doesn't generate RuboCop offenses.
* [X] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [ ] Updated cop documentation with `rake generate_cops_documentation` (required only when you've added a new cop or changed the configuration/documentation of an existing cop).

[1]: http://chris.beams.io/posts/git-commit/
