### PR TITLE
[Fix #4676] Make Style/RedundantConditional cop work with elsif

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@
 
 ### Bug fixes
 
+* [#4676](https://github.com/bbatsov/rubocop/issues/4676): Make `Style/RedundantConditional` cop work with elsif. ([@akhramov][])
 * [#4615](https://github.com/bbatsov/rubocop/pull/4615): Don't consider `<=>` a comparison method. ([@iGEL][])
 * [#4664](https://github.com/bbatsov/rubocop/pull/4664): Fix typos in Rails/HttpPositionalArguments. ([@JoeCohen][])
 * [#4618](https://github.com/bbatsov/rubocop/pull/4618): Fix `Lint/FormatParameterMismatch` false positive if format string includes `%%5B` (CGI encoded left bracket). ([@barthez][])
@@ -2893,3 +2894,4 @@
 [@donjar]: https://github.com/donjar
 [@highb]: https://github.com/highb
 [@JoeCohen]: https://github.com/JoeCohen
+[@akhramov]: https://github.com/akhramov

--- a/lib/rubocop/cop/style/redundant_conditional.rb
+++ b/lib/rubocop/cop/style/redundant_conditional.rb
@@ -25,19 +25,26 @@ module RuboCop
       #   # good
       #   x != y
       class RedundantConditional < Cop
+        include AutocorrectAlignment
+
         COMPARISON_OPERATORS = RuboCop::AST::Node::COMPARISON_OPERATORS
 
-        MSG = 'This conditional expression can just be replaced by %s'.freeze
+        MSG = 'This conditional expression can just be replaced by `%s`.'.freeze
 
         def on_if(node)
           return unless offense?(node)
 
-          add_offense(node,
-                      :expression,
-                      format(MSG, replacement_condition(node)))
+          add_offense(node)
         end
 
         private
+
+        def message(node)
+          replacement = replacement_condition(node)
+          msg = node.elsif? ? "\n#{replacement}" : replacement
+
+          format(MSG, msg)
+        end
 
         def_node_matcher :redundant_condition?, <<-RUBY
           (if (send _ {:#{COMPARISON_OPERATORS.join(' :')}} _) true false)
@@ -59,14 +66,28 @@ module RuboCop
         end
 
         def replacement_condition(node)
-          invert_expression = (
-            (node.if? || node.ternary?) &&
-            redundant_condition_inverted?(node)
-          ) || (node.unless? && redundant_condition?(node))
-
           condition = node.condition.source
+          expression = invert_expression?(node) ? "!(#{condition})" : condition
 
-          invert_expression ? "!(#{condition})" : condition
+          node.elsif? ? indented_else_node(expression, node) : expression
+        end
+
+        def invert_expression?(node)
+          (
+            (node.if? || node.elsif? || node.ternary?) &&
+            redundant_condition_inverted?(node)
+          ) || (
+            node.unless? &&
+            redundant_condition?(node)
+          )
+        end
+
+        def indented_else_node(expression, node)
+          "else\n#{indentation(node)}#{expression}"
+        end
+
+        def configured_indentation_width
+          super || 2
         end
       end
     end

--- a/lib/rubocop/formatter/simple_text_formatter.rb
+++ b/lib/rubocop/formatter/simple_text_formatter.rb
@@ -70,7 +70,7 @@ module RuboCop
       end
 
       def annotate_message(msg)
-        msg.gsub(/`(.*?)`/, yellow('\1'))
+        msg.gsub(/`(.*?)`/m, yellow('\1'))
       end
 
       def message(offense)

--- a/spec/rubocop/cop/style/redundant_conditional_spec.rb
+++ b/spec/rubocop/cop/style/redundant_conditional_spec.rb
@@ -13,7 +13,7 @@ describe RuboCop::Cop::Style::RedundantConditional do
       it 'registers an offense' do
         expected_message =
           'This conditional expression '\
-          "can just be replaced by #{message_expression || expected}"
+          "can just be replaced by `#{message_expression || expected}`."
         expect(cop.offenses.size).to eq(1)
         expect(cop.messages).to eq([expected_message])
       end
@@ -72,12 +72,61 @@ describe RuboCop::Cop::Style::RedundantConditional do
                   "!(x == y)\n",
                   '!(x == y)'
 
+  it_behaves_like 'code with offense',
+                  <<-RUBY.strip_indent,
+                    if cond
+                      false
+                    elsif x == y
+                      true
+                    else
+                      false
+                    end
+                  RUBY
+                  <<-RUBY.strip_indent,
+                    if cond
+                      false
+                    else
+                      x == y
+                    end
+                  RUBY
+                  "\nelse\n  x == y"
+
+  it_behaves_like 'code with offense',
+                  <<-RUBY.strip_indent,
+                    if cond
+                      false
+                    elsif x == y
+                      false
+                    else
+                      true
+                    end
+                  RUBY
+                  <<-RUBY.strip_indent,
+                    if cond
+                      false
+                    else
+                      !(x == y)
+                    end
+                  RUBY
+                  "\nelse\n  !(x == y)"
+
   it_behaves_like 'code without offense',
                   <<-RUBY.strip_indent
                     if x == y
                       1
                     else
                       2
+                    end
+                  RUBY
+
+  it_behaves_like 'code without offense',
+                  <<-RUBY.strip_indent
+                    if cond
+                      1
+                    elseif x == y
+                      2
+                    else
+                      3
                     end
                   RUBY
 end


### PR DESCRIPTION
Current implementation of `Style/RedundantConditional` cop doesn't
handle the case when redundant conditional occurred in the `elsif` node. As
a result, autocorrection fails.

This PR tweaks the cop so it handles the `elsif` nodes as well.

-----------------

Before submitting the PR make sure the following are checked:

* [ ] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [ ] Used the same coding conventions as the rest of the project.
* [ ] Feature branch is up-to-date with `master` (if not - rebase it).
* [ ] Squashed related commits together.
* [ ] Added tests.
* [ ] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [ ] All tests(`rake spec`) are passing.
* [ ] The new code doesn't generate RuboCop offenses that are checked by `rake internal_investigation`.
* [ ] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Updated cop documentation with `rake generate_cops_documentation` (required only when you've added a new cop or changed the configuration/documentation of an existing cop).

[1]: http://chris.beams.io/posts/git-commit/
