### PR TITLE
Remote config inheritance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@
 * [#4582](https://github.com/bbatsov/rubocop/issues/4582): `Severity` and other common parameters can be configured on department level. ([@jonas054][])
 * [#4787](https://github.com/bbatsov/rubocop/pull/4787): Analyzing code that needs to support MRI 2.0 is no longer supported. ([@deivid-rodriguez][])
 * [#4787](https://github.com/bbatsov/rubocop/pull/4787): RuboCop no longer installs on MRI 2.0. ([@deivid-rodriguez][])
+* [#4266](https://github.com/bbatsov/rubocop/issues/4266): Download the inherited config files of a remote file from the same remote. ([@tdeo][])
 
 ## 0.50.0 (2017-09-14)
 

--- a/lib/rubocop/config_loader_resolver.rb
+++ b/lib/rubocop/config_loader_resolver.rb
@@ -17,8 +17,9 @@ module RuboCop
       end
     end
 
-    def resolve_inheritance(path, hash)
-      base_configs(path, hash['inherit_from']).reverse_each do |base_config|
+    def resolve_inheritance(path, hash, file)
+      base_configs(path, hash['inherit_from'], file)
+        .reverse_each do |base_config|
         base_config.each do |k, v|
           hash[k] = hash.key?(k) ? merge(v, hash[k]) : v if v.is_a?(Hash)
         end

--- a/lib/rubocop/remote_config.rb
+++ b/lib/rubocop/remote_config.rb
@@ -6,6 +6,8 @@ require 'time'
 module RuboCop
   # Common methods and behaviors for dealing with remote config files.
   class RemoteConfig
+    attr_reader :uri
+
     CACHE_LIFETIME = 24 * 60 * 60
 
     def initialize(url, base_dir)
@@ -25,6 +27,12 @@ module RuboCop
       end
 
       cache_path
+    end
+
+    def inherit_from_remote(file, path)
+      new_uri = @uri.dup
+      new_uri.path.gsub!(%r{/[^/]*$}, "/#{file}")
+      RemoteConfig.new(new_uri.to_s, File.dirname(path))
     end
 
     private


### PR DESCRIPTION
To address https://github.com/bbatsov/rubocop/issues/4266, this tries to download inherited config files from the same remote as the inheriting remote file.

I'm afraid this might be a breaking change for some people:
- relying on the remote config to actually include local files.
- not actually wanting the inherited files from the remote.
- when the inherited file doesn't exist on the remote (should we fallback to local file, to nothing, raise an exception?)

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Used the same coding conventions as the rest of the project.
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] All tests(`rake spec`) are passing.
* [x] The new code doesn't generate RuboCop offenses that are checked by `rake internal_investigation`.
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Updated cop documentation with `rake generate_cops_documentation` (required only when you've added a new cop or changed the configuration/documentation of an existing cop).

[1]: http://chris.beams.io/posts/git-commit/
