### PR TITLE
Don't pluralize on -1 / -1.0.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@
 * Add auto-correct support to `Lint/ScriptPermission`. ([@rrosenblum][])
 * [#4514](https://github.com/bbatsov/rubocop/pull/4514): Add configuration options to `Style/YodaCondition` to support checking all comparison operators or equality operators only. ([@smakagon][])
 * Add new `Lint/BooleanSymbol` cop. ([@droptheplot][])
-* Make `Rails/PluralizationGrammar` use singular methods for `-1` / `-1.0` ([@promisedlandt])
+* Make `Rails/PluralizationGrammar` use singular methods for `-1` / `-1.0`. ([@promisedlandt][])
 
 ### Bug fixes
 
@@ -2845,3 +2845,4 @@
 [@timrogers]: https://github.com/timrogers
 [@harold-s]: https://github.com/harold-s
 [@daniloisr]: https://github.com/daniloisr
+[@promisedlandt]: https://github.com/promisedlandt

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 * Add auto-correct support to `Lint/ScriptPermission`. ([@rrosenblum][])
 * [#4514](https://github.com/bbatsov/rubocop/pull/4514): Add configuration options to `Style/YodaCondition` to support checking all comparison operators or equality operators only. ([@smakagon][])
 * Add new `Lint/BooleanSymbol` cop. ([@droptheplot][])
+* Make `Rails/PluralizationGrammar` use singular methods for `-1` / `-1.0` ([@promisedlandt])
 
 ### Bug fixes
 

--- a/lib/rubocop/cop/rails/pluralization_grammar.rb
+++ b/lib/rubocop/cop/rails/pluralization_grammar.rb
@@ -77,7 +77,7 @@ module RuboCop
         end
 
         def singular_receiver?(number)
-          number == 1
+          number.abs == 1
         end
 
         def plural_receiver?(number)

--- a/spec/rubocop/cop/rails/pluralization_grammar_spec.rb
+++ b/spec/rubocop/cop/rails/pluralization_grammar_spec.rb
@@ -51,7 +51,7 @@ describe RuboCop::Cop::Rails::PluralizationGrammar do
 
     context "when #{method_name} is called on any other literal number" do
       [-rand(2..1000),
-       rand(-1.0.next_float...0),
+       -rand(0...1.0),
        0,
        rand(0...1.0),
        rand(2..1000)].each do |plural_number|

--- a/spec/rubocop/cop/rails/pluralization_grammar_spec.rb
+++ b/spec/rubocop/cop/rails/pluralization_grammar_spec.rb
@@ -24,7 +24,7 @@ describe RuboCop::Cop::Rails::PluralizationGrammar do
       end
     end
 
-    [1, 1.0].each do |singular_literal|
+    [-1, -1.0, 1, 1.0].each do |singular_literal|
       context "when mis-pluralizing #{method_name} with #{singular_literal}" do
         let(:source) { "#{singular_literal}.#{method_name}s.ago" }
         it 'registers an offense' do
@@ -51,8 +51,7 @@ describe RuboCop::Cop::Rails::PluralizationGrammar do
 
     context "when #{method_name} is called on any other literal number" do
       [-rand(2..1000),
-       rand(-1.0...0),
-       -1,
+       rand(-1.0.next_float...0),
        0,
        rand(0...1.0),
        rand(2..1000)].each do |plural_number|


### PR DESCRIPTION
The `PluralizationGrammar` cop corrects `1.days` to `1.day`, but it corrects `-1.day` to `-1.days`.
I believe to be consistent, it should also do `-1.day`.

I did not add it to the examples as I think it is expeted behaviour, so no documentation update.

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [-] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Used the same coding conventions as the rest of the project.
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] All tests(`rake spec`) are passing.
* [x] The new code doesn't generate RuboCop offenses that are checked by `rake internal_investigation`.
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [-] Updated cop documentation with `rake generate_cops_documentation` (required only when you've added a new cop or changed the configuration/documentation of an existing cop).

[1]: http://chris.beams.io/posts/git-commit/
