### PR TITLE
Specify working RubyGems release for AppVeyor

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -4,7 +4,7 @@ version: "{build}"
 
 install:
   - set PATH=C:\Ruby%ruby_version%\bin;%PATH%
-  - gem update --system --no-document
+  - gem update --system 2.6.14 --no-document
   - gem install bundler --no-document
   - bundle install --jobs 3 --retry 3
 


### PR DESCRIPTION
AppVeyor has been having setup issues on this repo since Nov 2nd. All commits since then have this console error:
```
'C:\Ruby22\bin\gem" update --system --no-document' is not recognized as an internal or external command,
operable program or batch file.
```

This is the first master commit that ran into it. 
https://github.com/bbatsov/rubocop/commit/fc9d225e09361684552691a259205e03d2b51cc9 -
 https://ci.appveyor.com/project/bbatsov/rubocop/build/1301/job/i0698677ymj9yq55 

The bug due to RubyGems, as that commit is the first one to introduce a new minor release version (previous commit ran with RubyGems 2.6.14 - https://ci.appveyor.com/project/bbatsov/rubocop/build/1293/job/ylji5he97gtv8lgn )

-----------------

This PR fixes the broken AppVeyor integration by locking the system to the last working release of RubyGems.  

RubyGems documentation reference: http://guides.rubygems.org/command-reference/#gem-update

-----------------

The issue is known to the `rubygems` maintainers. But Window users are still reporting failures. #4998 hits the bug using the latest release RubyGems - 2.7.1 .

https://github.com/rubygems/rubygems/pull/2054#issuecomment-341877330

-----------------

* [x] Wrote [good commit messages][1].
* [x] Feature branch is up-to-date with `master` (if not - rebase it).

[1]: http://chris.beams.io/posts/git-commit/
