### PR TITLE
[Fix #4727] Check for nonmutating methods in Lint/Void

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -198,6 +198,7 @@
 * [#4874](https://github.com/bbatsov/rubocop/pull/4874): Add new `Gemspec/OrderedDependencies` cop. ([@sue445][])
 * [#4840](https://github.com/bbatsov/rubocop/pull/4840): Add new `Style/MixinUsage` cop. ([@koic][])
 * [#1952](https://github.com/bbatsov/rubocop/issues/1952): Add new `Style/DateTime` cop. ([@dpostorivo][])
+* [#4727](https://github.com/bbatsov/rubocop/issues/4727): Make `Lint/Void` check for nonmutating methods as well. ([@donjar][])
 
 ### Bug fixes
 

--- a/config/default.yml
+++ b/config/default.yml
@@ -1572,6 +1572,9 @@ Lint/UnusedMethodArgument:
   AllowUnusedKeywordArguments: false
   IgnoreEmptyMethods: true
 
+Lint/Void:
+  CheckForMethodsWithNoSideEffects: false
+
 #################### Performance ###########################
 
 Performance/DoubleStartEndWith:

--- a/manual/cops_lint.md
+++ b/manual/cops_lint.md
@@ -2347,8 +2347,8 @@ Enabled by default | Supports autocorrection
 --- | ---
 Enabled | No
 
-This cop checks for operators, variables and literals used
-in void context.
+This cop checks for operators, variables, literals, and nonmutating
+methods used in void context.
 
 ### Examples
 
@@ -2369,6 +2369,14 @@ def some_method(some_var)
 end
 ```
 ```ruby
+# bad, when CheckForMethodsWithNoSideEffects is set true
+
+def some_method(some_array)
+  some_array.sort
+  do_something(some_array)
+end
+```
+```ruby
 # good
 
 def some_method
@@ -2384,3 +2392,17 @@ def some_method(some_var)
   some_var
 end
 ```
+```ruby
+# good, when CheckForMethodsWithNoSideEffects is set true
+
+def some_method(some_array)
+  some_array.sort!
+  do_something(some_array)
+end
+```
+
+### Configurable attributes
+
+Name | Default value | Configurable values
+--- | --- | ---
+CheckForMethodsWithNoSideEffects | `false` | Boolean


### PR DESCRIPTION
`Lint/Void` will now check nonmutating methods used in void context, for example `[2, 3, 1].sort`, `'abc'.gsub`, etc.

Several things that I haven't resolved though:
- String has a `#delete` and `#delete!` method, whereas a hash only has a `#delete` method. Hence, this cop gives a false positive on `delete` methods used in hashes. Maybe using a blacklist of methods is better?
- Should I add more methods other than `Array` and `String`? I can't think of any at the moment.

-----------------

Before submitting the PR make sure the following are checked:

* [X] Wrote [good commit messages][1].
* [X] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [X] Used the same coding conventions as the rest of the project.
* [X] Feature branch is up-to-date with `master` (if not - rebase it).
* [X] Squashed related commits together.
* [X] Added tests.
* [X] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [X] All tests(`rake spec`) are passing.
* [x] The new code doesn't generate RuboCop offenses that are checked by `rake internal_investigation`.
* [X] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [X] Updated cop documentation with `rake generate_cops_documentation` (required only when you've added a new cop or changed the configuration/documentation of an existing cop).

[1]: http://chris.beams.io/posts/git-commit/
