### PR TITLE
[Fix #4888] Clarify the Style/StderrPuts cop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 * [#4881](https://github.com/bbatsov/rubocop/issues/4881): Fix a false positive for `Performance/HashEachMethods` when unused argument(s) exists in other blocks. ([@pocke][])
 * [#4883](https://github.com/bbatsov/rubocop/pull/4883): Fix auto-correction for `Performance/HashEachMethods`. ([@pocke][])
+* [#4888](https://github.com/bbatsov/rubocop/pull/4888): Improve offense message of `Style/StderPuts`. ([@jaredbeck][])
 
 ## 0.51.0 (2017-10-18)
 
@@ -2980,3 +2981,4 @@
 [@GauthamGoli]: https://github.com/GauthamGoli
 [@nelsonjr]: https://github.com/nelsonjr
 [@jonatas]: https://github.com/jonatas
+[@jaredbeck]: https://www.jaredbeck.com

--- a/lib/rubocop/cop/style/stderr_puts.rb
+++ b/lib/rubocop/cop/style/stderr_puts.rb
@@ -3,8 +3,9 @@
 module RuboCop
   module Cop
     module Style
-      # This cop identifies places where `$stderr.puts`
-      # can be replaced by `warn`.
+      # This cop identifies places where `$stderr.puts` can be replaced by
+      # `warn`. The latter has the advantage of easily being disabled by,
+      # e.g. the -W0 interpreter flag, or setting $VERBOSE to nil.
       #
       # @example
       #   # bad
@@ -14,7 +15,8 @@ module RuboCop
       #   warn('hello')
       #
       class StderrPuts < Cop
-        MSG = 'Use `warn` instead of `$stderr.puts`.'.freeze
+        MSG = 'Use `warn` instead of `$stderr.puts` to allow such output ' \
+              'to be disabled.'.freeze
 
         def_node_matcher :stderr_puts?, <<-PATTERN
           (send

--- a/manual/cops_style.md
+++ b/manual/cops_style.md
@@ -3634,8 +3634,9 @@ Enabled by default | Supports autocorrection
 --- | ---
 Enabled | Yes
 
-This cop identifies places where `$stderr.puts`
-can be replaced by `warn`.
+This cop identifies places where `$stderr.puts` can be replaced by
+`warn`. The latter has the advantage of easily being disabled by,
+e.g. the -W0 interpreter flag, or setting $VERBOSE to nil.
 
 ### Example
 

--- a/spec/rubocop/cop/style/stderr_puts_spec.rb
+++ b/spec/rubocop/cop/style/stderr_puts_spec.rb
@@ -7,7 +7,7 @@ describe RuboCop::Cop::Style::StderrPuts do
   it "registers an offense when using `$stderr.puts('hello')`" do
     expect_offense(<<-RUBY.strip_indent)
       $stderr.puts('hello')
-      ^^^^^^^^^^^^ Use `warn` instead of `$stderr.puts`.
+      ^^^^^^^^^^^^ Use `warn` instead of `$stderr.puts` to allow such output to be disabled.
     RUBY
   end
 


### PR DESCRIPTION
Improves the offense message, per
https://github.com/bbatsov/rubocop/issues/4888

-----------------

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Used the same coding conventions as the rest of the project.
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] All tests(`rake spec`) are passing.
* [x] The new code doesn't generate RuboCop offenses that are checked by `rake internal_investigation`.

😆 😭 "internal investigation" .. so good

* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Updated cop documentation with `rake generate_cops_documentation` (required only when you've added a new cop or changed the configuration/documentation of an existing cop).

[1]: http://chris.beams.io/posts/git-commit/
