### PR TITLE
Make `Lint/LiteralInCondition` cop aware of `!` and `not`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,7 @@
 * [#4787](https://github.com/bbatsov/rubocop/pull/4787): Analyzing code that needs to support MRI 2.0 is no longer supported. ([@deivid-rodriguez][])
 * [#4787](https://github.com/bbatsov/rubocop/pull/4787): RuboCop no longer installs on MRI 2.0. ([@deivid-rodriguez][])
 * [#4266](https://github.com/bbatsov/rubocop/issues/4266): Download the inherited config files of a remote file from the same remote. ([@tdeo][])
+* [#4853](https://github.com/bbatsov/rubocop/pull/4853): Make `Lint/LiteralInCondition` cop aware of `!` and `not`. ([@pocke][])
 
 ## 0.50.0 (2017-09-14)
 

--- a/lib/rubocop/ast/node/send_node.rb
+++ b/lib/rubocop/ast/node/send_node.rb
@@ -16,6 +16,10 @@ module RuboCop
       def node_parts
         to_a
       end
+
+      def negation_method?
+        keyword_bang? || keyword_not?
+      end
     end
   end
 end

--- a/lib/rubocop/cop/lint/literal_in_condition.rb
+++ b/lib/rubocop/cop/lint/literal_in_condition.rb
@@ -65,6 +65,11 @@ module RuboCop
           end
         end
 
+        def on_send(node)
+          return unless node.negation_method?
+          check_for_literal(node)
+        end
+
         def message(node)
           format(MSG, node.source)
         end
@@ -72,10 +77,11 @@ module RuboCop
         private
 
         def check_for_literal(node)
-          if node.condition.literal?
-            add_offense(node.condition)
+          cond = condition(node)
+          if cond.literal?
+            add_offense(cond)
           else
-            check_node(node.condition)
+            check_node(cond)
           end
         end
 
@@ -120,6 +126,14 @@ module RuboCop
           return if condition.dstr_type?
 
           handle_node(condition)
+        end
+
+        def condition(node)
+          if node.send_type?
+            node.receiver
+          else
+            node.condition
+          end
         end
       end
     end

--- a/spec/rubocop/ast/send_node_spec.rb
+++ b/spec/rubocop/ast/send_node_spec.rb
@@ -858,4 +858,24 @@ describe RuboCop::AST::SendNode do
       it { expect(send_node.def_modifier?).to be_truthy }
     end
   end
+
+  describe '#negation_method?' do
+    context 'with keyword `not`' do
+      let(:source) { 'not foo' }
+
+      it { expect(send_node).to be_negation_method }
+    end
+
+    context 'with bang method' do
+      let(:source) { '!foo' }
+
+      it { expect(send_node).to be_negation_method }
+    end
+
+    context 'with normal method' do
+      let(:source) { 'foo.bar' }
+
+      it { expect(send_node).not_to be_negation_method }
+    end
+  end
 end

--- a/spec/rubocop/cop/lint/literal_in_condition_spec.rb
+++ b/spec/rubocop/cop/lint/literal_in_condition_spec.rb
@@ -131,6 +131,20 @@ describe RuboCop::Cop::Lint::LiteralInCondition do
       RUBY
       expect(cop.offenses).to be_empty
     end
+
+    it "registers an offense for `!#{lit}`" do
+      inspect_source(<<-RUBY.strip_indent)
+        !#{lit}
+      RUBY
+      expect(cop.offenses.size).to eq(1)
+    end
+
+    it "registers an offense for `not #{lit}`" do
+      inspect_source(<<-RUBY.strip_indent)
+        !#{lit}
+      RUBY
+      expect(cop.offenses.size).to eq(1)
+    end
   end
 
   it 'accepts array literal in case, if it has non-literal elements' do


### PR DESCRIPTION
By this change, `Lint/LiteralInCondition` cop will register an offence for the following code.

```ruby
!'foo'

not 'foo'
```


-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Used the same coding conventions as the rest of the project.
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] All tests(`rake spec`) are passing.
* [x] The new code doesn't generate RuboCop offenses that are checked by `rake internal_investigation`.
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Updated cop documentation with `rake generate_cops_documentation` (required only when you've added a new cop or changed the configuration/documentation of an existing cop).

[1]: http://chris.beams.io/posts/git-commit/
