### PR TITLE
Use smart path for warning message

### DIFF
--- a/lib/rubocop/config.rb
+++ b/lib/rubocop/config.rb
@@ -377,7 +377,7 @@ module RuboCop
         next if Cop::Cop.registry.contains_cop_matching?([name])
 
         warn Rainbow("Warning: unrecognized cop #{name} found in " \
-                     "#{loaded_path}").yellow
+                     "#{smart_loaded_path}").yellow
       end
     end
 
@@ -386,13 +386,14 @@ module RuboCop
                     valid_cop_names.include?('Syntax')
 
       raise ValidationError,
-            "configuration for Syntax cop found in #{loaded_path}\n" \
+            "configuration for Syntax cop found in #{smart_loaded_path}\n" \
             'This cop cannot be configured.'
     end
 
     def validate_section_presence(name)
       return unless key?(name) && self[name].nil?
-      raise ValidationError, "empty section #{name} found in #{loaded_path}"
+      raise ValidationError,
+            "empty section #{name} found in #{smart_loaded_path}"
     end
 
     def validate_parameter_names(valid_cop_names)
@@ -403,7 +404,7 @@ module RuboCop
                   ConfigLoader.default_configuration[name].key?(param)
 
           warn Rainbow("Warning: unrecognized parameter #{name}:#{param} " \
-                       "found in #{loaded_path}").yellow
+                       "found in #{smart_loaded_path}").yellow
         end
       end
     end
@@ -419,7 +420,7 @@ module RuboCop
           next if valid.include?(style)
 
           msg = "invalid #{style_name} '#{style}' for #{name} found in " \
-            "#{loaded_path}\n" \
+            "#{smart_loaded_path}\n" \
             "Valid choices are: #{valid.join(', ')}"
           raise ValidationError, msg
         end
@@ -447,15 +448,15 @@ module RuboCop
       return unless self[cop] && self[cop].key?(parameter)
 
       "obsolete parameter #{parameter} (for #{cop}) " \
-        "found in #{loaded_path}" \
+        "found in #{smart_loaded_path}" \
         "\n#{alternative}"
     end
 
     def obsolete_cops
       OBSOLETE_COPS.map do |cop_name, message|
         next unless key?(cop_name) || key?(Cop::Badge.parse(cop_name).cop_name)
-        message + "\n(obsolete configuration found in #{loaded_path}, please" \
-                   ' update it)'
+        message + "\n(obsolete configuration found in #{smart_loaded_path}," \
+                   ' please update it)'
       end
     end
 
@@ -482,7 +483,7 @@ module RuboCop
       when :dot_ruby_version
         '`.ruby-version`'
       when :rubocop_yml
-        "`TargetRubyVersion` parameter (in #{loaded_path})"
+        "`TargetRubyVersion` parameter (in #{smart_loaded_path})"
       end
     end
 
@@ -507,6 +508,10 @@ module RuboCop
       end
 
       cop_options.fetch('Enabled', true)
+    end
+
+    def smart_loaded_path
+      PathUtil.smart_path(@loaded_path)
     end
   end
 end

--- a/lib/rubocop/cop/registry.rb
+++ b/lib/rubocop/cop/registry.rb
@@ -156,7 +156,8 @@ module RuboCop
 
       def resolve_badge(given_badge, real_badge, source_path)
         unless given_badge.match?(real_badge)
-          warn "#{source_path}: #{given_badge} has the wrong namespace - " \
+          path = PathUtil.smart_path(source_path)
+          warn "#{path}: #{given_badge} has the wrong namespace - " \
                "should be #{real_badge.department}"
         end
 

--- a/spec/rubocop/cli_spec.rb
+++ b/spec/rubocop/cli_spec.rb
@@ -295,7 +295,7 @@ describe RuboCop::CLI, :isolated_environment do
                    'end'])
       expect(cli.run(['--format', 'emacs', 'example.rb'])).to eq(1)
       expect($stderr.string)
-        .to eq(["#{abs('example.rb')}: Style/LineLength has the wrong " \
+        .to eq(['example.rb: Style/LineLength has the wrong ' \
                 'namespace - should be Metrics',
                 ''].join("\n"))
       # 3 cops were disabled, then 2 were enabled again, so we
@@ -1436,8 +1436,8 @@ describe RuboCop::CLI, :isolated_environment do
 
       expect(cli.run(%w[--format simple example])).to eq(1)
       expect($stderr.string)
-        .to eq(['Warning: unrecognized cop Style/LyneLenth found in ' +
-                abs('example/.rubocop.yml'),
+        .to eq(['Warning: unrecognized cop Style/LyneLenth found in ' \
+                'example/.rubocop.yml',
                 ''].join("\n"))
     end
 
@@ -1453,7 +1453,7 @@ describe RuboCop::CLI, :isolated_environment do
       expect(cli.run(%w[--format simple example])).to eq(1)
       expect($stderr.string)
         .to eq(['Warning: unrecognized parameter Metrics/LineLength:Min ' \
-                'found in ' + abs('example/.rubocop.yml'),
+                'found in example/.rubocop.yml',
                 ''].join("\n"))
     end
 
@@ -1467,8 +1467,8 @@ describe RuboCop::CLI, :isolated_environment do
       expect(cli.run(%w[--format simple example])).to eq(2)
       expect($stderr.string)
         .to eq(["Error: invalid EnforcedStyle 'context' for " \
-                'Style/BracesAroundHashParameters found in ' +
-                abs('example/.rubocop.yml'),
+                'Style/BracesAroundHashParameters found in ' \
+                'example/.rubocop.yml',
                 'Valid choices are: braces, no_braces, context_dependent',
                 ''].join("\n"))
     end
@@ -1678,7 +1678,7 @@ describe RuboCop::CLI, :isolated_environment do
           ['Error: The `Style/TrailingComma` cop no longer exists. Please ' \
            'use `Style/TrailingCommaInLiteral` and/or ' \
            '`Style/TrailingCommaInArguments` instead.',
-           "(obsolete configuration found in #{abs('.rubocop.yml')}, " \
+           '(obsolete configuration found in .rubocop.yml, ' \
            'please update it)'].join("\n")
         )
       end


### PR DESCRIPTION
Before:
-----

In warning, always path of `rubocop.yml` is an absolute path.

```
/path/to/.rubocop.yml: Style/MethodName has the wrong namespace - should be Naming
```

After
------

```
.rubocop.yml: Style/MethodName has the wrong namespace - should be Naming
```



-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Used the same coding conventions as the rest of the project.
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [ ] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] All tests(`rake spec`) are passing.
* [x] The new code doesn't generate RuboCop offenses that are checked by `rake internal_investigation`.
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Updated cop documentation with `rake generate_cops_documentation` (required only when you've added a new cop or changed the configuration/documentation of an existing cop).

[1]: http://chris.beams.io/posts/git-commit/
