### PR TITLE
[Fix #4732] Prevent `Performance/HashEachMethods` from registering an offense when `#each` follows `#to_a`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 * [#4741](https://github.com/bbatsov/rubocop/issues/4741): Make `Style/SafeNavigation` correctly exclude methods called without dot. ([@drenmi][])
 * [#4740](https://github.com/bbatsov/rubocop/issues/4740): Make `Lint/RescueWithoutErrorClass` aware of modifier form `rescue`. ([@drenmi][])
 * [#4745](https://github.com/bbatsov/rubocop/issues/4745): Make `Style/SafeNavigation` ignore negated continuations. ([@drenmi][])
+* [#4732](https://github.com/bbatsov/rubocop/issues/4732): Prevent `Performance/HashEachMethods` from registering an offense when `#each` follows `#to_a`. ([@drenmi][])
 
 ## 0.50.0 (2017-09-14)
 

--- a/lib/rubocop/cop/performance/hash_each_methods.rb
+++ b/lib/rubocop/cop/performance/hash_each_methods.rb
@@ -3,7 +3,11 @@
 module RuboCop
   module Cop
     module Performance
-      # This cop checks for uses of `each_key` & `each_value` Hash methods.
+      # This cop checks for uses of `each_key` and `each_value` Hash methods.
+      #
+      # Note: If you have an array of two-element arrays, you can put
+      #   parentheses around the block arguments to indicate that you're not
+      #   working with a hash, and supress RuboCop offenses.
       #
       # @example
       #   # bad
@@ -21,7 +25,7 @@ module RuboCop
         MSG = 'Use `%s` instead of `%s`.'.freeze
 
         def_node_matcher :plain_each, <<-PATTERN
-          (block $(send _ :each) (args (arg $_k) (arg $_v)) ...)
+          (block $(send !(send _ :to_a) :each) (args (arg $_k) (arg $_v)) ...)
         PATTERN
 
         def_node_matcher :kv_each, <<-PATTERN

--- a/manual/cops_performance.md
+++ b/manual/cops_performance.md
@@ -338,7 +338,11 @@ Enabled by default | Supports autocorrection
 --- | ---
 Enabled | Yes
 
-This cop checks for uses of `each_key` & `each_value` Hash methods.
+This cop checks for uses of `each_key` and `each_value` Hash methods.
+
+Note: If you have an array of two-element arrays, you can put
+  parentheses around the block arguments to indicate that you're not
+  working with a hash, and supress RuboCop offenses.
 
 ### Example
 

--- a/spec/rubocop/cop/performance/hash_each_methods_spec.rb
+++ b/spec/rubocop/cop/performance/hash_each_methods_spec.rb
@@ -18,6 +18,14 @@ describe RuboCop::Cop::Performance::HashEachMethods do
         expect_no_offenses("foo.each { |k, v| p \"\#{k}_\#{v}\" }")
       end
 
+      it 'does not register an offense when #each follows #to_a' do
+        expect_no_offenses('foo.to_a.each { |k, _v| bar(k) }')
+      end
+
+      it 'does not register an offense when using braces around arguments' do
+        expect_no_offenses('foo.each { |(k, _v)| bar(k) }')
+      end
+
       it 'does not register an offense for foo#each ' \
       ' if block takes only one arg' do
         expect_no_offenses('foo.each { |kv| p kv }')
@@ -60,6 +68,14 @@ describe RuboCop::Cop::Performance::HashEachMethods do
       it 'does not register an offense for {}#each ' \
       ' if block takes only one arg' do
         expect_no_offenses('{}.each { |kv| p kv }')
+      end
+
+      it 'does not register an offense when #each follows #to_a' do
+        expect_no_offenses('{}.to_a.each { |k, _v| bar(k) }')
+      end
+
+      it 'does not register an offense when using braces around arguments' do
+        expect_no_offenses('{}.each { |(k, _v)| bar(k) }')
       end
 
       it 'auto-corrects {}#each with unused value argument' \


### PR DESCRIPTION
This cop would register an offense when `#each` followed `#to_a`, despite only working on hashes.

This change fixes that, and also adds a note to the documentation about the possibility of adding parentheses around the arguments to indicate that one is working on a multidimensional array.

-----------------

Before submitting the PR make sure the following are checked:

* [X] Wrote [good commit messages][1].
* [X] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [X] Used the same coding conventions as the rest of the project.
* [X] Feature branch is up-to-date with `master` (if not - rebase it).
* [X] Squashed related commits together.
* [X] Added tests.
* [X] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [X] All tests(`rake spec`) are passing.
* [X] The new code doesn't generate RuboCop offenses that are checked by `rake internal_investigation`.
* [X] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [X] Updated cop documentation with `rake generate_cops_documentation` (required only when you've added a new cop or changed the configuration/documentation of an existing cop).

[1]: http://chris.beams.io/posts/git-commit/
