### PR TITLE
[Fix #3363] Style/EmptyElse autocorrection removes comments from braches

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@
 * [#4909](https://github.com/bbatsov/rubocop/issues/4909): Make `Rails/HasManyOrHasOneDependent` aware of multiple associations in `with_options`. ([@koic][])
 * [#4794](https://github.com/bbatsov/rubocop/issues/4794): Fix an error in `Layout/MultilineOperationIndentation` when an operation spans multiple lines and contains a ternary expression. ([@rrosenblum][])
 * [#4885](https://github.com/bbatsov/rubocop/issues/4885): Fix false offense detected by `Style/MixinUsage` cop. ([@koic][])
+* [#3363](https://github.com/bbatsov/rubocop/pull/3363): Fix `Style/EmptyElse` autocorrection removes comments from branches. ([@dpostorivo][])
 
 ### Changes
 

--- a/lib/rubocop/cop/style/empty_else.rb
+++ b/lib/rubocop/cop/style/empty_else.rb
@@ -112,12 +112,22 @@ module RuboCop
 
         def autocorrect(node)
           return false if autocorrect_forbidden?(node.type.to_s)
+          return false if comment_in_else?(node)
 
           lambda do |corrector|
             end_pos = base_if_node(node).loc.end.begin_pos
-
             corrector.remove(range_between(node.loc.else.begin_pos, end_pos))
           end
+        end
+
+        def comment_in_else?(node)
+          range = else_line_range(node.loc)
+          processed_source.comments.find { |c| range.include?(c.loc.line) }
+        end
+
+        def else_line_range(loc)
+          return 0..0 if loc.else.nil? || loc.end.nil?
+          loc.else.first_line..loc.end.first_line
         end
 
         def base_if_node(node)

--- a/spec/rubocop/cop/style/empty_else_spec.rb
+++ b/spec/rubocop/cop/style/empty_else_spec.rb
@@ -120,6 +120,25 @@ describe RuboCop::Cop::Style::EmptyElse do
         it_behaves_like 'auto-correct', 'if'
         it_behaves_like 'offense registration'
       end
+      context 'with an empty comment' do
+        let(:source) { <<-RUBY.strip_indent }
+          if cond
+            something
+          else
+            # TODO
+          end
+        RUBY
+        let(:corrected_source) { <<-RUBY.strip_indent }
+          if cond
+            something
+          else
+            # TODO
+          end
+        RUBY
+
+        it_behaves_like 'auto-correct', 'if'
+        it_behaves_like 'offense registration'
+      end
     end
 
     context 'given an unless-statement' do


### PR DESCRIPTION
This fixes the issue with Style/EmptyElse removing empty elses that also removed comments. The methodology for this fix is it checks for comments within the range of the else and end keywords.

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Used the same coding conventions as the rest of the project.
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] All tests(`rake spec`) are passing.
* [x] The new code doesn't generate RuboCop offenses that are checked by `rake internal_investigation`.
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [ ] Updated cop documentation with `rake generate_cops_documentation` (required only when you've added a new cop or changed the configuration/documentation of an existing cop).

[1]: http://chris.beams.io/posts/git-commit/
