### PR TITLE
[Fix #5016] Allow capitals with accents in Style/ConstantName

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@
 
 * [#5096](https://github.com/bbatsov/rubocop/issues/5096): Fix incorrect detection and autocorrection of multiple extend/include/prepend. ([@marcandre][])
 * [#4662](https://github.com/bbatsov/rubocop/issues/4662): Fix incorrect indent level detection when first line of heredoc is blank. ([@sambostock][])
+* [#5016](https://github.com/bbatsov/rubocop/issues/5016): Fix a false positive for `Style/ConstantName` with constant names using non-ASCII capital letters with accents. ([@timrogers][])
 * [#4866](https://github.com/bbatsov/rubocop/issues/4866): Prevent `Layout/BlockEndNewline` cop from introducing trailing whitespaces. ([@bgeuken][])
 * [#3396](https://github.com/bbatsov/rubocop/issues/3396): Concise error when config. file not found. ([@jaredbeck][])
 * [#4881](https://github.com/bbatsov/rubocop/issues/4881): Fix a false positive for `Performance/HashEachMethods` when unused argument(s) exists in other blocks. ([@pocke][])

--- a/lib/rubocop/cop/naming/constant_name.rb
+++ b/lib/rubocop/cop/naming/constant_name.rb
@@ -19,7 +19,9 @@ module RuboCop
       #   INCH_IN_CM = 2.54
       class ConstantName < Cop
         MSG = 'Use SCREAMING_SNAKE_CASE for constants.'.freeze
-        SNAKE_CASE = /^[\dA-Z_]+$/
+        # Use POSIX character classes, so we allow accented characters rather
+        # than just standard ASCII characters
+        SNAKE_CASE = /^[[:digit:][:upper:]_]+$/
 
         def_node_matcher :class_or_struct_return_method?, <<-PATTERN
           (send

--- a/spec/rubocop/cop/naming/constant_name_spec.rb
+++ b/spec/rubocop/cop/naming/constant_name_spec.rb
@@ -18,6 +18,13 @@ describe RuboCop::Cop::Naming::ConstantName do
     RUBY
   end
 
+  it 'registers an offense for non-POSIX upper case in const name' do
+    expect_offense(<<-RUBY.strip_indent)
+      Nö = 'no'
+      ^^ Use SCREAMING_SNAKE_CASE for constants.
+    RUBY
+  end
+
   it 'registers offenses for camel case in multiple const assignment' do
     expect_offense(<<-RUBY.strip_indent)
       TopCase, Test2, TEST_3 = 5, 6, 7
@@ -46,6 +53,10 @@ describe RuboCop::Cop::Naming::ConstantName do
 
   it 'allows screaming snake case in multiple const assignment' do
     expect_no_offenses('TOP_TEST, TEST_2 = 5, 6')
+  end
+
+  it 'allows screaming snake case with POSIX upper case characters' do
+    expect_no_offenses('TÖP_TEST = 5')
   end
 
   it 'does not check names if rhs is a method call' do


### PR DESCRIPTION
`Rubocop::Cop::Style::ConstantName` enforces that constant names must be written using SCREAMING_SNAKE_CASE, by comparing them to its regex, `SNAKE_CASE`.

Capital letters can have accents, but the regular expression only permits unaccented letters A-Z.

This modifies the regular expression to also permit capital letters with accents using [POSIX character classes][], and adds a spec confirming this behaviour.

Fixes https://github.com/bbatsov/rubocop/issues/5016.

[POSIX character classes]: https://en.wikibooks.org/wiki/Regular_Expressions/POSIX_Basic_Regular_Expressions#Character_classes

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Used the same coding conventions as the rest of the project.
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] All tests(`rake spec`) are passing.
* [x] The new code doesn't generate RuboCop offenses that are checked by `rake internal_investigation`.
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Updated cop documentation with `rake generate_cops_documentation` (required only when you've added a new cop or changed the configuration/documentation of an existing cop).

[1]: http://chris.beams.io/posts/git-commit/
