### PR TITLE
Fix spec to be meaningful again

### DIFF
--- a/spec/rubocop/ast/send_node_spec.rb
+++ b/spec/rubocop/ast/send_node_spec.rb
@@ -539,9 +539,9 @@ describe RuboCop::AST::SendNode do
 
   describe '#comparison_method?' do
     context 'with a comparison method' do
-      let(:source) { 'foo.bar <=> :baz' }
+      let(:source) { 'foo.bar >= :baz' }
 
-      it { expect(send_node.comparison_method?).to be_falsey }
+      it { expect(send_node.comparison_method?).to be_truthy }
     end
 
     context 'with a regular method' do


### PR DESCRIPTION
In @e900036, I changed a spec to make it pass without thinking about it. This was pointed out in the [code review](https://github.com/bbatsov/rubocop/pull/4615#pullrequestreview-50886019) by @mikegee and I fixed it, but then somehow that thing got lost again, possibly during rebasing. Sorry about that.

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Used the same coding conventions as the rest of the project.
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [ ] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] All tests(`rake spec`) are passing.
* [x] The new code doesn't generate RuboCop offenses that are checked by `rake internal_investigation`.
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [ ] Updated cop documentation with `rake generate_cops_documentation` (required only when you've added a new cop or changed the configuration/documentation of an existing cop).

[1]: http://chris.beams.io/posts/git-commit/
