### PR TITLE
Fix Style/LambdaCall to autocorrect obj.call to obj.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@
 
 ### Bug fixes
 
+* [#4604](https://github.com/bbatsov/rubocop/pull/4604): Fix `Style/LambdaCall` to autocorrect `obj.call` to `obj.`. ([@iGEL][])
 * [#4443](https://github.com/bbatsov/rubocop/pull/4443): Prevent `Style/YodaCondition` from breaking `not LITERAL`. ([@pocke][])
 * [#4434](https://github.com/bbatsov/rubocop/issues/4434): Prevent bad auto-correct in `Style/Alias` for non-literal arguments. ([@drenmi][])
 * [#4451](https://github.com/bbatsov/rubocop/issues/4451): Make `Style/AndOr` cop aware of comparison methods. ([@drenmi][])

--- a/lib/rubocop/cop/style/lambda_call.rb
+++ b/lib/rubocop/cop/style/lambda_call.rb
@@ -40,9 +40,30 @@ module RuboCop
 
               corrector.replace(node.source_range, replacement)
             else
+              add_parentheses(node, corrector) unless node.parenthesized?
               corrector.remove(node.loc.selector)
             end
           end
+        end
+
+        def add_parentheses(node, corrector)
+          if node.arguments.empty?
+            corrector.insert_after(node.source_range, '()')
+          else
+            corrector.replace(args_begin(node), '(')
+            corrector.insert_after(args_end(node), ')')
+          end
+        end
+
+        def args_begin(node)
+          loc = node.loc
+          selector =
+            node.super_type? || node.yield_type? ? loc.keyword : loc.selector
+          selector.end.resize(1)
+        end
+
+        def args_end(node)
+          node.loc.expression.end
         end
 
         def message(_node)

--- a/spec/rubocop/cop/style/lambda_call_spec.rb
+++ b/spec/rubocop/cop/style/lambda_call_spec.rb
@@ -61,5 +61,15 @@ describe RuboCop::Cop::Style::LambdaCall, :config do
       new_source = autocorrect_source(['a.call(x)'])
       expect(new_source).to eq('a.(x)')
     end
+
+    it 'auto-corrects x.call to x.()' do
+      new_source = autocorrect_source(['a.call'])
+      expect(new_source).to eq('a.()')
+    end
+
+    it 'auto-corrects x.call asdf, x123 to x.(asdf, x123)' do
+      new_source = autocorrect_source(['a.call asdf, x123'])
+      expect(new_source).to eq('a.(asdf, x123)')
+    end
   end
 end


### PR DESCRIPTION
The autocorrection of `Style/LambdaCall` generated invalid code when set to `braces` and the call didn't had parentheses (eg. `obj.call` was "corrected" to `obj.` instead of `obj.()`).

The code partially comes from `Style/MethodCallWithArgsParentheses`.

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Used the same coding conventions as the rest of the project.
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] All tests(`rake spec`) are passing.
* [x] The new code doesn't generate RuboCop offenses that are checked by `rake internal_investigation`.
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [ ] Updated cop documentation with `rake generate_cops_documentation` (required only when you've added a new cop or changed the configuration/documentation of an existing cop).

[1]: http://chris.beams.io/posts/git-commit/
