### PR TITLE
Restyle the example formatting for some Style cops

### DIFF
--- a/lib/rubocop/cop/style/braces_around_hash_parameters.rb
+++ b/lib/rubocop/cop/style/braces_around_hash_parameters.rb
@@ -17,7 +17,7 @@ module RuboCop
       #   # good
       #   some_method(x, y, {a: 1, b: 2})
       #
-      # @example EnforcedStyle: no_braces
+      # @example EnforcedStyle: no_braces (default)
       #   # The `no_braces` style checks that the last parameter doesn't
       #   # have braces around it.
       #

--- a/lib/rubocop/cop/style/conditional_assignment.rb
+++ b/lib/rubocop/cop/style/conditional_assignment.rb
@@ -108,9 +108,7 @@ module RuboCop
       # assignment to the same variable when using the return of the
       # condition can be used instead.
       #
-      # @example
-      #   EnforcedStyle: assign_to_condition
-      #
+      # @example EnforcedStyle: assign_to_condition (default)
       #   # bad
       #   if foo
       #     bar = 1
@@ -155,7 +153,7 @@ module RuboCop
       #            2
       #          end
       #
-      #   EnforcedStyle: assign_inside_condition
+      # @example EnforcedStyle: assign_inside_condition
       #   # bad
       #   bar = if foo
       #           1

--- a/lib/rubocop/cop/style/empty_method.rb
+++ b/lib/rubocop/cop/style/empty_method.rb
@@ -11,10 +11,7 @@ module RuboCop
       # Note: A method definition is not considered empty if it contains
       #       comments.
       #
-      # @example
-      #
-      #   # EnforcedStyle: compact (default)
-      #
+      # @example EnforcedStyle: compact (default)
       #   # bad
       #   def foo(bar)
       #   end
@@ -31,10 +28,7 @@ module RuboCop
       #
       #   def self.foo(bar); end
       #
-      # @example
-      #
-      #   # EnforcedStyle: expanded
-      #
+      # @example EnforcedStyle: expanded
       #   # bad
       #   def foo(bar); end
       #

--- a/lib/rubocop/cop/style/format_string_token.rb
+++ b/lib/rubocop/cop/style/format_string_token.rb
@@ -5,10 +5,7 @@ module RuboCop
     module Style
       # Use a consistent style for named format string tokens.
       #
-      # @example
-      #
-      #   EnforcedStyle: annotated
-      #
+      # @example EnforcedStyle: annotated (default)
       #   # bad
       #
       #   format('%{greeting}', greeting: 'Hello')
@@ -18,10 +15,7 @@ module RuboCop
       #
       #   format('%<greeting>s', greeting: 'Hello')
       #
-      # @example
-      #
-      #   EnforcedStyle: template
-      #
+      # @example EnforcedStyle: template
       #   # bad
       #
       #   format('%<greeting>s', greeting: 'Hello')

--- a/lib/rubocop/cop/style/hash_syntax.rb
+++ b/lib/rubocop/cop/style/hash_syntax.rb
@@ -19,9 +19,7 @@ module RuboCop
       # * ruby19_no_mixed_keys - forces use of ruby 1.9 syntax and forbids mixed
       #   syntax hashes
       #
-      # @example
-      #   "EnforcedStyle => 'ruby19'"
-      #
+      # @example EnforcedStyle: ruby19 (default)
       #   # bad
       #   {:a => 2}
       #   {b: 1, :c => 2}
@@ -31,9 +29,7 @@ module RuboCop
       #   {:c => 2, 'd' => 2} # acceptable since 'd' isn't a symbol
       #   {d: 1, 'e' => 2} # technically not forbidden
       #
-      # @example
-      #   "EnforcedStyle => 'hash_rockets'"
-      #
+      # @example EnforcedStyle: hash_rockets
       #   # bad
       #   {a: 1, b: 2}
       #   {c: 1, 'd' => 5}
@@ -41,9 +37,7 @@ module RuboCop
       #   # good
       #   {:a => 1, :b => 2}
       #
-      # @example
-      #   "EnforcedStyle => 'no_mixed_keys'"
-      #
+      # @example EnforcedStyle: no_mixed_keys
       #   # bad
       #   {:a => 1, b: 2}
       #   {c: 1, 'd' => 2}
@@ -52,9 +46,7 @@ module RuboCop
       #   {:a => 1, :b => 2}
       #   {c: 1, d: 2}
       #
