### PR TITLE
[Fix #4759] Make heredoc delimiter cops aware of more delimiter patterns

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@
 * [#4776](https://github.com/bbatsov/rubocop/issues/4776): Non utf-8 magic encoding comments are now respected. ([@deivid-rodriguez][])
 * [#4241](https://github.com/bbatsov/rubocop/issues/4241): Prevent `Rails/Blank` and `Rails/Present` from breaking when there is no explicit receiver. ([@rrosenblum][])
 * [#4814](https://github.com/bbatsov/rubocop/issues/4814): Prevent `Rails/Blank` from breaking on send with an argument. ([@pocke][])
+* [#4759](https://github.com/bbatsov/rubocop/issues/4759): Make `Naming/HeredocDelimiterNaming` and `Naming/HeredocDelimiterCase` aware of more delimiter patterns. ([@drenmi][])
 
 ### Changes
 

--- a/lib/rubocop/cop/mixin/heredoc.rb
+++ b/lib/rubocop/cop/mixin/heredoc.rb
@@ -2,7 +2,7 @@
 
 # Common functionality for working with heredoc strings.
 module Heredoc
-  OPENING_DELIMITER = /<<[~-]?'?(\w+)'?\b/
+  OPENING_DELIMITER = /<<[~-]?['"`]?([^'"`]+)['"`]?/
 
   def on_str(node)
     return unless heredoc?(node)

--- a/lib/rubocop/cop/naming/heredoc_delimiter_naming.rb
+++ b/lib/rubocop/cop/naming/heredoc_delimiter_naming.rb
@@ -27,7 +27,6 @@ module RuboCop
         include Heredoc
 
         MSG = 'Use meaningful heredoc delimiters.'.freeze
-        OPENING_DELIMITER = /<<[~-]?'?(\w+)'?\b/
 
         def on_heredoc(node)
           return if meaningful_delimiters?(node)
@@ -39,6 +38,8 @@ module RuboCop
 
         def meaningful_delimiters?(node)
           delimiters = delimiters(node)
+
+          return false unless delimiters =~ /\w/
 
           blacklisted_delimiters.none? do |blacklisted_delimiter|
             delimiters =~ Regexp.new(blacklisted_delimiter)

--- a/spec/rubocop/cop/naming/heredoc_delimiter_case_spec.rb
+++ b/spec/rubocop/cop/naming/heredoc_delimiter_case_spec.rb
@@ -44,30 +44,98 @@ describe RuboCop::Cop::Naming::HeredocDelimiterCase, :config do
     end
 
     context 'with a non-interpolated heredoc' do
-      it 'registers an offense with a lowercase delimiter' do
-        expect_offense(<<-RUBY.strip_indent)
-          <<-'sql'
-            foo
-          sql
-          ^^^ Use uppercase heredoc delimiters.
-        RUBY
+      context 'when using single quoted delimiters' do
+        it 'registers an offense with a lowercase delimiter' do
+          expect_offense(<<-RUBY.strip_indent)
+            <<-'sql'
+              foo
+            sql
+            ^^^ Use uppercase heredoc delimiters.
+          RUBY
+        end
+
+        it 'registers an offense with a camel case delimiter' do
+          expect_offense(<<-RUBY.strip_indent)
+            <<-'Sql'
+              foo
+            Sql
+            ^^^ Use uppercase heredoc delimiters.
+          RUBY
+        end
+
+        it 'does not register an offense with an uppercase delimiter' do
+          expect_no_offenses(<<-RUBY.strip_indent)
+            <<-'SQL'
+              foo
+            SQL
+          RUBY
+        end
       end
 
-      it 'registers an offense with a camel case delimiter' do
-        expect_offense(<<-RUBY.strip_indent)
-          <<-'Sql'
-            foo
-          Sql
-          ^^^ Use uppercase heredoc delimiters.
-        RUBY
+      context 'when using double quoted delimiters' do
+        it 'registers an offense with a lowercase delimiter' do
+          expect_offense(<<-RUBY.strip_indent)
+            <<-"sql"
+              foo
+            sql
+            ^^^ Use uppercase heredoc delimiters.
+          RUBY
+        end
+
+        it 'registers an offense with a camel case delimiter' do
+          expect_offense(<<-RUBY.strip_indent)
+            <<-"Sql"
+              foo
+            Sql
+            ^^^ Use uppercase heredoc delimiters.
+          RUBY
+        end
+
+        it 'does not register an offense with an uppercase delimiter' do
+          expect_no_offenses(<<-RUBY.strip_indent)
+            <<-"SQL"
+              foo
+            SQL
+          RUBY
+        end
       end
 
-      it 'does not register an offense with an uppercase delimiter' do
-        expect_no_offenses(<<-RUBY.strip_indent)
-          <<-'SQL'
-            foo
-          SQL
-        RUBY
+      context 'when using back tick delimiters' do
+        it 'registers an offense with a lowercase delimiter' do
+          expect_offense(<<-RUBY.strip_indent)
+            <<-`sql`
+              foo
+            sql
+            ^^^ Use uppercase heredoc delimiters.
+          RUBY
+        end
+
+        it 'registers an offense with a camel case delimiter' do
+          expect_offense(<<-RUBY.strip_indent)
+            <<-`Sql`
+              foo
+            Sql
+            ^^^ Use uppercase heredoc delimiters.
+          RUBY
+        end
+
+        it 'does not register an offense with an uppercase delimiter' do
+          expect_no_offenses(<<-RUBY.strip_indent)
+            <<-`SQL`
+              foo
+            SQL
+          RUBY
+        end
+      end
+
+      context 'when using non-word delimiters' do
+        it 'does not register an offense' do
+          expect_no_offenses(<<-RUBY.strip_indent)
+            <<-'+'
+              foo
+            +
+          RUBY
+        end
       end
     end
 

--- a/spec/rubocop/cop/naming/heredoc_delimiter_naming_spec.rb
+++ b/spec/rubocop/cop/naming/heredoc_delimiter_naming_spec.rb
@@ -31,21 +31,72 @@ describe RuboCop::Cop::Naming::HeredocDelimiterNaming, :config do
   end
 
   context 'with a non-interpolated heredoc' do
-    it 'registers an offense with a non-meaningful delimiter' do
-      expect_offense(<<-RUBY.strip_indent)
-        <<-'END'
-          foo
-        END
-        ^^^ Use meaningful heredoc delimiters.
-      RUBY
+    context 'when using single quoted delimiters' do
+      it 'registers an offense with a non-meaningful delimiter' do
+        expect_offense(<<-RUBY.strip_indent)
+          <<-'END'
+            foo
+          END
+          ^^^ Use meaningful heredoc delimiters.
+        RUBY
+      end
+
+      it 'does not register an offense with a meaningful delimiter' do
+        expect_no_offenses(<<-RUBY.strip_indent)
+          <<-'SQL'
+            foo
+          SQL
+        RUBY
+      end
     end
 
-    it 'does not register an offense with a meaningful delimiter' do
-      expect_no_offenses(<<-RUBY.strip_indent)
-        <<-'SQL'
-          foo
-        SQL
-      RUBY
+    context 'when using double quoted delimiters' do
+      it 'registers an offense with a non-meaningful delimiter' do
+        expect_offense(<<-RUBY.strip_indent)
+          <<-"END"
+            foo
+          END
+          ^^^ Use meaningful heredoc delimiters.
+        RUBY
+      end
+
+      it 'does not register an offense with a meaningful delimiter' do
+        expect_no_offenses(<<-RUBY.strip_indent)
+          <<-'SQL'
+            foo
+          SQL
+        RUBY
+      end
+    end
+
+    context 'when using back tick delimiters' do
+      it 'registers an offense with a non-meaningful delimiter' do
+        expect_offense(<<-RUBY.strip_indent)
+          <<-`END`
+            foo
+          END
+          ^^^ Use meaningful heredoc delimiters.
+        RUBY
+      end
+
+      it 'does not register an offense with a meaningful delimiter' do
+        expect_no_offenses(<<-RUBY.strip_indent)
+          <<-`SQL`
+            foo
+          SQL
+        RUBY
+      end
+    end
+
+    context 'when using non-word delimiters' do
+      it 'registers an offense' do
+        expect_offense(<<-RUBY.strip_indent)
+          <<-'+'
+            foo
+          +
+          ^ Use meaningful heredoc delimiters.
+        RUBY
+      end
     end
   end
 


### PR DESCRIPTION
Both `Naming/HeredocDelimiterNaming` and `Naming/HeredocDelimiterCase` were breaking when encountering heredoc delimiters wrapped in double quotes or back ticks, as well as delimiters consisting purely of non-word characters.

This change fixes that.

Kudos to @pocke for helping research the edge cases.

-----------------

Before submitting the PR make sure the following are checked:

* [X] Wrote [good commit messages][1].
* [X] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [X] Used the same coding conventions as the rest of the project.
* [X] Feature branch is up-to-date with `master` (if not - rebase it).
* [X] Squashed related commits together.
* [X] Added tests.
* [X] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [X] All tests(`rake spec`) are passing.
* [X] The new code doesn't generate RuboCop offenses that are checked by `rake internal_investigation`.
* [X] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [ ] Updated cop documentation with `rake generate_cops_documentation` (required only when you've added a new cop or changed the configuration/documentation of an existing cop).

[1]: http://chris.beams.io/posts/git-commit/
