### PR TITLE
Fixup naming cops and their specs

### DIFF
--- a/lib/rubocop/cop/naming/method_name.rb
+++ b/lib/rubocop/cop/naming/method_name.rb
@@ -4,29 +4,41 @@ module RuboCop
   module Cop
     module Naming
       # This cop makes sure that all methods use the configured style,
-      # snake_case or camelCase, for their names. Some special arrangements
-      # have to be made for operator methods.
+      # snake_case or camelCase, for their names.
+      #
+      # @example
+      #
+      #   # EnforcedStyle: snake_case
+      #
+      #   # bad
+      #   def fooBar; end
+      #
+      #   # good
+      #   def foo_bar; end
+      #
+      # @example
+      #
+      #   # EnforcedStyle: camelCase
+      #
+      #   # bad
+      #   def foo_bar; end
+      #
+      #   # good
+      #   def fooBar; end
       class MethodName < Cop
         include ConfigurableNaming
 
-        def on_def(node)
-          name, = *node
-          check_name(node, sanitize_name(name), node.loc.name)
-        end
+        MSG = 'Use %<style>s for method names.'.freeze
 
-        def on_defs(node)
-          _object, name, = *node
-          check_name(node, sanitize_name(name), node.loc.name)
+        def on_def(node)
+          check_name(node, node.method_name, node.loc.name)
         end
+        alias on_defs on_def
 
         private
 
         def message(style)
-          format('Use %s for method names.', style)
-        end
-
-        def sanitize_name(name)
-          name.to_s.delete('@').to_sym
+          format(MSG, style: style)
         end
       end
     end

--- a/lib/rubocop/cop/naming/variable_name.rb
+++ b/lib/rubocop/cop/naming/variable_name.rb
@@ -5,15 +5,36 @@ module RuboCop
     module Naming
       # This cop makes sure that all variables use the configured style,
       # snake_case or camelCase, for their names.
+      #
+      # @example
+      #
+      #   # EnforcedStyle: snake_case
+      #
+      #   # bad
+      #   fooBar = 1
+      #
+      #   # good
+      #   foo_bar = 1
+      #
+      # @example
+      #
+      #   # EnforcedStyle: camelCase
+      #
+      #   # bad
+      #   foo_bar = 1
+      #
+      #   # good
+      #   fooBar = 1
       class VariableName < Cop
         include ConfigurableNaming
+
+        MSG = 'Use %<style>s for variable names.'.freeze
 
         def on_lvasgn(node)
           name, = *node
           return unless name
           check_name(node, name, node.loc.name)
         end
-
         alias on_ivasgn    on_lvasgn
         alias on_cvasgn    on_lvasgn
         alias on_arg       on_lvasgn
@@ -27,7 +48,7 @@ module RuboCop
         private
 
         def message(style)
-          format('Use %s for variable names.', style)
+          format(MSG, style: style)
         end
       end
     end

--- a/lib/rubocop/cop/naming/variable_number.rb
+++ b/lib/rubocop/cop/naming/variable_number.rb
@@ -8,7 +8,8 @@ module RuboCop
       # for their numbering.
       #
       # @example
-      #   "EnforcedStyle => 'snake_case'"
+      #
+      #   # EnforcedStyle: snake_case
       #
       #   # bad
       #
@@ -19,7 +20,8 @@ module RuboCop
       #   variable_1 = 1
       #
       # @example
-      #   "EnforcedStyle => 'normalcase'"
+      #
+      #   # EnforcedStyle: normalcase
       #
       #   # bad
       #
@@ -30,47 +32,37 @@ module RuboCop
       #   variable1 = 1
       #
       # @example
-      #   "EnforcedStyle => 'non_integer'"
       #
-      #   #bad
+      #   # EnforcedStyle: non_integer
+      #
+      #   # bad
       #
       #   variable1 = 1
       #
       #   variable_1 = 1
       #
-      #   #good
+      #   # good
       #
       #   variableone = 1
       #
       #   variable_one = 1
-      #
       class VariableNumber < Cop
         include ConfigurableNumbering
 
-        def on_lvasgn(node)
-          name, = *node
-          check_name(node, name, node.loc.name)
-        end
-
-        def on_ivasgn(node)
-          name, = *node
-          check_name(node, name, node.loc.name)
-        end
-
-        def on_cvasgn(node)
-          name, = *node
-          check_name(node, name, node.loc.name)
-        end
+        MSG = 'Use %<style>s for variable numbers.'.freeze
 
         def on_arg(node)
           name, = *node
           check_name(node, name, node.loc.name)
         end
