### PR TITLE
Change a behavior when run `rake generate_cops_documentation` with CI

### DIFF
--- a/tasks/cops_documentation.rake
+++ b/tasks/cops_documentation.rake
@@ -163,8 +163,9 @@ task generate_cops_documentation: :yard_for_generate_documentation do
       # Output diff before raising error
       sh('git diff manual')
 
-      raise 'The manual directory is out of sync. ' \
-        'Run rake generate_cops_documentation and commit the results.'
+      warn 'The manual directory is out of sync. ' \
+        'Run `rake generate_cops_documentation` and commit the results.'
+      exit!
     end
   end
 


### PR DESCRIPTION
It is a similar change to #4805.

I found it in the following log of Travis CI.
https://travis-ci.org/bbatsov/rubocop/jobs/282028577#L612-L625

This PR changes the behavior when manual is out of synchronized
when run `rake generate_cops_documentation` with CI.

## Before

```console
% bundle exec rake generate_cops_documentation

(snip)

rake aborted!
The manual directory is out of sync. Run rake
generate_cops_documentation and commit the results.
tasks/cops_documentation.rake:166:in `block in
assert_manual_synchronized'
tasks/cops_documentation.rake:160:in `assert_manual_synchronized'
tasks/cops_documentation.rake:182:in `block in <top (required)>'
/Users/koic/.rbenv/versions/2.4.2/bin/bundle:23:in `load'
/Users/koic/.rbenv/versions/2.4.2/bin/bundle:23:in `<main>'
Tasks: TOP => generate_cops_documentation
(See full trace by running task with --trace)
```

## After

```console
% bundle exec rake generate_cops_documentation

(snip)

The manual directory is out of sync. Run `rake
generate_cops_documentation` and commit the results.
```

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Used the same coding conventions as the rest of the project.
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [ ] Added tests.
* [ ] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] All tests(`rake spec`) are passing.
* [x] The new code doesn't generate RuboCop offenses that are checked by `rake internal_investigation`.
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [ ] Updated cop documentation with `rake generate_cops_documentation` (required only when you've added a new cop or changed the configuration/documentation of an existing cop).

[1]: http://chris.beams.io/posts/git-commit/
