### PR TITLE
[Fix #5075] Fix auto-correct for `Style/RedundantParentheses`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,6 +49,7 @@
 * [#5089](https://github.com/bbatsov/rubocop/issues/5089): Fix false positive for `Style/SafeNavigation` when safe guarding arithmetic operation or assignment. ([@tiagotex][])
 * [#5099](https://github.com/bbatsov/rubocop/pull/5099): Prevent `Style/MinMax` from breaking on implicit receivers. ([@drenmi][])
 * [#5079](https://github.com/bbatsov/rubocop/issues/5079): Fix false positive for `Style/SafeNavigation` when safe guarding comparisons. ([@tiagotex][])
+* [#5075](https://github.com/bbatsov/rubocop/issues/5075): Fix auto-correct for `Style/RedundantParentheses` cop when unspaced ternary is present. ([@tiagotex][])
 
 ### Changes
 

--- a/lib/rubocop/cop/mixin/parentheses.rb
+++ b/lib/rubocop/cop/mixin/parentheses.rb
@@ -15,7 +15,19 @@ module RuboCop
         lambda do |corrector|
           corrector.remove(node.loc.begin)
           corrector.remove(node.loc.end)
+
+          if ternary_condition?(node) && next_char_is_question_mark?(node)
+            corrector.insert_after(node.loc.end, ' ')
+          end
         end
+      end
+
+      def ternary_condition?(node)
+        node.parent && node.parent.if_type? && node.parent.ternary?
+      end
+
+      def next_char_is_question_mark?(node)
+        node.loc.last_column == node.parent.loc.question.column
       end
     end
   end

--- a/spec/rubocop/cop/style/redundant_parentheses_spec.rb
+++ b/spec/rubocop/cop/style/redundant_parentheses_spec.rb
@@ -61,6 +61,9 @@ describe RuboCop::Cop::Style::RedundantParentheses do
   it_behaves_like 'redundant', '(retry)', 'retry', 'a keyword'
   it_behaves_like 'redundant', '(self)', 'self', 'a keyword'
 
+  it_behaves_like 'redundant', '(X) ? Y : N', 'X ? Y : N', 'a constant', '(X)'
+  it_behaves_like 'redundant', '(X)? Y : N', 'X ? Y : N', 'a constant', '(X)'
+
   it_behaves_like 'keyword with return value', 'break'
   it_behaves_like 'keyword with return value', 'next'
   it_behaves_like 'keyword with return value', 'return'


### PR DESCRIPTION
Fix #5075

`Style/RedundantParentheses` tried to autocorrect redundant parentheses in a unspaced ternary operation by removing the parenthesis but didn't add an extra space.

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [x] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Used the same coding conventions as the rest of the project.
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] All tests(`rake spec`) are passing.
* [x] The new code doesn't generate RuboCop offenses that are checked by `rake internal_investigation`.
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Updated cop documentation with `rake generate_cops_documentation` (required only when you've added a new cop or changed the configuration/documentation of an existing cop).

[1]: http://chris.beams.io/posts/git-commit/