### PR TITLE
Make a `Lint/DuplicateMethods` spec to pending

### DIFF
--- a/spec/rubocop/cop/lint/duplicate_methods_spec.rb
+++ b/spec/rubocop/cop/lint/duplicate_methods_spec.rb
@@ -225,7 +225,8 @@ describe RuboCop::Cop::Lint::DuplicateMethods do
       )
     end
 
-    it "doesn't register an offense when class << exp is used" do
+    it 'registers an offense when class << exp is used' do
+      pending
       inspect_source([opening_line,
                       '  class << blah',
                       '    def some_method',
@@ -236,7 +237,7 @@ describe RuboCop::Cop::Lint::DuplicateMethods do
                       '    end',
                       '  end',
                       'end'], 'test.rb')
-      expect(cop.offenses.empty?).to be(true)
+      expect(cop.offenses.empty?).to be(false)
     end
 
     it "registers an offense for duplicate alias in #{type}" do


### PR DESCRIPTION
Currently, the test case checks `Lint/DuplicateMethods` accepts the following duplicated methods.

```ruby
class << blah
  def a; end
  def a; end
end
```

But the cop should add an offense for the code. The methods are duplicated.
But the cop can't add an offense for the code, so this change will make the test case to pending.

Fixing this bug is a little hard. So I just changed the spec only.

I found the spec while I was trying https://github.com/bbatsov/rubocop/issues/5022 . Maybe we can remove the `pending` when we resolve the issue. 

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Used the same coding conventions as the rest of the project.
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [ ] Added tests.
* [ ] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] All tests(`rake spec`) are passing.
* [x] The new code doesn't generate RuboCop offenses that are checked by `rake internal_investigation`.
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [ ] Updated cop documentation with `rake generate_cops_documentation` (required only when you've added a new cop or changed the configuration/documentation of an existing cop).

[1]: http://chris.beams.io/posts/git-commit/
