### PR TITLE
[Fix #4910] added example to space inside hash literal braces

### DIFF
--- a/lib/rubocop/cop/layout/space_inside_hash_literal_braces.rb
+++ b/lib/rubocop/cop/layout/space_inside_hash_literal_braces.rb
@@ -6,12 +6,37 @@ module RuboCop
       # Checks that braces used for hash literals have or don't have
       # surrounding space depending on configuration.
       #
-      # @example
+      # @example EnforcedStyle: space
+      #   # The `space` style enforces that hash literals have
+      #   # surrounding space.
+      #
       #   # bad
-      #   h = {CA: "California", MA: "Massachusetts"}
+      #   h = {a: 1, b: 2}
       #
       #   # good
-      #   h = { CA: "California", MA: "Massachusetts" }
+      #   h = { a: 1, b: 2 }
+      #
+      # @example EnforcedStyle: no_space
+      #   # The `no_space` style enforces that hash literals have
+      #   # no surrounding space.
+      #
+      #   # bad
+      #   h = { a: 1, b: 2 }
+      #
+      #   # good
+      #   h = {a: 1, b: 2}
+      #
+      # @example EnforcedStyle: compact
+      #   # The `compact` style normally requires a space inside hash braces, with the exception
+      #   # that successive left braces or right braces are collapsed together in nested hashes.
+      #
+      #   # bad
+      #   h = { { a: 1 }, b: 2 }
+      #   h = { a: 1, { b: 2 } }
+      #
+      #   # good
+      #   h = {{ a: 1 }, b: 2 }
+      #   h = { a: 1, { b: 2 }}
       class SpaceInsideHashLiteralBraces < Cop
         include SurroundingSpace
         include ConfigurableEnforcedStyle

--- a/lib/rubocop/cop/layout/space_inside_hash_literal_braces.rb
+++ b/lib/rubocop/cop/layout/space_inside_hash_literal_braces.rb
@@ -27,8 +27,9 @@ module RuboCop
       #   h = {a: 1, b: 2}
       #
       # @example EnforcedStyle: compact
-      #   # The `compact` style normally requires a space inside hash braces, with the exception
-      #   # that successive left braces or right braces are collapsed together in nested hashes.
+      #   # The `compact` style normally requires a space inside
+      #   # hash braces, with the exception that successive left
+      #   # braces or right braces are collapsed together in nested hashes.
       #
       #   # bad
       #   h = { { a: 1 }, b: 2 }

--- a/lib/rubocop/cop/layout/space_inside_hash_literal_braces.rb
+++ b/lib/rubocop/cop/layout/space_inside_hash_literal_braces.rb
@@ -5,6 +5,13 @@ module RuboCop
     module Layout
       # Checks that braces used for hash literals have or don't have
       # surrounding space depending on configuration.
+      #
+      # @example
+      #   # bad
+      #   h = {CA: "California", MA: "Massachusetts"}
+      #
+      #   # good
+      #   h = { CA: "California", MA: "Massachusetts" }
       class SpaceInsideHashLiteralBraces < Cop
         include SurroundingSpace
         include ConfigurableEnforcedStyle

--- a/manual/cops_layout.md
+++ b/manual/cops_layout.md
@@ -2243,11 +2243,36 @@ surrounding space depending on configuration.
 ### Example
 
 ```ruby
+# The `space` style enforces that hash literals have
+# surrounding space.
+
 # bad
-h = {CA: "California", MA: "Massachusetts"}
+h = {a: 1, b: 2}
 
 # good
-h = { CA: "California", MA: "Massachusetts" }
+h = { a: 1, b: 2 }
+```
+```ruby
+# The `no_space` style enforces that hash literals have
+# no surrounding space.
+
+# bad
+h = { a: 1, b: 2 }
+
+# good
+h = {a: 1, b: 2}
+```
+```ruby
+# The `compact` style normally requires a space inside hash braces, with the exception
+# that successive left braces or right braces are collapsed together in nested hashes.
+
+# bad
+h = { { a: 1 }, b: 2 }
+h = { a: 1, { b: 2 } }
+
+# good
+h = {{ a: 1 }, b: 2 }
+h = { a: 1, { b: 2 }}
 ```
 
 ### Important attributes

--- a/manual/cops_layout.md
+++ b/manual/cops_layout.md
@@ -2240,6 +2240,16 @@ Enabled | Yes
 Checks that braces used for hash literals have or don't have
 surrounding space depending on configuration.
 
+### Example
+
+```ruby
+# bad
+h = {CA: "California", MA: "Massachusetts"}
+
+# good
+h = { CA: "California", MA: "Massachusetts" }
+```
+
 ### Important attributes
 
 Attribute | Value

--- a/manual/cops_layout.md
+++ b/manual/cops_layout.md
@@ -2263,8 +2263,9 @@ h = { a: 1, b: 2 }
 h = {a: 1, b: 2}
 ```
 ```ruby
-# The `compact` style normally requires a space inside hash braces, with the exception
-# that successive left braces or right braces are collapsed together in nested hashes.
+# The `compact` style normally requires a space inside
+# hash braces, with the exception that successive left
+# braces or right braces are collapsed together in nested hashes.
 
 # bad
 h = { { a: 1 }, b: 2 }


### PR DESCRIPTION
Added example documentation to `space_inside_hash_literal_braces.rb` cop.

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Used the same coding conventions as the rest of the project.
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [ ] Added tests.
* [ ] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] All tests(`rake spec`) are passing.
* [x] The new code doesn't generate RuboCop offenses that are checked by `rake internal_investigation`.
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Updated cop documentation with `rake generate_cops_documentation` (required only when you've added a new cop or changed the configuration/documentation of an existing cop).

[1]: http://chris.beams.io/posts/git-commit/
