### PR TITLE
Fix failing builds

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -13,6 +13,7 @@ gem 'yard', '~> 0.9'
 
 group :test do
   gem 'codeclimate-test-reporter', '~> 1.0', require: false
+  gem 'public_suffix', '~> 2.0', require: false
   gem 'safe_yaml', require: false
   gem 'webmock', require: false
 end

--- a/manual/cops_lint.md
+++ b/manual/cops_lint.md
@@ -1032,17 +1032,17 @@ Enabled | No
 
 This cop checks for interpolation in a single quoted string.
 
- foo = 'something with #{interpolation} inside'
-
- foo = "something with #{interpolation} inside"
-
 ### Example
 
 ```ruby
 # bad
+
+foo = 'something with #{interpolation} inside'
 ```
 ```ruby
 # good
+
+foo = "something with #{interpolation} inside"
 ```
 
 ## Lint/InvalidCharacterLiteral


### PR DESCRIPTION
1) Fixes forgotten docs sync in https://github.com/bbatsov/rubocop/commit/ff596950180f5b9bdc742a45b473a01234b0c4be.

2) Specify `public_suffix` version (since the latest restricts Ruby to >=2.1.0).

These two cause CI failures (in master too) https://travis-ci.org/bbatsov/rubocop/jobs/268281660 and https://travis-ci.org/bbatsov/rubocop/jobs/268281657 respectively.