### PR TITLE
Add a style guide link for Style/ColonMethodDefinition

### DIFF
--- a/config/enabled.yml
+++ b/config/enabled.yml
@@ -489,6 +489,7 @@ Style/ColonMethodCall:
 
 Style/ColonMethodDefinition:
   Description: 'Do not use :: for defining class methods.'
+  StyleGuide: '#colon-method-definition'
   Enabled: true
 
 Style/CommandLiteral:


### PR DESCRIPTION
This is dependent on https://github.com/bbatsov/ruby-style-guide/pull/685.