### PR TITLE
Add new `Performance/UriDefaultParser` cop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@
 * [#4368](https://github.com/bbatsov/rubocop/issues/4368): Make `Performance/HashEachMethod` inspect send nodes with any receiver. ([@gohdaniel15][])
 * [#4508](https://github.com/bbatsov/rubocop/issues/4508): Add new `Style/ReturnNil` cop. ([@donjar][])
 * [#4629](https://github.com/bbatsov/rubocop/issues/4629): Add Metrics/MethodLength cop for `define_method`. ([@jekuta][])
+* [#4696](https://github.com/bbatsov/rubocop/pull/4696): Add new `Performance/UriDefaultParser` cop. ([@koic][])
 
 ### Bug fixes
 

--- a/config/enabled.yml
+++ b/config/enabled.yml
@@ -1601,6 +1601,10 @@ Performance/UnfreezeString:
   Description: 'Use unary plus to get an unfrozen string literal.'
   Enabled: true
 
+Performance/UriDefaultParser:
+  Description: 'Use `URI::DEFAULT_PARSER` instead of `URI::Parser.new`.'
+  Enabled: true
+
 #################### Rails #################################
 
 Rails/ActionFilter:

--- a/lib/rubocop.rb
+++ b/lib/rubocop.rb
@@ -325,6 +325,7 @@ require 'rubocop/cop/performance/start_with'
 require 'rubocop/cop/performance/string_replacement'
 require 'rubocop/cop/performance/times_map'
 require 'rubocop/cop/performance/unfreeze_string'
+require 'rubocop/cop/performance/uri_default_parser'
 
 require 'rubocop/cop/style/alias'
 require 'rubocop/cop/style/and_or'

--- a/lib/rubocop/config_loader.rb
+++ b/lib/rubocop/config_loader.rb
@@ -85,7 +85,7 @@ module RuboCop
 
       def base_configs(path, inherit_from)
         configs = Array(inherit_from).compact.map do |f|
-          if f =~ /\A#{URI::Parser.new.make_regexp(%w[http https])}\z/
+          if f =~ /\A#{URI::DEFAULT_PARSER.make_regexp(%w[http https])}\z/
             f = RemoteConfig.new(f, File.dirname(path)).file
           else
             f = File.expand_path(f, File.dirname(path))

--- a/lib/rubocop/cop/metrics/line_length.rb
+++ b/lib/rubocop/cop/metrics/line_length.rb
@@ -123,7 +123,7 @@ module RuboCop
         end
 
         def uri_regexp
-          @regexp ||= URI::Parser.new.make_regexp(cop_config['URISchemes'])
+          @regexp ||= URI::DEFAULT_PARSER.make_regexp(cop_config['URISchemes'])
         end
 
         def check_directive_line(line, index)

--- a/lib/rubocop/cop/performance/uri_default_parser.rb
+++ b/lib/rubocop/cop/performance/uri_default_parser.rb
@@ -1,0 +1,47 @@
+# frozen_string_literal: true
+
+module RuboCop
+  module Cop
+    module Performance
+      # This cop identifies places where `URI::Parser.new`
+      # can be replaced by `URI::DEFAULT_PARSER`.
+      #
+      # @example
+      #   # bad
+      #   URI::Parser.new
+      #
+      #   # good
+      #   URI::DEFAULT_PARSER
+      #
+      class UriDefaultParser < Cop
+        MSG = 'Use `%sURI::DEFAULT_PARSER` instead of ' \
+              '`%sURI::Parser.new`.'.freeze
+
+        def_node_matcher :uri_parser_new?, <<-PATTERN
+          (send
+            (const
+              (const ${nil cbase} :URI) :Parser) :new)
+        PATTERN
+
+        def on_send(node)
+          return unless uri_parser_new?(node) do |captured_value|
+            double_colon = captured_value ? '::' : ''
+            message = format(MSG, double_colon, double_colon)
+
+            add_offense(node, :expression, message)
+          end
+        end
+
+        def autocorrect(node)
+          lambda do |corrector|
+            double_colon = uri_parser_new?(node) ? '::' : ''
+
+            corrector.replace(
+              node.loc.expression, "#{double_colon}URI::DEFAULT_PARSER"
+            )
+          end
+        end
+      end
+    end
+  end
+end

--- a/manual/cops.md
+++ b/manual/cops.md
@@ -288,6 +288,7 @@ In the following section you find all available cops:
 * [Performance/StringReplacement](cops_performance.md#performancestringreplacement)
 * [Performance/TimesMap](cops_performance.md#performancetimesmap)
 * [Performance/UnfreezeString](cops_performance.md#performanceunfreezestring)
+* [Performance/UriDefaultParser](cops_performance.md#performanceuridefaultparser)
 
 #### Department [Rails](cops_rails.md)
 

--- a/manual/cops_performance.md
+++ b/manual/cops_performance.md
@@ -786,3 +786,22 @@ String.new('something')
 +'something'
 +''
 ```
+
+## Performance/UriDefaultParser
+
+Enabled by default | Supports autocorrection
+--- | ---
+Enabled | Yes
+
+This cop identifies places where `URI::Parser.new`
+can be replaced by `URI::DEFAULT_PARSER`.
+
+### Example
+
+```ruby
+# bad
+URI::Parser.new
+
+# good
+URI::DEFAULT_PARSER
+```

--- a/spec/rubocop/ast/node_spec.rb
+++ b/spec/rubocop/ast/node_spec.rb
@@ -350,7 +350,7 @@ describe RuboCop::AST::Node do
       end
 
       context 'with no interpolation' do
-        let(:src) { URI::Parser.new.make_regexp.inspect }
+        let(:src) { URI::DEFAULT_PARSER.make_regexp.inspect }
         it 'returns true' do
           expect(node).to be_pure
         end

--- a/spec/rubocop/cop/performance/uri_default_parser_spec.rb
+++ b/spec/rubocop/cop/performance/uri_default_parser_spec.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+
+describe RuboCop::Cop::Performance::UriDefaultParser do
+  let(:config) { RuboCop::Config.new }
+  subject(:cop) { described_class.new(config) }
+
+  it 'registers an offense when using `URI::Parser.new`' do
+    expect_offense(<<-RUBY.strip_indent)
+      URI::Parser.new.make_regexp
+      ^^^^^^^^^^^^^^^ Use `URI::DEFAULT_PARSER` instead of `URI::Parser.new`.
+    RUBY
+  end
+
+  it 'registers an offense when using `::URI::Parser.new`' do
+    expect_offense(<<-RUBY.strip_indent)
+      ::URI::Parser.new.make_regexp
+      ^^^^^^^^^^^^^^^^^ Use `::URI::DEFAULT_PARSER` instead of `::URI::Parser.new`.
+    RUBY
+  end
+
+  it 'autocorrects `URI::DEFAULT_PARSER`' do
+    new_source = autocorrect_source('URI::Parser.new.make_regexp')
+
+    expect(new_source).to eq 'URI::DEFAULT_PARSER.make_regexp'
+  end
+
+  it 'autocorrects `::URI::DEFAULT_PARSER`' do
+    new_source = autocorrect_source('::URI::Parser.new.make_regexp')
+
+    expect(new_source).to eq '::URI::DEFAULT_PARSER.make_regexp'
+  end
+end


### PR DESCRIPTION
This cop is inspired by https://github.com/bbatsov/rubocop/pull/4694#discussion_r136707061.

## Feature

This cop identifies places where `URI::Parser.new` can be replaced by `URI::DEFAULT_PARSER`.

```console
% cat /tmp/test.rb
# frozen_string_literal: true

require 'uri'

URI::Parser.new.make_regexp
```

```console
% bundle exec rubocop /tmp/test.rb
Inspecting 1 file
C

Offenses:

/tmp/test.rb:5:1: C: Use URI::DEFAULT_PARSER instead of URI::Parser.new.
URI::Parser.new.make_regexp
^^^^^^^^^^^^^^^

1 file inspected, 1 offense detected
```

## Target Problem

The following is a benchmark script.

```ruby
require 'benchmark/ips'
require 'uri'

Benchmark.ips do |x|
  x.report('URI::Parser.new')     { URI::Parser.new }
  x.report('URI::DEFAULT_PARSER') { URI::DEFAULT_PARSER }
  x.compare!
end
```

It is the result of running the above benchmark script.

```console
% ruby bench.rb
Warming up --------------------------------------
     URI::Parser.new    70.000  i/100ms
 URI::DEFAULT_PARSER   315.505k i/100ms
Calculating -------------------------------------
     URI::Parser.new    714.537  (± 4.2%) i/s -      3.570k in   5.005495s
 URI::DEFAULT_PARSER     10.950M (± 6.2%) i/s -     54.582M in   5.007247s

Comparison:
 URI::DEFAULT_PARSER: 10949722.8 i/s
     URI::Parser.new:      714.5 i/s - 15324.22x  slower
```

It is a constant as follows and it is fast because it does not instantiate every time.
https://github.com/ruby/ruby/blob/v2_4_1/lib/uri/common.rb#L22

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Used the same coding conventions as the rest of the project.
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] All tests(`rake spec`) are passing.
* [x] The new code doesn't generate RuboCop offenses that are checked by `rake internal_investigation`.
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Updated cop documentation with `rake generate_cops_documentation` (required only when you've added a new cop or changed the configuration/documentation of an existing cop).

[1]: http://chris.beams.io/posts/git-commit/
