### PR TITLE
[Fix #4740] Make `Lint/RescueWithoutErrorClass` aware of modifier form `rescue`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## master (unreleased)
 
+### Bug fixes
+
+* [#4740](https://github.com/bbatsov/rubocop/issues/4740): Make `Lint/RescueWithoutErrorClass` aware of modifier form `rescue`. ([@drenmi][])
+
 ## 0.50.0 (2017-09-14)
 
 ### New features

--- a/lib/rubocop/cop/lint/rescue_without_error_class.rb
+++ b/lib/rubocop/cop/lint/rescue_without_error_class.rb
@@ -20,11 +20,19 @@ module RuboCop
       #   rescue
       #     bar
       #   end
+      #
+      # @example
+      #
+      #   # good
+      #   foo rescue BarError; "baz"
+      #
+      #   # bad
+      #   foo rescue "baz"
       class RescueWithoutErrorClass < Cop
         MSG = 'Avoid rescuing without specifying an error class.'.freeze
 
         def_node_matcher :rescue_without_error_class?, <<-PATTERN
-          (resbody nil ...)
+          (resbody nil _ !(const ...))
         PATTERN
 
         def on_resbody(node)

--- a/manual/cops_lint.md
+++ b/manual/cops_lint.md
@@ -1592,6 +1592,13 @@ rescue
   bar
 end
 ```
+```ruby
+# good
+foo rescue BarError; "baz"
+
+# bad
+foo rescue "baz"
+```
 
 ### References
 

--- a/spec/rubocop/cop/lint/rescue_without_error_class_spec.rb
+++ b/spec/rubocop/cop/lint/rescue_without_error_class_spec.rb
@@ -15,11 +15,33 @@ describe RuboCop::Cop::Lint::RescueWithoutErrorClass, :config do
       RUBY
     end
 
+    it 'registers an offense without an error class, assigning to variable' do
+      expect_offense(<<-RUBY.strip_indent)
+        begin
+          foo
+        rescue => e
+        ^^^^^^ Avoid rescuing without specifying an error class.
+          bar
+        end
+      RUBY
+    end
+
     it 'does not register an offense with an error class' do
       expect_no_offenses(<<-RUBY.strip_indent)
         begin
           foo
         rescue BarError
+          bar
+        end
+      RUBY
+    end
+
+    it 'does not register an offense with an error class, ' \
+       'assigning to variable' do
+      expect_no_offenses(<<-RUBY.strip_indent)
+        begin
+          foo
+        rescue BarError => e
           bar
         end
       RUBY
@@ -38,6 +60,17 @@ describe RuboCop::Cop::Lint::RescueWithoutErrorClass, :config do
       RUBY
     end
 
+    it 'registers an offense without an error class, assigning to variable' do
+      expect_offense(<<-RUBY.strip_indent)
+        def baz
+          foo
+        rescue => e
+        ^^^^^^ Avoid rescuing without specifying an error class.
+          bar
+        end
+      RUBY
+    end
+
     it 'does not register an offense with an error class' do
       expect_no_offenses(<<-RUBY.strip_indent)
         def baz
@@ -45,6 +78,32 @@ describe RuboCop::Cop::Lint::RescueWithoutErrorClass, :config do
         rescue BarError
           bar
         end
+      RUBY
+    end
+
+    it 'does not register an offense with an error class, ' \
+       'assigning to variable' do
+      expect_no_offenses(<<-RUBY.strip_indent)
+        def baz
+          foo
+        rescue BarError => e
+          bar
+        end
+      RUBY
+    end
+  end
+
+  context 'when rescuing as a modifier' do
+    it 'registers an offense with something besides an an error class' do
+      expect_offense(<<-RUBY.strip_indent)
+        foo rescue 42
+            ^^^^^^ Avoid rescuing without specifying an error class.
+      RUBY
+    end
+
+    it 'does not register an offense with an error class' do
+      expect_no_offenses(<<-RUBY.strip_indent)
+        foo rescue BarError
       RUBY
     end
   end


### PR DESCRIPTION
The cop would miss cases of `rescue` without error class when used in modifier form.

This change fixes that.

I also added some test cases for when rescuing and assigning to a variable. (The behaviour was incidentally correct already.)

-----------------

Before submitting the PR make sure the following are checked:

* [X] Wrote [good commit messages][1].
* [X] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [X] Used the same coding conventions as the rest of the project.
* [X] Feature branch is up-to-date with `master` (if not - rebase it).
* [X] Squashed related commits together.
* [X] Added tests.
* [X] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [X] All tests(`rake spec`) are passing.
* [X] The new code doesn't generate RuboCop offenses that are checked by `rake internal_investigation`.
* [X] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [X] Updated cop documentation with `rake generate_cops_documentation` (required only when you've added a new cop or changed the configuration/documentation of an existing cop).

[1]: http://chris.beams.io/posts/git-commit/