+        alias on_lvasgn on_arg
+        alias on_ivasgn on_arg
+        alias on_cvasgn on_arg
 
         private
 
         def message(style)
-          format('Use %s for variable numbers.', style)
+          format(MSG, style: style)
         end
       end
     end

--- a/lib/rubocop/cop/util.rb
+++ b/lib/rubocop/cop/util.rb
@@ -23,7 +23,7 @@ module RuboCop
       # Backtick is added last just to help editors parse this code.
       OPERATOR_METHODS = %w(
         | ^ & <=> == === =~ > >= < <= << >>
-        + - * / % ** ~ +@ -@ [] []= ! != !~
+        + - * / % ** ~ +@ -@ !@ ~@ [] []= ! != !~
       ).map(&:to_sym).push(:'`').freeze
 
       # Match literal regex characters, not including anchors, character

--- a/manual/cops_naming.md
+++ b/manual/cops_naming.md
@@ -211,8 +211,28 @@ Enabled by default | Supports autocorrection
 Enabled | No
 
 This cop makes sure that all methods use the configured style,
-snake_case or camelCase, for their names. Some special arrangements
-have to be made for operator methods.
+snake_case or camelCase, for their names.
+
+### Example
+
+```ruby
+# EnforcedStyle: snake_case
+
+# bad
+def fooBar; end
+
+# good
+def foo_bar; end
+```
+```ruby
+# EnforcedStyle: camelCase
+
+# bad
+def foo_bar; end
+
+# good
+def fooBar; end
+```
 
 ### Important attributes
 
@@ -272,6 +292,27 @@ Enabled | No
 This cop makes sure that all variables use the configured style,
 snake_case or camelCase, for their names.
 
+### Example
+
+```ruby
+# EnforcedStyle: snake_case
+
+# bad
+fooBar = 1
+
+# good
+foo_bar = 1
+```
+```ruby
+# EnforcedStyle: camelCase
+
+# bad
+foo_bar = 1
+
+# good
+fooBar = 1
+```
+
 ### Important attributes
 
 Attribute | Value
