### PR TITLE
Add new `InternalAffairs/OffenseLocationKeyword` cop

### DIFF
--- a/lib/rubocop/cop/internal_affairs.rb
+++ b/lib/rubocop/cop/internal_affairs.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 
 require 'rubocop/cop/internal_affairs/node_type_predicate'
+require 'rubocop/cop/internal_affairs/offense_location_keyword'
 require 'rubocop/cop/internal_affairs/redundant_message_argument'
 require 'rubocop/cop/internal_affairs/useless_message_assertion'

--- a/lib/rubocop/cop/internal_affairs/offense_location_keyword.rb
+++ b/lib/rubocop/cop/internal_affairs/offense_location_keyword.rb
@@ -1,0 +1,43 @@
+# frozen_string_literal: true
+
+module RuboCop
+  module Cop
+    module InternalAffairs
+      # Checks for potential uses of the location keywords which can be used as
+      # shortcut arguments to `#add_offense`.
+      #
+      # @example
+      #
+      #   # bad
+      #   add_offense(node, node.loc.selector)
+      #
+      #   # good
+      #   add_offense(node, :selector)
+      class OffenseLocationKeyword < Cop
+        MSG = 'Use `:%s` as the location argument to `#add_offense`.'.freeze
+
+        def on_send(node)
+          offense_location(node) do |location_argument, keyword|
+            add_offense(node, location_argument.loc.expression,
+                        format(MSG, keyword))
+          end
+        end
+
+        private
+
+        def_node_matcher :offense_location, <<-PATTERN
+          (send nil :add_offense _offender
+            $(send (send _offender :loc) $_) ...)
+        PATTERN
+
+        def autocorrect(node)
+          lambda do |corrector|
+            offense_location(node) do |location_argument, keyword|
+              corrector.replace(location_argument.loc.expression, ":#{keyword}")
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/rubocop/cop/layout/comment_indentation.rb
+++ b/lib/rubocop/cop/layout/comment_indentation.rb
@@ -33,7 +33,7 @@ module RuboCop
             return if column == correct_comment_indentation
           end
 
-          add_offense(comment, comment.loc.expression,
+          add_offense(comment, :expression,
                       format(MSG, column, correct_comment_indentation))
         end
 

--- a/lib/rubocop/cop/performance/size.rb
+++ b/lib/rubocop/cop/performance/size.rb
@@ -29,7 +29,7 @@ module RuboCop
         def on_send(node)
           return unless eligible_node?(node)
 
-          add_offense(node, node.loc.selector)
+          add_offense(node, :selector)
         end
 
         private

--- a/lib/rubocop/cop/rails/find_each.rb
+++ b/lib/rubocop/cop/rails/find_each.rb
@@ -24,7 +24,7 @@ module RuboCop
           return unless SCOPE_METHODS.include?(node.receiver.method_name)
           return if method_chain(node).any? { |m| ignored_by_find_each?(m) }
 
-          add_offense(node, node.loc.selector)
+          add_offense(node, :selector)
         end
 
         def autocorrect(node)

--- a/lib/rubocop/cop/rails/http_positional_arguments.rb
+++ b/lib/rubocop/cop/rails/http_positional_arguments.rb
@@ -39,7 +39,7 @@ module RuboCop
           return if data.nil?
           return unless needs_conversion?(data)
 
-          add_offense(node, node.loc.selector, format(MSG, node.method_name))
+          add_offense(node, :selector, format(MSG, node.method_name))
         end
 
         # @return [Boolean] true if the line needs to be converted

--- a/lib/rubocop/cop/rails/save_bang.rb
+++ b/lib/rubocop/cop/rails/save_bang.rb
@@ -70,7 +70,7 @@ module RuboCop
           return unless expected_signature?(node)
           return if persisted_referenced?(assignment)
 
-          add_offense(node, node.loc.selector,
+          add_offense(node, :selector,
                       format(CREATE_MSG,
                              "#{node.method_name}!",
                              node.method_name.to_s,
@@ -84,7 +84,7 @@ module RuboCop
           return if check_used_in_conditional(node)
           return if last_call_of_method?(node)
 
-          add_offense(node, node.loc.selector,
+          add_offense(node, :selector,
                       format(MSG,
                              "#{node.method_name}!",
                              node.method_name.to_s))
@@ -121,7 +121,7 @@ module RuboCop
           return false unless conditional?(node)
 
           unless MODIFY_PERSIST_METHODS.include?(node.method_name)
-            add_offense(node, node.loc.selector,
+            add_offense(node, :selector,
                         format(CREATE_CONDITIONAL_MSG,
                                node.method_name.to_s))
           end

--- a/lib/rubocop/cop/style/numeric_predicate.rb
+++ b/lib/rubocop/cop/style/numeric_predicate.rb
@@ -59,7 +59,7 @@ module RuboCop
 
           return unless numeric
 
-          add_offense(node, node.loc.expression,
+          add_offense(node, :expression,
                       format(MSG, replacement, node.source))
         end
 

--- a/spec/rubocop/cop/internal_affairs/offense_location_keyword_spec.rb
+++ b/spec/rubocop/cop/internal_affairs/offense_location_keyword_spec.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+describe RuboCop::Cop::InternalAffairs::OffenseLocationKeyword do
+  subject(:cop) { described_class.new }
+
+  it 'registers an offense when `node.loc.expression` is passed' do
+    expect_offense(<<-RUBY, 'example_cop.rb')
+      add_offense(node, node.loc.selector)
+                        ^^^^^^^^^^^^^^^^^ Use `:selector` as the location argument to `#add_offense`.
+    RUBY
+  end
+
+  it 'does not register an offense when the `loc` is on a child node' do
+    expect_no_offenses(<<-RUBY, 'example_cop.rb')
+      add_offense(node, node.arguments.loc.selector)
+    RUBY
+  end
+
+  it 'does not register an offense when the `loc` is on a different node' do
+    expect_no_offenses(<<-RUBY, 'example_cop.rb')
+      add_offense(node, oher_node.loc.selector)
+    RUBY
+  end
+end


### PR DESCRIPTION
This change adds another internal affairs cop, that checks for potential uses of location keyword arguments to `#add_offense`. E.g.:

```
add_offense(node, node.loc.selector)
```

can be written:

```
add_offense(node, :selector)
```

-----------------

Before submitting the PR make sure the following are checked:

* [X] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [X] Used the same coding conventions as the rest of the project.
* [X] Feature branch is up-to-date with `master` (if not - rebase it).
* [X] Squashed related commits together.
* [X] Added tests.
* [ ] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [X] All tests are passing.
* [X] The new code doesn't generate RuboCop offenses.
* [X] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [X] Updated cop documentation with `rake generate_cops_documentation` (required only when you've added a new cop or changed the configuration/documentation of an existing cop).

[1]: http://chris.beams.io/posts/git-commit/
