### PR TITLE
Fix Layout/ClassStructure configuration key

### DIFF
--- a/config/default.yml
+++ b/config/default.yml
@@ -534,7 +534,7 @@ Layout/SpaceInsideStringInterpolation:
 
 Layout/ClassStructure:
   Description: 'Enforces a configured order of definitions within a class body.'
-  StyleGuide: '#consistent-classes'
+  StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#consistent-classes'
   Enabled: false
   Categories:
     module_inclusion:
@@ -546,7 +546,7 @@ Layout/ClassStructure:
       - constants
       - public_class_methods
       - initializer
-      - instance_methods
+      - public_methods
       - protected_methods
       - private_methods
 

--- a/lib/rubocop/cop/layout/class_structure.rb
+++ b/lib/rubocop/cop/layout/class_structure.rb
@@ -30,7 +30,7 @@ module RuboCop
       #        - constants
       #        - public_class_methods
       #        - initializer
-      #        - instance_methods
+      #        - public_methods
       #        - protected_methods
       #        - private_methods
       #
@@ -109,7 +109,7 @@ module RuboCop
         HUMANIZED_NODE_TYPE = {
           casgn: :constants,
           defs: :class_methods,
-          def: :instance_methods
+          def: :public_methods
         }.freeze
 
         VISIBILITY_SCOPES = %i[private protected public].freeze

--- a/manual/cops_layout.md
+++ b/manual/cops_layout.md
@@ -384,7 +384,7 @@ You can configure the following order:
        - constants
        - public_class_methods
        - initializer
-       - instance_methods
+       - public_methods
        - protected_methods
        - private_methods
 
@@ -464,7 +464,7 @@ end
 Name | Default value | Configurable values
 --- | --- | ---
 Categories | `{"module_inclusion"=>["include", "prepend", "extend"]}` | 
-ExpectedOrder | `module_inclusion`, `constants`, `public_class_methods`, `initializer`, `instance_methods`, `protected_methods`, `private_methods` | Array
+ExpectedOrder | `module_inclusion`, `constants`, `public_class_methods`, `initializer`, `public_methods`, `protected_methods`, `private_methods` | Array
 
 ### References
 

--- a/manual/cops_style.md
+++ b/manual/cops_style.md
@@ -636,6 +636,10 @@ class Foo
 end
 ```
 
+### References
+
+* [https://github.com/bbatsov/ruby-style-guide#colon-method-definition](https://github.com/bbatsov/ruby-style-guide#colon-method-definition)
+
 ## Style/CommandLiteral
 
 Enabled by default | Supports autocorrection

--- a/spec/rubocop/cop/layout/class_structure_spec.rb
+++ b/spec/rubocop/cop/layout/class_structure_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe RuboCop::Cop::Layout::ClassStructure, :config do
           macros
           public_class_methods
           initializer
-          instance_methods
+          public_methods
           protected_methods
           private_methods
         ],


### PR DESCRIPTION
Fix configuration key from `instance_methods` to `public_methods`. It was not matching instance methods because the configuration says "public_methods" instead.

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages][1].
* (n/a) Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Used the same coding conventions as the rest of the project.
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [ ] Added tests.
* (n/a) Added an entry to the [Changelog](../blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](../blob/master/CONTRIBUTING.md#changelog-entry-format).
* [ ] All tests(`rake spec`) are passing.
* [x] The new code doesn't generate RuboCop offenses that are checked by `rake internal_investigation`.
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [x] Updated cop documentation with `rake generate_cops_documentation` (required only when you've added a new cop or changed the configuration/documentation of an existing cop).

[1]: http://chris.beams.io/posts/git-commit/
