### PR TITLE
Drop support for extra commas in node patterns (part 2)

### DIFF
--- a/lib/rubocop/node_pattern.rb
+++ b/lib/rubocop/node_pattern.rb
@@ -135,9 +135,11 @@ module RuboCop
       end
 
       def run(node_var)
-        tokens = @string.scan(TOKEN)
-        tokens.reject! { |token| token =~ /\A[\s,]+\Z/ } # drop whitespace
+        tokens =
+          @string.scan(TOKEN).reject { |token| token =~ /\A#{SEPARATORS}\Z/ }
+
         @match_code = compile_expr(tokens, node_var, false)
+
         fail_due_to('unbalanced pattern') unless tokens.empty?
       end
 

--- a/spec/rubocop/node_pattern_spec.rb
+++ b/spec/rubocop/node_pattern_spec.rb
@@ -912,11 +912,10 @@ describe RuboCop::NodePattern do
   end
 
   describe 'commas' do
-    # commas are just whitespace
     context 'with commas randomly strewn around' do
       let(:pattern) { ',,(,send,, ,int,:+, int ), ' }
       let(:ruby) { '1 + 2' }
-      it_behaves_like :matching
+      it_behaves_like :invalid
     end
   end
 


### PR DESCRIPTION
Work started in #4499. However, node patterns would still allow commas, due to another hard coded instance of the regexp that is now extracted into `NodePattern::Compiler::SEPARATORS`.

-----------------

Before submitting the PR make sure the following are checked:

* [X] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [X] Used the same coding conventions as the rest of the project.
* [X] Feature branch is up-to-date with `master` (if not - rebase it).
* [X] Squashed related commits together.
* [X] Added tests.
* [ ] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [X] All tests(`rake spec`) are passing.
* [X] The new code doesn't generate RuboCop offenses that are checked by `rake internal_investigation`.
* [X] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [ ] Updated cop documentation with `rake generate_cops_documentation` (required only when you've added a new cop or changed the configuration/documentation of an existing cop).

[1]: http://chris.beams.io/posts/git-commit/
