### PR TITLE
[Fix #5025] Fix error with Layout/MultilineMethodCallIndentation cop and lambda.(...).

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@
 * [#4794](https://github.com/bbatsov/rubocop/issues/4794): Fix an error in `Layout/MultilineOperationIndentation` when an operation spans multiple lines and contains a ternary expression. ([@rrosenblum][])
 * [#4885](https://github.com/bbatsov/rubocop/issues/4885): Fix false offense detected by `Style/MixinUsage` cop. ([@koic][])
 * [#3363](https://github.com/bbatsov/rubocop/pull/3363): Fix `Style/EmptyElse` autocorrection removes comments from branches. ([@dpostorivo][])
+* [#5025](https://github.com/bbatsov/rubocop/issues/5025): Fix error with Layout/MultilineMethodCallIndentation cop and lambda.(...). ([@dpostorivo][])
 
 ### Changes
 

--- a/lib/rubocop/cop/layout/multiline_method_call_indentation.rb
+++ b/lib/rubocop/cop/layout/multiline_method_call_indentation.rb
@@ -167,7 +167,7 @@ module RuboCop
           return unless rhs.source.start_with?('.')
 
           node = semantic_alignment_node(node)
-          return unless node
+          return unless node && node.loc.selector
 
           node.loc.dot.join(node.loc.selector)
         end

--- a/spec/rubocop/cop/layout/multiline_method_call_indentation_spec.rb
+++ b/spec/rubocop/cop/layout/multiline_method_call_indentation_spec.rb
@@ -107,6 +107,13 @@ describe RuboCop::Cop::Layout::MultilineMethodCallIndentation do
       RUBY
       expect(cop.offenses.size).to eq(1)
     end
+
+    it "doesn't crash on unaligned multiline lambdas" do
+      expect_no_offenses(<<-RUBY.strip_indent)
+        MyClass.(my_args)
+          .my_method
+      RUBY
+    end
   end
 
   shared_examples 'common for aligned and indented' do


### PR DESCRIPTION
This fixes the issue described in #5025. The issue was `node.loc.selector` was nil. This just checks to make sure it is not nil before  trying the join.

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Used the same coding conventions as the rest of the project.
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] All tests(`rake spec`) are passing.
* [x] The new code doesn't generate RuboCop offenses that are checked by `rake internal_investigation`.
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [ ] Updated cop documentation with `rake generate_cops_documentation` (required only when you've added a new cop or changed the configuration/documentation of an existing cop).

[1]: http://chris.beams.io/posts/git-commit/
