### PR TITLE
Use cached remote config on network failure

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@
 
 ### Bug fixes
 
+* [#4709](https://github.com/bbatsov/rubocop/pull/4709): Use cached remote config on network failure. ([@kristjan][])
 * [#4688](https://github.com/bbatsov/rubocop/pull/4688): Accept yoda condition which isn't commutative. ([@fujimura][])
 * [#4676](https://github.com/bbatsov/rubocop/issues/4676): Make `Style/RedundantConditional` cop work with elsif. ([@akhramov][])
 * [#4656](https://github.com/bbatsov/rubocop/issues/4656): Modify `Style/ConditionalAssignment` autocorrection to work with unbracketed arrays. ([@akhramov][])
@@ -2904,3 +2905,4 @@
 [@akhramov]: https://github.com/akhramov
 [@jekuta]: https://github.com/jekuta
 [@fujimura]: https://github.com/fujimura
+[@kristjan]: https://github.com/kristjan

--- a/spec/rubocop/remote_config_spec.rb
+++ b/spec/rubocop/remote_config_spec.rb
@@ -74,6 +74,17 @@ describe RuboCop::RemoteConfig do
       end
     end
 
+    context 'when the network is inaccessible' do
+      before do
+        stub_request(:get, remote_config_url)
+          .to_raise(SocketError)
+      end
+
+      it 'reuses the existing cached file' do
+        expect(remote_config).to eq(cached_file_path)
+      end
+    end
+
     context 'when the remote URL responds with 500' do
       before do
         stub_request(:get, remote_config_url)


### PR DESCRIPTION
If your configuration provides a URI to `inherit_from`, the locally
cached file is stale, and you are offline, then running RuboCop would
crash with an error like:

    Failed to open TCP connection to example.com:443 (getaddrinfo:
    nodename nor servname provided, or not known)

Since we do have a cached config, we can use it, and you can still run
cops without having to wait for the network to be available again.

Effectively, this behaves the same as if the network were accessible,
but the configuration file has not been modified.

If the file has never once been cached, the result is a different crash
reporting that the cached file does not exist. This may be confusing and
could be handled better, but is no worse than RuboCop's behavior when
you specify a nonexistent configuration file.

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Used the same coding conventions as the rest of the project.
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] All tests(`rake spec`) are passing.
* [x] The new code doesn't generate RuboCop offenses that are checked by `rake internal_investigation`.
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [ ] Updated cop documentation with `rake generate_cops_documentation` (required only when you've added a new cop or changed the configuration/documentation of an existing cop).

[1]: http://chris.beams.io/posts/git-commit/
