### PR TITLE
Fix markdown in WordArray lint

### DIFF
--- a/lib/rubocop/cop/style/word_array.rb
+++ b/lib/rubocop/cop/style/word_array.rb
@@ -11,8 +11,8 @@ module RuboCop
       #
       # Configuration option: MinSize
       # If set, arrays with fewer elements than this value will not trigger the
-      # cop. For example, a `MinSize of `3` will not enforce a style on an array
-      # of 2 or fewer elements.
+      # cop. For example, a `MinSize` of `3` will not enforce a style on an
+      # array of 2 or fewer elements.
       #
       # @example
       #   EnforcedStyle: percent (default)

--- a/manual/cops_style.md
+++ b/manual/cops_style.md
@@ -4046,8 +4046,8 @@ which do not want to include that syntax.
 
 Configuration option: MinSize
 If set, arrays with fewer elements than this value will not trigger the
-cop. For example, a `MinSize of `3` will not enforce a style on an array
-of 2 or fewer elements.
+cop. For example, a `MinSize` of `3` will not enforce a style on an
+array of 2 or fewer elements.
 
 ### Example
 


### PR DESCRIPTION
Fixes the Markdown style for the `WordArray` lint.
