### PR TITLE
[Fix #4656] Fix Style/ConditionalAssignment auto-correction

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@
 ### Bug fixes
 
 * [#4676](https://github.com/bbatsov/rubocop/issues/4676): Make `Style/RedundantConditional` cop work with elsif. ([@akhramov][])
+* [#4656](https://github.com/bbatsov/rubocop/issues/4656): Modify `Style/ConditionalAssignment` autocorrection to work with unbracketed arrays. ([@akhramov][])
 * [#4615](https://github.com/bbatsov/rubocop/pull/4615): Don't consider `<=>` a comparison method. ([@iGEL][])
 * [#4664](https://github.com/bbatsov/rubocop/pull/4664): Fix typos in Rails/HttpPositionalArguments. ([@JoeCohen][])
 * [#4618](https://github.com/bbatsov/rubocop/pull/4618): Fix `Lint/FormatParameterMismatch` false positive if format string includes `%%5B` (CGI encoded left bracket). ([@barthez][])

--- a/lib/rubocop/ast/node/array_node.rb
+++ b/lib/rubocop/ast/node/array_node.rb
@@ -43,6 +43,15 @@ module RuboCop
           loc.begin && loc.begin.source.start_with?('%')
         end
       end
+
+      # Checks whether the `array` literal is delimited by either percent or
+      # square brackets
+      #
+      # @return [Boolean] whether the array is enclosed in percent or square
+      # brackets
+      def bracketed?
+        square_brackets? || percent_literal?
+      end
     end
   end
 end

--- a/lib/rubocop/cop/style/conditional_assignment.rb
+++ b/lib/rubocop/cop/style/conditional_assignment.rb
@@ -469,7 +469,15 @@ module RuboCop
 
         def replace_branch_assignment(corrector, branch)
           _variable, *_operator, assignment = *branch
-          corrector.replace(branch.source_range, assignment.source)
+          source = assignment.source
+
+          replacement = if assignment.array_type? && !assignment.bracketed?
+                          "[#{source}]"
+                        else
+                          source
+                        end
+
+          corrector.replace(branch.source_range, replacement)
         end
 
         def correct_branches(corrector, branches)

--- a/lib/rubocop/cop/style/mutable_constant.rb
+++ b/lib/rubocop/cop/style/mutable_constant.rb
@@ -46,17 +46,13 @@ module RuboCop
           expr = node.source_range
 
           lambda do |corrector|
-            if unbracketed_array?(node)
+            if node.array_type? && !node.bracketed?
               corrector.insert_before(expr, '[')
               corrector.insert_after(expr, '].freeze')
             else
               corrector.insert_after(expr, '.freeze')
             end
           end
-        end
-
-        def unbracketed_array?(node)
-          node.array_type? && !node.square_brackets? && !node.percent_literal?
         end
 
         def_node_matcher :splat_value, <<-PATTERN

--- a/spec/rubocop/ast/array_node_spec.rb
+++ b/spec/rubocop/ast/array_node_spec.rb
@@ -70,4 +70,26 @@ describe RuboCop::AST::ArrayNode do
       it { expect(array_node.percent_literal?(:symbol)).to be_truthy }
     end
   end
+
+  describe '#bracketed?' do
+    context 'with square brackets' do
+      let(:source) { '[1, 2, 3]' }
+
+      it { expect(array_node).to be_bracketed }
+    end
+
+    context 'with a percent literal' do
+      let(:source) { '%w(foo bar)' }
+
+      it { expect(array_node).to be_bracketed }
+    end
+
+    context 'unbracketed' do
+      let(:array_node) do
+        parse_source('foo = 1, 2, 3').ast.to_a.last
+      end
+
+      it { expect(array_node).not_to be_bracketed }
+    end
+  end
 end

--- a/spec/rubocop/cop/style/conditional_assignment_assign_to_condition_spec.rb
+++ b/spec/rubocop/cop/style/conditional_assignment_assign_to_condition_spec.rb
@@ -12,7 +12,7 @@ describe RuboCop::Cop::Style::ConditionalAssignment do
                                                   assign_inside_condition]
                         },
                         'Lint/EndAlignment' => {
-                          'EnforcedStyleAlignWith' => 'keyword',
+                          'EnforcedStyleAlignWith' => end_alignment_align_with,
                           'Enabled' => true
                         },
                         'Metrics/LineLength' => {
@@ -20,6 +20,8 @@ describe RuboCop::Cop::Style::ConditionalAssignment do
                           'Enabled' => true
                         })
   end
+
+  let(:end_alignment_align_with) { 'start_of_line' }
 
   let(:message) do
     'Use the return of the conditional ' \
@@ -486,6 +488,8 @@ describe RuboCop::Cop::Style::ConditionalAssignment do
   it_behaves_like('all variable types', 'foo.bar')
 
   shared_examples 'all assignment types' do |assignment|
+    let(:end_alignment_align_with) { 'keyword' }
+
     { 'local variable' => 'bar',
       'constant' => 'CONST',
       'class variable' => '@@cvar',
@@ -670,7 +674,7 @@ describe RuboCop::Cop::Style::ConditionalAssignment do
         }
       else
         { }
-            end
+      end
     RUBY
   end
 
@@ -1069,6 +1073,8 @@ describe RuboCop::Cop::Style::ConditionalAssignment do
 
   context 'auto-correct' do
     shared_examples 'comparison correction' do |method|
+      let(:end_alignment_align_with) { 'keyword' }
+
       it 'corrects comparison methods in if elsif else' do
         source = <<-RUBY.strip_indent
           if foo
@@ -1188,7 +1194,27 @@ describe RuboCop::Cop::Style::ConditionalAssignment do
           1
         else
           2
-              end
+        end
+      RUBY
+    end
+
+    it 'corrects assignment to unbracketed array in if else' do
+      source = <<-RUBY.strip_indent
+        if foo
+          bar = 1
+        else
+          bar = 2, 5, 6
+        end
+      RUBY
+
+      new_source = autocorrect_source(source)
+
+      expect(new_source).to eq(<<-RUBY.strip_indent)
+        bar = if foo
+          1
+        else
+          [2, 5, 6]
+        end
       RUBY
     end
 
@@ -1212,7 +1238,7 @@ describe RuboCop::Cop::Style::ConditionalAssignment do
           2
         else
           3
-              end
+        end
       RUBY
     end
 
@@ -1237,7 +1263,7 @@ describe RuboCop::Cop::Style::ConditionalAssignment do
             2
           else
             3
-                 end
+          end
         RUBY
       end
 
@@ -1259,7 +1285,7 @@ describe RuboCop::Cop::Style::ConditionalAssignment do
             1
           else
             2
-                 end
+          end
         RUBY
       end
 
@@ -1279,7 +1305,7 @@ describe RuboCop::Cop::Style::ConditionalAssignment do
             1
           else
             2
-                 end
+          end
         RUBY
       end
     end
@@ -1309,7 +1335,7 @@ describe RuboCop::Cop::Style::ConditionalAssignment do
             2
           else
             3
-                  end
+          end
         RUBY
       end
 
@@ -1331,7 +1357,7 @@ describe RuboCop::Cop::Style::ConditionalAssignment do
             1
           else
             2
-                  end
+          end
         RUBY
       end
 
@@ -1351,7 +1377,7 @@ describe RuboCop::Cop::Style::ConditionalAssignment do
             1
           else
             2
-                  end
+          end
         RUBY
       end
     end
@@ -1383,7 +1409,7 @@ describe RuboCop::Cop::Style::ConditionalAssignment do
           3
         else
           4
-              end
+        end
       RUBY
     end
 
@@ -1403,7 +1429,7 @@ describe RuboCop::Cop::Style::ConditionalAssignment do
           1
         else
           2
-              end
+        end
       RUBY
     end
 
@@ -1425,7 +1451,7 @@ describe RuboCop::Cop::Style::ConditionalAssignment do
           1
         else
           2
-              end
+        end
       RUBY
     end
 
@@ -1451,7 +1477,7 @@ describe RuboCop::Cop::Style::ConditionalAssignment do
           2
         else
           3
-              end
+        end
       RUBY
     end
 
@@ -1472,7 +1498,7 @@ describe RuboCop::Cop::Style::ConditionalAssignment do
             foobar(var, all)
           else
             baz(var, all)
-                 end
+          end
         RUBY
       end
 
@@ -1492,7 +1518,7 @@ describe RuboCop::Cop::Style::ConditionalAssignment do
             foobar(var, all)
           else
             baz(var, all)
-                 end
+          end
         RUBY
       end
 
@@ -1514,7 +1540,7 @@ describe RuboCop::Cop::Style::ConditionalAssignment do
             foobar(var, all)
           else
             baz(var, all)
-                 end
+          end
         RUBY
       end
     end
@@ -1534,7 +1560,7 @@ describe RuboCop::Cop::Style::ConditionalAssignment do
           bar = if cond then 1
           elsif cond then 2
           else 3
-                end
+          end
         RUBY
       end
 
@@ -1552,7 +1578,7 @@ describe RuboCop::Cop::Style::ConditionalAssignment do
           bar = case foo
           when baz then 1
           else 2
-                end
+          end
         RUBY
       end
     end
@@ -1577,7 +1603,7 @@ describe RuboCop::Cop::Style::ConditionalAssignment do
         else
           # comment in else
           2
-              end
+        end
       RUBY
     end
 
@@ -1603,7 +1629,7 @@ describe RuboCop::Cop::Style::ConditionalAssignment do
         else
           # comment in else
           2
-              end
+        end
       RUBY
     end
 
@@ -1621,7 +1647,7 @@ describe RuboCop::Cop::Style::ConditionalAssignment do
             1
           else
             2
-                     end
+          end
         RUBY
       end
 
@@ -1652,7 +1678,7 @@ describe RuboCop::Cop::Style::ConditionalAssignment do
             1
           else
             2
-                           end
+          end
         RUBY
       end
 


### PR DESCRIPTION
`Style/ConditionalAssignment` cop's autocorrection results in invalid
syntax when it encounters assignment to unbracketed array.

This pull request modifies ConditionalAssignment cop's autocorrection so, it
wraps array in brackets, if needed.
This issue is very simillar to #3170, where `Style/MutableConstant`
wasn't able to properly handle assignment to unbracketed array.
Since both `MutableConstant` and `ConditionalAssignment` cops need to
check whether array node is bracketed or not, new method
`Rubocop::AST::ArrayNode#bracketed?` was introduced, to avoid
duplication.

-----------------

Before submitting the PR make sure the following are checked:

* [ ] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [ ] Used the same coding conventions as the rest of the project.
* [ ] Feature branch is up-to-date with `master` (if not - rebase it).
* [ ] Squashed related commits together.
* [ ] Added tests.
* [ ] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [ ] All tests(`rake spec`) are passing.
* [ ] The new code doesn't generate RuboCop offenses that are checked by `rake internal_investigation`.
* [ ] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Updated cop documentation with `rake generate_cops_documentation` (required only when you've added a new cop or changed the configuration/documentation of an existing cop).

[1]: http://chris.beams.io/posts/git-commit/
