### PR TITLE
Fix regexp for checking comment config of `rubocop:disable all` in `Lint/UnneededDisable`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,7 +23,7 @@
 * [#4529](https://github.com/bbatsov/rubocop/pull/4529): Make `Lint/UnreachableCode` aware of `if` and `case`. ([@pocke][])
 * [#4469](https://github.com/bbatsov/rubocop/issues/4469): Include permissions in file cache. ([@pocke][])
 * [#4270](https://github.com/bbatsov/rubocop/issues/4270): Fix false positive in `Performance/RegexpMatch` for named captures. ([@pocke][])
-
+* [#4525](https://github.com/bbatsov/rubocop/pull/4525): Fix regexp for checking comment config of `rubocop:disable all` in `Lint/UnneededDisable`. ([@meganemura][])
 
 ### Changes
 

--- a/lib/rubocop/cop/lint/unneeded_disable.rb
+++ b/lib/rubocop/cop/lint/unneeded_disable.rb
@@ -137,7 +137,7 @@ module RuboCop
         end
 
         def all_disabled?(comment)
-          comment.text =~ /rubocop:disable\s+all\b/
+          comment.text =~ /rubocop\s*:\s*disable\s+all\b/
         end
 
         def ignore_offense?(disabled_ranges, line_range)

--- a/spec/rubocop/cop/lint/unneeded_disable_spec.rb
+++ b/spec/rubocop/cop/lint/unneeded_disable_spec.rb
@@ -258,7 +258,7 @@ describe RuboCop::Cop::Lint::UnneededDisable do
           end
 
           context 'all cops' do
-            let(:source) { '# rubocop:disable all' }
+            let(:source) { '# rubocop : disable all' }
             let(:cop_disabled_line_ranges) do
               {
                 'Metrics/MethodLength' => [1..Float::INFINITY],
@@ -270,7 +270,7 @@ describe RuboCop::Cop::Lint::UnneededDisable do
 
             it 'returns an offense' do
               expect(cop.messages).to eq(['Unnecessary disabling of all cops.'])
-              expect(cop.highlights).to eq(['# rubocop:disable all'])
+              expect(cop.highlights).to eq([source])
             end
           end
         end
@@ -371,7 +371,7 @@ describe RuboCop::Cop::Lint::UnneededDisable do
           end
 
           context 'all cops' do
-            let(:source) { '# rubocop:disable all' }
+            let(:source) { '# rubocop : disable all' }
             let(:cop_disabled_line_ranges) do
               {
                 'Metrics/MethodLength' => [1..Float::INFINITY],


### PR DESCRIPTION
regexp for checking comment config of `rubocop:disable all` in `Lint/UnneededDisable` does not match to some comment config styles such as `rubocop: disable`, `rubocop :disable` that are allowed in `RuboCop::CommentConfig::COMMENT_DIRECTIVE_REGEXP`.

It raises RuntimeError in `RuboCop::Cop::Lint::UnneededDisable#cop_range`.
This change fixes it.

```
meganemura@meganemura:~/src/github.com/meganemura/rubocop$ cat test.rb                                                                                                   [10/208]
# rubocop : disable all
```

```
meganemura@meganemura:~/src/github.com/meganemura/rubocop$ bundle exec rubocop test.rb
Inspecting 1 file


0 files inspected, no offenses detected
Couldn't find Bundler/DuplicatedGem in comment: # rubocop : disable all
/Users/meganemura/src/github.com/meganemura/rubocop/lib/rubocop/cop/lint/unneeded_disable.rb:187:in `cop_range'
/Users/meganemura/src/github.com/meganemura/rubocop/lib/rubocop/cop/lint/unneeded_disable.rb:174:in `block in add_offense_for_some_cops'
/Users/meganemura/.rbenv/versions/2.3.1/lib/ruby/2.3.0/set.rb:306:in `each_key'
/Users/meganemura/.rbenv/versions/2.3.1/lib/ruby/2.3.0/set.rb:306:in `each'
/Users/meganemura/src/github.com/meganemura/rubocop/lib/rubocop/cop/lint/unneeded_disable.rb:174:in `map'
/Users/meganemura/src/github.com/meganemura/rubocop/lib/rubocop/cop/lint/unneeded_disable.rb:174:in `add_offense_for_some_cops'
/Users/meganemura/src/github.com/meganemura/rubocop/lib/rubocop/cop/lint/unneeded_disable.rb:161:in `block in add_offenses'
/Users/meganemura/src/github.com/meganemura/rubocop/lib/rubocop/cop/lint/unneeded_disable.rb:156:in `each'
/Users/meganemura/src/github.com/meganemura/rubocop/lib/rubocop/cop/lint/unneeded_disable.rb:156:in `add_offenses'
/Users/meganemura/src/github.com/meganemura/rubocop/lib/rubocop/cop/lint/unneeded_disable.rb:28:in `check'
/Users/meganemura/src/github.com/meganemura/rubocop/lib/rubocop/runner.rb:134:in `add_unneeded_disables'
/Users/meganemura/src/github.com/meganemura/rubocop/lib/rubocop/runner.rb:112:in `block in file_offenses'
/Users/meganemura/src/github.com/meganemura/rubocop/lib/rubocop/runner.rb:121:in `file_offense_cache'
/Users/meganemura/src/github.com/meganemura/rubocop/lib/rubocop/runner.rb:109:in `file_offenses'
/Users/meganemura/src/github.com/meganemura/rubocop/lib/rubocop/runner.rb:100:in `process_file'
/Users/meganemura/src/github.com/meganemura/rubocop/lib/rubocop/runner.rb:78:in `block in each_inspected_file'
/Users/meganemura/src/github.com/meganemura/rubocop/lib/rubocop/runner.rb:75:in `each'
/Users/meganemura/src/github.com/meganemura/rubocop/lib/rubocop/runner.rb:75:in `reduce'
/Users/meganemura/src/github.com/meganemura/rubocop/lib/rubocop/runner.rb:75:in `each_inspected_file'
/Users/meganemura/src/github.com/meganemura/rubocop/lib/rubocop/runner.rb:67:in `inspect_files'
/Users/meganemura/src/github.com/meganemura/rubocop/lib/rubocop/runner.rb:39:in `run'
/Users/meganemura/src/github.com/meganemura/rubocop/lib/rubocop/cli.rb:82:in `execute_runner'
/Users/meganemura/src/github.com/meganemura/rubocop/lib/rubocop/cli.rb:28:in `run'
/Users/meganemura/src/github.com/meganemura/rubocop/bin/rubocop:13:in `block in <top (required)>'
/Users/meganemura/.rbenv/versions/2.3.1/lib/ruby/2.3.0/benchmark.rb:308:in `realtime'
/Users/meganemura/src/github.com/meganemura/rubocop/bin/rubocop:12:in `<top (required)>'
/Users/meganemura/src/github.com/meganemura/rubocop/vendor/bundle/ruby/2.3.0/bin/rubocop:23:in `load'
/Users/meganemura/src/github.com/meganemura/rubocop/vendor/bundle/ruby/2.3.0/bin/rubocop:23:in `<top (required)>'
/Users/meganemura/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/bundler-1.15.1/lib/bundler/cli/exec.rb:74:in `load'
/Users/meganemura/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/bundler-1.15.1/lib/bundler/cli/exec.rb:74:in `kernel_load'
/Users/meganemura/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/bundler-1.15.1/lib/bundler/cli/exec.rb:27:in `run'
/Users/meganemura/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/bundler-1.15.1/lib/bundler/cli.rb:360:in `exec'
/Users/meganemura/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/bundler-1.15.1/lib/bundler/vendor/thor/lib/thor/command.rb:27:in `run'
/Users/meganemura/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/bundler-1.15.1/lib/bundler/vendor/thor/lib/thor/invocation.rb:126:in `invoke_command'
/Users/meganemura/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/bundler-1.15.1/lib/bundler/vendor/thor/lib/thor.rb:369:in `dispatch'
/Users/meganemura/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/bundler-1.15.1/lib/bundler/cli.rb:20:in `dispatch'
/Users/meganemura/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/bundler-1.15.1/lib/bundler/vendor/thor/lib/thor/base.rb:444:in `start'
/Users/meganemura/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/bundler-1.15.1/lib/bundler/cli.rb:10:in `start'
/Users/meganemura/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/bundler-1.15.1/exe/bundle:35:in `block in <top (required)>'
/Users/meganemura/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/bundler-1.15.1/lib/bundler/friendly_errors.rb:121:in `with_friendly_errors'
/Users/meganemura/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/bundler-1.15.1/exe/bundle:27:in `<top (required)>'
/Users/meganemura/.rbenv/versions/2.3.1/bin/bundle:23:in `load'
/Users/meganemura/.rbenv/versions/2.3.1/bin/bundle:23:in `<main>'
meganemura@meganemura:~/src/github.com/meganemura/rubocop$ echo $?
2
```

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Used the same coding conventions as the rest of the project.
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] All tests(`rake spec`) are passing.
* [ ] The new code doesn't generate RuboCop offenses that are checked by `rake internal_investigation`.
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [ ] Updated cop documentation with `rake generate_cops_documentation` (required only when you've added a new cop or changed the configuration/documentation of an existing cop).

[1]: http://chris.beams.io/posts/git-commit/
