### PR TITLE
CI against JRuby 9.1.14.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ cache: bundler
 language: ruby
 dist: trusty
 rvm:
-  - jruby-9.1.13.0
+  - jruby-9.1.14.0
   - jruby-head
   - 2.1.10
   - 2.2.8


### PR DESCRIPTION
JRuby 9.1.14.0 has been released and this version is available on Travis CI.
http://jruby.org/2017/11/08/jruby-9-1-14-0
