### PR TITLE
Fix obvious bug.

### DIFF
--- a/lib/rubocop/cop/lint/rescue_type.rb
+++ b/lib/rubocop/cop/lint/rescue_type.rb
@@ -59,7 +59,7 @@ module RuboCop
 
         def autocorrect(node)
           rescued, _, _body = *node
-          range = Parser::Source::Range.new(node.loc.expression,
+          range = Parser::Source::Range.new(node.loc.expression.source_buffer,
                                             node.loc.keyword.end_pos,
                                             rescued.loc.expression.end_pos)
 

--- a/lib/rubocop/cop/style/empty_literal.rb
+++ b/lib/rubocop/cop/style/empty_literal.rb
@@ -67,9 +67,8 @@ module RuboCop
             # to rewrite the arguments to wrap them in parenthesis.
             _receiver, _method_name, *args = *node.parent
 
-            Parser::Source::Range.new(node.parent.loc.expression,
-                                      args[0].loc.expression.begin_pos - 1,
-                                      args[-1].loc.expression.end_pos)
+            range_between(args[0].loc.expression.begin_pos - 1,
+                          args[-1].loc.expression.end_pos)
           else
             node.source_range
           end


### PR DESCRIPTION
While investigating other things, I found this obvious bug (first argument of `Range` should be a `SourceBuffer`, but it's not enforced)