### PR TITLE
Remove duplicate node matcher macro definition from `Node`

### DIFF
--- a/lib/rubocop/ast/node/send_node.rb
+++ b/lib/rubocop/ast/node/send_node.rb
@@ -173,7 +173,7 @@ module RuboCop
 
       private
 
-      def_matcher :macro_scope?, <<-PATTERN
+      def_node_matcher :macro_scope?, <<-PATTERN
         {^({class module} ...)
          ^^({class module} ... (begin ...))}
       PATTERN


### PR DESCRIPTION
Previously, `Node` re-implemented a near-identical version of `NodePattern::Macros#def_node_matcher`, and in doing so directly referenced the compiler, which is intended to be private.

This change allows `#def_node_matcher` to be called from within a node and have the node instance passed as the default argument.

It also definitively makes the compiler private through `#private_constant`.

-----------------

Before submitting the PR make sure the following are checked:

* [X] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [X] Used the same coding conventions as the rest of the project.
* [X] Feature branch is up-to-date with `master` (if not - rebase it).
* [X] Squashed related commits together.
* [ ] Added tests.
* [ ] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [X] All tests(`rake spec`) are passing.
* [X] The new code doesn't generate RuboCop offenses that are checked by `rake internal_investigation`.
* [X] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [ ] Updated cop documentation with `rake generate_cops_documentation` (required only when you've added a new cop or changed the configuration/documentation of an existing cop).

[1]: http://chris.beams.io/posts/git-commit/
