### PR TITLE
Use `# good / # bad` instead of `@good / @bad`

### DIFF
--- a/lib/rubocop/cop/layout/space_before_first_arg.rb
+++ b/lib/rubocop/cop/layout/space_before_first_arg.rb
@@ -11,12 +11,12 @@ module RuboCop
       # config parameter is true.
       #
       # @example
-      #   @bad
+      #   # bad
       #   something  x
       #   something   y, z
       #   something'hello'
       #
-      #   @good
+      #   # good
       #   something x
       #   something y, z
       #   something 'hello'

--- a/lib/rubocop/cop/layout/space_in_lambda_literal.rb
+++ b/lib/rubocop/cop/layout/space_in_lambda_literal.rb
@@ -7,17 +7,17 @@ module RuboCop
       # brace in lambda literals.
       #
       # @example EnforcedStyle: require_no_space (default)
-      #     @bad
+      #     # bad
       #     a = -> (x, y) { x + y }
       #
-      #     @good
+      #     # good
       #     a = ->(x, y) { x + y }
       #
       # @example EnforcedStyle: require_space
-      #     @bad
+      #     # bad
       #     a = ->(x, y) { x + y }
       #
-      #     @good
+      #     # good
       #     a = -> (x, y) { x + y }
       class SpaceInLambdaLiteral < Cop
         include ConfigurableEnforcedStyle

--- a/lib/rubocop/cop/layout/space_inside_array_percent_literal.rb
+++ b/lib/rubocop/cop/layout/space_inside_array_percent_literal.rb
@@ -7,11 +7,11 @@ module RuboCop
       # (i.e. %i/%w).
       #
       # @example
-      #   @good
-      #   %i(foo bar baz)
       #
-      #   @bad
+      #   # bad
       #   %w(foo  bar  baz)
+      #   # good
+      #   %i(foo bar baz)
       class SpaceInsideArrayPercentLiteral < Cop
         include MatchRange
         include PercentLiteral

--- a/lib/rubocop/cop/performance/casecmp.rb
+++ b/lib/rubocop/cop/performance/casecmp.rb
@@ -7,14 +7,14 @@ module RuboCop
       # can better be implemented using `casecmp`.
       #
       # @example
-      #   @bad
+      #   # bad
       #   str.downcase == 'abc'
       #   str.upcase.eql? 'ABC'
       #   'abc' == str.downcase
       #   'ABC'.eql? str.upcase
       #   str.downcase == str.downcase
       #
-      #   @good
+      #   # good
       #   str.casecmp('ABC').zero?
       #   'abc'.casecmp(str).zero?
       class Casecmp < Cop

--- a/lib/rubocop/cop/performance/compare_with_block.rb
+++ b/lib/rubocop/cop/performance/compare_with_block.rb
@@ -8,13 +8,13 @@ module RuboCop
       # This cop also checks `max` and `min` methods.
       #
       # @example
-      #   @bad
+      #   # bad
       #   array.sort { |a, b| a.foo <=> b.foo }
       #   array.max { |a, b| a.foo <=> b.foo }
       #   array.min { |a, b| a.foo <=> b.foo }
       #   array.sort { |a, b| a[:foo] <=> b[:foo] }
       #
-      #   @good
+      #   # good
       #   array.sort_by(&:foo)
       #   array.sort_by { |v| v.foo }
       #   array.sort_by do |var|

--- a/lib/rubocop/cop/performance/double_start_end_with.rb
+++ b/lib/rubocop/cop/performance/double_start_end_with.rb
@@ -8,15 +8,14 @@ module RuboCop
       # with an single `#start_with?`/`#end_with?` call.
       #
       # @example
-      #
-      #   @bad
+      #   # bad
       #   str.start_with?("a") || str.start_with?(Some::CONST)
       #   str.start_with?("a", "b") || str.start_with?("c")
       #   var1 = ...
       #   var2 = ...
       #   str.end_with?(var1) || str.end_with?(var2)
       #
-      #   @good
+      #   # good
       #   str.start_with?("a", Some::CONST)
       #   str.start_with?("a", "b", "c")
       #   var1 = ...

--- a/lib/rubocop/cop/performance/end_with.rb
+++ b/lib/rubocop/cop/performance/end_with.rb
@@ -7,11 +7,11 @@ module RuboCop
       # would suffice.
       #
       # @example
-      #   @bad
+      #   # bad
       #   'abc' =~ /bc\Z/
       #   'abc'.match(/bc\Z/)
       #
