### PR TITLE
Add tests for Lint/InterpolationCheck

### DIFF
--- a/lib/rubocop/cop/lint/interpolation_check.rb
+++ b/lib/rubocop/cop/lint/interpolation_check.rb
@@ -18,7 +18,7 @@ module RuboCop
       #   foo = "something with #{interpolation} inside"
       class InterpolationCheck < Cop
         MSG = 'Interpolation in single quoted string detected. '\
-	      'Use double quoted strings if you need interpolation.'.freeze
+        'Use double quoted strings if you need interpolation.'.freeze
 
         def on_str(node)
           return if heredoc?(node)

--- a/spec/rubocop/cop/lint/interpolation_check_spec.rb
+++ b/spec/rubocop/cop/lint/interpolation_check_spec.rb
@@ -10,6 +10,22 @@ describe RuboCop::Cop::Lint::InterpolationCheck do
     RUBY
   end
 
+  it 'does not register an offense for interpolation in heredoc' do
+    expect_no_offenses(<<-'RUBY'.strip_indent)
+      hello = <<-TEXT
+        foo #{bar}
+      TEXT
+    RUBY
+  end
+
+  it 'does not register an offense for an escaped interpolation in heredoc' do
+    expect_no_offenses(<<-'RUBY'.strip_indent)
+      hello = <<-TEXT
+        foo \#{bar}
+      TEXT
+    RUBY
+  end
+
   it 'does not register an offense for properly interpolation strings' do
     expect_no_offenses(<<-'RUBY'.strip_indent)
       hello = "foo #{bar}"


### PR DESCRIPTION
Adds test coverage for the `Lint::InterpolationCheck#heredoc?` method, which was completely absent before. Introduced in #4480.

Also changed a tab character into two spaces. (Why didn’t Layout/Tab catch this?)

cc @GauthamGoli 

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Used the same coding conventions as the rest of the project.
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [ ] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] All tests(`rake spec`) are passing.
* [x] The new code doesn't generate RuboCop offenses that are checked by `rake internal_investigation`.
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [ ] Updated cop documentation with `rake generate_cops_documentation` (required only when you've added a new cop or changed the configuration/documentation of an existing cop).

[1]: http://chris.beams.io/posts/git-commit/
