### PR TITLE
Remove unnecessary rubocop disables

### DIFF
--- a/lib/rubocop/config_loader.rb
+++ b/lib/rubocop/config_loader.rb
@@ -64,7 +64,6 @@ module RuboCop
         config
       end
 
-      # rubocop:disable Performance/HashEachMethods
       def add_missing_namespaces(path, hash)
         hash.keys.each do |key|
           q = Cop::Cop.qualified_cop_name(key, path)
@@ -73,7 +72,6 @@ module RuboCop
           hash[q] = hash.delete(key)
         end
       end
-      # rubocop:enable Performance/HashEachMethods
 
       # Return a recursive merge of two hashes. That is, a normal hash merge,
       # with the addition that any value that is a hash, and occurs in both

--- a/lib/rubocop/cop/lint/percent_string_array.rb
+++ b/lib/rubocop/cop/lint/percent_string_array.rb
@@ -53,7 +53,6 @@ module RuboCop
           end
         end
 
-        # rubocop:disable Performance/HashEachMethods
         def autocorrect(node)
           lambda do |corrector|
             node.values.each do |value|
@@ -68,7 +67,6 @@ module RuboCop
             end
           end
         end
-        # rubocop:enable Performance/HashEachMethod
       end
     end
   end

--- a/spec/rubocop/cop/cop_spec.rb
+++ b/spec/rubocop/cop/cop_spec.rb
@@ -89,7 +89,6 @@ describe RuboCop::Cop::Cop do
 
   describe '#add_offense positional arguments deprecation warning' do
     context 'when #add_offense called with positional arguments' do
-      # rubocop:disable InternalAffairs/DeprecatedPositionalArguments
       before { $stderr = StringIO.new }
       after { $stderr = STDERR }
 
@@ -106,7 +105,6 @@ describe RuboCop::Cop::Cop do
 
         expect($stderr.string).to include msg
       end
-      # rubocop:enable InternalAffairs/DeprecatedPositionalArguments
     end
 
     context 'when #add_offense is called with kwargs' do


### PR DESCRIPTION
Some of the rubocop disables are not needed anymore. This commit removes
them.

-----------------

Before submitting the PR make sure the following are checked:

* [ ] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [ ] Used the same coding conventions as the rest of the project.
* [ ] Feature branch is up-to-date with `master` (if not - rebase it).
* [ ] Squashed related commits together.
* [ ] Added tests.
* [ ] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [ ] All tests(`rake spec`) are passing.
* [ ] The new code doesn't generate RuboCop offenses that are checked by `rake internal_investigation`.
* [ ] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [ ] Updated cop documentation with `rake generate_cops_documentation` (required only when you've added a new cop or changed the configuration/documentation of an existing cop).

[1]: http://chris.beams.io/posts/git-commit/