-      # @example
-      #   "EnforcedStyle => 'ruby19_no_mixed_keys'"
-      #
+      # @example EnforcedStyle: ruby19_no_mixed_keys
       #   # bad
       #   {:a => 1, :b => 2}
       #   {c: 2, 'd' => 3} # should just use hash rockets

--- a/lib/rubocop/cop/style/lambda.rb
+++ b/lib/rubocop/cop/style/lambda.rb
@@ -8,10 +8,7 @@ module RuboCop
       # It is configurable to enforce one of the styles for both single line
       # and multiline lambdas as well.
       #
-      # @example
-      #
-      #   # EnforcedStyle: line_count_dependent (default)
-      #
+      # @example EnforcedStyle: line_count_dependent (default)
       #   # bad
       #   f = lambda { |x| x }
       #   f = ->(x) do
@@ -24,10 +21,7 @@ module RuboCop
       #         x
       #       end
       #
-      # @example
-      #
-      #   # EnforcedStyle: lambda
-      #
+      # @example EnforcedStyle: lambda
       #   # bad
       #   f = ->(x) { x }
       #   f = ->(x) do
@@ -40,10 +34,7 @@ module RuboCop
       #         x
       #       end
       #
-      # @example
-      #
-      #   # EnforcedStyle: literal
-      #
+      # @example EnforcedStyle: literal
       #   # bad
       #   f = lambda { |x| x }
       #   f = lambda do |x|

--- a/lib/rubocop/cop/style/mixin_grouping.rb
+++ b/lib/rubocop/cop/style/mixin_grouping.rb
@@ -7,10 +7,7 @@ module RuboCop
       # By default it enforces mixins to be placed in separate declarations,
       # but it can be configured to enforce grouping them in one declaration.
       #
-      # @example
-      #
-      #   EnforcedStyle: separated (default)
-      #
+      # @example EnforcedStyle: separated (default)
       #   # bad
       #   class Foo
       #     include Bar, Qox
@@ -22,8 +19,7 @@ module RuboCop
       #     include Bar
       #   end
       #
-      #   EnforcedStyle: grouped
-      #
+      # @example EnforcedStyle: grouped
       #   # bad
       #   class Foo
       #     extend Bar

--- a/lib/rubocop/cop/style/module_function.rb
+++ b/lib/rubocop/cop/style/module_function.rb
@@ -8,15 +8,27 @@ module RuboCop
       #
       # Supported styles are: module_function, extend_self.
       #
-      # @example
+      # @example EnforcedStyle: module_function (default)
+      #   # bad
+      #   module Test
+      #     extend self
+      #     ...
+      #   end
       #
-      #   # Good if EnforcedStyle is module_function
+      #   # good
       #   module Test
       #     module_function
       #     ...
       #   end
       #
-      #   # Good if EnforcedStyle is extend_self
+      # @example EnforcedStyle: extend_self
+      #   # bad
+      #   module Test
+      #     module_function
+      #     ...
+      #   end
+      #
+      #   # good
       #   module Test
       #     extend self
       #     ...

--- a/lib/rubocop/cop/style/multiline_if_then.rb
+++ b/lib/rubocop/cop/style/multiline_if_then.rb
@@ -5,13 +5,14 @@ module RuboCop
     module Style
       # Checks for uses of the `then` keyword in multi-line if statements.
       #
-      # @example This is considered bad practice:
-      #
+      # @example
+      #   # bad
+      #   # This is considered bad practice.
       #   if cond then
       #   end
       #
-      # @example If statements can contain `then` on the same line:
-      #
+      #   # good
+      #   # If statements can contain `then` on the same line.
       #   if cond then a
       #   elsif cond then b
       #   end

--- a/lib/rubocop/cop/style/multiline_memoization.rb
+++ b/lib/rubocop/cop/style/multiline_memoization.rb
@@ -5,10 +5,7 @@ module RuboCop
     module Style
       # This cop checks expressions wrapping styles for multiline memoization.
       #
-      # @example
-      #
-      #   # EnforcedStyle: keyword (default)
-      #
+      # @example EnforcedStyle: keyword (default)
       #   # bad
       #   foo ||= (
       #     bar
@@ -21,10 +18,7 @@ module RuboCop
       #     baz
       #   end
       #
-      # @example
-      #
-      #   # EnforcedStyle: braces
-      #
+      # @example EnforcedStyle: braces
       #   # bad
       #   foo ||= begin
       #     bar

