### PR TITLE
 Improve configurable attributes section in the documentation

### DIFF
--- a/manual/cops_bundler.md
+++ b/manual/cops_bundler.md
@@ -33,11 +33,11 @@ end
 gem 'rubocop', groups: [:development, :test]
 ```
 
-### Important attributes
+### Configurable attributes
 
-Attribute | Value
---- | ---
-Include | \*\*/Gemfile, \*\*/gems.rb
+Name | Default value | Configurable values
+--- | --- | ---
+Include | `**/Gemfile`, `**/gems.rb` | Array
 
 ## Bundler/InsecureProtocolSource
 
@@ -71,11 +71,11 @@ source 'https://rubygems.org' # strongly recommended
 source 'http://rubygems.org'
 ```
 
-### Important attributes
+### Configurable attributes
 
-Attribute | Value
---- | ---
-Include | \*\*/Gemfile, \*\*/gems.rb
+Name | Default value | Configurable values
+--- | --- | ---
+Include | `**/Gemfile`, `**/gems.rb` | Array
 
 ## Bundler/OrderedGems
 
@@ -108,9 +108,9 @@ gem 'rubocop'
 gem 'rspec'
 ```
 
-### Important attributes
+### Configurable attributes
 
-Attribute | Value
---- | ---
-Include | \*\*/Gemfile, \*\*/gems.rb
-TreatCommentsAsGroupSeparators | true
+Name | Default value | Configurable values
+--- | --- | ---
+Include | `**/Gemfile`, `**/gems.rb` | Array
+TreatCommentsAsGroupSeparators | `true` | Boolean

--- a/manual/cops_gemspec.md
+++ b/manual/cops_gemspec.md
@@ -41,11 +41,11 @@ Gem::Specification.new do |spec|
 end
 ```
 
-### Important attributes
+### Configurable attributes
 
-Attribute | Value
---- | ---
-Include | \*\*/\*.gemspec
+Name | Default value | Configurable values
+--- | --- | ---
+Include | `**/*.gemspec` | Array
 
 ## Gemspec/OrderedDependencies
 
@@ -104,12 +104,12 @@ spec.add_dependency 'rubocop'
 spec.add_dependency 'rspec'
 ```
 
-### Important attributes
+### Configurable attributes
 
-Attribute | Value
---- | ---
-Include | \*\*/\*.gemspec
-TreatCommentsAsGroupSeparators | true
+Name | Default value | Configurable values
+--- | --- | ---
+Include | `**/*.gemspec` | Array
+TreatCommentsAsGroupSeparators | `true` | Boolean
 
 ## Gemspec/RequiredRubyVersion
 
@@ -153,8 +153,8 @@ Gem::Specification.new do |spec|
 end
 ```
 
-### Important attributes
+### Configurable attributes
 
-Attribute | Value
---- | ---
-Include | \*\*/\*.gemspec
+Name | Default value | Configurable values
+--- | --- | ---
+Include | `**/*.gemspec` | Array

--- a/manual/cops_layout.md
+++ b/manual/cops_layout.md
@@ -38,13 +38,12 @@ private
 end
 ```
 
-### Important attributes
+### Configurable attributes
 
-Attribute | Value
---- | ---
-EnforcedStyle | indent
-SupportedStyles | outdent, indent
-IndentationWidth |
+Name | Default value | Configurable values
+--- | --- | ---
+EnforcedStyle | `indent` | `outdent`, `indent`
+IndentationWidth | `<none>` | Integer
 
 ### References
 
@@ -182,16 +181,13 @@ can also be configured. The options are:
 }
 ```
 
-### Important attributes
+### Configurable attributes
 
-Attribute | Value
---- | ---
-EnforcedHashRocketStyle | key
-SupportedHashRocketStyles | key, separator, table
-EnforcedColonStyle | key
-SupportedColonStyles | key, separator, table
-EnforcedLastArgumentHashStyle | always_inspect
-SupportedLastArgumentHashStyles | always_inspect, always_ignore, ignore_implicit, ignore_explicit
+Name | Default value | Configurable values
+--- | --- | ---
+EnforcedHashRocketStyle | `key` | `key`, `separator`, `table`
+EnforcedColonStyle | `key` | `key`, `separator`, `table`
+EnforcedLastArgumentHashStyle | `always_inspect` | `always_inspect`, `always_ignore`, `ignore_implicit`, `ignore_explicit`
 
 ## Layout/AlignParameters
 
@@ -227,13 +223,12 @@ foo :bar,
     :baz
 ```
 
-### Important attributes
+### Configurable attributes
 
-Attribute | Value
---- | ---
-EnforcedStyle | with_first_parameter
-SupportedStyles | with_first_parameter, with_fixed_indentation
-IndentationWidth |
+Name | Default value | Configurable values
+--- | --- | ---
+EnforcedStyle | `with_first_parameter` | `with_first_parameter`, `with_fixed_indentation`
+IndentationWidth | `<none>` | Integer
 
 ### References
 
@@ -344,14 +339,13 @@ else
 end
 ```
 
-### Important attributes
+### Configurable attributes
 
-Attribute | Value
---- | ---
-EnforcedStyle | case
-SupportedStyles | case, end
-IndentOneStep | false
-IndentationWidth |
+Name | Default value | Configurable values
+--- | --- | ---
+EnforcedStyle | `case` | `case`, `end`
+IndentOneStep | `false` | Boolean
+IndentationWidth | `<none>` | Integer
 
 ### References
 
@@ -465,12 +459,12 @@ class Person
 end
 ```
 
-### Important attributes
+### Configurable attributes
 
-Attribute | Value
---- | ---
-Categories | {"module_inclusion"=>["include", "prepend", "extend"]}
-ExpectedOrder | module_inclusion, constants, public_class_methods, initializer, instance_methods, protected_methods, private_methods
+Name | Default value | Configurable values
+--- | --- | ---
+Categories | `{"module_inclusion"=>["include", "prepend", "extend"]}` | 
+ExpectedOrder | `module_inclusion`, `constants`, `public_class_methods`, `initializer`, `instance_methods`, `protected_methods`, `private_methods` | Array
 
 ### References
 
@@ -574,12 +568,11 @@ something.
   mehod
 ```
 
-### Important attributes
+### Configurable attributes
 
-Attribute | Value
---- | ---
-EnforcedStyle | leading
-SupportedStyles | leading, trailing
+Name | Default value | Configurable values
+--- | --- | ---
+EnforcedStyle | `leading` | `leading`, `trailing`
 
 ### References
 
@@ -686,12 +679,12 @@ def b
 end
 ```
 
-### Important attributes
+### Configurable attributes
 
-Attribute | Value
---- | ---
-AllowAdjacentOneLineDefs | false
-NumberOfEmptyLines | 1
+Name | Default value | Configurable values
+--- | --- | ---
+AllowAdjacentOneLineDefs | `false` | Boolean
+NumberOfEmptyLines | `1` | Integer
 
 ### References
 
@@ -815,12 +808,11 @@ foo do |bar|
 end
 ```
 
-### Important attributes
+### Configurable attributes
 
-Attribute | Value
---- | ---
-EnforcedStyle | no_empty_lines
-SupportedStyles | empty_lines, no_empty_lines
+Name | Default value | Configurable values
+--- | --- | ---
+EnforcedStyle | `no_empty_lines` | `empty_lines`, `no_empty_lines`
 
 ### References
 
@@ -849,12 +841,11 @@ class Foo
 end
 ```
 
-### Important attributes
+### Configurable attributes
 
-Attribute | Value
---- | ---
-EnforcedStyle | no_empty_lines
-SupportedStyles | empty_lines, empty_lines_except_namespace, empty_lines_special, no_empty_lines
+Name | Default value | Configurable values
+--- | --- | ---
+EnforcedStyle | `no_empty_lines` | `empty_lines`, `empty_lines_except_namespace`, `empty_lines_special`, `no_empty_lines`
 
 ### References
 
@@ -990,12 +981,11 @@ module Foo
 end
 ```
 
-### Important attributes
+### Configurable attributes
 
-Attribute | Value
---- | ---
-EnforcedStyle | no_empty_lines
-SupportedStyles | empty_lines, empty_lines_except_namespace, empty_lines_special, no_empty_lines
+Name | Default value | Configurable values
+--- | --- | ---
+EnforcedStyle | `no_empty_lines` | `empty_lines`, `empty_lines_except_namespace`, `empty_lines_special`, `no_empty_lines`
 
 ### References
 
@@ -1009,12 +999,11 @@ Enabled | No
 
 This cop checks for Windows-style line endings in the source code.
 
-### Important attributes
+### Configurable attributes
 
-Attribute | Value
---- | ---
-EnforcedStyle | native
-SupportedStyles | native, lf, crlf
+Name | Default value | Configurable values
+--- | --- | ---
+EnforcedStyle | `native` | `native`, `lf`, `crlf`
 
 ### References
 
@@ -1043,12 +1032,12 @@ set_app("RuboCop")
 website  = "https://github.com/bbatsov/rubocop"
 ```
 
-### Important attributes
+### Configurable attributes
 
-Attribute | Value
---- | ---
-AllowForAlignment | true
-ForceEqualSignAlignment | false
+Name | Default value | Configurable values
+--- | --- | ---
+AllowForAlignment | `true` | Boolean
+ForceEqualSignAlignment | `false` | Boolean
 
 ## Layout/FirstArrayElementLineBreak
 
@@ -1176,13 +1165,12 @@ some_method(
 second_param)
 ```
 
-### Important attributes
+### Configurable attributes
 
-Attribute | Value
---- | ---
-EnforcedStyle | special_for_inner_method_call_in_parentheses
-SupportedStyles | consistent, special_for_inner_method_call, special_for_inner_method_call_in_parentheses
-IndentationWidth |
+Name | Default value | Configurable values
+--- | --- | ---
+EnforcedStyle | `special_for_inner_method_call_in_parentheses` | `consistent`, `special_for_inner_method_call`, `special_for_inner_method_call_in_parentheses`
+IndentationWidth | `<none>` | Integer
 
 ## Layout/IndentArray
 
@@ -1233,13 +1221,12 @@ and_now_for_something = [
                         ]
 ```
 
-### Important attributes
+### Configurable attributes
 
-Attribute | Value
---- | ---
-EnforcedStyle | special_inside_parentheses
-SupportedStyles | special_inside_parentheses, consistent, align_brackets
-IndentationWidth |
+Name | Default value | Configurable values
+--- | --- | ---
+EnforcedStyle | `special_inside_parentheses` | `special_inside_parentheses`, `consistent`, `align_brackets`
+IndentationWidth | `<none>` | Integer
 
 ## Layout/IndentAssignment
 
@@ -1269,11 +1256,11 @@ value =
   end
 ```
 
-### Important attributes
+### Configurable attributes
 
-Attribute | Value
---- | ---
-IndentationWidth |
+Name | Default value | Configurable values
+--- | --- | ---
+IndentationWidth | `<none>` | Integer
 
 ## Layout/IndentHash
 
