### PR TITLE
[Fix #4747] Fix `Rails/HasManyOrHasOneDependent` incorrectly flags `with_options` blocks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@
 * [#4814](https://github.com/bbatsov/rubocop/issues/4814): Prevent `Rails/Blank` from breaking on send with an argument. ([@pocke][])
 * [#4759](https://github.com/bbatsov/rubocop/issues/4759): Make `Naming/HeredocDelimiterNaming` and `Naming/HeredocDelimiterCase` aware of more delimiter patterns. ([@drenmi][])
 * [#4830](https://github.com/bbatsov/rubocop/issues/4830): Prevent `Lint/BooleanSymbol` from truncating symbol's value in the message when offense is located in the new syntax hash. ([@akhramov][])
+* [#4747](https://github.com/bbatsov/rubocop/issues/4747): Fix `Rails/HasManyOrHasOneDependent` cop incorrectly flags `with_options` blocks. ([@koic][])
 
 ### Changes
 

--- a/spec/rubocop/cop/rails/has_many_or_has_one_dependent_spec.rb
+++ b/spec/rubocop/cop/rails/has_many_or_has_one_dependent_spec.rb
@@ -40,6 +40,18 @@ describe RuboCop::Cop::Rails::HasManyOrHasOneDependent do
         RUBY
       end
     end
+
+    context 'with_options dependent: :destroy' do
+      it 'does not register an offense' do
+        expect_no_offenses(<<-RUBY.strip_indent)
+          class Person
+            with_options dependent: :destroy do
+              has_one :foo
+            end
+          end
+        RUBY
+      end
+    end
   end
 
   context 'has_many' do
@@ -76,6 +88,29 @@ describe RuboCop::Cop::Rails::HasManyOrHasOneDependent do
           has_many :foo, through: nil
           ^^^^^^^^ Specify a `:dependent` option.
         end
+        RUBY
+      end
+    end
+
+    context 'Surrounded `with_options` block' do
+      it 'registers an offense when `dependent: :destroy` is not present' do
+        expect_offense(<<-RUBY.strip_indent)
+          class Person
+            with_options through: nil do
+              has_many :foo
+              ^^^^^^^^ Specify a `:dependent` option.
+            end
+          end
+        RUBY
+      end
+
+      it "doesn't register an offense for `with_options dependent: :destroy`" do
+        expect_no_offenses(<<-RUBY.strip_indent)
+          class Person
+            with_options dependent: :destroy do
+              has_many :foo
+            end
+          end
         RUBY
       end
     end


### PR DESCRIPTION
This PR fixes #4747. `Rails/HasManyOrHasOneDependent` cop will also check `:dependent` option for `with_options` block.

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Used the same coding conventions as the rest of the project.
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] All tests(`rake spec`) are passing.
* [x] The new code doesn't generate RuboCop offenses that are checked by `rake internal_investigation`.
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [ ] Updated cop documentation with `rake generate_cops_documentation` (required only when you've added a new cop or changed the configuration/documentation of an existing cop).

[1]: http://chris.beams.io/posts/git-commit/