--- a/lib/rubocop/cop/style/negated_if.rb
+++ b/lib/rubocop/cop/style/negated_if.rb
@@ -10,17 +10,9 @@ module RuboCop
       #   - prefix
       #   - postfix
       #
-      # @example
-      #
-      #   # EnforcedStyle: both
+      # @example EnforcedStyle: both (default)
       #   # enforces `unless` for `prefix` and `postfix` conditionals
       #
-      #   # good
-      #
-      #   unless foo
-      #     bar
-      #   end
-      #
       #   # bad
       #
       #   if !foo
@@ -29,23 +21,21 @@ module RuboCop
       #
       #   # good
       #
-      #   bar unless foo
+      #   unless foo
+      #     bar
+      #   end
       #
       #   # bad
       #
       #   bar if !foo
       #
-      # @example
+      #   # good
       #
-      #   # EnforcedStyle: prefix
+      #   bar unless foo
+      #
+      # @example EnforcedStyle: prefix
       #   # enforces `unless` for just `prefix` conditionals
       #
-      #   # good
-      #
-      #   unless foo
-      #     bar
-      #   end
-      #
       #   # bad
       #
       #   if !foo
@@ -54,20 +44,24 @@ module RuboCop
       #
       #   # good
       #
-      #   bar if !foo
-      #
-      # @example
-      #
-      #   # EnforcedStyle: postfix
-      #   # enforces `unless` for just `postfix` conditionals
+      #   unless foo
+      #     bar
+      #   end
       #
       #   # good
       #
-      #   bar unless foo
+      #   bar if !foo
+      #
+      # @example EnforcedStyle: postfix
+      #   # enforces `unless` for just `postfix` conditionals
       #
       #   # bad
       #
       #   bar if !foo
+      #
+      #   # good
+      #
+      #   bar unless foo
       #
       #   # good
       #

--- a/lib/rubocop/cop/style/numeric_predicate.rb
+++ b/lib/rubocop/cop/style/numeric_predicate.rb
@@ -16,10 +16,7 @@ module RuboCop
       # populated with objects which can be compared with integers, but are
       # not themselves `Interger` polymorphic.
       #
-      # @example
-      #
-      #   # EnforcedStyle: predicate (default)
-      #
+      # @example EnforcedStyle: predicate (default)
       #   # bad
       #
       #   foo == 0
@@ -32,10 +29,7 @@ module RuboCop
       #   foo.negative?
       #   bar.baz.positive?
       #
-      # @example
-      #
-      #   # EnforcedStyle: comparison
-      #
+      # @example EnforcedStyle: comparison
       #   # bad
       #
       #   foo.zero?

--- a/lib/rubocop/cop/style/preferred_hash_methods.rb
+++ b/lib/rubocop/cop/style/preferred_hash_methods.rb
@@ -8,10 +8,7 @@ module RuboCop
       # It is configurable to enforce the inverse, using `verbose` method
       # names also.
       #
-      # @example
-      #
-      #  # EnforcedStyle: short (default)
-      #
+      # @example EnforcedStyle: short (default)
       #  # bad
       #  Hash#has_key?
       #  Hash#has_value?
@@ -20,10 +17,7 @@ module RuboCop
       #  Hash#key?
       #  Hash#value?
       #
-      # @example
-      #
-      #  # EnforcedStyle: verbose
-      #
+      # @example EnforcedStyle: verbose
       #  # bad
       #  Hash#key?
       #  Hash#value?

--- a/lib/rubocop/cop/style/raise_args.rb
+++ b/lib/rubocop/cop/style/raise_args.rb
@@ -13,10 +13,7 @@ module RuboCop
       # will also suggest constructing error objects when the exception is
       # passed multiple arguments.
       #
-      # @example
-      #
-      #   # EnforcedStyle: exploded
-      #
+      # @example EnforcedStyle: exploded (default)
       #   # bad
       #   raise StandardError.new("message")
       #
@@ -26,10 +23,7 @@ module RuboCop
       #   raise MyCustomError.new(arg1, arg2, arg3)
       #   raise MyKwArgError.new(key1: val1, key2: val2)
       #
-      # @example
-      #
-      #   # EnforcedStyle: compact
-      #
+      # @example EnforcedStyle: compact
       #   # bad
       #   raise StandardError, "message"
       #   raise RuntimeError, arg1, arg2, arg3

