### PR TITLE
Add last_line and last_column into outputs of the JSON formatter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,7 @@
 * [#5011](https://github.com/bbatsov/rubocop/pull/5011): Remove `SupportedStyles` from "Configuration parameters" in `.rubocop_todo.yml`. ([@pocke][])
 * `Lint/RescueWithoutErrorClass` has been replaced by `Style/RescueStandardError`. ([@rrosenblum][])
 * [#5042](https://github.com/bbatsov/rubocop/pull/5042): Make offense locations of metrics cops to contain whole a method. ([@pocke][])
+* [#5044](https://github.com/bbatsov/rubocop/pull/5044): Add last_line and last_column into outputs of the JSON formatter. ([@pocke][])
 
 ## 0.51.0 (2017-10-18)
 

--- a/lib/rubocop/cop/offense.rb
+++ b/lib/rubocop/cop/offense.rb
@@ -138,6 +138,11 @@ module RuboCop
       end
 
       # @api private
+      def last_column
+        location.last_column
+      end
+
+      # @api private
       def column_range
         location.column_range
       end

--- a/lib/rubocop/formatter/json_formatter.rb
+++ b/lib/rubocop/formatter/json_formatter.rb
@@ -64,9 +64,15 @@ module RuboCop
       # TODO: Consider better solution for Offense#real_column.
       def hash_for_location(offense)
         {
-          line:   offense.line,
-          column: offense.real_column,
-          length: offense.location.length
+          start_line:        offense.line,
+          start_column:      offense.real_column,
+          last_line:   offense.last_line,
+          last_column: offense.last_column,
+          length:      offense.location.length,
+          # `line` and `column` exist for compatibility.
+          # Use `start_line` and `start_column` instead.
+          line:        offense.line,
+          column:      offense.real_column
         }
       end
     end

--- a/spec/rubocop/formatter/json_formatter_spec.rb
+++ b/spec/rubocop/formatter/json_formatter_spec.rb
@@ -9,7 +9,7 @@ module RuboCop
     let(:location) do
       source_buffer = Parser::Source::Buffer.new('test', 1)
       source_buffer.source = %w[a b cdefghi].join("\n")
-      Parser::Source::Range.new(source_buffer, 9, 10)
+      Parser::Source::Range.new(source_buffer, 2, 10)
     end
     let(:offense) do
       Cop::Offense.new(:convention, location,
@@ -121,7 +121,15 @@ module RuboCop
       end
 
       it 'sets value of #hash_for_location for :location key' do
-        location_hash = { line: 3, column: 6, length: 1 }
+        location_hash = {
+          start_line: 2,
+          start_column: 1,
+          last_line: 3,
+          last_column: 6,
+          length: 8,
+          line: 2,
+          column: 1
+        }
         expect(hash[:location]).to eq(location_hash)
       end
     end
@@ -130,15 +138,15 @@ module RuboCop
       subject(:hash) { formatter.hash_for_location(offense) }
 
       it 'sets line value for :line key' do
-        expect(hash[:line]).to eq(3)
+        expect(hash[:line]).to eq(2)
       end
 
       it 'sets column value for :column key' do
-        expect(hash[:column]).to eq(6)
+        expect(hash[:column]).to eq(1)
       end
 
       it 'sets length value for :length key' do
-        expect(hash[:length]).to eq(1)
+        expect(hash[:length]).to eq(8)
       end
     end
   end


### PR DESCRIPTION
Problem
=====

Outputs of the JSON formatter does not include ending location.
For example:

```
"aa
bb
cc"
foo
```

Run `rubocop test.rb -f json | jq .`

```json
{
  "metadata": {
    "rubocop_version": "0.51.0",
    "ruby_engine": "ruby",
    "ruby_version": "2.4.2",
    "ruby_patchlevel": "198",
    "ruby_platform": "x86_64-linux"
  },
  "files": [
    {
      "path": "test.rb",
      "offenses": [
        {
          "severity": "warning",
          "message": "Literal `\"aa\nbb\ncc\"` used in void context.",
          "cop_name": "Lint/Void",
          "corrected": false,
          "location": {
            "line": 1,
            "column": 1,
            "length": 10
          }
        }
      ]
    }
  ],
  "summary": {
    "offense_count": 1,
    "target_file_count": 1,
    "inspected_file_count": 1
  }
}
```

The output has `length` field, so we can calculate `last_line` and `last_column` with these values, but it is difficult if the offense spans multiple lines.

Solution
=====

Add last_line and last_column fields into outputs of the JSON formatter.
By this change, we can get `last_line` and `last_column` without calculation.


-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Used the same coding conventions as the rest of the project.
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] All tests(`rake spec`) are passing.
* [x] The new code doesn't generate RuboCop offenses that are checked by `rake internal_investigation`.
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Updated cop documentation with `rake generate_cops_documentation` (required only when you've added a new cop or changed the configuration/documentation of an existing cop).

[1]: http://chris.beams.io/posts/git-commit/
