### PR TITLE
Remove duplicated scrub_string definition

### DIFF
--- a/lib/rubocop/cop/lint/percent_string_array.rb
+++ b/lib/rubocop/cop/lint/percent_string_array.rb
@@ -69,17 +69,6 @@ module RuboCop
           end
         end
         # rubocop:enable Performance/HashEachMethod
-
-        def scrub_string(string)
-          if string.respond_to?(:scrub)
-            string.scrub
-          else
-            string
-              .encode('UTF-16BE', 'UTF-8',
-                      invalid: :replace, undef: :replace, replace: '?')
-              .encode('UTF-8')
-          end
-        end
       end
     end
   end


### PR DESCRIPTION
Removes `RuboCop::Cop::Lint::PercentStringArray#scrub_string` as an identical method is defined at and [in scope](https://github.com/bbatsov/rubocop/blob/c52e0ffdcf416bfabe887679f61290fdee0e0d4a/lib/rubocop/cop/cop.rb#L30) from [`RuboCop::Cop::Util#scrub_string`](https://github.com/bbatsov/rubocop/blob/c3a9ad504d00c9090bd3152bb44d43de0a19cf38/lib/rubocop/cop/util.rb#L308-L317).

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Used the same coding conventions as the rest of the project.
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [ ] Added tests.
* [ ] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] All tests(`rake spec`) are passing.
* [x] The new code doesn't generate RuboCop offenses that are checked by `rake internal_investigation`.
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [ ] Updated cop documentation with `rake generate_cops_documentation` (required only when you've added a new cop or changed the configuration/documentation of an existing cop).

[1]: http://chris.beams.io/posts/git-commit/