@@ -1316,13 +1303,12 @@ styles are 'consistent' and 'align_braces'. Here are examples:
                               completely: :different
                             }
 
-### Important attributes
+### Configurable attributes
 
-Attribute | Value
---- | ---
-EnforcedStyle | special_inside_parentheses
-SupportedStyles | special_inside_parentheses, consistent, align_braces
-IndentationWidth |
+Name | Default value | Configurable values
+--- | --- | ---
+EnforcedStyle | `special_inside_parentheses` | `special_inside_parentheses`, `consistent`, `align_braces`
+IndentationWidth | `<none>` | Integer
 
 ## Layout/IndentHeredoc
 
@@ -1359,12 +1345,11 @@ RUBY
 RUBY
 ```
 
-### Important attributes
+### Configurable attributes
 
-Attribute | Value
---- | ---
-EnforcedStyle | auto_detection
-SupportedStyles | auto_detection, squiggly, active_support, powerpack, unindent
+Name | Default value | Configurable values
+--- | --- | ---
+EnforcedStyle | `auto_detection` | `auto_detection`, `squiggly`, `active_support`, `powerpack`, `unindent`
 
 ### References
 
@@ -1389,12 +1374,11 @@ class A
 end
 ```
 
-### Important attributes
+### Configurable attributes
 
-Attribute | Value
---- | ---
-EnforcedStyle | normal
-SupportedStyles | normal, rails
+Name | Default value | Configurable values
+--- | --- | ---
+EnforcedStyle | `normal` | `normal`, `rails`
 
 ### References
 
@@ -1452,12 +1436,12 @@ end
 end
 ```
 
-### Important attributes
+### Configurable attributes
 
-Attribute | Value
---- | ---
-Width | 2
-IgnoredPatterns |
+Name | Default value | Configurable values
+--- | --- | ---
+Width | `2` | Integer
+IgnoredPatterns | `[]` | Array
 
 ### References
 
@@ -1559,12 +1543,11 @@ line as the last element of the array.
 ]
 ```
 
-### Important attributes
+### Configurable attributes
 
-Attribute | Value
---- | ---
-EnforcedStyle | symmetrical
-SupportedStyles | symmetrical, new_line, same_line
+Name | Default value | Configurable values
+--- | --- | ---
+EnforcedStyle | `symmetrical` | `symmetrical`, `new_line`, `same_line`
 
 ## Layout/MultilineAssignmentLayout
 
@@ -1604,13 +1587,11 @@ foo = if expression
 end
 ```
 
-### Important attributes
+### Configurable attributes
 
-Attribute | Value
---- | ---
-SupportedTypes | block, case, class, if, kwbegin, module
-EnforcedStyle | new_line
-SupportedStyles | same_line, new_line
+Name | Default value | Configurable values
+--- | --- | ---
+EnforcedStyle | `new_line` | `same_line`, `new_line`
 
 ### References
 
@@ -1719,12 +1700,11 @@ line as the last element of the hash.
 }
 ```
 
-### Important attributes
+### Configurable attributes
 
-Attribute | Value
---- | ---
-EnforcedStyle | symmetrical
-SupportedStyles | symmetrical, new_line, same_line
+Name | Default value | Configurable values
+--- | --- | ---
+EnforcedStyle | `symmetrical` | `symmetrical`, `new_line`, `same_line`
 
 ## Layout/MultilineMethodCallBraceLayout
 
@@ -1787,12 +1767,11 @@ foo(
 )
 ```
 
-### Important attributes
+### Configurable attributes
 
-Attribute | Value
---- | ---
-EnforcedStyle | symmetrical
-SupportedStyles | symmetrical, new_line, same_line
+Name | Default value | Configurable values
+--- | --- | ---
+EnforcedStyle | `symmetrical` | `symmetrical`, `new_line`, `same_line`
 
 ## Layout/MultilineMethodCallIndentation
 
@@ -1848,13 +1827,12 @@ myvariable = Thing
                .c
 ```
 
-### Important attributes
+### Configurable attributes
 
-Attribute | Value
---- | ---
-EnforcedStyle | aligned
-SupportedStyles | aligned, indented, indented_relative_to_receiver
-IndentationWidth |
+Name | Default value | Configurable values
+--- | --- | ---
+EnforcedStyle | `aligned` | `aligned`, `indented`, `indented_relative_to_receiver`
+IndentationWidth | `<none>` | Integer
 
 ## Layout/MultilineMethodDefinitionBraceLayout
 
@@ -1917,12 +1895,11 @@ def foo(
 )
 ```
 
-### Important attributes
+### Configurable attributes
 
-Attribute | Value
---- | ---
-EnforcedStyle | symmetrical
-SupportedStyles | symmetrical, new_line, same_line
+Name | Default value | Configurable values
+--- | --- | ---
+EnforcedStyle | `symmetrical` | `symmetrical`, `new_line`, `same_line`
 
 ## Layout/MultilineOperationIndentation
 
@@ -1949,13 +1926,12 @@ if a +
 end
 ```
 
-### Important attributes
+### Configurable attributes
 
-Attribute | Value
---- | ---
-EnforcedStyle | aligned
-SupportedStyles | aligned, indented
-IndentationWidth |
+Name | Default value | Configurable values
+--- | --- | ---
+EnforcedStyle | `aligned` | `aligned`, `indented`
+IndentationWidth | `<none>` | Integer
 
 ## Layout/RescueEnsureAlignment
 
@@ -2129,12 +2105,11 @@ Checks the spacing inside and after block parameters pipes.
 ->( x, y ) { puts x }
 ```
 
-### Important attributes
+### Configurable attributes
 
-Attribute | Value
---- | ---
-EnforcedStyleInsidePipes | no_space
-SupportedStylesInsidePipes | space, no_space
+Name | Default value | Configurable values
+--- | --- | ---
+EnforcedStyleInsidePipes | `no_space` | `space`, `no_space`
 
 ## Layout/SpaceAroundEqualsInParameterDefault
 
@@ -2159,12 +2134,11 @@ def some_method(arg1 = :default, arg2 = nil, arg3 = [])
 end
 ```
 
-### Important attributes
+### Configurable attributes
 
-Attribute | Value
---- | ---
-EnforcedStyle | space
-SupportedStyles | space, no_space
+Name | Default value | Configurable values
+--- | --- | ---
+EnforcedStyle | `space` | `space`, `no_space`
 
 ### References
 
@@ -2225,11 +2199,11 @@ my_number = 38 / 4
 a**b
 ```
 
-### Important attributes
+### Configurable attributes
 
-Attribute | Value
---- | ---
-AllowForAlignment | true
+Name | Default value | Configurable values
+--- | --- | ---
+AllowForAlignment | `true` | Boolean
 
 ### References
 
@@ -2258,14 +2232,12 @@ foo.map { |a|
 }
 ```
 
-### Important attributes
+### Configurable attributes
 
-Attribute | Value
---- | ---
-EnforcedStyle | space
-SupportedStyles | space, no_space
-EnforcedStyleForEmptyBraces | no_space
-SupportedStylesForEmptyBraces | space, no_space
+Name | Default value | Configurable values
+--- | --- | ---
+EnforcedStyle | `space` | `space`, `no_space`
+EnforcedStyleForEmptyBraces | `no_space` | `space`, `no_space`
 
 ## Layout/SpaceBeforeComma
 
@@ -2335,11 +2307,11 @@ something y, z
 something 'hello'
 ```
 
-### Important attributes
+### Configurable attributes
 
-Attribute | Value
---- | ---
-AllowForAlignment | true
+Name | Default value | Configurable values
+--- | --- | ---
+AllowForAlignment | `true` | Boolean
 
 ## Layout/SpaceBeforeSemicolon
 
@@ -2385,12 +2357,11 @@ a = ->(x, y) { x + y }
 a = -> (x, y) { x + y }
 ```
 
-### Important attributes
+### Configurable attributes
 
-Attribute | Value
---- | ---
-EnforcedStyle | require_no_space
-SupportedStyles | require_no_space, require_space
+Name | Default value | Configurable values
+--- | --- | ---
+EnforcedStyle | `require_no_space` | `require_no_space`, `require_space`
 
 ## Layout/SpaceInsideArrayPercentLiteral
 
@@ -2490,15 +2461,13 @@ some_array.each {   }
 [1, 2, 3].each {|n| n * 2 }
 ```
 
-### Important attributes
+### Configurable attributes
 
-Attribute | Value
---- | ---
-EnforcedStyle | space
-SupportedStyles | space, no_space
-EnforcedStyleForEmptyBraces | no_space
-SupportedStylesForEmptyBraces | space, no_space
-SpaceBeforeBlockParameters | true
+Name | Default value | Configurable values
+--- | --- | ---
+EnforcedStyle | `space` | `space`, `no_space`
+EnforcedStyleForEmptyBraces | `no_space` | `space`, `no_space`
+SpaceBeforeBlockParameters | `true` | Boolean
 
 ## Layout/SpaceInsideBrackets
 
@@ -2567,14 +2536,12 @@ h = {{ a: 1 }, b: 2 }
 h = { a: 1, { b: 2 }}
 ```
 
-### Important attributes
+### Configurable attributes
 
-Attribute | Value
---- | ---
-EnforcedStyle | space
-SupportedStyles | space, no_space, compact
-EnforcedStyleForEmptyBraces | no_space
-SupportedStylesForEmptyBraces | space, no_space
+Name | Default value | Configurable values
+--- | --- | ---
+EnforcedStyle | `space` | `space`, `no_space`, `compact`
+EnforcedStyleForEmptyBraces | `no_space` | `space`, `no_space`
 
 ### References
 
@@ -2679,12 +2646,11 @@ This cop checks for whitespace within string interpolations.
    var = "This is the #{ space } example"
 ```
 
-### Important attributes
+### Configurable attributes
 
-Attribute | Value
---- | ---
-EnforcedStyle | no_space
-SupportedStyles | space, no_space
+Name | Default value | Configurable values
+--- | --- | ---
+EnforcedStyle | `no_space` | `space`, `no_space`
 
 ### References
 
@@ -2698,11 +2664,11 @@ Enabled | Yes
 
 This cop checks for tabs inside the source code.
 
-### Important attributes
+### Configurable attributes
 
-Attribute | Value
---- | ---
-IndentationWidth |
+Name | Default value | Configurable values
+--- | --- | ---
+IndentationWidth | `<none>` | Integer
 
 ### References
 
@@ -2717,12 +2683,11 @@ Enabled | Yes
 This cop looks for trailing blank lines and a final newline in the
 source code.
 
-### Important attributes
+### Configurable attributes
 
-Attribute | Value
---- | ---
-EnforcedStyle | final_newline
-SupportedStyles | final_newline, final_blank_line
+Name | Default value | Configurable values
+--- | --- | ---
+EnforcedStyle | `final_newline` | `final_newline`, `final_blank_line`
 
 ### References
 

--- a/manual/cops_lint.md
+++ b/manual/cops_lint.md
@@ -114,11 +114,11 @@ if some_var == true
 end
 ```
 
