### PR TITLE
Don't consider <=> a comparison method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@
 
 ### Bug fixes
 
+* [#4615](https://github.com/bbatsov/rubocop/pull/4615): Don't consider `<=>` a comparison method. ([@iGEL][])
 * [#4664](https://github.com/bbatsov/rubocop/pull/4664): Fix typos in Rails/HttpPositionalArguments. ([@JoeCohen][])
 * [#4618](https://github.com/bbatsov/rubocop/pull/4618): Fix `Lint/FormatParameterMismatch` false positive if format string includes `%%5B` (CGI encoded left bracket). ([@barthez][])
 * [#4604](https://github.com/bbatsov/rubocop/pull/4604): Fix `Style/LambdaCall` to autocorrect `obj.call` to `obj.`. ([@iGEL][])

--- a/lib/rubocop/ast/node.rb
+++ b/lib/rubocop/ast/node.rb
@@ -22,7 +22,8 @@ module RuboCop
       include RuboCop::AST::Sexp
       extend NodePattern::Macros
 
-      COMPARISON_OPERATORS = %i[== === != <= >= > < <=>].freeze
+      # <=> isn't included here, because it doesn't return a boolean.
+      COMPARISON_OPERATORS = %i[== === != <= >= > <].freeze
 
       TRUTHY_LITERALS = %i[str dstr xstr int float sym dsym array
                            hash regexp true irange erange complex
@@ -366,7 +367,7 @@ module RuboCop
           case type
           when :send
             receiver, method_name, *args = *self
-            [*COMPARISON_OPERATORS, :!].include?(method_name) &&
+            [*COMPARISON_OPERATORS, :!, :<=>].include?(method_name) &&
               receiver.send(recursive_kind) &&
               args.all?(&recursive_kind)
           when :begin, :pair, *OPERATOR_KEYWORDS, *COMPOSITE_LITERALS

--- a/spec/rubocop/ast/def_node_spec.rb
+++ b/spec/rubocop/ast/def_node_spec.rb
@@ -273,7 +273,7 @@ describe RuboCop::AST::DefNode do
 
   describe '#comparison_method?' do
     context 'with a comparison method' do
-      let(:source) { 'def <=>(bar); end' }
+      let(:source) { 'def <=(bar); end' }
 
       it { expect(def_node.comparison_method?).to be_truthy }
     end

--- a/spec/rubocop/ast/send_node_spec.rb
+++ b/spec/rubocop/ast/send_node_spec.rb
@@ -541,7 +541,7 @@ describe RuboCop::AST::SendNode do
     context 'with a comparison method' do
       let(:source) { 'foo.bar <=> :baz' }
 
-      it { expect(send_node.comparison_method?).to be_truthy }
+      it { expect(send_node.comparison_method?).to be_falsey }
     end
 
     context 'with a regular method' do

--- a/spec/rubocop/cop/style/yoda_condition_spec.rb
+++ b/spec/rubocop/cop/style/yoda_condition_spec.rb
@@ -52,6 +52,7 @@ describe RuboCop::Cop::Style::YodaCondition, :config do
   it_behaves_like 'accepts', '[1, 2, 3] <=> [4, 5, 6]'
   it_behaves_like 'accepts', '!true'
   it_behaves_like 'accepts', 'not true'
+  it_behaves_like 'accepts', '0 <=> val'
 
   it_behaves_like 'offense', '"foo" == bar'
   it_behaves_like 'offense', 'nil == bar'


### PR DESCRIPTION
I believe, the `<=>` operator should not be considered as a `.comparison_method?`.

The main reason is, that this method in difference to all other comparison methods doesn't return a boolean, but `-1`, `0` or `1`. Thus, many assumptions for comparison methods don't apply, for example,
there isn't an inverse comparison method (like `<` is the inverse of `>=)`, `* -1` isn't a comparison).

This is an alternative to #4603 by me, where I just prevented `Style/YodaCondition` to consider it.

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Used the same coding conventions as the rest of the project.
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] All tests(`rake spec`) are passing.
* [x] The new code doesn't generate RuboCop offenses that are checked by `rake internal_investigation`.
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Updated cop documentation with `rake generate_cops_documentation` (required only when you've added a new cop or changed the configuration/documentation of an existing cop).

[1]: http://chris.beams.io/posts/git-commit/