-      #   @good
+      #   # good
       #   'abc'.end_with?('bc')
       class EndWith < Cop
         MSG = 'Use `String#end_with?` instead of a regex match anchored to ' \

--- a/lib/rubocop/cop/performance/lstrip_rstrip.rb
+++ b/lib/rubocop/cop/performance/lstrip_rstrip.rb
@@ -7,11 +7,11 @@ module RuboCop
       # `strip`.
       #
       # @example
-      #   @bad
+      #   # bad
       #   'abc'.lstrip.rstrip
       #   'abc'.rstrip.lstrip
       #
-      #   @good
+      #   # good
       #   'abc'.strip
       class LstripRstrip < Cop
         MSG = 'Use `strip` instead of `%s.%s`.'.freeze

--- a/lib/rubocop/cop/performance/redundant_block_call.rb
+++ b/lib/rubocop/cop/performance/redundant_block_call.rb
@@ -7,7 +7,7 @@ module RuboCop
       # where `yield` would do just as well.
       #
       # @example
-      #   @bad
+      #   # bad
       #   def method(&block)
       #     block.call
       #   end
@@ -15,7 +15,7 @@ module RuboCop
       #     func.call 1, 2, 3
       #   end
       #
-      #   @good
+      #   # good
       #   def method
       #     yield
       #   end

--- a/lib/rubocop/cop/performance/redundant_match.rb
+++ b/lib/rubocop/cop/performance/redundant_match.rb
@@ -8,13 +8,13 @@ module RuboCop
       # index/`nil` and is more performant.
       #
       # @example
-      #   @bad
+      #   # bad
       #   do_something if str.match(/regex/)
       #   while regex.match('str')
       #     do_something
       #   end
       #
-      #   @good
+      #   # good
       #   method(str =~ /regex/)
       #   return value unless regex =~ 'str'
       class RedundantMatch < Cop

--- a/lib/rubocop/cop/performance/redundant_sort_by.rb
+++ b/lib/rubocop/cop/performance/redundant_sort_by.rb
@@ -7,13 +7,13 @@ module RuboCop
       # `sort`.
       #
       # @example
-      #   @bad
+      #   # bad
       #   array.sort_by { |x| x }
       #   array.sort_by do |var|
       #     var
       #   end
       #
-      #   @good
+      #   # good
       #   array.sort
       class RedundantSortBy < Cop
         MSG = 'Use `sort` instead of `sort_by { |%s| %s }`.'.freeze

--- a/lib/rubocop/cop/performance/start_with.rb
+++ b/lib/rubocop/cop/performance/start_with.rb
@@ -7,11 +7,11 @@ module RuboCop
       # `String#start_with?` would suffice.
       #
       # @example
-      #   @bad
+      #   # bad
       #   'abc' =~ /\Aab/
       #   'abc'.match(/\Aab/)
       #
-      #   @good
+      #   # good
       #   'abc'.start_with?('ab')
       class StartWith < Cop
         MSG = 'Use `String#start_with?` instead of a regex match anchored to ' \

--- a/lib/rubocop/cop/performance/string_replacement.rb
+++ b/lib/rubocop/cop/performance/string_replacement.rb
@@ -7,13 +7,13 @@ module RuboCop
       # `tr` or `delete`.
       #
       # @example
-      #   @bad
+      #   # bad
       #   'abc'.gsub('b', 'd')
       #   'abc'.gsub('a', '')
       #   'abc'.gsub(/a/, 'd')
       #   'abc'.gsub!('a', 'd')
       #
-      #   @good
+      #   # good
       #   'abc'.gsub(/.*/, 'a')
       #   'abc'.gsub(/a+/, 'd')
       #   'abc'.tr('b', 'd')

--- a/lib/rubocop/cop/performance/times_map.rb
+++ b/lib/rubocop/cop/performance/times_map.rb
@@ -8,13 +8,12 @@ module RuboCop
       # with an explicit array creation.
       #
       # @example
-      #
-      #   @bad
+      #   # bad
       #   9.times.map do |i|
       #     i.to_s
       #   end
       #
-      #   @good
+      #   # good
       #   Array.new(9) do |i|
       #     i.to_s
       #   end

--- a/lib/rubocop/cop/style/each_for_simple_loop.rb
+++ b/lib/rubocop/cop/style/each_for_simple_loop.rb
@@ -10,17 +10,17 @@ module RuboCop
       # This check only applies if the block takes no parameters.
       #
       # @example
-      #   @bad
+      #   # bad
       #   (1..5).each { }
       #
