### PR TITLE
Restyle example formatting for `Style/RegexpLiteral` cop

### DIFF
--- a/lib/rubocop/cop/style/regexp_literal.rb
+++ b/lib/rubocop/cop/style/regexp_literal.rb
@@ -5,28 +5,81 @@ module RuboCop
     module Style
       # This cop enforces using // or %r around regular expressions.
       #
-      # @example
-      #   # Good if EnforcedStyle is slashes or mixed, bad if percent_r.
-      #   snake_case = /^[\dA-Z_]+$/
-      #
-      #   # Good if EnforcedStyle is percent_r, bad if slashes or mixed.
+      # @example EnforcedStyle: slashes (default)
+      #   # bad
       #   snake_case = %r{^[\dA-Z_]+$}
       #
-      #   # Good if EnforcedStyle is slashes, bad if percent_r or mixed.
-      #   regex = /
-      #     foo
-      #     (bar)
-      #     (baz)
-      #   /x
-      #
-      #   # Good if EnforcedStyle is percent_r or mixed, bad if slashes.
+      #   # bad
       #   regex = %r{
       #     foo
       #     (bar)
       #     (baz)
       #   }x
       #
-      #   # Bad unless AllowInnerSlashes is true.
+      #   # good
+      #   snake_case = /^[\dA-Z_]+$/
+      #
+      #   # good
+      #   regex = /
+      #     foo
+      #     (bar)
+      #     (baz)
+      #   /x
+      #
+      # @example EnforcedStyle: percent_r
+      #   # bad
+      #   snake_case = /^[\dA-Z_]+$/
+      #
+      #   # bad
+      #   regex = /
+      #     foo
+      #     (bar)
+      #     (baz)
+      #   /x
+      #
+      #   # good
+      #   snake_case = %r{^[\dA-Z_]+$}
+      #
+      #   # good
+      #   regex = %r{
+      #     foo
+      #     (bar)
+      #     (baz)
+      #   }x
+      #
+      # @example EnforcedStyle: mixed
+      #   # bad
+      #   snake_case = %r{^[\dA-Z_]+$}
+      #
+      #   # bad
+      #   regex = /
+      #     foo
+      #     (bar)
+      #     (baz)
+      #   /x
+      #
+      #   # good
+      #   snake_case = /^[\dA-Z_]+$/
+      #
+      #   # good
+      #   regex = %r{
+      #     foo
+      #     (bar)
+      #     (baz)
+      #   }x
+      #
+      # @example AllowInnerSlashes: false (default)
+      #   # If `false`, the cop will always recommend using `%r` if one or more
+      #   # slashes are found in the regexp string.
+      #
+      #   # bad
+      #   x =~ /home\//
+      #
+      #   # good
+      #   x =~ %r{home/}
+      #
+      # @example AllowInnerSlashes: true
+      #   # good
       #   x =~ /home\//
       class RegexpLiteral < Cop
         include ConfigurableEnforcedStyle

--- a/manual/cops_style.md
+++ b/manual/cops_style.md
@@ -3742,27 +3742,80 @@ This cop enforces using // or %r around regular expressions.
 ### Example
 
 ```ruby
-# Good if EnforcedStyle is slashes or mixed, bad if percent_r.
-snake_case = /^[\dA-Z_]+$/
-
-# Good if EnforcedStyle is percent_r, bad if slashes or mixed.
+# bad
 snake_case = %r{^[\dA-Z_]+$}
 
-# Good if EnforcedStyle is slashes, bad if percent_r or mixed.
-regex = /
-  foo
-  (bar)
-  (baz)
-/x
-
-# Good if EnforcedStyle is percent_r or mixed, bad if slashes.
+# bad
 regex = %r{
   foo
   (bar)
   (baz)
 }x
 
-# Bad unless AllowInnerSlashes is true.
+# good
+snake_case = /^[\dA-Z_]+$/
+
+# good
+regex = /
+  foo
+  (bar)
+  (baz)
+/x
+```
+```ruby
+# bad
+snake_case = /^[\dA-Z_]+$/
+
+# bad
+regex = /
+  foo
+  (bar)
+  (baz)
+/x
+
+# good
+snake_case = %r{^[\dA-Z_]+$}
+
+# good
+regex = %r{
+  foo
+  (bar)
+  (baz)
+}x
+```
+```ruby
+# bad
+snake_case = %r{^[\dA-Z_]+$}
+
+# bad
+regex = /
+  foo
+  (bar)
+  (baz)
+/x
+
+# good
+snake_case = /^[\dA-Z_]+$/
+
+# good
+regex = %r{
+  foo
+  (bar)
+  (baz)
+}x
+```
+```ruby
+# If `false`, the cop will always recommend using `%r` if one or more
+# slashes are found in the regexp string.
+
+# bad
+x =~ /home\//
+
+# good
+x =~ %r{home/}
+```
+```ruby
+# good
 x =~ /home\//
 ```
 


### PR DESCRIPTION
Follow up of https://github.com/bbatsov/rubocop/pull/4880#issuecomment-338499947.

This commit is a change of document format for `Style/RegexpLiteral` cop.

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Used the same coding conventions as the rest of the project.
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [ ] Added tests.
* [ ] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] All tests(`rake spec`) are passing.
* [x] The new code doesn't generate RuboCop offenses that are checked by `rake internal_investigation`.
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Updated cop documentation with `rake generate_cops_documentation` (required only when you've added a new cop or changed the configuration/documentation of an existing cop).

[1]: http://chris.beams.io/posts/git-commit/
