### PR TITLE
Favor specifying error class over disabling Lint/RescueWithoutErrorClass

### DIFF
--- a/lib/rubocop/cop/commissioner.rb
+++ b/lib/rubocop/cop/commissioner.rb
@@ -105,11 +105,9 @@ module RuboCop
       # Allow blind rescues here, since we're absorbing and packaging or
       # re-raising exceptions that can be raised from within the individual
       # cops' `#investigate` methods.
-      #
-      # rubocop:disable Lint/RescueWithoutErrorClass
       def with_cop_error_handling(cop, node = nil)
         yield
-      rescue => e
+      rescue StandardError => e
         raise e if @options[:raise_error]
         if node
           line = node.loc.line
@@ -118,7 +116,6 @@ module RuboCop
         error = CopError.new(e, line, column)
         @errors[cop] << error
       end
-      # rubocop:enable Lint/RescueWithoutErrorClass
     end
   end
 end


### PR DESCRIPTION
I believe that this cop tells us to be explicit when rescuing `StandardError` rather than just omitting error name. As it's author [said](https://github.com/bbatsov/rubocop/issues/2943#issuecomment-330498988):

> The difference is saying "I'm deliberately rescuing StandardError, just so you know" vs. saying "I might have no idea what I'm rescuing, or I might, you figure it out."

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Used the same coding conventions as the rest of the project.
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] All tests(`rake spec`) are passing.
* [x] The new code doesn't generate RuboCop offenses that are checked by `rake internal_investigation`.
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Updated cop documentation with `rake generate_cops_documentation` (required only when you've added a new cop or changed the configuration/documentation of an existing cop).

[1]: http://chris.beams.io/posts/git-commit/
