### PR TITLE
Make `Lint/RedundantWithIndex` cop aware of offset argument

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 
 * [#4888](https://github.com/bbatsov/rubocop/pull/4888): Improve offense message of `Style/StderrPuts`. ([@jaredbeck][])
 * [#4886](https://github.com/bbatsov/rubocop/issues/4886): Fix false offense for Style/CommentedKeyword. ([@michniewicz][])
+* [#4977](https://github.com/bbatsov/rubocop/pull/4977): Make `Lint/RedundantWithIndex` cop aware of offset argument. ([@koic][])
 
 ### New features
 

--- a/lib/rubocop/cop/lint/redundant_with_index.rb
+++ b/lib/rubocop/cop/lint/redundant_with_index.rb
@@ -33,7 +33,7 @@ module RuboCop
         def_node_matcher :redundant_with_index?, <<-PATTERN
           (block
             $(send
-              _ {:each_with_index :with_index})
+              _ {:each_with_index :with_index} ...)
             (args
               (arg _))
             ...)
@@ -51,7 +51,7 @@ module RuboCop
               if send.method_name == :each_with_index
                 corrector.replace(send.loc.selector, 'each')
               else
-                corrector.remove(send.loc.selector)
+                corrector.remove(with_index_range(send))
                 corrector.remove(send.loc.dot)
               end
             end
@@ -69,7 +69,7 @@ module RuboCop
         end
 
         def with_index_range(send)
-          range_between(send.loc.selector.begin_pos, send.loc.selector.end_pos)
+          range_between(send.loc.selector.begin_pos, send.source.length)
         end
       end
     end

--- a/spec/rubocop/cop/lint/redundant_with_index_spec.rb
+++ b/spec/rubocop/cop/lint/redundant_with_index_spec.rb
@@ -19,6 +19,13 @@ describe RuboCop::Cop::Lint::RedundantWithIndex do
     RUBY
   end
 
+  it 'registers an offense when using `ary.each.with_index(1) { |v| v }`' do
+    expect_offense(<<-RUBY.strip_indent)
+      ary.each.with_index(1) { |v| v }
+               ^^^^^^^^^^^^^ Remove redundant `with_index`.
+    RUBY
+  end
+
   it 'registers an offense when using `ary.each_with_object([]).with_index ' \
      '{ |v| v }`' do
     expect_offense(<<-RUBY.strip_indent)
@@ -35,6 +42,12 @@ describe RuboCop::Cop::Lint::RedundantWithIndex do
 
   it 'autocorrects to ary.each from ary.each.with_index' do
     new_source = autocorrect_source('ary.each.with_index { |v| v }')
+
+    expect(new_source).to eq 'ary.each { |v| v }'
+  end
+
+  it 'autocorrects to ary.each from ary.each.with_index(1)' do
+    new_source = autocorrect_source('ary.each.with_index(1) { |v| v }')
 
     expect(new_source).to eq 'ary.each { |v| v }'
   end


### PR DESCRIPTION
Follow up of https://github.com/bbatsov/rubocop/pull/4796#discussion_r141739242.

Actually, it is only `with_index` method that accepts an offset argument. `with_with_index` method doesn't accept offset argument.
However, I think that the same AST will be low maintenance cost.

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Used the same coding conventions as the rest of the project.
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] All tests(`rake spec`) are passing.
* [x] The new code doesn't generate RuboCop offenses that are checked by `rake internal_investigation`.
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [ ] Updated cop documentation with `rake generate_cops_documentation` (required only when you've added a new cop or changed the configuration/documentation of an existing cop).

[1]: http://chris.beams.io/posts/git-commit/
