### PR TITLE
Make Style/AutoResourceCleanup examples equivalent

### DIFF
--- a/lib/rubocop/cop/style/auto_resource_cleanup.rb
+++ b/lib/rubocop/cop/style/auto_resource_cleanup.rb
@@ -13,7 +13,7 @@ module RuboCop
       #   f = File.open('file')
       #
       #   # good
-      #   f = File.open('file') do
+      #   File.open('file') do |f|
       #     ...
       #   end
       class AutoResourceCleanup < Cop

--- a/manual/cops_style.md
+++ b/manual/cops_style.md
@@ -147,7 +147,7 @@ resource cleanup.
 f = File.open('file')
 
 # good
-f = File.open('file') do
+File.open('file') do |f|
   ...
 end
 ```


### PR DESCRIPTION
In the bad example, `f` is the `File` object, so in the good example it should be the same.
(Prior to this commit, `f` in the good example is the return value of the block passed to `File.open`.)

Same as #4380, but after running `rake generate_cops_documentation`. (Commit still credited to @duckinator.)

-----------------

Before submitting the PR make sure the following are checked:

* [X] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [X] Used the same coding conventions as the rest of the project.
* [X] Feature branch is up-to-date with `master` (if not - rebase it).
* [X] Squashed related commits together.
* [ ] Added tests.
* [ ] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [X] All tests(`rake spec`) are passing.
* [X] The new code doesn't generate RuboCop offenses that are checked by `rake internal_investigation`.
* [X] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [X] Updated cop documentation with `rake generate_cops_documentation` (required only when you've added a new cop or changed the configuration/documentation of an existing cop).

[1]: http://chris.beams.io/posts/git-commit/
