### PR TITLE
[Fix #4437] Allow `NodePattern` to match string literals

### DIFF
--- a/spec/rubocop/node_pattern_spec.rb
+++ b/spec/rubocop/node_pattern_spec.rb
@@ -109,6 +109,24 @@ describe RuboCop::NodePattern do
       let(:ruby) { '-2.5' }
       it_behaves_like :matching
     end
+
+    context 'single quoted string literals' do
+      let(:pattern) { '(str "foo")' }
+      let(:ruby) { '"foo"' }
+      it_behaves_like :matching
+    end
+
+    context 'double quoted string literals' do
+      let(:pattern) { '(str "foo")' }
+      let(:ruby) { "'foo'" }
+      it_behaves_like :matching
+    end
+
+    context 'symbol literals' do
+      let(:pattern) { '(sym :foo)' }
+      let(:ruby) { ':foo' }
+      it_behaves_like :matching
+    end
   end
 
   describe 'simple sequence' do
@@ -286,6 +304,12 @@ describe RuboCop::NodePattern do
           let(:ruby) { 'obj.c' }
           it_behaves_like :nonmatching
         end
+      end
+
+      context 'containing string literals' do
+        let(:pattern) { '(send (str {"a" "b"}) :upcase)' }
+        let(:ruby) { '"a".upcase' }
+        it_behaves_like :matching
       end
 
       context 'containing integer literals' do
@@ -514,6 +538,20 @@ describe RuboCop::NodePattern do
       context 'with a non-matching symbol, but too many children' do
         let(:ruby) { 'obj.xyz(1)' }
         it_behaves_like :nonmatching
+      end
+    end
+
+    context 'on a string' do
+      let(:pattern) { '(send (str !"foo") :upcase)' }
+
+      context 'with a matching string' do
+        let(:ruby) { '"foo".upcase' }
+        it_behaves_like :nonmatching
+      end
+
+      context 'with a non-matching symbol' do
+        let(:ruby) { '"bar".upcase' }
+        it_behaves_like :matching
       end
     end
 


### PR DESCRIPTION
Previously, building a node matcher with a string literal would make the compiler error out, since it didn't recognize `"` in the AST.

This change fixes that, and allows matching patterns like:

```
(send (str "foo") :upcase)
```

-----------------

Before submitting the PR make sure the following are checked:

* [X] Wrote [good commit messages][1].
* [X] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [X] Used the same coding conventions as the rest of the project.
* [X] Feature branch is up-to-date with `master` (if not - rebase it).
* [X] Squashed related commits together.
* [X] Added tests.
* [ ] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [X] All tests(`rake spec`) are passing.
* [X] The new code doesn't generate RuboCop offenses that are checked by `rake internal_investigation`.
* [X] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [ ] Updated cop documentation with `rake generate_cops_documentation` (required only when you've added a new cop or changed the configuration/documentation of an existing cop).

[1]: http://chris.beams.io/posts/git-commit/
