### PR TITLE
Fix typos in Rails/HttpPositionalArguments

### DIFF
--- a/manual/cops_rails.md
+++ b/manual/cops_rails.md
@@ -518,7 +518,7 @@ Enabled | Yes
 This cop is used to identify usages of http methods like `get`, `post`,
 `put`, `patch` without the usage of keyword arguments in your tests and
 change them to use keyword args.  This cop only applies to Rails >= 5 .
-If you are not running Rails < 5 you should disable # the
+If you are running Rails < 5 you should disable the
 Rails/HttpPositionalArguments cop or set your TargetRailsVersion in your
 .rubocop.yml file to 4.0, etc.
 


### PR DESCRIPTION
The cop should be disabled when you **are** using Rails < 5.0.
Also remove stray hash mark.
