### PR TITLE
[Fix #4322] Fix Style/MultilineMemoization autocorrection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -61,6 +61,7 @@
 * [#4646](https://github.com/bbatsov/rubocop/issues/4646): Make `Lint/Debugger` aware of `Kernel` and cbase. ([@pocke][])
 * [#4643](https://github.com/bbatsov/rubocop/issues/4643): Modify `Style/InverseMethods` to not register a separate offense for an inverse method nested inside of the block of an inverse method offense. ([@rrosenblum][])
 * [#4593](https://github.com/bbatsov/rubocop/issues/4593): Fix false positive in `Rails/SaveBang` when `save/update_attribute` is used with a `case` statement. ([@theRealNG][])
+* [#4322](https://github.com/bbatsov/rubocop/issues/4322): Fix Style/MultilineMemoization from autocorrecting to invalid ruby. ([@dpostorivo][])
 
 ### Changes
 

--- a/lib/rubocop/cop/style/multiline_memoization.rb
+++ b/lib/rubocop/cop/style/multiline_memoization.rb
@@ -54,8 +54,7 @@ module RuboCop
         def autocorrect(node)
           lambda do |corrector|
             if style == :keyword
-              corrector.replace(node.loc.begin, 'begin')
-              corrector.replace(node.loc.end, 'end')
+              keyword_autocorrect(node, corrector)
             else
               corrector.replace(node.loc.begin, '(')
               corrector.replace(node.loc.end, ')')
@@ -69,6 +68,29 @@ module RuboCop
             rhs.begin_type?
           else
             rhs.kwbegin_type?
+          end
+        end
+
+        def keyword_autocorrect(node, corrector)
+          node_buf = node.source_range.source_buffer
+          corrector.replace(node.loc.begin, keyword_begin_str(node, node_buf))
+          corrector.replace(node.loc.end, keyword_end_str(node, node_buf))
+        end
+
+        def keyword_begin_str(node, node_buf)
+          indent = config.for_cop('IndentationWidth')['Width'] || 2
+          if node_buf.source[node.loc.begin.end_pos] == "\n"
+            'begin'
+          else
+            "begin\n" + (' ' * (node.loc.column + indent))
+          end
+        end
+
+        def keyword_end_str(node, node_buf)
+          if node_buf.source_line(node.loc.end.line) =~ /[^\s\)]/
+            "\n" + (' ' * node.loc.column) + 'end'
+          else
+            'end'
           end
         end
       end

--- a/spec/rubocop/cop/style/multiline_memoization_spec.rb
+++ b/spec/rubocop/cop/style/multiline_memoization_spec.rb
@@ -121,6 +121,18 @@ describe RuboCop::Cop::Style::MultilineMemoization, :config do
                                 baz
                               end
                           RUBY
+
+          it_behaves_like 'code with offense',
+                          <<-RUBY.strip_indent,
+                            foo ||= (bar ||
+                                     baz)
+                          RUBY
+                          <<-RUBY.strip_indent
+                             foo ||= begin
+                                       bar ||
+                                      baz
+                                     end
+                          RUBY
         end
       end
 


### PR DESCRIPTION
Fixes the issue seen in [#4322](https://github.com/bbatsov/rubocop/issues/4322) where the auto correct for Style/MultilineMemoization cop would break code. Specifically this where:

```
foo ||= (bar ||
            baz)
```
becomes:
```
foo ||= beginbar ||
            bazend

```

and now corrects to:

```
foo ||= begin
             bar ||
             baz
        end
```

This is the first autocorrect I've done so far so let me know if anything needs to be done differently or more test cases are needed.


-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Used the same coding conventions as the rest of the project.
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] All tests(`rake spec`) are passing.
* [x] The new code doesn't generate RuboCop offenses that are checked by `rake internal_investigation`.
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [ ] Updated cop documentation with `rake generate_cops_documentation` (required only when you've added a new cop or changed the configuration/documentation of an existing cop).

[1]: http://chris.beams.io/posts/git-commit/
