### PR TITLE
Add new `Bundler/InsecureProtocolSource` cop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@
 * [#4696](https://github.com/bbatsov/rubocop/pull/4696): Add new `Performance/UriDefaultParser` cop. ([@koic][])
 * [#4694](https://github.com/bbatsov/rubocop/pull/4694): Add new `Lint/UriRegexp` cop. ([@koic][])
 * Add new `Style/MinMax` cop. ([@drenmi][])
+* [#4720](https://github.com/bbatsov/rubocop/pull/4720): Add new `Bundler/InsecureProtocolSource` cop. ([@koic][])
 
 ### Bug fixes
 

--- a/config/enabled.yml
+++ b/config/enabled.yml
@@ -1832,6 +1832,16 @@ Bundler/DuplicatedGem:
     - '**/Gemfile'
     - '**/gems.rb'
 
+Bundler/InsecureProtocolSource:
+  Description: >-
+                 The source `:gemcutter`, `:rubygems` and `:rubyforge` are deprecated
+                 because HTTP requests are insecure. Please change your source to
+                 'https://rubygems.org' if possible, or 'http://rubygems.org' if not.
+  Enabled: true
+  Include:
+    - '**/Gemfile'
+    - '**/gems.rb'
+
 Bundler/OrderedGems:
   Description: >-
                  Gems within groups in the Gemfile should be alphabetically sorted.

--- a/lib/rubocop.rb
+++ b/lib/rubocop.rb
@@ -136,6 +136,7 @@ require 'rubocop/cop/mixin/trailing_comma'
 require 'rubocop/cop/mixin/unused_argument'
 
 require 'rubocop/cop/bundler/duplicated_gem'
+require 'rubocop/cop/bundler/insecure_protocol_source'
 require 'rubocop/cop/bundler/ordered_gems'
 
 require 'rubocop/cop/layout/access_modifier_indentation'

--- a/lib/rubocop/cop/bundler/insecure_protocol_source.rb
+++ b/lib/rubocop/cop/bundler/insecure_protocol_source.rb
@@ -1,0 +1,59 @@
+# frozen_string_literal: true
+
+module RuboCop
+  module Cop
+    module Bundler
+      # The source `:gemcutter`, `:rubygems` and `:rubyforge` are deprecated
+      # because HTTP requests are insecure. Please change your source to
+      # 'https://rubygems.org' if possible, or 'http://rubygems.org' if not.
+      #
+      # @example
+      #   # bad
+      #   source :gemcutter
+      #   source :rubygems
+      #   source :rubyforge
+      #
+      #   # good
+      #   source 'https://rubygems.org' # strongly recommended
+      #   source 'http://rubygems.org'
+      class InsecureProtocolSource < Cop
+        MSG = 'The source `:%s` is deprecated because HTTP requests are ' \
+              "insecure. Please change your source to 'https://rubygems.org' " \
+              "if possible, or 'http://rubygems.org' if not.".freeze
+
+        def_node_matcher :insecure_protocol_source?, <<-PATTERN
+          (send nil :source
+            (sym {:gemcutter :rubygems :rubyforge}))
+        PATTERN
+
+        def on_send(node)
+          insecure_protocol_source?(node) do
+            source = source_node(node)
+
+            message = format(MSG, source.children.last)
+
+            add_offense(node, source_range(source.loc.expression), message)
+          end
+        end
+
+        def autocorrect(node)
+          lambda do |corrector|
+            corrector.replace(
+              source_node(node).loc.expression, "'https://rubygems.org'"
+            )
+          end
+        end
+
+        private
+
+        def source_node(node)
+          node.children.last
+        end
+
+        def source_range(node)
+          range_between(node.begin_pos, node.end_pos)
+        end
+      end
+    end
+  end
+end

--- a/lib/rubocop/cop/bundler/insecure_protocol_source.rb
+++ b/lib/rubocop/cop/bundler/insecure_protocol_source.rb
@@ -3,9 +3,18 @@
 module RuboCop
   module Cop
     module Bundler
-      # The source `:gemcutter`, `:rubygems` and `:rubyforge` are deprecated
-      # because HTTP requests are insecure. Please change your source to
+      # The symbol argument `:gemcutter`, `:rubygems` and `:rubyforge`
+      # are deprecated. So please change your source to URL string that
       # 'https://rubygems.org' if possible, or 'http://rubygems.org' if not.
+      #
+      # This autocorrect will replace these symbols with 'https://rubygems.org'.
+      # Because it is secure, HTTPS request is strongly recommended. And in
+      # most use cases HTTPS will be fine.
+      #
+      # However, it don't replace all `sources` of `http://` with `https://`.
+      # For example, when specifying an internal gem server using HTTP on the
+      # intranet, a use case where HTTPS can not be specified was considered.
+      # Consider using HTTP only if you can not use HTTPS.
       #
       # @example
       #   # bad

--- a/lib/rubocop/cop/bundler/insecure_protocol_source.rb
+++ b/lib/rubocop/cop/bundler/insecure_protocol_source.rb
@@ -23,32 +23,28 @@ module RuboCop
 
         def_node_matcher :insecure_protocol_source?, <<-PATTERN
           (send nil :source
-            (sym {:gemcutter :rubygems :rubyforge}))
+            (sym ${:gemcutter :rubygems :rubyforge}))
         PATTERN
 
         def on_send(node)
-          insecure_protocol_source?(node) do
-            source = source_node(node)
+          insecure_protocol_source?(node) do |source|
+            message = format(MSG, source)
 
-            message = format(MSG, source.children.last)
-
-            add_offense(node, source_range(source.loc.expression), message)
+            add_offense(
+              node, source_range(node.first_argument.loc.expression), message
+            )
           end
         end
 
         def autocorrect(node)
           lambda do |corrector|
             corrector.replace(
-              source_node(node).loc.expression, "'https://rubygems.org'"
+              node.first_argument.loc.expression, "'https://rubygems.org'"
             )
           end
         end
 
         private
-
-        def source_node(node)
-          node.children.last
-        end
 
         def source_range(node)
           range_between(node.begin_pos, node.end_pos)

--- a/manual/cops.md
+++ b/manual/cops.md
@@ -89,6 +89,7 @@ In the following section you find all available cops:
 #### Department [Bundler](cops_bundler.md)
 
 * [Bundler/DuplicatedGem](cops_bundler.md#bundlerduplicatedgem)
+* [Bundler/InsecureProtocolSource](cops_bundler.md#bundlerinsecureprotocolsource)
 * [Bundler/OrderedGems](cops_bundler.md#bundlerorderedgems)
 
 #### Department [Layout](cops_layout.md)

--- a/manual/cops_bundler.md
+++ b/manual/cops_bundler.md
@@ -45,9 +45,18 @@ Enabled by default | Supports autocorrection
 --- | ---
 Enabled | Yes
 
-The source `:gemcutter`, `:rubygems` and `:rubyforge` are deprecated
-because HTTP requests are insecure. Please change your source to
+The symbol argument `:gemcutter`, `:rubygems` and `:rubyforge`
+are deprecated. So please change your source to URL string that
 'https://rubygems.org' if possible, or 'http://rubygems.org' if not.
+
+This autocorrect will replace these symbols with 'https://rubygems.org'.
+Because it is secure, HTTPS request is strongly recommended. And in
+most use cases HTTPS will be fine.
+
+However, it don't replace all `sources` of `http://` with `https://`.
+For example, when specifying an internal gem server using HTTP on the
+intranet, a use case where HTTPS can not be specified was considered.
+Consider using HTTP only if you can not use HTTPS.
 
 ### Example
 

--- a/manual/cops_bundler.md
+++ b/manual/cops_bundler.md
@@ -39,6 +39,35 @@ Attribute | Value
 --- | ---
 Include | \*\*/Gemfile, \*\*/gems.rb
 
+## Bundler/InsecureProtocolSource
+
+Enabled by default | Supports autocorrection
+--- | ---
+Enabled | Yes
+
+The source `:gemcutter`, `:rubygems` and `:rubyforge` are deprecated
+because HTTP requests are insecure. Please change your source to
+'https://rubygems.org' if possible, or 'http://rubygems.org' if not.
+
+### Example
+
+```ruby
+# bad
+source :gemcutter
+source :rubygems
+source :rubyforge
+
+# good
+source 'https://rubygems.org' # strongly recommended
+source 'http://rubygems.org'
+```
+
+### Important attributes
+
+Attribute | Value
+--- | ---
+Include | \*\*/Gemfile, \*\*/gems.rb
+
 ## Bundler/OrderedGems
 
 Enabled by default | Supports autocorrection

--- a/spec/rubocop/cop/bundler/insecure_protocol_source_spec.rb
+++ b/spec/rubocop/cop/bundler/insecure_protocol_source_spec.rb
@@ -1,0 +1,45 @@
+# frozen_string_literal: true
+
+describe RuboCop::Cop::Bundler::InsecureProtocolSource do
+  let(:config) { RuboCop::Config.new }
+  subject(:cop) { described_class.new(config) }
+
+  it 'registers an offense when using `source :gemcutter`' do
+    expect_offense(<<-RUBY.strip_indent)
+      source :gemcutter
+             ^^^^^^^^^^ The source `:gemcutter` is deprecated because HTTP requests are insecure. Please change your source to 'https://rubygems.org' if possible, or 'http://rubygems.org' if not.
+    RUBY
+  end
+
+  it 'registers an offense when using `source :rubygems`' do
+    expect_offense(<<-RUBY.strip_indent)
+      source :rubygems
+             ^^^^^^^^^ The source `:rubygems` is deprecated because HTTP requests are insecure. Please change your source to 'https://rubygems.org' if possible, or 'http://rubygems.org' if not.
+    RUBY
+  end
+
+  it 'registers an offense when using `source :rubyforge`' do
+    expect_offense(<<-RUBY.strip_indent)
+      source :rubyforge
+             ^^^^^^^^^^ The source `:rubyforge` is deprecated because HTTP requests are insecure. Please change your source to 'https://rubygems.org' if possible, or 'http://rubygems.org' if not.
+    RUBY
+  end
+
+  it 'autocorrects `source :gemcutter`' do
+    new_source = autocorrect_source('source :gemcutter')
+
+    expect(new_source).to eq "source 'https://rubygems.org'"
+  end
+
+  it 'autocorrects `source :rubygems`' do
+    new_source = autocorrect_source('source :rubygems')
+
+    expect(new_source).to eq "source 'https://rubygems.org'"
+  end
+
+  it 'autocorrects `source :rubyforge`' do
+    new_source = autocorrect_source('source :rubyforge')
+
+    expect(new_source).to eq "source 'https://rubygems.org'"
+  end
+end


### PR DESCRIPTION
## Feature

This cop emulates a Bundler's deprecation warning.

```console
% cat /tmp/Gemfile
# frozen_string_literal: true

source :rubygems

gem 'rubocop'
```

```console
% be rubocop /tmp/Gemfile
Inspecting 1 file
C

Offenses:

/tmp/Gemfile:3:8: C: The source :rubygems is deprecated because HTTP requests are insecure. Please change your source to 'https://rubygems.org' if possible, or 'http://rubygems.org' if not.
source :rubygems
       ^^^^^^^^^

1 file inspected, 1 offense detected
```

## Target Problem

This cop emulates Bundler's deprecation warning as below.

https://github.com/bundler/bundler/blob/v1.16.0.pre.2/lib/bundler/dsl.rb#L442-L446

This warning recommends using as secure a `https` protocol as possible. The argument (`:gemcutter`, `:rubygems` and `:rubyforge`) to replace the insecure `http` is deprecated.

## Other Information

As shown in Bundler's warning, users who can not use `https` may want to replace them with` http`. However, in many cases I think that it will be replaced with `https`.

And, the default in Gemfile generated by famous generators like `rails new` and `bundle init` is already using `source 'https://rubygems.org'`.

Gemfile template of `rails new`.
https://github.com/rails/rails/blob/v5.1.4/railties/lib/rails/generators/rails/app/templates/Gemfile#L1

Gemfile template of `bundle init`.
https://github.com/bundler/bundler/blob/v1.16.0.pre.2/lib/bundler/templates/Gemfile#L3

Therefore, using autocorrect will replace with `source 'https://rubygems.org'`.

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Used the same coding conventions as the rest of the project.
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] All tests(`rake spec`) are passing.
* [x] The new code doesn't generate RuboCop offenses that are checked by `rake internal_investigation`.
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Updated cop documentation with `rake generate_cops_documentation` (required only when you've added a new cop or changed the configuration/documentation of an existing cop).

[1]: http://chris.beams.io/posts/git-commit/
