### PR TITLE
Fix passing YAML.load too many arguments with Syck

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@
 
 ### Bug fixes
 
+* Fix passing `YAML.load` too many arguments when using syck. ([@trzejos][])
 * [#4604](https://github.com/bbatsov/rubocop/pull/4604): Fix `Style/LambdaCall` to autocorrect `obj.call` to `obj.`. ([@iGEL][])
 * [#4443](https://github.com/bbatsov/rubocop/pull/4443): Prevent `Style/YodaCondition` from breaking `not LITERAL`. ([@pocke][])
 * [#4434](https://github.com/bbatsov/rubocop/issues/4434): Prevent bad auto-correct in `Style/Alias` for non-literal arguments. ([@drenmi][])
@@ -2874,3 +2875,4 @@
 [@promisedlandt]: https://github.com/promisedlandt
 [@oboxodo]: https://github.com/oboxodo
 [@gohdaniel15]: https://github.com/gohdaniel15
+[@trzejos]: https://github.com/trzejos

--- a/lib/rubocop/config_loader.rb
+++ b/lib/rubocop/config_loader.rb
@@ -205,8 +205,11 @@ module RuboCop
         hash
       end
 
+      # rubocop:disable Metrics/PerceivedComplexity
       def yaml_safe_load(yaml_code, filename)
-        if YAML.respond_to?(:safe_load) # Ruby 2.1+
+        if defined?(Syck) && YAML == Syck
+          YAML.load(yaml_code) # rubocop:disable Security/YAMLLoad
+        elsif YAML.respond_to?(:safe_load) # Ruby 2.1+
           if defined?(SafeYAML) && SafeYAML.respond_to?(:load)
             SafeYAML.load(yaml_code, filename,
                           whitelisted_tags: %w[!ruby/regexp])
@@ -217,6 +220,7 @@ module RuboCop
           YAML.load(yaml_code, filename) # rubocop:disable Security/YAMLLoad
         end
       end
+      # rubocop:enable Metrics/PerceivedComplexity
 
       def gem_config_path(gem_name, relative_config_path)
         spec = Gem::Specification.find_by_name(gem_name)

--- a/spec/rubocop/config_loader_spec.rb
+++ b/spec/rubocop/config_loader_spec.rb
@@ -58,8 +58,7 @@ describe RuboCop::ConfigLoader do
 
       context 'when YAML has method :safe_load' do
         before do
-          @yaml = defined?(YAML) && YAML
-          Object.send(:remove_const, :YAML) if @yaml
+          Object.send(:remove_const, :YAML)
           class YAML
             def self.safe_load(*)
               :success
@@ -113,8 +112,7 @@ describe RuboCop::ConfigLoader do
 
       context 'when YAML does not have method :safe_load' do
         before do
-          @yaml = defined?(YAML) && YAML
-          Object.send(:remove_const, :YAML) if @yaml
+          Object.send(:remove_const, :YAML)
           class YAML
             def self.load(*)
               :success


### PR DESCRIPTION
When Syck is being used, YAML.load only expects a single argument.
Check if Syck is defined and if YAML is set to Syck before choosing
an appropriate method of loading the configuration.

---

Before submitting the PR make sure the following are checked:
* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Used the same coding conventions as the rest of the project.
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] All tests(`rake spec`) are passing.
* [x] The new code doesn't generate RuboCop offenses that are checked by `rake internal_investigation`.
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [ ] Updated cop documentation with `rake generate_cops_documentation` (required only when you've added a new cop or changed the configuration/documentation of an existing cop).

[1]: http://chris.beams.io/posts/git-commit/
