### PR TITLE
[Fix #5059] Fix a false positive for `Style/MixinUsage`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,7 @@
 * [#4363](https://github.com/bbatsov/rubocop/issues/4363): Fix `Style/PercentLiteralDelimiters` incorrectly automatically modifies escaped percent literal delimiter. ([@koic][])
 * [#5053](https://github.com/bbatsov/rubocop/issues/5053): Fix `Naming/ConstantName` false offense on assigning to a nonoffensive assignment. ([@garettarrowood][])
 * [#5019](https://github.com/bbatsov/rubocop/pull/5019): Fix auto-correct for `Style/HashSyntax` cop when hash is used as unspaced argument. ([@drenmi][])
+* [#5059](https://github.com/bbatsov/rubocop/issues/5059): Fix a false positive for `Style/MixinUsage` when `include` call is a method argument. ([@koic][])
 
 ### Changes
 

--- a/lib/rubocop/cop/style/mixin_usage.rb
+++ b/lib/rubocop/cop/style/mixin_usage.rb
@@ -53,6 +53,7 @@ module RuboCop
 
         def on_send(node)
           include_statement(node) do |statement|
+            return if node.argument?
             return if accepted_include?(node)
 
             add_offense(node, message: format(MSG, statement: statement))

--- a/spec/rubocop/cop/style/mixin_usage_spec.rb
+++ b/spec/rubocop/cop/style/mixin_usage_spec.rb
@@ -52,6 +52,12 @@ describe RuboCop::Cop::Style::MixinUsage do
       RUBY
     end
 
+    it "doesn't register an offense when `include` call is a method argument" do
+      expect_no_offenses(<<-RUBY.strip_indent)
+        obj(include(M))
+      RUBY
+    end
+
     context 'Multiple definition classes in one' do
       it 'does not register an offense when using inside class' do
         expect_no_offenses(<<-RUBY.strip_indent)


### PR DESCRIPTION
Fixes #5059.

This PR solves the issue based on false positives detected against RSpec `Include matcher`.
https://relishapp.com/rspec/rspec-expectations/v/2-0/docs/matchers/include-matcher

If an `include` method is called with a method argument, treat it as false negative.
In this case, it's safe to assume it's not a mixin.

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Used the same coding conventions as the rest of the project.
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] All tests(`rake spec`) are passing.
* [x] The new code doesn't generate RuboCop offenses that are checked by `rake internal_investigation`.
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [ ] Updated cop documentation with `rake generate_cops_documentation` (required only when you've added a new cop or changed the configuration/documentation of an existing cop).

[1]: http://chris.beams.io/posts/git-commit/
