### PR TITLE
Add Metrics/MethodLength cop for define_method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@
 * Make `rake new_cop` create parent directories if they do not already exist. ([@highb][])
 * [#4368](https://github.com/bbatsov/rubocop/issues/4368): Make `Performance/HashEachMethod` inspect send nodes with any receiver. ([@gohdaniel15][])
 * [#4508](https://github.com/bbatsov/rubocop/issues/4508): Add new `Style/ReturnNil` cop. ([@donjar][])
+* [#4629](https://github.com/bbatsov/rubocop/issues/4629): Add Metrics/MethodLength cop for `define_method`. ([@jekuta][])
 
 ### Bug fixes
 
@@ -2897,3 +2898,4 @@
 [@highb]: https://github.com/highb
 [@JoeCohen]: https://github.com/JoeCohen
 [@akhramov]: https://github.com/akhramov
+[@jekuta]: https://github.com/jekuta

--- a/lib/rubocop/cop/metrics/method_length.rb
+++ b/lib/rubocop/cop/metrics/method_length.rb
@@ -16,6 +16,11 @@ module RuboCop
         end
         alias on_defs on_def
 
+        def on_block(node)
+          return unless node.send_node.method_name == :define_method
+          check_code_length(node)
+        end
+
         private
 
         def cop_label

--- a/spec/rubocop/cop/metrics/method_length_spec.rb
+++ b/spec/rubocop/cop/metrics/method_length_spec.rb
@@ -4,37 +4,91 @@ describe RuboCop::Cop::Metrics::MethodLength, :config do
   subject(:cop) { described_class.new(config) }
   let(:cop_config) { { 'Max' => 5, 'CountComments' => false } }
 
-  it 'rejects a method with more than 5 lines' do
-    inspect_source(<<-RUBY.strip_indent)
-      def m()
-        a = 1
-        a = 2
-        a = 3
-        a = 4
-        a = 5
-        a = 6
-      end
-    RUBY
-    expect(cop.offenses.size).to eq(1)
-    expect(cop.offenses.map(&:line).sort).to eq([1])
-    expect(cop.config_to_allow_offenses).to eq('Max' => 6)
-    expect(cop.messages.first).to eq('Method has too many lines. [6/5]')
+  shared_examples 'reports violation' do |first_line, last_line|
+    it 'rejects a method with more than 5 lines' do
+      expect(cop.offenses.size).to eq(1)
+      expect(cop.offenses.map(&:line)).to contain_exactly(first_line)
+      expect(cop.config_to_allow_offenses).to eq('Max' => 6)
+      expect(cop.messages.first).to eq('Method has too many lines. [6/5]')
+    end
+
+    it 'reports the correct beginning and end lines' do
+      offense = cop.offenses.first
+      expect(offense.location.first_line).to eq(first_line)
+      expect(offense.location.last_line).to eq(last_line)
+    end
   end
 
-  it 'reports the correct beginning and end lines' do
-    inspect_source(<<-RUBY.strip_indent)
-      def m()
-        a = 1
-        a = 2
-        a = 3
-        a = 4
-        a = 5
-        a = 6
-      end
-    RUBY
-    offense = cop.offenses.first
-    expect(offense.location.first_line).to eq(1)
-    expect(offense.location.last_line).to eq(8)
+  context 'when method is an instance method' do
+    before do
+      inspect_source(<<-RUBY.strip_indent)
+        def m()
+          a = 1
+          a = 2
+          a = 3
+          a = 4
+          a = 5
+          a = 6
+        end
+      RUBY
+    end
+
+    include_examples 'reports violation', 1, 8
+  end
+
+  context 'when method is defined with `define_method`' do
+    before do
+      inspect_source(<<-RUBY.strip_indent)
+        define_method(:m) do
+          a = 1
+          a = 2
+          a = 3
+          a = 4
+          a = 5
+          a = 6
+        end
+      RUBY
+    end
+
+    include_examples 'reports violation', 1, 8
+  end
+
+  context 'when method is a class method' do
+    before do
+      inspect_source(<<-RUBY.strip_indent)
+        def self.m()
+          a = 1
+          a = 2
+          a = 3
+          a = 4
+          a = 5
+          a = 6
+        end
+      RUBY
+    end
+
+    include_examples 'reports violation', 1, 8
+  end
+
+  context 'when method is defined on a singleton class' do
+    before do
+      inspect_source(<<-RUBY.strip_indent)
+        class K
+          class << self
+            def m()
+              a = 1
+              a = 2
+              a = 3
+              a = 4
+              a = 5
+              a = 6
+            end
+          end
+        end
+      RUBY
+    end
+
+    include_examples 'reports violation', 3, 10
   end
 
   it 'accepts a method with less than 5 lines' do
@@ -108,40 +162,6 @@ describe RuboCop::Cop::Metrics::MethodLength, :config do
         a = 6
       end
     RUBY
-  end
-
-  it 'checks class methods, syntax #1' do
-    inspect_source(<<-RUBY.strip_indent)
-      def self.m()
-        a = 1
-        a = 2
-        a = 3
-        a = 4
-        a = 5
-        a = 6
-      end
-    RUBY
-    expect(cop.offenses.size).to eq(1)
-    expect(cop.offenses.map(&:line).sort).to eq([1])
-  end
-
-  it 'checks class methods, syntax #2' do
-    inspect_source(<<-RUBY.strip_indent)
-      class K
-        class << self
-          def m()
-            a = 1
-            a = 2
-            a = 3
-            a = 4
-            a = 5
-            a = 6
-          end
-        end
-      end
-    RUBY
-    expect(cop.offenses.size).to eq(1)
-    expect(cop.offenses.map(&:line).sort).to eq([3])
   end
 
   it 'properly counts lines when method ends with block' do


### PR DESCRIPTION
Metrics/MethodLength cop for `define_method`as described in #4629 

Feature
-----------------
This PR adds a `on_block` method to the cop. It checks whether we are sending the `define method` with a block and if so then passes the node to check_code_lenght method, as we would do with the normal method as well.

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Used the same coding conventions as the rest of the project.
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] All tests(`rake spec`) are passing.
* [x] The new code doesn't generate RuboCop offenses that are checked by `rake internal_investigation`.
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [ ] Updated cop documentation with `rake generate_cops_documentation` (required only when you've added a new cop or changed the configuration/documentation of an existing cop).

[1]: http://chris.beams.io/posts/git-commit/
