### PR TITLE
Add `def_node_search` method to `MethodDefineMacros` option

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -16,6 +16,7 @@ Naming/PredicateName:
     - define_method
     - define_singleton_method
     - def_node_matcher
+    - def_node_search
 
 Style/FrozenStringLiteralComment:
   EnforcedStyle: always


### PR DESCRIPTION
Follow up for #4862.

As with `def_node_matcher`, this PR added `def_node_search` method used for internal affair.
The following are the use cases.

```console
% git grep def_node_search
.rubocop.yml:    - def_node_search
lib/rubocop/cop/bundler/duplicated_gem.rb:        def_node_search: gem_declarations, '(send nil? :gem str ...)'
lib/rubocop/cop/bundler/ordered_gems.rb:        def_node_search :gem_declarations, <<-PATTERN
lib/rubocop/cop/internal_affairs/useless_message_assertion.rb: def_node_search :described_class_msg, <<-PATTERN
lib/rubocop/cop/mixin/unused_argument.rb:        def_node_search :uses_var?, '(lvar %)'
lib/rubocop/cop/performance/redundant_block_call.rb: def_node_search :blockarg_calls, <<-PATTERN
lib/rubocop/cop/performance/redundant_block_call.rb: def_node_search :blockarg_assigned?, <<-PATTERN
lib/rubocop/cop/performance/regexp_match.rb:        def_node_search :search_match_nodes, MATCH_NODE_PATTERN
lib/rubocop/cop/performance/regexp_match.rb:        def_node_search :last_matches, <<-PATTERN
lib/rubocop/cop/rails/file_path.rb:        def_node_search :rails_root_nodes?, <<-PATTERN
lib/rubocop/cop/style/parallel_assignment.rb:          def_node_search :uses_var?, '{({lvar ivar cvar gvar} %) (const _ %)}'
lib/rubocop/cop/style/parallel_assignment.rb:          def_node_search :matching_calls, '(send %1 %2 $...)'
lib/rubocop/cop/style/signal_exception.rb:        def_node_search :custom_fail_methods,
lib/rubocop/node_pattern.rb:      def def_node_search(method_name, pattern_str)
```

There are no offenses now, it will be set for the future.

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Used the same coding conventions as the rest of the project.
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [ ] Added tests.
* [ ] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] All tests(`rake spec`) are passing.
* [x] The new code doesn't generate RuboCop offenses that are checked by `rake internal_investigation`.
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [ ] Updated cop documentation with `rake generate_cops_documentation` (required only when you've added a new cop or changed the configuration/documentation of an existing cop).

[1]: http://chris.beams.io/posts/git-commit/
