### PR TITLE
Fixing missing commas for arrays in samples.

### DIFF
--- a/lib/rubocop/cop/layout/align_array.rb
+++ b/lib/rubocop/cop/layout/align_array.rb
@@ -8,14 +8,14 @@ module RuboCop
       #
       # @example
       #   # bad
-      #   a = [1, 2, 3
+      #   a = [1, 2, 3,
       #     4, 5, 6]
       #   array = ['run',
       #        'forrest',
       #        'run']
       #
       #   # good
-      #   a = [1, 2, 3
+      #   a = [1, 2, 3,
       #        4, 5, 6]
       #   a = ['run',
       #        'forrest',

--- a/manual/cops_layout.md
+++ b/manual/cops_layout.md
@@ -66,14 +66,14 @@ aligned.
 
 ```ruby
 # bad
-a = [1, 2, 3
+a = [1, 2, 3,
   4, 5, 6]
 array = ['run',
      'forrest',
      'run']
 
 # good
-a = [1, 2, 3
+a = [1, 2, 3,
      4, 5, 6]
 a = ['run',
      'forrest',


### PR DESCRIPTION
The good / bad examples both have arrays that wouldn’t parse. Addin missing commas to make it more clear.
