### PR TITLE
[Fix #4910] add examples for Layout/EmptyLines

### DIFF
--- a/lib/rubocop/cop/layout/empty_lines.rb
+++ b/lib/rubocop/cop/layout/empty_lines.rb
@@ -6,6 +6,27 @@ module RuboCop
   module Cop
     module Layout
       # This cops checks for two or more consecutive blank lines.
+      # @example
+      #   # bad
+      #   def method_name
+      #     puts 'hello world'
+      #
+      #
+      #   end
+      #
+      #   if a > b
+      #
+      #
+      #     a
+      #   end
+      #
+      #   # good
+      #   def method_name
+      #     puts 'hello world'
+      #   end
+      #   if a > b
+      #     a
+      #   end
       class EmptyLines < Cop
         MSG = 'Extra blank line detected.'.freeze
         LINE_OFFSET = 2

--- a/manual/cops_layout.md
+++ b/manual/cops_layout.md
@@ -557,6 +557,29 @@ Enabled | Yes
 
 This cops checks for two or more consecutive blank lines.
 
+### Example
+
+```ruby
+# bad
+def method_name
+  puts 'hello world'
+
+end
+
+if a > b
+
+  a
+end
+
+# good
+def method_name
+  puts 'hello world'
+end
+if a > b
+  a
+end
+```
+
 ### References
 
 * [https://github.com/bbatsov/ruby-style-guide#two-or-more-empty-lines](https://github.com/bbatsov/ruby-style-guide#two-or-more-empty-lines)

--- a/manual/cops_layout.md
+++ b/manual/cops_layout.md
@@ -564,9 +564,11 @@ This cops checks for two or more consecutive blank lines.
 def method_name
   puts 'hello world'
 
+
 end
 
 if a > b
+
 
   a
 end
@@ -575,6 +577,7 @@ end
 def method_name
   puts 'hello world'
 end
+
 if a > b
   a
 end


### PR DESCRIPTION
Adds examples for the `Layout/EmptyLines` cop.

Enabled by default | Supports autocorrection
--- | ---
Enabled | Yes

This cops checks for two or more consecutive blank lines.

### Example

```ruby
# bad
def method_name
  puts 'hello world'


end

if a > b


  a
end

# good
def method_name
  puts 'hello world'
end

if a > b
  a
end
```

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Used the same coding conventions as the rest of the project.
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [ ] Squashed related commits together.
* [ ] Added tests.
* [ ] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] All tests(`rake spec`) are passing.
* [x] The new code doesn't generate RuboCop offenses that are checked by `rake internal_investigation`.
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Updated cop documentation with `rake generate_cops_documentation` (required only when you've added a new cop or changed the configuration/documentation of an existing cop).

[1]: http://chris.beams.io/posts/git-commit/
