### PR TITLE
Do not auto-correct Security/YAMLLoad by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,7 @@
 * [#4551](https://github.com/bbatsov/rubocop/pull/4551): Make `Performance/Caller` aware of `caller_locations`. ([@pocke][])
 * Rename `Style/HeredocDelimiters` to `Style/HeredocDelimiterNaming`. ([@drenmi][])
 * [#4157](https://github.com/bbatsov/rubocop/issues/4157): Enhance offense message for `Style/RedudantReturn` cop. ([@gohdaniel15][])
+* [#3998](https://github.com/bbatsov/rubocop/issues/3998): Do not auto-correct `Security/YAMLLoad` by default. ([@NobodysNightmare][])
 
 ## 0.49.1 (2017-05-29)
 

--- a/config/enabled.yml
+++ b/config/enabled.yml
@@ -1773,6 +1773,9 @@ Security/YAMLLoad:
                  security issues. See reference for more information.
   Reference: 'https://ruby-doc.org/stdlib-2.3.3/libdoc/yaml/rdoc/YAML.html#module-YAML-label-Security'
   Enabled: true
+  # Autocorrect replaces YAML.load with YAML.safe_load, which by default will not
+  # be able to parse all files that load can parse (e.g. files using aliases).
+  AutoCorrect: false
 
 #################### Bundler ###############################
 

--- a/manual/cops_security.md
+++ b/manual/cops_security.md
@@ -104,6 +104,12 @@ YAML.safe_load("--- foo")
 YAML.dump("foo")
 ```
 
+### Important attributes
+
+Attribute | Value
+--- | ---
+AutoCorrect | false
+
 ### References
 
 * [https://ruby-doc.org/stdlib-2.3.3/libdoc/yaml/rdoc/YAML.html#module-YAML-label-Security](https://ruby-doc.org/stdlib-2.3.3/libdoc/yaml/rdoc/YAML.html#module-YAML-label-Security)


### PR DESCRIPTION
This PR addresses my concern raised in https://github.com/bbatsov/rubocop/issues/3998:

> ## Expected behaviour
> When auto correcting my code, rubocop only performs auto-corrections that can be expected to not break the semantics of my code.
>
> Thus I expect no auto-correction from `YAML.load` to `YAML.safe_load`, since that will break yaml files using aliases, e.g.
>
> ```yaml
> default: &default
>   foo: "bar"
> baz:
>   <<: *default
> ```

@bbatsov pointed me to #3398, which I understood as a request, to do the same for this cop.