### PR TITLE
[Fix #4967] Fix `Rails/DynamicFindBy` false-positives on non ActiveReord

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@
 * [#4987](https://github.com/bbatsov/rubocop/pull/4987): Skip permission check when using stdin option. ([@mtsmfm][])
 * [#4909](https://github.com/bbatsov/rubocop/issues/4909): Make `Rails/HasManyOrHasOneDependent` aware of multiple associations in `with_options`. ([@koic][])
 * [#4794](https://github.com/bbatsov/rubocop/issues/4794): Fix an error in `Layout/MultilineOperationIndentation` when an operation spans multiple lines and contains a ternary expression. ([@rrosenblum][])
+* [#4967](https://github.com/bbatsov/rubocop/issues/4967): Fix `Rails/DynamicFindBy` false-positives on non ActiveRecord model. ([@koic][])
 
 ### Changes
 

--- a/lib/rubocop/cop/rails/dynamic_find_by.rb
+++ b/lib/rubocop/cop/rails/dynamic_find_by.rb
@@ -30,6 +30,9 @@ module RuboCop
         METHOD_PATTERN = /^find_by_(.+?)(!)?$/
 
         def on_send(node)
+          return if node.receiver.nil? ||
+                    !inherited_active_record?(node.receiver.const_name)
+
           method_name = node.method_name.to_s
 
           return if whitelist.include?(method_name)
@@ -74,6 +77,13 @@ module RuboCop
           match = METHOD_PATTERN.match(method_name)
           return nil unless match
           match[2] ? 'find_by!' : 'find_by'
+        end
+
+        def inherited_active_record?(class_name)
+          klass = Object.const_get(class_name)
+
+          klass.respond_to?(:ancestors) &&
+            klass.ancestors.include?(ActiveRecord::Base)
         end
       end
     end

--- a/spec/rubocop/cop/rails/dynamic_find_by_spec.rb
+++ b/spec/rubocop/cop/rails/dynamic_find_by_spec.rb
@@ -7,6 +7,21 @@ describe RuboCop::Cop::Rails::DynamicFindBy, :config do
     { 'Whitelist' => %w[find_by_sql] }
   end
 
+  before do
+    module ActiveRecord
+      class Base
+      end
+    end
+
+    class User < ActiveRecord::Base; end
+  end
+
+  after do
+    Object.send(:remove_const, 'User')
+    ActiveRecord.send(:remove_const, 'Base')
+    Object.send(:remove_const, 'ActiveRecord')
+  end
+
   shared_examples 'register an offense and auto correct' do |message, corrected|
     it 'registers an offense' do
       inspect_source(source)
@@ -137,5 +152,13 @@ describe RuboCop::Cop::Rails::DynamicFindBy, :config do
     expect_no_offenses(<<-RUBY.strip_indent)
       User.find_by_sql(["select * from users where name = ?", name])
     RUBY
+  end
+
+  context 'When receiver class does not inherit `ActiveRecord::Base`' do
+    it 'accepts find_by_* method' do
+      expect_no_offenses(<<-RUBY.strip_indent)
+        Gem::Specification.find_by_name('loremipsum')
+      RUBY
+    end
   end
 end


### PR DESCRIPTION
Fixes #4967.
This PR applies `Rails/DynamicFindBy` cop only to receiver classes that inherit `ActiveRecord::Base` class.

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Used the same coding conventions as the rest of the project.
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] All tests(`rake spec`) are passing.
* [x] The new code doesn't generate RuboCop offenses that are checked by `rake internal_investigation`.
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [ ] Updated cop documentation with `rake generate_cops_documentation` (required only when you've added a new cop or changed the configuration/documentation of an existing cop).

[1]: http://chris.beams.io/posts/git-commit/
