### PR TITLE
Restyle the example formatting for some Layout cops

### DIFF
--- a/lib/rubocop/cop/layout/access_modifier_indentation.rb
+++ b/lib/rubocop/cop/layout/access_modifier_indentation.rb
@@ -6,9 +6,7 @@ module RuboCop
       # Modifiers should be indented as deep as method definitions, or as deep
       # as the class/module keyword, depending on configuration.
       #
-      # @example
-      #   # EnforcedStyle: indent (default)
-      #
+      # @example EnforcedStyle: indent (default)
       #   # bad
       #   class Plumbus
       #   private
@@ -21,8 +19,7 @@ module RuboCop
       #     def smooth; end
       #   end
       #
-      #   # EnforcedStyle: outdent
-      #
+      # @example EnforcedStyle: outdent
       #   # bad
       #   class Plumbus
       #     private

--- a/lib/rubocop/cop/layout/align_parameters.rb
+++ b/lib/rubocop/cop/layout/align_parameters.rb
@@ -6,10 +6,7 @@ module RuboCop
       # Here we check if the parameters on a multi-line method call or
       # definition are aligned.
       #
-      # @example
-      #
-      #   # EnforcedStyle: with_first_parameter
-      #
+      # @example EnforcedStyle: with_first_parameter (default)
       #   # good
       #
       #   foo :bar,
@@ -20,10 +17,7 @@ module RuboCop
       #   foo :bar,
       #     :baz
       #
-      # @example
-      #
-      #   # EnforcedStyle: with_fixed_indentation
-      #
+      # @example EnforcedStyle: with_fixed_indentation
       #   # good
       #
       #   foo :bar,

--- a/lib/rubocop/cop/layout/case_indentation.rb
+++ b/lib/rubocop/cop/layout/case_indentation.rb
@@ -30,12 +30,10 @@ module RuboCop
       #     y / 3
       #   end
       #
-      # @example
+      # @example EnforcedStyle: case (default)
       #   # if EndAlignment is set to other style such as
       #   # start_of_line (as shown below), then *when* alignment
       #   # configuration does have an effect.
-      #
-      #   # EnforcedStyle: case (default)
       #
       #   # bad
       #   a = case n
@@ -53,8 +51,7 @@ module RuboCop
       #         y / 3
       #   end
       #
-      #   # EnforcedStyle: end
-      #
+      # @example EnforcedStyle: end
       #   # bad
       #   a = case n
       #       when 0

--- a/lib/rubocop/cop/layout/empty_lines_around_block_body.rb
+++ b/lib/rubocop/cop/layout/empty_lines_around_block_body.rb
@@ -6,10 +6,7 @@ module RuboCop
       # This cops checks if empty lines around the bodies of blocks match
       # the configuration.
       #
-      # @example
-      #
-      #   # EnforcedStyle: empty_lines
-      #
+      # @example EnforcedStyle: empty_lines
       #   # good
       #
       #   foo do |bar|
@@ -18,8 +15,7 @@ module RuboCop
       #
       #   end
       #
-      #   # EnforcedStyle: no_empty_lines
-      #
+      # @example EnforcedStyle: no_empty_lines (default)
       #   # good
       #
       #   foo do |bar|

--- a/lib/rubocop/cop/layout/empty_lines_around_class_body.rb
+++ b/lib/rubocop/cop/layout/empty_lines_around_class_body.rb
@@ -6,10 +6,7 @@ module RuboCop
       # This cops checks if empty lines around the bodies of classes match
       # the configuration.
       #
-      # @example
-      #
-      #   EnforcedStyle: empty_lines
-      #
+      # @example EnforcedStyle: empty_lines
       #   # good
       #
       #   class Foo

--- a/lib/rubocop/cop/layout/empty_lines_around_module_body.rb
+++ b/lib/rubocop/cop/layout/empty_lines_around_module_body.rb
@@ -6,10 +6,7 @@ module RuboCop
       # This cops checks if empty lines around the bodies of modules match
       # the configuration.
       #
-      # @example
-      #
-      #   EnforcedStyle: empty_lines
-      #
+      # @example EnforcedStyle: empty_lines
       #   # good
       #
       #   module Foo
@@ -20,8 +17,7 @@ module RuboCop
       #
       #   end
       #
-      #   EnforcedStyle: no_empty_lines
-      #
+      # @example EnforcedStyle: no_empty_lines (default)
       #   # good
       #
       #   module Foo

