### PR TITLE
Change a todo message at `rake new_cop` task

### DIFF
--- a/lib/rubocop/cop/generator.rb
+++ b/lib/rubocop/cop/generator.rb
@@ -104,7 +104,7 @@ module RuboCop
 
           Do 3 steps:
             1. Add an entry to the "New features" section in CHANGELOG.md,
-               e.g. "Add new `#{badge.cop_name}` cop. ([@your_id][])"
+               e.g. "Add new `#{badge}` cop. ([@your_id][])"
             2. Add an entry into config/enabled.yml or config/disabled.yml
             3. Implement your new cop in the generated file!
         TODO

--- a/spec/rubocop/cop/generator_spec.rb
+++ b/spec/rubocop/cop/generator_spec.rb
@@ -120,7 +120,7 @@ RSpec.describe RuboCop::Cop::Generator do
 
         Do 3 steps:
           1. Add an entry to the "New features" section in CHANGELOG.md,
-             e.g. "Add new `FakeCop` cop. ([@your_id][])"
+             e.g. "Add new `Style/FakeCop` cop. ([@your_id][])"
           2. Add an entry into config/enabled.yml or config/disabled.yml
           3. Implement your new cop in the generated file!
       TODO


### PR DESCRIPTION
## Summary

This PR changes a todo message at `rake new_cop` task.

```diff
 % bundle exec rake new_cop\[Style/Fake\]
 Files created:
   - lib/rubocop/cop/style/fake.rb
   - spec/rubocop/cop/fake/fake_spec.rb

 Do 3 steps:
   1. Add an entry to the "New features" section in CHANGELOG.md,
-     e.g. "Add new `Fake` cop. ([@your_id][])"
+     e.g. "Add new `Style/Fake` cop. ([@your_id][])"
   2. Add an entry into config/enabled.yml or config/disabled.yml
   3. Implement your new cop in the generated file!
```

When adding a new cop, it seems to be written in [CHANGELOG.md](https://github.com/bbatsov/rubocop/blob/master/CHANGELOG.md) in the style of `DepartmentName/CopName`. So, I thought it would be more pragmatic to display a todo message in this style.

## Other Information

Also the following manual is written as such.

https://github.com/bbatsov/rubocop/blob/master/manual/development.md

Since this manual is a bit old, I'd like to update it with a separate PR.

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Used the same coding conventions as the rest of the project.
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [ ] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] All tests(`rake spec`) are passing.
* [x] The new code doesn't generate RuboCop offenses that are checked by `rake internal_investigation`.
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [ ] Updated cop documentation with `rake generate_cops_documentation` (required only when you've added a new cop or changed the configuration/documentation of an existing cop).

[1]: http://chris.beams.io/posts/git-commit/
