### PR TITLE
[Fix #4910] Add an example for Style/AsciiComments into the documentation

### DIFF
--- a/lib/rubocop/cop/style/ascii_comments.rb
+++ b/lib/rubocop/cop/style/ascii_comments.rb
@@ -5,12 +5,13 @@ module RuboCop
     module Style
       # This cop checks for non-ascii (non-English) characters
       # in comments.
+      #
       # @example
       #   # bad
-      #   # 🤔
+      #   # Translates from English to 日本語。
       #
       #   # good
-      #   # A comment in plain english.
+      #   # Translates from English to Japanese
       class AsciiComments < Cop
         MSG = 'Use only ascii symbols in comments.'.freeze
 

--- a/lib/rubocop/cop/style/ascii_comments.rb
+++ b/lib/rubocop/cop/style/ascii_comments.rb
@@ -8,7 +8,7 @@ module RuboCop
       #
       # @example
       #   # bad
-      #   # Translates from English to 日本語。
+      #   # Translates from English to 日本語。# rubocop:disable Style/AsciiComments
       #
       #   # good
       #   # Translates from English to Japanese

--- a/lib/rubocop/cop/style/ascii_comments.rb
+++ b/lib/rubocop/cop/style/ascii_comments.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+# rubocop:disable Style/AsciiComments
+
 module RuboCop
   module Cop
     module Style
@@ -8,7 +10,7 @@ module RuboCop
       #
       # @example
       #   # bad
-      #   # Translates from English to 日本語。# rubocop:disable Style/AsciiComments
+      #   # Translates from English to 日本語。
       #
       #   # good
       #   # Translates from English to Japanese

--- a/lib/rubocop/cop/style/ascii_comments.rb
+++ b/lib/rubocop/cop/style/ascii_comments.rb
@@ -5,6 +5,12 @@ module RuboCop
     module Style
       # This cop checks for non-ascii (non-English) characters
       # in comments.
+      # @example
+      #   # bad
+      #   # 🤔
+      #
+      #   # good
+      #   # A comment in plain english.
       class AsciiComments < Cop
         MSG = 'Use only ascii symbols in comments.'.freeze
 

--- a/manual/cops_style.md
+++ b/manual/cops_style.md
@@ -124,6 +124,16 @@ Enabled | No
 This cop checks for non-ascii (non-English) characters
 in comments.
 
+### Example
+
+```ruby
+# bad
+# 🤔
+
+# good
+# A comment in plain english.
+```
+
 ### References
 
 * [https://github.com/bbatsov/ruby-style-guide#english-comments](https://github.com/bbatsov/ruby-style-guide#english-comments)

--- a/manual/cops_style.md
+++ b/manual/cops_style.md
@@ -128,10 +128,10 @@ in comments.
 
 ```ruby
 # bad
-# 🤔
+# Translates from English to 日本語。
 
 # good
-# A comment in plain english.
+# Translates from English to Japanese
 ```
 
 ### References

--- a/manual/cops_style.md
+++ b/manual/cops_style.md
@@ -128,7 +128,7 @@ in comments.
 
 ```ruby
 # bad
-# Translates from English to 日本語。
+# Translates from English to 日本語。# rubocop:disable Style/AsciiComments
 
 # good
 # Translates from English to Japanese

--- a/manual/cops_style.md
+++ b/manual/cops_style.md
@@ -128,7 +128,7 @@ in comments.
 
 ```ruby
 # bad
-# Translates from English to 日本語。# rubocop:disable Style/AsciiComments
+# Translates from English to 日本語。
 
 # good
 # Translates from English to Japanese


### PR DESCRIPTION
Add an example for Style/AsciiComments into the documentation.

Note that this code fails `rake_internal_investigation` because the bad example requires putting a non-ascii character into a comment which will cause the investigation to fail.

Before submitting the PR make sure the following are checked:

* [X] Wrote [good commit messages][1].
* [X] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [X] Used the same coding conventions as the rest of the project.
* [X] Feature branch is up-to-date with `master` (if not - rebase it).
* [X] Squashed related commits together.
* [X] Added tests.
* [X] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [X] All tests(`rake spec`) are passing.
* [ ] The new code doesn't generate RuboCop offenses that are checked by `rake internal_investigation`.
* [X] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [X] Updated cop documentation with `rake generate_cops_documentation` (required only when you've added a new cop or changed the configuration/documentation of an existing cop).

[1]: http://chris.beams.io/posts/git-commit/
