### PR TITLE
[Fix #4843] Fix shadow rescued Exceptions of same error code

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@
 * [#4830](https://github.com/bbatsov/rubocop/issues/4830): Prevent `Lint/BooleanSymbol` from truncating symbol's value in the message when offense is located in the new syntax hash. ([@akhramov][])
 * [#4747](https://github.com/bbatsov/rubocop/issues/4747): Fix `Rails/HasManyOrHasOneDependent` cop incorrectly flags `with_options` blocks. ([@koic][])
 * [#4836](https://github.com/bbatsov/rubocop/issues/4836): Make `Rails/OutputSafety` aware of safe navigation operator. ([@drenmi][])
+* [#4843](https://github.com/bbatsov/rubocop/issues/4843): Fix `Lint/ShadowedException` cop aware of same system error code. ([@koic][])
 
 ### Changes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,7 +29,7 @@
 * [#4830](https://github.com/bbatsov/rubocop/issues/4830): Prevent `Lint/BooleanSymbol` from truncating symbol's value in the message when offense is located in the new syntax hash. ([@akhramov][])
 * [#4747](https://github.com/bbatsov/rubocop/issues/4747): Fix `Rails/HasManyOrHasOneDependent` cop incorrectly flags `with_options` blocks. ([@koic][])
 * [#4836](https://github.com/bbatsov/rubocop/issues/4836): Make `Rails/OutputSafety` aware of safe navigation operator. ([@drenmi][])
-* [#4843](https://github.com/bbatsov/rubocop/issues/4843): Fix `Lint/ShadowedException` cop aware of same system error code. ([@koic][])
+* [#4843](https://github.com/bbatsov/rubocop/issues/4843): Make `Lint/ShadowedException` cop aware of same system error code. ([@koic][])
 
 ### Changes
 

--- a/lib/rubocop/cop/lint/shadowed_exception.rb
+++ b/lib/rubocop/cop/lint/shadowed_exception.rb
@@ -77,7 +77,17 @@ module RuboCop
             return !(group.size == 2 && group.include?(NilClass))
           end
 
-          group.combination(2).any? { |a, b| a && b && a <=> b }
+          group.combination(2).any? { |a, b|
+            if system_call_error?(a) && system_call_error?(b)
+              a.const_get(:Errno) != b.const_get(:Errno)
+            else
+              a && b && a <=> b
+            end
+          }
+        end
+
+        def system_call_error?(error)
+          error && error.ancestors[1] == SystemCallError
         end
 
         def evaluate_exceptions(rescue_group)

--- a/lib/rubocop/cop/lint/shadowed_exception.rb
+++ b/lib/rubocop/cop/lint/shadowed_exception.rb
@@ -19,8 +19,6 @@ module RuboCop
       #     handle_standard_error
       #   end
       #
-      # @example
-      #
       #   # good
       #
       #   begin
@@ -30,6 +28,21 @@ module RuboCop
       #   rescue Exception
       #     handle_exception
       #   end
+      #
+      #   # good, however depending on runtime environment.
+      #   #
+      #   # This is a special case for system call errors.
+      #   # System dependent error code depends on runtime environment.
+      #   # For example, whether `Errno::EAGAIN` and `Errno::EWOULDBLOCK` are
+      #   # the same error code or different error code depends on environment.
+      #   # This good case is for `Errno::EAGAIN` and `Errno::EWOULDBLOCK` with
+      #   # the same error code.
+      #   begin
+      #     something
+      #   rescue Errno::EAGAIN, Errno::EWOULDBLOCK
+      #     handle_standard_error
+      #   end
+      #
       class ShadowedException < Cop
         include RescueNode
 
@@ -84,6 +97,11 @@ module RuboCop
 
         def compare_exceptions(exception, other_exception)
           if system_call_err?(exception) && system_call_err?(other_exception)
+            # This condition logic is for special case.
+            # System dependent error code depends on runtime environment.
+            # For example, whether `Errno::EAGAIN` and `Errno::EWOULDBLOCK` are
+            # the same error code or different error code depends on runtime
+            # environment. This checks the error code for that.
             exception.const_get(:Errno) != other_exception.const_get(:Errno) &&
               exception <=> other_exception
           else

--- a/lib/rubocop/cop/lint/shadowed_exception.rb
+++ b/lib/rubocop/cop/lint/shadowed_exception.rb
@@ -82,15 +82,16 @@ module RuboCop
           end
         end
 
-        def compare_exceptions(a, b)
-          if system_call_error?(a) && system_call_error?(b)
-            a.const_get(:Errno) != b.const_get(:Errno) && a <=> b
+        def compare_exceptions(exception, other_exception)
+          if system_call_err?(exception) && system_call_err?(other_exception)
+            exception.const_get(:Errno) != other_exception.const_get(:Errno) &&
+              exception <=> other_exception
           else
-            a && b && a <=> b
+            exception && other_exception && exception <=> other_exception
           end
         end
 
-        def system_call_error?(error)
+        def system_call_err?(error)
           error && error.ancestors[1] == SystemCallError
         end
 

--- a/lib/rubocop/cop/lint/shadowed_exception.rb
+++ b/lib/rubocop/cop/lint/shadowed_exception.rb
@@ -77,13 +77,17 @@ module RuboCop
             return !(group.size == 2 && group.include?(NilClass))
           end
 
-          group.combination(2).any? { |a, b|
-            if system_call_error?(a) && system_call_error?(b)
-              a.const_get(:Errno) != b.const_get(:Errno)
-            else
-              a && b && a <=> b
-            end
-          }
+          group.combination(2).any? do |a, b|
+            compare_exceptions(a, b)
+          end
+        end
+
+        def compare_exceptions(a, b)
+          if system_call_error?(a) && system_call_error?(b)
+            a.const_get(:Errno) != b.const_get(:Errno)
+          else
+            a && b && a <=> b
+          end
         end
 
         def system_call_error?(error)

--- a/lib/rubocop/cop/lint/shadowed_exception.rb
+++ b/lib/rubocop/cop/lint/shadowed_exception.rb
@@ -84,7 +84,7 @@ module RuboCop
 
         def compare_exceptions(a, b)
           if system_call_error?(a) && system_call_error?(b)
-            a.const_get(:Errno) != b.const_get(:Errno)
+            a.const_get(:Errno) != b.const_get(:Errno) && a <=> b
           else
             a && b && a <=> b
           end

--- a/manual/cops_lint.md
+++ b/manual/cops_lint.md
@@ -1704,8 +1704,7 @@ rescue Exception
 rescue StandardError
   handle_standard_error
 end
-```
-```ruby
+
 # good
 
 begin
@@ -1714,6 +1713,20 @@ rescue StandardError
   handle_standard_error
 rescue Exception
   handle_exception
+end
+
+# good, however depending on runtime environment.
+#
+# This is a special case for system call errors.
+# System dependent error code depends on runtime environment.
+# For example, whether `Errno::EAGAIN` and `Errno::EWOULDBLOCK` are
+# the same error code or different error code depends on environment.
+# This good case is for `Errno::EAGAIN` and `Errno::EWOULDBLOCK` with
+# the same error code.
+begin
+  something
+rescue Errno::EAGAIN, Errno::EWOULDBLOCK
+  handle_standard_error
 end
 ```
 

--- a/spec/rubocop/cop/lint/shadowed_exception_spec.rb
+++ b/spec/rubocop/cop/lint/shadowed_exception_spec.rb
@@ -60,7 +60,7 @@ describe RuboCop::Cop::Lint::ShadowedException do
       RUBY
     end
 
-    it 'accepts rescuing contain multiple same error code exceptions' do
+    it 'accepts rescue containing multiple same error code exceptions' do
       # System dependent error code depends on runtime environment.
       stub_const('Errno::EAGAIN::Errno', 35)
       stub_const('Errno::EWOULDBLOCK::Errno', 35)

--- a/spec/rubocop/cop/lint/shadowed_exception_spec.rb
+++ b/spec/rubocop/cop/lint/shadowed_exception_spec.rb
@@ -60,6 +60,20 @@ describe RuboCop::Cop::Lint::ShadowedException do
       RUBY
     end
 
+    it 'accepts rescuing multiple same error code exceptions' do
+      # System dependent error code depends on runtime environment.
+      stub_const('Errno::EAGAIN::Errno', 35)
+      stub_const('Errno::EWOULDBLOCK::Errno', 35)
+
+      expect_no_offenses(<<-RUBY.strip_indent)
+        begin
+          something
+        rescue Errno::EAGAIN, Errno::EWOULDBLOCK
+          handle_exception
+        end
+      RUBY
+    end
+
     it 'registers an offense rescuing exceptions that are ' \
       'ancestors of each other ' do
       inspect_source(<<-RUBY.strip_indent)

--- a/spec/rubocop/cop/lint/shadowed_exception_spec.rb
+++ b/spec/rubocop/cop/lint/shadowed_exception_spec.rb
@@ -60,15 +60,16 @@ describe RuboCop::Cop::Lint::ShadowedException do
       RUBY
     end
 
-    it 'accepts rescuing multiple same error code exceptions' do
+    it 'accepts rescuing contain multiple same error code exceptions' do
       # System dependent error code depends on runtime environment.
       stub_const('Errno::EAGAIN::Errno', 35)
       stub_const('Errno::EWOULDBLOCK::Errno', 35)
+      stub_const('Errno::ECONNABORTED::Errno', 53)
 
       expect_no_offenses(<<-RUBY.strip_indent)
         begin
           something
-        rescue Errno::EAGAIN, Errno::EWOULDBLOCK
+        rescue Errno::EAGAIN, Errno::EWOULDBLOCK, Errno::ECONNABORTED
           handle_exception
         end
       RUBY


### PR DESCRIPTION
This PR fixes #4843.
:memo: System dependent error code depends on runtime environment.

This PR also refactor against the following offenses arising from this change.
1db316c

```
% rubocop lib/rubocop/cop/lint/shadowed_exception.rb
Inspecting 1 file
C

Offenses:

lib/rubocop/cop/lint/shadowed_exception.rb:73:9: C: Cyclomatic complexity for contains_multiple_levels_of_exceptions? is too high. [8/6]
        def contains_multiple_levels_of_exceptions?(group)
        ^^^
lib/rubocop/cop/lint/shadowed_exception.rb:73:9: C: Perceived complexity for contains_multiple_levels_of_exceptions? is too high. [9/7]
        def contains_multiple_levels_of_exceptions?(group)
        ^^^
lib/rubocop/cop/lint/shadowed_exception.rb:80:37: C: Avoid using {...} for multi-line blocks.
          group.combination(2).any? { |a, b|
                                    ^

1 file inspected, 3 offenses detected
```

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Used the same coding conventions as the rest of the project.
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] All tests(`rake spec`) are passing.
* [x] The new code doesn't generate RuboCop offenses that are checked by `rake internal_investigation`.
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [ ] Updated cop documentation with `rake generate_cops_documentation` (required only when you've added a new cop or changed the configuration/documentation of an existing cop).

[1]: http://chris.beams.io/posts/git-commit/
