### PR TITLE
Fix a CI error due to Bundler integration to Ruby 2.5

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -27,8 +27,6 @@ matrix:
 before_install:
   - gem update --remote bundler
   - gem update --system
-  - rvm @global do gem uninstall bundler -a -x
-  - rvm @global do gem install bundler -v 1.13.7
 install:
   - bundle install --retry=3
 script:


### PR DESCRIPTION
Currently Travis CI has failed to build ruby-head.
https://travis-ci.org/bbatsov/rubocop/jobs/290423966#L571

The error log is as follows.

```console
$ rvm @global do gem uninstall bundler -a -x
ERROR: While executing gem ... (Gem::InstallError)
 gem "bundler" cannot be uninstalled because it is a default gem

The command "rvm @global do gem uninstall bundler -a -x" failed and
exited with 1 during .
```

This is because Ruby 2.5 integrates Bundler into Ruby.
https://bugs.ruby-lang.org/issues/12733

This PR will remove the Travis CI setting for JRuby introduced at #3966.
Because the version of JRuby used by Travis CI is different from that of #3966, it is likely to succeed with this.

My expectation is that installation builds on Bundler for both ruby-head and jruby-9.1.13.0 will succeed in this PR.

However, the following test is expected to fail on ruby-head.

```console
% ruby -v
ruby 2.5.0dev (2017-10-22 trunk 60318) [x86_64-darwin13]
% bundle exec rspec ./spec/rubocop/result_cache_spec.rb

(snip)

Failures:

  1) RuboCop::ResultCache cached result that was saved with no command
  line option when no option is given when a symlink is present in the
  cache location and symlink attack protection is disabled permits
  caching and prints no warning
     Failure/Error: FileUtils.rmdir(attack_target_dir)

     Errno::ENOTEMPTY:
       Directory not empty @ dir_s_rmdir - /var/folders/6g/n37ypc6554dcgy3fgdj9nkqm0000gn/T/d20171022-15315-1lytu2s
     # ./spec/rubocop/result_cache_spec.rb:97:in `block (5 levels) in <top (required)>'
     # ./lib/rubocop/rspec/shared_contexts.rb:27:in `block (4 levels) in <top (required)>'
     # ./lib/rubocop/rspec/shared_contexts.rb:26:in `chdir'
     # ./lib/rubocop/rspec/shared_contexts.rb:26:in `block (3 levels) in <top (required)>'
     # ./lib/rubocop/rspec/shared_contexts.rb:8:in `block (2 levels) in <top (required)>'

Finished in 0.21599 seconds (files took 1.02 seconds to load)
14 examples, 1 failure

Failed examples:

rspec ./spec/rubocop/result_cache_spec.rb:123 # RuboCop::ResultCache
cached result that was saved with no command line option when no option
is given when a symlink is present in the cache location and symlink
attack protection is disabled permits caching and prints no warning
```

First of all it is desirable to be able to know the test cases that fail with ruby-head like this. Therefore, I hope this will be merge if the installation build succeed.

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Used the same coding conventions as the rest of the project.
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [ ] Added tests.
* [ ] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] All tests(`rake spec`) are passing.
* [x] The new code doesn't generate RuboCop offenses that are checked by `rake internal_investigation`.
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [ ] Updated cop documentation with `rake generate_cops_documentation` (required only when you've added a new cop or changed the configuration/documentation of an existing cop).

[1]: http://chris.beams.io/posts/git-commit/
