### PR TITLE
Adds IfWithSemicolon example

### DIFF
--- a/lib/rubocop/cop/style/if_with_semicolon.rb
+++ b/lib/rubocop/cop/style/if_with_semicolon.rb
@@ -4,6 +4,15 @@ module RuboCop
   module Cop
     module Style
       # Checks for uses of semicolon in if statements.
+      #
+      # @example
+      #
+      #   # bad
+      #   result = if some_condition; something else another_thing end
+      #
+      #   # good
+      #   result = some_condition ? something : another_thing
+      #
       class IfWithSemicolon < Cop
         include OnNormalIfUnless
 

--- a/manual/cops_style.md
+++ b/manual/cops_style.md
@@ -1579,6 +1579,16 @@ Enabled | No
 
 Checks for uses of semicolon in if statements.
 
+### Example
+
+```ruby
+# bad
+result = if some_condition; something else another_thing end
+
+# good
+result = some_condition ? something : another_thing
+```
+
 ### References
 
 * [https://github.com/bbatsov/ruby-style-guide#no-semicolon-ifs](https://github.com/bbatsov/ruby-style-guide#no-semicolon-ifs)


### PR DESCRIPTION
This adds an example to the `Style::IfWithSemicolon` cop.

Related to Issue [#4910](https://github.com/bbatsov/rubocop/issues/4910)

-----------------

Before submitting the PR make sure the following are checked:

* [X] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [X] Used the same coding conventions as the rest of the project.
* [X] Feature branch is up-to-date with `master` (if not - rebase it).
* [X] Squashed related commits together.
* [ ] Added tests.
* [ ] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [X] All tests(`rake spec`) are passing.
* [X] The new code doesn't generate RuboCop offenses that are checked by `rake internal_investigation`.
* [X] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [X] Updated cop documentation with `rake generate_cops_documentation` (required only when you've added a new cop or changed the configuration/documentation of an existing cop).

[1]: http://chris.beams.io/posts/git-commit/
