### PR TITLE
[Fix #4491] Prevent bad auto-correct in `Style/EmptyElse` for nested `if`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 * [#4451](https://github.com/bbatsov/rubocop/issues/4451): Make `Style/AndOr` cop aware of comparison methods. ([@drenmi][])
 * [#4457](https://github.com/bbatsov/rubocop/pull/4457): Fix false negative in `Lint/Void` with initialize and setter methods. ([@pocke][])
 * [#4418](https://github.com/bbatsov/rubocop/issues/4418): Register an offense in `Style/ConditionalAssignment` when the assignment line is the longest line, and it does not exceed the max line length. ([@rrosenblum][])
+* [#4491](https://github.com/bbatsov/rubocop/issues/4491): Prevent bad auto-correct in `Style/EmptyElse` for nested `if`. ([@pocke][])
 
 ### Changes
 

--- a/lib/rubocop/cop/style/empty_else.rb
+++ b/lib/rubocop/cop/style/empty_else.rb
@@ -121,6 +121,7 @@ module RuboCop
         end
 
         def base_if_node(node)
+          return node unless node.case_type? || node.elsif?
           node.each_ancestor(:if).find { |parent| parent.loc.end } || node
         end
 

--- a/spec/rubocop/cop/style/empty_else_spec.rb
+++ b/spec/rubocop/cop/style/empty_else_spec.rb
@@ -98,6 +98,27 @@ describe RuboCop::Cop::Style::EmptyElse do
           expect_no_offenses('if cond; foo end')
         end
       end
+
+      context 'in an if-statement' do
+        let(:source) { <<-RUBY.strip_indent }
+          if cond
+            if cond2
+              something
+            else
+            end
+          end
+        RUBY
+        let(:corrected_source) { <<-RUBY.strip_indent }
+          if cond
+            if cond2
+              something
+            end
+          end
+        RUBY
+
+        it_behaves_like 'auto-correct', 'if'
+        it_behaves_like 'offense registration'
+      end
     end
 
     context 'given an unless-statement' do


### PR DESCRIPTION

See #4491.

Reproduce
======

```ruby
if cond
  if cond2
    some
  else
  end
end
```

```bash
$ rubocop -a --only EmptyElse
Inspecting 1 file
E

Offenses:

test.rb:4:3: C: [Corrected] Redundant else-clause.
  else
  ^^^^
test.rb:5:1: E: unexpected token $end
(Using Ruby 2.1 parser; configure using TargetRubyVersion parameter, under AllCops)

1 file inspected, 2 offenses detected, 1 offense corrected

$ cat test.rb
if cond
  if cond2
    some
  end
```

This change fixes the bug.



-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Used the same coding conventions as the rest of the project.
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] All tests are passing.
* [x] The new code doesn't generate RuboCop offenses.
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [ ] Updated cop documentation with `rake generate_cops_documentation` (required only when you've added a new cop or changed the configuration/documentation of an existing cop).

[1]: http://chris.beams.io/posts/git-commit/
