### PR TITLE
Remove duplicated rspec test

### DIFF
--- a/spec/rubocop/cop/style/guard_clause_spec.rb
+++ b/spec/rubocop/cop/style/guard_clause_spec.rb
@@ -27,28 +27,6 @@ describe RuboCop::Cop::Style::GuardClause, :config do
       expect(cop.highlights).to eq(%w[if unless])
     end
 
-    it 'reports an offense if method body is if / unless without else' do
-      inspect_source(<<-RUBY.strip_indent)
-        def func
-          if something
-            #{body}
-          end
-        end
-
-        def func
-          unless something
-            #{body}
-          end
-        end
-      RUBY
-      expect(cop.offenses.size).to eq(2)
-      expect(cop.offenses.map(&:line).sort).to eq([2, 8])
-      expect(cop.messages)
-        .to eq(['Use a guard clause instead of wrapping ' \
-                'the code inside a conditional expression.'] * 2)
-      expect(cop.highlights).to eq(%w[if unless])
-    end
-
     it 'reports an offense if method body ends with if / unless without else' do
       inspect_source(<<-RUBY.strip_indent)
         def func


### PR DESCRIPTION
That test was defined twice in the shared example of the
guard clause spec.

**Replace this text with a summary of the changes in your PR.
The more detailed you are, the better.**

-----------------

Before submitting the PR make sure the following are checked:

* [ ] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [ ] Used the same coding conventions as the rest of the project.
* [ ] Feature branch is up-to-date with `master` (if not - rebase it).
* [ ] Squashed related commits together.
* [ ] Added tests.
* [ ] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [ ] All tests(`rake spec`) are passing.
* [ ] The new code doesn't generate RuboCop offenses that are checked by `rake internal_investigation`.
* [ ] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [ ] Updated cop documentation with `rake generate_cops_documentation` (required only when you've added a new cop or changed the configuration/documentation of an existing cop).

[1]: http://chris.beams.io/posts/git-commit/
