### PR TITLE
Run tests against supported jRuby versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,8 @@ cache: bundler
 language: ruby
 dist: trusty
 rvm:
-  - jruby-9.0.1.0
+  - jruby-9.1.13.0
+  - jruby-head
   - 2.0.0
   - 2.1.10
   - 2.2.8
@@ -13,16 +14,16 @@ rvm:
   - rbx-3
 env:
   global:
-    - JRUBY_OPTS='--debug' # get more accurate coverage data in JRuby
+    - JRUBY_OPTS='--debug -J-Xmx1000M' # get more accurate coverage data in JRuby
   matrix:
     - 'TASK=spec'
     - 'TASK=ascii_spec'
     - 'TASK=internal_investigation'
 matrix:
   allow_failures:
-    - rvm: jruby-9.0.1.0
     - rvm: ruby-head
     - rvm: rbx-3
+    - rvm: jruby-head
   fast_finish: true
 before_install:
   - gem update --remote bundler

--- a/lib/rubocop/cop/util.rb
+++ b/lib/rubocop/cop/util.rb
@@ -295,7 +295,7 @@ module RuboCop
       end
 
       def compatible_external_encoding_for?(src)
-        src = src.dup if RUBY_VERSION < '2.3'
+        src = src.dup if RUBY_VERSION < '2.3' || RUBY_ENGINE == 'jruby'
         src.force_encoding(Encoding.default_external).valid_encoding?
       end
 


### PR DESCRIPTION
This is related to #4686. We aren't running tests against all supported jRuby versions. It would be really nice if we could specify `jruby-9.0` and `jruby-9.1` to test against the latest versions. I know that we have had issues with the Travis aliases in the past. It seems like we should always run against `jruby-head` even if it is an allowed failure.

https://docs.travis-ci.com/user/languages/ruby/
http://rubies.travis-ci.org/