### PR TITLE
[Fixes #5019] Make sure there are only one space before hash syntax

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@
 * [#4987](https://github.com/bbatsov/rubocop/pull/4987): Skip permission check when using stdin option. ([@mtsmfm][])
 * [#4909](https://github.com/bbatsov/rubocop/issues/4909): Make `Rails/HasManyOrHasOneDependent` aware of multiple associations in `with_options`. ([@koic][])
 * [#4794](https://github.com/bbatsov/rubocop/issues/4794): Fix an error in `Layout/MultilineOperationIndentation` when an operation spans multiple lines and contains a ternary expression. ([@rrosenblum][])
+* [#5019](https://github.com/bbatsov/rubocop/issues/5019): Fix an error in `Style/HashSyntax` when the hash is not separated by space with the method preceding it (e.g. `a:b => c`). ([@donjar][])
 
 ### Changes
 

--- a/lib/rubocop/cop/style/hash_syntax.rb
+++ b/lib/rubocop/cop/style/hash_syntax.rb
@@ -180,8 +180,20 @@ module RuboCop
 
           range = range_between(key.begin_pos, op.end_pos)
           range = range_with_surrounding_space(range, :right)
-          corrector.replace(range,
-                            range.source.sub(/^:(.*\S)\s*=>\s*$/, '\1: '))
+
+          hash_regex = /^:(.*\S)\s*=>\s*$/
+          if method_before_hash?(key)
+            corrector.replace(range,
+                              range.source.sub(hash_regex, ' \1: '))
+          else
+            corrector.replace(range,
+                              range.source.sub(hash_regex, '\1: '))
+          end
+        end
+
+        def method_before_hash?(key)
+          !key.begin_pos.zero? &&
+            processed_source.ast.source[key.begin_pos - 1] =~ /[^\s,{\[]/
         end
 
         def autocorrect_hash_rockets(corrector, node)


### PR DESCRIPTION
Previously, `a:b => c` gets auto-corrected erroneously to `ab: c`. This fix auto-corrects it to `a b: c` instead.

I am not very sure which tests to add/change, if any, since it seems that there is no way to only isolate a single cop (just like the `--only` option in the CLI)?

-----------------

Before submitting the PR make sure the following are checked:

* [X] Wrote [good commit messages][1].
* [X] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [X] Used the same coding conventions as the rest of the project.
* [X] Feature branch is up-to-date with `master` (if not - rebase it).
* [X] Squashed related commits together.
* [ ] Added tests.
* [X] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [X] All tests(`rake spec`) are passing.
* [X] The new code doesn't generate RuboCop offenses that are checked by `rake internal_investigation`.
* [X] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [X] Updated cop documentation with `rake generate_cops_documentation` (required only when you've added a new cop or changed the configuration/documentation of an existing cop).

[1]: http://chris.beams.io/posts/git-commit/
