### PR TITLE
Modify manual/development.md to describe alteration of lib/rubocop.rb

### DIFF
--- a/manual/development.md
+++ b/manual/development.md
@@ -7,11 +7,12 @@ $ bundle exec rake new_cop[Category/Name]
 created
 - lib/rubocop/cop/category/name.rb
 - spec/rubocop/cop/category/name_spec.rb
+modified
+- `require 'lib/rubocop/cop/category/name'` added into lib/rubocop.rb
 
-Do 4 steps
+Do 3 steps
 - Add an entry to `New feature` section in CHANGELOG.md
   - e.g. Add new `Category/Name` cop. ([@your_id][])
-- Add `require 'lib/rubocop/cop/category/name'` into lib/rubocop.rb
 - Add an entry into config/enabled.yml or config/disabled.yml
 - Implement a new cop to the generated file!
 ```


### PR DESCRIPTION
I have made a modification to the `manual/development.md` to reflect the automated entry of the
'lib/rubocop/cop/category/name' into lib/rubocop.rb when `new_cop` is called.

I was experimenting with the code as described in `manual/development.md` and noticed that `new_cop` makes this automatic entry, so there is no need for manual entry of a require statement by developer.

I hope this is ok? Your thoughts on this would be appreciated. Many thanks.

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Used the same coding conventions as the rest of the project.
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [ ] Added tests.
* [ ] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] All tests(`rake spec`) are passing.
* [x] The new code doesn't generate RuboCop offenses that are checked by `rake internal_investigation`.
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [ ] Updated cop documentation with `rake generate_cops_documentation` (required only when you've added a new cop or changed the configuration/documentation of an existing cop).

[1]: http://chris.beams.io/posts/git-commit/
