### PR TITLE
[FIX #4563] Style/TrailingUnderscoreVariable cop leaves an unclosed parentheses

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 * Add new `Style/Dir` cop. ([@drenmi][])
 * Add new `Style/HeredocDelimiterCase` cop. ([@drenmi][])
 * [#2943](https://github.com/bbatsov/rubocop/pull/2943): Add new `Lint/RescueWithoutErrorClass` cop. ([@drenmi][])
+* [#4568](https://github.com/bbatsov/rubocop/pull/4568): Fix autocorrection for `Style/TrailingUnderscoreVariable`. ([@smakagon][])
 
 ### Bug fixes
 

--- a/lib/rubocop/cop/style/trailing_underscore_variable.rb
+++ b/lib/rubocop/cop/style/trailing_underscore_variable.rb
@@ -96,16 +96,35 @@ module RuboCop
 
           return unless first_offense
 
-          end_position =
-            if first_offense.source_range == variables.first.source_range
-              right.source_range.begin_pos
-            else
-              node.loc.operator.begin_pos
-            end
+          if unused_variables_only?(first_offense, variables)
+            return left_side_range(left, right)
+          end
 
-          range = range_between(first_offense.source_range.begin_pos,
-                                end_position)
-          range_with_surrounding_space(range, :right)
+          if Util.parentheses?(left)
+            return range_for_parentheses(first_offense, left)
+          end
+
+          range_between(
+            first_offense.source_range.begin_pos,
+            node.loc.operator.begin_pos
+          )
+        end
+
+        def unused_variables_only?(offense, variables)
+          offense.source_range == variables.first.source_range
+        end
+
+        def left_side_range(left, right)
+          range_between(
+            left.source_range.begin_pos, right.source_range.begin_pos
+          )
+        end
+
+        def range_for_parentheses(offense, left)
+          range_between(
+            offense.source_range.begin_pos - 1,
+            left.loc.expression.end_pos - 1
+          )
         end
       end
     end

--- a/spec/rubocop/cop/style/trailing_underscore_variable_spec.rb
+++ b/spec/rubocop/cop/style/trailing_underscore_variable_spec.rb
@@ -169,6 +169,32 @@ describe RuboCop::Cop::Style::TrailingUnderscoreVariable do
 
         expect(new_source).to eq('a, = foo()')
       end
+
+      context 'with parentheses' do
+        it 'leaves parentheses but removes trailing underscores' do
+          new_source = autocorrect_source('(a, b, _) = foo()')
+
+          expect(new_source).to eq('(a, b,) = foo()')
+        end
+
+        it 'removes assignment part when every assignment is to `_`' do
+          new_source = autocorrect_source('(_, _, _,) = foo()')
+
+          expect(new_source).to eq('foo()')
+        end
+
+        it 'removes assignment part when it is the only variable' do
+          new_source = autocorrect_source('(_,) = foo()')
+
+          expect(new_source).to eq('foo()')
+        end
+
+        it 'leaves parentheses but removes trailing underscores and commas' do
+          new_source = autocorrect_source('(a, _, _,) = foo()')
+
+          expect(new_source).to eq('(a,) = foo()')
+        end
+      end
     end
   end
 


### PR DESCRIPTION
This fixes autocorrect issue with `Style/TrailingUnderscoreVariable`.
Without this fix cop would autocorrect this code:
```
(foo, _) = [1, 2, 3]
```

To this: 
```
(foo, = [1, 2, 3]
```

With the fix it autocorrects this code:
```
(foo, _) = [1, 2, 3]
```  

To the following:
```
(foo,) = [1, 2, 3]
```

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Used the same coding conventions as the rest of the project.
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] All tests(`rake spec`) are passing.
* [x] The new code doesn't generate RuboCop offenses that are checked by `rake internal_investigation`.
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Updated cop documentation with `rake generate_cops_documentation` (required only when you've added a new cop or changed the configuration/documentation of an existing cop).

[1]: http://chris.beams.io/posts/git-commit/
