### PR TITLE
Allow autocorrecting of ClassAndModuleChildren.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,7 @@
 * [#5177](https://github.com/bbatsov/rubocop/pull/5177): Add new `Rails/LexicallyScopedActionFilter` cop. ([@wata727][])
 * [#5173](https://github.com/bbatsov/rubocop/pull/5173): Add new `Style/EvalWithLocation` cop. ([@pocke][])
 * [#5208](https://github.com/bbatsov/rubocop/pull/5208): Add new `Rails/Presence` cop. ([@wata727][])
+* Allow auto-correction of ClassAndModuleChildren. ([@siggymcfried][], [@melch][])
 
 ### Bug fixes
 
@@ -3091,3 +3092,5 @@
 [@marcandre]: https://github.com/marcandre
 [@walf443]: https://github.com/walf443
 [@reitermarkus]: https://github.com/reitermarkus
+[@siggymcfried]: https://github.com/siggymcfried
+[@melch]: https://github.com/melch

--- a/config/enabled.yml
+++ b/config/enabled.yml
@@ -1327,6 +1327,12 @@ Style/CharacterLiteral:
 Style/ClassAndModuleChildren:
   Description: 'Checks style of children classes and modules.'
   StyleGuide: '#namespace-definition'
+  # Moving from compact to nested children requires knowledge of whether the
+  # outer parent is a module or a class. Moving from nested to compact requires
+  # verification that the outer parent is defined elsewhere. Rubocop does not
+  # have the knowledge to perform either operation safely and thus requires
+  # manual oversight.
+  AutoCorrect: false
   Enabled: true
 
 Style/ClassCheck:

--- a/lib/rubocop/cop/style/class_and_module_children.rb
+++ b/lib/rubocop/cop/style/class_and_module_children.rb
@@ -40,7 +40,73 @@ module RuboCop
           check_style(node, body)
         end
 
+        def autocorrect(node)
+          lambda do |corrector|
+            if node.class_type?
+              name, superclass, body = *node
+              return if superclass && style != :nested
+              nest_or_compact(corrector, node, name, body)
+            else
+              name, body = *node
+              nest_or_compact(corrector, node, name, body)
+            end
+          end
+        end
+
         private
+
+        def nest_or_compact(corrector, node, name, body)
+          if style == :nested
+            nest_definition(corrector, node)
+          else
+            compact_definition(corrector, node, name, body)
+          end
+        end
+
+        def nest_definition(corrector, node)
+          padding = ((' ' * indent_width) + leading_spaces(node)).to_s
+          padding_for_trailing_end = padding.sub(' ' * node.loc.end.column, '')
+
+          replace_keyword_with_module(corrector, node)
+          split_on_double_colon(corrector, node, padding)
+          add_trailing_end(corrector, node, padding_for_trailing_end)
+        end
+
+        def replace_keyword_with_module(corrector, node)
+          corrector.replace(node.loc.keyword, 'module'.freeze)
+        end
+
+        def split_on_double_colon(corrector, node, padding)
+          children_definition = node.children.first
+          range = range_between(children_definition.loc.double_colon.begin_pos,
+                                children_definition.loc.double_colon.end_pos)
+          replacement = "\n#{padding}#{node.loc.keyword.source} ".freeze
+
+          corrector.replace(range, replacement)
+        end
+
+        def add_trailing_end(corrector, node, padding)
+          replacement = "#{padding}end\n#{leading_spaces(node)}end".freeze
+          corrector.replace(node.loc.end, replacement)
+        end
+
+        def compact_definition(corrector, node, name, body)
+          replacement = "#{body.type.to_s} #{name.const_name}::#{body.children.first.const_name}"
+          range = range_between(node.loc.keyword.begin_pos,
+                                body.loc.name.end_pos)
+          corrector.replace(range, replacement)
+          range = range_between(body.loc.end.begin_pos - leading_spaces(body).size,
+                                body.loc.end.end_pos + 1)
+          corrector.remove(range)
+        end
+
+        def leading_spaces(node)
+          node.source_range.source_line[/\A\s*/]
+        end
+
+        def indent_width
+          @config.for_cop('IndentationWidth')['Width'] || 2
+        end
 
         def check_style(node, body)
           if style == :nested

--- a/lib/rubocop/cop/style/class_and_module_children.rb
+++ b/lib/rubocop/cop/style/class_and_module_children.rb
@@ -45,11 +45,10 @@ module RuboCop
             if node.class_type?
               name, superclass, body = *node
               return if superclass && style != :nested
-              nest_or_compact(corrector, node, name, body)
             else
               name, body = *node
-              nest_or_compact(corrector, node, name, body)
             end
+            nest_or_compact(corrector, node, name, body)
           end
         end
 
@@ -91,12 +90,23 @@ module RuboCop
         end
 
         def compact_definition(corrector, node, name, body)
-          replacement = "#{body.type.to_s} #{name.const_name}::#{body.children.first.const_name}"
+          compact_node(corrector, node, name, body)
+          remove_end(corrector, body)
+        end
+
+        def compact_node(corrector, node, name, body)
+          const_name = "#{name.const_name}::#{body.children.first.const_name}"
+          replacement = "#{body.type} #{const_name}"
           range = range_between(node.loc.keyword.begin_pos,
                                 body.loc.name.end_pos)
           corrector.replace(range, replacement)
-          range = range_between(body.loc.end.begin_pos - leading_spaces(body).size,
-                                body.loc.end.end_pos + 1)
+        end
+
+        def remove_end(corrector, body)
+          range = range_between(
+            body.loc.end.begin_pos - leading_spaces(body).size,
+            body.loc.end.end_pos + 1
+          )
           corrector.remove(range)
         end
 

--- a/manual/cops_style.md
+++ b/manual/cops_style.md
@@ -492,7 +492,7 @@ Checks for uses of the character literal ?x.
 
 Enabled by default | Supports autocorrection
 --- | ---
-Enabled | No
+Enabled | Yes
 
 This cop checks the style of children definitions at classes and
 modules. Basically there are two different styles:

--- a/manual/cops_style.md
+++ b/manual/cops_style.md
@@ -524,6 +524,7 @@ end
 
 Name | Default value | Configurable values
 --- | --- | ---
+AutoCorrect | `false` | Boolean
 EnforcedStyle | `nested` | `nested`, `compact`
 
 ### References

--- a/spec/rubocop/cop/style/class_and_module_children_spec.rb
+++ b/spec/rubocop/cop/style/class_and_module_children_spec.rb
@@ -128,8 +128,12 @@ describe RuboCop::Cop::Style::ClassAndModuleChildren, :config do
   end
 
   context 'autocorrect' do
+    let(:cop_config) do
+      { 'AutoCorrect' => 'true', 'EnforcedStyle' => enforced_style }
+    end
+
     context 'nested style' do
-      let(:cop_config) { { 'EnforcedStyle' => 'nested' } }
+      let(:enforced_style) { 'nested' }
 
       it 'corrects a not nested class' do
         source = <<-RUBY.strip_indent
@@ -205,7 +209,7 @@ describe RuboCop::Cop::Style::ClassAndModuleChildren, :config do
     end
 
     context 'compact style' do
-      let(:cop_config) { { 'EnforcedStyle' => 'compact' } }
+      let(:enforced_style) { 'compact' }
 
       it 'corrects nested children' do
         source = <<-RUBY.strip_indent


### PR DESCRIPTION
Provides the ability to automatically fix violations of
ClassAndModuleChildren. This mirrors the other rules that are
auto-correctable.

I would _love_ some pointers in cleaning this up. I'm far from confident with the DSL and am sure there are things I missed!

One limitation is that it doesn't seem to handle the indentation of deeply nested modules/classes well. It seems to autocorrect
```ruby
class Foo::Bar::Baz
end
```
as
```ruby
module Foo
  module Bar
  module Baz
  end
  end
end
```

-----------------------------

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Used the same coding conventions as the rest of the project.
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] All tests(`rake spec`) are passing.
* [x] The new code doesn't generate RuboCop offenses that are checked by `rake internal_investigation`.
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Updated cop documentation with `rake generate_cops_documentation` (required only when you've added a new cop or changed the configuration/documentation of an existing cop).

[1]: http://chris.beams.io/posts/git-commit/
