### PR TITLE
Change Unused Arguments cops' specs to use the new matcher format

### DIFF
--- a/spec/rubocop/cop/lint/unused_method_argument_spec.rb
+++ b/spec/rubocop/cop/lint/unused_method_argument_spec.rb
@@ -7,110 +7,87 @@ describe RuboCop::Cop::Lint::UnusedMethodArgument, :config do
   end
 
   describe 'inspection' do
-    before do
-      inspect_source(source)
-    end
-
     context 'when a method takes multiple arguments' do
       context 'and an argument is unused' do
-        let(:source) { <<-RUBY }
-          def some_method(foo, bar)
-            puts bar
-          end
-        RUBY
-
         it 'registers an offense' do
-          expect(cop.offenses.size).to eq(1)
-          expect(cop.offenses.first.message).to eq(
-            'Unused method argument - `foo`. ' \
-            "If it's necessary, use `_` or `_foo` " \
-            "as an argument name to indicate that it won't be used."
-          )
-          expect(cop.offenses.first.severity.name).to eq(:warning)
-          expect(cop.offenses.first.line).to eq(1)
-          expect(cop.highlights).to eq(['foo'])
+          message = 'Unused method argument - `foo`. ' \
+                      "If it's necessary, use `_` or `_foo` " \
+                      "as an argument name to indicate that it won't be used."
+
+          expect_offense(<<-RUBY.strip_indent)
+            def some_method(foo, bar)
+                            ^^^ #{message}
+              puts bar
+            end
+          RUBY
         end
 
         context 'and arguments are swap-assigned' do
-          let(:source) { <<-RUBY }
-            def foo(a, b)
-              a, b = b, a
-            end
-          RUBY
-
           it 'accepts' do
-            expect_no_offenses(source)
+            expect_no_offenses(<<-RUBY.strip_indent)
+              def foo(a, b)
+                a, b = b, a
+              end
+            RUBY
           end
         end
 
         context "and one argument is assigned to another, whilst other's " \
                   'value is not used' do
-          let(:source) { <<-RUBY }
-            def foo(a, b)
-              a, b = b, 42
-            end
-          RUBY
-
           it 'registers an offense' do
-            expect(cop.offenses.size).to eq(1)
-            expect(cop.offenses.first.message).to eq(
-              'Unused method argument - `a`. ' \
-                "If it's necessary, use `_` or `_a` as an argument name " \
-                "to indicate that it won't be used."
-            )
-            expect(cop.offenses.first.severity.name).to eq(:warning)
-            expect(cop.offenses.first.line).to eq(1)
-            expect(cop.highlights).to eq(['a'])
+            message = "Unused method argument - `a`. If it's necessary, use " \
+                        '`_` or `_a` as an argument name to indicate that ' \
+                        "it won't be used."
+
+            expect_offense(<<-RUBY.strip_indent)
+              def foo(a, b)
+                      ^ #{message}
+                a, b = b, 42
+              end
+            RUBY
           end
         end
       end
 
       context 'and all the arguments are unused' do
-        let(:source) { <<-RUBY }
-          def some_method(foo, bar)
-          end
-        RUBY
-
         it 'registers offenses and suggests the use of `*`' do
-          expect(cop.offenses.size).to eq(2)
-          expect(cop.offenses.first.message).to eq(
-            'Unused method argument - `foo`. ' \
-            "If it's necessary, use `_` or `_foo` " \
+          (foo_message, bar_message) = %w[foo bar].map do |arg|
+            "Unused method argument - `#{arg}`. " \
+            "If it's necessary, use `_` or `_#{arg}` " \
             "as an argument name to indicate that it won't be used. " \
             'You can also write as `some_method(*)` if you want the method ' \
             "to accept any arguments but don't care about them."
-          )
+          end
+
+          expect_offense(<<-RUBY.strip_indent)
+            def some_method(foo, bar)
+                                 ^^^ #{bar_message}
+                            ^^^ #{foo_message}
+            end
+          RUBY
         end
       end
     end
 
     context 'when a required keyword argument is unused', ruby: 2.1 do
-      let(:source) { <<-RUBY }
-        def self.some_method(foo, bar:)
-          puts foo
-        end
-      RUBY
-
       it 'registers an offense but does not suggest underscore-prefix' do
