### PR TITLE
Fix `nil` to `nil?` in the cop generator

### DIFF
--- a/lib/rubocop/cop/generator.rb
+++ b/lib/rubocop/cop/generator.rb
@@ -35,10 +35,10 @@ module RuboCop
                 # See. https://github.com/bbatsov/rubocop/blob/master/lib/rubocop/node_pattern.rb
                 #
                 # For example
-                MSG = 'Message of %<cop_name>s'.freeze
+                MSG = 'Use `#good_method` instead of `#bad_method`.'.freeze
 
                 def_node_matcher :bad_method?, <<-PATTERN
-                  (send nil :bad_method ...)
+                  (send nil? :bad_method ...)
                 PATTERN
 
                 def on_send(node)

--- a/spec/rubocop/cop/generator_spec.rb
+++ b/spec/rubocop/cop/generator_spec.rb
@@ -39,10 +39,10 @@ RSpec.describe RuboCop::Cop::Generator do
                 # See. https://github.com/bbatsov/rubocop/blob/master/lib/rubocop/node_pattern.rb
                 #
                 # For example
-                MSG = 'Message of FakeCop'.freeze
+                MSG = 'Use `#good_method` instead of `#bad_method`.'.freeze
 
                 def_node_matcher :bad_method?, <<-PATTERN
-                  (send nil :bad_method ...)
+                  (send nil? :bad_method ...)
                 PATTERN
 
                 def on_send(node)


### PR DESCRIPTION
Also fixes the initial `MSG` to match the real message and make
the tests pass in the first instance.

It's also related to #4815.

------------
Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Used the same coding conventions as the rest of the project.
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* (n/a) Added tests.
* (n/a) Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] All tests(`rake spec`) are passing.
* (n/a) The new code doesn't generate RuboCop offenses that are checked by `rake internal_investigation`.
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* (n/a) Updated cop documentation with `rake generate_cops_documentation` (required only when you've added a new cop or changed the configuration/documentation of an existing cop).

[1]: http://chris.beams.io/posts/git-commit/
