### PR TITLE
Remove Ruby 1.9 code from `Lint/ShadowedException` cop

### DIFF
--- a/lib/rubocop/cop/lint/shadowed_exception.rb
+++ b/lib/rubocop/cop/lint/shadowed_exception.rb
@@ -116,12 +116,6 @@ module RuboCop
         def rescued_exceptions(rescue_group)
           klasses = *rescue_group
           klasses.map do |klass|
-            # `rescue nil` is valid syntax in all versions of Ruby. In Ruby
-            # 1.9.3, it effectively disables the `rescue`. In versions
-            # after 1.9.3, a `TypeError` is thrown when the statement is
-            # rescued. In order to account for this, we convert `nil` to
-            # `NilClass`.
-            next 'NilClass' if klass.nil_type?
             next unless klass.const_type?
             klass.source
           end.compact


### PR DESCRIPTION
This looks like code for Ruby 1.9 no longer needed.

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Used the same coding conventions as the rest of the project.
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [ ] Added tests.
* [ ] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] All tests(`rake spec`) are passing.
* [x] The new code doesn't generate RuboCop offenses that are checked by `rake internal_investigation`.
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [ ] Updated cop documentation with `rake generate_cops_documentation` (required only when you've added a new cop or changed the configuration/documentation of an existing cop).

[1]: http://chris.beams.io/posts/git-commit/
