### PR TITLE
Refactor method names based on `PredicateName` cop rule

### DIFF
--- a/lib/rubocop/cop/rails/has_many_or_has_one_dependent.rb
+++ b/lib/rubocop/cop/rails/has_many_or_has_one_dependent.rb
@@ -23,19 +23,19 @@ module RuboCop
       class HasManyOrHasOneDependent < Cop
         MSG = 'Specify a `:dependent` option.'.freeze
 
-        def_node_matcher :has_many_or_has_one_without_options?, <<-PATTERN
+        def_node_matcher :association_without_options?, <<-PATTERN
           (send nil? {:has_many :has_one} _)
         PATTERN
 
-        def_node_matcher :has_many_or_has_one_with_options?, <<-PATTERN
+        def_node_matcher :association_with_options?, <<-PATTERN
           (send nil? {:has_many :has_one} _ (hash $...))
         PATTERN
 
-        def_node_matcher :has_dependent?, <<-PATTERN
+        def_node_matcher :dependent_option?, <<-PATTERN
           (pair (sym :dependent) !nil)
         PATTERN
 
-        def_node_matcher :has_through?, <<-PATTERN
+        def_node_matcher :present_option?, <<-PATTERN
           (pair (sym :through) !nil)
         PATTERN
 
@@ -47,8 +47,8 @@ module RuboCop
         PATTERN
 
         def on_send(node)
-          if !has_many_or_has_one_without_options?(node)
-            return if valid_options?(has_many_or_has_one_with_options?(node))
+          if !association_without_options?(node)
+            return if valid_options?(association_with_options?(node))
           elsif with_options_block(node.parent)
             return if valid_options?(with_options_block(node.parent))
           end
@@ -61,7 +61,7 @@ module RuboCop
         def valid_options?(options)
           return true unless options
           return true if options.any? do |o|
-            has_dependent?(o) || has_through?(o)
+            dependent_option?(o) || present_option?(o)
           end
 
           false

--- a/lib/rubocop/cop/rails/not_null_column.rb
+++ b/lib/rubocop/cop/rails/not_null_column.rb
@@ -31,7 +31,7 @@ module RuboCop
           (pair (sym :null) (false))
         PATTERN
 
-        def_node_matcher :has_default?, <<-PATTERN
+        def_node_matcher :default_option?, <<-PATTERN
           (pair (sym :default) !nil)
         PATTERN
 
@@ -54,7 +54,7 @@ module RuboCop
 
         def check_pairs(pairs)
           return unless pairs
-          return if pairs.any? { |pair| has_default?(pair) }
+          return if pairs.any? { |pair| default_option?(pair) }
 
           null_false = pairs.find { |pair| null_false?(pair) }
           return unless null_false


### PR DESCRIPTION
Follow up for https://github.com/bbatsov/rubocop/pull/4855#discussion_r144230757

RuboCop does not have an internal investigation cop that checks dynamically generated methods now. This is handmade modified based on `Naming/PredicateName` cop rule.

Cc @Drenmi who suggested these names 🙏 

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Used the same coding conventions as the rest of the project.
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [ ] Added tests.
* [ ] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] All tests(`rake spec`) are passing.
* [x] The new code doesn't generate RuboCop offenses that are checked by `rake internal_investigation`.
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [ ] Updated cop documentation with `rake generate_cops_documentation` (required only when you've added a new cop or changed the configuration/documentation of an existing cop).

[1]: http://chris.beams.io/posts/git-commit/
