### PR TITLE
Add new `Rails/UnknownEnv` cop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,12 @@
 
 ## master (unreleased)
 
-## Bug fixes
+### New features
+
+* [#4791](https://github.com/bbatsov/rubocop/pull/4791): Add new `Rails/UnknownEnv` cop. ([@pocke][])
+
+### Bug fixes
+
 * [#3312](https://github.com/bbatsov/rubocop/issues/3312): Make `Rails/Date` Correct false positive on `#to_time` for strings ending in UTC-"Z".([@erikdstock][])
 * [#4741](https://github.com/bbatsov/rubocop/issues/4741): Make `Style/SafeNavigation` correctly exclude methods called without dot. ([@drenmi][])
 * [#4740](https://github.com/bbatsov/rubocop/issues/4740): Make `Lint/RescueWithoutErrorClass` aware of modifier form `rescue`. ([@drenmi][])

--- a/config/default.yml
+++ b/config/default.yml
@@ -1576,6 +1576,12 @@ Rails/UniqBeforePluck:
     - aggressive
   AutoCorrect: false
 
+Rails/UnknownEnv:
+  Environments:
+    - development
+    - test
+    - production
+
 Rails/SkipsModelValidations:
   Blacklist:
     - decrement!

--- a/config/enabled.yml
+++ b/config/enabled.yml
@@ -1780,6 +1780,10 @@ Rails/UniqBeforePluck:
   Description: 'Prefer the use of uniq or distinct before pluck.'
   Enabled: true
 
+Rails/UnknownEnv:
+  Description: 'Use correct environment name.'
+  Enabled: true
+
 Rails/SkipsModelValidations:
   Description: >-
                  Use methods that skips model validations with caution.

--- a/lib/rubocop.rb
+++ b/lib/rubocop.rb
@@ -503,6 +503,7 @@ require_relative 'rubocop/cop/rails/scope_args'
 require_relative 'rubocop/cop/rails/skips_model_validations'
 require_relative 'rubocop/cop/rails/time_zone'
 require_relative 'rubocop/cop/rails/uniq_before_pluck'
+require_relative 'rubocop/cop/rails/unknown_env'
 require_relative 'rubocop/cop/rails/validation'
 
 require_relative 'rubocop/cop/security/eval'

--- a/lib/rubocop/cop/rails/unknown_env.rb
+++ b/lib/rubocop/cop/rails/unknown_env.rb
@@ -1,0 +1,63 @@
+# frozen_string_literal: true
+
+module RuboCop
+  module Cop
+    module Rails
+      # This cop checks that environments called with `Rails.env` predicates
+      # exist.
+      #
+      # @example
+      #   # bad
+      #   Rails.env.proudction?
+      #
+      #   # good
+      #   Rails.env.production?
+      class UnknownEnv < Cop
+        include NameSimilarity
+
+        MSG = 'Unknown environment `%<name>s`.'.freeze
+        MSG_SIMILAR = 'Unknown environment `%<name>s`. ' \
+                      'Did you mean `%<similar>s`?'.freeze
+
+        def_node_matcher :unknown_environment?, <<-PATTERN
+          (send
+            (send
+              {(const nil :Rails) (const (cbase) :Rails)}
+              :env)
+            $#unknown_env_name?)
+        PATTERN
+
+        def on_send(node)
+          unknown_environment?(node) do |name|
+            add_offense(node, :selector, message(name))
+          end
+        end
+
+        private
+
+        def collect_variable_like_names(_scope)
+          environments.map { |env| env + '?' }
+        end
+
+        def message(name)
+          similar = find_similar_name(name.to_s, [])
+          if similar
+            format(MSG_SIMILAR, name: name, similar: similar)
+          else
+            format(MSG, name: name)
+          end
+        end
+
+        def unknown_env_name?(name)
+          name = name.to_s
+          name.end_with?('?') &&
+            !environments.include?(name[0..-2])
+        end
+
+        def environments
+          cop_config['Environments']
+        end
+      end
+    end
+  end
+end

--- a/manual/cops.md
+++ b/manual/cops.md
@@ -327,6 +327,7 @@ In the following section you find all available cops:
 * [Rails/SkipsModelValidations](cops_rails.md#railsskipsmodelvalidations)
 * [Rails/TimeZone](cops_rails.md#railstimezone)
 * [Rails/UniqBeforePluck](cops_rails.md#railsuniqbeforepluck)
+* [Rails/UnknownEnv](cops_rails.md#railsunknownenv)
 * [Rails/Validation](cops_rails.md#railsvalidation)
 
 #### Department [Security](cops_security.md)

--- a/manual/cops_rails.md
+++ b/manual/cops_rails.md
@@ -1213,6 +1213,31 @@ EnforcedStyle | conservative
 SupportedStyles | conservative, aggressive
 AutoCorrect | false
 
+## Rails/UnknownEnv
+
+Enabled by default | Supports autocorrection
+--- | ---
+Enabled | No
+
+This cop checks that environments called with `Rails.env` predicates
+exist.
+
+### Example
+
+```ruby
+# bad
+Rails.env.proudction?
+
+# good
+Rails.env.production?
+```
+
+### Important attributes
+
+Attribute | Value
+--- | ---
+Environments | development, test, production
+
 ## Rails/Validation
 
 Enabled by default | Supports autocorrection

--- a/spec/rubocop/cop/rails/unknown_env_spec.rb
+++ b/spec/rubocop/cop/rails/unknown_env_spec.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+describe RuboCop::Cop::Rails::UnknownEnv, :config do
+  let(:cop_config) do
+    {
+      'Environments' => %w[
+        development
+        production
+        test
+      ]
+    }
+  end
+  subject(:cop) { described_class.new(config) }
+
+  it 'registers an offense for typo of environment name' do
+    expect_offense(<<-RUBY)
+      Rails.env.proudction?
+                ^^^^^^^^^^^ Unknown environment `proudction?`. Did you mean `production?`?
+      Rails.env.developpment?
+                ^^^^^^^^^^^^^ Unknown environment `developpment?`. Did you mean `development?`?
+      Rails.env.something?
+                ^^^^^^^^^^ Unknown environment `something?`.
+    RUBY
+  end
+
+  it 'accepts correct environment name' do
+    expect_no_offenses(<<-RUBY)
+      Rails.env.production?
+    RUBY
+  end
+end


### PR DESCRIPTION
This cop checks typo of `Rails.env.foobar`.

For example:

```ruby
if Rails.env.proudction?
  #          ^^^^^^^^^^^ `proudction?` is incorrect environment name. Did you mean `production?`?
end
```

And, the incorrect environment name does not raise errors. It just return `false`.



-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Used the same coding conventions as the rest of the project.
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] All tests(`rake spec`) are passing.
* [x] The new code doesn't generate RuboCop offenses that are checked by `rake internal_investigation`.
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Updated cop documentation with `rake generate_cops_documentation` (required only when you've added a new cop or changed the configuration/documentation of an existing cop).

[1]: http://chris.beams.io/posts/git-commit/
