### PR TITLE
Fix #4910 Layout/CommentIndentation cop examples

### DIFF
--- a/lib/rubocop/cop/layout/comment_indentation.rb
+++ b/lib/rubocop/cop/layout/comment_indentation.rb
@@ -4,7 +4,7 @@ module RuboCop
   module Cop
     module Layout
       # This cops checks the indentation of comments.
-
+      #
       # @example
       #   # bad
       #     # comment here
@@ -14,6 +14,11 @@ module RuboCop
       #     # comment here
       #   a = 'hello'
       #
+      #   # yet another comment
+      #     if true
+      #       true
+      #     end
+      #
       #   # good
       #   # comment here
       #   def method_name
@@ -21,6 +26,11 @@ module RuboCop
       #
       #   # comment here
       #   a = 'hello'
+      #
+      #   # yet another comment
+      #   if true
+      #     true
+      #   end
       #
       class CommentIndentation < Cop
         include AutocorrectAlignment

--- a/lib/rubocop/cop/layout/comment_indentation.rb
+++ b/lib/rubocop/cop/layout/comment_indentation.rb
@@ -4,6 +4,24 @@ module RuboCop
   module Cop
     module Layout
       # This cops checks the indentation of comments.
+
+      # @example
+      #   # bad
+      #     # comment here
+      #   def method_name
+      #   end
+      #
+      #     # comment here
+      #   a = 'hello'
+      #
+      #   # good
+      #   # comment here
+      #   def method_name
+      #   end
+      #
+      #   # comment here
+      #   a = 'hello'
+      #
       class CommentIndentation < Cop
         include AutocorrectAlignment
 

--- a/manual/cops_layout.md
+++ b/manual/cops_layout.md
@@ -404,7 +404,27 @@ Enabled by default | Supports autocorrection
 --- | ---
 Enabled | Yes
 
-This cops checks the indentation of comments.
+
+
+### Example
+
+```ruby
+# bad
+  # comment here
+def method_name
+end
+
+  # comment here
+a = 'hello'
+
+# good
+# comment here
+def method_name
+end
+
+# comment here
+a = 'hello'
+```
 
 ## Layout/DotPosition
 

--- a/manual/cops_layout.md
+++ b/manual/cops_layout.md
@@ -404,7 +404,7 @@ Enabled by default | Supports autocorrection
 --- | ---
 Enabled | Yes
 
-
+This cops checks the indentation of comments.
 
 ### Example
 
@@ -417,6 +417,11 @@ end
   # comment here
 a = 'hello'
 
+# yet another comment
+  if true
+    true
+  end
+
 # good
 # comment here
 def method_name
@@ -424,6 +429,11 @@ end
 
 # comment here
 a = 'hello'
+
+# yet another comment
+if true
+  true
+end
 ```
 
 ## Layout/DotPosition


### PR DESCRIPTION
Adds examples for the `Layout/CommentIndentation' cop.

## Layout/CommentIndentation

Enabled by default | Supports autocorrection
--- | ---
Enabled | Yes



### Example

```ruby
# bad
  # comment here
def method_name
end

  # comment here
a = 'hello'

# yet another comment
  if true
    true
  end

# good
# comment here
def method_name
end

# comment here
a = 'hello'

# yet another comment
if true
  true
end
```

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Used the same coding conventions as the rest of the project.
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [ ] Squashed related commits together.
* [ ] Added tests.
* [ ] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] All tests(`rake spec`) are passing.
* [x] The new code doesn't generate RuboCop offenses that are checked by `rake internal_investigation`.
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Updated cop documentation with `rake generate_cops_documentation` (required only when you've added a new cop or changed the configuration/documentation of an existing cop).

[1]: http://chris.beams.io/posts/git-commit/
