### PR TITLE
[Fix #4105] Fix `Lint/IndentationWidth` when `Lint/EndAlignment` is configured with `start_of_line`

### DIFF
--- a/spec/rubocop/cop/layout/indentation_width_spec.rb
+++ b/spec/rubocop/cop/layout/indentation_width_spec.rb
@@ -384,7 +384,7 @@ describe RuboCop::Cop::Layout::IndentationWidth do
       end
 
       context 'with assignment' do
-        context 'when alignment style is variable' do
+        shared_examples 'assignment with if statement' do
           context 'and end is aligned with variable' do
             it 'accepts an if with end aligned with setter' do
               expect_no_offenses(<<-RUBY.strip_indent)
@@ -536,7 +536,27 @@ describe RuboCop::Cop::Layout::IndentationWidth do
           end
         end
 
-        shared_examples 'assignment and if with keyword alignment' do
+        context 'when alignment style is variable' do
+          let(:end_alignment_config) do
+            { 'Enabled' => true, 'EnforcedStyleAlignWith' => 'variable' }
+          end
+
+          include_examples 'assignment with if statement'
+        end
+
+        context 'when alignment style is start_of_line' do
+          let(:end_alignment_config) do
+            { 'Enabled' => true, 'EnforcedStyleAlignWith' => 'start_of_line' }
+          end
+
+          include_examples 'assignment with if statement'
+        end
+
+        context 'when alignment style is keyword' do
+          let(:end_alignment_config) do
+            { 'Enabled' => true, 'EnforcedStyleAlignWith' => 'keyword' }
+          end
+
           context 'and end is aligned with variable' do
             it 'registers an offense for an if' do
               inspect_source(<<-RUBY.strip_indent)
@@ -627,14 +647,6 @@ describe RuboCop::Cop::Layout::IndentationWidth do
               RUBY
             end
           end
-        end
-
-        context 'when alignment style is keyword by choice' do
-          let(:end_alignment_config) do
-            { 'Enabled' => true, 'EnforcedStyleAlignWith' => 'keyword' }
-          end
-
-          include_examples 'assignment and if with keyword alignment'
         end
       end
 


### PR DESCRIPTION
Fix #4105

-----------------

Before submitting the PR make sure the following are checked:

* [ ] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [ ] Used the same coding conventions as the rest of the project.
* [ ] Feature branch is up-to-date with `master` (if not - rebase it).
* [ ] Squashed related commits together.
* [ ] Added tests.
* [ ] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [ ] All tests(`rake spec`) are passing.
* [ ] The new code doesn't generate RuboCop offenses that are checked by `rake internal_investigation`.
* [ ] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [ ] Updated cop documentation with `rake generate_cops_documentation` (required only when you've added a new cop or changed the configuration/documentation of an existing cop).

[1]: http://chris.beams.io/posts/git-commit/