-### Important attributes
+### Configurable attributes
 
-Attribute | Value
---- | ---
-AllowSafeAssignment | true
+Name | Default value | Configurable values
+--- | --- | ---
+AllowSafeAssignment | `true` | Boolean
 
 ### References
 
@@ -192,12 +192,11 @@ foo.bar
 end
 ```
 
-### Important attributes
+### Configurable attributes
 
-Attribute | Value
---- | ---
-EnforcedStyleAlignWith | either
-SupportedStylesAlignWith | either, start_of_block, start_of_line
+Name | Default value | Configurable values
+--- | --- | ---
+EnforcedStyleAlignWith | `either` | `either`, `start_of_block`, `start_of_line`
 
 ## Lint/BooleanSymbol
 
@@ -381,13 +380,12 @@ private def foo
         end
 ```
 
-### Important attributes
+### Configurable attributes
 
-Attribute | Value
---- | ---
-EnforcedStyleAlignWith | start_of_line
-SupportedStylesAlignWith | start_of_line, def
-AutoCorrect | false
+Name | Default value | Configurable values
+--- | --- | ---
+EnforcedStyleAlignWith | `start_of_line` | `start_of_line`, `def`
+AutoCorrect | `false` | Boolean
 
 ## Lint/DeprecatedClassMethods
 
@@ -611,11 +609,11 @@ ensure
 end
 ```
 
-### Important attributes
+### Configurable attributes
 
-Attribute | Value
---- | ---
-AutoCorrect | false
+Name | Default value | Configurable values
+--- | --- | ---
+AutoCorrect | `false` | Boolean
 
 ## Lint/EmptyExpression
 
@@ -754,13 +752,12 @@ puts(if true
 end)
 ```
 
-### Important attributes
+### Configurable attributes
 
-Attribute | Value
---- | ---
-EnforcedStyleAlignWith | keyword
-SupportedStylesAlignWith | keyword, variable, start_of_line
-AutoCorrect | false
+Name | Default value | Configurable values
+--- | --- | ---
+EnforcedStyleAlignWith | `keyword` | `keyword`, `variable`, `start_of_line`
+AutoCorrect | `false` | Boolean
 
 ## Lint/EndInMethod
 
@@ -1032,12 +1029,11 @@ class C < Exception; end
 class C < StandardError; end
 ```
 
-### Important attributes
+### Configurable attributes
 
-Attribute | Value
---- | ---
-EnforcedStyle | runtime_error
-SupportedStyles | runtime_error, standard_error
+Name | Default value | Configurable values
+--- | --- | ---
+EnforcedStyle | `runtime_error` | `runtime_error`, `standard_error`
 
 ## Lint/InterpolationCheck
 
@@ -1723,11 +1719,11 @@ x&.foo&.bar
 x&.foo || bar
 ```
 
-### Important attributes
+### Configurable attributes
 
-Attribute | Value
---- | ---
-Whitelist | present?, blank?, presence, try
+Name | Default value | Configurable values
+--- | --- | ---
+Whitelist | `present?`, `blank?`, `presence`, `try` | Array
 
 ## Lint/ScriptPermission
 
@@ -1779,11 +1775,11 @@ def do_something(foo)
 end
 ```
 
-### Important attributes
+### Configurable attributes
 
-Attribute | Value
---- | ---
-IgnoreImplicitReferences | false
+Name | Default value | Configurable values
+--- | --- | ---
+IgnoreImplicitReferences | `false` | Boolean
 
 ## Lint/ShadowedException
 
@@ -2137,12 +2133,12 @@ define_method(:foo) do |_bar|
 end
 ```
 
-### Important attributes
+### Configurable attributes
 
-Attribute | Value
---- | ---
-IgnoreEmptyBlocks | true
-AllowUnusedKeywordArguments | false
+Name | Default value | Configurable values
+--- | --- | ---
+IgnoreEmptyBlocks | `true` | Boolean
+AllowUnusedKeywordArguments | `false` | Boolean
 
 ### References
 
@@ -2173,12 +2169,12 @@ def some_method(used, _unused, _unused_but_allowed)
 end
 ```
 
-### Important attributes
+### Configurable attributes
 
-Attribute | Value
---- | ---
-AllowUnusedKeywordArguments | false
-IgnoreEmptyMethods | true
+Name | Default value | Configurable values
+--- | --- | ---
+AllowUnusedKeywordArguments | `false` | Boolean
+IgnoreEmptyMethods | `true` | Boolean
 
 ### References
 
@@ -2333,12 +2329,12 @@ class Foo
 end
 ```
 
-### Important attributes
+### Configurable attributes
 
-Attribute | Value
---- | ---
-ContextCreatingMethods |
-MethodCreatingMethods |
+Name | Default value | Configurable values
+--- | --- | ---
+ContextCreatingMethods | `[]` | Array
+MethodCreatingMethods | `[]` | Array
 
 ## Lint/UselessAssignment
 

--- a/manual/cops_metrics.md
+++ b/manual/cops_metrics.md
@@ -10,11 +10,11 @@ This cop checks that the ABC size of methods is not higher than the
 configured maximum. The ABC size is based on assignments, branches
 (method calls), and conditions. See http://c2.com/cgi/wiki?AbcMetric
 
-### Important attributes
+### Configurable attributes
 
-Attribute | Value
---- | ---
-Max | 15
+Name | Default value | Configurable values
+--- | --- | ---
+Max | `15` | Integer
 
 ### References
 
@@ -31,13 +31,13 @@ Comment lines can optionally be ignored.
 The maximum allowed length is configurable.
 The cop can be configured to ignore blocks passed to certain methods.
 
-### Important attributes
+### Configurable attributes
 
-Attribute | Value
---- | ---
-CountComments | false
-Max | 25
-ExcludedMethods |
+Name | Default value | Configurable values
+--- | --- | ---
+CountComments | `false` | Boolean
+Max | `25` | Integer
+ExcludedMethods | `[]` | Array
 
 ## Metrics/BlockNesting
 
@@ -54,12 +54,12 @@ towards the nesting level. Set to `true` to count blocks as well.
 
 The maximum level of nesting allowed is configurable.
 
-### Important attributes
+### Configurable attributes
 
-Attribute | Value
---- | ---
-CountBlocks | false
-Max | 3
+Name | Default value | Configurable values
+--- | --- | ---
+CountBlocks | `false` | Boolean
+Max | `3` | Integer
 
 ### References
 
@@ -75,12 +75,12 @@ This cop checks if the length a class exceeds some maximum value.
 Comment lines can optionally be ignored.
 The maximum allowed length is configurable.
 
-### Important attributes
+### Configurable attributes
 
-Attribute | Value
---- | ---
-CountComments | false
-Max | 100
+Name | Default value | Configurable values
+--- | --- | ---
+CountComments | `false` | Boolean
+Max | `100` | Integer
 
 ## Metrics/CyclomaticComplexity
 
@@ -99,11 +99,11 @@ operator (or keyword and) can be converted to a nested if statement,
 and ||/or is shorthand for a sequence of ifs, so they also add one.
 Loops can be said to have an exit condition, so they add one.
 
-### Important attributes
+### Configurable attributes
 
-Attribute | Value
---- | ---
-Max | 6
+Name | Default value | Configurable values
+--- | --- | ---
+Max | `6` | Integer
 
 ## Metrics/LineLength
 
@@ -114,16 +114,16 @@ Enabled | No
 This cop checks the length of lines in the source code.
 The maximum length is configurable.
 
-### Important attributes
+### Configurable attributes
 
-Attribute | Value
---- | ---
-Max | 80
-AllowHeredoc | true
-AllowURI | true
-URISchemes | http, https
-IgnoreCopDirectives | false
-IgnoredPatterns |
+Name | Default value | Configurable values
+--- | --- | ---
+Max | `80` | Integer
+AllowHeredoc | `true` | Boolean
+AllowURI | `true` | Boolean
+URISchemes | `http`, `https` | Array
+IgnoreCopDirectives | `false` | Boolean
+IgnoredPatterns | `[]` | Array
 
 ### References
 
@@ -139,12 +139,12 @@ This cop checks if the length of a method exceeds some maximum value.
 Comment lines can optionally be ignored.
 The maximum allowed length is configurable.
 
-### Important attributes
+### Configurable attributes
 
-Attribute | Value
---- | ---
-CountComments | false
-Max | 10
+Name | Default value | Configurable values
+--- | --- | ---
+CountComments | `false` | Boolean
+Max | `10` | Integer
 
 ### References
 
@@ -160,12 +160,12 @@ This cop checks if the length a module exceeds some maximum value.
 Comment lines can optionally be ignored.
 The maximum allowed length is configurable.
 
-### Important attributes
+### Configurable attributes
 
-Attribute | Value
---- | ---
-CountComments | false
-Max | 100
+Name | Default value | Configurable values
+--- | --- | ---
+CountComments | `false` | Boolean
+Max | `100` | Integer
 
 ## Metrics/ParameterLists
 
@@ -177,12 +177,12 @@ This cop checks for methods with too many parameters.
 The maximum number of parameters is configurable.
 Keyword arguments can optionally be excluded from the total count.
 
-### Important attributes
+### Configurable attributes
 
-Attribute | Value
---- | ---
-Max | 5
-CountKeywordArgs | true
+Name | Default value | Configurable values
+--- | --- | ---
+Max | `5` | Integer
+CountKeywordArgs | `true` | Boolean
 
 ### References
 
@@ -220,8 +220,8 @@ def my_method                   # 1
 end                             # 7 complexity points
 ```
 
-### Important attributes
+### Configurable attributes
 
-Attribute | Value
---- | ---
-Max | 7
+Name | Default value | Configurable values
+--- | --- | ---
+Max | `7` | Integer

--- a/manual/cops_naming.md
+++ b/manual/cops_naming.md
@@ -176,15 +176,15 @@ lib/layout_manager.rb
 anything/using_snake_case.rake
 ```
 
-### Important attributes
+### Configurable attributes
 
-Attribute | Value
---- | ---
-Exclude |
-ExpectMatchingDefinition | false
-Regex |
-IgnoreExecutableScripts | true
-AllowedAcronyms | CLI, DSL, ACL, API, ASCII, CPU, CSS, DNS, EOF, GUID, HTML, HTTP, HTTPS, ID, IP, JSON, LHS, QPS, RAM, RHS, RPC, SLA, SMTP, SQL, SSH, TCP, TLS, TTL, UDP, UI, UID, UUID, URI, URL, UTF8, VM, XML, XMPP, XSRF, XSS
+Name | Default value | Configurable values
+--- | --- | ---
+Exclude | `[]` | Array
+ExpectMatchingDefinition | `false` | Boolean
+Regex | `<none>` | 
+IgnoreExecutableScripts | `true` | Boolean
+AllowedAcronyms | `CLI`, `DSL`, `ACL`, `API`, `ASCII`, `CPU`, `CSS`, `DNS`, `EOF`, `GUID`, `HTML`, `HTTP`, `HTTPS`, `ID`, `IP`, `JSON`, `LHS`, `QPS`, `RAM`, `RHS`, `RPC`, `SLA`, `SMTP`, `SQL`, `SSH`, `TCP`, `TLS`, `TTL`, `UDP`, `UI`, `UID`, `UUID`, `URI`, `URL`, `UTF8`, `VM`, `XML`, `XMPP`, `XSRF`, `XSS` | Array
 
 ### References
 
