### PR TITLE
[Fix #2976] Add `Whitelist` configuration option to `Style/NestedParenthesizedCalls` cop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@
 * [#2943](https://github.com/bbatsov/rubocop/pull/2943): Add new `Lint/RescueWithoutErrorClass` cop. ([@drenmi][])
 * [#4568](https://github.com/bbatsov/rubocop/pull/4568): Fix autocorrection for `Style/TrailingUnderscoreVariable`. ([@smakagon][])
 * [#4586](https://github.com/bbatsov/rubocop/pull/4586): Add new `Performance/UnfreezeString` cop. ([@pocke][])
+* [#2976](https://github.com/bbatsov/rubocop/issues/2976): Add `Whitelist` configuration option to `Style/NestedParenthesizedCalls` cop. ([@drenmi][])
 
 ### Bug fixes
 

--- a/config/default.yml
+++ b/config/default.yml
@@ -1032,6 +1032,26 @@ Style/NegatedIf:
     - prefix
     - postfix
 
+Style/NestedParenthesizedCalls:
+  Whitelist:
+    - be
+    - be_a
+    - be_an
+    - be_between
+    - be_falsey
+    - be_kind_of
+    - be_instance_of
+    - be_truthy
+    - be_within
+    - eq
+    - eql
+    - end_with
+    - include
+    - match
+    - raise_error
+    - respond_to
+    - start_with
+
 Style/Next:
   # With `always` all conditions at the end of an iteration needs to be
   # replaced by next - with `skip_modifier_ifs` the modifier if like this one

--- a/spec/rubocop/cop/style/nested_parenthesized_calls_spec.rb
+++ b/spec/rubocop/cop/style/nested_parenthesized_calls_spec.rb
@@ -1,7 +1,13 @@
 # frozen_string_literal: true
 
 describe RuboCop::Cop::Style::NestedParenthesizedCalls do
-  subject(:cop) { described_class.new }
+  subject(:cop) { described_class.new(config) }
+
+  let(:config) do
+    RuboCop::Config.new(
+      'Style/NestedParenthesizedCalls' => { 'Whitelist' => ['be'] }
+    )
+  end
 
   context 'on a non-parenthesized method call' do
     it "doesn't register an offense" do
@@ -71,7 +77,7 @@ describe RuboCop::Cop::Style::NestedParenthesizedCalls do
     end
   end
 
-  context 'on an RSpec matcher' do
+  context 'on a whitelisted method' do
     it "doesn't register an offense" do
       expect_no_offenses('expect(obj).to(be true)')
     end


### PR DESCRIPTION
This cop was using hard coded RSpec methods for whitelisting. This change moves the whitelist into a configuration option.

@backus: Once this change is merged, perhaps we can move this configuration to `rubocop-rspec`? 🙂 

-----------------

Before submitting the PR make sure the following are checked:

* [X] Wrote [good commit messages][1].
* [X] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [X] Used the same coding conventions as the rest of the project.
* [X] Feature branch is up-to-date with `master` (if not - rebase it).
* [X] Squashed related commits together.
* [X] Added tests.
* [X] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [X] All tests(`rake spec`) are passing.
* [X] The new code doesn't generate RuboCop offenses that are checked by `rake internal_investigation`.
* [X] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [ ] Updated cop documentation with `rake generate_cops_documentation` (required only when you've added a new cop or changed the configuration/documentation of an existing cop).

[1]: http://chris.beams.io/posts/git-commit/
