### PR TITLE
BUGFIX - Missing docs

### DIFF
--- a/manual/cops_style.md
+++ b/manual/cops_style.md
@@ -636,6 +636,10 @@ class Foo
 end
 ```
 
+### References
+
+* [https://github.com/bbatsov/ruby-style-guide#colon-method-definition](https://github.com/bbatsov/ruby-style-guide#colon-method-definition)
+
 ## Style/CommandLiteral
 
 Enabled by default | Supports autocorrection


### PR DESCRIPTION
A recent master merge was missing this documentation and thus travis is failing across the board.

Example from last master CI run - https://travis-ci.org/bbatsov/rubocop/jobs/306816479

All I did here was run `rake generate_cops_documentation` on master and commit the changes.

-----------------

Before submitting the PR make sure the following are checked:

* [ ] Wrote [good commit messages][1].
* [x] Used the same coding conventions as the rest of the project.
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [x] All tests(`rake spec`) are passing.
* [x] The new code doesn't generate RuboCop offenses that are checked by `rake internal_investigation`. (unlike master)
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Updated cop documentation with `rake generate_cops_documentation` (required only when you've added a new cop or changed the configuration/documentation of an existing cop).

[1]: http://chris.beams.io/posts/git-commit/
