### PR TITLE
contributing docs: update link to CONTRIBUTING.md

### DIFF
--- a/manual/contributing.md
+++ b/manual/contributing.md
@@ -14,7 +14,7 @@ Patches in any form are always welcome! GitHub pull requests are even better! :-
 
 Before submitting a patch or a pull request make sure all tests are
 passing and that your patch is in line with the [contribution
-guidelines](https://github.com/bbatsov/rubocop/blob/master/.github/CONTRIBUTING.md).
+guidelines](https://github.com/bbatsov/rubocop/blob/master/CONTRIBUTING.md).
 
 See also. [development.md](development.md)
 


### PR DESCRIPTION
This PR updates a broken hyperlink in the published documentation to point to the current CONTRIBUTING.md.
