### PR TITLE
Accept yoda condition which isn't commutative

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@
 
 ### Bug fixes
 
+* [#4688](https://github.com/bbatsov/rubocop/pull/4688): Accept yoda condition which isn't commutative. ([@fujimura][])
 * [#4676](https://github.com/bbatsov/rubocop/issues/4676): Make `Style/RedundantConditional` cop work with elsif. ([@akhramov][])
 * [#4615](https://github.com/bbatsov/rubocop/pull/4615): Don't consider `<=>` a comparison method. ([@iGEL][])
 * [#4664](https://github.com/bbatsov/rubocop/pull/4664): Fix typos in Rails/HttpPositionalArguments. ([@JoeCohen][])
@@ -2897,3 +2898,4 @@
 [@highb]: https://github.com/highb
 [@JoeCohen]: https://github.com/JoeCohen
 [@akhramov]: https://github.com/akhramov
+[@fujimura]: https://github.com/fujimura

--- a/lib/rubocop/cop/style/yoda_condition.rb
+++ b/lib/rubocop/cop/style/yoda_condition.rb
@@ -48,6 +48,8 @@ module RuboCop
 
         EQUALITY_OPERATORS = %i[== !=].freeze
 
+        NONCOMMUTATIVE_OPERATORS = %i[===].freeze
+
         def on_send(node)
           return unless yoda_condition?(node)
 
@@ -63,6 +65,8 @@ module RuboCop
           if check_equality_only?
             return false if non_equality_operator?(operator)
           end
+
+          return false if noncommutative_operator?(operator)
 
           lhs.literal? && !rhs.literal?
         end
@@ -98,6 +102,10 @@ module RuboCop
 
         def non_equality_operator?(operator)
           !EQUALITY_OPERATORS.include?(operator)
+        end
+
+        def noncommutative_operator?(operator)
+          NONCOMMUTATIVE_OPERATORS.include?(operator)
         end
       end
     end

--- a/spec/rubocop/cop/style/yoda_condition_spec.rb
+++ b/spec/rubocop/cop/style/yoda_condition_spec.rb
@@ -53,6 +53,7 @@ describe RuboCop::Cop::Style::YodaCondition, :config do
   it_behaves_like 'accepts', '!true'
   it_behaves_like 'accepts', 'not true'
   it_behaves_like 'accepts', '0 <=> val'
+  it_behaves_like 'accepts', '"foo" === bar'
 
   it_behaves_like 'offense', '"foo" == bar'
   it_behaves_like 'offense', 'nil == bar'
@@ -83,10 +84,6 @@ describe RuboCop::Cop::Style::YodaCondition, :config do
 
     it_behaves_like(
       'autocorrect', 'nil != foo ? bar : baz', 'foo != nil ? bar : baz'
-    )
-
-    it_behaves_like(
-      'autocorrect', 'false === foo ? bar : baz', 'foo === false ? bar : baz'
     )
   end
 


### PR DESCRIPTION
Regexp#=== performs matching, but String#=== is for equality. Changing position of operands will change original behavior in this case.

For example,

```ruby
[1] pry(main)> "foobar" === /foo/
=> false
[2] pry(main)> /foo/ === "foobar"
=> true
```