### PR TITLE
[Fix #1583] Add a quiet formatter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@
 * [#4888](https://github.com/bbatsov/rubocop/pull/4888): Improve offense message of `Style/StderPuts`. ([@jaredbeck][])
 * [#4896](https://github.com/bbatsov/rubocop/pull/4896): Fix Style/DateTime wrongly triggered on classes `...::DateTime`. ([@dpostorivo][])
 
+### New features
+
+* [#1583](https://github.com/bbatsov/rubocop/issues/1583): Add a quiet formatter. ([@drenmi][])
+
 ## 0.51.0 (2017-10-18)
 
 ### New features

--- a/lib/rubocop.rb
+++ b/lib/rubocop.rb
@@ -536,6 +536,7 @@ require_relative 'rubocop/formatter/html_formatter'
 require_relative 'rubocop/formatter/json_formatter'
 require_relative 'rubocop/formatter/offense_count_formatter'
 require_relative 'rubocop/formatter/progress_formatter'
+require_relative 'rubocop/formatter/quiet_formatter'
 require_relative 'rubocop/formatter/tap_formatter'
 require_relative 'rubocop/formatter/worst_offenders_formatter'
 

--- a/lib/rubocop/formatter/formatter_set.rb
+++ b/lib/rubocop/formatter/formatter_set.rb
@@ -20,7 +20,8 @@ module RuboCop
         'offenses' => OffenseCountFormatter,
         'disabled' => DisabledLinesFormatter,
         'worst'    => WorstOffendersFormatter,
-        'tap'      => TapFormatter
+        'tap'      => TapFormatter,
+        'quiet'    => QuietFormatter
       }.freeze
 
       FORMATTER_APIS = %i[started finished].freeze

--- a/lib/rubocop/formatter/quiet_formatter.rb
+++ b/lib/rubocop/formatter/quiet_formatter.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+module RuboCop
+  module Formatter
+    # If no offenses are found, no output is displayed.
+    # Otherwise, SimpleTextFormatter's output is displayed.
+    class QuietFormatter < SimpleTextFormatter
+      def report_summary(file_count, offense_count, correction_count)
+        super unless offense_count.zero?
+      end
+    end
+  end
+end

--- a/lib/rubocop/options.rb
+++ b/lib/rubocop/options.rb
@@ -324,6 +324,7 @@ module RuboCop
                              '  [o]ffenses',
                              '  [w]orst',
                              '  [t]ap',
+                             '  [q]uiet',
                              '  custom formatter class name'],
       out:                  ['Write output to a file instead of STDOUT.',
                              'This option applies to the previously',

--- a/manual/formatters.md
+++ b/manual/formatters.md
@@ -136,6 +136,10 @@ W:  4:  5: end at 4, 4 is not aligned with if at 2, 2
 1 file inspected, 4 offenses detected
 ```
 
+### Quiet Formatter
+
+Behaves like Simple Formatter if there are offenses. Completely quiet otherwise.
+
 ### File List Formatter
 
  **Machine-parsable**

--- a/spec/rubocop/formatter/quiet_formatter_spec.rb
+++ b/spec/rubocop/formatter/quiet_formatter_spec.rb
@@ -1,0 +1,135 @@
+# frozen_string_literal: true
+
+module RuboCop
+  module Formatter
+    describe QuietFormatter do
+      before do
+        Rainbow.enabled = true
+      end
+
+      subject(:formatter) { described_class.new(output) }
+
+      let(:output) { StringIO.new }
+
+      describe '#report_file' do
+        before do
+          formatter.report_file(file, [offense])
+        end
+
+        let(:file) { '/path/to/file' }
+
+        let(:offense) do
+          Cop::Offense.new(:convention, location,
+                           'This is a message with `colored text`.',
+                           'CopName', status)
+        end
+
+        let(:location) do
+          source_buffer = Parser::Source::Buffer.new('test', 1)
+          source_buffer.source = "a\n"
+          Parser::Source::Range.new(source_buffer, 0, 1)
+        end
+
+        let(:status) { :uncorrected }
+
+        context 'the file is under the current working directory' do
+          let(:file) { File.expand_path('spec/spec_helper.rb') }
+
+          it 'prints as relative path' do
+            expect(output.string).to include('== spec/spec_helper.rb ==')
+          end
+        end
+
+        context 'the file is outside of the current working directory' do
+          let(:file) do
+            tempfile = Tempfile.new('')
+            tempfile.close
+            File.expand_path(tempfile.path)
+          end
+
+          it 'prints as absolute path' do
+            expect(output.string).to include("== #{file} ==")
+          end
+        end
+
+        context 'when the offense is not corrected' do
+          let(:status) { :uncorrected }
+
+          it 'prints message as-is' do
+            expect(output.string)
+              .to include(': This is a message with colored text.')
+          end
+        end
+
+        context 'when the offense is automatically corrected' do
+          let(:status) { :corrected }
+
+          it 'prints [Corrected] along with message' do
+            expect(output.string)
+              .to include(': [Corrected] This is a message with colored text.')
+          end
+        end
+      end
+
+      describe '#report_summary' do
+        context 'when no files inspected' do
+          it 'handles pluralization correctly' do
+            formatter.report_summary(0, 0, 0)
+            expect(output.string.empty?).to eq(true)
+          end
+        end
+
+        context 'when a file inspected and no offenses detected' do
+          it 'handles pluralization correctly' do
+            formatter.report_summary(1, 0, 0)
+            expect(output.string.empty?).to eq(true)
+          end
+        end
+
+        context 'when a offense detected' do
+          it 'handles pluralization correctly' do
+            formatter.report_summary(1, 1, 0)
+            expect(output.string).to eq(<<-OUTPUT.strip_indent)
+
+              1 file inspected, 1 offense detected
+            OUTPUT
+          end
+        end
+
+        context 'when 2 offenses detected' do
+          it 'handles pluralization correctly' do
+            formatter.report_summary(2, 2, 0)
+            expect(output.string).to eq(<<-OUTPUT.strip_indent)
+
+              2 files inspected, 2 offenses detected
+            OUTPUT
+          end
+        end
+
+        context 'when an offense is corrected' do
+          it 'prints about correction' do
+            formatter.report_summary(1, 1, 1)
+            expect(output.string).to eq(<<-OUTPUT.strip_indent)
+
+              1 file inspected, 1 offense detected, 1 offense corrected
+            OUTPUT
+          end
+        end
+
+        context 'when 2 offenses are corrected' do
+          it 'handles pluralization correctly' do
+            formatter.report_summary(1, 1, 2)
+            expect(output.string).to eq(<<-OUTPUT.strip_indent)
+
+              1 file inspected, 1 offense detected, 2 offenses corrected
+            OUTPUT
+          end
+        end
+      end
+
+      after do
+        Rainbow.enabled = false
+      end
+    end
+  end
+end

--- a/spec/rubocop/options_spec.rb
+++ b/spec/rubocop/options_spec.rb
@@ -69,6 +69,7 @@ describe RuboCop::Options, :isolated_environment do
                                                  [o]ffenses
                                                  [w]orst
                                                  [t]ap
+                                                 [q]uiet
                                                  custom formatter class name
               -o, --out FILE                   Write output to a file instead of STDOUT.
                                                This option applies to the previously


### PR DESCRIPTION
Behaves like `SimpleTextFormatter` in the case of offenses, and finishes completely quietly otherwise.

Partly retrofitted from #1593.

-----------------

Before submitting the PR make sure the following are checked:

* [X] Wrote [good commit messages][1].
* [X] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [X] Used the same coding conventions as the rest of the project.
* [X] Feature branch is up-to-date with `master` (if not - rebase it).
* [X] Squashed related commits together.
* [X] Added tests.
* [X] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [X] All tests(`rake spec`) are passing.
* [X] The new code doesn't generate RuboCop offenses that are checked by `rake internal_investigation`.
* [X] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.

[1]: http://chris.beams.io/posts/git-commit/
