### PR TITLE
Avoid "unused variable" in Ruby 2.5

### DIFF
--- a/lib/rubocop/node_pattern.rb
+++ b/lib/rubocop/node_pattern.rb
@@ -345,7 +345,8 @@ module RuboCop
         else
           n = @unify[name] = next_temp_value
           # double assign to temp#{n} to avoid "assigned but unused variable"
-          "(temp#{n} = temp#{n} = #{cur_node}#{'.type' if seq_head}; true)"
+          "(temp#{n} = #{cur_node}#{'.type' if seq_head}; " \
+          "temp#{n} = temp#{n}; true)"
         end
       end
 
@@ -462,7 +463,7 @@ module RuboCop
       def with_temp_node(cur_node)
         with_temp_variable do |temp_var|
           # double assign to temp#{n} to avoid "assigned but unused variable"
-          yield "#{temp_var} = #{temp_var} = #{cur_node}", temp_var
+          yield "#{temp_var} = #{cur_node}; #{temp_var} = #{temp_var}", temp_var
         end
       end
 


### PR DESCRIPTION
## Summary

This PR fixes the following Ruby 2.5 build error on Travis CI.

https://travis-ci.org/bbatsov/rubocop/jobs/271819723#L664-L676

It is how to reproduce.

```console
% ruby -v
ruby 2.5.0dev (2017-09-01) [x86_64-darwin13]
% bundle exec rspec ./spec/project_spec.rb:180
Run options:
  include {:focus=>true, :locations=>{"./spec/project_spec.rb"=>[180]}}
  exclude {:broken=>#<Proc:./spec/spec_helper.rb:42>}

Randomized with seed 46397
F

Failures:

  1) RuboCop Project requiring all of `lib` with verbose warnings enabled emits no warnings
     Failure/Error: expect(warnings).to be_empty
       expected `["/Users/koic/src/github.com/bbatsov/rubocop/lib/rubocop/cop/lint/duplicate_methods.rb:74: warning: a...atsov/rubocop/lib/rubocop/cop/rails/present.rb:59: warning: assigned but unused variable - temp4\n"].empty?` to return true, got false
     # ./spec/project_spec.rb:187:in `block (3 levels) in <top (required)>'

Finished in 0.89883 seconds (files took 1.35 seconds to load)
1 example, 1 failure

Failed examples:

rspec ./spec/project_spec.rb:180 # RuboCop Project requiring all of `lib` with verbose warnings enabled emits no warnings

Randomized with seed 46397
```

## Other Information

This change in Ruby 2.5, I learned at the following commit to Rails by Ruby / Rails committer @amatsuda.

https://github.com/rails/rails/commit/8ad8093accc2ab8a8bc727af02127a0b5d1a56f3

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Used the same coding conventions as the rest of the project.
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [ ] Added tests.
* [ ] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] All tests(`rake spec`) are passing.
* [x] The new code doesn't generate RuboCop offenses that are checked by `rake internal_investigation`.
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [ ] Updated cop documentation with `rake generate_cops_documentation` (required only when you've added a new cop or changed the configuration/documentation of an existing cop).

[1]: http://chris.beams.io/posts/git-commit/
