### PR TITLE
Make `Lint/UnreachableCode` aware of `if` and `case`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@
 * [#4418](https://github.com/bbatsov/rubocop/issues/4418): Register an offense in `Style/ConditionalAssignment` when the assignment line is the longest line, and it does not exceed the max line length. ([@rrosenblum][])
 * [#4491](https://github.com/bbatsov/rubocop/issues/4491): Prevent bad auto-correct in `Style/EmptyElse` for nested `if`. ([@pocke][])
 * [#4485](https://github.com/bbatsov/rubocop/pull/4485): Handle 304 status for remote config files. ([@daniloisr][])
+* [#4529](https://github.com/bbatsov/rubocop/pull/4529): Make `Lint/UnreachableCode` aware of `if` and `case`. ([@pocke][])
 
 ### Changes
 

--- a/lib/rubocop/cop/lint/unreachable_code.rb
+++ b/lib/rubocop/cop/lint/unreachable_code.rb
@@ -16,6 +16,17 @@ module RuboCop
       #     do_something
       #   end
       #
+      #   # bad
+      #
+      #   def some_method
+      #     if cond
+      #       return
+      #     else
+      #       return
+      #     end
+      #     do_something
+      #   end
+      #
       # @example
       #
       #   # good
@@ -26,25 +37,59 @@ module RuboCop
       class UnreachableCode < Cop
         MSG = 'Unreachable code detected.'.freeze
 
-        NODE_TYPES = %i[return next break retry redo].freeze
-        FLOW_COMMANDS = %i[throw raise fail].freeze
-
         def on_begin(node)
           expressions = *node
 
           expressions.each_cons(2) do |e1, e2|
-            next unless NODE_TYPES.include?(e1.type) || flow_command?(e1)
+            next unless flow_expression?(e1)
 
             add_offense(e2)
           end
         end
 
+        alias on_kwbegin on_begin
+
         private
 
-        def flow_command?(node)
-          return false unless node.send_type?
+        def_node_matcher :flow_command?, <<-PATTERN
+          {
+            return next break retry redo
+            (send
+             {nil (const {nil cbase} :Kernel)}
+             {:raise :fail :throw}
+             ...)
+          }
+        PATTERN
 
-          FLOW_COMMANDS.any? { |c| node.command?(c) }
+        def flow_expression?(node)
+          return true if flow_command?(node)
+          case node.type
+          when :begin, :kwbegin
+            expressions = *node
+            expressions.any? { |expr| flow_expression?(expr) }
+          when :if
+            check_if(node)
+          when :case
+            check_case(node)
+          else
+            false
+          end
+        end
+
+        def check_if(node)
+          if_branch = node.if_branch
+          else_branch = node.else_branch
+          if_branch && else_branch &&
+            flow_expression?(if_branch) && flow_expression?(else_branch)
+        end
+
+        def check_case(node)
+          else_branch = node.else_branch
+          return false unless else_branch
+          return false unless flow_expression?(else_branch)
+          node.when_branches.all? do |branch|
+            branch.body && flow_expression?(branch.body)
+          end
         end
       end
     end

--- a/manual/cops_lint.md
+++ b/manual/cops_lint.md
@@ -1562,7 +1562,7 @@ Whitelist | present?, blank?, presence, try
 
 Enabled by default | Supports autocorrection
 --- | ---
-Enabled | No
+Enabled | Yes
 
 This cop checks if a file which has a shebang line as
 its first line is granted execute permission.
@@ -1815,6 +1815,17 @@ statement in non-final position in *begin*(implicit) blocks.
 
 def some_method
   return
+  do_something
+end
+
+# bad
+
+def some_method
+  if cond
+    return
+  else
+    return
+  end
   do_something
 end
 ```

--- a/manual/cops_style.md
+++ b/manual/cops_style.md
@@ -1042,7 +1042,8 @@ def foo(bar)
 end
 
 def self.foo(bar); end
-
+```
+```ruby
 # EnforcedStyle: expanded
 
 # bad


### PR DESCRIPTION
Currently, `Lint/UnreachableCode` cop does not add offense to the following code.

```ruby
def some_method
  if cond
    return
  else
    return
  end
  do_something
end
```

However, the `do_something` is unreachable.

This change fixes the problem.


-----------------



* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Used the same coding conventions as the rest of the project.
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] All tests(`rake spec`) are passing.
* [x] The new code doesn't generate RuboCop offenses that are checked by `rake internal_investigation`.
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Updated cop documentation with `rake generate_cops_documentation` (required only when you've added a new cop or changed the configuration/documentation of an existing cop).

[1]: http://chris.beams.io/posts/git-commit/
