### PR TITLE
Add examples to Naming/FileName

### DIFF
--- a/lib/rubocop/cop/naming/file_name.rb
+++ b/lib/rubocop/cop/naming/file_name.rb
@@ -8,6 +8,17 @@ module RuboCop
       # This cop makes sure that Ruby source files have snake_case
       # names. Ruby scripts (i.e. source files with a shebang in the
       # first line) are ignored.
+      #
+      # @example
+      #   # bad
+      #   lib/layoutManager.rb
+      #
+      #   anything/usingCamelCase
+      #
+      #   # good
+      #   lib/layout_manager.rb
+      #
+      #   anything/using_snake_case.rake
       class FileName < Cop
         MSG_SNAKE_CASE = 'The name of this source file (`%s`) ' \
                          'should use snake_case.'.freeze

--- a/manual/cops_naming.md
+++ b/manual/cops_naming.md
@@ -102,6 +102,20 @@ This cop makes sure that Ruby source files have snake_case
 names. Ruby scripts (i.e. source files with a shebang in the
 first line) are ignored.
 
+### Example
+
+```ruby
+# bad
+lib/layoutManager.rb
+
+anything/usingCamelCase
+
+# good
+lib/layout_manager.rb
+
+anything/using_snake_case.rake
+```
+
 ### Important attributes
 
 Attribute | Value


### PR DESCRIPTION
This commit just adds examples to Naming/FileName cop.

* Instructions on #4910 noted to not include `[Fix foo]` in commit message.

-----------------

* [x] Wrote [good commit messages][1].
* [x] Used the same coding conventions as the rest of the project.
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] All tests(`rake spec`) are passing.
* [x] The new code doesn't generate RuboCop offenses that are checked by `rake internal_investigation`.
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Updated cop documentation with `rake generate_cops_documentation` (required only when you've added a new cop or changed the configuration/documentation of an existing cop).

[1]: http://chris.beams.io/posts/git-commit/
