### PR TITLE
Fix generating documentation bug

### DIFF
--- a/tasks/cops_documentation.rake
+++ b/tasks/cops_documentation.rake
@@ -98,9 +98,10 @@ task generate_cops_documentation: :yard_for_generate_documentation do
       content << print_cop_with_doc(cop, config)
     end
     file_name = "#{Dir.pwd}/manual/cops_#{department.downcase}.md"
-    file = File.open(file_name, 'w')
-    puts "* generated #{file_name}"
-    file.write(content.strip + "\n")
+    File.open(file_name, 'w') do |file|
+      puts "* generated #{file_name}"
+      file.write(content.strip + "\n")
+    end
   end
 
   def print_cop_with_doc(cop, config)


### PR DESCRIPTION
The documentation file descriptor is not closed after opened. I guess it is a cause of the generating documentation task's bug.



-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Used the same coding conventions as the rest of the project.
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [ ] Added tests.
* [ ] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] All tests(`rake spec`) are passing.
* [x] The new code doesn't generate RuboCop offenses that are checked by `rake internal_investigation`.
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [ ] Updated cop documentation with `rake generate_cops_documentation` (required only when you've added a new cop or changed the configuration/documentation of an existing cop).

[1]: http://chris.beams.io/posts/git-commit/
