### PR TITLE
Fix a document missing the `:` in title line

### DIFF
--- a/lib/rubocop/cop/layout/space_inside_string_interpolation.rb
+++ b/lib/rubocop/cop/layout/space_inside_string_interpolation.rb
@@ -5,14 +5,14 @@ module RuboCop
     module Layout
       # This cop checks for whitespace within string interpolations.
       #
-      # @example EnforcedStyle no_space (default)
+      # @example EnforcedStyle: no_space (default)
       #   # bad
       #      var = "This is the #{ space } example"
       #
       #   # good
       #      var = "This is the #{no_space} example"
       #
-      # @example EnforcedStyle space
+      # @example EnforcedStyle: space
       #   # bad
       #      var = "This is the #{no_space} example"
       #


### PR DESCRIPTION
Follow up of https://github.com/bbatsov/rubocop/pull/4978#discussion_r148457989.
This is a small fix to the document of `Layout/SpaceInsideStringInterpolation` cop.

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Used the same coding conventions as the rest of the project.
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [ ] Added tests.
* [ ] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] All tests(`rake spec`) are passing.
* [x] The new code doesn't generate RuboCop offenses that are checked by `rake internal_investigation`.
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [ ] Updated cop documentation with `rake generate_cops_documentation` (required only when you've added a new cop or changed the configuration/documentation of an existing cop).

[1]: http://chris.beams.io/posts/git-commit/
