### PR TITLE
Add gemspec metadata

### DIFF
--- a/rubocop.gemspec
+++ b/rubocop.gemspec
@@ -4,6 +4,7 @@ $LOAD_PATH.unshift File.expand_path('../lib', __FILE__)
 require 'rubocop/version'
 require 'English'
 
+# rubocop:disable Metrics/BlockLength
 Gem::Specification.new do |s|
   s.name = 'rubocop'
   s.version = RuboCop::Version::STRING
@@ -21,9 +22,19 @@ Gem::Specification.new do |s|
             .split($RS)
   s.executables = s.files.grep(%r{^bin/}) { |f| File.basename(f) }
   s.extra_rdoc_files = ['LICENSE.txt', 'README.md']
-  s.homepage = 'http://github.com/bbatsov/rubocop'
+  s.homepage = 'https://github.com/bbatsov/rubocop'
   s.licenses = ['MIT']
   s.summary = 'Automatic Ruby code style checking tool.'
+
+  if s.respond_to?(:metadata=)
+    s.metadata = {
+      'homepage_uri' => 'https://rubocop.readthedocs.io/',
+      'changelog_uri' => 'https://github.com/bbatsov/rubocop/blob/master/CHANGELOG.md',
+      'source_code_uri' => 'https://github.com/bbatsov/rubocop/',
+      'documentation_uri' => 'https://rubocop.readthedocs.io/',
+      'bug_tracker_uri' => 'https://github.com/bbatsov/rubocop/issues'
+    }
+  end
 
   s.add_runtime_dependency('rainbow', '>= 2.2.2', '< 3.0')
   s.add_runtime_dependency('parser', '>= 2.3.3.1', '< 3.0')
@@ -34,3 +45,4 @@ Gem::Specification.new do |s|
 
   s.add_development_dependency('bundler', '~> 1.3')
 end
+# rubocop:enable Metrics/BlockLength


### PR DESCRIPTION
Makes it easy to programatically find the source code and changelog for rubocop, using the rubygems API. Also adds a changelog link etc. to https://rubygems.org/gems/rubocop

See https://github.com/rubygems/rubygems.org/pull/1234 and https://github.com/rubygems/rubygems.org/blob/master/app/models/links.rb for more details.

I did not add `wiki_uri`, `mailing_list_uri` and `download_uri` because
1. the only wiki I could find (https://github.com/bbatsov/rubocop/wiki) looks abandoned;
2. there is no mailing list that I know of, and
3. rubygems.org will add a download link, e.g. https://rubygems.org/downloads/rubocop-0.49.1.gem if we don't add one.

By the way, the default `Max` value for `Metrics/BlockLength` (25) seems rather arbitrary.

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Used the same coding conventions as the rest of the project.
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [ ] Added tests.
* [ ] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] All tests(`rake spec`) are passing.
* [x] The new code doesn't generate RuboCop offenses that are checked by `rake internal_investigation`.
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [ ] Updated cop documentation with `rake generate_cops_documentation` (required only when you've added a new cop or changed the configuration/documentation of an existing cop).

[1]: http://chris.beams.io/posts/git-commit/