-      #   @good
+      #   # good
       #   5.times { }
       #
       # @example
-      #   @bad
+      #   # bad
       #   (0...10).each {}
       #
-      #   @good
+      #   # good
       #   10.times {}
       class EachForSimpleLoop < Cop
         MSG = 'Use `Integer#times` for a simple loop which iterates a fixed ' \

--- a/lib/rubocop/cop/style/hash_syntax.rb
+++ b/lib/rubocop/cop/style/hash_syntax.rb
@@ -22,46 +22,46 @@ module RuboCop
       # @example
       #   "EnforcedStyle => 'ruby19'"
       #
-      #   @good
+      #   # bad
+      #   {:a => 2}
+      #   {b: 1, :c => 2}
+      #
+      #   # good
       #   {a: 2, b: 1}
       #   {:c => 2, 'd' => 2} # acceptable since 'd' isn't a symbol
       #   {d: 1, 'e' => 2} # technically not forbidden
       #
-      #   @bad
-      #   {:a => 2}
-      #   {b: 1, :c => 2}
-      #
       # @example
       #   "EnforcedStyle => 'hash_rockets'"
       #
-      #   @good
-      #   {:a => 1, :b => 2}
-      #
-      #   @bad
+      #   # bad
       #   {a: 1, b: 2}
       #   {c: 1, 'd' => 5}
+      #
+      #   # good
+      #   {:a => 1, :b => 2}
       #
       # @example
       #   "EnforcedStyle => 'no_mixed_keys'"
       #
-      #   @good
-      #   {:a => 1, :b => 2}
-      #   {c: 1, d: 2}
-      #
-      #   @bad
+      #   # bad
       #   {:a => 1, b: 2}
       #   {c: 1, 'd' => 2}
+      #
+      #   # good
+      #   {:a => 1, :b => 2}
+      #   {c: 1, d: 2}
       #
       # @example
       #   "EnforcedStyle => 'ruby19_no_mixed_keys'"
       #
-      #   @good
-      #   {a: 1, b: 2}
-      #   {:c => 3, 'd' => 4}
-      #
-      #   @bad
+      #   # bad
       #   {:a => 1, :b => 2}
       #   {c: 2, 'd' => 3} # should just use hash rockets
+      #
+      #   # good
+      #   {a: 1, b: 2}
+      #   {:c => 3, 'd' => 4}
       class HashSyntax < Cop
         include ConfigurableEnforcedStyle
 

--- a/lib/rubocop/cop/style/identical_conditional_branches.rb
+++ b/lib/rubocop/cop/style/identical_conditional_branches.rb
@@ -7,7 +7,7 @@ module RuboCop
       # each branch of a conditional statement.
       #
       # @example
-      #   @bad
+      #   # bad
       #   if condition
       #     do_x
       #     do_z
@@ -16,7 +16,7 @@ module RuboCop
       #     do_z
       #   end
       #
-      #   @good
+      #   # good
       #   if condition
       #     do_x
       #   else
@@ -24,7 +24,7 @@ module RuboCop
       #   end
       #   do_z
       #
-      #   @bad
+      #   # bad
       #   if condition
       #     do_z
       #     do_x
@@ -33,7 +33,7 @@ module RuboCop
       #     do_y
       #   end
       #
-      #   @good
+      #   # good
       #   do_z
       #   if condition
       #     do_x
@@ -41,7 +41,7 @@ module RuboCop
       #     do_y
       #   end
       #
-      #   @bad
+      #   # bad
       #   case foo
       #   when 1
       #     do_x
@@ -51,7 +51,7 @@ module RuboCop
       #     do_x
       #   end
       #
-      #   @good
+      #   # good
       #   case foo
       #   when 1
       #     do_x

--- a/lib/rubocop/cop/style/if_inside_else.rb
+++ b/lib/rubocop/cop/style/if_inside_else.rb
@@ -8,16 +8,7 @@ module RuboCop
       # This helps to keep the nesting level from getting too deep.
       #
       # @example
-      #   @good
-      #   if condition_a
-      #     action_a
-      #   elsif condition_b
-      #     action_b
-      #   else
-      #     action_c
-      #   end
-      #
-      #   @bad
+      #   # bad
       #   if condition_a
       #     action_a
       #   else
@@ -26,6 +17,15 @@ module RuboCop
       #     else
       #       action_c
       #     end
