### PR TITLE
Drop support for extra commas in node patterns

### DIFF
--- a/lib/rubocop/node_pattern.rb
+++ b/lib/rubocop/node_pattern.rb
@@ -106,7 +106,7 @@ module RuboCop
       METHOD_NAME  = /\#?#{IDENTIFIER}+[\!\?]?\(?/
       PARAM_NUMBER = /%\d*/
 
-      SEPARATORS = /[\s,]+/
+      SEPARATORS = /[\s]+/
       TOKENS     = Regexp.union(META, PARAM_NUMBER, NUMBER,
                                 METHOD_NAME, SYMBOL, STRING)
 


### PR DESCRIPTION
**Note: this is based on #4498.**

The node pattern compiler had an undocumented and untested feature, in that it would allow any number of commas within patterns, e.g.:

```
(send, nil,, :foo)
```

IMHO, this only leads to less concise patterns, with more punctuation noise from non-functional characters. So I suggest dropping support.

The codebase currently doesn't contain any node patterns with commas, but there is a small chance there are user generated custom cops using this, which risk breaking.

-----------------

Before submitting the PR make sure the following are checked:

* [X] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [X] Used the same coding conventions as the rest of the project.
* [X] Feature branch is up-to-date with `master` (if not - rebase it).
* [X] Squashed related commits together.
* [X] Added tests.
* [ ] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [X] All tests(`rake spec`) are passing.
* [X] The new code doesn't generate RuboCop offenses that are checked by `rake internal_investigation`.
* [X] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [ ] Updated cop documentation with `rake generate_cops_documentation` (required only when you've added a new cop or changed the configuration/documentation of an existing cop).

[1]: http://chris.beams.io/posts/git-commit/
