### PR TITLE
[Fix #4643] Do not register an offense of a nested inverse method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,7 @@
 * [#4285](https://github.com/bbatsov/rubocop/issues/4285): Make `Lint/DefEndAlignment` aware of multiple modifiers. ([@drenmi][])
 * [#4634](https://github.com/bbatsov/rubocop/issues/4634): Handle heredoc that contains empty lines only in `Layout/IndentHeredoc` cop. ([@pocke][])
 * [#4646](https://github.com/bbatsov/rubocop/issues/4646): Make `Lint/Debugger` aware of `Kernel` and cbase. ([@pocke][])
+* [#4643](https://github.com/bbatsov/rubocop/issues/4643): Modify `Style/InverseMethods` to not register a separate offense for an inverse method nested inside of the block of an inverse method offense. ([@rrosenblum][])
 
 ### Changes
 

--- a/spec/rubocop/cop/style/inverse_methods_spec.rb
+++ b/spec/rubocop/cop/style/inverse_methods_spec.rb
@@ -195,6 +195,23 @@ describe RuboCop::Cop::Style::InverseMethods do
           .to eq(["Use `#{inverse}` instead of inverting `#{method}`."])
       end
 
+      it 'registers a single offense for nested inverse method calls' do
+        inspect_source(<<-RUBY.strip_indent)
+          y.#{method} { |key, _value| !(key =~ /c\d/) }
+        RUBY
+
+        expect(cop.messages)
+          .to eq(["Use `#{inverse}` instead of inverting `#{method}`."])
+      end
+
+      it 'corrects nested inverse method calls' do
+        new_source =
+          autocorrect_source("y.#{method} { |key, _value| !(key =~ /c\d/) }")
+
+        expect(new_source)
+          .to eq("y.#{inverse} { |key, _value| (key =~ /c\d/) }")
+      end
+
       it 'corrects a simple inverted block' do
         new_source = autocorrect_source("foo.#{method} { |e| !e }")
 


### PR DESCRIPTION
This fixes #4643. 

The issue here is that the method that is used to determine if the block method should be inverted is also an offense for `InverseMethods`. Autocorrect gets triggered twice, once for the block and once for the method. The correction for the block runs first, then the correction for the method runs and overwrites part of the block correction with code that is now invalid. There might be room to improve the way that we are handling this situation later on.