### PR TITLE
[Fix #4910] Add example for Layout/EndOfLine

### DIFF
--- a/lib/rubocop/cop/layout/end_of_line.rb
+++ b/lib/rubocop/cop/layout/end_of_line.rb
@@ -4,6 +4,20 @@ module RuboCop
   module Cop
     module Layout
       # This cop checks for Windows-style line endings in the source code.
+      #
+      # @example
+      #   # bad
+      #   puts 'foobar'; # superfluous semicolon
+      #
+      #   puts 'foo'; puts 'bar' # two expressions on the same line
+      #
+      #   # good
+      #   puts 'foobar'
+      #
+      #   puts 'foo'
+      #   puts 'bar'
+      #
+      #   puts 'foo', 'bar' # this applies to puts in particular
       class EndOfLine < Cop
         include ConfigurableEnforcedStyle
 

--- a/manual/cops_layout.md
+++ b/manual/cops_layout.md
@@ -884,6 +884,23 @@ Enabled | No
 
 This cop checks for Windows-style line endings in the source code.
 
+### Example
+
+```ruby
+# bad
+puts 'foobar'; # superfluous semicolon
+
+puts 'foo'; puts 'bar' # two expressions on the same line
+
+# good
+puts 'foobar'
+
+puts 'foo'
+puts 'bar'
+
+puts 'foo', 'bar' # this applies to puts in particular
+```
+
 ### Important attributes
 
 Attribute | Value


### PR DESCRIPTION
This PR adds example for `Style/EndOfLine`

Related to Issue #4910

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Used the same coding conventions as the rest of the project.
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [ ] Added tests.
* [ ] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] All tests(`rake spec`) are passing.
* [x] The new code doesn't generate RuboCop offenses that are checked by `rake internal_investigation`.
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Updated cop documentation with `rake generate_cops_documentation` (required only when you've added a new cop or changed the configuration/documentation of an existing cop).

[1]: http://chris.beams.io/posts/git-commit/