@@ -224,12 +224,11 @@ SQL
 sql
 ```
 
-### Important attributes
+### Configurable attributes
 
-Attribute | Value
---- | ---
-EnforcedStyle | uppercase
-SupportedStyles | lowercase, uppercase
+Name | Default value | Configurable values
+--- | --- | ---
+EnforcedStyle | `uppercase` | `lowercase`, `uppercase`
 
 ### References
 
@@ -264,11 +263,11 @@ END
 EOS
 ```
 
-### Important attributes
+### Configurable attributes
 
-Attribute | Value
---- | ---
-Blacklist | END, (?-mix:EO[A-Z]{1})
+Name | Default value | Configurable values
+--- | --- | ---
+Blacklist | `END`, `(?-mix:EO[A-Z]{1})` | Array
 
 ### References
 
@@ -300,12 +299,11 @@ def foo_bar; end
 def fooBar; end
 ```
 
-### Important attributes
+### Configurable attributes
 
-Attribute | Value
---- | ---
-EnforcedStyle | snake_case
-SupportedStyles | snake_case, camelCase
+Name | Default value | Configurable values
+--- | --- | ---
+EnforcedStyle | `snake_case` | `snake_case`, `camelCase`
 
 ### References
 
@@ -335,15 +333,15 @@ def has_value? ...
 def value? ...
 ```
 
-### Important attributes
+### Configurable attributes
 
-Attribute | Value
---- | ---
-NamePrefix | is_, has_, have_
-NamePrefixBlacklist | is_, has_, have_
-NameWhitelist | is_a?
-MethodDefinitionMacros | define_method, define_singleton_method
-Exclude | spec/\*\*/\*
+Name | Default value | Configurable values
+--- | --- | ---
+NamePrefix | `is_`, `has_`, `have_` | Array
+NamePrefixBlacklist | `is_`, `has_`, `have_` | Array
+NameWhitelist | `is_a?` | Array
+MethodDefinitionMacros | `define_method`, `define_singleton_method` | Array
+Exclude | `spec/**/*` | Array
 
 ### References
 
@@ -375,12 +373,11 @@ foo_bar = 1
 fooBar = 1
 ```
 
-### Important attributes
+### Configurable attributes
 
-Attribute | Value
---- | ---
-EnforcedStyle | snake_case
-SupportedStyles | snake_case, camelCase
+Name | Default value | Configurable values
+--- | --- | ---
+EnforcedStyle | `snake_case` | `snake_case`, `camelCase`
 
 ### References
 
@@ -430,9 +427,8 @@ variableone = 1
 variable_one = 1
 ```
 
-### Important attributes
+### Configurable attributes
 
-Attribute | Value
---- | ---
-EnforcedStyle | normalcase
-SupportedStyles | snake_case, normalcase, non_integer
+Name | Default value | Configurable values
+--- | --- | ---
+EnforcedStyle | `normalcase` | `snake_case`, `normalcase`, `non_integer`

--- a/manual/cops_performance.md
+++ b/manual/cops_performance.md
@@ -184,11 +184,11 @@ Model.select('field AS field_one').count
 Model.select(:value).count
 ```
 
-### Important attributes
+### Configurable attributes
 
-Attribute | Value
---- | ---
-SafeMode | true
+Name | Default value | Configurable values
+--- | --- | ---
+SafeMode | `true` | Boolean
 
 ## Performance/Detect
 
@@ -219,11 +219,11 @@ considered unsafe.
 [].reverse.detect { |item| true }
 ```
 
-### Important attributes
+### Configurable attributes
 
-Attribute | Value
---- | ---
-SafeMode | true
+Name | Default value | Configurable values
+--- | --- | ---
+SafeMode | `true` | Boolean
 
 ### References
 
@@ -257,11 +257,11 @@ var2 = ...
 str.end_with?(var1, var2)
 ```
 
-### Important attributes
+### Configurable attributes
 
-Attribute | Value
---- | ---
-IncludeActiveSupportAliases | false
+Name | Default value | Configurable values
+--- | --- | ---
+IncludeActiveSupportAliases | `false` | Boolean
 
 ## Performance/EndWith
 
@@ -283,11 +283,11 @@ would suffice.
 'abc'.end_with?('bc')
 ```
 
-### Important attributes
+### Configurable attributes
 
-Attribute | Value
---- | ---
-AutoCorrect | false
+Name | Default value | Configurable values
+--- | --- | ---
+AutoCorrect | `false` | Boolean
 
 ### References
 
@@ -322,11 +322,11 @@ This cop is used to identify usages of
 [1, 2, 3, 4].collect { |e| [e, e] }.flatten
 ```
 
-### Important attributes
+### Configurable attributes
 
-Attribute | Value
---- | ---
-EnabledForFlattenWithoutParams | false
+Name | Default value | Configurable values
+--- | --- | ---
+EnabledForFlattenWithoutParams | `false` | Boolean
 
 ### References
 
@@ -358,11 +358,11 @@ hash.each_key { |k| p k }
 hash.each_value { |v| p v }
 ```
 
-### Important attributes
+### Configurable attributes
 
-Attribute | Value
---- | ---
-AutoCorrect | false
+Name | Default value | Configurable values
+--- | --- | ---
+AutoCorrect | `false` | Boolean
 
 ### References
 
@@ -483,11 +483,11 @@ hash.merge!({'key' => 'value'})
 hash.merge!(a: 1, b: 2)
 ```
 
-### Important attributes
+### Configurable attributes
 
-Attribute | Value
---- | ---
-MaxKeyValuePairs | 2
+Name | Default value | Configurable values
+--- | --- | ---
+MaxKeyValuePairs | `2` | Integer
 
 ### References
 
@@ -693,11 +693,11 @@ This cop identifies unnecessary use of a regex where
 'abc'.start_with?('ab')
 ```
 
-### Important attributes
+### Configurable attributes
 
-Attribute | Value
---- | ---
-AutoCorrect | false
+Name | Default value | Configurable values
+--- | --- | ---
+AutoCorrect | `false` | Boolean
 
 ### References
 
@@ -756,11 +756,11 @@ Array.new(9) do |i|
 end
 ```
 
-### Important attributes
+### Configurable attributes
 
-Attribute | Value
---- | ---
-AutoCorrect | false
+Name | Default value | Configurable values
+--- | --- | ---
+AutoCorrect | `false` | Boolean
 
 ## Performance/UnfreezeString
 

--- a/manual/cops_rails.md
+++ b/manual/cops_rails.md
@@ -28,13 +28,12 @@ append_around_action :do_stuff
 skip_after_action :do_stuff
 ```
 
-### Important attributes
+### Configurable attributes
 
-Attribute | Value
---- | ---
-EnforcedStyle | action
-SupportedStyles | action, filter
-Include | app/controllers/\*\*/\*.rb
+Name | Default value | Configurable values
+--- | --- | ---
+EnforcedStyle | `action` | `action`, `filter`
+Include | `app/controllers/**/*.rb` | Array
 
 ## Rails/ActiveSupportAliases
 
@@ -149,13 +148,13 @@ Settings:
   end
 ```
 
-### Important attributes
+### Configurable attributes
 
-Attribute | Value
---- | ---
-NilOrEmpty | true
-NotPresent | true
-UnlessPresent | true
+Name | Default value | Configurable values
+--- | --- | ---
+NilOrEmpty | `true` | Boolean
+NotPresent | `true` | Boolean
+UnlessPresent | `true` | Boolean
 
 ## Rails/Date
 
@@ -199,12 +198,11 @@ date.to_time
 date.to_time_in_current_zone
 ```
 
-### Important attributes
+### Configurable attributes
 
-Attribute | Value
---- | ---
-EnforcedStyle | flexible
-SupportedStyles | strict, flexible
+Name | Default value | Configurable values
+--- | --- | ---
+EnforcedStyle | `flexible` | `strict`, `flexible`
 
 ## Rails/Delegate
 
@@ -265,11 +263,11 @@ end
 delegate :bar, to: :foo, prefix: true
 ```
 
-### Important attributes
+### Configurable attributes
 
-Attribute | Value
---- | ---
-EnforceForPrefixed | true
+Name | Default value | Configurable values
+--- | --- | ---
+EnforceForPrefixed | `true` | Boolean
 
 ## Rails/DelegateAllowBlank
 
@@ -323,11 +321,11 @@ User.find_by(name: name, email: email)
 User.find_by!(email: email)
 ```
 
-### Important attributes
+### Configurable attributes
 
-Attribute | Value
---- | ---
-Whitelist | find_by_sql
+Name | Default value | Configurable values
+--- | --- | ---
+Whitelist | `find_by_sql` | Array
 
 ### References
 
@@ -357,11 +355,11 @@ enum status: [:active, :archived, :active]
 enum status: [:active, :archived]
 ```
 
-### Important attributes
+### Configurable attributes
 
-Attribute | Value
---- | ---
-Include | app/models/\*\*/\*.rb
+Name | Default value | Configurable values
+--- | --- | ---
+Include | `app/models/**/*.rb` | Array
 
 ## Rails/EnvironmentComparison
 
@@ -405,12 +403,12 @@ is used.)
 the program exiting, which could result in the code failing to run and
 do its job.
 
-### Important attributes
+### Configurable attributes
 
-Attribute | Value
---- | ---
-Include | app/\*\*/\*.rb, config/\*\*/\*.rb, lib/\*\*/\*.rb
-Exclude | lib/\*\*/\*.rake
+Name | Default value | Configurable values
+--- | --- | ---
+Include | `app/**/*.rb`, `config/**/*.rb`, `lib/**/*.rb` | Array
+Exclude | `lib/**/*.rake` | Array
 
 ## Rails/FilePath
 
@@ -453,11 +451,11 @@ User.where(name: 'Bruce').take
 User.find_by(name: 'Bruce')
 ```
 
-### Important attributes
+### Configurable attributes
 
-Attribute | Value
---- | ---
-Include | app/models/\*\*/\*.rb
+Name | Default value | Configurable values
+--- | --- | ---
+Include | `app/models/**/*.rb` | Array
 
 ### References
 
