### PR TITLE
[Fix #5079] Fix false positive for `Style/SafeNavigation`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,7 @@
 * [#4071](https://github.com/bbatsov/rubocop/issues/4071): Prevent generating wrong code by Style/ColonMethodCall and Style/RedundantSelf. ([@pocke][])
 * [#5089](https://github.com/bbatsov/rubocop/issues/5089): Fix false positive for `Style/SafeNavigation` when safe guarding arithmetic operation or assignment. ([@tiagotex][])
 * [#5099](https://github.com/bbatsov/rubocop/pull/5099): Prevent `Style/MinMax` from breaking on implicit receivers. ([@drenmi][])
+* [#5079](https://github.com/bbatsov/rubocop/issues/5079): Fix false positive for `Style/SafeNavigation` when safe guarding comparisons. ([@tiagotex][])
 
 ### Changes
 

--- a/lib/rubocop/cop/style/safe_navigation.rb
+++ b/lib/rubocop/cop/style/safe_navigation.rb
@@ -151,11 +151,22 @@ module RuboCop
                      end
 
           if receiver == checked_variable
-            return nil if node.assignment? || node.parent.arithmetic_operation?
+            return nil if assignment_arithmetic_or_comparison?(node)
+
             return receiver
           end
 
           find_matching_receiver_invocation(receiver, checked_variable)
+        end
+
+        def assignment_arithmetic_or_comparison?(node)
+          node.assignment? ||
+            node.parent.arithmetic_operation? ||
+            comparison_node?(node.parent)
+        end
+
+        def comparison_node?(parent)
+          parent.send_type? && parent.comparison_method?
         end
 
         def unsafe_method?(send_node)

--- a/spec/rubocop/cop/style/safe_navigation_spec.rb
+++ b/spec/rubocop/cop/style/safe_navigation_spec.rb
@@ -40,6 +40,16 @@ describe RuboCop::Cop::Style::SafeNavigation, :config do
       expect_no_offenses('foo && !foo.bar?')
     end
 
+    it 'allows method call that are used in a comparison safe guarded by ' \
+      'an object check' do
+      expect_no_offenses('foo.bar > 2 if foo')
+    end
+
+    it 'allows an object check before a method call that are used in ' \
+      'a comparison' do
+      expect_no_offenses('foo && foo.bar > 2')
+    end
+
     it 'allows method calls that do not get called using . safe guarded by ' \
       'an object check' do
       expect_no_offenses('foo + bar if foo')


### PR DESCRIPTION
Fix #5079

This PR solves the false positive in `Style/SafeNavigation` when object check safe guards method calls used in a comparison.

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Used the same coding conventions as the rest of the project.
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] All tests(`rake spec`) are passing.
* [x] The new code doesn't generate RuboCop offenses that are checked by `rake internal_investigation`.
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Updated cop documentation with `rake generate_cops_documentation` (required only when you've added a new cop or changed the configuration/documentation of an existing cop).

[1]: http://chris.beams.io/posts/git-commit/