### PR TITLE
Workaround for `bundle conflict` in AppVeyor

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -5,7 +5,7 @@ version: "{build}"
 install:
   - set PATH=C:\Ruby%ruby_version%\bin;%PATH%
   - gem update --system 2.6.14 --no-document
-  - gem install bundler --no-document
+  - gem install bundler --no-document --force
   - bundle install --jobs 3 --retry 3
 
 build: off


### PR DESCRIPTION
Follow up of https://github.com/appveyor/ci/issues/1944#issuecomment-345496213

This is a workaround patch to AppVeyor config.
This change attempts to resolve the following error.

```console
gem install bundler --no-document
bundler's executable "bundle" conflicts with C:/Ruby23/bin/bundle
Overwrite the executable? [yN]
```

https://ci.appveyor.com/project/bbatsov/rubocop/build/1540/job/f8gxj2m6b53qe3tg#L23

This causes the job to fail with a timeout of 60 min.

> Build execution time has reached the maximum allowed time for your plan (60 minutes).

https://ci.appveyor.com/project/bbatsov/rubocop/build/1540/job/f8gxj2m6b53qe3tg/messages

This change attempt to solve by forcibly updating the bundler by adding `--force` option.