@@ -482,11 +480,11 @@ User.all.each
 User.all.find_each
 ```
 
-### Important attributes
+### Configurable attributes
 
-Attribute | Value
---- | ---
-Include | app/models/\*\*/\*.rb
+Name | Default value | Configurable values
+--- | --- | ---
+Include | `app/models/**/*.rb` | Array
 
 ### References
 
@@ -510,11 +508,11 @@ This cop checks for the use of the has_and_belongs_to_many macro.
 # has_many :ingredients, through: :recipe_ingredients
 ```
 
-### Important attributes
+### Configurable attributes
 
-Attribute | Value
---- | ---
-Include | app/models/\*\*/\*.rb
+Name | Default value | Configurable values
+--- | --- | ---
+Include | `app/models/**/*.rb` | Array
 
 ### References
 
@@ -547,11 +545,11 @@ class User < ActiveRecord::Base
 end
 ```
 
-### Important attributes
+### Configurable attributes
 
-Attribute | Value
---- | ---
-Include | app/models/\*\*/\*.rb
+Name | Default value | Configurable values
+--- | --- | ---
+Include | `app/models/**/*.rb` | Array
 
 ### References
 
@@ -580,11 +578,11 @@ get :new, { user_id: 1}
 get :new, params: { user_id: 1 }
 ```
 
-### Important attributes
+### Configurable attributes
 
-Attribute | Value
---- | ---
-Include | spec/\*\*/\*, test/\*\*/\*
+Name | Default value | Configurable values
+--- | --- | ---
+Include | `spec/**/*`, `test/**/*` | Array
 
 ## Rails/InverseOf
 
@@ -615,11 +613,11 @@ class Blog < ApplicationRecord
 end
 ```
 
-### Important attributes
+### Configurable attributes
 
-Attribute | Value
---- | ---
-Include | app/models/\*\*/\*.rb
+Name | Default value | Configurable values
+--- | --- | ---
+Include | `app/models/**/*.rb` | Array
 
 ## Rails/NotNullColumn
 
@@ -644,11 +642,11 @@ add_reference :products, :category
 add_reference :products, :category, null: false, default: 1
 ```
 
-### Important attributes
+### Configurable attributes
 
-Attribute | Value
---- | ---
-Include | db/migrate/\*.rb
+Name | Default value | Configurable values
+--- | --- | ---
+Include | `db/migrate/*.rb` | Array
 
 ## Rails/Output
 
@@ -658,11 +656,11 @@ Enabled | No
 
 This cop checks for the use of output calls like puts and print
 
-### Important attributes
+### Configurable attributes
 
-Attribute | Value
---- | ---
-Include | app/\*\*/\*.rb, config/\*\*/\*.rb, db/\*\*/\*.rb, lib/\*\*/\*.rb
+Name | Default value | Configurable values
+--- | --- | ---
+Include | `app/**/*.rb`, `config/**/*.rb`, `db/**/*.rb`, `lib/**/*.rb` | Array
 
 ## Rails/OutputSafety
 
@@ -800,13 +798,13 @@ Settings:
   something if  foo.present?
 ```
 
-### Important attributes
+### Configurable attributes
 
-Attribute | Value
---- | ---
-NotNilAndNotEmpty | true
-NotBlank | true
-UnlessBlank | true
+Name | Default value | Configurable values
+--- | --- | ---
+NotNilAndNotEmpty | `true` | Boolean
+NotBlank | `true` | Boolean
+UnlessBlank | `true` | Boolean
 
 ## Rails/ReadWriteAttribute
 
@@ -829,11 +827,11 @@ x = self[:attr]
 self[:attr] = val
 ```
 
-### Important attributes
+### Configurable attributes
 
-Attribute | Value
---- | ---
-Include | app/models/\*\*/\*.rb
+Name | Default value | Configurable values
+--- | --- | ---
+Include | `app/models/**/*.rb` | Array
 
 ### References
 
@@ -891,12 +889,11 @@ request.referer
 request.referrer
 ```
 
-### Important attributes
+### Configurable attributes
 
-Attribute | Value
---- | ---
-EnforcedStyle | referer
-SupportedStyles | referer, referrer
+Name | Default value | Configurable values
+--- | --- | ---
+EnforcedStyle | `referer` | `referer`, `referrer`
 
 ## Rails/ReversibleMigration
 
@@ -1028,11 +1025,11 @@ def change
 end
 ```
 
-### Important attributes
+### Configurable attributes
 
-Attribute | Value
---- | ---
-Include | db/migrate/\*.rb
+Name | Default value | Configurable values
+--- | --- | ---
+Include | `db/migrate/*.rb` | Array
 
 ### References
 
@@ -1084,11 +1081,11 @@ target Ruby version is set to 2.3+
   foo&.bar { |e| e.baz }
 ```
 
-### Important attributes
+### Configurable attributes
 
-Attribute | Value
---- | ---
-ConvertTry | false
+Name | Default value | Configurable values
+--- | --- | ---
+ConvertTry | `false` | Boolean
 
 ## Rails/SaveBang
 
@@ -1154,11 +1151,11 @@ scope :something, where(something: true)
 scope :something, -> { where(something: true) }
 ```
 
-### Important attributes
+### Configurable attributes
 
-Attribute | Value
---- | ---
-Include | app/models/\*\*/\*.rb
+Name | Default value | Configurable values
+--- | --- | ---
+Include | `app/models/**/*.rb` | Array
 
 ## Rails/SkipsModelValidations
 
@@ -1190,11 +1187,11 @@ user.update_attributes(website: 'example.com')
 FileUtils.touch('file')
 ```
 
-### Important attributes
+### Configurable attributes
 
-Attribute | Value
---- | ---
-Blacklist | decrement!, decrement_counter, increment!, increment_counter, toggle!, touch, update_all, update_attribute, update_column, update_columns, update_counters
+Name | Default value | Configurable values
+--- | --- | ---
+Blacklist | `decrement!`, `decrement_counter`, `increment!`, `increment_counter`, `toggle!`, `touch`, `update_all`, `update_attribute`, `update_column`, `update_columns`, `update_counters` | Array
 
 ### References
 
@@ -1234,12 +1231,11 @@ DateTime.strptime(str, "%Y-%m-%d %H:%M %Z").in_time_zone
 Time.at(timestamp).in_time_zone
 ```
 
-### Important attributes
+### Configurable attributes
 
-Attribute | Value
---- | ---
-EnforcedStyle | flexible
-SupportedStyles | strict, flexible
+Name | Default value | Configurable values
+--- | --- | ---
+EnforcedStyle | `flexible` | `strict`, `flexible`
 
 ### References
 
@@ -1286,13 +1282,12 @@ Model.where(...).pluck(:id).uniq
 instance.assoc.pluck(:id).uniq
 ```
 
-### Important attributes
+### Configurable attributes
 
-Attribute | Value
---- | ---
-EnforcedStyle | conservative
-SupportedStyles | conservative, aggressive
-AutoCorrect | false
+Name | Default value | Configurable values
+--- | --- | ---
+EnforcedStyle | `conservative` | `conservative`, `aggressive`
+AutoCorrect | `false` | Boolean
 
 ## Rails/UnknownEnv
 
@@ -1313,11 +1308,11 @@ Rails.env.proudction?
 Rails.env.production?
 ```
 
-### Important attributes
+### Configurable attributes
 
-Attribute | Value
---- | ---
-Environments | development, test, production
+Name | Default value | Configurable values
+--- | --- | ---
+Environments | `development`, `test`, `production` | Array
 
 ## Rails/Validation
 
@@ -1327,8 +1322,8 @@ Enabled | Yes
 
 This cop checks for the use of old-style attribute validation macros.
 
-### Important attributes
+### Configurable attributes
 
-Attribute | Value
---- | ---
-Include | app/models/\*\*/\*.rb
+Name | Default value | Configurable values
+--- | --- | ---
+Include | `app/models/**/*.rb` | Array

--- a/manual/cops_security.md
+++ b/manual/cops_security.md
@@ -45,11 +45,11 @@ JSON.restore("{}")
 JSON.parse("{}")
 ```
 
-### Important attributes
+### Configurable attributes
 
-Attribute | Value
---- | ---
-AutoCorrect | false
+Name | Default value | Configurable values
+--- | --- | ---
+AutoCorrect | `false` | Boolean
 
 ### References
 

--- a/manual/cops_style.md
+++ b/manual/cops_style.md
@@ -32,12 +32,11 @@ alias_method :bar, :foo
 alias bar foo
 ```
 
-### Important attributes
+### Configurable attributes
 
-Attribute | Value
---- | ---
-EnforcedStyle | prefer_alias
-SupportedStyles | prefer_alias, prefer_alias_method
+Name | Default value | Configurable values
+--- | --- | ---
+EnforcedStyle | `prefer_alias` | `prefer_alias`, `prefer_alias_method`
 
 ### References
 
@@ -78,12 +77,11 @@ if foo && bar
 if foo and bar
 ```
 
-### Important attributes
+### Configurable attributes
 
-Attribute | Value
---- | ---
-EnforcedStyle | always
-SupportedStyles | always, conditionals
+Name | Default value | Configurable values
+--- | --- | ---
+EnforcedStyle | `always` | `always`, `conditionals`
 
 ### References
 
@@ -135,11 +133,11 @@ AllowedChars attribute (empty by default).
 # Translates from English to Japanese
 ```
 
-### Important attributes
+### Configurable attributes
 
-Attribute | Value
---- | ---
-AllowedChars |
+Name | Default value | Configurable values
+--- | --- | ---
+AllowedChars | `[]` | Array
 
 ### References
 
@@ -220,12 +218,11 @@ This cop checks if usage of %() or %Q() matches configuration.
 %q/She said: 'Hi'/
 ```
 
-### Important attributes
+### Configurable attributes
 
-Attribute | Value
---- | ---
-EnforcedStyle | bare_percent
-SupportedStyles | percent_q, bare_percent
+Name | Default value | Configurable values
+--- | --- | ---
+EnforcedStyle | `bare_percent` | `percent_q`, `bare_percent`
 
 ### References
 
@@ -346,15 +343,14 @@ words.each { |word|
 }.join("-")
 ```
 
-### Important attributes
+### Configurable attributes
 
-Attribute | Value
---- | ---
-EnforcedStyle | line_count_based
-SupportedStyles | line_count_based, semantic, braces_for_chaining
-ProceduralMethods | benchmark, bm, bmbm, create, each_with_object, measure, new, realtime, tap, with_object
-FunctionalMethods | let, let!, subject, watch
-IgnoredMethods | lambda, proc, it
+Name | Default value | Configurable values
+--- | --- | ---
+EnforcedStyle | `line_count_based` | `line_count_based`, `semantic`, `braces_for_chaining`
+ProceduralMethods | `benchmark`, `bm`, `bmbm`, `create`, `each_with_object`, `measure`, `new`, `realtime`, `tap`, `with_object` | Array
+FunctionalMethods | `let`, `let!`, `subject`, `watch` | Array
+IgnoredMethods | `lambda`, `proc`, `it` | Array
 
 ### References
 
