### PR TITLE
Make the spec template use the new offense matchers

### DIFF
--- a/lib/rubocop/cop/generator.rb
+++ b/lib/rubocop/cop/generator.rb
@@ -51,7 +51,7 @@ module RuboCop
         end
       RUBY
 
-      SPEC_TEMPLATE = <<-RUBY.strip_indent
+      SPEC_TEMPLATE = <<-SPEC.strip_indent
         # frozen_string_literal: true
 
         describe RuboCop::Cop::%<department>s::%<cop_name>s do
@@ -61,19 +61,20 @@ module RuboCop
           # TODO: Write test code
           #
           # For example
-          it 'registers an offense for offending code' do
-            inspect_source(cop, 'bad_method')
-            expect(cop.offenses.size).to eq(1)
-            expect(cop.messages)
-              .to eq(['Message of %<cop_name>s'])
+          it 'registers an offense when using `#bad_method`' do
+            expect_offense(<<-RUBY.strip_indent)
+              bad_method
+              ^^^^^^^^^^ Use `#good_method` instead of `#bad_method`.
+            RUBY
           end
 
-          it 'accepts' do
-            inspect_source(cop, 'good_method')
-            expect(cop.offenses).to be_empty
+          it 'does not register an offense when using `#good_method`' do
+            expect_no_offenses(<<-RUBY.strip_indent)
+              good_method
+            RUBY
           end
         end
-      RUBY
+      SPEC
 
       def initialize(name)
         @badge = Badge.parse(name)

--- a/spec/rubocop/cop/generator_spec.rb
+++ b/spec/rubocop/cop/generator_spec.rb
@@ -60,7 +60,7 @@ RSpec.describe RuboCop::Cop::Generator do
   end
 
   it 'generates a helpful starting spec file with the class filled in' do
-    generated_source = <<-RUBY.strip_indent
+    generated_source = <<-SPEC.strip_indent
       # frozen_string_literal: true
 
       describe RuboCop::Cop::Style::FakeCop do
@@ -70,19 +70,20 @@ RSpec.describe RuboCop::Cop::Generator do
         # TODO: Write test code
         #
         # For example
-        it 'registers an offense for offending code' do
-          inspect_source(cop, 'bad_method')
-          expect(cop.offenses.size).to eq(1)
-          expect(cop.messages)
-            .to eq(['Message of FakeCop'])
+        it 'registers an offense when using `#bad_method`' do
+          expect_offense(<<-RUBY.strip_indent)
+            bad_method
+            ^^^^^^^^^^ Use `#good_method` instead of `#bad_method`.
+          RUBY
         end
 
-        it 'accepts' do
-          inspect_source(cop, 'good_method')
-          expect(cop.offenses).to be_empty
+        it 'does not register an offense when using `#good_method`' do
+          expect_no_offenses(<<-RUBY.strip_indent)
+            good_method
+          RUBY
         end
       end
-    RUBY
+    SPEC
 
     generator.write_spec
 


### PR DESCRIPTION
The rake task `new_cop` will generate templates for a cop and its spec file. This change replaces the old examples in the spec with the new `#expect_offense` and `#expect_no_offenses` matchers.

-----------------

Before submitting the PR make sure the following are checked:

* [X] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [X] Used the same coding conventions as the rest of the project.
* [X] Feature branch is up-to-date with `master` (if not - rebase it).
* [X] Squashed related commits together.
* [X] Added tests.
* [ ] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [X] All tests are passing.
* [X] The new code doesn't generate RuboCop offenses.
* [X] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [ ] Updated cop documentation with `rake generate_cops_documentation` (required only when you've added a new cop or changed the configuration/documentation of an existing cop).

[1]: http://chris.beams.io/posts/git-commit/
