### PR TITLE
[Fix #4664] Fix typos in Rails/HttpPositionalArguments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,7 +20,7 @@
 * [#2976](https://github.com/bbatsov/rubocop/issues/2976): Add `Whitelist` configuration option to `Style/NestedParenthesizedCalls` cop. ([@drenmi][])
 
 ### Bug fixes
-
+* [#4664](https://github.com/bbatsov/rubocop/pull/4664): Fix typos in Rails/HttpPositionalArguments. ([@JoeCohen][])
 * [#4618](https://github.com/bbatsov/rubocop/pull/4618): Fix `Lint/FormatParameterMismatch` false positive if format string includes `%%5B` (CGI encoded left bracket). ([@barthez][])
 * [#4604](https://github.com/bbatsov/rubocop/pull/4604): Fix `Style/LambdaCall` to autocorrect `obj.call` to `obj.`. ([@iGEL][])
 * [#4443](https://github.com/bbatsov/rubocop/pull/4443): Prevent `Style/YodaCondition` from breaking `not LITERAL`. ([@pocke][])
@@ -2882,3 +2882,4 @@
 [@gohdaniel15]: https://github.com/gohdaniel15
 [@barthez]: https://github.com/barthez
 [@Envek]: https://github.com/Envek
+[@JoeCohen]: https://github.com/JoeCohen

--- a/lib/rubocop/cop/rails/http_positional_arguments.rb
+++ b/lib/rubocop/cop/rails/http_positional_arguments.rb
@@ -6,7 +6,7 @@ module RuboCop
       # This cop is used to identify usages of http methods like `get`, `post`,
       # `put`, `patch` without the usage of keyword arguments in your tests and
       # change them to use keyword args.  This cop only applies to Rails >= 5 .
-      # If you are not running Rails < 5 you should disable # the
+      # If you are running Rails < 5 you should disable the
       # Rails/HttpPositionalArguments cop or set your TargetRailsVersion in your
       # .rubocop.yml file to 4.0, etc.
       #
@@ -81,7 +81,7 @@ module RuboCop
         # @return lambda of auto correct procedure
         # the result should look like:
         #     get :new, params: { user_id: @user.id }, headers: {}
-        # the http_method is the method use to call the controller
+        # the http_method is the method used to call the controller
         # the controller node can be a symbol, method, object or string
         # that represents the path/action on the Rails controller
         # the data is the http parameters and environment sent in

--- a/manual/cops_rails.md
+++ b/manual/cops_rails.md
@@ -518,7 +518,7 @@ Enabled | Yes
 This cop is used to identify usages of http methods like `get`, `post`,
 `put`, `patch` without the usage of keyword arguments in your tests and
 change them to use keyword args.  This cop only applies to Rails >= 5 .
-If you are not running Rails < 5 you should disable # the
+If you are running Rails < 5 you should disable the
 Rails/HttpPositionalArguments cop or set your TargetRailsVersion in your
 .rubocop.yml file to 4.0, etc.
 


### PR DESCRIPTION
Problem:
Documentation says: 
>If you are **not** running Rails < 5 you should disable # the Rails/HttpPositionalArguments cop ...

In fact, the cop should be disabled when you **are** using Rails < 5.0.

Therefore make this change:
>If you are **~~not~~** running Rails < 5 ... 

Also:
- Remove stray hash mark
- Correct tense of verb

$ rubocop -V
0.49.1 (using Parser 2.4.0.0, running on ruby 2.2.3 x86_64-darwin14)