@@ -406,12 +402,11 @@ some_method(x, y, a: 1, b: 2)
 some_method(x, y, {a: 1, b: 2}, {a: 1, b: 2})
 ```
 
-### Important attributes
+### Configurable attributes
 
-Attribute | Value
---- | ---
-EnforcedStyle | no_braces
-SupportedStyles | braces, no_braces, context_dependent
+Name | Default value | Configurable values
+--- | --- | ---
+EnforcedStyle | `no_braces` | `braces`, `no_braces`, `context_dependent`
 
 ## Style/CaseEquality
 
@@ -472,12 +467,11 @@ compact - combine definitions as much as possible
 
 The compact style is only forced for classes/modules with one child.
 
-### Important attributes
+### Configurable attributes
 
-Attribute | Value
---- | ---
-EnforcedStyle | nested
-SupportedStyles | nested, compact
+Name | Default value | Configurable values
+--- | --- | ---
+EnforcedStyle | `nested` | `nested`, `compact`
 
 ### References
 
@@ -512,12 +506,11 @@ var.kind_of?(Time)
 var.kind_of?(String)
 ```
 
-### Important attributes
+### Configurable attributes
 
-Attribute | Value
---- | ---
-EnforcedStyle | is_a?
-SupportedStyles | is_a?, kind_of?
+Name | Default value | Configurable values
+--- | --- | ---
+EnforcedStyle | `is_a?` | `is_a?`, `kind_of?`
 
 ## Style/ClassMethods
 
@@ -577,11 +570,11 @@ Unfortunately we cannot actually know if a method is from
 Enumerable or not (static analysis limitation), so this cop
 can yield some false positives.
 
-### Important attributes
+### Configurable attributes
 
-Attribute | Value
---- | ---
-PreferredMethods | {"collect"=>"map", "collect!"=>"map!", "inject"=>"reduce", "detect"=>"find", "find_all"=>"select"}
+Name | Default value | Configurable values
+--- | --- | ---
+PreferredMethods | `{"collect"=>"map", "collect!"=>"map!", "inject"=>"reduce", "detect"=>"find", "find_all"=>"select"}` | 
 
 ### References
 
@@ -721,13 +714,12 @@ folders = %x(find . -type d).split
 `echo \`ls\``
 ```
 
-### Important attributes
+### Configurable attributes
 
-Attribute | Value
---- | ---
-EnforcedStyle | backticks
-SupportedStyles | backticks, percent_x, mixed
-AllowInnerBackticks | false
+Name | Default value | Configurable values
+--- | --- | ---
+EnforcedStyle | `backticks` | `backticks`, `percent_x`, `mixed`
+AllowInnerBackticks | `false` | Boolean
 
 ### References
 
@@ -770,11 +762,11 @@ to guidelines.
 # OPTIMIZE: does not work
 ```
 
-### Important attributes
+### Configurable attributes
 
-Attribute | Value
---- | ---
-Keywords | TODO, FIXME, OPTIMIZE, HACK, REVIEW
+Name | Default value | Configurable values
+--- | --- | ---
+Keywords | `TODO`, `FIXME`, `OPTIMIZE`, `HACK`, `REVIEW` | Array
 
 ### References
 
@@ -922,14 +914,13 @@ else
 end
 ```
 
-### Important attributes
+### Configurable attributes
 
-Attribute | Value
---- | ---
-EnforcedStyle | assign_to_condition
-SupportedStyles | assign_to_condition, assign_inside_condition
-SingleLineConditionsOnly | true
-IncludeTernaryExpressions | true
+Name | Default value | Configurable values
+--- | --- | ---
+EnforcedStyle | `assign_to_condition` | `assign_to_condition`, `assign_inside_condition`
+SingleLineConditionsOnly | `true` | Boolean
+IncludeTernaryExpressions | `true` | Boolean
 
 ## Style/Copyright
 
@@ -949,12 +940,12 @@ This regex string is treated as an unanchored regex.  For each file
 that RuboCop scans, a comment that matches this regex must be found or
 an offense is reported.
 
-### Important attributes
+### Configurable attributes
 
-Attribute | Value
---- | ---
-Notice | ^Copyright (\(c\) )?2[0-9]{3} .+
-AutocorrectNotice |
+Name | Default value | Configurable values
+--- | --- | ---
+Notice | `^Copyright (\(c\) )?2[0-9]{3} .+` | String
+AutocorrectNotice | `` | String
 
 ## Style/DateTime
 
@@ -1083,11 +1074,11 @@ class Person
 end
 ```
 
-### Important attributes
+### Configurable attributes
 
-Attribute | Value
---- | ---
-Exclude | spec/\*\*/\*, test/\*\*/\*
+Name | Default value | Configurable values
+--- | --- | ---
+Exclude | `spec/**/*`, `test/**/*` | Array
 
 ## Style/DocumentationMethod
 
@@ -1142,12 +1133,12 @@ def foo.bar
 end
 ```
 
-### Important attributes
+### Configurable attributes
 
-Attribute | Value
---- | ---
-Exclude | spec/\*\*/\*, test/\*\*/\*
-RequireForNonPublicMethods | false
+Name | Default value | Configurable values
+--- | --- | ---
+Exclude | `spec/**/*`, `test/**/*` | Array
+RequireForNonPublicMethods | `false` | Boolean
 
 ## Style/DoubleNegation
 
@@ -1375,12 +1366,11 @@ else
 end
 ```
 
-### Important attributes
+### Configurable attributes
 
-Attribute | Value
---- | ---
-EnforcedStyle | both
-SupportedStyles | empty, nil, both
+Name | Default value | Configurable values
+--- | --- | ---
+EnforcedStyle | `both` | `empty`, `nil`, `both`
 
 ## Style/EmptyLambdaParameter
 
@@ -1479,12 +1469,11 @@ def self.foo(bar)
 end
 ```
 
-### Important attributes
+### Configurable attributes
 
-Attribute | Value
---- | ---
-EnforcedStyle | compact
-SupportedStyles | compact, expanded
+Name | Default value | Configurable values
+--- | --- | ---
+EnforcedStyle | `compact` | `compact`, `expanded`
 
 ### References
 
@@ -1574,12 +1563,11 @@ preferred alternative is set in the EnforcedStyle configuration
 parameter. An *each* call with a block on a single line is always
 allowed, however.
 
-### Important attributes
+### Configurable attributes
 
-Attribute | Value
---- | ---
-EnforcedStyle | each
-SupportedStyles | for, each
+Name | Default value | Configurable values
+--- | --- | ---
+EnforcedStyle | `each` | `for`, `each`
 
 ### References
 
@@ -1599,12 +1587,11 @@ manner for all cases, so only two scenarios are considered -
 if the first argument is a string literal and if the second
 argument is an array literal.
 
-### Important attributes
+### Configurable attributes
 
-Attribute | Value
---- | ---
-EnforcedStyle | format
-SupportedStyles | format, sprintf, percent
+Name | Default value | Configurable values
+--- | --- | ---
+EnforcedStyle | `format` | `format`, `sprintf`, `percent`
 
 ### References
 
@@ -1645,12 +1632,11 @@ format('%{greeting}', 'Hello')
 format('%s', 'Hello')
 ```
 
-### Important attributes
+### Configurable attributes
 
-Attribute | Value
---- | ---
-EnforcedStyle | annotated
-SupportedStyles | annotated, template, unannotated
+Name | Default value | Configurable values
+--- | --- | ---
+EnforcedStyle | `annotated` | `annotated`, `template`, `unannotated`
 
 ## Style/FrozenStringLiteralComment
 
@@ -1664,12 +1650,11 @@ enable frozen string literals. Frozen string literals may be default
 in Ruby 3.0. The comment will be added below a shebang and encoding
 comment. The frozen string literal comment is only valid in Ruby 2.3+.
 
-### Important attributes
+### Configurable attributes
 
-Attribute | Value
---- | ---
-EnforcedStyle | when_needed
-SupportedStyles | when_needed, always, never
+Name | Default value | Configurable values
+--- | --- | ---
+EnforcedStyle | `when_needed` | `when_needed`, `always`, `never`
 
 ## Style/GlobalVars
 
@@ -1697,11 +1682,11 @@ foo = 2
 $stdin.read
 ```
 
-### Important attributes
+### Configurable attributes
 
-Attribute | Value
---- | ---
-AllowedVariables |
+Name | Default value | Configurable values
+--- | --- | ---
+AllowedVariables | `[]` | Array
 
 ### References
 
@@ -1750,11 +1735,11 @@ raise 'exception' if something
 ok
 ```
 
-### Important attributes
+### Configurable attributes
 
-Attribute | Value
---- | ---
-MinBodyLength | 1
+Name | Default value | Configurable values
+--- | --- | ---
+MinBodyLength | `1` | Integer
 
 ### References
 
@@ -1821,14 +1806,13 @@ The supported styles are:
 {:c => 3, 'd' => 4}
 ```
 
-### Important attributes
+### Configurable attributes
 
-Attribute | Value
---- | ---
-EnforcedStyle | ruby19
-SupportedStyles | ruby19, hash_rockets, no_mixed_keys, ruby19_no_mixed_keys
-UseHashRocketsWithSymbolValues | false
-PreferHashRocketsForNonAlnumEndingSymbols | false
+Name | Default value | Configurable values
+--- | --- | ---
+EnforcedStyle | `ruby19` | `ruby19`, `hash_rockets`, `no_mixed_keys`, `ruby19_no_mixed_keys`
+UseHashRocketsWithSymbolValues | `false` | Boolean
+PreferHashRocketsForNonAlnumEndingSymbols | `false` | Boolean
 
 ### References
 
@@ -2105,12 +2089,12 @@ foo == bar
 !!('foo' =~ /^\w+$/)
 ```
 
-### Important attributes
+### Configurable attributes
 
-Attribute | Value
---- | ---
-InverseMethods | {:any?=>:none?, :even?=>:odd?, :===>:!=, :=~=>:!~, :<=>:>=, :>=>:<=}
-InverseBlocks | {:select=>:reject, :select!=>:reject!}
+Name | Default value | Configurable values
+--- | --- | ---
+InverseMethods | `{:any?=>:none?, :even?=>:odd?, :===>:!=, :=~=>:!~, :<=>:>=, :>=>:<=}` | 
+InverseBlocks | `{:select=>:reject, :select!=>:reject!}` | 
 
 ## Style/Lambda
 
@@ -2165,12 +2149,11 @@ f = ->(x) do
     end
 ```
 
-### Important attributes
+### Configurable attributes
 
-Attribute | Value
---- | ---
-EnforcedStyle | line_count_dependent
-SupportedStyles | line_count_dependent, lambda, literal
+Name | Default value | Configurable values
+--- | --- | ---
+EnforcedStyle | `line_count_dependent` | `line_count_dependent`, `lambda`, `literal`
 
 ### References
 
@@ -2201,12 +2184,11 @@ lambda.call(x, y)
 lambda.(x, y)
 ```
 
