### PR TITLE
[Fix #4071] Prevent generating wrong code by Style/ColonMethodCall and Style/RedundantSelf

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,7 @@
 * [#5019](https://github.com/bbatsov/rubocop/pull/5019): Fix auto-correct for `Style/HashSyntax` cop when hash is used as unspaced argument. ([@drenmi][])
 * [#5059](https://github.com/bbatsov/rubocop/issues/5059): Fix a false positive for `Style/MixinUsage` when `include` call is a method argument. ([@koic][])
 * [#5071](https://github.com/bbatsov/rubocop/pull/5071): Fix a false positive in `Lint/UnneededSplatExpansion`, when `Array.new` resides in an array literal. ([@akhramov][])
+* [#4071](https://github.com/bbatsov/rubocop/issues/4071): Prevent generating wrong code by Style/ColonMethodCall and Style/RedundantSelf. ([@pocke][])
 
 ### Changes
 

--- a/lib/rubocop/cop/style/colon_method_call.rb
+++ b/lib/rubocop/cop/style/colon_method_call.rb
@@ -26,6 +26,10 @@ module RuboCop
             {:boolean :byte :char :double :float :int :long :short})
         PATTERN
 
+        def self.autocorrect_incompatible_with
+          [RedundantSelf]
+        end
+
         def on_send(node)
           # ignore Java interop code like Java::int
           return if java_type_node?(node)

--- a/lib/rubocop/cop/style/redundant_self.rb
+++ b/lib/rubocop/cop/style/redundant_self.rb
@@ -44,6 +44,10 @@ module RuboCop
       class RedundantSelf < Cop
         MSG = 'Redundant `self` detected.'.freeze
 
+        def self.autocorrect_incompatible_with
+          [ColonMethodCall]
+        end
+
         def initialize(config = nil, options = nil)
           super
           @allowed_send_nodes = []

--- a/spec/rubocop/cop/team_spec.rb
+++ b/spec/rubocop/cop/team_spec.rb
@@ -28,6 +28,10 @@ describe RuboCop::Cop::Team do
           "#{baz}"
 
         i=i+1
+
+        def a
+          self::b
+        end
       RUBY
       corrected = <<-'RUBY'.strip_indent
         foo.map(&:nil?)
@@ -37,6 +41,10 @@ describe RuboCop::Cop::Team do
           "#{baz}"
 
         i += 1
+
+        def a
+          b
+        end
       RUBY
 
       create_file(file_path, source)


### PR DESCRIPTION

Problem
=====

Style/ColonMethodCall and Style/RedundantSelf generate wrong code with auto-correction.

```ruby
def a
  self::b
end
```

```bash
$ rubocop --only RedundantSelf,ColonMethodCall -a
Inspecting 2 files
C.

Offenses:

test.rb:2:3: C: [Corrected] Style/RedundantSelf: Redundant self detected.
  self::b
  ^^^^^^^
test.rb:2:7: C: [Corrected] Style/ColonMethodCall: Do not use :: for method calls.
  self::b
      ^^

2 files inspected, 2 offenses detected, 2 offenses corrected

$ cat test.rb
def a
  .b
end
```

See #4071

Solution
=====

Make auto-correction for these cops not to execute at the same time.



-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Used the same coding conventions as the rest of the project.
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] All tests(`rake spec`) are passing.
* [x] The new code doesn't generate RuboCop offenses that are checked by `rake internal_investigation`.
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Updated cop documentation with `rake generate_cops_documentation` (required only when you've added a new cop or changed the configuration/documentation of an existing cop).

[1]: http://chris.beams.io/posts/git-commit/
