### PR TITLE
Make the `new_cop` task add a require directive for the cop file

### DIFF
--- a/lib/rubocop/cop/generator.rb
+++ b/lib/rubocop/cop/generator.rb
@@ -92,18 +92,21 @@ module RuboCop
         write_unless_file_exists(spec_path, generated_spec)
       end
 
+      def inject_require
+        RequireFileInjector.new(require_path).inject
+      end
+
       def todo
         <<-TODO.strip_indent
-          created
-          - #{source_path}
-          - #{spec_path}
+          Files created:
+            - #{source_path}
+            - #{spec_path}
 
-          Do 4 steps
-          - Add an entry to `New feature` section in CHANGELOG.md
-            - e.g. Add new `#{badge.cop_name}` cop. ([@your_id][])
-          - Add `require '#{require_path}'` into lib/rubocop.rb
-          - Add an entry into config/enabled.yml or config/disabled.yml
-          - Implement a new cop to the generated file!
+          Do 3 steps:
+            1. Add an entry to the "New features" section in CHANGELOG.md,
+               e.g. "Add new `#{badge.cop_name}` cop. ([@your_id][])"
+            2. Add an entry into config/enabled.yml or config/disabled.yml
+            3. Implement your new cop in the generated file!
         TODO
       end
 
@@ -158,6 +161,67 @@ module RuboCop
           .gsub(/([^A-Z])([A-Z]+)/, '\1_\2')
           .gsub(/([A-Z])([A-Z][^A-Z\d]+)/, '\1_\2')
           .downcase