-### Important attributes
+### Configurable attributes
 
-Attribute | Value
---- | ---
-EnforcedStyle | call
-SupportedStyles | call, braces
+Name | Default value | Configurable values
+--- | --- | ---
+EnforcedStyle | `call` | `call`, `braces`
 
 ### References
 
@@ -2281,12 +2263,12 @@ class Foo
 end
 ```
 
-### Important attributes
+### Configurable attributes
 
-Attribute | Value
---- | ---
-IgnoreMacros | true
-IgnoredMethods |
+Name | Default value | Configurable values
+--- | --- | ---
+IgnoreMacros | `true` | Boolean
+IgnoredMethods | `[]` | Array
 
 ### References
 
@@ -2345,12 +2327,11 @@ Enabled | Yes
 This cops checks for parentheses around the arguments in method
 definitions. Both instance and class/singleton methods are checked.
 
-### Important attributes
+### Configurable attributes
 
-Attribute | Value
---- | ---
-EnforcedStyle | require_parentheses
-SupportedStyles | require_parentheses, require_no_parentheses, require_no_parentheses_except_multiline
+Name | Default value | Configurable values
+--- | --- | ---
+EnforcedStyle | `require_parentheses` | `require_parentheses`, `require_no_parentheses`, `require_no_parentheses_except_multiline`
 
 ### References
 
@@ -2444,12 +2425,11 @@ else
 end
 ```
 
-### Important attributes
+### Configurable attributes
 
-Attribute | Value
---- | ---
-EnforcedStyle | both
-SupportedStyles | if, case, both
+Name | Default value | Configurable values
+--- | --- | ---
+EnforcedStyle | `both` | `if`, `case`, `both`
 
 ## Style/MixinGrouping
 
@@ -2488,12 +2468,11 @@ class Foo
 end
 ```
 
-### Important attributes
+### Configurable attributes
 
-Attribute | Value
---- | ---
-EnforcedStyle | separated
-SupportedStyles | separated, grouped
+Name | Default value | Configurable values
+--- | --- | ---
+EnforcedStyle | `separated` | `separated`, `grouped`
 
 ### References
 
@@ -2591,12 +2570,11 @@ module Test
 end
 ```
 
-### Important attributes
+### Configurable attributes
 
-Attribute | Value
---- | ---
-EnforcedStyle | module_function
-SupportedStyles | module_function, extend_self
+Name | Default value | Configurable values
+--- | --- | ---
+EnforcedStyle | `module_function` | `module_function`, `extend_self`
 
 ### References
 
@@ -2713,12 +2691,11 @@ foo ||= (
 )
 ```
 
-### Important attributes
+### Configurable attributes
 
-Attribute | Value
---- | ---
-EnforcedStyle | keyword
-SupportedStyles | keyword, braces
+Name | Default value | Configurable values
+--- | --- | ---
+EnforcedStyle | `keyword` | `keyword`, `braces`
 
 ## Style/MultilineTernaryOperator
 
@@ -2847,12 +2824,11 @@ if !foo
 end
 ```
 
-### Important attributes
+### Configurable attributes
 
-Attribute | Value
---- | ---
-EnforcedStyle | both
-SupportedStyles | both, prefix, postfix
+Name | Default value | Configurable values
+--- | --- | ---
+EnforcedStyle | `both` | `both`, `prefix`, `postfix`
 
 ### References
 
@@ -2912,11 +2888,11 @@ method1(method2(arg), method3(arg))
 method1(method2 arg, method3, arg)
 ```
 
-### Important attributes
+### Configurable attributes
 
-Attribute | Value
---- | ---
-Whitelist | be, be_a, be_an, be_between, be_falsey, be_kind_of, be_instance_of, be_truthy, be_within, eq, eql, end_with, include, match, raise_error, respond_to, start_with
+Name | Default value | Configurable values
+--- | --- | ---
+Whitelist | `be`, `be_a`, `be_an`, `be_between`, `be_falsey`, `be_kind_of`, `be_instance_of`, `be_truthy`, `be_within`, `eq`, `eql`, `end_with`, `include`, `match`, `raise_error`, `respond_to`, `start_with` | Array
 
 ## Style/NestedTernaryOperator
 
@@ -2983,13 +2959,12 @@ end
 end
 ```
 
-### Important attributes
+### Configurable attributes
 
-Attribute | Value
---- | ---
-EnforcedStyle | skip_modifier_ifs
-MinBodyLength | 3
-SupportedStyles | skip_modifier_ifs, always
+Name | Default value | Configurable values
+--- | --- | ---
+EnforcedStyle | `skip_modifier_ifs` | `skip_modifier_ifs`, `always`
+MinBodyLength | `3` | Integer
 
 ### References
 
@@ -3046,11 +3021,11 @@ if !x.nil?
 if x
 ```
 
-### Important attributes
+### Configurable attributes
 
-Attribute | Value
---- | ---
-IncludeSemanticChanges | false
+Name | Default value | Configurable values
+--- | --- | ---
+IncludeSemanticChanges | `false` | Boolean
 
 ### References
 
@@ -3092,12 +3067,11 @@ eg. for octal use `0o` instead of `0` or `0O`.
 Can be configured to use `0` only for octal literals using
 `EnforcedOctalStyle` => `zero_only`
 
-### Important attributes
+### Configurable attributes
 
-Attribute | Value
---- | ---
-EnforcedOctalStyle | zero_with_o
-SupportedOctalStyles | zero_with_o, zero_only
+Name | Default value | Configurable values
+--- | --- | ---
+EnforcedOctalStyle | `zero_with_o` | `zero_with_o`, `zero_only`
 
 ### References
 
@@ -3131,12 +3105,12 @@ of digits in them.
 10_000_00 # typical representation of $10,000 in cents
 ```
 
-### Important attributes
+### Configurable attributes
 
-Attribute | Value
---- | ---
-MinDigits | 5
-Strict | false
+Name | Default value | Configurable values
+--- | --- | ---
+MinDigits | `5` | Integer
+Strict | `false` | Boolean
 
 ### References
 
@@ -3190,14 +3164,13 @@ foo == 0
 bar.baz > 0
 ```
 
-### Important attributes
+### Configurable attributes
 
-Attribute | Value
---- | ---
-AutoCorrect | false
-EnforcedStyle | predicate
-SupportedStyles | predicate, comparison
-Exclude | spec/\*\*/\*
+Name | Default value | Configurable values
+--- | --- | ---
+AutoCorrect | `false` | Boolean
+EnforcedStyle | `predicate` | `predicate`, `comparison`
+Exclude | `spec/**/*` | Array
 
 ### References
 
@@ -3242,11 +3215,11 @@ def fry(temperature: 300)
 end
 ```
 
-### Important attributes
+### Configurable attributes
 
-Attribute | Value
---- | ---
-SuspiciousParamNames | options, opts, args, params, parameters
+Name | Default value | Configurable values
+--- | --- | ---
+SuspiciousParamNames | `options`, `opts`, `args`, `params`, `parameters` | Array
 
 ## Style/OptionalArguments
 
@@ -3353,11 +3326,11 @@ Enabled | Yes
 This cop checks for the presence of superfluous parentheses around the
 condition of if/unless/while/until.
 
-### Important attributes
+### Configurable attributes
 
-Attribute | Value
---- | ---
-AllowSafeAssignment | true
+Name | Default value | Configurable values
+--- | --- | ---
+AllowSafeAssignment | `true` | Boolean
 
 ### References
 
@@ -3393,11 +3366,11 @@ default.
 %I(alpha beta)
 ```
 
-### Important attributes
+### Configurable attributes
 
-Attribute | Value
---- | ---
-PreferredDelimiters | {"default"=>"()", "%i"=>"[]", "%I"=>"[]", "%r"=>"{}", "%w"=>"[]", "%W"=>"[]"}
+Name | Default value | Configurable values
+--- | --- | ---
+PreferredDelimiters | `{"default"=>"()", "%i"=>"[]", "%I"=>"[]", "%r"=>"{}", "%w"=>"[]", "%W"=>"[]"}` | 
 
 ### References
 
@@ -3411,12 +3384,11 @@ Enabled | Yes
 
 This cop checks for usage of the %Q() syntax when %q() would do.
 
-### Important attributes
+### Configurable attributes
 
-Attribute | Value
---- | ---
-EnforcedStyle | lower_case_q
-SupportedStyles | lower_case_q, upper_case_q
+Name | Default value | Configurable values
+--- | --- | ---
+EnforcedStyle | `lower_case_q` | `lower_case_q`, `upper_case_q`
 
 ## Style/PerlBackrefs
 
@@ -3473,12 +3445,11 @@ Hash#has_key?
 Hash#has_value?
 ```
 
-### Important attributes
+### Configurable attributes
 
-Attribute | Value
---- | ---
-EnforcedStyle | short
-SupportedStyles | short, verbose
+Name | Default value | Configurable values
+--- | --- | ---
+EnforcedStyle | `short` | `short`, `verbose`
 
 ### References
 
@@ -3546,12 +3517,11 @@ raise MyCustomError.new(arg1, arg2, arg3)
 fail "message"
 ```
 
-### Important attributes
+### Configurable attributes
 
-Attribute | Value
---- | ---
-EnforcedStyle | exploded
-SupportedStyles | compact, exploded
+Name | Default value | Configurable values
+--- | --- | ---
+EnforcedStyle | `exploded` | `compact`, `exploded`
 
 ### References
 
@@ -3745,11 +3715,11 @@ def test
 end
 ```
 
-### Important attributes
+### Configurable attributes
 
-Attribute | Value
---- | ---
-AllowMultipleReturnValues | false
+Name | Default value | Configurable values
+--- | --- | ---
+AllowMultipleReturnValues | `false` | Boolean
 
 ### References
 
@@ -3894,13 +3864,12 @@ x =~ %r{home/}
 x =~ /home\//
 ```
 
-### Important attributes
+### Configurable attributes
 
-Attribute | Value
---- | ---
-EnforcedStyle | slashes
-SupportedStyles | slashes, percent_r, mixed
-AllowInnerSlashes | false
+Name | Default value | Configurable values
+--- | --- | ---
+EnforcedStyle | `slashes` | `slashes`, `percent_r`, `mixed`
+AllowInnerSlashes | `false` | Boolean
 
 ### References
 
@@ -3982,12 +3951,11 @@ rescue StandardError
 end
 ```
 
-### Important attributes
+### Configurable attributes
 
-Attribute | Value
---- | ---
-EnforcedStyle | explicit
-SupportedStyles | implicit, explicit
+Name | Default value | Configurable values
+--- | --- | ---
+EnforcedStyle | `explicit` | `implicit`, `explicit`
 
 ## Style/ReturnNil
 
