### PR TITLE
Swap `expected` and `got` in `expect_offense` spec helper

### DIFF
--- a/lib/rubocop/rspec/expect_offense.rb
+++ b/lib/rubocop/rspec/expect_offense.rb
@@ -56,7 +56,7 @@ module RuboCop
         inspect_source(cop, expected_annotations.plain_source, filename)
         actual_annotations =
           expected_annotations.with_offense_annotations(cop.offenses)
-        expect(expected_annotations.to_s).to eq(actual_annotations.to_s)
+        expect(actual_annotations.to_s).to eq(expected_annotations.to_s)
       end
 
       def expect_no_offenses(source, filename = DEFAULT_FILENAME)


### PR DESCRIPTION
I guess `expected` and `got` are inverses in the `expect_offense` spec helper.

For example:

```ruby
it 'registers an offense for wrong code' do
  expect_offense(<<-RUBY.strip_indent)
    something
    ^^^^^^^^^ It's wrong.
  RUBY
end
```

```
$ bundle exec rspec

(snip)

Failures:

  1) RuboCop::Cop::Lint::Loop registers an offense for wrong code
     Failure/Error: expect(expected_annotations.to_s).to eq(actual_annotations.to_s)

       expected: "something\n"
            got: "something\n^^^^^^^^^ It's wrong.\n"

       (compared using ==)

       Diff:
       @@ -1,2 +1,3 @@
        something
       +^^^^^^^^^ It's wrong.
     # ./lib/rubocop/rspec/expect_offense.rb:59:in `expect_offense'
     # ./spec/rubocop/cop/lint/loop_spec.rb:29:in `block (2 levels) in <top (required)>'

(snip)
```

The above spec expects to output `^^^^^^^^^ It's wrong.`.
But it is inverses in the spec failure message.

@backus WDYT?

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Used the same coding conventions as the rest of the project.
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [ ] Added tests.
* [ ] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] All tests(`rake spec`) are passing.
* [x] The new code doesn't generate RuboCop offenses that are checked by `rake internal_investigation`.
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [ ] Updated cop documentation with `rake generate_cops_documentation` (required only when you've added a new cop or changed the configuration/documentation of an existing cop).

[1]: http://chris.beams.io/posts/git-commit/
