### PR TITLE
[Fix #4909] Make `Rails/HasManyOrHasOneDependent` aware multiple associations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@
 
 * [#1583](https://github.com/bbatsov/rubocop/issues/1583): Add a quiet formatter. ([@drenmi][])
 * [#4794](https://github.com/bbatsov/rubocop/issues/4794): Fix an error in `Layout/MultilineOperationIndentation` when an operation spans multiple lines and contains a ternary expression. ([@rrosenblum][])
+* [#4909](https://github.com/bbatsov/rubocop/issues/4909): Make `Rails/HasManyOrHasOneDependent` aware of multiple associations in `with_options`. ([@koic][])
 
 ## 0.51.0 (2017-10-18)
 

--- a/lib/rubocop/cop/rails/has_many_or_has_one_dependent.rb
+++ b/lib/rubocop/cop/rails/has_many_or_has_one_dependent.rb
@@ -49,8 +49,12 @@ module RuboCop
         def on_send(node)
           if !association_without_options?(node)
             return if valid_options?(association_with_options?(node))
-          elsif with_options_block(node.parent)
-            return if valid_options?(with_options_block(node.parent))
+          else
+            n = node.parent.begin_type? ? node.parent.parent : node.parent
+
+            if with_options_block(n)
+              return if valid_options?(with_options_block(n))
+            end
           end
 
           add_offense(node, location: :selector)

--- a/spec/rubocop/cop/rails/has_many_or_has_one_dependent_spec.rb
+++ b/spec/rubocop/cop/rails/has_many_or_has_one_dependent_spec.rb
@@ -113,6 +113,20 @@ describe RuboCop::Cop::Rails::HasManyOrHasOneDependent do
           end
         RUBY
       end
+
+      context 'Multiple associations' do
+        it "doesn't register an offense for " \
+           '`with_options dependent: :destroy`' do
+          expect_no_offenses(<<-RUBY.strip_indent)
+            class Person
+              with_options dependent: :destroy do
+                has_many :foo
+                has_many :bar
+              end
+            end
+          RUBY
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
Fixes #4909.
This PR tested and fixed above the problem reproduction.

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Used the same coding conventions as the rest of the project.
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] All tests(`rake spec`) are passing.
* [x] The new code doesn't generate RuboCop offenses that are checked by `rake internal_investigation`.
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [ ] Updated cop documentation with `rake generate_cops_documentation` (required only when you've added a new cop or changed the configuration/documentation of an existing cop).

[1]: http://chris.beams.io/posts/git-commit/
