### PR TITLE
[Fix #5099] Prevent Style/MinMax from breaking on implicit receivers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,7 @@
 * [#5071](https://github.com/bbatsov/rubocop/pull/5071): Fix a false positive in `Lint/UnneededSplatExpansion`, when `Array.new` resides in an array literal. ([@akhramov][])
 * [#4071](https://github.com/bbatsov/rubocop/issues/4071): Prevent generating wrong code by Style/ColonMethodCall and Style/RedundantSelf. ([@pocke][])
 * [#5089](https://github.com/bbatsov/rubocop/issues/5089): Fix false positive for `Style/SafeNavigation` when safe guarding arithmetic operation or assignment. ([@tiagotex][])
+* [#5099](https://github.com/bbatsov/rubocop/pull/5099): Prevent `Style/MinMax` from breaking on implicit receivers. ([@drenmi][])
 
 ### Changes
 

--- a/lib/rubocop/cop/style/min_max.rb
+++ b/lib/rubocop/cop/style/min_max.rb
@@ -30,7 +30,7 @@ module RuboCop
         private
 
         def_node_matcher :min_max_candidate, <<-PATTERN
-          ({array return} (send $_receiver :min) (send $_receiver :max))
+          ({array return} (send [$_receiver !nil?] :min) (send [$_receiver !nil?] :max))
         PATTERN
 
         def message(offender, receiver)

--- a/spec/rubocop/cop/style/min_max_spec.rb
+++ b/spec/rubocop/cop/style/min_max_spec.rb
@@ -24,6 +24,12 @@ describe RuboCop::Cop::Style::MinMax, :config do
         RUBY
       end
 
+      it 'does not register an offense if the receiver is implicit' do
+        expect_no_offenses(<<-RUBY.strip_indent)
+          [min, max]
+        RUBY
+      end
+
       it 'auto-corrects an offense to use `#minmax`' do
         corrected = autocorrect_source(<<-RUBY.strip_indent)
           [foo.bar.min, foo.bar.max]
@@ -55,6 +61,12 @@ describe RuboCop::Cop::Style::MinMax, :config do
         RUBY
       end
 
+      it 'does not register an offense if the receiver is implicit' do
+        expect_no_offenses(<<-RUBY.strip_indent)
+          bar = min, max
+        RUBY
+      end
+
       it 'auto-corrects an offense to use `#minmax`' do
         corrected = autocorrect_source(<<-RUBY.strip_indent)
           baz = foo.bar.min, foo.bar.max
@@ -83,6 +95,12 @@ describe RuboCop::Cop::Style::MinMax, :config do
       it 'does not register an offense if there are additional elements' do
         expect_no_offenses(<<-RUBY.strip_indent)
           return foo.min, foo.baz, foo.max
+        RUBY
+      end
+
+      it 'does not register an offense if the receiver is implicit' do
+        expect_no_offenses(<<-RUBY.strip_indent)
+          return min, max
         RUBY
       end
 


### PR DESCRIPTION
This cop would break when encountering an implicit receiver, e.g.:

```ruby
foo = min, max
```

This change fixes that.

-----------------

Before submitting the PR make sure the following are checked:

* [X] Wrote [good commit messages][1].
* [X] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [X] Used the same coding conventions as the rest of the project.
* [X] Feature branch is up-to-date with `master` (if not - rebase it).
* [X] Squashed related commits together.
* [X] Added tests.
* [X] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [X] All tests(`rake spec`) are passing.
* [X] The new code doesn't generate RuboCop offenses that are checked by `rake internal_investigation`.
* [X] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [ ] Updated cop documentation with `rake generate_cops_documentation` (required only when you've added a new cop or changed the configuration/documentation of an existing cop).

[1]: http://chris.beams.io/posts/git-commit/
