### PR TITLE
[Fix #4633] Make metrics cops aware of `define_method`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,7 @@
 * [#5011](https://github.com/bbatsov/rubocop/pull/5011): Remove `SupportedStyles` from "Configuration parameters" in `.rubocop_todo.yml`. ([@pocke][])
 * `Lint/RescueWithoutErrorClass` has been replaced by `Style/RescueStandardError`. ([@rrosenblum][])
 * [#5042](https://github.com/bbatsov/rubocop/pull/5042): Make offense locations of metrics cops to contain whole a method. ([@pocke][])
+* [#4633](https://github.com/bbatsov/rubocop/issues/4633): Make metrics cops aware of `define_method`. ([@pocke][])
 
 ## 0.51.0 (2017-10-18)
 

--- a/lib/rubocop/cop/mixin/method_complexity.rb
+++ b/lib/rubocop/cop/mixin/method_complexity.rb
@@ -5,25 +5,46 @@ module RuboCop
     # This module handles measurement and reporting of complexity in methods.
     module MethodComplexity
       include ConfigurableMax
+      extend NodePattern::Macros
 
       def on_def(node)
+        check_complexity(node, node.method_name)
+      end
+      alias on_defs on_def
+
+      def on_block(node)
+        define_method?(node) do |name|
+          check_complexity(node, name)
+        end
+      end
+
+      private
+
+      def_node_matcher :define_method?, <<-PATTERN
+        (block
+         (send nil? :define_method ({sym str} $_))
+         args
+         _)
+      PATTERN
+
+      def check_complexity(node, method_name)
+        # Accepts empty methods always.
+        return unless node.body
+
         max = cop_config['Max']
-        complexity = complexity(node)
+        complexity = complexity(node.body)
 
         return unless complexity > max
 
-        msg = format(self.class::MSG, node.method_name, complexity, max)
+        msg = format(self.class::MSG, method_name, complexity, max)
 
         add_offense(node, message: msg) do
           self.max = complexity.ceil
         end
       end
-      alias on_defs on_def
 
-      private
-
-      def complexity(node)
-        node.each_node(*self.class::COUNTED_NODES).reduce(1) do |score, n|
+      def complexity(body)
+        body.each_node(*self.class::COUNTED_NODES).reduce(1) do |score, n|
           score + complexity_score_for(n)
         end
       end

--- a/spec/rubocop/cop/metrics/abc_size_spec.rb
+++ b/spec/rubocop/cop/metrics/abc_size_spec.rb
@@ -13,6 +13,13 @@ describe RuboCop::Cop::Metrics::AbcSize, :config do
       RUBY
     end
 
+    it 'accepts an empty `define_method`' do
+      expect_no_offenses(<<-RUBY.strip_indent)
+        define_method :method_name do
+        end
+      RUBY
+    end
+
     it 'registers an offense for an if modifier' do
       inspect_source(<<-RUBY.strip_indent)
         def method_name
@@ -68,6 +75,15 @@ describe RuboCop::Cop::Metrics::AbcSize, :config do
       expect(cop.messages)
         .to eq(['Assignment Branch Condition size for method_name is too ' \
                 'high. [6.4/0]']) # sqrt(1*1 + 6*6 + 2*2) => 6.4
+    end
+
+    it 'registers an offense for a `define_method`' do
+      expect_offense(<<-RUBY.strip_indent)
+        define_method :method_name do
+        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Assignment Branch Condition size for method_name is too high. [1/0]
+          x = 1
+        end
+      RUBY
     end
 
     context 'target_ruby_version >= 2.3', :ruby23 do

--- a/spec/rubocop/cop/metrics/cyclomatic_complexity_spec.rb
+++ b/spec/rubocop/cop/metrics/cyclomatic_complexity_spec.rb
@@ -14,6 +14,20 @@ describe RuboCop::Cop::Metrics::CyclomaticComplexity, :config do
       RUBY
     end
 
+    it 'accepts an empty method' do
+      expect_no_offenses(<<-RUBY.strip_indent)
+        def method_name
+        end
+      RUBY
+    end
+
+    it 'accepts an empty `define_method`' do
+      expect_no_offenses(<<-RUBY.strip_indent)
+        define_method :method_name do
+        end
+      RUBY
+    end
+
     it 'accepts complex code outside of methods' do
       expect_no_offenses(<<-RUBY.strip_indent)
         def method_name
@@ -193,6 +207,15 @@ describe RuboCop::Cop::Metrics::CyclomaticComplexity, :config do
 
         def method_name_2
         ^^^^^^^^^^^^^^^^^ Cyclomatic complexity for method_name_2 is too high. [2/1]
+          call_foo if some_condition
+        end
+      RUBY
+    end
+
+    it 'registers an offense for a `define_method`' do
+      expect_offense(<<-RUBY.strip_indent)
+        define_method :method_name do
+        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Cyclomatic complexity for method_name is too high. [2/1]
           call_foo if some_condition
         end
       RUBY

--- a/spec/rubocop/cop/metrics/perceived_complexity_spec.rb
+++ b/spec/rubocop/cop/metrics/perceived_complexity_spec.rb
@@ -14,6 +14,20 @@ describe RuboCop::Cop::Metrics::PerceivedComplexity, :config do
       RUBY
     end
 
+    it 'accepts an empty method' do
+      expect_no_offenses(<<-RUBY.strip_indent)
+        def method_name
+        end
+      RUBY
+    end
+
+    it 'accepts an empty `define_method`' do
+      expect_no_offenses(<<-RUBY.strip_indent)
+        define_method :method_name do
+        end
+      RUBY
+    end
+
     it 'accepts complex code outside of methods' do
       expect_no_offenses(<<-RUBY.strip_indent)
         def method_name
@@ -211,6 +225,15 @@ describe RuboCop::Cop::Metrics::PerceivedComplexity, :config do
 
         def method_name_2
         ^^^^^^^^^^^^^^^^^ Perceived complexity for method_name_2 is too high. [2/1]
+          call_foo if some_condition
+        end
+      RUBY
+    end
+
+    it 'registers an offense for a `define_method`' do
+      expect_offense(<<-RUBY.strip_indent)
+        define_method :method_name do
+        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Perceived complexity for method_name is too high. [2/1]
           call_foo if some_condition
         end
       RUBY


### PR DESCRIPTION
Problem
=======

`AbcSize`, `CyclomaticComplexity` and `PerceivedComplexity` cops ignore `define_method`.
See #4633 

Solution
====

Update `MethodComplexity` mix-in.
This change makes these cops aware of `define_method`.


-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Used the same coding conventions as the rest of the project.
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] All tests(`rake spec`) are passing.
* [x] The new code doesn't generate RuboCop offenses that are checked by `rake internal_investigation`.
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Updated cop documentation with `rake generate_cops_documentation` (required only when you've added a new cop or changed the configuration/documentation of an existing cop).

[1]: http://chris.beams.io/posts/git-commit/
