### PR TITLE
[Fix #4886] Fix false offense for Style/CommentedKeyword

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 * [#4883](https://github.com/bbatsov/rubocop/pull/4883): Fix auto-correction for `Performance/HashEachMethods`. ([@pocke][])
 * [#4888](https://github.com/bbatsov/rubocop/pull/4888): Improve offense message of `Style/StderPuts`. ([@jaredbeck][])
 * [#4896](https://github.com/bbatsov/rubocop/pull/4896): Fix Style/DateTime wrongly triggered on classes `...::DateTime`. ([@dpostorivo][])
+* [#4886](https://github.com/bbatsov/rubocop/issues/4886): Fix false offense for Style/CommentedKeyword. ([@michniewicz][])
 
 ## 0.51.0 (2017-10-18)
 
@@ -2983,3 +2984,4 @@
 [@nelsonjr]: https://github.com/nelsonjr
 [@jonatas]: https://github.com/jonatas
 [@jaredbeck]: https://www.jaredbeck.com
+[@michniewicz]: https://github.com/michniewicz

--- a/spec/rubocop/cop/style/commented_keyword_spec.rb
+++ b/spec/rubocop/cop/style/commented_keyword_spec.rb
@@ -141,4 +141,17 @@ describe RuboCop::Cop::Style::CommentedKeyword do
       end
     RUBY
   end
+
+  it 'does not register an offense if AST contains # symbol' do
+    expect_no_offenses(<<-RUBY.strip_indent)
+      def x(y = "#value")
+        y
+      end
+    RUBY
+    expect_no_offenses(<<-RUBY.strip_indent)
+      def x(y: "#value")
+        y
+      end
+    RUBY
+  end
 end


### PR DESCRIPTION
[Fix #4886] Fix false offense for Style/CommentedKeyword

Fix also contains cop improvements:
Instead of going through each line of the processed_source we can easily take comments only and cop only those lines, where comments are located.
Instead of splitting line with `#` symbol we take column values from `comment.location`.

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Used the same coding conventions as the rest of the project.
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] All tests(`rake spec`) are passing.
* [x] The new code doesn't generate RuboCop offenses that are checked by `rake internal_investigation`.
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [ ] Updated cop documentation with `rake generate_cops_documentation` (required only when you've added a new cop or changed the configuration/documentation of an existing cop).

[1]: http://chris.beams.io/posts/git-commit/
