### PR TITLE
[Fix #5052] Prevent Style/BracesAroundHashParameters from over autocorrection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,7 @@
 * [#4363](https://github.com/bbatsov/rubocop/issues/4363): Fix `Style/PercentLiteralDelimiters` incorrectly automatically modifies escaped percent literal delimiter. ([@koic][])
 * [#5053](https://github.com/bbatsov/rubocop/issues/5053): Fix `Naming/ConstantName` false offense on assigning to a nonoffensive assignment. ([@garettarrowood][])
 * [#5019](https://github.com/bbatsov/rubocop/pull/5019): Fix auto-correct for `Style/HashSyntax` cop when hash is used as unspaced argument. ([@drenmi][])
+* [#5052](https://github.com/bbatsov/rubocop/pull/5052): Improve accuracy of `Style/BracesAroundHashParameters` auto-correction. ([@garettarrowood][])
 * [#5059](https://github.com/bbatsov/rubocop/issues/5059): Fix a false positive for `Style/MixinUsage` when `include` call is a method argument. ([@koic][])
 * [#5071](https://github.com/bbatsov/rubocop/pull/5071): Fix a false positive in `Lint/UnneededSplatExpansion`, when `Array.new` resides in an array literal. ([@akhramov][])
 * [#4071](https://github.com/bbatsov/rubocop/issues/4071): Prevent generating wrong code by Style/ColonMethodCall and Style/RedundantSelf. ([@pocke][])

--- a/lib/rubocop/cop/internal_affairs/redundant_location_argument.rb
+++ b/lib/rubocop/cop/internal_affairs/redundant_location_argument.rb
@@ -49,7 +49,7 @@ module RuboCop
         end
 
         def offending_range(node)
-          with_space = range_with_surrounding_space(node.loc.expression)
+          with_space = range_with_surrounding_space(range: node.loc.expression)
 
           range_with_surrounding_comma(with_space, :left)
         end

--- a/lib/rubocop/cop/internal_affairs/redundant_message_argument.rb
+++ b/lib/rubocop/cop/internal_affairs/redundant_message_argument.rb
@@ -51,7 +51,7 @@ module RuboCop
         private
 
         def offending_range(node)
-          with_space = range_with_surrounding_space(node.loc.expression)
+          with_space = range_with_surrounding_space(range: node.loc.expression)
 
           range_with_surrounding_comma(with_space, :left)
         end

--- a/lib/rubocop/cop/layout/initial_indentation.rb
+++ b/lib/rubocop/cop/layout/initial_indentation.rb
@@ -29,7 +29,9 @@ module RuboCop
           return if token.pos.column.zero?
 
           token_with_space =
-            range_with_surrounding_space(token.pos, :left, false)
+            range_with_surrounding_space(range: token.pos,
+                                         side: :left,
+                                         newlines: false)
           # If the file starts with a byte order mark (BOM), the column can be
           # non-zero, but then we find out here if there's no space to the left
           # of the first token.

--- a/lib/rubocop/cop/layout/multiline_block_layout.rb
+++ b/lib/rubocop/cop/layout/multiline_block_layout.rb
@@ -85,8 +85,11 @@ module RuboCop
         end
 
         def autocorrect_arguments(corrector, node)
-          end_pos = range_with_surrounding_space(node.arguments.source_range,
-                                                 :right, false).end_pos
+          end_pos = range_with_surrounding_space(
+            range: node.arguments.source_range,
+            side: :right,
+            newlines: false
+          ).end_pos
           range = range_between(node.loc.begin.end.begin_pos, end_pos)
           corrector.replace(range, " |#{block_arg_string(node.arguments)}|")
         end

--- a/lib/rubocop/cop/layout/space_around_block_parameters.rb
+++ b/lib/rubocop/cop/layout/space_around_block_parameters.rb
@@ -99,8 +99,11 @@ module RuboCop
         def check_each_arg(args)
           args.children.butfirst.each do |arg|
             expr = arg.source_range
-            check_no_space(range_with_surrounding_space(expr, :left).begin_pos,
-                           expr.begin_pos - 1, 'Extra space before')
+            check_no_space(
+              range_with_surrounding_space(range: expr, side: :left).begin_pos,
+              expr.begin_pos - 1,
+              'Extra space before'
+            )
           end
         end
 

--- a/lib/rubocop/cop/layout/space_around_operators.rb
+++ b/lib/rubocop/cop/layout/space_around_operators.rb
@@ -99,7 +99,7 @@ module RuboCop
         end
 
         def check_operator(op, right_operand)
-          with_space = range_with_surrounding_space(op)
+          with_space = range_with_surrounding_space(range: op)
           return if with_space.source.start_with?("\n")
 
           offense(op, with_space, right_operand) do |msg|

--- a/lib/rubocop/cop/layout/space_before_block_braces.rb
+++ b/lib/rubocop/cop/layout/space_before_block_braces.rb
@@ -30,7 +30,7 @@ module RuboCop
           return if node.keywords?
 
           left_brace = node.loc.begin
-          space_plus_brace = range_with_surrounding_space(left_brace)
+          space_plus_brace = range_with_surrounding_space(range: left_brace)
           used_style =
             space_plus_brace.source.start_with?('{') ? :no_space : :space
 

--- a/lib/rubocop/cop/layout/space_before_first_arg.rb
+++ b/lib/rubocop/cop/layout/space_before_first_arg.rb
@@ -32,7 +32,8 @@ module RuboCop
           return unless expect_params_after_method_name?(node)
 
           first_arg = node.first_argument.source_range
-          first_arg_with_space = range_with_surrounding_space(first_arg, :left)
+          first_arg_with_space = range_with_surrounding_space(range: first_arg,
+                                                              side: :left)
           space = range_between(first_arg_with_space.begin_pos,
                                 first_arg.begin_pos)
 

--- a/lib/rubocop/cop/layout/space_inside_block_braces.rb
+++ b/lib/rubocop/cop/layout/space_inside_block_braces.rb
@@ -165,7 +165,8 @@ module RuboCop
               end
             end
           else
-            brace_with_space = range_with_surrounding_space(left_brace, :right)
+            brace_with_space = range_with_surrounding_space(range: left_brace,
+                                                            side: :right)
             space(brace_with_space.begin_pos + 1, brace_with_space.end_pos,
                   'Space inside { detected.')
           end
@@ -176,7 +177,8 @@ module RuboCop
         end
 
         def space_inside_right_brace(right_brace)
-          brace_with_space = range_with_surrounding_space(right_brace, :left)
+          brace_with_space = range_with_surrounding_space(range: right_brace,
+                                                          side: :left)
           space(brace_with_space.begin_pos, brace_with_space.end_pos - 1,
                 'Space inside } detected.')
         end

--- a/lib/rubocop/cop/layout/space_inside_string_interpolation.rb
+++ b/lib/rubocop/cop/layout/space_inside_string_interpolation.rb
@@ -51,14 +51,16 @@ module RuboCop
 
         def space_on_any_side?(node)
           interp = node.source_range
-          interp_with_surrounding_space = range_with_surrounding_space(interp)
+          interp_with_surrounding_space =
+            range_with_surrounding_space(range: interp)
 
           interp_with_surrounding_space != interp
         end
 
         def space_on_each_side?(node)
           interp = node.source_range
-          interp_with_surrounding_space = range_with_surrounding_space(interp)
+          interp_with_surrounding_space =
+            range_with_surrounding_space(range: interp)
 
           interp_with_surrounding_space.source == " #{interp.source} "
         end
@@ -66,8 +68,10 @@ module RuboCop
         def autocorrect(node)
           new_source = style == :no_space ? node.source : " #{node.source} "
           lambda do |corrector|
-            corrector.replace(range_with_surrounding_space(node.source_range),
-                              new_source)
+            corrector.replace(
+              range_with_surrounding_space(range: node.source_range),
+              new_source
+            )
           end
         end
       end

--- a/lib/rubocop/cop/lint/unneeded_disable.rb
+++ b/lib/rubocop/cop/lint/unneeded_disable.rb
@@ -48,12 +48,15 @@ module RuboCop
           # Eat the entire comment, the preceding space, and the preceding
           # newline if there is one.
           original_begin = range.begin_pos
-          range = range_with_surrounding_space(range, :left, true)
-          range_with_surrounding_space(range, :right,
+          range = range_with_surrounding_space(range: range,
+                                               side: :left,
+                                               newlines: true)
+          range_with_surrounding_space(range: range,
+                                       side: :right,
                                        # Special for a comment that
                                        # begins the file: remove
                                        # the newline at the end.
-                                       original_begin.zero?)
+                                       newlines: original_begin.zero?)
         end
 
         def directive_range_in_list(range, ranges)
@@ -61,13 +64,15 @@ module RuboCop
           # is NOT being removed?
           if ends_its_line?(ranges.last) && trailing_range?(ranges, range)
             # Eat the comma on the left.
-            range = range_with_surrounding_space(range, :left)
+            range = range_with_surrounding_space(range: range, side: :left)
             range = range_with_surrounding_comma(range, :left)
           end
 
           range = range_with_surrounding_comma(range, :right)
           # Eat following spaces up to EOL, but not the newline itself.
-          range_with_surrounding_space(range, :right, false)
+          range_with_surrounding_space(range: range,
+                                       side: :right,
+                                       newlines: false)
         end
 
         def each_unneeded_disable(cop_disabled_line_ranges, offenses, comments,

--- a/lib/rubocop/cop/lint/unneeded_require_statement.rb
+++ b/lib/rubocop/cop/lint/unneeded_require_statement.rb
@@ -40,7 +40,8 @@ module RuboCop
 
         def autocorrect(node)
           lambda do |corrector|
-            range = range_with_surrounding_space(node.loc.expression, :right)
+            range = range_with_surrounding_space(range: node.loc.expression,
+                                                 side: :right)
             corrector.remove(range)
           end
         end

--- a/lib/rubocop/cop/mixin/multiline_literal_brace_layout.rb
+++ b/lib/rubocop/cop/mixin/multiline_literal_brace_layout.rb
@@ -30,8 +30,8 @@ module RuboCop
           return if new_line_needed_before_closing_brace?(node)
 
           lambda do |corrector|
-            corrector.remove(range_with_surrounding_space(node.loc.end,
-                                                          :left))
+            corrector.remove(range_with_surrounding_space(range: node.loc.end,
+                                                          side: :left))
 
             corrector.insert_after(last_element_range_with_trailing_comma(node),
                                    node.loc.end.source)
@@ -113,8 +113,10 @@ module RuboCop
       end
 
       def last_element_trailing_comma_range(node)
-        range = range_with_surrounding_space(children(node).last.source_range,
-                                             :right).end.resize(1)
+        range = range_with_surrounding_space(
+          range: children(node).last.source_range,
+          side: :right
+        ).end.resize(1)
         range.source == ',' ? range : nil
       end
 

--- a/lib/rubocop/cop/mixin/unused_argument.rb
+++ b/lib/rubocop/cop/mixin/unused_argument.rb
@@ -31,7 +31,8 @@ module RuboCop
 
           if node.blockarg_type?
             lambda do |corrector|
-              range = range_with_surrounding_space(node.source_range, :left)
+              range = range_with_surrounding_space(range: node.source_range,
+                                                   side: :left)
               range = range_with_surrounding_comma(range, :left)
               corrector.remove(range)
             end

--- a/lib/rubocop/cop/style/braces_around_hash_parameters.rb
+++ b/lib/rubocop/cop/style/braces_around_hash_parameters.rb
@@ -135,10 +135,10 @@ module RuboCop
             remove_braces(corrector, node)
           else
             left_brace_and_space =
-              range_with_surrounding_space(node.loc.begin,
-                                           :right,
-                                           space[:newlines],
-                                           space[:left])
+              range_with_surrounding_space(range: node.loc.begin,
+                                           side: :right,
+                                           newlines: space[:newlines],
+                                           whitespace: space[:left])
             corrector.remove(left_brace_and_space)
             corrector.remove(right_brace_and_space)
           end
@@ -147,10 +147,10 @@ module RuboCop
         def right_brace_and_space(loc_end, space)
           brace_and_space =
             range_with_surrounding_space(
-              loc_end,
-              :left,
-              space[:newlines],
-              space[:right]
+              range: loc_end,
+              side: :left,
+              newlines: space[:newlines],
+              whitespace: space[:right]
             )
           range_with_surrounding_comma(brace_and_space, :left)
         end

--- a/lib/rubocop/cop/style/encoding.rb
+++ b/lib/rubocop/cop/style/encoding.rb
@@ -21,7 +21,8 @@ module RuboCop
 
         def autocorrect(range)
           lambda do |corrector|
-            corrector.remove(range_with_surrounding_space(range, :right))
+            corrector.remove(range_with_surrounding_space(range: range,
+                                                          side: :right))
           end
         end
 

--- a/lib/rubocop/cop/style/frozen_string_literal_comment.rb
+++ b/lib/rubocop/cop/style/frozen_string_literal_comment.rb
@@ -27,10 +27,11 @@ module RuboCop
           end
         end
 
-        def autocorrect(node)
+        def autocorrect(node) # rubocop:disable Metrics/MethodLength
           lambda do |corrector|
             if style == :never
-              corrector.remove(range_with_surrounding_space(node.pos, :right))
+              corrector.remove(range_with_surrounding_space(range: node.pos,
+                                                            side: :right))
             else
               last_special_comment = last_special_comment(processed_source)
               if last_special_comment.nil?

--- a/lib/rubocop/cop/style/hash_syntax.rb
+++ b/lib/rubocop/cop/style/hash_syntax.rb
@@ -171,7 +171,7 @@ module RuboCop
           op = pair_node.loc.operator
 
           range = range_between(key.source_range.begin_pos, op.end_pos)
-          range = range_with_surrounding_space(range, :right)
+          range = range_with_surrounding_space(range: range, side: :right)
 
           new_key = key.sym_type? ? key.value : key.source
 
@@ -191,7 +191,7 @@ module RuboCop
 
           corrector.insert_after(key, pair_node.inverse_delimiter(true))
           corrector.insert_before(key, ':')
-          corrector.remove(range_with_surrounding_space(op))
+          corrector.remove(range_with_surrounding_space(range: op))
         end
 
         def autocorrect_no_mixed_keys(corrector, pair_node)

--- a/lib/rubocop/cop/style/line_end_concatenation.rb
+++ b/lib/rubocop/cop/style/line_end_concatenation.rb
@@ -41,9 +41,9 @@ module RuboCop
 
         def autocorrect(operator_range)
           # Include any trailing whitespace so we don't create a syntax error.
-          operator_range = range_with_surrounding_space(operator_range,
-                                                        :right,
-                                                        false)
+          operator_range = range_with_surrounding_space(range: operator_range,
+                                                        side: :right,
+                                                        newlines: false)
           one_more_char = operator_range.resize(operator_range.size + 1)
           # Don't create a double backslash at the end of the line, in case
           # there already was a backslash after the concatenation operator.

--- a/lib/rubocop/cop/style/method_def_parentheses.rb
+++ b/lib/rubocop/cop/style/method_def_parentheses.rb
@@ -39,7 +39,8 @@ module RuboCop
               corrector.remove(node.loc.end)
             else
               args_expr = node.arguments.source_range
-              args_with_space = range_with_surrounding_space(args_expr, :left)
+              args_with_space = range_with_surrounding_space(range: args_expr,
+                                                             side: :left)
               just_space = range_between(args_with_space.begin_pos,
                                          args_expr.begin_pos)
               corrector.replace(just_space, '(')

--- a/lib/rubocop/cop/style/multiline_if_then.rb
+++ b/lib/rubocop/cop/style/multiline_if_then.rb
@@ -39,7 +39,7 @@ module RuboCop
         def autocorrect(node)
           lambda do |corrector|
             corrector.remove(
-              range_with_surrounding_space(node.loc.begin, :left)
+              range_with_surrounding_space(range: node.loc.begin, side: :left)
             )
           end
         end

--- a/lib/rubocop/cop/style/nested_parenthesized_calls.rb
+++ b/lib/rubocop/cop/style/nested_parenthesized_calls.rb
@@ -46,7 +46,8 @@ module RuboCop
           last_arg = nested.last_argument.source_range
 
           leading_space =
-            range_with_surrounding_space(first_arg, :left).begin.resize(1)
+            range_with_surrounding_space(range: first_arg,
+                                         side: :left).begin.resize(1)
 
           lambda do |corrector|
             corrector.replace(leading_space, '(')

--- a/lib/rubocop/cop/style/not.rb
+++ b/lib/rubocop/cop/style/not.rb
@@ -34,7 +34,8 @@ module RuboCop
         private
 
         def autocorrect(node)
-          range = range_with_surrounding_space(node.loc.selector, :right)
+          range = range_with_surrounding_space(range: node.loc.selector,
+                                               side: :right)
 
           if opposite_method?(node.receiver)
             correct_opposite_method(range, node.receiver)

--- a/lib/rubocop/cop/style/redundant_return.rb
+++ b/lib/rubocop/cop/style/redundant_return.rb
@@ -33,7 +33,7 @@ module RuboCop
 
         private
 
-        def autocorrect(node)
+        def autocorrect(node) # rubocop:disable Metrics/MethodLength
           lambda do |corrector|
             unless arguments?(node.children)
               corrector.replace(node.source_range, 'nil')
@@ -46,7 +46,8 @@ module RuboCop
             elsif return_value.hash_type?
               add_braces(corrector, return_value) unless return_value.braces?
             end
-            return_kw = range_with_surrounding_space(node.loc.keyword, :right)
+            return_kw = range_with_surrounding_space(range: node.loc.keyword,
+                                                     side: :right)
             corrector.remove(return_kw)
           end
         end

--- a/lib/rubocop/cop/style/symbol_proc.rb
+++ b/lib/rubocop/cop/style/symbol_proc.rb
@@ -102,7 +102,7 @@ module RuboCop
         def block_range_with_space(node)
           block_range = range_between(begin_pos_for_replacement(node),
                                       node.loc.end.end_pos)
-          range_with_surrounding_space(block_range, :left)
+          range_with_surrounding_space(range: block_range, side: :left)
         end
 
         def begin_pos_for_replacement(node)

--- a/lib/rubocop/cop/util.rb
+++ b/lib/rubocop/cop/util.rb
@@ -137,18 +137,19 @@ module RuboCop
         Parser::Source::Range.new(buffer, begin_pos, end_pos)
       end
 
-      def range_with_surrounding_space(range, side = :both, with_newline = true)
+      def range_with_surrounding_space(range,
+                                       side = :both,
+                                       newlines = true,
+                                       wspace = false)
         buffer = @processed_source.buffer
         src = buffer.source
 
         go_left, go_right = directions(side)
 
         begin_pos = range.begin_pos
+        begin_pos = final_pos(src, begin_pos, -1, newlines, wspace) if go_left
         end_pos = range.end_pos
-        begin_pos = move_pos(src, begin_pos, -1, go_left, /[ \t]/)
-        begin_pos = move_pos(src, begin_pos, -1, go_left && with_newline, /\n/)
-        end_pos = move_pos(src, end_pos, 1, go_right, /[ \t]/)
-        end_pos = move_pos(src, end_pos, 1, go_right && with_newline, /\n/)
+        end_pos = final_pos(src, end_pos, 1, newlines, wspace) if go_right
         Parser::Source::Range.new(buffer, begin_pos, end_pos)
       end
 
@@ -303,6 +304,14 @@ module RuboCop
         enforced_style
           .sub(/^Enforced/, 'Supported')
           .sub('Style', 'Styles')
+      end
+
+      private
+
+      def final_pos(src, pos, increment, newlines, whitespace)
+        pos = move_pos(src, pos, increment, true, /[ \t]/)
+        pos = move_pos(src, pos, increment, newlines, /\n/)
+        move_pos(src, pos, increment, whitespace, /\s/)
       end
     end
   end

--- a/spec/rubocop/cli/cli_autocorrect_spec.rb
+++ b/spec/rubocop/cli/cli_autocorrect_spec.rb
@@ -170,8 +170,10 @@ describe RuboCop::CLI, :isolated_environment do
 
         let(:expected_corrected_source) do
           <<-RUBY.strip_indent
-            func(@abc => 0,
-                 @xyz => 1)
+            func(
+              @abc => 0,
+              @xyz => 1,
+            )
             func(
               abc: 0,
             )
@@ -194,8 +196,10 @@ describe RuboCop::CLI, :isolated_environment do
 
         let(:expected_corrected_source) do
           <<-RUBY.strip_indent
-            func(@abc => 0,
-                 @xyz => 1)
+            func(
+              @abc => 0,
+              @xyz => 1,
+            )
             func(
               abc: 0,
             )
@@ -258,8 +262,10 @@ describe RuboCop::CLI, :isolated_environment do
 
         let(:expected_corrected_source) do
           <<-RUBY.strip_indent
-            func(@abc => 0,
-                 @xyz => 1,)
+            func(
+              @abc => 0,
+              @xyz => 1,
+            )
             func(
               abc: 0,
             )
@@ -282,8 +288,10 @@ describe RuboCop::CLI, :isolated_environment do
 
         let(:expected_corrected_source) do
           <<-RUBY.strip_indent
-            func(@abc => 0,
-                 @xyz => 1,)
+            func(
+              @abc => 0,
+              @xyz => 1,
+            )
             func(
               abc: 0,
             )
@@ -660,11 +668,13 @@ describe RuboCop::CLI, :isolated_environment do
     expect(cli.run(['-D', '--auto-correct'])).to eq(0)
     corrected =
       <<-RUBY.strip_indent
-        expect(subject[:address]).to eq(street1:     '1 Market',
-                                        street2:     '#200',
-                                        city:        'Some Town',
-                                        state:       'CA',
-                                        postal_code: '99999-1111')
+        expect(subject[:address]).to eq(
+          street1:     '1 Market',
+          street2:     '#200',
+          city:        'Some Town',
+          state:       'CA',
+          postal_code: '99999-1111'
+        )
       RUBY
     expect(IO.read('example.rb')).to eq(corrected)
   end

--- a/spec/rubocop/cop/style/braces_around_hash_parameters_spec.rb
+++ b/spec/rubocop/cop/style/braces_around_hash_parameters_spec.rb
@@ -138,6 +138,88 @@ describe RuboCop::Cop::Style::BracesAroundHashParameters, :config do
       expect(corrected).to eq('get :i, q: { x: 1 }')
     end
 
+    it 'does not remove trailing comma nor realign args' do
+      src = <<-RUBY.strip_indent
+      foo({
+        a: 1,
+        b: 2,
+      })
+      RUBY
+      corrected = autocorrect_source(src)
+      expect(corrected).to eq(<<-RUBY.strip_indent)
+      foo(
+        a: 1,
+        b: 2,
+      )
+      RUBY
+    end
+
+    it 'corrects brace removal with 2 extra lines' do
+      src = <<-RUBY.strip_indent
+      foo(
+        {
+          baz: 10
+        }
+      )
+      RUBY
+      corrected = autocorrect_source(src)
+      expect(corrected).to eq(<<-RUBY.strip_indent)
+      foo(
+        baz: 10
+      )
+      RUBY
+    end
+
+    it 'corrects brace removal with extra lines & mulitple pairs' do
+      src = <<-RUBY.strip_indent
+      foo(
+        {
+          qux: "bar",
+          baz: "bar",
+          thud: "bar"
+        }
+      )
+      RUBY
+      corrected = autocorrect_source(src)
+      expect(corrected).to eq(<<-RUBY.strip_indent)
+      foo(
+        qux: "bar",
+          baz: "bar",
+          thud: "bar"
+      )
+      RUBY
+    end
+
+    it 'corrects brace removal with lower extra line' do
+      src = <<-RUBY.strip_indent
+      foo({
+        baz: 7
+        }
+      )
+      RUBY
+      corrected = autocorrect_source(src)
+      expect(corrected).to eq(<<-RUBY.strip_indent)
+      foo(
+        baz: 7
+      )
+      RUBY
+    end
+
+    it 'corrects brace removal with top extra line' do
+      src = <<-RUBY.strip_indent
+      foo(
+        {
+          baz: 5
+      })
+      RUBY
+      corrected = autocorrect_source(src)
+      expect(corrected).to eq(<<-RUBY.strip_indent)
+      foo(
+        baz: 5
+      )
+      RUBY
+    end
+
     context 'with a comment following the last key-value pair' do
       it 'corrects and leaves line breaks' do
         src = <<-RUBY.strip_indent
@@ -195,6 +277,28 @@ describe RuboCop::Cop::Style::BracesAroundHashParameters, :config do
       it 'corrects two hash parameters with braces' do
         corrected = autocorrect_source(['where(1, { x: 1 }, { y: 2 })'])
         expect(corrected).to eq('where(1, { x: 1 }, y: 2)')
+      end
+
+      it 'corrects two hash parameters with braces & extra lines' do
+        src = <<-RUBY.strip_indent
+        foo(
+          {
+            qux: 9
+          },
+          {
+            bar: 0
+          }
+        )
+        RUBY
+        corrected = autocorrect_source(src)
+        expect(corrected).to eq(<<-RUBY.strip_indent)
+        foo(
+          {
+            qux: 9
+          },
+          bar: 0
+        )
+        RUBY
       end
     end
   end

--- a/spec/rubocop/cop/util_spec.rb
+++ b/spec/rubocop/cop/util_spec.rb
@@ -76,7 +76,8 @@ describe RuboCop::Cop::Util do
     subject do
       obj = TestUtil.new
       obj.instance_exec(processed_source) { |src| @processed_source = src }
-      r = obj.send(:range_with_surrounding_space, input_range, side)
+      r = obj.send(:range_with_surrounding_space, range: input_range,
+                                                  side: side)
       processed_source.buffer.source[r.begin_pos...r.end_pos]
     end
 


### PR DESCRIPTION
Addresses #5052 .

These changes make the autocorrection of `Style/BracesAroundHashParameters` quite a bit smarter. This solves the example from the issue, and goes a few steps further with slightly more complicated scenarios. Tests highlight the change.

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Used the same coding conventions as the rest of the project.
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] All tests(`rake spec`) are passing.
* [x] The new code doesn't generate RuboCop offenses that are checked by `rake internal_investigation`.
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.

[1]: http://chris.beams.io/posts/git-commit/
