### PR TITLE
Add an example of `EnforcedStyle` for `Layout/DotPosition` cop

### DIFF
--- a/lib/rubocop/cop/layout/dot_position.rb
+++ b/lib/rubocop/cop/layout/dot_position.rb
@@ -5,7 +5,7 @@ module RuboCop
     module Layout
       # This cop checks the . position in multi-line method calls.
       #
-      # @example
+      # @example EnforcedStyle: leading (default)
       #   # bad
       #   something.
       #     mehod
@@ -13,6 +13,15 @@ module RuboCop
       #   # good
       #   something
       #     .method
+      #
+      # @example EnforcedStyle: trailing
+      #   # bad
+      #   something
+      #     .method
+      #
+      #   # good
+      #   something.
+      #     mehod
       class DotPosition < Cop
         include ConfigurableEnforcedStyle
 

--- a/manual/cops_layout.md
+++ b/manual/cops_layout.md
@@ -564,6 +564,15 @@ something.
 something
   .method
 ```
+```ruby
+# bad
+something
+  .method
+
+# good
+something.
+  mehod
+```
 
 ### Important attributes
 


### PR DESCRIPTION
This is only document change.

This commit adds an example of `EnforcedStyle` to `Layout/DotPosition` cop.
I found it when I was investigating #4880.

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Used the same coding conventions as the rest of the project.
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [ ] Added tests.
* [ ] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] All tests(`rake spec`) are passing.
* [x] The new code doesn't generate RuboCop offenses that are checked by `rake internal_investigation`.
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Updated cop documentation with `rake generate_cops_documentation` (required only when you've added a new cop or changed the configuration/documentation of an existing cop).

[1]: http://chris.beams.io/posts/git-commit/
