### PR TITLE
Add an example of `EnforcedStyle` to `Style/LambdaCall` cop

### DIFF
--- a/lib/rubocop/cop/style/lambda_call.rb
+++ b/lib/rubocop/cop/style/lambda_call.rb
@@ -5,13 +5,19 @@ module RuboCop
     module Style
       # This cop checks for use of the lambda.(args) syntax.
       #
-      # @example
-      #
+      # @example EnforcedStyle: call (default)
       #  # bad
       #  lambda.(x, y)
       #
       #  # good
       #  lambda.call(x, y)
+      #
+      # @example EnforcedStyle: braces
+      #  # bad
+      #  lambda.call(x, y)
+      #
+      #  # good
+      #  lambda.(x, y)
       class LambdaCall < Cop
         include ConfigurableEnforcedStyle
 

--- a/manual/cops_style.md
+++ b/manual/cops_style.md
@@ -2150,6 +2150,13 @@ lambda.(x, y)
 # good
 lambda.call(x, y)
 ```
+```ruby
+# bad
+lambda.call(x, y)
+
+# good
+lambda.(x, y)
+```
 
 ### Important attributes
 


### PR DESCRIPTION
This is only document change.

This commit adds an example of `EnforcedStyle` to `Style/LambdaCall` cop.
I found it when I was investigating #4880.

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Used the same coding conventions as the rest of the project.
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [ ] Added tests.
* [ ] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] All tests(`rake spec`) are passing.
* [x] The new code doesn't generate RuboCop offenses that are checked by `rake internal_investigation`.
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Updated cop documentation with `rake generate_cops_documentation` (required only when you've added a new cop or changed the configuration/documentation of an existing cop).

[1]: http://chris.beams.io/posts/git-commit/
