### PR TITLE
Make `Lint/DuplicateMethods` aware of `attr_*` methods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,8 @@
 * [#4493](https://github.com/bbatsov/rubocop/pull/4493): Make `Lint/Void` cop aware of `Enumerable#each` and `for`. ([@pocke][])
 * [#4492](https://github.com/bbatsov/rubocop/pull/4492): Make `Lint/DuplicateMethods` aware of `alias` and `alias_method`. ([@pocke][])
 * [#4478](https://github.com/bbatsov/rubocop/issues/4478): Fix confusing message of `Performance/Caller` cop. ([@pocke][])
+* [#4543](https://github.com/bbatsov/rubocop/pull/4543): Make `Lint/DuplicateMethods` aware of `attr_*` methods. ([@pocke][])
+
 
 ## 0.49.1 (2017-05-29)
 

--- a/spec/rubocop/cop/lint/duplicate_methods_spec.rb
+++ b/spec/rubocop/cop/lint/duplicate_methods_spec.rb
@@ -291,6 +291,89 @@ describe RuboCop::Cop::Lint::DuplicateMethods do
         end
       RUBY
     end
+
+    it "registers an offense for duplicate attr_reader in #{type}" do
+      expect_offense(<<-RUBY, 'example.rb')
+        #{opening_line}
+          def something
+          end
+          attr_reader :something
+          ^^^^^^^^^^^ Method `A#something` is defined at both example.rb:2 and example.rb:4.
+        end
+      RUBY
+    end
+
+    it "registers an offense for duplicate attr_writer in #{type}" do
+      expect_offense(<<-RUBY, 'example.rb')
+        #{opening_line}
+          def something=(right)
+          end
+          attr_writer :something
+          ^^^^^^^^^^^ Method `A#something=` is defined at both example.rb:2 and example.rb:4.
+        end
+      RUBY
+    end
+
+    it "registers offenses for duplicate attr_accessor in #{type}" do
+      expect_offense(<<-RUBY, 'example.rb')
+        #{opening_line}
+          attr_accessor :something
+
+          def something
+          ^^^ Method `A#something` is defined at both example.rb:2 and example.rb:4.
+          end
+          def something=(right)
+          ^^^ Method `A#something=` is defined at both example.rb:2 and example.rb:6.
+          end
+        end
+      RUBY
+    end
+
+    it "registers an offense for duplicate attr in #{type}" do
+      expect_offense(<<-RUBY, 'example.rb')
+        #{opening_line}
+          def something
+          end
+          attr :something
+          ^^^^ Method `A#something` is defined at both example.rb:2 and example.rb:4.
+        end
+      RUBY
+    end
+
+    it "registers offenses for duplicate assignable attr in #{type}" do
+      expect_offense(<<-RUBY, 'example.rb')
+        #{opening_line}
+          attr :something, true
+
+          def something
+          ^^^ Method `A#something` is defined at both example.rb:2 and example.rb:4.
+          end
+          def something=(right)
+          ^^^ Method `A#something=` is defined at both example.rb:2 and example.rb:6.
+          end
+        end
+      RUBY
+    end
+
+    it "accepts for attr_reader and setter in #{type}" do
+      expect_no_offenses(<<-RUBY)
+        #{opening_line}
+          def something=(right)
+          end
+          attr_reader :something
+        end
+      RUBY
+    end
+
+    it "accepts for attr_writer and getter in #{type}" do
+      expect_no_offenses(<<-RUBY)
+        #{opening_line}
+          def something
+          end
+          attr_writer :something
+        end
+      RUBY
+    end
   end
 
   include_examples('in scope', 'class', 'class A')


### PR DESCRIPTION
`Lint/DuplicateMethods` cop does not offenses to the following code.

```ruby
class User
  attr_reader :name

  # This definition is unnecessary, but RuboCop does not detect it.
  def name
    @name
  end
end
```

This change fixes the problem.



-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Used the same coding conventions as the rest of the project.
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] All tests(`rake spec`) are passing.
* [x] The new code doesn't generate RuboCop offenses that are checked by `rake internal_investigation`.
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Updated cop documentation with `rake generate_cops_documentation` (required only when you've added a new cop or changed the configuration/documentation of an existing cop).

[1]: http://chris.beams.io/posts/git-commit/