--- a/lib/rubocop/cop/style/return_nil.rb
+++ b/lib/rubocop/cop/style/return_nil.rb
@@ -7,10 +7,7 @@ module RuboCop
       #
       # Supported styles are: return, return_nil.
       #
-      # @example
-      #
-      #   # EnforcedStyle: return (default)
-      #
+      # @example EnforcedStyle: return (default)
       #   # bad
       #   def foo(arg)
       #     return nil if arg
@@ -21,8 +18,7 @@ module RuboCop
       #     return if arg
       #   end
       #
-      #   # EnforcedStyle: return_nil
-      #
+      # @example EnforcedStyle: return_nil
       #   # bad
       #   def foo(arg)
       #     return if arg

--- a/lib/rubocop/cop/style/stabby_lambda_parentheses.rb
+++ b/lib/rubocop/cop/style/stabby_lambda_parentheses.rb
@@ -6,17 +6,18 @@ module RuboCop
       # Check for parentheses around stabby lambda arguments.
       # There are two different styles. Defaults to `require_parentheses`.
       #
-      # @example
-      #   # require_parentheses - bad
+      # @example EnforcedStyle: require_parentheses (default)
+      #   # bad
       #   ->a,b,c { a + b + c }
       #
-      #   # require_parentheses - good
+      #   # good
       #   ->(a,b,c) { a + b + c}
       #
-      #   # require_no_parentheses - bad
+      # @example EnforcedStyle: require_no_parentheses
+      #   # bad
       #   ->(a,b,c) { a + b + c }
       #
-      #   # require_no_parentheses - good
+      #   # good
       #   ->a,b,c { a + b + c}
       class StabbyLambdaParentheses < Cop
         include ConfigurableEnforcedStyle

--- a/lib/rubocop/cop/style/string_literals_in_interpolation.rb
+++ b/lib/rubocop/cop/style/string_literals_in_interpolation.rb
@@ -6,20 +6,14 @@ module RuboCop
       # This cop checks that quotes inside the string interpolation
       # match the configured preference.
       #
-      # @example
-      #
-      #   # EnforcedStyle: single_quotes
-      #
+      # @example EnforcedStyle: single_quotes (default)
       #   # bad
       #   result = "Tests #{success ? "PASS" : "FAIL"}"
       #
       #   # good
       #   result = "Tests #{success ? 'PASS' : 'FAIL'}"
       #
-      # @example
-      #
-      #   # EnforcedStyle: double_quotes
-      #
+      # @example EnforcedStyle: double_quotes
       #   # bad
       #   result = "Tests #{success ? 'PASS' : 'FAIL'}"
       #

--- a/lib/rubocop/cop/style/symbol_array.rb
+++ b/lib/rubocop/cop/style/symbol_array.rb
@@ -14,18 +14,14 @@ module RuboCop
       # cop. For example, a `MinSize of `3` will not enforce a style on an array
       # of 2 or fewer elements.
       #
-      # @example
-      #   EnforcedStyle: percent (default)
-      #
+      # @example EnforcedStyle: percent (default)
       #   # good
       #   %i[foo bar baz]
       #
       #   # bad
       #   [:foo, :bar, :baz]
       #
-      # @example
-      #   EnforcedStyle: brackets
-      #
+      # @example EnforcedStyle: brackets
       #   # good
       #   [:foo, :bar, :baz]
       #

--- a/lib/rubocop/cop/style/ternary_parentheses.rb
+++ b/lib/rubocop/cop/style/ternary_parentheses.rb
@@ -8,10 +8,7 @@ module RuboCop
       # parentheses using `EnforcedStyle`. Omission is only enforced when
       # removing the parentheses won't cause a different behavior.
       #
-      # @example
-      #
-      #   EnforcedStyle: require_no_parentheses (default)
-      #
+      # @example EnforcedStyle: require_no_parentheses (default)
       #   # bad
       #   foo = (bar?) ? a : b
       #   foo = (bar.baz?) ? a : b
@@ -22,10 +19,7 @@ module RuboCop
       #   foo = bar.baz? ? a : b
       #   foo = bar && baz ? a : b
       #
-      # @example
-      #
-      #   EnforcedStyle: require_parentheses
-      #
+      # @example EnforcedStyle: require_parentheses
       #   # bad
       #   foo = bar? ? a : b
       #   foo = bar.baz? ? a : b
@@ -36,10 +30,7 @@ module RuboCop
       #   foo = (bar.baz?) ? a : b
       #   foo = (bar && baz) ? a : b
       #
