### PR TITLE
[Fix #4730] False positive on Lint/InterpolationCheck

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 * [#4740](https://github.com/bbatsov/rubocop/issues/4740): Make `Lint/RescueWithoutErrorClass` aware of modifier form `rescue`. ([@drenmi][])
 * [#4745](https://github.com/bbatsov/rubocop/issues/4745): Make `Style/SafeNavigation` ignore negated continuations. ([@drenmi][])
 * [#4732](https://github.com/bbatsov/rubocop/issues/4732): Prevent `Performance/HashEachMethods` from registering an offense when `#each` follows `#to_a`. ([@drenmi][])
+* [#4730](https://github.com/bbatsov/rubocop/issues/4730): False positive on Lint/InterpolationCheck. ([@koic][])
 
 ## 0.50.0 (2017-09-14)
 

--- a/lib/rubocop/cop/lint/interpolation_check.rb
+++ b/lib/rubocop/cop/lint/interpolation_check.rb
@@ -22,6 +22,7 @@ module RuboCop
 
         def on_str(node)
           return if heredoc?(node)
+          return if node.parent && node.parent.dstr_type?
           return unless scrub_string(node.str_content) =~ /#\{.*\}/
           add_offense(node)
         end

--- a/lib/rubocop/cop/style/variable_interpolation.rb
+++ b/lib/rubocop/cop/style/variable_interpolation.rb
@@ -5,11 +5,9 @@ module RuboCop
     module Style
       # This cop checks for variable interpolation (like "#@ivar").
       class VariableInterpolation < Cop
-        # rubocop:disable Lint/InterpolationCheck
         MSG = 'Replace interpolated variable `%s` ' \
               'with expression `#{%s}`.'.freeze
 
-        # rubocop:enable Lint/InterpolationCheck
         def on_dstr(node)
           check_for_interpolation(node)
         end

--- a/spec/rubocop/cop/lint/interpolation_check_spec.rb
+++ b/spec/rubocop/cop/lint/interpolation_check_spec.rb
@@ -27,4 +27,10 @@ describe RuboCop::Cop::Lint::InterpolationCheck do
       foo = "\xff"
     RUBY
   end
+
+  it 'does not register an offense for escaped crab claws in dstr' do
+    expect_no_offenses(<<-'RUBY'.strip_indent)
+      foo = "alpha #{variable} beta \#{gamma}\" delta"
+    RUBY
+  end
 end


### PR DESCRIPTION
Fixes #4730.

## Summary

It was a problem that `" beta \#{gamma}\" delta"` containing `#{.*}` in the argument of `on_str` method. This PR will not interpolation check if the parent node is dstr.

```console
% cat example.rb
require 'parser/current'

p Parser::CurrentRuby.parse('"alpha #{variable} beta \#{gamma}\" delta"')
% ruby example.rb
warning: parser/current is loading parser/ruby24, which recognizes
warning: 2.4.0-compliant syntax, but you are running 2.4.2.
warning: please see https://github.com/whitequark/parser#compatibility-with-ruby-mri.
s(:dstr,
  s(:str, "alpha "),
  s(:begin,
    s(:send, nil, :variable)),
  s(:str, " beta \#{gamma}\" delta")) # It is judged whether this node's parent is dstr or not.
```

## Other Information

This PR also fixed the following offense caused by this change.

```console
% bundle exec rubocop lib/rubocop/cop/style/variable_interpolation.rb
Inspecting 1 file
W

Offenses:

lib/rubocop/cop/style/variable_interpolation.rb:8:9: W: Unnecessary disabling of Lint/InterpolationCheck.
        # rubocop:disable Lint/InterpolationCheck
        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
```

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Used the same coding conventions as the rest of the project.
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] All tests(`rake spec`) are passing.
* [x] The new code doesn't generate RuboCop offenses that are checked by `rake internal_investigation`.
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [ ] Updated cop documentation with `rake generate_cops_documentation` (required only when you've added a new cop or changed the configuration/documentation of an existing cop).

[1]: http://chris.beams.io/posts/git-commit/
