### PR TITLE
Allow `has_` as a prefix for boolean methods

### DIFF
--- a/config/default.yml
+++ b/config/default.yml
@@ -617,12 +617,10 @@ Naming/PredicateName:
   # Predicate name prefixes.
   NamePrefix:
     - is_
-    - has_
     - have_
   # Predicate name prefixes that should be removed.
   NamePrefixBlacklist:
     - is_
-    - has_
     - have_
   # Predicate names which, despite having a blacklisted prefix, or no `?`,
   # should still be accepted

--- a/manual/cops_naming.md
+++ b/manual/cops_naming.md
@@ -253,8 +253,8 @@ def value? ...
 
 Attribute | Value
 --- | ---
-NamePrefix | is_, has_, have_
-NamePrefixBlacklist | is_, has_, have_
+NamePrefix | is_, have_
+NamePrefixBlacklist | is_, have_
 NameWhitelist | is_a?
 Exclude | spec/\*\*/\*
 


### PR DESCRIPTION
The [original PR][1] which suggested predicate naming for the style guide
specifically pointed out well it works with RSpec matchers:

```
expect(foo).to be_red # => `foo.red?` rather than `foo.is_red?`
```

RSpec also has another [magic matcher][2] which does the same for have/has:

```
expect(foo).to have_beans # => `foo.has_beans?`
```

However, the default config for Rubocop rejects this method. It would be allowed
in the spec directory, but that isn't a useful exception, because the predicate
method being tested is a domain method, not a spec method.

In addition to this removal, I would be tempted to add the other predicate
methods [listed][3] in the style guide: `can` and `does`, but I think the less
controversial change is this simple one that enables behaviour that it was
always designed to do.

[1]: https://github.com/bbatsov/ruby-style-guide/pull/566
[2]: https://relishapp.com/rspec/rspec-expectations/v/2-4/docs/built-in-matchers/predicate-matchers
[3]: https://github.com/bbatsov/ruby-style-guide#bool-methods-prefix

I don't know whether this deserves an update to the Changelog - I imagine it doesn't.

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [x] ~Commit message starts with `[Fix #issue-number]` (if the related issue exists).~
* [x] Used the same coding conventions as the rest of the project.
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] ~Added tests.~
* [ ] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] All tests(`rake spec`) are passing.
* [x] The new code doesn't generate RuboCop offenses that are checked by `rake internal_investigation`.
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Updated cop documentation with `rake generate_cops_documentation` (required only when you've added a new cop or changed the configuration/documentation of an existing cop).

[1]: http://chris.beams.io/posts/git-commit/
