### PR TITLE
Skip permission check when using stdin option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 * [#4883](https://github.com/bbatsov/rubocop/pull/4883): Fix auto-correction for `Performance/HashEachMethods`. ([@pocke][])
 * [#4896](https://github.com/bbatsov/rubocop/pull/4896): Fix Style/DateTime wrongly triggered on classes `...::DateTime`. ([@dpostorivo][])
 * [#4887](https://github.com/bbatsov/rubocop/pull/4887): Add undeclared configuration option `EnforcedStyleForEmptyBraces` for `Layout/SpaceBeforeBlockBraces` cop. ([@drenmi][])
+* [#4987](https://github.com/bbatsov/rubocop/pull/4987): Skip permission check when using stdin option. ([@mtsmfm][])
 
 ### Changes
 
@@ -3000,3 +3001,4 @@
 [@jonatas]: https://github.com/jonatas
 [@jaredbeck]: https://www.jaredbeck.com
 [@michniewicz]: https://github.com/michniewicz
+[@mtsmfm]: https://github.com/mtsmfm

--- a/lib/rubocop/cop/lint/script_permission.rb
+++ b/lib/rubocop/cop/lint/script_permission.rb
@@ -10,6 +10,7 @@ module RuboCop
         SHEBANG = '#!'.freeze
 
         def investigate(processed_source)
+          return if @options.key?(:stdin)
           return if Platform.windows?
           return unless start_with_shebang?(processed_source)
           return if executable?(processed_source)

--- a/spec/rubocop/cop/lint/script_permission_spec.rb
+++ b/spec/rubocop/cop/lint/script_permission_spec.rb
@@ -2,9 +2,10 @@
 
 # rubocop:disable Style/NumericLiteralPrefix
 describe RuboCop::Cop::Lint::ScriptPermission do
-  subject(:cop) { described_class.new(config) }
+  subject(:cop) { described_class.new(config, options) }
 
   let(:config) { RuboCop::Config.new }
+  let(:options) { nil }
 
   let(:file) { Tempfile.new('') }
   let(:filename) { file.path.split('/').last }
@@ -61,6 +62,14 @@ describe RuboCop::Cop::Lint::ScriptPermission do
       File.write(file.path, '')
 
       expect_no_offenses(file.read, file)
+    end
+  end
+
+  context 'with stdin' do
+    let(:options) { { stdin: '' } }
+
+    it 'skips investigation' do
+      expect_no_offenses('#!/usr/bin/ruby')
     end
   end
 


### PR DESCRIPTION
We face the following error when we run `echo '#!/usr/bin/env ruby' | bundle exec rubocop --stdin dummy.rb`:

```
echo '#!/usr/bin/env ruby' | bundle exec rubocop --stdin dummy.rb
Inspecting 1 file
An error occurred while Lint/ScriptPermission cop was inspecting
/app/dummy.rb.
To see the complete backtrace run rubocop -d.
.

1 file inspected, no offenses detected

1 error occurred:
An error occurred while Lint/ScriptPermission cop was inspecting
/app/dummy.rb.
Errors are usually caused by RuboCop bugs.
Please, report your problems to RuboCop's issue tracker.
Mention the following information in the issue report:
0.51.0 (using Parser 2.4.0.0, running on ruby 2.4.2 x86_64-linux)
```

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Used the same coding conventions as the rest of the project.
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] All tests(`rake spec`) are passing.
* [x] The new code doesn't generate RuboCop offenses that are checked by `rake internal_investigation`.
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Updated cop documentation with `rake generate_cops_documentation` (required only when you've added a new cop or changed the configuration/documentation of an existing cop).

[1]: http://chris.beams.io/posts/git-commit/
