### PR TITLE
Mixin grouping

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@
 
 ### Bug fixes
 
+* [#5096](https://github.com/bbatsov/rubocop/issues/5096): Fix incorrect detection and autocorrection of multiple extend/include/prepend. ([@marcandre][])
 * [#4662](https://github.com/bbatsov/rubocop/issues/4662): Fix incorrect indent level detection when first line of heredoc is blank. ([@sambostock][])
 * [#4866](https://github.com/bbatsov/rubocop/issues/4866): Prevent `Layout/BlockEndNewline` cop from introducing trailing whitespaces. ([@bgeuken][])
 * [#3396](https://github.com/bbatsov/rubocop/issues/3396): Concise error when config. file not found. ([@jaredbeck][])
@@ -3041,3 +3042,4 @@
 [@sambostock]: https://github.com/sambostock
 [@asherkach]: https://github.com/asherkach
 [@tiagotex]: https://github.com/tiagotex
+[@marcandre]: https://github.com/marcandre

--- a/lib/rubocop/cop/style/mixin_grouping.rb
+++ b/lib/rubocop/cop/style/mixin_grouping.rb
@@ -95,6 +95,7 @@ module RuboCop
 
         def sibling_mixins(send_node)
           siblings = send_node.parent.each_child_node(:send)
+                              .select(&:macro?)
 
           siblings.select do |sibling_node|
             sibling_node.method_name == send_node.method_name

--- a/spec/rubocop/cop/style/mixin_grouping_spec.rb
+++ b/spec/rubocop/cop/style/mixin_grouping_spec.rb
@@ -266,6 +266,25 @@ describe RuboCop::Cop::Style::MixinGrouping, :config do
                          'end'].join("\n")
       end
 
+      context 'with mixins with receivers' do
+        let(:offenses) { 2 }
+        let(:message) { 'Put `prepend` mixins in a single statement.' }
+
+        it_behaves_like 'code with offense',
+                        ['class Foo',
+                         '  prepend Bar',
+                         '  Other.prepend Baz',
+                         '  do_something_else',
+                         '  prepend Qux',
+                         'end'].join("\n"),
+                        ['class Foo',
+                         '  prepend Qux, Bar',
+                         '  Other.prepend Baz',
+                         '  do_something_else',
+                         '  ', # extra line left by prepend Qux
+                         'end'].join("\n")
+      end
+
       context 'with several mixins in one call' do
         it_behaves_like 'code without offense', <<-RUBY.strip_indent
           class Foo

--- a/spec/rubocop/cop/style/mixin_grouping_spec.rb
+++ b/spec/rubocop/cop/style/mixin_grouping_spec.rb
@@ -248,6 +248,24 @@ describe RuboCop::Cop::Style::MixinGrouping, :config do
                          'end'].join("\n")
       end
 
+      context 'with single mixins in separate calls, intersperced' do
+        let(:offenses) { 3 }
+        let(:message) { 'Put `prepend` mixins in a single statement.' }
+
+        it_behaves_like 'code with offense',
+                        ['class Foo',
+                         '  prepend Bar',
+                         '  prepend Baz',
+                         '  do_something_else',
+                         '  prepend Qux',
+                         'end'].join("\n"),
+                        ['class Foo',
+                         '  prepend Qux, Baz, Bar',
+                         '  do_something_else',
+                         '  ', # extra line left by prepend Qux
+                         'end'].join("\n")
+      end
+
       context 'with several mixins in one call' do
         it_behaves_like 'code without offense', <<-RUBY.strip_indent
           class Foo


### PR DESCRIPTION
This is 3 fixes for the price of one.

First, this cop was doing multiple replacement rules for the same range. Only the first one was the correct one, so the tests were passing only because Rubocop silently swallows the `ClobberingError` of the erroneous subsequent replacements.

Second, the replacement was nuking anything in between two mixins

Thirdly, mixins with receivers could also create invalid code.

Note: Part of investigating [`parser`'s rewritter](https://github.com/whitequark/parser/issues/401)...