--- a/lib/rubocop/cop/layout/multiline_assignment_layout.rb
+++ b/lib/rubocop/cop/layout/multiline_assignment_layout.rb
@@ -6,30 +6,31 @@ module RuboCop
       # This cop checks whether the multiline assignments have a newline
       # after the assignment operator.
       #
-      # @example
-      #   # bad (with EnforcedStyle set to new_line)
+      # @example EnforcedStyle: new_line (default)
+      #   # bad
       #   foo = if expression
       #     'bar'
       #   end
       #
-      #   # good (with EnforcedStyle set to same_line)
-      #   foo = if expression
-      #     'bar'
-      #   end
-      #
-      #   # good (with EnforcedStyle set to new_line)
+      #   # good
       #   foo =
       #     if expression
       #       'bar'
       #     end
       #
-      #   # good (with EnforcedStyle set to new_line)
+      #   # good
       #   foo =
       #     begin
       #       compute
       #     rescue => e
       #       nil
       #     end
+      #
+      # @example EnforcedStyle: same_line
+      #   # good
+      #   foo = if expression
+      #     'bar'
+      #   end
       class MultilineAssignmentLayout < Cop
         include CheckAssignment
         include ConfigurableEnforcedStyle

--- a/lib/rubocop/cop/layout/space_around_block_parameters.rb
+++ b/lib/rubocop/cop/layout/space_around_block_parameters.rb
@@ -5,10 +5,7 @@ module RuboCop
     module Layout
       # Checks the spacing inside and after block parameters pipes.
       #
-      # @example
-      #
-      #   # EnforcedStyleInsidePipes: no_space (default)
-      #
+      # @example EnforcedStyleInsidePipes: no_space (default)
       #   # bad
       #   {}.each { | x,  y |puts x }
       #   ->( x,  y ) { puts x }
@@ -17,10 +14,7 @@ module RuboCop
       #   {}.each { |x, y| puts x }
       #   ->(x, y) { puts x }
       #
-      # @example
-      #
-      #   # EnforcedStyleInsidePipes: space
-      #
+      # @example EnforcedStyleInsidePipes: space
       #   # bad
       #   {}.each { |x,  y| puts x }
       #   ->(x,  y) { puts x }

--- a/lib/rubocop/cop/layout/space_in_lambda_literal.rb
+++ b/lib/rubocop/cop/layout/space_in_lambda_literal.rb
@@ -6,20 +6,14 @@ module RuboCop
       # This cop checks for spaces between -> and opening parameter
       # brace in lambda literals.
       #
-      # @example
-      #
-      #   EnforcedStyle: require_no_space (default)
-      #
+      # @example EnforcedStyle: require_no_space (default)
       #     @bad
       #     a = -> (x, y) { x + y }
       #
       #     @good
       #     a = ->(x, y) { x + y }
       #
-      # @example
-      #
-      #   EnforcedStyle: require_space
-      #
+      # @example EnforcedStyle: require_space
       #     @bad
       #     a = ->(x, y) { x + y }
       #

--- a/lib/rubocop/cop/layout/space_inside_string_interpolation.rb
+++ b/lib/rubocop/cop/layout/space_inside_string_interpolation.rb
@@ -5,11 +5,18 @@ module RuboCop
     module Layout
       # This cop checks for whitespace within string interpolations.
       #
-      # @example
-      #   # Good if EnforcedStyle is no_space, bad if space.
+      # @example EnforcedStyle no_space (default)
+      #   # bad
+      #      var = "This is the #{ space } example"
+      #
+      #   # good
       #      var = "This is the #{no_space} example"
       #
-      #   # Good if EnforceStyle is space, bad if no_space.
+      # @example EnforcedStyle space
+      #   # bad
+      #      var = "This is the #{no_space} example"
+      #
+      #   # good
       #      var = "This is the #{ space } example"
       class SpaceInsideStringInterpolation < Cop
         include ConfigurableEnforcedStyle

--- a/manual/cops_layout.md
+++ b/manual/cops_layout.md
@@ -12,8 +12,6 @@ as the class/module keyword, depending on configuration.
 ### Example
 
 ```ruby
-# EnforcedStyle: indent (default)
-
 # bad
 class Plumbus
 private
@@ -25,9 +23,8 @@ class Plumbus
   private
   def smooth; end
 end
-
-# EnforcedStyle: outdent
-
+```
+```ruby
 # bad
 class Plumbus
   private
@@ -208,8 +205,6 @@ definition are aligned.
 ### Example
 
 ```ruby
-# EnforcedStyle: with_first_parameter
-
 # good
 
 foo :bar,
@@ -221,8 +216,6 @@ foo :bar,
   :baz
 ```
 ```ruby
