### PR TITLE
Add Examples to six Style/* Cops

### DIFF
--- a/lib/rubocop/cop/style/bare_percent_literals.rb
+++ b/lib/rubocop/cop/style/bare_percent_literals.rb
@@ -4,6 +4,14 @@ module RuboCop
   module Cop
     module Style
       # This cop checks if usage of %() or %Q() matches configuration.
+      #
+      # @example
+      #   # bad -
+      #   %Q(My name is #{name})
+      #
+      #   # good
+      #   %(My name is #{name})
+      #
       class BarePercentLiterals < Cop
         include ConfigurableEnforcedStyle
 

--- a/lib/rubocop/cop/style/bare_percent_literals.rb
+++ b/lib/rubocop/cop/style/bare_percent_literals.rb
@@ -5,12 +5,23 @@ module RuboCop
     module Style
       # This cop checks if usage of %() or %Q() matches configuration.
       #
-      # @example
-      #   # bad -
-      #   %Q(My name is #{name})
+      # @example EnforcedStyle: bare_percent (default)
+      #   # bad
+      #   %Q(He said: "#{greeting}")
+      #   %q{She said: 'Hi'}
       #
       #   # good
-      #   %(My name is #{name})
+      #   %(He said: "#{greeting}")
+      #   %{She said: 'Hi'}
+      #
+      # @example EnforcedStyle: percent_q
+      #   # bad
+      #   %|He said: "#{greeting}"|
+      #   %/She said: 'Hi'/
+      #
+      #   # good
+      #   %Q|He said: "#{greeting}"|
+      #   %q/She said: 'Hi'/
       #
       class BarePercentLiterals < Cop
         include ConfigurableEnforcedStyle

--- a/lib/rubocop/cop/style/block_comments.rb
+++ b/lib/rubocop/cop/style/block_comments.rb
@@ -6,7 +6,7 @@ module RuboCop
       # This cop looks for uses of block comments (=begin...=end).
       #
       # @example
-      #   # bad -
+      #   # bad
       #   =begin
       #   Multiple lines
       #   of comments...

--- a/lib/rubocop/cop/style/block_comments.rb
+++ b/lib/rubocop/cop/style/block_comments.rb
@@ -4,6 +4,18 @@ module RuboCop
   module Cop
     module Style
       # This cop looks for uses of block comments (=begin...=end).
+      #
+      # @example
+      #   # bad -
+      #   =begin
+      #   Multiple lines
+      #   of comments...
+      #   =end
+      #
+      #   # good
+      #   # Multiple lines
+      #   # of comments...
+      #
       class BlockComments < Cop
         MSG = 'Do not use block comments.'.freeze
         BEGIN_LENGTH = "=begin\n".length

--- a/lib/rubocop/cop/style/block_delimiters.rb
+++ b/lib/rubocop/cop/style/block_delimiters.rb
@@ -6,24 +6,70 @@ module RuboCop
       # Check for uses of braces or do/end around single line or
       # multi-line blocks.
       #
-      # @example
+      # @example EnforcedStyle: line_count_based (default)
       #   # bad - single line block
-      #   collection.each do |item| item.method(x) end
+      #   items.each do |item| item / 5 end
       #
       #   # good - single line block
-      #   collection.each { |item| item.method(x) }
+      #   items.each { |item| item / 5 }
       #
       #   # bad - multi-line block
       #   things.map { |thing|
       #     something = thing.some_method
-      #     proces(something, something_else)
+      #     proces(something)
       #   }
       #
       #   # good - multi-line block
       #   things.map do |thing|
       #     something = thing.some_method
-      #     proces(something, something_else)
+      #     proces(something)
       #   end
+      #
+      # @example EnforcedStyle: semantic
+      #   # Prefer `do...end` over `{...}` for procedural blocks.
+      #
+      #   # return value is used/assigned
+      #   # bad
+      #   foo = map do |x|
+      #     x
+      #   end
+      #   puts (map do |x|
+      #     x
+      #   end)
+      #
+      #   # return value is not used out of scope
+      #   # good
+      #   map do |x|
+      #     x
+      #   end
+      #
+      #   # Prefer `{...}` over `do...end` for functional blocks.
+      #
+      #   # return value is not used out of scope
+      #   # bad
+      #   each { |x|
+      #     x
+      #   }
+      #
+      #   # return value is used/assigned
+      #   # good
+      #   foo = map { |x|
+      #     x
+      #   }
+      #   map { |x|
+      #     x
+      #   }.inspect
+      #
+      # @example EnforcedStyle: braces_for_chaining
+      #   # bad
+      #   words.each do |word|
+      #     word.flip.flop
+      #   end.join("-")
+      #
+      #   # good
+      #   words.each { |word|
+      #     word.flip.flop
+      #   }.join("-")
       #
       class BlockDelimiters < Cop
         include ConfigurableEnforcedStyle

--- a/lib/rubocop/cop/style/block_delimiters.rb
+++ b/lib/rubocop/cop/style/block_delimiters.rb
@@ -5,6 +5,26 @@ module RuboCop
     module Style
       # Check for uses of braces or do/end around single line or
       # multi-line blocks.
+      #
+      # @example
+      #   # bad - single line block
+      #   collection.each do |item| item.method(x) end
+      #
+      #   # good - single line block
+      #   collection.each { |item| item.method(x) }
+      #
+      #   # bad - multi-line block
+      #   things.map { |thing|
+      #     something = thing.some_method
+      #     proces(something, something_else)
+      #   }
+      #
+      #   # good - multi-line block
+      #   things.map do |thing|
+      #     something = thing.some_method
+      #     proces(something, something_else)
+      #   end
+      #
       class BlockDelimiters < Cop
         include ConfigurableEnforcedStyle
 

--- a/lib/rubocop/cop/style/class_check.rb
+++ b/lib/rubocop/cop/style/class_check.rb
@@ -4,6 +4,16 @@ module RuboCop
   module Cop
     module Style
       # This cop enforces consistent use of `Object#is_a?` or `Object#kind_of?`.
+      #
+      # @example
+      #   # bad
+      #   var.kind_of?(Date)
+      #   var.kind_of?(Integer)
+      #
+      #   # good
+      #   var.is_a?(Date)
+      #   var.is_a?(Integer)
+      #
       class ClassCheck < Cop
         include ConfigurableEnforcedStyle
 

--- a/lib/rubocop/cop/style/class_check.rb
+++ b/lib/rubocop/cop/style/class_check.rb
@@ -5,7 +5,7 @@ module RuboCop
     module Style
       # This cop enforces consistent use of `Object#is_a?` or `Object#kind_of?`.
       #
-      # @example
+      # @example EnforcedStyle: is_a? (default)
       #   # bad
       #   var.kind_of?(Date)
       #   var.kind_of?(Integer)
@@ -13,6 +13,15 @@ module RuboCop
       #   # good
       #   var.is_a?(Date)
       #   var.is_a?(Integer)
+      #
+      # @example EnforcedStyle: kind_of?
+      #   # bad
+      #   var.is_a?(Time)
+      #   var.is_a?(String)
+      #
+      #   # good
+      #   var.kind_of?(Time)
+      #   var.kind_of?(String)
       #
       class ClassCheck < Cop
         include ConfigurableEnforcedStyle

--- a/lib/rubocop/cop/style/colon_method_call.rb
+++ b/lib/rubocop/cop/style/colon_method_call.rb
@@ -5,6 +5,18 @@ module RuboCop
     module Style
       # This cop checks for methods invoked via the :: operator instead
       # of the . operator (like FileUtils::rmdir instead of FileUtils.rmdir).
+      #
+      # @example
+      #   # bad
+      #   Timeout::timeout(500) { ... }
+      #   FileUtils::rmdir(dir)
+      #   Marshal::dump(obj)
+      #
+      #   # good
+      #   Timeout.timeout(500) { ... }
+      #   FileUtils.rmdir(dir)
+      #   Marshal.dump(obj)
+      #
       class ColonMethodCall < Cop
         MSG = 'Do not use `::` for method calls.'.freeze
 

--- a/lib/rubocop/cop/style/documentation.rb
+++ b/lib/rubocop/cop/style/documentation.rb
@@ -11,6 +11,19 @@ module RuboCop
       # The documentation requirement is annulled if the class or module has
       # a "#:nodoc:" comment next to it. Likewise, "#:nodoc: all" does the
       # same for all its children.
+      #
+      # @example
+      #   # bad
+      #   class Person
+      #     ...
+      #   end
+      #
+      #   # good
+      #   # Description/Explanation of Person class
+      #   class Person
+      #     ...
+      #   end
+      #
       class Documentation < Cop
         include DocumentationComment
 

--- a/manual/cops_style.md
+++ b/manual/cops_style.md
@@ -195,11 +195,22 @@ This cop checks if usage of %() or %Q() matches configuration.
 ### Example
 
 ```ruby
-# bad -
-%Q(My name is #{name})
+# bad
+%Q(He said: "#{greeting}")
+%q{She said: 'Hi'}
 
 # good
-%(My name is #{name})
+%(He said: "#{greeting}")
+%{She said: 'Hi'}
+```
+```ruby
+# bad
+%|He said: "#{greeting}"|
+%/She said: 'Hi'/
+
+# good
+%Q|He said: "#{greeting}"|
+%q/She said: 'Hi'/
 ```
 
 ### Important attributes
@@ -236,7 +247,7 @@ This cop looks for uses of block comments (=begin...=end).
 ### Example
 
 ```ruby
-# bad -
+# bad
 =begin
 Multiple lines
 of comments...
@@ -264,22 +275,68 @@ multi-line blocks.
 
 ```ruby
 # bad - single line block
-collection.each do |item| item.method(x) end
+items.each do |item| item / 5 end
 
 # good - single line block
-collection.each { |item| item.method(x) }
+items.each { |item| item / 5 }
 
 # bad - multi-line block
 things.map { |thing|
   something = thing.some_method
-  proces(something, something_else)
+  proces(something)
 }
 
 # good - multi-line block
 things.map do |thing|
   something = thing.some_method
-  proces(something, something_else)
+  proces(something)
 end
+```
+```ruby
+# Prefer `do...end` over `{...}` for procedural blocks.
+
+# return value is used/assigned
+# bad
+foo = map do |x|
+  x
+end
+puts (map do |x|
+  x
+end)
+
+# return value is not used out of scope
+# good
+map do |x|
+  x
+end
+
+# Prefer `{...}` over `do...end` for functional blocks.
+
+# return value is not used out of scope
+# bad
+each { |x|
+  x
+}
+
+# return value is used/assigned
+# good
+foo = map { |x|
+  x
+}
+map { |x|
+  x
+}.inspect
+```
+```ruby
+# bad
+words.each do |word|
+  word.flip.flop
+end.join("-")
+
+# good
+words.each { |word|
+  word.flip.flop
+}.join("-")
 ```
 
 ### Important attributes
@@ -437,6 +494,15 @@ var.kind_of?(Integer)
 # good
 var.is_a?(Date)
 var.is_a?(Integer)
+```
+```ruby
+# bad
+var.is_a?(Time)
+var.is_a?(String)
+
+# good
+var.kind_of?(Time)
+var.kind_of?(String)
 ```
 
 ### Important attributes

--- a/manual/cops_style.md
+++ b/manual/cops_style.md
@@ -233,6 +233,20 @@ Enabled | Yes
 
 This cop looks for uses of block comments (=begin...=end).
 
+### Example
+
+```ruby
+# bad -
+=begin
+Multiple lines
+of comments...
+=end
+
+# good
+# Multiple lines
+# of comments...
+```
+
 ### References
 
 * [https://github.com/bbatsov/ruby-style-guide#no-block-comments](https://github.com/bbatsov/ruby-style-guide#no-block-comments)

--- a/manual/cops_style.md
+++ b/manual/cops_style.md
@@ -923,6 +923,21 @@ The documentation requirement is annulled if the class or module has
 a "#:nodoc:" comment next to it. Likewise, "#:nodoc: all" does the
 same for all its children.
 
+### Example
+
+```ruby
+# bad
+class Person
+  ...
+end
+
+# good
+# Description/Explanation of Person class
+class Person
+  ...
+end
+```
+
 ### Important attributes
 
 Attribute | Value

--- a/manual/cops_style.md
+++ b/manual/cops_style.md
@@ -427,6 +427,18 @@ Enabled | Yes
 
 This cop enforces consistent use of `Object#is_a?` or `Object#kind_of?`.
 
+### Example
+
+```ruby
+# bad
+var.kind_of?(Date)
+var.kind_of?(Integer)
+
+# good
+var.is_a?(Date)
+var.is_a?(Integer)
+```
+
 ### Important attributes
 
 Attribute | Value

--- a/manual/cops_style.md
+++ b/manual/cops_style.md
@@ -523,6 +523,20 @@ Enabled | Yes
 This cop checks for methods invoked via the :: operator instead
 of the . operator (like FileUtils::rmdir instead of FileUtils.rmdir).
 
+### Example
+
+```ruby
+# bad
+Timeout::timeout(500) { ... }
+FileUtils::rmdir(dir)
+Marshal::dump(obj)
+
+# good
+Timeout.timeout(500) { ... }
+FileUtils.rmdir(dir)
+Marshal.dump(obj)
+```
+
 ### References
 
 * [https://github.com/bbatsov/ruby-style-guide#double-colons](https://github.com/bbatsov/ruby-style-guide#double-colons)

--- a/manual/cops_style.md
+++ b/manual/cops_style.md
@@ -260,6 +260,28 @@ Enabled | Yes
 Check for uses of braces or do/end around single line or
 multi-line blocks.
 
+### Example
+
+```ruby
+# bad - single line block
+collection.each do |item| item.method(x) end
+
+# good - single line block
+collection.each { |item| item.method(x) }
+
+# bad - multi-line block
+things.map { |thing|
+  something = thing.some_method
+  proces(something, something_else)
+}
+
+# good - multi-line block
+things.map do |thing|
+  something = thing.some_method
+  proces(something, something_else)
+end
+```
+
 ### Important attributes
 
 Attribute | Value

--- a/manual/cops_style.md
+++ b/manual/cops_style.md
@@ -192,6 +192,16 @@ Enabled | Yes
 
 This cop checks if usage of %() or %Q() matches configuration.
 
+### Example
+
+```ruby
+# bad -
+%Q(My name is #{name})
+
+# good
+%(My name is #{name})
+```
+
 ### Important attributes
 
 Attribute | Value


### PR DESCRIPTION
This PR adds examples to six `Style` Cops listed in the `"Add examples in the documentation"` Issue #4910 .  At the time of writing, none of these Cops have any open "Add example" PRs associated with them.  Each example set is contained to one commit.

Those Cops are:
1. `Style/BarePercentLiterals`
2. `Style/BlockComments`
3. `Style/BlockDelimiters`
4. `Style/ClassCheck`
5. `Style/ColonMethodCall`
6. `Style/Documentation`

-----------------

* [x] Wrote [good commit messages][1].
* [x] Used the same coding conventions as the rest of the project.
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] All tests(`rake spec`) are passing.
* [x] The new code doesn't generate RuboCop offenses that are checked by `rake internal_investigation`.
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Updated cop documentation with `rake generate_cops_documentation` (required only when you've added a new cop or changed the configuration/documentation of an existing cop).

[1]: http://chris.beams.io/posts/git-commit/
