### PR TITLE
Fix broken doc style of `Style/BracesAroundHashParameters` cop

### DIFF
--- a/lib/rubocop/cop/style/braces_around_hash_parameters.rb
+++ b/lib/rubocop/cop/style/braces_around_hash_parameters.rb
@@ -5,11 +5,11 @@ module RuboCop
     module Style
       # This cop checks for braces around the last parameter in a method call
       # if the last parameter is a hash.
-      # It supports 3 styles.
+      # It supports `braces`, `no_braces` and `context_dependent` styles.
       #
-      # @example
-      #   # 1. The `braces` style enforces braces around all method
-      #   #    parameters that are hashes.
+      # @example EnforcedStyle: braces
+      #   # The `braces` style enforces braces around all method
+      #   # parameters that are hashes.
       #
       #   # bad
       #   some_method(x, y, a: 1, b: 2)
@@ -17,9 +17,9 @@ module RuboCop
       #   # good
       #   some_method(x, y, {a: 1, b: 2})
       #
-      # @example
-      #   # 2.  The `no_braces` style checks that the last parameter doesn't
-      #   #     have braces around it.
+      # @example EnforcedStyle: no_braces
+      #   # The `no_braces` style checks that the last parameter doesn't
+      #   # have braces around it.
       #
       #   # bad
       #   some_method(x, y, {a: 1, b: 2})
@@ -27,10 +27,10 @@ module RuboCop
       #   # good
       #   some_method(x, y, a: 1, b: 2)
       #
-      # @example
-      #   # 3. The `context_dependent` style checks that the last parameter
-      #   #    doesn't have braces around it, but requires braces if the
-      #   #    second to last parameter is also a hash literal.
+      # @example EnforcedStyle: context_dependent
+      #   # The `context_dependent` style checks that the last parameter
+      #   # doesn't have braces around it, but requires braces if the
+      #   # second to last parameter is also a hash literal.
       #
       #   # bad
       #   some_method(x, y, {a: 1, b: 2})

--- a/lib/rubocop/cop/style/braces_around_hash_parameters.rb
+++ b/lib/rubocop/cop/style/braces_around_hash_parameters.rb
@@ -5,43 +5,40 @@ module RuboCop
     module Style
       # This cop checks for braces around the last parameter in a method call
       # if the last parameter is a hash.
-      # It supports 3 styles:
+      # It supports 3 styles.
       #
-      # * The `braces` style enforces braces around all method
-      # parameters that are hashes.
+      # @example
+      #   # 1. The `braces` style enforces braces around all method
+      #   #    parameters that are hashes.
       #
-      #     ```
-      #     # bad
-      #     some_method(x, y, a: 1, b: 2)
+      #   # bad
+      #   some_method(x, y, a: 1, b: 2)
       #
-      #     # good
-      #     some_method(x, y, {a: 1, b: 2})
-      #     ```
+      #   # good
+      #   some_method(x, y, {a: 1, b: 2})
       #
-      # * The `no_braces` style checks that the last parameter doesn't
-      # have braces around it.
+      # @example
+      #   # 2.  The `no_braces` style checks that the last parameter doesn't
+      #   #     have braces around it.
       #
-      #     ```
-      #     # bad
-      #     some_method(x, y, {a: 1, b: 2})
+      #   # bad
+      #   some_method(x, y, {a: 1, b: 2})
       #
-      #     # good
-      #     some_method(x, y, a: 1, b: 2)
-      #     ```
+      #   # good
+      #   some_method(x, y, a: 1, b: 2)
       #
-      # * The `context_dependent` style checks that the last parameter
-      # doesn't have braces around it, but requires braces if the
-      # second to last parameter is also a hash literal.
+      # @example
+      #   # 3. The `context_dependent` style checks that the last parameter
+      #   #    doesn't have braces around it, but requires braces if the
+      #   #    second to last parameter is also a hash literal.
       #
-      #     ```
-      #     # bad
-      #     some_method(x, y, {a: 1, b: 2})
-      #     some_method(x, y, {a: 1, b: 2}, a: 1, b: 2)
+      #   # bad
+      #   some_method(x, y, {a: 1, b: 2})
+      #   some_method(x, y, {a: 1, b: 2}, a: 1, b: 2)
       #
-      #     # good
-      #     some_method(x, y, a: 1, b: 2)
-      #     some_method(x, y, {a: 1, b: 2}, {a: 1, b: 2})
-      #     ```
+      #   # good
+      #   some_method(x, y, a: 1, b: 2)
+      #   some_method(x, y, {a: 1, b: 2}, {a: 1, b: 2})
       class BracesAroundHashParameters < Cop
         include ConfigurableEnforcedStyle
 

