### PR TITLE
[Fix #5054] Lint/UnneededSplatExpansion: Array.new inside literal

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,7 @@
 * [#5053](https://github.com/bbatsov/rubocop/issues/5053): Fix `Naming/ConstantName` false offense on assigning to a nonoffensive assignment. ([@garettarrowood][])
 * [#5019](https://github.com/bbatsov/rubocop/pull/5019): Fix auto-correct for `Style/HashSyntax` cop when hash is used as unspaced argument. ([@drenmi][])
 * [#5059](https://github.com/bbatsov/rubocop/issues/5059): Fix a false positive for `Style/MixinUsage` when `include` call is a method argument. ([@koic][])
+* [#5071](https://github.com/bbatsov/rubocop/pull/5071): Fix a false positive in `Lint/UnneededSplatExpansion`, when `Array.new` resides in an array literal. ([@akhramov][])
 
 ### Changes
 


### PR DESCRIPTION
Currently `Lint/UnneededSplatExpansion` reports an offense when
`Array.new` is used inside array literal:

```ruby
foo = [1, 2, *Array.new(foo), 6]
```
Moreover, cop autocorrects this code to following:

```ruby
foo = [1, 2, [Array.new(foo)], 6]
```

This change adds a check whether `Array.new` resides in an array
literal, and if it does, the cop acts as following depending on
amount of elements in the literal:

| Example                | Offense reported?  | Autocorrects to  |
|------------------------|--------------------|------------------|
| `[*Array.new(foo)]`    | Yes                | `Array.new(foo)` |
| `[*Array.new(foo), 1]` | No                 |  N/A             |

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Used the same coding conventions as the rest of the project.
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] All tests(`rake spec`) are passing.
* [x] The new code doesn't generate RuboCop offenses that are checked by `rake internal_investigation`.
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [ ] Updated cop documentation with `rake generate_cops_documentation` (required only when you've added a new cop or changed the configuration/documentation of an existing cop).

[1]: http://chris.beams.io/posts/git-commit/
