### PR TITLE
Make `Lint/DuplicateMethods` aware of `alias` and `alias_method`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@
 
 * [#4444](https://github.com/bbatsov/rubocop/pull/4444): Make `Style/Encoding` cop enabled by default. ([@deivid-rodriguez][])
 * [#4452](https://github.com/bbatsov/rubocop/pull/4452): Add option to `Rails/Delegate` for enforcing the prefixed method name case. ([@klesse413][])
+* [#4492](https://github.com/bbatsov/rubocop/pull/4492): Make `Lint/DuplicateMethods` aware of `alias` and `alias_method`. ([@pocke][])
 
 ## 0.49.1 (2017-05-29)
 

--- a/manual/cops_lint.md
+++ b/manual/cops_lint.md
@@ -432,6 +432,15 @@ def duplicated
 end
 ```
 ```ruby
+# bad
+
+def duplicated
+  1
+end
+
+alias duplicated other_duplicated
+```
+```ruby
 # good
 
 def duplicated

--- a/spec/rubocop/cop/lint/duplicate_methods_spec.rb
+++ b/spec/rubocop/cop/lint/duplicate_methods_spec.rb
@@ -253,6 +253,60 @@ describe RuboCop::Cop::Lint::DuplicateMethods do
                       'end'], 'test.rb')
       expect(cop.offenses).to be_empty
     end
+
+    it "registers an offense for duplicate alias in #{type}" do
+      expect_offense(<<-RUBY)
+        #{opening_line}
+          def some_method
+            implement 1
+          end
+          alias some_method any_method
+          ^^^^^ Method `A#some_method` is defined at both example.rb:2 and example.rb:5.
+        end
+      RUBY
+    end
+
+    it "doesn't register an offense for non-duplicate alias in #{type}" do
+      expect_no_offenses(<<-RUBY)
+        #{opening_line}
+          def some_method
+            implement 1
+          end
+          alias any_method some_method
+        end
+      RUBY
+    end
+
+    it "registers an offense for duplicate alias_method in #{type}" do
+      expect_offense(<<-RUBY)
+        #{opening_line}
+          def some_method
+            implement 1
+          end
+          alias_method :some_method, :any_method
+          ^^^^^^^^^^^^ Method `A#some_method` is defined at both example.rb:2 and example.rb:5.
+        end
+      RUBY
+    end
+
+    it "accepts for non-duplicate alias_method in #{type}" do
+      expect_no_offenses(<<-RUBY)
+        #{opening_line}
+          def some_method
+            implement 1
+          end
+          alias_method :any_method, :some_method
+        end
+      RUBY
+    end
+
+    it "doesn't register an offense for alias for gvar in #{type}" do
+      expect_no_offenses(<<-RUBY)
+        #{opening_line}
+          alias $foo $bar
+        end
+      RUBY
+    end
   end
 
   include_examples('in scope', 'class', 'class A')


### PR DESCRIPTION
Currently `Lint/DuplicateMethods` cop does not aware of `alias`.

For example:

```ruby
class A
  def foo
  end
  def bar
  end

  # foo is redefined, but the cop does not detect it.
  alias foo bar
end
```

This change fixes the problem.



-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Used the same coding conventions as the rest of the project.
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] All tests are passing.
* [x] The new code doesn't generate RuboCop offenses.
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Updated cop documentation with `rake generate_cops_documentation` (required only when you've added a new cop or changed the configuration/documentation of an existing cop).

[1]: http://chris.beams.io/posts/git-commit/
