### PR TITLE
`URI.regexp` and `URI::Parser.new.make_regexp` are equivalent

### DIFF
--- a/spec/rubocop/ast/node_spec.rb
+++ b/spec/rubocop/ast/node_spec.rb
@@ -350,7 +350,7 @@ describe RuboCop::AST::Node do
       end
 
       context 'with no interpolation' do
-        let(:src) { URI::Parser.new.regexp.inspect }
+        let(:src) { URI::Parser.new.make_regexp.inspect }
         it 'returns true' do
           expect(node).to be_pure
         end


### PR DESCRIPTION
In #4254 I was misunderstanding.

`URI.regexp` and `URI::Parser.new.regexp` are not equivalent.
`URI.regexp` and `URI::Parser.new.make_regexp` are equivalent.

```console
% ruby -ruri -e 'puts URI.regexp == URI::Parser.new.regexp'
false
% ruby -ruri -e 'puts URI.regexp == URI::Parser.new.make_regexp'
true
```

The implementation of `URI.regexp` is as follows.

https://github.com/ruby/ruby/blob/v2_4_1/lib/uri/common.rb#L332-L335

This PR will be fixed to the change that I really wanted to do.

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Used the same coding conventions as the rest of the project.
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [ ] Squashed related commits together.
* [ ] Added tests.
* [ ] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] All tests(`rake spec`) are passing.
* [x] The new code doesn't generate RuboCop offenses that are checked by `rake internal_investigation`.
* [ ] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [ ] Updated cop documentation with `rake generate_cops_documentation` (required only when you've added a new cop or changed the configuration/documentation of an existing cop).

[1]: http://chris.beams.io/posts/git-commit/
