### PR TITLE
[Fix #4449] Make `Layout/IndentHeredoc` aware of line length

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -66,6 +66,7 @@
 * [#5044](https://github.com/bbatsov/rubocop/pull/5044): Add last_line and last_column into outputs of the JSON formatter. ([@pocke][])
 * [#4633](https://github.com/bbatsov/rubocop/issues/4633): Make metrics cops aware of `define_method`. ([@pocke][])
 * [#5037](https://github.com/bbatsov/rubocop/pull/5037): Make display cop names to enable by default. ([@pocke][])
+* [#4449](https://github.com/bbatsov/rubocop/issues/4449): Make `Layout/IndentHeredoc` aware of line length. ([@pocke][])
 
 ## 0.51.0 (2017-10-18)
 

--- a/lib/rubocop/cop/layout/indent_heredoc.rb
+++ b/lib/rubocop/cop/layout/indent_heredoc.rb
@@ -58,6 +58,7 @@ module RuboCop
             return unless body_indent_level.zero?
           end
 
+          return if too_long_line?(node)
           add_offense(node, location: :heredoc_body)
         end
 
@@ -113,6 +114,23 @@ module RuboCop
             indentation_width: indentation_width,
             current_indent_type: current_indent_type
           )
+        end
+
+        def too_long_line?(node)
+          return false if config.for_cop('Metrics/LineLength')['AllowHeredoc']
+          body = heredoc_body(node)
+
+          expected_indent = base_indent_level(node) + indentation_width
+          actual_indent = indent_level(body)
+          increase_indent_level = expected_indent - actual_indent
+
+          max_line = body.each_line.map { |line| line.chomp.size }.max
+
+          max_line + increase_indent_level >= max_line_length
+        end
+
+        def max_line_length
+          config.for_cop('Metrics/LineLength')['Max']
         end
 
         def correct_by_squiggly(node)

--- a/manual/cops_rails.md
+++ b/manual/cops_rails.md
@@ -203,11 +203,11 @@ create_table :users do |t|
 end
 ```
 
-### Important attributes
+### Configurable attributes
 
-Attribute | Value
---- | ---
-Include | db/migrate/\*.rb
+Name | Default value | Configurable values
+--- | --- | ---
+Include | `db/migrate/*.rb` | Array
 
 ## Rails/Date
 

--- a/spec/rubocop/cop/layout/indent_heredoc_spec.rb
+++ b/spec/rubocop/cop/layout/indent_heredoc_spec.rb
@@ -3,6 +3,13 @@
 describe RuboCop::Cop::Layout::IndentHeredoc, :config do
   subject(:cop) { described_class.new(config) }
 
+  let(:allow_heredoc) { true }
+  let(:other_cops) do
+    {
+      'Metrics/LineLength' => { 'Max' => 5, 'AllowHeredoc' => allow_heredoc }
+    }
+  end
+
   shared_examples :offense do |name, code, correction = nil|
     it "registers an offense for #{name}" do
       inspect_source(code.strip_indent)
@@ -141,6 +148,26 @@ describe RuboCop::Cop::Layout::IndentHeredoc, :config do
 
         RUBY2
       RUBY
+
+      context 'when Metrics/LineLength is configured' do
+        let(:allow_heredoc) { false }
+
+        include_examples :offense, 'short heredoc', <<-RUBY, <<-CORRECTION
+          <<#{quote}RUBY2#{quote}
+          12
+          RUBY2
+        RUBY
+          <<#{quote}RUBY2#{quote}.strip_indent
+            12
+          RUBY2
+        CORRECTION
+
+        include_examples :accept, 'long heredoc', <<-RUBY
+          <<#{quote}RUBY2#{quote}
+          12345678
+          RUBY2
+        RUBY
+      end
 
       include_examples :check_message, 'suggestion powerpack',
                        [


### PR DESCRIPTION
Problem
===

See #4449

`Layout/IndentHeredoc` does not treat line length. So the cop adds an offense for a heredoc with long line.

For example

```ruby
module A
  module B
    class C
      def foo
        puts <<-MSG
This message's max line length is 75.
So, if you add indentations to this heredoc, this code violates LineLength.
But if `Metrics/LineLength`'s `AllowHeredoc` is true(default),
it does not violate.
        MSG
      end
    end
  end
end
```

Solution
=====

This change will make `Layout/IndentHeredoc` to not register any offenses for a heredoc with long line when `AllowHeredoc` is false.



-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Used the same coding conventions as the rest of the project.
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] All tests(`rake spec`) are passing.
* [x] The new code doesn't generate RuboCop offenses that are checked by `rake internal_investigation`.
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Updated cop documentation with `rake generate_cops_documentation` (required only when you've added a new cop or changed the configuration/documentation of an existing cop).

[1]: http://chris.beams.io/posts/git-commit/
