### PR TITLE
[Fix #3892] Make `Style/NumericPredicate` ignore numeric comparison of global variables

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@
 * [#4555](https://github.com/bbatsov/rubocop/issues/4555): Make `Style/VariableName` aware of optarg, kwarg and other arguments. ([@pocke][])
 * [#4481](https://github.com/bbatsov/rubocop/issues/4481): Prevent `Style/WordArray` and `Style/SymbolArray` from registering offenses where percent arrays don't work. ([@drenmi][])
 * [#4447](https://github.com/bbatsov/rubocop/issues/4447): Prevent `Layout/EmptyLineBetweenDefs` from removing too many lines. ([@drenmi][])
+* [#3892](https://github.com/bbatsov/rubocop/issues/3892): Make `Style/NumericPredicate` ignore numeric comparison of global variables. ([@drenmi][])
 
 ### Changes
 

--- a/lib/rubocop/cop/style/numeric_predicate.rb
+++ b/lib/rubocop/cop/style/numeric_predicate.rb
@@ -8,9 +8,13 @@ module RuboCop
       # These can be replaced by their respective predicate methods.
       # The cop can also be configured to do the reverse.
       #
-      # The cop disregards `nonzero?` as it its value is truthy or falsey,
+      # The cop disregards `#nonzero?` as it its value is truthy or falsey,
       # but not `true` and `false`, and thus not always interchangeable with
       # `!= 0`.
+      #
+      # The cop ignores comparisons to global variables, since they are often
+      # populated with objects which can be compared with integers, but are
+      # not themselves `Interger` polymorphic.
       #
       # @example
       #
@@ -128,11 +132,11 @@ module RuboCop
         PATTERN
 
         def_node_matcher :comparison, <<-PATTERN
-          (send $(...) ${:== :> :<} (int 0))
+          (send [$(...) !gvar_type?] ${:== :> :<} (int 0))
         PATTERN
 
         def_node_matcher :inverted_comparison, <<-PATTERN
-          (send (int 0) ${:== :> :<} $(...))
+          (send (int 0) ${:== :> :<} [$(...) !gvar_type?])
         PATTERN
       end
     end

--- a/manual/cops_style.md
+++ b/manual/cops_style.md
@@ -2763,9 +2763,13 @@ This cop checks for usage of comparison operators (`==`,
 These can be replaced by their respective predicate methods.
 The cop can also be configured to do the reverse.
 
-The cop disregards `nonzero?` as it its value is truthy or falsey,
+The cop disregards `#nonzero?` as it its value is truthy or falsey,
 but not `true` and `false`, and thus not always interchangeable with
 `!= 0`.
+
+The cop ignores comparisons to global variables, since they are often
+populated with objects which can be compared with integers, but are
+not themselves `Interger` polymorphic.
 
 ### Example
 

--- a/spec/rubocop/cop/style/numeric_predicate_spec.rb
+++ b/spec/rubocop/cop/style/numeric_predicate_spec.rb
@@ -61,6 +61,14 @@ describe RuboCop::Cop::Style::NumericPredicate, :config do
                         '0 == foo - 1',
                         '(foo - 1).zero?'
       end
+
+      context 'when comparing against a global variable' do
+        it_behaves_like 'code without offense',
+                        '$CHILD_STATUS == 0'
+
+        it_behaves_like 'code without offense',
+                        '0 == $CHILD_STATUS'
+      end
     end
 
     context 'with checking if a number is not zero' do
@@ -76,6 +84,14 @@ describe RuboCop::Cop::Style::NumericPredicate, :config do
 
         it_behaves_like 'code without offense',
                         '0 != foo - 1'
+      end
+
+      context 'when comparing against a global variable' do
+        it_behaves_like 'code without offense',
+                        '$CHILD_STATUS != 0'
+
+        it_behaves_like 'code without offense',
+                        '0 != $CHILD_STATUS'
       end
     end
 


### PR DESCRIPTION
This cop would suggest replacing numeric comparison with predicate methods for global variables, but due to global variables often being objects that are not entirely polymorphic with `Integer`, this leads to a large amount of false positives.

This change fixes that.

-----------------

Before submitting the PR make sure the following are checked:

* [X] Wrote [good commit messages][1].
* [X] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [X] Used the same coding conventions as the rest of the project.
* [X] Feature branch is up-to-date with `master` (if not - rebase it).
* [X] Squashed related commits together.
* [X] Added tests.
* [X] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [X] All tests(`rake spec`) are passing.
* [X] The new code doesn't generate RuboCop offenses that are checked by `rake internal_investigation`.
* [X] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [X] Updated cop documentation with `rake generate_cops_documentation` (required only when you've added a new cop or changed the configuration/documentation of an existing cop).

[1]: http://chris.beams.io/posts/git-commit/
