### PR TITLE
Simplify `Offense#corrected`

### DIFF
--- a/lib/rubocop/cop/offense.rb
+++ b/lib/rubocop/cop/offense.rb
@@ -72,7 +72,7 @@ module RuboCop
       # @return [Boolean]
       #   whether this offense is automatically corrected.
       def corrected
-        @status == :unsupported ? false : @status == :corrected
+        @status == :corrected
       end
       alias corrected? corrected
 


### PR DESCRIPTION
We can simplify `a == b ? false : a == c` to `a == c`.

Note: This method returned a `nil` when `@status` is `:unsupported`. But the behaviour was removed, so we can simplify it.
https://github.com/bbatsov/rubocop/pull/4165/commits/23451c40056cfa036672a7d6501d8815f7a1a2c3

---

Maybe we can add a cop for this problem, but the cop will be for too rare cases. 

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Used the same coding conventions as the rest of the project.
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [ ] Added tests.
* [ ] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] All tests(`rake spec`) are passing.
* [x] The new code doesn't generate RuboCop offenses that are checked by `rake internal_investigation`.
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [ ] Updated cop documentation with `rake generate_cops_documentation` (required only when you've added a new cop or changed the configuration/documentation of an existing cop).

[1]: http://chris.beams.io/posts/git-commit/
