### PR TITLE
add possibility to allow certain non ascii chars in comments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 * [#4892](https://github.com/bbatsov/rubocop/issues/4892): Add new `Lint/ShadowedArgument` cop and remove argument shadowing detection from `Lint/UnusedBlockArgument` and `Lint/UnusedMethodArgument`. ([@akhramov][])
 * [#4674](https://github.com/bbatsov/rubocop/issues/4674): Add a new `Lint/MissingCopEnableDirective` cop. ([@tdeo][])
 * Add new `Rails/EnvironmentComparison` cop. ([@tdeo][])
+* Add `AllowedChars` option to `Style/AsciiComments` cop. ([@hedgesky][])
 
 ### Bug fixes
 

--- a/config/default.yml
+++ b/config/default.yml
@@ -677,6 +677,9 @@ Style/AndOr:
     - always
     - conditionals
 
+Style/AsciiComments:
+  AllowedChars: []
+
 # Checks if usage of `%()` or `%Q()` matches configuration.
 Style/BarePercentLiterals:
   EnforcedStyle: bare_percent

--- a/lib/rubocop/cop/style/ascii_comments.rb
+++ b/lib/rubocop/cop/style/ascii_comments.rb
@@ -6,7 +6,8 @@ module RuboCop
   module Cop
     module Style
       # This cop checks for non-ascii (non-English) characters
-      # in comments.
+      # in comments. You could set an array of allowed non-ascii chars in
+      # AllowedChars attribute (empty by default).
       #
       # @example
       #   # bad
@@ -19,9 +20,9 @@ module RuboCop
 
         def investigate(processed_source)
           processed_source.comments.each do |comment|
-            unless comment.text.ascii_only?
-              add_offense(comment, location: first_offense_range(comment))
-            end
+            next if comment.text.ascii_only?
+            next if only_allowed_non_ascii_chars?(comment.text)
+            add_offense(comment, location: first_offense_range(comment))
           end
         end
 
@@ -40,6 +41,15 @@ module RuboCop
 
         def first_non_ascii_chars(string)
           string.match(/[^[:ascii:]]+/).to_s
+        end
+
+        def only_allowed_non_ascii_chars?(string)
+          non_ascii = string.scan(/[^[:ascii:]]/)
+          (non_ascii - allowed_non_ascii_chars).empty?
+        end
+
+        def allowed_non_ascii_chars
+          cop_config['AllowedChars'] || []
         end
       end
     end

--- a/manual/cops_style.md
+++ b/manual/cops_style.md
@@ -122,7 +122,8 @@ Enabled by default | Supports autocorrection
 Enabled | No
 
 This cop checks for non-ascii (non-English) characters
-in comments.
+in comments. You could set an array of allowed non-ascii chars in
+AllowedChars attribute (empty by default).
 
 ### Example
 
@@ -133,6 +134,12 @@ in comments.
 # good
 # Translates from English to Japanese
 ```
+
+### Important attributes
+
+Attribute | Value
+--- | ---
+AllowedChars |
 
 ### References
 

--- a/spec/rubocop/cop/style/ascii_comments_spec.rb
+++ b/spec/rubocop/cop/style/ascii_comments_spec.rb
@@ -22,4 +22,22 @@ describe RuboCop::Cop::Style::AsciiComments do
   it 'accepts comments with only ascii chars' do
     expect_no_offenses('# AZaz1@$%~,;*_`|')
   end
+
+  context 'when certain non-ascii chars are allowed', :config do
+    subject(:cop) { described_class.new(config) }
+
+    let(:cop_config) { { 'AllowedChars' => ['∂'] } }
+
+    it 'accepts comment with allowed non-ascii chars' do
+      expect_no_offenses('# foo ∂ bar')
+    end
+
+    it 'registers an offense for commentes with non-allowed non-ascii chars' do
+      expect_offense(<<-RUBY.strip_indent)
+        # encoding: utf-8
+        # 这是什么？
+          ^^^^^ Use only ascii symbols in comments.
+      RUBY
+    end
+  end
 end


### PR DESCRIPTION
The reason behind this PR: from time to time I use dash symbol (—) in comments; Rubocop treats it as non-ascii symbol and fires an offense. As I don't wont to turn off the cop completely, I decided to make it configurable.

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Used the same coding conventions as the rest of the project.
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] All tests(`rake spec`) are passing.
* [x] The new code doesn't generate RuboCop offenses that are checked by `rake internal_investigation`.
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Updated cop documentation with `rake generate_cops_documentation` (required only when you've added a new cop or changed the configuration/documentation of an existing cop).

[1]: http://chris.beams.io/posts/git-commit/
