### PR TITLE
Fix FIELD_REGEX for Lint/FormatParameterMismatch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@
 
 ### Bug fixes
 
+* [#4618](https://github.com/bbatsov/rubocop/pull/4618): Fix `Lint/FormatParameterMismatch` false positive if format string includes `%%5B` (CGI encoded left bracket). ([@barthez][])
 * [#4604](https://github.com/bbatsov/rubocop/pull/4604): Fix `Style/LambdaCall` to autocorrect `obj.call` to `obj.`. ([@iGEL][])
 * [#4443](https://github.com/bbatsov/rubocop/pull/4443): Prevent `Style/YodaCondition` from breaking `not LITERAL`. ([@pocke][])
 * [#4434](https://github.com/bbatsov/rubocop/issues/4434): Prevent bad auto-correct in `Style/Alias` for non-literal arguments. ([@drenmi][])
@@ -2874,3 +2875,4 @@
 [@promisedlandt]: https://github.com/promisedlandt
 [@oboxodo]: https://github.com/oboxodo
 [@gohdaniel15]: https://github.com/gohdaniel15
+[@barthez]: https://github.com/barthez

--- a/lib/rubocop/cop/lint/format_parameter_mismatch.rb
+++ b/lib/rubocop/cop/lint/format_parameter_mismatch.rb
@@ -23,7 +23,7 @@ module RuboCop
         MSG = "Number of arguments (%i) to `%s` doesn't match the number of " \
               'fields (%i).'.freeze
         FIELD_REGEX =
-          /(%(([\s#+-0\*]*)(\d*)?(.\d+)?[bBdiouxXeEfgGaAcps]|%))/
+          /(%(([\s#+-0\*]*)(\d*)?(\.\d+)?[bBdiouxXeEfgGaAcps]|%))/
         NAMED_FIELD_REGEX = /%\{[_a-zA-Z][_a-zA-Z]+\}/
         KERNEL = 'Kernel'.freeze
         SHOVEL = '<<'.freeze

--- a/spec/rubocop/cop/lint/format_parameter_mismatch_spec.rb
+++ b/spec/rubocop/cop/lint/format_parameter_mismatch_spec.rb
@@ -82,7 +82,7 @@ describe RuboCop::Cop::Lint::FormatParameterMismatch do
   end
 
   it 'correctly ignores double percent' do
-    expect_no_offenses("format('%s %s %% %s %%%% %%%%%%', 1, 2, 3)")
+    expect_no_offenses("format('%s %s %% %s %%%% %%%%%% %%5B', 1, 2, 3)")
   end
 
   it 'constants do not register offenses' do


### PR DESCRIPTION
Regex was missing escape for . (dot) and it was matching CGI-escaped left bracket used in format calls.