### PR TITLE
Fix link to custom formatters

### DIFF
--- a/manual/formatters.md
+++ b/manual/formatters.md
@@ -39,7 +39,7 @@ $ rubocop --output result.txt --format simple
 #           default format        $stdout
 ```
 
-You can also load [custom formatters](#custom-formatters).
+You can also load [custom formatters](extensions.md#custom-formatters).
 
 ### Progress Formatter (default)
 


### PR DESCRIPTION
The link to custom formatters on the Formatters page was broken - it was an anchor link to a header that didn't exist on that page.