### PR TITLE
[Fix #4024] Update rainbow version to correctly include rake.

### DIFF
--- a/rubocop.gemspec
+++ b/rubocop.gemspec
@@ -25,7 +25,7 @@ Gem::Specification.new do |s|
   s.licenses = ['MIT']
   s.summary = 'Automatic Ruby code style checking tool.'
 
-  s.add_runtime_dependency('rainbow', '>= 1.99.1', '< 3.0')
+  s.add_runtime_dependency('rainbow', '>= 2.2.2', '< 3.0')
   s.add_runtime_dependency('parser', '>= 2.3.3.1', '< 3.0')
   s.add_runtime_dependency('powerpack', '~> 0.1')
   s.add_runtime_dependency('ruby-progressbar', '~> 1.7')


### PR DESCRIPTION
[#4024] Describes an issue where versions of the Rainbow gem have a rake dependency but do not explicitly declare this dependency, see this issue [57](https://github.com/sickill/rainbow/issues/57) in the rainbow repository. This was fixed in version 2.2.2 and this PR updates Rubocop to depend on the fixed version.

-----------------

Before submitting the PR make sure the following are checked:

* [X] Wrote [good commit messages][1].
* [X] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [X] Used the same coding conventions as the rest of the project.
* [X] Feature branch is up-to-date with `master` (if not - rebase it).
* [X] Squashed related commits together.
* [ ] Added tests.
* [X] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] All tests(`rake spec`) are passing.
* [x] The new code doesn't generate RuboCop offenses that are checked by `rake internal_investigation`.
* [X] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [ ] Updated cop documentation with `rake generate_cops_documentation` (required only when you've added a new cop or changed the configuration/documentation of an existing cop).

[1]: http://chris.beams.io/posts/git-commit/
