### PR TITLE
[Fix #4979] Disable Rails/FindBy when using rails3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Bug fixes
 
+* [#4979](https://github.com/bbatsov/rubocop/issues/4979): Disable `Rails/FindBy` for rails3 projects. ([@barodeur][])
 * [#3396](https://github.com/bbatsov/rubocop/issues/3396): Concise error when config. file not found. ([@jaredbeck][])
 * [#4881](https://github.com/bbatsov/rubocop/issues/4881): Fix a false positive for `Performance/HashEachMethods` when unused argument(s) exists in other blocks. ([@pocke][])
 * [#4883](https://github.com/bbatsov/rubocop/pull/4883): Fix auto-correction for `Performance/HashEachMethods`. ([@pocke][])
@@ -3000,3 +3001,4 @@
 [@jonatas]: https://github.com/jonatas
 [@jaredbeck]: https://www.jaredbeck.com
 [@michniewicz]: https://github.com/michniewicz
+[@barodeur]: https://github.com/barodeur

--- a/lib/rubocop/cop/rails/find_by.rb
+++ b/lib/rubocop/cop/rails/find_by.rb
@@ -6,6 +6,8 @@ module RuboCop
       # This cop is used to identify usages of `where.first` and
       # change them to use `find_by` instead.
       #
+      # This cop is disabled if the TargetRailsVersion is set to less than 4.0.
+      #
       # @example
       #   # bad
       #   User.where(name: 'Bruce').first
@@ -14,12 +16,16 @@ module RuboCop
       #   # good
       #   User.find_by(name: 'Bruce')
       class FindBy < Cop
+        extend TargetRailsVersion
+
         MSG = 'Use `find_by` instead of `where.%s`.'.freeze
         TARGET_SELECTORS = %i[first take].freeze
 
         def_node_matcher :where_first?, <<-PATTERN
           (send (send _ :where ...) {:first :take})
         PATTERN
+
+        minimum_target_rails_version 4.0
 
         def on_send(node)
           return unless where_first?(node)

--- a/manual/cops_rails.md
+++ b/manual/cops_rails.md
@@ -420,6 +420,8 @@ Enabled | Yes
 This cop is used to identify usages of `where.first` and
 change them to use `find_by` instead.
 
+This cop is disabled if the TargetRailsVersion is set to less than 4.0.
+
 ### Example
 
 ```ruby

--- a/spec/rubocop/cop/rails/find_by_spec.rb
+++ b/spec/rubocop/cop/rails/find_by_spec.rb
@@ -1,33 +1,59 @@
 # frozen_string_literal: true
 
-describe RuboCop::Cop::Rails::FindBy do
-  subject(:cop) { described_class.new }
+describe RuboCop::Cop::Rails::FindBy, :config do
+  context 'Rails < 4', :rails3 do
+    subject(:cop) { described_class.new(config) }
 
-  shared_examples 'registers_offense' do |selector|
-    it "when using where.#{selector}" do
-      inspect_source("User.where(id: x).#{selector}")
+    it 'does not register an offence with where.take' do
+      expect_no_offenses('User.where(id: x).take')
+    end
 
-      expect(cop.messages)
-        .to eq(["Use `find_by` instead of `where.#{selector}`."])
+    it 'does not register an offence with where.first' do
+      expect_no_offenses('User.where(id: x).first')
+    end
+
+    it 'does not autocorrect where.take' do
+      new_source = autocorrect_source('User.where(id: x).take')
+
+      expect(new_source).to eq('User.where(id: x).take')
+    end
+
+    it 'doest not autocorrect where.first' do
+      new_source = autocorrect_source('User.where(id: x).first')
+
+      expect(new_source).to eq('User.where(id: x).first')
     end
   end
 
-  it_behaves_like('registers_offense', 'first')
-  it_behaves_like('registers_offense', 'take')
+  context 'Rails >= 4.0', :rails4 do
+    subject(:cop) { described_class.new(config) }
 
-  it 'does not register an offense when using find_by' do
-    expect_no_offenses('User.find_by(id: x)')
-  end
+    shared_examples 'registers_offense' do |selector|
+      it "when using where.#{selector}" do
+        inspect_source("User.where(id: x).#{selector}")
 
-  it 'autocorrects where.take to find_by' do
-    new_source = autocorrect_source('User.where(id: x).take')
+        expect(cop.messages)
+          .to eq(["Use `find_by` instead of `where.#{selector}`."])
+      end
+    end
 
-    expect(new_source).to eq('User.find_by(id: x)')
-  end
+    it_behaves_like('registers_offense', 'first')
+    it_behaves_like('registers_offense', 'take')
 
-  it 'does not autocorrect where.first' do
-    new_source = autocorrect_source('User.where(id: x).first')
+    it 'does not register an offense when using find_by' do
+      expect_no_offenses('User.find_by(id: x)')
+    end
 
-    expect(new_source).to eq('User.where(id: x).first')
+    it 'autocorrects where.take to find_by' do
+      new_source = autocorrect_source('User.where(id: x).take')
+
+      expect(new_source).to eq('User.find_by(id: x)')
+    end
+
+    it 'does not autocorrect where.first' do
+      new_source = autocorrect_source('User.where(id: x).first')
+
+      expect(new_source).to eq('User.where(id: x).first')
+    end
   end
 end


### PR DESCRIPTION
As described in #4979 this will ensure that `Rails/FindBy` is disabled for rails projects with version < 4.0

It is simply using the TargetRailsVersion feature that was implemented in #4107

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Used the same coding conventions as the rest of the project.
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] All tests(`rake spec`) are passing.
* [x] The new code doesn't generate RuboCop offenses that are checked by `rake internal_investigation`.
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Updated cop documentation with `rake generate_cops_documentation` (required only when you've added a new cop or changed the configuration/documentation of an existing cop).

[1]: http://chris.beams.io/posts/git-commit/
