### PR TITLE
Disable auto-correction for `Performance/TimesMap` by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -65,6 +65,7 @@
 * [#4157](https://github.com/bbatsov/rubocop/issues/4157): Enhance offense message for `Style/RedudantReturn` cop. ([@gohdaniel15][])
 * [#4521](https://github.com/bbatsov/rubocop/issues/4521): Move naming related cops into their own `Naming` department. ([@drenmi][])
 * [#4600](https://github.com/bbatsov/rubocop/pull/4600): Make `Style/RedundantSelf` aware of arguments of a block. ([@Envek][])
+* [#4658](https://github.com/bbatsov/rubocop/issues/4658): Disable auto-correction for `Performance/TimesMap` by default. ([@Envek][])
 
 ## 0.49.1 (2017-05-29)
 

--- a/config/enabled.yml
+++ b/config/enabled.yml
@@ -1581,6 +1581,7 @@ Performance/StringReplacement:
 
 Performance/TimesMap:
   Description: 'Checks for .times.map calls.'
+  AutoCorrect: false
   Enabled: true
 
 Performance/UnfreezeString:

--- a/lib/rubocop/cop/performance/times_map.rb
+++ b/lib/rubocop/cop/performance/times_map.rb
@@ -19,7 +19,9 @@ module RuboCop
       #     i.to_s
       #   end
       class TimesMap < Cop
-        MSG = 'Use `Array.new` with a block instead of `.times.%s`.'.freeze
+        MESSAGE = 'Use `Array.new(%<count>s)` with a block ' \
+                  'instead of `.times.%<map_or_collect>s`'.freeze
+        MESSAGE_ONLY_IF = 'only if `%<count>s` is always 0 or more'.freeze
 
         def on_send(node)
           check(node)
@@ -32,27 +34,36 @@ module RuboCop
         private
 
         def check(node)
-          times_map_call(node) do |map_or_collect|
-            add_offense(node, :expression, format(MSG, map_or_collect))
+          times_map_call(node) do |map_or_collect, count|
+            add_offense(node, :expression, message(map_or_collect, count))
           end
         end
 
+        def message(map_or_collect, count)
+          template = if count.literal?
+                       MESSAGE + '.'
+                     else
+                       "#{MESSAGE} #{MESSAGE_ONLY_IF}."
+                     end
+          format(template,
+                 count: count.source,
+                 map_or_collect: map_or_collect.method_name)
+        end
+
         def_node_matcher :times_map_call, <<-PATTERN
-          {(block (send (send !nil :times) ${:map :collect}) ...)
-           (send (send !nil :times) ${:map :collect} (block_pass ...))}
+          {(block $(send (send $!nil :times) {:map :collect}) ...)
+           $(send (send $!nil :times) {:map :collect} (block_pass ...))}
         PATTERN
 
         def autocorrect(node)
-          send_node = node.send_type? ? node : node.each_descendant(:send).first
-
-          count, = *send_node.receiver
+          map_or_collect, count = times_map_call(node)
 
           replacement =
             "Array.new(#{count.source}" \
-            "#{send_node.arguments.map { |arg| ", #{arg.source}" }.join})"
+            "#{map_or_collect.arguments.map { |arg| ", #{arg.source}" }.join})"
 
           lambda do |corrector|
-            corrector.replace(send_node.loc.expression, replacement)
+            corrector.replace(map_or_collect.loc.expression, replacement)
           end
         end
       end

--- a/manual/cops_performance.md
+++ b/manual/cops_performance.md
@@ -751,6 +751,12 @@ Array.new(9) do |i|
 end
 ```
 
+### Important attributes
+
+Attribute | Value
+--- | ---
+AutoCorrect | false
+
 ## Performance/UnfreezeString
 
 Enabled by default | Supports autocorrection

--- a/spec/rubocop/cop/performance/times_map_spec.rb
+++ b/spec/rubocop/cop/performance/times_map_spec.rb
@@ -15,7 +15,7 @@ describe RuboCop::Cop::Performance::TimesMap do
         it 'registers an offense' do
           expect(cop.offenses.size).to eq(1)
           expect(cop.offenses.first.message).to eq(
-            "Use `Array.new` with a block instead of `.times.#{method}`."
+            "Use `Array.new(4)` with a block instead of `.times.#{method}`."
           )
           expect(cop.highlights).to eq(["4.times.#{method} { |i| i.to_s }"])
         end
@@ -26,13 +26,26 @@ describe RuboCop::Cop::Performance::TimesMap do
         end
       end
 
+      context 'for non-literal receiver' do
+        let(:source) { "n.times.#{method} { |i| i.to_s }" }
+
+        it 'registers an offense' do
+          expect(cop.offenses.size).to eq(1)
+          expect(cop.offenses.first.message).to eq(
+            "Use `Array.new(n)` with a block instead of `.times.#{method}` " \
+            'only if `n` is always 0 or more.'
+          )
+          expect(cop.highlights).to eq(["n.times.#{method} { |i| i.to_s }"])
+        end
+      end
+
       context 'with an explicitly passed block' do
         let(:source) { "4.times.#{method}(&method(:foo))" }
 
         it 'registers an offense' do
           expect(cop.offenses.size).to eq(1)
           expect(cop.offenses.first.message).to eq(
-            "Use `Array.new` with a block instead of `.times.#{method}`."
+            "Use `Array.new(4)` with a block instead of `.times.#{method}`."
           )
           expect(cop.highlights).to eq(["4.times.#{method}(&method(:foo))"])
         end


### PR DESCRIPTION
See #4658

This change has three changes.

- Disable auto-correction by default
- Improve the offense message
- Refactoring

Problem
=====

`Integer#times` does nothing if receiver is 0 or less.
However, `Array.new` raises an error if argument is less than 0.

For example:

```ruby
-1.times{}    # does nothing
Array.new(-1) # ArgumentError: negative array size
```

Solution
=====

Disable the non-safe auto-correction by default. And Improve the offense message.



-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Used the same coding conventions as the rest of the project.
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] All tests(`rake spec`) are passing.
* [x] The new code doesn't generate RuboCop offenses that are checked by `rake internal_investigation`.
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Updated cop documentation with `rake generate_cops_documentation` (required only when you've added a new cop or changed the configuration/documentation of an existing cop).

[1]: http://chris.beams.io/posts/git-commit/