+      end
+
+      # A class that injects a require directive into the root RuboCop file.
+      # It looks for other directives that require files in the same (cop)
+      # namespace and injects the provided one in alpha
+      class RequireFileInjector
+        REQUIRE_PATH = /require ['"](.+)['"]/
+
+        def initialize(require_path)
+          @require_path    = require_path
+          @require_entries = File.readlines(rubocop_root_file_path)
+        end
+
+        def inject
+          return if require_exists? || !target_line
+
+          File.write(rubocop_root_file_path, updated_directives)
+        end
+
+        private
+
+        attr_reader :require_path, :require_entries
+
+        def rubocop_root_file_path
+          File.join('lib', 'rubocop.rb')
+        end
+
+        def require_exists?
+          require_entries.any? do |entry|
+            entry == injectable_require_directive
+          end
+        end
+
+        def updated_directives
+          require_entries.insert(target_line,
+                                 injectable_require_directive).join
+        end
+
+        def target_line
+          @target_line ||= begin
+            inject_parts = require_path_fragments(injectable_require_directive)
+
+            require_entries.find.with_index do |entry, index|
+              current_entry_parts = require_path_fragments(entry)
+
+              next unless inject_parts[0..-2] == current_entry_parts[0..-2]
+
+              break index if inject_parts.last < current_entry_parts.last
+            end
+          end
+        end
+
+        def require_path_fragments(require_directove)
+          path = require_directove.match(REQUIRE_PATH)
+
+          path ? path.captures.first.split('/') : []
+        end
+
+        def injectable_require_directive
+          "require '#{require_path}'\n"
+        end
       end
     end
   end

--- a/spec/rubocop/cop/generator_spec.rb
+++ b/spec/rubocop/cop/generator_spec.rb
@@ -1,127 +1,269 @@
 # frozen_string_literal: true
 
 RSpec.describe RuboCop::Cop::Generator do
-  subject(:generator) { described_class.new('Style/FakeCop') }
+  subject(:generator)  { described_class.new(cop_identifier) }
+  let(:cop_identifier) { 'Style/FakeCop' }
 
   before do
     allow(File).to receive(:write)
   end
 
-  it 'generates a helpful source file with the name filled in' do
-    generated_source = <<-RUBY.strip_indent
-      # frozen_string_literal: true
+  describe '#write_source' do
+    it 'generates a helpful source file with the name filled in' do
+      generated_source = <<-RUBY.strip_indent
+        # frozen_string_literal: true
 
-      # TODO: when finished, run `rake generate_cops_documentation` to update the docs
-      module RuboCop
-        module Cop
-          module Style
-            # TODO: Write cop description and example of bad / good code.
-            #
-            # @example
-            #   # bad
-            #   bad_method()
-            #
-            #   # bad
-            #   bad_method(args)
-            #
-            #   # good
-            #   good_method()
-            #
-            #   # good
-            #   good_method(args)
-            class FakeCop < Cop
-              # TODO: Implement the cop into here.
+        # TODO: when finished, run `rake generate_cops_documentation` to update the docs
+        module RuboCop
+          module Cop
+            module Style
+              # TODO: Write cop description and example of bad / good code.
               #
-              # In many cases, you can use a node matcher for matching node pattern.
-              # See. https://github.com/bbatsov/rubocop/blob/master/lib/rubocop/node_pattern.rb
+              # @example
+              #   # bad
+              #   bad_method()
               #
-              # For example
-              MSG = 'Message of FakeCop'.freeze
+              #   # bad
+              #   bad_method(args)
+              #
+              #   # good
+              #   good_method()
+              #
+              #   # good
+              #   good_method(args)
+              class FakeCop < Cop
+                # TODO: Implement the cop into here.
+                #
+                # In many cases, you can use a node matcher for matching node pattern.
+                # See. https://github.com/bbatsov/rubocop/blob/master/lib/rubocop/node_pattern.rb
+                #
+                # For example
+                MSG = 'Message of FakeCop'.freeze
 
-              def_node_matcher :bad_method?, <<-PATTERN
-                (send nil :bad_method ...)
-              PATTERN
+                def_node_matcher :bad_method?, <<-PATTERN
+                  (send nil :bad_method ...)
+                PATTERN
 
-              def on_send(node)
-                return unless bad_method?(node)
-                add_offense(node)
+                def on_send(node)
+                  return unless bad_method?(node)
+                  add_offense(node)
+                end
               end
             end
           end
         end
-      end
-    RUBY
+      RUBY
 
-    generator.write_source
+      generator.write_source
 
-    expect(File)
-      .to have_received(:write)
-      .with('lib/rubocop/cop/style/fake_cop.rb', generated_source)
-  end
+      expect(File)
+        .to have_received(:write)
+        .with('lib/rubocop/cop/style/fake_cop.rb', generated_source)
+    end
 
-  it 'generates a helpful starting spec file with the class filled in' do
-    generated_source = <<-SPEC.strip_indent
-      # frozen_string_literal: true
+    it 'refuses to overwrite existing files' do
+      new_cop = described_class.new('Layout/Tab')
 
-      describe RuboCop::Cop::Style::FakeCop do
-        let(:config) { RuboCop::Config.new }
-        subject(:cop) { described_class.new(config) }
-
-        # TODO: Write test code
-        #
-        # For example
-        it 'registers an offense when using `#bad_method`' do
-          expect_offense(<<-RUBY.strip_indent)
-            bad_method
-            ^^^^^^^^^^ Use `#good_method` instead of `#bad_method`.
-          RUBY
-        end
-
-        it 'does not register an offense when using `#good_method`' do
-          expect_no_offenses(<<-RUBY.strip_indent)
-            good_method
-          RUBY
-        end
-      end
-    SPEC
-
-    generator.write_spec
-
-    expect(File)
-      .to have_received(:write)
-      .with('spec/rubocop/cop/style/fake_cop_spec.rb', generated_source)
-  end
-
-  it 'provides a checklist for implementing the cop' do
-    expect(generator.todo).to eql(<<-TODO.strip_indent)
-      created
-      - lib/rubocop/cop/style/fake_cop.rb
-      - spec/rubocop/cop/style/fake_cop_spec.rb
-
-      Do 4 steps
-      - Add an entry to `New feature` section in CHANGELOG.md
-        - e.g. Add new `FakeCop` cop. ([@your_id][])
-      - Add `require 'rubocop/cop/style/fake_cop'` into lib/rubocop.rb
-      - Add an entry into config/enabled.yml or config/disabled.yml
-      - Implement a new cop to the generated file!
-    TODO
-  end
-
-  it 'does not accept an unqualified cop' do
-    expect { described_class.new('FakeCop') }
-      .to raise_error(ArgumentError)
-      .with_message('Specify a cop name with Department/Name style')
-  end
-
-  it 'refuses to overwrite existing files' do
-    new_cop = described_class.new('Layout/Tab')
-
-    aggregate_failures('Overwrite checks') do
       expect { new_cop.write_source }
         .to raise_error('lib/rubocop/cop/layout/tab.rb already exists!')
+    end
+  end
+
+  describe '#write_spec' do
+    it 'generates a helpful starting spec file with the class filled in' do
+      generated_source = <<-SPEC.strip_indent
+        # frozen_string_literal: true
+
+        describe RuboCop::Cop::Style::FakeCop do
+          let(:config) { RuboCop::Config.new }
+          subject(:cop) { described_class.new(config) }
+
+          # TODO: Write test code
+          #
+          # For example
+          it 'registers an offense when using `#bad_method`' do
+            expect_offense(<<-RUBY.strip_indent)
+              bad_method
+              ^^^^^^^^^^ Use `#good_method` instead of `#bad_method`.
+            RUBY
+          end
+
+          it 'does not register an offense when using `#good_method`' do
+            expect_no_offenses(<<-RUBY.strip_indent)
+              good_method
+            RUBY
+          end
+        end
+      SPEC
+
+      generator.write_spec
+
+      expect(File)
+        .to have_received(:write)
+        .with('spec/rubocop/cop/style/fake_cop_spec.rb', generated_source)
+    end
+
+    it 'refuses to overwrite existing files' do
+      new_cop = described_class.new('Layout/Tab')
 
       expect { new_cop.write_spec }
         .to raise_error('spec/rubocop/cop/layout/tab_spec.rb already exists!')
+    end
+  end
+
+  describe '#todo' do
+    it 'provides a checklist for implementing the cop' do
+      expect(generator.todo).to eql(<<-TODO.strip_indent)
+        Files created:
+          - lib/rubocop/cop/style/fake_cop.rb
+          - spec/rubocop/cop/style/fake_cop_spec.rb
+
+        Do 3 steps:
+          1. Add an entry to the "New features" section in CHANGELOG.md,
+             e.g. "Add new `FakeCop` cop. ([@your_id][])"
+          2. Add an entry into config/enabled.yml or config/disabled.yml
+          3. Implement your new cop in the generated file!
+      TODO
+    end
+  end
+
+  describe '.new' do
+    it 'does not accept an unqualified cop' do
+      expect { described_class.new('FakeCop') }
+        .to raise_error(ArgumentError)
+        .with_message('Specify a cop name with Department/Name style')
+    end
+  end
+
+  describe '#inject_require' do
+    context 'when a `require` entry does not exist from before' do
+      before do
+        allow(File)
+          .to receive(:readlines).with('lib/rubocop.rb')
+                                 .and_return(<<-RUBY.strip_indent.lines)
+          # frozen_string_literal: true
+
+          require 'parser'
+          require 'rainbow'
+
+          require 'English'
+          require 'set'
+          require 'forwardable'
+
+          require 'rubocop/version'
+
+          require 'rubocop/cop/style/end_block'
+          require 'rubocop/cop/style/even_odd'
+          require 'rubocop/cop/style/file_name'
+          require 'rubocop/cop/style/flip_flop'
+
+          require 'rubocop/cop/rails/action_filter'
+
+          require 'rubocop/cop/team'
+        RUBY
+      end
+
+      it 'injects a `require` statement on the right line in the root file' do
+        generated_source = <<-RUBY.strip_indent
+          # frozen_string_literal: true
+
+          require 'parser'
+          require 'rainbow'
+
+          require 'English'
+          require 'set'
+          require 'forwardable'
+
+          require 'rubocop/version'
+
+          require 'rubocop/cop/style/end_block'
+          require 'rubocop/cop/style/even_odd'
+          require 'rubocop/cop/style/fake_cop'
+          require 'rubocop/cop/style/file_name'
+          require 'rubocop/cop/style/flip_flop'
+
+          require 'rubocop/cop/rails/action_filter'
+
+          require 'rubocop/cop/team'
+        RUBY
+
+        generator.inject_require
+
+        expect(File)
+          .to have_received(:write).with('lib/rubocop.rb', generated_source)
+      end
+    end
+
+    context 'when a `require` entry already exists' do
+      before do
+        allow(File)
+          .to receive(:readlines).with('lib/rubocop.rb')
+                                 .and_return(<<-RUBY.strip_indent.lines)
+          # frozen_string_literal: true
+
+          require 'parser'
+          require 'rainbow'
+
+          require 'English'
+          require 'set'
+          require 'forwardable'
+
+          require 'rubocop/version'
+
+          require 'rubocop/cop/style/end_block'
+          require 'rubocop/cop/style/even_odd'
+          require 'rubocop/cop/style/fake_cop'
+          require 'rubocop/cop/style/file_name'
+          require 'rubocop/cop/style/flip_flop'
+
+          require 'rubocop/cop/rails/action_filter'
+
+          require 'rubocop/cop/team'
+        RUBY
+      end
+
+      it 'does not write to any file' do
+        generator.inject_require
+
+        expect(File).not_to have_received(:write)
+      end
+    end
+
+    context 'when using an unknown department' do
+      let(:cop_identifier) { 'Unknown/FakeCop' }
+
+      before do
+        allow(File)
+          .to receive(:readlines).with('lib/rubocop.rb')
+                                 .and_return(<<-RUBY.strip_indent.lines)
+          # frozen_string_literal: true
+
+          require 'parser'
+          require 'rainbow'
+
+          require 'English'
+          require 'set'
+          require 'forwardable'
+
+          require 'rubocop/version'
+
+          require 'rubocop/cop/style/end_block'
+          require 'rubocop/cop/style/even_odd'
+          require 'rubocop/cop/style/fake_cop'
+          require 'rubocop/cop/style/file_name'
+          require 'rubocop/cop/style/flip_flop'
+
+          require 'rubocop/cop/rails/action_filter'
+
+          require 'rubocop/cop/team'
+        RUBY
+      end
+
+      it 'does not write to any file' do
+        generator.inject_require
+
+        expect(File).not_to have_received(:write)
+      end
     end
   end
 end

--- a/tasks/new_cop.rake
+++ b/tasks/new_cop.rake
@@ -12,6 +12,7 @@ task :new_cop, [:cop] do |_task, args|
 
   generator.write_source
   generator.write_spec
+  generator.inject_require
 
   puts generator.todo
 end


### PR DESCRIPTION
It would be nice to be taken straight to a failing test case after running the generator. This change reduces the number of manual steps needed by adding the `require` directive into the root file automatically.

-----------------

Before submitting the PR make sure the following are checked:

* [X] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [X] Used the same coding conventions as the rest of the project.
* [X] Feature branch is up-to-date with `master` (if not - rebase it).
* [X] Squashed related commits together.
* [X] Added tests.
* [ ] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [X] All tests(`rake spec`) are passing.
* [X] The new code doesn't generate RuboCop offenses that are checked by `rake internal_investigation`.
* [X] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [ ] Updated cop documentation with `rake generate_cops_documentation` (required only when you've added a new cop or changed the configuration/documentation of an existing cop).

[1]: http://chris.beams.io/posts/git-commit/
