### PR TITLE
[Fix #4745] Make `Style/SafeNavigation` ignore negated continuations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 * [#4741](https://github.com/bbatsov/rubocop/issues/4741): Make `Style/SafeNavigation` correctly exclude methods called without dot. ([@drenmi][])
 * [#4740](https://github.com/bbatsov/rubocop/issues/4740): Make `Lint/RescueWithoutErrorClass` aware of modifier form `rescue`. ([@drenmi][])
+* [#4745](https://github.com/bbatsov/rubocop/issues/4745): Make `Style/SafeNavigation` ignore negated continuations. ([@drenmi][])
 
 ## 0.50.0 (2017-09-14)
 

--- a/lib/rubocop/cop/style/safe_navigation.rb
+++ b/lib/rubocop/cop/style/safe_navigation.rb
@@ -156,19 +156,22 @@ module RuboCop
         end
 
         def unsafe_method?(send_node)
-          NIL_METHODS.include?(send_node.method_name) || !send_node.dot?
+          NIL_METHODS.include?(send_node.method_name) ||
+            negated?(send_node) || !send_node.dot?
+        end
+
+        def negated?(send_node)
+          send_node.parent.send_type? && send_node.parent.method?(:!)
         end
 
         def begin_range(node, method_call)
-          Parser::Source::Range.new(node.loc.expression.source_buffer,
-                                    node.loc.expression.begin_pos,
-                                    method_call.loc.expression.begin_pos)
+          range_between(node.loc.expression.begin_pos,
+                        method_call.loc.expression.begin_pos)
         end
 
         def end_range(node, method_call)
-          Parser::Source::Range.new(node.loc.expression,
-                                    method_call.loc.expression.end_pos,
-                                    node.loc.expression.end_pos)
+          range_between(method_call.loc.expression.end_pos,
+                        node.loc.expression.end_pos)
         end
       end
     end

--- a/spec/rubocop/cop/style/safe_navigation_spec.rb
+++ b/spec/rubocop/cop/style/safe_navigation_spec.rb
@@ -35,6 +35,10 @@ describe RuboCop::Cop::Style::SafeNavigation, :config do
       expect_no_offenses('foo && foo[:bar]')
     end
 
+    it 'allows an object check before a negated predicate' do
+      expect_no_offenses('foo && !foo.bar?')
+    end
+
     it 'allows method calls that do not get called using . safe guarded by ' \
       'an object check' do
       expect_no_offenses('foo + bar if foo')


### PR DESCRIPTION
This cop would suggest using the safe navigation operator when the continuation was negated. However, this results in different semantics.

Example:

```
foo && !foo.bar?
```

will be falsey if `foo` is `nil`. However, the suggested change:

```
!foo&.bar?
```

will be truthy (`!nil`).

This change fixes that by having the cop ignore negated continuations.

-----------------

Before submitting the PR make sure the following are checked:

* [X] Wrote [good commit messages][1].
* [X] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [X] Used the same coding conventions as the rest of the project.
* [X] Feature branch is up-to-date with `master` (if not - rebase it).
* [X] Squashed related commits together.
* [X] Added tests.
* [X] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [X] All tests(`rake spec`) are passing.
* [X] The new code doesn't generate RuboCop offenses that are checked by `rake internal_investigation`.
* [X] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [ ] Updated cop documentation with `rake generate_cops_documentation` (required only when you've added a new cop or changed the configuration/documentation of an existing cop).

[1]: http://chris.beams.io/posts/git-commit/
