### PR TITLE
[Fix #4850] `Lint/UnusedMethodArgument` respects `IgnoreEmptyMethods` setting by ignoring unused method arguments for singleton methods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@
 * [#4747](https://github.com/bbatsov/rubocop/issues/4747): Fix `Rails/HasManyOrHasOneDependent` cop incorrectly flags `with_options` blocks. ([@koic][])
 * [#4836](https://github.com/bbatsov/rubocop/issues/4836): Make `Rails/OutputSafety` aware of safe navigation operator. ([@drenmi][])
 * [#4843](https://github.com/bbatsov/rubocop/issues/4843): Make `Lint/ShadowedException` cop aware of same system error code. ([@koic][])
+* [#4850](https://github.com/bbatsov/rubocop/issues/4850): `Lint/UnusedMethodArgument` respects `IgnoreEmptyMethods` setting by ignoring unused method arguments for singleton methods. ([@jmks][])
 
 ### Changes
 

--- a/lib/rubocop/cop/lint/unused_method_argument.rb
+++ b/lib/rubocop/cop/lint/unused_method_argument.rb
@@ -29,7 +29,8 @@ module RuboCop
                     cop_config['AllowUnusedKeywordArguments']
 
           if cop_config['IgnoreEmptyMethods']
-            _name, _args, body = *variable.scope.node
+            body = variable.scope.node.body
+
             return if body.nil?
           end
 

--- a/spec/rubocop/cop/lint/unused_method_argument_spec.rb
+++ b/spec/rubocop/cop/lint/unused_method_argument_spec.rb
@@ -458,6 +458,13 @@ describe RuboCop::Cop::Lint::UnusedMethodArgument, :config do
       RUBY
     end
 
+    it 'accepts an empty singleton method with a single unused parameter' do
+      expect_no_offenses(<<-RUBY.strip_indent)
+        def self.method(unused)
+        end
+      RUBY
+    end
+
     it 'registers an offense for a non-empty method with a single unused ' \
         'parameter' do
 

--- a/spec/rubocop/cop/lint/unused_method_argument_spec.rb
+++ b/spec/rubocop/cop/lint/unused_method_argument_spec.rb
@@ -120,21 +120,25 @@ describe RuboCop::Cop::Lint::UnusedMethodArgument, :config do
     end
 
     context 'when an underscore-prefixed method argument is unused' do
+      let(:source) { <<-RUBY.strip_indent }
+        def some_method(_foo)
+        end
+      RUBY
+
       it 'accepts' do
-        expect_no_offenses(<<-RUBY.strip_indent)
-          def some_method(_foo)
-          end
-        RUBY
+        expect_no_offenses(source)
       end
     end
 
     context 'when a method argument is used' do
+      let(:source) { <<-RUBY.strip_indent }
+        def some_method(foo)
+          puts foo
+        end
+      RUBY
+
       it 'accepts' do
-        expect_no_offenses(<<-RUBY.strip_indent)
-          def some_method(foo)
-            puts foo
-          end
-        RUBY
+        expect_no_offenses(source)
       end
     end
 
@@ -212,21 +216,25 @@ describe RuboCop::Cop::Lint::UnusedMethodArgument, :config do
     end
 
     context 'when a variable is unused' do
+      let(:source) { <<-RUBY.strip_indent }
+        def some_method
+          foo = 1
+        end
+      RUBY
+
       it 'does not care' do
-        expect_no_offenses(<<-RUBY.strip_indent)
-          def some_method
-            foo = 1
-          end
-        RUBY
+        expect_no_offenses(source)
       end
     end
 
     context 'when a block argument is unused' do
+      let(:source) { <<-RUBY.strip_indent }
+        1.times do |foo|
+        end
+      RUBY
+
       it 'does not care' do
-        expect_no_offenses(<<-RUBY.strip_indent)
-          1.times do |foo|
-          end
-        RUBY
+        expect_no_offenses(source)
       end
     end
 
@@ -264,12 +272,14 @@ describe RuboCop::Cop::Lint::UnusedMethodArgument, :config do
     end
 
     context 'in a method calling `binding` without arguments' do
+      let(:source) { <<-RUBY.strip_indent }
+        def some_method(foo, bar)
+          do_something binding
+        end
+      RUBY
+
       it 'accepts all arguments' do
-        expect_no_offenses(<<-RUBY.strip_indent)
-          def some_method(foo, bar)
-            do_something binding
-          end
-        RUBY
+        expect_no_offenses(source)
       end
 
       context 'inside another method definition' do


### PR DESCRIPTION
 The Lint/UnusedMethodArgument gave inconsistent results on instance and singleton (class) methods with unused arguments with the `IgnoreEmptyMethods` on.

The destructuring of the `:def` and `:defs` nodes are different, so I used an existing method that correctly returns the node's body.

I have a second commit that removes several duplicated code examples in the spec file. The `source` variable is required in an outer context (it is used by `inspect_source` method in a `before` block), so methods not directly relying on the `cop` variable (e.g. `expect_no_offenses`) effectively process the source twice. I had the options to inline `inspect_source` or define `source` in each example, and I chose the later.

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Used the same coding conventions as the rest of the project.
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] All tests(`rake spec`) are passing.
* [x] The new code doesn't generate RuboCop offenses that are checked by `rake internal_investigation`.
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [ ] Updated cop documentation with `rake generate_cops_documentation` (required only when you've added a new cop or changed the configuration/documentation of an existing cop).

[1]: http://chris.beams.io/posts/git-commit/
