### PR TITLE
[Fix #4368] Extend flexibility of `Performance/HashEachMethod cop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@
 * [#2976](https://github.com/bbatsov/rubocop/issues/2976): Add `Whitelist` configuration option to `Style/NestedParenthesizedCalls` cop. ([@drenmi][])
 * [#3965](https://github.com/bbatsov/rubocop/issues/3965): Add new `Style/DoublePipeEquals` cop. ([@donjar][])
 * Make `rake new_cop` create parent directories if they do not already exist. ([@highb][])
+* [#4368](https://github.com/bbatsov/rubocop/issues/4368): Make `Performance/HashEachMethod` inspect send nodes with any receiver. ([@gohdaniel15][])
 
 ### Bug fixes
 

--- a/lib/rubocop/config.rb
+++ b/lib/rubocop/config.rb
@@ -174,6 +174,10 @@ module RuboCop
       @hash.keys
     end
 
+    def each_key(&block)
+      @hash.each_key(&block)
+    end
+
     def map(&block)
       @hash.map(&block)
     end
@@ -195,7 +199,7 @@ module RuboCop
     end
 
     def make_excludes_absolute
-      each do |key, _|
+      each_key do |key|
         validate_section_presence(key)
         next unless self[key]['Exclude']
 

--- a/lib/rubocop/config_loader.rb
+++ b/lib/rubocop/config_loader.rb
@@ -59,14 +59,16 @@ module RuboCop
         config
       end
 
+      # rubocop:disable Performance/HashEachMethods
       def add_missing_namespaces(path, hash)
-        hash.keys.each do |k|
-          q = Cop::Cop.qualified_cop_name(k, path)
-          next if q == k
+        hash.keys.each do |key|
+          q = Cop::Cop.qualified_cop_name(key, path)
+          next if q == key
 
-          hash[q] = hash.delete(k)
+          hash[q] = hash.delete(key)
         end
       end
+      # rubocop:enable Performance/HashEachMethods
 
       # Return a recursive merge of two hashes. That is, a normal hash merge,
       # with the addition that any value that is a hash, and occurs in both

--- a/lib/rubocop/cop/lint/percent_string_array.rb
+++ b/lib/rubocop/cop/lint/percent_string_array.rb
@@ -53,6 +53,7 @@ module RuboCop
           end
         end
 
+        # rubocop:disable Performance/HashEachMethods
         def autocorrect(node)
           lambda do |corrector|
             node.values.each do |value|
@@ -65,6 +66,18 @@ module RuboCop
                 corrector.remove_leading(range, 1)
               end
             end
+          end
+        end
+        # rubocop:enable Performance/HashEachMethod
+
+        def scrub_string(string)
+          if string.respond_to?(:scrub)
+            string.scrub
+          else
+            string
+              .encode('UTF-16BE', 'UTF-8',
+                      invalid: :replace, undef: :replace, replace: '?')
+              .encode('UTF-8')
           end
         end
       end

--- a/lib/rubocop/cop/performance/hash_each_methods.rb
+++ b/lib/rubocop/cop/performance/hash_each_methods.rb
@@ -21,29 +21,41 @@ module RuboCop
         MSG = 'Use `%s` instead of `%s`.'.freeze
 
         def_node_matcher :plain_each, <<-PATTERN
-          (block $(send (send _ :hash) :each) (args (arg $_k) (arg $_v)) ...)
+          (block $(send _ :each) (args (arg $_k) (arg $_v)) ...)
         PATTERN
 
         def_node_matcher :kv_each, <<-PATTERN
-          (block $(send (send (send _ :hash) ${:keys :values}) :each) ...)
+          (block $(send (send _ ${:keys :values}) :each) ...)
         PATTERN
 
         def on_block(node)
-          plain_each(node) do |target, k, v|
-            return if @args[k] && @args[v]
-            used = @args[k] ? :key : :value
-            add_offense(target, range(target), format(message,
-                                                      "each_#{used}",
-                                                      :each))
-          end
-          kv_each(node) do |target, method|
-            add_offense(target, range(target), format(message,
-                                                      "each_#{method[0..-2]}",
-                                                      "#{method}.each"))
-          end
+          register_each_offense(node)
+          register_kv_offense(node)
         end
 
         private
+
+        def register_each_offense(node)
+          plain_each(node) do |target, k, v|
+            return if @args[k] && @args[v]
+            used = @args[k] ? :key : :value
+            add_offense(
+              target, plain_range(target), format(message,
+                                                  "each_#{used}",
+                                                  :each)
+            )
+          end
+        end
+
+        def register_kv_offense(node)
+          kv_each(node) do |target, method|
+            add_offense(
+              target, kv_range(target), format(message,
+                                               "each_#{method[0..-2]}",
+                                               "#{method}.each")
+            )
+          end
+        end
 
         def check_argument(variable)
           return unless variable.block_argument?
@@ -55,17 +67,32 @@ module RuboCop
           caller, first_method = *receiver
 
           lambda do |corrector|
-            if receiver.method?(:hash)
-              correct_hash(node, corrector)
-            else
+            if first_method.eql?(:keys) || first_method.eql?(:values)
+              return correct_implicit(node, corrector) if receiver
+                                                          .child_nodes
+                                                          .first.nil?
+
               new_source = caller.source + ".each_#{first_method[0..-2]}"
               corrector.replace(node.loc.expression, new_source)
+            else
+              return correct_implicit(node, corrector) if receiver.nil?
+
+              correct_plain_each(node, corrector)
             end
           end
         end
 
-        def correct_hash(node, corrector)
-          method = @args.values.first ? :key : :value
+        def correct_implicit(node, corrector)
+          method = @args.key(true).eql?(:k) ? :key : :value
+          new_source = "each_#{method}"
+
+          corrector.replace(node.loc.expression, new_source)
+
+          correct_args(node, corrector)
+        end
+
+        def correct_plain_each(node, corrector)
+          method = @args.key(true).eql?(:k) ? :key : :value
           new_source = node.receiver.source + ".each_#{method}"
 
           corrector.replace(node.loc.expression, new_source)
@@ -80,7 +107,11 @@ module RuboCop
           corrector.replace(args.source_range, used_arg)
         end
 
-        def range(outer_node)
+        def plain_range(outer_node)
+          outer_node.loc.selector
+        end
+
+        def kv_range(outer_node)
           inner_node = outer_node.children.first
           inner_node.loc.selector.join(outer_node.loc.selector)
         end

--- a/lib/rubocop/cop/rails/active_support_aliases.rb
+++ b/lib/rubocop/cop/rails/active_support_aliases.rb
@@ -38,7 +38,7 @@ module RuboCop
         end
 
         def on_send(node)
-          ALIASES.keys.each do |aliased_method|
+          ALIASES.each_key do |aliased_method|
             register_offense(node, aliased_method) if
               public_send(aliased_method, node)
           end

--- a/lib/rubocop/cop/rails/save_bang.rb
+++ b/lib/rubocop/cop/rails/save_bang.rb
@@ -56,7 +56,7 @@ module RuboCop
         end
 
         def after_leaving_scope(scope, _variable_table)
-          scope.variables.each do |_name, variable|
+          scope.variables.each_value do |variable|
             variable.assignments.each do |assignment|
               check_assignment(assignment)
             end

--- a/lib/rubocop/cop/style/special_global_vars.rb
+++ b/lib/rubocop/cop/style/special_global_vars.rb
@@ -47,8 +47,8 @@ module RuboCop
         PERL_VARS.merge!(
           Hash[PERL_VARS.flat_map { |_, vs| vs.map { |v| [v, [v]] } }]
         )
-        ENGLISH_VARS.each { |_, v| v.freeze }.freeze
-        PERL_VARS.each { |_, v| v.freeze }.freeze
+        ENGLISH_VARS.each_value(&:freeze).freeze
+        PERL_VARS.each_value(&:freeze).freeze
 
         # Anything *not* in this set is provided by the English library.
         NON_ENGLISH_VARS = Set.new(%i[

--- a/spec/project_spec.rb
+++ b/spec/project_spec.rb
@@ -38,7 +38,7 @@ describe 'RuboCop Project' do
       cop_names.each do |name|
         enforced_styles = config[name]
                           .select { |key, _| key.start_with?('Enforced') }
-        enforced_styles.each do |style_name, _style|
+        enforced_styles.each_key do |style_name|
           supported_key = RuboCop::Cop::Util.to_supported_styles(style_name)
           valid = config[name][supported_key]
           errors.push("#{supported_key} is missing for #{name}") unless valid

--- a/spec/rubocop/cop/performance/hash_each_methods_spec.rb
+++ b/spec/rubocop/cop/performance/hash_each_methods_spec.rb
@@ -3,67 +3,218 @@
 describe RuboCop::Cop::Performance::HashEachMethods do
   subject(:cop) { described_class.new }
 
-  it 'registers an offense for Hash#keys.each' do
-    expect_offense(<<-RUBY.strip_indent)
-      hash.keys.each { |k| p k }
-           ^^^^^^^^^ Use `each_key` instead of `keys.each`.
-    RUBY
+  context 'when node matches a plain `#each` ' \
+  'with unused key or value' do
+    context 'when receiver is a send' do
+      it 'registers an offense for foo#each with unused value' do
+        expect_offense(<<-RUBY.strip_indent)
+          foo.each { |k, _v| p k }
+              ^^^^ Use `each_key` instead of `each`.
+        RUBY
+      end
+
+      it 'does not register an offense for foo#each' \
+      ' if both key/value are used' do
+        expect_no_offenses("foo.each { |k, v| p \"\#{k}_\#{v}\" }")
+      end
+
+      it 'does not register an offense for foo#each ' \
+      ' if block takes only one arg' do
+        expect_no_offenses('foo.each { |kv| p kv }')
+      end
+
+      it 'registers an offense for foo#each with unused key' do
+        expect_offense(<<-RUBY.strip_indent)
+          foo.each { |_k, v| p v }
+              ^^^^ Use `each_value` instead of `each`.
+        RUBY
+      end
+
+      it 'auto-corrects foo#each with unused value argument' \
+      ' with foo#each_key' do
+        new_source = autocorrect_source('foo.each { |k, _v| p k }')
+        expect(new_source).to eq('foo.each_key { |k| p k }')
+      end
+    end
+
+    context 'when receiver is a hash literal' do
+      it 'registers an offense for {}#each with unused value' do
+        expect_offense(<<-RUBY.strip_indent)
+          {}.each { |k, _v| p k }
+             ^^^^ Use `each_key` instead of `each`.
+        RUBY
+      end
+
+      it 'registers an offense for {}#each with unused key' do
+        expect_offense(<<-RUBY.strip_indent)
+          {}.each { |_k, v| p v }
+             ^^^^ Use `each_value` instead of `each`.
+        RUBY
+      end
+
+      it 'does not register an offense for {}#each' \
+      ' if both key/value are used' do
+        expect_no_offenses("{}.each { |k, v| p \"\#{k}_\#{v}\" }")
+      end
+
+      it 'does not register an offense for {}#each ' \
+      ' if block takes only one arg' do
+        expect_no_offenses('{}.each { |kv| p kv }')
+      end
+
+      it 'auto-corrects {}#each with unused value argument' \
+      ' with {}#each_key' do
+        new_source = autocorrect_source('{}.each { |k, _v| p k }')
+        expect(new_source).to eq('{}.each_key { |k| p k }')
+      end
+
+      it 'auto-corrects {}#each with unused key argument' \
+      ' with {}#each_value' do
+        new_source = autocorrect_source('{}.each { |_k, v| p v }')
+        expect(new_source).to eq('{}.each_value { |v| p v }')
+      end
+    end
+
+    context 'when receiver is implicit' do
+      it 'registers an offense for each with unused value' do
+        expect_offense(<<-RUBY.strip_indent)
+          each { |k, _v| p k }
+          ^^^^ Use `each_key` instead of `each`.
+        RUBY
+      end
+
+      it 'registers an offense for each with unused key' do
+        expect_offense(<<-RUBY.strip_indent)
+          each { |_k, v| p v }
+          ^^^^ Use `each_value` instead of `each`.
+        RUBY
+      end
+
+      it 'does not register an offense for each' \
+      ' if both key/value are used' do
+        expect_no_offenses("each { |k, v| p \"\#{k}_\#{v}\" }")
+      end
+
+      it 'does not register an offense for each ' \
+      ' if block takes only one arg' do
+        expect_no_offenses('each { |kv| p kv }')
+      end
+
+      it 'auto-corrects each with unused value argument' \
+      ' with each_key' do
+        new_source = autocorrect_source('each { |k, _v| p k }')
+        expect(new_source).to eq('each_key { |k| p k }')
+      end
+
+      it 'auto-corrects each with unused key argument' \
+      ' with each_value' do
+        new_source = autocorrect_source('each { |_k, v| p v }')
+        expect(new_source).to eq('each_value { |v| p v }')
+      end
+    end
   end
 
-  it 'registers an offense for Hash#values.each' do
-    expect_offense(<<-RUBY.strip_indent)
-      hash.values.each { |v| p v }
-           ^^^^^^^^^^^ Use `each_value` instead of `values.each`.
-    RUBY
-  end
+  context 'when node matches a keys#each or values#each' do
+    context 'when receiver is a send' do
+      it 'registers an offense for foo#keys.each' do
+        expect_offense(<<-RUBY.strip_indent)
+          foo.keys.each { |k| p k }
+              ^^^^^^^^^ Use `each_key` instead of `keys.each`.
+        RUBY
+      end
 
-  it 'registers an offense for Hash#each with unused value' do
-    expect_offense(<<-RUBY.strip_indent)
-      hash.each { |k, _v| p k }
-      ^^^^^^^^^ Use `each_key` instead of `each`.
-    RUBY
-  end
+      it 'registers an offense for foo#values.each' do
+        expect_offense(<<-RUBY.strip_indent)
+          foo.values.each { |v| p v }
+              ^^^^^^^^^^^ Use `each_value` instead of `values.each`.
+        RUBY
+      end
 
-  it 'registers an offense for Hash#each with unused key' do
-    expect_offense(<<-RUBY.strip_indent)
-      hash.each { |_k, v| p v }
-      ^^^^^^^^^ Use `each_value` instead of `each`.
-    RUBY
-  end
+      it 'does not register an offense for foo#each_key' do
+        expect_no_offenses('foo.each_key { |k| p k }')
+      end
 
-  it 'does not register an offense for Hash#each_key' do
-    expect_no_offenses('hash.each_key { |k| p k }')
-  end
+      it 'does not register an offense for Hash#each_value' do
+        expect_no_offenses('foo.each_value { |v| p v }')
+      end
 
-  it 'does not register an offense for Hash#each_value' do
-    expect_no_offenses('hash.each_value { |v| p v }')
-  end
+      it 'auto-corrects foo#keys.each with foo#each_key' do
+        new_source = autocorrect_source('foo.keys.each { |k| p k }')
+        expect(new_source).to eq('foo.each_key { |k| p k }')
+      end
 
-  it 'does not register an offense for Hash#each if both key/value are used' do
-    expect_no_offenses("hash.each { |k, v| p \"\#{k}_\#{v}\" }")
-  end
+      it 'auto-corrects foo#values.each with foo#each_value' do
+        new_source = autocorrect_source('foo.values.each { |v| p v }')
+        expect(new_source).to eq('foo.each_value { |v| p v }')
+      end
+    end
 
-  it 'does not register an offense for Hash#each if block takes only one arg' do
-    expect_no_offenses('hash.each { |kv| p kv }')
-  end
+    context 'when receiver is a hash literal' do
+      it 'registers an offense for {}#keys.each' do
+        expect_offense(<<-RUBY.strip_indent)
+          {}.keys.each { |k| p k }
+             ^^^^^^^^^ Use `each_key` instead of `keys.each`.
+        RUBY
+      end
 
-  it 'auto-corrects Hash#keys.each with Hash#each_key' do
-    new_source = autocorrect_source('hash.keys.each { |k| p k }')
-    expect(new_source).to eq('hash.each_key { |k| p k }')
-  end
+      it 'registers an offense for {}#values.each' do
+        expect_offense(<<-RUBY.strip_indent)
+          {}.values.each { |v| p v }
+             ^^^^^^^^^^^ Use `each_value` instead of `values.each`.
+        RUBY
+      end
 
-  it 'auto-corrects Hash#values.each with Hash#each_value' do
-    new_source = autocorrect_source('hash.values.each { |v| p v }')
-    expect(new_source).to eq('hash.each_value { |v| p v }')
-  end
+      it 'does not register an offense for {}#each_key' do
+        expect_no_offenses('{}.each_key { |k| p k }')
+      end
 
-  it 'auto-corrects Hash#each with unused value argument with Hash#each_key' do
-    new_source = autocorrect_source('hash.each { |k, _v| p k }')
-    expect(new_source).to eq('hash.each_key { |k| p k }')
-  end
+      it 'does not register an offense for {}#each_value' do
+        expect_no_offenses('{}.each_value { |v| p v }')
+      end
 
-  it 'auto-corrects Hash#each with unused key argument with Hash#each_value' do
-    new_source = autocorrect_source('hash.each { |_k, v| p v }')
-    expect(new_source).to eq('hash.each_value { |v| p v }')
+      it 'auto-corrects {}#keys.each with {}#each_key' do
+        new_source = autocorrect_source('{}.keys.each { |k| p k }')
+        expect(new_source).to eq('{}.each_key { |k| p k }')
+      end
+
+      it 'auto-corrects {}#values.each with {}#each_value' do
+        new_source = autocorrect_source('{}.values.each { |v| p v }')
+        expect(new_source).to eq('{}.each_value { |v| p v }')
+      end
+    end
+
+    context 'when receiver is implicit' do
+      it 'registers an offense for keys.each' do
+        expect_offense(<<-RUBY.strip_indent)
+          keys.each { |k| p k }
+          ^^^^^^^^^ Use `each_key` instead of `keys.each`.
+        RUBY
+      end
+
+      it 'registers an offense for values.each' do
+        expect_offense(<<-RUBY.strip_indent)
+          values.each { |v| p v }
+          ^^^^^^^^^^^ Use `each_value` instead of `values.each`.
+        RUBY
+      end
+
+      it 'does not register an offense for each_key' do
+        expect_no_offenses('each_key { |k| p k }')
+      end
+
+      it 'does not register an offense for each_value' do
+        expect_no_offenses('each_value { |v| p v }')
+      end
+
+      it 'auto-corrects keys.each with each_key' do
+        new_source = autocorrect_source('keys.each { |k| p k }')
+        expect(new_source).to eq('each_key { |k| p k }')
+      end
+
+      it 'auto-corrects values.each with each_value' do
+        new_source = autocorrect_source('values.each { |v| p v }')
+        expect(new_source).to eq('each_value { |v| p v }')
+      end
+    end
   end
 end


### PR DESCRIPTION
This PR extends the node matching capability of the `Performance/HashEachMethod` cop. Prior to this, the node matcher would only work on `Hash`. This has been extended to match any node. 

This cop was then run on the codebase, and the fixes were implemented in a70086b. 
Please see comments that I have left on the individual files. 

-----------------

Before submitting the PR make sure the following are checked:

* [X] Wrote [good commit messages][1].
* [X] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [X] Used the same coding conventions as the rest of the project.
* [X] Feature branch is up-to-date with `master` (if not - rebase it).
* [X] Squashed related commits together.
* [X] Added tests.
* [X] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [X] All tests(`rake spec`) are passing.
* [X] The new code doesn't generate RuboCop offenses that are checked by `rake internal_investigation`.
* [X] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [ ] Updated cop documentation with `rake generate_cops_documentation` (required only when you've added a new cop or changed the configuration/documentation of an existing cop).

[1]: http://chris.beams.io/posts/git-commit/