-        expect(cop.offenses.size).to eq(1)
-        expect(cop.highlights).to eq(['bar'])
-        expect(cop.offenses.first.message)
-          .to eq('Unused method argument - `bar`.')
+        expect_offense(<<-RUBY.strip_indent)
+          def self.some_method(foo, bar:)
+                                    ^^^ Unused method argument - `bar`.
+            puts foo
+          end
+        RUBY
       end
     end
 
     context 'when an optional keyword argument is unused' do
-      let(:source) { <<-RUBY }
-        def self.some_method(foo, bar: 1)
-          puts foo
-        end
-      RUBY
-
       it 'registers an offense but does not suggest underscore-prefix' do
-        expect(cop.offenses.size).to eq(1)
-        expect(cop.highlights).to eq(['bar'])
-        expect(cop.offenses.first.message)
-          .to eq('Unused method argument - `bar`.')
+        expect_offense(<<-RUBY.strip_indent)
+          def self.some_method(foo, bar: 1)
+                                    ^^^ Unused method argument - `bar`.
+            puts foo
+          end
+        RUBY
       end
 
       context 'and AllowUnusedKeywordArguments set' do
@@ -127,24 +104,22 @@ describe RuboCop::Cop::Lint::UnusedMethodArgument, :config do
     end
 
     context 'when a singleton method argument is unused' do
-      let(:source) { <<-RUBY }
-        def self.some_method(foo)
-        end
-      RUBY
-
       it 'registers an offense' do
-        expect(cop.offenses.size).to eq(1)
-        expect(cop.offenses.first.line).to eq(1)
-        expect(cop.highlights).to eq(['foo'])
+        message = "Unused method argument - `foo`. If it's necessary, use " \
+                    '`_` or `_foo` as an argument name to indicate that it ' \
+                    "won't be used. You can also write as `some_method(*)` " \
+                    'if you want the method to accept any arguments but ' \
+                    "don't care about them."
+
+        expect_offense(<<-RUBY.strip_indent)
+          def self.some_method(foo)
+                               ^^^ #{message}
+          end
+        RUBY
       end
     end
 
     context 'when an underscore-prefixed method argument is unused' do
-      let(:source) { <<-RUBY }
-        def some_method(_foo)
-        end
-      RUBY
-
       it 'accepts' do
         expect_no_offenses(<<-RUBY.strip_indent)
           def some_method(_foo)
@@ -154,12 +129,6 @@ describe RuboCop::Cop::Lint::UnusedMethodArgument, :config do
     end
 
     context 'when a method argument is used' do
-      let(:source) { <<-RUBY }
-        def some_method(foo)
-          puts foo
-        end
-      RUBY
-
       it 'accepts' do
         expect_no_offenses(<<-RUBY.strip_indent)
           def some_method(foo)
@@ -171,82 +140,78 @@ describe RuboCop::Cop::Lint::UnusedMethodArgument, :config do
 
     context 'when a method argument is reassigned' do
       context 'and the argument was reassigned in the conditional' do
-        let(:source) { <<-RUBY.strip_indent }
-          def some_method(foo)
-            foo = 42 if bar
-            puts foo
-          end
-        RUBY
-
         it 'accepts' do
-          expect_no_offenses(source)
+          expect_no_offenses(<<-RUBY.strip_indent)
+            def some_method(foo)
+              foo = 42 if bar
+              puts foo
+            end
+          RUBY
         end
 
         context 'and was not used after the reassignment' do
-          let(:source) { <<-RUBY.strip_indent }
-            def some_method(foo)
-              foo = 42 if bar
-              puts bar
-            end
-          RUBY
-
           it 'registers an offense' do
-            expect(cop.offenses.size).to eq(1)
+            message = "Unused method argument - `foo`. If it's necessary, " \
+                        'use `_` or `_foo` as an argument name to indicate ' \
+                        "that it won't be used. You can also write as " \
+                        '`some_method(*)` if you want the method to accept ' \
+                        "any arguments but don't care about them."
+
+            expect_offense(<<-RUBY.strip_indent)
+              def some_method(foo)
+                              ^^^ #{message}
+                foo = 42 if bar
+                puts bar
+              end
+            RUBY
           end
         end
       end
 
       context 'and the argument used at the assignment' do
