### PR TITLE
Add "unannotated" option to Style/FormatStringToken cop

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -23,6 +23,12 @@ Naming/PredicateName:
 Style/FrozenStringLiteralComment:
   EnforcedStyle: always
 
+Style/FormatStringToken:
+  # Because we parse a lot of source codes from strings. Percent arrays
+  # look like unannotated format string tokens to this cop.
+  Exclude:
+    - spec/**/*
+
 Layout/EndOfLine:
   EnforcedStyle: lf
 

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -95,3 +95,9 @@ RSpec/SubjectStub:
 # Configuration parameters: IgnoreSymbolicNames.
 RSpec/VerifiedDoubles:
   Enabled: false
+
+# Offense count: 386
+# Configuration parameters: EnforcedStyle.
+# SupportedStyles: annotated, template, unannotated
+Style/FormatStringToken:
+  Enabled: false

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
 * Add `AllowedChars` option to `Style/AsciiComments` cop. ([@hedgesky][])
 * [#5031](https://github.com/bbatsov/rubocop/pull/5031): Add new `Style/EmptyBlockParameter` and `Style/EmptyLambdaParameter` cops. ([@pocke][])
 * [#5057](https://github.com/bbatsov/rubocop/pull/5057): Add new `Gemspec/RequiredRubyVersion` cop. ([@koic][])
+* Add `unannotated` option to `Style/FormatStringToken` cop. ([@drenmi][])
 
 ### Bug fixes
 

--- a/config/default.yml
+++ b/config/default.yml
@@ -917,6 +917,7 @@ Style/FormatStringToken:
     - annotated
     # Prefer simple looking "template" style tokens like `%{name}`, `%{age}`
     - template
+    - unannotated
 
 Style/FrozenStringLiteralComment:
   EnforcedStyle: when_needed

--- a/lib/rubocop/cop/style/format_string_token.rb
+++ b/lib/rubocop/cop/style/format_string_token.rb
@@ -6,24 +6,31 @@ module RuboCop
       # Use a consistent style for named format string tokens.
       #
       # @example EnforcedStyle: annotated (default)
-      #   # bad
       #
+      #   # bad
       #   format('%{greeting}', greeting: 'Hello')
       #   format('%s', 'Hello')
       #
       #   # good
-      #
       #   format('%<greeting>s', greeting: 'Hello')
       #
       # @example EnforcedStyle: template
-      #   # bad
       #
+      #   # bad
       #   format('%<greeting>s', greeting: 'Hello')
       #   format('%s', 'Hello')
       #
       #   # good
-      #
       #   format('%{greeting}', greeting: 'Hello')
+      #
+      # @example EnforcedStyle: unannotated
+      #
+      #   # bad
+      #   format('%<greeting>s', greeting: 'Hello')
+      #   format('%{greeting}', 'Hello')
+      #
+      #   # good
+      #   format('%s', 'Hello')
       class FormatStringToken < Cop
         include ConfigurableEnforcedStyle
 
@@ -31,7 +38,8 @@ module RuboCop
 
         STYLE_PATTERNS = {
           annotated: /(?<token>%<[^>]+>#{FIELD_CHARACTERS})/,
-          template:  /(?<token>%\{[^\}]+\})/
+          template: /(?<token>%\{[^\}]+\})/,
+          unannotated: /(?<token>%#{FIELD_CHARACTERS})/
         }.freeze
 
         TOKEN_PATTERN = Regexp.union(STYLE_PATTERNS.values)
@@ -56,14 +64,13 @@ module RuboCop
           "Prefer #{message_text(style)} over #{message_text(detected_style)}."
         end
 
-        # rubocop:disable FormatStringToken
         def message_text(style)
           case style
           when :annotated then 'annotated tokens (like `%<foo>s`)'
-          when :template  then 'template tokens (like `%{foo}`)'
+          when :template then 'template tokens (like `%{foo}`)'
+          when :unannotated then 'unannotated tokens (like `%s`)'
           end
         end
-        # rubocop:enable FormatStringToken
 
         def tokens(str_node, &block)
           return if str_node.source == '__FILE__'

--- a/manual/cops_style.md
+++ b/manual/cops_style.md
@@ -1583,23 +1583,27 @@ Use a consistent style for named format string tokens.
 
 ```ruby
 # bad
-
 format('%{greeting}', greeting: 'Hello')
 format('%s', 'Hello')
 
 # good
-
 format('%<greeting>s', greeting: 'Hello')
 ```
 ```ruby
 # bad
-
 format('%<greeting>s', greeting: 'Hello')
 format('%s', 'Hello')
 
 # good
-
 format('%{greeting}', greeting: 'Hello')
+```
+```ruby
+# bad
+format('%<greeting>s', greeting: 'Hello')
+format('%{greeting}', 'Hello')
+
+# good
+format('%s', 'Hello')
 ```
 
 ### Important attributes
@@ -1607,7 +1611,7 @@ format('%{greeting}', greeting: 'Hello')
 Attribute | Value
 --- | ---
 EnforcedStyle | annotated
-SupportedStyles | annotated, template
+SupportedStyles | annotated, template, unannotated
 
 ## Style/FrozenStringLiteralComment
 

--- a/spec/rubocop/cop/lint/format_parameter_mismatch_spec.rb
+++ b/spec/rubocop/cop/lint/format_parameter_mismatch_spec.rb
@@ -1,6 +1,5 @@
 # frozen_string_literal: true
 
-# rubocop:disable Style/FormatStringToken
 describe RuboCop::Cop::Lint::FormatParameterMismatch do
   subject(:cop) { described_class.new }
 
@@ -328,4 +327,3 @@ describe RuboCop::Cop::Lint::FormatParameterMismatch do
       .to eq(1)
   end
 end
-# rubocop:enable Style/FormatStringToken

--- a/spec/rubocop/cop/style/format_string_token_spec.rb
+++ b/spec/rubocop/cop/style/format_string_token_spec.rb
@@ -1,6 +1,5 @@
 # frozen_string_literal: true
 
-# rubocop:disable Style/FormatStringToken
 describe RuboCop::Cop::Style::FormatStringToken, :config do
   subject(:cop) { described_class.new(config) }
 
@@ -9,7 +8,7 @@ describe RuboCop::Cop::Style::FormatStringToken, :config do
   let(:cop_config) do
     {
       'EnforcedStyle' => enforced_style,
-      'SupportedStyles' => %i[annotated template]
+      'SupportedStyles' => %i[annotated template unannotated]
     }
   end
 
@@ -129,5 +128,12 @@ describe RuboCop::Cop::Style::FormatStringToken, :config do
     'Prefer template tokens (like `%{foo}`) ' \
     'over annotated tokens (like `%<foo>s`).'
   )
+
+  include_examples(
+    'offense message',
+    :unannotated,
+    '"%{foo}"',
+    'Prefer unannotated tokens (like `%s`) ' \
+    'over template tokens (like `%{foo}`).'
+  )
 end
-# rubocop:enable Style/FormatStringToken


### PR DESCRIPTION
This cop would previously only distinguish between annotated:

```
%<foo>s
```

and template:

```
%{foo}
```

style template strings. This change adds the ability to distinguish unannotated style:

```
%s
```

as well. This also means we have offenses for more or less all our cop messages. I'm planning to open an issue for this and tag it as low-hanging fruit. 🙂 

-----------------

Before submitting the PR make sure the following are checked:

* [X] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [X] Used the same coding conventions as the rest of the project.
* [X] Feature branch is up-to-date with `master` (if not - rebase it).
* [X] Squashed related commits together.
* [X] Added tests.
* [X] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [X] All tests(`rake spec`) are passing.
* [X] The new code doesn't generate RuboCop offenses that are checked by `rake internal_investigation`.
* [X] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [X] Updated cop documentation with `rake generate_cops_documentation` (required only when you've added a new cop or changed the configuration/documentation of an existing cop).

[1]: http://chris.beams.io/posts/git-commit/
