### PR TITLE
[FIX #4578] False positive of sprintf in Lint/FormatParameterMismatch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,7 @@
 * [#3040](https://github.com/bbatsov/rubocop/issues/3040): Ignore safe navigation in `Rails/Delegate`. ([@cgriego][])
 * [#4587](https://github.com/bbatsov/rubocop/pull/4587): Fix false negative for void unary operators in `Lint/Void` cop. ([@pocke][])
 * [#4589](https://github.com/bbatsov/rubocop/issues/4589): Fix false positive in `Performance/RegexpMatch` cop for `=~` is in a class method. ([@pocke][])
+* [#4578](https://github.com/bbatsov/rubocop/issues/4578): Fix false positive in `Lint/FormatParameterMismatch` for format with "asterisk" (`*`) width and precision. ([@smakagon][])
 
 ### Changes
 

--- a/lib/rubocop/cop/lint/format_parameter_mismatch.rb
+++ b/lib/rubocop/cop/lint/format_parameter_mismatch.rb
@@ -111,12 +111,11 @@ module RuboCop
         end
 
         def count_format_matches(node)
-          [arguments_count(node.arguments) - 1,
-           expected_fields_count(node.first_argument)]
+          [node.arguments.count - 1, expected_fields_count(node.first_argument)]
         end
 
         def count_percent_matches(node)
-          [arguments_count(node.first_argument.child_nodes),
+          [node.first_argument.child_nodes.count,
            expected_fields_count(node.receiver)]
         end
 
@@ -136,15 +135,12 @@ module RuboCop
             .source
             .scan(FIELD_REGEX)
             .reject { |x| x.first == PERCENT_PERCENT }
-            .reduce(0) { |acc, elem| acc + (elem[2] =~ /\*/ ? 2 : 1) }
+            .reduce(0) { |acc, elem| acc + arguments_count(elem[2]) }
         end
 
-        def arguments_count(args)
-          if args.last && args.last.splat_type?
-            -(args.size - 1)
-          else
-            args.size
-          end
+        # number of arguments required for the format sequence
+        def arguments_count(format)
+          format.scan('*').count + 1
         end
 
         def format?(node)

--- a/spec/rubocop/cop/lint/format_parameter_mismatch_spec.rb
+++ b/spec/rubocop/cop/lint/format_parameter_mismatch_spec.rb
@@ -257,6 +257,24 @@ describe RuboCop::Cop::Lint::FormatParameterMismatch do
     end
   end
 
+  context 'with wildcard' do
+    it 'does not register an offence for width' do
+      expect_no_offenses('format("%*d", 10, 3)')
+    end
+
+    it 'does not register an offence for precision' do
+      expect_no_offenses('format("%.*f", 2, 20.19)')
+    end
+
+    it 'does not register an offense for width and precision' do
+      expect_no_offenses('format("%*.*f", 10, 3, 20.19)')
+    end
+
+    it 'does not register an offense for multiple wildcards' do
+      expect_no_offenses('format("%*.*f %*.*f", 10, 2, 20.19, 5, 1, 11.22)')
+    end
+  end
+
   it 'finds the correct number of fields' do
     expect(''.scan(described_class::FIELD_REGEX).size)
       .to eq(0)


### PR DESCRIPTION
Fixes issue #4578  with the following code:
`format('%*.*f', 10, 2, 10.9999)`

Without this fix `Lint/FormatParameterMismatch` would return error:
> Number of arguments (3) to `format` doesn't match the number of fields (2).

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Used the same coding conventions as the rest of the project.
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] All tests(`rake spec`) are passing.
* [x] The new code doesn't generate RuboCop offenses that are checked by `rake internal_investigation`.
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Updated cop documentation with `rake generate_cops_documentation` (required only when you've added a new cop or changed the configuration/documentation of an existing cop).

[1]: http://chris.beams.io/posts/git-commit/