-      # @example
-      #
-      #   EnforcedStyle: require_parentheses_when_complex
-      #
+      # @example EnforcedStyle: require_parentheses_when_complex
       #   # bad
       #   foo = (bar?) ? a : b
       #   foo = (bar.baz?) ? a : b

--- a/lib/rubocop/cop/style/trailing_comma_in_arguments.rb
+++ b/lib/rubocop/cop/style/trailing_comma_in_arguments.rb
@@ -5,23 +5,37 @@ module RuboCop
     module Style
       # This cop checks for trailing comma in argument lists.
       #
-      # @example
-      #   # always bad
+      # @example EnforcedStyleForMultiline: consistent_comma
+      #   # bad
       #   method(1, 2,)
       #
-      #   # good if EnforcedStyleForMultiline is consistent_comma
+      #   # good
       #   method(
       #     1, 2,
       #     3,
       #   )
       #
-      #   # good if EnforcedStyleForMultiline is comma or consistent_comma
+      #   # good
       #   method(
       #     1,
       #     2,
       #   )
       #
-      #   # good if EnforcedStyleForMultiline is no_comma
+      # @example EnforcedStyleForMultiline: comma
+      #   # bad
+      #   method(1, 2,)
+      #
+      #   # good
+      #   method(
+      #     1,
+      #     2,
+      #   )
+      #
+      # @example EnforcedStyleForMultiline: no_comma (default)
+      #   # bad
+      #   method(1, 2,)
+      #
+      #   # good
       #   method(
       #     1,
       #     2

--- a/lib/rubocop/cop/style/trailing_comma_in_literal.rb
+++ b/lib/rubocop/cop/style/trailing_comma_in_literal.rb
@@ -5,23 +5,37 @@ module RuboCop
     module Style
       # This cop checks for trailing comma in array and hash literals.
       #
-      # @example
-      #   # always bad
+      # @example EnforcedStyleForMultiline: consistent_comma
+      #   # bad
       #   a = [1, 2,]
       #
-      #   # good if EnforcedStyleForMultiline is consistent_comma
+      #   # good
       #   a = [
       #     1, 2,
       #     3,
       #   ]
       #
-      #   # good if EnforcedStyleForMultiline is comma or consistent_comma
+      #   # good
       #   a = [
       #     1,
       #     2,
       #   ]
       #
-      #   # good if EnforcedStyleForMultiline is no_comma
+      # @example EnforcedStyleForMultiline: comma
+      #   # bad
+      #   a = [1, 2,]
+      #
+      #   # good
+      #   a = [
+      #     1,
+      #     2,
+      #   ]
+      #
+      # @example EnforcedStyleForMultiline: no_comma (default)
+      #   # bad
+      #   a = [1, 2,]
+      #
+      #   # good
       #   a = [
       #     1,
       #     2

--- a/lib/rubocop/cop/style/word_array.rb
+++ b/lib/rubocop/cop/style/word_array.rb
@@ -14,18 +14,14 @@ module RuboCop
       # cop. For example, a `MinSize` of `3` will not enforce a style on an
       # array of 2 or fewer elements.
       #
-      # @example
-      #   EnforcedStyle: percent (default)
-      #
+      # @example EnforcedStyle: percent (default)
       #   # good
       #   %w[foo bar baz]
       #
       #   # bad
       #   ['foo', 'bar', 'baz']
       #
-      # @example
-      #   EnforcedStyle: brackets
-      #
+      # @example EnforcedStyle: brackets
       #   # good
       #   ['foo', 'bar', 'baz']
       #

--- a/lib/rubocop/cop/style/yoda_condition.rb
+++ b/lib/rubocop/cop/style/yoda_condition.rb
@@ -7,10 +7,7 @@ module RuboCop
       # readability is reduced because the operands are not ordered the same
       # way as they would be ordered in spoken English.
       #
-      # @example
-      #
-      #   # EnforcedStyle: all_comparison_operators
-      #
+      # @example EnforcedStyle: all_comparison_operators (default)
       #   # bad
       #   99 == foo
       #   "bar" != foo
@@ -23,10 +20,7 @@ module RuboCop
       #   foo <= 42
       #   bar > 10
       #
-      # @example
-      #
-      #   # EnforcedStyle: equality_operators_only
-      #
+      # @example EnforcedStyle: equality_operators_only
       #   # bad
       #   99 == foo
       #   "bar" != foo

