### PR TITLE
Fix `rake new_cop` problem that doesn't add `require` line

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -66,6 +66,7 @@
 * [#4643](https://github.com/bbatsov/rubocop/issues/4643): Modify `Style/InverseMethods` to not register a separate offense for an inverse method nested inside of the block of an inverse method offense. ([@rrosenblum][])
 * [#4593](https://github.com/bbatsov/rubocop/issues/4593): Fix false positive in `Rails/SaveBang` when `save/update_attribute` is used with a `case` statement. ([@theRealNG][])
 * [#4322](https://github.com/bbatsov/rubocop/issues/4322): Fix Style/MultilineMemoization from autocorrecting to invalid ruby. ([@dpostorivo][])
+* [#4722](https://github.com/bbatsov/rubocop/pull/4722): Fix `rake new_cop` problem that doesn't add `require` line. ([@koic][])
 
 ### Changes
 

--- a/lib/rubocop/cop/generator.rb
+++ b/lib/rubocop/cop/generator.rb
@@ -204,14 +204,19 @@ module RuboCop
 
         def target_line
           @target_line ||= begin
+            in_the_same_department = false
             inject_parts = require_path_fragments(injectable_require_directive)
 
             require_entries.find.with_index do |entry, index|
               current_entry_parts = require_path_fragments(entry)
 
-              next unless inject_parts[0..-2] == current_entry_parts[0..-2]
+              if inject_parts[0..-2] == current_entry_parts[0..-2]
+                in_the_same_department = true
 
-              break index if inject_parts.last < current_entry_parts.last
+                break index if inject_parts.last < current_entry_parts.last
+              elsif in_the_same_department
+                break index
+              end
             end
           end
         end

--- a/spec/rubocop/cop/generator_spec.rb
+++ b/spec/rubocop/cop/generator_spec.rb
@@ -194,7 +194,7 @@ RSpec.describe RuboCop::Cop::Generator do
       end
     end
 
-    context 'when a cops of style department already exists' do
+    context 'when a cop of style department already exists' do
       let(:cop_identifier) { 'Style/TheEndOfStyle' }
 
       before do

--- a/spec/rubocop/cop/generator_spec.rb
+++ b/spec/rubocop/cop/generator_spec.rb
@@ -194,6 +194,65 @@ RSpec.describe RuboCop::Cop::Generator do
       end
     end
 
+    context 'when a cops of style department already exists' do
+      let(:cop_identifier) { 'Style/TheEndOfStyle' }
+
+      before do
+        allow(File)
+          .to receive(:readlines).with('lib/rubocop.rb')
+                                 .and_return(<<-RUBY.strip_indent.lines)
+          # frozen_string_literal: true
+
+          require 'parser'
+          require 'rainbow'
+
+          require 'English'
+          require 'set'
+          require 'forwardable'
+
+          require 'rubocop/version'
+
+          require 'rubocop/cop/style/end_block'
+          require 'rubocop/cop/style/even_odd'
+          require 'rubocop/cop/style/file_name'
+          require 'rubocop/cop/style/flip_flop'
+
+          require 'rubocop/cop/rails/action_filter'
+
+          require 'rubocop/cop/team'
+        RUBY
+      end
+
+      it 'injects a `require` statement on the end of style department' do
+        generated_source = <<-RUBY.strip_indent
+          # frozen_string_literal: true
+
+          require 'parser'
+          require 'rainbow'
+
+          require 'English'
+          require 'set'
+          require 'forwardable'
+
+          require 'rubocop/version'
+
+          require 'rubocop/cop/style/end_block'
+          require 'rubocop/cop/style/even_odd'
+          require 'rubocop/cop/style/file_name'
+          require 'rubocop/cop/style/flip_flop'
+          require 'rubocop/cop/style/the_end_of_style'
+
+          require 'rubocop/cop/rails/action_filter'
+
+          require 'rubocop/cop/team'
+        RUBY
+
+        generator.inject_require
+        expect(File)
+          .to have_received(:write).with('lib/rubocop.rb', generated_source)
+      end
+    end
+
     context 'when a `require` entry already exists' do
       before do
         allow(File)


### PR DESCRIPTION
This PR fixes the following problem of `rake new_cop`.

For example use `rake new_cop` to add a new `Style/TheEndOfStyle` cop.

### Expected Behaviour

The following two files are generated.

```console
Files created:
  - lib/rubocop/cop/style/the_end_of_style.rb
  - spec/rubocop/cop/style/the_end_of_style_spec.rb
```

And a new `require` line is added to lib/rubocop.rb.

```ruby
(snip)

require 'rubocop/cop/style/file_name'
require 'rubocop/cop/style/flip_flop'
require 'rubocop/cop/style/the_end_of_style' # New line

require 'rubocop/cop/rails/action_filter'
```

### Actual Behaviour

A new `requrie` line is not added to lib/rubocop.rb.

```ruby
(snip)

require 'rubocop/cop/style/file_name'
require 'rubocop/cop/style/flip_flop'

require 'rubocop/cop/rails/action_filter'
```

This is because there was a problem when adding to the end of existing department.

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Used the same coding conventions as the rest of the project.
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] All tests(`rake spec`) are passing.
* [x] The new code doesn't generate RuboCop offenses that are checked by `rake internal_investigation`.
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [ ] Updated cop documentation with `rake generate_cops_documentation` (required only when you've added a new cop or changed the configuration/documentation of an existing cop).

[1]: http://chris.beams.io/posts/git-commit/
