### PR TITLE
[Fix #4830] `Lint/BooleanSymbol` issue with new hash syntax

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@
 * [#4241](https://github.com/bbatsov/rubocop/issues/4241): Prevent `Rails/Blank` and `Rails/Present` from breaking when there is no explicit receiver. ([@rrosenblum][])
 * [#4814](https://github.com/bbatsov/rubocop/issues/4814): Prevent `Rails/Blank` from breaking on send with an argument. ([@pocke][])
 * [#4759](https://github.com/bbatsov/rubocop/issues/4759): Make `Naming/HeredocDelimiterNaming` and `Naming/HeredocDelimiterCase` aware of more delimiter patterns. ([@drenmi][])
+* [#4830](https://github.com/bbatsov/rubocop/issues/4830): Prevent `Lint/BooleanSymbol` from truncating symbol's value in the message when offense is located in the new syntax hash. ([@akhramov][])
 
 ### Changes
 

--- a/lib/rubocop/cop/lint/boolean_symbol.rb
+++ b/lib/rubocop/cop/lint/boolean_symbol.rb
@@ -30,7 +30,7 @@ module RuboCop
         def on_sym(node)
           return unless boolean_symbol?(node)
 
-          add_offense(node, message: format(MSG, node.source[1..-1]))
+          add_offense(node, message: format(MSG, node.to_a.first))
         end
       end
     end

--- a/spec/rubocop/cop/lint/boolean_symbol_spec.rb
+++ b/spec/rubocop/cop/lint/boolean_symbol_spec.rb
@@ -17,6 +17,22 @@ describe RuboCop::Cop::Lint::BooleanSymbol, :config do
     RUBY
   end
 
+  context 'when using the new hash syntax' do
+    it 'registers an offense when using `true:`' do
+      expect_offense(<<-RUBY.strip_indent)
+        { true: 'Foo' }
+          ^^^^ Symbol with a boolean name - you probably meant to use `true`.
+      RUBY
+    end
+
+    it 'registers an offense when using `false:`' do
+      expect_offense(<<-RUBY.strip_indent)
+        { false: 'Bar' }
+          ^^^^^ Symbol with a boolean name - you probably meant to use `false`.
+      RUBY
+    end
+  end
+
   it 'does not register an offense when using regular symbol' do
     expect_no_offenses(<<-RUBY.strip_indent)
       :something


### PR DESCRIPTION
Currently, when a boolean symbol appears inside the new syntax hash, cop
message truncates the boolean's value. So, instead of "true" and
"false", message contains "rue" and "alse" respectively.

Since symbol interpolates into string, we can use node's value
directly. And this change modifies `Lint/BooleanSymbol` cop to do so.

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Used the same coding conventions as the rest of the project.
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] All tests(`rake spec`) are passing.
* [x] The new code doesn't generate RuboCop offenses that are checked by `rake internal_investigation`.
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [ ] Updated cop documentation with `rake generate_cops_documentation` (required only when you've added a new cop or changed the configuration/documentation of an existing cop).

[1]: http://chris.beams.io/posts/git-commit/
