### PR TITLE
Amend fix of `Lint/RescueWithoutErrorClass` on modifier `rescue`

### DIFF
--- a/lib/rubocop/cop/lint/rescue_without_error_class.rb
+++ b/lib/rubocop/cop/lint/rescue_without_error_class.rb
@@ -20,23 +20,18 @@ module RuboCop
       #   rescue
       #     bar
       #   end
-      #
-      # @example
-      #
-      #   # good
-      #   foo rescue BarError; "baz"
-      #
-      #   # bad
-      #   foo rescue "baz"
       class RescueWithoutErrorClass < Cop
+        include RescueNode
+
         MSG = 'Avoid rescuing without specifying an error class.'.freeze
 
         def_node_matcher :rescue_without_error_class?, <<-PATTERN
-          (resbody nil _ !(const ...))
+          (resbody nil _ _)
         PATTERN
 
         def on_resbody(node)
-          return unless rescue_without_error_class?(node)
+          return unless rescue_without_error_class?(node) &&
+                        !rescue_modifier?(node)
 
           add_offense(node, :keyword)
         end

--- a/manual/cops_lint.md
+++ b/manual/cops_lint.md
@@ -1592,13 +1592,6 @@ rescue
   bar
 end
 ```
-```ruby
-# good
-foo rescue BarError; "baz"
-
-# bad
-foo rescue "baz"
-```
 
 ### References
 

--- a/spec/fixtures/html_formatter/expected.html
+++ b/spec/fixtures/html_formatter/expected.html
@@ -367,7 +367,7 @@ TvFXMeuCkZPcaEBLqvgPBhCuiZo8+sAAAAAASUVORK5CYII=
       <div class="infobox">
         <div class="total">
           3 files inspected,
-          20 offenses detected:
+          19 offenses detected:
         </div>
         <ul class="offenses-list">
           
@@ -388,7 +388,7 @@ TvFXMeuCkZPcaEBLqvgPBhCuiZo8+sAAAAAASUVORK5CYII=
             
             <li>
               <a href="#offense_app/models/book.rb">
-                app/models/book.rb - 7 offenses
+                app/models/book.rb - 6 offenses
               </a>
             </li>
           
@@ -563,7 +563,7 @@ TvFXMeuCkZPcaEBLqvgPBhCuiZo8+sAAAAAASUVORK5CYII=
       
       <div class="offense-box" id="offense_app/models/book.rb">
         <div class="box-title-placeholder"><h3>&nbsp;</h3></div>
-        <div class="box-title"><h3>app/models/book.rb - 7 offenses</h3></div>
+        <div class="box-title"><h3>app/models/book.rb - 6 offenses</h3></div>
         <div class="offense-reports">
           
           <div class="report">
@@ -629,17 +629,6 @@ TvFXMeuCkZPcaEBLqvgPBhCuiZo8+sAAAAAASUVORK5CYII=
             </div>
             
             <pre><code>    Regexp.new(<span class="highlight convention">/\A&lt;p&gt;(.*)&lt;\/p&gt;\Z/m</span>).match(full_document)[1] rescue full_document</code></pre>
-            
-          </div>
-          
-          <div class="report">
-            <div class="meta">
-              <span class="location">Line #4</span> –
-              <span class="severity warning">warning:</span>
-              <span class="message">Avoid rescuing without specifying an error class.</span>
-            </div>
-            
-            <pre><code>    Regexp.new(/\A&lt;p&gt;(.*)&lt;\/p&gt;\Z/m).match(full_document)[1] <span class="highlight warning">rescue</span> full_document</code></pre>
             
           </div>
           

--- a/spec/rubocop/cop/lint/rescue_without_error_class_spec.rb
+++ b/spec/rubocop/cop/lint/rescue_without_error_class_spec.rb
@@ -94,16 +94,9 @@ describe RuboCop::Cop::Lint::RescueWithoutErrorClass, :config do
   end
 
   context 'when rescuing as a modifier' do
-    it 'registers an offense with something besides an an error class' do
-      expect_offense(<<-RUBY.strip_indent)
-        foo rescue 42
-            ^^^^^^ Avoid rescuing without specifying an error class.
-      RUBY
-    end
-
-    it 'does not register an offense with an error class' do
+    it 'does not register an offense without an error class' do
       expect_no_offenses(<<-RUBY.strip_indent)
-        foo rescue BarError
+        foo rescue 42
       RUBY
     end
   end


### PR DESCRIPTION
It turns out one can't specify an error class at all when using the modifier form. This change amends 059aee81, and makes the cop ignore modifier form `rescue` nodes.

-----------------

Before submitting the PR make sure the following are checked:

* [X] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [X] Used the same coding conventions as the rest of the project.
* [X] Feature branch is up-to-date with `master` (if not - rebase it).
* [X] Squashed related commits together.
* [X] Added tests.
* [ ] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [X] All tests(`rake spec`) are passing.
* [X] The new code doesn't generate RuboCop offenses that are checked by `rake internal_investigation`.
* [X] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [X] Updated cop documentation with `rake generate_cops_documentation` (required only when you've added a new cop or changed the configuration/documentation of an existing cop).

[1]: http://chris.beams.io/posts/git-commit/
