### PR TITLE
[Fix #3312] False positive for Rails/Date on Strings ending in "Z"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## master (unreleased)
 
 ## Bug fixes
-
+* [#3312](https://github.com/bbatsov/rubocop/issues/3312): Make `Rails/Date` Correct false positive on `#to_time` for strings ending in UTC-"Z".([@erikdstock][])
 * [#4741](https://github.com/bbatsov/rubocop/issues/4741): Make `Style/SafeNavigation` correctly exclude methods called without dot. ([@drenmi][])
 * [#4740](https://github.com/bbatsov/rubocop/issues/4740): Make `Lint/RescueWithoutErrorClass` aware of modifier form `rescue`. ([@drenmi][])
 * [#4745](https://github.com/bbatsov/rubocop/issues/4745): Make `Style/SafeNavigation` ignore negated continuations. ([@drenmi][])
@@ -2932,3 +2932,4 @@
 [@fujimura]: https://github.com/fujimura
 [@kristjan]: https://github.com/kristjan
 [@frodsan]: https://github.com/frodsan
+[@erikdstock]: https://github.com/erikdstock

--- a/lib/rubocop/cop/rails/date.rb
+++ b/lib/rubocop/cop/rails/date.rb
@@ -98,7 +98,7 @@ module RuboCop
           return unless node.method?(:to_time)
 
           if node.receiver.str_type?
-            zone_regexp = /[+-][\d:]+\z/
+            zone_regexp = /([+-][\d:]+|\dZ)\z/
 
             node.receiver.str_content.match(zone_regexp)
           else

--- a/spec/rubocop/cop/rails/date_spec.rb
+++ b/spec/rubocop/cop/rails/date_spec.rb
@@ -61,6 +61,12 @@ describe RuboCop::Cop::Rails::Date, :config do
       end
     end
 
+    context 'when a string literal with "Z"-style UTC timezone' do
+      it 'does not register an offense' do
+        expect_no_offenses('"2017-09-22T22:46:06.497Z".to_time(:utc)')
+      end
+    end
+
     it 'does not blow up in the presence of a single constant to inspect' do
       expect_no_offenses('A')
     end


### PR DESCRIPTION
String times ending in "Z" are valid UTC DateTimes. This updates
the regular expression to allow for a time offset or a "Z" character
to pass the string test.

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Used the same coding conventions as the rest of the project.
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] All tests(`rake spec`) are passing.
* [x] The new code doesn't generate RuboCop offenses that are checked by `rake internal_investigation`.
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [ ] Updated cop documentation with `rake generate_cops_documentation` (required only when you've added a new cop or changed the configuration/documentation of an existing cop).

[1]: http://chris.beams.io/posts/git-commit/
