### PR TITLE
Handle 304 status for remote config files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 * [#4451](https://github.com/bbatsov/rubocop/issues/4451): Make `Style/AndOr` cop aware of comparison methods. ([@drenmi][])
 * [#4457](https://github.com/bbatsov/rubocop/pull/4457): Fix false negative in `Lint/Void` with initialize and setter methods. ([@pocke][])
 * [#4418](https://github.com/bbatsov/rubocop/issues/4418): Register an offense in `Style/ConditionalAssignment` when the assignment line is the longest line, and it does not exceed the max line length. ([@rrosenblum][])
+* [#4485](https://github.com/bbatsov/rubocop/pull/4485): Handle 304 status for remote config files. ([@daniloisr][])
 
 ### Changes
 
@@ -2831,3 +2832,4 @@
 [@hoshinotsuyoshi]: https://github.com/hoshinotsuyoshi
 [@timrogers]: https://github.com/timrogers
 [@harold-s]: https://github.com/harold-s
+[@daniloisr]: https://github.com/daniloisr

--- a/lib/rubocop/remote_config.rb
+++ b/lib/rubocop/remote_config.rb
@@ -17,6 +17,7 @@ module RuboCop
       return cache_path unless cache_path_expired?
 
       request do |response|
+        next if response.is_a?(Net::HTTPNotModified)
         open cache_path, 'w' do |io|
           io.write response.body
         end
@@ -43,7 +44,7 @@ module RuboCop
 
     def handle_response(response, limit, &block)
       case response
-      when Net::HTTPSuccess
+      when Net::HTTPSuccess, Net::HTTPNotModified
         yield response
       when Net::HTTPRedirection
         request(URI.parse(response['location']), limit - 1, &block)

--- a/spec/rubocop/remote_config_spec.rb
+++ b/spec/rubocop/remote_config_spec.rb
@@ -58,6 +58,22 @@ describe RuboCop::RemoteConfig do
       end
     end
 
+    context 'when the remote URL responds with not modified' do
+      before do
+        stub_request(:get, remote_config_url)
+          .to_return(status: 304)
+      end
+
+      it 'reuses the existing cached file' do
+        FileUtils.touch cached_file_path, mtime: Time.now - ((60 * 60) * 30)
+
+        expect do
+          remote_config
+        end.to_not change(File.stat(cached_file_path), :mtime)
+        assert_requested :get, remote_config_url
+      end
+    end
+
     context 'when the remote URL responds with 500' do
       before do
         stub_request(:get, remote_config_url)


### PR DESCRIPTION
Hi all, when using remote config I was facing the following error:

> bad URI(is not URI?):

On lines [`lib/rubocop/remote_config.rb:48-49`](https://github.com/bbatsov/rubocop/blob/master/lib/rubocop/remote_config.rb#L48-L49):
```ruby
when Net::HTTPRedirection
  request(URI.parse(response['location']), limit - 1, &block)
```

This happens for 304 HTTPNotModified responses, which don't have the `'location'` key.
_(and to help reviewers, 304 responses occurs due [this header](https://github.com/bbatsov/rubocop/blob/master/lib/rubocop/remote_config.rb#L38))_

So my solution is to just handle this response and reuses the existing cached file.
