### PR TITLE
Fix typo in Style::ClassVars cop documentation

### DIFF
--- a/lib/rubocop/cop/style/class_vars.rb
+++ b/lib/rubocop/cop/style/class_vars.rb
@@ -5,7 +5,7 @@ module RuboCop
     module Style
       # This cop checks for uses of class variables. Offenses
       # are signaled only on assignment to class variables to
-      # reduced the number of offenses that would be reported.
+      # reduce the number of offenses that would be reported.
       class ClassVars < Cop
         MSG = 'Replace class var %s with a class instance var.'.freeze
 

--- a/manual/cops_style.md
+++ b/manual/cops_style.md
@@ -407,7 +407,7 @@ Enabled | No
 
 This cop checks for uses of class variables. Offenses
 are signaled only on assignment to class variables to
-reduced the number of offenses that would be reported.
+reduce the number of offenses that would be reported.
 
 ### References
 


### PR DESCRIPTION
Fix typo in Style::ClassVars cop documentation

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Used the same coding conventions as the rest of the project.
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [ ] Added tests.
* [ ] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] All tests(`rake spec`) are passing.
* [x] The new code doesn't generate RuboCop offenses that are checked by `rake internal_investigation`.
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Updated cop documentation with `rake generate_cops_documentation` (required only when you've added a new cop or changed the configuration/documentation of an existing cop).

[1]: http://chris.beams.io/posts/git-commit/