### PR TITLE
Fix a typo in mixin_usage_spec.rb

### DIFF
--- a/spec/rubocop/cop/style/mixin_usage_spec.rb
+++ b/spec/rubocop/cop/style/mixin_usage_spec.rb
@@ -54,7 +54,7 @@ describe RuboCop::Cop::Style::MixinUsage do
 
     it "doesn't register an offense when `include` call is a method argument" do
       expect_no_offenses(<<-RUBY.strip_indent)
-        obj(include(M))
+        do_something(include(M))
       RUBY
     end
 


### PR DESCRIPTION
Follow up of #5061.

This test case was intended for a method, not for an object.
This typo is my mistake 💦 I made the name used for test code proper.

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Used the same coding conventions as the rest of the project.
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [ ] Added tests.
* [ ] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] All tests(`rake spec`) are passing.
* [x] The new code doesn't generate RuboCop offenses that are checked by `rake internal_investigation`.
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [ ] Updated cop documentation with `rake generate_cops_documentation` (required only when you've added a new cop or changed the configuration/documentation of an existing cop).

[1]: http://chris.beams.io/posts/git-commit/
