### PR TITLE
Updates SpaceAfterMethodName examples/tests with assignment methods

### DIFF
--- a/lib/rubocop/cop/layout/space_after_method_name.rb
+++ b/lib/rubocop/cop/layout/space_after_method_name.rb
@@ -9,9 +9,11 @@ module RuboCop
       #
       #   # bad
       #   def func (x) ... end
+      #   def method= (y) ... end
       #
       #   # good
       #   def func(x) ... end
+      #   def method=(y) ... end
       class SpaceAfterMethodName < Cop
         MSG = 'Do not put a space between a method name and the opening ' \
               'parenthesis.'.freeze

--- a/manual/cops_layout.md
+++ b/manual/cops_layout.md
@@ -1911,9 +1911,11 @@ Checks for space between a method name and a left parenthesis in defs.
 ```ruby
 # bad
 def func (x) ... end
+def method= (y) ... end
 
 # good
 def func(x) ... end
+def method=(y) ... end
 ```
 
 ### References

--- a/spec/rubocop/cop/layout/space_after_method_name_spec.rb
+++ b/spec/rubocop/cop/layout/space_after_method_name_spec.rb
@@ -12,10 +12,19 @@ describe RuboCop::Cop::Layout::SpaceAfterMethodName do
     RUBY
   end
 
-  it 'registers an offense for defs with space before the parenthesis' do
+  it 'registers offense for class def with space before parenthesis' do
     expect_offense(<<-RUBY.strip_indent)
       def self.func (x)
                    ^ Do not put a space between a method name and the opening parenthesis.
+        a
+      end
+    RUBY
+  end
+
+  it 'registers offense for assignment def with space before parenthesis' do
+    expect_offense(<<-RUBY.strip_indent)
+      def func= (x)
+               ^ Do not put a space between a method name and the opening parenthesis.
         a
       end
     RUBY
@@ -45,9 +54,17 @@ describe RuboCop::Cop::Layout::SpaceAfterMethodName do
     RUBY
   end
 
-  it 'accepts a defs with arguments but no parentheses' do
+  it 'accepts class method def with arguments but no parentheses' do
     expect_no_offenses(<<-RUBY.strip_indent)
       def self.func x
+        a
+      end
+    RUBY
+  end
+
+  it 'accepts an assignment def with arguments but no parentheses' do
+    expect_no_offenses(<<-RUBY.strip_indent)
+      def func= x
         a
       end
     RUBY
@@ -61,12 +78,18 @@ describe RuboCop::Cop::Layout::SpaceAfterMethodName do
       def self.func (x)
         a
       end
+      def func= (x)
+        a
+      end
     RUBY
     expect(new_source).to eq(<<-RUBY.strip_indent)
       def func(x)
         a
       end
       def self.func(x)
+        a
+      end
+      def func=(x)
         a
       end
     RUBY


### PR DESCRIPTION
I was resolving rubocop offenses on a large repo today and found myself searching for the appropriate syntax for defining assignment methods. I was surprised not to find an example.

This PR adds assignment method examples to this cops documentation, extends the test file to cover assignment methods, and updates the cop's test descriptions to be more precise.

As far as I can see, there is no corresponding issue.

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [x] Used the same coding conventions as the rest of the project.
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] All tests(`rake spec`) are passing.
* [x] The new code doesn't generate RuboCop offenses that are checked by `rake internal_investigation`.
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Updated cop documentation with `rake generate_cops_documentation` (required only when you've added a new cop or changed the configuration/documentation of an existing cop).

[1]: http://chris.beams.io/posts/git-commit/