-        let(:source) { <<-RUBY.strip_indent }
-          def some_method(foo)
-            foo = foo + 42
-            puts foo
-          end
-        RUBY
-
         it 'accepts' do
-          expect_no_offenses(source)
+          expect_no_offenses(<<-RUBY.strip_indent)
+            def some_method(foo)
+              foo = foo + 42
+              puts foo
+            end
+          RUBY
         end
       end
 
       context 'and the argument is not used at the assignment' do
         context 'and the argument was not used before the assignment' do
-          let(:source) { <<-RUBY.strip_indent }
-            def some_method(foo)
-              puts 'bar'
-              foo = 42
-              puts foo
-            end
-          RUBY
-
           it 'registers an offense' do
-            expect(cop.offenses.size).to eq(1)
+            message = "Unused method argument - `foo`. If it's necessary, " \
+                        'use `_` or `_foo` as an argument name to indicate ' \
+                        "that it won't be used."
+
+            expect_offense(<<-RUBY.strip_indent)
+              def some_method(foo)
+                              ^^^ #{message}
+                puts 'bar'
+                foo = 42
+                puts foo
+              end
+            RUBY
           end
         end
 
         context 'and the argument was used before the assignment' do
-          let(:source) { <<-RUBY.strip_indent }
-            def some_method(foo)
-              puts foo
-              foo = 42
-              puts foo
-            end
-          RUBY
-
           it 'accepts' do
-            expect_no_offenses(source)
+            expect_no_offenses(<<-RUBY.strip_indent)
+              def some_method(foo)
+                puts foo
+                foo = 42
+                puts foo
+              end
+            RUBY
           end
         end
       end
     end
 
     context 'when a variable is unused' do
-      let(:source) { <<-RUBY }
-        def some_method
-          foo = 1
-        end
-      RUBY
-
       it 'does not care' do
         expect_no_offenses(<<-RUBY.strip_indent)
           def some_method
@@ -257,11 +222,6 @@ describe RuboCop::Cop::Lint::UnusedMethodArgument, :config do
     end
 
     context 'when a block argument is unused' do
-      let(:source) { <<-RUBY }
-        1.times do |foo|
-        end
-      RUBY
-
       it 'does not care' do
         expect_no_offenses(<<-RUBY.strip_indent)
           1.times do |foo|
@@ -272,42 +232,38 @@ describe RuboCop::Cop::Lint::UnusedMethodArgument, :config do
 
     context 'in a method calling `super` without arguments' do
       context 'when a method argument is not used explicitly' do
-        let(:source) { <<-RUBY }
-          def some_method(foo)
-            super
-          end
-        RUBY
-
         it 'accepts since the arguments are guaranteed to be the same as ' \
            "superclass' ones and the user has no control on them" do
-          expect(cop.offenses).to be_empty
+
+          expect_no_offenses(<<-RUBY.strip_indent)
+            def some_method(foo)
+              super
+            end
+           RUBY
         end
       end
     end
 
     context 'in a method calling `super` with arguments' do
       context 'when a method argument is unused' do
-        let(:source) { <<-RUBY }
-          def some_method(foo)
-            super(:something)
-          end
-        RUBY
-
         it 'registers an offense' do
-          expect(cop.offenses.size).to eq(1)
-          expect(cop.offenses.first.line).to eq(1)
-          expect(cop.highlights).to eq(['foo'])
+          message = "Unused method argument - `foo`. If it's necessary, use " \
+                      '`_` or `_foo` as an argument name to indicate that ' \
+                      "it won't be used. You can also write as " \
+                      '`some_method(*)` if you want the method to accept any ' \
+                      "arguments but don't care about them."
+
+          expect_offense(<<-RUBY.strip_indent)
+            def some_method(foo)
+                            ^^^ #{message}
+              super(:something)
+            end
+          RUBY
         end
       end
     end
 
     context 'in a method calling `binding` without arguments' do
-      let(:source) { <<-RUBY }
-        def some_method(foo, bar)
-          do_something binding
-        end
-      RUBY
-
       it 'accepts all arguments' do
         expect_no_offenses(<<-RUBY.strip_indent)
           def some_method(foo, bar)
@@ -317,34 +273,42 @@ describe RuboCop::Cop::Lint::UnusedMethodArgument, :config do
       end
 
       context 'inside another method definition' do
