### PR TITLE
[Fix #4252] Register `SingleLineMethod` when trailing body on_def line

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@
 * [#4909](https://github.com/bbatsov/rubocop/issues/4909): Make `Rails/HasManyOrHasOneDependent` aware of multiple associations in `with_options`. ([@koic][])
 * [#4794](https://github.com/bbatsov/rubocop/issues/4794): Fix an error in `Layout/MultilineOperationIndentation` when an operation spans multiple lines and contains a ternary expression. ([@rrosenblum][])
 * [#4885](https://github.com/bbatsov/rubocop/issues/4885): Fix false offense detected by `Style/MixinUsage` cop. ([@koic][])
+* [#4252](https://github.com/bbatsov/rubocop/issues/4252): Register an offense for a trailing body on definition line in `Style/SingleLineMethod`. ([@garettarrowood][])
 
 ### Changes
 
@@ -69,7 +70,6 @@
 * [#4597](https://github.com/bbatsov/rubocop/pull/4597): Fix `Style/StringLiterals` cop not registering an offense on single quoted strings containing an escaped single quote when configured to use double quotes. ([@promisedlandt][])
 * [#4850](https://github.com/bbatsov/rubocop/issues/4850): `Lint/UnusedMethodArgument` respects `IgnoreEmptyMethods` setting by ignoring unused method arguments for singleton methods. ([@jmks][])
 * [#2040](https://github.com/bbatsov/rubocop/issues/2040): Document how to write a custom cop. ([@jonatas][])
-* [#4252](https://github.com/bbatsov/rubocop/issues/4252): Raise `Style/SingleLineMethod` offense when trailing body on definition line. ([@garettarrowood][])
 
 ### Changes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -69,6 +69,7 @@
 * [#4597](https://github.com/bbatsov/rubocop/pull/4597): Fix `Style/StringLiterals` cop not registering an offense on single quoted strings containing an escaped single quote when configured to use double quotes. ([@promisedlandt][])
 * [#4850](https://github.com/bbatsov/rubocop/issues/4850): `Lint/UnusedMethodArgument` respects `IgnoreEmptyMethods` setting by ignoring unused method arguments for singleton methods. ([@jmks][])
 * [#2040](https://github.com/bbatsov/rubocop/issues/2040): Document how to write a custom cop. ([@jonatas][])
+* [#4252](https://github.com/bbatsov/rubocop/issues/4252): Raise `Style/SingleLineMethod` offense when trailing body on definition line. ([@garettarrowood][])
 
 ### Changes
 
@@ -3007,3 +3008,4 @@
 [@michniewicz]: https://github.com/michniewicz
 [@bgeuken]: https://github.com/bgeuken
 [@mtsmfm]: https://github.com/mtsmfm
+[@garettarrowood]: https://github.com/garettarrowood

--- a/lib/rubocop/ast/node.rb
+++ b/lib/rubocop/ast/node.rb
@@ -321,6 +321,10 @@ module RuboCop
         !multiline?
       end
 
+      def two_lines?
+        source_range && (source_range.last_line - source_range.first_line == 1)
+      end
+
       def asgn_method_call?
         !COMPARISON_OPERATORS.include?(method_name) &&
           method_name.to_s.end_with?('='.freeze)

--- a/lib/rubocop/ast/node.rb
+++ b/lib/rubocop/ast/node.rb
@@ -323,7 +323,7 @@ module RuboCop
 
       def line_count
         return 0 unless source_range
-        (source_range.last_line - source_range.first_line) + 1
+        source_range.last_line - source_range.first_line + 1
       end
 
       def asgn_method_call?

--- a/lib/rubocop/ast/node.rb
+++ b/lib/rubocop/ast/node.rb
@@ -314,15 +314,16 @@ module RuboCop
       ## Predicates
 
       def multiline?
-        source_range && (source_range.first_line != source_range.last_line)
+        line_count > 1
       end
 
       def single_line?
         !multiline?
       end
 
-      def two_lines?
-        source_range && (source_range.last_line - source_range.first_line == 1)
+      def line_count
+        return 0 unless source_range
+        (source_range.last_line - source_range.first_line) + 1
       end
 
       def asgn_method_call?

--- a/lib/rubocop/cop/style/single_line_methods.rb
+++ b/lib/rubocop/cop/style/single_line_methods.rb
@@ -11,8 +11,7 @@ module RuboCop
         MSG = 'Avoid single-line method definitions.'.freeze
 
         def on_def(node)
-          return if allow_empty? && !node.body
-          return unless node.single_line? || node.two_lines?
+          return if (allow_empty? && !node.body) || node.line_count > 2
 
           add_offense(node)
         end

--- a/lib/rubocop/cop/style/single_line_methods.rb
+++ b/lib/rubocop/cop/style/single_line_methods.rb
@@ -11,8 +11,8 @@ module RuboCop
         MSG = 'Avoid single-line method definitions.'.freeze
 
         def on_def(node)
-          return unless node.single_line?
           return if allow_empty? && !node.body
+          return unless node.single_line? || node.two_lines?
 
           add_offense(node)
         end

--- a/lib/rubocop/cop/style/single_line_methods.rb
+++ b/lib/rubocop/cop/style/single_line_methods.rb
@@ -5,6 +5,23 @@ module RuboCop
     module Style
       # This cop checks for single-line method definitions.
       # It can optionally accept single-line methods with no body.
+      #
+      # @example
+      #   # bad
+      #   def some_method; body end
+      #   def @table.columns; super; end
+      #
+      #   # bad (trailing body after def)
+      #   def foo; body
+      #   end
+      #
+      #   # good (when no body)
+      #   def no_op; end
+      #
+      #   # good
+      #   def some_method
+      #     do_things
+      #   end
       class SingleLineMethods < Cop
         include AutocorrectAlignment
 

--- a/manual/cops_style.md
+++ b/manual/cops_style.md
@@ -3763,6 +3763,26 @@ Enabled | Yes
 This cop checks for single-line method definitions.
 It can optionally accept single-line methods with no body.
 
+### Example
+
+```ruby
+# bad
+def some_method; body end
+def @table.columns; super; end
+
+# bad (trailing body after def)
+def foo; body
+end
+
+# good (when no body)
+def no_op; end
+
+# good
+def some_method
+  do_things
+end
+```
+
 ### Important attributes
 
 Attribute | Value

--- a/spec/rubocop/cop/style/single_line_methods_spec.rb
+++ b/spec/rubocop/cop/style/single_line_methods_spec.rb
@@ -21,12 +21,11 @@ describe RuboCop::Cop::Style::SingleLineMethods do
   end
 
   it 'registers an offense for trailing body after def line' do
-    inspect_source(<<-RUBY.strip_indent)
+    expect_offense(<<-RUBY.strip_indent)
       def foo; body
+      ^^^^^^^^^^^^^ Avoid single-line method definitions.
       end
     RUBY
-    expect(cop.offenses.size).to eq(1)
-    expect(cop.messages.first).to eq('Avoid single-line method definitions.')
   end
 
   context 'when AllowIfMethodIsEmpty is disabled' do

--- a/spec/rubocop/cop/style/single_line_methods_spec.rb
+++ b/spec/rubocop/cop/style/single_line_methods_spec.rb
@@ -20,6 +20,15 @@ describe RuboCop::Cop::Style::SingleLineMethods do
     RUBY
   end
 
+  it 'registers an offense for trailing body after def line' do
+    inspect_source(<<-RUBY.strip_indent)
+      def foo; body
+      end
+    RUBY
+    expect(cop.offenses.size).to eq(1)
+    expect(cop.messages.first).to eq('Avoid single-line method definitions.')
+  end
+
   context 'when AllowIfMethodIsEmpty is disabled' do
     let(:cop_config) { { 'AllowIfMethodIsEmpty' => false } }
 


### PR DESCRIPTION
This PR resolves issue #4252 .  

While aiming to resolve this new failing spec, it became clear that there was no appropriate scenario for a two-line method (please correct me if I'm wrong). Adding a check for a two-line method inside the `SingleLineMethod` class does feel pretty odd, but appears to satisfy the bug and similar situations. Suggestions are very welcome.

-----------------

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Used the same coding conventions as the rest of the project.
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Added tests.
* [x] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] All tests(`rake spec`) are passing.
* [x] The new code doesn't generate RuboCop offenses that are checked by `rake internal_investigation`.
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Updated cop documentation with `rake generate_cops_documentation` (required only when you've added a new cop or changed the configuration/documentation of an existing cop).

[1]: http://chris.beams.io/posts/git-commit/
