### PR TITLE
Make offense locations of metrics cops to contain whole a method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,7 @@
 * [#4943](https://github.com/bbatsov/rubocop/pull/4943): Make cop generator compliant with the repo's rubocop config. ([@tdeo][])
 * [#5011](https://github.com/bbatsov/rubocop/pull/5011): Remove `SupportedStyles` from "Configuration parameters" in `.rubocop_todo.yml`. ([@pocke][])
 * `Lint/RescueWithoutErrorClass` has been replaced by `Style/RescueStandardError`. ([@rrosenblum][])
+* [#5042](https://github.com/bbatsov/rubocop/pull/5042): Make offense locations of metrics cops to contain whole a method. ([@pocke][])
 
 ## 0.51.0 (2017-10-18)
 

--- a/lib/rubocop/cop/mixin/method_complexity.rb
+++ b/lib/rubocop/cop/mixin/method_complexity.rb
@@ -14,7 +14,7 @@ module RuboCop
 
         msg = format(self.class::MSG, node.method_name, complexity, max)
 
-        add_offense(node, location: :keyword, message: msg) do
+        add_offense(node, message: msg) do
           self.max = complexity.ceil
         end
       end

--- a/spec/rubocop/cop/metrics/abc_size_spec.rb
+++ b/spec/rubocop/cop/metrics/abc_size_spec.rb
@@ -22,7 +22,11 @@ describe RuboCop::Cop::Metrics::AbcSize, :config do
       expect(cop.messages)
         .to eq(['Assignment Branch Condition size for method_name is too ' \
                 'high. [2.24/0]'])
-      expect(cop.highlights).to eq(['def'])
+      expect(cop.highlights).to eq([<<-RUBY.strip_indent.chomp])
+        def method_name
+          call_foo if some_condition # 0 + 2*2 + 1*1
+        end
+      RUBY
       expect(cop.config_to_allow_offenses).to eq('Max' => 3)
     end
 
@@ -70,7 +74,7 @@ describe RuboCop::Cop::Metrics::AbcSize, :config do
       it 'treats safe navigation method calls like regular method calls' do
         expect_offense(<<-RUBY.strip_indent) # sqrt(0 + 2*2 + 0) => 2
           def method_name
-          ^^^ Assignment Branch Condition size for method_name is too high. [2/0]
+          ^^^^^^^^^^^^^^^ Assignment Branch Condition size for method_name is too high. [2/0]
             object&.do_something
           end
         RUBY

--- a/spec/rubocop/cop/metrics/cyclomatic_complexity_spec.rb
+++ b/spec/rubocop/cop/metrics/cyclomatic_complexity_spec.rb
@@ -35,14 +35,18 @@ describe RuboCop::Cop::Metrics::CyclomaticComplexity, :config do
       RUBY
       expect(cop.messages)
         .to eq(['Cyclomatic complexity for method_name is too high. [2/1]'])
-      expect(cop.highlights).to eq(['def'])
+      expect(cop.highlights).to eq([<<-RUBY.strip_indent.chomp])
+        def self.method_name
+          call_foo if some_condition
+        end
+      RUBY
       expect(cop.config_to_allow_offenses).to eq('Max' => 2)
     end
 
     it 'registers an offense for an unless modifier' do
       expect_offense(<<-RUBY.strip_indent)
         def method_name
-        ^^^ Cyclomatic complexity for method_name is too high. [2/1]
+        ^^^^^^^^^^^^^^^ Cyclomatic complexity for method_name is too high. [2/1]
           call_foo unless some_condition
         end
       RUBY
@@ -51,7 +55,7 @@ describe RuboCop::Cop::Metrics::CyclomaticComplexity, :config do
     it 'registers an offense for an elsif block' do
       expect_offense(<<-RUBY.strip_indent)
         def method_name
-        ^^^ Cyclomatic complexity for method_name is too high. [3/1]
+        ^^^^^^^^^^^^^^^ Cyclomatic complexity for method_name is too high. [3/1]
           if first_condition then
             call_foo
           elsif second_condition then
@@ -66,7 +70,7 @@ describe RuboCop::Cop::Metrics::CyclomaticComplexity, :config do
     it 'registers an offense for a ternary operator' do
       expect_offense(<<-RUBY.strip_indent)
         def method_name
-        ^^^ Cyclomatic complexity for method_name is too high. [2/1]
+        ^^^^^^^^^^^^^^^ Cyclomatic complexity for method_name is too high. [2/1]
           value = some_condition ? 1 : 2
         end
       RUBY
@@ -75,7 +79,7 @@ describe RuboCop::Cop::Metrics::CyclomaticComplexity, :config do
     it 'registers an offense for a while block' do
       expect_offense(<<-RUBY.strip_indent)
         def method_name
-        ^^^ Cyclomatic complexity for method_name is too high. [2/1]
+        ^^^^^^^^^^^^^^^ Cyclomatic complexity for method_name is too high. [2/1]
           while some_condition do
             call_foo
           end
@@ -86,7 +90,7 @@ describe RuboCop::Cop::Metrics::CyclomaticComplexity, :config do
     it 'registers an offense for an until block' do
       expect_offense(<<-RUBY.strip_indent)
         def method_name
-        ^^^ Cyclomatic complexity for method_name is too high. [2/1]
+        ^^^^^^^^^^^^^^^ Cyclomatic complexity for method_name is too high. [2/1]
           until some_condition do
             call_foo
           end
@@ -97,7 +101,7 @@ describe RuboCop::Cop::Metrics::CyclomaticComplexity, :config do
     it 'registers an offense for a for block' do
       expect_offense(<<-RUBY.strip_indent)
         def method_name
-        ^^^ Cyclomatic complexity for method_name is too high. [2/1]
+        ^^^^^^^^^^^^^^^ Cyclomatic complexity for method_name is too high. [2/1]
           for i in 1..2 do
             call_method
           end
@@ -108,7 +112,7 @@ describe RuboCop::Cop::Metrics::CyclomaticComplexity, :config do
     it 'registers an offense for a rescue block' do
       expect_offense(<<-RUBY.strip_indent)
         def method_name
-        ^^^ Cyclomatic complexity for method_name is too high. [2/1]
+        ^^^^^^^^^^^^^^^ Cyclomatic complexity for method_name is too high. [2/1]
           begin
             call_foo
           rescue Exception
@@ -121,7 +125,7 @@ describe RuboCop::Cop::Metrics::CyclomaticComplexity, :config do
     it 'registers an offense for a case/when block' do
       expect_offense(<<-RUBY.strip_indent)
         def method_name
-        ^^^ Cyclomatic complexity for method_name is too high. [3/1]
+        ^^^^^^^^^^^^^^^ Cyclomatic complexity for method_name is too high. [3/1]
           case value
           when 1
             call_foo
@@ -135,7 +139,7 @@ describe RuboCop::Cop::Metrics::CyclomaticComplexity, :config do
     it 'registers an offense for &&' do
       expect_offense(<<-RUBY.strip_indent)
         def method_name
-        ^^^ Cyclomatic complexity for method_name is too high. [2/1]
+        ^^^^^^^^^^^^^^^ Cyclomatic complexity for method_name is too high. [2/1]
           call_foo && call_bar
         end
       RUBY
@@ -144,7 +148,7 @@ describe RuboCop::Cop::Metrics::CyclomaticComplexity, :config do
     it 'registers an offense for and' do
       expect_offense(<<-RUBY.strip_indent)
         def method_name
-        ^^^ Cyclomatic complexity for method_name is too high. [2/1]
+        ^^^^^^^^^^^^^^^ Cyclomatic complexity for method_name is too high. [2/1]
           call_foo and call_bar
         end
       RUBY
@@ -153,7 +157,7 @@ describe RuboCop::Cop::Metrics::CyclomaticComplexity, :config do
     it 'registers an offense for ||' do
       expect_offense(<<-RUBY.strip_indent)
         def method_name
-        ^^^ Cyclomatic complexity for method_name is too high. [2/1]
+        ^^^^^^^^^^^^^^^ Cyclomatic complexity for method_name is too high. [2/1]
           call_foo || call_bar
         end
       RUBY
@@ -162,7 +166,7 @@ describe RuboCop::Cop::Metrics::CyclomaticComplexity, :config do
     it 'registers an offense for or' do
       expect_offense(<<-RUBY.strip_indent)
         def method_name
-        ^^^ Cyclomatic complexity for method_name is too high. [2/1]
+        ^^^^^^^^^^^^^^^ Cyclomatic complexity for method_name is too high. [2/1]
           call_foo or call_bar
         end
       RUBY
@@ -171,7 +175,7 @@ describe RuboCop::Cop::Metrics::CyclomaticComplexity, :config do
     it 'deals with nested if blocks containing && and ||' do
       expect_offense(<<-RUBY.strip_indent)
         def method_name
-        ^^^ Cyclomatic complexity for method_name is too high. [6/1]
+        ^^^^^^^^^^^^^^^ Cyclomatic complexity for method_name is too high. [6/1]
           if first_condition then
             call_foo if second_condition && third_condition
             call_bar if fourth_condition || fifth_condition
@@ -183,12 +187,12 @@ describe RuboCop::Cop::Metrics::CyclomaticComplexity, :config do
     it 'counts only a single method' do
       expect_offense(<<-RUBY.strip_indent)
         def method_name_1
-        ^^^ Cyclomatic complexity for method_name_1 is too high. [2/1]
+        ^^^^^^^^^^^^^^^^^ Cyclomatic complexity for method_name_1 is too high. [2/1]
           call_foo if some_condition
         end
 
         def method_name_2
-        ^^^ Cyclomatic complexity for method_name_2 is too high. [2/1]
+        ^^^^^^^^^^^^^^^^^ Cyclomatic complexity for method_name_2 is too high. [2/1]
           call_foo if some_condition
         end
       RUBY
@@ -201,7 +205,7 @@ describe RuboCop::Cop::Metrics::CyclomaticComplexity, :config do
     it 'counts stupid nested if and else blocks' do
       expect_offense(<<-RUBY.strip_indent)
         def method_name
-        ^^^ Cyclomatic complexity for method_name is too high. [5/2]
+        ^^^^^^^^^^^^^^^ Cyclomatic complexity for method_name is too high. [5/2]
           if first_condition then
             call_foo
           else

--- a/spec/rubocop/cop/metrics/perceived_complexity_spec.rb
+++ b/spec/rubocop/cop/metrics/perceived_complexity_spec.rb
@@ -35,14 +35,18 @@ describe RuboCop::Cop::Metrics::PerceivedComplexity, :config do
       RUBY
       expect(cop.messages)
         .to eq(['Perceived complexity for method_name is too high. [2/1]'])
-      expect(cop.highlights).to eq(['def'])
+      expect(cop.highlights).to eq([<<-RUBY.strip_indent.chomp])
+        def self.method_name
+          call_foo if some_condition
+        end
+      RUBY
       expect(cop.config_to_allow_offenses).to eq('Max' => 2)
     end
 
     it 'registers an offense for an unless modifier' do
       expect_offense(<<-RUBY.strip_indent)
         def method_name
-        ^^^ Perceived complexity for method_name is too high. [2/1]
+        ^^^^^^^^^^^^^^^ Perceived complexity for method_name is too high. [2/1]
           call_foo unless some_condition
         end
       RUBY
@@ -51,7 +55,7 @@ describe RuboCop::Cop::Metrics::PerceivedComplexity, :config do
     it 'registers an offense for elsif and else blocks' do
       expect_offense(<<-RUBY.strip_indent)
         def method_name
-        ^^^ Perceived complexity for method_name is too high. [4/1]
+        ^^^^^^^^^^^^^^^ Perceived complexity for method_name is too high. [4/1]
           if first_condition then
             call_foo
           elsif second_condition then
@@ -66,7 +70,7 @@ describe RuboCop::Cop::Metrics::PerceivedComplexity, :config do
     it 'registers an offense for a ternary operator' do
       expect_offense(<<-RUBY.strip_indent)
         def method_name
-        ^^^ Perceived complexity for method_name is too high. [2/1]
+        ^^^^^^^^^^^^^^^ Perceived complexity for method_name is too high. [2/1]
           value = some_condition ? 1 : 2
         end
       RUBY
@@ -75,7 +79,7 @@ describe RuboCop::Cop::Metrics::PerceivedComplexity, :config do
     it 'registers an offense for a while block' do
       expect_offense(<<-RUBY.strip_indent)
         def method_name
-        ^^^ Perceived complexity for method_name is too high. [2/1]
+        ^^^^^^^^^^^^^^^ Perceived complexity for method_name is too high. [2/1]
           while some_condition do
             call_foo
           end
@@ -86,7 +90,7 @@ describe RuboCop::Cop::Metrics::PerceivedComplexity, :config do
     it 'registers an offense for an until block' do
       expect_offense(<<-RUBY.strip_indent)
         def method_name
-        ^^^ Perceived complexity for method_name is too high. [2/1]
+        ^^^^^^^^^^^^^^^ Perceived complexity for method_name is too high. [2/1]
           until some_condition do
             call_foo
           end
@@ -97,7 +101,7 @@ describe RuboCop::Cop::Metrics::PerceivedComplexity, :config do
     it 'registers an offense for a for block' do
       expect_offense(<<-RUBY.strip_indent)
         def method_name
-        ^^^ Perceived complexity for method_name is too high. [2/1]
+        ^^^^^^^^^^^^^^^ Perceived complexity for method_name is too high. [2/1]
           for i in 1..2 do
             call_method
           end
@@ -108,7 +112,7 @@ describe RuboCop::Cop::Metrics::PerceivedComplexity, :config do
     it 'registers an offense for a rescue block' do
       expect_offense(<<-RUBY.strip_indent)
         def method_name
-        ^^^ Perceived complexity for method_name is too high. [2/1]
+        ^^^^^^^^^^^^^^^ Perceived complexity for method_name is too high. [2/1]
           begin
             call_foo
           rescue Exception
@@ -121,7 +125,7 @@ describe RuboCop::Cop::Metrics::PerceivedComplexity, :config do
     it 'registers an offense for a case/when block' do
       expect_offense(<<-RUBY.strip_indent)
         def method_name
-        ^^^ Perceived complexity for method_name is too high. [3/1]
+        ^^^^^^^^^^^^^^^ Perceived complexity for method_name is too high. [3/1]
           case value
           when 1 then call_foo_1
           when 2 then call_foo_2
@@ -153,7 +157,7 @@ describe RuboCop::Cop::Metrics::PerceivedComplexity, :config do
     it 'registers an offense for &&' do
       expect_offense(<<-RUBY.strip_indent)
         def method_name
-        ^^^ Perceived complexity for method_name is too high. [2/1]
+        ^^^^^^^^^^^^^^^ Perceived complexity for method_name is too high. [2/1]
           call_foo && call_bar
         end
       RUBY
@@ -162,7 +166,7 @@ describe RuboCop::Cop::Metrics::PerceivedComplexity, :config do
     it 'registers an offense for and' do
       expect_offense(<<-RUBY.strip_indent)
         def method_name
-        ^^^ Perceived complexity for method_name is too high. [2/1]
+        ^^^^^^^^^^^^^^^ Perceived complexity for method_name is too high. [2/1]
           call_foo and call_bar
         end
       RUBY
@@ -171,7 +175,7 @@ describe RuboCop::Cop::Metrics::PerceivedComplexity, :config do
     it 'registers an offense for ||' do
       expect_offense(<<-RUBY.strip_indent)
         def method_name
-        ^^^ Perceived complexity for method_name is too high. [2/1]
+        ^^^^^^^^^^^^^^^ Perceived complexity for method_name is too high. [2/1]
           call_foo || call_bar
         end
       RUBY
@@ -180,7 +184,7 @@ describe RuboCop::Cop::Metrics::PerceivedComplexity, :config do
     it 'registers an offense for or' do
       expect_offense(<<-RUBY.strip_indent)
         def method_name
-        ^^^ Perceived complexity for method_name is too high. [2/1]
+        ^^^^^^^^^^^^^^^ Perceived complexity for method_name is too high. [2/1]
           call_foo or call_bar
         end
       RUBY
@@ -189,7 +193,7 @@ describe RuboCop::Cop::Metrics::PerceivedComplexity, :config do
     it 'deals with nested if blocks containing && and ||' do
       expect_offense(<<-RUBY.strip_indent)
         def method_name
-        ^^^ Perceived complexity for method_name is too high. [6/1]
+        ^^^^^^^^^^^^^^^ Perceived complexity for method_name is too high. [6/1]
           if first_condition then
             call_foo if second_condition && third_condition
             call_bar if fourth_condition || fifth_condition
@@ -201,12 +205,12 @@ describe RuboCop::Cop::Metrics::PerceivedComplexity, :config do
     it 'counts only a single method' do
       expect_offense(<<-RUBY.strip_indent)
         def method_name_1
-        ^^^ Perceived complexity for method_name_1 is too high. [2/1]
+        ^^^^^^^^^^^^^^^^^ Perceived complexity for method_name_1 is too high. [2/1]
           call_foo if some_condition
         end
 
         def method_name_2
-        ^^^ Perceived complexity for method_name_2 is too high. [2/1]
+        ^^^^^^^^^^^^^^^^^ Perceived complexity for method_name_2 is too high. [2/1]
           call_foo if some_condition
         end
       RUBY
@@ -219,7 +223,7 @@ describe RuboCop::Cop::Metrics::PerceivedComplexity, :config do
     it 'counts stupid nested if and else blocks' do
       expect_offense(<<-RUBY.strip_indent)
         def method_name                   # 1
-        ^^^ Perceived complexity for method_name is too high. [7/2]
+        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Perceived complexity for method_name is too high. [7/2]
           if first_condition then         # 2
             call_foo
           else                            # 3


### PR DESCRIPTION
Problem
====

Currently, metrics cops add an offence for a complex method to `def` keyword.
For example, `Metrics/AbcSize`

```
Inspecting 1 file
C

Offenses:

test.rb:1:1: C: Assignment Branch Condition size for complex is too high. [1.41/1]
def complex
^^^

1 file inspected, 1 offense detected
```

However, the "`def`" is not complex, the method body is complex.
So I think this cop should add an offence whole the method.

Note: Metrics/MethodLength already adds offences whole the method.

Solution
====

Make offense locations of metrics cops to contain whole a method.
AbcSize, CyclomaticComplexity and PerceivedComplexity cops are targets of this change.

For example

```
Inspecting 1 file
C

Offenses:

test.rb:1:1: C: Assignment Branch Condition size for complex is too high. [1.41/1]
def complex ...
^^^^^^^^^^^

1 file inspected, 1 offense detected
```

Note
===

Our spec helper does not support multi line offences completely. But we have a workaround for multi line offences, we can write an annotation after first line of an offence to test the offence that is for multi-line.
For example:

```ruby
expect_offense(<<-RUBY)
  def foo
  ^^^^^^^ message
    bar
  end
RUBY
```



-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Used the same coding conventions as the rest of the project.
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] All tests(`rake spec`) are passing.
* [x] The new code doesn't generate RuboCop offenses that are checked by `rake internal_investigation`.
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Updated cop documentation with `rake generate_cops_documentation` (required only when you've added a new cop or changed the configuration/documentation of an existing cop).

[1]: http://chris.beams.io/posts/git-commit/
