### PR TITLE
Reduce .rubocop_todo.yml

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -32,14 +32,6 @@ RSpec/AnyInstance:
     - 'spec/rubocop/cop/lint/duplicate_methods_spec.rb'
     - 'spec/rubocop/target_finder_spec.rb'
 
-# Offense count: 1
-RSpec/BeforeAfterAll:
-  Exclude:
-    - 'spec/spec_helper.rb'
-    - 'spec/rails_helper.rb'
-    - 'spec/support/**/*.rb'
-    - 'spec/rubocop/ast/node_spec.rb'
-
 # Offense count: 2538
 # Configuration parameters: Max.
 RSpec/ExampleLength:

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -54,13 +54,6 @@ RSpec/ExpectOutput:
     - 'spec/rubocop/target_finder_spec.rb'
     - 'spec/support/cli_spec_behavior.rb'
 
-# Offense count: 6
-RSpec/IteratedExpectation:
-  Exclude:
-    - 'spec/project_spec.rb'
-    - 'spec/rubocop/cop/force_spec.rb'
-    - 'spec/rubocop/formatter/formatter_set_spec.rb'
-
 # Offense count: 36
 # Configuration parameters: EnforcedStyle, SupportedStyles.
 # SupportedStyles: have_received, receive

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -40,12 +40,6 @@ RSpec/BeforeAfterAll:
     - 'spec/support/**/*.rb'
     - 'spec/rubocop/ast/node_spec.rb'
 
-# Offense count: 2
-RSpec/DescribeClass:
-  Exclude:
-    - 'spec/isolated_environment_spec.rb'
-    - 'spec/project_spec.rb'
-
 # Offense count: 2538
 # Configuration parameters: Max.
 RSpec/ExampleLength:

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -107,11 +107,6 @@ RSpec/MultipleExpectations:
 RSpec/NestedGroups:
   Enabled: false
 
-# Offense count: 2
-RSpec/RepeatedExample:
-  Exclude:
-    - 'spec/rubocop/cop/style/trailing_underscore_variable_spec.rb'
-
 # Offense count: 21
 RSpec/SubjectStub:
   Exclude:

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -37,11 +37,6 @@ RSpec/AnyInstance:
 RSpec/ExampleLength:
   Enabled: false
 
-# Offense count: 4
-RSpec/ExpectInHook:
-  Exclude:
-    - 'spec/rubocop/cli/cli_options_spec.rb'
-
 # Offense count: 39
 RSpec/ExpectOutput:
   Exclude:

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -112,13 +112,6 @@ RSpec/RepeatedExample:
   Exclude:
     - 'spec/rubocop/cop/style/trailing_underscore_variable_spec.rb'
 
-# Offense count: 1
-# Configuration parameters: EnforcedStyle, SupportedStyles.
-# SupportedStyles: and_return, block
-RSpec/ReturnFromStub:
-  Exclude:
-    - 'spec/rubocop/config_store_spec.rb'
-
 # Offense count: 21
 RSpec/SubjectStub:
   Exclude:

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -119,12 +119,6 @@ RSpec/ReturnFromStub:
   Exclude:
     - 'spec/rubocop/config_store_spec.rb'
 
-# Offense count: 4
-RSpec/ScatteredSetup:
-  Exclude:
-    - 'spec/rubocop/cli/cli_autocorrect_spec.rb'
-    - 'spec/rubocop/formatter/disabled_config_formatter_spec.rb'
-
 # Offense count: 21
 RSpec/SubjectStub:
   Exclude:

--- a/spec/isolated_environment_spec.rb
+++ b/spec/isolated_environment_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-describe 'isolated environment', :isolated_environment do
+describe 'isolated environment', :isolated_environment, type: :feature do
   include_context 'cli spec behavior'
 
   let(:cli) { RuboCop::CLI.new }

--- a/spec/project_spec.rb
+++ b/spec/project_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-describe 'RuboCop Project' do
+describe 'RuboCop Project', type: :feature do
   let(:cop_names) do
     RuboCop::Cop::Cop
       .registry

--- a/spec/project_spec.rb
+++ b/spec/project_spec.rb
@@ -101,9 +101,7 @@ describe 'RuboCop Project', type: :feature do
       let(:lines) { changelog.each_line }
 
       it 'has a whitespace between the * and the body' do
-        entries.each do |entry|
-          expect(entry).to match(/^\* \S/)
-        end
+        expect(entries).to all(match(/^\* \S/))
       end
 
       context 'after version 0.14.0' do
@@ -114,9 +112,7 @@ describe 'RuboCop Project', type: :feature do
         end
 
         it 'has a link to the contributors at the end' do
-          entries.each do |entry|
-            expect(entry).to match(/\(\[@\S+\]\[\](?:, \[@\S+\]\[\])*\)$/)
-          end
+          expect(entries).to all(match(/\(\[@\S+\]\[\](?:, \[@\S+\]\[\])*\)$/))
         end
       end
 
