### PR TITLE
[Fix #5046] Disable auto-correction for `Style/SpecialGlobalVars` by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,7 @@
 * [#5011](https://github.com/bbatsov/rubocop/pull/5011): Remove `SupportedStyles` from "Configuration parameters" in `.rubocop_todo.yml`. ([@pocke][])
 * `Lint/RescueWithoutErrorClass` has been replaced by `Style/RescueStandardError`. ([@rrosenblum][])
 * [#5042](https://github.com/bbatsov/rubocop/pull/5042): Make offense locations of metrics cops to contain whole a method. ([@pocke][])
+* [#5046](https://github.com/bbatsov/rubocop/issues/5046): Disable auto-correction for `Style/SpecialGlobalVars` by default. ([@pocke][])
 
 ## 0.51.0 (2017-10-18)
 

--- a/config/default.yml
+++ b/config/default.yml
@@ -1205,6 +1205,7 @@ Style/SpecialGlobalVars:
   SupportedStyles:
     - use_perl_names
     - use_english_names
+  AutoCorrect: false
 
 Style/StabbyLambdaParentheses:
   EnforcedStyle: require_parentheses

--- a/manual/cops_style.md
+++ b/manual/cops_style.md
@@ -3995,6 +3995,7 @@ Attribute | Value
 --- | ---
 EnforcedStyle | use_english_names
 SupportedStyles | use_perl_names, use_english_names
+AutoCorrect | false
 
 ### References
 

--- a/spec/rubocop/cli/cli_auto_gen_config_spec.rb
+++ b/spec/rubocop/cli/cli_auto_gen_config_spec.rb
@@ -588,7 +588,7 @@ describe RuboCop::CLI, :isolated_environment do
           .to eq(<<-YAML.strip_indent)
             # Offense count: 2
             # Cop supports --auto-correct.
-            # Configuration parameters: EnforcedStyle.
+            # Configuration parameters: EnforcedStyle, AutoCorrect.
             # SupportedStyles: use_perl_names, use_english_names
             Style/SpecialGlobalVars:
               Enabled: false
@@ -602,7 +602,7 @@ describe RuboCop::CLI, :isolated_environment do
           .to eq(<<-YAML.strip_indent)
             # Offense count: 3
             # Cop supports --auto-correct.
-            # Configuration parameters: EnforcedStyle.
+            # Configuration parameters: EnforcedStyle, AutoCorrect.
             # SupportedStyles: use_perl_names, use_english_names
             Style/SpecialGlobalVars:
               Exclude:

--- a/spec/rubocop/cli/cli_options_spec.rb
+++ b/spec/rubocop/cli/cli_options_spec.rb
@@ -1175,22 +1175,21 @@ describe RuboCop::CLI, :isolated_environment do
 
     it 'prints corrected code to stdout if --autocorrect is used' do
       begin
-        $stdin = StringIO.new('p $/')
+        $stdin = StringIO.new('p "foo"')
         argv   = ['--auto-correct',
-                  '--only=Style/SpecialGlobalVars',
+                  '--only=Style/StringLiterals',
                   '--format=simple',
                   '--stdin',
                   'fake.rb']
         expect(cli.run(argv)).to eq(0)
-        expect($stdout.string).to eq([
-          '== fake.rb ==',
-          'C:  1:  3: [Corrected] Prefer $INPUT_RECORD_SEPARATOR or $RS from ' \
-          "the stdlib 'English' module (don't forget to require it) over $/.",
-          '',
-          '1 file inspected, 1 offense detected, 1 offense corrected',
-          '====================',
-          'p $INPUT_RECORD_SEPARATOR'
-        ].join("\n"))
+        expect($stdout.string).to eq(<<-RUBY.strip_indent.chomp)
+          == fake.rb ==
+          C:  1:  3: [Corrected] Prefer single-quoted strings when you don't need string interpolation or special symbols.
+
+          1 file inspected, 1 offense detected, 1 offense corrected
+          ====================
+          p 'foo'
+        RUBY
       ensure
         $stdin = STDIN
       end

--- a/spec/rubocop/cop/style/special_global_vars_spec.rb
+++ b/spec/rubocop/cop/style/special_global_vars_spec.rb
@@ -4,7 +4,12 @@ describe RuboCop::Cop::Style::SpecialGlobalVars, :config do
   subject(:cop) { described_class.new(config) }
 
   context 'when style is use_english_names' do
-    let(:cop_config) { { 'EnforcedStyle' => 'use_english_names' } }
+    let(:cop_config) do
+      {
+        'EnforcedStyle' => 'use_english_names',
+        'AutoCorrect' => true
+      }
+    end
 
     it 'registers an offense for $:' do
       expect_offense(<<-RUBY.strip_indent)
@@ -79,7 +84,12 @@ describe RuboCop::Cop::Style::SpecialGlobalVars, :config do
   end
 
   context 'when style is use_perl_names' do
-    let(:cop_config) { { 'EnforcedStyle' => 'use_perl_names' } }
+    let(:cop_config) do
+      {
+        'EnforcedStyle' => 'use_perl_names',
+        'AutoCorrect' => true
+      }
+    end
 
     it 'registers an offense for $LOAD_PATH' do
       expect_offense(<<-RUBY.strip_indent)


### PR DESCRIPTION
See #5046 

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Used the same coding conventions as the rest of the project.
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] All tests(`rake spec`) are passing.
* [x] The new code doesn't generate RuboCop offenses that are checked by `rake internal_investigation`.
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Updated cop documentation with `rake generate_cops_documentation` (required only when you've added a new cop or changed the configuration/documentation of an existing cop).

[1]: http://chris.beams.io/posts/git-commit/
