### PR TITLE
Remove Ruby 2.0 code from `Lint/CircularArgumentReference` cop

### DIFF
--- a/lib/rubocop/cop/lint/circular_argument_reference.rb
+++ b/lib/rubocop/cop/lint/circular_argument_reference.rb
@@ -61,19 +61,8 @@ module RuboCop
         private
 
         def check_for_circular_argument_references(arg_name, arg_value)
-          case arg_value.type
-          when :send
-            # Ruby 2.0 will have type send every time, and "send nil" if it is
-            # calling itself with a specified "self" receiver
-            receiver, name = *arg_value
-            return unless name == arg_name && receiver.nil?
-          when :lvar
-            # Ruby 2.2.2 will have type lvar if it is calling its own method
-            # without a specified "self"
-            return unless arg_value.to_a == [arg_name]
-          else
-            return
-          end
+          return unless arg_value.lvar_type?
+          return unless arg_value.to_a == [arg_name]
 
           add_offense(arg_value, message: format(MSG, arg_name))
         end


### PR DESCRIPTION
Follow up #4787.

This PR removes Ruby 2.0 code from `Lint/CircularArgumentReference` cop.

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Used the same coding conventions as the rest of the project.
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [ ] Added tests.
* [ ] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] All tests(`rake spec`) are passing.
* [x] The new code doesn't generate RuboCop offenses that are checked by `rake internal_investigation`.
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [ ] Updated cop documentation with `rake generate_cops_documentation` (required only when you've added a new cop or changed the configuration/documentation of an existing cop).

[1]: http://chris.beams.io/posts/git-commit/
