### PR TITLE
Corrector: Add check that range given has the right buffer.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### New features
 
+* Corrector now checks that Ranges given are of correct SourceBuffer. ([@marcandre][])
 * New cop `Rails/InverseOf` checks for association arguments that require setting the `inverse_of` option manually. ([@bdewater][])
 * [#4252](https://github.com/bbatsov/rubocop/issues/4252): Add new `Style/TrailingBodyOnMethodDefinition` cop. ([@garettarrowood][])
 * Add new `Style/TrailingMethodEndStatment` cop. ([@garettarrowood][])

--- a/lib/rubocop/cop/corrector.rb
+++ b/lib/rubocop/cop/corrector.rb
@@ -67,6 +67,7 @@ module RuboCop
       #
       # @param [Parser::Source::Range] range
       def remove(range)
+        check_range(range)
         @source_rewriter.remove(range)
       end
 
@@ -75,6 +76,7 @@ module RuboCop
       # @param [Parser::Source::Range] range
       # @param [String] content
       def insert_before(range, content)
+        check_range(range)
         @source_rewriter.insert_before(range, content)
       end
 
@@ -83,6 +85,7 @@ module RuboCop
       # @param [Parser::Source::Range] range
       # @param [String] content
       def insert_after(range, content)
+        check_range(range)
         @source_rewriter.insert_after(range, content)
       end
 
@@ -91,6 +94,7 @@ module RuboCop
       # @param [Parser::Source::Range] range
       # @param [String] content
       def replace(range, content)
+        check_range(range)
         @source_rewriter.replace(range, content)
       end
 
@@ -102,6 +106,7 @@ module RuboCop
         to_remove = Parser::Source::Range.new(range.source_buffer,
                                               range.begin_pos - size,
                                               range.begin_pos)
+        check_range(to_remove)
         @source_rewriter.remove(to_remove)
       end
 
@@ -115,6 +120,7 @@ module RuboCop
         to_remove = Parser::Source::Range.new(range.source_buffer,
                                               range.begin_pos,
                                               range.begin_pos + size)
+        check_range(to_remove)
         @source_rewriter.remove(to_remove)
       end
 
@@ -128,7 +134,13 @@ module RuboCop
         to_remove = Parser::Source::Range.new(range.source_buffer,
                                               range.end_pos - size,
                                               range.end_pos)
+        check_range(to_remove)
         @source_rewriter.remove(to_remove)
+      end
+
+      private
+      def check_range(range)
+        raise ArgumentError, "The given range has the wrong source_buffer" unless range.source_buffer == @source_buffer
       end
     end
   end

--- a/lib/rubocop/cop/lint/rescue_type.rb
+++ b/lib/rubocop/cop/lint/rescue_type.rb
@@ -59,7 +59,7 @@ module RuboCop
 
         def autocorrect(node)
           rescued, _, _body = *node
-          range = Parser::Source::Range.new(node.loc.expression,
+          range = Parser::Source::Range.new(node.loc.expression.source_buffer,
                                             node.loc.keyword.end_pos,
                                             rescued.loc.expression.end_pos)
 

--- a/lib/rubocop/cop/style/empty_literal.rb
+++ b/lib/rubocop/cop/style/empty_literal.rb
@@ -67,7 +67,7 @@ module RuboCop
             # to rewrite the arguments to wrap them in parenthesis.
             _receiver, _method_name, *args = *node.parent
 
-            Parser::Source::Range.new(node.parent.loc.expression,
+            Parser::Source::Range.new(node.parent.loc.expression.source_buffer,
                                       args[0].loc.expression.begin_pos - 1,
                                       args[-1].loc.expression.end_pos)
           else

--- a/spec/rubocop/cop/corrector_spec.rb
+++ b/spec/rubocop/cop/corrector_spec.rb
@@ -1,6 +1,29 @@
 # frozen_string_literal: true
 
 describe RuboCop::Cop::Corrector do
+  { replace: 'hello',
+    remove: nil,
+    insert_before: 'hi',
+    insert_after: '!',
+  }.each do |method, arg|
+    describe "##{method}" do
+      it 'requires ranges with the same source_buffer' do
+        processed_source = parse_source('2 * 21')
+        corrector = described_class.new(processed_source.buffer)
+        other_source = parse_source('42')
+
+        expect {
+          corrector.send(method, other_source.ast.loc.expression, *arg)
+        }.to raise_error(ArgumentError)
+
+        # Sanity check that test works with same buffer:
+        expect {
+          corrector.send(method, processed_source.ast.loc.expression, *arg)
+        }.not_to raise_error
+      end
+    end
+  end
+
   describe '#rewrite' do
     it 'allows removal of a range' do
       source = 'true and false'


### PR DESCRIPTION
This checks that range given to Corrector have the right buffer.

Two instances in the code where ranges have source buffers that are not even source buffers are also fixed.

This superceedes #5093.