### PR TITLE
Changing an error when running `rake new_cop` task

### DIFF
--- a/lib/rubocop/cop/generator.rb
+++ b/lib/rubocop/cop/generator.rb
@@ -117,7 +117,10 @@ module RuboCop
       attr_reader :badge
 
       def write_unless_file_exists(path, contents)
-        raise "#{path} already exists!" if File.exist?(path)
+        if File.exist?(path)
+          $stderr.puts "rake new_cop: #{path} already exists!"
+          exit!
+        end
 
         dir = File.dirname(path)
         FileUtils.mkdir_p(dir) unless File.exist?(dir)

--- a/lib/rubocop/cop/generator.rb
+++ b/lib/rubocop/cop/generator.rb
@@ -118,7 +118,7 @@ module RuboCop
 
       def write_unless_file_exists(path, contents)
         if File.exist?(path)
-          $stderr.puts "rake new_cop: #{path} already exists!"
+          warn "rake new_cop: #{path} already exists!"
           exit!
         end
 

--- a/spec/rubocop/cop/generator_spec.rb
+++ b/spec/rubocop/cop/generator_spec.rb
@@ -64,8 +64,11 @@ RSpec.describe RuboCop::Cop::Generator do
     it 'refuses to overwrite existing files' do
       new_cop = described_class.new('Layout/Tab')
 
+      expect(new_cop).to receive(:exit!)
       expect { new_cop.write_source }
-        .to raise_error('lib/rubocop/cop/layout/tab.rb already exists!')
+        .to output(
+          "rake new_cop: lib/rubocop/cop/layout/tab.rb already exists!\n"
+        ).to_stderr
     end
   end
 
@@ -106,8 +109,11 @@ RSpec.describe RuboCop::Cop::Generator do
     it 'refuses to overwrite existing files' do
       new_cop = described_class.new('Layout/Tab')
 
+      expect(new_cop).to receive(:exit!)
       expect { new_cop.write_spec }
-        .to raise_error('spec/rubocop/cop/layout/tab_spec.rb already exists!')
+        .to output(
+          "rake new_cop: spec/rubocop/cop/layout/tab_spec.rb already exists!\n"
+        ).to_stderr
     end
   end
 


### PR DESCRIPTION
This PR will changing an error when running `rake new_cop` task.

## Before

```console
% bundle exec rake new_cop[Style/SafeNavigation]
rake aborted!
lib/rubocop/cop/style/safe_navigation.rb already exists!
    /Users/koic/src/github.com/bbatsov/rubocop/lib/rubocop/cop/generator.rb:120:in `write_unless_file_exists'
    /Users/koic/src/github.com/bbatsov/rubocop/lib/rubocop/cop/generator.rb:88:in `write_source'
tasks/new_cop.rake:13:in `block in <top (required)>'
/Users/koic/.rbenv/versions/2.4.2/bin/bundle:23:in `load'
/Users/koic/.rbenv/versions/2.4.2/bin/bundle:23:in `<main>'
Tasks: TOP => new_cop
(See full trace by running task with --trace)
```

## After

```console
% bundle exec rake new_cop[Style/SafeNavigation]
rake new_cop: lib/rubocop/cop/style/safe_navigation.rb already exists!
```

My suggestion is to simply print only useful error message and exit with a non-zero status. Therefore, it does not print backtrace that is not important here.

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Used the same coding conventions as the rest of the project.
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [ ] Added tests.
* [ ] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] All tests(`rake spec`) are passing.
* [x] The new code doesn't generate RuboCop offenses that are checked by `rake internal_investigation`.
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [ ] Updated cop documentation with `rake generate_cops_documentation` (required only when you've added a new cop or changed the configuration/documentation of an existing cop).

[1]: http://chris.beams.io/posts/git-commit/