-# EnforcedStyle: with_fixed_indentation
-
 # good
 
 foo :bar,
@@ -317,8 +310,6 @@ end
 # start_of_line (as shown below), then *when* alignment
 # configuration does have an effect.
 
-# EnforcedStyle: case (default)
-
 # bad
 a = case n
 when 0
@@ -334,9 +325,8 @@ a = case n
     else
       y / 3
 end
-
-# EnforcedStyle: end
-
+```
+```ruby
 # bad
 a = case n
     when 0
@@ -666,8 +656,6 @@ the configuration.
 ### Example
 
 ```ruby
-# EnforcedStyle: empty_lines
-
 # good
 
 foo do |bar|
@@ -675,9 +663,8 @@ foo do |bar|
   ...
 
 end
-
-# EnforcedStyle: no_empty_lines
-
+```
+```ruby
 # good
 
 foo do |bar|
@@ -708,8 +695,6 @@ the configuration.
 ### Example
 
 ```ruby
-EnforcedStyle: empty_lines
-
 # good
 
 class Foo
@@ -842,8 +827,6 @@ the configuration.
 ### Example
 
 ```ruby
-EnforcedStyle: empty_lines
-
 # good
 
 module Foo
@@ -853,9 +836,8 @@ module Foo
   end
 
 end
-
-EnforcedStyle: no_empty_lines
-
+```
+```ruby
 # good
 
 module Foo
@@ -1445,29 +1427,30 @@ after the assignment operator.
 ### Example
 
 ```ruby
-# bad (with EnforcedStyle set to new_line)
+# bad
 foo = if expression
   'bar'
 end
 
-# good (with EnforcedStyle set to same_line)
-foo = if expression
-  'bar'
-end
-
-# good (with EnforcedStyle set to new_line)
+# good
 foo =
   if expression
     'bar'
   end
 
-# good (with EnforcedStyle set to new_line)
+# good
 foo =
   begin
     compute
   rescue => e
     nil
   end
+```
+```ruby
+# good
+foo = if expression
+  'bar'
+end
 ```
 
 ### Important attributes
@@ -1975,8 +1958,6 @@ Checks the spacing inside and after block parameters pipes.
 ### Example
 
 ```ruby
-# EnforcedStyleInsidePipes: no_space (default)
-
 # bad
 {}.each { | x,  y |puts x }
 ->( x,  y ) { puts x }
@@ -1986,8 +1967,6 @@ Checks the spacing inside and after block parameters pipes.
 ->(x, y) { puts x }
 ```
 ```ruby
-# EnforcedStyleInsidePipes: space
-
 # bad
 {}.each { |x,  y| puts x }
 ->(x,  y) { puts x }
@@ -2239,22 +2218,18 @@ brace in lambda literals.
 ### Example
 
 ```ruby
-EnforcedStyle: require_no_space (default)
+# bad
+a = -> (x, y) { x + y }
 
-  # bad
-  a = -> (x, y) { x + y }
-
-  # good
-  a = ->(x, y) { x + y }
+# good
+a = ->(x, y) { x + y }
 ```
 ```ruby
-EnforcedStyle: require_space
+# bad
+a = ->(x, y) { x + y }
 
-  # bad
-  a = ->(x, y) { x + y }
-
-  # good
-  a = -> (x, y) { x + y }
+# good
+a = -> (x, y) { x + y }
 ```
 
 ### Important attributes
@@ -2469,10 +2444,17 @@ This cop checks for whitespace within string interpolations.
 ### Example
 
 ```ruby
-# Good if EnforcedStyle is no_space, bad if space.
+# bad
+   var = "This is the #{ space } example"
+
+# good
+   var = "This is the #{no_space} example"
+```
+```ruby
+# bad
    var = "This is the #{no_space} example"
 
-# Good if EnforceStyle is space, bad if no_space.
+# good
    var = "This is the #{ space } example"
 ```
 


### PR DESCRIPTION
Follow up of https://github.com/bbatsov/rubocop/pull/4880#issuecomment-338499947.

This commit is a change of document format.

Because there are many cops to be changed 💦, this commit applied a new style to some Layout department cops first.

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Used the same coding conventions as the rest of the project.
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [ ] Added tests.
* [ ] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] All tests(`rake spec`) are passing.
* [x] The new code doesn't generate RuboCop offenses that are checked by `rake internal_investigation`.
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Updated cop documentation with `rake generate_cops_documentation` (required only when you've added a new cop or changed the configuration/documentation of an existing cop).

[1]: http://chris.beams.io/posts/git-commit/
