### PR TITLE
add example for Layout::EmptyLinesAroundAccessModifier

### DIFF
--- a/lib/rubocop/cop/layout/empty_lines_around_access_modifier.rb
+++ b/lib/rubocop/cop/layout/empty_lines_around_access_modifier.rb
@@ -4,6 +4,24 @@ module RuboCop
   module Cop
     module Layout
       # Access modifiers should be surrounded by blank lines.
+      #
+      # @example
+      #
+      #   # bad
+      #   class Foo
+      #     def bar; end
+      #     private
+      #     def baz; end
+      #   end
+      #
+      #   # good
+      #   class Foo
+      #     def bar; end
+      #
+      #     private
+      #
+      #     def baz; end
+      #   end
       class EmptyLinesAroundAccessModifier < Cop
         include AccessModifierNode
 

--- a/manual/cops_layout.md
+++ b/manual/cops_layout.md
@@ -570,6 +570,26 @@ Enabled | Yes
 
 Access modifiers should be surrounded by blank lines.
 
+### Example
+
+```ruby
+# bad
+class Foo
+  def bar; end
+  private
+  def baz; end
+end
+
+# good
+class Foo
+  def bar; end
+
+  private
+
+  def baz; end
+end
+```
+
 ### References
 
 * [https://github.com/bbatsov/ruby-style-guide#empty-lines-around-access-modifier](https://github.com/bbatsov/ruby-style-guide#empty-lines-around-access-modifier)


### PR DESCRIPTION
Adds an example for `RuboCop::Cop::Layout::EmptyLinesAroundAccessModifier

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Used the same coding conventions as the rest of the project.
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] All tests(`rake spec`) are passing.
* [x] The new code doesn't generate RuboCop offenses that are checked by `rake internal_investigation`.
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Updated cop documentation with `rake generate_cops_documentation` (required only when you've added a new cop or changed the configuration/documentation of an existing cop).

[1]: http://chris.beams.io/posts/git-commit/