### PR TITLE
[Fix #4981] Disable Rails/DynamicFindBy with rails3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Bug fixes
 
+* [#4979](https://github.com/bbatsov/rubocop/issues/4979): Disable `Rails/DynamicFindBy` for rails3. ([@barodeur][])
 * [#3396](https://github.com/bbatsov/rubocop/issues/3396): Concise error when config. file not found. ([@jaredbeck][])
 * [#4881](https://github.com/bbatsov/rubocop/issues/4881): Fix a false positive for `Performance/HashEachMethods` when unused argument(s) exists in other blocks. ([@pocke][])
 * [#4883](https://github.com/bbatsov/rubocop/pull/4883): Fix auto-correction for `Performance/HashEachMethods`. ([@pocke][])
@@ -3000,3 +3001,4 @@
 [@jonatas]: https://github.com/jonatas
 [@jaredbeck]: https://www.jaredbeck.com
 [@michniewicz]: https://github.com/michniewicz
+[@barodeur]: https://github.com/barodeur

--- a/lib/rubocop/cop/rails/dynamic_find_by.rb
+++ b/lib/rubocop/cop/rails/dynamic_find_by.rb
@@ -7,6 +7,8 @@ module RuboCop
       # Use `find_by` instead of dynamic method.
       # See. https://github.com/bbatsov/rails-style-guide#find_by
       #
+      # This cop is disabled if the TargetRailsVersion is set to less than 4.0.
+      #
       # @example
       #   # bad
       #   User.find_by_name(name)
@@ -26,8 +28,12 @@ module RuboCop
       #   # good
       #   User.find_by!(email: email)
       class DynamicFindBy < Cop
+        extend TargetRailsVersion
+
         MSG = 'Use `%s` instead of dynamic `%s`.'.freeze
         METHOD_PATTERN = /^find_by_(.+?)(!)?$/
+
+        minimum_target_rails_version 4.0
 
         def on_send(node)
           method_name = node.method_name.to_s

--- a/manual/cops_rails.md
+++ b/manual/cops_rails.md
@@ -301,6 +301,8 @@ This cop checks dynamic `find_by_*` methods.
 Use `find_by` instead of dynamic method.
 See. https://github.com/bbatsov/rails-style-guide#find_by
 
+This cop is disabled if the TargetRailsVersion is set to less than 4.0.
+
 ### Example
 
 ```ruby

--- a/spec/rubocop/cop/rails/dynamic_find_by_spec.rb
+++ b/spec/rubocop/cop/rails/dynamic_find_by_spec.rb
@@ -1,141 +1,169 @@
 # frozen_string_literal: true
 
 describe RuboCop::Cop::Rails::DynamicFindBy, :config do
-  subject(:cop) { described_class.new(config) }
+  context 'Rails < 4.0', :rails3 do
+    subject(:cop) { described_class.new(config) }
 
-  let(:cop_config) do
-    { 'Whitelist' => %w[find_by_sql] }
-  end
-
-  shared_examples 'register an offense and auto correct' do |message, corrected|
-    it 'registers an offense' do
-      inspect_source(source)
-      expect(cop.offenses.size).to eq(1)
-      expect(cop.messages)
-        .to eq([message])
+    let(:cop_config) do
+      { 'Whitelist' => %w[find_by_sql] }
     end
 
-    it 'auto-corrects' do
-      new_source = autocorrect_source(source)
-      expect(new_source).to eq(corrected)
+    shared_examples 'does not register an offense nor auto correct' do
+      it 'does not register an offence' do
+        inspect_source(source)
+        expect(cop.offenses.size).to eq(0)
+      end
+
+      it 'does not auto-correct' do
+        new_source = autocorrect_source(source)
+        expect(new_source).to eq(source)
+      end
+    end
+
+    context 'with dynamic find_by_*' do
+      let(:source) { 'User.find_by_name(name)' }
+
+      include_examples('does not register an offense nor auto correct')
     end
   end
 
-  context 'with dynamic find_by_*' do
-    let(:source) { 'User.find_by_name(name)' }
+  context 'Rails >= 4.0', :rails4 do
+    subject(:cop) { described_class.new(config) }
 
-    include_examples(
-      'register an offense and auto correct',
-      'Use `find_by` instead of dynamic `find_by_name`.',
-      'User.find_by(name: name)'
-    )
-  end
-
-  context 'with dynamic find_by_*_and_*' do
-    let(:source) { 'User.find_by_name_and_email(name, email)' }
-
-    include_examples(
-      'register an offense and auto correct',
-      'Use `find_by` instead of dynamic `find_by_name_and_email`.',
-      'User.find_by(name: name, email: email)'
-    )
-  end
-
-  context 'with dynamic find_by_*!' do
-    let(:source) { 'User.find_by_name!(name)' }
-
-    include_examples(
-      'register an offense and auto correct',
-      'Use `find_by!` instead of dynamic `find_by_name!`.',
-      'User.find_by!(name: name)'
-    )
-  end
-
-  context 'with dynamic find_by_*_and_*_and_*' do
-    let(:source) { 'User.find_by_name_and_email_and_token(name, email, token)' }
-
-    include_examples(
-      'register an offense and auto correct',
-      'Use `find_by` instead of dynamic `find_by_name_and_email_and_token`.',
-      'User.find_by(name: name, email: email, token: token)'
-    )
-  end
-
-  context 'with dynamic find_by_*_and_*_and_*!' do
-    let(:source) do
-      'User.find_by_name_and_email_and_token!(name, email, token)'
+    let(:cop_config) do
+      { 'Whitelist' => %w[find_by_sql] }
     end
 
-    include_examples(
-      'register an offense and auto correct',
-      'Use `find_by!` instead of dynamic `find_by_name_and_email_and_token!`.',
-      'User.find_by!(name: name, email: email, token: token)'
-    )
-  end
+    shared_examples 'register an offense and auto correct' do |message, corrected|
+      it 'registers an offense' do
+        inspect_source(source)
+        expect(cop.offenses.size).to eq(1)
+        expect(cop.messages)
+          .to eq([message])
+      end
 
-  context 'with dynamic find_by_*_and_*_and_* with newline' do
-    let(:source) do
-      <<-RUBY.strip_indent
-        User.find_by_name_and_email_and_token(
-          name,
-          email,
-          token
-        )
+      it 'auto-corrects' do
+        new_source = autocorrect_source(source)
+        expect(new_source).to eq(corrected)
+      end
+    end
+
+    context 'with dynamic find_by_*' do
+      let(:source) { 'User.find_by_name(name)' }
+
+      include_examples(
+        'register an offense and auto correct',
+        'Use `find_by` instead of dynamic `find_by_name`.',
+        'User.find_by(name: name)'
+      )
+    end
+
+    context 'with dynamic find_by_*_and_*' do
+      let(:source) { 'User.find_by_name_and_email(name, email)' }
+
+      include_examples(
+        'register an offense and auto correct',
+        'Use `find_by` instead of dynamic `find_by_name_and_email`.',
+        'User.find_by(name: name, email: email)'
+      )
+    end
+
+    context 'with dynamic find_by_*!' do
+      let(:source) { 'User.find_by_name!(name)' }
+
+      include_examples(
+        'register an offense and auto correct',
+        'Use `find_by!` instead of dynamic `find_by_name!`.',
+        'User.find_by!(name: name)'
+      )
+    end
+
+    context 'with dynamic find_by_*_and_*_and_*' do
+      let(:source) { 'User.find_by_name_and_email_and_token(name, email, token)' }
+
+      include_examples(
+        'register an offense and auto correct',
+        'Use `find_by` instead of dynamic `find_by_name_and_email_and_token`.',
+        'User.find_by(name: name, email: email, token: token)'
+      )
+    end
+
+    context 'with dynamic find_by_*_and_*_and_*!' do
+      let(:source) do
+        'User.find_by_name_and_email_and_token!(name, email, token)'
+      end
+
+      include_examples(
+        'register an offense and auto correct',
+        'Use `find_by!` instead of dynamic `find_by_name_and_email_and_token!`.',
+        'User.find_by!(name: name, email: email, token: token)'
+      )
+    end
+
+    context 'with dynamic find_by_*_and_*_and_* with newline' do
+      let(:source) do
+        <<-RUBY.strip_indent
+          User.find_by_name_and_email_and_token(
+            name,
+            email,
+            token
+          )
+        RUBY
+      end
+
+      include_examples(
+        'register an offense and auto correct',
+        'Use `find_by` instead of dynamic `find_by_name_and_email_and_token`.',
+        <<-RUBY.strip_indent
+          User.find_by(
+            name: name,
+            email: email,
+            token: token
+          )
+        RUBY
+      )
+    end
+
+    context 'with column includes undersoce' do
+      let(:source) { 'User.find_by_first_name(name)' }
+
+      include_examples(
+        'register an offense and auto correct',
+        'Use `find_by` instead of dynamic `find_by_first_name`.',
+        'User.find_by(first_name: name)'
+      )
+    end
+
+    context 'with too much arguments' do
+      let(:source) { 'User.find_by_name_and_email(name, email, token)' }
+
+      include_examples(
+        'register an offense and auto correct',
+        'Use `find_by` instead of dynamic `find_by_name_and_email`.',
+        # Do not correct
+        'User.find_by_name_and_email(name, email, token)'
+      )
+    end
+
+    context 'with too few arguments' do
+      let(:source) { 'User.find_by_name_and_email(name)' }
+
+      include_examples(
+        'register an offense and auto correct',
+        'Use `find_by` instead of dynamic `find_by_name_and_email`.',
+        # Do not correct
+        'User.find_by_name_and_email(name)'
+      )
+    end
+
+    it 'accepts' do
+      expect_no_offenses('User.find_by(name: name)')
+    end
+
+    it 'accepts method in whitelist' do
+      expect_no_offenses(<<-RUBY.strip_indent)
+        User.find_by_sql(["select * from users where name = ?", name])
       RUBY
     end
-
-    include_examples(
-      'register an offense and auto correct',
-      'Use `find_by` instead of dynamic `find_by_name_and_email_and_token`.',
-      <<-RUBY.strip_indent
-        User.find_by(
-          name: name,
-          email: email,
-          token: token
-        )
-      RUBY
-    )
-  end
-
-  context 'with column includes undersoce' do
-    let(:source) { 'User.find_by_first_name(name)' }
-
-    include_examples(
-      'register an offense and auto correct',
-      'Use `find_by` instead of dynamic `find_by_first_name`.',
-      'User.find_by(first_name: name)'
-    )
-  end
-
-  context 'with too much arguments' do
-    let(:source) { 'User.find_by_name_and_email(name, email, token)' }
-
-    include_examples(
-      'register an offense and auto correct',
-      'Use `find_by` instead of dynamic `find_by_name_and_email`.',
-      # Do not correct
-      'User.find_by_name_and_email(name, email, token)'
-    )
-  end
-
-  context 'with too few arguments' do
-    let(:source) { 'User.find_by_name_and_email(name)' }
-
-    include_examples(
-      'register an offense and auto correct',
-      'Use `find_by` instead of dynamic `find_by_name_and_email`.',
-      # Do not correct
-      'User.find_by_name_and_email(name)'
-    )
-  end
-
-  it 'accepts' do
-    expect_no_offenses('User.find_by(name: name)')
-  end
-
-  it 'accepts method in whitelist' do
-    expect_no_offenses(<<-RUBY.strip_indent)
-      User.find_by_sql(["select * from users where name = ?", name])
-    RUBY
   end
 end


### PR DESCRIPTION
Like #4980 this PR uses the TargetRailsVersion to disable an unsupported cop on rails 3 projects.

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Used the same coding conventions as the rest of the project.
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] All tests(`rake spec`) are passing.
* [x] The new code doesn't generate RuboCop offenses that are checked by `rake internal_investigation`.
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Updated cop documentation with `rake generate_cops_documentation` (required only when you've added a new cop or changed the configuration/documentation of an existing cop).

[1]: http://chris.beams.io/posts/git-commit/
