### PR TITLE
Update description of `Style/FrozenStringLiteralComment` cop

### DIFF
--- a/lib/rubocop/cop/style/frozen_string_literal_comment.rb
+++ b/lib/rubocop/cop/style/frozen_string_literal_comment.rb
@@ -5,7 +5,7 @@ module RuboCop
     module Style
       # This cop is designed to help upgrade to Ruby 3.0. It will add the
       # comment `# frozen_string_literal: true` to the top of files to
-      # enable frozen string literals. Frozen string literals will be default
+      # enable frozen string literals. Frozen string literals may be default
       # in Ruby 3.0. The comment will be added below a shebang and encoding
       # comment. The frozen string literal comment is only valid in Ruby 2.3+.
       class FrozenStringLiteralComment < Cop

--- a/manual/cops_style.md
+++ b/manual/cops_style.md
@@ -1517,7 +1517,7 @@ Enabled | Yes
 
 This cop is designed to help upgrade to Ruby 3.0. It will add the
 comment `# frozen_string_literal: true` to the top of files to
-enable frozen string literals. Frozen string literals will be default
+enable frozen string literals. Frozen string literals may be default
 in Ruby 3.0. The comment will be added below a shebang and encoding
 comment. The frozen string literal comment is only valid in Ruby 2.3+.
 


### PR DESCRIPTION
The following is Matz's comment.
https://bugs.ruby-lang.org/issues/8976#note-41

AFAIK, Frozen string literal will be default in Ruby 3.0 or not yet determinable.
Therefore, this commit makes the description somewhat vague.

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Used the same coding conventions as the rest of the project.
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [ ] Added tests.
* [ ] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] All tests(`rake spec`) are passing.
* [x] The new code doesn't generate RuboCop offenses that are checked by `rake internal_investigation`.
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [ ] Updated cop documentation with `rake generate_cops_documentation` (required only when you've added a new cop or changed the configuration/documentation of an existing cop).

[1]: http://chris.beams.io/posts/git-commit/