-        let(:source) { <<-RUBY }
-          def some_method(foo, bar)
-            def other(a)
-              puts something(binding)
-            end
-          end
-        RUBY
+        (foo_message, bar_message) = %w[foo bar].map do |arg|
+          "Unused method argument - `#{arg}`. If it's necessary, use `_` or " \
+          "`_#{arg}` as an argument name to indicate that it won't be " \
+          'used. You can also write as `some_method(*)` if you want the ' \
+          "method to accept any arguments but don't care about them."
+        end
 
         it 'registers offenses' do
-          expect(cop.offenses.size).to eq 2
-          expect(cop.offenses.first.line).to eq(1)
-          expect(cop.highlights).to eq(%w[foo bar])
+          expect_offense(<<-RUBY.strip_indent)
+            def some_method(foo, bar)
+                                 ^^^ #{bar_message}
+                            ^^^ #{foo_message}
+              def other(a)
+                puts something(binding)
+              end
+            end
+          RUBY
         end
       end
     end
 
     context 'in a method calling `binding` with arguments' do
       context 'when a method argument is unused' do
-        let(:source) { <<-RUBY }
-          def some_method(foo)
-            binding(:something)
-          end
-        RUBY
-
         it 'registers an offense' do
-          expect(cop.offenses.size).to eq(1)
-          expect(cop.offenses.first.line).to eq(1)
-          expect(cop.highlights).to eq(['foo'])
+          message = "Unused method argument - `foo`. If it's necessary, use " \
+                      '`_` or `_foo` as an argument name to indicate that it ' \
+                      "won't be used. You can also write as `some_method(*)` " \
+                      'if you want the method to accept any arguments but ' \
+                      "don't care about them."
+
+          expect_offense(<<-RUBY.strip_indent)
+            def some_method(foo)
+                            ^^^ #{message}
+              binding(:something)
+            end
+          RUBY
         end
       end
     end
@@ -486,12 +450,19 @@ describe RuboCop::Cop::Lint::UnusedMethodArgument, :config do
 
     it 'registers an offense for a non-empty method with a single unused ' \
         'parameter' do
-      inspect_source(<<-RUBY.strip_indent)
+
+      message = "Unused method argument - `arg`. If it's necessary, use " \
+                  '`_` or `_arg` as an argument name to indicate that it ' \
+                  "won't be used. You can also write as `method(*)` if you " \
+                  "want the method to accept any arguments but don't care " \
+                  'about them.'
+
+      expect_offense(<<-RUBY.strip_indent)
         def method(arg)
+                   ^^^ #{message}
           1
         end
       RUBY
-      expect(cop.offenses.size).to eq 1
     end
 
     it 'accepts an empty method with multiple unused parameters' do
@@ -502,13 +473,22 @@ describe RuboCop::Cop::Lint::UnusedMethodArgument, :config do
     end
 
     it 'registers an offense for a non-empty method with multiple unused ' \
-       'parameters' do
-      inspect_source(<<-RUBY.strip_indent)
+        'parameters' do
+      (a_message, b_message, others_message) = %w[a b others].map do |arg|
+        "Unused method argument - `#{arg}`. If it's necessary, use `_` or " \
+        "`_#{arg}` as an argument name to indicate that it won't be used. " \
+        'You can also write as `method(*)` if you want the method ' \
+        "to accept any arguments but don't care about them."
+      end
+
+      expect_offense(<<-RUBY.strip_indent)
         def method(a, b, *others)
+                          ^^^^^^ #{others_message}
+                      ^ #{b_message}
+                   ^ #{a_message}
           1
         end
       RUBY
-      expect(cop.offenses.size).to eq 3
     end
   end
 end


### PR DESCRIPTION
Per https://github.com/bbatsov/rubocop/pull/4826#issuecomment-333972915, we need to use the new matcher format in specs.

This change adapts `Lint/UnusedBlockArgument` and `Lint/UnusedMethodArguments` specs to the new standard.

cc: @Drenmi 

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Used the same coding conventions as the rest of the project.
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [ ] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] All tests(`rake spec`) are passing.
* [x] The new code doesn't generate RuboCop offenses that are checked by `rake internal_investigation`.
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [ ] Updated cop documentation with `rake generate_cops_documentation` (required only when you've added a new cop or changed the configuration/documentation of an existing cop).

[1]: http://chris.beams.io/posts/git-commit/
