### PR TITLE
Add `MethodDefineMacros` option to `Naming/PredicateName` cop

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -10,6 +10,13 @@ AllCops:
     - 'tmp/**/*'
   TargetRubyVersion: 2.1
 
+Naming/PredicateName:
+  # Method define macros for dynamically generated method.
+  MethodDefineMacros:
+    - define_method
+    - define_singleton_method
+    - def_node_matcher
+
 Style/FrozenStringLiteralComment:
   EnforcedStyle: always
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 * [#4663](https://github.com/bbatsov/rubocop/issues/4663): Add new `Style/CommentedKeyword` cop. ([@donjar][])
 * Add `IndentationWidth` configuration for `Layout/Tab` cop. ([@rrosenblum][])
 * [#4854](https://github.com/bbatsov/rubocop/pull/4854): Add new `Lint/RegexpAsCondition` cop. ([@pocke][])
+* [#4862](https://github.com/bbatsov/rubocop/pull/4862): Add `MethodDefineMacros` option to `Naming/PredicateName` cop. ([@koic][])
 
 ### Bug fixes
 

--- a/config/default.yml
+++ b/config/default.yml
@@ -638,6 +638,10 @@ Naming/PredicateName:
   # should still be accepted
   NameWhitelist:
     - is_a?
+  # Method define macros for dynamically generated method.
+  MethodDefineMacros:
+    - define_method
+    - define_singleton_method
   # Exclude Rspec specs because there is a strong convention to write spec
   # helpers in the form of `have_something` or `be_something`.
   Exclude:

--- a/manual/cops_naming.md
+++ b/manual/cops_naming.md
@@ -256,6 +256,7 @@ Attribute | Value
 NamePrefix | is_, has_, have_
 NamePrefixBlacklist | is_, has_, have_
 NameWhitelist | is_a?
+MethodDefineMacros | define_method, define_singleton_method
 Exclude | spec/\*\*/\*
 
 ### References

--- a/spec/rubocop/cop/naming/predicate_name_spec.rb
+++ b/spec/rubocop/cop/naming/predicate_name_spec.rb
@@ -73,4 +73,57 @@ describe RuboCop::Cop::Naming::PredicateName, :config do
       RUBY
     end
   end
+
+  context 'with method definition macros' do
+    let(:cop_config) do
+      { 'NamePrefix' => %w[is_], 'NamePrefixBlacklist' => %w[is_],
+        'MethodDefineMacros' => %w[define_method def_node_matcher] }
+    end
+
+    it 'registers an offense when using `define_method`' do
+      expect_offense(<<-RUBY.strip_indent)
+        define_method(:is_hello) do |method_name|
+                      ^^^^^^^^^ Rename `is_hello` to `hello?`.
+          method_name == 'hello'
+        end
+      RUBY
+    end
+
+    it 'registers an offense when using an internal affair macro' do
+      expect_offense(<<-RUBY.strip_indent)
+        def_node_matcher :is_hello, <<-PATTERN
+                         ^^^^^^^^^ Rename `is_hello` to `hello?`.
+          (send
+            (send nil? :method_name) :==
+            (str 'hello'))
+        PATTERN
+      RUBY
+    end
+  end
+
+  context 'without method definition macros' do
+    let(:cop_config) do
+      { 'NamePrefix' => %w[is_], 'NamePrefixBlacklist' => %w[is_] }
+    end
+
+    it 'registers an offense when using `define_method`' do
+      expect_offense(<<-RUBY.strip_indent)
+        define_method(:is_hello) do |method_name|
+                      ^^^^^^^^^ Rename `is_hello` to `hello?`.
+          method_name == 'hello'
+        end
+      RUBY
+    end
+
+    it 'does not register any offenses when using an internal affair macro' do
+      expect_no_offenses(<<-RUBY.strip_indent)
+        def_node_matcher :is_hello, <<-PATTERN
+                         ^^^^^^^^^ Rename `is_hello` to `hello?`.
+          (send
+            (send nil? :method_name) :==
+            (str 'hello'))
+        PATTERN
+      RUBY
+    end
+  end
 end


### PR DESCRIPTION
Follow up for https://github.com/bbatsov/rubocop/pull/4855#issuecomment-336011062.
Cc @pocke who suggested this feature.

## Feature

This PR also add the `MethodDefineMacros` option to check on methods dynamically defined to `Naming/PredicateName` cop.

The target that RuboCop checks by default is `define_method`. This also applies to end user application code. The following is config/default.yml.

```yaml
Naming/PredicateName:
  # Method define macros for dynamically generated method.
  MethodDefineMacros:
    - define_method
```

`def_node_matcher` is also used for internal affairs of RuboCop itself. The following is config/.rubocop.yml.

```yaml
Naming/PredicateName:
  # Method define macros for dynamically generated method.
  MethodDefineMacros:
    - define_method
    - def_node_matcher
```

The following is the effect applied to the the before master branch (995315f) .

```console
% bundle exec rake internal_investigation
Running RuboCop...
Inspecting 1010 files

(snip)

Offenses:

lib/rubocop/cop/rails/has_many_or_has_one_dependent.rb:26:26: C: Rename has_many_or_has_one_without_options? to many_or_has_one_without_options?.
        def_node_matcher :has_many_or_has_one_without_options?, <<-PATTERN
                         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
lib/rubocop/cop/rails/has_many_or_has_one_dependent.rb:30:26: C: Rename has_many_or_has_one_with_options? to many_or_has_one_with_options?.
        def_node_matcher :has_many_or_has_one_with_options?, <<-PATTERN
                         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
lib/rubocop/cop/rails/has_many_or_has_one_dependent.rb:34:26: C: Rename has_dependent? to dependent?.
        def_node_matcher :has_dependent?, <<-PATTERN
                         ^^^^^^^^^^^^^^^
lib/rubocop/cop/rails/has_many_or_has_one_dependent.rb:38:26: C: Rename has_through? to through?.
        def_node_matcher :has_through?, <<-PATTERN
                         ^^^^^^^^^^^^^
lib/rubocop/cop/rails/not_null_column.rb:34:26: C: Rename has_default? to default?.
        def_node_matcher :has_default?, <<-PATTERN
                         ^^^^^^^^^^^^^

1010 files inspected, 5 offenses detected
RuboCop failed!
```

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Used the same coding conventions as the rest of the project.
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] All tests(`rake spec`) are passing.
* [x] The new code doesn't generate RuboCop offenses that are checked by `rake internal_investigation`.
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Updated cop documentation with `rake generate_cops_documentation` (required only when you've added a new cop or changed the configuration/documentation of an existing cop).

[1]: http://chris.beams.io/posts/git-commit/
