### PR TITLE
Drop analysis of 1.9 code

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,10 +11,12 @@
 * [#4730](https://github.com/bbatsov/rubocop/issues/4730): False positive on Lint/InterpolationCheck. ([@koic][])
 * [#4751](https://github.com/bbatsov/rubocop/issues/4751): Prevent `Rails/HasManyOrHasOneDependent` cop from registering offense if `:through` option was specified. ([@smakagon][])
 * [#4737](https://github.com/bbatsov/rubocop/issues/4737): Fix ReturnInVoidContext cop when `return` is in top scope. ([@frodsan][])
+* [#4776](https://github.com/bbatsov/rubocop/issues/4776): Non utf-8 magic encoding comments are now respected. ([@deivid-rodriguez][])
 
 ### Changes
 
 * [#4746](https://github.com/bbatsov/rubocop/pull/4746): The `Lint/InvalidCharacterLiteral` cop has been removed since it was never being actually triggered. ([@deivid-rodriguez][])
+* [#4789](https://github.com/bbatsov/rubocop/pull/4789): Analyzing code that needs to support MRI 1.9 is no longer supported. ([@deivid-rodriguez][])
 
 ## 0.50.0 (2017-09-14)
 

--- a/config/default.yml
+++ b/config/default.yml
@@ -878,17 +878,6 @@ Style/EmptyMethod:
     - compact
     - expanded
 
-# Checks whether the source file has a utf-8 encoding comment or not
-# AutoCorrectEncodingComment must match the regex
-# /#.*coding\s?[:=]\s?(?:UTF|utf)-8/
-Style/Encoding:
-  EnforcedStyle: never
-  SupportedStyles:
-    - when_needed
-    - always
-    - never
-  AutoCorrectEncodingComment: '# encoding: utf-8'
-
 # Checks use of for or each in multiline loops.
 Style/For:
   EnforcedStyle: each

--- a/lib/rubocop/config.rb
+++ b/lib/rubocop/config.rb
@@ -17,7 +17,7 @@ module RuboCop
                        AutoCorrect StyleGuide Details].freeze
     # 2.1 is the oldest officially supported Ruby version.
     DEFAULT_RUBY_VERSION = 2.1
-    KNOWN_RUBIES = [1.9, 2.0, 2.1, 2.2, 2.3, 2.4].freeze
+    KNOWN_RUBIES = [2.0, 2.1, 2.2, 2.3, 2.4].freeze
     DEFAULT_RAILS_VERSION = 5.0
     OBSOLETE_COPS = {
       'Style/TrailingComma' =>
@@ -94,6 +94,24 @@ module RuboCop
         alternative: 'If your intention was to allow extra spaces ' \
                      'for alignment, please use AllowForAlignment: ' \
                      'true instead.'
+      },
+      {
+        cop: 'Style/Encoding',
+        parameter: 'EnforcedStyle',
+        alternative: 'Style/Encoding no longer supports styles. ' \
+                     'The "never" behavior is always assumed.'
+      },
+      {
+        cop: 'Style/Encoding',
+        parameter: 'SupportedStyles',
+        alternative: 'Style/Encoding no longer supports styles. ' \
+                     'The "never" behavior is always assumed.'
+      },
+      {
+        cop: 'Style/Encoding',
+        parameter: 'AutoCorrectEncodingComment',
+        alternative: 'Style/Encoding no longer supports styles. ' \
+                     'The "never" behavior is always assumed.'
       },
       {
         cop: 'Style/SpaceAroundOperators',

--- a/lib/rubocop/cop/style/encoding.rb
+++ b/lib/rubocop/cop/style/encoding.rb
@@ -3,23 +3,10 @@
 module RuboCop
   module Cop
     module Style
-      # This cop checks whether the source file has a utf-8 encoding
-      # comment or not.
-      # Setting this check to "always" and "when_needed" makes sense only
-      # for code that should support Ruby 1.9, since in 2.0+ utf-8 is the
-      # default source file encoding. There are three styles:
-      #
-      # when_needed - only enforce an encoding comment if there are non ASCII
-      #               characters, otherwise report an offense
-      # always - enforce encoding comment in all files
-      # never - enforce no encoding comment in all files
+      # This cop checks ensures source files have no utf-8 encoding comments.
       class Encoding < Cop
-        include ConfigurableEnforcedStyle
-
-        MSG_MISSING = 'Missing utf-8 encoding comment.'.freeze
         MSG_UNNECESSARY = 'Unnecessary utf-8 encoding comment.'.freeze
         ENCODING_PATTERN = /#.*coding\s?[:=]\s?(?:UTF|utf)-8/
-        AUTO_CORRECT_ENCODING_COMMENT = 'AutoCorrectEncodingComment'.freeze
         SHEBANG = '#!'.freeze
 
         def investigate(processed_source)
@@ -33,52 +20,21 @@ module RuboCop
         end
 
         def autocorrect(range)
-          if @message == MSG_MISSING
-            raise encoding_mismatch_message unless matching_encoding?
-
-            lambda do |corrector|
-              corrector.insert_before(range, "#{encoding}\n")
-            end
-          else
-            # Need to remove unnecessary encoding comment
-            lambda do |corrector|
-              corrector.remove(range_with_surrounding_space(range, :right))
-            end
+          lambda do |corrector|
+            corrector.remove(range_with_surrounding_space(range, :right))
           end
         end
 
         private
 
-        def encoding
-          cop_config[AUTO_CORRECT_ENCODING_COMMENT]
-        end
-
-        def matching_encoding?
-          encoding =~ ENCODING_PATTERN
-        end
-
-        def encoding_mismatch_message
-          "#{encoding} does not match #{ENCODING_PATTERN}"
-        end
-
         def offense(processed_source, line_number)
           line = processed_source[line_number]
 
-          if !encoding_present?(line) && !encoding_omitable?
-            MSG_MISSING
-          elsif encoding_present?(line) && encoding_omitable?
-            MSG_UNNECESSARY
-          end
+          MSG_UNNECESSARY if encoding_omitable?(line)
         end
 
-        def encoding_present?(line)
-          MagicComment.parse(line).encoding
-        end
-
-        def encoding_omitable?
-          return true if style == :never
-
-          style != :always && processed_source.buffer.source.ascii_only?
+        def encoding_omitable?(line)
+          line =~ ENCODING_PATTERN
         end
 
         def encoding_line_number(processed_source)

--- a/lib/rubocop/cop/style/option_hash.rb
+++ b/lib/rubocop/cop/style/option_hash.rb
@@ -35,17 +35,6 @@ module RuboCop
           add_offense(last_arg)
         end
 
-        def validate_config
-          return unless target_ruby_version < 2.0
-
-          raise ValidationError, 'The `Style/OptionHash` cop is only ' \
-                                'compatible with Ruby 2.0 and up, but the ' \
-                                'target Ruby version for your project is ' \
-                                "1.9.\nPlease disable this cop or adjust " \
-                                'the `TargetRubyVersion` parameter in your ' \
-                                'configuration.'
-        end
-
         private
 
         def suspicious_name?(arg_name)

--- a/lib/rubocop/processed_source.rb
+++ b/lib/rubocop/processed_source.rb
@@ -107,12 +107,9 @@ module RuboCop
       [ast, comments, tokens]
     end
 
-    # rubocop:disable Metrics/MethodLength, Metrics/CyclomaticComplexity
+    # rubocop:disable Metrics/MethodLength
     def parser_class(ruby_version)
       case ruby_version
-      when 1.9
-        require 'parser/ruby19'
-        Parser::Ruby19
       when 2.0
         require 'parser/ruby20'
         Parser::Ruby20
@@ -132,7 +129,7 @@ module RuboCop
         raise ArgumentError, "Unknown Ruby version: #{ruby_version.inspect}"
       end
     end
-    # rubocop:enable Metrics/MethodLength, Metrics/CyclomaticComplexity
+    # rubocop:enable Metrics/MethodLength
 
     def create_parser(ruby_version)
       builder = RuboCop::AST::Builder.new

--- a/lib/rubocop/rspec/shared_contexts.rb
+++ b/lib/rubocop/rspec/shared_contexts.rb
@@ -57,10 +57,6 @@ shared_context 'config', :config do
   end
 end
 
-shared_context 'ruby 1.9', :ruby19 do
-  let(:ruby_version) { 1.9 }
-end
-
 shared_context 'ruby 2.0', :ruby20 do
   let(:ruby_version) { 2.0 }
 end

--- a/manual/cops_style.md
+++ b/manual/cops_style.md
@@ -1030,24 +1030,7 @@ Enabled by default | Supports autocorrection
 --- | ---
 Enabled | Yes
 
-This cop checks whether the source file has a utf-8 encoding
-comment or not.
-Setting this check to "always" and "when_needed" makes sense only
-for code that should support Ruby 1.9, since in 2.0+ utf-8 is the
-default source file encoding. There are three styles:
-
-when_needed - only enforce an encoding comment if there are non ASCII
-              characters, otherwise report an offense
-always - enforce encoding comment in all files
-never - enforce no encoding comment in all files
-
-### Important attributes
-
-Attribute | Value
---- | ---
-EnforcedStyle | never
-SupportedStyles | when_needed, always, never
-AutoCorrectEncodingComment | # encoding: utf-8
+This cop checks ensures source files have no utf-8 encoding comments.
 
 ### References
 

--- a/spec/rubocop/cli_spec.rb
+++ b/spec/rubocop/cli_spec.rb
@@ -1608,26 +1608,7 @@ describe RuboCop::CLI, :isolated_environment do
           /\AError: Unknown Ruby version 2.5 found in `TargetRubyVersion`/
         )
         expect($stderr.string.strip).to match(
-          /Known versions: 1.9, 2.0, 2.1, 2.2, 2.3, 2.4/
-        )
-      end
-    end
-
-    context 'when set to 1.9 and Style/OptionHash is enabled' do
-      it 'fails with an error message' do
-        create_file('example1.rb', "puts 'hello'")
-        create_file('.rubocop.yml', <<-YAML.strip_indent)
-          AllCops:
-            TargetRubyVersion: 1.9
-          Style/OptionHash:
-            Enabled: true
-        YAML
-        expect(cli.run(['example1.rb'])).to eq(2)
-        expect($stderr.string.strip).to eq(
-          ['Error: The `Style/OptionHash` cop is only compatible with Ruby ' \
-           '2.0 and up, but the target Ruby version for your project is 1.9.',
-           'Please disable this cop or adjust the `TargetRubyVersion` ' \
-           'parameter in your configuration.'].join("\n")
+          /Known versions: 2.0, 2.1, 2.2, 2.3, 2.4/
         )
       end
     end

--- a/spec/rubocop/cop/layout/align_hash_spec.rb
+++ b/spec/rubocop/cop/layout/align_hash_spec.rb
@@ -239,35 +239,33 @@ describe RuboCop::Cop::Layout::AlignHash, :config do
       RUBY
     end
 
-    context 'ruby >= 2.0', :ruby20 do
-      it 'auto-corrects alignment when using double splat ' \
-         'in an explicit hash' do
-        new_source = autocorrect_source(<<-RUBY.strip_indent)
-          Hash(foo: 'bar',
-                 **extra_params
-          )
-        RUBY
-
-        expect(new_source).to eq(<<-RUBY.strip_indent)
-          Hash(foo: 'bar',
+    it 'auto-corrects alignment when using double splat ' \
+       'in an explicit hash' do
+      new_source = autocorrect_source(<<-RUBY.strip_indent)
+        Hash(foo: 'bar',
                **extra_params
-          )
-        RUBY
-      end
+        )
+      RUBY
 
-      it 'auto-corrects alignment when using double splat in braces' do
-        new_source = autocorrect_source(<<-RUBY.strip_indent)
-          {foo: 'bar',
-                 **extra_params
-          }
-        RUBY
+      expect(new_source).to eq(<<-RUBY.strip_indent)
+        Hash(foo: 'bar',
+             **extra_params
+        )
+      RUBY
+    end
 
-        expect(new_source).to eq(<<-RUBY.strip_indent)
-          {foo: 'bar',
-           **extra_params
-          }
-        RUBY
-      end
+    it 'auto-corrects alignment when using double splat in braces' do
+      new_source = autocorrect_source(<<-RUBY.strip_indent)
+        {foo: 'bar',
+               **extra_params
+        }
+      RUBY
+
+      expect(new_source).to eq(<<-RUBY.strip_indent)
+        {foo: 'bar',
+         **extra_params
+        }
+      RUBY
     end
   end
 
@@ -322,25 +320,23 @@ describe RuboCop::Cop::Layout::AlignHash, :config do
       RUBY
     end
 
-    context 'ruby >= 2.0', :ruby20 do
-      it 'accepts hashes that use different separators and double splats' do
-        expect_no_offenses(<<-RUBY.strip_indent)
-          hash = {
-            a: 1,
-            'bbb' => 2,
-            **foo
-          }
-        RUBY
-      end
+    it 'accepts hashes that use different separators and double splats' do
+      expect_no_offenses(<<-RUBY.strip_indent)
+        hash = {
+          a: 1,
+          'bbb' => 2,
+          **foo
+        }
+      RUBY
+    end
 
-      it 'accepts hashes that use different separators and double splats' do
-        expect_no_offenses(<<-RUBY.strip_indent)
-          hash = {
-            a: 1,
-            **kw
-          }
-        RUBY
-      end
+    it 'accepts hashes that use different separators and double splats' do
+      expect_no_offenses(<<-RUBY.strip_indent)
+        hash = {
+          a: 1,
+          **kw
+        }
+      RUBY
     end
 
     it 'registers an offense for misaligned hash values' do
@@ -481,14 +477,12 @@ describe RuboCop::Cop::Layout::AlignHash, :config do
       RUBY
     end
 
-    context 'ruby >= 2.0', :ruby20 do
-      it 'accepts hashes with different separators' do
-        expect_no_offenses(<<-RUBY.strip_indent)
-          {a: 1,
-            'b' => 2,
-             **params}
-        RUBY
-      end
+    it 'accepts hashes with different separators' do
+      expect_no_offenses(<<-RUBY.strip_indent)
+        {a: 1,
+          'b' => 2,
+           **params}
+      RUBY
     end
 
     include_examples 'not on separate lines'

--- a/spec/rubocop/cop/lint/circular_argument_reference_spec.rb
+++ b/spec/rubocop/cop/lint/circular_argument_reference_spec.rb
@@ -63,7 +63,29 @@ describe RuboCop::Cop::Lint::CircularArgumentReference do
   end
 
   describe 'circular argument references in keyword arguments' do
-    context 'ruby < 2.0, which has no keyword arguments', :ruby19 do
+    before do
+      inspect_source(source)
+    end
+
+    context 'when the keyword argument is not circular' do
+      let(:source) do
+        <<-RUBY.strip_indent
+          def some_method(some_arg: nil)
+            puts some_arg
+          end
+        RUBY
+      end
+
+      it 'does not register an offense' do
+        expect_no_offenses(<<-RUBY.strip_indent)
+          def some_method(some_arg: nil)
+            puts some_arg
+          end
+        RUBY
+      end
+    end
+
+    context 'when the keyword argument is not circular, and calls a method' do
       let(:source) do
         <<-RUBY.strip_indent
           def some_method(some_arg: some_method)
@@ -71,126 +93,85 @@ describe RuboCop::Cop::Lint::CircularArgumentReference do
           end
         RUBY
       end
-
-      it 'fails with a syntax error before the cop even comes into play' do
-        expect { inspect_source(source) }.to raise_error(
-          RuntimeError, /Error parsing/
-        )
-        expect(cop.offenses).to be_empty
+      it 'does not register an offense' do
+        expect_no_offenses(<<-RUBY.strip_indent)
+          def some_method(some_arg: some_method)
+            puts some_arg
+          end
+        RUBY
       end
     end
 
-    context 'ruby >= 2.0', :ruby20 do
-      before do
-        inspect_source(source)
+    context 'when there is one circular argument reference' do
+      let(:source) do
+        <<-RUBY.strip_indent
+          def some_method(some_arg: some_arg)
+            puts some_arg
+          end
+        RUBY
+      end
+      it 'registers an offense' do
+        expect(cop.offenses.size).to eq(1)
+        expect(cop.offenses.first.message)
+          .to eq('Circular argument reference - `some_arg`.')
+        expect(cop.highlights).to eq ['some_arg']
+      end
+    end
+
+    context 'when the keyword argument is not circular, but calls a method ' \
+            'of its own class with a self specification' do
+      let(:source) do
+        <<-RUBY.strip_indent
+          def puts_value(value: self.class.value, smile: self.smile)
+            puts value
+          end
+        RUBY
       end
 
-      context 'when the keyword argument is not circular' do
-        let(:source) do
-          <<-RUBY.strip_indent
-            def some_method(some_arg: nil)
-              puts some_arg
-            end
-          RUBY
-        end
+      it 'does not register an offense' do
+        expect_no_offenses(<<-RUBY.strip_indent)
+          def puts_value(value: self.class.value, smile: self.smile)
+            puts value
+          end
+        RUBY
+      end
+    end
 
-        it 'does not register an offense' do
-          expect_no_offenses(<<-RUBY.strip_indent)
-            def some_method(some_arg: nil)
-              puts some_arg
-            end
-          RUBY
-        end
+    context 'when the keyword argument is not circular, but calls a method ' \
+            'of some other object with the same name' do
+      let(:source) do
+        <<-RUBY.strip_indent
+          def puts_length(length: mystring.length)
+            puts length
+          end
+        RUBY
       end
 
-      context 'when the keyword argument is not circular, and calls a method' do
-        let(:source) do
-          <<-RUBY.strip_indent
-            def some_method(some_arg: some_method)
-              puts some_arg
-            end
-          RUBY
-        end
-        it 'does not register an offense' do
-          expect_no_offenses(<<-RUBY.strip_indent)
-            def some_method(some_arg: some_method)
-              puts some_arg
-            end
-          RUBY
-        end
+      it 'does not register an offense' do
+        expect_no_offenses(<<-RUBY.strip_indent)
+          def puts_length(length: mystring.length)
+            puts length
+          end
+        RUBY
+      end
+    end
+
+    context 'when there are multiple offensive keyword arguments' do
+      let(:source) do
+        <<-RUBY.strip_indent
+          def some_method(some_arg: some_arg, other_arg: other_arg)
+            puts [some_arg, other_arg]
+          end
+        RUBY
       end
 
-      context 'when there is one circular argument reference' do
-        let(:source) do
-          <<-RUBY.strip_indent
-            def some_method(some_arg: some_arg)
-              puts some_arg
-            end
-          RUBY
-        end
-        it 'registers an offense' do
-          expect(cop.offenses.size).to eq(1)
-          expect(cop.offenses.first.message)
-            .to eq('Circular argument reference - `some_arg`.')
-          expect(cop.highlights).to eq ['some_arg']
-        end
-      end
-
-      context 'when the keyword argument is not circular, but calls a method ' \
-              'of its own class with a self specification' do
-        let(:source) do
-          <<-RUBY.strip_indent
-            def puts_value(value: self.class.value, smile: self.smile)
-              puts value
-            end
-          RUBY
-        end
-
-        it 'does not register an offense' do
-          expect_no_offenses(<<-RUBY.strip_indent)
-            def puts_value(value: self.class.value, smile: self.smile)
-              puts value
-            end
-          RUBY
-        end
-      end
-
-      context 'when the keyword argument is not circular, but calls a method ' \
-              'of some other object with the same name' do
-        let(:source) do
-          <<-RUBY.strip_indent
-            def puts_length(length: mystring.length)
-              puts length
-            end
-          RUBY
-        end
-
-        it 'does not register an offense' do
-          expect_no_offenses(<<-RUBY.strip_indent)
-            def puts_length(length: mystring.length)
-              puts length
-            end
-          RUBY
-        end
-      end
-
-      context 'when there are multiple offensive keyword arguments' do
-        let(:source) do
-          <<-RUBY.strip_indent
-            def some_method(some_arg: some_arg, other_arg: other_arg)
-              puts [some_arg, other_arg]
-            end
-          RUBY
-        end
-
-        it 'registers two offenses' do
-          expect(cop.offenses.size).to eq(2)
-          expect(cop.offenses.first.message)
-            .to eq('Circular argument reference - `some_arg`.')
-          expect(cop.offenses.last.message)
-            .to eq('Circular argument reference - `other_arg`.')
-          expect(cop.highlights).to eq %w[some_arg other_arg]
-        end
+      it 'registers two offenses' do
+        expect(cop.offenses.size).to eq(2)
+        expect(cop.offenses.first.message)
+          .to eq('Circular argument reference - `some_arg`.')
+        expect(cop.offenses.last.message)
+          .to eq('Circular argument reference - `other_arg`.')
+        expect(cop.highlights).to eq %w[some_arg other_arg]
       end
     end
   end

--- a/spec/rubocop/cop/lint/shadowing_outer_local_variable_spec.rb
+++ b/spec/rubocop/cop/lint/shadowing_outer_local_variable_spec.rb
@@ -178,7 +178,7 @@ describe RuboCop::Cop::Lint::ShadowingOuterLocalVariable do
       RUBY
     end
 
-    include_examples 'accepts' unless RUBY_VERSION < '2.0'
+    include_examples 'accepts'
     include_examples 'mimics MRI 2.1'
   end
 

--- a/spec/rubocop/cop/lint/useless_assignment_spec.rb
+++ b/spec/rubocop/cop/lint/useless_assignment_spec.rb
@@ -1727,7 +1727,7 @@ describe RuboCop::Cop::Lint::UselessAssignment do
       RUBY
     end
 
-    include_examples 'accepts' unless RUBY_VERSION < '2.0'
+    include_examples 'accepts'
     include_examples 'mimics MRI 2.1'
   end
 
@@ -1740,7 +1740,7 @@ describe RuboCop::Cop::Lint::UselessAssignment do
       RUBY
     end
 
-    include_examples 'accepts' unless RUBY_VERSION < '2.0'
+    include_examples 'accepts'
     include_examples 'mimics MRI 2.1'
   end
 
@@ -1752,7 +1752,7 @@ describe RuboCop::Cop::Lint::UselessAssignment do
       RUBY
     end
 
-    include_examples 'accepts' unless RUBY_VERSION < '2.0'
+    include_examples 'accepts'
     include_examples 'mimics MRI 2.1'
   end
 
@@ -1764,7 +1764,7 @@ describe RuboCop::Cop::Lint::UselessAssignment do
       RUBY
     end
 
-    include_examples 'accepts' unless RUBY_VERSION < '2.0'
+    include_examples 'accepts'
     include_examples 'mimics MRI 2.1'
   end
 

--- a/spec/rubocop/cop/naming/heredoc_delimiter_naming_spec.rb
+++ b/spec/rubocop/cop/naming/heredoc_delimiter_naming_spec.rb
@@ -30,7 +30,7 @@ describe RuboCop::Cop::Naming::HeredocDelimiterNaming, :config do
     end
   end
 
-  context 'with a non-interpolated heredoc', :ruby20 do
+  context 'with a non-interpolated heredoc' do
     it 'registers an offense with a non-meaningful delimiter' do
       expect_offense(<<-RUBY.strip_indent)
         <<-'END'

--- a/spec/rubocop/cop/performance/fixed_size_spec.rb
+++ b/spec/rubocop/cop/performance/fixed_size_spec.rb
@@ -185,12 +185,10 @@ describe RuboCop::Cop::Performance::FixedSize do
         expect(cop.messages).to be_empty
       end
 
-      context 'ruby >= 2.0', :ruby20 do
-        it "accepts calling #{method} on a hash that contains a double splat" do
-          inspect_source("{a: 1, **foo}.#{method}")
+      it "accepts calling #{method} on a hash that contains a double splat" do
+        inspect_source("{a: 1, **foo}.#{method}")
 
-          expect(cop.messages).to be_empty
-        end
+        expect(cop.messages).to be_empty
       end
 
       it "accepts calling #{method} on an hash that is assigned " \

--- a/spec/rubocop/cop/rails/safe_navigation_spec.rb
+++ b/spec/rubocop/cop/rails/safe_navigation_spec.rb
@@ -33,7 +33,7 @@ describe RuboCop::Cop::Rails::SafeNavigation, :config do
 
     it_behaves_like :accepts, 'non try! method calls', 'join'
 
-    context 'target_ruby_version < 2.3', :ruby19 do
+    context 'target_ruby_version < 2.3', :ruby22 do
       it_behaves_like :accepts, 'try! with a single parameter', 'try!(:join)'
       it_behaves_like :accepts, 'try! with a multiple parameters',
                       'try!(:join, ",")'
@@ -115,7 +115,7 @@ describe RuboCop::Cop::Rails::SafeNavigation, :config do
   context 'convert try and try!' do
     let(:cop_config) { { 'ConvertTry' => true } }
 
-    context 'target_ruby_version < 2.3', :ruby19 do
+    context 'target_ruby_version < 2.3', :ruby22 do
       it_behaves_like :accepts, 'try! with a single parameter', 'try!(:join)'
       it_behaves_like :accepts, 'try! with a multiple parameters',
                       'try!(:join, ",")'

--- a/spec/rubocop/cop/style/dir_spec.rb
+++ b/spec/rubocop/cop/style/dir_spec.rb
@@ -32,19 +32,4 @@ describe RuboCop::Cop::Style::Dir, :config do
   it_behaves_like 'auto-correct',
                   'File.dirname(File.realpath(__FILE__))',
                   '__dir__'
-
-  context 'when target ruby version is 1.9', :ruby19 do
-    it 'does not register an offense when using `#expand_path` and ' \
-       '`#dirname`' do
-      expect_no_offenses(<<-RUBY.strip_indent)
-        File.expand_path(File.dirname(__FILE__))
-      RUBY
-    end
-
-    it 'does not register an offense when using `#dirname` and `#realpath`' do
-      expect_no_offenses(<<-RUBY.strip_indent)
-      File.dirname(File.realpath(__FILE__))
-      RUBY
-    end
-  end
 end

--- a/spec/rubocop/cop/style/encoding_spec.rb
+++ b/spec/rubocop/cop/style/encoding_spec.rb
@@ -3,273 +3,84 @@
 describe RuboCop::Cop::Style::Encoding, :config do
   subject(:cop) { described_class.new(config) }
 
-  context 'when_needed' do
-    let(:cop_config) do
-      { 'EnforcedStyle' => 'when_needed' }
-    end
+  it 'registers no offense when no encoding present' do
+    inspect_source('def foo() end')
 
-    it 'registers no offense when no encoding present but only ASCII ' \
-       'characters' do
-      inspect_source('def foo() end')
-
-      expect(cop.offenses).to be_empty
-    end
-
-    it 'registers an offense when there is no encoding present but non ' \
-       'ASCII characters' do
-      inspect_source('def foo() \'ä\' end')
-
-      expect(cop.offenses.size).to eq(1)
-      expect(cop.messages).to eq(
-        ['Missing utf-8 encoding comment.']
-      )
-    end
-
-    it 'registers an offense when encoding present but only ASCII ' \
-       'characters' do
-      inspect_source(<<-RUBY.strip_indent)
-        # encoding: utf-8
-        def foo() end
-      RUBY
-
-      expect(cop.offenses.size).to eq(1)
-      expect(cop.messages).to eq(
-        ['Unnecessary utf-8 encoding comment.']
-      )
-    end
-
-    it 'accepts an empty file' do
-      expect_no_offenses('')
-    end
-
-    it 'accepts encoding on first line' do
-      expect_no_offenses(<<-RUBY.strip_indent)
-        # encoding: utf-8
-        def foo() \'ä\' end
-      RUBY
-    end
-
-    it 'accepts encoding on second line when shebang present' do
-      expect_no_offenses(<<-RUBY.strip_indent)
-        #!/usr/bin/env ruby
-        # encoding: utf-8
-        def foo() 'ä' end
-      RUBY
-    end
-
-    it 'registers an offense when encoding is in the wrong place' do
-      expect_offense(<<-RUBY.strip_indent)
-        def foo() 'ä' end
-        ^^^^^^^^^^^^^^^^^ Missing utf-8 encoding comment.
-        # encoding: utf-8
-      RUBY
-    end
-
-    it 'accepts encoding inserted by magic_encoding gem' do
-      expect_no_offenses(<<-RUBY.strip_indent)
-        # -*- encoding : utf-8 -*-
-        def foo() 'ä' end
-      RUBY
-    end
-
-    it 'accepts vim-style encoding comments' do
-      expect_no_offenses(<<-RUBY.strip_indent)
-        # vim:filetype=ruby, fileencoding=utf-8
-        def foo() 'ä' end
-      RUBY
-    end
-
-    context 'auto-correct' do
-      it 'inserts an encoding comment on the first line when there are ' \
-         'non ASCII characters in the file' do
-        new_source = autocorrect_source(<<-RUBY.strip_indent)
-          def foo() 'ä' end
-        RUBY
-
-        expect(new_source).to eq(<<-RUBY.strip_indent)
-          # encoding: utf-8
-          def foo() 'ä' end
-        RUBY
-      end
-
-      it "removes encoding comment on first line when it's not needed" do
-        new_source = autocorrect_source(<<-RUBY.strip_indent)
-          # encoding: utf-8
-          blah
-        RUBY
-
-        expect(new_source).to eq(<<-RUBY.strip_indent)
-          blah
-        RUBY
-      end
-    end
+    expect(cop.offenses).to be_empty
   end
 
-  context 'always' do
-    let(:cop_config) do
-      { 'EnforcedStyle' => 'always' }
-    end
+  it 'registers no offense when encoding present but not UTF-8' do
+    inspect_source(<<-RUBY.strip_indent)
+      # encoding: us-ascii
+      def foo() end
+    RUBY
 
-    it 'registers an offense when no encoding present' do
-      expect_offense(<<-RUBY.strip_indent)
-        def foo() end
-        ^^^^^^^^^^^^^ Missing utf-8 encoding comment.
-      RUBY
-    end
-
-    it 'accepts an empty file' do
-      expect_no_offenses('')
-    end
-
-    it 'accepts encoding on first line' do
-      expect_no_offenses(<<-RUBY.strip_indent)
-        # encoding: utf-8
-        def foo() end
-      RUBY
-    end
-
-    it 'accepts encoding on second line when shebang present' do
-      expect_no_offenses(<<-RUBY.strip_indent)
-        #!/usr/bin/env ruby
-        # encoding: utf-8
-        def foo() end
-      RUBY
-    end
-
-    it 'books an offense when encoding is in the wrong place' do
-      expect_offense(<<-RUBY.strip_indent)
-        def foo() end
-        ^^^^^^^^^^^^^ Missing utf-8 encoding comment.
-        # encoding: utf-8
-      RUBY
-    end
-
-    it 'accepts encoding inserted by magic_encoding gem' do
-      expect_no_offenses(<<-RUBY.strip_indent)
-        # -*- encoding : utf-8 -*-
-        def foo() end
-      RUBY
-    end
-
-    it 'accepts vim-style encoding comments' do
-      expect_no_offenses(<<-RUBY.strip_indent)
-        # vim:filetype=ruby, fileencoding=utf-8
-        def foo() end
-      RUBY
-    end
-
-    context 'auto-correct' do
-      context 'valid auto correct encoding comment' do
-        it 'inserts an encoding comment on the first line of files without ' \
-           'a shebang' do
-          cop_config['AutoCorrectEncodingComment'] = '# encoding: utf-8'
-          new_source = autocorrect_source('def foo() end')
-
-          expect(new_source).to eq("# encoding: utf-8\ndef foo() end")
-        end
-
-        it 'inserts an encoding comment on the first line and leaves ' \
-           'the wrong encoding line when encoding is in the wrong place' do
-          cop_config['AutoCorrectEncodingComment'] = '# encoding: utf-8'
-          new_source = autocorrect_source(<<-RUBY.strip_indent)
-            def foo() end
-            # encoding: utf-8
-          RUBY
-
-          expect(new_source).to eq(<<-RUBY.strip_indent)
-            # encoding: utf-8
-            def foo() end
-            # encoding: utf-8
-          RUBY
-        end
-
-        it 'inserts an encoding comment on the second line when the first ' \
-           'line is a shebang' do
-          new_source = autocorrect_source(<<-RUBY.strip_indent)
-            #!/usr/bin/env ruby
-            def foo
-            end
-          RUBY
-
-          expect(new_source).to eq(<<-RUBY.strip_indent)
-            #!/usr/bin/env ruby
-            # encoding: utf-8
-            def foo
-            end
-          RUBY
-        end
-
-        it "doesn't infinite-loop when the first line is blank" do
-          new_source = autocorrect_source(<<-RUBY.strip_indent)
-
-            module Toto
-            end
-          RUBY
-          expect(new_source).to eq(<<-RUBY.strip_indent)
-            # encoding: utf-8
-
-            module Toto
-            end
-          RUBY
-        end
-      end
-
-      context 'invalid auto correct comment' do
-        it 'throws an exception' do
-          cop_config['AutoCorrectEncodingComment'] = 'invalid'
-          expect { autocorrect_source('def foo() end') }
-            .to raise_error(RuntimeError, 'invalid does not match ' \
-                          '(?-mix:#.*coding\s?[:=]\s?(?:UTF|utf)-8)')
-        end
-      end
-    end
+    expect(cop.offenses).to be_empty
   end
 
-  context 'never' do
-    let(:cop_config) do
-      { 'EnforcedStyle' => 'never' }
-    end
+  it 'registers an offense when encoding present and UTF-8' do
+    inspect_source(<<-RUBY.strip_indent)
+      # encoding: utf-8
+      def foo() end
+    RUBY
 
-    it 'registers no offense when no encoding present but only ASCII ' \
-       'characters' do
-      inspect_source('def foo() end')
+    expect(cop.offenses.size).to eq(1)
+    expect(cop.messages).to eq(
+      ['Unnecessary utf-8 encoding comment.']
+    )
+  end
 
-      expect(cop.offenses).to be_empty
-    end
+  it 'registers an offense when encoding present on 2nd line after shebang' do
+    inspect_source(<<-RUBY.strip_indent)
+      #!/usr/bin/env ruby
+      # encoding: utf-8
+      def foo() end
+    RUBY
 
-    it 'registers no offense when there is no encoding present but non ' \
-       'ASCII characters' do
-      inspect_source('def foo() \'ä\' end')
+    expect(cop.offenses.size).to eq(1)
+    expect(cop.messages).to eq(
+      ['Unnecessary utf-8 encoding comment.']
+    )
+  end
 
-      expect(cop.offenses).to be_empty
-    end
+  it 'registers an offense for vim-style encoding comments' do
+    inspect_source(<<-RUBY.strip_indent)
+      # vim:filetype=ruby, fileencoding=utf-8
+      def foo() end
+    RUBY
 
-    it 'registers an offense when encoding present but only ASCII ' \
-       'characters' do
-      inspect_source(<<-RUBY.strip_indent)
-        # encoding: utf-8
-        def foo() end
-      RUBY
+    expect(cop.offenses.size).to eq(1)
+    expect(cop.messages).to eq(
+      ['Unnecessary utf-8 encoding comment.']
+    )
+  end
 
-      expect(cop.offenses.size).to eq(1)
-      expect(cop.messages).to eq(
-        ['Unnecessary utf-8 encoding comment.']
-      )
-    end
+  it 'registers no offense when encoding is in the wrong place' do
+    inspect_source(<<-RUBY.strip_indent)
+      def foo() end
+      # encoding: utf-8
+    RUBY
 
-    context 'auto-correct' do
-      it 'removes encoding comment on first line when there are ' \
-         'non ASCII characters in the file' do
-        new_source = autocorrect_source('def foo() \'ä\' end')
+    expect(cop.offenses).to be_empty
+  end
 
-        expect(new_source).to eq('def foo() \'ä\' end')
-      end
+  it 'registers an offense for encoding inserted by magic_encoding gem' do
+    inspect_source(<<-RUBY.strip_indent)
+      # -*- encoding : utf-8 -*-
+      def foo() 'ä' end
+    RUBY
 
-      it "removes encoding comment on first line when it's not needed" do
-        new_source = autocorrect_source("# encoding: utf-8\nblah")
+    expect(cop.offenses.size).to eq(1)
+    expect(cop.messages).to eq(
+      ['Unnecessary utf-8 encoding comment.']
+    )
+  end
 
-        expect(new_source).to eq('blah')
-      end
+  context 'auto-correct' do
+    it 'removes encoding comment on first line' do
+      new_source = autocorrect_source("# encoding: utf-8\nblah")
+
+      expect(new_source).to eq('blah')
     end
   end
 end

--- a/spec/rubocop/cop/style/frozen_string_literal_comment_spec.rb
+++ b/spec/rubocop/cop/style/frozen_string_literal_comment_spec.rb
@@ -319,53 +319,51 @@ describe RuboCop::Cop::Style::FrozenStringLiteralComment, :config do
       end
     end
 
-    context 'ruby < 2.3' do
-      context 'target_ruby_version < 2.3', :ruby19 do
-        it 'accepts freezing a string' do
-          expect_no_offenses('"x".freeze')
-        end
-
-        it 'accepts calling << on a string' do
-          expect_no_offenses('"x" << "y"')
-        end
-
-        it 'accepts freezing a string with interpolation' do
-          expect_no_offenses('"#{foo}bar".freeze')
-        end
-
-        it 'accepts calling << on a string with interpolation' do
-          expect_no_offenses('"#{foo}bar" << "baz"')
-        end
+    context 'target_ruby_version < 2.3', :ruby22 do
+      it 'accepts freezing a string' do
+        expect_no_offenses('"x".freeze')
       end
 
-      context 'target_ruby_version 2.3+', :ruby23 do
-        it 'accepts freezing a string' do
-          expect_offense(<<-RUBY.strip_indent)
-            "x".freeze
-            ^ Missing magic comment `# frozen_string_literal: true`.
-          RUBY
-        end
+      it 'accepts calling << on a string' do
+        expect_no_offenses('"x" << "y"')
+      end
 
-        it 'accepts calling << on a string' do
-          expect_offense(<<-RUBY.strip_indent)
-            "x" << "y"
-            ^ Missing magic comment `# frozen_string_literal: true`.
-          RUBY
-        end
+      it 'accepts freezing a string with interpolation' do
+        expect_no_offenses('"#{foo}bar".freeze')
+      end
 
-        it 'accepts freezing a string with interpolation' do
-          expect_offense(<<-'RUBY'.strip_indent)
-            "#{foo}bar".freeze
-            ^ Missing magic comment `# frozen_string_literal: true`.
-          RUBY
-        end
+      it 'accepts calling << on a string with interpolation' do
+        expect_no_offenses('"#{foo}bar" << "baz"')
+      end
+    end
 
-        it 'accepts calling << on a string with interpolation' do
-          expect_offense(<<-'RUBY'.strip_indent)
-            "#{foo}bar" << "baz"
-            ^ Missing magic comment `# frozen_string_literal: true`.
-          RUBY
-        end
+    context 'target_ruby_version 2.3+', :ruby23 do
+      it 'accepts freezing a string' do
+        expect_offense(<<-RUBY.strip_indent)
+          "x".freeze
+          ^ Missing magic comment `# frozen_string_literal: true`.
+        RUBY
+      end
+
+      it 'accepts calling << on a string' do
+        expect_offense(<<-RUBY.strip_indent)
+          "x" << "y"
+          ^ Missing magic comment `# frozen_string_literal: true`.
+        RUBY
+      end
+
+      it 'accepts freezing a string with interpolation' do
+        expect_offense(<<-'RUBY'.strip_indent)
+          "#{foo}bar".freeze
+          ^ Missing magic comment `# frozen_string_literal: true`.
+        RUBY
+      end
+
+      it 'accepts calling << on a string with interpolation' do
+        expect_offense(<<-'RUBY'.strip_indent)
+          "#{foo}bar" << "baz"
+          ^ Missing magic comment `# frozen_string_literal: true`.
+        RUBY
       end
     end
   end

--- a/spec/rubocop/cop/style/optional_arguments_spec.rb
+++ b/spec/rubocop/cop/style/optional_arguments_spec.rb
@@ -72,7 +72,7 @@ describe RuboCop::Cop::Style::OptionalArguments do
   end
 
   context 'named params' do
-    context 'with default values', :ruby20 do
+    context 'with default values' do
       it 'allows optional arguments before an optional named argument' do
         expect_no_offenses(<<-RUBY.strip_indent)
           def foo(a = 1, b: 2)

--- a/spec/rubocop/cop/style/percent_literal_delimiters_spec.rb
+++ b/spec/rubocop/cop/style/percent_literal_delimiters_spec.rb
@@ -376,9 +376,6 @@ describe RuboCop::Cop::Style::PercentLiteralDelimiters, :config do
     it_behaves_like(:escape_characters, '%W')
     it_behaves_like(:escape_characters, '%x')
     it_behaves_like(:escape_characters, '%r')
-
-    context 'symbol array', :ruby20 do
-      it_behaves_like(:escape_characters, '%i')
-    end
+    it_behaves_like(:escape_characters, '%i')
   end
 end

--- a/spec/rubocop/cop/style/safe_navigation_spec.rb
+++ b/spec/rubocop/cop/style/safe_navigation_spec.rb
@@ -1004,7 +1004,7 @@ describe RuboCop::Cop::Style::SafeNavigation, :config do
     end
   end
 
-  context 'target_ruby_version < 2.3', :ruby19 do
+  context 'target_ruby_version < 2.3', :ruby22 do
     it 'allows a method call safeguarded by a check for the variable' do
       expect_no_offenses('foo.bar if foo')
     end

--- a/spec/rubocop/cop/style/symbol_array_spec.rb
+++ b/spec/rubocop/cop/style/symbol_array_spec.rb
@@ -102,12 +102,6 @@ describe RuboCop::Cop::Style::SymbolArray, :config do
       expect(cop.config_to_allow_offenses).to eq('Enabled' => false)
     end
 
-    context 'Ruby 1.9', :ruby19 do
-      it 'accepts arrays of smybols' do
-        expect_no_offenses('[:one, :two, :three]')
-      end
-    end
-
     context 'when PreferredDelimiters is specified' do
       let(:other_cops) do
         {


### PR DESCRIPTION
On #4787 I realized that there's two "policies" that rubocop needs to have. One for which rubies can run it, and another one for which rubies it can analyze... So it's not so simple.

I extracted this bit from #4787  that drops support for analyzing code that needs to support ruby 1.9. As a result, it turns out that I fixed #4776.

What do you think?
-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Used the same coding conventions as the rest of the project.
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [ ] Added tests.
* [x] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] All tests(`rake spec`) are passing.
* [x] The new code doesn't generate RuboCop offenses that are checked by `rake internal_investigation`.
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Updated cop documentation with `rake generate_cops_documentation` (required only when you've added a new cop or changed the configuration/documentation of an existing cop).

[1]: http://chris.beams.io/posts/git-commit/
