### PR TITLE
Avoid keyword_message_tail for nodes without keyword

### DIFF
--- a/lib/rubocop/cop/mixin/multiline_expression_indentation.rb
+++ b/lib/rubocop/cop/mixin/multiline_expression_indentation.rb
@@ -109,6 +109,7 @@ module RuboCop
       def kw_node_with_special_indentation(node)
         keyword_node =
           node.each_ancestor(*KEYWORD_ANCESTOR_TYPES).find do |ancestor|
+            next unless ancestor.loc.respond_to?(:keyword)
             within_node?(node, indented_keyword_expression(ancestor))
           end
 


### PR DESCRIPTION
Fix #4794 

This bug was introduced with e8a1b390f67b63ebf7a50fd4d79e4805f3bef4e9 when the `kw_node_with_special_indentation` method in `lib/rubocop/cop/mixin/multiline_expression_indentation.rb` was re-written. The important difference is that previously each ancestor was checked to ensure that it responded to the `keyword` method.