### PR TITLE
Restyle the example formatting for Naming cops

### DIFF
--- a/lib/rubocop/cop/naming/heredoc_delimiter_case.rb
+++ b/lib/rubocop/cop/naming/heredoc_delimiter_case.rb
@@ -6,33 +6,27 @@ module RuboCop
       # This cop checks that your heredocs are using the configured case.
       # By default it is configured to enforce uppercase heredocs.
       #
-      # @example
-      #
-      #   # EnforcedStyle: uppercase (default)
+      # @example EnforcedStyle: uppercase (default)
+      #   # bad
+      #   <<-sql
+      #     SELECT * FROM foo
+      #   sql
       #
       #   # good
       #   <<-SQL
       #     SELECT * FROM foo
       #   SQL
       #
+      # @example EnforcedStyle: lowercase
       #   # bad
-      #   <<-sql
+      #   <<-SQL
       #     SELECT * FROM foo
-      #   sql
-      #
-      # @example
-      #
-      #   # EnforcedStyle: lowercase
+      #   SQL
       #
       #   # good
       #   <<-sql
       #     SELECT * FROM foo
       #   sql
-      #
-      #   # bad
-      #   <<-SQL
-      #     SELECT * FROM foo
-      #   SQL
       class HeredocDelimiterCase < Cop
         include Heredoc
         include ConfigurableEnforcedStyle

--- a/lib/rubocop/cop/naming/method_name.rb
+++ b/lib/rubocop/cop/naming/method_name.rb
@@ -6,20 +6,14 @@ module RuboCop
       # This cop makes sure that all methods use the configured style,
       # snake_case or camelCase, for their names.
       #
-      # @example
-      #
-      #   # EnforcedStyle: snake_case
-      #
+      # @example EnforcedStyle: snake_case (default)
       #   # bad
       #   def fooBar; end
       #
       #   # good
       #   def foo_bar; end
       #
-      # @example
-      #
-      #   # EnforcedStyle: camelCase
-      #
+      # @example EnforcedStyle: camelCase
       #   # bad
       #   def foo_bar; end
       #

--- a/lib/rubocop/cop/naming/variable_name.rb
+++ b/lib/rubocop/cop/naming/variable_name.rb
@@ -6,20 +6,14 @@ module RuboCop
       # This cop makes sure that all variables use the configured style,
       # snake_case or camelCase, for their names.
       #
-      # @example
-      #
-      #   # EnforcedStyle: snake_case
-      #
+      # @example EnforcedStyle: snake_case (default)
       #   # bad
       #   fooBar = 1
       #
       #   # good
       #   foo_bar = 1
       #
-      # @example
-      #
-      #   # EnforcedStyle: camelCase
-      #
+      # @example EnforcedStyle: camelCase
       #   # bad
       #   foo_bar = 1
       #

--- a/lib/rubocop/cop/naming/variable_number.rb
+++ b/lib/rubocop/cop/naming/variable_number.rb
@@ -7,10 +7,7 @@ module RuboCop
       # configured style, snake_case, normalcase or non_integer,
       # for their numbering.
       #
-      # @example
-      #
-      #   # EnforcedStyle: snake_case
-      #
+      # @example EnforcedStyle: snake_case
       #   # bad
       #
       #   variable1 = 1
@@ -19,10 +16,7 @@ module RuboCop
       #
       #   variable_1 = 1
       #
-      # @example
-      #
-      #   # EnforcedStyle: normalcase
-      #
+      # @example EnforcedStyle: normalcase (default)
       #   # bad
       #
       #   variable_1 = 1
@@ -31,10 +25,7 @@ module RuboCop
       #
       #   variable1 = 1
       #
-      # @example
-      #
-      #   # EnforcedStyle: non_integer
-      #
+      # @example EnforcedStyle: non_integer
       #   # bad
       #
       #   variable1 = 1

--- a/manual/cops_naming.md
+++ b/manual/cops_naming.md
@@ -170,30 +170,26 @@ By default it is configured to enforce uppercase heredocs.
 ### Example
 
 ```ruby
-# EnforcedStyle: uppercase (default)
+# bad
+<<-sql
+  SELECT * FROM foo
+sql
 
 # good
 <<-SQL
   SELECT * FROM foo
 SQL
-
-# bad
-<<-sql
-  SELECT * FROM foo
-sql
 ```
 ```ruby
-# EnforcedStyle: lowercase
+# bad
+<<-SQL
+  SELECT * FROM foo
+SQL
 
 # good
 <<-sql
   SELECT * FROM foo
 sql
-
-# bad
-<<-SQL
-  SELECT * FROM foo
-SQL
 ```
 
 ### Important attributes
@@ -258,8 +254,6 @@ snake_case or camelCase, for their names.
 ### Example
 
 ```ruby
-# EnforcedStyle: snake_case
-
 # bad
 def fooBar; end
 
@@ -267,8 +261,6 @@ def fooBar; end
 def foo_bar; end
 ```
 ```ruby
-# EnforcedStyle: camelCase
-
 # bad
 def foo_bar; end
 
@@ -337,8 +329,6 @@ snake_case or camelCase, for their names.
 ### Example
 
 ```ruby
-# EnforcedStyle: snake_case
-
 # bad
 fooBar = 1
 
@@ -346,8 +336,6 @@ fooBar = 1
 foo_bar = 1
 ```
 ```ruby
-# EnforcedStyle: camelCase
-
 # bad
 foo_bar = 1
 
@@ -379,8 +367,6 @@ for their numbering.
 ### Example
 
 ```ruby
-# EnforcedStyle: snake_case
-
 # bad
 
 variable1 = 1
@@ -390,8 +376,6 @@ variable1 = 1
 variable_1 = 1
 ```
 ```ruby
-# EnforcedStyle: normalcase
-
 # bad
 
 variable_1 = 1
@@ -401,8 +385,6 @@ variable_1 = 1
 variable1 = 1
 ```
 ```ruby
-# EnforcedStyle: non_integer
-
 # bad
 
 variable1 = 1


### PR DESCRIPTION
Follow up of https://github.com/bbatsov/rubocop/pull/4880#issuecomment-338499947.

This commit is a change of document format. Cops of `naming` department are the target.

Since example of `Naming/HeredocDelimiterCase` cop was the opposite of `bad` and `good`, it was rearranged for unification.
Also added `default` information based on `config/default.yml`.

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Used the same coding conventions as the rest of the project.
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [ ] Added tests.
* [ ] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] All tests(`rake spec`) are passing.
* [x] The new code doesn't generate RuboCop offenses that are checked by `rake internal_investigation`.
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Updated cop documentation with `rake generate_cops_documentation` (required only when you've added a new cop or changed the configuration/documentation of an existing cop).

[1]: http://chris.beams.io/posts/git-commit/
