### PR TITLE
Use `String#scrub` always

### DIFF
--- a/lib/rubocop/cached_data.rb
+++ b/lib/rubocop/cached_data.rb
@@ -38,12 +38,7 @@ module RuboCop
     def message(offense)
       # JSON.dump will fail if the offense message contains text which is not
       # valid UTF-8
-      message = offense.message
-      if message.respond_to?(:scrub)
-        message.scrub
-      else
-        message.chars.select(&:valid_encoding?).join
-      end
+      offense.message.scrub
     end
 
     # Restore an offense object loaded from a JSON file.

--- a/lib/rubocop/cop/layout/indent_heredoc.rb
+++ b/lib/rubocop/cop/layout/indent_heredoc.rb
@@ -160,7 +160,7 @@ module RuboCop
         end
 
         def heredoc_body(node)
-          scrub_string(node.loc.heredoc_body.source)
+          node.loc.heredoc_body.source.scrub
         end
       end
     end

--- a/lib/rubocop/cop/lint/interpolation_check.rb
+++ b/lib/rubocop/cop/lint/interpolation_check.rb
@@ -23,7 +23,7 @@ module RuboCop
         def on_str(node)
           return if heredoc?(node)
           return if node.parent && node.parent.dstr_type?
-          return unless scrub_string(node.str_content) =~ /#\{.*\}/
+          return unless node.str_content.scrub =~ /#\{.*\}/
           add_offense(node)
         end
 

--- a/lib/rubocop/cop/lint/percent_string_array.rb
+++ b/lib/rubocop/cop/lint/percent_string_array.rb
@@ -44,7 +44,7 @@ module RuboCop
 
         def contains_quotes_or_commas?(node)
           node.values.any? do |value|
-            literal = scrub_string(value.children.first.to_s)
+            literal = value.children.first.to_s.scrub
 
             # To avoid likely false positives (e.g. a single ' or ")
             next if literal.gsub(/[^\p{Alnum}]/, '').empty?

--- a/lib/rubocop/cop/util.rb
+++ b/lib/rubocop/cop/util.rb
@@ -304,17 +304,6 @@ module RuboCop
           .sub(/^Enforced/, 'Supported')
           .sub('Style', 'Styles')
       end
-
-      def scrub_string(string)
-        if string.respond_to?(:scrub)
-          string.scrub
-        else
-          string
-            .encode('UTF-16BE', 'UTF-8',
-                    invalid: :replace, undef: :replace, replace: '?')
-            .encode('UTF-8')
-        end
-      end
     end
   end
 end


### PR DESCRIPTION
Because, `String#scrub` has been introduced from Ruby 2.1, and we drop Ruby 2.0 support 🎉

See also #4787



-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Used the same coding conventions as the rest of the project.
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [ ] Added tests.
* [ ] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] All tests(`rake spec`) are passing.
* [x] The new code doesn't generate RuboCop offenses that are checked by `rake internal_investigation`.
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [ ] Updated cop documentation with `rake generate_cops_documentation` (required only when you've added a new cop or changed the configuration/documentation of an existing cop).

[1]: http://chris.beams.io/posts/git-commit/
