### PR TITLE
Add a workaround for a failing in Travis CI with Ruby 2.0

### DIFF
--- a/.travis.rb
+++ b/.travis.rb
@@ -36,7 +36,11 @@ end
 sh!('bundle exec codeclimate-test-reporter') if master? && test?
 
 # Running YARD under jruby crashes so skip checking manual under jruby
-sh!('bundle exec rake generate_cops_documentation') unless jruby?
+# Workaround: This task makes a mysterious diff in Ruby 2.0.
+#             So we ignore Ruby 2.0.
+if RUBY_ENGINE == 'ruby' && RUBY_VERSION >= '2.1'
+  sh!('bundle exec rake generate_cops_documentation')
+end
 
 # Check requiring libraries successfully.
 # See https://github.com/bbatsov/rubocop/pull/4523#issuecomment-309136113


### PR DESCRIPTION
See https://github.com/bbatsov/rubocop/pull/4625#issuecomment-317418891


The failing cause is unknown. So I ignore the task in Ruby 2.0.
It is checked in other Rubies. So I think there is no problem even if ignore it.

-----------------

Before submitting the PR make sure the following are checked:

* [ ] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [ ] Used the same coding conventions as the rest of the project.
* [ ] Feature branch is up-to-date with `master` (if not - rebase it).
* [ ] Squashed related commits together.
* [ ] Added tests.
* [ ] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [ ] All tests(`rake spec`) are passing.
* [ ] The new code doesn't generate RuboCop offenses that are checked by `rake internal_investigation`.
* [ ] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [ ] Updated cop documentation with `rake generate_cops_documentation` (required only when you've added a new cop or changed the configuration/documentation of an existing cop).

[1]: http://chris.beams.io/posts/git-commit/
