### PR TITLE
Restyle the example formatting for Lint cops

### DIFF
--- a/lib/rubocop/cop/lint/block_alignment.rb
+++ b/lib/rubocop/cop/lint/block_alignment.rb
@@ -18,8 +18,7 @@ module RuboCop
       # `either` (which is the default) : the `end` is allowed to be in either
       # location. The autofixer will default to `start_of_line`.
       #
-      # @example
-      #
+      # @example EnforcedStyleAlignWith: either (default)
       #   # bad
       #
       #   foo.bar
@@ -27,19 +26,19 @@ module RuboCop
       #        baz
       #          end
       #
-      # @example
-      #
-      #   # EnforcedStyleAlignWith: either (default)
-      #
       #   # good
       #
       #   variable = lambda do |i|
       #     i
       #   end
       #
-      # @example
+      # @example EnforcedStyleAlignWith: start_of_block
+      #   # bad
       #
-      #   # EnforcedStyleAlignWith: start_of_block
+      #   foo.bar
+      #      .each do
+      #        baz
+      #          end
       #
       #   # good
       #
@@ -48,9 +47,13 @@ module RuboCop
       #        baz
       #      end
       #
-      # @example
+      # @example EnforcedStyleAlignWith: start_of_line
+      #   # bad
       #
-      #   # EnforcedStyleAlignWith: start_of_line
+      #   foo.bar
+      #      .each do
+      #        baz
+      #          end
       #
       #   # good
       #

--- a/lib/rubocop/cop/lint/def_end_alignment.rb
+++ b/lib/rubocop/cop/lint/def_end_alignment.rb
@@ -12,25 +12,22 @@ module RuboCop
       # keyword is. If it's set to `def`, the `end` shall be aligned with the
       # `def` keyword.
       #
-      # @example
-      #
+      # @example EnforcedStyleAlignWith: start_of_line (default)
       #   # bad
       #
       #   private def foo
       #               end
-      #
-      # @example
-      #
-      #   # EnforcedStyleAlignWith: start_of_line (default)
       #
       #   # good
       #
       #   private def foo
       #   end
       #
-      # @example
+      # @example EnforcedStyleAlignWith: def
+      #   # bad
       #
-      #   # EnforcedStyleAlignWith: def
+      #   private def foo
+      #               end
       #
       #   # good
       #

--- a/lib/rubocop/cop/lint/end_alignment.rb
+++ b/lib/rubocop/cop/lint/end_alignment.rb
@@ -24,27 +24,33 @@ module RuboCop
       #   variable = if true
       #       end
       #
-      # @example
+      # @example EnforcedStyleAlignWith: keyword (default)
+      #   # bad
       #
-      #   # EnforcedStyleAlignWith: keyword (default)
+      #   variable = if true
+      #       end
       #
       #   # good
       #
       #   variable = if true
       #              end
       #
-      # @example
+      # @example EnforcedStyleAlignWith: variable
+      #   # bad
       #
-      #   # EnforcedStyleAlignWith: variable
+      #   variable = if true
+      #       end
       #
       #   # good
       #
       #   variable = if true
       #   end
       #
-      # @example
+      # @example EnforcedStyleAlignWith: start_of_line
+      #   # bad
       #
-      #   # EnforcedStyleAlignWith: start_of_line
+      #   variable = if true
+      #       end
       #
       #   # good
       #

--- a/lib/rubocop/cop/lint/inherit_exception.rb
+++ b/lib/rubocop/cop/lint/inherit_exception.rb
@@ -8,23 +8,19 @@ module RuboCop
       # `StandardError`. It is configurable to suggest using either
       # `RuntimeError` (default) or `StandardError` instead.
       #
-      # @example
-      #
+      # @example EnforcedStyle: runtime_error (default)
       #   # bad
       #
       #   class C < Exception; end
-      #
-      # @example
-      #
-      #   # EnforcedStyle: runtime_error (default)
       #
       #   # good
       #
       #   class C < RuntimeError; end
       #
-      # @example
+      # @example EnforcedStyle: standard_error
+      #   # bad
       #
-      #   # EnforcedStyle: standard_error
+      #   class C < Exception; end
       #
       #   # good
       #

--- a/manual/cops_lint.md
+++ b/manual/cops_lint.md
@@ -154,9 +154,6 @@ foo.bar
    .each do
      baz
        end
-```
-```ruby
-# EnforcedStyleAlignWith: either (default)
 
 # good
 
@@ -165,7 +162,12 @@ variable = lambda do |i|
 end
 ```
 ```ruby
-# EnforcedStyleAlignWith: start_of_block
+# bad
+
+foo.bar
+   .each do
+     baz
+       end
 
 # good
 
@@ -175,7 +177,12 @@ foo.bar
    end
 ```
 ```ruby
-# EnforcedStyleAlignWith: start_of_line
+# bad
+
+foo.bar
+   .each do
+     baz
+       end
 
 # good
 
@@ -356,9 +363,6 @@ keyword is. If it's set to `def`, the `end` shall be aligned with the
 
 private def foo
             end
-```
-```ruby
-# EnforcedStyleAlignWith: start_of_line (default)
 
 # good
 
@@ -366,7 +370,10 @@ private def foo
 end
 ```
 ```ruby
-# EnforcedStyleAlignWith: def
+# bad
+
+private def foo
+            end
 
 # good
 
@@ -714,7 +721,10 @@ variable = if true
     end
 ```
 ```ruby
-# EnforcedStyleAlignWith: keyword (default)
+# bad
+
+variable = if true
+    end
 
 # good
 
@@ -722,7 +732,10 @@ variable = if true
            end
 ```
 ```ruby
-# EnforcedStyleAlignWith: variable
+# bad
+
+variable = if true
+    end
 
 # good
 
@@ -730,7 +743,10 @@ variable = if true
 end
 ```
 ```ruby
-# EnforcedStyleAlignWith: start_of_line
+# bad
+
+variable = if true
+    end
 
 # good
 
@@ -1001,16 +1017,15 @@ and its standard library subclasses, excluding subclasses of
 # bad
 
 class C < Exception; end
-```
-```ruby
-# EnforcedStyle: runtime_error (default)
 
 # good
 
 class C < RuntimeError; end
 ```
 ```ruby
-# EnforcedStyle: standard_error
+# bad
+
+class C < Exception; end
 
 # good
 


### PR DESCRIPTION
Follow up of https://github.com/bbatsov/rubocop/pull/4880#issuecomment-338499947.

This commit is a change of document format. Cops of `Lint` department are the target.

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Used the same coding conventions as the rest of the project.
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [ ] Added tests.
* [ ] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] All tests(`rake spec`) are passing.
* [x] The new code doesn't generate RuboCop offenses that are checked by `rake internal_investigation`.
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Updated cop documentation with `rake generate_cops_documentation` (required only when you've added a new cop or changed the configuration/documentation of an existing cop).

[1]: http://chris.beams.io/posts/git-commit/
