### PR TITLE
[Fix #3396] Concise error when config. file not found

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -13,7 +13,7 @@ Metrics/AbcSize:
 # Offense count: 37
 # Configuration parameters: CountComments.
 Metrics/ClassLength:
-  Max: 180
+  Max: 186
 
 # Offense count: 157
 # Configuration parameters: CountComments.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Bug fixes
 
+* [#3396](https://github.com/bbatsov/rubocop/issues/3396): Concise error when config. file not found. ([@jaredbeck][])
 * [#4881](https://github.com/bbatsov/rubocop/issues/4881): Fix a false positive for `Performance/HashEachMethods` when unused argument(s) exists in other blocks. ([@pocke][])
 * [#4883](https://github.com/bbatsov/rubocop/pull/4883): Fix auto-correction for `Performance/HashEachMethods`. ([@pocke][])
 * [#4896](https://github.com/bbatsov/rubocop/pull/4896): Fix Style/DateTime wrongly triggered on classes `...::DateTime`. ([@dpostorivo][])

--- a/lib/rubocop/config_loader.rb
+++ b/lib/rubocop/config_loader.rb
@@ -211,7 +211,7 @@ module RuboCop
       end
 
       def load_yaml_configuration(absolute_path)
-        yaml_code = IO.read(absolute_path, encoding: Encoding::UTF_8)
+        yaml_code = read_file(absolute_path)
         hash = yaml_safe_load(yaml_code, absolute_path) || {}
 
         puts "configuration from #{absolute_path}" if debug?
@@ -221,6 +221,16 @@ module RuboCop
         end
 
         hash
+      end
+
+      # Read the specified file, or exit with a friendly, concise message on
+      # stderr. Care is taken to use the standard OS exit code for a "file not
+      # found" error.
+      def read_file(absolute_path)
+        IO.read(absolute_path, encoding: Encoding::UTF_8)
+      rescue Errno::ENOENT
+        warn(format('Configuration file not found: %s', absolute_path))
+        exit(Errno::ENOENT::Errno)
       end
 
       def yaml_safe_load(yaml_code, filename)

--- a/spec/rubocop/config_loader_spec.rb
+++ b/spec/rubocop/config_loader_spec.rb
@@ -548,18 +548,6 @@ describe RuboCop::ConfigLoader do
       end
     end
 
-    context 'when a file inherits from a non http/https url' do
-      let(:file_path) { '.rubocop.yml' }
-
-      before do
-        create_file(file_path, ['inherit_from: c:\\\\foo\\bar.yml'])
-      end
-
-      it 'fails to load the resulting path' do
-        expect { configuration_from_file }.to raise_error(Errno::ENOENT)
-      end
-    end
-
     context 'EnabledByDefault / DisabledByDefault' do
       def cop_enabled?(cop_class)
         configuration_from_file.for_cop(cop_class).fetch('Enabled')
@@ -781,6 +769,20 @@ describe RuboCop::ConfigLoader do
             end
           end
         end
+      end
+    end
+
+    context 'when the file does not exist' do
+      let(:configuration_path) { 'file_that_does_not_exist.yml' }
+
+      it 'prints a friendly (concise) message to stderr and exits' do
+        expect { load_file }.to(
+          output(/Configuration file not found/).to_stderr.and(
+            raise_error(SystemExit) do |e|
+              expect(e.status).to(eq(Errno::ENOENT::Errno))
+            end
+          )
+        )
       end
     end
   end


### PR DESCRIPTION
Instead of a stack trace, prints a friendly (concise) message
to stderr when a configuration file, e.g. inherit_from, cannot
be found.

We use the constant Errno::ENOENT because it is present on
all major operating systems. According to the ruby documenation,
there may be some odd platforms that do not support this standard.
If we find that someone is using rubocop on such a platform, we
can rescue SystemCallError instead, but that will make it hard
to exit with the correct exit code.

-----------------

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Used the same coding conventions as the rest of the project.
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] All tests(`rake spec`) are passing.
* [x] The new code doesn't generate RuboCop offenses that are checked by `rake internal_investigation`.

```
Offenses:

lib/rubocop/config_loader.rb:12:3: C: Class has too many lines. [186/180]
  class ConfigLoader ...
  ^^^^^^^^^^^^^^^^^^

1019 files inspected, 1 offense detected
RuboCop failed!
```

Please advise on how to fix this.

* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Updated cop documentation with `rake generate_cops_documentation` (required only when you've added a new cop or changed the configuration/documentation of an existing cop).

Not relevant.

[1]: http://chris.beams.io/posts/git-commit/
