### PR TITLE
[#4910] Add documentation examples to Rails/Exit

### DIFF
--- a/lib/rubocop/cop/rails/exit.rb
+++ b/lib/rubocop/cop/rails/exit.rb
@@ -16,6 +16,13 @@ module RuboCop
       # - Usage in application code outside of the web process could result in
       # the program exiting, which could result in the code failing to run and
       # do its job.
+      #
+      # @example
+      #   # bad
+      #   exit(0)
+      #
+      #   # good
+      #   raise 'a bad error has happened'
       class Exit < Cop
         include ConfigurableEnforcedStyle
 

--- a/manual/cops_rails.md
+++ b/manual/cops_rails.md
@@ -456,6 +456,16 @@ is used.)
 the program exiting, which could result in the code failing to run and
 do its job.
 
+### Example
+
+```ruby
+# bad
+exit(0)
+
+# good
+raise 'a bad error has happened'
+```
+
 ### Configurable attributes
 
 Name | Default value | Configurable values


### PR DESCRIPTION
* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Used the same coding conventions as the rest of the project.
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [ ] Added tests.
* [ ] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] All tests(`rake spec`) are passing.
* [ ] The new code doesn't generate RuboCop offenses that are checked by `rake internal_investigation`.
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Updated cop documentation with `rake generate_cops_documentation` (required only when you've added a new cop or changed the configuration/documentation of an existing cop).

[1]: http://chris.beams.io/posts/git-commit/