--- a/manual/cops_style.md
+++ b/manual/cops_style.md
@@ -751,8 +751,6 @@ condition can be used instead.
 ### Example
 
 ```ruby
-EnforcedStyle: assign_to_condition
-
 # bad
 if foo
   bar = 1
@@ -796,8 +794,8 @@ bar << if foo
          some_other_method
          2
        end
-
-EnforcedStyle: assign_inside_condition
+```
+```ruby
 # bad
 bar = if foo
         1
@@ -1305,8 +1303,6 @@ Note: A method definition is not considered empty if it contains
 ### Example
 
 ```ruby
-# EnforcedStyle: compact (default)
-
 # bad
 def foo(bar)
 end
@@ -1324,8 +1320,6 @@ end
 def self.foo(bar); end
 ```
 ```ruby
-# EnforcedStyle: expanded
-
 # bad
 def foo(bar); end
 
@@ -1481,8 +1475,6 @@ Use a consistent style for named format string tokens.
 ### Example
 
 ```ruby
-EnforcedStyle: annotated
-
 # bad
 
 format('%{greeting}', greeting: 'Hello')
@@ -1493,8 +1485,6 @@ format('%s', 'Hello')
 format('%<greeting>s', greeting: 'Hello')
 ```
 ```ruby
-EnforcedStyle: template
-
 # bad
 
 format('%<greeting>s', greeting: 'Hello')
@@ -1645,8 +1635,6 @@ The supported styles are:
 ### Example
 
 ```ruby
-"EnforcedStyle => 'ruby19'"
-
 # bad
 {:a => 2}
 {b: 1, :c => 2}
@@ -1657,8 +1645,6 @@ The supported styles are:
 {d: 1, 'e' => 2} # technically not forbidden
 ```
 ```ruby
-"EnforcedStyle => 'hash_rockets'"
-
 # bad
 {a: 1, b: 2}
 {c: 1, 'd' => 5}
@@ -1667,8 +1653,6 @@ The supported styles are:
 {:a => 1, :b => 2}
 ```
 ```ruby
-"EnforcedStyle => 'no_mixed_keys'"
-
 # bad
 {:a => 1, b: 2}
 {c: 1, 'd' => 2}
@@ -1678,8 +1662,6 @@ The supported styles are:
 {c: 1, d: 2}
 ```
 ```ruby
-"EnforcedStyle => 'ruby19_no_mixed_keys'"
-
 # bad
 {:a => 1, :b => 2}
 {c: 2, 'd' => 3} # should just use hash rockets
@@ -1994,8 +1976,6 @@ and multiline lambdas as well.
 ### Example
 
 ```ruby
-# EnforcedStyle: line_count_dependent (default)
-
 # bad
 f = lambda { |x| x }
 f = ->(x) do
@@ -2009,8 +1989,6 @@ f = lambda do |x|
     end
 ```
 ```ruby
-# EnforcedStyle: lambda
-
 # bad
 f = ->(x) { x }
 f = ->(x) do
@@ -2024,8 +2002,6 @@ f = lambda do |x|
     end
 ```
 ```ruby
-# EnforcedStyle: literal
-
 # bad
 f = lambda { |x| x }
 f = lambda do |x|
@@ -2331,8 +2307,6 @@ but it can be configured to enforce grouping them in one declaration.
 ### Example
 
 ```ruby
-EnforcedStyle: separated (default)
-
 # bad
 class Foo
   include Bar, Qox
@@ -2343,9 +2317,8 @@ class Foo
   include Qox
   include Bar
 end
-
-EnforcedStyle: grouped
-
+```
+```ruby
 # bad
 class Foo
   extend Bar
@@ -2435,13 +2408,26 @@ implications to each approach.
 ### Example
 
 ```ruby
-# Good if EnforcedStyle is module_function
+# bad
+module Test
+  extend self
+  ...
+end
+
+# good
+module Test
+  module_function
+  ...
+end
+```
+```ruby
+# bad
 module Test
   module_function
   ...
 end
 
-# Good if EnforcedStyle is extend_self
+# good
 module Test
   extend self
   ...
@@ -2517,10 +2503,13 @@ Checks for uses of the `then` keyword in multi-line if statements.
 ### Example
 
 ```ruby
+# bad
+# This is considered bad practice.
 if cond then
 end
-```
-```ruby
+
+# good
+# If statements can contain `then` on the same line.
 if cond then a
 elsif cond then b
 end
