### PR TITLE
[FIX #4910] add example for Layout/EmptyLines

### DIFF
--- a/lib/rubocop/cop/layout/empty_lines.rb
+++ b/lib/rubocop/cop/layout/empty_lines.rb
@@ -6,6 +6,22 @@ module RuboCop
   module Cop
     module Layout
       # This cops checks for two or more consecutive blank lines.
+      # @example
+      #   # bad
+      #   def a
+      #   end
+      #
+      #
+      #   def b
+      #   end
+      #
+      # @example
+      #   # good
+      #   def a
+      #   end
+      #
+      #   def b
+      #   end
       class EmptyLines < Cop
         MSG = 'Extra blank line detected.'.freeze
         LINE_OFFSET = 2

--- a/manual/cops_layout.md
+++ b/manual/cops_layout.md
@@ -598,7 +598,6 @@ end
 def b
 end
 ```
-
 ```ruby
 # good
 def a

--- a/manual/cops_layout.md
+++ b/manual/cops_layout.md
@@ -587,6 +587,27 @@ Enabled | Yes
 
 This cops checks for two or more consecutive blank lines.
 
+### Example
+
+```ruby
+# bad
+def a
+end
+
+
+def b
+end
+```
+
+```ruby
+# good
+def a
+end
+
+def b
+end
+```
+
 ### References
 
 * [https://github.com/bbatsov/ruby-style-guide#two-or-more-empty-lines](https://github.com/bbatsov/ruby-style-guide#two-or-more-empty-lines)


### PR DESCRIPTION
Add example for `Layout/EmptyLines` cop. issue #4910.

Enabled by default | Supports autocorrection
--- | ---
Enabled | Yes

This checks continuous multiple blank lines.

```ruby
# bad
def a
end


def b
end
```

```ruby
# good
def a
end

def b
end
```


-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Used the same coding conventions as the rest of the project.
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] All tests(`rake spec`) are passing.
* [ ] The new code doesn't generate RuboCop offenses that are checked by `rake internal_investigation`.
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [ ] Updated cop documentation with `rake generate_cops_documentation` (required only when you've added a new cop or changed the configuration/documentation of an existing cop).

[1]: http://chris.beams.io/posts/git-commit/
