### PR TITLE
Restyle example formatting for `Style/CommandLiteral` cop

### DIFF
--- a/lib/rubocop/cop/style/command_literal.rb
+++ b/lib/rubocop/cop/style/command_literal.rb
@@ -5,26 +5,75 @@ module RuboCop
     module Style
       # This cop enforces using `` or %x around command literals.
       #
-      # @example
-      #   # Good if EnforcedStyle is backticks or mixed, bad if percent_x.
-      #   folders = `find . -type d`.split
-      #
-      #   # Good if EnforcedStyle is percent_x, bad if backticks or mixed.
+      # @example EnforcedStyle: backticks (default)
+      #   # bad
       #   folders = %x(find . -type d).split
       #
-      #   # Good if EnforcedStyle is backticks, bad if percent_x or mixed.
-      #   `
-      #     ln -s foo.example.yml foo.example
-      #     ln -s bar.example.yml bar.example
-      #   `
-      #
-      #   # Good if EnforcedStyle is percent_x or mixed, bad if backticks.
+      #   # bad
       #   %x(
       #     ln -s foo.example.yml foo.example
       #     ln -s bar.example.yml bar.example
       #   )
       #
-      #   # Bad unless AllowInnerBackticks is true.
+      #   # good
+      #   folders = `find . -type d`.split
+      #
+      #   # good
+      #   `
+      #     ln -s foo.example.yml foo.example
+      #     ln -s bar.example.yml bar.example
+      #   `
+      #
+      # @example EnforcedStyle: mixed
+      #   # bad
+      #   folders = %x(find . -type d).split
+      #
+      #   # bad
+      #   `
+      #     ln -s foo.example.yml foo.example
+      #     ln -s bar.example.yml bar.example
+      #   `
+      #
+      #   # good
+      #   folders = `find . -type d`.split
+      #
+      #   # good
+      #   %x(
+      #     ln -s foo.example.yml foo.example
+      #     ln -s bar.example.yml bar.example
+      #   )
+      #
+      # @example EnforcedStyle: percent_x
+      #   # bad
+      #   folders = `find . -type d`.split
+      #
+      #   # bad
+      #   `
+      #     ln -s foo.example.yml foo.example
+      #     ln -s bar.example.yml bar.example
+      #   `
+      #
+      #   # good
+      #   folders = %x(find . -type d).split
+      #
+      #   # good
+      #   %x(
+      #     ln -s foo.example.yml foo.example
+      #     ln -s bar.example.yml bar.example
+      #   )
+      #
+      # @example AllowInnerBackticks: false (default)
+      #   # If `false`, the cop will always recommend using `%x` if one or more
+      #   # backticks are found in the command string.
+      #
+      #   # bad
+      #   `echo \`ls\``
+      #
+      #   # good
+      #   %x(echo `ls`)
+      #
+      # @example AllowInnerBackticks: true
+      #   # good
       #   `echo \`ls\``
       class CommandLiteral < Cop
         include ConfigurableEnforcedStyle

--- a/manual/cops_style.md
+++ b/manual/cops_style.md
@@ -625,25 +625,74 @@ This cop enforces using `` or %x around command literals.
 ### Example
 
 ```ruby
-# Good if EnforcedStyle is backticks or mixed, bad if percent_x.
-folders = `find . -type d`.split
-
-# Good if EnforcedStyle is percent_x, bad if backticks or mixed.
+# bad
 folders = %x(find . -type d).split
 
-# Good if EnforcedStyle is backticks, bad if percent_x or mixed.
-`
-  ln -s foo.example.yml foo.example
-  ln -s bar.example.yml bar.example
-`
-
-# Good if EnforcedStyle is percent_x or mixed, bad if backticks.
+# bad
 %x(
   ln -s foo.example.yml foo.example
   ln -s bar.example.yml bar.example
 )
 
-# Bad unless AllowInnerBackticks is true.
+# good
+folders = `find . -type d`.split
+
+# good
+`
+  ln -s foo.example.yml foo.example
+  ln -s bar.example.yml bar.example
+`
+```
+```ruby
+# bad
+folders = %x(find . -type d).split
+
+# bad
+`
+  ln -s foo.example.yml foo.example
+  ln -s bar.example.yml bar.example
+`
+
+# good
+folders = `find . -type d`.split
+
+# good
+%x(
+  ln -s foo.example.yml foo.example
+  ln -s bar.example.yml bar.example
+)
+```
+```ruby
+# bad
+folders = `find . -type d`.split
+
+# bad
+`
+  ln -s foo.example.yml foo.example
+  ln -s bar.example.yml bar.example
+`
+
+# good
+folders = %x(find . -type d).split
+
+# good
+%x(
+  ln -s foo.example.yml foo.example
+  ln -s bar.example.yml bar.example
+)
+```
+```ruby
+# If `false`, the cop will always recommend using `%x` if one or more
+# backticks are found in the command string.
+
+# bad
+`echo \`ls\``
+
+# good
+%x(echo `ls`)
+```
+```ruby
+# good
 `echo \`ls\``
 ```
 


### PR DESCRIPTION
Follow up of https://github.com/bbatsov/rubocop/pull/4880#issuecomment-338499947.

This commit is a change of document format for `Style/CommandLiteral` cop.

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Used the same coding conventions as the rest of the project.
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [ ] Added tests.
* [ ] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] All tests(`rake spec`) are passing.
* [x] The new code doesn't generate RuboCop offenses that are checked by `rake internal_investigation`.
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Updated cop documentation with `rake generate_cops_documentation` (required only when you've added a new cop or changed the configuration/documentation of an existing cop).

[1]: http://chris.beams.io/posts/git-commit/
