### PR TITLE
[Fix 4363] Fix false offenses detected by `Style/PercentLiteralDelimiters` cop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@
 * [#3363](https://github.com/bbatsov/rubocop/pull/3363): Fix `Style/EmptyElse` autocorrection removes comments from branches. ([@dpostorivo][])
 * [#5025](https://github.com/bbatsov/rubocop/issues/5025): Fix error with Layout/MultilineMethodCallIndentation cop and lambda.(...). ([@dpostorivo][])
 * [#4781](https://github.com/bbatsov/rubocop/issues/4781): Prevent `Style/UnneededPercentQ` from breaking on strings that are concated with backslash. ([@pocke][])
+* [#4363](https://github.com/bbatsov/rubocop/issues/4363): Fix `Style/PercentLiteralDelimiters` incorrectly automatically modifies escaped percent literal delimiter. ([@koic][])
 
 ### Changes
 

--- a/lib/rubocop/cop/style/percent_literal_delimiters.rb
+++ b/lib/rubocop/cop/style/percent_literal_delimiters.rb
@@ -71,7 +71,8 @@ module RuboCop
         def on_percent_literal(node)
           type = type(node)
           return if uses_preferred_delimiter?(node, type) ||
-                    contains_preferred_delimiter?(node, type)
+                    contains_preferred_delimiter?(node, type) ||
+                    include_same_character_as_used_for_delimiter?(node, type)
 
           add_offense(node)
         end
@@ -87,12 +88,32 @@ module RuboCop
             .any? { |s| preferred_delimiters.any? { |d| s.include?(d) } }
         end
 
+        def include_same_character_as_used_for_delimiter?(node, type)
+          return false unless %w[%w %i].include?(type)
+
+          used_delimiters = matchpairs(begin_source(node)[-1])
+          escaped_delimiters = used_delimiters.map { |d| "\\#{d}" }.join('|')
+
+          node
+            .children.map { |n| string_source(n) }.compact
+            .any? { |s| Regexp.new(escaped_delimiters) =~ s }
+        end
+
         def string_source(node)
           if node.is_a?(String)
             node
           elsif node.respond_to?(:type) && node.str_type?
             node.source
           end
+        end
+
+        def matchpairs(begin_delimiter)
+          {
+            '(' => %w[( )],
+            '[' => %w[[ ]],
+            '{' => %w[{ }],
+            '<' => %w[< >]
+          }.fetch(begin_delimiter, [begin_delimiter])
         end
       end
     end

--- a/spec/rubocop/cop/style/percent_literal_delimiters_spec.rb
+++ b/spec/rubocop/cop/style/percent_literal_delimiters_spec.rb
@@ -108,6 +108,21 @@ describe RuboCop::Cop::Style::PercentLiteralDelimiters, :config do
       expect_no_offenses('%w[some words]')
     end
 
+    it 'does not register an offense for preferred delimiters ' \
+       'with a pairing delimiters' do
+      expect_no_offenses('%w(\(some words\))')
+    end
+
+    it 'does not register an offense for preferred delimiters ' \
+       'with only a closing delimiter' do
+      expect_no_offenses('%w(only closing delimiter charapter\))')
+    end
+
+    it 'does not register an offense for preferred delimiters ' \
+       'with not a pairing delimiter' do
+      expect_no_offenses('%w|\|not pairirng delimiter|')
+    end
+
     it 'registers an offense for other delimiters' do
       expect_offense(<<-RUBY.strip_indent)
         %w(some words)


### PR DESCRIPTION
Fixes #4363.

Percent notation targeted by Issue # 4363 are `%w` and `%i`.
`%W` and `%I` are not targets.

## %w / %W

The meaning changes.

```ruby
> %w(\() # => ["("]
> %w[\(] # => ["\\("]
```

The meaning does not change.

```ruby
> %W(\() # => ["("]
> %W[\(] # => ["("]
```

## %i / %I

The meaning changes.

```ruby
> %i(\() # => [:"("]
> %i[\(] # => [:"\\("]
```

The meaning does not change

```ruby
> %I(\() # => [:"("]
> %I[\(] # => [:"("]
```

Also, if we use open delimiter and closing delimiter like `(...)`, we need to target both of them.

```ruby
> %w(\() # => ["("]
> %w[\(] # => ["\\("]
> %w(\)) # => [")"]
> %w[\)] # => ["\\)"]
```

There are 4 cases of `%w(...)`, `%w[...]`, `%w{...}`, and `%w<...>`.

This commit changes so that it will not be offense if the same character as a percent notation delimiter is used for elements of an array.

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Used the same coding conventions as the rest of the project.
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] All tests(`rake spec`) are passing.
* [x] The new code doesn't generate RuboCop offenses that are checked by `rake internal_investigation`.
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [ ] Updated cop documentation with `rake generate_cops_documentation` (required only when you've added a new cop or changed the configuration/documentation of an existing cop).

[1]: http://chris.beams.io/posts/git-commit/
