### PR TITLE
[Fix #4885] Fix false offense detected by `Style/MixinUsage` cop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@
 * [#4987](https://github.com/bbatsov/rubocop/pull/4987): Skip permission check when using stdin option. ([@mtsmfm][])
 * [#4909](https://github.com/bbatsov/rubocop/issues/4909): Make `Rails/HasManyOrHasOneDependent` aware of multiple associations in `with_options`. ([@koic][])
 * [#4794](https://github.com/bbatsov/rubocop/issues/4794): Fix an error in `Layout/MultilineOperationIndentation` when an operation spans multiple lines and contains a ternary expression. ([@rrosenblum][])
+* [#4885](https://github.com/bbatsov/rubocop/issues/4885): Fix false offense detected by `Style/MixinUsage` cop. ([@koic][])
 
 ### Changes
 

--- a/lib/rubocop/cop/style/mixin_usage.rb
+++ b/lib/rubocop/cop/style/mixin_usage.rb
@@ -48,24 +48,21 @@ module RuboCop
 
         def_node_matcher :include_statement, <<-PATTERN
           (send nil? ${:include :extend :prepend}
-            (const nil? _))
+            const)
         PATTERN
 
         def on_send(node)
-          return unless (statement = include_statement(node))
-          return unless top_level_node?(node)
+          include_statement(node) do |statement|
+            return if accepted_include?(node)
 
-          add_offense(node, message: format(MSG, statement: statement))
+            add_offense(node, message: format(MSG, statement: statement))
+          end
         end
 
         private
 
-        def top_level_node?(node)
-          if node.parent.parent.nil?
-            node.sibling_index.zero?
-          else
-            top_level_node?(node.parent)
-          end
+        def accepted_include?(node)
+          node.parent && node.macro?
         end
       end
     end

--- a/spec/rubocop/cop/style/mixin_usage_spec.rb
+++ b/spec/rubocop/cop/style/mixin_usage_spec.rb
@@ -4,12 +4,35 @@ describe RuboCop::Cop::Style::MixinUsage do
   subject(:cop) { described_class.new }
 
   context 'include' do
-    it 'registers an offense when using outside class' do
+    it 'registers an offense when using outside class (used above)' do
       expect_offense(<<-RUBY.strip_indent)
         include M
         ^^^^^^^^^ `include` is used at the top level. Use inside `class` or `module`.
         class C
         end
+      RUBY
+    end
+
+    it 'registers an offense when using outside class (used below)' do
+      expect_offense(<<-RUBY.strip_indent)
+        class C
+        end
+        include M
+        ^^^^^^^^^ `include` is used at the top level. Use inside `class` or `module`.
+      RUBY
+    end
+
+    it 'registers an offense when using only `include` statement' do
+      expect_offense(<<-RUBY.strip_indent)
+        include M
+        ^^^^^^^^^ `include` is used at the top level. Use inside `class` or `module`.
+      RUBY
+    end
+
+    it 'does not register an offense when using outside class' do
+      expect_no_offenses(<<-RUBY.strip_indent)
+        Foo.include M
+        class C; end
       RUBY
     end
 
@@ -19,6 +42,39 @@ describe RuboCop::Cop::Style::MixinUsage do
           include M
         end
       RUBY
+    end
+
+    it 'does not register an offense when using inside block' do
+      expect_no_offenses(<<-RUBY.strip_indent)
+        Class.new do
+          include M
+        end
+      RUBY
+    end
+
+    context 'Multiple definition classes in one' do
+      it 'does not register an offense when using inside class' do
+        expect_no_offenses(<<-RUBY.strip_indent)
+          class C1
+            include M
+          end
+
+          class C2
+            include M
+          end
+        RUBY
+      end
+    end
+
+    context 'Nested module' do
+      it 'registers an offense when using outside class' do
+        expect_offense(<<-RUBY.strip_indent)
+          include M1::M2::M3
+          ^^^^^^^^^^^^^^^^^^ `include` is used at the top level. Use inside `class` or `module`.
+          class C
+          end
+        RUBY
+      end
     end
   end
 


### PR DESCRIPTION
Fixes https://github.com/bbatsov/rubocop/issues/4885.

This change makes the following modification based on Issue's report.

## Using `include` inside block

The follwing does not register an offense.

```ruby
Class.new do
  include IsNameValueType
end
```

and

```ruby
RSpec::Matchers.define :do_something do
  include Mixin
end
```

## Multiple definition classes in one

The follwing does not register an offense.

```ruby
class C1
  include M
end

class C2
  include M
end
```

## Nested module

The follwing register an offense.

```ruby
include M::M2::M3

class C
end
```

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Used the same coding conventions as the rest of the project.
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] All tests(`rake spec`) are passing.
* [x] The new code doesn't generate RuboCop offenses that are checked by `rake internal_investigation`.
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [ ] Updated cop documentation with `rake generate_cops_documentation` (required only when you've added a new cop or changed the configuration/documentation of an existing cop).

[1]: http://chris.beams.io/posts/git-commit/
