### PR TITLE
Make `Style/VariableName` aware of optarg, kwarg and other arguments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@
 * [#4469](https://github.com/bbatsov/rubocop/issues/4469): Include permissions in file cache. ([@pocke][])
 * [#4270](https://github.com/bbatsov/rubocop/issues/4270): Fix false positive in `Performance/RegexpMatch` for named captures. ([@pocke][])
 * [#4525](https://github.com/bbatsov/rubocop/pull/4525): Fix regexp for checking comment config of `rubocop:disable all` in `Lint/UnneededDisable`. ([@meganemura][])
+* [#4555](https://github.com/bbatsov/rubocop/issues/4555): Make `Style/VariableName` aware of optarg, kwarg and other arguments. ([@pocke][])
 
 ### Changes
 

--- a/lib/rubocop/cop/style/variable_name.rb
+++ b/lib/rubocop/cop/style/variable_name.rb
@@ -10,23 +10,19 @@ module RuboCop
 
         def on_lvasgn(node)
           name, = *node
+          return unless name
           check_name(node, name, node.loc.name)
         end
 
-        def on_ivasgn(node)
-          name, = *node
-          check_name(node, name, node.loc.name)
-        end
-
-        def on_cvasgn(node)
-          name, = *node
-          check_name(node, name, node.loc.name)
-        end
-
-        def on_arg(node)
-          name, = *node
-          check_name(node, name, node.loc.name)
-        end
+        alias on_ivasgn    on_lvasgn
+        alias on_cvasgn    on_lvasgn
+        alias on_arg       on_lvasgn
+        alias on_optarg    on_lvasgn
+        alias on_restarg   on_lvasgn
+        alias on_kwoptarg  on_lvasgn
+        alias on_kwarg     on_lvasgn
+        alias on_kwrestarg on_lvasgn
+        alias on_blockarg  on_lvasgn
 
         private
 

--- a/manual/cops_style.md
+++ b/manual/cops_style.md
@@ -713,7 +713,7 @@ class/singleton methods are checked.
 
 Enabled by default | Supports autocorrection
 --- | ---
-Enabled | No
+Enabled | Yes
 
 This cop checks for places where the `#__dir__` method can replace more
 complex constructs to retrieve a canonicalized absolute path to the
@@ -1492,7 +1492,7 @@ EOS
 
 Attribute | Value
 --- | ---
-Blacklist | END, (?i-mx:EO[A-Z]{1})
+Blacklist | END, (?-mix:EO[A-Z]{1})
 
 ### References
 

--- a/spec/rubocop/cop/style/variable_name_spec.rb
+++ b/spec/rubocop/cop/style/variable_name_spec.rb
@@ -69,6 +69,20 @@ describe RuboCop::Cop::Style::VariableName, :config do
       RUBY
     end
 
+    it 'registers offenses for method arguments' do
+      expect_offense(<<-RUBY.strip_indent)
+        def f(someArg, optArg = 1, *restArg, argAfterRest, kwOptArg: 1, kwArg:, **kwRest, &blockArg); end
+              ^^^^^^^ Use snake_case for variable names.
+                       ^^^^^^ Use snake_case for variable names.
+                                    ^^^^^^^ Use snake_case for variable names.
+                                             ^^^^^^^^^^^^ Use snake_case for variable names.
+                                                           ^^^^^^^^ Use snake_case for variable names.
+                                                                        ^^^^^ Use snake_case for variable names.
+                                                                                  ^^^^^^ Use snake_case for variable names.
+                                                                                           ^^^^^^^^ Use snake_case for variable names.
+      RUBY
+    end
+
     include_examples 'always accepted'
   end
 
@@ -113,6 +127,20 @@ describe RuboCop::Cop::Style::VariableName, :config do
 
     it 'accepts camel case local variables marked as unused' do
       expect_no_offenses('_myLocal = 1')
+    end
+
+    it 'registers offenses for method arguments' do
+      expect_offense(<<-RUBY.strip_indent)
+        def f(some_arg, opt_arg = 1, *rest_arg, arg_after_rest, kw_opt_arg: 1, kw_arg:, **kw_rest, &block_arg); end
+              ^^^^^^^^ Use camelCase for variable names.
+                        ^^^^^^^ Use camelCase for variable names.
+                                      ^^^^^^^^ Use camelCase for variable names.
+                                                ^^^^^^^^^^^^^^ Use camelCase for variable names.
+                                                                ^^^^^^^^^^ Use camelCase for variable names.
+                                                                               ^^^^^^ Use camelCase for variable names.
+                                                                                          ^^^^^^^ Use camelCase for variable names.
+                                                                                                    ^^^^^^^^^ Use camelCase for variable names.
+      RUBY
     end
 
     include_examples 'always accepted'


### PR DESCRIPTION
Fix #4555 

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Used the same coding conventions as the rest of the project.
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] All tests(`rake spec`) are passing.
* [x] The new code doesn't generate RuboCop offenses that are checked by `rake internal_investigation`.
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Updated cop documentation with `rake generate_cops_documentation` (required only when you've added a new cop or changed the configuration/documentation of an existing cop).

[1]: http://chris.beams.io/posts/git-commit/
