### PR TITLE
fix StringLiteral cop that converts /{/ in a wrong way

### DIFF
--- a/lib/rubocop/cop/style/regexp_literal.rb
+++ b/lib/rubocop/cop/style/regexp_literal.rb
@@ -73,6 +73,10 @@ module RuboCop
           !allow_inner_slashes? && contains_slash?(node)
         end
 
+        def contains_delimiter?(node)
+          node_body(node) =~ Regexp.union(preferred_delimiters)
+        end
+
         def contains_slash?(node)
           node_body(node).include?('/')
         end
@@ -95,13 +99,13 @@ module RuboCop
         end
 
         def autocorrect(node)
-          return if contains_slash?(node)
-
-          replacement = if slash_literal?(node)
-                          ['%r', ''].zip(preferred_delimiters).map(&:join)
-                        else
-                          %w[/ /]
-                        end
+          if slash_literal?(node)
+            return if contains_delimiter?(node)
+            replacement = ['%r', ''].zip(preferred_delimiters).map(&:join)
+          else
+            return if contains_slash?(node)
+            replacement = %w[/ /]
+          end
 
           lambda do |corrector|
             corrector.replace(node.loc.begin, replacement.first)

--- a/spec/rubocop/cop/style/regexp_literal_spec.rb
+++ b/spec/rubocop/cop/style/regexp_literal_spec.rb
@@ -65,9 +65,9 @@ describe RuboCop::Cop::Style::RegexpLiteral, :config do
         RUBY
       end
 
-      it 'cannot auto-correct' do
+      it 'auto-corrects' do
         new_source = autocorrect_source(cop, source)
-        expect(new_source).to eq(source)
+        expect(new_source).to eq('foo = %r{home\/}')
       end
 
       describe 'when configured to allow inner slashes' do
@@ -95,7 +95,7 @@ describe RuboCop::Cop::Style::RegexpLiteral, :config do
         ['foo = /',
          '  https?:\/\/',
          '  example\.com',
-         '/x']
+         "/x\n"]
       end
 
       it 'registers an offense' do
@@ -103,9 +103,14 @@ describe RuboCop::Cop::Style::RegexpLiteral, :config do
         expect(cop.messages).to eq(['Use `%r` around regular expression.'])
       end
 
-      it 'cannot auto-correct' do
+      it 'auto-corrects' do
         new_source = autocorrect_source(cop, source)
-        expect(new_source).to eq(source.join("\n"))
+        expect(new_source).to eq(<<-'RUBY'.strip_indent)
+          foo = %r{
+            https?:\/\/
+            example\.com
+          }x
+        RUBY
       end
 
       describe 'when configured to allow inner slashes' do
@@ -243,9 +248,9 @@ describe RuboCop::Cop::Style::RegexpLiteral, :config do
         RUBY
       end
 
-      it 'cannot auto-correct' do
+      it 'auto-corrects' do
         new_source = autocorrect_source(cop, source)
-        expect(new_source).to eq(source)
+        expect(new_source).to eq('foo = %r{home\/}')
       end
     end
 
@@ -273,7 +278,7 @@ describe RuboCop::Cop::Style::RegexpLiteral, :config do
         ['foo = /',
          '  https?:\/\/',
          '  example\.com',
-         '/x']
+         "/x\n"]
       end
 
       it 'registers an offense' do
@@ -281,9 +286,14 @@ describe RuboCop::Cop::Style::RegexpLiteral, :config do
         expect(cop.messages).to eq(['Use `%r` around regular expression.'])
       end
 
-      it 'cannot auto-correct' do
+      it 'auto-corrects' do
         new_source = autocorrect_source(cop, source)
-        expect(new_source).to eq(source.join("\n"))
+        expect(new_source).to eq(<<-'RUBY'.strip_indent)
+          foo = %r{
+            https?:\/\/
+            example\.com
+          }x
+        RUBY
       end
     end
 
@@ -320,6 +330,22 @@ describe RuboCop::Cop::Style::RegexpLiteral, :config do
         RUBY
       end
     end
+
+    describe 'a regex with open delimiters' do
+      let(:source) { 'foo = /{/' }
+      it 'cannot auto-correct' do
+        new_source = autocorrect_source(cop, source)
+        expect(new_source).to eq(source)
+      end
+    end
+
+    describe 'a regex with close delimiters' do
+      let(:source) { 'foo = /}/' }
+      it 'cannot auto-correct' do
+        new_source = autocorrect_source(cop, source)
+        expect(new_source).to eq(source)
+      end
+    end
   end
 
   context 'when EnforcedStyle is set to mixed' do
@@ -341,9 +367,9 @@ describe RuboCop::Cop::Style::RegexpLiteral, :config do
         RUBY
       end
 
-      it 'cannot auto-correct' do
+      it 'auto-corrects' do
         new_source = autocorrect_source(cop, source)
-        expect(new_source).to eq(source)
+        expect(new_source).to eq('foo = %r{home\/}')
       end
 
       describe 'when configured to allow inner slashes' do
@@ -379,7 +405,7 @@ describe RuboCop::Cop::Style::RegexpLiteral, :config do
         ['foo = /',
          '  https?:\/\/',
          '  example\.com',
-         '/x']
+         "/x\n"]
       end
 
       it 'registers an offense' do
@@ -387,9 +413,14 @@ describe RuboCop::Cop::Style::RegexpLiteral, :config do
         expect(cop.messages).to eq(['Use `%r` around regular expression.'])
       end
 
-      it 'cannot auto-correct' do
+      it 'auto-corrects' do
         new_source = autocorrect_source(cop, source)
-        expect(new_source).to eq(source.join("\n"))
+        expect(new_source).to eq(<<-'RUBY'.strip_indent)
+          foo = %r{
+            https?:\/\/
+            example\.com
+          }x
+        RUBY
       end
     end
 


### PR DESCRIPTION
The `StringLiteral` cop breaks the code if it enforced style `percent_r`:

```ruby
foo = /{/
```

it is converted in master:

```ruby
foo = %r{{}
```

This is because the guard condition, `return if contains_slash?(node)` is wrong, so I've fixed it as a right way.

As a side effect, the cop gets to able to auto-correct the code like `foo = /foo\//` which includes slashes in regexp literals, but I don't want to keep the old behavior so I've fixed the specs to follow the new behavior.

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Used the same coding conventions as the rest of the project.
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [ ] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] All tests are passing.
* [x] The new code doesn't generate RuboCop offenses.
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [ ] Updated cop documentation with `rake generate_cops_documentation` (required only when you've added a new cop or changed the configuration/documentation of an existing cop).

[1]: http://chris.beams.io/posts/git-commit/
