### PR TITLE
Don't consider <=> for yoda condition :space_invader:

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@
 
 ### Bug fixes
 
+* [#4603](https://github.com/bbatsov/rubocop/pull/4603): Don't consider `<=>` for `Style/YodaCondition`. ([@iGEL][])
 * [#4443](https://github.com/bbatsov/rubocop/pull/4443): Prevent `Style/YodaCondition` from breaking `not LITERAL`. ([@pocke][])
 * [#4434](https://github.com/bbatsov/rubocop/issues/4434): Prevent bad auto-correct in `Style/Alias` for non-literal arguments. ([@drenmi][])
 * [#4451](https://github.com/bbatsov/rubocop/issues/4451): Make `Style/AndOr` cop aware of comparison methods. ([@drenmi][])

--- a/lib/rubocop/cop/style/yoda_condition.rb
+++ b/lib/rubocop/cop/style/yoda_condition.rb
@@ -57,7 +57,7 @@ module RuboCop
         private
 
         def yoda_condition?(node)
-          return false unless node.comparison_method?
+          return false if !node.comparison_method? || node.method_name == :<=>
 
           lhs, operator, rhs = *node
           if check_equality_only?

--- a/spec/rubocop/cop/style/yoda_condition_spec.rb
+++ b/spec/rubocop/cop/style/yoda_condition_spec.rb
@@ -52,6 +52,7 @@ describe RuboCop::Cop::Style::YodaCondition, :config do
   it_behaves_like 'accepts', '[1, 2, 3] <=> [4, 5, 6]'
   it_behaves_like 'accepts', '!true'
   it_behaves_like 'accepts', 'not true'
+  it_behaves_like 'accepts', '0 <=> val'
 
   it_behaves_like 'offense', '"foo" == bar'
   it_behaves_like 'offense', 'nil == bar'


### PR DESCRIPTION
I believe, the `<=>` operator should not be considered for the yoda condition. Maybe even `.comparison_method?` shouldn't consider it.

The main reason is, that this method in difference to all other comparison methods doesn't return a boolean, but `-1`, `0` or `1`. Thus `0 <=> a` isn't an alternative for `a <=> 0`, because the one returns `-1` while the other returns `1` (unless `a` is `0` of course).

I haven't checked, but I'm pretty sure the autocorrect will just exchange the left & right side, which is wrong!

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Used the same coding conventions as the rest of the project.
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] All tests(`rake spec`) are passing.
* [x] The new code doesn't generate RuboCop offenses that are checked by `rake internal_investigation`.
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [ ] Updated cop documentation with `rake generate_cops_documentation` (required only when you've added a new cop or changed the configuration/documentation of an existing cop).

[1]: http://chris.beams.io/posts/git-commit/
