### PR TITLE
[Fix #4634] Handle heredoc that contains empty lines only in `Layout/IndentHeredoc` cop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,7 @@
 * [#4589](https://github.com/bbatsov/rubocop/issues/4589): Fix false positive in `Performance/RegexpMatch` cop for `=~` is in a class method. ([@pocke][])
 * [#4578](https://github.com/bbatsov/rubocop/issues/4578): Fix false positive in `Lint/FormatParameterMismatch` for format with "asterisk" (`*`) width and precision. ([@smakagon][])
 * [#4285](https://github.com/bbatsov/rubocop/issues/4285): Make `Lint/DefEndAlignment` aware of multiple modifiers. ([@drenmi][])
+* [#4634](https://github.com/bbatsov/rubocop/issues/4634): Handle heredoc that contains empty lines only in `Layout/IndentHeredoc` cop. ([@pocke][])
 
 ### Changes
 

--- a/lib/rubocop/cop/lint/percent_string_array.rb
+++ b/lib/rubocop/cop/lint/percent_string_array.rb
@@ -67,17 +67,6 @@ module RuboCop
             end
           end
         end
-
-        def scrub_string(string)
-          if string.respond_to?(:scrub)
-            string.scrub
-          else
-            string
-              .encode('UTF-16BE', 'UTF-8',
-                      invalid: :replace, undef: :replace, replace: '?')
-              .encode('UTF-8')
-          end
-        end
       end
     end
   end

--- a/lib/rubocop/cop/util.rb
+++ b/lib/rubocop/cop/util.rb
@@ -304,6 +304,17 @@ module RuboCop
           .sub(/^Enforced/, 'Supported')
           .sub('Style', 'Styles')
       end
+
+      def scrub_string(string)
+        if string.respond_to?(:scrub)
+          string.scrub
+        else
+          string
+            .encode('UTF-16BE', 'UTF-8',
+                    invalid: :replace, undef: :replace, replace: '?')
+            .encode('UTF-8')
+        end
+      end
     end
   end
 end

--- a/spec/rubocop/cop/layout/indent_heredoc_spec.rb
+++ b/spec/rubocop/cop/layout/indent_heredoc_spec.rb
@@ -136,6 +136,11 @@ describe RuboCop::Cop::Layout::IndentHeredoc, :config do
         RUBY2
         end
       RUBY
+      include_examples :accept, 'an empty line', <<-RUBY
+        <<-#{quote}RUBY2#{quote}
+
+        RUBY2
+      RUBY
 
       include_examples :check_message, 'suggestion powerpack',
                        [


### PR DESCRIPTION
Fix #4634

Problem
======

If a heredoc contains empty lines only, the cop raises an error.

Solution
======

The cop does not add any offences in that case.

**Replace this text with a summary of the changes in your PR.
The more detailed you are, the better.**

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Used the same coding conventions as the rest of the project.
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] All tests(`rake spec`) are passing.
* [x] The new code doesn't generate RuboCop offenses that are checked by `rake internal_investigation`.
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Updated cop documentation with `rake generate_cops_documentation` (required only when you've added a new cop or changed the configuration/documentation of an existing cop).

[1]: http://chris.beams.io/posts/git-commit/
