### PR TITLE
[Fix #5019] Fix auto-correct for `Style/HashSyntax` cop when hash is used as unspaced argument

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@
 * [#3363](https://github.com/bbatsov/rubocop/pull/3363): Fix `Style/EmptyElse` autocorrection removes comments from branches. ([@dpostorivo][])
 * [#5025](https://github.com/bbatsov/rubocop/issues/5025): Fix error with Layout/MultilineMethodCallIndentation cop and lambda.(...). ([@dpostorivo][])
 * [#4781](https://github.com/bbatsov/rubocop/issues/4781): Prevent `Style/UnneededPercentQ` from breaking on strings that are concated with backslash. ([@pocke][])
+* [#5019](https://github.com/bbatsov/rubocop/pull/5019): Fix auto-correct for `Style/HashSyntax` cop when hash is used as unspaced argument. ([@drenmi][])
 
 ### Changes
 

--- a/lib/rubocop/cop/style/hash_syntax.rb
+++ b/lib/rubocop/cop/style/hash_syntax.rb
@@ -167,13 +167,22 @@ module RuboCop
         end
 
         def autocorrect_ruby19(corrector, pair_node)
-          key = pair_node.key.source_range
+          key = pair_node.key
           op = pair_node.loc.operator
 
-          range = range_between(key.begin_pos, op.end_pos)
+          range = range_between(key.source_range.begin_pos, op.end_pos)
           range = range_with_surrounding_space(range, :right)
-          corrector.replace(range,
-                            range.source.sub(/^:(.*\S)\s*=>\s*$/, '\1: '))
+
+          new_key = key.sym_type? ? key.value : key.source
+
+          space = argument_without_space?(pair_node.parent) ? ' ' : ''
+
+          corrector.replace(range, "#{space}#{new_key}: ")
+        end
+
+        def argument_without_space?(node)
+          node.argument? &&
+            node.loc.expression.begin_pos == node.parent.loc.selector.end_pos
         end
 
         def autocorrect_hash_rockets(corrector, pair_node)

--- a/spec/rubocop/cop/style/hash_syntax_spec.rb
+++ b/spec/rubocop/cop/style/hash_syntax_spec.rb
@@ -135,6 +135,12 @@ describe RuboCop::Cop::Style::HashSyntax, :config do
         new_source = autocorrect_source('{ :a=>1, :b=>2 }')
         expect(new_source).to eq('{ a: 1, b: 2 }')
       end
+
+      # Bug: https://github.com/bbatsov/rubocop/issues/5019
+      it 'auto-corrects a missing space when hash is used as argument' do
+        new_source = autocorrect_source('foo:bar => 1')
+        expect(new_source).to eq('foo bar: 1')
+      end
     end
 
     context 'with SpaceAroundOperators disabled' do


### PR DESCRIPTION
This cop's' auto-correct would result in invalid syntax when hash rocket hashes are used as unspaced arguments. This change fixes that.

-----------------

Before submitting the PR make sure the following are checked:

* [X] Wrote [good commit messages][1].
* [X] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [X] Used the same coding conventions as the rest of the project.
* [X] Feature branch is up-to-date with `master` (if not - rebase it).
* [X] Squashed related commits together.
* [X] Added tests.
* [X] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [X] All tests(`rake spec`) are passing.
* [X] The new code doesn't generate RuboCop offenses that are checked by `rake internal_investigation`.
* [X] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [ ] Updated cop documentation with `rake generate_cops_documentation` (required only when you've added a new cop or changed the configuration/documentation of an existing cop).

[1]: http://chris.beams.io/posts/git-commit/
