### PR TITLE
adding space before comma and space around operators docs

### DIFF
--- a/lib/rubocop/cop/layout/space_around_operators.rb
+++ b/lib/rubocop/cop/layout/space_around_operators.rb
@@ -11,11 +11,13 @@ module RuboCop
       #   total = 3*4
       #   "apple"+"juice"
       #   my_number = 38/4
+      #   a ** b
       #
       #   # good
       #   total = 3 * 4
       #   "apple" + "juice"
       #   my_number = 38 / 4
+      #   a**b
       class SpaceAroundOperators < Cop
         include PrecedingFollowingAlignment
 

--- a/lib/rubocop/cop/layout/space_around_operators.rb
+++ b/lib/rubocop/cop/layout/space_around_operators.rb
@@ -5,6 +5,17 @@ module RuboCop
     module Layout
       # Checks that operators have space around them, except for **
       # which should not have surrounding space.
+      #
+      # @example
+      #   # bad
+      #   total = 3*4
+      #   "apple"+"juice"
+      #   my_number = 38/4
+      #
+      #   # good
+      #   total = 3 * 4
+      #   "apple" + "juice"
+      #   my_number = 38 / 4
       class SpaceAroundOperators < Cop
         include PrecedingFollowingAlignment
 

--- a/lib/rubocop/cop/layout/space_before_comma.rb
+++ b/lib/rubocop/cop/layout/space_before_comma.rb
@@ -4,6 +4,13 @@ module RuboCop
   module Cop
     module Layout
       # Checks for comma (,) preceded by space.
+      #
+      # @example
+      #   # bad
+      #   [1 , 2 , 3]
+      #
+      #   # good
+      #   [1, 2, 3]
       class SpaceBeforeComma < Cop
         include SpaceBeforePunctuation
 

--- a/lib/rubocop/cop/layout/space_before_comma.rb
+++ b/lib/rubocop/cop/layout/space_before_comma.rb
@@ -8,9 +8,15 @@ module RuboCop
       # @example
       #   # bad
       #   [1 , 2 , 3]
+      #   a(1 , 2)
+      #   each { |a , b| }
+      #   a ** b
       #
       #   # good
       #   [1, 2, 3]
+      #   a(1, 2)
+      #   each { |a, b| }
+      #   a**b
       class SpaceBeforeComma < Cop
         include SpaceBeforePunctuation
 

--- a/lib/rubocop/cop/layout/space_before_comma.rb
+++ b/lib/rubocop/cop/layout/space_before_comma.rb
@@ -10,13 +10,11 @@ module RuboCop
       #   [1 , 2 , 3]
       #   a(1 , 2)
       #   each { |a , b| }
-      #   a ** b
       #
       #   # good
       #   [1, 2, 3]
       #   a(1, 2)
       #   each { |a, b| }
-      #   a**b
       class SpaceBeforeComma < Cop
         include SpaceBeforePunctuation
 

--- a/manual/cops_layout.md
+++ b/manual/cops_layout.md
@@ -2030,11 +2030,13 @@ which should not have surrounding space.
 total = 3*4
 "apple"+"juice"
 my_number = 38/4
+a ** b
 
 # good
 total = 3 * 4
 "apple" + "juice"
 my_number = 38 / 4
+a**b
 ```
 
 ### Important attributes
@@ -2093,13 +2095,11 @@ Checks for comma (,) preceded by space.
 [1 , 2 , 3]
 a(1 , 2)
 each { |a , b| }
-a ** b
 
 # good
 [1, 2, 3]
 a(1, 2)
 each { |a, b| }
-a**b
 ```
 
 ## Layout/SpaceBeforeComment

--- a/manual/cops_layout.md
+++ b/manual/cops_layout.md
@@ -2091,9 +2091,15 @@ Checks for comma (,) preceded by space.
 ```ruby
 # bad
 [1 , 2 , 3]
+a(1 , 2)
+each { |a , b| }
+a ** b
 
 # good
 [1, 2, 3]
+a(1, 2)
+each { |a, b| }
+a**b
 ```
 
 ## Layout/SpaceBeforeComment

--- a/manual/cops_layout.md
+++ b/manual/cops_layout.md
@@ -2023,6 +2023,20 @@ Enabled | Yes
 Checks that operators have space around them, except for **
 which should not have surrounding space.
 
+### Example
+
+```ruby
+# bad
+total = 3*4
+"apple"+"juice"
+my_number = 38/4
+
+# good
+total = 3 * 4
+"apple" + "juice"
+my_number = 38 / 4
+```
+
 ### Important attributes
 
 Attribute | Value
@@ -2071,6 +2085,16 @@ Enabled by default | Supports autocorrection
 Enabled | Yes
 
 Checks for comma (,) preceded by space.
+
+### Example
+
+```ruby
+# bad
+[1 , 2 , 3]
+
+# good
+[1, 2, 3]
+```
 
 ## Layout/SpaceBeforeComment
 


### PR DESCRIPTION
added examples in the documentation for space before comma and space around operators cops.

Related to Issue #4910

**Replace this text with a summary of the changes in your PR.
The more detailed you are, the better.**

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Used the same coding conventions as the rest of the project.
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [ ] Added tests.
* [ ] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] All tests(`rake spec`) are passing.
* [x] The new code doesn't generate RuboCop offenses that are checked by `rake internal_investigation`.
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Updated cop documentation with `rake generate_cops_documentation` (required only when you've added a new cop or changed the configuration/documentation of an existing cop).

[1]: http://chris.beams.io/posts/git-commit/
