### PR TITLE
Parallelize RSpec by using test-queue on Travis CI

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,6 +16,7 @@ Gemfile.local
 
 # rspec
 /spec/examples.txt
+/.test_queue_stats
 
 # jeweler generated
 pkg

--- a/.travis.rb
+++ b/.travis.rb
@@ -1,0 +1,43 @@
+# frozen_string_literal: true
+
+require 'English'
+require 'benchmark'
+
+def jruby?
+  RUBY_ENGINE == 'jruby'
+end
+
+def master?
+  ENV['TRAVIS_BRANCH'] == 'master' && ENV['TRAVIS_PULL_REQUEST'] == 'false'
+end
+
+def test?
+  ENV['TASK'] != 'internal_investigation'
+end
+
+def sh!(command)
+  puts "$ #{command}"
+  time = Benchmark.realtime do
+    system(command)
+  end
+  puts "#{time} seconds"
+  puts
+  raise "`#{command}` is failed" unless $CHILD_STATUS.success?
+end
+
+# Run main task(RSpec or RuboCop).
+if master? || !test? || jruby? || RUBY_VERSION < '2.1.0'
+  sh!("bundle exec rake #{ENV['TASK']}")
+else
+  sh!("bundle exec rake parallel:#{ENV['TASK']}")
+end
+
+# Report test coverage
+sh!('bundle exec codeclimate-test-reporter') if master? && test?
+
+# Running YARD under jruby crashes so skip checking manual under jruby
+sh!('bundle exec rake generate_cops_documentation') unless jruby?
+
+# Check requiring libraries successfully.
+# See https://github.com/bbatsov/rubocop/pull/4523#issuecomment-309136113
+sh!("ruby -I lib -r rubocop -e 'exit 0'")

--- a/.travis.yml
+++ b/.travis.yml
@@ -30,12 +30,7 @@ before_install:
 install:
   - bundle install --retry=3
 script:
-  - 'bundle exec rake $TASK'
-  - ruby -e "exit 1 if ENV['TRAVIS_BRANCH'] == 'master' && ENV['TASK'] != 'internal_investigation'" || bundle exec codeclimate-test-reporter
-  # Running YARD under jruby crashes so skip checking manual under jruby
-  - ruby -e "exit 1 unless RUBY_PLATFORM == 'java'" || bundle exec rake generate_cops_documentation
-  # Check requiring libraries successfully. See https://github.com/bbatsov/rubocop/pull/4523#issuecomment-309136113
-  - "ruby -I lib -r rubocop -e 'exit 0'"
+  - ruby .travis.rb
 addons:
   code_climate:
     repo_token: a11b66bfbb1acdf220d5cb317b2e945a986fd85adebe29a76d411ad6d74ec31f

--- a/Gemfile
+++ b/Gemfile
@@ -8,6 +8,7 @@ gem 'pry'
 gem 'rake', '~> 12.0'
 gem 'rspec', '~> 3.6.0'
 gem 'simplecov', '~> 0.10'
+gem 'test-queue' if RUBY_VERSION >= '2.1.0'
 gem 'yard', '~> 0.9'
 
 group :test do

--- a/Rakefile
+++ b/Rakefile
@@ -20,6 +20,18 @@ Dir['tasks/**/*.rake'].each { |t| load t }
 RSpec::Core::RakeTask.new(:spec) { |t| t.ruby_opts = '-E UTF-8' }
 RSpec::Core::RakeTask.new(:ascii_spec) { |t| t.ruby_opts = '-E ASCII' }
 
+namespace :parallel do
+  desc 'Run RSpec in parallel'
+  task :spec do
+    sh('rspec-queue spec/')
+  end
+
+  desc 'Run RSpec in parallel with ASCII encoding'
+  task :ascii_spec do
+    sh('RUBYOPT="-E ASCII" rspec-queue spec/')
+  end
+end
+
 desc 'Run RSpec with code coverage'
 task :coverage do
   ENV['COVERAGE'] = 'true'

--- a/spec/rubocop/config_spec.rb
+++ b/spec/rubocop/config_spec.rb
@@ -592,7 +592,7 @@ describe RuboCop::Config do
       end
 
       before do
-        allow(File).to receive(:file?).with('.ruby-version')
+        allow(File).to receive(:file?).and_call_original
       end
 
       it 'uses TargetRubyVersion' do

--- a/spec/rubocop/formatter/formatter_set_spec.rb
+++ b/spec/rubocop/formatter/formatter_set_spec.rb
@@ -83,6 +83,15 @@ module RuboCop
           formatter_set.add_formatter('simple')
         end
 
+        around do |example|
+          begin
+            $stdout = StringIO.new
+            example.run
+          ensure
+            $stdout = STDOUT
+          end
+        end
+
         it 'closes all output files' do
           formatter_set.close_output_files
           formatter_set[0..1].each do |formatter|

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -26,8 +26,11 @@ RSpec.configure do |config|
   # to individual examples or groups you care about by tagging them with
   # `:focus` metadata. When nothing is tagged with `:focus`, all examples
   # get run.
-  config.filter_run :focus
-  config.run_all_when_everything_filtered = true
+  unless defined?(::TestQueue)
+    # See. https://github.com/tmm1/test-queue/issues/60#issuecomment-281948929
+    config.filter_run :focus
+    config.run_all_when_everything_filtered = true
+  end
 
   config.example_status_persistence_file_path = 'spec/examples.txt'
 

--- a/spec/support/coverage.rb
+++ b/spec/support/coverage.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
-if ENV['TRAVIS'] || ENV['COVERAGE']
+on_master = ENV['TRAVIS_BRANCH'] == 'master' &&
+            ENV['TRAVIS_PULL_REQUEST'] == 'false'
+if on_master || ENV['COVERAGE']
   require 'simplecov'
   SimpleCov.add_filter '/spec/'
   SimpleCov.add_filter '/vendor/bundle/'


### PR DESCRIPTION
This change parallelizes RSpec in Travis CI / local machine.

In Travis CI, the following jobs are parallelized.

- not jruby
- not on master branch( this means pull-request only)
  - Because coverage is calculated on master branch. I tried to work the coverage with test-queue, but it is very difficult 😢 
- Ruby 2.1.0 or higher
  - Because test-queue does not support Ruby 2.0.


In local machine, we can use `rake parallel:spec` and `rake parallel:ascii_spec`.




