### PR TITLE
Require forwardable library

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -28,6 +28,8 @@ script:
   - bundle exec codeclimate-test-reporter
   # Running YARD under jruby crashes so skip checking manual under jruby
   - ruby -e "exit 1 unless RUBY_PLATFORM == 'java'" || bundle exec rake generate_cops_documentation
+  # Check requiring libraries successfully. See https://github.com/bbatsov/rubocop/pull/4523#issuecomment-309136113
+  - "ruby -I lib -r rubocop -e 'exit 0'"
 addons:
   code_climate:
     repo_token: a11b66bfbb1acdf220d5cb317b2e945a986fd85adebe29a76d411ad6d74ec31f

--- a/lib/rubocop.rb
+++ b/lib/rubocop.rb
@@ -5,6 +5,7 @@ require 'rainbow'
 
 require 'English'
 require 'set'
+require 'forwardable'
 require 'powerpack/array/butfirst'
 require 'powerpack/enumerable/drop_last'
 require 'powerpack/hash/symbolize_keys'


### PR DESCRIPTION
In master branch, we can't execute `rubocop` command.

```bash
$ rubocop --help
/home/pocke/.gem/ruby/2.4.0/gems/rubocop-0.49.1/lib/rubocop/ast/node/mixin/collection_node.rb:7:in `<module:CollectionNode>': uninitialized constant RuboCop::AST::CollectionNode::Forwardable (NameError)
	from /home/pocke/.gem/ruby/2.4.0/gems/rubocop-0.49.1/lib/rubocop/ast/node/mixin/collection_node.rb:6:in `<module:AST>'
	from /home/pocke/.gem/ruby/2.4.0/gems/rubocop-0.49.1/lib/rubocop/ast/node/mixin/collection_node.rb:4:in `<module:RuboCop>'
	from /home/pocke/.gem/ruby/2.4.0/gems/rubocop-0.49.1/lib/rubocop/ast/node/mixin/collection_node.rb:3:in `<top (required)>'
	from /usr/lib/ruby/2.4.0/rubygems/core_ext/kernel_require.rb:68:in `require'
	from /usr/lib/ruby/2.4.0/rubygems/core_ext/kernel_require.rb:68:in `require'
	from /home/pocke/.gem/ruby/2.4.0/gems/rubocop-0.49.1/lib/rubocop.rb:26:in `<top (required)>'
	from /usr/lib/ruby/2.4.0/rubygems/core_ext/kernel_require.rb:68:in `require'
	from /usr/lib/ruby/2.4.0/rubygems/core_ext/kernel_require.rb:68:in `require'
	from /home/pocke/.gem/ruby/2.4.0/gems/rubocop-0.49.1/bin/rubocop:6:in `<top (required)>'
	from /home/pocke/.gem/ruby/2.4.0/bin/rubocop:22:in `load'
	from /home/pocke/.gem/ruby/2.4.0/bin/rubocop:22:in `<main>'
```

This change fixes the problem.

note: I guess RSpec or something requires forwardable library, so, our test does not fail.


-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Used the same coding conventions as the rest of the project.
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [ ] Added tests.
* [ ] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] All tests(`rake spec`) are passing.
* [x] The new code doesn't generate RuboCop offenses that are checked by `rake internal_investigation`.
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [ ] Updated cop documentation with `rake generate_cops_documentation` (required only when you've added a new cop or changed the configuration/documentation of an existing cop).

[1]: http://chris.beams.io/posts/git-commit/
