### PR TITLE
Syntax checking for the documentation comments

### DIFF
--- a/.travis.rb
+++ b/.travis.rb
@@ -36,7 +36,9 @@ end
 sh!('bundle exec codeclimate-test-reporter') if master? && test?
 
 # Running YARD under jruby crashes so skip checking manual under jruby
-sh!('bundle exec rake generate_cops_documentation') unless jruby?
+unless jruby?
+  sh!('bundle exec rake documentation_syntax_check generate_cops_documentation')
+end
 
 # Check requiring libraries successfully.
 # See https://github.com/bbatsov/rubocop/pull/4523#issuecomment-309136113

--- a/lib/rubocop/cop/layout/closing_parenthesis_indentation.rb
+++ b/lib/rubocop/cop/layout/closing_parenthesis_indentation.rb
@@ -25,6 +25,7 @@ module RuboCop
       #     x,
       #     y
       #     )
+      #   end
       class ClosingParenthesisIndentation < Cop
         include AutocorrectAlignment
 

--- a/lib/rubocop/cop/layout/empty_lines_around_begin_body.rb
+++ b/lib/rubocop/cop/layout/empty_lines_around_begin_body.rb
@@ -12,14 +12,14 @@ module RuboCop
       #   # good
       #
       #   begin
-      #     ...
+      #     # ...
       #   end
       #
       #   # bad
       #
       #   begin
       #
-      #     ...
+      #     # ...
       #
       #   end
       class EmptyLinesAroundBeginBody < Cop

--- a/lib/rubocop/cop/layout/empty_lines_around_block_body.rb
+++ b/lib/rubocop/cop/layout/empty_lines_around_block_body.rb
@@ -11,7 +11,7 @@ module RuboCop
       #
       #   foo do |bar|
       #
-      #     ...
+      #     # ...
       #
       #   end
       #
@@ -19,7 +19,7 @@ module RuboCop
       #   # good
       #
       #   foo do |bar|
-      #     ...
+      #     # ...
       #   end
       class EmptyLinesAroundBlockBody < Cop
         include EmptyLinesAroundBody

--- a/lib/rubocop/cop/layout/empty_lines_around_class_body.rb
+++ b/lib/rubocop/cop/layout/empty_lines_around_class_body.rb
@@ -12,7 +12,7 @@ module RuboCop
       #   class Foo
       #
       #      def bar
-      #        ...
+      #        # ...
       #      end
       #
       #   end

--- a/lib/rubocop/cop/layout/empty_lines_around_method_body.rb
+++ b/lib/rubocop/cop/layout/empty_lines_around_method_body.rb
@@ -10,14 +10,14 @@ module RuboCop
       #   # good
       #
       #   def foo
-      #     ...
+      #     # ...
       #   end
       #
       #   # bad
       #
       #   def bar
       #
-      #     ...
+      #     # ...
       #
       #   end
       class EmptyLinesAroundMethodBody < Cop

--- a/lib/rubocop/cop/layout/empty_lines_around_module_body.rb
+++ b/lib/rubocop/cop/layout/empty_lines_around_module_body.rb
@@ -12,7 +12,7 @@ module RuboCop
       #   module Foo
       #
       #     def bar
-      #       ...
+      #       # ...
       #     end
       #
       #   end
@@ -22,7 +22,7 @@ module RuboCop
       #
       #   module Foo
       #     def bar
-      #       ...
+      #       # ...
       #     end
       #   end
       class EmptyLinesAroundModuleBody < Cop

--- a/lib/rubocop/cop/layout/indentation_width.rb
+++ b/lib/rubocop/cop/layout/indentation_width.rb
@@ -10,16 +10,22 @@ module RuboCop
       # one.
       #
       # @example
-      #   # bad, Width: 2
+      #   # bad
       #   class A
       #    def test
       #     puts 'hello'
       #    end
       #   end
       #
-      #   # bad, Width: 2,
-      #          IgnoredPatterns:
-      #            - '^\s*module'
+      #   # good
+      #   class A
+      #     def test
+      #       puts 'hello'
+      #     end
+      #   end
+      #
+      # @example IgnoredPatterns: ['^\s*module']
+      #   # bad
       #   module A
       #   class B
       #     def test
@@ -28,16 +34,7 @@ module RuboCop
       #   end
       #   end
       #
-      #   # good, Width: 2
-      #   class A
-      #     def test
-      #       puts 'hello'
-      #     end
-      #   end
-      #
-      #   # good, Width: 2,
-      #           IgnoredPatterns:
-      #             - '^\s*module'
+      #   # good
       #   module A
       #   class B
       #     def test

--- a/lib/rubocop/cop/layout/multiline_method_call_indentation.rb
+++ b/lib/rubocop/cop/layout/multiline_method_call_indentation.rb
@@ -6,34 +6,34 @@ module RuboCop
       # This cop checks the indentation of the method name part in method calls
       # that span more than one line.
       #
-      # @example
+      # @example EnforcedStyle: aligned
       #   # bad
       #   while myvariable
       #   .b
       #     # do something
       #   end
       #
-      #   # good, EnforcedStyle: aligned
+      #   # good
       #   while myvariable
       #         .b
       #     # do something
       #   end
       #
-      #   # good, EnforcedStyle: aligned
+      #   # good
       #   Thing.a
       #        .b
       #        .c
       #
-      #   # good, EnforcedStyle:    indented,
-      #           IndentationWidth: 2
+      # @example EnforcedStyle: indented
+      #   # good
       #   while myvariable
       #     .b
       #
       #     # do something
       #   end
       #
