### PR TITLE
[Feature request] Support to ignore specified order gems

### DIFF
--- a/config/default.yml
+++ b/config/default.yml
@@ -1564,3 +1564,5 @@ Rails/Validation:
 
 Bundler/OrderedGems:
   TreatCommentsAsGroupSeparators: true
+  IgnoreGems:
+    - 'rails'

--- a/lib/rubocop/cop/bundler/ordered_gems.rb
+++ b/lib/rubocop/cop/bundler/ordered_gems.rb
@@ -40,6 +40,7 @@ module RuboCop
               gem_name(current),
               gem_name(previous)
             )
+            next if ignore_gem?(previous)
             register_offense(previous, current)
           end
         end
@@ -107,6 +108,10 @@ module RuboCop
         def_node_search :gem_declarations, <<-PATTERN
           (:send nil :gem ...)
         PATTERN
+
+        def ignore_gem?(node)
+          cop_config['IgnoreGems'].include?(gem_name(node))
+        end
       end
     end
   end

--- a/spec/rubocop/cop/bundler/ordered_gems_spec.rb
+++ b/spec/rubocop/cop/bundler/ordered_gems_spec.rb
@@ -32,15 +32,23 @@ describe RuboCop::Cop::Bundler::OrderedGems, :config do
       }
     end
 
-    let(:source) { <<-RUBY.strip_indent }
-      gem 'rails'
-      gem 'abc'
-      gem 'bcd'
-      gem 'cde'
-    RUBY
-
     it 'does not register any offenses' do
-      expect_no_offenses(source)
+      expect_no_offenses(<<-RUBY.strip_indent)
+        gem 'rails'
+        gem 'abc'
+        gem 'bcd'
+        gem 'cde'
+      RUBY
+    end
+
+    it 'register offenses' do
+      expect_offense(<<-RUBY.strip_indent)
+        gem 'rails'
+
+        gem 'b'
+        gem 'a'
+        ^^^^^^^ #{format(message, 'a', 'b')}
+      RUBY
     end
   end
 

--- a/spec/rubocop/cop/bundler/ordered_gems_spec.rb
+++ b/spec/rubocop/cop/bundler/ordered_gems_spec.rb
@@ -23,6 +23,27 @@ describe RuboCop::Cop::Bundler::OrderedGems, :config do
     end
   end
 
+  context 'When ignore gems were configured' do
+    let(:cop_config) do
+      {
+        'TreatCommentsAsGroupSeparators' => treat_comments_as_group_separators,
+        'Include' => nil,
+        'IgnoreGems' => ['rails']
+      }
+    end
+
+    let(:source) { <<-RUBY.strip_indent }
+      gem 'rails'
+      gem 'abc'
+      gem 'bcd'
+      gem 'cde'
+    RUBY
+
+    it 'does not register any offenses' do
+      expect_no_offenses(source)
+    end
+  end
+
   context 'When gems are not alphabetically sorted' do
     let(:source) { <<-RUBY.strip_indent }
       gem 'rubocop'


### PR DESCRIPTION
## Summary
[Feature request] 

In my opinion, When I was developing web application with ruby on rails, I'd like to the `gem 'rails'` definition to comes top of Gemfile.

E.g.
```rb
gem 'rails'

gem 'a'
gem 'b'
gem 'c'
# ...
```

and, i think this API has other use case too.
e.g. hanami or sinatra webapp development 🤔 💭 

What do you think about this?

-----------------

Before submitting the PR make sure the following are checked:

* [ ] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [ ] Used the same coding conventions as the rest of the project.
* [ ] Feature branch is up-to-date with `master` (if not - rebase it).
* [ ] Squashed related commits together.
* [ ] Added tests.
* [ ] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [ ] All tests(`rake spec`) are passing.
* [ ] The new code doesn't generate RuboCop offenses that are checked by `rake internal_investigation`.
* [ ] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [ ] Updated cop documentation with `rake generate_cops_documentation` (required only when you've added a new cop or changed the configuration/documentation of an existing cop).

[1]: http://chris.beams.io/posts/git-commit/
