### PR TITLE
Do not override offence message by warning message

### DIFF
--- a/lib/rubocop/cop/cop.rb
+++ b/lib/rubocop/cop/cop.rb
@@ -226,7 +226,10 @@ module RuboCop
       def add_offense_deprecated(node, loc = :expression, message = nil,
                                  severity = nil, &block)
 
-        message = <<-RUBY.strip_indent
+        caller = caller_locations(2..2).first
+        path = "#{caller.path}:#{caller.lineno}"
+        warn_message = <<-RUBY.strip_indent
+          #{path}
           Warning: The usage of positional location, message, and severity
           parameters to Cop#add_offense is deprecated.
           Please use keyword arguments instead.
@@ -235,7 +238,7 @@ module RuboCop
           RuboCop 0.52
         RUBY
 
-        warn(Rainbow(message).red)
+        warn(Rainbow(warn_message).red)
 
         add_offense_common(node, location: loc, message: message,
                                  severity: severity, &block)


### PR DESCRIPTION
Currently, the warning message overrides offence message. So, all cops that use deprecated style `add_offense` display "Warning: The usage of positional location, ...".
This change fixes the bug, and add a path into the message.



-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Used the same coding conventions as the rest of the project.
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [ ] Added tests.
* [ ] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] All tests(`rake spec`) are passing.
* [x] The new code doesn't generate RuboCop offenses that are checked by `rake internal_investigation`.
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [ ] Updated cop documentation with `rake generate_cops_documentation` (required only when you've added a new cop or changed the configuration/documentation of an existing cop).

[1]: http://chris.beams.io/posts/git-commit/
