### PR TITLE
[FIX #4513] Style/YodaCondition configuration for equality only operators

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 * Add new `Style/HeredocDelimiters` cop. ([@drenmi][])
 * [#4153](https://github.com/bbatsov/rubocop/issues/4153): New cop `Lint/ReturnInVoidContext` checks for the use of a return with a value in a context where it will be ignored. ([@harold-s][])
 * Add auto-correct support to `Lint/ScriptPermission`. ([@rrosenblum][])
+* [#4514](https://github.com/bbatsov/rubocop/pull/4514): Add configuration options to `Style/YodaCondition` to support checking all comparison operators or equality operators only. ([@smakagon][])
 
 ### Bug fixes
 

--- a/config/default.yml
+++ b/config/default.yml
@@ -1293,6 +1293,14 @@ Style/WordArray:
   # The regular expression `WordRegex` decides what is considered a word.
   WordRegex: !ruby/regexp '/\A[\p{Word}\n\t]+\z/'
 
+Style/YodaCondition:
+  EnforcedStyle: all_comparison_operators
+  SupportedStyles:
+    # check all comparison operators
+    - all_comparison_operators
+    # check only equality operators: `!=` and `==`
+    - equality_operators_only
+
 #################### Metrics ###############################
 
 Metrics/AbcSize:

--- a/manual/cops_style.md
+++ b/manual/cops_style.md
@@ -4183,17 +4183,38 @@ way as they would be ordered in spoken English.
 ### Example
 
 ```ruby
+# EnforcedStyle: all_comparison_operators
+
 # bad
 99 == foo
-"bar" == foo
+"bar" != foo
 42 >= foo
-```
-```ruby
+10 < bar
+
 # good
 foo == 99
 foo == "bar"
-for <= 42
+foo <= 42
+bar > 10
 ```
+```ruby
+# EnforcedStyle: equality_operators_only
+
+# bad
+99 == foo
+"bar" != foo
+
+# good
+99 >= foo
+3 < a && a < 5
+```
+
+### Important attributes
+
+Attribute | Value
+--- | ---
+EnforcedStyle | all_comparison_operators
+SupportedStyles | all_comparison_operators, equality_operators_only
 
 ### References
 

--- a/spec/rubocop/cop/style/yoda_condition_spec.rb
+++ b/spec/rubocop/cop/style/yoda_condition_spec.rb
@@ -2,8 +2,9 @@
 
 require 'spec_helper'
 
-describe RuboCop::Cop::Style::YodaCondition do
-  subject(:cop) { described_class.new }
+describe RuboCop::Cop::Style::YodaCondition, :config do
+  let(:cop_config) { { 'EnforcedStyle' => 'all_comparison_operators' } }
+  subject(:cop) { described_class.new(config) }
   let(:error_message) { 'Reverse the order of the operands `%s`.' }
 
   # needed because of usage of safe navigation operator
@@ -86,5 +87,14 @@ describe RuboCop::Cop::Style::YodaCondition do
     it_behaves_like(
       'autocorrect', 'false === foo ? bar : baz', 'foo === false ? bar : baz'
     )
+  end
+
+  context 'with EnforcedStyle: equality_operators_only' do
+    let(:cop_config) { { 'EnforcedStyle' => 'equality_operators_only' } }
+    it_behaves_like 'accepts', '42 < bar'
+    it_behaves_like 'accepts', 'nil >= baz'
+    it_behaves_like 'accepts', '3 < a && a < 5'
+    it_behaves_like 'offense', '42 != answer'
+    it_behaves_like 'offense', 'false == foo'
   end
 end


### PR DESCRIPTION
This PR adds EnforcedStyles to Style/YodaCondition cop with the following options:

```
Style/YodaCondition:
  EnforcedStyle: all_comparison_operators
  SupportedStyles:
    # check all comparison operators
    - all_comparison_operators
    # check only equality operators: `!=` and `==`
    - equality_only
```
-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Used the same coding conventions as the rest of the project.
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] All tests(`rake spec`) are passing.
* [x] The new code doesn't generate RuboCop offenses that are checked by `rake internal_investigation`.
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Updated cop documentation with `rake generate_cops_documentation` (required only when you've added a new cop or changed the configuration/documentation of an existing cop).

[1]: http://chris.beams.io/posts/git-commit/
