### PR TITLE
[Fix #4896] Fix Style/DateTime wrongly triggered on classes `...::DateTime`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 * [#4881](https://github.com/bbatsov/rubocop/issues/4881): Fix a false positive for `Performance/HashEachMethods` when unused argument(s) exists in other blocks. ([@pocke][])
 * [#4883](https://github.com/bbatsov/rubocop/pull/4883): Fix auto-correction for `Performance/HashEachMethods`. ([@pocke][])
 * [#4888](https://github.com/bbatsov/rubocop/pull/4888): Improve offense message of `Style/StderPuts`. ([@jaredbeck][])
+* [#4896](https://github.com/bbatsov/rubocop/pull/4896): Fix Style/DateTime wrongly triggered on classes `...::DateTime`. ([@dpostorivo][])
 
 ## 0.51.0 (2017-10-18)
 

--- a/lib/rubocop/cop/style/date_time.rb
+++ b/lib/rubocop/cop/style/date_time.rb
@@ -26,11 +26,11 @@ module RuboCop
         MSG = 'Prefer Date or Time over DateTime.'.freeze
 
         def_node_matcher :date_time?, <<-PATTERN
-          (send (const _ :DateTime) ...)
+          (send (const {nil? (cbase)} :DateTime) ...)
         PATTERN
 
         def_node_matcher :historic_date?, <<-PATTERN
-          (send _ _ _ (const (const _ :Date) _))
+          (send _ _ _ (const (const nil? :Date) _))
         PATTERN
 
         def on_send(node)

--- a/spec/rubocop/cop/style/date_time_spec.rb
+++ b/spec/rubocop/cop/style/date_time_spec.rb
@@ -11,6 +11,13 @@ describe RuboCop::Cop::Style::DateTime do
     RUBY
   end
 
+  it 'registers an offense when using ::DateTime for current time' do
+    expect_offense(<<-RUBY.strip_indent)
+      ::DateTime.now
+      ^^^^^^^^^^^^^^ Prefer Date or Time over DateTime.
+    RUBY
+  end
+
   it 'registers an offense when using DateTime for modern date' do
     expect_offense(<<-RUBY.strip_indent)
       DateTime.iso8601('2016-06-29')
@@ -28,5 +35,9 @@ describe RuboCop::Cop::Style::DateTime do
 
   it 'does not register an offense when using DateTime for historic date' do
     expect_no_offenses("DateTime.iso8601('2016-06-29', Date::ENGLAND)")
+  end
+
+  it 'does not register an offense when using DateTime in another namespace' do
+    expect_no_offenses('Icalendar::Values::DateTime.new(start_at)')
   end
 end


### PR DESCRIPTION
This fixes #4896 by checking if DateTime is in another namespace.

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Used the same coding conventions as the rest of the project.
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] All tests(`rake spec`) are passing.
* [x] The new code doesn't generate RuboCop offenses that are checked by `rake internal_investigation`.
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [ ] Updated cop documentation with `rake generate_cops_documentation` (required only when you've added a new cop or changed the configuration/documentation of an existing cop).

[1]: http://chris.beams.io/posts/git-commit/
