### PR TITLE
Add an example of `EnforcedStyle` to `Style/Next` cop

### DIFF
--- a/lib/rubocop/cop/style/next.rb
+++ b/lib/rubocop/cop/style/next.rb
@@ -5,7 +5,35 @@ module RuboCop
     module Style
       # Use `next` to skip iteration instead of a condition at the end.
       #
-      # @example
+      # @example EnforcedStyle: skip_modifier_ifs (default)
+      #   # bad
+      #   [1, 2].each do |a|
+      #     if a == 1
+      #       puts a
+      #     end
+      #   end
+      #
+      #   # good
+      #   [1, 2].each do |a|
+      #     next unless a == 1
+      #     puts a
+      #   end
+      #
+      #   # good
+      #   [1, 2].each do |o|
+      #     puts o unless o == 1
+      #   end
+      #
+      # @example EnforcedStyle: always
+      #   # With `always` all conditions at the end of an iteration needs to be
+      #   # replaced by next - with `skip_modifier_ifs` the modifier if like
+      #   # this one are ignored: `[1, 2].each { |a| return 'yes' if a == 1 }`
+      #
+      #   # bad
+      #   [1, 2].each do |o|
+      #     puts o unless o == 1
+      #   end
+      #
       #   # bad
       #   [1, 2].each do |a|
       #     if a == 1

--- a/manual/cops_style.md
+++ b/manual/cops_style.md
@@ -2953,6 +2953,34 @@ end
   next unless a == 1
   puts a
 end
+
+# good
+[1, 2].each do |o|
+  puts o unless o == 1
+end
+```
+```ruby
+# With `always` all conditions at the end of an iteration needs to be
+# replaced by next - with `skip_modifier_ifs` the modifier if like
+# this one are ignored: `[1, 2].each { |a| return 'yes' if a == 1 }`
+
+# bad
+[1, 2].each do |o|
+  puts o unless o == 1
+end
+
+# bad
+[1, 2].each do |a|
+  if a == 1
+    puts a
+  end
+end
+
+# good
+[1, 2].each do |a|
+  next unless a == 1
+  puts a
+end
 ```
 
 ### Important attributes


### PR DESCRIPTION
This is only document change.

This commit adds an example of `EnforcedStyle` to `Style/Next` cop.
I found it when I was investigating #4880.

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Used the same coding conventions as the rest of the project.
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [ ] Added tests.
* [ ] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] All tests(`rake spec`) are passing.
* [x] The new code doesn't generate RuboCop offenses that are checked by `rake internal_investigation`.
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Updated cop documentation with `rake generate_cops_documentation` (required only when you've added a new cop or changed the configuration/documentation of an existing cop).

[1]: http://chris.beams.io/posts/git-commit/