@@ -2541,8 +2530,6 @@ This cop checks expressions wrapping styles for multiline memoization.
 ### Example
 
 ```ruby
-# EnforcedStyle: keyword (default)
-
 # bad
 foo ||= (
   bar
@@ -2556,8 +2543,6 @@ foo ||= begin
 end
 ```
 ```ruby
-# EnforcedStyle: braces
-
 # bad
 foo ||= begin
   bar
@@ -2646,15 +2631,8 @@ without else are considered. There are three different styles:
 ### Example
 
 ```ruby
-# EnforcedStyle: both
 # enforces `unless` for `prefix` and `postfix` conditionals
 
-# good
-
-unless foo
-  bar
-end
-
 # bad
 
 if !foo
@@ -2663,22 +2641,21 @@ end
 
 # good
 
-bar unless foo
+unless foo
+  bar
+end
 
 # bad
 
 bar if !foo
+
+# good
+
+bar unless foo
 ```
 ```ruby
-# EnforcedStyle: prefix
 # enforces `unless` for just `prefix` conditionals
 
-# good
-
-unless foo
-  bar
-end
-
 # bad
 
 if !foo
@@ -2687,19 +2664,24 @@ end
 
 # good
 
-bar if !foo
-```
-```ruby
-# EnforcedStyle: postfix
-# enforces `unless` for just `postfix` conditionals
+unless foo
+  bar
+end
 
 # good
 
-bar unless foo
+bar if !foo
+```
+```ruby
+# enforces `unless` for just `postfix` conditionals
 
 # bad
 
 bar if !foo
+
+# good
+
+bar unless foo
 
 # good
 
@@ -2997,8 +2979,6 @@ not themselves `Interger` polymorphic.
 ### Example
 
 ```ruby
-# EnforcedStyle: predicate (default)
-
 # bad
 
 foo == 0
@@ -3012,8 +2992,6 @@ foo.negative?
 bar.baz.positive?
 ```
 ```ruby
-# EnforcedStyle: comparison
-
 # bad
 
 foo.zero?
@@ -3292,8 +3270,6 @@ names also.
 ### Example
 
 ```ruby
-# EnforcedStyle: short (default)
-
 # bad
 Hash#has_key?
 Hash#has_value?
@@ -3303,8 +3279,6 @@ Hash#key?
 Hash#value?
 ```
 ```ruby
-# EnforcedStyle: verbose
-
 # bad
 Hash#key?
 Hash#value?
@@ -3367,8 +3341,6 @@ passed multiple arguments.
 ### Example
 
 ```ruby
-# EnforcedStyle: exploded
-
 # bad
 raise StandardError.new("message")
 
@@ -3379,8 +3351,6 @@ raise MyCustomError.new(arg1, arg2, arg3)
 raise MyKwArgError.new(key1: val1, key2: val2)
 ```
 ```ruby
-# EnforcedStyle: compact
-
 # bad
 raise StandardError, "message"
 raise RuntimeError, arg1, arg2, arg3
@@ -3726,8 +3696,6 @@ Supported styles are: return, return_nil.
 ### Example
 
 ```ruby
-# EnforcedStyle: return (default)
-
 # bad
 def foo(arg)
   return nil if arg
@@ -3737,9 +3705,8 @@ end
 def foo(arg)
   return if arg
 end
-
-# EnforcedStyle: return_nil
-
+```
+```ruby
 # bad
 def foo(arg)
   return if arg
@@ -3967,16 +3934,17 @@ There are two different styles. Defaults to `require_parentheses`.
 ### Example
 
 ```ruby
-# require_parentheses - bad
+# bad
 ->a,b,c { a + b + c }
 
-# require_parentheses - good
+# good
 ->(a,b,c) { a + b + c}
-
-# require_no_parentheses - bad
+```
+```ruby
+# bad
 ->(a,b,c) { a + b + c }
 
-# require_no_parentheses - good
+# good
 ->a,b,c { a + b + c}
 ```
 
@@ -4070,8 +4038,6 @@ match the configured preference.
 ### Example
 
 ```ruby
-# EnforcedStyle: single_quotes
-
 # bad
 result = "Tests #{success ? "PASS" : "FAIL"}"
 
@@ -4079,8 +4045,6 @@ result = "Tests #{success ? "PASS" : "FAIL"}"
 result = "Tests #{success ? 'PASS' : 'FAIL'}"
 ```
 ```ruby
-# EnforcedStyle: double_quotes
-
 # bad
 result = "Tests #{success ? 'PASS' : 'FAIL'}"
 
@@ -4153,8 +4117,6 @@ of 2 or fewer elements.
 ### Example
 
 ```ruby
