### PR TITLE
[Fix #4910] add examples for Layout/SpaceInsideBrackets

### DIFF
--- a/lib/rubocop/cop/layout/space_inside_brackets.rb
+++ b/lib/rubocop/cop/layout/space_inside_brackets.rb
@@ -4,6 +4,12 @@ module RuboCop
   module Cop
     module Layout
       # Checks for spaces inside square brackets.
+      # @example
+      #   # bad
+      #   array = [ 1, 2, 3 ]
+      #
+      #   # good
+      #   array = [1, 2, 3]
       class SpaceInsideBrackets < Cop
         include SpaceInside
 

--- a/manual/cops_layout.md
+++ b/manual/cops_layout.md
@@ -2227,6 +2227,16 @@ Enabled | Yes
 
 Checks for spaces inside square brackets.
 
+### Example
+
+```ruby
+# bad
+array = [ 1, 2, 3 ]
+
+# good
+array = [1, 2, 3]
+```
+
 ### References
 
 * [https://github.com/bbatsov/ruby-style-guide#no-spaces-braces](https://github.com/bbatsov/ruby-style-guide#no-spaces-braces)


### PR DESCRIPTION
Adds examples for the `Layout/SpaceInsideBrackets` cop.


Enabled by default | Supports autocorrection
--- | ---
Enabled | Yes

Checks for spaces inside square brackets.

### Example

```ruby
# bad
array = [ 1, 2, 3 ]

# good
array = [1, 2, 3]
```

-----------------

Before submitting the PR make sure the following are checked:

* [ ] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [ ] Used the same coding conventions as the rest of the project.
* [ ] Feature branch is up-to-date with `master` (if not - rebase it).
* [ ] Squashed related commits together.
* [ ] Added tests.
* [ ] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [ ] All tests(`rake spec`) are passing.
* [ ] The new code doesn't generate RuboCop offenses that are checked by `rake internal_investigation`.
* [ ] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [ ] Updated cop documentation with `rake generate_cops_documentation` (required only when you've added a new cop or changed the configuration/documentation of an existing cop).

[1]: http://chris.beams.io/posts/git-commit/
