### PR TITLE
Remove `Node#method_args` matcher

### DIFF
--- a/lib/rubocop/ast/node.rb
+++ b/lib/rubocop/ast/node.rb
@@ -273,7 +273,6 @@ module RuboCop
 
       def_matcher :receiver,    '{(send $_ ...) (block (send $_ ...) ...)}'
       def_matcher :method_name, '{(send _ $_ ...) (block (send _ $_ ...) ...)}'
-      def_matcher :method_args, '{(send _ _ $...) (block (send _ _ $...) ...)}'
       # Note: for masgn, #asgn_rhs will be an array node
       def_matcher :asgn_rhs, '[assignment? (... $_)]'
       def_matcher :str_content, '(str $_)'

--- a/lib/rubocop/cop/bundler/duplicated_gem.rb
+++ b/lib/rubocop/cop/bundler/duplicated_gem.rb
@@ -36,7 +36,7 @@ module RuboCop
             nodes[1..-1].each do |node|
               register_offense(
                 node,
-                node.method_args.first.to_a.first,
+                node.first_argument.to_a.first,
                 nodes.first.loc.line
               )
             end
@@ -49,9 +49,9 @@ module RuboCop
 
         def duplicated_gem_nodes
           gem_declarations(processed_source.ast)
-            .group_by { |e| e.method_args.first }
-            .keep_if { |_, nodes| nodes.length > 1 }
+            .group_by(&:first_argument)
             .values
+            .select { |nodes| nodes.size > 1 }
         end
 
         def register_offense(node, gem_name, line_of_first_occurrence)

--- a/lib/rubocop/cop/rails/file_path.rb
+++ b/lib/rubocop/cop/rails/file_path.rb
@@ -43,7 +43,7 @@ module RuboCop
 
         def check_for_file_join_with_rails_root(node)
           return unless file_join_nodes?(node)
-          return unless node.method_args.any? { |e| rails_root_nodes?(e) }
+          return unless node.arguments.any? { |e| rails_root_nodes?(e) }
 
           register_offense(node)
         end
@@ -51,7 +51,7 @@ module RuboCop
         def check_for_rails_root_join_with_slash_separated_path(node)
           return unless rails_root_nodes?(node)
           return unless rails_root_join_nodes?(node)
-          return unless node.method_args.any? { |arg| string_with_slash?(arg) }
+          return unless node.arguments.any? { |arg| string_with_slash?(arg) }
 
           register_offense(node)
         end

--- a/lib/rubocop/cop/rails/relative_date_constant.rb
+++ b/lib/rubocop/cop/rails/relative_date_constant.rb
@@ -71,7 +71,7 @@ module RuboCop
         def relative_date_method?(node)
           node.send_type? &&
             RELATIVE_DATE_METHODS.include?(node.method_name) &&
-            node.method_args.empty?
+            !node.arguments?
         end
 
         def autocorrect(node)

--- a/lib/rubocop/cop/style/one_line_conditional.rb
+++ b/lib/rubocop/cop/style/one_line_conditional.rb
@@ -62,8 +62,7 @@ module RuboCop
         end
 
         def method_call_with_changed_precedence?(node)
-          return false unless node.send_type?
-          return false if node.method_args.empty?
+          return false unless node.send_type? && node.arguments?
           return false if parenthesized_call?(node)
 
           !operator?(node.method_name)

--- a/lib/rubocop/cop/style/parallel_assignment.rb
+++ b/lib/rubocop/cop/style/parallel_assignment.rb
@@ -159,7 +159,7 @@ module RuboCop
           def accesses?(rhs, lhs)
             if lhs.method?(:[]=)
               matching_calls(rhs, lhs.receiver, :[]).any? do |args|
-                args == lhs.method_args
+                args == lhs.arguments
               end
             else
               access_method = lhs.method_name.to_s.chop.to_sym


### PR DESCRIPTION
We've come to a point where the node extensions allow us to start removing some type specific matchers from the root `Node` type. 🎉 

This node type-specific matcher is no longer needed with the introduction of `SendNode`.

-----------------

Before submitting the PR make sure the following are checked:

* [X] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [X] Used the same coding conventions as the rest of the project.
* [X] Feature branch is up-to-date with `master` (if not - rebase it).
* [X] Squashed related commits together.
* [ ] Added tests.
* [ ] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [X] All tests(`rake spec`) are passing.
* [X] The new code doesn't generate RuboCop offenses that are checked by `rake internal_investigation`.
* [X] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [ ] Updated cop documentation with `rake generate_cops_documentation` (required only when you've added a new cop or changed the configuration/documentation of an existing cop).

[1]: http://chris.beams.io/posts/git-commit/