+      #   end
+      #
+      #   # good
+      #   if condition_a
+      #     action_a
+      #   elsif condition_b
+      #     action_b
+      #   else
+      #     action_c
       #   end
       class IfInsideElse < Cop
         MSG = 'Convert `if` nested inside `else` to `elsif`.'.freeze

--- a/lib/rubocop/cop/style/implicit_runtime_error.rb
+++ b/lib/rubocop/cop/style/implicit_runtime_error.rb
@@ -9,10 +9,10 @@ module RuboCop
       # nature of the error.)
       #
       # @example
-      #   @bad
+      #   # bad
       #   raise 'Error message here'
       #
-      #   @good
+      #   # good
       #   raise ArgumentError, 'Error message here'
       class ImplicitRuntimeError < Cop
         MSG = 'Use `%s` with an explicit exception class and message, ' \

--- a/lib/rubocop/cop/style/min_max.rb
+++ b/lib/rubocop/cop/style/min_max.rb
@@ -7,11 +7,11 @@ module RuboCop
       #
       # @example
       #
-      #   @bad
+      #   # bad
       #   bar = [foo.min, foo.max]
       #   return foo.min, foo.max
       #
-      #   @good
+      #   # good
       #   bar = foo.minmax
       #   return foo.minmax
       class MinMax < Cop

--- a/lib/rubocop/cop/style/mixin_grouping.rb
+++ b/lib/rubocop/cop/style/mixin_grouping.rb
@@ -11,12 +11,12 @@ module RuboCop
       #
       #   EnforcedStyle: separated (default)
       #
-      #   @bad
+      #   # bad
       #   class Foo
       #     include Bar, Qox
       #   end
       #
-      #   @good
+      #   # good
       #   class Foo
       #     include Qox
       #     include Bar
@@ -24,13 +24,13 @@ module RuboCop
       #
       #   EnforcedStyle: grouped
       #
-      #   @bad
+      #   # bad
       #   class Foo
       #     extend Bar
       #     extend Qox
       #   end
       #
-      #   @good
+      #   # good
       #   class Foo
       #     extend Qox, Bar
       #   end

--- a/lib/rubocop/cop/style/multiline_memoization.rb
+++ b/lib/rubocop/cop/style/multiline_memoization.rb
@@ -9,13 +9,13 @@ module RuboCop
       #
       #   # EnforcedStyle: keyword (default)
       #
-      #   @bad
+      #   # bad
       #   foo ||= (
       #     bar
       #     baz
       #   )
       #
-      #   @good
+      #   # good
       #   foo ||= begin
       #     bar
       #     baz
@@ -25,13 +25,13 @@ module RuboCop
       #
       #   # EnforcedStyle: braces
       #
-      #   @bad
+      #   # bad
       #   foo ||= begin
       #     bar
       #     baz
       #   end
       #
-      #   @good
+      #   # good
       #   foo ||= (
       #     bar
       #     baz

--- a/lib/rubocop/cop/style/nested_parenthesized_calls.rb
+++ b/lib/rubocop/cop/style/nested_parenthesized_calls.rb
@@ -7,10 +7,10 @@ module RuboCop
       # of a parenthesized method call.
       #
       # @example
-      #   @good
+      #   # good
       #   method1(method2(arg), method3(arg))
       #
-      #   @bad
+      #   # bad
       #   method1(method2 arg, method3, arg)
       class NestedParenthesizedCalls < Cop
         MSG = 'Add parentheses to nested method call `%s`.'.freeze

--- a/lib/rubocop/cop/style/ternary_parentheses.rb
+++ b/lib/rubocop/cop/style/ternary_parentheses.rb
@@ -12,12 +12,12 @@ module RuboCop
       #
       #   EnforcedStyle: require_no_parentheses (default)
       #
-      #   @bad
+      #   # bad
       #   foo = (bar?) ? a : b
       #   foo = (bar.baz?) ? a : b
       #   foo = (bar && baz) ? a : b
       #
-      #   @good
+      #   # good
       #   foo = bar? ? a : b
       #   foo = bar.baz? ? a : b
       #   foo = bar && baz ? a : b
@@ -26,12 +26,12 @@ module RuboCop
       #
       #   EnforcedStyle: require_parentheses
       #
-      #   @bad
+      #   # bad
       #   foo = bar? ? a : b
       #   foo = bar.baz? ? a : b
       #   foo = bar && baz ? a : b
       #
-      #   @good
+      #   # good
       #   foo = (bar?) ? a : b
       #   foo = (bar.baz?) ? a : b
       #   foo = (bar && baz) ? a : b
