### PR TITLE
Drop ruby 2.0 support

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -30,5 +30,5 @@ Include the output of `rubocop -V`. Here's an example:
 
 ```
 $ rubocop -V
-0.16.0 (using Parser 2.1.2, running on ruby 2.0.0 x86_64-darwin12.4.0)
+0.50.0 (using Parser 2.4.0.0, running on ruby 2.4.2 x86_64-linux)
 ```

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -8,7 +8,7 @@ AllCops:
     - 'vendor/**/*'
     - 'spec/fixtures/**/*'
     - 'tmp/**/*'
-  TargetRubyVersion: 2.0
+  TargetRubyVersion: 2.1
 
 Style/FrozenStringLiteralComment:
   EnforcedStyle: always

--- a/.travis.rb
+++ b/.travis.rb
@@ -26,7 +26,7 @@ def sh!(command)
 end
 
 # Run main task(RSpec or RuboCop).
-if master? || !test? || jruby? || RUBY_VERSION < '2.1.0'
+if master? || !test? || jruby?
   sh!("bundle exec rake #{ENV['TASK']}")
 else
   sh!("bundle exec rake parallel:#{ENV['TASK']}")

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,6 @@ dist: trusty
 rvm:
   - jruby-9.1.13.0
   - jruby-head
-  - 2.0.0
   - 2.1.10
   - 2.2.8
   - 2.3.5

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,8 @@
 * [#4746](https://github.com/bbatsov/rubocop/pull/4746): The `Lint/InvalidCharacterLiteral` cop has been removed since it was never being actually triggered. ([@deivid-rodriguez][])
 * [#4789](https://github.com/bbatsov/rubocop/pull/4789): Analyzing code that needs to support MRI 1.9 is no longer supported. ([@deivid-rodriguez][])
 * [#4582](https://github.com/bbatsov/rubocop/issues/4582): `Severity` and other common parameters can be configured on department level. ([@jonas054][])
+* [#4787](https://github.com/bbatsov/rubocop/pull/4787): Analyzing code that needs to support MRI 2.0 is no longer supported. ([@deivid-rodriguez][])
+* [#4787](https://github.com/bbatsov/rubocop/pull/4787): RuboCop no longer installs on MRI 2.0. ([@deivid-rodriguez][])
 
 ## 0.50.0 (2017-09-14)
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -17,7 +17,7 @@ do so.
 
 ```
 $ rubocop -V
-0.16.0 (using Parser 2.1.2, running on ruby 2.0.0 x86_64-darwin12.4.0)
+0.50.0 (using Parser 2.4.0.0, running on ruby 2.4.2 x86_64-linux)
 ```
 
 * Include any relevant code to the issue summary.

--- a/Gemfile
+++ b/Gemfile
@@ -9,7 +9,7 @@ gem 'pry'
 gem 'rake', '~> 12.0'
 gem 'rspec', '~> 3.6.0'
 gem 'simplecov', '~> 0.10'
-gem 'test-queue' if RUBY_VERSION >= '2.1.0'
+gem 'test-queue'
 gem 'yard', '~> 0.9'
 
 group :test do

--- a/README.md
+++ b/README.md
@@ -71,7 +71,6 @@ You can read a ton more about RuboCop in its [official manual](http://rubocop.re
 
 RuboCop supports the following Ruby implementations:
 
-* MRI 2.0
 * MRI 2.1
 * MRI 2.2
 * MRI 2.3

--- a/lib/rubocop/config.rb
+++ b/lib/rubocop/config.rb
@@ -17,7 +17,7 @@ module RuboCop
                        AutoCorrect StyleGuide Details].freeze
     # 2.1 is the oldest officially supported Ruby version.
     DEFAULT_RUBY_VERSION = 2.1
-    KNOWN_RUBIES = [2.0, 2.1, 2.2, 2.3, 2.4].freeze
+    KNOWN_RUBIES = [2.1, 2.2, 2.3, 2.4].freeze
     DEFAULT_RAILS_VERSION = 5.0
     OBSOLETE_COPS = {
       'Style/TrailingComma' =>

--- a/lib/rubocop/cop/metrics/parameter_lists.rb
+++ b/lib/rubocop/cop/metrics/parameter_lists.rb
@@ -5,8 +5,7 @@ module RuboCop
     module Metrics
       # This cop checks for methods with too many parameters.
       # The maximum number of parameters is configurable.
-      # On Ruby 2.0+ keyword arguments can optionally
-      # be excluded from the total count.
+      # Keyword arguments can optionally be excluded from the total count.
       class ParameterLists < Cop
         include ConfigurableMax
 

--- a/lib/rubocop/cop/style/dir.rb
+++ b/lib/rubocop/cop/style/dir.rb
@@ -17,8 +17,6 @@ module RuboCop
       #   # good
       #   path = __dir__
       class Dir < Cop
-        extend TargetRubyVersion
-
         MSG = 'Use `__dir__` to get an absolute path to the current ' \
               "file's directory.".freeze
 
@@ -26,8 +24,6 @@ module RuboCop
           {(send (const nil? :File) :expand_path (send (const nil? :File) :dirname  #file_keyword?))
            (send (const nil? :File) :dirname     (send (const nil? :File) :realpath #file_keyword?))}
         PATTERN
-
-        minimum_target_ruby_version 2.0
 
         def on_send(node)
           dir_replacement?(node) do

--- a/lib/rubocop/cop/style/symbol_array.rb
+++ b/lib/rubocop/cop/style/symbol_array.rb
@@ -7,8 +7,7 @@ module RuboCop
       # using the %i() syntax.
       #
       # Alternatively, it checks for symbol arrays using the %i() syntax on
-      # projects which do not want to use that syntax, perhaps because they
-      # support a version of Ruby lower than 2.0.
+      # projects which do not want to use that syntax.
       #
       # Configuration option: MinSize
       # If set, arrays with fewer elements than this value will not trigger the
@@ -38,9 +37,6 @@ module RuboCop
         include ConfigurableEnforcedStyle
         include PercentLiteral
         include PercentArray
-        extend TargetRubyVersion
-
-        minimum_target_ruby_version 2.0
 
         PERCENT_MSG = 'Use `%i` or `%I` for an array of symbols.'.freeze
         ARRAY_MSG = 'Use `[]` for an array of symbols.'.freeze

--- a/lib/rubocop/processed_source.rb
+++ b/lib/rubocop/processed_source.rb
@@ -110,9 +110,6 @@ module RuboCop
     # rubocop:disable Metrics/MethodLength
     def parser_class(ruby_version)
       case ruby_version
-      when 2.0
-        require 'parser/ruby20'
-        Parser::Ruby20
       when 2.1
         require 'parser/ruby21'
         Parser::Ruby21

--- a/lib/rubocop/rspec/shared_contexts.rb
+++ b/lib/rubocop/rspec/shared_contexts.rb
@@ -57,10 +57,6 @@ shared_context 'config', :config do
   end
 end
 
-shared_context 'ruby 2.0', :ruby20 do
-  let(:ruby_version) { 2.0 }
-end
-
 shared_context 'ruby 2.1', :ruby21 do
   let(:ruby_version) { 2.1 }
 end

--- a/manual/configuration.md
+++ b/manual/configuration.md
@@ -301,9 +301,9 @@ Style/PerlBackrefs:
 ### Setting the target Ruby version
 
 Some checks are dependent on the version of the Ruby interpreter which the
-inspected code must run on. For example, using Ruby 2.0+ keyword arguments
-rather than an options hash can help make your code shorter and more
-expressive... _unless_ it must run on Ruby 1.9.
+inspected code must run on. For example, enforcing using Ruby 2.3+ safe
+navigation operator rather than `try` can help make your code shorter and
+more consistent... _unless_ it must run on Ruby 2.2.
 
 If `.ruby-version` exists in the directory RuboCop is invoked in, RuboCop
 will use the version specified by it. Otherwise, users may let RuboCop
@@ -311,7 +311,7 @@ know the oldest version of Ruby which your project supports with:
 
 ```yaml
 AllCops:
-  TargetRubyVersion: 1.9
+  TargetRubyVersion: 2.2
 ```
 
 ### Automatically Generated Configuration

--- a/manual/cops_metrics.md
+++ b/manual/cops_metrics.md
@@ -175,8 +175,7 @@ Enabled | No
 
 This cop checks for methods with too many parameters.
 The maximum number of parameters is configurable.
-On Ruby 2.0+ keyword arguments can optionally
-be excluded from the total count.
+Keyword arguments can optionally be excluded from the total count.
 
 ### Important attributes
 

--- a/manual/cops_style.md
+++ b/manual/cops_style.md
@@ -3636,8 +3636,7 @@ This cop can check for array literals made up of symbols that are not
 using the %i() syntax.
 
 Alternatively, it checks for symbol arrays using the %i() syntax on
-projects which do not want to use that syntax, perhaps because they
-support a version of Ruby lower than 2.0.
+projects which do not want to use that syntax.
 
 Configuration option: MinSize
 If set, arrays with fewer elements than this value will not trigger the

--- a/manual/formatters.md
+++ b/manual/formatters.md
@@ -158,10 +158,10 @@ The JSON structure is like the following example:
 ```javascript
 {
   "metadata": {
-    "rubocop_version": "0.9.0",
+    "rubocop_version": "0.50.0",
     "ruby_engine": "ruby",
-    "ruby_version": "2.0.0",
-    "ruby_patchlevel": "195",
+    "ruby_version": "2.4.2",
+    "ruby_patchlevel": "198",
     "ruby_platform": "x86_64-darwin12.3.0"
   },
   "files": [{

--- a/rubocop.gemspec
+++ b/rubocop.gemspec
@@ -9,7 +9,7 @@ Gem::Specification.new do |s|
   s.name = 'rubocop'
   s.version = RuboCop::Version::STRING
   s.platform = Gem::Platform::RUBY
-  s.required_ruby_version = '>= 2.0.0'
+  s.required_ruby_version = '>= 2.1.0'
   s.authors = ['Bozhidar Batsov', 'Jonas Arvidsson', 'Yuji Nakayama']
   s.description = <<-DESCRIPTION
     Automatic Ruby code style checking tool.

--- a/spec/rubocop/cli_spec.rb
+++ b/spec/rubocop/cli_spec.rb
@@ -1618,7 +1618,29 @@ describe RuboCop::CLI, :isolated_environment do
           /\AError: Unknown Ruby version 2.5 found in `TargetRubyVersion`/
         )
         expect($stderr.string.strip).to match(
-          /Known versions: 2.1, 2.2, 2.3, 2.4/
+          /Supported versions: 2.1, 2.2, 2.3, 2.4/
+        )
+      end
+    end
+
+    context 'when configured with an unsupported ruby' do
+      it 'fails with an error message' do
+        create_file('.rubocop.yml', <<-YAML.strip_indent)
+          AllCops:
+            TargetRubyVersion: 2.0
+        YAML
+
+        expect(cli.run([])).to eq(2)
+        expect($stderr.string.strip).to match(
+          /\AError: Unsupported Ruby version 2.0 found in `TargetRubyVersion`/
+        )
+
+        expect($stderr.string.strip).to match(
+          /2\.0-compatible analysis was dropped after version 0\.50/
+        )
+
+        expect($stderr.string.strip).to match(
+          /Supported versions: 2.1, 2.2, 2.3, 2.4/
         )
       end
     end

--- a/spec/rubocop/cli_spec.rb
+++ b/spec/rubocop/cli_spec.rb
@@ -1618,7 +1618,7 @@ describe RuboCop::CLI, :isolated_environment do
           /\AError: Unknown Ruby version 2.5 found in `TargetRubyVersion`/
         )
         expect($stderr.string.strip).to match(
-          /Known versions: 2.0, 2.1, 2.2, 2.3, 2.4/
+          /Known versions: 2.1, 2.2, 2.3, 2.4/
         )
       end
     end

--- a/spec/rubocop/cop/layout/else_alignment_spec.rb
+++ b/spec/rubocop/cop/layout/else_alignment_spec.rb
@@ -411,32 +411,30 @@ describe RuboCop::Cop::Layout::ElseAlignment do
       RUBY
     end
 
-    if RUBY_VERSION >= '2.1'
-      context 'when modifier and def are on the same line' do
-        it 'accepts a correctly aligned body' do
-          expect_no_offenses(<<-RUBY.strip_indent)
-            private def test
-              something
-            rescue
-              handling
-            else
-              something_else
-            end
-          RUBY
-        end
+    context 'when modifier and def are on the same line' do
+      it 'accepts a correctly aligned body' do
+        expect_no_offenses(<<-RUBY.strip_indent)
+          private def test
+            something
+          rescue
+            handling
+          else
+            something_else
+          end
+        RUBY
+      end
 
-        it 'registers an offense for else not aligned with private' do
-          expect_offense(<<-RUBY.strip_indent)
-            private def test
-                      something
-                    rescue
-                      handling
-                    else
-                    ^^^^ Align `else` with `private`.
-                      something_else
-                    end
-          RUBY
-        end
+      it 'registers an offense for else not aligned with private' do
+        expect_offense(<<-RUBY.strip_indent)
+          private def test
+                    something
+                  rescue
+                    handling
+                  else
+                  ^^^^ Align `else` with `private`.
+                    something_else
+                  end
+        RUBY
       end
     end
   end

--- a/spec/rubocop/cop/layout/indentation_width_spec.rb
+++ b/spec/rubocop/cop/layout/indentation_width_spec.rb
@@ -863,33 +863,31 @@ describe RuboCop::Cop::Layout::IndentationWidth do
 
         include_examples 'without modifier on the same line'
 
-        if RUBY_VERSION >= '2.1'
-          context 'when modifier and def are on the same line' do
-            it 'accepts a correctly aligned body' do
-              expect_no_offenses(<<-RUBY.strip_indent)
-                foo def test
-                  something
-                end
-              RUBY
-            end
+        context 'when modifier and def are on the same line' do
+          it 'accepts a correctly aligned body' do
+            expect_no_offenses(<<-RUBY.strip_indent)
+              foo def test
+                something
+              end
+            RUBY
+          end
 
-            it 'registers an offense for bad indentation of a def body' do
-              expect_offense(<<-RUBY.strip_indent)
-                foo def test
-                      something
-                ^^^^^^ Use 2 (not 6) spaces for indentation.
-                    end
-              RUBY
-            end
+          it 'registers an offense for bad indentation of a def body' do
+            expect_offense(<<-RUBY.strip_indent)
+              foo def test
+                    something
+              ^^^^^^ Use 2 (not 6) spaces for indentation.
+                  end
+            RUBY
+          end
 
-            it 'registers an offense for bad indentation of a defs body' do
-              expect_offense(<<-RUBY.strip_indent)
-                foo def self.test
-                      something
-                ^^^^^^ Use 2 (not 6) spaces for indentation.
-                    end
-              RUBY
-            end
+          it 'registers an offense for bad indentation of a defs body' do
+            expect_offense(<<-RUBY.strip_indent)
+              foo def self.test
+                    something
+              ^^^^^^ Use 2 (not 6) spaces for indentation.
+                  end
+            RUBY
           end
         end
       end
@@ -901,33 +899,31 @@ describe RuboCop::Cop::Layout::IndentationWidth do
 
         include_examples 'without modifier on the same line'
 
-        if RUBY_VERSION >= '2.1'
-          context 'when modifier and def are on the same line' do
-            it 'accepts a correctly aligned body' do
-              expect_no_offenses(<<-RUBY.strip_indent)
-                foo def test
-                      something
-                end
-              RUBY
-            end
+        context 'when modifier and def are on the same line' do
+          it 'accepts a correctly aligned body' do
+            expect_no_offenses(<<-RUBY.strip_indent)
+              foo def test
+                    something
+              end
+            RUBY
+          end
 
-            it 'registers an offense for bad indentation of a def body' do
-              expect_offense(<<-RUBY.strip_indent)
-                foo def test
-                  something
-                  ^^ Use 2 (not -2) spaces for indentation.
-                    end
-              RUBY
-            end
+          it 'registers an offense for bad indentation of a def body' do
+            expect_offense(<<-RUBY.strip_indent)
+              foo def test
+                something
+                ^^ Use 2 (not -2) spaces for indentation.
+                  end
+            RUBY
+          end
 
-            it 'registers an offense for bad indentation of a defs body' do
-              expect_offense(<<-RUBY.strip_indent)
-                foo def self.test
-                  something
-                  ^^ Use 2 (not -2) spaces for indentation.
-                    end
-              RUBY
-            end
+          it 'registers an offense for bad indentation of a defs body' do
+            expect_offense(<<-RUBY.strip_indent)
+              foo def self.test
+                something
+                ^^ Use 2 (not -2) spaces for indentation.
+                  end
+            RUBY
           end
         end
       end

--- a/spec/rubocop/cop/layout/space_after_colon_spec.rb
+++ b/spec/rubocop/cop/layout/space_after_colon_spec.rb
@@ -45,21 +45,19 @@ describe RuboCop::Cop::Layout::SpaceAfterColon do
     RUBY
   end
 
-  if RUBY_VERSION >= '2.1'
-    it 'accepts colons denoting required keyword argument' do
-      expect_no_offenses(<<-RUBY.strip_indent)
-        def initialize(table:, nodes:)
-        end
-      RUBY
-    end
+  it 'accepts colons denoting required keyword argument' do
+    expect_no_offenses(<<-RUBY.strip_indent)
+      def initialize(table:, nodes:)
+      end
+    RUBY
+  end
 
-    it 'registers an offence if an keyword optional argument has no space' do
-      expect_offense(<<-RUBY.strip_indent)
-        def m(var:1, other_var: 2)
-                 ^ Space missing after colon.
-        end
-      RUBY
-    end
+  it 'registers an offence if an keyword optional argument has no space' do
+    expect_offense(<<-RUBY.strip_indent)
+      def m(var:1, other_var: 2)
+               ^ Space missing after colon.
+      end
+    RUBY
   end
 
   it 'auto-corrects missing space' do

--- a/spec/rubocop/cop/lint/useless_assignment_spec.rb
+++ b/spec/rubocop/cop/lint/useless_assignment_spec.rb
@@ -1578,10 +1578,6 @@ describe RuboCop::Cop::Lint::UselessAssignment do
       expect(cop.offenses.first.line).to eq(2)
       expect(cop.highlights).to eq(['/(?<foo>\w+)/'])
     end
-
-    # MRI 2.0 accepts this case, but I have no idea why it does so
-    # and there's no convincing reason to conform to this behavior,
-    # so RuboCop does not mimic MRI in this case.
   end
 
   context 'when a named capture is referenced' do

--- a/spec/rubocop/cop/naming/constant_name_spec.rb
+++ b/spec/rubocop/cop/naming/constant_name_spec.rb
@@ -46,7 +46,7 @@ describe RuboCop::Cop::Naming::ConstantName do
   end
 
   it 'does not check if rhs is another constant' do
-    expect_no_offenses('Parser::CurrentRuby = Parser::Ruby20')
+    expect_no_offenses('Parser::CurrentRuby = Parser::Ruby21')
   end
 
   it 'checks qualified const names' do

--- a/spec/rubocop/cop/style/optional_arguments_spec.rb
+++ b/spec/rubocop/cop/style/optional_arguments_spec.rb
@@ -81,7 +81,7 @@ describe RuboCop::Cop::Style::OptionalArguments do
       end
     end
 
-    context 'required params', :ruby21 do
+    context 'required params' do
       it 'registers an offense for optional arguments that come before ' \
          'required arguments where there are name arguments' do
         inspect_source(<<-RUBY.strip_indent)

--- a/spec/rubocop/cop/style/redundant_parentheses_spec.rb
+++ b/spec/rubocop/cop/style/redundant_parentheses_spec.rb
@@ -52,11 +52,8 @@ describe RuboCop::Cop::Style::RedundantParentheses do
   it_behaves_like 'redundant', '(/regexp/)', '/regexp/', 'a literal'
   it_behaves_like 'redundant', '("x"; "y")', '"x"; "y"', 'a literal'
   it_behaves_like 'redundant', '(1; 2)', '1; 2', 'a literal'
-  if RUBY_VERSION >= '2.1'
-    it_behaves_like 'redundant', '(1i)', '1i', 'a literal'
-    it_behaves_like 'redundant', '(1r)', '1r', 'a literal'
-  end
-
+  it_behaves_like 'redundant', '(1i)', '1i', 'a literal'
+  it_behaves_like 'redundant', '(1r)', '1r', 'a literal'
   it_behaves_like 'redundant', '(__FILE__)', '__FILE__', 'a keyword'
   it_behaves_like 'redundant', '(__LINE__)', '__LINE__', 'a keyword'
   it_behaves_like 'redundant', '(__ENCODING__)', '__ENCODING__', 'a keyword'

--- a/spec/rubocop/cop/style/trivial_accessors_spec.rb
+++ b/spec/rubocop/cop/style/trivial_accessors_spec.rb
@@ -198,10 +198,8 @@ describe RuboCop::Cop::Style::TrivialAccessors, :config do
     expect_no_offenses(<<-RUBY.strip_indent)
       module Foo
         begin
-          if RUBY_VERSION > "2.0"
-            def bar=(bar)
-              @bar = bar
-            end
+          def bar=(bar)
+            @bar = bar
           end
         end
       end
@@ -212,10 +210,8 @@ describe RuboCop::Cop::Style::TrivialAccessors, :config do
     expect_no_offenses(<<-RUBY.strip_indent)
       module Foo
         begin
-          if RUBY_VERSION > "2.0"
-            def bar
-              @bar
-            end
+          def bar
+            @bar
           end
         end
       end
@@ -226,10 +222,8 @@ describe RuboCop::Cop::Style::TrivialAccessors, :config do
     expect_no_offenses(<<-RUBY.strip_indent)
       something.instance_eval do
         begin
-          if RUBY_VERSION > "2.0"
-            def bar=(bar)
-              @bar = bar
-            end
+          def bar=(bar)
+            @bar = bar
           end
         end
       end
@@ -240,10 +234,8 @@ describe RuboCop::Cop::Style::TrivialAccessors, :config do
     expect_no_offenses(<<-RUBY.strip_indent)
       something.instance_eval do
         begin
-          if RUBY_VERSION > "2.0"
-            def bar
-              @bar
-            end
+          def bar
+            @bar
           end
         end
       end


### PR DESCRIPTION
I think it's time to drop Ruby 2.0 support.

* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Used the same coding conventions as the rest of the project.
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] All tests(`rake spec`) are passing.
* [x] The new code doesn't generate RuboCop offenses that are checked by `rake internal_investigation`.
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Updated cop documentation with `rake generate_cops_documentation` (required only when you've added a new cop or changed the configuration/documentation of an existing cop).

[1]: http://chris.beams.io/posts/git-commit/
