### PR TITLE
[Fix #4881] Fix a false positive for `HashEachMethods` when unused argument(s) exists in other blocks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## master (unreleased)
 
+### Bug fixes
+
+* [#4881](https://github.com/bbatsov/rubocop/issues/4881): Fix a false positive for `Performance/HashEachMethods` when unused argument(s) exists in other blocks. ([@pocke][])
+* [#4883](https://github.com/bbatsov/rubocop/pull/4883): Fix auto-correction for `Performance/HashEachMethods`. ([@pocke][])
+
 ## 0.51.0 (2017-10-18)
 
 ### New features

--- a/spec/rubocop/cop/performance/hash_each_methods_spec.rb
+++ b/spec/rubocop/cop/performance/hash_each_methods_spec.rb
@@ -4,7 +4,7 @@ describe RuboCop::Cop::Performance::HashEachMethods do
   subject(:cop) { described_class.new }
 
   context 'when node matches a plain `#each` ' \
-  'with unused key or value' do
+          'with unused key or value' do
     context 'when receiver is a send' do
       it 'registers an offense for foo#each with unused value' do
         expect_offense(<<-RUBY.strip_indent)
@@ -14,7 +14,7 @@ describe RuboCop::Cop::Performance::HashEachMethods do
       end
 
       it 'does not register an offense for foo#each' \
-      ' if both key/value are used' do
+         ' if both key/value are used' do
         expect_no_offenses("foo.each { |k, v| p \"\#{k}_\#{v}\" }")
       end
 
@@ -27,8 +27,17 @@ describe RuboCop::Cop::Performance::HashEachMethods do
       end
 
       it 'does not register an offense for foo#each ' \
-      ' if block takes only one arg' do
+         ' if block takes only one arg' do
         expect_no_offenses('foo.each { |kv| p kv }')
+      end
+
+      # Regression test. See https://github.com/bbatsov/rubocop/issues/4881
+      it 'does not register an offense for foo#each ' \
+         ' without unused arg, but unused arg exists in other method' do
+        expect_no_offenses(<<-RUBY.strip_indent)
+          foo.each { |k, v| p [k, v] }
+          foo.sum { |k, v| v }
+        RUBY
       end
 
       it 'registers an offense for foo#each with unused key' do
@@ -39,9 +48,16 @@ describe RuboCop::Cop::Performance::HashEachMethods do
       end
 
       it 'auto-corrects foo#each with unused value argument' \
-      ' with foo#each_key' do
+         ' with foo#each_key' do
         new_source = autocorrect_source('foo.each { |k, _v| p k }')
         expect(new_source).to eq('foo.each_key { |k| p k }')
+      end
+
+      # Regression test. See https://github.com/bbatsov/rubocop/pull/4883
+      it 'auto-corrects foo#each with unused value argument' \
+         ' with foo#each_key, and the used value name is not `k`' do
+        new_source = autocorrect_source('foo.each { |key, _v| p key }')
+        expect(new_source).to eq('foo.each_key { |key| p key }')
       end
     end
 
@@ -61,12 +77,12 @@ describe RuboCop::Cop::Performance::HashEachMethods do
       end
 
       it 'does not register an offense for {}#each' \
-      ' if both key/value are used' do
+         ' if both key/value are used' do
         expect_no_offenses("{}.each { |k, v| p \"\#{k}_\#{v}\" }")
       end
 
       it 'does not register an offense for {}#each ' \
-      ' if block takes only one arg' do
+         ' if block takes only one arg' do
         expect_no_offenses('{}.each { |kv| p kv }')
       end
 
@@ -79,13 +95,13 @@ describe RuboCop::Cop::Performance::HashEachMethods do
       end
 
       it 'auto-corrects {}#each with unused value argument' \
-      ' with {}#each_key' do
+         ' with {}#each_key' do
         new_source = autocorrect_source('{}.each { |k, _v| p k }')
         expect(new_source).to eq('{}.each_key { |k| p k }')
       end
 
       it 'auto-corrects {}#each with unused key argument' \
-      ' with {}#each_value' do
+         ' with {}#each_value' do
         new_source = autocorrect_source('{}.each { |_k, v| p v }')
         expect(new_source).to eq('{}.each_value { |v| p v }')
       end
@@ -107,23 +123,32 @@ describe RuboCop::Cop::Performance::HashEachMethods do
       end
 
       it 'does not register an offense for each' \
-      ' if both key/value are used' do
+         ' if both key/value are used' do
         expect_no_offenses("each { |k, v| p \"\#{k}_\#{v}\" }")
       end
 
       it 'does not register an offense for each ' \
-      ' if block takes only one arg' do
+         ' if block takes only one arg' do
         expect_no_offenses('each { |kv| p kv }')
       end
 
+      # Regression test. See https://github.com/bbatsov/rubocop/issues/4881
+      it 'does not register an offense for each ' \
+         ' without unused arg, but unused arg exists in other method' do
+        expect_no_offenses(<<-RUBY.strip_indent)
+          each { |k, v| p [k, v] }
+          sum { |k, v| v }
+        RUBY
+      end
+
       it 'auto-corrects each with unused value argument' \
-      ' with each_key' do
+         ' with each_key' do
         new_source = autocorrect_source('each { |k, _v| p k }')
         expect(new_source).to eq('each_key { |k| p k }')
       end
 
       it 'auto-corrects each with unused key argument' \
-      ' with each_value' do
+         ' with each_value' do
         new_source = autocorrect_source('each { |_k, v| p v }')
         expect(new_source).to eq('each_value { |v| p v }')
       end


### PR DESCRIPTION


Problem
===

`Performance/HashEachMethods` has a false positive for the following code.

```ruby
@h.each do |key, value|
  p(key * -value)
end
@h.sum { |key, value| -value }
```

The `each` does not have any unused arguments. `key` and `value` are used. So, this cop should not add an offense for the code.
But the cop adds an offence for the code currently.
This cause is the `sum` has an unused argument, and the argument is named `key`, the name is same as the `each`'s argument.
In this case, `Performance/HashEachMethods` adds a falsy offense.

Cause
=====

The cop handles only argument names to detect unused. So the cop does not work properly if an unused argument that has same name exists in other block.

Solution
=====

Check declared location of arguments instead of argument name.

Note
====

I found another bug while I was fixing this bug.
Auto-correction of this cop does not work properly.
For example:

```ruby
 # Auto-correct the following code.
foo.each { |key, _v| p key }
 # Expected
foo.each_key { |key| p key }
 # Actual
foo.each_value { |key| p key }
```

This change will fix the bug also.



-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Used the same coding conventions as the rest of the project.
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] All tests(`rake spec`) are passing.
* [x] The new code doesn't generate RuboCop offenses that are checked by `rake internal_investigation`.
* [ ] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Updated cop documentation with `rake generate_cops_documentation` (required only when you've added a new cop or changed the configuration/documentation of an existing cop).

[1]: http://chris.beams.io/posts/git-commit/
