### PR TITLE
Add new InternalAffairs/NodeDestructuring cop

### DIFF
--- a/lib/rubocop/cop/internal_affairs.rb
+++ b/lib/rubocop/cop/internal_affairs.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 
+require_relative 'internal_affairs/node_destructuring'
 require_relative 'internal_affairs/node_type_predicate'
 require_relative 'internal_affairs/offense_location_keyword'
 require_relative 'internal_affairs/redundant_message_argument'

--- a/lib/rubocop/cop/internal_affairs/node_destructuring.rb
+++ b/lib/rubocop/cop/internal_affairs/node_destructuring.rb
@@ -1,0 +1,46 @@
+# frozen_string_literal: true
+
+module RuboCop
+  module Cop
+    module InternalAffairs
+      # Checks that node destructuring is done either using the node
+      # extensions or using a splat.
+      #
+      # @example Using splat expansion
+      #
+      #   # bad
+      #   receiver, method_name, arguments = send_node.children
+      #
+      #   # good
+      #   receiver, method_name, arguments = *send_node
+      #
+      # @example Using node extensions
+      #
+      #   # bad
+      #   _receiver, method_name, _arguments = send_node.children
+      #
+      #   # good
+      #   method_name = send_node.method_name
+      class NodeDestructuring < Cop
+        MSG = 'Use the methods provided with the node extensions, or ' \
+              'destructure the node using `*`.'.freeze
+
+        def_node_matcher :node_children_destructuring?, <<-PATTERN
+          (masgn (mlhs ...) (send (send nil? [#node_suffix? _]) :children))
+        PATTERN
+
+        def on_masgn(node)
+          node_children_destructuring?(node) do
+            add_offense(node)
+          end
+        end
+
+        private
+
+        def node_suffix?(method_name)
+          method_name.to_s.end_with?('node')
+        end
+      end
+    end
+  end
+end

--- a/spec/rubocop/cop/internal_affairs/node_destructuring_spec.rb
+++ b/spec/rubocop/cop/internal_affairs/node_destructuring_spec.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+describe RuboCop::Cop::InternalAffairs::NodeDestructuring do
+  subject(:cop) { described_class.new }
+
+  context 'when destructuring using `node.children`' do
+    it 'registers an offense when receiver is named `node`' do
+      expect_offense(<<-RUBY, 'example_cop.rb')
+        lhs, rhs = node.children
+        ^^^^^^^^^^^^^^^^^^^^^^^^ Use the methods provided with the node extensions, or destructure the node using `*`.
+      RUBY
+    end
+
+    it 'registers an offense when receiver is named `send_node`' do
+      expect_offense(<<-RUBY, 'example_cop.rb')
+        lhs, rhs = send_node.children
+        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Use the methods provided with the node extensions, or destructure the node using `*`.
+      RUBY
+    end
+  end
+
+  it 'does not register an offense for a predicate node type check' do
+    expect_no_offenses(<<-RUBY, 'example_spec.rb')
+      lhs, rhs = *node
+    RUBY
+  end
+
+  it 'does not register an offense when receiver is named `array`' do
+    expect_no_offenses(<<-RUBY, 'example_spec.rb')
+      lhs, rhs = array.children
+    RUBY
+  end
+end


### PR DESCRIPTION
This cop checks for use of `#children` for node destructuring, e.g.:

```ruby
lhs, rhs = node.children
```

and recommends using either node extension methods or splat expansion.

This can surely be expanded on later, but the initial implementation should save @bbatsov quite a few PR comments. 😉 

I don't want to add auto-correct for this cop, because I want to encourage developers to go and look through the node extension methods.

-----------------

Before submitting the PR make sure the following are checked:

* [X] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [X] Used the same coding conventions as the rest of the project.
* [X] Feature branch is up-to-date with `master` (if not - rebase it).
* [X] Squashed related commits together.
* [X] Added tests.
* [ ] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [X] All tests(`rake spec`) are passing.
* [X] The new code doesn't generate RuboCop offenses that are checked by `rake internal_investigation`.
* [X] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [X] Updated cop documentation with `rake generate_cops_documentation` (required only when you've added a new cop or changed the configuration/documentation of an existing cop).

[1]: http://chris.beams.io/posts/git-commit/
