### PR TITLE
[Fix #5039] Fix Rails/Delegate by adding a necessary nil check.

### DIFF
--- a/lib/rubocop/cop/rails/delegate.rb
+++ b/lib/rubocop/cop/rails/delegate.rb
@@ -87,8 +87,8 @@ module RuboCop
         end
 
         def delegate?(body)
-          body && body.send_type? && body.receiver.send_type? &&
-            !body.receiver.receiver
+          body && body.send_type? && body.receiver &&
+            body.receiver.send_type? && !body.receiver.receiver
         end
 
         def arguments_match?(arg_array, body)

--- a/spec/rubocop/cop/rails/delegate_spec.rb
+++ b/spec/rubocop/cop/rails/delegate_spec.rb
@@ -138,6 +138,14 @@ describe RuboCop::Cop::Rails::Delegate do
     RUBY
   end
 
+  it 'ignores code with no receiver' do
+    expect_no_offenses(<<-RUBY.strip_indent)
+      def change
+        add_column :images, :size, :integer
+      end
+    RUBY
+  end
+
   context 'with EnforceForPrefixed: false' do
     let(:cop_config) do
       { 'EnforceForPrefixed' => false }


### PR DESCRIPTION
This [commit](https://github.com/bbatsov/rubocop/commit/779a4df62397f0dddd904bd2fd3627e9eaf328b6) altered the implementation of `Rubocop::Cop::Rails::Delegate#delegate?`. The previous `receiver.respond_to?(:type)` was an implicit null check on `receiver`, whereas the new `body.receiver.send_type?` does not offer this implicit safeguard. This PR makes the null check explicit by adding a `body.receiver` conjunct.

-----------------

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Used the same coding conventions as the rest of the project.
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [ ] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] All tests(`rake spec`) are passing.
* [x] The new code doesn't generate RuboCop offenses that are checked by `rake internal_investigation`.
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [ ] Updated cop documentation with `rake generate_cops_documentation` (required only when you've added a new cop or changed the configuration/documentation of an existing cop).

[1]: http://chris.beams.io/posts/git-commit/