@@ -146,9 +142,7 @@ describe 'RuboCop Project', type: :feature do
             entry.match(/^\*\s*\[/)
           end
 
-          entries_including_issue_link.each do |entry|
-            expect(entry).to include('): ')
-          end
+          expect(entries_including_issue_link).to all(be_include('): '))
         end
       end
 
@@ -169,9 +163,7 @@ describe 'RuboCop Project', type: :feature do
         end
 
         it 'ends with a punctuation' do
-          bodies.each do |body|
-            expect(body).to match(/[\.\!]$/)
-          end
+          expect(bodies).to all(match(/[\.\!]$/))
         end
       end
     end

--- a/spec/project_spec.rb
+++ b/spec/project_spec.rb
@@ -142,7 +142,7 @@ describe 'RuboCop Project', type: :feature do
             entry.match(/^\*\s*\[/)
           end
 
-          expect(entries_including_issue_link).to all(be_include('): '))
+          expect(entries_including_issue_link).to all(include('): '))
         end
       end
 

--- a/spec/rubocop/ast/node_spec.rb
+++ b/spec/rubocop/ast/node_spec.rb
@@ -36,7 +36,7 @@ describe RuboCop::AST::Node do
   describe '#value_used?' do
     let(:node) { RuboCop::ProcessedSource.new(src, ruby_version).ast }
 
-    before(:all) do
+    before do
       module RuboCop
         module AST
           class Node

--- a/spec/rubocop/cli/cli_autocorrect_spec.rb
+++ b/spec/rubocop/cli/cli_autocorrect_spec.rb
@@ -109,9 +109,6 @@ describe RuboCop::CLI, :isolated_environment do
 
     before do
       create_file('example.rb', source)
-    end
-
-    before do
       create_file('.rubocop.yml', YAML.dump(config))
     end
 

--- a/spec/rubocop/cli/cli_options_spec.rb
+++ b/spec/rubocop/cli/cli_options_spec.rb
@@ -1005,8 +1005,6 @@ describe RuboCop::CLI, :isolated_environment do
       RUBY
     end
 
-    after do
-    end
     def expect_offense_detected(num)
       expect($stderr.string).to eq('')
       expect($stdout.string)

--- a/spec/rubocop/cli/cli_options_spec.rb
+++ b/spec/rubocop/cli/cli_options_spec.rb
@@ -1006,29 +1006,35 @@ describe RuboCop::CLI, :isolated_environment do
     end
 
     after do
+    end
+    def expect_offense_detected(num)
       expect($stderr.string).to eq('')
       expect($stdout.string)
-        .to include('1 file inspected, 1 offense detected')
+        .to include("1 file inspected, #{num} offense detected")
     end
 
     it 'fails when option is less than the severity level' do
       expect(cli.run(['--fail-level', 'refactor', target_file])).to eq(1)
       expect(cli.run(['--fail-level', 'autocorrect', target_file])).to eq(1)
+      expect_offense_detected(1)
     end
 
     it 'fails when option is equal to the severity level' do
       expect(cli.run(['--fail-level', 'convention', target_file])).to eq(1)
+      expect_offense_detected(1)
     end
 
     it 'succeeds when option is greater than the severity level' do
       expect(cli.run(['--fail-level', 'warning', target_file])).to eq(0)
+      expect_offense_detected(1)
     end
 
     context 'with --auto-correct' do
-      after do
+      def expect_auto_corrected(num)
+        expect_offense_detected(num)
         expect($stdout.string.lines.to_a.last)
-          .to eq('1 file inspected, 1 offense detected, 1 offense corrected' \
-                 "\n")
+          .to eq("1 file inspected, #{num} offense detected, " \
+                 "#{num} offense corrected\n")
       end
 
       it 'fails when option is autocorrect and all offenses are ' \
@@ -1036,18 +1042,21 @@ describe RuboCop::CLI, :isolated_environment do
         expect(cli.run(['--auto-correct', '--format', 'simple',
                         '--fail-level', 'autocorrect',
                         target_file])).to eq(1)
+        expect_auto_corrected(1)
       end
 
       it 'fails when option is A and all offenses are autocorrected' do
         expect(cli.run(['--auto-correct', '--format', 'simple',
                         '--fail-level', 'A',
                         target_file])).to eq(1)
+        expect_auto_corrected(1)
       end
 
       it 'succeeds when option is not given and all offenses are ' \
          'autocorrected' do
         expect(cli.run(['--auto-correct', '--format', 'simple',
                         target_file])).to eq(0)
+        expect_auto_corrected(1)
       end
 
       it 'succeeds when option is refactor and all offenses are ' \
@@ -1055,6 +1064,7 @@ describe RuboCop::CLI, :isolated_environment do
         expect(cli.run(['--auto-correct', '--format', 'simple',
                         '--fail-level', 'refactor',
                         target_file])).to eq(0)
+        expect_auto_corrected(1)
       end
     end
   end
@@ -1062,11 +1072,6 @@ describe RuboCop::CLI, :isolated_environment do
   describe 'with --auto-correct and disabled offense' do
     let(:target_file) { 'example.rb' }
 
-    after do
-      expect($stdout.string.lines.to_a.last)
-        .to eq('1 file inspected, no offenses detected' \
-               "\n")
-    end
     it 'succeeds when there is only a disabled offense' do
       create_file(target_file, <<-RUBY.strip_indent)
         def f
@@ -1077,6 +1082,10 @@ describe RuboCop::CLI, :isolated_environment do
       expect(cli.run(['--auto-correct', '--format', 'simple',
                       '--fail-level', 'autocorrect',
                       target_file])).to eq(0)
+
+      expect($stdout.string.lines.to_a.last)
+        .to eq('1 file inspected, no offenses detected' \
+               "\n")
     end
   end
 

--- a/spec/rubocop/config_store_spec.rb
+++ b/spec/rubocop/config_store_spec.rb
@@ -19,7 +19,7 @@ describe RuboCop::ConfigStore do
     allow(RuboCop::ConfigLoader)
       .to receive(:merge_with_default) { |config| "merged #{config.to_h}" }
     allow(RuboCop::ConfigLoader)
-      .to receive(:default_configuration) { 'default config' }
+      .to receive(:default_configuration).and_return('default config')
   end
 
   describe '.for' do

--- a/spec/rubocop/cop/force_spec.rb
+++ b/spec/rubocop/cop/force_spec.rb
@@ -13,9 +13,7 @@ describe RuboCop::Cop::Force do
 
   describe '#run_hook' do
     it 'invokes a hook in all cops' do
-      cops.each do |cop|
-        expect(cop).to receive(:some_hook).with(:foo, :bar)
-      end
+      expect(cops).to all(receive(:some_hook).with(:foo, :bar))
 
       force.run_hook(:some_hook, :foo, :bar)
     end

--- a/spec/rubocop/cop/style/trailing_underscore_variable_spec.rb
+++ b/spec/rubocop/cop/style/trailing_underscore_variable_spec.rb
@@ -224,11 +224,6 @@ describe RuboCop::Cop::Style::TrailingUnderscoreVariable do
 
     include_examples 'common functionality'
 
-    it 'does not register an offense for an underscore variable preceded ' \
-       'by a named splat underscore variable' do
-      expect_no_offenses('a, *_b, _ = foo()')
-    end
-
     it 'does not register an offense for named variables ' \
        'that start with an underscore' do
       expect_no_offenses('a, b, _c = foo()')
@@ -239,8 +234,8 @@ describe RuboCop::Cop::Style::TrailingUnderscoreVariable do
       expect_no_offenses('a, *_b = foo()')
     end
 
-    it 'does not register an offense for an underscore preceded by ' \
-       'a named splat underscore' do
+    it 'does not register an offense for an underscore variable preceded ' \
+       'by a named splat underscore variable' do
       expect_no_offenses('a, *_b, _ = foo()')
     end
 

--- a/spec/rubocop/formatter/disabled_config_formatter_spec.rb
+++ b/spec/rubocop/formatter/disabled_config_formatter_spec.rb
@@ -91,9 +91,7 @@ module RuboCop
               Exclude:
                 - "**/*.blah"
           YAML
-        end
 
-        before do
           formatter.started(['test_a.rb', 'test_b.rb'])
           formatter.file_started('test_a.rb', {})
           formatter.file_finished('test_a.rb', offenses)

--- a/spec/rubocop/formatter/formatter_set_spec.rb
+++ b/spec/rubocop/formatter/formatter_set_spec.rb
@@ -20,9 +20,9 @@ module RuboCop
         let(:files) { ['/path/to/file1', '/path/to/file2'] }
 
         it 'invokes same method of all containing formatters' do
-          formatter_set.each do |formatter|
-            expect(formatter).to receive(:started).with(files)
-          end
+          # rubocop:disable RSpec/SubjectStub SEE ALSO: https://github.com/backus/rubocop-rspec/issues/488
+          expect(formatter_set).to all(receive(:started).with(files))
+          # rubocop:enable RSpec/SubjectStub
           formatter_set.started(files)
         end
       end


### PR DESCRIPTION
This PR reduce .rubocop_todo.yml

 * RSpec/ScatteredSetup
 * RSpec/ReturnFromStub
 * RSpec/RepeatedExample
 * Rspec/DescribeClass
 * RSpec/BeforeAfterAll
 * RSpec/ExpectInHook
 * RSpec/IteratedExpectation

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Used the same coding conventions as the rest of the project.
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [ ] Squashed related commits together.
* [x] Added tests.
* [ ] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] All tests(`rake spec`) are passing.
* [x] The new code doesn't generate RuboCop offenses that are checked by `rake internal_investigation`.
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Updated cop documentation with `rake generate_cops_documentation` (required only when you've added a new cop or changed the configuration/documentation of an existing cop).

[1]: http://chris.beams.io/posts/git-commit/
