### PR TITLE
Fix broken enabled.yml reference URI fragments

### DIFF
--- a/config/enabled.yml
+++ b/config/enabled.yml
@@ -300,7 +300,7 @@ Layout/SpaceInsidePercentLiteralDelimiters:
 
 Layout/SpaceInsideBrackets:
   Description: 'No spaces after [ or before ].'
-  StyleGuide: '#no-spaces-braces'
+  StyleGuide: '#spaces-braces'
   Enabled: true
 
 Layout/SpaceInsideHashLiteralBraces:
@@ -310,7 +310,7 @@ Layout/SpaceInsideHashLiteralBraces:
 
 Layout/SpaceInsideParens:
   Description: 'No spaces after ( or before ).'
-  StyleGuide: '#no-spaces-braces'
+  StyleGuide: '#spaces-braces'
   Enabled: true
 
 Layout/SpaceInsideRangeLiteral:
@@ -1578,7 +1578,7 @@ Performance/RangeInclude:
 
 Performance/RedundantBlockCall:
   Description: 'Use `yield` instead of `block.call`.'
-  Reference: 'https://github.com/JuanitoFatas/fast-ruby#proccall-vs-yield-code'
+  Reference: 'https://github.com/JuanitoFatas/fast-ruby#proccall-and-block-arguments-vs-yieldcode'
   Enabled: true
 
 Performance/RedundantMatch:
@@ -1618,7 +1618,7 @@ Performance/Size:
   Description: >-
                   Use `size` instead of `count` for counting
                   the number of elements in `Array` and `Hash`.
-  Reference: 'https://github.com/JuanitoFatas/fast-ruby#arraycount-vs-arraysize-code'
+  Reference: 'https://github.com/JuanitoFatas/fast-ruby#arraylength-vs-arraysize-vs-arraycount-code'
   Enabled: true
 
 Performance/CompareWithBlock:

--- a/manual/cops_layout.md
+++ b/manual/cops_layout.md
@@ -2301,7 +2301,7 @@ array = [1, 2, 3]
 
 ### References
 
-* [https://github.com/bbatsov/ruby-style-guide#no-spaces-braces](https://github.com/bbatsov/ruby-style-guide#no-spaces-braces)
+* [https://github.com/bbatsov/ruby-style-guide#spaces-braces](https://github.com/bbatsov/ruby-style-guide#spaces-braces)
 
 ## Layout/SpaceInsideHashLiteralBraces
 
@@ -2383,7 +2383,7 @@ g = (a + 3)
 
 ### References
 
-* [https://github.com/bbatsov/ruby-style-guide#no-spaces-braces](https://github.com/bbatsov/ruby-style-guide#no-spaces-braces)
+* [https://github.com/bbatsov/ruby-style-guide#spaces-braces](https://github.com/bbatsov/ruby-style-guide#spaces-braces)
 
 ## Layout/SpaceInsidePercentLiteralDelimiters
 

--- a/manual/cops_performance.md
+++ b/manual/cops_performance.md
@@ -440,7 +440,7 @@ end
 
 ### References
 
-* [https://github.com/JuanitoFatas/fast-ruby#proccall-vs-yield-code](https://github.com/JuanitoFatas/fast-ruby#proccall-vs-yield-code)
+* [https://github.com/JuanitoFatas/fast-ruby#proccall-and-block-arguments-vs-yieldcode](https://github.com/JuanitoFatas/fast-ruby#proccall-and-block-arguments-vs-yieldcode)
 
 ## Performance/RedundantMatch
 
@@ -671,7 +671,7 @@ have been assigned to an array or a hash.
 
 ### References
 
-* [https://github.com/JuanitoFatas/fast-ruby#arraycount-vs-arraysize-code](https://github.com/JuanitoFatas/fast-ruby#arraycount-vs-arraysize-code)
+* [https://github.com/JuanitoFatas/fast-ruby#arraylength-vs-arraysize-vs-arraycount-code](https://github.com/JuanitoFatas/fast-ruby#arraylength-vs-arraysize-vs-arraycount-code)
 
 ## Performance/StartWith
 


### PR DESCRIPTION
There are a few broken URI fragments in the `config/enabled.yml` file.

I ran into one of the broken fragments. when investigating Rubocop failure. I found the others by writing a simple Nokogiri script ([Gist](https://gist.github.com/dcecile/e63de623ff697fa053ef68f5e8dc988d)) that parses the YAML in this file and compares fragment identifiers to referenced HTML pages.

-----------------

Before submitting the PR make sure the following are checked:

* [ ] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [ ] Used the same coding conventions as the rest of the project.
* [ ] Feature branch is up-to-date with `master` (if not - rebase it).
* [ ] Squashed related commits together.
* [ ] Added tests.
* [ ] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [ ] All tests(`rake spec`) are passing.
* [ ] The new code doesn't generate RuboCop offenses that are checked by `rake internal_investigation`.
* [ ] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [ ] Updated cop documentation with `rake generate_cops_documentation` (required only when you've added a new cop or changed the configuration/documentation of an existing cop).

[1]: http://chris.beams.io/posts/git-commit/
