### PR TITLE
[Fix #4285] Make `Lint/DefEndAlignment` aware of multiple modifiers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,7 @@
 * [#4587](https://github.com/bbatsov/rubocop/pull/4587): Fix false negative for void unary operators in `Lint/Void` cop. ([@pocke][])
 * [#4589](https://github.com/bbatsov/rubocop/issues/4589): Fix false positive in `Performance/RegexpMatch` cop for `=~` is in a class method. ([@pocke][])
 * [#4578](https://github.com/bbatsov/rubocop/issues/4578): Fix false positive in `Lint/FormatParameterMismatch` for format with "asterisk" (`*`) width and precision. ([@smakagon][])
+* [#4285](https://github.com/bbatsov/rubocop/issues/4285): Make `Lint/DefEndAlignment` aware of multiple modifiers. ([@drenmi][])
 
 ### Changes
 

--- a/lib/rubocop/ast/node/mixin/method_dispatch_node.rb
+++ b/lib/rubocop/ast/node/mixin/method_dispatch_node.rb
@@ -115,6 +115,18 @@ module RuboCop
         parent if block_literal?
       end
 
+      # Checks if this node is part of a chain of `def` modifiers.
+      #
+      # @example
+      #
+      #   private def foo; end
+      #
+      # @return [Boolean] whether the dispatched method is a `def` modifier
+      def def_modifier?
+        send_type? &&
+          [self, *each_descendant(:send)].any?(&:adjacent_def_modifier?)
+      end
+
       private
 
       def_node_matcher :macro_scope?, <<-PATTERN
@@ -122,7 +134,7 @@ module RuboCop
          ^^({class module} ... (begin ...))}
       PATTERN
 
-      def_node_matcher :prefixed_def_modifier?, <<-PATTERN
+      def_node_matcher :adjacent_def_modifier?, <<-PATTERN
         (send nil _ ({def defs} ...))
       PATTERN
     end

--- a/lib/rubocop/cop/layout/indentation_width.rb
+++ b/lib/rubocop/cop/layout/indentation_width.rb
@@ -97,7 +97,7 @@ module RuboCop
 
         def on_send(node)
           super
-          return unless node.prefixed_def_modifier?
+          return unless node.adjacent_def_modifier?
 
           *_, body = *node.first_argument
 

--- a/lib/rubocop/cop/lint/def_end_alignment.rb
+++ b/lib/rubocop/cop/lint/def_end_alignment.rb
@@ -47,9 +47,9 @@ module RuboCop
         alias on_defs on_def
 
         def on_send(node)
-          return unless node.prefixed_def_modifier?
+          return unless node.def_modifier?
 
-          method_def = node.first_argument
+          method_def = node.each_descendant(:def, :defs).first
           expr = node.source_range
 
           line_start = range_between(expr.begin_pos,

--- a/spec/rubocop/ast/send_node_spec.rb
+++ b/spec/rubocop/ast/send_node_spec.rb
@@ -715,4 +715,18 @@ describe RuboCop::AST::SendNode do
       it { expect(send_node.splat_argument?).to be_truthy }
     end
   end
+
+  describe '#def_modifier?' do
+    context 'with a prefixed def modifier' do
+      let(:source) { 'foo def bar; end' }
+
+      it { expect(send_node.def_modifier?).to be_truthy }
+    end
+
+    context 'with several prefixed def modifiers' do
+      let(:source) { 'foo bar def baz; end' }
+
+      it { expect(send_node.def_modifier?).to be_truthy }
+    end
+  end
 end

--- a/spec/rubocop/cop/lint/def_end_alignment_spec.rb
+++ b/spec/rubocop/cop/lint/def_end_alignment_spec.rb
@@ -29,6 +29,7 @@ describe RuboCop::Cop::Lint::DefEndAlignment, :config do
 
     context 'in ruby 2.1 or later' do
       include_examples 'aligned', 'foo def', 'test', 'end'
+      include_examples 'aligned', 'foo bar def', 'test', 'end'
 
       include_examples('misaligned', '',
                        'foo def', 'test',


### PR DESCRIPTION
When configured to align with start of line, this cop correctly handled cases with a single `def` modifier, e.g.:

```
foo def bar
end
```

but failed in cases with several modifiers, e.g.:

```
foo bar def baz
end
```

This change fixes that.

-----------------

Before submitting the PR make sure the following are checked:

* [X] Wrote [good commit messages][1].
* [X] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [X] Used the same coding conventions as the rest of the project.
* [X] Feature branch is up-to-date with `master` (if not - rebase it).
* [X] Squashed related commits together.
* [X] Added tests.
* [X] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [X] All tests(`rake spec`) are passing.
* [X] The new code doesn't generate RuboCop offenses that are checked by `rake internal_investigation`.
* [X] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [ ] Updated cop documentation with `rake generate_cops_documentation` (required only when you've added a new cop or changed the configuration/documentation of an existing cop).

[1]: http://chris.beams.io/posts/git-commit/
