### PR TITLE
Add new `Gemspec/RequiredRubyVersion` cop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 * Add new `Rails/EnvironmentComparison` cop. ([@tdeo][])
 * Add `AllowedChars` option to `Style/AsciiComments` cop. ([@hedgesky][])
 * [#5031](https://github.com/bbatsov/rubocop/pull/5031): Add new `Style/EmptyBlockParameter` and `Style/EmptyLambdaParameter` cops. ([@pocke][])
+* [#5057](https://github.com/bbatsov/rubocop/pull/5057): Add new `Gemspec/RequiredRubyVersion` cop. ([@koic][])
 
 ### Bug fixes
 

--- a/config/enabled.yml
+++ b/config/enabled.yml
@@ -1928,3 +1928,9 @@ Gemspec/OrderedDependencies:
   Enabled: true
   Include:
     - '**/*.gemspec'
+
+Gemspec/RequiredRubyVersion:
+  Description: 'Checks that `required_ruby_version` of gemspec and `TargetRubyVersion` of .rubocop.yml are equal.'
+  Enabled: true
+  Include:
+    - '**/*.gemspec'

--- a/lib/rubocop.rb
+++ b/lib/rubocop.rb
@@ -144,6 +144,7 @@ require_relative 'rubocop/cop/bundler/insecure_protocol_source'
 require_relative 'rubocop/cop/bundler/ordered_gems'
 
 require_relative 'rubocop/cop/gemspec/ordered_dependencies'
+require_relative 'rubocop/cop/gemspec/required_ruby_version'
 
 require_relative 'rubocop/cop/layout/access_modifier_indentation'
 require_relative 'rubocop/cop/layout/align_array'

--- a/lib/rubocop/cop/gemspec/required_ruby_version.rb
+++ b/lib/rubocop/cop/gemspec/required_ruby_version.rb
@@ -1,0 +1,87 @@
+# frozen_string_literal: true
+
+module RuboCop
+  module Cop
+    module Gemspec
+      # Checks that `required_ruby_version` of gemspec and `TargetRubyVersion`
+      # of .rubocop.yml are equal.
+      # Thereby, RuboCop to perform static analysis working on the version
+      # required by gemspec.
+      #
+      # @example
+      #   # When `TargetRubyVersion` of .rubocop.yml is `2.3`.
+      #
+      #   # bad
+      #   Gem::Specification.new do |spec|
+      #     spec.required_ruby_version = '>= 2.2.0'
+      #   end
+      #
+      #   # bad
+      #   Gem::Specification.new do |spec|
+      #     spec.required_ruby_version = '>= 2.4.0'
+      #   end
+      #
+      #   # good
+      #   Gem::Specification.new do |spec|
+      #     spec.required_ruby_version = '>= 2.3.0'
+      #   end
+      #
+      #   # good
+      #   Gem::Specification.new do |spec|
+      #     spec.required_ruby_version = '>= 2.3'
+      #   end
+      #
+      #   # good
+      #   Gem::Specification.new do |spec|
+      #     spec.required_ruby_version = ['>= 2.3.0', '< 2.5.0']
+      #   end
+      class RequiredRubyVersion < Cop
+        MSG = '`required_ruby_version` (%<required_ruby_version>s, ' \
+              'declared in %<gemspec_filename>s) and `TargetRubyVersion` ' \
+              '(%<target_ruby_version>s, declared in .rubocop.yml) ' \
+              'should be equal.'.freeze
+
+        def_node_search :required_ruby_version, <<-PATTERN
+          (send _ :required_ruby_version= ${(str _) (array (str _))})
+        PATTERN
+
+        def investigate(processed_source)
+          required_ruby_version(processed_source.ast) do |version|
+            ruby_version = extract_ruby_version(version)
+
+            return if ruby_version == target_ruby_version.to_s
+
+            add_offense(
+              processed_source.ast,
+              location: version.loc.expression,
+              message: message(ruby_version, target_ruby_version)
+            )
+          end
+        end
+
+        private
+
+        def extract_ruby_version(required_ruby_version)
+          if required_ruby_version.array_type?
+            required_ruby_version = required_ruby_version.children.detect do |v|
+              v.str_content =~ /[>=]/
+            end
+          end
+
+          required_ruby_version.str_content.match(/(\d\.\d)/)[1]
+        end
+
+        def message(required_ruby_version, target_ruby_version)
+          file_path = processed_source.buffer.name
+
+          format(
+            MSG,
+            required_ruby_version: required_ruby_version,
+            gemspec_filename: File.basename(file_path),
+            target_ruby_version: target_ruby_version
+          )
+        end
+      end
+    end
+  end
+end

--- a/manual/cops.md
+++ b/manual/cops.md
@@ -99,6 +99,7 @@ In the following section you find all available cops:
 #### Department [Gemspec](cops_gemspec.md)
 
 * [Gemspec/OrderedDependencies](cops_gemspec.md#gemspecordereddependencies)
+* [Gemspec/RequiredRubyVersion](cops_gemspec.md#gemspecrequiredrubyversion)
 
 #### Department [Layout](cops_layout.md)
 

--- a/manual/cops_gemspec.md
+++ b/manual/cops_gemspec.md
@@ -63,3 +63,51 @@ Attribute | Value
 --- | ---
 Include | \*\*/\*.gemspec
 TreatCommentsAsGroupSeparators | true
+
+## Gemspec/RequiredRubyVersion
+
+Enabled by default | Supports autocorrection
+--- | ---
+Enabled | No
+
+Checks that `required_ruby_version` of gemspec and `TargetRubyVersion`
+of .rubocop.yml are equal.
+Thereby, RuboCop to perform static analysis working on the version
+required by gemspec.
+
+### Example
+
+```ruby
+# When `TargetRubyVersion` of .rubocop.yml is `2.3`.
+
+# bad
+Gem::Specification.new do |spec|
+  spec.required_ruby_version = '>= 2.2.0'
+end
+
+# bad
+Gem::Specification.new do |spec|
+  spec.required_ruby_version = '>= 2.4.0'
+end
+
+# good
+Gem::Specification.new do |spec|
+  spec.required_ruby_version = '>= 2.3.0'
+end
+
+# good
+Gem::Specification.new do |spec|
+  spec.required_ruby_version = '>= 2.3'
+end
+
+# good
+Gem::Specification.new do |spec|
+  spec.required_ruby_version = ['>= 2.3.0', '< 2.5.0']
+end
+```
+
+### Important attributes
+
+Attribute | Value
+--- | ---
+Include | \*\*/\*.gemspec

--- a/spec/rubocop/cop/gemspec/required_ruby_version_spec.rb
+++ b/spec/rubocop/cop/gemspec/required_ruby_version_spec.rb
@@ -1,0 +1,81 @@
+# frozen_string_literal: true
+
+describe RuboCop::Cop::Gemspec::RequiredRubyVersion, :config do
+  subject(:cop) { described_class.new(config) }
+
+  context 'target ruby version > 2.4', :ruby24 do
+    it 'registers an offense when `required_ruby_version` is lower than ' \
+       '`TargetRubyVersion`' do
+      expect_offense(<<-RUBY.strip_indent, '/path/to/foo.gemspec')
+        Gem::Specification.new do |spec|
+          spec.required_ruby_version = '>= 2.3.0'
+                                       ^^^^^^^^^^ `required_ruby_version` (2.3, declared in foo.gemspec) and `TargetRubyVersion` (2.4, declared in .rubocop.yml) should be equal.
+        end
+      RUBY
+    end
+
+    describe 'false negatives' do
+      it 'does not register an offense when `required_ruby_version` ' \
+         'is assigned as a variable (string literal)' do
+        expect_no_offenses(<<-RUBY.strip_indent)
+          Gem::Specification.new do |spec|
+            version = '>= 2.3.0'
+            spec.required_ruby_version = version
+          end
+        RUBY
+      end
+
+      it 'does not register an offense when `required_ruby_version` ' \
+         'is assigned as a variable (an array of string literal)' do
+        expect_no_offenses(<<-RUBY.strip_indent)
+          Gem::Specification.new do |spec|
+            lowest_version = '>= 2.3.0'
+            highest_version = '< 2.5.0'
+            spec.required_ruby_version = [lowest_version, highest_version]
+          end
+        RUBY
+      end
+    end
+  end
+
+  context 'target ruby version > 2.2', :ruby22 do
+    it 'registers an offense when `required_ruby_version` is higher than ' \
+       '`TargetRubyVersion`' do
+      expect_offense(<<-RUBY.strip_indent, '/path/to/bar.gemspec')
+        Gem::Specification.new do |spec|
+          spec.required_ruby_version = '>= 2.3.0'
+                                       ^^^^^^^^^^ `required_ruby_version` (2.3, declared in bar.gemspec) and `TargetRubyVersion` (2.2, declared in .rubocop.yml) should be equal.
+        end
+      RUBY
+    end
+  end
+
+  context 'target ruby version > 2.3', :ruby23 do
+    it 'does not register an offense when `required_ruby_version` equals ' \
+       '`TargetRubyVersion`' do
+      expect_no_offenses(<<-RUBY.strip_indent)
+        Gem::Specification.new do |spec|
+          spec.required_ruby_version = '>= 2.3.0'
+        end
+      RUBY
+    end
+
+    it 'does not register an offense when `required_ruby_version` ' \
+       '(omit patch version) equals `TargetRubyVersion`' do
+      expect_no_offenses(<<-RUBY.strip_indent)
+        Gem::Specification.new do |spec|
+          spec.required_ruby_version = '>= 2.3'
+        end
+      RUBY
+    end
+
+    it 'does not register an offense when lowest version of ' \
+       '`required_ruby_version` equals `TargetRubyVersion`' do
+      expect_no_offenses(<<-RUBY.strip_indent)
+        Gem::Specification.new do |spec|
+          spec.required_ruby_version = ['>= 2.3.0', '< 2.5.0']
+        end
+      RUBY
+    end
+  end
+end


### PR DESCRIPTION
## Feature

Checks that `require_ruby_version` of gemspec and `TargetRubyVersion` of .rubocop.yml are equal.

Thereby, RuboCop to perform static analysis working to the version required by gemspec.

For example, when `TargetRubyVersion` of .rubocop.yml is `2.3`.

```console
% cat foo.gemspec
# frozen_string_literal: true

Gem::Specification.new do |spec|
  spec.required_ruby_version = '>= 2.4.0'
end
```

```console
% rubocop foo.gemspec
Inspecting 1 file
C

Offenses:

foo.gemspec:4:32: C: require_ruby_version and TargetRubyVersion of
.rubocop.yml should be equal.
  spec.required_ruby_version = '>= 2.4.0'
                               ^^^^^^^^^^

1 file inspected, 1 offense detected
```

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Used the same coding conventions as the rest of the project.
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] All tests(`rake spec`) are passing.
* [x] The new code doesn't generate RuboCop offenses that are checked by `rake internal_investigation`.
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Updated cop documentation with `rake generate_cops_documentation` (required only when you've added a new cop or changed the configuration/documentation of an existing cop).

[1]: http://chris.beams.io/posts/git-commit/
