### PR TITLE
allow to specify TargetRubyVersion 2.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### New features
 
+* [#5101](https://github.com/bbatsov/rubocop/pull/5101): Allow to specify `TargetRubyVersion` 2.5. ([@walf443][])
 * New cop `Rails/InverseOf` checks for association arguments that require setting the `inverse_of` option manually. ([@bdewater][])
 * [#4252](https://github.com/bbatsov/rubocop/issues/4252): Add new `Style/TrailingBodyOnMethodDefinition` cop. ([@garettarrowood][])
 * Add new `Style/TrailingMethodEndStatment` cop. ([@garettarrowood][])
@@ -3044,3 +3045,4 @@
 [@asherkach]: https://github.com/asherkach
 [@tiagotex]: https://github.com/tiagotex
 [@marcandre]: https://github.com/marcandre
+[@walf443]: https://github.com/walf443

--- a/lib/rubocop/config.rb
+++ b/lib/rubocop/config.rb
@@ -17,7 +17,7 @@ module RuboCop
                        AutoCorrect StyleGuide Details].freeze
     # 2.1 is the oldest officially supported Ruby version.
     DEFAULT_RUBY_VERSION = 2.1
-    KNOWN_RUBIES = [2.1, 2.2, 2.3, 2.4].freeze
+    KNOWN_RUBIES = [2.1, 2.2, 2.3, 2.4, 2.5].freeze
     OBSOLETE_RUBIES = { 1.9 => '0.50', 2.0 => '0.50' }.freeze
     DEFAULT_RAILS_VERSION = 5.0
     OBSOLETE_COPS = {

--- a/lib/rubocop/processed_source.rb
+++ b/lib/rubocop/processed_source.rb
@@ -122,6 +122,9 @@ module RuboCop
       when 2.4
         require 'parser/ruby24'
         Parser::Ruby24
+      when 2.5
+        require 'parser/ruby25'
+        Parser::Ruby25
       else
         raise ArgumentError, "Unknown Ruby version: #{ruby_version.inspect}"
       end

--- a/rubocop.gemspec
+++ b/rubocop.gemspec
@@ -37,7 +37,7 @@ Gem::Specification.new do |s|
   end
 
   s.add_runtime_dependency('parallel', '~> 1.10')
-  s.add_runtime_dependency('parser', '>= 2.3.3.1', '< 3.0')
+  s.add_runtime_dependency('parser', '>= 2.4.0.2', '< 3.0')
   s.add_runtime_dependency('powerpack', '~> 0.1')
   s.add_runtime_dependency('rainbow', '>= 2.2.2', '< 3.0')
   s.add_runtime_dependency('ruby-progressbar', '~> 1.7')

--- a/spec/rubocop/cli_spec.rb
+++ b/spec/rubocop/cli_spec.rb
@@ -1605,14 +1605,14 @@ describe RuboCop::CLI, :isolated_environment do
       it 'fails with an error message' do
         create_file('.rubocop.yml', <<-YAML.strip_indent)
           AllCops:
-            TargetRubyVersion: 2.5
+            TargetRubyVersion: 2.6
         YAML
         expect(cli.run([])).to eq(2)
         expect($stderr.string.strip).to match(
-          /\AError: Unknown Ruby version 2.5 found in `TargetRubyVersion`/
+          /\AError: Unknown Ruby version 2.6 found in `TargetRubyVersion`/
         )
         expect($stderr.string.strip).to match(
-          /Supported versions: 2.1, 2.2, 2.3, 2.4/
+          /Supported versions: 2.1, 2.2, 2.3, 2.4, 2.5/
         )
       end
     end


### PR DESCRIPTION
parser gem v2.4.0 was released. It start support ruby25, So rubocop can allow to specify TargetRubyVersion 2.5 for preparing ruby 2.5.0 release.

https://github.com/whitequark/parser/blob/master/CHANGELOG.md#v2401-2017-11-13 

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Used the same coding conventions as the rest of the project.
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] All tests(`rake spec`) are passing.
* [x] The new code doesn't generate RuboCop offenses that are checked by `rake internal_investigation`.
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Updated cop documentation with `rake generate_cops_documentation` (required only when you've added a new cop or changed the configuration/documentation of an existing cop).

[1]: http://chris.beams.io/posts/git-commit/
