### PR TITLE
Use `--parallel` option for internal_investigation task

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -27,7 +27,12 @@ task :coverage do
 end
 
 desc 'Run RuboCop over itself'
-RuboCop::RakeTask.new(:internal_investigation)
+RuboCop::RakeTask.new(:internal_investigation).tap do |task|
+  if RUBY_ENGINE == 'ruby' &&
+     RbConfig::CONFIG['host_os'] !~ /mswin|msys|mingw|cygwin|bccwin|wince|emc/
+    task.options = %w[--parallel]
+  end
+end
 
 task default: %i[spec ascii_spec internal_investigation]
 


### PR DESCRIPTION
This change parallelizes internal investigation in local computer and CI.

checklist:

- [x] It works with JRuby? -> Memory error
- [x] It works on Windows? -> `Process.fork` is not supported

So, parallelizing is disabled in the above environments.

Note:

I'm trying parallelizing our tests by using [test-queue](https://github.com/tmm1/test-queue) also.