@@ -40,12 +40,12 @@ module RuboCop
       #
       #   EnforcedStyle: require_parentheses_when_complex
       #
-      #   @bad
+      #   # bad
       #   foo = (bar?) ? a : b
       #   foo = (bar.baz?) ? a : b
       #   foo = bar && baz ? a : b
       #
-      #   @good
+      #   # good
       #   foo = bar? ? a : b
       #   foo = bar.baz? ? a : b
       #   foo = (bar && baz) ? a : b

--- a/lib/rubocop/cop/style/zero_length_predicate.rb
+++ b/lib/rubocop/cop/style/zero_length_predicate.rb
@@ -10,8 +10,7 @@ module RuboCop
       # replaced by receiver.empty? and !receiver.empty.
       #
       # @example
-      #
-      #   @bad
+      #   # bad
       #   [1, 2, 3].length == 0
       #   0 == "foobar".length
       #   array.length < 1
@@ -19,7 +18,7 @@ module RuboCop
       #   string.length > 0
       #   hash.size > 0
       #
-      #   @good
+      #   # good
       #   [1, 2, 3].empty?
       #   "foobar".empty?
       #   array.empty?

--- a/manual/cops_layout.md
+++ b/manual/cops_layout.md
@@ -2276,11 +2276,10 @@ Checks for unnecessary additional spaces inside array percent literals
 ### Example
 
 ```ruby
-# good
-%i(foo bar baz)
-
 # bad
 %w(foo  bar  baz)
+# good
+%i(foo bar baz)
 ```
 
 ## Layout/SpaceInsideBlockBraces

--- a/manual/cops_style.md
+++ b/manual/cops_style.md
@@ -1494,46 +1494,46 @@ The supported styles are:
 ```ruby
 "EnforcedStyle => 'ruby19'"
 
+# bad
+{:a => 2}
+{b: 1, :c => 2}
+
 # good
 {a: 2, b: 1}
 {:c => 2, 'd' => 2} # acceptable since 'd' isn't a symbol
 {d: 1, 'e' => 2} # technically not forbidden
-
-# bad
-{:a => 2}
-{b: 1, :c => 2}
 ```
 ```ruby
 "EnforcedStyle => 'hash_rockets'"
 
-# good
-{:a => 1, :b => 2}
-
 # bad
 {a: 1, b: 2}
 {c: 1, 'd' => 5}
+
+# good
+{:a => 1, :b => 2}
 ```
 ```ruby
 "EnforcedStyle => 'no_mixed_keys'"
 
-# good
-{:a => 1, :b => 2}
-{c: 1, d: 2}
-
 # bad
 {:a => 1, b: 2}
 {c: 1, 'd' => 2}
+
+# good
+{:a => 1, :b => 2}
+{c: 1, d: 2}
 ```
 ```ruby
 "EnforcedStyle => 'ruby19_no_mixed_keys'"
 
-# good
-{a: 1, b: 2}
-{:c => 3, 'd' => 4}
-
 # bad
 {:a => 1, :b => 2}
 {c: 2, 'd' => 3} # should just use hash rockets
+
+# good
+{a: 1, b: 2}
+{:c => 3, 'd' => 4}
 ```
 
 ### Important attributes
@@ -1631,15 +1631,6 @@ This helps to keep the nesting level from getting too deep.
 ### Example
 
 ```ruby
-# good
-if condition_a
-  action_a
-elsif condition_b
-  action_b
-else
-  action_c
-end
-
 # bad
 if condition_a
   action_a
@@ -1649,6 +1640,15 @@ else
   else
     action_c
   end
+end
+
+# good
+if condition_a
+  action_a
+elsif condition_b
+  action_b
+else
+  action_c
 end
 ```
 


### PR DESCRIPTION
This commit is a small change of document. This change aims at unifying a notation.

This changes the example code `@good / @bad` notation to `# good / # bad` notaion. This `# good / # bad` notation conforms to the template generated by `rake new_cop`.
https://github.com/bbatsov/rubocop/blob/v0.51.0/lib/rubocop/cop/generator.rb#L19-L30

Also, it sorts in order of `# bad` and `# good`.

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Used the same coding conventions as the rest of the project.
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [ ] Added tests.
* [ ] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] All tests(`rake spec`) are passing.
* [x] The new code doesn't generate RuboCop offenses that are checked by `rake internal_investigation`.
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Updated cop documentation with `rake generate_cops_documentation` (required only when you've added a new cop or changed the configuration/documentation of an existing cop).

[1]: http://chris.beams.io/posts/git-commit/
