### PR TITLE
Remove Ruby 2.0 condition from fixed_size_spec.rb

### DIFF
--- a/spec/rubocop/cop/performance/fixed_size_spec.rb
+++ b/spec/rubocop/cop/performance/fixed_size_spec.rb
@@ -185,12 +185,10 @@ describe RuboCop::Cop::Performance::FixedSize do
         expect(cop.messages.empty?).to be(true)
       end
 
-      context 'ruby >= 2.0', :ruby20 do
-        it "accepts calling #{method} on a hash that contains a double splat" do
-          inspect_source("{a: 1, **foo}.#{method}")
+      it "accepts calling #{method} on a hash that contains a double splat" do
+        inspect_source("{a: 1, **foo}.#{method}")
 
-          expect(cop.messages.empty?).to be(true)
-        end
+        expect(cop.messages.empty?).to be(true)
       end
 
       it "accepts calling #{method} on an hash that is assigned " \


### PR DESCRIPTION
This condition is unnecessary because Ruby 1.9 and Ruby 2.0 have already
dropped support.

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Used the same coding conventions as the rest of the project.
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [ ] Added tests.
* [ ] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] All tests(`rake spec`) are passing.
* [x] The new code doesn't generate RuboCop offenses that are checked by `rake internal_investigation`.
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [ ] Updated cop documentation with `rake generate_cops_documentation` (required only when you've added a new cop or changed the configuration/documentation of an existing cop).

[1]: http://chris.beams.io/posts/git-commit/
