### PR TITLE
Make `rake new_cop` create parent directories

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@
 * [#4568](https://github.com/bbatsov/rubocop/pull/4568): Fix autocorrection for `Style/TrailingUnderscoreVariable`. ([@smakagon][])
 * [#4586](https://github.com/bbatsov/rubocop/pull/4586): Add new `Performance/UnfreezeString` cop. ([@pocke][])
 * [#2976](https://github.com/bbatsov/rubocop/issues/2976): Add `Whitelist` configuration option to `Style/NestedParenthesizedCalls` cop. ([@drenmi][])
+* Make `rake new_cop` create parent directories if they do not already exist. ([@highb][])
 
 ### Bug fixes
 
@@ -2882,3 +2883,4 @@
 [@gohdaniel15]: https://github.com/gohdaniel15
 [@barthez]: https://github.com/barthez
 [@Envek]: https://github.com/Envek
+[@highb]: https://github.com/highb

--- a/lib/rubocop/cop/generator.rb
+++ b/lib/rubocop/cop/generator.rb
@@ -117,6 +117,9 @@ module RuboCop
       def write_unless_file_exists(path, contents)
         raise "#{path} already exists!" if File.exist?(path)
 
+        dir = File.dirname(path)
+        FileUtils.mkdir_p(dir) unless File.exist?(dir)
+
         File.write(path, contents)
       end
 


### PR DESCRIPTION
Prior to this commit if you attempted to make a cop in a new category,
the generator would error out because the directory didn't exist yet.

This commit adds a check for the existence of the parent directory
in the `write_unless_file_exists` method and will create the directory
using `FileUtils.mkdir_p` if it doesn't exist.

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
  * No pre-existing issue that I could find.
* [x] Used the same coding conventions as the rest of the project.
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [ ] Added tests.
  * Not sure if the maintainers want to deal with FakeFS tests.
* [x] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] All tests(`rake spec`) are passing.
* [x] The new code doesn't generate RuboCop offenses that are checked by `rake internal_investigation`.
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Updated cop documentation with `rake generate_cops_documentation` (required only when you've added a new cop or changed the configuration/documentation of an existing cop).

[1]: http://chris.beams.io/posts/git-commit/
