### PR TITLE
[Fix #5053] Naming/ConstantName allows non-offensive casgn assignment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@
 * [#5025](https://github.com/bbatsov/rubocop/issues/5025): Fix error with Layout/MultilineMethodCallIndentation cop and lambda.(...). ([@dpostorivo][])
 * [#4781](https://github.com/bbatsov/rubocop/issues/4781): Prevent `Style/UnneededPercentQ` from breaking on strings that are concated with backslash. ([@pocke][])
 * [#4363](https://github.com/bbatsov/rubocop/issues/4363): Fix `Style/PercentLiteralDelimiters` incorrectly automatically modifies escaped percent literal delimiter. ([@koic][])
+* [#5053](https://github.com/bbatsov/rubocop/issues/5053): Fix `Naming/ConstantName` false offense on assigning to a nonoffensive assignment. ([@garettarrowood][])
 * [#5019](https://github.com/bbatsov/rubocop/pull/5019): Fix auto-correct for `Style/HashSyntax` cop when hash is used as unspaced argument. ([@drenmi][])
 
 ### Changes

--- a/lib/rubocop/cop/naming/constant_name.rb
+++ b/lib/rubocop/cop/naming/constant_name.rb
@@ -28,7 +28,7 @@ module RuboCop
           # NewClass = something_that_returns_a_class
           # It's also ok to assign a class constant another class constant
           # SomeClass = SomeOtherClass
-          return if value && %i[send block const].include?(value.type)
+          return if value && %i[send block const casgn].include?(value.type)
 
           add_offense(node, location: :name) if const_name !~ SNAKE_CASE
         end

--- a/spec/rubocop/cop/naming/constant_name_spec.rb
+++ b/spec/rubocop/cop/naming/constant_name_spec.rb
@@ -25,6 +25,13 @@ describe RuboCop::Cop::Naming::ConstantName do
     RUBY
   end
 
+  it 'registers 1 offense if rhs is offending const assignment' do
+    expect_offense(<<-RUBY.strip_indent)
+      Bar = Foo = 4
+            ^^^ Use SCREAMING_SNAKE_CASE for constants.
+    RUBY
+  end
+
   it 'allows screaming snake case in const name' do
     expect_no_offenses('TOP_TEST = 5')
   end
@@ -47,6 +54,12 @@ describe RuboCop::Cop::Naming::ConstantName do
 
   it 'does not check if rhs is another constant' do
     expect_no_offenses('Parser::CurrentRuby = Parser::Ruby21')
+  end
+
+  it 'does not check if rhs is a non-offensive const assignment' do
+    expect_no_offenses(<<-RUBY.strip_indent)
+      Bar = Foo = Qux
+    RUBY
   end
 
   it 'checks qualified const names' do


### PR DESCRIPTION
This change addresses #5053 .

If the rhs is another `casgn`, then the cop will double back and validate its correctness.

-----------------

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Used the same coding conventions as the rest of the project.
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] All tests(`rake spec`) are passing.
* [x] The new code doesn't generate RuboCop offenses that are checked by `rake internal_investigation`.
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.

[1]: http://chris.beams.io/posts/git-commit/
