### PR TITLE
Make Style/RedundantSelf aware of arguments of a block

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -63,6 +63,7 @@
 * Rename `Style/HeredocDelimiters` to `Style/HeredocDelimiterNaming`. ([@drenmi][])
 * [#4157](https://github.com/bbatsov/rubocop/issues/4157): Enhance offense message for `Style/RedudantReturn` cop. ([@gohdaniel15][])
 * [#4521](https://github.com/bbatsov/rubocop/issues/4521): Move naming related cops into their own `Naming` department. ([@drenmi][])
+* [#4600](https://github.com/bbatsov/rubocop/pull/4600): Make `Style/RedundantSelf` aware of arguments of a block. ([@Envek][])
 
 ## 0.49.1 (2017-05-29)
 
@@ -2879,3 +2880,4 @@
 [@oboxodo]: https://github.com/oboxodo
 [@gohdaniel15]: https://github.com/gohdaniel15
 [@barthez]: https://github.com/barthez
+[@Envek]: https://github.com/Envek

--- a/lib/rubocop/cop/style/redundant_self.rb
+++ b/lib/rubocop/cop/style/redundant_self.rb
@@ -30,6 +30,10 @@ module RuboCop
       #     self.bar # resolves name clash with local variable
       #   end
       #
+      #   %w[x y z].select do |bar|
+      #     self.bar == bar # resolves name clash with argument of a block
+      #   end
+      #
       # * Calling an attribute writer to prevent an local variable assignment
       #
       #   attr_writer :bar
@@ -93,6 +97,10 @@ module RuboCop
           add_offense(node)
         end
 
+        def on_block(node)
+          add_scope(node, @local_variables_scopes[node])
+        end
+
         private
 
         def autocorrect(node)
@@ -102,8 +110,7 @@ module RuboCop
           end
         end
 
-        def add_scope(node)
-          local_variables = []
+        def add_scope(node, local_variables = [])
           node.descendants.each do |child_node|
             @local_variables_scopes[child_node] = local_variables
           end

--- a/manual/cops_style.md
+++ b/manual/cops_style.md
@@ -3092,6 +3092,10 @@ This cop checks for redundant uses of `self`.
     self.bar # resolves name clash with local variable
   end
 
+  %w[x y z].select do |bar|
+    self.bar == bar # resolves name clash with argument of a block
+  end
+
 * Calling an attribute writer to prevent an local variable assignment
 
   attr_writer :bar

--- a/spec/rubocop/cop/style/redundant_self_spec.rb
+++ b/spec/rubocop/cop/style/redundant_self_spec.rb
@@ -82,6 +82,17 @@ describe RuboCop::Cop::Style::RedundantSelf do
     RUBY
   end
 
+  it 'accepts a self receiver used to distinguish from argument of block' do
+    expect_no_offenses(<<-RUBY.strip_indent)
+      %w[draft preview moderation approved rejected].each do |state|
+        self.state == state
+        define_method "\#{state}?" do
+          self.state == state
+        end
+      end
+    RUBY
+  end
+
   describe 'instance methods' do
     it 'accepts a self receiver used to distinguish from blockarg' do
       expect_no_offenses(<<-RUBY.strip_indent)


### PR DESCRIPTION
Currently, Rubocop complains about redundant self when using a block with argument name same with receiver method, like this:

```rb
  %w[draft preview moderation approved rejected].each do |state|
    define_method "#{state}?" do
      self.state == state
    end
  end
```

Autocorrection fixes this code to `state == state` effectively breaking it.

This PR removes offense for arguments of a block with names equal to receiver method name.

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists). **Not exists**
* [x] Used the same coding conventions as the rest of the project.
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] All tests(`rake spec`) are passing.
* [x] The new code doesn't generate RuboCop offenses that are checked by `rake internal_investigation`.
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Updated cop documentation with `rake generate_cops_documentation` (required only when you've added a new cop or changed the configuration/documentation of an existing cop). **Not required**

[1]: http://chris.beams.io/posts/git-commit/