@@ -296,7 +337,7 @@ for their numbering.
 ### Example
 
 ```ruby
-"EnforcedStyle => 'snake_case'"
+# EnforcedStyle: snake_case
 
 # bad
 
@@ -307,7 +348,7 @@ variable1 = 1
 variable_1 = 1
 ```
 ```ruby
-"EnforcedStyle => 'normalcase'"
+# EnforcedStyle: normalcase
 
 # bad
 
@@ -318,15 +359,15 @@ variable_1 = 1
 variable1 = 1
 ```
 ```ruby
-"EnforcedStyle => 'non_integer'"
+# EnforcedStyle: non_integer
 
-#bad
+# bad
 
 variable1 = 1
 
 variable_1 = 1
 
-#good
+# good
 
 variableone = 1
 

--- a/spec/rubocop/cop/naming/variable_name_spec.rb
+++ b/spec/rubocop/cop/naming/variable_name_spec.rb
@@ -25,20 +25,18 @@ describe RuboCop::Cop::Naming::VariableName, :config do
     let(:cop_config) { { 'EnforcedStyle' => 'snake_case' } }
 
     it 'registers an offense for camel case in local variable name' do
-      inspect_source('myLocal = 1')
-      expect(cop.offenses.size).to eq(1)
-      expect(cop.highlights).to eq(['myLocal'])
-      expect(cop.config_to_allow_offenses).to eq('EnforcedStyle' =>
-                                                 'camelCase')
+      expect_offense(<<-RUBY.strip_indent)
+        myLocal = 1
+        ^^^^^^^ Use snake_case for variable names.
+      RUBY
     end
 
     it 'registers an offense for correct + opposite' do
-      inspect_source(<<-RUBY.strip_indent)
+      expect_offense(<<-RUBY.strip_indent)
         my_local = 1
         myLocal = 1
+        ^^^^^^^ Use snake_case for variable names.
       RUBY
-      expect(cop.highlights).to eq(['myLocal'])
-      expect(cop.config_to_allow_offenses).to eq('Enabled' => false)
     end
 
     it 'registers an offense for camel case in instance variable name' do
@@ -55,31 +53,52 @@ describe RuboCop::Cop::Naming::VariableName, :config do
       RUBY
     end
 
-    it 'registers an offense for camel case in method parameter' do
+    it 'registers an offense for camel case local variables marked as unused' do
+      expect_offense(<<-RUBY.strip_indent)
+    _myLocal = 1
+    ^^^^^^^^ Use snake_case for variable names.
+    RUBY
+    end
+
+    it 'registers an offense for method arguments' do
       expect_offense(<<-RUBY.strip_indent)
         def method(funnyArg); end
                    ^^^^^^^^ Use snake_case for variable names.
       RUBY
     end
 
-    it 'registers an offense for camel case local variables marked as unused' do
+    it 'registers an offense for default method arguments' do
       expect_offense(<<-RUBY.strip_indent)
-        _myLocal = 1
-        ^^^^^^^^ Use snake_case for variable names.
+        def foo(optArg = 1); end
+                ^^^^^^ Use snake_case for variable names.
       RUBY
     end
 
-    it 'registers offenses for method arguments' do
+    it 'registers an offense for rest arguments' do
       expect_offense(<<-RUBY.strip_indent)
-        def f(someArg, optArg = 1, *restArg, argAfterRest, kwOptArg: 1, kwArg:, **kwRest, &blockArg); end
-              ^^^^^^^ Use snake_case for variable names.
-                       ^^^^^^ Use snake_case for variable names.
-                                    ^^^^^^^ Use snake_case for variable names.
-                                             ^^^^^^^^^^^^ Use snake_case for variable names.
-                                                           ^^^^^^^^ Use snake_case for variable names.
-                                                                        ^^^^^ Use snake_case for variable names.
-                                                                                  ^^^^^^ Use snake_case for variable names.
-                                                                                           ^^^^^^^^ Use snake_case for variable names.
+        def foo(*restArg); end
+                 ^^^^^^^ Use snake_case for variable names.
+      RUBY
+    end
+
+    it 'registers an offense for keyword arguments' do
+      expect_offense(<<-RUBY.strip_indent)
+        def foo(kwArg: 1); end
+                ^^^^^ Use snake_case for variable names.
+      RUBY
+    end
+
+    it 'registers an offense for keyword rest arguments' do
+      expect_offense(<<-RUBY.strip_indent)
+        def foo(**kwRest); end
+                  ^^^^^^ Use snake_case for variable names.
+      RUBY
+    end
+
+    it 'registers an offense for block arguments' do
+      expect_offense(<<-RUBY.strip_indent)
+        def foo(&blockArg); end
+                 ^^^^^^^^ Use snake_case for variable names.
       RUBY
     end
 
@@ -90,20 +109,18 @@ describe RuboCop::Cop::Naming::VariableName, :config do
     let(:cop_config) { { 'EnforcedStyle' => 'camelCase' } }
 
     it 'registers an offense for snake case in local variable name' do
-      inspect_source('my_local = 1')
-      expect(cop.offenses.size).to eq(1)
-      expect(cop.highlights).to eq(['my_local'])
-      expect(cop.config_to_allow_offenses).to eq('EnforcedStyle' =>
-                                                 'snake_case')
+      expect_offense(<<-RUBY.strip_indent)
+        my_local = 1
+        ^^^^^^^^ Use camelCase for variable names.
+      RUBY
     end
 
     it 'registers an offense for opposite + correct' do
-      inspect_source(<<-RUBY.strip_indent)
+      expect_offense(<<-RUBY.strip_indent)
         my_local = 1
+        ^^^^^^^^ Use camelCase for variable names.
         myLocal = 1
       RUBY
-      expect(cop.highlights).to eq(['my_local'])
-      expect(cop.config_to_allow_offenses).to eq('Enabled' => false)
     end
 
     it 'accepts camel case in local variable name' do
@@ -129,29 +146,48 @@ describe RuboCop::Cop::Naming::VariableName, :config do
       expect_no_offenses('_myLocal = 1')
     end
 
-    it 'registers offenses for method arguments' do
+    it 'registers an offense for method arguments' do
       expect_offense(<<-RUBY.strip_indent)
-        def f(some_arg, opt_arg = 1, *rest_arg, arg_after_rest, kw_opt_arg: 1, kw_arg:, **kw_rest, &block_arg); end
-              ^^^^^^^^ Use camelCase for variable names.
-                        ^^^^^^^ Use camelCase for variable names.
-                                      ^^^^^^^^ Use camelCase for variable names.
-                                                ^^^^^^^^^^^^^^ Use camelCase for variable names.
-                                                                ^^^^^^^^^^ Use camelCase for variable names.
-                                                                               ^^^^^^ Use camelCase for variable names.
-                                                                                          ^^^^^^^ Use camelCase for variable names.
-                                                                                                    ^^^^^^^^^ Use camelCase for variable names.
+        def method(funny_arg); end
+                   ^^^^^^^^^ Use camelCase for variable names.
+      RUBY
+    end
+
+    it 'registers an offense for default method arguments' do
+      expect_offense(<<-RUBY.strip_indent)
+        def foo(opt_arg = 1); end
+                ^^^^^^^ Use camelCase for variable names.
+      RUBY
+    end
+
+    it 'registers an offense for rest arguments' do
+      expect_offense(<<-RUBY.strip_indent)
+        def foo(*rest_arg); end
+                 ^^^^^^^^ Use camelCase for variable names.
+      RUBY
+    end
+
+    it 'registers an offense for keyword arguments' do
+      expect_offense(<<-RUBY.strip_indent)
+        def foo(kw_arg: 1); end
+                ^^^^^^ Use camelCase for variable names.
+      RUBY
+    end
+
+    it 'registers an offense for keyword rest arguments' do
+      expect_offense(<<-RUBY.strip_indent)
+        def foo(**kw_rest); end
+                  ^^^^^^^ Use camelCase for variable names.
+      RUBY
+    end
+
+    it 'registers an offense for block arguments' do
+      expect_offense(<<-RUBY.strip_indent)
+        def foo(&block_arg); end
+                 ^^^^^^^^^ Use camelCase for variable names.
       RUBY
     end
 
     include_examples 'always accepted'
-  end
-
-  context 'when configured with a bad value' do
-    let(:cop_config) { { 'EnforcedStyle' => 'other' } }
-
-    it 'fails' do
-      expect { inspect_source('a = 3') }
-        .to raise_error(RuntimeError)
-    end
   end
 end

--- a/spec/rubocop/cop/naming/variable_number_spec.rb
+++ b/spec/rubocop/cop/naming/variable_number_spec.rb
@@ -60,9 +60,10 @@ describe RuboCop::Cop::Naming::VariableNumber, :config do
 
     it 'registers an offense for normal case numbering in method camel case
      parameter' do
-      inspect_source('def method(funnyArg1); end')
-      expect(cop.offenses.size).to eq(1)
-      expect(cop.highlights).to eq(['funnyArg1'])
+      expect_offense(<<-RUBY.strip_indent)
+        def method(funnyArg1); end
+                   ^^^^^^^^^ Use snake_case for variable numbers.
+      RUBY
     end
   end
 
@@ -103,9 +104,10 @@ describe RuboCop::Cop::Naming::VariableNumber, :config do
 
     it 'registers an offense for snake case numbering in method camel case
      parameter' do
-      inspect_source('def method(funnyArg_1); end')
-      expect(cop.offenses.size).to eq(1)
-      expect(cop.highlights).to eq(['funnyArg_1'])
+      expect_offense(<<-RUBY.strip_indent)
+        def method(funnyArg_1); end
+                   ^^^^^^^^^^ Use normalcase for variable numbers.
+      RUBY
     end
   end
 
@@ -150,16 +152,18 @@ describe RuboCop::Cop::Naming::VariableNumber, :config do
 
     it 'registers an offense for snake case numbering in method camel case
      parameter' do
-      inspect_source('def method(myArg_1); end')
-      expect(cop.offenses.size).to eq(1)
-      expect(cop.highlights).to eq(['myArg_1'])
+      expect_offense(<<-RUBY.strip_indent)
+        def method(myArg_1); end
+                   ^^^^^^^ Use non_integer for variable numbers.
+      RUBY
     end
 
     it 'registers an offense for normal case numbering in method camel case
      parameter' do
-      inspect_source('def method(myArg1); end')
-      expect(cop.offenses.size).to eq(1)
-      expect(cop.highlights).to eq(['myArg1'])
+      expect_offense(<<-RUBY.strip_indent)
+        def method(myArg1); end
+                   ^^^^^^ Use non_integer for variable numbers.
+      RUBY
     end
   end
 end


### PR DESCRIPTION
Had some time at the airport, so picked a few cops, added missing documentation, did some minor touch up of their implementation, and changed their specs to use `expect_offense`.

-----------------

Before submitting the PR make sure the following are checked:

* [X] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [X] Used the same coding conventions as the rest of the project.
* [X] Feature branch is up-to-date with `master` (if not - rebase it).
* [X] Squashed related commits together.
* [ ] Added tests.
* [ ] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [X] All tests(`rake spec`) are passing.
* [X] The new code doesn't generate RuboCop offenses that are checked by `rake internal_investigation`.
* [X] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [X] Updated cop documentation with `rake generate_cops_documentation` (required only when you've added a new cop or changed the configuration/documentation of an existing cop).

[1]: http://chris.beams.io/posts/git-commit/
