### PR TITLE
[Fix #4582] Support department configuration of common params

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@
 
 * [#4746](https://github.com/bbatsov/rubocop/pull/4746): The `Lint/InvalidCharacterLiteral` cop has been removed since it was never being actually triggered. ([@deivid-rodriguez][])
 * [#4789](https://github.com/bbatsov/rubocop/pull/4789): Analyzing code that needs to support MRI 1.9 is no longer supported. ([@deivid-rodriguez][])
+* [#4582](https://github.com/bbatsov/rubocop/issues/4582): `Severity` and other common parameters can be configured on department level. ([@jonas054][])
 
 ## 0.50.0 (2017-09-14)
 

--- a/lib/rubocop/config.rb
+++ b/lib/rubocop/config.rb
@@ -491,7 +491,7 @@ module RuboCop
 
       unless department
         department_options = self[cop_department]
-        if department_options && department_options.fetch('Enabled') == false
+        if department_options && department_options['Enabled'] == false
           return false
         end
       end

--- a/lib/rubocop/cop/cop.rb
+++ b/lib/rubocop/cop/cop.rb
@@ -105,7 +105,10 @@ module RuboCop
       end
 
       def cop_config
-        @cop_config ||= @config.for_cop(self)
+        # Use department configuration as basis, but let individual cop
+        # configuration override.
+        @cop_config ||= @config.for_cop(self.class.department.to_s)
+                               .merge(@config.for_cop(self))
       end
 
       def message(_node = nil)

--- a/manual/configuration.md
+++ b/manual/configuration.md
@@ -254,9 +254,10 @@ using `Enabled: false` in user configuration files are enabled.
 #### Severity
 
 Each cop has a default severity level based on which department it belongs
-to. The level is `warning` for `Lint` and `convention` for all the others.
-Cops can customize their severity level. Allowed params are `refactor`,
-`convention`, `warning`, `error` and `fatal`.
+to. The level is normally `warning` for `Lint` and `convention` for all the
+others, but this can be changed in user configuration. Cops can customize their
+severity level. Allowed values are `refactor`, `convention`, `warning`, `error`
+and `fatal`.
 
 There is one exception from the general rule above and that is `Lint/Syntax`, a
 special cop that checks for syntax errors before the other cops are invoked. It
@@ -264,6 +265,9 @@ can not be disabled and its severity (`fatal`) can not be changed in
 configuration.
 
 ```yaml
+Lint:
+  Severity: error
+
 Metrics/CyclomaticComplexity:
   Severity: warning
 ```


### PR DESCRIPTION
Severity is the most obvious candidate for department-wide setting, but the solution is general. A cop's individual setting overrides the parameter from its department.