### PR TITLE
[Fix #5089] Fix false positive for `Style/SafeNavigation`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,7 @@
 * [#5019](https://github.com/bbatsov/rubocop/pull/5019): Fix auto-correct for `Style/HashSyntax` cop when hash is used as unspaced argument. ([@drenmi][])
 * [#5059](https://github.com/bbatsov/rubocop/issues/5059): Fix a false positive for `Style/MixinUsage` when `include` call is a method argument. ([@koic][])
 * [#5071](https://github.com/bbatsov/rubocop/pull/5071): Fix a false positive in `Lint/UnneededSplatExpansion`, when `Array.new` resides in an array literal. ([@akhramov][])
+* [#5089](https://github.com/bbatsov/rubocop/issues/5089): Fix false positive for `Style/SafeNavigation` when safe guarding arithmetic operation or assignment. ([@tiagotex][])
 
 ### Changes
 
@@ -3038,3 +3039,4 @@
 [@garettarrowood]: https://github.com/garettarrowood
 [@sambostock]: https://github.com/sambostock
 [@asherkach]: https://github.com/asherkach
+[@tiagotex]: https://github.com/tiagotex

--- a/lib/rubocop/ast/node.rb
+++ b/lib/rubocop/ast/node.rb
@@ -24,6 +24,7 @@ module RuboCop
 
       # <=> isn't included here, because it doesn't return a boolean.
       COMPARISON_OPERATORS = %i[== === != <= >= > <].freeze
+      ARITHMETIC_OPERATORS = %i[+ - * / % **].freeze
 
       TRUTHY_LITERALS = %i[str dstr xstr int float sym dsym array
                            hash regexp true irange erange complex
@@ -329,6 +330,10 @@ module RuboCop
       def asgn_method_call?
         !COMPARISON_OPERATORS.include?(method_name) &&
           method_name.to_s.end_with?('='.freeze)
+      end
+
+      def arithmetic_operation?
+        ARITHMETIC_OPERATORS.include?(method_name)
       end
 
       def_node_matcher :equals_asgn?, <<-PATTERN

--- a/lib/rubocop/cop/style/safe_navigation.rb
+++ b/lib/rubocop/cop/style/safe_navigation.rb
@@ -150,7 +150,10 @@ module RuboCop
                        node.receiver
                      end
 
-          return receiver if receiver == checked_variable
+          if receiver == checked_variable
+            return nil if node.assignment? || node.parent.arithmetic_operation?
+            return receiver
+          end
 
           find_matching_receiver_invocation(receiver, checked_variable)
         end

--- a/spec/rubocop/cop/style/safe_navigation_spec.rb
+++ b/spec/rubocop/cop/style/safe_navigation_spec.rb
@@ -45,6 +45,16 @@ describe RuboCop::Cop::Style::SafeNavigation, :config do
       expect_no_offenses('foo + bar if foo')
     end
 
+    it 'allows chained method calls during arithmetic operations safe ' \
+      'guarded by an object check' do
+      expect_no_offenses('foo.baz + bar if foo')
+    end
+
+    it 'allows chained method calls during assignment safe guarded' \
+      'by an object check' do
+      expect_no_offenses('foo.baz = bar if foo')
+    end
+
     it 'allows object checks in the condition of an elsif statement ' \
       'and a method call on that object in the body' do
       expect_no_offenses(<<-RUBY.strip_indent)


### PR DESCRIPTION
Fixes #5089.

This PR solves the false positive in Style/SafeNavigation when doing arithmetic operations or assignment with chained method calls with a safe guard on object check.

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Used the same coding conventions as the rest of the project.
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] All tests(`rake spec`) are passing.
* [x] The new code doesn't generate RuboCop offenses that are checked by `rake internal_investigation`.
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Updated cop documentation with `rake generate_cops_documentation` (required only when you've added a new cop or changed the configuration/documentation of an existing cop).

[1]: http://chris.beams.io/posts/git-commit/