### PR TITLE
Use `Parser::Source::Range#end_pos` instead of source length

### DIFF
--- a/lib/rubocop/cop/lint/redundant_with_index.rb
+++ b/lib/rubocop/cop/lint/redundant_with_index.rb
@@ -69,7 +69,10 @@ module RuboCop
         end
 
         def with_index_range(send)
-          range_between(send.loc.selector.begin_pos, send.source.length)
+          range_between(
+            send.loc.selector.begin_pos,
+            send.loc.expression.end_pos
+          )
         end
       end
     end

--- a/lib/rubocop/cop/lint/redundant_with_object.rb
+++ b/lib/rubocop/cop/lint/redundant_with_object.rb
@@ -72,7 +72,7 @@ module RuboCop
         def with_object_range(send)
           range_between(
             send.loc.selector.begin_pos,
-            send.source.length
+            send.loc.expression.end_pos
           )
         end
       end


### PR DESCRIPTION
Follow up of https://github.com/bbatsov/rubocop/pull/4977#discussion_r148397938.

This commit fixes the following potential problem.

> This actually only works incidentally because `processed_source` happens to start at the beginning of the node, which is kind of frail.

@Drenmi Thanks for letting me know this problem.

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Used the same coding conventions as the rest of the project.
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [ ] Added tests.
* [ ] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] All tests(`rake spec`) are passing.
* [x] The new code doesn't generate RuboCop offenses that are checked by `rake internal_investigation`.
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [ ] Updated cop documentation with `rake generate_cops_documentation` (required only when you've added a new cop or changed the configuration/documentation of an existing cop).

[1]: http://chris.beams.io/posts/git-commit/
