### PR TITLE
Prevent `Rails/Blank` from breaking on send with an argument

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@
 * [#4737](https://github.com/bbatsov/rubocop/issues/4737): Fix ReturnInVoidContext cop when `return` is in top scope. ([@frodsan][])
 * [#4776](https://github.com/bbatsov/rubocop/issues/4776): Non utf-8 magic encoding comments are now respected. ([@deivid-rodriguez][])
 * [#4241](https://github.com/bbatsov/rubocop/issues/4241): Prevent `Rails/Blank` and `Rails/Present` from breaking when there is no explicit receiver. ([@rrosenblum][])
+* [#4814](https://github.com/bbatsov/rubocop/issues/4814): Prevent `Rails/Blank` from breaking on send with an argument. ([@pocke][])
 
 ### Changes
 

--- a/lib/rubocop/ast/node.rb
+++ b/lib/rubocop/ast/node.rb
@@ -285,8 +285,8 @@ module RuboCop
       def_node_matcher :defined_module0, <<-PATTERN
         {(class (const $_ $_) ...)
          (module (const $_ $_) ...)
-         (casgn $_ $_        (send (const nil {:Class :Module}) :new ...))
-         (casgn $_ $_ (block (send (const nil {:Class :Module}) :new ...) ...))}
+         (casgn $_ $_        (send (const nil? {:Class :Module}) :new ...))
+         (casgn $_ $_ (block (send (const nil? {:Class :Module}) :new ...) ...))}
       PATTERN
       private :defined_module0
 
@@ -439,21 +439,21 @@ module RuboCop
       end
 
       def_node_matcher :guard_clause?, <<-PATTERN
-        [{(send nil {:raise :fail} ...) return break next} single_line?]
+        [{(send nil? {:raise :fail} ...) return break next} single_line?]
       PATTERN
 
       def_node_matcher :proc?, <<-PATTERN
-        {(block (send nil :proc) ...)
-         (block (send (const nil :Proc) :new) ...)
-         (send (const nil :Proc) :new)}
+        {(block (send nil? :proc) ...)
+         (block (send (const nil? :Proc) :new) ...)
+         (send (const nil? :Proc) :new)}
       PATTERN
 
-      def_node_matcher :lambda?, '(block (send nil :lambda) ...)'
+      def_node_matcher :lambda?, '(block (send nil? :lambda) ...)'
       def_node_matcher :lambda_or_proc?, '{lambda? proc?}'
 
       def_node_matcher :class_constructor?, <<-PATTERN
-        {       (send (const nil {:Class :Module}) :new ...)
-         (block (send (const nil {:Class :Module}) :new ...) ...)}
+        {       (send (const nil? {:Class :Module}) :new ...)
+         (block (send (const nil? {:Class :Module}) :new ...) ...)}
       PATTERN
 
       def_node_matcher :module_definition?, <<-PATTERN

--- a/lib/rubocop/ast/node/mixin/method_dispatch_node.rb
+++ b/lib/rubocop/ast/node/mixin/method_dispatch_node.rb
@@ -163,11 +163,11 @@ module RuboCop
       end
 
       def_node_matcher :adjacent_def_modifier?, <<-PATTERN
-        (send nil _ ({def defs} ...))
+        (send nil? _ ({def defs} ...))
       PATTERN
 
       def_node_matcher :bare_access_modifier?, <<-PATTERN
-        (send nil {:public :protected :private :module_function})
+        (send nil? {:public :protected :private :module_function})
       PATTERN
     end
   end

--- a/lib/rubocop/cop/bundler/duplicated_gem.rb
+++ b/lib/rubocop/cop/bundler/duplicated_gem.rb
@@ -45,7 +45,7 @@ module RuboCop
 
         private
 
-        def_node_search :gem_declarations, '(send nil :gem str ...)'
+        def_node_search :gem_declarations, '(send nil? :gem str ...)'
 
         def duplicated_gem_nodes
           gem_declarations(processed_source.ast)

--- a/lib/rubocop/cop/bundler/insecure_protocol_source.rb
+++ b/lib/rubocop/cop/bundler/insecure_protocol_source.rb
@@ -31,7 +31,7 @@ module RuboCop
               "if possible, or 'http://rubygems.org' if not.".freeze
 
         def_node_matcher :insecure_protocol_source?, <<-PATTERN
-          (send nil :source
+          (send nil? :source
             (sym ${:gemcutter :rubygems :rubyforge}))
         PATTERN
 

--- a/lib/rubocop/cop/bundler/ordered_gems.rb
+++ b/lib/rubocop/cop/bundler/ordered_gems.rb
@@ -105,7 +105,7 @@ module RuboCop
         end
 
         def_node_search :gem_declarations, <<-PATTERN
-          (:send nil :gem ...)
+          (:send nil? :gem ...)
         PATTERN
       end
     end

--- a/lib/rubocop/cop/internal_affairs/offense_location_keyword.rb
+++ b/lib/rubocop/cop/internal_affairs/offense_location_keyword.rb
@@ -26,7 +26,7 @@ module RuboCop
         private
 
         def_node_matcher :offense_location, <<-PATTERN
-          (send nil :add_offense _offender
+          (send nil? :add_offense _offender
             $(send (send _offender :loc) $_) ...)
         PATTERN
 

--- a/lib/rubocop/cop/internal_affairs/redundant_location_argument.rb
+++ b/lib/rubocop/cop/internal_affairs/redundant_location_argument.rb
@@ -21,7 +21,7 @@ module RuboCop
         MSG = 'Redundant location argument to `#add_offense`.'.freeze
 
         def_node_matcher :node_type_check, <<-PATTERN
-          (send nil :add_offense _ (sym :expression))
+          (send nil? :add_offense _ (sym :expression))
         PATTERN
 
         def on_send(node)

--- a/lib/rubocop/cop/internal_affairs/redundant_message_argument.rb
+++ b/lib/rubocop/cop/internal_affairs/redundant_message_argument.rb
@@ -23,8 +23,8 @@ module RuboCop
         MSG = 'Redundant message argument to `#add_offense`.'.freeze
 
         def_node_matcher :node_type_check, <<-PATTERN
-          (send nil :add_offense _offender _
-            {(const nil :MSG) (send nil :message) (send nil :message _offender)})
+          (send nil? :add_offense _offender _
+            {(const nil? :MSG) (send nil? :message) (send nil? :message _offender)})
         PATTERN
 
         def on_send(node)

--- a/lib/rubocop/cop/internal_affairs/useless_message_assertion.rb
+++ b/lib/rubocop/cop/internal_affairs/useless_message_assertion.rb
@@ -17,11 +17,11 @@ module RuboCop
         MSG = 'Do not specify cop behavior using `described_class::MSG`.'.freeze
 
         def_node_search :described_class_msg, <<-PATTERN
-          (const (send nil :described_class) :MSG)
+          (const (send nil? :described_class) :MSG)
         PATTERN
 
         def_node_matcher :rspec_expectation_on_msg?, <<-PATTERN
-          (send (send nil :expect #contains_described_class_msg?) :to ...)
+          (send (send nil? :expect #contains_described_class_msg?) :to ...)
         PATTERN
 
         def investigate(_processed_source)

--- a/lib/rubocop/cop/lint/debugger.rb
+++ b/lib/rubocop/cop/lint/debugger.rb
@@ -37,26 +37,26 @@ module RuboCop
 
         def_node_matcher :kernel?, <<-PATTERN
           {
-            (const nil :Kernel)
+            (const nil? :Kernel)
             (const (cbase) :Kernel)
           }
         PATTERN
 
         def_node_matcher :debugger_call?, <<-PATTERN
-          {(send {nil #kernel?} {:debugger :byebug} ...)
-           (send (send {#kernel? nil} :binding)
+          {(send {nil? #kernel?} {:debugger :byebug} ...)
+           (send (send {#kernel? nil?} :binding)
              {:pry :remote_pry :pry_remote} ...)
-           (send (const {nil (cbase)} :Pry) :rescue ...)
-           (send nil {:save_and_open_page
+           (send (const {nil? (cbase)} :Pry) :rescue ...)
+           (send nil? {:save_and_open_page
                       :save_and_open_screenshot
                       :save_screenshot} ...)}
         PATTERN
 
         def_node_matcher :binding_irb_call?, <<-PATTERN
-          (send (send {#kernel? nil} :binding) :irb ...)
+          (send (send {#kernel? nil?} :binding) :irb ...)
         PATTERN
 
-        def_node_matcher :pry_rescue?, '(send (const nil :Pry) :rescue ...)'
+        def_node_matcher :pry_rescue?, '(send (const nil? :Pry) :rescue ...)'
 
         def on_send(node)
           return unless debugger_call?(node) || binding_irb?(node)

--- a/lib/rubocop/cop/lint/duplicate_methods.rb
+++ b/lib/rubocop/cop/lint/duplicate_methods.rb
@@ -83,11 +83,11 @@ module RuboCop
         end
 
         def_node_matcher :alias_method?, <<-PATTERN
-          (send nil :alias_method (sym $_name) _)
+          (send nil? :alias_method (sym $_name) _)
         PATTERN
 
         def_node_matcher :attr?, <<-PATTERN
-          (send nil ${:attr_reader :attr_writer :attr_accessor :attr} $...)
+          (send nil? ${:attr_reader :attr_writer :attr_accessor :attr} $...)
         PATTERN
 
         def_node_matcher :sym_name, '(sym $_name)'

--- a/lib/rubocop/cop/lint/ineffective_access_modifier.rb
+++ b/lib/rubocop/cop/lint/ineffective_access_modifier.rb
@@ -54,7 +54,7 @@ module RuboCop
                                 'block'.freeze
 
         def_node_matcher :private_class_method, <<-PATTERN
-          (send nil :private_class_method $...)
+          (send nil? :private_class_method $...)
         PATTERN
 
         def on_class(node)

--- a/lib/rubocop/cop/lint/nested_method_definition.rb
+++ b/lib/rubocop/cop/lint/nested_method_definition.rb
@@ -95,7 +95,7 @@ module RuboCop
         PATTERN
 
         def_node_matcher :class_or_module_or_struct_new_call?, <<-PATTERN
-          (block (send (const nil {:Class :Module :Struct}) :new ...) ...)
+          (block (send (const nil? {:Class :Module :Struct}) :new ...) ...)
         PATTERN
       end
     end

--- a/lib/rubocop/cop/lint/non_local_exit_from_iterator.rb
+++ b/lib/rubocop/cop/lint/non_local_exit_from_iterator.rb
@@ -75,7 +75,7 @@ module RuboCop
           !return_node.children.empty?
         end
 
-        def_node_matcher :chained_send?, '(send !nil ...)'
+        def_node_matcher :chained_send?, '(send !nil? ...)'
         def_node_matcher :define_method?, <<-PATTERN
           (send _ {:define_method :define_singleton_method} _)
         PATTERN

--- a/lib/rubocop/cop/lint/rand_one.rb
+++ b/lib/rubocop/cop/lint/rand_one.rb
@@ -25,7 +25,7 @@ module RuboCop
               'Perhaps you meant `rand(2)` or `rand`?'.freeze
 
         def_node_matcher :rand_one?, <<-PATTERN
-          (send {(const nil :Kernel) nil} :rand {(int {-1 1}) (float {-1.0 1.0})})
+          (send {(const nil? :Kernel) nil?} :rand {(int {-1 1}) (float {-1.0 1.0})})
         PATTERN
 
         def on_send(node)

--- a/lib/rubocop/cop/lint/rescue_without_error_class.rb
+++ b/lib/rubocop/cop/lint/rescue_without_error_class.rb
@@ -26,7 +26,7 @@ module RuboCop
         MSG = 'Avoid rescuing without specifying an error class.'.freeze
 
         def_node_matcher :rescue_without_error_class?, <<-PATTERN
-          (resbody nil _ _)
+          (resbody nil? _ _)
         PATTERN
 
         def on_resbody(node)

--- a/lib/rubocop/cop/lint/unified_integer.rb
+++ b/lib/rubocop/cop/lint/unified_integer.rb
@@ -21,7 +21,7 @@ module RuboCop
         MSG = 'Use `Integer` instead of `%s`.'.freeze
 
         def_node_matcher :fixnum_or_bignum_const, <<-PATTERN
-          (:const {nil (:cbase)} ${:Fixnum :Bignum})
+          (:const {nil? (:cbase)} ${:Fixnum :Bignum})
         PATTERN
 
         def on_const(node)

--- a/lib/rubocop/cop/lint/unneeded_splat_expansion.rb
+++ b/lib/rubocop/cop/lint/unneeded_splat_expansion.rb
@@ -56,7 +56,7 @@ module RuboCop
         PERCENT_CAPITAL_W = '%W'.freeze
         PERCENT_I = '%i'.freeze
         PERCENT_CAPITAL_I = '%I'.freeze
-        ARRAY_NEW_PATTERN = '$(send (const nil :Array) :new ...)'.freeze
+        ARRAY_NEW_PATTERN = '$(send (const nil? :Array) :new ...)'.freeze
         ASSIGNMENT_TYPES = %i[lvasgn ivasgn cvasgn gvasgn].freeze
 
         def_node_matcher :literal_expansion?, <<-PATTERN

--- a/lib/rubocop/cop/lint/unreachable_code.rb
+++ b/lib/rubocop/cop/lint/unreachable_code.rb
@@ -55,7 +55,7 @@ module RuboCop
           {
             return next break retry redo
             (send
-             {nil (const {nil cbase} :Kernel)}
+             {nil? (const {nil? cbase} :Kernel)}
              {:raise :fail :throw}
              ...)
           }

--- a/lib/rubocop/cop/lint/uri_escape_unescape.rb
+++ b/lib/rubocop/cop/lint/uri_escape_unescape.rb
@@ -45,7 +45,7 @@ module RuboCop
 
         def_node_matcher :uri_escape_unescape?, <<-PATTERN
           (send
-            (const ${nil cbase} :URI) ${:escape :encode :unescape :decode}
+            (const ${nil? cbase} :URI) ${:escape :encode :unescape :decode}
             ...)
         PATTERN
 

--- a/lib/rubocop/cop/lint/uri_regexp.rb
+++ b/lib/rubocop/cop/lint/uri_regexp.rb
@@ -20,13 +20,13 @@ module RuboCop
 
         def_node_matcher :uri_regexp_with_argument?, <<-PATTERN
           (send
-            (const ${nil cbase} :URI) :regexp
+            (const ${nil? cbase} :URI) :regexp
             (str $_))
         PATTERN
 
         def_node_matcher :uri_regexp_without_argument?, <<-PATTERN
           (send
-            (const ${nil cbase} :URI) :regexp)
+            (const ${nil? cbase} :URI) :regexp)
         PATTERN
 
         def on_send(node)

--- a/lib/rubocop/cop/lint/useless_access_modifier.rb
+++ b/lib/rubocop/cop/lint/useless_access_modifier.rb
@@ -114,11 +114,11 @@ module RuboCop
         private
 
         def_node_matcher :static_method_definition?, <<-PATTERN
-          {def (send nil {:attr :attr_reader :attr_writer :attr_accessor} ...)}
+          {def (send nil? {:attr :attr_reader :attr_writer :attr_accessor} ...)}
         PATTERN
 
         def_node_matcher :dynamic_method_definition?, <<-PATTERN
-          {(send nil :define_method ...) (block (send nil :define_method ...) ...)}
+          {(send nil? :define_method ...) (block (send nil? :define_method ...) ...)}
         PATTERN
 
         def_node_matcher :class_or_instance_eval?, <<-PATTERN
@@ -126,7 +126,7 @@ module RuboCop
         PATTERN
 
         def_node_matcher :class_or_module_or_struct_new_call?, <<-PATTERN
-          (block (send (const nil {:Class :Module :Struct}) :new ...) ...)
+          (block (send (const nil? {:Class :Module :Struct}) :new ...) ...)
         PATTERN
 
         def check_node(node)
@@ -188,7 +188,7 @@ module RuboCop
             matcher_name = "#{m}_method?".to_sym
             unless respond_to?(matcher_name)
               self.class.def_node_matcher matcher_name, <<-PATTERN
-                {def (send nil :#{m} ...)}
+                {def (send nil? :#{m} ...)}
               PATTERN
             end
 
@@ -212,7 +212,7 @@ module RuboCop
             matcher_name = "#{m}_block?".to_sym
             unless respond_to?(matcher_name)
               self.class.def_node_matcher matcher_name, <<-PATTERN
-                (block (send {nil const} {:#{m}} ...) ...)
+                (block (send {nil? const} {:#{m}} ...) ...)
               PATTERN
             end
 

--- a/lib/rubocop/cop/mixin/def_node.rb
+++ b/lib/rubocop/cop/mixin/def_node.rb
@@ -20,7 +20,7 @@ module RuboCop
       end
 
       def_node_matcher :non_public_modifier?, <<-PATTERN
-        (send nil {:private :protected} ({def defs} ...))
+        (send nil? {:private :protected} ({def defs} ...))
       PATTERN
     end
   end

--- a/lib/rubocop/cop/mixin/enforce_superclass.rb
+++ b/lib/rubocop/cop/mixin/enforce_superclass.rb
@@ -10,7 +10,7 @@ module RuboCop
         PATTERN
 
         base.def_node_matcher :class_new_definition, <<-PATTERN
-        [!^(casgn nil :#{base::SUPERCLASS} ...) (send (const nil :Class) :new #{base::BASE_PATTERN})]
+        [!^(casgn nil? :#{base::SUPERCLASS} ...) (send (const nil? :Class) :new #{base::BASE_PATTERN})]
         PATTERN
       end
 

--- a/lib/rubocop/cop/performance/caller.rb
+++ b/lib/rubocop/cop/performance/caller.rb
@@ -26,8 +26,8 @@ module RuboCop
 
         def_node_matcher :slow_caller?, <<-PATTERN
           {
-            (send nil {:caller :caller_locations})
-            (send nil {:caller :caller_locations} int)
+            (send nil? {:caller :caller_locations})
+            (send nil? {:caller :caller_locations} int)
           }
         PATTERN
 

--- a/lib/rubocop/cop/performance/end_with.rb
+++ b/lib/rubocop/cop/performance/end_with.rb
@@ -19,7 +19,7 @@ module RuboCop
         SINGLE_QUOTE = "'".freeze
 
         def_node_matcher :redundant_regex?, <<-PATTERN
-          {(send $!nil {:match :=~} (regexp (str $#literal_at_end?) (regopt)))
+          {(send $!nil? {:match :=~} (regexp (str $#literal_at_end?) (regopt)))
            (send (regexp (str $#literal_at_end?) (regopt)) {:match :=~} $_)}
         PATTERN
 

--- a/lib/rubocop/cop/performance/redundant_match.rb
+++ b/lib/rubocop/cop/performance/redundant_match.rb
@@ -24,7 +24,7 @@ module RuboCop
         # a string or regexp literal on one side or the other
         def_node_matcher :match_call?, <<-PATTERN
           {(send {str regexp} :match _)
-           (send !nil :match {str regexp})}
+           (send !nil? :match {str regexp})}
         PATTERN
 
         def_node_matcher :only_truthiness_matters?, <<-PATTERN

--- a/lib/rubocop/cop/performance/redundant_merge.rb
+++ b/lib/rubocop/cop/performance/redundant_merge.rb
@@ -15,7 +15,7 @@ module RuboCop
         MSG = 'Use `%s` instead of `%s`.'.freeze
 
         def_node_matcher :redundant_merge_candidate, <<-PATTERN
-          (send $!nil :merge! [(hash $...) !kwsplat_type?])
+          (send $!nil? :merge! [(hash $...) !kwsplat_type?])
         PATTERN
 
         def_node_matcher :modifier_flow_control?, <<-PATTERN

--- a/lib/rubocop/cop/performance/regexp_match.rb
+++ b/lib/rubocop/cop/performance/regexp_match.rb
@@ -74,11 +74,11 @@ module RuboCop
         PATTERN
 
         def_node_matcher :match_operator?, <<-PATTERN
-          (send !nil :=~ !nil)
+          (send !nil? :=~ !nil?)
         PATTERN
 
         def_node_matcher :match_threequals?, <<-PATTERN
-          (send (regexp (str _) {(regopt) (regopt _)}) :=== !nil)
+          (send (regexp (str _) {(regopt) (regopt _)}) :=== !nil?)
         PATTERN
 
         def match_with_lvasgn?(node)
@@ -101,8 +101,8 @@ module RuboCop
 
         def_node_search :last_matches, <<-PATTERN
           {
-            (send (const nil :Regexp) :last_match)
-            (send (const nil :Regexp) :last_match _)
+            (send (const nil? :Regexp) :last_match)
+            (send (const nil? :Regexp) :last_match _)
             ({back_ref nth_ref} _)
             (gvar #match_gvar?)
           }

--- a/lib/rubocop/cop/performance/start_with.rb
+++ b/lib/rubocop/cop/performance/start_with.rb
@@ -19,7 +19,7 @@ module RuboCop
         SINGLE_QUOTE = "'".freeze
 
         def_node_matcher :redundant_regex?, <<-PATTERN
-          {(send $!nil {:match :=~} (regexp (str $#literal_at_start?) (regopt)))
+          {(send $!nil? {:match :=~} (regexp (str $#literal_at_start?) (regopt)))
            (send (regexp (str $#literal_at_start?) (regopt)) {:match :=~} $_)}
         PATTERN
 

--- a/lib/rubocop/cop/performance/string_replacement.rb
+++ b/lib/rubocop/cop/performance/string_replacement.rb
@@ -28,7 +28,7 @@ module RuboCop
 
         def_node_matcher :string_replacement?, <<-PATTERN
           (send _ {:gsub :gsub!}
-                    ${regexp str (send (const nil :Regexp) {:new :compile} _)}
+                    ${regexp str (send (const nil? :Regexp) {:new :compile} _)}
                     $str)
         PATTERN
 

--- a/lib/rubocop/cop/performance/times_map.rb
+++ b/lib/rubocop/cop/performance/times_map.rb
@@ -51,8 +51,8 @@ module RuboCop
         end
 
         def_node_matcher :times_map_call, <<-PATTERN
-          {(block $(send (send $!nil :times) {:map :collect}) ...)
-           $(send (send $!nil :times) {:map :collect} (block_pass ...))}
+          {(block $(send (send $!nil? :times) {:map :collect}) ...)
+           $(send (send $!nil? :times) {:map :collect} (block_pass ...))}
         PATTERN
 
         def autocorrect(node)

--- a/lib/rubocop/cop/performance/unfreeze_string.rb
+++ b/lib/rubocop/cop/performance/unfreeze_string.rb
@@ -36,8 +36,8 @@ module RuboCop
 
         def_node_matcher :string_new?, <<-PATTERN
           {
-            (send (const nil :String) :new {str dstr})
-            (send (const nil :String) :new)
+            (send (const nil? :String) :new {str dstr})
+            (send (const nil? :String) :new)
           }
         PATTERN
 

--- a/lib/rubocop/cop/performance/uri_default_parser.rb
+++ b/lib/rubocop/cop/performance/uri_default_parser.rb
@@ -20,7 +20,7 @@ module RuboCop
         def_node_matcher :uri_parser_new?, <<-PATTERN
           (send
             (const
-              (const ${nil cbase} :URI) :Parser) :new)
+              (const ${nil? cbase} :URI) :Parser) :new)
         PATTERN
 
         def on_send(node)

--- a/lib/rubocop/cop/rails/application_job.rb
+++ b/lib/rubocop/cop/rails/application_job.rb
@@ -23,7 +23,7 @@ module RuboCop
 
         MSG = 'Jobs should subclass `ApplicationJob`.'.freeze
         SUPERCLASS = 'ApplicationJob'.freeze
-        BASE_PATTERN = '(const (const nil :ActiveJob) :Base)'.freeze
+        BASE_PATTERN = '(const (const nil? :ActiveJob) :Base)'.freeze
 
         include RuboCop::Cop::EnforceSuperclass
       end

--- a/lib/rubocop/cop/rails/application_record.rb
+++ b/lib/rubocop/cop/rails/application_record.rb
@@ -23,7 +23,7 @@ module RuboCop
 
         MSG = 'Models should subclass `ApplicationRecord`.'.freeze
         SUPERCLASS = 'ApplicationRecord'.freeze
-        BASE_PATTERN = '(const (const nil :ActiveRecord) :Base)'.freeze
+        BASE_PATTERN = '(const (const nil? :ActiveRecord) :Base)'.freeze
 
         include RuboCop::Cop::EnforceSuperclass
       end

--- a/lib/rubocop/cop/rails/blank.rb
+++ b/lib/rubocop/cop/rails/blank.rb
@@ -42,18 +42,13 @@ module RuboCop
         MSG_NOT_PRESENT = 'Use `%s` instead of `%s`.'.freeze
         MSG_UNLESS_PRESENT = 'Use `if %s` instead of `%s`.'.freeze
 
-        # `(send nil $_)` is not actually a valid match for an offense. Nodes
-        # that have a single method call on the left hand side
-        # (`bar || foo.empty?`) will blow up when checking
-        # `(send (:nil) :== $_)`.
         def_node_matcher :nil_or_empty?, <<-PATTERN
           (or
               {
                 (send $_ :!)
                 (send $_ :nil?)
-                (send $_ :== (:nil))
-                (send nil $_)
-                (send (:nil) :== $_)
+                (send $_ :== nil)
+                (send nil :== $_)
               }
               {
                 (send $_ :empty?)
@@ -65,7 +60,7 @@ module RuboCop
         def_node_matcher :not_present?, '(send (send $_ :present?) :!)'
 
         def_node_matcher :unless_present?, <<-PATTERN
-          (:if $(send $_ :present?) {nil (...)} ...)
+          (:if $(send $_ :present?) {nil? (...)} ...)
         PATTERN
 
         def on_send(node)

--- a/lib/rubocop/cop/rails/delegate_allow_blank.rb
+++ b/lib/rubocop/cop/rails/delegate_allow_blank.rb
@@ -17,7 +17,7 @@ module RuboCop
         MSG = '`allow_blank` is not a valid option, use `allow_nil`.'.freeze
 
         def_node_matcher :delegate_options, <<-PATTERN
-          (send nil :delegate _ $hash)
+          (send nil? :delegate _ $hash)
         PATTERN
 
         def_node_matcher :allow_blank_option?, <<-PATTERN

--- a/lib/rubocop/cop/rails/enum_uniqueness.rb
+++ b/lib/rubocop/cop/rails/enum_uniqueness.rb
@@ -23,7 +23,7 @@ module RuboCop
         MSG = 'Duplicate value `%s` found in `%s` enum declaration.'.freeze
 
         def_node_matcher :enum_declaration, <<-PATTERN
-          (send nil :enum (hash (pair (_ $_) ${array hash})))
+          (send nil? :enum (hash (pair (_ $_) ${array hash})))
         PATTERN
 
         def on_send(node)

--- a/lib/rubocop/cop/rails/file_path.rb
+++ b/lib/rubocop/cop/rails/file_path.rb
@@ -18,15 +18,15 @@ module RuboCop
         MSG = 'Please use `Rails.root.join(\'path\', \'to\')` instead.'.freeze
 
         def_node_matcher :file_join_nodes?, <<-PATTERN
-          (send (const nil :File) :join ...)
+          (send (const nil? :File) :join ...)
         PATTERN
 
         def_node_search :rails_root_nodes?, <<-PATTERN
-          (send (const nil :Rails) :root)
+          (send (const nil? :Rails) :root)
         PATTERN
 
         def_node_matcher :rails_root_join_nodes?, <<-PATTERN
-          (send (send (const nil :Rails) :root) :join ...)
+          (send (send (const nil? :Rails) :root) :join ...)
         PATTERN
 
         def on_dstr(node)

--- a/lib/rubocop/cop/rails/has_many_or_has_one_dependent.rb
+++ b/lib/rubocop/cop/rails/has_many_or_has_one_dependent.rb
@@ -24,19 +24,19 @@ module RuboCop
         MSG = 'Specify a `:dependent` option.'.freeze
 
         def_node_matcher :is_has_many_or_has_one_without_options?, <<-PATTERN
-          (send nil {:has_many :has_one} _)
+          (send nil? {:has_many :has_one} _)
         PATTERN
 
         def_node_matcher :is_has_many_or_has_one_with_options?, <<-PATTERN
-          (send nil {:has_many :has_one} _ (hash $...))
+          (send nil? {:has_many :has_one} _ (hash $...))
         PATTERN
 
         def_node_matcher :has_dependent?, <<-PATTERN
-          (pair (sym :dependent) !(:nil))
+          (pair (sym :dependent) !nil)
         PATTERN
 
         def_node_matcher :has_through?, <<-PATTERN
-          (pair (sym :through) !(:nil))
+          (pair (sym :through) !nil)
         PATTERN
 
         def on_send(node)

--- a/lib/rubocop/cop/rails/http_positional_arguments.rb
+++ b/lib/rubocop/cop/rails/http_positional_arguments.rb
@@ -29,7 +29,7 @@ module RuboCop
         minimum_target_rails_version 5.0
 
         def_node_matcher :http_request?, <<-PATTERN
-          (send nil {#{HTTP_METHODS.map(&:inspect).join(' ')}} !nil $_data ...)
+          (send nil? {#{HTTP_METHODS.map(&:inspect).join(' ')}} !nil? $_data ...)
         PATTERN
 
         def on_send(node)

--- a/lib/rubocop/cop/rails/not_null_column.rb
+++ b/lib/rubocop/cop/rails/not_null_column.rb
@@ -20,11 +20,11 @@ module RuboCop
         MSG = 'Do not add a NOT NULL column without a default value.'.freeze
 
         def_node_matcher :add_not_null_column?, <<-PATTERN
-          (send nil :add_column _ _ _ (hash $...))
+          (send nil? :add_column _ _ _ (hash $...))
         PATTERN
 
         def_node_matcher :add_not_null_reference?, <<-PATTERN
-          (send nil :add_reference _ _ (hash $...))
+          (send nil? :add_reference _ _ (hash $...))
         PATTERN
 
         def_node_matcher :null_false?, <<-PATTERN
@@ -32,7 +32,7 @@ module RuboCop
         PATTERN
 
         def_node_matcher :has_default?, <<-PATTERN
-          (pair (sym :default) !(:nil))
+          (pair (sym :default) !nil)
         PATTERN
 
         def on_send(node)

--- a/lib/rubocop/cop/rails/output.rb
+++ b/lib/rubocop/cop/rails/output.rb
@@ -9,7 +9,7 @@ module RuboCop
               "Use Rails's logger if you want to log.".freeze
 
         def_node_matcher :output?, <<-PATTERN
-          (send nil {:ap :p :pp :pretty_print :print :puts} ...)
+          (send nil? {:ap :p :pp :pretty_print :print :puts} ...)
         PATTERN
 
         def on_send(node)

--- a/lib/rubocop/cop/rails/present.rb
+++ b/lib/rubocop/cop/rails/present.rb
@@ -44,7 +44,7 @@ module RuboCop
               {
                 (send (send $_ :nil?) :!)
                 (send (send $_ :!) :!)
-                (send $_ :!= (:nil))
+                (send $_ :!= nil)
                 $_
               }
               {
@@ -56,7 +56,7 @@ module RuboCop
         def_node_matcher :not_blank?, '(send (send $_ :blank?) :!)'
 
         def_node_matcher :unless_blank?, <<-PATTERN
-          (:if $(send $_ :blank?) {nil (...)} ...)
+          (:if $(send $_ :blank?) {nil? (...)} ...)
         PATTERN
 
         def on_send(node)

--- a/lib/rubocop/cop/rails/read_write_attribute.rb
+++ b/lib/rubocop/cop/rails/read_write_attribute.rb
@@ -20,8 +20,8 @@ module RuboCop
 
         def_node_matcher :read_write_attribute?, <<-PATTERN
           {
-            (send nil :read_attribute _)
-            (send nil :write_attribute _ _)
+            (send nil? :read_attribute _)
+            (send nil? :write_attribute _ _)
           }
         PATTERN
 

--- a/lib/rubocop/cop/rails/request_referer.rb
+++ b/lib/rubocop/cop/rails/request_referer.rb
@@ -26,7 +26,7 @@ module RuboCop
         MSG = 'Use `request.%s` instead of `request.%s`.'.freeze
 
         def_node_matcher :referer?, <<-PATTERN
-          (send (send nil :request) {:referer :referrer})
+          (send (send nil? :request) {:referer :referrer})
         PATTERN
 
         def on_send(node)

--- a/lib/rubocop/cop/rails/reversible_migration.rb
+++ b/lib/rubocop/cop/rails/reversible_migration.rb
@@ -132,27 +132,27 @@ module RuboCop
         ].freeze
 
         def_node_matcher :irreversible_schema_statement_call, <<-PATTERN
-          (send nil ${:change_table_comment :execute :remove_belongs_to} ...)
+          (send nil? ${:change_table_comment :execute :remove_belongs_to} ...)
         PATTERN
 
         def_node_matcher :drop_table_call, <<-PATTERN
-          (send nil :drop_table ...)
+          (send nil? :drop_table ...)
         PATTERN
 
         def_node_matcher :change_column_default_call, <<-PATTERN
-          (send nil :change_column_default _ _ $...)
+          (send nil? :change_column_default _ _ $...)
         PATTERN
 
         def_node_matcher :remove_column_call, <<-PATTERN
-          (send nil :remove_column $...)
+          (send nil? :remove_column $...)
         PATTERN
 
         def_node_matcher :remove_foreign_key_call, <<-PATTERN
-          (send nil :remove_foreign_key _ $_)
+          (send nil? :remove_foreign_key _ $_)
         PATTERN
 
         def_node_matcher :change_table_call, <<-PATTERN
-          (send nil :change_table $_ ...)
+          (send nil? :change_table $_ ...)
         PATTERN
 
         def on_send(node)

--- a/lib/rubocop/cop/rails/safe_navigation.rb
+++ b/lib/rubocop/cop/rails/safe_navigation.rb
@@ -45,7 +45,7 @@ module RuboCop
         MSG = 'Use safe navigation (`&.`) instead of `%s`.'.freeze
 
         def_node_matcher :try_call, <<-PATTERN
-          (send !nil ${:try :try!} $_ ...)
+          (send !nil? ${:try :try!} $_ ...)
         PATTERN
 
         minimum_target_ruby_version 2.3

--- a/lib/rubocop/cop/rails/scope_args.rb
+++ b/lib/rubocop/cop/rails/scope_args.rb
@@ -16,7 +16,7 @@ module RuboCop
       class ScopeArgs < Cop
         MSG = 'Use `lambda`/`proc` instead of a plain method call.'.freeze
 
-        def_node_matcher :scope?, '(send nil :scope _ $send)'
+        def_node_matcher :scope?, '(send nil? :scope _ $send)'
 
         def on_send(node)
           scope?(node) do |second_arg|

--- a/lib/rubocop/cop/rails/skips_model_validations.rb
+++ b/lib/rubocop/cop/rails/skips_model_validations.rb
@@ -38,7 +38,7 @@ module RuboCop
                                     update_counters].freeze
 
         def_node_matcher :good_touch?, <<-PATTERN
-          (send (const nil :FileUtils) :touch ...)
+          (send (const nil? :FileUtils) :touch ...)
         PATTERN
 
         def on_send(node)

--- a/lib/rubocop/cop/rails/unknown_env.rb
+++ b/lib/rubocop/cop/rails/unknown_env.rb
@@ -22,7 +22,7 @@ module RuboCop
         def_node_matcher :unknown_environment?, <<-PATTERN
           (send
             (send
-              {(const nil :Rails) (const (cbase) :Rails)}
+              {(const nil? :Rails) (const (cbase) :Rails)}
               :env)
             $#unknown_env_name?)
         PATTERN

--- a/lib/rubocop/cop/security/eval.rb
+++ b/lib/rubocop/cop/security/eval.rb
@@ -15,7 +15,7 @@ module RuboCop
         MSG = 'The use of `eval` is a serious security risk.'.freeze
 
         def_node_matcher :eval?, <<-PATTERN
-          (send {nil (send nil :binding)} :eval $!str ...)
+          (send {nil? (send nil? :binding)} :eval $!str ...)
         PATTERN
 
         def on_send(node)

--- a/lib/rubocop/cop/security/json_load.rb
+++ b/lib/rubocop/cop/security/json_load.rb
@@ -26,7 +26,7 @@ module RuboCop
         MSG = 'Prefer `JSON.parse` over `JSON.%s`.'.freeze
 
         def_node_matcher :json_load, <<-PATTERN
-          (send (const {nil cbase} :JSON) ${:load :restore} ...)
+          (send (const {nil? cbase} :JSON) ${:load :restore} ...)
         PATTERN
 
         def on_send(node)

--- a/lib/rubocop/cop/security/marshal_load.rb
+++ b/lib/rubocop/cop/security/marshal_load.rb
@@ -22,8 +22,8 @@ module RuboCop
         MSG = 'Avoid using `Marshal.%s`.'.freeze
 
         def_node_matcher :marshal_load, <<-PATTERN
-          (send (const {nil cbase} :Marshal) ${:load :restore}
-          !(send (const {nil cbase} :Marshal) :dump ...))
+          (send (const {nil? cbase} :Marshal) ${:load :restore}
+          !(send (const {nil? cbase} :Marshal) :dump ...))
         PATTERN
 
         def on_send(node)

--- a/lib/rubocop/cop/security/yaml_load.rb
+++ b/lib/rubocop/cop/security/yaml_load.rb
@@ -19,7 +19,7 @@ module RuboCop
         MSG = 'Prefer using `YAML.safe_load` over `YAML.load`.'.freeze
 
         def_node_matcher :yaml_load, <<-PATTERN
-          (send (const {nil cbase} :YAML) :load ...)
+          (send (const {nil? cbase} :YAML) :load ...)
         PATTERN
 
         def on_send(node)

--- a/lib/rubocop/cop/style/colon_method_call.rb
+++ b/lib/rubocop/cop/style/colon_method_call.rb
@@ -10,7 +10,7 @@ module RuboCop
 
         def_node_matcher :java_type_node?, <<-PATTERN
           (send
-            (const nil :Java)
+            (const nil? :Java)
             {:boolean :byte :char :double :float :int :long :short})
         PATTERN
 

--- a/lib/rubocop/cop/style/dir.rb
+++ b/lib/rubocop/cop/style/dir.rb
@@ -23,8 +23,8 @@ module RuboCop
               "file's directory.".freeze
 
         def_node_matcher :dir_replacement?, <<-PATTERN
-          {(send (const nil :File) :expand_path (send (const nil :File) :dirname  #file_keyword?))
-           (send (const nil :File) :dirname     (send (const nil :File) :realpath #file_keyword?))}
+          {(send (const nil? :File) :expand_path (send (const nil? :File) :dirname  #file_keyword?))
+           (send (const nil? :File) :dirname     (send (const nil? :File) :realpath #file_keyword?))}
         PATTERN
 
         minimum_target_ruby_version 2.0

--- a/lib/rubocop/cop/style/empty_literal.rb
+++ b/lib/rubocop/cop/style/empty_literal.rb
@@ -12,13 +12,13 @@ module RuboCop
         HASH_MSG = 'Use hash literal `{}` instead of `Hash.new`.'.freeze
         STR_MSG = 'Use string literal `%s` instead of `String.new`.'.freeze
 
-        def_node_matcher :array_node, '(send (const nil :Array) :new)'
-        def_node_matcher :hash_node, '(send (const nil :Hash) :new)'
-        def_node_matcher :str_node, '(send (const nil :String) :new)'
+        def_node_matcher :array_node, '(send (const nil? :Array) :new)'
+        def_node_matcher :hash_node, '(send (const nil? :Hash) :new)'
+        def_node_matcher :str_node, '(send (const nil? :String) :new)'
         def_node_matcher :array_with_block,
-                         '(block (send (const nil :Array) :new) args _)'
+                         '(block (send (const nil? :Array) :new) args _)'
         def_node_matcher :hash_with_block,
-                         '(block (send (const nil :Hash) :new) args _)'
+                         '(block (send (const nil? :Hash) :new) args _)'
 
         def on_send(node)
           add_offense(node, :expression, ARR_MSG)  if offense_array_node?(node)

--- a/lib/rubocop/cop/style/format_string.rb
+++ b/lib/rubocop/cop/style/format_string.rb
@@ -17,9 +17,9 @@ module RuboCop
 
         def_node_matcher :formatter, <<-PATTERN
         {
-          (send nil ${:sprintf :format} _ _ ...)
+          (send nil? ${:sprintf :format} _ _ ...)
           (send {str dstr} $:% ... )
-          (send !nil $:% {array hash})
+          (send !nil? $:% {array hash})
         }
         PATTERN
 

--- a/lib/rubocop/cop/style/implicit_runtime_error.rb
+++ b/lib/rubocop/cop/style/implicit_runtime_error.rb
@@ -19,7 +19,7 @@ module RuboCop
               'rather than just a message.'.freeze
 
         def_node_matcher :implicit_runtime_error_raise_or_fail,
-                         '(send nil ${:raise :fail} {str dstr})'
+                         '(send nil? ${:raise :fail} {str dstr})'
 
         def on_send(node)
           implicit_runtime_error_raise_or_fail(node) do |method|

--- a/lib/rubocop/cop/style/lambda.rb
+++ b/lib/rubocop/cop/style/lambda.rb
@@ -70,7 +70,7 @@ module RuboCop
           }
         }.freeze
 
-        def_node_matcher :lambda_node?, '(block $(send nil :lambda) ...)'
+        def_node_matcher :lambda_node?, '(block $(send nil? :lambda) ...)'
 
         def on_block(node)
           return unless node.lambda?

--- a/lib/rubocop/cop/style/module_function.rb
+++ b/lib/rubocop/cop/style/module_function.rb
@@ -32,8 +32,8 @@ module RuboCop
         EXTEND_SELF_MSG =
           'Use `extend self` instead of `module_function`.'.freeze
 
-        def_node_matcher :module_function_node?, '(send nil :module_function)'
-        def_node_matcher :extend_self_node?, '(send nil :extend self)'
+        def_node_matcher :module_function_node?, '(send nil? :module_function)'
+        def_node_matcher :extend_self_node?, '(send nil? :extend self)'
 
         def on_module(node)
           _name, body = *node

--- a/lib/rubocop/cop/style/nil_comparison.rb
+++ b/lib/rubocop/cop/style/nil_comparison.rb
@@ -15,7 +15,7 @@ module RuboCop
       class NilComparison < Cop
         MSG = 'Prefer the use of the `nil?` predicate.'.freeze
 
-        def_node_matcher :nil_comparison?, '(send _ {:== :===} (:nil))'
+        def_node_matcher :nil_comparison?, '(send _ {:== :===} nil)'
 
         def on_send(node)
           nil_comparison?(node) do

--- a/lib/rubocop/cop/style/non_nil_check.rb
+++ b/lib/rubocop/cop/style/non_nil_check.rb
@@ -24,7 +24,7 @@ module RuboCop
       #    !current_user.nil?
       #  end
       class NonNilCheck < Cop
-        def_node_matcher :not_equal_to_nil?, '(send _ :!= (:nil))'
+        def_node_matcher :not_equal_to_nil?, '(send _ :!= nil)'
         def_node_matcher :unless_check?, '(if (send _ :nil?) ...)'
         def_node_matcher :nil_check?, '(send _ :nil?)'
         def_node_matcher :not_and_nil_check?, '(send (send _ :nil?) :!)'

--- a/lib/rubocop/cop/style/or_assignment.rb
+++ b/lib/rubocop/cop/style/or_assignment.rb
@@ -39,7 +39,7 @@ module RuboCop
 
         def_node_matcher :unless_assignment?, <<-PATTERN
           (if
-            ({lvar ivar cvar gvar} _var) nil
+            ({lvar ivar cvar gvar} _var) nil?
             ({lvasgn ivasgn cvasgn gvasgn} _var
               _))
         PATTERN

--- a/lib/rubocop/cop/style/parallel_assignment.rb
+++ b/lib/rubocop/cop/style/parallel_assignment.rb
@@ -115,7 +115,7 @@ module RuboCop
           end
         end
 
-        def_node_matcher :implicit_self_getter?, '(send nil $_)'
+        def_node_matcher :implicit_self_getter?, '(send nil? $_)'
 
         # Helper class necessitated by silly design of TSort prior to Ruby 2.1
         # Newer versions have a better API, but that doesn't help us

--- a/lib/rubocop/cop/style/proc.rb
+++ b/lib/rubocop/cop/style/proc.rb
@@ -9,7 +9,7 @@ module RuboCop
         MSG = 'Use `proc` instead of `Proc.new`.'.freeze
 
         def_node_matcher :proc_new?,
-                         '(block $(send (const nil :Proc) :new) ...)'
+                         '(block $(send (const nil? :Proc) :new) ...)'
 
         def on_block(node)
           proc_new?(node) do |block_method|

--- a/lib/rubocop/cop/style/redundant_exception.rb
+++ b/lib/rubocop/cop/style/redundant_exception.rb
@@ -43,11 +43,11 @@ module RuboCop
         end
 
         def_node_matcher :exploded?, <<-PATTERN
-          (send nil ${:raise :fail} (const nil :RuntimeError) $_)
+          (send nil? ${:raise :fail} (const nil? :RuntimeError) $_)
         PATTERN
 
         def_node_matcher :compact?, <<-PATTERN
-          (send nil {:raise :fail} $(send (const nil :RuntimeError) :new $_))
+          (send nil? {:raise :fail} $(send (const nil? :RuntimeError) :new $_))
         PATTERN
       end
     end

--- a/lib/rubocop/cop/style/return_nil.rb
+++ b/lib/rubocop/cop/style/return_nil.rb
@@ -39,8 +39,7 @@ module RuboCop
         RETURN_NIL_MSG = 'Use `return nil` instead of `return`.'.freeze
 
         def_node_matcher :return_node?, '(return)'
-        # TODO: fix (return nil) on the NodePattern class
-        # def_node_matcher :return_nil_node?, '(return nil)'
+        def_node_matcher :return_nil_node?, '(return nil)'
 
         def on_return(node)
           # Check Lint/NonLocalExitFromIterator first before this cop
@@ -80,15 +79,11 @@ module RuboCop
             style == :return_nil && !return_node?(node)
         end
 
-        def return_nil_node?(node)
-          !node.children.empty? && node.children.first.nil_type?
-        end
-
         def scoped_node?(node)
           node.def_type? || node.defs_type? || node.lambda?
         end
 
-        def_node_matcher :chained_send?, '(send !nil ...)'
+        def_node_matcher :chained_send?, '(send !nil? ...)'
         def_node_matcher :define_method?, <<-PATTERN
           (send _ {:define_method :define_singleton_method} _)
         PATTERN

--- a/lib/rubocop/cop/style/safe_navigation.rb
+++ b/lib/rubocop/cop/style/safe_navigation.rb
@@ -59,12 +59,12 @@ module RuboCop
             (if {
                   (send $_ {:nil? :!})
                   $_
-                } nil $_)
+                } nil? $_)
 
             (if {
                   (send (send $_ :nil?) :!)
                   $_
-                } $_ nil)
+                } $_ nil?)
           }
         PATTERN
 

--- a/lib/rubocop/cop/style/signal_exception.rb
+++ b/lib/rubocop/cop/style/signal_exception.rb
@@ -11,7 +11,7 @@ module RuboCop
         RAISE_MSG = 'Use `raise` instead of `fail` to ' \
                     'rethrow exceptions.'.freeze
 
-        def_node_matcher :kernel_call?, '(send (const nil :Kernel) %1 ...)'
+        def_node_matcher :kernel_call?, '(send (const nil? :Kernel) %1 ...)'
         def_node_search :custom_fail_methods,
                         '{(def :fail ...) (defs _ :fail ...)}'
 

--- a/lib/rubocop/cop/style/struct_inheritance.rb
+++ b/lib/rubocop/cop/style/struct_inheritance.rb
@@ -23,8 +23,8 @@ module RuboCop
         end
 
         def_node_matcher :struct_constructor?, <<-PATTERN
-           {(send (const nil :Struct) :new ...)
-            (block (send (const nil :Struct) :new ...) ...)}
+           {(send (const nil? :Struct) :new ...)
+            (block (send (const nil? :Struct) :new ...) ...)}
         PATTERN
       end
     end

--- a/lib/rubocop/cop/style/symbol_proc.rb
+++ b/lib/rubocop/cop/style/symbol_proc.rb
@@ -15,7 +15,7 @@ module RuboCop
         MSG = 'Pass `&:%s` as an argument to `%s` instead of a block.'.freeze
         SUPER_TYPES = %i[super zsuper].freeze
 
-        def_node_matcher :proc_node?, '(send (const nil :Proc) :new)'
+        def_node_matcher :proc_node?, '(send (const nil? :Proc) :new)'
         def_node_matcher :symbol_proc?, <<-PATTERN
           (block
             ${(send ...) (super ...) zsuper}

--- a/lib/rubocop/cop/style/ternary_parentheses.rb
+++ b/lib/rubocop/cop/style/ternary_parentheses.rb
@@ -169,7 +169,7 @@ module RuboCop
 
         def_node_matcher :method_call_argument, <<-PATTERN
           {(:defined? $...)
-           (send {_ nil} _ $(send nil _)...)}
+           (send {_ nil?} _ $(send nil? _)...)}
         PATTERN
 
         def correct_parenthesized(condition)

--- a/lib/rubocop/node_pattern.rb
+++ b/lib/rubocop/node_pattern.rb
@@ -116,7 +116,7 @@ module RuboCop
       PREDICATE = /\A#{IDENTIFIER}+\?\(?\Z/
       WILDCARD  = /\A_#{IDENTIFIER}*\Z/
       FUNCALL   = /\A\##{METHOD_NAME}/
-      LITERAL   = /\A(?:#{SYMBOL}|#{NUMBER}|#{STRING}|nil)\Z/
+      LITERAL   = /\A(?:#{SYMBOL}|#{NUMBER}|#{STRING})\Z/
       PARAM     = /\A#{PARAM_NUMBER}\Z/
       CLOSING   = /\A(?:\)|\}|\])\Z/
 

--- a/spec/rubocop/cop/rails/blank_spec.rb
+++ b/spec/rubocop/cop/rails/blank_spec.rb
@@ -44,6 +44,11 @@ describe RuboCop::Cop::Rails::Blank, :config do
       expect_no_offenses('bar || foo.empty?')
     end
 
+    # Bug: https://github.com/bbatsov/rubocop/issues/4814
+    it 'does not break when LHS of `or` is a send node with an arugment' do
+      expect_no_offenses('x(1) || something')
+    end
+
     context 'nil or empty' do
       it_behaves_like :offense, 'foo.nil? || foo.empty?',
                       'foo.blank?',

--- a/spec/rubocop/node_pattern_spec.rb
+++ b/spec/rubocop/node_pattern_spec.rb
@@ -129,6 +129,26 @@ describe RuboCop::NodePattern do
     end
   end
 
+  describe 'nil' do
+    context 'nil literals' do
+      let(:pattern) { '(nil)' }
+      let(:ruby) { 'nil' }
+      it_behaves_like :matching
+    end
+
+    context 'nil value in AST' do
+      let(:pattern) { '(send nil :foo)' }
+      let(:ruby) { 'foo' }
+      it_behaves_like :nonmatching
+    end
+
+    context 'nil value in AST, use nil? method' do
+      let(:pattern) { '(send nil? :foo)' }
+      let(:ruby) { 'foo' }
+      it_behaves_like :matching
+    end
+  end
+
   describe 'simple sequence' do
     let(:pattern) { '(send int :+ int)' }
 
@@ -374,7 +394,7 @@ describe RuboCop::NodePattern do
     end
 
     context 'in a nested sequence' do
-      let(:pattern) { '(send (const nil $_) ...)' }
+      let(:pattern) { '(send (const nil? $_) ...)' }
       let(:ruby) { 'A.method' }
       let(:captured_val) { :A }
       it_behaves_like :single_capture


### PR DESCRIPTION
See #4814  for more information for this bug.


This pull-request will change behaviour of NodePattern to fix the bug.

Currently, `(send _ :== nil)` is compiled to like the below.


```ruby
node.send_type? &&
  children.size == 3 &&
  children[1] == :== &&
  children[2] == nil
```

So, we cannot check `nil`type node by `(nil)` matcher. The matcher checks `nil` value in AST.

By this change, the `(nil)` matcher will match `nil` type node..

For example:

```ruby
# (send _ :== nil)
node.send_type? &&
  children.size == 3 &&
  children[1] == :== &&
  children[2].nil_type?
```


And, we should use `nil?` to check  `nil` value in AST. For example: `(send nil? :foo)`



By this change, we will be able to separate `nil` type node and `nil` value in AST.
WDYT?




-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Used the same coding conventions as the rest of the project.
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [ ] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] All tests(`rake spec`) are passing.
* [x] The new code doesn't generate RuboCop offenses that are checked by `rake internal_investigation`.
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Updated cop documentation with `rake generate_cops_documentation` (required only when you've added a new cop or changed the configuration/documentation of an existing cop).

[1]: http://chris.beams.io/posts/git-commit/
