### PR TITLE
relax RSpec/NestedGroups Max to 7 (current maximum level)

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -61,3 +61,6 @@ Performance/Caller:
 
 RSpec/PredicateMatcher:
   EnforcedStyle: explicit
+
+RSpec/NestedGroups:
+  Max: 7

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -76,11 +76,6 @@ RSpec/MessageSpies:
 RSpec/MultipleExpectations:
   Max: 25
 
-# Offense count: 786
-# Configuration parameters: Max.
-RSpec/NestedGroups:
-  Enabled: false
-
 # Offense count: 21
 RSpec/SubjectStub:
   Exclude:


### PR DESCRIPTION
rubycop-rspec's Rspec/NestedGroups does not support --auto-gen config ( SEE https://github.com/backus/rubocop-rspec/pull/489 )

It's better to set Max explicitly for future.

