### PR TITLE
[FIX] Docs sequence for BracesAroundHashParameters

### DIFF
--- a/lib/rubocop/cop/style/braces_around_hash_parameters.rb
+++ b/lib/rubocop/cop/style/braces_around_hash_parameters.rb
@@ -10,35 +10,38 @@ module RuboCop
       # * The `braces` style enforces braces around all method
       # parameters that are hashes.
       #
-      # @example
-      #   # bad
-      #   some_method(x, y, a: 1, b: 2)
+      #     ```
+      #     # bad
+      #     some_method(x, y, a: 1, b: 2)
       #
-      #   # good
-      #   some_method(x, y, {a: 1, b: 2})
+      #     # good
+      #     some_method(x, y, {a: 1, b: 2})
+      #     ```
       #
       # * The `no_braces` style checks that the last parameter doesn't
       # have braces around it.
       #
-      # @example
-      #   # bad
-      #   some_method(x, y, {a: 1, b: 2})
+      #     ```
+      #     # bad
+      #     some_method(x, y, {a: 1, b: 2})
       #
-      #   # good
-      #   some_method(x, y, a: 1, b: 2)
+      #     # good
+      #     some_method(x, y, a: 1, b: 2)
+      #     ```
       #
       # * The `context_dependent` style checks that the last parameter
       # doesn't have braces around it, but requires braces if the
       # second to last parameter is also a hash literal.
       #
-      # @example
-      #   # bad
-      #   some_method(x, y, {a: 1, b: 2})
-      #   some_method(x, y, {a: 1, b: 2}, a: 1, b: 2)
+      #     ```
+      #     # bad
+      #     some_method(x, y, {a: 1, b: 2})
+      #     some_method(x, y, {a: 1, b: 2}, a: 1, b: 2)
       #
-      #   # good
-      #   some_method(x, y, a: 1, b: 2)
-      #   some_method(x, y, {a: 1, b: 2}, {a: 1, b: 2})
+      #     # good
+      #     some_method(x, y, a: 1, b: 2)
+      #     some_method(x, y, {a: 1, b: 2}, {a: 1, b: 2})
+      #     ```
       class BracesAroundHashParameters < Cop
         include ConfigurableEnforcedStyle
 

--- a/manual/cops_style.md
+++ b/manual/cops_style.md
@@ -231,38 +231,38 @@ It supports 3 styles:
 * The `braces` style enforces braces around all method
 parameters that are hashes.
 
+    ```
+    # bad
+    some_method(x, y, a: 1, b: 2)
+
+    # good
+    some_method(x, y, {a: 1, b: 2})
+    ```
+
 * The `no_braces` style checks that the last parameter doesn't
 have braces around it.
+
+    ```
+    # bad
+    some_method(x, y, {a: 1, b: 2})
+
+    # good
+    some_method(x, y, a: 1, b: 2)
+    ```
 
 * The `context_dependent` style checks that the last parameter
 doesn't have braces around it, but requires braces if the
 second to last parameter is also a hash literal.
 
-### Example
+    ```
+    # bad
+    some_method(x, y, {a: 1, b: 2})
+    some_method(x, y, {a: 1, b: 2}, a: 1, b: 2)
 
-```ruby
-# bad
-some_method(x, y, a: 1, b: 2)
-
-# good
-some_method(x, y, {a: 1, b: 2})
-```
-```ruby
-# bad
-some_method(x, y, {a: 1, b: 2})
-
-# good
-some_method(x, y, a: 1, b: 2)
-```
-```ruby
-# bad
-some_method(x, y, {a: 1, b: 2})
-some_method(x, y, {a: 1, b: 2}, a: 1, b: 2)
-
-# good
-some_method(x, y, a: 1, b: 2)
-some_method(x, y, {a: 1, b: 2}, {a: 1, b: 2})
-```
+    # good
+    some_method(x, y, a: 1, b: 2)
+    some_method(x, y, {a: 1, b: 2}, {a: 1, b: 2})
+    ```
 
 ### Important attributes
 


### PR DESCRIPTION
Code examples for each list item appeared all under the list, instead of having each code example
under the coresponding list item.

These changes does not influence any functionality, hence there is no changelog entry, spec .

![master-vs-docs-sequence-for-braces-around-hash-parameters](https://user-images.githubusercontent.com/173141/31620280-1cbe0682-b297-11e7-811e-12104cdb12d2.png)
