### PR TITLE
Add new `InternalAffairs/RedundantLocationArgument` cop

### DIFF
--- a/lib/rubocop/cop/internal_affairs.rb
+++ b/lib/rubocop/cop/internal_affairs.rb
@@ -3,4 +3,5 @@
 require 'rubocop/cop/internal_affairs/node_type_predicate'
 require 'rubocop/cop/internal_affairs/offense_location_keyword'
 require 'rubocop/cop/internal_affairs/redundant_message_argument'
+require 'rubocop/cop/internal_affairs/redundant_location_argument'
 require 'rubocop/cop/internal_affairs/useless_message_assertion'

--- a/lib/rubocop/cop/internal_affairs/redundant_location_argument.rb
+++ b/lib/rubocop/cop/internal_affairs/redundant_location_argument.rb
@@ -1,0 +1,46 @@
+# frozen_string_literal: true
+
+module RuboCop
+  module Cop
+    module InternalAffairs
+      # Checks for redundant `location` argument to `#add_offense`. `location`
+      # argument has a default value of `:expression` and this method will
+      # automatically use it.
+      #
+      # @example
+      #
+      #   # bad
+      #   add_offense(node, :expression)
+      #
+      #   # good
+      #   add_offense(node)
+      #   add_offense(node, :selector)
+      #   add_offense(node, :expression, 'message')
+      #
+      class RedundantLocationArgument < Cop
+        MSG = 'Redundant location argument to `#add_offense`.'.freeze
+
+        def_node_matcher :node_type_check, <<-PATTERN
+          (send nil :add_offense _ (sym :expression))
+        PATTERN
+
+        def on_send(node)
+          node_type_check(node) do
+            add_offense(node.last_argument)
+          end
+        end
+
+        def autocorrect(node)
+          first, second = node.parent.arguments
+
+          range = range_between(
+            first.loc.expression.end_pos,
+            second.loc.expression.end_pos
+          )
+
+          ->(corrector) { corrector.remove(range) }
+        end
+      end
+    end
+  end
+end

--- a/lib/rubocop/cop/lint/interpolation_check.rb
+++ b/lib/rubocop/cop/lint/interpolation_check.rb
@@ -23,7 +23,7 @@ module RuboCop
         def on_str(node)
           return if heredoc?(node)
           return unless scrub_string(node.str_content) =~ /#\{.*\}/
-          add_offense(node, :expression)
+          add_offense(node)
         end
 
         def heredoc?(node)

--- a/lib/rubocop/cop/style/identical_conditional_branches.rb
+++ b/lib/rubocop/cop/style/identical_conditional_branches.rb
@@ -100,7 +100,7 @@ module RuboCop
           return unless expressions.size > 1 && expressions.uniq.one?
 
           expressions.each do |expression|
-            add_offense(expression, :expression)
+            add_offense(expression)
           end
         end
 

--- a/lib/rubocop/cop/style/method_call_with_args_parentheses.rb
+++ b/lib/rubocop/cop/style/method_call_with_args_parentheses.rb
@@ -46,7 +46,7 @@ module RuboCop
           return if ignored_method?(node)
           return unless node.arguments? && !node.parenthesized?
 
-          add_offense(node, :expression)
+          add_offense(node)
         end
         alias on_super on_send
         alias on_yield on_send

--- a/spec/rubocop/cop/internal_affairs/redundant_location_argument_spec.rb
+++ b/spec/rubocop/cop/internal_affairs/redundant_location_argument_spec.rb
@@ -1,0 +1,46 @@
+# frozen_string_literal: true
+
+describe RuboCop::Cop::InternalAffairs::RedundantLocationArgument do
+  subject(:cop) { described_class.new }
+
+  context 'when location argument is passed' do
+    context 'when location argument is :expression' do
+      it 'registers an offense' do
+        expect_offense(<<-RUBY, 'example_cop.rb')
+          add_offense(node, :expression)
+                            ^^^^^^^^^^^ Redundant location argument to `#add_offense`.
+        RUBY
+      end
+
+      it 'auto-corrects an offense' do
+        new_source = autocorrect_source('add_offense(node, :expression)')
+
+        expect(new_source).to eq('add_offense(node)')
+      end
+
+      context 'when there is a message argument' do
+        it 'does not register an offense' do
+          expect_no_offenses(<<-RUBY, 'example_cop.rb')
+            add_offense(node, :expression, "message")
+          RUBY
+        end
+      end
+    end
+
+    context 'when location argument does not equal to :expression' do
+      it 'does not register an offense' do
+        expect_no_offenses(<<-RUBY, 'example_cop.rb')
+          add_offense(node, :selector)
+        RUBY
+      end
+    end
+  end
+
+  context 'when location argument is not passed' do
+    it 'does not register an offense' do
+      expect_no_offenses(<<-RUBY, 'example_cop.rb')
+        add_offense(node)
+      RUBY
+    end
+  end
+end


### PR DESCRIPTION
This pull request adds internal affairs cop, that checks if `loc` (location) argument
of `#add_offense` method can be omitted.

The idea of this cop belongs to @pocke  according to [comment](https://github.com/bbatsov/rubocop/pull/4681#discussion_r136286613).

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Used the same coding conventions as the rest of the project.
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] All tests(`rake spec`) are passing.
* [x] The new code doesn't generate RuboCop offenses that are checked by `rake internal_investigation`.
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Updated cop documentation with `rake generate_cops_documentation` (required only when you've added a new cop or changed the configuration/documentation of an existing cop).

[1]: http://chris.beams.io/posts/git-commit/
