### PR TITLE
Make `Lint/Void` cop aware of `Enumerable#each` and `for`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@
 
 * [#4444](https://github.com/bbatsov/rubocop/pull/4444): Make `Style/Encoding` cop enabled by default. ([@deivid-rodriguez][])
 * [#4452](https://github.com/bbatsov/rubocop/pull/4452): Add option to `Rails/Delegate` for enforcing the prefixed method name case. ([@klesse413][])
+* [#4493](https://github.com/bbatsov/rubocop/pull/4493): Make `Lint/Void` cop aware of `Enumerable#each` and `for`. ([@pocke][])
 
 ## 0.49.1 (2017-05-29)
 

--- a/spec/rubocop/cop/lint/void_spec.rb
+++ b/spec/rubocop/cop/lint/void_spec.rb
@@ -97,6 +97,28 @@ describe RuboCop::Cop::Lint::Void do
     RUBY
   end
 
+  it 'registers two offenses for void literals in a `#each` method' do
+    expect_offense(<<-RUBY.strip_indent)
+      array.each do |_item|
+        42
+        ^^ Literal `42` used in void context.
+        42
+        ^^ Literal `42` used in void context.
+      end
+    RUBY
+  end
+
+  it 'registers two offenses for void literals in a `for`' do
+    expect_offense(<<-RUBY.strip_indent)
+      for _item in array do
+        42
+        ^^ Literal `42` used in void context.
+        42
+        ^^ Literal `42` used in void context.
+      end
+    RUBY
+  end
+
   it 'handles explicit begin blocks' do
     expect_offense(<<-RUBY.strip_indent)
       begin


### PR DESCRIPTION
In `Enumerable#each` method, returned value is not used.

For example:

```ruby
array.each do |item|
  # The value is ignored.
  # It may be `array#map`?
  {
    something: item.something
  }
end

for item in array do
  # It has a same problem.
  {
    something: item.something
  }
end
```

But `Lint/Void` cop does not detect a problem about the above code.
This change fixes the problem.


-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Used the same coding conventions as the rest of the project.
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] All tests are passing.
* [x] The new code doesn't generate RuboCop offenses.
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Updated cop documentation with `rake generate_cops_documentation` (required only when you've added a new cop or changed the configuration/documentation of an existing cop).

[1]: http://chris.beams.io/posts/git-commit/
