### PR TITLE
Add `rake parallel` task to execute default tasks in parallel

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -20,6 +20,9 @@ Dir['tasks/**/*.rake'].each { |t| load t }
 RSpec::Core::RakeTask.new(:spec) { |t| t.ruby_opts = '-E UTF-8' }
 RSpec::Core::RakeTask.new(:ascii_spec) { |t| t.ruby_opts = '-E ASCII' }
 
+desc 'Run test and RuboCop in parallel'
+task parallel: %i[parallel:spec parallel:ascii_spec internal_investigation]
+
 namespace :parallel do
   desc 'Run RSpec in parallel'
   task :spec do


### PR DESCRIPTION
We can run test(with/without ASCII encoding) and the internal investigation by a rake task.

```bash
$ rake default
$ rake # same
```

However, we need three tasks to execute these in parallel.

```bash
$ rake parallel:spec parallel:ascii_spec internal_investigation
```

I think it is very long. So I add a shorthand for these tasks by this change.

```bash
$ rake parallel
```


WDYT?