### PR TITLE
[Fix #4836] Make `Rails/OutputSafety` aware of safe navigation operator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@
 * [#4823](https://github.com/bbatsov/rubocop/issues/4823): Make `Lint/UnusedMethodArgument` and `Lint/UnusedBlockArgument` aware of overriding assignments. ([@akhramov][])
 * [#4830](https://github.com/bbatsov/rubocop/issues/4830): Prevent `Lint/BooleanSymbol` from truncating symbol's value in the message when offense is located in the new syntax hash. ([@akhramov][])
 * [#4747](https://github.com/bbatsov/rubocop/issues/4747): Fix `Rails/HasManyOrHasOneDependent` cop incorrectly flags `with_options` blocks. ([@koic][])
+* [#4836](https://github.com/bbatsov/rubocop/issues/4836): Make `Rails/OutputSafety` aware of safe navigation operator. ([@drenmi][])
 
 ### Changes
 

--- a/lib/rubocop/cop/rails/output_safety.rb
+++ b/lib/rubocop/cop/rails/output_safety.rb
@@ -78,6 +78,7 @@ module RuboCop
 
           add_offense(node, location: :selector)
         end
+        alias on_csend on_send
 
         private
 

--- a/spec/rubocop/cop/rails/output_safety_spec.rb
+++ b/spec/rubocop/cop/rails/output_safety_spec.rb
@@ -10,11 +10,21 @@ describe RuboCop::Cop::Rails::OutputSafety do
             ^^^^^^^^^^^ Tagging a string as html safe may be a security risk.
       RUBY
     end
+
     it 'registers an offense when wrapped inside `#safe_join`' do
       expect_offense(<<-RUBY.strip_indent)
         safe_join([i18n_text.safe_concat(i18n_text)])
                              ^^^^^^^^^^^ Tagging a string as html safe may be a security risk.
       RUBY
+    end
+
+    context 'when using safe navigation operator', :ruby23 do
+      it 'registers an offense' do
+        expect_offense(<<-RUBY.strip_indent)
+          foo&.safe_concat('bar')
+               ^^^^^^^^^^^ Tagging a string as html safe may be a security risk.
+        RUBY
+      end
     end
   end
 
@@ -55,6 +65,15 @@ describe RuboCop::Cop::Rails::OutputSafety do
         foo(safe_join([i18n_text.html_safe, "bar"]))
                                  ^^^^^^^^^ Tagging a string as html safe may be a security risk.
       RUBY
+    end
+
+    context 'when using safe navigation operator', :ruby23 do
+      it 'registers an offense for variable receiver and no argument' do
+        expect_offense(<<-RUBY.strip_indent)
+          foo&.html_safe
+               ^^^^^^^^^ Tagging a string as html safe may be a security risk.
+        RUBY
+      end
     end
   end
 


### PR DESCRIPTION
The cop would not register an offense when `#html_safe` and `#safe_concat` were sent using the safe navigation operator. This change fixes that.

-----------------

Before submitting the PR make sure the following are checked:

* [X] Wrote [good commit messages][1].
* [X] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [X] Used the same coding conventions as the rest of the project.
* [X] Feature branch is up-to-date with `master` (if not - rebase it).
* [X] Squashed related commits together.
* [X] Added tests.
* [X] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [X] All tests(`rake spec`) are passing.
* [X] The new code doesn't generate RuboCop offenses that are checked by `rake internal_investigation`.
* [X] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [ ] Updated cop documentation with `rake generate_cops_documentation` (required only when you've added a new cop or changed the configuration/documentation of an existing cop).

[1]: http://chris.beams.io/posts/git-commit/
