### PR TITLE
[Fix #4781] Prevent `Style/UnneededPercentQ` from breaking on strings  that is concated with backslash

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@
 * [#4885](https://github.com/bbatsov/rubocop/issues/4885): Fix false offense detected by `Style/MixinUsage` cop. ([@koic][])
 * [#3363](https://github.com/bbatsov/rubocop/pull/3363): Fix `Style/EmptyElse` autocorrection removes comments from branches. ([@dpostorivo][])
 * [#5025](https://github.com/bbatsov/rubocop/issues/5025): Fix error with Layout/MultilineMethodCallIndentation cop and lambda.(...). ([@dpostorivo][])
+* [#4781](https://github.com/bbatsov/rubocop/issues/4781): Prevent `Style/UnneededPercentQ` from breaking on strings that are concated with backslash. ([@pocke][])
 
 ### Changes
 

--- a/lib/rubocop/cop/style/unneeded_percent_q.rb
+++ b/lib/rubocop/cop/style/unneeded_percent_q.rb
@@ -18,6 +18,7 @@ module RuboCop
         ESCAPED_NON_BACKSLASH = /\\[^\\]/
 
         def on_dstr(node)
+          return unless string_literal?(node)
           check(node)
         end
 

--- a/spec/rubocop/cop/style/unneeded_percent_q_spec.rb
+++ b/spec/rubocop/cop/style/unneeded_percent_q_spec.rb
@@ -65,6 +65,17 @@ describe RuboCop::Cop::Style::UnneededPercentQ do
 
         expect(new_source).to eq("'hi'")
       end
+
+      it 'auto-corrects for strings that is concated with backslash' do
+        new_source = autocorrect_source(<<-RUBY.strip_indent)
+          %q(foo bar baz) \
+            'boogers'
+        RUBY
+        expect(new_source).to eq(<<-RUBY.strip_indent)
+          'foo bar baz' \
+            'boogers'
+        RUBY
+      end
     end
   end
 
@@ -127,6 +138,17 @@ describe RuboCop::Cop::Style::UnneededPercentQ do
         new_source = autocorrect_source("%Q(hi\#{4})")
 
         expect(new_source).to eq(%("hi\#{4}"))
+      end
+
+      it 'auto-corrects for strings that is concated with backslash' do
+        new_source = autocorrect_source(<<-RUBY.strip_indent)
+          %Q(foo bar baz) \
+            'boogers'
+        RUBY
+        expect(new_source).to eq(<<-RUBY.strip_indent)
+          "foo bar baz" \
+            'boogers'
+        RUBY
       end
     end
   end


### PR DESCRIPTION
#4781

`Style/UnneededPercentQ` raises an error when it is auto-correcting the following code.

```ruby
puts %q(foo bar baz) \
  'boogers'
```

This change will fix this problem.



-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Used the same coding conventions as the rest of the project.
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] All tests(`rake spec`) are passing.
* [x] The new code doesn't generate RuboCop offenses that are checked by `rake internal_investigation`.
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Updated cop documentation with `rake generate_cops_documentation` (required only when you've added a new cop or changed the configuration/documentation of an existing cop).

[1]: http://chris.beams.io/posts/git-commit/