--- a/manual/cops_style.md
+++ b/manual/cops_style.md
@@ -226,43 +226,43 @@ Enabled | Yes
 
 This cop checks for braces around the last parameter in a method call
 if the last parameter is a hash.
-It supports 3 styles:
+It supports 3 styles.
 
-* The `braces` style enforces braces around all method
-parameters that are hashes.
+### Example
 
-    ```
-    # bad
-    some_method(x, y, a: 1, b: 2)
+```ruby
+# 1. The `braces` style enforces braces around all method
+#    parameters that are hashes.
 
-    # good
-    some_method(x, y, {a: 1, b: 2})
-    ```
+# bad
+some_method(x, y, a: 1, b: 2)
 
-* The `no_braces` style checks that the last parameter doesn't
-have braces around it.
+# good
+some_method(x, y, {a: 1, b: 2})
+```
+```ruby
+# 2.  The `no_braces` style checks that the last parameter doesn't
+#     have braces around it.
 
-    ```
-    # bad
-    some_method(x, y, {a: 1, b: 2})
+# bad
+some_method(x, y, {a: 1, b: 2})
 
-    # good
-    some_method(x, y, a: 1, b: 2)
-    ```
+# good
+some_method(x, y, a: 1, b: 2)
+```
+```ruby
+# 3. The `context_dependent` style checks that the last parameter
+#    doesn't have braces around it, but requires braces if the
+#    second to last parameter is also a hash literal.
 
-* The `context_dependent` style checks that the last parameter
-doesn't have braces around it, but requires braces if the
-second to last parameter is also a hash literal.
+# bad
+some_method(x, y, {a: 1, b: 2})
+some_method(x, y, {a: 1, b: 2}, a: 1, b: 2)
 
-    ```
-    # bad
-    some_method(x, y, {a: 1, b: 2})
-    some_method(x, y, {a: 1, b: 2}, a: 1, b: 2)
-
-    # good
-    some_method(x, y, a: 1, b: 2)
-    some_method(x, y, {a: 1, b: 2}, {a: 1, b: 2})
-    ```
+# good
+some_method(x, y, a: 1, b: 2)
+some_method(x, y, {a: 1, b: 2}, {a: 1, b: 2})
+```
 
 ### Important attributes
 

--- a/manual/cops_style.md
+++ b/manual/cops_style.md
@@ -226,13 +226,13 @@ Enabled | Yes
 
 This cop checks for braces around the last parameter in a method call
 if the last parameter is a hash.
-It supports 3 styles.
+It supports `braces`, `no_braces` and `context_dependent` styles.
 
 ### Example
 
 ```ruby
-# 1. The `braces` style enforces braces around all method
-#    parameters that are hashes.
+# The `braces` style enforces braces around all method
+# parameters that are hashes.
 
 # bad
 some_method(x, y, a: 1, b: 2)
@@ -241,8 +241,8 @@ some_method(x, y, a: 1, b: 2)
 some_method(x, y, {a: 1, b: 2})
 ```
 ```ruby
-# 2.  The `no_braces` style checks that the last parameter doesn't
-#     have braces around it.
+# The `no_braces` style checks that the last parameter doesn't
+# have braces around it.
 
 # bad
 some_method(x, y, {a: 1, b: 2})
@@ -251,9 +251,9 @@ some_method(x, y, {a: 1, b: 2})
 some_method(x, y, a: 1, b: 2)
 ```
 ```ruby
-# 3. The `context_dependent` style checks that the last parameter
-#    doesn't have braces around it, but requires braces if the
-#    second to last parameter is also a hash literal.
+# The `context_dependent` style checks that the last parameter
+# doesn't have braces around it, but requires braces if the
+# second to last parameter is also a hash literal.
 
 # bad
 some_method(x, y, {a: 1, b: 2})


### PR DESCRIPTION
This PR fixes the broken document style that `good` and `bad` are displayed in the sidebar.
https://rubocop.readthedocs.io/en/latest/cops_style/#bad

<img width="1302" alt="broken_document_style_of_style_braces_around_hash_parameters" src="https://user-images.githubusercontent.com/13203/31753227-42fbfb76-b4ca-11e7-80dc-0d9b6831088e.png">

----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Used the same coding conventions as the rest of the project.
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [ ] Added tests.
* [ ] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [ ] All tests(`rake spec`) are passing.
* [x] The new code doesn't generate RuboCop offenses that are checked by `rake internal_investigation`.
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Updated cop documentation with `rake generate_cops_documentation` (required only when you've added a new cop or changed the configuration/documentation of an existing cop).

[1]: http://chris.beams.io/posts/git-commit/
