### PR TITLE
Remove false positives from known commands in `Style/MethodCallWithArgsParentheses`

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -44,3 +44,10 @@ Metrics/ModuleLength:
 Performance/Caller:
   Exclude:
     - spec/rubocop/cop/performance/caller_spec.rb
+
+Style/MethodCallWithArgsParentheses:
+  Enabled: true
+  Exclude:
+    - 'Gemfile'
+    - 'lib/rubocop/rspec/**/*'
+    - 'spec/**/*.rb'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,7 @@
 * [#4589](https://github.com/bbatsov/rubocop/issues/4589): Fix false positive in `Performance/RegexpMatch` cop for `=~` is in a class method. ([@pocke][])
 * [#4578](https://github.com/bbatsov/rubocop/issues/4578): Fix false positive in `Lint/FormatParameterMismatch` for format with "asterisk" (`*`) width and precision. ([@smakagon][])
 * [#4285](https://github.com/bbatsov/rubocop/issues/4285): Make `Lint/DefEndAlignment` aware of multiple modifiers. ([@drenmi][])
+* Remove false positives from known methods in `Style/MethodCallWithArgsParentheses` cop. ([@drenmi][])
 
 ### Changes
 
@@ -58,6 +59,7 @@
 * Rename `Style/HeredocDelimiters` to `Style/HeredocDelimiterNaming`. ([@drenmi][])
 * [#4157](https://github.com/bbatsov/rubocop/issues/4157): Enhance offense message for `Style/RedudantReturn` cop. ([@gohdaniel15][])
 * [#4521](https://github.com/bbatsov/rubocop/issues/4521): Move naming related cops into their own `Naming` department. ([@drenmi][])
+* Make `Style/MethodCallWithArgsParentheses` cop enabled by default. ([@drenmi][])
 
 ## 0.49.1 (2017-05-29)
 

--- a/Rakefile
+++ b/Rakefile
@@ -15,7 +15,7 @@ require 'rspec/core'
 require 'rspec/core/rake_task'
 require 'rubocop/rake_task'
 
-Dir['tasks/**/*.rake'].each { |t| load t }
+Dir['tasks/**/*.rake'].each { |t| load(t) }
 
 RSpec::Core::RakeTask.new(:spec) { |t| t.ruby_opts = '-E UTF-8' }
 RSpec::Core::RakeTask.new(:ascii_spec) { |t| t.ruby_opts = '-E ASCII' }

--- a/config/default.yml
+++ b/config/default.yml
@@ -990,6 +990,11 @@ Style/LambdaCall:
     - braces
 
 Style/MethodCallWithArgsParentheses:
+  Exclude:
+    - 'Gemfile'
+    - 'app/controllers/**/*'
+    - 'app/models/**/*'
+    - 'spec/**/*'
   IgnoreMacros: true
   IgnoredMethods: []
 

--- a/config/disabled.yml
+++ b/config/disabled.yml
@@ -69,11 +69,6 @@ Style/InlineComment:
   Description: 'Avoid trailing inline comments.'
   Enabled: false
 
-Style/MethodCallWithArgsParentheses:
-  Description: 'Use parentheses for method calls with arguments.'
-  StyleGuide: '#method-invocation-parens'
-  Enabled: false
-
 Style/MethodCalledOnDoEndBlock:
   Description: 'Avoid chaining a method call on a do...end block.'
   StyleGuide: '#single-line-blocks'

--- a/config/enabled.yml
+++ b/config/enabled.yml
@@ -670,6 +670,11 @@ Style/LineEndConcatenation:
                  line end.
   Enabled: true
 
+Style/MethodCallWithArgsParentheses:
+  Description: 'Use parentheses for method calls with arguments.'
+  StyleGuide: '#method-invocation-parens'
+  Enabled: true
+
 Style/MethodCallWithoutArgsParentheses:
   Description: 'Do not use parentheses for method calls with no arguments.'
   StyleGuide: '#method-invocation-parens'

--- a/lib/rubocop/ast/node/mixin/method_identifier_predicates.rb
+++ b/lib/rubocop/ast/node/mixin/method_identifier_predicates.rb
@@ -12,6 +12,13 @@ module RuboCop
                               map reduce reject reject! reverse_each select
                               select! times upto].freeze
 
+      # A list of methods which are unparenthesized by convention.
+      UNPARENTHESIZED_COMMANDS = %i[abort alias_method attr_reader attr_writer
+                                    attr_accessor desc exit exit! extend fail
+                                    gets include namespace print puts raise
+                                    require require_relative sleep super task
+                                    throw warn write yield].freeze
+
       # Checks whether the method name matches the argument.
       #
       # @param [Symbol, String] name the method name to check for
@@ -83,6 +90,17 @@ module RuboCop
       # @return [Boolean] whether the receiver of this node is a `const` node
       def const_receiver?
         receiver && receiver.const_type?
+      end
+
+      # Checks whether calls to this method are usually unparenthesized
+      # by convention.
+      #
+      # @return [Boolean] whether calls to this method are unparenthesized
+      #                   by convention
+      def conventionally_unparenthesized?
+        setter_method? || operator_method? ||
+          receiver && receiver.gvar_type? ||
+          UNPARENTHESIZED_COMMANDS.include?(method_name)
       end
     end
   end

--- a/lib/rubocop/cli.rb
+++ b/lib/rubocop/cli.rb
@@ -92,7 +92,7 @@ module RuboCop
     end
 
     def handle_exiting_options
-      return unless Options::EXITING_OPTIONS.any? { |o| @options.key? o }
+      return unless Options::EXITING_OPTIONS.any? { |o| @options.key?(o) }
 
       puts RuboCop::Version.version(false) if @options[:version]
       puts RuboCop::Version.version(true) if @options[:verbose_version]

--- a/lib/rubocop/config_loader.rb
+++ b/lib/rubocop/config_loader.rb
@@ -239,7 +239,7 @@ module RuboCop
           break if dir_pathname.to_s == @root_level
           dirs_to_search << dir_pathname.to_s
         end
-        dirs_to_search << Dir.home if ENV.key? 'HOME'
+        dirs_to_search << Dir.home if ENV.key?('HOME')
         dirs_to_search
       end
     end

--- a/lib/rubocop/config_loader_resolver.rb
+++ b/lib/rubocop/config_loader_resolver.rb
@@ -35,7 +35,7 @@ module RuboCop
         hash['inherit_from'] = Array(hash['inherit_from'])
         Array(config_path).reverse.each do |path|
           # Put gem configuration first so local configuration overrides it.
-          hash['inherit_from'].unshift gem_config_path(gem_name, path)
+          hash['inherit_from'].unshift(gem_config_path(gem_name, path))
         end
       end
     end

--- a/lib/rubocop/cop/commissioner.rb
+++ b/lib/rubocop/cop/commissioner.rb
@@ -34,7 +34,7 @@ module RuboCop
 
       callback_methods.each do |callback|
         next unless method_defined?(callback)
-        class_eval <<-RUBY, __FILE__, __LINE__ + 1
+        class_eval(<<-RUBY, __FILE__, __LINE__ + 1)
           def #{callback}(node)
             @callbacks[:"#{callback}"] ||= @cops.select do |cop|
               cop.respond_to?(:"#{callback}")

--- a/lib/rubocop/cop/lint/useless_access_modifier.rb
+++ b/lib/rubocop/cop/lint/useless_access_modifier.rb
@@ -191,7 +191,7 @@ module RuboCop
           cop_config.fetch('MethodCreatingMethods', []).any? do |m|
             matcher_name = "#{m}_method?".to_sym
             unless respond_to?(matcher_name)
-              self.class.def_node_matcher matcher_name, <<-PATTERN
+              self.class.def_node_matcher(matcher_name, <<-PATTERN)
                 {def (send nil :#{m} ...)}
               PATTERN
             end
@@ -215,7 +215,7 @@ module RuboCop
           cop_config.fetch('ContextCreatingMethods', []).any? do |m|
             matcher_name = "#{m}_block?".to_sym
             unless respond_to?(matcher_name)
-              self.class.def_node_matcher matcher_name, <<-PATTERN
+              self.class.def_node_matcher(matcher_name, <<-PATTERN)
                 (block (send {nil const} {:#{m}} ...) ...)
               PATTERN
             end

--- a/lib/rubocop/cop/mixin/enforce_superclass.rb
+++ b/lib/rubocop/cop/mixin/enforce_superclass.rb
@@ -5,12 +5,12 @@ module RuboCop
     # Common functionality for enforcing a specific superclass
     module EnforceSuperclass
       def self.included(base)
-        base.def_node_matcher :class_definition, <<-PATTERN
-        (class (const _ !:#{base::SUPERCLASS}) #{base::BASE_PATTERN} ...)
+        base.def_node_matcher(:class_definition, <<-PATTERN)
+          (class (const _ !:#{base::SUPERCLASS}) #{base::BASE_PATTERN} ...)
         PATTERN
 
-        base.def_node_matcher :class_new_definition, <<-PATTERN
-        [!^(casgn nil :#{base::SUPERCLASS} ...) (send (const nil :Class) :new #{base::BASE_PATTERN})]
+        base.def_node_matcher(:class_new_definition, <<-PATTERN)
+          [!^(casgn nil :#{base::SUPERCLASS} ...) (send (const nil :Class) :new #{base::BASE_PATTERN})]
         PATTERN
       end
 

--- a/lib/rubocop/cop/rails/active_support_aliases.rb
+++ b/lib/rubocop/cop/rails/active_support_aliases.rb
@@ -34,7 +34,7 @@ module RuboCop
         }.freeze
 
         ALIASES.each do |aliased_method, options|
-          def_node_matcher aliased_method, options[:matcher]
+          def_node_matcher(aliased_method, options[:matcher])
         end
 
         def on_send(node)

--- a/lib/rubocop/cop/rails/time_zone.rb
+++ b/lib/rubocop/cop/rails/time_zone.rb
@@ -111,10 +111,10 @@ module RuboCop
         # called is part of the time class.
         def method_from_time_class?(node)
           receiver, method_name, *_args = *node
-          if (receiver.is_a? RuboCop::AST::Node) && !receiver.cbase_type?
+          if receiver && !receiver.cbase_type?
             method_from_time_class?(receiver)
           else
-            TIMECLASS.include? method_name
+            TIMECLASS.include?(method_name)
           end
         end
 

--- a/lib/rubocop/cop/style/conditional_assignment.rb
+++ b/lib/rubocop/cop/style/conditional_assignment.rb
@@ -231,7 +231,7 @@ module RuboCop
         PATTERN
 
         ASSIGNMENT_TYPES.each do |type|
-          define_method "on_#{type}" do |node|
+          define_method("on_#{type}") do |node|
             return if part_of_ignored_node?(node)
 
             check_assignment_to_condition(node)

--- a/lib/rubocop/cop/style/method_call_with_args_parentheses.rb
+++ b/lib/rubocop/cop/style/method_call_with_args_parentheses.rb
@@ -61,7 +61,7 @@ module RuboCop
         end
 
         def ignored_method?(node)
-          node.operator_method? || node.setter_method? ||
+          node.conventionally_unparenthesized? ||
             ignore_macros? && node.macro? ||
             ignored_list.include?(node.method_name)
         end

--- a/lib/rubocop/cop/style/multiple_comparison.rb
+++ b/lib/rubocop/cop/style/multiple_comparison.rb
@@ -62,7 +62,7 @@ module RuboCop
 
         def nested_comparison?(node)
           if node.or_type?
-            node.node_parts.all? { |node_part| comparison? node_part }
+            node.node_parts.all? { |node_part| comparison?(node_part) }
           else
             false
           end

--- a/lib/rubocop/cop/style/special_global_vars.rb
+++ b/lib/rubocop/cop/style/special_global_vars.rb
@@ -98,7 +98,7 @@ module RuboCop
 
         def format_english_message(global_var)
           regular, english = ENGLISH_VARS[global_var].partition do |var|
-            NON_ENGLISH_VARS.include? var
+            NON_ENGLISH_VARS.include?(var)
           end
 
           format_message(english, regular, global_var)

--- a/lib/rubocop/formatter/disabled_lines_formatter.rb
+++ b/lib/rubocop/formatter/disabled_lines_formatter.rb
@@ -46,7 +46,7 @@ module RuboCop
         # Ideally, we calculate this relative to the project root.
         base_dir = Dir.pwd
 
-        if path.start_with? base_dir
+        if path.start_with?(base_dir)
           relative_path(path, base_dir)
         else
           path

--- a/lib/rubocop/path_util.rb
+++ b/lib/rubocop/path_util.rb
@@ -18,7 +18,7 @@ module RuboCop
       # Ideally, we calculate this relative to the project root.
       base_dir = Dir.pwd
 
-      if path.start_with? base_dir
+      if path.start_with?(base_dir)
         relative_path(path, base_dir)
       else
         path

--- a/lib/rubocop/remote_config.rb
+++ b/lib/rubocop/remote_config.rb
@@ -18,7 +18,7 @@ module RuboCop
 
       request do |response|
         next if response.is_a?(Net::HTTPNotModified)
-        open cache_path, 'w' do |io|
+        open(cache_path, 'w') do |io|
           io.write response.body
         end
       end
@@ -32,7 +32,7 @@ module RuboCop
       raise ArgumentError, 'HTTP redirect too deep' if limit.zero?
 
       http = Net::HTTP.new(uri.hostname, uri.port)
-      http.use_ssl = true if uri.instance_of? URI::HTTPS
+      http.use_ssl = true if uri.instance_of?(URI::HTTPS)
 
       request = Net::HTTP::Get.new(uri.request_uri)
       if cache_path_exists?

--- a/manual/cops_style.md
+++ b/manual/cops_style.md
@@ -1767,7 +1767,7 @@ some_str = 'ala' \
 
 Enabled by default | Supports autocorrection
 --- | ---
-Disabled | Yes
+Enabled | Yes
 
 This cop checks presence of parentheses in method calls containing
 parameters. By default, macro methods are ignored. Additional methods
@@ -1812,6 +1812,7 @@ end
 
 Attribute | Value
 --- | ---
+Exclude | Gemfile, app/controllers/\*\*/\*, app/models/\*\*/\*, spec/\*\*/\*
 IgnoreMacros | true
 IgnoredMethods |
 
@@ -2363,6 +2364,12 @@ method1(method2(arg), method3(arg))
 # bad
 method1(method2 arg, method3, arg)
 ```
+
+### Important attributes
+
+Attribute | Value
+--- | ---
+Whitelist | be, be_a, be_an, be_between, be_falsey, be_kind_of, be_instance_of, be_truthy, be_within, eq, eql, end_with, include, match, raise_error, respond_to, start_with
 
 ## Style/NestedTernaryOperator
 

--- a/spec/rubocop/ast/send_node_spec.rb
+++ b/spec/rubocop/ast/send_node_spec.rb
@@ -729,4 +729,30 @@ describe RuboCop::AST::SendNode do
       it { expect(send_node.def_modifier?).to be_truthy }
     end
   end
+
+  describe '#conventionally_unparenthesized?' do
+    context 'with an operator method' do
+      let(:source) { 'foo == bar' }
+
+      it { expect(send_node.conventionally_unparenthesized?).to be_truthy }
+    end
+
+    context 'with a setter method' do
+      let(:source) { 'self.foo = bar' }
+
+      it { expect(send_node.conventionally_unparenthesized?).to be_truthy }
+    end
+
+    context 'with a method that is conventionally called without parens' do
+      let(:source) { 'puts foo' }
+
+      it { expect(send_node.conventionally_unparenthesized?).to be_truthy }
+    end
+
+    context 'with a regular method' do
+      let(:source) { 'foo' }
+
+      it { expect(send_node.conventionally_unparenthesized?).to be_falsey }
+    end
+  end
 end

--- a/spec/rubocop/ast/super_node_spec.rb
+++ b/spec/rubocop/ast/super_node_spec.rb
@@ -404,4 +404,10 @@ describe RuboCop::AST::SuperNode do
       it { expect(super_node.splat_argument?).to be_truthy }
     end
   end
+
+  describe '#conventionally_unparenthesized?' do
+    let(:source) { 'super' }
+
+    it { expect(super_node.conventionally_unparenthesized?).to be_truthy }
+  end
 end

--- a/spec/rubocop/ast/yield_node_spec.rb
+++ b/spec/rubocop/ast/yield_node_spec.rb
@@ -344,4 +344,10 @@ describe RuboCop::AST::YieldNode do
       it { expect(yield_node.splat_argument?).to be_truthy }
     end
   end
+
+  describe '#conventionally_unparenthesized?' do
+    let(:source) { 'yield' }
+
+    it { expect(yield_node.conventionally_unparenthesized?).to be_truthy }
+  end
 end

--- a/spec/rubocop/cli/cli_autocorrect_spec.rb
+++ b/spec/rubocop/cli/cli_autocorrect_spec.rb
@@ -558,6 +558,10 @@ describe RuboCop::CLI, :isolated_environment do
           end
     RUBY
     create_file('example.rb', source)
+    create_file('.rubocop.yml', <<-YAML.strip_indent)
+      Style/MethodCallWithArgsParentheses:
+        Enabled: false
+    YAML
     expect(cli.run(['--auto-correct'])).to eq(0)
     corrected = <<-RUBY.strip_indent
       render_views
@@ -589,6 +593,10 @@ describe RuboCop::CLI, :isolated_environment do
       end
     RUBY
     create_file('example.rb', source)
+    create_file('.rubocop.yml', <<-YAML.strip_indent)
+      Style/MethodCallWithArgsParentheses:
+        Enabled: false
+    YAML
     expect(cli.run(['--auto-correct'])).to eq(0)
     corrected = <<-RUBY.strip_indent
       require 'spec_helper'
@@ -660,6 +668,10 @@ describe RuboCop::CLI, :isolated_environment do
       })
     RUBY
     create_file('example.rb', source)
+    create_file('.rubocop.yml', <<-YAML.strip_indent)
+      Style/MethodCallWithArgsParentheses:
+        Enabled: false
+    YAML
     expect(cli.run(['-D', '--auto-correct'])).to eq(0)
     corrected =
       <<-RUBY.strip_indent
@@ -690,8 +702,8 @@ describe RuboCop::CLI, :isolated_environment do
       module Bar
       class Goo
         def something
-          first call
-            do_other 'things'
+          first(call)
+            do_other('things')
             if other > 34
               more_work
             end
@@ -720,8 +732,8 @@ describe RuboCop::CLI, :isolated_environment do
         module Bar
           class Goo
             def something
-              first call
-              do_other 'things'
+              first(call)
+              do_other('things')
               more_work if other > 34
             end
           end
@@ -793,6 +805,10 @@ describe RuboCop::CLI, :isolated_environment do
   it 'can handle spaces when removing braces' do
     create_file('example.rb',
                 ["assert_post_status_code 400, 's', {:type => 'bad'}"])
+    create_file('.rubocop.yml', <<-YAML.strip_indent)
+      Style/MethodCallWithArgsParentheses:
+        Enabled: false
+    YAML
     expect(cli.run(%w[--auto-correct --format emacs])).to eq(0)
     expect(IO.read('example.rb'))
       .to eq(<<-RUBY.strip_indent)
@@ -1145,14 +1161,12 @@ describe RuboCop::CLI, :isolated_environment do
 
   it 'does not say [Corrected] if correction was avoided' do
     src = <<-RUBY.strip_indent
-      func a do b end
       Signal.trap('TERM') { system(cmd); exit }
       def self.some_method(foo, bar: 1)
         log.debug(foo)
       end
     RUBY
     corrected = <<-RUBY.strip_indent
-      func a do b end
       Signal.trap('TERM') { system(cmd); exit }
       def self.some_method(foo, bar: 1)
         log.debug(foo)
@@ -1168,11 +1182,10 @@ describe RuboCop::CLI, :isolated_environment do
     expect(IO.read('example.rb')).to eq(corrected)
     expect($stdout.string).to eq(<<-RESULT.strip_indent)
       == example.rb ==
-      C:  1:  8: Prefer {...} over do...end for single-line blocks.
-      C:  2: 34: Do not use semicolons to terminate expressions.
-      W:  3: 27: Unused method argument - bar.
+      C:  1: 34: Do not use semicolons to terminate expressions.
+      W:  2: 27: Unused method argument - bar.
 
-      1 file inspected, 3 offenses detected
+      1 file inspected, 2 offenses detected
     RESULT
   end
 

--- a/spec/rubocop/cli_spec.rb
+++ b/spec/rubocop/cli_spec.rb
@@ -663,6 +663,9 @@ describe RuboCop::CLI, :isolated_environment do
         # config parameter is set for the rails cops. The paths are interpreted
         # as relative to dir1 because .rubocop.yml is placed there.
         create_file('dir1/.rubocop.yml', <<-YAML.strip_indent)
+          Style/MethodCallWithArgsParentheses:
+            Enabled: false
+
           Rails:
             Enabled: true
 
@@ -674,6 +677,10 @@ describe RuboCop::CLI, :isolated_environment do
         # are interpreted as relative to the current directory, so they don't
         # match.
         create_file('dir2/app/models/example4.rb', source)
+        create_file('dir2/.rubocop.yml', <<-YAML.strip_indent)
+          Style/MethodCallWithArgsParentheses:
+            Enabled: false
+        YAML
 
         expect(cli.run(%w[--format simple dir1 dir2])).to eq(1)
         expect($stdout.string)

--- a/spec/rubocop/cop/style/method_call_with_args_parentheses_spec.rb
+++ b/spec/rubocop/cop/style/method_call_with_args_parentheses_spec.rb
@@ -35,30 +35,28 @@ describe RuboCop::Cop::Style::MethodCallWithArgsParentheses, :config do
     RUBY
   end
 
-  it 'register an offense for superclass call without parens' do
-    expect_offense(<<-RUBY.strip_indent)
-      super a
-      ^^^^^^^ Use parentheses for method calls with arguments.
-    RUBY
+  it 'does not register an offense for superclass call without parens' do
+    expect_no_offenses('super foo')
   end
 
   it 'register no offense for superclass call without args' do
     expect_no_offenses('super')
   end
 
-  it 'register no offense for yield without args' do
-    expect_no_offenses('yield')
-  end
-
   it 'register no offense for superclass call with parens' do
     expect_no_offenses('super(a)')
   end
 
-  it 'register an offense for yield without parens' do
-    expect_offense(<<-RUBY.strip_indent)
-      yield a
-      ^^^^^^^ Use parentheses for method calls with arguments.
-    RUBY
+  it 'register no offense for yield with args' do
+    expect_no_offenses('yield foo')
+  end
+
+  it 'register no offense for yield without args' do
+    expect_no_offenses('yield')
+  end
+
+  it 'register no offense for yield with parens' do
+    expect_no_offenses('yield(foo)')
   end
 
   it 'accepts no parens for operators' do
@@ -76,16 +74,6 @@ describe RuboCop::Cop::Style::MethodCallWithArgsParentheses, :config do
   it 'auto-corrects call by adding needed braces' do
     new_source = autocorrect_source('top.test a')
     expect(new_source).to eq('top.test(a)')
-  end
-
-  it 'auto-corrects superclass call by adding needed braces' do
-    new_source = autocorrect_source('super a')
-    expect(new_source).to eq('super(a)')
-  end
-
-  it 'auto-corrects superclass call by adding needed braces' do
-    new_source = autocorrect_source('yield a')
-    expect(new_source).to eq('yield(a)')
   end
 
   it 'ignores method listed in IgnoredMethods' do

--- a/spec/rubocop/formatter/html_formatter_spec.rb
+++ b/spec/rubocop/formatter/html_formatter_spec.rb
@@ -18,7 +18,11 @@ module RuboCop
         path = File.expand_path('result.html')
         # Run without Style/EndOfLine as it gives different results on
         # different platforms.
-        CLI.new.run(['--except', 'Layout/EndOfLine', '--format', 'html',
+        # Run without MethodCallWithArgsParentheses as the fixture
+        # project uses Rails DSLs, resulting in false positives.
+        CLI.new.run(['--except', 'Layout/EndOfLine',
+                     '--except', 'Style/MethodCallWithArgsParentheses',
+                     '--format', 'html',
                      '--out', path])
         path
       end
@@ -26,7 +30,9 @@ module RuboCop
       let(:actual_html_path_cached) do
         path = File.expand_path('result_cached.html')
         2.times do
-          CLI.new.run(['--except', 'Layout/EndOfLine', '--format', 'html',
+          CLI.new.run(['--except', 'Layout/EndOfLine',
+                       '--except', 'Style/MethodCallWithArgsParentheses',
+                       '--format', 'html',
                        '--out', path])
         end
         path

--- a/tasks/cops_documentation.rake
+++ b/tasks/cops_documentation.rake
@@ -106,7 +106,7 @@ task generate_cops_documentation: :yard_for_generate_documentation do
   def print_cop_with_doc(cop, config)
     t = config.for_cop(cop)
     non_display_keys = %w[Description Enabled StyleGuide Reference]
-    pars = t.reject { |k| non_display_keys.include? k }
+    pars = t.reject { |k| non_display_keys.include?(k) }
     description = 'No documentation'
     examples_object = []
     YARD::Registry.all(:class).detect do |code_object|


### PR DESCRIPTION
This change removes false positives from method calls which are known to be unparenthesized by convention, e.g. `include`, `puts`, `raise`, etc.

It also makes the cop enabled by default.

I bumped into quite a few problems since some of our test fixtures are RSpec- and Rails projects. If we don't intend to support these out of the box in RuboCop core (which I don't think we should) we probably need to replace these at some point. 🙂 

-----------------

Before submitting the PR make sure the following are checked:

* [X] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [X] Used the same coding conventions as the rest of the project.
* [X] Feature branch is up-to-date with `master` (if not - rebase it).
* [X] Squashed related commits together.
* [X] Added tests.
* [X] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [X] All tests(`rake spec`) are passing.
* [X] The new code doesn't generate RuboCop offenses that are checked by `rake internal_investigation`.
* [X] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [X] Updated cop documentation with `rake generate_cops_documentation` (required only when you've added a new cop or changed the configuration/documentation of an existing cop).

[1]: http://chris.beams.io/posts/git-commit/
