### PR TITLE
[Fix #4662] Split heredoc indentation by lines

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@
 
 ### Bug fixes
 
+* [#4662](https://github.com/bbatsov/rubocop/issues/4662): Fix incorrect indent level detection when first line of heredoc is blank. ([@sambostock][])
 * [#4866](https://github.com/bbatsov/rubocop/issues/4866): Prevent `Layout/BlockEndNewline` cop from introducing trailing whitespaces. ([@bgeuken][])
 * [#3396](https://github.com/bbatsov/rubocop/issues/3396): Concise error when config. file not found. ([@jaredbeck][])
 * [#4881](https://github.com/bbatsov/rubocop/issues/4881): Fix a false positive for `Performance/HashEachMethods` when unused argument(s) exists in other blocks. ([@pocke][])
@@ -3029,3 +3030,4 @@
 [@mtsmfm]: https://github.com/mtsmfm
 [@bdewater]: https://github.com/bdewater
 [@garettarrowood]: https://github.com/garettarrowood
+[@sambostock]: https://github.com/sambostock

--- a/lib/rubocop/cop/layout/indent_heredoc.rb
+++ b/lib/rubocop/cop/layout/indent_heredoc.rb
@@ -146,7 +146,9 @@ module RuboCop
         end
 
         def indent_level(str)
-          indentations = str.scan(/^\s*/).reject { |line| line == "\n" }
+          indentations = str.lines
+                            .map { |line| line[/^\s*/] }
+                            .reject { |line| line == "\n" }
           indentations.empty? ? 0 : indentations.min_by(&:size).size
         end
 

--- a/spec/rubocop/cop/layout/indent_heredoc_spec.rb
+++ b/spec/rubocop/cop/layout/indent_heredoc_spec.rb
@@ -248,8 +248,9 @@ describe RuboCop::Cop::Layout::IndentHeredoc, :config do
             something
           RUBY2
         RUBY
-        include_examples :accept, 'include empty line', <<-RUBY
+        include_examples :accept, 'include empty lines', <<-RUBY
           <<~#{quote}MSG#{quote}
+
             foo
 
               bar


### PR DESCRIPTION
Checking indentation of heredocs would fail if the first line was empty, with a nonsense message:

```ruby
<<~HEREDOC

  foo
HEREDOC
```

> Use 2 spaces for indentation in a heredoc by using `<<~` instead of `<<~`.

Indentations were detected as leading contiguous whitespace. In the example above, this would be `"\n  "`, which fails the check due to being 3 characters long.

By first splitting lines, we are can safely rely on the leading contiguous whitespace being the indent.

Resolves: #4662
See also: #4465

<details>
<summary>Checklist</summary>

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Used the same coding conventions as the rest of the project.
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] All tests(`rake spec`) are passing.
* [x] The new code doesn't generate RuboCop offenses that are checked by `rake internal_investigation`.
* [x] The PR relates to *only* one subject with a clear title and description in grammatically correct, complete sentences.
* [x] Updated cop documentation with `rake generate_cops_documentation` (required only when you've added a new cop or changed the configuration/documentation of an existing cop).

[1]: http://chris.beams.io/posts/git-commit/
</details>