### PR TITLE
[Fix #3040] Ignore safe navigation in `Rails/Delegate`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,7 @@
 * [#4447](https://github.com/bbatsov/rubocop/issues/4447): Prevent `Layout/EmptyLineBetweenDefs` from removing too many lines. ([@drenmi][])
 * [#3892](https://github.com/bbatsov/rubocop/issues/3892): Make `Style/NumericPredicate` ignore numeric comparison of global variables. ([@drenmi][])
 * [#4518](https://github.com/bbatsov/rubocop/issues/4518): Fix bug where `Style/SafeNavigation` does not register an offense when there are chained method calls. ([@rrosenblum][])
+* [#3040](https://github.com/bbatsov/rubocop/issues/3040): Ignore safe navigation in `Rails/Delegate`. ([@cgriego][])
 
 ### Changes
 

--- a/lib/rubocop/cop/rails/delegate.rb
+++ b/lib/rubocop/cop/rails/delegate.rb
@@ -6,6 +6,10 @@ module RuboCop
       # This cop looks for delegations that could have been created
       # automatically with the `delegate` method.
       #
+      # Safe navigation `&.` is ignored because Rails' `allow_nil`
+      # option checks not just for nil but also delegates if nil
+      # responds to the delegated method.
+      #
       # The `EnforceForPrefixed` option (defaulted to `true`) means that
       # using the target object as a prefix of the method name
       # without using the `delegate` method will be a violation.
@@ -19,6 +23,11 @@ module RuboCop
       #
       #   # good
       #   delegate :bar, to: :foo
+      #
+      #   # good
+      #   def bar
+      #     foo&.bar
+      #   end
       #
       #   # good
       #   private
@@ -69,7 +78,7 @@ module RuboCop
         end
 
         def trivial_delegate?(method_name, args, body)
-          body && delegate?(body) &&
+          body && delegate?(body) && !body.csend_type? &&
             method_name_matches?(method_name, body) &&
             arguments_match?(args, body)
         end

--- a/manual/cops_rails.md
+++ b/manual/cops_rails.md
@@ -201,6 +201,10 @@ Enabled | Yes
 This cop looks for delegations that could have been created
 automatically with the `delegate` method.
 
+Safe navigation `&.` is ignored because Rails' `allow_nil`
+option checks not just for nil but also delegates if nil
+responds to the delegated method.
+
 The `EnforceForPrefixed` option (defaulted to `true`) means that
 using the target object as a prefix of the method name
 without using the `delegate` method will be a violation.
@@ -216,6 +220,11 @@ end
 
 # good
 delegate :bar, to: :foo
+
+# good
+def bar
+  foo&.bar
+end
 
 # good
 private

--- a/spec/rubocop/cop/rails/delegate_spec.rb
+++ b/spec/rubocop/cop/rails/delegate_spec.rb
@@ -151,6 +151,16 @@ describe RuboCop::Cop::Rails::Delegate do
     end
   end
 
+  context 'Ruby 2.3', :ruby23 do
+    it 'ignores trivial delegate with safe navigation' do
+      expect_no_offenses(<<-RUBY.strip_indent)
+        def foo
+          bar&.foo
+        end
+      RUBY
+    end
+  end
+
   describe '#autocorrect' do
     context 'trivial delegation' do
       let(:source) do


### PR DESCRIPTION
As described in #3040, `Rails/Delegate` is ignoring the Ruby 2.3 safe navigation operator `&.` and registering offenses for non-delegated code using the operator and, if active, auto-corrects it to code that is not equivalent.

The equivalent code, in most cases, would be a delegate with the `allow_nil` option set. However, `allow_nil` isn't always equivalent because `allow_nil` checks for if the object being delegated to is nil _or is responds to the delegated method_. Therefore, this change stops the offenses and rewritten code that does not work the same and leaves the possibility of handling `allow_nil` to a future change.

This problem is made worse by other cops that correct code to use the safe navigation operator and then `Rails/Delegate` breaks it.

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Used the same coding conventions as the rest of the project.
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] All tests(`rake spec`) are passing.
* [x] The new code doesn't generate RuboCop offenses that are checked by `rake internal_investigation`.
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Updated cop documentation with `rake generate_cops_documentation` (required only when you've added a new cop or changed the configuration/documentation of an existing cop).

[1]: http://chris.beams.io/posts/git-commit/