-      #   # good, EnforcedStyle:    indented_relative_to_receiver,
-      #           IndentationWidth: 2
+      # @example EnforcedStyle: indented_relative_to_receiver
+      #   # good
       #   while myvariable
       #           .a
       #           .b
@@ -41,8 +41,7 @@ module RuboCop
       #     # do something
       #   end
       #
-      #   # good, EnforcedStyle:    indented_relative_to_receiver,
-      #           IndentationWidth: 2
+      #   # good
       #   myvariable = Thing
       #                  .a
       #                  .b

--- a/lib/rubocop/cop/layout/multiline_method_definition_brace_layout.rb
+++ b/lib/rubocop/cop/layout/multiline_method_definition_brace_layout.rb
@@ -34,6 +34,7 @@ module RuboCop
       #     def foo(a,
       #       b
       #     )
+      #     end
       #
       #     # symmetrical: bad
       #     # new_line: bad
@@ -41,12 +42,14 @@ module RuboCop
       #     def foo(
       #       a,
       #       b)
+      #     end
       #
       #     # symmetrical: good
       #     # new_line: bad
       #     # same_line: good
       #     def foo(a,
       #       b)
+      #     end
       #
       #     # symmetrical: good
       #     # new_line: good
@@ -55,6 +58,7 @@ module RuboCop
       #       a,
       #       b
       #     )
+      #     end
       class MultilineMethodDefinitionBraceLayout < Cop
         include MultilineLiteralBraceLayout
 

--- a/lib/rubocop/cop/layout/space_after_comma.rb
+++ b/lib/rubocop/cop/layout/space_after_comma.rb
@@ -8,11 +8,11 @@ module RuboCop
       # @example
       #
       #   # bad
-      #   1,2
+      #   [1,2]
       #   { foo:bar,}
       #
       #   # good
-      #   1, 2
+      #   [1, 2]
       #   { foo:bar, }
       class SpaceAfterComma < Cop
         include SpaceAfterPunctuation

--- a/lib/rubocop/cop/layout/space_after_method_name.rb
+++ b/lib/rubocop/cop/layout/space_after_method_name.rb
@@ -8,12 +8,12 @@ module RuboCop
       # @example
       #
       #   # bad
-      #   def func (x) ... end
-      #   def method= (y) ... end
+      #   def func (x) end
+      #   def method= (y) end
       #
       #   # good
-      #   def func(x) ... end
-      #   def method=(y) ... end
+      #   def func(x) end
+      #   def method=(y) end
       class SpaceAfterMethodName < Cop
         MSG = 'Do not put a space between a method name and the opening ' \
               'parenthesis.'.freeze

--- a/lib/rubocop/cop/layout/space_inside_hash_literal_braces.rb
+++ b/lib/rubocop/cop/layout/space_inside_hash_literal_braces.rb
@@ -32,12 +32,10 @@ module RuboCop
       #   # braces or right braces are collapsed together in nested hashes.
       #
       #   # bad
-      #   h = { { a: 1 }, b: 2 }
-      #   h = { a: 1, { b: 2 } }
+      #   h = { a: { b: 2 } }
       #
       #   # good
-      #   h = {{ a: 1 }, b: 2 }
-      #   h = { a: 1, { b: 2 }}
+      #   h = { a: { b: 2 }}
       class SpaceInsideHashLiteralBraces < Cop
         include SurroundingSpace
         include ConfigurableEnforcedStyle

--- a/lib/rubocop/cop/lint/else_layout.rb
+++ b/lib/rubocop/cop/lint/else_layout.rb
@@ -12,7 +12,7 @@ module RuboCop
       #   # bad
       #
       #   if something
-      #     ...
+      #     # ...
       #   else do_this
       #     do_that
       #   end
@@ -22,7 +22,7 @@ module RuboCop
       #   # good
       #
       #   if something
-      #     ...
+      #     # ...
       #   else
       #     do_this
       #     do_that

--- a/lib/rubocop/cop/lint/non_local_exit_from_iterator.rb
+++ b/lib/rubocop/cop/lint/non_local_exit_from_iterator.rb
@@ -18,13 +18,13 @@ module RuboCop
       #
       #   class ItemApi
       #     rescue_from ValidationError do |e| # non-iteration block with arg
-      #       return message: 'validation error' unless e.errors # allowed
+      #       return { message: 'validation error' } unless e.errors # allowed
       #       error_array = e.errors.map do |error| # block with method chain
       #         return if error.suppress? # warned
       #         return "#{error.param}: invalid" unless error.message # allowed
       #         "#{error.param}: #{error.message}"
       #       end
-      #       message: 'validation error', errors: error_array
+      #       { message: 'validation error', errors: error_array }
       #     end
       #
       #     def update_items

--- a/lib/rubocop/cop/lint/require_parentheses.rb
+++ b/lib/rubocop/cop/lint/require_parentheses.rb
@@ -17,7 +17,7 @@ module RuboCop
       #   # bad
       #
       #   if day.is? :tuesday && month == :jan
-      #     ...
+      #     # ...
       #   end
       #
       # @example
@@ -25,6 +25,8 @@ module RuboCop
       #   # good
       #
       #   if day.is?(:tuesday) && month == :jan
+      #     # ...
+      #   end
       class RequireParentheses < Cop
         MSG = 'Use parentheses in the method call to avoid confusion about ' \
               'precedence.'.freeze

--- a/lib/rubocop/cop/naming/accessor_method_name.rb
+++ b/lib/rubocop/cop/naming/accessor_method_name.rb
@@ -7,16 +7,20 @@ module RuboCop
       #
       # @example
       #   # bad
-      #   def set_attribute(value) ...
+      #   def set_attribute(value)
+      #   end
       #
       #   # good
       #   def attribute=(value)
