### PR TITLE
Add naming cops to the documentation

### DIFF
--- a/manual/cops.md
+++ b/manual/cops.md
@@ -46,6 +46,11 @@ configuration parameter called `Max` and when running
 `rubocop --auto-gen-config`, this parameter will be set to the highest value
 found for the inspected code.
 
+### Naming
+
+Naming cops check for naming issue of your code, such as method name, constant
+name, file name, etc.
+
 ### Performance
 
 Performance cops catch Ruby idioms which are known to be slower than another,

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -21,6 +21,7 @@ pages:
     - Layout Cops: cops_layout.md
     - Linting Cops: cops_lint.md
     - Metrics Cops: cops_metrics.md
+    - Naming Cops: cops_naming.md
     - Performance Cops: cops_performance.md
     - Rails Cops: cops_rails.md
     - Security Cops: cops_security.md


### PR DESCRIPTION
Naming department was added in #4575 , but we can't find naming department from the documentation.This change will fix this problem.