### PR TITLE
Drop rbx-3 from travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,6 @@ rvm:
   - 2.3.5
   - 2.4.2
   - ruby-head
-  - rbx-3
 env:
   global:
     - JRUBY_OPTS='--debug -J-Xmx1000M' # get more accurate coverage data in JRuby
@@ -21,7 +20,6 @@ env:
 matrix:
   allow_failures:
     - rvm: ruby-head
-    - rvm: rbx-3
     - rvm: jruby-head
   fast_finish: true
 before_install:


### PR DESCRIPTION
## Summary

rbx-3 has been failed in Travis CI for a long while.
It seems that it already failed when upgrading from rbx-2 to rbx-3.
https://github.com/bbatsov/rubocop/pull/2706

It seems that there is no activity while failing with `allow_failures`. So I think that it is not necessary to use CI resources at present.
When passing the test with rbx-3, I think that it is better to add it again to travis.yml.

## Other Information

jruby-head (jruby 9.2.0.0-SNAPSHOT) will progress as soon as the following Issue is resolved.
https://github.com/jruby/jruby/issues/4809

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Used the same coding conventions as the rest of the project.
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [ ] Added tests.
* [ ] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] All tests(`rake spec`) are passing.
* [x] The new code doesn't generate RuboCop offenses that are checked by `rake internal_investigation`.
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [ ] Updated cop documentation with `rake generate_cops_documentation` (required only when you've added a new cop or changed the configuration/documentation of an existing cop).

[1]: http://chris.beams.io/posts/git-commit/
