### PR TITLE
[Fix #4910] added example to space around equals in parameter default

### DIFF
--- a/lib/rubocop/cop/layout/space_around_equals_in_parameter_default.rb
+++ b/lib/rubocop/cop/layout/space_around_equals_in_parameter_default.rb
@@ -5,6 +5,16 @@ module RuboCop
     module Layout
       # Checks that the equals signs in parameter default assignments
       # have or don't have surrounding space depending on configuration.
+      # @example
+      #   # bad
+      #   def some_method(arg1=:default, arg2=nil, arg3=[])
+      #     # do something...
+      #   end
+      #
+      #   # good
+      #   def some_method(arg1 = :default, arg2 = nil, arg3 = [])
+      #     # do something...
+      #   end
       class SpaceAroundEqualsInParameterDefault < Cop
         include SurroundingSpace
         include ConfigurableEnforcedStyle

--- a/manual/cops_layout.md
+++ b/manual/cops_layout.md
@@ -1973,6 +1973,20 @@ Enabled | Yes
 Checks that the equals signs in parameter default assignments
 have or don't have surrounding space depending on configuration.
 
+### Example
+
+```ruby
+# bad
+def some_method(arg1=:default, arg2=nil, arg3=[])
+  # do something...
+end
+
+# good
+def some_method(arg1 = :default, arg2 = nil, arg3 = [])
+  # do something...
+end
+```
+
 ### Important attributes
 
 Attribute | Value


### PR DESCRIPTION
Added an example to space around equals in parameter default cop

Related to Issue #4910

**Replace this text with a summary of the changes in your PR.
The more detailed you are, the better.**

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Used the same coding conventions as the rest of the project.
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [ ] Added tests.
* [ ] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] All tests(`rake spec`) are passing.
* [x] The new code doesn't generate RuboCop offenses that are checked by `rake internal_investigation`.
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Updated cop documentation with `rake generate_cops_documentation` (required only when you've added a new cop or changed the configuration/documentation of an existing cop).

[1]: http://chris.beams.io/posts/git-commit/
