### PR TITLE
Improve performance of `rake generate_cops_documentation`

### DIFF
--- a/tasks/cops_documentation.rake
+++ b/tasks/cops_documentation.rake
@@ -3,9 +3,13 @@
 require 'yard'
 require 'rubocop'
 
-desc 'Generate docs of all cops departments'
+YARD::Rake::YardocTask.new(:yard_for_generate_documentation) do |task|
+  task.files = ['lib/rubocop/cop/*/*.rb']
+  task.options = ['--no-output']
+end
 
-task generate_cops_documentation: :yard do
+desc 'Generate docs of all cops departments'
+task generate_cops_documentation: :yard_for_generate_documentation do
   def cops_of_department(cops, department)
     cops.with_department(department).sort!
   end


### PR DESCRIPTION
- Specify yard target files
- Add `--no-output` option.
  - `Only generate .yardoc database, no documentation.` (`yard doc --help`)

Benchmark
============

```bash
$ rm -rf .yardoc/  # Clear cache
$ time bundle exec rake generate_cops_documentation
```

|     | before | after |
| --- | -----  | ----  |
| 1st | 29.35  | 3.64  |
| 2nd | 32.40  | 3.67  |
| 3rd | 31.36  | 3.66  |
| avg | 31.04  | 3.66  |

Faster around 8.5x.

