### PR TITLE
[Fix #4641] Better Performance/RedundantMatch documentation

### DIFF
--- a/lib/rubocop/cop/performance/redundant_match.rb
+++ b/lib/rubocop/cop/performance/redundant_match.rb
@@ -3,8 +3,9 @@
 module RuboCop
   module Cop
     module Performance
-      # This cop identifies use of `Regexp#match` or `String#match` in a context
-      # where the integral return value of `=~` would do just as well.
+      # This cop identifies the use of `Regexp#match` or `String#match`, which
+      # returns `#<MatchData>`/`nil`. The return value of `=~` is an integral
+      # index/`nil` and is more performant.
       #
       # @example
       #   @bad
@@ -14,8 +15,8 @@ module RuboCop
       #   end
       #
       #   @good
-      #   method(str.match(/regex/))
-      #   return regex.match('str')
+      #   method(str =~ /regex/)
+      #   return value unless regex =~ 'str'
       class RedundantMatch < Cop
         MSG = 'Use `=~` in places where the `MatchData` returned by ' \
               '`#match` will not be used.'.freeze

--- a/manual/cops_performance.md
+++ b/manual/cops_performance.md
@@ -448,8 +448,9 @@ Enabled by default | Supports autocorrection
 --- | ---
 Enabled | Yes
 
-This cop identifies use of `Regexp#match` or `String#match` in a context
-where the integral return value of `=~` would do just as well.
+This cop identifies the use of `Regexp#match` or `String#match`, which
+returns `#<MatchData>`/`nil`. The return value of `=~` is an integral
+index/`nil` and is more performant.
 
 ### Example
 
@@ -461,8 +462,8 @@ while regex.match('str')
 end
 
 # good
-method(str.match(/regex/))
-return regex.match('str')
+method(str =~ /regex/)
+return value unless regex =~ 'str'
 ```
 
 ## Performance/RedundantMerge


### PR DESCRIPTION
As described in issue #4641 , the examples for `Performance/RedundantMatch` do not match the documentation. This change updates its "good" examples and adds return value detail to its description.

-----------------

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Used the same coding conventions as the rest of the project.
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] All tests(`rake spec`) are passing.
* [x] The new code doesn't generate RuboCop offenses that are checked by `rake internal_investigation`.
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.

[1]: http://chris.beams.io/posts/git-commit/
