### PR TITLE
[Fix #4823] Make unused argument cops aware of reassignments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@
 * [#4241](https://github.com/bbatsov/rubocop/issues/4241): Prevent `Rails/Blank` and `Rails/Present` from breaking when there is no explicit receiver. ([@rrosenblum][])
 * [#4814](https://github.com/bbatsov/rubocop/issues/4814): Prevent `Rails/Blank` from breaking on send with an argument. ([@pocke][])
 * [#4759](https://github.com/bbatsov/rubocop/issues/4759): Make `Naming/HeredocDelimiterNaming` and `Naming/HeredocDelimiterCase` aware of more delimiter patterns. ([@drenmi][])
+* [#4823](https://github.com/bbatsov/rubocop/issues/4823): Make `Lint/UnusedMethodArgument` and `Lint/UnusedBlockArgument` aware of overriding assignments. ([@akhramov][])
 
 ### Changes
 

--- a/lib/rubocop/cop/mixin/unused_argument.rb
+++ b/lib/rubocop/cop/mixin/unused_argument.rb
@@ -5,6 +5,10 @@ module RuboCop
     module Lint
       # Common functionality for cops handling unused arguments.
       module UnusedArgument
+        extend NodePattern::Macros
+
+        def_node_search :uses_var?, '(lvar %)'
+
         def join_force?(force_class)
           force_class == VariableForce
         end
@@ -17,7 +21,7 @@ module RuboCop
 
         def check_argument(variable)
           return if variable.should_be_unused?
-          return if variable.referenced?
+          return if variable_used?(variable)
 
           message = message(variable)
           add_offense(variable.declaration_node, location: :name,
@@ -35,6 +39,42 @@ module RuboCop
             end
           else
             ->(corrector) { corrector.insert_before(node.loc.name, '_') }
+          end
+        end
+
+        private
+
+        def variable_used?(variable)
+          return false unless variable.referenced?
+
+          assignment_without_usage =
+            find_assignment_without_variable_usage(variable)
+
+          # If variable is either not assigned or assigned with usages,
+          # then it's really used
+          return true unless assignment_without_usage
+
+          assignment_without_usage_pos =
+            assignment_without_usage.node.source_range.begin_pos
+
+          reference_positions =
+            variable.references.map { |var| var.node.source_range.begin_pos }
+
+          # Was variable referenced before it was reassigned?
+          reference_positions.any? { |pos| pos <= assignment_without_usage_pos }
+        end
+
+        # Find the first variable assignment, which doesn't reference the
+        # variable at the rhs.
+        def find_assignment_without_variable_usage(variable)
+          variable.assignments.find do |assignment|
+            # It's impossible to decide whether a branch is executed, so
+            # this case is ignored
+            next if assignment.branch
+
+            assignment_node = assignment.meta_assignment_node || assignment.node
+
+            !uses_var?(assignment_node, assignment.variable.name)
           end
         end
       end


### PR DESCRIPTION
As it stands now, unused argument cops (`Lint/UnusedBlockArgument` and
`Lint/UnusedMethodArgumentSpec`) treat reassignments as argument
usages.

This change makes unused argument cops aware of reassignments.
The following cases are handled:

* Argument was unused before the reassignment (cop complains):
  ```ruby
  def foobar(baz)
    baz = 42
    puts baz
  end
  ```
* Argument was used before the reassignment (cop does not complain):
  ```ruby
  def foobar(baz)
    puts baz
    baz = 42
    puts baz
  end
  ```
* Argument was used at the rhs of reassignment (cop does not
  complain):
  ```ruby
  def foobar(baz)
    baz = 42 + baz
    puts baz
  end
  ```
* Argument was reassigned in the conditional (cop does not complain
  since it is unknown whether the branch will be executed)
  ```ruby
  def foobar(baz)
    if condition?
      baz = 42
    end

    puts baz
  end
  ```

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Used the same coding conventions as the rest of the project.
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] All tests(`rake spec`) are passing.
* [x] The new code doesn't generate RuboCop offenses that are checked by `rake internal_investigation`.
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [ ] Updated cop documentation with `rake generate_cops_documentation` (required only when you've added a new cop or changed the configuration/documentation of an existing cop).

[1]: http://chris.beams.io/posts/git-commit/
