### PR TITLE
Allow predicates for Style/SafeNavigation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@
 * [#4881](https://github.com/bbatsov/rubocop/issues/4881): Fix a false positive for `Performance/HashEachMethods` when unused argument(s) exists in other blocks. ([@pocke][])
 * [#4883](https://github.com/bbatsov/rubocop/pull/4883): Fix auto-correction for `Performance/HashEachMethods`. ([@pocke][])
 
+### Changes
+
+* [#4891](https://github.com/bbatsov/rubocop/pull/4891): Allow predicates for `Style/SafeNavigation`. ([@onk][])
+
 ## 0.51.0 (2017-10-18)
 
 ### New features

--- a/config/default.yml
+++ b/config/default.yml
@@ -1167,6 +1167,7 @@ Style/SafeNavigation:
   # Safe navigation may cause a statement to start returning `nil` in addition
   # to whatever it used to return.
   ConvertCodeThatCanStartToReturnNil: false
+  AllowPredicates: true
 
 Style/Semicolon:
   # Allow `;` to separate several expressions on the same line.

--- a/lib/rubocop/cop/style/safe_navigation.rb
+++ b/lib/rubocop/cop/style/safe_navigation.rb
@@ -43,6 +43,10 @@ module RuboCop
       #   # Methods that `nil` will `respond_to?` should not be converted to
       #   # use safe navigation
       #   foo.to_i if foo
+      #
+      #   # Predicate methods should not be converted to use safe navigation.
+      #   # If using safe navigation, it seems to looks like it returns boolean.
+      #   foo && foo.bar?
       class SafeNavigation < Cop
         extend TargetRubyVersion
 
@@ -157,7 +161,11 @@ module RuboCop
 
         def unsafe_method?(send_node)
           NIL_METHODS.include?(send_node.method_name) ||
-            negated?(send_node) || !send_node.dot?
+            negated?(send_node) || predicate?(send_node) || !send_node.dot?
+        end
+
+        def predicate?(send_node)
+          allow_predicates? && send_node.predicate_method?
         end
 
         def negated?(send_node)
@@ -172,6 +180,10 @@ module RuboCop
         def end_range(node, method_call)
           range_between(method_call.loc.expression.end_pos,
                         node.loc.expression.end_pos)
+        end
+
+        def allow_predicates?
+          cop_config['AllowPredicates']
         end
       end
     end

--- a/manual/cops_style.md
+++ b/manual/cops_style.md
@@ -3456,6 +3456,10 @@ foo.nil? || foo.bar
 # Methods that `nil` will `respond_to?` should not be converted to
 # use safe navigation
 foo.to_i if foo
+
+# Predicate methods should not be converted to use safe navigation.
+# If using safe navigation, it seems to looks like it returns boolean.
+foo && foo.bar?
 ```
 
 ### Important attributes
@@ -3463,6 +3467,7 @@ foo.to_i if foo
 Attribute | Value
 --- | ---
 ConvertCodeThatCanStartToReturnNil | false
+AllowPredicates | true
 
 ## Style/SelfAssignment
 

--- a/spec/rubocop/cop/style/safe_navigation_spec.rb
+++ b/spec/rubocop/cop/style/safe_navigation_spec.rb
@@ -36,6 +36,23 @@ describe RuboCop::Cop::Style::SafeNavigation, :config do
       expect_no_offenses('foo && foo[:bar]')
     end
 
+    context 'AllowPredicates true' do
+      let(:cop_config) { { 'AllowPredicates' => true } }
+
+      it 'allows an object check before a predicate' do
+        expect_no_offenses('foo && foo.bar?')
+      end
+    end
+    context 'AllowPredicates false' do
+      let(:cop_config) { { 'AllowPredicates' => false } }
+
+      it 'registers an offense for an object check followed by a predicate ' \
+          'method call' do
+        inspect_source('foo && foo.bar?')
+        expect(cop.messages).to eq([message])
+      end
+    end
+
     it 'allows an object check before a negated predicate' do
       expect_no_offenses('foo && !foo.bar?')
     end


### PR DESCRIPTION
```ruby
# It seems to looks like it returns boolean.
# In fact it returns one of [nil, true, false].
user&.admin?

# It clearly returns nil
user && user.admin?
```

**Replace this text with a summary of the changes in your PR.
The more detailed you are, the better.**

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Used the same coding conventions as the rest of the project.
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] All tests(`rake spec`) are passing.
* [x] The new code doesn't generate RuboCop offenses that are checked by `rake internal_investigation`.
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Updated cop documentation with `rake generate_cops_documentation` (required only when you've added a new cop or changed the configuration/documentation of an existing cop).

[1]: http://chris.beams.io/posts/git-commit/
