### PR TITLE
Fix a CI failure with `FileUtils.rmdir` behavior changed Ruby 2.5

### DIFF
--- a/spec/rubocop/result_cache_spec.rb
+++ b/spec/rubocop/result_cache_spec.rb
@@ -94,7 +94,7 @@ describe RuboCop::ResultCache, :isolated_environment do
           $stderr = StringIO.new
         end
         after do
-          FileUtils.rmdir(attack_target_dir)
+          FileUtils.rm_rf(attack_target_dir)
           $stderr = STDERR
         end
 


### PR DESCRIPTION
Currently Travis CI has failed to build ruby-head.

https://travis-ci.org/bbatsov/rubocop/jobs/294862639#L682-L700

The error log is as follows.

```console
  1) RuboCop::ResultCache cached result that was saved with no command
  line option when no option is given when a symlink is present in the
  cache location and symlink attack protection is disabled permits
  caching and prints no warning
     Failure/Error: FileUtils.rmdir(attack_target_dir)

     Errno::ENOTEMPTY:
       Directory not empty @ dir_s_rmdir - /tmp/d20171030-6334-1pf27sw
     # ./spec/rubocop/result_cache_spec.rb:97:in `block (5 levels) in <top (required)>'
     # ./lib/rubocop/rspec/shared_contexts.rb:27:in `block (4 levels) in <top (required)>'
     # ./lib/rubocop/rspec/shared_contexts.rb:26:in `chdir'
     # ./lib/rubocop/rspec/shared_contexts.rb:26:in `block (3 levels) in <top (required)>'
     # ./lib/rubocop/rspec/shared_contexts.rb:8:in `block (2 levels) in <top (required)>'
```

In Ruby 2.5 the behavior of `FileUtils.rmdir` changes to non-empty directory.

- https://github.com/ruby/ruby/commit/2635984cf2b9b7632f8b35afa2f29d219aba104a
- https://github.com/ruby/ruby/commit/1241d59cefbe52fa13ad7bcfabe9dca5182c06d6

## Ruby 2.4.2

```console
% rm -rf /tmp/foo && ruby -v -rfileutils -e
'FileUtils.mkdir("/tmp/foo"); FileUtils.touch("/tmp/foo/bar.txt"); FileUtils.rmdir("/tmp/foo")'
ruby 2.4.2p198 (2017-09-14 revision 59899) [x86_64-darwin13]
% ls /tmp/foo
bar.txt
```

## Ruby 2.5.0-dev (2017-10-30 trunk 60580)

```console
% rm -rf /tmp/foo && ruby -v -rfileutils -e
'FileUtils.mkdir("/tmp/foo"); FileUtils.touch("/tmp/foo/bar.txt"); FileUtils.rmdir("/tmp/foo")'
  ruby 2.5.0dev (2017-10-30 trunk 60580) [x86_64-darwin13]
  Traceback (most recent call last):
        4: from -e:1:in `<main>'
        3: from /Users/koic/.rbenv/versions/2.5.0-dev/lib/ruby/2.5.0/fileutils.rb:247:in `rmdir'
        2: from /Users/koic/.rbenv/versions/2.5.0-dev/lib/ruby/2.5.0/fileutils.rb:247:in `each'
        1: from /Users/koic/.rbenv/versions/2.5.0-dev/lib/ruby/2.5.0/fileutils.rb:248:in `block in rmdir'
```

Since the file was not deleted even in Ruby 2.4 or lower, it seems that
it was probably working differently than intended.

This PR uses `FileUtils.rm_rf` instead of `FileUtils.rmdir`.

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Used the same coding conventions as the rest of the project.
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [ ] Added tests.
* [ ] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] All tests(`rake spec`) are passing.
* [x] The new code doesn't generate RuboCop offenses that are checked by `rake internal_investigation`.
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [ ] Updated cop documentation with `rake generate_cops_documentation` (required only when you've added a new cop or changed the configuration/documentation of an existing cop).

[1]: http://chris.beams.io/posts/git-commit/