+      #   end
       #
       #   # bad
-      #   def get_attribute ...
+      #   def get_attribute
+      #   end
       #
       #   # good
-      #   def attribute ...
+      #   def attribute
+      #   end
       class AccessorMethodName < Cop
         MSG_READER = 'Do not prefix reader method names with `get_`.'.freeze
         MSG_WRITER = 'Do not prefix writer method names with `set_`.'.freeze

--- a/lib/rubocop/cop/naming/predicate_name.rb
+++ b/lib/rubocop/cop/naming/predicate_name.rb
@@ -7,16 +7,20 @@ module RuboCop
       #
       # @example
       #   # bad
-      #   def is_even?(value) ...
+      #   def is_even?(value)
+      #   end
       #
       #   # good
       #   def even?(value)
+      #   end
       #
       #   # bad
-      #   def has_value? ...
+      #   def has_value?
+      #   end
       #
       #   # good
-      #   def value? ...
+      #   def value?
+      #   end
       class PredicateName < Cop
         def_node_matcher :dynamic_method_define, <<-PATTERN
           (send nil? #method_definition_macros

--- a/lib/rubocop/cop/performance/double_start_end_with.rb
+++ b/lib/rubocop/cop/performance/double_start_end_with.rb
@@ -11,15 +11,11 @@ module RuboCop
       #   # bad
       #   str.start_with?("a") || str.start_with?(Some::CONST)
       #   str.start_with?("a", "b") || str.start_with?("c")
-      #   var1 = ...
-      #   var2 = ...
       #   str.end_with?(var1) || str.end_with?(var2)
       #
       #   # good
       #   str.start_with?("a", Some::CONST)
       #   str.start_with?("a", "b", "c")
-      #   var1 = ...
-      #   var2 = ...
       #   str.end_with?(var1, var2)
       class DoubleStartEndWith < Cop
         MSG = 'Use `%<receiver>s.%<method>s(%<combined_args>s)` ' \

--- a/lib/rubocop/cop/rails/application_job.rb
+++ b/lib/rubocop/cop/rails/application_job.rb
@@ -9,12 +9,12 @@ module RuboCop
       #
       #  # good
       #  class Rails5Job < ApplicationJob
-      #    ...
+      #    # ...
       #  end
       #
       #  # bad
       #  class Rails4Job < ActiveJob::Base
-      #    ...
+      #    # ...
       #  end
       class ApplicationJob < Cop
         extend TargetRailsVersion

--- a/lib/rubocop/cop/rails/application_record.rb
+++ b/lib/rubocop/cop/rails/application_record.rb
@@ -9,12 +9,12 @@ module RuboCop
       #
       #  # good
       #  class Rails5Model < ApplicationRecord
-      #    ...
+      #    # ...
       #  end
       #
       #  # bad
       #  class Rails4Model < ActiveRecord::Base
-      #    ...
+      #    # ...
       #  end
       class ApplicationRecord < Cop
         extend TargetRailsVersion

--- a/lib/rubocop/cop/rails/output_safety.rb
+++ b/lib/rubocop/cop/rails/output_safety.rb
@@ -14,60 +14,54 @@ module RuboCop
       #
       #   # bad
       #   "<p>#{user_content}</p>".html_safe
-      #   => ActiveSupport::SafeBuffer
-      #   "<p><b>hi</b></p>"
+      #   # => ActiveSupport::SafeBuffer "<p><b>hi</b></p>"
       #
       #   # good
       #   content_tag(:p, user_content)
-      #   => ActiveSupport::SafeBuffer
-      #   "<p>&lt;b&gt;hi&lt;/b&gt;</p>"
+      #   # => ActiveSupport::SafeBuffer "<p>&lt;b&gt;hi&lt;/b&gt;</p>"
       #
       #   # bad
       #   out = ""
       #   out << "<li>#{user_content}</li>"
       #   out << "<li>#{user_content}</li>"
       #   out.html_safe
-      #   => ActiveSupport::SafeBuffer
-      #   "<li><b>hi</b></li><li><b>hi</b></li>"
+      #   # => ActiveSupport::SafeBuffer "<li><b>hi</b></li><li><b>hi</b></li>"
       #
       #   # good
       #   out = []
       #   out << content_tag(:li, user_content)
       #   out << content_tag(:li, user_content)
       #   safe_join(out)
-      #   => ActiveSupport::SafeBuffer
-      #   "<li>&lt;b&gt;hi&lt;/b&gt;</li><li>&lt;b&gt;hi&lt;/b&gt;</li>"
+      #   # => ActiveSupport::SafeBuffer
+      #   #    "<li>&lt;b&gt;hi&lt;/b&gt;</li><li>&lt;b&gt;hi&lt;/b&gt;</li>"
       #
       #   # bad
       #   out = "<h1>trusted content</h1>".html_safe
       #   out.safe_concat(user_content)
-      #   => ActiveSupport::SafeBuffer
-      #   "<h1>trusted_content</h1><b>hi</b>"
+      #   # => ActiveSupport::SafeBuffer "<h1>trusted_content</h1><b>hi</b>"
       #
       #   # good
       #   out = "<h1>trusted content</h1>".html_safe
       #   out.concat(user_content)
-      #   => ActiveSupport::SafeBuffer
-      #   "<h1>trusted_content</h1>&lt;b&gt;hi&lt;/b&gt;"
+      #   # => ActiveSupport::SafeBuffer
+      #   #    "<h1>trusted_content</h1>&lt;b&gt;hi&lt;/b&gt;"
       #
       #   # safe, though maybe not good style
       #   out = "trusted content"
       #   result = out.concat(user_content)
-      #   => String "trusted content<b>hi</b>"
+      #   # => String "trusted content<b>hi</b>"
       #   # because when rendered in ERB the String will be escaped:
-      #   <%= result %>
-      #   => trusted content&lt;b&gt;hi&lt;/b&gt;
+      #   # <%= result %>
+      #   # => trusted content&lt;b&gt;hi&lt;/b&gt;
       #
       #   # bad
       #   (user_content + " " + content_tag(:span, user_content)).html_safe
-      #   => ActiveSupport::SafeBuffer
-      #   "<b>hi</b> <span><b>hi</b></span>"
+      #   # => ActiveSupport::SafeBuffer "<b>hi</b> <span><b>hi</b></span>"
       #
       #   # good
       #   safe_join([user_content, " ", content_tag(:span, user_content)])
-      #   => ActiveSupport::SafeBuffer
-      #   "&lt;b&gt;hi&lt;/b&gt; <span>&lt;b&gt;hi&lt;/b&gt;</span>"
-      #
+      #   # => ActiveSupport::SafeBuffer
+      #   #    "&lt;b&gt;hi&lt;/b&gt; <span>&lt;b&gt;hi&lt;/b&gt;</span>"
       class OutputSafety < Cop
         MSG = 'Tagging a string as html safe may be a security risk.'.freeze
 

--- a/lib/rubocop/cop/rails/save_bang.rb
+++ b/lib/rubocop/cop/rails/save_bang.rb
@@ -24,7 +24,7 @@ module RuboCop
       #
       #   # good
       #   unless user.save
-      #      . . .
+      #     # ...
       #   end
       #   user.save!
       #   user.update!(name: 'Joe')
@@ -33,7 +33,7 @@ module RuboCop
       #
       #   user = User.find_or_create_by(name: 'Joe')
       #   unless user.persisted?
-      #      . . .
+      #     # ...
       #   end
       class SaveBang < Cop
         MSG = 'Use `%s` instead of `%s` if the return value is not checked.'

--- a/lib/rubocop/cop/rails/uniq_before_pluck.rb
+++ b/lib/rubocop/cop/rails/uniq_before_pluck.rb
@@ -26,7 +26,7 @@ module RuboCop
       #
       # @example
       #   # this will return a Relation that pluck is called on
-      #   Model.where(...).pluck(:id).uniq
+      #   Model.where(cond: true).pluck(:id).uniq
       #
       #   # an association on an instance will return a CollectionProxy
       #   instance.assoc.pluck(:id).uniq

--- a/lib/rubocop/cop/style/and_or.rb
+++ b/lib/rubocop/cop/style/and_or.rb
@@ -14,10 +14,12 @@ module RuboCop
       #   # good
       #   foo.save && return
       #   if foo && bar
+      #   end
       #
       #   # bad
       #   foo.save and return
       #   if foo and bar
+      #   end
       #
       # @example
       #
@@ -27,9 +29,11 @@ module RuboCop
       #   foo.save && return
       #   foo.save and return
       #   if foo && bar
+      #   end
       #
       #   # bad
       #   if foo and bar
+      #   end
       class AndOr < Cop
         include ConfigurableEnforcedStyle
 

--- a/lib/rubocop/cop/style/auto_resource_cleanup.rb
+++ b/lib/rubocop/cop/style/auto_resource_cleanup.rb
@@ -14,7 +14,7 @@ module RuboCop
       #
       #   # good
       #   File.open('file') do |f|
-      #     ...
+      #     # ...
       #   end
       class AutoResourceCleanup < Cop
         MSG = 'Use the block version of `%s.%s`.'.freeze

--- a/lib/rubocop/cop/style/class_methods.rb
+++ b/lib/rubocop/cop/style/class_methods.rb
@@ -10,14 +10,14 @@ module RuboCop
       #   # bad
       #   class SomeClass
       #     def SomeClass.class_method
-      #       ...
+      #       # ...
       #     end
       #   end
       #
       #   # good
       #   class SomeClass
       #     def self.class_method
-      #       ...
+      #       # ...
       #     end
       #   end
       class ClassMethods < Cop

--- a/lib/rubocop/cop/style/colon_method_call.rb
+++ b/lib/rubocop/cop/style/colon_method_call.rb
@@ -8,12 +8,12 @@ module RuboCop
       #
       # @example
       #   # bad
-      #   Timeout::timeout(500) { ... }
+      #   Timeout::timeout(500) { do_something }
       #   FileUtils::rmdir(dir)
       #   Marshal::dump(obj)
       #
       #   # good
-      #   Timeout.timeout(500) { ... }
+      #   Timeout.timeout(500) { do_something }
       #   FileUtils.rmdir(dir)
       #   Marshal.dump(obj)
       #

--- a/lib/rubocop/cop/style/commented_keyword.rb
+++ b/lib/rubocop/cop/style/commented_keyword.rb
@@ -29,7 +29,7 @@ module RuboCop
       #   end
       #
       #   # good
-      #   class x # :nodoc:
+      #   class X # :nodoc:
       #     y
       #   end
       class CommentedKeyword < Cop

--- a/lib/rubocop/cop/style/documentation.rb
+++ b/lib/rubocop/cop/style/documentation.rb
@@ -15,13 +15,13 @@ module RuboCop
       # @example
       #   # bad
       #   class Person
-      #     ...
+      #     # ...
       #   end
       #
       #   # good
       #   # Description/Explanation of Person class
       #   class Person
-      #     ...
+      #     # ...
       #   end
       #
       class Documentation < Cop

--- a/lib/rubocop/cop/style/even_odd.rb
+++ b/lib/rubocop/cop/style/even_odd.rb
@@ -10,9 +10,11 @@ module RuboCop
       #
       #   # bad
       #   if x % 2 == 0
+      #   end
       #
       #   # good
       #   if x.even?
+      #   end
       class EvenOdd < Cop
         MSG = 'Replace with `Integer#%s?`.'.freeze
 

--- a/lib/rubocop/cop/style/method_missing.rb
+++ b/lib/rubocop/cop/style/method_missing.rb
@@ -8,17 +8,17 @@ module RuboCop
       #
       # @example
       #   #bad
-      #   def method_missing(...)
-      #     ...
+      #   def method_missing(name, *args)
+      #     # ...
       #   end
       #
       #   #good
-      #   def respond_to_missing?(...)
-      #     ...
+      #   def respond_to_missing?(name, include_private)
+      #     # ...
       #   end
       #
-      #   def method_missing(...)
-      #     ...
+      #   def method_missing(name, *args)
+      #     # ...
       #     super
       #   end
       class MethodMissing < Cop

--- a/lib/rubocop/cop/style/module_function.rb
+++ b/lib/rubocop/cop/style/module_function.rb
@@ -12,26 +12,26 @@ module RuboCop
       #   # bad
       #   module Test
       #     extend self
-      #     ...
+      #     # ...
       #   end
       #
       #   # good
       #   module Test
       #     module_function
-      #     ...
+      #     # ...
       #   end
       #
       # @example EnforcedStyle: extend_self
       #   # bad
       #   module Test
       #     module_function
-      #     ...
+      #     # ...
       #   end
       #
       #   # good
       #   module Test
       #     extend self
-      #     ...
+      #     # ...
       #   end
       #
       # These offenses are not auto-corrected since there are different

--- a/lib/rubocop/cop/style/nil_comparison.rb
+++ b/lib/rubocop/cop/style/nil_comparison.rb
@@ -7,11 +7,13 @@ module RuboCop
       #
       # @example
       #
-      #  # bad
-      #  if x == nil
+      #   # bad
+      #   if x == nil
+      #   end
       #
-      #  # good
-      #  if x.nil?
+      #   # good
+      #   if x.nil?
+      #   end
       class NilComparison < Cop
         MSG = 'Prefer the use of the `nil?` predicate.'.freeze
 

--- a/lib/rubocop/cop/style/non_nil_check.rb
+++ b/lib/rubocop/cop/style/non_nil_check.rb
@@ -7,22 +7,25 @@ module RuboCop
       #
       # @example
       #
-      #  # bad
-      #  if x != nil
+      #   # bad
+      #   if x != nil
+      #   end
       #
-      #  # good (when not allowing semantic changes)
-      #  # bad (when allowing semantic changes)
-      #  if !x.nil?
+      #   # good (when not allowing semantic changes)
+      #   # bad (when allowing semantic changes)
+      #   if !x.nil?
+      #   end
       #
-      #  # good (when allowing semantic changes)
-      #  if x
+      #   # good (when allowing semantic changes)
+      #   if x
+      #   end
       #
       # Non-nil checks are allowed if they are the final nodes of predicate.
       #
-      #  # good
-      #  def signed_in?
-      #    !current_user.nil?
-      #  end
+      #   # good
+      #   def signed_in?
+      #     !current_user.nil?
+      #   end
       class NonNilCheck < Cop
         def_node_matcher :not_equal_to_nil?, '(send _ :!= nil)'
         def_node_matcher :unless_check?, '(if (send _ :nil?) ...)'

--- a/lib/rubocop/cop/style/option_hash.rb
+++ b/lib/rubocop/cop/style/option_hash.rb
@@ -7,17 +7,17 @@ module RuboCop
       # current Ruby version supports keyword arguments.
       #
       # @example
-      #   Instead of:
       #
+      #   # bad
       #   def fry(options = {})
       #     temperature = options.fetch(:temperature, 300)
-      #     ...
+      #     # ...
       #   end
       #
-      #   Prefer:
       #
+      #   # good
       #   def fry(temperature: 300)
-      #     ...
+      #     # ...
       #   end
       class OptionHash < Cop
         MSG = 'Prefer keyword arguments to options hashes.'.freeze

--- a/lib/rubocop/cop/style/trailing_underscore_variable.rb
+++ b/lib/rubocop/cop/style/trailing_underscore_variable.rb
@@ -15,8 +15,10 @@ module RuboCop
       #   # good
       #   a, b, = foo()
       #   a, = foo()
-      #   *a, b, _ = foo()  => We need to know to not include 2 variables in a
-      #   a, *b, _ = foo()  => The correction `a, *b, = foo()` is a syntax error
+      #   *a, b, _ = foo()
+      #   # => We need to know to not include 2 variables in a
+      #   a, *b, _ = foo()
+      #   # => The correction `a, *b, = foo()` is a syntax error
       #
       #   # good if AllowNamedUnderscoreVariables is true
       #   a, b, _something = foo()

--- a/manual/cops_layout.md
+++ b/manual/cops_layout.md
@@ -505,6 +505,7 @@ def func(
   x,
   y
   )
+end
 ```
 
 ## Layout/CommentIndentation
@@ -771,14 +772,14 @@ blocks.
 # good
 
 begin
-  ...
+  # ...
 end
 
 # bad
 
 begin
 
-  ...
+  # ...
 
 end
 ```
@@ -803,7 +804,7 @@ the configuration.
 
 foo do |bar|
 
-  ...
+  # ...
 
 end
 ```
@@ -811,7 +812,7 @@ end
 # good
 
 foo do |bar|
-  ...
+  # ...
 end
 ```
 
@@ -843,7 +844,7 @@ the configuration.
 class Foo
 
    def bar
-     ...
+     # ...
    end
 
 end
@@ -942,14 +943,14 @@ This cops checks if empty lines exist around the bodies of methods.
 # good
 
 def foo
-  ...
+  # ...
 end
 
 # bad
 
 def bar
 
-  ...
+  # ...
 
 end
 ```
@@ -975,7 +976,7 @@ the configuration.
 module Foo
 
   def bar
-    ...
+    # ...
   end
 
 end
@@ -985,7 +986,7 @@ end
 
 module Foo
   def bar
-    ...
+    # ...
   end
 end
 ```
@@ -1415,16 +1416,22 @@ one.
 ### Example
 
 ```ruby
-# bad, Width: 2
+# bad
 class A
  def test
   puts 'hello'
  end
 end
 
-# bad, Width: 2,
-       IgnoredPatterns:
-         - '^\s*module'
+# good
+class A
+  def test
+    puts 'hello'
+  end
+end
+```
+```ruby
+# bad
 module A
 class B
   def test
@@ -1433,16 +1440,7 @@ class B
 end
 end
 
-# good, Width: 2
-class A
-  def test
-    puts 'hello'
-  end
-end
-
-# good, Width: 2,
-        IgnoredPatterns:
-          - '^\s*module'
+# good
 module A
 class B
   def test
@@ -1812,27 +1810,27 @@ while myvariable
   # do something
 end
 
-# good, EnforcedStyle: aligned
+# good
 while myvariable
       .b
   # do something
 end
 
-# good, EnforcedStyle: aligned
+# good
 Thing.a
      .b
      .c
-
-# good, EnforcedStyle:    indented,
-        IndentationWidth: 2
+```
+```ruby
+# good
 while myvariable
   .b
 
   # do something
 end
-
-# good, EnforcedStyle:    indented_relative_to_receiver,
-        IndentationWidth: 2
+```
+```ruby
+# good
 while myvariable
         .a
         .b
@@ -1840,8 +1838,7 @@ while myvariable
   # do something
 end
 
-# good, EnforcedStyle:    indented_relative_to_receiver,
-        IndentationWidth: 2
+# good
 myvariable = Thing
                .a
                .b
@@ -1894,6 +1891,7 @@ line as the last parameter of the definition.
 def foo(a,
   b
 )
+end
 
 # symmetrical: bad
 # new_line: bad
@@ -1901,12 +1899,14 @@ def foo(a,
 def foo(
   a,
   b)
+end
 
 # symmetrical: good
 # new_line: bad
 # same_line: good
 def foo(a,
   b)
+end
 
 # symmetrical: good
 # new_line: good
@@ -1915,6 +1915,7 @@ def foo(
   a,
   b
 )
+end
 ```
 
 ### Important attributes
@@ -2020,11 +2021,11 @@ Checks for comma (,) not followed by some kind of space.
 
 ```ruby
 # bad
-1,2
+[1,2]
 { foo:bar,}
 
 # good
-1, 2
+[1, 2]
 { foo:bar, }
 ```
 
@@ -2044,12 +2045,12 @@ Checks for space between a method name and a left parenthesis in defs.
 
 ```ruby
 # bad
-def func (x) ... end
-def method= (y) ... end
+def func (x) end
+def method= (y) end
 
 # good
-def func(x) ... end
-def method=(y) ... end
+def func(x) end
+def method=(y) end
 ```
 
 ### References
@@ -2559,12 +2560,10 @@ h = {a: 1, b: 2}
 # braces or right braces are collapsed together in nested hashes.
 
 # bad
-h = { { a: 1 }, b: 2 }
-h = { a: 1, { b: 2 } }
+h = { a: { b: 2 } }
 
 # good
-h = {{ a: 1 }, b: 2 }
-h = { a: 1, { b: 2 }}
+h = { a: { b: 2 }}
 ```
 
 ### Important attributes

--- a/manual/cops_lint.md
+++ b/manual/cops_lint.md
@@ -550,7 +550,7 @@ which is usually a mistake.
 # bad
 
 if something
-  ...
+  # ...
 else do_this
   do_that
 end
@@ -559,7 +559,7 @@ end
 # good
 
 if something
-  ...
+  # ...
 else
   do_this
   do_that
@@ -1346,13 +1346,13 @@ value. It registers an offense under these conditions:
 ```ruby
 class ItemApi
   rescue_from ValidationError do |e| # non-iteration block with arg
-    return message: 'validation error' unless e.errors # allowed
+    return { message: 'validation error' } unless e.errors # allowed
     error_array = e.errors.map do |error| # block with method chain
       return if error.suppress? # warned
       return "#{error.param}: invalid" unless error.message # allowed
       "#{error.param}: #{error.message}"
     end
-    message: 'validation error', errors: error_array
+    { message: 'validation error', errors: error_array }
   end
 
   def update_items
@@ -1576,13 +1576,15 @@ an operand of &&/||.
 # bad
 
 if day.is? :tuesday && month == :jan
-  ...
+  # ...
 end
 ```
 ```ruby
 # good
 
 if day.is?(:tuesday) && month == :jan
+  # ...
+end
 ```
 
 ## Lint/RescueException

--- a/manual/cops_naming.md
+++ b/manual/cops_naming.md
@@ -12,16 +12,20 @@ This cop makes sure that accessor methods are named properly.
 
 ```ruby
 # bad
-def set_attribute(value) ...
+def set_attribute(value)
+end
 
 # good
 def attribute=(value)
+end
 
 # bad
-def get_attribute ...
+def get_attribute
+end
 
 # good
-def attribute ...
+def attribute
+end
 ```
 
 ### References
@@ -323,16 +327,20 @@ This cop makes sure that predicates are named properly.
 
 ```ruby
 # bad
-def is_even?(value) ...
+def is_even?(value)
+end
 
 # good
 def even?(value)
+end
 
 # bad
-def has_value? ...
+def has_value?
+end
 
 # good
-def value? ...
+def value?
+end
 ```
 
 ### Important attributes

--- a/manual/cops_performance.md
+++ b/manual/cops_performance.md
@@ -245,15 +245,11 @@ with an single `#start_with?`/`#end_with?` call.
 # bad
 str.start_with?("a") || str.start_with?(Some::CONST)
 str.start_with?("a", "b") || str.start_with?("c")
-var1 = ...
-var2 = ...
 str.end_with?(var1) || str.end_with?(var2)
 
 # good
 str.start_with?("a", Some::CONST)
 str.start_with?("a", "b", "c")
-var1 = ...
-var2 = ...
 str.end_with?(var1, var2)
 ```
 

--- a/manual/cops_rails.md
+++ b/manual/cops_rails.md
@@ -74,12 +74,12 @@ This cop checks that jobs subclass ApplicationJob with Rails 5.0.
 ```ruby
 # good
 class Rails5Job < ApplicationJob
-  ...
+  # ...
 end
 
 # bad
 class Rails4Job < ActiveJob::Base
-  ...
+  # ...
 end
 ```
 
@@ -96,12 +96,12 @@ This cop checks that models subclass ApplicationRecord with Rails 5.0.
 ```ruby
 # good
 class Rails5Model < ApplicationRecord
-  ...
+  # ...
 end
 
 # bad
 class Rails4Model < ActiveRecord::Base
-  ...
+  # ...
 end
 ```
 
@@ -683,59 +683,54 @@ user_content = "<b>hi</b>"
 
 # bad
 "<p>#{user_content}</p>".html_safe
-=> ActiveSupport::SafeBuffer
-"<p><b>hi</b></p>"
+# => ActiveSupport::SafeBuffer "<p><b>hi</b></p>"
 
 # good
 content_tag(:p, user_content)
-=> ActiveSupport::SafeBuffer
-"<p>&lt;b&gt;hi&lt;/b&gt;</p>"
+# => ActiveSupport::SafeBuffer "<p>&lt;b&gt;hi&lt;/b&gt;</p>"
 
 # bad
 out = ""
 out << "<li>#{user_content}</li>"
 out << "<li>#{user_content}</li>"
 out.html_safe
-=> ActiveSupport::SafeBuffer
-"<li><b>hi</b></li><li><b>hi</b></li>"
+# => ActiveSupport::SafeBuffer "<li><b>hi</b></li><li><b>hi</b></li>"
 
 # good
 out = []
 out << content_tag(:li, user_content)
 out << content_tag(:li, user_content)
 safe_join(out)
-=> ActiveSupport::SafeBuffer
-"<li>&lt;b&gt;hi&lt;/b&gt;</li><li>&lt;b&gt;hi&lt;/b&gt;</li>"
+# => ActiveSupport::SafeBuffer
+#    "<li>&lt;b&gt;hi&lt;/b&gt;</li><li>&lt;b&gt;hi&lt;/b&gt;</li>"
 
 # bad
 out = "<h1>trusted content</h1>".html_safe
 out.safe_concat(user_content)
-=> ActiveSupport::SafeBuffer
-"<h1>trusted_content</h1><b>hi</b>"
+# => ActiveSupport::SafeBuffer "<h1>trusted_content</h1><b>hi</b>"
 
 # good
 out = "<h1>trusted content</h1>".html_safe
 out.concat(user_content)
-=> ActiveSupport::SafeBuffer
-"<h1>trusted_content</h1>&lt;b&gt;hi&lt;/b&gt;"
+# => ActiveSupport::SafeBuffer
+#    "<h1>trusted_content</h1>&lt;b&gt;hi&lt;/b&gt;"
 
 # safe, though maybe not good style
 out = "trusted content"
 result = out.concat(user_content)
-=> String "trusted content<b>hi</b>"
+# => String "trusted content<b>hi</b>"
 # because when rendered in ERB the String will be escaped:
-<%= result %>
-=> trusted content&lt;b&gt;hi&lt;/b&gt;
+# <%= result %>
+# => trusted content&lt;b&gt;hi&lt;/b&gt;
 
 # bad
 (user_content + " " + content_tag(:span, user_content)).html_safe
-=> ActiveSupport::SafeBuffer
-"<b>hi</b> <span><b>hi</b></span>"
+# => ActiveSupport::SafeBuffer "<b>hi</b> <span><b>hi</b></span>"
 
 # good
 safe_join([user_content, " ", content_tag(:span, user_content)])
-=> ActiveSupport::SafeBuffer
-"&lt;b&gt;hi&lt;/b&gt; <span>&lt;b&gt;hi&lt;/b&gt;</span>"
+# => ActiveSupport::SafeBuffer
+#    "&lt;b&gt;hi&lt;/b&gt; <span>&lt;b&gt;hi&lt;/b&gt;</span>"
 ```
 
 ## Rails/PluralizationGrammar
@@ -1118,7 +1113,7 @@ user.destroy
 
 # good
 unless user.save
-   . . .
+  # ...
 end
 user.save!
 user.update!(name: 'Joe')
@@ -1127,7 +1122,7 @@ user.destroy!
 
 user = User.find_or_create_by(name: 'Joe')
 unless user.persisted?
-   . . .
+  # ...
 end
 ```
 
@@ -1280,7 +1275,7 @@ Model.uniq.pluck(:id)
 ```
 ```ruby
 # this will return a Relation that pluck is called on
-Model.where(...).pluck(:id).uniq
+Model.where(cond: true).pluck(:id).uniq
 
 # an association on an instance will return a CollectionProxy
 instance.assoc.pluck(:id).uniq

--- a/manual/cops_style.md
+++ b/manual/cops_style.md
@@ -61,10 +61,12 @@ all contexts.
 # good
 foo.save && return
 if foo && bar
+end
 
 # bad
 foo.save and return
 if foo and bar
+end
 ```
 ```ruby
 # EnforcedStyle: conditionals
@@ -73,9 +75,11 @@ if foo and bar
 foo.save && return
 foo.save and return
 if foo && bar
+end
 
 # bad
 if foo and bar
+end
 ```
 
 ### Important attributes
@@ -187,7 +191,7 @@ f = File.open('file')
 
 # good
 File.open('file') do |f|
-  ...
+  # ...
 end
 ```
 
@@ -534,14 +538,14 @@ self, when defining class/module methods.
 # bad
 class SomeClass
   def SomeClass.class_method
-    ...
+    # ...
   end
 end
 
 # good
 class SomeClass
   def self.class_method
-    ...
+    # ...
   end
 end
 ```
@@ -600,12 +604,12 @@ of the . operator (like FileUtils::rmdir instead of FileUtils.rmdir).
 
 ```ruby
 # bad
-Timeout::timeout(500) { ... }
+Timeout::timeout(500) { do_something }
 FileUtils::rmdir(dir)
 Marshal::dump(obj)
 
 # good
-Timeout.timeout(500) { ... }
+Timeout.timeout(500) { do_something }
 FileUtils.rmdir(dir)
 Marshal.dump(obj)
 ```
@@ -814,7 +818,7 @@ if condition
 end
 
 # good
-class x # :nodoc:
+class X # :nodoc:
   y
 end
 ```
@@ -1073,13 +1077,13 @@ same for all its children.
 ```ruby
 # bad
 class Person
-  ...
+  # ...
 end
 
 # good
 # Description/Explanation of Person class
 class Person
-  ...
+  # ...
 end
 ```
 
@@ -1528,9 +1532,11 @@ should have been used.
 ```ruby
 # bad
 if x % 2 == 0
+end
 
 # good
 if x.even?
+end
 ```
 
 ### References
@@ -2369,17 +2375,17 @@ defining `respond_to_missing?` and falling back on `super`.
 
 ```ruby
 #bad
-def method_missing(...)
-  ...
+def method_missing(name, *args)
+  # ...
 end
 
 #good
-def respond_to_missing?(...)
-  ...
+def respond_to_missing?(name, include_private)
+  # ...
 end
 
-def method_missing(...)
-  ...
+def method_missing(name, *args)
+  # ...
   super
 end
 ```
@@ -2568,26 +2574,26 @@ implications to each approach.
 # bad
 module Test
   extend self
-  ...
+  # ...
 end
 
 # good
 module Test
   module_function
-  ...
+  # ...
 end
 ```
 ```ruby
 # bad
 module Test
   module_function
-  ...
+  # ...
 end
 
 # good
 module Test
   extend self
-  ...
+  # ...
 end
 ```
 
@@ -3008,9 +3014,11 @@ This cop checks for comparison of something with nil using ==.
 ```ruby
 # bad
 if x == nil
+end
 
 # good
 if x.nil?
+end
 ```
 
 ### References
@@ -3027,23 +3035,26 @@ This cop checks for non-nil checks, which are usually redundant.
 
 Non-nil checks are allowed if they are the final nodes of predicate.
 
- # good
- def signed_in?
-   !current_user.nil?
- end
+  # good
+  def signed_in?
+    !current_user.nil?
+  end
 
 ### Example
 
 ```ruby
 # bad
 if x != nil
+end
 
 # good (when not allowing semantic changes)
 # bad (when allowing semantic changes)
 if !x.nil?
+end
 
 # good (when allowing semantic changes)
 if x
+end
 ```
 
 ### Important attributes
@@ -3228,17 +3239,15 @@ current Ruby version supports keyword arguments.
 ### Example
 
 ```ruby
-Instead of:
-
+# bad
 def fry(options = {})
   temperature = options.fetch(:temperature, 300)
-  ...
+  # ...
 end
 
-Prefer:
-
+# good
 def fry(temperature: 300)
-  ...
+  # ...
 end
 ```
 
@@ -4765,8 +4774,10 @@ a, _, _, = foo()
 # good
 a, b, = foo()
 a, = foo()
-*a, b, _ = foo()  => We need to know to not include 2 variables in a
-a, *b, _ = foo()  => The correction `a, *b, = foo()` is a syntax error
+*a, b, _ = foo()
+# => We need to know to not include 2 variables in a
+a, *b, _ = foo()
+# => The correction `a, *b, = foo()` is a syntax error
 
 # good if AllowNamedUnderscoreVariables is true
 a, b, _something = foo()


### PR DESCRIPTION
What's this pull-request?
===

This pull-request will add a syntax checker for the documentation comments.



I believe example codes must not have any syntax errors. If an example has a syntax error, users maybe misunderstand it. We can prevent this case by this pull-request.

Note: This pull-request will only fix syntax errors, in other words, this pull-request will not restyle the examples. For example: #5007
Restyling is out of the scope of this pull-request.

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Used the same coding conventions as the rest of the project.
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [ ] Squashed related commits together.
* [ ] Added tests.
* [ ] Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] All tests(`rake spec`) are passing.
* [x] The new code doesn't generate RuboCop offenses that are checked by `rake internal_investigation`.
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Updated cop documentation with `rake generate_cops_documentation` (required only when you've added a new cop or changed the configuration/documentation of an existing cop).

[1]: http://chris.beams.io/posts/git-commit/
