### PR TITLE
Remove the need to pass cop into the test inspection methods

### DIFF
--- a/lib/rubocop/rspec/cop_helper.rb
+++ b/lib/rubocop/rspec/cop_helper.rb
@@ -41,11 +41,11 @@ module CopHelper
     RuboCop::ProcessedSource.new(source, ruby_version, file)
   end
 
-  def autocorrect_source_file(cop, source)
-    Tempfile.open('tmp') { |f| autocorrect_source(cop, source, f) }
+  def autocorrect_source_file(source)
+    Tempfile.open('tmp') { |f| autocorrect_source(source, f) }
   end
 
-  def autocorrect_source(cop, source, file = nil)
+  def autocorrect_source(source, file = nil)
     cop.instance_variable_get(:@options)[:auto_correct] = true
     processed_source = parse_source(source, file)
     _investigate(cop, processed_source)
@@ -55,10 +55,10 @@ module CopHelper
     corrector.rewrite
   end
 
-  def autocorrect_source_with_loop(cop, source, file = nil)
+  def autocorrect_source_with_loop(source, file = nil)
     loop do
       cop.instance_variable_set(:@corrections, [])
-      new_source = autocorrect_source(cop, source, file)
+      new_source = autocorrect_source(source, file)
       return new_source if new_source == source
       source = new_source
     end

--- a/lib/rubocop/rspec/cop_helper.rb
+++ b/lib/rubocop/rspec/cop_helper.rb
@@ -10,15 +10,15 @@ module CopHelper
   let(:enabled_rails) { false }
   let(:rails_version) { false }
 
-  def inspect_source_file(cop, source)
-    Tempfile.open('tmp') { |f| inspect_source(cop, source, f) }
+  def inspect_source_file(source)
+    Tempfile.open('tmp') { |f| inspect_source(source, f) }
   end
 
-  def inspect_gemfile(cop, source)
-    inspect_source(cop, source, 'Gemfile')
+  def inspect_gemfile(source)
+    inspect_source(source, 'Gemfile')
   end
 
-  def inspect_source(cop, source, file = nil)
+  def inspect_source(source, file = nil)
     if source.is_a?(Array) && source.size == 1
       raise "Don't use an array for a single line of code: #{source}"
     end

--- a/lib/rubocop/rspec/expect_offense.rb
+++ b/lib/rubocop/rspec/expect_offense.rb
@@ -23,7 +23,7 @@ module RuboCop
     #
     # @example Equivalent assertion without `expect_offense`
     #
-    #     inspect_source(cop, <<-RUBY.strip_indent)
+    #     inspect_source(<<-RUBY.strip_indent)
     #       a do
     #         b
     #       end.c
@@ -51,14 +51,14 @@ module RuboCop
           raise 'Use expect_no_offenses to assert that no offenses are found'
         end
 
-        inspect_source(cop, expected_annotations.plain_source, file)
+        inspect_source(expected_annotations.plain_source, file)
         actual_annotations =
           expected_annotations.with_offense_annotations(cop.offenses)
         expect(actual_annotations.to_s).to eq(expected_annotations.to_s)
       end
 
       def expect_no_offenses(source, file = nil)
-        inspect_source(cop, source, file)
+        inspect_source(source, file)
 
         expect(cop.offenses).to be_empty
       end

--- a/lib/rubocop/rspec/expect_offense.rb
+++ b/lib/rubocop/rspec/expect_offense.rb
@@ -44,23 +44,21 @@ module RuboCop
     # that there were no offenses. The `expect_offenses` method has
     # to do more work by parsing out lines that contain carets.
     module ExpectOffense
-      DEFAULT_FILENAME = 'example.rb'.freeze
-
-      def expect_offense(source, filename = DEFAULT_FILENAME)
+      def expect_offense(source, file = nil)
         expected_annotations = AnnotatedSource.parse(source)
 
         if expected_annotations.plain_source == source
           raise 'Use expect_no_offenses to assert that no offenses are found'
         end
 
-        inspect_source(cop, expected_annotations.plain_source, filename)
+        inspect_source(cop, expected_annotations.plain_source, file)
         actual_annotations =
           expected_annotations.with_offense_annotations(cop.offenses)
         expect(actual_annotations.to_s).to eq(expected_annotations.to_s)
       end
 
-      def expect_no_offenses(source, filename = DEFAULT_FILENAME)
-        inspect_source(cop, source, filename)
+      def expect_no_offenses(source, file = nil)
+        inspect_source(cop, source, file)
 
         expect(cop.offenses).to be_empty
       end

--- a/lib/rubocop/rspec/shared_examples.rb
+++ b/lib/rubocop/rspec/shared_examples.rb
@@ -58,7 +58,7 @@ shared_examples_for 'misaligned' do |prefix, alignment_base, arg, end_kw, name|
   it "auto-corrects mismatched #{name} ... end" do
     aligned_source = ["#{prefix}#{alignment_base} #{arg}",
                       "#{' ' * prefix.length}#{end_kw.strip}"].join("\n")
-    corrected = autocorrect_source(cop, source)
+    corrected = autocorrect_source(source)
     expect(corrected).to eq(aligned_source)
   end
 end

--- a/lib/rubocop/rspec/shared_examples.rb
+++ b/lib/rubocop/rspec/shared_examples.rb
@@ -4,7 +4,7 @@
 
 shared_examples_for 'accepts' do
   it 'accepts' do
-    inspect_source(cop, source)
+    inspect_source(source)
     expect(cop.offenses).to be_empty
   end
 end
@@ -12,7 +12,7 @@ end
 shared_examples_for 'mimics MRI 2.1' do |grep_mri_warning|
   if RUBY_ENGINE == 'ruby' && RUBY_VERSION.start_with?('2.1')
     it "mimics MRI #{RUBY_VERSION} built-in syntax checking" do
-      inspect_source(cop, source)
+      inspect_source(source)
       offenses_by_mri = MRISyntaxChecker.offenses_for_source(
         source, cop.name, grep_mri_warning
       )
@@ -38,7 +38,7 @@ shared_examples_for 'misaligned' do |prefix, alignment_base, arg, end_kw, name|
             end_kw]
 
   it "registers an offense for mismatched #{name} ... end" do
-    inspect_source(cop, source)
+    inspect_source(source)
     expect(cop.offenses.size).to eq(1)
     base_regexp = Regexp.escape(alignment_base)
     regexp = /`end` at 2, \d+ is not aligned with `#{base_regexp}` at 1,/
@@ -67,15 +67,15 @@ shared_examples_for 'aligned' do |alignment_base, arg, end_kw, name|
   name ||= alignment_base
   name = name.gsub(/\n/, ' <newline>')
   it "accepts matching #{name} ... end" do
-    inspect_source(cop, ["#{alignment_base} #{arg}",
-                         end_kw])
+    inspect_source(["#{alignment_base} #{arg}",
+                    end_kw])
     expect(cop.offenses).to be_empty
   end
 end
 
 shared_examples_for 'debugger' do |name, src|
   it "reports an offense for a #{name} call" do
-    inspect_source(cop, src)
+    inspect_source(src)
     src = [src] if src.is_a? String
     expect(cop.offenses.size).to eq(src.size)
     expect(cop.messages)
@@ -86,7 +86,7 @@ end
 
 shared_examples_for 'non-debugger' do |name, src|
   it "does not report an offense for #{name}" do
-    inspect_source(cop, src)
+    inspect_source(src)
     expect(cop.offenses).to be_empty
   end
 end

--- a/spec/rubocop/cop/bundler/duplicated_gem_spec.rb
+++ b/spec/rubocop/cop/bundler/duplicated_gem_spec.rb
@@ -19,7 +19,7 @@ describe RuboCop::Cop::Bundler::DuplicatedGem, :config do
       let(:source) { '' }
 
       it 'does not raise an error' do
-        expect { inspect_source(cop, source, 'gems.rb') }.not_to raise_error
+        expect { inspect_source('gems.rb') }.not_to raise_error
       end
 
       it 'does not register any offenses' do
@@ -44,17 +44,17 @@ describe RuboCop::Cop::Bundler::DuplicatedGem, :config do
       GEM
 
       it 'registers an offense' do
-        inspect_gemfile(cop, source)
+        inspect_gemfile(source)
         expect(cop.offenses.size).to eq(1)
       end
 
       it "references gem's first occurance in message" do
-        inspect_gemfile(cop, source)
+        inspect_gemfile(source)
         expect(cop.offenses.first.message).to include('2')
       end
 
       it 'highlights the duplicate gem' do
-        inspect_gemfile(cop, source)
+        inspect_gemfile(source)
         expect(cop.highlights).to eq(["gem 'rubocop'"])
       end
     end
@@ -68,12 +68,12 @@ describe RuboCop::Cop::Bundler::DuplicatedGem, :config do
       GEM
 
       it 'registers an offense' do
-        inspect_gemfile(cop, source)
+        inspect_gemfile(source)
         expect(cop.offenses.size).to eq(1)
       end
 
       it 'highlights the duplicate gem' do
-        inspect_gemfile(cop, source)
+        inspect_gemfile(source)
         expect(cop.highlights).to eq(["gem 'rubocop', path: '/path/to/gem'"])
       end
     end

--- a/spec/rubocop/cop/bundler/ordered_gems_spec.rb
+++ b/spec/rubocop/cop/bundler/ordered_gems_spec.rb
@@ -38,7 +38,7 @@ describe RuboCop::Cop::Bundler::OrderedGems, :config do
     end
 
     it 'autocorrects' do
-      new_source = autocorrect_source_with_loop(cop, source)
+      new_source = autocorrect_source_with_loop(source)
       expect(new_source).to eq(<<-RUBY.strip_indent)
         gem 'rspec'
         gem 'rubocop'
@@ -75,7 +75,7 @@ describe RuboCop::Cop::Bundler::OrderedGems, :config do
     end
 
     it 'autocorrects' do
-      new_source = autocorrect_source_with_loop(cop, source)
+      new_source = autocorrect_source_with_loop(source)
       expect(new_source).to eq(<<-RUBY.strip_indent)
         gem 'rspec'
         gem 'rubocop',
@@ -126,7 +126,7 @@ describe RuboCop::Cop::Bundler::OrderedGems, :config do
     end
 
     it 'autocorrects' do
-      new_source = autocorrect_source_with_loop(cop, source)
+      new_source = autocorrect_source_with_loop(source)
       expect(new_source).to eq(<<-RUBY.strip_indent)
         gem "a"
         gem "b"
@@ -179,7 +179,7 @@ describe RuboCop::Cop::Bundler::OrderedGems, :config do
       end
 
       it 'autocorrects' do
-        new_source = autocorrect_source_with_loop(cop, source)
+        new_source = autocorrect_source_with_loop(source)
         expect(new_source).to eq(<<-RUBY.strip_indent)
           # For
           # test
@@ -208,7 +208,7 @@ describe RuboCop::Cop::Bundler::OrderedGems, :config do
     end
 
     it 'autocorrects' do
-      new_source = autocorrect_source_with_loop(cop, source)
+      new_source = autocorrect_source_with_loop(source)
       expect(new_source).to eq(<<-RUBY.strip_indent)
         gem 'pry'
         gem 'rspec'   # For test
@@ -250,7 +250,7 @@ describe RuboCop::Cop::Bundler::OrderedGems, :config do
     end
 
     it 'autocorrects' do
-      new_source = autocorrect_source_with_loop(cop, source)
+      new_source = autocorrect_source_with_loop(source)
       expect(new_source).to eq(<<-RUBY.strip_indent)
         gem 'a'
         gem 'Z'

--- a/spec/rubocop/cop/layout/access_modifier_indentation_spec.rb
+++ b/spec/rubocop/cop/layout/access_modifier_indentation_spec.rb
@@ -219,7 +219,7 @@ describe RuboCop::Cop::Layout::AccessModifierIndentation do
     end
 
     it 'auto-corrects incorrectly indented access modifiers' do
-      corrected = autocorrect_source(cop, <<-RUBY.strip_indent)
+      corrected = autocorrect_source(<<-RUBY.strip_indent)
         class Test
 
         public
@@ -400,7 +400,7 @@ describe RuboCop::Cop::Layout::AccessModifierIndentation do
     end
 
     it 'auto-corrects incorrectly indented access modifiers' do
-      corrected = autocorrect_source(cop, <<-RUBY.strip_indent)
+      corrected = autocorrect_source(<<-RUBY.strip_indent)
         module M
           class Test
 
@@ -427,7 +427,7 @@ describe RuboCop::Cop::Layout::AccessModifierIndentation do
     end
 
     it 'auto-corrects private in complicated case' do
-      corrected = autocorrect_source(cop, <<-RUBY.strip_indent)
+      corrected = autocorrect_source(<<-RUBY.strip_indent)
         class Hello
           def foo
             'hi'

--- a/spec/rubocop/cop/layout/access_modifier_indentation_spec.rb
+++ b/spec/rubocop/cop/layout/access_modifier_indentation_spec.rb
@@ -14,7 +14,7 @@ describe RuboCop::Cop::Layout::AccessModifierIndentation do
     let(:cop_config) { { 'EnforcedStyle' => 'indent' } }
 
     it 'registers an offense for misaligned private' do
-      inspect_source(cop, <<-RUBY.strip_indent)
+      inspect_source(<<-RUBY.strip_indent)
         class Test
 
         private
@@ -29,7 +29,7 @@ describe RuboCop::Cop::Layout::AccessModifierIndentation do
     end
 
     it 'registers an offense for misaligned private in module' do
-      inspect_source(cop, <<-RUBY.strip_indent)
+      inspect_source(<<-RUBY.strip_indent)
         module Test
 
          private
@@ -44,7 +44,7 @@ describe RuboCop::Cop::Layout::AccessModifierIndentation do
     end
 
     it 'registers an offense for misaligned module_function in module' do
-      inspect_source(cop, <<-RUBY.strip_indent)
+      inspect_source(<<-RUBY.strip_indent)
         module Test
 
          module_function
@@ -60,7 +60,7 @@ describe RuboCop::Cop::Layout::AccessModifierIndentation do
     end
 
     it 'registers an offense for correct + opposite alignment' do
-      inspect_source(cop, <<-RUBY.strip_indent)
+      inspect_source(<<-RUBY.strip_indent)
         module Test
 
           public
@@ -77,7 +77,7 @@ describe RuboCop::Cop::Layout::AccessModifierIndentation do
     end
 
     it 'registers an offense for opposite + correct alignment' do
-      inspect_source(cop, <<-RUBY.strip_indent)
+      inspect_source(<<-RUBY.strip_indent)
         module Test
 
         public
@@ -107,7 +107,7 @@ describe RuboCop::Cop::Layout::AccessModifierIndentation do
 
     it 'registers an offense for misaligned private in class ' \
        'defined with Class.new' do
-      inspect_source(cop, <<-RUBY.strip_indent)
+      inspect_source(<<-RUBY.strip_indent)
         Test = Class.new do
 
         private
@@ -122,7 +122,7 @@ describe RuboCop::Cop::Layout::AccessModifierIndentation do
 
     it 'accepts misaligned private in blocks that are not recognized as ' \
        'class/module definitions' do
-      inspect_source(cop, <<-RUBY.strip_indent)
+      inspect_source(<<-RUBY.strip_indent)
         Test = func do
 
         private
@@ -135,7 +135,7 @@ describe RuboCop::Cop::Layout::AccessModifierIndentation do
 
     it 'registers an offense for misaligned private in module ' \
        'defined with Module.new' do
-      inspect_source(cop, <<-RUBY.strip_indent)
+      inspect_source(<<-RUBY.strip_indent)
         Test = Module.new do
 
         private
@@ -279,7 +279,7 @@ describe RuboCop::Cop::Layout::AccessModifierIndentation do
     let(:indent_msg) { 'Outdent access modifiers like `private`.' }
 
     it 'registers offense for private indented to method depth in a class' do
-      inspect_source(cop, <<-RUBY.strip_indent)
+      inspect_source(<<-RUBY.strip_indent)
         class Test
 
           private
@@ -318,7 +318,7 @@ describe RuboCop::Cop::Layout::AccessModifierIndentation do
 
     it 'registers offense for private indented to method depth in singleton' \
        'class' do
-      inspect_source(cop, <<-RUBY.strip_indent)
+      inspect_source(<<-RUBY.strip_indent)
         class << self
 
           private
@@ -332,7 +332,7 @@ describe RuboCop::Cop::Layout::AccessModifierIndentation do
 
     it 'registers offense for private indented to method depth in class ' \
        'defined with Class.new' do
-      inspect_source(cop, <<-RUBY.strip_indent)
+      inspect_source(<<-RUBY.strip_indent)
         Test = Class.new do
 
           private
@@ -346,7 +346,7 @@ describe RuboCop::Cop::Layout::AccessModifierIndentation do
 
     it 'registers offense for private indented to method depth in module ' \
        'defined with Module.new' do
-      inspect_source(cop, <<-RUBY.strip_indent)
+      inspect_source(<<-RUBY.strip_indent)
         Test = Module.new do
 
           private

--- a/spec/rubocop/cop/layout/align_array_spec.rb
+++ b/spec/rubocop/cop/layout/align_array_spec.rb
@@ -46,7 +46,7 @@ describe RuboCop::Cop::Layout::AlignArray do
   end
 
   it 'auto-corrects alignment' do
-    new_source = autocorrect_source(cop, <<-RUBY.strip_indent)
+    new_source = autocorrect_source(<<-RUBY.strip_indent)
       array = [
         a,
          b,
@@ -72,7 +72,7 @@ describe RuboCop::Cop::Layout::AlignArray do
           [:l3,
            [:l4]]]]
     RUBY
-    new_source = autocorrect_source(cop, original_source)
+    new_source = autocorrect_source(original_source)
     expect(new_source).to eq(<<-RUBY.strip_indent)
       [:l1,
        [:l2,
@@ -90,7 +90,7 @@ describe RuboCop::Cop::Layout::AlignArray do
         [:l3,
          [:l4]]]]
     RUBY
-    new_source = autocorrect_source(cop, original_source)
+    new_source = autocorrect_source(original_source)
     expect(new_source).to eq(<<-RUBY.strip_indent)
       [:l1,
        [:l2,
@@ -105,7 +105,7 @@ describe RuboCop::Cop::Layout::AlignArray do
       array = [:bar, {
                whiz: 2, bang: 3 }, option: 3]
     RUBY
-    new_source = autocorrect_source(cop, original_source)
+    new_source = autocorrect_source(original_source)
     expect(new_source).to eq(original_source)
   end
 
@@ -126,7 +126,7 @@ describe RuboCop::Cop::Layout::AlignArray do
             }
       ]
     RUBY
-    new_source = autocorrect_source(cop, original_source)
+    new_source = autocorrect_source(original_source)
     expect(new_source).to eq(<<-RUBY.strip_indent)
       var = [
              { :type => 'something',

--- a/spec/rubocop/cop/layout/align_hash_spec.rb
+++ b/spec/rubocop/cop/layout/align_hash_spec.rb
@@ -432,7 +432,7 @@ describe RuboCop::Cop::Layout::AlignHash, :config do
           bb: 1
         }
       RUBY
-      expect { inspect_source(cop, src) }.to raise_error(RuntimeError)
+      expect { inspect_source(src) }.to raise_error(RuntimeError)
     end
   end
 

--- a/spec/rubocop/cop/layout/align_hash_spec.rb
+++ b/spec/rubocop/cop/layout/align_hash_spec.rb
@@ -27,7 +27,7 @@ describe RuboCop::Cop::Layout::AlignHash, :config do
             ), h: :i)
         end
       RUBY
-      new_source = autocorrect_source(cop, source)
+      new_source = autocorrect_source(source)
       expect(new_source).to eq(source)
     end
   end
@@ -208,7 +208,7 @@ describe RuboCop::Cop::Layout::AlignHash, :config do
     end
 
     it 'auto-corrects alignment' do
-      new_source = autocorrect_source(cop, <<-RUBY.strip_indent)
+      new_source = autocorrect_source(<<-RUBY.strip_indent)
         hash1 = { a: 0,
              bb: 1,
                    ccc: 2 }
@@ -229,7 +229,7 @@ describe RuboCop::Cop::Layout::AlignHash, :config do
     end
 
     it 'auto-corrects alignment for mixed multiline hash keys' do
-      new_sources = autocorrect_source(cop, <<-RUBY.strip_indent)
+      new_sources = autocorrect_source(<<-RUBY.strip_indent)
         hash = { a: 1, b: 2,
                 c: 3 }
       RUBY
@@ -242,7 +242,7 @@ describe RuboCop::Cop::Layout::AlignHash, :config do
     context 'ruby >= 2.0', :ruby20 do
       it 'auto-corrects alignment when using double splat ' \
          'in an explicit hash' do
-        new_source = autocorrect_source(cop, <<-RUBY.strip_indent)
+        new_source = autocorrect_source(<<-RUBY.strip_indent)
           Hash(foo: 'bar',
                  **extra_params
           )
@@ -256,7 +256,7 @@ describe RuboCop::Cop::Layout::AlignHash, :config do
       end
 
       it 'auto-corrects alignment when using double splat in braces' do
-        new_source = autocorrect_source(cop, <<-RUBY.strip_indent)
+        new_source = autocorrect_source(<<-RUBY.strip_indent)
           {foo: 'bar',
                  **extra_params
           }
@@ -386,7 +386,7 @@ describe RuboCop::Cop::Layout::AlignHash, :config do
     end
 
     it 'auto-corrects alignment' do
-      new_source = autocorrect_source(cop, <<-RUBY.strip_indent)
+      new_source = autocorrect_source(<<-RUBY.strip_indent)
         hash1 = { a: 0,
              bb:   1,
                    ccc: 2 }
@@ -494,7 +494,7 @@ describe RuboCop::Cop::Layout::AlignHash, :config do
     include_examples 'not on separate lines'
 
     it 'auto-corrects alignment' do
-      new_source = autocorrect_source(cop, <<-RUBY.strip_indent)
+      new_source = autocorrect_source(<<-RUBY.strip_indent)
         hash1 = { a: 0,
              bb:    1,
                    ccc: 2 }
@@ -514,11 +514,11 @@ describe RuboCop::Cop::Layout::AlignHash, :config do
 
     it "doesn't break code by moving long keys too far left" do
       # regression test; see GH issue 2582
-      new_source = autocorrect_source(cop, ['{',
-                                            '  sjtjo: sjtjo,',
-                                            '  too_ono_ilitjion_tofotono_o: ' \
-                                            'too_ono_ilitjion_tofotono_o,',
-                                            '}'])
+      new_source = autocorrect_source(['{',
+                                       '  sjtjo: sjtjo,',
+                                       '  too_ono_ilitjion_tofotono_o: ' \
+                                       'too_ono_ilitjion_tofotono_o,',
+                                       '}'])
       expect(new_source).to eq(['{',
                                 '  sjtjo: sjtjo,',
                                 'too_ono_ilitjion_tofotono_o: ' \

--- a/spec/rubocop/cop/layout/align_parameters_spec.rb
+++ b/spec/rubocop/cop/layout/align_parameters_spec.rb
@@ -214,7 +214,7 @@ describe RuboCop::Cop::Layout::AlignParameters do
           ]
         )
       RUBY
-      expect { inspect_source(cop, src) }.not_to raise_error
+      expect { inspect_source(src) }.not_to raise_error
     end
 
     context 'method definitions' do

--- a/spec/rubocop/cop/layout/align_parameters_spec.rb
+++ b/spec/rubocop/cop/layout/align_parameters_spec.rb
@@ -278,7 +278,7 @@ describe RuboCop::Cop::Layout::AlignParameters do
       end
 
       it 'auto-corrects alignment' do
-        new_source = autocorrect_source(cop, <<-RUBY.strip_indent)
+        new_source = autocorrect_source(<<-RUBY.strip_indent)
           def method(a,
               b)
           end
@@ -309,7 +309,7 @@ describe RuboCop::Cop::Layout::AlignParameters do
         end
 
         it 'auto-corrects alignment' do
-          new_source = autocorrect_source(cop, <<-RUBY.strip_indent)
+          new_source = autocorrect_source(<<-RUBY.strip_indent)
             def self.method(a,
                 b)
             end
@@ -345,7 +345,7 @@ describe RuboCop::Cop::Layout::AlignParameters do
     end
 
     it 'auto-corrects alignment' do
-      new_source = autocorrect_source(cop, <<-RUBY.strip_indent)
+      new_source = autocorrect_source(<<-RUBY.strip_indent)
         func(a,
                b,
         c)
@@ -359,7 +359,7 @@ describe RuboCop::Cop::Layout::AlignParameters do
 
     it 'auto-corrects each line of a multi-line parameter to the right' do
       new_source =
-        autocorrect_source(cop, <<-RUBY.strip_indent)
+        autocorrect_source(<<-RUBY.strip_indent)
           create :transaction, :closed,
                 account:          account,
                 open_price:       1.29,
@@ -376,7 +376,7 @@ describe RuboCop::Cop::Layout::AlignParameters do
 
     it 'auto-corrects each line of a multi-line parameter to the left' do
       new_source =
-        autocorrect_source(cop, <<-RUBY.strip_indent)
+        autocorrect_source(<<-RUBY.strip_indent)
           create :transaction, :closed,
                    account:          account,
                    open_price:       1.29,
@@ -396,7 +396,7 @@ describe RuboCop::Cop::Layout::AlignParameters do
         foo(:bar, {
             whiz: 2, bang: 3 }, option: 3)
       RUBY
-      new_source = autocorrect_source(cop, original_source)
+      new_source = autocorrect_source(original_source)
       expect(new_source).to eq(original_source)
     end
 
@@ -409,7 +409,7 @@ describe RuboCop::Cop::Layout::AlignParameters do
 
         end
       RUBY
-      new_source = autocorrect_source(cop, src)
+      new_source = autocorrect_source(src)
       expect(new_source)
         .to eq <<-'RUBY'.strip_indent
           class MyModel < ActiveRecord::Base
@@ -439,7 +439,7 @@ describe RuboCop::Cop::Layout::AlignParameters do
     end
 
     it 'does not autocorrect correct source' do
-      expect(autocorrect_source(cop, correct_source))
+      expect(autocorrect_source(correct_source))
         .to eq(correct_source)
     end
 
@@ -451,7 +451,7 @@ describe RuboCop::Cop::Layout::AlignParameters do
                close_price: 1.30
       RUBY
 
-      expect(autocorrect_source(cop, original_source))
+      expect(autocorrect_source(original_source))
         .to eq(correct_source)
     end
 
@@ -463,7 +463,7 @@ describe RuboCop::Cop::Layout::AlignParameters do
         close_price: 1.30
       RUBY
 
-      expect(autocorrect_source(cop, original_source))
+      expect(autocorrect_source(original_source))
         .to eq(correct_source)
     end
 
@@ -482,7 +482,7 @@ describe RuboCop::Cop::Layout::AlignParameters do
         |    close_price: 1.30
       RUBY
 
-      expect(autocorrect_source(cop, original_source))
+      expect(autocorrect_source(original_source))
         .to eq(correct_source)
     end
 
@@ -540,7 +540,7 @@ describe RuboCop::Cop::Layout::AlignParameters do
           |     c
           |   )
         RUBY
-        expect(autocorrect_source(cop, original_source))
+        expect(autocorrect_source(original_source))
           .to eq(correct_source)
       end
     end
@@ -607,7 +607,7 @@ describe RuboCop::Cop::Layout::AlignParameters do
       end
 
       it 'auto-corrects alignment' do
-        new_source = autocorrect_source(cop, <<-RUBY.strip_indent)
+        new_source = autocorrect_source(<<-RUBY.strip_indent)
           def method(a,
               b)
           end
@@ -638,7 +638,7 @@ describe RuboCop::Cop::Layout::AlignParameters do
         end
 
         it 'auto-corrects alignment' do
-          new_source = autocorrect_source(cop, <<-RUBY.strip_indent)
+          new_source = autocorrect_source(<<-RUBY.strip_indent)
             def self.method(a,
                 b)
             end
@@ -692,7 +692,7 @@ describe RuboCop::Cop::Layout::AlignParameters do
             | )
           RUBY
 
-          expect(autocorrect_source(cop, original_source))
+          expect(autocorrect_source(original_source))
             .to eq(correct_source)
         end
       end

--- a/spec/rubocop/cop/layout/block_end_newline_spec.rb
+++ b/spec/rubocop/cop/layout/block_end_newline_spec.rb
@@ -9,7 +9,7 @@ describe RuboCop::Cop::Layout::BlockEndNewline do
 
   it 'does not register an offense for multiline blocks with newlines before '\
      'the end' do
-    inspect_source(cop, <<-RUBY.strip_indent)
+    inspect_source(<<-RUBY.strip_indent)
       test do
         foo
       end

--- a/spec/rubocop/cop/layout/block_end_newline_spec.rb
+++ b/spec/rubocop/cop/layout/block_end_newline_spec.rb
@@ -39,7 +39,7 @@ describe RuboCop::Cop::Layout::BlockEndNewline do
         foo end
     RUBY
 
-    new_source = autocorrect_source(cop, src)
+    new_source = autocorrect_source(src)
 
     expect(new_source).to eq(['test do',
                               '  foo ',
@@ -53,7 +53,7 @@ describe RuboCop::Cop::Layout::BlockEndNewline do
         foo }
     RUBY
 
-    new_source = autocorrect_source(cop, src)
+    new_source = autocorrect_source(src)
 
     expect(new_source).to eq(['test {',
                               '  foo ',

--- a/spec/rubocop/cop/layout/case_indentation_spec.rb
+++ b/spec/rubocop/cop/layout/case_indentation_spec.rb
@@ -64,7 +64,7 @@ describe RuboCop::Cop::Layout::CaseIndentation do
           end
 
           it 'does auto-correction' do
-            corrected = autocorrect_source(cop, source)
+            corrected = autocorrect_source(source)
             expect(corrected).to eq correct_source
           end
         end
@@ -99,7 +99,7 @@ describe RuboCop::Cop::Layout::CaseIndentation do
           end
 
           it 'does auto-correction' do
-            corrected = autocorrect_source(cop, source)
+            corrected = autocorrect_source(source)
             expect(corrected).to eq correct_source
           end
         end
@@ -146,7 +146,7 @@ describe RuboCop::Cop::Layout::CaseIndentation do
           end
 
           it 'does auto-correction' do
-            corrected = autocorrect_source(cop, source)
+            corrected = autocorrect_source(source)
             expect(corrected).to eq(correct_source)
           end
         end
@@ -180,7 +180,7 @@ describe RuboCop::Cop::Layout::CaseIndentation do
         end
 
         it 'does auto-correction' do
-          corrected = autocorrect_source(cop, source)
+          corrected = autocorrect_source(source)
           expect(corrected).to eq(<<-RUBY.strip_indent)
             case a
             when 0 then return
@@ -313,7 +313,7 @@ describe RuboCop::Cop::Layout::CaseIndentation do
           end
 
           it 'does auto-correction' do
-            corrected = autocorrect_source(cop, source)
+            corrected = autocorrect_source(source)
             expect(corrected).to eq correct_source
           end
         end
@@ -370,7 +370,7 @@ describe RuboCop::Cop::Layout::CaseIndentation do
         end
 
         it 'does auto-correction' do
-          corrected = autocorrect_source(cop, source)
+          corrected = autocorrect_source(source)
           expect(corrected).to eq(<<-RUBY.strip_indent)
             y = case a
                   when 0 then break
@@ -470,7 +470,7 @@ describe RuboCop::Cop::Layout::CaseIndentation do
           end
 
           it 'does auto-correction' do
-            corrected = autocorrect_source(cop, source)
+            corrected = autocorrect_source(source)
             expect(corrected).to eq correct_source
           end
         end
@@ -532,7 +532,7 @@ describe RuboCop::Cop::Layout::CaseIndentation do
           end
 
           it 'does auto-correction' do
-            corrected = autocorrect_source(cop, source)
+            corrected = autocorrect_source(source)
             expect(corrected).to eq correct_source
           end
         end
@@ -568,7 +568,7 @@ describe RuboCop::Cop::Layout::CaseIndentation do
           end
 
           it 'does auto-correction' do
-            corrected = autocorrect_source(cop, source)
+            corrected = autocorrect_source(source)
             expect(corrected).to eq correct_source
           end
         end
@@ -594,7 +594,7 @@ describe RuboCop::Cop::Layout::CaseIndentation do
     end
 
     it "doesn't auto-correct" do
-      expect(autocorrect_source(cop, source))
+      expect(autocorrect_source(source))
         .to eq(source)
       expect(cop.offenses.map(&:corrected?)).to eq [false]
     end

--- a/spec/rubocop/cop/layout/case_indentation_spec.rb
+++ b/spec/rubocop/cop/layout/case_indentation_spec.rb
@@ -57,7 +57,7 @@ describe RuboCop::Cop::Layout::CaseIndentation do
           end
 
           it 'registers an offense' do
-            inspect_source(cop, source)
+            inspect_source(source)
             expect(cop.messages).to eq(['Indent `when` as deep as `case`.'])
             expect(cop.config_to_allow_offenses).to eq('EnforcedStyle' =>
                                                        'end')
@@ -93,7 +93,7 @@ describe RuboCop::Cop::Layout::CaseIndentation do
           end
 
           it 'registers an offense' do
-            inspect_source(cop, source)
+            inspect_source(source)
             expect(cop.messages).to eq(['Indent `when` as deep as `case`.'])
             expect(cop.config_to_allow_offenses).to eq('Enabled' => false)
           end
@@ -140,7 +140,7 @@ describe RuboCop::Cop::Layout::CaseIndentation do
           end
 
           it 'registers an offense' do
-            inspect_source(cop, source)
+            inspect_source(source)
             expect(cop.messages).to eq(['Indent `when` as deep as `case`.'])
             expect(cop.config_to_allow_offenses).to eq('Enabled' => false)
           end
@@ -524,7 +524,7 @@ describe RuboCop::Cop::Layout::CaseIndentation do
           end
 
           it 'registers an offense' do
-            inspect_source(cop, source)
+            inspect_source(source)
             expect(cop.messages)
               .to eq(['Indent `when` one step more than `end`.'])
             expect(cop.config_to_allow_offenses).to eq('EnforcedStyle' =>
@@ -561,7 +561,7 @@ describe RuboCop::Cop::Layout::CaseIndentation do
           end
 
           it 'registers an offense' do
-            inspect_source(cop, source)
+            inspect_source(source)
             expect(cop.messages)
               .to eq(['Indent `when` one step more than `end`.'])
             expect(cop.config_to_allow_offenses).to eq('Enabled' => false)

--- a/spec/rubocop/cop/layout/closing_parenthesis_indentation_spec.rb
+++ b/spec/rubocop/cop/layout/closing_parenthesis_indentation_spec.rb
@@ -21,7 +21,7 @@ describe RuboCop::Cop::Layout::ClosingParenthesisIndentation do
       end
 
       it 'autocorrects misaligned )' do
-        corrected = autocorrect_source(cop, <<-RUBY.strip_indent)
+        corrected = autocorrect_source(<<-RUBY.strip_indent)
           some_method(
             a
             )
@@ -52,7 +52,7 @@ describe RuboCop::Cop::Layout::ClosingParenthesisIndentation do
       end
 
       it 'autocorrects misaligned )' do
-        corrected = autocorrect_source(cop, <<-RUBY.strip_indent)
+        corrected = autocorrect_source(<<-RUBY.strip_indent)
           some_method(a
           )
         RUBY
@@ -89,7 +89,7 @@ describe RuboCop::Cop::Layout::ClosingParenthesisIndentation do
         end
 
         it 'autocorrects misindented )' do
-          corrected = autocorrect_source(cop, <<-RUBY.strip_indent)
+          corrected = autocorrect_source(<<-RUBY.strip_indent)
             some_method(a,
               x: 1,
               y: 2
@@ -125,7 +125,7 @@ describe RuboCop::Cop::Layout::ClosingParenthesisIndentation do
       end
 
       it 'autocorrects misaligned )' do
-        corrected = autocorrect_source(cop, <<-RUBY.strip_indent)
+        corrected = autocorrect_source(<<-RUBY.strip_indent)
           def some_method(
             a
             )
@@ -160,7 +160,7 @@ describe RuboCop::Cop::Layout::ClosingParenthesisIndentation do
       end
 
       it 'autocorrects misaligned )' do
-        corrected = autocorrect_source(cop, <<-RUBY.strip_indent)
+        corrected = autocorrect_source(<<-RUBY.strip_indent)
           def some_method(a
           )
           end
@@ -201,7 +201,7 @@ describe RuboCop::Cop::Layout::ClosingParenthesisIndentation do
       end
 
       it 'autocorrects misaligned )' do
-        corrected = autocorrect_source(cop, <<-RUBY.strip_indent)
+        corrected = autocorrect_source(<<-RUBY.strip_indent)
           w = x * (
             y + z
             )
@@ -232,7 +232,7 @@ describe RuboCop::Cop::Layout::ClosingParenthesisIndentation do
       end
 
       it 'autocorrects misaligned )' do
-        corrected = autocorrect_source(cop, <<-RUBY.strip_indent)
+        corrected = autocorrect_source(<<-RUBY.strip_indent)
           w = x * (y + z
             )
         RUBY

--- a/spec/rubocop/cop/layout/comment_indentation_spec.rb
+++ b/spec/rubocop/cop/layout/comment_indentation_spec.rb
@@ -140,7 +140,7 @@ describe RuboCop::Cop::Layout::CommentIndentation do
   end
 
   it 'auto-corrects' do
-    new_source = autocorrect_source(cop, <<-RUBY.strip_indent)
+    new_source = autocorrect_source(<<-RUBY.strip_indent)
        # comment
       hash1 = { a: 0,
            # comment

--- a/spec/rubocop/cop/layout/dot_position_spec.rb
+++ b/spec/rubocop/cop/layout/dot_position_spec.rb
@@ -51,7 +51,7 @@ describe RuboCop::Cop::Layout::DotPosition, :config do
     end
 
     it 'auto-corrects trailing dot in multi-line call' do
-      new_source = autocorrect_source(cop, <<-RUBY.strip_indent)
+      new_source = autocorrect_source(<<-RUBY.strip_indent)
         something.
           method_name
       RUBY
@@ -62,7 +62,7 @@ describe RuboCop::Cop::Layout::DotPosition, :config do
     end
 
     it 'auto-corrects trailing dot in multi-line call without selector' do
-      new_source = autocorrect_source(cop, <<-RUBY.strip_indent)
+      new_source = autocorrect_source(<<-RUBY.strip_indent)
         something.
           (1)
       RUBY
@@ -73,7 +73,7 @@ describe RuboCop::Cop::Layout::DotPosition, :config do
     end
 
     it 'auto-corrects correct + opposite style' do
-      new_source = autocorrect_source(cop, <<-RUBY.strip_indent)
+      new_source = autocorrect_source(<<-RUBY.strip_indent)
         something
           .method_name
         something.
@@ -155,7 +155,7 @@ describe RuboCop::Cop::Layout::DotPosition, :config do
     end
 
     it 'auto-corrects leading dot in multi-line call' do
-      new_source = autocorrect_source(cop, <<-RUBY.strip_indent)
+      new_source = autocorrect_source(<<-RUBY.strip_indent)
         something
           .method_name
       RUBY
@@ -166,7 +166,7 @@ describe RuboCop::Cop::Layout::DotPosition, :config do
     end
 
     it 'auto-corrects leading dot in multi-line call without selector' do
-      new_source = autocorrect_source(cop, <<-RUBY.strip_indent)
+      new_source = autocorrect_source(<<-RUBY.strip_indent)
         something
           .(1)
       RUBY

--- a/spec/rubocop/cop/layout/dot_position_spec.rb
+++ b/spec/rubocop/cop/layout/dot_position_spec.rb
@@ -7,7 +7,7 @@ describe RuboCop::Cop::Layout::DotPosition, :config do
     let(:cop_config) { { 'EnforcedStyle' => 'leading' } }
 
     it 'registers an offense for trailing dot in multi-line call' do
-      inspect_source(cop, <<-RUBY.strip_indent)
+      inspect_source(<<-RUBY.strip_indent)
         something.
           method_name
       RUBY
@@ -17,7 +17,7 @@ describe RuboCop::Cop::Layout::DotPosition, :config do
     end
 
     it 'registers an offense for correct + opposite' do
-      inspect_source(cop, <<-RUBY.strip_indent)
+      inspect_source(<<-RUBY.strip_indent)
         something
           .method_name
         something.
@@ -112,7 +112,7 @@ describe RuboCop::Cop::Layout::DotPosition, :config do
     let(:cop_config) { { 'EnforcedStyle' => 'trailing' } }
 
     it 'registers an offense for leading dot in multi-line call' do
-      inspect_source(cop, <<-RUBY.strip_indent)
+      inspect_source(<<-RUBY.strip_indent)
         something
           .method_name
       RUBY

--- a/spec/rubocop/cop/layout/else_alignment_spec.rb
+++ b/spec/rubocop/cop/layout/else_alignment_spec.rb
@@ -38,7 +38,7 @@ describe RuboCop::Cop::Layout::ElseAlignment do
 
     it 'accepts indentation after else when if is on new line after ' \
        'assignment' do
-      inspect_source(cop, <<-RUBY.strip_indent)
+      inspect_source(<<-RUBY.strip_indent)
         Rails.application.config.ideal_postcodes_key =
           if Rails.env.production? || Rails.env.staging?
             "AAAA-AAAA-AAAA-AAAA"

--- a/spec/rubocop/cop/layout/else_alignment_spec.rb
+++ b/spec/rubocop/cop/layout/else_alignment_spec.rb
@@ -51,7 +51,7 @@ describe RuboCop::Cop::Layout::ElseAlignment do
 
     describe '#autocorrect' do
       it 'corrects bad alignment' do
-        corrected = autocorrect_source(cop, <<-RUBY.strip_indent)
+        corrected = autocorrect_source(<<-RUBY.strip_indent)
             if a1
               b1
               elsif a2
@@ -224,7 +224,7 @@ describe RuboCop::Cop::Layout::ElseAlignment do
           end
 
           it 'autocorrects bad alignment' do
-            corrected = autocorrect_source(cop, <<-RUBY.strip_indent)
+            corrected = autocorrect_source(<<-RUBY.strip_indent)
               var = if a
                 b1
               else

--- a/spec/rubocop/cop/layout/empty_line_after_magic_comment_spec.rb
+++ b/spec/rubocop/cop/layout/empty_line_after_magic_comment_spec.rb
@@ -47,7 +47,7 @@ describe RuboCop::Cop::Layout::EmptyLineAfterMagicComment do
   end
 
   it 'autocorrects by adding a newline' do
-    new_source = autocorrect_source(cop, <<-RUBY.strip_indent)
+    new_source = autocorrect_source(<<-RUBY.strip_indent)
       # frozen_string_literal: true
       class Foo; end
     RUBY
@@ -59,7 +59,7 @@ describe RuboCop::Cop::Layout::EmptyLineAfterMagicComment do
   end
 
   it 'autocorrects by adding a newline above the documentation' do
-    new_source = autocorrect_source(cop, <<-RUBY.strip_indent)
+    new_source = autocorrect_source(<<-RUBY.strip_indent)
       # frozen_string_literal: true
       # Documentation for Foo
       class Foo; end

--- a/spec/rubocop/cop/layout/empty_line_between_defs_spec.rb
+++ b/spec/rubocop/cop/layout/empty_line_between_defs_spec.rb
@@ -54,7 +54,7 @@ describe RuboCop::Cop::Layout::EmptyLineBetweenDefs, :config do
     end
 
     it 'auto-corrects' do
-      corrected = autocorrect_source(cop, source)
+      corrected = autocorrect_source(source)
       expect(corrected).to eq(<<-RUBY.strip_indent)
         class J
           def n
@@ -134,7 +134,7 @@ describe RuboCop::Cop::Layout::EmptyLineBetweenDefs, :config do
       end
 
       it 'autocorrects it' do
-        corrected = autocorrect_source(cop, offending_source)
+        corrected = autocorrect_source(offending_source)
         expect(corrected).to eq(<<-RUBY.strip_indent)
           class Test
             def self.foo
@@ -178,7 +178,7 @@ describe RuboCop::Cop::Layout::EmptyLineBetweenDefs, :config do
       end
 
       it 'autocorrects it' do
-        corrected = autocorrect_source(cop, offending_source)
+        corrected = autocorrect_source(offending_source)
         expect(corrected).to eq(<<-RUBY.strip_indent)
           class Test
             def foo
@@ -271,7 +271,7 @@ describe RuboCop::Cop::Layout::EmptyLineBetweenDefs, :config do
   end
 
   it 'auto-corrects adjacent one-liners by default' do
-    corrected = autocorrect_source(cop, <<-RUBY.strip_indent)
+    corrected = autocorrect_source(<<-RUBY.strip_indent)
       def a; end
       def b; end
     RUBY
@@ -283,7 +283,7 @@ describe RuboCop::Cop::Layout::EmptyLineBetweenDefs, :config do
   end
 
   it 'auto-corrects when there are too many new lines' do
-    corrected = autocorrect_source(cop, <<-RUBY.strip_indent)
+    corrected = autocorrect_source(<<-RUBY.strip_indent)
       def a; end
 
 
@@ -391,7 +391,7 @@ describe RuboCop::Cop::Layout::EmptyLineBetweenDefs, :config do
         def o
         end
       RUBY
-      corrected = autocorrect_source(cop, source)
+      corrected = autocorrect_source(source)
       expect(corrected).to eq(<<-RUBY.strip_indent)
         def n
         end
@@ -424,7 +424,7 @@ describe RuboCop::Cop::Layout::EmptyLineBetweenDefs, :config do
         def o
         end
       RUBY
-      corrected = autocorrect_source(cop, source)
+      corrected = autocorrect_source(source)
       expect(corrected).to eq(<<-RUBY.strip_indent)
         def n
         end
@@ -443,7 +443,7 @@ describe RuboCop::Cop::Layout::EmptyLineBetweenDefs, :config do
         def o
         end
       RUBY
-      corrected = autocorrect_source(cop, source)
+      corrected = autocorrect_source(source)
       expect(corrected).to eq(<<-RUBY.strip_indent)
         def n
         end
@@ -465,7 +465,7 @@ describe RuboCop::Cop::Layout::EmptyLineBetweenDefs, :config do
         def o
         end
       RUBY
-      corrected = autocorrect_source(cop, source)
+      corrected = autocorrect_source(source)
       expect(corrected).to eq(<<-RUBY.strip_indent)
         def n
         end

--- a/spec/rubocop/cop/layout/empty_line_between_defs_spec.rb
+++ b/spec/rubocop/cop/layout/empty_line_between_defs_spec.rb
@@ -20,7 +20,7 @@ describe RuboCop::Cop::Layout::EmptyLineBetweenDefs, :config do
         end
       end
     RUBY
-    inspect_source(cop, source)
+    inspect_source(source)
     expect(cop.offenses.size).to eq(1)
     expect(cop.offenses.map(&:line).sort).to eq([7])
   end
@@ -99,7 +99,7 @@ describe RuboCop::Cop::Layout::EmptyLineBetweenDefs, :config do
           end
         end
       RUBY
-      inspect_source(cop, source)
+      inspect_source(source)
       expect(cop.offenses.size).to eq(1)
     end
   end
@@ -266,7 +266,7 @@ describe RuboCop::Cop::Layout::EmptyLineBetweenDefs, :config do
       def a; end
       def b; end
     RUBY
-    inspect_source(cop, source)
+    inspect_source(source)
     expect(cop.offenses.size).to eq(1)
   end
 
@@ -320,7 +320,7 @@ describe RuboCop::Cop::Layout::EmptyLineBetweenDefs, :config do
         end
       end
     RUBY
-    inspect_source(cop, source)
+    inspect_source(source)
     expect(cop.offenses.size).to eq(1)
   end
 
@@ -342,7 +342,7 @@ describe RuboCop::Cop::Layout::EmptyLineBetweenDefs, :config do
         end
         def d; end # Also an offense since previous was multi-line:
       RUBY
-      inspect_source(cop, source)
+      inspect_source(source)
       expect(cop.offenses.map(&:line)).to eq([3, 5])
     end
   end
@@ -378,7 +378,7 @@ describe RuboCop::Cop::Layout::EmptyLineBetweenDefs, :config do
         def o
         end
       RUBY
-      inspect_source(cop, source)
+      inspect_source(source)
       expect(cop.offenses.size).to eq(1)
     end
 
@@ -413,7 +413,7 @@ describe RuboCop::Cop::Layout::EmptyLineBetweenDefs, :config do
         def o
         end
       RUBY
-      inspect_source(cop, source)
+      inspect_source(source)
       expect(cop.offenses.size).to eq(1)
     end
 

--- a/spec/rubocop/cop/layout/empty_lines_around_access_modifier_spec.rb
+++ b/spec/rubocop/cop/layout/empty_lines_around_access_modifier_spec.rb
@@ -82,7 +82,7 @@ describe RuboCop::Cop::Layout::EmptyLinesAroundAccessModifier do
     end
 
     it "autocorrects blank line before #{access_modifier}" do
-      corrected = autocorrect_source(cop, <<-RUBY.strip_indent)
+      corrected = autocorrect_source(<<-RUBY.strip_indent)
         class Test
           something
           #{access_modifier}
@@ -102,7 +102,7 @@ describe RuboCop::Cop::Layout::EmptyLinesAroundAccessModifier do
     end
 
     it 'autocorrects blank line after #{access_modifier}' do
-      corrected = autocorrect_source(cop, <<-RUBY.strip_indent)
+      corrected = autocorrect_source(<<-RUBY.strip_indent)
         class Test
           something
 
@@ -122,7 +122,7 @@ describe RuboCop::Cop::Layout::EmptyLinesAroundAccessModifier do
     end
 
     it 'autocorrects blank line after #{access_modifier} with comment' do
-      corrected = autocorrect_source(cop, <<-RUBY.strip_indent)
+      corrected = autocorrect_source(<<-RUBY.strip_indent)
         class Test
           something
 

--- a/spec/rubocop/cop/layout/empty_lines_around_access_modifier_spec.rb
+++ b/spec/rubocop/cop/layout/empty_lines_around_access_modifier_spec.rb
@@ -5,7 +5,7 @@ describe RuboCop::Cop::Layout::EmptyLinesAroundAccessModifier do
 
   %w[private protected public module_function].each do |access_modifier|
     it "requires blank line before #{access_modifier}" do
-      inspect_source(cop, <<-RUBY.strip_indent)
+      inspect_source(<<-RUBY.strip_indent)
         class Test
           something
           #{access_modifier}
@@ -19,7 +19,7 @@ describe RuboCop::Cop::Layout::EmptyLinesAroundAccessModifier do
     end
 
     it "requires blank line after #{access_modifier}" do
-      inspect_source(cop, <<-RUBY.strip_indent)
+      inspect_source(<<-RUBY.strip_indent)
         class Test
           something
 
@@ -33,7 +33,7 @@ describe RuboCop::Cop::Layout::EmptyLinesAroundAccessModifier do
     end
 
     it "ignores comment line before #{access_modifier}" do
-      inspect_source(cop, <<-RUBY.strip_indent)
+      inspect_source(<<-RUBY.strip_indent)
         class Test
           something
 
@@ -47,7 +47,7 @@ describe RuboCop::Cop::Layout::EmptyLinesAroundAccessModifier do
     end
 
     it "ignores #{access_modifier} inside a method call" do
-      inspect_source(cop, <<-RUBY.strip_indent)
+      inspect_source(<<-RUBY.strip_indent)
         class Test
           def #{access_modifier}?
             #{access_modifier}
@@ -58,7 +58,7 @@ describe RuboCop::Cop::Layout::EmptyLinesAroundAccessModifier do
     end
 
     it "ignores #{access_modifier} deep inside a method call" do
-      inspect_source(cop, <<-RUBY.strip_indent)
+      inspect_source(<<-RUBY.strip_indent)
         class Test
           def #{access_modifier}?
             if true
@@ -71,7 +71,7 @@ describe RuboCop::Cop::Layout::EmptyLinesAroundAccessModifier do
     end
 
     it "ignores #{access_modifier} with a right-hand-side condition" do
-      inspect_source(cop, <<-RUBY.strip_indent)
+      inspect_source(<<-RUBY.strip_indent)
         class Test
           def #{access_modifier}?
             #{access_modifier} if true
@@ -153,7 +153,7 @@ describe RuboCop::Cop::Layout::EmptyLinesAroundAccessModifier do
 
     it "requires blank line after, but not before, #{access_modifier} " \
        'when at the beginning of class/module' do
-      inspect_source(cop, <<-RUBY.strip_indent)
+      inspect_source(<<-RUBY.strip_indent)
         class Test
           #{access_modifier}
           def test
@@ -188,7 +188,7 @@ describe RuboCop::Cop::Layout::EmptyLinesAroundAccessModifier do
         end
 
         it "requires blank line after, but not before, #{access_modifier}" do
-          inspect_source(cop, <<-RUBY.strip_indent)
+          inspect_source(<<-RUBY.strip_indent)
             included do
               #{access_modifier}
               def test

--- a/spec/rubocop/cop/layout/empty_lines_around_begin_body_spec.rb
+++ b/spec/rubocop/cop/layout/empty_lines_around_begin_body_spec.rb
@@ -12,7 +12,7 @@ describe RuboCop::Cop::Layout::EmptyLinesAroundBeginBody do
     end
 
     it "autocorrects for #{name} with a blank" do
-      corrected = autocorrect_source(cop, code.strip_indent)
+      corrected = autocorrect_source(code.strip_indent)
       expect(corrected).to eq(correction.strip_indent)
     end
   end
@@ -181,7 +181,7 @@ describe RuboCop::Cop::Layout::EmptyLinesAroundBeginBody do
     end
 
     it 'autocorrects' do
-      corrected = autocorrect_source(cop, source)
+      corrected = autocorrect_source(source)
       expect(corrected).to eq correction
     end
   end

--- a/spec/rubocop/cop/layout/empty_lines_around_begin_body_spec.rb
+++ b/spec/rubocop/cop/layout/empty_lines_around_begin_body_spec.rb
@@ -6,7 +6,7 @@ describe RuboCop::Cop::Layout::EmptyLinesAroundBeginBody do
 
   shared_examples :offense do |name, message, code, correction|
     it "registers an offense for #{name} with a blank" do
-      inspect_source(cop, code.strip_indent)
+      inspect_source(code.strip_indent)
       message = "Extra empty line detected at `begin` body #{message}."
       expect(cop.messages).to eq([message])
     end
@@ -19,7 +19,7 @@ describe RuboCop::Cop::Layout::EmptyLinesAroundBeginBody do
 
   shared_examples :accepts do |name, code|
     it "accepts #{name}" do
-      inspect_source(cop, code)
+      inspect_source(code)
       expect(cop.offenses).to be_empty
     end
   end
@@ -176,7 +176,7 @@ describe RuboCop::Cop::Layout::EmptyLinesAroundBeginBody do
     RUBY
 
     it 'registers many offenses' do
-      inspect_source(cop, source)
+      inspect_source(source)
       expect(cop.offenses.size).to eq(2)
     end
 

--- a/spec/rubocop/cop/layout/empty_lines_around_block_body_spec.rb
+++ b/spec/rubocop/cop/layout/empty_lines_around_block_body_spec.rb
@@ -9,8 +9,7 @@ describe RuboCop::Cop::Layout::EmptyLinesAroundBlockBody, :config do
       let(:cop_config) { { 'EnforcedStyle' => 'no_empty_lines' } }
 
       it 'registers an offense for block body starting with a blank' do
-        inspect_source(cop,
-                       ["some_method #{open}",
+        inspect_source(["some_method #{open}",
                         '',
                         '  do_something',
                         close])
@@ -28,8 +27,7 @@ describe RuboCop::Cop::Layout::EmptyLinesAroundBlockBody, :config do
       end
 
       it 'registers an offense for block body ending with a blank' do
-        inspect_source(cop,
-                       ["some_method #{open}",
+        inspect_source(["some_method #{open}",
                         '  do_something',
                         '',
                         close])
@@ -38,8 +36,7 @@ describe RuboCop::Cop::Layout::EmptyLinesAroundBlockBody, :config do
       end
 
       it 'accepts block body starting with a line with spaces' do
-        inspect_source(cop,
-                       ["some_method #{open}",
+        inspect_source(["some_method #{open}",
                         '  ',
                         '  do_something',
                         close])
@@ -60,8 +57,7 @@ describe RuboCop::Cop::Layout::EmptyLinesAroundBlockBody, :config do
 
       it 'registers an offense for block body not starting or ending with a ' \
          'blank' do
-        inspect_source(cop,
-                       ["some_method #{open}",
+        inspect_source(["some_method #{open}",
                         '  do_something',
                         close])
         expect(cop.messages).to eq(['Empty line missing at block body '\

--- a/spec/rubocop/cop/layout/empty_lines_around_block_body_spec.rb
+++ b/spec/rubocop/cop/layout/empty_lines_around_block_body_spec.rb
@@ -18,8 +18,7 @@ describe RuboCop::Cop::Layout::EmptyLinesAroundBlockBody, :config do
       end
 
       it 'autocorrects block body containing only a blank' do
-        corrected = autocorrect_source(cop,
-                                       ["some_method #{open}",
+        corrected = autocorrect_source(["some_method #{open}",
                                         '',
                                         close])
         expect(corrected).to eq ["some_method #{open}",
@@ -67,13 +66,12 @@ describe RuboCop::Cop::Layout::EmptyLinesAroundBlockBody, :config do
 
       it 'ignores block with an empty body' do
         source = "some_method #{open}\n#{close}"
-        corrected = autocorrect_source(cop, source)
+        corrected = autocorrect_source(source)
         expect(corrected).to eq(source)
       end
 
       it 'autocorrects beginning and end' do
-        new_source = autocorrect_source(cop,
-                                        ["some_method #{open}",
+        new_source = autocorrect_source(["some_method #{open}",
                                          '  do_something',
                                          close])
         expect(new_source).to eq(["some_method #{open}",

--- a/spec/rubocop/cop/layout/empty_lines_around_class_body_spec.rb
+++ b/spec/rubocop/cop/layout/empty_lines_around_class_body_spec.rb
@@ -13,7 +13,7 @@ describe RuboCop::Cop::Layout::EmptyLinesAroundClassBody, :config do
     let(:cop_config) { { 'EnforcedStyle' => 'no_empty_lines' } }
 
     it 'registers an offense for class body starting with a blank' do
-      inspect_source(cop, <<-RUBY.strip_indent)
+      inspect_source(<<-RUBY.strip_indent)
         class SomeClass
 
           do_something
@@ -36,7 +36,7 @@ describe RuboCop::Cop::Layout::EmptyLinesAroundClassBody, :config do
     end
 
     it 'registers an offense for class body ending with a blank' do
-      inspect_source(cop, <<-RUBY.strip_indent)
+      inspect_source(<<-RUBY.strip_indent)
         class SomeClass
           do_something
 
@@ -47,7 +47,7 @@ describe RuboCop::Cop::Layout::EmptyLinesAroundClassBody, :config do
     end
 
     it 'registers an offense for singleton class body starting with a blank' do
-      inspect_source(cop, <<-RUBY.strip_indent)
+      inspect_source(<<-RUBY.strip_indent)
         class << self
 
           do_something
@@ -70,7 +70,7 @@ describe RuboCop::Cop::Layout::EmptyLinesAroundClassBody, :config do
     end
 
     it 'registers an offense for singleton class body ending with a blank' do
-      inspect_source(cop, <<-RUBY.strip_indent)
+      inspect_source(<<-RUBY.strip_indent)
         class << self
           do_something
 
@@ -86,7 +86,7 @@ describe RuboCop::Cop::Layout::EmptyLinesAroundClassBody, :config do
 
     it 'registers an offense for class body not starting or ending with a ' \
        'blank' do
-      inspect_source(cop, <<-RUBY.strip_indent)
+      inspect_source(<<-RUBY.strip_indent)
         class SomeClass
           do_something
         end
@@ -118,7 +118,7 @@ describe RuboCop::Cop::Layout::EmptyLinesAroundClassBody, :config do
 
     it 'registers an offense for singleton class body not starting or ending ' \
        'with a blank' do
-      inspect_source(cop, <<-RUBY.strip_indent)
+      inspect_source(<<-RUBY.strip_indent)
         class << self
           do_something
         end
@@ -166,7 +166,7 @@ describe RuboCop::Cop::Layout::EmptyLinesAroundClassBody, :config do
       end
 
       it 'registers offence for namespace body starting with a blank' do
-        inspect_source(cop, <<-RUBY.strip_indent)
+        inspect_source(<<-RUBY.strip_indent)
           class Parent
 
             class Child
@@ -180,7 +180,7 @@ describe RuboCop::Cop::Layout::EmptyLinesAroundClassBody, :config do
       end
 
       it 'registers offence for namespace body ending with a blank' do
-        inspect_source(cop, <<-RUBY.strip_indent)
+        inspect_source(<<-RUBY.strip_indent)
           class Parent
             class Child
 
@@ -195,7 +195,7 @@ describe RuboCop::Cop::Layout::EmptyLinesAroundClassBody, :config do
 
       it 'registers offences for namespaced class body not starting '\
           'with a blank' do
-        inspect_source(cop, <<-RUBY.strip_indent)
+        inspect_source(<<-RUBY.strip_indent)
           class Parent
             class Child
               do_something
@@ -208,7 +208,7 @@ describe RuboCop::Cop::Layout::EmptyLinesAroundClassBody, :config do
 
       it 'registers offences for namespaced class body not ending '\
           'with a blank' do
-        inspect_source(cop, <<-RUBY.strip_indent)
+        inspect_source(<<-RUBY.strip_indent)
           class Parent
             class Child
 
@@ -253,7 +253,7 @@ describe RuboCop::Cop::Layout::EmptyLinesAroundClassBody, :config do
       end
 
       it 'registers offence for namespace body starting with a blank' do
-        inspect_source(cop, <<-RUBY.strip_indent)
+        inspect_source(<<-RUBY.strip_indent)
           class Parent
 
             module Child
@@ -265,7 +265,7 @@ describe RuboCop::Cop::Layout::EmptyLinesAroundClassBody, :config do
       end
 
       it 'registers offence for namespace body ending with a blank' do
-        inspect_source(cop, <<-RUBY.strip_indent)
+        inspect_source(<<-RUBY.strip_indent)
           class Parent
             module Child
               do_something
@@ -297,7 +297,7 @@ describe RuboCop::Cop::Layout::EmptyLinesAroundClassBody, :config do
 
       it 'registers offences for namespace body starting '\
         'and ending without a blank' do
-        inspect_source(cop, <<-RUBY.strip_indent)
+        inspect_source(<<-RUBY.strip_indent)
           class Parent
             class Mom
 

--- a/spec/rubocop/cop/layout/empty_lines_around_class_body_spec.rb
+++ b/spec/rubocop/cop/layout/empty_lines_around_class_body_spec.rb
@@ -24,7 +24,7 @@ describe RuboCop::Cop::Layout::EmptyLinesAroundClassBody, :config do
     end
 
     it 'autocorrects class body containing only a blank' do
-      corrected = autocorrect_source(cop, <<-RUBY.strip_indent)
+      corrected = autocorrect_source(<<-RUBY.strip_indent)
         class SomeClass
 
         end
@@ -58,7 +58,7 @@ describe RuboCop::Cop::Layout::EmptyLinesAroundClassBody, :config do
     end
 
     it 'autocorrects singleton class body containing only a blank' do
-      corrected = autocorrect_source(cop, <<-RUBY.strip_indent)
+      corrected = autocorrect_source(<<-RUBY.strip_indent)
         class << self
 
         end
@@ -97,12 +97,12 @@ describe RuboCop::Cop::Layout::EmptyLinesAroundClassBody, :config do
 
     it 'ignores classes with an empty body' do
       source = "class SomeClass\nend"
-      corrected = autocorrect_source(cop, source)
+      corrected = autocorrect_source(source)
       expect(corrected).to eq(source)
     end
 
     it 'autocorrects beginning and end' do
-      new_source = autocorrect_source(cop, <<-RUBY.strip_indent)
+      new_source = autocorrect_source(<<-RUBY.strip_indent)
         class SomeClass
           do_something
         end
@@ -129,12 +129,12 @@ describe RuboCop::Cop::Layout::EmptyLinesAroundClassBody, :config do
 
     it 'ignores singleton classes with an empty body' do
       source = "class << self\nend"
-      corrected = autocorrect_source(cop, source)
+      corrected = autocorrect_source(source)
       expect(corrected).to eq(source)
     end
 
     it 'autocorrects beginning and end for `class << self`' do
-      new_source = autocorrect_source(cop, <<-RUBY.strip_indent)
+      new_source = autocorrect_source(<<-RUBY.strip_indent)
         class << self
           do_something
         end
@@ -220,7 +220,7 @@ describe RuboCop::Cop::Layout::EmptyLinesAroundClassBody, :config do
       end
 
       it 'autocorrects beginning and end' do
-        new_source = autocorrect_source(cop, <<-RUBY.strip_indent)
+        new_source = autocorrect_source(<<-RUBY.strip_indent)
           class Parent < Base
 
             class Child

--- a/spec/rubocop/cop/layout/empty_lines_around_exception_handling_keywords_spec.rb
+++ b/spec/rubocop/cop/layout/empty_lines_around_exception_handling_keywords_spec.rb
@@ -6,7 +6,7 @@ describe RuboCop::Cop::Layout::EmptyLinesAroundExceptionHandlingKeywords do
 
   shared_examples :offense do |name, message, code, correction|
     it "registers an offense for #{name} with a blank" do
-      inspect_source(cop, code.strip_indent)
+      inspect_source(code.strip_indent)
       expect(cop.offenses.size).to eq(1)
       expect(cop.messages).to eq(["Extra empty line detected #{message}."])
     end
@@ -19,7 +19,7 @@ describe RuboCop::Cop::Layout::EmptyLinesAroundExceptionHandlingKeywords do
 
   shared_examples :accepts do |name, code|
     it "accepts #{name}" do
-      inspect_source(cop, code)
+      inspect_source(code)
       expect(cop.offenses).to be_empty
     end
   end
@@ -182,7 +182,7 @@ describe RuboCop::Cop::Layout::EmptyLinesAroundExceptionHandlingKeywords do
     RUBY
 
     it 'registers many offenses' do
-      inspect_source(cop, source)
+      inspect_source(source)
       expect(cop.offenses.size).to eq(10)
     end
 
@@ -240,7 +240,7 @@ describe RuboCop::Cop::Layout::EmptyLinesAroundExceptionHandlingKeywords do
     RUBY
 
     it 'registers many offenses' do
-      inspect_source(cop, source)
+      inspect_source(source)
       expect(cop.offenses.size).to eq(10)
     end
 

--- a/spec/rubocop/cop/layout/empty_lines_around_exception_handling_keywords_spec.rb
+++ b/spec/rubocop/cop/layout/empty_lines_around_exception_handling_keywords_spec.rb
@@ -12,7 +12,7 @@ describe RuboCop::Cop::Layout::EmptyLinesAroundExceptionHandlingKeywords do
     end
 
     it "autocorrects for #{name} with a blank" do
-      corrected = autocorrect_source(cop, code.strip_indent)
+      corrected = autocorrect_source(code.strip_indent)
       expect(corrected).to eq(correction.strip_indent)
     end
   end
@@ -187,7 +187,7 @@ describe RuboCop::Cop::Layout::EmptyLinesAroundExceptionHandlingKeywords do
     end
 
     it 'autocorrects' do
-      corrected = autocorrect_source(cop, source)
+      corrected = autocorrect_source(source)
       expect(corrected).to eq correction
     end
   end
@@ -245,7 +245,7 @@ describe RuboCop::Cop::Layout::EmptyLinesAroundExceptionHandlingKeywords do
     end
 
     it 'autocorrects' do
-      corrected = autocorrect_source(cop, source)
+      corrected = autocorrect_source(source)
       expect(corrected).to eq correction
     end
   end

--- a/spec/rubocop/cop/layout/empty_lines_around_method_body_spec.rb
+++ b/spec/rubocop/cop/layout/empty_lines_around_method_body_spec.rb
@@ -28,7 +28,7 @@ describe RuboCop::Cop::Layout::EmptyLinesAroundMethodBody do
   end
 
   it 'autocorrects method body starting with a blank' do
-    corrected = autocorrect_source(cop, <<-RUBY.strip_indent)
+    corrected = autocorrect_source(<<-RUBY.strip_indent)
       def some_method
 
         do_something
@@ -53,7 +53,7 @@ describe RuboCop::Cop::Layout::EmptyLinesAroundMethodBody do
   end
 
   it 'autocorrects class method body starting with a blank' do
-    corrected = autocorrect_source(cop, <<-RUBY.strip_indent)
+    corrected = autocorrect_source(<<-RUBY.strip_indent)
       def Test.some_method
 
         do_something

--- a/spec/rubocop/cop/layout/empty_lines_around_method_body_spec.rb
+++ b/spec/rubocop/cop/layout/empty_lines_around_method_body_spec.rb
@@ -4,7 +4,7 @@ describe RuboCop::Cop::Layout::EmptyLinesAroundMethodBody do
   subject(:cop) { described_class.new }
 
   it 'registers an offense for method body starting with a blank' do
-    inspect_source(cop, <<-RUBY.strip_indent)
+    inspect_source(<<-RUBY.strip_indent)
       def some_method
 
         do_something
@@ -42,7 +42,7 @@ describe RuboCop::Cop::Layout::EmptyLinesAroundMethodBody do
   end
 
   it 'registers an offense for class method body starting with a blank' do
-    inspect_source(cop, <<-RUBY.strip_indent)
+    inspect_source(<<-RUBY.strip_indent)
       def Test.some_method
 
         do_something
@@ -67,7 +67,7 @@ describe RuboCop::Cop::Layout::EmptyLinesAroundMethodBody do
   end
 
   it 'registers an offense for method body ending with a blank' do
-    inspect_source(cop, <<-RUBY.strip_indent)
+    inspect_source(<<-RUBY.strip_indent)
       def some_method
         do_something
 
@@ -78,7 +78,7 @@ describe RuboCop::Cop::Layout::EmptyLinesAroundMethodBody do
   end
 
   it 'registers an offense for class method body ending with a blank' do
-    inspect_source(cop, <<-RUBY.strip_indent)
+    inspect_source(<<-RUBY.strip_indent)
       def Test.some_method
         do_something
 

--- a/spec/rubocop/cop/layout/empty_lines_around_module_body_spec.rb
+++ b/spec/rubocop/cop/layout/empty_lines_around_module_body_spec.rb
@@ -13,7 +13,7 @@ describe RuboCop::Cop::Layout::EmptyLinesAroundModuleBody, :config do
     let(:cop_config) { { 'EnforcedStyle' => 'no_empty_lines' } }
 
     it 'registers an offense for module body starting with a blank' do
-      inspect_source(cop, <<-RUBY.strip_indent)
+      inspect_source(<<-RUBY.strip_indent)
         module SomeModule
 
           do_something
@@ -24,7 +24,7 @@ describe RuboCop::Cop::Layout::EmptyLinesAroundModuleBody, :config do
     end
 
     it 'registers an offense for module body ending with a blank' do
-      inspect_source(cop, <<-RUBY.strip_indent)
+      inspect_source(<<-RUBY.strip_indent)
         module SomeModule
           do_something
 
@@ -55,7 +55,7 @@ describe RuboCop::Cop::Layout::EmptyLinesAroundModuleBody, :config do
 
     it 'registers an offense for module body not starting or ending with a ' \
        'blank' do
-      inspect_source(cop, <<-RUBY.strip_indent)
+      inspect_source(<<-RUBY.strip_indent)
         module SomeModule
           do_something
         end
@@ -114,7 +114,7 @@ describe RuboCop::Cop::Layout::EmptyLinesAroundModuleBody, :config do
       end
 
       it 'registers offence for namespace body starting with a blank' do
-        inspect_source(cop, <<-RUBY.strip_indent)
+        inspect_source(<<-RUBY.strip_indent)
           module Parent
 
             module Child
@@ -128,7 +128,7 @@ describe RuboCop::Cop::Layout::EmptyLinesAroundModuleBody, :config do
       end
 
       it 'registers offence for namespace body ending with a blank' do
-        inspect_source(cop, <<-RUBY.strip_indent)
+        inspect_source(<<-RUBY.strip_indent)
           module Parent
             module Child
 
@@ -143,7 +143,7 @@ describe RuboCop::Cop::Layout::EmptyLinesAroundModuleBody, :config do
 
       it 'registers offences for namespaced module body not starting '\
           'with a blank' do
-        inspect_source(cop, <<-RUBY.strip_indent)
+        inspect_source(<<-RUBY.strip_indent)
           module Parent
             module Child
               do_something
@@ -156,7 +156,7 @@ describe RuboCop::Cop::Layout::EmptyLinesAroundModuleBody, :config do
 
       it 'registers offences for namespaced module body not ending '\
           'with a blank' do
-        inspect_source(cop, <<-RUBY.strip_indent)
+        inspect_source(<<-RUBY.strip_indent)
           module Parent
             module Child
 
@@ -201,7 +201,7 @@ describe RuboCop::Cop::Layout::EmptyLinesAroundModuleBody, :config do
       end
 
       it 'registers offence for namespace body starting with a blank' do
-        inspect_source(cop, <<-RUBY.strip_indent)
+        inspect_source(<<-RUBY.strip_indent)
           module Parent
 
             class SomeClass
@@ -213,7 +213,7 @@ describe RuboCop::Cop::Layout::EmptyLinesAroundModuleBody, :config do
       end
 
       it 'registers offence for namespace body ending with a blank' do
-        inspect_source(cop, <<-RUBY.strip_indent)
+        inspect_source(<<-RUBY.strip_indent)
           module Parent
             class SomeClass
               do_something
@@ -245,7 +245,7 @@ describe RuboCop::Cop::Layout::EmptyLinesAroundModuleBody, :config do
 
       it 'registers offences for namespace body starting '\
         'and ending without a blank' do
-        inspect_source(cop, <<-RUBY.strip_indent)
+        inspect_source(<<-RUBY.strip_indent)
           module Parent
             module Mom
 

--- a/spec/rubocop/cop/layout/empty_lines_around_module_body_spec.rb
+++ b/spec/rubocop/cop/layout/empty_lines_around_module_body_spec.rb
@@ -35,7 +35,7 @@ describe RuboCop::Cop::Layout::EmptyLinesAroundModuleBody, :config do
     end
 
     it 'autocorrects beginning and end' do
-      new_source = autocorrect_source(cop, <<-RUBY.strip_indent)
+      new_source = autocorrect_source(<<-RUBY.strip_indent)
         module SomeModule
 
           do_something
@@ -76,7 +76,7 @@ describe RuboCop::Cop::Layout::EmptyLinesAroundModuleBody, :config do
     end
 
     it 'autocorrects beginning and end' do
-      new_source = autocorrect_source(cop, <<-RUBY.strip_indent)
+      new_source = autocorrect_source(<<-RUBY.strip_indent)
         module SomeModule
           do_something
         end
@@ -92,7 +92,7 @@ describe RuboCop::Cop::Layout::EmptyLinesAroundModuleBody, :config do
 
     it 'ignores modules with an empty body' do
       source = "module A\nend"
-      corrected = autocorrect_source(cop, source)
+      corrected = autocorrect_source(source)
       expect(corrected).to eq(source)
     end
   end
@@ -168,7 +168,7 @@ describe RuboCop::Cop::Layout::EmptyLinesAroundModuleBody, :config do
       end
 
       it 'autocorrects beginning and end' do
-        new_source = autocorrect_source(cop, <<-RUBY.strip_indent)
+        new_source = autocorrect_source(<<-RUBY.strip_indent)
           module Parent
 
             module Child

--- a/spec/rubocop/cop/layout/empty_lines_spec.rb
+++ b/spec/rubocop/cop/layout/empty_lines_spec.rb
@@ -9,8 +9,7 @@ describe RuboCop::Cop::Layout::EmptyLines do
   end
 
   it 'auto-corrects consecutive empty lines' do
-    corrected = autocorrect_source(cop,
-                                   ['test = 5', '', '', '', 'top'])
+    corrected = autocorrect_source(['test = 5', '', '', '', 'top'])
     expect(corrected).to eq ['test = 5', '', 'top'].join("\n")
   end
 

--- a/spec/rubocop/cop/layout/empty_lines_spec.rb
+++ b/spec/rubocop/cop/layout/empty_lines_spec.rb
@@ -4,8 +4,7 @@ describe RuboCop::Cop::Layout::EmptyLines do
   subject(:cop) { described_class.new }
 
   it 'registers an offense for consecutive empty lines' do
-    inspect_source(cop,
-                   ['test = 5', '', '', '', 'top'])
+    inspect_source(['test = 5', '', '', '', 'top'])
     expect(cop.offenses.size).to eq(2)
   end
 

--- a/spec/rubocop/cop/layout/end_of_line_spec.rb
+++ b/spec/rubocop/cop/layout/end_of_line_spec.rb
@@ -5,15 +5,15 @@ describe RuboCop::Cop::Layout::EndOfLine, :config do
 
   shared_examples 'all configurations' do
     it 'accepts an empty file' do
-      inspect_source_file(cop, '')
+      inspect_source_file('')
       expect(cop.offenses).to be_empty
     end
   end
 
   shared_examples 'iso-8859-15' do |eol|
     it 'can inspect non-UTF-8 encoded source with proper encoding comment' do
-      inspect_source_file(cop, ["# coding: ISO-8859-15#{eol}",
-                                "# Euro symbol: \xa4#{eol}"])
+      inspect_source_file(["# coding: ISO-8859-15#{eol}",
+                           "# Euro symbol: \xa4#{eol}"])
       expect(cop.offenses.size).to eq(1)
     end
   end
@@ -26,7 +26,7 @@ describe RuboCop::Cop::Layout::EndOfLine, :config do
     end
 
     it 'registers an offense for an incorrect EOL' do
-      inspect_source_file(cop, ['x=0', '', "y=1\r"])
+      inspect_source_file(['x=0', '', "y=1\r"])
       expect(cop.messages).to eq(messages)
       expect(cop.offenses.map(&:line))
         .to eq([RuboCop::Platform.windows? ? 1 : 3])
@@ -39,31 +39,31 @@ describe RuboCop::Cop::Layout::EndOfLine, :config do
     include_examples 'all configurations'
 
     it 'registers an offense for CR+LF' do
-      inspect_source_file(cop, ['x=0', '', "y=1\r"])
+      inspect_source_file(['x=0', '', "y=1\r"])
       expect(cop.messages).to eq(messages)
       expect(cop.offenses.map(&:line)).to eq([1])
     end
 
     it 'highlights the whole offending line' do
-      inspect_source_file(cop, ['x=0', '', "y=1\r"])
+      inspect_source_file(['x=0', '', "y=1\r"])
       expect(cop.highlights).to eq(["x=0\n"])
     end
 
     it 'does not register offense for no CR at end of file' do
-      inspect_source_file(cop, 'x=0')
+      inspect_source_file('x=0')
       expect(cop.offenses).to be_empty
     end
 
     it 'does not register offenses after __END__' do
-      inspect_source(cop, ["x=0\r",
-                           '__END__',
-                           'x=0'])
+      inspect_source(["x=0\r",
+                      '__END__',
+                      'x=0'])
       expect(cop.offenses).to be_empty
     end
 
     context 'and there are many lines ending with LF' do
       it 'registers only one offense' do
-        inspect_source_file(cop, ['x=0', '', 'y=1'].join("\n"))
+        inspect_source_file(['x=0', '', 'y=1'].join("\n"))
         expect(cop.messages.size).to eq(1)
       end
 
@@ -83,7 +83,7 @@ describe RuboCop::Cop::Layout::EndOfLine, :config do
                   'class Epd::ReportsController < EpdAreaController',
                   "  'terecht bij uw ROM-coördinator.'",
                   'end'].join("\r\n")
-        inspect_source_file(cop, source)
+        inspect_source_file(source)
         expect(cop.offenses).to be_empty
       end
 
@@ -92,7 +92,7 @@ describe RuboCop::Cop::Layout::EndOfLine, :config do
 
     context 'and source is a string' do
       it 'registers an offense' do
-        inspect_source(cop, "x=0\ny=1")
+        inspect_source("x=0\ny=1")
 
         expect(cop.messages).to eq(['Carriage return character missing.'])
       end
@@ -104,31 +104,31 @@ describe RuboCop::Cop::Layout::EndOfLine, :config do
     include_examples 'all configurations'
 
     it 'registers an offense for CR+LF' do
-      inspect_source_file(cop, ['x=0', '', "y=1\r"])
+      inspect_source_file(['x=0', '', "y=1\r"])
       expect(cop.messages).to eq(['Carriage return character detected.'])
       expect(cop.offenses.map(&:line)).to eq([3])
     end
 
     it 'highlights the whole offending line' do
-      inspect_source_file(cop, ['x=0', '', "y=1\r"])
+      inspect_source_file(['x=0', '', "y=1\r"])
       expect(cop.highlights).to eq(["y=1\r"])
     end
 
     it 'registers an offense for CR at end of file' do
-      inspect_source_file(cop, "x=0\r")
+      inspect_source_file("x=0\r")
       expect(cop.messages).to eq(['Carriage return character detected.'])
     end
 
     it 'does not register offenses after __END__' do
-      inspect_source(cop, ['x=0',
-                           '__END__',
-                           "x=0\r"])
+      inspect_source(['x=0',
+                      '__END__',
+                      "x=0\r"])
       expect(cop.offenses).to be_empty
     end
 
     context 'and there are many lines ending with CR+LF' do
       it 'registers only one offense' do
-        inspect_source_file(cop, ['x=0', '', 'y=1'].join("\r\n"))
+        inspect_source_file(['x=0', '', 'y=1'].join("\r\n"))
         expect(cop.messages.size).to eq(1)
       end
 
@@ -148,7 +148,7 @@ describe RuboCop::Cop::Layout::EndOfLine, :config do
                   'class Epd::ReportsController < EpdAreaController',
                   "  'terecht bij uw ROM-coördinator.'",
                   'end'].join("\n")
-        inspect_source_file(cop, source)
+        inspect_source_file(source)
         expect(cop.offenses).to be_empty
       end
 

--- a/spec/rubocop/cop/layout/extra_spacing_spec.rb
+++ b/spec/rubocop/cop/layout/extra_spacing_spec.rb
@@ -125,7 +125,7 @@ describe RuboCop::Cop::Layout::ExtraSpacing, :config do
     end
 
     it 'auto-corrects a line indented with mixed whitespace' do
-      new_source = autocorrect_source(cop, <<-RUBY.strip_indent)
+      new_source = autocorrect_source(<<-RUBY.strip_indent)
         website("example.org")
         name    = "Jill"
       RUBY
@@ -136,7 +136,7 @@ describe RuboCop::Cop::Layout::ExtraSpacing, :config do
     end
 
     it 'auto-corrects the class inheritance' do
-      new_source = autocorrect_source(cop, <<-RUBY.strip_indent)
+      new_source = autocorrect_source(<<-RUBY.strip_indent)
         class A   < String
         end
       RUBY
@@ -305,7 +305,7 @@ describe RuboCop::Cop::Layout::ExtraSpacing, :config do
     end
 
     it 'autocorrects consecutive assignments which are not aligned' do
-      new_source = autocorrect_source(cop, <<-RUBY.strip_indent)
+      new_source = autocorrect_source(<<-RUBY.strip_indent)
         a = 1
         bb = 2
         ccc = 3
@@ -326,7 +326,7 @@ describe RuboCop::Cop::Layout::ExtraSpacing, :config do
     end
 
     it 'autocorrects consecutive operator assignments which are not aligned' do
-      new_source = autocorrect_source(cop, <<-RUBY.strip_indent)
+      new_source = autocorrect_source(<<-RUBY.strip_indent)
         a += 1
         bb = 2
         ccc <<= 3
@@ -347,7 +347,7 @@ describe RuboCop::Cop::Layout::ExtraSpacing, :config do
     end
 
     it 'autocorrects consecutive aref assignments which are not aligned' do
-      new_source = autocorrect_source(cop, <<-RUBY.strip_indent)
+      new_source = autocorrect_source(<<-RUBY.strip_indent)
         a[1] = 1
         bb[2,3] = 2
         ccc[:key] = 3
@@ -368,7 +368,7 @@ describe RuboCop::Cop::Layout::ExtraSpacing, :config do
     end
 
     it 'autocorrects consecutive attribute assignments which are not aligned' do
-      new_source = autocorrect_source(cop, <<-RUBY.strip_indent)
+      new_source = autocorrect_source(<<-RUBY.strip_indent)
         a.attr = 1
         bb &&= 2
         ccc.s = 3

--- a/spec/rubocop/cop/layout/extra_spacing_spec.rb
+++ b/spec/rubocop/cop/layout/extra_spacing_spec.rb
@@ -7,7 +7,7 @@ describe RuboCop::Cop::Layout::ExtraSpacing, :config do
     it 'registers an offense for alignment with token not preceded by space' do
       # The = and the ( are on the same column, but this is not for alignment,
       # it's just a mistake.
-      inspect_source(cop, <<-RUBY.strip_indent)
+      inspect_source(<<-RUBY.strip_indent)
         website("example.org")
         name   = "Jill"
       RUBY
@@ -22,7 +22,7 @@ describe RuboCop::Cop::Layout::ExtraSpacing, :config do
                  state:      'CA',
                  postal_code:'99999-1111')
       RUBY
-      inspect_source(cop, source)
+      inspect_source(source)
       expect(cop.offenses).to be_empty
     end
 
@@ -47,13 +47,13 @@ describe RuboCop::Cop::Layout::ExtraSpacing, :config do
           }
         }
       RUBY
-      inspect_source(cop, source)
+      inspect_source(source)
       expect(cop.offenses).to be_empty
     end
 
     context 'when spaces are present in a single-line hash literal' do
       it 'registers an offense for hashes with symbol keys' do
-        inspect_source(cop, 'hash = {a:   1,  b:    2}')
+        inspect_source('hash = {a:   1,  b:    2}')
         expect(cop.offenses.size).to eq(3)
       end
 
@@ -64,7 +64,7 @@ describe RuboCop::Cop::Layout::ExtraSpacing, :config do
           }
         RUBY
 
-        inspect_source(cop, source)
+        inspect_source(source)
         expect(cop.offenses.size).to eq(1)
         expect(cop.offenses.first.line).to eq(2)
       end
@@ -75,7 +75,7 @@ describe RuboCop::Cop::Layout::ExtraSpacing, :config do
         {:a => "a",
          :b => [nil,  2.5]}
       RUBY
-      inspect_source(cop, source)
+      inspect_source(source)
       expect(cop.offenses.size).to eq(1)
     end
 
@@ -85,12 +85,12 @@ describe RuboCop::Cop::Layout::ExtraSpacing, :config do
                           3,  +3, # Extra spacing only here.
                           4,+4)
       RUBY
-      inspect_source(cop, source)
+      inspect_source(source)
       expect(cop.offenses.map { |o| o.location.line }).to eq([2])
     end
 
     it 'gives the correct line' do
-      inspect_source(cop, <<-RUBY.strip_indent)
+      inspect_source(<<-RUBY.strip_indent)
         class A   < String
         end
       RUBY
@@ -98,7 +98,7 @@ describe RuboCop::Cop::Layout::ExtraSpacing, :config do
     end
 
     it 'registers an offense for double extra spacing on variable assignment' do
-      inspect_source(cop, 'm    = "hello"')
+      inspect_source('m    = "hello"')
       expect(cop.offenses.size).to eq(1)
     end
 
@@ -111,13 +111,13 @@ describe RuboCop::Cop::Layout::ExtraSpacing, :config do
     end
 
     it 'ignores trailing whitespace' do
-      inspect_source(cop, ['      class Benchmarker < Performer     ',
-                           '      end'])
+      inspect_source(['      class Benchmarker < Performer     ',
+                      '      end'])
       expect(cop.offenses).to be_empty
     end
 
     it 'registers an offense on class inheritance' do
-      inspect_source(cop, <<-RUBY.strip_indent)
+      inspect_source(<<-RUBY.strip_indent)
         class A   < String
         end
       RUBY
@@ -232,7 +232,7 @@ describe RuboCop::Cop::Layout::ExtraSpacing, :config do
       sources.each do |reason, src|
         context "such as #{reason}" do
           it 'allows it' do
-            inspect_source(cop, src)
+            inspect_source(src)
             expect(cop.offenses).to be_empty
           end
         end
@@ -251,7 +251,7 @@ describe RuboCop::Cop::Layout::ExtraSpacing, :config do
       sources.each do |reason, src|
         context "such as #{reason}" do
           it 'registers offense(s)' do
-            inspect_source(cop, src)
+            inspect_source(src)
             expect(cop.offenses).not_to be_empty
           end
         end
@@ -265,7 +265,7 @@ describe RuboCop::Cop::Layout::ExtraSpacing, :config do
     end
 
     it 'registers an offense if consecutive assignments are not aligned' do
-      inspect_source(cop, <<-RUBY.strip_indent)
+      inspect_source(<<-RUBY.strip_indent)
         a = 1
         bb = 2
         ccc = 3
@@ -390,7 +390,7 @@ describe RuboCop::Cop::Layout::ExtraSpacing, :config do
 
     it 'does not register an offense when optarg equals is not aligned with ' \
        'assignment equals sign' do
-      inspect_source(cop, <<-RUBY.strip_indent)
+      inspect_source(<<-RUBY.strip_indent)
         def method(arg = 1)
           var = arg
         end

--- a/spec/rubocop/cop/layout/first_array_element_line_break_spec.rb
+++ b/spec/rubocop/cop/layout/first_array_element_line_break_spec.rb
@@ -11,7 +11,7 @@ describe RuboCop::Cop::Layout::FirstArrayElementLineBreak do
       RUBY
     end
     it 'detects the offense' do
-      inspect_source(cop, source)
+      inspect_source(source)
 
       expect(cop.offenses.length).to eq(1)
       expect(cop.offenses.first.line).to eq(1)
@@ -39,7 +39,7 @@ describe RuboCop::Cop::Layout::FirstArrayElementLineBreak do
     end
 
     it 'detects the offense' do
-      inspect_source(cop, source)
+      inspect_source(source)
 
       expect(cop.offenses.length).to eq(1)
       expect(cop.offenses.first.line).to eq(1)
@@ -65,7 +65,7 @@ describe RuboCop::Cop::Layout::FirstArrayElementLineBreak do
     end
 
     it 'detects the offense' do
-      inspect_source(cop, source)
+      inspect_source(source)
 
       expect(cop.offenses.length).to eq(1)
       expect(cop.offenses.first.line).to eq(1)
@@ -101,7 +101,7 @@ describe RuboCop::Cop::Layout::FirstArrayElementLineBreak do
     end
 
     it 'detects the offense' do
-      inspect_source(cop, source)
+      inspect_source(source)
 
       expect(cop.offenses.length).to eq(1)
       expect(cop.offenses.first.line).to eq(2)
@@ -133,7 +133,7 @@ describe RuboCop::Cop::Layout::FirstArrayElementLineBreak do
     end
 
     it 'detects the offense' do
-      inspect_source(cop, source)
+      inspect_source(source)
 
       expect(cop.offenses.length).to eq(1)
       expect(cop.offenses.first.line).to eq(2)

--- a/spec/rubocop/cop/layout/first_array_element_line_break_spec.rb
+++ b/spec/rubocop/cop/layout/first_array_element_line_break_spec.rb
@@ -19,7 +19,7 @@ describe RuboCop::Cop::Layout::FirstArrayElementLineBreak do
     end
 
     it 'autocorrects the offense' do
-      new_source = autocorrect_source(cop, source)
+      new_source = autocorrect_source(source)
       # Alignment for the first element is set by IndentationWidth cop,
       # the rest of the elements should be aligned using the AlignArray cop.
       expect(new_source).to eq(<<-RUBY.strip_indent)
@@ -47,7 +47,7 @@ describe RuboCop::Cop::Layout::FirstArrayElementLineBreak do
     end
 
     it 'autocorrects the offense' do
-      new_source = autocorrect_source(cop, source)
+      new_source = autocorrect_source(source)
       expect(new_source).to eq(<<-RUBY.strip_indent)
         %w(
         a b
@@ -73,7 +73,7 @@ describe RuboCop::Cop::Layout::FirstArrayElementLineBreak do
     end
 
     it 'autocorrects the offense' do
-      new_source = autocorrect_source(cop, source)
+      new_source = autocorrect_source(source)
 
       expect(new_source).to eq(<<-RUBY.strip_indent)
         method([
@@ -109,7 +109,7 @@ describe RuboCop::Cop::Layout::FirstArrayElementLineBreak do
     end
 
     it 'autocorrects the offense' do
-      new_source = autocorrect_source(cop, source)
+      new_source = autocorrect_source(source)
 
       expect(new_source).to eq(correct_source)
     end
@@ -141,7 +141,7 @@ describe RuboCop::Cop::Layout::FirstArrayElementLineBreak do
     end
 
     it 'autocorrects the offense' do
-      new_source = autocorrect_source(cop, source)
+      new_source = autocorrect_source(source)
 
       expect(new_source).to eq(correct_source)
     end

--- a/spec/rubocop/cop/layout/first_hash_element_line_break_spec.rb
+++ b/spec/rubocop/cop/layout/first_hash_element_line_break_spec.rb
@@ -12,7 +12,7 @@ describe RuboCop::Cop::Layout::FirstHashElementLineBreak do
     end
 
     it 'detects the offense' do
-      inspect_source(cop, source)
+      inspect_source(source)
 
       expect(cop.offenses.length).to eq(1)
       expect(cop.offenses.first.line).to eq(1)
@@ -40,7 +40,7 @@ describe RuboCop::Cop::Layout::FirstHashElementLineBreak do
     end
 
     it 'detects the offense' do
-      inspect_source(cop, source)
+      inspect_source(source)
 
       expect(cop.offenses.length).to eq(1)
       expect(cop.offenses.first.line).to eq(1)

--- a/spec/rubocop/cop/layout/first_hash_element_line_break_spec.rb
+++ b/spec/rubocop/cop/layout/first_hash_element_line_break_spec.rb
@@ -20,7 +20,7 @@ describe RuboCop::Cop::Layout::FirstHashElementLineBreak do
     end
 
     it 'autocorrects the offense' do
-      new_source = autocorrect_source(cop, source)
+      new_source = autocorrect_source(source)
 
       expect(new_source).to eq([
         'a = { ',
@@ -48,7 +48,7 @@ describe RuboCop::Cop::Layout::FirstHashElementLineBreak do
     end
 
     it 'autocorrects the offense' do
-      new_source = autocorrect_source(cop, source)
+      new_source = autocorrect_source(source)
 
       expect(new_source).to eq([
         'method({ ',

--- a/spec/rubocop/cop/layout/first_method_argument_line_break_spec.rb
+++ b/spec/rubocop/cop/layout/first_method_argument_line_break_spec.rb
@@ -20,7 +20,7 @@ describe RuboCop::Cop::Layout::FirstMethodArgumentLineBreak do
     end
 
     it 'autocorrects the offense' do
-      new_source = autocorrect_source(cop, source)
+      new_source = autocorrect_source(source)
 
       expect(new_source).to eq([
         'foo(',
@@ -48,7 +48,7 @@ describe RuboCop::Cop::Layout::FirstMethodArgumentLineBreak do
     end
 
     it 'autocorrects the offense' do
-      new_source = autocorrect_source(cop, source)
+      new_source = autocorrect_source(source)
 
       expect(new_source).to eq([
         'something(',
@@ -76,7 +76,7 @@ describe RuboCop::Cop::Layout::FirstMethodArgumentLineBreak do
     end
 
     it 'autocorrects the offense' do
-      new_source = autocorrect_source(cop, source)
+      new_source = autocorrect_source(source)
 
       expect(new_source).to eq([
         'something(',

--- a/spec/rubocop/cop/layout/first_method_argument_line_break_spec.rb
+++ b/spec/rubocop/cop/layout/first_method_argument_line_break_spec.rb
@@ -12,7 +12,7 @@ describe RuboCop::Cop::Layout::FirstMethodArgumentLineBreak do
     end
 
     it 'detects the offense' do
-      inspect_source(cop, source)
+      inspect_source(source)
 
       expect(cop.offenses.length).to eq(1)
       expect(cop.offenses.first.line).to eq(1)
@@ -40,7 +40,7 @@ describe RuboCop::Cop::Layout::FirstMethodArgumentLineBreak do
     end
 
     it 'detects the offense' do
-      inspect_source(cop, source)
+      inspect_source(source)
 
       expect(cop.offenses.length).to eq(1)
       expect(cop.offenses.first.line).to eq(1)
@@ -68,7 +68,7 @@ describe RuboCop::Cop::Layout::FirstMethodArgumentLineBreak do
     end
 
     it 'detects the offense' do
-      inspect_source(cop, source)
+      inspect_source(source)
 
       expect(cop.offenses.length).to eq(1)
       expect(cop.offenses.first.line).to eq(1)

--- a/spec/rubocop/cop/layout/first_method_parameter_line_break_spec.rb
+++ b/spec/rubocop/cop/layout/first_method_parameter_line_break_spec.rb
@@ -22,7 +22,7 @@ describe RuboCop::Cop::Layout::FirstMethodParameterLineBreak do
     end
 
     it 'autocorrects the offense' do
-      new_source = autocorrect_source(cop, source)
+      new_source = autocorrect_source(source)
 
       expect(new_source).to eq([
         'def foo(',
@@ -54,7 +54,7 @@ describe RuboCop::Cop::Layout::FirstMethodParameterLineBreak do
     end
 
     it 'autocorrects the offense' do
-      new_source = autocorrect_source(cop, source)
+      new_source = autocorrect_source(source)
 
       expect(new_source).to eq([
         'def self.foo(',
@@ -115,7 +115,7 @@ describe RuboCop::Cop::Layout::FirstMethodParameterLineBreak do
     end
 
     it 'autocorrects the offense' do
-      new_source = autocorrect_source(cop, source)
+      new_source = autocorrect_source(source)
 
       expect(new_source).to eq([
         'def foo(',

--- a/spec/rubocop/cop/layout/first_method_parameter_line_break_spec.rb
+++ b/spec/rubocop/cop/layout/first_method_parameter_line_break_spec.rb
@@ -14,7 +14,7 @@ describe RuboCop::Cop::Layout::FirstMethodParameterLineBreak do
     end
 
     it 'detects the offense' do
-      inspect_source(cop, source)
+      inspect_source(source)
 
       expect(cop.offenses.length).to eq(1)
       expect(cop.offenses.first.line).to eq(1)
@@ -46,7 +46,7 @@ describe RuboCop::Cop::Layout::FirstMethodParameterLineBreak do
     end
 
     it 'detects the offense' do
-      inspect_source(cop, source)
+      inspect_source(source)
 
       expect(cop.offenses.length).to eq(1)
       expect(cop.offenses.first.line).to eq(1)
@@ -107,7 +107,7 @@ describe RuboCop::Cop::Layout::FirstMethodParameterLineBreak do
     end
 
     it 'detects the offense' do
-      inspect_source(cop, source)
+      inspect_source(source)
 
       expect(cop.offenses.length).to eq(1)
       expect(cop.offenses.first.line).to eq(1)

--- a/spec/rubocop/cop/layout/first_parameter_indentation_spec.rb
+++ b/spec/rubocop/cop/layout/first_parameter_indentation_spec.rb
@@ -61,7 +61,7 @@ describe RuboCop::Cop::Layout::FirstParameterIndentation do
       end
 
       it 'auto-corrects nested offenses' do
-        new_source = autocorrect_source(cop, <<-RUBY.strip_indent)
+        new_source = autocorrect_source(<<-RUBY.strip_indent)
           foo(
            bar(
             7
@@ -214,7 +214,7 @@ describe RuboCop::Cop::Layout::FirstParameterIndentation do
       end
 
       it 'auto-corrects an under-indented first parameter' do
-        new_source = autocorrect_source(cop, <<-RUBY.strip_indent)
+        new_source = autocorrect_source(<<-RUBY.strip_indent)
           x =
             run(
             :foo,
@@ -235,7 +235,7 @@ describe RuboCop::Cop::Layout::FirstParameterIndentation do
       let(:indentation_width) { 4 }
 
       it 'auto-corrects an over-indented first parameter' do
-        new_source = autocorrect_source(cop, <<-RUBY.strip_indent)
+        new_source = autocorrect_source(<<-RUBY.strip_indent)
           run(
                   :foo,
               bar: 3)
@@ -271,7 +271,7 @@ describe RuboCop::Cop::Layout::FirstParameterIndentation do
       end
 
       it 'auto-corrects an over-indented first parameter' do
-        new_source = autocorrect_source(cop, <<-RUBY.strip_indent)
+        new_source = autocorrect_source(<<-RUBY.strip_indent)
           run(
                   :foo,
               bar: 3)
@@ -312,7 +312,7 @@ describe RuboCop::Cop::Layout::FirstParameterIndentation do
       end
 
       it 'auto-corrects an over-indented first parameter' do
-        new_source = autocorrect_source(cop, <<-RUBY.strip_indent)
+        new_source = autocorrect_source(<<-RUBY.strip_indent)
           run(:foo, defaults.merge(
                                   bar: 3))
         RUBY
@@ -382,7 +382,7 @@ describe RuboCop::Cop::Layout::FirstParameterIndentation do
       end
 
       it 'auto-corrects an over-indented first parameter' do
-        new_source = autocorrect_source(cop, <<-RUBY.strip_indent)
+        new_source = autocorrect_source(<<-RUBY.strip_indent)
           run(:foo, defaults.merge(
                                   bar: 3))
         RUBY
@@ -417,7 +417,7 @@ describe RuboCop::Cop::Layout::FirstParameterIndentation do
       end
 
       it 'auto-corrects an over-indented first parameter' do
-        new_source = autocorrect_source(cop, <<-RUBY.strip_indent)
+        new_source = autocorrect_source(<<-RUBY.strip_indent)
           run(:foo, defaults.merge(
                                   bar: 3))
         RUBY

--- a/spec/rubocop/cop/layout/first_parameter_indentation_spec.rb
+++ b/spec/rubocop/cop/layout/first_parameter_indentation_spec.rb
@@ -18,7 +18,7 @@ describe RuboCop::Cop::Layout::FirstParameterIndentation do
       let(:indentation_width) { 2 }
 
       it 'registers an offense for an over-indented first parameter' do
-        inspect_source(cop, <<-RUBY.strip_indent)
+        inspect_source(<<-RUBY.strip_indent)
           run(
               :foo,
               bar: 3
@@ -31,7 +31,7 @@ describe RuboCop::Cop::Layout::FirstParameterIndentation do
       end
 
       it 'registers an offense for an under-indented first parameter' do
-        inspect_source(cop, <<-RUBY.strip_indent)
+        inspect_source(<<-RUBY.strip_indent)
           run(
            :foo,
               bar: 3
@@ -41,7 +41,7 @@ describe RuboCop::Cop::Layout::FirstParameterIndentation do
       end
 
       it 'registers an offense on lines affected by another offense' do
-        inspect_source(cop, <<-RUBY.strip_indent)
+        inspect_source(<<-RUBY.strip_indent)
           foo(
            bar(
             7
@@ -82,7 +82,7 @@ describe RuboCop::Cop::Layout::FirstParameterIndentation do
       context 'for assignment' do
         it 'accepts a correctly indented first parameter and does not care ' \
            'about the second parameter' do
-          inspect_source(cop, <<-RUBY.strip_indent)
+          inspect_source(<<-RUBY.strip_indent)
             x = run(
               :foo,
                 bar: 3
@@ -101,7 +101,7 @@ describe RuboCop::Cop::Layout::FirstParameterIndentation do
           end
 
           it 'registers an offense for an under-indented first parameter' do
-            inspect_source(cop, <<-RUBY.strip_indent)
+            inspect_source(<<-RUBY.strip_indent)
               @x =
                 run(
                 :foo)
@@ -129,7 +129,7 @@ describe RuboCop::Cop::Layout::FirstParameterIndentation do
         end
 
         it 'registers an offense for an over-indented first parameter' do
-          inspect_source(cop, <<-RUBY.strip_indent)
+          inspect_source(<<-RUBY.strip_indent)
             puts x.
               merge(
                   b: 2
@@ -143,7 +143,7 @@ describe RuboCop::Cop::Layout::FirstParameterIndentation do
 
         it 'accepts a correctly indented first parameter preceded by an ' \
            'empty line' do
-          inspect_source(cop, <<-RUBY.strip_indent)
+          inspect_source(<<-RUBY.strip_indent)
             puts x.
               merge(
 
@@ -165,7 +165,7 @@ describe RuboCop::Cop::Layout::FirstParameterIndentation do
           end
 
           it 'registers an offense for an under-indented first parameter' do
-            inspect_source(cop, <<-RUBY.strip_indent)
+            inspect_source(<<-RUBY.strip_indent)
               puts x.
                 merge(
                 # comment
@@ -204,7 +204,7 @@ describe RuboCop::Cop::Layout::FirstParameterIndentation do
       end
 
       it 'does not view chained call as an outer method call' do
-        inspect_source(cop, <<-'RUBY'.strip_margin('|'))
+        inspect_source(<<-'RUBY'.strip_margin('|'))
           |  A = Regexp.union(
           |    /[A-Za-z_][A-Za-z\d_]*[!?=]?/,
           |    *AST::Types::OPERATOR_METHODS.map(&:to_s)
@@ -364,7 +364,7 @@ describe RuboCop::Cop::Layout::FirstParameterIndentation do
 
         it 'accepts a correctly indented first parameter with fullwidth ' \
            'characters' do
-          inspect_source(cop, <<-RUBY.strip_indent)
+          inspect_source(<<-RUBY.strip_indent)
             puts('Ｒｕｂｙ', f(
                                a))
           RUBY

--- a/spec/rubocop/cop/layout/indent_array_spec.rb
+++ b/spec/rubocop/cop/layout/indent_array_spec.rb
@@ -36,7 +36,7 @@ describe RuboCop::Cop::Layout::IndentArray do
     end
 
     it 'auto-corrects incorrectly indented first element' do
-      corrected = autocorrect_source(cop, <<-RUBY.strip_indent)
+      corrected = autocorrect_source(<<-RUBY.strip_indent)
         a << [
          1
         ]
@@ -124,7 +124,7 @@ describe RuboCop::Cop::Layout::IndentArray do
     end
 
     it 'auto-corrects incorrectly indented first element' do
-      corrected = autocorrect_source(cop, <<-RUBY.strip_indent)
+      corrected = autocorrect_source(<<-RUBY.strip_indent)
         a = [
             1,
           2,
@@ -235,7 +235,7 @@ describe RuboCop::Cop::Layout::IndentArray do
         end
 
         it 'auto-corrects incorrectly indented first element' do
-          corrected = autocorrect_source(cop, <<-RUBY.strip_indent)
+          corrected = autocorrect_source(<<-RUBY.strip_indent)
             func([
               1
             ])
@@ -402,7 +402,7 @@ describe RuboCop::Cop::Layout::IndentArray do
       end
 
       it 'auto-corrects incorrectly indented first element' do
-        corrected = autocorrect_source(cop, <<-RUBY.strip_indent)
+        corrected = autocorrect_source(<<-RUBY.strip_indent)
           var = [
             1
           ]
@@ -457,7 +457,7 @@ describe RuboCop::Cop::Layout::IndentArray do
       end
 
       it 'autocorrects indentation which does not match IndentationWidth' do
-        new_source = autocorrect_source(cop, <<-RUBY.strip_indent)
+        new_source = autocorrect_source(<<-RUBY.strip_indent)
           a = [
                 1
               ]

--- a/spec/rubocop/cop/layout/indent_array_spec.rb
+++ b/spec/rubocop/cop/layout/indent_array_spec.rb
@@ -26,7 +26,7 @@ describe RuboCop::Cop::Layout::IndentArray do
     end
 
     it 'registers an offense for incorrectly indented first element' do
-      inspect_source(cop, <<-RUBY.strip_indent)
+      inspect_source(<<-RUBY.strip_indent)
         a << [
          1
         ]
@@ -49,7 +49,7 @@ describe RuboCop::Cop::Layout::IndentArray do
     end
 
     it 'registers an offense for incorrectly indented ]' do
-      inspect_source(cop, <<-RUBY.strip_indent)
+      inspect_source(<<-RUBY.strip_indent)
         a << [
           ]
       RUBY
@@ -72,7 +72,7 @@ describe RuboCop::Cop::Layout::IndentArray do
       end
 
       it 'registers an offense for incorrectly indented first element' do
-        inspect_source(cop, <<-RUBY.strip_indent)
+        inspect_source(<<-RUBY.strip_indent)
           a << [
             1
           ]
@@ -95,7 +95,7 @@ describe RuboCop::Cop::Layout::IndentArray do
     end
 
     it 'registers an offense for incorrectly indented first element' do
-      inspect_source(cop, <<-RUBY.strip_margin('|'))
+      inspect_source(<<-RUBY.strip_margin('|'))
         |   config.rack_cache = [
         |   "rails:/",
         |   "rails:/",
@@ -109,7 +109,7 @@ describe RuboCop::Cop::Layout::IndentArray do
 
   context 'when array is right hand side in assignment' do
     it 'registers an offense for incorrectly indented first element' do
-      inspect_source(cop, <<-RUBY.strip_indent)
+      inspect_source(<<-RUBY.strip_indent)
         a = [
             1,
           2,
@@ -204,7 +204,7 @@ describe RuboCop::Cop::Layout::IndentArray do
         end
 
         it "registers an offense for 'consistent' indentation" do
-          inspect_source(cop, <<-RUBY.strip_indent)
+          inspect_source(<<-RUBY.strip_indent)
             func([
               1
             ])
@@ -219,7 +219,7 @@ describe RuboCop::Cop::Layout::IndentArray do
         end
 
         it "registers an offense for 'align_brackets' indentation" do
-          inspect_source(cop, <<-RUBY.strip_indent)
+          inspect_source(<<-RUBY.strip_indent)
             var = [
                     1
                   ]
@@ -289,7 +289,7 @@ describe RuboCop::Cop::Layout::IndentArray do
         end
 
         it 'registers an offense for incorrect indentation' do
-          inspect_source(cop, <<-RUBY.strip_indent)
+          inspect_source(<<-RUBY.strip_indent)
             func([
                    1
                  ])
@@ -331,7 +331,7 @@ describe RuboCop::Cop::Layout::IndentArray do
 
       it 'registers an offense for incorrectly indented multi-line array ' \
          'with brackets' do
-        inspect_source(cop, <<-RUBY.strip_indent)
+        inspect_source(<<-RUBY.strip_indent)
           func x, [
                  1, 2]
         RUBY
@@ -388,7 +388,7 @@ describe RuboCop::Cop::Layout::IndentArray do
 
     context "when 'consistent' style is used" do
       it 'registers an offense for incorrect indentation' do
-        inspect_source(cop, <<-RUBY.strip_indent)
+        inspect_source(<<-RUBY.strip_indent)
           func([
             1
           ])
@@ -417,7 +417,7 @@ describe RuboCop::Cop::Layout::IndentArray do
 
     context "when 'special_inside_parentheses' style is used" do
       it 'registers an offense for incorrect indentation' do
-        inspect_source(cop, <<-RUBY.strip_indent)
+        inspect_source(<<-RUBY.strip_indent)
           var = [
             1
           ]
@@ -435,7 +435,7 @@ describe RuboCop::Cop::Layout::IndentArray do
     end
 
     it 'registers an offense for incorrectly indented ]' do
-      inspect_source(cop, <<-RUBY.strip_indent)
+      inspect_source(<<-RUBY.strip_indent)
         a << [
           ]
       RUBY

--- a/spec/rubocop/cop/layout/indent_assignment_spec.rb
+++ b/spec/rubocop/cop/layout/indent_assignment_spec.rb
@@ -68,7 +68,7 @@ describe RuboCop::Cop::Layout::IndentAssignment, :config do
 
   it 'auto-corrects indentation' do
     new_source = autocorrect_source(
-      cop, <<-RUBY.strip_indent
+      <<-RUBY.strip_indent
         a =
         if b ; end
       RUBY
@@ -93,7 +93,7 @@ describe RuboCop::Cop::Layout::IndentAssignment, :config do
 
     it 'auto-corrects indentation' do
       new_source = autocorrect_source(
-        cop, <<-RUBY.strip_indent
+        <<-RUBY.strip_indent
           a =
             if b ; end
         RUBY

--- a/spec/rubocop/cop/layout/indent_assignment_spec.rb
+++ b/spec/rubocop/cop/layout/indent_assignment_spec.rb
@@ -15,7 +15,7 @@ describe RuboCop::Cop::Layout::IndentAssignment, :config do
   end
 
   it 'registers an offense for incorrectly indented rhs' do
-    inspect_source(cop, <<-RUBY.strip_indent)
+    inspect_source(<<-RUBY.strip_indent)
       a =
       if b ; end
     RUBY
@@ -48,7 +48,7 @@ describe RuboCop::Cop::Layout::IndentAssignment, :config do
   end
 
   it 'registers an offense for multi-lhs' do
-    inspect_source(cop, <<-RUBY.strip_indent)
+    inspect_source(<<-RUBY.strip_indent)
       a,
       b =
       if b ; end

--- a/spec/rubocop/cop/layout/indent_hash_spec.rb
+++ b/spec/rubocop/cop/layout/indent_hash_spec.rb
@@ -122,7 +122,7 @@ describe RuboCop::Cop::Layout::IndentHash do
     end
 
     it 'auto-corrects incorrectly indented first pair' do
-      corrected = autocorrect_source(cop, <<-RUBY.strip_indent)
+      corrected = autocorrect_source(<<-RUBY.strip_indent)
         a << {
          a: 1
         }
@@ -178,7 +178,7 @@ describe RuboCop::Cop::Layout::IndentHash do
     end
 
     it 'auto-corrects incorrectly indented first pair' do
-      corrected = autocorrect_source(cop, <<-RUBY.strip_indent)
+      corrected = autocorrect_source(<<-RUBY.strip_indent)
         a = {
             a: 1,
           b: 2,
@@ -229,7 +229,7 @@ describe RuboCop::Cop::Layout::IndentHash do
       let(:cop_indent) { 3 }
 
       it 'auto-corrects incorrectly indented first pair' do
-        corrected = autocorrect_source(cop, <<-RUBY.strip_indent)
+        corrected = autocorrect_source(<<-RUBY.strip_indent)
           a = {
               a: 1,
             b: 2,
@@ -310,7 +310,7 @@ describe RuboCop::Cop::Layout::IndentHash do
         end
 
         it 'auto-corrects incorrectly indented first pair' do
-          corrected = autocorrect_source(cop, <<-RUBY.strip_indent)
+          corrected = autocorrect_source(<<-RUBY.strip_indent)
             func({
               a: 1
             })
@@ -469,7 +469,7 @@ describe RuboCop::Cop::Layout::IndentHash do
       end
 
       it 'auto-corrects incorrectly indented first pair' do
-        corrected = autocorrect_source(cop, <<-RUBY.strip_indent)
+        corrected = autocorrect_source(<<-RUBY.strip_indent)
           var = {
             a: 1
           }

--- a/spec/rubocop/cop/layout/indent_hash_spec.rb
+++ b/spec/rubocop/cop/layout/indent_hash_spec.rb
@@ -26,7 +26,7 @@ describe RuboCop::Cop::Layout::IndentHash do
 
   shared_examples 'right brace' do
     it 'registers an offense for incorrectly indented }' do
-      inspect_source(cop, <<-RUBY.strip_indent)
+      inspect_source(<<-RUBY.strip_indent)
         a << {
           }
       RUBY
@@ -57,7 +57,7 @@ describe RuboCop::Cop::Layout::IndentHash do
     end
 
     it 'registers an offense for incorrectly indented first pair with :' do
-      inspect_source(cop, <<-RUBY.strip_indent)
+      inspect_source(<<-RUBY.strip_indent)
         a << {
                a: 1,
              aaa: 222
@@ -89,7 +89,7 @@ describe RuboCop::Cop::Layout::IndentHash do
     end
 
     it 'registers an offense for incorrectly indented first pair with =>' do
-      inspect_source(cop, <<-RUBY.strip_indent)
+      inspect_source(<<-RUBY.strip_indent)
         a << {
            'a' => 1,
          'aaa' => 222
@@ -112,7 +112,7 @@ describe RuboCop::Cop::Layout::IndentHash do
     end
 
     it 'registers an offense for incorrectly indented first pair' do
-      inspect_source(cop, <<-RUBY.strip_indent)
+      inspect_source(<<-RUBY.strip_indent)
         a << {
          a: 1
         }
@@ -149,7 +149,7 @@ describe RuboCop::Cop::Layout::IndentHash do
     end
 
     it 'registers an offense for incorrectly indented first pair' do
-      inspect_source(cop, <<-RUBY.strip_margin('|'))
+      inspect_source(<<-RUBY.strip_margin('|'))
         |   config.rack_cache = {
         |   :metastore => "rails:/",
         |   :entitystore => "rails:/",
@@ -163,7 +163,7 @@ describe RuboCop::Cop::Layout::IndentHash do
 
   context 'when hash is right hand side in assignment' do
     it 'registers an offense for incorrectly indented first pair' do
-      inspect_source(cop, <<-RUBY.strip_indent)
+      inspect_source(<<-RUBY.strip_indent)
         a = {
             a: 1,
           b: 2,
@@ -279,7 +279,7 @@ describe RuboCop::Cop::Layout::IndentHash do
         end
 
         it "registers an offense for 'consistent' indentation" do
-          inspect_source(cop, <<-RUBY.strip_indent)
+          inspect_source(<<-RUBY.strip_indent)
             func({
               a: 1
             })
@@ -294,7 +294,7 @@ describe RuboCop::Cop::Layout::IndentHash do
         end
 
         it "registers an offense for 'align_braces' indentation" do
-          inspect_source(cop, <<-RUBY.strip_indent)
+          inspect_source(<<-RUBY.strip_indent)
             var = {
                     a: 1
                   }
@@ -364,7 +364,7 @@ describe RuboCop::Cop::Layout::IndentHash do
         end
 
         it 'registers an offense for incorrect indentation' do
-          inspect_source(cop, <<-RUBY.strip_indent)
+          inspect_source(<<-RUBY.strip_indent)
             func({
                    a: 1
                  })
@@ -406,7 +406,7 @@ describe RuboCop::Cop::Layout::IndentHash do
 
       it 'registers an offense for incorrectly indented multi-line hash ' \
          'with braces' do
-        inspect_source(cop, <<-RUBY.strip_indent)
+        inspect_source(<<-RUBY.strip_indent)
           func x, {
                  a: 1, b: 2 }
         RUBY
@@ -455,7 +455,7 @@ describe RuboCop::Cop::Layout::IndentHash do
 
     context "when 'consistent' style is used" do
       it 'registers an offense for incorrect indentation' do
-        inspect_source(cop, <<-RUBY.strip_indent)
+        inspect_source(<<-RUBY.strip_indent)
           func({
             a: 1
           })
@@ -484,7 +484,7 @@ describe RuboCop::Cop::Layout::IndentHash do
 
     context "when 'special_inside_parentheses' style is used" do
       it 'registers an offense for incorrect indentation' do
-        inspect_source(cop, <<-RUBY.strip_indent)
+        inspect_source(<<-RUBY.strip_indent)
           var = {
             a: 1
           }
@@ -502,7 +502,7 @@ describe RuboCop::Cop::Layout::IndentHash do
     end
 
     it 'registers an offense for incorrectly indented }' do
-      inspect_source(cop, <<-RUBY.strip_indent)
+      inspect_source(<<-RUBY.strip_indent)
         a << {
           }
       RUBY

--- a/spec/rubocop/cop/layout/indent_heredoc_spec.rb
+++ b/spec/rubocop/cop/layout/indent_heredoc_spec.rb
@@ -5,7 +5,7 @@ describe RuboCop::Cop::Layout::IndentHeredoc, :config do
 
   shared_examples :offense do |name, code, correction = nil|
     it "registers an offense for #{name}" do
-      inspect_source(cop, code.strip_indent)
+      inspect_source(code.strip_indent)
       expect(cop.offenses.size).to eq(1)
     end
 
@@ -17,14 +17,14 @@ describe RuboCop::Cop::Layout::IndentHeredoc, :config do
 
   shared_examples :accept do |name, code|
     it "accepts for #{name}" do
-      inspect_source(cop, code.strip_indent)
+      inspect_source(code.strip_indent)
       expect(cop.offenses).to be_empty
     end
   end
 
   shared_examples :check_message do |name, message|
     it "displays a message with #{name}" do
-      inspect_source(cop, <<-RUBY.strip_indent)
+      inspect_source(<<-RUBY.strip_indent)
         <<-RUBY2
         foo
         RUBY2
@@ -253,7 +253,7 @@ describe RuboCop::Cop::Layout::IndentHeredoc, :config do
         RUBY
 
         it 'displays message to use `<<~` instead of `<<`' do
-          inspect_source(cop, <<-RUBY.strip_indent)
+          inspect_source(<<-RUBY.strip_indent)
           <<RUBY2
           foo
           RUBY2
@@ -266,7 +266,7 @@ describe RuboCop::Cop::Layout::IndentHeredoc, :config do
           )
         end
         it 'displays message to use `<<~` instead of `<<-`' do
-          inspect_source(cop, <<-RUBY.strip_indent)
+          inspect_source(<<-RUBY.strip_indent)
           <<-RUBY2
           foo
           RUBY2

--- a/spec/rubocop/cop/layout/indent_heredoc_spec.rb
+++ b/spec/rubocop/cop/layout/indent_heredoc_spec.rb
@@ -10,7 +10,7 @@ describe RuboCop::Cop::Layout::IndentHeredoc, :config do
     end
 
     it "autocorrects for #{name}" do
-      corrected = autocorrect_source_with_loop(cop, code.strip_indent)
+      corrected = autocorrect_source_with_loop(code.strip_indent)
       expect(corrected).to eq(correction.strip_indent)
     end
   end
@@ -36,7 +36,7 @@ describe RuboCop::Cop::Layout::IndentHeredoc, :config do
   shared_examples :warning do |message|
     it 'warns' do
       correct = lambda do
-        autocorrect_source(cop, <<-RUBY.strip_indent)
+        autocorrect_source(<<-RUBY.strip_indent)
           <<-RUBY2
           foo
           RUBY2

--- a/spec/rubocop/cop/layout/indentation_consistency_spec.rb
+++ b/spec/rubocop/cop/layout/indentation_consistency_spec.rb
@@ -43,7 +43,7 @@ describe RuboCop::Cop::Layout::IndentationConsistency, :config do
     end
 
     it 'autocorrects bad indentation' do
-      corrected = autocorrect_source(cop, <<-RUBY.strip_indent)
+      corrected = autocorrect_source(<<-RUBY.strip_indent)
         if a1
            b1
         elsif a2
@@ -576,7 +576,7 @@ describe RuboCop::Cop::Layout::IndentationConsistency, :config do
     end
 
     it 'does not auto-correct an offense within another offense' do
-      corrected = autocorrect_source(cop, <<-RUBY.strip_indent)
+      corrected = autocorrect_source(<<-RUBY.strip_indent)
         require 'spec_helper'
         describe ArticlesController do
           render_views

--- a/spec/rubocop/cop/layout/indentation_consistency_spec.rb
+++ b/spec/rubocop/cop/layout/indentation_consistency_spec.rb
@@ -154,7 +154,7 @@ describe RuboCop::Cop::Layout::IndentationConsistency, :config do
 
     it 'accepts an if/else in assignment with end aligned with variable ' \
        'and chaining after the end' do
-      inspect_source(cop, <<-RUBY.strip_indent)
+      inspect_source(<<-RUBY.strip_indent)
         var = if a
           0
         else
@@ -166,7 +166,7 @@ describe RuboCop::Cop::Layout::IndentationConsistency, :config do
 
     it 'accepts an if/else in assignment with end aligned with variable ' \
        'and chaining with a block after the end' do
-      inspect_source(cop, <<-RUBY.strip_indent)
+      inspect_source(<<-RUBY.strip_indent)
         var = if a
           0
         else
@@ -196,7 +196,7 @@ describe RuboCop::Cop::Layout::IndentationConsistency, :config do
 
     it 'accepts an if/else in assignment on next line with end aligned ' \
        'with if' do
-      inspect_source(cop, <<-RUBY.strip_indent)
+      inspect_source(<<-RUBY.strip_indent)
         var =
           if a
             0
@@ -493,7 +493,7 @@ describe RuboCop::Cop::Layout::IndentationConsistency, :config do
 
       it 'registers an offense for bad indentation in def but not for ' \
          'outdented public, protected, and private' do
-        inspect_source(cop, <<-RUBY.strip_indent)
+        inspect_source(<<-RUBY.strip_indent)
           class Test
           public
 

--- a/spec/rubocop/cop/layout/indentation_width_spec.rb
+++ b/spec/rubocop/cop/layout/indentation_width_spec.rb
@@ -539,7 +539,7 @@ describe RuboCop::Cop::Layout::IndentationWidth do
         shared_examples 'assignment and if with keyword alignment' do
           context 'and end is aligned with variable' do
             it 'registers an offense for an if' do
-              inspect_source(cop, <<-RUBY.strip_indent)
+              inspect_source(<<-RUBY.strip_indent)
                 var = if a
                   0
                 end
@@ -549,7 +549,7 @@ describe RuboCop::Cop::Layout::IndentationWidth do
             end
 
             it 'registers an offense for a while' do
-              inspect_source(cop, <<-RUBY.strip_indent)
+              inspect_source(<<-RUBY.strip_indent)
                 var = while a
                   b
                 end
@@ -816,7 +816,7 @@ describe RuboCop::Cop::Layout::IndentationWidth do
     context 'with def/defs' do
       shared_examples 'without modifier on the same line' do
         it 'registers an offense for bad indentation of a def body' do
-          inspect_source(cop, <<-RUBY.strip_indent)
+          inspect_source(<<-RUBY.strip_indent)
             def test
                 func1
                  func2 # No offense registered for this.
@@ -826,7 +826,7 @@ describe RuboCop::Cop::Layout::IndentationWidth do
         end
 
         it 'registers an offense for bad indentation of a defs body' do
-          inspect_source(cop, <<-RUBY.strip_indent)
+          inspect_source(<<-RUBY.strip_indent)
             def self.test
                func
             end
@@ -978,7 +978,7 @@ describe RuboCop::Cop::Layout::IndentationWidth do
         let(:consistency_config) { { 'EnforcedStyle' => 'rails' } }
 
         it 'registers an offense for normal non-rails indentation' do
-          inspect_source(cop, <<-RUBY.strip_indent)
+          inspect_source(<<-RUBY.strip_indent)
             class Test
               public
 
@@ -1054,7 +1054,7 @@ describe RuboCop::Cop::Layout::IndentationWidth do
 
     context 'with begin/rescue/else/ensure/end' do
       it 'registers an offense for bad indentation of bodies' do
-        inspect_source(cop, <<-RUBY.strip_indent)
+        inspect_source(<<-RUBY.strip_indent)
           def my_func
             puts 'do something outside block'
             begin
@@ -1113,7 +1113,7 @@ describe RuboCop::Cop::Layout::IndentationWidth do
         let(:consistency_config) { { 'EnforcedStyle' => 'rails' } }
 
         it 'registers an offense for bad indentation in a do/end body' do
-          inspect_source(cop, <<-RUBY.strip_indent)
+          inspect_source(<<-RUBY.strip_indent)
             concern :Authenticatable do
               def foo
                 puts "foo"

--- a/spec/rubocop/cop/layout/indentation_width_spec.rb
+++ b/spec/rubocop/cop/layout/indentation_width_spec.rb
@@ -72,7 +72,7 @@ describe RuboCop::Cop::Layout::IndentationWidth do
 
     describe '#autocorrect' do
       it 'corrects bad indentation' do
-        corrected = autocorrect_source(cop, <<-RUBY.strip_indent)
+        corrected = autocorrect_source(<<-RUBY.strip_indent)
           if a1
              b1
              b1
@@ -185,7 +185,7 @@ describe RuboCop::Cop::Layout::IndentationWidth do
 
       describe '#autocorrect' do
         it 'corrects bad indentation' do
-          corrected = autocorrect_source(cop, <<-RUBY.strip_indent)
+          corrected = autocorrect_source(<<-RUBY.strip_indent)
             if a1
                b1
                b1
@@ -228,11 +228,11 @@ describe RuboCop::Cop::Layout::IndentationWidth do
             end
           RUBY
 
-          expect(autocorrect_source(cop, source)).to eq source
+          expect(autocorrect_source(source)).to eq source
         end
 
         it 'does not indent heredoc strings' do
-          corrected = autocorrect_source(cop, <<-'RUBY'.strip_indent)
+          corrected = autocorrect_source(<<-'RUBY'.strip_indent)
             module Foo
             module Bar
               SOMETHING = <<GOO
@@ -272,7 +272,7 @@ describe RuboCop::Cop::Layout::IndentationWidth do
               array_list << var1
             end
           RUBY
-          corrected = autocorrect_source(cop, src)
+          corrected = autocorrect_source(src)
           expect(corrected)
             .to eq <<-RUBY.strip_indent
               var1 = nil
@@ -293,7 +293,7 @@ describe RuboCop::Cop::Layout::IndentationWidth do
               rescue ; end # consume any exception
             end
           RUBY
-          corrected = autocorrect_source(cop, src)
+          corrected = autocorrect_source(src)
           expect(corrected).to eq src
         end
 
@@ -307,16 +307,16 @@ describe RuboCop::Cop::Layout::IndentationWidth do
                   :attr2 => Other.get_value(),
                   :attr3 => Another.get_value()) }
           RUBY
-          corrected = autocorrect_source(cop, src)
+          corrected = autocorrect_source(src)
           expect(corrected).to eq src
         end
 
         it 'handles lines with only whitespace' do
-          corrected = autocorrect_source(cop, ['def x',
-                                               '    y',
-                                               ' ',
-                                               'rescue',
-                                               'end'])
+          corrected = autocorrect_source(['def x',
+                                          '    y',
+                                          ' ',
+                                          'rescue',
+                                          'end'])
 
           expect(corrected).to eq ['def x',
                                    '  y',
@@ -559,7 +559,7 @@ describe RuboCop::Cop::Layout::IndentationWidth do
             end
 
             it 'autocorrects bad indentation' do
-              corrected = autocorrect_source(cop, <<-RUBY.strip_indent)
+              corrected = autocorrect_source(<<-RUBY.strip_indent)
                 var = if a
                   b
                 end

--- a/spec/rubocop/cop/layout/initial_indentation_spec.rb
+++ b/spec/rubocop/cop/layout/initial_indentation_spec.rb
@@ -59,7 +59,7 @@ describe RuboCop::Cop::Layout::InitialIndentation do
   end
 
   it 'auto-corrects indented method definition' do
-    corrected = autocorrect_source(cop, <<-RUBY.strip_margin('|'))
+    corrected = autocorrect_source(<<-RUBY.strip_margin('|'))
       |  def f
       |  end
     RUBY
@@ -70,7 +70,7 @@ describe RuboCop::Cop::Layout::InitialIndentation do
   end
 
   it 'auto-corrects indented assignment but not comment' do
-    corrected = autocorrect_source(cop, <<-RUBY.strip_margin('|'))
+    corrected = autocorrect_source(<<-RUBY.strip_margin('|'))
       |  # comment
       |  x = 1
     RUBY

--- a/spec/rubocop/cop/layout/leading_comment_space_spec.rb
+++ b/spec/rubocop/cop/layout/leading_comment_space_spec.rb
@@ -89,7 +89,7 @@ describe RuboCop::Cop::Layout::LeadingCommentSpace do
   end
 
   it 'auto-corrects missing space' do
-    new_source = autocorrect_source(cop, '#comment')
+    new_source = autocorrect_source('#comment')
     expect(new_source).to eq('# comment')
   end
 

--- a/spec/rubocop/cop/layout/multiline_assignment_layout_spec.rb
+++ b/spec/rubocop/cop/layout/multiline_assignment_layout_spec.rb
@@ -15,7 +15,7 @@ describe RuboCop::Cop::Layout::MultilineAssignmentLayout, :config do
     let(:enforced_style) { 'new_line' }
 
     it 'registers an offense when the rhs is on the same line' do
-      inspect_source(cop, <<-RUBY.strip_indent)
+      inspect_source(<<-RUBY.strip_indent)
         blarg = if true
         end
       RUBY
@@ -50,7 +50,7 @@ describe RuboCop::Cop::Layout::MultilineAssignmentLayout, :config do
       let(:supported_types) { %w[array] }
 
       it 'allows supported types to be configured' do
-        inspect_source(cop, <<-RUBY.strip_indent)
+        inspect_source(<<-RUBY.strip_indent)
           a, b = 4,
           5
         RUBY
@@ -71,7 +71,7 @@ describe RuboCop::Cop::Layout::MultilineAssignmentLayout, :config do
     end
 
     it 'registers an offense for masgn with multi-line lhs' do
-      inspect_source(cop, <<-RUBY.strip_indent)
+      inspect_source(<<-RUBY.strip_indent)
         a,
         b = if foo
         end
@@ -88,7 +88,7 @@ describe RuboCop::Cop::Layout::MultilineAssignmentLayout, :config do
     let(:enforced_style) { 'same_line' }
 
     it 'registers an offense when the rhs is a different line' do
-      inspect_source(cop, <<-RUBY.strip_indent)
+      inspect_source(<<-RUBY.strip_indent)
         blarg =
         if true
         end
@@ -125,7 +125,7 @@ describe RuboCop::Cop::Layout::MultilineAssignmentLayout, :config do
       let(:supported_types) { %w[array] }
 
       it 'allows supported types to be configured' do
-        inspect_source(cop, <<-RUBY.strip_indent)
+        inspect_source(<<-RUBY.strip_indent)
           a, b =
           4,
           5
@@ -146,7 +146,7 @@ describe RuboCop::Cop::Layout::MultilineAssignmentLayout, :config do
     end
 
     it 'registers an offense for masgn with multi-line lhs' do
-      inspect_source(cop, <<-RUBY.strip_indent)
+      inspect_source(<<-RUBY.strip_indent)
         a,
         b =
         if foo

--- a/spec/rubocop/cop/layout/multiline_assignment_layout_spec.rb
+++ b/spec/rubocop/cop/layout/multiline_assignment_layout_spec.rb
@@ -27,7 +27,7 @@ describe RuboCop::Cop::Layout::MultilineAssignmentLayout, :config do
     end
 
     it 'auto-corrects offenses' do
-      new_source = autocorrect_source(cop, <<-RUBY.strip_indent)
+      new_source = autocorrect_source(<<-RUBY.strip_indent)
         blarg = if true
         end
       RUBY
@@ -101,7 +101,7 @@ describe RuboCop::Cop::Layout::MultilineAssignmentLayout, :config do
     end
 
     it 'auto-corrects offenses' do
-      new_source = autocorrect_source(cop, <<-RUBY.strip_indent)
+      new_source = autocorrect_source(<<-RUBY.strip_indent)
         blarg =
         if true
         end

--- a/spec/rubocop/cop/layout/multiline_block_layout_spec.rb
+++ b/spec/rubocop/cop/layout/multiline_block_layout_spec.rb
@@ -117,7 +117,7 @@ describe RuboCop::Cop::Layout::MultilineBlockLayout do
       end
     RUBY
 
-    new_source = autocorrect_source(cop, src)
+    new_source = autocorrect_source(src)
 
     expect(new_source).to eq(['test do |foo| ',
                               '  bar',
@@ -132,7 +132,7 @@ describe RuboCop::Cop::Layout::MultilineBlockLayout do
       end
     RUBY
 
-    new_source = autocorrect_source(cop, src)
+    new_source = autocorrect_source(src)
 
     expect(new_source).to eq(['test do |foo| ',
                               '  bar',
@@ -147,7 +147,7 @@ describe RuboCop::Cop::Layout::MultilineBlockLayout do
       }
     RUBY
 
-    new_source = autocorrect_source(cop, src)
+    new_source = autocorrect_source(src)
 
     expect(new_source).to eq(['test { |foo| ',
                               '  bar',
@@ -163,7 +163,7 @@ describe RuboCop::Cop::Layout::MultilineBlockLayout do
       }
     RUBY
 
-    new_source = autocorrect_source(cop, src)
+    new_source = autocorrect_source(src)
 
     expect(new_source).to eq(['x = -> (y) { ',
                               '      foo',
@@ -173,7 +173,7 @@ describe RuboCop::Cop::Layout::MultilineBlockLayout do
   end
 
   it 'auto-corrects a line-break before arguments' do
-    new_source = autocorrect_source(cop, <<-RUBY.strip_indent)
+    new_source = autocorrect_source(<<-RUBY.strip_indent)
       test do
         |x| play_with(x)
       end
@@ -187,7 +187,7 @@ describe RuboCop::Cop::Layout::MultilineBlockLayout do
   end
 
   it 'auto-corrects a line-break before arguments with empty block' do
-    new_source = autocorrect_source(cop, <<-RUBY.strip_indent)
+    new_source = autocorrect_source(<<-RUBY.strip_indent)
       test do
         |x|
       end
@@ -200,7 +200,7 @@ describe RuboCop::Cop::Layout::MultilineBlockLayout do
   end
 
   it 'auto-corrects a line-break within arguments' do
-    new_source = autocorrect_source(cop, <<-RUBY.strip_indent)
+    new_source = autocorrect_source(<<-RUBY.strip_indent)
       test do |x,
         y| play_with(x, y)
       end
@@ -213,7 +213,7 @@ describe RuboCop::Cop::Layout::MultilineBlockLayout do
   end
 
   it 'auto-corrects a line break within destructured arguments' do
-    new_source = autocorrect_source(cop, <<-RUBY.strip_indent)
+    new_source = autocorrect_source(<<-RUBY.strip_indent)
       test do |(x,
         y)| play_with(x, y)
       end
@@ -227,7 +227,7 @@ describe RuboCop::Cop::Layout::MultilineBlockLayout do
 
   it "doesn't move end keyword in a way which causes infinite loop " \
      'in combination with Style/BlockEndNewLine' do
-    new_source = autocorrect_source(cop, <<-RUBY.strip_indent)
+    new_source = autocorrect_source(<<-RUBY.strip_indent)
       def f
         X.map do |(a,
         b)|

--- a/spec/rubocop/cop/layout/multiline_method_call_indentation_spec.rb
+++ b/spec/rubocop/cop/layout/multiline_method_call_indentation_spec.rb
@@ -296,7 +296,7 @@ describe RuboCop::Cop::Layout::MultilineMethodCallIndentation do
       end
 
       it 'auto-corrects' do
-        new_source = autocorrect_source(cop, <<-RUBY.strip_indent)
+        new_source = autocorrect_source(<<-RUBY.strip_indent)
           User.all.first
             .age.to_s
         RUBY
@@ -518,7 +518,7 @@ describe RuboCop::Cop::Layout::MultilineMethodCallIndentation do
     end
 
     it 'auto-corrects' do
-      new_source = autocorrect_source(cop, <<-RUBY.strip_indent)
+      new_source = autocorrect_source(<<-RUBY.strip_indent)
         until a.
             b
           something
@@ -644,7 +644,7 @@ describe RuboCop::Cop::Layout::MultilineMethodCallIndentation do
     end
 
     it 'auto-corrects' do
-      new_source = autocorrect_source(cop, <<-RUBY.strip_indent)
+      new_source = autocorrect_source(<<-RUBY.strip_indent)
         until a.
               b
           something
@@ -840,7 +840,7 @@ describe RuboCop::Cop::Layout::MultilineMethodCallIndentation do
     end
 
     it 'auto-corrects' do
-      new_source = autocorrect_source(cop, <<-RUBY.strip_indent)
+      new_source = autocorrect_source(<<-RUBY.strip_indent)
         until a.
               b
           something

--- a/spec/rubocop/cop/layout/multiline_method_call_indentation_spec.rb
+++ b/spec/rubocop/cop/layout/multiline_method_call_indentation_spec.rb
@@ -23,7 +23,7 @@ describe RuboCop::Cop::Layout::MultilineMethodCallIndentation do
     end
 
     it 'accepts indented methods inside and outside a block' do
-      inspect_source(cop, <<-RUBY.strip_indent)
+      inspect_source(<<-RUBY.strip_indent)
         a = b.map do |c|
           c
             .b
@@ -45,7 +45,7 @@ describe RuboCop::Cop::Layout::MultilineMethodCallIndentation do
     end
 
     it 'accepts indented methods in ordinary statement' do
-      inspect_source(cop, <<-RUBY.strip_indent)
+      inspect_source(<<-RUBY.strip_indent)
         a.
           b
       RUBY
@@ -53,7 +53,7 @@ describe RuboCop::Cop::Layout::MultilineMethodCallIndentation do
     end
 
     it 'accepts no extra indentation of third line' do
-      inspect_source(cop, <<-RUBY.strip_margin('|'))
+      inspect_source(<<-RUBY.strip_margin('|'))
         |   a.
         |     b.
         |     c
@@ -62,7 +62,7 @@ describe RuboCop::Cop::Layout::MultilineMethodCallIndentation do
     end
 
     it 'accepts indented methods in for body' do
-      inspect_source(cop, <<-RUBY.strip_indent)
+      inspect_source(<<-RUBY.strip_indent)
         for x in a
           something.
             something_else
@@ -72,7 +72,7 @@ describe RuboCop::Cop::Layout::MultilineMethodCallIndentation do
     end
 
     it 'accepts alignment inside a grouped expression' do
-      inspect_source(cop, <<-RUBY.strip_indent)
+      inspect_source(<<-RUBY.strip_indent)
         (a.
          b)
       RUBY
@@ -80,7 +80,7 @@ describe RuboCop::Cop::Layout::MultilineMethodCallIndentation do
     end
 
     it 'accepts an expression where the first method spans multiple lines' do
-      inspect_source(cop, <<-RUBY.strip_indent)
+      inspect_source(<<-RUBY.strip_indent)
         subject.each do |item|
           result = resolve(locale) and return result
         end.a
@@ -89,7 +89,7 @@ describe RuboCop::Cop::Layout::MultilineMethodCallIndentation do
     end
 
     it 'accepts any indentation of parameters to #[]' do
-      inspect_source(cop, <<-RUBY.strip_indent)
+      inspect_source(<<-RUBY.strip_indent)
         payment = Models::IncomingPayments[
                 id:      input['incoming-payment-id'],
                    user_id: @user[:id]]
@@ -98,7 +98,7 @@ describe RuboCop::Cop::Layout::MultilineMethodCallIndentation do
     end
 
     it "doesn't fail on unary operators" do
-      inspect_source(cop, <<-RUBY.strip_indent)
+      inspect_source(<<-RUBY.strip_indent)
         def foo
           !0
           .nil?
@@ -110,7 +110,7 @@ describe RuboCop::Cop::Layout::MultilineMethodCallIndentation do
 
   shared_examples 'common for aligned and indented' do
     it 'accepts even indentation of consecutive lines in typical RSpec code' do
-      inspect_source(cop, <<-RUBY.strip_indent)
+      inspect_source(<<-RUBY.strip_indent)
         expect { Foo.new }.
           to change { Bar.count }.
           from(1).to(2)
@@ -119,7 +119,7 @@ describe RuboCop::Cop::Layout::MultilineMethodCallIndentation do
     end
 
     it 'registers an offense for no indentation of second line' do
-      inspect_source(cop, <<-RUBY.strip_indent)
+      inspect_source(<<-RUBY.strip_indent)
         a.
         b
       RUBY
@@ -130,7 +130,7 @@ describe RuboCop::Cop::Layout::MultilineMethodCallIndentation do
     end
 
     it 'registers an offense for 3 spaces indentation of second line' do
-      inspect_source(cop, <<-RUBY.strip_indent)
+      inspect_source(<<-RUBY.strip_indent)
         a.
            b
         c.
@@ -143,7 +143,7 @@ describe RuboCop::Cop::Layout::MultilineMethodCallIndentation do
     end
 
     it 'registers an offense for extra indentation of third line' do
-      inspect_source(cop, <<-RUBY.strip_margin('|'))
+      inspect_source(<<-RUBY.strip_margin('|'))
         |   a.
         |     b.
         |       c
@@ -156,7 +156,7 @@ describe RuboCop::Cop::Layout::MultilineMethodCallIndentation do
 
     it 'registers an offense for the emacs ruby-mode 1.1 indentation of an ' \
        'expression in an array' do
-      inspect_source(cop, <<-RUBY.strip_margin('|'))
+      inspect_source(<<-RUBY.strip_margin('|'))
         |  [
         |   a.
         |   b
@@ -170,7 +170,7 @@ describe RuboCop::Cop::Layout::MultilineMethodCallIndentation do
 
     it 'registers an offense for extra indentation of 3rd line in typical ' \
        'RSpec code' do
-      inspect_source(cop, <<-RUBY.strip_indent)
+      inspect_source(<<-RUBY.strip_indent)
         expect { Foo.new }.
           to change { Bar.count }.
               from(1).to(2)
@@ -181,7 +181,7 @@ describe RuboCop::Cop::Layout::MultilineMethodCallIndentation do
     end
 
     it 'registers an offense for proc call without a selector' do
-      inspect_source(cop, <<-RUBY.strip_indent)
+      inspect_source(<<-RUBY.strip_indent)
         a
          .(args)
       RUBY
@@ -191,7 +191,7 @@ describe RuboCop::Cop::Layout::MultilineMethodCallIndentation do
     end
 
     it 'registers an offense for one space indentation of second line' do
-      inspect_source(cop, <<-RUBY.strip_indent)
+      inspect_source(<<-RUBY.strip_indent)
         a
          .b
       RUBY
@@ -226,8 +226,7 @@ describe RuboCop::Cop::Layout::MultilineMethodCallIndentation do
 
       it 'accepts method being aligned with method that is an argument in ' \
          'assignment' do
-        inspect_source(cop,
-                       ['user = authorize scope.includes(:user)',
+        inspect_source(['user = authorize scope.includes(:user)',
                         '                      .order(:name)'])
         expect(cop.offenses).to be_empty
       end
@@ -389,7 +388,7 @@ describe RuboCop::Cop::Layout::MultilineMethodCallIndentation do
     end
 
     it 'registers an offense for misaligned methods in if condition' do
-      inspect_source(cop, <<-RUBY.strip_indent)
+      inspect_source(<<-RUBY.strip_indent)
         if a.
             b
           something
@@ -426,7 +425,7 @@ describe RuboCop::Cop::Layout::MultilineMethodCallIndentation do
     end
 
     it 'registers an offense for misaligned methods in unless condition' do
-      inspect_source(cop, <<-RUBY.strip_indent)
+      inspect_source(<<-RUBY.strip_indent)
         unless a
         .b
           something
@@ -486,7 +485,7 @@ describe RuboCop::Cop::Layout::MultilineMethodCallIndentation do
 
     it 'registers an offense for misaligned methods in local variable ' \
        'assignment' do
-      inspect_source(cop, <<-RUBY.strip_indent)
+      inspect_source(<<-RUBY.strip_indent)
         a = b.c.
          d
       RUBY
@@ -540,7 +539,7 @@ describe RuboCop::Cop::Layout::MultilineMethodCallIndentation do
     # indented style, it doesn't come into play.
     context 'for possible semantic alignment' do
       it 'accepts indented methods' do
-        inspect_source(cop, <<-RUBY.strip_indent)
+        inspect_source(<<-RUBY.strip_indent)
           User.a
             .c
             .b
@@ -559,7 +558,7 @@ describe RuboCop::Cop::Layout::MultilineMethodCallIndentation do
     include_examples 'both indented* styles'
 
     it 'accepts correctly indented methods in operation' do
-      inspect_source(cop, <<-RUBY.strip_margin('|'))
+      inspect_source(<<-RUBY.strip_margin('|'))
         |        1 + a
         |              .b
         |              .c
@@ -585,7 +584,7 @@ describe RuboCop::Cop::Layout::MultilineMethodCallIndentation do
 
     it 'registers an offense for extra indentation of 3rd line in typical ' \
        'RSpec code' do
-      inspect_source(cop, <<-RUBY.strip_indent)
+      inspect_source(<<-RUBY.strip_indent)
         expect { Foo.new }.
           to change { Bar.count }.
               from(1).to(2)
@@ -633,7 +632,7 @@ describe RuboCop::Cop::Layout::MultilineMethodCallIndentation do
 
     it 'registers an offense for the emacs ruby-mode 1.1 indentation of an ' \
        'expression in an array' do
-      inspect_source(cop, <<-RUBY.strip_margin('|'))
+      inspect_source(<<-RUBY.strip_margin('|'))
         |  [
         |   a.
         |   b
@@ -668,7 +667,7 @@ describe RuboCop::Cop::Layout::MultilineMethodCallIndentation do
     include_examples 'both indented* styles'
 
     it 'accepts correctly indented methods in operation' do
-      inspect_source(cop, <<-RUBY.strip_margin('|'))
+      inspect_source(<<-RUBY.strip_margin('|'))
         |        1 + a
         |          .b
         |          .c
@@ -696,7 +695,7 @@ describe RuboCop::Cop::Layout::MultilineMethodCallIndentation do
     end
 
     it 'registers an offense for aligned methods in if condition' do
-      inspect_source(cop, <<-RUBY.strip_indent)
+      inspect_source(<<-RUBY.strip_indent)
         if a.
            b
           something
@@ -741,7 +740,7 @@ describe RuboCop::Cop::Layout::MultilineMethodCallIndentation do
       %w[an until]
     ].each do |article, keyword|
       it "accepts double indentation of #{keyword} condition" do
-        inspect_source(cop, <<-RUBY.strip_indent)
+        inspect_source(<<-RUBY.strip_indent)
           #{keyword} receiver.
               nil? &&
               !args.empty?
@@ -752,7 +751,7 @@ describe RuboCop::Cop::Layout::MultilineMethodCallIndentation do
 
       it "registers an offense for a 2 space indentation of #{keyword} " \
          'condition' do
-        inspect_source(cop, <<-RUBY.strip_indent)
+        inspect_source(<<-RUBY.strip_indent)
           #{keyword} receiver
             .nil? &&
             !args.empty?
@@ -765,7 +764,7 @@ describe RuboCop::Cop::Layout::MultilineMethodCallIndentation do
       end
 
       it "accepts indented methods in #{keyword} body" do
-        inspect_source(cop, <<-RUBY.strip_indent)
+        inspect_source(<<-RUBY.strip_indent)
           #{keyword} a
             something.
               something_else
@@ -777,7 +776,7 @@ describe RuboCop::Cop::Layout::MultilineMethodCallIndentation do
 
     %w[unless if].each do |keyword|
       it "accepts special indentation of return #{keyword} condition" do
-        inspect_source(cop, <<-RUBY.strip_indent)
+        inspect_source(<<-RUBY.strip_indent)
           return #{keyword} receiver.nil? &&
               !args.empty? &&
               BLACKLIST.include?(method_name)
@@ -815,7 +814,7 @@ describe RuboCop::Cop::Layout::MultilineMethodCallIndentation do
     end
 
     it 'registers an offense for correct + unrecognized style' do
-      inspect_source(cop, <<-RUBY.strip_indent)
+      inspect_source(<<-RUBY.strip_indent)
         a.
           b
         c.
@@ -867,7 +866,7 @@ describe RuboCop::Cop::Layout::MultilineMethodCallIndentation do
       end
 
       it 'accepts correctly indented methods in operation' do
-        inspect_source(cop, <<-RUBY.strip_margin('|'))
+        inspect_source(<<-RUBY.strip_margin('|'))
           |        1 + a
           |               .b
           |               .c
@@ -905,7 +904,7 @@ describe RuboCop::Cop::Layout::MultilineMethodCallIndentation do
           # normal code indentation is 2 spaces, and we have configured
           # multiline method indentation to 7 spaces
           # so in this case, 9 spaces are required
-          inspect_source(cop, <<-RUBY.strip_indent)
+          inspect_source(<<-RUBY.strip_indent)
             #{keyword} receiver.
                      nil? &&
                      !args.empty?
@@ -916,7 +915,7 @@ describe RuboCop::Cop::Layout::MultilineMethodCallIndentation do
 
         it "registers an offense for a 4 space indentation of #{keyword} " \
            'condition' do
-          inspect_source(cop, <<-RUBY.strip_indent)
+          inspect_source(<<-RUBY.strip_indent)
             #{keyword} receiver
                 .nil? &&
                 !args.empty?
@@ -929,7 +928,7 @@ describe RuboCop::Cop::Layout::MultilineMethodCallIndentation do
         end
 
         it "accepts indented methods in #{keyword} body" do
-          inspect_source(cop, <<-RUBY.strip_indent)
+          inspect_source(<<-RUBY.strip_indent)
             #{keyword} a
               something.
                      something_else

--- a/spec/rubocop/cop/layout/multiline_operation_indentation_spec.rb
+++ b/spec/rubocop/cop/layout/multiline_operation_indentation_spec.rb
@@ -16,7 +16,7 @@ describe RuboCop::Cop::Layout::MultilineOperationIndentation do
 
   shared_examples 'common' do
     it 'accepts indented operands in ordinary statement' do
-      inspect_source(cop, <<-RUBY.strip_indent)
+      inspect_source(<<-RUBY.strip_indent)
         a +
           b
       RUBY
@@ -24,7 +24,7 @@ describe RuboCop::Cop::Layout::MultilineOperationIndentation do
     end
 
     it 'accepts indented operands inside and outside a block' do
-      inspect_source(cop, <<-RUBY.strip_indent)
+      inspect_source(<<-RUBY.strip_indent)
         a = b.map do |c|
           c +
             b +
@@ -38,7 +38,7 @@ describe RuboCop::Cop::Layout::MultilineOperationIndentation do
     end
 
     it 'registers an offense for no indentation of second line' do
-      inspect_source(cop, <<-RUBY.strip_indent)
+      inspect_source(<<-RUBY.strip_indent)
         a +
         b
       RUBY
@@ -48,7 +48,7 @@ describe RuboCop::Cop::Layout::MultilineOperationIndentation do
     end
 
     it 'registers an offense for one space indentation of second line' do
-      inspect_source(cop, <<-RUBY.strip_indent)
+      inspect_source(<<-RUBY.strip_indent)
         a +
          b
       RUBY
@@ -77,7 +77,7 @@ describe RuboCop::Cop::Layout::MultilineOperationIndentation do
     end
 
     it 'registers an offense for three spaces indentation of second line' do
-      inspect_source(cop, <<-RUBY.strip_indent)
+      inspect_source(<<-RUBY.strip_indent)
         a ||
            b
         c and
@@ -89,7 +89,7 @@ describe RuboCop::Cop::Layout::MultilineOperationIndentation do
     end
 
     it 'registers an offense for extra indentation of third line' do
-      inspect_source(cop, <<-RUBY.strip_margin('|'))
+      inspect_source(<<-RUBY.strip_margin('|'))
         |   a ||
         |     b ||
         |       c
@@ -101,7 +101,7 @@ describe RuboCop::Cop::Layout::MultilineOperationIndentation do
 
     it 'registers an offense for the emacs ruby-mode 1.1 indentation of an ' \
        'expression in an array' do
-      inspect_source(cop, <<-RUBY.strip_margin('|'))
+      inspect_source(<<-RUBY.strip_margin('|'))
         |  [
         |   a +
         |   b
@@ -113,7 +113,7 @@ describe RuboCop::Cop::Layout::MultilineOperationIndentation do
     end
 
     it 'accepts indented operands in an array' do
-      inspect_source(cop, <<-RUBY.strip_margin('|'))
+      inspect_source(<<-RUBY.strip_margin('|'))
         |    dm[i][j] = [
         |      dm[i-1][j-1] +
         |        (this[j-1] == that[i-1] ? 0 : sub),
@@ -125,7 +125,7 @@ describe RuboCop::Cop::Layout::MultilineOperationIndentation do
     end
 
     it 'accepts two spaces indentation in assignment of local variable' do
-      inspect_source(cop, <<-RUBY.strip_indent)
+      inspect_source(<<-RUBY.strip_indent)
         a =
           'foo' +
           'bar'
@@ -134,7 +134,7 @@ describe RuboCop::Cop::Layout::MultilineOperationIndentation do
     end
 
     it 'accepts two spaces indentation in assignment of array element' do
-      inspect_source(cop, <<-RUBY.strip_indent)
+      inspect_source(<<-RUBY.strip_indent)
         a['test'] =
           'foo' +
           'bar'
@@ -143,7 +143,7 @@ describe RuboCop::Cop::Layout::MultilineOperationIndentation do
     end
 
     it 'accepts two spaces indentation of second line' do
-      inspect_source(cop, <<-RUBY.strip_margin('|'))
+      inspect_source(<<-RUBY.strip_margin('|'))
         |   a ||
         |     b
       RUBY
@@ -151,7 +151,7 @@ describe RuboCop::Cop::Layout::MultilineOperationIndentation do
     end
 
     it 'accepts no extra indentation of third line' do
-      inspect_source(cop, <<-RUBY.strip_margin('|'))
+      inspect_source(<<-RUBY.strip_margin('|'))
         |   a &&
         |     b &&
         |     c
@@ -160,7 +160,7 @@ describe RuboCop::Cop::Layout::MultilineOperationIndentation do
     end
 
     it 'accepts indented operands in for body' do
-      inspect_source(cop, <<-RUBY.strip_indent)
+      inspect_source(<<-RUBY.strip_indent)
         for x in a
           something &&
             something_else
@@ -170,7 +170,7 @@ describe RuboCop::Cop::Layout::MultilineOperationIndentation do
     end
 
     it 'accepts alignment inside a grouped expression' do
-      inspect_source(cop, <<-RUBY.strip_indent)
+      inspect_source(<<-RUBY.strip_indent)
         (a +
          b)
       RUBY
@@ -178,7 +178,7 @@ describe RuboCop::Cop::Layout::MultilineOperationIndentation do
     end
 
     it 'accepts an expression where the first operand spans multiple lines' do
-      inspect_source(cop, <<-RUBY.strip_indent)
+      inspect_source(<<-RUBY.strip_indent)
         subject.each do |item|
           result = resolve(locale) and return result
         end and nil
@@ -187,7 +187,7 @@ describe RuboCop::Cop::Layout::MultilineOperationIndentation do
     end
 
     it 'accepts any indentation of parameters to #[]' do
-      inspect_source(cop, <<-RUBY.strip_indent)
+      inspect_source(<<-RUBY.strip_indent)
         payment = Models::IncomingPayments[
                 id:      input['incoming-payment-id'],
                    user_id: @user[:id]]
@@ -197,7 +197,7 @@ describe RuboCop::Cop::Layout::MultilineOperationIndentation do
 
     it 'registers an offense for an unindented multiline operation that is ' \
        'the left operand in another operation' do
-      inspect_source(cop, <<-RUBY.strip_indent)
+      inspect_source(<<-RUBY.strip_indent)
         a +
         b < 3
       RUBY
@@ -222,7 +222,7 @@ describe RuboCop::Cop::Layout::MultilineOperationIndentation do
     end
 
     it 'registers an offense for indented operands in if condition' do
-      inspect_source(cop, <<-RUBY.strip_indent)
+      inspect_source(<<-RUBY.strip_indent)
         if a +
             b
           something
@@ -258,7 +258,7 @@ describe RuboCop::Cop::Layout::MultilineOperationIndentation do
     end
 
     it 'registers an offense for indented second part of string' do
-      inspect_source(cop, <<-RUBY.strip_indent)
+      inspect_source(<<-RUBY.strip_indent)
         it "should convert " +
           "a to " +
           "b" do
@@ -271,7 +271,7 @@ describe RuboCop::Cop::Layout::MultilineOperationIndentation do
     end
 
     it 'registers an offense for indented operand in second argument' do
-      inspect_source(cop, <<-RUBY.strip_indent)
+      inspect_source(<<-RUBY.strip_indent)
         puts a, 1 +
           2
       RUBY
@@ -283,8 +283,7 @@ describe RuboCop::Cop::Layout::MultilineOperationIndentation do
 
     it 'registers an offense for misaligned string operand when the first ' \
        'operand has backslash continuation' do
-      inspect_source(cop,
-                     ['def f',
+      inspect_source(['def f',
                       "  flash[:error] = 'Here is a string ' \\",
                       "                  'That spans' <<",
                       "    'multiple lines'",
@@ -304,7 +303,7 @@ describe RuboCop::Cop::Layout::MultilineOperationIndentation do
     end
 
     it 'registers an offense for misaligned operands in unless condition' do
-      inspect_source(cop, <<-RUBY.strip_indent)
+      inspect_source(<<-RUBY.strip_indent)
         unless a +
           b
           something
@@ -325,7 +324,7 @@ describe RuboCop::Cop::Layout::MultilineOperationIndentation do
     ].each do |article, keyword|
       it "registers an offense for misaligned operands in #{keyword} " \
          'condition' do
-        inspect_source(cop, <<-RUBY.strip_indent)
+        inspect_source(<<-RUBY.strip_indent)
           #{keyword} a or
               b
             something
@@ -395,7 +394,7 @@ describe RuboCop::Cop::Layout::MultilineOperationIndentation do
     end
 
     it 'registers an offense for aligned operands in if condition' do
-      inspect_source(cop, <<-RUBY.strip_indent)
+      inspect_source(<<-RUBY.strip_indent)
         if a +
            b
           something
@@ -457,7 +456,7 @@ describe RuboCop::Cop::Layout::MultilineOperationIndentation do
       %w[an until]
     ].each do |article, keyword|
       it "accepts double indentation of #{keyword} condition" do
-        inspect_source(cop, <<-RUBY.strip_indent)
+        inspect_source(<<-RUBY.strip_indent)
           #{keyword} receiver.nil? &&
               !args.empty? &&
               BLACKLIST.include?(method_name)
@@ -471,7 +470,7 @@ describe RuboCop::Cop::Layout::MultilineOperationIndentation do
 
       it "registers an offense for a 2 space indentation of #{keyword} " \
          'condition' do
-        inspect_source(cop, <<-RUBY.strip_indent)
+        inspect_source(<<-RUBY.strip_indent)
           #{keyword} receiver.nil? &&
             !args.empty? &&
             BLACKLIST.include?(method_name)
@@ -485,7 +484,7 @@ describe RuboCop::Cop::Layout::MultilineOperationIndentation do
       end
 
       it "accepts indented operands in #{keyword} body" do
-        inspect_source(cop, <<-RUBY.strip_indent)
+        inspect_source(<<-RUBY.strip_indent)
           #{keyword} a
             something &&
               something_else
@@ -497,7 +496,7 @@ describe RuboCop::Cop::Layout::MultilineOperationIndentation do
 
     %w[unless if].each do |keyword|
       it "accepts special indentation of return #{keyword} condition" do
-        inspect_source(cop, <<-RUBY.strip_indent)
+        inspect_source(<<-RUBY.strip_indent)
           return #{keyword} receiver.nil? &&
               !args.empty? &&
               BLACKLIST.include?(method_name)
@@ -532,7 +531,7 @@ describe RuboCop::Cop::Layout::MultilineOperationIndentation do
     end
 
     it 'registers an offense for correct + unrecognized style' do
-      inspect_source(cop, <<-RUBY.strip_indent)
+      inspect_source(<<-RUBY.strip_indent)
         a ||
           b
         c and
@@ -594,7 +593,7 @@ describe RuboCop::Cop::Layout::MultilineOperationIndentation do
           # normal code indentation is 2 spaces, and we have configured
           # multiline method indentation to 6 spaces
           # so in this case, 8 spaces are required
-          inspect_source(cop, <<-RUBY.strip_indent)
+          inspect_source(<<-RUBY.strip_indent)
             #{keyword} receiver.nil? &&
                     !args.empty? &&
                     BLACKLIST.include?(method_name)
@@ -608,7 +607,7 @@ describe RuboCop::Cop::Layout::MultilineOperationIndentation do
 
         it "registers an offense for a 4 space indentation of #{keyword} " \
            'condition' do
-          inspect_source(cop, <<-RUBY.strip_indent)
+          inspect_source(<<-RUBY.strip_indent)
             #{keyword} receiver.nil? &&
                 !args.empty? &&
                 BLACKLIST.include?(method_name)
@@ -622,7 +621,7 @@ describe RuboCop::Cop::Layout::MultilineOperationIndentation do
         end
 
         it "accepts indented operands in #{keyword} body" do
-          inspect_source(cop, <<-RUBY.strip_indent)
+          inspect_source(<<-RUBY.strip_indent)
             #{keyword} a
               something &&
                     something_else

--- a/spec/rubocop/cop/layout/multiline_operation_indentation_spec.rb
+++ b/spec/rubocop/cop/layout/multiline_operation_indentation_spec.rb
@@ -364,7 +364,7 @@ describe RuboCop::Cop::Layout::MultilineOperationIndentation do
     end
 
     it 'auto-corrects' do
-      new_source = autocorrect_source(cop, <<-RUBY.strip_indent)
+      new_source = autocorrect_source(<<-RUBY.strip_indent)
         until a +
             b
           something
@@ -556,7 +556,7 @@ describe RuboCop::Cop::Layout::MultilineOperationIndentation do
     end
 
     it 'auto-corrects' do
-      new_source = autocorrect_source(cop, <<-RUBY.strip_indent)
+      new_source = autocorrect_source(<<-RUBY.strip_indent)
         until a +
               b
           something
@@ -632,7 +632,7 @@ describe RuboCop::Cop::Layout::MultilineOperationIndentation do
       end
 
       it 'auto-corrects' do
-        new_source = autocorrect_source(cop, <<-RUBY.strip_indent)
+        new_source = autocorrect_source(<<-RUBY.strip_indent)
           until a +
                 b
             something

--- a/spec/rubocop/cop/layout/rescue_ensure_alignment_spec.rb
+++ b/spec/rubocop/cop/layout/rescue_ensure_alignment_spec.rb
@@ -72,7 +72,7 @@ describe RuboCop::Cop::Layout::RescueEnsureAlignment do
       end
 
       it 'auto-corrects' do
-        corrected = autocorrect_source(cop, <<-RUBY.strip_indent)
+        corrected = autocorrect_source(<<-RUBY.strip_indent)
           begin
             something
               #{keyword}

--- a/spec/rubocop/cop/layout/rescue_ensure_alignment_spec.rb
+++ b/spec/rubocop/cop/layout/rescue_ensure_alignment_spec.rb
@@ -6,7 +6,7 @@ describe RuboCop::Cop::Layout::RescueEnsureAlignment do
   shared_examples 'common behavior' do |keyword|
     context 'bad alignment' do
       it 'registers an offense when used with begin' do
-        inspect_source(cop, <<-RUBY.strip_indent)
+        inspect_source(<<-RUBY.strip_indent)
           begin
             something
               #{keyword}
@@ -18,7 +18,7 @@ describe RuboCop::Cop::Layout::RescueEnsureAlignment do
       end
 
       it 'registers an offense when used with def' do
-        inspect_source(cop, <<-RUBY.strip_indent)
+        inspect_source(<<-RUBY.strip_indent)
           def test
             something
               #{keyword}
@@ -30,7 +30,7 @@ describe RuboCop::Cop::Layout::RescueEnsureAlignment do
       end
 
       it 'registers an offense when used with defs' do
-        inspect_source(cop, <<-RUBY.strip_indent)
+        inspect_source(<<-RUBY.strip_indent)
           def Test.test
             something
               #{keyword}
@@ -42,7 +42,7 @@ describe RuboCop::Cop::Layout::RescueEnsureAlignment do
       end
 
       it 'registers an offense when used with class' do
-        inspect_source(cop, <<-RUBY.strip_indent)
+        inspect_source(<<-RUBY.strip_indent)
           class C
             something
               #{keyword}
@@ -54,7 +54,7 @@ describe RuboCop::Cop::Layout::RescueEnsureAlignment do
       end
 
       it 'registers an offense when used with module' do
-        inspect_source(cop, <<-RUBY.strip_indent)
+        inspect_source(<<-RUBY.strip_indent)
           module M
             something
               #{keyword}
@@ -66,7 +66,7 @@ describe RuboCop::Cop::Layout::RescueEnsureAlignment do
       end
 
       it 'accepts rescue and ensure on the same line' do
-        inspect_source(cop, 'begin; puts 1; rescue; ensure; puts 2; end')
+        inspect_source('begin; puts 1; rescue; ensure; puts 2; end')
 
         expect(cop.messages).to be_empty
       end
@@ -90,11 +90,11 @@ describe RuboCop::Cop::Layout::RescueEnsureAlignment do
     end
 
     it 'accepts correct alignment' do
-      inspect_source(cop, ['begin',
-                           '  something',
-                           keyword,
-                           '    error',
-                           'end'])
+      inspect_source(['begin',
+                      '  something',
+                      keyword,
+                      '    error',
+                      'end'])
       expect(cop.messages).to be_empty
     end
   end

--- a/spec/rubocop/cop/layout/space_after_colon_spec.rb
+++ b/spec/rubocop/cop/layout/space_after_colon_spec.rb
@@ -63,7 +63,7 @@ describe RuboCop::Cop::Layout::SpaceAfterColon do
   end
 
   it 'auto-corrects missing space' do
-    new_source = autocorrect_source(cop, 'def f(a:, b:2); {a:3}; end')
+    new_source = autocorrect_source('def f(a:, b:2); {a:3}; end')
     expect(new_source).to eq('def f(a:, b: 2); {a: 3}; end')
   end
 end

--- a/spec/rubocop/cop/layout/space_after_comma_spec.rb
+++ b/spec/rubocop/cop/layout/space_after_comma_spec.rb
@@ -9,7 +9,7 @@ describe RuboCop::Cop::Layout::SpaceAfterComma do
 
   shared_examples 'ends with an item' do |items, correct_items|
     it 'registers an offense' do
-      inspect_source(cop, source.call(items))
+      inspect_source(source.call(items))
       expect(cop.messages).to eq(
         ['Space missing after comma.']
       )
@@ -23,7 +23,7 @@ describe RuboCop::Cop::Layout::SpaceAfterComma do
 
   shared_examples 'trailing comma' do |items|
     it 'accepts the last comma' do
-      inspect_source(cop, source.call(items))
+      inspect_source(source.call(items))
       expect(cop.messages).to be_empty
     end
   end
@@ -51,7 +51,7 @@ describe RuboCop::Cop::Layout::SpaceAfterComma do
   context 'inside hash braces' do
     shared_examples 'common behavior' do
       it 'accepts a space between a comma and a closing brace' do
-        inspect_source(cop, '{ foo:bar, }')
+        inspect_source('{ foo:bar, }')
         expect(cop.messages).to be_empty
       end
     end
@@ -65,7 +65,7 @@ describe RuboCop::Cop::Layout::SpaceAfterComma do
 
       it 'registers an offense for no space between a comma and a ' \
          'closing brace' do
-        inspect_source(cop, '{ foo:bar,}')
+        inspect_source('{ foo:bar,}')
         expect(cop.messages).to eq(['Space missing after comma.'])
       end
     end

--- a/spec/rubocop/cop/layout/space_after_comma_spec.rb
+++ b/spec/rubocop/cop/layout/space_after_comma_spec.rb
@@ -16,7 +16,7 @@ describe RuboCop::Cop::Layout::SpaceAfterComma do
     end
 
     it 'does auto-correction' do
-      new_source = autocorrect_source(cop, source.call(items))
+      new_source = autocorrect_source(source.call(items))
       expect(new_source).to eq source.call(correct_items)
     end
   end

--- a/spec/rubocop/cop/layout/space_after_method_name_spec.rb
+++ b/spec/rubocop/cop/layout/space_after_method_name_spec.rb
@@ -54,7 +54,7 @@ describe RuboCop::Cop::Layout::SpaceAfterMethodName do
   end
 
   it 'auto-corrects unwanted space' do
-    new_source = autocorrect_source(cop, <<-RUBY.strip_indent)
+    new_source = autocorrect_source(<<-RUBY.strip_indent)
       def func (x)
         a
       end

--- a/spec/rubocop/cop/layout/space_after_not_spec.rb
+++ b/spec/rubocop/cop/layout/space_after_not_spec.rb
@@ -20,7 +20,7 @@ describe RuboCop::Cop::Layout::SpaceAfterNot do
 
   it 'reports an offense for space after ! with the negated receiver ' \
      'wrapped in parentheses' do
-    inspect_source(cop, '! (model)')
+    inspect_source('! (model)')
 
     expect(cop.messages)
       .to eq(['Do not leave space between `!` and its argument.'])

--- a/spec/rubocop/cop/layout/space_after_not_spec.rb
+++ b/spec/rubocop/cop/layout/space_after_not_spec.rb
@@ -29,19 +29,19 @@ describe RuboCop::Cop::Layout::SpaceAfterNot do
 
   context 'auto-correct' do
     it 'removes redundant space' do
-      new_source = autocorrect_source(cop, '!  something')
+      new_source = autocorrect_source('!  something')
 
       expect(new_source).to eq('!something')
     end
 
     it 'keeps space after not keyword' do
-      new_source = autocorrect_source(cop, 'not something')
+      new_source = autocorrect_source('not something')
 
       expect(new_source).to eq('not something')
     end
 
     it 'removes redundant space when there is a parentheses' do
-      new_source = autocorrect_source(cop, '!  (model)')
+      new_source = autocorrect_source('!  (model)')
 
       expect(new_source).to eq('!(model)')
     end

--- a/spec/rubocop/cop/layout/space_after_semicolon_spec.rb
+++ b/spec/rubocop/cop/layout/space_after_semicolon_spec.rb
@@ -26,7 +26,7 @@ describe RuboCop::Cop::Layout::SpaceAfterSemicolon do
   context 'inside block braces' do
     shared_examples 'common behavior' do
       it 'accepts a space between a semicolon and a closing brace' do
-        inspect_source(cop, 'test { ; }')
+        inspect_source('test { ; }')
         expect(cop.messages).to be_empty
       end
     end
@@ -40,7 +40,7 @@ describe RuboCop::Cop::Layout::SpaceAfterSemicolon do
 
       it 'registers an offense for no space between a semicolon and a ' \
          'closing brace' do
-        inspect_source(cop, 'test { ;}')
+        inspect_source('test { ;}')
         expect(cop.messages).to eq(['Space missing after semicolon.'])
       end
     end

--- a/spec/rubocop/cop/layout/space_after_semicolon_spec.rb
+++ b/spec/rubocop/cop/layout/space_after_semicolon_spec.rb
@@ -19,7 +19,7 @@ describe RuboCop::Cop::Layout::SpaceAfterSemicolon do
   end
 
   it 'auto-corrects missing space' do
-    new_source = autocorrect_source(cop, 'x = 1;y = 2')
+    new_source = autocorrect_source('x = 1;y = 2')
     expect(new_source).to eq('x = 1; y = 2')
   end
 

--- a/spec/rubocop/cop/layout/space_around_block_parameters_spec.rb
+++ b/spec/rubocop/cop/layout/space_around_block_parameters_spec.rb
@@ -103,14 +103,12 @@ describe RuboCop::Cop::Layout::SpaceAroundBlockParameters, :config do
     end
 
     it 'auto-corrects offenses' do
-      new_source = autocorrect_source(cop,
-                                      '{}.each { |  x=5,  (y,*z) |puts x }')
+      new_source = autocorrect_source('{}.each { |  x=5,  (y,*z) |puts x }')
       expect(new_source).to eq('{}.each { |x=5, (y,*z)| puts x }')
     end
 
     it 'auto-corrects offenses for a lambda' do
-      new_source = autocorrect_source(cop,
-                                      '->(  a,  b, c) { puts a }')
+      new_source = autocorrect_source('->(  a,  b, c) { puts a }')
       expect(new_source).to eq('->(a, b, c) { puts a }')
     end
   end
@@ -231,14 +229,12 @@ describe RuboCop::Cop::Layout::SpaceAroundBlockParameters, :config do
     end
 
     it 'auto-corrects offenses' do
-      new_source = autocorrect_source(cop,
-                                      '{}.each { |  x=5,  (y,*z)|puts x }')
+      new_source = autocorrect_source('{}.each { |  x=5,  (y,*z)|puts x }')
       expect(new_source).to eq('{}.each { | x=5, (y,*z) | puts x }')
     end
 
     it 'auto-corrects offenses' do
-      new_source = autocorrect_source(cop,
-                                      '->(  x,  y) { puts x }')
+      new_source = autocorrect_source('->(  x,  y) { puts x }')
       expect(new_source).to eq('->( x, y ) { puts x }')
     end
   end

--- a/spec/rubocop/cop/layout/space_around_equals_in_parameter_default_spec.rb
+++ b/spec/rubocop/cop/layout/space_around_equals_in_parameter_default_spec.rb
@@ -42,7 +42,7 @@ describe RuboCop::Cop::Layout::SpaceAroundEqualsInParameterDefault, :config do
     end
 
     it 'auto-corrects missing space' do
-      new_source = autocorrect_source(cop, ['def f(x, y=0, z=1)', 'end'])
+      new_source = autocorrect_source(['def f(x, y=0, z=1)', 'end'])
       expect(new_source).to eq(['def f(x, y = 0, z = 1)', 'end'].join("\n"))
     end
 
@@ -54,7 +54,7 @@ describe RuboCop::Cop::Layout::SpaceAroundEqualsInParameterDefault, :config do
     end
 
     it 'auto-corrects missing space for arguments with unary operators' do
-      new_source = autocorrect_source(cop, <<-RUBY.strip_indent)
+      new_source = autocorrect_source(<<-RUBY.strip_indent)
         def f(x=-1, y= 0, z =+1)
         end
       RUBY
@@ -104,7 +104,7 @@ describe RuboCop::Cop::Layout::SpaceAroundEqualsInParameterDefault, :config do
     end
 
     it 'auto-corrects unwanted space' do
-      new_source = autocorrect_source(cop, <<-RUBY.strip_indent)
+      new_source = autocorrect_source(<<-RUBY.strip_indent)
         def f(x, y = 0, z= 1, w= 2)
         end
       RUBY

--- a/spec/rubocop/cop/layout/space_around_equals_in_parameter_default_spec.rb
+++ b/spec/rubocop/cop/layout/space_around_equals_in_parameter_default_spec.rb
@@ -7,7 +7,7 @@ describe RuboCop::Cop::Layout::SpaceAroundEqualsInParameterDefault, :config do
     let(:cop_config) { { 'EnforcedStyle' => 'space' } }
 
     it 'registers an offense for default value assignment without space' do
-      inspect_source(cop, <<-RUBY.strip_indent)
+      inspect_source(<<-RUBY.strip_indent)
         def f(x, y=0, z= 1)
         end
       RUBY
@@ -18,7 +18,7 @@ describe RuboCop::Cop::Layout::SpaceAroundEqualsInParameterDefault, :config do
     end
 
     it 'registers an offense for assignment empty string without space' do
-      inspect_source(cop, <<-RUBY.strip_indent)
+      inspect_source(<<-RUBY.strip_indent)
         def f(x, y="", z=1)
         end
       RUBY
@@ -69,7 +69,7 @@ describe RuboCop::Cop::Layout::SpaceAroundEqualsInParameterDefault, :config do
     let(:cop_config) { { 'EnforcedStyle' => 'no_space' } }
 
     it 'registers an offense for default value assignment with space' do
-      inspect_source(cop, <<-RUBY.strip_indent)
+      inspect_source(<<-RUBY.strip_indent)
         def f(x, y = 0, z =1, w= 2)
         end
       RUBY
@@ -80,7 +80,7 @@ describe RuboCop::Cop::Layout::SpaceAroundEqualsInParameterDefault, :config do
     end
 
     it 'registers an offense for assignment empty string with space' do
-      inspect_source(cop, <<-RUBY.strip_indent)
+      inspect_source(<<-RUBY.strip_indent)
         def f(x, y = "", z = 1)
         end
       RUBY

--- a/spec/rubocop/cop/layout/space_around_keyword_spec.rb
+++ b/spec/rubocop/cop/layout/space_around_keyword_spec.rb
@@ -13,7 +13,7 @@ describe RuboCop::Cop::Layout::SpaceAroundKeyword do
     end
 
     it 'auto-corrects' do
-      expect(autocorrect_source(cop, expr)).to eq correct
+      expect(autocorrect_source(expr)).to eq correct
     end
   end
 
@@ -27,7 +27,7 @@ describe RuboCop::Cop::Layout::SpaceAroundKeyword do
     end
 
     it 'auto-corrects' do
-      expect(autocorrect_source(cop, expr)).to eq correct
+      expect(autocorrect_source(expr)).to eq correct
     end
   end
 

--- a/spec/rubocop/cop/layout/space_around_keyword_spec.rb
+++ b/spec/rubocop/cop/layout/space_around_keyword_spec.rb
@@ -6,7 +6,7 @@ describe RuboCop::Cop::Layout::SpaceAroundKeyword do
   shared_examples 'missing before' do |highlight, expr, correct|
     it 'registers an offense for missing space before keyword in ' \
        "`#{expr}`" do
-      inspect_source(cop, expr)
+      inspect_source(expr)
       expect(cop.messages)
         .to eq(["Space before keyword `#{highlight}` is missing."])
       expect(cop.highlights).to eq([highlight])
@@ -20,7 +20,7 @@ describe RuboCop::Cop::Layout::SpaceAroundKeyword do
   shared_examples 'missing after' do |highlight, expr, correct|
     it 'registers an offense for missing space after keyword in ' \
        "`#{expr}`" do
-      inspect_source(cop, expr)
+      inspect_source(expr)
       expect(cop.messages)
         .to eq(["Space after keyword `#{highlight}` is missing."])
       expect(cop.highlights).to eq([highlight])
@@ -33,21 +33,21 @@ describe RuboCop::Cop::Layout::SpaceAroundKeyword do
 
   shared_examples 'accept before' do |after, expr|
     it "accepts `#{after}` before keyword in `#{expr}`" do
-      inspect_source(cop, expr)
+      inspect_source(expr)
       expect(cop.offenses).to be_empty
     end
   end
 
   shared_examples 'accept after' do |after, expr|
     it "accepts `#{after}` after keyword in `#{expr}`" do
-      inspect_source(cop, expr)
+      inspect_source(expr)
       expect(cop.offenses).to be_empty
     end
   end
 
   shared_examples 'accept around' do |after, expr|
     it "accepts `#{after}` around keyword in `#{expr}`" do
-      inspect_source(cop, expr)
+      inspect_source(expr)
       expect(cop.offenses).to be_empty
     end
   end

--- a/spec/rubocop/cop/layout/space_around_operators_spec.rb
+++ b/spec/rubocop/cop/layout/space_around_operators_spec.rb
@@ -140,7 +140,7 @@ describe RuboCop::Cop::Layout::SpaceAroundOperators do
   end
 
   it 'auto-corrects unwanted space around **' do
-    new_source = autocorrect_source(cop, <<-RUBY.strip_indent)
+    new_source = autocorrect_source(<<-RUBY.strip_indent)
       x = a * b ** 2
       y = a * b** 2
     RUBY
@@ -205,7 +205,7 @@ describe RuboCop::Cop::Layout::SpaceAroundOperators do
           ['Surrounding space missing for operator `=`.'] * 2
         )
 
-        new_source = autocorrect_source(cop, src)
+        new_source = autocorrect_source(src)
         expect(new_source).to eq(<<-RUBY.strip_indent)
           a = 1 #{keyword} condition
           c = 2
@@ -225,7 +225,7 @@ describe RuboCop::Cop::Layout::SpaceAroundOperators do
     end
 
     it 'auto-corrects assignment without space on both sides' do
-      new_source = autocorrect_source(cop, ['x=0', 'y= 0', 'z =0'])
+      new_source = autocorrect_source(['x=0', 'y= 0', 'z =0'])
       expect(new_source).to eq(['x = 0', 'y = 0', 'z = 0'].join("\n"))
     end
 
@@ -255,7 +255,7 @@ describe RuboCop::Cop::Layout::SpaceAroundOperators do
       end
 
       it 'auto-corrects a ternary operator without space' do
-        new_source = autocorrect_source(cop, 'x == 0?1:2')
+        new_source = autocorrect_source('x == 0?1:2')
         expect(new_source).to eq('x == 0 ? 1 : 2')
       end
     end
@@ -277,7 +277,7 @@ describe RuboCop::Cop::Layout::SpaceAroundOperators do
     end
 
     it 'auto-corrects missing space in binary operators that could be unary' do
-      new_source = autocorrect_source(cop, ['a-3', 'x&0xff', 'z+0'])
+      new_source = autocorrect_source(['a-3', 'x&0xff', 'z+0'])
       expect(new_source).to eq(['a - 3', 'x & 0xff', 'z + 0'].join("\n"))
     end
 
@@ -289,7 +289,7 @@ describe RuboCop::Cop::Layout::SpaceAroundOperators do
     end
 
     it 'auto-corrects missing space in arguments to a method' do
-      new_source = autocorrect_source(cop, 'puts 1+2')
+      new_source = autocorrect_source('puts 1+2')
       expect(new_source).to eq('puts 1 + 2')
     end
 
@@ -313,7 +313,7 @@ describe RuboCop::Cop::Layout::SpaceAroundOperators do
     end
 
     it 'auto-corrects missing space' do
-      new_source = autocorrect_source(cop, <<-RUBY.strip_indent)
+      new_source = autocorrect_source(<<-RUBY.strip_indent)
         x+= a+b-c*d/e%f^g|h&i||j
         y -=k&&l
       RUBY
@@ -455,7 +455,7 @@ describe RuboCop::Cop::Layout::SpaceAroundOperators do
     end
 
     it "doesn't eat a newline when auto-correcting" do
-      new_source = autocorrect_source(cop, <<-RUBY.strip_indent)
+      new_source = autocorrect_source(<<-RUBY.strip_indent)
         'Here is a'+
         'joined string'+
         'across three lines'
@@ -489,7 +489,7 @@ describe RuboCop::Cop::Layout::SpaceAroundOperators do
           ['Operator `=` should be surrounded by a single space.'] * 2
         )
 
-        new_source = autocorrect_source(cop, src)
+        new_source = autocorrect_source(src)
         expect(new_source).to eq(<<-RUBY.strip_indent)
           a = 1 #{keyword} condition
           c = 2
@@ -509,7 +509,7 @@ describe RuboCop::Cop::Layout::SpaceAroundOperators do
     end
 
     it 'auto-corrects assignment with too many spaces on either side' do
-      new_source = autocorrect_source(cop, <<-RUBY.strip_indent)
+      new_source = autocorrect_source(<<-RUBY.strip_indent)
         x  = 0
         y =   0
         z  =   0
@@ -530,7 +530,7 @@ describe RuboCop::Cop::Layout::SpaceAroundOperators do
     end
 
     it 'auto-corrects a ternary operator too many spaces' do
-      new_source = autocorrect_source(cop, 'x == 0  ? 1 :  2')
+      new_source = autocorrect_source('x == 0  ? 1 :  2')
       expect(new_source).to eq('x == 0 ? 1 : 2')
     end
 
@@ -551,7 +551,7 @@ describe RuboCop::Cop::Layout::SpaceAroundOperators do
     end
 
     it 'auto-corrects missing space in binary operators that could be unary' do
-      new_source = autocorrect_source(cop, <<-RUBY.strip_indent)
+      new_source = autocorrect_source(<<-RUBY.strip_indent)
         a -  3
         x &   0xff
         z +  0
@@ -571,7 +571,7 @@ describe RuboCop::Cop::Layout::SpaceAroundOperators do
     end
 
     it 'auto-corrects missing space in arguments to a method' do
-      new_source = autocorrect_source(cop, 'puts 1 +  2')
+      new_source = autocorrect_source('puts 1 +  2')
       expect(new_source).to eq('puts 1 + 2')
     end
 
@@ -605,7 +605,6 @@ describe RuboCop::Cop::Layout::SpaceAroundOperators do
 
     it 'auto-corrects missing space' do
       new_source = autocorrect_source(
-        cop,
         <<-RUBY.strip_indent
           x +=  a  + b -  c  * d /  e  % f  ^ g   | h &  i  ||  j
           y  -=  k   &&        l

--- a/spec/rubocop/cop/layout/space_around_operators_spec.rb
+++ b/spec/rubocop/cop/layout/space_around_operators_spec.rb
@@ -199,7 +199,7 @@ describe RuboCop::Cop::Layout::SpaceAroundOperators do
           a=1 #{keyword} condition
           c=2
         RUBY
-        inspect_source(cop, src)
+        inspect_source(src)
         expect(cop.offenses.map(&:line)).to eq([1, 2])
         expect(cop.messages).to eq(
           ['Surrounding space missing for operator `=`.'] * 2
@@ -331,7 +331,7 @@ describe RuboCop::Cop::Layout::SpaceAroundOperators do
     end
 
     context 'when a hash literal is on a single line' do
-      before { inspect_source(cop, '{ 1=>2, a: b }') }
+      before { inspect_source('{ 1=>2, a: b }') }
 
       context 'and Layout/AlignHash:EnforcedHashRocketStyle is key' do
         let(:hash_style) { 'key' }
@@ -354,7 +354,7 @@ describe RuboCop::Cop::Layout::SpaceAroundOperators do
 
     context 'when a hash literal is on multiple lines' do
       before do
-        inspect_source(cop, <<-RUBY.strip_indent)
+        inspect_source(<<-RUBY.strip_indent)
           {
             1=>2,
             a: b
@@ -483,7 +483,7 @@ describe RuboCop::Cop::Layout::SpaceAroundOperators do
           a =  1 #{keyword} condition
           c =   2
         RUBY
-        inspect_source(cop, src)
+        inspect_source(src)
         expect(cop.offenses.map(&:line)).to eq([1, 2])
         expect(cop.messages).to eq(
           ['Operator `=` should be surrounded by a single space.'] * 2
@@ -633,7 +633,7 @@ describe RuboCop::Cop::Layout::SpaceAroundOperators do
 
     it 'registers an offense for a hash rocket with an extra space' \
       'on multiple line' do
-      inspect_source(cop, <<-RUBY.strip_indent)
+      inspect_source(<<-RUBY.strip_indent)
         {
           1 =>  2
         }
@@ -645,7 +645,7 @@ describe RuboCop::Cop::Layout::SpaceAroundOperators do
 
     it 'accepts for a hash rocket with an extra space for alignment' \
       'on multiple line' do
-      inspect_source(cop, <<-RUBY.strip_indent)
+      inspect_source(<<-RUBY.strip_indent)
         {
           1 =>  2,
           11 => 3
@@ -717,7 +717,7 @@ describe RuboCop::Cop::Layout::SpaceAroundOperators do
 
     it 'registers an offense for - with too many spaces with ' \
        'negative lhs operand' do
-      inspect_source(cop, '-1  - arg')
+      inspect_source('-1  - arg')
       expect(cop.messages)
         .to eq(['Operator `-` should be surrounded by a single space.'])
     end

--- a/spec/rubocop/cop/layout/space_before_block_braces_spec.rb
+++ b/spec/rubocop/cop/layout/space_before_block_braces_spec.rb
@@ -10,14 +10,14 @@ describe RuboCop::Cop::Layout::SpaceBeforeBlockBraces, :config do
     end
 
     it 'registers an offense for left brace without outer space' do
-      inspect_source(cop, 'each{ puts }')
+      inspect_source('each{ puts }')
       expect(cop.messages).to eq(['Space missing to the left of {.'])
       expect(cop.highlights).to eq(['{'])
       expect(cop.config_to_allow_offenses).to eq('EnforcedStyle' => 'no_space')
     end
 
     it 'registers an offense for opposite + correct style' do
-      inspect_source(cop, <<-RUBY.strip_indent)
+      inspect_source(<<-RUBY.strip_indent)
         each{ puts }
         each { puts }
       RUBY
@@ -27,7 +27,7 @@ describe RuboCop::Cop::Layout::SpaceBeforeBlockBraces, :config do
 
     it 'registers an offense for multiline block where left brace has no ' \
        'outer space' do
-      inspect_source(cop, <<-RUBY.strip_indent)
+      inspect_source(<<-RUBY.strip_indent)
         foo.map{ |a|
           a.bar.to_s
         }
@@ -47,14 +47,14 @@ describe RuboCop::Cop::Layout::SpaceBeforeBlockBraces, :config do
     let(:cop_config) { { 'EnforcedStyle' => 'no_space' } }
 
     it 'registers an offense for braces surrounded by spaces' do
-      inspect_source(cop, 'each { puts }')
+      inspect_source('each { puts }')
       expect(cop.messages).to eq(['Space detected to the left of {.'])
       expect(cop.highlights).to eq([' '])
       expect(cop.config_to_allow_offenses).to eq('EnforcedStyle' => 'space')
     end
 
     it 'registers an offense for correct + opposite style' do
-      inspect_source(cop, <<-RUBY.strip_indent)
+      inspect_source(<<-RUBY.strip_indent)
         each{ puts }
         each { puts }
       RUBY

--- a/spec/rubocop/cop/layout/space_before_block_braces_spec.rb
+++ b/spec/rubocop/cop/layout/space_before_block_braces_spec.rb
@@ -38,7 +38,7 @@ describe RuboCop::Cop::Layout::SpaceBeforeBlockBraces, :config do
     end
 
     it 'auto-corrects missing space' do
-      new_source = autocorrect_source(cop, 'each{}')
+      new_source = autocorrect_source('each{}')
       expect(new_source).to eq('each {}')
     end
   end
@@ -63,7 +63,7 @@ describe RuboCop::Cop::Layout::SpaceBeforeBlockBraces, :config do
     end
 
     it 'auto-corrects unwanted space' do
-      new_source = autocorrect_source(cop, 'each {}')
+      new_source = autocorrect_source('each {}')
       expect(new_source).to eq('each{}')
     end
 

--- a/spec/rubocop/cop/layout/space_before_comma_spec.rb
+++ b/spec/rubocop/cop/layout/space_before_comma_spec.rb
@@ -29,14 +29,12 @@ describe RuboCop::Cop::Layout::SpaceBeforeComma do
   end
 
   it 'auto-corrects space before comma' do
-    new_source = autocorrect_source(cop,
-                                    'each { |s , t| a(1 , formats[0 , 1])}')
+    new_source = autocorrect_source('each { |s , t| a(1 , formats[0 , 1])}')
     expect(new_source).to eq('each { |s, t| a(1, formats[0, 1])}')
   end
 
   it 'handles more than one space before a comma' do
-    new_source = autocorrect_source(cop,
-                                    'each { |s  , t| a(1  , formats[0  , 1])}')
+    new_source = autocorrect_source('each { |s  , t| a(1  , formats[0  , 1])}')
     expect(new_source).to eq('each { |s, t| a(1, formats[0, 1])}')
   end
 end

--- a/spec/rubocop/cop/layout/space_before_comment_spec.rb
+++ b/spec/rubocop/cop/layout/space_before_comment_spec.rb
@@ -27,7 +27,7 @@ describe RuboCop::Cop::Layout::SpaceBeforeComment do
   end
 
   it 'auto-corrects missing space' do
-    new_source = autocorrect_source(cop, 'a += 1# increment')
+    new_source = autocorrect_source('a += 1# increment')
     expect(new_source).to eq('a += 1 # increment')
   end
 end

--- a/spec/rubocop/cop/layout/space_before_first_arg_spec.rb
+++ b/spec/rubocop/cop/layout/space_before_first_arg_spec.rb
@@ -18,7 +18,7 @@ describe RuboCop::Cop::Layout::SpaceBeforeFirstArg, :config do
     end
 
     it 'auto-corrects extra space' do
-      new_source = autocorrect_source(cop, <<-RUBY.strip_indent)
+      new_source = autocorrect_source(<<-RUBY.strip_indent)
         something  x
         a.something   y, z
       RUBY
@@ -40,7 +40,7 @@ describe RuboCop::Cop::Layout::SpaceBeforeFirstArg, :config do
     end
 
     it 'auto-corrects missing space' do
-      new_source = autocorrect_source(cop, <<-RUBY.strip_indent)
+      new_source = autocorrect_source(<<-RUBY.strip_indent)
         something'hello'
         a.something'hello world'
       RUBY

--- a/spec/rubocop/cop/layout/space_before_first_arg_spec.rb
+++ b/spec/rubocop/cop/layout/space_before_first_arg_spec.rb
@@ -7,7 +7,7 @@ describe RuboCop::Cop::Layout::SpaceBeforeFirstArg, :config do
   context 'for method calls without parentheses' do
     it 'registers an offense for method call with two spaces before the ' \
        'first arg' do
-      inspect_source(cop, <<-RUBY.strip_indent)
+      inspect_source(<<-RUBY.strip_indent)
         something  x
         a.something  y, z
       RUBY
@@ -30,7 +30,7 @@ describe RuboCop::Cop::Layout::SpaceBeforeFirstArg, :config do
 
     it 'registers an offense for method call with no spaces before the '\
        'first arg' do
-      inspect_source(cop, <<-RUBY.strip_indent)
+      inspect_source(<<-RUBY.strip_indent)
         something'hello'
         a.something'hello world'
       RUBY

--- a/spec/rubocop/cop/layout/space_before_semicolon_spec.rb
+++ b/spec/rubocop/cop/layout/space_before_semicolon_spec.rb
@@ -31,7 +31,7 @@ describe RuboCop::Cop::Layout::SpaceBeforeSemicolon do
   context 'inside block braces' do
     shared_examples 'common behavior' do
       it 'accepts no space between an opening brace and a semicolon' do
-        inspect_source(cop, 'test {; }')
+        inspect_source('test {; }')
         expect(cop.messages).to be_empty
       end
     end
@@ -57,7 +57,7 @@ describe RuboCop::Cop::Layout::SpaceBeforeSemicolon do
 
       it 'registers an offense for a space between an opening brace and a ' \
          'semicolon' do
-        inspect_source(cop, 'test { ; }')
+        inspect_source('test { ; }')
         expect(cop.messages).to eq(['Space found before semicolon.'])
       end
     end

--- a/spec/rubocop/cop/layout/space_before_semicolon_spec.rb
+++ b/spec/rubocop/cop/layout/space_before_semicolon_spec.rb
@@ -19,12 +19,12 @@ describe RuboCop::Cop::Layout::SpaceBeforeSemicolon do
   end
 
   it 'auto-corrects space before semicolon' do
-    new_source = autocorrect_source(cop, 'x = 1 ; y = 2')
+    new_source = autocorrect_source('x = 1 ; y = 2')
     expect(new_source).to eq('x = 1; y = 2')
   end
 
   it 'handles more than one space before a semicolon' do
-    new_source = autocorrect_source(cop, 'x = 1  ; y = 2')
+    new_source = autocorrect_source('x = 1  ; y = 2')
     expect(new_source).to eq('x = 1; y = 2')
   end
 

--- a/spec/rubocop/cop/layout/space_in_lambda_literal_spec.rb
+++ b/spec/rubocop/cop/layout/space_in_lambda_literal_spec.rb
@@ -55,25 +55,25 @@ describe RuboCop::Cop::Layout::SpaceInLambdaLiteral, :config do
     it 'autocorrects an offense for no space between -> and (' do
       code = 'a = ->(b, c) { b + c }'
       expected = 'a = -> (b, c) { b + c }'
-      expect(autocorrect_source(cop, code)).to eq(expected)
+      expect(autocorrect_source(code)).to eq(expected)
     end
 
     it 'autocorrects an offense for no space in the inner nested lambda' do
       code = 'a = -> (b = ->(c) {}, d) { b + d }'
       expected = 'a = -> (b = -> (c) {}, d) { b + d }'
-      expect(autocorrect_source(cop, code)).to eq(expected)
+      expect(autocorrect_source(code)).to eq(expected)
     end
 
     it 'autocorrects an offense for no space in the outer nested lambda' do
       code = 'a = ->(b = -> (c) {}, d) { b + d }'
       expected = 'a = -> (b = -> (c) {}, d) { b + d }'
-      expect(autocorrect_source(cop, code)).to eq(expected)
+      expect(autocorrect_source(code)).to eq(expected)
     end
 
     it 'autocorrects an offense for no space in both lambdas when nested' do
       code = 'a = ->(b = ->(c) {}, d) { b + d }'
       expected = 'a = -> (b = -> (c) {}, d) { b + d }'
-      expect(autocorrect_source(cop, code)).to eq(expected)
+      expect(autocorrect_source(code)).to eq(expected)
     end
   end
 
@@ -136,31 +136,31 @@ describe RuboCop::Cop::Layout::SpaceInLambdaLiteral, :config do
     it 'autocorrects an offense for a space between -> and (' do
       code = 'a = -> (b, c) { b + c }'
       expected = 'a = ->(b, c) { b + c }'
-      expect(autocorrect_source(cop, code)).to eq(expected)
+      expect(autocorrect_source(code)).to eq(expected)
     end
 
     it 'autocorrects an offense for spaces between -> and (' do
       code = 'a = ->   (b, c) { b + c }'
       expected = 'a = ->(b, c) { b + c }'
-      expect(autocorrect_source(cop, code)).to eq(expected)
+      expect(autocorrect_source(code)).to eq(expected)
     end
 
     it 'autocorrects an offense for a space in the inner nested lambda' do
       code = 'a = ->(b = -> (c) {}, d) { b + d }'
       expected = 'a = ->(b = ->(c) {}, d) { b + d }'
-      expect(autocorrect_source(cop, code)).to eq(expected)
+      expect(autocorrect_source(code)).to eq(expected)
     end
 
     it 'autocorrects an offense for a space in the outer nested lambda' do
       code = 'a = -> (b = ->(c) {}, d) { b + d }'
       expected = 'a = ->(b = ->(c) {}, d) { b + d }'
-      expect(autocorrect_source(cop, code)).to eq(expected)
+      expect(autocorrect_source(code)).to eq(expected)
     end
 
     it 'autocorrects two offenses for a space in both lambdas when nested' do
       code = 'a = -> (b = -> (c) {}, d) { b + d }'
       expected = 'a = ->(b = ->(c) {}, d) { b + d }'
-      expect(autocorrect_source(cop, code)).to eq(expected)
+      expect(autocorrect_source(code)).to eq(expected)
     end
   end
 end

--- a/spec/rubocop/cop/layout/space_inside_array_percent_literal_spec.rb
+++ b/spec/rubocop/cop/layout/space_inside_array_percent_literal_spec.rb
@@ -20,7 +20,7 @@ describe RuboCop::Cop::Layout::SpaceInsideArrayPercentLiteral do
 
         it 'registers an offense for unnecessary spaces' do
           source = code_example('1   2')
-          inspect_source(cop, source)
+          inspect_source(source)
           expect(cop.offenses.size).to eq(1)
           expect(cop.highlights).to eq(['   '])
           expect(cop.messages).to eq([message])
@@ -29,30 +29,30 @@ describe RuboCop::Cop::Layout::SpaceInsideArrayPercentLiteral do
 
         it 'registers an offense for multiple spaces between items' do
           source = code_example('1   2   3')
-          inspect_source(cop, source)
+          inspect_source(source)
           expect(cop.offenses.size).to eq(2)
           expect_corrected(source, code_example('1 2 3'))
         end
 
         it 'accepts literals with escaped and additional spaces' do
           source = code_example('a\   b \ c')
-          inspect_source(cop, source)
+          inspect_source(source)
           expect(cop.offenses.size).to eq(1)
           expect_corrected(source, code_example('a\  b \ c'))
         end
 
         it 'accepts literals without additional spaces' do
-          inspect_source(cop, code_example('a b c'))
+          inspect_source(code_example('a b c'))
           expect(cop.messages).to be_empty
         end
 
         it 'accepts literals with escaped spaces' do
-          inspect_source(cop, code_example('a\  b\ \  c'))
+          inspect_source(code_example('a\  b\ \  c'))
           expect(cop.messages).to be_empty
         end
 
         it 'accepts multi-line literals' do
-          inspect_source(cop, <<-RUBY.strip_indent)
+          inspect_source(<<-RUBY.strip_indent)
             %#{type}(
               a
               b
@@ -63,7 +63,7 @@ describe RuboCop::Cop::Layout::SpaceInsideArrayPercentLiteral do
         end
 
         it 'accepts multi-line literals within a method' do
-          inspect_source(cop, <<-RUBY.strip_indent)
+          inspect_source(<<-RUBY.strip_indent)
             def foo
               %#{type}(
                 a
@@ -76,7 +76,7 @@ describe RuboCop::Cop::Layout::SpaceInsideArrayPercentLiteral do
         end
 
         it 'accepts newlines and additional following alignment spaces' do
-          inspect_source(cop, <<-RUBY.strip_indent)
+          inspect_source(<<-RUBY.strip_indent)
             %#{type}(a b
                c)
           RUBY

--- a/spec/rubocop/cop/layout/space_inside_array_percent_literal_spec.rb
+++ b/spec/rubocop/cop/layout/space_inside_array_percent_literal_spec.rb
@@ -15,7 +15,7 @@ describe RuboCop::Cop::Layout::SpaceInsideArrayPercentLiteral do
         end
 
         def expect_corrected(source, expected)
-          expect(autocorrect_source(cop, source)).to eq expected
+          expect(autocorrect_source(source)).to eq expected
         end
 
         it 'registers an offense for unnecessary spaces' do

--- a/spec/rubocop/cop/layout/space_inside_block_braces_spec.rb
+++ b/spec/rubocop/cop/layout/space_inside_block_braces_spec.rb
@@ -38,7 +38,7 @@ describe RuboCop::Cop::Layout::SpaceInsideBlockBraces, :config do
     end
 
     it 'registers an offense for empty braces with line break inside' do
-      inspect_source(cop, <<-RUBY.strip_margin('|'))
+      inspect_source(<<-RUBY.strip_margin('|'))
         |  each {
         |  }
       RUBY
@@ -93,7 +93,7 @@ describe RuboCop::Cop::Layout::SpaceInsideBlockBraces, :config do
     let(:cop_config) { { 'EnforcedStyleForEmptyBraces' => 'unknown' } }
 
     it 'fails with an error' do
-      expect { inspect_source(cop, 'each { }') }
+      expect { inspect_source('each { }') }
         .to raise_error('Unknown EnforcedStyleForEmptyBraces selected!')
     end
   end
@@ -107,21 +107,21 @@ describe RuboCop::Cop::Layout::SpaceInsideBlockBraces, :config do
   end
 
   it 'registers an offense for left brace without inner space' do
-    inspect_source(cop, 'each {puts }')
+    inspect_source('each {puts }')
     expect(cop.messages).to eq(['Space missing inside {.'])
     expect(cop.highlights).to eq(['p'])
     expect(cop.config_to_allow_offenses).to eq('Enabled' => false)
   end
 
   it 'registers an offense for right brace without inner space' do
-    inspect_source(cop, 'each { puts}')
+    inspect_source('each { puts}')
     expect(cop.messages).to eq(['Space missing inside }.'])
     expect(cop.highlights).to eq(['}'])
     expect(cop.config_to_allow_offenses).to eq('Enabled' => false)
   end
 
   it 'registers offenses for both braces without inner space' do
-    inspect_source(cop, <<-RUBY.strip_indent)
+    inspect_source(<<-RUBY.strip_indent)
       a {}
       b { }
       each {puts}
@@ -150,7 +150,7 @@ describe RuboCop::Cop::Layout::SpaceInsideBlockBraces, :config do
       end
 
       it 'registers an offense for left brace without inner space' do
-        inspect_source(cop, 'each {|x| puts }')
+        inspect_source('each {|x| puts }')
         expect(cop.messages).to eq(['Space between { and | missing.'])
         expect(cop.highlights).to eq(['{|'])
         expect(cop.config_to_allow_offenses).to eq('Enabled' => false)
@@ -167,7 +167,7 @@ describe RuboCop::Cop::Layout::SpaceInsideBlockBraces, :config do
       end
 
       it 'registers an offense for left brace without inner space' do
-        inspect_source(cop, <<-RUBY.strip_indent)
+        inspect_source(<<-RUBY.strip_indent)
           each {|x|
           puts
           }
@@ -237,7 +237,7 @@ describe RuboCop::Cop::Layout::SpaceInsideBlockBraces, :config do
       end
 
       it 'registers an offense for left brace with inner space' do
-        inspect_source(cop, 'each { |x| puts }')
+        inspect_source('each { |x| puts }')
         expect(cop.messages).to eq(['Space between { and | detected.'])
         expect(cop.highlights).to eq([' '])
         expect(cop.config_to_allow_offenses).to eq('Enabled' => false)
@@ -272,21 +272,21 @@ describe RuboCop::Cop::Layout::SpaceInsideBlockBraces, :config do
     end
 
     it 'registers an offense for left brace with inner space' do
-      inspect_source(cop, 'each { puts}')
+      inspect_source('each { puts}')
       expect(cop.messages).to eq(['Space inside { detected.'])
       expect(cop.highlights).to eq([' '])
       expect(cop.config_to_allow_offenses).to eq('Enabled' => false)
     end
 
     it 'registers an offense for right brace with inner space' do
-      inspect_source(cop, 'each {puts  }')
+      inspect_source('each {puts  }')
       expect(cop.messages).to eq(['Space inside } detected.'])
       expect(cop.highlights).to eq(['  '])
       expect(cop.config_to_allow_offenses).to eq('Enabled' => false)
     end
 
     it 'registers offenses for both braces with inner space' do
-      inspect_source(cop, 'each { puts  }')
+      inspect_source('each { puts  }')
       expect(cop.messages).to eq(['Space inside { detected.',
                                   'Space inside } detected.'])
       expect(cop.highlights).to eq([' ', '  '])
@@ -310,7 +310,7 @@ describe RuboCop::Cop::Layout::SpaceInsideBlockBraces, :config do
         end
 
         it 'registers an offense for left brace without inner space' do
-          inspect_source(cop, 'each {|x| puts}')
+          inspect_source('each {|x| puts}')
           expect(cop.messages).to eq(['Space between { and | missing.'])
           expect(cop.highlights).to eq(['{|'])
           expect(cop.config_to_allow_offenses).to eq('Enabled' => false)
@@ -336,7 +336,7 @@ describe RuboCop::Cop::Layout::SpaceInsideBlockBraces, :config do
         end
 
         it 'registers an offense for left brace with inner space' do
-          inspect_source(cop, 'each { |x| puts}')
+          inspect_source('each { |x| puts}')
           expect(cop.messages).to eq(['Space between { and | detected.'])
           expect(cop.highlights).to eq([' '])
           expect(cop.config_to_allow_offenses).to eq('Enabled' => false)

--- a/spec/rubocop/cop/layout/space_inside_block_braces_spec.rb
+++ b/spec/rubocop/cop/layout/space_inside_block_braces_spec.rb
@@ -54,7 +54,7 @@ describe RuboCop::Cop::Layout::SpaceInsideBlockBraces, :config do
     end
 
     it 'auto-corrects unwanted space' do
-      new_source = autocorrect_source(cop, 'each { }')
+      new_source = autocorrect_source('each { }')
       expect(new_source).to eq('each {}')
     end
 
@@ -64,7 +64,7 @@ describe RuboCop::Cop::Layout::SpaceInsideBlockBraces, :config do
           b
         }
       RUBY
-      new_source = autocorrect_source(cop, old_source)
+      new_source = autocorrect_source(old_source)
       expect(new_source).to eq(old_source)
     end
   end
@@ -84,7 +84,7 @@ describe RuboCop::Cop::Layout::SpaceInsideBlockBraces, :config do
     end
 
     it 'auto-corrects missing space' do
-      new_source = autocorrect_source(cop, 'each {}')
+      new_source = autocorrect_source('each {}')
       expect(new_source).to eq('each { }')
     end
   end
@@ -139,7 +139,7 @@ describe RuboCop::Cop::Layout::SpaceInsideBlockBraces, :config do
   end
 
   it 'auto-corrects missing space' do
-    new_source = autocorrect_source(cop, 'each {puts}')
+    new_source = autocorrect_source('each {puts}')
     expect(new_source).to eq('each { puts }')
   end
 
@@ -178,7 +178,7 @@ describe RuboCop::Cop::Layout::SpaceInsideBlockBraces, :config do
       end
 
       it 'auto-corrects missing space' do
-        new_source = autocorrect_source(cop, <<-SOURCE)
+        new_source = autocorrect_source(<<-SOURCE)
           each {|x|
             puts
           }
@@ -197,7 +197,7 @@ describe RuboCop::Cop::Layout::SpaceInsideBlockBraces, :config do
     end
 
     it 'auto-corrects missing space' do
-      new_source = autocorrect_source(cop, 'each {|x| puts }')
+      new_source = autocorrect_source('each {|x| puts }')
       expect(new_source).to eq('each { |x| puts }')
     end
 
@@ -208,7 +208,7 @@ describe RuboCop::Cop::Layout::SpaceInsideBlockBraces, :config do
       end
 
       it 'does auto-correction for single-line blocks' do
-        new_source = autocorrect_source(cop, 'each {|x| puts}')
+        new_source = autocorrect_source('each {|x| puts}')
         expect(new_source).to eq('each { |x| puts }')
       end
 
@@ -218,7 +218,7 @@ describe RuboCop::Cop::Layout::SpaceInsideBlockBraces, :config do
             puts
           }
         RUBY
-        new_source = autocorrect_source(cop, old_source)
+        new_source = autocorrect_source(old_source)
         expect(new_source).to eq(<<-RUBY.strip_indent)
           each { |x|
             puts
@@ -248,7 +248,7 @@ describe RuboCop::Cop::Layout::SpaceInsideBlockBraces, :config do
       end
 
       it 'auto-corrects unwanted space' do
-        new_source = autocorrect_source(cop, 'each { |x| puts }')
+        new_source = autocorrect_source('each { |x| puts }')
         expect(new_source).to eq('each {|x| puts }')
       end
 
@@ -299,7 +299,7 @@ describe RuboCop::Cop::Layout::SpaceInsideBlockBraces, :config do
     end
 
     it 'auto-corrects unwanted space' do
-      new_source = autocorrect_source(cop, 'each{ puts }')
+      new_source = autocorrect_source('each{ puts }')
       expect(new_source).to eq('each{puts}')
     end
 
@@ -321,7 +321,7 @@ describe RuboCop::Cop::Layout::SpaceInsideBlockBraces, :config do
         end
 
         it 'auto-corrects missing space' do
-          new_source = autocorrect_source(cop, 'each {|x| puts}')
+          new_source = autocorrect_source('each {|x| puts}')
           expect(new_source).to eq('each { |x| puts}')
         end
       end
@@ -347,7 +347,7 @@ describe RuboCop::Cop::Layout::SpaceInsideBlockBraces, :config do
         end
 
         it 'auto-corrects unwanted space' do
-          new_source = autocorrect_source(cop, 'each { |x| puts}')
+          new_source = autocorrect_source('each { |x| puts}')
           expect(new_source).to eq('each {|x| puts}')
         end
       end

--- a/spec/rubocop/cop/layout/space_inside_brackets_spec.rb
+++ b/spec/rubocop/cop/layout/space_inside_brackets_spec.rb
@@ -72,7 +72,7 @@ describe RuboCop::Cop::Layout::SpaceInsideBrackets do
   end
 
   it 'auto-corrects unwanted space' do
-    new_source = autocorrect_source(cop, <<-RUBY.strip_indent)
+    new_source = autocorrect_source(<<-RUBY.strip_indent)
       a = [1, 2 ]
       b = [ 1, 2]
       c[ :key]

--- a/spec/rubocop/cop/layout/space_inside_hash_literal_braces_spec.rb
+++ b/spec/rubocop/cop/layout/space_inside_hash_literal_braces_spec.rb
@@ -45,7 +45,7 @@ describe RuboCop::Cop::Layout::SpaceInsideHashLiteralBraces, :config do
   end
 
   it 'registers an offense for hashes with no spaces if so configured' do
-    inspect_source(cop, <<-RUBY.strip_indent)
+    inspect_source(<<-RUBY.strip_indent)
       h = {a: 1, b: 2}
       h = {a => 1}
     RUBY
@@ -58,8 +58,7 @@ describe RuboCop::Cop::Layout::SpaceInsideHashLiteralBraces, :config do
   end
 
   it 'registers an offense for correct + opposite' do
-    inspect_source(cop,
-                   'h = { a: 1}')
+    inspect_source('h = { a: 1}')
     expect(cop.messages).to eq(['Space inside } missing.'])
     expect(cop.config_to_allow_offenses).to eq('Enabled' => false)
   end
@@ -79,8 +78,7 @@ describe RuboCop::Cop::Layout::SpaceInsideHashLiteralBraces, :config do
     let(:cop_config) { { 'EnforcedStyle' => 'no_space' } }
 
     it 'registers an offense for hashes with spaces' do
-      inspect_source(cop,
-                     'h = { a: 1, b: 2 }')
+      inspect_source('h = { a: 1, b: 2 }')
       expect(cop.messages).to eq(['Space inside { detected.',
                                   'Space inside } detected.'])
       expect(cop.highlights).to eq([' ', ' '])
@@ -88,8 +86,7 @@ describe RuboCop::Cop::Layout::SpaceInsideHashLiteralBraces, :config do
     end
 
     it 'registers an offense for opposite + correct' do
-      inspect_source(cop,
-                     'h = {a: 1 }')
+      inspect_source('h = {a: 1 }')
       expect(cop.messages).to eq(['Space inside } detected.'])
       expect(cop.config_to_allow_offenses).to eq('Enabled' => false)
     end
@@ -135,7 +132,7 @@ describe RuboCop::Cop::Layout::SpaceInsideHashLiteralBraces, :config do
     let(:cop_config) { { 'EnforcedStyle' => 'compact' } }
 
     it "doesn't register an offense for non-nested hashes with spaces" do
-      inspect_source(cop, 'h = { a: 1, b: 2 }')
+      inspect_source('h = { a: 1, b: 2 }')
       expect(cop.offenses).to be_empty
       expect(cop.config_to_allow_offenses).to eq('EnforcedStyle' => 'compact')
     end
@@ -148,8 +145,7 @@ describe RuboCop::Cop::Layout::SpaceInsideHashLiteralBraces, :config do
     end
 
     it 'registers an offense for opposite + correct' do
-      inspect_source(cop,
-                     'h = {a: 1 }')
+      inspect_source('h = {a: 1 }')
       expect(cop.messages).to eq(['Space inside { missing.'])
       expect(cop.config_to_allow_offenses).to eq('Enabled' => false)
     end

--- a/spec/rubocop/cop/layout/space_inside_hash_literal_braces_spec.rb
+++ b/spec/rubocop/cop/layout/space_inside_hash_literal_braces_spec.rb
@@ -19,7 +19,7 @@ describe RuboCop::Cop::Layout::SpaceInsideHashLiteralBraces, :config do
     end
 
     it 'auto-corrects unwanted space' do
-      new_source = autocorrect_source(cop, 'h = { }')
+      new_source = autocorrect_source('h = { }')
       expect(new_source).to eq('h = {}')
     end
   end
@@ -39,7 +39,7 @@ describe RuboCop::Cop::Layout::SpaceInsideHashLiteralBraces, :config do
     end
 
     it 'auto-corrects missing space' do
-      new_source = autocorrect_source(cop, 'h = {}')
+      new_source = autocorrect_source('h = {}')
       expect(new_source).to eq('h = { }')
     end
   end
@@ -64,7 +64,7 @@ describe RuboCop::Cop::Layout::SpaceInsideHashLiteralBraces, :config do
   end
 
   it 'auto-corrects missing space' do
-    new_source = autocorrect_source(cop, <<-RUBY.strip_indent)
+    new_source = autocorrect_source(<<-RUBY.strip_indent)
       h = {a: 1, b: 2}
       h = {a => 1 }
     RUBY
@@ -92,7 +92,7 @@ describe RuboCop::Cop::Layout::SpaceInsideHashLiteralBraces, :config do
     end
 
     it 'auto-corrects unwanted space' do
-      new_source = autocorrect_source(cop, <<-RUBY.strip_indent)
+      new_source = autocorrect_source(<<-RUBY.strip_indent)
         h = { a: 1, b: 2 }
         h = {a => 1 }
       RUBY
@@ -151,7 +151,7 @@ describe RuboCop::Cop::Layout::SpaceInsideHashLiteralBraces, :config do
     end
 
     it 'auto-corrects hashes with no space' do
-      new_source = autocorrect_source(cop, <<-RUBY.strip_indent)
+      new_source = autocorrect_source(<<-RUBY.strip_indent)
         h = {a: 1, b: 2}
         h = {a => 1 }
       RUBY
@@ -162,7 +162,7 @@ describe RuboCop::Cop::Layout::SpaceInsideHashLiteralBraces, :config do
     end
 
     it 'auto-corrects nested hashes with spaces' do
-      new_source = autocorrect_source(cop, <<-RUBY.strip_indent)
+      new_source = autocorrect_source(<<-RUBY.strip_indent)
         h = { a: { a: 1, b: 2 } }
         h = {a => method { 1 } }
       RUBY

--- a/spec/rubocop/cop/layout/space_inside_parens_spec.rb
+++ b/spec/rubocop/cop/layout/space_inside_parens_spec.rb
@@ -38,7 +38,7 @@ describe RuboCop::Cop::Layout::SpaceInsideParens do
   end
 
   it 'auto-corrects unwanted space' do
-    new_source = autocorrect_source(cop, <<-RUBY.strip_indent)
+    new_source = autocorrect_source(<<-RUBY.strip_indent)
       f( 3)
       g = ( a + 3 )
     RUBY

--- a/spec/rubocop/cop/layout/space_inside_percent_literal_delimiters_spec.rb
+++ b/spec/rubocop/cop/layout/space_inside_percent_literal_delimiters_spec.rb
@@ -15,7 +15,7 @@ describe RuboCop::Cop::Layout::SpaceInsidePercentLiteralDelimiters do
         end
 
         def expect_corrected(source, expected)
-          expect(autocorrect_source(cop, source)).to eq expected
+          expect(autocorrect_source(source)).to eq expected
         end
 
         it 'registers an offense for unnecessary spaces' do

--- a/spec/rubocop/cop/layout/space_inside_percent_literal_delimiters_spec.rb
+++ b/spec/rubocop/cop/layout/space_inside_percent_literal_delimiters_spec.rb
@@ -20,7 +20,7 @@ describe RuboCop::Cop::Layout::SpaceInsidePercentLiteralDelimiters do
 
         it 'registers an offense for unnecessary spaces' do
           source = code_example(' 1 2  ')
-          inspect_source(cop, source)
+          inspect_source(source)
           expect(cop.offenses.size).to eq(2)
           expect(cop.messages.uniq).to eq([message])
           expect(cop.highlights).to eq([' ', '  '])
@@ -29,37 +29,37 @@ describe RuboCop::Cop::Layout::SpaceInsidePercentLiteralDelimiters do
 
         it 'registers an offense for spaces after first delimiter' do
           source = code_example(' 1 2')
-          inspect_source(cop, source)
+          inspect_source(source)
           expect(cop.offenses.size).to eq(1)
           expect_corrected(source, code_example('1 2'))
         end
 
         it 'registers an offense for spaces before final delimiter' do
           source = code_example('1 2 ')
-          inspect_source(cop, source)
+          inspect_source(source)
           expect(cop.offenses.size).to eq(1)
           expect_corrected(source, code_example('1 2'))
         end
 
         it 'registers an offense for literals with escaped and other spaces' do
           source = code_example(' \ a b c\  ')
-          inspect_source(cop, source)
+          inspect_source(source)
           expect(cop.offenses.size).to eq(2)
           expect_corrected(source, code_example('\ a b c\ '))
         end
 
         it 'accepts literals without additional spaces' do
-          inspect_source(cop, code_example('a b c'))
+          inspect_source(code_example('a b c'))
           expect(cop.messages).to be_empty
         end
 
         it 'accepts literals with escaped spaces' do
-          inspect_source(cop, code_example('\ a b c\ '))
+          inspect_source(code_example('\ a b c\ '))
           expect(cop.messages).to be_empty
         end
 
         it 'accepts multi-line literals' do
-          inspect_source(cop, <<-RUBY.strip_indent)
+          inspect_source(<<-RUBY.strip_indent)
             %#{type}(
               a
               b
@@ -70,7 +70,7 @@ describe RuboCop::Cop::Layout::SpaceInsidePercentLiteralDelimiters do
         end
 
         it 'accepts multi-line literals within a method' do
-          inspect_source(cop, <<-RUBY.strip_indent)
+          inspect_source(<<-RUBY.strip_indent)
             def foo
               %#{type}(
                 a
@@ -83,7 +83,7 @@ describe RuboCop::Cop::Layout::SpaceInsidePercentLiteralDelimiters do
         end
 
         it 'accepts newlines and additional following alignment spaces' do
-          inspect_source(cop, <<-RUBY.strip_indent)
+          inspect_source(<<-RUBY.strip_indent)
             %#{type}(a b
                c)
           RUBY
@@ -91,7 +91,7 @@ describe RuboCop::Cop::Layout::SpaceInsidePercentLiteralDelimiters do
         end
 
         it 'accepts spaces between entries' do
-          inspect_source(cop, code_example('a  b  c'))
+          inspect_source(code_example('a  b  c'))
           expect(cop.messages).to be_empty
         end
       end

--- a/spec/rubocop/cop/layout/space_inside_range_literal_spec.rb
+++ b/spec/rubocop/cop/layout/space_inside_range_literal_spec.rb
@@ -53,12 +53,12 @@ describe RuboCop::Cop::Layout::SpaceInsideRangeLiteral do
   end
 
   it 'autocorrects space around .. literal' do
-    corrected = autocorrect_source(cop, ['1  .. 2'])
+    corrected = autocorrect_source(['1  .. 2'])
     expect(corrected).to eq '1..2'
   end
 
   it 'autocorrects space around ... literal' do
-    corrected = autocorrect_source(cop, ['1  ... 2'])
+    corrected = autocorrect_source(['1  ... 2'])
     expect(corrected).to eq '1...2'
   end
 end

--- a/spec/rubocop/cop/layout/space_inside_range_literal_spec.rb
+++ b/spec/rubocop/cop/layout/space_inside_range_literal_spec.rb
@@ -4,7 +4,7 @@ describe RuboCop::Cop::Layout::SpaceInsideRangeLiteral do
   subject(:cop) { described_class.new }
 
   it 'registers an offense for space inside .. literal' do
-    inspect_source(cop, <<-RUBY.strip_indent)
+    inspect_source(<<-RUBY.strip_indent)
       1 .. 2
       1.. 2
       1 ..2
@@ -19,7 +19,7 @@ describe RuboCop::Cop::Layout::SpaceInsideRangeLiteral do
   end
 
   it 'registers an offense for space inside ... literal' do
-    inspect_source(cop, <<-RUBY.strip_indent)
+    inspect_source(<<-RUBY.strip_indent)
       1 ... 2
       1... 2
       1 ...2
@@ -45,7 +45,7 @@ describe RuboCop::Cop::Layout::SpaceInsideRangeLiteral do
   end
 
   it 'registers an offense in multiline range literal with space in it' do
-    inspect_source(cop, <<-RUBY.strip_indent)
+    inspect_source(<<-RUBY.strip_indent)
       x = 0 ..
           10
     RUBY

--- a/spec/rubocop/cop/layout/space_inside_string_interpolation_spec.rb
+++ b/spec/rubocop/cop/layout/space_inside_string_interpolation_spec.rb
@@ -22,7 +22,7 @@ describe RuboCop::Cop::Layout::SpaceInsideStringInterpolation, :config do
     end
 
     it 'auto-corrects spacing within a string interpolation' do
-      new_source = autocorrect_source(cop, source)
+      new_source = autocorrect_source(source)
       expected_source = ([corrected_source] * source_length).join("\n")
       expect(new_source).to eq(expected_source)
     end
@@ -62,7 +62,7 @@ describe RuboCop::Cop::Layout::SpaceInsideStringInterpolation, :config do
       end
 
       it 'does not correct valid string interpolations' do
-        new_source = autocorrect_source(cop, source)
+        new_source = autocorrect_source(source)
         expect(new_source).to eq(source.join("\n"))
       end
     end
@@ -106,7 +106,7 @@ describe RuboCop::Cop::Layout::SpaceInsideStringInterpolation, :config do
       end
 
       it 'does not correct valid string interpolations' do
-        new_source = autocorrect_source(cop, source)
+        new_source = autocorrect_source(source)
         expect(new_source).to eq(source.join("\n"))
       end
     end

--- a/spec/rubocop/cop/layout/space_inside_string_interpolation_spec.rb
+++ b/spec/rubocop/cop/layout/space_inside_string_interpolation_spec.rb
@@ -17,7 +17,7 @@ describe RuboCop::Cop::Layout::SpaceInsideStringInterpolation, :config do
     let(:source_length) { source.class == String ? 1 : source.length }
 
     it 'registers an offense for any irregular spacing inside the braces' do
-      inspect_source(cop, source)
+      inspect_source(source)
       expect(cop.messages).to eq([expected_message] * source_length)
     end
 

--- a/spec/rubocop/cop/layout/tab_spec.rb
+++ b/spec/rubocop/cop/layout/tab_spec.rb
@@ -46,22 +46,22 @@ describe RuboCop::Cop::Layout::Tab do
   end
 
   it 'auto-corrects a line indented with tab' do
-    new_source = autocorrect_source(cop, ["\tx = 0"])
+    new_source = autocorrect_source(["\tx = 0"])
     expect(new_source).to eq('  x = 0')
   end
 
   it 'auto-corrects a line indented with multiple tabs' do
-    new_source = autocorrect_source(cop, ["\t\t\tx = 0"])
+    new_source = autocorrect_source(["\t\t\tx = 0"])
     expect(new_source).to eq('      x = 0')
   end
 
   it 'auto-corrects a line indented with mixed whitespace' do
-    new_source = autocorrect_source(cop, [" \tx = 0"])
+    new_source = autocorrect_source([" \tx = 0"])
     expect(new_source).to eq('   x = 0')
   end
 
   it 'auto-corrects a line with tab in a string indented with tab' do
-    new_source = autocorrect_source(cop, ["\t(x = \"\t\")"])
+    new_source = autocorrect_source(["\t(x = \"\t\")"])
     expect(new_source).to eq("  (x = \"\t\")")
   end
 end

--- a/spec/rubocop/cop/layout/trailing_blank_lines_spec.rb
+++ b/spec/rubocop/cop/layout/trailing_blank_lines_spec.rb
@@ -57,17 +57,17 @@ describe RuboCop::Cop::Layout::TrailingBlankLines, :config do
     end
 
     it 'auto-corrects unwanted blank lines' do
-      new_source = autocorrect_source(cop, ['x = 0', '', '', '', ''])
+      new_source = autocorrect_source(['x = 0', '', '', '', ''])
       expect(new_source).to eq(['x = 0', ''].join("\n"))
     end
 
     it 'auto-corrects unwanted blank lines in an empty file' do
-      new_source = autocorrect_source(cop, ['', '', '', '', ''])
+      new_source = autocorrect_source(['', '', '', '', ''])
       expect(new_source).to eq(['', ''].join("\n"))
     end
 
     it 'auto-corrects even if some lines have space' do
-      new_source = autocorrect_source(cop, ['x = 0', '', '  ', '', ''])
+      new_source = autocorrect_source(['x = 0', '', '  ', '', ''])
       expect(new_source).to eq(['x = 0', ''].join("\n"))
     end
   end
@@ -104,22 +104,22 @@ describe RuboCop::Cop::Layout::TrailingBlankLines, :config do
     end
 
     it 'auto-corrects unwanted blank lines' do
-      new_source = autocorrect_source(cop, ['x = 0', '', '', '', ''])
+      new_source = autocorrect_source(['x = 0', '', '', '', ''])
       expect(new_source).to eq(['x = 0', '', ''].join("\n"))
     end
 
     it 'auto-corrects unwanted blank lines in an empty file' do
-      new_source = autocorrect_source(cop, ['', '', '', '', ''])
+      new_source = autocorrect_source(['', '', '', '', ''])
       expect(new_source).to eq(['', '', ''].join("\n"))
     end
 
     it 'auto-corrects missing blank line' do
-      new_source = autocorrect_source(cop, ['x = 0', ''])
+      new_source = autocorrect_source(['x = 0', ''])
       expect(new_source).to eq(['x = 0', '', ''].join("\n"))
     end
 
     it 'auto-corrects missing newline' do
-      new_source = autocorrect_source(cop, ['x = 0'])
+      new_source = autocorrect_source(['x = 0'])
       expect(new_source).to eq(['x = 0', '', ''].join("\n"))
     end
   end

--- a/spec/rubocop/cop/layout/trailing_blank_lines_spec.rb
+++ b/spec/rubocop/cop/layout/trailing_blank_lines_spec.rb
@@ -32,25 +32,24 @@ describe RuboCop::Cop::Layout::TrailingBlankLines, :config do
     end
 
     it 'registers an offense for multiple trailing blank lines' do
-      inspect_source(cop, ['x = 0', '', '', '', ''])
+      inspect_source(['x = 0', '', '', '', ''])
       expect(cop.offenses.size).to eq(1)
       expect(cop.messages).to eq(['3 trailing blank lines detected.'])
     end
 
     it 'registers an offense for multiple blank lines in an empty file' do
-      inspect_source(cop, ['', '', '', '', ''])
+      inspect_source(['', '', '', '', ''])
       expect(cop.offenses.size).to eq(1)
       expect(cop.messages).to eq(['3 trailing blank lines detected.'])
     end
 
     it 'registers an offense for no final newline after assignment' do
-      inspect_source(cop, 'x = 0')
+      inspect_source('x = 0')
       expect(cop.messages).to eq(['Final newline missing.'])
     end
 
     it 'registers an offense for no final newline after block comment' do
-      inspect_source(cop,
-                     "puts 'testing rubocop when final new line is missing " \
+      inspect_source("puts 'testing rubocop when final new line is missing " \
                      "after block comments'\n\n=begin\nfirst line\nsecond " \
                      "line\nthird line\n=end")
 
@@ -77,26 +76,26 @@ describe RuboCop::Cop::Layout::TrailingBlankLines, :config do
     let(:cop_config) { { 'EnforcedStyle' => 'final_blank_line' } }
 
     it 'registers an offense for final newline' do
-      inspect_source(cop, ['x = 0', ''])
+      inspect_source(['x = 0', ''])
       expect(cop.messages).to eq(['Trailing blank line missing.'])
     end
 
     it 'registers an offense for multiple trailing blank lines' do
-      inspect_source(cop, ['x = 0', '', '', '', ''])
+      inspect_source(['x = 0', '', '', '', ''])
       expect(cop.offenses.size).to eq(1)
       expect(cop.messages)
         .to eq(['3 trailing blank lines instead of 1 detected.'])
     end
 
     it 'registers an offense for multiple blank lines in an empty file' do
-      inspect_source(cop, ['', '', '', '', ''])
+      inspect_source(['', '', '', '', ''])
       expect(cop.offenses.size).to eq(1)
       expect(cop.messages)
         .to eq(['3 trailing blank lines instead of 1 detected.'])
     end
 
     it 'registers an offense for no final newline' do
-      inspect_source(cop, 'x = 0')
+      inspect_source('x = 0')
       expect(cop.messages).to eq(['Final newline missing.'])
     end
 

--- a/spec/rubocop/cop/layout/trailing_whitespace_spec.rb
+++ b/spec/rubocop/cop/layout/trailing_whitespace_spec.rb
@@ -67,8 +67,8 @@ describe RuboCop::Cop::Layout::TrailingWhitespace do
   end
 
   it 'auto-corrects unwanted space' do
-    new_source = autocorrect_source(cop, ['x = 0 ',
-                                          "x = 0\t"])
+    new_source = autocorrect_source(['x = 0 ',
+                                     "x = 0\t"])
     expect(new_source).to eq(['x = 0',
                               'x = 0'].join("\n"))
   end

--- a/spec/rubocop/cop/layout/trailing_whitespace_spec.rb
+++ b/spec/rubocop/cop/layout/trailing_whitespace_spec.rb
@@ -4,61 +4,61 @@ describe RuboCop::Cop::Layout::TrailingWhitespace do
   subject(:cop) { described_class.new }
 
   it 'registers an offense for a line ending with space' do
-    inspect_source(cop, 'x = 0 ')
+    inspect_source('x = 0 ')
     expect(cop.offenses.size).to eq(1)
   end
 
   it 'registers an offense for a blank line with space' do
-    inspect_source(cop, '  ')
+    inspect_source('  ')
     expect(cop.offenses.size).to eq(1)
   end
 
   it 'registers an offense for a line ending with tab' do
-    inspect_source(cop, "x = 0\t")
+    inspect_source("x = 0\t")
     expect(cop.offenses.size).to eq(1)
   end
 
   it 'registers an offense for trailing whitespace in a heredoc string' do
-    inspect_source(cop, ['x = <<RUBY',
-                         '  Hi   ',
-                         'RUBY'])
+    inspect_source(['x = <<RUBY',
+                    '  Hi   ',
+                    'RUBY'])
     expect(cop.offenses.size).to eq(1)
   end
 
   it 'registers offenses before __END__ but not after' do
-    inspect_source(cop, ["x = 0\t",
-                         ' ',
-                         '__END__',
-                         "x = 0\t"])
+    inspect_source(["x = 0\t",
+                    ' ',
+                    '__END__',
+                    "x = 0\t"])
     expect(cop.offenses.map(&:line)).to eq([1, 2])
   end
 
   it 'is not fooled by __END__ within a documentation comment' do
-    inspect_source(cop, ["x = 0\t",
-                         '=begin',
-                         '__END__',
-                         '=end',
-                         "x = 0\t"])
+    inspect_source(["x = 0\t",
+                    '=begin',
+                    '__END__',
+                    '=end',
+                    "x = 0\t"])
     expect(cop.offenses.map(&:line)).to eq([1, 5])
   end
 
   it 'is not fooled by heredoc containing __END__' do
-    inspect_source(cop, ['x1 = <<RUBY ',
-                         '__END__',
-                         "x2 = 0\t",
-                         'RUBY',
-                         "x3 = 0\t"])
+    inspect_source(['x1 = <<RUBY ',
+                    '__END__',
+                    "x2 = 0\t",
+                    'RUBY',
+                    "x3 = 0\t"])
     expect(cop.offenses.map(&:line)).to eq([1, 3, 5])
   end
 
   it 'is not fooled by heredoc containing __END__ within a doc comment' do
-    inspect_source(cop, ['x1 = <<RUBY ',
-                         '=begin  ',
-                         '__END__',
-                         '=end',
-                         "x2 = 0\t",
-                         'RUBY',
-                         "x3 = 0\t"])
+    inspect_source(['x1 = <<RUBY ',
+                    '=begin  ',
+                    '__END__',
+                    '=end',
+                    "x2 = 0\t",
+                    'RUBY',
+                    "x3 = 0\t"])
     expect(cop.offenses.map(&:line)).to eq([1, 2, 5, 7])
   end
 

--- a/spec/rubocop/cop/lint/ambiguous_block_association_spec.rb
+++ b/spec/rubocop/cop/lint/ambiguous_block_association_spec.rb
@@ -9,7 +9,7 @@ describe RuboCop::Cop::Lint::AmbiguousBlockAssociation do
       'associated with the `%s` method call.'
   end
 
-  before { inspect_source(cop, source) }
+  before { inspect_source(source) }
 
   shared_examples 'accepts' do |code|
     let(:source) { code }

--- a/spec/rubocop/cop/lint/ambiguous_operator_spec.rb
+++ b/spec/rubocop/cop/lint/ambiguous_operator_spec.rb
@@ -14,7 +14,7 @@ describe RuboCop::Cop::Lint::AmbiguousOperator do
         end
 
         it 'registers an offense' do
-          inspect_source(cop, source)
+          inspect_source(source)
           expect(cop.offenses.size).to eq(1)
           expect(cop.offenses.first.message).to eq(
             'Ambiguous splat operator. ' \
@@ -58,7 +58,7 @@ describe RuboCop::Cop::Lint::AmbiguousOperator do
         end
 
         it 'registers an offense' do
-          inspect_source(cop, source)
+          inspect_source(source)
           expect(cop.offenses.size).to eq(1)
           expect(cop.offenses.first.message).to eq(
             'Ambiguous block operator. ' \

--- a/spec/rubocop/cop/lint/ambiguous_regexp_literal_spec.rb
+++ b/spec/rubocop/cop/lint/ambiguous_regexp_literal_spec.rb
@@ -8,7 +8,7 @@ describe RuboCop::Cop::Lint::AmbiguousRegexpLiteral do
       let(:source) { 'p /pattern/' }
 
       it 'registers an offense' do
-        inspect_source(cop, source)
+        inspect_source(source)
         expect(cop.offenses.size).to eq(1)
         expect(cop.offenses.first.message).to eq(
           'Ambiguous regexp literal. Parenthesize the method arguments ' \

--- a/spec/rubocop/cop/lint/block_alignment_spec.rb
+++ b/spec/rubocop/cop/lint/block_alignment_spec.rb
@@ -16,7 +16,7 @@ describe RuboCop::Cop::Lint::BlockAlignment, :config do
     end
 
     it 'auto-corrects alignment' do
-      new_source = autocorrect_source(cop, <<-RUBY.strip_indent)
+      new_source = autocorrect_source(<<-RUBY.strip_indent)
         test do
           end
       RUBY
@@ -38,7 +38,7 @@ describe RuboCop::Cop::Lint::BlockAlignment, :config do
     end
 
     it 'auto-corrects alignment' do
-      new_source = autocorrect_source(cop, <<-RUBY.strip_indent)
+      new_source = autocorrect_source(<<-RUBY.strip_indent)
         test do |ala|
           end
       RUBY
@@ -93,7 +93,7 @@ describe RuboCop::Cop::Lint::BlockAlignment, :config do
     end
 
     it 'auto-corrects alignment to the first variable' do
-      new_source = autocorrect_source(cop, <<-RUBY.strip_indent)
+      new_source = autocorrect_source(<<-RUBY.strip_indent)
         a = b = c = test do |ala|
             end
       RUBY
@@ -145,7 +145,6 @@ describe RuboCop::Cop::Lint::BlockAlignment, :config do
 
     it 'auto-corrects alignment' do
       new_source = autocorrect_source(
-        cop,
         <<-RUBY.strip_indent
           variable =
             a_long_method_that_dont_fit_on_the_line do |v|
@@ -268,7 +267,7 @@ describe RuboCop::Cop::Lint::BlockAlignment, :config do
         end
       RUBY
 
-      new_source = autocorrect_source(cop, src)
+      new_source = autocorrect_source(src)
       expect(new_source).to eq(aligned_src)
     end
   end
@@ -309,7 +308,7 @@ describe RuboCop::Cop::Lint::BlockAlignment, :config do
           i - 5
         end
       RUBY
-      new_source = autocorrect_source(cop, src)
+      new_source = autocorrect_source(src)
       expect(new_source).to eq(corrected)
     end
   end
@@ -550,7 +549,7 @@ describe RuboCop::Cop::Lint::BlockAlignment, :config do
         end
       RUBY
 
-      new_source = autocorrect_source(cop, source)
+      new_source = autocorrect_source(source)
       expect(new_source).to eq(corrected)
     end
   end
@@ -582,7 +581,7 @@ describe RuboCop::Cop::Lint::BlockAlignment, :config do
         end
       RUBY
 
-      new_source = autocorrect_source(cop, source)
+      new_source = autocorrect_source(source)
       expect(new_source).to eq(corrected)
     end
   end
@@ -614,7 +613,7 @@ describe RuboCop::Cop::Lint::BlockAlignment, :config do
         end
       RUBY
 
-      new_source = autocorrect_source(cop, source)
+      new_source = autocorrect_source(source)
       expect(new_source).to eq(corrected)
     end
   end
@@ -646,7 +645,7 @@ describe RuboCop::Cop::Lint::BlockAlignment, :config do
         end
       RUBY
 
-      new_source = autocorrect_source(cop, source)
+      new_source = autocorrect_source(source)
       expect(new_source).to eq(corrected)
     end
   end
@@ -702,7 +701,7 @@ describe RuboCop::Cop::Lint::BlockAlignment, :config do
         end
       RUBY
 
-      new_source = autocorrect_source(cop, src)
+      new_source = autocorrect_source(src)
       expect(new_source).to eq(corrected)
     end
   end
@@ -748,7 +747,7 @@ describe RuboCop::Cop::Lint::BlockAlignment, :config do
           end
       RUBY
 
-      new_source = autocorrect_source(cop, src)
+      new_source = autocorrect_source(src)
       expect(new_source).to eq(corrected)
     end
   end

--- a/spec/rubocop/cop/lint/block_alignment_spec.rb
+++ b/spec/rubocop/cop/lint/block_alignment_spec.rb
@@ -196,7 +196,7 @@ describe RuboCop::Cop::Lint::BlockAlignment, :config do
                 end
         end
       RUBY
-      inspect_source(cop, src)
+      inspect_source(src)
       expect(cop.messages)
         .to eq(['`end` at 5, 8 is not aligned with `bar.get_stuffs` at 2, 2' \
                 ' or `.reject do |stuff|` at 3, 6.',
@@ -290,7 +290,7 @@ describe RuboCop::Cop::Lint::BlockAlignment, :config do
           i - 5
             end
       RUBY
-      inspect_source(cop, src)
+      inspect_source(src)
       expect(cop.messages)
         .to eq(['`end` at 4, 4 is not aligned with `e,` at 1, 0 or' \
                 ' `f = [5, 6].map do |i|` at 2, 0.'])
@@ -323,7 +323,7 @@ describe RuboCop::Cop::Lint::BlockAlignment, :config do
 
   it 'registers an offense for mismatched block end with' \
      ' an instance variable' do
-    inspect_source(cop, <<-RUBY.strip_indent)
+    inspect_source(<<-RUBY.strip_indent)
       @variable = test do |ala|
         end
     RUBY
@@ -404,7 +404,7 @@ describe RuboCop::Cop::Lint::BlockAlignment, :config do
 
   it 'registers an offense for mismatched end with a method call' \
      ' with arguments' do
-    inspect_source(cop, <<-RUBY.strip_indent)
+    inspect_source(<<-RUBY.strip_indent)
       @h[:f] = f.each_pair.map do |f, v|
         v = 1
         end
@@ -428,7 +428,7 @@ describe RuboCop::Cop::Lint::BlockAlignment, :config do
 
   it 'registers an offense for mismatched end not aligned with the block' \
      ' that is an argument' do
-    inspect_source(cop, <<-RUBY.strip_indent)
+    inspect_source(<<-RUBY.strip_indent)
       expect(arr.all? do |o|
         o.valid?
         end)
@@ -682,7 +682,7 @@ describe RuboCop::Cop::Lint::BlockAlignment, :config do
             baz
           end
       RUBY
-      inspect_source(cop, src)
+      inspect_source(src)
       expect(cop.messages)
         .to eq(['`end` at 4, 2 is not aligned with ' \
                 '`foo.bar` at 1, 0.'])
@@ -728,7 +728,7 @@ describe RuboCop::Cop::Lint::BlockAlignment, :config do
             baz
         end
       RUBY
-      inspect_source(cop, src)
+      inspect_source(src)
       expect(cop.messages)
         .to eq(['`end` at 4, 0 is not aligned with ' \
                 '`.each do` at 2, 2.'])

--- a/spec/rubocop/cop/lint/circular_argument_reference_spec.rb
+++ b/spec/rubocop/cop/lint/circular_argument_reference_spec.rb
@@ -5,7 +5,7 @@ describe RuboCop::Cop::Lint::CircularArgumentReference do
 
   describe 'circular argument references in ordinal arguments' do
     before do
-      inspect_source(cop, source)
+      inspect_source(source)
     end
 
     context 'when the method contains a circular argument reference' do
@@ -73,7 +73,7 @@ describe RuboCop::Cop::Lint::CircularArgumentReference do
       end
 
       it 'fails with a syntax error before the cop even comes into play' do
-        expect { inspect_source(cop, source) }.to raise_error(
+        expect { inspect_source(source) }.to raise_error(
           RuntimeError, /Error parsing/
         )
         expect(cop.offenses).to be_empty
@@ -82,7 +82,7 @@ describe RuboCop::Cop::Lint::CircularArgumentReference do
 
     context 'ruby >= 2.0', :ruby20 do
       before do
-        inspect_source(cop, source)
+        inspect_source(source)
       end
 
       context 'when the keyword argument is not circular' do

--- a/spec/rubocop/cop/lint/def_end_alignment_spec.rb
+++ b/spec/rubocop/cop/lint/def_end_alignment_spec.rb
@@ -37,7 +37,7 @@ describe RuboCop::Cop::Lint::DefEndAlignment, :config do
 
     context 'correct + opposite' do
       it 'registers an offense' do
-        inspect_source(cop, source)
+        inspect_source(source)
         expect(cop.offenses.size).to eq(1)
         expect(cop.messages.first)
           .to eq('`end` at 7, 4 is not aligned with `foo def` at 5, 0.')
@@ -82,7 +82,7 @@ describe RuboCop::Cop::Lint::DefEndAlignment, :config do
 
       context 'correct + opposite' do
         it 'registers an offense' do
-          inspect_source(cop, source)
+          inspect_source(source)
           expect(cop.offenses.size).to eq(1)
           expect(cop.messages.first)
             .to eq('`end` at 3, 0 is not aligned with `def` at 1, 4.')

--- a/spec/rubocop/cop/lint/def_end_alignment_spec.rb
+++ b/spec/rubocop/cop/lint/def_end_alignment_spec.rb
@@ -46,7 +46,7 @@ describe RuboCop::Cop::Lint::DefEndAlignment, :config do
       end
 
       it 'does auto-correction' do
-        corrected = autocorrect_source(cop, source)
+        corrected = autocorrect_source(source)
         expect(corrected).to eq(<<-RUBY.strip_indent)
           foo def a
             a1
@@ -91,7 +91,7 @@ describe RuboCop::Cop::Lint::DefEndAlignment, :config do
         end
 
         it 'does auto-correction' do
-          corrected = autocorrect_source(cop, source)
+          corrected = autocorrect_source(source)
           expect(corrected).to eq(<<-RUBY.strip_indent)
             foo def a
               a1

--- a/spec/rubocop/cop/lint/deprecated_class_methods_spec.rb
+++ b/spec/rubocop/cop/lint/deprecated_class_methods_spec.rb
@@ -29,12 +29,12 @@ describe RuboCop::Cop::Lint::DeprecatedClassMethods do
   end
 
   it 'auto-corrects File.exists? with File.exist?' do
-    new_source = autocorrect_source(cop, 'File.exists?(something)')
+    new_source = autocorrect_source('File.exists?(something)')
     expect(new_source).to eq('File.exist?(something)')
   end
 
   it 'auto-corrects Dir.exists? with Dir.exist?' do
-    new_source = autocorrect_source(cop, 'Dir.exists?(something)')
+    new_source = autocorrect_source('Dir.exists?(something)')
     expect(new_source).to eq('Dir.exist?(something)')
   end
 end

--- a/spec/rubocop/cop/lint/duplicate_methods_spec.rb
+++ b/spec/rubocop/cop/lint/duplicate_methods_spec.rb
@@ -1,12 +1,12 @@
 # frozen_string_literal: true
 
 describe RuboCop::Cop::Lint::DuplicateMethods do
-  subject(:cop) { described_class.new }
+  subject(:cop) { described_class.new(config) }
+  let(:config) { RuboCop::Config.new }
 
   shared_examples 'in scope' do |type, opening_line|
     it "registers an offense for duplicate method in #{type}" do
-      inspect_source(cop,
-                     [opening_line,
+      inspect_source([opening_line,
                       '  def some_method',
                       '    implement 1',
                       '  end',
@@ -18,8 +18,7 @@ describe RuboCop::Cop::Lint::DuplicateMethods do
     end
 
     it "doesn't register an offense for non-duplicate method in #{type}" do
-      inspect_source(cop,
-                     [opening_line,
+      inspect_source([opening_line,
                       '  def some_method',
                       '    implement 1',
                       '  end',
@@ -31,8 +30,7 @@ describe RuboCop::Cop::Lint::DuplicateMethods do
     end
 
     it "registers an offense for duplicate class methods in #{type}" do
-      inspect_source(cop,
-                     [opening_line,
+      inspect_source([opening_line,
                       '  def self.some_method',
                       '    implement 1',
                       '  end',
@@ -47,8 +45,7 @@ describe RuboCop::Cop::Lint::DuplicateMethods do
     end
 
     it "doesn't register offense for non-duplicate class methods in #{type}" do
-      inspect_source(cop,
-                     [opening_line,
+      inspect_source([opening_line,
                       '  def self.some_method',
                       '    implement 1',
                       '  end',
@@ -60,8 +57,7 @@ describe RuboCop::Cop::Lint::DuplicateMethods do
     end
 
     it "recognizes difference between instance and class methods in #{type}" do
-      inspect_source(cop,
-                     [opening_line,
+      inspect_source([opening_line,
                       '  def some_method',
                       '    implement 1',
                       '  end',
@@ -73,8 +69,7 @@ describe RuboCop::Cop::Lint::DuplicateMethods do
     end
 
     it "registers an offense for duplicate private methods in #{type}" do
-      inspect_source(cop,
-                     [opening_line,
+      inspect_source([opening_line,
                       '  private def some_method',
                       '    implement 1',
                       '  end',
@@ -86,8 +81,7 @@ describe RuboCop::Cop::Lint::DuplicateMethods do
     end
 
     it "registers an offense for duplicate private self methods in #{type}" do
-      inspect_source(cop,
-                     [opening_line,
+      inspect_source([opening_line,
                       '  private def self.some_method',
                       '    implement 1',
                       '  end',
@@ -99,8 +93,7 @@ describe RuboCop::Cop::Lint::DuplicateMethods do
     end
 
     it "doesn't register an offense for different private methods in #{type}" do
-      inspect_source(cop,
-                     [opening_line,
+      inspect_source([opening_line,
                       '  private def some_method',
                       '    implement 1',
                       '  end',
@@ -112,8 +105,7 @@ describe RuboCop::Cop::Lint::DuplicateMethods do
     end
 
     it "registers an offense for duplicate protected methods in #{type}" do
-      inspect_source(cop,
-                     [opening_line,
+      inspect_source([opening_line,
                       '  protected def some_method',
                       '    implement 1',
                       '  end',
@@ -125,8 +117,7 @@ describe RuboCop::Cop::Lint::DuplicateMethods do
     end
 
     it "registers 2 offenses for pair of duplicate methods in #{type}" do
-      inspect_source(cop,
-                     [opening_line,
+      inspect_source([opening_line,
                       '  def some_method',
                       '    implement 1',
                       '  end',
@@ -149,8 +140,7 @@ describe RuboCop::Cop::Lint::DuplicateMethods do
 
     it 'registers an offense for a duplicate instance method in separate ' \
        "#{type} blocks" do
-      inspect_source(cop,
-                     [opening_line,
+      inspect_source([opening_line,
                       '  def some_method',
                       '    implement 1',
                       '  end',
@@ -165,8 +155,7 @@ describe RuboCop::Cop::Lint::DuplicateMethods do
 
     it 'registers an offense for a duplicate class method in separate ' \
        "#{type} blocks" do
-      inspect_source(cop,
-                     [opening_line,
+      inspect_source([opening_line,
                       '  def self.some_method',
                       '    implement 1',
                       '  end',
@@ -180,14 +169,12 @@ describe RuboCop::Cop::Lint::DuplicateMethods do
     end
 
     it 'registers offense for a duplicate instance method in separate files' do
-      inspect_source(cop,
-                     [opening_line,
+      inspect_source([opening_line,
                       '  def some_method',
                       '    implement 1',
                       '  end',
                       'end'], 'first.rb')
-      inspect_source(cop,
-                     [opening_line,
+      inspect_source([opening_line,
                       '  def some_method',
                       '    implement 2',
                       '  end',
@@ -198,8 +185,7 @@ describe RuboCop::Cop::Lint::DuplicateMethods do
     end
 
     it 'understands class << self' do
-      inspect_source(cop,
-                     [opening_line,
+      inspect_source([opening_line,
                       '  class << self',
                       '    def some_method',
                       '      implement 1',
@@ -216,8 +202,7 @@ describe RuboCop::Cop::Lint::DuplicateMethods do
     end
 
     it 'understands nested modules' do
-      inspect_source(cop,
-                     ['module B',
+      inspect_source(['module B',
                       "  #{opening_line}",
                       '    def some_method',
                       '      implement 1',
@@ -240,8 +225,7 @@ describe RuboCop::Cop::Lint::DuplicateMethods do
     end
 
     it "doesn't register an offense when class << exp is used" do
-      inspect_source(cop,
-                     [opening_line,
+      inspect_source([opening_line,
                       '  class << blah',
                       '    def some_method',
                       '      implement 1',
@@ -316,8 +300,7 @@ describe RuboCop::Cop::Lint::DuplicateMethods do
   include_examples('in scope', 'class_eval block', 'A.class_eval do')
 
   it 'registers an offense for duplicate methods at top level' do
-    inspect_source(cop,
-                   ['  def some_method',
+    inspect_source(['  def some_method',
                     '    implement 1',
                     '  end',
                     '  def some_method',
@@ -331,8 +314,7 @@ describe RuboCop::Cop::Lint::DuplicateMethods do
   end
 
   it 'understands class << A' do
-    inspect_source(cop,
-                   ['class << A',
+    inspect_source(['class << A',
                     '  def some_method',
                     '    implement 1',
                     '  end',
@@ -347,16 +329,16 @@ describe RuboCop::Cop::Lint::DuplicateMethods do
   end
 
   it 'handles class_eval with implicit receiver' do
-    inspect_source(cop, ['module A',
-                         '  class_eval do',
-                         '    def some_method',
-                         '      implement 1',
-                         '    end',
-                         '    def some_method',
-                         '      implement 2',
-                         '    end',
-                         '  end',
-                         'end'], 'test.rb')
+    inspect_source(['module A',
+                    '  class_eval do',
+                    '    def some_method',
+                    '      implement 1',
+                    '    end',
+                    '    def some_method',
+                    '      implement 2',
+                    '    end',
+                    '  end',
+                    'end'], 'test.rb')
     expect(cop.offenses.size).to eq(1)
     expect(cop.messages).to eq(
       ['Method `A#some_method` is defined at both test.rb:3 and test.rb:6.']

--- a/spec/rubocop/cop/lint/duplicate_methods_spec.rb
+++ b/spec/rubocop/cop/lint/duplicate_methods_spec.rb
@@ -255,7 +255,7 @@ describe RuboCop::Cop::Lint::DuplicateMethods do
     end
 
     it "registers an offense for duplicate alias in #{type}" do
-      expect_offense(<<-RUBY)
+      expect_offense(<<-RUBY, 'example.rb')
         #{opening_line}
           def some_method
             implement 1
@@ -278,7 +278,7 @@ describe RuboCop::Cop::Lint::DuplicateMethods do
     end
 
     it "registers an offense for duplicate alias_method in #{type}" do
-      expect_offense(<<-RUBY)
+      expect_offense(<<-RUBY, 'example.rb')
         #{opening_line}
           def some_method
             implement 1

--- a/spec/rubocop/cop/lint/duplicated_key_spec.rb
+++ b/spec/rubocop/cop/lint/duplicated_key_spec.rb
@@ -8,7 +8,7 @@ describe RuboCop::Cop::Lint::DuplicatedKey do
     end
 
     it 'registers an offense' do
-      inspect_source(cop, source)
+      inspect_source(source)
       expect(cop.offenses.size).to eq(1)
       expect(cop.offenses.first.message)
         .to eq('Duplicated key in hash literal.')
@@ -22,7 +22,7 @@ describe RuboCop::Cop::Lint::DuplicatedKey do
     end
 
     it 'registers two offenses' do
-      inspect_source(cop, source)
+      inspect_source(source)
       expect(cop.offenses.size).to eq(2)
       expect(cop.messages).to eq(['Duplicated key in hash literal.'] * 2)
       expect(cop.highlights).to eq %w[veg fruit]
@@ -35,7 +35,7 @@ describe RuboCop::Cop::Lint::DuplicatedKey do
     end
 
     it 'registers two offenses' do
-      inspect_source(cop, source)
+      inspect_source(source)
       expect(cop.offenses.size).to eq(2)
       expect(cop.messages).to eq(['Duplicated key in hash literal.'] * 2)
       expect(cop.highlights).to eq %w[1 1]
@@ -52,7 +52,7 @@ describe RuboCop::Cop::Lint::DuplicatedKey do
 
   shared_examples :duplicated_literal_key do |key|
     it "registers an offense for duplicated `#{key}` hash keys" do
-      inspect_source(cop, "hash = { #{key} => 1, #{key} => 4}")
+      inspect_source("hash = { #{key} => 1, #{key} => 4}")
       expect(cop.offenses.size).to eq(1)
       expect(cop.offenses.first.message)
         .to eq('Duplicated key in hash literal.')
@@ -79,7 +79,7 @@ describe RuboCop::Cop::Lint::DuplicatedKey do
 
   shared_examples :duplicated_non_literal_key do |key|
     it "does not register an offense for duplicated `#{key}` hash keys" do
-      inspect_source(cop, "hash = { #{key} => 1, #{key} => 4}")
+      inspect_source("hash = { #{key} => 1, #{key} => 4}")
       expect(cop.offenses).to be_empty
     end
   end

--- a/spec/rubocop/cop/lint/empty_ensure_spec.rb
+++ b/spec/rubocop/cop/lint/empty_ensure_spec.rb
@@ -14,7 +14,7 @@ describe RuboCop::Cop::Lint::EmptyEnsure do
   end
 
   it 'autocorrects for empty ensure' do
-    corrected = autocorrect_source(cop, <<-RUBY.strip_indent)
+    corrected = autocorrect_source(<<-RUBY.strip_indent)
       begin
         something
       ensure

--- a/spec/rubocop/cop/lint/empty_expression_spec.rb
+++ b/spec/rubocop/cop/lint/empty_expression_spec.rb
@@ -18,11 +18,11 @@ describe RuboCop::Cop::Lint::EmptyExpression, :config do
 
       if expected
         it 'auto-corrects' do
-          expect(autocorrect_source(cop, code)).to eq(expected)
+          expect(autocorrect_source(code)).to eq(expected)
         end
       else
         it 'does not auto-correct' do
-          expect(autocorrect_source(cop, code)).to eq(code)
+          expect(autocorrect_source(code)).to eq(code)
         end
       end
     end

--- a/spec/rubocop/cop/lint/empty_expression_spec.rb
+++ b/spec/rubocop/cop/lint/empty_expression_spec.rb
@@ -4,7 +4,7 @@ describe RuboCop::Cop::Lint::EmptyExpression, :config do
   subject(:cop) { described_class.new(config) }
 
   before do
-    inspect_source(cop, source)
+    inspect_source(source)
   end
 
   shared_examples 'code with offense' do |code, expected = nil|

--- a/spec/rubocop/cop/lint/empty_interpolation_spec.rb
+++ b/spec/rubocop/cop/lint/empty_interpolation_spec.rb
@@ -22,12 +22,12 @@ describe RuboCop::Cop::Lint::EmptyInterpolation do
   end
 
   it 'autocorrects empty interpolation' do
-    new_source = autocorrect_source(cop, '"this is the #{}"')
+    new_source = autocorrect_source('"this is the #{}"')
     expect(new_source).to eq('"this is the "')
   end
 
   it 'autocorrects empty interpolation containing a space' do
-    new_source = autocorrect_source(cop, '"this is the #{ }"')
+    new_source = autocorrect_source('"this is the #{ }"')
     expect(new_source).to eq('"this is the "')
   end
 end

--- a/spec/rubocop/cop/lint/empty_when_spec.rb
+++ b/spec/rubocop/cop/lint/empty_when_spec.rb
@@ -4,7 +4,7 @@ describe RuboCop::Cop::Lint::EmptyWhen, :config do
   subject(:cop) { described_class.new(config) }
 
   before do
-    inspect_source(cop, source)
+    inspect_source(source)
   end
 
   shared_examples 'code with offense' do |code, expected = nil|

--- a/spec/rubocop/cop/lint/empty_when_spec.rb
+++ b/spec/rubocop/cop/lint/empty_when_spec.rb
@@ -18,11 +18,11 @@ describe RuboCop::Cop::Lint::EmptyWhen, :config do
 
       if expected
         it 'auto-corrects' do
-          expect(autocorrect_source(cop, code)).to eq(expected)
+          expect(autocorrect_source(code)).to eq(expected)
         end
       else
         it 'does not auto-correct' do
-          expect(autocorrect_source(cop, code)).to eq(code)
+          expect(autocorrect_source(code)).to eq(code)
         end
       end
     end

--- a/spec/rubocop/cop/lint/end_alignment_spec.rb
+++ b/spec/rubocop/cop/lint/end_alignment_spec.rb
@@ -140,7 +140,7 @@ describe RuboCop::Cop::Lint::EndAlignment, :config do
     end
 
     it 'does auto-correction' do
-      corrected = autocorrect_source(cop, source)
+      corrected = autocorrect_source(source)
       expect(corrected).to eq(<<-RUBY.strip_indent)
         x = if a
               a1
@@ -169,7 +169,7 @@ describe RuboCop::Cop::Lint::EndAlignment, :config do
     end
 
     it "doesn't auto-correct" do
-      expect(autocorrect_source(cop, source))
+      expect(autocorrect_source(source))
         .to eq(source)
       expect(cop.offenses.map(&:corrected?)).to eq [false]
     end

--- a/spec/rubocop/cop/lint/end_alignment_spec.rb
+++ b/spec/rubocop/cop/lint/end_alignment_spec.rb
@@ -131,7 +131,7 @@ describe RuboCop::Cop::Lint::EndAlignment, :config do
     end
 
     it 'registers an offense' do
-      inspect_source(cop, source)
+      inspect_source(source)
       expect(cop.offenses.size).to eq(1)
       expect(cop.messages.first)
         .to eq('`end` at 6, 0 is not aligned with `if` at 4, 4.')
@@ -161,7 +161,7 @@ describe RuboCop::Cop::Lint::EndAlignment, :config do
     end
 
     it 'registers an offense' do
-      inspect_source(cop, source)
+      inspect_source(source)
       expect(cop.offenses.size).to eq(1)
       expect(cop.messages.first)
         .to eq('`end` at 2, 7 is not aligned with `module` at 1, 0.')

--- a/spec/rubocop/cop/lint/end_in_method_spec.rb
+++ b/spec/rubocop/cop/lint/end_in_method_spec.rb
@@ -9,7 +9,7 @@ describe RuboCop::Cop::Lint::EndInMethod do
         END { something }
       end
     RUBY
-    inspect_source(cop, src)
+    inspect_source(src)
     expect(cop.offenses.size).to eq(1)
   end
 
@@ -19,7 +19,7 @@ describe RuboCop::Cop::Lint::EndInMethod do
         END { something }
       end
     RUBY
-    inspect_source(cop, src)
+    inspect_source(src)
     expect(cop.offenses.size).to eq(1)
   end
 

--- a/spec/rubocop/cop/lint/ensure_return_spec.rb
+++ b/spec/rubocop/cop/lint/ensure_return_spec.rb
@@ -28,7 +28,7 @@ describe RuboCop::Cop::Lint::EnsureReturn do
 
   it 'does not check when ensure block has no body' do
     expect do
-      inspect_source(cop, <<-RUBY.strip_indent)
+      inspect_source(<<-RUBY.strip_indent)
         begin
           something
         ensure

--- a/spec/rubocop/cop/lint/format_parameter_mismatch_spec.rb
+++ b/spec/rubocop/cop/lint/format_parameter_mismatch_spec.rb
@@ -6,7 +6,7 @@ describe RuboCop::Cop::Lint::FormatParameterMismatch do
 
   shared_examples 'variables' do |variable|
     it 'does not register an offense for % called on a variable' do
-      inspect_source(cop, <<-RUBY.strip_indent)
+      inspect_source(<<-RUBY.strip_indent)
         #{variable} = '%s'
         #{variable} % [foo]
       RUBY
@@ -15,7 +15,7 @@ describe RuboCop::Cop::Lint::FormatParameterMismatch do
     end
 
     it 'does not register an offense for format called on a variable' do
-      inspect_source(cop, <<-RUBY.strip_indent)
+      inspect_source(<<-RUBY.strip_indent)
         #{variable} = '%s'
         format(#{variable}, foo)
       RUBY
@@ -24,7 +24,7 @@ describe RuboCop::Cop::Lint::FormatParameterMismatch do
     end
 
     it 'does not register an offense for format called on a variable' do
-      inspect_source(cop, <<-RUBY.strip_indent)
+      inspect_source(<<-RUBY.strip_indent)
         #{variable} = '%s'
         sprintf(#{variable}, foo)
       RUBY
@@ -41,7 +41,7 @@ describe RuboCop::Cop::Lint::FormatParameterMismatch do
 
   it 'registers an offense when calling Kernel.format ' \
      'and the fields do not match' do
-    inspect_source(cop, 'Kernel.format("%s %s", 1)')
+    inspect_source('Kernel.format("%s %s", 1)')
     expect(cop.offenses.size).to eq(1)
     expect(cop.messages).to eq(
       ["Number of arguments (1) to `format` doesn't match the number of " \
@@ -51,7 +51,7 @@ describe RuboCop::Cop::Lint::FormatParameterMismatch do
 
   it 'registers an offense when calling Kernel.sprintf ' \
      'and the fields do not match' do
-    inspect_source(cop, 'Kernel.sprintf("%s %s", 1)')
+    inspect_source('Kernel.sprintf("%s %s", 1)')
     expect(cop.offenses.size).to eq(1)
     expect(cop.messages).to eq(
       ["Number of arguments (1) to `sprintf` doesn't match the number of " \
@@ -60,7 +60,7 @@ describe RuboCop::Cop::Lint::FormatParameterMismatch do
   end
 
   it 'registers an offense when there are less arguments than expected' do
-    inspect_source(cop, 'format("%s %s", 1)')
+    inspect_source('format("%s %s", 1)')
     expect(cop.offenses.size).to eq(1)
     expect(cop.messages).to eq(
       ["Number of arguments (1) to `format` doesn't match the number of " \
@@ -69,7 +69,7 @@ describe RuboCop::Cop::Lint::FormatParameterMismatch do
   end
 
   it 'registers an offense when there are more arguments than expected' do
-    inspect_source(cop, 'format("%s %s", 1, 2, 3)')
+    inspect_source('format("%s %s", 1, 2, 3)')
     expect(cop.offenses.size).to eq(1)
     expect(cop.messages).to eq(
       ["Number of arguments (3) to `format` doesn't match the number of " \
@@ -90,7 +90,7 @@ describe RuboCop::Cop::Lint::FormatParameterMismatch do
   end
 
   it 'registers offense with sprintf' do
-    inspect_source(cop, 'sprintf("%s %s", 1, 2, 3)')
+    inspect_source('sprintf("%s %s", 1, 2, 3)')
     expect(cop.offenses.size).to eq(1)
     expect(cop.messages).to eq(
       ["Number of arguments (3) to `sprintf` doesn't match the number of " \
@@ -103,7 +103,7 @@ describe RuboCop::Cop::Lint::FormatParameterMismatch do
   end
 
   it 'registers an offense for String#%' do
-    inspect_source(cop, '"%s %s" % [1, 2, 3]')
+    inspect_source('"%s %s" % [1, 2, 3]')
     expect(cop.offenses.size).to eq(1)
     expect(cop.messages).to eq(
       ["Number of arguments (3) to `String#%` doesn't match the number of " \
@@ -129,11 +129,11 @@ describe RuboCop::Cop::Lint::FormatParameterMismatch do
     end
 
     it 'does register an offense when args count is more than expected' do
-      inspect_source(cop, 'puts "%s, %s, %s" % [1, 2, 3, 4, *arr]')
+      inspect_source('puts "%s, %s, %s" % [1, 2, 3, 4, *arr]')
       expect(cop.offenses).not_to be_empty
-      inspect_source(cop, 'format("%s, %s, %s", 1, 2, 3, 4, *arr)')
+      inspect_source('format("%s, %s, %s", 1, 2, 3, 4, *arr)')
       expect(cop.offenses).not_to be_empty
-      inspect_source(cop, 'sprintf("%s, %s, %s", 1, 2, 3, 4, *arr)')
+      inspect_source('sprintf("%s, %s, %s", 1, 2, 3, 4, *arr)')
       expect(cop.offenses).not_to be_empty
     end
   end
@@ -175,7 +175,7 @@ describe RuboCop::Cop::Lint::FormatParameterMismatch do
   end
 
   it 'registers an offense if extra argument for dynamic width not given' do
-    inspect_source(cop, 'format("%*d", id)')
+    inspect_source('format("%*d", id)')
     expect(cop.offenses.size).to eq(1)
     expect(cop.messages).to eq(["Number of arguments (1) to `format` doesn't " \
                                 'match the number of fields (2).'])
@@ -203,7 +203,7 @@ describe RuboCop::Cop::Lint::FormatParameterMismatch do
 
   it 'finds faults even when the string looks like a HEREDOC' do
     # heredocs are ignored at the moment
-    inspect_source(cop, 'format("<< %s bleh", 1, 2)')
+    inspect_source('format("<< %s bleh", 1, 2)')
     expect(cop.offenses.size).to eq(1)
   end
 

--- a/spec/rubocop/cop/lint/implicit_string_concatenation_spec.rb
+++ b/spec/rubocop/cop/lint/implicit_string_concatenation_spec.rb
@@ -13,7 +13,7 @@ describe RuboCop::Cop::Lint::ImplicitStringConcatenation do
     let(:source) { 'class A; "abc" "def"; end' }
 
     it 'registers an offense' do
-      inspect_source(cop, source)
+      inspect_source(source)
       expect(cop.offenses.size).to eq(1)
       expect(cop.messages).to eq(['Combine "abc" and "def" into a single ' \
                                   'string literal, rather than using ' \
@@ -37,7 +37,7 @@ describe RuboCop::Cop::Lint::ImplicitStringConcatenation do
     let(:source) { "def method; 'ab\nc' 'de\nf'; end" }
 
     it 'registers an offense' do
-      inspect_source(cop, source)
+      inspect_source(source)
       expect(cop.offenses.size).to eq(1)
       expect(cop.messages).to eq(['Combine "ab\nc" and "de\nf" into a ' \
                                   'single string literal, rather than using ' \
@@ -56,7 +56,7 @@ describe RuboCop::Cop::Lint::ImplicitStringConcatenation do
     let(:source) { 'array = ["abc" "def"]' }
 
     it 'notes that the strings could be separated by a comma instead' do
-      inspect_source(cop, source)
+      inspect_source(source)
       expect(cop.offenses.size).to eq(1)
       expect(cop.messages).to eq(['Combine "abc" and "def" into a single ' \
                                   'string literal, rather than using ' \
@@ -71,7 +71,7 @@ describe RuboCop::Cop::Lint::ImplicitStringConcatenation do
     let(:source) { 'method("abc" "def")' }
 
     it 'notes that the strings could be separated by a comma instead' do
-      inspect_source(cop, source)
+      inspect_source(source)
       expect(cop.offenses.size).to eq(1)
       expect(cop.messages).to eq(['Combine "abc" and "def" into a single ' \
                                   'string literal, rather than using ' \

--- a/spec/rubocop/cop/lint/inherit_exception_spec.rb
+++ b/spec/rubocop/cop/lint/inherit_exception_spec.rb
@@ -5,7 +5,7 @@ describe RuboCop::Cop::Lint::InheritException, :config do
 
   shared_examples 'registers an offense' do |message|
     it 'registers an offense' do
-      inspect_source(cop, source)
+      inspect_source(source)
 
       expect(cop.offenses.size).to eq(1)
       expect(cop.messages).to eq([message])

--- a/spec/rubocop/cop/lint/inherit_exception_spec.rb
+++ b/spec/rubocop/cop/lint/inherit_exception_spec.rb
@@ -14,7 +14,7 @@ describe RuboCop::Cop::Lint::InheritException, :config do
 
   shared_examples 'auto-correct' do |expected|
     it 'auto-corrects' do
-      new_source = autocorrect_source(cop, source)
+      new_source = autocorrect_source(source)
 
       expect(new_source).to eq(expected)
     end

--- a/spec/rubocop/cop/lint/invalid_character_literal_spec.rb
+++ b/spec/rubocop/cop/lint/invalid_character_literal_spec.rb
@@ -20,7 +20,7 @@ describe RuboCop::Cop::Lint::InvalidCharacterLiteral do
     it 'registers an offense' do
       pending 'Is there a way to emit this warning without syntax errors?'
 
-      inspect_source(cop, source)
+      inspect_source(source)
 
       expect(cop.offenses.size).to eq(1)
       expect(cop.offenses.first.message)

--- a/spec/rubocop/cop/lint/literal_in_condition_spec.rb
+++ b/spec/rubocop/cop/lint/literal_in_condition_spec.rb
@@ -5,7 +5,7 @@ describe RuboCop::Cop::Lint::LiteralInCondition do
 
   %w(1 2.0 [1] {} :sym :"#{a}").each do |lit|
     it "registers an offense for literal #{lit} in if" do
-      inspect_source(cop, <<-RUBY.strip_indent)
+      inspect_source(<<-RUBY.strip_indent)
         if #{lit}
           top
         end
@@ -14,7 +14,7 @@ describe RuboCop::Cop::Lint::LiteralInCondition do
     end
 
     it "registers an offense for literal #{lit} in while" do
-      inspect_source(cop, <<-RUBY.strip_indent)
+      inspect_source(<<-RUBY.strip_indent)
         while #{lit}
           top
         end
@@ -23,7 +23,7 @@ describe RuboCop::Cop::Lint::LiteralInCondition do
     end
 
     it "registers an offense for literal #{lit} in post-loop while" do
-      inspect_source(cop, <<-RUBY.strip_indent)
+      inspect_source(<<-RUBY.strip_indent)
         begin
           top
         end while(#{lit})
@@ -32,7 +32,7 @@ describe RuboCop::Cop::Lint::LiteralInCondition do
     end
 
     it "registers an offense for literal #{lit} in until" do
-      inspect_source(cop, <<-RUBY.strip_indent)
+      inspect_source(<<-RUBY.strip_indent)
         until #{lit}
           top
         end
@@ -41,7 +41,7 @@ describe RuboCop::Cop::Lint::LiteralInCondition do
     end
 
     it "registers an offense for literal #{lit} in post-loop until" do
-      inspect_source(cop, <<-RUBY.strip_indent)
+      inspect_source(<<-RUBY.strip_indent)
         begin
           top
         end until #{lit}
@@ -50,7 +50,7 @@ describe RuboCop::Cop::Lint::LiteralInCondition do
     end
 
     it "registers an offense for literal #{lit} in case" do
-      inspect_source(cop, <<-RUBY.strip_indent)
+      inspect_source(<<-RUBY.strip_indent)
         case #{lit}
         when x then top
         end
@@ -60,7 +60,7 @@ describe RuboCop::Cop::Lint::LiteralInCondition do
 
     it "registers an offense for literal #{lit} in a when " \
        'of a case without anything after case keyword' do
-      inspect_source(cop, <<-RUBY.strip_indent)
+      inspect_source(<<-RUBY.strip_indent)
         case
         when #{lit} then top
         end
@@ -70,7 +70,7 @@ describe RuboCop::Cop::Lint::LiteralInCondition do
 
     it "accepts literal #{lit} in a when of a case with " \
        'something after case keyword' do
-      inspect_source(cop, <<-RUBY.strip_indent)
+      inspect_source(<<-RUBY.strip_indent)
         case x
         when #{lit} then top
         end
@@ -79,7 +79,7 @@ describe RuboCop::Cop::Lint::LiteralInCondition do
     end
 
     it "registers an offense for literal #{lit} in &&" do
-      inspect_source(cop, <<-RUBY.strip_indent)
+      inspect_source(<<-RUBY.strip_indent)
         if x && #{lit}
           top
         end
@@ -88,7 +88,7 @@ describe RuboCop::Cop::Lint::LiteralInCondition do
     end
 
     it "registers an offense for literal #{lit} in complex cond" do
-      inspect_source(cop, <<-RUBY.strip_indent)
+      inspect_source(<<-RUBY.strip_indent)
         if x && !(a && #{lit}) && y && z
           top
         end
@@ -97,7 +97,7 @@ describe RuboCop::Cop::Lint::LiteralInCondition do
     end
 
     it "registers an offense for literal #{lit} in !" do
-      inspect_source(cop, <<-RUBY.strip_indent)
+      inspect_source(<<-RUBY.strip_indent)
         if !#{lit}
           top
         end
@@ -106,7 +106,7 @@ describe RuboCop::Cop::Lint::LiteralInCondition do
     end
 
     it "registers an offense for literal #{lit} in complex !" do
-      inspect_source(cop, <<-RUBY.strip_indent)
+      inspect_source(<<-RUBY.strip_indent)
         if !(x && (y && #{lit}))
           top
         end
@@ -115,7 +115,7 @@ describe RuboCop::Cop::Lint::LiteralInCondition do
     end
 
     it "accepts literal #{lit} if it's not an and/or operand" do
-      inspect_source(cop, <<-RUBY.strip_indent)
+      inspect_source(<<-RUBY.strip_indent)
         if test(#{lit})
           top
         end
@@ -124,7 +124,7 @@ describe RuboCop::Cop::Lint::LiteralInCondition do
     end
 
     it "accepts literal #{lit} in non-toplevel and/or" do
-      inspect_source(cop, <<-RUBY.strip_indent)
+      inspect_source(<<-RUBY.strip_indent)
         if (a || #{lit}).something
           top
         end

--- a/spec/rubocop/cop/lint/literal_in_interpolation_spec.rb
+++ b/spec/rubocop/cop/lint/literal_in_interpolation_spec.rb
@@ -21,12 +21,12 @@ describe RuboCop::Cop::Lint::LiteralInInterpolation do
 
   shared_examples 'literal interpolation' do |literal, expected = literal|
     it "registers an offense for #{literal} in interpolation" do
-      inspect_source(cop, %("this is the \#{#{literal}}"))
+      inspect_source(%("this is the \#{#{literal}}"))
       expect(cop.offenses.size).to eq(1)
     end
 
     it "should have #{literal} as the message highlight" do
-      inspect_source(cop, %("this is the \#{#{literal}}"))
+      inspect_source(%("this is the \#{#{literal}}"))
       expect(cop.highlights).to eq([literal.to_s])
     end
 
@@ -67,7 +67,7 @@ describe RuboCop::Cop::Lint::LiteralInInterpolation do
     end
 
     it "registers an offense only for final #{literal} in interpolation" do
-      inspect_source(cop, %("this is the \#{#{literal};#{literal}}"))
+      inspect_source(%("this is the \#{#{literal};#{literal}}"))
       expect(cop.offenses.size).to eq(1)
     end
   end
@@ -99,7 +99,7 @@ describe RuboCop::Cop::Lint::LiteralInInterpolation do
 
   shared_examples 'special keywords' do |keyword|
     it "accepts strings like #{keyword}" do
-      inspect_source(cop, %("this is \#{#{keyword}} silly"))
+      inspect_source(%("this is \#{#{keyword}} silly"))
       expect(cop.offenses).to be_empty
     end
 
@@ -110,7 +110,7 @@ describe RuboCop::Cop::Lint::LiteralInInterpolation do
     end
 
     it "registers an offense for interpolation after #{keyword}" do
-      inspect_source(cop, %("this is the \#{#{keyword}} \#{1}"))
+      inspect_source(%("this is the \#{#{keyword}} \#{1}"))
       expect(cop.offenses.size).to eq(1)
     end
 
@@ -127,12 +127,12 @@ describe RuboCop::Cop::Lint::LiteralInInterpolation do
 
   shared_examples 'non-special string literal interpolation' do |string|
     it "registers an offense for #{string}" do
-      inspect_source(cop, %("this is the \#{#{string}}"))
+      inspect_source(%("this is the \#{#{string}}"))
       expect(cop.offenses.size).to eq(1)
     end
 
     it "should have #{string} in the message highlight" do
-      inspect_source(cop, %("this is the \#{#{string}}"))
+      inspect_source(%("this is the \#{#{string}}"))
       expect(cop.highlights).to eq([string])
     end
 

--- a/spec/rubocop/cop/lint/literal_in_interpolation_spec.rb
+++ b/spec/rubocop/cop/lint/literal_in_interpolation_spec.rb
@@ -31,20 +31,19 @@ describe RuboCop::Cop::Lint::LiteralInInterpolation do
     end
 
     it "removes interpolation around #{literal}" do
-      corrected = autocorrect_source(cop, %("this is the \#{#{literal}}"))
+      corrected = autocorrect_source(%("this is the \#{#{literal}}"))
       expect(corrected).to eq(%("this is the #{expected}"))
     end
 
     it "removes interpolation around #{literal} when there is more text" do
       corrected =
-        autocorrect_source(cop, %("this is the \#{#{literal}} literally"))
+        autocorrect_source(%("this is the \#{#{literal}} literally"))
       expect(corrected).to eq(%("this is the #{expected} literally"))
     end
 
     it "removes interpolation around multiple #{literal}" do
       corrected =
-        autocorrect_source(cop,
-                           %("some \#{#{literal}} with \#{#{literal}} too"))
+        autocorrect_source(%("some \#{#{literal}} with \#{#{literal}} too"))
       expect(corrected).to eq(%("some #{expected} with #{expected} too"))
     end
 
@@ -52,7 +51,7 @@ describe RuboCop::Cop::Lint::LiteralInInterpolation do
       context 'when literal interpolation is before non-literal' do
         it 'only remove interpolation around literal' do
           corrected =
-            autocorrect_source(cop, %("this is \#{#{literal}} with \#{a} now"))
+            autocorrect_source(%("this is \#{#{literal}} with \#{a} now"))
           expect(corrected).to eq(%("this is #{expected} with \#{a} now"))
         end
       end
@@ -60,7 +59,7 @@ describe RuboCop::Cop::Lint::LiteralInInterpolation do
       context 'when literal interpolation is after non-literal' do
         it 'only remove interpolation around literal' do
           corrected =
-            autocorrect_source(cop, %("this is \#{a} with \#{#{literal}} now"))
+            autocorrect_source(%("this is \#{a} with \#{#{literal}} now"))
           expect(corrected).to eq(%("this is \#{a} with #{expected} now"))
         end
       end
@@ -92,7 +91,7 @@ describe RuboCop::Cop::Lint::LiteralInInterpolation do
   it_behaves_like('literal interpolation', 1...2)
 
   it 'handles nested interpolations when auto-correction' do
-    corrected = autocorrect_source(cop, %("this is \#{"\#{1}"} silly"))
+    corrected = autocorrect_source(%("this is \#{"\#{1}"} silly"))
     # next iteration fixes this
     expect(corrected).to eq %("this is \#{"1"} silly")
   end
@@ -104,7 +103,7 @@ describe RuboCop::Cop::Lint::LiteralInInterpolation do
     end
 
     it "does not try to autocorrect strings like #{keyword}" do
-      corrected = autocorrect_source(cop, %("this is the \#{#{keyword}} silly"))
+      corrected = autocorrect_source(%("this is the \#{#{keyword}} silly"))
 
       expect(corrected).to eq(%("this is the \#{#{keyword}} silly"))
     end
@@ -115,7 +114,7 @@ describe RuboCop::Cop::Lint::LiteralInInterpolation do
     end
 
     it "auto-corrects literal interpolation after #{keyword}" do
-      corrected = autocorrect_source(cop, %("this is the \#{#{keyword}} \#{1}"))
+      corrected = autocorrect_source(%("this is the \#{#{keyword}} \#{1}"))
       expect(corrected).to eq(%("this is the \#{#{keyword}} 1"))
     end
   end
@@ -137,7 +136,7 @@ describe RuboCop::Cop::Lint::LiteralInInterpolation do
     end
 
     it "should remove the interpolation and quotes around #{string}" do
-      corrected = autocorrect_source(cop, %("this is the \#{#{string}}"))
+      corrected = autocorrect_source(%("this is the \#{#{string}}"))
       expect(corrected).to eq(%("this is the #{string.gsub(/'|"/, '')}"))
     end
   end

--- a/spec/rubocop/cop/lint/multiple_compare_spec.rb
+++ b/spec/rubocop/cop/lint/multiple_compare_spec.rb
@@ -16,7 +16,7 @@ describe RuboCop::Cop::Lint::MultipleCompare do
     end
 
     it 'autocorrects' do
-      new_source = autocorrect_source(cop, bad_source)
+      new_source = autocorrect_source(bad_source)
       expect(new_source).to eq(good_source)
     end
 

--- a/spec/rubocop/cop/lint/multiple_compare_spec.rb
+++ b/spec/rubocop/cop/lint/multiple_compare_spec.rb
@@ -9,7 +9,7 @@ describe RuboCop::Cop::Lint::MultipleCompare do
     good_source = "x #{op1} y && y #{op2} z"
 
     it "registers an offense for #{bad_source}" do
-      inspect_source(cop, bad_source)
+      inspect_source(bad_source)
       expect(cop.offenses.size).to eq(1)
       expect(cop.messages)
         .to eq(['Use the `&&` operator to compare multiple values.'])
@@ -21,7 +21,7 @@ describe RuboCop::Cop::Lint::MultipleCompare do
     end
 
     it "accepts for #{good_source}" do
-      inspect_source(cop, good_source)
+      inspect_source(good_source)
       expect(cop.offenses).to be_empty
     end
   end

--- a/spec/rubocop/cop/lint/nested_method_definition_spec.rb
+++ b/spec/rubocop/cop/lint/nested_method_definition_spec.rb
@@ -11,7 +11,7 @@ describe RuboCop::Cop::Lint::NestedMethodDefinition do
   end
 
   it 'registers an offense for a nested singleton method definition' do
-    inspect_source(cop, <<-RUBY.strip_indent)
+    inspect_source(<<-RUBY.strip_indent)
       class Foo
       end
       foo = Foo.new
@@ -33,7 +33,7 @@ describe RuboCop::Cop::Lint::NestedMethodDefinition do
   end
 
   it 'registers an offense for a nested class method definition' do
-    inspect_source(cop, <<-RUBY.strip_indent)
+    inspect_source(<<-RUBY.strip_indent)
       class Foo
         def self.x
           def self.y

--- a/spec/rubocop/cop/lint/next_without_accumulator_spec.rb
+++ b/spec/rubocop/cop/lint/next_without_accumulator_spec.rb
@@ -36,18 +36,18 @@ describe RuboCop::Cop::Lint::NextWithoutAccumulator do
   shared_examples 'reduce/inject' do |reduce_alias|
     context "given a #{reduce_alias} block" do
       it 'registers an offense for a bare next' do
-        inspect_source(cop, code_without_accumulator(reduce_alias))
+        inspect_source(code_without_accumulator(reduce_alias))
         expect(cop.offenses.size).to eq(1)
         expect(cop.highlights).to eq(['next'])
       end
 
       it 'accepts next with a value' do
-        inspect_source(cop, code_with_accumulator(reduce_alias))
+        inspect_source(code_with_accumulator(reduce_alias))
         expect(cop.offenses).to be_empty
       end
 
       it 'accepts next within a nested block' do
-        inspect_source(cop, code_with_nested_block(reduce_alias))
+        inspect_source(code_with_nested_block(reduce_alias))
         expect(cop.offenses).to be_empty
       end
     end

--- a/spec/rubocop/cop/lint/non_local_exit_from_iterator_spec.rb
+++ b/spec/rubocop/cop/lint/non_local_exit_from_iterator_spec.rb
@@ -5,7 +5,7 @@ describe RuboCop::Cop::Lint::NonLocalExitFromIterator do
 
   context 'inspection' do
     before do
-      inspect_source(cop, source)
+      inspect_source(source)
     end
 
     let(:message) do

--- a/spec/rubocop/cop/lint/parentheses_as_grouped_expression_spec.rb
+++ b/spec/rubocop/cop/lint/parentheses_as_grouped_expression_spec.rb
@@ -5,13 +5,13 @@ describe RuboCop::Cop::Lint::ParenthesesAsGroupedExpression do
 
   it 'registers an offense for method call with space before the ' \
      'parenthesis' do
-    inspect_source(cop, 'a.func (x)')
+    inspect_source('a.func (x)')
     expect(cop.offenses.size).to eq(1)
   end
 
   it 'registers an offense for predicate method call with space ' \
      'before the parenthesis' do
-    inspect_source(cop, 'is? (x)')
+    inspect_source('is? (x)')
     expect(cop.offenses.size).to eq(1)
   end
 

--- a/spec/rubocop/cop/lint/percent_string_array_spec.rb
+++ b/spec/rubocop/cop/lint/percent_string_array_spec.rb
@@ -69,7 +69,7 @@ describe RuboCop::Cop::Lint::PercentStringArray do
     end
 
     it 'removes undesireable characters' do
-      expect(autocorrect_source(cop, source)).to eq(expected_corrected_source)
+      expect(autocorrect_source(source)).to eq(expected_corrected_source)
     end
   end
 

--- a/spec/rubocop/cop/lint/percent_string_array_spec.rb
+++ b/spec/rubocop/cop/lint/percent_string_array_spec.rb
@@ -9,7 +9,7 @@ describe RuboCop::Cop::Lint::PercentStringArray do
   end
 
   def expect_offense(source)
-    inspect_source(cop, source)
+    inspect_source(source)
 
     expect(cop.offenses.map(&:message)).to eq([message])
     expect(cop.highlights).to eq([source])
@@ -18,7 +18,7 @@ describe RuboCop::Cop::Lint::PercentStringArray do
   context 'detecting quotes or commas in a %w/%W string' do
     %w[w W].each do |char|
       it 'accepts tokens without quotes or commas' do
-        inspect_source(cop, "%#{char}(foo bar baz)")
+        inspect_source("%#{char}(foo bar baz)")
 
         expect(cop.offenses).to be_empty
       end
@@ -30,7 +30,7 @@ describe RuboCop::Cop::Lint::PercentStringArray do
         %(%#{char}(\#{a} b))
       ].each do |false_positive|
         it "accepts likely false positive #{false_positive}" do
-          inspect_source(cop, false_positive)
+          inspect_source(false_positive)
 
           expect(cop.offenses).to be_empty
         end

--- a/spec/rubocop/cop/lint/percent_symbol_array_spec.rb
+++ b/spec/rubocop/cop/lint/percent_symbol_array_spec.rb
@@ -9,7 +9,7 @@ describe RuboCop::Cop::Lint::PercentSymbolArray do
   end
 
   def expect_offense(source)
-    inspect_source(cop, source)
+    inspect_source(source)
 
     expect(cop.offenses.map(&:message)).to eq([message])
     expect(cop.highlights).to eq([source])
@@ -18,13 +18,13 @@ describe RuboCop::Cop::Lint::PercentSymbolArray do
   context 'detecting colons or commas in a %i/%I string' do
     %w[i I].each do |char|
       it 'accepts tokens without colons or commas' do
-        inspect_source(cop, "%#{char}(foo bar baz)")
+        inspect_source("%#{char}(foo bar baz)")
 
         expect(cop.offenses).to be_empty
       end
 
       it 'accepts likely false positive $,' do
-        inspect_source(cop, "%#{char}{$,}")
+        inspect_source("%#{char}{$,}")
 
         expect(cop.offenses).to be_empty
       end

--- a/spec/rubocop/cop/lint/percent_symbol_array_spec.rb
+++ b/spec/rubocop/cop/lint/percent_symbol_array_spec.rb
@@ -58,7 +58,7 @@ describe RuboCop::Cop::Lint::PercentSymbolArray do
     end
 
     it 'removes undesireable characters' do
-      expect(autocorrect_source(cop, source)).to eq(expected_corrected_source)
+      expect(autocorrect_source(source)).to eq(expected_corrected_source)
     end
   end
 end

--- a/spec/rubocop/cop/lint/rand_one_spec.rb
+++ b/spec/rubocop/cop/lint/rand_one_spec.rb
@@ -2,7 +2,7 @@
 
 describe RuboCop::Cop::Lint::RandOne do
   subject(:cop) { described_class.new }
-  before { inspect_source(cop, source) }
+  before { inspect_source(source) }
 
   shared_examples 'offenses' do |source|
     describe source do

--- a/spec/rubocop/cop/lint/require_parentheses_spec.rb
+++ b/spec/rubocop/cop/lint/require_parentheses_spec.rb
@@ -5,7 +5,7 @@ describe RuboCop::Cop::Lint::RequireParentheses do
 
   it 'registers an offense for missing parentheses around expression with ' \
      '&& operator' do
-    inspect_source(cop, <<-RUBY.strip_indent)
+    inspect_source(<<-RUBY.strip_indent)
       if day.is? 'monday' && month == :jan
         foo
       end
@@ -18,13 +18,13 @@ describe RuboCop::Cop::Lint::RequireParentheses do
 
   it 'registers an offense for missing parentheses around expression with ' \
      '|| operator' do
-    inspect_source(cop, "day_is? 'tuesday' || true")
+    inspect_source("day_is? 'tuesday' || true")
     expect(cop.highlights).to eq(["day_is? 'tuesday' || true"])
   end
 
   it 'registers an offense for missing parentheses around expression in ' \
      'ternary' do
-    inspect_source(cop, "wd.include? 'tuesday' && true == true ? a : b")
+    inspect_source("wd.include? 'tuesday' && true == true ? a : b")
     expect(cop.highlights).to eq(["wd.include? 'tuesday' && true == true"])
   end
 

--- a/spec/rubocop/cop/lint/rescue_exception_spec.rb
+++ b/spec/rubocop/cop/lint/rescue_exception_spec.rb
@@ -115,7 +115,7 @@ describe RuboCop::Cop::Lint::RescueException do
 
   it 'does not crash when the namespace of a rescued class is in a local ' \
      'variable' do
-    inspect_source(cop, <<-RUBY.strip_indent)
+    inspect_source(<<-RUBY.strip_indent)
       adapter = current_adapter
       begin
       rescue adapter::ParseError

--- a/spec/rubocop/cop/lint/rescue_type_spec.rb
+++ b/spec/rubocop/cop/lint/rescue_type_spec.rb
@@ -52,7 +52,7 @@ describe RuboCop::Cop::Lint::RescueType do
         end
 
         it 'registers an offense' do
-          inspect_source(cop, source)
+          inspect_source(source)
 
           expect(cop.highlights).to eq(["rescue #{rescues}"])
           expect(cop.messages)
@@ -85,7 +85,7 @@ describe RuboCop::Cop::Lint::RescueType do
         end
 
         it 'registers an offense' do
-          inspect_source(cop, source)
+          inspect_source(source)
 
           expect(cop.highlights).to eq(["rescue #{rescues}, StandardError"])
           expect(cop.messages)
@@ -118,7 +118,7 @@ describe RuboCop::Cop::Lint::RescueType do
         end
 
         it 'registers an offense' do
-          inspect_source(cop, source)
+          inspect_source(source)
 
           expect(cop.highlights).to eq(["rescue StandardError, #{rescues}"])
           expect(cop.messages)
@@ -155,7 +155,7 @@ describe RuboCop::Cop::Lint::RescueType do
         end
 
         it 'registers an offense' do
-          inspect_source(cop, source)
+          inspect_source(source)
 
           expect(cop.highlights).to eq(["rescue #{rescues}"])
           expect(cop.messages)
@@ -192,7 +192,7 @@ describe RuboCop::Cop::Lint::RescueType do
         end
 
         it 'registers an offense' do
-          inspect_source(cop, source)
+          inspect_source(source)
 
           expect(cop.highlights).to eq(["rescue #{rescues}"])
           expect(cop.messages)
@@ -229,7 +229,7 @@ describe RuboCop::Cop::Lint::RescueType do
         end
 
         it 'registers an offense' do
-          inspect_source(cop, source)
+          inspect_source(source)
 
           expect(cop.highlights).to eq(["rescue #{rescues}"])
           expect(cop.messages)

--- a/spec/rubocop/cop/lint/rescue_type_spec.rb
+++ b/spec/rubocop/cop/lint/rescue_type_spec.rb
@@ -61,7 +61,7 @@ describe RuboCop::Cop::Lint::RescueType do
         end
 
         it 'auto-corrects' do
-          new_source = autocorrect_source(cop, source)
+          new_source = autocorrect_source(source)
 
           expect(new_source).to eq(<<-RUBY)
             begin
@@ -94,7 +94,7 @@ describe RuboCop::Cop::Lint::RescueType do
         end
 
         it 'auto-corrects' do
-          new_source = autocorrect_source(cop, source)
+          new_source = autocorrect_source(source)
 
           expect(new_source).to eq(<<-RUBY)
             begin
@@ -127,7 +127,7 @@ describe RuboCop::Cop::Lint::RescueType do
         end
 
         it 'auto-corrects' do
-          new_source = autocorrect_source(cop, source)
+          new_source = autocorrect_source(source)
 
           expect(new_source).to eq(<<-RUBY)
             begin
@@ -164,7 +164,7 @@ describe RuboCop::Cop::Lint::RescueType do
         end
 
         it 'auto-corrects' do
-          new_source = autocorrect_source(cop, source)
+          new_source = autocorrect_source(source)
 
           expect(new_source).to eq(<<-RUBY)
             begin
@@ -201,7 +201,7 @@ describe RuboCop::Cop::Lint::RescueType do
         end
 
         it 'auto-corrects' do
-          new_source = autocorrect_source(cop, source)
+          new_source = autocorrect_source(source)
 
           expect(new_source).to eq(<<-RUBY)
             def foobar
@@ -238,7 +238,7 @@ describe RuboCop::Cop::Lint::RescueType do
         end
 
         it 'auto-corrects' do
-          new_source = autocorrect_source(cop, source)
+          new_source = autocorrect_source(source)
 
           expect(new_source).to eq(<<-RUBY)
             def foobar

--- a/spec/rubocop/cop/lint/safe_navigation_chain_spec.rb
+++ b/spec/rubocop/cop/lint/safe_navigation_chain_spec.rb
@@ -8,7 +8,7 @@ describe RuboCop::Cop::Lint::SafeNavigationChain, :config do
 
   shared_examples :accepts do |name, code|
     it "accepts usages of #{name}" do
-      inspect_source(cop, code)
+      inspect_source(code)
 
       expect(cop.offenses).to be_empty
     end
@@ -16,7 +16,7 @@ describe RuboCop::Cop::Lint::SafeNavigationChain, :config do
 
   shared_examples :offense do |name, code|
     it "registers an offense for #{name}" do
-      inspect_source(cop, code)
+      inspect_source(code)
 
       expect(cop.messages)
         .to eq(

--- a/spec/rubocop/cop/lint/safe_navigation_chain_spec.rb
+++ b/spec/rubocop/cop/lint/safe_navigation_chain_spec.rb
@@ -27,7 +27,7 @@ describe RuboCop::Cop::Lint::SafeNavigationChain, :config do
 
   shared_examples :autocorrect do |name, source, correction|
     it "corrects #{name}" do
-      new_source = autocorrect_source_with_loop(cop, source)
+      new_source = autocorrect_source_with_loop(source)
 
       expect(new_source).to eq(correction)
     end

--- a/spec/rubocop/cop/lint/script_permission_spec.rb
+++ b/spec/rubocop/cop/lint/script_permission_spec.rb
@@ -68,7 +68,7 @@ describe RuboCop::Cop::Lint::ScriptPermission do
       it 'adds execute permissions to the file' do
         File.write(file.path, '#!/usr/bin/ruby')
 
-        autocorrect_source(cop, file.read, file)
+        autocorrect_source(file.read, file)
 
         expect(file.stat.executable?).to be_truthy
       end

--- a/spec/rubocop/cop/lint/shadowed_exception_spec.rb
+++ b/spec/rubocop/cop/lint/shadowed_exception_spec.rb
@@ -62,7 +62,7 @@ describe RuboCop::Cop::Lint::ShadowedException do
 
     it 'registers an offense rescuing exceptions that are ' \
       'ancestors of each other ' do
-      inspect_source(cop, <<-RUBY.strip_indent)
+      inspect_source(<<-RUBY.strip_indent)
         def
           something
         rescue StandardError, RuntimeError
@@ -75,7 +75,7 @@ describe RuboCop::Cop::Lint::ShadowedException do
 
     it 'registers an offense rescuing Exception with any other error or ' \
        'exception' do
-      inspect_source(cop, <<-RUBY.strip_indent)
+      inspect_source(<<-RUBY.strip_indent)
         begin
           something
         rescue NonStandardError, Exception
@@ -122,7 +122,7 @@ describe RuboCop::Cop::Lint::ShadowedException do
 
     it 'accepts rescuing a multiple exceptions that are not ancestors that ' \
        'have an else' do
-      inspect_source(cop, <<-RUBY.strip_indent)
+      inspect_source(<<-RUBY.strip_indent)
         begin
           something
         rescue NoMethodError, ZeroDivisionError
@@ -202,7 +202,7 @@ describe RuboCop::Cop::Lint::ShadowedException do
 
     it 'registers an offense when rescuing nil multiple exceptions of ' \
        'different levels' do
-      inspect_source(cop, <<-RUBY.strip_indent)
+      inspect_source(<<-RUBY.strip_indent)
         begin
           a
         rescue nil, StandardError, Exception
@@ -218,7 +218,7 @@ describe RuboCop::Cop::Lint::ShadowedException do
   context 'multiple rescues' do
     it 'registers an offense when a higher level exception is rescued before' \
        ' a lower level exception' do
-      inspect_source(cop, <<-RUBY.strip_indent)
+      inspect_source(<<-RUBY.strip_indent)
         begin
           something
         rescue Exception
@@ -237,7 +237,7 @@ describe RuboCop::Cop::Lint::ShadowedException do
     it 'registers an offense when a higher level exception is rescued before ' \
        'a lower level exception when there are multiple exceptions ' \
        'rescued in a group' do
-      inspect_source(cop, <<-RUBY.strip_indent)
+      inspect_source(<<-RUBY.strip_indent)
         begin
           something
         rescue Exception
@@ -256,7 +256,7 @@ describe RuboCop::Cop::Lint::ShadowedException do
 
     it 'registers an offense rescuing out of order exceptions when there ' \
        'is an ensure' do
-      inspect_source(cop, <<-RUBY.strip_indent)
+      inspect_source(<<-RUBY.strip_indent)
         begin
           something
         rescue Exception
@@ -310,7 +310,7 @@ describe RuboCop::Cop::Lint::ShadowedException do
 
     it 'accepts rescuing exceptions in order of level with multiple ' \
        'exceptions in a group' do
-      inspect_source(cop, <<-RUBY.strip_indent)
+      inspect_source(<<-RUBY.strip_indent)
         begin
           something
         rescue NoMethodError, ZeroDivisionError
@@ -325,7 +325,7 @@ describe RuboCop::Cop::Lint::ShadowedException do
 
     it 'accepts rescuing exceptions in order of level with multiple ' \
        'exceptions in a group with custom exceptions' do
-      inspect_source(cop, <<-RUBY.strip_indent)
+      inspect_source(<<-RUBY.strip_indent)
         begin
           something
         rescue NonStandardError, NoMethodError
@@ -365,7 +365,7 @@ describe RuboCop::Cop::Lint::ShadowedException do
 
       it 'registers an offense for splat arguments rescued after ' \
          'rescuing a known exception' do
-        inspect_source(cop, <<-RUBY.strip_indent)
+        inspect_source(<<-RUBY.strip_indent)
           begin
             a
           rescue StandardError
@@ -380,7 +380,7 @@ describe RuboCop::Cop::Lint::ShadowedException do
 
       it 'registers an offense for splat arguments rescued after ' \
          'rescuing Exception' do
-        inspect_source(cop, <<-RUBY.strip_indent)
+        inspect_source(<<-RUBY.strip_indent)
           begin
             a
           rescue Exception
@@ -486,7 +486,7 @@ describe RuboCop::Cop::Lint::ShadowedException do
     end
 
     it 'registers an offense rescuing Exception before an unknown exceptions' do
-      inspect_source(cop, <<-RUBY.strip_indent)
+      inspect_source(<<-RUBY.strip_indent)
         begin
           a
         rescue Exception
@@ -529,7 +529,7 @@ describe RuboCop::Cop::Lint::ShadowedException do
       end
 
       it 'does not raise error' do
-        expect { inspect_source(cop, source) }.not_to raise_error
+        expect { inspect_source(source) }.not_to raise_error
       end
 
       it 'highlights range ending at rescue keyword' do

--- a/spec/rubocop/cop/lint/shadowing_outer_local_variable_spec.rb
+++ b/spec/rubocop/cop/lint/shadowing_outer_local_variable_spec.rb
@@ -17,7 +17,7 @@ describe RuboCop::Cop::Lint::ShadowingOuterLocalVariable do
     end
 
     it 'registers an offense' do
-      inspect_source(cop, source)
+      inspect_source(source)
       expect(cop.offenses.size).to eq(1)
       expect(cop.offenses.first.message)
         .to eq('Shadowing outer local variable - `foo`.')
@@ -41,7 +41,7 @@ describe RuboCop::Cop::Lint::ShadowingOuterLocalVariable do
     end
 
     it 'registers an offense' do
-      inspect_source(cop, source)
+      inspect_source(source)
       expect(cop.offenses.size).to eq(1)
       expect(cop.offenses.first.message)
         .to eq('Shadowing outer local variable - `foo`.')
@@ -67,7 +67,7 @@ describe RuboCop::Cop::Lint::ShadowingOuterLocalVariable do
     end
 
     it 'registers an offense' do
-      inspect_source(cop, source)
+      inspect_source(source)
       expect(cop.offenses.size).to eq(1)
       expect(cop.offenses.first.message)
         .to eq('Shadowing outer local variable - `foo`.')
@@ -92,7 +92,7 @@ describe RuboCop::Cop::Lint::ShadowingOuterLocalVariable do
     end
 
     it 'registers an offense' do
-      inspect_source(cop, source)
+      inspect_source(source)
       expect(cop.offenses.size).to eq(1)
       expect(cop.offenses.first.message)
         .to eq('Shadowing outer local variable - `foo`.')

--- a/spec/rubocop/cop/lint/string_conversion_in_interpolation_spec.rb
+++ b/spec/rubocop/cop/lint/string_conversion_in_interpolation_spec.rb
@@ -37,12 +37,12 @@ describe RuboCop::Cop::Lint::StringConversionInInterpolation do
   end
 
   it 'autocorrects by removing the redundant to_s' do
-    corrected = autocorrect_source(cop, ['"some #{something.to_s}"'])
+    corrected = autocorrect_source(['"some #{something.to_s}"'])
     expect(corrected).to eq '"some #{something}"'
   end
 
   it 'autocorrects implicit receiver by replacing to_s with self' do
-    corrected = autocorrect_source(cop, ['"some #{to_s}"'])
+    corrected = autocorrect_source(['"some #{to_s}"'])
     expect(corrected).to eq '"some #{self}"'
   end
 end

--- a/spec/rubocop/cop/lint/underscore_prefixed_variable_name_spec.rb
+++ b/spec/rubocop/cop/lint/underscore_prefixed_variable_name_spec.rb
@@ -12,7 +12,7 @@ describe RuboCop::Cop::Lint::UnderscorePrefixedVariableName do
     RUBY
 
     it 'registers an offense' do
-      inspect_source(cop, source)
+      inspect_source(source)
       expect(cop.offenses.size).to eq(1)
       expect(cop.offenses.first.message)
         .to eq('Do not use prefix `_` for a variable that is used.')
@@ -52,7 +52,7 @@ describe RuboCop::Cop::Lint::UnderscorePrefixedVariableName do
     RUBY
 
     it 'registers an offense' do
-      inspect_source(cop, source)
+      inspect_source(source)
       expect(cop.offenses.size).to eq(1)
       expect(cop.offenses.first.line).to eq(1)
       expect(cop.highlights).to eq(['_foo'])
@@ -67,7 +67,7 @@ describe RuboCop::Cop::Lint::UnderscorePrefixedVariableName do
     RUBY
 
     it 'registers an offense' do
-      inspect_source(cop, source)
+      inspect_source(source)
       expect(cop.offenses.size).to eq(1)
       expect(cop.offenses.first.line).to eq(1)
       expect(cop.highlights).to eq(['_foo'])
@@ -81,7 +81,7 @@ describe RuboCop::Cop::Lint::UnderscorePrefixedVariableName do
     RUBY
 
     it 'registers an offense' do
-      inspect_source(cop, source)
+      inspect_source(source)
       expect(cop.offenses.size).to eq(1)
       expect(cop.offenses.first.line).to eq(1)
       expect(cop.highlights).to eq(['_foo'])
@@ -106,7 +106,7 @@ describe RuboCop::Cop::Lint::UnderscorePrefixedVariableName do
     RUBY
 
     it 'registers an offense' do
-      inspect_source(cop, source)
+      inspect_source(source)
       expect(cop.offenses.size).to eq(1)
       expect(cop.offenses.first.line).to eq(1)
       expect(cop.highlights).to eq(['/(?<_foo>\\w+)/'])
@@ -123,7 +123,7 @@ describe RuboCop::Cop::Lint::UnderscorePrefixedVariableName do
         RUBY
 
         it 'accepts' do
-          inspect_source(cop, source)
+          inspect_source(source)
           expect(cop.offenses).to be_empty
         end
       end
@@ -137,7 +137,7 @@ describe RuboCop::Cop::Lint::UnderscorePrefixedVariableName do
         RUBY
 
         it 'registers an offense' do
-          inspect_source(cop, source)
+          inspect_source(source)
           expect(cop.offenses.size).to eq(1)
           expect(cop.offenses.first.line).to eq(1)
           expect(cop.highlights).to eq(['_'])
@@ -154,7 +154,7 @@ describe RuboCop::Cop::Lint::UnderscorePrefixedVariableName do
         RUBY
 
         it 'accepts' do
-          inspect_source(cop, source)
+          inspect_source(source)
           expect(cop.offenses).to be_empty
         end
       end
@@ -167,7 +167,7 @@ describe RuboCop::Cop::Lint::UnderscorePrefixedVariableName do
         RUBY
 
         it 'registers an offense' do
-          inspect_source(cop, source)
+          inspect_source(source)
           expect(cop.offenses.size).to eq(1)
           expect(cop.offenses.first.line).to eq(1)
           expect(cop.highlights).to eq(['_'])

--- a/spec/rubocop/cop/lint/unified_integer_spec.rb
+++ b/spec/rubocop/cop/lint/unified_integer_spec.rb
@@ -16,7 +16,7 @@ describe RuboCop::Cop::Lint::UnifiedInteger do
         end
 
         it 'autocorrects' do
-          new_source = autocorrect_source(cop, source)
+          new_source = autocorrect_source(source)
           expect(new_source).to eq('1.is_a?(Integer)')
         end
       end
@@ -31,7 +31,7 @@ describe RuboCop::Cop::Lint::UnifiedInteger do
         end
 
         it 'autocorrects' do
-          new_source = autocorrect_source(cop, source)
+          new_source = autocorrect_source(source)
           expect(new_source).to eq('1.is_a?(::Integer)')
         end
       end

--- a/spec/rubocop/cop/lint/unified_integer_spec.rb
+++ b/spec/rubocop/cop/lint/unified_integer_spec.rb
@@ -10,7 +10,7 @@ describe RuboCop::Cop::Lint::UnifiedInteger do
         let(:source) { "1.is_a?(#{klass})" }
 
         it 'registers an offence' do
-          inspect_source(cop, source)
+          inspect_source(source)
           expect(cop.offenses.size).to eq(1)
           expect(cop.messages).to eq(["Use `Integer` instead of `#{klass}`."])
         end
@@ -25,7 +25,7 @@ describe RuboCop::Cop::Lint::UnifiedInteger do
         let(:source) { "1.is_a?(::#{klass})" }
 
         it 'registers an offence' do
-          inspect_source(cop, source)
+          inspect_source(source)
           expect(cop.offenses.size).to eq(1)
           expect(cop.messages).to eq(["Use `Integer` instead of `#{klass}`."])
         end

--- a/spec/rubocop/cop/lint/unneeded_splat_expansion_spec.rb
+++ b/spec/rubocop/cop/lint/unneeded_splat_expansion_spec.rb
@@ -34,7 +34,7 @@ describe RuboCop::Cop::Lint::UnneededSplatExpansion do
 
   shared_examples 'splat literal assignment' do |literal|
     it 'registers an offense for ' do
-      inspect_source(cop, "a = *#{literal}")
+      inspect_source("a = *#{literal}")
 
       expect(cop.messages).to eq([message])
       expect(cop.highlights).to eq(["*#{literal}"])
@@ -44,7 +44,7 @@ describe RuboCop::Cop::Lint::UnneededSplatExpansion do
   shared_examples 'array splat expansion' do |literal|
     context 'method parameters' do
       it 'registers an offense' do
-        inspect_source(cop, "array.push(*#{literal})")
+        inspect_source("array.push(*#{literal})")
 
         expect(cop.messages).to eq([array_param_message])
         expect(cop.highlights).to eq(["*#{literal}"])
@@ -57,7 +57,7 @@ describe RuboCop::Cop::Lint::UnneededSplatExpansion do
   shared_examples 'splat expansion' do |literal|
     context 'method parameters' do
       it 'registers an offense' do
-        inspect_source(cop, "array.push(*#{literal})")
+        inspect_source("array.push(*#{literal})")
 
         expect(cop.messages).to eq([message])
         expect(cop.highlights).to eq(["*#{literal}"])
@@ -169,7 +169,7 @@ describe RuboCop::Cop::Lint::UnneededSplatExpansion do
 
   it 'registers an offense for the expansion of an array literal' \
     'inside of an array literal' do
-    inspect_source(cop, '[1, 2, *[3, 4, 5], 6, 7]')
+    inspect_source('[1, 2, *[3, 4, 5], 6, 7]')
 
     expect(cop.messages).to eq([array_param_message])
     expect(cop.highlights).to eq(['*[3, 4, 5]'])
@@ -342,7 +342,7 @@ describe RuboCop::Cop::Lint::UnneededSplatExpansion do
     context 'arrays being expanded with %i variants using splat expansion' do
       it 'registers an offense for an array literal being expanded in a ' \
         'when condition' do
-        inspect_source(cop, <<-'RUBY'.strip_indent)
+        inspect_source(<<-'RUBY'.strip_indent)
           case foo
           when *%i(first second)
             bar

--- a/spec/rubocop/cop/lint/unneeded_splat_expansion_spec.rb
+++ b/spec/rubocop/cop/lint/unneeded_splat_expansion_spec.rb
@@ -182,43 +182,43 @@ describe RuboCop::Cop::Lint::UnneededSplatExpansion do
   context 'autocorrect' do
     context 'assignment to a splat expanded variable' do
       it 'removes the splat from an array using []' do
-        new_source = autocorrect_source(cop, 'a = *[1, 2, 3]')
+        new_source = autocorrect_source('a = *[1, 2, 3]')
 
         expect(new_source).to eq('a = [1, 2, 3]')
       end
 
       it 'removes the splat from an array using %w' do
-        new_source = autocorrect_source(cop, 'a = *%w(one two three)')
+        new_source = autocorrect_source('a = *%w(one two three)')
 
         expect(new_source).to eq('a = %w(one two three)')
       end
 
       it 'removes the splat from an array using %W' do
-        new_source = autocorrect_source(cop, 'a = *%W(one two three)')
+        new_source = autocorrect_source('a = *%W(one two three)')
 
         expect(new_source).to eq('a = %W(one two three)')
       end
 
       it 'converts an expanded string to an array' do
-        new_source = autocorrect_source(cop, "a = *'a'")
+        new_source = autocorrect_source("a = *'a'")
 
         expect(new_source).to eq("a = ['a']")
       end
 
       it 'converts an expanded string with interpolation to an array' do
-        new_source = autocorrect_source(cop, 'a = *"#{a}"')
+        new_source = autocorrect_source('a = *"#{a}"')
 
         expect(new_source).to eq('a = ["#{a}"]')
       end
 
       it 'converts an expanded integer to an array' do
-        new_source = autocorrect_source(cop, 'a = *1')
+        new_source = autocorrect_source('a = *1')
 
         expect(new_source).to eq('a = [1]')
       end
 
       it 'converts an expanded float to an array' do
-        new_source = autocorrect_source(cop, 'a = *1.1')
+        new_source = autocorrect_source('a = *1.1')
 
         expect(new_source).to eq('a = [1.1]')
       end
@@ -226,7 +226,7 @@ describe RuboCop::Cop::Lint::UnneededSplatExpansion do
 
     context 'splat expansion in when condition' do
       it 'removes the square brackets' do
-        new_source = autocorrect_source(cop, <<-RUBY.strip_indent)
+        new_source = autocorrect_source(<<-RUBY.strip_indent)
           case foo
           when *[1, 2, 3]
             bar
@@ -242,7 +242,7 @@ describe RuboCop::Cop::Lint::UnneededSplatExpansion do
       end
 
       it 'changes %w to a list of words' do
-        new_source = autocorrect_source(cop, <<-RUBY.strip_indent)
+        new_source = autocorrect_source(<<-RUBY.strip_indent)
           case foo
           when *%w(one two three)
             bar
@@ -258,7 +258,7 @@ describe RuboCop::Cop::Lint::UnneededSplatExpansion do
       end
 
       it 'changes %W to a list of words' do
-        new_source = autocorrect_source(cop, <<-'RUBY'.strip_indent)
+        new_source = autocorrect_source(<<-'RUBY'.strip_indent)
           case foo
           when *%W(one #{two} three)
             bar
@@ -276,7 +276,7 @@ describe RuboCop::Cop::Lint::UnneededSplatExpansion do
 
     context 'rescuing splat expansion' do
       it 'changes an array literal to a list of constants' do
-        new_source = autocorrect_source(cop, <<-RUBY.strip_indent)
+        new_source = autocorrect_source(<<-RUBY.strip_indent)
           begin
             foo
           rescue *[First, Second]
@@ -296,19 +296,19 @@ describe RuboCop::Cop::Lint::UnneededSplatExpansion do
 
     context 'splat expansion of method parameters' do
       it 'removes the splat and brackets from []' do
-        new_source = autocorrect_source(cop, 'foo(*[1, 2, 3])')
+        new_source = autocorrect_source('foo(*[1, 2, 3])')
 
         expect(new_source).to eq('foo(1, 2, 3)')
       end
 
       it 'changes %w to a list of words' do
-        new_source = autocorrect_source(cop, 'foo(*%w(one two three))')
+        new_source = autocorrect_source('foo(*%w(one two three))')
 
         expect(new_source).to eq("foo('one', 'two', 'three')")
       end
 
       it 'changes %W to a list of words' do
-        new_source = autocorrect_source(cop, 'foo(*%W(#{one} two three))')
+        new_source = autocorrect_source('foo(*%W(#{one} two three))')
 
         expect(new_source).to eq('foo("#{one}", "two", "three")')
       end
@@ -316,19 +316,19 @@ describe RuboCop::Cop::Lint::UnneededSplatExpansion do
 
     context 'splat expansion inside of an array' do
       it 'removes the splat and brackets from []' do
-        new_source = autocorrect_source(cop, '[1, 2, *[3, 4, 5], 6, 7]')
+        new_source = autocorrect_source('[1, 2, *[3, 4, 5], 6, 7]')
 
         expect(new_source).to eq('[1, 2, 3, 4, 5, 6, 7]')
       end
 
       it 'changes %w to a list of words' do
-        new_source = autocorrect_source(cop, "['a', 'b', *%w(c d e), 'f', 'g']")
+        new_source = autocorrect_source("['a', 'b', *%w(c d e), 'f', 'g']")
 
         expect(new_source).to eq("['a', 'b', 'c', 'd', 'e', 'f', 'g']")
       end
 
       it 'changes %W to a list of words' do
-        new_source = autocorrect_source(cop, '["a", "b", *%W(#{one} two)]')
+        new_source = autocorrect_source('["a", "b", *%W(#{one} two)]')
 
         expect(new_source).to eq('["a", "b", "#{one}", "two"]')
       end
@@ -374,7 +374,7 @@ describe RuboCop::Cop::Lint::UnneededSplatExpansion do
 
       context 'autocorrect' do
         it 'changes %i to a list of symbols' do
-          new_source = autocorrect_source(cop, <<-RUBY.strip_indent)
+          new_source = autocorrect_source(<<-RUBY.strip_indent)
             case foo
             when *%i(first second)
               baz
@@ -390,7 +390,7 @@ describe RuboCop::Cop::Lint::UnneededSplatExpansion do
         end
 
         it 'changes %I to a list of symbols' do
-          new_source = autocorrect_source(cop, <<-'RUBY'.strip_indent)
+          new_source = autocorrect_source(<<-'RUBY'.strip_indent)
             case foo
             when *%I(#{first} second)
               baz
@@ -408,13 +408,13 @@ describe RuboCop::Cop::Lint::UnneededSplatExpansion do
 
       context 'splat expansion inside of an array' do
         it 'changes %i to a list of symbols' do
-          new_source = autocorrect_source(cop, '[:a, :b, *%i(c d), :e]')
+          new_source = autocorrect_source('[:a, :b, *%i(c d), :e]')
 
           expect(new_source).to eq('[:a, :b, :c, :d, :e]')
         end
 
         it 'changes %I to a list of symbols' do
-          new_source = autocorrect_source(cop, '[:a, :b, *%I(#{one} two), :e]')
+          new_source = autocorrect_source('[:a, :b, *%I(#{one} two), :e]')
 
           expect(new_source).to eq('[:a, :b, :"#{one}", :"two", :e]')
         end

--- a/spec/rubocop/cop/lint/unreachable_code_spec.rb
+++ b/spec/rubocop/cop/lint/unreachable_code_spec.rb
@@ -5,15 +5,14 @@ describe RuboCop::Cop::Lint::UnreachableCode do
 
   described_class::NODE_TYPES.each do |t|
     it "registers an offense for #{t} before other statements" do
-      inspect_source(cop,
-                     ['foo = 5',
+      inspect_source(['foo = 5',
                       t.to_s,
                       'bar'])
       expect(cop.offenses.size).to eq(1)
     end
 
     it "accepts code with conditional #{t}" do
-      inspect_source(cop, <<-RUBY.strip_indent)
+      inspect_source(<<-RUBY.strip_indent)
         foo = 5
         #{t} if test
         bar
@@ -22,7 +21,7 @@ describe RuboCop::Cop::Lint::UnreachableCode do
     end
 
     it "accepts #{t} as the final expression" do
-      inspect_source(cop, <<-RUBY.strip_indent)
+      inspect_source(<<-RUBY.strip_indent)
         foo = 5
         #{t} if test
       RUBY
@@ -32,7 +31,7 @@ describe RuboCop::Cop::Lint::UnreachableCode do
 
   described_class::FLOW_COMMANDS.each do |t|
     it "registers an offense for #{t} before other statements" do
-      inspect_source(cop, <<-RUBY.strip_indent)
+      inspect_source(<<-RUBY.strip_indent)
         foo = 5
         #{t} something
         bar
@@ -41,7 +40,7 @@ describe RuboCop::Cop::Lint::UnreachableCode do
     end
 
     it "accepts code with conditional #{t}" do
-      inspect_source(cop, <<-RUBY.strip_indent)
+      inspect_source(<<-RUBY.strip_indent)
         foo = 5
         #{t} something if test
         bar
@@ -50,7 +49,7 @@ describe RuboCop::Cop::Lint::UnreachableCode do
     end
 
     it "accepts #{t} as the final expression" do
-      inspect_source(cop, <<-RUBY.strip_indent)
+      inspect_source(<<-RUBY.strip_indent)
         foo = 5
         #{t} something if test
       RUBY

--- a/spec/rubocop/cop/lint/unused_block_argument_spec.rb
+++ b/spec/rubocop/cop/lint/unused_block_argument_spec.rb
@@ -6,7 +6,7 @@ describe RuboCop::Cop::Lint::UnusedBlockArgument, :config do
 
   context 'inspection' do
     before do
-      inspect_source(cop, source)
+      inspect_source(source)
     end
 
     context 'when a block takes multiple arguments' do

--- a/spec/rubocop/cop/lint/unused_block_argument_spec.rb
+++ b/spec/rubocop/cop/lint/unused_block_argument_spec.rb
@@ -328,7 +328,7 @@ describe RuboCop::Cop::Lint::UnusedBlockArgument, :config do
 
   context 'auto-correct' do
     it 'fixes single' do
-      expect(autocorrect_source(cop, <<-SOURCE
+      expect(autocorrect_source(<<-SOURCE
       arr.map { |foo| stuff }
       SOURCE
                                )).to eq(<<-CORRECTED_SOURCE
@@ -338,7 +338,7 @@ describe RuboCop::Cop::Lint::UnusedBlockArgument, :config do
     end
 
     it 'fixes multiple' do
-      expect(autocorrect_source(cop, <<-SOURCE
+      expect(autocorrect_source(<<-SOURCE
       hash.map { |key, val| stuff }
       SOURCE
                                )).to eq(<<-CORRECTED_SOURCE
@@ -348,7 +348,7 @@ describe RuboCop::Cop::Lint::UnusedBlockArgument, :config do
     end
 
     it 'preserves whitespace' do
-      expect(autocorrect_source(cop, <<-SOURCE
+      expect(autocorrect_source(<<-SOURCE
       hash.map { |key,
                   val| stuff }
       SOURCE
@@ -360,7 +360,7 @@ describe RuboCop::Cop::Lint::UnusedBlockArgument, :config do
     end
 
     it 'preserves splat' do
-      expect(autocorrect_source(cop, <<-SOURCE
+      expect(autocorrect_source(<<-SOURCE
       obj.method { |foo, *bars, baz| stuff(foo, baz) }
       SOURCE
                                )).to eq(<<-CORRECTED_SOURCE
@@ -370,7 +370,7 @@ describe RuboCop::Cop::Lint::UnusedBlockArgument, :config do
     end
 
     it 'preserves default' do
-      expect(autocorrect_source(cop, <<-SOURCE
+      expect(autocorrect_source(<<-SOURCE
       obj.method { |foo, bar = baz| stuff(foo) }
       SOURCE
                                )).to eq(<<-CORRECTED_SOURCE
@@ -384,7 +384,7 @@ describe RuboCop::Cop::Lint::UnusedBlockArgument, :config do
       obj.method { |foo, baz| stuff(foo, baz) }
       SOURCE
 
-      expect(autocorrect_source(cop, original_source)).to eq(original_source)
+      expect(autocorrect_source(original_source)).to eq(original_source)
     end
   end
 

--- a/spec/rubocop/cop/lint/unused_method_argument_spec.rb
+++ b/spec/rubocop/cop/lint/unused_method_argument_spec.rb
@@ -8,7 +8,7 @@ describe RuboCop::Cop::Lint::UnusedMethodArgument, :config do
 
   describe 'inspection' do
     before do
-      inspect_source(cop, source)
+      inspect_source(source)
     end
 
     context 'when a method takes multiple arguments' do
@@ -382,7 +382,7 @@ describe RuboCop::Cop::Lint::UnusedMethodArgument, :config do
 
     it 'registers an offense for a non-empty method with a single unused ' \
         'parameter' do
-      inspect_source(cop, <<-RUBY.strip_indent)
+      inspect_source(<<-RUBY.strip_indent)
         def method(arg)
           1
         end
@@ -399,7 +399,7 @@ describe RuboCop::Cop::Lint::UnusedMethodArgument, :config do
 
     it 'registers an offense for a non-empty method with multiple unused ' \
        'parameters' do
-      inspect_source(cop, <<-RUBY.strip_indent)
+      inspect_source(<<-RUBY.strip_indent)
         def method(a, b, *others)
           1
         end

--- a/spec/rubocop/cop/lint/unused_method_argument_spec.rb
+++ b/spec/rubocop/cop/lint/unused_method_argument_spec.rb
@@ -247,7 +247,7 @@ describe RuboCop::Cop::Lint::UnusedMethodArgument, :config do
   end
 
   describe 'auto-correction' do
-    let(:corrected_source) { autocorrect_source(cop, source) }
+    let(:corrected_source) { autocorrect_source(source) }
 
     context 'when multiple arguments are unused' do
       let(:source) { <<-RUBY }

--- a/spec/rubocop/cop/lint/useless_access_modifier_spec.rb
+++ b/spec/rubocop/cop/lint/useless_access_modifier_spec.rb
@@ -20,7 +20,7 @@ describe RuboCop::Cop::Lint::UselessAccessModifier do
     end
 
     it 'registers an offense' do
-      inspect_source(cop, source)
+      inspect_source(source)
       expect(cop.offenses.size).to eq(1)
       expect(cop.offenses.first.message)
         .to eq('Useless `private` access modifier.')
@@ -42,7 +42,7 @@ describe RuboCop::Cop::Lint::UselessAccessModifier do
     end
 
     it 'registers an offense' do
-      inspect_source(cop, source)
+      inspect_source(source)
       expect(cop.offenses.size).to eq(1)
       expect(cop.offenses.first.message)
         .to eq('Useless `protected` access modifier.')
@@ -81,7 +81,7 @@ describe RuboCop::Cop::Lint::UselessAccessModifier do
     end
 
     it 'registers an offense' do
-      inspect_source(cop, source)
+      inspect_source(source)
       expect(cop.offenses.size).to eq(1)
       expect(cop.offenses.first.message)
         .to eq('Useless `protected` access modifier.')
@@ -107,7 +107,7 @@ describe RuboCop::Cop::Lint::UselessAccessModifier do
     end
 
     it 'registers an offense' do
-      inspect_source(cop, source)
+      inspect_source(source)
       expect(cop.offenses.size).to eq(1)
       expect(cop.offenses.first.message)
         .to eq('Useless `private` access modifier.')
@@ -139,7 +139,7 @@ describe RuboCop::Cop::Lint::UselessAccessModifier do
     end
 
     it 'registers an offense' do
-      inspect_source(cop, source)
+      inspect_source(source)
       expect(cop.offenses.size).to eq(1)
       expect(cop.offenses.first.message)
         .to eq('Useless `private` access modifier.')
@@ -160,7 +160,7 @@ describe RuboCop::Cop::Lint::UselessAccessModifier do
     end
 
     it 'registers an offense' do
-      inspect_source(cop, source)
+      inspect_source(source)
       expect(cop.offenses.size).to eq(1)
       expect(cop.offenses.first.message)
         .to eq('Useless `private` access modifier.')
@@ -182,7 +182,7 @@ describe RuboCop::Cop::Lint::UselessAccessModifier do
       end
 
       it 'does not register an offense' do
-        inspect_source(cop, source)
+        inspect_source(source)
         expect(cop.offenses).to be_empty
       end
     end
@@ -271,7 +271,7 @@ describe RuboCop::Cop::Lint::UselessAccessModifier do
           end
          end
       RUBY
-      inspect_source(cop, src)
+      inspect_source(src)
       expect(cop.offenses.size).to eq(1)
       expect(cop.offenses.first.line).to eq(17)
     end
@@ -296,7 +296,7 @@ describe RuboCop::Cop::Lint::UselessAccessModifier do
           end
         end
       RUBY
-      inspect_source(cop, src)
+      inspect_source(src)
       expect(cop.offenses.size).to eq(1)
     end
   end
@@ -356,7 +356,7 @@ describe RuboCop::Cop::Lint::UselessAccessModifier do
           private
         end
       RUBY
-      inspect_source(cop, src)
+      inspect_source(src)
       expect(cop.offenses.size).to eq(1)
       expect(cop.offenses.first.line).to eq(4)
     end
@@ -371,7 +371,7 @@ describe RuboCop::Cop::Lint::UselessAccessModifier do
           end
         end
       RUBY
-      inspect_source(cop, src)
+      inspect_source(src)
       expect(cop.offenses.size).to eq(1)
     end
 
@@ -383,7 +383,7 @@ describe RuboCop::Cop::Lint::UselessAccessModifier do
           end
         end
       RUBY
-      inspect_source(cop, src)
+      inspect_source(src)
       expect(cop.offenses).to be_empty
     end
 
@@ -395,7 +395,7 @@ describe RuboCop::Cop::Lint::UselessAccessModifier do
           end
         end
       RUBY
-      inspect_source(cop, src)
+      inspect_source(src)
       expect(cop.offenses).to be_empty
     end
   end
@@ -413,7 +413,7 @@ describe RuboCop::Cop::Lint::UselessAccessModifier do
           end
         end
       RUBY
-      inspect_source(cop, src)
+      inspect_source(src)
       expect(cop.offenses.size).to eq(1)
     end
   end
@@ -429,7 +429,7 @@ describe RuboCop::Cop::Lint::UselessAccessModifier do
           end
         end
       RUBY
-      inspect_source(cop, src)
+      inspect_source(src)
       expect(cop.offenses.size).to eq(1)
     end
 
@@ -443,7 +443,7 @@ describe RuboCop::Cop::Lint::UselessAccessModifier do
           end
         end
       RUBY
-      inspect_source(cop, src)
+      inspect_source(src)
       expect(cop.offenses).to be_empty
     end
 
@@ -457,7 +457,7 @@ describe RuboCop::Cop::Lint::UselessAccessModifier do
           end
         end
       RUBY
-      inspect_source(cop, src)
+      inspect_source(src)
       expect(cop.offenses).to be_empty
     end
   end
@@ -473,7 +473,7 @@ describe RuboCop::Cop::Lint::UselessAccessModifier do
           #{modifier}
         end
       RUBY
-      inspect_source(cop, src)
+      inspect_source(src)
       expect(cop.offenses.size).to eq(1)
     end
   end
@@ -495,7 +495,7 @@ describe RuboCop::Cop::Lint::UselessAccessModifier do
           end
         end
       RUBY
-      inspect_source(cop, src)
+      inspect_source(src)
       expect(cop.offenses.size).to eq(1)
     end
 
@@ -510,7 +510,7 @@ describe RuboCop::Cop::Lint::UselessAccessModifier do
             end
           end
         RUBY
-        inspect_source(cop, src)
+        inspect_source(src)
         expect(cop.offenses).to be_empty
       end
     end
@@ -530,7 +530,7 @@ describe RuboCop::Cop::Lint::UselessAccessModifier do
           end
         end
       RUBY
-      inspect_source(cop, src)
+      inspect_source(src)
       expect(cop.offenses.size).to eq(1)
     end
   end
@@ -547,7 +547,7 @@ describe RuboCop::Cop::Lint::UselessAccessModifier do
             end
           end
         RUBY
-        inspect_source(cop, src)
+        inspect_source(src)
         expect(cop.offenses).to be_empty
       end
     end
@@ -564,7 +564,7 @@ describe RuboCop::Cop::Lint::UselessAccessModifier do
                '    end',
                '  end',
                'end']
-        inspect_source(cop, src)
+        inspect_source(src)
         expect(cop.offenses).to be_empty
       end
     end
@@ -579,7 +579,7 @@ describe RuboCop::Cop::Lint::UselessAccessModifier do
           end
         end
       RUBY
-      inspect_source(cop, src)
+      inspect_source(src)
       expect(cop.offenses).to be_empty
     end
 
@@ -591,7 +591,7 @@ describe RuboCop::Cop::Lint::UselessAccessModifier do
             define_method(:method1, #{proc_type} { })
           end
         RUBY
-        inspect_source(cop, src)
+        inspect_source(src)
         expect(cop.offenses).to be_empty
       end
     end
@@ -609,7 +609,7 @@ describe RuboCop::Cop::Lint::UselessAccessModifier do
             end
           end
         RUBY
-        inspect_source(cop, src)
+        inspect_source(src)
         expect(cop.offenses).to be_empty
       end
 
@@ -627,7 +627,7 @@ describe RuboCop::Cop::Lint::UselessAccessModifier do
             end
           end
         RUBY
-        inspect_source(cop, src)
+        inspect_source(src)
         expect(cop.offenses).to be_empty
       end
 
@@ -639,7 +639,7 @@ describe RuboCop::Cop::Lint::UselessAccessModifier do
             end
           end
         RUBY
-        inspect_source(cop, src)
+        inspect_source(src)
         expect(cop.offenses.size).to eq(1)
       end
 
@@ -653,7 +653,7 @@ describe RuboCop::Cop::Lint::UselessAccessModifier do
             end
           end
         RUBY
-        inspect_source(cop, src)
+        inspect_source(src)
         expect(cop.offenses.size).to eq(1)
       end
 
@@ -668,7 +668,7 @@ describe RuboCop::Cop::Lint::UselessAccessModifier do
             end
           end
         RUBY
-        inspect_source(cop, src)
+        inspect_source(src)
         expect(cop.offenses.size).to eq(1)
       end
     end
@@ -682,7 +682,7 @@ describe RuboCop::Cop::Lint::UselessAccessModifier do
             end
           end
         RUBY
-        inspect_source(cop, src)
+        inspect_source(src)
         expect(cop.offenses).to be_empty
       end
 
@@ -692,7 +692,7 @@ describe RuboCop::Cop::Lint::UselessAccessModifier do
             #{modifier}
           end
         RUBY
-        inspect_source(cop, src)
+        inspect_source(src)
         expect(cop.offenses.size).to eq(1)
       end
 
@@ -704,7 +704,7 @@ describe RuboCop::Cop::Lint::UselessAccessModifier do
             #{modifier}
           end
         RUBY
-        inspect_source(cop, src)
+        inspect_source(src)
         expect(cop.offenses.size).to eq(1)
       end
     end
@@ -719,7 +719,7 @@ describe RuboCop::Cop::Lint::UselessAccessModifier do
           end
         end
       RUBY
-      inspect_source(cop, src)
+      inspect_source(src)
       expect(cop.offenses).to be_empty
     end
 
@@ -729,7 +729,7 @@ describe RuboCop::Cop::Lint::UselessAccessModifier do
           #{modifier}
         end
       RUBY
-      inspect_source(cop, src)
+      inspect_source(src)
       expect(cop.offenses.size).to eq(1)
     end
 
@@ -745,7 +745,7 @@ describe RuboCop::Cop::Lint::UselessAccessModifier do
             end
           end
         RUBY
-        inspect_source(cop, src)
+        inspect_source(src)
         expect(cop.offenses.size).to eq(1)
       end
 
@@ -759,7 +759,7 @@ describe RuboCop::Cop::Lint::UselessAccessModifier do
             end
           end
         RUBY
-        inspect_source(cop, src)
+        inspect_source(src)
         expect(cop.offenses.size).to eq(2)
       end
     end
@@ -774,7 +774,7 @@ describe RuboCop::Cop::Lint::UselessAccessModifier do
           end
         end
       RUBY
-      inspect_source(cop, src)
+      inspect_source(src)
       expect(cop.offenses).to be_empty
     end
 
@@ -784,7 +784,7 @@ describe RuboCop::Cop::Lint::UselessAccessModifier do
           #{modifier}
         end
       RUBY
-      inspect_source(cop, src)
+      inspect_source(src)
       expect(cop.offenses.size).to eq(1)
     end
   end
@@ -798,7 +798,7 @@ describe RuboCop::Cop::Lint::UselessAccessModifier do
           end
         end
       RUBY
-      inspect_source(cop, src)
+      inspect_source(src)
       expect(cop.offenses).to be_empty
     end
 
@@ -808,7 +808,7 @@ describe RuboCop::Cop::Lint::UselessAccessModifier do
           #{modifier}
         end
       RUBY
-      inspect_source(cop, src)
+      inspect_source(src)
       expect(cop.offenses.size).to eq(1)
     end
 
@@ -824,7 +824,7 @@ describe RuboCop::Cop::Lint::UselessAccessModifier do
             end
           end
         RUBY
-        inspect_source(cop, src)
+        inspect_source(src)
         expect(cop.offenses.size).to eq(1)
       end
 
@@ -838,7 +838,7 @@ describe RuboCop::Cop::Lint::UselessAccessModifier do
             end
           end
         RUBY
-        inspect_source(cop, src)
+        inspect_source(src)
         expect(cop.offenses.size).to eq(2)
       end
     end
@@ -860,7 +860,7 @@ describe RuboCop::Cop::Lint::UselessAccessModifier do
           end
         end
       RUBY
-      inspect_source(cop, src)
+      inspect_source(src)
       expect(cop.offenses).to be_empty
     end
 
@@ -874,7 +874,7 @@ describe RuboCop::Cop::Lint::UselessAccessModifier do
             end
           end
         RUBY
-        inspect_source(cop, src)
+        inspect_source(src)
         expect(cop.offenses.size).to eq(2)
       end
 
@@ -888,7 +888,7 @@ describe RuboCop::Cop::Lint::UselessAccessModifier do
             end
           end
         RUBY
-        inspect_source(cop, src)
+        inspect_source(src)
         expect(cop.offenses.size).to eq(1)
       end
 
@@ -900,7 +900,7 @@ describe RuboCop::Cop::Lint::UselessAccessModifier do
             end
           end
         RUBY
-        inspect_source(cop, src)
+        inspect_source(src)
         expect(cop.offenses.size).to eq(1)
       end
     end

--- a/spec/rubocop/cop/lint/useless_assignment_spec.rb
+++ b/spec/rubocop/cop/lint/useless_assignment_spec.rb
@@ -19,7 +19,7 @@ describe RuboCop::Cop::Lint::UselessAssignment do
     end
 
     it 'registers an offense' do
-      inspect_source(cop, source)
+      inspect_source(source)
       expect(cop.offenses.size).to eq(1)
       expect(cop.offenses.first.message)
         .to eq('Useless assignment to variable - `foo`.')
@@ -47,7 +47,7 @@ describe RuboCop::Cop::Lint::UselessAssignment do
     end
 
     it 'registers an offense' do
-      inspect_source(cop, source)
+      inspect_source(source)
       expect(cop.offenses.size).to eq(1)
       expect(cop.offenses.first.message)
         .to eq('Useless assignment to variable - `foo`.')
@@ -76,7 +76,7 @@ describe RuboCop::Cop::Lint::UselessAssignment do
     end
 
     it 'registers an offense' do
-      inspect_source(cop, source)
+      inspect_source(source)
       expect(cop.offenses.size).to eq(1)
       expect(cop.offenses.first.message)
         .to eq('Useless assignment to variable - `foo`.')
@@ -103,7 +103,7 @@ describe RuboCop::Cop::Lint::UselessAssignment do
     end
 
     it 'registers an offense' do
-      inspect_source(cop, source)
+      inspect_source(source)
       expect(cop.offenses.size).to eq(1)
       expect(cop.offenses.first.message)
         .to eq('Useless assignment to variable - `foo`.')
@@ -132,7 +132,7 @@ describe RuboCop::Cop::Lint::UselessAssignment do
     end
 
     it 'registers an offense' do
-      inspect_source(cop, source)
+      inspect_source(source)
       expect(cop.offenses.size).to eq(1)
       expect(cop.offenses.first.message)
         .to eq('Useless assignment to variable - `foo`.')
@@ -161,7 +161,7 @@ describe RuboCop::Cop::Lint::UselessAssignment do
     end
 
     it 'registers an offense' do
-      inspect_source(cop, source)
+      inspect_source(source)
       expect(cop.offenses.size).to eq(1)
       expect(cop.offenses.first.message)
         .to eq('Useless assignment to variable - `foo`.')
@@ -188,7 +188,7 @@ describe RuboCop::Cop::Lint::UselessAssignment do
     end
 
     it 'registers an offense' do
-      inspect_source(cop, source)
+      inspect_source(source)
       expect(cop.offenses.size).to eq(1)
       expect(cop.offenses.first.message)
         .to eq('Useless assignment to variable - `foo`.')
@@ -209,7 +209,7 @@ describe RuboCop::Cop::Lint::UselessAssignment do
     end
 
     it 'registers an offense' do
-      inspect_source(cop, source)
+      inspect_source(source)
       expect(cop.offenses.size).to eq(1)
       expect(cop.offenses.first.message)
         .to eq('Useless assignment to variable - `foo`.')
@@ -227,7 +227,7 @@ describe RuboCop::Cop::Lint::UselessAssignment do
     end
 
     it 'registers an offense' do
-      inspect_source(cop, source)
+      inspect_source(source)
       expect(cop.offenses.size).to eq(1)
       expect(cop.offenses.first.message).to eq(
         'Useless assignment to variable - `foo`. Use `||` instead of `||=`.'
@@ -251,7 +251,7 @@ describe RuboCop::Cop::Lint::UselessAssignment do
     end
 
     it 'registers offenses for each assignment' do
-      inspect_source(cop, source)
+      inspect_source(source)
       expect(cop.offenses.size).to eq(2)
 
       expect(cop.offenses[0].message)
@@ -279,7 +279,7 @@ describe RuboCop::Cop::Lint::UselessAssignment do
     end
 
     it 'registers an offense for the non-re-referenced assignment' do
-      inspect_source(cop, source)
+      inspect_source(source)
       expect(cop.offenses.size).to eq(1)
       expect(cop.offenses.first.message)
         .to eq('Useless assignment to variable - `foo`.')
@@ -301,7 +301,7 @@ describe RuboCop::Cop::Lint::UselessAssignment do
     end
 
     it 'registers an offense for the unreferenced assignment' do
-      inspect_source(cop, source)
+      inspect_source(source)
       expect(cop.offenses.size).to eq(1)
       expect(cop.offenses.first.message)
         .to eq('Useless assignment to variable - `foo`.')
@@ -372,7 +372,7 @@ describe RuboCop::Cop::Lint::UselessAssignment do
     end
 
     it 'registers offenses for the assignment' do
-      inspect_source(cop, source)
+      inspect_source(source)
       expect(cop.offenses.size).to eq(1)
       expect(cop.offenses.first.message)
         .to eq('Useless assignment to variable - `foo`.')
@@ -393,7 +393,7 @@ describe RuboCop::Cop::Lint::UselessAssignment do
     end
 
     it 'registers an offense' do
-      inspect_source(cop, source)
+      inspect_source(source)
       expect(cop.offenses.size).to eq(1)
       expect(cop.offenses.first.message)
         .to eq('Useless assignment to variable - `foo`.')
@@ -486,7 +486,7 @@ describe RuboCop::Cop::Lint::UselessAssignment do
     it 'registers an offense' do
       pending 'Requires an advanced logic that checks whether the return ' \
               'value of an operator assignment is used or not.'
-      inspect_source(cop, source)
+      inspect_source(source)
       expect(cop.offenses.size).to eq(1)
       expect(cop.offenses.first.message)
         .to eq('Useless assignment to variable - `foo`.')
@@ -510,7 +510,7 @@ describe RuboCop::Cop::Lint::UselessAssignment do
     end
 
     it 'registers an offense' do
-      inspect_source(cop, source)
+      inspect_source(source)
       expect(cop.offenses.size).to eq(1)
       expect(cop.offenses.first.message)
         .to eq('Useless assignment to variable - `foo`.')
@@ -535,7 +535,7 @@ describe RuboCop::Cop::Lint::UselessAssignment do
     end
 
     it 'registers an offense' do
-      inspect_source(cop, source)
+      inspect_source(source)
       expect(cop.offenses.size).to eq(1)
       expect(cop.offenses.first.message)
         .to eq('Useless assignment to variable - `foo`.')
@@ -557,7 +557,7 @@ describe RuboCop::Cop::Lint::UselessAssignment do
     end
 
     it 'registers an offense' do
-      inspect_source(cop, source)
+      inspect_source(source)
       expect(cop.offenses.size).to eq(1)
       expect(cop.offenses.first.message)
         .to eq('Useless assignment to variable - `foo`.')
@@ -584,7 +584,7 @@ describe RuboCop::Cop::Lint::UselessAssignment do
     end
 
     it 'registers an offense for the unreferenced assignment' do
-      inspect_source(cop, source)
+      inspect_source(source)
       expect(cop.offenses.size).to eq(1)
       expect(cop.offenses.first.message)
         .to eq('Useless assignment to variable - `foo`.')
@@ -746,7 +746,7 @@ describe RuboCop::Cop::Lint::UselessAssignment do
     end
 
     it 'registers an offense for the unreferenced assignment' do
-      inspect_source(cop, source)
+      inspect_source(source)
       expect(cop.offenses.size).to eq(1)
       expect(cop.offenses.first.message)
         .to eq('Useless assignment to variable - `foo`.')
@@ -771,7 +771,7 @@ describe RuboCop::Cop::Lint::UselessAssignment do
     end
 
     it 'registers an offense for the assignment in the if branch' do
-      inspect_source(cop, source)
+      inspect_source(source)
       expect(cop.offenses.size).to eq(1)
       expect(cop.offenses.first.message)
         .to eq('Useless assignment to variable - `foo`.')
@@ -798,7 +798,7 @@ describe RuboCop::Cop::Lint::UselessAssignment do
     end
 
     it 'registers an offense for the reassignment in the if branch' do
-      inspect_source(cop, source)
+      inspect_source(source)
       expect(cop.offenses.size).to eq(1)
       expect(cop.offenses.first.message)
         .to eq('Useless assignment to variable - `foo`.')
@@ -820,7 +820,7 @@ describe RuboCop::Cop::Lint::UselessAssignment do
     end
 
     it 'registers an offense for the assignment in the if branch' do
-      inspect_source(cop, source)
+      inspect_source(source)
       expect(cop.offenses.size).to eq(1)
       expect(cop.offenses.first.message)
         .to eq('Useless assignment to variable - `foo`.')
@@ -847,7 +847,7 @@ describe RuboCop::Cop::Lint::UselessAssignment do
     end
 
     it 'registers an offense for the reassignment in the if branch' do
-      inspect_source(cop, source)
+      inspect_source(source)
       expect(cop.offenses.size).to eq(1)
       expect(cop.offenses.first.message)
         .to eq('Useless assignment to variable - `foo`.')
@@ -878,7 +878,7 @@ describe RuboCop::Cop::Lint::UselessAssignment do
     end
 
     it 'registers an offense for the reassignment in the if branch' do
-      inspect_source(cop, source)
+      inspect_source(source)
       expect(cop.offenses.size).to eq(1)
       expect(cop.offenses.first.message)
         .to eq('Useless assignment to variable - `foo`.')
@@ -934,7 +934,7 @@ describe RuboCop::Cop::Lint::UselessAssignment do
     end
 
     it 'registers an offense' do
-      inspect_source(cop, source)
+      inspect_source(source)
       expect(cop.offenses.size).to eq(1)
       expect(cop.offenses.first.message)
         .to eq('Useless assignment to variable - `foo`.')
@@ -971,7 +971,7 @@ describe RuboCop::Cop::Lint::UselessAssignment do
     end
 
     it 'registers an offense for the unreferenced assignment' do
-      inspect_source(cop, source)
+      inspect_source(source)
       expect(cop.offenses.size).to eq(1)
       expect(cop.offenses.first.message)
         .to eq('Useless assignment to variable - `foo`.')
@@ -1058,7 +1058,7 @@ describe RuboCop::Cop::Lint::UselessAssignment do
     end
 
     it 'registers an offense for the assignment in rhs' do
-      inspect_source(cop, source)
+      inspect_source(source)
       expect(cop.offenses.size).to eq(1)
       expect(cop.offenses.first.message)
         .to eq('Useless assignment to variable - `foo`.')
@@ -1093,7 +1093,7 @@ describe RuboCop::Cop::Lint::UselessAssignment do
     end
 
     it 'registers an offense' do
-      inspect_source(cop, source)
+      inspect_source(source)
       expect(cop.offenses.size).to eq(1)
       expect(cop.offenses.first.message).to eq(
         'Useless assignment to variable - `foo`. Use `||` instead of `||=`.'
@@ -1116,7 +1116,7 @@ describe RuboCop::Cop::Lint::UselessAssignment do
     end
 
     it 'registers an offense' do
-      inspect_source(cop, source)
+      inspect_source(source)
       expect(cop.offenses.size).to eq(1)
       expect(cop.offenses.first.message)
         .to eq('Useless assignment to variable - `foo`.')
@@ -1137,7 +1137,7 @@ describe RuboCop::Cop::Lint::UselessAssignment do
     end
 
     it 'registers an offense' do
-      inspect_source(cop, source)
+      inspect_source(source)
       expect(cop.offenses.size).to eq(1)
       expect(cop.offenses.first.message).to eq(
         'Useless assignment to variable - `bar`. ' \
@@ -1211,7 +1211,7 @@ describe RuboCop::Cop::Lint::UselessAssignment do
     end
 
     it 'registers an offense' do
-      inspect_source(cop, source)
+      inspect_source(source)
       expect(cop.offenses.size).to eq(1)
       expect(cop.offenses.first.message)
         .to eq('Useless assignment to variable - `foo`.')
@@ -1325,7 +1325,7 @@ describe RuboCop::Cop::Lint::UselessAssignment do
     end
 
     it 'registers an offense' do
-      inspect_source(cop, source)
+      inspect_source(source)
       expect(cop.offenses.size).to eq(1)
       expect(cop.offenses.first.message)
         .to eq('Useless assignment to variable - `foo`.')
@@ -1354,7 +1354,7 @@ describe RuboCop::Cop::Lint::UselessAssignment do
     end
 
     it 'registers an offense' do
-      inspect_source(cop, source)
+      inspect_source(source)
       expect(cop.offenses.size).to eq(1)
       expect(cop.offenses.first.message)
         .to eq('Useless assignment to variable - `foo`.')
@@ -1381,7 +1381,7 @@ describe RuboCop::Cop::Lint::UselessAssignment do
     end
 
     it 'registers an offense' do
-      inspect_source(cop, source)
+      inspect_source(source)
       expect(cop.offenses.size).to eq(1)
       expect(cop.offenses.first.message)
         .to eq('Useless assignment to variable - `foo`.')
@@ -1452,7 +1452,7 @@ describe RuboCop::Cop::Lint::UselessAssignment do
     end
 
     it 'registers offenses for each assignment before ensure' do
-      inspect_source(cop, source)
+      inspect_source(source)
       expect(cop.offenses.size).to eq(4)
 
       expect(cop.offenses[0].line).to eq(3)
@@ -1476,7 +1476,7 @@ describe RuboCop::Cop::Lint::UselessAssignment do
     end
 
     it 'registers an offense' do
-      inspect_source(cop, source)
+      inspect_source(source)
       expect(cop.offenses.size).to eq(1)
       expect(cop.offenses.first.message)
         .to eq('Useless assignment to variable - `error`.')
@@ -1512,7 +1512,7 @@ describe RuboCop::Cop::Lint::UselessAssignment do
     end
 
     it 'registers an offense' do
-      inspect_source(cop, source)
+      inspect_source(source)
       expect(cop.offenses.size).to eq(1)
       expect(cop.offenses.first.message)
         .to eq('Useless assignment to variable - `foo`.')
@@ -1535,7 +1535,7 @@ describe RuboCop::Cop::Lint::UselessAssignment do
     end
 
     it 'registers an offense' do
-      inspect_source(cop, source)
+      inspect_source(source)
       expect(cop.offenses.size).to eq(1)
       expect(cop.offenses.first.message)
         .to eq('Useless assignment to variable - `foo`.')
@@ -1550,7 +1550,7 @@ describe RuboCop::Cop::Lint::UselessAssignment do
     end
 
     it 'registers an offense' do
-      inspect_source(cop, source)
+      inspect_source(source)
       expect(cop.offenses.size).to eq(1)
       expect(cop.offenses.first.message)
         .to eq('Useless assignment to variable - `foo`.')
@@ -1571,7 +1571,7 @@ describe RuboCop::Cop::Lint::UselessAssignment do
     end
 
     it 'registers an offense' do
-      inspect_source(cop, source)
+      inspect_source(source)
       expect(cop.offenses.size).to eq(1)
       expect(cop.offenses.first.message)
         .to eq('Useless assignment to variable - `foo`.')
@@ -1645,7 +1645,7 @@ describe RuboCop::Cop::Lint::UselessAssignment do
     end
 
     it 'registers an offense' do
-      inspect_source(cop, source)
+      inspect_source(source)
       expect(cop.offenses.size).to eq(1)
       expect(cop.offenses.first.message)
         .to eq('Useless assignment to variable - `foo`.')
@@ -1786,7 +1786,7 @@ describe RuboCop::Cop::Lint::UselessAssignment do
     end
 
     it 'registers an offense' do
-      inspect_source(cop, source)
+      inspect_source(source)
       expect(cop.offenses.size).to eq(1)
       expect(cop.offenses.first.message)
         .to eq('Useless assignment to variable - `foo`.')
@@ -1821,7 +1821,7 @@ describe RuboCop::Cop::Lint::UselessAssignment do
       end
 
       it 'registers an offense' do
-        inspect_source(cop, source)
+        inspect_source(source)
         expect(cop.offenses.size).to eq(1)
         expect(cop.offenses.first.message)
           .to eq('Useless assignment to variable - `foo`.')
@@ -1876,7 +1876,7 @@ describe RuboCop::Cop::Lint::UselessAssignment do
       end
 
       it 'suggests the method name' do
-        inspect_source(cop, source)
+        inspect_source(source)
         expect(cop.offenses.size).to eq(1)
         expect(cop.offenses.first.message).to eq(
           'Useless assignment to variable - `enviromnent`. ' \
@@ -1898,7 +1898,7 @@ describe RuboCop::Cop::Lint::UselessAssignment do
       end
 
       it 'suggests the variable name' do
-        inspect_source(cop, source)
+        inspect_source(source)
         expect(cop.offenses.size).to eq(1)
         expect(cop.offenses.first.message).to eq(
           'Useless assignment to variable - `enviromnent`. ' \
@@ -1919,7 +1919,7 @@ describe RuboCop::Cop::Lint::UselessAssignment do
       end
 
       it 'does not suggest any name' do
-        inspect_source(cop, source)
+        inspect_source(source)
         expect(cop.offenses.size).to eq(1)
         expect(cop.offenses.first.message)
           .to eq('Useless assignment to variable - `enviromnent`.')
@@ -1938,7 +1938,7 @@ describe RuboCop::Cop::Lint::UselessAssignment do
       end
 
       it 'does not suggest any name' do
-        inspect_source(cop, source)
+        inspect_source(source)
         expect(cop.offenses.size).to eq(1)
         expect(cop.offenses.first.message)
           .to eq('Useless assignment to variable - `enviromnent`.')
@@ -1957,7 +1957,7 @@ describe RuboCop::Cop::Lint::UselessAssignment do
       end
 
       it 'does not suggest any name' do
-        inspect_source(cop, source)
+        inspect_source(source)
         expect(cop.offenses.size).to eq(1)
         expect(cop.offenses.first.message)
           .to eq('Useless assignment to variable - `enviromnent`.')
@@ -1978,7 +1978,7 @@ describe RuboCop::Cop::Lint::UselessAssignment do
       end
 
       it 'does not suggest any name' do
-        inspect_source(cop, source)
+        inspect_source(source)
         expect(cop.offenses.size).to eq(1)
         expect(cop.offenses.first.message)
           .to eq('Useless assignment to variable - `enviromnent`.')

--- a/spec/rubocop/cop/lint/useless_comparison_spec.rb
+++ b/spec/rubocop/cop/lint/useless_comparison_spec.rb
@@ -5,7 +5,7 @@ describe RuboCop::Cop::Lint::UselessComparison do
 
   described_class::OPS.each do |op|
     it "registers an offense for a simple comparison with #{op}" do
-      inspect_source(cop, <<-RUBY.strip_indent)
+      inspect_source(<<-RUBY.strip_indent)
         5 #{op} 5
         a #{op} a
       RUBY
@@ -13,7 +13,7 @@ describe RuboCop::Cop::Lint::UselessComparison do
     end
 
     it "registers an offense for a complex comparison with #{op}" do
-      inspect_source(cop, <<-RUBY.strip_indent)
+      inspect_source(<<-RUBY.strip_indent)
         5 + 10 * 30 #{op} 5 + 10 * 30
         a.top(x) #{op} a.top(x)
       RUBY

--- a/spec/rubocop/cop/lint/useless_else_without_rescue_spec.rb
+++ b/spec/rubocop/cop/lint/useless_else_without_rescue_spec.rb
@@ -4,7 +4,7 @@ describe RuboCop::Cop::Lint::UselessElseWithoutRescue do
   subject(:cop) { described_class.new }
 
   before do
-    inspect_source(cop, source)
+    inspect_source(source)
   end
 
   context 'with `else` without `rescue`' do

--- a/spec/rubocop/cop/lint/void_spec.rb
+++ b/spec/rubocop/cop/lint/void_spec.rb
@@ -5,7 +5,7 @@ describe RuboCop::Cop::Lint::Void do
 
   described_class::OPS.each do |op|
     it "registers an offense for void op #{op} if not on last line" do
-      inspect_source(cop, <<-RUBY.strip_indent)
+      inspect_source(<<-RUBY.strip_indent)
         a #{op} b
         a #{op} b
         a #{op} b
@@ -16,7 +16,7 @@ describe RuboCop::Cop::Lint::Void do
 
   described_class::OPS.each do |op|
     it "accepts void op #{op} if on last line" do
-      inspect_source(cop, <<-RUBY.strip_indent)
+      inspect_source(<<-RUBY.strip_indent)
         something
         a #{op} b
       RUBY
@@ -26,15 +26,14 @@ describe RuboCop::Cop::Lint::Void do
 
   described_class::OPS.each do |op|
     it "accepts void op #{op} by itself without a begin block" do
-      inspect_source(cop, "a #{op} b")
+      inspect_source("a #{op} b")
       expect(cop.offenses).to be_empty
     end
   end
 
   %w[var @var @@var VAR $var].each do |var|
     it "registers an offense for void var #{var} if not on last line" do
-      inspect_source(cop,
-                     ["#{var} = 5",
+      inspect_source(["#{var} = 5",
                       var,
                       'top'])
       expect(cop.offenses.size).to eq(1)
@@ -43,8 +42,7 @@ describe RuboCop::Cop::Lint::Void do
 
   %w(1 2.0 :test /test/ [1] {}).each do |lit|
     it "registers an offense for void lit #{lit} if not on last line" do
-      inspect_source(cop,
-                     [lit,
+      inspect_source([lit,
                       'top'])
       expect(cop.offenses.size).to eq(1)
     end

--- a/spec/rubocop/cop/metrics/abc_size_spec.rb
+++ b/spec/rubocop/cop/metrics/abc_size_spec.rb
@@ -14,7 +14,7 @@ describe RuboCop::Cop::Metrics::AbcSize, :config do
     end
 
     it 'registers an offense for an if modifier' do
-      inspect_source(cop, <<-RUBY.strip_indent)
+      inspect_source(<<-RUBY.strip_indent)
         def method_name
           call_foo if some_condition # 0 + 2*2 + 1*1
         end
@@ -27,7 +27,7 @@ describe RuboCop::Cop::Metrics::AbcSize, :config do
     end
 
     it 'registers an offense for an assignment of a local variable' do
-      inspect_source(cop, <<-RUBY.strip_indent)
+      inspect_source(<<-RUBY.strip_indent)
         def method_name
           x = 1
         end
@@ -39,7 +39,7 @@ describe RuboCop::Cop::Metrics::AbcSize, :config do
     end
 
     it 'registers an offense for an assignment of an element' do
-      inspect_source(cop, <<-RUBY.strip_indent)
+      inspect_source(<<-RUBY.strip_indent)
         def method_name
           x[0] = 1
         end
@@ -52,7 +52,7 @@ describe RuboCop::Cop::Metrics::AbcSize, :config do
 
     it 'registers an offense for complex content including A, B, and C ' \
        'scores' do
-      inspect_source(cop, <<-RUBY.strip_indent)
+      inspect_source(<<-RUBY.strip_indent)
         def method_name
           my_options = Hash.new if 1 == 1 || 2 == 2 # 1, 3, 2
           my_options.each do |key, value|           # 0, 1, 0
@@ -116,9 +116,9 @@ describe RuboCop::Cop::Metrics::AbcSize, :config do
         # Build an amount of code large enough to register an offense.
         code = ['  x = Hash.new if 1 == 1 || 2 == 2'] * max
 
-        inspect_source(cop, ['def method_name',
-                             *code,
-                             'end'])
+        inspect_source(['def method_name',
+                        *code,
+                        'end'])
         expect(cop.messages)
           .to eq(['Assignment Branch Condition size for method_name is too ' \
                   "high. [#{presentation}]"])

--- a/spec/rubocop/cop/metrics/block_length_spec.rb
+++ b/spec/rubocop/cop/metrics/block_length_spec.rb
@@ -5,7 +5,7 @@ describe RuboCop::Cop::Metrics::BlockLength, :config do
   let(:cop_config) { { 'Max' => 2, 'CountComments' => false } }
 
   it 'rejects a block with more than 5 lines' do
-    inspect_source(cop, <<-RUBY.strip_indent)
+    inspect_source(<<-RUBY.strip_indent)
       something do
         a = 1
         a = 2
@@ -19,7 +19,7 @@ describe RuboCop::Cop::Metrics::BlockLength, :config do
   end
 
   it 'reports the correct beginning and end lines' do
-    inspect_source(cop, <<-RUBY.strip_indent)
+    inspect_source(<<-RUBY.strip_indent)
       something do
         a = 1
         a = 2
@@ -72,7 +72,7 @@ describe RuboCop::Cop::Metrics::BlockLength, :config do
   end
 
   it 'rejects brace blocks too' do
-    inspect_source(cop, <<-RUBY.strip_indent)
+    inspect_source(<<-RUBY.strip_indent)
       something {
         a = 1
         a = 2
@@ -83,7 +83,7 @@ describe RuboCop::Cop::Metrics::BlockLength, :config do
   end
 
   it 'properly counts nested blocks' do
-    inspect_source(cop, <<-RUBY.strip_indent)
+    inspect_source(<<-RUBY.strip_indent)
       something do
         something do
           a = 2
@@ -112,7 +112,7 @@ describe RuboCop::Cop::Metrics::BlockLength, :config do
     before { cop_config['CountComments'] = true }
 
     it 'also counts commented lines' do
-      inspect_source(cop, <<-RUBY.strip_indent)
+      inspect_source(<<-RUBY.strip_indent)
         something do
           a = 1
           #a = 2
@@ -128,7 +128,7 @@ describe RuboCop::Cop::Metrics::BlockLength, :config do
     before { cop_config['ExcludedMethods'] = ['foo'] }
 
     it 'still rejects other methods with long blocks' do
-      inspect_source(cop, <<-RUBY.strip_indent)
+      inspect_source(<<-RUBY.strip_indent)
         something do
           a = 1
           a = 2

--- a/spec/rubocop/cop/metrics/block_nesting_spec.rb
+++ b/spec/rubocop/cop/metrics/block_nesting_spec.rb
@@ -6,7 +6,7 @@ describe RuboCop::Cop::Metrics::BlockNesting, :config do
 
   shared_examples 'too deep' do |source, lines, max_to_allow = 3|
     it "registers #{lines.length} offense(s)" do
-      inspect_source(cop, source)
+      inspect_source(source)
       expect(cop.offenses.map(&:line)).to eq(lines)
       expect(cop.messages).to eq(
         ['Avoid more than 2 levels of block nesting.'] * lines.length
@@ -14,7 +14,7 @@ describe RuboCop::Cop::Metrics::BlockNesting, :config do
     end
 
     it 'sets `Max` value correctly' do
-      inspect_source(cop, source)
+      inspect_source(source)
       expect(cop.config_to_allow_offenses['Max']).to eq(max_to_allow)
     end
   end

--- a/spec/rubocop/cop/metrics/class_length_spec.rb
+++ b/spec/rubocop/cop/metrics/class_length_spec.rb
@@ -5,7 +5,7 @@ describe RuboCop::Cop::Metrics::ClassLength, :config do
   let(:cop_config) { { 'Max' => 5, 'CountComments' => false } }
 
   it 'rejects a class with more than 5 lines' do
-    inspect_source(cop, <<-RUBY.strip_indent)
+    inspect_source(<<-RUBY.strip_indent)
       class Test
         a = 1
         a = 2
@@ -21,7 +21,7 @@ describe RuboCop::Cop::Metrics::ClassLength, :config do
   end
 
   it 'reports the correct beginning and end lines' do
-    inspect_source(cop, <<-RUBY.strip_indent)
+    inspect_source(<<-RUBY.strip_indent)
       class Test
         a = 1
         a = 2
@@ -109,7 +109,7 @@ describe RuboCop::Cop::Metrics::ClassLength, :config do
     end
 
     it 'rejects a class with 6 lines that belong to the class directly' do
-      inspect_source(cop, <<-RUBY.strip_indent)
+      inspect_source(<<-RUBY.strip_indent)
         class NamespaceClass
           class TestOne
             a = 1
@@ -141,7 +141,7 @@ describe RuboCop::Cop::Metrics::ClassLength, :config do
     before { cop_config['CountComments'] = true }
 
     it 'also counts commented lines' do
-      inspect_source(cop, <<-RUBY.strip_indent)
+      inspect_source(<<-RUBY.strip_indent)
         class Test
           a = 1
           #a = 2

--- a/spec/rubocop/cop/metrics/cyclomatic_complexity_spec.rb
+++ b/spec/rubocop/cop/metrics/cyclomatic_complexity_spec.rb
@@ -28,7 +28,7 @@ describe RuboCop::Cop::Metrics::CyclomaticComplexity, :config do
     end
 
     it 'registers an offense for an if modifier' do
-      inspect_source(cop, <<-RUBY.strip_indent)
+      inspect_source(<<-RUBY.strip_indent)
         def self.method_name
           call_foo if some_condition
         end

--- a/spec/rubocop/cop/metrics/line_length_spec.rb
+++ b/spec/rubocop/cop/metrics/line_length_spec.rb
@@ -5,26 +5,26 @@ describe RuboCop::Cop::Metrics::LineLength, :config do
   let(:cop_config) { { 'Max' => 80, 'IgnoredPatterns' => nil } }
 
   it "registers an offense for a line that's 81 characters wide" do
-    inspect_source(cop, '#' * 81)
+    inspect_source('#' * 81)
     expect(cop.offenses.size).to eq(1)
     expect(cop.offenses.first.message).to eq('Line is too long. [81/80]')
     expect(cop.config_to_allow_offenses).to eq('Max' => 81)
   end
 
   it 'highlights excessive characters' do
-    inspect_source(cop, '#' * 80 + 'abc')
+    inspect_source('#' * 80 + 'abc')
     expect(cop.highlights).to eq(['abc'])
   end
 
   it "accepts a line that's 80 characters wide" do
-    inspect_source(cop, '#' * 80)
+    inspect_source('#' * 80)
     expect(cop.offenses).to be_empty
   end
 
   it 'registers an offense for long line before __END__ but not after' do
-    inspect_source(cop, ['#' * 150,
-                         '__END__',
-                         '#' * 200])
+    inspect_source(['#' * 150,
+                    '__END__',
+                    '#' * 200])
     expect(cop.messages).to eq(['Line is too long. [150/80]'])
   end
 
@@ -39,7 +39,7 @@ describe RuboCop::Cop::Metrics::LineLength, :config do
       RUBY
 
       it 'accepts the line' do
-        inspect_source(cop, source)
+        inspect_source(source)
         expect(cop.offenses).to be_empty
       end
     end
@@ -50,12 +50,12 @@ describe RuboCop::Cop::Metrics::LineLength, :config do
       RUBY
 
       it 'registers an offense for the line' do
-        inspect_source(cop, source)
+        inspect_source(source)
         expect(cop.offenses.size).to eq(1)
       end
 
       it 'highlights all the excessive characters' do
-        inspect_source(cop, source)
+        inspect_source(source)
         expect(cop.highlights).to eq(['http://plus.google.com/'])
       end
     end
@@ -68,12 +68,12 @@ describe RuboCop::Cop::Metrics::LineLength, :config do
       RUBY
 
       it 'registers an offense for the line' do
-        inspect_source(cop, source)
+        inspect_source(source)
         expect(cop.offenses.size).to eq(1)
       end
 
       it 'highlights only the non-URL part' do
-        inspect_source(cop, source)
+        inspect_source(source)
         expect(cop.highlights).to eq([' and'])
       end
     end
@@ -89,7 +89,7 @@ describe RuboCop::Cop::Metrics::LineLength, :config do
       RUBY
 
       it 'does not crash' do
-        expect { inspect_source(cop, source) }.not_to raise_error
+        expect { inspect_source(source) }.not_to raise_error
       end
     end
 
@@ -99,7 +99,7 @@ describe RuboCop::Cop::Metrics::LineLength, :config do
       RUBY
 
       it 'rejects the line' do
-        inspect_source(cop, source)
+        inspect_source(source)
         expect(cop.offenses.size).to eq(1)
       end
 
@@ -109,7 +109,7 @@ describe RuboCop::Cop::Metrics::LineLength, :config do
         end
 
         it 'accepts the line' do
-          inspect_source(cop, source)
+          inspect_source(source)
           expect(cop.offenses).to be_empty
         end
       end
@@ -136,7 +136,7 @@ describe RuboCop::Cop::Metrics::LineLength, :config do
     end
 
     it 'accepts long lines matching a pattern but not other long lines' do
-      inspect_source(cop, source)
+      inspect_source(source)
       expect(cop.highlights).to eq(['< TestCase'])
     end
   end
@@ -151,7 +151,7 @@ describe RuboCop::Cop::Metrics::LineLength, :config do
     RUBY
 
     it 'accepts long lines in heredocs' do
-      inspect_source(cop, source)
+      inspect_source(source)
       expect(cop.offenses).to be_empty
     end
 
@@ -159,7 +159,7 @@ describe RuboCop::Cop::Metrics::LineLength, :config do
       let(:source) { '# this results in AST being nil' }
 
       it 'does not crash' do
-        expect { inspect_source(cop, source) }.not_to raise_error
+        expect { inspect_source(source) }.not_to raise_error
       end
     end
 
@@ -191,7 +191,7 @@ describe RuboCop::Cop::Metrics::LineLength, :config do
       RUBY
 
       it 'rejects long lines in heredocs with not whitelisted delimiters' do
-        inspect_source(cop, source)
+        inspect_source(source)
         expect(cop.offenses.size).to eq(4)
       end
     end
@@ -206,7 +206,7 @@ describe RuboCop::Cop::Metrics::LineLength, :config do
       RUBY
 
       it 'registers an offense for the line' do
-        inspect_source(cop, source)
+        inspect_source(source)
         expect(cop.offenses.size).to eq(1)
       end
     end
@@ -223,12 +223,12 @@ describe RuboCop::Cop::Metrics::LineLength, :config do
         let(:source) { acceptable_source + cop_directive }
 
         it 'registers an offense for the line' do
-          inspect_source(cop, source)
+          inspect_source(source)
           expect(cop.offenses.size).to eq(1)
         end
 
         it 'highlights the excess directive' do
-          inspect_source(cop, source)
+          inspect_source(source)
           expect(cop.highlights).to eq([cop_directive])
         end
       end
@@ -238,7 +238,7 @@ describe RuboCop::Cop::Metrics::LineLength, :config do
         let(:source) { acceptable_source + excess_comment }
 
         it 'highlights the excess comment' do
-          inspect_source(cop, source)
+          inspect_source(source)
           expect(cop.highlights).to eq([excess_comment])
         end
       end
@@ -249,7 +249,7 @@ describe RuboCop::Cop::Metrics::LineLength, :config do
       let(:source) { 'a' * 80 + excess_with_directive }
 
       it 'highlights the excess source and cop directive' do
-        inspect_source(cop, source)
+        inspect_source(source)
         expect(cop.highlights).to eq([excess_with_directive])
       end
     end
@@ -264,7 +264,7 @@ describe RuboCop::Cop::Metrics::LineLength, :config do
       RUBY
 
       it 'accepts the line' do
-        inspect_source(cop, source)
+        inspect_source(source)
         expect(cop.offenses).to be_empty
       end
     end
@@ -277,7 +277,7 @@ describe RuboCop::Cop::Metrics::LineLength, :config do
       RUBY
 
       it 'accepts the line' do
-        inspect_source(cop, source)
+        inspect_source(source)
         expect(cop.offenses).to be_empty
       end
 
@@ -289,7 +289,7 @@ describe RuboCop::Cop::Metrics::LineLength, :config do
         RUBY
 
         it 'accepts the line' do
-          inspect_source(cop, source)
+          inspect_source(source)
           expect(cop.offenses).to be_empty
         end
       end
@@ -299,12 +299,12 @@ describe RuboCop::Cop::Metrics::LineLength, :config do
       let(:source) { 'a' * 80 + 'bcd' + ' # rubocop:enable Style/ClassVars' }
 
       it 'registers an offense for the line' do
-        inspect_source(cop, source)
+        inspect_source(source)
         expect(cop.offenses.size).to eq(1)
       end
 
       it 'highlights only the non-directive part' do
-        inspect_source(cop, source)
+        inspect_source(source)
         expect(cop.highlights).to eq(['bcd'])
       end
 
@@ -314,12 +314,12 @@ describe RuboCop::Cop::Metrics::LineLength, :config do
         RUBY
 
         it 'registers an offense for the line' do
-          inspect_source(cop, source)
+          inspect_source(source)
           expect(cop.offenses.size).to eq(1)
         end
 
         it 'highlights only the non-directive part' do
-          inspect_source(cop, source)
+          inspect_source(source)
           expect(cop.highlights).to eq(['bbbbbbb'])
         end
       end
@@ -330,12 +330,12 @@ describe RuboCop::Cop::Metrics::LineLength, :config do
         RUBY
 
         it 'registers an offense for the line' do
-          inspect_source(cop, source)
+          inspect_source(source)
           expect(cop.offenses.size).to eq(1)
         end
 
         it 'highlights only the non-directive part' do
-          inspect_source(cop, source)
+          inspect_source(source)
           expect(cop.highlights).to eq([']*={0,2})#([A-Za-z0-9+/#]*={0,2})z}'])
         end
       end

--- a/spec/rubocop/cop/metrics/method_length_spec.rb
+++ b/spec/rubocop/cop/metrics/method_length_spec.rb
@@ -5,7 +5,7 @@ describe RuboCop::Cop::Metrics::MethodLength, :config do
   let(:cop_config) { { 'Max' => 5, 'CountComments' => false } }
 
   it 'rejects a method with more than 5 lines' do
-    inspect_source(cop, <<-RUBY.strip_indent)
+    inspect_source(<<-RUBY.strip_indent)
       def m()
         a = 1
         a = 2
@@ -22,7 +22,7 @@ describe RuboCop::Cop::Metrics::MethodLength, :config do
   end
 
   it 'reports the correct beginning and end lines' do
-    inspect_source(cop, <<-RUBY.strip_indent)
+    inspect_source(<<-RUBY.strip_indent)
       def m()
         a = 1
         a = 2
@@ -50,7 +50,7 @@ describe RuboCop::Cop::Metrics::MethodLength, :config do
 
   it 'accepts a method with multiline arguments ' \
      'and less than 5 lines of body' do
-    inspect_source(cop, <<-RUBY.strip_indent)
+    inspect_source(<<-RUBY.strip_indent)
       def m(x,
             y,
             z)
@@ -111,7 +111,7 @@ describe RuboCop::Cop::Metrics::MethodLength, :config do
   end
 
   it 'checks class methods, syntax #1' do
-    inspect_source(cop, <<-RUBY.strip_indent)
+    inspect_source(<<-RUBY.strip_indent)
       def self.m()
         a = 1
         a = 2
@@ -126,7 +126,7 @@ describe RuboCop::Cop::Metrics::MethodLength, :config do
   end
 
   it 'checks class methods, syntax #2' do
-    inspect_source(cop, <<-RUBY.strip_indent)
+    inspect_source(<<-RUBY.strip_indent)
       class K
         class << self
           def m()
@@ -145,7 +145,7 @@ describe RuboCop::Cop::Metrics::MethodLength, :config do
   end
 
   it 'properly counts lines when method ends with block' do
-    inspect_source(cop, <<-RUBY.strip_indent)
+    inspect_source(<<-RUBY.strip_indent)
       def m()
         something do
           a = 2
@@ -176,7 +176,7 @@ describe RuboCop::Cop::Metrics::MethodLength, :config do
     before { cop_config['CountComments'] = true }
 
     it 'also counts commented lines' do
-      inspect_source(cop, <<-RUBY.strip_indent)
+      inspect_source(<<-RUBY.strip_indent)
         def m()
           a = 1
           #a = 2

--- a/spec/rubocop/cop/metrics/module_length_spec.rb
+++ b/spec/rubocop/cop/metrics/module_length_spec.rb
@@ -5,7 +5,7 @@ describe RuboCop::Cop::Metrics::ModuleLength, :config do
   let(:cop_config) { { 'Max' => 5, 'CountComments' => false } }
 
   it 'rejects a module with more than 5 lines' do
-    inspect_source(cop, <<-RUBY.strip_indent)
+    inspect_source(<<-RUBY.strip_indent)
       module Test
         a = 1
         a = 2
@@ -21,7 +21,7 @@ describe RuboCop::Cop::Metrics::ModuleLength, :config do
   end
 
   it 'reports the correct beginning and end lines' do
-    inspect_source(cop, <<-RUBY.strip_indent)
+    inspect_source(<<-RUBY.strip_indent)
       module Test
         a = 1
         a = 2
@@ -108,7 +108,7 @@ describe RuboCop::Cop::Metrics::ModuleLength, :config do
     end
 
     it 'rejects a module with 6 lines that belong to the module directly' do
-      inspect_source(cop, <<-RUBY.strip_indent)
+      inspect_source(<<-RUBY.strip_indent)
         module NamespaceModule
           module TestOne
             a = 1
@@ -164,7 +164,7 @@ describe RuboCop::Cop::Metrics::ModuleLength, :config do
     end
 
     it 'rejects a module with 6 lines that belong to the module directly' do
-      inspect_source(cop, <<-RUBY.strip_indent)
+      inspect_source(<<-RUBY.strip_indent)
         module NamespaceModule
           class TestOne
             a = 1
@@ -196,7 +196,7 @@ describe RuboCop::Cop::Metrics::ModuleLength, :config do
     before { cop_config['CountComments'] = true }
 
     it 'also counts commented lines' do
-      inspect_source(cop, <<-RUBY.strip_indent)
+      inspect_source(<<-RUBY.strip_indent)
         module Test
           a = 1
           #a = 2

--- a/spec/rubocop/cop/metrics/parameter_lists_spec.rb
+++ b/spec/rubocop/cop/metrics/parameter_lists_spec.rb
@@ -10,7 +10,7 @@ describe RuboCop::Cop::Metrics::ParameterLists, :config do
   end
 
   it 'registers an offense for a method def with 5 parameters' do
-    inspect_source(cop, <<-RUBY.strip_indent)
+    inspect_source(<<-RUBY.strip_indent)
       def meth(a, b, c, d, e)
       end
     RUBY
@@ -49,7 +49,7 @@ describe RuboCop::Cop::Metrics::ParameterLists, :config do
     end
 
     it 'does not count keyword arguments without default values', ruby: 2.1 do
-      inspect_source(cop, <<-RUBY.strip_indent)
+      inspect_source(<<-RUBY.strip_indent)
         def meth(a, b, c, d:, e:)
         end
       RUBY

--- a/spec/rubocop/cop/metrics/perceived_complexity_spec.rb
+++ b/spec/rubocop/cop/metrics/perceived_complexity_spec.rb
@@ -28,7 +28,7 @@ describe RuboCop::Cop::Metrics::PerceivedComplexity, :config do
     end
 
     it 'registers an offense for an if modifier' do
-      inspect_source(cop, <<-RUBY.strip_indent)
+      inspect_source(<<-RUBY.strip_indent)
         def self.method_name
           call_foo if some_condition
         end
@@ -134,7 +134,7 @@ describe RuboCop::Cop::Metrics::PerceivedComplexity, :config do
 
     it 'registers an offense for a case/when block without an expression ' \
        'after case' do
-      inspect_source(cop, <<-RUBY.strip_indent)
+      inspect_source(<<-RUBY.strip_indent)
         def method_name
           case
           when value == 1

--- a/spec/rubocop/cop/performance/case_when_splat_spec.rb
+++ b/spec/rubocop/cop/performance/case_when_splat_spec.rb
@@ -210,7 +210,7 @@ describe RuboCop::Cop::Performance::CaseWhenSplat do
           nil
         end
       RUBY
-      new_source = autocorrect_source(cop, source)
+      new_source = autocorrect_source(source)
       expect(new_source).to eq(<<-RUBY.strip_indent)
         case foo
         when Bar, Baz, *Foo
@@ -229,7 +229,7 @@ describe RuboCop::Cop::Performance::CaseWhenSplat do
           1
         end
       RUBY
-      new_source = autocorrect_source(cop, source)
+      new_source = autocorrect_source(source)
       expect(new_source).to eq(<<-RUBY.strip_indent)
         case foo
         when FooBar
@@ -250,7 +250,7 @@ describe RuboCop::Cop::Performance::CaseWhenSplat do
           1
         end
       RUBY
-      new_source = autocorrect_source(cop, source)
+      new_source = autocorrect_source(source)
       expect(new_source).to eq(<<-RUBY.strip_indent)
         case foo
         when FooBar
@@ -262,7 +262,7 @@ describe RuboCop::Cop::Performance::CaseWhenSplat do
     end
 
     it 'moves a single splat condition to the end of the when conditions' do
-      new_source = autocorrect_source(cop, <<-RUBY.strip_indent)
+      new_source = autocorrect_source(<<-RUBY.strip_indent)
         case foo
         when *cond
           bar
@@ -282,7 +282,7 @@ describe RuboCop::Cop::Performance::CaseWhenSplat do
     end
 
     it 'moves multiple splat condition to the end of the when conditions' do
-      new_source = autocorrect_source(cop, <<-RUBY.strip_indent)
+      new_source = autocorrect_source_with_loop(<<-RUBY.strip_indent)
         case foo
         when *cond1
           bar
@@ -292,11 +292,6 @@ describe RuboCop::Cop::Performance::CaseWhenSplat do
           baz
         end
       RUBY
-
-      # CaseWhenSplat requires multiple rounds of correction to avoid
-      # "clobbering errors" from Source::Rewriter
-      cop = described_class.new
-      new_source = autocorrect_source(cop, new_source)
 
       expect(new_source).to eq(<<-RUBY.strip_indent)
         case foo
@@ -312,7 +307,7 @@ describe RuboCop::Cop::Performance::CaseWhenSplat do
 
     it 'moves multiple out of order splat condition to the end ' \
        'of the when conditions' do
-      new_source = autocorrect_source(cop, <<-RUBY.strip_indent)
+      new_source = autocorrect_source_with_loop(<<-RUBY.strip_indent)
         case foo
         when *cond1
           bar
@@ -324,11 +319,6 @@ describe RuboCop::Cop::Performance::CaseWhenSplat do
           baz
         end
       RUBY
-
-      # CaseWhenSplat requires multiple rounds of correction to avoid
-      # "clobbering errors" from Source::Rewriter
-      cop = described_class.new
-      new_source = autocorrect_source(cop, new_source)
 
       expect(new_source).to eq(<<-RUBY.strip_indent)
         case foo
@@ -345,7 +335,7 @@ describe RuboCop::Cop::Performance::CaseWhenSplat do
     end
 
     it 'corrects splat condition when using when then' do
-      new_source = autocorrect_source(cop, <<-RUBY.strip_indent)
+      new_source = autocorrect_source(<<-RUBY.strip_indent)
         case foo
         when *cond then bar
         when 4 then baz
@@ -361,7 +351,7 @@ describe RuboCop::Cop::Performance::CaseWhenSplat do
     end
 
     it 'corrects nested case when statements' do
-      new_source = autocorrect_source(cop, <<-RUBY.strip_indent)
+      new_source = autocorrect_source(<<-RUBY.strip_indent)
         def check
           case foo
           when *cond
@@ -385,7 +375,7 @@ describe RuboCop::Cop::Performance::CaseWhenSplat do
     end
 
     it 'corrects splat on a variable and leaves an array literal alone' do
-      new_source = autocorrect_source(cop, <<-RUBY.strip_indent)
+      new_source = autocorrect_source(<<-RUBY.strip_indent)
         case foo
         when *cond
           bar
@@ -405,7 +395,7 @@ describe RuboCop::Cop::Performance::CaseWhenSplat do
     end
 
     it 'corrects a splat as part of the condition' do
-      new_source = autocorrect_source(cop, <<-RUBY.strip_indent)
+      new_source = autocorrect_source(<<-RUBY.strip_indent)
         case foo
         when cond1, *cond2
           bar
@@ -425,7 +415,7 @@ describe RuboCop::Cop::Performance::CaseWhenSplat do
     end
 
     it 'corrects an array followed by splat in the same condition' do
-      new_source = autocorrect_source(cop, <<-RUBY.strip_indent)
+      new_source = autocorrect_source(<<-RUBY.strip_indent)
         case foo
         when *[cond1, cond2], *cond3
           bar
@@ -445,7 +435,7 @@ describe RuboCop::Cop::Performance::CaseWhenSplat do
     end
 
     it 'corrects a splat followed by array in the same condition' do
-      new_source = autocorrect_source(cop, <<-RUBY.strip_indent)
+      new_source = autocorrect_source(<<-RUBY.strip_indent)
         case foo
         when *cond1, *[cond2, cond3]
           bar

--- a/spec/rubocop/cop/performance/case_when_splat_spec.rb
+++ b/spec/rubocop/cop/performance/case_when_splat_spec.rb
@@ -85,7 +85,7 @@ describe RuboCop::Cop::Performance::CaseWhenSplat do
 
   it 'registers an offense for a single when with splat expansion followed ' \
      'by another value' do
-    inspect_source(cop, <<-RUBY.strip_indent)
+    inspect_source(<<-RUBY.strip_indent)
       case foo
       when *Foo, Bar
         nil
@@ -176,7 +176,7 @@ describe RuboCop::Cop::Performance::CaseWhenSplat do
 
   it 'registers an offense for a splat on a variable that proceeds a splat ' \
      'on an array literal as the last condition' do
-    inspect_source(cop, <<-RUBY.strip_indent)
+    inspect_source(<<-RUBY.strip_indent)
       case foo
       when *cond
         bar

--- a/spec/rubocop/cop/performance/casecmp_spec.rb
+++ b/spec/rubocop/cop/performance/casecmp_spec.rb
@@ -5,79 +5,78 @@ describe RuboCop::Cop::Performance::Casecmp do
 
   shared_examples 'selectors' do |selector|
     it "autocorrects str.#{selector} ==" do
-      new_source = autocorrect_source(cop, "str.#{selector} == 'string'")
+      new_source = autocorrect_source("str.#{selector} == 'string'")
       expect(new_source).to eq "str.casecmp('string').zero?"
     end
 
     it "autocorrects str.#{selector} == with parens around arg" do
-      new_source = autocorrect_source(cop, "str.#{selector} == ('string')")
+      new_source = autocorrect_source("str.#{selector} == ('string')")
       expect(new_source).to eq "str.casecmp('string').zero?"
     end
 
     it "autocorrects str.#{selector} !=" do
-      new_source = autocorrect_source(cop, "str.#{selector} != 'string'")
+      new_source = autocorrect_source("str.#{selector} != 'string'")
       expect(new_source).to eq "!str.casecmp('string').zero?"
     end
 
     it "autocorrects str.#{selector} != with parens around arg" do
-      new_source = autocorrect_source(cop, "str.#{selector} != ('string')")
+      new_source = autocorrect_source("str.#{selector} != ('string')")
       expect(new_source).to eq "!str.casecmp('string').zero?"
     end
 
     it "autocorrects str.#{selector}.eql? without parens" do
-      new_source = autocorrect_source(cop, "str.#{selector}.eql? 'string'")
+      new_source = autocorrect_source("str.#{selector}.eql? 'string'")
       expect(new_source).to eq "str.casecmp('string').zero?"
     end
 
     it "autocorrects str.#{selector}.eql? with parens" do
-      new_source = autocorrect_source(cop, "str.#{selector}.eql?('string')")
+      new_source = autocorrect_source("str.#{selector}.eql?('string')")
       expect(new_source).to eq "str.casecmp('string').zero?"
     end
 
     it "autocorrects str.#{selector}.eql? with parens and funny spacing" do
-      new_source = autocorrect_source(cop, "str.#{selector}.eql? ( 'string' )")
+      new_source = autocorrect_source("str.#{selector}.eql? ( 'string' )")
       expect(new_source).to eq "str.casecmp( 'string' ).zero?"
     end
 
     it "autocorrects == str.#{selector}" do
-      new_source = autocorrect_source(cop, "'string' == str.#{selector}")
+      new_source = autocorrect_source("'string' == str.#{selector}")
       expect(new_source).to eq "str.casecmp('string').zero?"
     end
 
     it "autocorrects string with parens == str.#{selector}" do
-      new_source = autocorrect_source(cop, "('string') == str.#{selector}")
+      new_source = autocorrect_source("('string') == str.#{selector}")
       expect(new_source).to eq "str.casecmp('string').zero?"
     end
 
     it "autocorrects string != str.#{selector}" do
-      new_source = autocorrect_source(cop, "'string' != str.#{selector}")
+      new_source = autocorrect_source("'string' != str.#{selector}")
       expect(new_source).to eq "!str.casecmp('string').zero?"
     end
 
     it 'autocorrects string with parens and funny spacing ' \
        "eql? str.#{selector}" do
-      new_source = autocorrect_source(cop, "( 'string' ).eql? str.#{selector}")
+      new_source = autocorrect_source("( 'string' ).eql? str.#{selector}")
       expect(new_source).to eq "str.casecmp( 'string' ).zero?"
     end
 
     it "autocorrects string.eql? str.#{selector} without parens " do
-      new_source = autocorrect_source(cop, "'string'.eql? str.#{selector}")
+      new_source = autocorrect_source("'string'.eql? str.#{selector}")
       expect(new_source).to eq "str.casecmp('string').zero?"
     end
 
     it "autocorrects string.eql? str.#{selector} with parens " do
-      new_source = autocorrect_source(cop, "'string'.eql?(str.#{selector})")
+      new_source = autocorrect_source("'string'.eql?(str.#{selector})")
       expect(new_source).to eq "str.casecmp('string').zero?"
     end
 
     it "autocorrects obj.#{selector} == str.#{selector}" do
-      new_source = autocorrect_source(cop, "obj.#{selector} == str.#{selector}")
+      new_source = autocorrect_source("obj.#{selector} == str.#{selector}")
       expect(new_source).to eq "obj.casecmp(str.#{selector}).zero?"
     end
 
     it "autocorrects obj.#{selector} eql? str.#{selector}" do
-      new_source = autocorrect_source(cop,
-                                      "obj.#{selector}.eql? str.#{selector}")
+      new_source = autocorrect_source("obj.#{selector}.eql? str.#{selector}")
       expect(new_source).to eq "obj.casecmp(str.#{selector}).zero?"
     end
 

--- a/spec/rubocop/cop/performance/casecmp_spec.rb
+++ b/spec/rubocop/cop/performance/casecmp_spec.rb
@@ -82,26 +82,26 @@ describe RuboCop::Cop::Performance::Casecmp do
     end
 
     it "formats the error message correctly for str.#{selector} ==" do
-      inspect_source(cop, "str.#{selector} == 'string'")
+      inspect_source("str.#{selector} == 'string'")
       expect(cop.highlights).to eq(["#{selector} =="])
       expect(cop.messages).to eq(["Use `casecmp` instead of `#{selector} ==`."])
     end
 
     it "formats the error message correctly for == str.#{selector}" do
-      inspect_source(cop, "'string' == str.#{selector}")
+      inspect_source("'string' == str.#{selector}")
       expect(cop.highlights).to eq(["== str.#{selector}"])
       expect(cop.messages).to eq(["Use `casecmp` instead of `== #{selector}`."])
     end
 
     it 'formats the error message correctly for ' \
        "obj.#{selector} == str.#{selector}" do
-      inspect_source(cop, "obj.#{selector} == str.#{selector}")
+      inspect_source("obj.#{selector} == str.#{selector}")
       expect(cop.highlights).to eq(["obj.#{selector} == str.#{selector}"])
       expect(cop.messages).to eq(["Use `casecmp` instead of `#{selector} ==`."])
     end
 
     it "doesn't report an offense for variable == str.#{selector}" do
-      inspect_source(cop, <<-RUBY.strip_indent)
+      inspect_source(<<-RUBY.strip_indent)
         var = "a"
         var == str.#{selector}
       RUBY
@@ -109,7 +109,7 @@ describe RuboCop::Cop::Performance::Casecmp do
     end
 
     it "doesn't report an offense for str.#{selector} == variable" do
-      inspect_source(cop, <<-RUBY.strip_indent)
+      inspect_source(<<-RUBY.strip_indent)
         var = "a"
         str.#{selector} == var
       RUBY
@@ -117,12 +117,12 @@ describe RuboCop::Cop::Performance::Casecmp do
     end
 
     it "doesn't report an offense for obj.method == str.#{selector}" do
-      inspect_source(cop, "obj.method == str.#{selector}")
+      inspect_source("obj.method == str.#{selector}")
       expect(cop.offenses).to be_empty
     end
 
     it "doesn't report an offense for str.#{selector} == obj.method" do
-      inspect_source(cop, "str.#{selector} == obj.method")
+      inspect_source("str.#{selector} == obj.method")
       expect(cop.offenses).to be_empty
     end
   end

--- a/spec/rubocop/cop/performance/compare_with_block_spec.rb
+++ b/spec/rubocop/cop/performance/compare_with_block_spec.rb
@@ -5,37 +5,37 @@ describe RuboCop::Cop::Performance::CompareWithBlock do
 
   shared_examples 'compare with block' do |method|
     it "registers an offense for #{method}" do
-      inspect_source(cop, "array.#{method} { |a, b| a.foo <=> b.foo }")
+      inspect_source("array.#{method} { |a, b| a.foo <=> b.foo }")
       expect(cop.offenses.size).to eq(1)
     end
 
     it "registers an offense for #{method} with [:foo]" do
-      inspect_source(cop, "array.#{method} { |a, b| a[:foo] <=> b[:foo] }")
+      inspect_source("array.#{method} { |a, b| a[:foo] <=> b[:foo] }")
       expect(cop.offenses.size).to eq(1)
     end
 
     it "registers an offense for #{method} with ['foo']" do
-      inspect_source(cop, "array.#{method} { |a, b| a['foo'] <=> b['foo'] }")
+      inspect_source("array.#{method} { |a, b| a['foo'] <=> b['foo'] }")
       expect(cop.offenses.size).to eq(1)
     end
 
     it "registers an offense for #{method} with [1]" do
-      inspect_source(cop, "array.#{method} { |a, b| a[1] <=> b[1] }")
+      inspect_source("array.#{method} { |a, b| a[1] <=> b[1] }")
       expect(cop.offenses.size).to eq(1)
     end
 
     it 'highlights compare method' do
-      inspect_source(cop, "array.#{method} { |a, b| a.foo <=> b.foo }")
+      inspect_source("array.#{method} { |a, b| a.foo <=> b.foo }")
       expect(cop.highlights).to eq(["#{method} { |a, b| a.foo <=> b.foo }"])
     end
 
     it "accepts valid #{method} usage" do
-      inspect_source(cop, "array.#{method} { |a, b| b <=> a }")
+      inspect_source("array.#{method} { |a, b| b <=> a }")
       expect(cop.offenses).to be_empty
     end
 
     it "accepts #{method}_by" do
-      inspect_source(cop, "array.#{method}_by { |a| a.baz }")
+      inspect_source("array.#{method}_by { |a| a.baz }")
     end
 
     it "autocorrects array.#{method} { |a, b| a.foo <=> b.foo }" do
@@ -91,14 +91,14 @@ describe RuboCop::Cop::Performance::CompareWithBlock do
 
     it 'formats the error message correctly for ' \
       "array.#{method} { |a, b| a.foo <=> b.foo }" do
-      inspect_source(cop, "array.#{method} { |a, b| a.foo <=> b.foo }")
+      inspect_source("array.#{method} { |a, b| a.foo <=> b.foo }")
       expect(cop.messages).to eq(["Use `#{method}_by(&:foo)` instead of " \
                                   "`#{method} { |a, b| a.foo <=> b.foo }`."])
     end
 
     it 'formats the error message correctly for ' \
       "array.#{method} { |a, b| a[:foo] <=> b[:foo] }" do
-      inspect_source(cop, "array.#{method} { |a, b| a[:foo] <=> b[:foo] }")
+      inspect_source("array.#{method} { |a, b| a[:foo] <=> b[:foo] }")
       expected = ["Use `#{method}_by { |a| a[:foo] }` instead of " \
                   "`#{method} { |a, b| a[:foo] <=> b[:foo] }`."]
       expect(cop.messages).to eq(expected)

--- a/spec/rubocop/cop/performance/compare_with_block_spec.rb
+++ b/spec/rubocop/cop/performance/compare_with_block_spec.rb
@@ -40,24 +40,24 @@ describe RuboCop::Cop::Performance::CompareWithBlock do
 
     it "autocorrects array.#{method} { |a, b| a.foo <=> b.foo }" do
       new_source =
-        autocorrect_source(cop, "array.#{method} { |a, b| a.foo <=> b.foo }")
+        autocorrect_source("array.#{method} { |a, b| a.foo <=> b.foo }")
       expect(new_source).to eq "array.#{method}_by(&:foo)"
     end
 
     it "autocorrects array.#{method} { |a, b| a.bar <=> b.bar }" do
       new_source =
-        autocorrect_source(cop, "array.#{method} { |a, b| a.bar <=> b.bar }")
+        autocorrect_source("array.#{method} { |a, b| a.bar <=> b.bar }")
       expect(new_source).to eq "array.#{method}_by(&:bar)"
     end
 
     it "autocorrects array.#{method} { |x, y| x.foo <=> y.foo }" do
       new_source =
-        autocorrect_source(cop, "array.#{method} { |x, y| x.foo <=> y.foo }")
+        autocorrect_source("array.#{method} { |x, y| x.foo <=> y.foo }")
       expect(new_source).to eq "array.#{method}_by(&:foo)"
     end
 
     it "autocorrects array.#{method} do |a, b| a.foo <=> b.foo end" do
-      new_source = autocorrect_source(cop, <<-RUBY.strip_indent)
+      new_source = autocorrect_source(<<-RUBY.strip_indent)
         array.#{method} do |a, b|
           a.foo <=> b.foo
         end
@@ -67,7 +67,6 @@ describe RuboCop::Cop::Performance::CompareWithBlock do
 
     it "autocorrects array.#{method} { |a, b| a[:foo] <=> b[:foo] }" do
       new_source = autocorrect_source(
-        cop,
         "array.#{method} { |a, b| a[:foo] <=> b[:foo] }"
       )
       expect(new_source).to eq "array.#{method}_by { |a| a[:foo] }"
@@ -75,7 +74,6 @@ describe RuboCop::Cop::Performance::CompareWithBlock do
 
     it "autocorrects array.#{method} { |a, b| a['foo'] <=> b['foo'] }" do
       new_source = autocorrect_source(
-        cop,
         "array.#{method} { |a, b| a['foo'] <=> b['foo'] }"
       )
       expect(new_source).to eq "array.#{method}_by { |a| a['foo'] }"
@@ -83,7 +81,6 @@ describe RuboCop::Cop::Performance::CompareWithBlock do
 
     it "autocorrects array.#{method} { |a, b| a[1] <=> b[1] }" do
       new_source = autocorrect_source(
-        cop,
         "array.#{method} { |a, b| a[1] <=> b[1] }"
       )
       expect(new_source).to eq "array.#{method}_by { |a| a[1] }"

--- a/spec/rubocop/cop/performance/count_spec.rb
+++ b/spec/rubocop/cop/performance/count_spec.rb
@@ -208,21 +208,19 @@ describe RuboCop::Cop::Performance::Count do
   context 'autocorrect' do
     context 'will correct' do
       it 'select..size to count' do
-        new_source = autocorrect_source(cop, '[1, 2].select { |e| e > 2 }.size')
+        new_source = autocorrect_source('[1, 2].select { |e| e > 2 }.size')
 
         expect(new_source).to eq('[1, 2].count { |e| e > 2 }')
       end
 
       it 'select..count without a block to count' do
-        new_source = autocorrect_source(cop,
-                                        '[1, 2].select { |e| e > 2 }.count')
+        new_source = autocorrect_source('[1, 2].select { |e| e > 2 }.count')
 
         expect(new_source).to eq('[1, 2].count { |e| e > 2 }')
       end
 
       it 'select..length to count' do
-        new_source = autocorrect_source(cop,
-                                        '[1, 2].select { |e| e > 2 }.length')
+        new_source = autocorrect_source('[1, 2].select { |e| e > 2 }.length')
 
         expect(new_source).to eq('[1, 2].count { |e| e > 2 }')
       end
@@ -234,7 +232,7 @@ describe RuboCop::Cop::Performance::Count do
           puts array.select(&:value).size
         RUBY
 
-        new_source = autocorrect_source(cop, source)
+        new_source = autocorrect_source(source)
 
         expect(new_source)
           .to eq(<<-RUBY.strip_indent)
@@ -247,28 +245,26 @@ describe RuboCop::Cop::Performance::Count do
 
     describe 'will not correct' do
       it 'reject...size' do
-        new_source = autocorrect_source(cop, '[1, 2].reject { |e| e > 2 }.size')
+        new_source = autocorrect_source('[1, 2].reject { |e| e > 2 }.size')
 
         expect(new_source).to eq('[1, 2].reject { |e| e > 2 }.size')
       end
 
       it 'reject...count' do
-        new_source = autocorrect_source(cop,
-                                        '[1, 2].reject { |e| e > 2 }.count')
+        new_source = autocorrect_source('[1, 2].reject { |e| e > 2 }.count')
 
         expect(new_source).to eq('[1, 2].reject { |e| e > 2 }.count')
       end
 
       it 'reject...length' do
-        new_source = autocorrect_source(cop,
-                                        '[1, 2].reject { |e| e > 2 }.length')
+        new_source = autocorrect_source('[1, 2].reject { |e| e > 2 }.length')
 
         expect(new_source).to eq('[1, 2].reject { |e| e > 2 }.length')
       end
 
       it 'select...count when count has a block' do
         source = '[1, 2].select { |e| e > 2 }.count { |e| e.even? }'
-        new_source = autocorrect_source(cop, source)
+        new_source = autocorrect_source(source)
 
         expect(new_source).to eq(source)
       end
@@ -280,7 +276,7 @@ describe RuboCop::Cop::Performance::Count do
           puts array.reject(&:value).size
         RUBY
 
-        new_source = autocorrect_source(cop, source)
+        new_source = autocorrect_source(source)
 
         expect(new_source).to eq(source)
       end

--- a/spec/rubocop/cop/performance/count_spec.rb
+++ b/spec/rubocop/cop/performance/count_spec.rb
@@ -5,7 +5,7 @@ describe RuboCop::Cop::Performance::Count do
 
   shared_examples 'selectors' do |selector|
     it "registers an offense for using array.#{selector}...size" do
-      inspect_source(cop, "[1, 2, 3].#{selector} { |e| e.even? }.size")
+      inspect_source("[1, 2, 3].#{selector} { |e| e.even? }.size")
 
       expect(cop.messages)
         .to eq(["Use `count` instead of `#{selector}...size`."])
@@ -13,7 +13,7 @@ describe RuboCop::Cop::Performance::Count do
     end
 
     it "registers an offense for using hash.#{selector}...size" do
-      inspect_source(cop, "{a: 1, b: 2, c: 3}.#{selector} { |e| e == :a }.size")
+      inspect_source("{a: 1, b: 2, c: 3}.#{selector} { |e| e == :a }.size")
 
       expect(cop.messages)
         .to eq(["Use `count` instead of `#{selector}...size`."])
@@ -21,7 +21,7 @@ describe RuboCop::Cop::Performance::Count do
     end
 
     it "registers an offense for using array.#{selector}...length" do
-      inspect_source(cop, "[1, 2, 3].#{selector} { |e| e.even? }.length")
+      inspect_source("[1, 2, 3].#{selector} { |e| e.even? }.length")
 
       expect(cop.messages)
         .to eq(["Use `count` instead of `#{selector}...length`."])
@@ -29,7 +29,7 @@ describe RuboCop::Cop::Performance::Count do
     end
 
     it "registers an offense for using hash.#{selector}...length" do
-      inspect_source(cop, "{a: 1, b: 2}.#{selector} { |e| e == :a }.length")
+      inspect_source("{a: 1, b: 2}.#{selector} { |e| e == :a }.length")
 
       expect(cop.messages)
         .to eq(["Use `count` instead of `#{selector}...length`."])
@@ -37,7 +37,7 @@ describe RuboCop::Cop::Performance::Count do
     end
 
     it "registers an offense for using array.#{selector}...count" do
-      inspect_source(cop, "[1, 2, 3].#{selector} { |e| e.even? }.count")
+      inspect_source("[1, 2, 3].#{selector} { |e| e.even? }.count")
 
       expect(cop.messages)
         .to eq(["Use `count` instead of `#{selector}...count`."])
@@ -45,7 +45,7 @@ describe RuboCop::Cop::Performance::Count do
     end
 
     it "registers an offense for using hash.#{selector}...count" do
-      inspect_source(cop, "{a: 1, b: 2}.#{selector} { |e| e == :a }.count")
+      inspect_source("{a: 1, b: 2}.#{selector} { |e| e == :a }.count")
 
       expect(cop.messages)
         .to eq(["Use `count` instead of `#{selector}...count`."])
@@ -53,21 +53,20 @@ describe RuboCop::Cop::Performance::Count do
     end
 
     it "allows usage of #{selector}...count with a block on an array" do
-      inspect_source(cop,
-                     "[1, 2, 3].#{selector} { |e| e.odd? }.count { |e| e > 2 }")
+      inspect_source("[1, 2, 3].#{selector} { |e| e.odd? }.count { |e| e > 2 }")
 
       expect(cop.messages).to be_empty
     end
 
     it "allows usage of #{selector}...count with a block on a hash" do
       source = "{a: 1, b: 2}.#{selector} { |e| e == :a }.count { |e| e > 2 }"
-      inspect_source(cop, source)
+      inspect_source(source)
 
       expect(cop.messages).to be_empty
     end
 
     it "registers an offense for #{selector} with params instead of a block" do
-      inspect_source(cop, <<-RUBY.strip_indent)
+      inspect_source(<<-RUBY.strip_indent)
         Data = Struct.new(:value)
         array = [Data.new(2), Data.new(3), Data.new(2)]
         puts array.#{selector}(&:value).count
@@ -79,7 +78,7 @@ describe RuboCop::Cop::Performance::Count do
     end
 
     it "registers an offense for #{selector}(&:something).count" do
-      inspect_source(cop, "foo.#{selector}(&:something).count")
+      inspect_source("foo.#{selector}(&:something).count")
 
       expect(cop.messages)
         .to eq(["Use `count` instead of `#{selector}...count`."])
@@ -95,7 +94,7 @@ describe RuboCop::Cop::Performance::Count do
           end
         end
       RUBY
-      inspect_source(cop, source)
+      inspect_source(source)
 
       expect(cop.messages)
         .to eq(["Use `count` instead of `#{selector}...count`."])
@@ -103,29 +102,26 @@ describe RuboCop::Cop::Performance::Count do
     end
 
     it "allows usage of #{selector} without getting the size" do
-      inspect_source(cop, "[1, 2, 3].#{selector} { |e| e.even? }")
+      inspect_source("[1, 2, 3].#{selector} { |e| e.even? }")
 
       expect(cop.messages).to be_empty
     end
 
     context 'bang methods' do
       it "allows usage of #{selector}!...size" do
-        inspect_source(cop,
-                       "[1, 2, 3].#{selector}! { |e| e.odd? }.size")
+        inspect_source("[1, 2, 3].#{selector}! { |e| e.odd? }.size")
 
         expect(cop.messages).to be_empty
       end
 
       it "allows usage of #{selector}!...count" do
-        inspect_source(cop,
-                       "[1, 2, 3].#{selector}! { |e| e.odd? }.count")
+        inspect_source("[1, 2, 3].#{selector}! { |e| e.odd? }.count")
 
         expect(cop.messages).to be_empty
       end
 
       it "allows usage of #{selector}!...length" do
-        inspect_source(cop,
-                       "[1, 2, 3].#{selector}! { |e| e.odd? }.length")
+        inspect_source("[1, 2, 3].#{selector}! { |e| e.odd? }.length")
 
         expect(cop.messages).to be_empty
       end
@@ -177,7 +173,7 @@ describe RuboCop::Cop::Performance::Count do
 
   it 'allows usage of count on an interstitial method with blocks ' \
      'called on select' do
-    inspect_source(cop, <<-RUBY.strip_indent)
+    inspect_source(<<-RUBY.strip_indent)
       Data = Struct.new(:value)
       array = [Data.new(2), Data.new(3), Data.new(2)]
       array.select(&:value).uniq { |v| v > 2 }.count
@@ -199,12 +195,12 @@ describe RuboCop::Cop::Performance::Count do
 
   context 'properly parses non related code' do
     it 'will not raise an error for Bundler.setup' do
-      expect { inspect_source(cop, 'Bundler.setup(:default, :development)') }
+      expect { inspect_source('Bundler.setup(:default, :development)') }
         .not_to raise_error
     end
 
     it 'will not raise an error for RakeTask.new' do
-      expect { inspect_source(cop, 'RakeTask.new(:spec)') }
+      expect { inspect_source('RakeTask.new(:spec)') }
         .not_to raise_error
     end
   end
@@ -307,7 +303,7 @@ describe RuboCop::Cop::Performance::Count do
 
     shared_examples 'selectors' do |selector|
       it "allows using array.#{selector}...size" do
-        inspect_source(cop, "[1, 2, 3].#{selector} { |e| e.even? }.size")
+        inspect_source("[1, 2, 3].#{selector} { |e| e.even? }.size")
 
         expect(cop.offenses).to be_empty
       end

--- a/spec/rubocop/cop/performance/detect_spec.rb
+++ b/spec/rubocop/cop/performance/detect_spec.rb
@@ -20,31 +20,31 @@ describe RuboCop::Cop::Performance::Detect do
 
   select_methods.each do |method|
     it "registers an offense when first is called on #{method}" do
-      inspect_source(cop, "[1, 2, 3].#{method} { |i| i % 2 == 0 }.first")
+      inspect_source("[1, 2, 3].#{method} { |i| i % 2 == 0 }.first")
 
       expect(cop.messages)
         .to eq(["Use `detect` instead of `#{method}.first`."])
     end
 
     it "doesn't register an offense when first(n) is called on #{method}" do
-      inspect_source(cop, "[1, 2, 3].#{method} { |i| i % 2 == 0 }.first(n)")
+      inspect_source("[1, 2, 3].#{method} { |i| i % 2 == 0 }.first(n)")
       expect(cop.offenses).to be_empty
     end
 
     it "registers an offense when last is called on #{method}" do
-      inspect_source(cop, "[1, 2, 3].#{method} { |i| i % 2 == 0 }.last")
+      inspect_source("[1, 2, 3].#{method} { |i| i % 2 == 0 }.last")
 
       expect(cop.messages)
         .to eq(["Use `reverse.detect` instead of `#{method}.last`."])
     end
 
     it "doesn't register an offense when last(n) is called on #{method}" do
-      inspect_source(cop, "[1, 2, 3].#{method} { |i| i % 2 == 0 }.last(n)")
+      inspect_source("[1, 2, 3].#{method} { |i| i % 2 == 0 }.last(n)")
       expect(cop.offenses).to be_empty
     end
 
     it "registers an offense when first is called on multiline #{method}" do
-      inspect_source(cop, <<-RUBY.strip_indent)
+      inspect_source(<<-RUBY.strip_indent)
         [1, 2, 3].#{method} do |i|
           i % 2 == 0
         end.first
@@ -54,7 +54,7 @@ describe RuboCop::Cop::Performance::Detect do
     end
 
     it "registers an offense when last is called on multiline #{method}" do
-      inspect_source(cop, <<-RUBY.strip_indent)
+      inspect_source(<<-RUBY.strip_indent)
         [1, 2, 3].#{method} do |i|
           i % 2 == 0
         end.last
@@ -65,13 +65,13 @@ describe RuboCop::Cop::Performance::Detect do
     end
 
     it "registers an offense when first is called on #{method} short syntax" do
-      inspect_source(cop, "[1, 2, 3].#{method}(&:even?).first")
+      inspect_source("[1, 2, 3].#{method}(&:even?).first")
 
       expect(cop.messages).to eq(["Use `detect` instead of `#{method}.first`."])
     end
 
     it "registers an offense when last is called on #{method} short syntax" do
-      inspect_source(cop, "[1, 2, 3].#{method}(&:even?).last")
+      inspect_source("[1, 2, 3].#{method}(&:even?).last")
 
       expect(cop.messages)
         .to eq(["Use `reverse.detect` instead of `#{method}.last`."])
@@ -79,35 +79,35 @@ describe RuboCop::Cop::Performance::Detect do
 
     it "registers an offense when #{method} is called" \
        'on `lazy` without receiver' do
-      inspect_source(cop, "lazy.#{method}(&:even?).first")
+      inspect_source("lazy.#{method}(&:even?).first")
 
       expect(cop.messages).to eq(["Use `detect` instead of `#{method}.first`."])
     end
 
     it "does not register an offense when #{method} is used " \
        'without first or last' do
-      inspect_source(cop, "[1, 2, 3].#{method} { |i| i % 2 == 0 }")
+      inspect_source("[1, 2, 3].#{method} { |i| i % 2 == 0 }")
 
       expect(cop.messages).to be_empty
     end
 
     it "does not register an offense when #{method} is called" \
        'without block or args' do
-      inspect_source(cop, "adapter.#{method}.first")
+      inspect_source("adapter.#{method}.first")
 
       expect(cop.messages).to be_empty
     end
 
     it "does not register an offense when #{method} is called" \
        'with args but without ampersand syntax' do
-      inspect_source(cop, "adapter.#{method}('something').first")
+      inspect_source("adapter.#{method}('something').first")
 
       expect(cop.messages).to be_empty
     end
 
     it "does not register an offense when #{method} is called" \
        'on lazy enumerable' do
-      inspect_source(cop, "adapter.lazy.#{method} { 'something' }.first")
+      inspect_source("adapter.lazy.#{method} { 'something' }.first")
 
       expect(cop.messages).to be_empty
     end
@@ -242,7 +242,7 @@ describe RuboCop::Cop::Performance::Detect do
 
     select_methods.each do |method|
       it "doesn't register an offense when first is called on #{method}" do
-        inspect_source(cop, "[1, 2, 3].#{method} { |i| i % 2 == 0 }.first")
+        inspect_source("[1, 2, 3].#{method} { |i| i % 2 == 0 }.first")
 
         expect(cop.offenses).to be_empty
       end

--- a/spec/rubocop/cop/performance/detect_spec.rb
+++ b/spec/rubocop/cop/performance/detect_spec.rb
@@ -126,7 +126,7 @@ describe RuboCop::Cop::Performance::Detect do
           it "corrects #{method}.first to #{preferred_method} (with block)" do
             source = "[1, 2, 3].#{method} { |i| i % 2 == 0 }.first"
 
-            new_source = autocorrect_source(cop, source)
+            new_source = autocorrect_source(source)
 
             expect(new_source)
               .to eq("[1, 2, 3].#{preferred_method} { |i| i % 2 == 0 }")
@@ -136,7 +136,7 @@ describe RuboCop::Cop::Performance::Detect do
              '(with block)' do
             source = "[1, 2, 3].#{method} { |i| i % 2 == 0 }.last"
 
-            new_source = autocorrect_source(cop, source)
+            new_source = autocorrect_source(source)
 
             expect(new_source)
               .to eq("[1, 2, 3].reverse.#{preferred_method} { |i| i % 2 == 0 }")
@@ -145,7 +145,7 @@ describe RuboCop::Cop::Performance::Detect do
           it "corrects #{method}.first to #{preferred_method} (short syntax)" do
             source = "[1, 2, 3].#{method}(&:even?).first"
 
-            new_source = autocorrect_source(cop, source)
+            new_source = autocorrect_source(source)
 
             expect(new_source).to eq("[1, 2, 3].#{preferred_method}(&:even?)")
           end
@@ -154,7 +154,7 @@ describe RuboCop::Cop::Performance::Detect do
              '(short syntax)' do
             source = "[1, 2, 3].#{method}(&:even?).last"
 
-            new_source = autocorrect_source(cop, source)
+            new_source = autocorrect_source(source)
 
             expect(new_source)
               .to eq("[1, 2, 3].reverse.#{preferred_method}(&:even?)")
@@ -166,7 +166,7 @@ describe RuboCop::Cop::Performance::Detect do
                 i % 2 == 0
               end.first
             RUBY
-            new_source = autocorrect_source(cop, source)
+            new_source = autocorrect_source(source)
 
             expect(new_source).to eq(<<-RUBY.strip_indent)
               [1, 2, 3].#{preferred_method} do |i|
@@ -182,7 +182,7 @@ describe RuboCop::Cop::Performance::Detect do
                 i % 2 == 0
               end.last
             RUBY
-            new_source = autocorrect_source(cop, source)
+            new_source = autocorrect_source(source)
 
             expect(new_source)
               .to eq(<<-RUBY.strip_indent)
@@ -198,7 +198,7 @@ describe RuboCop::Cop::Performance::Detect do
               [1, 2, 3].#{method} { true }
               .first['x']
             RUBY
-            new_source = autocorrect_source(cop, source)
+            new_source = autocorrect_source(source)
 
             expect(new_source)
               .to eq("[1, 2, 3].#{preferred_method} { true }['x']\n")
@@ -210,7 +210,7 @@ describe RuboCop::Cop::Performance::Detect do
               [1, 2, 3].#{method}(&:blank?)
               .first['x']
             RUBY
-            new_source = autocorrect_source(cop, source)
+            new_source = autocorrect_source(source)
 
             expect(new_source)
               .to eq("[1, 2, 3].#{preferred_method}(&:blank?)['x']\n")

--- a/spec/rubocop/cop/performance/double_start_end_with_spec.rb
+++ b/spec/rubocop/cop/performance/double_start_end_with_spec.rb
@@ -18,7 +18,7 @@ describe RuboCop::Cop::Performance::DoubleStartEndWith do
           let(:source) { 'x.start_with?(a, b) || x.start_with?("c", D)' }
 
           it 'registers an offense' do
-            inspect_source(cop, source)
+            inspect_source(source)
             expect(cop.offenses.size).to eq(1)
             expect(cop.offenses.first.message).to eq(
               'Use `x.start_with?(a, b, "c", D)` instead of ' \
@@ -56,7 +56,7 @@ describe RuboCop::Cop::Performance::DoubleStartEndWith do
           let(:source) { 'x.end_with?(a, b) || x.end_with?("c", D)' }
 
           it 'registers an offense' do
-            inspect_source(cop, source)
+            inspect_source(source)
             expect(cop.offenses.size).to eq(1)
             expect(cop.offenses.first.message).to eq(
               'Use `x.end_with?(a, b, "c", D)` instead of ' \
@@ -122,7 +122,7 @@ describe RuboCop::Cop::Performance::DoubleStartEndWith do
           let(:source) { 'x.start_with?(a, b) || x.start_with?("c", D)' }
 
           it 'registers an offense' do
-            inspect_source(cop, source)
+            inspect_source(source)
             expect(cop.offenses.size).to eq(1)
             expect(cop.offenses.first.message)
               .to eq('Use `x.start_with?(a, b, "c", D)` instead of ' \
@@ -146,7 +146,7 @@ describe RuboCop::Cop::Performance::DoubleStartEndWith do
           let(:source) { 'x.end_with?(a, b) || x.end_with?("c", D)' }
 
           it 'registers an offense' do
-            inspect_source(cop, source)
+            inspect_source(source)
             expect(cop.offenses.size).to eq(1)
             expect(cop.offenses.first.message)
               .to eq('Use `x.end_with?(a, b, "c", D)` instead of ' \
@@ -170,7 +170,7 @@ describe RuboCop::Cop::Performance::DoubleStartEndWith do
           let(:source) { 'x.starts_with?(a, b) || x.starts_with?("c", D)' }
 
           it 'registers an offense' do
-            inspect_source(cop, source)
+            inspect_source(source)
             expect(cop.offenses.size).to eq(1)
             expect(cop.offenses.first.message).to eq(
               'Use `x.starts_with?(a, b, "c", D)` instead of ' \
@@ -210,7 +210,7 @@ describe RuboCop::Cop::Performance::DoubleStartEndWith do
           let(:source) { 'x.ends_with?(a, b) || x.ends_with?("c", D)' }
 
           it 'registers an offense' do
-            inspect_source(cop, source)
+            inspect_source(source)
             expect(cop.offenses.size).to eq(1)
             expect(cop.offenses.first.message).to eq(
               'Use `x.ends_with?(a, b, "c", D)` instead of ' \

--- a/spec/rubocop/cop/performance/double_start_end_with_spec.rb
+++ b/spec/rubocop/cop/performance/double_start_end_with_spec.rb
@@ -30,7 +30,7 @@ describe RuboCop::Cop::Performance::DoubleStartEndWith do
           end
 
           it 'corrects to a single start_with?' do
-            new_source = autocorrect_source(cop, source)
+            new_source = autocorrect_source(source)
 
             expect(new_source).to eq('x.start_with?(a, b, "c", D)')
           end
@@ -68,7 +68,7 @@ describe RuboCop::Cop::Performance::DoubleStartEndWith do
           end
 
           it 'corrects to a single end_with?' do
-            new_source = autocorrect_source(cop, source)
+            new_source = autocorrect_source(source)
 
             expect(new_source).to eq('x.end_with?(a, b, "c", D)')
           end
@@ -132,7 +132,7 @@ describe RuboCop::Cop::Performance::DoubleStartEndWith do
           end
 
           it 'corrects to a single start_with?' do
-            new_source = autocorrect_source(cop, source)
+            new_source = autocorrect_source(source)
 
             expect(new_source).to eq('x.start_with?(a, b, "c", D)')
           end
@@ -156,7 +156,7 @@ describe RuboCop::Cop::Performance::DoubleStartEndWith do
           end
 
           it 'corrects to a single end_with?' do
-            new_source = autocorrect_source(cop, source)
+            new_source = autocorrect_source(source)
 
             expect(new_source).to eq('x.end_with?(a, b, "c", D)')
           end
@@ -182,7 +182,7 @@ describe RuboCop::Cop::Performance::DoubleStartEndWith do
           end
 
           it 'corrects to a single starts_with?' do
-            new_source = autocorrect_source(cop, source)
+            new_source = autocorrect_source(source)
 
             expect(new_source).to eq('x.starts_with?(a, b, "c", D)')
           end
@@ -222,7 +222,7 @@ describe RuboCop::Cop::Performance::DoubleStartEndWith do
           end
 
           it 'corrects to a single ends_with?' do
-            new_source = autocorrect_source(cop, source)
+            new_source = autocorrect_source(source)
 
             expect(new_source).to eq('x.ends_with?(a, b, "c", D)')
           end

--- a/spec/rubocop/cop/performance/end_with_spec.rb
+++ b/spec/rubocop/cop/performance/end_with_spec.rb
@@ -5,23 +5,23 @@ describe RuboCop::Cop::Performance::EndWith do
 
   shared_examples 'different match methods' do |method|
     it "autocorrects #{method} /abc\\z/" do
-      new_source = autocorrect_source(cop, "str#{method} /abc\\z/")
+      new_source = autocorrect_source("str#{method} /abc\\z/")
       expect(new_source).to eq "str.end_with?('abc')"
     end
 
     it "autocorrects #{method} /\\n\\z/" do
-      new_source = autocorrect_source(cop, "str#{method} /\\n\\z/")
+      new_source = autocorrect_source("str#{method} /\\n\\z/")
       expect(new_source).to eq 'str.end_with?("\n")'
     end
 
     it "autocorrects #{method} /\\t\\z/" do
-      new_source = autocorrect_source(cop, "str#{method} /\\t\\z/")
+      new_source = autocorrect_source("str#{method} /\\t\\z/")
       expect(new_source).to eq 'str.end_with?("\t")'
     end
 
     %w[. $ ^ |].each do |str|
       it "autocorrects #{method} /\\#{str}\\z/" do
-        new_source = autocorrect_source(cop, "str#{method} /\\#{str}\\z/")
+        new_source = autocorrect_source("str#{method} /\\#{str}\\z/")
         expect(new_source).to eq "str.end_with?('#{str}')"
       end
 
@@ -36,7 +36,7 @@ describe RuboCop::Cop::Performance::EndWith do
     # but in a regex, it's an anchor on a word boundary
     %w[a e f r t v].each do |str|
       it "autocorrects #{method} /\\#{str}\\z/" do
-        new_source = autocorrect_source(cop, "str#{method} /\\#{str}\\z/")
+        new_source = autocorrect_source("str#{method} /\\#{str}\\z/")
         expect(new_source).to eq %{str.end_with?("\\#{str}")}
       end
     end
@@ -52,7 +52,7 @@ describe RuboCop::Cop::Performance::EndWith do
     # characters with no special meaning whatsoever
     %w[i j l m o q y].each do |str|
       it "autocorrects #{method} /\\#{str}\\z/" do
-        new_source = autocorrect_source(cop, "str#{method} /\\#{str}\\z/")
+        new_source = autocorrect_source("str#{method} /\\#{str}\\z/")
         expect(new_source).to eq "str.end_with?('#{str}')"
       end
     end
@@ -65,7 +65,7 @@ describe RuboCop::Cop::Performance::EndWith do
     end
 
     it "autocorrects #{method} /\\\\\\z/" do
-      new_source = autocorrect_source(cop, "str#{method} /\\\\\\z/")
+      new_source = autocorrect_source("str#{method} /\\\\\\z/")
       expect(new_source).to eq("str.end_with?('\\\\')")
     end
   end

--- a/spec/rubocop/cop/performance/end_with_spec.rb
+++ b/spec/rubocop/cop/performance/end_with_spec.rb
@@ -26,7 +26,7 @@ describe RuboCop::Cop::Performance::EndWith do
       end
 
       it "doesn't register an error for #{method} /#{str}\\z/" do
-        inspect_source(cop, "str#{method} /#{str}\\z/")
+        inspect_source("str#{method} /#{str}\\z/")
         expect(cop.messages).to be_empty
       end
     end
@@ -44,7 +44,7 @@ describe RuboCop::Cop::Performance::EndWith do
     # character classes, anchors
     %w[w W s S d D A Z z G b B h H R X S].each do |str|
       it "doesn't register an error for #{method} /\\#{str}\\z/" do
-        inspect_source(cop, "str#{method} /\\#{str}\\z/")
+        inspect_source("str#{method} /\\#{str}\\z/")
         expect(cop.messages).to be_empty
       end
     end
@@ -58,7 +58,7 @@ describe RuboCop::Cop::Performance::EndWith do
     end
 
     it "formats the error message correctly for #{method} /abc\\z/" do
-      inspect_source(cop, "str#{method} /abc\\z/")
+      inspect_source("str#{method} /abc\\z/")
       expect(cop.messages).to eq(['Use `String#end_with?` instead of a ' \
                                   'regex match anchored to the end of ' \
                                   'the string.'])

--- a/spec/rubocop/cop/performance/fixed_size_spec.rb
+++ b/spec/rubocop/cop/performance/fixed_size_spec.rb
@@ -11,80 +11,80 @@ describe RuboCop::Cop::Performance::FixedSize do
     context 'strings' do
       it "registers an offense when calling #{method} on a single quoted " \
          'string' do
-        inspect_source(cop, "'a'.#{method}")
+        inspect_source("'a'.#{method}")
 
         expect(cop.messages).to eq([message])
       end
 
       it "registers an offense when calling #{method} on a double quoted " \
          'string' do
-        inspect_source(cop, "\"a\".#{method}")
+        inspect_source("\"a\".#{method}")
 
         expect(cop.messages).to eq([message])
       end
 
       it "registers an offense when calling #{method} on a %q string" do
-        inspect_source(cop, "%q(a).#{method}")
+        inspect_source("%q(a).#{method}")
 
         expect(cop.messages).to eq([message])
       end
 
       it "registers an offense when calling #{method} on a %Q string" do
-        inspect_source(cop, "%Q(a).#{method}")
+        inspect_source("%Q(a).#{method}")
 
         expect(cop.messages).to eq([message])
       end
 
       it "registers an offense when calling #{method} on a % string" do
-        inspect_source(cop, "%(a).#{method}")
+        inspect_source("%(a).#{method}")
 
         expect(cop.messages).to eq([message])
       end
 
       it "accepts calling #{method} on a double quoted string that " \
          'contains interpolation' do
-        inspect_source(cop, "\"\#{foo}\".#{method}")
+        inspect_source("\"\#{foo}\".#{method}")
 
         expect(cop.messages).to be_empty
       end
 
       it "accepts calling #{method} on a %Q string that contains " \
          'interpolation' do
-        inspect_source(cop, "\%Q(\#{foo}).#{method}")
+        inspect_source("\%Q(\#{foo}).#{method}")
 
         expect(cop.messages).to be_empty
       end
 
       it "accepts calling #{method} on a % string that contains " \
          'interpolation' do
-        inspect_source(cop, "\%(\#{foo}).#{method}")
+        inspect_source("\%(\#{foo}).#{method}")
 
         expect(cop.messages).to be_empty
       end
 
       it "accepts calling #{method} on a single quoted string that " \
          'is assigned to a constant' do
-        inspect_source(cop, "CONST = 'a'.#{method}")
+        inspect_source("CONST = 'a'.#{method}")
 
         expect(cop.messages).to be_empty
       end
 
       it "accepts calling #{method} on a double quoted string that " \
          'is assigned to a constant' do
-        inspect_source(cop, "CONST = \"a\".#{method}")
+        inspect_source("CONST = \"a\".#{method}")
 
         expect(cop.messages).to be_empty
       end
 
       it "accepts calling #{method} on a %q string that is assigned to " \
          'a constant' do
-        inspect_source(cop, "CONST = %q(a).#{method}")
+        inspect_source("CONST = %q(a).#{method}")
 
         expect(cop.messages).to be_empty
       end
 
       it "accepts calling #{method} on a variable " do
-        inspect_source(cop, <<-RUBY.strip_indent)
+        inspect_source(<<-RUBY.strip_indent)
           foo = "abc"
           foo.#{method}
         RUBY
@@ -95,32 +95,32 @@ describe RuboCop::Cop::Performance::FixedSize do
 
     context 'symbols' do
       it "registers an offense when calling #{method} on a symbol" do
-        inspect_source(cop, ":foo.#{method}")
+        inspect_source(":foo.#{method}")
 
         expect(cop.messages).to eq([message])
       end
 
       it "registers an offense when calling #{method} on a quoted symbol" do
-        inspect_source(cop, ":'foo-bar'.#{method}")
+        inspect_source(":'foo-bar'.#{method}")
 
         expect(cop.messages).to eq([message])
       end
 
       it "accepts calling #{method} on an interpolated quoted symbol" do
-        inspect_source(cop, ":\"foo-\#{bar}\".#{method}")
+        inspect_source(":\"foo-\#{bar}\".#{method}")
 
         expect(cop.messages).to be_empty
       end
 
       it "registers an offense when calling #{method} on %s" do
-        inspect_source(cop, "%s(foo-bar).#{method}")
+        inspect_source("%s(foo-bar).#{method}")
 
         expect(cop.messages).to eq([message])
       end
 
       it "accepts calling #{method} on a symbol that is assigned " \
          'to a constant' do
-        inspect_source(cop, "CONST = :foo.#{method}")
+        inspect_source("CONST = :foo.#{method}")
 
         expect(cop.messages).to be_empty
       end
@@ -128,32 +128,32 @@ describe RuboCop::Cop::Performance::FixedSize do
 
     context 'arrays' do
       it "registers an offense when calling #{method} on an array using []" do
-        inspect_source(cop, "[1, 2, foo].#{method}")
+        inspect_source("[1, 2, foo].#{method}")
 
         expect(cop.messages).to eq([message])
       end
 
       it "registers an offense when calling #{method} on an array using %w" do
-        inspect_source(cop, "%w(1, 2, foo).#{method}")
+        inspect_source("%w(1, 2, foo).#{method}")
 
         expect(cop.messages).to eq([message])
       end
 
       it "registers an offense when calling #{method} on an array using %W" do
-        inspect_source(cop, "%W(1, 2, foo).#{method}")
+        inspect_source("%W(1, 2, foo).#{method}")
 
         expect(cop.messages).to eq([message])
       end
 
       it "accepts calling #{method} on an array using [] that contains " \
          'a splat' do
-        inspect_source(cop, "[1, 2, *foo].#{method}")
+        inspect_source("[1, 2, *foo].#{method}")
 
         expect(cop.messages).to be_empty
       end
 
       it "accepts calling #{method} on array that is set to a variable" do
-        inspect_source(cop, <<-RUBY.strip_indent)
+        inspect_source(<<-RUBY.strip_indent)
           foo = [1, 2, 3]
           foo.#{method}
         RUBY
@@ -163,7 +163,7 @@ describe RuboCop::Cop::Performance::FixedSize do
 
       it "accepts calling #{method} on an array that is assigned " \
          'to a constant' do
-        inspect_source(cop, "CONST = [1, 2, 3].#{method}")
+        inspect_source("CONST = [1, 2, 3].#{method}")
 
         expect(cop.messages).to be_empty
       end
@@ -171,13 +171,13 @@ describe RuboCop::Cop::Performance::FixedSize do
 
     context 'hashes' do
       it "registers an offense when calling #{method} on a hash using {}" do
-        inspect_source(cop, "{a: 1, b: 2}.#{method}")
+        inspect_source("{a: 1, b: 2}.#{method}")
 
         expect(cop.messages).to eq([message])
       end
 
       it "accepts calling #{method} on a hash set to a variable" do
-        inspect_source(cop, <<-RUBY.strip_indent)
+        inspect_source(<<-RUBY.strip_indent)
           foo = {a: 1, b: 2}
           foo.#{method}
         RUBY
@@ -187,7 +187,7 @@ describe RuboCop::Cop::Performance::FixedSize do
 
       context 'ruby >= 2.0', :ruby20 do
         it "accepts calling #{method} on a hash that contains a double splat" do
-          inspect_source(cop, "{a: 1, **foo}.#{method}")
+          inspect_source("{a: 1, **foo}.#{method}")
 
           expect(cop.messages).to be_empty
         end
@@ -195,7 +195,7 @@ describe RuboCop::Cop::Performance::FixedSize do
 
       it "accepts calling #{method} on an hash that is assigned " \
          'to a constant' do
-        inspect_source(cop, "CONST = {a: 1, b: 2}.#{method}")
+        inspect_source("CONST = {a: 1, b: 2}.#{method}")
 
         expect(cop.messages).to be_empty
       end
@@ -208,31 +208,31 @@ describe RuboCop::Cop::Performance::FixedSize do
 
   shared_examples :count_with_arguments do |variable|
     it 'accepts calling count with a variable' do
-      inspect_source(cop, "#{variable}.count(bar)")
+      inspect_source("#{variable}.count(bar)")
 
       expect(cop.messages).to be_empty
     end
 
     it 'accepts calling count with an instance variable' do
-      inspect_source(cop, "#{variable}.count(@bar)")
+      inspect_source("#{variable}.count(@bar)")
 
       expect(cop.messages).to be_empty
     end
 
     it 'registers an offense when calling count with a string' do
-      inspect_source(cop, "#{variable}.count('o')")
+      inspect_source("#{variable}.count('o')")
 
       expect(cop.messages).to eq([message])
     end
 
     it 'accepts calling count with a block' do
-      inspect_source(cop, "#{variable}.count { |v| v == 'a' }")
+      inspect_source("#{variable}.count { |v| v == 'a' }")
 
       expect(cop.messages).to be_empty
     end
 
     it 'accepts calling count with a symbol proc' do
-      inspect_source(cop, "#{variable}.count(&:any?) ")
+      inspect_source("#{variable}.count(&:any?) ")
 
       expect(cop.messages).to be_empty
     end

--- a/spec/rubocop/cop/performance/flat_map_spec.rb
+++ b/spec/rubocop/cop/performance/flat_map_spec.rb
@@ -27,7 +27,7 @@ describe RuboCop::Cop::Performance::FlatMap, :config do
 
     it "corrects #{method}..#{flatten}(1) to flat_map" do
       source = "[1, 2].#{method} { |e| [e, e] }.#{flatten}(1)"
-      new_source = autocorrect_source(cop, source)
+      new_source = autocorrect_source(source)
 
       expect(new_source).to eq('[1, 2].flat_map { |e| [e, e] }')
     end
@@ -81,7 +81,7 @@ describe RuboCop::Cop::Performance::FlatMap, :config do
 
       it "will not correct #{method}..#{flatten} to flat_map" do
         source = "[1, 2].map { |e| [e, e] }.#{flatten}"
-        new_source = autocorrect_source(cop, source)
+        new_source = autocorrect_source(source)
 
         expect(new_source).to eq("[1, 2].map { |e| [e, e] }.#{flatten}")
       end

--- a/spec/rubocop/cop/performance/flat_map_spec.rb
+++ b/spec/rubocop/cop/performance/flat_map_spec.rb
@@ -5,7 +5,7 @@ describe RuboCop::Cop::Performance::FlatMap, :config do
 
   shared_examples 'map_and_collect' do |method, flatten|
     it "registers an offense when calling #{method}...#{flatten}(1)" do
-      inspect_source(cop, "[1, 2, 3, 4].#{method} { |e| [e, e] }.#{flatten}(1)")
+      inspect_source("[1, 2, 3, 4].#{method} { |e| [e, e] }.#{flatten}(1)")
 
       expect(cop.messages)
         .to eq(["Use `flat_map` instead of `#{method}...#{flatten}`."])
@@ -14,13 +14,13 @@ describe RuboCop::Cop::Performance::FlatMap, :config do
 
     it "does not register an offense when calling #{method}...#{flatten} " \
       'with a number greater than 1' do
-      inspect_source(cop, "[1, 2, 3, 4].#{method} { |e| [e, e] }.#{flatten}(3)")
+      inspect_source("[1, 2, 3, 4].#{method} { |e| [e, e] }.#{flatten}(3)")
 
       expect(cop.messages).to be_empty
     end
 
     it "does not register an offense when calling #{method}!...#{flatten}" do
-      inspect_source(cop, "[1, 2, 3, 4].#{method}! { |e| [e, e] }.#{flatten}")
+      inspect_source("[1, 2, 3, 4].#{method}! { |e| [e, e] }.#{flatten}")
 
       expect(cop.messages).to be_empty
     end
@@ -43,7 +43,7 @@ describe RuboCop::Cop::Performance::FlatMap, :config do
 
     shared_examples 'flatten_with_params_disabled' do |method, flatten|
       it "does not register an offense when calling #{method}...#{flatten}" do
-        inspect_source(cop, "[1, 2, 3, 4].map { |e| [e, e] }.#{flatten}")
+        inspect_source("[1, 2, 3, 4].map { |e| [e, e] }.#{flatten}")
 
         expect(cop.messages).to be_empty
       end
@@ -70,7 +70,7 @@ describe RuboCop::Cop::Performance::FlatMap, :config do
 
     shared_examples 'flatten_with_params_enabled' do |method, flatten|
       it "registers an offense when calling #{method}...#{flatten}" do
-        inspect_source(cop, "[1, 2, 3, 4].map { |e| [e, e] }.#{flatten}")
+        inspect_source("[1, 2, 3, 4].map { |e| [e, e] }.#{flatten}")
 
         expect(cop.messages)
           .to eq(["Use `flat_map` instead of `map...#{flatten}`. " \

--- a/spec/rubocop/cop/performance/hash_each_methods_spec.rb
+++ b/spec/rubocop/cop/performance/hash_each_methods_spec.rb
@@ -48,22 +48,22 @@ describe RuboCop::Cop::Performance::HashEachMethods do
   end
 
   it 'auto-corrects Hash#keys.each with Hash#each_key' do
-    new_source = autocorrect_source(cop, 'hash.keys.each { |k| p k }')
+    new_source = autocorrect_source('hash.keys.each { |k| p k }')
     expect(new_source).to eq('hash.each_key { |k| p k }')
   end
 
   it 'auto-corrects Hash#values.each with Hash#each_value' do
-    new_source = autocorrect_source(cop, 'hash.values.each { |v| p v }')
+    new_source = autocorrect_source('hash.values.each { |v| p v }')
     expect(new_source).to eq('hash.each_value { |v| p v }')
   end
 
   it 'auto-corrects Hash#each with unused value argument with Hash#each_key' do
-    new_source = autocorrect_source(cop, 'hash.each { |k, _v| p k }')
+    new_source = autocorrect_source('hash.each { |k, _v| p k }')
     expect(new_source).to eq('hash.each_key { |k| p k }')
   end
 
   it 'auto-corrects Hash#each with unused key argument with Hash#each_value' do
-    new_source = autocorrect_source(cop, 'hash.each { |_k, v| p v }')
+    new_source = autocorrect_source('hash.each { |_k, v| p v }')
     expect(new_source).to eq('hash.each_value { |v| p v }')
   end
 end

--- a/spec/rubocop/cop/performance/lstrip_rstrip_spec.rb
+++ b/spec/rubocop/cop/performance/lstrip_rstrip_spec.rb
@@ -4,12 +4,12 @@ describe RuboCop::Cop::Performance::LstripRstrip do
   subject(:cop) { described_class.new }
 
   it 'autocorrects str.lstrip.rstrip' do
-    new_source = autocorrect_source(cop, 'str.lstrip.rstrip')
+    new_source = autocorrect_source('str.lstrip.rstrip')
     expect(new_source).to eq 'str.strip'
   end
 
   it 'autocorrects str.rstrip.lstrip' do
-    new_source = autocorrect_source(cop, 'str.rstrip.lstrip')
+    new_source = autocorrect_source('str.rstrip.lstrip')
     expect(new_source).to eq 'str.strip'
   end
 

--- a/spec/rubocop/cop/performance/range_include_spec.rb
+++ b/spec/rubocop/cop/performance/range_include_spec.rb
@@ -4,22 +4,22 @@ describe RuboCop::Cop::Performance::RangeInclude do
   subject(:cop) { described_class.new }
 
   it 'autocorrects (a..b).include? without parens' do
-    new_source = autocorrect_source(cop, '(a..b).include? 1')
+    new_source = autocorrect_source('(a..b).include? 1')
     expect(new_source).to eq '(a..b).cover? 1'
   end
 
   it 'autocorrects (a...b).include? without parens' do
-    new_source = autocorrect_source(cop, '(a...b).include? 1')
+    new_source = autocorrect_source('(a...b).include? 1')
     expect(new_source).to eq '(a...b).cover? 1'
   end
 
   it 'autocorrects (a..b).include? with parens' do
-    new_source = autocorrect_source(cop, '(a..b).include?(1)')
+    new_source = autocorrect_source('(a..b).include?(1)')
     expect(new_source).to eq '(a..b).cover?(1)'
   end
 
   it 'autocorrects (a...b).include? with parens' do
-    new_source = autocorrect_source(cop, '(a...b).include?(1)')
+    new_source = autocorrect_source('(a...b).include?(1)')
     expect(new_source).to eq '(a...b).cover?(1)'
   end
 

--- a/spec/rubocop/cop/performance/redundant_block_call_spec.rb
+++ b/spec/rubocop/cop/performance/redundant_block_call_spec.rb
@@ -4,7 +4,7 @@ describe RuboCop::Cop::Performance::RedundantBlockCall do
   subject(:cop) { described_class.new }
 
   it 'autocorrects block.call without arguments' do
-    new_source = autocorrect_source(cop, <<-RUBY.strip_indent)
+    new_source = autocorrect_source(<<-RUBY.strip_indent)
       def method(&block)
         block.call
       end
@@ -17,7 +17,7 @@ describe RuboCop::Cop::Performance::RedundantBlockCall do
   end
 
   it 'autocorrects block.call with empty parentheses' do
-    new_source = autocorrect_source(cop, <<-RUBY.strip_indent)
+    new_source = autocorrect_source(<<-RUBY.strip_indent)
       def method(&block)
         block.call()
       end
@@ -30,7 +30,7 @@ describe RuboCop::Cop::Performance::RedundantBlockCall do
   end
 
   it 'autocorrects block.call with arguments' do
-    new_source = autocorrect_source(cop, <<-RUBY.strip_indent)
+    new_source = autocorrect_source(<<-RUBY.strip_indent)
       def method(&block)
         block.call 1, 2
       end
@@ -43,7 +43,7 @@ describe RuboCop::Cop::Performance::RedundantBlockCall do
   end
 
   it 'autocorrects multiple occurances of block.call with arguments' do
-    new_source = autocorrect_source(cop, <<-RUBY.strip_indent)
+    new_source = autocorrect_source(<<-RUBY.strip_indent)
       def method(&block)
         block.call 1
         block.call 2
@@ -58,7 +58,7 @@ describe RuboCop::Cop::Performance::RedundantBlockCall do
   end
 
   it 'autocorrects even when block arg has a different name' do
-    new_source = autocorrect_source(cop, <<-RUBY.strip_indent)
+    new_source = autocorrect_source(<<-RUBY.strip_indent)
       def method(&func)
         func.call
       end
@@ -138,7 +138,7 @@ describe RuboCop::Cop::Performance::RedundantBlockCall do
   end
 
   it 'autocorrects using parentheses when block.call uses parentheses' do
-    new_source = autocorrect_source(cop, <<-RUBY.strip_indent)
+    new_source = autocorrect_source(<<-RUBY.strip_indent)
       def method(&block)
         block.call(a, b)
       end
@@ -161,7 +161,7 @@ describe RuboCop::Cop::Performance::RedundantBlockCall do
       end
     RUBY
 
-    new_source = autocorrect_source(cop, source)
+    new_source = autocorrect_source(source)
 
     expect(new_source).to eq(<<-RUBY.strip_indent)
       def method(&block)

--- a/spec/rubocop/cop/performance/redundant_match_spec.rb
+++ b/spec/rubocop/cop/performance/redundant_match_spec.rb
@@ -70,7 +70,7 @@ describe RuboCop::Cop::Performance::RedundantMatch do
 
   it 'does not register an error when return value of .match is passed ' \
      'to another method' do
-    inspect_source(cop, <<-RUBY.strip_indent)
+    inspect_source(<<-RUBY.strip_indent)
       def method(str)
        something(str.match(/regex/))
       end
@@ -80,7 +80,7 @@ describe RuboCop::Cop::Performance::RedundantMatch do
 
   it 'does not register an error when return value of .match is stored in an ' \
      'instance variable' do
-    inspect_source(cop, <<-RUBY.strip_indent)
+    inspect_source(<<-RUBY.strip_indent)
       def method(str)
        @var = str.match(/regex/)
        true
@@ -91,7 +91,7 @@ describe RuboCop::Cop::Performance::RedundantMatch do
 
   it 'does not register an error when return value of .match is returned from' \
      ' surrounding method' do
-    inspect_source(cop, <<-RUBY.strip_indent)
+    inspect_source(<<-RUBY.strip_indent)
       def method(str)
        str.match(/regex/)
       end

--- a/spec/rubocop/cop/performance/redundant_match_spec.rb
+++ b/spec/rubocop/cop/performance/redundant_match_spec.rb
@@ -13,17 +13,17 @@ describe RuboCop::Cop::Performance::RedundantMatch do
   subject(:cop) { described_class.new }
 
   it 'autocorrects .match in if condition' do
-    new_source = autocorrect_source(cop, 'something if str.match(/regex/)')
+    new_source = autocorrect_source('something if str.match(/regex/)')
     expect(new_source).to eq 'something if str =~ /regex/'
   end
 
   it 'autocorrects .match in unless condition' do
-    new_source = autocorrect_source(cop, 'something unless str.match(/regex/)')
+    new_source = autocorrect_source('something unless str.match(/regex/)')
     expect(new_source).to eq 'something unless str =~ /regex/'
   end
 
   it 'autocorrects .match in while condition' do
-    new_source = autocorrect_source(cop, <<-RUBY.strip_indent)
+    new_source = autocorrect_source(<<-RUBY.strip_indent)
       while str.match(/regex/)
         do_something
       end
@@ -36,7 +36,7 @@ describe RuboCop::Cop::Performance::RedundantMatch do
   end
 
   it 'autocorrects .match in until condition' do
-    new_source = autocorrect_source(cop, <<-RUBY.strip_indent)
+    new_source = autocorrect_source(<<-RUBY.strip_indent)
       until str.match(/regex/)
         do_something
       end
@@ -49,7 +49,7 @@ describe RuboCop::Cop::Performance::RedundantMatch do
   end
 
   it 'autocorrects .match in method body (but not tail position)' do
-    new_source = autocorrect_source(cop, <<-RUBY.strip_indent)
+    new_source = autocorrect_source(<<-RUBY.strip_indent)
       def method(str)
         str.match(/regex/)
         true
@@ -64,7 +64,7 @@ describe RuboCop::Cop::Performance::RedundantMatch do
   end
 
   it 'does not autocorrect if .match has a string agrgument' do
-    new_source = autocorrect_source(cop, 'something if str.match("string")')
+    new_source = autocorrect_source('something if str.match("string")')
     expect(new_source).to eq 'something if str.match("string")'
   end
 

--- a/spec/rubocop/cop/performance/redundant_merge_spec.rb
+++ b/spec/rubocop/cop/performance/redundant_merge_spec.rb
@@ -116,7 +116,7 @@ describe RuboCop::Cop::Performance::RedundantMerge, :config do
           why_are_you_doing_this?
         end
       RUBY
-      inspect_source(cop, source)
+      inspect_source(source)
 
       expect(cop.offenses).to be_empty
     end

--- a/spec/rubocop/cop/performance/redundant_merge_spec.rb
+++ b/spec/rubocop/cop/performance/redundant_merge_spec.rb
@@ -8,18 +8,18 @@ describe RuboCop::Cop::Performance::RedundantMerge, :config do
   end
 
   it 'autocorrects hash.merge!(a: 1)' do
-    new_source = autocorrect_source(cop, 'hash.merge!(a: 1)')
+    new_source = autocorrect_source('hash.merge!(a: 1)')
     expect(new_source).to eq 'hash[:a] = 1'
   end
 
   it 'autocorrects hash.merge!("abc" => "value")' do
-    new_source = autocorrect_source(cop, 'hash.merge!("abc" => "value")')
+    new_source = autocorrect_source('hash.merge!("abc" => "value")')
     expect(new_source).to eq 'hash["abc"] = "value"'
   end
 
   context 'when receiver is a local variable' do
     it 'autocorrects hash.merge!(a: 1, b: 2)' do
-      new_source = autocorrect_source(cop, <<-RUBY.strip_indent)
+      new_source = autocorrect_source(<<-RUBY.strip_indent)
         hash = {}
         hash.merge!(a: 1, b: 2)
       RUBY
@@ -33,14 +33,14 @@ describe RuboCop::Cop::Performance::RedundantMerge, :config do
 
   context 'when receiver is a method call' do
     it "doesn't autocorrect hash.merge!(a: 1, b: 2)" do
-      new_source = autocorrect_source(cop, 'hash.merge!(a: 1, b: 2)')
+      new_source = autocorrect_source('hash.merge!(a: 1, b: 2)')
       expect(new_source).to eq('hash.merge!(a: 1, b: 2)')
     end
   end
 
   context 'when receiver is implicit' do
     it "doesn't autocorrect" do
-      new_source = autocorrect_source(cop, 'merge!(foo: 1, bar: 2)')
+      new_source = autocorrect_source('merge!(foo: 1, bar: 2)')
       expect(new_source).to eq('merge!(foo: 1, bar: 2)')
     end
   end
@@ -60,7 +60,7 @@ describe RuboCop::Cop::Performance::RedundantMerge, :config do
           hash.merge!(a: 1, b: 2)
         end
       RUBY
-      new_source = autocorrect_source(cop, source)
+      new_source = autocorrect_source(source)
 
       expect(new_source).to eq(<<-RUBY.strip_indent)
         foo.each_with_object({}) do |f, hash|
@@ -78,7 +78,7 @@ describe RuboCop::Cop::Performance::RedundantMerge, :config do
           hash.merge!(a: 1, b: 2)
         end
       RUBY
-      new_source = autocorrect_source(cop, source)
+      new_source = autocorrect_source(source)
 
       expect(new_source).to eq(<<-RUBY.strip_indent)
         foo.each_with_object({}) do |f, hash|
@@ -97,7 +97,7 @@ describe RuboCop::Cop::Performance::RedundantMerge, :config do
           why_are_you_doing_this?
         end
       RUBY
-      new_source = autocorrect_source(cop, source)
+      new_source = autocorrect_source(source)
 
       expect(new_source).to eq(<<-RUBY.strip_indent)
         foo.each_with_object({}) do |f, hash|
@@ -128,7 +128,7 @@ describe RuboCop::Cop::Performance::RedundantMerge, :config do
           hash[:a].merge!(b: "")
         end
       RUBY
-      new_source = autocorrect_source(cop, source)
+      new_source = autocorrect_source(source)
 
       expect(new_source).to eq(<<-RUBY.strip_indent)
         foo.each_with_object(bar) do |f, hash|
@@ -144,7 +144,7 @@ describe RuboCop::Cop::Performance::RedundantMerge, :config do
           hash[:a][:b].merge!(c: "")
         end
       RUBY
-      new_source = autocorrect_source(cop, source)
+      new_source = autocorrect_source(source)
 
       expect(new_source).to eq(<<-RUBY.strip_indent)
         foo.each_with_object(bar) do |f, hash|
@@ -160,7 +160,7 @@ describe RuboCop::Cop::Performance::RedundantMerge, :config do
           hash.bar.merge!(c: "")
         end
       RUBY
-      new_source = autocorrect_source(cop, source)
+      new_source = autocorrect_source(source)
 
       expect(new_source).to eq(<<-RUBY.strip_indent)
         foo.each_with_object(bar) do |f, hash|
@@ -174,7 +174,6 @@ describe RuboCop::Cop::Performance::RedundantMerge, :config do
     context "when there is a modifier #{kw}, and more than 1 pair" do
       it "autocorrects it to an #{kw} block" do
         new_source = autocorrect_source(
-          cop,
           <<-RUBY.strip_indent
             hash = {}
             hash.merge!(a: 1, b: 2) #{kw} condition1 && condition2
@@ -192,7 +191,6 @@ describe RuboCop::Cop::Performance::RedundantMerge, :config do
       context 'when original code was indented' do
         it 'maintains proper indentation' do
           new_source = autocorrect_source(
-            cop,
             <<-RUBY.strip_indent
               hash = {}
               begin
@@ -216,7 +214,7 @@ describe RuboCop::Cop::Performance::RedundantMerge, :config do
 
   context 'when code is indented, and there is more than 1 pair' do
     it 'indents the autocorrected code properly' do
-      new_source = autocorrect_source(cop, <<-RUBY.strip_indent)
+      new_source = autocorrect_source(<<-RUBY.strip_indent)
         hash = {}
         begin
           hash.merge!(a: 1, b: 2)

--- a/spec/rubocop/cop/performance/redundant_sort_by_spec.rb
+++ b/spec/rubocop/cop/performance/redundant_sort_by_spec.rb
@@ -4,17 +4,17 @@ describe RuboCop::Cop::Performance::RedundantSortBy do
   subject(:cop) { described_class.new }
 
   it 'autocorrects array.sort_by { |x| x }' do
-    new_source = autocorrect_source(cop, 'array.sort_by { |x| x }')
+    new_source = autocorrect_source('array.sort_by { |x| x }')
     expect(new_source).to eq 'array.sort'
   end
 
   it 'autocorrects array.sort_by { |y| y }' do
-    new_source = autocorrect_source(cop, 'array.sort_by { |y| y }')
+    new_source = autocorrect_source('array.sort_by { |y| y }')
     expect(new_source).to eq 'array.sort'
   end
 
   it 'autocorrects array.sort_by do |x| x end' do
-    new_source = autocorrect_source(cop, <<-RUBY.strip_indent)
+    new_source = autocorrect_source(<<-RUBY.strip_indent)
       array.sort_by do |x|
         x
       end

--- a/spec/rubocop/cop/performance/regexp_match_spec.rb
+++ b/spec/rubocop/cop/performance/regexp_match_spec.rb
@@ -19,7 +19,7 @@ describe RuboCop::Cop::Performance::RegexpMatch, :config do
     end
 
     it "corrects #{name}" do
-      new_source = autocorrect_source(cop, code)
+      new_source = autocorrect_source(code)
 
       expect(new_source).to eq(correction)
     end

--- a/spec/rubocop/cop/performance/regexp_match_spec.rb
+++ b/spec/rubocop/cop/performance/regexp_match_spec.rb
@@ -5,7 +5,7 @@ describe RuboCop::Cop::Performance::RegexpMatch, :config do
 
   shared_examples :accepts do |name, code|
     it "accepts usages of #{name}" do
-      inspect_source(cop, code)
+      inspect_source(code)
 
       expect(cop.offenses).to be_empty
     end
@@ -13,7 +13,7 @@ describe RuboCop::Cop::Performance::RegexpMatch, :config do
 
   shared_examples :offense do |name, code, correction|
     it "registers an offense for #{name}" do
-      inspect_source(cop, code)
+      inspect_source(code)
 
       expect(cop.offenses.size).to eq(1)
     end

--- a/spec/rubocop/cop/performance/reverse_each_spec.rb
+++ b/spec/rubocop/cop/performance/reverse_each_spec.rb
@@ -20,7 +20,7 @@ describe RuboCop::Cop::Performance::ReverseEach do
 
   context 'autocorrect' do
     it 'corrects reverse.each to reverse_each' do
-      new_source = autocorrect_source(cop, '[1, 2].reverse.each { |e| puts e }')
+      new_source = autocorrect_source('[1, 2].reverse.each { |e| puts e }')
 
       expect(new_source).to eq('[1, 2].reverse_each { |e| puts e }')
     end

--- a/spec/rubocop/cop/performance/sample_spec.rb
+++ b/spec/rubocop/cop/performance/sample_spec.rb
@@ -11,7 +11,7 @@ describe RuboCop::Cop::Performance::Sample do
 
     context 'corrects' do
       it "#{wrong} to #{right}" do
-        new_source = autocorrect_source(cop, "[1, 2, 3].#{wrong}")
+        new_source = autocorrect_source("[1, 2, 3].#{wrong}")
         expect(new_source).to eq("[1, 2, 3].#{right}")
       end
     end

--- a/spec/rubocop/cop/performance/sample_spec.rb
+++ b/spec/rubocop/cop/performance/sample_spec.rb
@@ -5,7 +5,7 @@ describe RuboCop::Cop::Performance::Sample do
 
   shared_examples 'offense' do |wrong, right|
     it "when using #{wrong}" do
-      inspect_source(cop, "[1, 2, 3].#{wrong}")
+      inspect_source("[1, 2, 3].#{wrong}")
       expect(cop.messages).to eq(["Use `#{right}` instead of `#{wrong}`."])
     end
 
@@ -19,7 +19,7 @@ describe RuboCop::Cop::Performance::Sample do
 
   shared_examples 'accepts' do |acceptable|
     it acceptable do
-      inspect_source(cop, "[1, 2, 3].#{acceptable}")
+      inspect_source("[1, 2, 3].#{acceptable}")
       expect(cop.messages).to be_empty
     end
   end

--- a/spec/rubocop/cop/performance/size_spec.rb
+++ b/spec/rubocop/cop/performance/size_spec.rb
@@ -5,14 +5,14 @@ describe RuboCop::Cop::Performance::Size do
 
   it 'does not register an offense when calling count ' \
      'as a stand alone method' do
-    inspect_source(cop, 'count(items)')
+    inspect_source('count(items)')
 
     expect(cop.messages).to be_empty
   end
 
   it 'does not register an offense when calling count on an object ' \
      'other than an array or a hash' do
-    inspect_source(cop, 'object.count(items)')
+    inspect_source('object.count(items)')
 
     expect(cop.messages).to be_empty
   end

--- a/spec/rubocop/cop/performance/size_spec.rb
+++ b/spec/rubocop/cop/performance/size_spec.rb
@@ -60,19 +60,19 @@ describe RuboCop::Cop::Performance::Size do
     end
 
     it 'corrects count to size' do
-      new_source = autocorrect_source(cop, '[1, 2, 3].count')
+      new_source = autocorrect_source('[1, 2, 3].count')
 
       expect(new_source).to eq('[1, 2, 3].size')
     end
 
     it 'corrects count to size on to_a' do
-      new_source = autocorrect_source(cop, '(1..3).to_a.count')
+      new_source = autocorrect_source('(1..3).to_a.count')
 
       expect(new_source).to eq('(1..3).to_a.size')
     end
 
     it 'corrects count to size on Array[]' do
-      new_source = autocorrect_source(cop, 'Array[*1..5].count')
+      new_source = autocorrect_source('Array[*1..5].count')
 
       expect(new_source).to eq('Array[*1..5].size')
     end
@@ -121,19 +121,19 @@ describe RuboCop::Cop::Performance::Size do
     end
 
     it 'corrects count to size' do
-      new_source = autocorrect_source(cop, '{a: 1, b: 2, c: 3}.count')
+      new_source = autocorrect_source('{a: 1, b: 2, c: 3}.count')
 
       expect(new_source).to eq('{a: 1, b: 2, c: 3}.size')
     end
 
     it 'corrects count to size on to_h' do
-      new_source = autocorrect_source(cop, '[[:foo, :bar], [1, 2]].to_h.count')
+      new_source = autocorrect_source('[[:foo, :bar], [1, 2]].to_h.count')
 
       expect(new_source).to eq('[[:foo, :bar], [1, 2]].to_h.size')
     end
 
     it 'corrects count to size on Hash[]' do
-      new_source = autocorrect_source(cop, "Hash[*('a'..'z')].count")
+      new_source = autocorrect_source("Hash[*('a'..'z')].count")
 
       expect(new_source).to eq("Hash[*('a'..'z')].size")
     end

--- a/spec/rubocop/cop/performance/start_with_spec.rb
+++ b/spec/rubocop/cop/performance/start_with_spec.rb
@@ -5,7 +5,7 @@ describe RuboCop::Cop::Performance::StartWith do
 
   shared_examples 'different match methods' do |method|
     it "autocorrects #{method} /\\Aabc/" do
-      new_source = autocorrect_source(cop, "str#{method} /\\Aabc/")
+      new_source = autocorrect_source("str#{method} /\\Aabc/")
       expect(new_source).to eq "str.start_with?('abc')"
     end
 
@@ -14,7 +14,7 @@ describe RuboCop::Cop::Performance::StartWith do
     # but in a regex, it's an anchor on a word boundary
     %w[a e f r t v].each do |str|
       it "autocorrects #{method} /\\A\\#{str}/" do
-        new_source = autocorrect_source(cop, "str#{method} /\\A\\#{str}/")
+        new_source = autocorrect_source("str#{method} /\\A\\#{str}/")
         expect(new_source).to eq %{str.start_with?("\\#{str}")}
       end
     end
@@ -22,7 +22,7 @@ describe RuboCop::Cop::Performance::StartWith do
     # regexp metacharacters
     %w[. * ? $ ^ |].each do |str|
       it "autocorrects #{method} /\\A\\#{str}/" do
-        new_source = autocorrect_source(cop, "str#{method} /\\A\\#{str}/")
+        new_source = autocorrect_source("str#{method} /\\A\\#{str}/")
         expect(new_source).to eq "str.start_with?('#{str}')"
       end
 
@@ -43,7 +43,7 @@ describe RuboCop::Cop::Performance::StartWith do
     # characters with no special meaning whatsoever
     %w[i j l m o q y].each do |str|
       it "autocorrects #{method} /\\A\\#{str}/" do
-        new_source = autocorrect_source(cop, "str#{method} /\\A\\#{str}/")
+        new_source = autocorrect_source("str#{method} /\\A\\#{str}/")
         expect(new_source).to eq "str.start_with?('#{str}')"
       end
     end
@@ -56,7 +56,7 @@ describe RuboCop::Cop::Performance::StartWith do
     end
 
     it "autocorrects #{method} /\\A\\\\/" do
-      new_source = autocorrect_source(cop, "str#{method} /\\A\\\\/")
+      new_source = autocorrect_source("str#{method} /\\A\\\\/")
       expect(new_source).to eq("str.start_with?('\\\\')")
     end
   end

--- a/spec/rubocop/cop/performance/start_with_spec.rb
+++ b/spec/rubocop/cop/performance/start_with_spec.rb
@@ -27,7 +27,7 @@ describe RuboCop::Cop::Performance::StartWith do
       end
 
       it "doesn't register an error for #{method} /\\A#{str}/" do
-        inspect_source(cop, "str#{method} /\\A#{str}/")
+        inspect_source("str#{method} /\\A#{str}/")
         expect(cop.messages).to be_empty
       end
     end
@@ -35,7 +35,7 @@ describe RuboCop::Cop::Performance::StartWith do
     # character classes, anchors
     %w[w W s S d D A Z z G b B h H R X S].each do |str|
       it "doesn't register an error for #{method} /\\A\\#{str}/" do
-        inspect_source(cop, "str#{method} /\\A\\#{str}/")
+        inspect_source("str#{method} /\\A\\#{str}/")
         expect(cop.messages).to be_empty
       end
     end
@@ -49,7 +49,7 @@ describe RuboCop::Cop::Performance::StartWith do
     end
 
     it "formats the error message correctly for #{method} /\\Aabc/" do
-      inspect_source(cop, "str#{method} /\\Aabc/")
+      inspect_source("str#{method} /\\Aabc/")
       expect(cop.messages).to eq(['Use `String#start_with?` instead of a ' \
                                   'regex match anchored to the beginning of ' \
                                   'the string.'])

--- a/spec/rubocop/cop/performance/string_replacement_spec.rb
+++ b/spec/rubocop/cop/performance/string_replacement_spec.rb
@@ -311,69 +311,67 @@ describe RuboCop::Cop::Performance::StringReplacement do
   context 'auto-correct' do
     describe 'corrects to tr' do
       it 'corrects when the length of the pattern and replacement are one' do
-        new_source = autocorrect_source(cop, "'abc'.gsub('a', 'd')")
+        new_source = autocorrect_source("'abc'.gsub('a', 'd')")
 
         expect(new_source).to eq("'abc'.tr('a', 'd')")
       end
 
       it 'corrects when the pattern is a regex literal' do
-        new_source = autocorrect_source(cop, "'abc'.gsub(/a/, '1')")
+        new_source = autocorrect_source("'abc'.gsub(/a/, '1')")
 
         expect(new_source).to eq("'abc'.tr('a', '1')")
       end
 
       it 'corrects when the pattern is a regex literal using %r' do
-        new_source = autocorrect_source(cop, "'abc'.gsub(%r{a}, '1')")
+        new_source = autocorrect_source("'abc'.gsub(%r{a}, '1')")
 
         expect(new_source).to eq("'abc'.tr('a', '1')")
       end
 
       it 'corrects when the pattern uses Regexp.new' do
-        new_source = autocorrect_source(cop,
-                                        "'abc'.gsub(Regexp.new('a'), '1')")
+        new_source = autocorrect_source("'abc'.gsub(Regexp.new('a'), '1')")
 
         expect(new_source).to eq("'abc'.tr('a', '1')")
       end
 
       it 'corrects when the pattern uses Regexp.compile' do
-        new_source = autocorrect_source(cop,
-                                        "'abc'.gsub(Regexp.compile('a'), '1')")
+        new_source = autocorrect_source("'abc'.gsub(Regexp.compile('a'), '1')")
 
         expect(new_source).to eq("'abc'.tr('a', '1')")
       end
 
       it 'corrects when the replacement contains a new line character' do
-        new_source = autocorrect_source(cop, "'abc'.gsub('a', '\n')")
+        new_source = autocorrect_source("'abc'.gsub('a', '\n')")
 
         expect(new_source).to eq("'abc'.tr('a', '\n')")
       end
 
       it 'corrects when the replacement contains escape backslash' do
-        new_source = autocorrect_source(cop, "\"\".gsub('/', '\\\\')")
+        new_source = autocorrect_source("\"\".gsub('/', '\\\\')")
 
         expect(new_source).to eq("\"\".tr('/', '\\\\')")
       end
 
       it 'corrects when the pattern contains a new line character' do
-        new_source = autocorrect_source(cop, "'abc'.gsub('\n', ',')")
+        new_source = autocorrect_source("'abc'.gsub('\n', ',')")
 
         expect(new_source).to eq("'abc'.tr('\n', ',')")
       end
 
       it 'corrects when the pattern contains double backslash' do
-        new_source = autocorrect_source(cop, "''.gsub('\\\\', '')")
+        new_source = autocorrect_source("''.gsub('\\\\', '')")
 
         expect(new_source).to eq("''.delete('\\\\')")
       end
 
       it 'corrects when replacing to a single quote' do
-        new_source = autocorrect_source(cop, '"a`b".gsub("`", "\'")')
+        new_source = autocorrect_source('"a`b".gsub("`", "\'")')
 
         expect(new_source).to eq('"a`b".tr("`", "\'")')
       end
 
       it 'corrects when replacing to a double quote' do
-        new_source = autocorrect_source(cop, '"a`b".gsub("`", "\"")')
+        new_source = autocorrect_source('"a`b".gsub("`", "\"")')
 
         expect(new_source).to eq('"a`b".tr("`", "\"")')
       end
@@ -381,44 +379,43 @@ describe RuboCop::Cop::Performance::StringReplacement do
 
     describe 'corrects to delete' do
       it 'corrects when deleting a single character' do
-        new_source = autocorrect_source(cop, "'abc'.gsub!('a', '')")
+        new_source = autocorrect_source("'abc'.gsub!('a', '')")
 
         expect(new_source).to eq("'abc'.delete!('a')")
       end
 
       it 'corrects when the pattern is a regex literal' do
-        new_source = autocorrect_source(cop, "'abc'.gsub(/a/, '')")
+        new_source = autocorrect_source("'abc'.gsub(/a/, '')")
 
         expect(new_source).to eq("'abc'.delete('a')")
       end
 
       it 'corrects when deleting an escape character' do
-        new_source = autocorrect_source(cop, "'abc'.gsub('\n', '')")
+        new_source = autocorrect_source("'abc'.gsub('\n', '')")
 
         expect(new_source).to eq("'abc'.delete('\n')")
       end
 
       it 'corrects when the pattern uses Regexp.new' do
-        new_source = autocorrect_source(cop, "'abc'.gsub(Regexp.new('a'), '')")
+        new_source = autocorrect_source("'abc'.gsub(Regexp.new('a'), '')")
 
         expect(new_source).to eq("'abc'.delete('a')")
       end
 
       it 'corrects when the pattern uses Regexp.compile' do
-        new_source = autocorrect_source(cop,
-                                        "'ab'.gsub(Regexp.compile('a'), '')")
+        new_source = autocorrect_source("'ab'.gsub(Regexp.compile('a'), '')")
 
         expect(new_source).to eq("'ab'.delete('a')")
       end
 
       it 'corrects when there are no brackets' do
-        new_source = autocorrect_source(cop, "'abc'.gsub! 'a', ''")
+        new_source = autocorrect_source("'abc'.gsub! 'a', ''")
 
         expect(new_source).to eq("'abc'.delete! 'a'")
       end
 
       it 'corrects when a regexp contains escapes' do
-        new_source = autocorrect_source(cop, "'abc'.gsub(/\\n/, '')")
+        new_source = autocorrect_source("'abc'.gsub(/\\n/, '')")
 
         expect(new_source).to eq(%('abc'.delete("\\n")))
       end

--- a/spec/rubocop/cop/performance/string_replacement_spec.rb
+++ b/spec/rubocop/cop/performance/string_replacement_spec.rb
@@ -10,13 +10,13 @@ describe RuboCop::Cop::Performance::StringReplacement do
   shared_examples 'accepts' do |method|
     context 'non deterministic parameters' do
       it 'accepts gsub when the length of the pattern is greater than 1' do
-        inspect_source(cop, "'abc'.#{method}('ab', 'de')")
+        inspect_source("'abc'.#{method}('ab', 'de')")
 
         expect(cop.messages).to be_empty
       end
 
       it 'accepts the first param being a variable' do
-        inspect_source(cop, <<-RUBY.strip_indent)
+        inspect_source(<<-RUBY.strip_indent)
           regex = /a/
           'abc'.#{method}(regex, '1')
         RUBY
@@ -25,7 +25,7 @@ describe RuboCop::Cop::Performance::StringReplacement do
       end
 
       it 'accepts the second param being a variable' do
-        inspect_source(cop, <<-RUBY.strip_indent)
+        inspect_source(<<-RUBY.strip_indent)
           replacement = 'e'
           'abc'.#{method}('abc', replacement)
         RUBY
@@ -34,7 +34,7 @@ describe RuboCop::Cop::Performance::StringReplacement do
       end
 
       it 'accepts the both params being a variables' do
-        inspect_source(cop, <<-RUBY.strip_indent)
+        inspect_source(<<-RUBY.strip_indent)
           regex = /a/
           replacement = 'e'
           'abc'.#{method}(regex, replacement)
@@ -44,19 +44,19 @@ describe RuboCop::Cop::Performance::StringReplacement do
       end
 
       it 'accepts gsub with only one param' do
-        inspect_source(cop, "'abc'.#{method}('a')")
+        inspect_source("'abc'.#{method}('a')")
 
         expect(cop.messages).to be_empty
       end
 
       it 'accepts gsub with a block' do
-        inspect_source(cop, "'abc'.#{method}('a') { |s| s.upcase } ")
+        inspect_source("'abc'.#{method}('a') { |s| s.upcase } ")
 
         expect(cop.messages).to be_empty
       end
 
       it 'accepts a pattern with string interpolation' do
-        inspect_source(cop, <<-RUBY.strip_indent)
+        inspect_source(<<-RUBY.strip_indent)
           foo = 'a'
           'abc'.#{method}(\"\#{foo}\", '1')
         RUBY
@@ -65,7 +65,7 @@ describe RuboCop::Cop::Performance::StringReplacement do
       end
 
       it 'accepts a replacement with string interpolation' do
-        inspect_source(cop, <<-RUBY.strip_indent)
+        inspect_source(<<-RUBY.strip_indent)
           foo = '1'
           'abc'.#{method}('a', \"\#{foo}\")
         RUBY
@@ -74,37 +74,37 @@ describe RuboCop::Cop::Performance::StringReplacement do
       end
 
       it 'allows empty regex literal pattern' do
-        inspect_source(cop, "'abc'.#{method}(//, '1')")
+        inspect_source("'abc'.#{method}(//, '1')")
 
         expect(cop.messages).to be_empty
       end
 
       it 'allows empty regex pattern from string' do
-        inspect_source(cop, "'abc'.#{method}(Regexp.new(''), '1')")
+        inspect_source("'abc'.#{method}(Regexp.new(''), '1')")
 
         expect(cop.messages).to be_empty
       end
 
       it 'allows empty regex pattern from regex' do
-        inspect_source(cop, "'abc'.#{method}(Regexp.new(//), '1')")
+        inspect_source("'abc'.#{method}(Regexp.new(//), '1')")
 
         expect(cop.messages).to be_empty
       end
 
       it 'allows regex literals with options' do
-        inspect_source(cop, "'abc'.#{method}(/a/i, '1')")
+        inspect_source("'abc'.#{method}(/a/i, '1')")
 
         expect(cop.messages).to be_empty
       end
 
       it 'allows regex with options' do
-        inspect_source(cop, "'abc'.#{method}(Regexp.new(/a/i), '1')")
+        inspect_source("'abc'.#{method}(Regexp.new(/a/i), '1')")
 
         expect(cop.messages).to be_empty
       end
 
       it 'allows empty string pattern' do
-        inspect_source(cop, "'abc'.#{method}('', '1')")
+        inspect_source("'abc'.#{method}('', '1')")
 
         expect(cop.messages).to be_empty
       end
@@ -112,14 +112,14 @@ describe RuboCop::Cop::Performance::StringReplacement do
 
     it 'accepts calls to gsub when the length of the pattern is shorter than ' \
        'the length of the replacement' do
-      inspect_source(cop, "'abc'.#{method}('a', 'ab')")
+      inspect_source("'abc'.#{method}('a', 'ab')")
 
       expect(cop.messages).to be_empty
     end
 
     it 'accepts calls to gsub when the length of the pattern is longer than ' \
        'the length of the replacement' do
-      inspect_source(cop, "'abc'.#{method}('ab', 'd')")
+      inspect_source("'abc'.#{method}('ab', 'd')")
 
       expect(cop.messages).to be_empty
     end
@@ -140,25 +140,25 @@ describe RuboCop::Cop::Performance::StringReplacement do
       %w[a b c ' " % ! = < > # & ; : ` ~ 1 2 3 - _ , \r \\\\ \y \u1234
          \x65].each do |str|
         it "registers an offense when replacing #{str} with a literal" do
-          inspect_source(cop, "'abc'.gsub(/#{str}/, 'a')")
+          inspect_source("'abc'.gsub(/#{str}/, 'a')")
           expect(cop.messages).to eq(['Use `tr` instead of `gsub`.'])
         end
 
         it "registers an offense when deleting #{str}" do
-          inspect_source(cop, "'abc'.gsub(/#{str}/, '')")
+          inspect_source("'abc'.gsub(/#{str}/, '')")
           expect(cop.messages).to eq(['Use `delete` instead of `gsub`.'])
         end
       end
 
       it 'allows deterministic regex when the length of the pattern ' \
          'and the length of the replacement do not match' do
-        inspect_source(cop, %('abc'.gsub(/a/, 'def')))
+        inspect_source(%('abc'.gsub(/a/, 'def')))
 
         expect(cop.messages).to be_empty
       end
 
       it 'registers an offense when escape characters in regex' do
-        inspect_source(cop, %('abc'.gsub(/\n/, ',')))
+        inspect_source(%('abc'.gsub(/\n/, ',')))
 
         expect(cop.messages).to eq(['Use `tr` instead of `gsub`.'])
       end
@@ -268,14 +268,14 @@ describe RuboCop::Cop::Performance::StringReplacement do
 
   it 'registers an offense when the pattern has non deterministic regex ' \
      'as a string' do
-    inspect_source(cop, %('a + c'.gsub('+', '-')))
+    inspect_source(%('a + c'.gsub('+', '-')))
 
     expect(cop.messages).to eq(['Use `tr` instead of `gsub`.'])
   end
 
   it 'registers an offense when using gsub to find and replace ' \
      'a single character' do
-    inspect_source(cop, "'abc'.gsub('a', '1')")
+    inspect_source("'abc'.gsub('a', '1')")
 
     expect(cop.messages).to eq(['Use `tr` instead of `gsub`.'])
     expect(cop.highlights).to eq(["gsub('a', '1')"])
@@ -283,7 +283,7 @@ describe RuboCop::Cop::Performance::StringReplacement do
 
   it 'registers an offense when using gsub! to find and replace ' \
      'a single character ' do
-    inspect_source(cop, "'abc'.gsub!('a', '1')")
+    inspect_source("'abc'.gsub!('a', '1')")
 
     expect(cop.messages).to eq(['Use `tr!` instead of `gsub!`.'])
     expect(cop.highlights).to eq(["gsub!('a', '1')"])
@@ -297,13 +297,13 @@ describe RuboCop::Cop::Performance::StringReplacement do
   end
 
   it 'registers an offense when using escape characters in the replacement' do
-    inspect_source(cop, "'abc'.gsub('a', '\n')")
+    inspect_source("'abc'.gsub('a', '\n')")
 
     expect(cop.messages).to eq(['Use `tr` instead of `gsub`.'])
   end
 
   it 'registers an offense when using escape characters in the pattern' do
-    inspect_source(cop, "'abc'.gsub('\n', ',')")
+    inspect_source("'abc'.gsub('\n', ',')")
 
     expect(cop.messages).to eq(['Use `tr` instead of `gsub`.'])
   end

--- a/spec/rubocop/cop/performance/times_map_spec.rb
+++ b/spec/rubocop/cop/performance/times_map_spec.rb
@@ -4,7 +4,7 @@ describe RuboCop::Cop::Performance::TimesMap do
   subject(:cop) { described_class.new }
 
   before do
-    inspect_source(cop, source)
+    inspect_source(source)
   end
 
   shared_examples 'map_or_collect' do |method|

--- a/spec/rubocop/cop/performance/times_map_spec.rb
+++ b/spec/rubocop/cop/performance/times_map_spec.rb
@@ -21,7 +21,7 @@ describe RuboCop::Cop::Performance::TimesMap do
         end
 
         it 'auto-corrects' do
-          corrected = autocorrect_source(cop, source)
+          corrected = autocorrect_source(source)
           expect(corrected).to eq('Array.new(4) { |i| i.to_s }')
         end
       end
@@ -38,7 +38,7 @@ describe RuboCop::Cop::Performance::TimesMap do
         end
 
         it 'auto-corrects' do
-          corrected = autocorrect_source(cop, source)
+          corrected = autocorrect_source(source)
           expect(corrected).to eq('Array.new(4, &method(:foo))')
         end
       end

--- a/spec/rubocop/cop/rails/action_filter_spec.rb
+++ b/spec/rubocop/cop/rails/action_filter_spec.rb
@@ -48,19 +48,19 @@ describe RuboCop::Cop::Rails::ActionFilter, :config do
     context 'when using action methods' do
       described_class::FILTER_METHODS.each do |method|
         it "does not register an offense for #{method}" do
-          inspect_source_file(cop, "#{method} :name")
+          inspect_source_file("#{method} :name")
           expect(cop.offenses.size).to eq(0)
         end
 
         it "does not register an offense for #{method} with block" do
-          inspect_source_file(cop, "#{method} { |controller| something }")
+          inspect_source_file("#{method} { |controller| something }")
           expect(cop.offenses.size).to eq(0)
         end
       end
 
       described_class::ACTION_METHODS.each do |method|
         it "accepts #{method}" do
-          inspect_source_file(cop, "#{method} :something")
+          inspect_source_file("#{method} :something")
           expect(cop.offenses).to be_empty
         end
       end
@@ -74,19 +74,19 @@ describe RuboCop::Cop::Rails::ActionFilter, :config do
     context 'when using filter methods' do
       described_class::ACTION_METHODS.each do |method|
         it "does not register an offense for #{method}" do
-          inspect_source_file(cop, "#{method} :name")
+          inspect_source_file("#{method} :name")
           expect(cop.offenses.size).to eq(0)
         end
 
         it "does not register an offense for #{method} with block" do
-          inspect_source_file(cop, "#{method} { |controller| something }")
+          inspect_source_file("#{method} { |controller| something }")
           expect(cop.offenses.size).to eq(0)
         end
       end
 
       described_class::FILTER_METHODS.each do |method|
         it "accepts #{method}" do
-          inspect_source_file(cop, "#{method} :something")
+          inspect_source_file("#{method} :something")
           expect(cop.offenses).to be_empty
         end
       end
@@ -109,19 +109,19 @@ describe RuboCop::Cop::Rails::ActionFilter, :config do
 
       described_class::FILTER_METHODS.each do |method|
         it "registers an offense for #{method}" do
-          inspect_source_file(cop, "#{method} :name")
+          inspect_source_file("#{method} :name")
           expect(cop.offenses.size).to eq(1)
         end
 
         it "registers an offense for #{method} with block" do
-          inspect_source_file(cop, "#{method} { |controller| something }")
+          inspect_source_file("#{method} { |controller| something }")
           expect(cop.offenses.size).to eq(1)
         end
       end
 
       described_class::ACTION_METHODS.each do |method|
         it "accepts #{method}" do
-          inspect_source_file(cop, "#{method} :something")
+          inspect_source_file("#{method} :something")
           expect(cop.offenses).to be_empty
         end
       end
@@ -139,19 +139,19 @@ describe RuboCop::Cop::Rails::ActionFilter, :config do
 
       described_class::ACTION_METHODS.each do |method|
         it "registers an offense for #{method}" do
-          inspect_source_file(cop, "#{method} :name")
+          inspect_source_file("#{method} :name")
           expect(cop.offenses.size).to eq(1)
         end
 
         it "registers an offense for #{method} with block" do
-          inspect_source_file(cop, "#{method} { |controller| something }")
+          inspect_source_file("#{method} { |controller| something }")
           expect(cop.offenses.size).to eq(1)
         end
       end
 
       described_class::FILTER_METHODS.each do |method|
         it "accepts #{method}" do
-          inspect_source_file(cop, "#{method} :something")
+          inspect_source_file("#{method} :something")
           expect(cop.offenses).to be_empty
         end
       end

--- a/spec/rubocop/cop/rails/action_filter_spec.rb
+++ b/spec/rubocop/cop/rails/action_filter_spec.rb
@@ -66,7 +66,7 @@ describe RuboCop::Cop::Rails::ActionFilter, :config do
       end
 
       it 'does not auto-correct to preferred method' do
-        new_source = autocorrect_source_file(cop, 'before_filter :test')
+        new_source = autocorrect_source_file('before_filter :test')
         expect(new_source).to eq('before_filter :test')
       end
     end
@@ -92,7 +92,7 @@ describe RuboCop::Cop::Rails::ActionFilter, :config do
       end
 
       it 'does not auto-correct to preferred method' do
-        new_source = autocorrect_source_file(cop, 'before_action :test')
+        new_source = autocorrect_source_file('before_action :test')
         expect(new_source).to eq('before_action :test')
       end
     end
@@ -127,7 +127,7 @@ describe RuboCop::Cop::Rails::ActionFilter, :config do
       end
 
       it 'auto-corrects to preferred method' do
-        new_source = autocorrect_source_file(cop, 'before_filter :test')
+        new_source = autocorrect_source_file('before_filter :test')
         expect(new_source).to eq('before_action :test')
       end
     end
@@ -157,7 +157,7 @@ describe RuboCop::Cop::Rails::ActionFilter, :config do
       end
 
       it 'auto-corrects to preferred method' do
-        new_source = autocorrect_source_file(cop, 'before_action :test')
+        new_source = autocorrect_source_file('before_action :test')
         expect(new_source).to eq('before_filter :test')
       end
     end

--- a/spec/rubocop/cop/rails/active_support_aliases_spec.rb
+++ b/spec/rubocop/cop/rails/active_support_aliases_spec.rb
@@ -16,7 +16,7 @@ describe RuboCop::Cop::Rails::ActiveSupportAliases do
 
       it 'is autocorrected' do
         new_source = autocorrect_source(
-          cop, "'some_string'.starts_with?('prefix')"
+          "'some_string'.starts_with?('prefix')"
         )
         expect(new_source).to eq "'some_string'.start_with?('prefix')"
       end
@@ -38,7 +38,7 @@ describe RuboCop::Cop::Rails::ActiveSupportAliases do
 
       it 'is autocorrected' do
         new_source = autocorrect_source(
-          cop, "'some_string'.ends_with?('prefix')"
+          "'some_string'.ends_with?('prefix')"
         )
         expect(new_source).to eq "'some_string'.end_with?('prefix')"
       end
@@ -62,7 +62,7 @@ describe RuboCop::Cop::Rails::ActiveSupportAliases do
 
       it 'is not autocorrected' do
         source = "[1, 'a', 3].append('element')"
-        new_source = autocorrect_source(cop, source)
+        new_source = autocorrect_source(source)
         expect(new_source).to eq source
       end
     end
@@ -83,7 +83,7 @@ describe RuboCop::Cop::Rails::ActiveSupportAliases do
 
       it 'is autocorrected' do
         new_source = autocorrect_source(
-          cop, "[1, 'a', 3].prepend('element')"
+          "[1, 'a', 3].prepend('element')"
         )
         expect(new_source).to eq "[1, 'a', 3].unshift('element')"
       end

--- a/spec/rubocop/cop/rails/application_job_spec.rb
+++ b/spec/rubocop/cop/rails/application_job_spec.rb
@@ -69,7 +69,7 @@ describe RuboCop::Cop::Rails::ApplicationJob do
 
     it 'corrects jobs that subclass ActiveJob::Base' do
       source = "class MyJob < ActiveJob::Base\nend"
-      inspect_source(cop, source)
+      inspect_source(source)
       expect(cop.messages).to eq(msgs)
       expect(cop.highlights).to eq(['ActiveJob::Base'])
       expect(autocorrect_source(cop, source))
@@ -78,7 +78,7 @@ describe RuboCop::Cop::Rails::ApplicationJob do
 
     it 'corrects single-line class definitions' do
       source = 'class MyJob < ActiveJob::Base; end'
-      inspect_source(cop, source)
+      inspect_source(source)
       expect(cop.messages).to eq(msgs)
       expect(cop.highlights).to eq(['ActiveJob::Base'])
       expect(autocorrect_source(cop, source))
@@ -87,7 +87,7 @@ describe RuboCop::Cop::Rails::ApplicationJob do
 
     it 'corrects namespaced jobs that subclass ActiveJob::Base' do
       source = "module Nested\n  class MyJob < ActiveJob::Base\n  end\nend"
-      inspect_source(cop, source)
+      inspect_source(source)
       expect(cop.messages).to eq(msgs)
       expect(cop.highlights).to eq(['ActiveJob::Base'])
       expect(autocorrect_source(cop, source))
@@ -96,7 +96,7 @@ describe RuboCop::Cop::Rails::ApplicationJob do
 
     it 'corrects jobs defined using nested constants' do
       source = "class Nested::MyJob < ActiveJob::Base\nend"
-      inspect_source(cop, source)
+      inspect_source(source)
       expect(cop.messages).to eq(msgs)
       expect(cop.highlights).to eq(['ActiveJob::Base'])
       expect(autocorrect_source(cop, source))
@@ -105,7 +105,7 @@ describe RuboCop::Cop::Rails::ApplicationJob do
 
     it 'corrects jobs defined using Class.new' do
       source = 'MyJob = Class.new(ActiveJob::Base)'
-      inspect_source(cop, source)
+      inspect_source(source)
       expect(cop.messages).to eq(msgs)
       expect(cop.highlights).to eq(['ActiveJob::Base'])
       expect(autocorrect_source(cop, source))
@@ -114,7 +114,7 @@ describe RuboCop::Cop::Rails::ApplicationJob do
 
     it 'corrects nested jobs defined using Class.new' do
       source = 'Nested::MyJob = Class.new(ActiveJob::Base)'
-      inspect_source(cop, source)
+      inspect_source(source)
       expect(cop.messages).to eq(msgs)
       expect(cop.highlights).to eq(['ActiveJob::Base'])
       expect(autocorrect_source(cop, source))
@@ -123,7 +123,7 @@ describe RuboCop::Cop::Rails::ApplicationJob do
 
     it 'corrects anonymous jobs' do
       source = 'Class.new(ActiveJob::Base) {}'
-      inspect_source(cop, source)
+      inspect_source(source)
       expect(cop.messages).to eq(msgs)
       expect(cop.highlights).to eq(['ActiveJob::Base'])
       expect(autocorrect_source(cop, source))

--- a/spec/rubocop/cop/rails/application_job_spec.rb
+++ b/spec/rubocop/cop/rails/application_job_spec.rb
@@ -72,7 +72,7 @@ describe RuboCop::Cop::Rails::ApplicationJob do
       inspect_source(source)
       expect(cop.messages).to eq(msgs)
       expect(cop.highlights).to eq(['ActiveJob::Base'])
-      expect(autocorrect_source(cop, source))
+      expect(autocorrect_source(source))
         .to eq("class MyJob < ApplicationJob\nend")
     end
 
@@ -81,7 +81,7 @@ describe RuboCop::Cop::Rails::ApplicationJob do
       inspect_source(source)
       expect(cop.messages).to eq(msgs)
       expect(cop.highlights).to eq(['ActiveJob::Base'])
-      expect(autocorrect_source(cop, source))
+      expect(autocorrect_source(source))
         .to eq('class MyJob < ApplicationJob; end')
     end
 
@@ -90,7 +90,7 @@ describe RuboCop::Cop::Rails::ApplicationJob do
       inspect_source(source)
       expect(cop.messages).to eq(msgs)
       expect(cop.highlights).to eq(['ActiveJob::Base'])
-      expect(autocorrect_source(cop, source))
+      expect(autocorrect_source(source))
         .to eq("module Nested\n  class MyJob < ApplicationJob\n  end\nend")
     end
 
@@ -99,7 +99,7 @@ describe RuboCop::Cop::Rails::ApplicationJob do
       inspect_source(source)
       expect(cop.messages).to eq(msgs)
       expect(cop.highlights).to eq(['ActiveJob::Base'])
-      expect(autocorrect_source(cop, source))
+      expect(autocorrect_source(source))
         .to eq("class Nested::MyJob < ApplicationJob\nend")
     end
 
@@ -108,7 +108,7 @@ describe RuboCop::Cop::Rails::ApplicationJob do
       inspect_source(source)
       expect(cop.messages).to eq(msgs)
       expect(cop.highlights).to eq(['ActiveJob::Base'])
-      expect(autocorrect_source(cop, source))
+      expect(autocorrect_source(source))
         .to eq('MyJob = Class.new(ApplicationJob)')
     end
 
@@ -117,7 +117,7 @@ describe RuboCop::Cop::Rails::ApplicationJob do
       inspect_source(source)
       expect(cop.messages).to eq(msgs)
       expect(cop.highlights).to eq(['ActiveJob::Base'])
-      expect(autocorrect_source(cop, source))
+      expect(autocorrect_source(source))
         .to eq('Nested::MyJob = Class.new(ApplicationJob)')
     end
 
@@ -126,7 +126,7 @@ describe RuboCop::Cop::Rails::ApplicationJob do
       inspect_source(source)
       expect(cop.messages).to eq(msgs)
       expect(cop.highlights).to eq(['ActiveJob::Base'])
-      expect(autocorrect_source(cop, source))
+      expect(autocorrect_source(source))
         .to eq('Class.new(ApplicationJob) {}')
     end
 

--- a/spec/rubocop/cop/rails/application_record_spec.rb
+++ b/spec/rubocop/cop/rails/application_record_spec.rb
@@ -72,7 +72,7 @@ describe RuboCop::Cop::Rails::ApplicationRecord do
       inspect_source(source)
       expect(cop.messages).to eq(msgs)
       expect(cop.highlights).to eq(['ActiveRecord::Base'])
-      expect(autocorrect_source(cop, source))
+      expect(autocorrect_source(source))
         .to eq("class MyModel < ApplicationRecord\nend")
     end
 
@@ -81,7 +81,7 @@ describe RuboCop::Cop::Rails::ApplicationRecord do
       inspect_source(source)
       expect(cop.messages).to eq(msgs)
       expect(cop.highlights).to eq(['ActiveRecord::Base'])
-      expect(autocorrect_source(cop, source))
+      expect(autocorrect_source(source))
         .to eq('class MyModel < ApplicationRecord; end')
     end
 
@@ -90,7 +90,7 @@ describe RuboCop::Cop::Rails::ApplicationRecord do
       inspect_source(source)
       expect(cop.messages).to eq(msgs)
       expect(cop.highlights).to eq(['ActiveRecord::Base'])
-      expect(autocorrect_source(cop, source))
+      expect(autocorrect_source(source))
         .to eq("module Nested\n  class MyModel < ApplicationRecord\n  end\nend")
     end
 
@@ -99,7 +99,7 @@ describe RuboCop::Cop::Rails::ApplicationRecord do
       inspect_source(source)
       expect(cop.messages).to eq(msgs)
       expect(cop.highlights).to eq(['ActiveRecord::Base'])
-      expect(autocorrect_source(cop, source))
+      expect(autocorrect_source(source))
         .to eq("class Nested::MyModel < ApplicationRecord\nend")
     end
 
@@ -108,7 +108,7 @@ describe RuboCop::Cop::Rails::ApplicationRecord do
       inspect_source(source)
       expect(cop.messages).to eq(msgs)
       expect(cop.highlights).to eq(['ActiveRecord::Base'])
-      expect(autocorrect_source(cop, source))
+      expect(autocorrect_source(source))
         .to eq('MyModel = Class.new(ApplicationRecord)')
     end
 
@@ -117,7 +117,7 @@ describe RuboCop::Cop::Rails::ApplicationRecord do
       inspect_source(source)
       expect(cop.messages).to eq(msgs)
       expect(cop.highlights).to eq(['ActiveRecord::Base'])
-      expect(autocorrect_source(cop, source))
+      expect(autocorrect_source(source))
         .to eq('Nested::MyModel = Class.new(ApplicationRecord)')
     end
 
@@ -126,7 +126,7 @@ describe RuboCop::Cop::Rails::ApplicationRecord do
       inspect_source(source)
       expect(cop.messages).to eq(msgs)
       expect(cop.highlights).to eq(['ActiveRecord::Base'])
-      expect(autocorrect_source(cop, source))
+      expect(autocorrect_source(source))
         .to eq('Class.new(ApplicationRecord) {}')
     end
 

--- a/spec/rubocop/cop/rails/application_record_spec.rb
+++ b/spec/rubocop/cop/rails/application_record_spec.rb
@@ -69,7 +69,7 @@ describe RuboCop::Cop::Rails::ApplicationRecord do
 
     it 'corrects models that subclass ActiveRecord::Base' do
       source = "class MyModel < ActiveRecord::Base\nend"
-      inspect_source(cop, source)
+      inspect_source(source)
       expect(cop.messages).to eq(msgs)
       expect(cop.highlights).to eq(['ActiveRecord::Base'])
       expect(autocorrect_source(cop, source))
@@ -78,7 +78,7 @@ describe RuboCop::Cop::Rails::ApplicationRecord do
 
     it 'corrects single-line class definitions' do
       source = 'class MyModel < ActiveRecord::Base; end'
-      inspect_source(cop, source)
+      inspect_source(source)
       expect(cop.messages).to eq(msgs)
       expect(cop.highlights).to eq(['ActiveRecord::Base'])
       expect(autocorrect_source(cop, source))
@@ -87,7 +87,7 @@ describe RuboCop::Cop::Rails::ApplicationRecord do
 
     it 'corrects namespaced models that subclass ActiveRecord::Base' do
       source = "module Nested\n  class MyModel < ActiveRecord::Base\n  end\nend"
-      inspect_source(cop, source)
+      inspect_source(source)
       expect(cop.messages).to eq(msgs)
       expect(cop.highlights).to eq(['ActiveRecord::Base'])
       expect(autocorrect_source(cop, source))
@@ -96,7 +96,7 @@ describe RuboCop::Cop::Rails::ApplicationRecord do
 
     it 'corrects models defined using nested constants' do
       source = "class Nested::MyModel < ActiveRecord::Base\nend"
-      inspect_source(cop, source)
+      inspect_source(source)
       expect(cop.messages).to eq(msgs)
       expect(cop.highlights).to eq(['ActiveRecord::Base'])
       expect(autocorrect_source(cop, source))
@@ -105,7 +105,7 @@ describe RuboCop::Cop::Rails::ApplicationRecord do
 
     it 'corrects models defined using Class.new' do
       source = 'MyModel = Class.new(ActiveRecord::Base)'
-      inspect_source(cop, source)
+      inspect_source(source)
       expect(cop.messages).to eq(msgs)
       expect(cop.highlights).to eq(['ActiveRecord::Base'])
       expect(autocorrect_source(cop, source))
@@ -114,7 +114,7 @@ describe RuboCop::Cop::Rails::ApplicationRecord do
 
     it 'corrects nested models defined using Class.new' do
       source = 'Nested::MyModel = Class.new(ActiveRecord::Base)'
-      inspect_source(cop, source)
+      inspect_source(source)
       expect(cop.messages).to eq(msgs)
       expect(cop.highlights).to eq(['ActiveRecord::Base'])
       expect(autocorrect_source(cop, source))
@@ -123,7 +123,7 @@ describe RuboCop::Cop::Rails::ApplicationRecord do
 
     it 'corrects anonymous models' do
       source = 'Class.new(ActiveRecord::Base) {}'
-      inspect_source(cop, source)
+      inspect_source(source)
       expect(cop.messages).to eq(msgs)
       expect(cop.highlights).to eq(['ActiveRecord::Base'])
       expect(autocorrect_source(cop, source))

--- a/spec/rubocop/cop/rails/blank_spec.rb
+++ b/spec/rubocop/cop/rails/blank_spec.rb
@@ -12,7 +12,7 @@ describe RuboCop::Cop::Rails::Blank, :config do
     end
 
     it 'auto-corrects' do
-      new_source = autocorrect_source(cop, source)
+      new_source = autocorrect_source(source)
 
       expect(new_source).to eq(correction)
     end
@@ -173,7 +173,7 @@ describe RuboCop::Cop::Rails::Blank, :config do
       end
 
       it 'auto-corrects' do
-        new_source = autocorrect_source(cop, source)
+        new_source = autocorrect_source(source)
 
         expect(new_source).to eq('something if foo.blank?')
       end
@@ -198,7 +198,7 @@ describe RuboCop::Cop::Rails::Blank, :config do
       end
 
       it 'auto-corrects' do
-        new_source = autocorrect_source(cop, source)
+        new_source = autocorrect_source(source)
 
         expect(new_source).to eq(<<-RUBY.strip_indent)
           if foo.blank?
@@ -231,7 +231,7 @@ describe RuboCop::Cop::Rails::Blank, :config do
       end
 
       it 'auto-corrects' do
-        new_source = autocorrect_source(cop, source)
+        new_source = autocorrect_source(source)
 
         expect(new_source).to eq(<<-RUBY.strip_indent)
           if foo.blank?

--- a/spec/rubocop/cop/rails/blank_spec.rb
+++ b/spec/rubocop/cop/rails/blank_spec.rb
@@ -5,7 +5,7 @@ describe RuboCop::Cop::Rails::Blank, :config do
 
   shared_examples :offense do |source, correction, message|
     it 'registers an offense' do
-      inspect_source(cop, source)
+      inspect_source(source)
 
       expect(cop.messages).to eq([message])
       expect(cop.highlights).to eq([source])

--- a/spec/rubocop/cop/rails/date_spec.rb
+++ b/spec/rubocop/cop/rails/date_spec.rb
@@ -8,34 +8,34 @@ describe RuboCop::Cop::Rails::Date, :config do
 
     %w[today current yesterday tomorrow].each do |day|
       it "registers an offense for Date.#{day}" do
-        inspect_source(cop, "Date.#{day}")
+        inspect_source("Date.#{day}")
         expect(cop.offenses.size).to eq(1)
       end
 
       it "registers an offense for ::Date.#{day}" do
-        inspect_source(cop, "::Date.#{day}")
+        inspect_source("::Date.#{day}")
         expect(cop.offenses.size).to eq(1)
       end
 
       it "accepts Some::Date.#{day}" do
-        inspect_source(cop, "Some::Date.#{day}")
+        inspect_source("Some::Date.#{day}")
         expect(cop.offenses).to be_empty
       end
     end
 
     %w[to_time to_time_in_current_zone].each do |method|
       it "registers an offense for ##{method}" do
-        inspect_source(cop, "date.#{method}")
+        inspect_source("date.#{method}")
         expect(cop.offenses.size).to eq(1)
       end
 
       it "accepts variable named #{method}" do
-        inspect_source(cop, "#{method} = 1")
+        inspect_source("#{method} = 1")
         expect(cop.offenses).to be_empty
       end
 
       it "accepts variable #{method} as range end" do
-        inspect_source(cop, "from_time..#{method}")
+        inspect_source("from_time..#{method}")
         expect(cop.offenses).to be_empty
       end
     end
@@ -67,7 +67,7 @@ describe RuboCop::Cop::Rails::Date, :config do
 
     RuboCop::Cop::Rails::TimeZone::ACCEPTED_METHODS.each do |a_method|
       it "registers an offense for val.to_time.#{a_method}" do
-        inspect_source(cop, "val.to_time.#{a_method}")
+        inspect_source("val.to_time.#{a_method}")
         expect(cop.offenses.size).to eq(1)
       end
     end
@@ -78,7 +78,7 @@ describe RuboCop::Cop::Rails::Date, :config do
 
     %w[current yesterday tomorrow].each do |day|
       it "accepts Date.#{day}" do
-        inspect_source(cop, "Date.#{day}")
+        inspect_source("Date.#{day}")
         expect(cop.offenses).to be_empty
       end
     end
@@ -92,7 +92,7 @@ describe RuboCop::Cop::Rails::Date, :config do
 
     RuboCop::Cop::Rails::TimeZone::ACCEPTED_METHODS.each do |a_method|
       it "accepts val.to_time.#{a_method}" do
-        inspect_source(cop, "val.to_time.#{a_method}")
+        inspect_source("val.to_time.#{a_method}")
         expect(cop.offenses).to be_empty
       end
     end

--- a/spec/rubocop/cop/rails/delegate_allow_blank_spec.rb
+++ b/spec/rubocop/cop/rails/delegate_allow_blank_spec.rb
@@ -20,7 +20,7 @@ describe RuboCop::Cop::Rails::DelegateAllowBlank do
 
   it 'autocorrects allow_blank to allow_nil' do
     source = 'delegate :foo, to: :bar, allow_blank: true'
-    new_source = autocorrect_source(cop, source)
+    new_source = autocorrect_source(source)
 
     expect(new_source).to eq('delegate :foo, to: :bar, allow_nil: true')
   end

--- a/spec/rubocop/cop/rails/delegate_allow_blank_spec.rb
+++ b/spec/rubocop/cop/rails/delegate_allow_blank_spec.rb
@@ -4,7 +4,7 @@ describe RuboCop::Cop::Rails::DelegateAllowBlank do
   subject(:cop) { described_class.new }
 
   it 'registers an offense when using allow_blank' do
-    inspect_source(cop, 'delegate :foo, to: :bar, allow_blank: true')
+    inspect_source('delegate :foo, to: :bar, allow_blank: true')
 
     msg = '`allow_blank` is not a valid option, use `allow_nil`.'
     expect(cop.messages).to eq([msg])

--- a/spec/rubocop/cop/rails/delegate_spec.rb
+++ b/spec/rubocop/cop/rails/delegate_spec.rb
@@ -168,7 +168,7 @@ describe RuboCop::Cop::Rails::Delegate do
       end
 
       it 'autocorrects' do
-        expect(autocorrect_source(cop, source)).to eq(corrected_source)
+        expect(autocorrect_source(source)).to eq(corrected_source)
       end
     end
 
@@ -188,7 +188,7 @@ describe RuboCop::Cop::Rails::Delegate do
       end
 
       it 'autocorrects' do
-        expect(autocorrect_source(cop, source)).to eq(corrected_source)
+        expect(autocorrect_source(source)).to eq(corrected_source)
       end
 
       context 'with EnforceForPrefixed: false' do
@@ -197,7 +197,7 @@ describe RuboCop::Cop::Rails::Delegate do
         end
 
         it 'does not autocorrect' do
-          expect(autocorrect_source(cop, source)).to eq(source)
+          expect(autocorrect_source(source)).to eq(source)
         end
       end
     end

--- a/spec/rubocop/cop/rails/dynamic_find_by_spec.rb
+++ b/spec/rubocop/cop/rails/dynamic_find_by_spec.rb
@@ -15,7 +15,7 @@ describe RuboCop::Cop::Rails::DynamicFindBy, :config do
     end
 
     it 'auto-corrects' do
-      new_source = autocorrect_source(cop, source)
+      new_source = autocorrect_source(source)
       expect(new_source).to eq(corrected)
     end
   end

--- a/spec/rubocop/cop/rails/dynamic_find_by_spec.rb
+++ b/spec/rubocop/cop/rails/dynamic_find_by_spec.rb
@@ -8,7 +8,7 @@ describe RuboCop::Cop::Rails::DynamicFindBy, :config do
 
   shared_examples 'register an offense and auto correct' do |message, corrected|
     it 'registers an offense' do
-      inspect_source(cop, source)
+      inspect_source(source)
       expect(cop.offenses.size).to eq(1)
       expect(cop.messages)
         .to eq([message])

--- a/spec/rubocop/cop/rails/enum_uniqueness_spec.rb
+++ b/spec/rubocop/cop/rails/enum_uniqueness_spec.rb
@@ -6,7 +6,7 @@ describe RuboCop::Cop::Rails::EnumUniqueness, :config do
   context 'when array syntax is used' do
     context 'with a single duplicated enum value' do
       it 'registers an offense' do
-        inspect_source(cop, 'enum status: [:active, :archived, :active]')
+        inspect_source('enum status: [:active, :archived, :active]')
 
         msg = 'Duplicate value `:active` found in `status` enum declaration.'
         expect(cop.offenses.size).to eq(1)
@@ -34,7 +34,7 @@ describe RuboCop::Cop::Rails::EnumUniqueness, :config do
   context 'when hash syntax is used' do
     context 'with a single duplicated enum value' do
       it 'registers an offense' do
-        inspect_source(cop, 'enum status: { active: 0, archived: 0 }')
+        inspect_source('enum status: { active: 0, archived: 0 }')
 
         msg = 'Duplicate value `0` found in `status` enum declaration.'
         expect(cop.offenses.size).to eq(1)

--- a/spec/rubocop/cop/rails/exit_spec.rb
+++ b/spec/rubocop/cop/rails/exit_spec.rb
@@ -24,8 +24,7 @@ describe RuboCop::Cop::Rails::Exit, :config do
 
     it 'does not register an offense for an explicit exit call '\
       'with an argument on an object' do
-      inspect_source(cop,
-                     'Object.new.exit(0)')
+      inspect_source('Object.new.exit(0)')
       expect(cop.offenses).to be_empty
     end
 

--- a/spec/rubocop/cop/rails/find_by_spec.rb
+++ b/spec/rubocop/cop/rails/find_by_spec.rb
@@ -5,7 +5,7 @@ describe RuboCop::Cop::Rails::FindBy do
 
   shared_examples 'registers_offense' do |selector|
     it "when using where.#{selector}" do
-      inspect_source(cop, "User.where(id: x).#{selector}")
+      inspect_source("User.where(id: x).#{selector}")
 
       expect(cop.messages)
         .to eq(["Use `find_by` instead of `where.#{selector}`."])

--- a/spec/rubocop/cop/rails/find_by_spec.rb
+++ b/spec/rubocop/cop/rails/find_by_spec.rb
@@ -20,13 +20,13 @@ describe RuboCop::Cop::Rails::FindBy do
   end
 
   it 'autocorrects where.take to find_by' do
-    new_source = autocorrect_source(cop, 'User.where(id: x).take')
+    new_source = autocorrect_source('User.where(id: x).take')
 
     expect(new_source).to eq('User.find_by(id: x)')
   end
 
   it 'does not autocorrect where.first' do
-    new_source = autocorrect_source(cop, 'User.where(id: x).first')
+    new_source = autocorrect_source('User.where(id: x).first')
 
     expect(new_source).to eq('User.where(id: x).first')
   end

--- a/spec/rubocop/cop/rails/find_each_spec.rb
+++ b/spec/rubocop/cop/rails/find_each_spec.rb
@@ -5,25 +5,25 @@ describe RuboCop::Cop::Rails::FindEach do
 
   shared_examples 'register_offense' do |scope|
     it "registers an offense when using #{scope}.each" do
-      inspect_source(cop, "User.#{scope}.each { |u| u.something }")
+      inspect_source("User.#{scope}.each { |u| u.something }")
 
       expect(cop.messages).to eq(['Use `find_each` instead of `each`.'])
     end
 
     it "does not register an offense when using #{scope}.order(...).each" do
-      inspect_source(cop, "User.#{scope}.order(:name).each { |u| u.something }")
+      inspect_source("User.#{scope}.order(:name).each { |u| u.something }")
 
       expect(cop.offenses).to be_empty
     end
 
     it "does not register an offense when using #{scope}.limit(...).each" do
-      inspect_source(cop, "User.#{scope}.limit(10).each { |u| u.something }")
+      inspect_source("User.#{scope}.limit(10).each { |u| u.something }")
 
       expect(cop.offenses).to be_empty
     end
 
     it "does not register an offense when using #{scope}.select(...).each" do
-      inspect_source(cop, "User.#{scope}.select(:name, :age).each " \
+      inspect_source("User.#{scope}.select(:name, :age).each " \
                           '{ |u| u.something }')
 
       expect(cop.offenses).to be_empty

--- a/spec/rubocop/cop/rails/find_each_spec.rb
+++ b/spec/rubocop/cop/rails/find_each_spec.rb
@@ -39,7 +39,7 @@ describe RuboCop::Cop::Rails::FindEach do
   end
 
   it 'auto-corrects each to find_each' do
-    new_source = autocorrect_source(cop, 'User.all.each { |u| u.x }')
+    new_source = autocorrect_source('User.all.each { |u| u.x }')
 
     expect(new_source).to eq('User.all.find_each { |u| u.x }')
   end

--- a/spec/rubocop/cop/rails/http_positional_arguments_spec.rb
+++ b/spec/rubocop/cop/rails/http_positional_arguments_spec.rb
@@ -40,7 +40,7 @@ describe RuboCop::Cop::Rails::HttpPositionalArguments do
         end
 
         it 'does not register an offense' do
-          inspect_source(cop, source)
+          inspect_source(source)
           expect(cop.messages).to be_empty
         end
       end
@@ -132,14 +132,14 @@ describe RuboCop::Cop::Rails::HttpPositionalArguments do
     %w[post get patch put delete].each do |keyword|
       it 'does not register an offense when keyword' do
         source = "@user.#{keyword}.id = ''"
-        inspect_source(cop, source)
+        inspect_source(source)
         expect(cop.offenses.size).to eq(0)
       end
     end
 
     it 'does not auto-correct http action when method' do
       source = 'post user_attrs, id: 1'
-      inspect_source(cop, source)
+      inspect_source(source)
       expect(cop.offenses.size).to eq(0)
       new_source = autocorrect_source(cop, source)
       expect(new_source).to eq(source)
@@ -147,7 +147,7 @@ describe RuboCop::Cop::Rails::HttpPositionalArguments do
 
     it 'does not auto-correct http action when symbol' do
       source = 'post :user_attrs, id: 1'
-      inspect_source(cop, source)
+      inspect_source(source)
       expect(cop.offenses.size).to eq(0)
       new_source = autocorrect_source(cop, source)
       expect(new_source).to eq(source)
@@ -155,7 +155,7 @@ describe RuboCop::Cop::Rails::HttpPositionalArguments do
 
     it 'does not auto-correct' do
       source = 'post(:user_attrs, id: 1)'
-      inspect_source(cop, source)
+      inspect_source(source)
       expect(cop.offenses.size).to eq(0)
       new_source = autocorrect_source(cop, source)
       expect(new_source).to eq(source)
@@ -198,7 +198,7 @@ describe RuboCop::Cop::Rails::HttpPositionalArguments do
 
     it 'does not auto-correct http action when params is a method call' do
       source = 'post :create, confirmation_data'
-      inspect_source(cop, source)
+      inspect_source(source)
       expect(cop.offenses.size).to eq(0)
       new_source = autocorrect_source(cop, source)
       expect(new_source).to eq(source)
@@ -207,7 +207,7 @@ describe RuboCop::Cop::Rails::HttpPositionalArguments do
     # rubocop:disable LineLength
     it 'does not auto-correct http action when parameter matches keyword name' do
       source = 'post :create, id: 7, comment: { body: "hei" }'
-      inspect_source(cop, source)
+      inspect_source(source)
       expect(cop.offenses.size).to eq(0)
       new_source = autocorrect_source(cop, source)
       expect(new_source).to eq(source)
@@ -215,7 +215,7 @@ describe RuboCop::Cop::Rails::HttpPositionalArguments do
 
     it 'does not auto-correct http action when format keyword included but not alone' do
       source = 'post :create, id: 7, format: :rss'
-      inspect_source(cop, source)
+      inspect_source(source)
       expect(cop.offenses.size).to eq(0)
       new_source = autocorrect_source(cop, source)
       expect(new_source).to eq(source)
@@ -226,7 +226,7 @@ describe RuboCop::Cop::Rails::HttpPositionalArguments do
         params = { id: 1 }
         post user_attrs, params
       RUBY
-      inspect_source(cop, source)
+      inspect_source(source)
       expect(cop.offenses.size).to eq(0)
       new_source = autocorrect_source(cop, source)
       expect(new_source).to eq(source)
@@ -234,14 +234,14 @@ describe RuboCop::Cop::Rails::HttpPositionalArguments do
 
     it 'does not auto-correct http action when params is a method call' do
       source = 'post user_attrs, params'
-      inspect_source(cop, source)
+      inspect_source(source)
       expect(cop.offenses.size).to eq(0)
       new_source = autocorrect_source(cop, source)
       expect(new_source).to eq(source)
     end
     it 'does not auto-correct http action when params is a method call with chain' do
       source = 'post user_attrs, params.merge(foo: bar)'
-      inspect_source(cop, source)
+      inspect_source(source)
       expect(cop.offenses.size).to eq(0)
       new_source = autocorrect_source(cop, source)
       expect(new_source).to eq(source)
@@ -253,19 +253,19 @@ describe RuboCop::Cop::Rails::HttpPositionalArguments do
 
     it 'registers an offense for post method' do
       source = 'post :create, user_id: @user.id'
-      inspect_source(cop, source)
+      inspect_source(source)
       expect(cop.offenses.size).to eq(1)
     end
 
     it 'registers an offense for patch method' do
       source = 'patch :update, user_id: @user.id'
-      inspect_source(cop, source)
+      inspect_source(source)
       expect(cop.offenses.size).to eq(1)
     end
 
     it 'registers an offense for delete method' do
       source = 'delete :destroy, id: @user.id'
-      inspect_source(cop, source)
+      inspect_source(source)
       expect(cop.offenses.size).to eq(1)
     end
 
@@ -293,7 +293,7 @@ describe RuboCop::Cop::Rails::HttpPositionalArguments do
         end
 
         it 'does not register an offense' do
-          inspect_source(cop, source)
+          inspect_source(source)
           expect(cop.messages).to be_empty
         end
       end
@@ -414,14 +414,14 @@ describe RuboCop::Cop::Rails::HttpPositionalArguments do
     %w[post get patch put delete].each do |keyword|
       it 'does not register an offense when keyword' do
         source = "@user.#{keyword}.id = ''"
-        inspect_source(cop, source)
+        inspect_source(source)
         expect(cop.offenses.size).to eq(0)
       end
     end
 
     it 'auto-corrects http action when method' do
       source = 'post user_attrs, id: 1'
-      inspect_source(cop, source)
+      inspect_source(source)
       expect(cop.offenses.size).to eq(1)
       new_source = autocorrect_source(cop, source)
       expected = 'post user_attrs, params: { id: 1 }'
@@ -430,7 +430,7 @@ describe RuboCop::Cop::Rails::HttpPositionalArguments do
 
     it 'auto-corrects http action when symbol' do
       source = 'post :user_attrs, id: 1'
-      inspect_source(cop, source)
+      inspect_source(source)
       expect(cop.offenses.size).to eq(1)
       new_source = autocorrect_source(cop, source)
       expected = 'post :user_attrs, params: { id: 1 }'
@@ -439,7 +439,7 @@ describe RuboCop::Cop::Rails::HttpPositionalArguments do
 
     it 'maintains parentheses in auto-correcting' do
       source = 'post(:user_attrs, id: 1)'
-      inspect_source(cop, source)
+      inspect_source(source)
       expect(cop.offenses.size).to eq(1)
       new_source = autocorrect_source(cop, source)
       expected = 'post(:user_attrs, params: { id: 1 })'
@@ -488,7 +488,7 @@ describe RuboCop::Cop::Rails::HttpPositionalArguments do
 
     it 'auto-corrects http action when params is a method call' do
       source = 'post :create, confirmation_data'
-      inspect_source(cop, source)
+      inspect_source(source)
       expect(cop.offenses.size).to eq(1)
       new_source = autocorrect_source(cop, source)
       output = 'post :create, params: confirmation_data'
@@ -497,7 +497,7 @@ describe RuboCop::Cop::Rails::HttpPositionalArguments do
 
     it 'auto-corrects http action when parameter matches special keyword name' do
       source = 'post :create, id: 7, comment: { body: "hei" }'
-      inspect_source(cop, source)
+      inspect_source(source)
       expect(cop.offenses.size).to eq(1)
       new_source = autocorrect_source(cop, source)
       output = 'post :create, params: { id: 7, comment: { body: "hei" } }'
@@ -506,7 +506,7 @@ describe RuboCop::Cop::Rails::HttpPositionalArguments do
 
     it 'auto-corrects http action when format keyword included but not alone' do
       source = 'post :create, id: 7, format: :rss'
-      inspect_source(cop, source)
+      inspect_source(source)
       expect(cop.offenses.size).to eq(1)
       new_source = autocorrect_source(cop, source)
       output = 'post :create, params: { id: 7, format: :rss }'
@@ -518,7 +518,7 @@ describe RuboCop::Cop::Rails::HttpPositionalArguments do
         params = { id: 1 }
         post user_attrs, params
       RUBY
-      inspect_source(cop, source)
+      inspect_source(source)
       expect(cop.offenses.size).to eq(1)
       new_source = autocorrect_source(cop, source)
       expect(new_source).to eq(<<-RUBY.strip_indent)
@@ -529,7 +529,7 @@ describe RuboCop::Cop::Rails::HttpPositionalArguments do
 
     it 'auto-corrects http action when params is a method call' do
       source = 'post user_attrs, params'
-      inspect_source(cop, source)
+      inspect_source(source)
       expect(cop.offenses.size).to eq(1)
       new_source = autocorrect_source(cop, source)
       expected = 'post user_attrs, params: params'
@@ -538,7 +538,7 @@ describe RuboCop::Cop::Rails::HttpPositionalArguments do
 
     it 'auto-corrects http action when params is a method call with chain' do
       source = 'post user_attrs, params.merge(foo: bar)'
-      inspect_source(cop, source)
+      inspect_source(source)
       expect(cop.offenses.size).to eq(1)
       new_source = autocorrect_source(cop, source)
       expected = 'post user_attrs, params: params.merge(foo: bar)'

--- a/spec/rubocop/cop/rails/http_positional_arguments_spec.rb
+++ b/spec/rubocop/cop/rails/http_positional_arguments_spec.rb
@@ -56,7 +56,7 @@ describe RuboCop::Cop::Rails::HttpPositionalArguments do
       end
 
       it 'does not auto-correct' do
-        new_source = autocorrect_source(cop, source)
+        new_source = autocorrect_source(source)
         expect(new_source).to eq(source)
       end
 
@@ -93,7 +93,7 @@ describe RuboCop::Cop::Rails::HttpPositionalArguments do
       end
 
       it 'does not auto-correct' do
-        new_source = autocorrect_source(cop, source)
+        new_source = autocorrect_source(source)
         expect(new_source).to eq(source)
       end
     end
@@ -124,7 +124,7 @@ describe RuboCop::Cop::Rails::HttpPositionalArguments do
       end
 
       it 'does not auto-correct' do
-        new_source = autocorrect_source(cop, source)
+        new_source = autocorrect_source(source)
         expect(new_source).to eq(source)
       end
     end
@@ -141,7 +141,7 @@ describe RuboCop::Cop::Rails::HttpPositionalArguments do
       source = 'post user_attrs, id: 1'
       inspect_source(source)
       expect(cop.offenses.size).to eq(0)
-      new_source = autocorrect_source(cop, source)
+      new_source = autocorrect_source(source)
       expect(new_source).to eq(source)
     end
 
@@ -149,7 +149,7 @@ describe RuboCop::Cop::Rails::HttpPositionalArguments do
       source = 'post :user_attrs, id: 1'
       inspect_source(source)
       expect(cop.offenses.size).to eq(0)
-      new_source = autocorrect_source(cop, source)
+      new_source = autocorrect_source(source)
       expect(new_source).to eq(source)
     end
 
@@ -157,7 +157,7 @@ describe RuboCop::Cop::Rails::HttpPositionalArguments do
       source = 'post(:user_attrs, id: 1)'
       inspect_source(source)
       expect(cop.offenses.size).to eq(0)
-      new_source = autocorrect_source(cop, source)
+      new_source = autocorrect_source(source)
       expect(new_source).to eq(source)
     end
 
@@ -171,20 +171,20 @@ describe RuboCop::Cop::Rails::HttpPositionalArguments do
 
     it 'does not remove quotes when single quoted' do
       source = "get '/auth/linkedin/callback'"
-      new_source = autocorrect_source(cop, source)
+      new_source = autocorrect_source(source)
       expect(new_source).to eq("get '/auth/linkedin/callback'")
     end
 
     it 'does not remove quotes when double quoted' do
       source = 'get "/auth/linkedin/callback"'
-      new_source = autocorrect_source(cop, source)
+      new_source = autocorrect_source(source)
       expect(new_source).to eq('get "/auth/linkedin/callback"')
     end
 
     it 'does not add headers keyword when env or headers are used' do
       source = 'get some_path(profile.id), {},'
       source += " 'HTTP_REFERER' => p_url(p.id).to_s"
-      new_source = autocorrect_source(cop, source)
+      new_source = autocorrect_source(source)
       expect(new_source).to eq(source)
     end
 
@@ -192,7 +192,7 @@ describe RuboCop::Cop::Rails::HttpPositionalArguments do
       source = 'get some_path(profile.id), '
       source += '{ user_id: @user.id, profile_id: p.id },'
       source += " 'HTTP_REFERER' => p_url(p.id).to_s"
-      new_source = autocorrect_source(cop, source)
+      new_source = autocorrect_source(source)
       expect(new_source).to eq(source)
     end
 
@@ -200,7 +200,7 @@ describe RuboCop::Cop::Rails::HttpPositionalArguments do
       source = 'post :create, confirmation_data'
       inspect_source(source)
       expect(cop.offenses.size).to eq(0)
-      new_source = autocorrect_source(cop, source)
+      new_source = autocorrect_source(source)
       expect(new_source).to eq(source)
     end
 
@@ -209,7 +209,7 @@ describe RuboCop::Cop::Rails::HttpPositionalArguments do
       source = 'post :create, id: 7, comment: { body: "hei" }'
       inspect_source(source)
       expect(cop.offenses.size).to eq(0)
-      new_source = autocorrect_source(cop, source)
+      new_source = autocorrect_source(source)
       expect(new_source).to eq(source)
     end
 
@@ -217,7 +217,7 @@ describe RuboCop::Cop::Rails::HttpPositionalArguments do
       source = 'post :create, id: 7, format: :rss'
       inspect_source(source)
       expect(cop.offenses.size).to eq(0)
-      new_source = autocorrect_source(cop, source)
+      new_source = autocorrect_source(source)
       expect(new_source).to eq(source)
     end
 
@@ -228,7 +228,7 @@ describe RuboCop::Cop::Rails::HttpPositionalArguments do
       RUBY
       inspect_source(source)
       expect(cop.offenses.size).to eq(0)
-      new_source = autocorrect_source(cop, source)
+      new_source = autocorrect_source(source)
       expect(new_source).to eq(source)
     end
 
@@ -236,14 +236,14 @@ describe RuboCop::Cop::Rails::HttpPositionalArguments do
       source = 'post user_attrs, params'
       inspect_source(source)
       expect(cop.offenses.size).to eq(0)
-      new_source = autocorrect_source(cop, source)
+      new_source = autocorrect_source(source)
       expect(new_source).to eq(source)
     end
     it 'does not auto-correct http action when params is a method call with chain' do
       source = 'post user_attrs, params.merge(foo: bar)'
       inspect_source(source)
       expect(cop.offenses.size).to eq(0)
-      new_source = autocorrect_source(cop, source)
+      new_source = autocorrect_source(source)
       expect(new_source).to eq(source)
     end
   end
@@ -316,7 +316,7 @@ describe RuboCop::Cop::Rails::HttpPositionalArguments do
       end
 
       it 'autocorrects offense' do
-        new_source = autocorrect_source(cop, source)
+        new_source = autocorrect_source(source)
         expect(new_source).to eq(corrected_result)
       end
 
@@ -364,7 +364,7 @@ describe RuboCop::Cop::Rails::HttpPositionalArguments do
       end
 
       it 'autocorrects offense' do
-        new_source = autocorrect_source(cop, source)
+        new_source = autocorrect_source(source)
         expect(new_source).to eq(corrected_result)
       end
     end
@@ -406,7 +406,7 @@ describe RuboCop::Cop::Rails::HttpPositionalArguments do
       end
 
       it 'autocorrects offense' do
-        new_source = autocorrect_source(cop, source)
+        new_source = autocorrect_source(source)
         expect(new_source).to eq(corrected_result)
       end
     end
@@ -423,7 +423,7 @@ describe RuboCop::Cop::Rails::HttpPositionalArguments do
       source = 'post user_attrs, id: 1'
       inspect_source(source)
       expect(cop.offenses.size).to eq(1)
-      new_source = autocorrect_source(cop, source)
+      new_source = autocorrect_source(source)
       expected = 'post user_attrs, params: { id: 1 }'
       expect(new_source).to eq(expected)
     end
@@ -432,7 +432,7 @@ describe RuboCop::Cop::Rails::HttpPositionalArguments do
       source = 'post :user_attrs, id: 1'
       inspect_source(source)
       expect(cop.offenses.size).to eq(1)
-      new_source = autocorrect_source(cop, source)
+      new_source = autocorrect_source(source)
       expected = 'post :user_attrs, params: { id: 1 }'
       expect(new_source).to eq(expected)
     end
@@ -441,7 +441,7 @@ describe RuboCop::Cop::Rails::HttpPositionalArguments do
       source = 'post(:user_attrs, id: 1)'
       inspect_source(source)
       expect(cop.offenses.size).to eq(1)
-      new_source = autocorrect_source(cop, source)
+      new_source = autocorrect_source(source)
       expected = 'post(:user_attrs, params: { id: 1 })'
       expect(new_source).to eq(expected)
     end
@@ -456,20 +456,20 @@ describe RuboCop::Cop::Rails::HttpPositionalArguments do
 
     it 'does not remove quotes when single quoted' do
       source = "get '/auth/linkedin/callback'"
-      new_source = autocorrect_source(cop, source)
+      new_source = autocorrect_source(source)
       expect(new_source).to eq("get '/auth/linkedin/callback'")
     end
 
     it 'does not remove quotes when double quoted' do
       source = 'get "/auth/linkedin/callback"'
-      new_source = autocorrect_source(cop, source)
+      new_source = autocorrect_source(source)
       expect(new_source).to eq('get "/auth/linkedin/callback"')
     end
 
     it 'does add headers keyword when env or headers are used' do
       source = 'get some_path(profile.id), {},'
       source += " 'HTTP_REFERER' => p_url(p.id).to_s"
-      new_source = autocorrect_source(cop, source)
+      new_source = autocorrect_source(source)
       output = 'get some_path(profile.id),'
       output += " headers: { 'HTTP_REFERER' => p_url(p.id).to_s }"
       expect(new_source).to eq(output)
@@ -479,7 +479,7 @@ describe RuboCop::Cop::Rails::HttpPositionalArguments do
       source = 'get some_path(profile.id), '
       source += '{ user_id: @user.id, profile_id: p.id },'
       source += " 'HTTP_REFERER' => p_url(p.id).to_s"
-      new_source = autocorrect_source(cop, source)
+      new_source = autocorrect_source(source)
       output = 'get some_path(profile.id), params:'
       output += ' { user_id: @user.id, profile_id: p.id },'
       output += " headers: { 'HTTP_REFERER' => p_url(p.id).to_s }"
@@ -490,7 +490,7 @@ describe RuboCop::Cop::Rails::HttpPositionalArguments do
       source = 'post :create, confirmation_data'
       inspect_source(source)
       expect(cop.offenses.size).to eq(1)
-      new_source = autocorrect_source(cop, source)
+      new_source = autocorrect_source(source)
       output = 'post :create, params: confirmation_data'
       expect(new_source).to eq(output)
     end
@@ -499,7 +499,7 @@ describe RuboCop::Cop::Rails::HttpPositionalArguments do
       source = 'post :create, id: 7, comment: { body: "hei" }'
       inspect_source(source)
       expect(cop.offenses.size).to eq(1)
-      new_source = autocorrect_source(cop, source)
+      new_source = autocorrect_source(source)
       output = 'post :create, params: { id: 7, comment: { body: "hei" } }'
       expect(new_source).to eq(output)
     end
@@ -508,7 +508,7 @@ describe RuboCop::Cop::Rails::HttpPositionalArguments do
       source = 'post :create, id: 7, format: :rss'
       inspect_source(source)
       expect(cop.offenses.size).to eq(1)
-      new_source = autocorrect_source(cop, source)
+      new_source = autocorrect_source(source)
       output = 'post :create, params: { id: 7, format: :rss }'
       expect(new_source).to eq(output)
     end
@@ -520,7 +520,7 @@ describe RuboCop::Cop::Rails::HttpPositionalArguments do
       RUBY
       inspect_source(source)
       expect(cop.offenses.size).to eq(1)
-      new_source = autocorrect_source(cop, source)
+      new_source = autocorrect_source(source)
       expect(new_source).to eq(<<-RUBY.strip_indent)
         params = { id: 1 }
         post user_attrs, params: params
@@ -531,7 +531,7 @@ describe RuboCop::Cop::Rails::HttpPositionalArguments do
       source = 'post user_attrs, params'
       inspect_source(source)
       expect(cop.offenses.size).to eq(1)
-      new_source = autocorrect_source(cop, source)
+      new_source = autocorrect_source(source)
       expected = 'post user_attrs, params: params'
       expect(new_source).to eq(expected)
     end
@@ -540,7 +540,7 @@ describe RuboCop::Cop::Rails::HttpPositionalArguments do
       source = 'post user_attrs, params.merge(foo: bar)'
       inspect_source(source)
       expect(cop.offenses.size).to eq(1)
-      new_source = autocorrect_source(cop, source)
+      new_source = autocorrect_source(source)
       expected = 'post user_attrs, params: params.merge(foo: bar)'
       expect(new_source).to eq(expected)
     end

--- a/spec/rubocop/cop/rails/output_safety_spec.rb
+++ b/spec/rubocop/cop/rails/output_safety_spec.rb
@@ -7,7 +7,7 @@ describe RuboCop::Cop::Rails::OutputSafety do
     source = <<-RUBY.strip_indent
       foo.safe_concat('bar')
     RUBY
-    inspect_source(cop, source)
+    inspect_source(source)
     expect(cop.offenses.size).to eq(1)
   end
 
@@ -17,7 +17,7 @@ describe RuboCop::Cop::Rails::OutputSafety do
       foo.html_safe
       "foo".html_safe
     RUBY
-    inspect_source(cop, source)
+    inspect_source(source)
     expect(cop.offenses.size).to eq(2)
   end
 
@@ -37,7 +37,7 @@ describe RuboCop::Cop::Rails::OutputSafety do
       raw(foo)
       raw "foo"
     RUBY
-    inspect_source(cop, source)
+    inspect_source(source)
     expect(cop.offenses.size).to eq(2)
   end
 
@@ -66,35 +66,35 @@ describe RuboCop::Cop::Rails::OutputSafety do
   it 'does not accept safe_concat methods when wrapped in a safe_join' do
     source = 'safe_join([i18n_text.safe_concat(i18n_text),
               i18n_text.safe_concat(i18n_mode_additional_markup(key))])'
-    inspect_source(cop, source)
+    inspect_source(source)
     expect(cop.offenses.size).to eq(2)
   end
 
   it 'does not accept raw methods when wrapped in a safe_join' do
     source = 'safe_join([raw(i18n_text),
               raw(i18n_mode_additional_markup(key))])'
-    inspect_source(cop, source)
+    inspect_source(source)
     expect(cop.offenses.size).to eq(2)
   end
 
   it 'does not accept html_safe methods when wrapped in a safe_join' do
     source = 'safe_join([i18n_text.html_safe,
               i18n_mode_additional_markup(key).html_safe])'
-    inspect_source(cop, source)
+    inspect_source(source)
     expect(cop.offenses.size).to eq(2)
   end
 
   it 'does not accept html_safe methods wrapped in safe_join not at root' do
     source = 'foo(safe_join([i18n_text.html_safe,
               i18n_mode_additional_markup(key).html_safe]))'
-    inspect_source(cop, source)
+    inspect_source(source)
     expect(cop.offenses.size).to eq(2)
   end
 
   it 'does not accept raw methods wrapped in a safe_join not at root' do
     source = 'foo(safe_join([raw(i18n_text),
               raw(i18n_mode_additional_markup(key))]))'
-    inspect_source(cop, source)
+    inspect_source(source)
     expect(cop.offenses.size).to eq(2)
   end
 end

--- a/spec/rubocop/cop/rails/output_spec.rb
+++ b/spec/rubocop/cop/rails/output_spec.rb
@@ -10,7 +10,7 @@ describe RuboCop::Cop::Rails::Output do
       print "abbe busoni"
       pp "monte cristo"
     RUBY
-    inspect_source(cop, source)
+    inspect_source(source)
     expect(cop.offenses.size).to eq(4)
   end
 

--- a/spec/rubocop/cop/rails/pluralization_grammar_spec.rb
+++ b/spec/rubocop/cop/rails/pluralization_grammar_spec.rb
@@ -36,7 +36,7 @@ describe RuboCop::Cop::Rails::PluralizationGrammar do
         end
 
         it 'autocorrects to be grammatically correct' do
-          new_source = autocorrect_source(cop, source)
+          new_source = autocorrect_source(source)
           expect(new_source).to eq("#{singular_literal}.#{method_name}.ago")
         end
       end
@@ -74,7 +74,7 @@ describe RuboCop::Cop::Rails::PluralizationGrammar do
           end
 
           it 'autocorrects to be grammatically correct' do
-            new_source = autocorrect_source(cop, source)
+            new_source = autocorrect_source(source)
             expect(new_source)
               .to eq("#{plural_number}.#{method_name}s.from_now")
           end

--- a/spec/rubocop/cop/rails/pluralization_grammar_spec.rb
+++ b/spec/rubocop/cop/rails/pluralization_grammar_spec.rb
@@ -3,7 +3,7 @@
 describe RuboCop::Cop::Rails::PluralizationGrammar do
   subject(:cop) { described_class.new }
   before do
-    inspect_source(cop, source)
+    inspect_source(source)
   end
 
   shared_examples 'enforces pluralization grammar' do |method_name|

--- a/spec/rubocop/cop/rails/present_spec.rb
+++ b/spec/rubocop/cop/rails/present_spec.rb
@@ -12,7 +12,7 @@ describe RuboCop::Cop::Rails::Present, :config do
     end
 
     it 'auto-corrects' do
-      new_source = autocorrect_source(cop, source)
+      new_source = autocorrect_source(source)
 
       expect(new_source).to eq(correction)
     end
@@ -160,7 +160,7 @@ describe RuboCop::Cop::Rails::Present, :config do
         end
 
         it 'auto-corrects' do
-          new_source = autocorrect_source(cop, source)
+          new_source = autocorrect_source(source)
 
           expect(new_source).to eq('something if foo.present?')
         end
@@ -185,7 +185,7 @@ describe RuboCop::Cop::Rails::Present, :config do
         end
 
         it 'auto-corrects' do
-          new_source = autocorrect_source(cop, source)
+          new_source = autocorrect_source(source)
 
           expect(new_source).to eq(<<-RUBY.strip_indent)
             if foo.present?
@@ -218,7 +218,7 @@ describe RuboCop::Cop::Rails::Present, :config do
         end
 
         it 'auto-corrects' do
-          new_source = autocorrect_source(cop, source)
+          new_source = autocorrect_source(source)
 
           expect(new_source).to eq(<<-RUBY.strip_indent)
             if foo.present?

--- a/spec/rubocop/cop/rails/present_spec.rb
+++ b/spec/rubocop/cop/rails/present_spec.rb
@@ -5,7 +5,7 @@ describe RuboCop::Cop::Rails::Present, :config do
 
   shared_examples :offense do |source, correction, message|
     it 'registers an offense' do
-      inspect_source(cop, source)
+      inspect_source(source)
 
       expect(cop.messages).to eq([message])
       expect(cop.highlights).to eq([source])

--- a/spec/rubocop/cop/rails/read_write_attribute_spec.rb
+++ b/spec/rubocop/cop/rails/read_write_attribute_spec.rb
@@ -35,28 +35,28 @@ describe RuboCop::Cop::Rails::ReadWriteAttribute do
         source = 'write_attribute(:attr, var)'
         corrected_source = 'self[:attr] = var'
 
-        expect(autocorrect_source(cop, source)).to eq(corrected_source)
+        expect(autocorrect_source(source)).to eq(corrected_source)
       end
 
       it 'autocorrects string' do
         source = "write_attribute('attr', 'test')"
         corrected_source = "self['attr'] = 'test'"
 
-        expect(autocorrect_source(cop, source)).to eq(corrected_source)
+        expect(autocorrect_source(source)).to eq(corrected_source)
       end
 
       it 'autocorrects without parentheses' do
         source = "write_attribute 'attr', 'test'"
         corrected_source = "self['attr'] = 'test'"
 
-        expect(autocorrect_source(cop, source)).to eq(corrected_source)
+        expect(autocorrect_source(source)).to eq(corrected_source)
       end
 
       it 'autocorrects expression' do
         source = "write_attribute(:attr, 'test_' + postfix)"
         corrected_source = "self[:attr] = 'test_' + postfix"
 
-        expect(autocorrect_source(cop, source)).to eq(corrected_source)
+        expect(autocorrect_source(source)).to eq(corrected_source)
       end
 
       it 'autocorrects multiline' do
@@ -75,7 +75,7 @@ describe RuboCop::Cop::Rails::ReadWriteAttribute do
           ).to_sym
         RUBY
 
-        expect(autocorrect_source(cop, source)).to eq(corrected_source)
+        expect(autocorrect_source(source)).to eq(corrected_source)
       end
     end
 
@@ -84,28 +84,28 @@ describe RuboCop::Cop::Rails::ReadWriteAttribute do
         source = 'res = read_attribute(:test)'
         corrected_source = 'res = self[:test]'
 
-        expect(autocorrect_source(cop, source)).to eq(corrected_source)
+        expect(autocorrect_source(source)).to eq(corrected_source)
       end
 
       it 'autocorrects string' do
         source = "res = read_attribute('test')"
         corrected_source = "res = self['test']"
 
-        expect(autocorrect_source(cop, source)).to eq(corrected_source)
+        expect(autocorrect_source(source)).to eq(corrected_source)
       end
 
       it 'autocorrects without parentheses' do
         source = "res = read_attribute 'test'"
         corrected_source = "res = self['test']"
 
-        expect(autocorrect_source(cop, source)).to eq(corrected_source)
+        expect(autocorrect_source(source)).to eq(corrected_source)
       end
 
       it 'autocorrects expression' do
         source = "res = read_attribute('test_' + postfix)"
         corrected_source = "res = self['test_' + postfix]"
 
-        expect(autocorrect_source(cop, source)).to eq(corrected_source)
+        expect(autocorrect_source(source)).to eq(corrected_source)
       end
 
       it 'autocorrects multiline' do
@@ -122,7 +122,7 @@ describe RuboCop::Cop::Rails::ReadWriteAttribute do
           ).to_sym]
         RUBY
 
-        expect(autocorrect_source(cop, source)).to eq(corrected_source)
+        expect(autocorrect_source(source)).to eq(corrected_source)
       end
     end
   end

--- a/spec/rubocop/cop/rails/relative_date_constant_spec.rb
+++ b/spec/rubocop/cop/rails/relative_date_constant_spec.rb
@@ -73,7 +73,7 @@ describe RuboCop::Cop::Rails::RelativeDateConstant do
   end
 
   it 'autocorrects' do
-    new_source = autocorrect_source(cop, <<-RUBY.strip_indent)
+    new_source = autocorrect_source(<<-RUBY.strip_indent)
       class SomeClass
         EXPIRED_AT = 1.week.since
       end

--- a/spec/rubocop/cop/rails/request_referer_spec.rb
+++ b/spec/rubocop/cop/rails/request_referer_spec.rb
@@ -20,7 +20,7 @@ describe RuboCop::Cop::Rails::RequestReferer, :config do
     end
 
     it 'autocorrects referrer with referer' do
-      corrected = autocorrect_source(cop, ['puts request.referrer'])
+      corrected = autocorrect_source(['puts request.referrer'])
       expect(corrected).to eq 'puts request.referer'
     end
   end
@@ -42,7 +42,7 @@ describe RuboCop::Cop::Rails::RequestReferer, :config do
     end
 
     it 'autocorrects referer with referrer' do
-      corrected = autocorrect_source(cop, ['puts request.referer'])
+      corrected = autocorrect_source(['puts request.referer'])
       expect(corrected).to eq 'puts request.referrer'
     end
   end

--- a/spec/rubocop/cop/rails/request_referer_spec.rb
+++ b/spec/rubocop/cop/rails/request_referer_spec.rb
@@ -4,7 +4,7 @@ describe RuboCop::Cop::Rails::RequestReferer, :config do
   subject(:cop) { described_class.new(config) }
 
   context 'when EnforcedStyle is referer' do
-    before { inspect_source(cop, 'puts request.referrer') }
+    before { inspect_source('puts request.referrer') }
     let(:cop_config) { { 'EnforcedStyle' => 'referer' } }
     it 'registers an offense for request.referrer' do
       expect(cop.offenses.size).to eq(1)
@@ -26,7 +26,7 @@ describe RuboCop::Cop::Rails::RequestReferer, :config do
   end
 
   context 'when EnforcedStyle is referrer' do
-    before { inspect_source(cop, 'puts request.referer') }
+    before { inspect_source('puts request.referer') }
     let(:cop_config) { { 'EnforcedStyle' => 'referrer' } }
     it 'registers an offense for request.referer' do
       expect(cop.offenses.size).to eq(1)

--- a/spec/rubocop/cop/rails/reversible_migration_spec.rb
+++ b/spec/rubocop/cop/rails/reversible_migration_spec.rb
@@ -17,7 +17,7 @@ describe RuboCop::Cop::Rails::ReversibleMigration, :config do
     let(:code) { code }
 
     it "accepts usages of #{name}" do
-      inspect_source(cop, source)
+      inspect_source(source)
 
       expect(cop.offenses).to be_empty
     end
@@ -27,7 +27,7 @@ describe RuboCop::Cop::Rails::ReversibleMigration, :config do
     let(:code) { code }
 
     it "registers an offense for #{name}" do
-      inspect_source(cop, source)
+      inspect_source(source)
 
       expect(cop.messages).to eq(["#{name} is not reversible."])
     end

--- a/spec/rubocop/cop/rails/safe_navigation_spec.rb
+++ b/spec/rubocop/cop/rails/safe_navigation_spec.rb
@@ -22,7 +22,7 @@ describe RuboCop::Cop::Rails::SafeNavigation, :config do
 
   shared_examples :autocorrect do |name, source, correction|
     it "corrects #{name}" do
-      new_source = autocorrect_source(cop, source)
+      new_source = autocorrect_source(source)
 
       expect(new_source).to eq(correction)
     end

--- a/spec/rubocop/cop/rails/safe_navigation_spec.rb
+++ b/spec/rubocop/cop/rails/safe_navigation_spec.rb
@@ -5,7 +5,7 @@ describe RuboCop::Cop::Rails::SafeNavigation, :config do
 
   shared_examples :accepts do |name, code|
     it "accepts usages of #{name}" do
-      inspect_source(cop, "[1, 2].#{code}")
+      inspect_source("[1, 2].#{code}")
 
       expect(cop.offenses).to be_empty
     end
@@ -13,7 +13,7 @@ describe RuboCop::Cop::Rails::SafeNavigation, :config do
 
   shared_examples :offense do |name, method, params|
     it "registers an offense for #{name}" do
-      inspect_source(cop, "[1, 2].#{method}#{params}")
+      inspect_source("[1, 2].#{method}#{params}")
 
       expect(cop.messages)
         .to eq([format('Use safe navigation (`&.`) instead of `%s`.', method)])

--- a/spec/rubocop/cop/rails/save_bang_spec.rb
+++ b/spec/rubocop/cop/rails/save_bang_spec.rb
@@ -43,7 +43,7 @@ describe RuboCop::Cop::Rails::SaveBang do
     end
 
     it 'autocorrects' do
-      new_source = autocorrect_source(cop, "object.#{method}()")
+      new_source = autocorrect_source("object.#{method}()")
 
       expect(new_source).to eq("object.#{method}!()")
     end

--- a/spec/rubocop/cop/rails/save_bang_spec.rb
+++ b/spec/rubocop/cop/rails/save_bang_spec.rb
@@ -5,7 +5,7 @@ describe RuboCop::Cop::Rails::SaveBang do
 
   shared_examples 'checks_common_offense' do |method|
     it "when using #{method} with arguments" do
-      inspect_source(cop, "object.#{method}(name: 'Tom', age: 20)")
+      inspect_source("object.#{method}(name: 'Tom', age: 20)")
 
       if method == :destroy
         expect(cop.messages).to be_empty
@@ -17,7 +17,7 @@ describe RuboCop::Cop::Rails::SaveBang do
     end
 
     it "when using #{method} without arguments" do
-      inspect_source(cop, method.to_s)
+      inspect_source(method.to_s)
 
       expect(cop.messages)
         .to eq(["Use `#{method}!` instead of `#{method}` " \
@@ -25,19 +25,19 @@ describe RuboCop::Cop::Rails::SaveBang do
     end
 
     it "when using #{method}!" do
-      inspect_source(cop, "object.#{method}!")
+      inspect_source("object.#{method}!")
 
       expect(cop.messages).to be_empty
     end
 
     it "when using #{method} with 2 arguments" do
-      inspect_source(cop, "Model.#{method}(1, name: 'Tom')")
+      inspect_source("Model.#{method}(1, name: 'Tom')")
 
       expect(cop.messages).to be_empty
     end
 
     it "when using #{method} with wrong argument" do
-      inspect_source(cop, "object.#{method}('Tom')")
+      inspect_source("object.#{method}('Tom')")
 
       expect(cop.messages).to be_empty
     end
@@ -51,7 +51,7 @@ describe RuboCop::Cop::Rails::SaveBang do
 
   shared_examples 'checks_variable_return_use_offense' do |method, pass|
     it "when assigning the return value of #{method}" do
-      inspect_source(cop, "x = object.#{method}\n")
+      inspect_source("x = object.#{method}\n")
 
       if pass
         expect(cop.messages).to be_empty
@@ -64,7 +64,7 @@ describe RuboCop::Cop::Rails::SaveBang do
     end
 
     it "when assigning the return value of #{method} with block" do
-      inspect_source(cop, "x = object.#{method} do |obj|\n" \
+      inspect_source("x = object.#{method} do |obj|\n" \
                           "  obj.name = 'Tom'\n" \
                           'end')
 
@@ -79,7 +79,7 @@ describe RuboCop::Cop::Rails::SaveBang do
     end
 
     it "when using #{method} with if" do
-      inspect_source(cop, "if object.#{method}; something; end")
+      inspect_source("if object.#{method}; something; end")
 
       if pass
         expect(cop.messages).to be_empty
@@ -90,7 +90,7 @@ describe RuboCop::Cop::Rails::SaveBang do
     end
 
     it "when using #{method} with multiple conditional" do
-      inspect_source(cop, <<-RUBY.strip_indent)
+      inspect_source(<<-RUBY.strip_indent)
         if true && object.active? && object.#{method}
           something
         end
@@ -104,7 +104,7 @@ describe RuboCop::Cop::Rails::SaveBang do
     end
 
     it "when using #{method} with oneline if" do
-      inspect_source(cop, "something if object.#{method}")
+      inspect_source("something if object.#{method}")
 
       if pass
         expect(cop.messages).to be_empty
@@ -115,7 +115,7 @@ describe RuboCop::Cop::Rails::SaveBang do
     end
 
     it "when using #{method} with oneline if and multiple conditional" do
-      inspect_source(cop, "something if false || object.#{method}")
+      inspect_source("something if false || object.#{method}")
 
       if pass
         expect(cop.messages).to be_empty
@@ -126,16 +126,16 @@ describe RuboCop::Cop::Rails::SaveBang do
     end
 
     it "when using #{method} as last method call" do
-      inspect_source(cop, ['def foo', "object.#{method}", 'end'])
+      inspect_source(['def foo', "object.#{method}", 'end'])
       expect(cop.messages).to be_empty
     end
 
     # Bug: https://github.com/bbatsov/rubocop/issues/4264
     it 'when using the assigned variable as value in a hash' do
-      inspect_source(cop, ['def foo',
-                           "  foo = Foo.#{method}",
-                           '  render json: foo',
-                           'end'])
+      inspect_source(['def foo',
+                      "  foo = Foo.#{method}",
+                      '  render json: foo',
+                      'end'])
       if pass
         expect(cop.offenses).to be_empty
       else
@@ -151,14 +151,14 @@ describe RuboCop::Cop::Rails::SaveBang do
 
   shared_examples 'checks_create_offense' do |method|
     it "when using persisted? after #{method}" do
-      inspect_source(cop, "x = object.#{method}\n" \
+      inspect_source("x = object.#{method}\n" \
                           'if x.persisted? then; something; end')
 
       expect(cop.messages).to be_empty
     end
 
     it "when using persisted? after #{method} with block" do
-      inspect_source(cop, "x = object.#{method} do |obj|\n" \
+      inspect_source("x = object.#{method} do |obj|\n" \
                           "  obj.name = 'Tom'\n" \
                           "end\n" \
                           'if x.persisted? then; something; end')

--- a/spec/rubocop/cop/rails/skips_model_validations_spec.rb
+++ b/spec/rubocop/cop/rails/skips_model_validations_spec.rb
@@ -24,7 +24,7 @@ describe RuboCop::Cop::Rails::SkipsModelValidations, :config do
   context 'with default blacklist' do
     cop_config['Blacklist'].each do |method_name|
       it "registers an offense for `#{method_name}`" do
-        inspect_source(cop, "User.#{method_name}(:attr)")
+        inspect_source("User.#{method_name}(:attr)")
         expect(cop.offenses.size).to eq(1)
         expect(cop.messages)
           .to eq([format(msg, method_name)])
@@ -39,7 +39,7 @@ describe RuboCop::Cop::Rails::SkipsModelValidations, :config do
   context 'with methods that require at least an argument' do
     methods_with_arguments.each do |method_name|
       it "doesn't register an offense for `#{method_name}`" do
-        inspect_source(cop, "User.#{method_name}")
+        inspect_source("User.#{method_name}")
         expect(cop.offenses).to be_empty
       end
     end
@@ -48,7 +48,7 @@ describe RuboCop::Cop::Rails::SkipsModelValidations, :config do
   context "with methods that don't require an argument" do
     (cop_config['Blacklist'] - methods_with_arguments).each do |method_name|
       it "registers an offense for `#{method_name}`" do
-        inspect_source(cop, "User.#{method_name}")
+        inspect_source("User.#{method_name}")
         expect(cop.offenses.size).to eq(1)
         expect(cop.messages)
           .to eq([format(msg, method_name)])
@@ -67,7 +67,7 @@ describe RuboCop::Cop::Rails::SkipsModelValidations, :config do
 
     whitelist.each do |method_name|
       it "accepts `#{method_name}`" do
-        inspect_source(cop, "User.#{method_name}")
+        inspect_source("User.#{method_name}")
         expect(cop.offenses).to be_empty
       end
     end

--- a/spec/rubocop/cop/rails/time_zone_spec.rb
+++ b/spec/rubocop/cop/rails/time_zone_spec.rb
@@ -8,55 +8,54 @@ describe RuboCop::Cop::Rails::TimeZone, :config do
 
     described_class::TIMECLASS.each do |klass|
       it "registers an offense for #{klass}.now" do
-        inspect_source(cop, "#{klass}.now")
+        inspect_source("#{klass}.now")
         expect(cop.offenses.size).to eq(1)
         expect(cop.offenses.first.message).to include('`Time.zone.now`')
       end
 
       it "registers an offense for #{klass}.current" do
-        inspect_source(cop, "#{klass}.current")
+        inspect_source("#{klass}.current")
         expect(cop.offenses.size).to eq(1)
         expect(cop.offenses.first.message).to include('`Time.zone.now`')
       end
 
       it "registers an offense for #{klass}.new without argument" do
-        inspect_source(cop, "#{klass}.new")
+        inspect_source("#{klass}.new")
         expect(cop.offenses.size).to eq(1)
         expect(cop.offenses.first.message).to include('`Time.zone.now`')
       end
 
       it "registers an offense for #{klass}.new with argument" do
-        inspect_source(cop, "#{klass}.new(2012, 6, 10, 12, 00)")
+        inspect_source("#{klass}.new(2012, 6, 10, 12, 00)")
         expect(cop.offenses.size).to eq(1)
         expect(cop.offenses.first.message).to include('`Time.zone.local`')
       end
 
       it 'does not register an offense when a .new method is made
         independently of the Time class' do
-        inspect_source(cop,
-                       'Range.new(1,
+        inspect_source('Range.new(1,
                                   Time.days_in_month(date.month, date.year))')
         expect(cop.offenses).to be_empty
       end
 
       it "does not register an offense for #{klass}.new with zone argument" do
-        inspect_source(cop, "#{klass}.new(1988, 3, 15, 3, 0, 0, '-05:00')")
+        inspect_source("#{klass}.new(1988, 3, 15, 3, 0, 0, '-05:00')")
         expect(cop.offenses).to be_empty
       end
 
       it "registers an offense for ::#{klass}.now" do
-        inspect_source(cop, "::#{klass}.now")
+        inspect_source("::#{klass}.now")
         expect(cop.offenses.size).to eq(1)
       end
 
       it "accepts Some::#{klass}.now" do
-        inspect_source(cop, "Some::#{klass}.forward(0).strftime('%H:%M')")
+        inspect_source("Some::#{klass}.forward(0).strftime('%H:%M')")
         expect(cop.offenses).to be_empty
       end
 
       described_class::ACCEPTED_METHODS.each do |a_method|
         it "registers an offense #{klass}.now.#{a_method}" do
-          inspect_source(cop, "#{klass}.now.#{a_method}")
+          inspect_source("#{klass}.now.#{a_method}")
           expect(cop.offenses.size).to eq(1)
         end
       end
@@ -208,7 +207,7 @@ describe RuboCop::Cop::Rails::TimeZone, :config do
 
     described_class::DANGEROUS_METHODS.each do |a_method|
       it "accepts Some::Time.#{a_method}" do
-        inspect_source(cop, "Some::Time.#{a_method}")
+        inspect_source("Some::Time.#{a_method}")
         expect(cop.offenses).to be_empty
       end
     end
@@ -219,7 +218,7 @@ describe RuboCop::Cop::Rails::TimeZone, :config do
 
     described_class::TIMECLASS.each do |klass|
       it "registers an offense for #{klass}.now" do
-        inspect_source(cop, "#{klass}.now")
+        inspect_source("#{klass}.now")
         expect(cop.offenses.size).to eq(1)
 
         expect(cop.offenses.first.message).to include('Use one of')
@@ -233,40 +232,40 @@ describe RuboCop::Cop::Rails::TimeZone, :config do
       end
 
       it "accepts #{klass}.current" do
-        inspect_source(cop, "#{klass}.current")
+        inspect_source("#{klass}.current")
         expect(cop.offenses).to be_empty
       end
 
       described_class::ACCEPTED_METHODS.each do |a_method|
         it "accepts #{klass}.now.#{a_method}" do
-          inspect_source(cop, "#{klass}.now.#{a_method}")
+          inspect_source("#{klass}.now.#{a_method}")
           expect(cop.offenses).to be_empty
         end
       end
 
       it "accepts #{klass}.zone.now" do
-        inspect_source(cop, "#{klass}.zone.now")
+        inspect_source("#{klass}.zone.now")
         expect(cop.offenses).to be_empty
       end
 
       it "accepts #{klass}.zone_default.now" do
-        inspect_source(cop, "#{klass}.zone_default.now")
+        inspect_source("#{klass}.zone_default.now")
         expect(cop.offenses).to be_empty
       end
 
       it "accepts #{klass}.find_zone(time_zone).now" do
-        inspect_source(cop, "#{klass}.find_zone('EST').now")
+        inspect_source("#{klass}.find_zone('EST').now")
         expect(cop.offenses).to be_empty
       end
 
       it "accepts #{klass}.find_zone!(time_zone).now" do
-        inspect_source(cop, "#{klass}.find_zone!('EST').now")
+        inspect_source("#{klass}.find_zone!('EST').now")
         expect(cop.offenses).to be_empty
       end
 
       described_class::DANGEROUS_METHODS.each do |a_method|
         it "accepts #{klass}.current.#{a_method}" do
-          inspect_source(cop, "#{klass}.current.#{a_method}")
+          inspect_source("#{klass}.current.#{a_method}")
           expect(cop.offenses).to be_empty
         end
       end

--- a/spec/rubocop/cop/rails/uniq_before_pluck_spec.rb
+++ b/spec/rubocop/cop/rails/uniq_before_pluck_spec.rb
@@ -7,7 +7,7 @@ describe RuboCop::Cop::Rails::UniqBeforePluck, :config do
     do |method, source, action, corrected = nil|
       if action == :correct
         it "finds the use of #{method} after pluck in #{source}" do
-          inspect_source(cop, source)
+          inspect_source(source)
           expect(cop.messages).to eq(["Use `#{method}` before `pluck`."])
           expect(cop.highlights).to eq([method])
           corrected_source = corrected || "Model.#{method}.pluck(:id)"
@@ -15,7 +15,7 @@ describe RuboCop::Cop::Rails::UniqBeforePluck, :config do
         end
       else
         it "ignores pluck without errors in #{source}" do
-          inspect_source(cop, source)
+          inspect_source(source)
           expect(cop.messages).to be_empty
           expect(cop.highlights).to be_empty
           expect(cop.offenses).to be_empty

--- a/spec/rubocop/cop/rails/uniq_before_pluck_spec.rb
+++ b/spec/rubocop/cop/rails/uniq_before_pluck_spec.rb
@@ -11,7 +11,7 @@ describe RuboCop::Cop::Rails::UniqBeforePluck, :config do
           expect(cop.messages).to eq(["Use `#{method}` before `pluck`."])
           expect(cop.highlights).to eq([method])
           corrected_source = corrected || "Model.#{method}.pluck(:id)"
-          expect(autocorrect_source(cop, source)).to eq(corrected_source)
+          expect(autocorrect_source(source)).to eq(corrected_source)
         end
       else
         it "ignores pluck without errors in #{source}" do

--- a/spec/rubocop/cop/rails/validation_spec.rb
+++ b/spec/rubocop/cop/rails/validation_spec.rb
@@ -5,12 +5,12 @@ describe RuboCop::Cop::Rails::Validation do
 
   described_class::BLACKLIST.each_with_index do |validation, number|
     it "registers an offense for #{validation}" do
-      inspect_source(cop, "#{validation} :name")
+      inspect_source("#{validation} :name")
       expect(cop.offenses.size).to eq(1)
     end
 
     it "outputs the correct message for #{validation}" do
-      inspect_source(cop, "#{validation} :name")
+      inspect_source("#{validation} :name")
       expect(cop.offenses.first.message)
         .to include(described_class::WHITELIST[number])
     end

--- a/spec/rubocop/cop/rails/validation_spec.rb
+++ b/spec/rubocop/cop/rails/validation_spec.rb
@@ -19,7 +19,6 @@ describe RuboCop::Cop::Rails::Validation do
   described_class::TYPES.each_with_index do |parameter|
     it "autocorrect validates_#{parameter}_of" do
       new_source = autocorrect_source(
-        cop,
         "validates_#{parameter}_of :full_name, :birth_date"
       )
       expect(new_source).to eq(
@@ -34,7 +33,6 @@ describe RuboCop::Cop::Rails::Validation do
 
   it 'autocorrect validates_length_of' do
     new_source = autocorrect_source(
-      cop,
       'validates_numericality_of :age, minimum: 0, maximum: 122'
     )
     expect(new_source).to eq(

--- a/spec/rubocop/cop/security/yaml_load_spec.rb
+++ b/spec/rubocop/cop/security/yaml_load_spec.rb
@@ -30,7 +30,7 @@ describe RuboCop::Cop::Security::YAMLLoad, :config do
   end
 
   it 'autocorrects load to safe_load' do
-    expect(autocorrect_source(cop, '::YAML.load("-- foo")')).to eq(
+    expect(autocorrect_source('::YAML.load("-- foo")')).to eq(
       '::YAML.safe_load("-- foo")'
     )
   end

--- a/spec/rubocop/cop/style/alias_spec.rb
+++ b/spec/rubocop/cop/style/alias_spec.rb
@@ -14,7 +14,7 @@ describe RuboCop::Cop::Style::Alias, :config do
     end
 
     it 'autocorrects alias with symbol args' do
-      corrected = autocorrect_source(cop, 'alias :ala :bala')
+      corrected = autocorrect_source('alias :ala :bala')
       expect(corrected).to eq 'alias_method :ala, :bala'
     end
 
@@ -26,7 +26,7 @@ describe RuboCop::Cop::Style::Alias, :config do
     end
 
     it 'autocorrects alias with bareword args' do
-      corrected = autocorrect_source(cop, 'alias ala bala')
+      corrected = autocorrect_source('alias ala bala')
       expect(corrected).to eq 'alias_method :ala, :bala'
     end
 
@@ -62,7 +62,7 @@ describe RuboCop::Cop::Style::Alias, :config do
     end
 
     it 'autocorrects alias with symbol args' do
-      corrected = autocorrect_source(cop, ['alias :ala :bala'])
+      corrected = autocorrect_source(['alias :ala :bala'])
       expect(corrected).to eq 'alias ala bala'
     end
 
@@ -78,7 +78,7 @@ describe RuboCop::Cop::Style::Alias, :config do
     end
 
     it 'autocorrects alias_method at the top level' do
-      corrected = autocorrect_source(cop, 'alias_method :ala, :bala')
+      corrected = autocorrect_source('alias_method :ala, :bala')
       expect(corrected).to eq 'alias ala bala'
     end
 
@@ -92,7 +92,7 @@ describe RuboCop::Cop::Style::Alias, :config do
     end
 
     it 'autocorrects alias_method in a class block' do
-      corrected = autocorrect_source(cop, <<-RUBY.strip_indent)
+      corrected = autocorrect_source(<<-RUBY.strip_indent)
         class C
           alias_method :ala, :bala
         end
@@ -114,7 +114,7 @@ describe RuboCop::Cop::Style::Alias, :config do
     end
 
     it 'autocorrects alias_method in a module block' do
-      corrected = autocorrect_source(cop, <<-RUBY.strip_indent)
+      corrected = autocorrect_source(<<-RUBY.strip_indent)
         module M
           alias_method :ala, :bala
         end

--- a/spec/rubocop/cop/style/and_or_spec.rb
+++ b/spec/rubocop/cop/style/and_or_spec.rb
@@ -11,7 +11,7 @@ describe RuboCop::Cop::Style::AndOr, :config do
 
     %w[and or].each do |operator|
       it "accepts \"#{operator}\" outside of conditional" do
-        inspect_source(cop, "x = a + b #{operator} return x")
+        inspect_source("x = a + b #{operator} return x")
         expect(cop.offenses).to be_empty
       end
 
@@ -29,7 +29,7 @@ describe RuboCop::Cop::Style::AndOr, :config do
           }
           source = format(snippet_format, elements)
 
-          inspect_source(cop, source)
+          inspect_source(source)
           expect(cop.offenses.size).to eq(1)
         end
 
@@ -40,7 +40,7 @@ describe RuboCop::Cop::Style::AndOr, :config do
           }
           source = format(snippet_format, elements)
 
-          inspect_source(cop, source)
+          inspect_source(source)
           expect(cop.offenses).to be_empty
         end
       end
@@ -48,12 +48,12 @@ describe RuboCop::Cop::Style::AndOr, :config do
 
     %w[&& ||].each do |operator|
       it "accepts #{operator} inside of conditional" do
-        inspect_source(cop, "test if a #{operator} b")
+        inspect_source("test if a #{operator} b")
         expect(cop.offenses).to be_empty
       end
 
       it "accepts #{operator} outside of conditional" do
-        inspect_source(cop, "x = a #{operator} b")
+        inspect_source("x = a #{operator} b")
         expect(cop.offenses).to be_empty
       end
     end

--- a/spec/rubocop/cop/style/and_or_spec.rb
+++ b/spec/rubocop/cop/style/and_or_spec.rb
@@ -90,12 +90,12 @@ describe RuboCop::Cop::Style::AndOr, :config do
     end
 
     it 'auto-corrects "and" with &&' do
-      new_source = autocorrect_source(cop, 'true and false')
+      new_source = autocorrect_source('true and false')
       expect(new_source).to eq('true && false')
     end
 
     it 'auto-corrects "or" with ||' do
-      new_source = autocorrect_source(cop, <<-RUBY.strip_indent)
+      new_source = autocorrect_source(<<-RUBY.strip_indent)
         x = 12345
         true or false
       RUBY
@@ -106,7 +106,7 @@ describe RuboCop::Cop::Style::AndOr, :config do
     end
 
     it 'auto-corrects "or" with || inside def' do
-      new_source = autocorrect_source(cop, <<-RUBY.strip_indent)
+      new_source = autocorrect_source(<<-RUBY.strip_indent)
         def z(a, b)
           return true if a or b
         end
@@ -120,25 +120,25 @@ describe RuboCop::Cop::Style::AndOr, :config do
 
     it 'autocorrects "or" with an assignment on the left' do
       src = "x = y or teststring.include? 'b'"
-      new_source = autocorrect_source(cop, src)
+      new_source = autocorrect_source(src)
       expect(new_source).to eq("(x = y) || teststring.include?('b')")
     end
 
     it 'autocorrects "or" with an assignment on the right' do
       src = "teststring.include? 'b' or x = y"
-      new_source = autocorrect_source(cop, src)
+      new_source = autocorrect_source(src)
       expect(new_source).to eq("teststring.include?('b') || (x = y)")
     end
 
     it 'autocorrects "and" with an assignment and return on either side' do
       src = 'x = a + b and return x'
-      new_source = autocorrect_source(cop, src)
+      new_source = autocorrect_source(src)
       expect(new_source).to eq('(x = a + b) && (return x)')
     end
 
     it 'autocorrects "and" with an Enumerable accessor on either side' do
       src = 'foo[:bar] and foo[:baz]'
-      new_source = autocorrect_source(cop, src)
+      new_source = autocorrect_source(src)
       expect(new_source).to eq('foo[:bar] && foo[:baz]')
     end
 
@@ -199,114 +199,114 @@ describe RuboCop::Cop::Style::AndOr, :config do
     end
 
     it 'auto-corrects "or" with || in method calls' do
-      new_source = autocorrect_source(cop, 'method a or b')
+      new_source = autocorrect_source('method a or b')
       expect(new_source).to eq('method(a) || b')
     end
 
     it 'auto-corrects "or" with || in method calls (2)' do
-      new_source = autocorrect_source(cop, 'method a,b or b')
+      new_source = autocorrect_source('method a,b or b')
       expect(new_source).to eq('method(a,b) || b')
     end
 
     it 'auto-corrects "or" with || in method calls (3)' do
-      new_source = autocorrect_source(cop, 'obj.method a or b')
+      new_source = autocorrect_source('obj.method a or b')
       expect(new_source).to eq('obj.method(a) || b')
     end
 
     it 'auto-corrects "or" with || in method calls (4)' do
-      new_source = autocorrect_source(cop, 'obj.method a,b or b')
+      new_source = autocorrect_source('obj.method a,b or b')
       expect(new_source).to eq('obj.method(a,b) || b')
     end
 
     it 'auto-corrects "or" with || and doesn\'t add extra parentheses' do
-      new_source = autocorrect_source(cop, 'method(a, b) or b')
+      new_source = autocorrect_source('method(a, b) or b')
       expect(new_source).to eq('method(a, b) || b')
     end
 
     it 'auto-corrects "or" with || and adds parentheses to expr' do
-      new_source = autocorrect_source(cop, 'b or method a,b')
+      new_source = autocorrect_source('b or method a,b')
       expect(new_source).to eq('b || method(a,b)')
     end
 
     it 'auto-corrects "and" with && in method calls' do
-      new_source = autocorrect_source(cop, 'method a and b')
+      new_source = autocorrect_source('method a and b')
       expect(new_source).to eq('method(a) && b')
     end
 
     it 'auto-corrects "and" with && in method calls (2)' do
-      new_source = autocorrect_source(cop, 'method a,b and b')
+      new_source = autocorrect_source('method a,b and b')
       expect(new_source).to eq('method(a,b) && b')
     end
 
     it 'auto-corrects "and" with && in method calls (3)' do
-      new_source = autocorrect_source(cop, 'obj.method a and b')
+      new_source = autocorrect_source('obj.method a and b')
       expect(new_source).to eq('obj.method(a) && b')
     end
 
     it 'auto-corrects "and" with && in method calls (4)' do
-      new_source = autocorrect_source(cop, 'obj.method a,b and b')
+      new_source = autocorrect_source('obj.method a,b and b')
       expect(new_source).to eq('obj.method(a,b) && b')
     end
 
     it 'auto-corrects "and" with && and doesn\'t add extra parentheses' do
-      new_source = autocorrect_source(cop, 'method(a, b) and b')
+      new_source = autocorrect_source('method(a, b) and b')
       expect(new_source).to eq('method(a, b) && b')
     end
 
     it 'auto-corrects "and" with && and adds parentheses to expr' do
-      new_source = autocorrect_source(cop, 'b and method a,b')
+      new_source = autocorrect_source('b and method a,b')
       expect(new_source).to eq('b && method(a,b)')
     end
 
     context 'with !obj.method arg on right' do
       it 'autocorrects "and" with && and adds parens' do
-        new_source = autocorrect_source(cop, 'x and !obj.method arg')
+        new_source = autocorrect_source('x and !obj.method arg')
         expect(new_source).to eq('x && !obj.method(arg)')
       end
     end
 
     context 'with !obj.method arg on left' do
       it 'autocorrects "and" with && and adds parens' do
-        new_source = autocorrect_source(cop, '!obj.method arg and x')
+        new_source = autocorrect_source('!obj.method arg and x')
         expect(new_source).to eq('!obj.method(arg) && x')
       end
     end
 
     context 'with obj.method = arg on left' do
       it 'autocorrects "and" with && and adds parens' do
-        new_source = autocorrect_source(cop, 'obj.method = arg and x')
+        new_source = autocorrect_source('obj.method = arg and x')
         expect(new_source).to eq('(obj.method = arg) && x')
       end
     end
 
     context 'with obj.method= arg on left' do
       it 'autocorrects "and" with && and adds parens' do
-        new_source = autocorrect_source(cop, 'obj.method= arg and x')
+        new_source = autocorrect_source('obj.method= arg and x')
         expect(new_source).to eq('(obj.method= arg) && x')
       end
     end
 
     context 'with predicate method with arg without space on right' do
       it 'autocorrects "or" with || and adds parens' do
-        new_source = autocorrect_source(cop, 'false or 3.is_a?Integer')
+        new_source = autocorrect_source('false or 3.is_a?Integer')
         expect(new_source).to eq('false || 3.is_a?(Integer)')
       end
 
       it 'autocorrects "and" with && and adds parens' do
-        new_source = autocorrect_source(cop, 'false and 3.is_a?Integer')
+        new_source = autocorrect_source('false and 3.is_a?Integer')
         expect(new_source).to eq('false && 3.is_a?(Integer)')
       end
     end
 
     context 'with two predicate methods with args without spaces on right' do
       it 'autocorrects "or" with || and adds parens' do
-        new_source = autocorrect_source(cop, "'1'.is_a?Integer " \
+        new_source = autocorrect_source("'1'.is_a?Integer " \
                                              'or 1.is_a?Integer')
         expect(new_source).to eq('\'1\'.is_a?(Integer) || 1.is_a?(Integer)')
       end
 
       it 'autocorrects "and" with && and adds parens' do
-        new_source = autocorrect_source(cop, "'1'.is_a?Integer and" \
+        new_source = autocorrect_source("'1'.is_a?Integer and" \
                                              ' 1.is_a?Integer')
         expect(new_source).to eq('\'1\'.is_a?(Integer) && 1.is_a?(Integer)')
       end
@@ -315,13 +315,13 @@ describe RuboCop::Cop::Style::AndOr, :config do
     context 'with one predicate method without space on right and another ' \
             'method' do
       it 'autocorrects "or" with || and adds parens' do
-        new_source = autocorrect_source(cop, "'1'.is_a?Integer or" \
+        new_source = autocorrect_source("'1'.is_a?Integer or" \
                                              ' 1.is_a? Integer')
         expect(new_source).to eq("'1'.is_a?(Integer) || 1.is_a?(Integer)")
       end
 
       it 'autocorrects "and" with && and adds parens' do
-        new_source = autocorrect_source(cop, "'1'.is_a?Integer " \
+        new_source = autocorrect_source("'1'.is_a?Integer " \
                                               'and 1.is_a? Integer')
         expect(new_source).to eq('\'1\'.is_a?(Integer) && 1.is_a?(Integer)')
       end
@@ -329,14 +329,14 @@ describe RuboCop::Cop::Style::AndOr, :config do
 
     context 'with `not` expression on right' do
       it 'autocorrects "and" with && and adds parens' do
-        new_source = autocorrect_source(cop, 'x and not arg')
+        new_source = autocorrect_source('x and not arg')
         expect(new_source).to eq('x && (not arg)')
       end
     end
 
     context 'with `not` expression on left' do
       it 'autocorrects "and" with && and adds parens' do
-        new_source = autocorrect_source(cop, 'not arg and x')
+        new_source = autocorrect_source('not arg and x')
         expect(new_source).to eq('(not arg) && x')
       end
     end
@@ -354,7 +354,7 @@ describe RuboCop::Cop::Style::AndOr, :config do
     context 'within a nested begin node' do
       # regression test; see GH issue 2531
       it 'autocorrects "and" with && and adds parens' do
-        new_source = autocorrect_source(cop, <<-RUBY.strip_indent)
+        new_source = autocorrect_source(<<-RUBY.strip_indent)
           def x
           end
 
@@ -376,7 +376,7 @@ describe RuboCop::Cop::Style::AndOr, :config do
     context 'when left hand side is a comparison method' do
       # Regression: https://github.com/bbatsov/rubocop/issues/4451
       it 'autocorrects "and" with && and adds parens' do
-        new_source = autocorrect_source(cop, <<-RUBY.strip_indent)
+        new_source = autocorrect_source(<<-RUBY.strip_indent)
           foo == bar and baz
         RUBY
         expect(new_source).to eq(<<-RUBY.strip_indent)
@@ -388,7 +388,7 @@ describe RuboCop::Cop::Style::AndOr, :config do
     context 'within a nested begin node with one child only' do
       # regression test; see GH issue 2531
       it 'autocorrects "and" with && and adds parens' do
-        new_source = autocorrect_source(cop, <<-RUBY.strip_indent)
+        new_source = autocorrect_source(<<-RUBY.strip_indent)
           (def y
             a = b and a.c
           end)
@@ -411,7 +411,7 @@ describe RuboCop::Cop::Style::AndOr, :config do
 
       # regression test; see GH issue 2609
       it 'autocorrects "or" with ||' do
-        new_source = autocorrect_source(cop, source)
+        new_source = autocorrect_source(source)
         expect(new_source).to eq(
           <<-RUBY.strip_indent
             APP_ROOT = Pathname.new File.expand_path('../../', __FILE__)

--- a/spec/rubocop/cop/style/array_join_spec.rb
+++ b/spec/rubocop/cop/style/array_join_spec.rb
@@ -12,22 +12,19 @@ describe RuboCop::Cop::Style::ArrayJoin do
 
   it "autocorrects '*' to 'join' when there are spaces" do
     corrected =
-      autocorrect_source(cop,
-                         '%w(one two three) * ", "')
+      autocorrect_source('%w(one two three) * ", "')
     expect(corrected).to eq '%w(one two three).join(", ")'
   end
 
   it "autocorrects '*' to 'join' when there are no spaces" do
     corrected =
-      autocorrect_source(cop,
-                         '%w(one two three)*", "')
+      autocorrect_source('%w(one two three)*", "')
     expect(corrected).to eq '%w(one two three).join(", ")'
   end
 
   it "autocorrects '*' to 'join' when setting to a variable" do
     corrected =
-      autocorrect_source(cop,
-                         'foo = %w(one two three)*", "')
+      autocorrect_source('foo = %w(one two three)*", "')
     expect(corrected).to eq 'foo = %w(one two three).join(", ")'
   end
 

--- a/spec/rubocop/cop/style/attr_spec.rb
+++ b/spec/rubocop/cop/style/attr_spec.rb
@@ -22,22 +22,22 @@ describe RuboCop::Cop::Style::Attr do
 
   context 'auto-corrects' do
     it 'attr to attr_reader' do
-      new_source = autocorrect_source(cop, 'attr :name')
+      new_source = autocorrect_source('attr :name')
       expect(new_source).to eq('attr_reader :name')
     end
 
     it 'attr, false to attr_reader' do
-      new_source = autocorrect_source(cop, 'attr :name, false')
+      new_source = autocorrect_source('attr :name, false')
       expect(new_source).to eq('attr_reader :name')
     end
 
     it 'attr :name, true to attr_accessor :name' do
-      new_source = autocorrect_source(cop, 'attr :name, true')
+      new_source = autocorrect_source('attr :name, true')
       expect(new_source).to eq('attr_accessor :name')
     end
 
     it 'attr with multiple names to attr_reader' do
-      new_source = autocorrect_source(cop, 'attr :foo, :bar')
+      new_source = autocorrect_source('attr :foo, :bar')
       expect(new_source).to eq('attr_reader :foo, :bar')
     end
   end

--- a/spec/rubocop/cop/style/attr_spec.rb
+++ b/spec/rubocop/cop/style/attr_spec.rb
@@ -47,22 +47,22 @@ describe RuboCop::Cop::Style::Attr do
     let(:msg_accessor) { 'Do not use `attr`. Use `attr_accessor` instead.' }
 
     it 'for attr :name suggests to use attr_reader' do
-      inspect_source(cop, 'attr :name')
+      inspect_source('attr :name')
       expect(cop.offenses.first.message).to eq(msg_reader)
     end
 
     it 'for attr :name, false suggests to use attr_reader' do
-      inspect_source(cop, 'attr :name, false')
+      inspect_source('attr :name, false')
       expect(cop.offenses.first.message).to eq(msg_reader)
     end
 
     it 'for attr :name, true suggests to use attr_accessor' do
-      inspect_source(cop, 'attr :name, true')
+      inspect_source('attr :name, true')
       expect(cop.offenses.first.message).to eq(msg_accessor)
     end
 
     it 'for attr with multiple names suggests to use attr_reader' do
-      inspect_source(cop, 'attr :foo, :bar')
+      inspect_source('attr :foo, :bar')
       expect(cop.offenses.first.message).to eq(msg_reader)
     end
   end

--- a/spec/rubocop/cop/style/bare_percent_literals_spec.rb
+++ b/spec/rubocop/cop/style/bare_percent_literals_spec.rb
@@ -49,7 +49,7 @@ describe RuboCop::Cop::Style::BarePercentLiterals, :config do
       end
 
       it 'auto-corrects' do
-        new_source = autocorrect_source(cop, '%(hi)')
+        new_source = autocorrect_source('%(hi)')
         expect(new_source).to eq('%Q(hi)')
       end
 
@@ -69,7 +69,7 @@ describe RuboCop::Cop::Style::BarePercentLiterals, :config do
       end
 
       it 'auto-corrects' do
-        new_source = autocorrect_source(cop, '%(#{x})')
+        new_source = autocorrect_source('%(#{x})')
         expect(new_source).to eq('%Q(#{x})')
       end
 
@@ -93,7 +93,7 @@ describe RuboCop::Cop::Style::BarePercentLiterals, :config do
       end
 
       it 'auto-corrects' do
-        new_source = autocorrect_source(cop, '%Q(hi)')
+        new_source = autocorrect_source('%Q(hi)')
         expect(new_source).to eq('%(hi)')
       end
 
@@ -113,7 +113,7 @@ describe RuboCop::Cop::Style::BarePercentLiterals, :config do
       end
 
       it 'auto-corrects' do
-        new_source = autocorrect_source(cop, '%Q(#{x})')
+        new_source = autocorrect_source('%Q(#{x})')
         expect(new_source).to eq('%(#{x})')
       end
 

--- a/spec/rubocop/cop/style/begin_block_spec.rb
+++ b/spec/rubocop/cop/style/begin_block_spec.rb
@@ -5,7 +5,7 @@ describe RuboCop::Cop::Style::BeginBlock do
 
   it 'reports an offense for a BEGIN block' do
     src = 'BEGIN { test }'
-    inspect_source(cop, src)
+    inspect_source(src)
     expect(cop.offenses.size).to eq(1)
   end
 end

--- a/spec/rubocop/cop/style/block_comments_spec.rb
+++ b/spec/rubocop/cop/style/block_comments_spec.rb
@@ -17,7 +17,7 @@ describe RuboCop::Cop::Style::BlockComments do
   end
 
   it 'auto-corrects a block comment into a regular comment' do
-    new_source = autocorrect_source(cop, <<-RUBY.strip_indent)
+    new_source = autocorrect_source(<<-RUBY.strip_indent)
       =begin
       comment line 1
 
@@ -36,7 +36,7 @@ describe RuboCop::Cop::Style::BlockComments do
   end
 
   it 'auto-corrects an empty block comment by removing it' do
-    new_source = autocorrect_source(cop, <<-RUBY.strip_indent)
+    new_source = autocorrect_source(<<-RUBY.strip_indent)
       =begin
       =end
       def foo

--- a/spec/rubocop/cop/style/block_delimiters_spec.rb
+++ b/spec/rubocop/cop/style/block_delimiters_spec.rb
@@ -205,7 +205,7 @@ describe RuboCop::Cop::Style::BlockDelimiters, :config do
         }
         RUBY
 
-        new_source = autocorrect_source(cop, source)
+        new_source = autocorrect_source(source)
         expect(new_source).to eq(corrected_source)
       end
 
@@ -216,7 +216,7 @@ describe RuboCop::Cop::Style::BlockDelimiters, :config do
         }
         RUBY
 
-        new_source = autocorrect_source(cop, source)
+        new_source = autocorrect_source(source)
         expect(new_source).to eq(corrected_source)
       end
     end
@@ -229,7 +229,7 @@ describe RuboCop::Cop::Style::BlockDelimiters, :config do
         }
       RUBY
 
-      new_source = autocorrect_source(cop, source)
+      new_source = autocorrect_source(source)
       expect(new_source).to eq(source)
     end
 
@@ -241,7 +241,7 @@ describe RuboCop::Cop::Style::BlockDelimiters, :config do
         end
       RUBY
 
-      new_source = autocorrect_source(cop, source)
+      new_source = autocorrect_source(source)
       expect(new_source).to eq(source)
     end
 
@@ -258,7 +258,7 @@ describe RuboCop::Cop::Style::BlockDelimiters, :config do
         }
       RUBY
 
-      new_source = autocorrect_source(cop, source)
+      new_source = autocorrect_source(source)
       expect(new_source).to eq(expected_source)
     end
 
@@ -275,7 +275,7 @@ describe RuboCop::Cop::Style::BlockDelimiters, :config do
         }
       RUBY
 
-      new_source = autocorrect_source(cop, source)
+      new_source = autocorrect_source(source)
       expect(new_source).to eq(expected_source)
     end
 
@@ -293,7 +293,7 @@ describe RuboCop::Cop::Style::BlockDelimiters, :config do
         })
       RUBY
 
-      new_source = autocorrect_source(cop, source)
+      new_source = autocorrect_source(source)
       expect(new_source).to eq(expected_source)
     end
   end
@@ -309,13 +309,13 @@ describe RuboCop::Cop::Style::BlockDelimiters, :config do
     include_examples 'syntactic styles'
 
     it 'auto-corrects do and end for single line blocks to { and }' do
-      new_source = autocorrect_source(cop, 'block do |x| end')
+      new_source = autocorrect_source('block do |x| end')
       expect(new_source).to eq('block { |x| }')
     end
 
     it 'does not auto-correct do-end if {} would change the meaning' do
       src = "s.subspec 'Subspec' do |sp| end"
-      new_source = autocorrect_source(cop, src)
+      new_source = autocorrect_source(src)
       expect(new_source).to eq(src)
     end
 
@@ -325,7 +325,7 @@ describe RuboCop::Cop::Style::BlockDelimiters, :config do
           bar a
         }
       RUBY
-      new_source = autocorrect_source(cop, src)
+      new_source = autocorrect_source(src)
       expect(new_source).to eq(src)
     end
 
@@ -416,7 +416,7 @@ describe RuboCop::Cop::Style::BlockDelimiters, :config do
           end
         RUBY
 
-        new_source = autocorrect_source(cop, source)
+        new_source = autocorrect_source(source)
         expect(new_source).to eq(expected_source)
       end
 
@@ -427,7 +427,7 @@ describe RuboCop::Cop::Style::BlockDelimiters, :config do
           }}
         RUBY
 
-        new_source = autocorrect_source(cop, source)
+        new_source = autocorrect_source(source)
         expect(new_source).to eq(<<-RUBY.strip_indent)
           (0..3).each do |a| a.times do
             puts a
@@ -441,7 +441,7 @@ describe RuboCop::Cop::Style::BlockDelimiters, :config do
             something
           }, arg3: :another_value
         RUBY
-        new_source = autocorrect_source(cop, src)
+        new_source = autocorrect_source(src)
         expect(new_source).to eq(src)
       end
     end
@@ -470,7 +470,7 @@ describe RuboCop::Cop::Style::BlockDelimiters, :config do
         each do |x|
         end.map(&:to_s)
       RUBY
-      new_source = autocorrect_source(cop, src)
+      new_source = autocorrect_source(src)
       expect(new_source).to eq(<<-RUBY.strip_indent)
         each { |x|
         }.map(&:to_s)

--- a/spec/rubocop/cop/style/block_delimiters_spec.rb
+++ b/spec/rubocop/cop/style/block_delimiters_spec.rb
@@ -5,7 +5,7 @@ describe RuboCop::Cop::Style::BlockDelimiters, :config do
 
   shared_examples 'syntactic styles' do
     it 'registers an offense for a single line block with do-end' do
-      inspect_source(cop, 'each do |x| end')
+      inspect_source('each do |x| end')
       expect(cop.messages)
         .to eq(['Prefer `{...}` over `do...end` for single-line blocks.'])
     end
@@ -22,7 +22,7 @@ describe RuboCop::Cop::Style::BlockDelimiters, :config do
     end
 
     it 'accepts a multi-line block that needs braces to be valid ruby' do
-      inspect_source(cop, <<-RUBY.strip_indent)
+      inspect_source(<<-RUBY.strip_indent)
         puts [1, 2, 3].map { |n|
           n * n
         }, 1
@@ -43,7 +43,7 @@ describe RuboCop::Cop::Style::BlockDelimiters, :config do
 
     it 'accepts a multi-line block with braces if the return value is ' \
        'assigned' do
-      inspect_source(cop, <<-RUBY.strip_indent)
+      inspect_source(<<-RUBY.strip_indent)
         foo = map { |x|
           x
         }
@@ -53,7 +53,7 @@ describe RuboCop::Cop::Style::BlockDelimiters, :config do
 
     it 'accepts a multi-line block with braces if it is the return value ' \
        'of its scope' do
-      inspect_source(cop, <<-RUBY.strip_indent)
+      inspect_source(<<-RUBY.strip_indent)
         block do
           map { |x|
             x
@@ -81,7 +81,7 @@ describe RuboCop::Cop::Style::BlockDelimiters, :config do
 
     it 'accepts a multi-line block with braces when passed to a known ' \
        'functional method' do
-      inspect_source(cop, <<-RUBY.strip_indent)
+      inspect_source(<<-RUBY.strip_indent)
         let(:foo) {
           x
         }
@@ -91,7 +91,7 @@ describe RuboCop::Cop::Style::BlockDelimiters, :config do
 
     it 'registers an offense for a multi-line block with braces if the ' \
        'return value is not used' do
-      inspect_source(cop, <<-RUBY.strip_indent)
+      inspect_source(<<-RUBY.strip_indent)
         each { |x|
           x
         }
@@ -102,7 +102,7 @@ describe RuboCop::Cop::Style::BlockDelimiters, :config do
 
     it 'registers an offense for a multi-line block with do-end if the ' \
        'return value is assigned' do
-      inspect_source(cop, <<-RUBY.strip_indent)
+      inspect_source(<<-RUBY.strip_indent)
         foo = map do |x|
           x
         end
@@ -113,7 +113,7 @@ describe RuboCop::Cop::Style::BlockDelimiters, :config do
 
     it 'registers an offense for a multi-line block with do-end if the ' \
        'return value is passed to a method' do
-      inspect_source(cop, <<-RUBY.strip_indent)
+      inspect_source(<<-RUBY.strip_indent)
         puts (map do |x|
           x
         end)
@@ -124,7 +124,7 @@ describe RuboCop::Cop::Style::BlockDelimiters, :config do
 
     it 'accepts a multi-line block with do-end if it is the return value ' \
        'of its scope' do
-      inspect_source(cop, <<-RUBY.strip_indent)
+      inspect_source(<<-RUBY.strip_indent)
         block do
           map do |x|
             x
@@ -160,7 +160,7 @@ describe RuboCop::Cop::Style::BlockDelimiters, :config do
 
     it 'accepts a multi-line functional block with do-end if it is ' \
        'a known procedural method' do
-      inspect_source(cop, <<-RUBY.strip_indent)
+      inspect_source(<<-RUBY.strip_indent)
         foo = bar.tap do |x|
           x.age = 3
         end
@@ -170,7 +170,7 @@ describe RuboCop::Cop::Style::BlockDelimiters, :config do
 
     it 'accepts a multi-line functional block with do-end if it is ' \
        'an ignored method' do
-      inspect_source(cop, <<-RUBY.strip_indent)
+      inspect_source(<<-RUBY.strip_indent)
         foo = lambda do
           puts 42
         end
@@ -357,13 +357,13 @@ describe RuboCop::Cop::Style::BlockDelimiters, :config do
             expects :save
           }
         RUBY
-        inspect_source(cop, src)
+        inspect_source(src)
         expect(cop.offenses).to be_empty
       end
 
       it 'accepts a multi-line functional block with {} if it is ' \
          'an ignored method' do
-        inspect_source(cop, <<-RUBY.strip_indent)
+        inspect_source(<<-RUBY.strip_indent)
           foo = proc {
             puts 42
           }
@@ -382,7 +382,7 @@ describe RuboCop::Cop::Style::BlockDelimiters, :config do
             # ...
           })
         RUBY
-        inspect_source(cop, src)
+        inspect_source(src)
         expect(cop.offenses.size).to eq(2)
       end
 
@@ -396,7 +396,7 @@ describe RuboCop::Cop::Style::BlockDelimiters, :config do
             e.nil?
           }
         RUBY
-        inspect_source(cop, src)
+        inspect_source(src)
         expect(cop.messages)
           .to eq(['Avoid using `{...}` for multi-line blocks.'])
       end
@@ -479,7 +479,7 @@ describe RuboCop::Cop::Style::BlockDelimiters, :config do
 
     it 'accepts a multi-line functional block with {} if it is ' \
        'an ignored method' do
-      inspect_source(cop, <<-RUBY.strip_indent)
+      inspect_source(<<-RUBY.strip_indent)
         foo = proc {
           puts 42
         }

--- a/spec/rubocop/cop/style/braces_around_hash_parameters_spec.rb
+++ b/spec/rubocop/cop/style/braces_around_hash_parameters_spec.rb
@@ -7,20 +7,20 @@ describe RuboCop::Cop::Style::BracesAroundHashParameters, :config do
     after { expect(cop.offenses).to be_empty }
 
     it 'accepts one non-hash parameter' do
-      inspect_source(cop, 'where(2)')
+      inspect_source('where(2)')
     end
 
     it 'accepts multiple non-hash parameters' do
-      inspect_source(cop, 'where(1, "2")')
+      inspect_source('where(1, "2")')
     end
 
     it 'accepts one empty hash parameter' do
-      inspect_source(cop, 'where({})')
+      inspect_source('where({})')
     end
 
     it 'accepts one empty hash parameter with whitespace' do
-      inspect_source(cop, ['where(  {     ',
-                           " }\t   )  "])
+      inspect_source(['where(  {     ',
+                      " }\t   )  "])
     end
   end
 
@@ -28,23 +28,23 @@ describe RuboCop::Cop::Style::BracesAroundHashParameters, :config do
     after { expect(cop.offenses).to be_empty }
 
     it 'accepts one hash parameter without braces' do
-      inspect_source(cop, 'where(x: "y")')
+      inspect_source('where(x: "y")')
     end
 
     it 'accepts one hash parameter without braces and with multiple keys' do
-      inspect_source(cop, 'where(x: "y", foo: "bar")')
+      inspect_source('where(x: "y", foo: "bar")')
     end
 
     it 'accepts one hash parameter without braces and with one hash value' do
-      inspect_source(cop, 'where(x: { "y" => "z" })')
+      inspect_source('where(x: { "y" => "z" })')
     end
 
     it 'accepts property assignment with braces' do
-      inspect_source(cop, 'x.z = { y: "z" }')
+      inspect_source('x.z = { y: "z" }')
     end
 
     it 'accepts operator with a hash parameter with braces' do
-      inspect_source(cop, 'x.z - { y: "z" }')
+      inspect_source('x.z - { y: "z" }')
     end
   end
 
@@ -53,34 +53,34 @@ describe RuboCop::Cop::Style::BracesAroundHashParameters, :config do
 
     it 'registers an offense for one non-hash parameter followed by a hash ' \
        'parameter with braces' do
-      inspect_source(cop, 'where(1, { y: 2 })')
+      inspect_source('where(1, { y: 2 })')
       expect(cop.messages).to eq([msg])
       expect(cop.highlights).to eq(['{ y: 2 }'])
     end
 
     it 'registers an offense for one object method hash parameter with ' \
        'braces' do
-      inspect_source(cop, 'x.func({ y: "z" })')
+      inspect_source('x.func({ y: "z" })')
       expect(cop.messages).to eq([msg])
       expect(cop.highlights).to eq(['{ y: "z" }'])
     end
 
     it 'registers an offense for one hash parameter with braces' do
-      inspect_source(cop, 'where({ x: 1 })')
+      inspect_source('where({ x: 1 })')
       expect(cop.messages).to eq([msg])
       expect(cop.highlights).to eq(['{ x: 1 }'])
     end
 
     it 'registers an offense for one hash parameter with braces and ' \
        'whitespace' do
-      inspect_source(cop, "where(  \n { x: 1 }   )")
+      inspect_source("where(  \n { x: 1 }   )")
       expect(cop.messages).to eq([msg])
       expect(cop.highlights).to eq(['{ x: 1 }'])
     end
 
     it 'registers an offense for one hash parameter with braces and multiple ' \
        'keys' do
-      inspect_source(cop, 'where({ x: 1, foo: "bar" })')
+      inspect_source('where({ x: 1, foo: "bar" })')
       expect(cop.messages).to eq([msg])
       expect(cop.highlights).to eq(['{ x: 1, foo: "bar" }'])
     end
@@ -225,7 +225,7 @@ describe RuboCop::Cop::Style::BracesAroundHashParameters, :config do
 
       it 'registers an offense for one hash parameter with braces and one ' \
          'without' do
-        inspect_source(cop, 'where({ x: 1 }, y: 2)')
+        inspect_source('where({ x: 1 }, y: 2)')
         expect(cop.messages)
           .to eq(['Missing curly braces around a hash parameter.'])
         expect(cop.highlights).to eq(['y: 2'])
@@ -286,13 +286,13 @@ describe RuboCop::Cop::Style::BracesAroundHashParameters, :config do
 
       it 'registers an offense for one hash parameter with multiple keys and ' \
          'without braces' do
-        inspect_source(cop, 'where(x: "y", foo: "bar")')
+        inspect_source('where(x: "y", foo: "bar")')
         expect(cop.highlights).to eq(['x: "y", foo: "bar"'])
       end
 
       it 'registers an offense for one hash parameter without braces with ' \
          'one hash value' do
-        inspect_source(cop, 'where(x: { "y" => "z" })')
+        inspect_source('where(x: { "y" => "z" })')
         expect(cop.highlights).to eq(['x: { "y" => "z" }'])
       end
     end

--- a/spec/rubocop/cop/style/braces_around_hash_parameters_spec.rb
+++ b/spec/rubocop/cop/style/braces_around_hash_parameters_spec.rb
@@ -89,56 +89,56 @@ describe RuboCop::Cop::Style::BracesAroundHashParameters, :config do
   shared_examples 'no_braces and context_dependent auto-corrections' do
     it 'corrects one non-hash parameter followed by a hash parameter with ' \
        'braces' do
-      corrected = autocorrect_source(cop, ['where(1, { y: 2 })'])
+      corrected = autocorrect_source(['where(1, { y: 2 })'])
       expect(corrected).to eq('where(1, y: 2)')
     end
 
     it 'corrects one object method hash parameter with braces' do
-      corrected = autocorrect_source(cop, ['x.func({ y: "z" })'])
+      corrected = autocorrect_source(['x.func({ y: "z" })'])
       expect(corrected).to eq('x.func(y: "z")')
     end
 
     it 'corrects one hash parameter with braces' do
-      corrected = autocorrect_source(cop, ['where({ x: 1 })'])
+      corrected = autocorrect_source(['where({ x: 1 })'])
       expect(corrected).to eq('where(x: 1)')
     end
 
     it 'corrects one hash parameter with braces and whitespace' do
-      corrected = autocorrect_source(cop, ['where(  ',
-                                           ' { x: 1 }   )'])
+      corrected = autocorrect_source(['where(  ',
+                                      ' { x: 1 }   )'])
       expect(corrected).to eq(['where(  ',
                                ' x: 1   )'].join("\n"))
     end
 
     it 'corrects one hash parameter with braces and multiple keys' do
-      corrected = autocorrect_source(cop, ['where({ x: 1, foo: "bar" })'])
+      corrected = autocorrect_source(['where({ x: 1, foo: "bar" })'])
       expect(corrected).to eq('where(x: 1, foo: "bar")')
     end
 
     it 'corrects one hash parameter with braces and extra leading whitespace' do
-      corrected = autocorrect_source(cop, ['where({   x: 1, y: 2 })'])
+      corrected = autocorrect_source(['where({   x: 1, y: 2 })'])
       expect(corrected).to eq('where(x: 1, y: 2)')
     end
 
     it 'corrects one hash parameter with braces and extra trailing ' \
        'whitespace' do
-      corrected = autocorrect_source(cop, ['where({ x: 1, y: 2   })'])
+      corrected = autocorrect_source(['where({ x: 1, y: 2   })'])
       expect(corrected).to eq('where(x: 1, y: 2)')
     end
 
     it 'corrects one hash parameter with braces and a trailing comma' do
-      corrected = autocorrect_source(cop, ['where({ x: 1, y: 2, })'])
+      corrected = autocorrect_source(['where({ x: 1, y: 2, })'])
       expect(corrected).to eq('where(x: 1, y: 2)')
     end
 
     it 'corrects one hash parameter with braces and trailing comma and ' \
        'whitespace' do
-      corrected = autocorrect_source(cop, ['where({ x: 1, y: 2,   })'])
+      corrected = autocorrect_source(['where({ x: 1, y: 2,   })'])
       expect(corrected).to eq('where(x: 1, y: 2)')
     end
 
     it 'corrects one hash parameter with braces without adding extra space' do
-      corrected = autocorrect_source(cop, 'get :i, { q: { x: 1 } }')
+      corrected = autocorrect_source('get :i, { q: { x: 1 } }')
       expect(corrected).to eq('get :i, q: { x: 1 }')
     end
 
@@ -150,7 +150,7 @@ describe RuboCop::Cop::Style::BracesAroundHashParameters, :config do
             p2: (opts[:b] || opts[:c]) # a comment
           })
         RUBY
-        corrected = autocorrect_source(cop, src)
+        corrected = autocorrect_source(src)
         expect(corrected).to eq(<<-RUBY.strip_indent)
           r = opts.merge(
             p1: opts[:a],
@@ -163,7 +163,7 @@ describe RuboCop::Cop::Style::BracesAroundHashParameters, :config do
     context 'in a method call without parentheses' do
       it 'corrects a hash parameter with trailing comma' do
         src = 'get :i, { x: 1, }'
-        corrected = autocorrect_source(cop, src)
+        corrected = autocorrect_source(src)
         expect(corrected).to eq('get :i, x: 1')
       end
     end
@@ -197,12 +197,12 @@ describe RuboCop::Cop::Style::BracesAroundHashParameters, :config do
       include_examples 'no_braces and context_dependent auto-corrections'
 
       it 'corrects one hash parameter with braces' do
-        corrected = autocorrect_source(cop, ['where(1, { x: 1 })'])
+        corrected = autocorrect_source(['where(1, { x: 1 })'])
         expect(corrected).to eq('where(1, x: 1)')
       end
 
       it 'corrects two hash parameters with braces' do
-        corrected = autocorrect_source(cop, ['where(1, { x: 1 }, { y: 2 })'])
+        corrected = autocorrect_source(['where(1, { x: 1 }, { y: 2 })'])
         expect(corrected).to eq('where(1, { x: 1 }, y: 2)')
       end
     end
@@ -236,12 +236,12 @@ describe RuboCop::Cop::Style::BracesAroundHashParameters, :config do
       include_examples 'no_braces and context_dependent auto-corrections'
 
       it 'corrects one hash parameter with braces and one without' do
-        corrected = autocorrect_source(cop, ['where(1, { x: 1 }, y: 2)'])
+        corrected = autocorrect_source(['where(1, { x: 1 }, y: 2)'])
         expect(corrected).to eq('where(1, { x: 1 }, {y: 2})')
       end
 
       it 'corrects one hash parameter with braces' do
-        corrected = autocorrect_source(cop, ['where(1, { x: 1 })'])
+        corrected = autocorrect_source(['where(1, { x: 1 })'])
         expect(corrected).to eq('where(1, x: 1)')
       end
     end
@@ -299,17 +299,17 @@ describe RuboCop::Cop::Style::BracesAroundHashParameters, :config do
 
     describe '#autocorrect' do
       it 'corrects one hash parameter without braces' do
-        corrected = autocorrect_source(cop, ['where(x: "y")'])
+        corrected = autocorrect_source(['where(x: "y")'])
         expect(corrected).to eq('where({x: "y"})')
       end
 
       it 'corrects one hash parameter with multiple keys and without braces' do
-        corrected = autocorrect_source(cop, ['where(x: "y", foo: "bar")'])
+        corrected = autocorrect_source(['where(x: "y", foo: "bar")'])
         expect(corrected).to eq('where({x: "y", foo: "bar"})')
       end
 
       it 'corrects one hash parameter without braces with one hash value' do
-        corrected = autocorrect_source(cop, ['where(x: { "y" => "z" })'])
+        corrected = autocorrect_source(['where(x: { "y" => "z" })'])
         expect(corrected).to eq('where({x: { "y" => "z" }})')
       end
     end

--- a/spec/rubocop/cop/style/character_literal_spec.rb
+++ b/spec/rubocop/cop/style/character_literal_spec.rb
@@ -26,17 +26,17 @@ describe RuboCop::Cop::Style::CharacterLiteral do
   end
 
   it "auto-corrects ?x to 'x'" do
-    new_source = autocorrect_source(cop, 'x = ?x')
+    new_source = autocorrect_source('x = ?x')
     expect(new_source).to eq("x = 'x'")
   end
 
   it 'auto-corrects ?\n to "\\n"' do
-    new_source = autocorrect_source(cop, 'x = ?\n')
+    new_source = autocorrect_source('x = ?\n')
     expect(new_source).to eq('x = "\\n"')
   end
 
   it 'auto-corrects ?\' to "\'"' do
-    new_source = autocorrect_source(cop, 'x = ?\'')
+    new_source = autocorrect_source('x = ?\'')
     expect(new_source).to eq('x = "\'"')
   end
 end

--- a/spec/rubocop/cop/style/class_check_spec.rb
+++ b/spec/rubocop/cop/style/class_check_spec.rb
@@ -14,7 +14,7 @@ describe RuboCop::Cop::Style::ClassCheck, :config do
     end
 
     it 'auto-corrects kind_of? to is_a?' do
-      corrected = autocorrect_source(cop, ['x.kind_of? y'])
+      corrected = autocorrect_source(['x.kind_of? y'])
       expect(corrected).to eq 'x.is_a? y'
     end
   end
@@ -30,7 +30,7 @@ describe RuboCop::Cop::Style::ClassCheck, :config do
     end
 
     it 'auto-corrects is_a? to kind_of?' do
-      corrected = autocorrect_source(cop, ['x.is_a? y'])
+      corrected = autocorrect_source(['x.is_a? y'])
       expect(corrected).to eq 'x.kind_of? y'
     end
   end

--- a/spec/rubocop/cop/style/class_methods_spec.rb
+++ b/spec/rubocop/cop/style/class_methods_spec.rb
@@ -72,7 +72,7 @@ describe RuboCop::Cop::Style::ClassMethods do
       end
     RUBY
 
-    new_source = autocorrect_source(cop, src)
+    new_source = autocorrect_source(src)
     expect(new_source).to eq(correct_source)
   end
 end

--- a/spec/rubocop/cop/style/collection_methods_spec.rb
+++ b/spec/rubocop/cop/style/collection_methods_spec.rb
@@ -39,7 +39,7 @@ describe RuboCop::Cop::Style::CollectionMethods, :config do
     end
 
     it 'auto-corrects to preferred method' do
-      new_source = autocorrect_source(cop, 'some.collect(&:test)')
+      new_source = autocorrect_source('some.collect(&:test)')
       expect(new_source).to eq('some.map(&:test)')
     end
   end

--- a/spec/rubocop/cop/style/collection_methods_spec.rb
+++ b/spec/rubocop/cop/style/collection_methods_spec.rb
@@ -15,26 +15,26 @@ describe RuboCop::Cop::Style::CollectionMethods, :config do
 
   cop_config['PreferredMethods'].each do |method, preferred_method|
     it "registers an offense for #{method} with block" do
-      inspect_source(cop, "[1, 2, 3].#{method} { |e| e + 1 }")
+      inspect_source("[1, 2, 3].#{method} { |e| e + 1 }")
       expect(cop.offenses.size).to eq(1)
       expect(cop.messages)
         .to eq(["Prefer `#{preferred_method}` over `#{method}`."])
     end
 
     it "registers an offense for #{method} with proc param" do
-      inspect_source(cop, "[1, 2, 3].#{method}(&:test)")
+      inspect_source("[1, 2, 3].#{method}(&:test)")
       expect(cop.offenses.size).to eq(1)
       expect(cop.messages)
         .to eq(["Prefer `#{preferred_method}` over `#{method}`."])
     end
 
     it "accepts #{method} with more than 1 param" do
-      inspect_source(cop, "[1, 2, 3].#{method}(other, &:test)")
+      inspect_source("[1, 2, 3].#{method}(other, &:test)")
       expect(cop.offenses).to be_empty
     end
 
     it "accepts #{method} without a block" do
-      inspect_source(cop, "[1, 2, 3].#{method}")
+      inspect_source("[1, 2, 3].#{method}")
       expect(cop.offenses).to be_empty
     end
 

--- a/spec/rubocop/cop/style/colon_method_call_spec.rb
+++ b/spec/rubocop/cop/style/colon_method_call_spec.rb
@@ -52,7 +52,7 @@ describe RuboCop::Cop::Style::ColonMethodCall do
   end
 
   it 'auto-corrects "::" with "."' do
-    new_source = autocorrect_source(cop, 'test::method')
+    new_source = autocorrect_source('test::method')
     expect(new_source).to eq('test.method')
   end
 end

--- a/spec/rubocop/cop/style/command_literal_spec.rb
+++ b/spec/rubocop/cop/style/command_literal_spec.rb
@@ -33,7 +33,7 @@ describe RuboCop::Cop::Style::CommandLiteral, :config do
     end
 
     it 'respects the configuration when auto-correcting' do
-      new_source = autocorrect_source(cop, '`ls`')
+      new_source = autocorrect_source('`ls`')
       expect(new_source).to eq('%x[ls]')
     end
   end
@@ -70,7 +70,7 @@ describe RuboCop::Cop::Style::CommandLiteral, :config do
       end
 
       it 'cannot auto-correct' do
-        new_source = autocorrect_source(cop, source)
+        new_source = autocorrect_source(source)
         expect(new_source).to eq(source)
       end
 
@@ -113,7 +113,7 @@ describe RuboCop::Cop::Style::CommandLiteral, :config do
       end
 
       it 'cannot auto-correct' do
-        new_source = autocorrect_source(cop, source)
+        new_source = autocorrect_source(source)
         expect(new_source).to eq(source.join("\n"))
       end
 
@@ -142,7 +142,7 @@ describe RuboCop::Cop::Style::CommandLiteral, :config do
       end
 
       it 'auto-corrects' do
-        new_source = autocorrect_source(cop, source)
+        new_source = autocorrect_source(source)
         expect(new_source).to eq('foo = `ls`')
       end
     end
@@ -165,7 +165,7 @@ describe RuboCop::Cop::Style::CommandLiteral, :config do
         end
 
         it 'cannot auto-correct' do
-          new_source = autocorrect_source(cop, source)
+          new_source = autocorrect_source(source)
           expect(new_source).to eq(source)
         end
       end
@@ -190,7 +190,7 @@ describe RuboCop::Cop::Style::CommandLiteral, :config do
       end
 
       it 'auto-corrects' do
-        new_source = autocorrect_source(cop, source)
+        new_source = autocorrect_source(source)
         expect(new_source).to eq("foo = `\n  ls\n  ls -l\n`")
       end
     end
@@ -226,7 +226,7 @@ describe RuboCop::Cop::Style::CommandLiteral, :config do
         end
 
         it 'cannot auto-correct' do
-          new_source = autocorrect_source(cop, source)
+          new_source = autocorrect_source(source)
           expect(new_source).to eq(source.join("\n"))
         end
       end
@@ -247,7 +247,7 @@ describe RuboCop::Cop::Style::CommandLiteral, :config do
       end
 
       it 'auto-corrects' do
-        new_source = autocorrect_source(cop, source)
+        new_source = autocorrect_source(source)
         expect(new_source).to eq('foo = %x(ls)')
       end
     end
@@ -263,7 +263,7 @@ describe RuboCop::Cop::Style::CommandLiteral, :config do
       end
 
       it 'cannot auto-correct' do
-        new_source = autocorrect_source(cop, source)
+        new_source = autocorrect_source(source)
         expect(new_source).to eq(source)
       end
     end
@@ -287,7 +287,7 @@ describe RuboCop::Cop::Style::CommandLiteral, :config do
       end
 
       it 'auto-corrects' do
-        new_source = autocorrect_source(cop, source)
+        new_source = autocorrect_source(source)
         expect(new_source).to eq("foo = %x(\n  ls\n  ls -l\n)")
       end
     end
@@ -311,7 +311,7 @@ describe RuboCop::Cop::Style::CommandLiteral, :config do
       end
 
       it 'cannot auto-correct' do
-        new_source = autocorrect_source(cop, source)
+        new_source = autocorrect_source(source)
         expect(new_source).to eq(source.join("\n"))
       end
     end
@@ -371,7 +371,7 @@ describe RuboCop::Cop::Style::CommandLiteral, :config do
       end
 
       it 'cannot auto-correct' do
-        new_source = autocorrect_source(cop, source)
+        new_source = autocorrect_source(source)
         expect(new_source).to eq(source)
       end
 
@@ -403,7 +403,7 @@ describe RuboCop::Cop::Style::CommandLiteral, :config do
       end
 
       it 'auto-corrects' do
-        new_source = autocorrect_source(cop, source)
+        new_source = autocorrect_source(source)
         expect(new_source).to eq("foo = %x(\n  ls\n  ls -l\n)")
       end
     end
@@ -427,7 +427,7 @@ describe RuboCop::Cop::Style::CommandLiteral, :config do
       end
 
       it 'cannot auto-correct' do
-        new_source = autocorrect_source(cop, source)
+        new_source = autocorrect_source(source)
         expect(new_source).to eq(source.join("\n"))
       end
     end
@@ -443,7 +443,7 @@ describe RuboCop::Cop::Style::CommandLiteral, :config do
       end
 
       it 'auto-corrects' do
-        new_source = autocorrect_source(cop, source)
+        new_source = autocorrect_source(source)
         expect(new_source).to eq('foo = `ls`')
       end
     end
@@ -466,7 +466,7 @@ describe RuboCop::Cop::Style::CommandLiteral, :config do
         end
 
         it 'cannot auto-correct' do
-          new_source = autocorrect_source(cop, source)
+          new_source = autocorrect_source(source)
           expect(new_source).to eq(source)
         end
       end

--- a/spec/rubocop/cop/style/comment_annotation_spec.rb
+++ b/spec/rubocop/cop/style/comment_annotation_spec.rb
@@ -15,7 +15,7 @@ describe RuboCop::Cop::Style::CommentAnnotation, :config do
     end
 
     it 'autocorrects' do
-      corrected = autocorrect_source(cop, '# TODO make better')
+      corrected = autocorrect_source('# TODO make better')
       expect(corrected).to eq('# TODO: make better')
     end
   end
@@ -31,7 +31,7 @@ describe RuboCop::Cop::Style::CommentAnnotation, :config do
     end
 
     it 'autocorrects a missing colon after keyword' do
-      corrected = autocorrect_source(cop, '# ISSUE wrong order')
+      corrected = autocorrect_source('# ISSUE wrong order')
       expect(corrected).to eq('# ISSUE: wrong order')
     end
   end
@@ -45,7 +45,7 @@ describe RuboCop::Cop::Style::CommentAnnotation, :config do
     end
 
     it 'autocorrects' do
-      corrected = autocorrect_source(cop, '# TODO:make better')
+      corrected = autocorrect_source('# TODO:make better')
       expect(corrected).to eq('# TODO: make better')
     end
   end
@@ -59,7 +59,7 @@ describe RuboCop::Cop::Style::CommentAnnotation, :config do
     end
 
     it 'autocorrects' do
-      corrected = autocorrect_source(cop, '# fixme: does not work')
+      corrected = autocorrect_source('# fixme: does not work')
       expect(corrected).to eq('# FIXME: does not work')
     end
   end
@@ -73,7 +73,7 @@ describe RuboCop::Cop::Style::CommentAnnotation, :config do
     end
 
     it 'autocorrects' do
-      corrected = autocorrect_source(cop, '# Optimize: does not work')
+      corrected = autocorrect_source('# Optimize: does not work')
       expect(corrected).to eq('# OPTIMIZE: does not work')
     end
   end
@@ -88,7 +88,7 @@ describe RuboCop::Cop::Style::CommentAnnotation, :config do
 
     it 'does not autocorrects' do
       source = '# HACK:'
-      corrected = autocorrect_source(cop, source)
+      corrected = autocorrect_source(source)
       expect(corrected).to eq(source)
     end
   end

--- a/spec/rubocop/cop/style/conditional_assignment_assign_in_condition_spec.rb
+++ b/spec/rubocop/cop/style/conditional_assignment_assign_in_condition_spec.rb
@@ -165,7 +165,7 @@ describe RuboCop::Cop::Style::ConditionalAssignment do
 
     context 'auto-correct' do
       it 'corrects assigning any variable type to ternary' do
-        new_source = autocorrect_source(cop, "#{variable} = foo? ? 1 : 2")
+        new_source = autocorrect_source("#{variable} = foo? ? 1 : 2")
 
         expect(new_source).to eq("foo? ? #{variable} = 1 : #{variable} = 2")
       end
@@ -180,7 +180,7 @@ describe RuboCop::Cop::Style::ConditionalAssignment do
                           3
                         end
         RUBY
-        new_source = autocorrect_source(cop, source)
+        new_source = autocorrect_source(source)
 
         expect(new_source).to eq(<<-RUBY.strip_indent)
           if foo
@@ -201,7 +201,7 @@ describe RuboCop::Cop::Style::ConditionalAssignment do
                           2
                         end
         RUBY
-        new_source = autocorrect_source(cop, source)
+        new_source = autocorrect_source(source)
 
         expect(new_source).to eq(<<-RUBY.strip_indent)
           unless foo
@@ -223,7 +223,7 @@ describe RuboCop::Cop::Style::ConditionalAssignment do
                           3
                         end
         RUBY
-        new_source = autocorrect_source(cop, source)
+        new_source = autocorrect_source(source)
 
         expect(new_source).to eq(<<-RUBY.strip_indent)
           case foo
@@ -299,7 +299,7 @@ describe RuboCop::Cop::Style::ConditionalAssignment do
 
     context 'auto-correct' do
       it 'corrects any assignment to ternary' do
-        new_source = autocorrect_source(cop, "bar #{assignment} (foo? ? 1 : 2)")
+        new_source = autocorrect_source("bar #{assignment} (foo? ? 1 : 2)")
 
         expect(new_source)
           .to eq("foo? ? bar #{assignment} 1 : bar #{assignment} 2")
@@ -313,7 +313,7 @@ describe RuboCop::Cop::Style::ConditionalAssignment do
                           2
                         end
         RUBY
-        new_source = autocorrect_source(cop, source)
+        new_source = autocorrect_source(source)
 
         expect(new_source).to eq(<<-RUBY.strip_indent)
           if foo
@@ -332,7 +332,7 @@ describe RuboCop::Cop::Style::ConditionalAssignment do
                           2
                         end
         RUBY
-        new_source = autocorrect_source(cop, source)
+        new_source = autocorrect_source(source)
 
         expect(new_source).to eq(<<-RUBY.strip_indent)
           unless foo
@@ -352,7 +352,7 @@ describe RuboCop::Cop::Style::ConditionalAssignment do
                           2
                         end
         RUBY
-        new_source = autocorrect_source(cop, source)
+        new_source = autocorrect_source(source)
 
         expect(new_source).to eq(<<-RUBY.strip_indent)
           case foo
@@ -507,7 +507,7 @@ describe RuboCop::Cop::Style::ConditionalAssignment do
                 2
               end
       RUBY
-      new_source = autocorrect_source(cop, source)
+      new_source = autocorrect_source(source)
 
       expect(new_source).to eq(<<-RUBY.strip_indent)
         if foo
@@ -528,7 +528,7 @@ describe RuboCop::Cop::Style::ConditionalAssignment do
                 3
               end
       RUBY
-      new_source = autocorrect_source(cop, source)
+      new_source = autocorrect_source(source)
 
       expect(new_source).to eq(<<-RUBY.strip_indent)
         if foo
@@ -553,7 +553,7 @@ describe RuboCop::Cop::Style::ConditionalAssignment do
                 4
               end
       RUBY
-      new_source = autocorrect_source(cop, source)
+      new_source = autocorrect_source(source)
 
       expect(new_source).to eq(<<-RUBY.strip_indent)
         if foo
@@ -576,7 +576,7 @@ describe RuboCop::Cop::Style::ConditionalAssignment do
                 2
               end
       RUBY
-      new_source = autocorrect_source(cop, source)
+      new_source = autocorrect_source(source)
 
       expect(new_source).to eq(<<-RUBY.strip_indent)
         unless foo
@@ -596,7 +596,7 @@ describe RuboCop::Cop::Style::ConditionalAssignment do
                 2
               end
       RUBY
-      new_source = autocorrect_source(cop, source)
+      new_source = autocorrect_source(source)
 
       expect(new_source).to eq(<<-RUBY.strip_indent)
         case foo
@@ -619,7 +619,7 @@ describe RuboCop::Cop::Style::ConditionalAssignment do
                 3
               end
       RUBY
-      new_source = autocorrect_source(cop, source)
+      new_source = autocorrect_source(source)
 
       expect(new_source).to eq(<<-RUBY.strip_indent)
         case foo
@@ -634,7 +634,7 @@ describe RuboCop::Cop::Style::ConditionalAssignment do
     end
 
     it 'corrects assignment to a ternary operator' do
-      new_source = autocorrect_source(cop, 'bar = foo? ? 1 : 2')
+      new_source = autocorrect_source('bar = foo? ? 1 : 2')
 
       expect(new_source).to eq('foo? ? bar = 1 : bar = 2')
     end
@@ -783,7 +783,7 @@ describe RuboCop::Cop::Style::ConditionalAssignment do
                 end
         RUBY
 
-        new_source = autocorrect_source(cop, source)
+        new_source = autocorrect_source(source)
 
         expect(new_source).to eq(<<-RUBY.strip_indent)
           if foo then bar = 1
@@ -800,7 +800,7 @@ describe RuboCop::Cop::Style::ConditionalAssignment do
                 end
         RUBY
 
-        new_source = autocorrect_source(cop, source)
+        new_source = autocorrect_source(source)
 
         expect(new_source).to eq(<<-RUBY.strip_indent)
           case foo
@@ -811,7 +811,7 @@ describe RuboCop::Cop::Style::ConditionalAssignment do
       end
 
       it 'corrects assignment using a method that ends with an equal sign' do
-        new_source = autocorrect_source(cop, 'self.attributes = foo? ? 1 : 2')
+        new_source = autocorrect_source('self.attributes = foo? ? 1 : 2')
 
         expect(new_source)
           .to eq('foo? ? self.attributes = 1 : self.attributes = 2')
@@ -825,7 +825,7 @@ describe RuboCop::Cop::Style::ConditionalAssignment do
                       2
                     end
         RUBY
-        new_source = autocorrect_source(cop, source)
+        new_source = autocorrect_source(source)
 
         expect(new_source).to eq(<<-RUBY.strip_indent)
           if bar?
@@ -844,7 +844,7 @@ describe RuboCop::Cop::Style::ConditionalAssignment do
                        2
                      end
         RUBY
-        new_source = autocorrect_source(cop, source)
+        new_source = autocorrect_source(source)
 
         expect(new_source).to eq(<<-RUBY.strip_indent)
           if baz?
@@ -977,7 +977,7 @@ describe RuboCop::Cop::Style::ConditionalAssignment do
                 2
               end
       RUBY
-      new_source = autocorrect_source(cop, source)
+      new_source = autocorrect_source(source)
 
       expect(new_source).to eq(<<-RUBY.strip_indent)
         if foo
@@ -1003,7 +1003,7 @@ describe RuboCop::Cop::Style::ConditionalAssignment do
                 3
               end
       RUBY
-      new_source = autocorrect_source(cop, source)
+      new_source = autocorrect_source(source)
 
       expect(new_source).to eq(<<-RUBY.strip_indent)
         if foo
@@ -1035,7 +1035,7 @@ describe RuboCop::Cop::Style::ConditionalAssignment do
                 4
               end
       RUBY
-      new_source = autocorrect_source(cop, source)
+      new_source = autocorrect_source(source)
 
       expect(new_source).to eq(<<-RUBY.strip_indent)
         if foo
@@ -1064,7 +1064,7 @@ describe RuboCop::Cop::Style::ConditionalAssignment do
                 2
               end
       RUBY
-      new_source = autocorrect_source(cop, source)
+      new_source = autocorrect_source(source)
 
       expect(new_source).to eq(<<-RUBY.strip_indent)
         unless foo
@@ -1088,7 +1088,7 @@ describe RuboCop::Cop::Style::ConditionalAssignment do
                 2
               end
       RUBY
-      new_source = autocorrect_source(cop, source)
+      new_source = autocorrect_source(source)
 
       expect(new_source).to eq(<<-RUBY.strip_indent)
         case foo
@@ -1116,7 +1116,7 @@ describe RuboCop::Cop::Style::ConditionalAssignment do
                 3
               end
       RUBY
-      new_source = autocorrect_source(cop, source)
+      new_source = autocorrect_source(source)
 
       expect(new_source).to eq(<<-RUBY.strip_indent)
         case foo

--- a/spec/rubocop/cop/style/conditional_assignment_assign_in_condition_spec.rb
+++ b/spec/rubocop/cop/style/conditional_assignment_assign_in_condition_spec.rb
@@ -5,13 +5,13 @@ describe RuboCop::Cop::Style::ConditionalAssignment do
 
   shared_examples 'all variable types' do |variable|
     it 'registers an offense assigning any variable type to ternary' do
-      inspect_source(cop, "#{variable} = foo? ? 1 : 2")
+      inspect_source("#{variable} = foo? ? 1 : 2")
 
       expect(cop.messages).to eq([described_class::ASSIGN_TO_CONDITION_MSG])
     end
 
     it 'allows assigning any variable type inside ternary' do
-      inspect_source(cop, "foo? ? #{variable} = 1 : #{variable} = 2")
+      inspect_source("foo? ? #{variable} = 1 : #{variable} = 2")
 
       expect(cop.offenses).to be_empty
     end
@@ -24,7 +24,7 @@ describe RuboCop::Cop::Style::ConditionalAssignment do
                         2
                       end
       RUBY
-      inspect_source(cop, source)
+      inspect_source(source)
 
       expect(cop.messages).to eq([described_class::ASSIGN_TO_CONDITION_MSG])
     end
@@ -39,7 +39,7 @@ describe RuboCop::Cop::Style::ConditionalAssignment do
                         3
                       end
       RUBY
-      inspect_source(cop, source)
+      inspect_source(source)
 
       expect(cop.messages).to eq([described_class::ASSIGN_TO_CONDITION_MSG])
     end
@@ -53,7 +53,7 @@ describe RuboCop::Cop::Style::ConditionalAssignment do
                         something_else
                       end
       RUBY
-      inspect_source(cop, source)
+      inspect_source(source)
 
       expect(cop.messages).to eq([described_class::ASSIGN_TO_CONDITION_MSG])
     end
@@ -67,7 +67,7 @@ describe RuboCop::Cop::Style::ConditionalAssignment do
           #{variable}, #{variable} = something_else
         end
       RUBY
-      inspect_source(cop, source)
+      inspect_source(source)
 
       expect(cop.messages).to be_empty
     end
@@ -80,7 +80,7 @@ describe RuboCop::Cop::Style::ConditionalAssignment do
           #{variable} = 2
         end
       RUBY
-      inspect_source(cop, source)
+      inspect_source(source)
 
       expect(cop.offenses).to be_empty
     end
@@ -91,7 +91,7 @@ describe RuboCop::Cop::Style::ConditionalAssignment do
                         1
                       end
       RUBY
-      inspect_source(cop, source)
+      inspect_source(source)
 
       expect(cop.offenses).to be_empty
     end
@@ -104,7 +104,7 @@ describe RuboCop::Cop::Style::ConditionalAssignment do
                         2
                       end
       RUBY
-      inspect_source(cop, source)
+      inspect_source(source)
 
       expect(cop.messages).to eq([described_class::ASSIGN_TO_CONDITION_MSG])
     end
@@ -117,7 +117,7 @@ describe RuboCop::Cop::Style::ConditionalAssignment do
           #{variable} = 2
         end
       RUBY
-      inspect_source(cop, source)
+      inspect_source(source)
 
       expect(cop.offenses).to be_empty
     end
@@ -131,7 +131,7 @@ describe RuboCop::Cop::Style::ConditionalAssignment do
                         2
                       end
       RUBY
-      inspect_source(cop, source)
+      inspect_source(source)
 
       expect(cop.messages).to eq([described_class::ASSIGN_TO_CONDITION_MSG])
     end
@@ -145,7 +145,7 @@ describe RuboCop::Cop::Style::ConditionalAssignment do
           #{variable} = 2
         end
       RUBY
-      inspect_source(cop, source)
+      inspect_source(source)
 
       expect(cop.offenses).to be_empty
     end
@@ -158,7 +158,7 @@ describe RuboCop::Cop::Style::ConditionalAssignment do
           bar
         end
       RUBY
-      inspect_source(cop, source)
+      inspect_source(source)
 
       expect(cop.offenses).to be_empty
     end
@@ -241,7 +241,7 @@ describe RuboCop::Cop::Style::ConditionalAssignment do
 
   shared_examples 'all assignment types' do |assignment|
     it 'registers an offense for any assignment to ternary' do
-      inspect_source(cop, "bar #{assignment} (foo? ? 1 : 2)")
+      inspect_source("bar #{assignment} (foo? ? 1 : 2)")
 
       expect(cop.messages).to eq([described_class::ASSIGN_TO_CONDITION_MSG])
     end
@@ -254,7 +254,7 @@ describe RuboCop::Cop::Style::ConditionalAssignment do
                         2
                       end
       RUBY
-      inspect_source(cop, source)
+      inspect_source(source)
 
       expect(cop.messages).to eq([described_class::ASSIGN_TO_CONDITION_MSG])
     end
@@ -265,7 +265,7 @@ describe RuboCop::Cop::Style::ConditionalAssignment do
                         1
                       end
       RUBY
-      inspect_source(cop, source)
+      inspect_source(source)
 
       expect(cop.offenses).to be_empty
     end
@@ -278,7 +278,7 @@ describe RuboCop::Cop::Style::ConditionalAssignment do
                         2
                       end
       RUBY
-      inspect_source(cop, source)
+      inspect_source(source)
 
       expect(cop.messages).to eq([described_class::ASSIGN_TO_CONDITION_MSG])
     end
@@ -292,7 +292,7 @@ describe RuboCop::Cop::Style::ConditionalAssignment do
                         2
                       end
       RUBY
-      inspect_source(cop, source)
+      inspect_source(source)
 
       expect(cop.messages).to eq([described_class::ASSIGN_TO_CONDITION_MSG])
     end
@@ -377,7 +377,7 @@ describe RuboCop::Cop::Style::ConditionalAssignment do
                         2
                       end
       RUBY
-      inspect_source(cop, source)
+      inspect_source(source)
 
       expect(cop.messages).to eq(expected)
     end
@@ -392,7 +392,7 @@ describe RuboCop::Cop::Style::ConditionalAssignment do
                         2
                       end
       RUBY
-      inspect_source(cop, source)
+      inspect_source(source)
 
       expect(cop.messages).to eq(expected)
     end
@@ -413,7 +413,7 @@ describe RuboCop::Cop::Style::ConditionalAssignment do
                         4
                       end
       RUBY
-      inspect_source(cop, source)
+      inspect_source(source)
 
       expect(cop.messages).to eq(expected)
     end
@@ -428,7 +428,7 @@ describe RuboCop::Cop::Style::ConditionalAssignment do
                         2
                       end
       RUBY
-      inspect_source(cop, source)
+      inspect_source(source)
 
       expect(cop.messages).to eq(expected)
     end
@@ -444,7 +444,7 @@ describe RuboCop::Cop::Style::ConditionalAssignment do
                         2
                       end
       RUBY
-      inspect_source(cop, source)
+      inspect_source(source)
 
       expect(cop.messages).to eq(expected)
     end
@@ -461,7 +461,7 @@ describe RuboCop::Cop::Style::ConditionalAssignment do
                         2
                       end
       RUBY
-      inspect_source(cop, source)
+      inspect_source(source)
 
       expect(cop.messages).to eq(expected)
     end
@@ -476,7 +476,7 @@ describe RuboCop::Cop::Style::ConditionalAssignment do
                         2
                       end
       RUBY
-      inspect_source(cop, source)
+      inspect_source(source)
 
       expect(cop.messages).to eq(expected)
     end
@@ -492,7 +492,7 @@ describe RuboCop::Cop::Style::ConditionalAssignment do
                         2
                       end
       RUBY
-      inspect_source(cop, source)
+      inspect_source(source)
 
       expect(cop.messages).to eq(expected)
     end
@@ -726,7 +726,7 @@ describe RuboCop::Cop::Style::ConditionalAssignment do
 
     it 'registers an offense for assignment using a method that ends with ' \
        'an equal sign' do
-      inspect_source(cop, 'self.attributes = foo? ? 1 : 2')
+      inspect_source('self.attributes = foo? ? 1 : 2')
 
       expect(cop.messages).to eq([described_class::ASSIGN_TO_CONDITION_MSG])
     end
@@ -739,7 +739,7 @@ describe RuboCop::Cop::Style::ConditionalAssignment do
                     2
                   end
       RUBY
-      inspect_source(cop, source)
+      inspect_source(source)
 
       expect(cop.messages).to eq([described_class::ASSIGN_TO_CONDITION_MSG])
     end
@@ -750,7 +750,7 @@ describe RuboCop::Cop::Style::ConditionalAssignment do
               else 2
               end
       RUBY
-      inspect_source(cop, source)
+      inspect_source(source)
 
       expect(cop.messages).to eq([described_class::ASSIGN_TO_CONDITION_MSG])
     end
@@ -762,7 +762,7 @@ describe RuboCop::Cop::Style::ConditionalAssignment do
               else 2
               end
       RUBY
-      inspect_source(cop, source)
+      inspect_source(source)
 
       expect(cop.messages).to eq([described_class::ASSIGN_TO_CONDITION_MSG])
     end

--- a/spec/rubocop/cop/style/conditional_assignment_assign_to_condition_spec.rb
+++ b/spec/rubocop/cop/style/conditional_assignment_assign_to_condition_spec.rb
@@ -64,7 +64,7 @@ describe RuboCop::Cop::Style::ConditionalAssignment do
 
   it 'registers an offense for assignment in ternary operation' do
     source = 'foo? ? bar = "a" : bar = "b"'
-    inspect_source(cop, source)
+    inspect_source(source)
 
     expect(cop.messages).to eq([message])
   end
@@ -94,7 +94,7 @@ describe RuboCop::Cop::Style::ConditionalAssignment do
       end
     RUBY
 
-    inspect_source(cop, source)
+    inspect_source(source)
 
     expect(cop.offenses.size).to eq(1)
   end
@@ -109,7 +109,7 @@ describe RuboCop::Cop::Style::ConditionalAssignment do
         end
       RUBY
 
-      inspect_source(cop, source)
+      inspect_source(source)
 
       expect(cop.messages).to eq([message])
     end
@@ -123,7 +123,7 @@ describe RuboCop::Cop::Style::ConditionalAssignment do
         end
       RUBY
 
-      inspect_source(cop, source)
+      inspect_source(source)
 
       expect(cop.messages).to eq([message])
     end
@@ -138,7 +138,7 @@ describe RuboCop::Cop::Style::ConditionalAssignment do
         end
       RUBY
 
-      inspect_source(cop, source)
+      inspect_source(source)
 
       expect(cop.messages).to eq([message])
     end
@@ -354,7 +354,7 @@ describe RuboCop::Cop::Style::ConditionalAssignment do
       end
     RUBY
 
-    inspect_source(cop, source)
+    inspect_source(source)
 
     expect(cop.messages).to eq([message])
   end
@@ -371,7 +371,7 @@ describe RuboCop::Cop::Style::ConditionalAssignment do
         end
       RUBY
 
-      inspect_source(cop, source)
+      inspect_source(source)
 
       expect(cop.offenses).to be_empty
     end
@@ -386,7 +386,7 @@ describe RuboCop::Cop::Style::ConditionalAssignment do
         end
       RUBY
 
-      inspect_source(cop, source)
+      inspect_source(source)
 
       expect(cop.offenses).to be_empty
     end
@@ -403,7 +403,7 @@ describe RuboCop::Cop::Style::ConditionalAssignment do
         end
       RUBY
 
-      inspect_source(cop, source)
+      inspect_source(source)
 
       expect(cop.offenses).to be_empty
     end
@@ -411,7 +411,7 @@ describe RuboCop::Cop::Style::ConditionalAssignment do
 
   shared_examples 'all variable types' do |variable|
     it 'registers an offense assigning any variable type in ternary' do
-      inspect_source(cop, "foo? ? #{variable} = 1 : #{variable} = 2")
+      inspect_source("foo? ? #{variable} = 1 : #{variable} = 2")
 
       expect(cop.messages).to eq([message])
     end
@@ -424,7 +424,7 @@ describe RuboCop::Cop::Style::ConditionalAssignment do
           #{variable} = 2
         end
       RUBY
-      inspect_source(cop, source)
+      inspect_source(source)
 
       expect(cop.messages).to eq([message])
     end
@@ -438,7 +438,7 @@ describe RuboCop::Cop::Style::ConditionalAssignment do
           #{variable} = 2
         end
       RUBY
-      inspect_source(cop, source)
+      inspect_source(source)
 
       expect(cop.messages).to eq([message])
     end
@@ -451,7 +451,7 @@ describe RuboCop::Cop::Style::ConditionalAssignment do
                         2
                       end
       RUBY
-      inspect_source(cop, source)
+      inspect_source(source)
 
       expect(cop.offenses).to be_empty
     end
@@ -465,13 +465,13 @@ describe RuboCop::Cop::Style::ConditionalAssignment do
                         2
                       end
       RUBY
-      inspect_source(cop, source)
+      inspect_source(source)
 
       expect(cop.offenses).to be_empty
     end
 
     it 'allows assignment to the return of a ternary' do
-      inspect_source(cop, "#{variable} = foo? ? 1 : 2")
+      inspect_source("#{variable} = foo? ? 1 : 2")
 
       expect(cop.offenses).to be_empty
     end
@@ -495,14 +495,14 @@ describe RuboCop::Cop::Style::ConditionalAssignment do
         it "registers an offense for assignment using #{assignment} " \
            'in ternary' do
           source = "foo? ? #{name} #{assignment} 1 : #{name} #{assignment} 2"
-          inspect_source(cop, source)
+          inspect_source(source)
 
           expect(cop.messages).to eq([message])
         end
 
         it "allows assignment using #{assignment} to ternary" do
           source = "#{name} #{assignment} foo? ? 1 : 2"
-          inspect_source(cop, source)
+          inspect_source(source)
 
           expect(cop.offenses).to be_empty
         end
@@ -516,7 +516,7 @@ describe RuboCop::Cop::Style::ConditionalAssignment do
               #{name} #{assignment} 2
             end
           RUBY
-          inspect_source(cop, source)
+          inspect_source(source)
 
           expect(cop.messages).to eq([message])
         end
@@ -531,7 +531,7 @@ describe RuboCop::Cop::Style::ConditionalAssignment do
               #{name} #{assignment} 2
             end
           RUBY
-          inspect_source(cop, source)
+          inspect_source(source)
 
           expect(cop.messages).to eq([message])
         end
@@ -591,7 +591,7 @@ describe RuboCop::Cop::Style::ConditionalAssignment do
         bar = 3
       end
     RUBY
-    inspect_source(cop, source)
+    inspect_source(source)
 
     expect(cop.messages).to eq([message])
   end
@@ -608,7 +608,7 @@ describe RuboCop::Cop::Style::ConditionalAssignment do
         bar = 4
       end
     RUBY
-    inspect_source(cop, source)
+    inspect_source(source)
 
     expect(cop.messages).to eq([message])
   end
@@ -631,7 +631,7 @@ describe RuboCop::Cop::Style::ConditionalAssignment do
         foo = { }
       end
     RUBY
-    inspect_source(cop, source)
+    inspect_source(source)
 
     expect(cop.messages).to eq([message])
   end
@@ -762,7 +762,7 @@ describe RuboCop::Cop::Style::ConditionalAssignment do
           bar = 3
         end
       RUBY
-      inspect_source(cop, source)
+      inspect_source(source)
 
       expect(cop.offenses).to be_empty
     end
@@ -783,7 +783,7 @@ describe RuboCop::Cop::Style::ConditionalAssignment do
           bar = 3
         end
       RUBY
-      inspect_source(cop, source)
+      inspect_source(source)
 
       expect(cop.offenses).to be_empty
     end
@@ -861,7 +861,7 @@ describe RuboCop::Cop::Style::ConditionalAssignment do
           bar = 3
         end
       RUBY
-      inspect_source(cop, source)
+      inspect_source(source)
 
       expect(cop.offenses).to be_empty
     end
@@ -882,7 +882,7 @@ describe RuboCop::Cop::Style::ConditionalAssignment do
           bar = 3
         end
       RUBY
-      inspect_source(cop, source)
+      inspect_source(source)
 
       expect(cop.offenses).to be_empty
     end
@@ -903,7 +903,7 @@ describe RuboCop::Cop::Style::ConditionalAssignment do
           bar = 4
         end
       RUBY
-      inspect_source(cop, source)
+      inspect_source(source)
 
       expect(cop.offenses).to be_empty
     end
@@ -919,7 +919,7 @@ describe RuboCop::Cop::Style::ConditionalAssignment do
           bar = 2
         end
       RUBY
-      inspect_source(cop, source)
+      inspect_source(source)
 
       expect(cop.offenses).to be_empty
     end
@@ -937,7 +937,7 @@ describe RuboCop::Cop::Style::ConditionalAssignment do
         end
       RUBY
 
-      inspect_source(cop, source)
+      inspect_source(source)
 
       expect(cop.offenses).to be_empty
     end
@@ -996,7 +996,7 @@ describe RuboCop::Cop::Style::ConditionalAssignment do
       else bar = 2
       end
     RUBY
-    inspect_source(cop, source)
+    inspect_source(source)
 
     expect(cop.messages).to eq([message])
   end
@@ -1009,7 +1009,7 @@ describe RuboCop::Cop::Style::ConditionalAssignment do
         bar = 2
       end
     RUBY
-    inspect_source(cop, source)
+    inspect_source(source)
 
     expect(cop.messages).to eq([message])
   end
@@ -1021,7 +1021,7 @@ describe RuboCop::Cop::Style::ConditionalAssignment do
       else baz = 2
       end
     RUBY
-    inspect_source(cop, source)
+    inspect_source(source)
 
     expect(cop.messages).to eq([message])
   end
@@ -1037,7 +1037,7 @@ describe RuboCop::Cop::Style::ConditionalAssignment do
         bar = 3
       end
     RUBY
-    inspect_source(cop, source)
+    inspect_source(source)
 
     expect(cop.messages).to eq([message])
   end
@@ -1062,7 +1062,7 @@ describe RuboCop::Cop::Style::ConditionalAssignment do
         bar << 2 if foobar
       end
     RUBY
-    inspect_source(cop, source)
+    inspect_source(source)
 
     expect(cop.offenses).to be_empty
   end
@@ -1725,7 +1725,7 @@ describe RuboCop::Cop::Style::ConditionalAssignment do
             bar = 2
           end
         RUBY
-        inspect_source(cop, source)
+        inspect_source(source)
 
         expect(cop.messages).to eq([message])
       end
@@ -1744,7 +1744,7 @@ describe RuboCop::Cop::Style::ConditionalAssignment do
             bar = 3
           end
         RUBY
-        inspect_source(cop, source)
+        inspect_source(source)
 
         expect(cop.messages).to eq([message])
       end
@@ -1759,7 +1759,7 @@ describe RuboCop::Cop::Style::ConditionalAssignment do
             bar = 2
           end
         RUBY
-        inspect_source(cop, source)
+        inspect_source(source)
 
         expect(cop.messages).to eq([message])
       end
@@ -1777,7 +1777,7 @@ describe RuboCop::Cop::Style::ConditionalAssignment do
             bar = 3
           end
         RUBY
-        inspect_source(cop, source)
+        inspect_source(source)
 
         expect(cop.messages).to eq([message])
       end
@@ -1798,7 +1798,7 @@ describe RuboCop::Cop::Style::ConditionalAssignment do
             bar = 4
           end
         RUBY
-        inspect_source(cop, source)
+        inspect_source(source)
 
         expect(cop.messages).to eq([message])
       end
@@ -1828,7 +1828,7 @@ describe RuboCop::Cop::Style::ConditionalAssignment do
             bar = 2
           end
         RUBY
-        inspect_source(cop, source)
+        inspect_source(source)
 
         expect(cop.messages).to eq([message])
       end
@@ -1844,7 +1844,7 @@ describe RuboCop::Cop::Style::ConditionalAssignment do
             bar = 3
           end
         RUBY
-        inspect_source(cop, source)
+        inspect_source(source)
 
         expect(cop.messages).to eq([message])
       end
@@ -1863,7 +1863,7 @@ describe RuboCop::Cop::Style::ConditionalAssignment do
             bar = 3
           end
         RUBY
-        inspect_source(cop, source)
+        inspect_source(source)
 
         expect(cop.messages).to eq([message])
       end
@@ -1884,7 +1884,7 @@ describe RuboCop::Cop::Style::ConditionalAssignment do
             bar = 4
           end
         RUBY
-        inspect_source(cop, source)
+        inspect_source(source)
 
         expect(cop.messages).to eq([message])
       end
@@ -1900,7 +1900,7 @@ describe RuboCop::Cop::Style::ConditionalAssignment do
             bar = 2
           end
         RUBY
-        inspect_source(cop, source)
+        inspect_source(source)
 
         expect(cop.messages).to eq([message])
       end
@@ -1918,7 +1918,7 @@ describe RuboCop::Cop::Style::ConditionalAssignment do
           end
         RUBY
 
-        inspect_source(cop, source)
+        inspect_source(source)
 
         expect(cop.messages).to eq([message])
       end
@@ -1937,7 +1937,7 @@ describe RuboCop::Cop::Style::ConditionalAssignment do
               bar = 3
             end
           RUBY
-          inspect_source(cop, source)
+          inspect_source(source)
 
           expect(cop.offenses.size).to eq(1)
         end
@@ -1955,7 +1955,7 @@ describe RuboCop::Cop::Style::ConditionalAssignment do
               bar = 3
             end
           RUBY
-          inspect_source(cop, source)
+          inspect_source(source)
 
           expect(cop.offenses.size).to eq(1)
         end
@@ -1973,7 +1973,7 @@ describe RuboCop::Cop::Style::ConditionalAssignment do
               bar = 3
             end
           RUBY
-          inspect_source(cop, source)
+          inspect_source(source)
 
           expect(cop.offenses.size).to eq(1)
         end
@@ -1991,7 +1991,7 @@ describe RuboCop::Cop::Style::ConditionalAssignment do
           bar << 4 if foobar
         end
       RUBY
-      inspect_source(cop, source)
+      inspect_source(source)
 
       expect(cop.offenses).to be_empty
     end
@@ -2007,7 +2007,7 @@ describe RuboCop::Cop::Style::ConditionalAssignment do
           bar << 4
         end
       RUBY
-      inspect_source(cop, source)
+      inspect_source(source)
 
       expect(cop.messages).to eq([message])
     end

--- a/spec/rubocop/cop/style/conditional_assignment_assign_to_condition_spec.rb
+++ b/spec/rubocop/cop/style/conditional_assignment_assign_to_condition_spec.rb
@@ -544,7 +544,7 @@ describe RuboCop::Cop::Style::ConditionalAssignment do
               #{name} #{assignment} 2
             end
           RUBY
-          new_source = autocorrect_source(cop, source)
+          new_source = autocorrect_source(source)
 
           indent = ' ' * "#{name} #{assignment} ".length
           expect(new_source).to eq <<-RUBY.strip_indent
@@ -654,7 +654,7 @@ describe RuboCop::Cop::Style::ConditionalAssignment do
         foo = { }
       end
     RUBY
-    new_source = autocorrect_source(cop, source)
+    new_source = autocorrect_source(source)
 
     expect(new_source).to eq(<<-RUBY.strip_indent)
       foo = if foo
@@ -1080,7 +1080,7 @@ describe RuboCop::Cop::Style::ConditionalAssignment do
           end
         RUBY
 
-        new_source = autocorrect_source(cop, source)
+        new_source = autocorrect_source(source)
 
         indent = ' ' * "a #{method} ".length
         expect(new_source).to eq(<<-RUBY.strip_indent)
@@ -1103,7 +1103,7 @@ describe RuboCop::Cop::Style::ConditionalAssignment do
           end
         RUBY
 
-        new_source = autocorrect_source(cop, source)
+        new_source = autocorrect_source(source)
 
         indent = ' ' * "a #{method} ".length
         expect(new_source).to eq(<<-RUBY.strip_indent)
@@ -1125,7 +1125,7 @@ describe RuboCop::Cop::Style::ConditionalAssignment do
           end
         RUBY
 
-        new_source = autocorrect_source(cop, source)
+        new_source = autocorrect_source(source)
 
         indent = ' ' * "a #{method} ".length
         expect(new_source).to eq(<<-RUBY.strip_indent)
@@ -1146,29 +1146,29 @@ describe RuboCop::Cop::Style::ConditionalAssignment do
     it_behaves_like('comparison correction', '<=>')
 
     it 'corrects assignment in ternary operations' do
-      new_source = autocorrect_source(cop, 'foo? ? bar = 1 : bar = 2')
+      new_source = autocorrect_source('foo? ? bar = 1 : bar = 2')
 
       expect(new_source).to eq('bar = foo? ? 1 : 2')
     end
 
     it 'corrects assignment in ternary operations using strings' do
-      new_source = autocorrect_source(cop, 'foo? ? bar = "1" : bar = "2"')
+      new_source = autocorrect_source('foo? ? bar = "1" : bar = "2"')
 
       expect(new_source).to eq('bar = foo? ? "1" : "2"')
     end
 
     it 'corrects =~ in ternary operations' do
-      new_source = autocorrect_source(cop, 'foo? ? bar =~ /a/ : bar =~ /b/')
+      new_source = autocorrect_source('foo? ? bar =~ /a/ : bar =~ /b/')
       expect(new_source).to eq('bar =~ (foo? ? /a/ : /b/)')
     end
 
     it 'corrects aref assignment in ternary operations' do
-      new_source = autocorrect_source(cop, 'foo? ? bar[1] = 1 : bar[1] = 2')
+      new_source = autocorrect_source('foo? ? bar[1] = 1 : bar[1] = 2')
       expect(new_source).to eq('bar[1] = foo? ? 1 : 2')
     end
 
     it 'corrects << in ternary operations' do
-      new_source = autocorrect_source(cop, 'foo? ? bar << 1 : bar << 2')
+      new_source = autocorrect_source('foo? ? bar << 1 : bar << 2')
       expect(new_source).to eq('bar << (foo? ? 1 : 2)')
     end
 
@@ -1181,7 +1181,7 @@ describe RuboCop::Cop::Style::ConditionalAssignment do
         end
       RUBY
 
-      new_source = autocorrect_source(cop, source)
+      new_source = autocorrect_source(source)
 
       expect(new_source).to eq(<<-RUBY.strip_indent)
         bar = if foo
@@ -1203,7 +1203,7 @@ describe RuboCop::Cop::Style::ConditionalAssignment do
         end
       RUBY
 
-      new_source = autocorrect_source(cop, source)
+      new_source = autocorrect_source(source)
 
       expect(new_source).to eq(<<-RUBY.strip_indent)
         bar = if foo
@@ -1228,7 +1228,7 @@ describe RuboCop::Cop::Style::ConditionalAssignment do
           end
         RUBY
 
-        new_source = autocorrect_source(cop, source)
+        new_source = autocorrect_source(source)
 
         expect(new_source).to eq(<<-RUBY.strip_indent)
           bar #{asgn} if foo
@@ -1251,7 +1251,7 @@ describe RuboCop::Cop::Style::ConditionalAssignment do
           end
         RUBY
 
-        new_source = autocorrect_source(cop, source)
+        new_source = autocorrect_source(source)
 
         expect(new_source).to eq(<<-RUBY.strip_indent)
           baz #{asgn} case foo
@@ -1272,7 +1272,7 @@ describe RuboCop::Cop::Style::ConditionalAssignment do
           end
         RUBY
 
-        new_source = autocorrect_source(cop, source)
+        new_source = autocorrect_source(source)
 
         expect(new_source).to eq(<<-RUBY.strip_indent)
           bar #{asgn} unless foo
@@ -1300,7 +1300,7 @@ describe RuboCop::Cop::Style::ConditionalAssignment do
           end
         RUBY
 
-        new_source = autocorrect_source(cop, source)
+        new_source = autocorrect_source(source)
 
         expect(new_source).to eq(<<-RUBY.strip_indent)
           bar #{asgn} if foo
@@ -1323,7 +1323,7 @@ describe RuboCop::Cop::Style::ConditionalAssignment do
           end
         RUBY
 
-        new_source = autocorrect_source(cop, source)
+        new_source = autocorrect_source(source)
 
         expect(new_source).to eq(<<-RUBY.strip_indent)
           baz #{asgn} case foo
@@ -1344,7 +1344,7 @@ describe RuboCop::Cop::Style::ConditionalAssignment do
           end
         RUBY
 
-        new_source = autocorrect_source(cop, source)
+        new_source = autocorrect_source(source)
 
         expect(new_source).to eq(<<-RUBY.strip_indent)
           bar #{asgn} unless foo
@@ -1372,7 +1372,7 @@ describe RuboCop::Cop::Style::ConditionalAssignment do
         end
       RUBY
 
-      new_source = autocorrect_source(cop, source)
+      new_source = autocorrect_source(source)
 
       expect(new_source).to eq(<<-RUBY.strip_indent)
         bar = if foo
@@ -1396,7 +1396,7 @@ describe RuboCop::Cop::Style::ConditionalAssignment do
         end
       RUBY
 
-      new_source = autocorrect_source(cop, source)
+      new_source = autocorrect_source(source)
 
       expect(new_source).to eq(<<-RUBY.strip_indent)
         bar = unless foo
@@ -1417,7 +1417,7 @@ describe RuboCop::Cop::Style::ConditionalAssignment do
         end
       RUBY
 
-      new_source = autocorrect_source(cop, source)
+      new_source = autocorrect_source(source)
 
       expect(new_source).to eq(<<-RUBY.strip_indent)
         baz = case foo
@@ -1441,7 +1441,7 @@ describe RuboCop::Cop::Style::ConditionalAssignment do
         end
       RUBY
 
-      new_source = autocorrect_source(cop, source)
+      new_source = autocorrect_source(source)
 
       expect(new_source).to eq(<<-RUBY.strip_indent)
         baz = case foo
@@ -1465,7 +1465,7 @@ describe RuboCop::Cop::Style::ConditionalAssignment do
           end
         RUBY
 
-        new_source = autocorrect_source(cop, source)
+        new_source = autocorrect_source(source)
 
         expect(new_source).to eq(<<-RUBY.strip_indent)
           bar << if foo?(scope.node)
@@ -1485,7 +1485,7 @@ describe RuboCop::Cop::Style::ConditionalAssignment do
           end
         RUBY
 
-        new_source = autocorrect_source(cop, source)
+        new_source = autocorrect_source(source)
 
         expect(new_source).to eq(<<-RUBY.strip_indent)
           bar << unless foo?(scope.node)
@@ -1506,7 +1506,7 @@ describe RuboCop::Cop::Style::ConditionalAssignment do
           end
         RUBY
 
-        new_source = autocorrect_source(cop, source)
+        new_source = autocorrect_source(source)
 
         expect(new_source).to eq(<<-RUBY.strip_indent)
           bar << case foo
@@ -1528,7 +1528,7 @@ describe RuboCop::Cop::Style::ConditionalAssignment do
           end
         RUBY
 
-        new_source = autocorrect_source(cop, source)
+        new_source = autocorrect_source(source)
 
         expect(new_source).to eq(<<-RUBY.strip_indent)
           bar = if cond then 1
@@ -1546,7 +1546,7 @@ describe RuboCop::Cop::Style::ConditionalAssignment do
           end
         RUBY
 
-        new_source = autocorrect_source(cop, source)
+        new_source = autocorrect_source(source)
 
         expect(new_source).to eq(<<-RUBY.strip_indent)
           bar = case foo
@@ -1568,7 +1568,7 @@ describe RuboCop::Cop::Style::ConditionalAssignment do
         end
       RUBY
 
-      new_source = autocorrect_source(cop, source)
+      new_source = autocorrect_source(source)
 
       expect(new_source).to eq(<<-RUBY.strip_indent)
         bar = if foo
@@ -1593,7 +1593,7 @@ describe RuboCop::Cop::Style::ConditionalAssignment do
         end
       RUBY
 
-      new_source = autocorrect_source(cop, source)
+      new_source = autocorrect_source(source)
 
       expect(new_source).to eq(<<-RUBY.strip_indent)
         bar = case foo
@@ -1609,7 +1609,7 @@ describe RuboCop::Cop::Style::ConditionalAssignment do
 
     context 'aref assignment' do
       it 'corrects if..else' do
-        new_source = autocorrect_source(cop, <<-RUBY.strip_indent)
+        new_source = autocorrect_source(<<-RUBY.strip_indent)
           if something
             array[1] = 1
           else
@@ -1640,7 +1640,7 @@ describe RuboCop::Cop::Style::ConditionalAssignment do
 
     context 'self.attribute= assignment' do
       it 'corrects if..else' do
-        new_source = autocorrect_source(cop, <<-RUBY.strip_indent)
+        new_source = autocorrect_source(<<-RUBY.strip_indent)
           if something
             self.attribute = 1
           else
@@ -2023,7 +2023,7 @@ describe RuboCop::Cop::Style::ConditionalAssignment do
             bar = 3
           end
         RUBY
-        new_source = autocorrect_source(cop, source)
+        new_source = autocorrect_source(source)
 
         expect(new_source).to eq(<<-RUBY.strip_indent)
           bar = if foo
@@ -2049,7 +2049,7 @@ describe RuboCop::Cop::Style::ConditionalAssignment do
             bar = 3
           end
         RUBY
-        new_source = autocorrect_source(cop, source)
+        new_source = autocorrect_source(source)
 
         expect(new_source).to eq(<<-RUBY.strip_indent)
           bar = if foo
@@ -2081,7 +2081,7 @@ describe RuboCop::Cop::Style::ConditionalAssignment do
             bar = 4
           end
         RUBY
-        new_source = autocorrect_source(cop, source)
+        new_source = autocorrect_source(source)
 
         expect(new_source).to eq(<<-RUBY.strip_indent)
           bar = if foo
@@ -2111,7 +2111,7 @@ describe RuboCop::Cop::Style::ConditionalAssignment do
             bar = 2
           end
         RUBY
-        new_source = autocorrect_source(cop, source)
+        new_source = autocorrect_source(source)
 
         expect(new_source).to eq(<<-RUBY.strip_indent)
           bar = case foo
@@ -2139,7 +2139,7 @@ describe RuboCop::Cop::Style::ConditionalAssignment do
             bar = 3
           end
         RUBY
-        new_source = autocorrect_source(cop, source)
+        new_source = autocorrect_source(source)
 
         expect(new_source).to eq(<<-RUBY.strip_indent)
           bar = case foo
@@ -2166,7 +2166,7 @@ describe RuboCop::Cop::Style::ConditionalAssignment do
             bar = 2
           end
         RUBY
-        new_source = autocorrect_source(cop, source)
+        new_source = autocorrect_source(source)
 
         expect(new_source).to eq(<<-RUBY.strip_indent)
           bar = unless foo
@@ -2195,7 +2195,7 @@ describe RuboCop::Cop::Style::ConditionalAssignment do
           end
         RUBY
 
-        new_source = autocorrect_source(cop, source)
+        new_source = autocorrect_source(source)
 
         expect(new_source).to eq(<<-RUBY.strip_indent)
           unless foo
@@ -2243,7 +2243,7 @@ describe RuboCop::Cop::Style::ConditionalAssignment do
             end
           RUBY
 
-          new_source = autocorrect_source(cop, source)
+          new_source = autocorrect_source(source)
 
           expect(new_source).to eq(<<-RUBY.strip_indent)
             a = if foo
@@ -2265,7 +2265,7 @@ describe RuboCop::Cop::Style::ConditionalAssignment do
             end
           RUBY
 
-          new_source = autocorrect_source(cop, source)
+          new_source = autocorrect_source(source)
 
           expect(new_source).to eq(<<-RUBY.strip_indent)
             a = unless foo
@@ -2288,7 +2288,7 @@ describe RuboCop::Cop::Style::ConditionalAssignment do
             end
           RUBY
 
-          new_source = autocorrect_source(cop, source)
+          new_source = autocorrect_source(source)
 
           expect(new_source).to eq(<<-RUBY.strip_indent)
             a = case foo

--- a/spec/rubocop/cop/style/copyright_spec.rb
+++ b/spec/rubocop/cop/style/copyright_spec.rb
@@ -5,12 +5,12 @@ def unindent(s)
 end
 
 def expect_no_copyright_offense(cop, source)
-  inspect_source(cop, source)
+  inspect_source(source)
   expect(cop.offenses).to be_empty
 end
 
 def expect_copyright_offense(cop, source)
-  inspect_source(cop, source)
+  inspect_source(source)
   expect(cop.offenses.size).to eq(1)
 end
 

--- a/spec/rubocop/cop/style/copyright_spec.rb
+++ b/spec/rubocop/cop/style/copyright_spec.rb
@@ -78,7 +78,7 @@ describe RuboCop::Cop::Style::Copyright, :config do
 
     it 'correctly autocorrects the source code' do
       cop_config['AutocorrectNotice'] = '# Copyright (c) 2015 Acme Inc.'
-      autocorrected_source = autocorrect_source(cop, source)
+      autocorrected_source = autocorrect_source(source)
       expect(autocorrected_source).to eq(expected_autocorrected_source)
     end
 
@@ -86,14 +86,14 @@ describe RuboCop::Cop::Style::Copyright, :config do
        'not match the Notice pattern' do
       cop_config['AutocorrectNotice'] = '# Copyleft (c) 2015 Acme Inc.'
       expect do
-        autocorrect_source(cop, source)
+        autocorrect_source(source)
       end.to raise_error(RuboCop::Warning)
     end
 
     it 'fails to autocorrect if no AutocorrectNotice is given' do
       # cop_config['AutocorrectNotice'] = '# Copyleft (c) 2015 Acme Inc.'
       expect do
-        autocorrect_source(cop, source)
+        autocorrect_source(source)
       end.to raise_error(RuboCop::Warning)
     end
   end
@@ -120,7 +120,7 @@ describe RuboCop::Cop::Style::Copyright, :config do
 
     it 'correctly autocorrects the source code' do
       cop_config['AutocorrectNotice'] = '# Copyright (c) 2015 Acme Inc.'
-      autocorrected_source = autocorrect_source(cop, source)
+      autocorrected_source = autocorrect_source(source)
       expect(autocorrected_source).to eq(expected_autocorrected_source)
     end
   end
@@ -136,7 +136,7 @@ describe RuboCop::Cop::Style::Copyright, :config do
 
     it 'correctly autocorrects the source code' do
       cop_config['AutocorrectNotice'] = '# Copyright (c) 2015 Acme Inc.'
-      autocorrected_source = autocorrect_source(cop, source)
+      autocorrected_source = autocorrect_source(source)
       expect(autocorrected_source).to eq(expected_autocorrected_source)
     end
   end
@@ -162,7 +162,7 @@ describe RuboCop::Cop::Style::Copyright, :config do
 
     it 'correctly autocorrects the source code' do
       cop_config['AutocorrectNotice'] = '# Copyright (c) 2015 Acme Inc.'
-      autocorrected_source = autocorrect_source(cop, source)
+      autocorrected_source = autocorrect_source(source)
       expect(autocorrected_source).to eq(expected_autocorrected_source)
     end
   end
@@ -188,7 +188,7 @@ describe RuboCop::Cop::Style::Copyright, :config do
 
     it 'correctly autocorrects the source code' do
       cop_config['AutocorrectNotice'] = '# Copyright (c) 2015 Acme Inc.'
-      autocorrected_source = autocorrect_source(cop, source)
+      autocorrected_source = autocorrect_source(source)
       expect(autocorrected_source).to eq(expected_autocorrected_source)
     end
   end
@@ -217,7 +217,7 @@ describe RuboCop::Cop::Style::Copyright, :config do
 
     it 'correctly autocorrects the source code' do
       cop_config['AutocorrectNotice'] = '# Copyright (c) 2015 Acme Inc.'
-      autocorrected_source = autocorrect_source(cop, source)
+      autocorrected_source = autocorrect_source(source)
       expect(autocorrected_source).to eq(expected_autocorrected_source)
     end
   end

--- a/spec/rubocop/cop/style/def_with_parentheses_spec.rb
+++ b/spec/rubocop/cop/style/def_with_parentheses_spec.rb
@@ -33,7 +33,7 @@ describe RuboCop::Cop::Style::DefWithParentheses do
   end
 
   it 'auto-removes unneeded parens' do
-    new_source = autocorrect_source(cop, <<-RUBY.strip_indent)
+    new_source = autocorrect_source(<<-RUBY.strip_indent)
       def test();
       something
       end

--- a/spec/rubocop/cop/style/def_with_parentheses_spec.rb
+++ b/spec/rubocop/cop/style/def_with_parentheses_spec.rb
@@ -8,7 +8,7 @@ describe RuboCop::Cop::Style::DefWithParentheses do
       def func()
       end
     RUBY
-    inspect_source(cop, src)
+    inspect_source(src)
     expect(cop.offenses.size).to eq(1)
   end
 
@@ -17,7 +17,7 @@ describe RuboCop::Cop::Style::DefWithParentheses do
       def Test.func()
       end
     RUBY
-    inspect_source(cop, src)
+    inspect_source(src)
     expect(cop.offenses.size).to eq(1)
   end
 

--- a/spec/rubocop/cop/style/documentation_method_spec.rb
+++ b/spec/rubocop/cop/style/documentation_method_spec.rb
@@ -4,7 +4,7 @@ describe RuboCop::Cop::Style::DocumentationMethod, :config do
   subject(:cop) { described_class.new(config) }
 
   before do
-    inspect_source(cop, source)
+    inspect_source(source)
   end
 
   shared_examples 'code with offense' do |code|

--- a/spec/rubocop/cop/style/documentation_spec.rb
+++ b/spec/rubocop/cop/style/documentation_spec.rb
@@ -20,7 +20,7 @@ describe RuboCop::Cop::Style::Documentation do
 
   it 'does not consider comment followed by empty line to be class ' \
      'documentation' do
-    inspect_source(cop, <<-RUBY.strip_indent)
+    inspect_source(<<-RUBY.strip_indent)
       # Copyright 2014
       # Some company
 
@@ -108,7 +108,7 @@ describe RuboCop::Cop::Style::Documentation do
 
   it 'accepts non-empty class with annotation comment followed by other ' \
      'comment' do
-    inspect_source(cop, <<-RUBY.strip_indent)
+    inspect_source(<<-RUBY.strip_indent)
       # OPTIMIZE: Make this faster.
       # Class comment.
       class My_Class
@@ -189,7 +189,7 @@ describe RuboCop::Cop::Style::Documentation do
 
   it 'does not raise an error for an implicit match conditional' do
     expect do
-      inspect_source(cop, <<-RUBY.strip_indent)
+      inspect_source(<<-RUBY.strip_indent)
         class Test
           if //
           end
@@ -214,7 +214,7 @@ describe RuboCop::Cop::Style::Documentation do
   context 'sparse and trailing comments' do
     %w[class module].each do |keyword|
       it "ignores comments after #{keyword} node end" do
-        inspect_source(cop, <<-RUBY.strip_indent)
+        inspect_source(<<-RUBY.strip_indent)
           module TestModule
             # documentation comment
             #{keyword} Test
@@ -227,7 +227,7 @@ describe RuboCop::Cop::Style::Documentation do
       end
 
       it "ignores sparse comments inside #{keyword} node" do
-        inspect_source(cop, <<-RUBY.strip_indent)
+        inspect_source(<<-RUBY.strip_indent)
           module TestModule
             #{keyword} Test
               def method
@@ -244,7 +244,7 @@ describe RuboCop::Cop::Style::Documentation do
   context 'with # :nodoc:' do
     %w[class module].each do |keyword|
       it "accepts non-namespace #{keyword} without documentation" do
-        inspect_source(cop, <<-RUBY.strip_indent)
+        inspect_source(<<-RUBY.strip_indent)
           #{keyword} Test #:nodoc:
             def method
             end
@@ -254,7 +254,7 @@ describe RuboCop::Cop::Style::Documentation do
       end
 
       it "registers an offense for nested #{keyword} without documentation" do
-        inspect_source(cop, <<-RUBY.strip_indent)
+        inspect_source(<<-RUBY.strip_indent)
           module TestModule #:nodoc:
             TEST = 20
             #{keyword} Test
@@ -268,7 +268,7 @@ describe RuboCop::Cop::Style::Documentation do
 
       context 'with `all` modifier' do
         it "accepts nested #{keyword} without documentation" do
-          inspect_source(cop, <<-RUBY.strip_indent)
+          inspect_source(<<-RUBY.strip_indent)
             module A #:nodoc: all
               module B
                 TEST = 20

--- a/spec/rubocop/cop/style/each_for_simple_loop_spec.rb
+++ b/spec/rubocop/cop/style/each_for_simple_loop_spec.rb
@@ -61,12 +61,12 @@ describe RuboCop::Cop::Style::EachForSimpleLoop do
 
   context 'when using an inclusive range' do
     it 'autocorrects the source with inline block' do
-      corrected = autocorrect_source(cop, '(0..10).each {}')
+      corrected = autocorrect_source('(0..10).each {}')
       expect(corrected).to eq '11.times {}'
     end
 
     it 'autocorrects the source with multiline block' do
-      corrected = autocorrect_source(cop, <<-RUBY.strip_indent)
+      corrected = autocorrect_source(<<-RUBY.strip_indent)
         (0..10).each do
         end
       RUBY
@@ -78,7 +78,7 @@ describe RuboCop::Cop::Style::EachForSimpleLoop do
     end
 
     it 'autocorrects the range not starting with zero' do
-      corrected = autocorrect_source(cop, <<-RUBY.strip_indent)
+      corrected = autocorrect_source(<<-RUBY.strip_indent)
         (3..7).each do
         end
       RUBY
@@ -94,19 +94,19 @@ describe RuboCop::Cop::Style::EachForSimpleLoop do
         (3..7).each do |n|
         end
       RUBY
-      corrected = autocorrect_source(cop, source)
+      corrected = autocorrect_source(source)
       expect(corrected).to eq(source)
     end
   end
 
   context 'when using an exclusive range' do
     it 'autocorrects the source with inline block' do
-      corrected = autocorrect_source(cop, '(0...10).each {}')
+      corrected = autocorrect_source('(0...10).each {}')
       expect(corrected).to eq '10.times {}'
     end
 
     it 'autocorrects the source with multiline block' do
-      corrected = autocorrect_source(cop, <<-RUBY.strip_indent)
+      corrected = autocorrect_source(<<-RUBY.strip_indent)
         (0...10).each do
         end
       RUBY
@@ -118,7 +118,7 @@ describe RuboCop::Cop::Style::EachForSimpleLoop do
     end
 
     it 'autocorrects the range not starting with zero' do
-      corrected = autocorrect_source(cop, <<-RUBY.strip_indent)
+      corrected = autocorrect_source(<<-RUBY.strip_indent)
         (3...7).each do
         end
       RUBY
@@ -134,7 +134,7 @@ describe RuboCop::Cop::Style::EachForSimpleLoop do
         (3...7).each do |n|
         end
       RUBY
-      corrected = autocorrect_source(cop, source)
+      corrected = autocorrect_source(source)
       expect(corrected).to eq(source)
     end
   end

--- a/spec/rubocop/cop/style/each_with_object_spec.rb
+++ b/spec/rubocop/cop/style/each_with_object_spec.rb
@@ -18,7 +18,7 @@ describe RuboCop::Cop::Style::EachWithObject do
   end
 
   it 'correctly autocorrects' do
-    corrected = autocorrect_source(cop, <<-RUBY.strip_indent)
+    corrected = autocorrect_source(<<-RUBY.strip_indent)
       [1, 2, 3].inject({}) do |h, i|
         h[i] = i
         h
@@ -33,7 +33,7 @@ describe RuboCop::Cop::Style::EachWithObject do
   end
 
   it 'correctly autocorrects with return value only' do
-    corrected = autocorrect_source(cop, <<-RUBY.strip_indent)
+    corrected = autocorrect_source(<<-RUBY.strip_indent)
       [1, 2, 3].inject({}) do |h, i|
         h
       end

--- a/spec/rubocop/cop/style/empty_case_condition_spec.rb
+++ b/spec/rubocop/cop/style/empty_case_condition_spec.rb
@@ -14,7 +14,7 @@ describe RuboCop::Cop::Style::EmptyCaseCondition do
     end
 
     it 'correctly autocorrects' do
-      expect(autocorrect_source(cop, source)).to eq corrected_source
+      expect(autocorrect_source(source)).to eq corrected_source
     end
 
     let(:source_with_case) { source.sub(/case/, 'case :a') }

--- a/spec/rubocop/cop/style/empty_case_condition_spec.rb
+++ b/spec/rubocop/cop/style/empty_case_condition_spec.rb
@@ -9,7 +9,7 @@ describe RuboCop::Cop::Style::EmptyCaseCondition do
 
   shared_examples 'detect/correct empty case, accept non-empty case' do
     it 'registers an offense' do
-      inspect_source(cop, source)
+      inspect_source(source)
       expect(cop.messages).to eq [message]
     end
 
@@ -20,7 +20,7 @@ describe RuboCop::Cop::Style::EmptyCaseCondition do
     let(:source_with_case) { source.sub(/case/, 'case :a') }
 
     it 'accepts the source with case' do
-      inspect_source(cop, source_with_case)
+      inspect_source(source_with_case)
       expect(cop.messages).to be_empty
     end
   end

--- a/spec/rubocop/cop/style/empty_else_spec.rb
+++ b/spec/rubocop/cop/style/empty_else_spec.rb
@@ -34,12 +34,12 @@ describe RuboCop::Cop::Style::EmptyElse do
 
   shared_examples_for 'offense registration' do
     it 'registers an offense with correct message' do
-      inspect_source(cop, source)
+      inspect_source(source)
       expect(cop.messages).to eq(['Redundant `else`-clause.'])
     end
 
     it 'registers an offense with correct location' do
-      inspect_source(cop, source)
+      inspect_source(source)
       expect(cop.highlights).to eq(['else'])
     end
   end

--- a/spec/rubocop/cop/style/empty_else_spec.rb
+++ b/spec/rubocop/cop/style/empty_else_spec.rb
@@ -7,7 +7,7 @@ describe RuboCop::Cop::Style::EmptyElse do
   shared_examples 'auto-correct' do |keyword|
     context 'MissingElse is disabled' do
       it 'does auto-correction' do
-        expect(autocorrect_source(cop, source)).to eq(corrected_source)
+        expect(autocorrect_source(source)).to eq(corrected_source)
       end
     end
 
@@ -20,12 +20,12 @@ describe RuboCop::Cop::Style::EmptyElse do
 
         if ['both', keyword].include? missing_else_style
           it 'does not auto-correct' do
-            expect(autocorrect_source(cop, source)).to eq(source)
+            expect(autocorrect_source(source)).to eq(source)
             expect(cop.offenses.map(&:corrected?)).to eq [false]
           end
         else
           it 'does auto-correction' do
-            expect(autocorrect_source(cop, source)).to eq(corrected_source)
+            expect(autocorrect_source(source)).to eq(corrected_source)
           end
         end
       end

--- a/spec/rubocop/cop/style/empty_literal_spec.rb
+++ b/spec/rubocop/cop/style/empty_literal_spec.rb
@@ -23,13 +23,13 @@ describe RuboCop::Cop::Style::EmptyLiteral do
     end
 
     it 'auto-corrects Array.new to []' do
-      new_source = autocorrect_source(cop, 'test = Array.new')
+      new_source = autocorrect_source('test = Array.new')
       expect(new_source).to eq('test = []')
     end
 
     it 'auto-corrects Array.new in block in block' do
       source = 'puts { Array.new }'
-      new_source = autocorrect_source(cop, source)
+      new_source = autocorrect_source(source)
       expect(new_source).to eq 'puts { [] }'
     end
 
@@ -66,19 +66,19 @@ describe RuboCop::Cop::Style::EmptyLiteral do
     end
 
     it 'auto-corrects Hash.new to {}' do
-      new_source = autocorrect_source(cop, 'Hash.new')
+      new_source = autocorrect_source('Hash.new')
       expect(new_source).to eq('{}')
     end
 
     it 'auto-corrects Hash.new in block ' do
       source = 'puts { Hash.new }'
-      new_source = autocorrect_source(cop, source)
+      new_source = autocorrect_source(source)
       expect(new_source).to eq 'puts { {} }'
     end
 
     it 'auto-corrects Hash.new to {} in various contexts' do
       new_source =
-        autocorrect_source(cop, <<-RUBY.strip_indent)
+        autocorrect_source(<<-RUBY.strip_indent)
           test = Hash.new
           Hash.new.merge("a" => 3)
           yadayada.map { a }.reduce(Hash.new, :merge)
@@ -93,13 +93,13 @@ describe RuboCop::Cop::Style::EmptyLiteral do
 
     it 'auto-correct Hash.new to {} as the only parameter to a method' do
       source = 'yadayada.map { a }.reduce Hash.new'
-      new_source = autocorrect_source(cop, source)
+      new_source = autocorrect_source(source)
       expect(new_source).to eq('yadayada.map { a }.reduce({})')
     end
 
     it 'auto-correct Hash.new to {} as the first parameter to a method' do
       source = 'yadayada.map { a }.reduce Hash.new, :merge'
-      new_source = autocorrect_source(cop, source)
+      new_source = autocorrect_source(source)
       expect(new_source).to eq('yadayada.map { a }.reduce({}, :merge)')
     end
   end
@@ -124,7 +124,7 @@ describe RuboCop::Cop::Style::EmptyLiteral do
     end
 
     it 'auto-corrects String.new to empty string literal' do
-      new_source = autocorrect_source(cop, 'test = String.new')
+      new_source = autocorrect_source('test = String.new')
       expect(new_source).to eq("test = ''")
     end
 
@@ -147,7 +147,7 @@ describe RuboCop::Cop::Style::EmptyLiteral do
       end
 
       it 'auto-corrects String.new to a double-quoted empty string literal' do
-        new_source = autocorrect_source(cop, 'test = String.new')
+        new_source = autocorrect_source('test = String.new')
         expect(new_source).to eq('test = ""')
       end
     end

--- a/spec/rubocop/cop/style/empty_method_spec.rb
+++ b/spec/rubocop/cop/style/empty_method_spec.rb
@@ -18,11 +18,11 @@ describe RuboCop::Cop::Style::EmptyMethod, :config do
 
       if expected
         it 'auto-corrects' do
-          expect(autocorrect_source(cop, code)).to eq(expected)
+          expect(autocorrect_source(code)).to eq(expected)
         end
       else
         it 'does not auto-correct' do
-          expect(autocorrect_source(cop, code)).to eq(code)
+          expect(autocorrect_source(code)).to eq(code)
         end
       end
     end

--- a/spec/rubocop/cop/style/empty_method_spec.rb
+++ b/spec/rubocop/cop/style/empty_method_spec.rb
@@ -4,7 +4,7 @@ describe RuboCop::Cop::Style::EmptyMethod, :config do
   subject(:cop) { described_class.new(config) }
 
   before do
-    inspect_source(cop, source)
+    inspect_source(source)
   end
 
   shared_examples 'code with offense' do |code, expected|

--- a/spec/rubocop/cop/style/encoding_spec.rb
+++ b/spec/rubocop/cop/style/encoding_spec.rb
@@ -82,7 +82,7 @@ describe RuboCop::Cop::Style::Encoding, :config do
     context 'auto-correct' do
       it 'inserts an encoding comment on the first line when there are ' \
          'non ASCII characters in the file' do
-        new_source = autocorrect_source(cop, <<-RUBY.strip_indent)
+        new_source = autocorrect_source(<<-RUBY.strip_indent)
           def foo() 'ä' end
         RUBY
 
@@ -93,7 +93,7 @@ describe RuboCop::Cop::Style::Encoding, :config do
       end
 
       it "removes encoding comment on first line when it's not needed" do
-        new_source = autocorrect_source(cop, <<-RUBY.strip_indent)
+        new_source = autocorrect_source(<<-RUBY.strip_indent)
           # encoding: utf-8
           blah
         RUBY
@@ -163,7 +163,7 @@ describe RuboCop::Cop::Style::Encoding, :config do
         it 'inserts an encoding comment on the first line of files without ' \
            'a shebang' do
           cop_config['AutoCorrectEncodingComment'] = '# encoding: utf-8'
-          new_source = autocorrect_source(cop, 'def foo() end')
+          new_source = autocorrect_source('def foo() end')
 
           expect(new_source).to eq("# encoding: utf-8\ndef foo() end")
         end
@@ -171,7 +171,7 @@ describe RuboCop::Cop::Style::Encoding, :config do
         it 'inserts an encoding comment on the first line and leaves ' \
            'the wrong encoding line when encoding is in the wrong place' do
           cop_config['AutoCorrectEncodingComment'] = '# encoding: utf-8'
-          new_source = autocorrect_source(cop, <<-RUBY.strip_indent)
+          new_source = autocorrect_source(<<-RUBY.strip_indent)
             def foo() end
             # encoding: utf-8
           RUBY
@@ -185,7 +185,7 @@ describe RuboCop::Cop::Style::Encoding, :config do
 
         it 'inserts an encoding comment on the second line when the first ' \
            'line is a shebang' do
-          new_source = autocorrect_source(cop, <<-RUBY.strip_indent)
+          new_source = autocorrect_source(<<-RUBY.strip_indent)
             #!/usr/bin/env ruby
             def foo
             end
@@ -200,7 +200,7 @@ describe RuboCop::Cop::Style::Encoding, :config do
         end
 
         it "doesn't infinite-loop when the first line is blank" do
-          new_source = autocorrect_source(cop, <<-RUBY.strip_indent)
+          new_source = autocorrect_source(<<-RUBY.strip_indent)
 
             module Toto
             end
@@ -217,7 +217,7 @@ describe RuboCop::Cop::Style::Encoding, :config do
       context 'invalid auto correct comment' do
         it 'throws an exception' do
           cop_config['AutoCorrectEncodingComment'] = 'invalid'
-          expect { autocorrect_source(cop, 'def foo() end') }
+          expect { autocorrect_source('def foo() end') }
             .to raise_error(RuntimeError, 'invalid does not match ' \
                           '(?-mix:#.*coding\s?[:=]\s?(?:UTF|utf)-8)')
         end
@@ -260,13 +260,13 @@ describe RuboCop::Cop::Style::Encoding, :config do
     context 'auto-correct' do
       it 'removes encoding comment on first line when there are ' \
          'non ASCII characters in the file' do
-        new_source = autocorrect_source(cop, 'def foo() \'ä\' end')
+        new_source = autocorrect_source('def foo() \'ä\' end')
 
         expect(new_source).to eq('def foo() \'ä\' end')
       end
 
       it "removes encoding comment on first line when it's not needed" do
-        new_source = autocorrect_source(cop, "# encoding: utf-8\nblah")
+        new_source = autocorrect_source("# encoding: utf-8\nblah")
 
         expect(new_source).to eq('blah')
       end

--- a/spec/rubocop/cop/style/encoding_spec.rb
+++ b/spec/rubocop/cop/style/encoding_spec.rb
@@ -10,14 +10,14 @@ describe RuboCop::Cop::Style::Encoding, :config do
 
     it 'registers no offense when no encoding present but only ASCII ' \
        'characters' do
-      inspect_source(cop, 'def foo() end')
+      inspect_source('def foo() end')
 
       expect(cop.offenses).to be_empty
     end
 
     it 'registers an offense when there is no encoding present but non ' \
        'ASCII characters' do
-      inspect_source(cop, 'def foo() \'ä\' end')
+      inspect_source('def foo() \'ä\' end')
 
       expect(cop.offenses.size).to eq(1)
       expect(cop.messages).to eq(
@@ -27,7 +27,7 @@ describe RuboCop::Cop::Style::Encoding, :config do
 
     it 'registers an offense when encoding present but only ASCII ' \
        'characters' do
-      inspect_source(cop, <<-RUBY.strip_indent)
+      inspect_source(<<-RUBY.strip_indent)
         # encoding: utf-8
         def foo() end
       RUBY
@@ -232,21 +232,21 @@ describe RuboCop::Cop::Style::Encoding, :config do
 
     it 'registers no offense when no encoding present but only ASCII ' \
        'characters' do
-      inspect_source(cop, 'def foo() end')
+      inspect_source('def foo() end')
 
       expect(cop.offenses).to be_empty
     end
 
     it 'registers no offense when there is no encoding present but non ' \
        'ASCII characters' do
-      inspect_source(cop, 'def foo() \'ä\' end')
+      inspect_source('def foo() \'ä\' end')
 
       expect(cop.offenses).to be_empty
     end
 
     it 'registers an offense when encoding present but only ASCII ' \
        'characters' do
-      inspect_source(cop, <<-RUBY.strip_indent)
+      inspect_source(<<-RUBY.strip_indent)
         # encoding: utf-8
         def foo() end
       RUBY

--- a/spec/rubocop/cop/style/end_block_spec.rb
+++ b/spec/rubocop/cop/style/end_block_spec.rb
@@ -5,7 +5,7 @@ describe RuboCop::Cop::Style::EndBlock do
 
   it 'reports an offense for an END block' do
     src = 'END { test }'
-    inspect_source(cop, src)
+    inspect_source(src)
     expect(cop.offenses.size).to eq(1)
   end
 end

--- a/spec/rubocop/cop/style/even_odd_spec.rb
+++ b/spec/rubocop/cop/style/even_odd_spec.rb
@@ -82,77 +82,77 @@ describe RuboCop::Cop::Style::EvenOdd do
   end
 
   it 'converts x % 2 == 0 to #even?' do
-    corrected = autocorrect_source(cop, 'x % 2 == 0')
+    corrected = autocorrect_source('x % 2 == 0')
     expect(corrected).to eq('x.even?')
   end
 
   it 'converts x % 2 != 0 to #odd?' do
-    corrected = autocorrect_source(cop, 'x % 2 != 0')
+    corrected = autocorrect_source('x % 2 != 0')
     expect(corrected).to eq('x.odd?')
   end
 
   it 'converts (x % 2) == 0 to #even?' do
-    corrected = autocorrect_source(cop, '(x % 2) == 0')
+    corrected = autocorrect_source('(x % 2) == 0')
     expect(corrected).to eq('x.even?')
   end
 
   it 'converts (x % 2) != 0 to #odd?' do
-    corrected = autocorrect_source(cop, '(x % 2) != 0')
+    corrected = autocorrect_source('(x % 2) != 0')
     expect(corrected).to eq('x.odd?')
   end
 
   it 'converts x % 2 == 1 to odd?' do
-    corrected = autocorrect_source(cop, 'x % 2 == 1')
+    corrected = autocorrect_source('x % 2 == 1')
     expect(corrected).to eq('x.odd?')
   end
 
   it 'converts x % 2 != 1 to even?' do
-    corrected = autocorrect_source(cop, 'x % 2 != 1')
+    corrected = autocorrect_source('x % 2 != 1')
     expect(corrected).to eq('x.even?')
   end
 
   it 'converts (x % 2) == 1 to odd?' do
-    corrected = autocorrect_source(cop, '(x % 2) == 1')
+    corrected = autocorrect_source('(x % 2) == 1')
     expect(corrected).to eq('x.odd?')
   end
 
   it 'converts (y % 2) != 1 to even?' do
-    corrected = autocorrect_source(cop, '(y % 2) != 1')
+    corrected = autocorrect_source('(y % 2) != 1')
     expect(corrected).to eq('y.even?')
   end
 
   it 'converts (x.y % 2) != 1 to even?' do
-    corrected = autocorrect_source(cop, '(x.y % 2) != 1')
+    corrected = autocorrect_source('(x.y % 2) != 1')
     expect(corrected).to eq('x.y.even?')
   end
 
   it 'converts (x(y) % 2) != 1 to even?' do
-    corrected = autocorrect_source(cop, '(x(y) % 2) != 1')
+    corrected = autocorrect_source('(x(y) % 2) != 1')
     expect(corrected).to eq('x(y).even?')
   end
 
   it 'converts (x._(y) % 2) != 1 to even?' do
-    corrected = autocorrect_source(cop, '(x._(y) % 2) != 1')
+    corrected = autocorrect_source('(x._(y) % 2) != 1')
     expect(corrected).to eq('x._(y).even?')
   end
 
   it 'converts (x._(y)) % 2 != 1 to even?' do
-    corrected = autocorrect_source(cop, '(x._(y)) % 2 != 1')
+    corrected = autocorrect_source('(x._(y)) % 2 != 1')
     expect(corrected).to eq('(x._(y)).even?')
   end
 
   it 'converts x._(y) % 2 != 1 to even?' do
-    corrected = autocorrect_source(cop, 'x._(y) % 2 != 1')
+    corrected = autocorrect_source('x._(y) % 2 != 1')
     expect(corrected).to eq('x._(y).even?')
   end
 
   it 'converts 1 % 2 != 1 to even?' do
-    corrected = autocorrect_source(cop, '1 % 2 != 1')
+    corrected = autocorrect_source('1 % 2 != 1')
     expect(corrected).to eq('1.even?')
   end
 
   it 'converts complex examples' do
-    corrected = autocorrect_source(cop, <<-RUBY.strip_indent)
+    corrected = autocorrect_source(<<-RUBY.strip_indent)
       if (y % 2) != 1
         method == :== ? :even : :odd
       elsif x % 2 == 1

--- a/spec/rubocop/cop/style/for_spec.rb
+++ b/spec/rubocop/cop/style/for_spec.rb
@@ -7,7 +7,7 @@ describe RuboCop::Cop::Style::For, :config do
     let(:cop_config) { { 'EnforcedStyle' => 'each' } }
 
     it 'registers an offense for for' do
-      inspect_source(cop, <<-RUBY.strip_indent)
+      inspect_source(<<-RUBY.strip_indent)
         def func
           for n in [1, 2, 3] do
             puts n
@@ -20,7 +20,7 @@ describe RuboCop::Cop::Style::For, :config do
     end
 
     it 'registers an offense for opposite + correct style' do
-      inspect_source(cop, <<-RUBY.strip_indent)
+      inspect_source(<<-RUBY.strip_indent)
         def func
           for n in [1, 2, 3] do
             puts n
@@ -67,7 +67,7 @@ describe RuboCop::Cop::Style::For, :config do
     end
 
     it 'registers an offense for multiline each' do
-      inspect_source(cop, <<-RUBY.strip_indent)
+      inspect_source(<<-RUBY.strip_indent)
         def func
           [1, 2, 3].each do |n|
             puts n
@@ -80,7 +80,7 @@ describe RuboCop::Cop::Style::For, :config do
     end
 
     it 'registers an offense for correct + opposite style' do
-      inspect_source(cop, <<-RUBY.strip_indent)
+      inspect_source(<<-RUBY.strip_indent)
         def func
           for n in [1, 2, 3] do
             puts n

--- a/spec/rubocop/cop/style/format_string_spec.rb
+++ b/spec/rubocop/cop/style/format_string_spec.rb
@@ -49,22 +49,22 @@ describe RuboCop::Cop::Style::FormatString, :config do
     end
 
     it 'auto-corrects format' do
-      corrected = autocorrect_source(cop, 'format(something, a, b)')
+      corrected = autocorrect_source('format(something, a, b)')
       expect(corrected).to eq 'sprintf(something, a, b)'
     end
 
     it 'auto-corrects String#%' do
-      corrected = autocorrect_source(cop, 'puts "%d" % 10')
+      corrected = autocorrect_source('puts "%d" % 10')
       expect(corrected).to eq 'puts sprintf("%d", 10)'
     end
 
     it 'auto-corrects String#% with an array argument' do
-      corrected = autocorrect_source(cop, 'puts x % [10, 11]')
+      corrected = autocorrect_source('puts x % [10, 11]')
       expect(corrected).to eq 'puts sprintf(x, 10, 11)'
     end
 
     it 'auto-corrects String#% with a hash argument' do
-      corrected = autocorrect_source(cop, 'puts x % { a: 10, b: 11 }')
+      corrected = autocorrect_source('puts x % { a: 10, b: 11 }')
       expect(corrected).to eq 'puts sprintf(x, a: 10, b: 11)'
     end
   end
@@ -123,22 +123,22 @@ describe RuboCop::Cop::Style::FormatString, :config do
     end
 
     it 'auto-corrects sprintf' do
-      corrected = autocorrect_source(cop, 'sprintf(something, a, b)')
+      corrected = autocorrect_source('sprintf(something, a, b)')
       expect(corrected).to eq 'format(something, a, b)'
     end
 
     it 'auto-corrects String#%' do
-      corrected = autocorrect_source(cop, 'puts "%d" % 10')
+      corrected = autocorrect_source('puts "%d" % 10')
       expect(corrected).to eq 'puts format("%d", 10)'
     end
 
     it 'auto-corrects String#% with an array argument' do
-      corrected = autocorrect_source(cop, 'puts x % [10, 11]')
+      corrected = autocorrect_source('puts x % [10, 11]')
       expect(corrected).to eq 'puts format(x, 10, 11)'
     end
 
     it 'auto-corrects String#% with a hash argument' do
-      corrected = autocorrect_source(cop, 'puts x % { a: 10, b: 11 }')
+      corrected = autocorrect_source('puts x % { a: 10, b: 11 }')
       expect(corrected).to eq 'puts format(x, a: 10, b: 11)'
     end
   end
@@ -188,32 +188,32 @@ describe RuboCop::Cop::Style::FormatString, :config do
     end
 
     it 'auto-corrects format with 2 arguments' do
-      corrected = autocorrect_source(cop, 'format(something, a)')
+      corrected = autocorrect_source('format(something, a)')
       expect(corrected).to eq 'something % a'
     end
 
     it 'auto-corrects format with 3 arguments' do
-      corrected = autocorrect_source(cop, 'format(something, a, b)')
+      corrected = autocorrect_source('format(something, a, b)')
       expect(corrected).to eq 'something % [a, b]'
     end
 
     it 'auto-corrects format with a hash argument' do
-      corrected = autocorrect_source(cop, 'format(something, a: 10, b: 11)')
+      corrected = autocorrect_source('format(something, a: 10, b: 11)')
       expect(corrected).to eq 'something % { a: 10, b: 11 }'
     end
 
     it 'auto-corrects sprintf with 2 arguments' do
-      corrected = autocorrect_source(cop, 'sprintf(something, a)')
+      corrected = autocorrect_source('sprintf(something, a)')
       expect(corrected).to eq 'something % a'
     end
 
     it 'auto-corrects sprintf with 3 arguments' do
-      corrected = autocorrect_source(cop, 'sprintf(something, a, b)')
+      corrected = autocorrect_source('sprintf(something, a, b)')
       expect(corrected).to eq 'something % [a, b]'
     end
 
     it 'auto-corrects sprintf with a hash argument' do
-      corrected = autocorrect_source(cop, 'sprintf(something, a: 10, b: 11)')
+      corrected = autocorrect_source('sprintf(something, a: 10, b: 11)')
       expect(corrected).to eq 'something % { a: 10, b: 11 }'
     end
   end

--- a/spec/rubocop/cop/style/format_string_token_spec.rb
+++ b/spec/rubocop/cop/style/format_string_token_spec.rb
@@ -20,7 +20,7 @@ describe RuboCop::Cop::Style::FormatStringToken, :config do
       let(:enforced_style) { name }
 
       it "registers offenses for #{bad_style1}" do
-        inspect_source(cop, [
+        inspect_source([
                          '<<-HEREDOC',
                          "foo #{good} + bar #{bad_style1}",
                          'HEREDOC'
@@ -31,7 +31,6 @@ describe RuboCop::Cop::Style::FormatStringToken, :config do
 
       it 'supports dynamic string with interpolation' do
         inspect_source(
-          cop,
           %("a\#{b}#{good} c\#{d}#{bad_style1} e\#{f}")
         )
 
@@ -39,7 +38,7 @@ describe RuboCop::Cop::Style::FormatStringToken, :config do
       end
 
       it 'sets the enforced style to annotated after inspecting "%<a>s"' do
-        inspect_source(cop, '"%<a>s"')
+        inspect_source('"%<a>s"')
 
         expect(cop.config_to_allow_offenses).to eq(
           'EnforcedStyle' => 'annotated'
@@ -47,7 +46,7 @@ describe RuboCop::Cop::Style::FormatStringToken, :config do
       end
 
       it 'configures the enforced style to template after inspecting "%{a}"' do
-        inspect_source(cop, '"%{a}"')
+        inspect_source('"%{a}"')
 
         expect(cop.config_to_allow_offenses).to eq(
           'EnforcedStyle' => 'template'
@@ -76,7 +75,7 @@ describe RuboCop::Cop::Style::FormatStringToken, :config do
       let(:enforced_style) { enforced_style }
 
       it 'gives a helpful error message' do
-        inspect_source(cop, source)
+        inspect_source(source)
 
         expect(cop.messages.first).to eql(message)
       end
@@ -88,7 +87,7 @@ describe RuboCop::Cop::Style::FormatStringToken, :config do
   end
 
   it 'handles dstrs' do
-    inspect_source(cop, '"c#{b}%{template}"')
+    inspect_source('"c#{b}%{template}"')
     expect(cop.highlights).to eql(['%{template}'])
   end
 

--- a/spec/rubocop/cop/style/frozen_string_literal_comment_spec.rb
+++ b/spec/rubocop/cop/style/frozen_string_literal_comment_spec.rb
@@ -33,7 +33,7 @@ describe RuboCop::Cop::Style::FrozenStringLiteralComment, :config do
 
     it 'registers an offense for not having a frozen string literal comment ' \
        'on the top line' do
-      inspect_source(cop, 'puts 1')
+      inspect_source('puts 1')
 
       expect(cop.messages)
         .to eq(['Missing magic comment `# frozen_string_literal: true`.'])
@@ -41,7 +41,7 @@ describe RuboCop::Cop::Style::FrozenStringLiteralComment, :config do
 
     it 'registers an offense for not having a frozen string literal comment ' \
        'under a shebang' do
-      inspect_source(cop, <<-RUBY.strip_indent)
+      inspect_source(<<-RUBY.strip_indent)
         #!/usr/bin/env ruby
         puts 1
       RUBY
@@ -68,7 +68,7 @@ describe RuboCop::Cop::Style::FrozenStringLiteralComment, :config do
 
     it 'registers an offense for not having a frozen string literal comment ' \
        'under an encoding comment' do
-      inspect_source(cop, <<-RUBY.strip_indent)
+      inspect_source(<<-RUBY.strip_indent)
         # encoding: utf-8
         puts 1
       RUBY
@@ -95,7 +95,7 @@ describe RuboCop::Cop::Style::FrozenStringLiteralComment, :config do
 
     it 'registers an offense for not having a frozen string literal comment ' \
        'under a shebang and an encoding comment' do
-      inspect_source(cop, <<-RUBY.strip_indent)
+      inspect_source(<<-RUBY.strip_indent)
         #!/usr/bin/env ruby
         # encoding: utf-8
         puts 1
@@ -107,7 +107,7 @@ describe RuboCop::Cop::Style::FrozenStringLiteralComment, :config do
 
     it 'accepts a frozen string literal comment below shebang and encoding ' \
        'comments' do
-      inspect_source(cop, <<-RUBY.strip_indent)
+      inspect_source(<<-RUBY.strip_indent)
         #!/usr/bin/env ruby
         # encoding: utf-8
         # frozen_string_literal: true
@@ -119,7 +119,7 @@ describe RuboCop::Cop::Style::FrozenStringLiteralComment, :config do
 
     it 'accepts a disabled frozen string literal comment below shebang and ' \
        'encoding comments' do
-      inspect_source(cop, <<-RUBY.strip_indent)
+      inspect_source(<<-RUBY.strip_indent)
         #!/usr/bin/env ruby
         # encoding: utf-8
         # frozen_string_literal: false
@@ -131,7 +131,7 @@ describe RuboCop::Cop::Style::FrozenStringLiteralComment, :config do
 
     it 'accepts a frozen string literal comment below shebang above an ' \
        'encoding comments' do
-      inspect_source(cop, <<-RUBY.strip_indent)
+      inspect_source(<<-RUBY.strip_indent)
         #!/usr/bin/env ruby
         # frozen_string_literal: true
         # encoding: utf-8
@@ -143,7 +143,7 @@ describe RuboCop::Cop::Style::FrozenStringLiteralComment, :config do
 
     it 'accepts a disabled frozen string literal comment below shebang above ' \
        'an encoding comments' do
-      inspect_source(cop, <<-RUBY.strip_indent)
+      inspect_source(<<-RUBY.strip_indent)
         #!/usr/bin/env ruby
         # frozen_string_literal: false
         # encoding: utf-8
@@ -299,7 +299,7 @@ describe RuboCop::Cop::Style::FrozenStringLiteralComment, :config do
 
         it 'accepts freezing a string when there is a frozen string literal ' \
            'comment' do
-          inspect_source(cop, <<-RUBY.strip_indent)
+          inspect_source(<<-RUBY.strip_indent)
             # frozen_string_literal: true
             "x".freeze
           RUBY
@@ -309,7 +309,7 @@ describe RuboCop::Cop::Style::FrozenStringLiteralComment, :config do
 
         it 'accepts shoveling into a string when there is a frozen string ' \
            'literal comment' do
-          inspect_source(cop, <<-RUBY.strip_indent)
+          inspect_source(<<-RUBY.strip_indent)
             # frozen_string_literal: true
             "x" << "y"
           RUBY
@@ -386,7 +386,7 @@ describe RuboCop::Cop::Style::FrozenStringLiteralComment, :config do
 
     it 'registers an offense for a frozen string literal comment ' \
       'on the top line' do
-      inspect_source(cop, <<-RUBY.strip_indent)
+      inspect_source(<<-RUBY.strip_indent)
         # frozen_string_literal: true
         puts 1
       RUBY
@@ -397,7 +397,7 @@ describe RuboCop::Cop::Style::FrozenStringLiteralComment, :config do
 
     it 'registers an offense for a disabled frozen string literal comment ' \
       'on the top line' do
-      inspect_source(cop, <<-RUBY.strip_indent)
+      inspect_source(<<-RUBY.strip_indent)
         # frozen_string_literal: false
         puts 1
       RUBY
@@ -412,7 +412,7 @@ describe RuboCop::Cop::Style::FrozenStringLiteralComment, :config do
 
     it 'accepts not having not having a frozen string literal comment ' \
       'under a shebang' do
-      inspect_source(cop, <<-RUBY.strip_indent)
+      inspect_source(<<-RUBY.strip_indent)
         #!/usr/bin/env ruby
         puts 1
       RUBY
@@ -422,7 +422,7 @@ describe RuboCop::Cop::Style::FrozenStringLiteralComment, :config do
 
     it 'registers an offense for a frozen string literal comment ' \
       'below a shebang comment' do
-      inspect_source(cop, <<-RUBY.strip_indent)
+      inspect_source(<<-RUBY.strip_indent)
         #!/usr/bin/env ruby
         # frozen_string_literal: true
         puts 1
@@ -434,7 +434,7 @@ describe RuboCop::Cop::Style::FrozenStringLiteralComment, :config do
 
     it 'registers an offense for a disabled frozen string literal ' \
       'below a shebang comment' do
-      inspect_source(cop, <<-RUBY.strip_indent)
+      inspect_source(<<-RUBY.strip_indent)
         #!/usr/bin/env ruby
         # frozen_string_literal: false
         puts 1
@@ -446,7 +446,7 @@ describe RuboCop::Cop::Style::FrozenStringLiteralComment, :config do
 
     it 'allows not having a frozen string literal comment ' \
       'under an encoding comment' do
-      inspect_source(cop, <<-RUBY.strip_indent)
+      inspect_source(<<-RUBY.strip_indent)
         # encoding: utf-8
         puts 1
       RUBY
@@ -456,7 +456,7 @@ describe RuboCop::Cop::Style::FrozenStringLiteralComment, :config do
 
     it 'registers an offense for a frozen string literal comment below ' \
       'an encoding comment' do
-      inspect_source(cop, <<-RUBY.strip_indent)
+      inspect_source(<<-RUBY.strip_indent)
         # encoding: utf-8
         # frozen_string_literal: true
         puts 1
@@ -468,7 +468,7 @@ describe RuboCop::Cop::Style::FrozenStringLiteralComment, :config do
 
     it 'registers an offense for a dsabled frozen string literal below ' \
       'an encoding comment' do
-      inspect_source(cop, <<-RUBY.strip_indent)
+      inspect_source(<<-RUBY.strip_indent)
         # encoding: utf-8
         # frozen_string_literal: false
         puts 1
@@ -480,7 +480,7 @@ describe RuboCop::Cop::Style::FrozenStringLiteralComment, :config do
 
     it 'allows not having a frozen string literal comment ' \
       'under a shebang and an encoding comment' do
-      inspect_source(cop, <<-RUBY.strip_indent)
+      inspect_source(<<-RUBY.strip_indent)
         #!/usr/bin/env ruby
         # encoding: utf-8
         puts 1
@@ -491,7 +491,7 @@ describe RuboCop::Cop::Style::FrozenStringLiteralComment, :config do
 
     it 'registers an offense for a frozen string literal comment ' \
       'below shebang and encoding comments' do
-      inspect_source(cop, <<-RUBY.strip_indent)
+      inspect_source(<<-RUBY.strip_indent)
         #!/usr/bin/env ruby
         # encoding: utf-8
         # frozen_string_literal: true
@@ -504,7 +504,7 @@ describe RuboCop::Cop::Style::FrozenStringLiteralComment, :config do
 
     it 'registers an offense for a disabled frozen string literal comment ' \
       'below shebang and encoding comments' do
-      inspect_source(cop, <<-RUBY.strip_indent)
+      inspect_source(<<-RUBY.strip_indent)
         #!/usr/bin/env ruby
         # encoding: utf-8
         # frozen_string_literal: false
@@ -517,7 +517,7 @@ describe RuboCop::Cop::Style::FrozenStringLiteralComment, :config do
 
     it 'registers an offense for a frozen string literal comment ' \
       'below shebang above an encoding comments' do
-      inspect_source(cop, <<-RUBY.strip_indent)
+      inspect_source(<<-RUBY.strip_indent)
         #!/usr/bin/env ruby
         # frozen_string_literal: true
         # encoding: utf-8
@@ -530,7 +530,7 @@ describe RuboCop::Cop::Style::FrozenStringLiteralComment, :config do
 
     it 'registers an offense for a disabled frozen string literal comment ' \
       'below shebang above an encoding comments' do
-      inspect_source(cop, <<-RUBY.strip_indent)
+      inspect_source(<<-RUBY.strip_indent)
         #!/usr/bin/env ruby
         # frozen_string_literal: false
         # encoding: utf-8

--- a/spec/rubocop/cop/style/frozen_string_literal_comment_spec.rb
+++ b/spec/rubocop/cop/style/frozen_string_literal_comment_spec.rb
@@ -165,7 +165,7 @@ describe RuboCop::Cop::Style::FrozenStringLiteralComment, :config do
     context 'auto-correct' do
       it 'adds a frozen string literal comment to the first line if one is ' \
          'missing' do
-        new_source = autocorrect_source(cop, <<-RUBY.strip_indent)
+        new_source = autocorrect_source(<<-RUBY.strip_indent)
           puts 1
         RUBY
 
@@ -176,7 +176,7 @@ describe RuboCop::Cop::Style::FrozenStringLiteralComment, :config do
       end
 
       it 'adds a frozen string literal comment after a shebang' do
-        new_source = autocorrect_source(cop, <<-RUBY.strip_indent)
+        new_source = autocorrect_source(<<-RUBY.strip_indent)
           #!/usr/bin/env ruby
           puts 1
         RUBY
@@ -189,7 +189,7 @@ describe RuboCop::Cop::Style::FrozenStringLiteralComment, :config do
       end
 
       it 'adds a frozen string literal comment after an encoding comment' do
-        new_source = autocorrect_source(cop, <<-RUBY.strip_indent)
+        new_source = autocorrect_source(<<-RUBY.strip_indent)
           # encoding: utf-8
           puts 1
         RUBY
@@ -203,7 +203,7 @@ describe RuboCop::Cop::Style::FrozenStringLiteralComment, :config do
 
       it 'adds a frozen string literal comment after a shebang and encoding ' \
          'comment' do
-        new_source = autocorrect_source(cop, <<-RUBY.strip_indent)
+        new_source = autocorrect_source(<<-RUBY.strip_indent)
           #!/usr/bin/env ruby
           # encoding: utf-8
           puts 1
@@ -219,7 +219,7 @@ describe RuboCop::Cop::Style::FrozenStringLiteralComment, :config do
 
       it 'adds a frozen string literal comment after a shebang and encoding ' \
          'comment when there is an empty line before the code' do
-        new_source = autocorrect_source(cop, <<-RUBY.strip_indent)
+        new_source = autocorrect_source(<<-RUBY.strip_indent)
           #!/usr/bin/env ruby
           # encoding: utf-8
 
@@ -237,7 +237,7 @@ describe RuboCop::Cop::Style::FrozenStringLiteralComment, :config do
 
       it 'adds a frozen string literal comment after an encoding comment ' \
          'when there is an empty line before the code' do
-        new_source = autocorrect_source(cop, <<-RUBY.strip_indent)
+        new_source = autocorrect_source(<<-RUBY.strip_indent)
           # encoding: utf-8
 
           puts 1
@@ -543,7 +543,7 @@ describe RuboCop::Cop::Style::FrozenStringLiteralComment, :config do
 
     context 'auto-correct' do
       it 'removes the frozen string literal comment from the top line' do
-        new_source = autocorrect_source(cop, <<-RUBY.strip_indent)
+        new_source = autocorrect_source(<<-RUBY.strip_indent)
           # frozen_string_literal: true
           puts 1
         RUBY
@@ -554,7 +554,7 @@ describe RuboCop::Cop::Style::FrozenStringLiteralComment, :config do
       end
 
       it 'removes a disabled frozen string literal comment on the top line' do
-        new_source = autocorrect_source(cop, <<-RUBY.strip_indent)
+        new_source = autocorrect_source(<<-RUBY.strip_indent)
           # frozen_string_literal: false
           puts 1
         RUBY
@@ -565,7 +565,7 @@ describe RuboCop::Cop::Style::FrozenStringLiteralComment, :config do
       end
 
       it 'removes a frozen string literal comment below a shebang comment' do
-        new_source = autocorrect_source(cop, <<-RUBY.strip_indent)
+        new_source = autocorrect_source(<<-RUBY.strip_indent)
           #!/usr/bin/env ruby
           # frozen_string_literal: true
           puts 1
@@ -578,7 +578,7 @@ describe RuboCop::Cop::Style::FrozenStringLiteralComment, :config do
       end
 
       it 'removes a disabled frozen string literal below a shebang comment' do
-        new_source = autocorrect_source(cop, <<-RUBY.strip_indent)
+        new_source = autocorrect_source(<<-RUBY.strip_indent)
           #!/usr/bin/env ruby
           # frozen_string_literal: false
           puts 1
@@ -591,7 +591,7 @@ describe RuboCop::Cop::Style::FrozenStringLiteralComment, :config do
       end
 
       it 'removes a frozen string literal comment below an encoding comment' do
-        new_source = autocorrect_source(cop, <<-RUBY.strip_indent)
+        new_source = autocorrect_source(<<-RUBY.strip_indent)
           # encoding: utf-8
           # frozen_string_literal: true
           puts 1
@@ -604,7 +604,7 @@ describe RuboCop::Cop::Style::FrozenStringLiteralComment, :config do
       end
 
       it 'removes a dsabled frozen string literal below an encoding comment' do
-        new_source = autocorrect_source(cop, <<-RUBY.strip_indent)
+        new_source = autocorrect_source(<<-RUBY.strip_indent)
           # encoding: utf-8
           # frozen_string_literal: false
           puts 1
@@ -618,7 +618,7 @@ describe RuboCop::Cop::Style::FrozenStringLiteralComment, :config do
 
       it 'removes a frozen string literal comment ' \
         'below shebang and encoding comments' do
-        new_source = autocorrect_source(cop, <<-RUBY.strip_indent)
+        new_source = autocorrect_source(<<-RUBY.strip_indent)
           #!/usr/bin/env ruby
           # encoding: utf-8
           # frozen_string_literal: true
@@ -634,7 +634,7 @@ describe RuboCop::Cop::Style::FrozenStringLiteralComment, :config do
 
       it 'removes a disabled frozen string literal comment from ' \
         'below shebang and encoding comments' do
-        new_source = autocorrect_source(cop, <<-RUBY.strip_indent)
+        new_source = autocorrect_source(<<-RUBY.strip_indent)
           #!/usr/bin/env ruby
           # encoding: utf-8
           # frozen_string_literal: false
@@ -650,7 +650,7 @@ describe RuboCop::Cop::Style::FrozenStringLiteralComment, :config do
 
       it 'removes a frozen string literal comment ' \
         'below shebang above an encoding comments' do
-        new_source = autocorrect_source(cop, <<-RUBY.strip_indent)
+        new_source = autocorrect_source(<<-RUBY.strip_indent)
           #!/usr/bin/env ruby
           # frozen_string_literal: true
           # encoding: utf-8
@@ -666,7 +666,7 @@ describe RuboCop::Cop::Style::FrozenStringLiteralComment, :config do
 
       it 'removes a disabled frozen string literal comment ' \
         'below shebang above an encoding comments' do
-        new_source = autocorrect_source(cop, <<-RUBY.strip_indent)
+        new_source = autocorrect_source(<<-RUBY.strip_indent)
           #!/usr/bin/env ruby
           # frozen_string_literal: false
           # encoding: utf-8

--- a/spec/rubocop/cop/style/global_vars_spec.rb
+++ b/spec/rubocop/cop/style/global_vars_spec.rb
@@ -21,7 +21,7 @@ describe RuboCop::Cop::Style::GlobalVars, :config do
 
   described_class::BUILT_IN_VARS.each do |var|
     it "does not register an offense for built-in variable #{var}" do
-      inspect_source(cop, "puts #{var}")
+      inspect_source("puts #{var}")
       expect(cop.offenses).to be_empty
     end
   end

--- a/spec/rubocop/cop/style/guard_clause_spec.rb
+++ b/spec/rubocop/cop/style/guard_clause_spec.rb
@@ -6,7 +6,7 @@ describe RuboCop::Cop::Style::GuardClause, :config do
 
   shared_examples 'reports offense' do |body|
     it 'reports an offense if method body is if / unless without else' do
-      inspect_source(cop, <<-RUBY.strip_indent)
+      inspect_source(<<-RUBY.strip_indent)
         def func
           if something
             #{body}
@@ -28,7 +28,7 @@ describe RuboCop::Cop::Style::GuardClause, :config do
     end
 
     it 'reports an offense if method body is if / unless without else' do
-      inspect_source(cop, <<-RUBY.strip_indent)
+      inspect_source(<<-RUBY.strip_indent)
         def func
           if something
             #{body}
@@ -50,7 +50,7 @@ describe RuboCop::Cop::Style::GuardClause, :config do
     end
 
     it 'reports an offense if method body ends with if / unless without else' do
-      inspect_source(cop, <<-RUBY.strip_indent)
+      inspect_source(<<-RUBY.strip_indent)
         def func
           test
           if something
@@ -221,14 +221,14 @@ describe RuboCop::Cop::Style::GuardClause, :config do
         end
       RUBY
 
-      expect { inspect_source(cop, source) }
+      expect { inspect_source(source) }
         .to raise_error('MinBodyLength needs to be a positive integer!')
     end
   end
 
   shared_examples 'on if nodes which exit current scope' do |kw|
     it "registers an error with #{kw} in the if branch" do
-      inspect_source(cop, <<-RUBY.strip_indent)
+      inspect_source(<<-RUBY.strip_indent)
         if something
           #{kw}
         else
@@ -241,7 +241,7 @@ describe RuboCop::Cop::Style::GuardClause, :config do
     end
 
     it "registers an error with #{kw} in the else branch" do
-      inspect_source(cop, <<-RUBY.strip_indent)
+      inspect_source(<<-RUBY.strip_indent)
         if something
          puts "hello"
         else
@@ -265,7 +265,7 @@ describe RuboCop::Cop::Style::GuardClause, :config do
     end
 
     it "does not report an offense if #{kw} is inside elsif" do
-      inspect_source(cop, <<-RUBY.strip_indent)
+      inspect_source(<<-RUBY.strip_indent)
         if something
           a
         elsif something_else
@@ -276,7 +276,7 @@ describe RuboCop::Cop::Style::GuardClause, :config do
     end
 
     it "does not report an offense if #{kw} is inside if..elsif..else..end" do
-      inspect_source(cop, <<-RUBY.strip_indent)
+      inspect_source(<<-RUBY.strip_indent)
         if something
           a
         elsif something_else
@@ -289,22 +289,22 @@ describe RuboCop::Cop::Style::GuardClause, :config do
     end
 
     it "doesn't register an error if control flow expr has multiple lines" do
-      inspect_source(cop, ['if something',
-                           "  #{kw} 'blah blah blah' \\",
-                           "        'blah blah blah'",
-                           'else',
-                           '  puts "hello"',
-                           'end'])
+      inspect_source(['if something',
+                      "  #{kw} 'blah blah blah' \\",
+                      "        'blah blah blah'",
+                      'else',
+                      '  puts "hello"',
+                      'end'])
       expect(cop.offenses).to be_empty
     end
 
     it 'registers an error if non-control-flow branch has multiple lines' do
-      inspect_source(cop, ['if something',
-                           "  #{kw}",
-                           'else',
-                           '  puts "hello" \\',
-                           '       "blah blah blah"',
-                           'end'])
+      inspect_source(['if something',
+                      "  #{kw}",
+                      'else',
+                      '  puts "hello" \\',
+                      '       "blah blah blah"',
+                      'end'])
       expect(cop.offenses.size).to eq(1)
     end
   end

--- a/spec/rubocop/cop/style/hash_syntax_spec.rb
+++ b/spec/rubocop/cop/style/hash_syntax_spec.rb
@@ -125,14 +125,14 @@ describe RuboCop::Cop::Style::HashSyntax, :config do
       end
 
       it 'auto-corrects old to new style' do
-        new_source = autocorrect_source(cop, '{ :a => 1, :b   =>  2}')
+        new_source = autocorrect_source('{ :a => 1, :b   =>  2}')
         expect(new_source).to eq('{ a: 1, b: 2}')
       end
 
       it 'auto-corrects even if it interferes with SpaceAroundOperators' do
         # Clobbering caused by two cops changing in the same range is dealt with
         # by the auto-correct loop, so there's no reason to avoid a change.
-        new_source = autocorrect_source(cop, '{ :a=>1, :b=>2 }')
+        new_source = autocorrect_source('{ :a=>1, :b=>2 }')
         expect(new_source).to eq('{ a: 1, b: 2 }')
       end
     end
@@ -153,7 +153,7 @@ describe RuboCop::Cop::Style::HashSyntax, :config do
       end
 
       it 'auto-corrects even if there is no space around =>' do
-        new_source = autocorrect_source(cop, '{ :a=>1, :b=>2 }')
+        new_source = autocorrect_source('{ :a=>1, :b=>2 }')
         expect(new_source).to eq('{ a: 1, b: 2 }')
       end
     end
@@ -217,25 +217,25 @@ describe RuboCop::Cop::Style::HashSyntax, :config do
       end
 
       it 'auto-corrects to ruby19 style when there are no symbol values' do
-        new_source = autocorrect_source(cop, '{ :a => 1, :b => 2 }')
+        new_source = autocorrect_source('{ :a => 1, :b => 2 }')
         expect(new_source).to eq('{ a: 1, b: 2 }')
       end
 
       it 'auto-corrects to hash rockets ' \
         'when there is an element with a symbol value' do
-        new_source = autocorrect_source(cop, '{ a: 1, :b => :c }')
+        new_source = autocorrect_source('{ a: 1, :b => :c }')
         expect(new_source).to eq('{ :a => 1, :b => :c }')
       end
 
       it 'auto-corrects to hash rockets ' \
         'when all elements have symbol value' do
-        new_source = autocorrect_source(cop, '{ a: :b, c: :d }')
+        new_source = autocorrect_source('{ a: :b, c: :d }')
         expect(new_source).to eq('{ :a => :b, :c => :d }')
       end
 
       it 'auto-correct does not change anything when the hash ' \
         'is already ruby19 style and there are no symbol values' do
-        new_source = autocorrect_source(cop, '{ a: 1, b: 2 }')
+        new_source = autocorrect_source('{ a: 1, b: 2 }')
         expect(new_source).to eq('{ a: 1, b: 2 }')
       end
     end
@@ -282,7 +282,7 @@ describe RuboCop::Cop::Style::HashSyntax, :config do
     end
 
     it 'auto-corrects new style to hash rockets' do
-      new_source = autocorrect_source(cop, '{ a: 1, b: 2}')
+      new_source = autocorrect_source('{ a: 1, b: 2}')
       expect(new_source).to eq('{ :a => 1, :b => 2}')
     end
 
@@ -409,13 +409,13 @@ describe RuboCop::Cop::Style::HashSyntax, :config do
       end
 
       it 'auto-corrects old to new style' do
-        new_source = autocorrect_source(cop, '{ :a => 1, :b => 2 }')
+        new_source = autocorrect_source('{ :a => 1, :b => 2 }')
         expect(new_source).to eq('{ a: 1, b: 2 }')
       end
 
       it 'auto-corrects to hash rockets when new style cannot be used ' \
         'for all' do
-        new_source = autocorrect_source(cop, '{ a: 1, "b" => 2 }')
+        new_source = autocorrect_source('{ a: 1, "b" => 2 }')
         expect(new_source).to eq('{ :a => 1, "b" => 2 }')
       end
     end
@@ -444,13 +444,13 @@ describe RuboCop::Cop::Style::HashSyntax, :config do
 
       it 'auto-corrects to hash rockets ' \
         'when there is an element with a symbol value' do
-        new_source = autocorrect_source(cop, '{ a: 1, :b => :c }')
+        new_source = autocorrect_source('{ a: 1, :b => :c }')
         expect(new_source).to eq('{ :a => 1, :b => :c }')
       end
 
       it 'auto-corrects to hash rockets ' \
         'when all elements have symbol value' do
-        new_source = autocorrect_source(cop, '{ a: :b, c: :d }')
+        new_source = autocorrect_source('{ a: :b, c: :d }')
         expect(new_source).to eq('{ :a => :b, :c => :d }')
       end
 
@@ -553,13 +553,13 @@ describe RuboCop::Cop::Style::HashSyntax, :config do
       end
 
       it 'auto-corrects old to new style' do
-        new_source = autocorrect_source(cop, '{ :a => 1, :b => 2 }')
+        new_source = autocorrect_source('{ :a => 1, :b => 2 }')
         expect(new_source).to eq('{ a: 1, b: 2 }')
       end
 
       it 'auto-corrects to hash rockets when new style cannot be used ' \
         'for all' do
-        new_source = autocorrect_source(cop, '{ a: 1, "b" => 2 }')
+        new_source = autocorrect_source('{ a: 1, "b" => 2 }')
         expect(new_source).to eq('{ :a => 1, "b" => 2 }')
       end
     end
@@ -640,23 +640,23 @@ describe RuboCop::Cop::Style::HashSyntax, :config do
     end
 
     it 'does not auto-correct old to new style' do
-      new_source = autocorrect_source(cop, '{ :a => 1, :b => 2 }')
+      new_source = autocorrect_source('{ :a => 1, :b => 2 }')
       expect(new_source).to eq('{ :a => 1, :b => 2 }')
     end
 
     it 'does not auto-correct new to hash rockets style' do
-      new_source = autocorrect_source(cop, '{ a: 1, b: 2 }')
+      new_source = autocorrect_source('{ a: 1, b: 2 }')
       expect(new_source).to eq('{ a: 1, b: 2 }')
     end
 
     it 'auto-corrects mixed key hashes' do
-      new_source = autocorrect_source(cop, '{ a: 1, :b => 2 }')
+      new_source = autocorrect_source('{ a: 1, :b => 2 }')
       expect(new_source).to eq('{ a: 1, b: 2 }')
     end
 
     it 'auto-corrects to hash rockets when new style cannot be used ' \
       'for all' do
-      new_source = autocorrect_source(cop, '{ a: 1, "b" => 2 }')
+      new_source = autocorrect_source('{ a: 1, "b" => 2 }')
       expect(new_source).to eq('{ :a => 1, "b" => 2 }')
     end
   end

--- a/spec/rubocop/cop/style/hash_syntax_spec.rb
+++ b/spec/rubocop/cop/style/hash_syntax_spec.rb
@@ -27,14 +27,14 @@ describe RuboCop::Cop::Style::HashSyntax, :config do
       let(:cop_config_overrides) { {} }
 
       it 'registers offense for hash rocket syntax when new is possible' do
-        inspect_source(cop, 'x = { :a => 0 }')
+        inspect_source('x = { :a => 0 }')
         expect(cop.messages).to eq(['Use the new Ruby 1.9 hash syntax.'])
         expect(cop.config_to_allow_offenses)
           .to eq('EnforcedStyle' => 'hash_rockets')
       end
 
       it 'registers an offense for mixed syntax when new is possible' do
-        inspect_source(cop, 'x = { :a => 0, b: 1 }')
+        inspect_source('x = { :a => 0, b: 1 }')
         expect(cop.messages).to eq(['Use the new Ruby 1.9 hash syntax.'])
         expect(cop.config_to_allow_offenses).to eq('Enabled' => false)
       end
@@ -173,7 +173,7 @@ describe RuboCop::Cop::Style::HashSyntax, :config do
 
       it 'accepts ruby19 syntax when no elements have symbol values ' \
         'in method calls' do
-        inspect_source(cop, 'func(3, a: 0)')
+        inspect_source('func(3, a: 0)')
         expect(cop.messages).to be_empty
       end
 
@@ -195,13 +195,13 @@ describe RuboCop::Cop::Style::HashSyntax, :config do
 
       it 'registers an offense when any element has a symbol value ' \
         'in method calls' do
-        inspect_source(cop, 'func(3, b: :c)')
+        inspect_source('func(3, b: :c)')
         expect(cop.messages).to eq(['Use hash rockets syntax.'])
       end
 
       it 'registers an offense when using hash rockets ' \
         'and no elements have a symbol value' do
-        inspect_source(cop, 'x = { :a => 1, :b => 2 }')
+        inspect_source('x = { :a => 1, :b => 2 }')
         expect(cop.messages)
           .to eq(['Use the new Ruby 1.9 hash syntax.',
                   'Use the new Ruby 1.9 hash syntax.'])
@@ -251,13 +251,13 @@ describe RuboCop::Cop::Style::HashSyntax, :config do
     end
 
     it 'registers offense for Ruby 1.9 style' do
-      inspect_source(cop, 'x = { a: 0 }')
+      inspect_source('x = { a: 0 }')
       expect(cop.messages).to eq(['Use hash rockets syntax.'])
       expect(cop.config_to_allow_offenses).to eq('EnforcedStyle' => 'ruby19')
     end
 
     it 'registers an offense for mixed syntax' do
-      inspect_source(cop, 'x = { :a => 0, b: 1 }')
+      inspect_source('x = { :a => 0, b: 1 }')
       expect(cop.messages).to eq(['Use hash rockets syntax.'])
       expect(cop.config_to_allow_offenses).to eq('Enabled' => false)
     end
@@ -315,14 +315,14 @@ describe RuboCop::Cop::Style::HashSyntax, :config do
       end
 
       it 'registers offense for hash rocket syntax when new is possible' do
-        inspect_source(cop, 'x = { :a => 0 }')
+        inspect_source('x = { :a => 0 }')
         expect(cop.messages).to eq(['Use the new Ruby 1.9 hash syntax.'])
         expect(cop.config_to_allow_offenses)
           .to eq('EnforcedStyle' => 'hash_rockets')
       end
 
       it 'registers an offense for mixed syntax when new is possible' do
-        inspect_source(cop, 'x = { :a => 0, b: 1 }')
+        inspect_source('x = { :a => 0, b: 1 }')
         expect(cop.messages).to eq(['Use the new Ruby 1.9 hash syntax.'])
         expect(cop.config_to_allow_offenses).to eq('Enabled' => false)
       end
@@ -347,7 +347,7 @@ describe RuboCop::Cop::Style::HashSyntax, :config do
       end
 
       it 'registers an offense when keys have different types and styles' do
-        inspect_source(cop, 'x = { a: 0, "b" => 1 }')
+        inspect_source('x = { a: 0, "b" => 1 }')
         expect(cop.messages).to eq(["Don't mix styles in the same hash."])
         expect(cop.config_to_allow_offenses).to eq('Enabled' => false)
       end
@@ -358,7 +358,7 @@ describe RuboCop::Cop::Style::HashSyntax, :config do
         end
 
         it 'registers an offense when keys have whitespaces and mix styles' do
-          inspect_source(cop, 'x = { :"t o" => 0, b: 1 }')
+          inspect_source('x = { :"t o" => 0, b: 1 }')
           expect(cop.messages).to eq(["Don't mix styles in the same hash."])
           expect(cop.config_to_allow_offenses).to eq('Enabled' => false)
         end
@@ -369,7 +369,7 @@ describe RuboCop::Cop::Style::HashSyntax, :config do
 
         it 'registers an offense when keys have special symbols and '\
           'mix styles' do
-          inspect_source(cop, 'x = { :"\tab" => 1, b: 1 }')
+          inspect_source('x = { :"\tab" => 1, b: 1 }')
           expect(cop.messages).to eq(["Don't mix styles in the same hash."])
           expect(cop.config_to_allow_offenses).to eq('Enabled' => false)
         end
@@ -379,7 +379,7 @@ describe RuboCop::Cop::Style::HashSyntax, :config do
         end
 
         it 'registers an offense when keys start with a digit and mix styles' do
-          inspect_source(cop, 'x = { :"1" => 1, b: 1 }')
+          inspect_source('x = { :"1" => 1, b: 1 }')
           expect(cop.messages).to eq(["Don't mix styles in the same hash."])
           expect(cop.config_to_allow_offenses).to eq('Enabled' => false)
         end
@@ -438,7 +438,7 @@ describe RuboCop::Cop::Style::HashSyntax, :config do
 
       it 'registers an offense when any element has a symbol value ' \
         'in method calls' do
-        inspect_source(cop, 'func(3, b: :c)')
+        inspect_source('func(3, b: :c)')
         expect(cop.messages).to eq(['Use hash rockets syntax.'])
       end
 
@@ -459,14 +459,14 @@ describe RuboCop::Cop::Style::HashSyntax, :config do
       end
 
       it 'registers offense for hash rocket syntax when new is possible' do
-        inspect_source(cop, 'x = { :a => 0 }')
+        inspect_source('x = { :a => 0 }')
         expect(cop.messages).to eq(['Use the new Ruby 1.9 hash syntax.'])
         expect(cop.config_to_allow_offenses)
           .to eq('EnforcedStyle' => 'hash_rockets')
       end
 
       it 'registers an offense for mixed syntax when new is possible' do
-        inspect_source(cop, 'x = { :a => 0, b: 1 }')
+        inspect_source('x = { :a => 0, b: 1 }')
         expect(cop.messages).to eq(['Use the new Ruby 1.9 hash syntax.'])
         expect(cop.config_to_allow_offenses).to eq('Enabled' => false)
       end
@@ -491,7 +491,7 @@ describe RuboCop::Cop::Style::HashSyntax, :config do
       end
 
       it 'registers an offense when keys have different types and styles' do
-        inspect_source(cop, 'x = { a: 0, "b" => 1 }')
+        inspect_source('x = { a: 0, "b" => 1 }')
         expect(cop.messages).to eq(["Don't mix styles in the same hash."])
         expect(cop.config_to_allow_offenses).to eq('Enabled' => false)
       end
@@ -502,7 +502,7 @@ describe RuboCop::Cop::Style::HashSyntax, :config do
         end
 
         it 'registers an offense when keys have whitespaces and mix styles' do
-          inspect_source(cop, 'x = { :"t o" => 0, b: 1 }')
+          inspect_source('x = { :"t o" => 0, b: 1 }')
           expect(cop.messages).to eq(["Don't mix styles in the same hash."])
           expect(cop.config_to_allow_offenses).to eq('Enabled' => false)
         end
@@ -513,7 +513,7 @@ describe RuboCop::Cop::Style::HashSyntax, :config do
 
         it 'registers an offense when keys have special symbols and ' \
           'mix styles' do
-          inspect_source(cop, 'x = { :"\tab" => 1, b: 1 }')
+          inspect_source('x = { :"\tab" => 1, b: 1 }')
           expect(cop.messages).to eq(["Don't mix styles in the same hash."])
           expect(cop.config_to_allow_offenses).to eq('Enabled' => false)
         end
@@ -523,7 +523,7 @@ describe RuboCop::Cop::Style::HashSyntax, :config do
         end
 
         it 'registers an offense when keys start with a digit and mix styles' do
-          inspect_source(cop, 'x = { :"1" => 1, b: 1 }')
+          inspect_source('x = { :"1" => 1, b: 1 }')
           expect(cop.messages).to eq(["Don't mix styles in the same hash."])
           expect(cop.config_to_allow_offenses).to eq('Enabled' => false)
         end
@@ -581,7 +581,7 @@ describe RuboCop::Cop::Style::HashSyntax, :config do
     end
 
     it 'registers an offense for mixed syntax when new is possible' do
-      inspect_source(cop, 'x = { :a => 0, b: 1 }')
+      inspect_source('x = { :a => 0, b: 1 }')
       expect(cop.messages).to eq(['Don\'t mix styles in the same hash.'])
       expect(cop.config_to_allow_offenses).to eq('Enabled' => false)
     end
@@ -603,7 +603,7 @@ describe RuboCop::Cop::Style::HashSyntax, :config do
     end
 
     it 'registers an offense when keys have different types and styles' do
-      inspect_source(cop, 'x = { a: 0, "b" => 1 }')
+      inspect_source('x = { a: 0, "b" => 1 }')
       expect(cop.messages).to eq(["Don't mix styles in the same hash."])
       expect(cop.config_to_allow_offenses).to eq('Enabled' => false)
     end
@@ -613,7 +613,7 @@ describe RuboCop::Cop::Style::HashSyntax, :config do
     end
 
     it 'registers an offense when keys have whitespaces and mix styles' do
-      inspect_source(cop, 'x = { :"t o" => 0, b: 1 }')
+      inspect_source('x = { :"t o" => 0, b: 1 }')
       expect(cop.messages).to eq(["Don't mix styles in the same hash."])
       expect(cop.config_to_allow_offenses).to eq('Enabled' => false)
     end
@@ -624,7 +624,7 @@ describe RuboCop::Cop::Style::HashSyntax, :config do
 
     it 'registers an offense when keys have special symbols and '\
       'mix styles' do
-      inspect_source(cop, 'x = { :"\tab" => 1, b: 1 }')
+      inspect_source('x = { :"\tab" => 1, b: 1 }')
       expect(cop.messages).to eq(["Don't mix styles in the same hash."])
       expect(cop.config_to_allow_offenses).to eq('Enabled' => false)
     end
@@ -634,7 +634,7 @@ describe RuboCop::Cop::Style::HashSyntax, :config do
     end
 
     it 'registers an offense when keys start with a digit and mix styles' do
-      inspect_source(cop, 'x = { :"1" => 1, b: 1 }')
+      inspect_source('x = { :"1" => 1, b: 1 }')
       expect(cop.messages).to eq(["Don't mix styles in the same hash."])
       expect(cop.config_to_allow_offenses).to eq('Enabled' => false)
     end

--- a/spec/rubocop/cop/style/if_unless_modifier_of_if_unless_spec.rb
+++ b/spec/rubocop/cop/style/if_unless_modifier_of_if_unless_spec.rb
@@ -7,7 +7,7 @@ describe RuboCop::Cop::Style::IfUnlessModifierOfIfUnless do
 
   it 'provides a good error message' do
     source = 'condition ? then_part : else_part unless external_condition'
-    inspect_source(cop, source)
+    inspect_source(source)
     expect(cop.messages)
       .to eq(['Avoid modifier `unless` after another conditional.'])
   end

--- a/spec/rubocop/cop/style/if_unless_modifier_spec.rb
+++ b/spec/rubocop/cop/style/if_unless_modifier_spec.rb
@@ -28,7 +28,7 @@ describe RuboCop::Cop::Style::IfUnlessModifier do
       # modifier.
       expect("#{body} if #{condition}".length).to eq(80)
 
-      inspect_source(cop, source)
+      inspect_source(source)
       expect(cop.messages).to eq(
         ['Favor modifier `if` usage when having a single-line' \
          ' body. Another good alternative is the usage of control flow' \
@@ -224,7 +224,7 @@ describe RuboCop::Cop::Style::IfUnlessModifier do
       it 'registers an offense' do
         expect("  #{body} if #{conditional}".length).to eq(80)
 
-        inspect_source(cop, source)
+        inspect_source(source)
         expect(cop.offenses.size).to eq(1)
       end
 
@@ -240,7 +240,7 @@ describe RuboCop::Cop::Style::IfUnlessModifier do
       it 'accepts' do
         expect("  #{body} if #{conditional}".length).to eq(81)
 
-        inspect_source(cop, source)
+        inspect_source(source)
         expect(cop.offenses).to be_empty
       end
     end

--- a/spec/rubocop/cop/style/if_unless_modifier_spec.rb
+++ b/spec/rubocop/cop/style/if_unless_modifier_spec.rb
@@ -37,7 +37,7 @@ describe RuboCop::Cop::Style::IfUnlessModifier do
     end
 
     it 'does auto-correction' do
-      corrected = autocorrect_source(cop, source)
+      corrected = autocorrect_source(source)
       expect(corrected).to eq "#{body} if #{condition}\n"
     end
 
@@ -71,7 +71,7 @@ describe RuboCop::Cop::Style::IfUnlessModifier do
     end
 
     it 'does auto-correction and preserves comment' do
-      corrected = autocorrect_source(cop, source)
+      corrected = autocorrect_source(source)
       expect(corrected).to eq "b if a # comment\n"
     end
   end
@@ -129,7 +129,7 @@ describe RuboCop::Cop::Style::IfUnlessModifier do
     end
 
     it 'does auto-correction' do
-      corrected = autocorrect_source(cop, source)
+      corrected = autocorrect_source(source)
       expect(corrected).to eq(<<-RUBY.strip_indent)
         if x
           y
@@ -173,7 +173,7 @@ describe RuboCop::Cop::Style::IfUnlessModifier do
     end
 
     it 'does auto-correction' do
-      corrected = autocorrect_source(cop, source)
+      corrected = autocorrect_source(source)
       expect(corrected).to eq "b unless a\n"
     end
   end
@@ -229,7 +229,7 @@ describe RuboCop::Cop::Style::IfUnlessModifier do
       end
 
       it 'does auto-correction' do
-        corrected = autocorrect_source(cop, source)
+        corrected = autocorrect_source(source)
         expect(corrected).to eq "  #{body} if #{conditional}\n"
       end
     end
@@ -273,7 +273,7 @@ describe RuboCop::Cop::Style::IfUnlessModifier do
   end
 
   it "doesn't break if-end when used as RHS of local var assignment" do
-    corrected = autocorrect_source(cop, <<-RUBY.strip_indent)
+    corrected = autocorrect_source(<<-RUBY.strip_indent)
       a = if b
         1
       end
@@ -282,7 +282,7 @@ describe RuboCop::Cop::Style::IfUnlessModifier do
   end
 
   it "doesn't break if-end when used as RHS of instance var assignment" do
-    corrected = autocorrect_source(cop, <<-RUBY.strip_indent)
+    corrected = autocorrect_source(<<-RUBY.strip_indent)
       @a = if b
         1
       end
@@ -291,7 +291,7 @@ describe RuboCop::Cop::Style::IfUnlessModifier do
   end
 
   it "doesn't break if-end when used as RHS of class var assignment" do
-    corrected = autocorrect_source(cop, <<-RUBY.strip_indent)
+    corrected = autocorrect_source(<<-RUBY.strip_indent)
       @@a = if b
         1
       end
@@ -300,7 +300,7 @@ describe RuboCop::Cop::Style::IfUnlessModifier do
   end
 
   it "doesn't break if-end when used as RHS of constant assignment" do
-    corrected = autocorrect_source(cop, <<-RUBY.strip_indent)
+    corrected = autocorrect_source(<<-RUBY.strip_indent)
       A = if b
         1
       end
@@ -309,7 +309,7 @@ describe RuboCop::Cop::Style::IfUnlessModifier do
   end
 
   it "doesn't break if-end when used as RHS of binary arithmetic" do
-    corrected = autocorrect_source(cop, <<-RUBY.strip_indent)
+    corrected = autocorrect_source(<<-RUBY.strip_indent)
       a + if b
         1
       end
@@ -327,7 +327,7 @@ describe RuboCop::Cop::Style::IfUnlessModifier do
 
   context 'if-end is argument to a parenthesized method call' do
     it "doesn't add redundant parentheses" do
-      corrected = autocorrect_source(cop, <<-RUBY.strip_indent)
+      corrected = autocorrect_source(<<-RUBY.strip_indent)
         puts("string", if a
           1
         end)
@@ -338,7 +338,7 @@ describe RuboCop::Cop::Style::IfUnlessModifier do
 
   context 'if-end is argument to a non-parenthesized method call' do
     it 'adds parentheses so as not to change meaning' do
-      corrected = autocorrect_source(cop, <<-RUBY.strip_indent)
+      corrected = autocorrect_source(<<-RUBY.strip_indent)
         puts "string", if a
           1
         end

--- a/spec/rubocop/cop/style/implicit_runtime_error_spec.rb
+++ b/spec/rubocop/cop/style/implicit_runtime_error_spec.rb
@@ -5,7 +5,7 @@ describe RuboCop::Cop::Style::ImplicitRuntimeError do
 
   %w[raise fail].each do |method|
     it "registers an offense for #{method} 'message'" do
-      inspect_source(cop, "#{method} 'message'")
+      inspect_source("#{method} 'message'")
       expect(cop.offenses.size).to eq 1
       expect(cop.messages).to eq(["Use `#{method}` with an explicit " \
                                  'exception class and message, rather than ' \
@@ -14,7 +14,7 @@ describe RuboCop::Cop::Style::ImplicitRuntimeError do
     end
 
     it "registers an offense for #{method} with a multiline string" do
-      inspect_source(cop, ["#{method} 'message' \\", "'2nd line'"])
+      inspect_source(["#{method} 'message' \\", "'2nd line'"])
       expect(cop.offenses.size).to eq 1
       expect(cop.messages).to eq(["Use `#{method}` with an explicit " \
                                  'exception class and message, rather than ' \
@@ -23,12 +23,12 @@ describe RuboCop::Cop::Style::ImplicitRuntimeError do
     end
 
     it "doesn't register an offense for #{method} StandardError, 'message'" do
-      inspect_source(cop, "#{method} StandardError, 'message'")
+      inspect_source("#{method} StandardError, 'message'")
       expect(cop.offenses).to be_empty
     end
 
     it "doesn't register an offense for #{method} with no arguments" do
-      inspect_source(cop, method)
+      inspect_source(method)
       expect(cop.offenses).to be_empty
     end
   end

--- a/spec/rubocop/cop/style/infinite_loop_spec.rb
+++ b/spec/rubocop/cop/style/infinite_loop_spec.rb
@@ -8,7 +8,7 @@ describe RuboCop::Cop::Style::InfiniteLoop do
 
   %w(1 2.0 [1] {}).each do |lit|
     it "registers an offense for a while loop with #{lit} as condition" do
-      inspect_source(cop, <<-RUBY.strip_indent)
+      inspect_source(<<-RUBY.strip_indent)
         while #{lit}
           top
         end
@@ -20,7 +20,7 @@ describe RuboCop::Cop::Style::InfiniteLoop do
 
   %w[false nil].each do |lit|
     it "registers an offense for a until loop with #{lit} as condition" do
-      inspect_source(cop, <<-RUBY.strip_indent)
+      inspect_source(<<-RUBY.strip_indent)
         until #{lit}
           top
         end

--- a/spec/rubocop/cop/style/infinite_loop_spec.rb
+++ b/spec/rubocop/cop/style/infinite_loop_spec.rb
@@ -37,7 +37,7 @@ describe RuboCop::Cop::Style::InfiniteLoop do
   shared_examples_for 'auto-corrector' do |keyword, lit|
     it "auto-corrects single line modifier #{keyword}" do
       new_source =
-        autocorrect_source(cop, "something += 1 #{keyword} #{lit} # comment")
+        autocorrect_source("something += 1 #{keyword} #{lit} # comment")
       expect(new_source).to eq('loop { something += 1 } # comment')
     end
 
@@ -47,7 +47,7 @@ describe RuboCop::Cop::Style::InfiniteLoop do
       end
 
       it "auto-corrects multi-line modifier #{keyword} and indents correctly" do
-        new_source = autocorrect_source(cop, <<-RUBY.strip_indent)
+        new_source = autocorrect_source(<<-RUBY.strip_indent)
           # comment
           something 1, # comment 1
               # comment 2
@@ -65,7 +65,7 @@ describe RuboCop::Cop::Style::InfiniteLoop do
     end
 
     it "auto-corrects begin-end-#{keyword} with one statement" do
-      new_source = autocorrect_source(cop, <<-RUBY.strip_margin('|'))
+      new_source = autocorrect_source(<<-RUBY.strip_margin('|'))
         |  begin # comment 1
         |    something += 1 # comment 2
         |  end #{keyword} #{lit} # comment 3
@@ -78,7 +78,7 @@ describe RuboCop::Cop::Style::InfiniteLoop do
     end
 
     it "auto-corrects begin-end-#{keyword} with two statements" do
-      new_source = autocorrect_source(cop, <<-RUBY.strip_margin('|'))
+      new_source = autocorrect_source(<<-RUBY.strip_margin('|'))
         | begin
         |  something += 1
         |  something_else += 1
@@ -94,13 +94,12 @@ describe RuboCop::Cop::Style::InfiniteLoop do
 
     it "auto-corrects single line modifier #{keyword} with and" do
       new_source =
-        autocorrect_source(cop,
-                           "something and something_else #{keyword} #{lit}")
+        autocorrect_source("something and something_else #{keyword} #{lit}")
       expect(new_source).to eq('loop { something and something_else }')
     end
 
     it "auto-corrects the usage of #{keyword} with do" do
-      new_source = autocorrect_source(cop, <<-RUBY.strip_indent)
+      new_source = autocorrect_source(<<-RUBY.strip_indent)
         #{keyword} #{lit} do
         end
       RUBY
@@ -111,7 +110,7 @@ describe RuboCop::Cop::Style::InfiniteLoop do
     end
 
     it "auto-corrects the usage of #{keyword} without do" do
-      new_source = autocorrect_source(cop, <<-RUBY.strip_indent)
+      new_source = autocorrect_source(<<-RUBY.strip_indent)
         #{keyword} #{lit}
         end
       RUBY

--- a/spec/rubocop/cop/style/inverse_methods_spec.rb
+++ b/spec/rubocop/cop/style/inverse_methods_spec.rb
@@ -52,13 +52,13 @@ describe RuboCop::Cop::Style::InverseMethods do
 
   context 'auto-correct' do
     it 'corrects !.none? wiht a symbol proc to any?' do
-      new_source = autocorrect_source(cop, '!foo.none?(&:even?)')
+      new_source = autocorrect_source('!foo.none?(&:even?)')
 
       expect(new_source).to eq('foo.any?(&:even?)')
     end
 
     it 'corrects !.none? with a block to any?' do
-      new_source = autocorrect_source(cop, '!foo.none? { |f| f.even? }')
+      new_source = autocorrect_source('!foo.none? { |f| f.even? }')
 
       expect(new_source).to eq('foo.any? { |f| f.even? }')
     end
@@ -80,13 +80,13 @@ describe RuboCop::Cop::Style::InverseMethods do
     end
 
     it "corrects !#{variable}.none? to #{variable}.any?" do
-      new_source = autocorrect_source(cop, "!#{variable}.none?")
+      new_source = autocorrect_source("!#{variable}.none?")
 
       expect(new_source).to eq("#{variable}.any?")
     end
 
     it "corrects not #{variable}.none? to #{variable}.any?" do
-      new_source = autocorrect_source(cop, "not #{variable}.none?")
+      new_source = autocorrect_source("not #{variable}.none?")
 
       expect(new_source).to eq("#{variable}.any?")
     end
@@ -117,7 +117,7 @@ describe RuboCop::Cop::Style::InverseMethods do
       end
 
       it "corrects #{method} to #{inverse}" do
-        new_source = autocorrect_source(cop, "!foo.#{method}")
+        new_source = autocorrect_source("!foo.#{method}")
 
         expect(new_source).to eq("foo.#{inverse}")
       end
@@ -144,7 +144,7 @@ describe RuboCop::Cop::Style::InverseMethods do
     end
 
     it "corrects #{method} to #{inverse}" do
-      new_source = autocorrect_source(cop, "!(foo #{method} bar)")
+      new_source = autocorrect_source("!(foo #{method} bar)")
 
       expect(new_source).to eq("foo #{inverse} bar")
     end
@@ -196,26 +196,26 @@ describe RuboCop::Cop::Style::InverseMethods do
       end
 
       it 'corrects a simple inverted block' do
-        new_source = autocorrect_source(cop, "foo.#{method} { |e| !e }")
+        new_source = autocorrect_source("foo.#{method} { |e| !e }")
 
         expect(new_source).to eq("foo.#{inverse} { |e| e }")
       end
 
       it 'corrects an inverted method call' do
-        new_source = autocorrect_source(cop, "foo.#{method} { |e| !e.bar? }")
+        new_source = autocorrect_source("foo.#{method} { |e| !e.bar? }")
 
         expect(new_source).to eq("foo.#{inverse} { |e| e.bar? }")
       end
 
       it 'corrects a complex inverted method call' do
         source = "puts 1 if !foo.#{method} { |e| !e.bar? }"
-        new_source = autocorrect_source(cop, source)
+        new_source = autocorrect_source(source)
 
         expect(new_source).to eq("puts 1 if !foo.#{inverse} { |e| e.bar? }")
       end
 
       it 'corrects an inverted do end method call' do
-        new_source = autocorrect_source(cop, <<-RUBY.strip_indent)
+        new_source = autocorrect_source(<<-RUBY.strip_indent)
           foo.#{method} do |e|
             !e.bar
           end
@@ -229,7 +229,7 @@ describe RuboCop::Cop::Style::InverseMethods do
       end
 
       it 'corrects a multiline method call where the last method is inverted' do
-        new_source = autocorrect_source(cop, <<-RUBY.strip_indent)
+        new_source = autocorrect_source(<<-RUBY.strip_indent)
           foo.#{method} do |e|
             something
             something_else
@@ -247,13 +247,13 @@ describe RuboCop::Cop::Style::InverseMethods do
       end
 
       it 'corrects an offense for an inverted equality block' do
-        new_source = autocorrect_source(cop, "foo.#{method} { |e| e != 2 }")
+        new_source = autocorrect_source("foo.#{method} { |e| e != 2 }")
 
         expect(new_source).to eq("foo.#{inverse} { |e| e == 2 }")
       end
 
       it 'corrects an offense for a multiline inverted equality block' do
-        new_source = autocorrect_source(cop, <<-RUBY.strip_indent)
+        new_source = autocorrect_source(<<-RUBY.strip_indent)
           foo.#{method} do |e|
             something
             something_else

--- a/spec/rubocop/cop/style/inverse_methods_spec.rb
+++ b/spec/rubocop/cop/style/inverse_methods_spec.rb
@@ -66,14 +66,14 @@ describe RuboCop::Cop::Style::InverseMethods do
 
   shared_examples :all_variable_types do |variable|
     it "registers an offense for calling !#{variable}.none?" do
-      inspect_source(cop, "!#{variable}.none?")
+      inspect_source("!#{variable}.none?")
 
       expect(cop.messages).to eq(['Use `any?` instead of inverting `none?`.'])
       expect(cop.highlights).to eq(["!#{variable}.none?"])
     end
 
     it "registers an offense for calling not #{variable}.none?" do
-      inspect_source(cop, "not #{variable}.none?")
+      inspect_source("not #{variable}.none?")
 
       expect(cop.messages).to eq(['Use `any?` instead of inverting `none?`.'])
       expect(cop.highlights).to eq(["not #{variable}.none?"])
@@ -110,7 +110,7 @@ describe RuboCop::Cop::Style::InverseMethods do
     blank?: :present?,
     exclude?: :include? }.each do |method, inverse|
       it "registers an offense for !foo.#{method}" do
-        inspect_source(cop, "!foo.#{method}")
+        inspect_source("!foo.#{method}")
 
         expect(cop.messages)
           .to eq(["Use `#{inverse}` instead of inverting `#{method}`."])
@@ -130,14 +130,14 @@ describe RuboCop::Cop::Style::InverseMethods do
     :< => :>=,
     :> => :<= }.each do |method, inverse|
     it "registers an offense for !(foo #{method} bar)" do
-      inspect_source(cop, "!(foo #{method} bar)")
+      inspect_source("!(foo #{method} bar)")
 
       expect(cop.messages)
         .to eq(["Use `#{inverse}` instead of inverting `#{method}`."])
     end
 
     it "registers an offense for not (foo #{method} bar)" do
-      inspect_source(cop, "not (foo #{method} bar)")
+      inspect_source("not (foo #{method} bar)")
 
       expect(cop.messages)
         .to eq(["Use `#{inverse}` instead of inverting `#{method}`."])
@@ -156,7 +156,7 @@ describe RuboCop::Cop::Style::InverseMethods do
       select!: :reject!,
       reject!: :select! }.each do |method, inverse|
       it "registers an offense for foo.#{method} { |e| !e }" do
-        inspect_source(cop, "foo.#{method} { |e| !e }")
+        inspect_source("foo.#{method} { |e| !e }")
 
         expect(cop.messages)
           .to eq(["Use `#{inverse}` instead of inverting `#{method}`."])
@@ -164,7 +164,7 @@ describe RuboCop::Cop::Style::InverseMethods do
 
       it 'registers an offense for a multiline method call where the last ' \
         'method is inverted' do
-        inspect_source(cop, <<-RUBY.strip_indent)
+        inspect_source(<<-RUBY.strip_indent)
           foo.#{method} do |e|
             something
             !e.bar
@@ -183,7 +183,7 @@ describe RuboCop::Cop::Style::InverseMethods do
       end
 
       it 'registers an offense for a multiline inverted equality block' do
-        inspect_source(cop, <<-RUBY.strip_indent)
+        inspect_source(<<-RUBY.strip_indent)
           foo.#{method} do |e|
             something
             something_else

--- a/spec/rubocop/cop/style/lambda_call_spec.rb
+++ b/spec/rubocop/cop/style/lambda_call_spec.rb
@@ -7,14 +7,13 @@ describe RuboCop::Cop::Style::LambdaCall, :config do
     let(:cop_config) { { 'EnforcedStyle' => 'call' } }
 
     it 'registers an offense for x.()' do
-      inspect_source(cop,
-                     'x.(a, b)')
+      inspect_source('x.(a, b)')
       expect(cop.offenses.size).to eq(1)
       expect(cop.config_to_allow_offenses).to eq('EnforcedStyle' => 'braces')
     end
 
     it 'registers an offense for correct + opposite' do
-      inspect_source(cop, <<-RUBY.strip_indent)
+      inspect_source(<<-RUBY.strip_indent)
         x.call(a, b)
         x.(a, b)
       RUBY
@@ -36,14 +35,13 @@ describe RuboCop::Cop::Style::LambdaCall, :config do
     let(:cop_config) { { 'EnforcedStyle' => 'braces' } }
 
     it 'registers an offense for x.call()' do
-      inspect_source(cop,
-                     'x.call(a, b)')
+      inspect_source('x.call(a, b)')
       expect(cop.offenses.size).to eq(1)
       expect(cop.config_to_allow_offenses).to eq('EnforcedStyle' => 'call')
     end
 
     it 'registers an offense for opposite + correct' do
-      inspect_source(cop, <<-RUBY.strip_indent)
+      inspect_source(<<-RUBY.strip_indent)
         x.call(a, b)
         x.(a, b)
       RUBY

--- a/spec/rubocop/cop/style/lambda_call_spec.rb
+++ b/spec/rubocop/cop/style/lambda_call_spec.rb
@@ -26,7 +26,7 @@ describe RuboCop::Cop::Style::LambdaCall, :config do
     end
 
     it 'auto-corrects x.() to x.call()' do
-      new_source = autocorrect_source(cop, ['a.(x)'])
+      new_source = autocorrect_source(['a.(x)'])
       expect(new_source).to eq('a.call(x)')
     end
   end
@@ -58,7 +58,7 @@ describe RuboCop::Cop::Style::LambdaCall, :config do
     end
 
     it 'auto-corrects x.call() to x.()' do
-      new_source = autocorrect_source(cop, ['a.call(x)'])
+      new_source = autocorrect_source(['a.call(x)'])
       expect(new_source).to eq('a.(x)')
     end
   end

--- a/spec/rubocop/cop/style/lambda_spec.rb
+++ b/spec/rubocop/cop/style/lambda_spec.rb
@@ -5,7 +5,7 @@ describe RuboCop::Cop::Style::Lambda, :config do
 
   shared_examples 'registers an offense' do |message|
     it 'registers an offense' do
-      inspect_source(cop, source)
+      inspect_source(source)
 
       expect(cop.offenses.size).to eq(1)
       expect(cop.messages).to eq([message])

--- a/spec/rubocop/cop/style/lambda_spec.rb
+++ b/spec/rubocop/cop/style/lambda_spec.rb
@@ -14,7 +14,7 @@ describe RuboCop::Cop::Style::Lambda, :config do
 
   shared_examples 'auto-correct' do |expected|
     it 'auto-corrects' do
-      new_source = autocorrect_source(cop, source)
+      new_source = autocorrect_source(source)
 
       expect(new_source).to eq(expected)
     end
@@ -22,7 +22,7 @@ describe RuboCop::Cop::Style::Lambda, :config do
 
   shared_examples 'does not auto-correct' do
     it 'does not autocorrect' do
-      expect(autocorrect_source(cop, source)).to eq(source)
+      expect(autocorrect_source(source)).to eq(source)
       expect(cop.offenses.map(&:corrected?)).to eq [false]
     end
   end

--- a/spec/rubocop/cop/style/line_end_concatenation_spec.rb
+++ b/spec/rubocop/cop/style/line_end_concatenation_spec.rb
@@ -66,8 +66,7 @@ describe RuboCop::Cop::Style::LineEndConcatenation do
 
   it 'registers multiple offenses when there are chained concatenations' \
      'combined with << calls' do
-    inspect_source(cop,
-                   ['top = "test#{x}" <<',
+    inspect_source(['top = "test#{x}" <<',
                     '"top" +',
                     '"foo" <<',
                     '"bar"'])
@@ -97,7 +96,7 @@ describe RuboCop::Cop::Style::LineEndConcatenation do
       x3a = 'x' +
         "\#{'a' + "\#{3}"}".reverse
     RUBY
-    inspect_source(cop, source)
+    inspect_source(source)
     expect(cop.offenses).to be_empty
   end
 

--- a/spec/rubocop/cop/style/line_end_concatenation_spec.rb
+++ b/spec/rubocop/cop/style/line_end_concatenation_spec.rb
@@ -142,8 +142,7 @@ describe RuboCop::Cop::Style::LineEndConcatenation do
   end
 
   it 'autocorrects in the simple case by replacing + with \\' do
-    corrected = autocorrect_source(cop,
-                                   ['top = "test" +',
+    corrected = autocorrect_source(['top = "test" +',
                                     '"top"'])
     expect(corrected).to eq ['top = "test" \\', '"top"'].join("\n")
   end
@@ -152,22 +151,19 @@ describe RuboCop::Cop::Style::LineEndConcatenation do
   # the code has syntax errors, so it's important to fix the trailing
   # whitespace in this cop.
   it 'autocorrects a + with trailing whitespace to \\' do
-    corrected = autocorrect_source(cop,
-                                   ['top = "test" + ',
+    corrected = autocorrect_source(['top = "test" + ',
                                     '"top"'])
     expect(corrected).to eq ['top = "test" \\', '"top"'].join("\n")
   end
 
   it 'autocorrects a + with \\ to just \\' do
-    corrected = autocorrect_source(cop,
-                                   ['top = "test" + \\',
+    corrected = autocorrect_source(['top = "test" + \\',
                                     '"top"'])
     expect(corrected).to eq ['top = "test" \\', '"top"'].join("\n")
   end
 
   it 'autocorrects for chained concatenations and << calls' do
-    corrected = autocorrect_source(cop,
-                                   ['top = "test#{x}" <<',
+    corrected = autocorrect_source(['top = "test#{x}" <<',
                                     '"top" +',
                                     '"ubertop" <<',
                                     '"foo"'])
@@ -179,8 +175,7 @@ describe RuboCop::Cop::Style::LineEndConcatenation do
   end
 
   it 'autocorrects only the lines that should be autocorrected' do
-    corrected = autocorrect_source(cop,
-                                   ['top = "test#{x}" <<',
+    corrected = autocorrect_source(['top = "test#{x}" <<',
                                     '"top" + # comment',
                                     '"foo" +',
                                     '"bar" +',

--- a/spec/rubocop/cop/style/method_call_with_args_parentheses_spec.rb
+++ b/spec/rubocop/cop/style/method_call_with_args_parentheses_spec.rb
@@ -74,17 +74,17 @@ describe RuboCop::Cop::Style::MethodCallWithArgsParentheses, :config do
   end
 
   it 'auto-corrects call by adding needed braces' do
-    new_source = autocorrect_source(cop, 'top.test a')
+    new_source = autocorrect_source('top.test a')
     expect(new_source).to eq('top.test(a)')
   end
 
   it 'auto-corrects superclass call by adding needed braces' do
-    new_source = autocorrect_source(cop, 'super a')
+    new_source = autocorrect_source('super a')
     expect(new_source).to eq('super(a)')
   end
 
   it 'auto-corrects superclass call by adding needed braces' do
-    new_source = autocorrect_source(cop, 'yield a')
+    new_source = autocorrect_source('yield a')
     expect(new_source).to eq('yield(a)')
   end
 

--- a/spec/rubocop/cop/style/method_call_without_args_parentheses_spec.rb
+++ b/spec/rubocop/cop/style/method_call_without_args_parentheses_spec.rb
@@ -78,7 +78,7 @@ describe RuboCop::Cop::Style::MethodCallWithoutArgsParentheses do
   end
 
   it 'auto-corrects by removing unneeded braces' do
-    new_source = autocorrect_source(cop, 'test()')
+    new_source = autocorrect_source('test()')
     expect(new_source).to eq('test')
   end
 
@@ -90,7 +90,7 @@ describe RuboCop::Cop::Style::MethodCallWithoutArgsParentheses do
       Array.new()
       String.new()
     RUBY
-    new_source = autocorrect_source(cop, original)
+    new_source = autocorrect_source(original)
     expect(new_source).to eq(<<-RUBY.strip_indent)
       Hash.new
       Array.new

--- a/spec/rubocop/cop/style/method_def_parentheses_spec.rb
+++ b/spec/rubocop/cop/style/method_def_parentheses_spec.rb
@@ -46,17 +46,17 @@ describe RuboCop::Cop::Style::MethodDefParentheses, :config do
     end
 
     it 'auto-adds required parens for a def' do
-      new_source = autocorrect_source(cop, 'def test param; end')
+      new_source = autocorrect_source('def test param; end')
       expect(new_source).to eq('def test(param); end')
     end
 
     it 'auto-adds required parens for a defs' do
-      new_source = autocorrect_source(cop, 'def self.test param; end')
+      new_source = autocorrect_source('def self.test param; end')
       expect(new_source).to eq('def self.test(param); end')
     end
 
     it 'auto-adds required parens to argument lists on multiple lines' do
-      new_source = autocorrect_source(cop, <<-RUBY.strip_indent)
+      new_source = autocorrect_source(<<-RUBY.strip_indent)
         def test one,
         two
         end
@@ -142,12 +142,12 @@ describe RuboCop::Cop::Style::MethodDefParentheses, :config do
     end
 
     it 'auto-removes the parens' do
-      new_source = autocorrect_source(cop, 'def test(param); end')
+      new_source = autocorrect_source('def test(param); end')
       expect(new_source).to eq('def test param; end')
     end
 
     it 'auto-removes the parens for defs' do
-      new_source = autocorrect_source(cop, 'def self.test(param); end')
+      new_source = autocorrect_source('def self.test(param); end')
       expect(new_source).to eq('def self.test param; end')
     end
   end
@@ -183,7 +183,7 @@ describe RuboCop::Cop::Style::MethodDefParentheses, :config do
       end
 
       it 'auto-adds required parens to argument lists on multiple lines' do
-        new_source = autocorrect_source(cop, <<-RUBY.strip_indent)
+        new_source = autocorrect_source(<<-RUBY.strip_indent)
           def test one,
           two
           end

--- a/spec/rubocop/cop/style/method_def_parentheses_spec.rb
+++ b/spec/rubocop/cop/style/method_def_parentheses_spec.rb
@@ -11,7 +11,7 @@ describe RuboCop::Cop::Style::MethodDefParentheses, :config do
         def func a, b
         end
       RUBY
-      inspect_source(cop, src)
+      inspect_source(src)
       expect(cop.offenses.size).to eq(1)
       expect(cop.config_to_allow_offenses).to eq('EnforcedStyle' =>
                                                  'require_no_parentheses')
@@ -24,7 +24,7 @@ describe RuboCop::Cop::Style::MethodDefParentheses, :config do
         def func a, b
         end
       RUBY
-      inspect_source(cop, src)
+      inspect_source(src)
       expect(cop.offenses.size).to eq(1)
       expect(cop.config_to_allow_offenses).to eq('Enabled' => false)
     end
@@ -34,7 +34,7 @@ describe RuboCop::Cop::Style::MethodDefParentheses, :config do
         def Test.func a, b
         end
       RUBY
-      inspect_source(cop, src)
+      inspect_source(src)
       expect(cop.offenses.size).to eq(1)
     end
 
@@ -78,7 +78,7 @@ describe RuboCop::Cop::Style::MethodDefParentheses, :config do
         def func(a, b)
         end
       RUBY
-      inspect_source(cop, src)
+      inspect_source(src)
       expect(cop.offenses.size).to eq(1)
       expect(cop.config_to_allow_offenses).to eq('EnforcedStyle' =>
                                                  'require_parentheses')
@@ -89,7 +89,7 @@ describe RuboCop::Cop::Style::MethodDefParentheses, :config do
         def func a, b
         end
       RUBY
-      inspect_source(cop, src)
+      inspect_source(src)
       expect(cop.offenses).to be_empty
     end
 
@@ -100,7 +100,7 @@ describe RuboCop::Cop::Style::MethodDefParentheses, :config do
         def func a, b
         end
       RUBY
-      inspect_source(cop, src)
+      inspect_source(src)
       expect(cop.offenses.size).to eq(1)
       expect(cop.config_to_allow_offenses).to eq('Enabled' => false)
     end
@@ -110,7 +110,7 @@ describe RuboCop::Cop::Style::MethodDefParentheses, :config do
         def Test.func(a, b)
         end
       RUBY
-      inspect_source(cop, src)
+      inspect_source(src)
       expect(cop.offenses.size).to eq(1)
     end
 
@@ -119,7 +119,7 @@ describe RuboCop::Cop::Style::MethodDefParentheses, :config do
         def Test.func a, b
         end
       RUBY
-      inspect_source(cop, src)
+      inspect_source(src)
       expect(cop.offenses).to be_empty
     end
 
@@ -128,7 +128,7 @@ describe RuboCop::Cop::Style::MethodDefParentheses, :config do
         def func()
         end
       RUBY
-      inspect_source(cop, src)
+      inspect_source(src)
       expect(cop.offenses.size).to eq(1)
     end
 
@@ -137,7 +137,7 @@ describe RuboCop::Cop::Style::MethodDefParentheses, :config do
         def func
         end
       RUBY
-      inspect_source(cop, src)
+      inspect_source(src)
       expect(cop.offenses).to be_empty
     end
 
@@ -177,7 +177,7 @@ describe RuboCop::Cop::Style::MethodDefParentheses, :config do
                    b
           end
         RUBY
-        inspect_source(cop, src)
+        inspect_source(src)
         expect(cop.offenses.size).to eq(1)
         expect(cop.config_to_allow_offenses).to eq('Enabled' => false)
       end

--- a/spec/rubocop/cop/style/method_missing_spec.rb
+++ b/spec/rubocop/cop/style/method_missing_spec.rb
@@ -4,7 +4,7 @@ describe RuboCop::Cop::Style::MethodMissing do
   subject(:cop) { described_class.new }
 
   before do
-    inspect_source(cop, source)
+    inspect_source(source)
   end
 
   shared_examples 'code with offense' do |code|

--- a/spec/rubocop/cop/style/method_name_spec.rb
+++ b/spec/rubocop/cop/style/method_name_spec.rb
@@ -5,7 +5,7 @@ describe RuboCop::Cop::Style::MethodName, :config do
 
   shared_examples 'never accepted' do
     it 'registers an offense for mixed snake case and camel case' do
-      inspect_source(cop, <<-RUBY.strip_indent)
+      inspect_source(<<-RUBY.strip_indent)
         def visit_Arel_Nodes_SelectStatement
         end
       RUBY
@@ -14,7 +14,7 @@ describe RuboCop::Cop::Style::MethodName, :config do
     end
 
     it 'registers an offense for capitalized camel case' do
-      inspect_source(cop, <<-RUBY.strip_indent)
+      inspect_source(<<-RUBY.strip_indent)
         class MyClass
           def MyMethod
           end
@@ -26,7 +26,7 @@ describe RuboCop::Cop::Style::MethodName, :config do
 
     it 'registers an offense for singleton upper case method without ' \
        'corresponding class' do
-      inspect_source(cop, <<-RUBY.strip_indent)
+      inspect_source(<<-RUBY.strip_indent)
         module Sequel
           def self.Model(source)
           end
@@ -61,7 +61,7 @@ describe RuboCop::Cop::Style::MethodName, :config do
 
     %w[class module].each do |kind|
       it "accepts class emitter method in a #{kind}" do
-        inspect_source(cop, <<-RUBY.strip_indent)
+        inspect_source(<<-RUBY.strip_indent)
           #{kind} Sequel
             def self.Model(source)
             end
@@ -75,7 +75,7 @@ describe RuboCop::Cop::Style::MethodName, :config do
 
       it "accepts class emitter method in a #{kind}, even when it is " \
          'defined inside another method' do
-        inspect_source(cop, <<-RUBY.strip_indent)
+        inspect_source(<<-RUBY.strip_indent)
           module DPN
             module Flow
               module BaseFlow
@@ -98,7 +98,7 @@ describe RuboCop::Cop::Style::MethodName, :config do
     let(:cop_config) { { 'EnforcedStyle' => 'snake_case' } }
 
     it 'registers an offense for camel case in instance method name' do
-      inspect_source(cop, <<-RUBY.strip_indent)
+      inspect_source(<<-RUBY.strip_indent)
         def myMethod
           # ...
         end
@@ -110,7 +110,7 @@ describe RuboCop::Cop::Style::MethodName, :config do
     end
 
     it 'registers an offense for opposite + correct' do
-      inspect_source(cop, <<-RUBY.strip_indent)
+      inspect_source(<<-RUBY.strip_indent)
         def my_method
         end
         def myMethod
@@ -170,7 +170,7 @@ describe RuboCop::Cop::Style::MethodName, :config do
     end
 
     it 'registers an offense for snake case in names' do
-      inspect_source(cop, <<-RUBY.strip_indent)
+      inspect_source(<<-RUBY.strip_indent)
         def my_method
         end
       RUBY
@@ -181,7 +181,7 @@ describe RuboCop::Cop::Style::MethodName, :config do
     end
 
     it 'registers an offense for correct + opposite' do
-      inspect_source(cop, <<-RUBY.strip_indent)
+      inspect_source(<<-RUBY.strip_indent)
         def my_method
         end
         def myMethod
@@ -209,7 +209,7 @@ describe RuboCop::Cop::Style::MethodName, :config do
     let(:cop_config) { { 'EnforcedStyle' => 'other' } }
 
     it 'fails' do
-      expect { inspect_source(cop, 'def a', 'end') }
+      expect { inspect_source('end') }
         .to raise_error(RuntimeError)
     end
   end

--- a/spec/rubocop/cop/style/missing_else_spec.rb
+++ b/spec/rubocop/cop/style/missing_else_spec.rb
@@ -233,7 +233,7 @@ describe RuboCop::Cop::Style::MissingElse do
 
       context 'with no else-clause' do
         it 'registers an offense' do
-          inspect_source(cop, 'if cond; foo end')
+          inspect_source('if cond; foo end')
           msg = ['`if` condition requires an `else`-clause with `nil` in it.']
           expect(cop.messages)
             .to eq(msg)
@@ -269,7 +269,7 @@ describe RuboCop::Cop::Style::MissingElse do
 
       context 'with no else-clause' do
         it 'registers an offense' do
-          inspect_source(cop, 'unless cond; foo end')
+          inspect_source('unless cond; foo end')
           msg = ['`if` condition requires an `else`-clause with `nil` in it.']
           expect(cop.messages)
             .to eq(msg)
@@ -298,7 +298,7 @@ describe RuboCop::Cop::Style::MissingElse do
 
       context 'with no else-clause' do
         it 'registers an offense' do
-          inspect_source(cop, 'case v; when a; foo; when b; bar; end')
+          inspect_source('case v; when a; foo; when b; bar; end')
           msg = ['`case` condition requires an `else`-clause with `nil` in it.']
           expect(cop.messages)
             .to eq(msg)

--- a/spec/rubocop/cop/style/mixin_grouping_spec.rb
+++ b/spec/rubocop/cop/style/mixin_grouping_spec.rb
@@ -4,7 +4,7 @@ describe RuboCop::Cop::Style::MixinGrouping, :config do
   subject(:cop) { described_class.new(config) }
 
   before do
-    inspect_source(cop, source)
+    inspect_source(source)
   end
 
   shared_examples 'code with offense' do |code, expected|

--- a/spec/rubocop/cop/style/mixin_grouping_spec.rb
+++ b/spec/rubocop/cop/style/mixin_grouping_spec.rb
@@ -18,11 +18,11 @@ describe RuboCop::Cop::Style::MixinGrouping, :config do
 
       if expected
         it 'auto-corrects' do
-          expect(autocorrect_source(cop, code)).to eq(expected)
+          expect(autocorrect_source(code)).to eq(expected)
         end
       else
         it 'does not auto-correct' do
-          expect(autocorrect_source(cop, code)).to eq(code)
+          expect(autocorrect_source(code)).to eq(code)
         end
       end
     end

--- a/spec/rubocop/cop/style/multiline_block_chain_spec.rb
+++ b/spec/rubocop/cop/style/multiline_block_chain_spec.rb
@@ -42,7 +42,7 @@ describe RuboCop::Cop::Style::MultilineBlockChain do
 
     it 'registers an offense for a chain where the second block is ' \
        'single-line' do
-      inspect_source(cop, <<-RUBY.strip_indent)
+      inspect_source(<<-RUBY.strip_indent)
         Thread.list.find_all { |t|
           t.alive?
         }.map { |thread| thread.object_id }

--- a/spec/rubocop/cop/style/multiline_if_modifier_spec.rb
+++ b/spec/rubocop/cop/style/multiline_if_modifier_spec.rb
@@ -21,7 +21,7 @@ describe RuboCop::Cop::Style::MultilineIfModifier do
 
   shared_examples 'autocorrect' do |correct_code|
     it 'auto-corrects' do
-      corrected = autocorrect_source(cop, source)
+      corrected = autocorrect_source(source)
       expect(corrected).to eq(correct_code)
     end
   end

--- a/spec/rubocop/cop/style/multiline_if_modifier_spec.rb
+++ b/spec/rubocop/cop/style/multiline_if_modifier_spec.rb
@@ -5,7 +5,7 @@ describe RuboCop::Cop::Style::MultilineIfModifier do
 
   shared_examples 'offense' do |modifier|
     it 'registers an offense' do
-      inspect_source(cop, source)
+      inspect_source(source)
       expect(cop.messages)
         .to eq(["Favor a normal #{modifier}-statement over a modifier" \
                 ' clause in a multiline statement.'])
@@ -14,7 +14,7 @@ describe RuboCop::Cop::Style::MultilineIfModifier do
 
   shared_examples 'no offense' do
     it 'does not register an offense' do
-      inspect_source(cop, source)
+      inspect_source(source)
       expect(cop.messages).to be_empty
     end
   end

--- a/spec/rubocop/cop/style/multiline_if_then_spec.rb
+++ b/spec/rubocop/cop/style/multiline_if_then_spec.rb
@@ -14,17 +14,17 @@ describe RuboCop::Cop::Style::MultilineIfThen do
   end
 
   it 'registers an offense for then in multiline if' do
-    inspect_source(cop, ['if cond then',
-                         'end',
-                         "if cond then\t",
-                         'end',
-                         'if cond then  ',
-                         'end',
-                         'if cond',
-                         'then',
-                         'end',
-                         'if cond then # bad',
-                         'end'])
+    inspect_source(['if cond then',
+                    'end',
+                    "if cond then\t",
+                    'end',
+                    'if cond then  ',
+                    'end',
+                    'if cond',
+                    'then',
+                    'end',
+                    'if cond then # bad',
+                    'end'])
     expect(cop.offenses.map(&:line)).to eq([1, 3, 5, 8, 10])
     expect(cop.highlights).to eq(['then'] * 5)
     expect(cop.messages).to eq(['Do not use `then` for multi-line `if`.'] * 5)
@@ -80,7 +80,7 @@ describe RuboCop::Cop::Style::MultilineIfThen do
 
   it 'does not raise an error for an implicit match if' do
     expect do
-      inspect_source(cop, <<-RUBY.strip_indent)
+      inspect_source(<<-RUBY.strip_indent)
         if //
         end
       RUBY
@@ -118,7 +118,7 @@ describe RuboCop::Cop::Style::MultilineIfThen do
 
   it 'does not raise an error for an implicit match unless' do
     expect do
-      inspect_source(cop, <<-RUBY.strip_indent)
+      inspect_source(<<-RUBY.strip_indent)
         unless //
         end
       RUBY

--- a/spec/rubocop/cop/style/multiline_if_then_spec.rb
+++ b/spec/rubocop/cop/style/multiline_if_then_spec.rb
@@ -126,7 +126,7 @@ describe RuboCop::Cop::Style::MultilineIfThen do
   end
 
   it 'auto-corrects the usage of "then" in multiline if' do
-    new_source = autocorrect_source(cop, <<-RUBY.strip_indent)
+    new_source = autocorrect_source(<<-RUBY.strip_indent)
       if cond then
         something
       end

--- a/spec/rubocop/cop/style/multiline_memoization_spec.rb
+++ b/spec/rubocop/cop/style/multiline_memoization_spec.rb
@@ -17,7 +17,7 @@ describe RuboCop::Cop::Style::MultilineMemoization, :config do
     end
 
     it 'auto-corrects' do
-      expect(autocorrect_source(cop, code)).to eq(expected)
+      expect(autocorrect_source(code)).to eq(expected)
     end
   end
 

--- a/spec/rubocop/cop/style/multiline_memoization_spec.rb
+++ b/spec/rubocop/cop/style/multiline_memoization_spec.rb
@@ -5,7 +5,7 @@ describe RuboCop::Cop::Style::MultilineMemoization, :config do
   let(:message) { 'Wrap multiline memoization blocks in `begin` and `end`.' }
 
   before do
-    inspect_source(cop, source)
+    inspect_source(source)
   end
 
   shared_examples 'code with offense' do |code, expected|

--- a/spec/rubocop/cop/style/multiline_ternary_operator_spec.rb
+++ b/spec/rubocop/cop/style/multiline_ternary_operator_spec.rb
@@ -5,7 +5,7 @@ describe RuboCop::Cop::Style::MultilineTernaryOperator do
 
   it 'registers offense when the if branch and the else branch are ' \
      'on a separate line from the condition' do
-    inspect_source(cop, <<-RUBY.strip_indent)
+    inspect_source(<<-RUBY.strip_indent)
       a = cond ?
         b : c
     RUBY
@@ -13,7 +13,7 @@ describe RuboCop::Cop::Style::MultilineTernaryOperator do
   end
 
   it 'registers an offense when the false branch is on a separate line' do
-    inspect_source(cop, <<-RUBY.strip_indent)
+    inspect_source(<<-RUBY.strip_indent)
       a = cond ? b :
           c
     RUBY
@@ -22,7 +22,7 @@ describe RuboCop::Cop::Style::MultilineTernaryOperator do
   end
 
   it 'registers an offense when everything is on a separate line' do
-    inspect_source(cop, <<-RUBY.strip_indent)
+    inspect_source(<<-RUBY.strip_indent)
       a = cond ?
           b :
           c

--- a/spec/rubocop/cop/style/multiple_comparison_spec.rb
+++ b/spec/rubocop/cop/style/multiple_comparison_spec.rb
@@ -7,100 +7,100 @@ describe RuboCop::Cop::Style::MultipleComparison do
   subject(:cop) { described_class.new(config) }
 
   it 'accepts' do
-    inspect_source(cop, ['a = "a"',
-                         'if a == "a"',
-                         '  print a',
-                         'end'])
+    inspect_source(['a = "a"',
+                    'if a == "a"',
+                    '  print a',
+                    'end'])
     expect(cop.offenses).to be_empty
   end
 
   it 'registers an offense for offending code' do
-    inspect_source(cop, ['a = "a"',
-                         'if a == "a" || a == "b"',
-                         '  print a',
-                         'end'])
+    inspect_source(['a = "a"',
+                    'if a == "a" || a == "b"',
+                    '  print a',
+                    'end'])
     expect(cop.offenses.size).to eq(1)
   end
 
   it 'registers an offense for offending code' do
-    inspect_source(cop, ['a = "a"',
-                         'if a == "a" || a == "b" || a == "c"',
-                         '  print a',
-                         'end'])
+    inspect_source(['a = "a"',
+                    'if a == "a" || a == "b" || a == "c"',
+                    '  print a',
+                    'end'])
     expect(cop.offenses.size).to eq(1)
   end
 
   it 'registers an offense for offending code' do
-    inspect_source(cop, ['a = "a"',
-                         'if "a" == a || "b" == a || "c" == a',
-                         '  print a',
-                         'end'])
+    inspect_source(['a = "a"',
+                    'if "a" == a || "b" == a || "c" == a',
+                    '  print a',
+                    'end'])
     expect(cop.offenses.size).to eq(1)
   end
 
   it 'registers an offense for offending code' do
-    inspect_source(cop, ['a = "a"',
-                         'if a == "a" || "b" == a || a == "c"',
-                         '  print a',
-                         'end'])
+    inspect_source(['a = "a"',
+                    'if a == "a" || "b" == a || a == "c"',
+                    '  print a',
+                    'end'])
     expect(cop.offenses.size).to eq(1)
   end
 
   it 'accepts' do
-    inspect_source(cop, ['if "a" == "a" || "a" == "c"',
-                         '  print "a"',
-                         'end'])
+    inspect_source(['if "a" == "a" || "a" == "c"',
+                    '  print "a"',
+                    'end'])
     expect(cop.offenses).to be_empty
   end
 
   it 'accepts' do
-    inspect_source(cop, ['if 1 == 1 || 1 == 2',
-                         '  print 1',
-                         'end'])
+    inspect_source(['if 1 == 1 || 1 == 2',
+                    '  print 1',
+                    'end'])
     expect(cop.offenses).to be_empty
   end
 
   it 'accepts' do
-    inspect_source(cop, ['a = "a"',
-                         'b = "b"',
-                         'if a == "a" || b == "b"',
-                         '  print a',
-                         'end'])
+    inspect_source(['a = "a"',
+                    'b = "b"',
+                    'if a == "a" || b == "b"',
+                    '  print a',
+                    'end'])
     expect(cop.offenses).to be_empty
   end
 
   it 'accepts' do
-    inspect_source(cop, ['a = "a"',
-                         'b = "b"',
-                         'if a == "a" || "b" == b',
-                         '  print a',
-                         'end'])
+    inspect_source(['a = "a"',
+                    'b = "b"',
+                    'if a == "a" || "b" == b',
+                    '  print a',
+                    'end'])
     expect(cop.offenses).to be_empty
   end
 
   it 'accepts' do
-    inspect_source(cop, ['a = "a"',
-                         'b = "b"',
-                         'if a == b || b == a',
-                         '  print a',
-                         'end'])
+    inspect_source(['a = "a"',
+                    'b = "b"',
+                    'if a == b || b == a',
+                    '  print a',
+                    'end'])
     expect(cop.offenses).to be_empty
   end
 
   it 'accepts' do
-    inspect_source(cop, ['a = "a"',
-                         'b = "b"',
-                         'if a == b || a == b',
-                         '  print a',
-                         'end'])
+    inspect_source(['a = "a"',
+                    'b = "b"',
+                    'if a == b || a == b',
+                    '  print a',
+                    'end'])
     expect(cop.offenses).to be_empty
   end
 
   it 'accepts' do
-    inspect_source(cop, ['a = "a"',
-                         'if ["a", "b", "c"].include? a',
-                         '  print a',
-                         'end'])
+    inspect_source(['a = "a"',
+                    'if ["a", "b", "c"].include? a',
+                    '  print a',
+                    'end'])
     expect(cop.offenses).to be_empty
   end
 end

--- a/spec/rubocop/cop/style/mutable_constant_spec.rb
+++ b/spec/rubocop/cop/style/mutable_constant_spec.rb
@@ -15,7 +15,7 @@ describe RuboCop::Cop::Style::MutableConstant do
 
       it 'auto-corrects by adding .freeze' do
         source = [prefix, "CONST = #{o}"].compact.join("\n")
-        new_source = autocorrect_source(cop, source)
+        new_source = autocorrect_source(source)
         expect(new_source).to eq("#{source}.freeze")
       end
     end
@@ -29,7 +29,7 @@ describe RuboCop::Cop::Style::MutableConstant do
 
       it 'auto-corrects by adding .freeze' do
         source = [prefix, "CONST ||= #{o}"].compact.join("\n")
-        new_source = autocorrect_source(cop, source)
+        new_source = autocorrect_source(source)
         expect(new_source).to eq("#{source}.freeze")
       end
     end
@@ -77,7 +77,7 @@ describe RuboCop::Cop::Style::MutableConstant do
       inspect_source(source)
       expect(cop.offenses.size).to eq(1)
 
-      corrected = autocorrect_source(cop, source)
+      corrected = autocorrect_source(source)
 
       expect(corrected).to eq('BAR = *[1, 2, 3].freeze')
     end
@@ -85,12 +85,12 @@ describe RuboCop::Cop::Style::MutableConstant do
 
   context 'when assigning an array without brackets' do
     it 'adds brackets when auto-correcting' do
-      new_source = autocorrect_source(cop, 'XXX = YYY, ZZZ')
+      new_source = autocorrect_source('XXX = YYY, ZZZ')
       expect(new_source).to eq 'XXX = [YYY, ZZZ].freeze'
     end
 
     it 'does not add brackets to %w() arrays' do
-      new_source = autocorrect_source(cop, 'XXX = %w(YYY ZZZ)')
+      new_source = autocorrect_source('XXX = %w(YYY ZZZ)')
       expect(new_source).to eq 'XXX = %w(YYY ZZZ).freeze'
     end
   end

--- a/spec/rubocop/cop/style/mutable_constant_spec.rb
+++ b/spec/rubocop/cop/style/mutable_constant_spec.rb
@@ -9,7 +9,7 @@ describe RuboCop::Cop::Style::MutableConstant do
     context 'when assigning with =' do
       it "registers an offense for #{o} assigned to a constant" do
         source = [prefix, "CONST = #{o}"].compact.join("\n")
-        inspect_source(cop, source)
+        inspect_source(source)
         expect(cop.offenses.size).to eq(1)
       end
 
@@ -23,7 +23,7 @@ describe RuboCop::Cop::Style::MutableConstant do
     context 'when assigning with ||=' do
       it "registers an offense for #{o} assigned to a constant" do
         source = [prefix, "CONST ||= #{o}"].compact.join("\n")
-        inspect_source(cop, source)
+        inspect_source(source)
         expect(cop.offenses.size).to eq(1)
       end
 
@@ -43,13 +43,13 @@ describe RuboCop::Cop::Style::MutableConstant do
   shared_examples :immutable_objects do |o|
     it "allows #{o} to be assigned to a constant" do
       source = [prefix, "CONST = #{o}"].compact.join("\n")
-      inspect_source(cop, source)
+      inspect_source(source)
       expect(cop.offenses).to be_empty
     end
 
     it "allows #{o} to be ||= to a constant" do
       source = [prefix, "CONST ||= #{o}"].compact.join("\n")
-      inspect_source(cop, source)
+      inspect_source(source)
       expect(cop.offenses).to be_empty
     end
   end
@@ -74,7 +74,7 @@ describe RuboCop::Cop::Style::MutableConstant do
     it 'registers an offense for a mutable value' do
       source = 'BAR = *[1, 2, 3]'
 
-      inspect_source(cop, source)
+      inspect_source(source)
       expect(cop.offenses.size).to eq(1)
 
       corrected = autocorrect_source(cop, source)

--- a/spec/rubocop/cop/style/negated_if_spec.rb
+++ b/spec/rubocop/cop/style/negated_if_spec.rb
@@ -13,7 +13,7 @@ describe RuboCop::Cop::Style::NegatedIf do
 
   describe 'with “both” style' do
     it 'registers an offense for if with exclamation point condition' do
-      inspect_source(cop, <<-RUBY.strip_indent)
+      inspect_source(<<-RUBY.strip_indent)
         if !a_condition
           some_method
         end
@@ -26,7 +26,7 @@ describe RuboCop::Cop::Style::NegatedIf do
     end
 
     it 'registers an offense for unless with exclamation point condition' do
-      inspect_source(cop, <<-RUBY.strip_indent)
+      inspect_source(<<-RUBY.strip_indent)
         unless !a_condition
           some_method
         end
@@ -37,7 +37,7 @@ describe RuboCop::Cop::Style::NegatedIf do
     end
 
     it 'registers an offense for if with "not" condition' do
-      inspect_source(cop, <<-RUBY.strip_indent)
+      inspect_source(<<-RUBY.strip_indent)
         if not a_condition
           some_method
         end
@@ -145,7 +145,7 @@ describe RuboCop::Cop::Style::NegatedIf do
     end
 
     it 'registers an offence for prefix' do
-      inspect_source(cop, <<-RUBY.strip_indent)
+      inspect_source(<<-RUBY.strip_indent)
         if !foo
         end
       RUBY

--- a/spec/rubocop/cop/style/negated_if_spec.rb
+++ b/spec/rubocop/cop/style/negated_if_spec.rb
@@ -99,28 +99,28 @@ describe RuboCop::Cop::Style::NegatedIf do
     end
 
     it 'autocorrects for postfix' do
-      corrected = autocorrect_source(cop, 'bar if !foo')
+      corrected = autocorrect_source('bar if !foo')
 
       expect(corrected).to eq 'bar unless foo'
     end
 
     it 'autocorrects by replacing if not with unless' do
-      corrected = autocorrect_source(cop, 'something if !x.even?')
+      corrected = autocorrect_source('something if !x.even?')
       expect(corrected).to eq 'something unless x.even?'
     end
 
     it 'autocorrects by replacing parenthesized if not with unless' do
-      corrected = autocorrect_source(cop, 'something if (!x.even?)')
+      corrected = autocorrect_source('something if (!x.even?)')
       expect(corrected).to eq 'something unless (x.even?)'
     end
 
     it 'autocorrects by replacing unless not with if' do
-      corrected = autocorrect_source(cop, 'something unless !x.even?')
+      corrected = autocorrect_source('something unless !x.even?')
       expect(corrected).to eq 'something if x.even?'
     end
 
     it 'autocorrects for prefix' do
-      corrected = autocorrect_source(cop, <<-RUBY.strip_indent)
+      corrected = autocorrect_source(<<-RUBY.strip_indent)
         if !foo
         end
       RUBY
@@ -160,7 +160,7 @@ describe RuboCop::Cop::Style::NegatedIf do
     end
 
     it 'autocorrects for prefix' do
-      corrected = autocorrect_source(cop, <<-RUBY.strip_indent)
+      corrected = autocorrect_source(<<-RUBY.strip_indent)
         if !foo
         end
       RUBY
@@ -199,7 +199,7 @@ describe RuboCop::Cop::Style::NegatedIf do
     end
 
     it 'autocorrects for postfix' do
-      corrected = autocorrect_source(cop, 'bar if !foo')
+      corrected = autocorrect_source('bar if !foo')
 
       expect(corrected).to eq 'bar unless foo'
     end

--- a/spec/rubocop/cop/style/negated_while_spec.rb
+++ b/spec/rubocop/cop/style/negated_while_spec.rb
@@ -4,7 +4,7 @@ describe RuboCop::Cop::Style::NegatedWhile do
   subject(:cop) { described_class.new }
 
   it 'registers an offense for while with exclamation point condition' do
-    inspect_source(cop, <<-RUBY.strip_indent)
+    inspect_source(<<-RUBY.strip_indent)
       while !a_condition
         some_method
       end
@@ -16,7 +16,7 @@ describe RuboCop::Cop::Style::NegatedWhile do
   end
 
   it 'registers an offense for until with exclamation point condition' do
-    inspect_source(cop, <<-RUBY.strip_indent)
+    inspect_source(<<-RUBY.strip_indent)
       until !a_condition
         some_method
       end
@@ -27,7 +27,7 @@ describe RuboCop::Cop::Style::NegatedWhile do
   end
 
   it 'registers an offense for while with "not" condition' do
-    inspect_source(cop, <<-RUBY.strip_indent)
+    inspect_source(<<-RUBY.strip_indent)
       while (not a_condition)
         some_method
       end

--- a/spec/rubocop/cop/style/negated_while_spec.rb
+++ b/spec/rubocop/cop/style/negated_while_spec.rb
@@ -61,7 +61,7 @@ describe RuboCop::Cop::Style::NegatedWhile do
   end
 
   it 'autocorrects by replacing while not with until' do
-    corrected = autocorrect_source(cop, <<-RUBY.strip_indent)
+    corrected = autocorrect_source(<<-RUBY.strip_indent)
       something while !x.even?
       something while(!x.even?)
     RUBY
@@ -72,7 +72,7 @@ describe RuboCop::Cop::Style::NegatedWhile do
   end
 
   it 'autocorrects by replacing until not with while' do
-    corrected = autocorrect_source(cop, 'something until !x.even?')
+    corrected = autocorrect_source('something until !x.even?')
     expect(corrected).to eq 'something while x.even?'
   end
 

--- a/spec/rubocop/cop/style/nested_modifier_spec.rb
+++ b/spec/rubocop/cop/style/nested_modifier_spec.rb
@@ -5,7 +5,7 @@ describe RuboCop::Cop::Style::NestedModifier do
 
   shared_examples 'avoidable' do |keyword|
     it "registers an offense for modifier #{keyword}" do
-      inspect_source(cop, "something #{keyword} a if b")
+      inspect_source("something #{keyword} a if b")
       expect(cop.messages).to eq(['Avoid using nested modifiers.'])
       expect(cop.highlights).to eq([keyword])
     end

--- a/spec/rubocop/cop/style/nested_modifier_spec.rb
+++ b/spec/rubocop/cop/style/nested_modifier_spec.rb
@@ -14,14 +14,14 @@ describe RuboCop::Cop::Style::NestedModifier do
   shared_examples 'not correctable' do |keyword|
     it "does not auto-correct when #{keyword} is the outer modifier" do
       source = "something if a #{keyword} b"
-      corrected = autocorrect_source(cop, source)
+      corrected = autocorrect_source(source)
       expect(corrected).to eq source
       expect(cop.offenses.map(&:corrected?)).to eq [false]
     end
 
     it "does not auto-correct when #{keyword} is the inner modifier" do
       source = "something #{keyword} a if b"
-      corrected = autocorrect_source(cop, source)
+      corrected = autocorrect_source(source)
       expect(corrected).to eq source
       expect(cop.offenses.map(&:corrected?)).to eq [false]
     end
@@ -36,37 +36,37 @@ describe RuboCop::Cop::Style::NestedModifier do
   end
 
   it 'auto-corrects if + if' do
-    corrected = autocorrect_source(cop, 'something if a if b')
+    corrected = autocorrect_source('something if a if b')
     expect(corrected).to eq 'something if b && a'
   end
 
   it 'auto-corrects unless + unless' do
-    corrected = autocorrect_source(cop, 'something unless a unless b')
+    corrected = autocorrect_source('something unless a unless b')
     expect(corrected).to eq 'something unless b || a'
   end
 
   it 'auto-corrects if + unless' do
-    corrected = autocorrect_source(cop, 'something if a unless b')
+    corrected = autocorrect_source('something if a unless b')
     expect(corrected).to eq 'something unless b || !a'
   end
 
   it 'auto-corrects unless with a comparison operator + if' do
-    corrected = autocorrect_source(cop, 'something unless b > 1 if true')
+    corrected = autocorrect_source('something unless b > 1 if true')
     expect(corrected).to eq 'something if true && !(b > 1)'
   end
 
   it 'auto-corrects unless + if' do
-    corrected = autocorrect_source(cop, 'something unless a if b')
+    corrected = autocorrect_source('something unless a if b')
     expect(corrected).to eq 'something if b && !a'
   end
 
   it 'adds parentheses when needed in auto-correction' do
-    corrected = autocorrect_source(cop, 'something if a || b if c || d')
+    corrected = autocorrect_source('something if a || b if c || d')
     expect(corrected).to eq 'something if (c || d) && (a || b)'
   end
 
   it 'does not add redundant parentheses in auto-correction' do
-    corrected = autocorrect_source(cop, 'something if a unless c || d')
+    corrected = autocorrect_source('something if a unless c || d')
     expect(corrected).to eq 'something unless c || d || !a'
   end
 

--- a/spec/rubocop/cop/style/nested_parenthesized_calls_spec.rb
+++ b/spec/rubocop/cop/style/nested_parenthesized_calls_spec.rb
@@ -33,7 +33,7 @@ describe RuboCop::Cop::Style::NestedParenthesizedCalls do
       end
 
       it 'auto-corrects by adding parentheses' do
-        new_source = autocorrect_source(cop, source)
+        new_source = autocorrect_source(source)
         expect(new_source).to eq('puts(compute(something))')
       end
     end
@@ -47,7 +47,7 @@ describe RuboCop::Cop::Style::NestedParenthesizedCalls do
       end
 
       it 'auto-corrects by adding parentheses' do
-        new_source = autocorrect_source(cop, 'puts(compute first, second)')
+        new_source = autocorrect_source('puts(compute first, second)')
         expect(new_source).to eq('puts(compute(first, second))')
       end
     end

--- a/spec/rubocop/cop/style/next_spec.rb
+++ b/spec/rubocop/cop/style/next_spec.rb
@@ -8,7 +8,7 @@ describe RuboCop::Cop::Style::Next, :config do
     let(:opposite) { condition == 'if' ? 'unless' : 'if' }
 
     it "registers an offense for #{condition} inside of downto" do
-      inspect_source(cop, <<-RUBY.strip_indent)
+      inspect_source(<<-RUBY.strip_indent)
         3.downto(1) do
           #{condition} o == 1
             puts o
@@ -37,7 +37,7 @@ describe RuboCop::Cop::Style::Next, :config do
     end
 
     it "registers an offense for #{condition} inside of each" do
-      inspect_source(cop, <<-RUBY.strip_indent)
+      inspect_source(<<-RUBY.strip_indent)
         [].each do |o|
           #{condition} o == 1
             puts o
@@ -66,7 +66,7 @@ describe RuboCop::Cop::Style::Next, :config do
     end
 
     it "registers an offense for #{condition} inside of each_with_object" do
-      inspect_source(cop, <<-RUBY.strip_indent)
+      inspect_source(<<-RUBY.strip_indent)
         [].each_with_object({}) do |o, a|
           #{condition} o == 1
             a[o] = {}
@@ -79,7 +79,7 @@ describe RuboCop::Cop::Style::Next, :config do
     end
 
     it "registers an offense for #{condition} inside of for" do
-      inspect_source(cop, <<-RUBY.strip_indent)
+      inspect_source(<<-RUBY.strip_indent)
         for o in 1..3 do
           #{condition} o == 1
             puts o
@@ -108,7 +108,7 @@ describe RuboCop::Cop::Style::Next, :config do
     end
 
     it "registers an offense for #{condition} inside of loop" do
-      inspect_source(cop, <<-RUBY.strip_indent)
+      inspect_source(<<-RUBY.strip_indent)
         loop do
           #{condition} o == 1
             puts o
@@ -121,7 +121,7 @@ describe RuboCop::Cop::Style::Next, :config do
     end
 
     it "registers an offense for #{condition} inside of map" do
-      inspect_source(cop, <<-RUBY.strip_indent)
+      inspect_source(<<-RUBY.strip_indent)
         loop do
           {}.map do |k, v|
             #{condition} v == 1
@@ -136,7 +136,7 @@ describe RuboCop::Cop::Style::Next, :config do
     end
 
     it "registers an offense for #{condition} inside of times" do
-      inspect_source(cop, <<-RUBY.strip_indent)
+      inspect_source(<<-RUBY.strip_indent)
         loop do
           3.times do |o|
             #{condition} o == 1
@@ -151,7 +151,7 @@ describe RuboCop::Cop::Style::Next, :config do
     end
 
     it "registers an offense for #{condition} inside of collect" do
-      inspect_source(cop, <<-RUBY.strip_indent)
+      inspect_source(<<-RUBY.strip_indent)
         [].collect do |o|
           #{condition} o == 1
             true
@@ -164,7 +164,7 @@ describe RuboCop::Cop::Style::Next, :config do
     end
 
     it "registers an offense for #{condition} inside of select" do
-      inspect_source(cop, <<-RUBY.strip_indent)
+      inspect_source(<<-RUBY.strip_indent)
         [].select do |o|
           #{condition} o == 1
             true
@@ -177,7 +177,7 @@ describe RuboCop::Cop::Style::Next, :config do
     end
 
     it "registers an offense for #{condition} inside of select!" do
-      inspect_source(cop, <<-RUBY.strip_indent)
+      inspect_source(<<-RUBY.strip_indent)
         [].select! do |o|
           #{condition} o == 1
             true
@@ -190,7 +190,7 @@ describe RuboCop::Cop::Style::Next, :config do
     end
 
     it "registers an offense for #{condition} inside of reject" do
-      inspect_source(cop, <<-RUBY.strip_indent)
+      inspect_source(<<-RUBY.strip_indent)
         [].reject do |o|
           #{condition} o == 1
             true
@@ -203,7 +203,7 @@ describe RuboCop::Cop::Style::Next, :config do
     end
 
     it "registers an offense for #{condition} inside of reject!" do
-      inspect_source(cop, <<-RUBY.strip_indent)
+      inspect_source(<<-RUBY.strip_indent)
         [].reject! do |o|
           #{condition} o == 1
             true
@@ -216,7 +216,7 @@ describe RuboCop::Cop::Style::Next, :config do
     end
 
     it "registers an offense for #{condition} inside of nested iterators" do
-      inspect_source(cop, <<-RUBY.strip_indent)
+      inspect_source(<<-RUBY.strip_indent)
         loop do
           until false
             #{condition} o == 1
@@ -231,7 +231,7 @@ describe RuboCop::Cop::Style::Next, :config do
     end
 
     it "registers an offense for #{condition} inside of nested iterators" do
-      inspect_source(cop, <<-RUBY.strip_indent)
+      inspect_source(<<-RUBY.strip_indent)
         loop do
           while true
             #{condition} o == 1
@@ -247,7 +247,7 @@ describe RuboCop::Cop::Style::Next, :config do
 
     it 'registers an offense for a condition at the end of an iterator ' \
        'when there is more in the iterator than the condition' do
-      inspect_source(cop, <<-RUBY.strip_indent)
+      inspect_source(<<-RUBY.strip_indent)
         [].each do |o|
           puts o
           #{condition} o == 1
@@ -279,7 +279,7 @@ describe RuboCop::Cop::Style::Next, :config do
     end
 
     it "allows loops with #{condition} being the entire body with else" do
-      inspect_source(cop, <<-RUBY.strip_indent)
+      inspect_source(<<-RUBY.strip_indent)
         [].each do |o|
           #{condition} o == 1
             puts o
@@ -294,7 +294,7 @@ describe RuboCop::Cop::Style::Next, :config do
 
     it "allows loops with #{condition} with else, nested in another " \
        'condition' do
-      inspect_source(cop, <<-RUBY.strip_indent)
+      inspect_source(<<-RUBY.strip_indent)
         [].each do |o|
           if foo
             #{condition} o == 1
@@ -310,7 +310,7 @@ describe RuboCop::Cop::Style::Next, :config do
     end
 
     it "allows loops with #{condition} with else at the end" do
-      inspect_source(cop, <<-RUBY.strip_indent)
+      inspect_source(<<-RUBY.strip_indent)
         [].each do |o|
           puts o
           #{condition} o == 1
@@ -325,7 +325,7 @@ describe RuboCop::Cop::Style::Next, :config do
     end
 
     it "reports an offense for #{condition} whose body has 3 lines" do
-      inspect_source(cop, <<-RUBY.strip_indent)
+      inspect_source(<<-RUBY.strip_indent)
         arr.each do |e|
           #{condition} something
             work
@@ -345,7 +345,7 @@ describe RuboCop::Cop::Style::Next, :config do
       end
 
       it "allows modifier #{condition}" do
-        inspect_source(cop, <<-RUBY.strip_indent)
+        inspect_source(<<-RUBY.strip_indent)
           [].each do |o|
             puts o #{condition} o == 1
           end
@@ -369,7 +369,7 @@ describe RuboCop::Cop::Style::Next, :config do
       end
 
       it "registers an offense for modifier #{condition}" do
-        inspect_source(cop, source)
+        inspect_source(source)
 
         expect(cop.messages).to eq(['Use `next` to skip iteration.'])
         expect(cop.highlights).to eq(["puts o #{condition} o == 1"])
@@ -581,7 +581,7 @@ describe RuboCop::Cop::Style::Next, :config do
         end
       RUBY
 
-      expect { inspect_source(cop, source) }
+      expect { inspect_source(source) }
         .to raise_error('MinBodyLength needs to be a positive integer!')
     end
   end

--- a/spec/rubocop/cop/style/next_spec.rb
+++ b/spec/rubocop/cop/style/next_spec.rb
@@ -21,7 +21,7 @@ describe RuboCop::Cop::Style::Next, :config do
     end
 
     it "autocorrects #{condition} inside of downto" do
-      new_source = autocorrect_source(cop, <<-RUBY.strip_indent)
+      new_source = autocorrect_source(<<-RUBY.strip_indent)
         3.downto(1) do
           #{condition} o == 1
             puts o
@@ -50,7 +50,7 @@ describe RuboCop::Cop::Style::Next, :config do
     end
 
     it "autocorrects #{condition} inside of each" do
-      new_source = autocorrect_source(cop, <<-RUBY.strip_indent)
+      new_source = autocorrect_source(<<-RUBY.strip_indent)
         [].each do |o|
           #{condition} o == 1
             puts o
@@ -92,7 +92,7 @@ describe RuboCop::Cop::Style::Next, :config do
     end
 
     it "autocorrects #{condition} inside of for" do
-      new_source = autocorrect_source(cop, <<-RUBY.strip_indent)
+      new_source = autocorrect_source(<<-RUBY.strip_indent)
         for o in 1..3 do
           #{condition} o == 1
             puts o
@@ -376,7 +376,7 @@ describe RuboCop::Cop::Style::Next, :config do
       end
 
       it "auto-corrects modifier #{condition}" do
-        corrected = autocorrect_source(cop, source)
+        corrected = autocorrect_source(source)
         expect(corrected).to eq(<<-RUBY.strip_indent)
           [].each do |o|
             next #{opposite} o == 1
@@ -387,7 +387,7 @@ describe RuboCop::Cop::Style::Next, :config do
     end
 
     it 'auto-corrects a misaligned end' do
-      new_source = autocorrect_source(cop, <<-RUBY.strip_indent)
+      new_source = autocorrect_source(<<-RUBY.strip_indent)
         [1, 2, 3, 4].each do |num|
           if !opts.nil?
             puts num
@@ -413,14 +413,14 @@ describe RuboCop::Cop::Style::Next, :config do
   end
 
   it 'keeps comments when autocorrecting' do
-    new_source = autocorrect_source(cop, ['loop do',
-                                          '  if test # keep me',
-                                          '    # keep me',
-                                          '    something # keep me',
-                                          '    # keep me',
-                                          '    ',
-                                          '  end # keep me',
-                                          'end'])
+    new_source = autocorrect_source(['loop do',
+                                     '  if test # keep me',
+                                     '    # keep me',
+                                     '    something # keep me',
+                                     '    # keep me',
+                                     '    ',
+                                     '  end # keep me',
+                                     'end'])
     expect(new_source).to eq(['loop do',
                               '  next unless test # keep me',
                               '  # keep me',
@@ -432,7 +432,7 @@ describe RuboCop::Cop::Style::Next, :config do
   end
 
   it 'handles `then` when autocorrecting' do
-    new_source = autocorrect_source(cop, <<-RUBY.strip_indent)
+    new_source = autocorrect_source(<<-RUBY.strip_indent)
       loop do
         if test then
           something
@@ -448,7 +448,7 @@ describe RuboCop::Cop::Style::Next, :config do
   end
 
   it "doesn't reindent heredoc bodies when autocorrecting" do
-    new_source = autocorrect_source(cop, <<-RUBY.strip_indent)
+    new_source = autocorrect_source(<<-RUBY.strip_indent)
       loop do
         if test
           str = <<-BLAH
@@ -472,7 +472,7 @@ describe RuboCop::Cop::Style::Next, :config do
   end
 
   it 'handles nested autocorrections' do
-    new_source = autocorrect_source(cop, <<-RUBY.strip_indent)
+    new_source = autocorrect_source(<<-RUBY.strip_indent)
       loop do
         if test
           loop do

--- a/spec/rubocop/cop/style/nil_comparison_spec.rb
+++ b/spec/rubocop/cop/style/nil_comparison_spec.rb
@@ -18,12 +18,12 @@ describe RuboCop::Cop::Style::NilComparison do
   end
 
   it 'autocorrects by replacing == nil with .nil?' do
-    corrected = autocorrect_source(cop, 'x == nil')
+    corrected = autocorrect_source('x == nil')
     expect(corrected).to eq 'x.nil?'
   end
 
   it 'autocorrects by replacing === nil with .nil?' do
-    corrected = autocorrect_source(cop, 'x === nil')
+    corrected = autocorrect_source('x === nil')
     expect(corrected).to eq 'x.nil?'
   end
 end

--- a/spec/rubocop/cop/style/non_nil_check_spec.rb
+++ b/spec/rubocop/cop/style/non_nil_check_spec.rb
@@ -64,23 +64,23 @@ describe RuboCop::Cop::Style::NonNilCheck, :config do
     end
 
     it 'autocorrects by changing `!= nil` to `!x.nil?`' do
-      corrected = autocorrect_source(cop, 'x != nil')
+      corrected = autocorrect_source('x != nil')
       expect(corrected).to eq '!x.nil?'
     end
 
     it 'does not autocorrect by removing non-nil (!x.nil?) check' do
-      corrected = autocorrect_source(cop, '!x.nil?')
+      corrected = autocorrect_source('!x.nil?')
       expect(corrected).to eq '!x.nil?'
     end
 
     it 'does not blow up when autocorrecting implicit receiver' do
-      corrected = autocorrect_source(cop, '!nil?')
+      corrected = autocorrect_source('!nil?')
       expect(corrected).to eq '!nil?'
     end
 
     it 'does not report corrected when the code was not modified' do
       source = 'return nil unless (line =~ //) != nil'
-      corrected = autocorrect_source(cop, source)
+      corrected = autocorrect_source(source)
 
       expect(corrected).to eq(source)
       expect(cop.corrections).to be_empty
@@ -130,29 +130,28 @@ describe RuboCop::Cop::Style::NonNilCheck, :config do
     end
 
     it 'autocorrects by changing unless x.nil? to if x' do
-      corrected = autocorrect_source(cop, 'puts a unless x.nil?')
+      corrected = autocorrect_source('puts a unless x.nil?')
       expect(corrected).to eq 'puts a if x'
     end
 
     it 'autocorrects by changing `x != nil` to `x`' do
-      corrected = autocorrect_source(cop, 'x != nil')
+      corrected = autocorrect_source('x != nil')
       expect(corrected).to eq 'x'
     end
 
     it 'autocorrects by changing `!x.nil?` to `x`' do
-      corrected = autocorrect_source(cop, '!x.nil?')
+      corrected = autocorrect_source('!x.nil?')
       expect(corrected).to eq 'x'
     end
 
     it 'does not blow up when autocorrecting implicit receiver' do
-      corrected = autocorrect_source(cop, '!nil?')
+      corrected = autocorrect_source('!nil?')
       expect(corrected).to eq 'self'
     end
 
     it 'corrects code that would not be modified if ' \
        'IncludeSemanticChanges were false' do
-      corrected = autocorrect_source(cop,
-                                     'return nil unless (line =~ //) != nil')
+      corrected = autocorrect_source('return nil unless (line =~ //) != nil')
 
       expect(corrected).to eq('return nil unless (line =~ //)')
     end

--- a/spec/rubocop/cop/style/not_spec.rb
+++ b/spec/rubocop/cop/style/not_spec.rb
@@ -15,42 +15,42 @@ describe RuboCop::Cop::Style::Not, :config do
   end
 
   it 'auto-corrects "not" with !' do
-    new_source = autocorrect_source(cop, 'x = 10 if not y')
+    new_source = autocorrect_source('x = 10 if not y')
     expect(new_source).to eq('x = 10 if !y')
   end
 
   it 'auto-corrects "not" followed by parens with !' do
-    new_source = autocorrect_source(cop, 'not(test)')
+    new_source = autocorrect_source('not(test)')
     expect(new_source).to eq('!(test)')
   end
 
   it 'uses the reverse operator when `not` is applied to a comparison' do
     src = 'not x < y'
-    new_source = autocorrect_source(cop, src)
+    new_source = autocorrect_source(src)
     expect(new_source).to eq('x >= y')
   end
 
   it 'parenthesizes when `not` would change the meaning of a binary exp' do
     src = 'not a >> b'
-    new_source = autocorrect_source(cop, src)
+    new_source = autocorrect_source(src)
     expect(new_source).to eq('!(a >> b)')
   end
 
   it 'parenthesizes when `not` is applied to a ternary op' do
     src = 'not a ? b : c'
-    new_source = autocorrect_source(cop, src)
+    new_source = autocorrect_source(src)
     expect(new_source).to eq('!(a ? b : c)')
   end
 
   it 'parenthesizes when `not` is applied to and' do
     src = 'not a && b'
-    new_source = autocorrect_source(cop, src)
+    new_source = autocorrect_source(src)
     expect(new_source).to eq('!(a && b)')
   end
 
   it 'parenthesizes when `not` is applied to or' do
     src = 'not a || b'
-    new_source = autocorrect_source(cop, src)
+    new_source = autocorrect_source(src)
     expect(new_source).to eq('!(a || b)')
   end
 end

--- a/spec/rubocop/cop/style/numeric_literal_prefix_spec.rb
+++ b/spec/rubocop/cop/style/numeric_literal_prefix_spec.rb
@@ -12,7 +12,7 @@ describe RuboCop::Cop::Style::NumericLiteralPrefix, :config do
       end
 
       it 'registers an offense for prefixes `0` and `0O`' do
-        inspect_source(cop, <<-RUBY.strip_indent)
+        inspect_source(<<-RUBY.strip_indent)
           a = 01234
           b(0O1234)
         RUBY
@@ -47,7 +47,7 @@ describe RuboCop::Cop::Style::NumericLiteralPrefix, :config do
       end
 
       it 'registers an offense for prefix `0O` and `0o`' do
-        inspect_source(cop, <<-RUBY.strip_indent)
+        inspect_source(<<-RUBY.strip_indent)
           a = 0O1234
           b(0o1234)
         RUBY
@@ -81,7 +81,7 @@ describe RuboCop::Cop::Style::NumericLiteralPrefix, :config do
 
   context 'hex literals' do
     it 'registers an offense for uppercase prefix' do
-      inspect_source(cop, <<-RUBY.strip_indent)
+      inspect_source(<<-RUBY.strip_indent)
         a = 0X1AC
         b(0XABC)
       RUBY
@@ -102,7 +102,7 @@ describe RuboCop::Cop::Style::NumericLiteralPrefix, :config do
 
   context 'binary literals' do
     it 'registers an offense for uppercase prefix' do
-      inspect_source(cop, <<-RUBY.strip_indent)
+      inspect_source(<<-RUBY.strip_indent)
         a = 0B10101
         b(0B111)
       RUBY
@@ -123,7 +123,7 @@ describe RuboCop::Cop::Style::NumericLiteralPrefix, :config do
 
   context 'decimal literals' do
     it 'registers an offense for prefixes' do
-      inspect_source(cop, <<-RUBY.strip_indent)
+      inspect_source(<<-RUBY.strip_indent)
         a = 0d1234
         b(0D1234)
       RUBY

--- a/spec/rubocop/cop/style/numeric_literal_prefix_spec.rb
+++ b/spec/rubocop/cop/style/numeric_literal_prefix_spec.rb
@@ -29,12 +29,12 @@ describe RuboCop::Cop::Style::NumericLiteralPrefix, :config do
       end
 
       it 'autocorrects an octal literal starting with 0' do
-        corrected = autocorrect_source(cop, ['a = 01234'])
+        corrected = autocorrect_source(['a = 01234'])
         expect(corrected).to eq('a = 0o1234')
       end
 
       it 'autocorrects an octal literal starting with 0O' do
-        corrected = autocorrect_source(cop, ['b(0O1234, a)'])
+        corrected = autocorrect_source(['b(0O1234, a)'])
         expect(corrected).to eq('b(0o1234, a)')
       end
     end
@@ -61,7 +61,7 @@ describe RuboCop::Cop::Style::NumericLiteralPrefix, :config do
       end
 
       it 'autocorrects an octal literal starting with 0O or 0o' do
-        corrected = autocorrect_source(cop, <<-RUBY.strip_indent)
+        corrected = autocorrect_source(<<-RUBY.strip_indent)
           a = 0O1234
           b(0o1234)
         RUBY
@@ -73,7 +73,7 @@ describe RuboCop::Cop::Style::NumericLiteralPrefix, :config do
       end
 
       it 'does not autocorrect an octal literal starting with 0' do
-        corrected = autocorrect_source(cop, ['b(01234, a)'])
+        corrected = autocorrect_source(['b(01234, a)'])
         expect(corrected).to eq 'b(01234, a)'
       end
     end
@@ -95,7 +95,7 @@ describe RuboCop::Cop::Style::NumericLiteralPrefix, :config do
     end
 
     it 'autocorrects literals with uppercase prefix' do
-      corrected = autocorrect_source(cop, ['a = 0XAB'])
+      corrected = autocorrect_source(['a = 0XAB'])
       expect(corrected).to eq 'a = 0xAB'
     end
   end
@@ -116,7 +116,7 @@ describe RuboCop::Cop::Style::NumericLiteralPrefix, :config do
     end
 
     it 'autocorrects literals with uppercase prefix' do
-      corrected = autocorrect_source(cop, ['a = 0B1010'])
+      corrected = autocorrect_source(['a = 0B1010'])
       expect(corrected).to eq 'a = 0b1010'
     end
   end
@@ -138,12 +138,12 @@ describe RuboCop::Cop::Style::NumericLiteralPrefix, :config do
     end
 
     it 'autocorrects literals with prefix' do
-      corrected = autocorrect_source(cop, ['a = 0d1234', 'b(0D1990)'])
+      corrected = autocorrect_source(['a = 0d1234', 'b(0D1990)'])
       expect(corrected).to eq "a = 1234\nb(1990)"
     end
 
     it 'does not autocorrect literals with no prefix' do
-      corrected = autocorrect_source(cop, ['a = 1234', 'b(1990)'])
+      corrected = autocorrect_source(['a = 1234', 'b(1990)'])
       expect(corrected).to eq "a = 1234\nb(1990)"
     end
   end

--- a/spec/rubocop/cop/style/numeric_literals_spec.rb
+++ b/spec/rubocop/cop/style/numeric_literals_spec.rb
@@ -63,27 +63,27 @@ describe RuboCop::Cop::Style::NumericLiterals, :config do
   end
 
   it 'autocorrects a long integer offense' do
-    corrected = autocorrect_source(cop, ['a = 123456'])
+    corrected = autocorrect_source(['a = 123456'])
     expect(corrected).to eq 'a = 123_456'
   end
 
   it 'autocorrects an integer with misplaced underscore' do
-    corrected = autocorrect_source(cop, ['a = 123_456_78_90_00'])
+    corrected = autocorrect_source(['a = 123_456_78_90_00'])
     expect(corrected).to eq 'a = 123_456_789_000'
   end
 
   it 'autocorrects negative numbers' do
-    corrected = autocorrect_source(cop, ['a = -123456'])
+    corrected = autocorrect_source(['a = -123456'])
     expect(corrected).to eq 'a = -123_456'
   end
 
   it 'autocorrects floating-point numbers' do
-    corrected = autocorrect_source(cop, ['a = 123456.78'])
+    corrected = autocorrect_source(['a = 123456.78'])
     expect(corrected).to eq 'a = 123_456.78'
   end
 
   it 'autocorrects negative floating-point numbers' do
-    corrected = autocorrect_source(cop, ['a = -123456.78'])
+    corrected = autocorrect_source(['a = -123456.78'])
     expect(corrected).to eq 'a = -123_456.78'
   end
 

--- a/spec/rubocop/cop/style/numeric_literals_spec.rb
+++ b/spec/rubocop/cop/style/numeric_literals_spec.rb
@@ -5,13 +5,13 @@ describe RuboCop::Cop::Style::NumericLiterals, :config do
   let(:cop_config) { { 'MinDigits' => 5 } }
 
   it 'registers an offense for a long undelimited integer' do
-    inspect_source(cop, 'a = 12345')
+    inspect_source('a = 12345')
     expect(cop.offenses.size).to eq(1)
     expect(cop.config_to_allow_offenses).to eq('MinDigits' => 6)
   end
 
   it 'registers an offense for a float with a long undelimited integer part' do
-    inspect_source(cop, 'a = 123456.789')
+    inspect_source('a = 123456.789')
     expect(cop.offenses.size).to eq(1)
     expect(cop.config_to_allow_offenses).to eq('MinDigits' => 7)
   end
@@ -24,7 +24,7 @@ describe RuboCop::Cop::Style::NumericLiterals, :config do
   end
 
   it 'registers an offense for an integer with misplaced underscore' do
-    inspect_source(cop, <<-RUBY.strip_indent)
+    inspect_source(<<-RUBY.strip_indent)
       a = 123_456_78_90_00
       b = 1_8192
     RUBY
@@ -96,7 +96,7 @@ describe RuboCop::Cop::Style::NumericLiterals, :config do
     end
 
     it 'registers an offense for an integer with misplaced underscore' do
-      inspect_source(cop, <<-RUBY.strip_indent)
+      inspect_source(<<-RUBY.strip_indent)
         a = 123_456_78_90_00
         b = 81_92
       RUBY

--- a/spec/rubocop/cop/style/numeric_predicate_spec.rb
+++ b/spec/rubocop/cop/style/numeric_predicate_spec.rb
@@ -4,7 +4,7 @@ describe RuboCop::Cop::Style::NumericPredicate, :config do
   subject(:cop) { described_class.new(config) }
 
   before do
-    inspect_source(cop, source)
+    inspect_source(source)
   end
 
   shared_examples 'code with offense' do |code, expected|

--- a/spec/rubocop/cop/style/numeric_predicate_spec.rb
+++ b/spec/rubocop/cop/style/numeric_predicate_spec.rb
@@ -20,11 +20,11 @@ describe RuboCop::Cop::Style::NumericPredicate, :config do
 
       if expected
         it 'auto-corrects' do
-          expect(autocorrect_source(cop, code)).to eq(expected)
+          expect(autocorrect_source(code)).to eq(expected)
         end
       else
         it 'does not auto-correct' do
-          expect(autocorrect_source(cop, code)).to eq(code)
+          expect(autocorrect_source(code)).to eq(code)
         end
       end
     end

--- a/spec/rubocop/cop/style/one_line_conditional_spec.rb
+++ b/spec/rubocop/cop/style/one_line_conditional_spec.rb
@@ -21,7 +21,7 @@ describe RuboCop::Cop::Style::OneLineConditional do
 
   shared_examples 'autocorrect' do |correct_code|
     it 'auto-corrects' do
-      corrected = autocorrect_source(cop, source)
+      corrected = autocorrect_source(source)
       expect(corrected).to eq(correct_code)
     end
   end
@@ -68,15 +68,14 @@ describe RuboCop::Cop::Style::OneLineConditional do
      && ||].each do |operator|
     it 'parenthesizes the expression if it is preceded by an operator' do
       corrected =
-        autocorrect_source(cop, "a #{operator} if cond then run else dont end")
+        autocorrect_source("a #{operator} if cond then run else dont end")
       expect(corrected).to eq("a #{operator} (cond ? run : dont)")
     end
   end
 
   shared_examples 'changed precedence' do |expr|
     it "adds parentheses around `#{expr}`" do
-      corrected = autocorrect_source(cop,
-                                     "if #{expr} then #{expr} else #{expr} end")
+      corrected = autocorrect_source("if #{expr} then #{expr} else #{expr} end")
       expect(corrected).to eq("(#{expr}) ? (#{expr}) : (#{expr})")
     end
   end
@@ -94,13 +93,13 @@ describe RuboCop::Cop::Style::OneLineConditional do
   it 'does not parenthesize expressions when they do not contain method ' \
      'calls with unparenthesized arguments' do
     corrected =
-      autocorrect_source(cop, 'if a(0) then puts(1) else yield(2) end')
+      autocorrect_source('if a(0) then puts(1) else yield(2) end')
     expect(corrected).to eq('a(0) ? puts(1) : yield(2)')
   end
 
   it 'does not parenthesize expressions when they contain unparenthesized ' \
      'operator method calls' do
-    corrected = autocorrect_source(cop, 'if 0 + 0 then 1 + 1 else 2 + 2 end')
+    corrected = autocorrect_source('if 0 + 0 then 1 + 1 else 2 + 2 end')
     expect(corrected).to eq('0 + 0 ? 1 + 1 : 2 + 2')
   end
 end

--- a/spec/rubocop/cop/style/one_line_conditional_spec.rb
+++ b/spec/rubocop/cop/style/one_line_conditional_spec.rb
@@ -5,7 +5,7 @@ describe RuboCop::Cop::Style::OneLineConditional do
 
   shared_examples 'offense' do |condition|
     it 'registers an offense' do
-      inspect_source(cop, source)
+      inspect_source(source)
       expect(cop.messages)
         .to eq(['Favor the ternary operator (`?:`)' \
                 " over `#{condition}/then/else/end` constructs."])
@@ -14,7 +14,7 @@ describe RuboCop::Cop::Style::OneLineConditional do
 
   shared_examples 'no offense' do
     it 'does not register an offense' do
-      inspect_source(cop, source)
+      inspect_source(source)
       expect(cop.messages).to be_empty
     end
   end

--- a/spec/rubocop/cop/style/op_method_spec.rb
+++ b/spec/rubocop/cop/style/op_method_spec.rb
@@ -5,7 +5,7 @@ describe RuboCop::Cop::Style::OpMethod do
 
   %i[+ eql? equal?].each do |op|
     it "registers an offense for #{op} with arg not named other" do
-      inspect_source(cop, <<-RUBY.strip_indent)
+      inspect_source(<<-RUBY.strip_indent)
         def #{op}(another)
           another
         end

--- a/spec/rubocop/cop/style/option_hash_spec.rb
+++ b/spec/rubocop/cop/style/option_hash_spec.rb
@@ -13,7 +13,7 @@ describe RuboCop::Cop::Style::OptionHash, :config do
   end
 
   it 'registers an offense' do
-    inspect_source(cop, source)
+    inspect_source(source)
     expect(cop.offenses.size).to eq(1)
     expect(cop.messages.first)
       .to eq('Prefer keyword arguments to options hashes.')
@@ -42,7 +42,7 @@ describe RuboCop::Cop::Style::OptionHash, :config do
     it 'registers an offense when in SuspiciousParamNames list' do
       cop_config['SuspiciousParamNames'] = ['config']
 
-      inspect_source(cop, source)
+      inspect_source(source)
 
       expect(cop.offenses.size).to eq(1)
       expect(cop.messages.first)

--- a/spec/rubocop/cop/style/optional_arguments_spec.rb
+++ b/spec/rubocop/cop/style/optional_arguments_spec.rb
@@ -9,7 +9,7 @@ describe RuboCop::Cop::Style::OptionalArguments do
 
   it 'registers an offense when an optional argument is followed by a ' \
      'required argument' do
-    inspect_source(cop, <<-RUBY.strip_indent)
+    inspect_source(<<-RUBY.strip_indent)
       def foo(a = 1, b)
       end
     RUBY
@@ -20,7 +20,7 @@ describe RuboCop::Cop::Style::OptionalArguments do
 
   it 'registers an offense for each optional argument when multiple ' \
      'optional arguments are followed by a required argument' do
-    inspect_source(cop, <<-RUBY.strip_indent)
+    inspect_source(<<-RUBY.strip_indent)
       def foo(a = 1, b = 2, c)
       end
     RUBY
@@ -84,7 +84,7 @@ describe RuboCop::Cop::Style::OptionalArguments do
     context 'required params', :ruby21 do
       it 'registers an offense for optional arguments that come before ' \
          'required arguments where there are name arguments' do
-        inspect_source(cop, <<-RUBY.strip_indent)
+        inspect_source(<<-RUBY.strip_indent)
           def foo(a = 1, b, c:, d: 4)
           end
         RUBY
@@ -102,7 +102,7 @@ describe RuboCop::Cop::Style::OptionalArguments do
 
       it 'allows optional arguments to come before a mix of required and ' \
          'optional named argument' do
-        inspect_source(cop, <<-RUBY.strip_indent)
+        inspect_source(<<-RUBY.strip_indent)
           def foo(a = 1, b:, c: 3)
           end
         RUBY

--- a/spec/rubocop/cop/style/parallel_assignment_spec.rb
+++ b/spec/rubocop/cop/style/parallel_assignment_spec.rb
@@ -114,7 +114,7 @@ describe RuboCop::Cop::Style::ParallelAssignment, :config do
   describe 'autocorrect' do
     it 'corrects when the number of left hand variables matches ' \
       'the number of right hand variables' do
-        new_source = autocorrect_source(cop, <<-RUBY.strip_indent)
+        new_source = autocorrect_source(<<-RUBY.strip_indent)
           a, b, c = 1, 2, 3
         RUBY
 
@@ -126,7 +126,7 @@ describe RuboCop::Cop::Style::ParallelAssignment, :config do
       end
 
     it 'corrects when the right variable is an array' do
-      new_source = autocorrect_source(cop, <<-RUBY.strip_indent)
+      new_source = autocorrect_source(<<-RUBY.strip_indent)
         a, b, c = ["1", "2", :c]
       RUBY
 
@@ -138,7 +138,7 @@ describe RuboCop::Cop::Style::ParallelAssignment, :config do
     end
 
     it 'corrects when the right variable is a word array' do
-      new_source = autocorrect_source(cop, <<-RUBY.strip_indent)
+      new_source = autocorrect_source(<<-RUBY.strip_indent)
         a, b, c = %w(1 2 3)
       RUBY
 
@@ -150,7 +150,7 @@ describe RuboCop::Cop::Style::ParallelAssignment, :config do
     end
 
     it 'corrects when the right variable is a symbol array' do
-      new_source = autocorrect_source(cop, <<-RUBY.strip_indent)
+      new_source = autocorrect_source(<<-RUBY.strip_indent)
         a, b, c = %i(a b c)
       RUBY
 
@@ -162,7 +162,7 @@ describe RuboCop::Cop::Style::ParallelAssignment, :config do
     end
 
     it 'corrects when assigning to method returns' do
-      new_source = autocorrect_source(cop, <<-RUBY.strip_indent)
+      new_source = autocorrect_source(<<-RUBY.strip_indent)
         a, b = foo(), bar()
       RUBY
 
@@ -173,7 +173,7 @@ describe RuboCop::Cop::Style::ParallelAssignment, :config do
     end
 
     it 'corrects when assigning from multiple methods with blocks' do
-      new_source = autocorrect_source(cop, <<-RUBY.strip_indent)
+      new_source = autocorrect_source(<<-RUBY.strip_indent)
         a, b = foo() { |c| puts c }, bar() { |d| puts d }
       RUBY
 
@@ -184,7 +184,7 @@ describe RuboCop::Cop::Style::ParallelAssignment, :config do
     end
 
     it 'corrects when using constants' do
-      new_source = autocorrect_source(cop, <<-RUBY.strip_indent)
+      new_source = autocorrect_source(<<-RUBY.strip_indent)
         CONSTANT1, CONSTANT2 = CONSTANT3, CONSTANT4
       RUBY
 
@@ -195,7 +195,7 @@ describe RuboCop::Cop::Style::ParallelAssignment, :config do
     end
 
     it 'corrects when the expression is missing spaces' do
-      new_source = autocorrect_source(cop, <<-RUBY.strip_indent)
+      new_source = autocorrect_source(<<-RUBY.strip_indent)
         a,b,c=1,2,3
       RUBY
 
@@ -207,7 +207,7 @@ describe RuboCop::Cop::Style::ParallelAssignment, :config do
     end
 
     it 'corrects when using single indentation' do
-      new_source = autocorrect_source(cop, <<-RUBY.strip_indent)
+      new_source = autocorrect_source(<<-RUBY.strip_indent)
         def foo
           a, b, c = 1, 2, 3
         end
@@ -223,7 +223,7 @@ describe RuboCop::Cop::Style::ParallelAssignment, :config do
     end
 
     it 'corrects when using nested indentation' do
-      new_source = autocorrect_source(cop, <<-RUBY.strip_indent)
+      new_source = autocorrect_source(<<-RUBY.strip_indent)
         def foo
           if true
             a, b, c = 1, 2, 3
@@ -243,7 +243,7 @@ describe RuboCop::Cop::Style::ParallelAssignment, :config do
     end
 
     it 'corrects when the expression uses a modifier if statement' do
-      new_source = autocorrect_source(cop, <<-RUBY.strip_indent)
+      new_source = autocorrect_source(<<-RUBY.strip_indent)
         a, b = 1, 2 if foo
       RUBY
 
@@ -257,7 +257,7 @@ describe RuboCop::Cop::Style::ParallelAssignment, :config do
 
     it 'corrects when the expression uses a modifier if statement ' \
        'inside a method' do
-      new_source = autocorrect_source(cop, <<-RUBY.strip_indent)
+      new_source = autocorrect_source(<<-RUBY.strip_indent)
         def foo
           a, b = 1, 2 if foo
         end
@@ -274,7 +274,7 @@ describe RuboCop::Cop::Style::ParallelAssignment, :config do
     end
 
     it 'corrects parallel assignment in if statements' do
-      new_source = autocorrect_source(cop, <<-RUBY.strip_indent)
+      new_source = autocorrect_source(<<-RUBY.strip_indent)
         if foo
           a, b = 1, 2
         end
@@ -289,7 +289,7 @@ describe RuboCop::Cop::Style::ParallelAssignment, :config do
     end
 
     it 'corrects when the expression uses a modifier unless statement' do
-      new_source = autocorrect_source(cop, <<-RUBY.strip_indent)
+      new_source = autocorrect_source(<<-RUBY.strip_indent)
         a, b = 1, 2 unless foo
       RUBY
 
@@ -302,7 +302,7 @@ describe RuboCop::Cop::Style::ParallelAssignment, :config do
     end
 
     it 'corrects parallel assignment in unless statements' do
-      new_source = autocorrect_source(cop, <<-RUBY.strip_indent)
+      new_source = autocorrect_source(<<-RUBY.strip_indent)
         unless foo
           a, b = 1, 2
         end
@@ -317,7 +317,7 @@ describe RuboCop::Cop::Style::ParallelAssignment, :config do
     end
 
     it 'corrects when the expression uses a modifier while statement' do
-      new_source = autocorrect_source(cop, <<-RUBY.strip_indent)
+      new_source = autocorrect_source(<<-RUBY.strip_indent)
         a, b = 1, 2 while foo
       RUBY
 
@@ -330,7 +330,7 @@ describe RuboCop::Cop::Style::ParallelAssignment, :config do
     end
 
     it 'corrects parallel assignment in while statements' do
-      new_source = autocorrect_source(cop, <<-RUBY.strip_indent)
+      new_source = autocorrect_source(<<-RUBY.strip_indent)
         while foo
           a, b = 1, 2
         end
@@ -345,7 +345,7 @@ describe RuboCop::Cop::Style::ParallelAssignment, :config do
     end
 
     it 'corrects when the expression uses a modifier until statement' do
-      new_source = autocorrect_source(cop, <<-RUBY.strip_indent)
+      new_source = autocorrect_source(<<-RUBY.strip_indent)
         a, b = 1, 2 until foo
       RUBY
 
@@ -358,7 +358,7 @@ describe RuboCop::Cop::Style::ParallelAssignment, :config do
     end
 
     it 'corrects parallel assignment in until statements' do
-      new_source = autocorrect_source(cop, <<-RUBY.strip_indent)
+      new_source = autocorrect_source(<<-RUBY.strip_indent)
         until foo
           a, b = 1, 2
         end
@@ -373,7 +373,7 @@ describe RuboCop::Cop::Style::ParallelAssignment, :config do
     end
 
     it 'corrects when the expression uses a modifier rescue statement' do
-      new_source = autocorrect_source(cop, <<-RUBY.strip_indent)
+      new_source = autocorrect_source(<<-RUBY.strip_indent)
         a, b = 1, 2 rescue foo
       RUBY
 
@@ -389,7 +389,7 @@ describe RuboCop::Cop::Style::ParallelAssignment, :config do
 
     it 'corrects parallel assignment inside rescue statements '\
        'within method definitions' do
-      new_source = autocorrect_source(cop, <<-RUBY.strip_indent)
+      new_source = autocorrect_source(<<-RUBY.strip_indent)
         def bar
           a, b = 1, 2
         rescue
@@ -409,7 +409,7 @@ describe RuboCop::Cop::Style::ParallelAssignment, :config do
 
     it 'corrects parallel assignment in rescue statements '\
        'within begin ... rescue' do
-      new_source = autocorrect_source(cop, <<-RUBY.strip_indent)
+      new_source = autocorrect_source(<<-RUBY.strip_indent)
         begin
           a, b = 1, 2
         rescue
@@ -429,7 +429,7 @@ describe RuboCop::Cop::Style::ParallelAssignment, :config do
 
     it 'corrects when the expression uses a modifier rescue statement ' \
        'as the only thing inside of a method' do
-      new_source = autocorrect_source(cop, <<-RUBY.strip_indent)
+      new_source = autocorrect_source(<<-RUBY.strip_indent)
         def foo
           a, b = 1, 2 rescue foo
         end
@@ -447,7 +447,7 @@ describe RuboCop::Cop::Style::ParallelAssignment, :config do
 
     it 'corrects when the expression uses a modifier rescue statement ' \
        'inside of a method' do
-      new_source = autocorrect_source(cop, <<-RUBY.strip_indent)
+      new_source = autocorrect_source(<<-RUBY.strip_indent)
         def foo
           a, b = %w(1 2) rescue foo
           something_else
@@ -469,7 +469,7 @@ describe RuboCop::Cop::Style::ParallelAssignment, :config do
 
     it 'corrects when assignments must be reordered to avoid changing ' \
        'meaning' do
-      new_source = autocorrect_source(cop, <<-RUBY.strip_indent)
+      new_source = autocorrect_source(<<-RUBY.strip_indent)
         a, b, c, d = 1, a + 1, b + 1, a + b + c
       RUBY
 
@@ -484,7 +484,7 @@ describe RuboCop::Cop::Style::ParallelAssignment, :config do
     shared_examples('no correction') do |description, source|
       context description do
         it "does not change: #{source.gsub(/\s*\n\s*/, '; ')}" do
-          new_source = autocorrect_source(cop, source)
+          new_source = autocorrect_source(source)
           expect(new_source).to eq(source)
         end
       end
@@ -516,7 +516,7 @@ describe RuboCop::Cop::Style::ParallelAssignment, :config do
       end
 
       it 'works with standard correction' do
-        new_source = autocorrect_source(cop, <<-RUBY.strip_indent)
+        new_source = autocorrect_source(<<-RUBY.strip_indent)
           a, b, c = 1, 2, 3
         RUBY
 
@@ -528,7 +528,7 @@ describe RuboCop::Cop::Style::ParallelAssignment, :config do
       end
 
       it 'works with guard clauses' do
-        new_source = autocorrect_source(cop, <<-RUBY.strip_indent)
+        new_source = autocorrect_source(<<-RUBY.strip_indent)
           a, b = 1, 2 if foo
         RUBY
 
@@ -541,7 +541,7 @@ describe RuboCop::Cop::Style::ParallelAssignment, :config do
       end
 
       it 'works with rescue' do
-        new_source = autocorrect_source(cop, <<-RUBY.strip_indent)
+        new_source = autocorrect_source(<<-RUBY.strip_indent)
           a, b = 1, 2 rescue foo
         RUBY
 
@@ -556,7 +556,7 @@ describe RuboCop::Cop::Style::ParallelAssignment, :config do
       end
 
       it 'works with nesting' do
-        new_source = autocorrect_source(cop, <<-RUBY.strip_indent)
+        new_source = autocorrect_source(<<-RUBY.strip_indent)
           def foo
              if true
                 a, b, c = 1, 2, 3

--- a/spec/rubocop/cop/style/parallel_assignment_spec.rb
+++ b/spec/rubocop/cop/style/parallel_assignment_spec.rb
@@ -9,7 +9,7 @@ describe RuboCop::Cop::Style::ParallelAssignment, :config do
 
   shared_examples('offenses') do |source|
     it "registers an offense for: #{source.gsub(/\s*\n\s*/, '; ')}" do
-      inspect_source(cop, source)
+      inspect_source(source)
 
       expect(cop.messages).to eq(['Do not use parallel assignment.'])
     end
@@ -51,7 +51,7 @@ describe RuboCop::Cop::Style::ParallelAssignment, :config do
 
   shared_examples('allowed') do |source|
     it "allows assignment of: #{source.gsub(/\s*\n\s*/, '; ')}" do
-      inspect_source(cop, source)
+      inspect_source(source)
 
       expect(cop.messages).to be_empty
     end

--- a/spec/rubocop/cop/style/parentheses_around_condition_spec.rb
+++ b/spec/rubocop/cop/style/parentheses_around_condition_spec.rb
@@ -35,7 +35,7 @@ describe RuboCop::Cop::Style::ParenthesesAroundCondition, :config do
   end
 
   it 'auto-corrects parentheses around condition' do
-    corrected = autocorrect_source(cop, <<-RUBY.strip_indent)
+    corrected = autocorrect_source(<<-RUBY.strip_indent)
       if (x > 10)
       elsif (x < 3)
       end

--- a/spec/rubocop/cop/style/parentheses_around_condition_spec.rb
+++ b/spec/rubocop/cop/style/parentheses_around_condition_spec.rb
@@ -5,7 +5,7 @@ describe RuboCop::Cop::Style::ParenthesesAroundCondition, :config do
   let(:cop_config) { { 'AllowSafeAssignment' => true } }
 
   it 'registers an offense for parentheses around condition' do
-    inspect_source(cop, <<-RUBY.strip_indent)
+    inspect_source(<<-RUBY.strip_indent)
       if (x > 10)
       elsif (x < 3)
       end
@@ -101,7 +101,7 @@ describe RuboCop::Cop::Style::ParenthesesAroundCondition, :config do
 
   %w[rescue if unless while until].each do |op|
     it "allows parens if the condition node is a modifier #{op} op" do
-      inspect_source(cop, <<-RUBY.strip_indent)
+      inspect_source(<<-RUBY.strip_indent)
         if (something #{op} top)
         end
       RUBY
@@ -158,7 +158,7 @@ describe RuboCop::Cop::Style::ParenthesesAroundCondition, :config do
 
     it 'does not accept variable assignment in condition surrounded with ' \
        'parentheses' do
-      inspect_source(cop, <<-RUBY.strip_indent)
+      inspect_source(<<-RUBY.strip_indent)
         if (test = 10)
         end
       RUBY
@@ -167,7 +167,7 @@ describe RuboCop::Cop::Style::ParenthesesAroundCondition, :config do
 
     it 'does not accept element assignment in condition surrounded with ' \
        'parentheses' do
-      inspect_source(cop, <<-RUBY.strip_indent)
+      inspect_source(<<-RUBY.strip_indent)
         if (test[0] = 10)
         end
       RUBY

--- a/spec/rubocop/cop/style/percent_literal_delimiters_spec.rb
+++ b/spec/rubocop/cop/style/percent_literal_delimiters_spec.rb
@@ -30,7 +30,7 @@ describe RuboCop::Cop::Style::PercentLiteralDelimiters, :config do
     let(:cop_config) { { 'PreferredDelimiters' => { 'foobar' => '()' } } }
 
     it 'raises an error when invalid configuration is specified' do
-      expect { inspect_source(cop, '%w[string]') }.to raise_error(ArgumentError)
+      expect { inspect_source('%w[string]') }.to raise_error(ArgumentError)
     end
   end
 
@@ -48,13 +48,13 @@ describe RuboCop::Cop::Style::PercentLiteralDelimiters, :config do
 
     it 'does not register an offense for other delimiters ' \
        'when containing preferred delimiter characters' do
-      inspect_source(cop, '%([string])')
+      inspect_source('%([string])')
       expect(cop.offenses).to be_empty
     end
 
     it 'registers an offense for other delimiters ' \
        'when containing preferred delimiter characters in interpolation' do
-      inspect_source(cop, '%(#{[1].first})')
+      inspect_source('%(#{[1].first})')
       expect(cop.messages.size).to eq(1)
     end
   end
@@ -73,7 +73,7 @@ describe RuboCop::Cop::Style::PercentLiteralDelimiters, :config do
 
     it 'does not register an offense for other delimiters ' \
        'when containing preferred delimiter characters' do
-      inspect_source(cop, '%q([string])')
+      inspect_source('%q([string])')
       expect(cop.offenses).to be_empty
     end
   end
@@ -92,13 +92,13 @@ describe RuboCop::Cop::Style::PercentLiteralDelimiters, :config do
 
     it 'does not register an offense for other delimiters ' \
        'when containing preferred delimiter characters' do
-      inspect_source(cop, '%Q([string])')
+      inspect_source('%Q([string])')
       expect(cop.offenses).to be_empty
     end
 
     it 'registers an offense for other delimiters ' \
        'when containing preferred delimiter characters in interpolation' do
-      inspect_source(cop, '%Q(#{[1].first})')
+      inspect_source('%Q(#{[1].first})')
       expect(cop.messages.size).to eq(1)
     end
   end
@@ -117,7 +117,7 @@ describe RuboCop::Cop::Style::PercentLiteralDelimiters, :config do
 
     it 'does not register an offense for other delimiters ' \
        'when containing preferred delimiter characters' do
-      inspect_source(cop, '%w([some] [words])')
+      inspect_source('%w([some] [words])')
       expect(cop.offenses).to be_empty
     end
   end
@@ -136,13 +136,13 @@ describe RuboCop::Cop::Style::PercentLiteralDelimiters, :config do
 
     it 'does not register an offense for other delimiters ' \
        'when containing preferred delimiter characters' do
-      inspect_source(cop, '%W([some] [words])')
+      inspect_source('%W([some] [words])')
       expect(cop.offenses).to be_empty
     end
 
     it 'registers an offense for other delimiters ' \
        'when containing preferred delimiter characters in interpolation' do
-      inspect_source(cop, '%W(#{[1].first})')
+      inspect_source('%W(#{[1].first})')
       expect(cop.messages.size).to eq(1)
     end
   end
@@ -161,13 +161,13 @@ describe RuboCop::Cop::Style::PercentLiteralDelimiters, :config do
 
     it 'does not register an offense for other delimiters ' \
        'when containing preferred delimiter characters' do
-      inspect_source(cop, '%r([regexp])')
+      inspect_source('%r([regexp])')
       expect(cop.offenses).to be_empty
     end
 
     it 'registers an offense for other delimiters ' \
        'when containing preferred delimiter characters in interpolation' do
-      inspect_source(cop, '%r(#{[1].first})')
+      inspect_source('%r(#{[1].first})')
       expect(cop.messages.size).to eq(1)
     end
   end
@@ -199,7 +199,7 @@ describe RuboCop::Cop::Style::PercentLiteralDelimiters, :config do
 
     it 'registers an offense for other delimiters ' \
        'when containing preferred delimiter characters in interpolation' do
-      inspect_source(cop, '%I(#{[1].first})')
+      inspect_source('%I(#{[1].first})')
       expect(cop.messages).to eq(
         ['`%I`-literals should be delimited by `[` and `]`.']
       )
@@ -233,13 +233,13 @@ describe RuboCop::Cop::Style::PercentLiteralDelimiters, :config do
 
     it 'does not register an offense for other delimiters ' \
        'when containing preferred delimiter characters' do
-      inspect_source(cop, '%x([command])')
+      inspect_source('%x([command])')
       expect(cop.offenses).to be_empty
     end
 
     it 'registers an offense for other delimiters ' \
        'when containing preferred delimiter characters in interpolation' do
-      inspect_source(cop, '%x(#{[1].first})')
+      inspect_source('%x(#{[1].first})')
       expect(cop.messages.size).to eq(1)
     end
   end

--- a/spec/rubocop/cop/style/percent_literal_delimiters_spec.rb
+++ b/spec/rubocop/cop/style/percent_literal_delimiters_spec.rb
@@ -246,22 +246,22 @@ describe RuboCop::Cop::Style::PercentLiteralDelimiters, :config do
 
   context 'auto-correct' do
     it 'fixes a string' do
-      new_source = autocorrect_source(cop, '%(string)')
+      new_source = autocorrect_source('%(string)')
       expect(new_source).to eq('%[string]')
     end
 
     it 'fixes a string with no content' do
-      new_source = autocorrect_source(cop, '%()')
+      new_source = autocorrect_source('%()')
       expect(new_source).to eq('%[]')
     end
 
     it 'fixes a string array' do
-      new_source = autocorrect_source(cop, '%w(some words)')
+      new_source = autocorrect_source('%w(some words)')
       expect(new_source).to eq('%w[some words]')
     end
 
     it 'fixes a string array in a scope' do
-      new_source = autocorrect_source(cop, <<-RUBY.strip_indent)
+      new_source = autocorrect_source(<<-RUBY.strip_indent)
         module Foo
            class Bar
              def baz
@@ -283,30 +283,30 @@ describe RuboCop::Cop::Style::PercentLiteralDelimiters, :config do
 
     it 'fixes a regular expression' do
       original_source = '%r(.*)'
-      new_source = autocorrect_source(cop, original_source)
+      new_source = autocorrect_source(original_source)
       expect(new_source).to eq('%r[.*]')
     end
 
     it 'fixes a string with interpolation' do
       original_source = '%Q|#{with_interpolation}|'
-      new_source = autocorrect_source(cop, original_source)
+      new_source = autocorrect_source(original_source)
       expect(new_source).to eq('%Q[#{with_interpolation}]')
     end
 
     it 'fixes a regular expression with interpolation' do
       original_source = '%r|#{with_interpolation}|'
-      new_source = autocorrect_source(cop, original_source)
+      new_source = autocorrect_source(original_source)
       expect(new_source).to eq('%r[#{with_interpolation}]')
     end
 
     it 'fixes a regular expression with option' do
       original_source = '%r(.*)i'
-      new_source = autocorrect_source(cop, original_source)
+      new_source = autocorrect_source(original_source)
       expect(new_source).to eq('%r[.*]i')
     end
 
     it 'preserves line breaks when fixing a multiline array' do
-      new_source = autocorrect_source(cop, <<-RUBY.strip_indent)
+      new_source = autocorrect_source(<<-RUBY.strip_indent)
         %w(
         some
         words
@@ -333,7 +333,7 @@ describe RuboCop::Cop::Style::PercentLiteralDelimiters, :config do
         |    second
         |  ]
       RUBY
-      new_source = autocorrect_source(cop, original_source)
+      new_source = autocorrect_source(original_source)
       expect(new_source).to eq(corrected_source)
     end
 
@@ -350,19 +350,19 @@ describe RuboCop::Cop::Style::PercentLiteralDelimiters, :config do
           second
         ]
       RUBY
-      new_source = autocorrect_source(cop, original_source)
+      new_source = autocorrect_source(original_source)
       expect(new_source).to eq(corrected_source)
     end
 
     shared_examples :escape_characters do |percent_literal|
       it "corrects #{percent_literal} with \\n in it" do
-        new_source = autocorrect_source(cop, "#{percent_literal}{\n}")
+        new_source = autocorrect_source("#{percent_literal}{\n}")
 
         expect(new_source).to eq("#{percent_literal}[\n]")
       end
 
       it "corrects #{percent_literal} with \\t in it" do
-        new_source = autocorrect_source(cop, "#{percent_literal}{\t}")
+        new_source = autocorrect_source("#{percent_literal}{\t}")
 
         expect(new_source).to eq("#{percent_literal}[\t]")
       end

--- a/spec/rubocop/cop/style/percent_q_literals_spec.rb
+++ b/spec/rubocop/cop/style/percent_q_literals_spec.rb
@@ -41,7 +41,7 @@ describe RuboCop::Cop::Style::PercentQLiterals, :config do
       end
 
       it 'auto-corrects' do
-        new_source = autocorrect_source(cop, '%Q(hi)')
+        new_source = autocorrect_source('%Q(hi)')
         expect(new_source).to eq('%q(hi)')
       end
 
@@ -79,7 +79,7 @@ describe RuboCop::Cop::Style::PercentQLiterals, :config do
       end
 
       it 'auto-corrects' do
-        new_source = autocorrect_source(cop, '%q[hi]')
+        new_source = autocorrect_source('%q[hi]')
         expect(new_source).to eq('%Q[hi]')
       end
 
@@ -101,7 +101,7 @@ describe RuboCop::Cop::Style::PercentQLiterals, :config do
 
       it 'does not auto-correct' do
         source = '%q(#{1 + 2})'
-        new_source = autocorrect_source(cop, source)
+        new_source = autocorrect_source(source)
         expect(new_source).to eq(source)
       end
 

--- a/spec/rubocop/cop/style/perl_backrefs_spec.rb
+++ b/spec/rubocop/cop/style/perl_backrefs_spec.rb
@@ -11,12 +11,12 @@ describe RuboCop::Cop::Style::PerlBackrefs do
   end
 
   it 'auto-corrects $1 to Regexp.last_match[1]' do
-    new_source = autocorrect_source(cop, '$1')
+    new_source = autocorrect_source('$1')
     expect(new_source).to eq('Regexp.last_match(1)')
   end
 
   it 'auto-corrects #$1 to #{Regexp.last_match[1]}' do
-    new_source = autocorrect_source(cop, '"#$1"')
+    new_source = autocorrect_source('"#$1"')
     expect(new_source).to eq('"#{Regexp.last_match(1)}"')
   end
 end

--- a/spec/rubocop/cop/style/predicate_name_spec.rb
+++ b/spec/rubocop/cop/style/predicate_name_spec.rb
@@ -11,7 +11,7 @@ describe RuboCop::Cop::Style::PredicateName, :config do
 
     %w[has is].each do |prefix|
       it 'registers an offense when method name starts with known prefix' do
-        inspect_source(cop, <<-RUBY.strip_indent)
+        inspect_source(<<-RUBY.strip_indent)
           def #{prefix}_attr
             # ...
           end
@@ -38,7 +38,7 @@ describe RuboCop::Cop::Style::PredicateName, :config do
 
     %w[has is].each do |prefix|
       it 'registers an offense when method name starts with known prefix' do
-        inspect_source(cop, <<-RUBY.strip_indent)
+        inspect_source(<<-RUBY.strip_indent)
           def #{prefix}_attr
             # ...
           end

--- a/spec/rubocop/cop/style/preferred_hash_methods_spec.rb
+++ b/spec/rubocop/cop/style/preferred_hash_methods_spec.rb
@@ -29,12 +29,12 @@ describe RuboCop::Cop::Style::PreferredHashMethods, :config do
     end
 
     it 'auto-corrects has_key? with key?' do
-      new_source = autocorrect_source(cop, 'hash.has_key?(:test)')
+      new_source = autocorrect_source('hash.has_key?(:test)')
       expect(new_source).to eq('hash.key?(:test)')
     end
 
     it 'auto-corrects has_value? with value?' do
-      new_source = autocorrect_source(cop, 'hash.has_value?(value)')
+      new_source = autocorrect_source('hash.has_value?(value)')
       expect(new_source).to eq('hash.value?(value)')
     end
   end
@@ -65,12 +65,12 @@ describe RuboCop::Cop::Style::PreferredHashMethods, :config do
     end
 
     it 'auto-corrects key? with has_key?' do
-      new_source = autocorrect_source(cop, 'hash.key?(:test)')
+      new_source = autocorrect_source('hash.key?(:test)')
       expect(new_source).to eq('hash.has_key?(:test)')
     end
 
     it 'auto-corrects value? with has_value?' do
-      new_source = autocorrect_source(cop, 'hash.value?(value)')
+      new_source = autocorrect_source('hash.value?(value)')
       expect(new_source).to eq('hash.has_value?(value)')
     end
   end

--- a/spec/rubocop/cop/style/proc_spec.rb
+++ b/spec/rubocop/cop/style/proc_spec.rb
@@ -19,7 +19,7 @@ describe RuboCop::Cop::Style::Proc do
   end
 
   it 'auto-corrects Proc.new to proc' do
-    corrected = autocorrect_source(cop, ['Proc.new { test }'])
+    corrected = autocorrect_source(['Proc.new { test }'])
     expect(corrected).to eq 'proc { test }'
   end
 end

--- a/spec/rubocop/cop/style/raise_args_spec.rb
+++ b/spec/rubocop/cop/style/raise_args_spec.rb
@@ -8,7 +8,7 @@ describe RuboCop::Cop::Style::RaiseArgs, :config do
 
     context 'with a raise with 2 args' do
       it 'reports an offense' do
-        inspect_source(cop, 'raise RuntimeError, msg')
+        inspect_source('raise RuntimeError, msg')
         expect(cop.offenses.size).to eq(1)
         expect(cop.config_to_allow_offenses)
           .to eq('EnforcedStyle' => 'exploded')
@@ -22,7 +22,7 @@ describe RuboCop::Cop::Style::RaiseArgs, :config do
 
     context 'with correct + opposite' do
       it 'reports an offense' do
-        inspect_source(cop, <<-RUBY.strip_indent)
+        inspect_source(<<-RUBY.strip_indent)
           if a
             raise RuntimeError, msg
           else
@@ -83,7 +83,7 @@ describe RuboCop::Cop::Style::RaiseArgs, :config do
     context 'with a raise with exception object' do
       context 'with one argument' do
         it 'reports an offense' do
-          inspect_source(cop, 'raise Ex.new(msg)')
+          inspect_source('raise Ex.new(msg)')
           expect(cop.offenses.size).to eq(1)
           expect(cop.messages)
             .to eq(['Provide an exception class and message ' \
@@ -100,7 +100,7 @@ describe RuboCop::Cop::Style::RaiseArgs, :config do
 
       context 'with no arguments' do
         it 'reports an offense' do
-          inspect_source(cop, 'raise Ex.new')
+          inspect_source('raise Ex.new')
           expect(cop.offenses.size).to eq(1)
           expect(cop.messages)
             .to eq(['Provide an exception class and message ' \
@@ -118,7 +118,7 @@ describe RuboCop::Cop::Style::RaiseArgs, :config do
 
     context 'with opposite + correct' do
       it 'reports an offense for opposite + correct' do
-        inspect_source(cop, <<-RUBY.strip_indent)
+        inspect_source(<<-RUBY.strip_indent)
           if a
             raise RuntimeError, msg
           else

--- a/spec/rubocop/cop/style/raise_args_spec.rb
+++ b/spec/rubocop/cop/style/raise_args_spec.rb
@@ -15,7 +15,7 @@ describe RuboCop::Cop::Style::RaiseArgs, :config do
       end
 
       it 'auto-corrects to compact style' do
-        new_source = autocorrect_source(cop, 'raise RuntimeError, msg')
+        new_source = autocorrect_source('raise RuntimeError, msg')
         expect(new_source).to eq('raise RuntimeError.new(msg)')
       end
     end
@@ -36,7 +36,7 @@ describe RuboCop::Cop::Style::RaiseArgs, :config do
       end
 
       it 'auto-corrects to compact style' do
-        new_source = autocorrect_source(cop, <<-RUBY.strip_indent)
+        new_source = autocorrect_source(<<-RUBY.strip_indent)
           if a
             raise RuntimeError, msg
           else
@@ -62,8 +62,7 @@ describe RuboCop::Cop::Style::RaiseArgs, :config do
       end
 
       it 'auto-corrects to compact style' do
-        new_source = autocorrect_source(cop,
-                                        ['raise RuntimeError, msg, caller'])
+        new_source = autocorrect_source(['raise RuntimeError, msg, caller'])
         expect(new_source).to eq('raise RuntimeError.new(msg, caller)')
       end
     end
@@ -93,7 +92,7 @@ describe RuboCop::Cop::Style::RaiseArgs, :config do
         end
 
         it 'auto-corrects to exploded style' do
-          new_source = autocorrect_source(cop, ['raise Ex.new(msg)'])
+          new_source = autocorrect_source(['raise Ex.new(msg)'])
           expect(new_source).to eq('raise Ex, msg')
         end
       end
@@ -110,7 +109,7 @@ describe RuboCop::Cop::Style::RaiseArgs, :config do
         end
 
         it 'auto-corrects to exploded style' do
-          new_source = autocorrect_source(cop, ['raise Ex.new'])
+          new_source = autocorrect_source(['raise Ex.new'])
           expect(new_source).to eq('raise Ex')
         end
       end
@@ -130,7 +129,7 @@ describe RuboCop::Cop::Style::RaiseArgs, :config do
       end
 
       it 'auto-corrects to exploded style' do
-        new_source = autocorrect_source(cop, <<-RUBY.strip_indent)
+        new_source = autocorrect_source(<<-RUBY.strip_indent)
           if a
             raise RuntimeError, msg
           else

--- a/spec/rubocop/cop/style/redundant_begin_spec.rb
+++ b/spec/rubocop/cop/style/redundant_begin_spec.rb
@@ -5,7 +5,7 @@ describe RuboCop::Cop::Style::RedundantBegin do
 
   it 'reports an offense for single line def with redundant begin block' do
     src = '  def func; begin; x; y; rescue; z end end'
-    inspect_source(cop, src)
+    inspect_source(src)
     expect(cop.offenses.size).to eq(1)
   end
 
@@ -19,7 +19,7 @@ describe RuboCop::Cop::Style::RedundantBegin do
         end
       end
     RUBY
-    inspect_source(cop, src)
+    inspect_source(src)
     expect(cop.offenses.size).to eq(1)
   end
 
@@ -33,7 +33,7 @@ describe RuboCop::Cop::Style::RedundantBegin do
         end
       end
     RUBY
-    inspect_source(cop, src)
+    inspect_source(src)
     expect(cop.offenses.size).to eq(1)
   end
 

--- a/spec/rubocop/cop/style/redundant_begin_spec.rb
+++ b/spec/rubocop/cop/style/redundant_begin_spec.rb
@@ -84,7 +84,7 @@ describe RuboCop::Cop::Style::RedundantBegin do
                   '    ',
                   '  end',
                   ''].join("\n")
-    new_source = autocorrect_source(cop, src)
+    new_source = autocorrect_source(src)
     expect(new_source).to eq(result_src)
   end
 
@@ -92,7 +92,7 @@ describe RuboCop::Cop::Style::RedundantBegin do
      'by removing redundant begin blocks' do
     src = '  def func; begin; x; y; rescue; z end end'
     result_src = '  def func; ; x; y; rescue; z  end'
-    new_source = autocorrect_source(cop, src)
+    new_source = autocorrect_source(src)
     expect(new_source).to eq(result_src)
   end
 
@@ -129,7 +129,7 @@ describe RuboCop::Cop::Style::RedundantBegin do
                   '  ',
                   'end',
                   ''].join("\n")
-    new_source = autocorrect_source(cop, src)
+    new_source = autocorrect_source(src)
     expect(new_source).to eq(result_src)
   end
 
@@ -150,7 +150,7 @@ describe RuboCop::Cop::Style::RedundantBegin do
          # comment 3
       end
     RUBY
-    new_source = autocorrect_source(cop, src)
+    new_source = autocorrect_source(src)
     expect(new_source).to eq(result_src)
   end
 end

--- a/spec/rubocop/cop/style/redundant_exception_spec.rb
+++ b/spec/rubocop/cop/style/redundant_exception_spec.rb
@@ -29,7 +29,7 @@ describe RuboCop::Cop::Style::RedundantException do
     it "auto-corrects a #{keyword} RuntimeError by removing RuntimeError" do
       src = "#{keyword} RuntimeError, msg"
       result_src = "#{keyword} msg"
-      new_src = autocorrect_source(cop, src)
+      new_src = autocorrect_source(src)
       expect(new_src).to eq(result_src)
     end
 
@@ -37,7 +37,7 @@ describe RuboCop::Cop::Style::RedundantException do
        'removing RuntimeError.new' do
       src = "#{keyword} RuntimeError.new(msg)"
       result_src = "#{keyword} msg"
-      new_src = autocorrect_source(cop, src)
+      new_src = autocorrect_source(src)
       expect(new_src).to eq(result_src)
     end
 
@@ -45,20 +45,20 @@ describe RuboCop::Cop::Style::RedundantException do
        'removing RuntimeError.new' do
       src = "#{keyword} RuntimeError.new msg"
       result_src = "#{keyword} msg"
-      new_src = autocorrect_source(cop, src)
+      new_src = autocorrect_source(src)
       expect(new_src).to eq(result_src)
     end
 
     it "does not modify #{keyword} w/ RuntimeError if it does not have 2 " \
        'args' do
       src = "#{keyword} runtimeError, msg, caller"
-      new_src = autocorrect_source(cop, src)
+      new_src = autocorrect_source(src)
       expect(new_src).to eq(src)
     end
 
     it 'does not modify rescue w/ non redundant error' do
       src = "#{keyword} OtherError, msg"
-      new_src = autocorrect_source(cop, src)
+      new_src = autocorrect_source(src)
       expect(new_src).to eq(src)
     end
   end

--- a/spec/rubocop/cop/style/redundant_exception_spec.rb
+++ b/spec/rubocop/cop/style/redundant_exception_spec.rb
@@ -6,7 +6,7 @@ describe RuboCop::Cop::Style::RedundantException do
   shared_examples 'common behavior' do |keyword|
     it "reports an offense for a #{keyword} with RuntimeError" do
       src = "#{keyword} RuntimeError, msg"
-      inspect_source(cop, src)
+      inspect_source(src)
       expect(cop.highlights).to eq([src])
       expect(cop.messages)
         .to eq(['Redundant `RuntimeError` argument can be removed.'])
@@ -14,7 +14,7 @@ describe RuboCop::Cop::Style::RedundantException do
 
     it "reports an offense for a #{keyword} with RuntimeError.new" do
       src = "#{keyword} RuntimeError.new(msg)"
-      inspect_source(cop, src)
+      inspect_source(src)
       expect(cop.highlights).to eq([src])
       expect(cop.messages)
         .to eq(['Redundant `RuntimeError.new` call can be replaced with ' \
@@ -22,7 +22,7 @@ describe RuboCop::Cop::Style::RedundantException do
     end
 
     it "accepts a #{keyword} with RuntimeError if it does not have 2 args" do
-      inspect_source(cop, "#{keyword} RuntimeError, msg, caller")
+      inspect_source("#{keyword} RuntimeError, msg, caller")
       expect(cop.offenses).to be_empty
     end
 

--- a/spec/rubocop/cop/style/redundant_freeze_spec.rb
+++ b/spec/rubocop/cop/style/redundant_freeze_spec.rb
@@ -7,7 +7,7 @@ describe RuboCop::Cop::Style::RedundantFreeze do
   shared_examples :immutable_objects do |o|
     it "registers an offense for frozen #{o}" do
       source = [prefix, "CONST = #{o}.freeze"].compact.join("\n")
-      inspect_source(cop, source)
+      inspect_source(source)
       expect(cop.offenses.size).to eq(1)
     end
 
@@ -28,7 +28,7 @@ describe RuboCop::Cop::Style::RedundantFreeze do
   shared_examples :mutable_objects do |o|
     it "allows #{o} with freeze" do
       source = [prefix, "CONST = #{o}.freeze"].compact.join("\n")
-      inspect_source(cop, source)
+      inspect_source(source)
       expect(cop.offenses).to be_empty
     end
   end

--- a/spec/rubocop/cop/style/redundant_freeze_spec.rb
+++ b/spec/rubocop/cop/style/redundant_freeze_spec.rb
@@ -13,7 +13,7 @@ describe RuboCop::Cop::Style::RedundantFreeze do
 
     it 'auto-corrects by removing .freeze' do
       source = [prefix, "CONST = #{o}.freeze"].compact.join("\n")
-      new_source = autocorrect_source(cop, source)
+      new_source = autocorrect_source(source)
       expect(new_source).to eq(source.chomp('.freeze'))
     end
   end

--- a/spec/rubocop/cop/style/redundant_parentheses_spec.rb
+++ b/spec/rubocop/cop/style/redundant_parentheses_spec.rb
@@ -12,7 +12,7 @@ describe RuboCop::Cop::Style::RedundantParentheses do
     end
 
     it 'auto-corrects' do
-      expect(autocorrect_source(cop, expr)).to eq correct
+      expect(autocorrect_source(expr)).to eq correct
     end
   end
 

--- a/spec/rubocop/cop/style/redundant_parentheses_spec.rb
+++ b/spec/rubocop/cop/style/redundant_parentheses_spec.rb
@@ -5,7 +5,7 @@ describe RuboCop::Cop::Style::RedundantParentheses do
 
   shared_examples 'redundant' do |expr, correct, type, highlight = nil|
     it "registers an offense for parentheses around #{type}" do
-      inspect_source(cop, expr)
+      inspect_source(expr)
       expect(cop.messages)
         .to eq(["Don't use parentheses around #{type}."])
       expect(cop.highlights).to eq([highlight || expr])
@@ -18,7 +18,7 @@ describe RuboCop::Cop::Style::RedundantParentheses do
 
   shared_examples 'plausible' do |expr|
     it 'accepts parentheses when arguments are unparenthesized' do
-      inspect_source(cop, expr)
+      inspect_source(expr)
       expect(cop.offenses).to be_empty
     end
   end
@@ -168,7 +168,7 @@ describe RuboCop::Cop::Style::RedundantParentheses do
 
   it 'accepts parentheses around a method call with unparenthesized ' \
      'arguments' do
-    inspect_source(cop, '(a 1, 2) && (1 + 1)')
+    inspect_source('(a 1, 2) && (1 + 1)')
     expect(cop.offenses).to be_empty
   end
 

--- a/spec/rubocop/cop/style/redundant_return_spec.rb
+++ b/spec/rubocop/cop/style/redundant_return_spec.rb
@@ -10,7 +10,7 @@ describe RuboCop::Cop::Style::RedundantReturn, :config do
         return something
       end
     RUBY
-    inspect_source(cop, src)
+    inspect_source(src)
     expect(cop.offenses.size).to eq(1)
   end
 
@@ -20,7 +20,7 @@ describe RuboCop::Cop::Style::RedundantReturn, :config do
         return something
       end
     RUBY
-    inspect_source(cop, src)
+    inspect_source(src)
     expect(cop.offenses.size).to eq(1)
   end
 
@@ -32,7 +32,7 @@ describe RuboCop::Cop::Style::RedundantReturn, :config do
         return something
       end
     RUBY
-    inspect_source(cop, src)
+    inspect_source(src)
     expect(cop.offenses.size).to eq(1)
   end
 
@@ -44,7 +44,7 @@ describe RuboCop::Cop::Style::RedundantReturn, :config do
         return something
       end
     RUBY
-    inspect_source(cop, src)
+    inspect_source(src)
     expect(cop.offenses.size).to eq(1)
   end
 
@@ -107,7 +107,7 @@ describe RuboCop::Cop::Style::RedundantReturn, :config do
       end
 
       it "registers an offense for #{ret}" do
-        inspect_source(cop, src)
+        inspect_source(src)
         expect(cop.offenses.size).to eq(1)
       end
 
@@ -135,7 +135,7 @@ describe RuboCop::Cop::Style::RedundantReturn, :config do
           return something, test
         end
       RUBY
-      inspect_source(cop, src)
+      inspect_source(src)
       expect(cop.offenses.size).to eq(1)
     end
 
@@ -145,7 +145,7 @@ describe RuboCop::Cop::Style::RedundantReturn, :config do
           return something, test
         end
       RUBY
-      inspect_source(cop, src)
+      inspect_source(src)
       expect(cop.offenses.size).to eq(1)
     end
 
@@ -157,7 +157,7 @@ describe RuboCop::Cop::Style::RedundantReturn, :config do
           return something, test
         end
       RUBY
-      inspect_source(cop, src)
+      inspect_source(src)
       expect(cop.offenses.size).to eq(1)
     end
 
@@ -169,7 +169,7 @@ describe RuboCop::Cop::Style::RedundantReturn, :config do
           return something, test
         end
       RUBY
-      inspect_source(cop, src)
+      inspect_source(src)
       expect(cop.offenses.size).to eq(1)
     end
 

--- a/spec/rubocop/cop/style/redundant_return_spec.rb
+++ b/spec/rubocop/cop/style/redundant_return_spec.rb
@@ -89,7 +89,7 @@ describe RuboCop::Cop::Style::RedundantReturn, :config do
         something
       end
     RUBY
-    new_source = autocorrect_source(cop, src)
+    new_source = autocorrect_source(src)
     expect(new_source).to eq(result_src)
   end
 
@@ -112,7 +112,7 @@ describe RuboCop::Cop::Style::RedundantReturn, :config do
       end
 
       it "auto-corrects by replacing #{ret} with nil" do
-        new_source = autocorrect_source(cop, src)
+        new_source = autocorrect_source(src)
         expect(new_source).to eq(<<-RUBY.strip_indent)
           def func
             one
@@ -185,7 +185,7 @@ describe RuboCop::Cop::Style::RedundantReturn, :config do
           [1, 2]
         end
       RUBY
-      new_source = autocorrect_source(cop, src)
+      new_source = autocorrect_source(src)
       expect(new_source).to eq(result_src)
     end
 
@@ -201,7 +201,7 @@ describe RuboCop::Cop::Style::RedundantReturn, :config do
           {:a => 1, :b => 2}
         end
       RUBY
-      new_source = autocorrect_source(cop, src)
+      new_source = autocorrect_source(src)
       expect(new_source).to eq(result_src)
     end
 
@@ -217,7 +217,7 @@ describe RuboCop::Cop::Style::RedundantReturn, :config do
           {:a => 1, :b => 2}
         end
       RUBY
-      new_source = autocorrect_source(cop, src)
+      new_source = autocorrect_source(src)
       expect(new_source).to eq(result_src)
     end
   end
@@ -267,7 +267,7 @@ describe RuboCop::Cop::Style::RedundantReturn, :config do
           return  1, 2
         end
       RUBY
-      new_source = autocorrect_source(cop, src)
+      new_source = autocorrect_source(src)
       expect(new_source).to eq(src)
     end
   end
@@ -305,7 +305,7 @@ describe RuboCop::Cop::Style::RedundantReturn, :config do
     end
 
     it 'auto-corrects' do
-      corrected = autocorrect_source(cop, src)
+      corrected = autocorrect_source(src)
       expect(corrected).to eq <<-RUBY.strip_indent
         def func
           if x
@@ -353,7 +353,7 @@ describe RuboCop::Cop::Style::RedundantReturn, :config do
     end
 
     it 'auto-corrects' do
-      corrected = autocorrect_source(cop, src)
+      corrected = autocorrect_source(src)
       expect(corrected).to eq <<-RUBY.strip_indent
         def func
           case x

--- a/spec/rubocop/cop/style/redundant_self_spec.rb
+++ b/spec/rubocop/cop/style/redundant_self_spec.rb
@@ -193,7 +193,7 @@ describe RuboCop::Cop::Style::RedundantSelf do
   end
 
   it 'auto-corrects by removing redundant self' do
-    new_source = autocorrect_source(cop, 'self.x')
+    new_source = autocorrect_source('self.x')
     expect(new_source).to eq('x')
   end
 end

--- a/spec/rubocop/cop/style/redundant_self_spec.rb
+++ b/spec/rubocop/cop/style/redundant_self_spec.rb
@@ -5,7 +5,7 @@ describe RuboCop::Cop::Style::RedundantSelf do
 
   it 'reports an offense a self receiver on an rvalue' do
     src = 'a = self.b'
-    inspect_source(cop, src)
+    inspect_source(src)
     expect(cop.offenses.size).to eq(1)
   end
 
@@ -135,7 +135,7 @@ describe RuboCop::Cop::Style::RedundantSelf do
           puts bar, self.bar
         end
       RUBY
-      inspect_source(cop, src)
+      inspect_source(src)
       expect(cop.offenses).to be_empty
     end
   end
@@ -188,7 +188,7 @@ describe RuboCop::Cop::Style::RedundantSelf do
 
   it 'reports an offence a self receiver of .call' do
     src = 'self.call'
-    inspect_source(cop, src)
+    inspect_source(src)
     expect(cop.offenses.size).to eq(1)
   end
 

--- a/spec/rubocop/cop/style/regexp_literal_spec.rb
+++ b/spec/rubocop/cop/style/regexp_literal_spec.rb
@@ -99,7 +99,7 @@ describe RuboCop::Cop::Style::RegexpLiteral, :config do
       end
 
       it 'registers an offense' do
-        inspect_source(cop, source)
+        inspect_source(source)
         expect(cop.messages).to eq(['Use `%r` around regular expression.'])
       end
 
@@ -171,7 +171,7 @@ describe RuboCop::Cop::Style::RegexpLiteral, :config do
       end
 
       it 'registers an offense' do
-        inspect_source(cop, source)
+        inspect_source(source)
         expect(cop.messages).to eq(['Use `//` around regular expression.'])
       end
 
@@ -202,7 +202,7 @@ describe RuboCop::Cop::Style::RegexpLiteral, :config do
         before { cop_config['AllowInnerSlashes'] = true }
 
         it 'registers an offense' do
-          inspect_source(cop, source)
+          inspect_source(source)
           expect(cop.messages).to eq(['Use `//` around regular expression.'])
         end
 
@@ -258,7 +258,7 @@ describe RuboCop::Cop::Style::RegexpLiteral, :config do
       end
 
       it 'registers an offense' do
-        inspect_source(cop, source)
+        inspect_source(source)
         expect(cop.messages).to eq(['Use `%r` around regular expression.'])
       end
 
@@ -277,7 +277,7 @@ describe RuboCop::Cop::Style::RegexpLiteral, :config do
       end
 
       it 'registers an offense' do
-        inspect_source(cop, source)
+        inspect_source(source)
         expect(cop.messages).to eq(['Use `%r` around regular expression.'])
       end
 
@@ -364,7 +364,7 @@ describe RuboCop::Cop::Style::RegexpLiteral, :config do
       end
 
       it 'registers an offense' do
-        inspect_source(cop, source)
+        inspect_source(source)
         expect(cop.messages).to eq(['Use `%r` around regular expression.'])
       end
 
@@ -383,7 +383,7 @@ describe RuboCop::Cop::Style::RegexpLiteral, :config do
       end
 
       it 'registers an offense' do
-        inspect_source(cop, source)
+        inspect_source(source)
         expect(cop.messages).to eq(['Use `%r` around regular expression.'])
       end
 

--- a/spec/rubocop/cop/style/regexp_literal_spec.rb
+++ b/spec/rubocop/cop/style/regexp_literal_spec.rb
@@ -41,7 +41,7 @@ describe RuboCop::Cop::Style::RegexpLiteral, :config do
     end
 
     it 'respects the configuration when auto-correcting' do
-      new_source = autocorrect_source(cop, '/a/')
+      new_source = autocorrect_source('/a/')
       expect(new_source).to eq('%r[a]')
     end
   end
@@ -66,7 +66,7 @@ describe RuboCop::Cop::Style::RegexpLiteral, :config do
       end
 
       it 'cannot auto-correct' do
-        new_source = autocorrect_source(cop, source)
+        new_source = autocorrect_source(source)
         expect(new_source).to eq(source)
       end
 
@@ -104,7 +104,7 @@ describe RuboCop::Cop::Style::RegexpLiteral, :config do
       end
 
       it 'cannot auto-correct' do
-        new_source = autocorrect_source(cop, source)
+        new_source = autocorrect_source(source)
         expect(new_source).to eq(source.join("\n"))
       end
 
@@ -133,7 +133,7 @@ describe RuboCop::Cop::Style::RegexpLiteral, :config do
       end
 
       it 'auto-corrects' do
-        new_source = autocorrect_source(cop, source)
+        new_source = autocorrect_source(source)
         expect(new_source).to eq('foo = /a/')
       end
     end
@@ -156,7 +156,7 @@ describe RuboCop::Cop::Style::RegexpLiteral, :config do
         end
 
         it 'cannot auto-correct' do
-          new_source = autocorrect_source(cop, source)
+          new_source = autocorrect_source(source)
           expect(new_source).to eq(source)
         end
       end
@@ -176,7 +176,7 @@ describe RuboCop::Cop::Style::RegexpLiteral, :config do
       end
 
       it 'auto-corrects' do
-        new_source = autocorrect_source(cop, source)
+        new_source = autocorrect_source(source)
         expect(new_source).to eq("foo = /\n  foo\n  bar\n/x")
       end
     end
@@ -207,7 +207,7 @@ describe RuboCop::Cop::Style::RegexpLiteral, :config do
         end
 
         it 'cannot auto-correct' do
-          new_source = autocorrect_source(cop, source)
+          new_source = autocorrect_source(source)
           expect(new_source).to eq(source.join("\n"))
         end
       end
@@ -228,7 +228,7 @@ describe RuboCop::Cop::Style::RegexpLiteral, :config do
       end
 
       it 'auto-corrects' do
-        new_source = autocorrect_source(cop, source)
+        new_source = autocorrect_source(source)
         expect(new_source).to eq('foo = %r{a}')
       end
     end
@@ -244,7 +244,7 @@ describe RuboCop::Cop::Style::RegexpLiteral, :config do
       end
 
       it 'cannot auto-correct' do
-        new_source = autocorrect_source(cop, source)
+        new_source = autocorrect_source(source)
         expect(new_source).to eq(source)
       end
     end
@@ -263,7 +263,7 @@ describe RuboCop::Cop::Style::RegexpLiteral, :config do
       end
 
       it 'auto-corrects' do
-        new_source = autocorrect_source(cop, source)
+        new_source = autocorrect_source(source)
         expect(new_source).to eq("foo = %r{\n  foo\n  bar\n}x")
       end
     end
@@ -282,7 +282,7 @@ describe RuboCop::Cop::Style::RegexpLiteral, :config do
       end
 
       it 'cannot auto-correct' do
-        new_source = autocorrect_source(cop, source)
+        new_source = autocorrect_source(source)
         expect(new_source).to eq(source.join("\n"))
       end
     end
@@ -342,7 +342,7 @@ describe RuboCop::Cop::Style::RegexpLiteral, :config do
       end
 
       it 'cannot auto-correct' do
-        new_source = autocorrect_source(cop, source)
+        new_source = autocorrect_source(source)
         expect(new_source).to eq(source)
       end
 
@@ -369,7 +369,7 @@ describe RuboCop::Cop::Style::RegexpLiteral, :config do
       end
 
       it 'auto-corrects' do
-        new_source = autocorrect_source(cop, source)
+        new_source = autocorrect_source(source)
         expect(new_source).to eq("foo = %r{\n  foo\n  bar\n}x")
       end
     end
@@ -388,7 +388,7 @@ describe RuboCop::Cop::Style::RegexpLiteral, :config do
       end
 
       it 'cannot auto-correct' do
-        new_source = autocorrect_source(cop, source)
+        new_source = autocorrect_source(source)
         expect(new_source).to eq(source.join("\n"))
       end
     end
@@ -404,7 +404,7 @@ describe RuboCop::Cop::Style::RegexpLiteral, :config do
       end
 
       it 'auto-corrects' do
-        new_source = autocorrect_source(cop, source)
+        new_source = autocorrect_source(source)
         expect(new_source).to eq('foo = /a/')
       end
     end
@@ -427,7 +427,7 @@ describe RuboCop::Cop::Style::RegexpLiteral, :config do
         end
 
         it 'cannot auto-correct' do
-          new_source = autocorrect_source(cop, source)
+          new_source = autocorrect_source(source)
           expect(new_source).to eq(source)
         end
       end

--- a/spec/rubocop/cop/style/rescue_modifier_spec.rb
+++ b/spec/rubocop/cop/style/rescue_modifier_spec.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 
+require 'pry'
 describe RuboCop::Cop::Style::RescueModifier do
   let(:config) do
     RuboCop::Config.new('Layout/IndentationWidth' => {
@@ -142,7 +143,7 @@ describe RuboCop::Cop::Style::RescueModifier do
 
   context 'autocorrect' do
     it 'corrects basic rescue modifier' do
-      new_source = autocorrect_source(cop, <<-RUBY.strip_indent)
+      new_source = autocorrect_source(<<-RUBY.strip_indent)
         foo rescue bar
       RUBY
 
@@ -156,7 +157,7 @@ describe RuboCop::Cop::Style::RescueModifier do
     end
 
     it 'corrects complex rescue modifier' do
-      new_source = autocorrect_source(cop, <<-RUBY.strip_indent)
+      new_source = autocorrect_source(<<-RUBY.strip_indent)
         foo || bar rescue bar
       RUBY
 
@@ -175,7 +176,7 @@ describe RuboCop::Cop::Style::RescueModifier do
           test rescue modifier_handle
         end
       RUBY
-      new_source = autocorrect_source(cop, source)
+      new_source = autocorrect_source(source)
 
       expect(new_source).to eq(<<-RUBY.strip_indent)
         def foo
@@ -196,7 +197,7 @@ describe RuboCop::Cop::Style::RescueModifier do
           normal_handle
         end
       RUBY
-      new_source = autocorrect_source(cop, source)
+      new_source = autocorrect_source(source)
 
       expect(new_source).to eq(<<-RUBY.strip_indent)
         begin
@@ -212,12 +213,9 @@ describe RuboCop::Cop::Style::RescueModifier do
     end
 
     it 'corrects doubled rescue modifiers' do
-      new_source = autocorrect_source(cop, <<-RUBY.strip_indent)
+      new_source = autocorrect_source_with_loop(<<-RUBY.strip_indent)
         blah rescue 1 rescue 2
       RUBY
-
-      # Another round of autocorrection is needed
-      new_source = autocorrect_source(described_class.new(config), new_source)
 
       expect(new_source).to eq(<<-RUBY.strip_indent)
         begin

--- a/spec/rubocop/cop/style/rescue_modifier_spec.rb
+++ b/spec/rubocop/cop/style/rescue_modifier_spec.rb
@@ -31,7 +31,7 @@ describe RuboCop::Cop::Style::RescueModifier do
   end
 
   it 'handles modifier rescue in normal rescue' do
-    inspect_source(cop, <<-RUBY.strip_indent)
+    inspect_source(<<-RUBY.strip_indent)
       begin
         test rescue modifier_handle
       rescue
@@ -45,7 +45,7 @@ describe RuboCop::Cop::Style::RescueModifier do
   end
 
   it 'handles modifier rescue in a method' do
-    inspect_source(cop, <<-RUBY.strip_indent)
+    inspect_source(<<-RUBY.strip_indent)
       def a_method
         test rescue nil
       end
@@ -102,7 +102,7 @@ describe RuboCop::Cop::Style::RescueModifier do
     end
 
     it 'handles modifier rescue in body of implicit begin' do
-      inspect_source(cop, <<-RUBY.strip_indent)
+      inspect_source(<<-RUBY.strip_indent)
         def some_method
           test rescue modifier_handle
         rescue
@@ -127,7 +127,7 @@ describe RuboCop::Cop::Style::RescueModifier do
     end
 
     it 'handles modifier rescue in body of implicit begin' do
-      inspect_source(cop, <<-RUBY.strip_indent)
+      inspect_source(<<-RUBY.strip_indent)
         def self.some_method
           test rescue modifier_handle
         rescue

--- a/spec/rubocop/cop/style/safe_navigation_spec.rb
+++ b/spec/rubocop/cop/style/safe_navigation_spec.rb
@@ -24,21 +24,21 @@ describe RuboCop::Cop::Style::SafeNavigation, :config do
 
     it 'allows method calls that nil responds to safe guarded by ' \
       'an object check' do
-      inspect_source(cop, 'foo.to_i if foo')
+      inspect_source('foo.to_i if foo')
 
       expect(cop.offenses).to be_empty
     end
 
     it 'allows method calls that do not get called using . safe guarded by ' \
       'an object check' do
-      inspect_source(cop, 'foo + bar if foo')
+      inspect_source('foo + bar if foo')
 
       expect(cop.offenses).to be_empty
     end
 
     it 'allows object checks in the condition of an elsif statement ' \
       'and a method call on that object in the body' do
-      inspect_source(cop, <<-RUBY.strip_indent)
+      inspect_source(<<-RUBY.strip_indent)
         if foo
           something
         elsif bar
@@ -53,58 +53,56 @@ describe RuboCop::Cop::Style::SafeNavigation, :config do
       context 'modifier if' do
         it 'registers an offense for a method call on an accessor ' \
           'safeguarded by a check for the accessed variable' do
-          inspect_source(cop, "#{variable}[1].bar if #{variable}[1]")
+          inspect_source("#{variable}[1].bar if #{variable}[1]")
 
           expect(cop.messages).to eq([message])
         end
 
         it 'registers an offense for a method call safeguarded with a check ' \
           'for the object' do
-          inspect_source(cop, "#{variable}.bar if #{variable}")
+          inspect_source("#{variable}.bar if #{variable}")
 
           expect(cop.messages).to eq([message])
         end
 
         it 'registers an offense for a method call with params safeguarded ' \
           'with a check for the object' do
-          inspect_source(cop, "#{variable}.bar(baz) if #{variable}")
+          inspect_source("#{variable}.bar(baz) if #{variable}")
 
           expect(cop.messages).to eq([message])
         end
 
         it 'registers an offense for a method call with a block safeguarded ' \
           'with a check for the object' do
-          inspect_source(cop, "#{variable}.bar { |e| e.qux } if #{variable}")
+          inspect_source("#{variable}.bar { |e| e.qux } if #{variable}")
 
           expect(cop.messages).to eq([message])
         end
 
         it 'registers an offense for a method call with params and a block ' \
           'safeguarded with a check for the object' do
-          inspect_source(cop,
-                         "#{variable}.bar(baz) { |e| e.qux } if #{variable}")
+          inspect_source("#{variable}.bar(baz) { |e| e.qux } if #{variable}")
 
           expect(cop.messages).to eq([message])
         end
 
         it 'registers an offense for a method call safeguarded with a ' \
           'negative check for the object' do
-          inspect_source(cop, "#{variable}.bar unless !#{variable}")
+          inspect_source("#{variable}.bar unless !#{variable}")
 
           expect(cop.messages).to eq([message])
         end
 
         it 'registers an offense for a method call with params safeguarded ' \
           'with a negative check for the object' do
-          inspect_source(cop, "#{variable}.bar(baz) unless !#{variable}")
+          inspect_source("#{variable}.bar(baz) unless !#{variable}")
 
           expect(cop.messages).to eq([message])
         end
 
         it 'registers an offense for a method call with a block safeguarded ' \
           'with a negative check for the object' do
-          inspect_source(cop,
-                         "#{variable}.bar { |e| e.qux } unless !#{variable}")
+          inspect_source("#{variable}.bar { |e| e.qux } unless !#{variable}")
 
           expect(cop.messages).to eq([message])
         end
@@ -113,21 +111,21 @@ describe RuboCop::Cop::Style::SafeNavigation, :config do
           'safeguarded with a negative check for the object' do
           source = "#{variable}.bar(baz) { |e| e.qux } unless !#{variable}"
 
-          inspect_source(cop, source)
+          inspect_source(source)
 
           expect(cop.messages).to eq([message])
         end
 
         it 'registers an offense for a method call safeguarded with a nil ' \
           'check for the object' do
-          inspect_source(cop, "#{variable}.bar unless #{variable}.nil?")
+          inspect_source("#{variable}.bar unless #{variable}.nil?")
 
           expect(cop.messages).to eq([message])
         end
 
         it 'registers an offense for a method call with params safeguarded ' \
           'with a nil check for the object' do
-          inspect_source(cop, "#{variable}.bar(baz) unless #{variable}.nil?")
+          inspect_source("#{variable}.bar(baz) unless #{variable}.nil?")
 
           expect(cop.messages).to eq([message])
         end
@@ -136,7 +134,7 @@ describe RuboCop::Cop::Style::SafeNavigation, :config do
           'with a nil check for the object' do
           source = "#{variable}.bar { |e| e.qux } unless #{variable}.nil?"
 
-          inspect_source(cop, source)
+          inspect_source(source)
 
           expect(cop.messages).to eq([message])
         end
@@ -145,21 +143,21 @@ describe RuboCop::Cop::Style::SafeNavigation, :config do
           'safeguarded with a nil check for the object' do
           source = "#{variable}.bar(baz) { |e| e.qux } unless #{variable}.nil?"
 
-          inspect_source(cop, source)
+          inspect_source(source)
 
           expect(cop.messages).to eq([message])
         end
 
         it 'registers an offense for a method call safeguarded with a ' \
           'negative nil check for the object' do
-          inspect_source(cop, "#{variable}.bar if !#{variable}.nil?")
+          inspect_source("#{variable}.bar if !#{variable}.nil?")
 
           expect(cop.messages).to eq([message])
         end
 
         it 'registers an offense for a method call with params safeguarded ' \
           'with a negative nil check for the object' do
-          inspect_source(cop, "#{variable}.bar(baz) if !#{variable}.nil?")
+          inspect_source("#{variable}.bar(baz) if !#{variable}.nil?")
 
           expect(cop.messages).to eq([message])
         end
@@ -168,7 +166,7 @@ describe RuboCop::Cop::Style::SafeNavigation, :config do
           'with a negative nil check for the object' do
           source = "#{variable}.bar { |e| e.qux } if !#{variable}.nil?"
 
-          inspect_source(cop, source)
+          inspect_source(source)
 
           expect(cop.messages).to eq([message])
         end
@@ -177,7 +175,7 @@ describe RuboCop::Cop::Style::SafeNavigation, :config do
           'safeguarded with a negative nil check for the object' do
           source = "#{variable}.bar(baz) { |e| e.qux } if !#{variable}.nil?"
 
-          inspect_source(cop, source)
+          inspect_source(source)
 
           expect(cop.messages).to eq([message])
         end
@@ -186,7 +184,7 @@ describe RuboCop::Cop::Style::SafeNavigation, :config do
       context 'if expression' do
         it 'registers an offense for a single method call inside of a check ' \
           'for the object' do
-          inspect_source(cop, <<-RUBY.strip_indent)
+          inspect_source(<<-RUBY.strip_indent)
             if #{variable}
               #{variable}.bar
             end
@@ -197,7 +195,7 @@ describe RuboCop::Cop::Style::SafeNavigation, :config do
 
         it 'registers an offense for a single method call inside of a ' \
           'non-nil check for the object' do
-          inspect_source(cop, <<-RUBY.strip_indent)
+          inspect_source(<<-RUBY.strip_indent)
             if !#{variable}.nil?
               #{variable}.bar
             end
@@ -208,7 +206,7 @@ describe RuboCop::Cop::Style::SafeNavigation, :config do
 
         it 'registers an offense for a single method call inside of an ' \
           'unless nil check for the object' do
-          inspect_source(cop, <<-RUBY.strip_indent)
+          inspect_source(<<-RUBY.strip_indent)
             unless #{variable}.nil?
               #{variable}.bar
             end
@@ -219,7 +217,7 @@ describe RuboCop::Cop::Style::SafeNavigation, :config do
 
         it 'registers an offense for a single method call inside of an ' \
           'unless negative check for the object' do
-          inspect_source(cop, <<-RUBY.strip_indent)
+          inspect_source(<<-RUBY.strip_indent)
             unless !#{variable}
               #{variable}.bar
             end
@@ -230,7 +228,7 @@ describe RuboCop::Cop::Style::SafeNavigation, :config do
 
         it 'accepts a single method call inside of a check for the object ' \
            'with an else' do
-          inspect_source(cop, <<-RUBY.strip_indent)
+          inspect_source(<<-RUBY.strip_indent)
             if #{variable}
               #{variable}.bar
             else
@@ -244,7 +242,7 @@ describe RuboCop::Cop::Style::SafeNavigation, :config do
         context 'ternary expression' do
           it 'accepts ternary expression' do
             source = "!#{variable}.nil? ? #{variable}.bar : something"
-            inspect_source(cop, source)
+            inspect_source(source)
 
             expect(cop.offenses).to be_empty
           end
@@ -257,14 +255,14 @@ describe RuboCop::Cop::Style::SafeNavigation, :config do
 
           it 'registers an offense for a non-nil object check followed by a ' \
             'method call' do
-            inspect_source(cop, "!#{variable}.nil? && #{variable}.bar")
+            inspect_source("!#{variable}.nil? && #{variable}.bar")
 
             expect(cop.messages).to eq([message])
           end
 
           it 'registers an offense for a non-nil object check followed by a ' \
             'method call with params' do
-            inspect_source(cop, "!#{variable}.nil? && #{variable}.bar(baz)")
+            inspect_source("!#{variable}.nil? && #{variable}.bar(baz)")
 
             expect(cop.messages).to eq([message])
           end
@@ -273,7 +271,7 @@ describe RuboCop::Cop::Style::SafeNavigation, :config do
             'method call with a block' do
             source = "!#{variable}.nil? && #{variable}.bar { |e| e.qux }"
 
-            inspect_source(cop, source)
+            inspect_source(source)
 
             expect(cop.messages).to eq([message])
           end
@@ -282,28 +280,28 @@ describe RuboCop::Cop::Style::SafeNavigation, :config do
             'method call with params and a block' do
             source = "!#{variable}.nil? && #{variable}.bar(baz) { |e| e.qux }"
 
-            inspect_source(cop, source)
+            inspect_source(source)
 
             expect(cop.messages).to eq([message])
           end
 
           it 'registers an offense for an object check followed by a ' \
             'method call' do
-            inspect_source(cop, "#{variable} && #{variable}.bar")
+            inspect_source("#{variable} && #{variable}.bar")
 
             expect(cop.messages).to eq([message])
           end
 
           it 'registers an offense for an object check followed by a ' \
             'method call with params' do
-            inspect_source(cop, "#{variable} && #{variable}.bar(baz)")
+            inspect_source("#{variable} && #{variable}.bar(baz)")
 
             expect(cop.messages).to eq([message])
           end
 
           it 'registers an offense for an object check followed by a ' \
             'method call with a block' do
-            inspect_source(cop, "#{variable} && #{variable}.bar { |e| e.qux }")
+            inspect_source("#{variable} && #{variable}.bar { |e| e.qux }")
 
             expect(cop.messages).to eq([message])
           end
@@ -312,14 +310,14 @@ describe RuboCop::Cop::Style::SafeNavigation, :config do
             'method call with params and a block' do
             source = "#{variable} && #{variable}.bar(baz) { |e| e.qux }"
 
-            inspect_source(cop, source)
+            inspect_source(source)
 
             expect(cop.messages).to eq([message])
           end
 
           it 'registers an offense for a check for the object followed by a ' \
             'method call in the condition for an if expression' do
-            inspect_source(cop, <<-RUBY.strip_indent)
+            inspect_source(<<-RUBY.strip_indent)
               if #{variable} && #{variable}.bar
                 something
               end
@@ -332,14 +330,14 @@ describe RuboCop::Cop::Style::SafeNavigation, :config do
         context 'ConvertCodeThatCanStartToReturnNil false' do
           it 'registers an offense for a non-nil object check followed by a ' \
             'method call' do
-            inspect_source(cop, "!#{variable}.nil? && #{variable}.bar")
+            inspect_source("!#{variable}.nil? && #{variable}.bar")
 
             expect(cop.offenses).to be_empty
           end
 
           it 'registers an offense for a non-nil object check followed by a ' \
             'method call with params' do
-            inspect_source(cop, "!#{variable}.nil? && #{variable}.bar(baz)")
+            inspect_source("!#{variable}.nil? && #{variable}.bar(baz)")
 
             expect(cop.offenses).to be_empty
           end
@@ -348,7 +346,7 @@ describe RuboCop::Cop::Style::SafeNavigation, :config do
             'method call with a block' do
             source = "!#{variable}.nil? && #{variable}.bar { |e| e.qux }"
 
-            inspect_source(cop, source)
+            inspect_source(source)
 
             expect(cop.offenses).to be_empty
           end
@@ -357,28 +355,28 @@ describe RuboCop::Cop::Style::SafeNavigation, :config do
             'method call with params and a block' do
             source = "!#{variable}.nil? && #{variable}.bar(baz) { |e| e.qux }"
 
-            inspect_source(cop, source)
+            inspect_source(source)
 
             expect(cop.offenses).to be_empty
           end
 
           it 'registers an offense for an object check followed by a ' \
             'method call' do
-            inspect_source(cop, "#{variable} && #{variable}.bar")
+            inspect_source("#{variable} && #{variable}.bar")
 
             expect(cop.offenses).to be_empty
           end
 
           it 'registers an offense for an object check followed by a ' \
             'method call with params' do
-            inspect_source(cop, "#{variable} && #{variable}.bar(baz)")
+            inspect_source("#{variable} && #{variable}.bar(baz)")
 
             expect(cop.offenses).to be_empty
           end
 
           it 'registers an offense for an object check followed by a ' \
             'method call with a block' do
-            inspect_source(cop, "#{variable} && #{variable}.bar { |e| e.qux }")
+            inspect_source("#{variable} && #{variable}.bar { |e| e.qux }")
 
             expect(cop.offenses).to be_empty
           end
@@ -387,14 +385,14 @@ describe RuboCop::Cop::Style::SafeNavigation, :config do
             'method call with params and a block' do
             source = "#{variable} && #{variable}.bar(baz) { |e| e.qux }"
 
-            inspect_source(cop, source)
+            inspect_source(source)
 
             expect(cop.offenses).to be_empty
           end
 
           it 'registers an offense for a check for the object followed by a ' \
             'method call in the condition for an if expression' do
-            inspect_source(cop, <<-RUBY.strip_indent)
+            inspect_source(<<-RUBY.strip_indent)
               if #{variable} && #{variable}.bar
                 something
               end
@@ -405,13 +403,13 @@ describe RuboCop::Cop::Style::SafeNavigation, :config do
         end
 
         it 'allows a nil object check followed by a method call' do
-          inspect_source(cop, "#{variable}.nil? || #{variable}.bar")
+          inspect_source("#{variable}.nil? || #{variable}.bar")
 
           expect(cop.offenses).to be_empty
         end
 
         it 'allows a nil object check followed by a method call with params' do
-          inspect_source(cop, "#{variable}.nil? || #{variable}.bar(baz)")
+          inspect_source("#{variable}.nil? || #{variable}.bar(baz)")
 
           expect(cop.offenses).to be_empty
         end
@@ -419,7 +417,7 @@ describe RuboCop::Cop::Style::SafeNavigation, :config do
         it 'allows a nil object check followed by a method call with a block' do
           source = "#{variable}.nil? || #{variable}.bar { |e| e.qux }"
 
-          inspect_source(cop, source)
+          inspect_source(source)
 
           expect(cop.offenses).to be_empty
         end
@@ -428,25 +426,25 @@ describe RuboCop::Cop::Style::SafeNavigation, :config do
           'and a block' do
           source = "#{variable}.nil? || #{variable}.bar(baz) { |e| e.qux }"
 
-          inspect_source(cop, source)
+          inspect_source(source)
 
           expect(cop.offenses).to be_empty
         end
 
         it 'allows a non object check followed by a method call' do
-          inspect_source(cop, "!#{variable} || #{variable}.bar")
+          inspect_source("!#{variable} || #{variable}.bar")
 
           expect(cop.offenses).to be_empty
         end
 
         it 'allows a non object check followed by a method call with params' do
-          inspect_source(cop, "!#{variable} || #{variable}.bar(baz)")
+          inspect_source("!#{variable} || #{variable}.bar(baz)")
 
           expect(cop.offenses).to be_empty
         end
 
         it 'allows a non object check followed by a method call with a block' do
-          inspect_source(cop, "!#{variable} || #{variable}.bar { |e| e.qux }")
+          inspect_source("!#{variable} || #{variable}.bar { |e| e.qux }")
 
           expect(cop.offenses).to be_empty
         end
@@ -455,7 +453,7 @@ describe RuboCop::Cop::Style::SafeNavigation, :config do
           'and a block' do
           source = "!#{variable} || #{variable}.bar(baz) { |e| e.qux }"
 
-          inspect_source(cop, source)
+          inspect_source(source)
 
           expect(cop.offenses).to be_empty
         end
@@ -476,28 +474,28 @@ describe RuboCop::Cop::Style::SafeNavigation, :config do
 
       it 'allows method calls safeguarded by a respond_to check to a ' \
         'different method' do
-        inspect_source(cop, 'foo.bar if foo.respond_to?(:foobar)')
+        inspect_source('foo.bar if foo.respond_to?(:foobar)')
 
         expect(cop.offenses).to be_empty
       end
 
       it 'allows method calls safeguarded by a respond_to check on a' \
         'different variable but the same method' do
-        inspect_source(cop, 'foo.bar if baz.respond_to?(:bar)')
+        inspect_source('foo.bar if baz.respond_to?(:bar)')
 
         expect(cop.offenses).to be_empty
       end
 
       it 'allows method calls safeguarded by a respond_to check on a' \
         'different variable and method' do
-        inspect_source(cop, 'foo.bar if baz.respond_to?(:foo)')
+        inspect_source('foo.bar if baz.respond_to?(:foo)')
 
         expect(cop.offenses).to be_empty
       end
 
       it 'allows enumerable accessor method calls safeguarded by ' \
         'a respond_to check' do
-        inspect_source(cop, 'foo[0] if foo.respond_to?(:[])')
+        inspect_source('foo[0] if foo.respond_to?(:[])')
 
         expect(cop.offenses).to be_empty
       end

--- a/spec/rubocop/cop/style/safe_navigation_spec.rb
+++ b/spec/rubocop/cop/style/safe_navigation_spec.rb
@@ -507,7 +507,7 @@ describe RuboCop::Cop::Style::SafeNavigation, :config do
           it 'corrects a method call safeguarded with a check for the object' do
             source = "#{variable}.bar if #{variable}"
 
-            new_source = autocorrect_source(cop, source)
+            new_source = autocorrect_source(source)
 
             expect(new_source).to eq("#{variable}&.bar")
           end
@@ -516,7 +516,7 @@ describe RuboCop::Cop::Style::SafeNavigation, :config do
             'for the object' do
             source = "#{variable}.bar(baz) if #{variable}"
 
-            new_source = autocorrect_source(cop, source)
+            new_source = autocorrect_source(source)
 
             expect(new_source).to eq("#{variable}&.bar(baz)")
           end
@@ -525,7 +525,7 @@ describe RuboCop::Cop::Style::SafeNavigation, :config do
             'for the object' do
             source = "#{variable}.bar { |e| e.qux } if #{variable}"
 
-            new_source = autocorrect_source(cop, source)
+            new_source = autocorrect_source(source)
 
             expect(new_source).to eq("#{variable}&.bar { |e| e.qux }")
           end
@@ -534,7 +534,7 @@ describe RuboCop::Cop::Style::SafeNavigation, :config do
             'with a check for the object' do
             source = "#{variable}.bar(baz) { |e| e.qux } if #{variable}"
 
-            new_source = autocorrect_source(cop, source)
+            new_source = autocorrect_source(source)
 
             expect(new_source).to eq("#{variable}&.bar(baz) { |e| e.qux }")
           end
@@ -543,7 +543,7 @@ describe RuboCop::Cop::Style::SafeNavigation, :config do
             'the object' do
             source = "#{variable}.bar unless !#{variable}"
 
-            new_source = autocorrect_source(cop, source)
+            new_source = autocorrect_source(source)
 
             expect(new_source).to eq("#{variable}&.bar")
           end
@@ -552,7 +552,7 @@ describe RuboCop::Cop::Style::SafeNavigation, :config do
             'negative check for the object' do
             source = "#{variable}.bar(baz) unless !#{variable}"
 
-            new_source = autocorrect_source(cop, source)
+            new_source = autocorrect_source(source)
 
             expect(new_source).to eq("#{variable}&.bar(baz)")
           end
@@ -561,7 +561,7 @@ describe RuboCop::Cop::Style::SafeNavigation, :config do
             'negative check for the object' do
             source = "#{variable}.bar { |e| e.qux } unless !#{variable}"
 
-            new_source = autocorrect_source(cop, source)
+            new_source = autocorrect_source(source)
 
             expect(new_source).to eq("#{variable}&.bar { |e| e.qux }")
           end
@@ -570,7 +570,7 @@ describe RuboCop::Cop::Style::SafeNavigation, :config do
             'with a negative check for the object' do
             source = "#{variable}.bar(baz) { |e| e.qux } unless !#{variable}"
 
-            new_source = autocorrect_source(cop, source)
+            new_source = autocorrect_source(source)
 
             expect(new_source).to eq("#{variable}&.bar(baz) { |e| e.qux }")
           end
@@ -579,7 +579,7 @@ describe RuboCop::Cop::Style::SafeNavigation, :config do
             'object' do
             source = "#{variable}.bar unless #{variable}.nil?"
 
-            new_source = autocorrect_source(cop, source)
+            new_source = autocorrect_source(source)
 
             expect(new_source).to eq("#{variable}&.bar")
           end
@@ -588,7 +588,7 @@ describe RuboCop::Cop::Style::SafeNavigation, :config do
             'check for the object' do
             source = "#{variable}.bar(baz) unless #{variable}.nil?"
 
-            new_source = autocorrect_source(cop, source)
+            new_source = autocorrect_source(source)
 
             expect(new_source).to eq("#{variable}&.bar(baz)")
           end
@@ -597,7 +597,7 @@ describe RuboCop::Cop::Style::SafeNavigation, :config do
             'check for the object' do
             source = "#{variable}.bar { |e| e.qux } unless #{variable}.nil?"
 
-            new_source = autocorrect_source(cop, source)
+            new_source = autocorrect_source(source)
 
             expect(new_source).to eq("#{variable}&.bar { |e| e.qux }")
           end
@@ -607,7 +607,7 @@ describe RuboCop::Cop::Style::SafeNavigation, :config do
             source =
               "#{variable}.bar(baz) { |e| e.qux } unless #{variable}.nil?"
 
-            new_source = autocorrect_source(cop, source)
+            new_source = autocorrect_source(source)
 
             expect(new_source).to eq("#{variable}&.bar(baz) { |e| e.qux }")
           end
@@ -616,7 +616,7 @@ describe RuboCop::Cop::Style::SafeNavigation, :config do
             'for the object' do
             source = "#{variable}.bar if !#{variable}.nil?"
 
-            new_source = autocorrect_source(cop, source)
+            new_source = autocorrect_source(source)
 
             expect(new_source).to eq("#{variable}&.bar")
           end
@@ -625,7 +625,7 @@ describe RuboCop::Cop::Style::SafeNavigation, :config do
             'negative nil check for the object' do
             source = "#{variable}.bar(baz) if !#{variable}.nil?"
 
-            new_source = autocorrect_source(cop, source)
+            new_source = autocorrect_source(source)
 
             expect(new_source).to eq("#{variable}&.bar(baz)")
           end
@@ -634,7 +634,7 @@ describe RuboCop::Cop::Style::SafeNavigation, :config do
             'negative nil check for the object' do
             source = "#{variable}.bar { |e| e.qux } if !#{variable}.nil?"
 
-            new_source = autocorrect_source(cop, source)
+            new_source = autocorrect_source(source)
 
             expect(new_source).to eq("#{variable}&.bar { |e| e.qux }")
           end
@@ -643,7 +643,7 @@ describe RuboCop::Cop::Style::SafeNavigation, :config do
             'with a negative nil check for the object' do
             source = "#{variable}.bar(baz) { |e| e.qux } if !#{variable}.nil?"
 
-            new_source = autocorrect_source(cop, source)
+            new_source = autocorrect_source(source)
 
             expect(new_source).to eq("#{variable}&.bar(baz) { |e| e.qux }")
           end
@@ -652,7 +652,7 @@ describe RuboCop::Cop::Style::SafeNavigation, :config do
             'for the accessed variable' do
             source = "#{variable}[1].bar if #{variable}[1]"
 
-            new_source = autocorrect_source(cop, source)
+            new_source = autocorrect_source(source)
 
             expect(new_source).to eq("#{variable}[1]&.bar")
           end
@@ -660,7 +660,7 @@ describe RuboCop::Cop::Style::SafeNavigation, :config do
 
         context 'if expression' do
           it 'corrects a single method call inside of a check for the object' do
-            new_source = autocorrect_source(cop, <<-RUBY.strip_indent)
+            new_source = autocorrect_source(<<-RUBY.strip_indent)
               if #{variable}
                 #{variable}.bar
               end
@@ -671,7 +671,7 @@ describe RuboCop::Cop::Style::SafeNavigation, :config do
 
           it 'corrects a single method call with params inside of a check ' \
             'for the object' do
-            new_source = autocorrect_source(cop, <<-RUBY.strip_indent)
+            new_source = autocorrect_source(<<-RUBY.strip_indent)
               if #{variable}
                 #{variable}.bar(baz)
               end
@@ -687,7 +687,7 @@ describe RuboCop::Cop::Style::SafeNavigation, :config do
                 #{variable}.bar { |e| e.qux }
               end
             RUBY
-            new_source = autocorrect_source(cop, source)
+            new_source = autocorrect_source(source)
 
             expect(new_source).to eq("#{variable}&.bar { |e| e.qux }\n")
           end
@@ -699,14 +699,14 @@ describe RuboCop::Cop::Style::SafeNavigation, :config do
                 #{variable}.bar(baz) { |e| e.qux }
               end
             RUBY
-            new_source = autocorrect_source(cop, source)
+            new_source = autocorrect_source(source)
 
             expect(new_source).to eq("#{variable}&.bar(baz) { |e| e.qux }\n")
           end
 
           it 'corrects a single method call inside of a non-nil check for ' \
             'the object' do
-            new_source = autocorrect_source(cop, <<-RUBY.strip_indent)
+            new_source = autocorrect_source(<<-RUBY.strip_indent)
               if !#{variable}.nil?
                 #{variable}.bar
               end
@@ -717,7 +717,7 @@ describe RuboCop::Cop::Style::SafeNavigation, :config do
 
           it 'corrects a single method call with params inside of a non-nil ' \
             'check for the object' do
-            new_source = autocorrect_source(cop, <<-RUBY.strip_indent)
+            new_source = autocorrect_source(<<-RUBY.strip_indent)
               if !#{variable}.nil?
                 #{variable}.bar(baz)
               end
@@ -733,7 +733,7 @@ describe RuboCop::Cop::Style::SafeNavigation, :config do
                 #{variable}.bar { |e| e.qux }
               end
             RUBY
-            new_source = autocorrect_source(cop, source)
+            new_source = autocorrect_source(source)
 
             expect(new_source).to eq("#{variable}&.bar { |e| e.qux }\n")
           end
@@ -745,14 +745,14 @@ describe RuboCop::Cop::Style::SafeNavigation, :config do
                 #{variable}.bar(baz) { |e| e.qux }
               end
             RUBY
-            new_source = autocorrect_source(cop, source)
+            new_source = autocorrect_source(source)
 
             expect(new_source).to eq("#{variable}&.bar(baz) { |e| e.qux }\n")
           end
 
           it 'corrects a single method call inside of an unless nil check ' \
             'for the object' do
-            new_source = autocorrect_source(cop, <<-RUBY.strip_indent)
+            new_source = autocorrect_source(<<-RUBY.strip_indent)
               unless #{variable}.nil?
                 #{variable}.bar
               end
@@ -763,7 +763,7 @@ describe RuboCop::Cop::Style::SafeNavigation, :config do
 
           it 'corrects a single method call with params inside of an unless ' \
             'nil check for the object' do
-            new_source = autocorrect_source(cop, <<-RUBY.strip_indent)
+            new_source = autocorrect_source(<<-RUBY.strip_indent)
               unless #{variable}.nil?
                 #{variable}.bar(baz)
               end
@@ -779,7 +779,7 @@ describe RuboCop::Cop::Style::SafeNavigation, :config do
                 #{variable}.bar { |e| e.qux }
               end
             RUBY
-            new_source = autocorrect_source(cop, source)
+            new_source = autocorrect_source(source)
 
             expect(new_source).to eq("#{variable}&.bar { |e| e.qux }\n")
           end
@@ -791,14 +791,14 @@ describe RuboCop::Cop::Style::SafeNavigation, :config do
                 #{variable}.bar(baz) { |e| e.qux }
               end
             RUBY
-            new_source = autocorrect_source(cop, source)
+            new_source = autocorrect_source(source)
 
             expect(new_source).to eq("#{variable}&.bar(baz) { |e| e.qux }\n")
           end
 
           it 'corrects a single method call inside of an unless negative ' \
             'check for the object' do
-            new_source = autocorrect_source(cop, <<-RUBY.strip_indent)
+            new_source = autocorrect_source(<<-RUBY.strip_indent)
               unless !#{variable}
                 #{variable}.bar
               end
@@ -809,7 +809,7 @@ describe RuboCop::Cop::Style::SafeNavigation, :config do
 
           it 'corrects a single method call with params inside of an unless ' \
             'negative check for the object' do
-            new_source = autocorrect_source(cop, <<-RUBY.strip_indent)
+            new_source = autocorrect_source(<<-RUBY.strip_indent)
               unless !#{variable}
                 #{variable}.bar(baz)
               end
@@ -825,7 +825,7 @@ describe RuboCop::Cop::Style::SafeNavigation, :config do
                 #{variable}.bar { |e| e.qux }
               end
             RUBY
-            new_source = autocorrect_source(cop, source)
+            new_source = autocorrect_source(source)
 
             expect(new_source).to eq("#{variable}&.bar { |e| e.qux }\n")
           end
@@ -837,7 +837,7 @@ describe RuboCop::Cop::Style::SafeNavigation, :config do
                 #{variable}.bar(baz) { |e| e.qux }
               end
             RUBY
-            new_source = autocorrect_source(cop, source)
+            new_source = autocorrect_source(source)
 
             expect(new_source).to eq("#{variable}&.bar(baz) { |e| e.qux }\n")
           end
@@ -852,7 +852,7 @@ describe RuboCop::Cop::Style::SafeNavigation, :config do
             it 'corrects an object check followed by a method call' do
               source = "#{variable} && #{variable}.bar"
 
-              new_source = autocorrect_source(cop, source)
+              new_source = autocorrect_source(source)
 
               expect(new_source).to eq("#{variable}&.bar")
             end
@@ -861,7 +861,7 @@ describe RuboCop::Cop::Style::SafeNavigation, :config do
               'with params' do
               source = "#{variable} && #{variable}.bar(baz)"
 
-              new_source = autocorrect_source(cop, source)
+              new_source = autocorrect_source(source)
 
               expect(new_source).to eq("#{variable}&.bar(baz)")
             end
@@ -870,7 +870,7 @@ describe RuboCop::Cop::Style::SafeNavigation, :config do
               'a block' do
               source = "#{variable} && #{variable}.bar { |e| e.qux }"
 
-              new_source = autocorrect_source(cop, source)
+              new_source = autocorrect_source(source)
 
               expect(new_source).to eq("#{variable}&.bar { |e| e.qux }")
             end
@@ -879,7 +879,7 @@ describe RuboCop::Cop::Style::SafeNavigation, :config do
               'params and a block' do
               source = "#{variable} && #{variable}.bar(baz) { |e| e.qux }"
 
-              new_source = autocorrect_source(cop, source)
+              new_source = autocorrect_source(source)
 
               expect(new_source).to eq("#{variable}&.bar(baz) { |e| e.qux }")
             end
@@ -887,7 +887,7 @@ describe RuboCop::Cop::Style::SafeNavigation, :config do
             it 'corrects a non-nil object check followed by a method call' do
               source = "!#{variable}.nil? && #{variable}.bar"
 
-              new_source = autocorrect_source(cop, source)
+              new_source = autocorrect_source(source)
 
               expect(new_source).to eq("#{variable}&.bar")
             end
@@ -896,7 +896,7 @@ describe RuboCop::Cop::Style::SafeNavigation, :config do
               'with params' do
               source = "!#{variable}.nil? && #{variable}.bar(baz)"
 
-              new_source = autocorrect_source(cop, source)
+              new_source = autocorrect_source(source)
 
               expect(new_source).to eq("#{variable}&.bar(baz)")
             end
@@ -905,7 +905,7 @@ describe RuboCop::Cop::Style::SafeNavigation, :config do
               'with a block' do
               source = "!#{variable}.nil? && #{variable}.bar { |e| e.qux }"
 
-              new_source = autocorrect_source(cop, source)
+              new_source = autocorrect_source(source)
 
               expect(new_source).to eq("#{variable}&.bar { |e| e.qux }")
             end
@@ -914,7 +914,7 @@ describe RuboCop::Cop::Style::SafeNavigation, :config do
               'with params and a block' do
               source = "!#{variable}.nil? && #{variable}.bar(baz) { |e| e.qux }"
 
-              new_source = autocorrect_source(cop, source)
+              new_source = autocorrect_source(source)
 
               expect(new_source).to eq("#{variable}&.bar(baz) { |e| e.qux }")
             end
@@ -923,7 +923,7 @@ describe RuboCop::Cop::Style::SafeNavigation, :config do
               'another check' do
               source = "#{variable} && #{variable}.bar && something"
 
-              new_source = autocorrect_source(cop, source)
+              new_source = autocorrect_source(source)
 
               expect(new_source).to eq("#{variable}&.bar && something")
             end

--- a/spec/rubocop/cop/style/self_assignment_spec.rb
+++ b/spec/rubocop/cop/style/self_assignment_spec.rb
@@ -17,7 +17,7 @@ describe RuboCop::Cop::Style::SelfAssignment do
     end
 
     it "auto-corrects a non-shorthand assignment #{op} and #{var}" do
-      new_source = autocorrect_source(cop, "#{var} = #{var} #{op} y")
+      new_source = autocorrect_source("#{var} = #{var} #{op} y")
       expect(new_source).to eq("#{var} #{op}= y")
     end
   end
@@ -36,7 +36,7 @@ describe RuboCop::Cop::Style::SelfAssignment do
     end
 
     it "auto-corrects a non-shorthand assignment #{op} and #{var}" do
-      new_source = autocorrect_source(cop, "#{var} = #{var} #{op} y")
+      new_source = autocorrect_source("#{var} = #{var} #{op} y")
       expect(new_source).to eq("#{var} #{op}= y")
     end
   end

--- a/spec/rubocop/cop/style/self_assignment_spec.rb
+++ b/spec/rubocop/cop/style/self_assignment_spec.rb
@@ -5,16 +5,14 @@ describe RuboCop::Cop::Style::SelfAssignment do
 
   %i[+ - * ** / | &].product(['x', '@x', '@@x']).each do |op, var|
     it "registers an offense for non-shorthand assignment #{op} and #{var}" do
-      inspect_source(cop,
-                     "#{var} = #{var} #{op} y")
+      inspect_source("#{var} = #{var} #{op} y")
       expect(cop.offenses.size).to eq(1)
       expect(cop.messages)
         .to eq(["Use self-assignment shorthand `#{op}=`."])
     end
 
     it "accepts shorthand assignment for #{op} and #{var}" do
-      inspect_source(cop,
-                     "#{var} #{op}= y")
+      inspect_source("#{var} #{op}= y")
       expect(cop.offenses).to be_empty
     end
 
@@ -26,16 +24,14 @@ describe RuboCop::Cop::Style::SelfAssignment do
 
   ['||', '&&'].product(['x', '@x', '@@x']).each do |op, var|
     it "registers an offense for non-shorthand assignment #{op} and #{var}" do
-      inspect_source(cop,
-                     "#{var} = #{var} #{op} y")
+      inspect_source("#{var} = #{var} #{op} y")
       expect(cop.offenses.size).to eq(1)
       expect(cop.messages)
         .to eq(["Use self-assignment shorthand `#{op}=`."])
     end
 
     it "accepts shorthand assignment for #{op} and #{var}" do
-      inspect_source(cop,
-                     "#{var} #{op}= y")
+      inspect_source("#{var} #{op}= y")
       expect(cop.offenses).to be_empty
     end
 

--- a/spec/rubocop/cop/style/semicolon_spec.rb
+++ b/spec/rubocop/cop/style/semicolon_spec.rb
@@ -87,7 +87,7 @@ describe RuboCop::Cop::Style::Semicolon, :config do
 
   it 'auto-corrects semicolons when syntactically possible' do
     corrected =
-      autocorrect_source(cop, <<-RUBY.strip_indent)
+      autocorrect_source(<<-RUBY.strip_indent)
         module Foo; end;
         puts "this is a test";
         puts "this is a test"; puts "So is this"

--- a/spec/rubocop/cop/style/signal_exception_spec.rb
+++ b/spec/rubocop/cop/style/signal_exception_spec.rb
@@ -171,7 +171,7 @@ describe RuboCop::Cop::Style::SignalException, :config do
     end
 
     it 'auto-corrects raise to fail when appropriate' do
-      new_source = autocorrect_source(cop, <<-RUBY.strip_indent)
+      new_source = autocorrect_source(<<-RUBY.strip_indent)
         begin
           raise
         rescue Exception
@@ -188,7 +188,7 @@ describe RuboCop::Cop::Style::SignalException, :config do
     end
 
     it 'auto-corrects fail to raise when appropriate' do
-      new_source = autocorrect_source(cop, <<-RUBY.strip_indent)
+      new_source = autocorrect_source(<<-RUBY.strip_indent)
         begin
           fail
         rescue Exception
@@ -277,7 +277,7 @@ describe RuboCop::Cop::Style::SignalException, :config do
     end
 
     it 'auto-corrects fail to raise always' do
-      new_source = autocorrect_source(cop, <<-RUBY.strip_indent)
+      new_source = autocorrect_source(<<-RUBY.strip_indent)
         begin
           fail
         rescue Exception
@@ -342,7 +342,7 @@ describe RuboCop::Cop::Style::SignalException, :config do
     end
 
     it 'auto-corrects raise to fail always' do
-      new_source = autocorrect_source(cop, <<-RUBY.strip_indent)
+      new_source = autocorrect_source(<<-RUBY.strip_indent)
         begin
           raise
         rescue Exception

--- a/spec/rubocop/cop/style/signal_exception_spec.rb
+++ b/spec/rubocop/cop/style/signal_exception_spec.rb
@@ -117,7 +117,7 @@ describe RuboCop::Cop::Style::SignalException, :config do
 
     it 'registers an offense for `raise` and `fail` with `Kernel` as ' \
        'explicit receiver' do
-      inspect_source(cop, <<-RUBY.strip_indent)
+      inspect_source(<<-RUBY.strip_indent)
         def test
           Kernel.raise
         rescue Exception
@@ -142,7 +142,7 @@ describe RuboCop::Cop::Style::SignalException, :config do
     end
 
     it 'registers one offense for each raise' do
-      inspect_source(cop, <<-RUBY.strip_indent)
+      inspect_source(<<-RUBY.strip_indent)
         cop.stub(:on_def) { raise RuntimeError }
         cop.stub(:on_def) { raise RuntimeError }
       RUBY
@@ -152,7 +152,7 @@ describe RuboCop::Cop::Style::SignalException, :config do
     end
 
     it 'is not confused by nested begin/rescue' do
-      inspect_source(cop, <<-RUBY.strip_indent)
+      inspect_source(<<-RUBY.strip_indent)
         begin
           raise
           begin

--- a/spec/rubocop/cop/style/single_line_block_params_spec.rb
+++ b/spec/rubocop/cop/style/single_line_block_params_spec.rb
@@ -9,7 +9,7 @@ describe RuboCop::Cop::Style::SingleLineBlockParams, :config do
   end
 
   it 'finds wrong argument names in calls with different syntax' do
-    inspect_source(cop, <<-RUBY.strip_indent)
+    inspect_source(<<-RUBY.strip_indent)
       def m
         [0, 1].reduce { |c, d| c + d }
         [0, 1].reduce{ |c, d| c + d }

--- a/spec/rubocop/cop/style/single_line_methods_spec.rb
+++ b/spec/rubocop/cop/style/single_line_methods_spec.rb
@@ -34,7 +34,7 @@ describe RuboCop::Cop::Style::SingleLineMethods do
     end
 
     it 'auto-corrects an empty method' do
-      corrected = autocorrect_source(cop, 'def x; end')
+      corrected = autocorrect_source('def x; end')
       expect(corrected).to eq(['def x; ',
                                'end'].join("\n"))
     end
@@ -68,8 +68,7 @@ describe RuboCop::Cop::Style::SingleLineMethods do
   end
 
   it 'auto-corrects def with semicolon after method name' do
-    corrected = autocorrect_source(cop,
-                                   ['  def some_method; body end # Cmnt'])
+    corrected = autocorrect_source(['  def some_method; body end # Cmnt'])
     expect(corrected).to eq ['  # Cmnt',
                              '  def some_method; ',
                              '    body ',
@@ -77,28 +76,28 @@ describe RuboCop::Cop::Style::SingleLineMethods do
   end
 
   it 'auto-corrects defs with parentheses after method name' do
-    corrected = autocorrect_source(cop, ['  def self.some_method() body end'])
+    corrected = autocorrect_source(['  def self.some_method() body end'])
     expect(corrected).to eq ['  def self.some_method() ',
                              '    body ',
                              '  end'].join("\n")
   end
 
   it 'auto-corrects def with argument in parentheses' do
-    corrected = autocorrect_source(cop, ['  def some_method(arg) body end'])
+    corrected = autocorrect_source(['  def some_method(arg) body end'])
     expect(corrected).to eq ['  def some_method(arg) ',
                              '    body ',
                              '  end'].join("\n")
   end
 
   it 'auto-corrects def with argument and no parentheses' do
-    corrected = autocorrect_source(cop, ['  def some_method arg; body end'])
+    corrected = autocorrect_source(['  def some_method arg; body end'])
     expect(corrected).to eq ['  def some_method arg; ',
                              '    body ',
                              '  end'].join("\n")
   end
 
   it 'auto-corrects def with semicolon before end' do
-    corrected = autocorrect_source(cop, ['  def some_method; b1; b2; end'])
+    corrected = autocorrect_source(['  def some_method; b1; b2; end'])
     expect(corrected).to eq ['  def some_method; ',
                              '    b1; ',
                              '    b2; ',

--- a/spec/rubocop/cop/style/special_global_vars_spec.rb
+++ b/spec/rubocop/cop/style/special_global_vars_spec.rb
@@ -66,14 +66,14 @@ describe RuboCop::Cop::Style::SpecialGlobalVars, :config do
     end
 
     it 'generates correct auto-config when Perl variable names are used' do
-      inspect_source(cop, '$0')
+      inspect_source('$0')
       expect(cop.config_to_allow_offenses).to eq(
         'EnforcedStyle' => 'use_perl_names'
       )
     end
 
     it 'generates correct auto-config when mixed styles are used' do
-      inspect_source(cop, '$!; $ERROR_INFO')
+      inspect_source('$!; $ERROR_INFO')
       expect(cop.config_to_allow_offenses).to eq('Enabled' => false)
     end
   end

--- a/spec/rubocop/cop/style/special_global_vars_spec.rb
+++ b/spec/rubocop/cop/style/special_global_vars_spec.rb
@@ -46,22 +46,22 @@ describe RuboCop::Cop::Style::SpecialGlobalVars, :config do
     end
 
     it 'auto-corrects $: to $LOAD_PATH' do
-      new_source = autocorrect_source(cop, '$:')
+      new_source = autocorrect_source('$:')
       expect(new_source).to eq('$LOAD_PATH')
     end
 
     it 'auto-corrects $/ to $INPUT_RECORD_SEPARATOR' do
-      new_source = autocorrect_source(cop, '$/')
+      new_source = autocorrect_source('$/')
       expect(new_source).to eq('$INPUT_RECORD_SEPARATOR')
     end
 
     it 'auto-corrects #$: to #{$LOAD_PATH}' do
-      new_source = autocorrect_source(cop, '"#$:"')
+      new_source = autocorrect_source('"#$:"')
       expect(new_source).to eq('"#{$LOAD_PATH}"')
     end
 
     it 'auto-corrects #{$!} to #{$ERROR_INFO}' do
-      new_source = autocorrect_source(cop, '"#{$!}"')
+      new_source = autocorrect_source('"#{$!}"')
       expect(new_source).to eq('"#{$ERROR_INFO}"')
     end
 
@@ -121,17 +121,17 @@ describe RuboCop::Cop::Style::SpecialGlobalVars, :config do
     end
 
     it 'auto-corrects $LOAD_PATH to $:' do
-      new_source = autocorrect_source(cop, '$LOAD_PATH')
+      new_source = autocorrect_source('$LOAD_PATH')
       expect(new_source).to eq('$:')
     end
 
     it 'auto-corrects $INPUT_RECORD_SEPARATOR to $/' do
-      new_source = autocorrect_source(cop, '$INPUT_RECORD_SEPARATOR')
+      new_source = autocorrect_source('$INPUT_RECORD_SEPARATOR')
       expect(new_source).to eq('$/')
     end
 
     it 'auto-corrects #{$LOAD_PATH} to #$:' do
-      new_source = autocorrect_source(cop, '"#{$LOAD_PATH}"')
+      new_source = autocorrect_source('"#{$LOAD_PATH}"')
       expect(new_source).to eq('"#$:"')
     end
   end

--- a/spec/rubocop/cop/style/stabby_lambda_parentheses_spec.rb
+++ b/spec/rubocop/cop/style/stabby_lambda_parentheses_spec.rb
@@ -34,7 +34,7 @@ describe RuboCop::Cop::Style::StabbyLambdaParentheses, :config do
     end
 
     it 'autocorrects when a stabby lambda has no parentheses' do
-      corrected = autocorrect_source(cop, ['->a,b,c { a + b + c }'])
+      corrected = autocorrect_source(['->a,b,c { a + b + c }'])
       expect(corrected).to eq '->(a,b,c) { a + b + c }'
     end
   end
@@ -52,7 +52,7 @@ describe RuboCop::Cop::Style::StabbyLambdaParentheses, :config do
     end
 
     it 'autocorrects when a stabby lambda does not parentheses' do
-      corrected = autocorrect_source(cop, ['->(a,b,c) { a + b + c }'])
+      corrected = autocorrect_source(['->(a,b,c) { a + b + c }'])
       expect(corrected).to eq '->a,b,c { a + b + c }'
     end
   end

--- a/spec/rubocop/cop/style/string_literals_in_interpolation_spec.rb
+++ b/spec/rubocop/cop/style/string_literals_in_interpolation_spec.rb
@@ -8,7 +8,7 @@ describe RuboCop::Cop::Style::StringLiteralsInInterpolation, :config do
 
     it 'registers an offense for double quotes within embedded expression' do
       src = '"#{"A"}"'
-      inspect_source(cop, src)
+      inspect_source(src)
       expect(cop.messages)
         .to eq(['Prefer single-quoted strings inside interpolations.'])
     end
@@ -18,7 +18,7 @@ describe RuboCop::Cop::Style::StringLiteralsInInterpolation, :config do
       src = ['<<RUBY',
              '#{"A"}',
              'RUBY']
-      inspect_source(cop, src)
+      inspect_source(src)
       expect(cop.messages)
         .to eq(['Prefer single-quoted strings inside interpolations.'])
     end
@@ -66,7 +66,7 @@ describe RuboCop::Cop::Style::StringLiteralsInInterpolation, :config do
 
     it 'registers an offense for single quotes within embedded expression' do
       src = %q("#{'A'}")
-      inspect_source(cop, src)
+      inspect_source(src)
       expect(cop.messages)
         .to eq(['Prefer double-quoted strings inside interpolations.'])
     end
@@ -76,7 +76,7 @@ describe RuboCop::Cop::Style::StringLiteralsInInterpolation, :config do
       src = ['<<RUBY',
              '#{\'A\'}',
              'RUBY']
-      inspect_source(cop, src)
+      inspect_source(src)
       expect(cop.messages)
         .to eq(['Prefer double-quoted strings inside interpolations.'])
     end
@@ -86,7 +86,7 @@ describe RuboCop::Cop::Style::StringLiteralsInInterpolation, :config do
     let(:cop_config) { { 'EnforcedStyle' => 'other' } }
 
     it 'fails' do
-      expect { inspect_source(cop, 'a = "#{"b"}"') }
+      expect { inspect_source('a = "#{"b"}"') }
         .to raise_error(RuntimeError)
     end
   end

--- a/spec/rubocop/cop/style/string_literals_in_interpolation_spec.rb
+++ b/spec/rubocop/cop/style/string_literals_in_interpolation_spec.rb
@@ -56,7 +56,7 @@ describe RuboCop::Cop::Style::StringLiteralsInInterpolation, :config do
     end
 
     it 'auto-corrects " with \'' do
-      new_source = autocorrect_source(cop, 's = "#{"abc"}"')
+      new_source = autocorrect_source('s = "#{"abc"}"')
       expect(new_source).to eq(%q(s = "#{'abc'}"))
     end
   end

--- a/spec/rubocop/cop/style/string_literals_spec.rb
+++ b/spec/rubocop/cop/style/string_literals_spec.rb
@@ -133,7 +133,7 @@ describe RuboCop::Cop::Style::StringLiterals, :config do
     end
 
     it 'auto-corrects " with \'' do
-      new_source = autocorrect_source(cop, 's = "abc"')
+      new_source = autocorrect_source('s = "abc"')
       expect(new_source).to eq("s = 'abc'")
     end
 
@@ -152,7 +152,7 @@ describe RuboCop::Cop::Style::StringLiterals, :config do
     end
 
     it 'autocorrects words with non-ascii chars' do
-      new_source = autocorrect_source(cop, '"España"')
+      new_source = autocorrect_source('"España"')
       expect(new_source).to eq("'España'")
     end
 
@@ -164,7 +164,7 @@ describe RuboCop::Cop::Style::StringLiterals, :config do
 
     it 'does not autocorrect words with non-ascii chars and other control ' \
        'sequences' do
-      new_source = autocorrect_source(cop, '"España\n"')
+      new_source = autocorrect_source('"España\n"')
       expect(new_source).to eq('"España\n"')
     end
   end
@@ -248,7 +248,7 @@ describe RuboCop::Cop::Style::StringLiterals, :config do
     end
 
     it "auto-corrects ' with \"" do
-      new_source = autocorrect_source(cop, "s = 'abc'")
+      new_source = autocorrect_source("s = 'abc'")
       expect(new_source).to eq('s = "abc"')
     end
   end

--- a/spec/rubocop/cop/style/string_literals_spec.rb
+++ b/spec/rubocop/cop/style/string_literals_spec.rb
@@ -7,10 +7,10 @@ describe RuboCop::Cop::Style::StringLiterals, :config do
     let(:cop_config) { { 'EnforcedStyle' => 'single_quotes' } }
 
     it 'registers offense for double quotes when single quotes suffice' do
-      inspect_source(cop, ['s = "abc"',
-                           'x = "a\\\\b"',
-                           'y ="\\\\b"',
-                           'z = "a\\\\"'])
+      inspect_source(['s = "abc"',
+                      'x = "a\\\\b"',
+                      'y ="\\\\b"',
+                      'z = "a\\\\"'])
       expect(cop.highlights).to eq(['"abc"',
                                     '"a\\\\b"',
                                     '"\\\\b"',
@@ -23,8 +23,8 @@ describe RuboCop::Cop::Style::StringLiterals, :config do
     end
 
     it 'registers offense for correct + opposite' do
-      inspect_source(cop, ['s = "abc"',
-                           "x = 'abc'"])
+      inspect_source(['s = "abc"',
+                      "x = 'abc'"])
       expect(cop.messages)
         .to eq(["Prefer single-quoted strings when you don't need " \
                 'string interpolation or special symbols.'])
@@ -116,7 +116,7 @@ describe RuboCop::Cop::Style::StringLiterals, :config do
 
     it 'detects unneeded double quotes within concatenated string' do
       src = ['"#{x}" \\', '"y"']
-      inspect_source(cop, src)
+      inspect_source(src)
       expect(cop.offenses.size).to eq(1)
     end
 
@@ -158,7 +158,7 @@ describe RuboCop::Cop::Style::StringLiterals, :config do
 
     it 'does not register an offense for words with non-ascii chars and ' \
        'other control sequences' do
-      inspect_source(cop, '"España\n"')
+      inspect_source('"España\n"')
       expect(cop.offenses.size).to eq(0)
     end
 
@@ -174,7 +174,7 @@ describe RuboCop::Cop::Style::StringLiterals, :config do
 
     it 'registers offense for single quotes when double quotes would ' \
       'be equivalent' do
-      inspect_source(cop, "s = 'abc'")
+      inspect_source("s = 'abc'")
       expect(cop.highlights).to eq(["'abc'"])
       expect(cop.messages)
         .to eq(['Prefer double-quoted strings unless you need ' \
@@ -185,8 +185,8 @@ describe RuboCop::Cop::Style::StringLiterals, :config do
     end
 
     it 'registers offense for opposite + correct' do
-      inspect_source(cop, ['s = "abc"',
-                           "x = 'abc'"])
+      inspect_source(['s = "abc"',
+                      "x = 'abc'"])
       expect(cop.messages)
         .to eq(['Prefer double-quoted strings unless you need ' \
                 'single quotes to avoid extra backslashes for ' \
@@ -227,7 +227,7 @@ describe RuboCop::Cop::Style::StringLiterals, :config do
     end
 
     it 'flags single quotes with plain # (not #@var or #{interpolation}' do
-      inspect_source(cop, "a = 'blah #'")
+      inspect_source("a = 'blah #'")
       expect(cop.offenses.size).to be 1
     end
 
@@ -257,7 +257,7 @@ describe RuboCop::Cop::Style::StringLiterals, :config do
     let(:cop_config) { { 'EnforcedStyle' => 'other' } }
 
     it 'fails' do
-      expect { inspect_source(cop, 'a = "b"') }
+      expect { inspect_source('a = "b"') }
         .to raise_error(RuntimeError)
     end
   end
@@ -272,8 +272,7 @@ describe RuboCop::Cop::Style::StringLiterals, :config do
       end
 
       it 'registers an offense for strings with line breaks in them' do
-        inspect_source(cop,
-                       ['"--',
+        inspect_source(['"--',
                         'SELECT *',
                         'LEFT JOIN X on Y',
                         'FROM Models"'])
@@ -291,16 +290,16 @@ describe RuboCop::Cop::Style::StringLiterals, :config do
       end
 
       it 'registers an offense for mixed quote styles in a continued string' do
-        inspect_source(cop, ["'abc' \\",
-                             '"def"'])
+        inspect_source(["'abc' \\",
+                        '"def"'])
         expect(cop.offenses.size).to eq(1)
         expect(cop.messages).to eq(['Inconsistent quote style.'])
         expect(cop.highlights).to eq(["'abc' \\\n\"def\""])
       end
 
       it 'registers an offense for unneeded double quotes in continuation' do
-        inspect_source(cop, ['"abc" \\',
-                             '"def"'])
+        inspect_source(['"abc" \\',
+                        '"def"'])
         expect(cop.offenses.size).to eq(1)
         expect(cop.messages).to eq(['Prefer single-quoted strings when you ' \
                                     "don't need string interpolation or " \
@@ -362,16 +361,16 @@ describe RuboCop::Cop::Style::StringLiterals, :config do
       end
 
       it 'registers an offense for mixed quote styles in a continued string' do
-        inspect_source(cop, ["'abc' \\",
-                             '"def"'])
+        inspect_source(["'abc' \\",
+                        '"def"'])
         expect(cop.offenses.size).to eq(1)
         expect(cop.messages).to eq(['Inconsistent quote style.'])
         expect(cop.highlights).to eq(["'abc' \\\n\"def\""])
       end
 
       it 'registers an offense for unneeded single quotes in continuation' do
-        inspect_source(cop, ["'abc' \\",
-                             "'def'"])
+        inspect_source(["'abc' \\",
+                        "'def'"])
         expect(cop.offenses.size).to eq(1)
         expect(cop.messages).to eq(['Prefer double-quoted strings unless you ' \
                                     'need single quotes to avoid extra ' \

--- a/spec/rubocop/cop/style/string_methods_spec.rb
+++ b/spec/rubocop/cop/style/string_methods_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe RuboCop::Cop::Style::StringMethods, :config do
   let(:cop_config) { { 'intern' => 'to_sym' } }
 
   let(:source) { "'something'.intern" }
-  let(:corrected) { autocorrect_source(cop, source) }
+  let(:corrected) { autocorrect_source(source) }
 
   it 'registers an offense' do
     inspect_source(source)

--- a/spec/rubocop/cop/style/string_methods_spec.rb
+++ b/spec/rubocop/cop/style/string_methods_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe RuboCop::Cop::Style::StringMethods, :config do
   let(:corrected) { autocorrect_source(cop, source) }
 
   it 'registers an offense' do
-    inspect_source(cop, source)
+    inspect_source(source)
 
     expect(cop.offenses.size).to eq(1)
     expect(cop.messages).to eq(['Prefer `to_sym` over `intern`.'])

--- a/spec/rubocop/cop/style/symbol_array_spec.rb
+++ b/spec/rubocop/cop/style/symbol_array_spec.rb
@@ -25,7 +25,7 @@ describe RuboCop::Cop::Style::SymbolArray, :config do
     end
 
     it 'registers an offense for arrays of symbols' do
-      inspect_source(cop, '[:one, :two, :three]')
+      inspect_source('[:one, :two, :three]')
       expect(cop.offenses.size).to eq(1)
       expect(cop.messages).to eq(['Use `%i` or `%I` for an array of symbols.'])
       expect(cop.config_to_allow_offenses).to eq('EnforcedStyle' => 'brackets')
@@ -69,7 +69,7 @@ describe RuboCop::Cop::Style::SymbolArray, :config do
     end
 
     it 'detects right value for MinSize to use for --auto-gen-config' do
-      inspect_source(cop, <<-RUBY.strip_indent)
+      inspect_source(<<-RUBY.strip_indent)
         [:one, :two, :three]
         %i(a b c d)
       RUBY
@@ -81,7 +81,7 @@ describe RuboCop::Cop::Style::SymbolArray, :config do
     end
 
     it 'detects when the cop must be disabled to avoid offenses' do
-      inspect_source(cop, <<-RUBY.strip_indent)
+      inspect_source(<<-RUBY.strip_indent)
         [:one, :two, :three]
         %i(a b)
       RUBY

--- a/spec/rubocop/cop/style/symbol_array_spec.rb
+++ b/spec/rubocop/cop/style/symbol_array_spec.rb
@@ -32,23 +32,23 @@ describe RuboCop::Cop::Style::SymbolArray, :config do
     end
 
     it 'autocorrects arrays of symbols' do
-      new_source = autocorrect_source(cop, '[:one, :two, :three]')
+      new_source = autocorrect_source('[:one, :two, :three]')
       expect(new_source).to eq('%i(one two three)')
     end
 
     it 'autocorrects arrays of symbols with new line' do
-      new_source = autocorrect_source(cop, "[:one,\n:two, :three,\n:four]")
+      new_source = autocorrect_source("[:one,\n:two, :three,\n:four]")
       expect(new_source).to eq("%i(one \ntwo three \nfour)")
     end
 
     it 'uses %I when appropriate' do
-      new_source = autocorrect_source(cop, '[:"\\t", :"\\n", :three]')
+      new_source = autocorrect_source('[:"\\t", :"\\n", :three]')
       expect(new_source).to eq('%I(\\t \\n three)')
     end
 
     it "doesn't break when a symbol contains )" do
       source = '[:one, :")", :three, :"(", :"]", :"["]'
-      new_source = autocorrect_source(cop, source)
+      new_source = autocorrect_source(source)
       expect(new_source).to eq('%i(one \\) three \\( ] [)')
     end
 
@@ -109,7 +109,7 @@ describe RuboCop::Cop::Style::SymbolArray, :config do
 
       it 'autocorrects an array with delimiters' do
         source = '[:one, :")", :three, :"(", :"]", :"["]'
-        new_source = autocorrect_source(cop, source)
+        new_source = autocorrect_source(source)
         expect(new_source).to eq('%i[one ) three ( \\] \\[]')
       end
     end
@@ -130,7 +130,7 @@ describe RuboCop::Cop::Style::SymbolArray, :config do
     end
 
     it 'autocorrects an array starting with %i' do
-      new_source = autocorrect_source(cop, '%i(one @two $three four-five)')
+      new_source = autocorrect_source('%i(one @two $three four-five)')
       expect(new_source).to eq("[:one, :@two, :$three, :'four-five']")
     end
   end

--- a/spec/rubocop/cop/style/symbol_literal_spec.rb
+++ b/spec/rubocop/cop/style/symbol_literal_spec.rb
@@ -23,7 +23,7 @@ describe RuboCop::Cop::Style::SymbolLiteral do
   end
 
   it 'auto-corrects by removing quotes' do
-    new_source = autocorrect_source(cop, '{ :"ala" => 1, :"bala" => 2 }')
+    new_source = autocorrect_source('{ :"ala" => 1, :"bala" => 2 }')
     expect(new_source).to eq('{ :ala => 1, :bala => 2 }')
   end
 end

--- a/spec/rubocop/cop/style/symbol_proc_spec.rb
+++ b/spec/rubocop/cop/style/symbol_proc_spec.rb
@@ -7,7 +7,7 @@ describe RuboCop::Cop::Style::SymbolProc, :config do
 
   it 'registers an offense for a block with parameterless method call on ' \
      'param' do
-    inspect_source(cop, 'coll.map { |e| e.upcase }')
+    inspect_source('coll.map { |e| e.upcase }')
     expect(cop.offenses.size).to eq(1)
     expect(cop.messages)
       .to eq(['Pass `&:upcase` as an argument to `map` instead of a block.'])
@@ -98,7 +98,7 @@ describe RuboCop::Cop::Style::SymbolProc, :config do
   end
 
   it 'does not crash with a bare method call' do
-    run = -> { inspect_source(cop, 'coll.map { |s| bare_method }') }
+    run = -> { inspect_source('coll.map { |s| bare_method }') }
     expect(&run).not_to raise_error
   end
 

--- a/spec/rubocop/cop/style/symbol_proc_spec.rb
+++ b/spec/rubocop/cop/style/symbol_proc_spec.rb
@@ -76,24 +76,24 @@ describe RuboCop::Cop::Style::SymbolProc, :config do
     end
 
     it 'auto-corrects' do
-      corrected = autocorrect_source(cop, source)
+      corrected = autocorrect_source(source)
       expect(corrected).to eq 'method(one, 2, &:test)'
     end
   end
 
   it 'autocorrects alias with symbols as proc' do
-    corrected = autocorrect_source(cop, ['coll.map { |s| s.upcase }'])
+    corrected = autocorrect_source(['coll.map { |s| s.upcase }'])
     expect(corrected).to eq 'coll.map(&:upcase)'
   end
 
   it 'autocorrects multiple aliases with symbols as proc' do
-    corrected = autocorrect_source(cop, ['coll.map { |s| s.upcase }' \
+    corrected = autocorrect_source(['coll.map { |s| s.upcase }' \
                                          '.map { |s| s.downcase }'])
     expect(corrected).to eq 'coll.map(&:upcase).map(&:downcase)'
   end
 
   it 'auto-corrects correctly when there are no arguments in parentheses' do
-    corrected = autocorrect_source(cop, ['coll.map(   ) { |s| s.upcase }'])
+    corrected = autocorrect_source(['coll.map(   ) { |s| s.upcase }'])
     expect(corrected).to eq 'coll.map(&:upcase)'
   end
 
@@ -113,7 +113,7 @@ describe RuboCop::Cop::Style::SymbolProc, :config do
     end
 
     it 'auto-corrects' do
-      corrected = autocorrect_source(cop, source)
+      corrected = autocorrect_source(source)
       expect(corrected).to eq 'super(one, two, &:test)'
     end
   end
@@ -129,13 +129,13 @@ describe RuboCop::Cop::Style::SymbolProc, :config do
     end
 
     it 'auto-corrects' do
-      corrected = autocorrect_source(cop, source)
+      corrected = autocorrect_source(source)
       expect(corrected).to eq 'super(&:test)'
     end
   end
 
   it 'auto-corrects correctly when args have a trailing comma' do
-    corrected = autocorrect_source(cop, <<-RUBY.strip_indent)
+    corrected = autocorrect_source(<<-RUBY.strip_indent)
       mail(
         to: 'foo',
         subject: 'bar',

--- a/spec/rubocop/cop/style/ternary_parentheses_spec.rb
+++ b/spec/rubocop/cop/style/ternary_parentheses_spec.rb
@@ -25,20 +25,20 @@ describe RuboCop::Cop::Style::TernaryParentheses, :config do
 
       if expected
         it 'auto-corrects' do
-          expect(autocorrect_source(cop, code)).to eq(expected)
+          expect(autocorrect_source(code)).to eq(expected)
         end
 
         it 'claims to auto-correct' do
-          autocorrect_source(cop, code)
+          autocorrect_source(code)
           expect(cop.offenses.last.status).to eq(:corrected)
         end
       else
         it 'does not auto-correct' do
-          expect(autocorrect_source(cop, code)).to eq(code)
+          expect(autocorrect_source(code)).to eq(code)
         end
 
         it 'does not claim to auto-correct' do
-          autocorrect_source(cop, code)
+          autocorrect_source(code)
           expect(cop.offenses.last.status).to eq(:uncorrected)
         end
       end

--- a/spec/rubocop/cop/style/ternary_parentheses_spec.rb
+++ b/spec/rubocop/cop/style/ternary_parentheses_spec.rb
@@ -4,7 +4,7 @@ describe RuboCop::Cop::Style::TernaryParentheses, :config do
   subject(:cop) { described_class.new(config) }
 
   before do
-    inspect_source(cop, source)
+    inspect_source(source)
   end
 
   let(:redundant_parens_enabled) { false }

--- a/spec/rubocop/cop/style/trailing_comma_in_arguments_spec.rb
+++ b/spec/rubocop/cop/style/trailing_comma_in_arguments_spec.rb
@@ -5,7 +5,7 @@ describe RuboCop::Cop::Style::TrailingCommaInArguments, :config do
 
   shared_examples 'single line lists' do |extra_info|
     it 'registers an offense for trailing comma in a method call' do
-      inspect_source(cop, 'some_method(a, b, c, )')
+      inspect_source('some_method(a, b, c, )')
       expect(cop.messages)
         .to eq(['Avoid comma after the last parameter of a method ' \
                 "call#{extra_info}."])
@@ -14,7 +14,7 @@ describe RuboCop::Cop::Style::TrailingCommaInArguments, :config do
 
     it 'registers an offense for trailing comma in a method call with hash' \
        ' parameters at the end' do
-      inspect_source(cop, 'some_method(a, b, c: 0, d: 1, )')
+      inspect_source('some_method(a, b, c: 0, d: 1, )')
       expect(cop.messages)
         .to eq(['Avoid comma after the last parameter of a method ' \
                 "call#{extra_info}."])
@@ -27,7 +27,7 @@ describe RuboCop::Cop::Style::TrailingCommaInArguments, :config do
 
     it 'accepts method call without trailing comma with single element hash' \
         ' parameters at the end' do
-      inspect_source(cop, 'some_method(a: 1)')
+      inspect_source('some_method(a: 1)')
       expect(cop.offenses).to be_empty
     end
 
@@ -79,7 +79,7 @@ describe RuboCop::Cop::Style::TrailingCommaInArguments, :config do
 
       it 'registers an offense for trailing comma in a method call with ' \
          'hash parameters at the end' do
-        inspect_source(cop, <<-RUBY.strip_indent)
+        inspect_source(<<-RUBY.strip_indent)
           some_method(
                         a,
                         b,
@@ -91,7 +91,7 @@ describe RuboCop::Cop::Style::TrailingCommaInArguments, :config do
 
       it 'accepts a method call with ' \
          'hash parameters at the end and no trailing comma' do
-        inspect_source(cop, <<-RUBY.strip_indent)
+        inspect_source(<<-RUBY.strip_indent)
           some_method(a,
                       b,
                       c: 0,
@@ -136,7 +136,7 @@ describe RuboCop::Cop::Style::TrailingCommaInArguments, :config do
       context 'when closing bracket is on same line as last value' do
         it 'accepts a method call with Hash as last parameter split on ' \
            'multiple lines' do
-          inspect_source(cop, <<-RUBY.strip_indent)
+          inspect_source(<<-RUBY.strip_indent)
             some_method(a: "b",
                         c: "d")
           RUBY
@@ -146,7 +146,7 @@ describe RuboCop::Cop::Style::TrailingCommaInArguments, :config do
 
       it 'registers an offense for no trailing comma in a method call with' \
          ' hash parameters at the end' do
-        inspect_source(cop, <<-RUBY.strip_indent)
+        inspect_source(<<-RUBY.strip_indent)
           some_method(
                         a,
                         b,
@@ -169,7 +169,7 @@ describe RuboCop::Cop::Style::TrailingCommaInArguments, :config do
 
       it 'accepts trailing comma in a method call with hash' \
          ' parameters at the end' do
-        inspect_source(cop, <<-RUBY.strip_indent)
+        inspect_source(<<-RUBY.strip_indent)
           some_method(
                         a,
                         b,
@@ -182,7 +182,7 @@ describe RuboCop::Cop::Style::TrailingCommaInArguments, :config do
 
       it 'accepts no trailing comma in a method call with a multiline' \
          ' braceless hash at the end with more than one parameter on a line' do
-        inspect_source(cop, <<-RUBY.strip_indent)
+        inspect_source(<<-RUBY.strip_indent)
           some_method(
                         a,
                         b: 0,
@@ -194,7 +194,7 @@ describe RuboCop::Cop::Style::TrailingCommaInArguments, :config do
 
       it 'accepts a trailing comma in a method call with single ' \
          'line hashes' do
-        inspect_source(cop, <<-RUBY.strip_indent)
+        inspect_source(<<-RUBY.strip_indent)
           some_method(
            { a: 0, b: 1 },
            { a: 1, b: 0 },
@@ -246,7 +246,7 @@ describe RuboCop::Cop::Style::TrailingCommaInArguments, :config do
       context 'when closing bracket is on same line as last value' do
         it 'registers an offense for a method call, with a Hash as the ' \
            'last parameter, split on multiple lines' do
-          inspect_source(cop, <<-RUBY.strip_indent)
+          inspect_source(<<-RUBY.strip_indent)
             some_method(a: "b",
                         c: "d")
           RUBY
@@ -258,7 +258,7 @@ describe RuboCop::Cop::Style::TrailingCommaInArguments, :config do
 
       it 'registers an offense for no trailing comma in a method call with' \
          ' hash parameters at the end' do
-        inspect_source(cop, <<-RUBY.strip_indent)
+        inspect_source(<<-RUBY.strip_indent)
           some_method(
                         a,
                         b,
@@ -274,7 +274,7 @@ describe RuboCop::Cop::Style::TrailingCommaInArguments, :config do
 
       it 'registers an offense for no trailing comma in a method call with' \
           'two parameters on the same line' do
-        inspect_source(cop, <<-RUBY.strip_indent)
+        inspect_source(<<-RUBY.strip_indent)
           some_method(a, b
                      )
         RUBY
@@ -285,7 +285,7 @@ describe RuboCop::Cop::Style::TrailingCommaInArguments, :config do
 
       it 'accepts trailing comma in a method call with hash' \
          ' parameters at the end' do
-        inspect_source(cop, <<-RUBY.strip_indent)
+        inspect_source(<<-RUBY.strip_indent)
           some_method(
                         a,
                         b,
@@ -298,7 +298,7 @@ describe RuboCop::Cop::Style::TrailingCommaInArguments, :config do
 
       it 'accepts a trailing comma in a method call with ' \
          'a single hash parameter' do
-        inspect_source(cop, <<-RUBY.strip_indent)
+        inspect_source(<<-RUBY.strip_indent)
           some_method(
                         a: 0,
                         b: 1,
@@ -309,7 +309,7 @@ describe RuboCop::Cop::Style::TrailingCommaInArguments, :config do
 
       it 'accepts a trailing comma in a method call with single ' \
          'line hashes' do
-        inspect_source(cop, <<-RUBY.strip_indent)
+        inspect_source(<<-RUBY.strip_indent)
           some_method(
            { a: 0, b: 1 },
            { a: 1, b: 0 },
@@ -322,7 +322,7 @@ describe RuboCop::Cop::Style::TrailingCommaInArguments, :config do
       # this is a sad parse error
       it 'accepts no trailing comma in a method call with a block' \
          ' parameter at the end' do
-        inspect_source(cop, <<-RUBY.strip_indent)
+        inspect_source(<<-RUBY.strip_indent)
           some_method(
                         a,
                         b,
@@ -375,7 +375,7 @@ describe RuboCop::Cop::Style::TrailingCommaInArguments, :config do
 
       it 'accepts a multiline call with arguments on a single line and' \
          ' trailing comma' do
-        inspect_source(cop, <<-RUBY.strip_indent)
+        inspect_source(<<-RUBY.strip_indent)
           method(
             1, 2,
           )

--- a/spec/rubocop/cop/style/trailing_comma_in_arguments_spec.rb
+++ b/spec/rubocop/cop/style/trailing_comma_in_arguments_spec.rb
@@ -43,13 +43,13 @@ describe RuboCop::Cop::Style::TrailingCommaInArguments, :config do
     end
 
     it 'auto-corrects unwanted comma in a method call' do
-      new_source = autocorrect_source(cop, 'some_method(a, b, c, )')
+      new_source = autocorrect_source('some_method(a, b, c, )')
       expect(new_source).to eq('some_method(a, b, c )')
     end
 
     it 'auto-corrects unwanted comma in a method call with hash parameters at' \
        ' the end' do
-      new_source = autocorrect_source(cop, 'some_method(a, b, c: 0, d: 1, )')
+      new_source = autocorrect_source('some_method(a, b, c: 0, d: 1, )')
       expect(new_source).to eq('some_method(a, b, c: 0, d: 1 )')
     end
   end
@@ -113,7 +113,7 @@ describe RuboCop::Cop::Style::TrailingCommaInArguments, :config do
 
       it 'auto-corrects unwanted comma in a method call with hash parameters' \
          ' at the end' do
-        new_source = autocorrect_source(cop, <<-RUBY.strip_indent)
+        new_source = autocorrect_source(<<-RUBY.strip_indent)
           some_method(
                         a,
                         b,
@@ -213,7 +213,7 @@ describe RuboCop::Cop::Style::TrailingCommaInArguments, :config do
 
       it 'auto-corrects missing comma in a method call with hash parameters' \
          ' at the end' do
-        new_source = autocorrect_source(cop, <<-RUBY.strip_indent)
+        new_source = autocorrect_source(<<-RUBY.strip_indent)
           some_method(
                         a,
                         b,
@@ -347,7 +347,7 @@ describe RuboCop::Cop::Style::TrailingCommaInArguments, :config do
 
       it 'auto-corrects missing comma in a method call with hash parameters' \
          ' at the end' do
-        new_source = autocorrect_source(cop, <<-RUBY.strip_indent)
+        new_source = autocorrect_source(<<-RUBY.strip_indent)
           some_method(
                         a,
                         b,

--- a/spec/rubocop/cop/style/trailing_comma_in_literal_spec.rb
+++ b/spec/rubocop/cop/style/trailing_comma_in_literal_spec.rb
@@ -53,13 +53,12 @@ describe RuboCop::Cop::Style::TrailingCommaInLiteral, :config do
     end
 
     it 'auto-corrects unwanted comma in an Array literal' do
-      new_source = autocorrect_source(cop, 'VALUES = [1001, 2020, 3333, ]')
+      new_source = autocorrect_source('VALUES = [1001, 2020, 3333, ]')
       expect(new_source).to eq('VALUES = [1001, 2020, 3333 ]')
     end
 
     it 'auto-corrects unwanted comma in a Hash literal' do
-      new_source = autocorrect_source(cop,
-                                      'MAP = { a: 1001, b: 2020, c: 3333, }')
+      new_source = autocorrect_source('MAP = { a: 1001, b: 2020, c: 3333, }')
       expect(new_source).to eq('MAP = { a: 1001, b: 2020, c: 3333 }')
     end
   end
@@ -146,7 +145,7 @@ describe RuboCop::Cop::Style::TrailingCommaInLiteral, :config do
       end
 
       it 'auto-corrects unwanted comma in an Array literal' do
-        new_source = autocorrect_source(cop, <<-RUBY.strip_indent)
+        new_source = autocorrect_source(<<-RUBY.strip_indent)
           VALUES = [
                      1001,
                      2020,
@@ -163,7 +162,7 @@ describe RuboCop::Cop::Style::TrailingCommaInLiteral, :config do
       end
 
       it 'auto-corrects unwanted comma in a Hash literal' do
-        new_source = autocorrect_source(cop, <<-RUBY.strip_indent)
+        new_source = autocorrect_source(<<-RUBY.strip_indent)
           MAP = { a: 1001,
                   b: 2020,
                   c: 3333,
@@ -293,7 +292,7 @@ describe RuboCop::Cop::Style::TrailingCommaInLiteral, :config do
 
       it 'auto-corrects an Array literal with two of the values on the same' \
          ' line and a trailing comma' do
-        new_source = autocorrect_source(cop, <<-RUBY.strip_indent)
+        new_source = autocorrect_source(<<-RUBY.strip_indent)
           VALUES = [
                      1001, 2020,
                      3333
@@ -308,7 +307,7 @@ describe RuboCop::Cop::Style::TrailingCommaInLiteral, :config do
       end
 
       it 'auto-corrects missing comma in a Hash literal' do
-        new_source = autocorrect_source(cop, <<-RUBY.strip_indent)
+        new_source = autocorrect_source(<<-RUBY.strip_indent)
           MAP = { a: 1001,
                   b: 2020,
                   c: 3333
@@ -364,7 +363,7 @@ describe RuboCop::Cop::Style::TrailingCommaInLiteral, :config do
         end
 
         it 'auto-corrects a missing comma in a Hash literal' do
-          new_source = autocorrect_source(cop, <<-RUBY.strip_indent)
+          new_source = autocorrect_source(<<-RUBY.strip_indent)
             MAP = { a: 1001,
                     b: 2020,
                     c: 3333}
@@ -451,7 +450,7 @@ describe RuboCop::Cop::Style::TrailingCommaInLiteral, :config do
 
       it 'auto-corrects an Array literal with two of the values on the same' \
          ' line and a trailing comma' do
-        new_source = autocorrect_source(cop, <<-RUBY.strip_indent)
+        new_source = autocorrect_source(<<-RUBY.strip_indent)
           VALUES = [
                      1001, 2020,
                      3333
@@ -466,7 +465,7 @@ describe RuboCop::Cop::Style::TrailingCommaInLiteral, :config do
       end
 
       it 'auto-corrects missing comma in a Hash literal' do
-        new_source = autocorrect_source(cop, <<-RUBY.strip_indent)
+        new_source = autocorrect_source(<<-RUBY.strip_indent)
           MAP = { a: 1001,
                   b: 2020,
                   c: 3333

--- a/spec/rubocop/cop/style/trailing_comma_in_literal_spec.rb
+++ b/spec/rubocop/cop/style/trailing_comma_in_literal_spec.rb
@@ -5,14 +5,14 @@ describe RuboCop::Cop::Style::TrailingCommaInLiteral, :config do
 
   shared_examples 'single line lists' do |extra_info|
     it 'registers an offense for trailing comma in an Array literal' do
-      inspect_source(cop, 'VALUES = [1001, 2020, 3333, ]')
+      inspect_source('VALUES = [1001, 2020, 3333, ]')
       expect(cop.messages)
         .to eq(["Avoid comma after the last item of an array#{extra_info}."])
       expect(cop.highlights).to eq([','])
     end
 
     it 'registers an offense for trailing comma in a Hash literal' do
-      inspect_source(cop, 'MAP = { a: 1001, b: 2020, c: 3333, }')
+      inspect_source('MAP = { a: 1001, b: 2020, c: 3333, }')
       expect(cop.messages)
         .to eq(["Avoid comma after the last item of a hash#{extra_info}."])
       expect(cop.highlights).to eq([','])
@@ -212,7 +212,7 @@ describe RuboCop::Cop::Style::TrailingCommaInLiteral, :config do
 
       it 'registers an offense for an Array literal with two of the values ' \
          'on the same line and a trailing comma' do
-        inspect_source(cop, <<-RUBY.strip_indent)
+        inspect_source(<<-RUBY.strip_indent)
           VALUES = [
                      1001, 2020,
                      3333,
@@ -388,7 +388,7 @@ describe RuboCop::Cop::Style::TrailingCommaInLiteral, :config do
 
       it 'registers an offense for an Array literal with two of the values ' \
          'on the same line and no trailing comma' do
-        inspect_source(cop, <<-RUBY.strip_indent)
+        inspect_source(<<-RUBY.strip_indent)
           VALUES = [
                      1001, 2020,
                      3333
@@ -498,7 +498,7 @@ describe RuboCop::Cop::Style::TrailingCommaInLiteral, :config do
 
       it 'accepts a multiline array with items on a single line and' \
          'trailing comma' do
-        inspect_source(cop, <<-RUBY.strip_indent)
+        inspect_source(<<-RUBY.strip_indent)
           foo = [
             1, 2,
           ]
@@ -508,7 +508,7 @@ describe RuboCop::Cop::Style::TrailingCommaInLiteral, :config do
 
       it 'accepts a multiline hash with pairs on a single line and' \
          'trailing comma' do
-        inspect_source(cop, <<-RUBY.strip_indent)
+        inspect_source(<<-RUBY.strip_indent)
           bar = {
             a: 1001, b: 2020,
           }

--- a/spec/rubocop/cop/style/trailing_underscore_variable_spec.rb
+++ b/spec/rubocop/cop/style/trailing_underscore_variable_spec.rb
@@ -6,7 +6,7 @@ describe RuboCop::Cop::Style::TrailingUnderscoreVariable do
   shared_examples 'common functionality' do
     it 'registers an offense when the last variable of parallel assignment ' \
        'is an underscore' do
-      inspect_source(cop, 'a, b, _ = foo()')
+      inspect_source('a, b, _ = foo()')
 
       expect(cop.messages)
         .to eq(['Do not use trailing `_`s in parallel assignment. ' \
@@ -15,7 +15,7 @@ describe RuboCop::Cop::Style::TrailingUnderscoreVariable do
 
     it 'registers an offense when multiple underscores are used '\
        'as the last variables of parallel assignment ' do
-      inspect_source(cop, 'a, _, _ = foo()')
+      inspect_source('a, _, _ = foo()')
 
       expect(cop.messages)
         .to eq(['Do not use trailing `_`s in parallel assignment. ' \
@@ -23,7 +23,7 @@ describe RuboCop::Cop::Style::TrailingUnderscoreVariable do
     end
 
     it 'registers an offense for splat underscore as the last variable' do
-      inspect_source(cop, 'a, *_ = foo()')
+      inspect_source('a, *_ = foo()')
 
       expect(cop.messages)
         .to eq(['Do not use trailing `_`s in parallel assignment. ' \
@@ -32,7 +32,7 @@ describe RuboCop::Cop::Style::TrailingUnderscoreVariable do
 
     it 'registers an offense when underscore is the second to last variable ' \
        'and blank is the last variable' do
-      inspect_source(cop, 'a, _, = foo()')
+      inspect_source('a, _, = foo()')
 
       expect(cop.messages)
         .to eq(['Do not use trailing `_`s in parallel assignment. ' \
@@ -41,7 +41,7 @@ describe RuboCop::Cop::Style::TrailingUnderscoreVariable do
 
     it 'registers an offense when underscore is the only variable ' \
        'in parallel assignment' do
-      inspect_source(cop, '_, = foo()')
+      inspect_source('_, = foo()')
 
       expect(cop.messages)
         .to eq(['Do not use trailing `_`s in parallel assignment. ' \
@@ -50,7 +50,7 @@ describe RuboCop::Cop::Style::TrailingUnderscoreVariable do
 
     it 'registers an offense for an underscore as the last param ' \
        'when there is also an underscore as the first param' do
-      inspect_source(cop, '_, b, _ = foo()')
+      inspect_source('_, b, _ = foo()')
 
       expect(cop.messages)
         .to eq(['Do not use trailing `_`s in parallel assignment. ' \
@@ -58,55 +58,55 @@ describe RuboCop::Cop::Style::TrailingUnderscoreVariable do
     end
 
     it 'does not register an offense when there are no underscores' do
-      inspect_source(cop, 'a, b, c = foo()')
+      inspect_source('a, b, c = foo()')
 
       expect(cop.messages).to be_empty
     end
 
     it 'does not register an offense for underscores at the beginning' do
-      inspect_source(cop, '_, a, b = foo()')
+      inspect_source('_, a, b = foo()')
 
       expect(cop.messages).to be_empty
     end
 
     it 'does not register an offense for an underscore preceded by a ' \
        'splat variable anywhere in the argument chain' do
-      inspect_source(cop, '*a, b, _ = foo()')
+      inspect_source('*a, b, _ = foo()')
 
       expect(cop.messages).to be_empty
     end
 
     it 'does not register an offense for an underscore preceded by a ' \
        'splat variable' do
-      inspect_source(cop, 'a, *b, _ = foo()')
+      inspect_source('a, *b, _ = foo()')
 
       expect(cop.messages).to be_empty
     end
 
     it 'does not register an offense for an underscore preceded by a ' \
        'splat variable and another underscore' do
-      inspect_source(cop, '_, *b, _ = *foo')
+      inspect_source('_, *b, _ = *foo')
 
       expect(cop.messages).to be_empty
     end
 
     it 'does not register an offense for multiple underscores preceded by a ' \
        'splat variable' do
-      inspect_source(cop, 'a, *b, _, _ = foo()')
+      inspect_source('a, *b, _, _ = foo()')
 
       expect(cop.messages).to be_empty
     end
 
     it 'does not register an offense for multiple named underscores ' \
        'preceded by a splat variable' do
-      inspect_source(cop, 'a, *b, _c, _d = foo()')
+      inspect_source('a, *b, _c, _d = foo()')
 
       expect(cop.messages).to be_empty
     end
 
     it 'registers an offense for multiple underscore variables preceded by ' \
        'a splat underscore variable' do
-      inspect_source(cop, 'a, *_, _, _ = foo()')
+      inspect_source('a, *_, _, _ = foo()')
 
       expect(cop.messages)
         .to eq(['Do not use trailing `_`s in parallel assignment. ' \
@@ -115,14 +115,14 @@ describe RuboCop::Cop::Style::TrailingUnderscoreVariable do
 
     it 'does not register an offense for a named underscore variable ' \
        'preceded by a splat variable' do
-      inspect_source(cop, 'a, *b, _c = foo()')
+      inspect_source('a, *b, _c = foo()')
 
       expect(cop.messages).to be_empty
     end
 
     it 'does not register an offense for a named variable preceded by a ' \
        'names splat underscore variable' do
-      inspect_source(cop, 'a, *b, _c = foo()')
+      inspect_source('a, *b, _c = foo()')
 
       expect(cop.messages).to be_empty
     end
@@ -184,35 +184,35 @@ describe RuboCop::Cop::Style::TrailingUnderscoreVariable do
 
     it 'does not register an offense for an underscore variable preceded ' \
        'by a named splat underscore variable' do
-      inspect_source(cop, 'a, *_b, _ = foo()')
+      inspect_source('a, *_b, _ = foo()')
 
       expect(cop.messages).to be_empty
     end
 
     it 'does not register an offense for named variables ' \
        'that start with an underscore' do
-      inspect_source(cop, 'a, b, _c = foo()')
+      inspect_source('a, b, _c = foo()')
 
       expect(cop.messages).to be_empty
     end
 
     it 'does not register an offense for a named splat underscore ' \
        'as the last variable' do
-      inspect_source(cop, 'a, *_b = foo()')
+      inspect_source('a, *_b = foo()')
 
       expect(cop.messages).to be_empty
     end
 
     it 'does not register an offense for an underscore preceded by ' \
        'a named splat underscore' do
-      inspect_source(cop, 'a, *_b, _ = foo()')
+      inspect_source('a, *_b, _ = foo()')
 
       expect(cop.messages).to be_empty
     end
 
     it 'does not register an offense for multiple underscore variables ' \
        'preceded by a named splat underscore variable' do
-      inspect_source(cop, 'a, *_b, _, _ = foo()')
+      inspect_source('a, *_b, _, _ = foo()')
 
       expect(cop.messages).to be_empty
     end
@@ -230,7 +230,7 @@ describe RuboCop::Cop::Style::TrailingUnderscoreVariable do
 
     it 'registers an offense for named variables ' \
        'that start with an underscore' do
-      inspect_source(cop, 'a, b, _c = foo()')
+      inspect_source('a, b, _c = foo()')
 
       expect(cop.messages)
         .to eq(['Do not use trailing `_`s in parallel assignment. ' \
@@ -239,7 +239,7 @@ describe RuboCop::Cop::Style::TrailingUnderscoreVariable do
 
     it 'registers an offense for a named splat underscore ' \
        'as the last variable' do
-      inspect_source(cop, 'a, *_b = foo()')
+      inspect_source('a, *_b = foo()')
 
       expect(cop.messages)
         .to eq(['Do not use trailing `_`s in parallel assignment. ' \
@@ -248,14 +248,14 @@ describe RuboCop::Cop::Style::TrailingUnderscoreVariable do
 
     it 'does not register an offense for a named underscore preceded by a ' \
        'splat variable' do
-      inspect_source(cop, 'a, *b, _c = foo()')
+      inspect_source('a, *b, _c = foo()')
 
       expect(cop.messages).to be_empty
     end
 
     it 'registers an offense for an underscore variable preceded ' \
        'by a named splat underscore variable' do
-      inspect_source(cop, 'a, *_b, _ = foo()')
+      inspect_source('a, *_b, _ = foo()')
 
       expect(cop.messages)
         .to eq(['Do not use trailing `_`s in parallel assignment. ' \
@@ -264,7 +264,7 @@ describe RuboCop::Cop::Style::TrailingUnderscoreVariable do
 
     it 'registers an offense for an underscore preceded by ' \
        'a named splat underscore' do
-      inspect_source(cop, 'a, b, *_c, _ = foo()')
+      inspect_source('a, b, *_c, _ = foo()')
 
       expect(cop.messages)
         .to eq(['Do not use trailing `_`s in parallel assignment. ' \
@@ -273,7 +273,7 @@ describe RuboCop::Cop::Style::TrailingUnderscoreVariable do
 
     it 'registers an offense for multiple underscore variables ' \
        'preceded by a named splat underscore variable' do
-      inspect_source(cop, 'a, *_b, _, _ = foo()')
+      inspect_source('a, *_b, _, _ = foo()')
 
       expect(cop.messages)
         .to eq(['Do not use trailing `_`s in parallel assignment. ' \

--- a/spec/rubocop/cop/style/trailing_underscore_variable_spec.rb
+++ b/spec/rubocop/cop/style/trailing_underscore_variable_spec.rb
@@ -129,43 +129,43 @@ describe RuboCop::Cop::Style::TrailingUnderscoreVariable do
 
     describe 'autocorrect' do
       it 'removes trailing underscores automatically' do
-        new_source = autocorrect_source(cop, 'a, b, _ = foo()')
+        new_source = autocorrect_source('a, b, _ = foo()')
 
         expect(new_source).to eq('a, b, = foo()')
       end
 
       it 'removes trailing underscores and commas' do
-        new_source = autocorrect_source(cop, 'a, b, _, = foo()')
+        new_source = autocorrect_source('a, b, _, = foo()')
 
         expect(new_source).to eq('a, b, = foo()')
       end
 
       it 'removes multiple trailing underscores' do
-        new_source = autocorrect_source(cop, 'a, _, _ = foo()')
+        new_source = autocorrect_source('a, _, _ = foo()')
 
         expect(new_source).to eq('a, = foo()')
       end
 
       it 'removes trailing underscores and commas and preserves assignments' do
-        new_source = autocorrect_source(cop, 'a, _, _, = foo()')
+        new_source = autocorrect_source('a, _, _, = foo()')
 
         expect(new_source).to eq('a, = foo()')
       end
 
       it 'removes trailing comma when it is the only variable' do
-        new_source = autocorrect_source(cop, '_, = foo()')
+        new_source = autocorrect_source('_, = foo()')
 
         expect(new_source).to eq('foo()')
       end
 
       it 'removes all assignments when every assignment is to `_`' do
-        new_source = autocorrect_source(cop, '_, _, _, = foo()')
+        new_source = autocorrect_source('_, _, _, = foo()')
 
         expect(new_source).to eq('foo()')
       end
 
       it 'remove splat underscore' do
-        new_source = autocorrect_source(cop, 'a, *_ = foo()')
+        new_source = autocorrect_source('a, *_ = foo()')
 
         expect(new_source).to eq('a, = foo()')
       end
@@ -282,25 +282,25 @@ describe RuboCop::Cop::Style::TrailingUnderscoreVariable do
 
     context 'autocorrect' do
       it 'removes named underscore variables' do
-        new_source = autocorrect_source(cop, 'a, _b = foo()')
+        new_source = autocorrect_source('a, _b = foo()')
 
         expect(new_source).to eq('a, = foo()')
       end
 
       it 'removes named splat underscore variables' do
-        new_source = autocorrect_source(cop, 'a, *_b = foo()')
+        new_source = autocorrect_source('a, *_b = foo()')
 
         expect(new_source).to eq('a, = foo()')
       end
 
       it 'removes named splat underscore and named underscore variables' do
-        new_source = autocorrect_source(cop, 'a, *_b, _c = foo()')
+        new_source = autocorrect_source('a, *_b, _c = foo()')
 
         expect(new_source).to eq('a, = foo()')
       end
 
       it 'works when last underscore is followed by a comma' do
-        new_source = autocorrect_source(cop, 'a, _, = foo()')
+        new_source = autocorrect_source('a, _, = foo()')
 
         expect(new_source).to eq('a, = foo()')
       end

--- a/spec/rubocop/cop/style/trivial_accessors_spec.rb
+++ b/spec/rubocop/cop/style/trivial_accessors_spec.rb
@@ -39,13 +39,13 @@ describe RuboCop::Cop::Style::TrivialAccessors, :config do
   end
 
   it 'show correct message on reader' do
-    inspect_source(cop, trivial_reader)
+    inspect_source(trivial_reader)
     expect(cop.messages.first)
       .to eq('Use `attr_reader` to define trivial reader methods.')
   end
 
   it 'show correct message on writer' do
-    inspect_source(cop, trivial_writer)
+    inspect_source(trivial_writer)
     expect(cop.messages.first)
       .to eq('Use `attr_writer` to define trivial writer methods.')
   end

--- a/spec/rubocop/cop/style/trivial_accessors_spec.rb
+++ b/spec/rubocop/cop/style/trivial_accessors_spec.rb
@@ -385,7 +385,7 @@ describe RuboCop::Cop::Style::TrivialAccessors, :config do
       let(:corrected_source) { "attr_reader :foo\n" }
 
       it 'autocorrects' do
-        expect(autocorrect_source(cop, source)).to eq(corrected_source)
+        expect(autocorrect_source(source)).to eq(corrected_source)
       end
     end
 
@@ -401,7 +401,7 @@ describe RuboCop::Cop::Style::TrivialAccessors, :config do
       end
 
       it 'does not autocorrect' do
-        expect(autocorrect_source(cop, source)).to eq(source)
+        expect(autocorrect_source(source)).to eq(source)
         expect(cop.offenses.map(&:corrected?)).to eq [false]
       end
     end
@@ -417,7 +417,7 @@ describe RuboCop::Cop::Style::TrivialAccessors, :config do
       end
 
       it 'does not autocorrect' do
-        expect(autocorrect_source(cop, source)).to eq(source)
+        expect(autocorrect_source(source)).to eq(source)
         expect(cop.offenses.map(&:corrected?)).to eq [false]
       end
     end
@@ -428,7 +428,7 @@ describe RuboCop::Cop::Style::TrivialAccessors, :config do
       let(:corrected_source) { "attr_writer :foo\n" }
 
       it 'autocorrects' do
-        expect(autocorrect_source(cop, source)).to eq(corrected_source)
+        expect(autocorrect_source(source)).to eq(corrected_source)
       end
     end
 
@@ -442,7 +442,7 @@ describe RuboCop::Cop::Style::TrivialAccessors, :config do
       end
 
       it 'does not autocorrect' do
-        expect(autocorrect_source(cop, source)).to eq(source)
+        expect(autocorrect_source(source)).to eq(source)
         expect(cop.offenses.map(&:corrected?)).to eq [false]
       end
     end
@@ -457,7 +457,7 @@ describe RuboCop::Cop::Style::TrivialAccessors, :config do
       end
 
       it 'does not autocorrect' do
-        expect(autocorrect_source(cop, source)).to eq(source)
+        expect(autocorrect_source(source)).to eq(source)
         expect(cop.offenses.map(&:corrected?)).to eq [false]
       end
     end
@@ -484,7 +484,7 @@ describe RuboCop::Cop::Style::TrivialAccessors, :config do
       end
 
       it 'autocorrects with class-level attr_reader' do
-        expect(autocorrect_source(cop, source)).to eq(corrected_source)
+        expect(autocorrect_source(source)).to eq(corrected_source)
       end
     end
 
@@ -510,7 +510,7 @@ describe RuboCop::Cop::Style::TrivialAccessors, :config do
       end
 
       it 'autocorrects with class-level attr_writer' do
-        expect(autocorrect_source(cop, source)).to eq(corrected_source)
+        expect(autocorrect_source(source)).to eq(corrected_source)
       end
     end
   end

--- a/spec/rubocop/cop/style/unless_else_spec.rb
+++ b/spec/rubocop/cop/style/unless_else_spec.rb
@@ -15,7 +15,7 @@ describe RuboCop::Cop::Style::UnlessElse do
     end
 
     it 'registers an offense' do
-      inspect_source(cop, source)
+      inspect_source(source)
       expect(cop.offenses.size).to eq(1)
     end
 
@@ -49,7 +49,7 @@ describe RuboCop::Cop::Style::UnlessElse do
     end
 
     it 'registers an offense' do
-      inspect_source(cop, source)
+      inspect_source(source)
       expect(cop.offenses.size).to eq(1)
     end
 

--- a/spec/rubocop/cop/style/unless_else_spec.rb
+++ b/spec/rubocop/cop/style/unless_else_spec.rb
@@ -20,7 +20,7 @@ describe RuboCop::Cop::Style::UnlessElse do
     end
 
     it 'auto-corrects' do
-      corrected = autocorrect_source(cop, source)
+      corrected = autocorrect_source(source)
       expect(corrected).to eq(<<-RUBY.strip_indent)
         if x # positive 1
           a = 0 # positive 2
@@ -54,7 +54,7 @@ describe RuboCop::Cop::Style::UnlessElse do
     end
 
     it 'auto-corrects' do
-      corrected = autocorrect_source(cop, source)
+      corrected = autocorrect_source(source)
       expect(corrected).to eq(<<-RUBY.strip_indent)
         if(x)
           a = 3

--- a/spec/rubocop/cop/style/unneeded_capital_w_spec.rb
+++ b/spec/rubocop/cop/style/unneeded_capital_w_spec.rb
@@ -72,12 +72,12 @@ describe RuboCop::Cop::Style::UnneededCapitalW do
   end
 
   it 'auto-corrects an array of words' do
-    new_source = autocorrect_source(cop, '%W(one two three)')
+    new_source = autocorrect_source('%W(one two three)')
     expect(new_source).to eq('%w(one two three)')
   end
 
   it 'auto-corrects an array of words with different bracket' do
-    new_source = autocorrect_source(cop, '%W[one two three]')
+    new_source = autocorrect_source('%W[one two three]')
     expect(new_source).to eq('%w[one two three]')
   end
 end

--- a/spec/rubocop/cop/style/unneeded_interpolation_spec.rb
+++ b/spec/rubocop/cop/style/unneeded_interpolation_spec.rb
@@ -136,22 +136,22 @@ describe RuboCop::Cop::Style::UnneededInterpolation do
   end
 
   it 'autocorrects "#{1 + 1; 2 + 2}"' do
-    corrected = autocorrect_source(cop, ['"#{1 + 1; 2 + 2}"'])
+    corrected = autocorrect_source(['"#{1 + 1; 2 + 2}"'])
     expect(corrected).to eq '(1 + 1; 2 + 2).to_s'
   end
 
   it 'autocorrects "#@var"' do
-    corrected = autocorrect_source(cop, ['"#@var"'])
+    corrected = autocorrect_source(['"#@var"'])
     expect(corrected).to eq '@var.to_s'
   end
 
   it 'autocorrects "#{var}"' do
-    corrected = autocorrect_source(cop, ['var = 1; "#{var}"'])
+    corrected = autocorrect_source(['var = 1; "#{var}"'])
     expect(corrected).to eq 'var = 1; var.to_s'
   end
 
   it 'autocorrects "#{@var}"' do
-    corrected = autocorrect_source(cop, ['"#{@var}"'])
+    corrected = autocorrect_source(['"#{@var}"'])
     expect(corrected).to eq '@var.to_s'
   end
 end

--- a/spec/rubocop/cop/style/unneeded_percent_q_spec.rb
+++ b/spec/rubocop/cop/style/unneeded_percent_q_spec.rb
@@ -30,7 +30,7 @@ describe RuboCop::Cop::Style::UnneededPercentQ do
     end
 
     it 'registers an offfense for a string containing escaped backslashes' do
-      inspect_source(cop, '%q(\\\\foo\\\\)')
+      inspect_source('%q(\\\\foo\\\\)')
 
       expect(cop.messages.length).to eq 1
     end
@@ -142,28 +142,28 @@ describe RuboCop::Cop::Style::UnneededPercentQ do
 
   it 'accepts %q at the beginning of a double quoted string ' \
      'with interpolation' do
-    inspect_source(cop, "\"%q(a)\#{b}\"")
+    inspect_source("\"%q(a)\#{b}\"")
 
     expect(cop.messages).to be_empty
   end
 
   it 'accepts %Q at the beginning of a double quoted string ' \
      'with interpolation' do
-    inspect_source(cop, "\"%Q(a)\#{b}\"")
+    inspect_source("\"%Q(a)\#{b}\"")
 
     expect(cop.messages).to be_empty
   end
 
   it 'accepts %q at the beginning of a section of a double quoted string ' \
      'with interpolation' do
-    inspect_source(cop, %("%\#{b}%q(a)"))
+    inspect_source(%("%\#{b}%q(a)"))
 
     expect(cop.messages).to be_empty
   end
 
   it 'accepts %Q at the beginning of a section of a double quoted string ' \
      'with interpolation' do
-    inspect_source(cop, %("%\#{b}%Q(a)"))
+    inspect_source(%("%\#{b}%Q(a)"))
 
     expect(cop.messages).to be_empty
   end

--- a/spec/rubocop/cop/style/unneeded_percent_q_spec.rb
+++ b/spec/rubocop/cop/style/unneeded_percent_q_spec.rb
@@ -49,19 +49,19 @@ describe RuboCop::Cop::Style::UnneededPercentQ do
 
     context 'auto-correct' do
       it 'registers an offense for only single quotes' do
-        new_source = autocorrect_source(cop, "%q('hi')")
+        new_source = autocorrect_source("%q('hi')")
 
         expect(new_source).to eq(%q("'hi'"))
       end
 
       it 'registers an offense for only double quotes' do
-        new_source = autocorrect_source(cop, '%q("hi")')
+        new_source = autocorrect_source('%q("hi")')
 
         expect(new_source).to eq(%q('"hi"'))
       end
 
       it 'registers an offense for no quotes' do
-        new_source = autocorrect_source(cop, '%q(hi)')
+        new_source = autocorrect_source('%q(hi)')
 
         expect(new_source).to eq("'hi'")
       end
@@ -112,19 +112,19 @@ describe RuboCop::Cop::Style::UnneededPercentQ do
 
     context 'auto-correct' do
       it 'corrects a static string without quotes' do
-        new_source = autocorrect_source(cop, '%Q(hi)')
+        new_source = autocorrect_source('%Q(hi)')
 
         expect(new_source).to eq('"hi"')
       end
 
       it 'corrects a static string with only double quotes' do
-        new_source = autocorrect_source(cop, '%Q("hi")')
+        new_source = autocorrect_source('%Q("hi")')
 
         expect(new_source).to eq(%q('"hi"'))
       end
 
       it 'corrects a dynamic string without quotes' do
-        new_source = autocorrect_source(cop, "%Q(hi\#{4})")
+        new_source = autocorrect_source("%Q(hi\#{4})")
 
         expect(new_source).to eq(%("hi\#{4}"))
       end

--- a/spec/rubocop/cop/style/variable_interpolation_spec.rb
+++ b/spec/rubocop/cop/style/variable_interpolation_spec.rb
@@ -57,7 +57,7 @@ describe RuboCop::Cop::Style::VariableInterpolation do
   end
 
   it 'autocorrects by adding the missing {}' do
-    corrected = autocorrect_source(cop, ['"some #@var"'])
+    corrected = autocorrect_source(['"some #@var"'])
     expect(corrected).to eq '"some #{@var}"'
   end
 end

--- a/spec/rubocop/cop/style/variable_name_spec.rb
+++ b/spec/rubocop/cop/style/variable_name_spec.rb
@@ -25,7 +25,7 @@ describe RuboCop::Cop::Style::VariableName, :config do
     let(:cop_config) { { 'EnforcedStyle' => 'snake_case' } }
 
     it 'registers an offense for camel case in local variable name' do
-      inspect_source(cop, 'myLocal = 1')
+      inspect_source('myLocal = 1')
       expect(cop.offenses.size).to eq(1)
       expect(cop.highlights).to eq(['myLocal'])
       expect(cop.config_to_allow_offenses).to eq('EnforcedStyle' =>
@@ -33,7 +33,7 @@ describe RuboCop::Cop::Style::VariableName, :config do
     end
 
     it 'registers an offense for correct + opposite' do
-      inspect_source(cop, <<-RUBY.strip_indent)
+      inspect_source(<<-RUBY.strip_indent)
         my_local = 1
         myLocal = 1
       RUBY
@@ -76,7 +76,7 @@ describe RuboCop::Cop::Style::VariableName, :config do
     let(:cop_config) { { 'EnforcedStyle' => 'camelCase' } }
 
     it 'registers an offense for snake case in local variable name' do
-      inspect_source(cop, 'my_local = 1')
+      inspect_source('my_local = 1')
       expect(cop.offenses.size).to eq(1)
       expect(cop.highlights).to eq(['my_local'])
       expect(cop.config_to_allow_offenses).to eq('EnforcedStyle' =>
@@ -84,7 +84,7 @@ describe RuboCop::Cop::Style::VariableName, :config do
     end
 
     it 'registers an offense for opposite + correct' do
-      inspect_source(cop, <<-RUBY.strip_indent)
+      inspect_source(<<-RUBY.strip_indent)
         my_local = 1
         myLocal = 1
       RUBY
@@ -122,7 +122,7 @@ describe RuboCop::Cop::Style::VariableName, :config do
     let(:cop_config) { { 'EnforcedStyle' => 'other' } }
 
     it 'fails' do
-      expect { inspect_source(cop, 'a = 3') }
+      expect { inspect_source('a = 3') }
         .to raise_error(RuntimeError)
     end
   end

--- a/spec/rubocop/cop/style/variable_number_spec.rb
+++ b/spec/rubocop/cop/style/variable_number_spec.rb
@@ -5,7 +5,7 @@ describe RuboCop::Cop::Style::VariableNumber, :config do
 
   shared_examples :offense do |style, variable, style_to_allow_offenses|
     it "registers an offense for #{Array(variable).first} in #{style}" do
-      inspect_source(cop, Array(variable).map { |v| "#{v} = 1" }.join("\n"))
+      inspect_source(Array(variable).map { |v| "#{v} = 1" }.join("\n"))
 
       expect(cop.messages).to eq(["Use #{style} for variable numbers."])
       expect(cop.highlights).to eq(Array(variable)[0, 1])
@@ -21,7 +21,7 @@ describe RuboCop::Cop::Style::VariableNumber, :config do
 
   shared_examples :accepts do |style, variable|
     it "accepts #{variable} in #{style}" do
-      inspect_source(cop, "#{variable} = 1")
+      inspect_source("#{variable} = 1")
 
       expect(cop.offenses).to be_empty
     end
@@ -60,7 +60,7 @@ describe RuboCop::Cop::Style::VariableNumber, :config do
 
     it 'registers an offense for normal case numbering in method camel case
      parameter' do
-      inspect_source(cop, 'def method(funnyArg1); end')
+      inspect_source('def method(funnyArg1); end')
       expect(cop.offenses.size).to eq(1)
       expect(cop.highlights).to eq(['funnyArg1'])
     end
@@ -103,7 +103,7 @@ describe RuboCop::Cop::Style::VariableNumber, :config do
 
     it 'registers an offense for snake case numbering in method camel case
      parameter' do
-      inspect_source(cop, 'def method(funnyArg_1); end')
+      inspect_source('def method(funnyArg_1); end')
       expect(cop.offenses.size).to eq(1)
       expect(cop.highlights).to eq(['funnyArg_1'])
     end
@@ -150,14 +150,14 @@ describe RuboCop::Cop::Style::VariableNumber, :config do
 
     it 'registers an offense for snake case numbering in method camel case
      parameter' do
-      inspect_source(cop, 'def method(myArg_1); end')
+      inspect_source('def method(myArg_1); end')
       expect(cop.offenses.size).to eq(1)
       expect(cop.highlights).to eq(['myArg_1'])
     end
 
     it 'registers an offense for normal case numbering in method camel case
      parameter' do
-      inspect_source(cop, 'def method(myArg1); end')
+      inspect_source('def method(myArg1); end')
       expect(cop.offenses.size).to eq(1)
       expect(cop.highlights).to eq(['myArg1'])
     end

--- a/spec/rubocop/cop/style/when_then_spec.rb
+++ b/spec/rubocop/cop/style/when_then_spec.rb
@@ -34,7 +34,7 @@ describe RuboCop::Cop::Style::WhenThen do
   end
 
   it 'auto-corrects "when x;" with "when x then"' do
-    new_source = autocorrect_source(cop, <<-RUBY.strip_indent)
+    new_source = autocorrect_source(<<-RUBY.strip_indent)
       case a
       when b; c
       end

--- a/spec/rubocop/cop/style/while_until_do_spec.rb
+++ b/spec/rubocop/cop/style/while_until_do_spec.rb
@@ -42,7 +42,7 @@ describe RuboCop::Cop::Style::WhileUntilDo do
   end
 
   it 'auto-corrects the usage of "do" in multiline while' do
-    new_source = autocorrect_source(cop, <<-RUBY.strip_indent)
+    new_source = autocorrect_source(<<-RUBY.strip_indent)
       while cond do
       end
     RUBY
@@ -53,7 +53,7 @@ describe RuboCop::Cop::Style::WhileUntilDo do
   end
 
   it 'auto-corrects the usage of "do" in multiline until' do
-    new_source = autocorrect_source(cop, <<-RUBY.strip_indent)
+    new_source = autocorrect_source(<<-RUBY.strip_indent)
       until cond do
       end
     RUBY

--- a/spec/rubocop/cop/style/while_until_modifier_spec.rb
+++ b/spec/rubocop/cop/style/while_until_modifier_spec.rb
@@ -23,7 +23,7 @@ describe RuboCop::Cop::Style::WhileUntilModifier do
     end
 
     it 'does auto-correction' do
-      autocorrect_really_short(cop, 'while')
+      autocorrect_really_short('while')
     end
   end
 
@@ -63,7 +63,7 @@ describe RuboCop::Cop::Style::WhileUntilModifier do
     end
 
     it 'does auto-correction' do
-      corrected = autocorrect_source(cop, source)
+      corrected = autocorrect_source(source)
       expect(corrected).to eq "x = 0 while true\n"
     end
   end
@@ -74,7 +74,7 @@ describe RuboCop::Cop::Style::WhileUntilModifier do
     end
 
     it 'does auto-correction' do
-      autocorrect_really_short(cop, 'until')
+      autocorrect_really_short('until')
     end
   end
 

--- a/spec/rubocop/cop/style/word_array_spec.rb
+++ b/spec/rubocop/cop/style/word_array_spec.rb
@@ -66,7 +66,7 @@ describe RuboCop::Cop::Style::WordArray, :config do
     end
 
     it 'uses %W when autocorrecting strings with newlines and tabs' do
-      new_source = autocorrect_source(cop, %(["one\\n", "hi\\tthere"]))
+      new_source = autocorrect_source(%(["one\\n", "hi\\tthere"]))
       expect(new_source).to eq('%W(one\\n hi\\tthere)')
     end
 
@@ -118,18 +118,17 @@ describe RuboCop::Cop::Style::WordArray, :config do
     end
 
     it 'auto-corrects an array of words' do
-      new_source = autocorrect_source(cop, "['one', %q(two), 'three']")
+      new_source = autocorrect_source("['one', %q(two), 'three']")
       expect(new_source).to eq('%w(one two three)')
     end
 
     it 'auto-corrects an array of words and character constants' do
-      new_source = autocorrect_source(cop, '[%|one|, %Q(two), ?\n, ?\t]')
+      new_source = autocorrect_source('[%|one|, %Q(two), ?\n, ?\t]')
       expect(new_source).to eq('%W(one two \n \t)')
     end
 
     it 'keeps the line breaks in place after auto-correct' do
-      new_source = autocorrect_source(cop,
-                                      ["['one',",
+      new_source = autocorrect_source(["['one',",
                                        "'two', 'three']"])
       expect(new_source).to eq(['%w(one ',
                                 'two three)'].join("\n"))
@@ -194,17 +193,17 @@ describe RuboCop::Cop::Style::WordArray, :config do
     end
 
     it 'auto-corrects a %w() array' do
-      new_source = autocorrect_source(cop, '%w(one two three)')
+      new_source = autocorrect_source('%w(one two three)')
       expect(new_source).to eq("['one', 'two', 'three']")
     end
 
     it 'autocorrects a %w() array which uses single quotes' do
-      new_source = autocorrect_source(cop, "%w(one's two's three's)")
+      new_source = autocorrect_source("%w(one's two's three's)")
       expect(new_source).to eq('["one\'s", "two\'s", "three\'s"]')
     end
 
     it 'autocorrects a %W() array which uses escapes' do
-      new_source = autocorrect_source(cop, '%W(\\n \\t \\b \\v \\f)')
+      new_source = autocorrect_source('%W(\\n \\t \\b \\v \\f)')
       expect(new_source).to eq('["\n", "\t", "\b", "\v", "\f"]')
     end
 
@@ -247,7 +246,7 @@ describe RuboCop::Cop::Style::WordArray, :config do
     end
 
     it 'auto-corrects an array of email addresses' do
-      new_source = autocorrect_source(cop, "['a@example.com', 'b@example.com']")
+      new_source = autocorrect_source("['a@example.com', 'b@example.com']")
       expect(new_source).to eq('%w(a@example.com b@example.com)')
     end
   end
@@ -264,12 +263,12 @@ describe RuboCop::Cop::Style::WordArray, :config do
     let(:cop_config) { { 'MinSize' => 0, 'WordRegex' => /\S+/ } }
 
     it 'uses %W when autocorrecting strings with non-printable chars' do
-      new_source = autocorrect_source(cop, '["\x1f\x1e", "hello"]')
+      new_source = autocorrect_source('["\x1f\x1e", "hello"]')
       expect(new_source).to eq('%W(\u001F\u001E hello)')
     end
 
     it 'uses %w for strings which only appear to have an escape' do
-      new_source = autocorrect_source(cop, "['hi\\tthere', 'again\\n']")
+      new_source = autocorrect_source("['hi\\tthere', 'again\\n']")
       expect(new_source).to eq('%w(hi\\tthere again\\n)')
     end
   end
@@ -278,12 +277,12 @@ describe RuboCop::Cop::Style::WordArray, :config do
     let(:cop_config) { { 'MinSize' => 0, 'WordRegex' => /[\w \[\]\(\)]/ } }
 
     it "doesn't break when words contain whitespace" do
-      new_source = autocorrect_source(cop, "['hi there', 'something\telse']")
+      new_source = autocorrect_source("['hi there', 'something\telse']")
       expect(new_source).to eq("['hi there', 'something\telse']")
     end
 
     it "doesn't break when words contain delimiters" do
-      new_source = autocorrect_source(cop, "[')', ']', '(']")
+      new_source = autocorrect_source("[')', ']', '(']")
       expect(new_source).to eq('%w(\\) ] \\()')
     end
 
@@ -299,7 +298,7 @@ describe RuboCop::Cop::Style::WordArray, :config do
       end
 
       it 'autocorrects an array with delimiters' do
-        new_source = autocorrect_source(cop, "[')', ']', '(', '[']")
+        new_source = autocorrect_source("[')', ']', '(', '[']")
         expect(new_source).to eq('%w[) \\] ( \\[]')
       end
     end

--- a/spec/rubocop/cop/style/word_array_spec.rb
+++ b/spec/rubocop/cop/style/word_array_spec.rb
@@ -26,7 +26,7 @@ describe RuboCop::Cop::Style::WordArray, :config do
     end
 
     it 'registers an offense for arrays of single quoted strings' do
-      inspect_source(cop, "['one', 'two', 'three']")
+      inspect_source("['one', 'two', 'three']")
       expect(cop.offenses.size).to eq(1)
       expect(cop.messages).to eq(['Use `%w` or `%W` for an array of words.'])
       expect(cop.config_to_allow_offenses).to eq('EnforcedStyle' => 'brackets')
@@ -54,7 +54,7 @@ describe RuboCop::Cop::Style::WordArray, :config do
     end
 
     it 'registers an offense for strings with embedded newlines and tabs' do
-      inspect_source(cop, %(["one\n", "hi\tthere"]))
+      inspect_source(%(["one\n", "hi\tthere"]))
       expect(cop.offenses.size).to eq(1)
     end
 
@@ -106,7 +106,7 @@ describe RuboCop::Cop::Style::WordArray, :config do
     end
 
     it 'registers an offense for an array with comments outside of it' do
-      inspect_source(cop, <<-RUBY.strip_indent)
+      inspect_source(<<-RUBY.strip_indent)
         [
         "foo",
         "bar",
@@ -136,7 +136,7 @@ describe RuboCop::Cop::Style::WordArray, :config do
     end
 
     it 'detects right value of MinSize to use for --auto-gen-config' do
-      inspect_source(cop, <<-RUBY.strip_indent)
+      inspect_source(<<-RUBY.strip_indent)
         ['one', 'two', 'three']
         %w(a b c d)
       RUBY
@@ -147,7 +147,7 @@ describe RuboCop::Cop::Style::WordArray, :config do
     end
 
     it 'detects when the cop must be disabled to avoid offenses' do
-      inspect_source(cop, <<-RUBY.strip_indent)
+      inspect_source(<<-RUBY.strip_indent)
         ['one', 'two', 'three']
         %w(a b)
       RUBY
@@ -256,7 +256,7 @@ describe RuboCop::Cop::Style::WordArray, :config do
     let(:cop_config) { { 'WordRegex' => 'just_a_string' } }
 
     it 'still parses the code without raising an error' do
-      expect { inspect_source(cop, '') }.to_not raise_error
+      expect { inspect_source('') }.to_not raise_error
     end
   end
 

--- a/spec/rubocop/cop/style/yoda_condition_spec.rb
+++ b/spec/rubocop/cop/style/yoda_condition_spec.rb
@@ -33,7 +33,7 @@ describe RuboCop::Cop::Style::YodaCondition do
   shared_examples 'autocorrect' do |code, corrected|
     let(:source) { code }
     it 'autocorrects code' do
-      expect(autocorrect_source(cop, source)).to eq(corrected)
+      expect(autocorrect_source(source)).to eq(corrected)
     end
   end
 

--- a/spec/rubocop/cop/style/yoda_condition_spec.rb
+++ b/spec/rubocop/cop/style/yoda_condition_spec.rb
@@ -9,7 +9,7 @@ describe RuboCop::Cop::Style::YodaCondition do
   # needed because of usage of safe navigation operator
   let(:ruby_version) { 2.3 }
 
-  before { inspect_source(cop, source) }
+  before { inspect_source(source) }
 
   shared_examples 'accepts' do |code|
     let(:source) { code }

--- a/spec/rubocop/cop/style/zero_length_predicate_spec.rb
+++ b/spec/rubocop/cop/style/zero_length_predicate_spec.rb
@@ -4,7 +4,7 @@ describe RuboCop::Cop::Style::ZeroLengthPredicate do
   subject(:cop) { described_class.new }
 
   before do
-    inspect_source(cop, source)
+    inspect_source(source)
   end
 
   shared_examples 'code with offense' do |code, message, expected|

--- a/spec/rubocop/cop/style/zero_length_predicate_spec.rb
+++ b/spec/rubocop/cop/style/zero_length_predicate_spec.rb
@@ -18,7 +18,7 @@ describe RuboCop::Cop::Style::ZeroLengthPredicate do
       end
 
       it 'auto-corrects' do
-        expect(autocorrect_source(cop, code)).to eq expected
+        expect(autocorrect_source(code)).to eq expected
       end
     end
   end

--- a/spec/support/empty_lines_around_body_shared_examples.rb
+++ b/spec/support/empty_lines_around_body_shared_examples.rb
@@ -6,7 +6,7 @@ shared_examples_for 'empty_lines_around_class_or_module_body' do |type|
 
     context 'when first child is method' do
       it "requires blank line at the beginning and ending of #{type} body" do
-        inspect_source(cop, <<-RUBY.strip_indent)
+        inspect_source(<<-RUBY.strip_indent)
           #{type} SomeObject
 
             def do_something; end
@@ -27,7 +27,7 @@ shared_examples_for 'empty_lines_around_class_or_module_body' do |type|
 
         it "registers an offense for #{type} not beginning "\
           'and ending with a blank line' do
-          inspect_source(cop, source)
+          inspect_source(source)
           expect(cop.messages).to eq([missing_begin, missing_end])
         end
 
@@ -46,7 +46,7 @@ shared_examples_for 'empty_lines_around_class_or_module_body' do |type|
       context "when #{type} has a namespace" do
         it 'requires no empty lines for namespace but '\
           "requires blank line at the beginning and ending of #{type} body" do
-          inspect_source(cop, <<-RUBY.strip_indent)
+          inspect_source(<<-RUBY.strip_indent)
             #{type} Parent
               #{type} SomeObject
 
@@ -123,7 +123,7 @@ shared_examples_for 'empty_lines_around_class_or_module_body' do |type|
       it "does not require blank line at the beginning of #{type} body "\
         'but requires blank line before first def definition '\
         "and requires blank line at the end of #{type} body" do
-        inspect_source(cop, <<-RUBY.strip_indent)
+        inspect_source(<<-RUBY.strip_indent)
           #{type} SomeObject
             include Something
 
@@ -145,7 +145,7 @@ shared_examples_for 'empty_lines_around_class_or_module_body' do |type|
         end
 
         it "registers an offense for #{type} not ending with a blank line" do
-          inspect_source(cop, source)
+          inspect_source(source)
           expect(cop.messages).to eq([missing_def, missing_end])
         end
 
@@ -175,7 +175,7 @@ shared_examples_for 'empty_lines_around_class_or_module_body' do |type|
         end
 
         it "registers an offense for #{type} beginning with a blank line" do
-          inspect_source(cop, source)
+          inspect_source(source)
           expect(cop.messages).to eq([extra_begin, missing_def])
         end
 
@@ -206,7 +206,7 @@ shared_examples_for 'empty_lines_around_class_or_module_body' do |type|
         end
 
         it "registers an offense for #{type} beginning with a blank line" do
-          inspect_source(cop, source)
+          inspect_source(source)
           expect(cop.messages).to eq([extra_begin, missing_def])
         end
 
@@ -228,7 +228,7 @@ shared_examples_for 'empty_lines_around_class_or_module_body' do |type|
         it 'requires no empty lines for namespace '\
           "and does not require blank line at the beginning of #{type} body "\
           "but requires blank line at the end of #{type} body" do
-          inspect_source(cop, <<-RUBY.strip_indent)
+          inspect_source(<<-RUBY.strip_indent)
             #{type} Parent
               #{type} SomeObject
                 include Something
@@ -338,7 +338,7 @@ shared_examples_for 'empty_lines_around_class_or_module_body' do |type|
 
     context 'when namespace has multiple children' do
       it 'requires empty lines for namespace' do
-        inspect_source(cop, <<-RUBY.strip_indent)
+        inspect_source(<<-RUBY.strip_indent)
           #{type} Parent
 
             #{type} Mom
@@ -396,7 +396,7 @@ shared_examples_for 'empty_lines_around_class_or_module_body' do |type|
       end
 
       it 'registers offenses' do
-        inspect_source(cop, source)
+        inspect_source(source)
         expect(cop.messages).to eq([missing_type,
                                     missing_begin,
                                     missing_end,
@@ -431,7 +431,7 @@ shared_examples_for 'empty_lines_around_class_or_module_body' do |type|
         end
 
         it 'does NOT register offenses' do
-          inspect_source(cop, source)
+          inspect_source(source)
           expect(cop.messages).to eq([])
         end
       end
@@ -445,7 +445,7 @@ shared_examples_for 'empty_lines_around_class_or_module_body' do |type|
         end
 
         it 'does NOT register offenses' do
-          inspect_source(cop, source)
+          inspect_source(source)
           expect(cop.messages).to eq([])
         end
       end

--- a/spec/support/empty_lines_around_body_shared_examples.rb
+++ b/spec/support/empty_lines_around_body_shared_examples.rb
@@ -32,7 +32,7 @@ shared_examples_for 'empty_lines_around_class_or_module_body' do |type|
         end
 
         it 'autocorrects the offenses' do
-          new_source = autocorrect_source(cop, source)
+          new_source = autocorrect_source(source)
           expect(new_source).to eq(<<-RUBY.strip_indent)
             #{type} SomeObject
 
@@ -72,7 +72,7 @@ shared_examples_for 'empty_lines_around_class_or_module_body' do |type|
           end
 
           it 'autocorrects the offenses' do
-            new_source = autocorrect_source(cop, source)
+            new_source = autocorrect_source(source)
             expect(new_source).to eq(<<-RUBY.strip_indent)
               #{type} Parent
                 #{type} SomeObject
@@ -103,7 +103,7 @@ shared_examples_for 'empty_lines_around_class_or_module_body' do |type|
           end
 
           it 'autocorrects the offenses' do
-            new_source = autocorrect_source(cop, source)
+            new_source = autocorrect_source(source)
             expect(new_source).to eq(<<-RUBY.strip_indent)
               #{type} Parent
                 #{type} SomeObject
@@ -150,7 +150,7 @@ shared_examples_for 'empty_lines_around_class_or_module_body' do |type|
         end
 
         it 'autocorrects the offenses' do
-          new_source = autocorrect_source(cop, source)
+          new_source = autocorrect_source(source)
           expect(new_source).to eq(<<-RUBY.strip_indent)
             #{type} SomeObject
               include Something
@@ -180,7 +180,7 @@ shared_examples_for 'empty_lines_around_class_or_module_body' do |type|
         end
 
         it 'autocorrects the offenses' do
-          new_source = autocorrect_source(cop, source)
+          new_source = autocorrect_source(source)
           expect(new_source).to eq(<<-RUBY.strip_indent)
             #{type} SomeObject
               include Something
@@ -211,7 +211,7 @@ shared_examples_for 'empty_lines_around_class_or_module_body' do |type|
         end
 
         it 'autocorrects the offenses' do
-          new_source = autocorrect_source(cop, source)
+          new_source = autocorrect_source(source)
           expect(new_source).to eq(<<-RUBY.strip_indent)
             #{type} SomeObject
               include Something
@@ -256,7 +256,7 @@ shared_examples_for 'empty_lines_around_class_or_module_body' do |type|
           end
 
           it 'autocorrects the offenses' do
-            new_source = autocorrect_source(cop, source)
+            new_source = autocorrect_source(source)
             expect(new_source).to eq(<<-RUBY.strip_indent)
               #{type} Parent
                 #{type} SomeObject
@@ -290,7 +290,7 @@ shared_examples_for 'empty_lines_around_class_or_module_body' do |type|
           end
 
           it 'autocorrects the offenses' do
-            new_source = autocorrect_source(cop, source)
+            new_source = autocorrect_source(source)
             expect(new_source).to eq(<<-RUBY.strip_indent)
               #{type} Parent
                 #{type} SomeObject
@@ -319,7 +319,7 @@ shared_examples_for 'empty_lines_around_class_or_module_body' do |type|
           end
 
           it 'autocorrects the offenses' do
-            new_source = autocorrect_source(cop, source)
+            new_source = autocorrect_source(source)
             expect(new_source).to eq(<<-RUBY.strip_indent)
               #{type} Parent
                 #{type} SomeObject
@@ -370,7 +370,7 @@ shared_examples_for 'empty_lines_around_class_or_module_body' do |type|
       end
 
       it 'autocorrects the offenses' do
-        new_source = autocorrect_source(cop, source)
+        new_source = autocorrect_source(source)
         expect(new_source).to eq(<<-RUBY.strip_indent)
           #{type} Parent
             #{type} SomeObject
@@ -404,7 +404,7 @@ shared_examples_for 'empty_lines_around_class_or_module_body' do |type|
       end
 
       it 'autocorrects the offenses' do
-        new_source = autocorrect_source(cop, source)
+        new_source = autocorrect_source(source)
         expect(new_source).to eq(<<-RUBY.strip_indent)
           #{type} Parent
             URL = %q(http://example.com)

--- a/spec/support/multiline_literal_brace_layout_examples.rb
+++ b/spec/support/multiline_literal_brace_layout_examples.rb
@@ -61,13 +61,13 @@ shared_examples_for 'multiline literal brace layout' do
     let(:cop_config) { { 'EnforcedStyle' => 'same_line' } }
 
     it 'ignores heredocs that could share a last line' do
-      inspect_source(cop, construct(false, a, make_multi(heredoc), true))
+      inspect_source(construct(false, a, make_multi(heredoc), true))
 
       expect(cop.offenses).to be_empty
     end
 
     it 'detects heredoc structures that are safe to add to' do
-      inspect_source(cop, construct(false, a, make_multi(safe_heredoc), true))
+      inspect_source(construct(false, a, make_multi(safe_heredoc), true))
 
       expect(cop.offenses.size).to eq(1)
     end
@@ -87,20 +87,20 @@ shared_examples_for 'multiline literal brace layout' do
 
     context 'opening brace on same line as first element' do
       it 'allows closing brace on same line as last element' do
-        inspect_source(cop, construct(false, false))
+        inspect_source(construct(false, false))
 
         expect(cop.offenses).to be_empty
       end
 
       it 'allows closing brace on same line as last multiline element' do
-        inspect_source(cop, construct(false, a, make_multi(multi), false))
+        inspect_source(construct(false, a, make_multi(multi), false))
 
         expect(cop.offenses).to be_empty
       end
 
       it 'detects closing brace on different line from last element' do
         src = construct(false, true)
-        inspect_source(cop, src)
+        inspect_source(src)
 
         expect(cop.offenses.size).to eq(1)
         expect(cop.offenses.first.line)
@@ -122,20 +122,20 @@ shared_examples_for 'multiline literal brace layout' do
 
     context 'opening brace on separate line from first element' do
       it 'allows closing brace on separate line from last element' do
-        inspect_source(cop, construct(true, true))
+        inspect_source(construct(true, true))
 
         expect(cop.offenses).to be_empty
       end
 
       it 'allows closing brace on separate line from last multiline element' do
-        inspect_source(cop, construct(true, a, make_multi(multi), true))
+        inspect_source(construct(true, a, make_multi(multi), true))
 
         expect(cop.offenses).to be_empty
       end
 
       it 'detects closing brace on same line as last element' do
         src = construct(true, false)
-        inspect_source(cop, src)
+        inspect_source(src)
 
         expect(cop.offenses.size).to eq(1)
         expect(cop.offenses.first.line)
@@ -157,20 +157,20 @@ shared_examples_for 'multiline literal brace layout' do
 
     context 'opening brace on same line as first element' do
       it 'allows closing brace on different line from last element' do
-        inspect_source(cop, construct(false, true))
+        inspect_source(construct(false, true))
 
         expect(cop.offenses).to be_empty
       end
 
       it 'allows closing brace on different line from multi-line element' do
-        inspect_source(cop, construct(false, a, make_multi(multi), true))
+        inspect_source(construct(false, a, make_multi(multi), true))
 
         expect(cop.offenses).to be_empty
       end
 
       it 'detects closing brace on same line as last element' do
         src = construct(false, false)
-        inspect_source(cop, src)
+        inspect_source(src)
 
         expect(cop.offenses.size).to eq(1)
         expect(cop.offenses.first.line)
@@ -181,7 +181,7 @@ shared_examples_for 'multiline literal brace layout' do
 
       it 'detects closing brace on same line as last multiline element' do
         src = construct(false, a, make_multi(multi), false)
-        inspect_source(cop, src)
+        inspect_source(src)
 
         expect(cop.offenses.size).to eq(1)
         expect(cop.offenses.first.line)
@@ -202,20 +202,20 @@ shared_examples_for 'multiline literal brace layout' do
 
     context 'opening brace on separate line from first element' do
       it 'allows closing brace on separate line from last element' do
-        inspect_source(cop, construct(true, true))
+        inspect_source(construct(true, true))
 
         expect(cop.offenses).to be_empty
       end
 
       it 'allows closing brace on separate line from last multiline element' do
-        inspect_source(cop, construct(true, a, make_multi(multi), true))
+        inspect_source(construct(true, a, make_multi(multi), true))
 
         expect(cop.offenses).to be_empty
       end
 
       it 'detects closing brace on same line as last element' do
         src = construct(true, false)
-        inspect_source(cop, src)
+        inspect_source(src)
 
         expect(cop.offenses.size).to eq(1)
         expect(cop.offenses.first.line)
@@ -237,20 +237,20 @@ shared_examples_for 'multiline literal brace layout' do
 
     context 'opening brace on same line as first element' do
       it 'allows closing brace on same line from last element' do
-        inspect_source(cop, construct(false, false))
+        inspect_source(construct(false, false))
 
         expect(cop.offenses).to be_empty
       end
 
       it 'allows closing brace on same line as multi-line element' do
-        inspect_source(cop, construct(false, a, make_multi(multi), false))
+        inspect_source(construct(false, a, make_multi(multi), false))
 
         expect(cop.offenses).to be_empty
       end
 
       it 'detects closing brace on different line from last element' do
         src = construct(false, true)
-        inspect_source(cop, src)
+        inspect_source(src)
 
         expect(cop.offenses.size).to eq(1)
         expect(cop.offenses.first.line)
@@ -261,7 +261,7 @@ shared_examples_for 'multiline literal brace layout' do
 
       it 'detects closing brace on different line from multiline element' do
         src = construct(false, a, make_multi(multi), true)
-        inspect_source(cop, src)
+        inspect_source(src)
 
         expect(cop.offenses.size).to eq(1)
         expect(cop.offenses.first.line)
@@ -283,20 +283,20 @@ shared_examples_for 'multiline literal brace layout' do
 
     context 'opening brace on separate line from first element' do
       it 'allows closing brace on same line as last element' do
-        inspect_source(cop, construct(true, false))
+        inspect_source(construct(true, false))
 
         expect(cop.offenses).to be_empty
       end
 
       it 'allows closing brace on same line as last multiline element' do
-        inspect_source(cop, construct(true, a, make_multi(multi), false))
+        inspect_source(construct(true, a, make_multi(multi), false))
 
         expect(cop.offenses).to be_empty
       end
 
       it 'detects closing brace on different line from last element' do
         src = construct(true, true)
-        inspect_source(cop, src)
+        inspect_source(src)
         expect(cop.offenses.size).to eq(1)
         expect(cop.offenses.first.line)
           .to eq(src.length - (suffix.empty? ? 0 : 1))

--- a/spec/support/multiline_literal_brace_layout_examples.rb
+++ b/spec/support/multiline_literal_brace_layout_examples.rb
@@ -74,7 +74,7 @@ shared_examples_for 'multiline literal brace layout' do
 
     it 'auto-corrects safe heredoc offenses' do
       new_source = autocorrect_source(
-        cop, construct(false, a, make_multi(safe_heredoc), true)
+        construct(false, a, make_multi(safe_heredoc), true)
       )
 
       expect(new_source)
@@ -110,10 +110,10 @@ shared_examples_for 'multiline literal brace layout' do
       end
 
       it 'autocorrects closing brace on different line from last element' do
-        new_source = autocorrect_source(cop, ["#{prefix}#{open}#{a}, # a",
-                                              "#{b} # b",
-                                              close,
-                                              suffix])
+        new_source = autocorrect_source(["#{prefix}#{open}#{a}, # a",
+                                         "#{b} # b",
+                                         close,
+                                         suffix])
 
         expect(new_source)
           .to eq("#{prefix}#{open}#{a}, # a\n#{b}#{close} # b\n#{suffix}")
@@ -145,7 +145,7 @@ shared_examples_for 'multiline literal brace layout' do
       end
 
       it 'autocorrects closing brace on same line from last element' do
-        new_source = autocorrect_source(cop, construct(true, false))
+        new_source = autocorrect_source(construct(true, false))
 
         expect(new_source).to eq(construct(true, true).join("\n"))
       end
@@ -191,9 +191,9 @@ shared_examples_for 'multiline literal brace layout' do
       end
 
       it 'autocorrects closing brace on same line as last element' do
-        new_source = autocorrect_source(cop, ["#{prefix}#{open}#{a}, # a",
-                                              "#{b}#{close} # b",
-                                              suffix])
+        new_source = autocorrect_source(["#{prefix}#{open}#{a}, # a",
+                                         "#{b}#{close} # b",
+                                         suffix])
 
         expect(new_source)
           .to eq("#{prefix}#{open}#{a}, # a\n#{b}\n#{close} # b\n#{suffix}")
@@ -225,7 +225,7 @@ shared_examples_for 'multiline literal brace layout' do
       end
 
       it 'autocorrects closing brace on same line from last element' do
-        new_source = autocorrect_source(cop, construct(true, false))
+        new_source = autocorrect_source(construct(true, false))
 
         expect(new_source).to eq(construct(true, true).join("\n"))
       end
@@ -271,10 +271,10 @@ shared_examples_for 'multiline literal brace layout' do
       end
 
       it 'autocorrects closing brace on different line as last element' do
-        new_source = autocorrect_source(cop, ["#{prefix}#{open}#{a}, # a",
-                                              "#{b} # b",
-                                              close,
-                                              suffix])
+        new_source = autocorrect_source(["#{prefix}#{open}#{a}, # a",
+                                         "#{b} # b",
+                                         close,
+                                         suffix])
 
         expect(new_source)
           .to eq("#{prefix}#{open}#{a}, # a\n#{b}#{close} # b\n#{suffix}")
@@ -305,7 +305,7 @@ shared_examples_for 'multiline literal brace layout' do
       end
 
       it 'autocorrects closing brace on different line from last element' do
-        new_source = autocorrect_source(cop, construct(true, true))
+        new_source = autocorrect_source(construct(true, true))
 
         expect(new_source).to eq(construct(true, false).join("\n"))
       end

--- a/spec/support/multiline_literal_brace_layout_trailing_comma_examples.rb
+++ b/spec/support/multiline_literal_brace_layout_trailing_comma_examples.rb
@@ -14,10 +14,10 @@ shared_examples_for 'multiline literal brace layout trailing comma' do
     context 'opening brace on same line as first element' do
       context 'last element has a trailing comma' do
         it 'autocorrects closing brace on different line from last element' do
-          new_source = autocorrect_source(cop, ["#{prefix}#{open}#{a}, # a",
-                                                "#{b}, # b",
-                                                close,
-                                                suffix])
+          new_source = autocorrect_source(["#{prefix}#{open}#{a}, # a",
+                                           "#{b}, # b",
+                                           close,
+                                           suffix])
 
           expect(new_source)
             .to eq("#{prefix}#{open}#{a}, # a\n#{b},#{close} # b\n#{suffix}")
@@ -32,10 +32,10 @@ shared_examples_for 'multiline literal brace layout trailing comma' do
     context 'opening brace on same line as first element' do
       context 'last element has a trailing comma' do
         it 'autocorrects closing brace on different line as last element' do
-          new_source = autocorrect_source(cop, ["#{prefix}#{open}#{a}, # a",
-                                                "#{b}, # b",
-                                                close,
-                                                suffix])
+          new_source = autocorrect_source(["#{prefix}#{open}#{a}, # a",
+                                           "#{b}, # b",
+                                           close,
+                                           suffix])
 
           expect(new_source)
             .to eq("#{prefix}#{open}#{a}, # a\n#{b},#{close} # b\n#{suffix}")

--- a/spec/support/statement_modifier_helper.rb
+++ b/spec/support/statement_modifier_helper.rb
@@ -21,8 +21,8 @@ module StatementModifierHelper
     expect(cop.offenses.map { |o| o.location.source }).to eq([keyword])
   end
 
-  def autocorrect_really_short(cop, keyword)
-    corrected = autocorrect_source(cop, <<-RUBY.strip_indent)
+  def autocorrect_really_short(keyword)
+    corrected = autocorrect_source(<<-RUBY.strip_indent)
       #{keyword} a
         b
       end

--- a/spec/support/statement_modifier_helper.rb
+++ b/spec/support/statement_modifier_helper.rb
@@ -2,7 +2,7 @@
 
 module StatementModifierHelper
   def check_empty(cop, keyword)
-    inspect_source(cop, <<-RUBY.strip_indent)
+    inspect_source(<<-RUBY.strip_indent)
       #{keyword} cond
       end
     RUBY
@@ -10,7 +10,7 @@ module StatementModifierHelper
   end
 
   def check_really_short(cop, keyword)
-    inspect_source(cop, <<-RUBY.strip_indent)
+    inspect_source(<<-RUBY.strip_indent)
       #{keyword} a
         b
       end
@@ -36,7 +36,7 @@ module StatementModifierHelper
     body = 'b' * 37
     expect("  #{body} #{keyword} #{condition}".length).to eq(81)
 
-    inspect_source(cop, <<-RUBY.strip_margin('|'))
+    inspect_source(<<-RUBY.strip_margin('|'))
       |  #{keyword} #{condition}
       |    #{body}
       |  end
@@ -46,7 +46,7 @@ module StatementModifierHelper
   end
 
   def check_short_multiline(cop, keyword)
-    inspect_source(cop, <<-RUBY.strip_indent)
+    inspect_source(<<-RUBY.strip_indent)
       #{keyword} ENV['COVERAGE']
         require 'simplecov'
         SimpleCov.start


### PR DESCRIPTION
Modify `expect_offense` and `expect_no_offense` to follow the same contract as `inspect_source`. `inspect_source` takes in a file as the last argument. The `expect_offense` methods were taking in a filename.

It has been bugging me for a while now that we have to pass the cop into the inspection methods. It turns out that we don't need to be doing that. `cop` is available because it is defined as a `subject`.
