### PR TITLE
Indicate file modified by `rake new_cop`

### DIFF
--- a/lib/rubocop/cop/generator.rb
+++ b/lib/rubocop/cop/generator.rb
@@ -101,6 +101,8 @@ module RuboCop
           Files created:
             - #{source_path}
             - #{spec_path}
+          File modified:
+            - `require '#{require_path}'` added into lib/rubocop.rb
 
           Do 3 steps:
             1. Add an entry to the "New features" section in CHANGELOG.md,

--- a/manual/development.md
+++ b/manual/development.md
@@ -7,10 +7,12 @@ $ bundle exec rake new_cop[Department/Name]
 Files created:
   - lib/rubocop/cop/department/name.rb
   - spec/rubocop/cop/department/name_spec.rb
+File modified:
+  - `require 'rubocop/cop/department/name_cop'` added into lib/rubocop.rb
 
 Do 3 steps:
   1. Add an entry to the "New features" section in CHANGELOG.md,
-     e.g. "Add new `Style/FooName` cop. ([@your_id][])"
+     e.g. "Add new `Department/Name` cop. ([@your_id][])"
   2. Add an entry into config/enabled.yml or config/disabled.yml
   3. Implement your new cop in the generated file!
 ```

--- a/spec/rubocop/cop/generator_spec.rb
+++ b/spec/rubocop/cop/generator_spec.rb
@@ -117,6 +117,8 @@ RSpec.describe RuboCop::Cop::Generator do
         Files created:
           - lib/rubocop/cop/style/fake_cop.rb
           - spec/rubocop/cop/style/fake_cop_spec.rb
+        File modified:
+          - `require 'rubocop/cop/style/fake_cop'` added into lib/rubocop.rb
 
         Do 3 steps:
           1. Add an entry to the "New features" section in CHANGELOG.md,


### PR DESCRIPTION
Follow up for https://github.com/bbatsov/rubocop/pull/4738#discussion_r139091347.
This PR indicates the file modified by `rake new_cop`.

```diff
% bundle exec rake new_cop\[Style/FooName\]
 Files created:
   - lib/rubocop/cop/style/foo_name.rb
   - spec/rubocop/cop/style/foo_name_spec.rb
+File modified:
+  - `require 'rubocop/cop/style/foo_name'` added into lib/rubocop.rb

 Do 3 steps:
   1. Add an entry to the "New features" section in CHANGELOG.md,
      e.g. "Add new `Style/FooName` cop. ([@your_id][])"
   2. Add an entry into config/enabled.yml or config/disabled.yml
   3. Implement your new cop in the generated file!
```

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Used the same coding conventions as the rest of the project.
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [ ] Added tests.
* [ ] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] All tests(`rake spec`) are passing.
* [x] The new code doesn't generate RuboCop offenses that are checked by `rake internal_investigation`.
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [ ] Updated cop documentation with `rake generate_cops_documentation` (required only when you've added a new cop or changed the configuration/documentation of an existing cop).

[1]: http://chris.beams.io/posts/git-commit/
