### PR TITLE
Fixes name of renamed OpMethod cop in config check

### DIFF
--- a/lib/rubocop/config.rb
+++ b/lib/rubocop/config.rb
@@ -60,8 +60,8 @@ module RuboCop
         'The `Style/AsciiIdentifiers` cop has been moved to ' \
           '`Naming/AccessorMethodName`.',
       'Style/OpMethod' =>
-        'The `Style/OpMethods` cop has been renamed and moved to ' \
-          '`Naming/BinaryOperatorParameter`.',
+        'The `Style/OpMethod` cop has been renamed and moved to ' \
+          '`Naming/BinaryOperatorParameterName`.',
       'Style/ClassAndModuleCamelCase' =>
         'The `Style/ClassAndModuleCamelCase` cop has been renamed to ' \
           '`Naming/ClassAndModuleCamelCase`.',


### PR DESCRIPTION
The error message printed out to the user is

    The `Style/OpMethods` cop has been renamed and moved to `Naming/BinaryOperatorParameter`.

although the old name was actually

    Style/OpMethod

and the new cop name is

    Naming/BinaryOperatorParameterName