### PR TITLE
[#4910] Add documentation examples to Style/RedundantSelf

### DIFF
--- a/lib/rubocop/cop/style/redundant_self.rb
+++ b/lib/rubocop/cop/style/redundant_self.rb
@@ -5,47 +5,42 @@ module RuboCop
     module Style
       # This cop checks for redundant uses of `self`.
       #
-      # `self` is only needed when:
+      # The usage of `self` is only needed when:
       #
       # * Sending a message to same object with zero arguments in
       #   presence of a method name clash with an argument or a local
       #   variable.
       #
-      #   Note, with using explicit self you can only send messages
-      #   with public or protected scope, you cannot send private
-      #   messages this way.
+      # * Calling an attribute writer to prevent an local variable assignment.
       #
-      #   Example:
+      # Note, with using explicit self you can only send messages with public or
+      # protected scope, you cannot send private messages this way.
       #
-      #   def bar
-      #     :baz
-      #   end
+      # Note we allow uses of `self` with operators because it would be awkward
+      # otherwise.
       #
+      # @example
+      #
+      #   # bad
       #   def foo(bar)
-      #     self.bar # resolves name clash with argument
+      #     self.baz
       #   end
       #
-      #   def foo2
-      #     bar = 1
-      #     self.bar # resolves name clash with local variable
+      #   # good
+      #   def foo(bar)
+      #     self.bar  # Resolves name clash with the argument.
       #   end
-      #
-      #   %w[x y z].select do |bar|
-      #     self.bar == bar # resolves name clash with argument of a block
-      #   end
-      #
-      # * Calling an attribute writer to prevent an local variable assignment
-      #
-      #   attr_writer :bar
       #
       #   def foo
-      #     self.bar= 1 # Make sure above attr writer is called
+      #     bar = 1
+      #     self.bar  # Resolves name clash with the local variable.
       #   end
       #
-      # Special cases:
-      #
-      # We allow uses of `self` with operators because it would be awkward
-      # otherwise.
+      #   def foo
+      #     %w[x y z].select do |bar|
+      #       self.bar == bar  # Resolves name clash with argument of the block.
+      #     end
+      #   end
       class RedundantSelf < Cop
         MSG = 'Redundant `self` detected.'.freeze
 

--- a/manual/cops_style.md
+++ b/manual/cops_style.md
@@ -3685,47 +3685,44 @@ Enabled | Yes
 
 This cop checks for redundant uses of `self`.
 
-`self` is only needed when:
+The usage of `self` is only needed when:
 
 * Sending a message to same object with zero arguments in
   presence of a method name clash with an argument or a local
   variable.
 
-  Note, with using explicit self you can only send messages
-  with public or protected scope, you cannot send private
-  messages this way.
+* Calling an attribute writer to prevent an local variable assignment.
 
-  Example:
+Note, with using explicit self you can only send messages with public or
+protected scope, you cannot send private messages this way.
 
-  def bar
-    :baz
-  end
-
-  def foo(bar)
-    self.bar # resolves name clash with argument
-  end
-
-  def foo2
-    bar = 1
-    self.bar # resolves name clash with local variable
-  end
-
-  %w[x y z].select do |bar|
-    self.bar == bar # resolves name clash with argument of a block
-  end
-
-* Calling an attribute writer to prevent an local variable assignment
-
-  attr_writer :bar
-
-  def foo
-    self.bar= 1 # Make sure above attr writer is called
-  end
-
-Special cases:
-
-We allow uses of `self` with operators because it would be awkward
+Note we allow uses of `self` with operators because it would be awkward
 otherwise.
+
+### Example
+
+```ruby
+# bad
+def foo(bar)
+  self.baz
+end
+
+# good
+def foo(bar)
+  self.bar  # Resolves name clash with the argument.
+end
+
+def foo
+  bar = 1
+  self.bar  # Resolves name clash with the local variable.
+end
+
+def foo
+  %w[x y z].select do |bar|
+    self.bar == bar  # Resolves name clash with argument of the block.
+  end
+end
+```
 
 ### References
 


### PR DESCRIPTION
Modifies the text and formatting of existing comments for Style/RedundantSelf to include the `@example` tag.

* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Used the same coding conventions as the rest of the project.
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [ ] Added tests.
* [ ] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] All tests(`rake spec`) are passing.
* [x] The new code doesn't generate RuboCop offenses that are checked by `rake internal_investigation`.
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Updated cop documentation with `rake generate_cops_documentation` (required only when you've added a new cop or changed the configuration/documentation of an existing cop).

[1]: http://chris.beams.io/posts/git-commit/
