### PR TITLE
Fix false negative for void unary operators in `Lint/Void` cop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,7 @@
 * [#3892](https://github.com/bbatsov/rubocop/issues/3892): Make `Style/NumericPredicate` ignore numeric comparison of global variables. ([@drenmi][])
 * [#4518](https://github.com/bbatsov/rubocop/issues/4518): Fix bug where `Style/SafeNavigation` does not register an offense when there are chained method calls. ([@rrosenblum][])
 * [#3040](https://github.com/bbatsov/rubocop/issues/3040): Ignore safe navigation in `Rails/Delegate`. ([@cgriego][])
+* [#4587](https://github.com/bbatsov/rubocop/pull/4587): Fix false negative for void unary operators in `Lint/Void` cop. ([@pocke][])
 
 ### Changes
 

--- a/lib/rubocop/cop/lint/void.rb
+++ b/lib/rubocop/cop/lint/void.rb
@@ -48,7 +48,9 @@ module RuboCop
         SELF_MSG = '`self` used in void context.'.freeze
         DEFINED_MSG = '`%s` used in void context.'.freeze
 
-        OPS = %i[* / % + - == === != < > <= >= <=>].freeze
+        BINARY_OPERATORS = %i[* / % + - == === != < > <= >= <=>].freeze
+        UNARY_OPERATORS = %i[+@ -@ ~ !].freeze
+        OPERATORS = (BINARY_OPERATORS + UNARY_OPERATORS).freeze
         VOID_CONTEXT_TYPES = %i[def for block].freeze
 
         def on_begin(node)
@@ -71,7 +73,7 @@ module RuboCop
         end
 
         def check_void_op(node)
-          return unless node.send_type? && OPS.include?(node.method_name)
+          return unless node.send_type? && OPERATORS.include?(node.method_name)
 
           add_offense(node, :selector, format(OP_MSG, node.method_name))
         end

--- a/spec/rubocop/cop/lint/void_spec.rb
+++ b/spec/rubocop/cop/lint/void_spec.rb
@@ -3,7 +3,7 @@
 describe RuboCop::Cop::Lint::Void do
   subject(:cop) { described_class.new }
 
-  described_class::OPS.each do |op|
+  described_class::BINARY_OPERATORS.each do |op|
     it "registers an offense for void op #{op} if not on last line" do
       inspect_source(<<-RUBY.strip_indent)
         a #{op} b
@@ -14,20 +14,45 @@ describe RuboCop::Cop::Lint::Void do
     end
   end
 
-  described_class::OPS.each do |op|
+  described_class::BINARY_OPERATORS.each do |op|
     it "accepts void op #{op} if on last line" do
-      inspect_source(<<-RUBY.strip_indent)
+      expect_no_offenses(<<-RUBY.strip_indent)
         something
         a #{op} b
       RUBY
-      expect(cop.offenses).to be_empty
     end
   end
 
-  described_class::OPS.each do |op|
+  described_class::BINARY_OPERATORS.each do |op|
     it "accepts void op #{op} by itself without a begin block" do
-      inspect_source("a #{op} b")
-      expect(cop.offenses).to be_empty
+      expect_no_offenses("a #{op} b")
+    end
+  end
+
+  unary_operators = %i[+ - ~ !]
+  unary_operators.each do |op|
+    it "registers an offense for void op #{op} if not on last line" do
+      inspect_source(<<-RUBY.strip_indent)
+        #{op}b
+        #{op}b
+        #{op}b
+      RUBY
+      expect(cop.offenses.size).to eq(2)
+    end
+  end
+
+  unary_operators.each do |op|
+    it "accepts void op #{op} if on last line" do
+      expect_no_offenses(<<-RUBY.strip_indent)
+        something
+        #{op}b
+      RUBY
+    end
+  end
+
+  unary_operators.each do |op|
+    it "accepts void op #{op} by itself without a begin block" do
+      expect_no_offenses("#{op}b")
     end
   end
 


### PR DESCRIPTION
```ruby
def foo
  +1
  something
end
```

The `+1` is in void context. So I think `Lint/Void` cop should detect this code.
However this cop does not add offenses for the above ruby code.

This change makes to detect it.

Note: MRI warns the code.

```bash
$ ruby -cw test.rb
test.rb:2: warning: unused literal ignored
Syntax OK
```



-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Used the same coding conventions as the rest of the project.
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] All tests(`rake spec`) are passing.
* [x] The new code doesn't generate RuboCop offenses that are checked by `rake internal_investigation`.
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [ ] Updated cop documentation with `rake generate_cops_documentation` (required only when you've added a new cop or changed the configuration/documentation of an existing cop).

[1]: http://chris.beams.io/posts/git-commit/
