### PR TITLE
[FIX #4723] RaiseArgs shouldn't autocorrect 3-args form

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -68,6 +68,7 @@
 * [#4593](https://github.com/bbatsov/rubocop/issues/4593): Fix false positive in `Rails/SaveBang` when `save/update_attribute` is used with a `case` statement. ([@theRealNG][])
 * [#4322](https://github.com/bbatsov/rubocop/issues/4322): Fix Style/MultilineMemoization from autocorrecting to invalid ruby. ([@dpostorivo][])
 * [#4722](https://github.com/bbatsov/rubocop/pull/4722): Fix `rake new_cop` problem that doesn't add `require` line. ([@koic][])
+* [#4723](https://github.com/bbatsov/rubocop/issues/4723): Fix `RaiseArgs` auto-correction issue for `raise` with 3 arguments. ([@smakagon][])
 
 ### Changes
 

--- a/spec/rubocop/cop/style/raise_args_spec.rb
+++ b/spec/rubocop/cop/style/raise_args_spec.rb
@@ -61,9 +61,11 @@ describe RuboCop::Cop::Style::RaiseArgs, :config do
         RUBY
       end
 
-      it 'auto-corrects to compact style' do
-        new_source = autocorrect_source(['raise RuntimeError, msg, caller'])
-        expect(new_source).to eq('raise RuntimeError.new(msg, caller)')
+      it 'does not auto-correct to compact style' do
+        initial_source = 'raise RuntimeError, msg, caller'
+
+        new_source = autocorrect_source([initial_source])
+        expect(new_source).to eq(initial_source)
       end
     end
 


### PR DESCRIPTION
Fixes the auto-correction issue for `raise` with 3 arguments:

Without this fix, the following code: 
```ruby
begin
  1 / 0
rescue => e
  raise StandardError, 'hi', e.backtrace
end
```
would be auto-corrected to the broken one:

```ruby
begin
  1 / 0
rescue => e
  raise StandardError.new('hi', e.backtrace) # wrong number of arguments (given 2, expected 0..1) (ArgumentError)
end
```

With this fix, any `raise` with more than 2 arguments will not be autocorrected.

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Used the same coding conventions as the rest of the project.
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] All tests(`rake spec`) are passing.
* [x] The new code doesn't generate RuboCop offenses that are checked by `rake internal_investigation`.
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [ ] Updated cop documentation with `rake generate_cops_documentation` (required only when you've added a new cop or changed the configuration/documentation of an existing cop).

[1]: http://chris.beams.io/posts/git-commit/
