### PR TITLE
[Fix #4910] added example to space inside block braces

### DIFF
--- a/lib/rubocop/cop/layout/space_inside_block_braces.rb
+++ b/lib/rubocop/cop/layout/space_inside_block_braces.rb
@@ -7,6 +7,15 @@ module RuboCop
       # them on configuration. For blocks taking parameters, it checks that the
       # left brace has or doesn't have trailing space depending on
       # configuration.
+      #
+      # @example
+      #   # bad
+      #   array = [1, 2, 3]
+      #   array.each {|x| puts x}
+      #
+      #   # good
+      #   array = [1, 2, 3]
+      #   array.each { |x| puts x }
       class SpaceInsideBlockBraces < Cop
         include ConfigurableEnforcedStyle
         include SurroundingSpace

--- a/lib/rubocop/cop/layout/space_inside_block_braces.rb
+++ b/lib/rubocop/cop/layout/space_inside_block_braces.rb
@@ -8,14 +8,31 @@ module RuboCop
       # left brace has or doesn't have trailing space depending on
       # configuration.
       #
-      # @example
+      # @example EnforcedStyle: space
+      #   # The `space` style accepts empty braces with space inside
+      #   # and checks that block braces have surrounding spaces inside.
       #   # bad
-      #   array = [1, 2, 3]
-      #   array.each {|x| puts x}
+      #   h = {}
+      #   array.each{|x| puts x}
+      #   array.each{|x| puts x }
+      #   array.each{ |x| puts x}
       #
       #   # good
-      #   array = [1, 2, 3]
+      #   h = { }
+      #   array.each{ |x| puts x }
       #   array.each { |x| puts x }
+      #
+      # @example EnforcedStyle: no_space
+      #   # The `no_space` style accepts braces and empty braces without
+      #   # surrounding space/spaces inside.
+      #   # bad
+      #   h = { }
+      #   array.each{ |x| puts x }
+      #
+      #   # good
+      #   h = {}
+      #   array.each {|x| puts x}
+      #   array.each{|x| puts x}
       class SpaceInsideBlockBraces < Cop
         include ConfigurableEnforcedStyle
         include SurroundingSpace

--- a/manual/cops_layout.md
+++ b/manual/cops_layout.md
@@ -2212,13 +2212,30 @@ configuration.
 ### Example
 
 ```ruby
+# The `space` style accepts empty braces with space inside
+# and checks that block braces have surrounding spaces inside.
 # bad
-array = [1, 2, 3]
-array.each {|x| puts x}
+h = {}
+array.each{|x| puts x}
+array.each{|x| puts x }
+array.each{ |x| puts x}
 
 # good
-array = [1, 2, 3]
+h = { }
+array.each{ |x| puts x }
 array.each { |x| puts x }
+```
+```ruby
+# The `no_space` style accepts braces and empty braces without
+# surrounding space/spaces inside.
+# bad
+h = { }
+array.each{ |x| puts x }
+
+# good
+h = {}
+array.each {|x| puts x}
+array.each{|x| puts x}
 ```
 
 ### Important attributes

--- a/manual/cops_layout.md
+++ b/manual/cops_layout.md
@@ -2209,6 +2209,18 @@ them on configuration. For blocks taking parameters, it checks that the
 left brace has or doesn't have trailing space depending on
 configuration.
 
+### Example
+
+```ruby
+# bad
+array = [1, 2, 3]
+array.each {|x| puts x}
+
+# good
+array = [1, 2, 3]
+array.each { |x| puts x }
+```
+
 ### Important attributes
 
 Attribute | Value


### PR DESCRIPTION
Added an example documentation to `space_inside_block_braces.rb` cop.

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Used the same coding conventions as the rest of the project.
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [ ] Added tests.
* [ ] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] All tests(`rake spec`) are passing.
* [x] The new code doesn't generate RuboCop offenses that are checked by `rake internal_investigation`.
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Updated cop documentation with `rake generate_cops_documentation` (required only when you've added a new cop or changed the configuration/documentation of an existing cop).

[1]: http://chris.beams.io/posts/git-commit/
