### PR TITLE
Make cop generator rubocop-compliant

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@
 * [#4883](https://github.com/bbatsov/rubocop/pull/4883): Fix auto-correction for `Performance/HashEachMethods`. ([@pocke][])
 * [#4888](https://github.com/bbatsov/rubocop/pull/4888): Improve offense message of `Style/StderPuts`. ([@jaredbeck][])
 
+### Changes
+
+* [#4943](https://github.com/bbatsov/rubocop/pull/4943): Make cop generator compliant with the repo's rubocop config. ([@tdeo][])
+
 ## 0.51.0 (2017-10-18)
 
 ### New features

--- a/Rakefile
+++ b/Rakefile
@@ -31,7 +31,7 @@ namespace :parallel do
 
   desc 'Run RSpec in parallel with ASCII encoding'
   task :ascii_spec do
-    sh('RUBYOPT="-E ASCII" rspec-queue spec/')
+    sh('RUBYOPT="$RUBYOPT -E ASCII" rspec-queue spec/')
   end
 end
 

--- a/lib/rubocop/cop/generator.rb
+++ b/lib/rubocop/cop/generator.rb
@@ -55,8 +55,9 @@ module RuboCop
         # frozen_string_literal: true
 
         describe RuboCop::Cop::%<department>s::%<cop_name>s do
-          let(:config) { RuboCop::Config.new }
           subject(:cop) { described_class.new(config) }
+
+          let(:config) { RuboCop::Config.new }
 
           # TODO: Write test code
           #

--- a/spec/project_spec.rb
+++ b/spec/project_spec.rb
@@ -32,7 +32,7 @@ describe 'RuboCop Project' do
       end
     end
 
-    it 'has a SupportedStyles for all EnforcedStyle' \
+    it 'has a SupportedStyles for all EnforcedStyle ' \
       'and EnforcedStyle is valid' do
       errors = []
       cop_names.each do |name|

--- a/spec/rubocop/cop/generator_spec.rb
+++ b/spec/rubocop/cop/generator_spec.rb
@@ -337,3 +337,27 @@ RSpec.describe RuboCop::Cop::Generator do
     end
   end
 end
+
+RSpec.describe RuboCop::Cop::Generator, :isolated_environment do
+  include FileHelper
+  subject(:generator) { described_class.new('Test/Test') }
+
+  let(:config) do
+    config = RuboCop::ConfigStore.new
+    path = File.join(RuboCop::ConfigLoader::RUBOCOP_HOME,
+                     RuboCop::ConfigLoader::DOTFILE)
+    config.options_config = path
+    config
+  end
+  let(:runner) { RuboCop::Runner.new({}, config) }
+
+  it 'generates a cop file that has no offense' do
+    generator.write_source
+    expect(runner.run([])).to be true
+  end
+
+  it 'generates a spec file that has no offense' do
+    generator.write_spec
+    expect(runner.run([])).to be true
+  end
+end

--- a/spec/rubocop/cop/generator_spec.rb
+++ b/spec/rubocop/cop/generator_spec.rb
@@ -79,8 +79,9 @@ RSpec.describe RuboCop::Cop::Generator do
         # frozen_string_literal: true
 
         describe RuboCop::Cop::Style::FakeCop do
-          let(:config) { RuboCop::Config.new }
           subject(:cop) { described_class.new(config) }
+
+          let(:config) { RuboCop::Config.new }
 
           # TODO: Write test code
           #

--- a/spec/rubocop/cop/generator_spec.rb
+++ b/spec/rubocop/cop/generator_spec.rb
@@ -341,6 +341,14 @@ RSpec.describe RuboCop::Cop::Generator do
   describe 'compliance with rubocop', :isolated_environment do
     include FileHelper
 
+    around do |example|
+      orig_registry = RuboCop::Cop::Cop.registry
+      RuboCop::Cop::Cop.instance_variable_set(:@registry,
+                                              RuboCop::Cop::Registry.new)
+      example.run
+      RuboCop::Cop::Cop.instance_variable_set(:@registry, orig_registry)
+    end
+
     before { allow(File).to receive(:write).and_call_original }
 
     let(:config) do

--- a/spec/rubocop/cop/generator_spec.rb
+++ b/spec/rubocop/cop/generator_spec.rb
@@ -340,7 +340,7 @@ RSpec.describe RuboCop::Cop::Generator do
   describe 'compliance with rubocop', :isolated_environment do
     include FileHelper
 
-    before(:each) { allow(File).to receive(:write).and_call_original }
+    before { allow(File).to receive(:write).and_call_original }
 
     let(:config) do
       config = RuboCop::ConfigStore.new
@@ -349,7 +349,8 @@ RSpec.describe RuboCop::Cop::Generator do
       config.options_config = path
       config
     end
-    let(:runner) { RuboCop::Runner.new({}, config) }
+    let(:options) { { formatters: [] } }
+    let(:runner) { RuboCop::Runner.new(options, config) }
 
     it 'generates a cop file that has no offense' do
       generator.write_source

--- a/spec/rubocop/cop/generator_spec.rb
+++ b/spec/rubocop/cop/generator_spec.rb
@@ -336,28 +336,29 @@ RSpec.describe RuboCop::Cop::Generator do
       end
     end
   end
-end
 
-RSpec.describe RuboCop::Cop::Generator, :isolated_environment do
-  include FileHelper
-  subject(:generator) { described_class.new('Test/Test') }
+  describe 'compliance with rubocop', :isolated_environment do
+    include FileHelper
 
-  let(:config) do
-    config = RuboCop::ConfigStore.new
-    path = File.join(RuboCop::ConfigLoader::RUBOCOP_HOME,
-                     RuboCop::ConfigLoader::DOTFILE)
-    config.options_config = path
-    config
-  end
-  let(:runner) { RuboCop::Runner.new({}, config) }
+    before(:each) { allow(File).to receive(:write).and_call_original }
 
-  it 'generates a cop file that has no offense' do
-    generator.write_source
-    expect(runner.run([])).to be true
-  end
+    let(:config) do
+      config = RuboCop::ConfigStore.new
+      path = File.join(RuboCop::ConfigLoader::RUBOCOP_HOME,
+                       RuboCop::ConfigLoader::DOTFILE)
+      config.options_config = path
+      config
+    end
+    let(:runner) { RuboCop::Runner.new({}, config) }
 
-  it 'generates a spec file that has no offense' do
-    generator.write_spec
-    expect(runner.run([])).to be true
+    it 'generates a cop file that has no offense' do
+      generator.write_source
+      expect(runner.run([])).to be true
+    end
+
+    it 'generates a spec file that has no offense' do
+      generator.write_spec
+      expect(runner.run([])).to be true
+    end
   end
 end


### PR DESCRIPTION
I noticed while working on https://github.com/bbatsov/rubocop/pull/4937 that the cop generator generates files that are not passing the internal investigation. This PR adds a test that checks it.
Actual fix will come in a 2nd commit to make sure tests were failing and make then green

-----------------

Before submitting the PR make sure the following are checked:

* [ ] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [ ] Used the same coding conventions as the rest of the project.
* [ ] Feature branch is up-to-date with `master` (if not - rebase it).
* [ ] Squashed related commits together.
* [ ] Added tests.
* [ ] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [ ] All tests(`rake spec`) are passing.
* [ ] The new code doesn't generate RuboCop offenses that are checked by `rake internal_investigation`.
* [ ] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [ ] Updated cop documentation with `rake generate_cops_documentation` (required only when you've added a new cop or changed the configuration/documentation of an existing cop).

[1]: http://chris.beams.io/posts/git-commit/
