### PR TITLE
Make the rubocop process to exit with 2 on LoadError

### DIFF
--- a/lib/rubocop/cli.rb
+++ b/lib/rubocop/cli.rb
@@ -35,7 +35,7 @@ module RuboCop
       return 2
     rescue Finished
       return 0
-    rescue StandardError, SyntaxError => e
+    rescue StandardError, SyntaxError, LoadError => e
       warn e.message
       warn e.backtrace
       return 2

--- a/spec/rubocop/cli_spec.rb
+++ b/spec/rubocop/cli_spec.rb
@@ -1646,6 +1646,25 @@ describe RuboCop::CLI, :isolated_environment do
     end
   end
 
+  context 'configuration of `require`' do
+    context 'unknown library is specified' do
+      it 'exits with 2' do
+        create_file('.rubocop.yml', <<-YAML.strip_indent)
+          require: unknownlibrary
+        YAML
+
+        regexp =
+          if RUBY_ENGINE == 'jruby'
+            /no such file to load -- unknownlibrary/
+          else
+            /cannot load such file -- unknownlibrary/
+          end
+        expect(cli.run([])).to eq(2)
+        expect($stderr.string).to match(regexp)
+      end
+    end
+  end
+
   describe 'obsolete cops' do
     context 'when configuration for TrailingComma is given' do
       it 'fails with an error message' do


### PR DESCRIPTION
Problem
========

Currently, RuboCop exits with 1 status code on LoadError.
So, we can't distinguish between LoadError and a case that has offences.
Because in the case, RuboCop exits with 1 status code also.

Reproduce
----

```yaml
require: unknownlibrary
```

```bash
$ rubocop
/usr/lib/ruby/site_ruby/2.4.0/rubygems/core_ext/kernel_require.rb:120:in `require': cannot load such file -- unknownlibrary (LoadError)
	from /usr/lib/ruby/site_ruby/2.4.0/rubygems/core_ext/kernel_require.rb:120:in `require'
	from /home/pocke/.gem/ruby/2.4.0/gems/rubocop-0.50.0/lib/rubocop/config_loader_resolver.rb:15:in `block in resolve_requires'
	from /home/pocke/.gem/ruby/2.4.0/gems/rubocop-0.50.0/lib/rubocop/config_loader_resolver.rb:11:in `each'
	from /home/pocke/.gem/ruby/2.4.0/gems/rubocop-0.50.0/lib/rubocop/config_loader_resolver.rb:11:in `resolve_requires'
	from /home/pocke/.gem/ruby/2.4.0/gems/rubocop-0.50.0/lib/rubocop/config_loader.rb:42:in `load_file'
	from /home/pocke/.gem/ruby/2.4.0/gems/rubocop-0.50.0/lib/rubocop/config_loader.rb:124:in `configuration_from_file'
	from /home/pocke/.gem/ruby/2.4.0/gems/rubocop-0.50.0/lib/rubocop/config_store.rb:44:in `for'
	from /home/pocke/.gem/ruby/2.4.0/gems/rubocop-0.50.0/lib/rubocop/cli.rb:108:in `apply_default_formatter'
	from /home/pocke/.gem/ruby/2.4.0/gems/rubocop-0.50.0/lib/rubocop/cli.rb:30:in `run'
	from /home/pocke/.gem/ruby/2.4.0/gems/rubocop-0.50.0/bin/rubocop:13:in `block in <top (required)>'
	from /usr/lib/ruby/2.4.0/benchmark.rb:308:in `realtime'
	from /home/pocke/.gem/ruby/2.4.0/gems/rubocop-0.50.0/bin/rubocop:12:in `<top (required)>'
	from /home/pocke/.gem/ruby/2.4.0/bin/rubocop:23:in `load'
	from /home/pocke/.gem/ruby/2.4.0/bin/rubocop:23:in `<main>'

$ echo $?
1
```

Solution
=======

Make the rubocop process to exit with 2 on LoadError.

LoadError is not a child of StandardError. So we should specify LoadError expressly.


-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Used the same coding conventions as the rest of the project.
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [ ] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] All tests(`rake spec`) are passing.
* [x] The new code doesn't generate RuboCop offenses that are checked by `rake internal_investigation`.
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [ ] Updated cop documentation with `rake generate_cops_documentation` (required only when you've added a new cop or changed the configuration/documentation of an existing cop).

[1]: http://chris.beams.io/posts/git-commit/
