### PR TITLE
Fix offenses of naming/variable_name_spec.rb

### DIFF
--- a/spec/rubocop/cop/naming/variable_name_spec.rb
+++ b/spec/rubocop/cop/naming/variable_name_spec.rb
@@ -146,13 +146,6 @@ describe RuboCop::Cop::Naming::VariableName, :config do
       expect_no_offenses('_myLocal = 1')
     end
 
-    it 'registers an offense for method arguments' do
-      expect_offense(<<-RUBY.strip_indent)
-        def method(funny_arg); end
-                   ^^^^^^^^^ Use camelCase for variable names.
-      RUBY
-    end
-
     it 'registers an offense for default method arguments' do
       expect_offense(<<-RUBY.strip_indent)
         def foo(opt_arg = 1); end


### PR DESCRIPTION
Fix the following offenses.

```console
% bundle exec rake internal_investigation

(snip)

Offenses:

spec/rubocop/cop/naming/variable_name_spec.rb:138:5: C: Don't repeat
examples within an example group.
    it 'registers an offense for snake case in method parameter' do ...
        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
spec/rubocop/cop/naming/variable_name_spec.rb:149:5: C: Don't repeat examples within an example group.
    it 'registers an offense for method arguments' do ...
        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

1019 files inspected, 2 offenses detected
RuboCop failed!
```

This PR removes a redundant test. The following tests are the same.

https://github.com/bbatsov/rubocop/blob/834262bf83f00462333245547727e102736daccd/spec/rubocop/cop/naming/variable_name_spec.rb#L138-L143

https://github.com/bbatsov/rubocop/blob/834262bf83f00462333245547727e102736daccd/spec/rubocop/cop/naming/variable_name_spec.rb#L149-L154

I left a more clearer explanation test.

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Used the same coding conventions as the rest of the project.
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [ ] Added tests.
* [ ] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] All tests(`rake spec`) are passing.
* [x] The new code doesn't generate RuboCop offenses that are checked by `rake internal_investigation`.
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [ ] Updated cop documentation with `rake generate_cops_documentation` (required only when you've added a new cop or changed the configuration/documentation of an existing cop).

[1]: http://chris.beams.io/posts/git-commit/
