### PR TITLE
[Fix #4646] Make `Lint/Debugger` aware of `Kernel` and cbase

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,7 @@
 * [#4578](https://github.com/bbatsov/rubocop/issues/4578): Fix false positive in `Lint/FormatParameterMismatch` for format with "asterisk" (`*`) width and precision. ([@smakagon][])
 * [#4285](https://github.com/bbatsov/rubocop/issues/4285): Make `Lint/DefEndAlignment` aware of multiple modifiers. ([@drenmi][])
 * [#4634](https://github.com/bbatsov/rubocop/issues/4634): Handle heredoc that contains empty lines only in `Layout/IndentHeredoc` cop. ([@pocke][])
+* [#4646](https://github.com/bbatsov/rubocop/issues/4646): Make `Lint/Debugger` aware of `Kernel` and cbase. ([@pocke][])
 
 ### Changes
 

--- a/lib/rubocop/cop/lint/debugger.rb
+++ b/lib/rubocop/cop/lint/debugger.rb
@@ -35,18 +35,25 @@ module RuboCop
       class Debugger < Cop
         MSG = 'Remove debugger entry point `%s`.'.freeze
 
+        def_node_matcher :kernel?, <<-PATTERN
+          {
+            (const nil :Kernel)
+            (const (cbase) :Kernel)
+          }
+        PATTERN
+
         def_node_matcher :debugger_call?, <<-PATTERN
-          {(send nil {:debugger :byebug} ...)
-           (send (send nil :binding)
+          {(send {nil #kernel?} {:debugger :byebug} ...)
+           (send (send {#kernel? nil} :binding)
              {:pry :remote_pry :pry_remote} ...)
-           (send (const nil :Pry) :rescue ...)
+           (send (const {nil (cbase)} :Pry) :rescue ...)
            (send nil {:save_and_open_page
                       :save_and_open_screenshot
                       :save_screenshot} ...)}
         PATTERN
 
         def_node_matcher :binding_irb_call?, <<-PATTERN
-          (send (send nil :binding) :irb ...)
+          (send (send {#kernel? nil} :binding) :irb ...)
         PATTERN
 
         def_node_matcher :pry_rescue?, '(send (const nil :Pry) :rescue ...)'

--- a/spec/rubocop/cop/lint/debugger_spec.rb
+++ b/spec/rubocop/cop/lint/debugger_spec.rb
@@ -24,6 +24,12 @@ describe RuboCop::Cop::Lint::Debugger, :config do
                     'save_screenshot foo']
   include_examples 'non-debugger', 'a non-pry binding', 'binding.pirate'
 
+  include_examples 'debugger', 'debugger with Kernel', 'Kernel.debugger'
+  include_examples 'debugger', 'debugger with ::Kernel', '::Kernel.debugger'
+  include_examples 'debugger', 'binding.pry with Kernel', 'Kernel.binding.pry'
+  include_examples 'non-debugger', 'save_and_open_page with Kernel',
+                   'Kernel.save_and_open_page'
+
   ALL_COMMANDS = %w[debugger byebug pry remote_pry pry_remote irb
                     save_and_open_page save_and_open_screenshot
                     save_screenshot].freeze
@@ -38,12 +44,15 @@ describe RuboCop::Cop::Lint::Debugger, :config do
       def method
         Pry.rescue { puts 1 }
         ^^^^^^^^^^ Remove debugger entry point `Pry.rescue`.
+        ::Pry.rescue { puts 1 }
+        ^^^^^^^^^^^^ Remove debugger entry point `::Pry.rescue`.
       end
     RUBY
   end
 
   context 'target_ruby_version >= 2.4', :ruby24 do
     include_examples 'debugger', 'irb binding', 'binding.irb'
+    include_examples 'debugger', 'binding.irb with Kernel', 'Kernel.binding.irb'
 
     ALL_COMMANDS.each do |src|
       include_examples 'non-debugger', "a #{src} in comments", "# #{src}"


### PR DESCRIPTION
`binding`, `debugger` and `byebug` is a `Kernel` method. Therefore those methods are callable with `Kernel` receiver expressly.

```bash
binding.pry        # => start a pry
Kernel.binding.pry # => start a pry
```

`save_and_open_page` and others are not defined in `Kernel`. Therefore those method is not callable with `Kernel` receiver.

```
     Failure/Error: Kernel.save_and_open_screenshot

     NoMethodError:
       undefined method `save_and_open_screenshot' for Kernel:Module
```

And this change makes the cop aware of `cbase`.

```ruby
Pry == ::Pry
```


-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Used the same coding conventions as the rest of the project.
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] All tests(`rake spec`) are passing.
* [x] The new code doesn't generate RuboCop offenses that are checked by `rake internal_investigation`.
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Updated cop documentation with `rake generate_cops_documentation` (required only when you've added a new cop or changed the configuration/documentation of an existing cop).

[1]: http://chris.beams.io/posts/git-commit/
