### PR TITLE
[Fix #3001] Add configuration to `Lint/MissingCopEnableDirective`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -71,6 +71,7 @@
 * [#4449](https://github.com/bbatsov/rubocop/issues/4449): Make `Layout/IndentHeredoc` aware of line length. ([@pocke][])
 * [#5146](https://github.com/bbatsov/rubocop/pull/5146): Make `--show-cops` option aware of `--force-default-config`. ([@pocke][])
 
+* [#3001](https://github.com/bbatsov/rubocop/issues/3001): Add configuration to `Lint/MissingCopEnableDirective` cop. ([@tdeo][])
 ## 0.51.0 (2017-10-18)
 
 ### New features

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -70,8 +70,8 @@
 * [#5037](https://github.com/bbatsov/rubocop/pull/5037): Make display cop names to enable by default. ([@pocke][])
 * [#4449](https://github.com/bbatsov/rubocop/issues/4449): Make `Layout/IndentHeredoc` aware of line length. ([@pocke][])
 * [#5146](https://github.com/bbatsov/rubocop/pull/5146): Make `--show-cops` option aware of `--force-default-config`. ([@pocke][])
-
 * [#3001](https://github.com/bbatsov/rubocop/issues/3001): Add configuration to `Lint/MissingCopEnableDirective` cop. ([@tdeo][])
+
 ## 0.51.0 (2017-10-18)
 
 ### New features

--- a/config/default.yml
+++ b/config/default.yml
@@ -1480,6 +1480,16 @@ Lint/InheritException:
     - runtime_error
     - standard_error
 
+Lint/MissingCopEnableDirective:
+  # Maximum number of consecutive lines the cop can be disabled for.
+  # 0 allows only single-line disables
+  # 1 would mean the following is the maximum allowed is:
+  #   # rubocop:disable SomeCop
+  #   a = 1
+  #   # rubocop:enable SomeCop
+  # .inf for any size
+  MaximumRangeSize: .inf
+
 Lint/SafeNavigationChain:
   Whitelist:
     - present?

--- a/config/default.yml
+++ b/config/default.yml
@@ -1483,7 +1483,7 @@ Lint/InheritException:
 Lint/MissingCopEnableDirective:
   # Maximum number of consecutive lines the cop can be disabled for.
   # 0 allows only single-line disables
-  # 1 would mean the following is the maximum allowed is:
+  # 1 would mean the maximum allowed is the following:
   #   # rubocop:disable SomeCop
   #   a = 1
   #   # rubocop:enable SomeCop

--- a/lib/rubocop/cop/lint/missing_cop_enable_directive.rb
+++ b/lib/rubocop/cop/lint/missing_cop_enable_directive.rb
@@ -10,8 +10,8 @@ module RuboCop
       # a file wouldn't be aware of.
       #
       # @example
-      #   Lint/MissingCopEnableDirective
-      #     MaximumRangeSize: .inf
+      #   # Lint/MissingCopEnableDirective:
+      #   #   MaximumRangeSize: .inf
       #
       #   # good
       #   # rubocop:disable Layout/SpaceAroundOperators
@@ -26,8 +26,8 @@ module RuboCop
       #   # EOF
       #
       # @example
-      #   Lint/MissingCopEnableDirective
-      #     MaximumRangeSize: 2
+      #   # Lint/MissingCopEnableDirective:
+      #   #   MaximumRangeSize: 2
       #
       #   # good
       #   # rubocop:disable Layout/SpaceAroundOperators

--- a/lib/rubocop/cop/lint/missing_cop_enable_directive.rb
+++ b/lib/rubocop/cop/lint/missing_cop_enable_directive.rb
@@ -10,6 +10,9 @@ module RuboCop
       # a file wouldn't be aware of.
       #
       # @example
+      #   Lint/MissingCopEnableDirective
+      #     MaximumRangeSize: .inf
+      #
       #   # good
       #   # rubocop:disable Layout/SpaceAroundOperators
       #   x= 0
@@ -22,19 +25,51 @@ module RuboCop
       #   x= 0
       #   # EOF
       #
+      # @example
+      #   Lint/MissingCopEnableDirective
+      #     MaximumRangeSize: 2
+      #
+      #   # good
+      #   # rubocop:disable Layout/SpaceAroundOperators
+      #   x= 0
+      #   # With the previous, there are 2 lines on which cop is disabled.
+      #   # rubocop:enable Layout/SpaceAroundOperators
+      #
+      #   # bad
+      #   # rubocop:disable Layout/SpaceAroundOperators
+      #   x= 0
+      #   x += 1
+      #   # Including this, that's 3 lines on which the cop is disabled.
+      #   # rubocop:enable Layout/SpaceAroundOperators
+      #
       class MissingCopEnableDirective < Cop
         MSG = 'Re-enable %s cop with `# rubocop:enable` after disabling it.'
               .freeze
 
         def investigate(processed_source)
+          max_range = cop_config['MaximumRangeSize']
           processed_source.disabled_line_ranges.each do |cop, line_ranges|
             line_ranges.each do |line_range|
-              next unless line_range.max == Float::INFINITY
+              # This has to remain a strict inequality to handle
+              # the case when max_range is Float::INFINITY
+              next if line_range.max - line_range.min < max_range + 2
               range = source_range(processed_source.buffer,
                                    line_range.min,
                                    (0..0))
-              add_offense(range, location: range, message: format(MSG, cop))
+              add_offense(range,
+                          location: range,
+                          message: format(message(max_range), cop))
             end
+          end
+        end
+
+        private
+
+        def message(max_range)
+          if max_range == Float::INFINITY
+            MSG
+          else
+            "Re-enable %s cop within #{max_range} lines after disabling it."
           end
         end
       end

--- a/lib/rubocop/cop/lint/missing_cop_enable_directive.rb
+++ b/lib/rubocop/cop/lint/missing_cop_enable_directive.rb
@@ -43,8 +43,10 @@ module RuboCop
       #   # rubocop:enable Layout/SpaceAroundOperators
       #
       class MissingCopEnableDirective < Cop
-        MSG = 'Re-enable %s cop with `# rubocop:enable` after disabling it.'
+        MSG = 'Re-enable %{cop} cop with `# rubocop:enable` after disabling it.'
               .freeze
+        MSG_BOUND = 'Re-enable %{cop} cop within %{max_range} lines after ' \
+                    'disabling it.'.freeze
 
         def investigate(processed_source)
           max_range = cop_config['MaximumRangeSize']
@@ -58,18 +60,18 @@ module RuboCop
                                    (0..0))
               add_offense(range,
                           location: range,
-                          message: format(message(max_range), cop))
+                          message: message(max_range: max_range, cop: cop))
             end
           end
         end
 
         private
 
-        def message(max_range)
+        def message(max_range:, cop:)
           if max_range == Float::INFINITY
-            MSG
+            format(MSG, cop: cop)
           else
-            "Re-enable %s cop within #{max_range} lines after disabling it."
+            format(MSG_BOUND, cop: cop, max_range: max_range)
           end
         end
       end

--- a/manual/cops_lint.md
+++ b/manual/cops_lint.md
@@ -1205,11 +1205,11 @@ x += 1
 # rubocop:enable Layout/SpaceAroundOperators
 ```
 
-### Important attributes
+### Configurable attributes
 
-Attribute | Value
---- | ---
-MaximumRangeSize | Infinity
+Name | Default value | Configurable values
+--- | --- | ---
+MaximumRangeSize | `Infinity` | Float
 
 ## Lint/MultipleCompare
 

--- a/manual/cops_lint.md
+++ b/manual/cops_lint.md
@@ -1172,6 +1172,9 @@ a file wouldn't be aware of.
 ### Example
 
 ```ruby
+Lint/MissingCopEnableDirective
+  MaximumRangeSize: .inf
+
 # good
 # rubocop:disable Layout/SpaceAroundOperators
 x= 0
@@ -1184,6 +1187,29 @@ x= 0
 x= 0
 # EOF
 ```
+```ruby
+Lint/MissingCopEnableDirective
+  MaximumRangeSize: 2
+
+# good
+# rubocop:disable Layout/SpaceAroundOperators
+x= 0
+# With the previous, there are 2 lines on which cop is disabled.
+# rubocop:enable Layout/SpaceAroundOperators
+
+# bad
+# rubocop:disable Layout/SpaceAroundOperators
+x= 0
+x += 1
+# Including this, that's 3 lines on which the cop is disabled.
+# rubocop:enable Layout/SpaceAroundOperators
+```
+
+### Important attributes
+
+Attribute | Value
+--- | ---
+MaximumRangeSize | Infinity
 
 ## Lint/MultipleCompare
 

--- a/manual/cops_lint.md
+++ b/manual/cops_lint.md
@@ -1172,8 +1172,8 @@ a file wouldn't be aware of.
 ### Example
 
 ```ruby
-Lint/MissingCopEnableDirective
-  MaximumRangeSize: .inf
+# Lint/MissingCopEnableDirective:
+#   MaximumRangeSize: .inf
 
 # good
 # rubocop:disable Layout/SpaceAroundOperators
@@ -1188,8 +1188,8 @@ x= 0
 # EOF
 ```
 ```ruby
-Lint/MissingCopEnableDirective
-  MaximumRangeSize: 2
+# Lint/MissingCopEnableDirective:
+#   MaximumRangeSize: 2
 
 # good
 # rubocop:disable Layout/SpaceAroundOperators

--- a/manual/cops_style.md
+++ b/manual/cops_style.md
@@ -1569,13 +1569,12 @@ module Foo
 end
 ```
 
-### Important attributes
+### Configurable attributes
 
-Attribute | Value
---- | ---
-Autocorrect | false
-EnforcedStyle | module_function
-SupportedStyles | module_function, extend_self
+Name | Default value | Configurable values
+--- | --- | ---
+Autocorrect | `false` | Boolean
+EnforcedStyle | `module_function` | `module_function`, `extend_self`
 
 ### References
 

--- a/spec/rubocop/cop/lint/missing_cop_enable_directive_spec.rb
+++ b/spec/rubocop/cop/lint/missing_cop_enable_directive_spec.rb
@@ -1,25 +1,62 @@
 # frozen_string_literal: true
 
-describe RuboCop::Cop::Lint::MissingCopEnableDirective do
+describe RuboCop::Cop::Lint::MissingCopEnableDirective, :config do
   subject(:cop) { described_class.new(config) }
 
-  let(:config) { RuboCop::Config.new }
+  context 'when the maximum range size is infinite' do
+    let(:cop_config) { { 'MaximumRangeSize' => Float::INFINITY } }
 
-  it 'registers an offense when a cop is disabled and never re-enabled' do
-    expect_offense(<<-RUBY.strip_indent)
-      # rubocop:disable Layout/SpaceAroundOperators
-      ^ Re-enable Layout/SpaceAroundOperators cop with `# rubocop:enable` after disabling it.
-      x =   0
-      # Some other code
-    RUBY
+    it 'registers an offense when a cop is disabled and never re-enabled' do
+      expect_offense(<<-RUBY.strip_indent)
+        # rubocop:disable Layout/SpaceAroundOperators
+        ^ Re-enable Layout/SpaceAroundOperators cop with `# rubocop:enable` after disabling it.
+        x =   0
+        # Some other code
+      RUBY
+    end
+
+    it 'does not register an offense when the disable cop is re-enabled' do
+      expect_no_offenses(<<-RUBY.strip_indent)
+        # rubocop:disable Layout/SpaceAroundOperators
+        x =   0
+        # rubocop:enable Layout/SpaceAroundOperators
+        # Some other code
+      RUBY
+    end
   end
 
-  it 'does not register an offense when the disable cop is re-enabled' do
-    expect_no_offenses(<<-RUBY.strip_indent)
-      # rubocop:disable Layout/SpaceAroundOperators
-      x =   0
-      # rubocop:enable Layout/SpaceAroundOperators
-      # Some other code
-    RUBY
+  context 'when the maximum range size is finite' do
+    let(:cop_config) { { 'MaximumRangeSize' => 2 } }
+
+    it 'registers an offense when a cop is disabled for too many lines' do
+      expect_offense(<<-RUBY.strip_indent)
+        # rubocop:disable Layout/SpaceAroundOperators
+        ^ Re-enable Layout/SpaceAroundOperators cop within 2 lines after disabling it.
+        x =   0
+        y = 1
+        # Some other code
+        # rubocop:enable Layout/SpaceAroundOperators
+      RUBY
+    end
+
+    it 'registers an offense when a cop is disabled and never re-enabled' do
+      expect_offense(<<-RUBY.strip_indent)
+        # rubocop:disable Layout/SpaceAroundOperators
+        ^ Re-enable Layout/SpaceAroundOperators cop within 2 lines after disabling it.
+        x =   0
+        # Some other code
+      RUBY
+    end
+
+    it 'does not register an offense when the disable cop is re-enabled ' \
+       'within the limit' do
+      expect_no_offenses(<<-RUBY.strip_indent)
+        # rubocop:disable Layout/SpaceAroundOperators
+        x =   0
+        y = 1
+        # rubocop:enable Layout/SpaceAroundOperators
+        # Some other code
+      RUBY
+    end
   end
 end

--- a/tasks/cops_documentation.rake
+++ b/tasks/cops_documentation.rake
@@ -90,6 +90,8 @@ task generate_cops_documentation: :yard_for_generate_documentation do
         'String'
       when Integer
         'Integer'
+      when Float
+        'Float'
       when true, false
         'Boolean'
       when Array


### PR DESCRIPTION
This adds a `MaximumRangeSize` configuration option to the
`Lint/MissingCopEnableDirective` cop to allow customization of the
maximum number of consecutive lines a cop can be disabled for.

-----------------

Before submitting the PR make sure the following are checked:

* [ ] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [ ] Used the same coding conventions as the rest of the project.
* [ ] Feature branch is up-to-date with `master` (if not - rebase it).
* [ ] Squashed related commits together.
* [ ] Added tests.
* [x] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [ ] All tests(`rake spec`) are passing.
* [ ] The new code doesn't generate RuboCop offenses that are checked by `rake internal_investigation`.
* [ ] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [ ] Updated cop documentation with `rake generate_cops_documentation` (required only when you've added a new cop or changed the configuration/documentation of an existing cop).

[1]: http://chris.beams.io/posts/git-commit/
