### PR TITLE
Change behavior when arg for run `rake new_cop` is incorrect

### DIFF
--- a/tasks/new_cop.rake
+++ b/tasks/new_cop.rake
@@ -5,7 +5,8 @@ require 'rubocop'
 desc 'Generate a new cop template'
 task :new_cop, [:cop] do |_task, args|
   cop_name = args.fetch(:cop) do
-    raise ArgumentError, 'One argument is required'
+    warn 'usage: bundle exec rake new_cop[Department/Name]'
+    exit!
   end
 
   generator = RuboCop::Cop::Generator.new(cop_name)


### PR DESCRIPTION
This PR changes the behavior when the argument for running `rake new_cop` command is incorrect.
When usage was incorrect, I think that it is more user-friendly to show usage.

## Before

```console
% bundle exec rake new_cop
rake aborted!
ArgumentError: One argument is required
tasks/new_cop.rake:8:in `block (2 levels) in <top (required)>'
tasks/new_cop.rake:7:in `block in <top (required)>'
/Users/koic/.rbenv/versions/2.4.2/bin/bundle:23:in `load'
/Users/koic/.rbenv/versions/2.4.2/bin/bundle:23:in `<main>'
Tasks: TOP => new_cop
(See full trace by running task with --trace)
```

## After

```console
% bundle exec rake new_cop
usage: bundle exec rake new_cop[Department/Name]
```

How to use commands is in accordance with the following manual.
https://github.com/bbatsov/rubocop/blob/v0.50.0/manual/development.md

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Used the same coding conventions as the rest of the project.
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [ ] Added tests.
* [ ] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] All tests(`rake spec`) are passing.
* [x] The new code doesn't generate RuboCop offenses that are checked by `rake internal_investigation`.
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [ ] Updated cop documentation with `rake generate_cops_documentation` (required only when you've added a new cop or changed the configuration/documentation of an existing cop).

[1]: http://chris.beams.io/posts/git-commit/