-EnforcedStyle: percent (default)
-
 # good
 %i[foo bar baz]
 
@@ -4162,8 +4124,6 @@ EnforcedStyle: percent (default)
 [:foo, :bar, :baz]
 ```
 ```ruby
-EnforcedStyle: brackets
-
 # good
 [:foo, :bar, :baz]
 
@@ -4239,8 +4199,6 @@ removing the parentheses won't cause a different behavior.
 ### Example
 
 ```ruby
-EnforcedStyle: require_no_parentheses (default)
-
 # bad
 foo = (bar?) ? a : b
 foo = (bar.baz?) ? a : b
@@ -4252,8 +4210,6 @@ foo = bar.baz? ? a : b
 foo = bar && baz ? a : b
 ```
 ```ruby
-EnforcedStyle: require_parentheses
-
 # bad
 foo = bar? ? a : b
 foo = bar.baz? ? a : b
@@ -4265,8 +4221,6 @@ foo = (bar.baz?) ? a : b
 foo = (bar && baz) ? a : b
 ```
 ```ruby
-EnforcedStyle: require_parentheses_when_complex
-
 # bad
 foo = (bar?) ? a : b
 foo = (bar.baz?) ? a : b
@@ -4297,22 +4251,36 @@ This cop checks for trailing comma in argument lists.
 ### Example
 
 ```ruby
-# always bad
+# bad
 method(1, 2,)
 
-# good if EnforcedStyleForMultiline is consistent_comma
+# good
 method(
   1, 2,
   3,
 )
 
-# good if EnforcedStyleForMultiline is comma or consistent_comma
+# good
 method(
   1,
   2,
 )
+```
+```ruby
+# bad
+method(1, 2,)
 
-# good if EnforcedStyleForMultiline is no_comma
+# good
+method(
+  1,
+  2,
+)
+```
+```ruby
+# bad
+method(1, 2,)
+
+# good
 method(
   1,
   2
@@ -4341,22 +4309,36 @@ This cop checks for trailing comma in array and hash literals.
 ### Example
 
 ```ruby
-# always bad
+# bad
 a = [1, 2,]
 
-# good if EnforcedStyleForMultiline is consistent_comma
+# good
 a = [
   1, 2,
   3,
 ]
 
-# good if EnforcedStyleForMultiline is comma or consistent_comma
+# good
 a = [
   1,
   2,
 ]
+```
+```ruby
+# bad
+a = [1, 2,]
 
-# good if EnforcedStyleForMultiline is no_comma
+# good
+a = [
+  1,
+  2,
+]
+```
+```ruby
+# bad
+a = [1, 2,]
+
+# good
 a = [
   1,
   2
@@ -4587,8 +4569,6 @@ array of 2 or fewer elements.
 ### Example
 
 ```ruby
-EnforcedStyle: percent (default)
-
 # good
 %w[foo bar baz]
 
@@ -4596,8 +4576,6 @@ EnforcedStyle: percent (default)
 ['foo', 'bar', 'baz']
 ```
 ```ruby
-EnforcedStyle: brackets
-
 # good
 ['foo', 'bar', 'baz']
 
@@ -4631,8 +4609,6 @@ way as they would be ordered in spoken English.
 ### Example
 
 ```ruby
-# EnforcedStyle: all_comparison_operators
-
 # bad
 99 == foo
 "bar" != foo
@@ -4646,8 +4622,6 @@ foo <= 42
 bar > 10
 ```
 ```ruby
-# EnforcedStyle: equality_operators_only
-
 # bad
 99 == foo
 "bar" != foo


### PR DESCRIPTION
Follow up of https://github.com/bbatsov/rubocop/pull/4880#issuecomment-338499947.

This PR applied a new style to some `Style` department cops, the same policy as #4978.

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Used the same coding conventions as the rest of the project.
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [ ] Added tests.
* [ ] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] All tests(`rake spec`) are passing.
* [x] The new code doesn't generate RuboCop offenses that are checked by `rake internal_investigation`.
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Updated cop documentation with `rake generate_cops_documentation` (required only when you've added a new cop or changed the configuration/documentation of an existing cop).

[1]: http://chris.beams.io/posts/git-commit/