@@ -4024,12 +3992,11 @@ def foo(arg)
 end
 ```
 
-### Important attributes
+### Configurable attributes
 
-Attribute | Value
---- | ---
-EnforcedStyle | return
-SupportedStyles | return, return_nil
+Name | Default value | Configurable values
+--- | --- | ---
+EnforcedStyle | `return` | `return`, `return_nil`
 
 ## Style/SafeNavigation
 
@@ -4081,11 +4048,11 @@ foo.nil? || foo.bar
 foo.to_i if foo
 ```
 
-### Important attributes
+### Configurable attributes
 
-Attribute | Value
---- | ---
-ConvertCodeThatCanStartToReturnNil | false
+Name | Default value | Configurable values
+--- | --- | ---
+ConvertCodeThatCanStartToReturnNil | `false` | Boolean
 
 ## Style/SelfAssignment
 
@@ -4131,11 +4098,11 @@ bar = 2
 baz = 3
 ```
 
-### Important attributes
+### Configurable attributes
 
-Attribute | Value
---- | ---
-AllowAsExpressionSeparator | false
+Name | Default value | Configurable values
+--- | --- | ---
+AllowAsExpressionSeparator | `false` | Boolean
 
 ### References
 
@@ -4161,12 +4128,11 @@ Enabled | Yes
 
 This cop checks for uses of `fail` and `raise`.
 
-### Important attributes
+### Configurable attributes
 
-Attribute | Value
---- | ---
-EnforcedStyle | only_raise
-SupportedStyles | only_raise, only_fail, semantic
+Name | Default value | Configurable values
+--- | --- | ---
+EnforcedStyle | `only_raise` | `only_raise`, `only_fail`, `semantic`
 
 ### References
 
@@ -4184,11 +4150,11 @@ method accepting a block match the names specified via configuration.
 For instance one can configure `reduce`(`inject`) to use |a, e| as
 parameters.
 
-### Important attributes
+### Configurable attributes
 
-Attribute | Value
---- | ---
-Methods | {"reduce"=>["acc", "elem"]}, {"inject"=>["acc", "elem"]}
+Name | Default value | Configurable values
+--- | --- | ---
+Methods | `{"reduce"=>["acc", "elem"]}`, `{"inject"=>["acc", "elem"]}` | Array
 
 ## Style/SingleLineMethods
 
@@ -4213,11 +4179,11 @@ def self.resource_class=(klass); end
 def @table.columns; end
 ```
 
-### Important attributes
+### Configurable attributes
 
-Attribute | Value
---- | ---
-AllowIfMethodIsEmpty | true
+Name | Default value | Configurable values
+--- | --- | ---
+AllowIfMethodIsEmpty | `true` | Boolean
 
 ### References
 
@@ -4231,12 +4197,11 @@ Enabled | Yes
 
 This cop looks for uses of Perl-style global variables.
 
-### Important attributes
+### Configurable attributes
 
-Attribute | Value
---- | ---
-EnforcedStyle | use_english_names
-SupportedStyles | use_perl_names, use_english_names
+Name | Default value | Configurable values
+--- | --- | ---
+EnforcedStyle | `use_english_names` | `use_perl_names`, `use_english_names`
 
 ### References
 
@@ -4268,12 +4233,11 @@ There are two different styles. Defaults to `require_parentheses`.
 ->a,b,c { a + b + c}
 ```
 
-### Important attributes
+### Configurable attributes
 
-Attribute | Value
---- | ---
-EnforcedStyle | require_parentheses
-SupportedStyles | require_parentheses, require_no_parentheses
+Name | Default value | Configurable values
+--- | --- | ---
+EnforcedStyle | `require_parentheses` | `require_parentheses`, `require_no_parentheses`
 
 ### References
 
@@ -4334,13 +4298,12 @@ Enabled | Yes
 
 Checks if uses of quotes match the configured preference.
 
-### Important attributes
+### Configurable attributes
 
-Attribute | Value
---- | ---
-EnforcedStyle | single_quotes
-SupportedStyles | single_quotes, double_quotes
-ConsistentQuotesInMultiline | false
+Name | Default value | Configurable values
+--- | --- | ---
+EnforcedStyle | `single_quotes` | `single_quotes`, `double_quotes`
+ConsistentQuotesInMultiline | `false` | Boolean
 
 ### References
 
@@ -4372,12 +4335,11 @@ result = "Tests #{success ? 'PASS' : 'FAIL'}"
 result = "Tests #{success ? "PASS" : "FAIL"}"
 ```
 
-### Important attributes
+### Configurable attributes
 
-Attribute | Value
---- | ---
-EnforcedStyle | single_quotes
-SupportedStyles | single_quotes, double_quotes
+Name | Default value | Configurable values
+--- | --- | ---
+EnforcedStyle | `single_quotes` | `single_quotes`, `double_quotes`
 
 ## Style/StringMethods
 
@@ -4388,11 +4350,11 @@ Disabled | Yes
 This cop enforces the use of consistent method names
 from the String class.
 
-### Important attributes
+### Configurable attributes
 
-Attribute | Value
---- | ---
-PreferredMethods | {"intern"=>"to_sym"}
+Name | Default value | Configurable values
+--- | --- | ---
+PreferredMethods | `{"intern"=>"to_sym"}` | 
 
 ## Style/StructInheritance
 
@@ -4451,13 +4413,12 @@ of 2 or fewer elements.
 %i[foo bar baz]
 ```
 
-### Important attributes
+### Configurable attributes
 
-Attribute | Value
---- | ---
-EnforcedStyle | percent
-MinSize | 0
-SupportedStyles | percent, brackets
+Name | Default value | Configurable values
+--- | --- | ---
+EnforcedStyle | `percent` | `percent`, `brackets`
+MinSize | `0` | Integer
 
 ### References
 
@@ -4499,11 +4460,11 @@ something.map { |s| s.upcase }
 something.map(&:upcase)
 ```
 
-### Important attributes
+### Configurable attributes
 
-Attribute | Value
---- | ---
-IgnoredMethods | respond_to, define_method
+Name | Default value | Configurable values
+--- | --- | ---
+IgnoredMethods | `respond_to`, `define_method` | Array
 
 ## Style/TernaryParentheses
 
@@ -4552,13 +4513,12 @@ foo = bar.baz? ? a : b
 foo = (bar && baz) ? a : b
 ```
 
-### Important attributes
+### Configurable attributes
 
-Attribute | Value
---- | ---
-EnforcedStyle | require_no_parentheses
-SupportedStyles | require_parentheses, require_no_parentheses, require_parentheses_when_complex
-AllowSafeAssignment | true
+Name | Default value | Configurable values
+--- | --- | ---
+EnforcedStyle | `require_no_parentheses` | `require_parentheses`, `require_no_parentheses`, `require_parentheses_when_complex`
+AllowSafeAssignment | `true` | Boolean
 
 ## Style/TrailingBodyOnMethodDefinition
 
@@ -4637,12 +4597,11 @@ method(
 )
 ```
 
-### Important attributes
+### Configurable attributes
 
-Attribute | Value
---- | ---
-EnforcedStyleForMultiline | no_comma
-SupportedStylesForMultiline | comma, consistent_comma, no_comma
+Name | Default value | Configurable values
+--- | --- | ---
+EnforcedStyleForMultiline | `no_comma` | `comma`, `consistent_comma`, `no_comma`
 
 ### References
 
@@ -4695,12 +4654,11 @@ a = [
 ]
 ```
 
-### Important attributes
+### Configurable attributes
 
-Attribute | Value
---- | ---
-EnforcedStyleForMultiline | no_comma
-SupportedStylesForMultiline | comma, consistent_comma, no_comma
+Name | Default value | Configurable values
+--- | --- | ---
+EnforcedStyleForMultiline | `no_comma` | `comma`, `consistent_comma`, `no_comma`
 
 ### References
 
@@ -4772,11 +4730,11 @@ a, *b, _ = foo()  => The correction `a, *b, = foo()` is a syntax error
 a, b, _something = foo()
 ```
 
-### Important attributes
+### Configurable attributes
 
-Attribute | Value
---- | ---
-AllowNamedUnderscoreVariables | true
+Name | Default value | Configurable values
+--- | --- | ---
+AllowNamedUnderscoreVariables | `true` | Boolean
 
 ## Style/TrivialAccessors
 
@@ -4787,15 +4745,15 @@ Enabled | Yes
 This cop looks for trivial reader/writer methods, that could
 have been created with the attr_* family of functions automatically.
 
-### Important attributes
+### Configurable attributes
 
-Attribute | Value
---- | ---
-ExactNameMatch | true
-AllowPredicates | true
-AllowDSLWriters | false
-IgnoreClassMethods | false
-Whitelist | to_ary, to_a, to_c, to_enum, to_h, to_hash, to_i, to_int, to_io, to_open, to_path, to_proc, to_r, to_regexp, to_str, to_s, to_sym
+Name | Default value | Configurable values
+--- | --- | ---
+ExactNameMatch | `true` | Boolean
+AllowPredicates | `true` | Boolean
+AllowDSLWriters | `false` | Boolean
+IgnoreClassMethods | `false` | Boolean
+Whitelist | `to_ary`, `to_a`, `to_c`, `to_enum`, `to_h`, `to_hash`, `to_i`, `to_int`, `to_io`, `to_open`, `to_path`, `to_proc`, `to_r`, `to_regexp`, `to_str`, `to_s`, `to_sym` | Array
 
 ### References
 
@@ -4972,14 +4930,13 @@ array of 2 or fewer elements.
 %w[foo bar baz]
 ```
 
-### Important attributes
+### Configurable attributes
 
-Attribute | Value
---- | ---
-EnforcedStyle | percent
-SupportedStyles | percent, brackets
-MinSize | 0
-WordRegex | (?-mix:\A[\p{Word}\n\t]+\z)
+Name | Default value | Configurable values
+--- | --- | ---
+EnforcedStyle | `percent` | `percent`, `brackets`
+MinSize | `0` | Integer
+WordRegex | `(?-mix:\A[\p{Word}\n\t]+\z)` | 
 
 ### References
 
@@ -5020,12 +4977,11 @@ bar > 10
 3 < a && a < 5
 ```
 
-### Important attributes
+### Configurable attributes
 
-Attribute | Value
---- | ---
-EnforcedStyle | all_comparison_operators
-SupportedStyles | all_comparison_operators, equality_operators_only
+Name | Default value | Configurable values
+--- | --- | ---
+EnforcedStyle | `all_comparison_operators` | `all_comparison_operators`, `equality_operators_only`
 
 ### References
 


### PR DESCRIPTION
The current documentation has some problems.


- "Important attributes" is not "important". It is "configurable".
- Relationships between `EnforcedStyle` and `SupportedStyles` are not clear.
- `nil` is not displayed.


This change will fix the problems.

before
----

![171123054337](https://user-images.githubusercontent.com/4361134/33148981-3b21112c-d011-11e7-8072-ed55d68ee9df.png)



after
----

![171123054310](https://user-images.githubusercontent.com/4361134/33148963-29dd4f84-d011-11e7-8fd2-01e6194bec8d.png)
