### PR TITLE
[#4601] - Find .ruby-version relative to rubocop config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,7 @@
 * [#4587](https://github.com/bbatsov/rubocop/pull/4587): Fix false negative for void unary operators in `Lint/Void` cop. ([@pocke][])
 * [#4589](https://github.com/bbatsov/rubocop/issues/4589): Fix false positive in `Performance/RegexpMatch` cop for `=~` is in a class method. ([@pocke][])
 * [#4578](https://github.com/bbatsov/rubocop/issues/4578): Fix false positive in `Lint/FormatParameterMismatch` for format with "asterisk" (`*`) width and precision. ([@smakagon][])
+* [#4601](https://github.com/bbatsov/rubocop/issues/4601): Make .ruby-version lookup work relatively, so it is still found when running rubocop from a subdirectory. ([@aclemons][])
 
 ### Changes
 
@@ -2872,3 +2873,4 @@
 [@promisedlandt]: https://github.com/promisedlandt
 [@oboxodo]: https://github.com/oboxodo
 [@gohdaniel15]: https://github.com/gohdaniel15
+[@aclemons]: https://github.com/aclemons

--- a/lib/rubocop/config.rb
+++ b/lib/rubocop/config.rb
@@ -327,14 +327,18 @@ module RuboCop
           @target_ruby_version_source = :rubocop_yml
 
           for_all_cops['TargetRubyVersion']
-        elsif File.file?('.ruby-version') &&
-              /\A(ruby-)?(?<version>\d+\.\d+)/ =~ File.read('.ruby-version')
-
-          @target_ruby_version_source = :dot_ruby_version
-
-          version.to_f
         else
-          DEFAULT_RUBY_VERSION
+          ruby_version_file = File.join(base_dir_for_path_parameters, '.ruby-version')
+
+          if File.file?(ruby_version_file) &&
+              /\A(ruby-)?(?<version>\d+\.\d+)/ =~ File.read(ruby_version_file)
+
+            @target_ruby_version_source = :dot_ruby_version
+
+            version.to_f
+          else
+            DEFAULT_RUBY_VERSION
+          end
         end
     end
 

--- a/spec/rubocop/config_spec.rb
+++ b/spec/rubocop/config_spec.rb
@@ -580,6 +580,10 @@ describe RuboCop::Config do
   end
 
   describe '#target_ruby_version' do
+    let(:ruby_version_file) do
+      File.join(File.expand_path(File.dirname(loaded_path)), '.ruby-version')
+    end
+
     context 'when TargetRubyVersion is set' do
       let(:ruby_version) { 2.1 }
 
@@ -601,17 +605,17 @@ describe RuboCop::Config do
 
       it 'does not read .ruby-version' do
         configuration.target_ruby_version
-        expect(File).not_to have_received(:file?).with('.ruby-version')
+        expect(File).not_to have_received(:file?).with(ruby_version_file)
       end
     end
 
     context 'when TargetRubyVersion is not set' do
       context 'when .ruby-version is present' do
         before do
-          allow(File).to receive(:file?).with('.ruby-version').and_return true
+          allow(File).to receive(:file?).with(ruby_version_file).and_return true
           allow(File)
             .to receive(:read)
-            .with('.ruby-version')
+            .with(ruby_version_file)
             .and_return ruby_version
         end
 
@@ -672,7 +676,7 @@ describe RuboCop::Config do
 
       context 'when .ruby-version is not present' do
         before do
-          allow(File).to receive(:file?).with('.ruby-version').and_return false
+          allow(File).to receive(:file?).with(ruby_version_file).and_return false
         end
 
         it 'uses the default target ruby version' do


### PR DESCRIPTION
Also find the .ruby-version file, even if rubocop is run from a
subdirectory.  Previously, rubocop would only look for the version file
in the current directory, thus falling back to the default ruby version,
even if there was a .ruby-version file in the root of the project.